### PR TITLE
tetris: fix ubuntu libfreetype6 dependency

### DIFF
--- a/examples/tetris/README.md
+++ b/examples/tetris/README.md
@@ -6,7 +6,7 @@ Tetris has a temporary dependency on GLFW.
 `brew install glfw` 
  
 ## Ubuntu 
-`sudo apt install libglfw3 libglfw3-dev`
+`sudo apt install libglfw3 libglfw3-dev libfreetype6-dev libssl-dev`
 
 ## Arch (and Manjaro)
 `sudo pacman -S glfw-x11` 


### PR DESCRIPTION
References #2518

Fixes ubuntu specific error where freetype is not included in the README resulting in the following error:

```bash
~/v/examples$ ../v -g run tetris/tetris.v 
C compiler=cc
all .v files:
["/home/drdippy/v/vlib/builtin/array.v", "/home/drdippy/v/vlib/builtin/builtin.v", "/home/drdippy/v/vlib/builtin/cfns.v", "/home/drdippy/v/vlib/builtin/float.v", "/home/drdippy/v/vlib/builtin/hashmap.v", "/home/drdippy/v/vlib/builtin/int.v", "/home/drdippy/v/vlib/builtin/map.v", "/home/drdippy/v/vlib/builtin/option.v", "/home/drdippy/v/vlib/builtin/string.v", "/home/drdippy/v/vlib/builtin/utf8.v", "/home/drdippy/v/vlib/gx/gx.v", "/home/drdippy/v/vlib/gl/1shader.v", "/home/drdippy/v/vlib/gl/gl.v", "/home/drdippy/v/vlib/strings/builder_c.v", "/home/drdippy/v/vlib/strings/similarity.v", "/home/drdippy/v/vlib/strings/strings.v", "/home/drdippy/v/vlib/strconv/atoi.v", "/home/drdippy/v/vlib/rand/pcg32.v", "/home/drdippy/v/vlib/rand/rand.v", "/home/drdippy/v/vlib/rand/splitmix64.v", "/home/drdippy/v/vlib/math/bits.v", "/home/drdippy/v/vlib/math/const.v", "/home/drdippy/v/vlib/math/math.v", "/home/drdippy/v/vlib/math/unsafe.v", "/home/drdippy/v/vlib/os/const.v", "/home/drdippy/v/vlib/os/os.v", "/home/drdippy/v/vlib/os/os_nix.v", "/home/drdippy/v/vlib/stbi/stbi.v", "/home/drdippy/v/vlib/glfw/glfw.v", "/home/drdippy/v/vlib/glm/glm.v", "/home/drdippy/v/vlib/time/time.v", "/home/drdippy/v/vlib/gg/gg.v", "/home/drdippy/v/vlib/freetype/freetype.v", "tetris/tetris.v"]
In file included from /home/drdippy/v/examples/tetris/tetris.v:454:
/home/drdippy/v/examples/tetris/tetris.v:454: error: include file 'ft2build.h' not found
V error: C error. This should never happen. 
Please create a GitHub issue: https://github.com/vlang/v/issues/new/choose
```

With the fix:
```
$ ../../v run tetris.v 
create window wnd=0xc25770 ptr==0x7ffcdcdecac8
#version 330 core
layout (location = 0) in vec4 vertex; // <vec2 pos, vec2 tex>
out vec2 TexCoords;

uniform mat4 projection;

void main()
{
    gl_Position = projection * vec4(vertex.xy, 0.0, 1.0);
    TexCoords = vertex.zw;
}  
Trying to load font from RobotoMono-Regular.ttf
new gg text context vao=3
```