### PR TITLE
Add fibonnaci example to gitignore

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -9,3 +9,4 @@
 /spectral
 /database/mysql
 /hello_v_js
+/fibonacci


### PR DESCRIPTION
After running ``v test v``,  a 'fibonnaci' executable file is left in the examples folder, that isn't in the .gitignore. This PR fixes that.