### PR TITLE
builtin: fix a memory leak in utf32_to_str()

### DIFF
--- a/vlib/builtin/utf8.v
+++ b/vlib/builtin/utf8.v
@@ -12,30 +12,32 @@ pub fn utf8_char_len(b byte) int {
 // utf32 == Codepoint
 pub fn utf32_to_str(code u32) string {
 	icode := int(code) 	//Prevents doing casts everywhere
-  mut buffer := malloc(5)
+	mut buffer := malloc(5)
+	mut retval := ''
 	if icode <= 127 /* 0x7F */ {
 		buffer[0] = icode
-		return tos(buffer, 1)
+		retval = tos(buffer, 1)
 	}
-	if (icode <= 2047 /* 0x7FF */) {
+	else if (icode <= 2047 /* 0x7FF */) {
 		buffer[0] = 192 /*0xC0*/ | (icode >> 6)                   /* 110xxxxx */
 		buffer[1] = 128 /*0x80*/ | (icode & 63 /*0x3F*/)          /* 10xxxxxx */
-		return tos(buffer, 2)
+		retval = tos(buffer, 2)
 	}
-	if (icode <= 65535 /* 0xFFFF */) {
+	else if (icode <= 65535 /* 0xFFFF */) {
 		buffer[0] = 224 /*0xE0*/ | (icode >> 12)                  /* 1110xxxx */
 		buffer[1] = 128 /*0x80*/ | ((icode >> 6) & 63 /*0x3F*/)   /* 10xxxxxx */
 		buffer[2] = 128 /*0x80*/ | (icode & 63 /*0x3F*/)          /* 10xxxxxx */
-		return tos(buffer, 3)
+		retval = tos(buffer, 3)
 	}
-	if (icode <= 1114111 /* 0x10FFFF */) {
+	else if (icode <= 1114111 /* 0x10FFFF */) {
 		buffer[0] = 240 /*0xF0*/ | (icode >> 18)                  /* 11110xxx */
 		buffer[1] = 128 /*0x80*/ | ((icode >> 12) & 63 /*0x3F*/)  /* 10xxxxxx */
 		buffer[2] = 128 /*0x80*/ | ((icode >> 6) & 63 /*0x3F*/)   /* 10xxxxxx */
 		buffer[3] = 128 /*0x80*/ | (icode & 63 /*0x3F*/)          /* 10xxxxxx */
-		return tos(buffer, 4)
+		retval = tos(buffer, 4)
 	}
-	return ''
+	free(buffer)
+	return retval
 }
 
 // TODO copypasta


### PR DESCRIPTION
Trivial bug, trivial fix.