### PR TITLE
VGet: Fix for dot folder name import

### DIFF
--- a/tools/vget.v
+++ b/tools/vget.v
@@ -30,12 +30,12 @@ fn main() {
 		return
 	} 
 	home := os.home_dir() 
-    if !os.dir_exists(home + '/.vmodules') {
+        if !os.dir_exists(home + '/.vmodules') {
 	println('Creating vmodules directory...') 
 	os.chdir(home) 
 	os.mkdir('.vmodules') 
 	println('Done.') 
 	} 
-	os.exec('git -C "$home/.vmodules" clone --depth=1 $mod.url $mod.name')
+	os.exec('git -C "$home/.vmodules" clone --depth=1 $mod.url ' + mod.name.replace('.', '/'))
 	println(s) 
 } 


### PR DESCRIPTION
Due to conflicts between Submodules and VPM maintainer name at the start of directory name, Importing vpm modules that includes dot in their package name fails.
This PR should clone VPM modules as submodule and fix the problem.