### PR TITLE
urllib: fix crash when converting URL to string

### DIFF
--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -564,7 +564,7 @@ fn parse_authority(authority string) ?ParseAuthorityRes {
 		host = h
 	}
 	if i < 0 {
-		return ParseAuthorityRes{host: host}
+		return ParseAuthorityRes{host: host, user: user}
 	}
 	mut userinfo := authority[..i]
 	if !valid_userinfo(userinfo) {


### PR DESCRIPTION
This fixes a crash when trying to convert a `URL` to string. 

For example, running this code resulted in a crash:
```v
import net.urllib
fn main(){
	url := urllib.parse("https://en.wikipedia.org/wiki/Brazil_(1985_film)") or {
		panic("unable to parse URL")
	}
	println(url.str())
}
```
Reference issue: #2670