### PR TITLE
vlib.crypto: add last commit to help track changes.

### DIFF
--- a/vlib/crypto/aes/aes.v
+++ b/vlib/crypto/aes/aes.v
@@ -2,7 +2,11 @@
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 
-// Adapted from: https://github.com/golang/go/blob/master/src/crypto/aes
+// Based off:   https://github.com/golang/go/blob/master/src/crypto/aes
+// Last commit: https://github.com/golang/go/commit/691a2d457ab1bf03bd46d4b69e0f93b8993c0055
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
 module aes
 

--- a/vlib/crypto/aes/aes.v
+++ b/vlib/crypto/aes/aes.v
@@ -4,9 +4,6 @@
 
 // Based off:   https://github.com/golang/go/blob/master/src/crypto/aes
 // Last commit: https://github.com/golang/go/commit/691a2d457ab1bf03bd46d4b69e0f93b8993c0055
-// Copyright 2009 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
 
 module aes
 

--- a/vlib/crypto/md5/md5.v
+++ b/vlib/crypto/md5/md5.v
@@ -7,7 +7,11 @@
 // MD5 is cryptographically broken and should not be used for secure
 // applications.
 
-// Adapted from: https://github.com/golang/go/blob/master/src/crypto/md5
+// Based off:   https://github.com/golang/go/blob/master/src/crypto/md5
+// Last commit: https://github.com/golang/go/commit/ed7f323c8f4f6bc61a75146bf34f5b8f73063a17
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
 module md5
 

--- a/vlib/crypto/md5/md5.v
+++ b/vlib/crypto/md5/md5.v
@@ -9,9 +9,6 @@
 
 // Based off:   https://github.com/golang/go/blob/master/src/crypto/md5
 // Last commit: https://github.com/golang/go/commit/ed7f323c8f4f6bc61a75146bf34f5b8f73063a17
-// Copyright 2009 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
 
 module md5
 

--- a/vlib/crypto/rc4/rc4.v
+++ b/vlib/crypto/rc4/rc4.v
@@ -8,7 +8,11 @@
 // RC4 is cryptographically broken and should not be used for secure
 // applications.
 
-// Adapted from: https://github.com/golang/go/blob/master/src/crypto/rc4
+// Based off:   https://github.com/golang/go/blob/master/src/crypto/rc4
+// Last commit: https://github.com/golang/go/commit/b35dacaac57b039205d9b07ea24098e2c3fcb12e
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
 module rc4
 

--- a/vlib/crypto/rc4/rc4.v
+++ b/vlib/crypto/rc4/rc4.v
@@ -10,9 +10,6 @@
 
 // Based off:   https://github.com/golang/go/blob/master/src/crypto/rc4
 // Last commit: https://github.com/golang/go/commit/b35dacaac57b039205d9b07ea24098e2c3fcb12e
-// Copyright 2009 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
 
 module rc4
 

--- a/vlib/crypto/sha1/sha1.v
+++ b/vlib/crypto/sha1/sha1.v
@@ -7,7 +7,11 @@
 // SHA-1 is cryptographically broken and should not be used for secure
 // applications.
 
-// Adapted from: https://github.com/golang/go/blob/master/src/crypto/sha1
+// Based off:   https://github.com/golang/go/blob/master/src/crypto/sha1
+// Last commit: https://github.com/golang/go/commit/3ce865d7a0b88714cc433454ae2370a105210c01 
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
 module sha1
 

--- a/vlib/crypto/sha1/sha1.v
+++ b/vlib/crypto/sha1/sha1.v
@@ -9,9 +9,6 @@
 
 // Based off:   https://github.com/golang/go/blob/master/src/crypto/sha1
 // Last commit: https://github.com/golang/go/commit/3ce865d7a0b88714cc433454ae2370a105210c01 
-// Copyright 2009 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
 
 module sha1
 

--- a/vlib/crypto/sha256/sha256.v
+++ b/vlib/crypto/sha256/sha256.v
@@ -5,7 +5,11 @@
 // Package sha256 implements the SHA224 and SHA256 hash algorithms as defined
 // in FIPS 180-4.
 
-// Adaped from https://github.com/golang/go/tree/master/src/crypto/sha256
+// Based off:   https://github.com/golang/go/tree/master/src/crypto/sha256
+// Last commit: https://github.com/golang/go/commit/3ce865d7a0b88714cc433454ae2370a105210c01
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
 module sha256
 

--- a/vlib/crypto/sha256/sha256.v
+++ b/vlib/crypto/sha256/sha256.v
@@ -7,9 +7,6 @@
 
 // Based off:   https://github.com/golang/go/tree/master/src/crypto/sha256
 // Last commit: https://github.com/golang/go/commit/3ce865d7a0b88714cc433454ae2370a105210c01
-// Copyright 2009 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
 
 module sha256
 

--- a/vlib/crypto/sha512/sha512.v
+++ b/vlib/crypto/sha512/sha512.v
@@ -5,7 +5,11 @@
 // Package sha512 implements the SHA-384, SHA-512, SHA-512/224, and SHA-512/256
 // hash algorithms as defined in FIPS 180-4.
 
-// Adaped from https://github.com/golang/go/tree/master/src/crypto/sha512
+// Based off:   https://github.com/golang/go/tree/master/src/crypto/sha512
+// Last commit: https://github.com/golang/go/commit/3ce865d7a0b88714cc433454ae2370a105210c01
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
 module sha512
 

--- a/vlib/crypto/sha512/sha512.v
+++ b/vlib/crypto/sha512/sha512.v
@@ -7,9 +7,6 @@
 
 // Based off:   https://github.com/golang/go/tree/master/src/crypto/sha512
 // Last commit: https://github.com/golang/go/commit/3ce865d7a0b88714cc433454ae2370a105210c01
-// Copyright 2009 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
 
 module sha512
 


### PR DESCRIPTION
I added the latest commit at the time of writing.
It will help track any changes later by doing a diff from that commit until current.
This can get updated if any updates are merged over.