### PR TITLE
readline: basic mac and windows version using os.getline to read

### DIFF
--- a/vlib/readline/readline.v
+++ b/vlib/readline/readline.v
@@ -1,0 +1,42 @@
+// Copyright (c) 2019 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+// Will serve as more advanced input method
+// Based on the work of https://github.com/AmokHuginnsson/replxx
+
+module readline
+
+// Linux
+// Used to change the terminal options
+struct Termios {
+mut:
+  c_iflag int
+  c_oflag int
+  c_cflag int
+  c_lflag int
+  c_cc [12]int //NCCS == 12. Cant use the defined value here
+}
+
+// Linux
+// Used to collect the screen information
+struct Winsize {
+  ws_row u16
+  ws_col u16
+  ws_xpixel u16
+  ws_ypixel u16
+}
+
+struct Readline {
+mut:
+  is_raw bool
+  orig_termios Termios // Linux
+  current ustring // Line being edited
+  cursor int // Cursor position
+  overwrite bool
+  cursor_row_offset int
+  prompt string
+  previous_lines []ustring
+  search_index int
+  is_tty bool
+}

--- a/vlib/readline/readline_lin.v
+++ b/vlib/readline/readline_lin.v
@@ -13,39 +13,6 @@ import term
 #include <termios.h>
 #include <sys/ioctl.h>
 
-// Used to change the terminal options
-struct Termios {
-mut:
-  c_iflag int
-  c_oflag int
-  c_cflag int
-  c_lflag int
-  c_cc [12]int //NCCS == 12. Cant use the defined value here
-}
-
-// Used to collect the screen information
-struct Winsize {
-  ws_row u16
-  ws_col u16
-  ws_xpixel u16
-  ws_ypixel u16
-}
-
-struct Readline {
-mut:
-  is_raw bool
-  orig_termios Termios
-  current ustring // Line being edited
-  cursor int // Cursor position
-  overwrite bool
-  cursor_row_offset int
-  prompt string
-  previous_lines []ustring
-  search_index int
-  is_tty bool
-}
-
-
 // Defines actions to execute
 enum Action {
   eof
@@ -104,7 +71,7 @@ fn (r mut Readline) enable_raw_mode2() {
 }
 
 // Reset back the terminal to its default value
-pub fn (r mut Readline) disable_raw_mode() {
+fn (r mut Readline) disable_raw_mode() {
   if r.is_raw {
     C.tcsetattr(0, C.TCSADRAIN, &r.orig_termios)
     r.is_raw = false

--- a/vlib/readline/readline_mac.v
+++ b/vlib/readline/readline_mac.v
@@ -1,0 +1,66 @@
+// Copyright (c) 2019 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+// Mac version
+// Need to be implemented
+// Will serve as more advanced input method
+// Based on the work of https://github.com/AmokHuginnsson/replxx
+
+module readline
+
+import os
+
+// Only use standard os.get_line
+// Need implementation for readline capabilities
+pub fn (r mut Readline) read_line_utf8(prompt string) ?ustring {
+  r.current = ''.ustring()
+  r.cursor = 0
+  r.prompt = prompt
+  r.search_index = 0
+  if r.previous_lines.len <= 1 {
+    r.previous_lines << ''.ustring()
+    r.previous_lines << ''.ustring()
+  }
+  else {
+    r.previous_lines[0] = ''.ustring()
+  }
+
+  print(r.prompt)
+  r.current = os.get_line().ustring()
+
+  r.previous_lines[0] = ''.ustring()
+  r.search_index = 0
+  if r.current.s == '' {
+    return error('empty line')
+  }
+  return r.current
+}
+
+// Returns the string from the utf8 ustring
+pub fn (r mut Readline) read_line(prompt string) ?string {
+  s := r.read_line_utf8(prompt) or {
+    return error(err)
+  }
+  return s.s
+}
+
+// Standalone function without persistent functionnalities (eg: history)
+// Returns utf8 based ustring
+pub fn read_line_utf8(prompt string) ?ustring {
+  mut r := Readline{}
+  s := r.read_line_utf8(prompt) or {
+    return error(err)
+  }
+  return s
+}
+
+// Standalone function without persistent functionnalities (eg: history)
+// Return string from utf8 ustring
+pub fn read_line(prompt string) ?string {
+  mut r := Readline{}
+  s := r.read_line(prompt) or {
+    return error(err)
+  }
+  return s
+}

--- a/vlib/readline/readline_win.v
+++ b/vlib/readline/readline_win.v
@@ -1,0 +1,66 @@
+// Copyright (c) 2019 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+// Windows version
+// Need to be implemented
+// Will serve as more advanced input method
+// Based on the work of https://github.com/AmokHuginnsson/replxx
+
+module readline
+
+import os
+
+// Only use standard os.get_line
+// Need implementation for readline capabilities
+pub fn (r mut Readline) read_line_utf8(prompt string) ?ustring {
+  r.current = ''.ustring()
+  r.cursor = 0
+  r.prompt = prompt
+  r.search_index = 0
+  if r.previous_lines.len <= 1 {
+    r.previous_lines << ''.ustring()
+    r.previous_lines << ''.ustring()
+  }
+  else {
+    r.previous_lines[0] = ''.ustring()
+  }
+
+  print(r.prompt)
+  r.current = os.get_line().ustring()
+
+  r.previous_lines[0] = ''.ustring()
+  r.search_index = 0
+  if r.current.s == '' {
+    return error('empty line')
+  }
+  return r.current
+}
+
+// Returns the string from the utf8 ustring
+pub fn (r mut Readline) read_line(prompt string) ?string {
+  s := r.read_line_utf8(prompt) or {
+    return error(err)
+  }
+  return s.s
+}
+
+// Standalone function without persistent functionnalities (eg: history)
+// Returns utf8 based ustring
+pub fn read_line_utf8(prompt string) ?ustring {
+  mut r := Readline{}
+  s := r.read_line_utf8(prompt) or {
+    return error(err)
+  }
+  return s
+}
+
+// Standalone function without persistent functionnalities (eg: history)
+// Return string from utf8 ustring
+pub fn read_line(prompt string) ?string {
+  mut r := Readline{}
+  s := r.read_line(prompt) or {
+    return error(err)
+  }
+  return s
+}


### PR DESCRIPTION
**Additions:**
Basic function for mac and windows.
Is only a get_line wrapper.
`disable_raw_mode` now private as `enable_raw_mode` is too.

**Notes:**
I would be grateful if someone can test copying linux version on mac to see if it works as is.
Would also be good if someone can port on windows.
Needed in order to use readline in the REPL as is part of compiler core thus need to compile on all OS.