### PR TITLE
Allow to parse uppercase hex numbers

### DIFF
--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -94,7 +94,7 @@ fn (s mut Scanner) ident_number() string {
 		if c == `.` {
 			is_float = true
 		}
-		is_good_hex := is_hex && (c == `x`  || (c >= `a` && c <= `f`))
+		is_good_hex := is_hex && (c == `x`  || (c >= `a` && c <= `f`)  || (c >= `A` && c <= `F`))
 		// 1e+3, 1e-3, 1e3
 		if !is_hex && c == `e` && s.pos + 1 < s.text.len {
 			next := s.text[s.pos + 1]


### PR DESCRIPTION
Allow to handle uppercase hex numbers e.g. 0xFF as it already do for lowercase ones by adding a condition in the scanner.

V compile itself (./v -o v compiler ran twice) and then the folliwng code work.

```
fn main() {
    println(0xf & 0xf)
    println(0xF & 0xF)
}
```

Output:

```
10
10
```