### PR TITLE
compiler: #3031 fix 1 - allow vgen to access methods like .str() defined in other modules or non public.

### DIFF
--- a/vlib/compiler/comptime.v
+++ b/vlib/compiler/comptime.v
@@ -314,7 +314,7 @@ fn (p mut Parser) gen_array_str(typ Type) {
 		p.error('cant print ${elm_type}[], unhandled print of ${elm_type}')
 	}
 	p.v.vgen_buf.writeln('
-fn (a $typ.name) str() string {
+pub fn (a $typ.name) str() string {
 	mut sb := strings.new_builder(a.len * 3)
 	sb.write("[")
 	for i, elm in a {
@@ -366,7 +366,7 @@ fn (p mut Parser) gen_varg_str(typ Type) {
 		p.gen_struct_str(elm_type2)
 	}
 	p.v.vgen_buf.writeln('
-fn (a $typ.name) str() string {
+pub fn (a $typ.name) str() string {
 	mut sb := strings.new_builder(a.len * 3)
 	sb.write("[")
 	for i, elm in a {

--- a/vlib/compiler/fn.v
+++ b/vlib/compiler/fn.v
@@ -254,7 +254,7 @@ fn (p mut Parser) fn_decl() {
 		}
 		// Don't allow modifying types from a different module
 		if !p.first_pass() && !p.builtin_mod && t.mod != p.mod &&
-			!p.is_vgen // allow .str()
+			!p.is_vgen // let vgen define methods like .str() on types defined in other modules
 		{
 			//println('T.mod=$T.mod')
 			//println('p.mod=$p.mod')
@@ -726,7 +726,9 @@ fn (p mut Parser) fn_call(f mut Fn, method_ph int, receiver_var, receiver_type s
 	if f.is_deprecated {
 		p.warn('$f.name is deprecated')
 	}
-	if !f.is_public &&  !f.is_c && !p.pref.is_test && !f.is_interface && f.mod != p.mod {
+	if !f.is_public && !f.is_c && !p.pref.is_test && !f.is_interface && f.mod != p.mod &&
+		!p.is_vgen // allow vgen access to methods like .str() defined in other modules 
+	{
 		if f.name == 'contains' {
 			println('use `value in numbers` instead of `numbers.contains(value)`')
 		}


### PR DESCRIPTION
EDIT: I think this makes more sense: https://github.com/vlang/v/pull/3040 just close one
closes #3031

@medvednikov 
Can you take a look at #3031 please?
Perhaps it should just show an error saying to define .str() methods as public?

Then this isnt even needed, I think that is better