### PR TITLE
parser: fix `in` expression

### DIFF
--- a/vlib/compiler/optimization.v
+++ b/vlib/compiler/optimization.v
@@ -18,23 +18,25 @@ fn (p mut Parser) in_optimization(typ string, ph int) {
 			}	else {
 				p.gen(' || $expr == ')
 			}
-		}	
+		}
 		if i == 0 {
 			if is_str {
-				p.cgen.set_placeholder(ph, ' string_eq(')
+				p.cgen.set_placeholder(ph, ' (string_eq(')
 				p.gen(', ')
 			} else {
+				p.cgen.set_placeholder(ph, ' (')
 				p.gen(' ==')
-			}	
-		}	
+			}
+		}
 		p.check_types(p.bool_expression(), typ)
 		if is_str {
 			p.gen(')')
-		}	
+		}
 		if p.tok != .rsbr {
 			p.check(.comma)
 		}
 		i++
-	}	
+	}
+	p.gen(')')
 	p.check(.rsbr)
 }

--- a/vlib/compiler/tests/in_expression_test.v
+++ b/vlib/compiler/tests/in_expression_test.v
@@ -1,0 +1,174 @@
+enum Colors {
+	red green blue yellow
+}
+
+fn test_in_expression(){
+	mut a := false
+	arr1 := [1, 2]
+	arr2 := [0, 2]
+	arr3 := [1, 0]
+	a = true && 2 in arr1
+	assert a == true
+	a = false && 2 in arr1
+	assert a == false
+	a = true && 0 in arr2
+	assert a == true
+	a = false && 0 in arr3
+	assert a == false
+
+	a = true && 0 in arr1
+	assert a == false
+	a = true && 3 in arr1
+	assert a == false
+
+	a = true && !2 in arr2
+	assert a == false
+	a = true && !3 in arr2
+	assert a == true
+
+	a = 1 in arr1 && true
+	assert a == true
+	a = 1 in arr1 && false
+	assert a == false
+}
+/* not implemented
+fn test_in_expression_with_enum(){
+	mut a := false
+	arr1 := [Colors.green, .blue]
+	arr2 := [Colors.red, .blue]
+	arr3 := [Colors.green, .red]
+	a = true && Colors.blue in arr1
+	assert a == true
+	a = false && Colors.blue in arr1
+	assert a == false
+	a = true && Colors.red in arr2
+	assert a == true
+	a = false && Colors.red in arr3
+	assert a == false
+
+	a = true && Colors.red in arr1
+	assert a == false
+	a = true && Colors.yellow in arr1
+	assert a == false
+
+	a = true && !Colors.blue in arr2
+	assert a == false
+	a = true && !Colors.yellow in arr2
+	assert a == true
+
+	a = Colors.green in arr1 && true
+	assert a == true
+	a = Colors.green in arr1 && false
+	assert a == false
+}
+*/
+fn test_in_expression_with_string(){
+	mut a := false
+	arr1 := ['ab', 'bc']
+	arr2 := ['', 'bc']
+	arr3 := ['ab', '']
+	a = true && 'bc' in arr1
+	assert a == true
+	a = false && 'bc' in arr1
+	assert a == false
+	a = true && '' in arr2
+	assert a == true
+	a = false && '' in arr3
+	assert a == false
+
+	a = true && '' in arr1
+	assert a == false
+	a = true && 'abc' in arr1
+	assert a == false
+
+	a = true && !'bc' in arr2
+	assert a == false
+	a = true && !'abc' in arr2
+	assert a == true
+
+	a = 'ab' in arr1 && true
+	assert a == true
+	a = 'ab' in arr1 && false
+	assert a == false
+}
+
+fn test_optimized_in_expression(){
+	mut a := false
+	a = true && 2 in [1, 2]
+	assert a == true
+	a = false && 2 in [1, 2]
+	assert a == false
+	a = true && 0 in [0, 2]
+	assert a == true
+	a = false && 0 in [1, 0]
+	assert a == false
+
+	a = true && 0 in [1, 2]
+	assert a == false
+	a = true && 3 in [1, 2]
+	assert a == false
+
+	a = true && !2 in [0, 2]
+	assert a == false
+	a = true && !3 in [0, 2]
+	assert a == true
+
+	a = 1 in [1, 2] && true
+	assert a == true
+	a = 1 in [1, 2] && false
+	assert a == false
+}
+
+fn test_optimized_in_expression_with_enum(){
+	mut a := false
+	a = true && Colors.blue in [.green, .blue]
+	assert a == true
+	a = false && Colors.blue in [.green, .blue]
+	assert a == false
+	a = true && Colors.red in [.red, .blue]
+	assert a == true
+	a = false && Colors.red in [.green, .red]
+	assert a == false
+
+	a = true && Colors.red in [.green, .blue]
+	assert a == false
+	a = true && Colors.yellow in [.green, .blue]
+	assert a == false
+
+	a = true && !Colors.blue in [.red, .blue]
+	assert a == false
+	a = true && !Colors.yellow in [.red, .blue]
+	assert a == true
+
+	a = Colors.green in [.green, .blue] && true
+	assert a == true
+	a = Colors.green in [.green, .blue] && false
+	assert a == false
+}
+
+fn test_optimized_in_expression_with_string(){
+	mut a := false
+	a = true && 'bc' in ['ab', 'bc']
+	assert a == true
+	a = false && 'bc' in ['ab', 'bc']
+	assert a == false
+	a = true && '' in ['', 'bc']
+	assert a == true
+	a = false && '' in ['ab', '']
+	assert a == false
+
+	a = true && '' in ['ab', 'bc']
+	assert a == false
+	a = true && 'abc' in ['ab', 'bc']
+	assert a == false
+
+	a = true && !'bc' in ['', 'bc']
+	assert a == false
+	a = true && !'abc' in ['', 'bc']
+	assert a == true
+
+	a = 'ab' in ['ab', 'bc'] && true
+	assert a == true
+	a = 'ab' in ['ab', 'bc'] && false
+	assert a == false
+}


### PR DESCRIPTION
```
false && 2 in [1, 2] // expected: 0 && (2 == 1 || 2 == 2) => 0 , actual: 0 && 2 == 1 || 2 == 2 => 1
```
the same as `if` expression in #2852 , lack of brackets