### PR TITLE
complex: add angle

### DIFF
--- a/vlib/math/complex.v
+++ b/vlib/math/complex.v
@@ -26,6 +26,11 @@ pub fn (c Complex) str() string {
 	return out
 }
 
+// Complex Angle
+pub fn (c Complex) angle() f64 { 
+	return atan(c.re / c.im)
+}
+
 // Complex Addition c1 + c2
 pub fn (c1 Complex) + (c2 Complex) Complex {
 	return Complex{c1.re+c2.re,c1.im+c2.im}

--- a/vlib/math/complex_test.v
+++ b/vlib/math/complex_test.v
@@ -102,3 +102,16 @@ fn test_complex_equals() {
 	c2 = math.complex(-3,19)
 	assert c1.equals(c2)
 }
+
+fn test_complex_angle(){
+	mut c := math.complex(0, 8)
+	assert c.angle() == C.atan(0)
+	c = math.complex(8, 0)
+	assert c.angle() == C.atan2(8, 0)
+	c = math.complex(1, 2)
+	assert c.angle() == C.atan(0.5)
+	c = math.complex(3, 1)
+	assert c.angle() == C.atan(3)
+	mut cc := c.conjugate()
+	assert cc.angle() + c.angle() == 0
+}


### PR DESCRIPTION
This PR adds `angle` method for a `Complex` struct. It is quite essential and part of basic definition of a complex number. This PR adds this missing functionality.
