### PR TITLE
compiler: add missing header file to compile vc on OpenBSD

### DIFF
--- a/vlib/compiler/cheaders.v
+++ b/vlib/compiler/cheaders.v
@@ -48,6 +48,12 @@ CommonCHeaders = '
 #include <sys/wait.h> // os__wait uses wait on nix
 #endif
 
+#ifdef __OpenBSD__
+#include <sys/types.h>
+#include <sys/resource.h>
+#include <sys/wait.h> // os__wait uses wait on nix
+#endif
+
 #define EMPTY_STRUCT_DECLARATION
 #define EMPTY_STRUCT_INITIALIZATION 0
 // Due to a tcc bug, the length of an array needs to be specified, but GCC crashes if it is...


### PR DESCRIPTION
Add missing header file for generating  working vc.c on OpenBSD.