### PR TITLE
compiler: access index when casting array into an array[] for pointer

### DIFF
--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -898,7 +898,7 @@ fn (p mut Parser) fn_call_args(f mut Fn) *Fn {
 				// have to use `(array[]){ expr }` hack.
 				if expected.starts_with('array_') && expected.ends_with('*') {
 					p.cgen.set_placeholder(ph, '& /*111*/ (array[]){')
-					p.gen('} ')
+					p.gen('}[0] ')
 				}
 				// println('\ne:"$expected" got:"$got"')
 				else if ! (expected == 'void*' && got == 'int') &&


### PR DESCRIPTION
**Additions:**
Accesses first case newly created array that serves to get the pointer from array.
Removes a compilation warning :
```
test.tmp.c: In function ‘map_keys’:
test.tmp.c:3222:28: warning: passing argument 2 of ‘preorder_keys’ from incompatible pointer type [-Wincompatible-pointer-types]
  preorder_keys ( m ->root ,& /*111*/ (array[]){ keys }  , 0 ) ;
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~
test.tmp.c:3174:46: note: expected ‘array_string *’ {aka ‘struct array *’} but argument is of type ‘array (*)[1]’ {aka ‘struct array (*)[1]’}
  int preorder_keys(Node* node, array_string* keys, int key_i) {
                                ~~~~~~~~~~~~~~^~~~
```