### PR TITLE
compiler: improve error handling for 'v install'

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -141,13 +141,18 @@ fn main() {
 		if true {
 			//println('Building vget...')
 			os.chdir(vroot + '/tools')
-			_ := os.exec('$vexec -o $vget vget.v') or {
+			vgetcompilation := os.exec('$vexec -o $vget vget.v') or {
 				panic(err)
 			}
+			if vgetcompilation.exit_code != 0 {
+				panic( vgetcompilation.output )
+			}
 		}
-
-		_ := os.exec('$vget ' + names.join(' ')) or {
-				panic(err)
+		vgetresult := os.exec('$vget ' + names.join(' ')) or {
+			panic(err)
+		}
+		if vgetresult.exit_code != 0 {
+			panic( vgetresult.output )
 		}
 		return
 	}

--- a/tools/vget.v
+++ b/tools/vget.v
@@ -35,17 +35,32 @@ fn main() {
 	mut errors := 0
 	names := os.args.slice(1, os.args.len)
 	for name in names {
-		s := http.get_text(url + '/jsmod/$name')
+		modurl := url + '/jsmod/$name'
+		r := http.get(modurl) or { panic(err) }
+		
+		if r.status_code == 404 {
+			println('Skipping module "$name", since $url reported that "$name" does not exist.')
+			errors++
+			continue
+        }
+		
+        if r.status_code != 200 {
+			println('Skipping module "$name", since $url responded with $r.status_code http status code. Please try again later.')
+			errors++
+			continue
+		}
+		
+		s := r.text
 		mod := json.decode(Mod, s) or {
 			errors++
-			println('Error. Make sure you are online.')
+			println('Skipping module "$name", since its information is not in json format.')
 			continue
 		}
 		
 		if( '' == mod.url || '' == mod.name ){
 			errors++
 			// a possible 404 error, which means a missing module?
-			println('Skipping module "$name", since it does not exist.')
+			println('Skipping module "$name", since it is missing name or url information.')
 			continue
 		}
 

--- a/tools/vget.v
+++ b/tools/vget.v
@@ -42,9 +42,9 @@ fn main() {
 			println('Skipping module "$name", since $url reported that "$name" does not exist.')
 			errors++
 			continue
-        }
+        	}
 		
-        if r.status_code != 200 {
+        	if r.status_code != 200 {
 			println('Skipping module "$name", since $url responded with $r.status_code http status code. Please try again later.')
 			errors++
 			continue


### PR DESCRIPTION
This PR makes `v install glfw` produce:
```
0[15:42:08] /v/v $ /v/v/v install glfw
V panic: Skipping module "glfw", since https://vpm.best responded with 502 http status code. Please try again later.
1[15:42:12] /v/v $ 
```
... when the server is down, instead of silently doing nothing.