### PR TITLE
http.new_request: Don't ignore mutated variables url, data

### DIFF
--- a/vlib/http/http.v
+++ b/vlib/http/http.v
@@ -56,8 +56,8 @@ pub fn new_request(typ, _url, _data string) *Request {
 	// req.headers = new_map(0, sizeof(string))// []string{}
 	return &Request {
 		typ: typ
-		url: _url
-		data: _data
+		url: url
+		data: data
 		ws_func: 0
 		user_ptr: 0
 		headers: map[string]string{} 


### PR DESCRIPTION
These look like bugs:
* `url` gets assigned to but the result is not used
* `data` gets cleared but the result is not used

I've not tested the change, but either it is correct or the `if typ == 'GET'` block needs to be removed, as it does nothing.