### PR TITLE
compiler: produce more exact errors in C filepath:line:column: format.

### DIFF
--- a/compiler/tests/repl/error.repl
+++ b/compiler/tests/repl/error.repl
@@ -1,3 +1,3 @@
 println(a)
 ===output===
-.vrepl.v:2 undefined: `a`
+.vrepl.v:2:9: undefined: `a`

--- a/compiler/tests/repl/error_nosave.repl
+++ b/compiler/tests/repl/error_nosave.repl
@@ -1,5 +1,5 @@
 a
 33
 ===output===
-.vrepl_temp.v:2 undefined: `a`
+.vrepl_temp.v:2:9: undefined: `a`
 33

--- a/compiler/tests/repl/repl_test.v
+++ b/compiler/tests/repl/repl_test.v
@@ -2,7 +2,7 @@ import os
 
 fn test_repl() {
 	test_files := os.walk_ext('.', '.repl')
-
+	wd := os.getwd() + '/'  
   for file in test_files {
     content := os.read_file(file) or {
       assert false
@@ -19,7 +19,7 @@ fn test_repl() {
       assert false
       break
     }
-    result := r.output.replace('>>> ', '').replace('>>>', '').replace('... ', '').all_after('Use Ctrl-C or `exit` to exit\n')
+    result := r.output.replace('>>> ', '').replace('>>>', '').replace('... ', '').all_after('Use Ctrl-C or `exit` to exit\n').replace( wd, '' )
     assert result == output
     if result != output {
       println(file)

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -745,7 +745,7 @@ pub fn getwd() string {
 //  and https://insanecoding.blogspot.com/2007/11/implementing-realpath-in-c.html
 // NB: this particular rabbit hole is *deep* ...
 pub fn realpath(fpath string) string {
-	mut fullpath := [MAX_PATH]byte
+	mut fullpath := malloc( MAX_PATH )
 	mut res := 0
 	$if windows {
 		res = int( C._fullpath( fullpath, fpath.str, MAX_PATH ) )
@@ -754,7 +754,7 @@ pub fn realpath(fpath string) string {
 		res = int( C.realpath( fpath.str, fullpath ) )
 	}
 	if res != 0 {
-		return tos(fullpath, strlen(fullpath)).clone()
+		return string(fullpath, strlen(fullpath))
 	}
 	return fpath
 }

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -753,7 +753,9 @@ pub fn realpath(fpath string) string {
 	$else{
 		res = int( C.realpath( fpath.str, fullpath ) )
 	}
-	if res != 0 { return tos(fullpath, strlen(fullpath)) }
+	if res != 0 {
+		return tos(fullpath, strlen(fullpath)).clone()
+	}
 	return fpath
 }
 

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -739,6 +739,24 @@ pub fn getwd() string {
 	}
 }
 
+// Returns the full absolute path for fpath, with all relative ../../, symlinks and so on resolved.
+// See http://pubs.opengroup.org/onlinepubs/9699919799/functions/realpath.html
+// Also https://insanecoding.blogspot.com/2007/11/pathmax-simply-isnt.html
+//  and https://insanecoding.blogspot.com/2007/11/implementing-realpath-in-c.html
+// NB: this particular rabbit hole is *deep* ...
+pub fn realpath(fpath string) string {
+	mut fullpath := [MAX_PATH]byte
+	mut res := 0
+	$if windows {
+		res = int( C._fullpath( fullpath, fpath.str, MAX_PATH ) )
+	}
+	$else{
+		res = int( C.realpath( fpath.str, fullpath ) )
+	}
+	if res != 0 { return tos(fullpath, strlen(fullpath)) }
+	return fpath
+}
+
 // walk_ext returns a recursive list of all file paths ending with `ext`. 
 pub fn walk_ext(path, ext string) []string {
 	if !os.is_dir(path) { 


### PR DESCRIPTION
This PR makes v produce more IDE friendly compilation errors.
![v error message](https://url4e.com/gyazo/images/4e27bcc7.png)

In this example, when I compile a file containing an error, when I press keyboard shortcuts for compilation and going to the next error, my cursor is positioned directly at the offending asd symbol.

This PR also implements os.realpath/1 .