### PR TITLE
tetris: Use standard colors for tetronomes

### DIFF
--- a/examples/tetris/tetris.v
+++ b/examples/tetris/tetris.v
@@ -77,13 +77,13 @@ const (
 	// Each tetro has its unique color
 	Colors = [
 		gx.rgb(0, 0, 0),        // unused ?
-		gx.rgb(253, 32, 47),    // lightred quad
-		gx.rgb(0, 110, 194),    // lightblue triple
-		gx.rgb(170, 170, 0),    // darkyellow short topright
-		gx.rgb(170, 0, 170),    // purple short topleft
-		gx.rgb(50, 90, 110),    // darkgrey long topleft
-		gx.rgb(0, 170, 0),      // lightgreen long topright
-		gx.rgb(170, 85, 0),     // brown longest
+		gx.rgb(255, 242, 0),    // yellow quad
+		gx.rgb(174, 0, 255),    // purple triple
+		gx.rgb(60, 255, 0),     // green short topright
+		gx.rgb(255, 0, 0),      // red short topleft
+		gx.rgb(255, 180, 31),   // orange long topleft
+		gx.rgb(33, 66, 255),    // blue long topright
+		gx.rgb(74, 198, 255),   // lightblue longest
 		gx.rgb(0, 170, 170),    // unused ?
 	]
 


### PR DESCRIPTION
I noticed that the colors were incorrect when I played so here are some nice looking ones. The tetris.v file previously used custom colors for the tetronomes, but there is a set of standard colors for the tetros. The colors were determined from wikipedia.org/wiki/tetris.
