### PR TITLE
mysql: fix problem with mysql module

### DIFF
--- a/vlib/mysql/mysql.v
+++ b/vlib/mysql/mysql.v
@@ -12,7 +12,7 @@ struct Result {
 }
 
 struct Row {
-pub:
+pub mut:
 	vals []string
 }
 

--- a/vlib/mysql/mysql.v
+++ b/vlib/mysql/mysql.v
@@ -27,7 +27,7 @@ fn C.mysql_query(mysql *C.MYSQL, q byteptr) int
 fn C.mysql_error(mysql *C.MYSQL) byteptr
 fn C.mysql_num_fields(res *C.MYSQL_RES) int
 fn C.mysql_store_result(mysql *C.MYSQL) *C.MYSQL_RES
-fn C.mysql_fetch_row(res *C.MYSQL_RES) *byteptr
+fn C.mysql_fetch_row(res *C.MYSQL_RES) &byteptr
 fn C.mysql_free_result(res *C.MYSQL_RES)
 fn C.mysql_close(sock *C.MYSQL)
 
@@ -62,7 +62,7 @@ pub fn (db DB) close() {
 	C.mysql_close(db.conn)
 }
 
-pub fn (r Result) fetch_row() *byteptr {
+pub fn (r Result) fetch_row() &byteptr {
 	return C.mysql_fetch_row(r.result)
 }
 


### PR DESCRIPTION
### Try to fix this issue 👉  #2092 

The `vals` field in the` Rows` struct is immutable, so we add the `Access modifiers` to` mut` to it.
And we replace the pointer `*` to `&` on [this line](https://github.com/vlang/v/blob/master/vlib/mysql/mysql.v#L30) and [this line](https://github.com/vlang/v/blob/master/vlib/mysql/mysql.v#L65).

Thank you...  ✌️ 🙌