### PR TITLE
Makefile: parallel optimizations. Run make with -j4 on unix CIs.

### DIFF
--- a/.github/workflows/alpine.build.sh
+++ b/.github/workflows/alpine.build.sh
@@ -6,7 +6,7 @@ pwd
 
 uname -a
 
-make
+make -j4
 
 ./v --version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         brew install freetype glfw openssl postgres sdl2 sdl2_ttf sdl2_mixer sdl2_image
         export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/openssl/lib/"
     - name: Build V
-      run:  make && ./v -o v v.v
+      run:  make -j4 && ./v -o v v.v
     - name: Build V using V
       run:  ./v -o v2 v.v && ./v2 -o v3 v.v
     - name: Test symlink
@@ -72,7 +72,7 @@ jobs:
     - name: Install dependencies
       run: sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list; sudo apt-get update; sudo apt-get install --quiet -y postgresql libpq-dev libglfw3 libglfw3-dev libfreetype6-dev libssl-dev sqlite3 libsqlite3-dev libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
     - name: Build V
-      run: make && ./v -cc gcc -o v v.v
+      run: make -j4 && ./v -cc gcc -o v v.v
     - name: Test V
       run: ./v test-compiler
     - name: Test v binaries
@@ -131,7 +131,7 @@ jobs:
     - name: Install dependencies
       run: sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list; sudo apt-get update; sudo apt-get install --quiet -y libglfw3 libglfw3-dev libfreetype6-dev libssl-dev sqlite3 libsqlite3-dev libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
     - name: Build v
-      run: echo $VFLAGS && make && ./v -o v v.v
+      run: echo $VFLAGS && make -j4 && ./v -o v v.v
     - name: Test v->c
       run: |
         sudo ln -s /var/tmp/tcc/bin/tcc /usr/local/bin/tcc
@@ -153,7 +153,7 @@ jobs:
     - name: Install dependencies
       run: sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list; sudo apt-get update; sudo apt-get install --quiet -y musl musl-tools libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
     - name: Build v
-      run: echo $VFLAGS && make && ./v -o v v.v
+      run: echo $VFLAGS && make -j4 && ./v -o v v.v
     - name: Test v binaries
       run: ./v build-vbinaries
 #    - name: Test v->js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,25 @@ name: CI
 on: [push, pull_request]
 jobs:
 
+  ubuntu-tcc:
+    runs-on: ubuntu-18.04
+    env:
+      VFLAGS: -cc tcc
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list; sudo apt-get update; sudo apt-get install --quiet -y libglfw3 libglfw3-dev libfreetype6-dev libssl-dev sqlite3 libsqlite3-dev libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
+    - name: Build v
+      run: echo $VFLAGS && make -j4 && ./v -o v v.v
+    - name: Test v->c
+      run: |
+        sudo ln -s /var/tmp/tcc/bin/tcc /usr/local/bin/tcc
+        tcc -version
+        ./v -o v2 v.v # Make sure vtcc can build itself
+        ./v test-compiler
+    - name: Test v binaries
+      run: ./v build-vbinaries
+
   alpine-docker-musl-gcc:
     name: alpine-musl
     runs-on: ubuntu-latest
@@ -120,26 +139,6 @@ jobs:
       run: echo "test" #wget https://github.com/vbinaries/vbinaries/releases/download/latest/v_windows.zip && unzip v_windows.zip && ./v.exe --version
     - name: Test V
       run: echo "test" #./v.exe examples/hello_world.v && examples/hello_world.exe
-
-
-  ubuntu-tcc:
-    runs-on: ubuntu-18.04
-    env:
-      VFLAGS: -cc tcc
-    steps:
-    - uses: actions/checkout@v1
-    - name: Install dependencies
-      run: sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list; sudo apt-get update; sudo apt-get install --quiet -y libglfw3 libglfw3-dev libfreetype6-dev libssl-dev sqlite3 libsqlite3-dev libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
-    - name: Build v
-      run: echo $VFLAGS && make -j4 && ./v -o v v.v
-    - name: Test v->c
-      run: |
-        sudo ln -s /var/tmp/tcc/bin/tcc /usr/local/bin/tcc
-        tcc -version
-        ./v -o v2 v.v # Make sure vtcc can build itself
-        ./v test-compiler
-    - name: Test v binaries
-      run: ./v build-vbinaries
 
   ubuntu-musl:
     runs-on: ubuntu-18.04

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ ANDROID := 1
 undefine LINUX
 endif
 
-all: fresh_vc fresh_tcc
+all: fresh_vc latest_tcc
+
 ifdef WIN32
 	$(CC) -std=c99 -w -o v0.exe vc/v_win.c $(LDFLAGS)
 	./v0.exe -o v.exe v.v
@@ -51,6 +52,14 @@ fresh_vc:
 	rm -rf vc/
 	git clone --depth 1 --quiet https://github.com/vlang/vc
 	#cp fns.h vc/fns.h
+
+
+latest_tcc:
+ifeq (,$(wildcard /var/tmp/tcc/.git/config))
+	make fresh_tcc
+else
+	cd /var/tmp/tcc && git clean -xf && git pull --quiet
+endif
 
 fresh_tcc:
 ifdef WIN32

--- a/Makefile
+++ b/Makefile
@@ -31,17 +31,12 @@ undefine LINUX
 endif
 #####
 
-ALL_TARGETS = latest_vc
-ifndef ANDROID
-ALL_TARGETS += latest_tcc
-endif
-
 ifdef WIN32
 TCCREPO := https://github.com/vlang/tccbin_win
 VCFILE := v_win.c
 endif
 
-all: $(ALL_TARGETS)
+all: latest_vc latest_tcc
 ifdef WIN32
 	$(CC) -std=c99 -w -o v0.exe $(TMPVC)/$(VCFILE) $(LDFLAGS)
 	./v0.exe -o v.exe v.v
@@ -64,12 +59,9 @@ endif
 	@echo "V has been successfully built"
 
 clean:
-	rm -rf $(TMPTCC)/
-	rm -rf $(TMPVC)/
+	rm -rf $(TMPTCC)
+	rm -rf $(TMPVC)
 	git clean -xf
-
-latest_tcc: $(TMPTCC)/.git/config
-	cd $(TMPTCC) && $(GITCLEANPULL)
 
 latest_vc: $(TMPVC)/.git/config
 	cd $(TMPVC) && $(GITCLEANPULL)
@@ -78,9 +70,16 @@ fresh_vc:
 	rm -rf $(TMPVC)
 	$(GITFASTCLONE) $(VCREPO) $(TMPVC)
 
+latest_tcc: $(TMPTCC)/.git/config
+ifndef ANDROID
+	cd $(TMPTCC) && $(GITCLEANPULL)
+endif
+
 fresh_tcc:
-	rm -rf $(TMPTCC)/  
+ifndef ANDROID
+	rm -rf $(TMPTCC)
 	$(GITFASTCLONE) $(TCCREPO) $(TMPTCC)  
+endif
 
 $(TMPTCC)/.git/config:
 	$(MAKE) fresh_tcc

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC ?= cc
-TMPVC ?= /tmp/vc
 
 VCFILE := v.c
+TMPVC  := /tmp/vc
 TMPTCC := /var/tmp/tcc
 VCREPO := https://github.com/vlang/vc
 TCCREPO := https://github.com/vlang/tccbin
@@ -55,15 +55,17 @@ endif
 	V_V=`git rev-parse --short HEAD`; \
 	if [ $$VC_V != $$V_V ]; then \
 		echo "Self rebuild ($$VC_V => $$V_V)"; \
-		make selfcompile; \
+		$(MAKE) selfcompile; \
 	fi)
 ifndef ANDROID
-	make modules
+	$(MAKE) modules
 endif  
 endif
 	@echo "V has been successfully built"
 
 clean:
+	rm -rf $(TMPTCC)/
+	rm -rf $(TMPVC)/
 	git clean -xf
 
 latest_tcc: $(TMPTCC)/.git/config
@@ -81,15 +83,18 @@ fresh_tcc:
 	$(GITFASTCLONE) $(TCCREPO) $(TMPTCC)  
 
 $(TMPTCC)/.git/config:
-	make fresh_tcc
+	$(MAKE) fresh_tcc
 
 $(TMPVC)/.git/config:
-	make fresh_vc
+	$(MAKE) fresh_vc
 
 selfcompile:
 	./v -o v v.v
 
-modules:
+modules: module_builtin module_strings module_strconv
+module_builtin:
 	./v build module vlib/builtin > /dev/null
+module_strings:  
 	./v build module vlib/strings > /dev/null
+module_strconv:  
 	./v build module vlib/strconv > /dev/null


### PR DESCRIPTION
This PR shaves ~4-5 seconds of make runtime on linux, *after the first run*, since it does not download the whole https://github.com/vlang/tccbin and https://github.com/vlang/vc repos, instead it pull just the latest changes from them.

It also now uses -j4 on unix CIs.