### PR TITLE
fix: check whether is_tmp is true when generating "get map item"

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -2052,8 +2052,14 @@ fn (p mut Parser) index_expr(typ_ string, fn_ph int) string {
 		// Erase var name we generated earlier:	"int a = m, 0"
 		// "m, 0" gets killed since we need to start from scratch. It's messy.
 		// "m, 0" is an index expression, save it before deleting and insert later in map_get()
-		index_expr := p.cgen.cur_line.right(fn_ph)
-		p.cgen.resetln(p.cgen.cur_line.left(fn_ph))
+		mut index_expr := ''
+		if p.cgen.is_tmp {
+			index_expr = p.cgen.tmp_line.right(fn_ph)
+			p.cgen.resetln(p.cgen.tmp_line.left(fn_ph))
+		} else {
+			index_expr = p.cgen.cur_line.right(fn_ph)
+			p.cgen.resetln(p.cgen.cur_line.left(fn_ph))
+		}
 		// Can't pass integer literal, because map_get() requires a void*
 		tmp := p.get_tmp()
 		tmp_ok := p.get_tmp()


### PR DESCRIPTION
https://github.com/vlang/v/issues/1721
When generating "get map item" we are using `p.cgen.cur_line`. Though, we should check if there is `is_tmp` set to `true` in the `p.cgen`. In such a case we should use `p.cgen.tmp_line`.

Please title your PR as follows: `time: fix foo bar`. Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

Before submitting a PR, please run the tests with `make test`, and make sure V can still compile itself. Run this twice:

./v -o v compiler
./v -o v compiler
OK

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!
