### PR TITLE
Windows: Implement getwd() & make ls() public.

### DIFF
--- a/os/os_win.v
+++ b/os/os_win.v
@@ -4,9 +4,20 @@
 
 module os
 
-fn ls(path string) []string {
+pub fn ls(path string) []string {
 	mut res := []string
 	return res
+}
+
+pub fn getwd() string {
+	mut buffer := malloc(512)
+	
+	buffer = C._getcwd(0, 0)
+	// A NULL return value indicates an error
+	if isnil(buffer) {
+		return ''
+	}
+	return string(buffer)
 }
 
 const (
@@ -20,11 +31,6 @@ fn is_dir(path string) bool {
 
 fn chdir(path string) {
 	C._chdir(path.cstr())
-}
-
-fn getwd() string {
-	panic('getwd() not impl')
-	return ''
 }
 
 fn log(s string) {


### PR DESCRIPTION
This PR implements getwd() for Windows and makes ls() public.

