### PR TITLE
compiler: make Fn struct public, thus fixing compilation of tools/vnames

### DIFF
--- a/vlib/compiler/fn.v
+++ b/vlib/compiler/fn.v
@@ -12,7 +12,7 @@ const (
 	MaxLocalVars = 50
 )
 
-
+pub
 struct Fn {
 	// addr int
 pub:


### PR DESCRIPTION
Compiling of this tool failed with:
```
tools/vnames.v:13:41: type `compiler.Fn` is private
   12| 
   13| fn f_to_string(fmod string, f compiler.Fn) ?string {
```