### PR TITLE
os: capture signals

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -53,9 +53,14 @@ import const (
 	SEEK_SET
 	SEEK_END
 	SA_SIGINFO
-	SIGSEGV
 	S_IFMT
 	S_IFDIR
+	SIGABRT
+	SIGFPE
+	SIGILL
+	SIGINT
+	SIGSEGV
+	SIGTERM
 )
 
 struct C.stat {
@@ -585,6 +590,10 @@ $else {
 	C.closedir(dir)
 	return res
 } 
+}
+
+pub fn signal(signum int, handler voidptr) {
+	C.signal(signum, handler)
 }
 
 fn log(s string) {


### PR DESCRIPTION
Add support for capturing OS signals.  Asked about in #721 

```
import os

pub fn capture() {
    println('Interrupt Captured')
}

fn main() {
        os.signal(SIGINT, capture)
        for {
        }
}
```
