### PR TITLE
compiler: remove unreachable code - duplicated `get` option

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -154,13 +154,6 @@ fn main() {
 		vfmt(args)
 		return
 	}
-	// v get sqlite
-	if 'get' in args {
-		// Create the modules directory if it's not there.
-		if !os.file_exists(ModPath)  {
-			os.mkdir(ModPath)
-		}
-	}
 	// Construct the V object from command line arguments
 	mut v := new_v(args)
 	if v.pref.is_verbose {


### PR DESCRIPTION
Deleted code is never run as the `get` option is handled above (printing a message to use `install`).