### PR TITLE
fix sizeof and cc

### DIFF
--- a/compiler/cc.v
+++ b/compiler/cc.v
@@ -119,16 +119,17 @@ fn (v mut V) cc() {
 		a << '-mmacosx-version-min=10.7'
 	}
 	cflags := v.get_os_cflags()
-	// add all flags (-I -l -L etc) not .o files
-	for flag in cflags {
-		if flag.value.ends_with('.o') { continue }
-		a << flag.format()
-	}
 	// add .o files
 	for flag in cflags {
 		if !flag.value.ends_with('.o') { continue }
 		a << flag.format()
 	}
+	// add all flags (-I -l -L etc) not .o files
+	for flag in cflags {
+		if flag.value.ends_with('.o') { continue }
+		a << flag.format()
+	}
+	
 	a << libs
 	// Without these libs compilation will fail on Linux
 	// || os.user_os() == 'linux'

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -2348,11 +2348,7 @@ fn (p mut Parser) factor() string {
 		p.fgen('sizeof(')
 		p.next()
 		p.check(.lpar)
-		mut sizeof_typ := p.get_type()
-		if sizeof_typ.ends_with('*') {
-			// Move * from the end to the beginning, as C requires
-			sizeof_typ = '*' + sizeof_typ.left(sizeof_typ.len - 1)
-		}
+		mut sizeof_typ := p.get_type()		
 		p.check(.rpar)
 		p.gen('$sizeof_typ)')
 		p.fgen('$sizeof_typ)')


### PR DESCRIPTION
**Explanation of `fix sizeof`**

```V
fn main(){
    mut s := sizeof(voidptr)
    println(s)
    s = sizeof(&C.int)
    println(s)
    s = sizeof(byteptr)
    println(s)
    s = sizeof(u64)
    println(s)
    s = sizeof(int)
    println(s)
}
```

**Explanation of `fix cc`**

move 'add .o files' before 'add all flags (-I -l -L etc)'
Because some .o files require later links, such as-lole32-loleaut32-luuid