### PR TITLE
Sep 6, 2019: Add CentOS / RHEL / Fedora instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ On macOS run `xcode-select --install` if you don't have XCode or XCode tools.
 
 On Debian/Ubuntu run `sudo apt install build-essential`.
 
+On CentOS/RHEL run 'sudo yum groupinstall "Development Tools"`.
+
+On Fedora run `sudo dnf install @development-tools`.
+
 On Windows follow these instructions: [github.com/vlang/v/wiki/Installing-a-C-compiler-on-Windows](https://github.com/vlang/v/wiki/Installing-a-C-compiler-on-Windows)
 
 


### PR DESCRIPTION
The current `README.md` contains instructions on installing basic development tools on Debian Linux and its derivatives, but Fedora / CentOS / RHEL is also a series of popular Linux choice. This PR adds guides for F / C / R similar to the existing guide on Debian / Ubuntu, with the intention that it might be helpful.