### PR TITLE
added -user_mod_path command line option to add a module search path

### DIFF
--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -125,6 +125,7 @@ pub mut:
 	is_fmt bool
 	is_bare bool
 
+	user_mod_path string // `v -user_mod_path /Users/user/modules` adds a new lookup path for imported modules
 	vlib_path string
 	vpath string
 	x64 bool
@@ -848,6 +849,9 @@ pub fn new_v(args[]string) &V {
 		os.mkdir('$v_modules_path${os.path_separator}cache') or { panic(err) }
 	}
 	
+	// optional, custom modules search path
+	user_mod_path := get_cmdline_option(args, '-user_mod_path', '')
+
 	// Location of all vlib files
 	vroot := os.dir(vexe_path())
 	vlib_path := get_cmdline_option(args, '-vlib-path', filepath.join(vroot, 'vlib'))
@@ -1036,6 +1040,7 @@ pub fn new_v(args[]string) &V {
 		building_v: !is_repl && (rdir_name == 'compiler' || rdir_name == 'v.v'  || dir.contains('vlib'))
 		comptime_define: comptime_define
 		is_fmt: comptime_define == 'vfmt'
+		user_mod_path: user_mod_path
 		vlib_path: vlib_path
 		vpath: vpath
 	}

--- a/vlib/compiler/modules.v
+++ b/vlib/compiler/modules.v
@@ -163,6 +163,9 @@ fn (v &V) find_module_path(mod string) ?string {
 	tried_paths << filepath.join(v.compiled_dir, mod_path)
 	tried_paths << filepath.join(v.pref.vlib_path, mod_path)
 	tried_paths << filepath.join(modules_lookup_path, mod_path)
+	if v.pref.user_mod_path.len > 0 {
+		tried_paths << v.pref.user_mod_path
+	}
 	for try_path in tried_paths {
 		if v.pref.is_verbose { println('  >> trying to find $mod in $try_path ...') }
 		if os.dir_exists(try_path) { 


### PR DESCRIPTION
This PR adds a new command line option: `-user_mod_path`. When `user_mod_path` is set, the passed in path is added to the list of paths checked for imported modules.