### PR TITLE
parser: check type for all integer only assignment operators

### DIFF
--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -1301,20 +1301,13 @@ fn ($v.name mut $v.typ) $p.cur_fn.name (...) {
 		}
 		p.cgen.resetln('memcpy( (& $left), ($etype{$expr}), sizeof( $left ) );')
 	}
-	else if tok == .left_shift_assign || tok == .righ_shift_assign {
+	// check type for <<= >>= %= ^= &= |=
+	else if tok in [.left_shift_assign, .righ_shift_assign, .mod_assign, .xor_assign, .and_assign, .or_assign] {
 		if !is_integer_type(p.assigned_type) {
-			p.error_with_token_index( 'cannot use shift operator on non-integer type `$p.assigned_type`', errtok)
+			p.error_with_token_index( 'cannot use ${tok.str()} assignment operator on non-integer type `$p.assigned_type`', errtok)
 		}
 		if !is_integer_type(expr_type) {
-			p.error_with_token_index( 'cannot use non-integer type `$expr_type` as shift argument', errtok)
-		}
-	}
-	else if tok == .mod_assign {
-		if !is_integer_type(p.assigned_type) {
-			p.error_with_token_index( 'cannot use modulo operator on non-integer type `$p.assigned_type`', errtok)
-		}
-		if !is_integer_type(expr_type) {
-			p.error_with_token_index( 'cannot use non-integer type `$expr_type` as modulo argument', errtok)
+			p.error_with_token_index( 'cannot use non-integer type `$expr_type` as ${tok.str()} argument', errtok)
 		}
 	}
 	else if !p.builtin_mod && !p.check_types_no_throw(expr_type, p.assigned_type) {


### PR DESCRIPTION
Assignment operators %=, &=, |=, ^=, >>=, <<= are limited to integers only.