### PR TITLE
builtin: use last_index for find_between function

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -648,7 +648,7 @@ pub fn (s string) find_between(start, end string) string {
 	}
 	// First get everything to the right of 'start'
 	val := s.right(start_pos + start.len)
-	end_pos := val.index(end)
+	end_pos := val.last_index(end)
 	if end_pos == -1 {
 		return val
 	}


### PR DESCRIPTION
This PR uses `last_index` as finding for the last character of the string as opposed to using `index` function which fixes some of the cases wherein the function might not work as expected.

Before:
```v
tag_str := '{{foobar}}'
println(tag_str.find_between('{', '}')) // {foobar
```

After:
```v
tag_str := '{{foobar}}'
println(tag_str.find_between('{', '}')) // {foobar}
```