### PR TITLE
fix interface: enable calling interface with multi-args

### DIFF
--- a/vlib/compiler/fn.v
+++ b/vlib/compiler/fn.v
@@ -722,6 +722,8 @@ fn (p mut Parser) fn_call(f mut Fn, method_ph int, receiver_var, receiver_type s
 	// we need to preappend "method(receiver, ...)"
 	if f.is_method {
 		receiver := f.args.first()
+
+		mut receiver_is_interface := false
 		if receiver.typ.ends_with('er') {
 			// I absolutely love this syntax
 			// `s.speak()` =>
@@ -740,7 +742,8 @@ fn (p mut Parser) fn_call(f mut Fn, method_ph int, receiver_var, receiver_type s
 				p.cgen.resetln('')
 				var := p.expr_var.name
 				iname := f.args[0].typ // Speaker
-				p.gen('(($f.typ (*)())(${iname}_name_table[${var}._interface_idx][$idx]))(${var}._object)')
+				p.gen('(($f.typ (*)())(${iname}_name_table[${var}._interface_idx][$idx]))(${var}._object')
+				receiver_is_interface = true
 			}
 		}
 		//println('r=$receiver.typ RT=$receiver_type')
@@ -756,7 +759,10 @@ fn (p mut Parser) fn_call(f mut Fn, method_ph int, receiver_var, receiver_type s
 		if !p.expr_var.is_changed && receiver.is_mut {
 			p.mark_var_changed(p.expr_var)
 		}
-		p.gen_method_call(receiver, receiver_type, cgen_name, f.typ, method_ph)
+
+		if !receiver_is_interface {
+			p.gen_method_call(receiver, receiver_type, cgen_name, f.typ, method_ph)
+		}
 	} else {
 		// Normal function call
 		p.gen('$cgen_name (')


### PR DESCRIPTION
case example：
```
interface Speaker {
	talk(s string) int
	walk(n int) int
}

struct Human {
	name string
}

fn (me &Human) talk(s string) int {
	println('human talk $s')
	return 0
}

fn (me &Human) walk(n int) int {
	return 1
}

struct Animal {
	age int
}

fn (me &Animal) talk(s string) int {
	println('animal talk $s')
	return 0
}

fn (me &Animal) walk(n int) int {
	return 1
}

fn do_talk(p Speaker) int {
	p.talk('aaa')
	ret := p.walk(100)
	return ret
}

fn main() {
	h := Human{}
	animal := Animal{}

	do_talk(h)
	do_talk(animal)
}
````
problem:
    calling interface with multi-args will cause a C compile error

```
fn do_talk(p Speaker) int {
	p.talk('aaa')
	ret := p.walk(100)
	return ret
}
```
    p.talk will cause a C error

    this is fixed in fn_call @ vlib/compiler/fn.v




