### PR TITLE
Fix #2084, by making socket.recv return *both* the buffer and the received message length.

### DIFF
--- a/vlib/net/socket.v
+++ b/vlib/net/socket.v
@@ -206,22 +206,19 @@ pub fn dial(address string, port int) ?Socket {
 }
 
 // send string data to socket
-pub fn (s Socket) send(buf byteptr, len int) int {
-	res := C.send(s.sockfd, buf, len, 0)
-//	if res < 0 {
-//		return error('socket: send failed')
-//	}
+pub fn (s Socket) send(buf byteptr, len int) int? {
+	res := int( C.send(s.sockfd, buf, len, 0) )
+	if res < 0 {
+		return error('socket: send failed')
+	}
 	return res
 }
 
 // receive string data from socket
-pub fn (s Socket) recv(bufsize int) byteptr {
+pub fn (s Socket) recv(bufsize int) (byteptr, int) {
 	buf := malloc(bufsize)
-	res := C.recv(s.sockfd, buf, bufsize, 0)
-//	if res < 0 {
-//		return error('socket: recv failed')
-//	}
-	return buf
+	res := int( C.recv(s.sockfd, buf, bufsize, 0) )
+	return buf, res
 }
 
 // TODO: remove cread/2 and crecv/2 when the Go net interface is done

--- a/vlib/net/socket_test.v
+++ b/vlib/net/socket_test.v
@@ -17,9 +17,13 @@ fn test_socket() {
 	
 	message := 'Hello World'
 	socket.send(message.str, message.len)	
+	$if debug {	println('message send: $message')	}
+	$if debug {	println('send socket: $socket.sockfd')	}
 
-	bytes := client.recv(1024)
-	received := tos(bytes, message.len)
+	bytes, blen := client.recv(1024) 
+	received := tos(bytes, blen)
+	$if debug {	println('message received: $received')	}
+	$if debug {	println('client: $client.sockfd')	}
 
 	assert message == received
 


### PR DESCRIPTION
With this PR:
```shell
0[17:39:09] /v/nv $ ./v -debug vlib/net/socket_test.v
C compiler=cc
all .v files: .... // truncated to remove horizontal scroller
net.listen(0)
listen res = 0
accept()
message send: Hello World
send socket: 5
message received: Hello World
client: 4
0[17:39:11] /v/nv $
```