### PR TITLE
compiler: allow multi returns to be used with high order fn & add decl tests

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -937,7 +937,9 @@ fn (p mut Parser) get_type() string {
 		}
 		p.check(.rpar)
 		// p.inside_tuple = false
-		return '_V_MulRet_' + types.join('_V_').replace('*', '_PTR_')
+		typ = '_V_MulRet_' + types.join('_V_').replace('*', '_PTR_')
+		p.register_multi_return_stuct(typ)
+		return typ
 	}
 	// fn type
 	if p.tok == .func {

--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -937,8 +937,7 @@ fn (p mut Parser) get_type() string {
 		}
 		p.check(.rpar)
 		// p.inside_tuple = false
-		typ = '_V_MulRet_' + types.join('_V_').replace('*', '_PTR_')
-		p.register_multi_return_stuct(typ)
+		typ = p.register_multi_return_stuct(types)
 		return typ
 	}
 	// fn type

--- a/compiler/tests/fn_test.v
+++ b/compiler/tests/fn_test.v
@@ -107,6 +107,14 @@ fn high_fn(f fn(int) int) {
 
 }
 
+fn high_fn_array(f fn(a []int) []int) {
+
+}
+
+fn high_fn_multi_return(a int, b fn (c []int, d []string) ([]int, []string)) {
+
+}
+
 fn test_fns() {
 	// no asserts for now, just test function declarations above
 }


### PR DESCRIPTION
compiler: allow multi returns to be used with high order fn & add decl tests