### PR TITLE
readline: fix reading on linux, crash on mac

### DIFF
--- a/vlib/readline/readline_js.v
+++ b/vlib/readline/readline_js.v
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 
-// Windows version
+// JS version
 // Need to be implemented
 // Will serve as more advanced input method
 // Based on the work of https://github.com/AmokHuginnsson/replxx

--- a/vlib/readline/readline_lin.v
+++ b/vlib/readline/readline_lin.v
@@ -149,7 +149,7 @@ pub fn read_line(prompt string) ?string {
   return s
 }
 
-fn (r Readline) analyse(c byte) Action {
+fn (r Readline) analyse(c int) Action {
   switch c {
     case `\0`: return Action.eof
     case 0x3 : return Action.eof // End of Text
@@ -295,7 +295,9 @@ fn (r mut Readline) refresh_line() {
 fn (r mut Readline) eof() bool {
   r.previous_lines.insert(1, r.current)
   r.cursor = r.current.len
-  r.refresh_line()
+  if r.is_tty {
+    r.refresh_line()
+  }
   return true
 }
 
@@ -337,8 +339,8 @@ fn (r mut Readline) commit_line() bool {
   a := '\n'.ustring()
   r.current = r.current + a
   r.cursor = r.current.len
-  r.refresh_line()
   if r.is_tty {
+    r.refresh_line()
     println('')
   }
   return true

--- a/vlib/readline/readline_mac.v
+++ b/vlib/readline/readline_mac.v
@@ -9,9 +9,9 @@
 
 module readline
 
-#include <termios.h>
-
 import os
+
+#include <sys/termios.h>
 
 // Only use standard os.get_line
 // Need implementation for readline capabilities
@@ -29,8 +29,11 @@ pub fn (r mut Readline) read_line_utf8(prompt string) ?ustring {
   }
 
   print(r.prompt)
-  r.current = os.get_line().ustring()
+  line := os.get_raw_line()
 
+  if line.len >= 0 {
+    r.current = line.ustring()
+  }
   r.previous_lines[0] = ''.ustring()
   r.search_index = 0
   if r.current.s == '' {


### PR DESCRIPTION
**Additions:**
get_raw_line on readline for win and mac version
Fix special character reading in readline linux
JS backend version of readline
Removed trying to convert empty string to ustring in readline on Mac (Was resulting in panic)

**Note:**
Adds include for mac, part of a two step PR for readline to be included.
Couldn't compile mac afterwards in one PR #2359