### PR TITLE
compiler: fix vpath module search order regression

### DIFF
--- a/vlib/compiler/modules.v
+++ b/vlib/compiler/modules.v
@@ -160,9 +160,14 @@ fn (v &V) find_module_path(mod string) ?string {
 	mod_path := v.module_path(mod)
 	mut tried_paths := []string
 	tried_paths << filepath.join(v.compiled_dir, mod_path)
-	tried_paths << filepath.join(os.getwd(), mod_path)
-	tried_paths << filepath.join(v.pref.vlib_path, mod_path)
-	tried_paths << filepath.join(v_modules_path, mod_path)
+	if v.pref.vpath.len > 0 {
+		tried_paths << filepath.join(v.pref.vlib_path, mod_path)
+		tried_paths << filepath.join(v.pref.vpath, mod_path)
+	}else{
+		tried_paths << filepath.join(os.getwd(), mod_path)
+		tried_paths << filepath.join(v.pref.vlib_path, mod_path)
+		tried_paths << filepath.join(v_modules_path, mod_path)
+	}
 	for try_path in tried_paths {
 		if v.pref.is_verbose { println('  >> trying to find $mod in $try_path ...') }
 		if os.dir_exists(try_path) { 


### PR DESCRIPTION
Restore the seeking for user modules inside v.pref.vpath when it is non empty.
Regression started in f42be062