### PR TITLE
os.v getexepath(): C.GetmoduleFileName compiles to incompatible type pointer *GetModuleF…

### DIFF
--- a/os/os.v
+++ b/os/os.v
@@ -476,7 +476,7 @@ pub fn getexepath() string {
 	}
 
 	$if windows {
-		return tos( result, C.GetModuleFileName( 0, result, MAX_PATH ) )
+		return tos( result, int(C.GetModuleFileName( 0, result, MAX_PATH )) )
 	}
 
 	$if mac {


### PR DESCRIPTION
…ileName. Casting to int fixes the problem. Investigate: Is it default behavior for v C calls to return pointers?

Fixes getexepath() on windows. 
when compiled C.GetModuleFileName becomes a pointer, which is incompatible with tos(). 