### PR TITLE
add static inline attribute

### DIFF
--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -278,6 +278,8 @@ fn (p mut Parser) fn_decl() {
 	}
 	dll_export_linkage := if p.os == .msvc && p.attr == 'live' && p.pref.is_so {
 		'__declspec(dllexport) '
+	} else if p.attr == 'inline' {
+		'static inline '
 	} else {
 		''
 	}


### PR DESCRIPTION
- added [inline] attribute, which translate to `static inline`
- gcc / clang automatically inline some small function but it is not very smart, thats why inline keyword is in use in many c/c++ projects.