### PR TITLE
compiler: rework flags & support win path spaces + more. closes #1847

### DIFF
--- a/compiler/cc.v
+++ b/compiler/cc.v
@@ -128,7 +128,7 @@ mut args := ''
 		a << '-mmacosx-version-min=10.7'
 	}
 	for flag in v.get_os_cflags() {
-		a << flag.tos()
+		a << flag.format()
 	}
 	a << libs
 	// macOS code can include objective C  TODO remove once objective C is replaced with C
@@ -222,7 +222,7 @@ fn (c mut V) cc_windows_cross() {
 	// -I flags
 	for flag in c.get_os_cflags() {
 		if flag.name != '-l' {
-				args += flag.tos()
+				args += flag.format()
 				args += ' '
 		}
 	}
@@ -241,7 +241,7 @@ fn (c mut V) cc_windows_cross() {
 	// -l flags (libs)
 	for flag in c.get_os_cflags() {
 			if flag.name == '-l' {
-					args += flag.tos()
+					args += flag.format()
 					args += ' '
 			}
 	}
@@ -287,7 +287,7 @@ fn (c mut V) cc_windows_cross() {
 
 fn (c V) build_thirdparty_obj_files() {
 	for flag in c.get_os_cflags() {
-		if flag.value.contains('.o') {
+		if flag.value.ends_with('.o') {
 			if c.os == .msvc {
 				build_thirdparty_obj_file_with_msvc(flag.value)
 			}
@@ -315,6 +315,6 @@ fn find_c_compiler_default() string {
 }
 
 fn find_c_compiler_thirdparty_options() string {
-	$if windows {	return '' }
+	$if windows { return '' }
 	return '-fPIC'
 }

--- a/compiler/cc.v
+++ b/compiler/cc.v
@@ -33,9 +33,7 @@ fn (v mut V) cc() {
 	v.log('cc() isprod=$v.pref.is_prod outname=$v.out_name')
 	mut a := [v.pref.cflags, '-std=gnu11', '-w'] // arguments for the C compiler
 
-
 	flags := parse_flags(v.table.flags)
-	//mut shared := ''
 	if v.pref.is_so {
 		a << '-shared -fPIC '// -Wl,-z,defs'
 		v.out_name = v.out_name + '.so'

--- a/compiler/cc.v
+++ b/compiler/cc.v
@@ -33,7 +33,7 @@ fn (v mut V) cc() {
 	v.log('cc() isprod=$v.pref.is_prod outname=$v.out_name')
 	mut a := [v.pref.cflags, '-std=gnu11', '-w'] // arguments for the C compiler
 
-	flags := parse_flags(v.table.flags)
+	flags := parse_cflags(v.table.flags)
 	if v.pref.is_so {
 		a << '-shared -fPIC '// -Wl,-z,defs'
 		v.out_name = v.out_name + '.so'

--- a/compiler/cflags.v
+++ b/compiler/cflags.v
@@ -1,0 +1,118 @@
+// Copyright (c) 2019 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+module main
+
+import os
+
+// C flag
+struct CFlag{
+	os    string // eg. windows | darwin | linux
+	name  string // eg. -I
+	value string // eg. /path/to/incude
+}
+
+fn (table &Table) has_cflag(cflag CFlag) bool {
+	for cf in table.cflags {
+		if cf.os == cflag.os && cf.name == cflag.name && cf.value == cflag.value {
+			return true
+		}
+	}
+	return false
+}
+
+// parse the flags to []CFlag
+// Note: clean up big time (joe-c)
+fn (table mut Table) parse_cflag(cflag string) {
+	allowed_flags := [
+		'framework',
+		'library',
+		'I', 'l', 'L', 
+	]
+	mut flag := cflag.trim_space()
+	if flag == '' {
+		return
+	}
+	mut fos := ''
+	mut name := ''
+	if flag.starts_with('linux') || flag.starts_with('darwin') || flag.starts_with('windows') {
+		pos := flag.index(' ')
+		fos = flag.left(pos).trim_space()
+		flag = flag.right(pos).trim_space()
+	}
+	for {
+		mut index := -1
+		mut value := ''
+		if flag[0] == `-` {
+			for f in allowed_flags {
+				i := 1+f.len
+				if i < flag.len && f == flag.substr(1,i) {
+					name = flag.left(i).trim_space()
+					flag = flag.right(i).trim_space()
+					break
+				}
+			}
+		}
+		for i in [flag.index(' '), flag.index(',')] {
+			if index == -1 || (i != -1 && i < index) {
+				index = i
+			}
+		} if index != -1 && flag[index] == ` ` && flag[index+1] == `-` {
+			for f in allowed_flags {
+				i := index+f.len
+				if i < flag.len && f == flag.substr(index, i) {
+					index = i
+					break
+				}
+			}
+			value = flag.left(index).trim_space()
+			flag = flag.right(index).trim_space()
+		} else if index != -1 && index < flag.len-2 && flag[index] == `,` {
+			value = flag.left(index).trim_space()
+			flag = flag.right(index+1).trim_space()
+		} else {
+			value = flag.trim_space()
+			index = -1
+		}
+		cf := CFlag{
+			os:    fos,
+			name:  name,
+			value: value
+		}
+		if !table.has_cflag(cf) {
+			table.cflags << cf
+		}
+		if index == -1 {
+			break
+		}
+	}
+}
+
+fn (v V) get_os_cflags() []CFlag {
+	mut flags := []CFlag
+	for flag in v.table.cflags {
+		if flag.os == ''
+		|| (flag.os == 'linux' && v.os == .linux)
+		|| (flag.os == 'darwin' && v.os == .mac)
+		|| (flag.os == 'windows' && (v.os == .windows || v.os == .msvc)) {
+			flags << flag
+		}
+	}
+	return flags
+}
+
+fn (cf &CFlag) tos() string {
+	mut value := cf.value
+	// convert to absolute path
+	if cf.name == '-I' || cf.name == '-L' || value.ends_with('.o') {
+		// msvc expects .obj not .o
+		$if msvc {
+			if value.ends_with('.o') {
+				value = '${value}bj'
+			}
+		}
+		value = '"'+os.realpath(value)+'"'
+	}
+	return '$cf.name $cf.value'.trim_space()
+}

--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -384,53 +384,60 @@ fn sort_structs(types []Type) []Type {
 	return types_sorted
 }
 
-// compiler flag
-struct CompilerFlag{
+// C flag
+struct CFlag{
 	name  string // eg. -I
 	value string // eg. /path/to/incude
 }
 
-// parse the flags to []CompilerFlag
+// C flag
+struct CFlag{
+	name  string // eg. -I
+	value string // eg. /path/to/incude
+}
+
+// parse the flags to []CFlag
 // Note: clean up big time (joe-c)
-fn parse_flags(flags []string) []CompilerFlag {
+fn parse_cflags(flags []string) []CFlag {
 	allowed_flags := [
 		'library', 'I', 'l', 'L', 
 	]
-	mut compiler_flags := []CompilerFlag{}
+	mut compiler_flags := []CFlag{}
 	for f in flags {
 		mut flag := f.trim_space()
+		if flag == '' {
+			continue
+		}
 		mut name := ''
 		for {
 			mut index := -1
 			mut value := ''
-			if flag[0] == `-` {
+            if flag[0] == `-` {
 				for f in allowed_flags {
 					i := 1+f.len
-					if i < flag.len && flag.substr(1,i) == f {
+					if i < flag.len && f == flag.substr(1,i) {
 						name = flag.left(i).trim_space()
 						flag = flag.right(i).trim_space()
 						break
 					}
 				}
 			}
-			for i in [flag.index(' '), flag.index(',')] {
+            for i in [flag.index(' '), flag.index(',')] {
 				if index == -1 || (i != -1 && i < index) {
 					index = i
 				}
-			}
-			if index != -1 && flag[index+1] == `-` {
+			} if index != -1 && flag[index] == ` ` && flag[index+1] == `-` {
 				for f in allowed_flags {
 					i := index+f.len
-					if f == flag.substr(index, i) {
+					if i < flag.len && f == flag.substr(index, i) {
 						index = i
 						break
 					}
 				}
 				value = flag.left(index).trim_space()
 				flag = flag.right(index).trim_space()
-			}
-			else if index != -1 && flag[index] == `,` {
-				value = flag.left(index).trim_space()
+			} else if index != -1 && index < flag.len-2 && flag[index] == `,` {
+                value = flag.left(index).trim_space()
 				flag = flag.right(index+1).trim_space()
 			} else {
 				value = flag.trim_space()
@@ -444,7 +451,9 @@ fn parse_flags(flags []string) []CompilerFlag {
 				}
 			}
 			if !exists {
-				compiler_flags << CompilerFlag{
+				println(' # name: $name')
+				println(' # value: $value')
+				compiler_flags << CFlag{
 					name:  name,
 					value: value
 				}

--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -240,8 +240,7 @@ fn (g mut CGen) add_to_main(s string) {
 }
 
 
-fn build_thirdparty_obj_file(flag string) {
-	obj_path := flag.trim_space()
+fn build_thirdparty_obj_file(obj_path string) {
 	if os.file_exists(obj_path) {
 		return
 	}
@@ -382,78 +381,4 @@ fn sort_structs(types []Type) []Type {
 		}
 	}
 	return types_sorted
-}
-
-// C flag
-struct CFlag{
-	name  string // eg. -I
-	value string // eg. /path/to/incude
-}
-
-// parse the flags to []CFlag
-// Note: clean up big time (joe-c)
-fn parse_cflags(flags []string) []CFlag {
-	allowed_flags := [
-		'library', 'I', 'l', 'L', 
-	]
-	mut compiler_flags := []CFlag{}
-	for f in flags {
-		mut flag := f.trim_space()
-		if flag == '' {
-			continue
-		}
-		mut name := ''
-		for {
-			mut index := -1
-			mut value := ''
-			if flag[0] == `-` {
-				for f in allowed_flags {
-					i := 1+f.len
-					if i < flag.len && f == flag.substr(1,i) {
-						name = flag.left(i).trim_space()
-						flag = flag.right(i).trim_space()
-						break
-					}
-				}
-			}
-			for i in [flag.index(' '), flag.index(',')] {
-				if index == -1 || (i != -1 && i < index) {
-					index = i
-				}
-			} if index != -1 && flag[index] == ` ` && flag[index+1] == `-` {
-				for f in allowed_flags {
-					i := index+f.len
-					if i < flag.len && f == flag.substr(index, i) {
-						index = i
-						break
-					}
-				}
-				value = flag.left(index).trim_space()
-				flag = flag.right(index).trim_space()
-			} else if index != -1 && index < flag.len-2 && flag[index] == `,` {
-				value = flag.left(index).trim_space()
-				flag = flag.right(index+1).trim_space()
-			} else {
-				value = flag.trim_space()
-				index = -1
-			}
-			mut exists := false
-			for cf in compiler_flags {
-				if name == cf.name && value == cf.value {
-					exists = true
-					break
-				}
-			}
-			if !exists {
-				compiler_flags << CFlag{
-					name:  name,
-					value: value
-				}
-			}
-			if index == -1 {
-				break
-			}
-		}
-	}
-	return compiler_flags
 }

--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -390,12 +390,6 @@ struct CFlag{
 	value string // eg. /path/to/incude
 }
 
-// C flag
-struct CFlag{
-	name  string // eg. -I
-	value string // eg. /path/to/incude
-}
-
 // parse the flags to []CFlag
 // Note: clean up big time (joe-c)
 fn parse_cflags(flags []string) []CFlag {
@@ -451,8 +445,6 @@ fn parse_cflags(flags []string) []CFlag {
 				}
 			}
 			if !exists {
-				println(' # name: $name')
-				println(' # value: $value')
 				compiler_flags << CFlag{
 					name:  name,
 					value: value

--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -240,7 +240,8 @@ fn (g mut CGen) add_to_main(s string) {
 }
 
 
-fn build_thirdparty_obj_file(obj_path string) {
+fn build_thirdparty_obj_file(path string) {
+	obj_path := os.realpath(path)
 	if os.file_exists(obj_path) {
 		return
 	}

--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -281,15 +281,15 @@ fn os_name_to_ifdef(name string) string {
 }
 
 fn platform_postfix_to_ifdefguard(name string) string {
-  switch name {
-    case '.v': return '' // no guard needed
-    case '_win.v': return '#ifdef _WIN32'
-    case '_nix.v': return '#ifndef _WIN32'
-    case '_lin.v': return '#ifdef __linux__'
-    case '_mac.v': return '#ifdef __APPLE__'
-  }
-  cerror('bad platform_postfix "$name"')
-  return ''
+	switch name {
+		case '.v': return '' // no guard needed
+		case '_win.v': return '#ifdef _WIN32'
+		case '_nix.v': return '#ifndef _WIN32'
+		case '_lin.v': return '#ifdef __linux__'
+		case '_mac.v': return '#ifdef __APPLE__'
+	}
+	cerror('bad platform_postfix "$name"')
+	return ''
 }
 
 // C struct definitions, ordered
@@ -406,7 +406,7 @@ fn parse_cflags(flags []string) []CFlag {
 		for {
 			mut index := -1
 			mut value := ''
-            if flag[0] == `-` {
+			if flag[0] == `-` {
 				for f in allowed_flags {
 					i := 1+f.len
 					if i < flag.len && f == flag.substr(1,i) {
@@ -416,7 +416,7 @@ fn parse_cflags(flags []string) []CFlag {
 					}
 				}
 			}
-            for i in [flag.index(' '), flag.index(',')] {
+			for i in [flag.index(' '), flag.index(',')] {
 				if index == -1 || (i != -1 && i < index) {
 					index = i
 				}
@@ -431,7 +431,7 @@ fn parse_cflags(flags []string) []CFlag {
 				value = flag.left(index).trim_space()
 				flag = flag.right(index).trim_space()
 			} else if index != -1 && index < flag.len-2 && flag[index] == `,` {
-                value = flag.left(index).trim_space()
+				value = flag.left(index).trim_space()
 				flag = flag.right(index+1).trim_space()
 			} else {
 				value = flag.trim_space()

--- a/compiler/comptime.v
+++ b/compiler/comptime.v
@@ -141,46 +141,11 @@ fn (p mut Parser) chash() {
 	is_sig := p.is_sig()
 	if hash.starts_with('flag ') {
 		mut flag := hash.right(5)
-		// No the right os? Skip!
-		// mut ok := true
-		if hash.contains('linux') && p.os != .linux {
-			return
-		}
-		else if hash.contains('darwin') && p.os != .mac {
-			return
-		}
-		else if hash.contains('windows') && (p.os != .windows && p.os != .msvc) {
-			return
-		}
-		// Remove "linux" etc from flag
-		if flag.contains('linux') || flag.contains('darwin') || flag.contains('windows') {
-			pos := flag.index(' ')
-			flag = flag.right(pos)
-		}
-		has_vroot := flag.contains('@VROOT')
-		flag = flag.trim_space().replace('@VROOT', p.vroot)
-		if p.table.flags.contains(flag) {
-			return
-		}
-		// expand `@VMOD/pg/pg.o` to absolute path
-		has_vmod := flag.contains('@VMOD')
-		flag = flag.trim_space().replace('@VMOD', ModPath)
-		if p.table.flags.contains(flag) {
-			return
-		}
+		// expand `@VROOT` `@VMOD` to absolute path
+		flag = flag.replace('@VROOT', p.vroot)
+		flag = flag.replace('@VMOD', ModPath)
 		p.log('adding flag "$flag"')
-		// `@VROOT/thirdparty/glad/glad.o`, make sure it exists, otherwise build it
-		if (has_vroot || has_vmod) && flag.contains('.o') {
-			flag = os.realpath( flag )
-			//println( 'absolute filepath to objectfile is now: $flag | os is: $p.os ')
-			if p.os == .msvc {
-				build_thirdparty_obj_file_with_msvc(flag)
-			}
-			else {
-				build_thirdparty_obj_file(flag)
-			}
-		}
-		p.table.flags << flag
+		p.table.parse_cflag(flag)
 		return
 	}
 	if hash.starts_with('include') {

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -326,7 +326,7 @@ fn (v mut V) compile() {
 	if v.pref.is_verbose {
 		v.log('flags=')
 		for flag in v.get_os_cflags() {
-			println(' * ' + flag.tos())
+			println(' * ' + flag.format())
 		}
 	}
 	v.cc()

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -325,7 +325,9 @@ fn (v mut V) compile() {
   cgen.save()
 	if v.pref.is_verbose {
 		v.log('flags=')
-		println(v.table.flags)
+		for flag in v.get_os_cflags() {
+			println(' * ' + flag.tos())
+		}
 	}
 	v.cc()
 }

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -433,7 +433,7 @@ fn (v V) run_compiled_executable_and_exit() {
 	if v.pref.is_verbose {
 		println('============ running $v.out_name ============')
 	}	
-	mut cmd := final_target_out_name(v.out_name).replace('.exe','')
+	mut cmd := '"' + final_target_out_name(v.out_name).replace('.exe','') + '"'
 	if os.args.len > 3 {
 		cmd += ' ' + os.args.right(3).join(' ')
 	}
@@ -757,9 +757,7 @@ fn new_v(args[]string) &V {
 	vroot := os.dir(os.executable())
 	//println('VROOT=$vroot')
 	// v.exe's parent directory should contain vlib
-	if os.dir_exists(vroot) && os.dir_exists(vroot + '/vlib/builtin') {
-
-	}  else {
+	if !os.dir_exists(vroot) || !os.dir_exists(vroot + '/vlib/builtin') {
 		println('vlib not found. It should be next to the V executable. ')
 		println('Go to https://vlang.io to install V.')
 		exit(1)

--- a/compiler/msvc.v
+++ b/compiler/msvc.v
@@ -300,7 +300,7 @@ pub fn (v mut V) cc_msvc() {
 	mut lib_paths := []string{}
 	mut other_flags := []string{}
 
-	for flag in parse_flags(v.table.flags) {
+	for flag in parse_cflags(v.table.flags) {
 		mut arg := flag.value
 		if flag.name == '-I' || flag.name == '-L' {
 			arg = os.realpath( arg )

--- a/compiler/msvc.v
+++ b/compiler/msvc.v
@@ -207,11 +207,6 @@ fn find_msvc() ?MsvcResult {
 	}
 }
 
-struct ParsedFlag {
-	f string
-	arg string
-}
-
 pub fn (v mut V) cc_msvc() { 
 	r := find_msvc() or {
 		// TODO: code reuse
@@ -305,99 +300,45 @@ pub fn (v mut V) cc_msvc() {
 	mut lib_paths := []string{}
 	mut other_flags := []string{}
 
-	// Emily:
-	// this is a hack to try and support -l -L and object files
-	// passed on the command line
-	mut seenflags := map[string]int // no need to add the same flags more than once
-	for f in v.table.flags {
-		seenflags[ f ] = seenflags[ f ] + 1
-		if seenflags[ f ] > 1 { continue }
-		// People like to put multiple flags per line (which really complicates things)
-		// ...so we need to handle that
-		mut rest := f
-
-		mut flags := []ParsedFlag{}
-		for {
-			mut base := rest
-
-			fl := if rest.starts_with('-') {
-				base = rest.right(2).trim_space()
-				rest.left(2)
-			} else {
-				''
-			}
-
-			// Which ever one of these is lowest we use
-			// TODO: we really shouldnt support all of these cmon
-			mut lowest := base.index('-')
-			// dont break paths with hyphens
-			if lowest != 0  {
-				lowest = -1
-			}
-			for x in [base.index(' '), base.index(',')] {
-				if (x < lowest && x != -1) || lowest == -1 {
-					lowest = x
-				}
-			}
-			arg := if lowest != -1 {
-				rest = base.right(lowest).trim_space().trim(',')
-				base.left(lowest).trim_space().trim(',')
-			} else {
-				rest = ''
-				base.trim_space()
-			}
-
-			flags << ParsedFlag {
-				fl, arg
-			}
-
-			if rest.len == 0 {
-				break
-			}
+	for flag in parse_flags(v.table.flags) {
+		mut arg := flag.value
+		if flag.name == '-I' || flag.name == '-L' {
+			arg = os.realpath( arg )
 		}
+		//println('fl: $flag.name | flag arg: $arg')
 
-		for flag in flags {
-			fl := flag.f
-			mut arg := flag.arg
-			if fl == '-I' || fl == '-L' {
-				arg = os.realpath( arg )
+		// We need to see if the flag contains -l
+		// -l isnt recognised and these libs will be passed straight to the linker
+		// by the compiler
+		if flag.name == '-l' {
+			if arg.ends_with('.dll') {
+				cerror('MSVC cannot link against a dll (`#flag -l $arg`)')
 			}
-			//println('fl: $fl | flag arg: $arg')
-
-			// We need to see if the flag contains -l
-			// -l isnt recognised and these libs will be passed straight to the linker
-			// by the compiler
-			if fl == '-l' {
-				if arg.ends_with('.dll') {
-					cerror('MSVC cannot link against a dll (`#flag -l $arg`)')
-				}
-				// MSVC has no method of linking against a .dll
-				// TODO: we should look for .defs aswell
-				lib_lib := arg + '.lib'
-				real_libs << lib_lib
-			}
-			else if fl == '-I' {
-				inc_paths << ' -I "$arg" '
-			}
-			else if fl == '-L' {
-				lpath := f.right(2).trim_space()
-				lib_paths << lpath
-				lib_paths << lpath + os.PathSeparator + 'msvc'
-				// The above allows putting msvc specific .lib files in a subfolder msvc/ ,
-				// where gcc will NOT find them, but cl will do...
-				// NB: gcc is smart enough to not need .lib files at all in most cases, the .dll is enough.
-				// When both a msvc .lib file and .dll file are present in the same folder,
-				// as for example for glfw3, compilation with gcc would fail.
-			}
-			else if arg.ends_with('.o') {
-				// msvc expects .obj not .o
-				other_flags << arg + 'bj'
-			} 
-			else {
-				other_flags << arg
-			}
+			// MSVC has no method of linking against a .dll
+			// TODO: we should look for .defs aswell
+			lib_lib := arg + '.lib'
+			real_libs << lib_lib
 		}
-		
+		else if flag.name == '-I' {
+			inc_paths << ' -I "$arg" '
+		}
+		else if flag.name == '-L' {
+			lpath := flag.value
+			lib_paths << '"' + lpath + '"'
+			lib_paths << '"' + lpath + os.PathSeparator + 'msvc' + '"'
+			// The above allows putting msvc specific .lib files in a subfolder msvc/ ,
+			// where gcc will NOT find them, but cl will do...
+			// NB: gcc is smart enough to not need .lib files at all in most cases, the .dll is enough.
+			// When both a msvc .lib file and .dll file are present in the same folder,
+			// as for example for glfw3, compilation with gcc would fail.
+		}
+		else if arg.ends_with('.o') {
+			// msvc expects .obj not .o
+			other_flags << '"' + os.realpath(arg+'bj') + '"'
+		} 
+		else {
+			other_flags << arg
+		}
 	}
 
 	// Include the base paths
@@ -469,11 +410,11 @@ fn build_thirdparty_obj_file_with_msvc(flag string) {
 		return
 	}
 
-	mut obj_path := flag.all_after(' ')
+	mut obj_path := flag.trim_space()
 
 	if obj_path.ends_with('.o') {
 		// msvc expects .obj not .o
-		obj_path = obj_path + 'bj'
+		obj_path = os.realpath(obj_path + 'bj')
 	}
 
 	if os.file_exists(obj_path) {

--- a/compiler/msvc.v
+++ b/compiler/msvc.v
@@ -317,7 +317,7 @@ pub fn (v mut V) cc_msvc() {
 			real_libs << lib_lib
 		}
 		else if flag.name == '-I' {
-			inc_paths << ' ' + flag.tos() + ' '
+			inc_paths << ' ' + flag.format() + ' '
 		}
 		else if flag.name == '-L' {
 			lpath := flag.value
@@ -328,6 +328,9 @@ pub fn (v mut V) cc_msvc() {
 			// NB: gcc is smart enough to not need .lib files at all in most cases, the .dll is enough.
 			// When both a msvc .lib file and .dll file are present in the same folder,
 			// as for example for glfw3, compilation with gcc would fail.
+		}
+		else if flag.value.ends_with('.o') {
+			other_flags << flag.format().replace('.o', '.obj')
 		}
 		else {
 			other_flags << arg
@@ -397,12 +400,16 @@ pub fn (v mut V) cc_msvc() {
 	os.rm(out_name_obj)
 }
 
-fn build_thirdparty_obj_file_with_msvc(obj_path string) {
+fn build_thirdparty_obj_file_with_msvc(path string) {
 	msvc := find_msvc() or {
 		println('Could not find visual studio')
 		return
 	}
 
+	// msvc expects .obj not .o
+	mut obj_path := '${path}bj'
+
+	obj_path = os.realpath(obj_path)
 
 	if os.file_exists(obj_path) {
 		println('$obj_path already build.')
@@ -417,7 +424,7 @@ fn build_thirdparty_obj_file_with_msvc(obj_path string) {
 	for file in files {
 		if file.ends_with('.c') { 
 			cfiles += '"' + os.realpath( parent + os.PathSeparator + file )  + '" '
-		} 
+		}
 	}
 
 	include_string := '-I "$msvc.ucrt_include_path" -I "$msvc.vs_include_path" -I "$msvc.um_include_path" -I "$msvc.shared_include_path"'

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -17,7 +17,7 @@ mut:
 	modules      []string // List of all modules registered by the application
 	imports      []string // List of all imports
 	file_imports []FileImportTable // List of imports for file
-	flags        []string //  ['-framework Cocoa', '-lglfw3']
+	cflags       []CFlag  // ['-framework Cocoa', '-lglfw3']
 	fn_cnt       int //atomic
 	obfuscate    bool
 }
@@ -78,8 +78,6 @@ mut:
 	scope_level     int
 }
 
-
-
 struct Type {
 mut:
 	mod            string
@@ -105,7 +103,6 @@ struct TypeNode {
 	next &TypeNode
 	typ Type
 }
-
 
 // For debugging types
 fn (t Type) str() string {


### PR DESCRIPTION
cflags now parsed to CFlag struct. table.flags is now table.cflags []CFlag. all uses of flags have been updated. flags for all os's are added to table.cflags, I thought this could be useful for cross compiling or other things. you can just get the flags for just the current os os by v.get_os_cflags() and also flag.os will be set if the flag had os specified so you can filter yourself.

This PR fixes flag paths with spaces. (fixes #1847)
It also allows V to live in a path with spaces. 

And adds support multiple flags on a line like so (gcc & msvc):
```
#flag -I /usr/dir1, /usr/dir2
#flag -I /usr/dir1 -I /usr/dir2
```

There is still a bug with running `v test v` when v lives in a path with spaces, this will be fixed soon in another PR.