### PR TITLE
compiler: rename struct V to struct VFrontend to avoid V warnings

### DIFF
--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -14,7 +14,7 @@ fn todo() {
 	
 }	
 
-fn (v mut V) cc() {
+fn (v mut VFrontend) cc() {
 	v.build_thirdparty_obj_files()
 	vexe := vexe_path()
 	vdir := os.dir(vexe)
@@ -349,7 +349,7 @@ start:
 }
 
 
-fn (c mut V) cc_windows_cross() {
+fn (c mut VFrontend) cc_windows_cross() {
 	if !c.out_name.ends_with('.exe') {
 		c.out_name = c.out_name + '.exe'
 	}
@@ -418,7 +418,7 @@ fn (c mut V) cc_windows_cross() {
 	println('Done!')
 }
 
-fn (c &V) build_thirdparty_obj_files() {
+fn (c &VFrontend) build_thirdparty_obj_files() {
 	for flag in c.get_os_cflags() {
 		if flag.value.ends_with('.o') {			
 			rest_of_module_flags := c.get_rest_of_module_cflags( flag )

--- a/vlib/compiler/cflags.v
+++ b/vlib/compiler/cflags.v
@@ -19,7 +19,7 @@ fn (c &CFlag) str() string {
 }
 
 // get flags for current os
-fn (v &V) get_os_cflags() []CFlag {
+fn (v &VFrontend) get_os_cflags() []CFlag {
 	mut flags := []CFlag
 	for flag in v.table.cflags {
 		if flag.os == ''
@@ -33,7 +33,7 @@ fn (v &V) get_os_cflags() []CFlag {
 	return flags
 }
 
-fn (v &V) get_rest_of_module_cflags(c &CFlag) []CFlag {
+fn (v &VFrontend) get_rest_of_module_cflags(c &CFlag) []CFlag {
 	mut flags := []CFlag
 	cflags := v.get_os_cflags()
 	for flag in cflags {

--- a/vlib/compiler/cgen.v
+++ b/vlib/compiler/cgen.v
@@ -184,7 +184,7 @@ fn (g mut CGen) register_thread_fn(wrapper_name, wrapper_text, struct_text strin
 	g.thread_args << wrapper_text
 }
 
-fn (v &V) prof_counters() string {
+fn (v &VFrontend) prof_counters() string {
 	mut res := []string
 	// Global fns
 	//for f in c.table.fns {
@@ -321,7 +321,7 @@ fn platform_postfix_to_ifdefguard(name string) string {
 // C struct definitions, ordered
 // Sort the types, make sure types that are referenced by other types
 // are added before them.
-fn (v &V) type_definitions() string {
+fn (v &VFrontend) type_definitions() string {
 	mut types := []Type // structs that need to be sorted
 	mut builtin_types := []Type // builtin types
 	// builtin types need to be on top

--- a/vlib/compiler/live.v
+++ b/vlib/compiler/live.v
@@ -3,7 +3,7 @@ module compiler
 import os
 import time
 
-fn (v &V) generate_hotcode_reloading_compiler_flags() []string {
+fn (v &VFrontend) generate_hotcode_reloading_compiler_flags() []string {
 	mut a := []string
 	if v.pref.is_live || v.pref.is_so {
 		// See 'man dlopen', and test running a GUI program compiled with -live
@@ -17,7 +17,7 @@ fn (v &V) generate_hotcode_reloading_compiler_flags() []string {
 	return a
 }
 
-fn (v &V) generate_hotcode_reloading_declarations() {
+fn (v &VFrontend) generate_hotcode_reloading_declarations() {
 	mut cgen := v.cgen
 	if v.os != .windows {
 		if v.pref.is_so {
@@ -44,7 +44,7 @@ void pthread_mutex_unlock(HANDLE *m) {
 	}
 }
 
-fn (v &V) generate_hotcode_reloading_main_caller() {
+fn (v &VFrontend) generate_hotcode_reloading_main_caller() {
 	if !v.pref.is_live { return }
 	// We are in live code reload mode, so start the .so loader in the background
 	mut cgen := v.cgen
@@ -68,7 +68,7 @@ fn (v &V) generate_hotcode_reloading_main_caller() {
 	}
 }
 
-fn (v &V) generate_hot_reload_code() {
+fn (v &VFrontend) generate_hot_reload_code() {
 	mut cgen := v.cgen
 	
 	// Hot code reloading

--- a/vlib/compiler/modules.v
+++ b/vlib/compiler/modules.v
@@ -101,7 +101,7 @@ fn (it &ImportTable) is_used_import(alias string) bool {
 }
 
 // return resolved dep graph (order deps)
-pub fn (v &V) resolve_deps() &DepGraph {
+pub fn (v &VFrontend) resolve_deps() &DepGraph {
 	graph := v.import_graph()
 	deps_resolved := graph.resolve()
 	if !deps_resolved.acyclic {
@@ -111,7 +111,7 @@ pub fn (v &V) resolve_deps() &DepGraph {
 }
 
 // graph of all imported modules
-pub fn(v &V) import_graph() &DepGraph {
+pub fn(v &VFrontend) import_graph() &DepGraph {
 	mut graph := new_dep_graph()
 	for p in v.parsers {
 		mut deps := []string
@@ -132,7 +132,7 @@ pub fn(graph &DepGraph) imports() []string {
 	return mods
 }
 
-fn (v &V) module_path(mod string) string {
+fn (v &VFrontend) module_path(mod string) string {
 	// submodule support
 	if mod.contains('.') {
 		return mod.replace('.', os.path_separator)
@@ -144,7 +144,7 @@ fn (v &V) module_path(mod string) string {
 // 'strings' => 'VROOT/vlib/strings'
 // 'installed_mod' => '~/.vmodules/installed_mod'
 // 'local_mod' => '/path/to/current/dir/local_mod'
-fn (v &V) find_module_path(mod string) ?string {
+fn (v &VFrontend) find_module_path(mod string) ?string {
 	mod_path := v.module_path(mod)
 	// First check for local modules in the same directory
 	mut import_path := os.getwd() + '${os.path_separator}$mod_path'

--- a/vlib/compiler/msvc.v
+++ b/vlib/compiler/msvc.v
@@ -222,7 +222,7 @@ fn find_msvc() ?MsvcResult {
 	}
 }
 
-pub fn (v mut V) cc_msvc() {
+pub fn (v mut VFrontend) cc_msvc() {
 	r := find_msvc() or {
 		// TODO: code reuse
 		if !v.pref.is_keep_c && v.out_name_c != 'v.c' && v.out_name_c != 'v_macos.c' {

--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -17,7 +17,7 @@ struct Parser {
 	// C ifdef guard clause that must be put before
 	// the #include directives in the parsed .v file
 	file_pcguard   string
-	v              &V
+	v              &VFrontend
 	pref           &Preferences // Preferences shared from V struct
 mut:
 	scanner        &Scanner
@@ -82,19 +82,19 @@ const (
 
 // new parser from string. unique id specified in `id`.
 // tip: use a hashing function to auto generate `id` from `text` eg. sha1.hexhash(text)
-fn (v mut V) new_parser_from_string(text string) Parser {
+fn (v mut VFrontend) new_parser_from_string(text string) Parser {
 	mut p := v.new_parser(new_scanner(text))
 	p.scan_tokens()
 	return p
 }
 
-fn (v mut V) reset_cgen_file_line_parameters(){
+fn (v mut VFrontend) reset_cgen_file_line_parameters(){
 	v.cgen.line = 0
 	v.cgen.file = ''
 	v.cgen.line_directives = v.pref.is_vlines
 }
 
-fn (v mut V) new_parser_from_file(path string) Parser {
+fn (v mut VFrontend) new_parser_from_file(path string) Parser {
 	v.reset_cgen_file_line_parameters()
 	//println('new_parser("$path")')
 	mut path_pcguard := ''
@@ -146,7 +146,7 @@ fn (v mut V) new_parser_from_file(path string) Parser {
 
 // creates a new parser. most likely you will want to use
 // `new_parser_file` or `new_parser_string` instead.
-fn (v mut V) new_parser(scanner &Scanner) Parser {
+fn (v mut VFrontend) new_parser(scanner &Scanner) Parser {
 	v.reset_cgen_file_line_parameters()
 	mut p := Parser {
 		scanner: scanner


### PR DESCRIPTION
When compiling programs that `import compiler` V produces warnings like these:
warning: vlib/compiler/main.v:58:10: struct names must have more than one character

After this PR, the V struct is renamed to VFrontend, so it is both longer (thus easier to search for) and more meaningful too (because it collects the information that the V frontend program accumulates, like preferences, chosen backend compiler, parser states, program options and so on).