### PR TITLE
compiler: support @FILE, @LINE, @FN, @COLUMN

### DIFF
--- a/compiler/comptime.v
+++ b/compiler/comptime.v
@@ -115,7 +115,7 @@ fn (p mut Parser) comp_time() {
 			os.rm('.vwebtmpl.v')
 		}
 		pp.is_vweb = true
-		pp.cur_fn = p.cur_fn // give access too all variables in current function
+		pp.set_current_fn( p.cur_fn ) // give access too all variables in current function
 		pp.parse(.main)
 		tmpl_fn_body := p.cgen.lines.slice(pos + 2, p.cgen.lines.len).join('\n').clone()
 		end_pos := tmpl_fn_body.last_index('Builder_str( sb )')  + 19 // TODO

--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -284,7 +284,7 @@ fn (p mut Parser) fn_decl() {
 		''
 	}
 	if !p.is_vweb {
-		p.cur_fn = f
+		p.set_current_fn( f )
 	}
 	// Generate `User_register()` instead of `register()`
 	// Internally it's still stored as "register" in type User
@@ -492,7 +492,7 @@ _thread_so = CreateThread(0, 0, (LPTHREAD_START_ROUTINE)&reload_so, 0, 0, 0);
 		return
 	}
 	p.check_unused_variables()
-	p.cur_fn = EmptyFn
+	p.set_current_fn( EmptyFn )
 	p.returns = false
 	if !is_generic {
 		p.genln('}')

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -2537,20 +2537,28 @@ fn (p mut Parser) string_expr() {
 		// Custom format? ${t.hour:02d}
 		custom := p.tok == .colon
 		if custom {
-			format += '%'
+			mut cformat := ''
 			p.next()
 			if p.tok == .dot {
-				format += '.'
+				cformat += '.'
 				p.next()
 			}
 			if p.tok == .minus { // support for left aligned formatting
-				format += '-'
+				cformat += '-'
 				p.next()
 			}
-			format += p.lit// 02
+			cformat += p.lit// 02
 			p.next()
-			format += p.lit// f
-			// println('custom str F=$format')
+			fspec := p.lit // f
+			cformat += fspec
+			if fspec == 's' {
+				//println('custom str F=$cformat | format_specifier: "$fspec" | typ: $typ ')
+				if typ != 'string' {
+					p.error('only v strings can be formatted with a :${cformat} format, but you have given "${val}", which has type ${typ}.')
+				}
+				args = args.all_before_last('${val}.len, ${val}.str') + '${val}.str'
+			}
+			format += '%$cformat'
 			p.next()
 		}
 		else {
@@ -2572,6 +2580,7 @@ fn (p mut Parser) string_expr() {
 			}
 			format += f
 		}
+		//println('interpolation format is: |${format}| args are: |${args}| ')
 	}
 	if complex_inter {
 		p.fgen('}')

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -2538,6 +2538,10 @@ fn (p mut Parser) string_expr() {
 				format += '.'
 				p.next()
 			}
+			if p.tok == .minus { // support for left aligned formatting
+				format += '-'
+				p.next()
+			}
 			format += p.lit// 02
 			p.next()
 			format += p.lit// f

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -119,6 +119,11 @@ fn (v mut V) new_parser(path string) Parser {
 	return p
 }
 
+fn (p mut Parser) set_current_fn(f &Fn) {
+	p.cur_fn = f
+	p.scanner.fn_name = '${f.mod}.${f.name}'
+}
+
 fn (p mut Parser) next() {
 	p.prev_tok2 = p.prev_tok
 	p.prev_tok = p.tok
@@ -262,7 +267,7 @@ fn (p mut Parser) parse(pass Pass) {
 		case Token.eof:
 			p.log('end of parse()')
 			if p.is_script && !p.pref.is_test {
-				p.cur_fn = MainFn
+				p.set_current_fn( MainFn )
 				p.check_unused_variables()
 			}
 			if false && !p.first_pass() && p.fileis('main.v') {
@@ -281,12 +286,12 @@ fn (p mut Parser) parse(pass Pass) {
 				// we need to set it to save and find variables
 				if p.first_pass() {
 					if p.cur_fn.name == '' {
-						p.cur_fn = MainFn
+						p.set_current_fn( MainFn )
 					}
 					return
 				}
 				if p.cur_fn.name == '' {
-					p.cur_fn = MainFn
+					p.set_current_fn( MainFn )
 					if p.pref.is_repl {
 						p.cur_fn.clear_vars()
 					}

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -394,6 +394,12 @@ fn (s mut Scanner) scan() ScanRes {
 	case `@`:
 		s.pos++
 		name := s.ident_name()
+		// @LINE => will be substituted with a string containing the current V line number
+		// @FILE => will be substituted with a string containing the path of the current V source file
+		// This allows things like this: `println( 'file: ' + @FILE + ' | line: ' + @LINE)`
+		// which is useful while debugging/tracing
+		if name == 'LINE' { return scan_res(.str, (s.line_nr+1).str()) }
+		if name == 'FILE' { return scan_res(.str, os.realpath(s.file_path)) }
 		if !is_key(name) {
 			s.error('@ must be used before keywords (e.g. `@type string`)')
 		}


### PR DESCRIPTION
Close #1737 . 

Also improves string interpolation, now ${fname:-10.7s} works.

This PR supports compiling the following V program:
```v
fn traceline(filename, line, fname string) {
        println('$filename:${line:-3s}: tracing in fn: ${fname:-10.7s} .')
}

fn f1(){
        traceline( @FILE, @LINE, @FN)
}

fn f2(){
        traceline( @FILE, @LINE, @FN)
        traceline( @FILE, @LINE, @FN)
}

traceline( @FILE, @LINE, @FN)
traceline( @FILE, @LINE, @FN)


traceline( @FILE, @LINE, @FN)

f1()
f2()

traceline( @FILE, @LINE, @FN)
```

produces:
```
/v/misc/AT_FILE_and_AT_LINE_literals.v:15 : tracing in fn: .main      .
/v/misc/AT_FILE_and_AT_LINE_literals.v:16 : tracing in fn: .main      .
/v/misc/AT_FILE_and_AT_LINE_literals.v:19 : tracing in fn: .main      .
/v/misc/AT_FILE_and_AT_LINE_literals.v:7  : tracing in fn: main.f1    .
/v/misc/AT_FILE_and_AT_LINE_literals.v:11 : tracing in fn: main.f2    .
/v/misc/AT_FILE_and_AT_LINE_literals.v:12 : tracing in fn: main.f2    .
/v/misc/AT_FILE_and_AT_LINE_literals.v:24 : tracing in fn: .main      .
```
