### PR TITLE
compiler: support passing -cc to specify the desired C compiler.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@ CC ?= cc
 PREFIX ?= /usr/local
 
 all: 
+	rm -rf vc/
 	git clone --depth 1 --quiet https://github.com/vlang/vc
 	${CC} -std=gnu11 -w -o v vc/v.c -lm
 	./v -o v compiler
-	rm -rf vc
+	rm -rf vc/
 	@echo "V has been successfully built"
 
 symlink: v

--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -257,8 +257,9 @@ fn build_thirdparty_obj_file(flag string) {
 			cfiles += parent + '/' + file + ' ' 
 		} 
 	} 
-	cc := find_c_compiler() 
-	res := os.exec('$cc -fPIC -c -o $obj_path $cfiles') or {
+	cc := find_c_compiler()
+	cc_thirdparty_options := find_c_compiler_thirdparty_options()
+	res := os.exec('$cc $cc_thirdparty_options -c -o $obj_path $cfiles') or {
 		panic(err)
 	}
 	println(res.output) 

--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -257,7 +257,7 @@ fn build_thirdparty_obj_file(flag string) {
 			cfiles += parent + '/' + file + ' ' 
 		} 
 	} 
-	cc := if os.user_os() == 'windows' { 'gcc' } else { 'cc' } // TODO clang support on Windows  
+	cc := find_c_compiler() 
 	res := os.exec('$cc -fPIC -c -o $obj_path $cfiles') or {
 		panic(err)
 	}

--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -39,7 +39,7 @@ mut:
 }
 
 fn new_cgen(out_name_c string) *CGen {
-	path:='.$out_name_c'
+	path := out_name_c
 	out := os.create(path) or {
 		println('failed to create $path') 
 		return &CGen{} 

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -1189,3 +1189,8 @@ fn find_c_compiler_default() string {
 	$if windows {	return 'gcc' }
 	return 'cc'
 }
+
+fn find_c_compiler_thirdparty_options() string {
+	$if windows {	return '' }
+	return '-fPIC'
+}

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -94,6 +94,7 @@ mut:
 						 // For example, passing -cflags -Os will cause the C compiler to optimize the generated binaries for size.
 						 // You could pass several -cflags XXX arguments. They will be merged with each other.
 						 // You can also quote several options at the same time: -cflags '-Os -fno-inline-small-functions'.
+	ccompiler  string // the name of the used C compiler
 }
 
 
@@ -628,18 +629,8 @@ mut args := ''
 	if v.os == .windows {
 		a << '-DUNICODE -D_UNICODE'
 	}
-	// Find clang executable
-	//fast_clang := '/usr/local/Cellar/llvm/8.0.0/bin/clang'
 	args := a.join(' ')
-	//mut cmd := if os.file_exists(fast_clang) {
-	//'$fast_clang $args'
-	//}
-	//else {
-	mut cmd := ('cc $args') // TODO fix $if after 'string'
-	//}
-	$if windows {
-		cmd = 'gcc $args'
-	}
+	cmd := '${v.pref.ccompiler} $args'
 	if v.out_name.ends_with('.c') {
 		os.mv( '.$v.out_name_c', v.out_name )
 		exit(0)
@@ -677,7 +668,7 @@ mut args := ''
 	diff := time.ticks() - ticks
 	// Print the C command
 	if v.pref.show_c_cmd || v.pref.is_verbose {
-		println('cc took $diff ms')
+		println('${v.pref.ccompiler} took $diff ms')
 		println('=========\n')
 	}
 	// Link it if we are cross compiling and need an executable
@@ -1051,6 +1042,7 @@ fn new_v(args[]string) *V {
 		is_repl: args.contains('-repl')
 		build_mode: build_mode
 		cflags: cflags
+		ccompiler: find_c_compiler()
 	}
 	if pref.is_play {
 		println('Playground')
@@ -1182,3 +1174,18 @@ fn test_v() {
 	}
 }
 
+fn find_c_compiler() string {
+	args := env_vflags_and_os_args().join(' ')
+	defaultcc := find_c_compiler_default()
+	return get_arg( args, 'cc', defaultcc )
+}  
+
+fn find_c_compiler_default() string {
+	//fast_clang := '/usr/local/Cellar/llvm/8.0.0/bin/clang'
+	//if os.file_exists(fast_clang) {
+	//	return fast_clang
+	//}
+	// TODO fix $if after 'string'
+	$if windows {	return 'gcc' }
+	return 'cc'
+}

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -605,7 +605,7 @@ mut args := ''
 		a << '-x objective-c'
 	}
 	// The C file we are compiling
-	a << '".$v.out_name_c"'
+	a << '"$v.out_name_c"'
 	if v.os == .mac {
 		a << '-x none'
 	}
@@ -632,7 +632,7 @@ mut args := ''
 	args := a.join(' ')
 	cmd := '${v.pref.ccompiler} $args'
 	if v.out_name.ends_with('.c') {
-		os.mv( '.$v.out_name_c', v.out_name )
+		os.mv( v.out_name_c, v.out_name )
 		exit(0)
 	}
 	// Run
@@ -691,7 +691,7 @@ mut args := ''
 		println('linux cross compilation done. resulting binary: "$v.out_name"')
 	}
 	if !v.pref.is_debug && v.out_name_c != 'v.c' && v.out_name_c != 'v_macos.c' {
-		os.rm('.$v.out_name_c')
+		os.rm(v.out_name_c)
 	}
 }
 
@@ -1000,7 +1000,7 @@ fn new_v(args[]string) *V {
 		println('Go to https://vlang.io to install V.')
 		exit(1)
 	}
-	mut out_name_c := out_name.all_after('/') + '.c'
+	mut out_name_c := out_name.all_after('/') + '.tmp.c'
 	mut files := []string
 	// Add builtin files
 	if !out_name.contains('builtin.o') {

--- a/make.bat
+++ b/make.bat
@@ -1,3 +1,4 @@
+rd /s /q vc
 git clone --depth 1 --quiet https://github.com/vlang/vc
 gcc -std=gnu11 -DUNICODE -D_UNICODE -w -o v2.exe vc/v_win.c
 v2.exe -o v.exe compiler


### PR DESCRIPTION
`v -cc clang source.v` will use clang for compiling.
It will also use the *same compiler* for compiling the thirdparty C files.