### PR TITLE
cfns: fix some declarations.

### DIFF
--- a/vlib/builtin/cfns.v
+++ b/vlib/builtin/cfns.v
@@ -30,9 +30,9 @@ fn C.realpath(byteptr, byteptr) &char
 
 
 
-fn C.chmod(byteptr, int)
-fn C.printf(byteptr, ...byteptr)
-fn C.fputs(byteptr)
+fn C.chmod(byteptr, int) int
+fn C.printf(byteptr, ...byteptr) int
+fn C.fputs(byteptr) int
 fn C.fflush(byteptr) int
 // TODO define args in these functions
 fn C.fseek() int
@@ -93,7 +93,7 @@ fn C.syscall() int
 
 
 // Windows
-fn C._setmode(int, int)
+fn C._setmode(int, int) int
 fn C._fileno(int) int
 fn C._get_osfhandle(fd int) C.intptr_t
 fn C.GetModuleFileNameW(hModule voidptr, lpFilename &u16, nSize u32) u32


### PR DESCRIPTION
Some of these C functions return ints, despite commonly ignored.