### PR TITLE
math: digits function; SqrtTau; extra spaces; re writed doc's to correct form; test for factorial

### DIFF
--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -13,6 +13,7 @@ const (
 	Sqrt2   = 1.41421356237309504880168872420969807856967187537694807317667974
 	SqrtE   = 1.64872127070012814684865078781416357165377610071014801157507931
 	SqrtPi  = 1.77245385090551602729816748334114518279754945612238712821380779
+	SqrtTau = 2.50662827463100050241576528481104525300698674060993831662992357
 	SqrtPhi = 1.27201964951406896425242246173749149171560804184009624861664038
 
 	Ln2    = 0.693147180559945309417232121458176568075500134360255254120680009
@@ -29,67 +30,82 @@ pub fn abs(a f64) f64 {
 	return a
 }
 
-// Inverse cosine.
+// acos calculates inversed cosine (arccosine).
 pub fn acos(a f64) f64 {
 	return C.acos(a)
 }
 
-// Inverse sine.
+// asin calculates inversed sine (arcsine).
 pub fn asin(a f64) f64 {
 	return C.asin(a)
 }
 
-// Inverse tangent
+// atan calculates inversed tangent (arctangent).
 pub fn atan(a f64) f64 {
 	return C.atan(a)
 }
 
-// Inverse tangent with two arguments, returns angle between the X axis and the point.
+// atan2 calculates inverseed tangent with two arguments, returns angle between the X axis and the point.
 pub fn atan2(a, b f64) f64 {
 	return C.atan2(a, b)
 }
 
-// Cubic root.
+// cbrt calculates cubic root.
 pub fn cbrt(a f64) f64 {
-	return C.cbrt(a)	
+	return C.cbrt(a)
 }
 
-// Returns the nearest integer equal or higher to the provided value.
+// ceil returns the nearest integer equal or higher to the provided value.
 pub fn ceil(a f64) f64 {
 	return C.ceil(a)
 }
 
-// Cosine.
+// cos calculates cosine.
 pub fn cos(a f64) f64 {
 	return C.cos(a)
 }
 
-// Hyperbolic cosine.
+// cosh calculates hyperbolic cosine.
 pub fn cosh(a f64) f64 {
 	return C.cosh(a)
 }
 
-// Returns euler number (e) raised to the provided power.
+// exp calculates exponement of the number (math.pow(math.E, a)).
 pub fn exp(a f64) f64 {
 	return C.exp(a)
 }
 
-// Returns the base-2 exponential function of x.
-pub fn exp2(a f64) f64 {
-	return C.exp2(a)	
+// digits returns an array of the digits of n in the given base.
+pub fn digits(n, base int) []int {
+	mut sign := 1
+	if n < 0 {
+		sign = -1
+		n = -n
+	}
+	mut res := []int
+	for n != 0 {
+		res << (n % base) * sign
+		n /= base
+	}
+	return res
 }
 
-// Returns the nearest integer equal or lower of the provided value.
+// exp2 returns the base-2 exponential function of a (math.pow(2, a)).
+pub fn exp2(a f64) f64 {
+	return C.exp2(a)
+}
+
+// floor returns the nearest integer equal or lower of the provided value.
 pub fn floor(a f64) f64 {
 	return C.floor(a)
 }
 
-// Returns the floating-point remainder of number / denom (rounded towards zero):
+// fmod returns the floating-point remainder of number / denom (rounded towards zero):
 pub fn fmod(a, b f64) f64 {
 	return C.fmod(a, b)
 }
 
-// gcd calculates greatest common (positive) divisor (or zero if x and y are both zero).
+// gcd calculates greatest common (positive) divisor (or zero if a and b are both zero).
 pub fn gcd(a, b int) int {
 	if a < 0 {
 		a = -a
@@ -119,27 +135,27 @@ pub fn lcm(a, b int) int {
 	return res
 }
 
-// Returns natural (base e) logarithm of the provided value.
+// log calculates natural (base e) logarithm of the provided value.
 pub fn log(a f64) f64 {
 	return C.log(a)
 }
 
-// Returns base 2 logarithm of the provided value.
+// log2 calculates base-2 logarithm of the provided value.
 pub fn log2(a f64) f64 {
-	return C.log(a) / C.log(2)	
+	return C.log(a) / C.log(2)
 }
 
-// Returns the common (base-10) logarithm of x.
+// log10 calculates the common (base-10) logarithm of the provided value.
 pub fn log10(a f64) f64 {
 	return C.log10(a)
 }
 
-// Returns base N logarithm of the provided value.
+// log_n calculates base-N logarithm of the provided value.
 pub fn log_n(a, b f64) f64 {
 	return C.log(a) / C.log(b)
 }
 
-// Returns the maximum value of the two provided.
+// max returns the maximum value of the two provided.
 pub fn max(a, b f64) f64 {
 	if a > b {
 		return a
@@ -147,7 +163,7 @@ pub fn max(a, b f64) f64 {
 	return b
 }
 
-// Returns the minimum value of all the values provided.
+// min returns the minimum value of all the values provided.
 pub fn min(a, b f64) f64 {
 	if a < b {
 		return a
@@ -155,59 +171,59 @@ pub fn min(a, b f64) f64 {
 	return b
 }
 
-// Returns base raised to the provided power.
+// pow returns base raised to the provided power.
 pub fn pow(a, b f64) f64 {
 	return C.pow(a, b)
 }
 
-// Radians conversion.
+// radians convert from radians to degrees.
 pub fn radians(degrees f64) f64 {
 	return degrees * (Pi / 180.0)
 }
 
-// Degrees conversion.
+// degrees convert from degrees to radians.
 pub fn degrees(radians f64) f64 {
 	return radians * (180.0 / Pi)
 }
 
-// Returns the integer nearest to the provided value.
+// round returns the integer nearest to the provided value.
 pub fn round(f f64) f64 {
 	return C.round(f)
 }
 
-// Sine.
+// sin calculates sine.
 pub fn sin(a f64) f64 {
 	return C.sin(a)
 }
 
-// Hyperbolic sine.
+// sinh calculates hyperbolic sine.
 pub fn sinh(a f64) f64 {
 	return C.sinh(a)
 }
 
-// Returns square of the provided value.
+// sqrt calculates square of the provided value.
 pub fn sqrt(a f64) f64 {
 	return C.sqrt(a)
 }
-// Tangent.
+// tan calculates tangent.
 pub fn tan(a f64) f64 {
 	return C.tan(a)
 }
 
-// Hyperbolic tangent.
+// tanh calculates hyperbolic tangent.
 pub fn tanh(a f64) f64 {
 	return C.tanh(a)
 }
 
-// Rounds a toward zero, returning the nearest integral value that is not
+// trunc rounds a toward zero, returning the nearest integral value that is not
 // larger in magnitude than a.
 pub fn trunc(a f64) f64 {
 	return C.trunc(a)
 }
 
-// Return the factorial of the value provided.
+// factorial calculates the factorial of the provided value.
 pub fn factorial(a int) i64 {
-	mut prod := 1	
+	mut prod := 1
 	for i:= 0; i < a; i++ {
 		prod = prod * (i+1)
 	}

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -13,3 +13,21 @@ fn test_lcm() {
 	assert math.lcm(-2, -3) == 6
 	assert math.lcm(0, 0) == 0
 }
+
+fn test_digits() {
+	digits_in_10th_base := math.digits(125, 10)
+	assert digits_in_10th_base[0] == 5
+	assert digits_in_10th_base[1] == 2
+	assert digits_in_10th_base[2] == 1
+
+	digits_in_16th_base := math.digits(15, 16)
+	assert digits_in_16th_base[0] == 15
+
+	negative_digits := math.digits(-4, 2)
+	assert negative_digits[2] == -1
+}
+
+fn test_factorial() {
+	assert math.factorial(5) == 120
+	assert math.factorial(0) == 1
+}


### PR DESCRIPTION
added `fn digits(n, base int) []int`
added `SqrtTau` constant
removed extra spaces
correct form of the docs
test for factorial