### PR TITLE
.gitignore: ignore DLL and lib files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ vjs
 *.exp
 *.ilk
 *.pdb
+*.dll
+*.lib
 
 #
 # macOS.gitignore


### PR DESCRIPTION
I have a lot of `dll` and `lib` files after running tests. I'm not sure if they should be tracked, so I added them in `.gitignore` file.