### PR TITLE
F fix i64 overflow warning

### DIFF
--- a/vlib/math/const.v
+++ b/vlib/math/const.v
@@ -41,7 +41,10 @@ pub const (
 	min_i16 = -32768
 	max_i32 = 2147483647
 	min_i32 = -2147483648
-	min_i64 = -9223372036854775808
+	// -9223372036854775808 is wrong because C compilers parse litteral values
+	// without sign first, and 9223372036854775808 overflows i64, hence the
+	// consecutive subtraction by 1
+	min_i64 = -9223372036854775807 - 1
 	max_i64 = 9223372036854775807
 	max_u8  = 255
 	max_u16 = 65535

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -865,7 +865,9 @@ pub fn realpath(fpath string) string {
 		res = int( C._fullpath( fullpath, fpath.str, MAX_PATH ) )
 	}
 	$else{
-		res = int( C.realpath( fpath.str, fullpath ) )
+		// here we want an int==0 if realpath failed, in which case
+		// realpath would return NULL, and !isnil(NULL) would be false==0
+		res = int( !isnil(C.realpath( fpath.str, fullpath )) )
 	}
 	if res != 0 {
 		return string(fullpath, vstrlen(fullpath))


### PR DESCRIPTION
This trivial fix removes an i64 overflow warning

This is due to C compilers treating litteral values without sign first
the easy fix is to subsequently subtract by 1