### PR TITLE
fix new_array in  vlib/builtin/array.v

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -17,7 +17,7 @@ pub:
 }
 
 // Private function, used by V (`nums := []int`)
-pub fn new_array(mylen, cap, elm_size int) array {
+fn new_array(mylen, cap, elm_size int) array {
 	arr := array {
 		len: mylen
 		cap: cap


### PR DESCRIPTION
It is very simple PR.

The code says that  private function but it is a public function.

// Private function, used by V (`nums := []int`)
pub fn new_array(mylen, cap, elm_size int) array {
	arr := array {
		len: mylen
		cap: cap
		element_size: elm_size
		data: calloc(cap * elm_size)
	}
	return arr
}

- Removed pub and make it as private function.