### PR TITLE
bf: add cmp(), join(), slice(), popcount() and hamming()

### DIFF
--- a/vlib/bf/bf.v
+++ b/vlib/bf/bf.v
@@ -178,3 +178,11 @@ pub fn clone(input BitField) BitField {
 	return output
 }
 
+pub fn cmp(input1 BitField, input2 BitField) bool {
+	if input1.size != input2.size {return false}
+	for i := 0; i < bitnslots(input1.size); i++ {
+		if input1.field[i] != input2.field[i] {return false}
+	}
+	return true
+}
+

--- a/vlib/bf/bf.v
+++ b/vlib/bf/bf.v
@@ -186,3 +186,22 @@ pub fn cmp(input1 BitField, input2 BitField) bool {
 	return true
 }
 
+pub fn (instance BitField) popcount() int {
+	size := instance.size
+	bitnslots := bitnslots(size)
+	tail := size % SLOT_SIZE
+	mut count := 0
+	for i := 0; i < bitnslots - 1; i++ {
+		for j := 0; j < SLOT_SIZE; j++ {
+			if u32(instance.field[i] >> u32(j)) & u32(1) == u32(1) {
+				count++
+			}
+		}
+	}
+	for j := 0; j < tail; j++ {
+		if u32(instance.field[bitnslots - 1] >> u32(j)) & u32(1) == u32(1) {
+			count++
+		}
+	}
+	return count
+}

--- a/vlib/bf/bf.v
+++ b/vlib/bf/bf.v
@@ -205,3 +205,8 @@ pub fn (instance BitField) popcount() int {
 	}
 	return count
 }
+
+pub fn hamming (input1 BitField, input2 BitField) int {
+	input_xored := bfxor(input1, input2)
+	return input_xored.popcount()
+}

--- a/vlib/bf/bf.v
+++ b/vlib/bf/bf.v
@@ -13,7 +13,7 @@ const (
 )
 
 fn bitmask(bitnr int) u32 {
-	return u32(1 << (bitnr % SLOT_SIZE))
+	return u32(u32(1) << u32(bitnr % SLOT_SIZE))
 }
 
 fn bitslot(size int) int {

--- a/vlib/bf/bf_test.v
+++ b/vlib/bf/bf_test.v
@@ -3,18 +3,18 @@ import bf
 import rand
 
 fn test_bf_new_size() {
-	instance := bf.new(5)
-	assert instance.getsize() == 5
+	instance := bf.new(75)
+	assert instance.getsize() == 75
 }
 
 fn test_bf_set_clear_toggle_get() {
-	mut instance := bf.new(5)
-	instance.setbit(4)
-	assert instance.getbit(4) == 1
-	instance.clearbit(4)
-	assert instance.getbit(4) == 0
-	instance.togglebit(4)
-	assert instance.getbit(4) == 1
+	mut instance := bf.new(75)
+	instance.setbit(47)
+	assert instance.getbit(47) == 1
+	instance.clearbit(47)
+	assert instance.getbit(47) == 0
+	instance.togglebit(47)
+	assert instance.getbit(47) == 1
 }
 
 fn test_bf_and_not_or_xor() {

--- a/vlib/bf/bf_test.v
+++ b/vlib/bf/bf_test.v
@@ -72,3 +72,26 @@ fn test_popcount() {
 	count1 := input.popcount()
 	assert count0 == count1
 }
+
+fn test_hamming() {
+	rand.seed()
+	len := 80
+	mut count := 0
+	mut input1 := bf.new(len)
+	mut input2 := bf.new(len)
+	for i := 0; i < len; i++ {
+		switch rand.next(4) {
+			case 0:
+			case 1:
+				input1.setbit(i)
+				count++
+			case 2:
+				input2.setbit(i)
+				count++
+			case 3:
+				input1.setbit(i)
+				input2.setbit(i)
+		}
+	}
+	assert count == bf.hamming(input1, input2)
+}

--- a/vlib/bf/bf_test.v
+++ b/vlib/bf/bf_test.v
@@ -57,3 +57,18 @@ fn test_clone_cmp() {
 	assert output.getsize() == len
 	assert bf.cmp(input, output) == true
 }
+
+fn test_popcount() {
+	rand.seed()
+	len := 80
+	mut count0 := 0
+	mut input := bf.new(len)
+	for i := 0; i < len; i++ {
+		if rand.next(2) == 1 {
+			input.setbit(i)
+			count0++
+		}
+	}
+	count1 := input.popcount()
+	assert count0 == count1
+}

--- a/vlib/bf/bf_test.v
+++ b/vlib/bf/bf_test.v
@@ -58,6 +58,29 @@ fn test_clone_cmp() {
 	assert bf.cmp(input, output) == true
 }
 
+fn test_slice_join() {
+	rand.seed()
+	len := 80
+	mut input := bf.new(len)
+	for i := 0; i < len; i++ {
+		if rand.next(2) == 1 {
+			input.setbit(i)
+		}
+	}
+	mut result := 1
+	for point := 1; point < (len - 1); point++ {
+		// divide a bitfield into two subfields
+		chunk1 := input.slice(0, point)
+		chunk2 := input.slice(point, input.getsize())
+		// concatenate them back into one and compare to the original
+		output := bf.join(chunk1, chunk2)
+		if !bf.cmp(input, output) {
+			result = 0
+		}
+	}
+	assert result == 1
+}
+
 fn test_popcount() {
 	rand.seed()
 	len := 80

--- a/vlib/bf/bf_test.v
+++ b/vlib/bf/bf_test.v
@@ -43,3 +43,17 @@ fn test_bf_and_not_or_xor() {
 	}
 	assert result == 1
 }
+
+fn test_clone_cmp() {
+	rand.seed()
+	len := 80
+	mut input := bf.new(len)
+	for i := 0; i < len; i++ {
+		if rand.next(2) == 1 {
+			input.setbit(i)
+		}
+	}
+	output := bf.clone(input)
+	assert output.getsize() == len
+	assert bf.cmp(input, output) == true
+}


### PR DESCRIPTION
This PR adds the following methods/functions to bf module:

// compare two bit arrays and return true/false
pub fn cmp(input1 BitField, input2 BitField) bool {...}

// join/concatenate two bit arrays and return the result as a new bit array
pub fn join(input1 BitField, input2 BitField) BitField {...}

// extract a slice (sub-array) and return it as a new bit array
pub fn (input BitField) slice(_start int, _end int) BitField {...}

// count the set (1) bits in an array
pub fn (instance BitField) popcount() int {

// compute the difference ('Hamming distance') between two bit arrays
pub fn hamming (input1 BitField, input2 BitField) int {...}