### PR TITLE
os: add win cp

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -129,8 +129,10 @@ pub fn mv(old, new string) {
 // TODO implement actual cp()
 pub fn cp(old, new string) {
 	$if windows {
-		panic('not implemented')
-	}	$else {
+		_old := old.replace('/', '\\')
+		_new := new.replace('/', '\\')
+		C.CopyFile(_old.to_wide(), _new.to_wide(), false)
+	} $else {
 		os.system('cp $old $new')
 	}	
 }

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -126,7 +126,7 @@ pub fn mv(old, new string) {
 	}
 }
 
-// TODO implement actual cp()
+// TODO implement actual cp for linux
 pub fn cp(old, new string) {
 	$if windows {
 		_old := old.replace('/', '\\')

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -117,7 +117,7 @@ fn test_cp() {
   $if windows {
     old_file_name := './example.txt'
     new_file_name := './new_example.txt'
-
+    
     os.write_file(old_file_name, 'Test data 1 2 3, V is awesome #$%^[]!~⭐')
     os.cp(old_file_name, new_file_name)
 

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -119,7 +119,7 @@ fn test_cp() {
     new_file_name := './new_example.txt'
     
     os.write_file(old_file_name, 'Test data 1 2 3, V is awesome #$%^[]!~⭐')
-    os.cp(old_file_name, new_file_name)
+    result := os.cp(old_file_name, new_file_name) or { panic('$err: errcode: $errcode') }
 
     old_file := os.read_file(old_file_name) or { panic(err) }
     new_file := os.read_file(new_file_name) or { panic(err) }

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -113,6 +113,23 @@ fn test_walk() {
 	os.rmdir(folder)
 }
 
+fn test_cp() {
+  $if windows {
+    old_file_name := './example.txt'
+    new_file_name := './new_example.txt'
+
+    os.write_file(old_file_name, 'Test data 1 2 3, V is awesome #$%^[]!~⭐')
+    os.cp(old_file_name, new_file_name)
+
+    old_file := os.read_file(old_file_name) or { panic(err) }
+    new_file := os.read_file(new_file_name) or { panic(err) }
+    assert old_file == new_file
+    
+    os.rm(old_file_name)
+    os.rm(new_file_name)
+  }
+}
+
 //fn test_fork() {
 //  pid := os.fork()
 //  if pid == 0 {

--- a/vlib/os/os_windows.v
+++ b/vlib/os/os_windows.v
@@ -61,7 +61,7 @@ pub fn ls(path string) ?[]string {
 	// }
 	// C.FindClose(h_find_dir)
 	if !dir_exists(path) {
-		return error('ls() couldnt open dir "$path"')
+		return error('ls() couldnt open dir "$path": directory does not exist')
 	}
 	// NOTE: Should eventually have path struct & os dependant path seperator (eg os.PATH_SEPERATOR)
 	// we need to add files to path eg. c:\windows\*.dll or :\windows\*


### PR DESCRIPTION
This PR implements `os.cp` for Windows using the Windows API, and adds a test for `os.cp` in `os_test.v`.
`os.cp` returns a `?bool` where `true` represents success and `false` represents a failure, and it also returns the respective error code.

```v
// file os.v
pub fn cp(old, new string) ?bool {
	$if windows {
		_old := old.replace('/', '\\')
		_new := new.replace('/', '\\')
		C.CopyFile(_old.to_wide(), _new.to_wide(), false)

		result := C.GetLastError()
		if result == 0 {
			return true
		} else {
			return error_with_code('failed to copy $old to $new', int(result))
		}
	} $else {
		os.system('cp $old $new')
		return true // TODO make it return true or error when cp for linux is implemented
	}
}
```

```v
// file os_test.v
fn test_cp() {
  $if windows {
    old_file_name := './example.txt'
    new_file_name := './new_example.txt'
    
    os.write_file(old_file_name, 'Test data 1 2 3, V is awesome #$%^[]!~⭐')
    result := os.cp(old_file_name, new_file_name) or { panic('$err: errcode: $errcode') }

    old_file := os.read_file(old_file_name) or { panic(err) }
    new_file := os.read_file(new_file_name) or { panic(err) }
    assert old_file == new_file
    
    os.rm(old_file_name)
    os.rm(new_file_name)
  }
}
```

Usage of `os.cp` is as simple as `result := os.cp("file1.txt", "file2.txt") or { ... }`
Note: `os.cp` doesn't create non-existing directories, that's up to the user