### PR TITLE
pointer:multi-level pointer

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -123,6 +123,13 @@ pub fn (s string) cstr() byteptr {
 	return clone.str
 }
 */
+pub fn (s string) replace_once(rep, with string) string {
+    index := s.index(rep)
+    if index != -1 {
+        return s.substr(0,index) + with + s.substr(index + rep.len, s.len)
+    }
+    return s
+}
 
 pub fn (s string) replace(rep, with string) string {
 	if s.len == 0 || rep.len == 0 {

--- a/vlib/compiler/table.v
+++ b/vlib/compiler/table.v
@@ -334,7 +334,7 @@ fn (table &Table) known_type(typ_ string) bool {
 	mut typ := typ_
 	// 'byte*' => look up 'byte', but don't mess up fns
 	if typ.ends_with('*') && !typ.contains(' ') {
-		typ = typ[..typ.len - 1]
+		typ = typ.replace('*', '')
 	}
 	t := table.typesmap[typ]
 	return t.name.len > 0 && !t.is_placeholder
@@ -558,7 +558,7 @@ fn (p &Parser) find_type(name string) Type {
 fn (t &Table) find_type(name_ string) Type {
 	mut name := name_
 	if name.ends_with('*') && !name.contains(' ') {
-		name = name[..name.len - 1]
+		name = name.replace('*', '')
 	}
 	if !(name in t.typesmap) {
 		//println('ret Type')

--- a/vlib/compiler/tests/pointers_test.v
+++ b/vlib/compiler/tests/pointers_test.v
@@ -1,0 +1,24 @@
+
+fn test_pointer_arithmetic() {
+	arr := [1,2,3,4]
+	unsafe {
+		mut parr := *int(arr.data)
+		parr += 1
+		assert 2 == *parr
+	}
+}
+
+fn test_multi_level_pointer_dereferencing() {
+	n := 100
+	pn := &n
+	ppn := &pn
+
+	unsafe {
+		mut pppn := &ppn
+		***pppn = 300
+		pppa := ***int(pppn)
+		assert 300 == ***pppa
+	}
+
+	assert n == 300 // updated by the unsafe pointer manipulation
+}


### PR DESCRIPTION
With multi-level pointers, we can more easily encapsulate C functions

```
fn main() {
	arr := [1,2,3,4]
	mut parr := *int(arr.data)
	parr += 1
	println(*parr)

	n := 100
	pn := &n
	ppn := &pn
	mut pppn := &ppn

	***pppn = 300

	pppa := ***int(pppn)
	println(***pppa)
}
```
