### PR TITLE
bf: add a module implementing operations with bit arrays

### DIFF
--- a/vlib/bf/bf.v
+++ b/vlib/bf/bf.v
@@ -130,7 +130,7 @@ pub fn bfor(input1 BitField, input2 BitField) BitField {
 	mut output := new(size)
 	mut i := 0
 	for i < bitnslots {
-		output.field[i] = input1.field[1] | input2.field[i]
+		output.field[i] = input1.field[i] | input2.field[i]
 		i++
 	}
 	cleartail(output)
@@ -143,7 +143,7 @@ pub fn bfxor(input1 BitField, input2 BitField) BitField {
 	mut output := new(size)
 	mut i := 0
 	for i < bitnslots {
-		output.field[i] = input1.field[1] ^ input2.field[i]
+		output.field[i] = input1.field[i] ^ input2.field[i]
 		i++
 	}
 	cleartail(output)

--- a/vlib/bf/bf.v
+++ b/vlib/bf/bf.v
@@ -1,9 +1,10 @@
 module bf
 
-struct bitfield {
+struct BitField {
 mut:
 	size int
-	field *u32//[]u32
+	//field *u32
+	field []u32
 }
 
 /* helper functions */
@@ -19,19 +20,19 @@ fn bitslot(size int) int {
 	return size / SLOT_SIZE
 }
 
-fn bitget(instance *bitfield, bitnr int) int {
+fn bitget(instance BitField, bitnr int) int {
 	return (instance.field[bitslot(bitnr)] >> u32(bitnr % SLOT_SIZE)) & 1
 }
 
-fn bitset(instance *bitfield, bitnr int) {
+fn bitset(instance BitField, bitnr int) {
 	instance.field[bitslot(bitnr)] = instance.field[bitslot(bitnr)] | bitmask(bitnr)
 }
 
-fn bitclear(instance *bitfield, bitnr int) {
+fn bitclear(instance BitField, bitnr int) {
 	instance.field[bitslot(bitnr)] = instance.field[bitslot(bitnr)] & ~bitmask(bitnr)
 }
 
-fn bittoggle(instance *bitfield, bitnr int) {
+fn bittoggle(instance BitField, bitnr int) {
 	instance.field[bitslot(bitnr)] = instance.field[bitslot(bitnr)] ^ bitmask(bitnr)
 }
 /*
@@ -51,7 +52,7 @@ fn bitnslots(length int) int {
 	return (length - 1) / SLOT_SIZE + 1
 } 
 
-fn cleartail(instance *bitfield) {
+fn cleartail(instance BitField) {
 	tail := instance.size % SLOT_SIZE
 	if tail != 0 {
 		/* create a mask for the tail */
@@ -63,40 +64,41 @@ fn cleartail(instance *bitfield) {
 
 /* public functions */
 
-pub fn new(size int) *bitfield {
-	output := &bitfield{
+pub fn new(size int) BitField {
+	output := BitField{
 		size: size 
-		field: *u32(calloc(bitnslots(size) * SLOT_SIZE / 8)) //[u32(0); bitnslots(size)]
+		//field: *u32(calloc(bitnslots(size) * SLOT_SIZE / 8))
+		field: [u32(0); bitnslots(size)]
 	}
 	return output
 }
-
-pub fn del(instance *bitfield) {
+/*
+pub fn del(instance *BitField) {
 	free(instance.field)
 	free(instance)
 }
-
-pub fn getbit(instance *bitfield, bitnr int) int {
+*/
+pub fn (instance BitField) getbit(bitnr int) int {
 	if bitnr >= instance.size {return 0}
 	return bitget(instance, bitnr)
 }
 
-pub fn setbit(instance *bitfield, bitnr int) {
+pub fn (instance mut BitField) setbit(bitnr int) {
 	if bitnr >= instance.size {return}
 	bitset(instance, bitnr)
 }
 
-pub fn clearbit(instance *bitfield, bitnr int) {
+pub fn (instance mut BitField) clearbit(bitnr int) {
 	if bitnr >= instance.size {return}
 	bitclear(instance, bitnr)
 }
 
-pub fn togglebit(instance *bitfield, bitnr int) {
+pub fn (instance mut BitField) togglebit(bitnr int) {
 	if bitnr >= instance.size {return}
 	bittoggle(instance, bitnr)
 }
 
-pub fn bfand(input1 *bitfield, input2 *bitfield) *bitfield {
+pub fn bfand(input1 BitField, input2 BitField) BitField {
 	size := min(input1.size, input2.size)
 	bitnslots := bitnslots(size)
 	mut output := new(size)
@@ -109,7 +111,7 @@ pub fn bfand(input1 *bitfield, input2 *bitfield) *bitfield {
 	return output
 }
 
-pub fn bfnot(input *bitfield) *bitfield {
+pub fn bfnot(input BitField) BitField {
 	size := input.size
 	bitnslots := bitnslots(size)
 	mut output := new(size)
@@ -122,7 +124,7 @@ pub fn bfnot(input *bitfield) *bitfield {
 	return output
 }
 
-pub fn bfor(input1 *bitfield, input2 *bitfield) *bitfield {
+pub fn bfor(input1 BitField, input2 BitField) BitField {
 	size := min(input1.size, input2.size)
 	bitnslots := bitnslots(size)
 	mut output := new(size)
@@ -135,7 +137,7 @@ pub fn bfor(input1 *bitfield, input2 *bitfield) *bitfield {
 	return output
 }
 
-pub fn bfxor(input1 *bitfield, input2 *bitfield) *bitfield {
+pub fn bfxor(input1 BitField, input2 BitField) BitField {
 	size := min(input1.size, input2.size)
 	bitnslots := bitnslots(size)
 	mut output := new(size)
@@ -148,10 +150,10 @@ pub fn bfxor(input1 *bitfield, input2 *bitfield) *bitfield {
 	return output
 }
 
-pub fn print(instance *bitfield) {
+pub fn print(instance BitField) {
 	mut i := 0
 	for i < instance.size {
-		if getbit(instance, i) == 1 {
+		if instance.getbit(i) == 1 {
 			print('1')
 		}
 		else {
@@ -161,11 +163,11 @@ pub fn print(instance *bitfield) {
 	}
 }
 
-pub fn size(instance *bitfield) int {
+pub fn (instance BitField) getsize() int {
 	return instance.size
 }
 
-pub fn clone(input *bitfield) *bitfield {
+pub fn clone(input BitField) BitField {
 	bitnslots := bitnslots(input.size)
 	mut output := new(input.size)
 	mut i := 0

--- a/vlib/bf/bf.v
+++ b/vlib/bf/bf.v
@@ -1,0 +1,177 @@
+module bf
+
+struct bitfield {
+mut:
+	size int
+	field *u32//[]u32
+}
+
+/* helper functions */
+const (
+	SLOT_SIZE = 32
+)
+
+fn bitmask(bitnr int) u32 {
+	return u32(1 << (bitnr % SLOT_SIZE))
+}
+
+fn bitslot(size int) int {
+	return size / SLOT_SIZE
+}
+
+fn bitget(instance *bitfield, bitnr int) int {
+	return (instance.field[bitslot(bitnr)] >> u32(bitnr % SLOT_SIZE)) & 1
+}
+
+fn bitset(instance *bitfield, bitnr int) {
+	instance.field[bitslot(bitnr)] = instance.field[bitslot(bitnr)] | bitmask(bitnr)
+}
+
+fn bitclear(instance *bitfield, bitnr int) {
+	instance.field[bitslot(bitnr)] = instance.field[bitslot(bitnr)] & ~bitmask(bitnr)
+}
+
+fn bittoggle(instance *bitfield, bitnr int) {
+	instance.field[bitslot(bitnr)] = instance.field[bitslot(bitnr)] ^ bitmask(bitnr)
+}
+/*
+#define BITTEST(a, b) ((a)->field[BITSLOT(b)] & BITMASK(b))
+*/
+
+fn min(input1 int, input2 int) int {
+	if input1 < input2 {
+		return input1
+	}
+	else {
+		return input2
+	}
+}
+
+fn bitnslots(length int) int {
+	return (length - 1) / SLOT_SIZE + 1
+} 
+
+fn cleartail(instance *bitfield) {
+	tail := instance.size % SLOT_SIZE
+	if tail != 0 {
+		/* create a mask for the tail */
+		mask := u32((1 << tail) - 1)
+		/* clear the extra bits */
+		instance.field[bitnslots(instance.size) - 1] = instance.field[bitnslots(instance.size) - 1] & mask
+	}
+}
+
+/* public functions */
+
+pub fn new(size int) *bitfield {
+	output := &bitfield{
+		size: size 
+		field: *u32(calloc(bitnslots(size) * SLOT_SIZE / 8)) //[u32(0); bitnslots(size)]
+	}
+	return output
+}
+
+pub fn del(instance *bitfield) {
+	free(instance.field)
+	free(instance)
+}
+
+pub fn getbit(instance *bitfield, bitnr int) int {
+	if bitnr >= instance.size {return 0}
+	return bitget(instance, bitnr)
+}
+
+pub fn setbit(instance *bitfield, bitnr int) {
+	if bitnr >= instance.size {return}
+	bitset(instance, bitnr)
+}
+
+pub fn clearbit(instance *bitfield, bitnr int) {
+	if bitnr >= instance.size {return}
+	bitclear(instance, bitnr)
+}
+
+pub fn togglebit(instance *bitfield, bitnr int) {
+	if bitnr >= instance.size {return}
+	bittoggle(instance, bitnr)
+}
+
+pub fn bfand(input1 *bitfield, input2 *bitfield) *bitfield {
+	size := min(input1.size, input2.size)
+	bitnslots := bitnslots(size)
+	mut output := new(size)
+	mut i := 0
+	for i < bitnslots {
+		output.field[i] = input1.field[i] & input2.field[i]
+		i++
+	}
+	cleartail(output)
+	return output
+}
+
+pub fn bfnot(input *bitfield) *bitfield {
+	size := input.size
+	bitnslots := bitnslots(size)
+	mut output := new(size)
+	mut i := 0
+	for i < bitnslots {
+		output.field[i] = ~input.field[i]
+		i++
+	}
+	cleartail(output)
+	return output
+}
+
+pub fn bfor(input1 *bitfield, input2 *bitfield) *bitfield {
+	size := min(input1.size, input2.size)
+	bitnslots := bitnslots(size)
+	mut output := new(size)
+	mut i := 0
+	for i < bitnslots {
+		output.field[i] = input1.field[1] | input2.field[i]
+		i++
+	}
+	cleartail(output)
+	return output
+}
+
+pub fn bfxor(input1 *bitfield, input2 *bitfield) *bitfield {
+	size := min(input1.size, input2.size)
+	bitnslots := bitnslots(size)
+	mut output := new(size)
+	mut i := 0
+	for i < bitnslots {
+		output.field[i] = input1.field[1] ^ input2.field[i]
+		i++
+	}
+	cleartail(output)
+	return output
+}
+
+pub fn print(instance *bitfield) {
+	mut i := 0
+	for i < instance.size {
+		if getbit(instance, i) == 1 {
+			print('1')
+		}
+		else {
+			print('0')
+		}
+		i++
+	}
+}
+
+pub fn size(instance *bitfield) int {
+	return instance.size
+}
+
+pub fn clone(input *bitfield) *bitfield {
+	bitnslots := bitnslots(input.size)
+	mut output := new(input.size)
+	mut i := 0
+	for i < bitnslots {
+		output.field[i] = input.field[i]
+		i++
+	}
+	return output
+}

--- a/vlib/bf/bf_test.v
+++ b/vlib/bf/bf_test.v
@@ -1,0 +1,51 @@
+import bf
+
+import rand
+
+fn test_bf_new_size_del() {
+	mut result := 1
+	instance := bf.new(5)
+	if bf.size(instance) != 5 {result = 0}
+	bf.del(instance)
+	if bf.size(instance) == 5 {result = 0}
+	assert result == 1
+}
+
+fn test_bf_set_clear_toggle_get() {
+	mut result := 1
+	instance := bf.new(5)
+	bf.setbit(instance, 4)
+	if bf.getbit(instance, 4) != 1 {result = 0}
+	bf.clearbit(instance, 4)
+	if bf.getbit(instance, 4) != 0 {result = 0}
+	bf.togglebit(instance, 4)
+	if bf.getbit(instance, 4) != 1 {result = 0}
+	assert result == 1
+}
+
+fn test_bf_and_not_or_xor() {
+	rand.seed()
+	len := 80
+	input1 := bf.new(len)
+	input2 := bf.new(len)
+	mut i := 0
+	for i < len {
+		if rand.next(2) == 1 {
+			bf.setbit(input1, i)
+		}
+		if rand.next(2) == 1{
+			bf.setbit(input2, i)
+		}
+		i++
+	}
+	output1 := bf.bfxor(input1, input2)
+	bfand := bf.bfand(input1, input2)
+	bfor := bf.bfor(input1, input2)
+	bfnot := bf.bfnot(bfand)
+	output2 := bf.bfand(bfor, bfnot)
+	mut result := 1
+	for i < len {
+		if bf.getbit(output1, i) != bf.getbit(output2, i) {result = 0}
+	}
+	assert result == 1
+}

--- a/vlib/bf/bf_test.v
+++ b/vlib/bf/bf_test.v
@@ -2,39 +2,33 @@ import bf
 
 import rand
 
-fn test_bf_new_size_del() {
-	mut result := 1
+fn test_bf_new_size() {
 	instance := bf.new(5)
-	if bf.size(instance) != 5 {result = 0}
-	bf.del(instance)
-	if bf.size(instance) == 5 {result = 0}
-	assert result == 1
+	assert instance.getsize() == 5
 }
 
 fn test_bf_set_clear_toggle_get() {
-	mut result := 1
-	instance := bf.new(5)
-	bf.setbit(instance, 4)
-	if bf.getbit(instance, 4) != 1 {result = 0}
-	bf.clearbit(instance, 4)
-	if bf.getbit(instance, 4) != 0 {result = 0}
-	bf.togglebit(instance, 4)
-	if bf.getbit(instance, 4) != 1 {result = 0}
-	assert result == 1
+	mut instance := bf.new(5)
+	instance.setbit(4)
+	assert instance.getbit(4) == 1
+	instance.clearbit(4)
+	assert instance.getbit(4) == 0
+	instance.togglebit(4)
+	assert instance.getbit(4) == 1
 }
 
 fn test_bf_and_not_or_xor() {
 	rand.seed()
 	len := 80
-	input1 := bf.new(len)
-	input2 := bf.new(len)
+	mut input1 := bf.new(len)
+	mut input2 := bf.new(len)
 	mut i := 0
 	for i < len {
 		if rand.next(2) == 1 {
-			bf.setbit(input1, i)
+			input1.setbit(i)
 		}
 		if rand.next(2) == 1{
-			bf.setbit(input2, i)
+			input2.setbit(i)
 		}
 		i++
 	}
@@ -45,7 +39,7 @@ fn test_bf_and_not_or_xor() {
 	output2 := bf.bfand(bfor, bfnot)
 	mut result := 1
 	for i < len {
-		if bf.getbit(output1, i) != bf.getbit(output2, i) {result = 0}
+		if output1.getbit(i) != output2.getbit(i) {result = 0}
 	}
 	assert result == 1
 }


### PR DESCRIPTION
This PR implements a set of functions to work with bit arrays

```
// an opaque structure to store the array of bits
struct BitField {...}

// create a new bit array capable to store 'size' bits
pub fn new(size int) BitField {...}

// get the value (0 or 1) of bit number 'bitnr' in a bit array
pub fn (instance Bitfield) getbit(bitnr int) int {...}

// set bit number 'bitnr' to 1
pub fn (instance mut BitField) setbit(bitnr int) {...}

// clear (set to 0) bit number 'bitnr'
pub fn (instance mut BitField) clearbit(bitnr int) {...}

// toggle (from 0 to 1 and vice-versa) bit number 'bitnr'
pub fn (instance mut BitField) togglebit(bitnr int) {...}

// performs bitwise AND over a pair of bitfields
pub fn bfand(input1 BitField, input2 BitField) BitField {...}

// reverse all bits in an array and return the result in a new array
pub fn bfnot(input BitField) BitField {...}

// perform bitwise inclusive OR over a pair of bit arrays
pub fn bfor(input1 BitField, input2 BitField) BitField {...}

// perform bitwise exclusive OR over a pair of bit arrays
pub fn bfxor(input1 BitField, input2 BitField) BitField {...}

// print a bit array as a series of ones and zeroes, least significant bit first
pub fn print(instance BitField) {...}

// get the number of bits an array can hold
pub fn (instance BitField) getsize() int {...}

// create a copy of an existing bit array
pub fn clone(input BitField) BitField {...}