### PR TITLE
int: add abs function

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -177,3 +177,10 @@ pub fn (c byte) str() string {
 	return str
 }
 
+pub fn abs(a int) int {
+    if a<0{
+        return -a
+    } else {
+        return a
+    }
+}


### PR DESCRIPTION
Add abs function. This function is used for calculating a absolute value for an int object.