### PR TITLE
builtin : fix buffer overflow and i64 issue with hex()

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -123,17 +123,25 @@ pub fn (b bool) str() string {
 }
 
 pub fn (n int) hex() string {
-	s := n.str()
-	hex := malloc(s.len + 3) // 0x + \n 
+	len := if n >= 0 {
+		n.str().len + 3
+	} else {
+		11
+	}
+	hex := malloc(len) // 0x + \n 
 	count := int(C.sprintf(hex, '0x%x', n))
 	return tos(hex, count)
 }
 
 pub fn (n i64) hex() string {
-	s := n.str()
-	hex := malloc(s.len + 3)
-	C.sprintf(hex, '0x%x', n)
-	return tos(hex, s.len + 3)
+	len := if n >= i64(0) {
+		n.str().len + 3
+	} else {
+		19
+	}
+	hex := malloc(len)
+	count := int(C.sprintf(hex, '0x%x', n))
+	return tos(hex, count)
 }
 
 pub fn (a []byte) contains(val byte) bool {


### PR DESCRIPTION
Fix buffer overflow in method `hex` and left #820 support for `i64`.

If you give a minus number as -1 to method `hex`, it calculates that the length of variable `hex` is 5 while `C.sprintf` puts `0xffffffff`. This case causes buffer overflow.