### PR TITLE
socket: WSACleanup should not be called on socket close

### DIFF
--- a/vlib/net/socket.v
+++ b/vlib/net/socket.v
@@ -227,11 +227,6 @@ pub fn (s Socket) recv(bufsize int) byteptr {
 
 // shutdown and close socket
 pub fn (s Socket) close() ?int {
-	// WinSock
-	$if windows {
-		C.WSACleanup()
-	}
-
 	mut shutdown_res := 0
 	$if windows {
 		shutdown_res = C.shutdown(s.sockfd, SD_BOTH)


### PR DESCRIPTION
Winsock initialization/cleanup should only be called on program start/end (do we have the way to run some code on module init/deinit?)