### PR TITLE
testing: enable same module tests to import the same module with no custom options

### DIFF
--- a/vlib/compiler/tests/modules/simplemodule/importing_test.v
+++ b/vlib/compiler/tests/modules/simplemodule/importing_test.v
@@ -1,0 +1,11 @@
+import simplemodule
+
+// this tests whether the tests can import the same module without any special
+// custom paths setup on the CLI
+fn test_iadd(){
+	assert simplemodule.iadd(10, 20) == 30
+}
+
+fn test_imul(){
+	assert simplemodule.imul(5,8) == 40
+}

--- a/vlib/compiler/tests/modules/simplemodule/simplemodule.v
+++ b/vlib/compiler/tests/modules/simplemodule/simplemodule.v
@@ -1,0 +1,9 @@
+module simplemodule
+
+pub fn iadd(x int, y int) int {
+	return x + y
+}
+
+pub fn imul(x int, y int) int {
+	return x * y
+}


### PR DESCRIPTION
This PR solves a common problem, described recently on Discord:
https://discordapp.com/channels/592103645835821068/618363736503353374/654414766680571906
```
I have a _test.v file for my module in my repo at the same
folder level as the module file itself. My module (veasing) 
is imported in the test file as: import veasing. This fails though
because it's looking for it in a subfolder I could change it to use
the vpm name and require it to be installed before testing, but 
that would make testing not work if people just clone the git repo 
or use vpkg. Is there a "right" way to do this? I'm seeing a couple 
modules writing shell scripts that copy files around and create 
subfolders to run the tests.
```
Before this PR, the best generalized solution for this was (without moving stuff/symlinking):
`v -user_mod_path $PWD/../  veasing_test.v`
... which is not very intuitive, and is not very portable to say windows.

Now _test.v files that are located in the same module that they want to import/test, can be run without needing to add a custom -user_mod_path option, so the above command in the same situation becomes just: `v veasing_test.v`