### PR TITLE
azure: trigger PR builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,3 @@
-trigger:
-  branches:
-    include:
-    - '*'
 jobs:
   - job: LinuxBuild
     pool: 
@@ -32,3 +28,12 @@ jobs:
       - script: |
           cd compiler && make && make test
         displayName: 'Build V'
+trigger:
+  branches:
+    include:
+      - '*'
+pr:
+  autoCancel: false
+  branches:
+    include:
+      - '*'


### PR DESCRIPTION
Though #696 was merged, it doesn't seem that PR builds are triggered. Hence, I experimentally updated `azure-pipelines.yml` by referring to [docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops&tabs=yaml#pr-triggers).

In addition, I added `autoCancel: false` because canceled builds cause :x: which makes people disgusted.