### PR TITLE
net.urllib: fix values (used for query string/form data)

### DIFF
--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -861,7 +861,7 @@ fn _parse_query(m mut Values, query string) ?bool {
 
 // encode encodes the values into ``URL encoded'' form
 // ('bar=baz&foo=quux') sorted by key.
-fn (v Values) encode() string {
+pub fn (v Values) encode() string {
 	if v.size == 0 {
 		return ''
 	}

--- a/vlib/net/urllib/values.v
+++ b/vlib/net/urllib/values.v
@@ -10,6 +10,8 @@ mut:
 	data []string
 }
 
+// using this instead of just ValueStruct
+// because of unknown map initializer bug
 type Value ValueStruct
 
 struct Values {
@@ -19,7 +21,7 @@ mut:
 	size int
 }
 
-fn new_values() Values {
+pub fn new_values() Values {
 	return Values{
 		data: map[string]Value{}
 	}
@@ -33,7 +35,7 @@ pub fn (v Value) all() []string {
 // If there are no values associated with the key, Get returns
 // the empty string. To access multiple values, use the map
 // directly.
-fn (v Values) get(key string) string {
+pub fn (v Values) get(key string) string {
 	if v.data.size == 0 {
 		return ''
 	}
@@ -46,20 +48,27 @@ fn (v Values) get(key string) string {
 
 // Set sets the key to value. It replaces any existing
 // values.
-fn (v Values) set(key, value string) {
-	v.data[key].data = [value]
+pub fn (v mut Values) set(key, value string) {
+	mut a := v.data[key]
+	a.data = [value]
+	v.data[key] = a
 	v.size = v.data.size
 }
 
 // Add adds the value to key. It appends to any existing
 // values associated with key.
-fn (v mut Values) add(key, value string) {
-	mut a := v.data[key]
-	a.data << value
+pub fn (v mut Values) add(key, value string) {
+    mut a := v.data[key]
+    if a.data.len == 0 {
+    	a.data = []string
+    }
+    a.data << value
+    v.data[key] = a
+	v.size = v.data.size
 }
 
 // Del deletes the values associated with key.
-fn (v mut Values) del(key string) {
+pub fn (v mut Values) del(key string) {
 	v.data.delete(key)
 	v.size = v.data.size
 }

--- a/vlib/net/urllib/values.v
+++ b/vlib/net/urllib/values.v
@@ -27,14 +27,13 @@ pub fn new_values() Values {
 	}
 }
 
-pub fn (v Value) all() []string {
+pub fn (v &Value) all() []string {
 	return v.data
 }
 
 // Get gets the first value associated with the given key.
-// If there are no values associated with the key, Get returns
-// the empty string. To access multiple values, use the map
-// directly.
+// If there are no values associated with the key, get returns
+// a empty string.
 pub fn (v Values) get(key string) string {
 	if v.data.size == 0 {
 		return ''
@@ -44,6 +43,20 @@ pub fn (v Values) get(key string) string {
 		return ''
 	}
 	return vs.data[0]
+}
+
+// Get gets the all the values associated with the given key.
+// If there are no values associated with the key, get returns
+// a empty []string.
+pub fn (v Values) get_all(key string) []string {
+	if v.data.size == 0 {
+		return []string
+	}
+	vs := v.data[key]
+	if vs.data.len == 0 {
+		return []string
+	}
+	return vs.data
 }
 
 // Set sets the key to value. It replaces any existing

--- a/vlib/net/urllib/values.v
+++ b/vlib/net/urllib/values.v
@@ -21,12 +21,19 @@ mut:
 	size int
 }
 
+// Used for constructing query string parameters
+// can also be to post form data with
+// application/x-www-form-urlencoded
+// values.encode() will return the encoded data
 pub fn new_values() Values {
 	return Values{
 		data: map[string]Value{}
 	}
 }
 
+// Currently you will need to use all()[key].data
+// once map[string][]string is implemented
+// this will be fixed
 pub fn (v &Value) all() []string {
 	return v.data
 }

--- a/vlib/net/urllib/values.v
+++ b/vlib/net/urllib/values.v
@@ -58,12 +58,12 @@ pub fn (v mut Values) set(key, value string) {
 // Add adds the value to key. It appends to any existing
 // values associated with key.
 pub fn (v mut Values) add(key, value string) {
-    mut a := v.data[key]
-    if a.data.len == 0 {
-    	a.data = []string
-    }
-    a.data << value
-    v.data[key] = a
+	mut a := v.data[key]
+	if a.data.len == 0 {
+		a.data = []string
+	}
+	a.data << value
+	v.data[key] = a
 	v.size = v.data.size
 }
 

--- a/vlib/net/urllib/values.v
+++ b/vlib/net/urllib/values.v
@@ -92,7 +92,3 @@ pub fn (v mut Values) del(key string) {
 	v.data.delete(key)
 	v.size = v.data.size
 }
-
-pub fn (v Values) iter() map[string]Value {
-	return v.data
-}

--- a/vlib/net/urllib/values.v
+++ b/vlib/net/urllib/values.v
@@ -21,9 +21,9 @@ mut:
 	size int
 }
 
-// Used for constructing query string parameters
-// can also be to post form data with
-// application/x-www-form-urlencoded
+// new_values returns a new Values struct for creating
+// urlencoded query string parameters. it can also be to 
+// post form data with application/x-www-form-urlencoded.
 // values.encode() will return the encoded data
 pub fn new_values() Values {
 	return Values{
@@ -38,7 +38,7 @@ pub fn (v &Value) all() []string {
 	return v.data
 }
 
-// Get gets the first value associated with the given key.
+// get gets the first value associated with the given key.
 // If there are no values associated with the key, get returns
 // a empty string.
 pub fn (v Values) get(key string) string {
@@ -52,7 +52,7 @@ pub fn (v Values) get(key string) string {
 	return vs.data[0]
 }
 
-// Get gets the all the values associated with the given key.
+// get_all gets the all the values associated with the given key.
 // If there are no values associated with the key, get returns
 // a empty []string.
 pub fn (v Values) get_all(key string) []string {
@@ -66,7 +66,7 @@ pub fn (v Values) get_all(key string) []string {
 	return vs.data
 }
 
-// Set sets the key to value. It replaces any existing
+// set sets the key to value. It replaces any existing
 // values.
 pub fn (v mut Values) set(key, value string) {
 	mut a := v.data[key]
@@ -75,7 +75,7 @@ pub fn (v mut Values) set(key, value string) {
 	v.size = v.data.size
 }
 
-// Add adds the value to key. It appends to any existing
+// add adds the value to key. It appends to any existing
 // values associated with key.
 pub fn (v mut Values) add(key, value string) {
 	mut a := v.data[key]
@@ -87,7 +87,7 @@ pub fn (v mut Values) add(key, value string) {
 	v.size = v.data.size
 }
 
-// Del deletes the values associated with key.
+// del deletes the values associated with key.
 pub fn (v mut Values) del(key string) {
 	v.data.delete(key)
 	v.size = v.data.size


### PR DESCRIPTION
Now this works as it's supposed to:
```
import net.urllib

fn main() {
    mut data := urllib.new_values()
    data.add('firsname', 'joe')
    data.add('lastname', 'conigliaro')
    data.add('age', '34')
    data.add('test', '1%$1=&()-*')
    println(data.encode())
}
```
Prints: `age=34&firsname=joe&lastname=conigliaro&test=1%25%241%3D%26%28%29-%2A`
