### PR TITLE
Fix #1021 - Optional `or` branch doesn't define `err`

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1128,6 +1128,13 @@ fn (p mut Parser) var_decl() {
 		p.next()
 		p.check(LCBR)
 		p.genln('if (!$tmp .ok) {')
+		p.register_var(Var {
+			name: 'err'
+			typ: 'string'
+			is_mut: false
+			is_used: true
+		})
+		p.genln('string err = $tmp . error;')
 		p.statements()
 		p.genln('$typ $name = *($typ*) $tmp . data;')
 		if !p.returns && p.prev_tok2 != CONTINUE && p.prev_tok2 != BREAK {

--- a/compiler/tests/option_test.v
+++ b/compiler/tests/option_test.v
@@ -1,0 +1,10 @@
+fn opt_err() ?string {return error('hi')}
+
+fn test_err(){
+	v := opt_err() or {
+		assert err == 'hi'
+		return
+	}
+	assert false
+	println(v) // suppress not used error
+}


### PR DESCRIPTION
This is an attempt to fix #1021.