### PR TITLE
Makefile curl

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -5,7 +5,7 @@ v: v.c
 	./v -o v .
 
 v.c:
-	wget https://raw.githubusercontent.com/vlang/vc/master/v.c
+	curl -Os https://raw.githubusercontent.com/vlang/vc/master/v.c
 
 test:
 	find .. -name '*_test.v' | xargs v {}


### PR DESCRIPTION
`curl` should be used in Makefile as more common and lightweight