### PR TITLE
repl: add more stats and tests. compiler: fixes for tcc (struct/libs)

### DIFF
--- a/compiler/cflags.v
+++ b/compiler/cflags.v
@@ -30,6 +30,9 @@ fn (v V) get_os_cflags() []CFlag {
 // format flag
 fn (cf &CFlag) format() string {
 	mut value := cf.value
+	if cf.name == '-l' && value.len>0 {
+		return '${cf.name}${value}'.trim_space()
+	}
 	// convert to absolute path
 	if cf.name == '-I' || cf.name == '-L' || value.ends_with('.o') {
 		value = '"'+os.realpath(value)+'"'

--- a/compiler/cheaders.v
+++ b/compiler/cheaders.v
@@ -38,12 +38,8 @@ CommonCHeaders = '
 #include <sys/wait.h> // os__wait uses wait on nix
 #endif
 
-
 #define EMPTY_STRUCT_DECLARATION
-#ifdef _MSC_VER
-#define EMPTY_STRUCT_DECLARATION int:0
-#endif
-
+#define EMPTY_STRUCT_INITIALIZATION
 #define OPTION_CAST(x) (x)
 
 #ifdef _WIN32
@@ -65,9 +61,11 @@ CommonCHeaders = '
 
 // MSVC cannot parse some things properly
 #undef EMPTY_STRUCT_DECLARATION
-#define EMPTY_STRUCT_DECLARATION void *____dummy_variable
-
+#undef EMPTY_STRUCT_INITIALIZATION
 #undef OPTION_CAST
+
+#define EMPTY_STRUCT_DECLARATION int ____dummy_variable
+#define EMPTY_STRUCT_INITIALIZATION 0
 #define OPTION_CAST(x)
 #endif
 

--- a/compiler/gen_c.v
+++ b/compiler/gen_c.v
@@ -330,7 +330,7 @@ fn (p mut Parser) gen_struct_init(typ string, t Type) bool {
 		else {
 			p.gen('($typ) {')
 			if t.fields.len == 1 && t.fields[0].name == '' && t.fields[0].typ.starts_with('EMPTY_STRUCT_DECLARATION') {
-				p.gen(' 0 /* v empty struct initialization */ ')
+				p.gen(' EMPTY_STRUCT_INITIALIZATION ')
 			}
 		}
 	}

--- a/compiler/tests/repl/README.md
+++ b/compiler/tests/repl/README.md
@@ -5,6 +5,17 @@
   - Write the input to be given to REPL
   - Add `===output===`
   - Write the output expected
+  
+### Notes
+Keep in mind, that the way V repl works for now, every non empty line
+would cause a new recompilation of the entire repl content that was
+collected so far. 
+
+*Longer REPL files would cause measurably*
+*longer recompilation/testing times.*
+
+Also, longer repl files would be slower to debug when they fail,
+*It is better to have several smaller files vs one huge REPL file.*
 
 ### Example :
 ```

--- a/compiler/tests/repl/chained_fields.correct.repl
+++ b/compiler/tests/repl/chained_fields.correct.repl
@@ -1,0 +1,16 @@
+struct A { mut: v int } struct B {      a A } struct C { mut: b B }  struct D { mut: c C } struct E { mut: v []int } struct F { e []E }
+
+mut b := B{} b = B{A{2}} 
+println('b is: ' + b.a.v.str())
+
+mut c := C{} c.b = B{}
+
+mut d := D{} d.c.b = B{}
+
+f := F{[E{[10,20,30]},E{[100,200,300,400]}]}
+println('f.e[0].v.len: ${f.e[0].v.len}')
+println('f.e[1].v.len: ${f.e[1].v.len}')
+===output===
+b is: 2
+f.e[0].v.len: 3
+f.e[1].v.len: 4

--- a/compiler/tests/repl/empty_struct.repl
+++ b/compiler/tests/repl/empty_struct.repl
@@ -1,0 +1,4 @@
+struct Empty{} ee := Empty{}
+println('OK')
+===output===
+OK

--- a/compiler/tests/repl/immutable_len_fields.repl
+++ b/compiler/tests/repl/immutable_len_fields.repl
@@ -1,0 +1,30 @@
+mut s := 'hello world'
+s.len = 0   // Error (field len immutable)
+
+mut a := []string
+a.len = 0   // Error (field len immutable)
+
+mut ints := []int
+ints.len = 0   // Error (field len immutable)
+
+println('BYE')
+===output===
+.vrepl_temp.v:2:5: cannot modify immutable field `len` (type `string`)
+declare the field with `mut:`
+struct string {
+  mut:
+	len int
+}
+.vrepl_temp.v:3:5: cannot modify immutable field `len` (type `array`)
+declare the field with `mut:`
+struct array {
+  mut:
+	len int
+}
+.vrepl_temp.v:4:8: cannot modify immutable field `len` (type `array`)
+declare the field with `mut:`
+struct array {
+  mut:
+	len int
+}
+BYE

--- a/compiler/tests/repl/repl_test.v
+++ b/compiler/tests/repl/repl_test.v
@@ -20,17 +20,24 @@ fn test_the_v_compiler_can_be_invoked() {
 
 fn test_all_v_repl_files() {
 	options := runner.new_options()
-	global_start_time := runner.now()	
+	global_start_time := runner.now()
+	mut total_tests := 0
+	mut ok_tests := 0
+	mut failed_tests := 0
 	for file in options.files {
+		total_tests++
 		sticks := runner.now()
 		fres := runner.run_repl_file(options.wd, options.vexec, file) or {
+			failed_tests++
 			assert false
 			eprintln( runner.tdiff_in_ms(err, sticks) )
 			continue
 		}
 		assert true
 		println( runner.tdiff_in_ms(fres, sticks) )
+		ok_tests++
 	}
 	println( runner.tdiff_in_ms('<=== total time spent running REPL files', global_start_time) )
+	println( '            ok, failed, total : ${ok_tests:5d}, ${failed_tests:5d}, ${total_tests:5d}' )
 }
 


### PR DESCRIPTION
Print number of ok/failed/total REPL tests.
Fix empty struct generation for tcc (it is the opposite of msvc in a way, and does not handle 0s in empty struct initializers).
Fix gui examples building with tcc on linux ( i.e. linking to glfw by reapplying 982a162 ).