### PR TITLE
compiler: fix a syntax error in os.v in Freebsd case.

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -692,7 +692,7 @@ pub fn executable() string {
 	}
 	$if freebsd {
 		mut result := malloc(MAX_PATH)
-		mut mib := [1 /* CTL_KERN */, 14 /* KERN_PROC */, 12 /* KERN_PROC_PATHNAME */, -1]!! 
+		mut mib := [1 /* CTL_KERN */, 14 /* KERN_PROC */, 12 /* KERN_PROC_PATHNAME */, -1]
 		size := MAX_PATH 
 		C.sysctl(mib, 4, result, &size, 0, 0) 
 		return string(result) 


### PR DESCRIPTION
Ability to compile V on FreeBSD 12.
Fixes issue #1457 (need to test on a real/virtual freebsd machine) ?