### PR TITLE
Fixed fraction types mismatching

### DIFF
--- a/vlib/math/fraction.v
+++ b/vlib/math/fraction.v
@@ -6,14 +6,14 @@ module math
 
 // Fraction Struct
 struct Fraction {
-	n int
-	d int
+	n i64
+	d i64
 }
 
 // A factory function for creating a Fraction, adds a boundary condition
-pub fn fraction(n int,d int) Fraction{
+pub fn fraction(n i64, d i64) Fraction{
 	if d != 0 {
-		return Fraction{n,d}
+		return Fraction{n, d}
 	} 
 	else {
 		panic('Denominator cannot be zero')
@@ -31,28 +31,28 @@ pub fn (f1 Fraction) + (f2 Fraction) Fraction {
 		return Fraction{f1.n + f2.n,f1.d}
 	}
 	else {
-		return Fraction{(f1.n * f2.d) + (f2.n * f1.d),f1.d * f2.d}
+		return Fraction{(f1.n * f2.d) + (f2.n * f1.d), f1.d * f2.d}
 	}
 }
 
 // Fraction substract using operator overloading
 pub fn (f1 Fraction) - (f2 Fraction) Fraction {
 	if f1.d == f2.d {
-		return Fraction{f1.n - f2.n,f1.d}
+		return Fraction{f1.n - f2.n, f1.d}
 	}
 	else {
-		return Fraction{(f1.n * f2.d) - (f2.n * f1.d),f1.d * f2.d}
+		return Fraction{(f1.n * f2.d) - (f2.n * f1.d), f1.d * f2.d}
 	}
 }
 
 // Fraction multiply using operator overloading
 // pub fn (f1 Fraction) * (f2 Fraction) Fraction {
-// 	return Fraction{f1.n * f2.n,f1.d * f2.d}
+// 	return Fraction{f1.n * f2.n, f1.d * f2.d}
 // }
 
 // Fraction divide using operator overloading
 // pub fn (f1 Fraction) / (f2 Fraction) Fraction {
-// 	return Fraction{f1.n * f2.d,f1.d * f2.n}
+// 	return Fraction{f1.n * f2.d, f1.d * f2.n}
 // }
 
 // Fraction add method
@@ -67,33 +67,33 @@ pub fn (f1 Fraction) substract(f2 Fraction) Fraction {
 
 // Fraction multiply method
 pub fn (f1 Fraction) multiply(f2 Fraction) Fraction {
-	return Fraction{f1.n * f2.n,f1.d * f2.d}
+	return Fraction{f1.n * f2.n, f1.d * f2.d}
 }
 
 // Fraction divide method
 pub fn (f1 Fraction) divide(f2 Fraction) Fraction {
-	return Fraction{f1.n * f2.d,f1.d * f2.n}
+	return Fraction{f1.n * f2.d, f1.d * f2.n}
 }
 
 // Fraction reciprocal method
 pub fn (f1 Fraction) reciprocal() Fraction {
-	return Fraction{f1.d,f1.n}
+	return Fraction{f1.d, f1.n}
 }
 
 // Fraction method which gives greatest common divisor of numerator and denominator
-pub fn (f1 Fraction) gcf() int {
-	return gcd(f1.n,f1.d)
+pub fn (f1 Fraction) gcf() i64 {
+	return gcd(f1.n, f1.d)
 }
 
 // Fraction method which reduces the fraction
 pub fn (f1 Fraction) reduce() Fraction {
-	cf := gcd(f1.n,f1.d)
-	return Fraction{f1.n/cf,f1.d/cf}
+	cf := gcd(f1.n, f1.d)
+	return Fraction{f1.n/cf, f1.d/cf}
 }
 
 // Converts Fraction to decimal
 pub fn (f1 Fraction) to_decimal() f64 {
-	return f64(f1.n)/f64(f1.d)
+	return f64(f1.n) / f64(f1.d)
 }
 
 // Compares two Fractions


### PR DESCRIPTION
Replaced int -> `i64`
Function `gcd` takes i64, but not i32. 