### PR TITLE
compiler: improve error reporting when building thirdparty .o files.

### DIFF
--- a/vlib/compiler/cgen.v
+++ b/vlib/compiler/cgen.v
@@ -267,6 +267,11 @@ fn build_thirdparty_obj_file(path string, moduleflags []CFlag) {
 		verror(err)
 		return
 	}
+	if res.exit_code != 0 {
+		println('failed thirdparty object build cmd: $cmd')
+		verror(res.output)
+		return
+	}
 	println(res.output)
 }
 

--- a/vlib/compiler/msvc.v
+++ b/vlib/compiler/msvc.v
@@ -414,7 +414,13 @@ fn build_thirdparty_obj_file_with_msvc(path string, moduleflags []CFlag) {
 	//NB: the quotes above ARE balanced.
 	println('thirdparty cmd line: $cmd')
 	res := os.exec(cmd) or {
+		println('msvc: failed thirdparty object build cmd: $cmd')
 		verror(err)
+		return
+	}
+	if res.exit_code != 0 {
+		println('msvc: failed thirdparty object build cmd: $cmd')
+		verror(res.output)
 		return
 	}
 	println(res.output)


### PR DESCRIPTION
Handle the case when the thirdparty compilation fails (i.e. returns a non zero error code).