### PR TITLE
compiler expression.v: fix unused variable warning

### DIFF
--- a/vlib/compiler/expression.v
+++ b/vlib/compiler/expression.v
@@ -320,7 +320,7 @@ fn (p mut Parser) name_expr() string {
 	new_f := f
 	p.fn_call(mut new_f, 0, '', '')
 	if f.is_generic {
-		f2 := p.table.find_fn(f.name) or {
+		_ = p.table.find_fn(f.name) or {
 			return ''
 		}
 		// println('after call of generic instance $new_f.name(${new_f.str_args(p.table)}) $new_f.typ')


### PR DESCRIPTION
fix

> compiler\expression.v:323:15: warning: variable 'f2' set but not used [-Wunused-but-set-variable]