### PR TITLE
examples: use BYTE.is_letter()

### DIFF
--- a/examples/word_counter/word_counter.v
+++ b/examples/word_counter/word_counter.v
@@ -61,19 +61,13 @@ fn filter_word(word string) string {
 		return ''
 	}
 	mut i := 0
-	for i < word.len && !is_letter(word[i]) {
+	for i < word.len && !word[i].is_letter() {
 		i++
 	}
 	start := i
-	for i < word.len && is_letter(word[i]) {
+	for i < word.len && word[i].is_letter() {
 		i++
 	}
 	end := i
 	return word.substr(start, end)
 }
-
-// TODO remove once it's possible to call word[i].is_letter()
-fn is_letter(c byte) bool {
-	return c.is_letter()
-}
-


### PR DESCRIPTION
The current version of `word_counter.v` uses a custom function of `is_letter()`, but this function does now exist, so this is no longer necessary.

It is only a small change, but I think it's important that the examples show the correct use of built in functions.