### PR TITLE
fix: nreadelements naming

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -98,9 +98,9 @@ pub fn read_bytes(path string) ?[]byte {
 	C.rewind(fp)
 
 	mut res	 := [`0`].repeat(fsize)
-	nreadelements := C.fread(res.data, fsize, 1, fp)
+	n_read_elements := C.fread(res.data, fsize, 1, fp)
 	C.fclose(fp)
-	return res[0..nreadelements * fsize]
+	return res[0..n_read_elements * fsize]
 }
 
 // read_file reads the file in `path` and returns the contents.

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -98,9 +98,9 @@ pub fn read_bytes(path string) ?[]byte {
 	C.rewind(fp)
 
 	mut res	 := [`0`].repeat(fsize)
-	n_read_elements := C.fread(res.data, fsize, 1, fp)
+	nr_read_elements := C.fread(res.data, fsize, 1, fp)
 	C.fclose(fp)
-	return res[0..n_read_elements * fsize]
+	return res[0..nr_read_elements * fsize]
 }
 
 // read_file reads the file in `path` and returns the contents.


### PR DESCRIPTION
It was giving an error that `nreadelements` should be `n_read_elements`, so fixed that.