### PR TITLE
detect & block internal module import

### DIFF
--- a/compiler/modules.v
+++ b/compiler/modules.v
@@ -139,6 +139,10 @@ pub fn(graph &ModDepGraph) last_node() {
 	return graph.nodes[graph.nodes.len-1]
 }
 
+pub fn(graph &ModDepGraph) last_cycle() string {
+	return graph.nodes[graph.nodes.len-1].last_cycle
+}
+
 pub fn(graph &ModDepGraph) display() {
 	for i:=0; i<graph.nodes.len; i++ {
 		node := graph.nodes[i]

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -713,7 +713,19 @@ fn (fit mut FileImportTable) register_alias(alias string, mod string) {
 	if alias in fit.imports { 
 		panic('cannot import $mod as $alias: import name $alias already in use in "${fit.file_path}".')
 		return 
-	} 
+	}
+	if mod.contains('.internal.') {
+		mod_parts := mod.split('.')
+		mut internal_mod_parts := []string
+		for part in mod_parts {
+			if part == 'internal' { break }
+			internal_mod_parts << part
+		}
+		internal_parent := internal_mod_parts.join('.')
+		if !fit.module_name.starts_with(internal_parent) {
+			panic('module $mod can only imported by internal libs.')
+		}
+	}
 	fit.imports[alias] = mod
 }
 

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -723,7 +723,7 @@ fn (fit mut FileImportTable) register_alias(alias string, mod string) {
 		}
 		internal_parent := internal_mod_parts.join('.')
 		if !fit.module_name.starts_with(internal_parent) {
-			panic('module $mod can only imported by internal libs.')
+			panic('module $mod can only imported by internally by libs.')
 		}
 	}
 	fit.imports[alias] = mod

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -723,7 +723,7 @@ fn (fit mut FileImportTable) register_alias(alias string, mod string) {
 		}
 		internal_parent := internal_mod_parts.join('.')
 		if !fit.module_name.starts_with(internal_parent) {
-			panic('module $mod can only imported by internally by libs.')
+			panic('module $mod can only be imported internally by libs.')
 		}
 	}
 	fit.imports[alias] = mod


### PR DESCRIPTION
Block import of internal modules. For example:

modules in
`crypto.internal.*`
can only be imported by modules in
`crypto.*`

I also added a helper function to dependency graph. it will be used later.