### PR TITLE
refactoring: mainly focused on scanner.v

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ test: v
 	find examples -name '*.v' -not -path "examples/hot_code_reloading/*" -print0 | xargs -0 -n1 ./v
 
 clean:
-	-rm -f v.c .v.c v vprod thirdparty/**/*.o
+	rm -f v.c .v.c v vprod thirdparty/**/*.o
+	find . -name '.*.c' -print0 | xargs -0 -n1 rm -f
 
 SOURCES = $(wildcard thirdparty/**/*.c)
 OBJECTS := ${SOURCES:.c=.o} 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test: v
 	find examples -name '*.v' -not -path "examples/hot_code_reloading/*" -print0 | xargs -0 -n1 ./v
 
 clean:
-	rm -f v.c .v.c v vprod thirdparty/**/*.o
+	-rm -f v.c .v.c v vprod thirdparty/**/*.o
 	find . -name '.*.c' -print0 | xargs -0 -n1 rm -f
 
 SOURCES = $(wildcard thirdparty/**/*.c)

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -806,7 +806,7 @@ fn (p mut Parser) get_type() string {
 	if p.tok == .lsbr {
 		p.check(.lsbr)
 		// [10]int
-		if p.tok == .integer {
+		if p.tok == .number {
 			typ = '[$p.lit]'
 			p.next()
 		}
@@ -817,9 +817,9 @@ fn (p mut Parser) get_type() string {
 		// [10][3]int
 		if p.tok == .lsbr {
 			p.next()
-			if p.tok == .integer {
+			if p.tok == .number {
 				typ += '[$p.lit]'
-				p.check(.integer)
+				p.check(.number)
 			}
 			else {
 				is_arr2 = true
@@ -2026,7 +2026,7 @@ fn (p mut Parser) term() string {
 		p.next()
 		p.gen(tok.str())// + ' /*op2*/ ')
 		p.fgen(' ' + tok.str() + ' ')
-		if is_div && p.tok == .integer && p.lit == '0' {
+		if is_div && p.tok == .number && p.lit == '0' {
 			p.error('division by zero')
 		}
 		if is_mod && (is_float_type(typ) || !is_number_type(typ)) {
@@ -2060,7 +2060,7 @@ fn (p mut Parser) factor() string {
 	mut typ := ''
 	tok := p.tok
 	switch tok {
-	case .integer:
+	case .number:
 		typ = 'int'
 		// Check if float (`1.0`, `1e+3`) but not if is hexa
 		if (p.lit.contains('.') || (p.lit.contains('e') || p.lit.contains('E'))) && 
@@ -2382,7 +2382,7 @@ fn (p mut Parser) map_init() string {
 // [1,2,3]
 fn (p mut Parser) array_init() string {
 	p.check(.lsbr)
-	is_integer := p.tok == .integer
+	is_integer := p.tok == .number
 	lit := p.lit
 	mut typ := ''
 	new_arr_ph := p.cgen.add_placeholder()
@@ -3209,7 +3209,7 @@ fn (p mut Parser) return_st() {
 	}
 	else {
 		// Don't allow `return val` in functions that don't return anything
-		if false && p.tok == .name || p.tok == .integer {
+		if false && p.tok == .name || p.tok == .number {
 			p.error('function `$p.cur_fn.name` does not return a value')
 		}
 

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -3411,3 +3411,7 @@ fn (p mut Parser) peek() Token {
 		}
 	}
 }
+
+fn (p mut Parser) create_type_string(T Type, name string) {
+	p.scanner.create_type_string(T, name)
+}

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -3402,3 +3402,12 @@ fn (p mut Parser) fspace() {
 fn (p mut Parser) fgenln(s string) {
 	p.scanner.fgenln(s)
 }
+
+fn (p mut Parser) peek() Token {
+	for {
+		tok := p.scanner.peek()
+		if tok != .nl {
+			return tok
+		}
+	}
+}

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -512,10 +512,6 @@ fn (s &Scanner) error(msg string) {
 fn (s mut Scanner) ident_string() string {
 	// println("\nidentString() at char=", string(s.text[s.pos]),
 	// "chard=", s.text[s.pos], " pos=", s.pos, "txt=", s.text[s.pos:s.pos+7])
-	debug := s.file_path.contains('test_test')
-	if debug {
-		println('identStr() $s.file_path line=$s.line_nr pos=$s.pos')
-	}
 	mut start := s.pos
 	s.inside_string = false
 	slash := `\\`
@@ -525,9 +521,6 @@ fn (s mut Scanner) ident_string() string {
 			break
 		}
 		c := s.text[s.pos]
-		if debug {
-			println(c.str())
-		}
 		prevc := s.text[s.pos - 1]
 		// end of string
 		if c == `\'` && (prevc != slash || (prevc == slash && s.text[s.pos - 2] == slash)) {

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -740,7 +740,3 @@ fn (s mut Scanner) create_type_string(T Type, name string) {
 	s.line_nr = line
 	s.inside_string = inside_string
 }
-
-fn (p mut Parser) create_type_string(T Type, name string) {
-	p.scanner.create_type_string(T, name)
-}

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -673,6 +673,10 @@ fn (s mut Scanner) expect(want string, start_pos int) bool {
 fn (s mut Scanner) debug_tokens() {
 	s.pos = 0
 	s.debug = true
+
+	fname := s.file_path.all_after('/')
+	println('\n===DEBUG TOKENS $fname===')
+
 	for {
 		res := s.scan()
 		tok := res.tok
@@ -685,6 +689,7 @@ fn (s mut Scanner) debug_tokens() {
 			println('')
 		}
 		if tok == .eof {
+			println('============ END OF DEBUG TOKENS ==================')
 			break
 		}
 	}

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -212,30 +212,13 @@ fn (s Scanner) has_gone_over_line_end() bool {
 
 fn (s mut Scanner) skip_whitespace() {
 	for s.pos < s.text.len && s.text[s.pos].is_white() {
-		if is_nl(s.text[s.pos]) {
-			// Count \r\n as one line 
-			if !s.expect('\r\n', s.pos-1) {
+		// Count \r\n as one line 
+		if is_nl(s.text[s.pos]) && !s.expect('\r\n', s.pos-1) {
 				s.line_nr++
-			} 
 		}
 		s.pos++
 	}
 }
-
-fn (s mut Scanner) get_var_name(pos int) string {
-	mut pos_start := pos
-
-	for ; pos_start >= 0 && s.text[pos_start] != `\n` && s.text[pos_start] != `;`; pos_start-- {}
-	pos_start++
-	return s.text.substr(pos_start, pos)
-}
-
-// CAO stands for Compound Assignment Operators  (e.g '+=' )
-/* 
-fn (s mut Scanner) cao_change(operator string) {
-	s.text = s.text.substr(0, s.pos - operator.len) + ' = ' + s.get_var_name(s.pos - operator.len) + ' ' + operator + ' ' + s.text.substr(s.pos + 1, s.text.len)
-}
-*/ 
 
 fn (s mut Scanner) scan() ScanRes {
 	if s.line_comment != '' { 

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -68,10 +68,6 @@ fn scan_res(tok Token, lit string) ScanRes {
 	return ScanRes{tok, lit}
 }
 
-fn is_white(c byte) bool {
-	return c.is_white()
-}
-
 fn is_nl(c byte) bool {
 	return c == `\r` || c == `\n`
 }
@@ -134,10 +130,10 @@ fn (s mut Scanner) ident_number() string {
 
 fn (s Scanner) has_gone_over_line_end() bool {
 	mut i := s.pos-1
-	for i >= 0 && !is_white(s.text[i]) {
+	for i >= 0 && !s.text[i].is_white() {
 		i--
 	}
-	for i >= 0 && is_white(s.text[i]) {
+	for i >= 0 && s.text[i].is_white() {
 		if is_nl(s.text[i]) {
 			return true
 		}
@@ -147,7 +143,7 @@ fn (s Scanner) has_gone_over_line_end() bool {
 }
 
 fn (s mut Scanner) skip_whitespace() {
-	for s.pos < s.text.len && is_white(s.text[s.pos]) {
+	for s.pos < s.text.len && s.text[s.pos].is_white() {
 		if is_nl(s.text[s.pos]) {
 			// Count \r\n as one line 
 			if !s.expect('\r\n', s.pos-1) {

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -26,11 +26,6 @@ mut:
 	prev_tok Token 
 }
 
-const (
-	SingleQuote = `\'`
-	//QUOTE        = `"`
-)
-
 fn new_scanner(file_path string) *Scanner {
 	if !os.file_exists(file_path) {
 		panic('"$file_path" doesn\'t exist')
@@ -205,7 +200,7 @@ if s.line_comment != '' {
 	// End of $var, start next string
 	if s.dollar_end {
 		// fmt.Println("end of $var, get string", s.pos, string(s.text[s.pos]))
-		if s.text[s.pos] == SingleQuote {
+		if s.text[s.pos] == `\'` {
 			s.dollar_end = false
 			return scan_res(.str, '')
 		}
@@ -241,7 +236,7 @@ if s.line_comment != '' {
 		// at the next ', skip it
 		if s.inside_string {
 			// println('is_letter inside string! nextc=${nextc.str()}')
-			if next_char == SingleQuote {
+			if next_char == `\'` {
 				// println('var is last before QUOTE')
 				s.pos++
 				s.dollar_start = false
@@ -307,7 +302,7 @@ if s.line_comment != '' {
 		return scan_res(.mod, '')
 	case `?`:
 		return scan_res(.question, '')
-	case SingleQuote:
+	case `\'`:
 		return scan_res(.str, s.ident_string())
 		// TODO allow double quotes
 		// case QUOTE:
@@ -336,7 +331,7 @@ if s.line_comment != '' {
 		if s.inside_string {
 			s.pos++
 			// TODO UN.neEDED?
-			if s.text[s.pos] == SingleQuote {
+			if s.text[s.pos] == `\'` {
 				s.inside_string = false
 				return scan_res(.str, '')
 			}
@@ -549,7 +544,7 @@ fn (s mut Scanner) ident_string() string {
 		}
 		prevc := s.text[s.pos - 1]
 		// end of string
-		if c == SingleQuote && (prevc != slash || (prevc == slash && s.text[s.pos - 2] == slash)) {
+		if c == `\'` && (prevc != slash || (prevc == slash && s.text[s.pos - 2] == slash)) {
 			// handle '123\\'  slash at the end
 			break
 		}
@@ -583,7 +578,7 @@ fn (s mut Scanner) ident_string() string {
 		}
 	}
 	mut lit := ''
-	if s.text[start] == SingleQuote {
+	if s.text[start] == `\'` {
 		start++
 	}
 	mut end := s.pos

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -248,7 +248,7 @@ fn (s mut Scanner) scan() ScanRes {
 	// `123`, `.123`
 	else if c.is_digit() || c == `.` && nextc.is_digit() {
 		num := s.ident_number()
-		return scan_res(.integer, num)
+		return scan_res(.number, num)
 	}
 	// all other tokens
 	switch c {

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -601,15 +601,6 @@ fn (s mut Scanner) ident_char() string {
 	return c
 }
 
-fn (p mut Parser) peek() Token {
-	for {
-		tok := p.scanner.peek()
-		if tok != .nl {
-			return tok
-		}
-	}
-}
-
 fn (s mut Scanner) peek() Token {
 	pos := s.pos
 	line := s.line_nr

--- a/compiler/token.v
+++ b/compiler/token.v
@@ -7,7 +7,7 @@ module main
 enum Token {
 	eof
 	name        // user 
-	integer     // 123 
+	number      // 123 
 	str         // 'foo' 
 	str_inter   // 'name=$user.name' 
 	chartoken   // `A` 
@@ -127,7 +127,7 @@ fn build_token_str() []string {
 	s[Token.keyword_end] = ''
 	s[Token.eof] = '.eof'
 	s[Token.name] = '.name'
-	s[Token.integer] = '.integer'
+	s[Token.number] = '.number'
 	s[Token.str] = 'STR'
 	s[Token.chartoken] = '.chartoken'
 	s[Token.plus] = '+'

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -709,7 +709,7 @@ pub fn (c byte) is_digit() bool {
 }
 
 pub fn (c byte) is_hex_digit() bool {
-	return c.is_digit() || (c >= `a` && c <= `f`) || (c >= `a` && c <= `f`)
+	return c.is_digit() || (c >= `a` && c <= `f`) || (c >= `A` && c <= `F`)
 }
 
 pub fn (c byte) is_oct_digit() bool {

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -708,6 +708,14 @@ pub fn (c byte) is_digit() bool {
 	return c >= `0` && c <= `9`
 }
 
+pub fn (c byte) is_hex_digit() bool {
+	return c.is_digit() || (c >= `a` && c <= `f`) || (c >= `a` && c <= `f`)
+}
+
+pub fn (c byte) is_oct_digit() bool {
+	return c >= `0` && c <= `7`
+}
+
 pub fn (c byte) is_letter() bool {
 	return (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`)
 }


### PR DESCRIPTION
New version of PR #1015
Following is what I did.
- Split ident_number into 3 parts (ident_hex_number, ident_oct_number, ident_dec_number)
- Add new methods for byte (is_hex_digit, is_oct_digit)
- Add Scanner.expect(want int, start_pos int) method
- Remove some debug prints,  comments. unused function
- let "make clean" remove .*.c files