### PR TITLE
REPL: checks if EOF

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -1314,8 +1314,11 @@ fn run_repl() []string {
 			continue
 		}
 		line = line.trim_space()
-		if line == '' || line == 'exit' {
+		if line.len == -1 || line == '' || line == 'exit' {
 			break
+		}
+		if line == '\n' {
+			continue
 		}
 		// Save the source only if the user is printing something,
 		// but don't add this print call to the `lines` array,


### PR DESCRIPTION
Will now check if given string is EOF, or else REPL will try to create an empty `println`.

Fix #1533 