### PR TITLE
compiler: fix "nested comment won't compile" (#908)

### DIFF
--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -455,8 +455,9 @@ fn (s mut Scanner) scan() ScanRes {
 		// Multiline comments
 		if nextc == `*` {
 			start := s.pos
+			mut nest_count := 1
 			// Skip comment
-			for ! (s.text[s.pos] == `*` && s.text[s.pos + 1] == `/`) {
+			for nest_count > 0 {
 				s.pos++
 				if s.pos >= s.text.len {
 					s.line_nr--
@@ -464,6 +465,14 @@ fn (s mut Scanner) scan() ScanRes {
 				}
 				if s.text[s.pos] == `\n` {
 					s.line_nr++
+					continue
+				}
+				if s.text[s.pos] == `/` && s.text[s.pos + 1] == `*` {
+					nest_count++
+					continue
+				}
+				if s.text[s.pos] == `*` && s.text[s.pos + 1] == `/` {
+					nest_count--
 				}
 			}
 			s.pos++

--- a/compiler/tests/fn_test.v
+++ b/compiler/tests/fn_test.v
@@ -1,3 +1,26 @@
+// 1 line comment
+
+/* 1 line comment */
+
+/*
+multi line comment (1)
+multi line comment (2)
+multi line comment (3)
+*/
+
+/*
+	multi line comment (1)
+	/*
+		nested comment
+	*/
+	/*nested comment*/
+	/*nested comment
+*/
+	/* nested comment */
+	/* /* nested comment */ */
+	multi line comment (2)
+*/
+
 type myfn fn (int) string
 
 type myfn2 fn (a int, b int) int
@@ -35,6 +58,9 @@ type actionf_p2 fn (voidptr, voidptr)
 
 fn myprint(s string, ..) {
 	println('my print')
+	println('// comment')
+	println('/* comment */')
+	println('/* /* comment */ */')
 }
 
 fn test_fns() {


### PR DESCRIPTION
This code couldn't compile.
I will fix it.
And I add tests of comment to `./compiler/tests/fn_test.v`.

```
// This is a single line comment.

/* This is a multiline comment.
/* It can be nested. */
*/

fn main() {
println('hello v')
}
```
