### PR TITLE
Use correct English in error messages.

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -512,7 +512,7 @@ fn (c &V) v_files_from_dir(dir string) []string {
 	mut res := []string
 	mut files := os.ls(dir)
 	if !os.file_exists(dir) {
-		panic('$dir doesnt exist')
+		panic('$dir doesn\'t exist')
 	}
 	if c.is_verbose {
 		println('v_files_from_dir ("$dir")')

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -26,7 +26,7 @@ const (
 
 fn new_scanner(file_path string) *Scanner {
 	if !os.file_exists(file_path) {
-		panic('"$file_path" doesnt exist')
+		panic('"$file_path" doesn\'t exist')
 	}
 	scanner := &Scanner {
 		file_path: file_path

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -519,7 +519,7 @@ fn (p mut Parser) satisfies_interface(interface_name, _typ string, throw bool) b
 	for method in int_typ.methods {
 		if !typ.has_method(method.name) {
 			// if throw {
-			p.error('Type "$_typ" doesnt satisfy interface "$interface_name" (method "$method.name" is not implemented)')
+			p.error('Type "$_typ" doesn\'t satisfy interface "$interface_name" (method "$method.name" is not implemented)')
 			// }
 			return false
 		}


### PR DESCRIPTION
This PR changes `doesnt` -> `doesn't` in error messages.

I checked at least `main.v` change works with this patch.
```
$ ./v -o v .
ls() couldnt open dir "/Users/kt3k//code/v//os"
errno=2 err='No such file or directory'
V panic: /Users/kt3k//code/v//os doesn't exist
```