### PR TITLE
vlib: remove negative checks on unsigned

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -76,22 +76,12 @@ pub fn (nn u32) str() string {
 	max := 16
 	mut buf := malloc(max)
 	mut len := 0
-	mut is_neg := false
-	if n < u32(0) {
-		n = -n
-		is_neg = true
-	}
 	// Fill the string from the end
 	for n > u32(0) {
 		d := n % u32(10)
 		buf[max - len - 1] = d + u32(`0`)
 		len++
 		n = n / u32(10)
-	}
-	// Prepend - if it's negative
-	if is_neg {
-		buf[max - len - 1] = `-`
-		len++
 	}
 	return tos(buf + max - len, len)
 }
@@ -104,22 +94,12 @@ pub fn (nn u8) str() string {
 	max := 5
 	mut buf := malloc(max)
 	mut len := 0
-	mut is_neg := false
-	if n < u8(0) {
-		n = -n
-		is_neg = true
-	}
 	// Fill the string from the end
 	for n > u8(0) {
 		d := n % u8(10)
 		buf[max - len - 1] = d + u8(`0`)
 		len++
 		n = n / u8(10)
-	}
-	// Prepend - if it's negative
-	if is_neg {
-		buf[max - len - 1] = `-`
-		len++
 	}
 	return tos(buf + max - len, len)
 }
@@ -160,22 +140,12 @@ pub fn (nn u64) str() string {
 	max := 32
 	mut buf := malloc(max)
 	mut len := 0
-	mut is_neg := false
-	if n < u64(0) {
-		n = -n
-		is_neg = true
-	}
 	// Fill the string from the end
 	for n > u64(0) {
 		d := n % u64(10)
 		buf[max - len - 1] = d + u64(`0`)
 		len++
 		n = n / u64(10)
-	}
-	// Prepend - if it's negative
-	if is_neg {
-		buf[max - len - 1] = `-`
-		len++
 	}
 	return tos(buf + max - len, len)
 }


### PR DESCRIPTION
**Removals:**
Deletes the checks for negative numbers on unsigned conversion to string.
It caused compilation warnings like :
```
test.tmp.c: In function ‘u32_str’:
test.tmp.c:2488:9: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
  if ( n < ((u32)( 0 ) ) ) {
```
