### PR TITLE
net: added listen_backlog to enable custom backlog

### DIFF
--- a/examples/using_constructs.v
+++ b/examples/using_constructs.v
@@ -1,0 +1,18 @@
+import math
+
+fn main() {
+	f1 := math.fraction(2,4)
+	f2 := math.fraction(5,10)
+	println(f1 + f2)
+	println(f2 - f1)
+	println(f1.multiply(f2))
+	println(f1.divide(f2))
+	println(f1.gcf())
+	println(f1.reduce())
+	println(f2.gcf())
+	println(f2.reduce())
+	println(f1.reciprocal())
+	println(f2.reciprocal())
+	println(f1.equals(f1))
+	println(f2.equals(f2))
+}

--- a/examples/using_constructs.v
+++ b/examples/using_constructs.v
@@ -15,4 +15,7 @@ fn main() {
 	println(f2.reciprocal())
 	println(f1.equals(f1))
 	println(f2.equals(f2))
+	println(f1.equals(f2))
+	println(f1.to_decimal())
+	println(f2.to_decimal())
 }

--- a/vlib/math/fraction.v
+++ b/vlib/math/fraction.v
@@ -1,0 +1,103 @@
+// Copyright (c) 2019 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+module math
+
+// Fraction Struct
+struct Fraction {
+	n int
+	d int
+}
+
+// A factory function for creating a Fraction, adds a boundary condition
+pub fn fraction(n int,d int) Fraction{
+	if d != 0 {
+		return Fraction{n,d}
+	} 
+	else {
+		panic('Denominator cannot be zero')
+	}
+}
+
+// To String method
+pub fn (f Fraction) str() string { 
+	return '$f.n/$f.d' 
+}
+
+// Fraction add using operator overloading
+pub fn (f1 Fraction) + (f2 Fraction) Fraction {
+	if f1.d == f2.d {
+		return Fraction{f1.n + f2.n,f1.d}
+	}
+	else {
+		return Fraction{(f1.n * f2.d) + (f2.n * f1.d),f1.d * f2.d}
+	}
+}
+
+// Fraction substract using operator overloading
+pub fn (f1 Fraction) - (f2 Fraction) Fraction {
+	if f1.d == f2.d {
+		return Fraction{f1.n - f2.n,f1.d}
+	}
+	else {
+		return Fraction{(f1.n * f2.d) - (f2.n * f1.d),f1.d * f2.d}
+	}
+}
+
+// Fraction multiply using operator overloading
+// pub fn (f1 Fraction) * (f2 Fraction) Fraction {
+// 	return Fraction{f1.n * f2.n,f1.d * f2.d}
+// }
+
+// Fraction divide using operator overloading
+// pub fn (f1 Fraction) / (f2 Fraction) Fraction {
+// 	return Fraction{f1.n * f2.d,f1.d * f2.n}
+// }
+
+// Fraction add method
+pub fn (f1 Fraction) add(f2 Fraction) Fraction {
+	return f1 + f2
+}
+
+// Fraction substract method
+pub fn (f1 Fraction) substract(f2 Fraction) Fraction {
+	return f1 - f2
+}
+
+// Fraction multiply method
+pub fn (f1 Fraction) multiply(f2 Fraction) Fraction {
+	return Fraction{f1.n * f2.n,f1.d * f2.d}
+}
+
+// Fraction divide method
+pub fn (f1 Fraction) divide(f2 Fraction) Fraction {
+	return Fraction{f1.n * f2.d,f1.d * f2.n}
+}
+
+// Fraction reciprocal method
+pub fn (f1 Fraction) reciprocal() Fraction {
+	return Fraction{f1.d,f1.n}
+}
+
+// Fraction method which gives greatest common divisor of numerator and denominator
+pub fn (f1 Fraction) gcf() int {
+	return gcd(f1.n,f1.d)
+}
+
+// Fraction method which reduces the fraction
+pub fn (f1 Fraction) reduce() Fraction {
+	cf := gcd(f1.n,f1.d)
+	return Fraction{f1.n/cf,f1.d/cf}
+}
+
+// Converts Fraction to decimal
+// Typecasting?
+// pub fn (f1 Fraction) to_decimal() f64 {
+// 	return f1.n/f1.d
+// }
+
+// Compares two Fractions
+pub fn (f1 Fraction) equals(f2 Fraction) bool {
+	return (f1.n == f2.n) && (f1.d == f2.d)
+}

--- a/vlib/math/fraction.v
+++ b/vlib/math/fraction.v
@@ -92,12 +92,13 @@ pub fn (f1 Fraction) reduce() Fraction {
 }
 
 // Converts Fraction to decimal
-// Typecasting?
-// pub fn (f1 Fraction) to_decimal() f64 {
-// 	return f1.n/f1.d
-// }
+pub fn (f1 Fraction) to_decimal() f64 {
+	return f64(f1.n)/f64(f1.d)
+}
 
 // Compares two Fractions
 pub fn (f1 Fraction) equals(f2 Fraction) bool {
-	return (f1.n == f2.n) && (f1.d == f2.d)
+	r1 := f1.reduce()
+	r2 := f2.reduce()
+	return (r1.n == r1.n) && (r2.d == r2.d)
 }

--- a/vlib/net/socket.v
+++ b/vlib/net/socket.v
@@ -88,6 +88,16 @@ pub fn (s Socket) listen() int {
 	return res
 }
 
+// put socket into passive mode with user specified backlog and wait to receive
+pub fn (s Socket) listen_backlog(backlog int) int {
+	mut n := 0
+	if backlog > 0 {
+		n = backlog
+	}
+	res := C.listen(s.sockfd, n)
+	return res
+}
+
 // helper method to create, bind, and listen given port number
 pub fn listen(port int) Socket {
 	s := socket(AF_INET, SOCK_STREAM, 0)


### PR DESCRIPTION
This PR introduces a new method namely ```listen_backlog```  in to the net module which allows user to listen and specify the number of backlog connections to be allowed on a given socket