### PR TITLE
CI: Windows - build and test both msvc and gcc

### DIFF
--- a/make_tests.bat
+++ b/make_tests.bat
@@ -3,9 +3,14 @@ curl -O https://raw.githubusercontent.com/vlang/vc/master/v.c
 gcc -std=gnu11 -DUNICODE -D_UNICODE -w -o vc.exe v.c
 del v.c
 vc.exe -o v.exe compiler
+vc.exe -o v.msvc.exe compiler
 setlocal EnableDelayedExpansion
 for /r . %%x in (*_test.v) do (
   v -o test.exe -debug %%x
+  if !ERRORLEVEL! NEQ 0 goto :fail
+)
+for /r . %%x in (*_test.v) do (
+  v.msvc -o test.exe -debug %%x
   if !ERRORLEVEL! NEQ 0 goto :fail
 )
 goto :done

--- a/make_tests.bat
+++ b/make_tests.bat
@@ -3,14 +3,24 @@ curl -O https://raw.githubusercontent.com/vlang/vc/master/v.c
 gcc -std=gnu11 -DUNICODE -D_UNICODE -w -o vc.exe v.c
 del v.c
 vc.exe -o v.exe compiler
-vc.exe -o v.msvc.exe compiler
+vc.exe -os msvc -o v.msvc.exe compiler
+v.msvc.exe -os msvc -o v.msvc.2.exe compiler
+v.msvc.exe -o v.gcc.exe compiler
 setlocal EnableDelayedExpansion
 for /r . %%x in (*_test.v) do (
   v -o test.exe -debug %%x
   if !ERRORLEVEL! NEQ 0 goto :fail
 )
 for /r . %%x in (*_test.v) do (
-  v.msvc -o test.exe -debug %%x
+  v.msvc.exe -o test.exe -debug %%x
+  if !ERRORLEVEL! NEQ 0 goto :fail
+)
+for /r . %%x in (*_test.v) do (
+  v.msvc.2.exe -o test.exe -debug %%x
+  if !ERRORLEVEL! NEQ 0 goto :fail
+)
+for /r . %%x in (*_test.v) do (
+  v.gcc.exe -o test.exe -debug %%x
   if !ERRORLEVEL! NEQ 0 goto :fail
 )
 goto :done

--- a/make_tests.bat
+++ b/make_tests.bat
@@ -4,6 +4,7 @@ gcc -std=gnu11 -DUNICODE -D_UNICODE -w -o vc.exe v.c
 del v.c
 vc.exe -o v.exe compiler
 vc.exe -os msvc -o v.msvc.exe compiler
+dir
 v.msvc.exe -os msvc -o v.msvc.2.exe compiler
 v.msvc.exe -o v.gcc.exe compiler
 setlocal EnableDelayedExpansion

--- a/make_tests.bat
+++ b/make_tests.bat
@@ -6,7 +6,7 @@ del v.c
 "%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
 
 vc.exe -o v.exe compiler
-vc.exe -os msvc -o v.msvc.exe compiler
+v.exe -os msvc -o v.msvc.exe compiler
 v.msvc.exe -os msvc -o v.msvc.2.exe compiler
 v.msvc.exe -o v.gcc.exe compiler
 

--- a/make_tests.bat
+++ b/make_tests.bat
@@ -9,6 +9,9 @@ vc.exe -o v.exe compiler
 vc.exe -os msvc -o v.msvc.exe compiler
 v.msvc.exe -os msvc -o v.msvc.2.exe compiler
 v.msvc.exe -o v.gcc.exe compiler
+
+dir
+
 setlocal EnableDelayedExpansion
 for /r . %%x in (*_test.v) do (
   v -o test.exe -debug %%x

--- a/make_tests.bat
+++ b/make_tests.bat
@@ -1,17 +1,11 @@
-REM @echo off
+@echo off
 curl -O https://raw.githubusercontent.com/vlang/vc/master/v.c
 gcc -std=gnu11 -DUNICODE -D_UNICODE -w -o vc.exe v.c
 del v.c
-
-"%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
-
 vc.exe -o v.exe compiler
 v.exe -os msvc -o v.msvc.exe compiler
 v.msvc.exe -os msvc -o v.msvc.2.exe compiler
 v.msvc.exe -o v.gcc.exe compiler
-
-dir
-
 setlocal EnableDelayedExpansion
 for /r . %%x in (*_test.v) do (
   v -o test.exe -debug %%x

--- a/make_tests.bat
+++ b/make_tests.bat
@@ -1,10 +1,12 @@
-@echo off
+REM @echo off
 curl -O https://raw.githubusercontent.com/vlang/vc/master/v.c
 gcc -std=gnu11 -DUNICODE -D_UNICODE -w -o vc.exe v.c
 del v.c
+
+"%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+
 vc.exe -o v.exe compiler
 vc.exe -os msvc -o v.msvc.exe compiler
-dir
 v.msvc.exe -os msvc -o v.msvc.2.exe compiler
 v.msvc.exe -o v.gcc.exe compiler
 setlocal EnableDelayedExpansion


### PR DESCRIPTION
Make sure that msvc doesnt regress.

At some point we should also be able to bootstrap with msvc - but for that we need to be able to `#ifdef` guard `dirent.h` and `unistd.h` (becuase the v.c file is generated on a nix platform they are included - but not available on msvc windows - this could be done with a find replace for those lines into nothing but that seems dodgy).