### PR TITLE
http/win: fix schannel from crashing

### DIFF
--- a/thirdparty/vschannel/vschannel.c
+++ b/thirdparty/vschannel/vschannel.c
@@ -930,7 +930,7 @@ static DWORD verify_server_certificate( PCCERT_CONTEXT  pServerCert, LPWSTR host
 	CHAR *rgszUsages[] = {  szOID_PKIX_KP_SERVER_AUTH,
 							szOID_SERVER_GATED_CRYPTO,
 							szOID_SGC_NETSCAPE };
-	DWORD cUsages = sizeof(rgszUsages) / sizeof(LPSTR);
+	DWORD cUsages = sizeof(rgszUsages) / sizeof(CHAR*);
 
 	PWSTR   pwszServerName = NULL;
 	DWORD   cchServerName;

--- a/thirdparty/vschannel/vschannel.c
+++ b/thirdparty/vschannel/vschannel.c
@@ -930,7 +930,7 @@ static DWORD verify_server_certificate( PCCERT_CONTEXT  pServerCert, LPWSTR host
 	CHAR *rgszUsages[] = {  szOID_PKIX_KP_SERVER_AUTH,
 							szOID_SERVER_GATED_CRYPTO,
 							szOID_SGC_NETSCAPE };
-	DWORD cUsages = sizeof(rgszUsages) / sizeof(CHAR);
+	DWORD cUsages = sizeof(rgszUsages) / sizeof(LPSTR);
 
 	PWSTR   pwszServerName = NULL;
 	DWORD   cchServerName;

--- a/thirdparty/vschannel/vschannel.c
+++ b/thirdparty/vschannel/vschannel.c
@@ -263,8 +263,8 @@ static INT connect_to_server(TlsContext *tls_ctx, LPWSTR host, INT port_number) 
 	SOCKADDR_STORAGE local_address = { 0 };
 	SOCKADDR_STORAGE remote_address = { 0 };
 
-	DWORD local_address_length;
-	DWORD remote_address_length;
+	DWORD local_address_length =  sizeof(local_address);
+	DWORD remote_address_length = sizeof(remote_address);
 
 	struct timeval tv;
 	tv.tv_sec = 60;
@@ -281,8 +281,8 @@ static INT connect_to_server(TlsContext *tls_ctx, LPWSTR host, INT port_number) 
 	WCHAR service_name[10];
 	int res = wsprintf(service_name, L"%d", port_number);
 
-	if(WSAConnectByName(Socket,connect_name, service_name, local_address_length, 
-		&local_address, remote_address_length, &remote_address, &tv, NULL) == SOCKET_ERROR) {
+	if(WSAConnectByName(Socket,connect_name, service_name, &local_address_length, 
+		&local_address, &remote_address_length, &remote_address, &tv, NULL) == SOCKET_ERROR) {
 		wprintf(L"Error %d connecting to \"%s\" (%s)\n", 
 			WSAGetLastError(),
 			connect_name, 


### PR DESCRIPTION
windows HTTPS requests were crashing, since update in this PR, I think maybe overlooked pointer:
https://github.com/vlang/v/pull/2120

This fixes it the issue with GCC
crashing on the call to `CertVerifyCertificateChainPolicy` on line `978`

There seems to be another issue with MSVC which this does not fix
crashing on line `284`, call: `WSAConnectByName`