### PR TITLE
compiler: fix 'v -debug examples/hello_world.v'

### DIFF
--- a/compiler/module_header.v
+++ b/compiler/module_header.v
@@ -44,7 +44,7 @@ fn (f &Fn) v_definition() string {
 		if i == 0 && f.is_method { // skip the receiver
 			continue
 		}	
-		typ := v_type_str(arg.typ)
+		typ := v_type_str(arg.typ).replace('*', '&')
 		if arg.name == '' {
 			sb.write(typ)
 		}	 else {
@@ -56,7 +56,7 @@ fn (f &Fn) v_definition() string {
 	}
 	sb.write(')')
 	if f.typ != 'void' {
-		typ := v_type_str(f.typ)
+		typ := v_type_str(f.typ).replace('*', '&')
 		sb.write(' ')
 		sb.write(typ)
 		sb.writeln(' ')
@@ -170,7 +170,7 @@ fn (v &V) generate_vh() {
 				if field.access_mod == .public {
 					continue
 				}	
-				field_type := v_type_str(field.typ)
+				field_type := v_type_str(field.typ).replace('*', '&')
 				file.writeln('\t$field.name $field_type')
 			}	
 			//file.writeln('pub:')
@@ -179,7 +179,7 @@ fn (v &V) generate_vh() {
 				if field.access_mod == .private {
 					continue
 				}	
-				field_type := v_type_str(field.typ)
+				field_type := v_type_str(field.typ).replace('*', '&')
 				public_str += '\t$field.name $field_type\n'
 				//file.writeln('\t$field.name $field_type')
 			}	

--- a/vlib/builtin/hashmap.v
+++ b/vlib/builtin/hashmap.v
@@ -14,8 +14,6 @@ module builtin
 	the performance gains are basically non-existent.
 */
 
-import math
-
 struct hashmap {
 	cap          int
 	keys         []string
@@ -52,7 +50,7 @@ fn new_hashmap(planned_nr_items int) hashmap {
 }	
 
 fn (m mut hashmap) set(key string, val int) {
-	hash := int(math.abs(key.hash()))
+	mut hash := int(b_fabs( key.hash() ))
 	idx := hash % m.cap
 	if m.table[idx].key.len != 0 {
 		//println('\nset() idx=$idx key="$key" hash="$hash" val=$val')
@@ -69,7 +67,7 @@ fn (m mut hashmap) set(key string, val int) {
 }	
 
 fn (m mut hashmap) get(key string) int {
-	hash := int(math.abs(key.hash()))
+	hash := int(b_fabs( key.hash() ))
 	idx := hash % m.cap
 	mut e := &m.table[idx]
 	for e.next != 0 { // todo unsafe {
@@ -81,4 +79,4 @@ fn (m mut hashmap) get(key string) int {
 	return e.val
 }
 
-
+[inline] fn b_fabs(v int) f64 { return if v < 0 { -v } else { v } }

--- a/vlib/builtin/hashmap_test.v
+++ b/vlib/builtin/hashmap_test.v
@@ -1,5 +1,4 @@
 import rand
-import strings
 
 fn test_random_strings() {
 	mut m := new_hashmap(1000)


### PR DESCRIPTION
With this PR:
```shell
0[13:28:11] /v/nv $ 
0[13:28:11] /v/nv $ bat /v/rebuild_vmodules.sh
───────┬──────────────────────────────────────────────────────────────────────────────
       │ File: /v/rebuild_vmodules.sh
───────┼──────────────────────────────────────────────────────────────────────────────
   1   │ #!/bin/bash
   2   │ rm -rf ~/.vmodules/ ;
   3   │ mkdir -p ~/.vmodules/vlib/ ;
   4   │ ## for mod in builtin os strings math math time term rand  ; do
   5   │ for mod in builtin strings ; do
   6   │    ./v -debug -o build module "vlib/$mod"
   7   │ done
───────┴──────────────────────────────────────────────────────────────────────────────
0[13:28:11] /v/nv $ export VFLAGS='-cc gcc' ; \
time ( /v/rebuild_vmodules.sh > /dev/null 2>&1 ) ; \
du -s ~/.vmodules/ ;

real    0m0.367s
user    0m0.317s
sys     0m0.047s
464     /home/delian/.vmodules/
0[13:28:16] /v/nv $ time ./v run examples/hello_world.v
Hello, World!

real    0m0.289s
user    0m0.258s
sys     0m0.028s
0[13:28:19] /v/nv $ time ./v -debug run examples/hello_world.v
C compiler=gcc
all .v files:
["/home/delian/.vmodules/builtin.vh", "examples/hello_world.v"]
adding strings.o
Hello, World!

real    0m0.091s
user    0m0.071s
sys     0m0.019s
0[13:28:23] /v/nv $
```