### PR TITLE
fix parser so v will compile on win

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -2112,12 +2112,10 @@ fn (p mut Parser) char_expr() {
 
 fn format_str(str string) string {
 	str = str.replace('"', '\\"')
-	
 	// convert windows style line ending to newline
 	str = str.replace('\r\n', '\n')
 	// replace all newlines
 	str = str.replace('\n', '\\n')
-
 	return str
 }
 

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -2112,12 +2112,12 @@ fn (p mut Parser) char_expr() {
 
 fn format_str(str string) string {
 	str = str.replace('"', '\\"')
-	$if windows {
-		str = str.replace('\r\n', '\\n')
-	} 
-	$else { 
-		str = str.replace('\n', '\\n')
-	} 
+	
+	// convert windows style line ending to newline
+	str = str.replace('\r\n', '\n')
+	// replace all newlines
+	str = str.replace('\n', '\\n')
+
 	return str
 }
 


### PR DESCRIPTION
This fixes the string literal compile problem on windows (when files have unix line endings).
Before the parser would check the platform and only replace \r\n on win and \n on other platforms. This didn't work in all situations because the files might still have unix line endings on windows, or windows style on another os.
This method first normalises any windows style to newline, then just replaces all newlines, so even if there are different files with mixed line endings there won't be any issues.

This is useful because sometimes development for different platforms and working from the same repo. Or if someone has git on windows setup not to convert line endings.

I don't think this should have much of a performance cost? 