### PR TITLE
builtin : fix issue with int.hex

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -125,8 +125,8 @@ pub fn (b bool) str() string {
 pub fn (n int) hex() string {
 	s := n.str()
 	hex := malloc(s.len + 3) // 0x + \n 
-	C.sprintf(hex, '0x%x', n)
-	return tos(hex, s.len + 3)
+	count := int(C.sprintf(hex, '0x%x', n))
+	return tos(hex, count)
 }
 
 pub fn (n i64) hex() string {


### PR DESCRIPTION
Fix issue with `int` method `hex`.

`hex` method returned a string with the new hex value and it length + 3. But not all hex's needs the +3, hence the length of the hex wrong in some cases.

The fix simply consist of taking the return value from `C.sprintf` and use it as the string length.
 
Fixes #820 