### PR TITLE
Readme fix: How to exit from REPL doesn't match actual output of REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ v -o v compiler
 ```
 $ v
 V 0.1.x
-Use Ctrl-D to exit
+Use Ctrl-C or `exit` to exit
 
 >>> println('hello world')
 hello world


### PR DESCRIPTION
Hi. The example of Readme said 'Use Ctrl-D' to exit but the actual message from REPL is 'Ctrl-C'. 
Both Ctrl-C and Ctrl-D works and `help` explains both but I wanted to make it accurate.

```
./v
V 0.1.20 049e228
Use Ctrl-C or `exit` to exit
>>> help

V 0.1.20 049e228
  help                   Displays this information.
  Ctrl-C, Ctrl-D, exit   Exits the REPL.
  clear                  Clears the screen.
```

Regarding `help`, Ctrl-Z is used for EOF instead of Ctrl-D in Windows. So adding Ctrl-Z to `help` explanation could be better.
