### PR TITLE
change hardcoded u64's back to consts (in crypto.sha512)

### DIFF
--- a/vlib/crypto/sha512/sha512.v
+++ b/vlib/crypto/sha512/sha512.v
@@ -74,8 +74,8 @@ mut:
 }
 
 fn (d mut Digest) reset() {
-    d.h = [u64(0); 8]
-    d.x = [byte(0); Chunk]
+	d.h = [u64(0); 8]
+	d.x = [byte(0); Chunk]
 	switch d.function {
 	case crypto.Hash.SHA384:
 		d.h[0] = u64(Init0_384)

--- a/vlib/crypto/sha512/sha512.v
+++ b/vlib/crypto/sha512/sha512.v
@@ -73,93 +73,46 @@ mut:
 	function crypto.Hash
 }
 
-// Note: when u64 const is working uncomment this and remove reset() below
-// fn (d mut Digest) reset() {
-//     d.h = [u64(0); 8]
-//     d.x = [byte(0); Chunk]
-// 	switch d.function {
-// 	case crypto.Hash.SHA384:
-// 		d.h[0] = u64(Init0_384)
-// 		d.h[1] = u64(Init1_384)
-// 		d.h[2] = u64(Init2_384)
-// 		d.h[3] = u64(Init3_384)
-// 		d.h[4] = u64(Init4_384)
-// 		d.h[5] = u64(Init5_384)
-// 		d.h[6] = u64(Init6_384)
-// 		d.h[7] = u64(Init7_384)
-// 	case crypto.Hash.SHA512_224:
-// 		d.h[0] = u64(Init0_224)
-// 		d.h[1] = u64(Init1_224)
-// 		d.h[2] = u64(Init2_224)
-// 		d.h[3] = u64(Init3_224)
-// 		d.h[4] = u64(Init4_224)
-// 		d.h[5] = u64(Init5_224)
-// 		d.h[6] = u64(Init6_224)
-// 		d.h[7] = u64(Init7_224)
-// 	case crypto.Hash.SHA512_256:
-// 		d.h[0] = u64(Init0_256)
-// 		d.h[1] = u64(Init1_256)
-// 		d.h[2] = u64(Init2_256)
-// 		d.h[3] = u64(Init3_256)
-// 		d.h[4] = u64(Init4_256)
-// 		d.h[5] = u64(Init5_256)
-// 		d.h[6] = u64(Init6_256)
-// 		d.h[7] = u64(Init7_256)
-// 	default:
-// 		d.h[0] = u64(Init0)
-// 		d.h[1] = u64(Init1)
-// 		d.h[2] = u64(Init2)
-// 		d.h[3] = u64(Init3)
-// 		d.h[4] = u64(Init4)
-// 		d.h[5] = u64(Init5)
-// 		d.h[6] = u64(Init6)
-// 		d.h[7] = u64(Init7)
-// 	}
-// 	d.nx = 0
-// 	d.len = u64(0)
-// }
-
-// Note: when u64 const is working remove this and uncomment above
 fn (d mut Digest) reset() {
-	d.h = [u64(0); 8]
-	d.x = [byte(0); Chunk]
+    d.h = [u64(0); 8]
+    d.x = [byte(0); Chunk]
 	switch d.function {
 	case crypto.Hash.SHA384:
-		d.h[0] = u64(0xcbbb9d5dc1059ed8)
-		d.h[1] = u64(0x629a292a367cd507)
-		d.h[2] = u64(0x9159015a3070dd17)
-		d.h[3] = u64(0x152fecd8f70e5939)
-		d.h[4] = u64(0x67332667ffc00b31)
-		d.h[5] = u64(0x8eb44a8768581511)
-		d.h[6] = u64(0xdb0c2e0d64f98fa7)
-		d.h[7] = u64(0x47b5481dbefa4fa4)
+		d.h[0] = u64(Init0_384)
+		d.h[1] = u64(Init1_384)
+		d.h[2] = u64(Init2_384)
+		d.h[3] = u64(Init3_384)
+		d.h[4] = u64(Init4_384)
+		d.h[5] = u64(Init5_384)
+		d.h[6] = u64(Init6_384)
+		d.h[7] = u64(Init7_384)
 	case crypto.Hash.SHA512_224:
-		d.h[0] = u64(0x8c3d37c819544da2)
-		d.h[1] = u64(0x73e1996689dcd4d6)
-		d.h[2] = u64(0x1dfab7ae32ff9c82)
-		d.h[3] = u64(0x679dd514582f9fcf)
-		d.h[4] = u64(0x0f6d2b697bd44da8)
-		d.h[5] = u64(0x77e36f7304c48942)
-		d.h[6] = u64(0x3f9d85a86a1d36c8)
-		d.h[7] = u64(0x1112e6ad91d692a1)
+		d.h[0] = u64(Init0_224)
+		d.h[1] = u64(Init1_224)
+		d.h[2] = u64(Init2_224)
+		d.h[3] = u64(Init3_224)
+		d.h[4] = u64(Init4_224)
+		d.h[5] = u64(Init5_224)
+		d.h[6] = u64(Init6_224)
+		d.h[7] = u64(Init7_224)
 	case crypto.Hash.SHA512_256:
-		d.h[0] = u64(0x22312194fc2bf72c)
-		d.h[1] = u64(0x9f555fa3c84c64c2)
-		d.h[2] = u64(0x2393b86b6f53b151)
-		d.h[3] = u64(0x963877195940eabd)
-		d.h[4] = u64(0x96283ee2a88effe3)
-		d.h[5] = u64(0xbe5e1e2553863992)
-		d.h[6] = u64(0x2b0199fc2c85b8aa)
-		d.h[7] = u64(0x0eb72ddc81c52ca2)
+		d.h[0] = u64(Init0_256)
+		d.h[1] = u64(Init1_256)
+		d.h[2] = u64(Init2_256)
+		d.h[3] = u64(Init3_256)
+		d.h[4] = u64(Init4_256)
+		d.h[5] = u64(Init5_256)
+		d.h[6] = u64(Init6_256)
+		d.h[7] = u64(Init7_256)
 	default:
-		d.h[0] = u64(0x6a09e667f3bcc908)
-		d.h[1] = u64(0xbb67ae8584caa73b)
-		d.h[2] = u64(0x3c6ef372fe94f82b)
-		d.h[3] = u64(0xa54ff53a5f1d36f1)
-		d.h[4] = u64(0x510e527fade682d1)
-		d.h[5] = u64(0x9b05688c2b3e6c1f)
-		d.h[6] = u64(0x1f83d9abfb41bd6b)
-		d.h[7] = u64(0x5be0cd19137e2179)
+		d.h[0] = u64(Init0)
+		d.h[1] = u64(Init1)
+		d.h[2] = u64(Init2)
+		d.h[3] = u64(Init3)
+		d.h[4] = u64(Init4)
+		d.h[5] = u64(Init5)
+		d.h[6] = u64(Init6)
+		d.h[7] = u64(Init7)
 	}
 	d.nx = 0
 	d.len = u64(0)

--- a/vlib/crypto/sha512/sha512block_generic.v
+++ b/vlib/crypto/sha512/sha512block_generic.v
@@ -95,90 +95,6 @@ const(
 )
 
 fn block_generic(dig &Digest, p []byte) {
-	// Note: When u64 const is working remove this
-	_k := [
-		u64(0x428a2f98d728ae22),
-		u64(0x7137449123ef65cd),
-		u64(0xb5c0fbcfec4d3b2f),
-		u64(0xe9b5dba58189dbbc),
-		u64(0x3956c25bf348b538),
-		u64(0x59f111f1b605d019),
-		u64(0x923f82a4af194f9b),
-		u64(0xab1c5ed5da6d8118),
-		u64(0xd807aa98a3030242),
-		u64(0x12835b0145706fbe),
-		u64(0x243185be4ee4b28c),
-		u64(0x550c7dc3d5ffb4e2),
-		u64(0x72be5d74f27b896f),
-		u64(0x80deb1fe3b1696b1),
-		u64(0x9bdc06a725c71235),
-		u64(0xc19bf174cf692694),
-		u64(0xe49b69c19ef14ad2),
-		u64(0xefbe4786384f25e3),
-		u64(0x0fc19dc68b8cd5b5),
-		u64(0x240ca1cc77ac9c65),
-		u64(0x2de92c6f592b0275),
-		u64(0x4a7484aa6ea6e483),
-		u64(0x5cb0a9dcbd41fbd4),
-		u64(0x76f988da831153b5),
-		u64(0x983e5152ee66dfab),
-		u64(0xa831c66d2db43210),
-		u64(0xb00327c898fb213f),
-		u64(0xbf597fc7beef0ee4),
-		u64(0xc6e00bf33da88fc2),
-		u64(0xd5a79147930aa725),
-		u64(0x06ca6351e003826f),
-		u64(0x142929670a0e6e70),
-		u64(0x27b70a8546d22ffc),
-		u64(0x2e1b21385c26c926),
-		u64(0x4d2c6dfc5ac42aed),
-		u64(0x53380d139d95b3df),
-		u64(0x650a73548baf63de),
-		u64(0x766a0abb3c77b2a8),
-		u64(0x81c2c92e47edaee6),
-		u64(0x92722c851482353b),
-		u64(0xa2bfe8a14cf10364),
-		u64(0xa81a664bbc423001),
-		u64(0xc24b8b70d0f89791),
-		u64(0xc76c51a30654be30),
-		u64(0xd192e819d6ef5218),
-		u64(0xd69906245565a910),
-		u64(0xf40e35855771202a),
-		u64(0x106aa07032bbd1b8),
-		u64(0x19a4c116b8d2d0c8),
-		u64(0x1e376c085141ab53),
-		u64(0x2748774cdf8eeb99),
-		u64(0x34b0bcb5e19b48a8),
-		u64(0x391c0cb3c5c95a63),
-		u64(0x4ed8aa4ae3418acb),
-		u64(0x5b9cca4f7763e373),
-		u64(0x682e6ff3d6b2b8a3),
-		u64(0x748f82ee5defb2fc),
-		u64(0x78a5636f43172f60),
-		u64(0x84c87814a1f0ab72),
-		u64(0x8cc702081a6439ec),
-		u64(0x90befffa23631e28),
-		u64(0xa4506cebde82bde9),
-		u64(0xbef9a3f7b2c67915),
-		u64(0xc67178f2e372532b),
-		u64(0xca273eceea26619c),
-		u64(0xd186b8c721c0c207),
-		u64(0xeada7dd6cde0eb1e),
-		u64(0xf57d4f7fee6ed178),
-		u64(0x06f067aa72176fba),
-		u64(0x0a637dc5a2c898a6),
-		u64(0x113f9804bef90dae),
-		u64(0x1b710b35131c471b),
-		u64(0x28db77f523047d84),
-		u64(0x32caab7b40c72493),
-		u64(0x3c9ebe0a15c9bebc),
-		u64(0x431d67c49c100d4c),
-		u64(0x4cc5d4becb3e42b6),
-		u64(0x597f299cfc657e2a),
-		u64(0x5fcb6fab3ad6faec),
-		u64(0x6c44198c4a475817)
-	]
-	
 	mut w := [u64(0); 80]
 	
 	mut h0 := dig.h[0]
@@ -215,9 +131,7 @@ fn block_generic(dig &Digest, p []byte) {
 		mut h := h7
 
 		for i := 0; i < 80; i++ {
-			// t1 := h + (u64(u64(e>>u64(14)) | u64(e<<u64(64-14))) ^ u64(u64(e>>u64(18)) | u64(e<<u64(64-18))) ^ u64(u64(e>>u64(41)) | u64(e<<u64(64-41)))) + ((e & f) ^ (~e & g)) + u64(_K[i]) + w[i]
-			// Note: When u64 const is working replace this line with the one above
-			t1 := h + (u64(u64(e>>u64(14)) | u64(e<<u64(64-14))) ^ u64(u64(e>>u64(18)) | u64(e<<u64(64-18))) ^ u64(u64(e>>u64(41)) | u64(e<<u64(64-41)))) + ((e & f) ^ (~e & g)) + u64(_k[i]) + w[i]
+			t1 := h + (u64(u64(e>>u64(14)) | u64(e<<u64(64-14))) ^ u64(u64(e>>u64(18)) | u64(e<<u64(64-18))) ^ u64(u64(e>>u64(41)) | u64(e<<u64(64-41)))) + ((e & f) ^ (~e & g)) + _K[i] + w[i]
 			t2 := (u64(u64(a>>u64(28)) | u64(a<<u64(64-28))) ^ u64(u64(a>>u64(34)) | u64(a<<u64(64-34))) ^ u64(u64(a>>u64(39)) | u64(a<<u64(64-39)))) + ((a & b) ^ (a & c) ^ (b & c))
 			h = g
 			g = f


### PR DESCRIPTION
Now that u64 works in costs I have switched back to using consts