### PR TITLE
news_fetcher: unlock mutex before terminating

### DIFF
--- a/examples/news_fetcher.v
+++ b/examples/news_fetcher.v
@@ -27,6 +27,7 @@ fn (f mut Fetcher) fetch() {
 	for {
 		f.mu.lock()
 		if f.cursor >= f.ids.len {
+			f.mu.unlock()
 			return
 		}
 		id := f.ids[f.cursor]


### PR DESCRIPTION
As can be seen in #711, the example does not unlock the mutex before terminating the application. This PR resolves that.