### PR TITLE
2321: const declarations should be order independent

### DIFF
--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -534,6 +534,21 @@ fn (p mut Parser) const_decl() {
 		if p.first_pass() {
 			p.table.register_const(name, typ, p.mod)
 		}
+		// Check to see if this constant exists, and is void. If so, try and get the type again:
+		for { // TODO: Find out how the error handling, and use it here instead of the for/break hack...
+			my_const := p.v.table.find_const(name) or {
+				break
+			} 
+			if my_const.typ == 'void' {
+				for i, v in p.v.table.consts {
+					if v.name == name {
+						p.v.table.consts[i].typ = typ
+						break
+					}
+				}
+			}
+			break
+		}
 		if p.pass == .main && !p.cgen.nogen {
 			// TODO hack
 			// cur_line has const's value right now. if it's just a number, then optimize generation:

--- a/vlib/compiler/tests/const_test.v
+++ b/vlib/compiler/tests/const_test.v
@@ -1,0 +1,10 @@
+const (
+	// c = a // TODO
+	a = b
+	b = 1
+)
+
+fn test_const() {
+	assert a == 1
+	// assert c == 1 // TODO: This will not build yet
+}


### PR DESCRIPTION
If type of a const can't be inferred on the first pass, try to get the type on the second pass.

Partially fixes #1400

(See ``const_test.v`` for example of what's not working yet)
