### PR TITLE
compiler/enum: fix hexadecimal constants

### DIFF
--- a/vlib/builtin/bare/.checks/linuxsys/linuxsys.v
+++ b/vlib/builtin/bare/.checks/linuxsys/linuxsys.v
@@ -87,14 +87,18 @@ fn check_read_file() {
 	}
 	assert 0 == sys_close(fd)
 
-	fd1, ec1 := sys_open("./nofilehere".str, .o_rdonly, 0)
-	assert fd1 == -1
-//ss1
-	assert ec1 == .enoent
-//ss2
 	println("read file passed")
 }
 
+fn check_open_file_fail() {
+	println ("checking 'open file fail'")
+	fd1, ec1 := sys_open("./nofilehere".str, .o_rdonly, 0)
+	assert fd1 == -1
+	assert ec1 == .enoent
+	println ("'open file fail' check passed")
+}
+
+/*
 fn check_print() {
 	println ("checking print and println")
 
@@ -106,11 +110,13 @@ fn check_print() {
 	//sys_dup2
 	println ("print and println passed")
 }
+*/
 
 fn main() {
 	check_read_write_pipe()
 	check_read_file()
-	check_print()
+	// check_print()
+	check_open_file_fail()
 	sys_exit(0)
 }
 

--- a/vlib/builtin/bare/.checks/linuxsys/linuxsys.v
+++ b/vlib/builtin/bare/.checks/linuxsys/linuxsys.v
@@ -7,14 +7,26 @@ const (
 	sample_text_file1 = ""
 )
 
+fn fork_test (test_fn fn(), name string) {
+	//print ("checking")
+	// a := "$name"
+	println (name)
+	child := sys_fork()
+	if child == 0 {
+		test_fn()
+		sys_exit(0)
+	}
+//	pid := sys_wait(0)
+//	assert
+}
+
 fn check_read_write_pipe() {
-	/*
-		Checks the following system calls:
-			sys_pipe
-			sys_write
-			sys_read
-			sys_close
-	*/
+	//	Checks the following system calls:
+	//		sys_pipe
+	//		sys_write
+	//		sys_read
+	//		sys_close
+	//
 	println ("checking pipe read/write")
 	fd[0] = -1
 	fd[1] = -1
@@ -59,12 +71,14 @@ fn check_read_file() {
 			sys_read
 			sys_write
 			sys_close
+			sys_open
 	*/
 	test_file := "sample_text1.txt"
 	sample_text := "Do not change this text.\n"
 	println ("checking read file")
-	fd := sys_open(test_file.str, int(fcntl.o_rdonly), 0)
+	fd, ec := sys_open(test_file.str, .o_rdonly, 0)
 	assert fd > 0
+	assert ec == .enoerror
 	n := sample_text.len
 	c := sys_read(fd, buffer, u64(n*2))
 	assert c == n
@@ -72,12 +86,31 @@ fn check_read_file() {
 		assert sample_text[i] == buffer[i]
 	}
 	assert 0 == sys_close(fd)
+
+	fd1, ec1 := sys_open("./nofilehere".str, .o_rdonly, 0)
+	assert fd1 == -1
+//ss1
+	assert ec1 == .enoent
+//ss2
 	println("read file passed")
+}
+
+fn check_print() {
+	println ("checking print and println")
+
+	a := sys_pipe(intptr(fd))
+	assert a != -1
+	assert fd[0] != -1
+	assert fd[1] != -1
+
+	//sys_dup2
+	println ("print and println passed")
 }
 
 fn main() {
 	check_read_write_pipe()
 	check_read_file()
+	check_print()
 	sys_exit(0)
 }
 

--- a/vlib/builtin/bare/.checks/string/string.v
+++ b/vlib/builtin/bare/.checks/string/string.v
@@ -1,5 +1,7 @@
 module main
 
+__global buffer [128]byte
+
 fn check_string_eq () {
 	println ("checking string_eq")
 	assert "monkey" != "rat"
@@ -9,6 +11,11 @@ fn check_string_eq () {
 }
 
 fn main () {
+	s := i64_tos(buffer, 70, 140, 10)
+	s1 := i64_tos(buffer, 70, -140, 10)
+	println(s)
+	println(s1)
+
 	check_string_eq ()
 	sys_exit(0)
 }

--- a/vlib/builtin/bare/.checks/string/string.v
+++ b/vlib/builtin/bare/.checks/string/string.v
@@ -10,13 +10,23 @@ fn check_string_eq () {
 	println ("string_eq passed")
 }
 
-fn main () {
-	s := i64_tos(buffer, 70, 140, 10)
-	s1 := i64_tos(buffer, 70, -140, 10)
-	println(s)
-	println(s1)
+fn check_i64_tos() {
+	s0 := i64_tos(buffer, 70, 140, 10)
+	assert s0 == "140"
 
+	s1 := i64_tos(buffer, 70, -160, 10)
+	assert s1 == "-160"
+
+	s2 := i64_tos(buffer, 70, 65537, 16)
+	assert s2 == "10001"
+
+	s3 := i64_tos(buffer, 70, -160000, 10)
+	assert s3 == "-160000"
+}
+
+fn main () {
 	check_string_eq ()
+	check_i64_tos()
 	sys_exit(0)
 }
 

--- a/vlib/builtin/bare/builtin_bare.v
+++ b/vlib/builtin/bare/builtin_bare.v
@@ -10,7 +10,13 @@ pub fn print(s string) {
 
 pub fn println(s string) {
 	print(s)
-	sys_write(1, "\n".str, 1)
+	print("\n")
+}
+
+pub fn panic(s string) {
+	print('V panic: ')
+	println(s)
+	sys_exit(1)
 }
 
 // replaces panic when -debug arg is passed
@@ -29,16 +35,21 @@ fn panic_debug(line_no int, file,  mod, fn_name, s string) {
 	println('=========================================')
 	sys_exit(1)
 }
+pub fn eprint(s string) {
+	if isnil(s.str) {
+		panic('eprint(NIL)')
+	}
+	sys_write(1, s.str, u64(s.len))
+}
 
-pub fn panic(s string) {
-	print('V panic: ')
-	println(s)
-	sys_exit(1)
+pub fn eprint_ln(s string) {
+	eprint(s)
+	eprint("\n")
 }
 
 pub fn eprintln(s string) {
 	if isnil(s.str) {
 		panic('eprintln(NIL)')
 	}
-	println(s)
+	eprint_ln(s)
 }

--- a/vlib/builtin/bare/builtin_bare.v
+++ b/vlib/builtin/bare/builtin_bare.v
@@ -39,7 +39,7 @@ pub fn eprint(s string) {
 	if isnil(s.str) {
 		panic('eprint(NIL)')
 	}
-	sys_write(1, s.str, u64(s.len))
+	sys_write(2, s.str, u64(s.len))
 }
 
 pub fn eprint_ln(s string) {

--- a/vlib/builtin/bare/string_bare.v
+++ b/vlib/builtin/bare/string_bare.v
@@ -91,7 +91,7 @@ pub fn i64_tos(buf byteptr, len int, n0 i64, base int) string {
 	}
 	offset := i+1
 	b.str = b.str + offset
-	b.len -= offset
+	b.len -= (offset+1)
 	return b
 }
 

--- a/vlib/builtin/bare/string_bare.v
+++ b/vlib/builtin/bare/string_bare.v
@@ -64,6 +64,39 @@ pub fn string_ne (s1, s2 string) bool {
 	return !string_eq(s1,s2)
 }
 
+
+pub fn i64_tos(buf byteptr, len int, n0 i64, base int) string {
+	if base < 2 { panic("base must be >= 2")}
+	if base > 36 { panic("base must be <= 36")}
+
+	mut b := tos(buf, len)
+	mut i := len-1
+
+	mut n := n0
+	neg := n < 0
+	if neg { n = -n }
+
+	b[i--] = 0
+
+	for {
+		c := (n%base) + 48
+		b[i--] = if c > 57 {c+7} else {c}
+		if i < 0 { panic ("buffer to small") }
+		n /= base
+		if n < 1 {break}
+	}
+	if (neg) {
+		if i < 0 { panic ("buffer to small") }
+		b[i--] = 45
+	}
+	offset := i+1
+	b.str = b.str + offset
+	b.len -= offset
+	return b
+}
+
+
+
 /*
 pub fn (a string) clone() string {
 	mut b := string {

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -185,30 +185,10 @@ pub fn (s string) replace(rep, with string) string {
 	return tos(b, new_len)
 }
 
-/*
-pub fn (s string) int() int {
-	return strconv.parse_int(s, 0, 32)
-}
-*/
 
 pub fn (s string) int() int {
-	mut neg := false
-	mut i := 0
-	if s[0] == `-` {
-		neg = true
-		i++
-	}
-	else if s[0] == `+` {
-		i++
-	}
-	mut n := 0
-	for C.isdigit(s[i]) {
-		n = 10 * n - int(s[i] - `0`)
-		i++
-	}
-	return if neg { n } else { -n }
+	return int(strconv.parse_int(s,0,32))
 }
-
 
 pub fn (s string) i64() i64 {
 	return strconv.parse_int(s, 0, 64)
@@ -223,23 +203,7 @@ pub fn (s string) f64() f64 {
 }
 
 pub fn (s string) u32() u32 {
-	mut neg := false
-	mut i := 0
-	if s[0] == `-` {
-		neg = true
-		i++
-	}
-	else if s[0] == `+` {
-		i++
-	}
-	mut n := u32(0)
-	for C.isdigit(s[i]) {
-		n = u32(10) * n - u32(s[i] - `0`)
-		i++
-	}
-	return if neg { n } else { -n }
-	//return C.atol(*char(s.str))
-	//return strconv.parse_uint(s, 0, 32)
+	return u32(strconv.parse_uint(s, 0, 32))
 }
 
 pub fn (s string) u64() u64 {

--- a/vlib/compiler/tests/enum_hex_test.v
+++ b/vlib/compiler/tests/enum_hex_test.v
@@ -1,0 +1,33 @@
+enum w_hex {
+	a = 0x001
+	b = 0x010
+	c = 0x100
+}
+
+enum w_decimal {
+	a = 1
+	b = 16
+	c = 256
+}
+
+const (
+	ca = 1
+	cb = 16
+	cc = 256
+)
+
+
+fn test_enum_hex() {
+	assert ca == int(w_decimal.a)
+	assert cb == int(w_decimal.b)
+	assert cc == int(w_decimal.c)
+
+	assert int(w_hex.a) == ca
+	assert int(w_hex.b) == cb
+	assert int(w_hex.c) == cc
+
+	assert int(w_hex.a) == int(w_decimal.a)
+	assert int(w_hex.b) == int(w_decimal.b)
+	assert int(w_hex.c) == int(w_decimal.c)
+}
+


### PR DESCRIPTION
When adding tests for syscall wrappers that were separating the return value from the error, I could not proceed because the error enum constants were in hex and they were all getting #defined in C as 0.

I corrected this by changing the string int() to use strconv.parse_int 
See https://github.com/vlang/v/issues/2876

Also added **i64_tos** to debug numeric returns from syscalls (Takes a buffer and length and a number a base 2-36)

This fix (hex support for enums) allows me to continue splitting out error from value in the syscall wrappers.