### PR TITLE
repl: add exit command

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -852,14 +852,14 @@ fn new_v(args[]string) *V {
 
 fn run_repl() []string {
 	println('V $Version')
-	println('Use Ctrl-D to exit')
+	println('Use exit() to exit')
 	println('For now you have to use println() to print values, this will be fixed soon\n')
 	file := TmpPath + '/vrepl.v'
 	mut lines := []string
 	for {
 		print('>>> ')
 		mut line := os.get_line().trim_space()
-		if line == '' {
+		if line == 'exit()' {
 			break
 		}
 		// Save the source only if the user is printing something,

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -852,14 +852,14 @@ fn new_v(args[]string) *V {
 
 fn run_repl() []string {
 	println('V $Version')
-	println('Use exit() to exit')
+	println('Use Ctrl-D to exit')
 	println('For now you have to use println() to print values, this will be fixed soon\n')
 	file := TmpPath + '/vrepl.v'
 	mut lines := []string
 	for {
 		print('>>> ')
 		mut line := os.get_line().trim_space()
-		if line == 'exit()' {
+		if line == '' || line == 'exit' {
 			break
 		}
 		// Save the source only if the user is printing something,


### PR DESCRIPTION
Typing `exit()` in REPL will exit.  While `Ctrl+D` is `End Of File` on *nix, it's `Ctrl-Z` on Windows.  `Ctrl-D` also has the unfortunate side effect of closing WSL entirely.

This also addresses #718 as now just pressing enter will do nothing
