### PR TITLE
windows: escape os.exec('"$vexec"')

### DIFF
--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -983,7 +983,7 @@ pub fn install_v(args[]string) {
 	if true {
 		//println('Building vget...')
 		os.chdir(vroot + '/tools')
-		vget_compilation := os.exec('$vexec -o $vget vget.v') or {
+		vget_compilation := os.exec('"$vexec" -o $vget vget.v') or {
 			verror(err)
 			return
 		}

--- a/vlib/compiler/repl.v
+++ b/vlib/compiler/repl.v
@@ -133,7 +133,7 @@ pub fn run_repl() []string {
 		if r.line.starts_with('print') {
 			source_code := r.functions.join('\n') + r.lines.join('\n') + '\n' + r.line
 			os.write_file(file, source_code)
-			s := os.exec('$vexe run $file -repl') or {
+			s := os.exec('"$vexe" run $file -repl') or {
 				verror(err)
 				return []string
 			}
@@ -152,7 +152,7 @@ pub fn run_repl() []string {
 			}
 			temp_source_code := r.functions.join('\n') + r.lines.join('\n') + '\n' + r.temp_lines.join('\n') + '\n' + temp_line
 			os.write_file(temp_file, temp_source_code)
-			s := os.exec('$vexe run $temp_file -repl') or {
+			s := os.exec('"$vexe" run $temp_file -repl') or {
 				verror(err)
 				return []string
 			}

--- a/vlib/compiler/tests/repl/repl_test.v
+++ b/vlib/compiler/tests/repl/repl_test.v
@@ -7,12 +7,12 @@ fn test_the_v_compiler_can_be_invoked() {
 	println('vexecutable: $vexec')
 	assert vexec != ''
 
-	vcmd := '$vexec --version'
+	vcmd := '"$vexec" --version'
 	r := os.exec(vcmd) or { panic(err) }
 	//println('"$vcmd" exit_code: $r.exit_code | output: $r.output')
 	assert r.exit_code == 0
 
-	vcmd_error := '$vexec nonexisting.v'
+	vcmd_error := '"$vexec" nonexisting.v'
 	r_error := os.exec(vcmd_error) or { panic(err) }
 	//println('"$vcmd_error" exit_code: $r_error.exit_code | output: $r_error.output')
 	assert r_error.exit_code == 1

--- a/vlib/compiler/tests/repl/runner/runner.v
+++ b/vlib/compiler/tests/repl/runner/runner.v
@@ -48,7 +48,7 @@ pub fn run_repl_file(wd string, vexec string, file string) ?string {
 	input_temporary_filename := 'input_temporary_filename.txt'
 	os.write_file(input_temporary_filename, input)
 
-	r := os.exec('$vexec runrepl < $input_temporary_filename') or {
+	r := os.exec('"$vexec" runrepl < $input_temporary_filename') or {
 		os.rm(input_temporary_filename)
 		return error('Could not execute "$vexec runrepl < $input_temporary_filename" ')
 	}


### PR DESCRIPTION
Tests are passed locally in directory with spaces

