### PR TITLE
Support for VFLAGS environment variable, enabling better debugging of sub process compilers.

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -93,7 +93,7 @@ mut:
 
 fn main() {
 	// There's no `flags` module yet, so args have to be parsed manually
-	args := os.args
+	args := env_vflags_and_os_args()
 	// Print the version and exit.
 	if '-v' in args || '--version' in args || 'version' in args {
 		println('V $Version')
@@ -1097,3 +1097,18 @@ v -nofmt file.v
 are working on vlib) 
 v -embed_vlib file.v 
 */
+
+fn env_vflags_and_os_args() []string {
+   mut args := []string
+   vflags := os.getenv('VFLAGS')
+   if '' != vflags {
+     args << os.args[0]
+     args << vflags.split(' ')
+     if os.args.len > 1 {
+       args << os.args.right(1)
+     }
+   }else{
+     args << os.args
+   }
+   return args
+}


### PR DESCRIPTION
Using VFLAGS, you can pass common options to the V compiler,
without having to manually specify them everytime when you type 'v -debug -show_c_cmd ...'

In addition, since environment variables are *inherited*, all subprocess
V compilers, which V launches (for example when compiling with -live),
will *also* use the same VFLAGS environment variable.

Example usage:
  export VFLAGS="-debug -show_c_cmd"
  v -live message.v

=> This will keep *both* of the generated C source files .message.c
   *AND* .message_shared_lib.c . It will also cause both V compile
   subprocesses to print their resulting C compiler backend lines.
   This is very useful when using GDB to debug problems.
