### PR TITLE
mysql: add mysql.escape_string() method

### DIFF
--- a/vlib/mysql/mysql.v
+++ b/vlib/mysql/mysql.v
@@ -1,7 +1,7 @@
 module mysql
 
 // if mysql.h is not in your CPATH (include path), set environment CPATH 
-//     export CPATH=/usr/include/mysql
+//     export CPATH=$CPATH:/usr/include/mysql
 // or include -cflags flag to v compiler
 //     v -cflags '-I/usr/include/mysql' program.v
 

--- a/vlib/mysql/mysql.v
+++ b/vlib/mysql/mysql.v
@@ -59,7 +59,7 @@ pub fn (db DB) query(q string) ?Result {
 
 pub fn (db DB) escape_string(s string) string {
     len := strlen(s.str)
-    to := malloc(2 * len)
+    to := malloc(2 * len + 1)
     quote := byte(39) // single quote
 
     C.mysql_real_escape_string_quote(db.conn, to, s.str, len, quote)

--- a/vlib/mysql/mysql.v
+++ b/vlib/mysql/mysql.v
@@ -59,7 +59,7 @@ pub fn (db DB) query(q string) ?Result {
 
 pub fn (db DB) escape_string(s string) string {
     len := strlen(s.str)
-    to := malloc(len)
+    to := malloc(2 * len)
     quote := byte(39) // single quote
 
     C.mysql_real_escape_string_quote(db.conn, to, s.str, len, quote)


### PR DESCRIPTION
Wrap C.mysql_real_escape_string_quote()

new function:
```
fn C.mysql_real_escape_string_quote(mysql &C.MYSQL, to byteptr, from byteptr, len u64, quote byte) u64

pub fn (db DB) escape_string(s string) string {
    len := strlen(s.str)
    to := malloc(2 * len + 1)
    quote := byte(39) // single quote

    C.mysql_real_escape_string_quote(db.conn, to, s.str, len, quote)
    return string(to)
}
```

test_mysql.v
```
import mysql

fn main() {
    db := mysql.connect("localhost", "vlang", "vlang", "vlang_test") or {
        println("Unable to connect to db")
        return
    }

    assert "\\'" == db.escape_string('\'')
    assert '\\n' == db.escape_string('
')

    db.close()
}
```
