### PR TITLE
compiler: pass -cflags to the thirdparty building stage too

### DIFF
--- a/compiler/cc.v
+++ b/compiler/cc.v
@@ -369,17 +369,23 @@ fn find_c_compiler_default() string {
 }
 
 fn find_c_compiler_thirdparty_options() string {
-	if '-m32' in os.args{
-		$if windows {
-			return '-m32'
-		}$else{
-			return '-fPIC -m32'
-		}
-	}else{
-		$if windows {
-			return ''
-		}$else{
-			return '-fPIC'
+	fullargs := env_vflags_and_os_args()
+	mut cflags := get_cmdline_cflags( fullargs )
+	$if !windows {
+		cflags += ' -fPIC'
+	}
+	if '-m32' in fullargs {
+		cflags += ' -m32'
+	}
+	return cflags
+}
+
+fn get_cmdline_cflags(args []string) string {
+	mut cflags := ''
+	for ci, cv in args {
+		if cv == '-cflags' {
+			cflags += args[ci+1] + ' '
 		}
 	}
+	return cflags
 }

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -842,12 +842,7 @@ fn new_v(args[]string) &V {
 			files << f
 		}
 
-	mut cflags := ''
-	for ci, cv in args {
-		if cv == '-cflags' {
-			cflags += args[ci+1] + ' '
-		}
-	}
+	cflags := get_cmdline_cflags(args)
 
 	rdir := os.realpath( dir )
 	rdir_name := os.filename( rdir )


### PR DESCRIPTION
This PR allows you to pass C optimization flags to the building stage of thirdparty objects too.
For example, you can do:
`v  -cflags -mtune=native -cflags -march=native program.v`
... where program.v uses an object file produced by a C source, 
and the C object file would be build with `-mtune=native -march=native` , just like the main program.v .