### PR TITLE
Travis: run tests for Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,8 @@ script:
     fi
   - |
     if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
-      echo "Running make.bat..."
-      ./make.bat
-      ./v.exe -debug -o v2.exe compiler
-      gcc -Ithirdparty/microsoft_craziness -DUNICODE -D_UNICODE .v2.exe.c thirdparty/microsoft_craziness/microsoft_craziness.c -o v2.exe -lole32 -ladvapi32 -loleaut32
-      ./v2.exe -o v3.exe compiler
+      echo "Running make_tests.bat..."
+      ./make_tests.bat
     fi
   - |
     if [[ "${TRAVIS_OS_NAME}" != "windows" ]]; then

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -366,7 +366,7 @@ void init_consts();')
 	// if v.build_mode in [.default, .embed_vlib] {
 	if v.pref.build_mode == .default_mode || v.pref.build_mode == .embed_vlib {
 		// vlib can't have `init_consts()`
-		cgen.genln('void init_consts() { \n#ifdef _WIN32\n _setmode(_fileno(stdout), _O_U8TEXT); \n#endif\n g_str_buf=malloc(1000); ${cgen.consts_init.join_lines()} }')
+		cgen.genln('void init_consts() { \n#ifdef _WIN32\n _setmode(_fileno(stdout), _O_U8TEXT); \nSetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), ENABLE_PROCESSED_OUTPUT | 0x0004); // ENABLE_VIRTUAL_TERMINAL_PROCESSING\n#endif\n g_str_buf=malloc(1000); ${cgen.consts_init.join_lines()} }')
 		// _STR function can't be defined in vlib
 		cgen.genln('
 string _STR(const char *fmt, ...) {

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -3086,10 +3086,10 @@ fn (p mut Parser) assert_statement() {
 	p.gen('bool $tmp = ')
 	p.check_types(p.bool_expression(), 'bool')
 	// TODO print "expected:  got" for failed tests
-	filename := p.file_path
+	filename := p.file_path.replace('\\', '\\\\')
 	p.genln(';\n 
-if (!$tmp) { 
-  puts("\\x1B[31mFAILED: $p.cur_fn.name() in $filename:$p.scanner.line_nr\\x1B[0m");  
+if (!$tmp) {
+  println(tos2("\\x1B[31mFAILED: $p.cur_fn.name() in $filename:$p.scanner.line_nr\\x1B[0m"));
 g_test_ok = 0 ; 
 	// TODO
 	// Maybe print all vars in a test function if it fails? 

--- a/vlib/term/colors_win.v
+++ b/vlib/term/colors_win.v
@@ -6,28 +6,6 @@ module term
 
 import os
 
-// Calling this functions enables color terminal output on windows
-// Maybe implement a way to auto run an init function when a module
-// is imported on a certain os. for example to run this?
-pub fn enable_term_color_win() {
-	mode_wanted := os.ENABLE_PROCESSED_OUTPUT | os.ENABLE_VIRTUAL_TERMINAL_PROCESSING
-	mut mode_current := 0
-	h_output := C.GetStdHandle(os.STD_OUTPUT_HANDLE)
-	if h_output == os.INVALID_HANDLE_VALUE {
-		panic('term.enable_term_color_win(): error getting output handle.')
-	}
-	if !C.GetConsoleMode(h_output, &mode_current) {
-		panic('term.enable_term_color_win(): error getting console mode.')
-	}
-	if mode_wanted == mode_current {
-		return
-	}
-	if !C.SetConsoleMode(h_output, mode_wanted) {
-		panic('term.enable_term_color_win(): error setting console mode.')
-	}
-}
-
 pub fn format(msg, open, close string) string {
-	enable_term_color_win()
 	return _format(msg, open, close)
 }


### PR DESCRIPTION
Windows are now fully pass tests, few last changes:
1. Make Travis run `make_tests.bat`
2. Always enable ANSI sequences processing (it may only not needed for GUI apps)
3. Do not use `puts` in test codegen and use well-tested `println`
4. Escape `\` to correctly show filenames in test assertions