### PR TITLE
Makefile: update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,14 @@ all: clean v
 	$(info V has been successfully built)
 
 v: v.c
-	${CC} -std=gnu11 -w -o v v.c -lm 
 	./v -o v compiler
-	rm v.c
+
+v-release: v.c
+	./v -prod -o v compiler
 
 v.c:
 	curl -Os https://raw.githubusercontent.com/vlang/vc/master/v.c
+	${CC} -std=gnu11 -w -o v v.c -lm 
 
 test: v
 	./v -prod -o vprod compiler # Test prod build
@@ -26,3 +28,11 @@ SOURCES = $(wildcard thirdparty/**/*.c)
 OBJECTS := ${SOURCES:.c=.o} 
 
 thirdparty: ${OBJECTS}
+
+thirdparty-release: ${OBJECTS}
+	strip ${OBJECTS}
+
+debug: clean v thirdparty
+
+release: CFLAGS += -pie
+release: clean v-release thirdparty-release


### PR DESCRIPTION
```
$ namcap vlang-git-r619.c35adbe-1-x86_64.pkg.tar.xz 
vlang-git W: ELF file ('usr/lib/vlang/thirdparty/cJSON/cJSON.o') lacks FULL RELRO, check LDFLAGS.
vlang-git W: ELF file ('usr/lib/vlang/thirdparty/glad/glad.o') lacks FULL RELRO, check LDFLAGS.
vlang-git W: ELF file ('usr/lib/vlang/thirdparty/zip/zip.o') lacks FULL RELRO, check LDFLAGS.
vlang-git W: ELF file ('usr/lib/vlang/v') lacks FULL RELRO, check LDFLAGS.
vlang-git W: ELF file ('usr/lib/vlang/thirdparty/cJSON/cJSON.o') is unstripped.
vlang-git W: ELF file ('usr/lib/vlang/thirdparty/glad/glad.o') is unstripped.
vlang-git W: ELF file ('usr/lib/vlang/thirdparty/zip/zip.o') is unstripped.
vlang-git W: ELF file ('usr/lib/vlang/thirdparty/cJSON/cJSON.o') lacks PIE.
vlang-git W: ELF file ('usr/lib/vlang/thirdparty/glad/glad.o') lacks PIE.
vlang-git W: ELF file ('usr/lib/vlang/thirdparty/zip/zip.o') lacks PIE.
vlang-git W: Unused shared library '/usr/lib/libdl.so.2' by file ('usr/lib/vlang/v')
```
resolving lacks PIE and unstripped issues for release builds
```
make debug
make release
```