### PR TITLE
fix `b_error` to `v_error`

### DIFF
--- a/compiler/jsgen.v
+++ b/compiler/jsgen.v
@@ -64,7 +64,7 @@ Option $dec_fn.name(cJSON* root, $t* res) {
     if (error_ptr != NULL)	{
       fprintf(stderr, "Error in decode() for $t error_ptr=: %%s\\n", error_ptr);
 //      printf("\\nbad js=%%s\\n", js.str); 
-      return b_error(tos2(error_ptr));
+      return v_error(tos2(error_ptr));
     }
   }
 '


### PR DESCRIPTION
As far as I checked `v.c`, it should be `v_error`.
I confirmed that `v.c` is already fixed.

```c
  dec = string_add(
      dec,
      _STR(
          "\n//%.*s %.*s(cJSON* root) {  \nOption %.*s(cJSON* root, %.*s* res) "
          "{  \n//  %.*s res; \n  if (!root) {\n    const char *error_ptr = "
          "cJSON_GetErrorPtr();\n    if (error_ptr != NULL)	{\n      "
          "fprintf(stderr, \"Error in decode() for %.*s error_ptr=: %%s\\n\", "
          "error_ptr);\n//      printf(\"\\nbad js=%%s\\n\", js.str); \n      "
          "return v_error(tos2(error_ptr));\n    }\n  }\n",
```