### PR TITLE
20:17: Fix Scanner.debug_tokens skipping first char

### DIFF
--- a/compiler/scanner.v
+++ b/compiler/scanner.v
@@ -722,6 +722,7 @@ fn (s &Scanner) expect(want string, start_pos int) bool {
 
 fn (s mut Scanner) debug_tokens() {
 	s.pos = 0
+	s.started = false
 	s.debug = true
 
 	fname := s.file_path.all_after(os.PathSeparator)


### PR DESCRIPTION
This small PR fixes the output of debug_tokens: it was skipping the first character when doing the dump.