### PR TITLE
sync: fix #1362 nix mutex

### DIFF
--- a/vlib/sync/sync_nix.v
+++ b/vlib/sync/sync_nix.v
@@ -9,11 +9,11 @@ struct Mutex {
 	mutex C.pthread_mutex_t
 }
 
-pub fn (m Mutex) lock() {
+pub fn (m mut Mutex) lock() {
 	C.pthread_mutex_lock(&m.mutex)
 }
 
-pub fn (m Mutex) unlock() {
+pub fn (m mut Mutex) unlock() {
 	C.pthread_mutex_unlock(&m.mutex)
 }
 


### PR DESCRIPTION
Made lock and unlock use mutable, so that the mutex could update state and therefore work.

# test now "hangs" correctly
import sync
mut m := &sync.Mutex{}
m.lock()
m.lock()
println('hello')
