### PR TITLE
CGen: Add command line flag to allow for interactive debugging

### DIFF
--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -24,14 +24,17 @@ struct CGen {
 	//buf          strings.Builder 
 	is_user      bool
 mut:
-	run          Pass
-	nogen        bool
-	tmp_line     string
-	cur_line     string
-	prev_line    string
-	is_tmp       bool
-	fn_main      string
-	stash        string
+	run             Pass
+	nogen           bool
+	tmp_line        string
+	cur_line        string
+	prev_line       string
+	is_tmp          bool
+	fn_main         string
+	stash           string
+	file            string
+	line            int
+	line_directives bool
 }
 
 fn new_cgen(out_name_c string) *CGen {
@@ -44,9 +47,14 @@ fn new_cgen(out_name_c string) *CGen {
 		out_path: path 
 		out: out 
 		//buf: strings.new_builder(10000) 
-		lines: _make(0, 1000, sizeof(string)) 
+		lines: _make(0, 1000, sizeof(string))
 	}
 	return gen
+}
+
+fn (g mut CGen) set_file_and_line(file string, line int) {
+	g.file = file
+	g.line = line
 }
 
 fn (g mut CGen) genln(s string) {
@@ -58,7 +66,10 @@ fn (g mut CGen) genln(s string) {
 		return
 	}
 	g.cur_line = '$g.cur_line $s'
-	if g.cur_line != '' {
+	if g.cur_line.trim_space() != '' {
+		if g.line_directives {
+			g.lines << '#line $g.line "$g.file"'
+		}
 		g.lines << g.cur_line
 		g.prev_line = g.cur_line
 		g.cur_line = ''

--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -52,11 +52,6 @@ fn new_cgen(out_name_c string) *CGen {
 	return gen
 }
 
-fn (g mut CGen) set_file_and_line(file string, line int) {
-	g.file = file
-	g.line = line
-}
-
 fn (g mut CGen) genln(s string) {
 	if g.nogen || g.run != .main {
 		return

--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -61,8 +61,8 @@ fn (g mut CGen) genln(s string) {
 		return
 	}
 	g.cur_line = '$g.cur_line $s'
-	if g.cur_line.trim_space() != '' {
-		if g.line_directives {
+	if g.cur_line != '' {
+		if g.line_directives && g.cur_line.trim_space() != '' {
 			g.lines << '#line $g.line "$g.file"'
 		}
 		g.lines << g.cur_line

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -90,6 +90,7 @@ mut:
 	is_run         bool
 	show_c_cmd     bool // `v -show_c_cmd` prints the C command to build program.v.c
 	sanitize       bool // use Clang's new "-fsanitize" option
+	is_debuggable  bool
 	is_debug       bool // keep compiled C files
 	no_auto_free   bool // `v -nofree` disable automatic `free()` insertion for better performance in some applications  (e.g. compilers) 
 	cflags        string // Additional options which will be passed to the C compiler.
@@ -1158,6 +1159,7 @@ fn new_v(args[]string) *V {
 		is_play: args.contains('play')
 		is_prod: args.contains('-prod')
 		is_verbose: args.contains('-verbose')
+		is_debuggable: args.contains('-debuggable') // -debuggable implys debug
 		is_debug: args.contains('-debug')
 		obfuscate: obfuscate
 		is_prof: args.contains('-prof')

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -1159,8 +1159,8 @@ fn new_v(args[]string) *V {
 		is_play: args.contains('play')
 		is_prod: args.contains('-prod')
 		is_verbose: args.contains('-verbose')
-		is_debuggable: args.contains('-debuggable') // -debuggable implys debug
-		is_debug: args.contains('-debug')
+		is_debuggable: args.contains('-g') // -debuggable implys debug
+		is_debug: args.contains('-debug') || args.contains('-g')
 		obfuscate: obfuscate
 		is_prof: args.contains('-prof')
 		is_live: args.contains('-live')

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -104,6 +104,10 @@ fn (c mut V) new_parser(path string, run Pass) Parser {
 			path.contains('v/vlib')) 
 			 
 	}
+
+	c.cgen.line_directives = c.pref.is_debuggable
+	c.cgen.file = path
+
 	p.next()
 	// p.scanner.debug_tokens()
 	return p
@@ -1243,7 +1247,7 @@ fn (p mut Parser) var_decl() {
 		// User user = *(User*)tmp.data;
 		// p.assigned_var = ''
 		p.cgen.set_placeholder(pos, '$typ $tmp = ')
-		p.gen(';')
+		p.genln(';')
 		typ = typ.replace('Option_', '')
 		p.next()
 		p.check(.lcbr)
@@ -3317,7 +3321,7 @@ fn (p mut Parser) return_st() {
 					p.cgen.resetln('return $ret')
 				}  else { 
 					tmp := p.get_tmp() 
-					p.cgen.resetln('$expr_type $tmp = $ret;') 
+					p.cgen.resetln('$expr_type $tmp = $ret;\n')
 					p.genln(p.cur_fn.defer_text) 
 					p.genln('return $tmp;') 
 				} 
@@ -3525,10 +3529,11 @@ fn (p mut Parser) fgenln(s string) {
 
 fn (p mut Parser) peek() Token {
 	for {
+		p.cgen.line = p.scanner.line_nr + 1
 		tok := p.scanner.peek()
 		if tok != .nl {
 			return tok
-		}
+		} 
 	}
 }
 

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -210,7 +210,7 @@ fn (s mut Scanner) skip_whitespace() {
 	for s.pos < s.text.len && s.text[s.pos].is_white() {
 		// Count \r\n as one line 
 		if is_nl(s.text[s.pos]) && !s.expect('\r\n', s.pos-1) {
-				s.line_nr++
+			s.line_nr++
 		}
 		s.pos++
 	}


### PR DESCRIPTION
This PR adds a flag `-debuggable` that allows for v code to be directly debugged. This is done using `#line` directives which tell the compiler to reset the line number and filename. This means that debug information picks that up and uses the V file for debugging.

This is added with a flag becuase it completely destroys the readability of the file:
```c
#line 3 "debug_testing.v"
 void test_function() {
#line 4 "debug_testing.v"
  println ( tos2("Excuse me?") ) ;
#line 5 "debug_testing.v"
  println ( tos2("Okay good?") ) ;
#line 6 "debug_testing.v"
  println ( tos2("Make sure these number line up?") ) ;
#line 7 "debug_testing.v"
   }
```
Which is not something that we always want!

[Example MP4](https://i.f1ssi0n.com/SarcophilicShiftableSpittlebug.mp4)

I have no idea whether the same stuff works with DWARF debugging information or not.