### PR TITLE
builtin: add free()

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -221,10 +221,6 @@ pub fn (a []string) str() string {
 	return res
 }
 
-fn free(a voidptr) {
-	C.free(a)
-}
-
 pub fn (b []byte) hex() string {
 	mut hex := malloc(b.len*2+1)
 	mut ptr := &hex[0]

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -89,6 +89,10 @@ pub fn calloc(n int) byteptr {
 	return C.calloc(n, 1)
 }
 
+pub fn free(ptr voidptr) {
+	C.free(ptr)
+}
+
 fn _strlen(s byteptr) int {
 	return C.strlen(s)
 }


### PR DESCRIPTION
Add `free()`.  `malloc()` and `calloc()` already exist