### PR TITLE
string: update split() method

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -315,8 +315,8 @@ pub fn (s string) split(delim string) []string {
 	// 	return res
 	// }
 	if delim.len == 0 {
-		for i := 0; i < s.len; i++ {
-			res << s.substr(i, i+1)
+		for ch in s {
+			res << ch.str()
 		}
 		return res
 	}

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -310,8 +310,14 @@ fn (s string) add(a string) string {
 pub fn (s string) split(delim string) []string {
 	// println('string split delim="$delim" s="$s"')
 	mut res := []string
+	// if delim.len == 0 {
+	// 	res << s
+	// 	return res
+	// }
 	if delim.len == 0 {
-		res << s
+		for i := 0; i < s.len; i++ {
+			res << s.substr(i, i+1)
+		}
 		return res
 	}
 	if delim.len == 1 {

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -113,6 +113,17 @@ fn test_split() {
 	assert vals[0] == 'l'
 	assert vals[1] == 'l'
 	assert vals[2] == 'l'
+	// /////////
+	s = 'awesome'
+	a := s.split('')
+	assert a.len == 7
+	assert a[0] == 'a'
+	assert a[1] == 'w'
+	assert a[2] == 'e'
+	assert a[3] == 's'
+	assert a[4] == 'o'
+	assert a[5] == 'm'
+	assert a[6] == 'e'
 }
 
 fn test_trim_space() {


### PR DESCRIPTION
I think it will be better if the split () method works like this:
```go
s := 'awesome'
a := s.split('')
print(a)
``` 
Output:
```go
["a", "w", "e", "s", "o", "m", "e"]
```

`split()` method will return an array that contains each char of the string if we pass an empty string `''`.

The old way will only return all strings wrapped in an array. it's like converting strings to arrays. I don't think this is expected. What do you think guys?