### PR TITLE
Restructured termcolor to term module and added CSI/Cursor Control support

### DIFF
--- a/examples/terminal_control.v
+++ b/examples/terminal_control.v
@@ -1,0 +1,30 @@
+import term
+
+fn main() {
+	term.erase_clear()
+	sleeping_line(5,5,5,'*')
+	standing_line(5,5,5,'*')
+	sleeping_line(5,10,5,'*')
+	standing_line(9,5,5,'*')
+	term.cursor_down(5)
+	print('\n')
+	println(term.bold(term.red('It Worked!')))
+}
+
+fn sleeping_line(x,y,size int, ch string) {
+	mut i := 0
+	for i < size {
+		term.set_cursor_position(x+i,y)
+		print(term.bold(term.yellow(ch)))
+		i++
+	}
+}
+
+fn standing_line(x,y,size int, ch string) {
+	mut i := 0
+	for i < size {
+		term.set_cursor_position(x,y+i)
+		print(term.bold(term.yellow(ch)))
+		i++
+	}
+}

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -1,6 +1,6 @@
 module log
 
-import termcolor
+import term
 
 const (
     FATAL = 1
@@ -26,28 +26,28 @@ pub fn (l Log) fatal(s string){
 
 pub fn (l Log) error(s string){
     if l.level >= ERROR{
-        f := termcolor.red('E')
+        f := term.red('E')
         println('[$f]$s')
     }
 }
 
 pub fn (l Log) warn(s string){
     if l.level >= WARN{
-        f := termcolor.yellow('W')
+        f := term.yellow('W')
         println('[$f]$s')
     }
 }
 
 pub fn (l Log) info(s string){
     if l.level >= INFO{
-        f := termcolor.white('I')
+        f := term.white('I')
         println('[$f]$s')
     }
 }
 
 pub fn (l Log) debug(s string){
     if l.level >= DEBUG{
-        f := termcolor.blue('D')
+        f := term.blue('D')
         println('[$f]$s')
     }
 }

--- a/vlib/term/colors.v
+++ b/vlib/term/colors.v
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 
-module termcolor
+module term
 
 pub fn format(msg, open, close string) string {
     return '\x1b[' + open + 'm' + msg + '\x1b[' + close + 'm'

--- a/vlib/term/control.v
+++ b/vlib/term/control.v
@@ -1,0 +1,110 @@
+// Copyright (c) 2019 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+module term
+
+// Sources for ANSI Control Sequences
+// https://github.com/RajeshPatkarInstitute/Panim
+// https://www.gnu.org/software/screen/manual/html_node/Control-Sequences.html
+// https://en.wikipedia.org/wiki/ANSI_escape_code
+
+// Support for Windows
+// https://en.wikipedia.org/wiki/ANSI.SYS
+// #include <windows.h>
+// C.SetConsoleMode(ENABLE_VIRTUAL_TERMINAL_INPUT)
+
+// Setting cursor to the given position
+// x is the x coordinate
+// y is the y coordinate
+pub fn set_cursor_position(x int,y int) {
+    print('\x1b[$y;$x;H')
+}
+
+// n is number of cells
+// direction: A is up / North
+// direction: B is down / South
+// direction: C is forward / East
+// direction: D is backward / West
+pub fn move(n int,direction string) string {
+    return '\x1b[$n$direction'
+}
+
+pub fn cursor_up(n int) {
+    print(move(n,'A'))
+}
+
+pub fn cursor_down(n int) {
+    print(move(n,'B'))
+}
+
+pub fn cursor_forward(n int) {
+    print(move(n,'C'))
+}
+
+pub fn cursor_back(n int) {
+    print(move(n,'D'))
+}
+
+// type: 0 -> current cursor postion to end of the screen
+// type: 1 -> current cursor postion to beginning of the screen
+// type: 2 -> clears entire screen
+// type: 3 -> clears entire screen and also delete scrollback buffer
+pub fn erase_display(t string) {
+    print('\x1b[' + t + 'J')
+}
+
+pub fn erase_toend()
+{
+    erase_display('0')
+}
+
+pub fn erase_tobeg()
+{
+    erase_display('1')
+}
+
+pub fn erase_clear()
+{
+    erase_display('2')
+}
+
+pub fn erase_del_clear()
+{
+    erase_display('3')
+}
+
+// type: 0 -> current cursor postion to end of the line
+// type: 1 -> current cursor postion to beginning of the line
+// type: 2 -> clears entire line
+// Note: Cursor position does not change
+pub fn erase_line(t string) {
+    print('\x1b[' + t + 'K')
+}
+
+pub fn erase_line_toend()
+{
+    erase_line('0')
+}
+
+pub fn erase_line_tobeg()
+{
+    erase_line('1')
+}
+
+pub fn erase_line_clear()
+{
+    erase_line('2')
+}
+
+// Will make cursor appear if not visible
+pub fn show_cursor()
+{
+	print('\x1b[?25h')
+}
+
+// Will make cursor invisible
+pub fn hide_cursor()
+{
+	print('\x1b[?25l')
+}


### PR DESCRIPTION
Restructured the termcolor module which was purely for color and text is now transformed into term module which has CSI Sequence support which allows the user to control the cursor in the terminal, also added utility functions for clearing console screen, clearing line and also cursor visibility.

An example code has been added to examples folder under the name ```terminal_control.v```.