### PR TITLE
Docker: Easy to use docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ docker.build: ## Build docker image
 docker.rebuild: ## Rebuild docker image
 	docker build --no-cache -t ${NAME} .
 
-docker.run: ## Run a console with vlang
+docker.run: docker.build ## Run a console with vlang
 	docker run --rm -it ${NAME}:${TAG_NAME}
 
-docker.run.v: ## Run vlang REPL on docker
-	docker run --rm -it ${IMAGE_NAME}:${TAG_NAME} v
+docker.run.v: docker.build ## Run vlang REPL on docker
+	docker run --rm -it ${NAME}:${TAG_NAME} v

--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,18 @@ uninstall:
 
 symlink:
 	ln -sf `pwd`/v ${PREFIX}/bin/v
+
+NAME := vlang
+TAG_NAME := latest
+
+docker.build: ## Build docker image
+	docker build -t ${NAME} .
+
+docker.rebuild: ## Rebuild docker image
+	docker build --no-cache -t ${NAME} .
+
+docker.run: ## Run a console with vlang
+	docker run --rm -it ${NAME}:${TAG_NAME}
+
+docker.run.v: ## Run vlang REPL on docker
+	docker run --rm -it ${IMAGE_NAME}:${TAG_NAME} v

--- a/README.md
+++ b/README.md
@@ -91,13 +91,17 @@ make
 ## Docker
 
 ```bash
-git clone https://github.com/vlang/v
-cd v
-docker build -t vlang .
-docker run --rm -it vlang:latest
-v
+$ git clone https://github.com/vlang/v
+$ cd v
+$ make docker.build
+$ make docker.run.v
 ```
 
+If you wanna rebuild, execute the following command.
+
+```bash
+$ make docker.rebuild
+```
 
 
 ### Testing


### PR DESCRIPTION
## Overview
I created to make easier to execute on docker this PR.
Now it can be realized with two commands after cloning.

## Command
- `make docker.build`
<details>
<summary>Execution history</summary>

```bash
$ make docker.build
docker build -t vlang .
Sending build context to Docker daemon  8.663MB
Step 1/7 : FROM buildpack-deps:buster-curl
 ---> af83f416912b
Step 2/7 : LABEL maintainer="ANAGO Ronnel <anagoandy@gmail.com>"
 ---> Using cache
 ---> fd26a33a7171
Step 3/7 : WORKDIR /etc/vlang
 ---> Using cache
 ---> a2c0c6e16075
Step 4/7 : RUN apt-get -yq update &&     apt-get install -y --no-install-recommends gcc clang make &&     rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> f5a05bf5e786
Step 5/7 : COPY . .
 ---> 4f04aa3318a4
Step 6/7 : RUN make &&     ln -s /etc/vlang/v /usr/local/bin/v
 ---> Running in 342c552ad579
rm -f v.c .v.c v vprod thirdparty/**/*.o
find . -name '.*.c' -print0 | xargs -0 -n1 rm -f
curl -Os https://raw.githubusercontent.com/vlang/vc/master/v.c
cc -std=gnu11 -w -o v v.c -lm
./v -o v compiler
V has been successfully built
Removing intermediate container 342c552ad579
 ---> 0175f2e75c93
Step 7/7 : CMD [ "bash" ]
 ---> Running in 66ae7ca585f0
Removing intermediate container 66ae7ca585f0
 ---> 8e6e725d7091
Successfully built 8e6e725d7091
Successfully tagged vlang:latest 
```

</details>

- `make docker.rebuild`

<details>
<summary>Execution history</summary>

```bash
$ make docker.rebuild
docker build --no-cache -t vlang .
Sending build context to Docker daemon  8.657MB
Step 1/7 : FROM buildpack-deps:buster-curl
 ---> af83f416912b
Step 2/7 : LABEL maintainer="ANAGO Ronnel <anagoandy@gmail.com>"
 ---> Running in 98c49cddcc29
Removing intermediate container 98c49cddcc29
 ---> b633646cb660
Step 3/7 : WORKDIR /etc/vlang
 ---> Running in a14c8d0999d1
Removing intermediate container a14c8d0999d1
 ---> 334ed9a7b73d
Step 4/7 : RUN apt-get -yq update &&     apt-get install -y --no-install-recommends gcc clang make &&     rm -rf /var/lib/apt/lists/*
 ---> Running in c71732ac807a
Get:1 http://security.debian.org/debian-security buster/updates InRelease [39.1 kB]
Get:2 http://security.debian.org/debian-security buster/updates/main amd64 Packages [50.7 kB]
Get:3 http://deb.debian.org/debian buster InRelease [118 kB]
Get:4 http://deb.debian.org/debian buster-updates InRelease [46.8 kB]
Get:5 http://deb.debian.org/debian buster/main amd64 Packages [7897 kB]
Fetched 8152 kB in 4s (2175 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  binutils binutils-common binutils-x86-64-linux-gnu clang-7 cpp cpp-8 gcc-8
  lib32gcc1 lib32stdc++6 libasan5 libatomic1 libbinutils libbsd0 libc-dev-bin
  libc6-dev libc6-i386 libcc1-0 libclang-common-7-dev libclang1-7 libedit2
  libgc1c2 libgcc-8-dev libgomp1 libisl19 libitm1 libllvm7 liblsan0 libmpc3
  libmpfr6 libmpx2 libobjc-8-dev libobjc4 libquadmath0 libstdc++-8-dev
  libtsan0 libubsan1 linux-libc-dev
Suggested packages:
  binutils-doc clang-7-doc cpp-doc gcc-8-locales gcc-multilib manpages-dev
  autoconf automake libtool flex bison gdb gcc-doc gcc-8-multilib gcc-8-doc
  libgcc1-dbg libgomp1-dbg libitm1-dbg libatomic1-dbg libasan5-dbg
  liblsan0-dbg libtsan0-dbg libubsan1-dbg libmpx2-dbg libquadmath0-dbg
  glibc-doc libstdc++-8-doc make-doc
Recommended packages:
  llvm-7-dev python libomp-7-dev manpages manpages-dev
The following NEW packages will be installed:
  binutils binutils-common binutils-x86-64-linux-gnu clang clang-7 cpp cpp-8
  gcc gcc-8 lib32gcc1 lib32stdc++6 libasan5 libatomic1 libbinutils libbsd0
  libc-dev-bin libc6-dev libc6-i386 libcc1-0 libclang-common-7-dev libclang1-7
  libedit2 libgc1c2 libgcc-8-dev libgomp1 libisl19 libitm1 libllvm7 liblsan0
  libmpc3 libmpfr6 libmpx2 libobjc-8-dev libobjc4 libquadmath0 libstdc++-8-dev
  libtsan0 libubsan1 linux-libc-dev make
0 upgraded, 40 newly installed, 0 to remove and 0 not upgraded.
Need to get 67.9 MB of archives.
After this operation, 331 MB of additional disk space will be used.
Get:1 http://security.debian.org/debian-security buster/updates/main amd64 linux-libc-dev amd64 4.19.37-5+deb10u1 [1185 kB]
Get:2 http://deb.debian.org/debian buster/main amd64 binutils-common amd64 2.31.1-16 [2073 kB]
Get:3 http://deb.debian.org/debian buster/main amd64 libbinutils amd64 2.31.1-16 [478 kB]
Get:4 http://deb.debian.org/debian buster/main amd64 binutils-x86-64-linux-gnu amd64 2.31.1-16 [1823 kB]
Get:5 http://deb.debian.org/debian buster/main amd64 binutils amd64 2.31.1-16 [56.8 kB]
Get:6 http://deb.debian.org/debian buster/main amd64 libbsd0 amd64 0.9.1-2 [99.5 kB]
Get:7 http://deb.debian.org/debian buster/main amd64 libedit2 amd64 3.1-20181209-1 [94.0 kB]
Get:8 http://deb.debian.org/debian buster/main amd64 libllvm7 amd64 1:7.0.1-8 [13.0 MB]
Get:9 http://deb.debian.org/debian buster/main amd64 libgomp1 amd64 8.3.0-6 [75.8 kB]
Get:10 http://deb.debian.org/debian buster/main amd64 libitm1 amd64 8.3.0-6 [27.7 kB]
Get:11 http://deb.debian.org/debian buster/main amd64 libatomic1 amd64 8.3.0-6 [9032 B]
Get:12 http://deb.debian.org/debian buster/main amd64 libasan5 amd64 8.3.0-6 [362 kB]
Get:13 http://deb.debian.org/debian buster/main amd64 liblsan0 amd64 8.3.0-6 [131 kB]
Get:14 http://deb.debian.org/debian buster/main amd64 libtsan0 amd64 8.3.0-6 [283 kB]
Get:15 http://deb.debian.org/debian buster/main amd64 libubsan1 amd64 8.3.0-6 [120 kB]
Get:16 http://deb.debian.org/debian buster/main amd64 libmpx2 amd64 8.3.0-6 [11.4 kB]
Get:17 http://deb.debian.org/debian buster/main amd64 libquadmath0 amd64 8.3.0-6 [133 kB]
Get:18 http://deb.debian.org/debian buster/main amd64 libgcc-8-dev amd64 8.3.0-6 [2298 kB]
Get:19 http://deb.debian.org/debian buster/main amd64 libc-dev-bin amd64 2.28-10 [275 kB]
Get:20 http://deb.debian.org/debian buster/main amd64 libc6-dev amd64 2.28-10 [2691 kB]
Get:21 http://deb.debian.org/debian buster/main amd64 libstdc++-8-dev amd64 8.3.0-6 [1532 kB]
Get:22 http://deb.debian.org/debian buster/main amd64 libgc1c2 amd64 1:7.6.4-0.4 [224 kB]
Get:23 http://deb.debian.org/debian buster/main amd64 libobjc4 amd64 8.3.0-6 [50.3 kB]
Get:24 http://deb.debian.org/debian buster/main amd64 libobjc-8-dev amd64 8.3.0-6 [226 kB]
Get:25 http://deb.debian.org/debian buster/main amd64 libc6-i386 amd64 2.28-10 [2872 kB]
Get:26 http://deb.debian.org/debian buster/main amd64 lib32gcc1 amd64 1:8.3.0-6 [47.9 kB]
Get:27 http://deb.debian.org/debian buster/main amd64 lib32stdc++6 amd64 8.3.0-6 [407 kB]
Get:28 http://deb.debian.org/debian buster/main amd64 libclang-common-7-dev amd64 1:7.0.1-8 [3154 kB]
Get:29 http://deb.debian.org/debian buster/main amd64 libclang1-7 amd64 1:7.0.1-8 [5993 kB]
Get:30 http://deb.debian.org/debian buster/main amd64 clang-7 amd64 1:7.0.1-8 [7891 kB]
Get:31 http://deb.debian.org/debian buster/main amd64 clang amd64 1:7.0-47 [7468 B]
Get:32 http://deb.debian.org/debian buster/main amd64 libisl19 amd64 0.20-2 [587 kB]
Get:33 http://deb.debian.org/debian buster/main amd64 libmpfr6 amd64 4.0.2-1 [775 kB]
Get:34 http://deb.debian.org/debian buster/main amd64 libmpc3 amd64 1.1.0-1 [41.3 kB]
Get:35 http://deb.debian.org/debian buster/main amd64 cpp-8 amd64 8.3.0-6 [8914 kB]
Get:36 http://deb.debian.org/debian buster/main amd64 cpp amd64 4:8.3.0-1 [19.4 kB]
Get:37 http://deb.debian.org/debian buster/main amd64 libcc1-0 amd64 8.3.0-6 [46.6 kB]
Get:38 http://deb.debian.org/debian buster/main amd64 gcc-8 amd64 8.3.0-6 [9452 kB]
Get:39 http://deb.debian.org/debian buster/main amd64 gcc amd64 4:8.3.0-1 [5196 B]
Get:40 http://deb.debian.org/debian buster/main amd64 make amd64 4.2.1-1.2 [341 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 67.9 MB in 16s (4279 kB/s)
Selecting previously unselected package binutils-common:amd64.
(Reading database ... 7457 files and directories currently installed.)
Preparing to unpack .../00-binutils-common_2.31.1-16_amd64.deb ...
Unpacking binutils-common:amd64 (2.31.1-16) ...
Selecting previously unselected package libbinutils:amd64.
Preparing to unpack .../01-libbinutils_2.31.1-16_amd64.deb ...
Unpacking libbinutils:amd64 (2.31.1-16) ...
Selecting previously unselected package binutils-x86-64-linux-gnu.
Preparing to unpack .../02-binutils-x86-64-linux-gnu_2.31.1-16_amd64.deb ...
Unpacking binutils-x86-64-linux-gnu (2.31.1-16) ...
Selecting previously unselected package binutils.
Preparing to unpack .../03-binutils_2.31.1-16_amd64.deb ...
Unpacking binutils (2.31.1-16) ...
Selecting previously unselected package libbsd0:amd64.
Preparing to unpack .../04-libbsd0_0.9.1-2_amd64.deb ...
Unpacking libbsd0:amd64 (0.9.1-2) ...
Selecting previously unselected package libedit2:amd64.
Preparing to unpack .../05-libedit2_3.1-20181209-1_amd64.deb ...
Unpacking libedit2:amd64 (3.1-20181209-1) ...
Selecting previously unselected package libllvm7:amd64.
Preparing to unpack .../06-libllvm7_1%3a7.0.1-8_amd64.deb ...
Unpacking libllvm7:amd64 (1:7.0.1-8) ...
Selecting previously unselected package libgomp1:amd64.
Preparing to unpack .../07-libgomp1_8.3.0-6_amd64.deb ...
Unpacking libgomp1:amd64 (8.3.0-6) ...
Selecting previously unselected package libitm1:amd64.
Preparing to unpack .../08-libitm1_8.3.0-6_amd64.deb ...
Unpacking libitm1:amd64 (8.3.0-6) ...
Selecting previously unselected package libatomic1:amd64.
Preparing to unpack .../09-libatomic1_8.3.0-6_amd64.deb ...
Unpacking libatomic1:amd64 (8.3.0-6) ...
Selecting previously unselected package libasan5:amd64.
Preparing to unpack .../10-libasan5_8.3.0-6_amd64.deb ...
Unpacking libasan5:amd64 (8.3.0-6) ...
Selecting previously unselected package liblsan0:amd64.
Preparing to unpack .../11-liblsan0_8.3.0-6_amd64.deb ...
Unpacking liblsan0:amd64 (8.3.0-6) ...
Selecting previously unselected package libtsan0:amd64.
Preparing to unpack .../12-libtsan0_8.3.0-6_amd64.deb ...
Unpacking libtsan0:amd64 (8.3.0-6) ...
Selecting previously unselected package libubsan1:amd64.
Preparing to unpack .../13-libubsan1_8.3.0-6_amd64.deb ...
Unpacking libubsan1:amd64 (8.3.0-6) ...
Selecting previously unselected package libmpx2:amd64.
Preparing to unpack .../14-libmpx2_8.3.0-6_amd64.deb ...
Unpacking libmpx2:amd64 (8.3.0-6) ...
Selecting previously unselected package libquadmath0:amd64.
Preparing to unpack .../15-libquadmath0_8.3.0-6_amd64.deb ...
Unpacking libquadmath0:amd64 (8.3.0-6) ...
Selecting previously unselected package libgcc-8-dev:amd64.
Preparing to unpack .../16-libgcc-8-dev_8.3.0-6_amd64.deb ...
Unpacking libgcc-8-dev:amd64 (8.3.0-6) ...
Selecting previously unselected package libc-dev-bin.
Preparing to unpack .../17-libc-dev-bin_2.28-10_amd64.deb ...
Unpacking libc-dev-bin (2.28-10) ...
Selecting previously unselected package linux-libc-dev:amd64.
Preparing to unpack .../18-linux-libc-dev_4.19.37-5+deb10u1_amd64.deb ...
Unpacking linux-libc-dev:amd64 (4.19.37-5+deb10u1) ...
Selecting previously unselected package libc6-dev:amd64.
Preparing to unpack .../19-libc6-dev_2.28-10_amd64.deb ...
Unpacking libc6-dev:amd64 (2.28-10) ...
Selecting previously unselected package libstdc++-8-dev:amd64.
Preparing to unpack .../20-libstdc++-8-dev_8.3.0-6_amd64.deb ...
Unpacking libstdc++-8-dev:amd64 (8.3.0-6) ...
Selecting previously unselected package libgc1c2:amd64.
Preparing to unpack .../21-libgc1c2_1%3a7.6.4-0.4_amd64.deb ...
Unpacking libgc1c2:amd64 (1:7.6.4-0.4) ...
Selecting previously unselected package libobjc4:amd64.
Preparing to unpack .../22-libobjc4_8.3.0-6_amd64.deb ...
Unpacking libobjc4:amd64 (8.3.0-6) ...
Selecting previously unselected package libobjc-8-dev:amd64.
Preparing to unpack .../23-libobjc-8-dev_8.3.0-6_amd64.deb ...
Unpacking libobjc-8-dev:amd64 (8.3.0-6) ...
Selecting previously unselected package libc6-i386.
Preparing to unpack .../24-libc6-i386_2.28-10_amd64.deb ...
Unpacking libc6-i386 (2.28-10) ...
Selecting previously unselected package lib32gcc1.
Preparing to unpack .../25-lib32gcc1_1%3a8.3.0-6_amd64.deb ...
Unpacking lib32gcc1 (1:8.3.0-6) ...
Selecting previously unselected package lib32stdc++6.
Preparing to unpack .../26-lib32stdc++6_8.3.0-6_amd64.deb ...
Unpacking lib32stdc++6 (8.3.0-6) ...
Selecting previously unselected package libclang-common-7-dev.
Preparing to unpack .../27-libclang-common-7-dev_1%3a7.0.1-8_amd64.deb ...
Unpacking libclang-common-7-dev (1:7.0.1-8) ...
Selecting previously unselected package libclang1-7.
Preparing to unpack .../28-libclang1-7_1%3a7.0.1-8_amd64.deb ...
Unpacking libclang1-7 (1:7.0.1-8) ...
Selecting previously unselected package clang-7.
Preparing to unpack .../29-clang-7_1%3a7.0.1-8_amd64.deb ...
Unpacking clang-7 (1:7.0.1-8) ...
Selecting previously unselected package clang.
Preparing to unpack .../30-clang_1%3a7.0-47_amd64.deb ...
Unpacking clang (1:7.0-47) ...
Selecting previously unselected package libisl19:amd64.
Preparing to unpack .../31-libisl19_0.20-2_amd64.deb ...
Unpacking libisl19:amd64 (0.20-2) ...
Selecting previously unselected package libmpfr6:amd64.
Preparing to unpack .../32-libmpfr6_4.0.2-1_amd64.deb ...
Unpacking libmpfr6:amd64 (4.0.2-1) ...
Selecting previously unselected package libmpc3:amd64.
Preparing to unpack .../33-libmpc3_1.1.0-1_amd64.deb ...
Unpacking libmpc3:amd64 (1.1.0-1) ...
Selecting previously unselected package cpp-8.
Preparing to unpack .../34-cpp-8_8.3.0-6_amd64.deb ...
Unpacking cpp-8 (8.3.0-6) ...
Selecting previously unselected package cpp.
Preparing to unpack .../35-cpp_4%3a8.3.0-1_amd64.deb ...
Unpacking cpp (4:8.3.0-1) ...
Selecting previously unselected package libcc1-0:amd64.
Preparing to unpack .../36-libcc1-0_8.3.0-6_amd64.deb ...
Unpacking libcc1-0:amd64 (8.3.0-6) ...
Selecting previously unselected package gcc-8.
Preparing to unpack .../37-gcc-8_8.3.0-6_amd64.deb ...
Unpacking gcc-8 (8.3.0-6) ...
Selecting previously unselected package gcc.
Preparing to unpack .../38-gcc_4%3a8.3.0-1_amd64.deb ...
Unpacking gcc (4:8.3.0-1) ...
Selecting previously unselected package make.
Preparing to unpack .../39-make_4.2.1-1.2_amd64.deb ...
Unpacking make (4.2.1-1.2) ...
Setting up libgc1c2:amd64 (1:7.6.4-0.4) ...
Setting up binutils-common:amd64 (2.31.1-16) ...
Setting up linux-libc-dev:amd64 (4.19.37-5+deb10u1) ...
Setting up libobjc4:amd64 (8.3.0-6) ...
Setting up libgomp1:amd64 (8.3.0-6) ...
Setting up libasan5:amd64 (8.3.0-6) ...
Setting up make (4.2.1-1.2) ...
Setting up libmpfr6:amd64 (4.0.2-1) ...
Setting up libquadmath0:amd64 (8.3.0-6) ...
Setting up libmpc3:amd64 (1.1.0-1) ...
Setting up libatomic1:amd64 (8.3.0-6) ...
Setting up libmpx2:amd64 (8.3.0-6) ...
Setting up libubsan1:amd64 (8.3.0-6) ...
Setting up libisl19:amd64 (0.20-2) ...
Setting up libc6-i386 (2.28-10) ...
Setting up libbinutils:amd64 (2.31.1-16) ...
Setting up cpp-8 (8.3.0-6) ...
Setting up libc-dev-bin (2.28-10) ...
Setting up libbsd0:amd64 (0.9.1-2) ...
Setting up libcc1-0:amd64 (8.3.0-6) ...
Setting up liblsan0:amd64 (8.3.0-6) ...
Setting up libitm1:amd64 (8.3.0-6) ...
Setting up binutils-x86-64-linux-gnu (2.31.1-16) ...
Setting up libtsan0:amd64 (8.3.0-6) ...
Setting up libedit2:amd64 (3.1-20181209-1) ...
Setting up binutils (2.31.1-16) ...
Setting up lib32gcc1 (1:8.3.0-6) ...
Setting up lib32stdc++6 (8.3.0-6) ...
Setting up libgcc-8-dev:amd64 (8.3.0-6) ...
Setting up cpp (4:8.3.0-1) ...
Setting up libllvm7:amd64 (1:7.0.1-8) ...
Setting up libc6-dev:amd64 (2.28-10) ...
Setting up libclang1-7 (1:7.0.1-8) ...
Setting up libstdc++-8-dev:amd64 (8.3.0-6) ...
Setting up gcc-8 (8.3.0-6) ...
Setting up gcc (4:8.3.0-1) ...
Setting up libobjc-8-dev:amd64 (8.3.0-6) ...
Setting up libclang-common-7-dev (1:7.0.1-8) ...
Setting up clang-7 (1:7.0.1-8) ...
Setting up clang (1:7.0-47) ...
Processing triggers for libc-bin (2.28-10) ...
Removing intermediate container c71732ac807a
 ---> f83eb4945dd3
Step 5/7 : COPY . .
 ---> 71d246f4b826
Step 6/7 : RUN make &&     ln -s /etc/vlang/v /usr/local/bin/v
 ---> Running in 87282f80fccc
rm -f v.c .v.c v vprod thirdparty/**/*.o
find . -name '.*.c' -print0 | xargs -0 -n1 rm -f
curl -Os https://raw.githubusercontent.com/vlang/vc/master/v.c
cc -std=gnu11 -w -o v v.c -lm
./v -o v compiler
V has been successfully built
Removing intermediate container 87282f80fccc
 ---> a0d9e855d00c
Step 7/7 : CMD [ "bash" ]
 ---> Running in 6dcc20e5a009
Removing intermediate container 6dcc20e5a009
 ---> 44a34b54cf22
Successfully built 44a34b54cf22
Successfully tagged vlang:latest
```

</details>

- `make docker.run`

<details>
<summary>Execution history</summary>

```bash
$ make docker.run
docker build -t vlang .
Sending build context to Docker daemon  8.657MB
Step 1/7 : FROM buildpack-deps:buster-curl
 ---> af83f416912b
Step 2/7 : LABEL maintainer="ANAGO Ronnel <anagoandy@gmail.com>"
 ---> Using cache
 ---> fd26a33a7171
Step 3/7 : WORKDIR /etc/vlang
 ---> Using cache
 ---> a2c0c6e16075
Step 4/7 : RUN apt-get -yq update &&     apt-get install -y --no-install-recommends gcc clang make &&     rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> f5a05bf5e786
Step 5/7 : COPY . .
 ---> Using cache
 ---> 1095d259ac0e
Step 6/7 : RUN make &&     ln -s /etc/vlang/v /usr/local/bin/v
 ---> Using cache
 ---> 3b7add0671fb
Step 7/7 : CMD [ "bash" ]
 ---> Using cache
 ---> 439fc178be73
Successfully built 439fc178be73
Successfully tagged vlang:latest
docker run --rm -it vlang:latest
root@cfb4c836995a:/etc/vlang#
```

</details>

- `make docker.run.v`

<details>
<summary>Execution history</summary>

```bash
$ make docker.run.v
docker build -t vlang .
Sending build context to Docker daemon  8.657MB
Step 1/7 : FROM buildpack-deps:buster-curl
 ---> af83f416912b
Step 2/7 : LABEL maintainer="ANAGO Ronnel <anagoandy@gmail.com>"
 ---> Using cache
 ---> fd26a33a7171
Step 3/7 : WORKDIR /etc/vlang
 ---> Using cache
 ---> a2c0c6e16075
Step 4/7 : RUN apt-get -yq update &&     apt-get install -y --no-install-recommends gcc clang make &&     rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> f5a05bf5e786
Step 5/7 : COPY . .
 ---> Using cache
 ---> 1095d259ac0e
Step 6/7 : RUN make &&     ln -s /etc/vlang/v /usr/local/bin/v
 ---> Using cache
 ---> 3b7add0671fb
Step 7/7 : CMD [ "bash" ]
 ---> Using cache
 ---> 439fc178be73
Successfully built 439fc178be73
Successfully tagged vlang:latest
docker run --rm -it vlang:latest v
V 0.1.16
Use Ctrl-C or `exit` to exit
>>>
```

</details>


Please merge if possible.
