### PR TITLE
fix array initial with [0.0/f32/f64; length] compile error

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -223,6 +223,8 @@ typedef array array_int;
 typedef array array_byte; 
 typedef array array_uint; 
 typedef array array_float; 
+typedef array array_f32; 
+typedef array array_f64; 
 typedef map map_int; 
 typedef map map_string; 
 #ifndef bool

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -95,6 +95,25 @@ fn test_repeat() {
 	b := [7; 3]
 	assert b.len == 3
 	assert b[0] == 7 && b[1] == 7 && b[2] == 7
+	{
+		mut aa := [1.1 ; 10]
+		// FIXME: assert aa[0] == 1.1 will fail, need fix
+		assert aa[0] == f32(1.1)
+		assert aa[5] == f32(1.1)
+		assert aa[9] == f32(1.1)
+	}
+	{
+		mut aa := [f32(1.1) ; 10]
+		assert aa[0] == f32(1.1)
+		assert aa[5] == f32(1.1)
+		assert aa[9] == f32(1.1)
+	}
+	{
+		mut aa := [f64(1.1) ; 10]
+		assert aa[0] == f64(1.1)
+		assert aa[5] == f64(1.1)
+		assert aa[9] == f64(1.1)
+	}
 }
 
 fn test_right() {


### PR DESCRIPTION
solution: add array_f32/array_f64 type
Signed-off-by: Cytown <cytown@gmail.com>

Now the following code will success compiled.
```
fn foo() {
   mut array1 := [0.0 ; arraylength]
   mut array1 := [f32(0.0) ; arraylength]
   mut array1 := [f64(0.0) ; arraylength]
}
```
