### PR TITLE
parser: float1 == float2 considers machine epsilon by default

### DIFF
--- a/compiler/cheaders.v
+++ b/compiler/cheaders.v
@@ -122,7 +122,6 @@ typedef map map_string;
 #define _PUSH_MANY(arr, val, tmp, tmp_typ) {tmp_typ tmp = (val); array__push_many(arr, tmp.data, tmp.len);}
 #define _IN(typ, val, arr) array_##typ##_contains(arr, val)
 #define _IN_MAP(val, m) map__exists(m, val)
-#define DEFAULT_EQUAL(a, b) (a == b)
 //================================== GLOBALS =================================*/
 byteptr g_str_buf;
 int load_so(byteptr);

--- a/compiler/cheaders.v
+++ b/compiler/cheaders.v
@@ -122,6 +122,7 @@ typedef map map_string;
 #define _PUSH_MANY(arr, val, tmp, tmp_typ) {tmp_typ tmp = (val); array__push_many(arr, tmp.data, tmp.len);}
 #define _IN(typ, val, arr) array_##typ##_contains(arr, val)
 #define _IN_MAP(val, m) map__exists(m, val)
+#define DEFAULT_EQUAL(a, b) (a == b)
 //================================== GLOBALS =================================*/
 byteptr g_str_buf;
 int load_so(byteptr);

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1597,11 +1597,12 @@ fn (p mut Parser) bterm() string {
 	p.expected_type = typ
 	is_str := typ=='string'  &&   !p.is_sql
 	is_ustr := typ=='ustring'
+	is_f64 := typ=='f64'
 	tok := p.tok
 	// if tok in [ .eq, .gt, .lt, .le, .ge, .ne] {
 	if tok == .eq || tok == .gt || tok == .lt || tok == .le || tok == .ge || tok == .ne {
 		p.fgen(' ${p.tok.str()} ')
-		if (is_str || is_ustr) && !p.is_js {
+		if ((is_f64 && tok == .eq) || (is_str || is_ustr)) && !p.is_js {
 			p.gen(',')
 		}
 		else if p.is_sql && tok == .eq {
@@ -1654,6 +1655,10 @@ fn (p mut Parser) bterm() string {
 			case Token.gt: p.cgen.set_placeholder(ph, 'ustring_gt(')
 			case Token.lt: p.cgen.set_placeholder(ph, 'ustring_lt(')
 			}
+		}
+		if is_f64 && tok == .eq {
+			p.gen(')')
+			p.cgen.set_placeholder(ph, 'f64_eq(')
 		}
 	}
 	return typ

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1597,12 +1597,14 @@ fn (p mut Parser) bterm() string {
 	p.expected_type = typ
 	is_str := typ=='string'  &&   !p.is_sql
 	is_ustr := typ=='ustring'
-	is_f64 := typ=='f64'
+	is_float := typ=='f64' || typ=='f32'
+	expr_type := typ
+
 	tok := p.tok
 	// if tok in [ .eq, .gt, .lt, .le, .ge, .ne] {
 	if tok == .eq || tok == .gt || tok == .lt || tok == .le || tok == .ge || tok == .ne {
 		p.fgen(' ${p.tok.str()} ')
-		if ((is_f64 && tok == .eq) || (is_str || is_ustr)) && !p.is_js {
+		if ((is_float && tok == .eq) || (is_str || is_ustr)) && !p.is_js {
 			p.gen(',')
 		}
 		else if p.is_sql && tok == .eq {
@@ -1656,9 +1658,9 @@ fn (p mut Parser) bterm() string {
 			case Token.lt: p.cgen.set_placeholder(ph, 'ustring_lt(')
 			}
 		}
-		if is_f64 && tok == .eq {
+		if is_float && tok == .eq {
 			p.gen(')')
-			p.cgen.set_placeholder(ph, 'f64_eq(')
+			p.cgen.set_placeholder(ph, '${expr_type}_eq(')
 		}
 	}
 	return typ

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -30,7 +30,7 @@ pub fn (a f64) eq(b f64) bool {
 	return C.fabs(a - b) <= C.DBL_EPSILON	
 }
 pub fn (a f32) eq(b f32) bool {
-	return C.fabs(a - b) <= C.FLT_EPSILON	
+	return C.fabsf(a - b) <= C.FLT_EPSILON	
 }
 
 // fn (nn i32) str() string {

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -32,6 +32,12 @@ pub fn (a f64) eq(b f64) bool {
 pub fn (a f32) eq(b f32) bool {
 	return C.fabsf(a - b) <= C.FLT_EPSILON	
 }
+pub fn (a f64) eqbit(b f64) bool {
+	return C.DEFAULT_EQUAL(a, b)
+}
+pub fn (a f32) eqbit(b f32) bool {
+	return C.DEFAULT_EQUAL(a, b)
+}
 
 // fn (nn i32) str() string {
 // return i

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -29,6 +29,9 @@ pub fn ptr_str(ptr voidptr) string {
 pub fn (a f64) eq(b f64) bool {
 	return C.fabs(a - b) <= C.DBL_EPSILON	
 }
+pub fn (a f32) eq(b f32) bool {
+	return C.fabs(a - b) <= C.FLT_EPSILON	
+}
 
 // fn (nn i32) str() string {
 // return i

--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -11,6 +11,20 @@ fn test_const() {
 	assert u == 1 // make sure this works without the cast
 }
 
+fn test_float_equal_operator() {
+	mut a := f32(1)
+	a += 0.000001
+	a -= 0.000001
+	assert a == 1
+	assert !a.eqbit(1)
+
+	a = f64(1)
+	a += 0.000001
+	a -= 0.000001
+	assert a == 1
+	assert !a.eqbit(1)
+}
+
 fn test_str_methods() {
 	assert i8(1).str() == '1'
 	assert i8(-1).str() == '-1'

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -37,14 +37,14 @@ fn test_factorial() {
 
 fn test_erf() {
 	assert math.erf(0) == 0
-	assert (math.erf(1.5) + math.erf(-1.5)).eq(0)
+	assert math.erf(1.5) + math.erf(-1.5) == 0
 	assert math.erfc(0) == 1
-	assert (math.erf(2.5) + math.erfc(2.5)).eq(1)
-	assert (math.erfc(3.6) + math.erfc(-3.6)).eq(2)
+	assert math.erf(2.5) + math.erfc(2.5) == 1
+	assert math.erfc(3.6) + math.erfc(-3.6) == 2
 }
 
 fn test_gamma() {
 	assert math.gamma(1) == 1
 	assert math.gamma(5) == 24
-	assert math.log_gamma(4.5).eq(math.log(math.gamma(4.5)))
+	assert math.log_gamma(4.5) == math.log(math.gamma(4.5))
 }


### PR DESCRIPTION
This PR is based on the talk https://github.com/vlang/v/pull/2133
After this PR,
`float1 == float2` equals to `float1.eq(float2)`