### PR TITLE
main.v: exits when prompting help

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -94,6 +94,7 @@ fn main() {
 	}
 	if '-h' in args || '--help' in args || 'help' in args {
 		println(HelpText)
+		return
 	}
 	// TODO quit if the compiler is too old 
 	// u := os.file_last_mod_unix('/var/tmp/alex')


### PR DESCRIPTION
When asking for help via `-h` `--help` or `help` arguments, prompts then quits instead of trying to open a file with that name.

```
$ v --help

- To build a V program:
v file.v

- To get current V version:
v version

- To build an optimized executable:
v -prod file.v

- To specify the executable's name:
v -o program file.v 

ls() couldnt open dir "--help"
fish: “v --help” terminated by signal SIGSEGV (Address boundary error)
```