### PR TITLE
Fix a small typo

### DIFF
--- a/vlib/compiler/asm.v
+++ b/vlib/compiler/asm.v
@@ -6,7 +6,7 @@ module compiler
 
 fn (p mut Parser) inline_asm() {
 	if !p.inside_unsafe {
-		p.error('asm() needs to be run unside `unsafe {}`')
+		p.error('asm() needs to be run inside `unsafe {}`')
 	}	
 	p.next()
 	p.check(.lcbr)


### PR DESCRIPTION
Minor typo fix `unside` -> `inside`
