### PR TITLE
windows: Unicode input in REPL

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -355,6 +355,10 @@ fn (v mut V) generate_main() {
 		// vlib can't have `init_consts()`
 		cgen.genln('void init_consts() {
 #ifdef _WIN32
+DWORD consoleMode;
+BOOL isConsole = GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &consoleMode);
+int mode = isConsole ? _O_U16TEXT : _O_U8TEXT;
+_setmode(_fileno(stdin), mode);
 _setmode(_fileno(stdout), _O_U8TEXT);
 SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), ENABLE_PROCESSED_OUTPUT | 0x0004);
 // ENABLE_VIRTUAL_TERMINAL_PROCESSING

--- a/compiler/msvc.v
+++ b/compiler/msvc.v
@@ -292,8 +292,7 @@ pub fn (v mut V) cc_msvc() {
 		'oleaut32.lib',
 		'uuid.lib',
 		'odbc32.lib',
-		'odbccp32.lib',
-		'vcruntime.lib',
+		'odbccp32.lib'
 	]
 
 	mut inc_paths := []string{}

--- a/compiler/tests/repl/println.repl
+++ b/compiler/tests/repl/println.repl
@@ -1,3 +1,7 @@
-println('hello world')
+println('Hello, world!')
+println('Привет, мир!')
+println('你好世界')
 ===output===
-hello world
+Hello, world!
+Привет, мир!
+你好世界

--- a/make.bat
+++ b/make.bat
@@ -34,8 +34,9 @@ if %ERRORLEVEL% NEQ 0 (
     exit /b 1
 )
 
-echo Building v.v...
-v2.exe -o v.exe compiler
+echo rebuild from source (twice, in case of C definitions changes)
+v2.exe -o v3.exe compiler
+v3.exe -o v.exe -prod compiler
 if %ERRORLEVEL% NEQ 0 (
     echo v.exe failed to compile itself - Create an issue at 'https://github.com/vlang'
     exit /b 1
@@ -66,14 +67,16 @@ if %ERRORLEVEL% NEQ 0 (
     goto :compileerror
 )
 
-echo rebuild from source
-v2.exe -os msvc -o v.exe compiler
+echo rebuild from source (twice, in case of C definitions changes)
+v2.exe -os msvc -o v3.exe compiler
+v3.exe -os msvc -o v.exe -prod compiler
 if %ERRORLEVEL% NEQ 0 (
     echo V failed to build itself
     goto :compileerror
 )
 
 del v2.exe
+del v3.exe
 rd /s /q vc
 
 goto :success

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -469,10 +469,10 @@ pub fn get_line() string {
 pub fn get_raw_line() string {
 	$if windows {
         maxlinechars := 256
-        buf := &u16(malloc(maxlinechars*2))
+        buf := &byte(malloc(maxlinechars*2))
         res := int( C.fgetws(buf, maxlinechars, C.stdin ) )
-        len := int(  C.wcslen(buf) )
-        if 0 != res { return string_from_wide2( buf, len ) }
+        len := int(  C.wcslen(&u16(buf)) )
+        if 0 != res { return string_from_wide2( &u16(buf), len ) }
         return ''
     }
 	$else {


### PR DESCRIPTION
* stdin must be set to UTF-16 mode, redirected stdin must be UTF-8
* updated println.repl test with unicode characters
* build V twice to stop waiting v.c update
* vcruntime.lib should not be linked explicitly (linker selects vcruntime or vcruntime**d** for debug builds)
