### PR TITLE
backtraces: cleaner looking backtrace output on linux

### DIFF
--- a/vlib/builtin/builtin_nix.v
+++ b/vlib/builtin/builtin_nix.v
@@ -50,6 +50,7 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 			for sframe in sframes {
 				executable := sframe.all_before('(')
 				addr := sframe.all_after('[').all_before(']')
+				beforeaddr := sframe.all_before('[')
 				cmd := 'addr2line -e $executable $addr'
 
 				// taken from os, to avoid depending on the os module inside builtin.v
@@ -67,7 +68,7 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 					println(sframe) continue
 				}
 				if output in ['??:0:','??:?:'] { output = '' }
-				println( '${output:-48s} | $sframe')
+				println( '${output:-46s} | ${addr:14s} | $beforeaddr')
 			}
 			//C.backtrace_symbols_fd(*voidptr(&buffer[skipframes]), nr_actual_frames, 1)
 			return true

--- a/vlib/builtin/builtin_nix.v
+++ b/vlib/builtin/builtin_nix.v
@@ -66,7 +66,8 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 				if 0 != int(C.pclose(f)) {
 					println(sframe) continue
 				}
-				println( '${output:-45s} | $sframe')
+				if output in ['??:0:','??:?:'] { output = '' }
+				println( '${output:-48s} | $sframe')
 			}
 			//C.backtrace_symbols_fd(*voidptr(&buffer[skipframes]), nr_actual_frames, 1)
 			return true


### PR DESCRIPTION
Before, when running `v -g vlib/compiler/tests/backtrace_test.v`:
```shell
/v/nv/vlib/compiler/tests/backtrace_test.v:7: | ./vlib/compiler/tests/backtrace_test(main__a_method+0xe) [0x415039]
/v/nv/vlib/compiler/tests/backtrace_test.v:12: | ./vlib/compiler/tests/backtrace_test(main__test_backtrace+0xe) [0x41504a]
/tmp/v/backtrace_test.tmp.c:12305:            | ./vlib/compiler/tests/backtrace_test(main+0x23) [0x415697]
??:0:                                         | /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0) [0x7ffff7810830]
??:?:                                         | ./vlib/compiler/tests/backtrace_test(_start+0x29) [0x4064c9]
```
After:
```shell
/v/nv/vlib/compiler/tests/backtrace_test.v:7:  |       0x4150dd | ./vlib/compiler/tests/backtrace_test(main__a_method+0xe)
/v/nv/vlib/compiler/tests/backtrace_test.v:12: |       0x4150ee | ./vlib/compiler/tests/backtrace_test(main__test_backtrace+0xe)
/tmp/v/backtrace_test.tmp.c:12320:             |       0x41573b | ./vlib/compiler/tests/backtrace_test(main+0x23)
                                               | 0x7ffff7810830 | /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)
                                               |       0x4064c9 | ./vlib/compiler/tests/backtrace_test(_start+0x29)
```
