### PR TITLE
README: Remove version number from title; make Changelog & Releases more visible 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The V Programming Language 0.1.x
+# The V Programming Language
 
 [![Build Status](https://travis-ci.org/vlang/v.svg?branch=master)](https://travis-ci.org/vlang/v)
 <a href='https://patreon.com/vlang'><img src='https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fshieldsio-patreon.herokuapp.com%2Fvlang%2Fpledges&style=for-the-badge' height='20'></a>
@@ -6,6 +6,8 @@
 https://vlang.io
 
 Documentation: https://vlang.io/docs
+
+Changelog: [Master Changelog](https://github.com/vlang/v/blob/master/CHANGELOG.md) | [Releases (with changelogs)](https://github.com/vlang/v/releases)
 
 Twitter: https://twitter.com/v_language
 


### PR DESCRIPTION
This seems like just one more thing to remember to update and, if forgotten about, it might lend to the idea that V is something that should be avoided. I think version info like probably should be kept in Changelog and other such locations.

One more thing we might add is to say "Changelog & Version Info:"...