### PR TITLE
compiler: pass -lXXX flags without space to C backend (needed for tcc)

### DIFF
--- a/compiler/cflags.v
+++ b/compiler/cflags.v
@@ -31,6 +31,9 @@ fn (v V) get_os_cflags() []CFlag {
 fn (cf &CFlag) format() string {
 	mut value := cf.value
 	// convert to absolute path
+	if cf.name == '-l' && value.len>0 {
+		return '${cf.name}${value}'.trim_space()
+	}
 	if cf.name == '-I' || cf.name == '-L' || value.ends_with('.o') {
 		value = '"'+os.realpath(value)+'"'
 	}

--- a/compiler/cflags.v
+++ b/compiler/cflags.v
@@ -30,10 +30,10 @@ fn (v V) get_os_cflags() []CFlag {
 // format flag
 fn (cf &CFlag) format() string {
 	mut value := cf.value
-	// convert to absolute path
 	if cf.name == '-l' && value.len>0 {
 		return '${cf.name}${value}'.trim_space()
 	}
+	// convert to absolute path
 	if cf.name == '-I' || cf.name == '-L' || value.ends_with('.o') {
 		value = '"'+os.realpath(value)+'"'
 	}


### PR DESCRIPTION
tcc does not understand -l flags with space after them (for example -l glfw leads to compilation error about a missing library with tcc, while -lglfw is ok).