### PR TITLE
android: support more termux users without make errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,15 +28,20 @@ ifdef WIN32
 	rm -f v0.exe
 else
 	$(CC) -std=gnu11 -w -o v vc/v.c $(LDFLAGS) -lm
+ifdef ANDROID
+	chmod 755 v
+endif  
 	@(VC_V=`./v version | cut -f 3 -d " "`; \
 	V_V=`git rev-parse --short HEAD`; \
 	if [ $$VC_V != $$V_V ]; then \
 		echo "Self rebuild ($$VC_V => $$V_V)"; \
 		./v -o v v.v; \
 	fi)
+ifndef ANDROID
 	./v build module vlib/builtin > /dev/null
 	./v build module vlib/strings > /dev/null
 	./v build module vlib/strconv > /dev/null
+endif  
 endif
 	rm -rf vc/
 	@echo "V has been successfully built"


### PR DESCRIPTION
Skip the build module steps on Android, so it will work for more people out of the box.
