### PR TITLE
compiler: let methods return voidptr without a segfault

### DIFF
--- a/compiler/gen_c.v
+++ b/compiler/gen_c.v
@@ -238,9 +238,13 @@ fn (p mut Parser) gen_method_call(receiver_type, ftyp string, cgen_name string, 
 	// Method returns (void*) => cast it to int, string, user etc
 	// number := *(int*)numbers.first()
 	if ftyp == 'void*' {
-		// array_int => int
-		cast = receiver_type.all_after('_')
-		cast = '*($cast*) '
+		if receiver_type.starts_with('array_') {
+			// array_int => int
+			cast = receiver_type.all_after('_')
+			cast = '*($cast*) '
+		}else{
+			cast = '(voidptr) '
+		}
 	}
 	p.cgen.set_placeholder(method_ph, '$cast $method_call')
 	//return method_call

--- a/compiler/tests/return_voidptr_test.v
+++ b/compiler/tests/return_voidptr_test.v
@@ -4,13 +4,20 @@ struct Zest { val int }
 fn (t Zest) get_a_finger_to_the_moon() voidptr {
 	return voidptr(0)
 }
+
+fn get_the_dao_way() voidptr {
+	return voidptr(0)
+}
         
 fn test_returning_a_void_pointer_from_a_method() {
-	t := &Zest{ val: 123 }
-	
-	mut z := voidptr(0)
-	z = t.get_a_finger_to_the_moon()
-	C.printf( "%x\n", z)
-
+	t := &Zest{ val: 123 }	
+	z := voidptr(0)
+	assert z == t.get_a_finger_to_the_moon()
 	assert t.get_a_finger_to_the_moon() == 0
+}
+
+fn test_returning_a_void_pointer_from_a_function() {
+	z := voidptr(0)
+	assert z == get_the_dao_way()
+	assert get_the_dao_way() == 0
 }

--- a/compiler/tests/return_voidptr_test.v
+++ b/compiler/tests/return_voidptr_test.v
@@ -1,0 +1,16 @@
+
+struct Zest { val int }
+    
+fn (t Zest) get_a_finger_to_the_moon() voidptr {
+	return voidptr(0)
+}
+        
+fn test_returning_a_void_pointer_from_a_method() {
+	t := &Zest{ val: 123 }
+	
+	mut z := voidptr(0)
+	z = t.get_a_finger_to_the_moon()
+	C.printf( "%x\n", z)
+
+	assert t.get_a_finger_to_the_moon() == 0
+}


### PR DESCRIPTION
This PR closes issue #2210 .

NB, till now, this block of code in gen_c.v's gen_method_call:
```
    // Method returns (void*) => cast it to int, string, user etc
    // number := *(int*)numbers.first()
    if ftyp == 'void*' {
           // array_int => int
           cast = receiver_type.all_after('_')
           cast = '*($cast*) '
    } 
```
... seem to me, that was used actively only by the vlib/builtin/array.v methods (thus the check to keep its current behavior for them).

The method in vlib/builtin/string.v, is from a commented function `pub fn (a []string) to_c() voidptr {`, so is not affected by this change. 
The method in vlib/glfw/glfw.v `pub fn (w &Window) user_ptr() voidptr {` also seems to not be used now.

I do not know how to test the vlib/szip/szip.v one, but it returns ?voidptr, so probably it is not affected too (btw, szip does not have tests).

```shell
0[19:51:48] /v/oldv $ rg 'voidptr +\{'
vlib/szip/szip.v
225:pub fn (zentry mut zip_ptr) read_entry() ?voidptr {

vlib/builtin/array.v
114:fn (a array) _get(i int) voidptr {
121:pub fn (a array) first() voidptr {
128:pub fn (a array) last() voidptr {

vlib/builtin/string.v
611:pub fn (a []string) to_c() voidptr {

vlib/builtin/builtin.v
155:fn memdup(src voidptr, sz int) voidptr {

vlib/os/os_win.v
166:fn ptr_win_get_error_msg(code u32) voidptr {

vlib/glfw/glfw.v
226:pub fn (w &Window) user_ptr() voidptr {
251:pub fn get_window_user_pointer(gwnd voidptr) voidptr {

vlib/builtin/js/array.v
59:pub fn (a array) first() voidptr {
66:pub fn (a array) last() voidptr {
```
