### PR TITLE
option.v: allocate the struct size on the stack instead of using a hardcoded size

### DIFF
--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -5,19 +5,18 @@
 module builtin
 
 struct Option {
-	data [500]byte 
+	data *byte
 	error string
 	ok    bool
 }
 
 // `fn foo() ?Foo { return foo }` => `fn foo() ?Foo { return opt_ok(foo); }`
 fn opt_ok(data voidptr, size int) Option {
-	if size >= 500 {
-		panic('option size too big: $size (max is 500), this is a temporary limit') 
-	} 
-	res := Option { 
+	res := Option {
 		ok: true
+		data : C.alloca(size)
 	}
+
 	C.memcpy(res.data, data, size) 
 	return res 
 }


### PR DESCRIPTION
This allows an arbitrary size struct to be returned as an option (fixing the problem with vgram).

Structs that are still too big will lead to a segmentation fault as the maximum struct size is exceeded - this would need to be fixed with some form of alternative allocation either on the heap or with magic (which would then require some `opt_cleanup()` function that could be implemented fairly easily and would need to be cgened after opts for structs of a large size.