### PR TITLE
colors.v: allow more colors to be used (bright styled ansi, rgb and hex)

### DIFF
--- a/vlib/term/colors.v
+++ b/vlib/term/colors.v
@@ -31,7 +31,7 @@ pub fn hex(hex int, msg string) string {
 }
 
 pub fn bg_hex(hex int, msg string) string {
-		return format_rgb(
+	return format_rgb(
 		hex >> 16,
 		hex >> 8 & 0xFF,
 		hex & 0xFF,

--- a/vlib/term/colors.v
+++ b/vlib/term/colors.v
@@ -10,6 +10,18 @@ fn _format(msg, open, close string) string {
 	return '\x1b[' + open + 'm' + msg + '\x1b[' + close + 'm'
 }
 
+fn _format_rgb(r, g, b int, msg, open, close string) string {
+	return '\x1b[' + open + ';2;' + r.str() + ';' + g.str() + ';' + b.str() + 'm' + msg + '\x1b[' + close + 'm'
+}
+
+pub fn rgb(r, g, b int, msg string) string {
+	return format_rgb(r, g, b, msg, '38', '39')
+}
+
+pub fn bg_rgb(r, g, b int, msg string) string {
+	return format_rgb(r, g, b, msg, '48', '49')
+}
+
 pub fn bg_black(msg string) string {
 	return format(msg, '40', '49')
 }

--- a/vlib/term/colors.v
+++ b/vlib/term/colors.v
@@ -22,6 +22,22 @@ pub fn bg_rgb(r, g, b int, msg string) string {
 	return format_rgb(r, g, b, msg, '48', '49')
 }
 
+pub fn hex(hex int, msg string) string {
+	return format_rgb(
+		hex >> 16,
+		hex >> 8 & 0xFF,
+		hex & 0xFF,
+		msg, '38', '39')
+}
+
+pub fn bg_hex(hex int, msg string) string {
+		return format_rgb(
+		hex >> 16,
+		hex >> 8 & 0xFF,
+		hex & 0xFF,
+		msg, '48', '49')
+}
+
 pub fn bg_black(msg string) string {
 	return format(msg, '40', '49')
 }

--- a/vlib/term/colors.v
+++ b/vlib/term/colors.v
@@ -14,40 +14,80 @@ pub fn bg_black(msg string) string {
 	return format(msg, '40', '49')
 }
 
+pub fn bright_bg_black(msg string) string {
+	return format(msg, '100', '49')
+}
+
 pub fn bg_blue(msg string) string {
 	return format(msg, '44', '49')
+}
+
+pub fn bright_bg_blue(msg string) string {
+	return format(msg, '104', '49')
 }
 
 pub fn bg_cyan(msg string) string {
 	return format(msg, '46', '49')
 }
 
+pub fn bright_bg_cyan(msg string) string {
+	return format(msg, '106', '49')
+}
+
 pub fn bg_green(msg string) string {
 	return format(msg, '42', '49')
+}
+
+pub fn bright_bg_green(msg string) string {
+	return format(msg, '102', '49')
 }
 
 pub fn bg_magenta(msg string) string {
 	return format(msg, '45', '49')
 }
 
+pub fn bright_bg_magenta(msg string) string {
+	return format(msg, '105', '49')
+}
+
 pub fn bg_red(msg string) string {
 	return format(msg, '41', '49')
+}
+
+pub fn bright_bg_red(msg string) string {
+	return format(msg, '101', '49')
 }
 
 pub fn bg_white(msg string) string {
 	return format(msg, '47', '49')
 }
 
+pub fn bright_bg_white(msg string) string {
+	return format(msg, '107', '49')
+}
+
 pub fn bg_yellow(msg string) string {
 	return format(msg, '43', '49')
+}
+
+pub fn bright_bg_yellow(msg string) string {
+	return format(msg, '103', '49')
 }
 
 pub fn black(msg string) string {
 	return format(msg, '30', '39')
 }
 
+pub fn bright_black(msg string) string {
+	return format(msg, '90', '39')
+}
+
 pub fn blue(msg string) string {
 	return format(msg, '34', '39')
+}
+
+pub fn bright_blue(msg string) string {
+	return format(msg, '94', '39')
 }
 
 pub fn bold(msg string) string {
@@ -58,6 +98,10 @@ pub fn cyan(msg string) string {
 	return format(msg, '36', '39')
 }
 
+pub fn bright_cyan(msg string) string {
+	return format(msg, '96', '39')
+}
+
 pub fn dim(msg string) string {
 	return format(msg, '2', '22')
 }
@@ -66,8 +110,12 @@ pub fn green(msg string) string {
 	return format(msg, '32', '39')
 }
 
+pub fn bright_green(msg string) string {
+	return format(msg, '92', '39')
+}
+
 pub fn gray(msg string) string {
-	return format(msg, '90', '39')
+	return bright_black(msg)
 }
 
 pub fn hidden(msg string) string {
@@ -86,12 +134,20 @@ pub fn magenta(msg string) string {
 	return format(msg, '35', '39')
 }
 
+pub fn bright_magenta(msg string) string {
+	return format(msg, '95', '39')
+}
+
 pub fn reset(msg string) string {
 	return format(msg, '0', '0')
 }
 
 pub fn red(msg string) string {
 	return format(msg, '31', '39')
+}
+
+pub fn bright_red(msg string) string {
+	return format(msg, '91', '39')
 }
 
 pub fn strikethrough(msg string) string {
@@ -106,6 +162,14 @@ pub fn white(msg string) string {
 	return format(msg, '37', '39')
 }
 
+pub fn bright_white(msg string) string {
+	return format(msg, '97', '39')
+}
+
 pub fn yellow(msg string) string {
 	return format(msg, '33', '39')
+}
+
+pub fn bright_yellow(msg string) string {
+	return format(msg, '93', '39')
 }

--- a/vlib/term/colors_nix.v
+++ b/vlib/term/colors_nix.v
@@ -7,3 +7,7 @@ module term
 pub fn format(msg, open, close string) string {
 	return _format(msg, open, close)
 }
+
+pub fn format_rgb(r, g, b int, msg, open, close string) string {
+	return _format_rgb(r, g, b, msg, open, close)
+}

--- a/vlib/term/colors_win.v
+++ b/vlib/term/colors_win.v
@@ -31,3 +31,8 @@ pub fn format(msg, open, close string) string {
 	enable_term_color_win()
 	return _format(msg, open, close)
 }
+
+pub fn format_rgb(r, g, b int, msg, open, close string) string {
+	enable_term_color_win()
+	return _format_rgb(r, g, b, msg, open, close)
+}


### PR DESCRIPTION
### This PR does what?
This PR adds new functions to stylize your terminal messages with:
- bright styled ansi (bright cyan, bright red, bright yellow etc. [standard colors])
- using rgb (`#rgb(...) / #bg_rgb(...) / #format_rgb(...)`)
- using hex (`#hex(...) / #bg_hex(...) / #format_hex(...)`)

Everything has been tested thoroughly. No compile errors, tests where successfully executed, and the features actually work. See below.

![grafik](https://user-images.githubusercontent.com/50335928/62212557-40378e00-b3a1-11e9-8508-74f95639e627.png)