### PR TITLE
compiler: a warning/error path is now relative for user code

### DIFF
--- a/compiler/compile_errors.v
+++ b/compiler/compile_errors.v
@@ -76,24 +76,23 @@ fn (s &Scanner) warn(msg string) {
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
-
 fn (s &Scanner) warn_with_col(msg string, col int) {
-	fullpath := os.realpath( s.file_path )
+	fullpath := s.get_error_filepath()		
 	color_on := s.is_color_output_on()
 	final_message := if color_on { term.bold(term.bright_blue( msg )) } else { msg }
 	eprintln('warning: ${fullpath}:${s.line_nr+1}:${col}: $final_message')
 }
 
 fn (s &Scanner) error_with_col(msg string, col int) {
-	fullpath := os.realpath( s.file_path )
+	fullpath := s.get_error_filepath()		
 	color_on := s.is_color_output_on()
 	final_message := if color_on { term.red( term.bold( msg ) ) } else { msg }
 	// The filepath:line:col: format is the default C compiler
 	// error output format. It allows editors and IDE's like
 	// emacs to quickly find the errors in the output
 	// and jump to their source with a keyboard shortcut.
-	// Using only the filename leads to inability of IDE/editors
-	// to find the source file, when it is in another folder.
+	// NB: using only the filename may lead to inability of IDE/editors
+	// to find the source file, when the IDE has a different working folder than v itself.
 	eprintln('${fullpath}:${s.line_nr + 1}:${col}: $final_message')
 	
 	if s.should_print_line_on_error && s.file_lines.len > 0 {
@@ -131,6 +130,13 @@ fn (s &Scanner) error_with_col(msg string, col int) {
 [inline] fn (p &Parser) cur_tok_index() int { return p.token_idx - 1 }
 [inline] fn imax(a,b int) int { 	return if a > b { a } else { b } }
 [inline] fn imin(a,b int) int { 	return if a < b { a } else { b } }
+
+fn (s &Scanner) get_error_filepath() string {
+	if s.should_print_relative_paths_on_error {
+		return s.file_path
+	}
+	return os.realpath( s.file_path )
+}
 
 fn (s &Scanner) is_color_output_on() bool {
 	return s.should_print_errors_in_color && term.can_show_color_on_stderr()	

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -124,6 +124,9 @@ fn (v mut V) new_parser_file(path string) Parser {
 		file_pcguard: path_pcguard,
 		is_script: (v.pref.is_script && path == v.dir)
 	}
+	if p.pref.building_v {
+		p.scanner.should_print_relative_paths_on_error = false
+	}
 	v.cgen.file = path
 	p.scan_tokens()
 	//p.scanner.debug_tokens()
@@ -155,6 +158,7 @@ fn (v mut V) new_parser(scanner &Scanner, id string) Parser {
 	if p.pref.is_repl {
 		p.scanner.should_print_line_on_error = false
 		p.scanner.should_print_errors_in_color = false
+		p.scanner.should_print_relative_paths_on_error = true
 	}
 	v.cgen.line_directives = v.pref.is_debuggable
 	// v.cgen.file = path

--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -37,6 +37,7 @@ mut:
 	fn_name string // needed for @FN
 	should_print_line_on_error bool
 	should_print_errors_in_color bool
+	should_print_relative_paths_on_error bool
 	quote byte // which quote is used to denote current string: ' or "
 	file_lines   []string // filled *only on error* by rescanning the source till the error (and several lines more)
 }
@@ -76,6 +77,7 @@ fn new_scanner(text string) &Scanner {
 		fmt_out: strings.new_builder(1000)
 		should_print_line_on_error: true
 		should_print_errors_in_color: true
+		should_print_relative_paths_on_error: true
 	}
 }
 


### PR DESCRIPTION
When compiling user code, v now prints shorter file paths in most cases.