### PR TITLE
readline: fix incorrect cursor position when using ANSI character sequences in prompt

### DIFF
--- a/vlib/readline/readline_linux.v
+++ b/vlib/readline/readline_linux.v
@@ -100,10 +100,7 @@ pub fn (r mut Readline) read_line_utf8(prompt string) ?ustring {
   else {
     r.previous_lines[0] = ''.ustring()
   }
-  if !r.is_raw {
-    r.enable_raw_mode()
-  }
-
+  
   print(r.prompt)
   for {
     c := r.read_char()
@@ -115,7 +112,7 @@ pub fn (r mut Readline) read_line_utf8(prompt string) ?ustring {
 
   r.previous_lines[0] = ''.ustring()
   r.search_index = 0
-  r.disable_raw_mode()
+  
   if r.current.s == '' {
     return error('empty line')
   }


### PR DESCRIPTION
Toggling raw mode is unnecessary and programs run absolutely fine (even better) without it. Especially when handling ANSI character sequences, terminal with raw_mode acts weird: the cursor jumps ahead and always stays ahead.

Reference issue: #2701 

Before:
![Screenshot_20191108_174319](https://user-images.githubusercontent.com/7473959/68478575-11f40500-0252-11ea-82a7-f4c3170c757b.png)

After:
![Screenshot_20191108_180445](https://user-images.githubusercontent.com/7473959/68478684-4d8ecf00-0252-11ea-8979-682cbd6ae1d6.png)

**Note: maybe raw mode has other uses, I don't know. But things seem to be working fine without it.**
