### PR TITLE
live reload: stability fixes. Works on MacOS too.

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -254,7 +254,7 @@ void reload_so();
 void init_consts();')
 	
 	if v.pref.is_so {
-		cgen.genln('extern pthread_mutex_t live_fn_mutex;')
+		cgen.genln('pthread_mutex_t live_fn_mutex;')
 	}  
 	if v.pref.is_live {
 		cgen.genln('pthread_mutex_t live_fn_mutex = PTHREAD_MUTEX_INITIALIZER;')


### PR DESCRIPTION
At the expense of a small memory leak (since the .so files are now not closed first, but overlay-ed by the new .so files), now the live reload functionality is rock solid.
I've run a 5 minute long stress test with a
```
while true; do date; touch x.v; sleep 0.1; done
```
loop on both Linux and MacOS X; no crashes so far.

