### PR TITLE
Use a temporary folder in cd instead of manipulating a homepath folder

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -30,7 +30,7 @@ fn vtmp_path() string {
 
 const (
 	SupportedPlatforms = ['windows', 'mac', 'linux']
-	TmpPath            = vtmp_path()
+	TmpPath            = './.tmp/'
 )
 
 enum Os {


### PR DESCRIPTION
I suppose this also prompts a function in `os` that can recursively delete files in folders (and folders themselves)