### PR TITLE
Windows : fix build

### DIFF
--- a/vlib/os/os_win.v
+++ b/vlib/os/os_win.v
@@ -1,5 +1,8 @@
 module os
 
+#flag -lws2_32
+#include <winsock2.h>
+
 const (
 	PathSeparator = '\\' 
 ) 


### PR DESCRIPTION
```
curl -Os https://raw.githubusercontent.com/vlang/vc/master/v.c
cc -std=gnu11 -w -o v v.c -lm
ccK5ic4o.o:v.c:(.text+0x6f62): undefined reference to `__imp_gethostname'
collect2.exe: error: ld returned 1 exit status

```
add include <winsock2.h>
for gethostname

https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-gethostname