### PR TITLE
compiler/tests: workaround msvc 0 struct field bug

### DIFF
--- a/compiler/tests/interface_test.v
+++ b/compiler/tests/interface_test.v
@@ -1,4 +1,5 @@
 struct Dog {
+	breed string
 }
 
 fn (d Dog) speak() {


### PR DESCRIPTION
compiler/tests: workaround msvc 0 struct field bug