### PR TITLE
Compiler: Scoped defer + Build tests with msvc

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1069,9 +1069,15 @@ fn (p mut Parser) close_scope() {
 			else if v.ptr {
 				//p.genln('free($v.name); // close_scope free') 
 			} 
-		} 
-
+		}
 	}
+
+	if p.cur_fn.defer_text != '' {
+		println('scope closed')
+		p.genln(p.cur_fn.defer_text)
+		p.cur_fn.defer_text = ''
+	}
+
 	p.cur_fn.var_idx = i + 1
 	// println('close_scope new var_idx=$f.var_idx\n')
 	p.cur_fn.scope_level--

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1072,16 +1072,15 @@ fn (p mut Parser) close_scope() {
 		}
 	}
 
-	if p.cur_fn.defer_text != '' {
-		println('scope closed')
-		p.genln(p.cur_fn.defer_text)
-		p.cur_fn.defer_text = ''
+	if p.cur_fn.defer_text.last() != '' {
+		p.genln(p.cur_fn.defer_text.last())
+		//p.cur_fn.defer_text[f] = ''
 	}
-
+	
+	p.cur_fn.close_scope()
 	p.cur_fn.var_idx = i + 1
 	// println('close_scope new var_idx=$f.var_idx\n')
-	p.cur_fn.scope_level--
-} 
+}
 
 fn (p mut Parser) genln(s string) {
 	p.cgen.genln(s)
@@ -3243,13 +3242,27 @@ fn (p mut Parser) return_st() {
 			}
 			else {
 				ret := p.cgen.cur_line.right(ph)
-				p.cgen(p.cur_fn.defer_text) 
-				if p.cur_fn.defer_text == '' || expr_type == 'void*' { 
+
+				// @emily33901: Scoped defer
+				// Check all of our defer texts to see if there is one at a higher scope level
+				// The one for our current scope would be the last so any before that need to be
+				// added.
+
+				mut total_text := ''
+
+				for text in p.cur_fn.defer_text {
+					if text != '' {
+						// In reverse order
+						total_text = text + total_text
+					}
+				}
+
+				if total_text == '' || expr_type == 'void*' {
 					p.cgen.resetln('return $ret')
 				}  else { 
 					tmp := p.get_tmp() 
 					p.cgen.resetln('$expr_type $tmp = $ret;\n')
-					p.genln(p.cur_fn.defer_text) 
+					p.genln(total_text)
 					p.genln('return $tmp;') 
 				} 
 			}
@@ -3403,9 +3416,14 @@ fn (p mut Parser) defer_st() {
 
 	// Save everything inside the defer block to `defer_text`.
 	// It will be inserted before every `return`
+
+	// Emily: TODO: all variables that are used in this defer statement need to be evaluated when the block
+	// is defined otherwise they could change over the course of the function
+	// (make temps out of them)
+
 	p.genln('{') 
 	p.statements() 
-	p.cur_fn.defer_text = p.cgen.lines.right(pos).join('\n') + p.cur_fn.defer_text 
+	p.cur_fn.defer_text.last() = p.cgen.lines.right(pos).join('\n') + p.cur_fn.defer_text.last()
 
 	// Rollback p.cgen.lines
 	p.cgen.lines = p.cgen.lines.left(pos)

--- a/make_tests.bat
+++ b/make_tests.bat
@@ -1,11 +1,20 @@
 @echo off
 curl -O https://raw.githubusercontent.com/vlang/vc/master/v.c
+
+echo DOWNLOAD COMPLETE
+
 gcc -std=gnu11 -DUNICODE -D_UNICODE -w -o vc.exe v.c
+
+echo BUILD COMPLETE
+
 del v.c
+
 vc.exe -o v.exe compiler
 v.exe -os msvc -o v.msvc.exe compiler
 v.msvc.exe -os msvc -o v.msvc.2.exe compiler
 v.msvc.exe -o v.gcc.exe compiler
+
+
 setlocal EnableDelayedExpansion
 for /r . %%x in (*_test.v) do (
   v -o test.exe -debug %%x
@@ -23,6 +32,24 @@ for /r . %%x in (*_test.v) do (
   v.gcc.exe -o test.exe -debug %%x
   if !ERRORLEVEL! NEQ 0 goto :fail
 )
+
+for /r . %%x in (*_test.v) do (
+  v -os msvc -o test.exe -debug %%x
+  if !ERRORLEVEL! NEQ 0 goto :fail
+)
+for /r . %%x in (*_test.v) do (
+  v.msvc.exe -os msvc -o test.exe -debug %%x
+  if !ERRORLEVEL! NEQ 0 goto :fail
+)
+for /r . %%x in (*_test.v) do (
+  v.msvc.2.exe -os msvc -o test.exe -debug %%x
+  if !ERRORLEVEL! NEQ 0 goto :fail
+)
+for /r . %%x in (*_test.v) do (
+  v.gcc.exe -os msvc -o test.exe -debug %%x
+  if !ERRORLEVEL! NEQ 0 goto :fail
+)
+
 goto :done
 
 :fail

--- a/make_tests.bat
+++ b/make_tests.bat
@@ -1,22 +1,13 @@
-REM @echo off
+@echo off
+
 curl -O https://raw.githubusercontent.com/vlang/vc/master/v.c
-
-echo DOWNLOAD COMPLETE
-
 gcc -std=gnu11 -DUNICODE -D_UNICODE -w -o vc.exe v.c
-
-echo BUILD COMPLETE
-
-dir
-
 del v.c
 
 vc.exe -o v.exe compiler
 v.exe -os msvc -o v.msvc.exe compiler
 v.msvc.exe -os msvc -o v.msvc.2.exe compiler
 v.msvc.exe -o v.gcc.exe compiler
-
-dir
 
 setlocal EnableDelayedExpansion
 for /r . %%x in (*_test.v) do (
@@ -27,14 +18,6 @@ for /r . %%x in (*_test.v) do (
   v.msvc.exe -o test.exe -debug %%x
   if !ERRORLEVEL! NEQ 0 goto :fail
 )
-for /r . %%x in (*_test.v) do (
-  v.msvc.2.exe -o test.exe -debug %%x
-  if !ERRORLEVEL! NEQ 0 goto :fail
-)
-for /r . %%x in (*_test.v) do (
-  v.gcc.exe -o test.exe -debug %%x
-  if !ERRORLEVEL! NEQ 0 goto :fail
-)
 
 for /r . %%x in (*_test.v) do (
   v -os msvc -o test.exe -debug %%x
@@ -42,14 +25,6 @@ for /r . %%x in (*_test.v) do (
 )
 for /r . %%x in (*_test.v) do (
   v.msvc.exe -os msvc -o test.exe -debug %%x
-  if !ERRORLEVEL! NEQ 0 goto :fail
-)
-for /r . %%x in (*_test.v) do (
-  v.msvc.2.exe -os msvc -o test.exe -debug %%x
-  if !ERRORLEVEL! NEQ 0 goto :fail
-)
-for /r . %%x in (*_test.v) do (
-  v.gcc.exe -os msvc -o test.exe -debug %%x
   if !ERRORLEVEL! NEQ 0 goto :fail
 )
 

--- a/make_tests.bat
+++ b/make_tests.bat
@@ -7,6 +7,8 @@ gcc -std=gnu11 -DUNICODE -D_UNICODE -w -o vc.exe v.c
 
 echo BUILD COMPLETE
 
+dir
+
 del v.c
 
 vc.exe -o v.exe compiler
@@ -14,6 +16,7 @@ v.exe -os msvc -o v.msvc.exe compiler
 v.msvc.exe -os msvc -o v.msvc.2.exe compiler
 v.msvc.exe -o v.gcc.exe compiler
 
+dir
 
 setlocal EnableDelayedExpansion
 for /r . %%x in (*_test.v) do (

--- a/make_tests.bat
+++ b/make_tests.bat
@@ -1,4 +1,4 @@
-@echo off
+REM @echo off
 curl -O https://raw.githubusercontent.com/vlang/vc/master/v.c
 
 echo DOWNLOAD COMPLETE

--- a/vlib/crypto/rand/rand_win.v
+++ b/vlib/crypto/rand/rand_win.v
@@ -4,7 +4,8 @@
 
 module rand
 
-#flag windows -Llibraries/bcrypt -lbcrypt
+#flag windows -Llibraries/bcrypt
+#flag windows -lbcrypt
 #include <bcrypt.h>
 
 const (

--- a/vlib/math/stats_test.v
+++ b/vlib/math/stats_test.v
@@ -37,7 +37,7 @@ fn test_geometric_mean() {
 	o = stats.geometric_mean(data)
 	println(o)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('nan') || o.str().eq('-nan') || o.str().eq('-1.#IND00') || o == f64(0) || o.str.eq('-nan(ind)') // Because in math it yields a complex number
+	assert o.str().eq('nan') || o.str().eq('-nan') || o.str().eq('-1.#IND00') || o == f64(0) || o.str().eq('-nan(ind)') // Because in math it yields a complex number
 	data = [f64(12.0),f64(7.88),f64(76.122),f64(54.83)]
 	o = stats.geometric_mean(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string

--- a/vlib/math/stats_test.v
+++ b/vlib/math/stats_test.v
@@ -37,7 +37,7 @@ fn test_geometric_mean() {
 	o = stats.geometric_mean(data)
 	println(o)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('nan') || o.str().eq('-nan') || o.str().eq('-1.#IND00') || o == f64(0) // Because in math it yields a complex number
+	assert o.str().eq('nan') || o.str().eq('-nan') || o.str().eq('-1.#IND00') || o == f64(0) || o.str.eq('-nan(ind)') // Because in math it yields a complex number
 	data = [f64(12.0),f64(7.88),f64(76.122),f64(54.83)]
 	o = stats.geometric_mean(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string


### PR DESCRIPTION
Changes defer to perform at the end of every scope (including returns) as opposed to singularly at the end of functions - I think this makes more sense and could also be more useful. 

It may also end up that having a non-scoped defer and using lambdas to control defers may be better (like is done in go). 

And building tests with `-os msvc` instead of just with the msvc built compiler to make sure it doesnt regress for real!