### PR TITLE
fix winsock2 compile error on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /v
 /vprod
 /v.c
+/v.exe
+/*.exe

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -197,7 +197,7 @@ fn (v mut V) compile() {
 
 #ifdef _WIN32 
 #include <windows.h>
-//#include <WinSock2.h> 
+#include <winsock2.h> 
 #endif 
 
 //================================== TYPEDEFS ================================*/ 

--- a/make.bat
+++ b/make.bat
@@ -1,3 +1,3 @@
 curl -O https://raw.githubusercontent.com/vlang/vc/master/v.c
-gcc -std=gnu11 -w -o v.exe v.c
+gcc -std=gnu11 -w -o v.exe v.c -lws2_32
 del v.c

--- a/vlib/net/socket_win.v
+++ b/vlib/net/socket_win.v
@@ -1,5 +1,7 @@
 module net
 
+#ifdef _WIN32 
 #flag -lws2_32
 #include <winsock2.h>
 #include <Ws2tcpip.h>
+#endif 

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -8,7 +8,9 @@ module os
 #include <signal.h>
 #include <unistd.h>
 #include <errno.h>
+#ifdef _WIN32 
 #include <winsock2.h>
+#endif 
 //#include <execinfo.h> // for backtrace_symbols_fd 
 
 /* 

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -8,6 +8,7 @@ module os
 #include <signal.h>
 #include <unistd.h>
 #include <errno.h>
+#include <winsock2.h>
 //#include <execinfo.h> // for backtrace_symbols_fd 
 
 /* 

--- a/vlib/os/os_win.v
+++ b/vlib/os/os_win.v
@@ -1,8 +1,9 @@
 module os
 
+#ifdef _WIN32 
 #flag -lws2_32
 #include <winsock2.h>
-
+#endif 
 const (
 	PathSeparator = '\\' 
 ) 


### PR DESCRIPTION
- Fixes compiler error by adding an additional flag to the gcc compiler on windows. `-lws2_32`
- Adds `v.exe` to `.gitignore`
- Properly import `winsock2.h`