### PR TITLE
v test: add ability to test a folder or a set of _test.v files

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -154,12 +154,12 @@ fn main() {
 		vfmt(args)
 		return
 	}
-	// Construct the V object from command line arguments
-	mut v := new_v(args)
-	if args.join(' ').contains(' test v') {
-		v.test_v()
+	if 'test' in args {
+		test_v(args)
 		return
 	}
+	// Construct the V object from command line arguments
+	mut v := new_v(args)
 	if v.pref.is_verbose {
 		println(args)
 	}
@@ -1038,7 +1038,7 @@ fn install_v(args[]string) {
 	}
 }
 
-fn (v &V) test_vget() {
+fn test_vget() {
 	/*
 	vexe := os.executable()
 	ret := os.system('$vexe install nedpals.args')
@@ -1054,7 +1054,30 @@ fn (v &V) test_vget() {
 	*/
 }
 
-fn (v &V) test_v() {
+fn test_v(args[]string) {
+	if args.len < 3 {
+		println('Usage:')
+		println('   A)')
+		println('      v test v  : run all v tests and build all the examples')
+		println('   B)')
+		println('      v test folder/ : run all v tests in the given folder.')
+		println('      v -stats test folder/ : the same, but print more stats.')
+		println('   C)')
+		println('      v test file_test.v : run test functions in a given test file.')
+		println('      v -stats test file_test.v : as above, but with more stats.')
+		println('   NB: you can also give many and mixed folder/ file_test.v arguments after test.')
+		println('')
+		return
+	}
+	testargs := get_all_after(args.join(' '), 'test', '')
+	if testargs == 'v' {
+		v_test_v()
+		return
+	}
+	println('testargs: $testargs')
+}
+
+fn v_test_v(){	
 	args := env_vflags_and_os_args()
 	vexe := os.executable()
 	parent_dir := os.dir(vexe)
@@ -1145,7 +1168,7 @@ fn (v &V) test_v() {
 	}
 	bmark.stop()
 	println( bmark.total_message('building examples') )
-	v.test_vget()
+	test_vget()
 	if failed {
 		exit(1)
 	}

--- a/compiler/vhelp.v
+++ b/compiler/vhelp.v
@@ -46,6 +46,7 @@ Options/commands:
                     Example: -cflags `sdl2-config --cflags`
   -debug            Keep the generated C file for debugging in program.tmp.c even after compilation.
   -shared           Build a shared library.
+  -stats            Show additional stats when compiling/running tests. Try `v -stats test .`
   -g                Show v line numbers in backtraces. Implies -debug.
   -obf              Obfuscate the resulting binary.
   -show_c_cmd       Print the full C compilation command and how much time it took.
@@ -58,6 +59,7 @@ Options/commands:
   symlink           Useful on unix systems. Symlinks the current V executable to /usr/local/bin/v, so that V is globally available.
   install <module>  Install a user module from https://vpm.vlang.io/.
   test v            Run all V test files, and compile all V examples.
+  test folder/      Run all V test files located in the folder and its subfolders. You can also pass individual _test.v files too.
   fmt               Run vfmt to format the source code. [wip]
   doc               Run vdoc over the source code and produce documentation. [wip]
   translate         Translates C to V. [wip, will be available in V 0.3]

--- a/compiler/vtest.v
+++ b/compiler/vtest.v
@@ -124,6 +124,9 @@ fn stable_example(example string, index int, arr []string) bool {
 fn v_test_v(args_before_test string){
 	vexe := os.executable()
 	parent_dir := os.dir(vexe)
+	// Changing the current directory is needed for some of the compiler tests,
+	// compiler/tests/local_test.v and compiler/tests/repl/repl_test.v
+	os.chdir( parent_dir )
 	if !os.dir_exists(parent_dir + '/vlib') {
 		println('vlib/ is missing, it must be next to the V executable')
 		exit(1)

--- a/compiler/vtest.v
+++ b/compiler/vtest.v
@@ -1,0 +1,179 @@
+module main
+
+import (
+	os
+	term
+	benchmark
+)
+
+struct TestSession {
+mut:
+	files []string
+	vexe string
+	vargs string
+	failed bool
+	benchmark benchmark.Benchmark
+}
+
+fn new_test_sesion(vargs string) TestSession {
+	return TestSession{
+		vexe: os.executable()
+		vargs: vargs
+	}
+}
+
+fn test_v() {
+	args := os.args
+	if args.last() == 'test' {
+		println('Usage:')
+		println('   A)')
+		println('      v test v  : run all v tests and build all the examples')
+		println('   B)')
+		println('      v test folder/ : run all v tests in the given folder.')
+		println('      v -stats test folder/ : the same, but print more stats.')
+		println('   C)')
+		println('      v test file_test.v : run test functions in a given test file.')
+		println('      v -stats test file_test.v : as above, but with more stats.')
+		println('   NB: you can also give many and mixed folder/ file_test.v arguments after test.')
+		println('')
+		return
+	}
+
+	args_string := args.right(1).join(' ')
+	args_before := args_string.all_before('test ')
+	args_after  := args_string.all_after('test ')
+
+	if args_after == 'v' {
+		v_test_v(args_before)
+		return
+	}
+
+	mut ts := new_test_sesion(args_before)
+	for targ in args_after.split(' ') {
+		if os.file_exists(targ) && targ.ends_with('_test.v') {
+			ts.files << targ
+			continue
+		}
+		if os.dir_exists(targ) {
+
+			ts.files << os.walk_ext( targ.trim_right(os.PathSeparator), '_test.v')
+			continue
+		}
+		println('Unrecognized test file $targ .')
+	}
+
+	println('Testing...')
+	ts.test()
+	println('----------------------------------------------------------------------------')
+	println( ts.benchmark.total_message('running V _test.v files') )
+	if ts.failed {
+		exit(1)
+	}
+}
+
+fn (ts mut TestSession) test() {
+	ok   := term.ok_message('OK')
+	fail := term.fail_message('FAIL')
+	cmd_needs_quoting := (os.user_os() == 'windows')
+	show_stats := '-stats' in ts.vargs.split(' ')
+	ts.benchmark = benchmark.new_benchmark()
+	for dot_relative_file in ts.files {
+		relative_file := dot_relative_file.replace('./', '')
+		file := os.realpath( relative_file )
+		tmpc_filepath := file.replace('.v', '.tmp.c')
+
+		mut cmd := '"$ts.vexe" $ts.vargs "$file"'
+		if cmd_needs_quoting { cmd = '"$cmd"' }
+
+		ts.benchmark.step()
+		if show_stats {
+			println('-------------------------------------------------')
+			status := os.system(cmd)
+			if status == 0 {
+				ts.benchmark.ok()
+			}else{
+				ts.benchmark.fail()
+				ts.failed = true
+				continue
+			}
+		}else{
+			r := os.exec(cmd) or {
+				ts.benchmark.fail()
+				ts.failed = true
+				println(ts.benchmark.step_message('$relative_file $fail'))
+				continue
+			}
+			if r.exit_code != 0 {
+				ts.benchmark.fail()
+				ts.failed = true
+				println(ts.benchmark.step_message('$relative_file $fail\n`$file`\n (\n$r.output\n)'))
+			} else {
+				ts.benchmark.ok()
+				println(ts.benchmark.step_message('$relative_file $ok'))
+			}
+		}
+		os.rm( tmpc_filepath )
+	}
+	ts.benchmark.stop()
+}
+
+fn stable_example(example string, index int, arr []string) bool {
+	return !example.contains('vweb')
+}
+
+fn v_test_v(args_before_test string){
+	vexe := os.executable()
+	parent_dir := os.dir(vexe)
+	if !os.dir_exists(parent_dir + '/vlib') {
+		println('vlib/ is missing, it must be next to the V executable')
+		exit(1)
+	}
+	if !os.dir_exists(parent_dir + '/compiler') {
+		println('compiler/ is missing, it must be next to the V executable')
+		exit(1)
+	}
+	// Make sure v.c can be compiled without warnings
+	$if mac {
+		os.system('$vexe -o v.c compiler')
+		if os.system('cc -Werror v.c') != 0 {
+			println('cc failed to build v.c without warnings')
+			exit(1)
+		}
+		println('v.c can be compiled without warnings. This is good :)')
+	}
+	//////////////////////////////////////////////////////////////
+	println('Testing...')
+	mut ts := new_test_sesion( args_before_test )
+	ts.files << os.walk_ext(parent_dir, '_test.v')
+	ts.test()
+	println( ts.benchmark.total_message('running V tests') )
+	//////////////////////////////////////////////////////////////
+	println('\nBuilding examples...')
+	mut es := new_test_sesion( args_before_test )
+	es.files << os.walk_ext(parent_dir+'/examples','.v').filter(stable_example)
+	es.test()
+	println( es.benchmark.total_message('building examples') )
+	//////////////////////////////////////////////////////////////
+
+	test_vget()
+
+	if ts.failed || es.failed {
+		exit(1)
+	}
+}
+
+fn test_vget() {
+	/*
+	vexe := os.executable()
+	ret := os.system('$vexe install nedpals.args')
+	if ret != 0 {
+		println('failed to run v install')
+		exit(1)
+	}
+	if !os.file_exists(v_modules_path + '/nedpals/args') {
+		println('v failed to install a test module')
+		exit(1)
+	}
+	println('vget is OK')
+	*/
+}


### PR DESCRIPTION
With this PR:
```shell
0[01:02:21] /v/nv $ ./v test  vlib/json/ vlib/net/ vlib/os/os_test.v
Testing...
    80 ms | vlib/json/json_test.v OK
    93 ms | vlib/net/urllib/urllib_test.v OK
    85 ms | vlib/net/socket_test.v OK
    82 ms | vlib/net/socket_udp_test.v OK
    92 ms | vlib/os/os_test.v OK
----------------------------------------------------------------------------
   433 ms | <=== total time spent running V _test.v files
 ok, fail, total =     5,     0,     5
0[01:02:30] /v/nv $
```

Also:
```shell
0[01:05:46] /v/nv $ ./v -stats test  vlib/json/ vlib/net/ vlib/os/os_test.v
Testing...
-------------------------------------------------
compilation took: 145ms
running tests in: /v/nv/vlib/json/json_test.v
   OK     0 ms |  7 asserts | test_parse_user()
   OK     0 ms |  1 assert  | test_encode_user()
   OK     0 ms |  2 asserts | test_raw_json_field()
          0 ms | <=== total time spent running V tests in "json_test.v"
 ok, fail, total =    10,     0,    10
-------------------------------------------------
compilation took: 151ms
running tests in: /v/nv/vlib/net/urllib/urllib_test.v
   OK     1 ms |  2 asserts | test_net_urllib()
          1 ms | <=== total time spent running V tests in "urllib_test.v"
 ok, fail, total =     2,     0,     2
-------------------------------------------------
compilation took: 122ms
running tests in: /v/nv/vlib/net/socket_test.v
   OK     0 ms |  1 assert  | test_socket()
          0 ms | <=== total time spent running V tests in "socket_test.v"
 ok, fail, total =     1,     0,     1
-------------------------------------------------
compilation took: 120ms
running tests in: /v/nv/vlib/net/socket_udp_test.v
          0 ms | NO asserts | test_udp_server()
          0 ms | <=== total time spent running V tests in "socket_udp_test.v"
 ok, fail, total =     0,     0,     0
-------------------------------------------------
compilation took: 110ms
running tests in: /v/nv/vlib/os/os_test.v
   OK     0 ms |  3 asserts | test_setenv()
   OK     0 ms |  2 asserts | test_create_and_delete_folder()
   OK     0 ms |  1 assert  | test_dir()
   OK     0 ms |  1 assert  | test_unsetenv()
   OK     0 ms |  2 asserts | test_write_and_read_string_to_file()
          0 ms | <=== total time spent running V tests in "os_test.v"
 ok, fail, total =     9,     0,     9
----------------------------------------------------------------------------
   682 ms | <=== total time spent running V _test.v files
 ok, fail, total =     5,     0,     5
0[01:05:49] /v/nv $
```

Most conveniently, you can also do:
```shell
0[01:06:32] /v/nv/vlib/net $ /v/nv/v test .
Testing...
    98 ms | urllib/urllib_test.v OK
    82 ms | socket_test.v OK
    82 ms | socket_udp_test.v OK
----------------------------------------------------------------------------
   262 ms | <=== total time spent running V _test.v files
 ok, fail, total =     3,     0,     3
0[01:06:42] /v/nv/vlib/net $
```