### PR TITLE
compiler: Emit Option_ typedef for fn args and struct fields

### DIFF
--- a/vlib/compiler/fn.v
+++ b/vlib/compiler/fn.v
@@ -368,9 +368,14 @@ fn (p mut Parser) fn_decl() {
 		p.check(.lcbr)
 		//p.fgen_nl()
 	}
-	// Register ?option type
-	if typ.starts_with('Option_') {
+	// Register ?option type for return value and args
+	if typ.starts_with('Option_') { 
 		p.cgen.typedefs << 'typedef Option $typ;'
+	}
+	for arg in f.args {
+		if arg.typ.starts_with('Option_') {
+			p.cgen.typedefs << 'typedef Option $arg.typ;'
+		}
 	}
 	// Register function
 	f.typ = typ

--- a/vlib/compiler/struct.v
+++ b/vlib/compiler/struct.v
@@ -196,6 +196,10 @@ fn (p mut Parser) struct_decl() {
 		if field_type == name {
 			p.error_with_token_index( 'cannot embed struct `$name` in itself (field `$field_name`)', field_name_token_idx)
 		}
+		// Register ?option type
+		if field_type.starts_with('Option_') {
+			p.gen_typedef('typedef Option $field_type;')
+		}
 		p.check_and_register_used_imported_type(field_type)
 		is_atomic := p.tok == .key_atomic
 		if is_atomic {


### PR DESCRIPTION
If you try to use `?string` (or any Option type) as a struct field or a function argument, you'll get a C error *unless* it's already been used as a return type. This happens for me on master (5536eb581cd62dfeba82cae46eb037955dc82bdb) on macOS 10.14.5 and Arch Linux 4.19.21-1-ec2-lts.

**fields.v:**

````v
module main

struct Person {
  name ?string
  age int
}

fn main() {}
````

````
$ v run fields.v
/var/folders/cy/y7xw6jcj231g_6p3qnx_yp3r0000gn/T/v/fields.tmp.c:230:2: error: unknown type name 'Option_string'
        Option_string name;
        ^
1 error generated.
V error: C error. This should never happen. 
Please create a GitHub issue: https://github.com/vlang/v/issues/new/choose
````

**args.v:**

````v
module main

fn greet(name ?string) {
  println('Hi there...')
}

fn main() {}
````

````
$ v run args.v 
/var/folders/cy/y7xw6jcj231g_6p3qnx_yp3r0000gn/T/v/args.tmp.c:513:18: error: unknown type name 'Option_string'
void main__greet(Option_string name);
                 ^
/var/folders/cy/y7xw6jcj231g_6p3...
(Use `v -g` to print the entire error message)

V error: C error. This should never happen. 
Please create a GitHub issue: https://github.com/vlang/v/issues/new/choosechoose
````

This PR adds the same `typedef` emitting for Option_ types that return values use to fn args and struct fields. I'm not sure if copying the code like this is the best way to do it, open to any approaches. Thanks for V! 

