### PR TITLE
tetris: remove spurious printing of gl.TEXT_VERT .

### DIFF
--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -27,7 +27,6 @@ pub fn vec2(x, y int) Vec2 {
 
 pub fn init_gg() {
 	glfw.init_glfw()
-	println(gl.TEXT_VERT)
 	gl.init_glad()
 }
 


### PR DESCRIPTION
This PR makes running gg based programs less noisy.
The printed shader source is redundant, since it will get printed anyway, if/when the shader compilation fails.
