### PR TITLE
compiler: fix debug builds of programs without main function

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -465,7 +465,9 @@ string _STR_TMP(const char *fmt, ...) {
 			// It can be skipped in single file programs
 			if v.pref.is_script {
 				//println('Generating main()...')
-				cgen.genln('int main() { init_consts(); $cgen.fn_main; return 0; }')
+				cgen.genln('int main() { init_consts();')
+				cgen.genln('$cgen.fn_main;')
+				cgen.genln('return 0; }')
 			}
 			else {
 				println('panic: function `main` is undeclared in the main module')


### PR DESCRIPTION
Generate the main body on a new line below `init_consts` so that `#line ...` debug info is always on its own line.

`init_consts(); #line ...` causes errors.

Fixes issue #1551.