### PR TITLE
compiler: use cerror instead of panic.

### DIFF
--- a/compiler/cc.v
+++ b/compiler/cc.v
@@ -101,7 +101,7 @@ mut args := ''
 	// else {
 	a << '-o $v.out_name'
 	if os.dir_exists(v.out_name) {
-		panic('\'$v.out_name\' is a directory')
+		cerror('\'$v.out_name\' is a directory')
 	}
 	if v.os == .mac {
 		a << '-x objective-c'
@@ -143,12 +143,12 @@ mut args := ''
 		println(cmd)
 	}
 	ticks := time.ticks()
-	res := os.exec(cmd) or { panic(err) }
+	res := os.exec(cmd) or { cerror(err) return }
 	if res.exit_code != 0 {
 
 		if res.exit_code == 127 {
 			// the command could not be found by the system
-			panic('C compiler error, while attempting to run: \n' +
+			cerror('C compiler error, while attempting to run: \n' +
 				'-----------------------------------------------------------\n' +
 				'$cmd\n' +
 				'-----------------------------------------------------------\n' +
@@ -159,12 +159,15 @@ mut args := ''
 		if v.pref.is_debug {
 			println(res.output)
 		} else {
-			print(res.output.limit(200))
-			if res.output.len > 200 {
+			partial_output := res.output.limit(200).trim_right('\r\n')
+			print(partial_output)
+			if res.output.len > partial_output.len {
 				println('...\n(Use `v -debug` to print the entire error message)\n')
+			}else{
+				println('')
 			}
 		}
-		panic('C error. This should never happen. ' +
+		cerror('C error. This should never happen. ' +
 			'Please create a GitHub issue: https://github.com/vlang/v/issues/new/choose')
 	}
 	diff := time.ticks() - ticks
@@ -187,7 +190,8 @@ mut args := ''
 		obj_file +
 		' /usr/lib/x86_64-linux-gnu/libc.so ' +
 		'/usr/lib/x86_64-linux-gnu/crtn.o') or {
-			panic(err)
+			cerror(err)
+			return
 		}
 		println(ress.output)
 		println('linux cross compilation done. resulting binary: "$v.out_name"')

--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -263,7 +263,8 @@ fn build_thirdparty_obj_file(flag string) {
 	cc := find_c_compiler()
 	cc_thirdparty_options := find_c_compiler_thirdparty_options()
 	res := os.exec('$cc $cc_thirdparty_options -c -o $obj_path $cfiles') or {
-		panic(err)
+		cerror(err)
+		return
 	}
 	println(res.output)
 }
@@ -279,7 +280,8 @@ fn os_name_to_ifdef(name string) string {
 		case 'dragonfly': return '__DragonFly__'
 		case 'msvc': return '_MSC_VER'
 	}
-	panic('bad os ifdef name "$name"')
+	cerror('bad os ifdef name "$name"')
+	return ''
 }
 
 fn platform_postfix_to_ifdefguard(name string) string {
@@ -290,7 +292,8 @@ fn platform_postfix_to_ifdefguard(name string) string {
     case '_lin.v': return '#ifdef __linux__'
     case '_mac.v': return '#ifdef __APPLE__'
   }
-  panic('bad platform_postfix "$name"')
+  cerror('bad platform_postfix "$name"')
+  return ''
 }
 
 // C struct definitions, ordered

--- a/compiler/modules.v
+++ b/compiler/modules.v
@@ -164,7 +164,7 @@ fn (v &V) find_module_path(mod string) string {
 	if !os.dir_exists(import_path) {
 		import_path = '$ModPath/$mod_path'
 		if !os.dir_exists(import_path){
-			panic('module "$mod" not found')
+			cerror('module "$mod" not found')
 		} 
 	}
 	return import_path 

--- a/compiler/msvc.v
+++ b/compiler/msvc.v
@@ -200,7 +200,8 @@ fn find_msvc() ?MsvcResult {
 		}
 	}
 	$else {
-		panic('Cannot find msvc on this OS')
+		cerror('Cannot find msvc on this OS')
+		return error('msvc not found')
 	}
 }
 
@@ -215,7 +216,8 @@ pub fn (v mut V) cc_msvc() {
 		if !v.pref.is_debug && v.out_name_c != 'v.c' && v.out_name_c != 'v_macos.c' {
 			os.rm('.$v.out_name_c')
 		}
-		panic('Cannot find MSVC on this OS.')
+		cerror('Cannot find MSVC on this OS.')
+		return
 	}
 
 	out_name_obj := v.out_name_c + '.obj'
@@ -349,7 +351,7 @@ pub fn (v mut V) cc_msvc() {
 			// by the compiler
 			if fl == '-l' {
 				if arg.ends_with('.dll') {
-					panic('MSVC cannot link against a dll (`#flag -l $arg`)')
+					cerror('MSVC cannot link against a dll (`#flag -l $arg`)')
 				}
 
 				// MSVC has no method of linking against a .dll
@@ -410,10 +412,11 @@ pub fn (v mut V) cc_msvc() {
 
 	res := os.exec(cmd) or {
 		println(err)
-		panic('msvc error')
+		cerror('msvc error')
+		return
 	}
 	if res.exit_code != 0 {
-		panic(res.output)
+		cerror(res.output)
 	}
 	// println(res)
 	// println('C OUTPUT:')
@@ -458,7 +461,8 @@ fn build_thirdparty_obj_file_with_msvc(flag string) {
 	println('$cfiles')
 
 	res := os.exec('""$msvc.exe_path\\cl.exe" /volatile:ms /Z7 $include_string /c $cfiles /Fo"$obj_path" /D_UNICODE /DUNICODE"') or {
-		panic(err)
+		cerror(err)
+		return
 	}
 	println(res.output)
 }

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -265,7 +265,8 @@ fn (p mut Parser) parse(pass Pass) {
 			}
 			if false && !p.first_pass() && p.fileis('main.v') {
 				out := os.create('/var/tmp/fmt.v') or {
-					panic('failed to create fmt.v')
+					cerror('failed to create fmt.v')
+					return
 				}
 				out.writeln(p.scanner.fmt_out.str())
 				out.close()
@@ -462,7 +463,8 @@ fn key_to_type_cat(tok Token) TypeCategory {
 	case Token.key_union: return TypeCategory.union_
 	//Token.key_ => return .interface_
 	}
-	panic('')
+	cerror('Unknown token: $tok')
+	return TypeCategory.builtin
 }
 
 // also unions and interfaces

--- a/compiler/query.v
+++ b/compiler/query.v
@@ -23,7 +23,7 @@ fn sql_params2params_gen(sql_params []string, sql_types []string, qprefix string
 			}else if paramtype == 'string' {
 				params_gen += '${qprefix}params[$i] = ${param}.str;\n'
 			}else{
-				panic('orm: only int and string variable types are supported in queries')
+				cerror('orm: only int and string variable types are supported in queries')
 			}
 		}
 	}

--- a/compiler/repl.v
+++ b/compiler/repl.v
@@ -122,7 +122,8 @@ fn run_repl() []string {
 			source_code := r.functions.join('\n') + r.lines.join('\n') + '\n' + line
 			os.write_file(file, source_code)
 			s := os.exec('$vexe run $file -repl') or {
-				panic(err)
+				cerror(err)
+				return []string
 			}
 			vals := s.output.split('\n')
 			for i:=0; i < vals.len; i++ {
@@ -140,7 +141,8 @@ fn run_repl() []string {
 			temp_source_code := r.functions.join('\n') + r.lines.join('\n') + r.temp_lines.join('\n') + '\n' + temp_line
 			os.write_file(temp_file, temp_source_code)
 			s := os.exec('$vexe run $temp_file -repl') or {
-				panic(err)
+				cerror(err)
+				return []string
 			}
 			if !func_call && !s.exit_code {
 				for r.temp_lines.len > 0 {

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -28,11 +28,12 @@ mut:
 
 fn new_scanner(file_path string) *Scanner {
 	if !os.file_exists(file_path) {
-		panic('"$file_path" doesn\'t exist')
+		cerror('"$file_path" doesn\'t exist')
 	}
 
 	mut raw_text := os.read_file(file_path) or {
-		panic('scanner: failed to open "$file_path"')
+		cerror('scanner: failed to open "$file_path"')
+		return 0
 	}
 
 	// BOM check

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -800,7 +800,8 @@ fn (t mut Table) fn_gen_types(fn_name string) []string {
 			return f.types
 		}
 	}
-	panic('function $fn_name not found')
+	cerror('function $fn_name not found')
+	return []string
 }
 
 // `foo<Bar>()`
@@ -892,7 +893,7 @@ fn (fit mut FileImportTable) register_import(mod string) {
 
 fn (fit mut FileImportTable) register_alias(alias string, mod string) {
 	if alias in fit.imports {
-		panic('cannot import $mod as $alias: import name $alias already in use in "${fit.file_path}".')
+		cerror('cannot import $mod as $alias: import name $alias already in use in "${fit.file_path}".')
 	}
 	if mod.contains('.internal.') {
 		mod_parts := mod.split('.')
@@ -903,7 +904,7 @@ fn (fit mut FileImportTable) register_alias(alias string, mod string) {
 		}
 		internal_parent := internal_mod_parts.join('.')
 		if !fit.module_name.starts_with(internal_parent) {
-			panic('module $mod can only be imported internally by libs.')
+			cerror('module $mod can only be imported internally by libs.')
 		}
 	}
 	fit.imports[alias] = mod


### PR DESCRIPTION
V compiler does not use panic internally anymore (thus v compiler error messages do not print backtraces).

Example before:
```shell
0[03:35:26] /v/v $ ./v run bt.v 
/v/v/bt.tmp.c:178:6: error: expected identifier or ‘(’ before ‘register’
 bool register;
      ^V panic: C error. This should never happen. Please create a GitHub issue: https://github.com/vlang/v/issues/new/choose
./v[0x405ce7]
./v[0x40e5e2]
./v[0x41c2c3]
./v[0x41b873]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7fe1b5e8b830]
./v[0x402199]
1[03:36:07] /v/v $ 
```

Same example after this PR:
```shell
0[03:36:48] /v/v $ ./vv run bt.v 
/v/v/bt.tmp.c:178:6: error: expected identifier or ‘(’ before ‘register’
 bool register;
      ^
V error: C error. This should never happen. Please create a GitHub issue: https://github.com/vlang/v/issues/new/choose
1[03:36:49] /v/v $ 
```