### PR TITLE
compiler: add vfmt() to reduce complexity

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -148,7 +148,7 @@ fn main() {
 */
 	// Just fmt and exit
 	if 'fmt' in args {
-		vmft(args)
+		vfmt(args)
 		return
 	}
 	// v get sqlite
@@ -895,7 +895,7 @@ fn update_v() {
 	}
 }
 
-fn vmft(args[]string) {
+fn vfmt(args[]string) {
 	file := args.last()
 	if !os.file_exists(file) {
 		println('"$file" does not exist')

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -148,7 +148,7 @@ fn main() {
 */
 	// Just fmt and exit
 	if 'fmt' in args {
-		fmt_v(args)
+		vmft(args)
 		return
 	}
 	// v get sqlite
@@ -895,7 +895,7 @@ fn update_v() {
 	}
 }
 
-fn fmt_v(args[]string) {
+fn vmft(args[]string) {
 	file := args.last()
 	if !os.file_exists(file) {
 		println('"$file" does not exist')

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -148,16 +148,7 @@ fn main() {
 */
 	// Just fmt and exit
 	if 'fmt' in args {
-		file := args.last()
-		if !os.file_exists(file) {
-			println('"$file" does not exist')
-			exit(1)
-		}
-		if !file.ends_with('.v') {
-			println('v fmt can only be used on .v files')
-			exit(1)
-		}
-		println('vfmt is temporarily disabled')
+		fmt_v(args)
 		return
 	}
 	// v get sqlite
@@ -902,6 +893,19 @@ fn update_v() {
 		}
 		println(s2.output)
 	}
+}
+
+fn fmt_v(args[]string) {
+	file := args.last()
+	if !os.file_exists(file) {
+		println('"$file" does not exist')
+		exit(1)
+	}
+	if !file.ends_with('.v') {
+		println('v fmt can only be used on .v files')
+		exit(1)
+	}
+	println('vfmt is temporarily disabled')
 }
 
 fn install_v(args[]string) {


### PR DESCRIPTION
Isolate responsibility to reduce complexity in the main method.

Similar PR: https://github.com/vlang/v/pull/1910