### PR TITLE
compiler tcc: fix for stb_image.h compilation

### DIFF
--- a/thirdparty/stb_image/stb_image.h
+++ b/thirdparty/stb_image/stb_image.h
@@ -315,6 +315,9 @@ RECENT REVISION HISTORY:
 //     want the zlib decoder to be available, #define STBI_SUPPORT_ZLIB
 //
 
+#ifdef __TINYC__
+#define STBI_NO_SIMD
+#endif
 
 #ifndef STBI_NO_STDIO
 #include <stdio.h>


### PR DESCRIPTION
The tcc compiler does not have emmintrin.h . 
This PR patches stb_image.h , so that STBI_NO_SIMD is defined when tcc is used.

In effect, examples/hot_reload/bounce.v and examples/hot_reload/graph.v can be compiled with tcc too.

(before this, the result of using -cc tcc with them was:
```shell
0[18:48:16] /v/nv $ /v/nv/v -cc tcc -debug examples/hot_reload/bounce.v
C compiler=tcc
INFO: run `v -live program.v` if you want to use [live] functions
In file included from /v/nv/examples/hot_reload/bounce.tmp.c:126:
In file included from /v/nv/thirdparty/stb_image/stb_image.h:651:
/v/nv/thirdparty/stb_image/stb_image.h:651: error: include file 'emmintrin.h' not found
V panic: C error. This should never happen. Please create a GitHub issue: https://github.com/vlang/v/issues/new/choose
1[18:48:18] /v/nv $ 
```
)