### PR TITLE
compiler: support storing temporary files under TMPDIR/v/ . Fix for filepath.join not \0 terminating its result.

### DIFF
--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -799,11 +799,7 @@ pub fn new_v(args[]string) &V {
 	vgen_buf.writeln('module vgen\nimport strings')
 
 	joined_args := args.join(' ')
-	
-	// support passing -vtmp on the CLI
-	vtmp := get_arg(joined_args, 'vtmp', '')
-	if vtmp.len != 0 { set_vtmp_folder(vtmp) }
-	
+		
 	target_os := get_arg(joined_args, 'os', '')
 	comptime_define := get_arg(joined_args, 'd', '')
 	//println('comptimedefine=$comptime_define')

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -799,6 +799,11 @@ pub fn new_v(args[]string) &V {
 	vgen_buf.writeln('module vgen\nimport strings')
 
 	joined_args := args.join(' ')
+	
+	// support passing -vtmp on the CLI
+	vtmp := get_arg(joined_args, 'vtmp', '')
+	if vtmp.len != 0 { set_vtmp_folder(vtmp) }
+	
 	target_os := get_arg(joined_args, 'os', '')
 	comptime_define := get_arg(joined_args, 'd', '')
 	//println('comptimedefine=$comptime_define')
@@ -930,8 +935,8 @@ pub fn new_v(args[]string) &V {
 		println('Go to https://vlang.io to install V.')
 		exit(1)
 	}
-	// println('out_name:$out_name')
-	mut out_name_c := os.realpath('${out_name}.tmp.c')
+
+	mut out_name_c := get_vtmp_filename( out_name, '.tmp.c')
 
 	cflags := get_cmdline_cflags(args)
 
@@ -978,7 +983,7 @@ pub fn new_v(args[]string) &V {
 		println('C compiler=$pref.ccompiler')
 	}
 	if pref.is_so {
-		out_name_c = out_name.all_after(os.path_separator) + '_shared_lib.c'
+		out_name_c = get_vtmp_filename( out_name, '.tmp.so.c')
 	}
 	$if !linux {
 		if pref.is_bare && !out_name.ends_with('.c') {

--- a/vlib/compiler/vhelp.v
+++ b/vlib/compiler/vhelp.v
@@ -28,7 +28,7 @@ pub const (
    You can set it like this: `export VFLAGS="-cc clang -debug"` on *nix,
    `set VFLAGS=-cc msvc` on Windows.
 
-   V respects the TMPDIR environment variable, and will put .tmp.c files in $TMPDIR/v/ .
+   V respects the TMPDIR environment variable, and will put .tmp.c files in \$TMPDIR/v/ .
    If you have not set it, a suitable platform specific folder (like /tmp) will be used.
 
 Options/commands:

--- a/vlib/compiler/vhelp.v
+++ b/vlib/compiler/vhelp.v
@@ -59,6 +59,9 @@ Options for debugging/troubleshooting v programs:
                     Common C compilers are gcc, clang, tcc, icc, cl...
   -cflags <flags>   Pass additional C flags to the C backend compiler.
                     Example: -cflags `sdl2-config --cflags`
+  -vtmp /var/tmp    Changes the default folder that V uses for storing .tmp.c files.
+                    The environment variable VTMP and -vtmp are equivalent.
+                    -vtmp has higher precedence over VTMP.
 
 Commands:
   up                Update V. Run `v up` at least once per day, since V development is rapid and features/bugfixes are added constantly.

--- a/vlib/compiler/vhelp.v
+++ b/vlib/compiler/vhelp.v
@@ -60,8 +60,8 @@ Options for debugging/troubleshooting v programs:
   -cflags <flags>   Pass additional C flags to the C backend compiler.
                     Example: -cflags `sdl2-config --cflags`
   -vtmp /var/tmp    Changes the default folder that V uses for storing .tmp.c files.
-                    The environment variable VTMP and -vtmp are equivalent.
-                    -vtmp has higher precedence over VTMP.
+                    The environment variable VTMP and -vtmp are equivalent,
+                    but -vtmp has higher precedence over VTMP.
 
 Commands:
   up                Update V. Run `v up` at least once per day, since V development is rapid and features/bugfixes are added constantly.

--- a/vlib/compiler/vhelp.v
+++ b/vlib/compiler/vhelp.v
@@ -28,7 +28,7 @@ pub const (
    You can set it like this: `export VFLAGS="-cc clang -debug"` on *nix,
    `set VFLAGS=-cc msvc` on Windows.
 
-   V respects the TMPDIR environment variable, and will put .tmp.c files in \$TMPDIR/v/ .
+   V respects the TMPDIR environment variable, and will put .tmp.c files in TMPDIR/v/ .
    If you have not set it, a suitable platform specific folder (like /tmp) will be used.
 
 Options/commands:

--- a/vlib/compiler/vhelp.v
+++ b/vlib/compiler/vhelp.v
@@ -28,6 +28,9 @@ pub const (
    You can set it like this: `export VFLAGS="-cc clang -debug"` on *nix,
    `set VFLAGS=-cc msvc` on Windows.
 
+   V respects the TMPDIR environment variable, and will put .tmp.c files in $TMPDIR/v/ .
+   If you have not set it, a suitable platform specific folder (like /tmp) will be used.
+
 Options/commands:
   -h, help          Display this information.
   -o <file>         Write output to <file>.
@@ -59,9 +62,6 @@ Options for debugging/troubleshooting v programs:
                     Common C compilers are gcc, clang, tcc, icc, cl...
   -cflags <flags>   Pass additional C flags to the C backend compiler.
                     Example: -cflags `sdl2-config --cflags`
-  -vtmp /var/tmp    Changes the default folder that V uses for storing .tmp.c files.
-                    The environment variable VTMP and -vtmp are equivalent,
-                    but -vtmp has higher precedence over VTMP.
 
 Commands:
   up                Update V. Run `v up` at least once per day, since V development is rapid and features/bugfixes are added constantly.

--- a/vlib/compiler/vtmp.v
+++ b/vlib/compiler/vtmp.v
@@ -1,0 +1,35 @@
+// Copyright (c) 2019 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+module compiler
+
+import os
+import filepath
+
+pub fn set_vtmp_folder(vtmp string){
+	// set_vtmp_folder is needed, so that external tools
+	// that import the compiler module can call
+	// compiler.set_vtmp_folder('their_path')
+	// instead of os.setenv themselves.
+	// It is also used when passing -vtmp, so that
+	// subprocesses can know the toplevel VTMP too.
+	os.setenv('VTMP', vtmp, true)
+}
+
+pub fn get_vtmp_folder() string {
+	mut vtmp := os.getenv('VTMP')
+	if vtmp.len == 0 || !os.dir_exists( vtmp ) {
+		vtmp = if os.user_os() == 'windows' { os.getenv('TMP') } else { '/tmp' }
+	}
+	if vtmp.len == 0 || !os.dir_exists( vtmp ) {
+		vtmp = filepath.join(v_modules_path, '_vtmp')
+		if !os.dir_exists( vtmp ) { os.mkdir(vtmp) }
+	}
+	return vtmp
+}
+
+pub fn get_vtmp_filename(base_file_name string, postfix string) string {
+	vtmp := get_vtmp_folder()
+	return os.realpath( filepath.join(vtmp, os.filename( base_file_name ) + postfix) )
+}

--- a/vlib/compiler/vtmp.v
+++ b/vlib/compiler/vtmp.v
@@ -7,24 +7,10 @@ module compiler
 import os
 import filepath
 
-pub fn set_vtmp_folder(vtmp string){
-	// set_vtmp_folder is needed, so that external tools
-	// that import the compiler module can call
-	// compiler.set_vtmp_folder('their_path')
-	// instead of os.setenv themselves.
-	// It is also used when passing -vtmp, so that
-	// subprocesses can know the toplevel VTMP too.
-	os.setenv('VTMP', vtmp, true)
-}
-
 pub fn get_vtmp_folder() string {
-	mut vtmp := os.getenv('VTMP')
-	if vtmp.len == 0 || !os.dir_exists( vtmp ) {
-		vtmp = os.tmpdir()
-	}
-	if vtmp.len == 0 || !os.dir_exists( vtmp ) {
-		vtmp = filepath.join(v_modules_path, '_vtmp')
-		if !os.dir_exists( vtmp ) { os.mkdir(vtmp) }
+	vtmp := os.tmpdir() + os.path_separator + 'v'
+	if !os.dir_exists( vtmp ) {
+		os.mkdir(vtmp)
 	}
 	return vtmp
 }

--- a/vlib/compiler/vtmp.v
+++ b/vlib/compiler/vtmp.v
@@ -8,7 +8,7 @@ import os
 import filepath
 
 pub fn get_vtmp_folder() string {
-	vtmp := os.tmpdir() + os.path_separator + 'v'
+	vtmp := filepath.join(os.tmpdir(),'v')
 	if !os.dir_exists( vtmp ) {
 		os.mkdir(vtmp)
 	}

--- a/vlib/compiler/vtmp.v
+++ b/vlib/compiler/vtmp.v
@@ -20,7 +20,7 @@ pub fn set_vtmp_folder(vtmp string){
 pub fn get_vtmp_folder() string {
 	mut vtmp := os.getenv('VTMP')
 	if vtmp.len == 0 || !os.dir_exists( vtmp ) {
-		vtmp = if os.user_os() == 'windows' { os.getenv('TMP') } else { '/tmp' }
+		vtmp = os.tmpdir()
 	}
 	if vtmp.len == 0 || !os.dir_exists( vtmp ) {
 		vtmp = filepath.join(v_modules_path, '_vtmp')

--- a/vlib/filepath/filepath.v
+++ b/vlib/filepath/filepath.v
@@ -32,5 +32,6 @@ pub fn join(base string, dirs ...string) string {
 		path.write(os.path_separator)
 		path.write(d)
 	}
+	path.write(byte(0).str())
 	return path.str()
 }

--- a/vlib/filepath/filepath.v
+++ b/vlib/filepath/filepath.v
@@ -2,7 +2,6 @@ module filepath
 
 import(
 	os
-	strings
 )
 
 // return the extension in the file `path`
@@ -26,12 +25,8 @@ pub fn is_abs(path string) bool {
 // pass directories as parameters, returns path as string 
 // TODO use []string.join once ...string becomes "[]string"
 pub fn join(base string, dirs ...string) string {
-	mut path := strings.new_builder(50)
-	path.write(base.trim_right('\\/'))
-	for d in dirs {
-		path.write(os.path_separator)
-		path.write(d)
-	}
-	path.write(byte(0).str())
-	return path.str()
+	mut result := []string
+	result << base.trim_right('\\/')
+	for d in dirs {	result << d	}
+	return result.join( os.path_separator )
 }

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -844,10 +844,6 @@ pub fn realpath(fpath string) string {
 		res = int( !isnil(C._fullpath( fullpath, fpath.str, MAX_PATH )) )
 	}
 	$else{
-		if fpath.len != strlen(fpath.str) {
-			l := strlen(fpath.str)
-			println('FIXME realpath diff len $fpath.len strlen=$l')
-		}	
 		ret := C.realpath(fpath.str, fullpath)
 		if ret == 0 {
 			return fpath

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -978,9 +978,12 @@ pub fn tmpdir() string {
 		if path == '' { path = '/tmp' }
 	}
 	$if mac {
+		/*
 		if path == '' {
-			path = C.NSTemporaryDirectory() // TODO untested
+			// TODO untested
+			path = C.NSTemporaryDirectory() 
 		}
+        */
 		if path == '' {	path = '/tmp' }
 	}
 	$if windows {
@@ -993,6 +996,5 @@ pub fn tmpdir() string {
 			if path == '' {	path = 'C:/tmp'	}
 		}
 	}
-	println('tmpdir: $path')
 	return path
 }

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -145,17 +145,26 @@ pub fn cp(old, new string) ?bool {
 	}
 }
 
-pub fn cp_r(source_path, dest_path string, overwrite bool) ?bool{
+pub fn cp_r(osource_path, odest_path string, overwrite bool) ?bool{
+	source_path := os.realpath( osource_path )
+	dest_path := os.realpath( odest_path )
 	if !os.file_exists(source_path) {
 		return error('Source path doesn\'t exist')
 	}
 	//single file copy
 	if !os.is_dir(source_path) {
 		adjasted_path := if os.is_dir(dest_path) {
-			filepath.join(dest_path, os.basedir(source_path)) } else { dest_path }
+			filepath.join(dest_path, os.filename(source_path)) 
+		} else { 
+			dest_path 
+		}
 		if os.file_exists(adjasted_path) {
-			if overwrite { os.rm(adjasted_path) }
-			else { return error('Destination file path already exist') }
+			if overwrite {
+				os.rm(adjasted_path) 
+			}
+			else { 
+				return error('Destination file path already exist') 
+			}
 		}
 		os.cp(source_path, adjasted_path) or { return error(err) }
 		return true
@@ -558,7 +567,7 @@ pub fn basedir(path string) string {
 	if pos == -1 {
 		return path
 	}
-	return path[..pos + 1]
+	return path[..pos ] // NB: *without* terminating /
 }
 
 pub fn filename(path string) string {

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -970,3 +970,11 @@ pub fn join(base string, dirs ...string) string {
 	println('use filepath.join')
 	return filepath.join(base, dirs)
 }
+
+// tmpdir returns the path to a folder, that is suitable for storing temporary files
+pub fn tmpdir() string {
+	if os.user_os() == 'windows' {
+		return os.getenv('TEMP')
+	}
+	return '/tmp'
+}

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -973,8 +973,26 @@ pub fn join(base string, dirs ...string) string {
 
 // tmpdir returns the path to a folder, that is suitable for storing temporary files
 pub fn tmpdir() string {
-	if os.user_os() == 'windows' {
-		return os.getenv('TEMP')
+	mut path := os.getenv('TMPDIR')
+	$if linux {
+		if path == '' { path = '/tmp' }
 	}
-	return '/tmp'
+	$if mac {
+		if path == '' {
+			path = C.NSTemporaryDirectory() // TODO untested
+		}
+		if path == '' {	path = '/tmp' }
+	}
+	$if windows {
+		if path == '' {
+			// TODO see Qt's implementation?
+			// https://doc.qt.io/qt-5/qdir.html#tempPath
+			// https://github.com/qt/qtbase/blob/e164d61ca8263fc4b46fdd916e1ea77c7dd2b735/src/corelib/io/qfilesystemengine_win.cpp#L1275
+			path = os.getenv('TEMP')
+			if path == '' {	path = os.getenv('TMP')	}
+			if path == '' {	path = 'C:/tmp'	}
+		}
+	}
+	println('tmpdir: $path')
+	return path
 }

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -152,6 +152,24 @@ fn test_cp_r() {
   os.cp_r('ex', './', true) or { panic(err) }
 }
 
+fn test_tmpdir(){
+	t := os.tmpdir()
+	assert t.len > 0
+	assert os.is_dir(t)
+	
+	tfile := t + os.path_separator + 'tmpfile.txt'
+	
+	os.rm(tfile) // just in case
+	
+	tfile_content := 'this is a temporary file'
+	os.write_file(tfile, tfile_content)
+	
+	tfile_content_read := os.read_file(tfile) or { panic(err) }
+	assert tfile_content_read == tfile_content
+	
+	os.rm(tfile)
+}
+
 //fn test_fork() {
 //  pid := os.fork()
 //  if pid == 0 {
@@ -178,7 +196,6 @@ fn test_cp_r() {
 fn test_zzz_cleanup(){
 	cleanup_leftovers() assert true
 }
-
 
 // this function is called by both test_aaa_setup & test_zzz_cleanup
 // it ensures that os tests do not polute the filesystem with leftover

--- a/vlib/strings/builder_c.v
+++ b/vlib/strings/builder_c.v
@@ -37,6 +37,10 @@ pub fn (b mut Builder) writeln(s string) {
 }
 
 pub fn (b Builder) str() string {
+	unsafe {
+		mut mb := b
+		mb.buf << 0
+	}
 	return string(b.buf, b.len)
 }
 

--- a/vlib/strings/builder_c.v
+++ b/vlib/strings/builder_c.v
@@ -37,10 +37,6 @@ pub fn (b mut Builder) writeln(s string) {
 }
 
 pub fn (b Builder) str() string {
-	unsafe {
-		mut mb := b
-		mb.buf << 0
-	}
 	return string(b.buf, b.len)
 }
 


### PR DESCRIPTION
This PR enables:
`TMPDIR=/var/tmp v ... file.v`
and
```shell
export TMPDIR=/var/tmp
v ... file.v
```
In effect, the .tmp.c files that v produces, will not be stored in the current folder, but inside the specified TMPDIR/v/ one. If TMPDIR is not set, a platform specific tmp folder will be used, like /tmp/v on nix, or TEMP/v/ or c:\tmp\v on windows (see the source of os.tmpdir() for the details).