### PR TITLE
log: add seconds to terminal output too.

### DIFF
--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -54,7 +54,7 @@ pub fn (l Log) error(s string){
         case 'terminal':
             f := term.red('E')
             t := time.now()
-            println('[$f ${t.format()}] $s')
+            println('[$f ${t.format_ss()}] $s')
 
         default:
             l.log_file(s, 'E')
@@ -68,7 +68,7 @@ pub fn (l Log) warn(s string){
         case 'terminal':
             f := term.yellow('W')
             t := time.now()
-            println('[$f ${t.format()}] $s')
+            println('[$f ${t.format_ss()}] $s')
 
         default:
             l.log_file(s, 'W')
@@ -82,7 +82,7 @@ pub fn (l Log) info(s string){
         case 'terminal':
             f := term.white('I')
             t := time.now()
-            println('[$f ${t.format()}] $s')
+            println('[$f ${t.format_ss()}] $s')
 
         default:
             l.log_file(s, 'I')
@@ -96,7 +96,7 @@ pub fn (l Log) debug(s string){
         case 'terminal':
             f := term.blue('D')
             t := time.now()
-            println('[$f ${t.format()}] $s')
+            println('[$f ${t.format_ss()}] $s')
 
         default:
             l.log_file(s, 'D')


### PR DESCRIPTION
With this PR, logging in a terminal prints seconds too.

Example:
```
0[13:00:02] /v/wip_vcupdate $ v -debug run /v/v/examples/log.v 
C compiler=cc
[I 2019-08-30 13:00:06] info
[W 2019-08-30 13:00:06] warn
[E 2019-08-30 13:00:06] error
[D 2019-08-30 13:00:06] debug
================ V panic ================
   module: log
 function: fatal()
     file: /v/v/vlib/log/log.v
     line: 47
  message: fatal
=========================================
/v/v/examples/log(_panic_debug+0x123)[0x40a746]
/v/v/examples/log(log__Log_fatal+0x84)[0x4117a4]
/v/v/examples/log(main+0x19f)[0x411f23]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7fbe7b8b3830]
/v/v/examples/log(_start+0x29)[0x406679]
```