### PR TITLE
compiler/main.v: OpenBSD needs pthread.h

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -189,7 +189,7 @@ fn (v mut V) compile() {
 #include <inttypes.h>  // int64_t etc 
 
 
-#ifdef __linux__ 
+#if defined(__linux__) || defined(__OpenBSD__) 
 #include <pthread.h> 
 #endif 
 


### PR DESCRIPTION
compiler/main.v: Like Linux, OpenBSD also needs pthread.h (likely that all the BSDs do).