### PR TITLE
Fix #1254

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -136,6 +136,9 @@ pub fn (s array) slice(start, _end int) array {
 	if start > end {
 		panic('invalid slice index: $start > $end')
 	}
+	if start < 0 {
+		panic('invalid slice index: $start < 0')
+	}
 	if end >= s.len {
 		end = s.len
 	}


### PR DESCRIPTION
just fix #1254

compile following code generates `V panic: invalid slice index: -4 < 0`
```
fn main(){
    arr := [5,4,3,2,1]
    res := arr.slice(-4,3)
    println(res)
}
```