### PR TITLE
os: make ls() return an optional

### DIFF
--- a/vlib/compiler/cgen.v
+++ b/vlib/compiler/cgen.v
@@ -250,7 +250,7 @@ fn build_thirdparty_obj_file(path string, moduleflags []CFlag) {
 	}
 	println('$obj_path not found, building it...')
 	parent := os.dir(obj_path)
-	files := os.ls(parent)
+	files := os.ls(parent) or { panic(err) }
 	mut cfiles := ''
 	for file in files {
 		if file.ends_with('.c') {

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -499,7 +499,7 @@ pub fn (v &V) v_files_from_dir(dir string) []string {
 	} else if !os.dir_exists(dir) {
 		verror("$dir isn't a directory")
 	}
-	mut files := os.ls(dir)
+	mut files := os.ls(dir) or { panic(err) }
 	if v.pref.is_verbose {
 		println('v_files_from_dir ("$dir")')
 	}

--- a/vlib/compiler/msvc.v
+++ b/vlib/compiler/msvc.v
@@ -100,7 +100,7 @@ fn find_windows_kit_root(host_arch string) ?WindowsKit {
 
 		// println(kit_lib)
 
-		files := os.ls(kit_lib)
+		files := os.ls(kit_lib) or { panic(err) }
 		mut highest_path := ''
 		mut highest_int := 0
 		for f in files {
@@ -395,7 +395,7 @@ fn build_thirdparty_obj_file_with_msvc(path string, moduleflags []CFlag) {
 
 	println('$obj_path not found, building it (with msvc)...')
 	parent := os.dir(obj_path)
-	files := os.ls(parent)
+	files := os.ls(parent) or { panic(err) }
 
 	mut cfiles := ''
 	for file in files {

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -788,7 +788,7 @@ pub fn walk_ext(path, ext string) []string {
 	if !os.is_dir(path) {
 		return []string
 	}
-	mut files := os.ls(path)
+	mut files := os.ls(path) or { panic(err) }
 	mut res := []string
 	for i, file in files {
 		if file.starts_with('.') {

--- a/vlib/os/os_nix.v
+++ b/vlib/os/os_nix.v
@@ -25,13 +25,11 @@ pub fn get_error_msg(code int) string {
 	return tos(_ptr_text, vstrlen(_ptr_text))
 }
 
-pub fn ls(path string) []string {
+pub fn ls(path string) ?[]string {
 	mut res := []string
 	dir := C.opendir(path.str)
 	if isnil(dir) {
-		println('ls() couldnt open dir "$path"')
-		print_c_errno()
-		return res
+		return error('ls() couldnt open dir "$path"')
 	}
 	mut ent := &C.dirent{!}
 	for {

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -37,7 +37,7 @@ fn test_create_and_delete_folder() {
   folder := './test1'
   os.mkdir(folder)
 
-  folder_contents := os.ls(folder)
+  folder_contents := os.ls(folder) or { panic(err) }
   assert folder_contents.len == 0
 
   os.rmdir(folder)

--- a/vlib/os/os_win.v
+++ b/vlib/os/os_win.v
@@ -51,7 +51,7 @@ fn init_os_args(argc int, argv &byteptr) []string {
 }
 
 
-pub fn ls(path string) []string {
+pub fn ls(path string) ?[]string {
 	mut find_file_data := Win32finddata{}
 	mut dir_files := []string
 	// We can also check if the handle is valid. but using dir_exists instead
@@ -61,8 +61,7 @@ pub fn ls(path string) []string {
 	// }
 	// C.FindClose(h_find_dir)
 	if !dir_exists(path) {
-		println('ls() couldnt open dir "$path" (does not exist).')
-		return dir_files
+		return error('ls() couldnt open dir "$path"')
 	}
 	// NOTE: Should eventually have path struct & os dependant path seperator (eg os.PATH_SEPERATOR)
 	// we need to add files to path eg. c:\windows\*.dll or :\windows\*

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -194,7 +194,7 @@ fn (ctx mut Context) parse_form(s string) {
 }
 
 fn (ctx mut Context) scan_static_directory(directory_path, mount_path string) {
-	files := os.ls(directory_path)
+	files := os.ls(directory_path) or { panic(err) }
 	if files.len > 0 {
 		for file in files {
 			mut ext := ''


### PR DESCRIPTION
Makes `os.ls()` return an optional.

This enables us to catch errors when the directory is non-existent.
The previous behavior was to print an error, and return an empty array. Which made an empty directory indistinguishable from a non-existent one.