### PR TITLE
hot_code_reloading: fix reloading on linux by adding -fPIC flag and passing ./object.so to dlopen

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -386,9 +386,11 @@ string _STR_TMP(const char *fmt, ...) {
 #include <dlfcn.h>
 void* live_lib; 
 int load_so(byteptr path) {
-	//printf("load_so %s\\n", path); 
+	char cpath[1024];
+	sprintf(cpath,"./%s", path);
+	//printf("load_so %s\\n", cpath); 
 	if (live_lib) dlclose(live_lib); 
-	live_lib = dlopen(path, RTLD_LAZY);
+	live_lib = dlopen(cpath, RTLD_LAZY);
 	if (!live_lib) {puts("open failed"); exit(1); return 0;} 
 ')
 		for so_fn in cgen.so_fns {
@@ -534,7 +536,7 @@ fn (v mut V) cc() {
 	flags := v.table.flags.join(' ')
 	//mut shared := ''
 	if v.pref.is_so {
-		a << '-shared'// -Wl,-z,defs'
+		a << '-shared -fPIC '// -Wl,-z,defs'
 		v.out_name = v.out_name + '.so'
 	}
 	if v.pref.is_prod {


### PR DESCRIPTION
Trying to run the hot_code_reloading example, I got:

0[08:23:09]delian@nemesis: ~/vlang/examples/hot_code_reloading $ vlang -live message.v 
/usr/bin/ld: /tmp/ccoVnsQj.o: relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/tmp/ccoVnsQj.o: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
V panic: clang error

I've changed compiler/main.v to add the needed -fPIC flag. 

After that, I could compile message.v properly, but could not run it, because dlopen tried to open 'message.so' . 

On linux, dlopen's manpage says:
```
       If  filename  is NULL, then the returned handle is for the main program.  If filename contains a slash ("/"), then it is interpreted as a (relative or absolute) pathname.  Otherwise, the dynamic linker searches for the object as follows (see ld.so(8) for further details):
       o   (ELF only) If the executable file for the calling program contains a DT_RPATH tag, and does not contain a DT_RUNPATH tag, then the  directories listed in the DT_RPATH tag are searched.
       o   If,  at the time that the program was started, the environment variable LD_LIBRARY_PATH was defined to contain a colon-separated list of directories, then these are searched.  (As a security measure, this variable is ignored for set-user-ID and set-group-ID programs.)
       o   (ELF only) If the executable file for the calling program contains a DT_RUNPATH tag, then the directories listed in that tag are searched.
       o   The cache file /etc/ld.so.cache (maintained by ldconfig(8)) is checked to see whether it contains an entry for filename.
       o   The directories /lib and /usr/lib are searched (in that order).
```


In comparison, on MacOS X, man dlopen says:
```
SEARCHING
     dlopen() searches for a compatible Mach-O file in the directories specified by a set of environment variables and the process's current working directory.  When set, the environment variables contain a colon-separated list of directory paths, which can be absolute or relative to the current working directory.
     When path does not contain a slash character (i.e. it is just a leaf name), dlopen() searches the following until it finds a compatible Mach-O file: $LD_LIBRARY_PATH, $DYLD_LIBRARY_PATH, current working directory, $DYLD_FALLBACK_LIBRARY_PATH.
````

The common behavior is that if we pass ./message.so to dlopen, it will try to load it from the current directory on both MacOS and Linux. The other option is to pass an absolute filepath to the .so file, which seems more complex to me.

This pull request contains both
1) passing -fPIC and 
2) passing ./object.so to dlopen
so that live reloading continues to work on MacOS, while now it can work on linux too.