### PR TITLE
Fix compile error due to missing `module main`

### DIFF
--- a/examples/tetris/tetris.v
+++ b/examples/tetris/tetris.v
@@ -2,6 +2,8 @@
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 
+module main
+
 import rand
 import time
 import gx


### PR DESCRIPTION
Error message:

```
$ ../../v .
check()
next token = `rand`
0   v                                   0x000000010d2aa3c6 Parser_check + 294
1   v                                   0x000000010d2ab922 Parser_parse + 466
2   v                                   0x000000010d2c78be V_add_v_files_to_compile + 1502
3   v                                   0x000000010d2c62e5 V_compile + 517
4   v                                   0x000000010d2c32ae main + 2174
5   libdyld.dylib                       0x00007fff66e5b3d5 start + 1
6   ???                                 0x0000000000000002 0x0 + 2
import rand
          ^
/Users/zhb/tmp/v/examples/tetris/tetris.v:5:11: expected `module` but got `import`
```