### PR TITLE
log: Added enum for logger level

### DIFF
--- a/examples/log.v
+++ b/examples/log.v
@@ -1,12 +1,12 @@
 import log
 
-fn main(){
-    mut l := log.Log{log.INFO, 'terminal'}
-    l.info('info')
-    l.warn('warn')
-    l.error('error')
-    l.debug('no debug')
-    l.set_level(log.DEBUG)
-    l.debug('debug')
-    l.fatal('fatal')
+fn main() {
+	mut l := Log { LogLevel.info, 'info', true }
+	l.info('info')
+	l.warn('warn')
+	l.error('error')
+	l.debug('no debug')
+	l.set_level(DEBUG)
+	l.debug('debug')
+	l.fatal('fatal')
 }

--- a/examples/log.v
+++ b/examples/log.v
@@ -1,12 +1,12 @@
 import log
 
 fn main() {
-	mut l := Log { LogLevel.info, 'info', true }
+	mut l := log.Log { log.LogLevel.info, 'info', true }
 	l.info('info')
 	l.warn('warn')
 	l.error('error')
 	l.debug('no debug')
-	l.set_level(DEBUG)
+	l.set_level(log.DEBUG)
 	l.debug('debug')
 	l.fatal('fatal')
 }

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -4,101 +4,128 @@ import os
 import time
 import term
 
+pub enum LogLevel {
+	fatal
+	error
+	warning
+	info
+	debug
+}
+
 pub const (
     FATAL = 1
-    ERROR = 2 
+    ERROR = 2
     WARN  = 3
     INFO  = 4
     DEBUG = 5
 )
 
 interface Logger {
-    fatal(s string)
-    error(s string)
-    warn(s string)
-    info(s string)
-    debug(s string)
+	fatal(s string)
+	error(s string)
+	warn(s string)
+	info(s string)
+	debug(s string)
 }
 
 pub struct Log {
-mut:
-    level int
-    output string
+	mut:
+	level LogLevel
+	output_label string
+	output_to_file bool
 }
 
 pub fn (l mut Log) set_level(level int){
-    l.level = level
+	l.level = match level {
+		FATAL { LogLevel.fatal }
+		ERROR { LogLevel.error }
+		WARN { LogLevel.warning }
+		INFO { LogLevel.info }
+		DEBUG { LogLevel.debug }
+		else { .debug }
+	}
 }
 
-pub fn (l mut Log) set_output(output string) {
-    l.output = output
+pub fn (l mut Log) set_output_level(level LogLevel){
+	l.level = level
+}
+
+pub fn (l mut Log) set_output_label(label string) {
+	l.output_label = label
+}
+
+pub fn (l mut Log) set_output(output string){
+	l.output_label = output
 }
 
 fn (l Log) log_file(s string, e string) {
-    filename := l.output
-    f := os.open_append(l.output) or {
-        panic('error reading file $filename')
-    }
-    timestamp := time.now().format_ss()
-    f.writeln('$timestamp [$e] $s')
+	filename := '${l.output_label}.log'.replace(' ', '')
+	f := os.open_append(filename) or {
+		panic('error reading file $filename')
+	}
+	timestamp := time.now().format_ss()
+	f.writeln('$timestamp [$e] $s')
 }
 
 pub fn (l Log) fatal(s string){
-    panic(s)
+	if l.level == .fatal {
+		if l.output_to_file {
+			l.log_file(s, 'F')
+		} else {
+			f := term.red('F')
+			t := time.now()
+			println('[$f ${t.format_ss()}] $s')
+		}
+		panic('$l.output_label: $s')
+	}
 }
 
 pub fn (l Log) error(s string){
-    if l.level >= ERROR{
-        match l.output {
-            'terminal'{
-                f := term.red('E')
-                t := time.now()
-                println('[$f ${t.format_ss()}] $s')
-            } else {
-                l.log_file(s, 'E')
-            }
-        }
-    }
+
+	if l.level in [.info, .debug, .warning, .error] {
+		if l.output_to_file {
+			l.log_file(s, 'E')
+		} else {
+			f := term.red('E')
+			t := time.now()
+			println('[$f ${t.format_ss()}] $s')
+		}
+	}
 }
 
 pub fn (l Log) warn(s string){
-    if l.level >= WARN{
-        match l.output {
-            'terminal'{
-                f := term.yellow('W')
-                t := time.now()
-                println('[$f ${t.format_ss()}] $s')
-            } else {
-                l.log_file(s, 'W')
-            }
-        }
-    }
+	if l.level in [.info, .debug, .warning] {
+		if l.output_to_file {
+			l.log_file(s, 'W')
+		} else {
+			f := term.yellow('W')
+			t := time.now()
+			println('[$f ${t.format_ss()}] $s')
+		}
+	}
 }
 
 pub fn (l Log) info(s string){
-    if l.level >= INFO{
-        match l.output {
-            'terminal'{
-                f := term.white('I')
-                t := time.now()
-                println('[$f ${t.format_ss()}] $s')
-            } else {
-              l.log_file(s, 'I')
-            }
-        }
-    }
+	if l.level in [.info, .debug] {
+		if l.output_to_file {
+			l.log_file(s, 'I')
+		} else {
+			f := term.white('I')
+			t := time.now()
+			println('[$f ${t.format_ss()}] $s')
+		}
+	}
 }
 
 pub fn (l Log) debug(s string){
-    if l.level >= DEBUG{
-        match l.output {
-            'terminal' {
-                f := term.blue('D')
-                t := time.now()
-                println('[$f ${t.format_ss()}] $s')
-            } else {
-                l.log_file(s, 'D')
-            }
-        }
-    }
+	if l.level != .debug {
+		return
+	}
+	if l.output_to_file {
+		l.log_file(s, 'D')
+	} else {
+		f := term.blue('D')
+		t := time.now()
+		println('[$f ${t.format_ss()}] $s')
+	}
 }

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -1,3 +1,5 @@
+module log
+
 import os
 import time
 import term
@@ -95,7 +97,6 @@ pub fn (l Log) fatal(s string){
 }
 
 pub fn (l Log) error(s string){
-
 	if l.level in [.info, .debug, .warning, .error] {
 		if l.output_to_file {
 			l.log_file(s, .error)
@@ -136,15 +137,3 @@ pub fn (l Log) debug(s string){
 		l.log_cli(s, .debug)
 	}
 }
-
-fn main() {
-	mut l := Log { LogLevel.info, 'info', true }
-	l.info('info')
-	l.warn('warn')
-	l.error('error')
-	l.debug('no debug')
-	l.set_level(DEBUG)
-	l.debug('debug')
-	l.fatal('fatal')
-}
-


### PR DESCRIPTION
This PR adds `LogLevel` which is a simple enum for the log output levels. 

### Added:
- LogLevel
```
pub enum LogLevel {
	fatal
	error
	warning
	info
	debug
}
```

### Changed
- Log
```
pub struct Log {
	mut:
	level LogLevel
	output_label string
	output_to_file bool
}
```

### Example
```
fn main() {
	mut l := log.Log { log.LogLevel.info, 'info', true }
	l.info('info')
	l.warn('warn')
	l.error('error')
	l.debug('no debug')
	l.set_output_level(.debug) // l.set_level(log.DEBUG)
	l.debug('debug')
	l.fatal('fatal')
}
```