### PR TITLE
compiler: support for 'enum Color {red = 31 yellow green blue}' .

### DIFF
--- a/vlib/compiler/enum.v
+++ b/vlib/compiler/enum.v
@@ -22,6 +22,18 @@ fn (p mut Parser) enum_decl(_enum_name string) {
 		fields << field
 		p.fgenln('')
 		name := '${mod_gen_name(p.mod)}__${enum_name}_$field'
+		if p.tok == .assign {
+			mut enum_assign_tidx := p.cur_tok_index()
+			if p.peek() == .number {
+				p.next()
+				val = p.lit.int()
+				p.next()
+			}else{
+				p.next()
+				enum_assign_tidx = p.cur_tok_index()
+				p.error_with_token_index('only numbers are allowed in enum initializations', enum_assign_tidx)
+			}			
+		}
 		if p.pass == .main {
 			p.cgen.consts << '#define $name $val'
 		}


### PR DESCRIPTION
This PR makes the following program possible:
```v
enum Color {
   red=31
   yellow
   green
   blue
}

fn main(){
  c := Color.green
  println(c)
}
```
... which prints 33 .