### PR TITLE
make install: use sudo just for the installation. Compile vget only once.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,14 +49,14 @@ release: CFLAGS += -pie
 release: clean v-release thirdparty-release
 
 install: uninstall all
-	mkdir -p ${PREFIX}/lib/vlang ${PREFIX}/bin
-	cp -r {v,tools,vlib,thirdparty} ${PREFIX}/lib/vlang
-	ln -sf ${PREFIX}/lib/vlang/v ${PREFIX}/bin/v
-	ln -sf ${PREFIX}/lib/vlang/tools/vget ${PREFIX}/bin/vget
+	sudo mkdir -p ${PREFIX}/lib/vlang ${PREFIX}/bin
+	sudo cp -r {v,tools,vlib,thirdparty} ${PREFIX}/lib/vlang
+	sudo ln -sf ${PREFIX}/lib/vlang/v ${PREFIX}/bin/v
+	sudo ln -sf ${PREFIX}/lib/vlang/tools/vget ${PREFIX}/bin/vget
 
 uninstall:
-	rm -rf ${PREFIX}/{bin/v,bin/vget,lib/vlang}
+	sudo rm -rf ${PREFIX}/{bin/v,bin/vget,lib/vlang}
 
 symlink: v tools/vget
-	ln -sf `pwd`/v ${PREFIX}/bin/v
-	ln -sf `pwd`/tools/vget ${PREFIX}/bin/vget
+	sudo ln -sf `pwd`/v ${PREFIX}/bin/v
+	sudo ln -sf `pwd`/tools/vget ${PREFIX}/bin/vget

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -137,9 +137,13 @@ fn main() {
 			//println('Building vget...') 
 			os.chdir(vroot + '/tools') 
 			vexec := os.executable()
-			os.system('$vexec vget.v')
+			_ := os.exec('$vexec vget.v') or {
+				panic(err)      
+			}
 		}
-		os.system('$vget ' + names.join(' '))
+		_ := os.exec('$vget ' + names.join(' ')) or {
+			panic(err)    
+    }
 		return
 	} 
 	// TODO quit if the compiler is too old 

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -126,26 +126,20 @@ fn main() {
 		return 
 	} 
 	if 'install' in args {
-		if args.len <= 3 {
+		if args.len < 3 {
 			println('usage: v install [module] [module] [...]')
 			return 
 		}
-
 		names := args.slice(2, args.len)
 		vroot := os.dir(os.executable()) 
 		vget := '$vroot/tools/vget' 
-		if true {
+		if !os.file_exists( vget ) {
 			//println('Building vget...') 
 			os.chdir(vroot + '/tools') 
-			vexec := os.args[0] 
-			_ := os.exec('$vexec vget.v') or {
-				panic(err)
-			}
+			vexec := os.executable()
+			os.system('$vexec vget.v')
 		}
-
-		_ := os.exec('$vget ' + names.join(' ')) or {
-				panic(err)
-		}
+		os.system('$vget ' + names.join(' '))
 		return
 	} 
 	// TODO quit if the compiler is too old 

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -131,19 +131,19 @@ fn main() {
 			return 
 		}
 		names := args.slice(2, args.len)
-		vroot := os.dir(os.executable()) 
-		vget := '$vroot/tools/vget' 
+		vroot := os.dir(os.executable())
+		vget := '$vroot/tools/vget'
 		if !os.file_exists( vget ) {
-			//println('Building vget...') 
-			os.chdir(vroot + '/tools') 
+			//println('Building vget...')
+			os.chdir(vroot + '/tools')
 			vexec := os.executable()
 			_ := os.exec('$vexec vget.v') or {
-				panic(err)      
+				panic(err)
 			}
 		}
 		_ := os.exec('$vget ' + names.join(' ')) or {
-			panic(err)    
-    }
+			panic(err)
+		}
 		return
 	} 
 	// TODO quit if the compiler is too old 


### PR DESCRIPTION
The actual compilation and preparation for installing (make all), does not require root privileges.
/usr/local however is owned by root user in most unix system, so writing to it does requires root privileges. => The install/uninstall/symlink make targets, should use sudo (which may ask the user for root credentials).

Alternatives: running: `sudo make install` in a freshly cloned repository, will also work, but it will compile v and vget binaries with root user in the current folder. That in turn will make later developing harder (since it will be done with the normal user, which does not have permission to change files owned by root user).

Recompiling vget on each `v install module` invocation should not be done for a similar reason: if vget is installed with a root user, it is not write accessible to a v compiler running as a normal user.

Should be merged after #1565 (or another PR that fixes vget.v).
