### PR TITLE
example: Add the log example to .gitignore

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -2,6 +2,7 @@ game_of_life/life
 hello_world
 json
 links_scraper
+log
 news_fetcher
 tetris/tetris
 word_counter/word_counter


### PR DESCRIPTION
The compiled log file should no longer cause a file to be added to the git repo during `make test`.