### PR TITLE
live reload: the reload_so function now uses vexe too

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -409,7 +409,7 @@ void reload_so() {
 		int now = os__file_last_mod_unix(tos2("$file")); 
 		if (now != last) {
 			//v -o bounce -shared bounce.v 
-			os__system(tos2("v -o $file_base -shared $file")); 
+			os__system(tos2("$vexe -o $file_base -shared $file")); 
 			last = now; 
 			load_so("$so_name"); 
 		}


### PR DESCRIPTION
Instead of hard coding the v name (which some people seems to not have in their PATH, or have as an alias which could not be used inside a system() call), the reload_so function may need to use vexe (which is more likely to be found, since it was used during the initial compilation).
