### PR TITLE
compiler: passing -g adds more informative debug information

### DIFF
--- a/compiler/cc.v
+++ b/compiler/cc.v
@@ -70,11 +70,27 @@ fn (v mut V) cc() {
 		v.out_name = ModPath + v.dir + '.o' //v.out_name
 		println('Building ${v.out_name}...')
 	}
+  
+	mut debug_options := '-g'
+	mut optimization_options := '-O2'
+	if v.pref.ccompiler.contains('clang') {
+		if v.pref.is_debug {
+			debug_options = '-g -O0'
+		}
+		optimization_options = '-O3 -flto'
+	}
+	if v.pref.ccompiler.contains('gcc') {
+		if v.pref.is_debug {
+			debug_options = '-g3'
+		}
+		optimization_options = '-O3 -fno-strict-aliasing -flto'
+	}
+
 	if v.pref.is_prod {
-		a << '-O2'
+		a << optimization_options
 	}
 	else {
-		a << '-g'
+		a << debug_options
 	}
 
 	if v.pref.is_debug && os.user_os() != 'windows'{


### PR DESCRIPTION
gcc supports -g3 which adds macro expansion information for gdb.
clang also generates more debugging information when given -g -O0 (this is even recommended in their official documentation at https://www.llvm.org/docs/SourceLevelDebugging.html#debug-information-and-optimizations )

The same is true for their optimization modes, where both support -O3 -flto .

This PR detects the compiler of the user and gives the appropriate extended debugging/optimization options.
