### PR TITLE
math: Factorial of negative numbers will result in an error

### DIFF
--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -223,9 +223,12 @@ pub fn trunc(a f64) f64 {
 
 // factorial calculates the factorial of the provided value.
 pub fn factorial(a int) i64 {
+	if a < 0 {
+		panic('factorial: Cannot find factorial of negative number')
+	}
 	mut prod := 1
 	for i:= 0; i < a; i++ {
-		prod = prod * (i+1)
+		prod *= (i+1)
 	}
 	return prod
 }


### PR DESCRIPTION
Factorial of negative numbers aren't defined yet the implementation in `math.v` would accept negative numbers and gave 1 as the result

Although this may look right but debugging this while doing mathematical computation can be a nightmare. I believe the behavior of `factorial` should remain consistent with the implementation in other languages and with its core definition and hence should <b>not allow negative numbers</b> altogether.