### PR TITLE
pg: Don't hard code server host, add missing port number.

### DIFF
--- a/vlib/orm/orm_test.v
+++ b/vlib/orm/orm_test.v
@@ -9,7 +9,7 @@ struct Mod {
 
 fn test_orm() {
 /* 
-	db := pg.connect('vpm', 'alex')
+	db := pg.connect('localhost', 5432, 'vpm', 'alex')
 	nr_modules := select count from db.modules 
 	mod := select from db.modules where id = 1 limit 1 
 	println(mod.name) 

--- a/vlib/pg/pg.v
+++ b/vlib/pg/pg.v
@@ -29,8 +29,8 @@ fn C.PQerrorMessage(voidptr) byteptr
 fn C.PQgetvalue(voidptr, int, int) byteptr
 fn C.PQstatus(voidptr) int 
 
-pub fn connect(dbname, user string) DB {
-	conninfo := 'host=localhost user=$user dbname=$dbname'
+pub fn connect(host string, port int, dbname, user string) DB {
+	conninfo := 'host=$host port=$port user=$user dbname=$dbname'
 	conn:=C.PQconnectdb(conninfo.str)
 	status := C.PQstatus(conn)
 	if status != CONNECTION_OK { 


### PR DESCRIPTION
pg module:

- Don't hard code server host.
- Add missing port number.