### PR TITLE
os: make Result public again

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -326,7 +326,7 @@ fn pclose(f *C.FILE) int {
 	}
 }
 
-struct Result {
+pub struct Result {
 pub:
 	exit_code int
 	output string


### PR DESCRIPTION
This PR makes `os.Result` public again, after the recent change that made all structs private by default.