### PR TITLE
jsgen: fix bug with fields renaming

### DIFF
--- a/compiler/jsgen.v
+++ b/compiler/jsgen.v
@@ -109,7 +109,7 @@ string res = tos2("");
 					'root, "$name"))'
 			}
 			else {
-				dec += ' $dec_name(js_get(root, "$name"), & (res->$name))'
+				dec += ' $dec_name(js_get(root, "$name"), & (res->$field.name))'
 			}
 			dec += ';\n'
 		}


### PR DESCRIPTION
https://github.com/vlang/v/issues/1715
Change `(res->name)` to `(res->$field.name)` in 
jsgen.v:112
```
dec += ' $dec_name(js_get(root, "$name"), & (res->name))'
```

Please title your PR as follows: `time: fix foo bar`. Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

Before submitting a PR, please run the tests with `make test`, and make sure V can still compile itself. Run this twice:

./v -o v compiler
./v -o v compiler
OK
I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!
