### PR TITLE
make empty module dir error less confusing

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -920,7 +920,7 @@ fn (v mut V) add_user_v_files() {
 	if v.pref.build_mode == .default_mode {
 		for i := 0; i < v.table.imports.len; i++ {
 			mod := v.table.imports[i]
-			mod_path := v.module_path(v.table.imports[i])
+			mod_path := v.module_path(mod)
 			vfiles := v.v_files_from_dir('$ModPath/vlib/$mod_path')
 			if vfiles.len == 0 {
 				panic('cannot import module $mod, it does not exist.')
@@ -938,7 +938,7 @@ fn (v mut V) add_user_v_files() {
 		// for mod in v.table.imports {
 		for i := 0; i < v.table.imports.len; i++ {
 			mod := v.table.imports[i]
-			mod_path := v.module_path(v.table.imports[i])
+			mod_path := v.module_path(mod)
 			idir := os.getwd()
 			mut import_path := '$idir/$mod_path'
 			if !os.file_exists(import_path) {

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -924,7 +924,7 @@ fn (v mut V) add_user_v_files() {
 			import_path := '$ModPath/vlib/$mod_path'
 			vfiles := v.v_files_from_dir(import_path)
 			if vfiles.len == 0 {
-				panic('Cannot import module ${mod} (no .v files in "${import_path}").')
+				panic('cannot import module $mod (no .v files in "$import_path").')
 			}
 			// Add all imports referenced by these libs
 			for file in vfiles {
@@ -947,7 +947,7 @@ fn (v mut V) add_user_v_files() {
 			}
 			vfiles := v.v_files_from_dir(import_path)
 			if vfiles.len == 0 {
-				panic('Cannot import module ${mod} (no .v files in "${import_path}").')
+				panic('cannot import module $mod (no .v files in "$import_path").')
 			}
 			// Add all imports referenced by these libs
 			for file in vfiles {

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -921,9 +921,10 @@ fn (v mut V) add_user_v_files() {
 		for i := 0; i < v.table.imports.len; i++ {
 			mod := v.table.imports[i]
 			mod_path := v.module_path(mod)
-			vfiles := v.v_files_from_dir('$ModPath/vlib/$mod_path')
+			import_path := '$ModPath/vlib/$mod_path'
+			vfiles := v.v_files_from_dir(import_path)
 			if vfiles.len == 0 {
-				panic('cannot import module $mod, it does not exist.')
+				panic('Cannot import module ${mod} (no .v files in "${import_path}").')
 			}
 			// Add all imports referenced by these libs
 			for file in vfiles {
@@ -946,7 +947,7 @@ fn (v mut V) add_user_v_files() {
 			}
 			vfiles := v.v_files_from_dir(import_path)
 			if vfiles.len == 0 {
-				panic('cannot import module $mod, it does not exist.')
+				panic('Cannot import module ${mod} (no .v files in "${import_path}").')
 			}
 			// Add all imports referenced by these libs
 			for file in vfiles {


### PR DESCRIPTION
The case where a user tries to import a module but the module directory is empty, let them know.
Because they might see that the directory exists but not check if there are files in there.
The previous error might have confused them.