### PR TITLE
array: delete double declarations of data types in args of filter and reduce

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -293,7 +293,6 @@ pub fn (a mut []int) sort() {
 
 // Looking for an array index based on value.
 // If there is, it will return the index and if not, it will return `-1`
-// TODO: Implement for all types
 pub fn (a []string) index(v string) int {
 	for i := 0; i < a.len; i++ {
 		if a[i] == v {
@@ -344,7 +343,7 @@ pub fn (a  []string) filter(predicate fn(p_val string, p_i int, p_arr []string) 
 	return res
 }
 
-pub fn (a []int) filter(predicate fn(p_val int, p_i int, p_arr []int) bool) []int
+pub fn (a []int) filter(predicate fn(p_val, p_i int, p_arr []int) bool) []int
 {
 	mut res := []int
 	for i := 0; i < a.len; i++  {
@@ -357,13 +356,9 @@ pub fn (a []int) filter(predicate fn(p_val int, p_i int, p_arr []int) bool) []in
 
 ////////////// REDUCE //////////////
 
-// method executes a reducer function (that you provide) on each element of the array, 
+// Executes a reducer function (that you provide) on each element of the array, 
 // resulting in a single output value.
-pub fn (a []int) reduce(
-	iter fn (accum int, curr int) int,
-	accum_start int
-) int
-{
+pub fn (a []int) reduce(iter fn (accum, curr int) int, accum_start int) int {
 	mut _accum := 0
 	_accum = accum_start
 	for i := 0; i < a.len; i++ {


### PR DESCRIPTION
In this PR:
- Delete double declarations of data types in params
- Fix some doc comment
- Delete unnecessary comment