### PR TITLE
net connect: fix error/return type

### DIFF
--- a/vlib/net/socket.v
+++ b/vlib/net/socket.v
@@ -188,7 +188,7 @@ pub fn (s Socket) connect(address string, port int) ?int {
 	if info_res != 0 {
 		return error('socket: connect failed')
 	}
-	res := C.connect(s.sockfd, info.ai_addr, info.ai_addrlen)
+	res := int(C.connect(s.sockfd, info.ai_addr, info.ai_addrlen))
 	if res < 0 {
 		return error('socket: connect failed')
 	}


### PR DESCRIPTION
I found out that net connect doesn't return an error on linux, eg: when no server is listening on the given port
This is due to the fact that unix connect returns an int, and current v net connect implementation generates C code that expects an void* return type, and tries to test it like an int which is an error
I found a trivial fix actually inspired from other net functions, that explicitly cast C.connect return to be an int and it works
not tested on windows, mac, etc..