### PR TITLE
Fix v command to accept '.v' as valid file

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -899,7 +899,7 @@ fn new_v(args[]string) &V {
 		exit(1)
 	}
 	// No -o provided? foo.v => foo
-	if out_name == 'a.out' && dir.ends_with('.v') {
+	if out_name == 'a.out' && dir.ends_with('.v') && dir != '.v' {
 		out_name = dir.left(dir.len - 2)
 	}
 	// if we are in `/foo` and run `v .`, the executable should be `foo`


### PR DESCRIPTION
When passing '.v' as a file name to compile / run, V gets confused and uses an emptry string as output filename, which the compiler doesn't seem to like. Dunno why.

See this for more info: https://github.com/vlang/v/issues/2164

Fixes #2164?