### PR TITLE
http: add vschannel_cleanup() back. / already added in http.

### DIFF
--- a/vlib/http/backend_win.v
+++ b/vlib/http/backend_win.v
@@ -22,9 +22,9 @@ fn ssl_do(method, host_name, path string) Response {
 	// dynamically increase in vschannel.c if needed
 	mut buff := malloc(44000)
 	
-	p := if path == '' { '/' } else { path }
-	req := build_request_headers('', method, host_name, p)
+	req := build_request_headers('', method, host_name, path)
 	length := int(C.request(host_name.str, req.str, buff))
 	
+	C.vschannel_cleanup()
 	return parse_response(string(buff, length))
 }


### PR DESCRIPTION
Accidentally got rid of vschannel_cleanup() in updated yesterday.
Also no need to add / in backend_win.v as already done in http.v now.