### PR TITLE
ci:fix github actions to run & show output of windows tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         git clone --depth=1 https://github.com/ubawurinna/freetype-windows-binaries.git thirdparty/freetype/
         make -gcc
-        ./v.exe test v
+        v.exe test v
         echo "Done"
   build-windows-msvc:
     runs-on: ${{ matrix.os }}
@@ -70,5 +70,5 @@ jobs:
       run: |
         git clone --depth=1 https://github.com/ubawurinna/freetype-windows-binaries.git thirdparty/freetype/
         make -msvc
-        ./v.exe test v
+        v.exe test v
         echo "Done"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,8 @@ jobs:
       shell: powershell
       run: |
         git clone --depth=1 https://github.com/ubawurinna/freetype-windows-binaries.git thirdparty/freetype/
-        make.bat -gcc
-        ./v.exe test v
+        .\make.bat -gcc
+        .\v.exe test v
   build-windows-msvc:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -70,5 +70,5 @@ jobs:
         VFLAGS: -os msvc
       run: |
         git clone --depth=1 https://github.com/ubawurinna/freetype-windows-binaries.git thirdparty/freetype/
-        make.bat -msvc
-        ./v.exe test v
+        .\make.bat -msvc
+        .\v.exe test v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,11 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Build and test
+      shell: powershell
       run: |
         git clone --depth=1 https://github.com/ubawurinna/freetype-windows-binaries.git thirdparty/freetype/
         make -gcc
-        v.exe test v
-        echo "Done"
+        ./v.exe test v
   build-windows-msvc:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -65,10 +65,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Build and test
+      shell: powershell
       env:
         VFLAGS: -os msvc
       run: |
         git clone --depth=1 https://github.com/ubawurinna/freetype-windows-binaries.git thirdparty/freetype/
         make -msvc
-        v.exe test v
-        echo "Done"
+        ./v.exe test v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       shell: powershell
       run: |
         git clone --depth=1 https://github.com/ubawurinna/freetype-windows-binaries.git thirdparty/freetype/
-        make -gcc
+        make.bat -gcc
         ./v.exe test v
   build-windows-msvc:
     runs-on: ${{ matrix.os }}
@@ -70,5 +70,5 @@ jobs:
         VFLAGS: -os msvc
       run: |
         git clone --depth=1 https://github.com/ubawurinna/freetype-windows-binaries.git thirdparty/freetype/
-        make -msvc
+        make.bat -msvc
         ./v.exe test v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
         git clone --depth=1 https://github.com/ubawurinna/freetype-windows-binaries.git thirdparty/freetype/
         make -gcc
         ./v.exe test v
+        echo "Done"
   build-windows-msvc:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -70,3 +71,4 @@ jobs:
         git clone --depth=1 https://github.com/ubawurinna/freetype-windows-binaries.git thirdparty/freetype/
         make -msvc
         ./v.exe test v
+        echo "Done"


### PR DESCRIPTION
I'm not even sure if the tests were running on windows before. Judging but the time difference I don't think they were.
They definitely are now though