### PR TITLE
compiler: pass -no-pie to gcc and clang for debug builds

### DIFF
--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -118,13 +118,13 @@ fn (v mut V) cc() {
 	mut optimization_options := '-O2'
 	if v.pref.ccompiler.contains('clang') {
 		if debug_mode {
-			debug_options = '-g -O0'
+			debug_options = '-g -O0 -no-pie'
 		}
 		optimization_options = '-O3 -flto'
 	}
 	if v.pref.ccompiler.contains('gcc') {
 		if debug_mode {
-			debug_options = '-g3'
+			debug_options = '-g3 -no-pie'
 		}
 		optimization_options = '-O3 -fno-strict-aliasing -flto'
 	}


### PR DESCRIPTION
When building debug executables with -g or -cg, pass -no-pie too, otherwise backtraces do not work on more modern linux distros, like latest ubuntu or clearlinux.