### PR TITLE
compiler: clears MainFn vars when recompile on repl

### DIFF
--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -88,6 +88,11 @@ fn (f mut Fn) register_var(v Var) {
 	f.var_idx++
 }
 
+fn (f mut Fn) clear_vars() {
+	f.var_idx = 0
+	f.local_vars = []Var
+}
+
 // vlib header file?
 fn (p mut Parser) is_sig() bool {
 	return (p.build_mode == DEFAULT_MODE || p.build_mode == BUILD) &&

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -249,6 +249,9 @@ fn (p mut Parser) parse() {
 				} 
 				if p.cur_fn.name == '' {
 					p.cur_fn = MainFn 
+					if p.is_repl {
+						p.cur_fn.clear_vars()
+					}
 				} 
 				start := p.cgen.lines.len
 				p.statement(true)


### PR DESCRIPTION
Clear MainFn var when recompile with repl otherwise variables would have already been defined:

```
>>> ab := 0
>>> println(ab)
p0
>>> rintln(ab)
panic: vrepl.v:1
redefinition of `ab`
```

Fixes #756 