### PR TITLE
compiler: make `p.opt()?` work for methods

### DIFF
--- a/vlib/compiler/expression.v
+++ b/vlib/compiler/expression.v
@@ -329,17 +329,7 @@ fn (p mut Parser) name_expr() string {
 	is_or_else := p.tok == .key_orelse
 	if p.tok == .question {
 		// `files := os.ls('.')?`
-		if p.cur_fn.name != 'main__main' {
-			p.error('`func()?` syntax can only be used inside `fn main()` for now')
-		}	
-		p.next()
-		tmp := p.get_tmp()
-		p.cgen.set_placeholder(fn_call_ph, '$f.typ $tmp = ')
-		p.genln(';')
-		p.genln('if (!${tmp}.ok) v_panic(${tmp}.error);')
-		typ := f.typ[7..] // option_xxx
-		p.gen('*($typ*) ${tmp}.data;')
-		return typ
+		return p.gen_handle_question_suffix(f, fn_call_ph)
 	}	
 	else if !p.is_var_decl && is_or_else {
 		f.typ = p.gen_handle_option_or_else(f.typ, '', fn_call_ph)

--- a/vlib/compiler/gen_c.v
+++ b/vlib/compiler/gen_c.v
@@ -144,6 +144,21 @@ fn (p mut Parser) gen_handle_option_or_else(_typ, name string, fn_call_ph int) s
 	return typ
 }
 
+// `files := os.ls('.')?`
+fn (p mut Parser) gen_handle_question_suffix(f Fn, ph int) string {
+	if p.cur_fn.name != 'main__main' {
+		p.error('`func()?` syntax can only be used inside `fn main()` for now')
+	}
+	p.check(.question)
+	tmp := p.get_tmp()
+	p.cgen.set_placeholder(ph, '$f.typ $tmp = ')
+	p.genln(';')
+	p.genln('if (!${tmp}.ok) v_panic(${tmp}.error);')
+	typ := f.typ[7..] // option_xxx
+	p.gen('*($typ*) ${tmp}.data;')
+	return typ
+}
+
 fn types_to_c(types []Type, table &Table) string {
 	mut sb := strings.new_builder(10)
 	for t in types {

--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -1858,17 +1858,7 @@ struct $typ.name {
     is_or_else := p.tok == .key_orelse
 	if p.tok == .question {
 		// `files := os.ls('.')?`
-		if p.cur_fn.name != 'main__main' {
-			p.error('`func()?` syntax can only be used inside `fn main()` for now')
-		}
-		p.next()
-		tmp := p.get_tmp()
-		p.cgen.set_placeholder(method_ph, '$method.typ $tmp = ')
-		p.genln(';')
-		p.genln('if (!${tmp}.ok) v_panic(${tmp}.error);')
-		ty := method.typ[7..] // option_xxx
-		p.gen('*($ty*) ${tmp}.data;')
-		return ty
+		return p.gen_handle_question_suffix(method, method_ph)
 	}
 	else if !p.is_var_decl && is_or_else {
 		method.typ = p.gen_handle_option_or_else(method.typ, '', method_ph)


### PR DESCRIPTION
Right now this works:

````v
fn opt(i int) ?int {
    return i
}

fn main() {
    i := opt(99)?
    println('i is $i')
}
````

````
$ v run opt.v                                                                                             master
i is 99
````

But this (calling method on struct) doesn't:

````v
struct Person { i int }
fn (p Person) opt() ?int { return p.i }

fn main() {
    p := Person{i:9999}
    i := p.opt()?
    println('i is $i')
}
````

````
opt.v:8:17: unexpected token: `?`
    6| fn main() {
    7|     p := Person{i:9999}
    8|     i := p.opt()?
                       ^
    9|     println('i is $i')
   10| }
````

This patch just copies the `?` existing handling code and uses it for method calls:

```
$ v run opt.v                                                                                            master
i is 9999
```
