### PR TITLE
parser: fix bug not printing percentages

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -2222,6 +2222,7 @@ fn (p mut Parser) string_expr() {
 	mut format := '"'
 	for p.tok == .strtoken {
 		// Add the string between %d's
+		p.lit = p.lit.replace('%', '%%')
 		format += format_str(p.lit)
 		p.next()// skip $
 		if p.tok != .dollar {


### PR DESCRIPTION
Adds a `%` to the generated format to the printf in order to print correctly the percentages.

This now do that :
```
>>> a := 'a'
>>> println('$a %x %x %x')
a %x %x %x
```

Fixes #1097 