### PR TITLE
compiler: generate such a v.c, that it can be used to bootstrap v with latest tcc

### DIFF
--- a/compiler/cheaders.v
+++ b/compiler/cheaders.v
@@ -40,9 +40,17 @@ CommonCHeaders = '
 
 #define EMPTY_STRUCT_DECLARATION
 #define EMPTY_STRUCT_INITIALIZATION 0
+// Due to a tcc bug, the length of an array needs to be specified, but GCC crashes if it is...
+#define EMPTY_ARRAY_OF_ELEMS(x,n) (x[])
+#define TCCSKIP(x) x
+
 #ifdef __TINYC__
 #undef EMPTY_STRUCT_INITIALIZATION
 #define EMPTY_STRUCT_INITIALIZATION
+#undef EMPTY_ARRAY_OF_ELEMS
+#define EMPTY_ARRAY_OF_ELEMS(x,n) (x[n])
+#undef TCCSKIP
+#define TCCSKIP(x)
 #endif
 
 #define OPTION_CAST(x) (x)

--- a/compiler/gen_c.v
+++ b/compiler/gen_c.v
@@ -317,18 +317,15 @@ fn (p mut Parser) gen_array_init(typ string, no_alloc bool, new_arr_ph int, nr_e
 	if no_alloc {
 		new_arr += '_no_alloc'
 	}
-	if nr_elems == 0 && p.pref.ccompiler != 'tcc' {
-		p.gen(' 0 })')
+	if nr_elems == 0 {
+		p.gen(' TCCSKIP(0) })')
 	} else {
 		p.gen(' })')
 	}
 	// Need to do this in the second pass, otherwise it goes to the very top of the out.c file
-	if !p.first_pass() {
-		// Due to a tcc bug, the length needs to be specified.
-		// GCC crashes if it is.
-		cast := if p.pref.ccompiler == 'tcc' { '($typ[$nr_elems])' } else { '($typ[])' }
-		p.cgen.set_placeholder(new_arr_ph,		
-			'$new_arr($nr_elems, $nr_elems, sizeof($typ), $cast { ')
+	if !p.first_pass() {		
+		p.cgen.set_placeholder(new_arr_ph,
+			'$new_arr($nr_elems, $nr_elems, sizeof($typ), EMPTY_ARRAY_OF_ELEMS( $typ, $nr_elems ) { ')
 	}
 }	
 


### PR DESCRIPTION
I've downloaded latest tcc, and I can bootstrap v with it finally.
`./v -cc tcc -o v compiler` works, with the latest tcc, several times in order.

This PR though, makes it possible so that the latest tcc can be used to compile v from vc/v.c (so there would not be a need for another vc/v_tcc.v) .

Instructions for compiling a recent tcc:
```shell
0[12:50:16] ~ $ git clone --quiet git://repo.or.cz/tinycc.git /v/tcc.latest
0[12:50:53] ~ $ cd /v/tcc.latest/
0[12:51:09] /v/tcc.latest $ git rev-parse --short HEAD
944c400
0[12:51:11] /v/tcc.latest $ ./configure --prefix=/opt/tcc.latest
Perhaps you want ./configure --config-musl
Binary directory    /opt/tcc.latest/bin
TinyCC directory    /opt/tcc.latest/lib/tcc
Library directory   /opt/tcc.latest/lib
Include directory   /opt/tcc.latest/include
Manual directory    /opt/tcc.latest/share/man
Info directory      /opt/tcc.latest/share/info
Doc directory       /opt/tcc.latest/share/doc
Source path         /v/tcc.latest
C compiler          gcc (5.5)
Target OS           Linux
CPU                 x86_64
Triplet             x86_64-linux-gnu
Creating config.mak and config.h
0[12:51:37] /v/tcc.latest $ make
gcc -o tcc.o -c tcc.c -DCONFIG_TRIPLET="\"x86_64-linux-gnu\"" -DTCC_TARGET_X86_64       -DONE_SOURCE=0 -Wall -g -O2 -Wdeclaration-after-statement -fno-strict-aliasing -Wno-pointer-sign -Wno-sign-compare -Wno-unused-result -I. 
gcc -o libtcc.o -c libtcc.c -DCONFIG_TRIPLET="\"x86_64-linux-gnu\"" -DTCC_TARGET_X86_64       -DONE_SOURCE=0 -Wall -g -O2 -Wdeclaration-after-statement -fno-strict-aliasing -Wno-pointer-sign -Wno-sign-compare -Wno-unused-result -I. 
gcc -o tccpp.o -c tccpp.c -DCONFIG_TRIPLET="\"x86_64-linux-gnu\"" -DTCC_TARGET_X86_64       -DONE_SOURCE=0 -Wall -g -O2 -Wdeclaration-after-statement -fno-strict-aliasing -Wno-pointer-sign -Wno-sign-compare -Wno-unused-result -I. 
gcc -o tccgen.o -c tccgen.c -DCONFIG_TRIPLET="\"x86_64-linux-gnu\"" -DTCC_TARGET_X86_64       -DONE_SOURCE=0 -Wall -g -O2 -Wdeclaration-after-statement -fno-strict-aliasing -Wno-pointer-sign -Wno-sign-compare -Wno-unused-result -I. 
gcc -o tccelf.o -c tccelf.c -DCONFIG_TRIPLET="\"x86_64-linux-gnu\"" -DTCC_TARGET_X86_64       -DONE_SOURCE=0 -Wall -g -O2 -Wdeclaration-after-statement -fno-strict-aliasing -Wno-pointer-sign -Wno-sign-compare -Wno-unused-result -I. 
gcc -o tccasm.o -c tccasm.c -DCONFIG_TRIPLET="\"x86_64-linux-gnu\"" -DTCC_TARGET_X86_64       -DONE_SOURCE=0 -Wall -g -O2 -Wdeclaration-after-statement -fno-strict-aliasing -Wno-pointer-sign -Wno-sign-compare -Wno-unused-result -I. 
gcc -o tccrun.o -c tccrun.c -DCONFIG_TRIPLET="\"x86_64-linux-gnu\"" -DTCC_TARGET_X86_64       -DONE_SOURCE=0 -Wall -g -O2 -Wdeclaration-after-statement -fno-strict-aliasing -Wno-pointer-sign -Wno-sign-compare -Wno-unused-result -I. 
gcc -o x86_64-gen.o -c x86_64-gen.c -DCONFIG_TRIPLET="\"x86_64-linux-gnu\"" -DTCC_TARGET_X86_64       -DONE_SOURCE=0 -Wall -g -O2 -Wdeclaration-after-statement -fno-strict-aliasing -Wno-pointer-sign -Wno-sign-compare -Wno-unused-result -I. 
gcc -o x86_64-link.o -c x86_64-link.c -DCONFIG_TRIPLET="\"x86_64-linux-gnu\"" -DTCC_TARGET_X86_64       -DONE_SOURCE=0 -Wall -g -O2 -Wdeclaration-after-statement -fno-strict-aliasing -Wno-pointer-sign -Wno-sign-compare -Wno-unused-result -I.
gcc -o i386-asm.o -c i386-asm.c -DCONFIG_TRIPLET="\"x86_64-linux-gnu\"" -DTCC_TARGET_X86_64       -DONE_SOURCE=0 -Wall -g -O2 -Wdeclaration-after-statement -fno-strict-aliasing -Wno-pointer-sign -Wno-sign-compare -Wno-unused-result -I.
ar rcs libtcc.a libtcc.o tccpp.o tccgen.o tccelf.o tccasm.o tccrun.o x86_64-gen.o x86_64-link.o i386-asm.o
gcc -o tcc tcc.o libtcc.a -lm -ldl
make[1]: Entering directory '/v/tcc.latest/lib'
../tcc -c libtcc1.c -o libtcc1.o -B..
../tcc -c alloca86_64.S -o alloca86_64.o -B..
../tcc -c alloca86_64-bt.S -o alloca86_64-bt.o -B..
../tcc -c va_list.c -o va_list.o -B..
../tcc -c bcheck.c -o bcheck.o -B..
../tcc -c dsohandle.c -o dsohandle.o -B..
../tcc -ar rcs ../libtcc1.a libtcc1.o alloca86_64.o alloca86_64-bt.o va_list.o bcheck.o dsohandle.o
make[1]: Leaving directory '/v/tcc.latest/lib'
./texi2pod.pl tcc-doc.texi tcc.pod \
&& pod2man --section=1 --center="Tiny C Compiler" --release="0.9.27" tcc.pod >tmp.1 \
&& mv tmp.1 tcc.1 || rm -f tmp.1
makeinfo --no-split --html --number-sections -o tcc-doc.html tcc-doc.texi || true
makeinfo tcc-doc.texi || true
0[12:51:52] /v/tcc.latest $ sudo make install
[sudo] password for delian:
mkdir -p "/opt/tcc.latest/bin" && install -m755  tcc "/opt/tcc.latest/bin"
mkdir -p "/opt/tcc.latest/lib/tcc" && install -m644 libtcc1.a "/opt/tcc.latest/lib/tcc"
mkdir -p "/opt/tcc.latest/lib/tcc/include" && install -m644 ./include/*.h ./tcclib.h "/opt/tcc.latest/lib/tcc/include"
mkdir -p "/opt/tcc.latest/lib" && install -m644 libtcc.a "/opt/tcc.latest/lib"
mkdir -p "/opt/tcc.latest/include" && install -m644 ./libtcc.h "/opt/tcc.latest/include"
mkdir -p "/opt/tcc.latest/share/man/man1" && install -m644 tcc.1 "/opt/tcc.latest/share/man/man1"
mkdir -p "/opt/tcc.latest/share/info" && install -m644 tcc-doc.info "/opt/tcc.latest/share/info"
mkdir -p "/opt/tcc.latest/share/doc" && install -m644 tcc-doc.html "/opt/tcc.latest/share/doc"
0[12:52:02] /v/tcc.latest $ rm /usr/local/bin/tcc
0[12:52:15] /v/tcc.latest $ ln -s /opt/tcc.latest/bin/tcc /usr/local/bin/tcc
0[12:52:24] /v/tcc.latest $ /usr/local/bin/tcc -version
tcc version 0.9.27 (x86_64 Linux)
0[12:52:39] /v/tcc.latest $ which tcc
/usr/local/bin/tcc
0[12:52:41] /v/tcc.latest $
```

NB: the last official 0.9.27 tcc release was cut from their master branch, and was done at 
  ` d348a9a 2017-12-12 17:57 +0100 grischka           ∙ {origin/master} <release_0_9_27> final update for 0.9.27`

The recent tcc current version is at:
  ` 944c400 2019-09-16 15:24 +0800 JBoon              ∙ [mob] {origin/mob} {origin/HEAD} Add function to list all symbols, for purpose of linking separate in-memory compilations`

... which is over 195 commits newer...