### PR TITLE
builder_js: fix mutable error

### DIFF
--- a/vlib/strings/builder_js.v
+++ b/vlib/strings/builder_js.v
@@ -7,7 +7,7 @@ module strings
 pub struct Builder {
 mut:
 	buf []byte
-pub:
+pub mut:
 	len int
 	initial_size int = 1
 }


### PR DESCRIPTION
Fix builder js error

Fixed error
```shell
v/vlib/strings/builder_js.v:24:6: cannot modify immutable field `len` (type `strings.Builder`)
declare the field with `mut:`
struct strings.Builder {
  mut:
        len int
}

   22| pub fn (b mut Builder) write_b(data byte) {
   23|  b.buf << data
   24|  b.len++
            ^
   25| }
   26|
Failed.
```
