### PR TITLE
module aliasing and sub modules for import () syntax

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -306,21 +306,16 @@ fn (p mut Parser) imports() {
 	if p.tok == .lpar {
 		p.check(.lpar)
 		for p.tok != .rpar && p.tok != .eof {
-			pkg := p.lit.trim_space()
-			p.next()
-			// TODO: aliased for import() syntax
-			// p.import_table.register_alias(alias, pkg)
-			// p.import_table.register_import(pkg)
-			if p.table.imports.contains(pkg) {
-				continue
-			}
-			p.table.imports << pkg
-			p.table.register_package(pkg)
+			p.register_import()
 		}
 		p.check(.rpar)
 		return
 	}
 	// `import foo`
+	p.register_import()
+}
+
+fn (p mut Parser) register_import() {
 	if p.tok != .name {
 		p.error('bad import format')
 	}
@@ -344,16 +339,15 @@ fn (p mut Parser) imports() {
 		p.check(.key_as) 
 		mod_alias = p.check_name()
 	}
-	p.fgenln(' ' + pkg)
 	// add import to file scope import table
 	p.import_table.register_alias(mod_alias, pkg)
 	// Make sure there are no duplicate imports
-	if p.table.imports.contains(pkg) {
-		return
+	if !p.table.imports.contains(pkg) {
+		p.log('adding import $pkg')
+		p.table.imports << pkg
+		p.table.register_package(pkg)
 	}
-	p.log('adding import $pkg')
-	p.table.imports << pkg
-	p.table.register_package(pkg)
+	p.fgenln(' ' + pkg)
 }
 
 fn (p mut Parser) const_decl() {

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -342,11 +342,13 @@ fn (p mut Parser) register_import() {
 	// add import to file scope import table
 	p.import_table.register_alias(mod_alias, pkg)
 	// Make sure there are no duplicate imports
-	if !p.table.imports.contains(pkg) {
-		p.log('adding import $pkg')
-		p.table.imports << pkg
-		p.table.register_package(pkg)
+	if p.table.imports.contains(pkg) {
+		return
 	}
+	p.log('adding import $pkg')
+	p.table.imports << pkg
+	p.table.register_package(pkg)
+	
 	p.fgenln(' ' + pkg)
 }
 


### PR DESCRIPTION
This allows sub modules and import aliasing to work with multiple import syntax:
```
import (
    os
    math
    encoding.base64 as b64
)
```