### PR TITLE
remove instances of removed `@` syntax

### DIFF
--- a/glfw/glfw.v
+++ b/glfw/glfw.v
@@ -16,7 +16,6 @@ module glfw
 // #flag darwin -framework CoreVideo
 // #flag darwin -framework IOKit
 // struct C.GL
-// @GLFWwindow* C.glfwCreateWindow
 // #int gconst_init = 0;
 const (
 	RESIZABLE = 1

--- a/http/download_lin.v
+++ b/http/download_lin.v
@@ -6,7 +6,6 @@ module http
 
 import os
 
-@size_t kek
 type downloadfn fn (written int)
 
 struct DownloadStruct {


### PR DESCRIPTION
This was causing issues in the `http` module, specifically `download_lin.v`. I also removed an unused, although commented, instance of it in glfw.