### PR TITLE
string: add negative pos for left and right methods

### DIFF
--- a/builtin/string.v
+++ b/builtin/string.v
@@ -305,7 +305,14 @@ pub fn (s string) split_into_lines() []string {
 }
 
 // 'hello'.left(2) => 'he'
+// 'hello'.left(-2) => 'hel'
 pub fn (s string) left(n int) string {
+	if n < 0 {
+		if -n >= s.len {
+			return ''
+		}
+		return s.substr(0, s.len + n)
+	}
 	if n >= s.len {
 		return s
 	}
@@ -313,6 +320,12 @@ pub fn (s string) left(n int) string {
 }
 
 pub fn (s string) right(n int) string {
+	if n < 0 {
+		if -n >= s.len {
+			return s
+		}
+		return s.substr(s.len + n, s.len)
+	}
 	if n >= s.len {
 		return ''
 	}
@@ -669,10 +682,28 @@ fn (u ustring) substr(start, end int) string {
 }
 
 fn (u ustring) left(pos int) string {
+	if pos < 0 {
+		if -pos >= u.len {
+			return ''
+		}
+		return u.substr(0, u.len + pos)
+	}
+	if pos >= u.len {
+		return u.s
+	}
 	return u.substr(0, pos)
 }
 
 fn (u ustring) right(pos int) string {
+	if pos < 0 {
+		if -pos >= u.len {
+			return u.s
+		}
+		return u.substr(u.len + pos, u.len)
+	}
+	if pos >= u.len {
+		return ''
+	}
 	return u.substr(pos, u.len)
 }
 

--- a/builtin/string_test.v
+++ b/builtin/string_test.v
@@ -231,9 +231,21 @@ fn test_left_right() {
 	s := 'ALOHA'
 	assert s.left(3) == 'ALO'
 	assert s.right(3) == 'HA'
+	assert s.left(10) == 'ALOHA'
+	assert s.right(10) == ''
+	assert s.left(-2) == 'ALO'
+	assert s.right(-2) == 'HA'
+	assert s.left(-10) == ''
+	assert s.right(-10) == 'ALOHA'
 	u := s.ustring()
 	assert u.left(3) == 'ALO'
 	assert u.right(3) == 'HA'
+	assert u.left(10) == 'ALOHA'
+	assert u.right(10) == ''
+	assert u.left(-2) == 'ALO'
+	assert u.right(-2) == 'HA'
+	assert u.left(-10) == ''
+	assert u.right(-10) == 'ALOHA'
 }
 
 fn test_contains() {


### PR DESCRIPTION
Left and Right methods for string can now accept negative positions.
```
'hello'.left(-2) //hel
'hello'.right(-2) // lo
```
Strings tests have been updated for that.