### PR TITLE
log: Allow to log in terminal or in file

### DIFF
--- a/examples/log.v
+++ b/examples/log.v
@@ -1,7 +1,7 @@
 import log
 
 fn main(){
-    mut l := log.Log{level:log.INFO}
+    mut l := log.Log{level:log.INFO, 'terminal'}
     l.info('info')
     l.warn('warn')
     l.error('error')

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -1,5 +1,7 @@
 module log
 
+import os
+import time
 import term
 
 const (
@@ -13,11 +15,26 @@ const (
 struct Log{
 mut:
     level int
+    output string
 }
 
 
 pub fn (l mut Log) set_level(level int){
     l.level = level
+}
+
+pub fn (l mut Log) set_output(output string) {
+    l.output = output
+}
+
+fn (l Log) log_file(s string, e string) {
+    filename := l.output
+    f := os.open_append(l.output) or {
+        panic('error reading file $filename')
+        return
+    }
+    timestamp := time.now().format_ss()
+    f.writeln('$timestamp [$e] $s')
 }
 
 pub fn (l Log) fatal(s string){
@@ -26,28 +43,52 @@ pub fn (l Log) fatal(s string){
 
 pub fn (l Log) error(s string){
     if l.level >= ERROR{
-        f := term.red('E')
-        println('[$f]$s')
+        switch l.output {
+        case 'terminal':
+            f := term.red('E')
+            println('[$f]$s')
+
+        default:
+            l.log_file(s, 'E')
+        }
     }
 }
 
 pub fn (l Log) warn(s string){
     if l.level >= WARN{
-        f := term.yellow('W')
-        println('[$f]$s')
-    }
+        switch l.output {
+        case 'terminal':
+            f := term.yellow('W')
+            println('[$f]$s')
+
+        default:
+            l.log_file(s, 'W')
+        }
+    }  
 }
 
 pub fn (l Log) info(s string){
     if l.level >= INFO{
-        f := term.white('I')
-        println('[$f]$s')
+        switch l.output {
+        case 'terminal':
+            f := term.white('I')
+            println('[$f]$s')
+
+        default:
+            l.log_file(s, 'I')
+        }
     }
 }
 
 pub fn (l Log) debug(s string){
     if l.level >= DEBUG{
-        f := term.blue('D')
-        println('[$f]$s')
+        switch l.output {
+        case 'terminal':
+            f := term.blue('D')
+            println('[$f]$s')
+
+        default:
+            l.log_file(s, 'D')
+        }
     }
 }


### PR DESCRIPTION
Allow to log in terminal or in file by passing 'terminal' or 'myFile.log' as Log parameter

Log in terminal :
```
import log

fn main() {
    mut l := log.Log{log.DEBUG, 'terminal'}
    l.error('error')
}
```

Log in file :
```
import log

fn main() {
    mut l := log.Log{log.DEBUG, 'myLog.log'}
    l.error('error')
}
```
