### PR TITLE
 Makefile: rebuild compiler when sources change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /v
 /vprod
 /v.c
+/v.*.c
+/v.c.out
 /v.exe
 *.exe
 *.o

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ v.c.out: v.${VC}.c
 	${CC} -std=gnu11 -w -o v.c.out v.${VC}.c -lm
 
 v.${VC}.c:
-	curl -o v.${VC}.c -Ls https://github.com/vlang/vc/raw/${VC}/v.c
+	curl -o v.${VC}.c -LsSf https://github.com/vlang/vc/raw/${VC}/v.c
 
 test: v
 	./v -prod -o vprod compiler # Test prod build

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ VC ?= 0.1.17
 all: v
 	$(info V has been successfully built)
 
-v: v.c.out
+v: v.c.out compiler/*.v vlib/**/*.v
 	./v.c.out -o v compiler
 
-v-release: v.c
+v-release:
 	./v -cflags '${CFLAGS}' -o v compiler
 	strip v
 

--- a/examples/vweb/.gitignore
+++ b/examples/vweb/.gitignore
@@ -1,0 +1,1 @@
+test_app


### PR DESCRIPTION
This adds all V files as dependencies to make sure that `make` builds the latest source.

Was about to submit a bug report about an error that remained after `git pull && make` but then I ran `make clean v` and the error disappeared. I had pulled in the latest changes but `make` had skipped building them.

Also updated `.gitignore` with some files created by `make test`, and made `curl` return an exit code on server error so that `LC=nonexistenttag make all` doesn't pass on GitHubs HTML error page to the V compiler.