### PR TITLE
cc.v: disable implicit-function-declaration for FreeBSD

### DIFF
--- a/compiler/cc.v
+++ b/compiler/cc.v
@@ -39,7 +39,7 @@ fn (v mut V) cc() {
 	else {
 		a << '-g'
 	}
-	if v.os != .msvc {
+	if v.os != .msvc && v.os != .freebsd {
 		a << '-Werror=implicit-function-declaration'
 	}
 


### PR DESCRIPTION
To compile V on FreeBSD, "-Werror=implicit-function-declaration" in both v.c and cc.v must be disabled or there will be errors