### PR TITLE
os: Fix os.user_os() to return 'windows' when msvc is used for compilation

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -568,9 +568,9 @@ pub fn user_os() string {
 	$if dragonfly {
 		return 'dragonfly' 
 	}
-	// $if msvc {
-	// 	return 'windows'
-	// }
+	$if msvc {
+		return 'windows'
+	}
 	return 'unknown'
 }
 


### PR DESCRIPTION
Should be pretty self-explanatory - this couldnt happen before but can now that msvc is a valid os in v.c