### PR TITLE
Implement sync.new_mutex and sync.new_waitgroup .

### DIFF
--- a/examples/news_fetcher.v
+++ b/examples/news_fetcher.v
@@ -17,10 +17,10 @@ struct Story {
 
 struct Fetcher {
 mut:
-	mu      sync.Mutex
+	mu      &sync.Mutex
 	ids     []int
 	cursor  int
-	wg		&sync.WaitGroup
+	wg      &sync.WaitGroup
 }
 
 fn (f mut Fetcher) fetch() {
@@ -65,12 +65,15 @@ fn main() {
 		ids = tmp
 	}
 	
-	mut wg := &sync.WaitGroup{}
-	fetcher := &Fetcher{ids: ids, wg: wg} // wg sent via ptr
-	wg.add(ids.len)
+	wg := sync.new_waitgroup()
+	mtx := sync.new_mutex()
+	mut fetcher := &Fetcher{ids: ids}
+	fetcher.mu = &mtx
+	fetcher.wg = &wg
+	fetcher.wg.add(ids.len)
 	for i := 0; i < NR_THREADS; i++ {
 		go fetcher.fetch()
 	}
-	wg.wait()
+	fetcher.wg.wait()
 }
 

--- a/vlib/sync/sync_nix.v
+++ b/vlib/sync/sync_nix.v
@@ -5,8 +5,16 @@
 module sync
 
 #include <pthread.h>
+
+//[init_with=new_mutex] // TODO: implement support for this struct attribute, and disallow Mutex{} from outside the sync.new_mutex() function.
 pub struct Mutex {
 	mutex C.pthread_mutex_t
+}
+
+pub fn new_mutex() Mutex {
+	m := Mutex{}
+	C.pthread_mutex_init( &m.mutex, C.NULL)
+	return m
 }
 
 pub fn (m mut Mutex) lock() {

--- a/vlib/sync/sync_win.v
+++ b/vlib/sync/sync_win.v
@@ -7,6 +7,7 @@ module sync
 // Mutex HANDLE
 type MHANDLE voidptr
 
+//[init_with=new_mutex] // TODO: implement support for this struct attribute, and disallow Mutex{} from outside the sync.new_mutex() function.
 pub struct Mutex {
 mut:
 	mx           MHANDLE    // mutex handle
@@ -37,6 +38,16 @@ const (
 	WAIT_TIMEOUT       = 0x00000102
 	WAIT_FAILED        = 0xFFFFFFFF
 )
+
+pub fn new_mutex() Mutex {
+	m := Mutex{}
+	m.mx = C.CreateMutex(0, false, 0)
+	if isnil(m.mx) {
+		m.state = .broken // handle broken and mutex state are broken
+		return m
+	}
+	return m
+}
 
 pub fn (m mut Mutex) lock() {
 	// if mutex handle not initalized

--- a/vlib/sync/sync_windows.v
+++ b/vlib/sync/sync_windows.v
@@ -40,13 +40,16 @@ const (
 )
 
 pub fn new_mutex() Mutex {
-	m := Mutex{}
-	m.mx = C.CreateMutex(0, false, 0)
-	if isnil(m.mx) {
-		m.state = .broken // handle broken and mutex state are broken
-		return m
+	sm := Mutex{}
+	unsafe {
+		mut m := sm		
+		m.mx = C.CreateMutex(0, false, 0)
+		if isnil(m.mx) {
+			m.state = .broken // handle broken and mutex state are broken
+			return sm
+		}		
+		return sm
 	}
-	return m
 }
 
 pub fn (m mut Mutex) lock() {
@@ -60,9 +63,9 @@ pub fn (m mut Mutex) lock() {
 	}
 	state := C.WaitForSingleObject(m.mx, INFINITE) // infinite wait
 	m.state = match state {
-		WAIT_ABANDONED => { MutexState.abandoned }
-		WAIT_OBJECT_0  => { MutexState.waiting }
-		else           => { MutexState.broken }
+		WAIT_ABANDONED { MutexState.abandoned }
+		WAIT_OBJECT_0  { MutexState.waiting }
+		else           { MutexState.broken }
 	}
 }
 

--- a/vlib/sync/waitgroup.v
+++ b/vlib/sync/waitgroup.v
@@ -4,10 +4,17 @@
 
 module sync
 
+//[init_with=new_waitgroup] // TODO: implement support for init_with struct attribute, and disallow WaitGroup{} from outside the sync.new_waitgroup() function.
 pub struct WaitGroup {
 mut:
 	mu Mutex
 	active int
+}
+
+pub fn new_waitgroup() WaitGroup {
+	mut w := WaitGroup{}
+	w.mu = sync.new_mutex()
+	return w
 }
 
 pub fn (wg mut WaitGroup) add(delta int) {


### PR DESCRIPTION
Use them in examples/news_fetcher.v .
The [init_with=new_mutex] attribute is commented for now.
Close #2537 .