### PR TITLE
fix_replace

### DIFF
--- a/builtin/string.v
+++ b/builtin/string.v
@@ -75,7 +75,7 @@ pub fn (s string) cstr() byteptr {
 
 pub fn (s string) replace(rep, with string) string {
 	if s.len == 0 || rep.len == 0 {
-		return ''
+		return s
 	}
 	if !s.contains(rep) {
 		return s

--- a/builtin/string_test.v
+++ b/builtin/string_test.v
@@ -165,6 +165,8 @@ fn test_replace() {
 	assert b.replace('B', '') == 'onetwothree'
 	b = '**char'
 	assert b.replace('*char', 'byteptr') == '*byteptr'
+	mut c :='abc'
+	assert c.replace('','-') == c
 }
 
 fn test_itoa() {


### PR DESCRIPTION
fix string replace function ,
fix before 
'abc'.replace('','-') --> ''
fix after 
'abc'.replace('','-') --> 'abc'
that is to say ,when rep is blank, will return source string
