### PR TITLE
string: Properly null-terminate repeated string

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1021,5 +1021,6 @@ pub fn (s string) repeat(count int) string {
 			ret[i*s.len + j] = s[j]
 		}
 	}
+	ret[s.len * count] = 0
 	return string(ret)
 }


### PR DESCRIPTION
This allows C.strlen() to behave properly in `tos2()` as the string could leak memory if it is not properly null-terminated. It is also the cause of the MSVC build failing.

Edit: I didn't notice the existence of #2143 when this PR was created. Please close this if it's no longer needed.