### PR TITLE
Makefile: 'make install' should build v too.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /v.*.c
 /v.c.out
 /v.exe
+/tools/vget
+/tools/vget.exe
 *.exe
 *.o
 .*.c

--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,9 @@ debug: clean v thirdparty
 release: CFLAGS += -pie
 release: clean v-release thirdparty-release
 
-install: uninstall
+install: uninstall all
 	mkdir -p ${PREFIX}/lib/vlang ${PREFIX}/bin
-	cp -r v vlib thirdparty ${PREFIX}/lib/vlang
+	cp -r {v,vlib,thirdparty} ${PREFIX}/lib/vlang  
 	ln -sf ${PREFIX}/lib/vlang/v ${PREFIX}/bin/v
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ CFLAGS ?= -O2 -fPIC
 PREFIX ?= /usr/local
 VC ?= 0.1.17
 
-all: v
+all: v tools/vget
 	$(info V has been successfully built)
 
 v: v.c.out compiler/*.v vlib/**/*.v
 	./v.c.out -o v compiler
 
-v-release:
+v-release: v
 	./v -cflags '${CFLAGS}' -o v compiler
 	strip v
 
@@ -19,6 +19,9 @@ v.c.out: v.${VC}.c
 v.${VC}.c:
 	curl -o v.${VC}.c -LsSf https://github.com/vlang/vc/raw/${VC}/v.c
 	curl -o v.${VC}.c -LsSf https://raw.githubusercontent.com/vlang/vc/master/v.c
+
+tools/vget: v
+	./v tools/vget.v
 
 test: v
 	./v -prod -o vprod compiler # Test prod build
@@ -35,9 +38,9 @@ clean:
 SOURCES = $(wildcard thirdparty/**/*.c)
 OBJECTS := ${SOURCES:.c=.o} 
 
-thirdparty: ${OBJECTS}
+thirdparty: v ${OBJECTS}
 
-thirdparty-release: ${OBJECTS}
+thirdparty-release: v ${OBJECTS}
 	strip ${OBJECTS}
 
 debug: clean v thirdparty
@@ -47,11 +50,13 @@ release: clean v-release thirdparty-release
 
 install: uninstall all
 	mkdir -p ${PREFIX}/lib/vlang ${PREFIX}/bin
-	cp -r {v,vlib,thirdparty} ${PREFIX}/lib/vlang
+	cp -r {v,tools,vlib,thirdparty} ${PREFIX}/lib/vlang
 	ln -sf ${PREFIX}/lib/vlang/v ${PREFIX}/bin/v
+	ln -sf ${PREFIX}/lib/vlang/tools/vget ${PREFIX}/bin/vget
 
 uninstall:
-	rm -rf ${PREFIX}/{bin/v,lib/vlang}
+	rm -rf ${PREFIX}/{bin/v,bin/vget,lib/vlang}
 
-symlink:
+symlink: v tools/vget
 	ln -sf `pwd`/v ${PREFIX}/bin/v
+	ln -sf `pwd`/tools/vget ${PREFIX}/bin/vget

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ release: clean v-release thirdparty-release
 
 install: uninstall all
 	mkdir -p ${PREFIX}/lib/vlang ${PREFIX}/bin
-	cp -r {v,vlib,thirdparty} ${PREFIX}/lib/vlang  
+	cp -r {v,vlib,thirdparty} ${PREFIX}/lib/vlang
 	ln -sf ${PREFIX}/lib/vlang/v ${PREFIX}/bin/v
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test: v
 	bash ./compiler/tests/repl/repl.sh
 
 clean:
-	-rm -f v.c v*.c v.c.out v vprod thirdparty/**/*.o
+	-rm -f v.c v*.c v.c.out v vprod thirdparty/**/*.o tools/vget
 	find . -name '.*.c' -print0 | xargs -0 -n1 rm -f
 
 SOURCES = $(wildcard thirdparty/**/*.c)


### PR DESCRIPTION
Running 'make install' on a freshly cloned v repository, should first build v.
In make terms: the 'install' target, should depend on the 'all' target.
