### PR TITLE
tetris.v: minor User Interface improvements

### DIFF
--- a/examples/tetris/tetris.v
+++ b/examples/tetris/tetris.v
@@ -21,6 +21,7 @@ const (
 	WinHeight = BlockSize * FieldHeight
 	TimerPeriod = 250 // ms
 	TextSize = 12
+	LimitThickness = 3
 )
 
 const (
@@ -80,6 +81,9 @@ const (
 		gx.rgb(170, 85, 0),     // brown longest
 		gx.rgb(0, 170, 170),    // unused ?
 	]
+
+	BackgroundColor = gx.rgb(235, 235, 235)
+	UIColor = gx.rgb(240, 0, 0)
 )
 
 // TODO: type Tetro [TetroSize]struct{ x, y int }
@@ -319,23 +323,35 @@ fn (g &Game) draw_field() {
 	}
 }
 
-fn (g mut Game) draw_score() {
-	if g.font_loaded {
+fn (g mut Game) draw_ui() {
+	if g.font_loaded {WinHeight / 2 + 2 * TextSize
 		g.ft.draw_text(1, 2, 'score: ' + g.score.str(), text_cfg)
 		if g.state == .gameover {
+			g.gg.draw_rect(0, WinHeight / 2 - TextSize, WinWidth,
+			 								5 * TextSize, UIColor)
 			g.ft.draw_text(1, WinHeight / 2 + 0 * TextSize, 'Game Over', text_cfg)
 			g.ft.draw_text(1, WinHeight / 2 + 2 * TextSize, 'SPACE to restart', text_cfg)
 		} else if g.state == .paused {
+			g.gg.draw_rect(0, WinHeight / 2 - TextSize, WinWidth,
+										5 * TextSize, UIColor)
 			g.ft.draw_text(1, WinHeight / 2 + 0 * TextSize, 'Game Paused', text_cfg)
 			g.ft.draw_text(1, WinHeight / 2 + 2 * TextSize, 'SPACE to resume', text_cfg)
 		}
 	}
+
+	g.gg.draw_rect(0, BlockSize, WinWidth, LimitThickness, UIColor)
+
+}
+
+fn (g &Game) draw_background() {
+	g.gg.draw_rect(0, 0, WinWidth, WinHeight, BackgroundColor)
 }
 
 fn (g mut Game) draw_scene() {
+	g.draw_background()
 	g.draw_tetro()
 	g.draw_field()
-	g.draw_score()
+	g.draw_ui()
 }
 
 fn parse_binary_tetro(t_ int) []Block {

--- a/examples/tetris/tetris.v
+++ b/examples/tetris/tetris.v
@@ -83,7 +83,6 @@ const (
 	]
 
 	BackgroundColor = gx.White
-	ClearColor = gx.rgb(230, 230, 230)
 	UIColor = gx.Red
 )
 
@@ -145,7 +144,7 @@ fn main() {
 	game.init_game()
 	game.gg.window.onkeydown(key_down)
 	go game.run() // Run the game loop in a new thread
-	gg.clear(ClearColor)
+	gg.clear(BackgroundColor)
 	// Try to load font
 	game.ft = freetype.new_context(gg.Cfg{
 			width: WinWidth
@@ -156,7 +155,7 @@ fn main() {
 	})
 	game.font_loaded = (game.ft != 0 )
 	for {
-		gg.clear(ClearColor)
+		gg.clear(BackgroundColor)
 		game.draw_scene()
 		game.gg.render()
 		if game.gg.window.should_close() {
@@ -344,12 +343,7 @@ fn (g mut Game) draw_ui() {
 
 }
 
-fn (g &Game) draw_background() {
-	g.gg.draw_rect(0, 0, WinWidth, WinHeight, BackgroundColor)
-}
-
 fn (g mut Game) draw_scene() {
-	g.draw_background()
 	g.draw_tetro()
 	g.draw_field()
 	g.draw_ui()

--- a/examples/tetris/tetris.v
+++ b/examples/tetris/tetris.v
@@ -82,8 +82,9 @@ const (
 		gx.rgb(0, 170, 170),    // unused ?
 	]
 
-	BackgroundColor = gx.rgb(235, 235, 235)
-	UIColor = gx.rgb(240, 0, 0)
+	BackgroundColor = gx.White
+	ClearColor = gx.rgb(230, 230, 230)
+	UIColor = gx.Red
 )
 
 // TODO: type Tetro [TetroSize]struct{ x, y int }
@@ -144,7 +145,7 @@ fn main() {
 	game.init_game()
 	game.gg.window.onkeydown(key_down)
 	go game.run() // Run the game loop in a new thread
-	gg.clear(gx.White)
+	gg.clear(ClearColor)
 	// Try to load font
 	game.ft = freetype.new_context(gg.Cfg{
 			width: WinWidth
@@ -155,7 +156,7 @@ fn main() {
 	})
 	game.font_loaded = (game.ft != 0 )
 	for {
-		gg.clear(gx.White)
+		gg.clear(ClearColor)
 		game.draw_scene()
 		game.gg.render()
 		if game.gg.window.should_close() {


### PR DESCRIPTION
I've improved the user interface of the tetris example. These are the changes I've done:

- I've added a gray (almost white, but less saturated) background to make it less eye straining. This also allows to differentiate the play area from the rest of the window when the user resizes it.
- I've added an upper bar that shows where the limit is, the player can see when he's going to lose clearer.
- I've added a background color to the pause and gameover texts.

This image resumes all the changes:
![Screenshot from 2019-10-22 19-46-22](https://user-images.githubusercontent.com/26823024/67314514-0f30aa80-f505-11e9-839c-d49f624bedd3.png)
