### PR TITLE
Fix for installation not equal /usr/local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ release: CFLAGS += -pie
 release: clean v-release thirdparty-release
 
 install: uninstall
-	mkdir -p ${PREFIX}/lib/vlang
+	mkdir -p ${PREFIX}/lib/vlang ${PREFI}/bin
 	cp -r {v,vlib,thirdparty} ${PREFIX}/lib/vlang
 	ln -s ${PREFIX}/lib/vlang/v ${PREFIX}/bin/v
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ release: CFLAGS += -pie
 release: clean v-release thirdparty-release
 
 install: uninstall
-	mkdir -p ${PREFIX}/lib/vlang ${PREFI}/bin
+	mkdir -p ${PREFIX}/lib/vlang ${PREFIX}/bin
 	cp -r {v,vlib,thirdparty} ${PREFIX}/lib/vlang
 	ln -s ${PREFIX}/lib/vlang/v ${PREFIX}/bin/v
 


### PR DESCRIPTION
This PR allows for an installation, say to /opt/v.

Previously, if ${PREFIX}/bin did not exist, the installation would fail to create a symbolic link from ${PREFIX}/lib/vlang/v to ${PREFIX}/bin/v.
