### PR TITLE
os.write_file: do not add and newline

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -231,7 +231,6 @@ pub fn (f File) writeln(s string) {
 	// TODO perf
 	C.fputs(s.cstr(), f.cfile)
 	// ss.free()
-	C.fputs('\n', f.cfile)
 }
 
 pub fn (f File) close() {


### PR DESCRIPTION
Do not add any newline at the end of the file. We should let the user choose it he want a newline or not at the end of the file. If yes he can simply wirte 'some text\n'

V compile itself without issue.
