### PR TITLE
time: fix uni was zero

### DIFF
--- a/time/time.v
+++ b/time/time.v
@@ -64,6 +64,7 @@ pub fn convert_ctime(t tm) Time {
 		hour: t.tm_hour
 		minute: t.tm_min
 		second: t.tm_sec
+		uni: C.mktime(&t)
 	}
 	// uni = uni;
 }


### PR DESCRIPTION
When `calc_unix`  is `pub`.
Change `rand`
```
pub fn seed() {
	C.srand(time.now().calc_unix())
}
```
Run:
```
import rand

fn main(){
  rand.seed()
  println(rand.next(10))
}
```
Out:
```
/Users/nzlov//.vlang//hello_world.c:3232:41: error: passing 'time__Time' (aka 'struct time__Time') to parameter of incompatible type 'unsigned int'
 time__Time_calc_unix(& /* ? */ srand ( time__now ( ) ) ) ;
                                        ^~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdlib.h:164:21: note: passing argument to parameter here
void     srand(unsigned) __swift_unavailable("Use arc4random instead.");
                       ^
1 error generated.
V panic: clang error
```