### PR TITLE
json: fix #1751; support unsigned integers

### DIFF
--- a/compiler/jsgen.v
+++ b/compiler/jsgen.v
@@ -124,7 +124,8 @@ string res = tos2("");
 fn is_js_prim(typ string) bool {
 	return typ == 'int' || typ == 'string' ||
 	typ == 'bool' || typ == 'f32' || typ == 'f64' ||
-	typ == 'i8' || typ == 'i16' || typ == 'i32' || typ == 'i64'
+	typ == 'i8' || typ == 'i16' || typ == 'i32' || typ == 'i64' ||
+	typ == 'u8' || typ == 'u16' || typ == 'u32' || typ == 'u64'
 }
 
 fn (p mut Parser) decode_array(array_type string) string {

--- a/vlib/json/json_primitives.v
+++ b/vlib/json/json_primitives.v
@@ -49,6 +49,34 @@ fn jsdecode_i64(root *C.cJSON) i64 {
 	return i64(root.valuedouble) //i64 is double in C
 }
 
+fn jsdecode_u8(root *C.cJSON) u8 {
+	if isnil(root) {
+		return u8(0)
+	}
+	return u8(root.valueint)
+}
+
+fn jsdecode_u16(root *C.cJSON) u16 {
+	if isnil(root) {
+		return u16(0)
+	}
+	return u16(root.valueint)
+}
+
+fn jsdecode_u32(root *C.cJSON) u32 {
+	if isnil(root) {
+		return u32(0)
+	}
+	return u32(root.valueint)
+}
+
+fn jsdecode_u64(root *C.cJSON) u64 {
+	if isnil(root) {
+		return u64(0)
+	}
+	return u64(root.valueint)
+}
+
 fn jsdecode_f32(root *C.cJSON) f32 {
 	if isnil(root) {
 		return f32(0)
@@ -95,11 +123,28 @@ fn jsencode_i8(val i8) *C.cJSON {
 fn jsencode_i16(val i16) *C.cJSON {
 	return C.cJSON_CreateNumber(val)
 }
+
 fn jsencode_i32(val i32) *C.cJSON {
 	return C.cJSON_CreateNumber(val)
 }
 
 fn jsencode_i64(val i64) *C.cJSON {
+	return C.cJSON_CreateNumber(val)
+}
+
+fn jsencode_u8(val u8) *C.cJSON {
+	return C.cJSON_CreateNumber(val)
+}
+
+fn jsencode_u16(val u16) *C.cJSON {
+	return C.cJSON_CreateNumber(val)
+}
+
+fn jsencode_u32(val u32) *C.cJSON {
+	return C.cJSON_CreateNumber(val)
+}
+
+fn jsencode_u64(val u64) *C.cJSON {
 	return C.cJSON_CreateNumber(val)
 }
 


### PR DESCRIPTION
Issue #1751 describes a problem in which unsigned integers are not correctly encoded (and decoded) by the default json library.

I have added support for these types. For future reference: the parser checks if the function for encoding exists, by checking if the function for decoding exists. That means that every encoding function needs a counterpart.

**Test:**
```go
import json

struct test {
    v0 f32
    v1 int 
    v2 u16
    v3 u32
}

t   := test{1.0, 13, u16(17), u32(29)}
js  := json.encode(t)
o   := json.decode(test, js) or {
    panic('Error decoding JSON')
}

println(js)
println('v0: $o.v0, v1: $o.v1, v2: $o.v2, v3: $o.v3')
```

```
[bowero]% v run test.v
{"v0":1,"v1":13,"v2":17,"v3":29}
v0: 1.000000, v1: 13, v2: 17, v3: 29
```