### PR TITLE
Update PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,3 +1,5 @@
+Please, delete this in your PR, after reading it.
+
 Please title your PR as follows: `time: fix foo bar`. Always start with the thing you are fixing, then describe the fix.
 Don't use past tense (e.g. "fixed foo bar").
 


### PR DESCRIPTION
Politely ask people to delete the PR boilerplate text, thus hopefully making issue/PR search more useful in the future by reducing the noise.
