### PR TITLE
live reload: fix SIGSEGV when calling dlclose, while a live fn is still running

### DIFF
--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -344,6 +344,12 @@ fn (p mut Parser) fn_decl() {
 		}
 		return
 	}
+
+	if p.attr == 'live' && p.pref.is_so {
+		//p.genln('// live_function body start')
+		p.genln('pthread_mutex_lock(&live_fn_mutex);')
+	}
+
 	if f.name == 'main' || f.name == 'WinMain' {
 		p.genln('init_consts();')
 		if p.table.imports.contains('os') {
@@ -388,6 +394,12 @@ pthread_create(&_thread_so , NULL, &reload_so, NULL); ')
 	if typ != 'void' && !p.returns && f.name != 'main' && f.name != 'WinMain' {
 		p.error('$f.name must return "$typ"')
 	}
+	
+	if p.attr == 'live' && p.pref.is_so {
+		//p.genln('// live_function body end')
+		p.genln('pthread_mutex_unlock(&live_fn_mutex);')
+	}
+	
 	// {} closed correctly? scope_level should be 0
 	if p.mod == 'main' {
 		// println(p.cur_fn.scope_level)


### PR DESCRIPTION
How to test:

1) In a file called x.v put:

```
module main

import time
import os

[live]
fn print_message() {
  println('print_message start')
  for i := 0; i < 10; i++ {
    println('.. print_message sleeping $i')
    time.sleep_ms(100)
  }
  println('print_message done')
}

fn main() {
  for {
    print_message()
    time.sleep_ms(500)
  }
}
```

2) compile it with:
```
v -live x.v
```

3) run it with:
```
./x
```

4) in a separate shell, run:
```
while true; do date; touch x.v; sleep 0.1; done
```

5) The ./x process should NOT crash with a SIGSEGV for at least a minute. 

6) There should be blocks of lines like:
```
print_message start
.. print_message sleeping 0
.. print_message sleeping 1
.. print_message sleeping 2
.. print_message sleeping 3
.. print_message sleeping 4
.. print_message sleeping 5
.. print_message sleeping 6
.. print_message sleeping 7
.. print_message sleeping 8
.. print_message sleeping 9
print_message done
```

7) There should NOT be partial blocks of lines like the above (counting to a number below 9).
