### PR TITLE
Change CGen so that v.c is compileable with msvc

### DIFF
--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -493,9 +493,9 @@ fn (p mut Parser) async_fn_call(f Fn, method_ph int, receiver_var, receiver_type
 		did_gen_something = true
 	}
 
-	if p.os == .msvc && !did_gen_something {
+	if !did_gen_something {
 		// Msvc doesnt like empty struct
-		arg_struct += 'void *____dummy_variable;'
+		arg_struct += 'EMPTY_STRUCT_DECLARATION'
 	}
 
 	arg_struct += '} $arg_struct_name ;'

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -189,6 +189,10 @@ fn (v mut V) compile() {
 #include <stdarg.h> // for va_list 
 #include <inttypes.h>  // int64_t etc 
 
+#define STRUCT_DEFAULT_VALUE {}
+#define EMPTY_STRUCT_DECLARATION
+#define EMPTY_STRUCT_INIT
+#define OPTION_CAST(x) (x)
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
@@ -201,6 +205,15 @@ fn (v mut V) compile() {
 #ifdef _MSC_VER
 // On MSVC these are the same (as long as /volatile:ms is passed)
 #define _Atomic volatile
+
+// MSVC can\'t parse some things properly
+#undef STRUCT_DEFAULT_VALUE
+#define STRUCT_DEFAULT_VALUE {0}
+#undef EMPTY_STRUCT_DECLARATION
+#define EMPTY_STRUCT_DECLARATION void *____dummy_variable;
+#undef EMPTY_STRUCT_INIT
+#define EMPTY_STRUCT_INIT 0
+#define OPTION_CAST(x)
 #endif
 
 void pthread_mutex_lock(HANDLE *m) {

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1895,7 +1895,7 @@ fn (p mut Parser) index_expr(typ string, fn_ph int) string {
 		if is_map {
 			p.gen('$tmp')
 			mut def := type_default(typ)
-			if def == '{}' {
+			if def == 'STRUCT_DEFAULT_VALUE' {
 				def = '{0}'
 			}
 			p.cgen.insert_before('$typ $tmp = $def; bool $tmp_ok = map_get($index_expr, & $tmp);')
@@ -3104,7 +3104,7 @@ fn (p mut Parser) for_st() {
 			p.genln('  string $i = ((string*)keys_$tmp .data)[l];') 
 			//p.genln('  string $i = *(string*) ( array__get(keys_$tmp, l) );') 
 			mut def := type_default(typ)
-			if def == '{}' {
+			if def == 'STRUCT_DEFAULT_VALUE' {
 				def = '{0}'
 			}
 			// TODO don't call map_get() for each key, fetch values while traversing

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -544,7 +544,7 @@ fn type_default(typ string) string {
 	}
 	// User struct defined in another module. 
 	if typ.contains('__') {
-		return '{}'
+		return 'STRUCT_DEFAULT_VALUE'
 	}
 	// Default values for other types are not needed because of mandatory initialization
 	switch typ {
@@ -566,7 +566,7 @@ fn type_default(typ string) string {
 	case 'byteptr': return '0'
 	case 'voidptr': return '0'
 	}
-	return '{}' 
+	return 'STRUCT_DEFAULT_VALUE' 
 }
 
 // TODO PERF O(n)


### PR DESCRIPTION
With these changes the C output of `./v -debug -o v compiler` (i.e. what I assume is transformed into the v.c that is found in vlang/vc should now be compileable with MSVC - meaning that v can be bootstrapped on windows entirely without gcc.