### PR TITLE
v2js: on linux -lm is needed for acos functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ matrix:
       dist: xenial
       sudo: required
       addons:
+        snaps:
+          - name: node
+            channel: latest/edge
+            confinement: classic
         apt:
           sources:
             - ubuntu-toolchain-r-test
@@ -17,7 +21,6 @@ matrix:
             - libglfw3-dev
             - libfreetype6-dev
             - libssl-dev
-            - nodejs
     - os: windows
       name: "windows_gcc"
       language: bash
@@ -77,7 +80,9 @@ script:
     fi
   - |
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      node --version
+      alias node=/snap/node/current/bin/node
+      echo "Nodejs version:"
+      node --version      
       # Build hi.js
       echo "fn main(){ println('Hello from V.js') }" > hi.v
       ./v -o hi.js hi.v
@@ -85,13 +90,16 @@ script:
     fi
   - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+      echo "Nodejs version:"
+      node --version      
+      # Build hi.js
+      echo "fn main(){ println('Hello from V.js') }" > hi.v
+      ./v -o hi.js hi.v 
+      node --harmony-class-fields hi.js
+    fi
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
       # Build Vid
       git clone https://github.com/vlang/vid
       cd vid && ../v -debug -o vid .
-      
-      # Build hi.js
-      node --version
-      echo "fn main(){ println('Hello from V.js') }" > hi.v
-      ../v -o hi.js hi.v 
-      node --harmony-class-fields hi.js
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,8 @@ script:
       node --version      
       # Build hi.js
       echo "fn main(){ println('Hello from V.js') }" > hi.v
-      ./v -o hi.js hi.v 
+      ./v -o hi.js hi.v
+      ## the node on osx requires --harmony-class-fields for now
       node --harmony-class-fields hi.js
     fi
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,13 +80,13 @@ script:
     fi
   - |
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      alias node="snap run node"
+      ## aliases do not work for some reason in travis, just use full commands :-|
       echo "Nodejs version:"
-      node --version      
+      snap run node --version      
       # Build hi.js
       echo "fn main(){ println('Hello from V.js') }" > hi.v
       ./v -o hi.js hi.v
-      node hi.js
+      snap run node hi.js
     fi
   - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ script:
       # Build hi.js
       echo "fn main(){ println('Hello from V.js') }" > hi.v
       ./v -o hi.js hi.v 
-      node hi.js
+      node --harmony-class-fields hi.js
     fi
   - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,11 +76,11 @@ script:
     fi
   - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-      # Build hi.js
-      echo "println('Hello from V.js')" > hi.js
-      ./v -o hi.js hi.v && node hi.js
-      
       # Build Vid
       git clone https://github.com/vlang/vid
       cd vid && ../v -debug -o vid .
+      
+      echo "fn main(){ println('Hello from V.js') }" > hi.v
+      ../v -o hi.js hi.v 
+      node --harmony-class-fields hi.js
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,9 +77,10 @@ script:
     fi
   - |
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      node --version
       # Build hi.js
       echo "fn main(){ println('Hello from V.js') }" > hi.v
-      ./v -o hi.js hi.v 
+      ./v -o hi.js hi.v
       node --harmony-class-fields hi.js
     fi
   - |
@@ -88,6 +89,8 @@ script:
       git clone https://github.com/vlang/vid
       cd vid && ../v -debug -o vid .
       
+      # Build hi.js
+      node --version
       echo "fn main(){ println('Hello from V.js') }" > hi.v
       ../v -o hi.js hi.v 
       node --harmony-class-fields hi.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
             - libglfw3-dev
             - libfreetype6-dev
             - libssl-dev
+            - nodejs
     - os: windows
       name: "windows_gcc"
       language: bash
@@ -73,6 +74,13 @@ script:
       make
       ./v -o v compiler
       ./v test v
+    fi
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      # Build hi.js
+      echo "fn main(){ println('Hello from V.js') }" > hi.v
+      ./v -o hi.js hi.v 
+      node --harmony-class-fields hi.js
     fi
   - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,13 +80,13 @@ script:
     fi
   - |
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      alias node=/snap/node/current/bin/node
+      alias node="snap run node"
       echo "Nodejs version:"
       node --version      
       # Build hi.js
       echo "fn main(){ println('Hello from V.js') }" > hi.v
       ./v -o hi.js hi.v
-      node --harmony-class-fields hi.js
+      node hi.js
     fi
   - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
@@ -95,7 +95,7 @@ script:
       # Build hi.js
       echo "fn main(){ println('Hello from V.js') }" > hi.v
       ./v -o hi.js hi.v 
-      node --harmony-class-fields hi.js
+      node hi.js
     fi
   - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then

--- a/compiler/cc.v
+++ b/compiler/cc.v
@@ -169,10 +169,8 @@ fn (v mut V) cc() {
 		}
 	}
 
-	if v.os == .js && ( v.out_name.ends_with('v2js') || v.out_name.ends_with('v2js.exe') ) {
-		if os.user_os() == 'linux' {
-			a << '-lm'
-		}
+	if v.os == .js && os.user_os() == 'linux' {
+		a << '-lm'
 	}
 	
 	if v.os == .windows {

--- a/compiler/cc.v
+++ b/compiler/cc.v
@@ -168,6 +168,13 @@ fn (v mut V) cc() {
 			a << ' -ldl '
 		}
 	}
+
+	if v.os == .js && ( v.out_name.ends_with('v2js') || v.out_name.ends_with('v2js.exe') ) {
+		if os.user_os() == 'linux' {
+			a << '-lm'
+		}
+	}
+	
 	if v.os == .windows {
 		a << '-DUNICODE -D_UNICODE'
 	}


### PR DESCRIPTION
Without this, on linux:
```shell
0[19:41:45] /v/v $ ./v -o hi.js hi.v
V.js compiler not found, building...
/tmp/ccZd6SdJ.o: In function `math__acos':
/v/v/v2js.tmp.c:6149: undefined reference to `acos'
/tmp/ccZd6SdJ.o: In function `math__asin':
/v/v/v2js.tmp.c:6154: undefined reference to `asin'
/tmp/ccZd6...
(Use `v -debug` to print the entire error message)

V error: C error. This should never happen. Please create a GitHub issue: https://github.com/vlang/v/issues/new/choose
Failed.
1[19:41:48] /v/v $
```

With it:
```shell
0[19:53:01] /v/v $ ./v2 -o hi.js hi.v
V.js compiler not found, building...
Done.
js typ to code
js typ to code
Done. Run it with `node hi.js`
JS backend is at a very early stage.
0[19:53:05] /v/v $
0[19:53:08] /v/v $
0[19:53:09] /v/v $ node --version
v10.13.0
0[19:53:11] /v/v $ node hi.js
/v/v/hi.js:30
        str; // byte*
           ^

SyntaxError: Unexpected token ;
    at new Script (vm.js:79:7)
    at createScript (vm.js:251:10)
    at Object.runInThisContext (vm.js:303:10)
    at Module._compile (internal/modules/cjs/loader.js:656:28)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:699:10)
    at Module.load (internal/modules/cjs/loader.js:598:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:537:12)
    at Function.Module._load (internal/modules/cjs/loader.js:529:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:741:12)
    at startup (internal/bootstrap/node.js:285:19)
1[19:53:16] /v/v $ ls -lart hi.js
-rw-rw-r-- 1 delian delian 15458 сеп 16 19:53 hi.js
0[19:53:22] /v/v $
```