### PR TITLE
compiler: streamline main function handling

### DIFF
--- a/compiler/cgen.v
+++ b/compiler/cgen.v
@@ -63,7 +63,7 @@ fn (g mut CGen) genln(s string) {
 	g.cur_line = '$g.cur_line $s'
 	if g.cur_line != '' {
 		if g.line_directives && g.cur_line.trim_space() != '' {
-			g.lines << '#line $g.line "$g.file"'
+			g.lines << '\n#line $g.line "$g.file"'
 		}
 		g.lines << g.cur_line
 		g.prev_line = g.cur_line

--- a/compiler/gen_js.v
+++ b/compiler/gen_js.v
@@ -36,7 +36,7 @@ fn (p mut Parser) gen_fn_decl(f Fn, typ, _str_args string) {
 fn (p mut Parser) gen_blank_identifier_assign() {
 	p.check_name()
 	p.check_space(.assign)
-	typ := p.bool_expression()
+	p.bool_expression()
 	or_else := p.tok == .key_orelse
 	//tmp := p.get_tmp()
 	if or_else {

--- a/compiler/live.v
+++ b/compiler/live.v
@@ -1,9 +1,10 @@
 module main
 
 import os
+import time
 
 fn (v &V) generate_hotcode_reloading_compiler_flags() []string {
-  mut a := []string
+	mut a := []string
 	if v.pref.is_live || v.pref.is_so {
 		// See 'man dlopen', and test running a GUI program compiled with -live
 		if (v.os == .linux || os.user_os() == 'linux'){
@@ -13,11 +14,11 @@ fn (v &V) generate_hotcode_reloading_compiler_flags() []string {
 			a << '-flat_namespace'
 		}
 	}
-  return a
+	return a
 }
 
 fn (v &V) generate_hotcode_reloading_declarations() {
-  mut cgen := v.cgen
+	mut cgen := v.cgen
 	if v.os != .windows && v.os != .msvc {
 		if v.pref.is_so {
 			cgen.genln('pthread_mutex_t live_fn_mutex;')
@@ -35,9 +36,33 @@ fn (v &V) generate_hotcode_reloading_declarations() {
 	}
 }
 
-fn (v &V) generate_hot_reload_code() {
-  mut cgen := v.cgen
+fn (v &V) generate_hotcode_reloading_main_caller() {
+	if !v.pref.is_live { return }
+	// We are in live code reload mode, so start the .so loader in the background
+	mut cgen := v.cgen
+	cgen.genln('')
+	file_base := os.filename(v.dir).replace('.v', '')
+	if !(v.os == .windows || v.os == .msvc) {
+		// unix:
+		so_name := file_base + '.so'
+		cgen.genln('  char *live_library_name = "$so_name";')
+		cgen.genln('  load_so(live_library_name);')
+		cgen.genln('  pthread_t _thread_so;')
+		cgen.genln('  pthread_create(&_thread_so , NULL, &reload_so, live_library_name);')
+	} else {
+		// windows:
+		so_name := file_base + if v.os == .msvc {'.dll'} else {'.so'}
+		cgen.genln('  char *live_library_name = "$so_name";')
+		cgen.genln('  live_fn_mutex = CreateMutexA(0, 0, 0);')
+		cgen.genln('  load_so(live_library_name);')
+		cgen.genln('  unsigned long _thread_so;')
+		cgen.genln('  _thread_so = CreateThread(0, 0, (LPTHREAD_START_ROUTINE)&reload_so, 0, 0, 0);')
+	}
+}
 
+fn (v &V) generate_hot_reload_code() {
+	mut cgen := v.cgen
+	
 	// Hot code reloading
 	if v.pref.is_live {
 		mut file := os.realpath(v.dir)
@@ -46,24 +71,33 @@ fn (v &V) generate_hot_reload_code() {
 		// Need to build .so file before building the live application
 		// The live app needs to load this .so file on initialization.
 		mut vexe := os.args[0]
-
+		
 		if os.user_os() == 'windows' {
 			vexe = vexe.replace('\\', '\\\\')
 			file = file.replace('\\', '\\\\')
 		}
-
+		
 		mut msvc := ''
 		if v.os == .msvc {
 			msvc = '-os msvc'
 		}
-
+		
 		mut debug := ''
-
+		
 		if v.pref.is_debug {
 			debug = '-debug'
 		}
-
-		os.system('$vexe $msvc $debug -o $file_base -shared $file')
+		
+		cmd_compile_shared_library := '$vexe $msvc $debug -o $file_base -shared $file'
+		if v.pref.show_c_cmd {
+			println(cmd_compile_shared_library)
+		}
+		ticks := time.ticks()
+		os.system(cmd_compile_shared_library)
+		diff := time.ticks() - ticks
+		println('compiling shared library took $diff ms')
+		println('=========\n')
+		
 		cgen.genln('
 
 void lfnmutex_print(char *s){

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -458,7 +458,7 @@ string _STR_TMP(const char *fmt, ...) {
 			// Generate `main` which calls every single test function
 			v.gen_main_start()
 			for _, f in v.table.fns {
-				if f.name.starts_with('test_') {
+				if f.name.starts_with('main__test_') {
 					cgen.genln('$f.name();')
 				}
 			}

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -439,33 +439,52 @@ string _STR_TMP(const char *fmt, ...) {
 			// It can be skipped in single file programs
 			if v.pref.is_script {
 				//println('Generating main()...')
-				cgen.genln('int main() { init_consts();')
+				v.gen_main_start()
 				cgen.genln('$cgen.fn_main;')
-				cgen.genln('return 0; }')
+				v.gen_main_end('return 0')
 			}
 			else {
-				println('panic: function `main` is undeclared in the main module')
-				exit(1)
+				verror('function `main` is not declared in the main module')
 			}
 		}
 		else if v.pref.is_test {
 			if v.table.main_exists() {
 				verror('test files cannot have function `main`')
-			}	
+			}
 			// make sure there's at least on test function
 			if !v.table.has_at_least_one_test_fn() {
 				verror('test files need to have at least one test function')
-			}	
+			}
 			// Generate `main` which calls every single test function
-			cgen.genln('int main() { init_consts();')
+			v.gen_main_start()
 			for _, f in v.table.fns {
 				if f.name.starts_with('test_') {
 					cgen.genln('$f.name();')
 				}
 			}
-			cgen.genln('return g_test_ok == 0; }')
+			v.gen_main_end('return g_test_ok == 0')
+		}
+		else if v.table.main_exists() {
+			v.gen_main_start()
+			cgen.genln('  main__main();')
+			v.gen_main_end('return 0')
 		}
 	}
+}
+
+fn (v mut V) gen_main_start(){
+	v.cgen.genln('int main(int argc, char** argv) { ')
+	v.cgen.genln('  init_consts();')
+	if 'os' in v.table.imports {
+		v.cgen.genln('  os__args = os__init_os_args(argc, (byteptr*)argv);')
+	}
+	v.generate_hotcode_reloading_main_caller()
+	v.cgen.genln('')
+}
+fn (v mut V) gen_main_end(return_statement string){
+	v.cgen.genln('')
+	v.cgen.genln('  $return_statement;')
+	v.cgen.genln('}')
 }
 
 fn final_target_out_name(out_name string) string {

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -368,7 +368,7 @@ fn (v mut V) compile() {
 		}
 	}
 	$if js {
-		cgen.genln('main();')
+		cgen.genln('main__main();')
 	}	
 	cgen.save()
 	v.cc()

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -643,6 +643,17 @@ fn (s &Scanner) error_with_col(msg string, col int) {
 	column := col-1
 	linestart := s.find_current_line_start_position()
 	lineend := s.find_current_line_end_position()
+  
+	fullpath := os.realpath( s.file_path )	
+	// The filepath:line:col: format is the default C compiler
+	// error output format. It allows editors and IDE's like
+	// emacs to quickly find the errors in the output
+	// and jump to their source with a keyboard shortcut.
+	// Using only the filename leads to inability of IDE/editors
+	// to find the source file, when it is in another folder.
+	//println('${s.file_path}:${s.line_nr + 1}:${column+1}: $msg')
+	println('${fullpath}:${s.line_nr + 1}:${column+1}: $msg')
+
 	if s.should_print_line_on_error && lineend > linestart {
 		line := s.text.substr( linestart, lineend )
 		// The pointerline should have the same spaces/tabs as the offending
@@ -659,16 +670,7 @@ fn (s &Scanner) error_with_col(msg string, col int) {
 		println(line)
 		println(pointerline)
 	}
-	fullpath := os.realpath( s.file_path )
-	_ = fullpath
-	// The filepath:line:col: format is the default C compiler
-	// error output format. It allows editors and IDE's like
-	// emacs to quickly find the errors in the output
-	// and jump to their source with a keyboard shortcut.
-	// Using only the filename leads to inability of IDE/editors
-	// to find the source file, when it is in another folder.
-	//println('${s.file_path}:${s.line_nr + 1}:${column+1}: $msg')
-	println('${fullpath}:${s.line_nr + 1}:${column+1}: $msg')
+
 	exit(1)
 }
 

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -707,7 +707,7 @@ fn (t &Table) main_exists() bool {
 
 fn (t &Table) has_at_least_one_test_fn() bool {
 	for _, f in t.fns {
-		if f.name.starts_with('test_') {
+		if f.name.starts_with('main__test_') {
 			return true
 		}	
 	}

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -698,7 +698,7 @@ fn (table &Table) is_interface(name string) bool {
 // Do we have fn main()?
 fn (t &Table) main_exists() bool {
 	for _, f in t.fns {
-		if f.name == 'main' {
+		if f.name == 'main__main' {
 			return true
 		}
 	}

--- a/examples/hot_reload/graph.v
+++ b/examples/hot_reload/graph.v
@@ -4,7 +4,8 @@ import gx
 import gg
 import time
 import glfw
-// import math
+import math
+import os
 
 const (
 	Size  = 700
@@ -16,6 +17,7 @@ struct Context {
 }
 
 fn main() {
+	os.clear()
 	glfw.init()
 	ctx:= &Context{ 
 		gg: gg.new_context(gg.Cfg {
@@ -40,11 +42,12 @@ fn main() {
 fn (ctx &Context) draw() {
 	ctx.gg.draw_line(0, Size / 2, Size, Size / 2) // x axis 
 	ctx.gg.draw_line(Size / 2, 0, Size / 2, Size) // y axis 
-	center := f64(Size / 2) 
+	center := f64(Size / 2)
+	mut y := 0.0
 	for x := -10.0; x <= 10.0; x += 0.002 {
-		y := x * x - 1 
-		//y := (x + 3) * (x + 3) - 1
-		//y := math.sqrt(30.0 - x * x)
+		y = x * x - 1 
+		//y = (x + 3) * (x + 3) - 1
+		//y = math.sqrt(30.0 - x * x)
 		ctx.gg.draw_rect(center + x * Scale, center - y * Scale, 1, 1, gx.Black) 
 		//ctx.gg.draw_rect(center + x * Scale, center + y * Scale, 1, 1, gx.Black) 
 	}

--- a/examples/hot_reload/message.v
+++ b/examples/hot_reload/message.v
@@ -2,6 +2,7 @@
 // v -live message.v
 module main
 
+import os
 import time
 
 [live]
@@ -10,6 +11,7 @@ fn print_message() {
 }
 
 fn main() {
+	os.clear()
 	for {
 		print_message()
 		time.sleep_ms(500)


### PR DESCRIPTION
The v main function is now translated as an ordinary v module function.
It is now named main__main in the generated C code.
It is treated like all the other v functions more or less.
This simplifies the generation of the C main() ( and in turn enables moving the -live implementation nearly completely into an ordinary v module on a next stage)