### PR TITLE
compiler/gen_c: Fix deferencing cast that is causing a cast of a voidptr to u64 to segfault.

### DIFF
--- a/vlib/compiler/gen_c.v
+++ b/vlib/compiler/gen_c.v
@@ -538,7 +538,7 @@ fn (p mut Parser) cast(typ string) {
 		p.error('cannot cast `$expr_typ` to `$typ`, use backquotes `` to create a `$typ` or access the value of an index of `$expr_typ` using []')
 	}
 	else if casting_voidptr_to_value {
-		p.cgen.set_placeholder(pos, '*($typ*)(')
+		p.cgen.set_placeholder(pos, '($typ)(')
 	}
 	else {
 		// Nothing can be cast to bool

--- a/vlib/compiler/tests/voidptr_to_u64_cast_a_test.v
+++ b/vlib/compiler/tests/voidptr_to_u64_cast_a_test.v
@@ -1,0 +1,11 @@
+fn receive_addr_return_u64 (addr voidptr) u64 {
+	return u64(addr)
+}
+
+fn test_void_pointer_to_u64_cast_via_fn_call() {
+	a := u64(10)
+	b := voidptr(a)
+	c := receive_addr_return_u64(b)
+	assert (a == c)
+}
+

--- a/vlib/compiler/tests/voidptr_to_u64_cast_b_test.v
+++ b/vlib/compiler/tests/voidptr_to_u64_cast_b_test.v
@@ -1,0 +1,11 @@
+fn receive_u64_return_addr (something u64) voidptr {
+	return voidptr(something)
+}
+
+fn test_u64_to_void_pointer_cast_via_fn_call() {
+	a := u64(100)
+	b := receive_u64_return_addr(a)
+	c := u64(b)
+	assert (a == c)
+}
+


### PR DESCRIPTION
when casting a voidptr to a u64 I was I getting segfaults.
The c code in question was showing that it was casting to voidptr to a u64 pointer and then de-referencing.

--> ( * ( u64 * )( addr ) ) <-- I expect to see (u64)(addr)
that is with casting a voidptr to a u64
it causes a segfault
( * ( u64 * ) ( addr ) )
casting a byteptr to u64 does not do that
