### PR TITLE
docs: update syntax highlighting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ glfw dependency will be removed soon.
 
 [examples/hello_v_js.v](examples/hello_v_js.v):
 
-```
+```v
 fn main() {
         for i := 0; i < 3; i++ {
                 println('Hello from V.js')


### PR DESCRIPTION
Seeing that V now has syntax highlighting on GitHub, I noticed that it wasn't using it in the README.md, so I decided to update it!