### PR TITLE
compiler: print relative file paths for files in the current directory

### DIFF
--- a/vlib/compiler/compile_errors.v
+++ b/vlib/compiler/compile_errors.v
@@ -133,6 +133,10 @@ fn (s &Scanner) error_with_col(msg string, col int) {
 
 fn (s &Scanner) get_error_filepath() string {
 	if s.should_print_relative_paths_on_error {
+		workdir := os.getwd() + os.path_separator
+		if s.file_path.starts_with(workdir) {
+			return s.file_path.replace( workdir, '') 
+		}
 		return s.file_path
 	}
 	return os.realpath( s.file_path )


### PR DESCRIPTION
With this PR:
```shell
0[08:32:40] /v/nv/vlib/compiler $
0[08:32:41] /v/nv/vlib/compiler $ /v/nv/v ../../v.v
0[08:32:42] /v/nv/vlib/compiler $ jed cheaders.v
0[08:32:49] /v/nv/vlib/compiler $ /v/nv/v ../../v.v
cheaders.v:3:25: undefined: `this_is_an_explicit_error`
    2|

    3| this_is_an_explicit_error

                               ^
    4|

    5| const (

1[08:32:51] /v/nv/vlib/compiler $
```
