### PR TITLE
Add option to .reverse()

### DIFF
--- a/builtin/string.v
+++ b/builtin/string.v
@@ -777,11 +777,9 @@ fn (s string) reverse() string {
 		str: malloc(s.len + 1)
 	}
 
-	mut c := 0
 	for i := s.len - 1; i >= 0; i-- {
-        res[c] = s.at(i)
-		c++
-    }
+        res[s.len-i-1] = s.at(i)
+	}
 
 	return res
 }

--- a/builtin/string.v
+++ b/builtin/string.v
@@ -778,7 +778,7 @@ fn (s string) reverse() string {
 	}
 
 	for i := s.len - 1; i >= 0; i-- {
-        res[s.len-i-1] = s.at(i)
+        res[s.len-i-1] = s[i]
 	}
 
 	return res

--- a/builtin/string.v
+++ b/builtin/string.v
@@ -771,6 +771,21 @@ fn (s[]string) join_lines() string {
 	return s.join('\n')
 }
 
+fn (s string) reverse() string {
+	mut res := string {
+		len: s.len
+		str: malloc(s.len + 1)
+	}
+
+	mut c := 0
+	for i := s.len - 1; i >= 0; i-- {
+        res[c] = s.at(i)
+		c++
+    }
+
+	return res
+}
+
 // 'hello'.limit(2) => 'he'
 // 'hi'.limit(10) => 'hi'
 fn (s string) limit(max int) string {


### PR DESCRIPTION
With this commit, users can cast `.reverse()` on strings.

```
fn main() {
    n := 'hello'

    println(n.reverse())
}
```

results in `olleh` with this.