### PR TITLE
vweb: continue after bad http client connection

### DIFF
--- a/examples/vweb/vweb_example.v
+++ b/examples/vweb/vweb_example.v
@@ -22,7 +22,7 @@ pub fn (app mut App) init() {
 	app.vweb.handle_static('.')
 }
 
-pub fn (app & App) json_endpoint() {
+pub fn (app mut App) json_endpoint() {
 	app.vweb.json('{"a": 3}')
 }
 

--- a/vlib/compiler/comptime.v
+++ b/vlib/compiler/comptime.v
@@ -178,7 +178,7 @@ fn (p mut Parser) comp_time() {
 		p.genln('/////////////////// tmpl end')
 		receiver := p.cur_fn.args[0]
 		dot := if receiver.is_mut || receiver.ptr || receiver.typ.ends_with('*') { '->' } else { '.' }
-		p.genln('vweb__Context_html($receiver.name /*!*/$dot vweb, tmpl_res)')
+		p.genln('vweb__Context_html( & $receiver.name /*!*/$dot vweb, tmpl_res)')
 	}
 	else {
 		p.error('bad comptime expr')

--- a/vlib/compiler/fn.v
+++ b/vlib/compiler/fn.v
@@ -627,7 +627,7 @@ fn (p mut Parser) check_unused_and_mut_vars() {
 			break
 		}
 		if !var.is_used && !p.pref.is_repl &&  !var.is_arg &&
-			!p.pref.translated && var.name != 'tmpl_res'
+			!p.pref.translated && var.name != 'tmpl_res' && p.mod != 'vweb'
 		{
 			p.production_error_with_token_index('`$var.name` declared and not used', var.token_idx )
 		}

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -518,8 +518,8 @@ fn parse_url(rawurl string, via_request bool) ?URL {
 		// RFC 3986, §3.3:
 		// In addition, a URI reference (Section 4.1) may be a relative-path reference,
 		// in which case the first path segment cannot contain a colon (':') character.
-		colon := rest.index(':') or { -1 }
-		slash := rest.index('/') or { -1 }
+		colon := rest.index(':') or { return error('there should be a : in the URL') }
+		slash := rest.index('/') or { return error('there should be a / in the URL') }
 		if colon >= 0 && (slash < 0 || colon < slash) {
 			// First path segment has colon. Not allowed in relative URL.
 			return error(error_msg('parse_url: first path segment in URL cannot contain colon', ''))

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -553,7 +553,7 @@ struct ParseAuthorityRes {
 fn parse_authority(authority string) ?ParseAuthorityRes {
 	i := authority.last_index('@')
 	mut host := ''
-	mut user := user('')
+	mut zuser := user('')
 	if i < 0 {
 		h := parse_host(authority) or {
 			return error(err)
@@ -566,7 +566,7 @@ fn parse_authority(authority string) ?ParseAuthorityRes {
 		host = h
 	}
 	if i < 0 {
-		return ParseAuthorityRes{host: host, user: user}
+		return ParseAuthorityRes{host: host, user: zuser}
 	}
 	mut userinfo := authority[..i]
 	if !valid_userinfo(userinfo) {
@@ -577,7 +577,7 @@ fn parse_authority(authority string) ?ParseAuthorityRes {
 			return error(err)
 		}
 		userinfo = u
-		user = user(userinfo)
+		zuser = user(userinfo)
 	} else {
 		mut username, mut password := split(userinfo, `:`, true)
 		u := unescape(username, .encode_user_password) or {
@@ -588,10 +588,10 @@ fn parse_authority(authority string) ?ParseAuthorityRes {
 			return error(err)
 		}
 		password = p
-		user = user_password(username, password)
+		zuser = user_password(username, password)
 	}
 	return ParseAuthorityRes{
-		user: user
+		user: zuser
 		host: host
 	}
 }

--- a/vlib/strings/builder_c.v
+++ b/vlib/strings/builder_c.v
@@ -9,11 +9,13 @@ mut:
 	buf []byte
 pub:
 	len int
+	initial_size int = 1
 }
 
 pub fn new_builder(initial_size int) Builder {
 	return Builder {
 		buf: make(0, initial_size, 1)
+		initial_size: initial_size
 	}
 }
 
@@ -48,6 +50,6 @@ pub fn (b mut Builder) str() string {
 
 pub fn (b mut Builder) free() {
 	unsafe{ free(b.buf.data) }
-	b.buf = make(0, 1, 1)
+	b.buf = make(0, b.initial_size, 1)
 	b.len = 0
 }

--- a/vlib/strings/builder_js.v
+++ b/vlib/strings/builder_js.v
@@ -9,11 +9,13 @@ mut:
 	buf []byte
 pub:
 	len int
+	initial_size int = 1
 }
 
 pub fn new_builder(initial_size int) Builder {
 	return Builder {
 		buf: make(0, initial_size, sizeof(byte))
+		initial_size: initial_size
 	}
 }
 
@@ -44,4 +46,6 @@ pub fn (b mut Builder) cut(n int) {
 }
 
 pub fn (b mut Builder) free() {
+	b.buf = make(0, b.initial_size, 1)
+	b.len = 0
 }

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -9,6 +9,7 @@ import (
 	net
 	http
 	net.urllib
+	strings
 )
 
 const (
@@ -49,8 +50,11 @@ mut:
 pub fn (ctx mut Context) html(html string) {
 	if ctx.done { return }
 	ctx.done = true
-	ctx.conn.send_string('HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: ${html.len}${ctx.headers}\r\n${HEADERS_CLOSE}') or { return }
-	ctx.conn.send_string(html) or { return }
+	mut sb := strings.new_builder(1024)
+	sb.write('HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: ${html.len}${ctx.headers}\r\n${HEADERS_CLOSE}')
+	sb.write(html)
+	ctx.conn.send_string(sb.str()) or { return }
+	sb.free()
 }
 
 pub fn (ctx mut Context) text(s string) {

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -117,7 +117,7 @@ pub fn run<T>(app mut T, port int) {
 		if first_line == '' {
 			conn.write(HTTP_500) or {}
 			conn.close() or {}
-			return
+			continue
 		}
 		// Parse the first line
 		// "GET / HTTP/1.1"
@@ -127,7 +127,7 @@ pub fn run<T>(app mut T, port int) {
 			println('no vals for http')
 			conn.write(HTTP_500) or {}
 			conn.close() or {}
-			return
+			continue
 		}
 		mut headers := []string
 		for _ in 0..30 {

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -49,28 +49,28 @@ mut:
 pub fn (ctx mut Context) html(html string) {
 	if ctx.done { return }
 	ctx.done = true
-	ctx.conn.send_string('HTTP/1.1 200 OK${ctx.headers}\r\nContent-Type: text/html\r\nContent-Length: ${html.len}\r\n${HEADERS_CLOSE}') or { return }
+	ctx.conn.send_string('HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: ${html.len}${ctx.headers}\r\n${HEADERS_CLOSE}') or { return }
 	ctx.conn.send_string(html) or { return }
 }
 
 pub fn (ctx mut Context) text(s string) {
 	if ctx.done { return }
 	ctx.done = true
-	ctx.conn.send_string('HTTP/1.1 200 OK${ctx.headers}\r\nContent-Type: text/plain\r\nContent-Length: ${s.len}\r\n${HEADERS_CLOSE}') or { return }
+	ctx.conn.send_string('HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: ${s.len}${ctx.headers}\r\n${HEADERS_CLOSE}') or { return }
 	ctx.conn.send_string(s) or { return }
 }
 
 pub fn (ctx mut Context) json(s string) {
 	if ctx.done { return }
 	ctx.done = true
-	ctx.conn.send_string('HTTP/1.1 200 OK${ctx.headers}\r\nContent-Type: application/json\r\nContent-Length: ${s.len}\r\n${HEADERS_CLOSE}') or { return }
+	ctx.conn.send_string('HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${s.len}${ctx.headers}\r\n${HEADERS_CLOSE}') or { return }
 	ctx.conn.send_string(s) or { return }
 }
 
 pub fn (ctx mut Context) redirect(url string) {
 	if ctx.done { return }
 	ctx.done = true
-	ctx.conn.send_string('HTTP/1.1 302 Found${ctx.headers}\r\nLocation: ${url}\r\n${HEADERS_CLOSE}') or { return }
+	ctx.conn.send_string('HTTP/1.1 302 Found\r\nLocation: ${url}${ctx.headers}\r\n${HEADERS_CLOSE}') or { return }
 }
 
 pub fn (ctx mut Context) not_found(s string) {
@@ -100,7 +100,7 @@ pub fn (ctx &Context) get_cookie(key string) ?string { // TODO refactor
 
 fn (ctx mut Context) add_header(key, val string) {
 	//println('add_header($key, $val)')
-	ctx.headers = ctx.headers + if ctx.headers == '' { '$key: $val' } else { '\r\n$key: $val' }
+	ctx.headers = ctx.headers + '\r\n$key: $val'
 	//println(ctx.headers)
 }
 
@@ -282,7 +282,7 @@ pub fn (ctx mut Context) handle_static(directory_path string) bool {
 	if static_file != '' {
 		data := os.read_file(static_file) or { return false }
 		ctx.done = true
-		ctx.conn.send_string('HTTP/1.1 200 OK\r\nContent-Type: $mime_type\r\nContent-Length: ${data.len}\r\n${HEADERS_CLOSE}') or { return false }
+		ctx.conn.send_string('HTTP/1.1 200 OK\r\nContent-Type: $mime_type\r\nContent-Length: ${data.len}${ctx.headers}\r\n${HEADERS_CLOSE}') or { return false }
 		ctx.conn.send_string(data) or { return false }
 		return true
 	}

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -197,7 +197,9 @@ pub fn run<T>(app mut T, port int) {
 		// }
 
 		// Call the right action
-		println('action=$action')
+		$if debug {
+			println('action=$action')
+		}
 		app.$action() or {
 			conn.send_string(HTTP_404) or {}
 		}

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -131,13 +131,12 @@ pub fn run<T>(app mut T, port int) {
 			continue
 		}
 		mut headers := []string
-		for _ in 0..30 {
+		for {
+			if headers.len >= 30 { break }
 			header := conn.read_line()
 			headers << header
 			//println('header="$header" len = ' + header.len.str())
-			if header.len <= 2 {
-				break
-			}
+			if header.len <= 2 { break }
 		}
 		mut action := vals[1][1..].all_before('/')
 		if action.contains('?') {

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -51,7 +51,11 @@ pub fn (ctx mut Context) html(html string) {
 	if ctx.done { return }
 	ctx.done = true
 	mut sb := strings.new_builder(1024)
-	sb.write('HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: ${html.len}${ctx.headers}\r\n${HEADERS_CLOSE}')
+	sb.write('HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: ')
+	sb.write( html.len.str() )
+	sb.write( ctx.headers )
+	sb.write('\r\n')
+	sb.write(HEADERS_CLOSE)
 	sb.write(html)
 	ctx.conn.send_string(sb.str()) or { return }
 	sb.free()


### PR DESCRIPTION
Enables benching with wrk:
```shell
0[16:17:58] /v/vex LINUX $ /usr/local/bin/wrk -t12 -c400 -d5s http://static.dev:8082/
Running 5s test @ http://static.dev:8082/
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    60.81ms  206.97ms   1.67s    92.59%
    Req/Sec     0.98k     0.90k    4.84k    77.68%
  35442 requests in 5.04s, 2.60MB read
  Socket errors: connect 0, read 35442, write 0, timeout 0
Requests/sec:   7034.91
Transfer/sec:    528.99KB
0[16:21:19] /v/vex LINUX $
```