### PR TITLE
compiler-fix: allow usage of function pointers

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1649,9 +1649,10 @@ fn (p mut Parser) var_expr(v Var) string {
 	p.next()
 	mut typ := v.typ
 	// Function pointer?
-	if typ.starts_with('fn ') {
-		//println('CALLING FN PTR')
-		//p.print_tok()
+
+	//println('CALLING FN PTR')
+	//p.print_tok()
+	if typ.starts_with('fn ') && p.tok == .lpar {
 		T := p.table.find_type(typ)
 		p.gen('(')
 		p.fn_call_args(mut T.func)


### PR DESCRIPTION
We have a restriction on usage of FP(function pointer). We can only call FPs now. This PR removes this restriction. Fixes https://github.com/vlang/v/issues/1805.

Please title your PR as follows: `time: fix foo bar`. Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

Before submitting a PR, please run the tests with `make test`, and make sure V can still compile itself. Run this twice:

./v -o v compiler
./v -o v compiler
OK
I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!
