### PR TITLE
compile 32 bit module

### DIFF
--- a/compiler/cc.v
+++ b/compiler/cc.v
@@ -119,7 +119,7 @@ fn (v mut V) cc() {
 		a << '-mmacosx-version-min=10.7'
 	}
 	cflags := v.get_os_cflags()
-	
+
 	// add .o files
 	for flag in cflags {
 		if !flag.value.ends_with('.o') { continue }
@@ -317,6 +317,17 @@ fn find_c_compiler_default() string {
 }
 
 fn find_c_compiler_thirdparty_options() string {
-	$if windows { return '' }
-	return '-fPIC'
+	if '-m32' in os.args{
+		$if windows {
+			return '-m32'
+		}$else{
+			return '-fPIC -m32'
+		}
+	}else{
+		$if windows {
+			return ''
+		}$else{
+			return '-fPIC'
+		}
+	}
 }

--- a/compiler/cc.v
+++ b/compiler/cc.v
@@ -119,16 +119,19 @@ fn (v mut V) cc() {
 		a << '-mmacosx-version-min=10.7'
 	}
 	cflags := v.get_os_cflags()
-	// add all flags (-I -l -L etc) not .o files
-	for flag in cflags {
-		if flag.value.ends_with('.o') { continue }
-		a << flag.format()
-	}
+	
 	// add .o files
 	for flag in cflags {
 		if !flag.value.ends_with('.o') { continue }
 		a << flag.format()
 	}
+
+	// add all flags (-I -l -L etc) not .o files
+	for flag in cflags {
+		if flag.value.ends_with('.o') { continue }
+		a << flag.format()
+	}
+	
 	a << libs
 	// Without these libs compilation will fail on Linux
 	// || os.user_os() == 'linux'


### PR DESCRIPTION
When compiling a 32-bit program, you need to compile a 32-bit third-party library.
v run json.v -cflags -m32