### PR TITLE
run: arguments handling

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -380,11 +380,14 @@ string _STR_TMP(const char *fmt, ...) {
 		if true || c.is_verbose {
 			println('============running $c.out_name==============================')
 		}
-		cmd := if c.out_name.starts_with('/') {
+		mut cmd := if c.out_name.starts_with('/') {
 			c.out_name
 		}
 		else {
 			'./' + c.out_name
+		}
+		if os.args.len > 3 {
+			cmd += ' ' + os.args.right(3).join(' ')
 		}
 		ret := os.system2(cmd)
 		if ret != 0 {
@@ -687,6 +690,9 @@ fn (c &V) log(s string) {
 
 fn new_v(args[]string) *V {
 	mut dir := args.last()
+	if args.contains('run') {
+		dir = args[2]
+	}
 	// println('new compiler "$dir"')
 	if args.len < 2 {
 		dir = ''


### PR DESCRIPTION
Adds arguments handling for run option.
It will compile then pass arguments to the execution.

Solves #610 