### PR TITLE
compiler: Temporary fix for issue #2897 (allow voidptr and byteptr in value multi returns)

### DIFF
--- a/vlib/compiler/table.v
+++ b/vlib/compiler/table.v
@@ -446,7 +446,7 @@ fn (table mut Table) add_default_val(idx int, type_name, val_expr string) {
 	mut t := table.typesmap[type_name]
 	if t.default_vals.len == 0 {
 		t.default_vals = [''].repeat(t.fields.len)
-	}	
+	}
 	t.default_vals[idx] = val_expr
 	table.typesmap[type_name] = t
 }
@@ -696,7 +696,7 @@ fn (p mut Parser) check_types2(got_, expected_ string, throw bool) bool {
 	}
 
 	expected = expected.replace('*', '')
-	got = got.replace('*', '')
+	got = got.replace('*', '').replace('ptr','')
 	if got != expected {
 		// Interface check
 		if expected.ends_with('er') {

--- a/vlib/compiler/tests/multiret_with_ptrtype.v
+++ b/vlib/compiler/tests/multiret_with_ptrtype.v
@@ -1,0 +1,18 @@
+fn multi_voidptr_ret() (voidptr, bool) {
+	return voidptr(0), true
+}
+
+fn multi_byteptr_ret() (byteptr, bool) {
+	return byteptr(0), true
+}
+
+fn test_multi_ptrtype_ret() {
+	a, b := multi_voidptr_ret()
+	assert a == voidptr(0)
+	assert b == true
+
+	c, d := multi_byteptr_ret()
+	assert c == byteptr(0)
+	assert d == true
+}
+


### PR DESCRIPTION
No test is broken by this, and all the examples still compile.
However, I feel is only temporary fix, as it may not address the underlying issue that caused this.

I added the test for it. This will resolve #2897 in that it code that would not compile due to it will now compile and run correctly.

