### PR TITLE
os: fix read_lines for win/dos files on unix

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -190,7 +190,7 @@ pub fn read_lines(path string) []string {
 			buf_index = len
 			continue
 		}
-		if buf[len - 1] == 10 {
+		if buf[len - 1] == 10 || buf[len - 1] == 13 {
 			buf[len - 1] = `\0`
 		}
 		if len > 1 && buf[len - 2] == 13 {

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -193,10 +193,8 @@ pub fn read_lines(path string) []string {
 		if buf[len - 1] == 10 {
 			buf[len - 1] = `\0`
 		}
-		$if windows {
-			if buf[len - 2] == 13 {
-				buf[len - 2] = `\0`
-			}
+		if len > 1 && buf[len - 2] == 13 {
+			buf[len - 2] = `\0`
 		}
 		res << tos_clone(buf)
 		buf_index = 0


### PR DESCRIPTION
Fix read_lines for win/dos files on linux. Resolves #1410.