### PR TITLE
Add raw_name to var so we can get it in jsgen.v

### DIFF
--- a/vlib/compiler/fn.v
+++ b/vlib/compiler/fn.v
@@ -1034,8 +1034,8 @@ fn (p mut Parser) fn_register_vargs_stuct(f &Fn, typ string, values []string) st
 	} else {
 		p.table.register_type2(varg_type)
 	}
-	p.table.add_field(vargs_struct, 'len', 'int', false, '', .public)
-	p.table.add_field(vargs_struct, 'args[$values.len]', typ, false, '', .public)
+	p.table.add_field(vargs_struct, 'len', 'len', 'int', false, '', .public)
+	p.table.add_field(vargs_struct, 'args[$values.len]', 'args[$values.len]', typ, false, '', .public)
 	return vargs_struct
 }
 
@@ -1079,7 +1079,7 @@ fn (p mut Parser) register_multi_return_stuct(types []string) string {
 		mod: p.mod
 	})
 	for i, t in typ.replace('_V_MulRet_', '').replace('_PTR_', '*').split('_V_') {
-		p.table.add_field(typ, 'var_$i', t, false, '', .public)
+		p.table.add_field(typ, 'var_$i', 'var_$i', t, false, '', .public)
 	}
 	p.cgen.typedefs << 'typedef struct $typ $typ;'
 	return typ

--- a/vlib/compiler/jsgen.v
+++ b/vlib/compiler/jsgen.v
@@ -88,7 +88,7 @@ string res = tos2("");
 		name := if field.attr.starts_with('json:') {
 			field.attr.right(5)
 		} else {
-			field.name
+			field.raw_name
 		}
 		field_type := p.table.find_type(field.typ)
 		_typ := field.typ.replace('*', '')

--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -765,7 +765,8 @@ fn (p mut Parser) struct_decl() {
 		// }
 		// Check if reserved name
 		field_name_token_idx := p.cur_tok_index()
-		field_name := if name != 'Option' { p.table.var_cgen_name(p.check_name()) } else { p.check_name() }
+		raw_field_name := p.check_name()
+		field_name := if name != 'Option' { p.table.var_cgen_name(raw_field_name) } else { raw_field_name }
 		// Check dups
 		if field_name in names {
 			p.error('duplicate field `$field_name`')
@@ -820,7 +821,7 @@ fn (p mut Parser) struct_decl() {
 
 		did_gen_something = true
 		if p.first_pass() {
-			p.table.add_field(typ.name, field_name, field_type, is_mut, attr, access_mod)
+			p.table.add_field(typ.name, field_name, raw_field_name, field_type, is_mut, attr, access_mod)
 		}
 		p.fgenln('')
 	}
@@ -828,7 +829,7 @@ fn (p mut Parser) struct_decl() {
 	if !is_c {
 		if !did_gen_something {
 			if p.first_pass() {
-				p.table.add_field(typ.name, '', 'EMPTY_STRUCT_DECLARATION', false, '', .private)
+				p.table.add_field(typ.name, '', '', 'EMPTY_STRUCT_DECLARATION', false, '', .private)
 			}
 		}
 	}

--- a/vlib/compiler/table.v
+++ b/vlib/compiler/table.v
@@ -84,6 +84,7 @@ struct Var {
 mut:
 	typ             string
 	name            string
+	raw_name        string
 	idx             int // index in the local_vars array
 	is_arg          bool
 	is_const        bool
@@ -433,7 +434,7 @@ fn (t mut Table) rewrite_type(typ Type) {
 	t.typesmap[typ.name]  = typ
 }
 
-fn (table mut Table) add_field(type_name, field_name, field_type string, is_mut bool, attr string, access_mod AccessMod) {
+fn (table mut Table) add_field(type_name, field_name, raw_field_name, field_type string, is_mut bool, attr string, access_mod AccessMod) {
 	if type_name == '' {
 		print_backtrace()
 		verror('add_field: empty type')
@@ -441,6 +442,7 @@ fn (table mut Table) add_field(type_name, field_name, field_type string, is_mut 
 	mut t := table.typesmap[type_name]
 	t.fields << Var {
 		name: field_name
+		raw_name: raw_field_name
 		typ: field_type
 		is_mut: is_mut
 		attr: attr


### PR DESCRIPTION
Change function `add_field` in table.v so that it can receive `raw_field_name`.
Raw_field_name is just a raw name because default `field_name`s in structures are formatted so that there are no collisions with C keywords.
Fixes https://github.com/vlang/v/issues/2424