### PR TITLE
Fix copy issue and symbol link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ release: clean v-release thirdparty-release
 
 install: uninstall
 	mkdir -p ${PREFIX}/lib/vlang ${PREFIX}/bin
-	cp -r {v,vlib,thirdparty} ${PREFIX}/lib/vlang
-	ln -s ${PREFIX}/lib/vlang/v ${PREFIX}/bin/v
+	cp -r v vlib thirdparty ${PREFIX}/lib/vlang
+	ln -sf ${PREFIX}/lib/vlang/v ${PREFIX}/bin/v
 
 uninstall:
 	rm -rf ${PREFIX}/{bin/v,lib/vlang}


### PR DESCRIPTION
- Fix the issue while running `make install` on Debian 10:

```
# make install
rm -rf /usr/local/{bin/v,lib/vlang}
mkdir -p /usr/local/lib/vlang /usr/local/bin
cp -fr {v,vlib,thirdparty} /usr/local/lib/vlang
cp: cannot stat '{v,vlib,thirdparty}': No such file or directory
make: *** [Makefile:49: install] Error 1
```

- Force to create symbol link if `${PREFIX}/bin/v` already exists.