### PR TITLE
Fix decl c struct follow a v struct

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -416,7 +416,7 @@ fn (p mut Parser) struct_decl() {
 		}
 	}
 	// V used to have 'type Foo struct', many Go users might use this syntax
-	if p.tok == STRUCT {
+	if !is_c && p.tok == STRUCT {
 		p.error('use `struct $name {` instead of `type $name struct {`')
 	}
 	// Register the type


### PR DESCRIPTION
struct C.CURL

struct Curl {
    h *C.CURL
}

orignal log:
```
pass=1 fn=``
panic: curl.v:13
use `struct CURL {` instead of `type CURL struct {`
exit(): 
```