### PR TITLE
compiler: allow --version arg as it already do for help

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -95,7 +95,7 @@ mut:
 fn main() {
 	args := os.args
 	// Print the version and exit.
-	if '-v' in args || 'version' in args {
+	if '-v' in args || '--version' in args || 'version' in args {
 		println('V $Version')
 		return
 	}


### PR DESCRIPTION
I just allow to run V with --version as argument as it's possible with help. Just for consistency.


Make test failed but it the root should not be my change

I ran twice the next cmd
./v -o v compiler

and then I ran V with the new --version arg successfully
```
[yvan@manjaro v]$ ./v --version
V 0.1.11
```

PS it's also my first commit. So I started with an easy one ;)