### PR TITLE
crypto.rand: add PRNG function read_u64 + test

### DIFF
--- a/vlib/crypto/rand/rand_test.v
+++ b/vlib/crypto/rand/rand_test.v
@@ -4,7 +4,7 @@
 
 import crypto.rand
 
-fn test_crypto_rand() {
+fn test_crypto_rand_read() {
 	no_bytes := 100
 	max_percentage_diff := 20
 
@@ -27,4 +27,17 @@ fn test_crypto_rand() {
 	diff_percentage := f32(100) - (f32(difference)/f32(no_bytes)*100)
 
 	assert diff_percentage <= max_percentage_diff
+}
+
+fn test_crypto_rand_read_i64() {
+	max := u64(200)
+	r1 := rand.read_i64(max) or {
+		assert false
+		return
+	}
+	r2 := rand.read_i64(max) or {
+		assert false
+		return
+	}
+	assert r1 > u64(0) && r2 > u64(0) && r1 < max && r2 < max
 }

--- a/vlib/crypto/rand/rand_test.v
+++ b/vlib/crypto/rand/rand_test.v
@@ -29,13 +29,13 @@ fn test_crypto_rand_read() {
 	assert diff_percentage <= max_percentage_diff
 }
 
-fn test_crypto_rand_read_i64() {
+fn test_crypto_rand_read_u64() {
 	max := u64(200)
-	r1 := rand.read_i64(max) or {
+	r1 := rand.read_u64(max) or {
 		assert false
 		return
 	}
-	r2 := rand.read_i64(max) or {
+	r2 := rand.read_u64(max) or {
 		assert false
 		return
 	}

--- a/vlib/crypto/rand/utils.v
+++ b/vlib/crypto/rand/utils.v
@@ -1,0 +1,63 @@
+// Copyright (c) 2019 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+module rand
+
+import(
+	math
+	encoding.binary
+)
+
+pub fn read_i64(max u64) u64? {
+	if max <= u64(0) {
+		return error('crypto.rand: argument to read_i64 is <= 0')
+	}
+	// bitlen := int(math.floor(math.log2(f64(max))+1))
+	bitlen := int(math.floor(math.log(f64(max))/math.log(2)) + 1)
+	if bitlen == 0 {
+		return u64(0)
+	}
+	k := (bitlen + 7) / 8
+	mut b := u64(bitlen % 8)
+	if b == u64(0) {
+		b = u64(8)
+	}
+	mut n := u64(0)
+	for {
+		mut bytes := read(k) or {
+			return error(err)
+		}
+		bytes[0] &= byte(int(u64(1)<<b) - 1)
+		x := bytes_to_u64(bytes)
+		n = x[0]
+		if x.len > 1 {
+			n = u64(u32(x[1])<<u32(32)) | n
+		}
+		if int(n) < 0 {
+			n = -n
+		}
+		if n < max {
+			return n
+		}
+	}
+	return n
+}
+
+fn bytes_to_u64(b []byte) []u64 {   
+	mut z := [u64(0)].repeat((b.len + 8 - 1) / 8)
+	mut i := b.len
+	for k := 0; i >= 8; k++ {
+		z[k] = binary.big_endian_u64(b.slice(i-8, i))
+		i -= 8
+	}
+	if i > 0 {
+		mut d := u64(0)
+		for s := u64(0); i > 0; s += u64(8) {
+			d |= u64(u64(b[i-1]) << s)
+			i--
+		}
+		z[z.len-1] = d
+	}
+	return z
+}

--- a/vlib/crypto/rand/utils.v
+++ b/vlib/crypto/rand/utils.v
@@ -9,9 +9,9 @@ import(
 	encoding.binary
 )
 
-pub fn read_i64(max u64) u64? {
+pub fn read_u64(max u64) u64? {
 	if max <= u64(0) {
-		return error('crypto.rand: argument to read_i64 is <= 0')
+		return error('crypto.rand: argument to read_u64 is <= 0')
 	}
 	// bitlen := int(math.floor(math.log2(f64(max))+1))
 	bitlen := int(math.floor(math.log(f64(max))/math.log(2)) + 1)


### PR DESCRIPTION
crypto.rand: add PRNG function read_i64 + test

This function is an analogue of go's crypto.rand.Int()

Sample distribution of 0 to 200
```
77|133|85|49|36|149|137|6|110|62|126|39|48|35|154|109|24|93|170|90|111|69|70|171|167|82|104|69|37|135|6|139|34|195|67|2|170|126|147|40|3|153|133|106|92|104|79|152|76|125|58|134|83|28|107|186|142|20|118|27|69|102|9|106|197|155|5|159|50|52|47|91|10|159|147|23|181|32|150|1|20|113|65|101|122|72|137|180|61|162|9|32|100|75|67|111|179|108|180|66|28|175|197|95|73|92|2|127|40|142|107|133|89|195|132|176|146|157|76|105|196|83|163|126|107|140|66|175|99|196|190|166|49|64|71|86|28|151|195|145|151|99|84|94|157|9|193|43|115|29|27|107|135|198|51|88|113|197|75|176|85|132|26|164|73|52|24|154|80|60|56|33|35|179|171|2|1|150|34|196|19|121|105|103|32|72|39|50|13|140|135|108|190|35|67|66|39|194|19|32|36|9|94|49|35|177|95|94|103|85|36|76|5|83|55|64|46|77|192|14|160|142|146|53|21|168|127|41|87|107|72|11
```