### PR TITLE
bf: add setall(), clearall(), string() and str2bf()

### DIFF
--- a/vlib/bf/bf.v
+++ b/vlib/bf/bf.v
@@ -64,6 +64,29 @@ fn cleartail(instance BitField) {
 
 // public functions 
 
+pub fn str2bf(input string) BitField {
+	mut output := new(input.len)
+	for i := 0; i < input.len; i++ {
+		if input[i] != 48 {
+			output.setbit(i)
+		}
+	}
+	return output
+}
+
+pub fn (input BitField) string() string {
+	mut output := ''
+	for i := 0; i < input.size; i++ {
+		if input.getbit(i) == 1 {
+			output = output + '1'
+		}
+		else {
+			output = output + '0'
+		}
+	}
+	return output
+}
+
 pub fn new(size int) BitField {
 	output := BitField{
 		size: size 
@@ -91,6 +114,19 @@ pub fn (instance mut BitField) setbit(bitnr int) {
 pub fn (instance mut BitField) clearbit(bitnr int) {
 	if bitnr >= instance.size {return}
 	bitclear(instance, bitnr)
+}
+
+pub fn (instance mut BitField) setall() {
+	for i := 0; i < bitnslots(instance.size); i++ {
+		instance.field[i] = u32(-1)
+	}
+	cleartail(instance)
+}
+
+pub fn (instance mut BitField) clearall() {
+	for i := 0; i < bitnslots(instance.size); i++ {
+		instance.field[i] = u32(0)
+	}
 }
 
 pub fn (instance mut BitField) togglebit(bitnr int) {

--- a/vlib/bf/bf_test.v
+++ b/vlib/bf/bf_test.v
@@ -119,3 +119,86 @@ fn test_hamming() {
 	}
 	assert count == bf.hamming(input1, input2)
 }
+
+fn test_bf_str2bf() {
+	rand.seed(time.now().uni)
+	len := 80
+	mut input := ''
+	for i := 0; i < len; i++ {
+		if rand.next(2) == 1 {
+			input = input + '1'
+		}
+		else {
+			input = input + '0'
+		}
+	}
+	output := bf.str2bf(input)
+	mut result := 1
+	for i := 0; i < len; i++ {
+		if input[i] != output.getbit(i) + 48 {
+			result = 0
+		}
+	}
+	assert result == 1
+}
+
+fn test_bf_bf2str() {
+	rand.seed(time.now().uni)
+	len := 80
+	mut input := bf.new(len)
+	for i := 0; i < len; i++ {
+		if rand.next(2) == 1 {
+			input.setbit(i)
+		}
+	}
+	mut check := ''
+	for i := 0; i < len; i++ {
+		if input.getbit(i) == 1 {
+			check = check + '1'
+		}
+		else {
+			check = check + '0'
+		}
+	}
+	output := input.string()
+	mut result := 1
+	for i := 0; i < len; i++ {
+		if check[i] != output[i] {
+			result = 0
+		}
+	}
+	assert result == 1
+}
+
+fn test_bf_setall() {
+		rand.seed(time.now().uni)
+	len := 80
+	mut input := bf.new(len)
+	input.setall()
+	mut result := 1
+	for i := 0; i < len; i++ {
+		if input.getbit(i) != 1 {
+			result = 0
+		}
+	}
+	assert result == 1
+}
+
+fn test_bf_clearall() {
+		rand.seed(time.now().uni)
+	len := 80
+	mut input := bf.new(len)
+	for i := 0; i < len; i++ {
+		if rand.next(2) == 1 {
+			input.setbit(i)
+		}
+	}
+	input.clearall()
+	mut result := 1
+	for i := 0; i < len; i++ {
+		if input.getbit(i) != 0 {
+			result = 0
+		}
+	}
+	assert result == 1
+}


### PR DESCRIPTION
This PR adds the following methods/functions to bf module:

// set all bits in a bit array to 1
pub fn (instance BitField) setall() {...}

// clear all bits in a bit array (i.e. set to 0)
pub fn (instance BitField) clearall() {...}

// convert a bit array into a string of 1s and 0s and return the result
pub fn (input BitField) string() string {...}

// convert a string of 0s and 1s into a bit array and return the result
pub fn str2bf(input string) BitField {...}

Planned features:
* shift/rotate an array
* search for sub-array
* resize (have to find out how to shrink and enlarge an array)
* reverse the order if bits 