### PR TITLE
buildin: add flush_stdout() func

### DIFF
--- a/builtin/builtin.v
+++ b/builtin/builtin.v
@@ -57,6 +57,10 @@ pub fn print(s string) {
 	C.printf('%.*s', s.len, s.str)
 }
 
+pub fn flush_stdout() {
+	C.fflush(stdout)
+}
+
 __global total_m i64 = 0
 pub fn malloc(n int) byteptr {
 	if n < 0 {


### PR DESCRIPTION
in default, print string to `stdout` has buffer, short message printed to stdout cannot display immediately, add flush_stdout() function resolve this problem

sample code:
```v
import time

fn main() {
        print('hello ')
        flush_stdout()
        time.sleep(time.Time{ sec: 2 })
        println('world!')
}
```
