### PR TITLE
stats: use c style for loop

### DIFF
--- a/vlib/math/stats/stats.v
+++ b/vlib/math/stats/stats.v
@@ -118,13 +118,11 @@ pub fn mode(arr []f64) f64 {
 	for v in arr {
 		freqs<<freq(arr,v)
 	}
-	mut i := 0
 	mut max := 0
-	for i < freqs.len {
+	for i := 0; i < freqs.len; i++ {
 		if freqs[i] > freqs[max] {
 			max = i
 		}
-		i++
 	}
 	return arr[max]
 }

--- a/vlib/math/stats/stats_test.v
+++ b/vlib/math/stats/stats_test.v
@@ -35,7 +35,6 @@ fn test_geometric_mean() {
 	assert o.str().eq('5.159932')
 	data = [f64(-3.0),f64(67.31),f64(4.4),f64(1.89)]
 	o = stats.geometric_mean(data)
-	println(o)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
 	assert o.str().eq('nan') || o.str().eq('-nan') || o.str().eq('-1.#IND00') || o == f64(0) || o.str().eq('-nan(ind)') // Because in math it yields a complex number
 	data = [f64(12.0),f64(7.88),f64(76.122),f64(54.83)]


### PR DESCRIPTION
The function `mode` in the module `stats` uses a while style for loop that can be replaced by a c style for loop.

Also, there is a leftover `println` statement in `stats_test.v` that should be removed.