### PR TITLE
23:59 Fix poorly formated text block during javascript code generation.

### DIFF
--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -253,7 +253,7 @@ pub fn (v mut V) compile() {
 		cgen.genln('#define DEBUG_ALLOC 1')
 	}
 	//cgen.genln('/*================================== FNS =================================*/')
-	cgen.genln('this line will be replaced with definitions')
+	cgen.genln('// this line will be replaced with definitions')
 	mut defs_pos := cgen.lines.len - 1
 	if defs_pos == -1 {
 		defs_pos = 0


### PR DESCRIPTION
This small fix resolves a tiny occurrence of the text: `this line will be replaced with definitions`
at the top of the generated JS file. This ideally should be a comment -at least - in the  form
`// this line will be replaced with definitions`. 

Ways to reproduce: Create any V program and generate JS output using the commands `v -o test.js test.v`
The error may not arise from a simple Hello world program,  however, fairly complex examples may have this error

Actual  example : -> [hello world](https://github.com/TheBeachMaster/v-lang/blob/master/helloworld/hello.v) 