### PR TITLE
builtin: added read and readln functions

### DIFF
--- a/examples/testing_readline.v
+++ b/examples/testing_readline.v
@@ -1,0 +1,8 @@
+fn main() {
+	print('Enter a character: ')
+	ch := read()
+	println('You entered $ch')
+	println('Please enter your name')
+	name := readln()
+	println('Hello $name')
+}

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -57,6 +57,24 @@ pub fn print(s string) {
 	C.printf('%.*s', s.len, s.str)
 }
 
+pub fn read() string {
+	mut ch := malloc(1)
+	*ch = C.getchar()
+	return tos(ch,1)
+}
+	
+pub fn readln() string {
+	mut str := ''
+	mut ch := malloc(1)
+	*ch = C.getchar()
+	curr := tos(ch,1)
+	for curr.ne('\n') {
+		str = str.add(curr)
+		*ch = C.getchar()
+	}
+	return str
+}
+
 __global total_m i64 = 0
 pub fn malloc(n int) byteptr {
 	if n < 0 {


### PR DESCRIPTION
This PR adds two functions  ```read``` and ```readln``` into the builtin module which facilitate reading a single character from **stdin** and a reading a line from **stdin** ( reading characters till ```\n``` ) these are essential functions which facilitate user input. These functions are platform independent as they use ```getchar``` which is available on every platform ( ```stdio.h``` )