### PR TITLE
compiler/msvc: support paths with hyphen. fixes #1847

### DIFF
--- a/compiler/msvc.v
+++ b/compiler/msvc.v
@@ -346,7 +346,7 @@ pub fn (v mut V) cc_msvc() {
 				rest = ''
 				base.trim_space()
 			}
-			println('arg: $arg')
+
 			flags << ParsedFlag {
 				fl, arg
 			}

--- a/compiler/msvc.v
+++ b/compiler/msvc.v
@@ -331,7 +331,7 @@ pub fn (v mut V) cc_msvc() {
 			// TODO: we really shouldnt support all of these cmon
 			mut lowest := base.index('-')
 			// make sure hyphen comes before I|l|L to not break paths with hyphens
-			if lowest < base.len-2 && !(base[lowest+1] in [`I`, `l`, `L`]) {
+			if lowest != -1 && lowest < base.len-2 && !(base[lowest+1] in [`I`, `l`, `L`]) {
 				lowest = -1
 			}
 			for x in [base.index(' '), base.index(',')] {

--- a/compiler/msvc.v
+++ b/compiler/msvc.v
@@ -330,6 +330,10 @@ pub fn (v mut V) cc_msvc() {
 			// Which ever one of these is lowest we use
 			// TODO: we really shouldnt support all of these cmon
 			mut lowest := base.index('-')
+			// make sure hyphen comes before I|l|L incase there is hyphen in a path
+			if lowest < base.len-2 && !(base[lowest+1] in [`I`, `l`, `L`]) {
+				lowest = -1
+			}
 			for x in [base.index(' '), base.index(',')] {
 				if (x < lowest && x != -1) || lowest == -1 {
 					lowest = x

--- a/compiler/msvc.v
+++ b/compiler/msvc.v
@@ -330,7 +330,7 @@ pub fn (v mut V) cc_msvc() {
 			// Which ever one of these is lowest we use
 			// TODO: we really shouldnt support all of these cmon
 			mut lowest := base.index('-')
-			// make sure hyphen comes before I|l|L incase there is hyphen in a path
+			// make sure hyphen comes before I|l|L to not break paths with hyphens
 			if lowest < base.len-2 && !(base[lowest+1] in [`I`, `l`, `L`]) {
 				lowest = -1
 			}

--- a/compiler/msvc.v
+++ b/compiler/msvc.v
@@ -330,8 +330,8 @@ pub fn (v mut V) cc_msvc() {
 			// Which ever one of these is lowest we use
 			// TODO: we really shouldnt support all of these cmon
 			mut lowest := base.index('-')
-			// make sure hyphen comes before I|l|L to not break paths with hyphens
-			if lowest != -1 && lowest < base.len-2 && !(base[lowest+1] in [`I`, `l`, `L`]) {
+			// dont break paths with hyphens
+			if lowest != 0  {
 				lowest = -1
 			}
 			for x in [base.index(' '), base.index(',')] {
@@ -346,7 +346,7 @@ pub fn (v mut V) cc_msvc() {
 				rest = ''
 				base.trim_space()
 			}
-
+			println('arg: $arg')
 			flags << ParsedFlag {
 				fl, arg
 			}


### PR DESCRIPTION
compiler/msvc: support paths with hyphen. fixes #1847