### PR TITLE
repl: do not eat first line

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -1255,7 +1255,7 @@ fn run_repl() []string {
 				}
 			}
 			else {
-				for i:=0; i<vals.len-1; i++ {
+				for i:=0; i < vals.len; i++ {
 					println(vals[i])
 				}
 			}
@@ -1273,7 +1273,7 @@ fn run_repl() []string {
 			if s.contains('panic: ') {
 				if !s.contains('declared and not used') 	{
 					mut vals := s.split('\n')
-					for i:=1; i<vals.len; i++ {
+					for i:=0; i < vals.len; i++ {
 						println(vals[i])
 					} 
 				}


### PR DESCRIPTION
for some reason first or last line was skipped. Let me know if it was intended, but now it works with one line println on windows at least