### PR TITLE
compiler: fix `v up` when run from dir with space in name (win). closes #2031

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -901,7 +901,7 @@ fn update_v() {
 			os.rm( v_backup_file )
 		}
 		os.mv('$vroot/v.exe', v_backup_file)
-		s2 := os.exec('$vroot/make.bat') or {
+		s2 := os.exec('"$vroot/make.bat"') or {
 			cerror(err)
 			return
 		}


### PR DESCRIPTION
compiler: fix `v up` when run from dir with space in name. closes #2031