### PR TITLE
implement missing string to int type methods

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -150,11 +150,11 @@ pub fn (s string) f64() f64 {
 }
 
 pub fn (s string) u32() u32 {
-	return C.strtoul(s.str, 0, 10)
+	return C.strtoul(s.str, 0, 0)
 }
 
 pub fn (s string) u64() u64 {
-	return C.strtoull(s.str, 0, 10)
+	return C.strtoull(s.str, 0, 0)
 }
 
 // ==

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -133,12 +133,28 @@ pub fn (s string) int() int {
 	return C.atoi(s.str)
 }
 
+pub fn (s string) i32() i32 {
+	return C.atol(s.str)
+}
+
 pub fn (s string) i64() i64 {
 	return C.atoll(s.str)
 }
 
 pub fn (s string) f32() f32 {
 	return C.atof(s.str)
+}
+
+pub fn (s string) f64() f64 {
+	return C.atof(s.str)
+}
+
+pub fn (s string) u32() u32 {
+	return C.strtoul(s.str, 0, 10)
+}
+
+pub fn (s string) u64() u64 {
+	return C.strtoull(s.str, 0, 10)
 }
 
 // ==


### PR DESCRIPTION
This implement the following methods on string

- int (already existed)
- i32
- i64 (already existed)
- f32 (already existed)
- f64
- u32
- u64

I will be using this as I add the detection in the parser for const types etc