### PR TITLE
Recompile V itself also for nix, if needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,17 @@ all:
 	git clone --depth 1 --quiet https://github.com/vlang/vc
 ifdef WIN32
 	$(CC) -std=gnu11 -w -o v0.exe vc/v_win.c
+	./v0.exe -o v.exe compiler
+	rm -f v0.exe
 else
-	$(CC) -std=gnu11 -w -o v0 vc/v.c -lm
+	$(CC) -std=gnu11 -w -o v vc/v.c -lm
+	@(VC_V=`./v version | cut -f 3 -d " "`; \
+	V_V=`git rev-parse --short HEAD`; \
+	if [ $$VC_V != $$V_V ]; then \
+		echo "Self rebuild ($$VC_V => $$V_V)"; \
+		./v -o v compiler; \
+	fi)
 endif
-	./v0 -o v compiler
-	rm -rf v0 vc/
+	rm -rf vc/
 	@echo "V has been successfully built"
 

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ all:
 	git clone --depth 1 --quiet https://github.com/vlang/vc
 ifdef WIN32
 	$(CC) -std=gnu11 -w -o v0.exe vc/v_win.c
-	./v0.exe -o v.exe compiler
 else
-	$(CC) -std=gnu11 -w -o v vc/v.c -lm
+	$(CC) -std=gnu11 -w -o v0 vc/v.c -lm
 endif
-	rm -rf vc/
+	./v0 -o v compiler
+	rm -rf v0 vc/
 	@echo "V has been successfully built"
 


### PR DESCRIPTION
Rebuild V itself also for nix (as for windows)
UPDATE: only rebuild if actual C source and HEAD versions differ !

This way, we're sure that the resulting V compiler binary is compiled from V sources (rather than by a possibly lagging compiler from C sources)