### PR TITLE
compiler: cleanup v.pref.building_v flag setting in compiler/main.v

### DIFF
--- a/compiler/main.v
+++ b/compiler/main.v
@@ -57,7 +57,6 @@ fn main() {
 	}
 	// Construct the V object from command line arguments
 	mut v := compiler.new_v(args)
-	v.pref.building_v = true
 	if v.pref.is_verbose {
 		println(args)
 	}


### PR DESCRIPTION
That is not needed anymore, now that the compiler is now in vlib/compiler not vlib/vcompiler.