### PR TITLE
compiler: allows compound assignment operators on array

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -199,3 +199,10 @@ fn test_clone() {
 	assert nums.slice(1, 3).str() == '[2, 3]' 
 } 
  
+fn test_doubling() {
+	mut nums := [1, 2, 3, 4, 5]
+	for i := 0; i < nums.len; i++ {
+		nums[i] *= 2
+	}
+	assert nums.str() == '[2, 4, 6, 8, 10]'
+}


### PR DESCRIPTION
**Additions:**
Handling Compound Operators Assignment (e.g; `+=` or `*=`) to arrays.
Added tests for this case.

**Notes**
Fix #1692 
Not added on maps, they require to tweak a bit more.

**Examples**
```
mut test := [1, 2, 3, 4]
for i := 0; i < test.len; ++i {
    test[i] += 2
}
test[0] *= 10
```