### PR TITLE
compiler: prevent string to byte cast

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -2916,6 +2916,9 @@ fn (p mut Parser) cast(typ string) string {
 			p.error('cannot cast `$expr_typ` to `$typ`') 
 		} 
 	}
+	else if typ == 'byte' && expr_typ == 'string' {
+		p.error('cannot cast `$expr_typ` to `$typ`, use backquotes `` to create a `$typ` or access the value of an index of `$expr_typ` using []')
+	}
 	else {
 		p.cgen.set_placeholder(pos, '($typ)(')
 	}


### PR DESCRIPTION
Will prompt an error message when trying to cast a string to a byte.
Suggests to use backquotes or accessing a string value.

Partly fix #1439 