### PR TITLE
Compiler: Fix unicode printf handling

### DIFF
--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -367,7 +367,9 @@ fn (p mut Parser) fn_decl() {
 	}
 
 	if f.name == 'main' || f.name == 'WinMain' {
+		p.genln('')
 		p.genln('init_consts();')
+		p.genln('#ifdef _WIN32\n fflush(stdout); _setmode(_fileno(stdout), _O_U8TEXT); \n#endif\n')
 		if p.table.imports.contains('os') {
 			if f.name == 'main' {
 				p.genln('os__args = os__init_os_args(argc, argv);')
@@ -743,7 +745,13 @@ fn (p mut Parser) fn_call_args(f *Fn) *Fn {
 			T := p.table.find_type(typ)
 			fmt := p.typ_to_fmt(typ, 0) 
 			if fmt != '' { 
-				p.cgen.resetln(p.cgen.cur_line.replace('println (', '/*opt*/printf ("' + fmt + '\\n", '))
+				// Fix for win32 unicode support
+				if p.os == .windows || p.os == .msvc {
+					//p.cgen.resetln(p.cgen.cur_line.replace('println (', '/*opt*/printf ("' + fmt + '\\n", '))
+					p.cgen.resetln(p.cgen.cur_line.replace('println (', '/*opt*/wprintf (L"' + fmt.replace('%.*s', '%.*S') + '\\n", '))
+				} else {
+					p.cgen.resetln(p.cgen.cur_line.replace('println (', '/*opt*/printf ("' + fmt + '\\n", '))
+				}
 				continue 
 			}  
 			if typ.ends_with('*') {

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -404,7 +404,7 @@ string _STR_TMP(const char *fmt, ...) {
 			// It can be skipped in single file programs
 			if v.pref.is_script {
 				//println('Generating main()...')
-				cgen.genln('int main() { \n#ifdef _WIN32\n _setmode(_fileno(stdout), _O_U8TEXT); \n#endif\n init_consts(); $cgen.fn_main; return 0; }')
+				cgen.genln('int main() { \n#ifdef _WIN32\n fflush(stdout); _setmode(_fileno(stdout), _O_U8TEXT); \n#endif\n init_consts(); $cgen.fn_main; return 0; }')
 			}
 			else {
 				println('panic: function `main` is undeclared in the main module')
@@ -413,7 +413,7 @@ string _STR_TMP(const char *fmt, ...) {
 		}
 		// Generate `main` which calls every single test function
 		else if v.pref.is_test {
-			cgen.genln('int main() { \n#ifdef _WIN32\n _setmode(_fileno(stdout), _O_U8TEXT); \n#endif\n init_consts();')
+			cgen.genln('int main() { \n#ifdef _WIN32\n fflush(stdout); _setmode(_fileno(stdout), _O_U8TEXT); \n#endif\n init_consts();')
 			for key, f in v.table.fns { 
 				if f.name.starts_with('test_') {
 					cgen.genln('$f.name();')

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -2423,9 +2423,19 @@ fn (p mut Parser) string_expr() {
 	cur_line := p.cgen.cur_line.trim_space()
 	if cur_line.contains('println (') && p.tok != .plus && 
 		!cur_line.contains('string_add') && !cur_line.contains('eprintln') {
-		p.cgen.resetln(cur_line.replace('println (', 'printf('))
-		p.gen('$format\\n$args')
-		return
+			if p.os == .windows || p.os == .msvc {
+				p.cgen.resetln(cur_line.replace('println (', 'wprintf( TEXT('))// .replace('%.*s', '%.*S'))
+
+				// Emily: HACKY HACK
+				real_format := format.replace('%.*s', '%.*S')
+				real_args := args.right(1)
+				p.gen('$real_format\\n")$real_args')
+			} else {
+				p.cgen.resetln(cur_line.replace('println (', 'printf('))
+				p.gen('$format\\n$args')
+			}
+
+			return
 	}
 	// '$age'! means the user wants this to be a tmp string (uses global buffer, no allocation,
 	// won't be used	again)

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -38,7 +38,9 @@ pub fn println(s string) {
 		panic('println(NIL)')
 	}
 	$if windows {
-		C._putws(s.to_wide())
+		// HACKY HACK 
+		// use capital s for printing regular ascii strings
+		C.wprintf(C.TEXT('%.*S\n'), s.len, s)
 	} $else {
 		C.printf('%.*s\n', s.len, s.str)
 	}


### PR DESCRIPTION
Also fixes that tests were opening a unicode stream but regular builds were not. `_wputs()` doesnt support a unicode output stream (*becuase microsoft*) so that is replaced with wprintf.

the `TEXT()` macro is used to properly paste the `L` token to the front of the `"` token whilst allowing for extra whitespace to be arbitrarily inserted by other areas of the compiler.

Overall whilst I think this optimization has good intentions - when strings and whatnot are better designed and optimized in general then this should be replaced.