### PR TITLE
Fixed clang build for windows.

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -653,13 +653,17 @@ pub fn signal(signum int, handler voidptr) {
 }
 
 pub fn fork() int {
-	pid := C.fork()
-	return pid
+	$if !windows {
+		pid := C.fork()
+		return pid
+	}
 }
 
 pub fn wait() int {
-	pid := C.wait(0)
-	return pid
+	$if !windows {
+		pid := C.wait(0)
+		return pid
+	}
 }
 
 pub fn file_last_mod_unix(path string) int {


### PR DESCRIPTION
Fixed:
```
C:\Users\C182~1\AppData\Local\Temp\ccb5oFDP.o: In function `os__fork':
C:/Users/─рэ //.vlang//v2.exe.c:4831: undefined reference to `fork'
C:\Users\C182~1\AppData\Local\Temp\ccb5oFDP.o: In function `os__wait':
C:/Users/─рэ //.vlang//v2.exe.c:4840: undefined reference to `wait'
collect2.exe: error: ld returned 1 exit status
```