### PR TITLE
01:18: fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,9 @@ ifdef WIN32
 	./v0.exe -o v.exe compiler
 	rm -f v0.exe
 else
-	$(CC) -std=gnu11 -w -o v vc/v.c -lm
-	@(VC_V=`./v version | cut -f 3 -d " "`; \
-	V_V=`git rev-parse --short HEAD`; \
-	if [ $$VC_V != $$V_V ]; then \
-		echo "Self rebuild ($$VC_V => $$V_V)"; \
-		./v -o v compiler; \
-	fi)
+	$(CC) -std=gnu11 -w -o v vc/v.c -lm && \
+	./v -o v2 compiler && \
+	mv -f v2 v
 endif
 	rm -rf vc/
 	@echo "V has been successfully built"


### PR DESCRIPTION
# Makefile: always rebuild V locally on Linux also

The Makefile works differently on Windows and Linux: in the Linux instructions, it would only build the local changes if there had been a recent commit. (I need to rebuild my local changes before commiting them to a repo.)

What I've done in this PR is make the Linux only instructions work the same way as the Windows only instructions.