### PR TITLE
compiler: automatically detect builtin files

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -873,6 +873,7 @@ fn new_v(args[]string) &V {
 	'string.v',
 	'builtin.v',
 	'int.v',
+	'float.v',
 	'utf8.v',
 	'map.v',
 	'hashmap.v',


### PR DESCRIPTION
This PR enables the compiler to automatically detect `vlib/builtin/*.v` or `vlib/builtin/js/*.v`, simultaneously simplifying the `main.v` source code.

This PR makes it easy to organize builtin files.
Before this PR, if you hoped to add `float.v` in order to separate float functions from `int.v` in `builtin`, you needed to follow the following steps:
1. add `float.v` to the `builtins` array in the `main.v` and compile V at this point to deal with chicken and egg problems
2. transplant float functions into `float.v` and delete them in `int.v`

These 2 steps will be reduced to only the 2nd step.