### PR TITLE
compiler: float comparison uses machine epsilon by default

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1540,7 +1540,7 @@ fn (p mut Parser) bterm() string {
 	// if tok in [ .eq, .gt, .lt, .le, .ge, .ne] {
 	if tok == .eq || tok == .gt || tok == .lt || tok == .le || tok == .ge || tok == .ne {
 		p.fgen(' ${p.tok.str()} ')
-		if ((is_float && tok == .eq) || (is_str || is_ustr)) && !p.is_js {
+		if (is_float || is_str || is_ustr) && !p.is_js {
 			p.gen(',')
 		}
 		else if p.is_sql && tok == .eq {
@@ -1596,7 +1596,14 @@ fn (p mut Parser) bterm() string {
 		}
 		if is_float && tok == .eq {
 			p.gen(')')
-			p.cgen.set_placeholder(ph, '${expr_type}_eq(')
+			switch tok {
+			case Token.eq: p.cgen.set_placeholder(ph, '${expr_typ}_eq(')
+			case Token.ne: p.cgen.set_placeholder(ph, '${expr_typ}_ne(')
+			case Token.le: p.cgen.set_placeholder(ph, '${expr_typ}_le(')
+			case Token.ge: p.cgen.set_placeholder(ph, '${expr_typ}_ge(')
+			case Token.gt: p.cgen.set_placeholder(ph, '${expr_typ}_gt(')
+			case Token.lt: p.cgen.set_placeholder(ph, '${expr_typ}_ll(')
+			}
 		}
 	}
 	return typ

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1594,7 +1594,7 @@ fn (p mut Parser) bterm() string {
 			case Token.lt: p.cgen.set_placeholder(ph, 'ustring_lt(')
 			}
 		}
-		if is_float && tok == .eq {
+		if is_float {
 			p.gen(')')
 			switch tok {
 			case Token.eq: p.cgen.set_placeholder(ph, '${expr_type}_eq(')

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -1597,12 +1597,12 @@ fn (p mut Parser) bterm() string {
 		if is_float && tok == .eq {
 			p.gen(')')
 			switch tok {
-			case Token.eq: p.cgen.set_placeholder(ph, '${expr_typ}_eq(')
-			case Token.ne: p.cgen.set_placeholder(ph, '${expr_typ}_ne(')
-			case Token.le: p.cgen.set_placeholder(ph, '${expr_typ}_le(')
-			case Token.ge: p.cgen.set_placeholder(ph, '${expr_typ}_ge(')
-			case Token.gt: p.cgen.set_placeholder(ph, '${expr_typ}_gt(')
-			case Token.lt: p.cgen.set_placeholder(ph, '${expr_typ}_ll(')
+			case Token.eq: p.cgen.set_placeholder(ph, '${expr_type}_eq(')
+			case Token.ne: p.cgen.set_placeholder(ph, '${expr_type}_ne(')
+			case Token.le: p.cgen.set_placeholder(ph, '${expr_type}_le(')
+			case Token.ge: p.cgen.set_placeholder(ph, '${expr_type}_ge(')
+			case Token.gt: p.cgen.set_placeholder(ph, '${expr_type}_gt(')
+			case Token.lt: p.cgen.set_placeholder(ph, '${expr_type}_lt(')
 			}
 		}
 	}

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -26,6 +26,7 @@ pub fn ptr_str(ptr voidptr) string {
 }
 
 // compare floats using C epsilon
+// ==
 pub fn (a f64) eq(b f64) bool {
 	return C.fabs(a - b) <= C.DBL_EPSILON	
 }
@@ -46,29 +47,53 @@ fn (a f64) ne(b f64) bool {
 fn (a f32) ne(b f32) bool {
 	return !a.eq(b)
 }
+pub fn (a f64) neqbit(b f64) bool {
+	return C.DEFAULT_NOT_EQUAL(a, b)
+}
+pub fn (a f32) neqbit(b f32) bool {
+	return C.DEFAULT_NOT_EQUAL(a, b)
+}
 
 // a < b
 fn (a f64) lt(b f64) bool {
-	return a.ne(b) && C.DEFAULT_LT(a, b)
+	return a.ne(b) && a.ltbit(b)
 }
 fn (a f32) lt(b f32) bool {
-	return a.ne(b) && C.DEFAULT_LT(a, b)
+	return a.ne(b) && a.ltbit(b)
+}
+fn (a f64) ltbit(b f64) bool {
+	return C.DEFAULT_LT(a, b)
+}
+fn (a f32) ltbit(b f32) bool {
+	return C.DEFAULT_LT(a, b)
 }
 
 // a <= b
 fn (a f64) le(b f64) bool {
-	return a.ne(b) && C.DEFAULT_LE(a, b)
+	return !a.gt(b)
 }
 fn (a f32) le(b f32) bool {
-	return a.ne(b) && C.DEFAULT_LE(a, b)
+	return !a.gt(b)
+}
+fn (a f64) lebit(b f64) bool {
+	return C.DEFAULT_LE(a, b)
+}
+fn (a f32) lebit(b f32) bool {
+	return C.DEFAULT_LE(a, b)
 }
 
 // a > b
 fn (a f64) gt(b f64) bool {
-	return a.ne(b) && C.DEFAULT_GT(a, b)
+	return a.ne(b) && a.gtbit(b)
 }
 fn (a f32) gt(b f32) bool {
-	return a.ne(b) && C.DEFAULT_GT(a, b)
+	return a.ne(b) && a.gtbit(b)
+}
+fn (a f64) gtbit(b f64) bool {
+	return C.DEFAULT_GT(a, b)
+}
+fn (a f32) gtbit(b f32) bool {
+	return C.DEFAULT_GT(a, b)
 }
 
 // a >= b
@@ -77,6 +102,12 @@ fn (a f64) ge(b f64) bool {
 }
 fn (a f32) ge(b f32) bool {
 	return !a.lt(b)
+}
+fn (a f64) gebit(b f64) bool {
+	return C.DEFAULT_GE(a, b)
+}
+fn (a f32) gebit(b f32) bool {
+	return C.DEFAULT_GE(a, b)
 }
 
 

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -47,10 +47,10 @@ fn (a f64) ne(b f64) bool {
 fn (a f32) ne(b f32) bool {
 	return !a.eq(b)
 }
-pub fn (a f64) neqbit(b f64) bool {
+pub fn (a f64) nebit(b f64) bool {
 	return C.DEFAULT_NOT_EQUAL(a, b)
 }
-pub fn (a f32) neqbit(b f32) bool {
+pub fn (a f32) nebit(b f32) bool {
 	return C.DEFAULT_NOT_EQUAL(a, b)
 }
 

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -39,6 +39,48 @@ pub fn (a f32) eqbit(b f32) bool {
 	return C.DEFAULT_EQUAL(a, b)
 }
 
+// !=
+fn (a f64) ne(b f64) bool {
+	return !a.eq(b)
+}
+fn (a f32) ne(b f32) bool {
+	return !a.eq(b)
+}
+
+// a < b
+fn (a f64) lt(b f64) bool {
+	return a.ne(b) && C.DEFAULT_LT(a, b)
+}
+fn (a f32) lt(b f32) bool {
+	return a.ne(b) && C.DEFAULT_LT(a, b)
+}
+
+// a <= b
+fn (a f64) le(b f64) bool {
+	return a.ne(b) && C.DEFAULT_LE(a, b)
+}
+fn (a f32) le(b f32) bool {
+	return a.ne(b) && C.DEFAULT_LE(a, b)
+}
+
+// a > b
+fn (a f64) gt(b f64) bool {
+	return a.ne(b) && C.DEFAULT_GT(a, b)
+}
+fn (a f32) gt(b f32) bool {
+	return a.ne(b) && C.DEFAULT_GT(a, b)
+}
+
+// a >= b
+fn (a f64) ge(b f64) bool {
+	return !a.lt(b)
+}
+fn (a f32) ge(b f32) bool {
+	return !a.lt(b)
+}
+
+
+
 // fn (nn i32) str() string {
 // return i
 // }

--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -21,9 +21,9 @@ fn test_float_equal_operator() {
 	assert a.nebit(1)
 	a += 0.000001
 	assert !(a < 1)
-	assert a.ltbit(1)
+	assert !a.ltbit(1)
 	assert !(a <= 1)
-	assert a.lebit(1)
+	assert !a.lebit(1)
 	assert a > 1
 	assert a.gtbit(1)
 	assert a >= 1
@@ -37,9 +37,9 @@ fn test_float_equal_operator() {
 	assert !(a != 1)
 	a += 0.000001
 	assert !(a < 1)
-	assert a.ltbit(1)
+	assert !a.ltbit(1)
 	assert !(a <= 1)
-	assert a.lebit(1)
+	assert !a.lebit(1)
 	assert a > 1
 	assert a.gtbit(1)
 	assert a >= 1

--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -17,12 +17,33 @@ fn test_float_equal_operator() {
 	a -= 0.000001
 	assert a == 1
 	assert !a.eqbit(1)
+	assert !(a != 1)
+	assert a.nebit(1)
+	a += 0.000001
+	assert !(a < 1)
+	assert a.ltbit(1)
+	assert !(a <= 1)
+	assert a.lebit(1)
+	assert a > 1
+	assert a.gtbit(1)
+	assert a >= 1
+	assert a.gebit(1)
 
 	a = f64(1)
 	a += 0.000001
 	a -= 0.000001
 	assert a == 1
 	assert !a.eqbit(1)
+	assert !(a != 1)
+	a += 0.000001
+	assert !(a < 1)
+	assert a.ltbit(1)
+	assert !(a <= 1)
+	assert a.lebit(1)
+	assert a > 1
+	assert a.gtbit(1)
+	assert a >= 1
+	assert a.gebit(1)
 }
 
 fn test_str_methods() {


### PR DESCRIPTION
This PR lets the compiler to evaluate comparisons using machine epsilon by default, in order to do away with incoherent evaluations.
https://github.com/vlang/v/pull/2194 needs to be merged before this PR to deal with chicken and egg problem.

Before this PR, `float1 == float2` and `float1 != float2` can show the same bool value.
ex.
```
mut a := f64(1)
a += 0.001
a -= 0.001
println(a == 1)
println(a != 1)
// => 1 1
```