### PR TITLE
vlib: add cli module

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,3 +1,4 @@
+/cli
 /hello_world
 /json
 /links_scraper

--- a/examples/cli.v
+++ b/examples/cli.v
@@ -1,0 +1,38 @@
+module main
+
+import (
+	cli
+	os
+)
+
+fn main() {
+	mut cmd := cli.Command{
+		name: 'cli', 
+		description: 'An example of the cli library',
+	}
+
+	mut greet_cmd := cli.Command{
+		name: 'greet',
+		description: 'Prints greeting in different languages',
+		execute: greet_func,
+	}
+	greet_cmd.add_flag(cli.Flag{
+		flag: .string, 
+		required: true,
+		name: 'language',
+		abbrev: 'l',
+	})
+
+	cmd.add_command(greet_cmd)
+	cmd.parse(os.args)
+}
+
+fn greet_func(cmd cli.Command, args []string) {
+	language := cmd.flags.get_string('language') or { panic('failed to get language flag') }
+	match language {
+		'english' { println('Hello World') }
+		'german' { println('Hallo Welt') }
+		'dutch' { println('Hallo Wereld') }
+		else { println('unsupported language') }
+	}
+}

--- a/examples/cli.v
+++ b/examples/cli.v
@@ -22,17 +22,26 @@ fn main() {
 		name: 'language',
 		abbrev: 'l',
 	})
+	greet_cmd.add_flag(cli.Flag{
+		flag: .int,
+		name: 'times',
+		value: '3',
+	})
 
 	cmd.add_command(greet_cmd)
 	cmd.parse(os.args)
 }
 
 fn greet_func(cmd cli.Command, args []string) {
-	language := cmd.flags.get_string('language') or { panic('failed to get language flag') }
-	match language {
-		'english' { println('Hello World') }
-		'german' { println('Hallo Welt') }
-		'dutch' { println('Hallo Wereld') }
-		else { println('unsupported language') }
+	language := cmd.flags.get_string('language') or { panic('failed to get \'language\' flag: $err') }
+	times := cmd.flags.get_int('times') or { panic('failed to get \'times\' flag: $err') }
+
+	for i := 0; i < times; i++ {
+		match language {
+			'english' { println('Hello World') }
+			'german' { println('Hallo Welt') }
+			'dutch' { println('Hallo Wereld') }
+			else { println('unsupported language') }
+		}
 	}
 }

--- a/examples/cli.v
+++ b/examples/cli.v
@@ -9,6 +9,7 @@ fn main() {
 	mut cmd := cli.Command{
 		name: 'cli', 
 		description: 'An example of the cli library',
+		version: '1.0.0',
 	}
 
 	mut greet_cmd := cli.Command{
@@ -21,18 +22,20 @@ fn main() {
 		required: true,
 		name: 'language',
 		abbrev: 'l',
+		description: 'Language of the message'
 	})
 	greet_cmd.add_flag(cli.Flag{
 		flag: .int,
 		name: 'times',
 		value: '3',
+		description: 'Number of times the message gets printed'
 	})
 
 	cmd.add_command(greet_cmd)
 	cmd.parse(os.args)
 }
 
-fn greet_func(cmd cli.Command, args []string) {
+fn greet_func(cmd cli.Command) {
 	language := cmd.flags.get_string('language') or { panic('failed to get \'language\' flag: $err') }
 	times := cmd.flags.get_int('times') or { panic('failed to get \'times\' flag: $err') }
 

--- a/vlib/cli/command.v
+++ b/vlib/cli/command.v
@@ -11,7 +11,7 @@ pub mut:
 	disable_version bool
 
 	parent &Command
-	commands []&Command
+	commands []Command
 	flags []Flag
 	args []string
 }
@@ -30,7 +30,7 @@ pub fn (cmd Command) root() Command {
 	return cmd.parent.root()
 }
 
-pub fn (cmd mut Command) add_command(command &Command) {
+pub fn (cmd mut Command) add_command(command Command) {
 	cmd.commands << command
 }
 

--- a/vlib/cli/command.v
+++ b/vlib/cli/command.v
@@ -1,0 +1,96 @@
+module cli
+
+pub struct Command {
+pub mut:
+	name string
+	description string
+	execute fn(cmd cli.Command, args []string)
+
+	commands []Command
+	flags []Flag
+	args []string
+}
+
+pub fn (cmd mut Command) add_command(command Command) {
+	cmd.commands << command
+}
+
+pub fn (cmd mut Command) add_flag(flag Flag) {
+	cmd.flags << flag
+}
+
+pub fn (cmd mut Command) parse(args []string) {
+	cmd.args = args.right(1)
+
+	cmd.parse_flags()
+	cmd.check_required_flags()
+	cmd.parse_command()
+}
+
+fn (cmd mut Command) parse_flags() {
+	for {
+		if cmd.args.len < 1 || !cmd.args[0].starts_with('-') {
+			break
+		}
+
+		mut found := false
+		for i := 0; i < cmd.flags.len; i++ {
+			mut flag := &cmd.flags[i]
+			if flag.matches(cmd.args) {
+				found = true
+				mut args := flag.parse(cmd.args) or {	// TODO: fix once options types can be assigned to struct variables
+					println('failed to parse flag ${cmd.args[0]}')
+					exit(1)
+				}
+				cmd.args = args
+				break
+			}
+		}
+
+		if !found {
+			println('invalid flag: ${cmd.args[0]}')
+			exit(1)
+		}
+	}
+}
+
+fn (cmd mut Command) check_required_flags() {
+	for flag in cmd.flags {
+		if flag.required && flag.value == '' {
+			println('flag ${flag.name} is required')
+			exit(1)
+		}
+	}
+}
+
+fn (cmd mut Command) parse_command() {
+	flags := cmd.flags
+	global_flags := flags.filter(it.global) // TODO: fix once filter can be applied to struct variable
+
+	for i := 0; i < cmd.args.len; i++ {
+		arg := cmd.args[i]
+		for j := 0; j < cmd.commands.len; j++ {
+			mut command := cmd.commands[j]
+			if command.name == arg {
+				command.flags << global_flags
+				command.parse(cmd.args.right(i))
+				return
+			}
+		}
+	}
+
+	if int(cmd.execute) == 0 {
+		cmd.print_usage()
+	} else {
+		execute := cmd.execute
+		execute(cmd, cmd.args) // TODO: fix once higher order function can be execute on struct variable
+	}
+}
+
+pub fn (cmd mut Command) print_usage() {
+	println(cmd.description + '\n')
+	println('COMMAND:')
+	for command in cmd.commands {
+		println(command.name + '\t' + command.description)
+	}
+}

--- a/vlib/cli/command_test.v
+++ b/vlib/cli/command_test.v
@@ -1,0 +1,187 @@
+import cli
+
+fn test_if_command_parses_empty_args() {
+	mut cmd := cli.Command{
+		name: 'command', 
+		execute: empty_func,
+	}
+	cmd.parse(['command'])
+	assert cmd.name == 'command'
+		&& compare_arrays(cmd.args, [])
+}
+
+fn test_if_command_parses_args() {
+	mut cmd := cli.Command{
+		name: 'command', 
+		execute: empty_func,
+	}
+	cmd.parse(['command', 'arg0', 'arg1'])
+
+	assert cmd.name == 'command'
+		&& compare_arrays(cmd.args, ['arg0', 'arg1'])
+}
+
+fn test_if_subcommands_parse_args() {
+	mut cmd := cli.Command{
+		name: 'command',
+	}
+	subcmd := cli.Command{
+		name: 'subcommand',
+		execute: empty_func,
+	}
+	cmd.add_command(subcmd)
+	cmd.parse(['command', 'subcommand', 'arg0', 'arg1'])
+}
+
+fn if_subcommands_parse_args_func(cmd cli.Command) {
+	assert cmd.name == 'subcommand'
+		&& compare_arrays(cmd.args, ['arg0', 'arg1'])
+}
+
+fn test_if_command_has_default_help_subcommand() {
+	mut cmd := cli.Command{
+		name: 'command',
+	}
+	cmd.parse(['command'])
+
+	assert has_command(cmd, 'help')
+}
+
+fn test_if_command_has_default_version_subcommand_if_version_is_set() {
+	mut cmd := cli.Command{
+		name: 'command',
+		version: '1.0.0',
+	}
+	cmd.parse(['command'])
+
+	assert has_command(cmd, 'version')
+}
+
+fn test_if_flag_gets_set() {
+	mut cmd := cli.Command{
+		name: 'command',
+		execute: if_flag_gets_set_func,
+	}
+	cmd.add_flag(cli.Flag{
+		flag: .string
+		name: 'flag'
+	})
+	cmd.parse(['command', '--flag', 'value'])
+}
+
+fn if_flag_gets_set_func(cmd cli.Command) {
+	flag := cmd.flags.get_string('flag') or { panic(err) }
+	assert flag == 'value'
+}
+
+fn test_if_flag_gets_set_with_abbrev() {
+	mut cmd := cli.Command{
+		name: 'command',
+		execute: if_flag_gets_set_with_abbrev_func,
+	}
+	cmd.add_flag(cli.Flag{
+		flag: .string,
+		name: 'flag',
+		abbrev: 'f',
+	})
+	cmd.parse(['command', '-f', 'value'])
+}
+
+fn if_flag_gets_set_with_abbrev_func(cmd cli.Command) {
+	flag := cmd.flags.get_string('flag') or { panic(err) }
+	assert flag == 'value'
+}
+
+fn test_if_multiple_flags_get_set() {
+	mut cmd := cli.Command{
+		name: 'command',
+		execute: if_multiple_flags_get_set_func,
+	}
+	cmd.add_flag(cli.Flag{
+		flag: .string
+		name: 'flag'
+	})
+	cmd.add_flag(cli.Flag{
+		flag: .int
+		name: 'value'
+	})
+	cmd.parse(['command', '--flag', 'value', '--value', '42'])
+}
+
+fn if_multiple_flags_get_set_func(cmd cli.Command) {
+	flag := cmd.flags.get_string('flag') or { panic(err) }
+	value := cmd.flags.get_int('value') or { panic(err) }
+	assert flag == 'value'
+		&& value == 42
+}
+
+fn test_if_flag_gets_set_in_subcommand() {
+	mut cmd := cli.Command{
+		name: 'command',
+		execute: empty_func,
+	}
+	mut subcmd := cli.Command{
+		name: 'subcommand',
+		execute: if_flag_gets_set_in_subcommand_func
+	}
+	subcmd.add_flag(cli.Flag{
+		flag: .string
+		name: 'flag'
+	})
+	cmd.add_command(subcmd)
+	cmd.parse(['command', 'subcommand', '--flag', 'value'])
+}
+
+fn if_flag_gets_set_in_subcommand_func(cmd cli.Command) {
+	flag := cmd.flags.get_string('flag') or { panic(err) }
+	assert flag == 'value'
+}
+
+fn test_if_global_flag_gets_set_in_subcommand() {
+	mut cmd := cli.Command{
+		name: 'command',
+		execute: empty_func,
+	}
+	cmd.add_flag(cli.Flag{
+		flag: .string,
+		name: 'flag',
+		global: true,
+	})
+	subcmd := cli.Command{
+		name: 'subcommand',
+		execute: if_global_flag_gets_set_in_subcommand_func,
+	}
+	cmd.add_command(subcmd)
+	cmd.parse(['command', '--flag', 'value', 'subcommand'])
+}
+
+fn if_global_flag_gets_set_in_subcommand_func(cmd cli.Command) {
+	flag := cmd.flags.get_string('flag') or { panic(err) }
+	assert flag == 'value'
+}
+
+
+// helper functions
+
+fn empty_func(cmd cli.Command) {}
+
+fn has_command(cmd cli.Command, name string) bool {
+	for subcmd in cmd.commands {
+		if subcmd.name == name {
+			return true
+		}
+	}
+	return false
+}
+
+fn compare_arrays(array0 []string, array1 []string) bool {
+	if array0.len != array1.len {
+		return false
+	}
+	for i := 0; i < array0.len; i++ {
+		if array0[i] != array1[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/vlib/cli/flag.v
+++ b/vlib/cli/flag.v
@@ -20,29 +20,27 @@ pub mut:
 }
 
 pub fn (flags []Flag) get_bool(name string) ?bool {
-	value := flags.get_raw(name) or { return error(err) }
-	return value == 'true'
+	flag := flags.get(name) or { return error(err) }
+	if flag.flag != .bool { return error('invalid flag type') }
+	return flag.value == 'true'
 }
 
 pub fn (flags []Flag) get_int(name string) ?int {
-	value := flags.get_raw(name) or { return error(err) }
-	return value.int()
+	flag := flags.get(name) or { return error(err) }
+	if flag.flag != .int { return error('invalid flag type') }
+	return flag.value.int()
 }
 
 pub fn (flags []Flag) get_float(name string) ?f32 {
-	value := flags.get_raw(name) or { return error(err) }
-	return value.f32()
+	flag := flags.get(name) or { return error(err) }
+	if flag.flag != .float { return error('invalid flag type') }
+	return flag.value.f32()
 }
 
 pub fn (flags []Flag) get_string(name string) ?string {
-	return flags.get_raw(name)
-}
-
-// check if first arg matches flag
-fn (flag mut Flag) matches(args []string) bool {
-	return 
-		(flag.name != '' && args[0].starts_with('--${flag.name}')) ||
-		(flag.abbrev != '' && args[0].starts_with('-${flag.abbrev}'))
+	flag := flags.get(name) or { return error(err) }
+	if flag.flag != .string { return error('invalid flag type') }
+	return flag.value
 }
 
 // parse flag value from arguments and return arguments with all consumed element removed
@@ -58,6 +56,13 @@ fn (flag mut Flag) parse(args []string) ?[]string {
 	} else {
 		return args
 	}
+}
+
+// check if first arg matches flag
+fn (flag mut Flag) matches(args []string) bool {
+	return 
+		(flag.name != '' && args[0].starts_with('--${flag.name}')) ||
+		(flag.abbrev != '' && args[0].starts_with('-${flag.abbrev}'))
 }
 
 fn (flag mut Flag) parse_raw(args []string) ?[]string {
@@ -86,10 +91,10 @@ fn (flag mut Flag) parse_bool(args []string) ?[]string {
 	return args.right(1)
 }
 
-fn (flags []Flag) get_raw(name string) ?string {
+fn (flags []Flag) get(name string) ?Flag {
 	for flag in flags {
 		if flag.name == name {
-			return flag.value
+			return flag
 		}
 	}
 	return error('flag ${name} not found.')

--- a/vlib/cli/flag.v
+++ b/vlib/cli/flag.v
@@ -8,7 +8,7 @@ pub enum FlagType {
 }
 
 pub struct Flag {
-mut:
+pub mut:
 	flag FlagType
 	name string
 	abbrev string

--- a/vlib/cli/flag.v
+++ b/vlib/cli/flag.v
@@ -15,7 +15,27 @@ mut:
 	description string
 	global bool
 	required bool
+
 	value string
+}
+
+pub fn (flags []Flag) get_bool(name string) ?bool {
+	value := flags.get_raw(name) or { return error(err) }
+	return value == 'true'
+}
+
+pub fn (flags []Flag) get_int(name string) ?int {
+	value := flags.get_raw(name) or { return error(err) }
+	return value.int()
+}
+
+pub fn (flags []Flag) get_float(name string) ?f32 {
+	value := flags.get_raw(name) or { return error(err) }
+	return value.f32()
+}
+
+pub fn (flags []Flag) get_string(name string) ?string {
+	return flags.get_raw(name)
 }
 
 // check if first arg matches flag
@@ -42,6 +62,7 @@ fn (flag mut Flag) parse(args []string) ?[]string {
 
 fn (flag mut Flag) parse_raw(args []string) ?[]string {
 	if args[0].len > flag.name.len && args[0].contains('=') {
+		println('1')
 		flag.value = args[0].split('=')[1]
 		return args.right(1)
 	} else if args.len >= 2 {
@@ -55,13 +76,14 @@ fn (flag mut Flag) parse_bool(args []string) ?[]string {
 	if args[0].len > flag.name.len && args[0].contains('=') {
 		flag.value = args[0].split('=')[1]
 		return args.right(1)
-	} else if args.len >= 2 && args[1] in ['true', 'false'] {
-		flag.value = args[1]
-		return args.right(2)
-	} else {
-		flag.value = 'true'
-		return args.right(1)
-	}
+	} else if args.len >= 2 { 
+		if args[1] in ['true', 'false'] {
+			flag.value = args[1]
+			return args.right(2)
+		} 
+	} 
+	flag.value = 'true'
+	return args.right(1)
 }
 
 fn (flags []Flag) get_raw(name string) ?string {
@@ -73,21 +95,11 @@ fn (flags []Flag) get_raw(name string) ?string {
 	return error('flag ${name} not found.')
 }
 
-pub fn (flags []Flag) get_bool(name string) ?bool {
-	value := flags.get_raw(name) or { return error(err) }
-	return value == 'true'
-}
-
-pub fn (flags []Flag) get_int(name string) ?int {
-	value := flags.get_raw(name) or { return error(err) }
-	return value.int()
-}
-
-pub fn (flags []Flag) get_float(name string) ?f32 {
-	value := flags.get_raw(name) or { return error(err) }
-	return value.f32()
-}
-
-pub fn (flags []Flag) get_string(name string) ?string {
-	return flags.get_raw(name)
+fn (flags []Flag) contains(name string) bool {
+	for flag in flags {
+		if flag.name == name || flag.abbrev == name {
+			return true
+		}
+	}
+	return false
 }

--- a/vlib/cli/flag.v
+++ b/vlib/cli/flag.v
@@ -3,6 +3,7 @@ module cli
 pub enum FlagType {
 	bool
 	int
+	float
 	string
 }
 
@@ -17,30 +18,37 @@ mut:
 	value string
 }
 
+// check if first arg matches flag
 fn (flag mut Flag) matches(args []string) bool {
 	return 
 		(flag.name != '' && args[0].starts_with('--${flag.name}')) ||
 		(flag.abbrev != '' && args[0].starts_with('-${flag.abbrev}'))
 }
 
+// parse flag value from arguments and return arguments with all consumed element removed
 fn (flag mut Flag) parse(args []string) ?[]string {
 	if flag.matches(args) {
-		match flag.flag {
-			.bool { 
-				new_args := flag.parse_bool(args) or { return error(err) } 
-				return new_args 
-			}
-			.int { 
-				new_args := flag.parse_int(args) or { return error(err) } 
-				return new_args 
-			}
-			.string { 
-				new_args := flag.parse_string(args) or { return error(err) } 
-				return new_args 
-			}
+		if flag.flag == .bool {
+			new_args := flag.parse_bool(args) or { return error(err) }
+			return new_args
+		} else {
+			new_args := flag.parse_raw(args) or { return error(err) }
+			return new_args
 		}
+	} else {
+		return args
 	}
-	return args
+}
+
+fn (flag mut Flag) parse_raw(args []string) ?[]string {
+	if args[0].len > flag.name.len && args[0].contains('=') {
+		flag.value = args[0].split('=')[1]
+		return args.right(1)
+	} else if args.len >= 2 {
+		flag.value = args[1]
+		return args.right(2)
+	}
+	return error('missing argument for ${flag.name}')
 }
 
 fn (flag mut Flag) parse_bool(args []string) ?[]string {
@@ -56,30 +64,7 @@ fn (flag mut Flag) parse_bool(args []string) ?[]string {
 	}
 }
 
-fn (flag mut Flag) parse_int(args []string) ?[]string {
-	if args[0].len > flag.name.len && args[0].contains('=') {
-		flag.value = args[0].split('=')[1]
-		return args.right(1)
-	} else if args.len >= 2 {
-		flag.value = args[1]
-		return args.right(2)
-	}
-	return error('missing argument for ${flag.name}')
-}
-
-fn (flag mut Flag) parse_string(args []string) ?[]string {
-	if args[0].len > flag.name.len && args[0].contains('=') {
-		flag.value = args[0].split('=')[1]
-		return args.right(1)
-	} else if args.len >= 2 {
-		flag.value = args[1]
-		return args.right(2)
-	} 
-	return error('missing argument for ${flag.name}')
-}
-
-
-pub fn (flags []Flag) get_string(name string) ?string {
+fn (flags []Flag) get_raw(name string) ?string {
 	for flag in flags {
 		if flag.name == name {
 			return flag.value
@@ -89,11 +74,20 @@ pub fn (flags []Flag) get_string(name string) ?string {
 }
 
 pub fn (flags []Flag) get_bool(name string) ?bool {
-	value := flags.get_string(name) or { return error(err) }
+	value := flags.get_raw(name) or { return error(err) }
 	return value == 'true'
 }
 
 pub fn (flags []Flag) get_int(name string) ?int {
-	value := flags.get_string(name) or { return error(err) }
+	value := flags.get_raw(name) or { return error(err) }
 	return value.int()
+}
+
+pub fn (flags []Flag) get_float(name string) ?f32 {
+	value := flags.get_raw(name) or { return error(err) }
+	return value.f32()
+}
+
+pub fn (flags []Flag) get_string(name string) ?string {
+	return flags.get_raw(name)
 }

--- a/vlib/cli/flag.v
+++ b/vlib/cli/flag.v
@@ -1,0 +1,99 @@
+module cli
+
+pub enum FlagType {
+	bool
+	int
+	string
+}
+
+pub struct Flag {
+mut:
+	flag FlagType
+	name string
+	abbrev string
+	description string
+	global bool
+	required bool
+	value string
+}
+
+fn (flag mut Flag) matches(args []string) bool {
+	return 
+		(flag.name != '' && args[0].starts_with('--${flag.name}')) ||
+		(flag.abbrev != '' && args[0].starts_with('-${flag.abbrev}'))
+}
+
+fn (flag mut Flag) parse(args []string) ?[]string {
+	if flag.matches(args) {
+		match flag.flag {
+			.bool { 
+				new_args := flag.parse_bool(args) or { return error(err) } 
+				return new_args 
+			}
+			.int { 
+				new_args := flag.parse_int(args) or { return error(err) } 
+				return new_args 
+			}
+			.string { 
+				new_args := flag.parse_string(args) or { return error(err) } 
+				return new_args 
+			}
+		}
+	}
+	return args
+}
+
+fn (flag mut Flag) parse_bool(args []string) ?[]string {
+	if args[0].len > flag.name.len && args[0].contains('=') {
+		flag.value = args[0].split('=')[1]
+		return args.right(1)
+	} else if args.len >= 2 && args[1] in ['true', 'false'] {
+		flag.value = args[1]
+		return args.right(2)
+	} else {
+		flag.value = 'true'
+		return args.right(1)
+	}
+}
+
+fn (flag mut Flag) parse_int(args []string) ?[]string {
+	if args[0].len > flag.name.len && args[0].contains('=') {
+		flag.value = args[0].split('=')[1]
+		return args.right(1)
+	} else if args.len >= 2 {
+		flag.value = args[1]
+		return args.right(2)
+	}
+	return error('missing argument for ${flag.name}')
+}
+
+fn (flag mut Flag) parse_string(args []string) ?[]string {
+	if args[0].len > flag.name.len && args[0].contains('=') {
+		flag.value = args[0].split('=')[1]
+		return args.right(1)
+	} else if args.len >= 2 {
+		flag.value = args[1]
+		return args.right(2)
+	} 
+	return error('missing argument for ${flag.name}')
+}
+
+
+pub fn (flags []Flag) get_string(name string) ?string {
+	for flag in flags {
+		if flag.name == name {
+			return flag.value
+		}
+	}
+	return error('flag ${name} not found.')
+}
+
+pub fn (flags []Flag) get_bool(name string) ?bool {
+	value := flags.get_string(name) or { return error(err) }
+	return value == 'true'
+}
+
+pub fn (flags []Flag) get_int(name string) ?int {
+	value := flags.get_string(name) or { return error(err) }
+	return value.int()
+}

--- a/vlib/cli/flag_test.v
+++ b/vlib/cli/flag_test.v
@@ -1,0 +1,56 @@
+import cli
+
+fn test_if_string_flag_parses() {
+	mut flag := cli.Flag{
+		flag: .string,
+		name: 'flag',
+	}
+
+	flag.parse(['--flag', 'value']) or { panic(err) }
+	assert flag.value == 'value'
+
+	flag.parse(['--flag=value']) or { panic(err) }
+	assert flag.value == 'value'
+}
+
+fn test_if_bool_flag_parses() {
+	mut flag := cli.Flag{
+		flag: .bool,
+		name: 'flag',
+	}
+
+	flag.parse(['--flag']) or { panic(err) }
+	assert flag.value == 'true'
+
+	flag.parse(['--flag', 'true']) or { panic(err) }
+	assert flag.value == 'true'
+
+	flag.parse(['--flag=true']) or { panic(err) }
+	assert flag.value == 'true'
+}
+
+fn test_if_int_flag_parses() {
+	mut flag := cli.Flag{
+		flag: .int,
+		name: 'flag',
+	}
+
+	flag.parse(['--flag', '42']) or { panic(err) }
+	assert flag.value.int() == 42
+
+	flag.parse(['--flag=42']) or { panic(err) }
+	assert flag.value.int() == 42
+}
+
+fn test_if_float_flag_parses() {
+	mut flag := cli.Flag{
+		flag: .float,
+		name: 'flag',
+	}
+
+	flag.parse(['--flag', '3.14159']) or { panic(err) }
+	assert flag.value.f32() == 3.14159
+
+	flag.parse(['--flag=3.14159']) or { panic(err) }
+	assert flag.value.f32() == 3.14159
+}

--- a/vlib/cli/help.v
+++ b/vlib/cli/help.v
@@ -1,0 +1,72 @@
+module cli
+
+const (
+	BASE_INDENT = 2
+	ABBREV_INDENT = 5
+	DESCRIPTION_INDENT = 20
+)
+
+fn help_flag() Flag {
+	return Flag{
+		flag: .bool,
+		name: 'help',
+		abbrev: 'h',
+		description: 'Prints help information',
+	}
+}
+
+fn help_cmd() Command {
+	return Command{
+		name: 'help',
+		description: 'Prints help information',
+		execute: help_func,
+	}
+}
+
+fn help_func(cmd cli.Command) {
+	full_name := cmd.full_name()
+
+	mut help := ''
+	help += 'Usage: ${full_name}'
+	if cmd.flags.len > 0 { help += ' [FLAGS]'}
+	if cmd.commands.len > 0 { help += ' [COMMANDS]'}
+	help += '\n\n'
+
+	if cmd.description != '' {
+		help += '${cmd.description}\n\n'
+	}
+	if cmd.flags.len > 0 {
+		help += 'Flags:\n'
+		for flag in cmd.flags {
+			mut flag_name := ''
+			if flag.abbrev != '' {
+				abbrev_indent := ' '.repeat(ABBREV_INDENT-(flag.abbrev.len+1))
+				flag_name = '-${flag.abbrev}${abbrev_indent}--${flag.name}'
+			} else {
+				abbrev_indent := ' '.repeat(ABBREV_INDENT-(flag.abbrev.len))
+				flag_name = '${abbrev_indent}--${flag.name}'
+			}
+			mut required := ''
+			if flag.required {
+				required = ' (required)'
+			}
+
+			base_indent := ' '.repeat(BASE_INDENT)
+			description_indent := ' '.repeat(DESCRIPTION_INDENT-flag_name.len)
+			help += '${base_indent}${flag_name}${description_indent}${flag.description}${required}\n'
+		}
+		help += '\n'
+	}
+	if cmd.commands.len > 0 {
+		help += 'Commands:\n'
+		for command in cmd.commands {
+			base_indent := ' '.repeat(BASE_INDENT)
+			description_indent := ' '.repeat(DESCRIPTION_INDENT-command.name.len)
+
+			help += '${base_indent}${command.name}${description_indent}${command.description}\n'
+		}
+		help += '\n'
+	}
+
+	print(help)
+}

--- a/vlib/cli/help.v
+++ b/vlib/cli/help.v
@@ -23,7 +23,8 @@ fn help_cmd() Command {
 	}
 }
 
-fn help_func(cmd cli.Command) {
+fn help_func(help_cmd cli.Command) {
+	cmd := help_cmd.parent	
 	full_name := cmd.full_name()
 
 	mut help := ''

--- a/vlib/cli/version.v
+++ b/vlib/cli/version.v
@@ -3,7 +3,6 @@ module cli
 fn version_flag() Flag {
 	return Flag{
 		flag: .bool,
-		global: true,
 		name: 'version',
 		abbrev: 'v',
 		description: 'Prints version information',
@@ -18,9 +17,8 @@ fn version_cmd() Command {
 	}
 }
 
-fn version_func(cmd cli.Command) {
-	root := cmd.root()
-
-	version := '${root.name} v${root.version}'
+fn version_func(version_cmd cli.Command) {
+	cmd := version_cmd.parent
+	version := '${cmd.name} v${cmd.version}'
 	println(version)
 }

--- a/vlib/cli/version.v
+++ b/vlib/cli/version.v
@@ -1,0 +1,26 @@
+module cli
+
+fn version_flag() Flag {
+	return Flag{
+		flag: .bool,
+		global: true,
+		name: 'version',
+		abbrev: 'v',
+		description: 'Prints version information',
+	}
+}
+
+fn version_cmd() Command {
+	return Command{
+		name: 'version'
+		description: 'Prints version information',
+		execute: version_func,
+	}
+}
+
+fn version_func(cmd cli.Command) {
+	root := cmd.root()
+
+	version := '${root.name} v${root.version}'
+	println(version)
+}


### PR DESCRIPTION
This adds a cli module to vlib.

The module provides functionality for creating CLIs with flags and multi-layered commands. 
Work is mostly completed and the module is working. Missing things are listed below the example.

Usage: 
```v
module main

import (
	cli
	os
)

fn main() {
	mut cmd := cli.Command{
		name: 'cli', 
		description: 'An example of the cli library',
	}

	mut greet_cmd := cli.Command{
		name: 'greet',
		description: 'Prints greeting in different languages',
		execute: greet_func,
	}
	greet_cmd.add_flag(cli.Flag{
		flag: .string, 
		required: true,
		name: 'language',
		abbrev: 'l',
	})

	cmd.add_command(greet_cmd)
	cmd.parse(os.args)
}

fn greet_func(cmd cli.Command, args []string) {
	language := cmd.flags.get_string('language') or { panic('failed to get language flag') }
	match language {
		'english' { println('Hello World') }
		'german' { println('Hallo Welt') }
		'dutch' { println('Hallo Wereld') }
		else { println('unsupported language') }
	}
}

```

## Todo
- [x] add float flag
- [x] implement prettier usage message
- [x] add special handling for help and version flags
- [x] add tests
- [x] add clarification comments

:question: add additional features
:question: fix bugs