### PR TITLE
Fix windows printf output to match standard unix line buffering

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -362,6 +362,7 @@ _setmode(_fileno(stdin), mode);
 _setmode(_fileno(stdout), _O_U8TEXT);
 SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), ENABLE_PROCESSED_OUTPUT | 0x0004);
 // ENABLE_VIRTUAL_TERMINAL_PROCESSING
+setbuf(stdout,0);
 #endif
 g_str_buf=malloc(1000);
 $consts_init_body


### PR DESCRIPTION
This one-liner fixes windows printf buffering to match standard (unix) line buffering

This way, ./v test v nicely prints tests text output as they are printed