### PR TITLE
compiler: fix regression for -d option flag.

### DIFF
--- a/vlib/compiler/compiler_options.v
+++ b/vlib/compiler/compiler_options.v
@@ -14,7 +14,7 @@ pub fn get_v_options_and_main_command(args []string) ([]string,string) {
 			continue
 		}else{
 			options << a
-			if a in ['-o', '-os', '-cc', '-cflags'] { i++ }
+			if a in ['-o', '-os', '-cc', '-cflags', '-d'] { i++ }
 		}
 	}
 	// potential_commands[0] is always the executable itself, so ignore it


### PR DESCRIPTION
Restores ability to pass `-d xyz` to V.