### PR TITLE
0723: parser: fix incorrect unused var message

### DIFF
--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -2622,6 +2622,7 @@ fn (p mut Parser) assoc() string {
 		p.error('unknown variable `$name`')
 		exit(1)
 	}
+	p.mark_var_used(var)
 	p.check(.pipe)
 	p.gen('($var.typ){')
 	mut fields := []string// track the fields user is setting, the rest will be copied from the old object


### PR DESCRIPTION
Fixes the incorrect message returned in this case:

fn get_st_3(s string) MyStruct {
    r := new_st(s)
    return {r | str2: "t"} // <- `r` unused
}