### PR TITLE
os: fix 'rm' and 'rmdir' implementation on windows

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -347,27 +347,18 @@ pub fn mkdir(path string) {
 
 // rm removes file in `path`.
 pub fn rm(path string) {
-	$if windows {
-		os.system('del /f $path')
-	}
-	$else {
 		C.remove(path.cstr())
-		C.unlink(path.cstr())
-	}
+	// C.unlink(path.cstr())
 }
 
 
-// TODO
+// rmdir removes a specified directory.
 pub fn rmdir(path string) {
-	// if !path.contains(guard) {
-	//	println('rmdir canceled because the path doesnt contain $guard')
-	//	return
-	// }
 	$if !windows {
 		C.rmdir(path.cstr())		
 	}
 	$else {
-		C.rmdir(path.cstr())
+		C.RemoveDirectoryA(path.cstr())
 	}
 }
 

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -6,7 +6,7 @@ module os
 
 #include <sys/stat.h>
 #include <signal.h>
-//#include <unistd.h>
+#include <unistd.h>
 #include <errno.h>
 //#include <execinfo.h> // for backtrace_symbols_fd 
 
@@ -347,27 +347,29 @@ pub fn mkdir(path string) {
 // rm removes file in `path`.
 pub fn rm(path string) {
 	$if windows {
-		// os.system2('del /f $path')
+		os.system('del /f $path')
 	}
 	$else {
 		C.remove(path.cstr())
+		C.unlink(path.cstr())
 	}
-	// C.unlink(path.cstr())
 }
 
-/*
+
 // TODO
-fn rmdir(path, guard string) {
-	if !path.contains(guard) {
-		println('rmdir canceled because the path doesnt contain $guard')
-		return
-	}
+pub fn rmdir(path string) {
+	// if !path.contains(guard) {
+	//	println('rmdir canceled because the path doesnt contain $guard')
+	//	return
+	// }
 	$if !windows {
+		C.rmdir(path.cstr())		
 	}
 	$else {
+		C.rmdir(path.cstr())
 	}
 }
-*/
+
 
 fn print_c_errno() {
 	//C.printf('errno=%d err="%s"\n', errno, C.strerror(errno)) 

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -34,9 +34,23 @@ fn test_write_and_read_string_to_file() {
   os.rm(filename)
 }
 
+fn test_create_and_delete_folder() {
+  folder := './test1'
+  os.mkdir(folder)
+
+  folder_contents := os.ls(folder)
+  assert folder_contents.len == 0
+
+  os.rmdir(folder)
+
+  folder_exists := os.dir_exists(folder)
+
+  assert folder_exists == false
+}
+
 fn test_dir() {
 	$if windows {
-		assert os.dir('C:\a\b\c') == 'C:\a\b' 
+		assert os.dir('C:\\a\\b\\c') == 'C:\\a\\b' 
  
 	} $else { 
 		assert os.dir('/var/tmp/foo') == '/var/tmp' 


### PR DESCRIPTION
Fixes the implementation of the `rm` and `rmdir` functions from the `os` module.
- Remove `$if` statement and uses a single `C.remove()` function instead.
- Added test for `rmdir` (and fixed a test in paths)
- Uses `C.RemoveDirectoryA()` function for windows