### PR TITLE
Detect Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,13 @@ ifneq ($(filter $(_SYS),MSYS MinGW),)
 WIN32 := 1
 endif
 
-_SYS := $(shell uname -o)
+_SYS := $(shell uname)
 ifeq ($(_SYS),GNU/Linux)
 LINUX := 1
+else
+	ifeq ($(_SYS), Darwin)
+	MAC := 1
+	endif
 endif
 
 all: fresh_vc fresh_tcc


### PR DESCRIPTION
Detect Mac system. Removes `-o` option from `uname` since this causes error to compile on Mac.