### PR TITLE
compiler/msvc: msvc empty struct decl fix

### DIFF
--- a/compiler/cheaders.v
+++ b/compiler/cheaders.v
@@ -40,6 +40,10 @@ CommonCHeaders = '
 
 
 #define EMPTY_STRUCT_DECLARATION
+#ifdef _MSC_VER
+#define EMPTY_STRUCT_DECLARATION int:0
+#endif
+
 #define OPTION_CAST(x) (x)
 
 #ifdef _WIN32


### PR DESCRIPTION
I'm not sure if this is better or: 
```
#define EMPTY_STRUCT_DECLARATION void *____dummy_variable
```