### PR TITLE
cc.v: use -rdynamic only if host os is not windows

### DIFF
--- a/compiler/cc.v
+++ b/compiler/cc.v
@@ -40,7 +40,7 @@ fn (v mut V) cc() {
 		a << '-g'
 	}
 
-	if v.pref.is_debug {
+	if v.pref.is_debug && os.user_os() != 'windows'{
 		a << ' -rdynamic ' // needed for nicer symbolic backtraces
 	}
 


### PR DESCRIPTION
-rdynamic

Pass the flag -export-dynamic to the ELF linker, on targets that support it. This instructs the linker to add all symbols, not only used ones, to the dynamic symbol table. This option is needed for some uses of dlopen or to allow obtaining backtraces from within a program.
(https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html)

with -rdynamic 
`gcc: error: unrecognized command line option '-rdynamic'`

with -export-dynamic

`ld.exe: warning: --export-dynamic is not supported for PE+ targets, did you mean --export-all-symbols?`
