### PR TITLE
compiler: add "modules/ " folder for searching local modules

### DIFF
--- a/vlib/compiler/modules.v
+++ b/vlib/compiler/modules.v
@@ -154,13 +154,15 @@ fn (v &V) find_module_path(mod string) ?string {
 	// Module search order:
 	// 1) search in the *same* directory, as the compiled final v program source
 	//    (i.e. the . in `v .` or file.v in `v file.v`)
-	// 2) search in vlib/
-	// 3.1) search in -vpath (if given)
-	// 3.2) search in ~/.vmodules/ (i.e. modules installed with vpm) (no -vpath)
+	// 2) search in the modules/ in the same directory.
+	// 3) search in vlib/
+	// 4.1) search in -vpath (if given)
+	// 4.2) search in ~/.vmodules/ (i.e. modules installed with vpm) (no -vpath)
 	modules_lookup_path := if v.pref.vpath.len > 0 { v.pref.vpath } else { v_modules_path }
 	mod_path := v.module_path(mod)
 	mut tried_paths := []string
 	tried_paths << filepath.join(v.compiled_dir, mod_path)
+	tried_paths << filepath.join(v.compiled_dir, '/modules', mod_path)
 	tried_paths << filepath.join(v.pref.vlib_path, mod_path)
 	tried_paths << filepath.join(modules_lookup_path, mod_path)
 	for try_path in tried_paths {

--- a/vlib/compiler/modules.v
+++ b/vlib/compiler/modules.v
@@ -162,7 +162,7 @@ fn (v &V) find_module_path(mod string) ?string {
 	mod_path := v.module_path(mod)
 	mut tried_paths := []string
 	tried_paths << filepath.join(v.compiled_dir, mod_path)
-	tried_paths << filepath.join(v.compiled_dir, '/modules', mod_path)
+	tried_paths << filepath.join(v.compiled_dir, 'modules', mod_path)
 	tried_paths << filepath.join(v.pref.vlib_path, mod_path)
 	tried_paths << filepath.join(modules_lookup_path, mod_path)
 	for try_path in tried_paths {


### PR DESCRIPTION
May be a bit of a hot topic here, but adding `${compiled_dir}/modules/` folder to the list of paths where the compiler will lookup for modules has lots of advantages here:

- Developers can distinguish their own modules from the ones cloned/downloaded on the internet.
- Easy to put into `.gitignore` compared to listing down multiple modules which would change over time.
- A potential useful feature for `vpm` (adding them as a local module through the `--local` flag)

My initial idea was to put them inside the `lib/` folder, but changed it into `modules/` to follow V conventions as well as consistency with the global module folder (`.vmodules`).