### PR TITLE
travis: fix travis windows user home

### DIFF
--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -33,6 +33,7 @@ mut:
 }
 
 fn new_cgen(out_name_c string) *CGen {
+	//println('TmpPath: "$TmpPath"')
 	path:='$TmpPath/$out_name_c'
 	out := os.create(path) or {
 		println('failed to create $path') 

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -459,7 +459,14 @@ pub fn home_dir() string {
 	mut home := os.getenv('HOME')
 	$if windows {
 		home = os.getenv('HOMEDRIVE')
-		home += os.getenv('HOMEPATH')
+		if home.len == 0 {
+			home = os.getenv('SYSTEMDRIVE')
+		}
+		mut homepath := os.getenv('HOMEPATH')
+		if homepath.len == 0 {
+			homepath = '\\Users\\' + os.getenv('USERNAME')
+		}
+		home += homepath
 	}
 	home += '/'
 	return home


### PR DESCRIPTION
This will fix travis windows build once v.c is regenerated with this patch.

Current implementation fails because some windows systems do not have HOMEDRIVE nor HOMEPATH defined. So this could fix some windows builds issues for some users.
