### PR TITLE
Compiler: Add C headers to avoid undefined symbol error in FreeBSD

### DIFF
--- a/compiler/cheaders.v
+++ b/compiler/cheaders.v
@@ -38,6 +38,11 @@ CommonCHeaders = '
 #include <sys/wait.h> // os__wait uses wait on nix
 #endif
 
+#ifdef __FreeBSD__
+#include <sys/types.h>
+#include <sys/wait.h> // os__wait uses wait on nix
+#endif
+
 #define EMPTY_STRUCT_DECLARATION
 #define EMPTY_STRUCT_INITIALIZATION 0
 // Due to a tcc bug, the length of an array needs to be specified, but GCC crashes if it is...


### PR DESCRIPTION
To avoid these errors when compiling the current version of V under FreeBSD
/usr/bin/ld: error: undefined symbol: WIFEXITED
/usr/bin/ld: error: undefined symbol: WEXITSTATUS
/usr/bin/ld: error: undefined symbol: WIFSIGNALED
/usr/bin/ld: error: undefined symbol: WTERMSIG