### PR TITLE
compiler: nested structure print error fix

### DIFF
--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -860,7 +860,7 @@ fn (p mut Parser) fn_call_args(f mut Fn) *Fn {
 				error_msg := ('`$typ` needs to have method `str() string` to be printable')
 				if T.fields.len > 0 {
 					mut index := p.cgen.cur_line.len - 1
-					for index > 0 && p.cgen.cur_line[index] != ` ` { index-- }
+					for index > 0 && p.cgen.cur_line[index - 1] != `(` { index-- }
 					name := p.cgen.cur_line.right(index + 1)
 					if name == '}' {
 						p.error(error_msg)


### PR DESCRIPTION
**Additions:**
Fix a C compilation error when trying to print a nested structure

**Notes:**
Answers part of #1727 
The printing doesn't work. The compiler will try to print the `Outer` struct, not the inner one. (See examples below).

**Examples:**
```
struct Inner {
  val i32
}
struct Outer {
  foo Inner
}
p := Outer{Inner{}}
println(p.foo)
```
- Before :
```
/.../test.tmp.c: In function ‘main’:
/.../test.tmp.c:3613:14: error: expected ‘)’ before ‘tos2’
   println ( p tos2((byte*)"{ val: $.foo.val }") ) ;
              ^~~~~
              )
/.../test.tmp.c:3613:13: error: incompatible type for argument 1 of ‘println’
   println ( p tos2((byte*)"{ val: $.foo.val }") ) ;
             ^
/.../test.tmp.c:2383:22: note: expected ‘string’ {aka ‘struct string’} but argument is of type ‘Outer’ {aka ‘struct Outer’}
  void println(string s) {
               ~~~~~~~^
V error: C error. This should never happen. Please create a GitHub issue: https://github.com/vlang/v/issues/new/choose

```
- After (To fix) :
```
/.../test.v:8:30: unhandled sprintf format "Outer"
```