### PR TITLE
eventbus: remove hacks, add sender

### DIFF
--- a/examples/eventbus/eventbus.v
+++ b/examples/eventbus/eventbus.v
@@ -11,6 +11,8 @@ fn main(){
 	some_module.do_work()
 }
 
-fn on_error(p eventbus.Params) {
+fn on_error(sender voidptr, p eventbus.Params) {
+	work := *(*some_module.Work(sender))
+	println(work.hours)
 	println(p.get_string("error"))
 }

--- a/examples/eventbus/modules/some_module/some_module.v
+++ b/examples/eventbus/modules/some_module/some_module.v
@@ -8,14 +8,20 @@ const (
 	eb = eventbus.new()
 )
 
+pub struct Work {
+	pub:
+	hours int
+}
+
 pub fn do_work(){
+	work := Work{20}
 	mut params := eventbus.Params{}
 	for i in 0..20 {
 		println("working...")
 		if i == 15 {
 			params.put_string("error", "CRASH!!")
-			eb.publish("error", params)
-			eb.publish("error", params)
+			eb.publish("error", work, params)
+			eb.publish("error", work, params)
 			return
 		}
 	}

--- a/vlib/eventbus/README.md
+++ b/vlib/eventbus/README.md
@@ -10,14 +10,14 @@ A module to provide eventing capabilities using pub/sub.
 
 **EventBus:**
 
-1. `publish(string, Params)` - publish an event with provided Params & name
+1. `publish(string, voidptr, Params)` - publish an event with provided Params & name
 2. `clear_all()` - clear all subscribers
 3. `has_subscriber(string)` - check if a subscriber to an event exists
 
 **Subscriber:**
 
-1. `subscribe(string, fn(Params))` - subscribe to an event
-2. `subscribe_once(string, fn(Params))` - subscribe only once to an event
+1. `subscribe(string, fn(voidptr, Params))` - subscribe to an event
+2. `subscribe_once(string, fn(voidptr, Params))` - subscribe only once to an event
 3. `is_subscribed(string)` - check if we are subscribed to an event
 4. `unsubscribe(string)` - unsubscribe from an event
 
@@ -26,11 +26,11 @@ A module to provide eventing capabilities using pub/sub.
 The function given to `subscribe` and `subscribe_once` must match this:
 
 ```v
-fn(Params){
+fn(voidptr, Params){
 
 }
 // Example
-fn onPress(p Params){
+fn onPress(sender voidptr, p Params){
     //your code here...
 }
 ```
@@ -39,7 +39,7 @@ fn onPress(p Params){
 
 For **usage across modules** [check the example](https://github.com/vlang/v/tree/master/examples/eventbus).
 
-_Note: As a general rule, you will need to **subscribe before emitting**._
+_Note: As a general rule, you will need to **subscribe before publishing**._
 
 **main.v**
 
@@ -62,8 +62,13 @@ fn main(){
 }
 
 // the event handler
-fn on_error(p eventbus.Params) {
-	println(p.get_string("error"))
+fn on_error(sender voidptr, p eventbus.Params) {
+    //cast the sender to the real type
+    //you can also make this mutable if required.
+    work := *(*Work(sender)) //a little verbose but works
+
+    error := p.get_string("error")
+	println('error occured on ${work.hours}. Error: ${error}')
 }
 ```
 
@@ -76,12 +81,17 @@ import (
 	eventbus
 )
 
+struct Work{
+    hours int
+}
+
 fn do_work(){
+    work := Work{20}
     // get a mutable Params instance & put some data into it
 	mut params := eventbus.Params{}
     params.put_string("error", "Error: no internet connection.")
     // publish the event
-    eb.publish("error", params)
+    eb.publish("error", work, params)
 }
 ```
 
@@ -89,31 +99,32 @@ fn do_work(){
 
 ```v
 mut params := eventbus.Params{}
-params.put_string("string", "vevent")
+
+params.put_string("string", "some_string")
 params.put_int("int", 20)
-params.put_bool("bo", true)
-//the array  & map currently needs to set like this
-eventbus.put_array(mut params, "array", [1,2,3])
-eventbus.put_map(mut params, "map", "", {"hello": "world"})
+params.put_bool("bool", true)
 
-params.get_string("string") == "vevent"
-params.get_int("int") == 20
-params.get_bool("bo") == true
-m := params.get_string_map("map")
-//the array currently needs to gotten like this
-arr := eventbus.get_array(params, "array", 0)
+// add maps and arrays of any type like this
+arr := [1,2,3]
+params.put_array("array", arr)
+mp :=  {"hello": "world"}
+params.put_map("map", mp)
 
-//you can also pass around custom type arrays & maps (it's a little crude but works):
-struct Example{}
-custom_map := {"example": Example{}}
-eventbus.put_map(mut params, "custom_map", Example{}, custom_map)
-//and get it like this
-eventbus.get_map(params, "custom_map", {"":Example{}}
+//get and use the params like this
+assert params.get_string("string") == "some_string"
+assert params.get_int("int") == 20
+assert params.get_bool("bool") == true
 
-//For arrays:
-eventbus.put_array(mut params, "array", [Example{}])
-eventbus.get_array(params, "custom_array", Example{})
+g_arr := params.get_array("array", 0)
+assert g_arr[0] == 1
+
+g_m := params.get_map("map", "")
+assert g_m["hello"] == "world"
 ```
+
+#### Caution when putting arrays:
+
+Currently putting arrays and maps directly as parameters in `put_array` doesn't work, so make a variable first and use that.
 
 ### Notes:
 
@@ -121,6 +132,6 @@ eventbus.get_array(params, "custom_array", Example{})
 2. Each `EventBus` has a `Subscriber` instance which will need to be either exposed or you can make small public helper functions specific to your module like (`onPress`, `onError`) and etc.
 3. The `eventbus` module has some helpers to ease getting/setting of Params (since V doesn't support empty interfaces yet or reflection) so use them (see usage above).
 
-**The rationale behind separating Subscriber & Emitter:**
+**The rationale behind separating Subscriber & Publisher:**
 
-This is mainly for security because the if emitter & subscriber are both passed around, a client can easily emit events acting as the server. So a client should only be able to use the Subscriber methods.
+This is mainly for security because the if publisher & subscriber are both passed around, a client can easily publish events acting as the server. So a client should only be able to use the Subscriber methods.

--- a/vlib/eventbus/eventbus_test.v
+++ b/vlib/eventbus/eventbus_test.v
@@ -5,38 +5,60 @@ import (
 fn test_eventbus(){
 	mut eb := eventbus.new()
 	eb.subscriber.subscribe_once("on_test", on_test)
-	assert eb.has_subscriber("on_test") == true
-	assert eb.subscriber.is_subscribed("on_test") == true
+	
+	assert eb.has_subscriber("on_test")
+	assert eb.subscriber.is_subscribed("on_test")
+
 	mut params := eventbus.Params{}
 	params.put_string("eventbus", "vevent")
-	eb.publish("on_test", params)
-	assert eb.has_subscriber("on_test") == false
-	assert eb.subscriber.is_subscribed("on_test") == false
-	eb.subscriber.subscribe_once("on_test", on_test)
-	assert eb.has_subscriber("on_test") == true
-	assert eb.subscriber.is_subscribed("on_test") == true
+
+	eb.publish("on_test", eb, params)
+
+	assert !eb.has_subscriber("on_test")
+	assert !eb.subscriber.is_subscribed("on_test")
+
+	eb.subscriber.subscribe("on_test", on_test)
+
+	assert eb.has_subscriber("on_test")
+	assert eb.subscriber.is_subscribed("on_test")
+
 	eb.clear_all()
-	assert eb.has_subscriber("on_test") == false
-	assert eb.subscriber.is_subscribed("on_test") == false
+
+	assert !eb.has_subscriber("on_test")
+	assert !eb.subscriber.is_subscribed("on_test")
 }
 
 fn test_params(){
 	mut params := eventbus.Params{}
-	params.put_string("string", "vevent")
-	params.put_int("int", 20)
-	params.put_bool("bo", true)
-	eventbus.put_array(mut params, "array", [1,2,3])
-	eventbus.put_map(mut params, "map", "", {"hello": "world"})
 
-	assert params.get_string("string") == "vevent"
+	params.put_string("string", "some_string")
+	params.put_int("int", 20)
+	params.put_bool("bool", true)
+	arr := [1,2,3]
+	params.put_array("array", arr)
+	mp :=  {"hello": "world"}
+	params.put_map("map", mp)
+
+	assert params.get_string("string") == "some_string"
 	assert params.get_int("int") == 20
-	assert params.get_bool("bo") == true
-	arr := eventbus.get_array(params, "array", 0)
-	assert arr[0] == 1
-	m := params.get_string_map("map") 
-	assert m["hello"] == "world"
+	assert params.get_bool("bool") == true
+
+	g_arr := params.get_array("array", 0)
+	assert g_arr[0] == 1 
+
+	g_m := params.get_map("map", "")
+	assert g_m["hello"] == "world"
 }
 
-fn on_test(p eventbus.Params) {
+fn on_test(sender voidptr, p eventbus.Params) {
+	mut eb := *(*eventbus.EventBus(sender))
+	
+	eb.subscriber.subscribe("on_test_2", on_test_2)
+	eb.clear_all()
+	assert !eb.has_subscriber("on_test_2")
+	assert !eb.subscriber.is_subscribed("on_test_2")
+
 	assert p.get_string("eventbus") == "vevent"
 }
+
+fn on_test_2(sender voidptr, p eventbus.Params){}


### PR DESCRIPTION
This PR removes all the hacks that were used for marshalling/marshalling arrays and maps resulting in a much simpler experience.

The EventHandler signature has also changed. It now takes  an `sender voidptr` parameter which can be casted to the real `struct` etc. and used as usual.

Aside from that, I cleaned the tests, improved the example a bit too.

**Note:**
This PR is part of the bigger `websocket` implementation that affects multiple modules, so I am pushing them one by one for better testing and review.