### PR TITLE
fix README faster build

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ GitHub marks V's code as written in Go. It's actually written in V, GitHub doesn
 
 The compilation is temporarily slower for this release:
 
-- Debug builds are used (use `v -prod -o v` to get faster compilation).
+- Debug builds are used (use `./v -prod -o v .` to get faster compilation).
 - vlib is recompiled with every program you build.
 - The new formatter runs on every single token and slows the compiler down by ~20%. This will be taken care of.
 - There are a lot of known issues that are quick to fix (like function lookups being O(n)).


### PR DESCRIPTION
README: faster build instruction should be: `./v -prod -o v .` in [Makefile](https://github.com/vlang/v/blob/master/compiler/Makefile#L5)
