### PR TITLE
03:38: Fix Multiline strings with CRLF endings for Linux

### DIFF
--- a/compiler/parser.v
+++ b/compiler/parser.v
@@ -2814,9 +2814,7 @@ fn (p mut Parser) char_expr() {
 fn format_str(_str string) string {
 	// TODO don't call replace 3 times for every string, do this in scanner.v
 	mut str := _str.replace('"', '\\"')
-	$if windows {
-		str = str.replace('\r\n', '\\n')
-	}
+	str = str.replace('\r\n', '\\n')
 	str = str.replace('\n', '\\n')
 	return str
 }


### PR DESCRIPTION
With multiline strings, if they have CRLF in them, they weren't being parsed to \n, unless the current platform was Windows.

I changed this, so that it always converts CRLF -> \n

Fixes #1553 