### PR TITLE
repl: fix incorrect string open/close check

### DIFF
--- a/compiler/repl.v
+++ b/compiler/repl.v
@@ -22,7 +22,7 @@ fn (r mut Repl) checks(line string) bool {
 	was_indent := r.indent > 0
 
 	for i := 0; i < line.len; i++ {
-		if line[i] == `\'` && (i != 0 && line[i - 1] != `\\`) {
+		if line[i] == `\'` && (i == 0 || line[i - 1] != `\\`) {
 			in_string = !in_string
 		}
 		if line[i] == `{` && !in_string {

--- a/compiler/tests/repl/naked_strings.repl
+++ b/compiler/tests/repl/naked_strings.repl
@@ -1,5 +1,9 @@
 'abc'
 'abc'+'xyz'
+'{'
+'}'
 ===output===
 abc
 abcxyz
+{
+}


### PR DESCRIPTION
Run REPL, type `'{'` and the REPL waits for further input by showing `...`. Fixed and added tests, hope it makes sense ^ ^

Ref: #1777, #1779