### PR TITLE
string: index_after method now returns ?int rather than int

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -775,9 +775,8 @@ fn get_arg(joined_args, arg, def string) string {
 		return def
 	}
 	pos += key.len
-	mut space := joined_args.index_after(' ', pos)
-	if space == -1 {
-		space = joined_args.len
+	mut space := joined_args.index_after(' ', pos) or {
+		return joined_args.substr(pos, joined_args.len)
 	}
 	res := joined_args.substr(pos, space)
 	// println('get_arg($arg) = "$res"')

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1627,7 +1627,7 @@ fn (p mut Parser) index_expr(typ string, fn_ph int) string {
 		if is_fixed_arr {
 			// `[10]int` => `int`, `[10][3]int` => `[3]int`
 			if typ.contains('][') {
-				pos := typ.index_after('[', 1)
+				pos := typ.index_after('[', 1)?
 				typ = typ.right(pos)
 			}
 			else {

--- a/examples/links_scraper.v
+++ b/examples/links_scraper.v
@@ -8,11 +8,10 @@ fn main() {
 	html := http.get('https://news.ycombinator.com')
 	mut pos := 0
 	for {
-		pos = html.index_after('https://', pos + 1)
-		if pos == -1 {
+		pos = html.index_after('https://', pos + 1) or {
 			break
 		}
-		end := html.index_after('"', pos)
+		end := html.index_after('"', pos)?
 		println(html.substr(pos, end))
 	}
 }

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -389,16 +389,16 @@ pub fn (s string) last_index(p string) int {
 	return -1
 }
 
-pub fn (s string) index_after(p string, start int) int {
+pub fn (s string) index_after(p string, start int) ?int {
 	if p.len > s.len {
-		return -1
+		return error('p.len > s.len')
 	}
 	mut strt := start
 	if start < 0 {
 		strt = 0
 	}
 	if start >= s.len {
-		return -1
+		return error('start >= length of receiver str')
 	}
 	mut i := strt
 	for i < s.len {
@@ -413,7 +413,7 @@ pub fn (s string) index_after(p string, start int) int {
 		}
 		i++
 	}
-	return -1
+	return error('string not found after given index')
 }
 
 pub fn (s string) contains(p string) bool {


### PR DESCRIPTION
string.index_after method now returns a `?int`

EDIT: I now see that the `val := f()?` functionality mentioned in https://vlang.io/docs#option , namely making

```
resp := http.get(url)?
println(resp.body)
```

a valid abbreviation of

```
resp := http.get(url) or {
	panic(err)
}
println(resp.body)
```

does not yet exist.

Once it does, the code in this PR will work.