### PR TITLE
compiler: tmp variables on scripts inside generated main function

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -259,8 +259,11 @@ fn (p mut Parser) parse() {
 						p.cur_fn.clear_vars()
 					}
 				} 
-				start := p.cgen.lines.len
+				mut start := p.cgen.lines.len
 				p.statement(true)
+				if p.cgen.lines[start - 1] != '' && p.cgen.fn_main != '' {
+					start--
+				}
 				p.genln('') 
 				end := p.cgen.lines.len
 				lines := p.cgen.lines.slice(start, end)


### PR DESCRIPTION
Generated tmp variables were outside of generated main function scope on scripts with no main.

Fixes #887 