### PR TITLE
compiler: fix regression. show error when using blank ident as value

### DIFF
--- a/vlib/compiler/expression.v
+++ b/vlib/compiler/expression.v
@@ -167,6 +167,10 @@ fn (p mut Parser) name_expr() string {
 		return temp_type
 	}
 	mut name := p.lit
+	// blank identifier (not var)
+	if name == '_' {
+		p.error('cannot use `_` as value')
+	}
 	// generic type check
 	if name in p.cur_fn.dispatch_of.inst.keys() {
 		name = p.cur_fn.dispatch_of.inst[name]

--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -1619,9 +1619,6 @@ fn (p mut Parser) get_struct_type(name_ string, is_c bool, is_ptr bool) string {
 
 fn (p mut Parser) get_var_type(name string, is_ptr bool, deref_nr int) string {
 	v := p.find_var_check_new_var(name) or { return "" }
-	if name == '_' {
-		p.error('cannot use `_` as value')
-	}
 	if is_ptr {
 		p.gen('&')
 	}


### PR DESCRIPTION
compiler: fix regression. show error when using blank ident as value>

for example when trying to do:
```
_ := getint()
b = _ // THIS
println(_) // OR THIS
```