### PR TITLE
builtin.string: make trim_left/right() behave correctly

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -591,7 +591,8 @@ pub fn (s string) trim_left(cutset string) string {
 		return s
 	}
 	mut pos := 0
-	for s[pos] in cutset.bytes() {
+	cs_arr := cutset.bytes()
+	for s[pos] in cs_arr {
 		pos++
 	}
 	return s.right(pos)
@@ -602,7 +603,8 @@ pub fn (s string) trim_right(cutset string) string {
 		return s
 	}
 	mut pos := s.len - 1
-	for s[pos] in cutset.bytes() {
+	cs_arr := cutset.bytes()
+	for s[pos] in cs_arr {
 		pos--
 	}
 	return s.left(pos+1)

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -587,22 +587,22 @@ pub fn (s string) trim(c byte) string {
 }
 
 pub fn (s string) trim_left(cutset string) string {
-	mut start := s.index(cutset)
-	if start != 0 {
+	if s.len == 0 || cutset.len == 0 {
 		return s
 	}
-	for start < s.len - 1 && s[start] == cutset[0] {
-		start++
+	mut pos := 0
+	for s[pos] in cutset.bytes() {
+		pos++
 	}
-	return s.right(start)
+	return s.right(pos)
 }
 
 pub fn (s string) trim_right(cutset string) string {
-	if s.len == 0 {
+	if s.len == 0 || cutset.len == 0 {
 		return s
 	}
 	mut pos := s.len - 1
-	for s[pos] == cutset[0] {
+	for s[pos] in cutset.bytes() {
 		pos--
 	}
 	return s.left(pos+1)

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -292,6 +292,9 @@ fn test_trim_left() {
 	assert s.trim_left(' ') == 'module main'
 	s = ' module main'
 	assert s.trim_left(' ') == 'module main'
+	// test cutset
+	s = 'banana'
+	assert s.trim_left('ba') == 'nana'
 }
 
 fn test_trim_right() {
@@ -299,6 +302,9 @@ fn test_trim_right() {
 	assert s.trim_right(' ') == 'module main'
 	s = 'module main '
 	assert s.trim_right(' ') == 'module main'
+	// test cutset
+	s = 'banana'
+	assert s.trim_right('na') == 'b'
 }
 
 fn test_all_after() {


### PR DESCRIPTION
builtin.string: make trim_left/right() behave correctly