### PR TITLE
compiler: stage 1 of printing shortened commit on v --version

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -100,13 +100,13 @@ mut:
 	building_v bool
 }
 
-
 fn main() {
 	// There's no `flags` module yet, so args have to be parsed manually
 	args := env_vflags_and_os_args()
 	// Print the version and exit.
 	if '-v' in args || '--version' in args || 'version' in args {
-		println('V $Version')
+		versionhash := vhash()
+		println('V $Version $versionhash')
 		return
 	}
 	if '-h' in args || '--help' in args || 'help' in args {
@@ -231,8 +231,14 @@ fn (v mut V) compile() {
 		cgen.genln('#define VDEBUG (1) ')
 	}
 
-	cgen.genln(CommonCHeaders)
+	if v.pref.building_v {
+		cgen.genln('#ifndef V_COMMIT_HASH')
+		cgen.genln('#define V_COMMIT_HASH "' + vhash() + '"')
+		cgen.genln('#endif')
+	}
 	
+	cgen.genln(CommonCHeaders)
+		
 	v.generate_hotcode_reloading_declarations()
 
 	imports_json := v.table.imports.contains('json')
@@ -1007,4 +1013,15 @@ pub fn cerror(s string) {
 	println('V error: $s')
 	os.flush_stdout()
 	exit(1)
+}
+
+// TODO: this must be uncommented on stage 2, after V_COMMIT_HASH is always present and preserved
+fn vhash() string {
+	/*
+	mut buf := [50]byte
+	buf[0] = 0
+	C.snprintf(buf, 50, '%s', C.V_COMMIT_HASH )
+	return tos_clone(buf)
+	*/
+	return '0000000'
 }

--- a/compiler/repl.v
+++ b/compiler/repl.v
@@ -51,8 +51,9 @@ fn (r mut Repl) function_call(line string) bool {
 }
 
 fn repl_help() {
+versionhash := vhash()
 println('
-V $Version
+V $Version $versionhash
   help                   Displays this information.
   Ctrl-C, Ctrl-D, exit   Exits the REPL.
   clear                  Clears the screen.
@@ -60,7 +61,8 @@ V $Version
 }
 
 fn run_repl() []string {
-	println('V $Version')
+	versionhash := vhash()
+	println('V $Version $versionhash')
 	println('Use Ctrl-C or `exit` to exit')
 	file := '.vrepl.v'
 	temp_file := '.vrepl_temp.v'

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -401,6 +401,7 @@ fn (s mut Scanner) scan() ScanRes {
 		// @FILE => will be substituted with the path of the V source file
 		// @LINE => will be substituted with the V line number where it appears (as a string).
 		// @COLUMN => will be substituted with the column where it appears (as a string).
+		// @VHASH  => will be substituted with the shortened commit hash of the V compiler (as a string).
 		// This allows things like this: 
 		// println( 'file: ' + @FILE + ' | line: ' + @LINE + ' | fn: ' + @FN)
 		// ... which is useful while debugging/tracing
@@ -408,6 +409,7 @@ fn (s mut Scanner) scan() ScanRes {
 		if name == 'FILE' { return scan_res(.str, os.realpath(s.file_path)) }
 		if name == 'LINE' { return scan_res(.str, (s.line_nr+1).str()) }
 		if name == 'COLUMN' { return scan_res(.str, (s.current_column()).str()) }
+		if name == 'VHASH' { return scan_res(.str, vhash()) }
 		if !is_key(name) {
 			s.error('@ must be used before keywords (e.g. `@type string`)')
 		}


### PR DESCRIPTION
After this PR:
```shell
0[22:53:47] /v/v $ ./v --version
V 0.1.18 0000000
0[22:53:49] /v/v $ 
```
This is in preparation for another PR (stage 2), which would turn on the support for the actual V_COMMIT_HASH macro (so that the zeros above will actually be a real hash).
V_COMMIT_HASH contains the commit hash of the vlang/v repo. It is already generated by the tools/gen_vc service (but v itself does not generate it yet, hence the need for the 2 stages).

The combined goal of these 2 PRs is to have the V compiler print more detailed version information.