### PR TITLE
compiler: bootstrap with MSVC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ script:
   - |
     if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
       choco install openssl.light
+      echo "Testing msvc bootstrapping"
+      ./make_msvc.bat
       echo "Running make_tests.bat..."
       ./make_tests.bat
     fi

--- a/make_msvc.bat
+++ b/make_msvc.bat
@@ -2,7 +2,7 @@
 
 set exiterror=0
 
-REM find an MSVC installation
+echo finding an MSVC installation
 
 for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
   set InstallDir=%%i
@@ -16,17 +16,18 @@ if exist "%InstallDir%\Common7\Tools\vsdevcmd.bat" (
   goto :nomsvc
 )
 
-REM get ourselves a copy of v.c
+echo fetch v.c
 curl -O https://raw.githubusercontent.com/vlang/vc/master/v.c
 
+echo build v.c with msvc
 cl.exe /w /volatile:ms /D_UNICODE /DUNICODE /Fo.v.c.obj /O2 /MD v.c user32.lib kernel32.lib advapi32.lib shell32.lib /link /NOLOGO /OUT:v2.exe /INCREMENTAL:NO
 
 if %ERRORLEVEL% GEQ 1 (
    goto :compileerror
 )
 
-REM rebuild from source
-v2.exe -os msvc -o v.exe compiler
+echo rebuild from source
+v2.exe -o v.exe compiler
 
 del .v.c.obj
 del v.c

--- a/make_msvc.bat
+++ b/make_msvc.bat
@@ -11,7 +11,7 @@ for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio
 REM set up a devcmd
 
 if exist "%InstallDir%\Common7\Tools\vsdevcmd.bat" (
-  "%InstallDir%\Common7\Tools\vsdevcmd.bat" -arch=x64 -host_arch=x64
+  call "%InstallDir%\Common7\Tools\vsdevcmd.bat" -arch=x64 -host_arch=x64
 ) else (
   goto :nomsvc
 )

--- a/make_msvc.bat
+++ b/make_msvc.bat
@@ -1,0 +1,47 @@
+@echo off
+
+set exiterror=0
+
+REM find an MSVC installation
+
+for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+  set InstallDir=%%i
+)
+
+REM set up a devcmd
+
+if exist "%InstallDir%\Common7\Tools\vsdevcmd.bat" (
+  "%InstallDir%\Common7\Tools\vsdevcmd.bat" -arch=x64 -host_arch=x64
+) else (
+  goto :nomsvc
+)
+
+REM get ourselves a copy of v.c
+curl -O https://raw.githubusercontent.com/vlang/vc/master/v.c
+
+cl.exe /w /volatile:ms /D_UNICODE /DUNICODE /Fo.v.c.obj /O2 /MD v.c user32.lib kernel32.lib advapi32.lib shell32.lib /link /NOLOGO /OUT:v2.exe /INCREMENTAL:NO
+
+if %ERRORLEVEL% GEQ 1 (
+   goto :compileerror
+)
+
+REM rebuild from source
+v2.exe -os msvc -o v.exe compiler
+
+del .v.c.obj
+del v.c
+del v2.exe
+
+exit
+
+:nomsvc
+echo Cannot find an msvc installation
+goto :error
+
+:compileerror
+echo Failed to compile - Create an issue at 'https://github.com/vlang' and tag '@emily33901'!
+goto :error
+
+:error
+echo Exiting from error
+exit /b 1

--- a/make_tests.bat
+++ b/make_tests.bat
@@ -22,6 +22,8 @@ echo build vc.msvc using vc
 vc.exe -o -os msvc v.msvc.exe compiler
 if %ERRORLEVEL% NEQ 0 goto :fail
 
+dir
+
 echo build v.msvc.3 using v
 v.exe -os msvc -o v.msvc.2.exe compiler
 if %ERRORLEVEL% NEQ 0 goto :fail

--- a/make_tests.bat
+++ b/make_tests.bat
@@ -19,10 +19,8 @@ vc.exe -o v.exe compiler
 if %ERRORLEVEL% NEQ 0 goto :fail
 
 echo build vc.msvc using vc
-vc.exe -o -os msvc v.msvc.exe compiler
+vc.exe -os msvc -o v.msvc.exe compiler
 if %ERRORLEVEL% NEQ 0 goto :fail
-
-dir
 
 echo build v.msvc.3 using v
 v.exe -os msvc -o v.msvc.2.exe compiler

--- a/make_tests.bat
+++ b/make_tests.bat
@@ -1,5 +1,10 @@
 @echo off
 
+echo Cleanup
+del v.exe
+del v.c
+del v2.exe
+
 echo fetch v.c
 curl -O https://raw.githubusercontent.com/vlang/vc/master/v.c
 if %ERRORLEVEL% NEQ 0 goto :fail
@@ -13,12 +18,16 @@ echo build v using vc
 vc.exe -o v.exe compiler
 if %ERRORLEVEL% NEQ 0 goto :fail
 
-echo build v.msvc using v
-v.exe -os msvc -o v.msvc.exe compiler
+echo build vc.msvc using vc
+vc.exe -o -os msvc v.msvc.exe compiler
 if %ERRORLEVEL% NEQ 0 goto :fail
 
-echo build v.msvc.2 using v.msvc
-v.msvc.exe -os msvc -o v.msvc.2.exe compiler
+echo build v.msvc.3 using v
+v.exe -os msvc -o v.msvc.2.exe compiler
+if %ERRORLEVEL% NEQ 0 goto :fail
+
+echo build v.msvc.3 using v.msvc
+v.msvc.exe -os msvc -o v.msvc.3.exe compiler
 if %ERRORLEVEL% NEQ 0 goto :fail
 
 echo build v.gcc using v.msvc

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -724,13 +724,6 @@ fn (u ustring) free() {
 	u.runes.free()
 }
 
-fn abs(a int) int {
-	if a >= 0 {
-		return a
-	}
-	return -a
-}
-
 pub fn (c byte) is_digit() bool {
 	return c >= `0` && c <= `9`
 }


### PR DESCRIPTION
Now im not on a windows box at the moment so I have no idea if this will pass at all at the moment. (Some of it wont until vc/v.c is updated). So I am kind of using travis to debug this (if it needs debugging).

This allows for the compiler to be bootstrapped with msvc using the `make_msvc.bat` file - also checks that it works using the CI.

Since my previous pr compiled the msvc building code into the C source code I have also added a CI case for that.