### PR TITLE
vweb: handle_static with mime types

### DIFF
--- a/examples/vweb/test_app.v
+++ b/examples/vweb/test_app.v
@@ -17,8 +17,7 @@ fn main() {
 }
 
 pub fn (app mut App) init() {
-	app.vweb.serve_static('/css.css', 'static/css.css')
-	app.vweb.serve_static('/jquery.js', 'static/jquery.js')
+	app.vweb.handle_static('.')
 }
 
 pub fn (app mut App) json_endpoint() {


### PR DESCRIPTION
`vweb.handle_static` with recursive directory scanning and auto mime time attribution.

Usage example:
```
module main

import vweb
import os

struct Server {
pub mut:
    vweb vweb.Context
}

fn main() {
    println('http://localhost:4000')
    vweb.run<Server>(4000)
}

pub fn (t mut Server) init() {
    t.vweb.handle_static('./frontend/build')
}
```
