### PR TITLE
test: use 'stty size' for vtest --- line instead of 'tput cols' .

### DIFF
--- a/tools/modules/testing/common.v
+++ b/tools/modules/testing/common.v
@@ -94,6 +94,7 @@ pub fn (ts mut TestSession) test() {
 		os.rm( tmpc_filepath )
 	}
 	ts.benchmark.stop()
+	eprintln(term.h_divider())
 }
 
 pub fn vlib_should_be_present( parent_dir string ) {
@@ -177,6 +178,7 @@ pub fn building_any_v_binaries_failed() bool {
 		eprintln(bmark.step_message('$cmd => ${bok}'))
 	}
 	bmark.stop()
+	eprintln(term.h_divider())  
 	eprintln( bmark.total_message( 'building v binaries' ) )
 
 	return failed

--- a/tools/vtest.v
+++ b/tools/vtest.v
@@ -47,15 +47,6 @@ pub fn main() {
 	println('Testing...')
 	ts.test()
 
-	// Print separator with dynamic width
-	mut cols := 76
-	if tput := os.exec('stty size') {
-		if tput.exit_code == 0 {
-			cols = tput.output.split(' ')[1].int()
-		}
-	}
-	println("-".repeat(cols))
-
 	println( ts.benchmark.total_message('running V _test.v files') )
 	if ts.failed {
 		exit(1)

--- a/tools/vtest.v
+++ b/tools/vtest.v
@@ -49,9 +49,9 @@ pub fn main() {
 
 	// Print separator with dynamic width
 	mut cols := 76
-	if tput := os.exec("tput cols; echo") {
+	if tput := os.exec('stty size') {
 		if tput.exit_code == 0 {
-			cols = tput.output.int()
+			cols = tput.output.split(' ')[1].int()
 		}
 	}
 	println("-".repeat(cols))

--- a/vlib/term/can_show_color.v
+++ b/vlib/term/can_show_color.v
@@ -27,3 +27,17 @@ pub fn fail_message(s string) string {
 	return if can_show_color_on_stdout() { red(s) } else { s }
 }
 
+// h_divider will return a horizontal divider line with a dynamic width,
+// that depends on the current terminal settings
+pub fn h_divider() string {
+	mut cols := 76
+	if term_size := os.exec('stty size') {
+		if term_size.exit_code == 0 {
+			term_cols := term_size.output.split(' ')[1].int()
+			if term_cols > 0 {
+				cols = term_cols
+      }
+		}
+	}
+	return '-'.repeat(cols)
+}  

--- a/vlib/term/control.v
+++ b/vlib/term/control.v
@@ -95,4 +95,3 @@ pub fn show_cursor() {
 pub fn hide_cursor() {
 	print('\x1b[?25l')
 }
-


### PR DESCRIPTION
Small fix: `stty size` is more stable than `tput cols` .
It also does not need a `; echo ` hack to be run with os.exec().