### PR TITLE
add darwin.resource_path()

### DIFF
--- a/vlib/darwin/darwin.v
+++ b/vlib/darwin/darwin.v
@@ -1,6 +1,8 @@
 module darwin
 
 #include <Cocoa/Cocoa.h>
+#include <CoreFoundation/CoreFoundation.h>
+
 #flag -framework Cocoa
 
 struct C.NSString { }
@@ -15,5 +17,24 @@ pub fn nsstring(s string) *C.NSString {
 	//ns := C.alloc_NSString()
 	//return ns.initWithBytesNoCopy(s.str, length: s.len,
 		//encoding: NSUTF8StringEncoding,		freeWhenDone: false)
+}
+
+// returns absolute path to folder where your resources should / will reside
+// for .app packages: .../my.app/Contents/Resources
+// for cli: .../parent_folder/my.exe/Resources
+pub fn resource_path() string {
+
+	main_bundle := C.CFBundleGetMainBundle()
+	resource_dir_url := C.CFBundleCopyResourcesDirectoryURL(main_bundle)
+	assert !isnil(resource_dir_url)
+	buffer_size := 4096
+	mut buffer := malloc(buffer_size)
+	buffer[0] = 0
+	conv_result := C.CFURLGetFileSystemRepresentation(resource_dir_url, true, buffer, buffer_size)
+	assert conv_result
+	result := tos_clone(buffer)
+	C.CFRelease(resource_dir_url)
+	free(buffer)
+	return result
 }
 

--- a/vlib/darwin/darwin.v
+++ b/vlib/darwin/darwin.v
@@ -21,7 +21,7 @@ pub fn nsstring(s string) *C.NSString {
 
 // returns absolute path to folder where your resources should / will reside
 // for .app packages: .../my.app/Contents/Resources
-// for cli: .../parent_folder/my.exe/Resources
+// for cli: .../parent_folder/Resources
 pub fn resource_path() string {
 
 	main_bundle := C.CFBundleGetMainBundle()

--- a/vlib/darwin/darwin.v
+++ b/vlib/darwin/darwin.v
@@ -32,7 +32,7 @@ pub fn resource_path() string {
 	buffer[0] = 0
 	conv_result := C.CFURLGetFileSystemRepresentation(resource_dir_url, true, buffer, buffer_size)
 	assert conv_result
-	result := tos_clone(buffer)
+	result := string(buffer)
 	C.CFRelease(resource_dir_url)
 	free(buffer)
 	return result


### PR DESCRIPTION
returns absolute path to folder containing application resources. 