### PR TITLE
gg: fix clear function

### DIFF
--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -38,7 +38,7 @@ pub:
 	height    int
 	use_ortho bool
 	retina    bool
-	
+
 	font_size int
 	font_path string
 	create_window bool
@@ -113,7 +113,7 @@ pub fn new_context(cfg Cfg) &GG {
 		vao: vao
 		vbo: vbo
 		window: window
-	
+
 		// /line_vao: gl.gen_vertex_array()
 		// /line_vbo: gl.gen_buffer()
 		//text_ctx: new_context_text(cfg, scale),
@@ -136,8 +136,8 @@ pub fn (gg &GG) render_loop() bool {
 */
 
 pub fn clear(color gx.Color) {
+	gl.clear_color(color.r, color.g, color.b, 255)
 	gl.clear()
-	gl.clear_color(255, 255, 255, 255)
 }
 
 pub fn (gg &GG) render() {
@@ -437,4 +437,3 @@ pub fn (c &GG) draw_empty_rect(x, y, w, h int, color gx.Color) {
 	c.draw_line_c(x, y + h, x + w, y + h, color)
 	c.draw_line_c(x + w, y, x + w, y + h, color)
 }
-


### PR DESCRIPTION
While working on #2496 I found that the 'clear' function of `gg` always cleared the screen white, no matter the color you passed as argument.

I found that clear wasn't actually using the color parameter, but instead it always passed `(255, 255, 255, 255)` to the `gl` clear function. Also, `clear_color` should be called before `clear`; first set the buffer color, and then call the clear function that uses that buffer. It still works if you call it after `clear`, you would just be updating the buffer of the next frame instead of the current, I don't believe that's the intended behaviour though.

After fixing it, I've correctly passed all the tests and compiled V a couple of times without running into any issue.

By the way, the PR default text is outdated, it encourages to use `./v -o v compiler` and `make test` instead of `v v.v` and `v test v`.

Thanks!