### PR TITLE
complex, fraction: simplify and format source code

### DIFF
--- a/vlib/math/complex.v
+++ b/vlib/math/complex.v
@@ -26,10 +26,15 @@ pub fn (c Complex) str() string {
 	return out
 }
 
-// Complex Absolute value
+// Complex Modulus value
+// mod() and abs() return the same
 pub fn (c Complex) abs() f64 {
 	return C.hypot(c.re, c.im)
 }
+pub fn (c Complex) mod() f64 {
+	return C.hypot(c.re, c.im)
+}
+
 
 // Complex Angle
 pub fn (c Complex) angle() f64 { 

--- a/vlib/math/complex.v
+++ b/vlib/math/complex.v
@@ -114,8 +114,8 @@ pub fn (c Complex) addinv() Complex {
 // http://tutorial.math.lamar.edu/Extras/ComplexPrimer/Arithmetic.aspx
 pub fn (c Complex) mulinv() Complex {
 	return Complex {
-		c.re / c.abs(),
-		-c.im / c.abs()
+		c.re / (c.re * c.re + c.im * c.im),
+		-c.im / (c.re * c.re + c.im * c.im)
 	}
 }
  

--- a/vlib/math/complex.v
+++ b/vlib/math/complex.v
@@ -32,7 +32,7 @@ pub fn (c Complex) abs() f64 {
 	return C.hypot(c.re, c.im)
 }
 pub fn (c Complex) mod() f64 {
-	return C.hypot(c.re, c.im)
+	return c.abs()
 }
 
 

--- a/vlib/math/complex.v
+++ b/vlib/math/complex.v
@@ -93,40 +93,33 @@ pub fn (c1 Complex) divide(c2 Complex) Complex {
 }
 
 // Complex Conjugate
-pub fn (c1 Complex) conjugate() Complex{
-	return Complex{c1.re,-c1.im}
+pub fn (c Complex) conjugate() Complex{
+	return Complex{c.re,-c.im}
 }
 
 // Complex Additive Inverse
 // Based on 
 // http://tutorial.math.lamar.edu/Extras/ComplexPrimer/Arithmetic.aspx
-pub fn (c1 Complex) addinv() Complex {
-	return Complex{-c1.re,-c1.im}
+pub fn (c Complex) addinv() Complex {
+	return Complex{-c.re,-c.im}
 }
 
 // Complex Multiplicative Inverse
 // Based on
 // http://tutorial.math.lamar.edu/Extras/ComplexPrimer/Arithmetic.aspx
-pub fn (c1 Complex) mulinv() Complex {
+pub fn (c Complex) mulinv() Complex {
 	return Complex {
-		c1.re / (pow(c1.re,2) + pow(c1.im,2)),
-		-c1.im / (pow(c1.re,2) + pow(c1.im,2))
+		c.re / c.abs(),
+		-c.im / c.abs()
 	}
 }
  
-// Complex Mod or Absolute
-// Based on
-// http://tutorial.math.lamar.edu/Extras/ComplexPrimer/ConjugateModulus.aspx
-pub fn (c1 Complex) mod() f64 {
-	return sqrt(pow(c1.re,2)+pow(c1.im,2))
-}
-
 // Complex Power
 // Based on
 // https://www.khanacademy.org/math/precalculus/imaginary-and-complex-numbers/multiplying-and-dividing-complex-numbers-in-polar-form/a/complex-number-polar-form-review
-pub fn (c1 Complex) pow(n f64) Complex {
-	r := pow(c1.mod(),n)
-	angle := atan2(c1.im,c1.re)
+pub fn (c Complex) pow(n f64) Complex {
+	r := pow(c.abs(),n)
+	angle := c.angle()
 	return Complex {
 		r * cos(n*angle),
 		r * sin(n*angle)
@@ -134,29 +127,29 @@ pub fn (c1 Complex) pow(n f64) Complex {
 }
 
 // Complex nth root 
-pub fn (c1 Complex) root(n f64) Complex {
-	return c1.pow(1.0/n)
+pub fn (c Complex) root(n f64) Complex {
+	return c.pow(1.0/n)
 }
 
 // Complex Exponential
 // Using Euler's Identity 
 // Based on
 // https://www.math.wisc.edu/~angenent/Free-Lecture-Notes/freecomplexnumbers.pdf
-pub fn (c1 Complex) exp() Complex {
-	a := exp(c1.re)
+pub fn (c Complex) exp() Complex {
+	a := exp(c.re)
 	return Complex {
-		a * cos(c1.im),
-		a * sin(c1.im)
+		a * cos(c.im),
+		a * sin(c.im)
 	}
 }
 
 // Complex Natural Logarithm
 // Based on 
 // http://www.chemistrylearning.com/logarithm-of-complex-number/
-pub fn (c1 Complex) ln() Complex {
+pub fn (c Complex) ln() Complex {
 	return Complex {
-		log(c1.mod()),
-		atan2(c1.im,c1.re)
+		log(c.abs()),
+		c.angle()
 	}
 }
 

--- a/vlib/math/complex.v
+++ b/vlib/math/complex.v
@@ -9,8 +9,8 @@ struct Complex {
 	im f64
 }
 
-pub fn complex(re f64,im f64) Complex {
-	return Complex{re,im}
+pub fn complex(re f64, im f64) Complex {
+	return Complex{re, im}
 }
 
 // To String method
@@ -28,7 +28,7 @@ pub fn (c Complex) str() string {
 
 // Complex Absolute value
 pub fn (c Complex) abs() f64 {
-	return C.hypot(c.re,c.im)
+	return C.hypot(c.re, c.im)
 }
 
 // Complex Angle
@@ -38,12 +38,12 @@ pub fn (c Complex) angle() f64 {
 
 // Complex Addition c1 + c2
 pub fn (c1 Complex) + (c2 Complex) Complex {
-	return Complex{c1.re+c2.re,c1.im+c2.im}
+	return Complex{c1.re + c2.re, c1.im + c2.im}
 }
 
 // Complex Substraction c1 - c2
 pub fn (c1 Complex) - (c2 Complex) Complex {
-	return Complex{c1.re-c2.re,c1.im-c2.im}
+	return Complex{c1.re - c2.re, c1.im - c2.im}
 }
 
 // Complex Multiplication c1 * c2
@@ -87,21 +87,21 @@ pub fn (c1 Complex) multiply(c2 Complex) Complex {
 pub fn (c1 Complex) divide(c2 Complex) Complex {
 	denom := (c2.re * c2.re) + (c2.im * c2.im)
 	return Complex { 
-		((c1.re * c2.re) + ((c1.im * -c2.im) * -1))/denom, 
-		((c1.re * -c2.im) + (c1.im * c2.re))/denom
+		((c1.re * c2.re) + ((c1.im * -c2.im) * -1)) / denom, 
+		((c1.re * -c2.im) + (c1.im * c2.re)) / denom
 	}
 }
 
 // Complex Conjugate
 pub fn (c Complex) conjugate() Complex{
-	return Complex{c.re,-c.im}
+	return Complex{c.re, -c.im}
 }
 
 // Complex Additive Inverse
 // Based on 
 // http://tutorial.math.lamar.edu/Extras/ComplexPrimer/Arithmetic.aspx
 pub fn (c Complex) addinv() Complex {
-	return Complex{-c.re,-c.im}
+	return Complex{-c.re, -c.im}
 }
 
 // Complex Multiplicative Inverse
@@ -118,17 +118,17 @@ pub fn (c Complex) mulinv() Complex {
 // Based on
 // https://www.khanacademy.org/math/precalculus/imaginary-and-complex-numbers/multiplying-and-dividing-complex-numbers-in-polar-form/a/complex-number-polar-form-review
 pub fn (c Complex) pow(n f64) Complex {
-	r := pow(c.abs(),n)
+	r := pow(c.abs(), n)
 	angle := c.angle()
 	return Complex {
-		r * cos(n*angle),
-		r * sin(n*angle)
+		r * cos(n * angle),
+		r * sin(n * angle)
 	}
 }
 
 // Complex nth root 
 pub fn (c Complex) root(n f64) Complex {
-	return c.pow(1.0/n)
+	return c.pow(1.0 / n)
 }
 
 // Complex Exponential

--- a/vlib/math/fraction.v
+++ b/vlib/math/fraction.v
@@ -22,7 +22,7 @@ pub fn fraction(n i64, d i64) Fraction{
 
 // To String method
 pub fn (f Fraction) str() string { 
-	return '$f.n / $f.d' 
+	return '$f.n/$f.d' 
 }
 
 // Fraction add using operator overloading

--- a/vlib/math/fraction.v
+++ b/vlib/math/fraction.v
@@ -11,9 +11,9 @@ struct Fraction {
 }
 
 // A factory function for creating a Fraction, adds a boundary condition
-pub fn fraction(n i64,d i64) Fraction{
+pub fn fraction(n i64, d i64) Fraction{
 	if d != 0 {
-		return Fraction{n,d}
+		return Fraction{n, d}
 	} 
 	else {
 		panic('Denominator cannot be zero')
@@ -22,26 +22,26 @@ pub fn fraction(n i64,d i64) Fraction{
 
 // To String method
 pub fn (f Fraction) str() string { 
-	return '$f.n/$f.d' 
+	return '$f.n / $f.d' 
 }
 
 // Fraction add using operator overloading
 pub fn (f1 Fraction) + (f2 Fraction) Fraction {
 	if f1.d == f2.d {
-		return Fraction{f1.n + f2.n,f1.d}
+		return Fraction{f1.n + f2.n, f1.d}
 	}
 	else {
-		return Fraction{(f1.n * f2.d) + (f2.n * f1.d),f1.d * f2.d}
+		return Fraction{(f1.n * f2.d) + (f2.n * f1.d), f1.d * f2.d}
 	}
 }
 
 // Fraction substract using operator overloading
 pub fn (f1 Fraction) - (f2 Fraction) Fraction {
 	if f1.d == f2.d {
-		return Fraction{f1.n - f2.n,f1.d}
+		return Fraction{f1.n - f2.n, f1.d}
 	}
 	else {
-		return Fraction{(f1.n * f2.d) - (f2.n * f1.d),f1.d * f2.d}
+		return Fraction{(f1.n * f2.d) - (f2.n * f1.d), f1.d * f2.d}
 	}
 }
 
@@ -67,33 +67,33 @@ pub fn (f1 Fraction) subtract(f2 Fraction) Fraction {
 
 // Fraction multiply method
 pub fn (f1 Fraction) multiply(f2 Fraction) Fraction {
-	return Fraction{f1.n * f2.n,f1.d * f2.d}
+	return Fraction{f1.n * f2.n, f1.d * f2.d}
 }
 
 // Fraction divide method
 pub fn (f1 Fraction) divide(f2 Fraction) Fraction {
-	return Fraction{f1.n * f2.d,f1.d * f2.n}
+	return Fraction{f1.n * f2.d, f1.d * f2.n}
 }
 
 // Fraction reciprocal method
 pub fn (f1 Fraction) reciprocal() Fraction {
-	return Fraction{f1.d,f1.n}
+	return Fraction{f1.d, f1.n}
 }
 
 // Fraction method which gives greatest common divisor of numerator and denominator
 pub fn (f1 Fraction) gcd() i64 {
-	return gcd(f1.n,f1.d)
+	return gcd(f1.n, f1.d)
 }
 
 // Fraction method which reduces the fraction
 pub fn (f1 Fraction) reduce() Fraction {
-	cf := gcd(f1.n,f1.d)
-	return Fraction{f1.n/cf,f1.d/cf}
+	cf := gcd(f1.n, f1.d)
+	return Fraction{f1.n / cf, f1.d / cf}
 }
 
 // Converts Fraction to decimal
 pub fn (f1 Fraction) f64() f64 {
-	return f64(f1.n)/f64(f1.d)
+	return f64(f1.n) / f64(f1.d)
 }
 
 // Compares two Fractions


### PR DESCRIPTION
This PR simplifies the code mixed with https://github.com/vlang/v/commit/3f916efb6419aefc690ff45398fded1663245432 and https://github.com/vlang/v/commit/385f47c0cd7f4618640eee84124acdeea51cbb5a .
* replaced `mod()` with `abs()`
* replaced hypotenuse computings with `complex.abs()`, avoiding using `pow(num, 2)` for the sake of performance

Also, i inserted some spaces in the codes so that they look more consistent.