### PR TITLE
windows: cleanup make.bat and .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,10 +65,6 @@ script:
         ./make.bat -msvc
       fi
 
-      ### running just repl_test.v produces failing results earlier and is easier to read
-      echo "Running only the repl tests directly..."
-      ./v.exe ./compiler/tests/repl/repl_test.v
-      echo "Running ALL tests..."
       ./v.exe test v
       set +e
     fi

--- a/make.bat
+++ b/make.bat
@@ -28,7 +28,7 @@ if not exist "%gccpath%" (
     goto:msvcstrap
 )
 
-gcc -DUNICODE -D_UNICODE -std=gnu11 -w -o v2.exe vc\v_win.c
+gcc -std=gnu11 -w -o v2.exe vc\v_win.c
 if %ERRORLEVEL% NEQ 0 (
     echo gcc failed to compile - Create an issue at 'https://github.com/vlang'
     exit /b 1
@@ -60,7 +60,7 @@ if exist "%InstallDir%\Common7\Tools\vsdevcmd.bat" (
     goto :nocompiler
 )
 
-cl.exe -DUNICODE -D_UNICODE /nologo /w /volatile:ms /Fo.v.c.obj /O2 /MD vc\v_win.c user32.lib kernel32.lib advapi32.lib shell32.lib /link /NOLOGO /OUT:v2.exe /INCREMENTAL:NO
+cl.exe /nologo /w /volatile:ms /Fo.v.c.obj /O2 /MD vc\v_win.c user32.lib kernel32.lib advapi32.lib shell32.lib /link /NOLOGO /OUT:v2.exe /INCREMENTAL:NO
 if %ERRORLEVEL% NEQ 0 (
     echo cl.exe failed to build V
     goto :compileerror


### PR DESCRIPTION
* bootstrapping does not require unicode defines anymore
* no need to run repl tests twice anymore