### PR TITLE
compiler: move `v up` implementation to tools/vup.v

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ vjs
 ._*
 .vrepl_temp.v
 a.out
+tools/vrepl
+tools/vtest
+tools/vup
+examples/sqlite

--- a/tools/vup.v
+++ b/tools/vup.v
@@ -1,0 +1,21 @@
+import os
+
+fn main() {
+	println('Updating V...')
+	vroot := os.dir(os.args[1])
+	os.chdir(vroot)
+	s := os.exec('git -C "$vroot" pull --rebase origin master') or { panic(err) }
+	println(s.output)
+	$if windows {
+		v_backup_file := '$vroot/v_old.exe'
+		if os.file_exists( v_backup_file ) {
+			os.rm( v_backup_file )
+		}
+		os.mv('$vroot/v.exe', v_backup_file)
+		s2 := os.exec('"$vroot/make.bat"') or { panic(err) }
+		println(s2.output)
+	} $else {
+		s2 := os.exec('make -C "$vroot"') or { panic(err) }
+		println(s2.output)
+	}
+}

--- a/v.v
+++ b/v.v
@@ -33,7 +33,7 @@ fn main() {
 		return
 	}
 	else if 'up' in commands {
-		compiler.update_v()
+		compiler.launch_tool('vup')
 		return
 	}
 	else if 'get' in commands {

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -978,34 +978,6 @@ pub fn env_vflags_and_os_args() []string {
 	return args
 }
 
-pub fn update_v() {
-	println('Updating V...')
-	vroot := os.dir(vexe_path())
-	s := os.exec('git -C "$vroot" pull --rebase origin master') or {
-		verror(err)
-		return
-	}
-	println(s.output)
-	$if windows {
-		v_backup_file := '$vroot/v_old.exe'
-		if os.file_exists( v_backup_file ) {
-			os.rm( v_backup_file )
-		}
-		os.mv('$vroot/v.exe', v_backup_file)
-		s2 := os.exec('"$vroot/make.bat"') or {
-			verror(err)
-			return
-		}
-		println(s2.output)
-	} $else {
-		s2 := os.exec('make -C "$vroot"') or {
-			verror(err)
-			return
-		}
-		println(s2.output)
-	}
-}
-
 pub fn vfmt(args[]string) {
 	file := args.last()
 	if !os.file_exists(file) {


### PR DESCRIPTION
With this PR, similar to `v test` and `v runrepl` now `v up` is also a separate program, launched by the v frontend.

Probably obsoleted by PR #2611 , because #2611 is its extension.