### PR TITLE
Optimize reserved type check in O(1) and apply it to for cycles

### DIFF
--- a/vlib/compiler/for.v
+++ b/vlib/compiler/for.v
@@ -22,6 +22,7 @@ fn (p mut Parser) for_st() {
 	else if next_tok == .decl_assign || next_tok == .assign || p.tok == .semicolon {
 		p.genln('for (')
 		if next_tok == .decl_assign {
+			p.check_not_reserved()
 			p.var_decl()
 		}
 		else if p.tok != .semicolon {

--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -697,8 +697,8 @@ fn (p mut Parser) check_string() string {
 }
 
 fn (p mut Parser) check_not_reserved () {
-	if p.lit in Reserved_Types {
-		p.error('`$p.lit` can\'t be used as name')
+	if Reserved_Types[p.lit] { 
+		p.error('`$p.lit` can\'t be used as name') 
 	}
 }
 


### PR DESCRIPTION
This PR use O(1) access (instead of using `in`) to reserved types map and the check is applied also to `for` cycles when a var is declared . #2669 