### PR TITLE
string: avoid double allocation in trim_space()

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -545,13 +545,12 @@ pub fn (s string) trim_space() string {
 	for i < s.len && is_space(s[i]) {
 		i++
 	}
-	mut res := s.right(i)
-	mut end := res.len - 1
-	for end >= 0 && is_space(res[end]) {
+	mut end := s.len - 1
+	for end >= 0 && is_space(s[end]) {
 		// C.printf('end=%d c=%d %c\n', end, res.str[end])
 		end--
 	}
-	res = res.left(end + 1)
+	res := s.substr(i, end + 1)
 	// println('after SPACE "$res"')
 	return res
 }


### PR DESCRIPTION
This replaces two `substr` calls with a single one that trims both sides.

The recent change that made `substr` copy data caused the use of two left and right slices in `trim_space` to make two allocations and double copying.

It also caused the first `right()` substring to leak its memory. This fix uses no explicit free and doesn't need automatic cleanup by the compiler. The little performance boost doesn't hurt either.