### PR TITLE
base64: fix build

### DIFF
--- a/base64/base64.v
+++ b/base64/base64.v
@@ -44,6 +44,6 @@ fn decode(data string) string {
 		}
 	}
 	str[str_len + 1] = `\0`
-	return string(str)
+	return tos(str, str_len+2)
 }
 


### PR DESCRIPTION
$ cat hello_world.v
import base64
println('Hello!')

$ v run hello_world.v
============running hello_world==============================
Hello!
10
vlang-zh.cn
chai-mba:examples chai$ v run hello_world.v
println
println
Generating main()...
/Users/chai//.vlang0.0.12//hello_world.c:3783:22: error: used type 'string' (aka 'struct string') where arithmetic or pointer type is required
 return  (/*casttt*/ (string)( /*77*/ str ) ) ;
                     ^       ~~~~~~~~~~~~~~
1 error generated.
V panic: clang error