### PR TITLE
compiler: implement error_with_code(s string, code int) .

### DIFF
--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -7,6 +7,7 @@ module builtin
 struct Option {
 	data     [255]byte
 	error    string
+	ecode    int
 	ok       bool
 	is_none  bool
 }
@@ -33,5 +34,13 @@ pub fn error(s string) Option {
 		error: s
 	}
 }
+
+pub fn error_with_code(s string, code int) Option {
+	return Option {
+		error: s
+		ecode: code
+	}
+}
+
 
 

--- a/vlib/compiler/gen_c.v
+++ b/vlib/compiler/gen_c.v
@@ -42,7 +42,14 @@ fn (p mut Parser) gen_var_decl(name string, is_static bool) string {
 			is_mut: false
 			is_used: true
 		})
+		p.register_var(Var {
+			name: 'errcode'
+			typ: 'int'
+			is_mut: false
+			is_used: true
+		})
 		p.genln('string err = $tmp . error;')
+		p.genln('int    errcode = $tmp . ecode;')
 		p.statements()
 		p.genln('$typ $name = *($typ*) $tmp . data;')
 		if !p.returns && p.prev_tok2 != .key_continue && p.prev_tok2 != .key_break {
@@ -114,7 +121,14 @@ fn (p mut Parser) gen_blank_identifier_assign() {
 			is_mut: false
 			is_used: true
 		})
+		p.register_var(Var {
+			name: 'errcode'
+			typ: 'int'
+			is_mut: false
+			is_used: true
+		})
 		p.genln('string err = $tmp . error;')
+		p.genln('int    errcode = $tmp . ecode;')
 		p.statements()
 		p.returns = false
 	} else {

--- a/vlib/compiler/tests/option_test.v
+++ b/vlib/compiler/tests/option_test.v
@@ -1,3 +1,15 @@
+
+fn opt_err_with_code() ?string {return error_with_code('hi',137)}
+fn test_err_with_code(){
+	v := opt_err_with_code() or {
+		assert err == 'hi'
+		assert errcode == 137
+		return
+	}
+	assert false
+	println(v) // suppress not used error
+}
+
 fn opt_err() ?string {return error('hi')}
 
 fn test_err(){


### PR DESCRIPTION
 Make available the integer code as errcode to callers/unwrappers.

With this PR:
```shell
0[21:07:44] /v/newv LINUX $ head /v/newv/vlib/compiler/tests/option_test.v -n 12

fn opt_err_with_code() ?string {return error_with_code('hi',137)}
fn test_err_with_code(){
        v := opt_err_with_code() or {
                assert err == 'hi'
                assert errcode == 137
                return
        }
        assert false
        println(v) // suppress not used error
}

0[21:07:44] /v/newv LINUX $ ./v2 -stats /v/newv/vlib/compiler/tests/option_test.v
compilation took: 100ms
running tests in: /v/newv/vlib/compiler/tests/option_test.v
   OK     0 ms |  2 asserts | test_err_with_code()
   OK     0 ms |  1 assert  | test_err()
hm
yep
   OK     0 ms |  1 assert  | test_option_for_base_type_without_variable()
nice
   OK     0 ms |  1 assert  | test_if_opt()
          0 ms | <=== total time spent running V tests in "option_test.v"
 ok, fail, total =     5,     0,     5
0[21:07:48] /v/newv LINUX $
```

