### PR TITLE
vget: clone with depth 1 and use module name instead of repository name

### DIFF
--- a/tools/vget.v
+++ b/tools/vget.v
@@ -27,7 +27,7 @@ fn main() {
 	s := http.get_text(url + '/jsmod/$name') 
 	mod := json.decode(Mod, s) or { return } 
 	home := os.home_dir() 
-	os.exec('git -C "$home/.vmodules" clone $mod.url') 
+	os.exec('git -C "$home/.vmodules" clone --depth=1 $mod.url $mod.name')
 	println(s) 
 } 
 


### PR DESCRIPTION
- git clone can be done with depth 1, because you don't need history anyway.
- sometimes repository name can be different for module name, like github.com/A/B.v but module name is B.