### PR TITLE
compiler: prevent multiple same field initialization

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -2856,6 +2856,9 @@ p.gen('($no_star*)memdup(&($no_star)  {') //sizeof(Node));
 			if !t.has_field(field) {
 				p.error('`$t.name` has no field `$field`')
 			}
+			if inited_fields.contains(field) {
+				p.error('already initialized field `$field` in `$t.name`')
+			}
 			f := t.find_field(field)
 			inited_fields << field
 			p.gen('.$field = ')


### PR DESCRIPTION
**Additions:**
Will prompt an error message when trying to initialize the same field multiple time in a struct declaration.

**Notes:**
Have to be merge **after** #1739 . There is a duplicate field initialization in `main.v`, compiling V would prompt an error

**Examples:**
```
struct Foo {
  a int
  b int
}
bar := Foo {
  a: 1
  b: 2
  a: 3
}
```
```
test.v:8:4: already initialized field `a` in `Foo`
```
