### PR TITLE
compiler: simplify cflag parsing, and allow -Wl, comma

### DIFF
--- a/vlib/compiler/cflags.v
+++ b/vlib/compiler/cflags.v
@@ -74,6 +74,7 @@ fn (table mut Table) parse_cflag(cflag string, mod string) ?bool {
 	allowed_flags := [
 		'framework',
 		'library',
+		'Wl',
 		'I', 'l', 'L',
 	]
 	flag_orig := cflag.trim_space()
@@ -82,14 +83,13 @@ fn (table mut Table) parse_cflag(cflag string, mod string) ?bool {
 		return true
 	}
 	mut fos := ''
-	mut name := ''
 	if flag.starts_with('linux') || flag.starts_with('darwin') || flag.starts_with('freebsd') || flag.starts_with('windows') {
 		pos := flag.index(' ') or { return none }
 		fos = flag[..pos].trim_space()
 		flag = flag[pos..].trim_space()
 	}
 	for {
-		mut index := -1
+		mut name := ''
 		mut value := ''
 		if flag[0] == `-` {
 			for f in allowed_flags {
@@ -101,34 +101,23 @@ fn (table mut Table) parse_cflag(cflag string, mod string) ?bool {
 				}
 			}
 		}
-		if i := flag.index(' ') {
-			if index == -1 || i < index {
-				index = i
-			}
-		}
-		if i := flag.index(',') {
-			if index == -1 || i < index {
-				index = i
-			}
-		}
-		if index != -1 && flag[index] == ` ` && flag[index+1] == `-` {
+		mut index := flag.index(' -') or { -1 }
+		for index > -1 {
+			mut has_next := false
 			for f in allowed_flags {
-				j := index+f.len
-				if j < flag.len && f == flag[index..j] {
-					index = j
+				i := index+2+f.len
+				if i <= flag.len && f == flag[index+2..i] {
+					value = flag[..index+1].trim_space()
+					flag = flag[index+1..].trim_space()
+					has_next = true
 					break
 				}
 			}
-			value = flag[..index].trim_space()
-			flag = flag[index..].trim_space()
+			if has_next { break }
+			index = flag.index_after(' -', index+1)
 		}
-		else if index != -1 && index < flag.len-2 && flag[index] == `,` {
-			value = flag[..index].trim_space()
-			flag = flag[index+1..].trim_space()
-		}
-		else {
+		if index == -1 {
 			value = flag.trim_space()
-			index = -1
 		}
 		if (name in ['-I', '-l', '-L']) && value == '' {
 			hint := if name == '-l' { 'library name' } else { 'path' }

--- a/vlib/freetype/freetype.v
+++ b/vlib/freetype/freetype.v
@@ -18,7 +18,7 @@ import (
 #flag darwin -I/usr/local/include/freetype2
 #flag darwin -I/opt/local/include/freetype2
 #flag freebsd -I/usr/local/include/freetype2
-#flag freebsd -Wl,-L/usr/local/lib
+#flag freebsd -Wl -L/usr/local/lib
 #flag -lfreetype
 
 //#flag -I @VROOT/thirdparty/freetype

--- a/vlib/http/backend_windows.v
+++ b/vlib/http/backend_windows.v
@@ -5,7 +5,7 @@
 module http
 
 #flag windows -I @VROOT/thirdparty/vschannel
-#flag -l ws2_32, crypt32, secur32
+#flag -l ws2_32 -l crypt32 -l secur32
  
 #include "vschannel.c"
 

--- a/vlib/sqlite/sqlite.v
+++ b/vlib/sqlite/sqlite.v
@@ -2,7 +2,7 @@ module sqlite
 
 #flag -lsqlite3
 #flag freebsd -I/usr/local/include
-#flag freebsd -Wl,-L/usr/local/lib,-lsqlite3
+#flag freebsd -Wl -L/usr/local/lib -lsqlite3
 #include "sqlite3.h"
 
 struct C.sqlite3


### PR DESCRIPTION
Needs #3084 
Remove support for `-L lib1,lib2` just use `-L lib1 -L lib2` instead, this simplifies things, and and also makes more sense since the flag line actually is the same as you would use in command. I don't think many people even knew this special use existed.
And allows comma to be used for other things like -Wl without adding special cases