### PR TITLE
Update vtest to print separator with dynamic width

### DIFF
--- a/tools/vtest.v
+++ b/tools/vtest.v
@@ -51,8 +51,8 @@ pub fn main() {
 	tput := os.exec("tput cols") or {
 		return
 	}
-	cols := if tpu.exit_code == 0 {
-		tpu.output.int()
+	cols := if tput.exit_code == 0 {
+		tput.output.int()
 	} else {
 		76
 	}

--- a/tools/vtest.v
+++ b/tools/vtest.v
@@ -46,7 +46,18 @@ pub fn main() {
 
 	println('Testing...')
 	ts.test()
-	println('----------------------------------------------------------------------------')
+
+	// Print separator with dynamic width
+	tpu := os.exec("tput cols") or {
+		return
+	}
+	cols := if tpu.exit_code == 0 {
+		tpu.output.int()
+	} else {
+		76
+	}
+	println("-".repeat(cols))
+
 	println( ts.benchmark.total_message('running V _test.v files') )
 	if ts.failed {
 		exit(1)

--- a/tools/vtest.v
+++ b/tools/vtest.v
@@ -48,13 +48,11 @@ pub fn main() {
 	ts.test()
 
 	// Print separator with dynamic width
-	tput := os.exec("tput cols") or {
-		return
-	}
-	cols := if tput.exit_code == 0 {
-		tput.output.int()
-	} else {
-		76
+	mut cols := 76
+	if tput := os.exec("tput cols") {
+		if tput.exit_code == 0 {
+			cols = tput.output.int()
+		}
 	}
 	println("-".repeat(cols))
 

--- a/tools/vtest.v
+++ b/tools/vtest.v
@@ -48,7 +48,7 @@ pub fn main() {
 	ts.test()
 
 	// Print separator with dynamic width
-	tpu := os.exec("tput cols") or {
+	tput := os.exec("tput cols") or {
 		return
 	}
 	cols := if tpu.exit_code == 0 {

--- a/tools/vtest.v
+++ b/tools/vtest.v
@@ -49,7 +49,7 @@ pub fn main() {
 
 	// Print separator with dynamic width
 	mut cols := 76
-	if tput := os.exec("tput cols") {
+	if tput := os.exec("tput cols; echo") {
 		if tput.exit_code == 0 {
 			cols = tput.output.int()
 		}


### PR DESCRIPTION
Just a small visual improvement.

The separator before total time spent had a fixed width of 76 characters. Now it tries to find the actual width of the terminal using `tput cols` and uses that width, so that the separator fits into one line.