### PR TITLE
compiler: Allow `or` usage when assigning to struct fields.

### DIFF
--- a/vlib/compiler/gen_c.v
+++ b/vlib/compiler/gen_c.v
@@ -117,7 +117,7 @@ fn (p mut Parser) gen_handle_option_or_else(_typ, name string, fn_call_ph int) s
 		is_mut: false
 		is_used: true
 	})
-	if is_assign {
+	if is_assign && !name.contains('.') { // don't initialize struct fields
 		p.genln('$typ $name;')
 	}
 	p.genln('if (!$tmp .ok) {')

--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -1353,7 +1353,9 @@ fn ($v.name mut $v.typ) $p.cur_fn.name (...) {
 	p.next()
 	p.fspace()
 	pos := p.cgen.cur_line.len
+	p.is_var_decl = true
 	expr_type := p.bool_expression()
+	p.is_var_decl = false
 	//if p.expected_type.starts_with('array_') {
 		//p.warn('expecting array got $expr_type')
 	//}
@@ -1368,6 +1370,13 @@ fn ($v.name mut $v.typ) $p.cur_fn.name (...) {
 		left := p.cgen.cur_line[..pos]
 		typ := expr_type.replace('Option_', '')
 		p.cgen.resetln(left + 'opt_ok($expr, sizeof($typ))')
+	}
+	else if expr_type.starts_with('Option_') &&
+		p.assigned_type == expr_type['Option_'.len..] && p.tok == .key_orelse {
+			line := p.cgen.cur_line
+			vname := line[..pos].replace('=','')
+			p.cgen.resetln(line.replace(line[..line.index('=')+1], ''))
+			p.gen_handle_option_or_else(expr_type, vname, ph)
 	}
 	else if expr_type[0]==`[` {
 		// assignment to a fixed_array `mut a:=[3]int a=[1,2,3]!!`

--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -1372,15 +1372,16 @@ fn ($v.name mut $v.typ) $p.cur_fn.name (...) {
 		p.cgen.resetln(left + 'opt_ok($expr, sizeof($typ))')
 	}
 	else if expr_type.starts_with('Option_') &&
-		p.assigned_type == expr_type['Option_'.len..] && p.tok == .key_orelse {
-			line := p.cgen.cur_line
-			vname := line[..pos].replace('=','')
-			p.cgen.resetln(line.replace(line[..line.index('=')+1], ''))
-			p.gen_handle_option_or_else(expr_type, vname, ph)
+		p.assigned_type == expr_type['Option_'.len..] && p.tok == .key_orelse
+	{
+		line := p.cgen.cur_line
+		vname := line[..pos].replace('=','') // TODO cgen line hack
+		p.cgen.resetln(line.replace(line[..line.index('=')+1], ''))
+		p.gen_handle_option_or_else(expr_type, vname, ph)
 	}
 	else if expr_type[0]==`[` {
-		// assignment to a fixed_array `mut a:=[3]int a=[1,2,3]!!`
-		expr := p.cgen.cur_line[pos..].all_after('{').all_before('}')
+		// assignment to a fixed_array `mut a:=[3]int a=[1,2,3]!!` 
+		expr := p.cgen.cur_line[pos..].all_after('{').all_before('}') // TODO cgen line hack
 		left := p.cgen.cur_line[..pos].all_before('=')
 		cline_pos := p.cgen.cur_line[pos..]
 		etype := cline_pos.all_before(' {')

--- a/vlib/compiler/tests/option_test.v
+++ b/vlib/compiler/tests/option_test.v
@@ -75,6 +75,40 @@ fn foo_ok() ?int {
 	return 777
 }	
 
+fn foo_str() ?string {
+	return 'something'
+}
+
 fn test_q() {
 	//assert foo_ok()? == true
 }	
+
+struct Person {
+mut:
+	name string
+	age int
+	title ?string
+}
+
+fn test_field_or() {
+	name := foo_str() or {
+		'nada'
+	}
+	assert name == 'something'
+
+	mut p := Person {}
+	p.name = foo_str() or {
+		'nothing'
+	}
+	assert p.name == 'something'
+
+	p.age = foo_ok() or {
+		panic('no age')
+	}
+	assert p.age == 777
+
+	mytitle := p.title or {
+		'default'
+	}
+	assert mytitle == 'default'
+}


### PR DESCRIPTION
Fix for #2806

This checks for an `Option_` type when assigning to a struct field and runs the same code that regular vars use, `gen_handle_option_or_else`, if detected.