### PR TITLE
parser: Cleanup enum code and add tokens after pub checks

### DIFF
--- a/builtin/string_test.v
+++ b/builtin/string_test.v
@@ -289,4 +289,5 @@ fn test_all_after() {
 	s := 'fn hello'
 	q := s.all_after('fn ')
 	assert q == 'hello'
+}
 

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -161,26 +161,33 @@ fn (p mut Parser) parse() {
 			}
 		case ENUM:
 			p.next()
-			if p.tok == NAME {
-				p.fgen('enum ')
-				name := p.check_name()
-				p.fgen(' ')
-				p.enum_decl(name)
-			}
 			// enum without a name, only allowed in code, translated from C
 			// it's a very bad practice in C as well, but is used unfortunately (for example, by DOOM)
 			// such fields are basically int consts
-			else if p.translated {
+			if p.translated && p.tok != NAME {
 				p.enum_decl('int')
 			}
 			else {
-				p.check(NAME)
+				name := p.check_name()
+				p.fgen('enum ')
+				p.fgen(' ')
+				p.enum_decl(name)
 			}
 		case PUB:
-			if p.peek() == FUNC {
+			next := p.peek()
+			if next == FUNC {
 				p.fn_decl()
 			}
-			// TODO public structs
+			else if next == STRUCT {
+				//TODO public structs
+				println('Public structs are still a todo. Code might break!')	
+			}
+			else {
+				println('parse()')
+				s := 'Expected `fn` or `struct` after `pub` token. Got ${next.str()} instead.'
+				print_backtrace()
+				p.error(s)
+			}
 		case FUNC:
 			p.fn_decl()
 		case TIP:


### PR DESCRIPTION
The redundant else case to cause a compilation error has been optimized into the code while pub token now only allow structs and fn tokens after it.

The else case in the enum code had no reason to be there except to cause a compilation error so I grouped it together with the initial if case.
Currently, `pub` should only be followed by struct and fn so I added a check for that.

This commit also fixes the string_test.v because it was failing the `make test`.