### PR TITLE
compiler: clean up. remove new_parser_string_id

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -335,7 +335,7 @@ fn (v mut V) compile() {
 		}
 	}
 	// parse generated V code (str() methods etc)
-	mut vgen_parser := v.new_parser_string_id(v.vgen_buf.str(), 'vgen')
+	mut vgen_parser := v.new_parser_string(v.vgen_buf.str(), 'vgen')
 	// free the string builder which held the generated methods
 	v.vgen_buf.free()
 	vgen_parser.parse(.main)

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -95,7 +95,7 @@ const (
 )
 
 // new parser from string. unique id specified in `id`.
-// tip: use a hashing function to `auto` generate id from `text` eg. sha1.hexhash(text)
+// tip: use a hashing function to auto generate `id` from `text` eg. sha1.hexhash(text)
 fn (v mut V) new_parser_string(text string, id string) Parser {
 	mut p := v.new_parser(new_scanner(text), id)
 	p.scan_tokens()

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -132,8 +132,8 @@ fn (v mut V) new_parser_file(path string) Parser {
 	return p
 }
 
-// creates a new parser. .mos likely you will want to use
-// `new_parser_file` or
+// creates a new parser. most likely you will want to use
+// `new_parser_file` or `new_parser_string` instead.
 fn (v mut V) new_parser(scanner &Scanner, id string) Parser {
 	mut p := Parser {
 		id: id


### PR DESCRIPTION
clean up a few things.

Leave the id generation up to the implementation.
added a tip comment to use a hash