### PR TITLE
parser: change cur_line, tmp_line only in main pass

### DIFF
--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -121,7 +121,7 @@ fn (g mut CGen) add_placeholder() int {
 }
 
 fn (g mut CGen) set_placeholder(pos int, val string) {
-	if g.nogen || g.run == .decl {
+	if g.nogen || g.run != .main {
 		return
 	}
 	// g.lines.set(pos, val)

--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -50,7 +50,7 @@ fn new_cgen(out_name_c string) *CGen {
 }
 
 fn (g mut CGen) genln(s string) {
-	if g.nogen || g.run == .decl {
+	if g.nogen || g.run != .main {
 		return
 	}
 	if g.is_tmp {
@@ -66,7 +66,7 @@ fn (g mut CGen) genln(s string) {
 }
 
 fn (g mut CGen) gen(s string) {
-	if g.nogen || g.run == .decl {
+	if g.nogen || g.run != .main {
 		return
 	}
 	if g.is_tmp {
@@ -74,6 +74,18 @@ fn (g mut CGen) gen(s string) {
 	}
 	else {
 		g.cur_line = '$g.cur_line $s'
+	}
+}
+
+fn (g mut CGen) resetln(s string) {
+	if g.nogen || g.run != .main {
+		return
+	}
+	if g.is_tmp {
+		g.tmp_line = s
+	}
+	else {
+		g.cur_line = s
 	}
 }
 
@@ -109,7 +121,7 @@ fn (g mut CGen) add_placeholder() int {
 }
 
 fn (g mut CGen) set_placeholder(pos int, val string) {
-	if g.nogen {
+	if g.nogen || g.run == .decl {
 		return
 	}
 	// g.lines.set(pos, val)
@@ -135,7 +147,7 @@ fn (g mut CGen) add_placeholder2() int {
 }
 
 fn (g mut CGen) set_placeholder2(pos int, val string) {
-	if g.nogen {
+	if g.nogen || g.run != .main {
 		return
 	}
 	if g.is_tmp {

--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -682,7 +682,7 @@ fn (p mut Parser) fn_call_args(f *Fn) *Fn {
 			T := p.table.find_type(typ)
 			fmt := p.typ_to_fmt(typ, 0) 
 			if fmt != '' { 
-				p.cgen.cur_line = p.cgen.cur_line.replace('println (', '/*opt*/printf ("' + fmt + '\\n", ')    
+				p.cgen.resetln(p.cgen.cur_line.replace('println (', '/*opt*/printf ("' + fmt + '\\n", '))
 				continue 
 			}  
 			if typ.ends_with('*') {
@@ -700,7 +700,7 @@ fn (p mut Parser) fn_call_args(f *Fn) *Fn {
 					if name == '}' {
 						p.error(error_msg) 
 					}
-					p.cgen.cur_line = p.cgen.cur_line.left(index)
+					p.cgen.resetln(p.cgen.cur_line.left(index))
 					p.create_type_string(T, name)
 					p.cgen.cur_line.replace(typ, '')
 					p.next()


### PR DESCRIPTION
This PR restrict the parser to change cur_line, tmp_line only in main pass.
I add a resetln method in cgen.v and force the parser to use it (get rid of all direct change of cur_line, tmp_line in parser).

This PR also fix #1162