### PR TITLE
fix math.abs (in case of -0.0)

### DIFF
--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -18,6 +18,7 @@ fn C.erf(x f64) f64
 fn C.erfc(x f64) f64
 fn C.exp(x f64) f64
 fn C.exp2(x f64) f64
+fn C.fabs(x f64) f64
 fn C.floor(x f64) f64
 fn C.fmod(x f64, y f64) f64
 fn C.hypot(x f64, y f64) f64
@@ -42,10 +43,7 @@ fn C.trunc(x f64) f64
 
 // Returns the absolute value.
 pub fn abs(a f64) f64 {
-	if a < 0 {
-		return -a
-	}
-	return a
+	return C.fabs(a)
 }
 
 // acos calculates inverse cosine (arccosine).


### PR DESCRIPTION
`math.abs(-0.0)` should return `0.000000`, not `-0.000000`.   

<br>

Since `0.0 == -0.0` is `true`, it is quite hard to distinguish between `0.0` and `-0.0` using boolean operator.   
You could implement this with `copysign` function (`copysign(1.0, 0.0)`  = `1.0` and `copysign(1.0, -0.0)` = `-1.0`), but it's much easier to use built-in `fabs` function.