### PR TITLE
 wrong symbolic link target path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ cc -w -o vc v.c           # Build it with Clang or GCC
 ./vc -o v .               # Use the resulting V binary to build V from V source
 ```
 
-That's it! Now you have a V executable at `~/v/compiler/v`.
+That's it! Now you have a V executable at `~/code/v/compiler/v`.
 
 You can create a symlink so that it's globally available:
 
 ```
-sudo ln -s /$HOME/v/compiler/v /usr/local/bin/v
+sudo ln -s $HOME/code/v/compiler/v /usr/local/bin/v
 ```
 
 ### Windows


### PR DESCRIPTION
We need to change v compiler binary path in README.md:69 to make v compiler working globally.