### PR TITLE
log: allow to log in file for persitance

### DIFF
--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -1,5 +1,7 @@
 module log
 
+import os
+import time
 import term
 
 const (
@@ -13,11 +15,23 @@ const (
 struct Log{
 mut:
     level int
+    output string
 }
 
 
-pub fn (l mut Log) set_level(level int){
+pub fn (l mut Log) set_level(level int, output string){
     l.level = level
+    l.output = output
+}
+
+fn (l Log) log2file(s string, e string) {
+    filename := l.output
+    f := os.open_append(l.output) or {
+        panic('error reading file $filename')
+        return
+    }
+    timestamp := time.now().format_ss()
+    f.writeln('$timestamp [$e] $s')
 }
 
 pub fn (l Log) fatal(s string){
@@ -26,28 +40,52 @@ pub fn (l Log) fatal(s string){
 
 pub fn (l Log) error(s string){
     if l.level >= ERROR{
-        f := term.red('E')
-        println('[$f]$s')
+        switch l.output {
+        case 'terminal':
+            f := term.red('E')
+            println('[$f]$s')
+
+        default:
+            l.log2file(s, 'E')
+        }
     }
 }
 
 pub fn (l Log) warn(s string){
     if l.level >= WARN{
-        f := term.yellow('W')
-        println('[$f]$s')
-    }
+        switch l.output {
+        case 'terminal':
+            f := term.yellow('W')
+            println('[$f]$s')
+
+        default:
+            l.log2file(s, 'W')
+        }
+    }  
 }
 
 pub fn (l Log) info(s string){
     if l.level >= INFO{
-        f := term.white('I')
-        println('[$f]$s')
+        switch l.output {
+        case 'terminal':
+            f := term.white('I')
+            println('[$f]$s')
+
+        default:
+            l.log2file(s, 'I')
+        }
     }
 }
 
 pub fn (l Log) debug(s string){
     if l.level >= DEBUG{
-        f := term.blue('D')
-        println('[$f]$s')
+        switch l.output {
+        case 'terminal':
+            f := term.blue('D')
+            println('[$f]$s')
+
+        default:
+            l.log2file(s, 'D')
+        }
     }
 }


### PR DESCRIPTION
Allow to log event in file
```
import log

fn main() {
    mut l := log.Log{log.DEBUG, 'myLog.lg'}
    l.error('error')
}
```

Previous behavior (write in terminal) is still available by  
```
import log

fn main() {
    mut l := log.Log{log.DEBUG, 'terminal'}
    l.error('error')
}
```