### PR TITLE
live reloading: improve gdb debugging information, when compiling with -shared

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -942,7 +942,7 @@ fn new_v(args[]string) *V {
 			exit(1) 
 		}
 	} 
-	out_name_c := out_name.all_after('/') + '.c'
+	mut out_name_c := out_name.all_after('/') + '.c'
 	mut files := []string
 	// Add builtin files
 	if !out_name.contains('builtin.o') {
@@ -974,7 +974,12 @@ fn new_v(args[]string) *V {
 		is_run: args.contains('run')
 		is_repl: args.contains('-repl')
 		build_mode: build_mode
+	}  
+
+	if pref.is_so {
+		out_name_c = out_name.all_after('/') + '_shared_lib.c'
 	}
+
 	return &V {
 		os: _os
 		out_name: out_name


### PR DESCRIPTION
As a step in compiling with -live, the v compiler stores a C intermediary file, which is later overwritten by the later compilation (containing the main program), and then overwritten again on each change in the .v source by the compiler invocation in reload_so. This causes confusion for gdb (and probably other debuggers).

This PR changes the postfix of the C intermediary file for the -shared step to be '_shared_lib.c' instead of the main '.c' one. Thus the main and the .so debug information remains correct, and symbols are correctly resolved when debugging.