### PR TITLE
hot reload: no -sanitize is needed anymore, -live is now enough on both Linux and MacOS X

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -389,7 +389,7 @@ int load_so(byteptr path) {
 		cgen.genln('return 1; }
  
 void reload_so() {
-	int last = 0; 
+	int last = os__file_last_mod_unix(tos2("$file"));
 	while (1) {
 		// TODO use inotify 
 		int now = os__file_last_mod_unix(tos2("$file")); 

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -535,8 +535,14 @@ fn (v mut V) cc() {
 	else {
 		a << '-g'
 	}
-	if v.pref.is_live {
-		a << '-rdynamic'
+	if v.pref.is_live || v.pref.is_so {
+		// See 'man dlopen', and test running a GUI program compiled with -live
+		if (v.os == .linux || os.user_os() == 'linux'){    
+			a << '-rdynamic'
+		}
+		if (v.os == .mac || os.user_os() == 'mac'){
+			a << '-flat_namespace'
+		}
 	}
 	mut libs := ''// builtin.o os.o http.o etc
 	if v.pref.build_mode == .build {

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -535,6 +535,9 @@ fn (v mut V) cc() {
 	else {
 		a << '-g'
 	}
+	if v.pref.is_live {
+		a << '-rdynamic'
+	}
 	mut libs := ''// builtin.o os.o http.o etc
 	if v.pref.build_mode == .build {
 		a << '-c'

--- a/examples/hot_code_reloading/bounce.v
+++ b/examples/hot_code_reloading/bounce.v
@@ -1,5 +1,5 @@
 // Build this example with
-// v -live -sanitize bounce.v
+// v -live bounce.v
 module main
 
 import gx


### PR DESCRIPTION
The bounce crash was caused by uninitialized glad_XXXXX symbols in the shared library (which are loaded by gl__init_glad, which in turn uses dlopen/dlsym too, but is called only in the main executable, not in the shared library). 

The 'man dlopen' page on Linux says:
       External  references  in  the  shared  object are resolved using the
       shared objects in  that  object's  dependency  list  and  any  other
       objects  previously  opened  with the RTLD_GLOBAL flag.  If the 
       executable was linked with  the  flag  "-rdynamic"  (or,  synonymously,
       "--export-dynamic"),  then the global symbols in the executable will
       also be used to resolve references in a  dynamically  loaded  shared
       object.

On MacOS X the reason is similar, but the flag to solve it is different: -flat_namespace .

It seems that -sanitize may have turned on -rdynamic for my compiler (clang7 on linux), thus the earlier partial solution.

The bounce example now runs and does hot code reload on *both* Linux and MacOS X for me (I do not have a windows box at the moment, so I can not test there easily).
