### PR TITLE
repl: add readline for user input

### DIFF
--- a/vlib/compiler/repl.v
+++ b/vlib/compiler/repl.v
@@ -4,8 +4,11 @@
 
 module compiler
 
-import os
-import term
+import (
+	os
+	term
+	readline
+)
 
 struct Repl {
 mut:
@@ -74,6 +77,7 @@ pub fn run_repl() []string {
 	println('Use Ctrl-C or `exit` to exit')
 	file := '.vrepl.v'
 	temp_file := '.vrepl_temp.v'
+	mut prompt := '>>> '
 	defer {
 		os.rm(file)
 		os.rm(temp_file)
@@ -81,22 +85,26 @@ pub fn run_repl() []string {
 		os.rm(temp_file.left(temp_file.len - 2))
 	}
 	mut r := Repl{}
+	mut readline := readline.Readline{}
 	vexe := os.args[0]
 	for {
 		if r.indent == 0 {
-			print('>>> ')
+			prompt = '>>> '
 		}
 		else {
-			print('... ')
+			prompt = '... '
 		}
-		r.line = os.get_raw_line()
-		if r.line.trim_space() == '' && r.line.ends_with('\n') {
-			continue
-		}
-		r.line = r.line.trim_space()
-		if r.line.len == -1 || r.line == '' || r.line == 'exit' {
+		mut line := readline.read_line(prompt) or {
 			break
 		}
+		if line.trim_space() == '' && line.ends_with('\n') {
+			continue
+		}
+		line = line.trim_space()
+		if line.len <= -1 || line == '' || line == 'exit' {
+			break
+		}
+		r.line = line
 		if r.line == '\n' {
 			continue
 		}


### PR DESCRIPTION
**Additions:**
Readline powered REPL line reading. Allows to use arrows to edit or history or previous lines.

**Note**:
Fixes #2355
Fixes #390

**Examples:**
![Peek 2019-10-15 21-02](https://user-images.githubusercontent.com/30901439/66910914-cd3ccb80-f00f-11e9-94ce-a7922e8f9016.gif)
