### PR TITLE
repl: default printing fix and test

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -1349,7 +1349,7 @@ fn run_repl() []string {
 			}
 			lines << line
 			vals := s.split('\n')
-			for i:=0; i<vals.len-1; i++ {
+			for i:=0; i<vals.len; i++ {
 				println(vals[i])
 			}
 		}

--- a/compiler/tests/repl/default_printing.repl
+++ b/compiler/tests/repl/default_printing.repl
@@ -1,0 +1,7 @@
+num := 1
+string := 'Hello'
+num
+string
+===output===
+1
+Hello


### PR DESCRIPTION
Printing of variables in REPL and automated tests for it : 
```
>>> a := 1
>>> b := 'foo'
>>> a
1
>>> b
foo
```
Fix #1298 