### PR TITLE
vget.v: Create VModules directory before git clone

### DIFF
--- a/tools/vget.v
+++ b/tools/vget.v
@@ -30,7 +30,12 @@ fn main() {
 		return
 	} 
 	home := os.home_dir() 
+    if !os.dir_exists(home + '/.vmodules') {
+	println('Creating vmodules directory...') 
+	os.chdir(home) 
+	os.mkdir('.vmodules') 
+	println('Done.') 
+	} 
 	os.exec('git -C "$home/.vmodules" clone --depth=1 $mod.url $mod.name')
 	println(s) 
 } 
-


### PR DESCRIPTION
by default vget is trying to clone modules into a non-existent directory.
This fix will create the ".VModules" directory if it doesn't exist before trying to clone the module.