### PR TITLE
compiler/main: enable consts with operators in scripts

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -345,7 +345,7 @@ string _STR_TMP(const char *fmt, ...) {
 			// It can be skipped in single file programs
 			if v.pref.is_script {
 				//println('Generating main()...')
-				cgen.genln('int main() { $cgen.fn_main; return 0; }')
+				cgen.genln('int main() { init_consts(); $cgen.fn_main; return 0; }')
 			}
 			else {
 				println('panic: function `main` is undeclared in the main module')


### PR DESCRIPTION
This PR enables constant values with operators in scripts.
Currently, constants with operators returns `0` in **scripts**.

examples:
```
const (
	YearInHour = 365 * 24
)

println(YearInHour)
// expected => 8760
// result => 0
```

```
import math

max := math.MaxU8 // const defined as `(1<<8) - 1`

println(max)
// expected => 255
// result => 0
```

This bug is caused by the lack of `init_consts()` at the head of C `main` 