### PR TITLE
WIP -- Fix Windows warnings (cc)

### DIFF
--- a/thirdparty/vschannel/vschannel.c
+++ b/thirdparty/vschannel/vschannel.c
@@ -1092,5 +1092,3 @@ static void get_new_client_credentials(TlsContext *tls_ctx) {
 		break;
 	}
 }
-	
-

--- a/thirdparty/vschannel/vschannel.h
+++ b/thirdparty/vschannel/vschannel.h
@@ -1,7 +1,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <windows.h> 
+#include <windows.h>
 #include <winsock.h>
 #include <wincrypt.h>
 #include <wintrust.h>

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -162,9 +162,10 @@ fn v_ptr_free(ptr voidptr) {
 
 pub fn is_atty(fd int) int {
 	$if windows {
-		mut mode := 0
-		C.GetConsoleMode(C._get_osfhandle(fd), &mode)
-		return mode
+		mut mode := u32(0)
+		osfh := voidptr(C._get_osfhandle(fd))
+		C.GetConsoleMode(osfh, voidptr(&mode))
+		return int(mode)
 	} $else {
 		return C.isatty(fd)
 	}

--- a/vlib/builtin/cfns.v
+++ b/vlib/builtin/cfns.v
@@ -32,5 +32,4 @@ fn C.realpath(byteptr, byteptr) &char
 // Windows
 fn C._setmode(int, int)
 fn C._fileno(int) int
-
-
+fn C._get_osfhandle(fd int) voidptr

--- a/vlib/builtin/cfns.v
+++ b/vlib/builtin/cfns.v
@@ -32,4 +32,11 @@ fn C.realpath(byteptr, byteptr) &char
 // Windows
 fn C._setmode(int, int)
 fn C._fileno(int) int
-fn C._get_osfhandle(fd int) voidptr
+fn C._get_osfhandle(fd int) C.intptr_t
+fn C.GetModuleFileNameW(hModule voidptr, lpFilename &u16, nSize u32) u32
+fn C.CreatePipe(hReadPipe &voidptr, hWritePipe &voidptr, lpPipeAttributes voidptr, nSize u32) bool
+fn C.SetHandleInformation(hObject voidptr, dwMask u32, dwFlags u32) bool
+fn C.ExpandEnvironmentStringsW(lpSrc &u16, lpDst &u16, nSize u32) u32
+fn C.CreateProcessW(lpApplicationName &u16, lpCommandLine &u16, lpProcessAttributes voidptr, lpThreadAttributes voidptr, bInheritHandles bool, dwCreationFlags u32, lpEnvironment voidptr, lpCurrentDirectory &u16, lpStartupInfo voidptr, lpProcessInformation voidptr) bool
+fn C.ReadFile(hFile voidptr, lpBuffer voidptr, nNumberOfBytesToRead u32, lpNumberOfBytesRead voidptr, lpOverlapped voidptr) bool
+fn C.GetFileAttributesW(lpFileName byteptr) u32

--- a/vlib/builtin/cfns.v
+++ b/vlib/builtin/cfns.v
@@ -40,3 +40,5 @@ fn C.ExpandEnvironmentStringsW(lpSrc &u16, lpDst &u16, nSize u32) u32
 fn C.CreateProcessW(lpApplicationName &u16, lpCommandLine &u16, lpProcessAttributes voidptr, lpThreadAttributes voidptr, bInheritHandles bool, dwCreationFlags u32, lpEnvironment voidptr, lpCurrentDirectory &u16, lpStartupInfo voidptr, lpProcessInformation voidptr) bool
 fn C.ReadFile(hFile voidptr, lpBuffer voidptr, nNumberOfBytesToRead u32, lpNumberOfBytesRead voidptr, lpOverlapped voidptr) bool
 fn C.GetFileAttributesW(lpFileName byteptr) u32
+fn C.RegQueryValueExW(hKey voidptr, lpValueName &u16, lpReserved &u32, lpType &u32, lpData byteptr, lpcbData &u32) int
+fn C.RegOpenKeyExW(hKey voidptr, lpSubKey &u16, ulOptions u32, samDesired u32, phkResult voidptr) int

--- a/vlib/builtin/utf8.v
+++ b/vlib/builtin/utf8.v
@@ -96,17 +96,17 @@ const (
 	)
 
 pub fn (_str string) to_wide() &u16 {
-    $if windows {
-   	    num_chars := int(C.MultiByteToWideChar(CP_UTF8, 0, _str.str, _str.len, 0, 0))
-	    mut wstr := &u16(malloc((num_chars + 1) * 2)) // sizeof(wchar_t)
-	    if wstr > 0 {
-		    C.MultiByteToWideChar(CP_UTF8, 0, _str.str, _str.len, wstr, num_chars)
-		    C.memset(&byte(wstr) + num_chars * 2, 0, 2)
-	    }
-	    return wstr
-    } $else {
-        return 0
-    }
+	$if windows {
+		num_chars := int(C.MultiByteToWideChar(CP_UTF8, 0, _str.str, _str.len, 0, 0))
+		mut wstr := &u16(malloc((num_chars + 1) * 2)) // sizeof(wchar_t)
+		if !isnil(wstr) {
+			C.MultiByteToWideChar(CP_UTF8, 0, _str.str, _str.len, wstr, num_chars)
+			C.memset(&byte(wstr) + num_chars * 2, 0, 2)
+		}
+		return wstr
+	} $else {
+		return 0
+	}
 }
 
 pub fn string_from_wide(_wstr &u16) string {
@@ -122,7 +122,7 @@ pub fn string_from_wide2(_wstr &u16, len int) string {
     $if windows {
     	num_chars := int(C.WideCharToMultiByte(CP_UTF8, 0, _wstr, len, 0, 0, 0, 0))
     	mut str_to := &byte(malloc(num_chars + 1))
-    	if str_to > 0 {
+    	if !isnil(str_to) {
     		C.WideCharToMultiByte(CP_UTF8, 0, _wstr, len, str_to, num_chars, 0, 0)
 		    C.memset(&byte(str_to) + num_chars, 0, 1)
 	    }

--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -103,7 +103,20 @@ fn (v mut V) cc() {
 	}
 	//linux_host := os.user_os() == 'linux'
 	v.log('cc() isprod=$v.pref.is_prod outname=$v.out_name')
-	mut a := [v.pref.cflags, '-std=gnu11', '-w'] // arguments for the C compiler
+	// arguments for the C compiler
+	mut a := [v.pref.cflags, '-std=gnu11',
+		'-Wall',
+		'-Wextra',
+		// TODO : activate -Werror once no warnings remain
+//		'-Werror',
+		// TODO : try and remove the below workaround options when the corresponding
+		// warnings are totally fixed/removed
+		'-Wno-unused-variable',
+		'-Wno-unused-but-set-variable',
+		'-Wno-unused-parameter',
+		'-Wno-unused-result',
+		'-Wno-missing-braces',
+		'-Wno-unused-label']
 
 	if v.pref.is_so {
 		a << '-shared -fPIC '// -Wl,-z,defs'

--- a/vlib/compiler/cheaders.v
+++ b/vlib/compiler/cheaders.v
@@ -89,7 +89,9 @@ c_headers = '
 
 #ifdef _WIN32
 #define WINVER 0x0600
+#ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0600
+#endif
 #define WIN32_LEAN_AND_MEAN
 #define _UNICODE
 #define UNICODE

--- a/vlib/compiler/cheaders.v
+++ b/vlib/compiler/cheaders.v
@@ -89,9 +89,10 @@ c_headers = '
 
 #ifdef _WIN32
 #define WINVER 0x0600
-#ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0600
+#ifdef _WIN32_WINNT
+#undef _WIN32_WINNT
 #endif
+#define _WIN32_WINNT 0x0600
 #define WIN32_LEAN_AND_MEAN
 #define _UNICODE
 #define UNICODE

--- a/vlib/compiler/fn.v
+++ b/vlib/compiler/fn.v
@@ -646,9 +646,9 @@ fn (p mut Parser) async_fn_call(f Fn, method_ph int, receiver_var, receiver_type
 	wrapper_name := '${fn_name}_thread_wrapper'
 	mut wrapper_type := 'void*'
 	if p.os == .windows {
-		wrapper_type = 'void* __stdcall'
+		wrapper_type = 'DWORD WINAPI'
 	}
-	wrapper_text := '$wrapper_type $wrapper_name($arg_struct_name * arg) {$fn_name( /*f*/$str_args ); return NULL; }'
+	wrapper_text := '$wrapper_type $wrapper_name($arg_struct_name * arg) {$fn_name( /*f*/$str_args ); return 0; }'
 	p.cgen.register_thread_fn(wrapper_name, wrapper_text, arg_struct)
 	// Create thread object
 	tmp_nr := p.get_tmp_counter()
@@ -663,7 +663,7 @@ fn (p mut Parser) async_fn_call(f Fn, method_ph int, receiver_var, receiver_type
 	}
 	// Call the wrapper
 	if p.os == .windows {
-		p.genln(' CreateThread(0,0, $wrapper_name, $parg, 0,0);')
+		p.genln(' CreateThread(0,0, (LPTHREAD_START_ROUTINE)$wrapper_name, $parg, 0,0);')
 	}
 	else {
 		p.genln('int $tmp2 = pthread_create(& $thread_name, NULL, (void *)$wrapper_name, $parg);')

--- a/vlib/compiler/msvc.v
+++ b/vlib/compiler/msvc.v
@@ -4,7 +4,7 @@ import os
 
 #flag windows -l shell32
 #flag windows -l dbghelp
-// RegOpenKeyExA etc
+// RegOpenKeyExW etc
 #flag windows -l advapi32
 
 struct MsvcResult {

--- a/vlib/os/const_windows.v
+++ b/vlib/os/const_windows.v
@@ -66,7 +66,7 @@ const (
 )
 
 const(
-	INVALID_HANDLE_VALUE = -1
+	INVALID_HANDLE_VALUE = voidptr(-1)
 )
 
 // https://docs.microsoft.com/en-us/windows/console/setconsolemode

--- a/vlib/os/os_windows.v
+++ b/vlib/os/os_windows.v
@@ -78,7 +78,7 @@ fn init_os_args(argc int, argv &byteptr) []string {
 	mut args := []string
 	mut args_list := &voidptr(0)
 	mut args_count := 0
-	args_list = C.CommandLineToArgvW(C.GetCommandLine(), &args_count)
+	args_list = &voidptr(C.CommandLineToArgvW(C.GetCommandLine(), &args_count))
 	for i := 0; i < args_count; i++ {
 		args << string_from_wide(&u16(args_list[i]))
 	}
@@ -103,12 +103,12 @@ pub fn ls(path string) ?[]string {
 	path_files := '$path\\*'
 	// NOTE:TODO: once we have a way to convert utf16 wide character to utf8
 	// we should use FindFirstFileW and FindNextFileW
-	h_find_files := C.FindFirstFile(path_files.to_wide(), &find_file_data)
+	h_find_files := C.FindFirstFile(path_files.to_wide(), voidptr(&find_file_data))
 	first_filename := string_from_wide(&u16(find_file_data.cFileName))
 	if first_filename != '.' && first_filename != '..' {
 		dir_files << first_filename
 	}
-	for C.FindNextFile(h_find_files, &find_file_data) {
+	for C.FindNextFile(h_find_files, voidptr(&find_file_data)) {
 		filename := string_from_wide(&u16(find_file_data.cFileName))
 		if filename != '.' && filename != '..' {
 			dir_files << filename.clone()
@@ -120,11 +120,11 @@ pub fn ls(path string) ?[]string {
 
 pub fn dir_exists(path string) bool {
 	_path := path.replace('/', '\\')
-	attr := int(C.GetFileAttributes(_path.to_wide()))
-	if attr == C.INVALID_FILE_ATTRIBUTES {
+	attr := C.GetFileAttributesW(_path.to_wide())
+	if int(attr) == int(C.INVALID_FILE_ATTRIBUTES) {
 		return false
 	}
-	if (attr & C.FILE_ATTRIBUTE_DIRECTORY) != 0 {
+	if (int(attr) & C.FILE_ATTRIBUTE_DIRECTORY) != 0 {
 		return true
 	}
 	return false
@@ -149,7 +149,7 @@ pub fn get_file_handle(path string) HANDLE {
     if _fd == 0 {
 	    return HANDLE(INVALID_HANDLE_VALUE)
     }
-    _handle := C._get_osfhandle(C._fileno(_fd)) // CreateFile? - hah, no -_-
+    _handle := HANDLE(C._get_osfhandle(C._fileno(_fd))) // CreateFile? - hah, no -_-
     return _handle
 }
 
@@ -160,7 +160,7 @@ pub fn get_module_filename(handle HANDLE) ?string {
     mut sz := int(4096) // Optimized length
     mut buf := &u16(malloc(4096))
     for {
-        status := C.GetModuleFileName(handle, &buf, sz)
+        status := int(C.GetModuleFileNameW(handle, voidptr(&buf), sz))
         match status {
             SUCCESS {
                 _filename := string_from_wide2(buf, sz)
@@ -209,7 +209,7 @@ fn ptr_win_get_error_msg(code u32) voidptr {
 		FORMAT_MESSAGE_ALLOCATE_BUFFER
 		| FORMAT_MESSAGE_FROM_SYSTEM
 		| FORMAT_MESSAGE_IGNORE_INSERTS,
-        0, code, C.MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), &buf, 0, 0)
+        0, code, C.MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), voidptr(&buf), 0, 0)
     return buf
 }
 
@@ -237,12 +237,12 @@ pub fn exec(cmd string) ?Result {
 	sa.nLength = sizeof(C.SECURITY_ATTRIBUTES)
 	sa.bInheritHandle = true
 
-	create_pipe_result := C.CreatePipe(&child_stdout_read, &child_stdout_write, &sa, 0)
+	create_pipe_result := int(C.CreatePipe(voidptr(&child_stdout_read), voidptr(&child_stdout_write), voidptr(&sa), 0))
 	if create_pipe_result == 0 {
 		error_msg := get_error_msg(int(C.GetLastError()))
 		return error('exec failed (CreatePipe): $error_msg')
 	}
-	set_handle_info_result := C.SetHandleInformation(child_stdout_read, C.HANDLE_FLAG_INHERIT, 0)
+	set_handle_info_result := int(C.SetHandleInformation(child_stdout_read, C.HANDLE_FLAG_INHERIT, 0))
 	if set_handle_info_result == 0 {
 		error_msg := get_error_msg(int(C.GetLastError()))
 		panic('exec failed (SetHandleInformation): $error_msg')
@@ -256,8 +256,8 @@ pub fn exec(cmd string) ?Result {
 	start_info.hStdError = child_stdout_write
 	start_info.dwFlags = u32(C.STARTF_USESTDHANDLES)
 	command_line := [32768]u16
-	C.ExpandEnvironmentStrings(cmd.to_wide(), &command_line, 32768)
-	create_process_result := C.CreateProcess(0, command_line, 0, 0, C.TRUE, 0, 0, 0, &start_info, &proc_info)
+	C.ExpandEnvironmentStringsW(cmd.to_wide(), voidptr(&command_line), 32768)
+	create_process_result := int(C.CreateProcessW(0, command_line, 0, 0, C.TRUE, 0, 0, 0, voidptr(&start_info), voidptr(&proc_info)))
 	if create_process_result == 0 {
 		error_msg := get_error_msg(int(C.GetLastError()))
 		return error('exec failed (CreateProcess): $error_msg')
@@ -265,23 +265,23 @@ pub fn exec(cmd string) ?Result {
 	C.CloseHandle(child_stdin)
 	C.CloseHandle(child_stdout_write)	
 	buf := [1000]byte
-	mut bytes_read := 0
+	mut bytes_read := u32(0)
 	mut read_data := ''
 	for {
-		readfile_result := C.ReadFile(child_stdout_read, buf, 1000, &bytes_read, 0)
-		read_data += tos(buf, bytes_read)
-		if (readfile_result == 0 || bytes_read == 0) {
+		readfile_result := C.ReadFile(child_stdout_read, buf, 1000, voidptr(&bytes_read), 0)
+		read_data += tos(buf, int(bytes_read))
+		if (readfile_result == false || int(bytes_read) == 0) {
 			break 
 		}		
 	}
 	read_data = read_data.trim_space()
-	exit_code := 0	
+	exit_code := u32(0)
 	C.WaitForSingleObject(proc_info.hProcess, C.INFINITE)
-	C.GetExitCodeProcess(proc_info.hProcess, &exit_code)
+	C.GetExitCodeProcess(proc_info.hProcess, voidptr(&exit_code))
 	C.CloseHandle(proc_info.hProcess)
 	C.CloseHandle(proc_info.hThread)
 	return Result {
 		output: read_data
-		exit_code: exit_code
+		exit_code: int(exit_code)
 	}
 }

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -445,7 +445,7 @@ pub fn ticks() i64 {
 
 pub fn sleep(seconds int) {
 	$if windows {
-		C._sleep(seconds * 1000)
+		C.Sleep(seconds * 1000)
 	}
 	$else {
 		C.sleep(seconds)


### PR DESCRIPTION
This PR aims at removing as much warnings as possible, generated on windows (MSYS2/mingw)
The test case is building tvintris/vsdl2
The ultimate goal is to activate ASAP by default the following gcc compile flags (linux and windows) :
```
CFLAGS+=-Wall
CFLAGS+=-Werror
CFLAGS+=-Wextra
CFLAGS+=-Wno-unused-variable
CFLAGS+=-Wno-unused-parameter
CFLAGS+=-Wno-unused-result
```
There are quite a lot of changes, so I'll try to group them in several commits