### PR TITLE
hot code reloading for bounce gui example on linux

### DIFF
--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -241,7 +241,7 @@ fn build_thirdparty_obj_file(flag string) {
 		} 
 	} 
 	cc := if os.user_os() == 'windows' { 'gcc' } else { 'cc' } // TODO clang support on Windows  
-	res := os.exec('$cc -c -o $obj_path $cfiles') 
+	res := os.exec('$cc -fPIC -c -o $obj_path $cfiles') 
 	println(res) 
 } 
 

--- a/examples/hot_code_reloading/bounce.v
+++ b/examples/hot_code_reloading/bounce.v
@@ -1,5 +1,5 @@
 // Build this example with
-// v -live bounce.v 
+// v -live -sanitize bounce.v
 module main
 
 import gx
@@ -64,7 +64,7 @@ const (
 	W = 50
 )
 
-//[live] TODO segfaults
+[live]
 fn (ctx &Game) draw() {
 	ctx.vg.draw_rect(ctx.x, ctx.y, W, W, gx.rgb(0, 0, 255))
 }


### PR DESCRIPTION
The example works fine when compiled with -sanitize .
It still crashes with SIGSEGV, when -sanitize is not given.
Also thirdparty/glad/glad.o should be build with -fPIC .
