### PR TITLE
base64: some optimizations

### DIFF
--- a/vlib/encoding/base64/base64.v
+++ b/vlib/encoding/base64/base64.v
@@ -4,7 +4,7 @@
 
 module base64
 
-const (	
+const (
 	Index = [int(0), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	62, 63, 62, 62, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 0, 0, 0,
@@ -12,21 +12,42 @@ const (
 	17, 18, 19, 20, 21, 22, 23, 24, 25, 0, 0, 0, 0, 63, 0, 26, 27, 28, 29,
 	30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
 	47, 48, 49, 50, 51]!!
-	
+
 	EndingTable = [0, 2, 1]
-	EncodingTable = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'	
+	EncodingTable = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
 )
 
+/**
+ * decode - expects a base64 encoded string. Returns its decoded version.
+ * @param data - the encoded input string.
+ * @return the decoded version of the input string data.
+ * NB: if you need to decode many strings repeatedly, take a look at decode_in_buffer too.
+ */
 pub fn decode(data string) string {
 	buffer := malloc( data.len * 3 / 4 )
 	return tos(buffer, decode_in_buffer(data, mut buffer) )
 }
 
+/**
+ * decode - expects a string. Returns its base64 encoded version.
+ * @param data - the input string.
+ * @return the base64 encoded version of the input string. 
+ * NB: base64 encoding returns a string that is ~ 4/3 larger than the input.
+ * NB: if you need to encode many strings repeatedly, take a look at encode_in_buffer too.
+ */
 pub fn encode(data string) string {
 	buffer := malloc( 4 * ((data.len + 2) / 3) )
 	return tos(buffer, encode_in_buffer(data, mut buffer))
 }
 
+/**
+ * decode_in_buffer - expects a string reference, and a buffer in which to store its decoded version.
+ * @param data - a reference/pointer to the input string that will be decoded.
+ * @param buffer - a reference/pointer to the buffer that will hold the result. 
+ * The buffer should be large enough (i.e. 3/4 of the data.len, or larger) to hold the decoded data.
+ * @return the actual size of the decoded data in the buffer.
+ * NB: this function does NOT allocate new memory, and is suitable for handling very large strings.
+ */
 pub fn decode_in_buffer(data &string, buffer mut byteptr) int {
 	mut padding := 0
 	if data.ends_with('=') {
@@ -39,7 +60,7 @@ pub fn decode_in_buffer(data &string, buffer mut byteptr) int {
 	//input_length is the length of meaningful data
 	input_length := data.len - padding
 	output_length := input_length * 3 / 4
-	//////////////////////////////////////////////////
+
 	mut i := 0
 	mut j := 0
 	mut b := &byte(0)
@@ -48,7 +69,7 @@ pub fn decode_in_buffer(data &string, buffer mut byteptr) int {
 		d = byteptr(data.str)
 		b = byteptr(buffer)
 	}
-		
+
 	for i < input_length {
 		mut char_a := 0
 		mut char_b := 0
@@ -70,7 +91,7 @@ pub fn decode_in_buffer(data &string, buffer mut byteptr) int {
 			char_d = Index[d[i]]
 			i++
 		}
-		
+
 		decoded_bytes := (char_a << 18) | (char_b << 12) | (char_c << 6) | (char_d << 0)
 		b[j]   = decoded_bytes >> 16
 		b[j+1] = (decoded_bytes >> 8) & 0xff
@@ -79,23 +100,31 @@ pub fn decode_in_buffer(data &string, buffer mut byteptr) int {
 	}
 	return output_length
 }
-	
+
+/**
+ * encode_in_buffer - expects a string reference, and a buffer in which to store its base64 encoded version.
+ * @param data - a reference/pointer to the input string.
+ * @param buffer - a reference/pointer to the buffer that will hold the result. 
+ * The buffer should be large enough (i.e. 4/3 of the data.len, or larger) to hold the encoded data.
+ * @return the actual size of the encoded data in the buffer.
+ * NB: this function does NOT allocate new memory, and is suitable for handling very large strings.
+ */
 pub fn encode_in_buffer(data &string, buffer mut byteptr) int {
 	input_length := data.len
 	output_length := 4 * ((input_length + 2) / 3)
 
 	mut i := 0
 	mut j := 0
-	
-	mut d      := &byte(0)
-	mut b      := &byte(0)
+
+	mut d	   := &byte(0)
+	mut b	   := &byte(0)
 	mut etable := &byte(0)
 	unsafe{
 		d = &byte(data.str)
 		b = &byte(buffer)
 		etable = &byte(EncodingTable.str)
 	}
-	
+
 	for i < input_length {
 		mut octet_a := 0
 		mut octet_b := 0

--- a/vlib/encoding/base64/base64.v
+++ b/vlib/encoding/base64/base64.v
@@ -14,12 +14,12 @@ const (
 	47, 48, 49, 50, 51]
 )
 
-pub fn decode(data &string) string {
+pub fn decode(data string) string {
 	buffer := malloc( data.len * 3 / 4 )
 	return tos(buffer, decode_in_buffer(data, mut buffer) )
 }
 
-pub fn encode(data &string) string {
+pub fn encode(data string) string {
 	buffer := malloc( 4 * ((data.len + 2) / 3) )
 	return tos(buffer, encode_in_buffer(data, mut buffer))
 }

--- a/vlib/encoding/base64/base64.v
+++ b/vlib/encoding/base64/base64.v
@@ -4,14 +4,17 @@
 
 module base64
 
-const (
-	Index = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+const (	
+	Index = [int(0), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	62, 63, 62, 62, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 0, 0, 0,
 	0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
 	17, 18, 19, 20, 21, 22, 23, 24, 25, 0, 0, 0, 0, 63, 0, 26, 27, 28, 29,
 	30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
-	47, 48, 49, 50, 51]
+	47, 48, 49, 50, 51]!!
+	
+	EndingTable = [0, 2, 1]
+	EncodingTable = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'	
 )
 
 pub fn decode(data string) string {
@@ -45,6 +48,7 @@ pub fn decode_in_buffer(data &string, buffer mut byteptr) int {
 		d = byteptr(data.str)
 		b = byteptr(buffer)
 	}
+		
 	for i < input_length {
 		mut char_a := 0
 		mut char_b := 0
@@ -76,11 +80,6 @@ pub fn decode_in_buffer(data &string, buffer mut byteptr) int {
 	return output_length
 }
 	
-const (
-	EndingTable = [0, 2, 1]
-	EncodingTable = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
-)
-
 pub fn encode_in_buffer(data &string, buffer mut byteptr) int {
 	input_length := data.len
 	output_length := 4 * ((input_length + 2) / 3)

--- a/vlib/encoding/base64/base64_memory_test.v
+++ b/vlib/encoding/base64/base64_memory_test.v
@@ -13,11 +13,14 @@ fn test_long_encoding(){
 	mut s := 0
 	for i := 0; i < repeats; i++ {
 		s_encoded = base64.encode(s_original)
-		s_decoded = base64.decode(s_encoded)
 		s+= s_encoded.len
-		s+= s_decoded.len
 	}
 
+	for i := 0; i < repeats; i++ {
+		s_decoded = base64.decode(s_encoded)
+		s+= s_decoded.len
+	}
+	
 	assert s_encoded.len > s_original.len
 	assert s_original == s_decoded	
 }

--- a/vlib/encoding/base64/base64_memory_test.v
+++ b/vlib/encoding/base64/base64_memory_test.v
@@ -1,8 +1,8 @@
 import encoding.base64
 
 fn test_long_encoding(){
-	repeats := 128
-	input_size := 131072
+	repeats := 1000
+	input_size := 3000
 	
 	s_original := 'a'.repeat(input_size)
 	s_encoded := base64.encode(s_original)

--- a/vlib/encoding/base64/base64_memory_test.v
+++ b/vlib/encoding/base64/base64_memory_test.v
@@ -1,0 +1,23 @@
+import encoding.base64
+
+fn test_long_encoding(){
+	repeats := 256
+	input_size := 131072
+	
+	s_original := 'a'.repeat(input_size)
+	mut s_encoded := base64.encode(s_original)
+	assert s_encoded.len > s_original.len
+	mut s_decoded := base64.decode(s_encoded)
+	assert s_original == s_decoded
+
+	mut s := 0
+	for i := 0; i < repeats; i++ {
+		s_encoded = base64.encode(s_original)
+		s_decoded = base64.decode(s_encoded)
+		s+= s_encoded.len
+		s+= s_decoded.len
+	}
+
+	assert s_encoded.len > s_original.len
+	assert s_original == s_decoded	
+}

--- a/vlib/encoding/base64/base64_memory_test.v
+++ b/vlib/encoding/base64/base64_memory_test.v
@@ -1,26 +1,32 @@
 import encoding.base64
 
 fn test_long_encoding(){
-	repeats := 256
+	repeats := 128
 	input_size := 131072
 	
 	s_original := 'a'.repeat(input_size)
-	mut s_encoded := base64.encode(s_original)
+	s_encoded := base64.encode(s_original)
+	s_decoded := base64.decode(s_encoded)
+	
 	assert s_encoded.len > s_original.len
-	mut s_decoded := base64.decode(s_encoded)
 	assert s_original == s_decoded
 
 	mut s := 0
+	
+	ebuffer := malloc( s_encoded.len )
 	for i := 0; i < repeats; i++ {
-		s_encoded = base64.encode(s_original)
-		s+= s_encoded.len
+		resultsize := base64.encode_in_buffer(s_original, mut ebuffer)
+		s += resultsize
+		assert resultsize == s_encoded.len
 	}
 
+	dbuffer := malloc( s_decoded.len )
 	for i := 0; i < repeats; i++ {
-		s_decoded = base64.decode(s_encoded)
-		s+= s_decoded.len
+		resultsize := base64.decode_in_buffer(s_encoded, mut dbuffer)
+		s += resultsize
+		assert resultsize == s_decoded.len
 	}
-	
-	assert s_encoded.len > s_original.len
-	assert s_original == s_decoded	
+
+	println( 'Final s: $s' )
+	//	assert s == 39147008
 }

--- a/vlib/encoding/base64/base64_test.v
+++ b/vlib/encoding/base64/base64_test.v
@@ -31,11 +31,16 @@ const (
 		TestPair{'asure.', 'YXN1cmUu'},
 		TestPair{'sure.', 'c3VyZS4='},
 	]
+	
+	man_pair = TestPair{
+		'Man is distinguished, not only by his reason, but by this singular passion from other animals, which is a lust of the mind, that by a perseverance of delight in the continued and indefatigable generation of knowledge, exceeds the short vehemence of any carnal pleasure.',
+		'TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlzIHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIGx1c3Qgb2YgdGhlIG1pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY29udGludWVkIGFuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdlLCBleGNlZWRzIHRoZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4='
+	}
+		
 )
 
 fn test_decode() {
-	assert base64.decode('TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlzIHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIGx1c3Qgb2YgdGhlIG1pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY29udGludWVkIGFuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdlLCBleGNlZWRzIHRoZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4=')
-	== 'Man is distinguished, not only by his reason, but by this singular passion from other animals, which is a lust of the mind, that by a perseverance of delight in the continued and indefatigable generation of knowledge, exceeds the short vehemence of any carnal pleasure.'
+	assert base64.decode(man_pair.encoded) == man_pair.decoded
 
 	// Test for incorrect padding.
 	assert base64.decode('aGk') == 'hi'
@@ -52,8 +57,7 @@ fn test_decode() {
 }
 
 fn test_encode() {
-	assert base64.encode('Man is distinguished, not only by his reason, but by this singular passion from other animals, which is a lust of the mind, that by a perseverance of delight in the continued and indefatigable generation of knowledge, exceeds the short vehemence of any carnal pleasure.')
-	== 'TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlzIHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIGx1c3Qgb2YgdGhlIG1pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY29udGludWVkIGFuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdlLCBleGNlZWRzIHRoZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4='
+	assert base64.encode(man_pair.decoded) == man_pair.encoded
 
 	for i, p in pairs {
 		got := base64.encode(p.decoded)


### PR DESCRIPTION
Implement base64.encode_in_buffer and base64.decode_in_buffer .
With this PR:
```shell
0[17:00:01] /v/benchmarks/base64 LINUX $
0[17:00:01] /v/benchmarks/base64 LINUX $ /v/vmaster/v -prod -cc clang-7 -o base64_v_clang_vmaster test.v
0[17:00:03] /v/benchmarks/base64 LINUX $ /v/newv/v  -prod -cc clang-7 -o base64_v_clang_newv test.v
0[17:00:21] /v/benchmarks/base64 LINUX $ /v/newv/v  -prod -cc clang-7 -o base64_v_clang_newv_2 test2.v
0[17:00:30] /v/benchmarks/base64 LINUX $
0[17:00:31] /v/benchmarks/base64 LINUX $ ../xtime.rb  ./base64_v_clang_vmaster
encode aaaa... to YWFh...:   1498 ms | 1431666688
decode YWFh... to aaaa...:   2706 ms | 1073741824
4.30s, 2418.6Mb
0[17:00:38] /v/benchmarks/base64 LINUX $ ../xtime.rb  ./base64_v_clang_newv
encode aaaa... to YWFh...:   1389 ms | 1431666688
decode YWFh... to aaaa...:   2553 ms | 1073741824
4.04s, 2430.9Mb
0[17:00:50] /v/benchmarks/base64 LINUX $ ../xtime.rb  ./base64_v_clang_newv_2
encode aaaa... to YWFh...:   1017 ms | 1431666688
decode YWFh... to aaaa...:   2307 ms | decode: 1073741824
  3325 ms | <=== total time spent running base64 encode/decode ops
 ok, fail, total =     2,     0,     2
3.33s, 2.3Mb
0[17:00:56] /v/benchmarks/base64 LINUX $
```
NB: the memory consumption of the last example is reduced, because no additional memory allocations are made, just base64 encoding/decoding .

The benchmark program test.v is from https://github.com/kostya/benchmarks .

test2.v is:
```v
import encoding.base64
import benchmark

fn main() {
  str_size := 131072
  tries := 8192

  str := 'a'.repeat(str_size)

  str2 := base64.encode(str)
  str3 := base64.decode(str2)

  str2_buffer := malloc( str2.len )
  str3_buffer := malloc( str3.len )

  print('encode ${str.substr(0, 4)}... to ${str2.substr(0, 4)}...: ')

  mut bench := benchmark.new_benchmark()
  bench.step()
  mut s := 0
  for i := 0; i < tries; i++ {
    s += base64.encode_in_buffer(str, mut str2_buffer)
  }
  bench.ok()
  println(bench.step_message('$s'))

  print('decode ${str2.substr(0, 4)}... to ${str3.substr(0, 4)}...: ')

  bench.step()
  s = 0
  for i := 0; i < tries; i++ {
    s += base64.decode_in_buffer( str2, mut str3_buffer )
  }
  bench.ok()
  println(bench.step_message('decode: $s'))

  bench.stop()
  println(bench.total_message('running base64 encode/decode ops'))
}
```