### PR TITLE
parser: interpolation calling twice fix

### DIFF
--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -2922,7 +2922,9 @@ fn (p mut Parser) string_expr() {
 					if is_array && !has_str_method {
 						p.gen_array_str(typ2)
 					}
-					args = args.all_before_last(val) + '${typ}_str(${val}).len, ${typ}_str(${val}).str'
+					tmp_var := p.get_tmp()
+					p.cgen.insert_before('string $tmp_var = ${typ}_str(${val});')
+					args = args.all_before_last(val) + '${tmp_var}.len, ${tmp_var}.str'
 					format += '%.*s '
 				}
 				else {


### PR DESCRIPTION
if string interpolation needs to call a function, it will cache the
return to .len & .str usage in the generated code

Fixes #2360