### PR TITLE
Add term color for win. move consts. minor fixes

### DIFF
--- a/vlib/os/const.v
+++ b/vlib/os/const.v
@@ -73,3 +73,35 @@ const (
     O_SYNC   = 64  // open for synchronous I/O.
     O_TRUNC  = 128 // truncate regular writable file when opened.
 )
+
+// Windows 
+const(
+	INVALID_HANDLE_VALUE = -1
+)
+
+const(
+    STD_INPUT_HANDLE  = -10
+    STD_OUTPUT_HANDLE = -11
+    STD_ERROR_HANDLE  = -12
+)
+
+// https://docs.microsoft.com/en-us/windows/console/setconsolemode
+const (
+    // Input Buffer
+    ENABLE_ECHO_INPUT                  = 0x0004
+    ENABLE_EXTENDED_FLAGS              = 0x0080
+    ENABLE_INSERT_MODE                 = 0x0020
+    ENABLE_LINE_INPUT                  = 0x0002
+    ENABLE_MOUSE_INPUT                 = 0x0010
+    ENABLE_PROCESSED_INPUT             = 0x0001	
+    ENABLE_QUICK_EDIT_MODE             = 0x0040
+    ENABLE_WINDOW_INPUT                = 0x0008
+    ENABLE_VIRTUAL_TERMINAL_INPUT      = 0x0200
+    // Output Screen Buffer
+    ENABLE_PROCESSED_OUTPUT            = 0x0001
+    ENABLE_WRAP_AT_EOL_OUTPUT          = 0x0002
+    ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+    DISABLE_NEWLINE_AUTO_RETURN        = 0x0008
+    ENABLE_LVB_GRID_WORLDWIDE          = 0x0010
+)
+// End Windows

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -438,17 +438,15 @@ pub fn get_line() string {
     return str
 }
 
-const(
-	STD_INPUT_HANDLE = -10
-)
-
 // get_raw_line returns a one-line string from stdin along with '\n' if there is any
 pub fn get_raw_line() string {
 	$if windows {
 		max := 256
 		buf := malloc(max)
-		// TODO: Use HANDLE instead of voidptr
-		h_input := voidptr(C.GetStdHandle(STD_INPUT_HANDLE))
+		h_input := C.GetStdHandle(STD_INPUT_HANDLE)
+		if h_input == INVALID_HANDLE_VALUE {
+			panic('get_raw_line() error getting input handle.')
+		}
 		nr_chars := 0
 		// NOTE: Once we have UTF8 encode function to
 		// convert utf16 to utf8, change to ReadConsoleW
@@ -584,12 +582,6 @@ pub fn getwd() string {
 	} 
 	return string(buf)
 }
-
-
-// windows
-const(
-	INVALID_HANDLE_VALUE = -1
-)
 
 // win: FILETIME
 // https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime

--- a/vlib/term/colors.v
+++ b/vlib/term/colors.v
@@ -4,6 +4,8 @@
 
 module term
 
+import os
+
 // Calling this functions enables color terminal output on windows
 // Maybe implement a way to auto run an init function when a module
 // is imported on a certain os. for example to run this?

--- a/vlib/term/colors.v
+++ b/vlib/term/colors.v
@@ -4,6 +4,17 @@
 
 module term
 
+// Calling this functions enables color terminal output on windows
+// Maybe implement a way to auto run an init function when a module
+// is imported on a certain os. for example to run this?
+pub fn enable_term_color_win() {
+    h_output := C.GetStdHandle(os.STD_OUTPUT_HANDLE)
+    if h_output == os.INVALID_HANDLE_VALUE
+        || !C.SetConsoleMode(h_output, os.ENABLE_PROCESSED_OUTPUT|os.ENABLE_VIRTUAL_TERMINAL_PROCESSING) {
+        println('Sorry, there was an error enabling terminal color.')
+    }
+}
+
 pub fn format(msg, open, close string) string {
     return '\x1b[' + open + 'm' + msg + '\x1b[' + close + 'm'
 }

--- a/vlib/term/colors.v
+++ b/vlib/term/colors.v
@@ -8,10 +8,15 @@ module term
 // Maybe implement a way to auto run an init function when a module
 // is imported on a certain os. for example to run this?
 pub fn enable_term_color_win() {
-    h_output := C.GetStdHandle(os.STD_OUTPUT_HANDLE)
-    if h_output == os.INVALID_HANDLE_VALUE
-        || !C.SetConsoleMode(h_output, os.ENABLE_PROCESSED_OUTPUT|os.ENABLE_VIRTUAL_TERMINAL_PROCESSING) {
-        println('Sorry, there was an error enabling terminal color.')
+    $if windows {
+        h_output := C.GetStdHandle(os.STD_OUTPUT_HANDLE)
+        if h_output == os.INVALID_HANDLE_VALUE
+            || !C.SetConsoleMode(h_output, os.ENABLE_PROCESSED_OUTPUT|os.ENABLE_VIRTUAL_TERMINAL_PROCESSING) {
+            println('enable_term_color_win() Sorry, there was an error enabling terminal color.')
+        }
+    }
+    $else {
+        println('enable_term_color_win() should only be called on windows.')
     }
 }
 


### PR DESCRIPTION
This PR enables color terminal output on windows.
It works in powershell and cmd.
The only thing is at the moment you need to call os.enable_term_color_win() until we have a way to run it automatically? 
Also moved windows constants to consts.v (didn't move to os_win because i would to have to move a few functions into os_mac etc)
Also added some better error handling cases for some of the windows handle stuff