### PR TITLE
test: add assert_eq and assert_ne functions

### DIFF
--- a/vlib/builtin/test.v
+++ b/vlib/builtin/test.v
@@ -1,0 +1,23 @@
+// Copyright (c) 2019 V lang team. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+module builtin
+
+import test
+
+// Checks whether two elements are equal
+pub fn assert_eq<T>(left, right T) {
+    test.assert_eq(left, right)
+}
+
+// Checks whether two integers are not equal
+pub fn assert_ne<T>(left T, right T) {
+    test.assert_ne(left, right)
+}
+
+// Checks whether provided value is set to true
+// It returns value to be compatible with builtin `assert` statement
+pub fn assert_true(val bool) bool {
+    return test.assert_true(val)
+}

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -235,7 +235,9 @@ pub fn (v mut V) compile() {
 		// `/usr/bin/ld: multiple definition of 'total_m'`
 		$if !js {
 			cgen.genln('int g_test_oks = 0;')
+			cgen.genln('void __increase_g_test_oks() { g_test_oks += 1; }')
 			cgen.genln('int g_test_fails = 0;')
+			cgen.genln('void __increase_g_test_fails() { g_test_fails += 1; }')
 		}
 		if imports_json {
 			cgen.genln('

--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -3905,20 +3905,13 @@ fn (p mut Parser) assert_statement() {
 	tmp := p.get_tmp()
 	p.gen('bool $tmp = ')
 	p.check_types(p.bool_expression(), 'bool')
-	// TODO print "expected:  got" for failed tests
 	filename := cescaped_path(p.file_path_id)
 	p.genln(';
 \n
 
-if (!$tmp) {
-  println(tos2((byte *)"\\x1B[31mFAILED: $p.cur_fn.name() in $filename:$p.scanner.line_nr\\x1B[0m"));
-  g_test_fails++;
+if (!assert_true($tmp)) {
+  eprintln(tos2((byte *)"\\x1B[31mFAILED: $p.cur_fn.name() in $filename:$p.scanner.line_nr\\x1B[0m"));
   return;
-  // TODO
-  // Maybe print all vars in a test function if it fails?
-} else {
-  g_test_oks++;
-  //println(tos2((byte *)"\\x1B[32mPASSED: $p.cur_fn.name()\\x1B[0m"));
 }
 
 ')

--- a/vlib/test/test.v
+++ b/vlib/test/test.v
@@ -1,0 +1,141 @@
+// Copyright (c) 2019 V lang team. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+module test
+
+import term
+
+
+// Checks whether two values are equal
+pub fn assert_eq<T>(left, right T) {
+    if left == right {
+        C.__increase_g_test_oks()
+        return
+    }
+    
+    eprintln(assert_eq_fail_msg(left.str(), right.str()))
+    C.__increase_g_test_fails()
+    
+    // Panic will print backtrace, so user'll be able to see where
+    // exactly assert happened.
+    panic("")
+}
+
+// Checks whether two values are not equal
+pub fn assert_ne<T>(left T, right T) {
+    if left != right {
+        C.__increase_g_test_oks()
+        return
+    }
+    
+    eprintln(assert_ne_fail_msg(left.str(), right.str()))
+    C.__increase_g_test_fails()
+    
+    panic("")
+}
+
+// Checks whether provided value is set to true
+// This functions exists for support of builtin assert keyword
+pub fn assert_true(val bool) bool {
+    assert_eq(true, val)
+    return true
+}
+
+// Builds a colored diff between two strings
+fn build_diff(left_input string, right_input string) string {
+    left := unescape_newline(left_input)
+    right := unescape_newline(right_input)
+
+    mut min_length := 0
+    if left.len <= right.len {
+        min_length = left.len
+    } else {
+        min_length = right.len
+    }
+
+    mut left_diff := ""
+    mut right_diff := ""
+    mut i := 0
+
+    for i < min_length {
+        if left[i] == right[i] {
+            left_diff += left[i].str()
+            right_diff += right[i].str()
+            i += 1
+            continue
+        }
+
+        mut left_current_diff := ""
+        mut right_current_diff := ""
+
+        for i < min_length && left[i] != right[i] {
+            left_current_diff += left[i].str()
+            right_current_diff += right[i].str()
+            i += 1
+        }
+
+        left_diff += term.green(left_current_diff)
+        right_diff += term.red(right_current_diff)
+    }
+
+    if left.len > right.len {
+        left_diff += term.green(left.substr(right.len, left.len))
+    } else if right.len > left.len {
+        right_diff += term.red(right.substr(left.len, right.len))
+    }
+    
+    mut diff_msg := "Left:  `$left_diff`" + NEWLINE_SEPARATOR
+    diff_msg += "Right: `$right_diff`" + NEWLINE_SEPARATOR
+
+    return diff_msg
+}
+
+fn assertion_failure_msg() string {
+    fail_msg_prefix := term.red("Assertion failure:") + NEWLINE_SEPARATOR
+    return fail_msg_prefix
+}
+
+fn assert_eq_fail_msg(left string, right string) string {
+    mut message := assertion_failure_msg()
+
+    message += build_diff(left, right)
+    
+    return message
+}
+
+fn assert_ne_fail_msg(left string, right string) string {
+    mut message := assertion_failure_msg()
+
+    message += "Equal values in assert_ne: $left == $right" + NEWLINE_SEPARATOR
+    
+    return message
+}
+
+fn assert_bool_fail_msg(expected bool, got bool) string {
+    mut message := assertion_failure_msg()
+
+    message += "Expected " + term.green(expected.str()) + ", got " + term.red(got.str()) + NEWLINE_SEPARATOR
+
+    return message
+}
+
+fn assert_bool(expected bool, got bool) {
+    if expected != got {
+        eprintln(assert_bool_fail_msg(expected, got))
+        C.__increase_g_test_fails()
+        
+        panic("")
+    }
+    C.__increase_g_test_oks()
+}
+
+// Replaces \n in string with \\n
+fn unescape_newline(input string) string {
+    return input.split('\n').join('\\n')
+}
+
+const (
+    // TODO should be OS-independent
+    NEWLINE_SEPARATOR = "\n"
+)

--- a/vlib/test/test_test.v
+++ b/vlib/test/test_test.v
@@ -1,0 +1,35 @@
+// Copyright (c) 2019 V lang team. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+import (
+    test
+    term
+)
+
+fn test_asserts() {
+    test.assert_true(true)
+
+    // test.assert_eq(1, 1)
+
+    test.assert_ne("abc", "abc")
+
+    test.assert_true(true)
+}
+
+fn test_unescape_newline() {
+    value := "1000\n2000"
+
+    test.assert_eq(test.unescape_newline(value), "1000\\n2000")
+}
+
+fn test_build() {
+    left := "1000\n1000"
+    right := "1320\n1000"
+
+    mut expected_msg := ""
+    expected_msg += "Left:  `1" + term.green("00") + "0\\n1000`" + test.NEWLINE_SEPARATOR
+    expected_msg += "Right: `1" + term.red("32") + "0\\n1000`" + test.NEWLINE_SEPARATOR
+
+    test.assert_eq(expected_msg, test.build_diff(left, right))
+}


### PR DESCRIPTION
**Warning:** This PR may (for some reason I don't understand) break the compiler, so try to test it yourself before actual merge. Detailed description of that is in the bottom of the PR description.

This PR introduces `assert_eq` and `assert_ne` functions as they implemented in [vtest](https://github.com/popzxc/vtest)

Also, `assert` keyword is adapted to use `assert_eq` (through non-generic `assert_true` proxy).

Key moments as Q/A:

- *Why not `assert_eq` and `assert_ne` keywords?*
  Current implementation of `assert` generates a raw C code. `assert_eq` and `assert_ne` are generic. I found no easy way to call a generic function from C.
  However, those functions call `print_backtrace` so user will be able to see where exactly assertion failed.
- *Then why do we need `assert` to be a keyword?*
  For backward compatibility I guess. I didn't want to break anything already built.
- *What were you talking about in the disclaimer above?*
  Well, for some reason I started getting weird compile errors associated with generic functions. And they were different depending on what I tried to do (`make` / `./v v.v` / `./v test .`) and didn't seem related to any changes introduced by me.
  Examples:

```sh
make
rm -rf vc/
git clone --depth 1 --quiet https://github.com/vlang/vc
rm -rf /var/tmp/tcc/
git clone --depth 1 --quiet https://github.com/vlang/tccbin /var/tmp/tcc
cc -std=gnu11 -w -o v vc/v.c  -lm
Self rebuild (f7c00b8 => 8a31ee4)
tcc: error: undefined symbol '__increase_g_test_oks'
tcc: error: undefined symbol '__increase_g_test_fails'
V error: C error. This should never happen. Please create a GitHub issue: https://github.com/vlang/v/issues/new/choose
```

```sh
vlib/compiler/tests/generic_test.v`
 (
vlib/compiler/tests/generic_test.v:5:8: the letter `T` is reserved for type parameters
    4| 

    5| fn sum<T>(l []T, nil T) T {

              ^
    6|     mut r := nil

    7|     for e in l {
)
```

```sh
vlib/test/test_test.v:32:16: undefined symbol: `expected_msg`
   31|     expected_msg += "Left:  `1" + term.green("00") + "0\\n1000`" + test.NEWLINE_SEPARATOR

   32|     expected_msg += "Right: `1" + term.red("32") + "0\\n1000`" + test.NEWLINE_SEPARATOR

                      ^
   33| 

   34|     test.assert_eq(expected_msg, test.build_diff(left, right))
)
```

I really don't know what causes this (I can't imagine how could my changes affect `generic_test.v` for example), but my weekend is over and I have no time to work on this anymore.

Feel free to do anything you want with that PR :)