### PR TITLE
Makefile: add make install command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,10 @@ test: v
 	echo "Building V examples..."
 	find examples -name '*.v' -print0 | xargs -0 -n1 ./v
 
+install:
+	mkdir -p /opt/v/
+	cp -ar ./* /opt/v/
+	ln -s /opt/v/v /usr/local/bin/v
+
 clean:
 	-rm -f v.c v vprod

--- a/README.md
+++ b/README.md
@@ -68,8 +68,12 @@ cc -std=gnu11 -w -o v v.c  # Build it with Clang or GCC
 
 That's it! Now you have a V executable at `[path to V repo]/v`.
 
-You can create a symlink so that it's globally available:
+You can now install it globally by executing:
 
+```
+sudo make install
+```
+Or without make:
 ```
 sudo ln -s [path to V repo]/v /usr/local/bin/v
 ```


### PR DESCRIPTION
This PR adds the `install` target to the Makefile.

By implementing this command, V can be installed via the standart
```
make
sudo make install
```
Workflow