### PR TITLE
parser: fixed problem hexa being casted into float

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1933,7 +1933,8 @@ fn (p mut Parser) factor() string {
 	switch tok {
 	case INT:
 		typ = 'int'
-		if p.lit.contains('.') || p.lit.contains('e') {
+		//Check if float but not if is hexa
+		if (p.lit.contains('.') || p.lit.contains('e')) && !(p.lit[0] == `0` && p.lit[1] == `x`) {
 			typ = 'f32'
 			// typ = 'f64' // TODO 
 		}


### PR DESCRIPTION
Add new check to not transform an hex to a float if it has 'e'.

**NOTE**: I don't understand the use of checking for the 'e' character, does anybody can enlight me ?

Fixes #681 