### PR TITLE
compiler: scanner: string interpolation with $var at the end

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -869,7 +869,7 @@ mut args := ''
 	//'$fast_clang $args'
 	//}
 	//else {
-	mut cmd := 'cc $args'
+	mut cmd := ('cc $args') // TODO fix $if after 'string'
 	//}
 	$if windows {
 		cmd = 'gcc $args' 

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -264,7 +264,7 @@ fn (s mut Scanner) scan() ScanRes {
 		// at the next ', skip it
 		if s.inside_string {
 			if next_char == `\'` {
-				s.pos++
+				s.dollar_end = true
 				s.dollar_start = false
 				s.inside_string = false
 			}

--- a/compiler/tests/string_interpolation_test.v
+++ b/compiler/tests/string_interpolation_test.v
@@ -15,3 +15,15 @@ fn test_excape_dollar_in_string() {
   assert !'(\\\\${i})'.contains('i') && '(\\\\${i})'.contains('42') && '(\\\\${i})'.contains('\\\\')
   assert i==42
 }
+
+fn test_implicit_str() {
+  i := 42
+  assert 'int $i' == 'int 42'
+  assert '$i' == '42'
+
+  check := '$i' == '42'
+  assert check
+
+  text := '$i' + '42'
+  assert text == '4242'
+}


### PR DESCRIPTION
the string token was not finalized in an expression if the variable
was written to the end

this fixes #1605
