### PR TITLE
Add rand_r

### DIFF
--- a/vlib/rand/rand.v
+++ b/vlib/rand/rand.v
@@ -14,6 +14,13 @@ pub fn next(max int) int {
 
 fn C.rand() int
 
+/**
+ * rand_r - reentrant pseudo-random number generator
+ *
+ * @param seed byref reentrant seed, holding current state
+ *
+ * @return a value between 0 and C.RAND_MAX (inclusive)
+ */
 pub fn rand_r(seed &int) int {
 	mut rs := seed
 	ns := ( *rs * 1103515245 + 12345 )

--- a/vlib/rand/rand.v
+++ b/vlib/rand/rand.v
@@ -12,4 +12,11 @@ pub fn next(max int) int {
 	return C.rand() % max
 }
 
-fn C.rand() int 
+fn C.rand() int
+
+pub fn rand_r(seed &int) int {
+	mut rs := seed
+	ns := ( *rs * 1103515245 + 12345 )
+	*rs = ns
+	return ns & 0x7fffffff
+}

--- a/vlib/rand/rand_test.v
+++ b/vlib/rand/rand_test.v
@@ -28,3 +28,31 @@ fn test_rand_reproducibility() {
 		assert randoms1[i] == randoms2[i]
 	}
 }
+
+fn gen_randoms_r(seed int) []int {
+	mut randoms := [0].repeat(20)
+	for i in 0..20 {
+		randoms[i] = rand.rand_r(&seed)
+	}
+	return randoms
+}
+
+fn test_rand_r_reproducibility() {
+	mut randoms1 := gen_randoms_r(42)
+	mut randoms2 := gen_randoms_r(42)
+	assert randoms1.len == randoms2.len
+
+	mut len := randoms1.len
+	for i in 0..len {
+		assert randoms1[i] == randoms2[i]
+	}
+
+	randoms1 = gen_randoms_r(256)
+	randoms2 = gen_randoms_r(256)
+	assert randoms1.len == randoms2.len
+
+	len = randoms1.len
+	for i in 0..len {
+		assert randoms1[i] == randoms2[i]
+	}
+}


### PR DESCRIPTION
Add standard rand_r function and tests
rand_r is a reentrant version of rand, with a self-contained, single function API
For example, tVintris (fork of V tetris) uses it because it needs to get random values in 2 concurrent threads

Credits to @spytheman for the port from https://git.musl-libc.org/cgit/musl/diff/src/prng/rand_r.c?id=0b44a0315b47dd8eced9f3b7f31580cf14bbfc01
