### PR TITLE
vweb: fix example

### DIFF
--- a/examples/vweb/test_app.v
+++ b/examples/vweb/test_app.v
@@ -23,11 +23,11 @@ pub fn (app mut App) json_endpoint() {
 	app.vweb.json('{"a": 3}')
 }
 
-/*
+
 pub fn (app mut App) index() {
-	$vweb.html() 
+	$vweb.html()
 }
-*/
+
 
 pub fn (app mut App) text() {
 	app.vweb.text('hello world')

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -201,17 +201,9 @@ fn (ctx mut Context) scan_static_directory(directory_path, mount_path string) {
 			mut ext := ''
 			mut i := file.len
 			mut flag := true
-			for i > 0 {
-		 		i--
-				if flag {
-					ext = file.substr(i, i + 1) + ext
-				}
-				if file.substr(i, i + 1) == '.' {
-					flag = false
-				}
-			}
+                        // todo: os.is_dir is broken on some systems
+                        flag = os.is_dir(file)
 
-			// todo: os.is_dir is broken now so we expect that file is dir it has no extension
 			if flag {
 				ctx.scan_static_directory(directory_path + '/' + file, mount_path + '/' + file)
 			} else {


### PR DESCRIPTION
This changes makes the vweb example work. 

It does so be reenabling the index method and using the broken(?) `os.dir`. 

If I understand things correctly, the code will fail on Windows but at least will allow new users to run the example and avoid seeing a confusing error/warning.