### PR TITLE
Checks if dir given exists and is a directory before ls

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -516,7 +516,7 @@ mut args := ''
 
 fn (c &V) v_files_from_dir(dir string) []string {
 	mut res := []string
-	if !os.file_exists(dir) {
+	if !os.dir_exists(dir) {
 		panic('$dir doesn\'t exist')
 	}
 	mut files := os.ls(dir)

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -516,8 +516,10 @@ mut args := ''
 
 fn (c &V) v_files_from_dir(dir string) []string {
 	mut res := []string
-	if !os.dir_exists(dir) {
+	if !os.file_exists(dir) {
 		panic('$dir doesn\'t exist')
+	} else if !os.dir_exists(dir) {
+		panic('$dir isn\'t a directory')
 	}
 	mut files := os.ls(dir)
 	if c.is_verbose {

--- a/os/os.v
+++ b/os/os.v
@@ -332,13 +332,10 @@ pub fn file_exists(path string) bool {
 }
 
 pub fn dir_exists(path string) bool {
-	res := false
-	if file_exists(path) {
-		# DIR *dir = opendir(path.str);
-		# res = dir != NULL;
-		if res {
-			# closedir(dir);
-		}
+	dir := C.opendir(path.cstr())
+	res := !isnil(dir)
+	if res {
+		C.closedir(dir)
 	}
 	return res
 }

--- a/os/os.v
+++ b/os/os.v
@@ -331,6 +331,18 @@ pub fn file_exists(path string) bool {
 	return res
 }
 
+pub fn dir_exists(path string) bool {
+	res := false
+	if file_exists(path) {
+		# DIR *dir = opendir(path.str);
+		# res = dir != NULL;
+		if res {
+			# closedir(dir);
+		}
+	}
+	return res
+}
+
 // `mkdir` creates a new directory with the specified path.
 pub fn mkdir(path string) {
 	$if windows {


### PR DESCRIPTION
On top of checking if dir given exists, we should also check if it is indeed a directory.

It prevents a crash that happens when you give a file as a directory :

```
$ v -o file
ls() couldnt open dir "file"
“./v -o file” terminated by signal SIGSEGV (Address boundary error)
```