### PR TITLE
live: always add os and time when compiling -live programs

### DIFF
--- a/vlib/compiler/live.v
+++ b/vlib/compiler/live.v
@@ -91,7 +91,7 @@ fn (v &V) generate_hot_reload_code() {
 		}
 
 		so_debug_flag := if v.pref.is_debug { '-g' } else { '' }
-		cmd_compile_shared_library := '$vexe $msvc $so_debug_flag -o $file_base -shared $file'
+		cmd_compile_shared_library := '$vexe $msvc $so_debug_flag -o $file_base -solive -shared $file'
 		if v.pref.show_c_cmd {
 			println(cmd_compile_shared_library)
 		}
@@ -187,7 +187,7 @@ void reload_so() {
 			#else
 			sprintf(new_so_name, "%s.so", new_so_base);
 			#endif
-			sprintf(compile_cmd, "$vexe $msvc -o %s -shared $file", new_so_base);
+			sprintf(compile_cmd, "$vexe $msvc -o %s -solive -shared $file", new_so_base);
 			os__system(tos2(compile_cmd));
 
 			if( !os__exists(tos2(new_so_name)) ) {

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -85,8 +85,9 @@ pub mut:
 	//nofmt         bool   // disable vfmt
 	is_test       bool   // `v test string_test.v`
 	is_script     bool   // single file mode (`v program.v`), main function can be skipped
-	is_live       bool   // for hot code reloading
-	is_so         bool
+	is_live       bool   // main program that contains live/hot code
+	is_solive     bool   // a shared library, that will be used in a -live main program
+	is_so         bool   // an ordinary shared library, -shared, no matter if it is live or not
 	is_prof       bool   // benchmark every function
 	translated    bool   // `v translate doom.v` are we running V code translated from C? allow globals, ++ expressions, etc
 	is_prod       bool   // use "-O2"
@@ -731,15 +732,22 @@ pub fn (v &V)  get_user_files() []string {
 	// libs, but we dont know	which libs need to be added yet
 	mut user_files := []string
 
+	preludes_path := filepath.join(v.pref.vlib_path,'compiler','preludes')
+
+	if v.pref.is_live {
+		user_files << filepath.join(preludes_path,'live_main.v')
+	}
+	if v.pref.is_solive {
+		user_files << filepath.join(preludes_path,'live_shared.v')
+	}
+
 	if v.pref.is_test {
-		// TODO this somtimes fails on CI
-		user_files << filepath.join(v.pref.vlib_path,'compiler','preludes','tests_assertions.v')
+		user_files << filepath.join(preludes_path,'tests_assertions.v')
 	}
-
 	if v.pref.is_test && v.pref.is_stats {
-		user_files << filepath.join(v.pref.vlib_path,'compiler','preludes','tests_with_stats.v')
+		user_files << filepath.join(preludes_path,'tests_with_stats.v')
 	}
-
+	
 	// v volt/slack_test.v: compile all .v files to get the environment
 	// I need to implement user packages! TODO
 	is_test_with_imports := dir.ends_with('_test.v') &&
@@ -1027,6 +1035,7 @@ pub fn new_v(args[]string) &V {
 		is_test: is_test
 		is_script: is_script
 		is_so: '-shared' in args
+		is_solive: '-solive' in args
 		is_prod: '-prod' in args
 		is_verbose: '-verbose' in args || '--verbose' in args
 

--- a/vlib/compiler/preludes/live_main.v
+++ b/vlib/compiler/preludes/live_main.v
@@ -1,0 +1,9 @@
+module main
+
+import os
+import time
+
+const (
+  os_used = os.MAX_PATH
+  time_used = time.now()
+)

--- a/vlib/compiler/preludes/live_shared.v
+++ b/vlib/compiler/preludes/live_shared.v
@@ -1,0 +1,9 @@
+module main
+
+import os
+import time
+
+const (
+  os_used = os.MAX_PATH
+  time_used = time.now()
+)


### PR DESCRIPTION
Fixes runtime errors when -live user programs do not use os and time.