### PR TITLE
Docs: fix interface example

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -885,14 +885,14 @@ interface Speaker {
     speak() string
 }
 
-fn perform(s Speaker) {
-    println(s.speak())
+fn perform(s Speaker) string {
+    return s.speak()
 }
 
 dog := Dog{}
 cat := Cat{}
-perform(dog) // "woof"
-perform(cat) // "meow"
+println(perform(dog)) // "woof"
+println(perform(cat)) // "meow"
 ```
 
 A type implements an interface by implementing its methods.


### PR DESCRIPTION
Changed interfaces example code so that it compiles and works:
(tested on Windows, Linux, and PlayGround)

```v
interface Speaker {
  speak() string
}

struct Dog { }
struct Cat { }

fn (d Dog) speak() string {
	return 'woof'
}

fn (c Cat) speak() string {
	return 'meow'
}

fn perform(s Speaker) string {
	return s.speak()
}

dog := Dog{}
cat := Cat{}
println(perform(dog)) // -> "woof"
println(perform(cat)) // -> "meow"   
```