### PR TITLE
compiler: improved error, when c compiler is missing/not found.

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -892,6 +892,17 @@ mut args := ''
 	ticks := time.ticks()
 	res := os.exec(cmd) or { panic(err) }
 	if res.exit_code != 0 {
+
+		if res.exit_code == 127 {
+			// the command could not be found by the system
+			panic('C compiler error, while attempting to run: \n' +
+				'-----------------------------------------------------------\n' +
+				'$cmd\n' +
+				'-----------------------------------------------------------\n' +
+				'Probably your C compiler is missing. \n' +
+				'Please reinstall it, or make it available in your PATH.')
+		}
+
 		if v.pref.is_debug {
 			println(res.output)
 		} else {


### PR DESCRIPTION
When the c compiler is not found, this PR prints:

```
V panic: C compiler error, while attempting to run: 
-----------------------------------------------------------
cc  -std=gnu11 -w -g -o z ".v.c"   -lm -lpthread   -ldl 
-----------------------------------------------------------
Probably your C compiler is missing. 
Please reinstall it, or make it available in your PATH.
```
