### PR TITLE
compiler: support for ptr_str/1, string concatenation and struct declaration in -freestanding mode

### DIFF
--- a/vlib/builtin/bare/.checks/.gitignore
+++ b/vlib/builtin/bare/.checks/.gitignore
@@ -1,1 +1,5 @@
 checks
+linuxsys/linuxsys
+string/string
+consts/consts
+structs/structs

--- a/vlib/builtin/bare/.checks/checks.v
+++ b/vlib/builtin/bare/.checks/checks.v
@@ -26,6 +26,7 @@ fn main() {
 	vcheck("linuxsys")
 	vcheck("string")
 	vcheck("consts")
+	vcheck("structs")
 	exit(0)
 }
 

--- a/vlib/builtin/bare/.checks/string/string.v
+++ b/vlib/builtin/bare/.checks/string/string.v
@@ -39,12 +39,24 @@ fn check_str_clone() {
 	assert c == "-6789"
 }
 
+fn check_string_add_works(){
+  abc := 'abc'
+  combined := 'a' + 'b' + 'c'
+  assert abc.len == combined.len
+  assert abc[0] == combined[0]
+  assert abc[1] == combined[1]
+  assert abc[2] == combined[2]
+  assert abc[0] == `a`
+  assert abc == combined
+}  
+
 fn main () {
 	mut fails := 0
 	fails += forkedtest.normal_run(check_string_eq, "check_string_eq")
 	fails += forkedtest.normal_run(check_i64_tos, "check_i64_tos")
 	fails += forkedtest.normal_run(check_i64_str, "check_i64_str")
 	fails += forkedtest.normal_run(check_str_clone, "check_str_clone")
+	fails += forkedtest.normal_run(check_string_add_works,    "check_string_add_works")
 	assert fails == 0
 	sys_exit(0)
 }

--- a/vlib/builtin/bare/.checks/structs/structs.v
+++ b/vlib/builtin/bare/.checks/structs/structs.v
@@ -33,21 +33,10 @@ fn check_non_empty_struct(){
   println('sizeof NonEmptyStruct:' + i64_str( sizeof(NonEmptyStruct) , 10 ))
 }
 
-fn check_string_add_works(){
-  abc := 'abc'
-  combined := 'a' + 'b' + 'c'
-  assert abc.len == combined.len
-  assert abc[0] == combined[0]
-  assert abc[1] == combined[1]
-  assert abc[2] == combined[2]
-  assert abc == combined
-}  
-
 fn main(){
 	mut fails := 0
 	fails += forkedtest.normal_run(check_simple_empty_struct, "check_simple_empty_struct")
 	fails += forkedtest.normal_run(check_non_empty_struct,    "check_non_empty_struct")
-	fails += forkedtest.normal_run(check_string_add_works,    "check_string_add_works")
 	assert fails == 0
 	sys_exit(0)
 }

--- a/vlib/builtin/bare/.checks/structs/structs.v
+++ b/vlib/builtin/bare/.checks/structs/structs.v
@@ -1,0 +1,53 @@
+module main
+import forkedtest
+
+struct SimpleEmptyStruct{
+}
+
+struct NonEmptyStruct{
+  x int
+  y int
+  z int
+}
+
+fn check_simple_empty_struct(){  
+  s := SimpleEmptyStruct{}
+  addr_s := &s
+  str_addr_s := ptr_str( addr_s )
+  assert !isnil(addr_s)
+  assert str_addr_s.len > 3
+  println(str_addr_s)
+}
+
+fn check_non_empty_struct(){  
+  a := NonEmptyStruct{1,2,3}
+  b := NonEmptyStruct{4,5,6}
+  assert sizeof(NonEmptyStruct) > 0
+  assert sizeof(SimpleEmptyStruct) < sizeof(NonEmptyStruct)
+  assert a.x == 1
+  assert a.y == 2
+  assert a.z == 3
+  assert b.x + b.y + b.z == 15
+  assert ptr_str(&a) != ptr_str(&b)
+  println('sizeof SimpleEmptyStruct:' + i64_str( sizeof(SimpleEmptyStruct) , 10 ))
+  println('sizeof NonEmptyStruct:' + i64_str( sizeof(NonEmptyStruct) , 10 ))
+}
+
+fn check_string_add_works(){
+  abc := 'abc'
+  combined := 'a' + 'b' + 'c'
+  assert abc.len == combined.len
+  assert abc[0] == combined[0]
+  assert abc[1] == combined[1]
+  assert abc[2] == combined[2]
+  assert abc == combined
+}  
+
+fn main(){
+	mut fails := 0
+	fails += forkedtest.normal_run(check_simple_empty_struct, "check_simple_empty_struct")
+	fails += forkedtest.normal_run(check_non_empty_struct,    "check_non_empty_struct")
+	fails += forkedtest.normal_run(check_string_add_works,    "check_string_add_works")
+	assert fails == 0
+	sys_exit(0)
+}

--- a/vlib/builtin/bare/string_bare.v
+++ b/vlib/builtin/bare/string_bare.v
@@ -22,6 +22,22 @@ pub fn tos(s byteptr, len int) string {
 	}
 }
 
+fn (s string) add(a string) string {
+	new_len := a.len + s.len
+	mut res := string {
+		len: new_len
+		str: malloc(new_len + 1)
+	}
+	for j := 0; j < s.len; j++ {
+		res[j] = s[j]
+	}
+	for j := 0; j < a.len; j++ {
+		res[s.len + j] = a[j]
+	}
+	res[new_len] = `\0`// V strings are not null terminated, but just in case
+	return res
+}
+
 /*
 pub fn tos_clone(s byteptr) string {
 	if s == 0 {
@@ -100,6 +116,13 @@ pub fn i64_str(n0 i64, base int) string {
 	return i64_tos(buf, 79, n0, base)
 }
 
+pub fn ptr_str(ptr voidptr) string {
+  buf := [16]byte
+  hex := i64_tos(buf, 15, i64(ptr), 16)
+  res := '0x' + hex
+  return res
+}
+
 pub fn (a string) clone() string {
 	mut b := string {
 		len: a.len
@@ -109,3 +132,4 @@ pub fn (a string) clone() string {
 	b[a.len] = `\0`
 	return b
 }
+

--- a/vlib/compiler/cheaders.v
+++ b/vlib/compiler/cheaders.v
@@ -2,6 +2,28 @@ module compiler
 
 const (
 
+c_common_macros = '
+
+#define EMPTY_STRUCT_DECLARATION
+#define EMPTY_STRUCT_INITIALIZATION 0
+// Due to a tcc bug, the length of an array needs to be specified, but GCC crashes if it is...
+#define EMPTY_ARRAY_OF_ELEMS(x,n) (x[])
+#define TCCSKIP(x) x
+
+#ifdef __TINYC__
+#undef EMPTY_STRUCT_DECLARATION
+#undef EMPTY_STRUCT_INITIALIZATION
+#define EMPTY_STRUCT_DECLARATION char _dummy
+#define EMPTY_STRUCT_INITIALIZATION 0
+#undef EMPTY_ARRAY_OF_ELEMS
+#define EMPTY_ARRAY_OF_ELEMS(x,n) (x[n])
+#undef TCCSKIP
+#define TCCSKIP(x)
+#endif
+
+#define OPTION_CAST(x) (x)
+'
+
 c_headers = '
 
 //#include <inttypes.h>  // int64_t etc
@@ -69,24 +91,7 @@ c_headers = '
 #include <sys/wait.h> // os__wait uses wait on nix
 #endif
 
-#define EMPTY_STRUCT_DECLARATION
-#define EMPTY_STRUCT_INITIALIZATION 0
-// Due to a tcc bug, the length of an array needs to be specified, but GCC crashes if it is...
-#define EMPTY_ARRAY_OF_ELEMS(x,n) (x[])
-#define TCCSKIP(x) x
-
-#ifdef __TINYC__
-#undef EMPTY_STRUCT_DECLARATION
-#undef EMPTY_STRUCT_INITIALIZATION
-#define EMPTY_STRUCT_DECLARATION char _dummy
-#define EMPTY_STRUCT_INITIALIZATION 0
-#undef EMPTY_ARRAY_OF_ELEMS
-#define EMPTY_ARRAY_OF_ELEMS(x,n) (x[n])
-#undef TCCSKIP
-#define TCCSKIP(x)
-#endif
-
-#define OPTION_CAST(x) (x)
+$c_common_macros 
 
 #ifdef _WIN32
 #define WINVER 0x0600
@@ -209,19 +214,7 @@ typedef map map_string;
 
 bare_c_headers = '
 
-#define EMPTY_ARRAY_OF_ELEMS(x,n) (x[])
-#define TCCSKIP(x) x
-
-#ifdef __TINYC__
-#undef EMPTY_ARRAY_OF_ELEMS
-#define EMPTY_ARRAY_OF_ELEMS(x,n) (x[n])
-#undef TCCSKIP
-#define TCCSKIP(x)
-#endif
-
-#ifndef EMPTY_STRUCT_INITIALIZATION
-#define EMPTY_STRUCT_INITIALIZATION 0
-#endif
+$c_common_macros
 
 #ifndef exit
 #define exit(rc) sys_exit(rc)
@@ -229,3 +222,5 @@ void sys_exit (int);
 #endif
 '
 )
+
+


### PR DESCRIPTION
With this PR the following program can be compiled and run:
```v
struct Abc {
}

fn main() {
  a := Abc{}
  z := ptr_str(&a)
  println(z)
  println('a' + 'b' + 'c')
}
```
Result:
```shell
0[13:25:49] /v/nv LINUX $ /v/nv/v -keep_c -show_c_cmd -freestanding run f.v

==========
cc  -std=gnu11 -Wall -Wextra -Wno-unused-variable 
-Wno-unused-parameter -Wno-unused-result 
-Wno-unused-function -Wno-missing-braces 
-Wno-unused-label 
-fno-stack-protector -static -ffreestanding -nostdlib 
-Werror=implicit-function-declaration 
-o "f" "/tmp/v/f.tmp.c"
cc took 61 ms
=========

0x7FFF85934BD0
abc
0[13:26:10] /v/nv LINUX $ ls -lart f
-rwxrwxr-x 1 delian delian 11384 дек 16 13:26 f
0[13:26:20] /v/nv LINUX $ strip f
0[13:26:26] /v/nv LINUX $ ls -lart f
-rwxrwxr-x 1 delian delian 8776 дек 16 13:26 f
0[13:26:27] /v/nv LINUX $ file f
f: ELF 64-bit LSB executable, x86-64, 
version 1 (SYSV), statically linked, 
BuildID[sha1]=0899125f45968f4105a652b60ca8885e128658e9, stripped
0[13:26:30] /v/nv LINUX $ ./f
0x7FFF58C7C9D0
abc
0[13:26:32] /v/nv LINUX $ ldd f
        not a dynamic executable
1[13:26:51] /v/nv LINUX $
```

