### PR TITLE
bf: fix a bug in bf.resize()

### DIFF
--- a/vlib/bf/bf.v
+++ b/vlib/bf/bf.v
@@ -479,11 +479,11 @@ pub fn (instance mut BitField) reverse() BitField {
 // resize() changes the size of the bit array to 'new_size'
 
 pub fn (instance mut BitField) resize(size int) {
-	bitnslots := bitnslots(size)
+	new_bitnslots := bitnslots(size)
 	old_size := instance.size
 	old_bitnslots := bitnslots(old_size)
-	mut field := [u32(0); bitnslots]
-	for i := 0; i < old_bitnslots && i < bitnslots; i++ {
+	mut field := [u32(0); new_bitnslots]
+	for i := 0; i < old_bitnslots && i < new_bitnslots; i++ {
 		field[i] = instance.field[i]
 	}
 	instance.field = field

--- a/vlib/bf/bf_test.v
+++ b/vlib/bf/bf_test.v
@@ -226,9 +226,9 @@ fn test_bf_reverse() {
 fn test_bf_resize() {
 	rand.seed(time.now().uni)
 	len := 80
-	mut input := bf.new(len)
+	mut input := bf.new(rand.next(len) + 1)
 	for i := 0; i < 100; i++ {
-		input.resize(rand.next(input.getsize()) + 1)
+		input.resize(rand.next(len) + 1)
 		input.setbit(input.getsize() - 1)
 	}
 	assert input.getbit(input.getsize() - 1) == 1


### PR DESCRIPTION
A variable name in resize() method coincides with a function name. Actually, the buggy code should not even compile, so the real bug is deeper.
