### PR TITLE
Print backtraces on panic on mac and linux

### DIFF
--- a/compiler/cc.v
+++ b/compiler/cc.v
@@ -39,6 +39,11 @@ fn (v mut V) cc() {
 	else {
 		a << '-g'
 	}
+
+	if v.pref.is_debug {
+		a << ' -rdynamic ' // needed for nicer symbolic backtraces
+	}
+
 	if v.os != .msvc && v.os != .freebsd {
 		a << '-Werror=implicit-function-declaration'
 	}

--- a/compiler/cheaders.v
+++ b/compiler/cheaders.v
@@ -21,6 +21,15 @@ CommonCHeaders = '
 #include <execinfo.h> // backtrace and backtrace_symbols_fd
 #endif
 
+#ifdef __linux__
+#include <execinfo.h> // backtrace and backtrace_symbols_fd
+#endif
+
+#ifdef __linux__
+#include <sys/types.h>
+#include <sys/wait.h> // os__wait uses wait on nix
+#endif
+
 
 #define EMPTY_STRUCT_DECLARATION
 #define OPTION_CAST(x) (x)

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -18,13 +18,18 @@ fn on_panic(f fn (int) int) {
 }
 
 pub fn print_backtrace() {
-	if true {
-		return // TODO
-	}
 	$if mac {
 		buffer := [100]voidptr
 		nr_ptrs := C.backtrace(buffer, 100)
 		C.backtrace_symbols_fd(buffer, nr_ptrs, 1)
+	}
+	$if linux {
+		buffer := [100]voidptr
+		nr_ptrs := C.backtrace(buffer, 100)
+		C.backtrace_symbols_fd(buffer, nr_ptrs, 1)
+	}
+	if true {
+		return // TODO
 	}
 }
 
@@ -43,7 +48,7 @@ fn _panic_debug(line_no int, file,  mod, fn_name, s string) {
 
 pub fn panic(s string) {
 	println('V panic: $s')
-	print_backtrace()
+	//print_backtrace()
 	C.exit(1)
 }
 

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -50,7 +50,7 @@ fn _panic_debug(line_no int, file,  mod, fn_name, s string) {
 	println('     line: ' + line_no.str())
 	println('  message: $s')
 	println('=========================================')
-	print_backtrace_skipping_top_frames(2)
+	print_backtrace_skipping_top_frames(1)
 	C.exit(1)
 }
 

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -56,7 +56,7 @@ fn _panic_debug(line_no int, file,  mod, fn_name, s string) {
 
 pub fn panic(s string) {
 	println('V panic: $s')
-	//print_backtrace()
+	print_backtrace()
 	C.exit(1)
 }
 


### PR DESCRIPTION
Enables meaningful backtraces containing function names on v panics, when compiled with -debug flag on linux.

Example:
```v
0[23:01:37] /v/misc $ cat backtrace_example.v 

fn func_x(){
  print_backtrace()
}  
fn func_a(){
  func_x()
}
func_a()

0[23:01:38] /v/misc $ /v/v/v run backtrace_example.v 
./backtrace_example[0x406527]
./backtrace_example[0x406538]
./backtrace_example[0x4067ca]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7fc49eb5e830]
./backtrace_example[0x400bd9]
0[23:01:51] /v/misc $
0[23:01:52] /v/misc $
0[23:01:53] /v/misc $ /v/v/v -debug run backtrace_example.v 
C compiler=cc
./backtrace_example(func_x+0xe)[0x408fc2]
./backtrace_example(func_a+0xe)[0x408fd3]
./backtrace_example(main+0x18)[0x409265]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7f8d14aa6830]
./backtrace_example(_start+0x29)[0x402dc9]
0[23:02:01] /v/misc $ 
```

On Mac the same example always prints symbolic backtraces, no matter whether -debug is given:
```
0[23:13:27] /v/misc $ /v/v/v -debug run backtrace_example.v 
C compiler=cc
0   backtrace_example                   0x000000010273ebd9 func_x + 9
1   backtrace_example                   0x000000010273ebe9 func_a + 9
2   backtrace_example                   0x000000010273ee29 main + 25
3   backtrace_example                   0x00000001027377e4 start + 52
4   ???                                 0x0000000000000002 0x0 + 2
0[23:13:32] /v/misc $ 
```