### PR TITLE
builtin.string: make trim use cutset like trim_right/trim_left

### DIFF
--- a/compiler/msvc.v
+++ b/compiler/msvc.v
@@ -325,8 +325,8 @@ pub fn (v mut V) cc_msvc() {
 				}
 			}
 			arg := if lowest != -1 {
-				rest = base.right(lowest).trim_space().trim(`,`)
-				base.left(lowest).trim_space().trim(`,`)
+				rest = base.right(lowest).trim_space().trim(',')
+				base.left(lowest).trim_space().trim(',')
 			} else {
 				rest = ''
 				base.trim_space()

--- a/compiler/query.v
+++ b/compiler/query.v
@@ -9,12 +9,12 @@ import strings
 fn sql_params2params_gen(sql_params []string, sql_types []string, qprefix string) string {
 	mut params_gen := ''
 	for i, mparam in sql_params {
-		param := mparam.trim(` `)
+		param := mparam.trim_space()
 		paramtype := sql_types[ i ]
 		if param[0].is_digit() {
 			params_gen += '${qprefix}params[$i] = int_str($param).str;\n'
 		}else if param[0] == `\'` {
-			sparam := param.trim(`\'`)
+			sparam := param.trim('\'')
 			params_gen += '${qprefix}params[$i] = "$sparam";\n'
 		} else {
 			// A variable like q.nr_orders

--- a/compiler/tests/msvc_test.v
+++ b/compiler/tests/msvc_test.v
@@ -28,8 +28,8 @@ fn test_flag_parsing() {
 			}
 		}
 		arg := if lowest != -1 {
-			rest = base.right(lowest).trim_space().trim(`,`)
-			base.left(lowest).trim_space().trim(`,`)
+			rest = base.right(lowest).trim_space().trim(',')
+			base.left(lowest).trim_space().trim(',')
 		} else {
 			rest = ''
 			base.trim_space()

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -590,30 +590,38 @@ pub fn (s string) trim_space() string {
 	return res
 }
 
-pub fn (s string) trim(c byte) string {
-	if s == '' {
-		return ''
+pub fn (s string) trim(cutset string) string {
+	if s.len == 0 || cutset.len == 0 {
+		return s
 	}
-	mut i := 0
-	for i < s.len && c == s[i] {
-		i++
+	cs_arr := cutset.bytes()
+	mut pos_left := 0
+	mut pos_right := s.len - 1
+	mut cs_match := true
+	for pos_left <= s.len && pos_right >= -1 && cs_match {
+		cs_match = false
+		if s[pos_left] in cs_arr {
+			pos_left++
+			cs_match = true
+		}
+		if s[pos_right] in cs_arr {
+			pos_right--
+			cs_match = true
+		}
+		if pos_left > pos_right {
+			return ''
+		}
 	}
-	mut res := s.right(i)
-	mut end := res.len - 1
-	for end >= 0 && c == res[end] {
-		end--
-	}
-	res = res.left(end + 1)
-	return res
+	return s.substr(pos_left, pos_right+1)
 }
 
 pub fn (s string) trim_left(cutset string) string {
 	if s.len == 0 || cutset.len == 0 {
 		return s
 	}
-	mut pos := 0
 	cs_arr := cutset.bytes()
-	for s[pos] in cs_arr {
+	mut pos := 0
+	for pos <= s.len && s[pos] in cs_arr {
 		pos++
 	}
 	return s.right(pos)
@@ -623,9 +631,9 @@ pub fn (s string) trim_right(cutset string) string {
 	if s.len == 0 || cutset.len == 0 {
 		return s
 	}
-	mut pos := s.len - 1
 	cs_arr := cutset.bytes()
-	for s[pos] in cs_arr {
+	mut pos := s.len - 1
+	for pos >= -1 && s[pos] in cs_arr {
 		pos--
 	}
 	return s.left(pos+1)

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -302,6 +302,12 @@ fn test_hash() {
 	assert s5.hash() % ((1 << 20) -1) == 592861
 }
 
+fn test_trim() {
+	assert 'banana'.trim('bna') == ''
+	assert 'abc'.trim('ac') == 'b'
+	assert 'aaabccc'.trim('ac') == 'b'
+}
+
 fn test_trim_left() {
 	mut s := 'module main'
 	assert s.trim_left(' ') == 'module main'


### PR DESCRIPTION
I suggest trim should take cutset (string) over byte as it currently does.
This will make the signature the same as trim_right & trim_left and also the same as in go.

**Another option could be to use generic function so that it can take byte or string?**

I also added extra bounds check to trim_left/trim_right