### PR TITLE
build: allow to build a specific version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 CC ?= cc
 PREFIX ?= /usr/local
+BRANCH ?= master
 
 all: 
-	git clone --depth 1 --quiet https://github.com/vlang/vc
+	git clone --depth 1 --quiet --branch ${BRANCH} https://github.com/vlang/vc
 	${CC} -std=gnu11 -w -o v vc/v.c -lm
 	./v -o v compiler
 	rm -rf vc


### PR DESCRIPTION
with the next version (0.1.19) we should be able to build an old
version of the v compiler, like:

```
git co 0.1.19
make BRANCH=0.1.19
```

it is not an ideal solution, but will help bootstrap projects that
depend on v compiler