### PR TITLE
log: make const/struct public

### DIFF
--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -4,7 +4,7 @@ import os
 import time
 import term
 
-const (
+pub const (
     FATAL = 1
     ERROR = 2 
     WARN  = 3
@@ -20,12 +20,11 @@ interface Logger {
     debug(s string)
 }
 
-struct Log{
+pub struct Log {
 mut:
     level int
     output string
 }
-
 
 pub fn (l mut Log) set_level(level int){
     l.level = level


### PR DESCRIPTION
When I ran `examples/log.v`, I found some warnings as follows:

```
warning: log.v:4:20: type `log.Log` is private
warning: log.v:4:29: constant `log.INFO` is private
warning: log.v:9:25: constant `log.DEBUG` is private
```

I thought these should be public so I made this change.
