### PR TITLE
string: Graceful substr() handling like Python slices

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -330,16 +330,39 @@ pub fn (s string) right(n int) string {
 // puts(substr.str) will print 'rivet'
 // Avoid using C functions with these substrs!
 pub fn (s string) substr(start, end int) string {
-	/*
-	if start > end || start >= s.len || end > s.len || start < 0 || end < 0 {
-		panic('substr($start, $end) out of bounds (len=$s.len)')
-		return ''
+	// Think of the indices as pointing between characters,
+	// like slicing a salami:
+	//  0	1   2	3   4	5   6
+	//  +---+---+---+---+---+---+
+	//  | p | r | i | v | e | t |
+	//  +---+---+---+---+---+---+
+	// -6  -5  -4  -3  -2  -1
+	// Negative indexes count from the back
+	if start < 0 {
+	    start = s.len + start
 	}
-*/
-	if start >= s.len {
-		return ''
+	if end < 0 {
+	    end = s.len + end
 	}
+	// Handle overflows
+	if start > s.len {
+	    start = s.len
+	}
+	if end > s.len {
+	    end = s.len
+	}
+	// Handle underflows
+	if start < 0 {
+	    start = 0
+	}
+	if end < 0 {
+	    end = 0
+	}
+	// Cannot be less than empty (handles switched indexes)
 	len := end - start
+	if len <= 0 {
+	    return ''
+	}
 	res := string {
 		str: s.str + start
 		len: len

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -205,6 +205,34 @@ fn test_runes() {
 	assert u.substr(1, 4) == 'рив'
 	assert s2.substr(1, 2) == 'r'
 	assert u.substr(1, 2) == 'р'
+	assert s2.substr(1, 4).len == 3
+	assert s2.substr(1, 4) == 'riv'
+	assert s2.substr(0, 2).len == 2
+	assert s2.substr(0, 2) == 'pr'
+	assert s2.substr(0, 6).len == 6
+	assert s2.substr(0, 6) == 'privet'
+	assert s2.substr(0, 7).len == 6
+	assert s2.substr(0, 7) == 'privet'
+	assert s2.substr(2, 2).len == 0
+	assert s2.substr(2, 2) == ''
+	assert s2.substr(4, 2).len == 0
+	assert s2.substr(4, 2) == ''
+	assert s2.substr(20, 2).len == 0
+	assert s2.substr(20, 2) == ''
+	assert s2.substr(1, 99).len == 5
+	assert s2.substr(1, 99) == 'rivet'
+	assert s2.substr(-4, -1).len == 3
+	assert s2.substr(-4, -1) == 'ive'
+	assert s2.substr(-4, 4).len == 2
+	assert s2.substr(-4, 4) == 'iv'
+	assert s2.substr(-1, -3) == ''
+	assert s2.substr(-1, -3).len == 0
+	assert s2.substr(-8, -1) == 'prive'
+	assert s2.substr(-8, -1).len == 5
+	assert s2.substr(-10, -44).len == 0
+	assert s2.substr(-10, -44) == ''
+	assert u.substr(1, 4).len == 6
+	assert u.substr(1, 4) == 'рив'
 	assert s2.ustring().at(1) == 'r'
 	assert u.at(1) == 'р'
 	// ///////


### PR DESCRIPTION
- Do not overflow or underflow, but always return a sensible string
- Handle negative indexes (counting from the end)
- Add more unit tests for special cases
- Keep existing test cases passing

Think of the indices as pointing between characters,
like in Python:
https://stackoverflow.com/questions/509211/understanding-slice-notation
