### PR TITLE
Fix for jsdecode struct initialisation

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -3278,7 +3278,7 @@ fn (p mut Parser) js_decode() string {
 		for field in T.fields {
 			def_val := type_default(field.typ)
 			if def_val != '' {
-				decl += '$tmp . $field.name = $def_val;\n'
+				decl += '$tmp . $field.name = OPTION_CAST($field.typ) $def_val;\n'
 			}
 		}
 		p.gen_json_for_type(T)


### PR DESCRIPTION
Fixes #1441 where js_decode wasnt casting struct default values and GCC couldnt infer them as an expression.

Not sure whether this is correct for MSVC - will check when I get back to my windows box in ~1 week (unless someone does it before me)