### PR TITLE
os: path seperator

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -408,6 +408,13 @@ fn path_sans_ext(path string) string {
 	return path.left(pos)
 }
 
+pub fn path(path string) string {
+	$if windows {
+		return path.replace('/', '\\')
+	}
+	return path
+}
+
 
 pub fn basedir(path string) string {
 	pos := path.last_index('/')

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -41,6 +41,10 @@ fn test_dir() {
 	} $else { 
 		assert os.dir('/var/tmp/foo') == '/var/tmp' 
 	} 
+}
+
+fn test_path() {
+  assert os.path('this/is/a/test') == 'this\\is\\a\\test'
 } 
 
 //fn test_fork() {


### PR DESCRIPTION
Add `os.path` to replace `/` with `\\` if on Windows.

The compiler is occasionally panicking because Windows hates `/`
