### PR TITLE
compiler: escape '$' in string with '\$'

### DIFF
--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -569,6 +569,18 @@ fn (s &Scanner) error(msg string) {
 	exit(1)
 }
 
+
+fn (s Scanner) count_symbol_before(p int, sym byte) int {
+  mut count := 0
+  for i:=p; i>=0; i-- {
+    if s.text[i] != sym {
+      break
+    }
+    count++
+  }
+  return count
+}
+
 // println('array out of bounds $idx len=$a.len')
 // This is really bad. It needs a major clean up
 fn (s mut Scanner) ident_string() string {
@@ -584,7 +596,6 @@ fn (s mut Scanner) ident_string() string {
 		}
 		c := s.text[s.pos]
 		prevc := s.text[s.pos - 1]
-		prevprevc := if s.pos > 1 { s.text[s.pos - 2] } else { `\0` }
 		// end of string
 		if c == `\'` && (prevc != slash || (prevc == slash && s.text[s.pos - 2] == slash)) {
 			// handle '123\\'  slash at the end
@@ -602,14 +613,14 @@ fn (s mut Scanner) ident_string() string {
 			s.error('0 character in a string literal')
 		}
 		// ${var}
-		if c == `{` && prevc == `$` && prevprevc != `$` {
+		if c == `{` && s.count_symbol_before(s.pos-1, `$`) % 2 == 1 {
 			s.inside_string = true
 			// so that s.pos points to $ at the next step
 			s.pos -= 2
 			break
 		}
 		// $var
-		if (c.is_letter() || c == `_`) && prevc == `$` && prevprevc != `$` {
+		if (c.is_letter() || c == `_`) && s.count_symbol_before(s.pos-1, `$`) % 2 == 1 {
 			s.inside_string = true
 			s.dollar_start = true
 			s.pos -= 2

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -613,14 +613,14 @@ fn (s mut Scanner) ident_string() string {
 			s.error('0 character in a string literal')
 		}
 		// ${var}
-		if c == `{` && s.count_symbol_before(s.pos-1, `$`) % 2 == 1 {
+		if c == `{` && prevc == `$` && s.count_symbol_before(s.pos-2, `\\`) % 2 == 0 {
 			s.inside_string = true
 			// so that s.pos points to $ at the next step
 			s.pos -= 2
 			break
 		}
 		// $var
-		if (c.is_letter() || c == `_`) && s.count_symbol_before(s.pos-1, `$`) % 2 == 1 {
+		if (c.is_letter() || c == `_`) && prevc == `$` && s.count_symbol_before(s.pos-2, `\\`) % 2 == 0 {
 			s.inside_string = true
 			s.dollar_start = true
 			s.pos -= 2

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -584,6 +584,7 @@ fn (s mut Scanner) ident_string() string {
 		}
 		c := s.text[s.pos]
 		prevc := s.text[s.pos - 1]
+		prevprevc := if s.pos > 1 { s.text[s.pos - 2] } else { `\0` }
 		// end of string
 		if c == `\'` && (prevc != slash || (prevc == slash && s.text[s.pos - 2] == slash)) {
 			// handle '123\\'  slash at the end
@@ -601,14 +602,14 @@ fn (s mut Scanner) ident_string() string {
 			s.error('0 character in a string literal')
 		}
 		// ${var}
-		if c == `{` && prevc == `$` {
+		if c == `{` && prevc == `$` && prevprevc != `$` {
 			s.inside_string = true
 			// so that s.pos points to $ at the next step
 			s.pos -= 2
 			break
 		}
 		// $var
-		if (c.is_letter() || c == `_`) && prevc == `$` {
+		if (c.is_letter() || c == `_`) && prevc == `$` && prevprevc != `$` {
 			s.inside_string = true
 			s.dollar_start = true
 			s.pos -= 2

--- a/compiler/tests/string_interpolation_test.v
+++ b/compiler/tests/string_interpolation_test.v
@@ -4,5 +4,6 @@ fn test_excape_dollar_in_string() {
 
   assert '($i)' == '(42)'
   assert '($$i)'.contains('i') && !'($$i)'.contains('42')
+  assert !'($$$i)'.contains('i') && '($$$i)'.contains('42') && '($$$i)'.contains('$')
   assert i==42
 }

--- a/compiler/tests/string_interpolation_test.v
+++ b/compiler/tests/string_interpolation_test.v
@@ -3,7 +3,15 @@ fn test_excape_dollar_in_string() {
   i := 42
 
   assert '($i)' == '(42)'
-  assert '($$i)'.contains('i') && !'($$i)'.contains('42')
-  assert !'($$$i)'.contains('i') && '($$$i)'.contains('42') && '($$$i)'.contains('$')
+  assert '(\$i)'.contains('i') && !'(\$i)'.contains('42')
+  assert !'(\\$i)'.contains('i') && '(\\$i)'.contains('42') && '(\\$i)'.contains('\\')
+  assert '(\\\$i)'.contains('i') && !'(\\\$i)'.contains('42') && '(\\$i)'.contains('\\')
+  assert !'(\\\\$i)'.contains('i') && '(\\\\$i)'.contains('42') && '(\\\\$i)'.contains('\\\\')
+
+  assert '(${i})' == '(42)'
+  assert '(\${i})'.contains('i') && !'(\${i})'.contains('42')
+  assert !'(\\${i})'.contains('i') && '(\\${i})'.contains('42') && '(\\${i})'.contains('\\')
+  assert '(\\\${i})'.contains('i') && !'(\\\${i})'.contains('42') && '(\\${i})'.contains('\\')
+  assert !'(\\\\${i})'.contains('i') && '(\\\\${i})'.contains('42') && '(\\\\${i})'.contains('\\\\')
   assert i==42
 }

--- a/compiler/tests/string_interpolation_test.v
+++ b/compiler/tests/string_interpolation_test.v
@@ -1,0 +1,8 @@
+
+fn test_excape_dollar_in_string() {
+  i := 42
+
+  assert '($i)' == '(42)'
+  assert '($$i)'.contains('i') && !'($$i)'.contains('42')
+  assert i==42
+}


### PR DESCRIPTION
now you could use a dollar sign in a string by escaping it:
'\\$var' will not interpolate var.
