### PR TITLE
parser.v: fixed pub mut handling

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -460,7 +460,9 @@ fn (p mut Parser) struct_decl() {
 			is_mut = false
 			p.scanner.fmt_indent--
 			p.check(PUB)
-			p.check(COLON)
+			if p.tok != MUT {
+				p.check(COLON)
+			}
 			p.scanner.fmt_indent++
 			p.fgenln('')
 		}
@@ -472,7 +474,9 @@ fn (p mut Parser) struct_decl() {
 			is_pub = false
 			p.scanner.fmt_indent--
 			p.check(MUT)
-			p.check(COLON)
+			if p.tok != MUT {
+				p.check(COLON)
+			}
 			p.scanner.fmt_indent++
 			p.fgenln('')
 		}

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -457,7 +457,6 @@ fn (p mut Parser) struct_decl() {
 				p.error('structs can only have one `pub:`, all public fields have to be grouped')
 			}
 			is_pub = true
-			is_mut = false
 			p.scanner.fmt_indent--
 			p.check(PUB)
 			if p.tok != MUT {
@@ -471,7 +470,6 @@ fn (p mut Parser) struct_decl() {
 				p.error('structs can only have one `mut:`, all private mutable fields have to be grouped')
 			}
 			is_mut = true
-			is_pub = false
 			p.scanner.fmt_indent--
 			p.check(MUT)
 			if p.tok != MUT {


### PR DESCRIPTION
Note: could have added `pub mut mut` checking, but it doesnt seem there is a compilation for that (the variable for that has been commented before)

Solves #481 