### PR TITLE
repl: delete binary files when exiting

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -1304,6 +1304,8 @@ fn run_repl() []string {
 	defer {
 		os.rm(file) 
 		os.rm(temp_file) 
+		os.rm(file.left(file.len - 2))
+		os.rm(temp_file.left(temp_file.len - 2))
 	} 
 	mut lines := []string
 	vexe := os.args[0] 


### PR DESCRIPTION
Will delete created repl binaries to help echo piping work on V REPL.
It is also good for the user as it would not have hidden REPL binaries on its computer.

Fix #1540 