### PR TITLE
testing: turn on showing the timing information by default

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -962,7 +962,6 @@ fn (v &V) test_v() {
   
 	println('Testing...')
 	mut tmark := benchmark.new_benchmark()  
-	tmark.verbose = v.pref.is_verbose
 	for dot_relative_file in test_files {		
 		relative_file := dot_relative_file.replace('./', '')
 		file := os.realpath( relative_file )
@@ -994,7 +993,6 @@ fn (v &V) test_v() {
 	println('\nBuilding examples...')
 	examples := os.walk_ext('examples', '.v')
 	mut bmark := benchmark.new_benchmark()
-	bmark.verbose = v.pref.is_verbose
 	for relative_file in examples {
 		file := os.realpath( relative_file )
 		tmpcfilepath := file.replace('.v', '.tmp.c')

--- a/vlib/benchmark/benchmark.v
+++ b/vlib/benchmark/benchmark.v
@@ -44,10 +44,6 @@ pub fn new_benchmark() Benchmark{
 	}
 }
 
-pub fn now() i64 {
-	return time.ticks()
-}
-
 pub fn (b mut Benchmark) stop() {
 	b.bench_end_time = benchmark.now()
 }
@@ -89,3 +85,8 @@ fn (b mut Benchmark) tdiff_in_ms(s string, sticks i64, eticks i64) string {
 	}
 	return s
 }
+
+fn now() i64 {
+	return time.ticks()
+}
+


### PR DESCRIPTION
Turns on timing info when doing `v test v`, without --verbose needed.
The benchmark.run function is now private.