### PR TITLE
compiler: fix v test v on paths with spaces

### DIFF
--- a/compiler/cc.v
+++ b/compiler/cc.v
@@ -85,14 +85,14 @@ fn (v mut V) cc() {
 	}
 	// -I flags
 	/*
-mut args := ''
+	mut args := ''
 	for flag in v.get_os_cflags() {
 		if !flag.starts_with('-l') {
-			args += flag
+			args += flag.value
 			args += ' '
 		}
 	}
-*/
+	*/
 	if v.pref.sanitize {
 		a << '-fsanitize=leak'
 	}
@@ -127,6 +127,7 @@ mut args := ''
 	if v.os == .mac {
 		a << '-mmacosx-version-min=10.7'
 	}
+	// add all flags
 	for flag in v.get_os_cflags() {
 		a << flag.format()
 	}

--- a/compiler/cc.v
+++ b/compiler/cc.v
@@ -111,7 +111,7 @@ mut args := ''
 	// Cross compiling windows
 	//
 	// Output executable name
-	a << '-o $v.out_name'
+	a << '-o "$v.out_name"'
 	if os.dir_exists(v.out_name) {
 		cerror('\'$v.out_name\' is a directory')
 	}

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -942,7 +942,9 @@ fn test_v() {
 		file := os.realpath( relative_file )
 		tmpcfilepath := file.replace('_test.v', '_test.tmp.c')
 		print(relative_file + ' ')
-		r := os.exec('$vexe $joined_args -debug $file') or {
+		mut cmd := '"$vexe" $joined_args -debug "$file"'
+		if os.user_os() == 'windows' { cmd = '"$cmd"' }
+		r := os.exec(cmd) or {
 			failed = true
 			println('FAIL')
 			continue
@@ -961,7 +963,9 @@ fn test_v() {
 		file := os.realpath( relative_file )
 		tmpcfilepath := file.replace('.v', '.tmp.c')
 		print(relative_file + ' ')
-		r := os.exec('$vexe $joined_args -debug $file') or {
+		mut cmd := '"$vexe" $joined_args -debug "$file"'
+		if os.user_os() == 'windows' { cmd = '"$cmd"' }
+		r := os.exec(cmd) or {
 			failed = true
 			println('FAIL')
 			continue


### PR DESCRIPTION
This allows `v test v` to work when v path has spaces in it