### PR TITLE
compiler: more precise 'declared and not used' error positioning.

### DIFF
--- a/compiler/compile_errors.v
+++ b/compiler/compile_errors.v
@@ -1,0 +1,244 @@
+module main
+
+import (
+	os
+	term
+)
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// NB: The code in this file is organized in layers (between the ///// lines).
+// This allows for easier keeping in sync of error/warn functions.
+// The functions in each of the layers, call the functions from the layers *below*.
+// The functions in each of the layers, also have more details about the warn/error situation,
+// so they can display more informative message, so please call the lowest level variant you can.
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// TLDR: If you have a token, call:
+//     p.error_with_token(msg, token)
+// ... not just :
+//     p.error(msg)
+//////////////////////////////////////////////////////////////////////////////////////////////////
+
+fn (p mut Parser) error(s string) {
+	// no positioning info, so just assume that the last token was the culprit:
+	p.error_with_token(s, p.tokens[p.token_idx-1] )
+}
+
+fn (p mut Parser) warn(s string) {
+	p.warn_with_token(s, p.tokens[p.token_idx-1] )
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+
+fn (p mut Parser) production_error_with_token(e string, tok Tok) {
+	if p.pref.is_prod {
+		p.error_with_token( e, tok )
+	}else {
+		p.warn_with_token( e, tok )
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+
+fn (p mut Parser) error_with_token(s string, tok Tok) {
+	p.error_with_position(s, p.scanner.get_scanner_pos_of_token(tok) )
+}
+
+fn (p mut Parser) warn_with_token(s string, tok Tok) {
+	p.warn_with_position(s, p.scanner.get_scanner_pos_of_token(tok) )
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+
+fn (p mut Parser) error_with_position(s string, sp ScannerPos) {
+	p.print_error_context()
+	e := normalized_error( s )
+	p.scanner.goto_scanner_position( sp )
+	p.scanner.error_with_col(e, sp.pos - sp.last_nl_pos)
+}
+
+fn (p mut Parser) warn_with_position(s string, sp ScannerPos) {
+	// on a warning, restore the scanner state after printing the warning:
+	cpos := p.scanner.get_scanner_pos()
+	e := normalized_error( s )
+	p.scanner.goto_scanner_position( sp )
+	p.scanner.warn_with_col(e, sp.pos - sp.last_nl_pos)
+	p.scanner.goto_scanner_position( cpos )
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+
+fn (s &Scanner) error(msg string) {
+	s.error_with_col(msg, 0)
+}
+
+fn (s &Scanner) warn(msg string) {
+	s.warn_with_col(msg, 0)
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+
+fn (s &Scanner) warn_with_col(msg string, col int) {
+	fullpath := os.realpath( s.file_path )
+	color_on := s.is_color_output_on()
+	final_message := if color_on { term.bold(term.bright_blue( msg )) } else { msg }
+	eprintln('warning: ${fullpath}:${s.line_nr+1}:${col}: $final_message')
+}
+
+fn (s &Scanner) error_with_col(msg string, col int) {
+	fullpath := os.realpath( s.file_path )
+	color_on := s.is_color_output_on()
+	final_message := if color_on { term.red( term.bold( msg ) ) } else { msg }
+	// The filepath:line:col: format is the default C compiler
+	// error output format. It allows editors and IDE's like
+	// emacs to quickly find the errors in the output
+	// and jump to their source with a keyboard shortcut.
+	// Using only the filename leads to inability of IDE/editors
+	// to find the source file, when it is in another folder.
+	eprintln('error: ${fullpath}:${s.line_nr + 1}:${col}: $final_message')
+	
+	if s.should_print_line_on_error && s.file_lines.len > 0 {
+		context_start_line := imax(0,                (s.line_nr - error_context_before + 1 ))
+		context_end_line   := imin(s.file_lines.len, (s.line_nr + error_context_after + 1 ))
+		for cline := context_start_line; cline < context_end_line; cline++ {
+			line := '${(cline+1):5d}| ' + s.file_lines[ cline ]
+			coloredline := if cline == s.line_nr && color_on { term.red(line) } else { line }
+			eprintln( coloredline )
+			if cline != s.line_nr { continue }
+			// The pointerline should have the same spaces/tabs as the offending
+			// line, so that it prints the ^ character exactly on the *same spot*
+			// where it is needed. That is the reason we can not just
+			// use strings.repeat(` `, col) to form it.
+			mut pointerline := []string		
+			for i , c in line {
+				if i < col {
+					x := if c.is_space() { c } else { ` ` }
+					pointerline << x.str()
+					continue
+				}
+				pointerline << if color_on { term.bold( term.blue('^') ) } else { '^' }
+				break
+			}
+			eprintln( '      ' + pointerline.join('') )
+		}
+	}
+	exit(1)
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Misc error helper functions, can be called by any of the functions above
+
+fn imax(a,b int) int { 	return if a > b { a } else { b } }
+fn imin(a,b int) int { 	return if a < b { a } else { b } }
+
+fn (s &Scanner) is_color_output_on() bool {
+	return s.should_print_errors_in_color && term.can_show_color_on_stderr()	
+}
+
+fn (p mut Parser) print_error_context(){
+	// Dump all vars and types for debugging
+	if p.pref.is_debug {
+		// os.write_to_file('/var/tmp/lang.types', '')//pes(p.table.types))
+		os.write_file('fns.txt', p.table.debug_fns())
+	}
+	if p.pref.is_verbose || p.pref.is_debug {
+		println('pass=$p.pass fn=`$p.cur_fn.name`\n')
+	}
+	p.cgen.save()
+	// V up hint
+	cur_path := os.getwd()
+	if !p.pref.is_repl && !p.pref.is_test && ( p.file_path.contains('v/compiler') || cur_path.contains('v/compiler') ){
+		println('\n=========================')
+		println('It looks like you are building V. It is being frequently updated every day.')
+		println('If you didn\'t modify V\'s code, most likely there was a change that ')
+		println('lead to this error.')
+		println('\nRun `v up`, that will most likely fix it.')
+		//println('\nIf this doesn\'t help, re-install V from source or download a precompiled' + ' binary from\nhttps://vlang.io.')
+		println('\nIf this doesn\'t help, please create a GitHub issue.')
+		println('=========================\n')
+	}
+	if p.pref.is_debug {
+		print_backtrace()
+	}
+	// p.scanner.debug_tokens()
+}
+
+fn normalized_error( s string ) string {
+	// Print `[]int` instead of `array_int` in errors
+	return s.replace('array_', '[]')
+	.replace('__', '.')
+	.replace('Option_', '?')
+	.replace('main.', '')
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+
+// The goal of ScannerPos is to track the current scanning position,
+// so that if there is an error found later, v could show a more accurate
+// position about where the error initially was.
+// NB: The fields of ScannerPos *should be kept synchronized* with the
+// corresponding fields in Scanner.
+
+struct ScannerPos {
+mut:
+   pos int
+   line_nr int
+   last_nl_pos int
+}
+
+fn (s ScannerPos) str() string {
+	return 'ScannerPos{ ${s.pos:5d} , ${s.line_nr:5d} , ${s.last_nl_pos:5d} }'
+}
+
+fn (s &Scanner) get_scanner_pos() ScannerPos {
+	return ScannerPos{ pos: s.pos line_nr: s.line_nr last_nl_pos: s.last_nl_pos }
+}
+
+fn (s mut Scanner) goto_scanner_position(scp ScannerPos) {
+	s.pos = scp.pos
+	s.line_nr = scp.line_nr
+	s.last_nl_pos = scp.last_nl_pos
+}
+
+// get_scanner_pos_of_token rescans *the whole source* till it reaches {t.line_nr, t.col} .
+fn (s mut Scanner) get_scanner_pos_of_token(t Tok) ScannerPos {
+	// This rescanning is done just once on error, so it is fine for now.
+	// Be careful for the performance implications, if you want to
+	// do it more frequently. The alternative would be to store
+	// the scanpos (12 bytes) for each token, and there are potentially many tokens.
+	tline := t.line_nr
+	tcol  := if t.line_nr == 0 { t.col + 1 } else { t.col - 1 }
+	// save the current scanner position, it will be restored later
+	cpos := s.get_scanner_pos()
+	mut sptoken := ScannerPos{}
+	// Starting from the start, scan the source lines
+	// till the desired tline is reached, then
+	// s.pos + tcol would be the proper position
+	// of the token. Continue scanning for some more lines of context too.
+	s.goto_scanner_position(ScannerPos{})
+	s.file_lines = []string
+	mut prevlinepos := 0
+	for {
+		prevlinepos = s.pos
+		if s.pos >= s.text.len { break }		
+		if s.line_nr > tline + 10 { break }
+		////////////////////////////////////////
+		if tline == s.line_nr {
+			sptoken = s.get_scanner_pos()
+			sptoken.pos += tcol
+		}
+		s.ignore_line() s.eat_single_newline()
+		sline := s.text.substr( prevlinepos, s.pos ).trim_right('\r\n')
+		s.file_lines << sline
+	}
+	//////////////////////////////////////////////////
+	s.goto_scanner_position(cpos)
+	return sptoken
+}
+
+fn (s mut Scanner) eat_single_newline(){
+	if s.pos >= s.text.len { return }
+	if s.expect('\r\n', s.pos) { s.pos += 2 return }
+	if s.text[ s.pos ] == `\n` { s.pos ++ return }
+	if s.text[ s.pos ] == `\r` { s.pos ++ return }
+}

--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -33,7 +33,7 @@ mut:
 	is_decl       bool // type myfn fn(int, int)
 	defer_text    []string
 	//gen_types []string
-	fn_name_token Tok
+	fn_name_token_idx int // used by error reporting
 }
 
 fn (p &Parser) find_var(name string) ?Var {
@@ -110,8 +110,8 @@ fn (p mut Parser) known_var(name string) bool {
 fn (p mut Parser) register_var(v Var) {
 	mut new_var := {v | idx: p.var_idx, scope_level: p.cur_fn.scope_level}
 	if v.line_nr == 0 {
-		new_var.token = p.cur_tok()
-		new_var.line_nr = new_var.token.line_nr
+		new_var.token_idx = p.cur_tok_index()
+		new_var.line_nr = p.cur_tok().line_nr
 	}
 	// Expand the array
 	if p.var_idx >= p.local_vars.len {
@@ -213,7 +213,7 @@ fn (p mut Parser) fn_decl() {
 			ref: is_amp
 			ptr: is_mut
 			line_nr: p.scanner.line_nr
-			token: p.cur_tok()
+			token_idx: p.cur_tok_index()
 		}
 		f.args << receiver
 		p.register_var(receiver)
@@ -226,7 +226,7 @@ fn (p mut Parser) fn_decl() {
 	else {
 		f.name = p.check_name()
 	}
-	f.fn_name_token = p.cur_tok()
+	f.fn_name_token_idx = p.cur_tok_index()
 	// C function header def? (fn C.NSMakeRect(int,int,int,int))
 	is_c := f.name == 'C' && p.tok == .dot
 	// Just fn signature? only builtin.v + default build mode
@@ -334,7 +334,7 @@ fn (p mut Parser) fn_decl() {
 	// Special case for main() args
 	if f.name == 'main__main' && !has_receiver {
 		if str_args != '' || typ != 'void' {
-			p.error_with_token('fn main must have no arguments and no return values', f.fn_name_token)
+			p.error_with_token_index('fn main must have no arguments and no return values', f.fn_name_token_idx)
 		}
 	}
 	dll_export_linkage := if p.os == .msvc && p.attr == 'live' && p.pref.is_so {
@@ -439,7 +439,7 @@ fn (p mut Parser) fn_decl() {
 
 	if f.name == 'main__main' || f.name == 'main' || f.name == 'WinMain' {
 		if p.pref.is_test && !p.scanner.file_path.contains('/volt') {
-			p.error_with_token('tests cannot have function `main`', f.fn_name_token)
+			p.error_with_token_index('tests cannot have function `main`', f.fn_name_token_idx)
 		}
 	}
 	// println('is_c=$is_c name=$f.name')
@@ -472,7 +472,7 @@ fn (p mut Parser) fn_decl() {
 		}
 	}
 	if typ != 'void' && !p.returns {
-		p.error_with_token('$f.name must return "$typ"', f.fn_name_token)
+		p.error_with_token_index('$f.name must return "$typ"', f.fn_name_token_idx)
 	}
 	if p.attr == 'live' && p.pref.is_so {
 		//p.genln('// live_function body end')
@@ -535,10 +535,10 @@ fn (p mut Parser) check_unused_variables() {
 			break
 		}
 		if !var.is_used && !p.pref.is_repl && !var.is_arg && !p.pref.translated {
-			p.production_error_with_token('`$var.name` declared and not used', var.token )
+			p.production_error_with_token_index('`$var.name` declared and not used', var.token_idx )
 		}
 		if !var.is_changed && var.is_mut && !p.pref.is_repl && !p.pref.translated {
-			p.error_with_token( '`$var.name` is declared as mutable, but it was never changed', var.token )
+			p.error_with_token_index( '`$var.name` is declared as mutable, but it was never changed', var.token_idx )
 		}
 	}
 }
@@ -698,7 +698,7 @@ fn (p mut Parser) fn_args(f mut Fn) {
 	if f.is_interface {
 		int_arg := Var {
 			typ: f.receiver_typ
-			token: p.cur_tok()
+			token_idx: p.cur_tok_index()
 		}
 		f.args << int_arg
 	}
@@ -714,7 +714,7 @@ fn (p mut Parser) fn_args(f mut Fn) {
 				is_arg: true
 				// is_mut: is_mut
 				line_nr: p.scanner.line_nr
-				token: p.cur_tok()
+				token_idx: p.cur_tok_index()
 			}
 			// f.register_var(v)
 			f.args << v
@@ -757,7 +757,7 @@ fn (p mut Parser) fn_args(f mut Fn) {
 				is_mut: is_mut
 				ptr: is_mut
 				line_nr: p.scanner.line_nr
-				token: p.cur_tok()
+				token_idx: p.cur_tok_index()
 			}
 			p.register_var(v)
 			f.args << v

--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -334,7 +334,7 @@ fn (p mut Parser) fn_decl() {
 	// Special case for main() args
 	if f.name == 'main__main' && !has_receiver {
 		if str_args != '' || typ != 'void' {
-			p.error_with_tok('fn main must have no arguments and no return values', f.fn_name_token)
+			p.error_with_token('fn main must have no arguments and no return values', f.fn_name_token)
 		}
 	}
 	dll_export_linkage := if p.os == .msvc && p.attr == 'live' && p.pref.is_so {
@@ -439,7 +439,7 @@ fn (p mut Parser) fn_decl() {
 
 	if f.name == 'main__main' || f.name == 'main' || f.name == 'WinMain' {
 		if p.pref.is_test && !p.scanner.file_path.contains('/volt') {
-			p.error_with_tok('tests cannot have function `main`', f.fn_name_token)
+			p.error_with_token('tests cannot have function `main`', f.fn_name_token)
 		}
 	}
 	// println('is_c=$is_c name=$f.name')
@@ -472,7 +472,7 @@ fn (p mut Parser) fn_decl() {
 		}
 	}
 	if typ != 'void' && !p.returns {
-		p.error_with_tok('$f.name must return "$typ"', f.fn_name_token)
+		p.error_with_token('$f.name must return "$typ"', f.fn_name_token)
 	}
 	if p.attr == 'live' && p.pref.is_so {
 		//p.genln('// live_function body end')
@@ -538,7 +538,7 @@ fn (p mut Parser) check_unused_variables() {
 			p.production_error_with_token('`$var.name` declared and not used', var.token )
 		}
 		if !var.is_changed && var.is_mut && !p.pref.is_repl && !p.pref.translated {
-			p.error_with_tok( '`$var.name` is declared as mutable, but it was never changed', var.token )
+			p.error_with_token( '`$var.name` is declared as mutable, but it was never changed', var.token )
 		}
 	}
 }

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1486,10 +1486,14 @@ fn (p mut Parser) var_decl() {
 	}
 	
 	mut names := []string
+	mut vtokens := []Tok
+	
+	vtokens << p.cur_tok()
 	names << p.check_name()
 	p.scanner.validate_var_name(names[0])
 	for p.tok == .comma {
 		p.check(.comma)
+		vtokens << p.cur_tok()
 		names << p.check_name()
 	}
 	mr_var_name := if names.len > 1 { '__ret_'+names.join('_') } else { names[0] }
@@ -1504,6 +1508,7 @@ fn (p mut Parser) var_decl() {
 		types = t.replace('_V_MulRet_', '').replace('_PTR_', '*').split('_V_')
 	}
 	for i, name in names {
+		var_token := vtokens[i]
 		if name == '_' {
 			if names.len == 1 {
 				p.error('no new variables on left side of `:=`')
@@ -1512,7 +1517,6 @@ fn (p mut Parser) var_decl() {
 		}
 		typ := types[i]
 		// println('var decl tok=${p.strtok()} ismut=$is_mut')
-		var_token := p.cur_tok()
 		// name := p.check_name()
 		// p.var_decl_name = name
 		// Don't allow declaring a variable with the same name. Even in a child scope

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -7,7 +7,6 @@ module main
 import (
 	os
 	strings
-	term
 )
 
 const (
@@ -78,72 +77,6 @@ fn new_scanner(text string) &Scanner {
 		should_print_line_on_error: true
 		should_print_errors_in_color: true
 	}
-}
-
-
-// The goal of ScannerPos is to track the current scanning position,
-// so that if there is an error found later, v could show a more accurate
-// position about where the error initially was.
-// NB: The fields of ScannerPos *should be kept synchronized* with the
-// corresponding fields in Scanner.
-struct ScannerPos {
-mut:
-   pos int
-   line_nr int
-   last_nl_pos int
-}
-fn (s ScannerPos) str() string {
-	return 'ScannerPos{ ${s.pos:5d} , ${s.line_nr:5d} , ${s.last_nl_pos:5d} }'
-}
-fn (s &Scanner) get_scanner_pos() ScannerPos {
-	return ScannerPos{ pos: s.pos line_nr: s.line_nr last_nl_pos: s.last_nl_pos }
-}
-fn (s mut Scanner) goto_scanner_position(scp ScannerPos) {
-	s.pos = scp.pos
-	s.line_nr = scp.line_nr
-	s.last_nl_pos = scp.last_nl_pos
-}
-
-// get_scanner_pos_of_token rescans *the whole source* till it reaches {t.line_nr, t.col} .
-fn (s mut Scanner) get_scanner_pos_of_token(t Tok) ScannerPos {
-	// This rescanning is done just once on error, so it is fine for now.
-	// Be careful for the performance implications, if you want to
-	// do it more frequently. The alternative would be to store
-	// the scanpos (12 bytes) for each token, and there are potentially many tokens.
-	tline := t.line_nr
-	tcol  := if t.line_nr == 0 { t.col + 1 } else { t.col - 1 }
-	// save the current scanner position, it will be restored later
-	cpos := s.get_scanner_pos()
-	mut sptoken := ScannerPos{}
-	// Starting from the start, scan the source lines
-	// till the desired tline is reached, then
-	// s.pos + tcol would be the proper position
-	// of the token. Continue scanning for some more lines of context too.
-	s.goto_scanner_position(ScannerPos{})
-	s.file_lines = []string
-	mut prevlinepos := 0
-	for {
-		prevlinepos = s.pos
-		if s.pos >= s.text.len { break }		
-		if s.line_nr > tline + 10 { break }
-		////////////////////////////////////////
-		if tline == s.line_nr {
-			sptoken = s.get_scanner_pos()
-			sptoken.pos += tcol
-		}
-		s.ignore_line() s.eat_single_newline()
-		sline := s.text.substr( prevlinepos, s.pos ).trim_right('\r\n')
-		s.file_lines << sline
-	}
-	//////////////////////////////////////////////////
-	s.goto_scanner_position(cpos)
-	return sptoken
-}
-fn (s mut Scanner) eat_single_newline(){
-	if s.pos >= s.text.len { return }
-	if s.expect('\r\n', s.pos) { s.pos += 2 return }
-	if s.text[ s.pos ] == `\n` { s.pos ++ return }
-	if s.text[ s.pos ] == `\r` { s.pos ++ return }
 }
 
 
@@ -650,52 +583,6 @@ fn (s mut Scanner) scan() ScanRes {
 
 fn (s &Scanner) current_column() int {
 	return s.pos - s.last_nl_pos
-}
-
-fn imax(a,b int) int { 	return if a > b { a } else { b } }
-fn imin(a,b int) int { 	return if a < b { a } else { b } }
-fn (s &Scanner) error(msg string) {
-	s.error_with_col(msg, 0)
-}
-
-fn (s &Scanner) error_with_col(msg string, col int) {
-	fullpath := os.realpath( s.file_path )
-	color_on := s.should_print_errors_in_color && term.can_show_color()
-	final_message := if color_on { term.red( term.bold( msg ) ) } else { msg }
-	// The filepath:line:col: format is the default C compiler
-	// error output format. It allows editors and IDE's like
-	// emacs to quickly find the errors in the output
-	// and jump to their source with a keyboard shortcut.
-	// Using only the filename leads to inability of IDE/editors
-	// to find the source file, when it is in another folder.
-	eprintln('${fullpath}:${s.line_nr + 1}:${col}: $final_message')
-	
-	if s.should_print_line_on_error && s.file_lines.len > 0 {
-		context_start_line := imax(0,                (s.line_nr - error_context_before + 1 ))
-		context_end_line   := imin(s.file_lines.len, (s.line_nr + error_context_after + 1 ))
-		for cline := context_start_line; cline < context_end_line; cline++ {
-			line := '${(cline+1):5d}| ' + s.file_lines[ cline ]
-			coloredline := if cline == s.line_nr && color_on { term.red(line) } else { line }
-			println( coloredline )
-			if cline != s.line_nr { continue }
-			// The pointerline should have the same spaces/tabs as the offending
-			// line, so that it prints the ^ character exactly on the *same spot*
-			// where it is needed. That is the reason we can not just
-			// use strings.repeat(` `, col) to form it.
-			mut pointerline := []string		
-			for i , c in line {
-				if i < col {
-					x := if c.is_space() { c } else { ` ` }
-					pointerline << x.str()
-					continue
-				}
-				pointerline << if color_on { term.bold( term.blue('^') ) } else { '^' }
-				break
-			}
-			println( '      ' + pointerline.join('') )
-		}
-	}
-	exit(1)
 }
 
 fn (s Scanner) count_symbol_before(p int, sym byte) int {

--- a/compiler/table.v
+++ b/compiler/table.v
@@ -97,7 +97,7 @@ mut:
 	is_c            bool // todo remove once `typ` is `Type`, not string
 	is_moved        bool
 	line_nr         int
-	token           Tok // TODO: use only var.token.line_nr, remove var.line_nr
+	token_idx       int // this is a token index, which will be used by error reporting
 }
 
 struct Type {

--- a/tools/performance_compare.v
+++ b/tools/performance_compare.v
@@ -94,6 +94,7 @@ fn (c &Context) prepare_v( cdir string, commit string ) {
 	show_sizes_of_files(["$cdir/v",     "$cdir/v_stripped",      "$cdir/v_stripped_upxed"])
 	show_sizes_of_files(["$cdir/vprod", "$cdir/vprod_stripped",  "$cdir/vprod_stripped_upxed"])
 	println("V version is: " + run("$cdir/v --version") + " , local source commit: " + run("git rev-parse --short  --verify HEAD") )
+	println('Source lines in compiler/ ' + run('wc compiler/*.v | tail -n -1') )
 }
 
 
@@ -119,7 +120,7 @@ fn validate_commit_exists( commit string ){
 }
 
 fn main(){
-	used_tools_must_exist(['cp','rm','strip','make','git','upx','cc','hyperfine'])
+	used_tools_must_exist(['cp','rm','strip','make','git','upx','cc','wc','tail','hyperfine'])
 	mut context := new_context()  
 	mut fp := flag.new_flag_parser(os.args)
 	fp.application(os.filename(os.executable()))

--- a/vlib/term/can_show_color.v
+++ b/vlib/term/can_show_color.v
@@ -1,0 +1,9 @@
+module term
+
+pub fn can_show_color_on_stdout() bool {
+	return can_show_color_on_fd(int(C.STDOUT_FILENO))
+}
+
+pub fn can_show_color_on_stderr() bool {
+	return can_show_color_on_fd(int(C.STDERR_FILENO))
+}

--- a/vlib/term/can_show_color.v
+++ b/vlib/term/can_show_color.v
@@ -1,9 +1,9 @@
 module term
 
 pub fn can_show_color_on_stdout() bool {
-	return can_show_color_on_fd(int(C.STDOUT_FILENO))
+	return can_show_color_on_fd(1)
 }
 
 pub fn can_show_color_on_stderr() bool {
-	return can_show_color_on_fd(int(C.STDERR_FILENO))
+	return can_show_color_on_fd(2)
 }

--- a/vlib/term/can_show_color_nix.v
+++ b/vlib/term/can_show_color_nix.v
@@ -4,8 +4,8 @@ import os
 
 fn C.isatty(int) int
 
-pub fn can_show_color() bool {
+pub fn can_show_color_on_fd(fd int) bool {
 	if os.getenv('TERM') == 'dumb' { return false }
-	if C.isatty(1) != 0 { return true }
+	if C.isatty(fd) != 0 { return true }
 	return false
 }

--- a/vlib/term/can_show_color_win.v
+++ b/vlib/term/can_show_color_win.v
@@ -4,7 +4,7 @@ import os
 
 // TODO: implement proper checking on windows too.
 // For now, just return false by default
-pub fn can_show_color() bool {
+pub fn can_show_color_on_fd(fd int) bool {
 	if os.getenv('TERM') == 'dumb' { return false }
 	return false
 }


### PR DESCRIPTION
This PR fixes the positioning for `declared and not used` errors/warnings.
Before this, when the declaration line was followed by a comment, the error pointed to the line after the comment.
Now:
![fixed error positioning](https://url4e.com/gyazo/images/1d825b75.png)
