### PR TITLE
1956: Minor syntax fix in parser

### DIFF
--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -531,10 +531,7 @@ fn (p mut Parser) const_decl() {
 			p.table.register_const(name, typ, p.mod)
 		}
 		// Check to see if this constant exists, and is void. If so, try and get the type again:
-		for { // TODO: Find out how the error handling, and use it here instead of the for/break hack...
-			my_const := p.v.table.find_const(name) or {
-				break
-			} 
+		if my_const := p.v.table.find_const(name) {
 			if my_const.typ == 'void' {
 				for i, v in p.v.table.consts {
 					if v.name == name {
@@ -543,7 +540,6 @@ fn (p mut Parser) const_decl() {
 					}
 				}
 			}
-			break
 		}
 		if p.pass == .main && !p.cgen.nogen {
 			// TODO hack


### PR DESCRIPTION
Change the for/break syntax hack in the PR from the other day.
