### PR TITLE
compiler: fix newline being added when using print with type other than string - closes #2253

### DIFF
--- a/compiler/fn.v
+++ b/compiler/fn.v
@@ -911,7 +911,8 @@ fn (p mut Parser) fn_call_args(f mut Fn) &Fn {
 			$if !js {
 				fmt := p.typ_to_fmt(typ, 0)
 				if fmt != '' {
-					p.cgen.resetln(p.cgen.cur_line.replace(f.name + ' (', '/*opt*/printf ("' + fmt + '\\n", '))
+					nl := if f.name == 'println' { '\\n' } else { '' }
+					p.cgen.resetln(p.cgen.cur_line.replace(f.name + ' (', '/*opt*/printf ("' + fmt + '$nl", '))
 					continue
 				}
 			}


### PR DESCRIPTION
compiler: fix newline being added when using print with int - closes #2253