### PR TITLE
Add outdir to Makefile

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -1,11 +1,13 @@
-all: v
+outdir := .
 
-v: v.c
+all: ${outdir}/v
+
+${outdir}/v: v.c
 	cc -std=gnu11 -w -o v v.c
-	./v -o v .
+	./v -o ${outdir}/v .
 
 v.c:
 	wget https://vlang.io/v.c
 
 clean:
-	-rm vc v.c
+	-rm -f ${outdir}/v ./v vc v.c


### PR DESCRIPTION
 - Allow v executable to be placed in a different directory such as ~/bin/

 - In clean target use -f to suppress warnings
   and remove ${outdir}/v and the local v