### PR TITLE
compiler: change non-allocation condition for print optimization

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -2536,8 +2536,7 @@ fn (p mut Parser) string_expr() {
 	// println: don't allocate a new string, just print	it.
 	$if !windows {
 		cur_line := p.cgen.cur_line.trim_space()
-		if cur_line.contains('println (') && p.tok != .plus &&
-			!cur_line.contains('string_add') && !cur_line.contains('eprintln') {
+		if cur_line == 'println (' && p.tok != .plus {
 			p.cgen.resetln(cur_line.replace('println (', 'printf('))
 			p.gen('$format\\n$args')
 			return


### PR DESCRIPTION
**Additions:**
Changes case to access non-allocation condition for print optimization.

Explanation : Only if `cur_line` is `println (` can something like `printf ("foo %d", bar);` be generated. 

**Notes:**
Fix #1662 

**Examples:**
```
fn foo(s string) string {
  return s
}

a := 1
println(foo('bar $a'))
```
- Before :
```
/.../test.tmp.c: In function ‘main’:
/.../test.tmp.c:3563:15: error: incompatible type for argument 1 of ‘foo’
 printf( foo ( "bar %d\n", a ) ) ;
               ^~~~~~~~~~
/.../test.tmp.c:3552:20: note: expected ‘string’ {aka ‘struct string’} but argument is of type ‘char *’
  string foo(string s) {
             ~~~~~~~^
/.../test.tmp.c:3563:9: error: too many arguments to function ‘foo’
 printf( foo ( "bar %d\n", a ) ) ;
         ^~~
/.../test.tmp.c:3552:9: note: declared here
  string foo(string s) {
         ^~~
V error: C error. This should never happen. Please create a GitHub issue: https://github.com/vlang/v/issues/new/choose
```
- After :
```
bar 1
```