### PR TITLE
scanner:  refactoring ident_number() in scanner.v

### DIFF
--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -145,7 +145,7 @@ fn (s mut Scanner) ident_decimal_number() string {
 
 		// 1234.123.123
 		if is_float && c == `.` {
-			s.error('too many too many decimal points in number')
+			s.error('too many decimal points in number')
 		}
 
 		// 123e+123e-123, 123e+123.0

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -686,6 +686,14 @@ pub fn (c byte) is_digit() bool {
 	return c >= `0` && c <= `9`
 }
 
+pub fn (c byte) is_octdigit() bool {
+	return c >= `0` && c <= `7`
+}
+
+pub fn (c byte) is_hexdigit() bool {
+	return c.is_digit() || (c >= `a` && c <= `f`) || (c >= `A` && c <= `F`)
+}
+
 pub fn (c byte) is_letter() bool {
 	return (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`)
 }


### PR DESCRIPTION
Scanning hex number, oct number and decimal number in one function makes code hard to read.
I splitted ident_number() into 3 parts
- ident_hex_number() in scanner.v
- ident_oct_number() in scanner.v
- ident_decimal_number() in scanner.v

And I also added some helper functions
- expect_string() in scanner.v
- is_hexdigit()  in string.v
- is_octdigit()  in string.v

This PR also fixed some bugs when scanning numbers like
```
0xx123
123.123.123
123e+123e+13
123e+123.45
```