### PR TITLE
compiler-fix: fix match statemtent unreachable code

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -3400,7 +3400,11 @@ fn (p mut Parser) match_statement(is_expr bool) string {
 
 					return res_typ
 				} else {
-					p.match_parse_statement_branch()
+					p.returns = false
+					p.check(.lcbr)
+					
+					p.genln('{ ')
+					p.statements()
 					p.returns = all_cases_return && p.returns
 					return ''
 				}
@@ -3427,8 +3431,14 @@ fn (p mut Parser) match_statement(is_expr bool) string {
 
 				return res_typ
 			} else {
+				p.returns = false
 				p.genln('else // default:')
-				p.match_parse_statement_branch()
+
+				p.check(.lcbr)
+				
+				p.genln('{ ')
+				p.statements()
+
 				p.returns = all_cases_return && p.returns
 				return ''
 			}
@@ -3504,11 +3514,15 @@ fn (p mut Parser) match_statement(is_expr bool) string {
 			p.gen(')')
 		}
 		else {
-			p.match_parse_statement_branch()
+			p.returns = false
+			p.check(.lcbr)
+			
+			p.genln('{ ')
+			p.statements()
+
+			all_cases_return = all_cases_return && p.returns
 			// p.gen(')')
 		}
-
-		all_cases_return = all_cases_return && p.returns
 		i++
 	}
 
@@ -3520,13 +3534,6 @@ fn (p mut Parser) match_statement(is_expr bool) string {
 	p.returns = false // only get here when no default, so return is not guaranteed
 
 	return ''
-}
-
-fn (p mut Parser) match_parse_statement_branch(){
-	p.check(.lcbr)
-	
-	p.genln('{ ')
-	p.statements()
 }
 
 fn (p mut Parser) assert_statement() {


### PR DESCRIPTION
Add setting `p.return` to false before `p.statements()`
Fixes https://github.com/vlang/v/issues/1850.

Please title your PR as follows: `time: fix foo bar`. Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

Before submitting a PR, please run the tests with `make test`, and make sure V can still compile itself. Run this twice:

./v -o v compiler
./v -o v compiler
OK
I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!
