### PR TITLE
log: Adds a logger interface to the std modules

### DIFF
--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -7,10 +7,18 @@ import term
 const (
     FATAL = 1
     ERROR = 2 
-    WARN = 3
-    INFO = 4
-    DEBUG =5
+    WARN  = 3
+    INFO  = 4
+    DEBUG = 5
 )
+
+interface Logger {
+    fatal(s string)
+    error(s string)
+    warn(s string)
+    info(s string)
+    debug(s string)
+}
 
 struct Log{
 mut:


### PR DESCRIPTION
By defining a standard logger interface, it pushes 3rd parties to create logger modules that follow this interface and for the community to standardize on this interface.  

This could prevent issues down the road where every package uses a different type of logger all of which are not compatible. 