### PR TITLE
Fix missing protos for popen and backtrace_symbols

### DIFF
--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -54,7 +54,7 @@ pub fn print_backtrace_skipping_top_frames(skipframes int) {
 					cmd := 'addr2line -e $executable $addr'
 
 					// taken from os, to avoid depending on the os module inside builtin.v
-					f := byteptr(C.popen(cmd.str, 'r'))
+					f := C.popen(cmd.str, 'r')
 					if isnil(f) {
 						println(sframe) continue
 					}

--- a/vlib/builtin/cfns.v
+++ b/vlib/builtin/cfns.v
@@ -14,11 +14,12 @@ fn C.sprintf(a ...voidptr) byteptr
 fn C.strlen(s byteptr) int
 fn C.isdigit(s byteptr) bool
 
-
-
+// stdio.h
+fn C.popen(c byteptr, t byteptr) voidptr
 
 // <execinfo.h>
 fn backtrace(a voidptr, b int) int
+fn backtrace_symbols(voidptr, int) &byteptr
 fn backtrace_symbols_fd(voidptr, int, int)
 
 // <libproc.h>

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -282,7 +282,7 @@ pub fn (f File) close() {
 }
 
 // system starts the specified command, waits for it to complete, and returns its code.
-fn popen(path string) *C.FILE {
+fn vpopen(path string) *C.FILE {
 	$if windows {
 		mode := 'rb'
 		wpath := path.to_wide()
@@ -333,7 +333,7 @@ pub:
 // exec starts the specified command, waits for it to complete, and returns its output.
 pub fn exec(cmd string) ?Result {
 	pcmd := '$cmd 2>&1'
-	f := popen(pcmd)
+	f := vpopen(pcmd)
 	if isnil(f) {
 		return error('exec("$cmd") failed')
 	}

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -313,7 +313,7 @@ fn posix_wait4_to_exit_status(waitret int) (int,bool) {
 	}
 }
 
-fn pclose(f *C.FILE) int {
+fn vpclose(f *C.FILE) int {
 	$if windows {
 		return int( C._pclose(f) )
 	}
@@ -343,7 +343,7 @@ pub fn exec(cmd string) ?Result {
 		res += tos(buf, vstrlen(buf))
 	}
 	res = res.trim_space()
-	exit_code := pclose(f)
+	exit_code := vpclose(f)
 	//if exit_code != 0 {
 		//return error(res)
 	//}


### PR DESCRIPTION
Trivial missing prototypes fix to remove warnings and crash, notably in backtrace dump