### PR TITLE
compiler: realpath before trying to basefilename

### DIFF
--- a/vlib/compiler/vtmp.v
+++ b/vlib/compiler/vtmp.v
@@ -17,5 +17,5 @@ pub fn get_vtmp_folder() string {
 
 pub fn get_vtmp_filename(base_file_name string, postfix string) string {
 	vtmp := get_vtmp_folder()
-	return os.realpath( filepath.join(vtmp, os.filename( base_file_name ) + postfix) )
+	return os.realpath( filepath.join(vtmp, os.filename( os.realpath(base_file_name) ) + postfix) )
 }


### PR DESCRIPTION
Fixes a situation where os.basefilename cant parse the filename out becuase it doesnt use the correct os path seperator (which on windows is not "/").