### PR TITLE
testing: support for internal module testing 

### DIFF
--- a/vlib/compiler/preludes/tests_assertions.v
+++ b/vlib/compiler/preludes/tests_assertions.v
@@ -19,7 +19,7 @@ fn cb_assertion_failed(filename string, line int, sourceline string, funcname st
 		else { true }
 	}
 	final_filename := if use_relative_paths { filename } else { os.realpath( filename ) }
-	final_funcname := funcname.replace('main__','')
+	final_funcname := funcname.replace('main__','').replace('__','.')
 
 	mut fail_message := 'FAILED assertion'
 	if color_on { fail_message = term.bold(term.red(fail_message)) }

--- a/vlib/compiler/preludes/tests_with_stats.v
+++ b/vlib/compiler/preludes/tests_with_stats.v
@@ -34,8 +34,7 @@ fn start_testing() BenchedTests {
 
 // Called before each test_ function, defined in file_test.v
 fn (b mut BenchedTests) testing_step_start(stepfunc string) {
-	b.step_func_name = stepfunc.replace('main__','')
-  b.step_func_name = b.step_func_name.replace('__','.')
+	b.step_func_name = stepfunc.replace('main__','').replace('__','.')
 	b.oks   = C.g_test_oks
 	b.fails = C.g_test_fails
 	b.bench.step()

--- a/vlib/compiler/preludes/tests_with_stats.v
+++ b/vlib/compiler/preludes/tests_with_stats.v
@@ -35,6 +35,7 @@ fn start_testing() BenchedTests {
 // Called before each test_ function, defined in file_test.v
 fn (b mut BenchedTests) testing_step_start(stepfunc string) {
 	b.step_func_name = stepfunc.replace('main__','')
+  b.step_func_name = b.step_func_name.replace('__','.')
 	b.oks   = C.g_test_oks
 	b.fails = C.g_test_fails
 	b.bench.step()

--- a/vlib/compiler/table.v
+++ b/vlib/compiler/table.v
@@ -778,13 +778,14 @@ fn (t &Table) main_exists() bool {
 	return false
 }
 
-fn (t &Table) has_at_least_one_test_fn() bool {
+fn (t &Table) all_test_function_names() []string {
+	mut res := []string
 	for _, f in t.fns {
-		if f.name.starts_with('main__test_') {
-			return true
+		if f.name.contains('__test_') {
+			res << f.name
 		}
 	}
-	return false
+	return res
 }
 
 fn (t &Table) find_const(name string) ?Var {

--- a/vlib/compiler/tests/modules/amodule/another_internal_module_test.v
+++ b/vlib/compiler/tests/modules/amodule/another_internal_module_test.v
@@ -1,0 +1,16 @@
+module amodule
+
+// This tests whether _test.v files can be *internal* to a 
+// module, and thus have access to its guts.
+
+// NB: the function test_private_isub() is defined both here
+// and inside internal_module_test.v . That is done on purpose, 
+// with the goal of ensuring that _test.v files are compiled 
+// *independently* from each other.
+//
+// _test.v files should *only* import all the other normal .v 
+// files from the same folder, NOT other _test.v files from it.
+
+fn test_private_isub(){
+  assert private_isub(7,5) == 2
+}

--- a/vlib/compiler/tests/modules/amodule/internal_module_test.v
+++ b/vlib/compiler/tests/modules/amodule/internal_module_test.v
@@ -1,0 +1,16 @@
+module amodule
+
+// this tests whether _test.v files can be *internal* 
+// to a module, and thus have access to its guts.
+
+fn test_iadd(){
+	assert iadd(10, 20) == 30
+}
+
+fn test_imul(){
+	assert imul(5,8) == 40
+}
+
+fn test_private_isub(){
+  assert private_isub(10,6) == 4
+}

--- a/vlib/compiler/tests/modules/amodule/module.v
+++ b/vlib/compiler/tests/modules/amodule/module.v
@@ -1,0 +1,15 @@
+module amodule
+
+pub fn iadd(x int, y int) int {
+	return x + y
+}
+
+pub fn imul(x int, y int) int {
+	return x * y
+}
+
+///////////////////////////////////////
+
+fn private_isub(x int, y int) int {
+  return x - y
+}

--- a/vlib/compiler/tests/repl/repl_test.v
+++ b/vlib/compiler/tests/repl/repl_test.v
@@ -1,3 +1,5 @@
+module main
+
 import os
 import compiler.tests.repl.runner
 import benchmark


### PR DESCRIPTION
With this PR, you can write _test.v files in the same module without needing to import the module.
You have to specify `module yourmodulename` just like for other module .v files, and you will have access to the internals (non public functions and so on) of the module, so you can test them thoroughly :-) .

Example:
```shell
0[13:14:28] /v/amodule LINUX $ cat module.v
module amodule

pub fn iadd(x int, y int) int {
        return x + y
}

pub fn imul(x int, y int) int {
        return x * y
}

///////////////////////////////////////

fn private_isub(x int, y int) int {
  return x - y
}
0[13:14:30] /v/amodule LINUX $
0[13:14:31] /v/amodule LINUX $ cat internal_module_test.v
module amodule

// this tests whether _test.v files can be *internal*
// to a module, and thus have access to its guts.

fn test_iadd(){
        assert iadd(10, 20) == 30
}

fn test_imul(){
        assert imul(5,8) == 40
}

fn test_private_isub(){
  assert private_isub(10,6) == 4
}
0[13:14:39] /v/amodule LINUX $ /v/nv/v -stats internal_module_test.v
compilation took: 543ms
running tests in: /v/amodule/internal_module_test.v
   OK     0 ms |  1 assert  | amodule.test_iadd()
   OK     0 ms |  1 assert  | amodule.test_imul()
   OK     0 ms |  1 assert  | amodule.test_private_isub()
          0 ms | <=== total time spent running V tests in "internal_module_test.v"
 ok, fail, total =     3,     0,     3
0[13:14:57] /v/amodule LINUX $
```
