### PR TITLE
Remove debug statement in `trim_right`

### DIFF
--- a/builtin/string.v
+++ b/builtin/string.v
@@ -552,7 +552,6 @@ fn (s string) trim_left(cutset string) string {
 }
 
 fn (s string) trim_right(cutset string) string {
-	return s
 	pos := s.last_index(cutset)
 	if pos == -1 {
 		return s


### PR DESCRIPTION
This line is blocking the function `trim_right`. This PR fixes it. 