### PR TITLE
fix get_line in windows

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -333,7 +333,8 @@ fn (v mut V) generate_main() {
 		cgen.genln('void init_consts() {
 #ifdef _WIN32
 #ifndef _BOOTSTRAP_NO_UNICODE_STREAM
-_setmode(_fileno(stdout), _O_U8TEXT);
+_setmode(_fileno(stdin), _O_U16TEXT);
+_setmode(_fileno(stdout), _O_U16TEXT);
 SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), ENABLE_PROCESSED_OUTPUT | 0x0004);
 // ENABLE_VIRTUAL_TERMINAL_PROCESSING
 #endif


### PR DESCRIPTION
With this modification, you can enter Chinese and read Chinese under Windows.
fn main () {
    println('请输入：')
    s := os.get_line()
    println(s)
}
![image](https://user-images.githubusercontent.com/5841609/64934963-a0668e80-d880-11e9-8347-e094f0741839.png)
