### PR TITLE
compiler: support explicit runrepl argument, in addition to just plain v

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -193,11 +193,6 @@ fn main() {
 			os.mkdir(ModPath)
 		}
 	}
-	// No args? REPL
-	if args.len < 2 || (args.len == 2 && args[1] == '-') {
-		run_repl()
-		return
-	}
 	// Construct the V object from command line arguments
 	mut v := new_v(args)
 	if v.pref.is_verbose {
@@ -214,6 +209,12 @@ fn main() {
 		// for example for -repl usage, especially when piping lines to v
 		v.compile()
 		v.run_compiled_executable_and_exit()
+	}
+
+	// No args? REPL
+	if args.len < 2 || (args.len == 2 && args[1] == '-') || 'runrepl' in args {
+		run_repl()
+		return
 	}
 
 	v.compile()

--- a/compiler/tests/repl/repl_test.v
+++ b/compiler/tests/repl/repl_test.v
@@ -50,7 +50,7 @@ fn test_the_v_repl() {
 		input_temporary_filename := 'input_temporary_filename.txt'
 		os.write_file(input_temporary_filename, input)
 		defer { os.rm(input_temporary_filename) }		
-		r := os.exec('$vexec < $input_temporary_filename') or {
+		r := os.exec('$vexec runrepl < $input_temporary_filename') or {
 			assert false
 			break
 		}


### PR DESCRIPTION
The goal is to have the ability to pass options like -debug or -os xxx, and so on to v, *without* affecting the repl tests.

Without this, the following fails:
```shell
export VFLAGS="-os linux"
v compiler/tests/repl/repl_test.v
v test v
```

With it, VFLAGS will be passed to all subsequent v processes, so that they all will share the same compiler options...