### PR TITLE
v test v: cleanup more temporary files

### DIFF
--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -193,5 +193,7 @@ fn cleanup_leftovers(){
 	os.rm('ex/ex1.txt')
 	os.rm('ex')  
 	os.rm('ex2/ex2.txt')
-	os.rm('ex2')  
+	os.rm('ex2')
+	os.rm('ex1.txt')
+	os.rm('ex2.txt')
 }

--- a/vlib/sqlite/sqlite_test.v
+++ b/vlib/sqlite/sqlite_test.v
@@ -1,7 +1,9 @@
+import os
 import sqlite
 
 fn test_sqlite() {
-	db := sqlite.connect('users.db')
+	db_file := 'users.db'
+	db := sqlite.connect(db_file)
 	db.exec("drop table if exists users")
 	db.exec("create table users (id integer primary key, name text default '');")
 	
@@ -20,4 +22,5 @@ fn test_sqlite() {
 	for row in users {
 		println(row.vals)
 	}	
+	os.rm(db_file)
 }	


### PR DESCRIPTION
After this PR, running `v test v` cleans up users.db, ex1.txt, and ex2.txt from the toplevel vroot folder.