### PR TITLE
Enhance non-pub struct fields error message

### DIFF
--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -2189,7 +2189,13 @@ struct $f.parent_fn {
 		if field.access_mod == .private && !p.builtin_mod && !p.pref.translated && p.mod != typ.mod && p.file_path_id != 'vgen' {
 			// println('$typ.name :: $field.name ')
 			// println(field.access_mod)
-			p.error_with_token_index('cannot refer to unexported field `$struct_field` (type `$typ.name`)', fname_tidx)
+			p.error_with_token_index('cannot refer to unexported field `$struct_field` (type `$typ.name`)\n' +
+					'declare the field with `pub:`
+struct $typ.name {
+  pub:
+	$struct_field $field.typ
+}
+', fname_tidx)
 		}
 		p.gen(dot + struct_field)
 		p.next()


### PR DESCRIPTION
Current error message when modifying a non-pub struct field is :

>mainnk_v.v:86:20: cannot refer to unexported field `r` (type `NkColorF`)
>   85|                 C.nk_layout_row_dynamic(ctx, 25, 1)
>   86|                 bg.r = C.nk_propertyf(ctx, "#R:", 0, bg.r, 1.0, 0.01, 0.005)

This trivial patch changes it to :

>mainnk_v.v:86:20: cannot refer to unexported field `r` (type `NkColorF`)
>declare the field with `pub:`
>struct NkColorF {
>  mut:
>	r f32
>}
>   85|                 C.nk_layout_row_dynamic(ctx, 25, 1)
>   86|                 bg.r = C.nk_propertyf(ctx, "#R:", 0, bg.r, 1.0, 0.01, 0.005)