### PR TITLE
v.v: fix regression of 'v build module file.v'

### DIFF
--- a/v.v
+++ b/v.v
@@ -77,7 +77,7 @@ fn main() {
 
 fn v_command(command string, args []string) {
 	match command {
-		'', '.', 'run' {
+		'', '.', 'run', 'build' { // handled later in vlib/compiler/main.v
 			return
 		}
 		'version' {


### PR DESCRIPTION
Before:
```
6[17:07:31]delian@nemesis: /v/nv $ ./v build module vlib/builtin
v build: unknown command
Run "v help" for usage.
0[17:07:34]delian@nemesis: /v/nv $
```


After PR:
```
0[17:13:18]delian@nemesis: /v/nv $ ./v build module vlib/builtin
Building module "builtin" (dir="vlib/builtin")...
C compiler=clang-7




Generating a V header file for module `vlib/builtin`
/v/nv/vlib/builtin
Building /home/delian/.vmodules/cache/vlib/builtin.o...
0[17:13:29]delian@nemesis: /v/nv $ 
```