### PR TITLE
REPL: Create new line while pressing enter

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -859,7 +859,7 @@ fn run_repl() []string {
 		print('>>> ')
 		mut line := os.get_line().trim_space()
 		if line == '' {
-			break
+			continue
 		}
 		// Save the source only if the user is printing something,
 		// but don't add this print call to the `lines` array,


### PR DESCRIPTION
Pressing Enter in REPL should create new line instead of quitting the REPL.

closes #718