### PR TITLE
additional `.gitignore` rules for windows development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /vprod
 /v.c
 /v.exe
+*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /v
 /vprod
 /v.c
+/v.exe

--- a/make.bat
+++ b/make.bat
@@ -1,3 +1,3 @@
 curl -O https://raw.githubusercontent.com/vlang/vc/master/v.c
-gcc -std=gnu11 -w -o v.exe v.c -lws2_32
+gcc -std=gnu11 -w -o v.exe v.c
 del v.c

--- a/make.bat
+++ b/make.bat
@@ -1,3 +1,3 @@
 curl -O https://raw.githubusercontent.com/vlang/vc/master/v.c
-gcc -std=gnu11 -w -o v.exe v.c
+gcc -std=gnu11 -w -o v.exe v.c -lws2_32
 del v.c


### PR DESCRIPTION
- Ignores `v.exe` and other executable files on git
- ~~Fixes compile error when executing the `make.bat` on windows. (prev on #1197 and fixes #1205 )~~