### PR TITLE
compiler: allow functions return without main function

### DIFF
--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -494,6 +494,7 @@ _thread_so = CreateThread(0, 0, (LPTHREAD_START_ROUTINE)&reload_so, 0, 0, 0);
 	}
 	p.check_unused_variables()
 	p.cur_fn = EmptyFn
+	p.returns = false
 	if !is_generic {
 		p.genln('}')
 	}


### PR DESCRIPTION
**Additions:**
Allows to compiles functions with returns in a file without a main

**Notes:**
Fix #1663 

**Examples:**
```
fn test() int {
  return 42
}
println(test())
```
- Before :
```
/.../test.v:4:7: unreachable code
```
- After :
```
42
```