### PR TITLE
compiler: cast correctly strings between byte* and char* when needed

### DIFF
--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -779,7 +779,7 @@ fn (p mut Parser) fn_call_args(f mut Fn) *Fn {
 		file_path := p.file_path.replace('\\', '\\\\') // escape \
 		p.cgen.resetln(p.cgen.cur_line.replace(
 			'v_panic (',
-			'_panic_debug ($p.scanner.line_nr, tos2("$file_path"), tos2("$mod_name"), tos2("$fn_name"), '
+			'_panic_debug ($p.scanner.line_nr, tos2((byte *)"$file_path"), tos2((byte *)"$mod_name"), tos2((byte *)"$fn_name"), '
 		))
 	}
 	// Receiver - first arg

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -357,7 +357,7 @@ string _STR(const char *fmt, ...) {
 	va_end(argptr);
 	byte* buf = malloc(len);
 	va_start(argptr, fmt);
-	vsprintf(buf, fmt, argptr);
+	vsprintf((char *)buf, fmt, argptr);
 	va_end(argptr);
 #ifdef DEBUG_ALLOC
 	puts("_STR:");
@@ -369,10 +369,10 @@ string _STR(const char *fmt, ...) {
 string _STR_TMP(const char *fmt, ...) {
 	va_list argptr;
 	va_start(argptr, fmt);
-	size_t len = vsnprintf(0, 0, fmt, argptr) + 1;
+	//size_t len = vsnprintf(0, 0, fmt, argptr) + 1;
 	va_end(argptr);
 	va_start(argptr, fmt);
-	vsprintf(g_str_buf, fmt, argptr);
+	vsprintf((char *)g_str_buf, fmt, argptr);
 	va_end(argptr);
 #ifdef DEBUG_ALLOC
 	//puts("_STR_TMP:");

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -2088,7 +2088,7 @@ fn (p mut Parser) index_expr(typ_ string, fn_ph int) string {
 		// TODO what about user types?
 		if is_map && typ == 'string' {
 			// p.cgen.insert_before('if (!${tmp}.str) $tmp = tos("", 0);')
-			p.cgen.insert_before('if (!$tmp_ok) $tmp = tos("", 0);')
+			p.cgen.insert_before('if (!$tmp_ok) $tmp = tos((byte *)"", 0);')
 		}
 	}
 	// else if is_arr && is_indexer{}
@@ -2608,7 +2608,7 @@ fn (p mut Parser) map_init() string {
 		mut i := 0
 		for {
 			key := p.lit
-			keys_gen += 'tos2("$key"), '
+			keys_gen += 'tos2((byte*)"$key"), '
 			p.check(.str)
 			p.check(.colon)
 			p.cgen.start_tmp()
@@ -2974,7 +2974,7 @@ fn (p mut Parser) cast(typ string) string {
 		if is_byteptr || is_bytearr {
 			if p.tok == .comma {
 				p.check(.comma)
-				p.cgen.set_placeholder(pos, 'tos(')
+				p.cgen.set_placeholder(pos, 'tos((byte *)')
 				if is_bytearr {
 					p.gen('.data')
 				}
@@ -2984,7 +2984,7 @@ fn (p mut Parser) cast(typ string) string {
 				if is_bytearr {
 					p.gen('.data')
 				}
-				p.cgen.set_placeholder(pos, 'tos2(')
+				p.cgen.set_placeholder(pos, 'tos2((byte *)')
 			}
 		}
 		// `string(234)` => error
@@ -3359,7 +3359,7 @@ fn (p mut Parser) assert_statement() {
 	filename := p.file_path.replace('\\', '\\\\')
 	p.genln(';\n
 if (!$tmp) {
-  println(tos2("\\x1B[31mFAILED: $p.cur_fn.name() in $filename:$p.scanner.line_nr\\x1B[0m"));
+  println(tos2((byte *)"\\x1B[31mFAILED: $p.cur_fn.name() in $filename:$p.scanner.line_nr\\x1B[0m"));
 g_test_ok = 0 ;
 	// TODO
 	// Maybe print all vars in a test function if it fails?

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -608,7 +608,7 @@ fn type_default(typ string) string {
 	// Default values for other types are not needed because of mandatory initialization
 	switch typ {
 	case 'bool': return '0'
-	case 'string': return 'tos("", 0)'
+	case 'string': return 'tos((byte *)"", 0)'
 	case 'i8': return '0'
 	case 'i16': return '0'
 	case 'i32': return '0'


### PR DESCRIPTION
**Additions:**
Properly casts strings in C between byte* to char* 

**Prevents those compiler warnings :**
- Panic message (There was a lot of them, around 60)
```
test.tmp.c:721:9: note: expected ‘byte *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
  string tos2(byte* s) {
         ^~~~
test.tmp.c:2332:100: warning: pointer targets in passing argument 1 of ‘tos2’ differ in signedness [-Wpointer-sign]
  _panic_debug (104, tos2("/home/Henrixounez/code/v/vlib/builtin/builtin.v"), tos2("builtin"), tos2("malloc"),  _STR("malloc(%d) failed", n) ) ;
```
<br>

- _STR and _STR_TMP base functions (+ Unused variable)
```
test.tmp.c: In function ‘_STR’:
test.tmp.c:3486:11: warning: pointer targets in passing argument 1 of ‘vsprintf’ differ in signedness [-Wpointer-sign]
  vsprintf(buf, fmt, argptr);
           ^~~
In file included from test.tmp.c:4:
/usr/include/stdio.h:349:12: note: expected ‘char * restrict’ but argument is of type ‘byte *’ {aka ‘unsigned char *’}
 extern int vsprintf (char *__restrict __s, const char *__restrict __format,
            ^~~~~~~~

test.tmp.c: In function ‘_STR_TMP’:
test.tmp.c:3501:11: warning: pointer targets in passing argument 1 of ‘vsprintf’ differ in signedness [-Wpointer-sign]
  vsprintf(g_str_buf, fmt, argptr);
           ^~~~~~~~~
In file included from test.tmp.c:4:
/usr/include/stdio.h:349:12: note: expected ‘char * restrict’ but argument is of type ‘byteptr’ {aka ‘unsigned char *’}
 extern int vsprintf (char *__restrict __s, const char *__restrict __format,
            ^~~~~~~~

test.tmp.c:3498:9: warning: unused variable ‘len’ [-Wunused-variable]
  size_t len = vsnprintf(0, 0, fmt, argptr) + 1;
         ^~~
```
<br>

- Option creation
```
test.tmp.c: In function ‘opt_ok’:
test.tmp.c:3358:48: warning: pointer targets in passing argument 1 of ‘tos’ differ in signedness [-Wpointer-sign]
 Option res= (Option) { .ok =  1 , .error = tos("", 0) , } ;
                                                ^~
test.tmp.c:695:9: note: expected ‘byte *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
  string tos(byte* s, int len) {
         ^~~
```
