### PR TITLE
crypto: add utility hexhash functions 

### DIFF
--- a/vlib/crypto/md5/md5.v
+++ b/vlib/crypto/md5/md5.v
@@ -49,7 +49,7 @@ fn (d mut Digest) reset() {
 }
 
 // new returns a new Digest (implementing hash.Hash) computing the MD5 checksum.
-pub fn new() *Digest {
+pub fn new() &Digest {
 	mut d := &Digest{}
 	d.reset()
 	return d

--- a/vlib/crypto/md5/md5.v
+++ b/vlib/crypto/md5/md5.v
@@ -141,3 +141,5 @@ fn block(dig mut Digest, p []byte) {
 pub fn (d &Digest) size() int { return Size }
 
 pub fn (d &Digest) block_size() int { return BlockSize }
+
+pub fn hexhash(s string) string { return sum(s.bytes()).hex() }

--- a/vlib/crypto/sha1/sha1.v
+++ b/vlib/crypto/sha1/sha1.v
@@ -146,3 +146,5 @@ fn block(dig &Digest, p []byte) {
 pub fn (d &Digest) size() int { return Size }
 
 pub fn (d &Digest) block_size() int { return BlockSize }
+
+pub fn hexhash(s string) string { return sum(s.bytes()).hex() }

--- a/vlib/crypto/sha256/sha256.v
+++ b/vlib/crypto/sha256/sha256.v
@@ -212,3 +212,6 @@ pub fn (d &Digest) size() int {
 }
 
 pub fn (d &Digest) block_size() int { return BlockSize }
+
+pub fn hexhash(s string) string { return sum256(s.bytes()).hex() }
+pub fn hexhash_224(s string) string { return sum224(s.bytes()).hex() }

--- a/vlib/crypto/sha256/sha256.v
+++ b/vlib/crypto/sha256/sha256.v
@@ -78,14 +78,14 @@ fn (d mut Digest) reset() {
 }
 
 // new returns a new Digest (implementing hash.Hash) computing the SHA256 checksum.
-pub fn new() *Digest {
+pub fn new() &Digest {
 	mut d := &Digest{}
 	d.reset()
 	return d
 }
 
 // new224 returns a new Digest (implementing hash.Hash) computing the SHA224 checksum.
-pub fn new224() *Digest {
+pub fn new224() &Digest {
 	mut d := &Digest{}
 	d.is224 = true
 	d.reset()

--- a/vlib/crypto/sha512/sha512.v
+++ b/vlib/crypto/sha512/sha512.v
@@ -299,3 +299,8 @@ pub fn (d &Digest) size() int {
 }
 
 pub fn (d &Digest) block_size() int { return BlockSize }
+
+pub fn hexhash(s string) string { return sum512(s.bytes()).hex() }
+pub fn hexhash_384(s string) string { return sum384(s.bytes()).hex() }
+pub fn hexhash_512_224(s string) string { return sum512_224(s.bytes()).hex() }
+pub fn hexhash_512_256(s string) string { return sum512_256(s.bytes()).hex() }

--- a/vlib/crypto/sha512/sha512.v
+++ b/vlib/crypto/sha512/sha512.v
@@ -120,29 +120,29 @@ fn (d mut Digest) reset() {
 	d.len = u64(0)
 }
 
-fn _new(hash crypto.Hash) *Digest {
+fn _new(hash crypto.Hash) &Digest {
 	mut d := &Digest{function: hash}
 	d.reset()
 	return d
 }
 
 // new returns a new Digest (implementing hash.Hash) computing the SHA-512 checksum.
-pub fn new() *Digest {
+pub fn new() &Digest {
 	return _new(crypto.Hash.SHA512)
 }
 
 // new512_224 returns a new Digest (implementing hash.Hash) computing the SHA-512/224 checksum.
-fn new512_224() *Digest {
+fn new512_224() &Digest {
 	return _new(crypto.Hash.SHA512_224)
 }
 
 // new512_256 returns a new Digest (implementing hash.Hash) computing the SHA-512/256 checksum.
-fn new512_256() *Digest {
+fn new512_256() &Digest {
 	return _new(crypto.Hash.SHA512_256)
 }
 
 // new384 returns a new Digest (implementing hash.Hash) computing the SHA-384 checksum.
-fn new384() *Digest {
+fn new384() &Digest {
 	return _new(crypto.Hash.SHA384)
 }
 


### PR DESCRIPTION
This PR makes possible the following user code:
```v
import crypto.md5
println( md5.hexhash('my string') )
```

instead of :
```v
import crypto.md5
println( md5.sum( 'my string'.bytes() ).hex() )
```
