### PR TITLE
hash.crc32: modify sum methods to take []byte instead of string

### DIFF
--- a/vlib/hash/crc32/crc32.v
+++ b/vlib/hash/crc32/crc32.v
@@ -37,16 +37,16 @@ fn(c mut Crc32) generate_table(poly int) {
 	}
 }
  
-fn(c &Crc32) sum32(s string) u32 {
+fn(c &Crc32) sum32(b []byte) u32 {
 	mut crc := ~u32(0)
-	for i := 0; i < s.len; i++ {
-		crc = c.table[byte(crc)^s[i]] ^ u32(crc >> u32(8))
+	for i := 0; i < b.len; i++ {
+		crc = c.table[byte(crc)^b[i]] ^ u32(crc >> u32(8))
 	}
 	return ~crc
 }
 
-pub fn(c &Crc32) checksum(s string) u32 {
-	return c.sum32(s)
+pub fn(c &Crc32) checksum(b []byte) u32 {
+	return c.sum32(b)
 }
 
 // pass the polinomial to use
@@ -57,8 +57,7 @@ pub fn new(poly int) *Crc32 {
 }
 
 // calculate crc32 using IEEE
-pub fn sum(s string) u32 {
+pub fn sum(b []byte) u32 {
 	mut c := new(IEEE)
-	return c.sum32(s)
+	return c.sum32(b)
 }
-

--- a/vlib/hash/crc32/crc32_test.v
+++ b/vlib/hash/crc32/crc32_test.v
@@ -1,10 +1,15 @@
 import hash.crc32
 
 fn test_hash_crc32() {
-	assert crc32.sum('testing crc32') == u32(1212124400)
-	assert crc32.sum('testing crc32').hex() == '0x483f8cf0'
+	b1 := 'testing crc32'.bytes()
+	sum1 := crc32.sum(b1)
+	assert sum1 == u32(1212124400)
+	assert sum1.hex() == '0x483f8cf0'
 
+	
 	c := crc32.new(crc32.IEEE)
-	assert c.checksum('testing crc32 again') == u32(1420327025)
-	assert c.checksum('testing crc32 again').hex() == '0x54a87871'
+	b2 := 'testing crc32 again'.bytes()
+	sum2 := c.checksum(b2)
+	assert sum2 == u32(1420327025)
+	assert sum2.hex() == '0x54a87871'
 }


### PR DESCRIPTION
This was supposed to be changed a while back but i forgot.