### PR TITLE
compiler: escapes quote on literals

### DIFF
--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -752,7 +752,8 @@ fn (s mut Scanner) ident_char() string {
 			s.error('invalid character literal (more than one character: $len)')
 		}
 	}
-	return c
+	// Escapes a `'` character
+	return if c == '\'' { '\\' + c } else { c }
 }
 
 fn (s mut Scanner) peek() Token {

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -418,3 +418,8 @@ fn test_for_loop_two() {
 		assert c == s[i]
 	}
 }
+
+fn test_quote() {
+	a := `'`
+	assert a.str() == '\''
+}


### PR DESCRIPTION
**Additions:**
Allows to pass single quote as a literal character.
Test for this case.

**Notes:**
Thanks Julian on discord for finding this.

**Examples:**
```
a := `'`
```