### PR TITLE
compiler c backend: avoid C warnings on linux (when -w is removed)

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -18,8 +18,6 @@ pub:
 
 // Private function, used by V (`nums := []int`)
 fn new_array(mylen, cap, elm_size int) array {
-	a := 3
-	_ = a
 	//println(a)
 	arr := array {
 		len: mylen

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -38,7 +38,7 @@ pub fn print_backtrace_skipping_top_frames(skipframes int) {
 			if C.backtrace_symbols_fd != 0 {
 				buffer := [100]byteptr
 				nr_ptrs := C.backtrace(*voidptr(buffer), 100)
-				C.backtrace_symbols_fd(&buffer[skipframes], nr_ptrs-skipframes, 1)
+				C.backtrace_symbols_fd(*voidptr(&buffer[skipframes]), nr_ptrs-skipframes, 1)
 				return
 			}else{
 				C.printf('backtrace_symbols_fd is missing, so printing backtraces is not available.\n')

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -179,7 +179,7 @@ pub fn (n i64) hex() string {
 		19
 	}
 	hex := malloc(len)
-	count := int(C.sprintf(*char(hex), '0x%llx', n))
+	count := int(C.sprintf(*char(hex), '0x%lx', n))
 	return tos(hex, count)
 }
 


### PR DESCRIPTION
By default v should not need to pass -w to the c backend compiler to silence its warnings. This PR just fixes warnings that remained on linux, as well as some code in vlib/builtin/array.v that does not seem to do anything, which also lead to a warning (but only with clang-7).