### PR TITLE
vweb assets: the assets cache files are now immutable after creation.

### DIFF
--- a/vlib/vweb/assets/assets.v
+++ b/vlib/vweb/assets/assets.v
@@ -77,13 +77,13 @@ fn (am mut AssetManager) combine(asset_type string, to_file bool) string {
 	mut out := ''
 	// use cache 
 	if os.file_exists(out_file) {
+		if to_file {
+			return out_file
+		}    	
 		cached := os.read_file(out_file) or {
 			return ''
 		}
-		out = cached
-		if !to_file {
-			return out
-		}
+		return cached
 	}
 	// rebuild
 	for asset in am.get_assets(asset_type) {


### PR DESCRIPTION
After running the example below several times, the contents of the assets were appended several times in the cache/ files. This PR generates cache/*.js and cache/*.css files only once, after that they will be  immutable.

```
import (
    vweb.assets
)

mut am := assets.new_manager()
am.cache_dir = 'cache'
am.minify = true
am.add_css('assets/css/a.css')
am.add_css('assets/css/b.css')
am.add_js('assets/js/a.js')
am.add_js('assets/js/b.js')

println(am.include_css(false))
println(am.include_js(false))

println(am.include_css(true))
println(am.include_js(true))
```
