### PR TITLE
v run: windows and repl fixes

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -657,7 +657,7 @@ fn (v V) run_compiled_executable_and_exit() {
 	if v.pref.is_verbose {
 		println('============ running $v.out_name ============') 
 	}	  
-	mut cmd := final_target_out_name(v.out_name)
+	mut cmd := final_target_out_name(v.out_name).replace('.exe','')
 	if os.args.len > 3 {
 		cmd += ' ' + os.args.right(3).join(' ')
 	}

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -198,6 +198,7 @@ fn main() {
   
 	if 'run' in args {
 		// always recompile for now, too error prone to skip recompilation otherwise
+    // for example for -repl usage, especially when piping lines to v
 		v.compile() 
 		v.run_compiled_executable_and_exit()
 	}

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -197,15 +197,8 @@ fn main() {
 	}
   
 	if 'run' in args {
-		vsource := v.dir
-		vtarget := final_target_out_name( v.out_name )
-    
-		// 1) A REPL source may change very fast, especially when piping, so it is best to always recompile
-		// 2) When there is no executable, it should be created by a compilation
-		// 3) Normally 'v run file.v', after file.v was changed, has to recompile as well
-		if v.pref.is_repl || !os.file_exists(vtarget) || (os.file_last_mod_unix(vsource) > os.file_last_mod_unix(vtarget)) {
-			v.compile()
-		}      
+		// always recompile for now, too error prone to skip recompilation otherwise
+		v.compile() 
 		v.run_compiled_executable_and_exit()
 	}
   

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -198,7 +198,7 @@ fn main() {
   
 	if 'run' in args {
 		// always recompile for now, too error prone to skip recompilation otherwise
-    // for example for -repl usage, especially when piping lines to v
+		// for example for -repl usage, especially when piping lines to v
 		v.compile() 
 		v.run_compiled_executable_and_exit()
 	}


### PR DESCRIPTION
`v run file.v` recompiles file.v just once on windows too 
(since on windows the final executable has .exe suffix, in effect before it always recompiled the .exe).

`v run file.v -repl` should now always recompile 
(since the repl source may change very fast, especially when piping source lines to v).

Add source comments on the different reasons for recompilation in the 'v run' high level block.