### PR TITLE
Added different functions for casting to integers and strings

### DIFF
--- a/builtin/string.v
+++ b/builtin/string.v
@@ -138,14 +138,29 @@ pub fn (s string) replace(rep, with string) string {
 	return tos(b, new_len)
 }
 
-// TODO `.int()` ?
-pub fn (s string) to_i() int {
+// Casting to numbers (integers and floats)
+fn (s string) to_i() int {
 	return C.atoi(s.str)
 }
 
-// TODO `.f32()`
+fn (s string) int() int {
+	return s.to_i()
+}
+
+fn (s string) i32() int {
+	return s.to_i()
+}
+
 fn (s string) to_float() float {
 	return C.atof(s.str)
+}
+
+fn (s string) float() float {
+	return s.to_float()
+}
+
+fn (s string) f32() float {
+	return s.to_float()
 }
 
 // ==

--- a/builtin/string.v
+++ b/builtin/string.v
@@ -138,7 +138,6 @@ pub fn (s string) replace(rep, with string) string {
 	return tos(b, new_len)
 }
 
-// Casting to numbers (integers and floats)
 fn (s string) to_i() int {
 	return C.atoi(s.str)
 }
@@ -149,18 +148,6 @@ fn (s string) int() int {
 
 fn (s string) i32() int {
 	return s.to_i()
-}
-
-fn (s string) to_float() float {
-	return C.atof(s.str)
-}
-
-fn (s string) float() float {
-	return s.to_float()
-}
-
-fn (s string) f32() float {
-	return s.to_float()
 }
 
 // ==


### PR DESCRIPTION
This PR allows you to use the following functions on a string:

+ `.int()`
+ `.i32()`

This was mentioned in these TODOs: 
https://github.com/vlang/v/blob/353a6edb7c2389d5d10cb0b68ff9504dd54cf392/builtin/string.v#L141 https://github.com/vlang/v/blob/353a6edb7c2389d5d10cb0b68ff9504dd54cf392/builtin/string.v#L146

You could already do this:

+ `.to_i()`