### PR TITLE
add: write_b to strings.Builder

### DIFF
--- a/examples/game_of_life/modules/automaton/automaton.v
+++ b/examples/game_of_life/modules/automaton/automaton.v
@@ -74,7 +74,7 @@ pub fn (aa mut Automaton) update() {
 			aa.new_field.set(x,y, if v { 1 } else { 0 })
 		}
 	}
-	mut tmp := aa.field
+	tmp := aa.field
 	aa.field = aa.new_field
 	aa.new_field = tmp
 }

--- a/vlib/bitfield/bitfield.v
+++ b/vlib/bitfield/bitfield.v
@@ -460,7 +460,7 @@ pub fn (input BitField) slice(_start int, _end int) BitField {
 // reverse() reverses the order of bits in the array (swap the first with the
 // last, the second with the last but one and so on)
 
-pub fn (instance mut BitField) reverse() BitField {
+pub fn (instance BitField) reverse() BitField {
 	size := instance.size
 	bitnslots := bitnslots(size)
 	mut output := new(size)

--- a/vlib/clipboard/clipboard.v
+++ b/vlib/clipboard/clipboard.v
@@ -26,7 +26,7 @@ pub fn (cb mut Clipboard) destroy() {
 }
 
 // check if we own the clipboard
-pub fn (cb mut Clipboard) check_ownership() bool {
+pub fn (cb Clipboard) check_ownership() bool {
 	return cb.has_ownership()
 }
 

--- a/vlib/crypto/rand/rand_lin.v
+++ b/vlib/crypto/rand/rand_lin.v
@@ -13,7 +13,7 @@ const (
 )
 
 pub fn read(bytes_needed int) ?[]byte {	
-	mut buffer := malloc(bytes_needed)
+	buffer := malloc(bytes_needed)
 	mut bytes_read := 0
 	// getrandom syscall wont block if requesting <= 256 bytes
 	if bytes_needed > read_batch_size {

--- a/vlib/encoding/base64/base64.v
+++ b/vlib/encoding/base64/base64.v
@@ -48,7 +48,7 @@ pub fn encode(data string) string {
  * @return the actual size of the decoded data in the buffer.
  * NB: this function does NOT allocate new memory, and is suitable for handling very large strings.
  */
-pub fn decode_in_buffer(data &string, buffer mut byteptr) int {
+pub fn decode_in_buffer(data &string, buffer byteptr) int {
 	mut padding := 0
 	if data.ends_with('=') {
 		if data.ends_with('==') {

--- a/vlib/strings/builder_c.v
+++ b/vlib/strings/builder_c.v
@@ -17,6 +17,11 @@ pub fn new_builder(initial_size int) Builder {
 	}
 }
 
+pub fn (b mut Builder) write_b(data byte) {
+	b.buf << data
+	b.len += 1
+}
+
 pub fn (b mut Builder) write(s string) {
 	b.buf.push_many(s.str, s.len)
 	//for c in s {

--- a/vlib/strings/builder_js.v
+++ b/vlib/strings/builder_js.v
@@ -17,6 +17,11 @@ pub fn new_builder(initial_size int) Builder {
 	}
 }
 
+pub fn (b mut Builder) write_b(data byte) {
+	b.buf << data
+	b.len += 1
+}
+
 pub fn (b mut Builder) write(s string) {
 	b.buf.push_many(s.str, s.len)
 	//b.buf << []byte(s)  // TODO

--- a/vlib/strings/builder_test.v
+++ b/vlib/strings/builder_test.v
@@ -38,3 +38,14 @@ fn test_big_sb() {
 	
 }	
 
+fn test_byte_write() {
+	mut sb := strings.new_builder(100)
+	temp_str := "byte testing"
+	mut count := 0
+	for word in temp_str {
+		sb.write_b(word)
+		count += 1
+		assert count == sb.len
+	}
+	assert sb.str() == temp_str
+}


### PR DESCRIPTION
Added test in builder_test.v `test_byte_write`

Why add it: Sometimes you want to add a specific byte to a string without needing to cast it to string