### PR TITLE
fix building v on alpine with musl libc

### DIFF
--- a/compiler/cheaders.v
+++ b/compiler/cheaders.v
@@ -23,6 +23,8 @@ CommonCHeaders = '
 
 #ifdef __linux__
 #include <execinfo.h> // backtrace and backtrace_symbols_fd
+#pragma weak backtrace
+#pragma weak backtrace_symbols_fd
 #endif
 
 #ifdef __linux__

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -25,10 +25,15 @@ pub fn print_backtrace_skipping_top_frames(skipframes int) {
 		return
 	}
 	$if linux {
-		buffer := [100]voidptr
-		nr_ptrs := C.backtrace(buffer, 100)
-		C.backtrace_symbols_fd(&buffer[skipframes], nr_ptrs-skipframes, 1)
-		return
+		if C.backtrace_symbols_fd != 0 {
+			buffer := [100]voidptr
+			nr_ptrs := C.backtrace(buffer, 100)
+			C.backtrace_symbols_fd(&buffer[skipframes], nr_ptrs-skipframes, 1)
+			return
+		}else{
+			C.printf('backtrace_symbols_fd is missing, so printing backtraces is not available.\n')
+			C.printf('Some libc implementations like musl simply do not provide it.\n')
+		}
 	}
 	C.printf('print_backtrace_skipping_top_frames is not implemented on this platform for now...\n')
 }

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -19,14 +19,14 @@ fn on_panic(f fn (int) int) {
 
 pub fn print_backtrace_skipping_top_frames(skipframes int) {
 	$if mac {
-		buffer := [100]voidptr
+		buffer := [100]byteptr
 		nr_ptrs := C.backtrace(buffer, 100)
 		C.backtrace_symbols_fd(&buffer[skipframes], nr_ptrs-skipframes, 1)
 		return
 	}
 	$if linux {
 		if C.backtrace_symbols_fd != 0 {
-			buffer := [100]voidptr
+			buffer := [100]byteptr
 			nr_ptrs := C.backtrace(buffer, 100)
 			C.backtrace_symbols_fd(&buffer[skipframes], nr_ptrs-skipframes, 1)
 			return


### PR DESCRIPTION
Alpine linux uses musl as its libc. 
musl does not have backtrace nor backtrace_symbols_fd.
This leads to the following error:
```
/v # make
rm -rf vc/
git clone --depth 1 --quiet https://github.com/vlang/vc
cc -std=gnu11 -w -o v vc/v.c -lm
cc -/usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /tmp/cceKAeaM.o: in function `print_backtrace_skipping_top_frames':
v.c:(.text+0x38c3): undefined reference to `backtrace'
/usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: v.c:(.text+0x390c): undefined reference to `backtrace_symbols_fd'
collect2: error: ld returned 1 exit status
make: *** [Makefile:6: all] Error 1
/v #
```

With this PR, v can build again, and print_backtrace_skipping_top_frames will print:
```
backtrace_symbols_fd is missing, so printing backtraces is not available.
Some libc implementations like musl simply do not provide it.
```