### PR TITLE
map: add unset & index methods

### DIFF
--- a/builtin/map.v
+++ b/builtin/map.v
@@ -133,13 +133,23 @@ fn (m map) get(key string, out voidptr) bool {
 	return false
 }
 
+fn (m map) exists(key string) bool {
+	for i := 0; i < m.entries.len; i++ {
+		entry := m.entries[i]
+		if entry.key == key {
+			return true
+		}
+	}
+	return false
+}
+
 fn (m map) print() {
 	println('<<<<<<<<')
 	for i := 0; i < m.entries.len; i++ {
 		// entry := m.entries[i]
 		// println('$entry.key => $entry.val')
 	}
-	/* 
+	/*
 	for i := 0; i < m.cap * m.element_size; i++ {
 		b := m.table[i]
 		print('$i: ')
@@ -169,4 +179,3 @@ fn (m map_string) str() string {
 	s += '}'
 	return s
 }
-

--- a/builtin/map.v
+++ b/builtin/map.v
@@ -157,6 +157,7 @@ fn (m mut map) unset(i int) {
     }
 	}
 
+  C.free(m.entries[i].val)
   m.entries = entries
 }
 
@@ -167,6 +168,7 @@ fn (m map) index(key string) int {
 			return i
 		}
 	}
+
 	return -1
 }
 

--- a/builtin/map.v
+++ b/builtin/map.v
@@ -143,6 +143,34 @@ fn (m map) exists(key string) bool {
 	return false
 }
 
+
+fn (m mut map) unset(i int) {
+  if i < 0 || i >= m.entries.len {
+		panic('map.unset: index out of range: $i/$m.entries.len')
+    return
+	}
+
+  mut entries := []Entry
+
+  for j := 0; j < m.entries.len; j++ {
+    if j != i {
+      entries << m.entries[j]
+    }
+	}
+
+  m.entries = entries
+}
+
+fn (m map) index(key string) int {
+	for i := 0; i < m.entries.len; i++ {
+		entry := m.entries[i]
+		if entry.key == key {
+			return i
+		}
+	}
+	return -1
+}
+
 fn (m map) print() {
 	println('<<<<<<<<')
 	for i := 0; i < m.entries.len; i++ {


### PR DESCRIPTION
```
mut fruits := map[string]string{}

fruits['banana'] = '🍌'
fruits['apple'] = '🍎'
fruits['orange'] = '🍊'

fruits['pizza'] = '🍕' // 🤔🤔🤔

println(fruits)
/*
  {
    "banana" => "🍌"
    "apple" => "🍎"
    "orange" => "🍊"
    "pizza" => "🍕"
  }
*/
// ❌❌❌
pizzaIndex := fruits.index('pizza')
println('Pizza: $pizzaIndex')
// Pizza: 3

fruits.unset(pizzaIndex)

println(fruits)
/*
  {
    "banana" => "🍌"
    "apple" => "🍎"
    "orange" => "🍊"
  }
*/
// ✅✅✅