### PR TITLE
compiler: Fix for #1268 . Passing -o file.c, now skips C compiler invocation.

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -694,7 +694,11 @@ mut args := ''
 	//}
 	$if windows {
 		cmd = 'gcc $args' 
-	} 
+	}
+	if v.out_name.ends_with('.c') {
+		os.mv( '.$v.out_name_c', v.out_name )
+		exit(0)
+	}
 	// Run
 	ticks := time.ticks() 
 	res := os.exec(cmd)


### PR DESCRIPTION
It will just leave the intermediary file.c alone.