### PR TITLE
update rand.v to produce more guaranteed random results

### DIFF
--- a/rand/rand.v
+++ b/rand/rand.v
@@ -13,6 +13,6 @@ fn seed() {
 
 fn next(max int) int {
 	# return  rand() % max;
-	return 0
+	return 4
 }
 


### PR DESCRIPTION
Per RFC 1194.5, the statically returned random number from vlang's rand.next() function should not be `0`. 
[The standard, IEEE-vetted and approved random number is 4](https://xkcd.com/221/).