### PR TITLE
strings : add tests for reverse()

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -769,7 +769,7 @@ pub fn (s []string) join_lines() string {
 pub fn (s string) reverse() string {
 	mut res := string {
 		len: s.len
-		str: malloc(s.len + 1)
+		str: malloc(s.len)
 	}
 
 	for i := s.len - 1; i >= 0; i-- {

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -293,3 +293,9 @@ fn test_all_after() {
 	assert q == 'hello'
 }
 
+fn test_reverse() {
+	s := 'hello'
+	assert s.reverse() == 'olleh'
+	t := ''
+	assert t.reverse() == t
+}


### PR DESCRIPTION
save an excess byteptr memory allocated during `reverse` and add tests