### PR TITLE
compiler: fix live reload on win with auto completed filename `.\file.v` (start with .\)

### DIFF
--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -4,7 +4,10 @@
 
 module main
 
-import strings
+import(
+	os
+	strings
+)
 
 const (
 	MaxLocalVars = 50
@@ -455,7 +458,7 @@ fn (p mut Parser) fn_decl() {
 		}
 		// We are in live code reload mode, call the .so loader in bg
 		if p.pref.is_live {
-			file_base := p.file_path.replace('.v', '')
+			file_base := os.filename(p.file_path).replace('.v', '')
 			if p.os != .windows && p.os != .msvc {
 				so_name := file_base + '.so'
 				p.genln('

--- a/compiler/live.v
+++ b/compiler/live.v
@@ -40,8 +40,8 @@ fn (v &V) generate_hot_reload_code() {
 
 	// Hot code reloading
 	if v.pref.is_live {
-		file := v.dir
-		file_base := file.replace('.v', '')
+		mut file := os.realpath(v.dir)
+		file_base := os.filename(file).replace('.v', '')
 		so_name := file_base + '.so'
 		// Need to build .so file before building the live application
 		// The live app needs to load this .so file on initialization.
@@ -49,6 +49,7 @@ fn (v &V) generate_hot_reload_code() {
 
 		if os.user_os() == 'windows' {
 			vexe = vexe.replace('\\', '\\\\')
+			file = file.replace('\\', '\\\\')
 		}
 
 		mut msvc := ''

--- a/compiler/live.v
+++ b/compiler/live.v
@@ -35,13 +35,13 @@ fn (v &V) generate_hotcode_reloading_declarations() {
 	}
 }
 
-fn (v mut V) generate_hot_reload_code() {
+fn (v &V) generate_hot_reload_code() {
   mut cgen := v.cgen
 
 	// Hot code reloading
 	if v.pref.is_live {
-		file := v.dir
-		file_base := v.dir.replace('.v', '')
+		file := os.filename(v.dir)
+		file_base := file.replace('.v', '')
 		so_name := file_base + '.so'
 		// Need to build .so file before building the live application
 		// The live app needs to load this .so file on initialization.

--- a/compiler/live.v
+++ b/compiler/live.v
@@ -40,7 +40,7 @@ fn (v &V) generate_hot_reload_code() {
 
 	// Hot code reloading
 	if v.pref.is_live {
-		file := os.filename(v.dir)
+		file := v.dir
 		file_base := file.replace('.v', '')
 		so_name := file_base + '.so'
 		// Need to build .so file before building the live application


### PR DESCRIPTION
compiler: fix live reload on win with auto completed filename `.\file.v` (start with .\)

This issue was brought up in #questions on discord by HammockTime.