### PR TITLE
compiler: fix building v with tcc on linux.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,14 +56,6 @@ script:
       ./v test v
     fi
   - |
-## tcc on ubuntu is 0.9.26, while v can compile with 0.9.27
-##    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-##      echo "Ensure that v can build itself with tcc too ..."
-##      /usr/bin/tcc -version
-##      ./v -cc /usr/bin/tcc -o vtcc compiler/
-##      ls -la vtcc
-##    fi
-##  - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
       git clone https://github.com/vlang/vid
       cd vid && ../v -debug -o vid .

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
             - libglfw3-dev
             - libfreetype6-dev
             - libssl-dev
+            - tcc
     - os: windows
       language: sh
       filter_secrets: false
@@ -54,6 +55,13 @@ script:
       make
       #./v install glfw
       ./v test v
+    fi
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      echo "Ensure that v can build itself with tcc too ..."
+      /usr/bin/tcc -version
+      ./v -cc /usr/bin/tcc -o vtcc compiler/
+      ls -la vtcc
     fi
   - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
             - libglfw3-dev
             - libfreetype6-dev
             - libssl-dev
-            - tcc
     - os: windows
       language: sh
       filter_secrets: false
@@ -57,13 +56,14 @@ script:
       ./v test v
     fi
   - |
-    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      echo "Ensure that v can build itself with tcc too ..."
-      /usr/bin/tcc -version
-      ./v -cc /usr/bin/tcc -o vtcc compiler/
-      ls -la vtcc
-    fi
-  - |
+## tcc on ubuntu is 0.9.26, while v can compile with 0.9.27
+##    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+##      echo "Ensure that v can build itself with tcc too ..."
+##      /usr/bin/tcc -version
+##      ./v -cc /usr/bin/tcc -o vtcc compiler/
+##      ls -la vtcc
+##    fi
+##  - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
       git clone https://github.com/vlang/vid
       cd vid && ../v -debug -o vid .

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -2731,7 +2731,7 @@ fn (p mut Parser) array_init() string {
 		new_arr += '_no_alloc'
 	}
 
-	if i == 0 {
+	if i == 0 && p.pref.ccompiler != 'tcc' {
 		p.gen(' 0 })')
 	} else {
 		p.gen(' })')


### PR DESCRIPTION
Without this PR:
```
0[13:28:01] /v/v $ ./v -cc tcc -o vtcc compiler
/v/v/vtcc.tmp.c:1883: error: index too large
V error: C error. This should never happen. 
Please create a GitHub issue: 
https://github.com/vlang/v/issues/new/choose
```