### PR TITLE
Fix `$if msvc` conditional define.

### DIFF
--- a/vlib/compiler/comptime.v
+++ b/vlib/compiler/comptime.v
@@ -75,7 +75,7 @@ fn (p mut Parser) comp_time() {
 			p.comptime_if_block('__MINGW32__')
 		}
 		else if name == 'msvc' {
-			p.comptime_if_block('__MSC_VER__')
+			p.comptime_if_block('_MSC_VER')
 		}
 		else if name == 'clang' {
 			p.comptime_if_block('__clang__')


### PR DESCRIPTION
MSVC probably because it desires to be unique, defines `_MSC_VER` instead of `__MSC_VER__` ...