### PR TITLE
compiler: handles printing of structures and arrays of structures

### DIFF
--- a/compiler/comptime.v
+++ b/compiler/comptime.v
@@ -252,6 +252,9 @@ fn (p mut Parser) gen_array_str(typ mut Type) {
 	}) 
 	t := typ.name 
 	elm_type := t.right(6) 
+	if p.typ_to_fmt(elm_type, 0) == '' && !p.table.type_has_method(p.table.find_type(elm_type), 'str') {
+		p.error('cant print ${elm_type}[], unhandled print of ${elm_type}')
+	}
 	p.cgen.fns << '
 string ${t}_str($t a) {
 	strings__Builder sb = strings__new_builder(a.len * 3); 

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -2547,7 +2547,18 @@ fn (p mut Parser) string_expr() {
 		else {
 			f := p.typ_to_fmt(typ, 0)
 			if f == '' {
-				p.error('unhandled sprintf format "$typ" ')
+				is_array := typ.starts_with('array_')
+				has_str_method := p.table.type_has_method(p.table.find_type(typ), 'str')
+				if is_array || has_str_method {
+					if is_array && !has_str_method {
+						p.gen_array_str(mut p.table.find_type(typ))
+					}
+					args = args.all_before_last(val) + '${typ}_str(${val}).len, ${typ}_str(${val}).str'
+					format += '%.*s '
+				}
+				else {
+					p.error('unhandled sprintf format "$typ" ')
+				}
 			}
 			format += f
 		}

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -206,3 +206,37 @@ fn test_doubling() {
 	}
 	assert nums.str() == '[2, 4, 6, 8, 10]'
 }
+
+struct Test2 {
+	one int
+	two int
+}
+
+struct Test {
+	a string
+	b []Test2
+}
+
+fn (t Test2) str() string {
+	return '{$t.one $t.two}'
+}
+
+fn (t Test) str() string {
+	return '{$t.a $t.b}'
+}
+
+fn test_struct_print() {
+	mut a := Test {
+		a: 'Test',
+		b: []Test2
+	}
+	b := Test2 {
+		one: 1,
+		two: 2
+	}
+	a.b << b
+	a.b << b
+	assert a.str() == '{Test [{1 2}, {1 2}] }'
+	assert b.str() == '{1 2}'
+	assert a.b.str() == '[{1 2}, {1 2}]'
+}


### PR DESCRIPTION
**Additions:**
Allows to print a structure using its `str()` method.
Allows to print arrays of structures by generating a function to print it.
Function to print arrays of structures will check if `str()` method for that type exists.
Added tests for printing of arrays.
<br>
**Notes:**
Fixes: #1679 
*How to go further* : Auto-generate complex structure's `str()` methods like what is done to currently print simple structures
<br>
**Examples:**
- Correct
```
struct Test2 {
	one int
	two int
}

struct Test {
	a string
	b []Test2
}

fn (t Test2) str() string {
	return '{$t.one $t.two}'
}

fn (t Test) str() string {
	return '{$t.a $t.b}'
}

fn test_struct_print() {
	mut a := Test {
		a: 'Test',
		b: []Test2
	}
	b := Test2 {
		one: 1,
		two: 2
	}
	a.b << b
	a.b << b
	println(a)     // '{Test [{1 2}, {1 2}] }'
	println('$a')  // '{Test [{1 2}, {1 2}] }'
}
```
- Error (*no str method*)
```
struct Test2 {
	one int
	two int
}

struct Test {
	a string
	b []Test2
}

fn main() {
	mut a := Test {
		a: 'Test',
		b: []Test2
	}
	b := Test2 {
		one: 1,
		two: 2
	}
	a.b << b
	a.b << b
	println(a)    // test.v:22 cant print Test2[], unhandled print of Test2
}
```