### PR TITLE
compiler: check if-expressions returning only one type

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -3073,9 +3073,11 @@ fn (p mut Parser) if_st(is_expr bool, elif_depth int) string {
 		}
 		p.check(.lcbr)
 		// statements() returns the type of the last statement
+		first_typ := typ
 		typ = p.statements()
 		p.inside_if_expr = false
 		if is_expr {
+			p.check_types(first_typ, typ)
 			p.gen(strings.repeat(`)`, elif_depth + 1))
 		}
 		else_returns := p.returns


### PR DESCRIPTION
**Additions:**
Won't compile if an if expression is returning different types

**Notes:**
Fix #1862 

**Examples:**
```
a := if true { 'a' } else { 42 } // Error: if expression returns `string` and `int`
```