### PR TITLE
move module test and update

### DIFF
--- a/compiler/tests/module_test.v
+++ b/compiler/tests/module_test.v
@@ -1,0 +1,14 @@
+import os
+import time as t
+
+import (
+	math
+	log as l
+)
+
+pub fn test_modules() {
+	assert os.SUCCESS == os.SUCCESS &&
+		t.MonthDays[0] == t.MonthDays[0] &&
+		math.Pi == math.Pi &&
+		l.INFO == l.INFO
+}

--- a/compiler/tests/module_test.v
+++ b/compiler/tests/module_test.v
@@ -5,10 +5,10 @@ import crypto.sha256 as s2
 import (
 	math
 	log as l
-	crypto.sha515 as s5
+	crypto.sha512 as s5
 )
 
-pub fn test_modules() {
+pub fn main() {
 	assert os.SUCCESS == os.SUCCESS &&
 		t.MonthDays[0] == t.MonthDays[0] &&
 		s2.Size == s2.Size &&

--- a/compiler/tests/module_test.v
+++ b/compiler/tests/module_test.v
@@ -1,14 +1,18 @@
 import os
 import time as t
+import crypto.sha256 as s2
 
 import (
 	math
 	log as l
+	crypto.sha515 as s5
 )
 
 pub fn test_modules() {
 	assert os.SUCCESS == os.SUCCESS &&
 		t.MonthDays[0] == t.MonthDays[0] &&
+		s2.Size == s2.Size &&
 		math.Pi == math.Pi &&
-		l.INFO == l.INFO
+		l.INFO == l.INFO &&
+		s5.Size == s5.Size
 }

--- a/compiler/tests/submodule_test.v
+++ b/compiler/tests/submodule_test.v
@@ -1,5 +1,0 @@
-import encoding.base64
-
-pub fn test_submodules() {
-    assert base64.decode('c3VibW9kdWxlcyBhcmUgd29ya2luZyE=') == 'submodules are working!'
-}


### PR DESCRIPTION
This moves compiler/submodule_test.v to compiler/module_test.v.
Updated to test both import formats with aliases and submodules.