### PR TITLE
bootstrap: add BSD makefile

### DIFF
--- a/BSDmakefile
+++ b/BSDmakefile
@@ -1,4 +1,4 @@
-CC = cc
+CC ?= cc
 
 all:
 	rm -rf vc/

--- a/BSDmakefile
+++ b/BSDmakefile
@@ -1,0 +1,8 @@
+CC = cc
+
+all:
+	rm -rf vc/
+	git clone --depth 1 --quiet https://github.com/vlang/vc
+	$(CC) -std=gnu11 -w -o v vc/v.c -lm
+	rm -rf vc/
+	@echo "V has been successfully built"


### PR DESCRIPTION
bootstrap: add BSD makefile

After looking at Makefile, it seems like it's only the stuff in there to detect the operating system which is  GNU specific. It might be handy to leave this in, as we could also use it to detect osx or any os's... I'm not sure if that will useful to keep. But without it we could probably have a single Makefile.

In either case here is a BSD Makefile