### PR TITLE
Add thirdparty cjson

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "thirdparty/cJSON"]
+	path = thirdparty/cJSON
+	url = git@github.com:DaveGamble/cJSON.git

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -233,12 +233,12 @@ void init_consts();')
 	// Embed cjson either in embedvlib or in json.o
 	if imports_json && c.build_mode == EMBED_VLIB ||
 	(c.build_mode == BUILD && c.out_name.contains('json.o')) {
-		cgen.genln('#include "json/cJSON/cJSON.c" ')
+		cgen.genln('#include "cJSON.c" ')
 	}
 	// We need the cjson header for all the json decoding user will do in default mode
 	if c.build_mode == DEFAULT_MODE {
 		if imports_json {
-			cgen.genln('#include "json/cJSON/cJSON.h"')
+			cgen.genln('#include "cJSON.h"')
 		}
 	}
 	if c.build_mode == EMBED_VLIB || c.build_mode == DEFAULT_MODE {

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -448,6 +448,8 @@ mut args := ''
 	// Output executable name
 	// else {
 	a << '-o $c.out_name'
+	// The C file we are compiling
+	a << '$TmpPath/$c.out_name_c'
 	// }
 	// Min macos version is mandatory I think?
 	if c.os == MAC {
@@ -459,8 +461,6 @@ mut args := ''
 	if c.os == MAC {
 		a << '-x objective-c'
 	}
-	// The C file we are compiling
-	a << '$TmpPath/$c.out_name_c'
 	// Without these libs compilation will fail on Linux
 	if c.os == LINUX && c.build_mode != BUILD {
 		a << '-lm -ldl -lpthread'

--- a/json/json_primitives.v
+++ b/json/json_primitives.v
@@ -1,7 +1,11 @@
 module json
 
-// #include "json/cJSON/cJSON.c"
-#include "json/cJSON/cJSON.h"
+// TODO: windows support
+#flag linux -I$HOME/code/v/thirdpaty/cJSON
+#flag mac -I$HOME/code/v/thirdpaty/cJSON
+
+// #include "cJSON.c"
+#include "cJSON.h"
 struct C.cJSON {
 	valueint    int
 	valuestring byteptr


### PR DESCRIPTION
closes #369 #406 

**This PR doesn't includes windows support.**
I don't have windows env, so I can't test it....

currently, `json` module depends on cJSON library.
to make it easy for developers to build, this PR add `cJSON` to this repository as git submodule.
In the future, JSON parser will be written by vlang.
but until then, it is better to keep add third-party libraries to `thirdparty` dir.
