### PR TITLE
[]byte copy(dst, src)

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -253,7 +253,7 @@ pub fn (b []byte) hex() string {
 }
 
 // TODO: implement for all types
-fn copy(dst []byte, src []byte) int {
+pub fn copy(dst []byte, src []byte) int {
 	if dst.len > 0 && src.len > 0 {
 		min := if dst.len < src.len { dst.len } else { src.len }
 		C.memcpy(dst.data, src.left(min).data, dst.element_size*min)

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -251,3 +251,13 @@ pub fn (b []byte) hex() string {
 	}
 	return string(hex)
 }
+
+// TODO: implement for all types
+fn copy(dst []byte, src []byte) int {
+	if dst.len > 0 && src.len > 0 {
+		min := if dst.len < src.len { dst.len } else { src.len }
+		C.memcpy(dst.data, src.left(min).data, dst.element_size*min)
+		return min
+	}
+	return 0
+}

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -253,7 +253,7 @@ pub fn (b []byte) hex() string {
 }
 
 // TODO: implement for all types
-pub fn copy(dst []byte, src []byte) int {
+pub fn copy(dst, src []byte) int {
 	if dst.len > 0 && src.len > 0 {
 		min := if dst.len < src.len { dst.len } else { src.len }
 		C.memcpy(dst.data, src.left(min).data, dst.element_size*min)


### PR DESCRIPTION
For now just implement copy(dst, src) for []byte
needs to be implemented for all types.

This is an analogue of go's copy() minus the special case where if copies from a string to []bytes.