### PR TITLE
module aliasing & file import scope

### DIFF
--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -4,6 +4,8 @@
 
 module main
 
+import os
+
 struct CGen {
 	out          os.File
 	out_path     string

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -6,6 +6,7 @@ module main
 
 import os
 import time
+import strings
 
 const (
 	Version = '0.1.13' 

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -317,11 +317,10 @@ fn (p mut Parser) import_statement() {
 	mut pkg := p.lit.trim_space()
 	// submodule support
 	mut depth := 1
-	mut submodule := ''
-	p.next() 
+	p.next()
 	for p.tok == .dot {
 		p.check(.dot) 
-		submodule = p.check_name()
+		submodule := p.check_name()
 		if alias == '' { alias = submodule }
 		pkg += '.' + submodule
 		depth++

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1304,11 +1304,12 @@ fn (p mut Parser) name_expr() string {
 	// //////////////////////////
 	// module ?
 	// Allow shadowing (gg = gg.newcontext(); gg.draw_triangle())
-	if (p.table.known_pkg(name) || p.import_table.known_alias(name))
+	// if p.table.known_pkg(name)
+	if ((name == p.mod && p.table.known_pkg(name)) || p.import_table.known_alias(name))
 		&& !p.cur_fn.known_var(name) && !is_c {
 		mut pkg := name
 		// must be aliased module
-		if name != p.mod && p.import_table.known_alias(name) {
+		if name != p.mod && !p.table.known_pkg(name) {
 			// we replaced "." with "_" in p.mod for C variable names, do same here.
 			pkg = p.import_table.resolve_alias(name).replace('.', '_')
 		}

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1304,12 +1304,11 @@ fn (p mut Parser) name_expr() string {
 	// //////////////////////////
 	// module ?
 	// Allow shadowing (gg = gg.newcontext(); gg.draw_triangle())
-	// if p.table.known_pkg(name)
 	if ((name == p.mod && p.table.known_pkg(name)) || p.import_table.known_alias(name))
 		&& !p.cur_fn.known_var(name) && !is_c {
 		mut pkg := name
 		// must be aliased module
-		if name != p.mod && !p.table.known_pkg(name) {
+		if name != p.mod && p.import_table.known_alias(name) {
 			// we replaced "." with "_" in p.mod for C variable names, do same here.
 			pkg = p.import_table.resolve_alias(name).replace('.', '_')
 		}

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -86,7 +86,7 @@ fn (c mut V) new_parser(path string, run Pass) Parser {
 		file_name: path.all_after('/')
 		scanner: new_scanner(path)
 		table: c.table
-        f_import_table: new_file_import_table(path)
+		f_import_table: new_file_import_table(path)
 		cur_fn: EmptyFn
 		cgen: c.cgen
 		is_script: (c.pref.is_script && path == c.dir)

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -334,7 +334,7 @@ fn (p mut Parser) import_statement() {
 	// add import to file scope import table
 	p.f_import_table.register_alias(alias, pkg)
 	// Make sure there are no duplicate imports
-	if p.table.imports.contains(pkg)  {
+	if p.table.imports.contains(pkg) {
 		return
 	}
 	p.log('adding import $pkg')

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -4,6 +4,9 @@
 
 module main
 
+import os
+import strings
+
 struct Scanner {
 mut:
 	file_path      string

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -646,6 +646,24 @@ fn (table &Table) cgen_name_type_pair(name, typ string) string {
 	return '$typ $name'
 }
 
+fn is_valid_int_const(val, typ string) bool {
+	x := val.int() 
+	switch typ {
+	case 'byte', 'u8': return 0 <= x && x <= math.MaxU8 
+	case 'u16': return 0 <= x && x <= math.MaxU16 
+	//case 'u32': return 0 <= x && x <= math.MaxU32 
+	//case 'u64': return 0 <= x && x <= math.MaxU64 
+	////////////// 
+	case 'i8': return math.MinI8 <= x && x <= math.MaxI8 
+	case 'i16': return math.MinI16 <= x && x <= math.MaxI16 
+	case 'int', 'i32': return math.MinI32 <= x && x <= math.MaxI32 
+	//case 'i64': 
+		//x64 := val.i64() 
+		//return i64(-(1<<63)) <= x64 && x64 <= i64((1<<63)-1) 
+	} 
+	return true 
+}
+
 // Once we have a module format we can read from module file instead
 // this is not optimal
 fn (table &Table) qualify_module(mod string, file_path string) string {
@@ -661,8 +679,9 @@ fn (table &Table) qualify_module(mod string, file_path string) string {
 	return mod
 }
 
-fn new_file_import_table() *FileImportTable {
+fn new_file_import_table(file_path) *FileImportTable {
 	mut t := &FileImportTable{
+		file_path: file_path
 		imports:   map[string]string{}
 	}
 	return t
@@ -701,22 +720,3 @@ fn (fit &FileImportTable) resolve_alias(alias string) string {
 	}
 	return ''
 }
-
-fn is_valid_int_const(val, typ string) bool {
-	x := val.int() 
-	switch typ {
-	case 'byte', 'u8': return 0 <= x && x <= math.MaxU8 
-	case 'u16': return 0 <= x && x <= math.MaxU16 
-	//case 'u32': return 0 <= x && x <= math.MaxU32 
-	//case 'u64': return 0 <= x && x <= math.MaxU64 
-	////////////// 
-	case 'i8': return math.MinI8 <= x && x <= math.MaxI8 
-	case 'i16': return math.MinI16 <= x && x <= math.MaxI16 
-	case 'int', 'i32': return math.MinI32 <= x && x <= math.MaxI32 
-	//case 'i64': 
-		//x64 := val.i64() 
-		//return i64(-(1<<63)) <= x64 && x64 <= i64((1<<63)-1) 
-	} 
-	return true 
-} 
-

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -698,6 +698,8 @@ fn (fit mut FileImportTable) register_import(mod string) {
 fn (fit mut FileImportTable) register_alias(alias string, mod string) {
 	if !fit.imports.exists(alias) {
 		fit.imports[alias] = mod
+	} else {
+		panic('Cannot import $mod as $alias: import name $alias already in use.')
 	}
 }
 

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -668,7 +668,7 @@ fn is_valid_int_const(val, typ string) bool {
 // this is not optimal
 fn (table &Table) qualify_module(mod string, file_path string) string {
 	for m in table.imports {
-		if m.contains('.') {
+		if m.contains('.') && m.contains(mod) {
 			m_parts := m.split('.')
 			m_path := m_parts.join('/')
 			if mod == m_parts[m_parts.len-1] && file_path.contains(m_path) {

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -679,7 +679,7 @@ fn (table &Table) qualify_module(mod string, file_path string) string {
 	return mod
 }
 
-fn new_file_import_table(file_path) *FileImportTable {
+fn new_file_import_table(file_path string) *FileImportTable {
 	mut t := &FileImportTable{
 		file_path: file_path
 		imports:   map[string]string{}

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -8,15 +8,15 @@ import math
 
 struct Table {
 mut:
-	types        []Type
-	consts       []Var
-	fns          map[string]Fn 
-	obf_ids      map[string]int // obf_ids['myfunction'] == 23
-	packages     []string // List of all modules registered by the application
-	imports      []string // List of all imports
-	flags        []string //  ['-framework Cocoa', '-lglfw3']
-	fn_cnt       int atomic
-	obfuscate    bool
+	types     []Type
+	consts    []Var
+	fns       map[string]Fn 
+	obf_ids   map[string]int // obf_ids['myfunction'] == 23
+	packages  []string // List of all modules registered by the application
+	imports   []string // List of all imports
+	flags     []string //  ['-framework Cocoa', '-lglfw3']
+	fn_cnt    int atomic
+	obfuscate bool
 }
 
 // Holds import information scoped to the parsed file

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -699,7 +699,7 @@ fn (fit mut FileImportTable) register_alias(alias string, mod string) {
 	if !fit.imports.exists(alias) {
 		fit.imports[alias] = mod
 	} else {
-		panic('Cannot import $mod as $alias: import name $alias already in use.')
+		panic('Cannot import $mod as $alias: import name $alias already in use in "${fit.file_path}".')
 	}
 }
 

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -7,6 +7,7 @@ module gg
 import stbi
 import glm
 import gl
+import gx
 import os
 
 #flag darwin -I/usr/local/Cellar/freetype/2.10.0/include/freetype2

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -7,6 +7,7 @@ module gg
 import stbi
 import glm
 import gl
+import os
 
 #flag darwin -I/usr/local/Cellar/freetype/2.10.0/include/freetype2
 #flag -lfreetype

--- a/vlib/glm/glm_test.v
+++ b/vlib/glm/glm_test.v
@@ -5,6 +5,7 @@
 import os
 import gl
 import gg
+import glm
 
 fn cmp(a, b f32) bool {
 	return int(a * 1000) == int(b * 1000)


### PR DESCRIPTION
This PR implements module aliasing, GO style, eg:
```
import b64 encoding.base64
```
It also adds import scope, so that you actually have to import a module explicitly in a file for it to be available, even if it was imported in another file.

For example if module A imports B and B imports C

**Current V Implementation:**
```
A can access modules imported from B and C (and any from the files they import etc).
B can access modules imported from A and C (and any from the files they import etc).
C can access modules imported from A and B (and any from the files they import etc).
```
**This PR's Implementation:**
```
A can only access modules it imports.
B can only access modules it imports.
C can only access modules it imports.
```
This will prevent naming conflicts, and allow us to use the same modules/aliases in different files.