### PR TITLE
compiler: prevent accessing negative index of arrays

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1963,10 +1963,14 @@ fn (p mut Parser) index_expr(typ_ string, fn_ph int) string {
 		}
 		// expression inside [ ]
 		if is_arr {
+			index_pos := p.cgen.cur_line.len
 			T := p.table.find_type(p.expression())
 			// Allows only i8-64 and u8-64 to be used when accessing an array
 			if T.parent != 'int' && T.parent != 'u32' {
 				p.check_types(T.name, 'int')
+			}
+			if p.cgen.cur_line.right(index_pos).replace(' ', '').int() < 0 {
+				p.error('cannot access negative array index')
 			}
 		}
 		else {


### PR DESCRIPTION
Will prompt an error upon compilation when trying to access negative array through numeric value.

Partly Fix #1628 