### PR TITLE
v panic debug information

### DIFF
--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -752,6 +752,15 @@ fn (p mut Parser) fn_call_args(f mut Fn) *Fn {
 		p.check(.rpar)
 		return f
 	}
+	// Add debug information to panic when -debug is passed
+	if p.v.pref.is_debug && f.name == 'panic' {
+		fn_name := p.cur_fn.name.replace('${p.mod}__', '')
+		file_path := p.file_path.replace('\\', '\\\\') // esecape \
+		p.cgen.resetln(p.cgen.cur_line.replace(
+			'v_panic (',
+			'_panic_debug ($p.scanner.line_nr, tos2("$file_path"), tos2("$p.mod"), tos2("$fn_name"), '
+		))
+	}
 	// Receiver - first arg
 	for i, arg in f.args {
 		// println('$i) arg=$arg.name')

--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -754,11 +754,12 @@ fn (p mut Parser) fn_call_args(f mut Fn) *Fn {
 	}
 	// add debug information to panic when -debug arg is passed
 	if p.v.pref.is_debug && f.name == 'panic' {
+		mod_name := p.mod.replace('_dot_', '.')
 		fn_name := p.cur_fn.name.replace('${p.mod}__', '')
 		file_path := p.file_path.replace('\\', '\\\\') // escape \
 		p.cgen.resetln(p.cgen.cur_line.replace(
 			'v_panic (',
-			'_panic_debug ($p.scanner.line_nr, tos2("$file_path"), tos2("$p.mod"), tos2("$fn_name"), '
+			'_panic_debug ($p.scanner.line_nr, tos2("$file_path"), tos2("$mod_name"), tos2("$fn_name"), '
 		))
 	}
 	// Receiver - first arg

--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -752,7 +752,7 @@ fn (p mut Parser) fn_call_args(f mut Fn) *Fn {
 		p.check(.rpar)
 		return f
 	}
-	// Add debug information to panic when -debug is passed
+	// add debug information to panic when -debug arg is passed
 	if p.v.pref.is_debug && f.name == 'panic' {
 		fn_name := p.cur_fn.name.replace('${p.mod}__', '')
 		file_path := p.file_path.replace('\\', '\\\\') // escape \

--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -755,7 +755,7 @@ fn (p mut Parser) fn_call_args(f mut Fn) *Fn {
 	// Add debug information to panic when -debug is passed
 	if p.v.pref.is_debug && f.name == 'panic' {
 		fn_name := p.cur_fn.name.replace('${p.mod}__', '')
-		file_path := p.file_path.replace('\\', '\\\\') // esecape \
+		file_path := p.file_path.replace('\\', '\\\\') // escape \
 		p.cgen.resetln(p.cgen.cur_line.replace(
 			'v_panic (',
 			'_panic_debug ($p.scanner.line_nr, tos2("$file_path"), tos2("$p.mod"), tos2("$fn_name"), '

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -26,6 +26,19 @@ pub fn print_backtrace() {
 	}
 }
 
+// replaces panic when -debug arg is passed
+fn _panic_debug(line_no int, file,  mod, fn_name, s string) {
+	println('================ V panic ================')
+	println('   module: $mod')
+	println(' function: ${fn_name}()')
+	println('     file: $file')
+	println('     line: ' + line_no.str())
+	println('  message: $s')
+	println('=========================================')
+	print_backtrace()
+	C.exit(1)
+}
+
 pub fn panic(s string) {
 	println('V panic: $s')
 	print_backtrace()

--- a/vlib/crypto/sha512/sha512.v
+++ b/vlib/crypto/sha512/sha512.v
@@ -146,7 +146,6 @@ fn new384() *Digest {
 }
 
 fn (d mut Digest) write(p []byte) ?int {
-	panic('error writing')
 	nn := p.len
 	d.len += u64(nn)
 	if d.nx > 0 {

--- a/vlib/crypto/sha512/sha512.v
+++ b/vlib/crypto/sha512/sha512.v
@@ -146,6 +146,7 @@ fn new384() *Digest {
 }
 
 fn (d mut Digest) write(p []byte) ?int {
+	panic('error writing')
 	nn := p.len
 	d.len += u64(nn)
 	if d.nx > 0 {


### PR DESCRIPTION
This PR adds debug information to panic when -debug argument is passed. Example:
```
# v run myfile.v -debug
================ V panic ================
   module: mymodule
 function: panic_causing_function()
     file: /home/joe/dev/v/myfile.v
     line: 11
  message: error reading file.
=========================================
```