### PR TITLE
match: fix typo and remove arrows

### DIFF
--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -3372,7 +3372,7 @@ fn (p mut Parser) switch_statement() {
 		'https://vlang.io/docs#match')
 }
 
-// Returns typ if used as expession
+// Returns typ if used as expression
 fn (p mut Parser) match_statement(is_expr bool) string {
 	p.check(.key_match)
 	p.cgen.start_tmp()
@@ -3566,7 +3566,7 @@ fn (p mut Parser) match_statement(is_expr bool) string {
 
 	if is_expr {
 		// we get here if no else found, ternary requires "else" branch
-		p.error('Match expession requires "else"')
+		p.error('Match expression requires "else"')
 	}
 
 	p.returns = false // only get here when no default, so return is not guaranteed

--- a/vlib/compiler/tests/match_test.v
+++ b/vlib/compiler/tests/match_test.v
@@ -3,38 +3,40 @@ enum Color{
 }
 
 fn test_match_integers() {
-	// a := 3 
-	// mut b := 0 
-	// match a {
-	//    2 => println('two') 
-	//    3 => println('three') 
-	//         b = 3 
-	//    4 => println('four') 
-	// else => println('???') 
-	// } 
-	// assert b == 3 
+	mut a := 3
+	mut b := 0
+	match a {
+	    2 { println('two') }
+	    3 {
+            println('three')
+            b = 3
+        }
+	    4 { println('four') }
+	    else { println('???') }
+    }
+	assert b == 3
 
     assert match 2 {
-        1 => {2}
-        2 => {3}
-        else => {5}
+        1 { 2 }
+        2 { 3 }
+        else { 5 }
     } == 3
     
     assert match 0 {
-        1 => {2}
-        2 => {3}
-        else => 5
+        1 { 2 }
+        2 { 3 }
+        else 5
     } == 5
 
     assert match 1 {
-        else => {5}
+        else { 5 }
     } == 5
     
-    mut a := 0
+    a = 0
     match 2 {
-        0 => {a = 1}
-        1 => {a = 2}
-        else => {
+        0 { a = 1 }
+        1 { a = 2 }
+        else {
             a = 3
             println('a is $a')
         }
@@ -43,8 +45,8 @@ fn test_match_integers() {
     
     a = 0
     match 1 {
-        0 => {a = 1}
-        1 => {
+        0 { a = 1 }
+        1 {
             a = 2
             a = a + 2
             a = a + 2
@@ -54,7 +56,7 @@ fn test_match_integers() {
 
     a = 0
     match 1 {
-        else => {
+        else {
             a = -2
         }
     }
@@ -64,11 +66,13 @@ fn test_match_integers() {
 fn test_match_enums(){
     mut b := Color.red
     match b{
-        .red => {
+        .red {
             b = .green
         }
-        .green => {b = .blue}
-        else => {
+        .green {
+            b = .blue
+        }
+        else {
             println('b is ${b.str()}')
             b = .red
         }
@@ -76,10 +80,10 @@ fn test_match_enums(){
     assert b == .green
 
     match b{
-        .red => {
+        .red {
             b = .green
         }
-        else => {
+        else {
             println('b is ${b.str()}')
             b = .blue
         }


### PR DESCRIPTION
I fixed expession -> expression on error message.
I also fixed test to suppress warning messages.
