### PR TITLE
Makefile: use simpler shell syntax.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ release: clean v-release thirdparty-release
 
 install: uninstall all
 	mkdir -p ${PREFIX}/lib/vlang ${PREFIX}/bin
-	cp -r {v,tools,vlib,thirdparty} ${PREFIX}/lib/vlang
+	cp -r v tools vlib thirdparty ${PREFIX}/lib/vlang
 	ln -sf ${PREFIX}/lib/vlang/v ${PREFIX}/bin/v
 	ln -sf ${PREFIX}/lib/vlang/tools/vget ${PREFIX}/bin/vget
 


### PR DESCRIPTION
On some systems, the default shell used by make is more limited than bash. 

For example on Debian, the dash shell gives the following error, when running 'make install':
cp: cannot stat '{v,tools,vlib,thirdparty}': No such file or directory

This PR uses a simpler shell syntax to do the same thing.