### PR TITLE
compiler: only check unused vars in fn_decl

### DIFF
--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -69,7 +69,7 @@ fn (p mut Parser) open_scope() {
 }
 
 fn (p mut Parser) mark_var_used(v Var) {
-	if v.idx == -1 {
+	if v.idx == -1 || v.idx >= p.local_vars.len {
 		return
 	}	
 	p.local_vars[v.idx].is_used = true

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -276,10 +276,10 @@ fn (p mut Parser) parse(pass Pass) {
 			p.cgen.consts << g
 		case Token.eof:
 			//p.log('end of parse()')
-			if p.is_script && !p.pref.is_test {
-				p.set_current_fn( MainFn )
-				p.check_unused_variables()
-			}
+			// if p.is_script && !p.pref.is_test {
+			// 	p.set_current_fn( MainFn )
+			// 	p.check_unused_variables()
+			// }
 			if !p.first_pass() && !p.pref.is_repl {
 				p.check_unused_imports()
 			}


### PR DESCRIPTION
compiler: only check unused vars in fn_decl