### PR TITLE
docker build: make building image more effecient

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@ FROM buildpack-deps:buster-curl
 
 LABEL maintainer="ANAGO Ronnel <anagoandy@gmail.com>"
 WORKDIR /etc/vlang
-COPY . .
 RUN apt-get -yq update && \
-    apt-get install -y gcc clang make && \
-    make && \
+    apt-get install -y --no-install-recommends gcc clang make && \
+    rm -rf /var/lib/apt/lists/*
+COPY . .
+RUN make && \
     ln -s /etc/vlang/v /usr/local/bin/v
 
 CMD [ "bash" ]


### PR DESCRIPTION
- cleaning up apt cache will reduce image size
- doing COPY after apt will allow to reuse previous layer on recompile