### PR TITLE
windows: Unicode and IPv6 http/sockets

### DIFF
--- a/compiler/cheaders.v
+++ b/compiler/cheaders.v
@@ -48,6 +48,8 @@ CommonCHeaders = '
 #define OPTION_CAST(x) (x)
 
 #ifdef _WIN32
+#define WINVER 0x0600
+#define _WIN32_WINNT 0x0600
 #define WIN32_LEAN_AND_MEAN
 #define _UNICODE
 #define UNICODE

--- a/thirdparty/vschannel/vschannel.h
+++ b/thirdparty/vschannel/vschannel.h
@@ -28,19 +28,19 @@ static void vschannel_init(TlsContext *tls_ctx);
 
 static void vschannel_cleanup(TlsContext *tls_ctx);
 
-static INT request(TlsContext *tls_ctx, INT iport, CHAR *host, CHAR *req, CHAR **out);
+static INT request(TlsContext *tls_ctx, INT iport, LPWSTR host, CHAR *req, CHAR **out);
 
 static SECURITY_STATUS https_make_request(TlsContext *tls_ctx, CHAR *req, CHAR **out, int *length);
 
-static INT connect_to_server(TlsContext *tls_ctx, CHAR *host, INT port_number);
+static INT connect_to_server(TlsContext *tls_ctx, LPWSTR host, INT port_number);
 
 static LONG disconnect_from_server(TlsContext *tls_ctx);
 
-static SECURITY_STATUS perform_client_handshake(TlsContext *tls_ctx, CHAR *host, SecBuffer *pExtraData);
+static SECURITY_STATUS perform_client_handshake(TlsContext *tls_ctx, LPWSTR host, SecBuffer *pExtraData);
 
 static SECURITY_STATUS client_handshake_loop(TlsContext *tls_ctx, BOOL fDoInitialRead, SecBuffer *pExtraData);
 
-static DWORD verify_server_certificate(PCCERT_CONTEXT  pServerCert, PSTR host, DWORD dwCertFlags);
+static DWORD verify_server_certificate(PCCERT_CONTEXT  pServerCert, LPWSTR host, DWORD dwCertFlags);
 
 static SECURITY_STATUS create_credentials(TlsContext *tls_ctx);
 

--- a/vlib/http/backend_nix.v
+++ b/vlib/http/backend_nix.v
@@ -28,14 +28,7 @@ struct C.SSL {
 } 
 
 fn init() int {
-	$if mac { 
-		C.SSL_library_init() 
-	} 
-	$if linux { 
-		C.SSL_library_init() 
-	} 
-	//C.SSL_load_error_strings() 
-	//C.OPENSSL_config(0) 
+	C.SSL_library_init() 
 	return 1
 }
 

--- a/vlib/http/backend_win.v
+++ b/vlib/http/backend_win.v
@@ -8,6 +8,7 @@ module http
 #flag windows -I @VROOT/thirdparty/vschannel
 #flag -l ws2_32
 #flag -l crypt32
+#flag -l secur32
  
 #include "vschannel.c"
 
@@ -22,7 +23,7 @@ fn (req &Request) ssl_do(port int, method, host_name, path string) Response {
 	mut buff := malloc(C.vsc_init_resp_buff_size)
 	addr := host_name
 	sdata := req.build_request_headers(method, host_name, path)
-	length := int(C.request(&ctx, port, addr.str, sdata.str, &buff))
+	length := int(C.request(&ctx, port, addr.to_wide(), sdata.str, &buff))
 
 	C.vschannel_cleanup(&ctx)
 	return parse_response(string(buff, length))

--- a/vlib/http/http_test.v
+++ b/vlib/http/http_test.v
@@ -1,5 +1,5 @@
 // import net.urllib
-// import http
+import http
 
 fn test_escape_unescape() {
 /*
@@ -12,15 +12,11 @@ fn test_escape_unescape() {
 }
 
 fn test_http_get() {
-/*
-	$if windows { return }
 	assert http.get_text('https://vlang.io/version') == '0.1.5'
 	println('http ok')
-*/
 }
 
-fn test_http_get_from_vlang_utc_now() {
-	/*
+fn test_http_get_from_vlang_utc_now() {	
 	urls := ['http://vlang.io/utc_now', 'https://vlang.io/utc_now']
 	for url in urls {
 		println('Test getting current time from $url by http.get')
@@ -30,11 +26,9 @@ fn test_http_get_from_vlang_utc_now() {
 		assert res.text.int() > 1566403696
 		println('Current time is: ${res.text.int()}')
 	}
-	*/
 }
 
 fn test_public_servers() {
-	/*
 	urls := [
 		'http://github.com/robots.txt',
 		'http://google.com/robots.txt',
@@ -49,5 +43,4 @@ fn test_public_servers() {
 		assert 200 == res.status_code
 		assert res.text.len > 0
 	}
-	*/
 }

--- a/vlib/net/socket.v
+++ b/vlib/net/socket.v
@@ -176,9 +176,11 @@ pub fn (s Socket) connect(address string, port int) ?int {
 	hints.ai_family = C.AF_UNSPEC
 	hints.ai_socktype = C.SOCK_STREAM
 	hints.ai_flags = C.AI_PASSIVE
+	hints.ai_protocol = 0
 	hints.ai_addrlen = 0
 	hints.ai_canonname = C.NULL
 	hints.ai_addr = C.NULL
+	hints.ai_next = C.NULL
 	
 
 	info := &C.addrinfo{!}

--- a/vlib/net/socket_test.v
+++ b/vlib/net/socket_test.v
@@ -2,17 +2,14 @@ import net
 
 fn test_socket() {
 	mut server := net.listen(0) or {
-		println(err)
-		return
+		panic(err)
 	}
 	server_port := server.get_port()
 	mut client := net.dial('127.0.0.1', server_port) or {
-		println(err)
-		return
+		panic(err)
 	}
 	mut socket := server.accept() or {
-		println(err)
-		return
+		panic(err)
 	}
 	
 	message := 'Hello World'


### PR DESCRIPTION
* cleanup schannel implementation (drop NT4.0 compatibility, use unicode strings, etc)
* restore http tests
* fix socket test: it did not throw before