### PR TITLE
compiler: improve v --help . Move help descriptions to compiler/vhelp.v

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -122,7 +122,7 @@ fn main() {
 		return
 	}
 	if 'get' in args {
-		println('use `v install` to install modules from vpm.best ')
+		println('use `v install` to install modules from vpm.vlang.io ')
 		return
 	}
 	if 'symlink' in args {

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -122,7 +122,7 @@ fn main() {
 		return
 	}
 	if 'get' in args {
-		println('use `v install` to install modules from vpm.vlang.io')
+		println('use `v install` to install modules from vpm.best ')
 		return
 	}
 	if 'symlink' in args {
@@ -829,41 +829,6 @@ fn new_v(args[]string) &V {
 		mod: mod
 	}
 }
-
-
-const (
-	HelpText = '
-Usage: v [options] [file | directory]
-
-Options:
-  -                 Read from stdin (Default; Interactive mode if in a tty)
-  -h, help          Display this information.
-  -v, version       Display compiler version.
-  -prod             Build an optimized executable.
-  -o <file>         Place output into <file>.
-  -obf              Obfuscate the resulting binary.
-  -show_c_cmd       Print the full C compilation command and how much time it took.
-  -debug            Leave a C file for debugging in .program.c.
-  -live             Enable hot code reloading (required by functions marked with [live]).
-  fmt               Run vfmt to format the source code.
-  up                Update V.
-  run               Build and execute a V program. You can add arguments after the file name.
-  build module      Compile a module into an object file.
-
-
-Files:
-  <file>_test.v     Test file.
-'
-)
-
-/*
-- To disable automatic formatting:
-v -nofmt file.v
-
-- To build a program with an embedded vlib  (use this if you do not have prebuilt vlib libraries or if you
-are working on vlib)
-v -embed_vlib file.v
-*/
 
 fn env_vflags_and_os_args() []string {
    mut args := []string

--- a/compiler/vhelp.v
+++ b/compiler/vhelp.v
@@ -14,6 +14,9 @@ const (
    When V is given a file ending with _test.v, V will compile and run *every* function in it that is named test_xxxxx . 
    Use `assert false` inside the test functions to validate the test results.
 
+   You can put common options inside an environment variable named VFLAGS, so that you do not repeat them. 
+   You can set it like this: `export VFLAGS="-cc clang -debug"` on unix, `set VFLAGS=-os msvc` on windows.
+   
 Options:  
   -                 Shorthand for `v runrepl` .
   -h, help          Display this information.

--- a/compiler/vhelp.v
+++ b/compiler/vhelp.v
@@ -1,0 +1,64 @@
+module main
+
+const (
+	HelpText = 'Usage: v [options/subcommands] [file.v | directory]
+
+   When V is run without any options/subcommands and files given, it is a shorthand for `v runrepl`.
+
+   When V is given just a vprogram.v file, it will compile it, and will produce an executable named vprogram.
+   You can use -o to specify a different output name.
+
+   When V is given a directory name, it will compile all *.v files in the directory, as being part of a single main module. 
+   It will produce an executable named a.out by default.
+
+   When V is given a file ending with _test.v, V will compile and run *every* function in it that is named test_xxxxx . 
+   Use `assert false` inside the test functions to validate the test results.
+
+Options:  
+  -                 Shorthand for `v runrepl` .
+  -h, help          Display this information.
+  -live             Enable hot code reloading (required by functions marked with [live]).
+  -os <OS>          Produce an executable for the selected OS. 
+                    OS can be linux, mac, windows, msvc, etc...
+                    -os msvc is useful, if you want to use the MSVC compiler on Windows.
+  -prod             Build an optimized executable.
+  -v, version       Display compiler version and git hash of the compiler source.
+  
+Debugging options:
+  -cc <ccompiler>   Specify which C compiler you want to use as a C backend. 
+                    The C backend compiler should be able to handle C99 compatible C code.
+                    Common C compilers are gcc, clang, tcc, icc, cl ...
+  -cflags flags     Pass additional C flags to the C backend compiler.
+                    Example: -cflags `sdl2-config --cflags`
+                    
+  -debug            Keep the generatd C file for debugging in program.tmp.c even after compilation.
+  -g                Show v line numbers in backtraces. Implies -debug.  
+  -o <file>         Place output into <file>. If file has a .c suffix, produce C source, and do not compile it further.
+  -obf              Obfuscate the resulting binary.
+  -show_c_cmd       Print the full C compilation command and how much time it took.
+  
+
+Subcommands:
+  up                Update V. Run `v up` at least once per day, since V development is rapid and features/bugfixes are added constantly.
+  run <file.v>      Build and execute the V program in file.v . You can add arguments for the V program *after* the file name.
+  build module      Compile a module into an object file.
+  runrepl           Run the V REPL. If V is running in a tty terminal, the repl is interactive, otherwise it just reads from stdin.
+  symlink           Useful on unix systems. Symlinks the current V executable to /usr/local/bin/v, so that V is globally available.
+  install module    Install an user module from https://vpm.best/ .
+  test v            Run all V test files, and compile all V examples.
+
+  fmt               Run vfmt to format the source code. [wip]
+  doc               Run vdoc over the source code and produce documenation. [wip]
+  translate         Translates C to V. [wip, will be available in V 0.3]  
+'
+)
+
+
+/*
+- To disable automatic formatting:
+v -nofmt file.v
+
+- To build a program with an embedded vlib  (use this if you do not have prebuilt vlib libraries or if you
+are working on vlib)
+v -embed_vlib file.v
+*/

--- a/compiler/vhelp.v
+++ b/compiler/vhelp.v
@@ -3,16 +3,18 @@ module main
 const (
 	HelpText = 'Usage: v [options/subcommands] [file.v | directory]
 
-   When V is run without any options/subcommands and files given, it is a shorthand for `v runrepl`.
 
-   When V is given just a vprogram.v file, it will compile it, and will produce an executable named vprogram.
+
+   When V is run without any arguments, it is a shorthand for `v runrepl`.
+
+   When given a .v file, it will be compiled. The output executable will have the same name as the input .v file.
    You can use -o to specify a different output name.
 
-   When V is given a directory name, it will compile all *.v files in the directory, as being part of a single main module. 
-   It will produce an executable named a.out by default.
+   When given a directory, all the .v files contained in it, will be compiled as part of a single main module. 
+   By default the executable will be named a.out.
 
-   When V is given a file ending with _test.v, V will compile and run *every* function in it that is named test_xxxxx . 
-   Use `assert false` inside the test functions to validate the test results.
+   Any file ending in _test.v, will be treated as a test. 
+   It will be compiled and run, evaluating the assert statements in every function named test_xxx.
 
    You can put common options inside an environment variable named VFLAGS, so that you do not repeat them. 
    You can set it like this: `export VFLAGS="-cc clang -debug"` on unix, `set VFLAGS=-os msvc` on windows.

--- a/compiler/vhelp.v
+++ b/compiler/vhelp.v
@@ -47,7 +47,7 @@ Subcommands:
   build module      Compile a module into an object file.
   runrepl           Run the V REPL. If V is running in a tty terminal, the repl is interactive, otherwise it just reads from stdin.
   symlink           Useful on unix systems. Symlinks the current V executable to /usr/local/bin/v, so that V is globally available.
-  install module    Install an user module from https://vpm.best/ .
+  install module    Install an user module from https://vpm.vlang.io/ .
   test v            Run all V test files, and compile all V examples.
 
   fmt               Run vfmt to format the source code. [wip]


### PR DESCRIPTION
Document most current v options, so that `v --help` is more useful/non misleading.