### PR TITLE
compiler: no free on stack allocated array

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -2760,6 +2760,7 @@ fn (p mut Parser) array_init() string {
 					if p.table.known_type(array_elem_typ) {
 						p.cgen.resetln('')
 						p.gen('{0}')
+						p.is_alloc = false
 						if is_const_len {
 							return '[${p.mod}__$lit]$array_elem_typ'
 						}


### PR DESCRIPTION
**Additions:**
Will not create a free on closing scope for a stack allocated array.

**Notes:**
Solves #1965 (*Only the crash, creating generics structs gives an error*)
