### PR TITLE
math: converting gcd and lcm to accept i64

### DIFF
--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -106,7 +106,7 @@ pub fn fmod(a, b f64) f64 {
 }
 
 // gcd calculates greatest common (positive) divisor (or zero if a and b are both zero).
-pub fn gcd(a, b int) int {
+pub fn gcd(a, b i64) i64 {
 	if a < 0 {
 		a = -a
 	}
@@ -124,7 +124,7 @@ pub fn gcd(a, b int) int {
 }
 
 // lcm calculates least common (non-negative) multiple.
-pub fn lcm(a, b int) int {
+pub fn lcm(a, b i64) i64 {
 	if a == 0 {
 		return a
 	}


### PR DESCRIPTION
When refactoring Fraction to use ```i64```, I found that ```gcd``` and  ```lcm``` functions only accept int inputs so this PR is to convert those functions to support ```i64``` inputs. Will address the failing tests in the next commit which will convert fractions to ```i64```