### PR TITLE
compiler: extract testing to tools/vtest.v

### DIFF
--- a/tools/vtest.v
+++ b/tools/vtest.v
@@ -1,4 +1,4 @@
-module compiler
+module main
 
 import (
 	os
@@ -22,7 +22,15 @@ pub fn new_test_sesion(vargs string) TestSession {
 	}
 }
 
-pub fn test_v() {
+fn vexe_path() string {
+	// NB: tools extracted from v require that the first
+	// argument to them to be the v executable location.
+	// They are usually launched by vlib/compiler/vtools.v,
+	// launch_tool/1 , which provides it.
+	return os.args[1]
+}
+
+pub fn main() {
 	args := os.args
 	if args.last() == 'test' {
 		println('Usage:')

--- a/v.v
+++ b/v.v
@@ -58,7 +58,7 @@ fn main() {
 		return
 	}
 	else if 'test' in commands {
-		compiler.test_v()
+		compiler.launch_tool('vtest')
 		return
 	}
 	// Generate the docs and exit

--- a/vlib/compiler/vtools.v
+++ b/vlib/compiler/vtools.v
@@ -1,0 +1,25 @@
+module compiler
+
+import os
+
+pub fn launch_tool(tname string){
+	vexe := vexe_path()
+	vroot := os.dir(vexe)
+	mut oargs := os.args
+	oargs[0] = vexe // make it more explicit
+	tool_exe := os.realpath('$vroot/tools/$tname')
+	tool_source := os.realpath('$vroot/tools/${tname}.v')
+	//////////////////////////////////////////////////////
+	tool_args := oargs.join(' ')
+	tool_command := '$tool_exe $tool_args'
+	//println('Launching: "$tool_command" ...')
+	if !os.file_exists( tool_exe ) {
+		compilation_command := '$vexe -prod $tool_source'
+		//println('Compiling $tname with: "$compilation_command"')
+		tool_compilation := os.exec(compilation_command) or { panic(err) }
+		if tool_compilation.exit_code != 0 {
+			panic('V tool "$tool_source" could not be compiled.')
+		}
+	}
+	exit( os.system(tool_command) )
+}


### PR DESCRIPTION
Extract the test runner functionality from the v compiler to a separate program in tools/vtest.v, that is compiled the first time v is called with test, and afterwards is executed.
It makes the actual v compiler smaller and faster (similarly to the repl extraction).