### PR TITLE
compiler: fix if expression

### DIFF
--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -2499,7 +2499,7 @@ fn (p mut Parser) if_st(is_expr bool, elif_depth int) string {
 			//println('IF EXPR')
 		//}
 		p.inside_if_expr = true
-		p.gen('(')
+		p.gen('((')
 	}
 	else {
 		p.gen('if (')
@@ -2594,7 +2594,7 @@ fn (p mut Parser) if_st(is_expr bool, elif_depth int) string {
 		p.inside_if_expr = false
 		if is_expr {
 			p.check_types(first_typ, typ)
-			p.gen(strings.repeat(`)`, elif_depth + 1))
+			p.gen(strings.repeat(`)`, 2 * (elif_depth + 1)))
 		}
 		else_returns := p.returns
 		p.returns = if_returns && else_returns

--- a/vlib/compiler/tests/if_expression_test.v
+++ b/vlib/compiler/tests/if_expression_test.v
@@ -1,0 +1,14 @@
+
+fn test_if_expression_precedence_false_condition(){
+	b := 10
+	c := 20
+	res := 1 + if b > c { b } else { c } + 1
+	assert res == c + 2
+}
+
+fn test_if_expression_precedence_true_condition(){
+	b := 20
+	c := 10
+	res := 1 + if b > c { b } else { c } + 1
+	assert res == b + 2
+}


### PR DESCRIPTION
```
1 + if b > c { b } else { c }
```
should be
```
1 + ((b > c) ? (b) : (c))
```
, not
```
1 + (b > c) ? (b) : (c)
//   ^ wait, I'm always true
```