### PR TITLE
compiler: add os.mv_by_cp and use it for the temporary files made by the compiler

### DIFF
--- a/tools/vup.v
+++ b/tools/vup.v
@@ -11,7 +11,7 @@ fn main() {
 		if os.file_exists( v_backup_file ) {
 			os.rm( v_backup_file )
 		}
-		os.mv('$vroot/v.exe', v_backup_file)
+		os.mv_by_cp('$vroot/v.exe', v_backup_file)
 		s2 := os.exec('"$vroot/make.bat"') or { panic(err) }
 		println(s2.output)
 	} $else {

--- a/tools/vup.v
+++ b/tools/vup.v
@@ -11,7 +11,7 @@ fn main() {
 		if os.file_exists( v_backup_file ) {
 			os.rm( v_backup_file )
 		}
-		os.mv_by_cp('$vroot/v.exe', v_backup_file)
+		os.mv_by_cp('$vroot/v.exe', v_backup_file) or { panic(err) }
 		s2 := os.exec('"$vroot/make.bat"') or { panic(err) }
 		println(s2.output)
 	} $else {

--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -59,7 +59,7 @@ fn (v mut V) cc() {
 		}
     
 		// v.out_name_c may be on a different partition than v.out_name
-		os.mv_by_cp(v.out_name_c, v.out_name)
+		os.mv_by_cp(v.out_name_c, v.out_name) or { panic(err) }
 		exit(0)
 	}
 	// Cross compiling for Windows

--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -57,7 +57,9 @@ fn (v mut V) cc() {
 				}	
 			}
 		}
-		os.mv(v.out_name_c, v.out_name)
+    
+		// v.out_name_c may be on a different partition than v.out_name
+		os.mv_by_cp(v.out_name_c, v.out_name)
 		exit(0)
 	}
 	// Cross compiling for Windows

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -187,6 +187,13 @@ pub fn cp_r(osource_path, odest_path string, overwrite bool) ?bool{
 	return true
 }
 
+// mv_by_cp first copies the source file, and if it is copied successfully, deletes the source file.
+// mv_by_cp may be used when you are not sure that the source and target are on the same mount/partition.
+pub fn mv_by_cp(source string, target string) ?bool {
+	os.cp(source, target) or { return error(err) }
+	os.rm(source)
+}
+
 fn vfopen(path, mode string) *C.FILE {
 	$if windows {
 		return C._wfopen(path.to_wide(), mode.to_wide())

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -192,6 +192,7 @@ pub fn cp_r(osource_path, odest_path string, overwrite bool) ?bool{
 pub fn mv_by_cp(source string, target string) ?bool {
 	os.cp(source, target) or { return error(err) }
 	os.rm(source)
+	return true
 }
 
 fn vfopen(path, mode string) *C.FILE {


### PR DESCRIPTION
This PR implements a new os.mv_by_cp , because os.mv does not work across mounts.