### PR TITLE
make `string.str` and `array.data` public

### DIFF
--- a/builtin/array.v
+++ b/builtin/array.v
@@ -3,8 +3,8 @@ module builtin
 struct array {
 	// Using a void pointer allows to implement arrays without generics and without generating
 	// extra code for every type.
-	data         voidptr
 pub:
+	data         voidptr
 	len          int
 	cap          int
 	element_size int

--- a/builtin/string.v
+++ b/builtin/string.v
@@ -2,8 +2,8 @@ module builtin
 
 // V strings are not null-terminated.
 struct string {
-	str byteptr
 pub:
+	str byteptr
 	len int
 }
 


### PR DESCRIPTION
some source code(ex. builtin.v) seems to references these fields.