### PR TITLE
fibonacci: stop before overflowing and use u64

### DIFF
--- a/examples/fibonacci.v
+++ b/examples/fibonacci.v
@@ -14,10 +14,16 @@ fn main() {
 	// Parse first argument and cast it to int
 	stop := os.args[1].int()
 
+	// Can only calculate correctly until rank 92
+	if stop > 92 {
+		println('rank must be 92 or less')
+		return
+	}
+
 	// Three consecutive terms of the sequence
-	mut a := i64(0)
-	mut b := i64(0)
-	mut c := i64(1)
+	mut a := u64(0)
+	mut b := u64(0)
+	mut c := u64(1)
 
 	for i := 0; i < stop; i++ {
 		// Set a and b to the next term


### PR DESCRIPTION
The u64 fits the example better, and we get one more correct value before overflowing.
Ranks after 92 are wrong because the numbers cant fit into u64.
