### PR TITLE
builtin/array.v: Fix typo in new_array (cap -> cap_)

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -20,7 +20,7 @@ fn new_array(mylen, cap, elm_size int) array {
 	cap_ := if cap == 0 { 1 } else { cap }
 	arr := array{
 		len: mylen
-		cap: cap
+		cap: cap_
 		element_size: elm_size
 		data: calloc(cap_ * elm_size)
 	}


### PR DESCRIPTION
It appears that the `cap_` variable isn't used where it should be.