### PR TITLE
net: add windows socket support

### DIFF
--- a/vlib/net/socket_mac.v
+++ b/vlib/net/socket_mac.v
@@ -1,0 +1,5 @@
+module net
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>

--- a/vlib/net/socket_win.v
+++ b/vlib/net/socket_win.v
@@ -1,0 +1,5 @@
+module net
+
+#flag -lws2_32
+#include <winsock2.h>
+#include <Ws2tcpip.h>


### PR DESCRIPTION
Add windows support for sockets.

`ws2_32.lib` is included in the Windows 10 SDK.
