### PR TITLE
add negative indexes to arrays and strings

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -198,9 +198,39 @@ fn (a array) right(n int) array {
 }
 
 // used internally for [2..4]
+/*
 fn (a array) slice2(start, _end int, end_max bool) array {
 	end := if end_max { a.len } else { _end }
 	return a.slice(start, end)
+}
+*/
+fn (a array) slice2(start, _end int, end_max bool) array {
+	//C.printf("DEBUG: slice2 [%d..%d] [in_end_max=%d] \n",start,_end,end_max)
+	mut tmp_start:=start
+	if start < 0 {
+		tmp_start = a.len+start
+		if tmp_start < 0 {
+			tmp_start = 0
+		}
+	}else if start > a.len {
+		tmp_start = a.len
+	}
+
+	mut tmp_end:=_end
+	if _end < 0 {
+		tmp_end = a.len+_end
+		if tmp_end < 0 {
+			tmp_end = 0
+		}
+	}else if _end > a.len {
+		tmp_end = a.len
+	}
+
+	if end_max { tmp_end = a.len}
+
+	if tmp_end <= tmp_start { return array{} }
+
+	return a.slice(tmp_start, tmp_end)
 }
 
 // array.slice returns an array using the same buffer as original array

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -508,7 +508,25 @@ fn test_sort() {
 	assert nums[4] == 108
 }
 
-
+fn test_slice2(){
+	//
+	// test negative indexes in slices
+	//
+	a:=[0,1,2,3,4,5,6,7,8,9]
+	// normal behaviour
+	assert a[1..3].str() == '[1, 2]'
+	assert a[..3].str() == '[0, 1, 2]'
+	assert a[8..].str() == '[8, 9]'
+	// negative indexes behaviour
+	assert a[-2..].str() == '[8, 9]'
+	assert a[..-8].str() == '[0, 1]'
+	assert a[2..-2].str() == '[2, 3, 4, 5, 6, 7]'
+	assert a[-12..-16].str() == '[]'
+	assert a[-8..-2].str() == '[2, 3, 4, 5, 6, 7]'
+	// out of bound both indexes
+	assert a[12..14].str() == '[]'
+	assert a[-12..16].str() == a.str()
+}
 
 /*
 fn test_for_last() {

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -369,9 +369,41 @@ fn (s string) right(n int) string {
 }
 
 // used internally for [2..4]
+/*
 fn (s string) substr2(start, _end int, end_max bool) string {
 	end := if end_max { s.len } else { _end }
 	return s.substr(start, end)
+}
+*/
+
+fn (s string) substr2(start , end int, end_max bool) string {
+	//C.printf("DEBUG: substr2 [%d..%d] [in_end_max=%d] \n",start,end,end_max)
+	
+	mut _start:=start
+	if start < 0 {
+		_start = s.len+start
+		if _start < 0 {
+			_start = 0
+		}
+	}else if start > s.len {
+		_start = s.len
+	}
+
+	mut _end:=end
+	if end < 0 {
+		_end = s.len+end
+		if _end < 0 {
+			_end = 0
+		}
+	}else if end > s.len {
+		_end = s.len
+	}
+
+	if end_max { _end = s.len}
+
+	if _end <= _start { return '' }
+
+	return s.substr(_start, _end)
 }
 
 fn (s string) substr(start, end int) string {

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -565,3 +565,23 @@ fn test_inter_before_comp_if() {
 	}
 }
 
+fn test_slice2_negative(){
+	//
+	// test negative indexes in slices
+	//
+	s := '0123456789'
+	// normal behaviour
+	assert s[1..3] == '12'
+	assert s[..3] == '012'
+	assert s[8..] == '89'
+	// negative indexes behaviour
+	assert s[-2..] == '89'
+	assert s[..-8] == '01'
+	assert s[2..-2] == '234567'
+	assert s[-12..-16] == ''
+	assert s[-8..-2]== '234567'
+	// out of bound both indexes
+	assert s[12..14] == ''
+	assert s[-12..16] == '0123456789'
+}
+

--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -2058,9 +2058,11 @@ fn (p mut Parser) index_expr(typ_ string, fn_ph int) string {
 				if T.parent != 'int' && T.parent != 'u32' {
 					p.check_types(T.name, 'int')
 				}
+				/*
 				if p.cgen.cur_line[index_pos..].replace(' ', '').int() < 0 {
 					p.error('cannot access negative array index')
 				}
+				*/
 			}
 			// [..
 			else {


### PR DESCRIPTION
**Reasons for the negative index**
Writing my code in v and using strings and arrays I thinked that can be very useful have negative indexes like in python.
The code can be smaller and the job to check the bounds will be done by the compiler incrementing the safety for the code.

**Example of usage in strings**
```v
//
// test negative indexes in slices
//
s := '0123456789'

// normal behaviour
assert s[1..3] == '12'
assert s[..3] == '012'
assert s[8..] == '89'

// negative indexes behaviour
assert s[-2..] == '89'
assert s[..-8] == '01'
assert s[2..-2] == '234567'
assert s[-12..-16] == ''
assert s[-8..-2]== '234567'

// out of bound both indexes
assert s[12..14] == ''
assert s[-12..16] == '0123456789'
```

```v
//
// test negative indexes in slices
//
a:=[0,1,2,3,4,5,6,7,8,9]

// normal behaviour
assert a[1..3].str() == '[1, 2]'
assert a[..3].str() == '[0, 1, 2]'
assert a[8..].str() == '[8, 9]'

// negative indexes behaviour
assert a[-2..].str() == '[8, 9]'
assert a[..-8].str() == '[0, 1]'
assert a[2..-2].str() == '[2, 3, 4, 5, 6, 7]'
assert a[-12..-16].str() == '[]'
assert a[-8..-2].str() == '[2, 3, 4, 5, 6, 7]'

// out of bound both indexes
assert a[12..14].str() == '[]'
assert a[-12..16].str() == a.str()
```
