### PR TITLE
parser: fix #1107

### DIFF
--- a/compiler/tests/option_test.v
+++ b/compiler/tests/option_test.v
@@ -8,3 +8,18 @@ fn test_err(){
 	assert false
 	println(v) // suppress not used error
 }
+
+fn err_call(ok bool) ?int {
+	if !ok {
+		return error('Not ok!')
+	}
+	return 42
+}
+
+fn test_option_for_base_type_without_variable() {
+	val := err_call(true) or {
+		panic(err)
+		return
+	}
+	assert val == 42
+}


### PR DESCRIPTION
This PR fix #1107 .
Now we can compile following code.
```go
fn err_call(ok bool) ?int {
  if !ok {
    return error('Not ok!')
  }
  return 42
}

fn test_err_call() {
  val := err_call(true) or {
    panic(err)
    return
  }
  assert val == 42
}
```