### PR TITLE
Feature: Add bytes2bf function

### DIFF
--- a/vlib/bitfield/bitfield.v
+++ b/vlib/bitfield/bitfield.v
@@ -77,6 +77,29 @@ fn cleartail(instance mut BitField) {
 
 // public functions
 
+pub fn bytes2bf(input []byte) BitField {
+	mut output := new(input.len * 8)
+	for i, b in input {
+		pos := i / 4
+		match i % 4 {
+			0 {
+				output.field[pos] = output.field[pos] | (u32(b) << 24)
+			}
+			1 {
+				output.field[pos] = output.field[pos] | (u32(b) << 16)
+			}
+			2 {
+				output.field[pos] = output.field[pos] | (u32(b) << 8)
+			}
+			3 {
+				output.field[pos] = output.field[pos] | u32(b)
+			}
+		}
+	}
+
+	return output
+}
+
 // str2bf() converts a string of characters ('0' and '1') to a bit
 // array. Any character different from '0' is treated as '1'.
 

--- a/vlib/bitfield/bitfield.v
+++ b/vlib/bitfield/bitfield.v
@@ -77,6 +77,9 @@ fn cleartail(instance mut BitField) {
 
 // public functions
 
+// bytes2bf() converts a byte arry into a bitfield.
+// Be aware of possible trailing zeroes being added
+// due to the underlying 32bit int containers.
 pub fn bytes2bf(input []byte) BitField {
 	mut output := new(input.len * 8)
 	for i, b in input {

--- a/vlib/bitfield/bitfield.v
+++ b/vlib/bitfield/bitfield.v
@@ -77,10 +77,10 @@ fn cleartail(instance mut BitField) {
 
 // public functions
 
-// bytes2bf() converts a byte arry into a bitfield.
+// from_bytes() converts a byte arry into a bitfield.
 // Be aware of possible trailing zeroes being added
 // due to the underlying 32bit int containers.
-pub fn bytes2bf(input []byte) BitField {
+pub fn from_bytes(input []byte) BitField {
 	mut output := new(input.len * 8)
 	for i, b in input {
 		pos := i / 4

--- a/vlib/bitfield/bitfield_test.v
+++ b/vlib/bitfield/bitfield_test.v
@@ -122,6 +122,20 @@ fn test_hamming() {
 	assert count == bitfield.hamming(input1, input2)
 }
 
+fn test_bf_bytes2bf() {
+	input := [byte(0xF0), byte(0x0F), byte(0xF0), byte(0xFF)]
+	output := bitfield.bytes2bf(input)
+	mut result := 1
+	for i := 0; i < input.len * 8; i++ {
+		expected := input[input.len - 1 - i / 8] >> i % 8 & 1
+		actual := output.getbit(i)
+		if expected != actual {
+			result = 0
+		}
+	}
+	assert result == 1
+}
+
 fn test_bf_str2bf() {
 	rand.seed(time.now().uni)
 	len := 80

--- a/vlib/bitfield/bitfield_test.v
+++ b/vlib/bitfield/bitfield_test.v
@@ -122,9 +122,9 @@ fn test_hamming() {
 	assert count == bitfield.hamming(input1, input2)
 }
 
-fn test_bf_bytes2bf() {
+fn test_bf_from_bytes() {
 	input := [byte(0xF0), byte(0x0F), byte(0xF0), byte(0xFF)]
-	output := bitfield.bytes2bf(input)
+	output := bitfield.from_bytes(input)
 	mut result := 1
 	for i := 0; i < input.len * 8; i++ {
 		expected := input[input.len - 1 - i / 8] >> i % 8 & 1


### PR DESCRIPTION
This PR adds a function that creates a Bitfield from a byte array.
It seems necessary to me that they can be created from more than strings of '1' ans '0' or from scratch.

Documentation and test are in place.

```
some_bytes := [byte(0xFF), byte(0xF0)]
some_bitfield := bitfield.bytes2bf(some_bytes)
```