### PR TITLE
v up: on windows delete v_old.exe before renaming the new v.exe to it.

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -856,7 +856,11 @@ fn update_v() {
 	}
 	println(s.output)
 	$if windows {
-		os.mv('$vroot/v.exe', '$vroot/v_old.exe')
+		v_backup_file := '$vroot/v_old.exe'
+		if os.file_exists( v_backup_file ) {
+			os.rm( v_backup_file )
+		}
+		os.mv('$vroot/v.exe', v_backup_file)
 		s2 := os.exec('$vroot/make.bat') or {
 			cerror(err)
 			return


### PR DESCRIPTION
On windows os.mv seems to do nothing when the target file exists, which then prevents building since v.exe is not renamed ...