### PR TITLE
compiler: fix #202 Cannot create interface that has no return value method

### DIFF
--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -120,6 +120,20 @@ fn (s mut Scanner) ident_number() string {
 	return number
 }
 
+fn (s Scanner) has_gone_over_line_end() bool {
+	mut i := s.pos-1
+	for i >= 0 && !is_white(s.text[i]) {
+		i--
+	}
+	for i >= 0 && is_white(s.text[i]) {
+		if is_nl(s.text[i]) {
+			return true
+		}
+		i--
+	}
+	return false
+}
+
 fn (s mut Scanner) skip_whitespace() {
 	for s.pos < s.text.len && is_white(s.text[s.pos]) {
 		if is_nl(s.text[s.pos]) {
@@ -148,7 +162,8 @@ fn (s mut Scanner) cao_change(operator string) {
 	s.text = s.text.substr(0, s.pos - operator.len) + ' = ' + s.get_var_name(s.pos - operator.len) + ' ' + operator + ' ' + s.text.substr(s.pos + 1, s.text.len)
 }
 
-fn (s mut Scanner) scan() ScanRes {
+fn (s mut Scanner) scan() 
+ScanRes {
 	// if s.file_path == 'd.v' {
 	// println('\nscan()')
 	// }

--- a/compiler/tests/interface_test.v
+++ b/compiler/tests/interface_test.v
@@ -1,0 +1,32 @@
+
+struct Dog {
+}
+
+fn (d Dog) speak() {
+	println('dog.speak()')
+}
+
+fn (d Dog) name() string {
+	return 'old gray'
+}
+
+interface Speaker {
+	name() string
+	speak() 
+}
+
+interface Speak2er {
+	speak() 
+	name() string
+}
+
+fn perform_speak(s Speaker) bool {
+	s.speak()
+	return true
+}
+
+fn test_perform_speak() {
+	d := Dog{}
+	assert perform_speak(d)
+}
+


### PR DESCRIPTION
allow interface method with empty (void) return type

-> only look for type declaration if no new line has been
   while skipping white space
