### PR TITLE
fix cc()

### DIFF
--- a/compiler/cc.v
+++ b/compiler/cc.v
@@ -119,16 +119,19 @@ fn (v mut V) cc() {
 		a << '-mmacosx-version-min=10.7'
 	}
 	cflags := v.get_os_cflags()
-	// add all flags (-I -l -L etc) not .o files
-	for flag in cflags {
-		if flag.value.ends_with('.o') { continue }
-		a << flag.format()
-	}
+	
 	// add .o files
 	for flag in cflags {
 		if !flag.value.ends_with('.o') { continue }
 		a << flag.format()
 	}
+
+	// add all flags (-I -l -L etc) not .o files
+	for flag in cflags {
+		if flag.value.ends_with('.o') { continue }
+		a << flag.format()
+	}
+	
 	a << libs
 	// Without these libs compilation will fail on Linux
 	// || os.user_os() == 'linux'


### PR DESCRIPTION
move 'add .o files' before 'add all flags (-I -l -L etc)'
Because some .o files require later links, such as-lole32-loleaut32-luuid