### PR TITLE
add @VMOD to resolve modules path

### DIFF
--- a/compiler/comptime.v
+++ b/compiler/comptime.v
@@ -151,8 +151,7 @@ fn (p mut Parser) chash() {
 		}
 		// expand `@VMOD/pg/pg.o` to absolute path
 		has_vmod := flag.contains('@VMOD')
-		home := os.home_dir()
-		flag = flag.trim_space().replace('@VMOD', home + '/.vmodules')
+		flag = flag.trim_space().replace('@VMOD', ModPath)
 		if p.table.flags.contains(flag) {
 			return
 		}

--- a/compiler/comptime.v
+++ b/compiler/comptime.v
@@ -149,9 +149,16 @@ fn (p mut Parser) chash() {
 		if p.table.flags.contains(flag) {
 			return
 		}
+		// expand `@VMOD/pg/pg.o` to absolute path
+		has_vmod := flag.contains('@VMOD')
+		home := os.home_dir()
+		flag = flag.trim_space().replace('@VMOD', home + '/.vmodules')
+		if p.table.flags.contains(flag) {
+			return
+		}
 		p.log('adding flag "$flag"')
 		// `@VROOT/thirdparty/glad/glad.o`, make sure it exists, otherwise build it 
-		if has_vroot && flag.contains('.o') {
+		if (has_vroot || has_vmod) && flag.contains('.o') {
 			if p.os == .msvc {
 				build_thirdparty_obj_file_with_msvc(flag)
 			} 


### PR DESCRIPTION
Currently I don't see any way to compile v modules with c dependencies.
WIth @VMOD you could able to write like following without having to have c files included in vlang/v main repository.

```
#flag -I @VMOD/glad
#flag @VMOD/glad/glad.o
#include "glad.h"
```

