### PR TITLE
compiler: fix #1193 . Flag -c_options is now named -cflags.

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -91,9 +91,10 @@ mut:
 	sanitize       bool // use Clang's new "-fsanitize" option
 	is_debug       bool // keep compiled C files
 	no_auto_free   bool // `v -nofree` disable automatic `free()` insertion for better performance in some applications  (e.g. compilers) 
-	c_options      string // Additional options which will be passed to the C compiler.
-                        // For example, passing -c_options=-Os will cause the C compiler to optimize the generated binaries for size.
-                        // You could pass several -c_options=XXX arguments. They will be merged with each other.
+	cflags        string // Additional options which will be passed to the C compiler.
+	                     // For example, passing -cflags -Os will cause the C compiler to optimize the generated binaries for size.
+	                     // You could pass several -cflags XXX arguments. They will be merged with each other.
+	                     // You can also quote several options at the same time: -cflags '-Os -fno-inline-small-functions'.
 }
 
 
@@ -536,7 +537,7 @@ fn (v mut V) cc() {
 	} 
 	linux_host := os.user_os() == 'linux'
 	v.log('cc() isprod=$v.pref.is_prod outname=$v.out_name')
-	mut a := [v.pref.c_options, '-w'] // arguments for the C compiler
+	mut a := [v.pref.cflags, '-w'] // arguments for the C compiler
 	flags := v.table.flags.join(' ')
 	//mut shared := ''
 	if v.pref.is_so {
@@ -969,10 +970,10 @@ fn new_v(args[]string) *V {
 		}
 	}
 
-	mut c_options := ''
+	mut cflags := ''
 	for ci, cv in args {
-		if cv.starts_with('-c_options=') {
-			c_options += cv.replace('-c_options=','') + ' '
+		if cv == '-cflags' {
+			cflags += args[ci+1] + ' '
 		}
 	}
 
@@ -995,7 +996,7 @@ fn new_v(args[]string) *V {
 		is_run: args.contains('run')
 		is_repl: args.contains('-repl')
 		build_mode: build_mode
-		c_options: c_options
+		cflags: cflags
 	}  
 
 	if pref.is_so {


### PR DESCRIPTION
You can also pass several C options at once like this:
v -cflags '-Os -fno-inline-small-functions'  file.v
