### PR TITLE
msvc: stop v2 from not producing anything

### DIFF
--- a/make_msvc.bat
+++ b/make_msvc.bat
@@ -27,7 +27,7 @@ if %ERRORLEVEL% GEQ 1 (
 )
 
 echo rebuild from source
-v2.exe -os msvc -o v.exe compiler
+v2.exe -o v.exe compiler
 if %ERRORLEVEL% GEQ 1 (
    goto :compileerror
 )


### PR DESCRIPTION
This parameter seems to stop v2 from dropping `v.exe` in the directory when producing with MSVC. The fact that `v2` silently fails if the `-os` parameter is provided should be looked into. This PR fixes #1740.