### PR TITLE
math : change log2 implementation

### DIFF
--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -157,7 +157,7 @@ pub fn log(a f64) f64 {
 
 // log2 calculates base-2 logarithm of the provided value.
 pub fn log2(a f64) f64 {
-	return C.log(a) / C.log(2)
+	return C.log2(a)
 }
 
 // log10 calculates the common (base-10) logarithm of the provided value.


### PR DESCRIPTION
update the `log2` implementation to use `log2()` provided by C