### PR TITLE
scanner: fix bug when scanning program starting with one character int

### DIFF
--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -151,8 +151,7 @@ fn (s mut Scanner) scan() ScanRes {
 	// if s.file_path == 'd.v' {
 	// println('\nscan()')
 	// }
-	// if s.started {
-	if s.pos > 0 {
+	if s.started {
 		// || (s.pos == 0 && s.text.len > 0 && s.text[s.pos] == `\n`) {
 		s.pos++
 	}


### PR DESCRIPTION
This PR fixes #898.

If we compile the program starting with one character integer like
```go
1+1
```
V compiler never returns and fall into an infinite loop. The cause of this bug is following code in scanner.v
```go
fn (s mut Scanner) scan() ScanRes {
        ...
         if s.pos > 0 {
                // || (s.pos == 0 && s.text.len > 0 && s.text[s.pos] == `\n`) {
                 s.pos++
         }
        ...
```
In first time of scanning, we scan `1` and `s.pos` is 0. After first time of scanning, we want scan next token('+') but `s.pos` is still 0, the scanner doesn't do `s.pos++` so we scan `1` again and again.

This PR fixes this bug.