### PR TITLE
vlib: properly add submodule to types. fixes unknown type for arrays using submodule type etc.

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -931,6 +931,15 @@ fn (p mut Parser) get_type() string {
 		// "typ" not found? try "mod__typ"
 		if t.name == '' && !p.builtin_mod {
 			// && !p.first_pass() {
+			// we are a module
+			if typ.contains('__') {
+				// so try resolve full submodule
+				mod := p.import_table.resolve_alias(p.lit).replace('.', '_dot_')
+				if mod != '' {
+					typ = prepend_mod(mod, typ)
+				}
+			}
+			t = p.table.find_type(typ)
 			if !typ.contains('array_') && p.mod != 'main' && !typ.contains('__') &&
 				!typ.starts_with('[') { 
 				typ = p.prepend_mod(typ)


### PR DESCRIPTION
vlib: properly add submodule to types. fixes unknown type for arrays using submodule type etc.

fixes the error cause by the type not being found for ` []vgram.Update{}` as it's from a user module vpervenditti.vgram

example:
```
import vgram
bot := vgram.new_bot('TOKEN', false) // <- set true to see debug log
mut updates := []vgram.Update{} // 
```