### PR TITLE
compiler: prompt error if trying to use f for floats

### DIFF
--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -146,6 +146,9 @@ fn (s mut Scanner) ident_dec_number() string {
 		for s.pos < s.text.len && s.text[s.pos].is_digit() {
 			s.pos++
 		}
+		if !s.inside_string && s.pos < s.text.len && s.text[s.pos] == `f` {
+			s.error('no `f` is needed for floats')
+		}
 	}
 
 	// scan exponential part


### PR DESCRIPTION
**Additions:**
Will gives an error if you try to add `f` to create a float

**Notes:**
Fix #1750 

**Examples:**
```
a := 1.0f
```
```
/.../test.v:1:8: no `f` is needed for floats
```