### PR TITLE
term: fix escape sequence

### DIFF
--- a/vlib/term/control.v
+++ b/vlib/term/control.v
@@ -18,7 +18,7 @@ module term
 // x is the x coordinate
 // y is the y coordinate
 pub fn set_cursor_position(x int,y int) {
-    print('\x1b[$y;$x;H')
+    print('\x1b[$y;$x'+'H')
 }
 
 // n is number of cells


### PR DESCRIPTION
In fn set_cursor_position building escape sequence '\x1b[$y;$x;H' is not valid.
There is ';' before 'H' but this is not valid escape sequence.
The '\x1b[$y;$xH' is not valid too.
I have to build escape sequence without ';' like that '\x1b[$y;$x'+'H'.
Now cursor positioning works :)