### PR TITLE
compiler: cgen - fix typo. dependency was spelled wrong

### DIFF
--- a/vlib/compiler/cgen.v
+++ b/vlib/compiler/cgen.v
@@ -361,7 +361,7 @@ fn sort_structs(types []Type) []Type {
 	// sort graph
 	dep_graph_sorted := dep_graph.resolve()
 	if !dep_graph_sorted.acyclic {
-		verror('cgen.sort_structs(): the following structs form a dependancy cycle:\n' +
+		verror('cgen.sort_structs(): the following structs form a dependency cycle:\n' +
 			dep_graph_sorted.display_cycles() +
 			'\nyou can solve this by making one or both of the dependant struct fields references, eg: field &MyStruct' +
 			'\nif you feel this is an error, please create a new issue here: https://github.com/vlang/v/issues and tag @joe-conigliaro')


### PR DESCRIPTION
compiler: cgen - fix typo. dependency was spelled wrong