### PR TITLE
compiler: allows dir spelling with slash at the end

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -678,6 +678,9 @@ fn new_v(args[]string) &V {
 	if args.contains('run') {
 		dir = get_all_after(joined_args, 'run', '')
 	}
+	if dir.ends_with('/') {
+		dir = dir.all_before_last('/')
+	}
 	if args.len < 2 {
 		dir = ''
 	}
@@ -690,8 +693,10 @@ fn new_v(args[]string) &V {
 		build_mode = .build
 		// v -lib ~/v/os => os.o
 		//mod = os.dir(dir)
-		if dir.contains('/') {
-			mod = dir.all_after('/')
+		mod = if dir.contains('/') {
+			dir.all_after('/')
+		} else {
+			dir
 		}
 		println('Building module "${mod}" (dir="$dir")...')
 		//out_name = '$TmpPath/vlib/${base}.o'


### PR DESCRIPTION
**Additions:**
Allows to write `v build module` with spelling of dir as : `./dir/` or `dir/`

Fixes #1857 and #1736 
