### PR TITLE
compiler: temp mem free fix win - use `p.os` instead of `$if !windows`

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1068,7 +1068,7 @@ fn (p mut Parser) close_scope() {
 			break
 		}
 		// Clean up memory, only do this for V compiler for now
-		$if !windows {
+		if p.os != .windows {
 		if p.pref.building_v && v.is_alloc && !p.pref.is_test {
 			mut free_fn := 'free'
 			if v.typ.starts_with('array_') {


### PR DESCRIPTION
compiler: temp mem free fix win - use `p.os` instead of `$if !windows`

With this change, v_win.c should be generated correctly from linux, since the `-os windows` flag will override `v.os`