### PR TITLE
compiler: unsigned number properly printed and converted to string

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1962,7 +1962,8 @@ fn (p mut Parser) index_expr(typ_ string, fn_ph int) string {
 		// expression inside [ ]
 		if is_arr {
 			T := p.table.find_type(p.expression())
-			if T.parent != 'int' {
+			// Allows only i8-64 and u8-64 to be used when accessing an array
+			if T.parent != 'int' && T.parent != 'u32' {
 				p.check_types(T.name, 'int')
 			}
 		}

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -147,14 +147,14 @@ fn new_table(obfuscate bool) *Table {
 	t.register_type('int')
 	t.register_type('size_t')
 	t.register_type_with_parent('i8', 'int')
-	t.register_type_with_parent('u8', 'int')
+	t.register_type_with_parent('u8', 'u32')
 	t.register_type_with_parent('i16', 'int')
-	t.register_type_with_parent('u16', 'int')
+	t.register_type_with_parent('u16', 'u32')
 	t.register_type_with_parent('i32', 'int')
 	t.register_type_with_parent('u32', 'int')
 	t.register_type_with_parent('byte', 'int')
 	t.register_type_with_parent('i64', 'int')
-	t.register_type_with_parent('u64', 'int')
+	t.register_type_with_parent('u64', 'u32')
 	t.register_type('byteptr')
 	t.register_type('intptr')
 	t.register_type('f32')
@@ -764,9 +764,11 @@ fn (p mut Parser) typ_to_fmt(typ string, level int) string {
 	case 'string': return '%.*s'
 	//case 'bool': return '%.*s'
 	case 'ustring': return '%.*s'
-	case 'byte', 'bool', 'int', 'char', 'byte', 'u32', 'i32', 'i16', 'u16', 'i8', 'u8': return '%d'
+	case 'byte', 'bool', 'int', 'char', 'byte', 'i32', 'i16', 'i8': return '%d'
+	case 'u8', 'u16', 'u32': return '%u'
 	case 'f64', 'f32': return '%f'
-	case 'i64', 'u64': return '%lld'
+	case 'i64': return '%lld'
+	case 'u64': return '%llu'
 	case 'byte*', 'byteptr': return '%s'
 		// case 'array_string': return '%s'
 		// case 'array_int': return '%s'

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -70,6 +70,34 @@ pub fn (nn int) str() string {
 	return tos(buf + max - len, len)
 }
 
+pub fn (nn u32) str() string {
+	 mut n := nn
+	if n == u32(0) {
+		return '0'
+	}
+	max := 16
+	mut buf := malloc(max)
+	mut len := 0
+	mut is_neg := false
+	if n < u32(0) {
+		n = -n
+		is_neg = true
+	}
+	// Fill the string from the end
+	for n > u32(0) {
+		d := n % u32(10)
+		buf[max - len - 1] = d + u32(`0`)
+		len++
+		n = n / u32(10)
+	}
+	// Prepend - if it's negative
+	if is_neg {
+		buf[max - len - 1] = `-`
+		len++
+	}
+	return tos(buf + max - len, len)
+}
+
 pub fn (nn u8) str() string {
 	 mut n := nn
 	if n == u8(0) {
@@ -117,6 +145,34 @@ pub fn (nn i64) str() string {
 		buf[max - len - 1] = d + int(`0`)
 		len++
 		n = n / i64(10)
+	}
+	// Prepend - if it's negative
+	if is_neg {
+		buf[max - len - 1] = `-`
+		len++
+	}
+	return tos(buf + max - len, len)
+}
+
+pub fn (nn u64) str() string {
+	 mut n := nn
+	if n == u64(0) {
+		return '0'
+	}
+	max := 32
+	mut buf := malloc(max)
+	mut len := 0
+	mut is_neg := false
+	if n < u64(0) {
+		n = -n
+		is_neg = true
+	}
+	// Fill the string from the end
+	for n > u64(0) {
+		d := n % u64(10)
+		buf[max - len - 1] = d + u64(`0`)
+		len++
+		n = n / u64(10)
 	}
 	// Prepend - if it's negative
 	if is_neg {

--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -10,6 +10,26 @@ fn test_const() {
 	assert u == u64(1) 
 } 
 
+fn test_str_methods() {
+	assert i8(1).str() == '1'
+	assert i8(-1).str() == '-1'
+	assert i16(1).str() == '1'
+	assert i16(-1).str() == '-1'
+	assert i32(1).str() == '1'
+	assert i32(-1).str() == '-1'
+	assert i64(1).str() == '1'
+	assert i64(-1).str() == '-1'
+
+	assert u8(1).str() == '1'
+	assert u8(-1).str() == '255'
+	assert u16(1).str() == '1'
+	assert u16(-1).str() == '65535'
+	assert u32(1).str() == '1'
+	assert u32(-1).str() == '4294967295'
+	assert u64(1).str() == '1'
+	assert u64(-1).str() == '18446744073709551615'
+}
+
 /*
 fn test_cmp() {
 	assert 1 ≠ 2


### PR DESCRIPTION
Add u32 and u64 str methods.
Changes the parent of u8, u16 and u64 to u32. (For method inheritance)

Prints unsigned numbers correctly ( `println(u32(-1))` for example).

Tests for str methods of i8, i16, i32, i64 and u8, u16, u32, 64.

Fix #1575 