### PR TITLE
Added colors.v: Bring colors to terminal

### DIFF
--- a/colors/colors.v
+++ b/colors/colors.v
@@ -1,0 +1,109 @@
+// Copyright (c) 2019 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+module colors
+
+fn format(msg, open, close string) string {
+    return '\x1b[' + open + 'm' + msg + '\x1b[' + close + 'm'
+}
+
+fn bg_black(msg string) string {
+    return format(msg, '40', '49')
+}
+
+fn bg_blue(msg string) string {
+    return format(msg, '44', '49')
+}
+
+fn bg_cyan(msg string) string {
+    return format(msg, '46', '49')
+}
+
+fn bg_green(msg string) string {
+    return format(msg, '42', '49')
+}
+
+fn bg_magenta(msg string) string {
+    return format(msg, '45', '49')
+}
+
+fn bg_red(msg string) string {
+    return format(msg, '41', '49')
+}
+
+fn bg_white(msg string) string {
+    return format(msg, '47', '49')
+}
+
+fn bg_yellow(msg string) string {
+    return format(msg, '43', '49')
+}
+
+fn black(msg string) string {
+    return format(msg, '30', '39')
+}
+
+fn blue(msg string) string {
+    return format(msg, '34', '39')
+}
+
+fn bold(msg string) string {
+    return format(msg, '1', '22')
+}
+
+fn cyan(msg string) string {
+    return format(msg, '36', '39')
+}
+
+fn dim(msg string) string {
+    return format(msg, '2', '22')
+}
+
+fn green(msg string) string {
+    return format(msg, '32', '39')
+}
+
+fn gray(msg string) string {
+    return format(msg, '90', '39')
+}
+
+fn hidden(msg string) string {
+    return format(msg, '8', '28')
+}
+
+fn italic(msg string) string {
+    return format(msg, '3', '23')
+}
+
+fn inverse(msg string) string {
+    return format(msg, '7', '27')
+}
+
+fn magenta(msg string) string {
+    return format(msg, '35', '39')
+}
+
+fn reset(msg string) string {
+    return format(msg, '0', '0')
+}
+
+fn red(msg string) string {
+    return format(msg, '31', '39')
+}
+
+fn strikethrough(msg string) string {
+    return format(msg, '9', '29')
+}
+
+fn underline(msg string) string {
+    return format(msg, '4', '24')
+}
+
+fn white(msg string) string {
+    return format(msg, '37', '39')
+}
+
+fn yellow(msg string) string {
+    return format(msg, '33', '39')
+}


### PR DESCRIPTION
V is a great language to write backend programs. Let's bring the colors to the terminal then.

Running this program:
```go
import colors

fn main()
{
	println('bgblack: ' + colors.bg_black('bgblack'))
	println('bgblue: ' + colors.bg_blue('bgblue'))
	println('bgcyan: ' + colors.bg_cyan('bgcyan'))
	println('bggreen: ' + colors.bg_green('bggreen'))
	println('bgmagenta: ' + colors.bg_magenta('bgmagenta'))
	println('bgred: ' + colors.bg_red('bgred'))
	println('bgwhite: ' + colors.bg_white('bgwhite'))
	println('bgyellow: ' + colors.bg_yellow('bgyellow'))
	println('black: ' + colors.black('black'))
	println('blue: ' + colors.blue('blue'))
	println('bold: ' + colors.bold('bold'))
	println('cyan: ' + colors.cyan('cyan'))
	println('dim: ' + colors.dim('dim'))
	println('green: ' + colors.green('green'))
	println('gray: ' + colors.gray('gray'))
	println('hidden: ' + colors.hidden('hidden'))
	println('italic:' + colors.italic('italic'))
	println('inverse: ' + colors.inverse('inverse'))
	println('magenta: ' + colors.magenta('magenta'))
	println('reset: ' + colors.reset('reset'))
	println('red: ' + colors.red('red'))
	println('strikethrough: ' + colors.strikethrough('strikethrough'))
	println('underline: ' + colors.underline('underline'))
	println('white: ' + colors.white('white'))
	println('yellow: ' + colors.yellow('yellow'))
}
```

[This is the output](https://drive.google.com/file/d/1JhNnKrluq0XyOZV8m2WuJpt9K6JTj1YT/view)
I wasn't able to upload the image on imgur for some reason so I had to use Google Drive :octocat: 