### PR TITLE
vlib/compiler: fix launch_tool fn when used with paths w/spaces (win/nix) & overcome win _wsystem flaw in os.system

### DIFF
--- a/vlib/compiler/vtools.v
+++ b/vlib/compiler/vtools.v
@@ -6,12 +6,12 @@ pub fn launch_tool(tname string){
 	vexe := vexe_path()
 	vroot := os.dir(vexe)
 	mut oargs := os.args
-	oargs[0] = vexe // make it more explicit
+	oargs[0] = '"$vexe"' // make it more explicit
 	tool_exe := os.realpath('$vroot/tools/$tname')
 	tool_source := os.realpath('$vroot/tools/${tname}.v')
 	//////////////////////////////////////////////////////
 	tool_args := oargs.join(' ')
-	tool_command := '$tool_exe $tool_args'
+	tool_command := '"$tool_exe" $tool_args'
 	//println('Launching: "$tool_command" ...')
 	
 	mut tool_should_be_recompiled := false
@@ -31,13 +31,12 @@ pub fn launch_tool(tname string){
 	}
 	
 	if tool_should_be_recompiled {
-		compilation_command := '$vexe $tool_source'
+		compilation_command := '"$vexe" "$tool_source"'
 		//println('Compiling $tname with: "$compilation_command"')
 		tool_compilation := os.exec(compilation_command) or { panic(err) }
 		if tool_compilation.exit_code != 0 {
 			panic('V tool "$tool_source" could not be compiled\n' + tool_compilation.output)
 		}
 	}
-	
 	exit( os.system(tool_command) )
 }

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -399,7 +399,9 @@ pub fn system(cmd string) int {
 	}
 	mut ret := int(0)
 	$if windows {
-		ret = C._wsystem(cmd.to_wide())
+		// overcome bug in system & _wsystem (cmd) when first char is quote `"`
+		wcmd := if cmd.len > 1 && cmd[0] == `"` && cmd[1] != `"` { '"$cmd"' } else { cmd }
+		ret = C._wsystem(wcmd.to_wide())
 	} $else {
 		ret = C.system(cmd.str)
 	}


### PR DESCRIPTION
vlib/compiler: fix compiler/vtools.v launch_tool fn when used with paths w/spaces (win/nix) & fix win _wsystem flaw

- adds os.system fix _wsystem bug on windows when first char is quote in for example quoted path
- This fixed `v test v` or anything with vtool on windows when v in is path with space
- fixes `v` or anything with vtool when run on path with space on nix

closes https://github.com/vlang/v/issues/2742