### PR TITLE
f64: fix f64.eq(); math: fix test

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -27,8 +27,7 @@ pub fn ptr_str(ptr voidptr) string {
 
 // compare floats using C epsilon
 pub fn (a f64) eq(b f64) bool {
-	//return C.fabs(a - b) <= C.DBL_EPSILON	
-	return (a - b) <= C.DBL_EPSILON	
+	return C.fabs(a - b) <= C.DBL_EPSILON	
 }
 
 // fn (nn i32) str() string {

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -46,5 +46,5 @@ fn test_erf() {
 fn test_gamma() {
 	assert math.gamma(1) == 1
 	assert math.gamma(5) == 24
-	assert math.log_gamma(4.5) == math.log(math.gamma(4.5))
+	assert math.log_gamma(4.5).eq(math.log(math.gamma(4.5)))
 }


### PR DESCRIPTION
This PR fixes `f64.eq()` and `gamma_test()` in math_test.v
Before this PR, `f64(1).eq(f64(2))` evaluates 1.
Without this fix, math_test.v causes an error on Android.