### PR TITLE
net: added listen_backlog to enable custom backlog

### DIFF
--- a/vlib/net/socket.v
+++ b/vlib/net/socket.v
@@ -88,6 +88,16 @@ pub fn (s Socket) listen() int {
 	return res
 }
 
+// put socket into passive mode with user specified backlog and wait to receive
+pub fn (s Socket) listen_backlog(backlog int) int {
+	mut n := 0
+	if backlog > 0 {
+		n = backlog
+	}
+	res := C.listen(s.sockfd, n)
+	return res
+}
+
 // helper method to create, bind, and listen given port number
 pub fn listen(port int) Socket {
 	s := socket(AF_INET, SOCK_STREAM, 0)


### PR DESCRIPTION
This PR adds a new method in the Socket struct namely ```listen_backlog``` enabling the user to listen with custom backlog