### PR TITLE
freetype,gg: option to pass a custom font_path to freetype.new_context

### DIFF
--- a/vlib/freetype/freetype.v
+++ b/vlib/freetype/freetype.v
@@ -151,17 +151,20 @@ pub fn new_context(cfg gg.Cfg, scale int) *Context {
 	println('ERROR::FREETYPE: Could not init FreeType Library')
 	// Load font as face
 	// face := FT_Face{}
-	mut font_path := 'RobotoMono-Regular.ttf'
+	mut font_path := cfg.font_path
+	if font_path == '' {
+		font_path = 'RobotoMono-Regular.ttf'
+	}
 	if !os.file_exists(font_path) {
 		exe_path := os.executable()
 		exe_dir := os.basedir(exe_path)
-		println('Trying to load from $exe_dir')
-		font_path = '$exe_dir/RobotoMono-Regular.ttf'
+		font_path = '$exe_dir/$font_path'
 	}
 	if !os.file_exists(font_path) {
-		println('failed to load RobotoMono-Regular.ttf')
+		println('failed to load $font_path')
 		return 0
 	}
+	println('Trying to load font from $font_path')
 	# FT_Face face;
 	# if (FT_New_Face(ft, font_path.str, 0, &face))
 	// # if (FT_New_Face(ft, "/Library/Fonts/Courier New.ttf", 0, &face))

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -48,6 +48,7 @@ pub:
 	retina    bool
 	 
 	font_size int
+	font_path string
 	create_window bool 
 	window_user_ptr voidptr 
 	window_title string 


### PR DESCRIPTION
Makes possible:
```
    game.ft = freetype.new_context(gg.Cfg{
                                          width: WinWidth
                                          height: WinHeight
                                          use_ortho: true
                                          font_size: 18
                                          font_path: 'assets/GameFont.ttf'
                                          }, 1)
```
