### PR TITLE
Add getters for complex numbers

### DIFF
--- a/vlib/math/complex/complex.v
+++ b/vlib/math/complex/complex.v
@@ -7,6 +7,7 @@ module complex
 import math 
 
 struct Complex {
+pub:
 	re f64
 	im f64
 }

--- a/vlib/math/complex/complex_test.v
+++ b/vlib/math/complex/complex_test.v
@@ -781,3 +781,9 @@ fn test_complex_acsch() {
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
 	assert result.str().eq(c2.str())
 }
+
+fn test_complex_re_im() {
+	c := cmplx.complex(2.1, 9.05)
+	assert c.re == 2.1
+	assert c.im == 9.05
+}


### PR DESCRIPTION
Added getters for `re`/`im` part of complex numbers. (Fixes #2344)

```v
c := cmplx.complex(5,2)
re := c.real()
im := c.imag()
```
