### PR TITLE
compiler: option/command parsing bugfix

### DIFF
--- a/vlib/compiler/compiler_options.v
+++ b/vlib/compiler/compiler_options.v
@@ -10,7 +10,7 @@ pub fn get_v_options_and_main_command(args []string) ([]string,string) {
 	for i := 0; i < args.len; i++ {
 		a := args[i]
 		if !a.starts_with('-') {
-			if a.len > 0 { potential_commands << a }
+			potential_commands << a
 			continue
 		}else{
 			options << a

--- a/vlib/compiler/compiler_options.v
+++ b/vlib/compiler/compiler_options.v
@@ -10,7 +10,7 @@ pub fn get_v_options_and_main_command(args []string) ([]string,string) {
 	for i := 0; i < args.len; i++ {
 		a := args[i]
 		if !a.starts_with('-') {
-			potential_commands << a
+			if a.len > 0 { potential_commands << a }
 			continue
 		}else{
 			options << a

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -1126,9 +1126,13 @@ pub fn new_v(args[]string) &V {
 	}
 }
 
+fn non_empty(a []string) []string {
+	return a.filter(it.len != 0)
+}
+
 pub fn env_vflags_and_os_args() []string {
 	vosargs := os.getenv('VOSARGS')
-	if '' != vosargs { return vosargs.split(' ') }
+	if '' != vosargs { return non_empty(vosargs.split(' ')) }
 
 	mut args := []string
 	vflags := os.getenv('VFLAGS')
@@ -1141,7 +1145,7 @@ pub fn env_vflags_and_os_args() []string {
 	} else{
 		args << os.args
 	}
-	return args
+	return non_empty(args)
 }
 
 pub fn vfmt(args[]string) {


### PR DESCRIPTION
This PR fixes a v -> v vrepl.v -> v -> v vrepl.v loop, when VFLAGS was for example:
`export VFLAGS='-cc clang-7 -show_c_cmd -keep_c -cg   '`
(note the additional spaces after -cg)