### PR TITLE
cmath: added arg, log and complex power operations

### DIFF
--- a/vlib/cmath/complex.v
+++ b/vlib/cmath/complex.v
@@ -160,6 +160,34 @@ pub fn (c Complex) ln() Complex {
 	}
 }
 
+// Complex Log Base Complex
+// Based on 
+// http://www.milefoot.com/math/complex/summaryops.htm
+pub fn (c Complex) log(base Complex) Complex {
+	return base.ln().divide(c.ln())
+}
+
+// Complex Argument
+// Based on
+// http://mathworld.wolfram.com/ComplexArgument.html
+pub fn (c Complex) arg() f64 {
+	return math.atan2(c.im,c.re)
+}
+
+// Complex raised to Complex Power
+// Based on
+// http://mathworld.wolfram.com/ComplexExponentiation.html
+pub fn (c Complex) cpow(p Complex) Complex {
+	a := c.arg()
+	b := math.pow(c.re,2) + math.pow(c.im,2)
+	d := p.re * a + (1.0/2) * p.im * math.log(b)
+	t1 := math.pow(b,p.re/2) * math.exp(-p.im*a)
+	return Complex{
+		t1 * math.cos(d), 
+		t1 * math.sin(d)
+	}
+}
+
 // Complex Sin
 // Based on
 // http://www.milefoot.com/math/complex/functionsofi.htm

--- a/vlib/cmath/complex_test.v
+++ b/vlib/cmath/complex_test.v
@@ -254,6 +254,69 @@ fn test_complex_ln() {
 	assert result.str().eq(c2.str())
 }
 
+fn test_complex_arg() {
+	// Tests were also verified on Wolfram Alpha
+	mut c1 := cmath.complex(5,7)
+	mut c2 := cmath.complex(2.152033,0.950547)
+	mut result := c1.arg()
+	// Some issue with precision comparison in f64 using == operator hence serializing to string
+	assert result.str().eq('0.950547')
+	c1 = cmath.complex(-3,4)
+	c2 = cmath.complex(1.609438,2.214297)
+	result = c1.arg()
+	// Some issue with precision comparison in f64 using == operator hence serializing to string
+	assert result.str().eq('2.214297')
+	c1 = cmath.complex(-1,-2)
+	c2 = cmath.complex(0.804719,-2.034444)
+	result = c1.arg()
+	// Some issue with precision comparison in f64 using == operator hence serializing to string
+	assert result.str().eq('-2.034444')
+}
+
+fn test_complex_log() {
+	// Tests were also verified on Wolfram Alpha
+	mut c1 := cmath.complex(5,7)
+	mut b1 := cmath.complex(-6,-2)
+	mut c2 := cmath.complex(0.232873,-1.413175)
+	mut result := c1.log(b1)
+	// Some issue with precision comparison in f64 using == operator hence serializing to string
+	assert result.str().eq(c2.str())
+	c1 = cmath.complex(-3,4)
+	b1 = cmath.complex(3,-1)
+	c2 = cmath.complex(0.152198,-0.409312)
+	result = c1.log(b1)
+	// Some issue with precision comparison in f64 using == operator hence serializing to string
+	assert result.str().eq(c2.str())
+	c1 = cmath.complex(-1,-2)
+	b1 = cmath.complex(0,9)
+	c2 = cmath.complex(-0.298243,1.197981)
+	result = c1.log(b1)
+	// Some issue with precision comparison in f64 using == operator hence serializing to string
+	assert result.str().eq(c2.str())
+}
+
+fn test_complex_cpow() {
+	// Tests were also verified on Wolfram Alpha
+	mut c1 := cmath.complex(5,7)
+	mut r1 := cmath.complex(2,2)
+	mut c2 := cmath.complex(11.022341,-0.861785)
+	mut result := c1.cpow(r1)
+	// Some issue with precision comparison in f64 using == operator hence serializing to string
+	assert result.str().eq(c2.str())
+	c1 = cmath.complex(-3,4)
+	r1 = cmath.complex(-4,-2)
+	c2 = cmath.complex(0.118303,0.063148)
+	result = c1.cpow(r1)
+	// Some issue with precision comparison in f64 using == operator hence serializing to string
+	assert result.str().eq(c2.str())
+	c1 = cmath.complex(-1,-2)
+	r1 = cmath.complex(8,-9)
+	c2 = cmath.complex(-0.000000,0.000007)
+	result = c1.cpow(r1)
+	// Some issue with precision comparison in f64 using == operator hence serializing to string
+	assert result.str().eq(c2.str())
+}
+
 fn test_complex_sin() {
 	// Tests were also verified on Wolfram Alpha
 	mut c1 := cmath.complex(5,7)


### PR DESCRIPTION
This PR adds the following operations-
1. `arg` - Complex Argument
2. `log` - Complex Log with base also as Complex number
3. `cpow` - Complex Power with power also as Complex number

Unit tests are added and cross verified with **Wolfram Alpha**