### PR TITLE
Fix #1334. Module glfw now imports gl.

### DIFF
--- a/vlib/glfw/glfw.v
+++ b/vlib/glfw/glfw.v
@@ -4,6 +4,8 @@
 
 module glfw
 
+import gl
+
 #flag -I @VROOT/thirdparty/glfw 
 #flag -L @VROOT/thirdparty/glfw 
 


### PR DESCRIPTION
```
import gg
import glfw
```
... now does not produce a compile error (when given without import gl too)