### PR TITLE
compiler: check is ptr when free in closing scope

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1029,7 +1029,7 @@ fn (p mut Parser) close_scope() {
 			else if v.typ == 'string' { 
 				p.genln('v_string_free($v.name); // close_scope free') 
 			} 
-			else { 
+			else if v.ptr {
 				p.genln('free($v.name); // close_scope free') 
 			} 
 		} 


### PR DESCRIPTION
The compiler will check that a variable is a pointer to apply a free when a scope is closing.

Fix #1368 