### PR TITLE
compiler: comptime generated str methods for arrays are public

### DIFF
--- a/compiler/comptime.v
+++ b/compiler/comptime.v
@@ -248,6 +248,7 @@ fn (p mut Parser) gen_array_str(typ mut Type) {
 		typ: 'string'
 		args: [Var{typ: typ.name, is_arg:true}] 
 		is_method: true 
+		is_public: true
 		receiver_typ: typ.name 
 	}) 
 	t := typ.name 


### PR DESCRIPTION
**Additions:**
Allows use of automatically generated `.str()` methods of arrays types.

**Notes:**
Fix #1697

**Examples:**
```
nums := [1, 2, 3, 4]
s := nums.str()
println(s)
```
```
nums := [1.0, 2.1, 3.5]
s := nums.str()
println(s)
```