### PR TITLE
compiler: -show_c_cmd should always print the C compiler command

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -876,6 +876,10 @@ mut args := ''
 		exit(0)
 	}
 	// Run
+	if v.pref.show_c_cmd || v.pref.is_verbose {
+		println('\n==========')
+		println(cmd)
+	}    
 	ticks := time.ticks() 
 	_ := os.exec(cmd) or {
 		if v.pref.is_debug {
@@ -893,8 +897,6 @@ mut args := ''
 	diff := time.ticks() - ticks 
 	// Print the C command
 	if v.pref.show_c_cmd || v.pref.is_verbose {
-		println('\n==========')
-		println(cmd) 
 		println('cc took $diff ms') 
 		println('=========\n')
 	}


### PR DESCRIPTION
When debugging compiler/C library linking issues, it is useful to know the full C compiler invokation. 
The -show_c_cmd is meant to do that. When the compiler invokation fails however for any reason, the code that prints the c command is not reached.

This PR makes the printing code run before the c compiler is invoked.

Example before:
```
0[12:10:41]/v/v $ /v/v/v tools/vget.v     
/tmp/ccvmSzmi.o: In function `http__init_module':
/v/v/.vget.c:7611: undefined reference to `SSL_library_init'
collect2: error: ld returned 1 exit statusV panic: C error. This should never happen. Please create a GitHub issue: https://github.com/vlang/v/issues/new/choose
148[12:10:59]/v/v $ /v/v/v -show_c_cmd tools/vget.v   
/tmp/cc4kG9CD.o: In function `http__init_module':
/v/v/.vget.c:7611: undefined reference to `SSL_library_init'
collect2: error: ld returned 1 exit statusV panic: C error. This should never happen. Please create a GitHub issue: https://github.com/vlang/v/issues/new/choose
1[12:11:01]/v/v $
```

Example after:
```
0[12:25:17]/v/v $ /v/v/v -show_c_cmd tools/vget.v

==========
cc  -std=gnu11 -w -g -o tools/vget ".vget.c" -I /v/v/thirdparty/cJSON /v/v/thirdparty/cJSON/cJSON.o -lssl -lcrypto  -lm -lpthread   -ldl 
/tmp/ccyswstK.o: In function `http__init_module':
/v/v/.vget.c:7611: undefined reference to `OPENSSL_init_ssl'
/tmp/ccyswstK.o: In function `http__ssl_do':
/v/v/.vget.c:7638: undefined reference to `S...
(Use `v -debug` to print the entire error message)

V panic: C error. This should never happen. Please create a GitHub issue: https://github.com/vlang/v/issues/new/choose
1[12:25:20]/v/v $ 
```