### PR TITLE
sync/waitgroup: force sleeping for 1ms. Fixes issues #2874 and #2961.

### DIFF
--- a/examples/news_fetcher.v
+++ b/examples/news_fetcher.v
@@ -67,7 +67,7 @@ fn main() {
 	
 	wg := sync.new_waitgroup()
 	mtx := sync.new_mutex()
-	mut fetcher := &Fetcher{ids: ids}
+	mut fetcher := &Fetcher{ids: ids mu: 0 wg: 0}
 	fetcher.mu = &mtx
 	fetcher.wg = &wg
 	fetcher.wg.add(ids.len)

--- a/vlib/sync/waitgroup.v
+++ b/vlib/sync/waitgroup.v
@@ -32,7 +32,8 @@ pub fn (wg mut WaitGroup) done() {
 
 pub fn (wg mut WaitGroup) wait() {
 	for wg.active > 0 {
-		// waiting
+		// Do not remove this, busy empty loops are optimized
+		// with -prod by some compilers, see issue #2874
+		C.usleep(1000) 
 	}
 }
-

--- a/vlib/sync/waitgroup.v
+++ b/vlib/sync/waitgroup.v
@@ -34,6 +34,10 @@ pub fn (wg mut WaitGroup) wait() {
 	for wg.active > 0 {
 		// Do not remove this, busy empty loops are optimized
 		// with -prod by some compilers, see issue #2874
-		C.usleep(1000) 
+		$if windows {
+			C.Sleep(1)
+		} $else {
+			C.usleep(1000)
+		}
 	}
 }


### PR DESCRIPTION
Busy empty loops are optimized by some compilers with -prod.
This PR adds a C.usleep(1000) line inside the WaitGroup.wait() loop to prevent that.
