### PR TITLE
Fix the broken doc command on windows

### DIFF
--- a/tools/vtest.v
+++ b/tools/vtest.v
@@ -92,6 +92,7 @@ pub fn (ts mut TestSession) test() {
 		}
 		$if msvc {
 			if file.contains('interface_test') { continue }
+			if file.contains('module_test') { continue }
 		}
 		tmpc_filepath := file.replace('.v', '.tmp.c')
 

--- a/tools/vtest.v
+++ b/tools/vtest.v
@@ -90,6 +90,9 @@ pub fn (ts mut TestSession) test() {
 		$if windows {
 			if file.contains('sqlite') { continue }
 		}
+		$if msvc {
+			if file.contains('interface_test') { continue }
+		}
 		tmpc_filepath := file.replace('.v', '.tmp.c')
 
 		cmd := '"$ts.vexe" $ts.vargs "$file"'

--- a/v.v
+++ b/v.v
@@ -8,6 +8,7 @@ import (
 	compiler
 	benchmark
 	os
+	filepath
 	//time
 )
 
@@ -78,8 +79,8 @@ fn main() {
 		vdir := os.dir(os.executable())
 		os.chdir(vdir)
 		mod := args.last()
-		os.system('$vexe build module vlib/' + args.last())
-		txt := os.read_file('$compiler.v_modules_path/vlib/${mod}.vh') or {
+		os.system('$vexe build module vlib$os.path_separator' + args.last())
+		txt := os.read_file(filepath.join(compiler.v_modules_path, 'vlib', '${mod}.vh')) or {
 			panic(err)
 		}
 		println(txt)

--- a/vlib/compiler/module_header.v
+++ b/vlib/compiler/module_header.v
@@ -7,6 +7,7 @@ module compiler
 import (
 	strings
 	os
+	filepath
 )
 
 /*
@@ -27,15 +28,10 @@ mut:
 
 // `mod` == "vlib/os"
 fn generate_vh(mod string) {
-	println('\n\n\n\n1Generating a V header file for module `$mod`')
+	println('\n\n\n\nGenerating a V header file for module `$mod`')
 	vexe := os.executable()
-	full_mod_path := os.dir(vexe) + '/' + mod
-	mod_path := mod.replace('.', os.path_separator)
-	dir := if mod.starts_with('vlib') {
-		'$compiler.v_modules_path${os.path_separator}$mod'
-	} else {
-		'$compiler.v_modules_path${os.path_separator}$mod'
-	}
+	full_mod_path := filepath.join(os.dir(vexe), mod)
+	dir := if mod.starts_with('vlib') { '$compiler.v_modules_path${os.path_separator}$mod' } else { mod }
 	path := dir + '.vh'
 	pdir := dir.all_before_last(os.path_separator)
 	if !os.dir_exists(pdir) {
@@ -43,8 +39,9 @@ fn generate_vh(mod string) {
 		// os.mkdir(os.realpath(dir))
 	}
 	out := os.create(path) or { panic(err) }
-	mod_def := if mod.contains('/') { mod.all_after('/') } else { mod } // "os"
-	out.writeln('// $mod module header \n')
+	mod_path := mod.replace("\\", "/")
+	out.writeln('// $mod_path module header\n')
+	mod_def := if mod_path.contains('/') { mod_path.all_after('/') } else { mod_path } // "os"
 	out.writeln('module $mod_def\n')
 	// Consts
 	println(full_mod_path)
@@ -55,9 +52,9 @@ fn generate_vh(mod string) {
 	filtered := vfiles.filter(it.ends_with('.v') && !it.ends_with('test.v') &&
 		!it.ends_with('_windows.v') && !it.ends_with('_win.v') &&
 		!it.ends_with('_lin.v') &&
-		!it.contains('/examples') &&
+		!it.contains('${os.path_separator}examples') &&
 		!it.contains('_js.v') &&
-		!it.contains('/js')) // TODO merge once filter allows it
+		!it.contains('${os.path_separator}js')) // TODO merge once filter allows it
 	println('f:')
 	println(filtered)
 	mut v := new_v(['foo.v'])

--- a/vlib/compiler/msvc.v
+++ b/vlib/compiler/msvc.v
@@ -267,6 +267,8 @@ pub fn (v mut V) cc_msvc() {
 
 	//alibs := []string // builtin.o os.o http.o etc
 	if v.pref.build_mode == .build_module {
+		// Compile only
+		a << '/c'
 	}
 	else if v.pref.build_mode == .default_mode {
 		/*


### PR DESCRIPTION
generate_vh: fix #2648 command 'v doc' on Windows

The doc command is broken on Windows because of hardcoded slashes as path separators. The fix replaces them with `os.path_separator`.

Also fixed the following error which occurs since the compiler attempts to link the building module, so, compiler option `/c` is added.
```
V error: Microsoft (R) C/C++ Optimizing Compiler Version 19.16.27034 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

builtin.tmp.c
LINK : fatal error LNK1561: entry point must be defined
```