### PR TITLE
compiler: stage 2 of vhash support

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -105,8 +105,8 @@ fn main() {
 	args := env_vflags_and_os_args()
 	// Print the version and exit.
 	if '-v' in args || '--version' in args || 'version' in args {
-		versionhash := vhash()
-		println('V $Version $versionhash')
+		version_hash := vhash()
+		println('V $Version $version_hash')
 		return
 	}
 	if '-h' in args || '--help' in args || 'help' in args {
@@ -1015,13 +1015,9 @@ pub fn cerror(s string) {
 	exit(1)
 }
 
-// TODO: this must be uncommented on stage 2, after V_COMMIT_HASH is always present and preserved
 fn vhash() string {
-	/*
 	mut buf := [50]byte
 	buf[0] = 0
 	C.snprintf(buf, 50, '%s', C.V_COMMIT_HASH )
-	return tos_clone(buf)
-	*/
-	return '0000000'
+	return tos_clone(buf)  
 }

--- a/compiler/repl.v
+++ b/compiler/repl.v
@@ -51,9 +51,9 @@ fn (r mut Repl) function_call(line string) bool {
 }
 
 fn repl_help() {
-versionhash := vhash()
+version_hash := vhash()
 println('
-V $Version $versionhash
+V $Version $version_hash
   help                   Displays this information.
   Ctrl-C, Ctrl-D, exit   Exits the REPL.
   clear                  Clears the screen.
@@ -61,8 +61,8 @@ V $Version $versionhash
 }
 
 fn run_repl() []string {
-	versionhash := vhash()
-	println('V $Version $versionhash')
+	version_hash := vhash()
+	println('V $Version $version_hash')
 	println('Use Ctrl-C or `exit` to exit')
 	file := '.vrepl.v'
 	temp_file := '.vrepl_temp.v'


### PR DESCRIPTION
This is stage 2 of #1918 .
It should be merged after #1919 , so that the v.c and v_win.c files had the chance to be regenerated.