### PR TITLE
Make Makefile make windows build succesfully on MSYS2/mingw64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,20 @@
 CC ?= cc
 
+_SYS:=$(shell uname -o)
+ifeq ($(_SYS),Msys)
+WIN32:=1
+endif
+
 all:
 	rm -rf vc/
 	git clone --depth 1 --quiet https://github.com/vlang/vc
+ifdef WIN32
+	${CC} -std=gnu11 -DUNICODE -D_UNICODE -w -o v0.exe vc/v_win.c
+	./v0.exe -o v.exe compiler
+else
 	${CC} -std=gnu11 -w -o v vc/v.c -lm
 	./v -o v compiler
+endif
 	rm -rf vc/
 	@echo "V has been successfully built"
 


### PR DESCRIPTION
This PR adds support for Windows build in the top V Makefile
Useful for MSYS2/mingw64 windows setup, that ship with standard GCC, Make and bash