### PR TITLE
fractions: panic when reciprocal produces invalid fraction

### DIFF
--- a/vlib/math/fractions/fraction.v
+++ b/vlib/math/fractions/fraction.v
@@ -79,10 +79,8 @@ pub fn (f1 Fraction) divide(f2 Fraction) Fraction {
 
 // Fraction reciprocal method
 pub fn (f1 Fraction) reciprocal() Fraction {
-	if f1.n != 0 {
-		return Fraction{f1.d, f1.n}
-	}
-	panic('Denominator cannot be zero')
+	if f1.n == 0 { panic('Denominator cannot be zero') }
+	return Fraction{f1.d, f1.n}
 }
 
 // Fraction method which gives greatest common divisor of numerator and denominator

--- a/vlib/math/fractions/fraction.v
+++ b/vlib/math/fractions/fraction.v
@@ -79,7 +79,10 @@ pub fn (f1 Fraction) divide(f2 Fraction) Fraction {
 
 // Fraction reciprocal method
 pub fn (f1 Fraction) reciprocal() Fraction {
-	return Fraction{f1.d, f1.n}
+	if f1.n != 0 {
+		return Fraction{f1.d, f1.n}
+	}
+	panic('Denominator cannot be zero')
 }
 
 // Fraction method which gives greatest common divisor of numerator and denominator


### PR DESCRIPTION
Fractions with zero numerator shouldn't be allowed to call the reciprocal method.

The following now panics.
```v
import math.fractions

fn main() {
	a := fractions.fraction(0, 5)
	println(a.reciprocal())
}
```