### PR TITLE
time: add new public functions for stringify time struct

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -90,7 +90,7 @@ fn array_repeat_old(val voidptr, nr_repeats, elm_size int) array {
 	return arr
 }
 
-// array.repeat returns new array with the given array elements 
+// array.repeat returns new array with the given array elements
 // repeated `nr_repeat` times
 pub fn (a array) repeat(nr_repeats int) array {
 	if nr_repeats < 0 {
@@ -184,7 +184,7 @@ pub fn (a array) left(n int) array {
 }
 
 // array.right returns an array using same buffer as the given array
-// but starting with the element of the given array beyond the index `n`. 
+// but starting with the element of the given array beyond the index `n`.
 // If `n` is bigger or equal to the length of the given array,
 // returns an empty array of the same type as the given array.
 pub fn (a array) right(n int) array {
@@ -204,8 +204,8 @@ fn (a array) slice2(start, _end int, end_max bool) array {
 }
 
 // array.slice returns an array using the same buffer as original array
-// but starting from the `start` element and ending with the element before 
-// the `end` element of the original array with the length and capacity 
+// but starting from the `start` element and ending with the element before
+// the `end` element of the original array with the length and capacity
 // set to the number of the elements in the slice.
 pub fn (a array) slice(start, _end int) array {
 	mut end := _end
@@ -251,7 +251,7 @@ pub fn (a mut array) push_many(val voidptr, size int) {
 	a.len += size
 }
 
-// array.reverse returns a new array with the elements of 
+// array.reverse returns a new array with the elements of
 // the original array in reverse order.
 pub fn (a array) reverse() array {
 	arr := array {
@@ -325,7 +325,7 @@ pub fn (a []bool) str() string {
 	return sb.str()
 }
 
-// []byte.hex returns a string with the hexadecimal representation 
+// []byte.hex returns a string with the hexadecimal representation
 // of the byte elements of the array
 pub fn (b []byte) hex() string {
 	mut hex := malloc(b.len*2+1)

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -54,7 +54,7 @@ pub fn print_backtrace_skipping_top_frames(skipframes int) {
 					cmd := 'addr2line -e $executable $addr'
 
 					// taken from os, to avoid depending on the os module inside builtin.v
-					f := byteptr(C.popen(cmd.str, 'r'))
+					f := C.popen(cmd.str, 'r')
 					if isnil(f) {
 						println(sframe) continue
 					}

--- a/vlib/builtin/cfns.v
+++ b/vlib/builtin/cfns.v
@@ -14,11 +14,12 @@ fn C.sprintf(a ...voidptr) byteptr
 fn C.strlen(s byteptr) int
 fn C.isdigit(s byteptr) bool
 
-
-
+// stdio.h
+fn C.popen(c byteptr, t byteptr) voidptr
 
 // <execinfo.h>
 fn backtrace(a voidptr, b int) int
+fn backtrace_symbols(voidptr, int) &byteptr
 fn backtrace_symbols_fd(voidptr, int, int)
 
 // <libproc.h>

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -4,7 +4,7 @@
 
 module builtin
 
-//import strconv
+import strconv
 
 /*
 NB: A V string should be/is immutable from the point of view of
@@ -203,23 +203,7 @@ pub fn (s string) int() int {
 
 
 pub fn (s string) i64() i64 {
-	mut neg := false
-	mut i := 0
-	if s[0] == `-` {
-		neg = true
-		i++
-	}
-	else if s[0] == `+` {
-		i++
-	}
-	mut n := i64(0)
-	for C.isdigit(s[i]) {
-		n = i64(10) * n - i64(s[i] - `0`)
-		i++
-	}
-	return if neg { n } else { -n }
-	//return strconv.parse_int(s, 0, 64)
-	//return C.atoll(*char(s.str))
+	return strconv.parse_int(s, 0, 64)
 }
 
 pub fn (s string) f32() f32 {
@@ -251,23 +235,7 @@ pub fn (s string) u32() u32 {
 }
 
 pub fn (s string) u64() u64 {
-	mut neg := false
-	mut i := 0
-	if s[0] == `-` {
-		neg = true
-		i++
-	}
-	else if s[0] == `+` {
-		i++
-	}
-	mut n := u64(0)
-	for C.isdigit(s[i]) {
-		n = u64(10) * n - u64(s[i] - `0`)
-		i++
-	}
-	return if neg { n } else { -n }
-	//return C.atoll(*char(s.str))
-	//return strconv.parse_uint(s, 0, 64)
+	return strconv.parse_uint(s, 0, 64)
 }
 
 // ==

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -114,6 +114,7 @@ pub mut:
 						 // work on the builtin module itself.
 	//generating_vh bool
 	comptime_define string  // -D vfmt for `if $vfmt {`
+	fast bool // use tcc/x64 codegen
 }
 
 // Should be called by main at the end of the compilation process, to cleanup
@@ -930,6 +931,7 @@ pub fn new_v(args[]string) &V {
 		is_run: 'run' in args
 		autofree: '-autofree' in args
 		compress: '-compress' in args
+		fast: '-fast' in args
 		is_repl: is_repl
 		build_mode: build_mode
 		cflags: cflags

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -282,7 +282,7 @@ pub fn (f File) close() {
 }
 
 // system starts the specified command, waits for it to complete, and returns its code.
-fn popen(path string) *C.FILE {
+fn vpopen(path string) *C.FILE {
 	$if windows {
 		mode := 'rb'
 		wpath := path.to_wide()
@@ -313,7 +313,7 @@ fn posix_wait4_to_exit_status(waitret int) (int,bool) {
 	}
 }
 
-fn pclose(f *C.FILE) int {
+fn vpclose(f *C.FILE) int {
 	$if windows {
 		return int( C._pclose(f) )
 	}
@@ -333,7 +333,7 @@ pub:
 // exec starts the specified command, waits for it to complete, and returns its output.
 pub fn exec(cmd string) ?Result {
 	pcmd := '$cmd 2>&1'
-	f := popen(pcmd)
+	f := vpopen(pcmd)
 	if isnil(f) {
 		return error('exec("$cmd") failed')
 	}
@@ -343,7 +343,7 @@ pub fn exec(cmd string) ?Result {
 		res += tos(buf, vstrlen(buf))
 	}
 	res = res.trim_space()
-	exit_code := pclose(f)
+	exit_code := vpclose(f)
 	//if exit_code != 0 {
 		//return error(res)
 	//}

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -55,6 +55,32 @@ pub:
 	uni    int // TODO it's safe to use "unix" now
 }
 
+pub enum FormatTime {
+        hhmm12
+        hhmm24
+        hhmmss12
+        hhmmss24
+        no_time
+}
+
+pub enum FormatDate {
+        ddmmyy
+        ddmmyyyy
+        mmddyy
+        mmddyyyy
+        mmmd
+        mmmdd
+        mmmddyyyy
+        no_date
+        yyyymmdd
+}
+
+pub enum FormatDelimiter {
+        dot
+        hyphen
+        slash
+        space
+}
 
 fn C.localtime(int) &C.tm
 
@@ -174,12 +200,22 @@ pub fn convert_ctime(t tm) Time {
 	}
 }
 
+// format_ss  returns a string for t in a given format YYYY-MM-DD HH:MM:SS in
+//            24h notation
+// @param
+// @return    string
+// @example   1980-07-11 21:23:42
 pub fn (t Time) format_ss() string {
-	return '${t.year}-${t.month:02d}-${t.day:02d} ${t.hour:02d}:${t.minute:02d}:${t.second:02d}'
+        return t.get_fmt_str(FormatDelimiter.hyphen, FormatTime.hhmmss24, FormatDate.yyyymmdd)
 }
 
+// format_ss  returns a string for t in a given format YYYY-MM-DD HH:MM in 24h
+//            notation
+// @param
+// @return    string
+// @example   1980-07-11 21:23
 pub fn (t Time) format() string {
-	return '${t.year}-${t.month:02d}-${t.day:02d} ${t.hour:02d}:${t.minute:02d}'
+        return t.get_fmt_str(FormatDelimiter.hyphen, FormatTime.hhmm24, FormatDate.yyyymmdd)
 }
 
 
@@ -188,9 +224,12 @@ pub fn (t Time) smonth() string {
 	return months_string[i * 3..(i + 1) * 3]
 }
 
-// 21:04
+// hhmm     returns a string for t in the given format HH:MM in 24h notation
+// @param
+// @return  string
+// @example 21:04
 pub fn (t Time) hhmm() string {
-	return '${t.hour:02d}:${t.minute:02d}'
+        return t.get_fmt_time_str(FormatTime.hhmm24)
 }
 
 /*
@@ -199,42 +238,44 @@ fn (t Time) hhmm_tmp() string {
 }
 */
 
-// 9:04pm
+// hhmm12   returns a string for t in the given format HH:MM in 12h notation
+// @param
+// @return  string
+// @example 9:04 p.m.
 pub fn (t Time) hhmm12() string {
-	mut am := 'am'
-	mut hour := t.hour
-	if t.hour > 11 {
-		am = 'pm'
-	}
-	if t.hour > 12 {
-		hour = hour - 12
-	}
-	if t.hour == 0 {
-		hour = 12
-	}
-	return '$hour:${t.minute:02d} $am'
+        return t.get_fmt_time_str(FormatTime.hhmm12)
 }
 
-// 21:04:03
+// hhmmss   returns a string for t in the given format HH:MM:SS in 24h notation
+// @param
+// @return  string
+// @example 21:04:03
 pub fn (t Time) hhmmss() string {
-	return '${t.hour:02d}:${t.minute:02d}:${t.second:02d}'
+        return t.get_fmt_time_str(FormatTime.hhmmss24)
 }
 
-// 2012-01-05
+// ymmdd    returns a string for t in the given format YYYY-MM-DD
+// @param
+// @return  string
+// @example 2012-01-05
 pub fn (t Time) ymmdd() string {
-	return '${t.year}-${t.month:02d}-${t.day:02d}'
+        return t.get_fmt_date_str(FormatDelimiter.hyphen, FormatDate.yyyymmdd)
 }
 
-// 05.02.2012
+// ddmmy    returns a string for t in the given format DD.MM.YYYY
+// @param
+// @return  string
+// @example 05.02.2012
 pub fn (t Time) ddmmy() string {
-	return '${t.day:02d}.${t.month:02d}.${t.year}'
+        return t.get_fmt_date_str(FormatDelimiter.dot, FormatDate.ddmmyyyy)
 }
 
-// Jul 3
+// md       returns a string for t in the given format MMM D
+// @param
+// @return  string
+// @example Jul 3
 pub fn (t Time) md() string {
-	// jl := t.smonth()
-	s := '${t.smonth()} $t.day'
-	return s
+        return t.get_fmt_date_str(FormatDelimiter.space, FormatDate.mmmd) 
 }
 
 pub fn (t Time) clean() string {
@@ -244,7 +285,7 @@ pub fn (t Time) clean() string {
 	// }
 	// Today
 	if t.month == nowe.month && t.year == nowe.year && t.day == nowe.day {
-		return t.hhmm()
+                return t.get_fmt_time_str(FormatTime.hhmm24)
 	}
 	// This week
 	// if time.Since(t) < 24*7*time.Hour {
@@ -252,7 +293,7 @@ pub fn (t Time) clean() string {
 	// }
 	// This year
 	if t.year == nowe.year {
-		return '${t.smonth()} ${t.day} ${t.hhmm()}'
+                return t.get_fmt_str(FormatDelimiter.space, FormatTime.hhmm24, FormatDate.mmmd)
 	}
 	return t.format()
 	// return fmt.Sprintf("%4d/%02d/%02d", t.Year(), t.Month(), t.Day()) + " " + hm
@@ -265,7 +306,7 @@ pub fn (t Time) clean12() string {
 	// }
 	// Today
 	if t.month == nowe.month && t.year == nowe.year && t.day == nowe.day {
-		return t.hhmm12()
+                return t.get_fmt_time_str(FormatTime.hhmm12)
 	}
 	// This week
 	// if time.Since(t) < 24*7*time.Hour {
@@ -273,7 +314,7 @@ pub fn (t Time) clean12() string {
 	// }
 	// This year
 	if t.year == nowe.year {
-		return '${t.smonth()} ${t.day} ${t.hhmm12()}'
+                return t.get_fmt_str(FormatDelimiter.space, FormatTime.hhmm12, FormatDate.mmmd)
 	}
 	return t.format()
 	// return fmt.Sprintf("%4d/%02d/%02d", t.Year(), t.Month(), t.Day()) + " " + hm
@@ -448,4 +489,92 @@ pub fn days_in_month(month, year int) ?int {
 	extra :=	if month == 2 && is_leap_year(year) {1} else {0}
 	res := month_days[month-1] + extra
 	return res
+}
+
+// get_fmt_time_str   returns a string for time t in a given format
+// @param             FormatTime
+// @return            string
+// @example           21:23:42
+pub fn (t Time) get_fmt_time_str(fmt_time FormatTime) string {
+        if fmt_time == FormatTime.no_time {
+                return ''
+        }
+
+        tp            :=  if t.hour > 11 {
+                                  'p.m.'
+                          } else {
+                                  'a.m.'
+                          }
+
+        hour          :=  if t.hour > 12 {
+                                  t.hour - 12
+                          } else  if t.hour == 0 {
+                                          12
+                                  } else {
+                                           t.hour
+                                  }
+
+        return  match fmt_time {
+                        .hhmm12     { '$hour:${t.minute:02d} $tp' }
+                        .hhmm24     { '${t.hour:02d}:${t.minute:02d}' }
+                        .hhmmss12   { '$hour:${t.minute:02d}:${t.second:02d} $tp' }
+                        .hhmmss24   { '${t.hour:02d}:${t.minute:02d}:${t.second:02d}' }
+                        else        { 'unknown enumeration $fmt_time' }
+                }
+}
+
+// get_fmt_date_str   returns a string for t in a given date format
+// @param             FormatDelimiter, FormatDate
+// @return            string
+// @example           11.07.1980
+pub fn (t Time) get_fmt_date_str(fmt_dlmtr FormatDelimiter, fmt_date FormatDate) string {
+        if fmt_date == FormatDate.no_date {
+                return ''
+        }
+
+        month         := '${t.smonth()}'
+
+        year          :=  t.year.str().right(2)
+
+        return  match fmt_date {
+                        .ddmmyy     { '${t.day:02d}|${t.month:02d}|$year' }
+                        .ddmmyyyy   { '${t.day:02d}|${t.month:02d}|${t.year}' }
+                        .mmddyy     { '${t.month:02d}|${t.day:02d}|$year' }
+                        .mmddyyyy   { '${t.month:02d}|${t.day:02d}|${t.year}' }
+                        .mmmd       { '$month|${t.day}' }
+                        .mmmdd      { '$month|${t.day:02d}' }
+                        .mmmddyyyy  { '$month|${t.day:02d}|${t.year}' }
+                        .yyyymmdd   { '${t.year}|${t.month:02d}|${t.day:02d}' }
+                        else        { 'unknown enumeration $fmt_date' }
+                }.replace('|',  match fmt_dlmtr {
+                                        .dot    { '.' }
+                                        .hyphen { '-' }
+                                        .slash  { '/' }
+                                        .space  { ' ' }
+                                        else    { 'unknown enumeration $fmt_dlmtr' }
+                                })
+}
+
+// get_fmt_str  returns a string for t in a given format for time and date
+// @param       FormatDelimiter, FormatTime, FormatDate
+// @return      string
+// @example     11.07.1980 21:23:42
+pub fn (t Time) get_fmt_str(fmt_dlmtr FormatDelimiter, fmt_time FormatTime, fmt_date FormatDate) string {
+        if fmt_date == FormatDate.no_date {
+                if fmt_time == FormatTime.no_time {
+                        // saving one function call although it's checked in
+                        // t.get_fmt_time_str(fmt_time) in the beginning
+                        return ''
+                } else {
+                        return t.get_fmt_time_str(fmt_time)
+                }
+        } else {
+                if fmt_time != FormatTime.no_time {
+                        return t.get_fmt_date_str(fmt_dlmtr, fmt_date)
+                               + ' '
+                               + t.get_fmt_time_str(fmt_time)
+                } else {
+                        return t.get_fmt_date_str(fmt_dlmtr, fmt_date)
+                }
+        }
 }

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -500,19 +500,19 @@ pub fn (t Time) get_fmt_time_str(fmt_time FormatTime) string {
                 return ''
         }
 
-        tp            :=  if t.hour > 11 {
-                                  'p.m.'
-                          } else {
-                                  'a.m.'
-                          }
+        tp := if t.hour > 11 {
+                'p.m.'
+              } else {
+                'a.m.'
+              }
 
-        hour          :=  if t.hour > 12 {
-                                  t.hour - 12
-                          } else  if t.hour == 0 {
-                                          12
-                                  } else {
-                                           t.hour
-                                  }
+        hour := if t.hour > 12 {
+                        t.hour - 12
+                } else  if t.hour == 0 {
+                              12
+                        } else {
+                              t.hour
+                        }
 
         return  match fmt_time {
                         .hhmm12     { '$hour:${t.minute:02d} $tp' }
@@ -532,9 +532,8 @@ pub fn (t Time) get_fmt_date_str(fmt_dlmtr FormatDelimiter, fmt_date FormatDate)
                 return ''
         }
 
-        month         := '${t.smonth()}'
-
-        year          :=  t.year.str().right(2)
+        month := '${t.smonth()}'
+        year := t.year.str().right(2)
 
         return  match fmt_date {
                         .ddmmyy     { '${t.day:02d}|${t.month:02d}|$year' }

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -206,7 +206,7 @@ pub fn convert_ctime(t tm) Time {
 // @return    string
 // @example   1980-07-11 21:23:42
 pub fn (t Time) format_ss() string {
-        return t.get_fmt_str(FormatDelimiter.hyphen, FormatTime.hhmmss24, FormatDate.yyyymmdd)
+        return t.get_fmt_str(.hyphen, .hhmmss24, .yyyymmdd)
 }
 
 // format_ss  returns a string for t in a given format YYYY-MM-DD HH:MM in 24h
@@ -215,7 +215,7 @@ pub fn (t Time) format_ss() string {
 // @return    string
 // @example   1980-07-11 21:23
 pub fn (t Time) format() string {
-        return t.get_fmt_str(FormatDelimiter.hyphen, FormatTime.hhmm24, FormatDate.yyyymmdd)
+        return t.get_fmt_str(.hyphen, .hhmm24, .yyyymmdd)
 }
 
 
@@ -229,7 +229,7 @@ pub fn (t Time) smonth() string {
 // @return  string
 // @example 21:04
 pub fn (t Time) hhmm() string {
-        return t.get_fmt_time_str(FormatTime.hhmm24)
+        return t.get_fmt_time_str(.hhmm24)
 }
 
 /*
@@ -243,7 +243,7 @@ fn (t Time) hhmm_tmp() string {
 // @return  string
 // @example 9:04 p.m.
 pub fn (t Time) hhmm12() string {
-        return t.get_fmt_time_str(FormatTime.hhmm12)
+        return t.get_fmt_time_str(.hhmm12)
 }
 
 // hhmmss   returns a string for t in the given format HH:MM:SS in 24h notation
@@ -251,7 +251,7 @@ pub fn (t Time) hhmm12() string {
 // @return  string
 // @example 21:04:03
 pub fn (t Time) hhmmss() string {
-        return t.get_fmt_time_str(FormatTime.hhmmss24)
+        return t.get_fmt_time_str(.hhmmss24)
 }
 
 // ymmdd    returns a string for t in the given format YYYY-MM-DD
@@ -259,7 +259,7 @@ pub fn (t Time) hhmmss() string {
 // @return  string
 // @example 2012-01-05
 pub fn (t Time) ymmdd() string {
-        return t.get_fmt_date_str(FormatDelimiter.hyphen, FormatDate.yyyymmdd)
+        return t.get_fmt_date_str(.hyphen, .yyyymmdd)
 }
 
 // ddmmy    returns a string for t in the given format DD.MM.YYYY
@@ -267,7 +267,7 @@ pub fn (t Time) ymmdd() string {
 // @return  string
 // @example 05.02.2012
 pub fn (t Time) ddmmy() string {
-        return t.get_fmt_date_str(FormatDelimiter.dot, FormatDate.ddmmyyyy)
+        return t.get_fmt_date_str(.dot, .ddmmyyyy)
 }
 
 // md       returns a string for t in the given format MMM D
@@ -275,7 +275,7 @@ pub fn (t Time) ddmmy() string {
 // @return  string
 // @example Jul 3
 pub fn (t Time) md() string {
-        return t.get_fmt_date_str(FormatDelimiter.space, FormatDate.mmmd) 
+        return t.get_fmt_date_str(.space, .mmmd) 
 }
 
 pub fn (t Time) clean() string {
@@ -285,7 +285,7 @@ pub fn (t Time) clean() string {
 	// }
 	// Today
 	if t.month == nowe.month && t.year == nowe.year && t.day == nowe.day {
-                return t.get_fmt_time_str(FormatTime.hhmm24)
+                return t.get_fmt_time_str(.hhmm24)
 	}
 	// This week
 	// if time.Since(t) < 24*7*time.Hour {
@@ -293,7 +293,7 @@ pub fn (t Time) clean() string {
 	// }
 	// This year
 	if t.year == nowe.year {
-                return t.get_fmt_str(FormatDelimiter.space, FormatTime.hhmm24, FormatDate.mmmd)
+                return t.get_fmt_str(.space, .hhmm24, .mmmd)
 	}
 	return t.format()
 	// return fmt.Sprintf("%4d/%02d/%02d", t.Year(), t.Month(), t.Day()) + " " + hm
@@ -306,7 +306,7 @@ pub fn (t Time) clean12() string {
 	// }
 	// Today
 	if t.month == nowe.month && t.year == nowe.year && t.day == nowe.day {
-                return t.get_fmt_time_str(FormatTime.hhmm12)
+                return t.get_fmt_time_str(.hhmm12)
 	}
 	// This week
 	// if time.Since(t) < 24*7*time.Hour {
@@ -314,7 +314,7 @@ pub fn (t Time) clean12() string {
 	// }
 	// This year
 	if t.year == nowe.year {
-                return t.get_fmt_str(FormatDelimiter.space, FormatTime.hhmm12, FormatDate.mmmd)
+                return t.get_fmt_str(.space, .hhmm12, .mmmd)
 	}
 	return t.format()
 	// return fmt.Sprintf("%4d/%02d/%02d", t.Year(), t.Month(), t.Day()) + " " + hm
@@ -496,7 +496,7 @@ pub fn days_in_month(month, year int) ?int {
 // @return            string
 // @example           21:23:42
 pub fn (t Time) get_fmt_time_str(fmt_time FormatTime) string {
-        if fmt_time == FormatTime.no_time {
+        if fmt_time == .no_time {
                 return ''
         }
 
@@ -528,7 +528,7 @@ pub fn (t Time) get_fmt_time_str(fmt_time FormatTime) string {
 // @return            string
 // @example           11.07.1980
 pub fn (t Time) get_fmt_date_str(fmt_dlmtr FormatDelimiter, fmt_date FormatDate) string {
-        if fmt_date == FormatDate.no_date {
+        if fmt_date == .no_date {
                 return ''
         }
 
@@ -560,8 +560,8 @@ pub fn (t Time) get_fmt_date_str(fmt_dlmtr FormatDelimiter, fmt_date FormatDate)
 // @return      string
 // @example     11.07.1980 21:23:42
 pub fn (t Time) get_fmt_str(fmt_dlmtr FormatDelimiter, fmt_time FormatTime, fmt_date FormatDate) string {
-        if fmt_date == FormatDate.no_date {
-                if fmt_time == FormatTime.no_time {
+        if fmt_date == .no_date {
+                if fmt_time == .no_time {
                         // saving one function call although it's checked in
                         // t.get_fmt_time_str(fmt_time) in the beginning
                         return ''
@@ -569,7 +569,7 @@ pub fn (t Time) get_fmt_str(fmt_dlmtr FormatDelimiter, fmt_time FormatTime, fmt_
                         return t.get_fmt_time_str(fmt_time)
                 }
         } else {
-                if fmt_time != FormatTime.no_time {
+                if fmt_time != .no_time {
                         return t.get_fmt_date_str(fmt_dlmtr, fmt_date)
                                + ' '
                                + t.get_fmt_time_str(fmt_time)

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -59,9 +59,9 @@ fn test_format_ss() {
                             second:   42,
                             uni:      0 }
 
-        assert  '11.07.1980 21:23:42' == t.get_fmt_str(time.FormatDelimiter.dot,
-                                                       time.FormatTime.hhmmss24,
-                                                       time.FormatDate.ddmmyyyy)
+        assert  '11.07.1980 21:23:42' == t.get_fmt_str(.dot,
+                                                       .hhmmss24,
+                                                       .ddmmyyyy)
 }
 
 fn test_format() {
@@ -73,9 +73,9 @@ fn test_format() {
                             second:   42,
                             uni:      0 }
 
-        assert  '11.07.1980 21:23' == t.get_fmt_str(time.FormatDelimiter.dot,
-                                                    time.FormatTime.hhmm24,
-                                                    time.FormatDate.ddmmyyyy)
+        assert  '11.07.1980 21:23' == t.get_fmt_str(.dot,
+                                                    .hhmm24,
+                                                    .ddmmyyyy)
 }
 
 fn test_hhmm() {
@@ -87,7 +87,7 @@ fn test_hhmm() {
                             second:   42,
                             uni:      0 }
 
-        assert  '21:23' == t.get_fmt_time_str(time.FormatTime.hhmm24)
+        assert  '21:23' == t.get_fmt_time_str(.hhmm24)
 }
 
 fn test_hhmm12() {
@@ -99,7 +99,7 @@ fn test_hhmm12() {
                             second:   42,
                             uni:      0 }
 
-        assert  '9:23 p.m.' == t.get_fmt_time_str(time.FormatTime.hhmm12)
+        assert  '9:23 p.m.' == t.get_fmt_time_str(.hhmm12)
 }
 
 fn test_hhmmss() {
@@ -111,7 +111,7 @@ fn test_hhmmss() {
                             second:   42,
                             uni:      0 }
 
-        assert  '21:23:42' == t.get_fmt_time_str(time.FormatTime.hhmmss24)
+        assert  '21:23:42' == t.get_fmt_time_str(.hhmmss24)
 }
 
 fn test_ymmdd() {
@@ -123,8 +123,8 @@ fn test_ymmdd() {
                             second:   42,
                             uni:      0 }
 
-        assert  '1980-07-11' == t.get_fmt_date_str(time.FormatDelimiter.hyphen,
-                                                   time.FormatDate.yyyymmdd)
+        assert  '1980-07-11' == t.get_fmt_date_str(.hyphen,
+                                                   .yyyymmdd)
 }
 
 fn test_ddmmy() {
@@ -136,8 +136,8 @@ fn test_ddmmy() {
                             second:   42,
                             uni:      0 }
 
-        assert  '11.07.1980' == t.get_fmt_date_str(time.FormatDelimiter.dot,
-                                                   time.FormatDate.ddmmyyyy)
+        assert  '11.07.1980' == t.get_fmt_date_str(.dot,
+                                                   .ddmmyyyy)
 }
 
 fn test_md() {
@@ -149,8 +149,8 @@ fn test_md() {
                             second:   42,
                             uni:      0 }
 
-        assert 'Jul 11' == t.get_fmt_date_str(time.FormatDelimiter.space,
-                                              time.FormatDate.mmmd)
+        assert 'Jul 11' == t.get_fmt_date_str(.space,
+                                              .mmmd)
 }
 
 fn test_get_fmt_time_str() {
@@ -162,10 +162,10 @@ fn test_get_fmt_time_str() {
                             second:   42,
                             uni:      0 }
 
-        assert  '21:23:42' == t.get_fmt_time_str(time.FormatTime.hhmmss24)
-        assert  '21:23' == t.get_fmt_time_str(time.FormatTime.hhmm24)
-        assert  '9:23:42 p.m.' == t.get_fmt_time_str(time.FormatTime.hhmmss12)
-        assert  '9:23 p.m.' == t.get_fmt_time_str(time.FormatTime.hhmm12)
+        assert  '21:23:42' == t.get_fmt_time_str(.hhmmss24)
+        assert  '21:23' == t.get_fmt_time_str(.hhmm24)
+        assert  '9:23:42 p.m.' == t.get_fmt_time_str(.hhmmss12)
+        assert  '9:23 p.m.' == t.get_fmt_time_str(.hhmm12)
 }
 
 fn test_get_fmt_date_str() {
@@ -177,46 +177,46 @@ fn test_get_fmt_date_str() {
                             second:   42,
                             uni:      0 }
 
-        assert  '11.07.1980' == t.get_fmt_date_str(time.FormatDelimiter.dot,
-                                                   time.FormatDate.ddmmyyyy)
-        assert  '11/07/1980' == t.get_fmt_date_str(time.FormatDelimiter.slash,
-                                                   time.FormatDate.ddmmyyyy)
-        assert  '11-07-1980' == t.get_fmt_date_str(time.FormatDelimiter.hyphen,
-                                                   time.FormatDate.ddmmyyyy)
-        assert  '11 07 1980' == t.get_fmt_date_str(time.FormatDelimiter.space,
-                                                   time.FormatDate.ddmmyyyy)
-        assert  '07.11.1980' == t.get_fmt_date_str(time.FormatDelimiter.dot,
-                                                   time.FormatDate.mmddyyyy)
-        assert  '07/11/1980' == t.get_fmt_date_str(time.FormatDelimiter.slash,
-                                                   time.FormatDate.mmddyyyy)
-        assert  '07-11-1980' == t.get_fmt_date_str(time.FormatDelimiter.hyphen,
-                                                   time.FormatDate.mmddyyyy)
-        assert  '07 11 1980' == t.get_fmt_date_str(time.FormatDelimiter.space,
-                                                   time.FormatDate.mmddyyyy)
-        assert  '11.07.80'   == t.get_fmt_date_str(time.FormatDelimiter.dot,
-                                                   time.FormatDate.ddmmyy)
-        assert  '11/07/80'   == t.get_fmt_date_str(time.FormatDelimiter.slash,
-                                                   time.FormatDate.ddmmyy)
-        assert  '11-07-80'   == t.get_fmt_date_str(time.FormatDelimiter.hyphen,
-                                                   time.FormatDate.ddmmyy)
-        assert  '11 07 80'   == t.get_fmt_date_str(time.FormatDelimiter.space,
-                                                   time.FormatDate.ddmmyy)
-        assert  '07.11.80'   == t.get_fmt_date_str(time.FormatDelimiter.dot,
-                                                   time.FormatDate.mmddyy)
-        assert  '07/11/80'   == t.get_fmt_date_str(time.FormatDelimiter.slash,
-                                                   time.FormatDate.mmddyy)
-        assert  '07-11-80'   == t.get_fmt_date_str(time.FormatDelimiter.hyphen,
-                                                   time.FormatDate.mmddyy)
-        assert  '07 11 80'   == t.get_fmt_date_str(time.FormatDelimiter.space,
-                                                   time.FormatDate.mmddyy)
-        assert  'Jul 11'     == t.get_fmt_date_str(time.FormatDelimiter.space,
-                                                   time.FormatDate.mmmd)
-        assert  'Jul 11'     == t.get_fmt_date_str(time.FormatDelimiter.space,
-                                                   time.FormatDate.mmmdd)
-        assert  'Jul 11 1980' == t.get_fmt_date_str(time.FormatDelimiter.space,
-                                                    time.FormatDate.mmmddyyyy)
-        assert  '1980-07-11'  == t.get_fmt_date_str(time.FormatDelimiter.hyphen,
-                                                    time.FormatDate.yyyymmdd)
+        assert  '11.07.1980' == t.get_fmt_date_str(.dot,
+                                                   .ddmmyyyy)
+        assert  '11/07/1980' == t.get_fmt_date_str(.slash,
+                                                   .ddmmyyyy)
+        assert  '11-07-1980' == t.get_fmt_date_str(.hyphen,
+                                                   .ddmmyyyy)
+        assert  '11 07 1980' == t.get_fmt_date_str(.space,
+                                                   .ddmmyyyy)
+        assert  '07.11.1980' == t.get_fmt_date_str(.dot,
+                                                   .mmddyyyy)
+        assert  '07/11/1980' == t.get_fmt_date_str(.slash,
+                                                   .mmddyyyy)
+        assert  '07-11-1980' == t.get_fmt_date_str(.hyphen,
+                                                   .mmddyyyy)
+        assert  '07 11 1980' == t.get_fmt_date_str(.space,
+                                                   .mmddyyyy)
+        assert  '11.07.80'   == t.get_fmt_date_str(.dot,
+                                                   .ddmmyy)
+        assert  '11/07/80'   == t.get_fmt_date_str(.slash,
+                                                   .ddmmyy)
+        assert  '11-07-80'   == t.get_fmt_date_str(.hyphen,
+                                                   .ddmmyy)
+        assert  '11 07 80'   == t.get_fmt_date_str(.space,
+                                                   .ddmmyy)
+        assert  '07.11.80'   == t.get_fmt_date_str(.dot,
+                                                   .mmddyy)
+        assert  '07/11/80'   == t.get_fmt_date_str(.slash,
+                                                   .mmddyy)
+        assert  '07-11-80'   == t.get_fmt_date_str(.hyphen,
+                                                   .mmddyy)
+        assert  '07 11 80'   == t.get_fmt_date_str(.space,
+                                                   .mmddyy)
+        assert  'Jul 11'     == t.get_fmt_date_str(.space,
+                                                   .mmmd)
+        assert  'Jul 11'     == t.get_fmt_date_str(.space,
+                                                   .mmmdd)
+        assert  'Jul 11 1980' == t.get_fmt_date_str(.space,
+                                                    .mmmddyyyy)
+        assert  '1980-07-11'  == t.get_fmt_date_str(.hyphen,
+                                                    .yyyymmdd)
 }
 
 fn test_get_fmt_str() {
@@ -231,7 +231,7 @@ fn test_get_fmt_str() {
         // Since get_fmt_time_str and get_fmt_date_str do have comprehensive
         // tests I don't want to exaggerate here with all possible
         // combinations.
-        assert  '11.07.1980 21:23:42' == t.get_fmt_str(time.FormatDelimiter.dot,
-                                                       time.FormatTime.hhmmss24,
-                                                       time.FormatDate.ddmmyyyy)
+        assert  '11.07.1980 21:23:42' == t.get_fmt_str(.dot,
+                                                       .hhmmss24,
+                                                       .ddmmyyyy)
 }

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -50,4 +50,188 @@ fn test_unix() {
 	//assert t.second == 32  // TODO broken 
 } 
 
+fn test_format_ss() {
+        t :=    time.Time{  year:     1980,
+                            month:    7,
+                            day:      11,
+                            hour:     21,
+                            minute:   23,
+                            second:   42,
+                            uni:      0 }
 
+        assert  '11.07.1980 21:23:42' == t.get_fmt_str(time.FormatDelimiter.dot,
+                                                       time.FormatTime.hhmmss24,
+                                                       time.FormatDate.ddmmyyyy)
+}
+
+fn test_format() {
+        t :=    time.Time{  year:     1980,
+                            month:    7,
+                            day:      11,
+                            hour:     21,
+                            minute:   23,
+                            second:   42,
+                            uni:      0 }
+
+        assert  '11.07.1980 21:23' == t.get_fmt_str(time.FormatDelimiter.dot,
+                                                    time.FormatTime.hhmm24,
+                                                    time.FormatDate.ddmmyyyy)
+}
+
+fn test_hhmm() {
+        t :=    time.Time{  year:     1980,
+                            month:    7,
+                            day:      11,
+                            hour:     21,
+                            minute:   23,
+                            second:   42,
+                            uni:      0 }
+
+        assert  '21:23' == t.get_fmt_time_str(time.FormatTime.hhmm24)
+}
+
+fn test_hhmm12() {
+        t :=    time.Time{  year:     1980,
+                            month:    7,
+                            day:      11,
+                            hour:     21,
+                            minute:   23,
+                            second:   42,
+                            uni:      0 }
+
+        assert  '9:23 p.m.' == t.get_fmt_time_str(time.FormatTime.hhmm12)
+}
+
+fn test_hhmmss() {
+        t :=    time.Time{  year:     1980,
+                            month:    7,
+                            day:      11,
+                            hour:     21,
+                            minute:   23,
+                            second:   42,
+                            uni:      0 }
+
+        assert  '21:23:42' == t.get_fmt_time_str(time.FormatTime.hhmmss24)
+}
+
+fn test_ymmdd() {
+        t :=    time.Time{  year:     1980,
+                            month:    7,
+                            day:      11,
+                            hour:     21,
+                            minute:   23,
+                            second:   42,
+                            uni:      0 }
+
+        assert  '1980-07-11' == t.get_fmt_date_str(time.FormatDelimiter.hyphen,
+                                                   time.FormatDate.yyyymmdd)
+}
+
+fn test_ddmmy() {
+        t :=    time.Time{  year:     1980,
+                            month:    7,
+                            day:      11,
+                            hour:     21,
+                            minute:   23,
+                            second:   42,
+                            uni:      0 }
+
+        assert  '11.07.1980' == t.get_fmt_date_str(time.FormatDelimiter.dot,
+                                                   time.FormatDate.ddmmyyyy)
+}
+
+fn test_md() {
+        t :=    time.Time{  year:     1980,
+                            month:    7,
+                            day:      11,
+                            hour:     21,
+                            minute:   23,
+                            second:   42,
+                            uni:      0 }
+
+        assert 'Jul 11' == t.get_fmt_date_str(time.FormatDelimiter.space,
+                                              time.FormatDate.mmmd)
+}
+
+fn test_get_fmt_time_str() {
+        t :=    time.Time{  year:     1980,
+                            month:    7,
+                            day:      11,
+                            hour:     21,
+                            minute:   23,
+                            second:   42,
+                            uni:      0 }
+
+        assert  '21:23:42' == t.get_fmt_time_str(time.FormatTime.hhmmss24)
+        assert  '21:23' == t.get_fmt_time_str(time.FormatTime.hhmm24)
+        assert  '9:23:42 p.m.' == t.get_fmt_time_str(time.FormatTime.hhmmss12)
+        assert  '9:23 p.m.' == t.get_fmt_time_str(time.FormatTime.hhmm12)
+}
+
+fn test_get_fmt_date_str() {
+        t :=    time.Time{  year:     1980,
+                            month:    7,
+                            day:      11,
+                            hour:     21,
+                            minute:   23,
+                            second:   42,
+                            uni:      0 }
+
+        assert  '11.07.1980' == t.get_fmt_date_str(time.FormatDelimiter.dot,
+                                                   time.FormatDate.ddmmyyyy)
+        assert  '11/07/1980' == t.get_fmt_date_str(time.FormatDelimiter.slash,
+                                                   time.FormatDate.ddmmyyyy)
+        assert  '11-07-1980' == t.get_fmt_date_str(time.FormatDelimiter.hyphen,
+                                                   time.FormatDate.ddmmyyyy)
+        assert  '11 07 1980' == t.get_fmt_date_str(time.FormatDelimiter.space,
+                                                   time.FormatDate.ddmmyyyy)
+        assert  '07.11.1980' == t.get_fmt_date_str(time.FormatDelimiter.dot,
+                                                   time.FormatDate.mmddyyyy)
+        assert  '07/11/1980' == t.get_fmt_date_str(time.FormatDelimiter.slash,
+                                                   time.FormatDate.mmddyyyy)
+        assert  '07-11-1980' == t.get_fmt_date_str(time.FormatDelimiter.hyphen,
+                                                   time.FormatDate.mmddyyyy)
+        assert  '07 11 1980' == t.get_fmt_date_str(time.FormatDelimiter.space,
+                                                   time.FormatDate.mmddyyyy)
+        assert  '11.07.80'   == t.get_fmt_date_str(time.FormatDelimiter.dot,
+                                                   time.FormatDate.ddmmyy)
+        assert  '11/07/80'   == t.get_fmt_date_str(time.FormatDelimiter.slash,
+                                                   time.FormatDate.ddmmyy)
+        assert  '11-07-80'   == t.get_fmt_date_str(time.FormatDelimiter.hyphen,
+                                                   time.FormatDate.ddmmyy)
+        assert  '11 07 80'   == t.get_fmt_date_str(time.FormatDelimiter.space,
+                                                   time.FormatDate.ddmmyy)
+        assert  '07.11.80'   == t.get_fmt_date_str(time.FormatDelimiter.dot,
+                                                   time.FormatDate.mmddyy)
+        assert  '07/11/80'   == t.get_fmt_date_str(time.FormatDelimiter.slash,
+                                                   time.FormatDate.mmddyy)
+        assert  '07-11-80'   == t.get_fmt_date_str(time.FormatDelimiter.hyphen,
+                                                   time.FormatDate.mmddyy)
+        assert  '07 11 80'   == t.get_fmt_date_str(time.FormatDelimiter.space,
+                                                   time.FormatDate.mmddyy)
+        assert  'Jul 11'     == t.get_fmt_date_str(time.FormatDelimiter.space,
+                                                   time.FormatDate.mmmd)
+        assert  'Jul 11'     == t.get_fmt_date_str(time.FormatDelimiter.space,
+                                                   time.FormatDate.mmmdd)
+        assert  'Jul 11 1980' == t.get_fmt_date_str(time.FormatDelimiter.space,
+                                                    time.FormatDate.mmmddyyyy)
+        assert  '1980-07-11'  == t.get_fmt_date_str(time.FormatDelimiter.hyphen,
+                                                    time.FormatDate.yyyymmdd)
+}
+
+fn test_get_fmt_str() {
+        t :=    time.Time{  year:     1980,
+                            month:    7,
+                            day:      11,
+                            hour:     21,
+                            minute:   23,
+                            second:   42,
+                            uni:      0 }
+
+        // Since get_fmt_time_str and get_fmt_date_str do have comprehensive
+        // tests I don't want to exaggerate here with all possible
+        // combinations.
+        assert  '11.07.1980 21:23:42' == t.get_fmt_str(time.FormatDelimiter.dot,
+                                                       time.FormatTime.hhmmss24,
+                                                       time.FormatDate.ddmmyyyy)
+}


### PR DESCRIPTION
* adds public FormatDelimiter, FormatTime and FormatDate enumerations
* adds new pub fn (t Time) get_fmt_time_str(...) string {...}
* adds new pub fn (t Time) get_fmt_date_str(...) string {...}
* modifies pub fn (t Time) get_fmt_str(...) string {...} and all custom
  functions that are formatting Time
* adds documentation and test for following functions
  * format_ss()
  * format()
  * hhmm()
  * hhmm12()
  * hhmmss()
  * ymmdd()
  * ddmmy()
  * md()
  * get_fmt_time_str(...)
  * get_fmt_date_str(...)
  * get_fmt_str(...)
* reduces memory load (no extra allocation for some return vars anymore)
* speedup 'cause of early return under some conditions
* makes the enumerations public

Signed-off-by: Enrico Lefass <enrico.lefass@mailbox.org>