### PR TITLE
Fix nix realpath cast warning

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -865,7 +865,9 @@ pub fn realpath(fpath string) string {
 		res = int( C._fullpath( fullpath, fpath.str, MAX_PATH ) )
 	}
 	$else{
-		res = int( C.realpath( fpath.str, fullpath ) )
+		// here we want an int==0 if realpath failed, in which case
+		// realpath would return NULL, and !isnil(NULL) would be false==0
+		res = int( !isnil(C.realpath( fpath.str, fullpath )) )
 	}
 	if res != 0 {
 		return string(fullpath, vstrlen(fullpath))


### PR DESCRIPTION
This trivial change fixes a warning on 64 bit linux related to realpath() returning a void *, that we cast to an int

The solution is to obtain a bool stating the pointer is NULL, inverting it, then casting the bool to an int