### PR TITLE
term: enable render term color on windows by default

### DIFF
--- a/vlib/term/colors.v
+++ b/vlib/term/colors.v
@@ -23,6 +23,10 @@ pub fn enable_term_color_win() {
 }
 
 pub fn format(msg, open, close string) string {
+    $if windows {
+        enable_term_color_win()
+    }
+
     return '\x1b[' + open + 'm' + msg + '\x1b[' + close + 'm'
 }
 


### PR DESCRIPTION
Adds `enable_term_color_win()` inside the `format()` function.