### PR TITLE
compiler: make vgen use strings.Builder & allow parser/scanner creation from string

### DIFF
--- a/compiler/comptime.v
+++ b/compiler/comptime.v
@@ -117,7 +117,7 @@ fn (p mut Parser) comp_time() {
 		// Parse the function and embed resulting C code in current function so that
 		// all variables are available.
 		pos := p.cgen.lines.len - 1
-		mut pp := p.v.new_parser('.vwebtmpl.v')
+		mut pp := p.v.new_parser_file('.vwebtmpl.v')
 		if !p.pref.is_debug {
 			os.rm('.vwebtmpl.v')
 		}
@@ -245,7 +245,7 @@ fn (p mut Parser) gen_array_str(typ Type) {
 		!p.table.type_has_method(elm_type2, 'str') {
 		p.error('cant print ${elm_type}[], unhandled print of ${elm_type}')
 	}
-	p.v.vgen_file.writeln('
+	p.v.vgen_buf.writeln('
 fn (a $typ.name) str() string {
 	mut sb := strings.new_builder(a.len * 3)
 	sb.write("[")
@@ -281,7 +281,7 @@ fn (p mut Parser) gen_struct_str(typ Type) {
 	}
 	sb.writeln("\n}'")
 	sb.writeln('}')
-	p.v.vgen_file.writeln(sb.str())
+	p.v.vgen_buf.writeln(sb.str())
 	// Need to manually add the definition to `fns` so that it stays
 	// at the top of the file.
 	// This function will get parsee by V after the main pass.

--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -178,7 +178,7 @@ fn (p mut Parser) fn_decl() {
 		}
 		// Don't allow modifying types from a different module
 		if !p.first_pass() && !p.builtin_mod && T.mod != p.mod &&
-			!p.fileis(vgen_file_name) { // allow .str() on builtin arrays
+			p.id != 'vgen' { // allow .str() on builtin arrays
 			println('T.mod=$T.mod')
 			println('p.mod=$p.mod')
 			p.error('cannot define new methods on non-local type `$receiver_typ`')

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -74,8 +74,6 @@ mut:
 	vroot      string
 	mod        string  // module being built with -lib
 	parsers    []Parser
-	// vgen_file  os.File
-	// vgen_file  os.File
 	vgen_buf   strings.Builder
 }
 
@@ -337,7 +335,7 @@ fn (v mut V) compile() {
 		}
 	}
 	// parse generated V code (str() methods etc)
-	mut vgen_parser := v.new_parser_string_id(v.vgen_buf.str(),'vgen')
+	mut vgen_parser := v.new_parser_string_id(v.vgen_buf.str(), 'vgen')
 	// free the string builder which held the generated methods
 	v.vgen_buf.free()
 	vgen_parser.parse(.main)

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -337,8 +337,8 @@ fn (v mut V) compile() {
 		}
 	}
 	// parse generated V code (str() methods etc)
-	mut vgen_parser := v.new_parser_string(v.vgen_buf.str())
-	// Close the string builder which held the generated methods
+	mut vgen_parser := v.new_parser_string_id(v.vgen_buf.str(),'vgen')
+	// free the string builder which held the generated methods
 	v.vgen_buf.free()
 	vgen_parser.parse(.main)
 	v.log('Done parsing.')

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -102,12 +102,8 @@ fn (v mut V) new_parser_string(text string) Parser {
 
 // new parser from string. with id specified in `id`
 fn (v mut V) new_parser_string_id(text string, id string) Parser {
-	mut p := v.new_parser(id)
-	p = { p|
-		scanner: new_scanner(text),
-		import_table: v.table.get_file_import_table(id),
-		
-	}
+	mut p := v.new_parser(new_scanner(text), id)
+	p.import_table = v.table.get_file_import_table(id)
 	p.scan_tokens()
 	v.add_parser(p)
 	return p
@@ -126,9 +122,8 @@ fn (v mut V) new_parser_file(path string) Parser {
 		}		
 	}
 
-	mut p := v.new_parser(path)
+	mut p := v.new_parser(new_scanner_file(path), path)
 	p = { p|
-		scanner: new_scanner_file(path),
 		file_path: path,
 		file_name: path.all_after('/'),
 		file_platform: path_platform,
@@ -144,9 +139,10 @@ fn (v mut V) new_parser_file(path string) Parser {
 	return p
 }
 
-fn (v mut V) new_parser(parser_id string) Parser {
+fn (v mut V) new_parser(scanner &Scanner, id string) Parser {
 	mut p := Parser {
-		id: parser_id,
+		id: id
+		scanner: scanner
 		v: v
 		table: v.table
 		cur_fn: EmptyFn

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -21,7 +21,7 @@ struct Tok {
 }
 
 struct Parser {
-	id             string
+	id             string // unique id. if parsing file will be same as file_path
 	file_path      string // "/home/user/hello.v"
 	file_name      string // "hello.v"
 	file_platform  string // ".v", "_win.v", "_nix.v", "_mac.v", "_lin.v" ...
@@ -96,15 +96,15 @@ const (
 )
 
 // new parser from string. parser id will be hash of s
-fn (v mut V) new_parser_string(s string) Parser {
-	return v.new_parser_string_id(s, sha1.hexhash(s))
+fn (v mut V) new_parser_string(text string) Parser {
+	return v.new_parser_string_id(text, sha1.hexhash(text))
 }
 
 // new parser from string. with id specified in `id`
-fn (v mut V) new_parser_string_id(s string, id string) Parser {
+fn (v mut V) new_parser_string_id(text string, id string) Parser {
 	mut p := v.new_parser(id)
 	p = { p|
-		scanner: new_scanner(s),
+		scanner: new_scanner(text),
 		import_table: v.table.get_file_import_table(id),
 		
 	}

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -103,8 +103,14 @@ fn (v mut V) new_parser_string(s string) Parser {
 	parser_id := md5.hexhash(s)
 
 	mut p := v.new_parser(parser_id)
+	path := vgen_file_name
 	p = { p|
-		scanner: new_scanner(s)
+		scanner: new_scanner(s),
+		file_path: path,
+		file_name: path.all_after('/'),
+		file_platform: '.v',
+		import_table: v.table.get_file_import_table(path),
+		
 	}
 	p.scan_tokens()
 	v.add_parser(p)

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -37,7 +37,7 @@ mut:
 	quote byte // which quote is used to denote current string: ' or "
 }
 
-fn new_scanner(file_path string) &Scanner {
+fn new_scanner_file(file_path string) &Scanner {
 	if !os.file_exists(file_path) {
 		verror("$file_path doesn't exist")
 	}
@@ -46,7 +46,7 @@ fn new_scanner(file_path string) &Scanner {
 		verror('scanner: failed to open $file_path')
 		return 0
 	}
-
+		
 	// BOM check
 	if raw_text.len >= 3 {
 		c_text := raw_text.str
@@ -58,9 +58,16 @@ fn new_scanner(file_path string) &Scanner {
 		}
 	}
 
+	mut s := new_scanner(raw_text)
+	s.file_path = file_path
+
+	return s
+}
+
+fn new_scanner(s string) &Scanner {
 	return &Scanner {
-		file_path: file_path
-		text: raw_text
+		// file_path: file_path
+		text: s
 		fmt_out: strings.new_builder(1000)
 		should_print_line_on_error: true
 	}

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -37,6 +37,7 @@ mut:
 	quote byte // which quote is used to denote current string: ' or "
 }
 
+// new scanner from file.
 fn new_scanner_file(file_path string) &Scanner {
 	if !os.file_exists(file_path) {
 		verror("$file_path doesn't exist")
@@ -64,6 +65,7 @@ fn new_scanner_file(file_path string) &Scanner {
 	return s
 }
 
+// new scanner from string.
 fn new_scanner(s string) &Scanner {
 	return &Scanner {
 		// file_path: file_path
@@ -72,7 +74,6 @@ fn new_scanner(s string) &Scanner {
 		should_print_line_on_error: true
 	}
 }
-
 
 struct ScannerPos {
 mut:
@@ -689,10 +690,10 @@ fn (s &Scanner) error_with_col(msg string, col int) {
 fn (s Scanner) count_symbol_before(p int, sym byte) int {
   mut count := 0
   for i:=p; i>=0; i-- {
-    if s.text[i] != sym {
-      break
-    }
-    count++
+	if s.text[i] != sym {
+	  break
+	}
+	count++
   }
   return count
 }
@@ -870,5 +871,3 @@ fn good_type_name(s string) bool {
 	}
 	return true
 }
-
-

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -66,10 +66,9 @@ fn new_scanner_file(file_path string) &Scanner {
 }
 
 // new scanner from string.
-fn new_scanner(s string) &Scanner {
+fn new_scanner(text string) &Scanner {
 	return &Scanner {
-		// file_path: file_path
-		text: s
+		text: text
 		fmt_out: strings.new_builder(1000)
 		should_print_line_on_error: true
 	}

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -855,14 +855,14 @@ fn (table &Table) qualify_module(mod string, file_path string) string {
 	return mod
 }
 
-fn (table &Table) get_file_import_table(file_path string) FileImportTable {
+fn (table &Table) get_file_import_table(id string) FileImportTable {
 	// if file_path.clone() in table.file_imports {
 	// 	return table.file_imports[file_path.clone()]
 	// }
 	// just get imports. memory error when recycling import table
-	mut fit := new_file_import_table(file_path)
-	if file_path in table.file_imports {
-		fit.imports = table.file_imports[file_path].imports
+	mut fit := new_file_import_table(id)
+	if id in table.file_imports {
+		fit.imports = table.file_imports[id].imports
 	}
 	return fit
 }


### PR DESCRIPTION
compiler: make vgen use strings.Builder & allow parser/scanner creation from string

This pr gets rid of the vgen tmp file. It is now uses strings.Builder instead.
It also adds support for creating a parser/scanner from string.