### PR TITLE
compiler: enhanced wording of obsolete import const error message.

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -469,9 +469,13 @@ fn (p mut Parser) import_statement() {
 }
 
 fn (p mut Parser) const_decl() {
-	if p.tok == .key_import {
-		p.error('`import const` was removed from the language, ' +
-			'use `foo(C.CONST_NAME)` instead')
+	if p.tok == .key_import {    
+		p.error_with_token_index(
+    '`import const` was removed from the language, ' +
+    'because predeclaring C constants is not needed anymore. ' + 
+    'You can use them directly with C.CONST_NAME',
+    p.cur_tok_index() 
+    )
 	}
 	p.inside_const = true
 	p.check(.key_const)

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -471,11 +471,11 @@ fn (p mut Parser) import_statement() {
 fn (p mut Parser) const_decl() {
 	if p.tok == .key_import {    
 		p.error_with_token_index(
-    '`import const` was removed from the language, ' +
-    'because predeclaring C constants is not needed anymore. ' + 
-    'You can use them directly with C.CONST_NAME',
-    p.cur_tok_index() 
-    )
+			'`import const` was removed from the language, ' +
+			'because predeclaring C constants is not needed anymore. ' + 
+			'You can use them directly with C.CONST_NAME',
+			p.cur_tok_index()
+		)
 	}
 	p.inside_const = true
 	p.check(.key_const)


### PR DESCRIPTION
Just changed wording of the message, in order to help maintainers of older packages know how to update them to current v versions with minimum effort.