### PR TITLE
compiler: remove special case for http__init_module call

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -357,11 +357,6 @@ fn (v mut V) generate_main() {
 	// if v.build_mode in [.default, .embed_vlib] {
 	if v.pref.build_mode == .default_mode || v.pref.build_mode == .embed_vlib {
 		mut consts_init_body := cgen.consts_init.join_lines()
-		for imp in v.table.imports {
-			if imp == 'http' {
-				consts_init_body += '\n http__init_module();'
-			}
-		}
 		// vlib can't have `init_consts()`
 		cgen.genln('void init_consts() {
 #ifdef _WIN32

--- a/vlib/http/backend_nix.v
+++ b/vlib/http/backend_nix.v
@@ -27,7 +27,7 @@ struct C.SSL {
  
 } 
 
-fn init_module() {
+fn init() int {
 	$if mac { 
 		C.SSL_library_init() 
 	} 
@@ -36,6 +36,7 @@ fn init_module() {
 	} 
 	//C.SSL_load_error_strings() 
 	//C.OPENSSL_config(0) 
+	return 1
 }
 
 fn (req &Request) ssl_do(port int, method, host_name, path string) Response {

--- a/vlib/http/backend_win.v
+++ b/vlib/http/backend_win.v
@@ -13,7 +13,7 @@ module http
 
 fn C.new_tls_context() C.TlsContext
 
-fn init_module() {}
+fn init() int { return 1 }
 
 fn (req &Request) ssl_do(port int, method, host_name, path string) Response {
 	mut ctx := C.new_tls_context()

--- a/vlib/http/http.v
+++ b/vlib/http/http.v
@@ -9,6 +9,7 @@ import http.chunked
 
 const (
 	max_redirects = 4
+	started = http.init()
 )
 
 struct Request {


### PR DESCRIPTION
Instead, now the http module uses a const that calls http.init() .