### PR TITLE
tools/vbuild-examples: test hot code reloading examples with -live too.

### DIFF
--- a/tools/modules/testing/common.v
+++ b/tools/modules/testing/common.v
@@ -59,6 +59,7 @@ pub fn (ts mut TestSession) test() {
 		tmpc_filepath := file.replace('.v', '.tmp.c')
 
 		cmd := '"$ts.vexe" $ts.vargs "$file"'
+		//eprintln('>>> v cmd: $cmd')
 
 		ts.benchmark.step()
 		if show_stats {
@@ -100,14 +101,17 @@ pub fn vlib_should_be_present( parent_dir string ) {
 	}
 }
 
-pub fn v_build_failing(vargs string, folder string) bool {
+pub fn v_build_failing(zargs string, folder string) bool {
 	main_label := 'Building $folder ...'
 	finish_label := 'building $folder'
 	vexe := vexe_path()
 	parent_dir := os.dir(vexe)
 	vlib_should_be_present( parent_dir )
-  
+	vargs := zargs.replace(vexe, '')
+	
 	eprintln(main_label)
+	eprintln('   v compiler args: "$vargs"')
+	
 	mut session := new_test_sesion( vargs )
 	files := os.walk_ext(filepath.join(parent_dir, folder),'.v')
 	mains := files.filter(!it.contains('modules'))

--- a/tools/vbuild-examples.v
+++ b/tools/vbuild-examples.v
@@ -3,22 +3,20 @@ module main
 import (
 	os
 	testing
+	filepath
 )
 
 fn main() {
 	args := os.args
 	args_string := args[1..].join(' ')
-	if testing.v_build_failing(
-		args_string.all_before('build-examples'), 'examples')
-	{
+	params := args_string.all_before('build-examples')
+	
+	if testing.v_build_failing(params, 'examples'){
 		exit(1)
 	}
-	// Test -live
-	vexe := args[1]
-	ret := os.system('$vexe -live examples/hot_reload/message.v')
-	if ret != 0 {
-		println('v -live message.v failed')
+
+	if testing.v_build_failing(params + '-live', filepath.join( 'examples', 'hot_reload')){
 		exit(1)
 	}
-	println('v -live message.v is ok')
+
 }

--- a/tools/vtest-compiler.v
+++ b/tools/vtest-compiler.v
@@ -4,7 +4,7 @@ import (
 	os
 	testing
 	benchmark
-  filepath
+	filepath
 )  
 
 pub const (
@@ -56,6 +56,7 @@ fn v_test_compiler(vargs string){
 	eprintln('')
 	building_examples_failed := testing.v_build_failing(vargs, 'examples')
 
+	eprintln('')
 	building_live_failed := testing.v_build_failing(vargs + '-live', 
                                     filepath.join( 'examples', 'hot_reload'))
 

--- a/tools/vtest-compiler.v
+++ b/tools/vtest-compiler.v
@@ -4,6 +4,7 @@ import (
 	os
 	testing
 	benchmark
+  filepath
 )  
 
 pub const (

--- a/tools/vtest-compiler.v
+++ b/tools/vtest-compiler.v
@@ -55,6 +55,9 @@ fn v_test_compiler(vargs string){
 	eprintln('')
 	building_examples_failed := testing.v_build_failing(vargs, 'examples')
 
+	building_live_failed := testing.v_build_failing(vargs + '-live', 
+                                    filepath.join( 'examples', 'hot_reload'))
+
 	eprintln('')
 	v_module_install_cmd := '$vexe install nedpals.args'
 	eprintln('\nInstalling a v module with: $v_module_install_cmd ')
@@ -69,7 +72,10 @@ fn v_test_compiler(vargs string){
 	vmark.stop()
 	eprintln( 'Installing a v module took: ' + vmark.total_duration().str() + 'ms')
 	
-	if building_tools_failed || compiler_test_session.failed || building_examples_failed {
+	if building_tools_failed || 
+     compiler_test_session.failed || 
+     building_examples_failed || 
+     building_live_failed {
 		exit(1)
 	}
 	

--- a/tools/vtest-compiler.v
+++ b/tools/vtest-compiler.v
@@ -34,7 +34,7 @@ fn v_test_compiler(vargs string){
 	*/
 	
 	// Make sure v.c can be compiled without warnings
-	$if mac {
+	$if macos {
 		if os.exists('/v.v') {
 			os.system('$vexe -o v.c v.v')
 			if os.system('cc -Werror v.c') != 0 {


### PR DESCRIPTION
After this PR:
```shell
0[12:43:16]delian@nemesis: /v/nv $ ./v build-examples      
Building examples ...
   v compiler args: " "
   346 ms | /v/nv/examples/database/mysql.v OK
   343 ms | /v/nv/examples/database/pg/customer.v OK
   379 ms | /v/nv/examples/eventbus/eventbus.v OK
   337 ms | /v/nv/examples/hello_v_js.v OK
   409 ms | /v/nv/examples/json.v OK
   889 ms | /v/nv/examples/news_fetcher.v OK
   516 ms | /v/nv/examples/vcasino/VCasino.v OK
   357 ms | /v/nv/examples/hello_world.v OK
   381 ms | /v/nv/examples/random_ips.v OK
   495 ms | /v/nv/examples/cli.v OK
  1728 ms | /v/nv/examples/game_of_life/life_gg.v OK
   496 ms | /v/nv/examples/game_of_life/life.v OK
  1037 ms | /v/nv/examples/links_scraper.v OK
  1703 ms | /v/nv/examples/hot_reload/bounce.v OK
   495 ms | /v/nv/examples/hot_reload/message.v OK
  1106 ms | /v/nv/examples/hot_reload/graph.v OK
   404 ms | /v/nv/examples/nbody.v OK
   752 ms | /v/nv/examples/vweb/vweb_example.v OK
   449 ms | /v/nv/examples/word_counter/word_counter.v OK
   348 ms | /v/nv/examples/rune.v OK
   362 ms | /v/nv/examples/sqlite.v OK
  1223 ms | /v/nv/examples/tetris/tetris.v OK
   656 ms | /v/nv/examples/terminal_control.v OK
   801 ms | /v/nv/examples/log.v OK
  1158 ms | /v/nv/examples/empty_gg_freetype.v OK
   433 ms | /v/nv/examples/fibonacci.v OK
   512 ms | /v/nv/examples/spectral.v OK
   349 ms | /v/nv/examples/x64/hello_world.v OK
 18468 ms | <=== total time spent building examples 
 ok, fail, total =    28,     0,    28
Building examples/hot_reload ...
   v compiler args: " -live"
  2498 ms | /v/nv/examples/hot_reload/bounce.v OK
  1184 ms | /v/nv/examples/hot_reload/message.v OK
  2124 ms | /v/nv/examples/hot_reload/graph.v OK
  5806 ms | <=== total time spent building examples/hot_reload 
 ok, fail, total =     3,     0,     3
0[12:43:45]delian@nemesis: /v/nv $
```