### PR TITLE
web: create http server

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -656,17 +656,21 @@ pub fn signal(signum int, handler voidptr) {
 }
 
 pub fn fork() int {
-	$if !windows {
-		pid := C.fork()
-		return pid
+	$if windows {
+		return -1
 	}
+
+	pid := C.fork()
+	return pid
 }
 
 pub fn wait() int {
-	$if !windows {
-		pid := C.wait(0)
-		return pid
+	$if windows {
+		return -1
 	}
+
+	pid := C.wait(0)
+	return pid
 }
 
 pub fn file_last_mod_unix(path string) int {

--- a/vlib/web/web.v
+++ b/vlib/web/web.v
@@ -1,0 +1,124 @@
+module web
+
+import net
+import os
+
+// until embedded structs are supported
+// we must reconstruct the net.Socket struct
+// every time we want to call one of its methods
+struct Server {
+	sockfd int
+	family int
+	_type int
+	proto int
+	port int
+}
+
+// create server
+pub fn server(port int) Server {
+	socket := net.socket(AF_INET, SOCK_STREAM, 0)
+	opt := 1
+	socket.setsockopt(SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &opt)
+	s := Server {
+		sockfd: socket.sockfd
+		family: socket.family
+		_type: socket._type
+		proto: socket.proto
+		port: port
+	}
+	return s
+}
+
+// serve server forever
+pub fn (s Server) serve() {
+	socket := net.Socket {
+		sockfd: s.sockfd
+		family: s.family
+		_type: s._type
+		proto: s.proto
+	}
+	socket.bind(s.port)
+	socket.listen()
+
+	dir := os.getwd() + '/'
+
+	for {
+		connection := socket.accept()
+
+		if os.fork() == 0 {
+			request := tos(connection.recv(65535), 65535)
+
+			data := request.substr(0, request.index('\r\n')).split(' ')
+			method := data[0]
+			uri := data[1]
+			version := data[2]
+
+			// TODO: build request struct
+			// and do stuff with headers
+
+			switch method {
+			case 'GET':
+				mut path := dir
+				if uri == '/' {
+					path = dir + 'index.html'
+				}
+				else {
+					path = dir + uri
+				}
+
+				contents := os.read_file(path) or {
+					return
+				}
+				length := contents.len
+				mt := mimetype(path)
+
+				// TODO: build response struct
+				// and set other headers
+				mut response := '$version 200 OK\r\n'
+				response += 'Content-Type: $mt\r\n'
+				response += 'Content-Length: $length\r\n\r\n'
+				response += contents
+				response_raw := response.cstr()
+				connection.send(response_raw, response.len)
+			}
+
+			connection.close()
+			exit(0)
+		}
+	}
+}
+
+pub fn mimetype(filename string) string {
+	ext := os.ext(filename)
+	mut mt := 'application/octet-stream'
+	// TODO: use map
+	switch ext {
+	case '.css':
+		mt = 'text/css'
+	case '.gif':
+		mt = 'image/gif'
+	case '.htm':
+		mt = 'text/html'
+	case '.html':
+		mt = 'text/html'
+	case '.ico':
+		mt = 'image/vnd.microsoft.icon'
+	case '.jpeg':
+		mt = 'image/jpeg'
+	case '.jpg':
+		mt = 'image/jpeg'
+	case '.js':
+		mt = 'text/javascript'
+	case '.json':
+		mt = 'application/json'
+	case '.png':
+		mt = 'image/png'
+	case '.pdf':
+		mt = 'application/pdf'
+	case '.txt':
+		mt = 'text/plain'
+	case '.xml':
+		mt = 'application/xml'
+	}
+	return mt
+}


### PR DESCRIPTION
Add a web module to host an HTTP server.  Not production ready.  Currently supports only `GET` requests and ignores most headers

Doesn't work on Windows yet due to lack of `fork()`.  Windows support could probably be added via `popen` or `CreateProcess`

Create an `index.html` and `style.css` in `VROOT`

```
<!DOCTYPE html>
<html>
  <head>
    <title>HTTP Demo</title>
    <link rel="stylesheet" type="text/css" href="style.css">
  </head>
  <body>
    <h1>Hello World</h1>
  </body>
</html>
```

```
h1 {
    color: #ff0000;
}
```

Create `server.v`

```
import web

fn main() {
    s := s.server(8080)
    s.serve()
}
```

`localhost:8080` should now show a red `Hello World`
