### PR TITLE
compiler: allow mut passed as argument to be modified

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1213,7 +1213,7 @@ fn (p mut Parser) name_expr() string {
 	// amp
 	 
 	ptr := p.tok == AMP
-	deref := p.tok == MUL
+	mut deref := p.tok == MUL
 	if ptr || deref {
 		p.next()
 	}
@@ -1268,6 +1268,7 @@ fn (p mut Parser) name_expr() string {
 	// Variable
 	v := p.cur_fn.find_var(name)
 	if v.name.len != 0 {
+		deref = deref || (v.is_arg && v.is_mut && is_mutable_type(v.typ))
 		if ptr {
 			p.gen('& /*vvar*/ ')
 		}

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -736,3 +736,24 @@ fn (s mut Scanner) create_type_string(T Type, name string) {
 fn (p mut Parser) create_type_string(T Type, name string) {
 	p.scanner.create_type_string(T, name)
 }
+
+//Checks if mut type can be dereferenced to be modified
+fn is_mutable_type(typ string) bool {
+	if typ == 'bool*' {
+		return true
+	}
+	if typ == 'int*' || typ == 'rune*' || typ == 'i8*' ||
+	   typ == 'i16*' || typ == 'i32*' || typ == 'i64*' {
+		return true
+	}
+	if typ == 'byte*' || typ == 'u8*' || typ == 'u16*' ||
+	   typ == 'u32*' || typ == 'u64*' {
+		return true
+	}
+	if typ == 'f32*' || typ == 'f64*' {
+		return true
+	}
+	if typ == 'string*' {
+		return true
+	}
+}


### PR DESCRIPTION
New Pull Request for #769 that was reverted in 249fa95 thus making the issue still open.
-
Checks in a list of know type if mut can be dereferenced

This can now be compiled :

fn multiply_by_2(num mut int) {
    num = num * 2
}

fn main() {
    mut num := 1
    multiply_by_2(mut num)
    println(num)
}