### PR TITLE
main.v: checking directory before trying to fetch files

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -516,10 +516,10 @@ mut args := ''
 
 fn (c &V) v_files_from_dir(dir string) []string {
 	mut res := []string
-	mut files := os.ls(dir)
 	if !os.file_exists(dir) {
 		panic('$dir doesn\'t exist')
 	}
+	mut files := os.ls(dir)
 	if c.is_verbose {
 		println('v_files_from_dir ("$dir")')
 	}


### PR DESCRIPTION
Moved the line checking if the directory exists before the os.ls call, otherwise if a folder doesn't exists, it would crash:

```
$ ./v folder
ls() couldnt open dir "folder"
“./v test” terminated by signal SIGSEGV (Address boundary error)
```