### PR TITLE
net: socket send and recv

### DIFF
--- a/vlib/net/socket.v
+++ b/vlib/net/socket.v
@@ -154,6 +154,25 @@ pub fn dial(address string, port int) Socket {
 	return s
 }
 
+// send string data to socket
+pub fn (s Socket) send(buf byteptr, len int) int {
+	res := C.send(s.sockfd, buf, len, 0)
+	if res < 0 {
+		println('socket: send failed')
+	}
+	return res
+}
+
+// receive string data from socket
+pub fn (s Socket) recv(bufsize int) byteptr {
+	buf := malloc(bufsize)
+	res := C.recv(s.sockfd, buf, bufsize, 0)
+	if res < 0 {
+		println('socket: recv failed')
+	}
+	return buf
+}
+
 // shutdown and close socket
 pub fn (s Socket) close() int {
 	shutdown_res := C.shutdown(s.sockfd, SHUT_RDWR)

--- a/vlib/net/socket_test.v
+++ b/vlib/net/socket_test.v
@@ -7,7 +7,14 @@ fn test_socket() {
 //	println(client)
 //	socket := server.accept()
 //	println(socket)
-//
+
+//	message := 'Hello World'
+//	socket.send(message.cstr(), message.len)
+//	println('Sent: ' + message)
+
+//	bytes := client.recv(1024)
+//	println('Received: ' + tos(bytes, message.len))
+
 //	server.close()
 //	client.close()
 //	socket.close()


### PR DESCRIPTION
Data can now be exchanged between sockets

Here's an example web server

```
import net

fn main() {
        server := net.listen(8080)
        response := 'Hello World'

        for {
                connection := server.accept()
                connection.recv(1024)
                connection.send(response.str, response.len)
                connection.close()
        }
}
```

If you go to `localhost:8080` you should see `Hello World`
