### PR TITLE
repl: readline line editing

### DIFF
--- a/vlib/compiler/repl.v
+++ b/vlib/compiler/repl.v
@@ -4,8 +4,11 @@
 
 module compiler
 
-import os
-import term
+import (
+	os
+	term
+	readline
+)
 
 struct Repl {
 mut:
@@ -81,22 +84,27 @@ pub fn run_repl() []string {
 		os.rm(temp_file.left(temp_file.len - 2))
 	}
 	mut r := Repl{}
+	mut readline := readline.Readline{}
 	vexe := os.args[0]
+	mut prompt := '>>> '
 	for {
 		if r.indent == 0 {
-			print('>>> ')
+			prompt = '>>> '
 		}
 		else {
-			print('... ')
+			prompt = '... '
 		}
-		r.line = os.get_raw_line()
-		if r.line.trim_space() == '' && r.line.ends_with('\n') {
+		mut line := readline.read_line(prompt) or {
+				break
+		}
+		if line.trim_space() == '' && line.ends_with('\n') {
 			continue
 		}
-		r.line = r.line.trim_space()
-		if r.line.len == -1 || r.line == '' || r.line == 'exit' {
+		line = line.trim_space()
+		if line.len <= -1 || line == '' || line == 'exit' {
 			break
 		}
+		r.line = line
 		if r.line == '\n' {
 			continue
 		}

--- a/vlib/readline/readline_js.v
+++ b/vlib/readline/readline_js.v
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 
-// Windows version
+// JS version
 // Need to be implemented
 // Will serve as more advanced input method
 // Based on the work of https://github.com/AmokHuginnsson/replxx

--- a/vlib/readline/readline_lin.v
+++ b/vlib/readline/readline_lin.v
@@ -149,7 +149,7 @@ pub fn read_line(prompt string) ?string {
   return s
 }
 
-fn (r Readline) analyse(c byte) Action {
+fn (r Readline) analyse(c int) Action {
   switch c {
     case `\0`: return Action.eof
     case 0x3 : return Action.eof // End of Text
@@ -295,7 +295,9 @@ fn (r mut Readline) refresh_line() {
 fn (r mut Readline) eof() bool {
   r.previous_lines.insert(1, r.current)
   r.cursor = r.current.len
-  r.refresh_line()
+  if r.is_tty {
+    r.refresh_line()
+  }
   return true
 }
 
@@ -337,8 +339,8 @@ fn (r mut Readline) commit_line() bool {
   a := '\n'.ustring()
   r.current = r.current + a
   r.cursor = r.current.len
-  r.refresh_line()
   if r.is_tty {
+    r.refresh_line()
     println('')
   }
   return true

--- a/vlib/readline/readline_mac.v
+++ b/vlib/readline/readline_mac.v
@@ -27,8 +27,11 @@ pub fn (r mut Readline) read_line_utf8(prompt string) ?ustring {
   }
 
   print(r.prompt)
-  r.current = os.get_line().ustring()
+  line := os.get_raw_line()
 
+  if line.len >= 0 {
+    r.current = line.ustring()
+  }
   r.previous_lines[0] = ''.ustring()
   r.search_index = 0
   if r.current.s == '' {


### PR DESCRIPTION
**Additions:**
Readline powered REPL line reading. Allows to use arrows to edit or history or previous lines.
`get_raw_line` on readline for win and mac version.
Fix special character reading in readline
JS backend version of readline
Removed trying to convert empty string to ustring in readline on Mac (Was resulting in panic)

**Note:**
Solves the problem long awaited to edit line in REPL
Fixes #2355 
Fixes #390

**Example:**
![Peek 2019-10-15 21-02](https://user-images.githubusercontent.com/30901439/66861643-accd2c80-ef8f-11e9-93c1-e91ba25f7db3.gif)
