### PR TITLE
fix #1317

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -918,6 +918,8 @@ fn (v mut V) add_user_v_files() {
 	}
 	// Parse lib imports
 	if v.pref.build_mode == .default_mode {
+		// strange ( for mod in v.table.imports ) dosent loop all items
+		// for mod in v.table.imports {
 		for i := 0; i < v.table.imports.len; i++ {
 			mod := v.table.imports[i]
 			mod_path := v.module_path(mod)
@@ -935,14 +937,15 @@ fn (v mut V) add_user_v_files() {
 		}
 	}
 	else {
-		// TODO this used to crash compiler?
+		// strange ( for mod in v.table.imports ) dosent loop all items
 		// for mod in v.table.imports {
 		for i := 0; i < v.table.imports.len; i++ {
 			mod := v.table.imports[i]
 			mod_path := v.module_path(mod)
 			idir := os.getwd()
 			mut import_path := '$idir/$mod_path'
-			if !os.file_exists(import_path) {
+			//if !os.file_exists(import_path) || !os.is_dir(import_path){
+			if !os.is_dir(import_path){
 				import_path = '$v.lang_dir/vlib/$mod_path'
 			}
 			vfiles := v.v_files_from_dir(import_path)
@@ -980,7 +983,7 @@ fn (v mut V) add_user_v_files() {
 		if v.pref.build_mode == .default_mode || v.pref.build_mode == .build {
 			module_path = '$ModPath/vlib/$mod_p'
 		}
-		if !os.file_exists(module_path) {
+		if !os.is_dir(module_path) {
 			module_path = '$v.lang_dir/vlib/$mod_p'
 		}
 		vfiles := v.v_files_from_dir(module_path)
@@ -989,7 +992,6 @@ fn (v mut V) add_user_v_files() {
 				v.files << file
 			}
 		}
-		// TODO v.files.append_array(vfiles)
 	}
 	// add remaining files (not mods)
 	for fit in file_imports {


### PR DESCRIPTION
Fix for: https://github.com/vlang/v/issues/1317

@medvednikov the reason your commit didn't work was the **for in loop** wasn't looping through all the imports. **I cant explain why?**  Other form of loop works perfectly. Because of this some of the imports were never parsed & added to the dep graph, so it was as if term module did not exist and the dep graph could not resolve, hence false cycle error.

This is really weird but I've encountered that loop thing before, when I was first working on the modules, and It was always around that same location, even you had a note there about crashing the compiler... so weird!