### PR TITLE
v run: in unix systems, you can now run file.v directly.

### DIFF
--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -414,6 +414,13 @@ fn (s mut Scanner) scan() ScanRes {
 			s.pos++
 		}
 		s.line_nr++
+		if nextc == `!` {
+			// treat shebang line (#!) as a comment
+			s.line_nr++
+			s.line_comment = s.text.substr(start + 1, s.pos).trim_space()
+			s.fgenln('// shebang line "$s.line_comment"')
+			return s.scan()
+		}
 		hash := s.text.substr(start, s.pos)
 		return scan_res(.hash, hash.trim_space())
 	case `>`:

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -416,7 +416,6 @@ fn (s mut Scanner) scan() ScanRes {
 		s.line_nr++
 		if nextc == `!` {
 			// treat shebang line (#!) as a comment
-			s.line_nr++
 			s.line_comment = s.text.substr(start + 1, s.pos).trim_space()
 			s.fgenln('// shebang line "$s.line_comment"')
 			return s.scan()


### PR DESCRIPTION
1) The file needs to be marked as an executable.
2) The file has to have a shebang first line, for example:
```
$ cat file.v
#!/usr/local/bin/v run
println('hello')

$ chmod 755 file.v
$ ./file.v
============ running ./file ============
hello
```
