### PR TITLE
fix get_line in windows

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -333,6 +333,7 @@ fn (v mut V) generate_main() {
 		cgen.genln('void init_consts() {
 #ifdef _WIN32
 #ifndef _BOOTSTRAP_NO_UNICODE_STREAM
+_setmode(_fileno(stdin), _O_U16TEXT);
 _setmode(_fileno(stdout), _O_U8TEXT);
 SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), ENABLE_PROCESSED_OUTPUT | 0x0004);
 // ENABLE_VIRTUAL_TERMINAL_PROCESSING


### PR DESCRIPTION
With this modification, you can enter Chinese and read Chinese under Windows.
fn main () {
    println('请输入：‘)
    s := os.get_line()
    println(s)
}
