### PR TITLE
windows: read console with ReadConsole

### DIFF
--- a/compiler/cheaders.v
+++ b/compiler/cheaders.v
@@ -141,7 +141,9 @@ byteptr g_str_buf;
 int load_so(byteptr);
 void reload_so();
 void init_consts();
-
+#ifdef _WIN32
+BOOL isConsole;
+#endif
 '
 
 js_headers = '

--- a/compiler/main.v
+++ b/compiler/main.v
@@ -395,7 +395,7 @@ fn (v mut V) generate_main() {
 		cgen.genln('void init_consts() {
 #ifdef _WIN32
 DWORD consoleMode;
-BOOL isConsole = GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &consoleMode);
+isConsole = GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &consoleMode);
 int mode = isConsole ? _O_U16TEXT : _O_U8TEXT;
 _setmode(_fileno(stdin), mode);
 _setmode(_fileno(stdout), _O_U8TEXT);


### PR DESCRIPTION
This will fix compatibility with mingw64: fgetws does not work correctly on console there

Tests will not pass, because `os.get_raw_line` used in compiler, it may require to manually commit new v.c

Alternatively, you can merge all changes except `os.v`, and commit `os.v` after `v.c` update
