### PR TITLE
os: cp_r fn to copy files and directory recursively with checks

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -151,7 +151,7 @@ pub fn cp(old, new string) ?bool {
 	}
 }
 
-fn cp_r(source_path, dest_path string, overwrite bool) ?bool{
+pub fn cp_r(source_path, dest_path string, overwrite bool) ?bool{
 	if !os.file_exists(source_path) {
 		return error('Source path doesn\'t exist')
 	}

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -171,8 +171,8 @@ pub fn cp_r(source_path, dest_path string, overwrite bool) ?bool{
 	}
 	files := os.ls(source_path) or { return error(err) }
 	for file in files {
-		sp := source_path + os.path_separator + file
-		dp := dest_path + os.path_separator + file
+		sp := filepath.join(source_path, file)
+		dp := filepath.join(dest_path, file)
 		if os.is_dir(sp) {
 			os.mkdir(dp)
 		}

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -157,10 +157,8 @@ pub fn cp_r(source_path, dest_path string, overwrite bool) ?bool{
 	}
 	//single file copy
 	if !os.is_dir(source_path) {
-		mut adjasted_path := dest_path
-		if os.is_dir(adjasted_path) {
-			adjasted_path = dest_path + os.path_separator + os.basedir(source_path)
-		}
+		adjasted_path := if os.is_dir(dest_path) { 
+			filepath.join(dest_path, os.basedir(source_path)) } else { dest_path }
 		if os.file_exists(adjasted_path) {
 			if overwrite { os.rm(adjasted_path) }
 			else { return error('Destination file path already exist') }

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -130,6 +130,24 @@ fn test_cp() {
   }
 }
 
+fn test_cp_r() {
+  //fileX -> dir/fileX
+  os.write_file('ex1.txt', 'wow!')
+  os.mkdir('ex')
+  os.cp_r('ex1.txt', 'ex', false) or { panic(err) }
+  old := os.read_file('ex1.txt') or { panic(err) }
+  new := os.read_file('ex/ex1.txt') or { panic(err) }
+  assert old == new
+  os.mkdir('ex/ex2')
+  os.write_file('ex2.txt', 'great!')
+  os.cp_r('ex2.txt', 'ex/ex2', false) or { panic(err) }
+  old2 := os.read_file('ex2.txt') or { panic(err) }
+  new2 := os.read_file('ex/ex2/ex2.txt') or { panic(err) }
+  assert old2 == new2
+  //recurring on dir -> local dir
+  os.cp_r('ex', './', true) or { panic(err) }
+}
+
 //fn test_fork() {
 //  pid := os.fork()
 //  if pid == 0 {


### PR DESCRIPTION
This functions allows copy of a file or directory (recursively) doing the right checks about file naming and overwriting (that is settable with a boolean param). It uses only `os.v` functions, all tested.