### PR TITLE
compiler: c'str' now has type charptr

### DIFF
--- a/vlib/compiler/expression.v
+++ b/vlib/compiler/expression.v
@@ -167,12 +167,12 @@ fn (p mut Parser) name_expr() string {
 	}
 
 	// Raw string (`s := r'hello \n ')
-	if (name == 'r') && p.peek() == .str && p.prev_tok != .str_dollar {
+	if name == 'r' && p.peek() == .str && p.prev_tok != .str_dollar {
 		p.string_expr()
 		return 'string'
 	}
 	// C string (a zero terminated one) C.func( c'hello' )
-	if (name == 'c') && p.peek() == .str && p.prev_tok != .str_dollar {
+	if name == 'c' && p.peek() == .str && p.prev_tok != .str_dollar {
 		p.string_expr()
 		return 'charptr'
 	}

--- a/vlib/compiler/expression.v
+++ b/vlib/compiler/expression.v
@@ -167,9 +167,14 @@ fn (p mut Parser) name_expr() string {
 	}
 
 	// Raw string (`s := r'hello \n ')
-	if (name == 'r' || name == 'c') && p.peek() == .str && p.prev_tok != .str_dollar {
+	if (name == 'r') && p.peek() == .str && p.prev_tok != .str_dollar {
 		p.string_expr()
 		return 'string'
+	}
+	// C string (a zero terminated one) C.func( c'hello' )
+	if (name == 'c') && p.peek() == .str && p.prev_tok != .str_dollar {
+		p.string_expr()
+		return 'charptr'
 	}
 	// known_type := p.table.known_type(name)
 	orig_name := name

--- a/vlib/compiler/tests/cstrings_test.v
+++ b/vlib/compiler/tests/cstrings_test.v
@@ -1,0 +1,9 @@
+
+fn C.puts(charptr) int
+
+fn test_cstring(){
+  h := c'world'
+  C.puts( c'hello' )
+  C.puts( h )
+  assert true
+}

--- a/vlib/compiler/tests/cstrings_test.v
+++ b/vlib/compiler/tests/cstrings_test.v
@@ -3,7 +3,7 @@ fn C.puts(charptr) int
 
 fn test_cstring(){
   h := c'world'
-  C.puts( c'hello' )
-  C.puts( h )
+  C.puts(c'hello')
+  C.puts(h)
   assert true
 }


### PR DESCRIPTION
This PR enables the following program:
```v
fn C.puts(charptr) int
fn main(){
  h := c'world'
  C.puts( c'hello' )
  C.puts( h )
}
```
which previously produced a C error.