### PR TITLE
compiler-testing: Correct defer_test (+=1 to ++)

### DIFF
--- a/vlib/compiler/tests/defer_test.v
+++ b/vlib/compiler/tests/defer_test.v
@@ -21,7 +21,7 @@ fn set_num(i int, n mut Num) {
 	if i < 5 {
 		return
 	} else {
-		n.val+=1
+		n.val++
 	}
 }
 


### PR DESCRIPTION
Only corrects vlib/compiler/tests/defer_test.v 

vlib/compiler/tests/mut_test.v is still broken, is not recognizing ++

    89 ms | /home/dwight/v-workspace/v.bogen85/vlib/compiler/tests/mut_test.v FAIL
`/home/dwight/v-workspace/v.bogen85/vlib/compiler/tests/mut_test.v`
 (
vlib/compiler/tests/mut_test.v:44:30: unexpected token: `++`
   42| 
   43| 	b.a[0].v[zero] = 3
   44| 	b.a[0].v[b.a[zero].v[zero]]++
             	                      ^
   45| 	b.a[0].v[b.a[0].v[zero]]++
   46|
)
