### PR TITLE
repl: dont save line if last compilation errored

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -1375,7 +1375,9 @@ fn run_repl() []string {
 			s := os.exec('$vexe run $temp_file -repl') or {
 				panic(err)
 			}
-			lines << line
+			if !s.exit_code {
+				lines << line
+			}
 			vals := s.output.split('\n')
 			for i:=0; i<vals.len; i++ {
 				println(vals[i])

--- a/compiler/tests/repl/error_nosave.repl
+++ b/compiler/tests/repl/error_nosave.repl
@@ -1,0 +1,5 @@
+a
+33
+===output===
+.vrepl_temp.v:2 undefined: `a`
+33


### PR DESCRIPTION
Will not add the faulty line to the rest if compilation doesn't work correctly.
Added test to check this case.

Fix #1655 