### PR TITLE
array: eq() for builtins (byte, string, int, i64, f32)

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -382,6 +382,10 @@ pub fn (a []int) eq(a2 []int) bool {
 	return array_eq(a, a2) 
 }
 
+pub fn (a []i64) eq(a2 []i64) bool { 
+	return array_eq(a, a2) 
+}
+
 pub fn (a []string) eq(a2 []string) bool { 
 	return array_eq(a, a2) 
 }

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -366,6 +366,7 @@ pub fn (a []int) reduce(iter fn (accum, curr int) int, accum_start int) int {
 	return _accum
 }
 
+// []int == []int (also for: i64, f32, f64, byte, string)
 fn array_eq<T>(a1, a2 []T) bool {
 	if a1.len != a2.len {
 		return false

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -399,6 +399,3 @@ pub fn (a []f32) eq(a2 []f32) bool {
 	return array_eq(a, a2) 
 }
 
-pub fn (a []f64) eq(a2 []f64) bool { 
-	return array_eq(a, a2) 
-}

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -365,3 +365,35 @@ pub fn (a []int) reduce(iter fn (accum, curr int) int, accum_start int) int {
 	}
 	return _accum
 }
+
+fn array_eq<T>(a1, a2 []T) bool {
+	if a1.len != a2.len {
+		return false
+	}
+	for i := 0; i < a1.len; i++ {
+		if a1[i] != a2[i] {
+			return false
+		}
+	}
+	return true
+}
+
+pub fn (a []int) eq(a2 []int) bool { 
+	return array_eq(a, a2) 
+}
+
+pub fn (a []string) eq(a2 []string) bool { 
+	return array_eq(a, a2) 
+}
+
+pub fn (a []byte) eq(a2 []byte) bool { 
+	return array_eq(a, a2) 
+}
+
+pub fn (a []f32) eq(a2 []f32) bool { 
+	return array_eq(a, a2) 
+}
+
+pub fn (a []f64) eq(a2 []f64) bool { 
+	return array_eq(a, a2) 
+}

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -387,4 +387,9 @@ fn test_array_str() {
 	assert true
 	assert numbers.str() == '[1, 2, 3]'
 	assert numbers2.str() == '[[1, 2, 3], [4, 5, 6]]'
-}	
+}
+
+fn test_eq() {
+	assert [5,6,7].eq([6,7]) == false
+	assert [`a`,`b`].eq([`a`,`b`]) == true
+}


### PR DESCRIPTION
This is an initial array.eq(...) implementation. Since generics don't allow us to write types that extend other types like `T : Equalizer`, and generics methods aren't ready yet, it isn't possible until now to write a single generic method for arrays (i've written it yet, but i'll push it only when it will possible)
Users can use `[]int.eq([]int)` (also with `f32, i64, byte, string`.