### PR TITLE
parser: prompt error if struct is made public and if pub is wrongly used

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -179,8 +179,12 @@ fn (p mut Parser) parse() {
 		case PUB:
 			if p.peek() == FUNC {
 				p.fn_decl()
+			} else if p.peek() == STRUCT {
+				p.error('structs can\'t be declared public *yet*')
+				// TODO public structs
+			} else {
+				p.error('wrong pub keyword usage')
 			}
-			// TODO public structs
 		case FUNC:
 			p.fn_decl()
 		case TIP:


### PR DESCRIPTION
Fix the infinite loop appearing when a struct has the pub keyword.
Prompts an error when it is the case.
Alse prompts error if pub is misplaced.

Fixes #666 