### PR TITLE
fix find vsdevcmd.bat in VS2019Preview

### DIFF
--- a/compiler/msvc.v
+++ b/compiler/msvc.v
@@ -141,7 +141,7 @@ fn find_vs() ?VsInstallation {
 	// VSWhere is guaranteed to be installed at this location now
 	// If its not there then end user needs to update their visual studio 
 	// installation!
-	res := os.exec('""%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath"') or {
+	res := os.exec('""%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\vswhere.exe" -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath"') or {
 		return error(err)
 	}
 	// println('res: "$res"')

--- a/make.bat
+++ b/make.bat
@@ -52,7 +52,7 @@ goto :success
 :msvcstrap
 echo Attempting to build v.c  with MSVC...
 
-for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
   set InstallDir=%%i
 )
 


### PR DESCRIPTION
if only preview version is installed make.bat did not find vsdevcmd.bat

![изображение](https://user-images.githubusercontent.com/55323/66261400-3d0fb280-e7d5-11e9-84d6-333fb7ab3033.png)


