### PR TITLE
compiler: add android to supported platforms

### DIFF
--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -274,7 +274,6 @@ fn os_name_to_ifdef(name string) string {
 		case 'netbsd': return '__NetBSD__'
 		case 'dragonfly': return '__DragonFly__'
 		case 'msvc': return '_MSC_VER'
-		case 'android': return '__BIONIC__'
 		case 'js': return '_VJS'
 	}
 	cerror('bad os ifdef name "$name"')

--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -274,6 +274,7 @@ fn os_name_to_ifdef(name string) string {
 		case 'netbsd': return '__NetBSD__'
 		case 'dragonfly': return '__DragonFly__'
 		case 'msvc': return '_MSC_VER'
+		case 'android': return '__BIONIC__'
 		case 'js': return '_VJS'
 	}
 	cerror('bad os ifdef name "$name"')

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -28,7 +28,7 @@ enum BuildMode {
 
 const (
 	SupportedPlatforms = ['windows', 'mac', 'linux', 'freebsd', 'openbsd',
-		'netbsd', 'dragonfly', 'msvc', 'android', 'js']
+		'netbsd', 'dragonfly', 'msvc', 'js']
 	ModPath            = os.home_dir() + '/.vmodules/'
 )
 

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -28,7 +28,7 @@ enum BuildMode {
 
 const (
 	SupportedPlatforms = ['windows', 'mac', 'linux', 'freebsd', 'openbsd',
-		'netbsd', 'dragonfly', 'msvc', 'js']
+		'netbsd', 'dragonfly', 'msvc', 'android', 'js']
 	ModPath            = os.home_dir() + '/.vmodules/'
 )
 


### PR DESCRIPTION
This PR is the 1st step to fix V build problems on Android.

This PR adds `'android'` to `SupportedPlatforms` in order to fix V build problems on Android.

Without these changes, compiler detects `$if android` as errors.

This PR needs to be merged before https://github.com/vlang/v/pull/2006 to avoid compiler causing errors. 