### PR TITLE
os.exec: return ?string instead of just string

### DIFF
--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -261,7 +261,10 @@ fn build_thirdparty_obj_file(flag string) {
 		} 
 	} 
 	cc := if os.user_os() == 'windows' { 'gcc' } else { 'cc' } // TODO clang support on Windows  
-	res := os.exec('$cc -fPIC -c -o $obj_path $cfiles') 
+	res := os.exec('$cc -fPIC -c -o $obj_path $cfiles') or {
+		panic(err)
+		return // TODO remove return
+	}
 	println(res) 
 } 
 

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -137,11 +137,17 @@ fn main() {
 			println('Building vget...') 
 			os.chdir(vroot + '/tools') 
 			vexec := os.args[0] 
-			os.exec('$vexec vget.v') 
+			_ := os.exec('$vexec vget.v') or {
+				panic(err)
+				return // TODO remove return
+			}
 			println('Done.') 
 		} 
 		println('Installing module ${mod}...') 
-		os.exec('$vget $mod') 
+		_ := os.exec('$vget $mod') or {
+			panic(err)
+			return // TODO remove return
+		}
 		return 
 	} 
 	// TODO quit if the compiler is too old 
@@ -631,7 +637,10 @@ void reload_so() {
 		ret := os.system(cmd)
 		if ret != 0 {
 			if !v.pref.is_test { 
-				s := os.exec(cmd)
+				s := os.exec(cmd) or {
+					panic(err)
+					return // TODO remove return
+				}
 				println(s)
 				println('failed to run the compiled program')
 			} 
@@ -842,7 +851,10 @@ mut args := ''
 	}
 	// Run
 	ticks := time.ticks() 
-	res := os.exec(cmd)
+	res := os.exec(cmd) or {
+		panic(err)
+		return // TODO remove return
+	}
 	diff := time.ticks() - ticks 
 	// Print the C command
 	if v.pref.show_c_cmd || v.pref.is_verbose {
@@ -876,7 +888,10 @@ mut args := ''
 		'/usr/lib/x86_64-linux-gnu/crti.o ' +
 		obj_file +
 		' /usr/lib/x86_64-linux-gnu/libc.so ' +
-		'/usr/lib/x86_64-linux-gnu/crtn.o')
+		'/usr/lib/x86_64-linux-gnu/crtn.o') or {
+			panic(err)
+			return // TODO remove return
+		}
 		println(ress)
 		if ress.contains('error:') {
 			exit(1)
@@ -1286,7 +1301,10 @@ fn run_repl() []string {
 		if line.starts_with('print') {
 			source_code := lines.join('\n') + '\n' + line 
 			os.write_file(file, source_code)
-			s := os.exec('$vexe run $file -repl')
+			s := os.exec('$vexe run $file -repl') or {
+				panic(err)
+				break // TODO remove break
+			}
 			mut vals := s.split('\n')
 			if s.contains('panic: ') {
 				if !s.contains('declared and not used') 	{
@@ -1313,7 +1331,10 @@ fn run_repl() []string {
 			}
 			temp_source_code := lines.join('\n') + '\n' + temp_line
 			os.write_file(temp_file, temp_source_code)
-			s := os.exec('$vexe run $temp_file -repl')
+			s := os.exec('$vexe run $temp_file -repl') or {
+				panic(err)
+				break // TODO remove break
+			}
 			if s.contains('panic: ') {
 				if !s.contains('declared and not used') 	{
 					mut vals := s.split('\n')
@@ -1389,15 +1410,24 @@ fn env_vflags_and_os_args() []string {
 fn update_v() {
 	println('Updating V...') 
 	vroot := os.dir(os.executable()) 
-	mut s := os.exec('git -C "$vroot" pull --rebase origin master') 
+	s := os.exec('git -C "$vroot" pull --rebase origin master') or {
+		panic(err)
+		return // TODO remove return
+	}
 	println(s) 
 	$if windows { 
 		os.mv('$vroot/v.exe', '$vroot/v_old.exe') 
-		s = os.exec('$vroot/make.bat') 
-		println(s) 
+		s2 := os.exec('$vroot/make.bat') or {
+			panic(err)
+			return // TODO remove return
+		}
+		println(s2) 
 	} $else { 
-		s = os.exec('make -C "$vroot"') 
-		println(s) 
+		s2 := os.exec('make -C "$vroot"') or {
+			panic(err)
+			return // TODO remove return
+		}
+		println(s2) 
 	} 
 } 
 

--- a/compiler/msvc_win.v
+++ b/compiler/msvc_win.v
@@ -344,16 +344,13 @@ pub fn cc_msvc(v *V) {
 
 	// println('$cmd')
 
-	res := os.exec(cmd) or {
-		panic(err)
+	_ := os.exec(cmd) or {
+		println(err)
+		panic('msvc error')
 		return // TODO remove return
 	}
 	// println(res)
 	// println('C OUTPUT:')
-	if res.contains('error') {
-		println(res)
-		panic('msvc error')
-	}
 
 	if !v.pref.is_debug && v.out_name_c != 'v.c' && v.out_name_c != 'v_macos.c' {
 		os.rm('.$v.out_name_c') 

--- a/compiler/msvc_win.v
+++ b/compiler/msvc_win.v
@@ -134,7 +134,10 @@ fn find_vs() ?VsInstallation {
 	// VSWhere is guaranteed to be installed at this location now
 	// If its not there then end user needs to update their visual studio 
 	// installation!
-	res := os.exec('""%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath"')
+	res := os.exec('""%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath"') or {
+		panic(err)
+		return error(err)// TODO remove return
+	}
 	// println('res: "$res"')
 
 	version := os.read_file('$res\\VC\\Auxiliary\\Build\\Microsoft.VCToolsVersion.default.txt') or {
@@ -341,7 +344,10 @@ pub fn cc_msvc(v *V) {
 
 	// println('$cmd')
 
-	res := os.exec(cmd)
+	res := os.exec(cmd) or {
+		panic(err)
+		return // TODO remove return
+	}
 	// println(res)
 	// println('C OUTPUT:')
 	if res.contains('error') {
@@ -386,7 +392,10 @@ fn build_thirdparty_obj_file_with_msvc(flag string) {
 
 	println('$cfiles')
 
-	res := os.exec('""$msvc.exe_path\\cl.exe" /volatile:ms /Z7 $include_string /c $cfiles /Fo"$obj_path" /D_UNICODE /DUNICODE"')
+	res := os.exec('""$msvc.exe_path\\cl.exe" /volatile:ms /Z7 $include_string /c $cfiles /Fo"$obj_path" /D_UNICODE /DUNICODE"') or {
+		panic(err)
+		return // TODO remove return
+	}
 	println(res)
 } 
 

--- a/make_tests.bat
+++ b/make_tests.bat
@@ -26,6 +26,7 @@ for /r . %%x in (*_test.v) do (
 goto :done
 
 :fail
+echo fail
 exit /b 1
 
 :done

--- a/tools/vget.v
+++ b/tools/vget.v
@@ -36,6 +36,9 @@ fn main() {
 	os.mkdir('.vmodules') 
 	println('Done.') 
 	} 
-	os.exec('git -C "$home/.vmodules" clone --depth=1 $mod.url ' + mod.name.replace('.', '/'))
+	_ := os.exec('git -C "$home/.vmodules" clone --depth=1 $mod.url ' + mod.name.replace('.', '/')) or {
+		panic(err)
+		return // TODO remove return
+	}
 	println(s) 
 } 

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -346,8 +346,8 @@ fn pclose(f *FILE) int {
 }
 
 // exec starts the specified command, waits for it to complete, and returns its output.
-pub fn exec(cmd string) ?string {
-	cmd = '$cmd 2>&1'
+pub fn exec(_cmd string) ?string {
+	cmd := '$_cmd 2>&1'
 	f := popen(cmd)
 	if isnil(f) {
 		return error('popen $cmd failed')


### PR DESCRIPTION
This changes os.exec to return a ?string, based on if the command ran successfully.
- Return the error 'popen $cmd failed' if the popen call failed.
- Return the command's output as an error if the return code was non-zero.
- Otherwise return the output as a string.

Also updated all the calls to os.exec to handle the option type.