### PR TITLE
make: fix make on android/termux.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ ifeq ($(_SYS),Darwin)
 MAC := 1
 endif
 
+ifdef ANDROID_ROOT
+ANDROID := 1
+undefine LINUX
+endif
+
 all: fresh_vc fresh_tcc
 ifdef WIN32
 	$(CC) -std=c99 -w -o v0.exe vc/v_win.c $(LDFLAGS)


### PR DESCRIPTION
With this PR, make works without errors on Termux (an Android terminal emulator/environment):
![fixed make on termux](https://media.discordapp.net/attachments/592114487759470596/646987166588862465/Screenshot_20191121-101523.png?width=376&height=669)