### PR TITLE
compiler: fix generic function call in `for in` expression

### DIFF
--- a/vlib/compiler/fn.v
+++ b/vlib/compiler/fn.v
@@ -834,7 +834,12 @@ fn (p mut Parser) fn_call(f mut Fn, method_ph int, receiver_var, receiver_type s
 	generic := f.is_generic
 	p.fn_call_args(mut f)
 	if generic {
-		p.cgen.resetln(p.cgen.cur_line.replace('$cgen_name (', '$f.name ('))
+		line := if p.cgen.is_tmp {
+			p.cgen.tmp_line
+		} else {
+			p.cgen.cur_line
+		}
+		p.cgen.resetln(line.replace('$cgen_name (', '$f.name ('))
 		// println('calling inst $f.name: $p.cgen.cur_line')
 	}
 

--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -99,6 +99,7 @@ struct ParserState {
 	cgen_lines    []string
 	cgen_cur_line string
 	cgen_tmp_line string
+	cgen_is_tmp   bool
 	tokens        []Token
 	token_idx     int
 	tok           TokenKind
@@ -293,6 +294,7 @@ pub fn (p &Parser) save_state() ParserState {
 		cgen_lines    : p.cgen.lines
 		cgen_cur_line : p.cgen.cur_line
 		cgen_tmp_line : p.cgen.tmp_line
+		cgen_is_tmp   : p.cgen.is_tmp
 		tokens       : p.tokens
 		token_idx    : p.token_idx
 		tok          : p.tok
@@ -314,6 +316,7 @@ pub fn (p mut Parser) restore_state(state ParserState, scanner bool, cgen bool) 
 		p.cgen.lines    = state.cgen_lines
 		p.cgen.cur_line = state.cgen_cur_line
 		p.cgen.tmp_line = state.cgen_tmp_line
+		p.cgen.is_tmp   = state.cgen_is_tmp
 	}
 	p.tokens        = state.tokens
 	p.token_idx     = state.token_idx
@@ -335,6 +338,7 @@ fn (p mut Parser) clear_state(scanner bool, cgen bool) {
 		p.cgen.lines    = []
 		p.cgen.cur_line = ''
 		p.cgen.tmp_line = ''
+		p.cgen.is_tmp   = false
 	}
 	p.tokens = []
 	p.token_idx = 0

--- a/vlib/compiler/tests/generic_test.v
+++ b/vlib/compiler/tests/generic_test.v
@@ -80,3 +80,21 @@ fn test_generic_method() {
     p.translate(2, 1.0)
     assert p.x == 2.0 && p.y == 1.0
 }
+
+fn get_values<T>(i T) []T {
+    return [i]
+}
+
+fn test_generic_fn_in_for_in_expression() {
+    for value in get_values(1) {
+        assert value == 1
+    }
+
+    for i, val in get_values(0) {
+        assert i == val
+    }
+
+    for value in get_values('a') {
+        assert value == 'a'
+    }
+}


### PR DESCRIPTION
Calling a generic function in a `for in` expression resulted in a C error:

```v
fn get_values<T>(i T) []T {
	return [i]
}

fn main() {
	for value in get_values(1) {
		assert value == 1
	}
}
```

```
(base) ➜  v git:(master) ✗ v -g run test.v
C compiler=cc
/Users/hillerstorm/test.v:4:2: error: expected expression
 ) array_int tmp1 =  main__get_values ( 1;
 ^
/Users/hillerstorm/test.v:2:1: error: expected identifier or '('
return new_array_from_c_array(1, 1, sizeof(int), EMPTY_ARRAY_OF_ELEMS( int, 1 ) {  i  }) ;
^
/Users/hillerstorm/test.v:4:2: error: extraneous closing brace ('}')
 }
 ^
3 errors generated.
V error: C error. This should never happen. 
```

This was due to the `ParserState` struct not saving/restoring `p.cgen.is_tmp`
and also because the code replacing the function name with the generic
counterpart was hard coded to `p.cgen.cur_line` regardless of `is_tmp`.

It already works in `for some_bool(1) {` expressions, since it doesn't
create any temp variables.