### PR TITLE
vlib/math: add robust_equal

### DIFF
--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -24,6 +24,7 @@ const (
 	Log2E  = 1.0 / Ln2
 	Ln10   = 2.30258509299404568401799145468436420760110148862877297603332790
 	Log10E = 1.0 / Ln10
+	F64Epsilon = 2.2204460492503131e-16
 )
 
 const (
@@ -313,4 +314,9 @@ pub fn tanh(a f64) f64 {
 // larger in magnitude than a.
 pub fn trunc(a f64) f64 {
 	return C.trunc(a)
+}
+
+// equality considering machine epsilon.
+pub fn robust_equal(a, b f64) bool {
+	return abs(a - b) <= F64Epsilon * max(abs(a), abs(b))
 }

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -51,4 +51,5 @@ fn test_gamma() {
 
 fn test_robust_equal() {
 	assert math.robust_equal(1.0000000000000000, 0.9999999999999999)
+	assert !math.robust_equal(1.0000, 0.9999)
 }

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -46,5 +46,9 @@ fn test_erf() {
 fn test_gamma() {
 	assert math.gamma(1) == 1
 	assert math.gamma(5) == 24
-	assert math.log_gamma(4.5) == math.log(math.gamma(4.5))
+	assert math.robust_equal(math.log_gamma(4.5), math.log(math.gamma(4.5)))
+}
+
+fn test_robust_equal() {
+	assert math.robust_equal(1.0000000000000000, 0.9999999999999999)
 }


### PR DESCRIPTION
This PR adds `robust_equal(a, b f64) bool` to math module.
This function evaluates equality considering *machine epsilon*.
The number `2.2204460492503131e-16` is based on Python `sys.float_info.epsilon`

In mathematical contexts, evaluating the equality of two floating-point numbers `d1` and `d2` using `d1 == d2` usually gives rise to problems.
Without this PR, `test_gamma()` in math_test.v causes an error on Android.
Furthermore, the following source code shows "0" at least in my OS X laptop environment, which is rather a C problem than a V problem.
```
mut a := f64(1)
b := f64(1)
a += 0.001
a -= 0.001

print(a == b)
// => 0
```