### PR TITLE
fix str_index

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -2556,8 +2556,13 @@ fn (p mut Parser) factor() string {
 		typ = 'byte'
 		return typ
 	case Token.str:
+		ph := p.cgen.add_placeholder()
 		p.string_expr()
 		typ = 'string'
+		if p.tok == .lsbr {
+			typ = 'byte'
+			p.index_expr('string', ph)
+		}
 		return typ
 	case Token.key_false:
 		typ = 'bool'

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1021,5 +1021,6 @@ pub fn (s string) repeat(count int) string {
 			ret[i*s.len + j] = s[j]
 		}
 	}
+	ret[s.len * count] = `\0`
 	return string(ret)
 }


### PR DESCRIPTION
```go
fn main() {
    s := 'abc'
    c := 'abc'[1]
    println(s[1])
    println(c)
    println('abc'[1])
}
```