### PR TITLE
os, filepath: reorganize functions

### DIFF
--- a/tools/fast/fast.v
+++ b/tools/fast/fast.v
@@ -2,13 +2,16 @@
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 
-import os
-import time
+import (
+	os
+	time
+	filepath
+)
 
 fn main() {
 	exe := os.executable()
-	dir := os.dir(exe)
-	vdir := os.dir(os.dir(dir))
+	dir := filepath.dir(exe)
+	vdir := filepath.dir(filepath.dir(dir))
 	if !os.exists('$vdir/v') && !os.is_dir('$vdir/vlib') {
 		println('fast.html generator needs to be located in `v/tools/fast/`')
 	}

--- a/tools/modules/testing/common.v
+++ b/tools/modules/testing/common.v
@@ -108,7 +108,7 @@ pub fn v_build_failing(zargs string, folder string) bool {
 	main_label := 'Building $folder ...'
 	finish_label := 'building $folder'
 	vexe := vexe_path()
-	parent_dir := os.dir(vexe)
+	parent_dir := filepath.dir(vexe)
 	vlib_should_be_present( parent_dir )
 	vargs := zargs.replace(vexe, '')
 
@@ -148,7 +148,7 @@ pub fn building_any_v_binaries_failed() bool {
 	eprintln('Building V binaries...')
 	eprintln('VFLAGS is: "' + os.getenv('VFLAGS') + '"')
 	vexe := testing.vexe_path()
-	parent_dir := os.dir(vexe)
+	parent_dir := filepath.dir(vexe)
 	testing.vlib_should_be_present( parent_dir )
 	os.chdir( parent_dir )
 

--- a/tools/performance_compare.v
+++ b/tools/performance_compare.v
@@ -1,6 +1,8 @@
-import os
-
-import flag
+import (
+	os
+	flag
+	filepath
+)
 
 const (
 	tool_version = '0.0.4'
@@ -212,7 +214,7 @@ fn main(){
 	used_tools_must_exist(['cp','rm','strip','make','git','upx','cc','wc','tail','hyperfine'])
 	mut context := new_context()
 	mut fp := flag.new_flag_parser(os.args)
-	fp.application(os.filename(os.executable()))
+	fp.application(filepath.filename(os.executable()))
 	fp.version( tool_version )
 	fp.description( tool_description )
 	fp.arguments_description('COMMIT_BEFORE [COMMIT_AFTER]')

--- a/tools/vnames.v
+++ b/tools/vnames.v
@@ -1,9 +1,12 @@
 module main
 
-import os
-import flag
-import compiler
-import strings
+import (
+	os
+	flag
+	strings
+	filepath
+	compiler
+)
 
 const (
 	tool_version = '0.0.1'
@@ -48,10 +51,10 @@ fn analyze_v_file(file string) {
 
 fn main(){
 	toolexe := os.executable()
-	compiler.set_vroot_folder( os.dir(os.dir(toolexe)) )
-	
+	compiler.set_vroot_folder( filepath.dir(filepath.dir(toolexe)) )
+
 	mut fp := flag.new_flag_parser(os.args)
-	fp.application(os.filename(toolexe))
+	fp.application(filepath.filename(toolexe))
 	fp.version( tool_version )
 	fp.description( tool_description )
 	fp.arguments_description('FILE.v/FOLDER [FILE.v/FOLDER]...')

--- a/tools/vtest-compiler.v
+++ b/tools/vtest-compiler.v
@@ -25,7 +25,7 @@ fn v_test_compiler(vargs string){
 fn v_test_compiler2(vargs string){
 
 	vexe := testing.vexe_path()
-	parent_dir := os.dir(vexe)
+	parent_dir := filepath.dir(vexe)
 	testing.vlib_should_be_present( parent_dir )
 
 	// Changing the current directory is needed for some of the compiler tests,

--- a/tools/vup.v
+++ b/tools/vup.v
@@ -1,8 +1,11 @@
-import os
+import (
+	os
+	filepath
+)
 
 fn main() {
 	println('Updating V...')
-	vroot := os.dir(os.args[1])
+	vroot := filepath.dir(os.args[1])
 	os.chdir(vroot)
 	s := os.exec('git -C "$vroot" pull --rebase origin master') or { panic(err) }
 	println(s.output)

--- a/v.v
+++ b/v.v
@@ -105,7 +105,7 @@ fn v_command(command string, args []string) {
 		}
 		'doc' {
 			vexe := os.executable()
-			vdir := os.dir(os.executable())
+			vdir := filepath.dir(os.executable())
 			os.chdir(vdir)
 			mod := args.last()
 			os.system('$vexe build module vlib$os.path_separator' + args.last())

--- a/vlib/builtin/bare/syscallwrapper_test.v
+++ b/vlib/builtin/bare/syscallwrapper_test.v
@@ -1,11 +1,14 @@
-import os
+import (
+	os
+	filepath
+)
 
 fn test_syscallwrappers() {
 	if true { return }
 	$if linux {
 		$if x64 {
 			exe := os.executable()
-			vdir := os.dir(exe)
+			vdir := filepath.dir(exe)
 			if vdir.len > 1 {
 				dot_checks := vdir + "/.checks"
 				assert os.is_dir(dot_checks)

--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -30,7 +30,7 @@ fn (v mut V) cc() {
 	}
 	v.build_thirdparty_obj_files()
 	vexe := vexe_path()
-	vdir := os.dir(vexe)
+	vdir := filepath.dir(vexe)
 	// Just create a C/JavaScript file and exit
 	// for example: `v -o v.c compiler`
 	if v.out_name.ends_with('.c') || v.out_name.ends_with('.js') {

--- a/vlib/compiler/cgen.v
+++ b/vlib/compiler/cgen.v
@@ -3,8 +3,11 @@
 // that can be found in the LICENSE file.
 module compiler
 
-import os
-import strings
+import (
+	os
+	strings
+	filepath
+)
 
 struct CGen {
 	out             os.File
@@ -275,7 +278,7 @@ fn build_thirdparty_obj_file(path string, moduleflags []CFlag) {
 		return
 	}
 	println('$obj_path not found, building it...')
-	parent := os.dir(obj_path)
+	parent := filepath.dir(obj_path)
 	files := os.ls(parent)or{
 		panic(err)
 	}

--- a/vlib/compiler/comptime.v
+++ b/vlib/compiler/comptime.v
@@ -7,6 +7,7 @@ import (
 	vweb.tmpl // for `$vweb_html()`
 	os
 	strings
+	filepath
 )
 
 fn (p mut Parser) comp_time() {
@@ -160,7 +161,7 @@ fn (p mut Parser) comp_time() {
 			// Can't find the template file in current directory,
 			// try looking next to the vweb program, in case it's run with
 			// v path/to/vweb_app.v
-			path = os.dir(p.scanner.file_path) + '/' + path
+			path = filepath.dir(p.scanner.file_path) + '/' + path
 			if !os.exists(path) {
 				p.error('vweb HTML template "$path" not found')
 			}

--- a/vlib/compiler/live.v
+++ b/vlib/compiler/live.v
@@ -1,7 +1,10 @@
 module compiler
 
-import os
-import time
+import (
+	os
+	time
+	filepath
+)
 
 fn (v &V) generate_hotcode_reloading_compiler_flags() []string {
 	mut a := []string
@@ -52,7 +55,7 @@ fn (v &V) generate_hotcode_reloading_main_caller() {
 	// We are in live code reload mode, so start the .so loader in the background
 	mut cgen := v.cgen
 	cgen.genln('')
-	file_base := os.filename(v.dir).replace('.v', '')
+	file_base := filepath.filename(v.dir).replace('.v', '')
 	if v.os != .windows {
 		// unix:
 		so_name := file_base + '.so'
@@ -77,7 +80,7 @@ fn (v &V) generate_hot_reload_code() {
 	// Hot code reloading
 	if v.pref.is_live {
 		mut file := os.realpath(v.dir)
-		file_base := os.filename(file).replace('.v', '')
+		file_base := filepath.filename(file).replace('.v', '')
 		so_name := file_base + '.so'
 		// Need to build .so file before building the live application
 		// The live app needs to load this .so file on initialization.

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -777,7 +777,7 @@ pub fn (v &V) get_user_files() []string {
 			v.log('> That brings in all other ordinary .v files in the same module too .')
 		}
 		user_files << single_test_v_file
-		dir = os.basedir(single_test_v_file)
+		dir = filepath.basedir(single_test_v_file)
 	}
 	if dir.ends_with('.v') || dir.ends_with('.vsh') {
 		single_v_file := dir
@@ -898,7 +898,7 @@ pub fn new_v(args []string) &V {
 	// optional, custom modules search path
 	user_mod_path := get_cmdline_option(args, '-user_mod_path', '')
 	// Location of all vlib files
-	vroot := os.dir(vexe_path())
+	vroot := filepath.dir(vexe_path())
 	vlib_path := get_cmdline_option(args, '-vlib-path', filepath.join(vroot,'vlib'))
 	vpath := get_cmdline_option(args, '-vpath', v_modules_path)
 	mut vgen_buf := strings.new_builder(1000)
@@ -1033,7 +1033,7 @@ pub fn new_v(args []string) &V {
 	mut out_name_c := get_vtmp_filename(out_name, '.tmp.c')
 	cflags := get_cmdline_cflags(args)
 	rdir := os.realpath(dir)
-	rdir_name := os.filename(rdir)
+	rdir_name := filepath.filename(rdir)
 	if '-bare' in args {
 		verror('use -freestanding instead of -bare')
 	}
@@ -1095,7 +1095,7 @@ pub fn new_v(args []string) &V {
 		os: _os
 		out_name: out_name
 		dir: dir
-		compiled_dir: if os.is_dir(rdir) { rdir } else { os.dir(rdir) }
+		compiled_dir: if os.is_dir(rdir) { rdir } else { filepath.dir(rdir) }
 		lang_dir: vroot
 		table: new_table(obfuscate)
 		out_name_c: out_name_c
@@ -1144,7 +1144,7 @@ pub fn vfmt(args []string) {
 	}
 	vexe := vexe_path()
 	// launch_tool('vfmt', '-d vfmt')
-	vroot := os.dir(vexe)
+	vroot := filepath.dir(vexe)
 	os.chdir(vroot)
 	println('building vfmt... (it will be cached soon)')
 	ret := os.system('$vexe -o $vroot/tools/vfmt -d vfmt v.v')

--- a/vlib/compiler/module_header.v
+++ b/vlib/compiler/module_header.v
@@ -28,7 +28,7 @@ mut:
 fn generate_vh(mod string) {
 	println('\n\n\n\nGenerating a V header file for module `$mod`')
 	vexe := vexe_path()
-	full_mod_path := filepath.join(os.dir(vexe),mod)
+	full_mod_path := filepath.join(filepath.dir(vexe),mod)
 	dir := if mod.starts_with('vlib') { '$compiler.v_modules_path${os.path_separator}$mod' } else { mod }
 	path := dir + '.vh'
 	pdir := dir.all_before_last(os.path_separator)

--- a/vlib/compiler/modules.v
+++ b/vlib/compiler/modules.v
@@ -165,7 +165,7 @@ fn (v mut V) set_module_lookup_paths() {
 	// 4.2) search in ~/.vmodules/ (i.e. modules installed with vpm) (no -vpath)
 	v.module_lookup_paths = []
 	if v.pref.is_test {
-		v.module_lookup_paths << os.basedir(v.compiled_dir) // pdir of _test.v
+		v.module_lookup_paths << filepath.basedir(v.compiled_dir) // pdir of _test.v
 	}
 	v.module_lookup_paths << v.compiled_dir
 	v.module_lookup_paths << filepath.join(v.compiled_dir,'modules')

--- a/vlib/compiler/msvc.v
+++ b/vlib/compiler/msvc.v
@@ -1,6 +1,9 @@
 module compiler
 
-import os
+import (
+	os
+	filepath
+)
 
 #flag windows -l shell32
 #flag windows -l dbghelp
@@ -311,7 +314,7 @@ fn build_thirdparty_obj_file_with_msvc(path string, moduleflags []CFlag) {
 		return
 	}
 	println('$obj_path not found, building it (with msvc)...')
-	parent := os.dir(obj_path)
+	parent := filepath.dir(obj_path)
 	files := os.ls(parent)or{
 		panic(err)
 	}

--- a/vlib/compiler/parser.v
+++ b/vlib/compiler/parser.v
@@ -6,6 +6,7 @@ module compiler
 import (
 	os
 	strings
+	filepath
 	compiler.x64
 	// time
 )
@@ -2317,7 +2318,7 @@ struct IndexConfig {
 
 // for debugging only
 fn (p &Parser) fileis(s string) bool {
-	return os.filename(p.scanner.file_path).contains(s)
+	return filepath.filename(p.scanner.file_path).contains(s)
 }
 
 // in and dot have higher priority than `!`

--- a/vlib/compiler/preludes/tests_with_stats.v
+++ b/vlib/compiler/preludes/tests_with_stats.v
@@ -9,9 +9,12 @@ module main
 /// code, instead of in embedded C ...
 ///////////////////////////////////////////////////////////////////////
 
-import os
-import benchmark
-import term
+import (
+	os
+	term
+	filepath
+	benchmark
+)
 
 struct BenchedTests {
 mut:
@@ -75,7 +78,7 @@ fn (b &BenchedTests) fn_name() string {
 // Called at the end of the test program produced by `v -stats file_test.v`
 fn (b mut BenchedTests) end_testing() {
 	b.bench.stop()
-	println( '     ' + b.bench.total_message('running V tests in "' + os.filename(b.test_suit_file) + '"' ) )
+	println( '     ' + b.bench.total_message('running V tests in "' + filepath.filename(b.test_suit_file) + '"' ) )
 }
 
 /////////////////////////////////////////////////////////////////////

--- a/vlib/compiler/tests/repl/runner/runner.v
+++ b/vlib/compiler/tests/repl/runner/runner.v
@@ -1,6 +1,9 @@
 module runner
 
-import os
+import (
+	os
+	filepath
+)
 
 struct RunnerOptions {
 pub:
@@ -17,7 +20,7 @@ pub fn full_path_to_v(dirs_in int) string {
 	vname := if os.user_os() == 'windows' { 'v.exe' } else { 'v' }
 	mut path := os.executable()
 	for i := 0; i < dirs_in; i++ {
-		path = os.dir(path)
+		path = filepath.dir(path)
 	}
 	vexec := path + os.path_separator + vname
 	/*

--- a/vlib/compiler/vtmp.v
+++ b/vlib/compiler/vtmp.v
@@ -18,6 +18,5 @@ pub fn get_vtmp_folder() string {
 
 pub fn get_vtmp_filename(base_file_name string, postfix string) string {
 	vtmp := get_vtmp_folder()
-	return os.realpath(filepath.join(vtmp,os.filename(os.realpath(base_file_name)) + postfix))
+	return os.realpath(filepath.join(vtmp,filepath.filename(os.realpath(base_file_name)) + postfix))
 }
-

--- a/vlib/compiler/vtools.v
+++ b/vlib/compiler/vtools.v
@@ -1,10 +1,13 @@
 module compiler
 
-import os
+import (
+	os
+	filepath
+)
 
 pub fn launch_tool(tname string) {
 	vexe := vexe_path()
-	vroot := os.dir(vexe)
+	vroot := filepath.dir(vexe)
 	mut oargs := os.args
 	oargs[0] = '"$vexe"' // make it more explicit
 	tool_exe := os.realpath('$vroot/tools/$tname')

--- a/vlib/filepath/filepath.v
+++ b/vlib/filepath/filepath.v
@@ -3,18 +3,16 @@ module filepath
 import (
 	os
 )
-// return the extension in the file `path`
 
-
+// ext returns the extension in the file `path`.
 pub fn ext(path string) string {
-	pos := path.last_index_byte(`.`)
-	if pos != -1 {
-		return path[pos..]
+	pos := path.last_index('.') or {
+		return ''
 	}
-	return ''
+	return path[pos..]
 }
 
-// returns true if `path` is absolute
+// is_abs returns true if `path` is absolute.
 pub fn is_abs(path string) bool {
 	$if windows {
 		return path[0] == `/` || // incase we're in MingGW bash
@@ -23,8 +21,7 @@ pub fn is_abs(path string) bool {
 	return path[0] == `/`
 }
 
-// pass directories as parameters, returns path as string
-// TODO use []string.join once ...string becomes "[]string"
+// join returns path as string from string parameter(s).
 pub fn join(base string, dirs ...string) string {
 	mut result := []string
 	result << base.trim_right('\\/')
@@ -34,3 +31,27 @@ pub fn join(base string, dirs ...string) string {
 	return result.join(os.path_separator)
 }
 
+// dir returns all but the last element of path, typically the path's directory.
+pub fn dir(path string) string {
+	if path == '.' {
+		return os.getwd()
+	}
+	pos := path.last_index(os.path_separator) or {
+		return '.'
+	}
+	return path[..pos]
+}
+
+// basedir returns a directory name from path
+pub fn basedir(path string) string {
+	pos := path.last_index(os.path_separator) or {
+		return path
+	}
+	// NB: *without* terminating /
+	return path[..pos]
+}
+
+// filename returns a file name from path
+pub fn filename(path string) string {
+	return path.all_after(os.path_separator)
+}

--- a/vlib/filepath/filepath_test.v
+++ b/vlib/filepath/filepath_test.v
@@ -7,8 +7,11 @@ fn test_ext() {
 
 fn test_is_abs() {
 	assert filepath.is_abs('/home/user') == true
-	assert filepath.is_abs('C:\\Windows\\') == true
 	assert filepath.is_abs('v/vlib') == false
+
+	$if windows {
+		assert filepath.is_abs('C:\\Windows\\') == true
+	}
 }
 
 fn test_join() {

--- a/vlib/filepath/filepath_test.v
+++ b/vlib/filepath/filepath_test.v
@@ -1,0 +1,40 @@
+import filepath
+
+fn test_ext() {
+	assert filepath.ext('file.v') == '.v'
+	assert filepath.ext('file') == ''
+}
+
+fn test_is_abs() {
+	assert filepath.is_abs('/home/user') == true
+	assert filepath.is_abs('C:\\Windows\\') == true
+	assert filepath.is_abs('v/vlib') == false
+}
+
+fn test_join() {
+	$if windows {
+		assert filepath.join('v', 'vlib', 'filepath') == 'v\\vlib\\filepath'
+	} $else {
+		assert filepath.join('v', 'vlib', 'filepath') == 'v/vlib/filepath'
+	}
+}
+
+fn test_dir() {
+	$if windows {
+		assert filepath.dir('C:\\a\\b\\c') == 'C:\\a\\b'
+	} $else {
+		assert filepath.dir('/var/tmp/foo') == '/var/tmp'
+	}
+
+	assert filepath.dir('filepath') == '.'
+}
+
+fn test_basedir() {
+	$if windows {
+		assert filepath.basedir('v\\vlib\\filepath') == 'v\\vlib'
+	} $else {
+		assert filepath.basedir('v/vlib/filepath') == 'v/vlib'
+	}
+
+	assert filepath.basedir('filename') == 'filename'
+}

--- a/vlib/freetype/freetype.v
+++ b/vlib/freetype/freetype.v
@@ -10,6 +10,7 @@ import (
 	gg
 	glm
 	gl
+	filepath
 )
 
 #flag windows -I @VROOT/thirdparty/freetype/include
@@ -175,7 +176,7 @@ pub fn new_context(cfg gg.Cfg) &FreeType {
 	}
 	if !os.exists(font_path) {
 		exe_path := os.executable()
-		exe_dir := os.basedir(exe_path)
+		exe_dir := filepath.basedir(exe_path)
 		font_path = '$exe_dir/$font_path'
 	}
 	if !os.exists(font_path) {

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -67,8 +67,8 @@ pub fn (l mut Log) set_output_level(level LogLevel){
 
 pub fn (l mut Log) set_full_logpath(full_log_path string) {
 	rlog_file := os.realpath( full_log_path )
-	l.set_output_label( os.filename( rlog_file ) )
-	l.set_output_path( os.basedir( rlog_file ) )
+	l.set_output_label( filepath.filename( rlog_file ) )
+	l.set_output_path( filepath.basedir( rlog_file ) )
 }
 
 pub fn (l mut Log) set_output_label(label string){

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -169,7 +169,7 @@ pub fn cp_r(osource_path, odest_path string, overwrite bool) ?bool {
 	}
 	// single file copy
 	if !os.is_dir(source_path) {
-		adjasted_path := if os.is_dir(dest_path) { filepath.join(dest_path,os.filename(source_path)) } else { dest_path }
+		adjasted_path := if os.is_dir(dest_path) { filepath.join(dest_path,filepath.filename(source_path)) } else { dest_path }
 		if os.exists(adjasted_path) {
 			if overwrite {
 				os.rm(adjasted_path)
@@ -611,40 +611,28 @@ fn print_c_errno() {
 	// C.printf('errno=%d err="%s"\n', C.errno, C.strerror(C.errno))
 }
 
+[deprecated]
 pub fn ext(path string) string {
-	pos := path.last_index('.') or {
-		return ''
-	}
-	return path[pos..]
+	println('Use filepath.ext')
+	return filepath.ext(path)
 }
 
-// dir returns all but the last element of path, typically the path's directory.
+[deprecated]
 pub fn dir(path string) string {
-	if path == '.' {
-		return getwd()
-	}
-	pos := path.last_index(path_separator) or {
-		return '.'
-	}
-	return path[..pos]
+	println('Use filepath.dir')
+	return filepath.ext(path)
 }
 
-fn path_sans_ext(path string) string {
-	pos := path.last_index('.') or {
-		return path
-	}
-	return path[..pos]
-}
-
+[deprecated]
 pub fn basedir(path string) string {
-	pos := path.last_index(path_separator) or {
-		return path
-	}
-	return path[..pos] // NB: *without* terminating /
+	println('Use filepath.basedir')
+	return filepath.basedir(path)
 }
 
+[deprecated]
 pub fn filename(path string) string {
-	return path.all_after(path_separator)
+	println('Use filepath.filename')
+	return filepath.filename(path)
 }
 
 // get_line returns a one-line string from stdin

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -88,15 +88,6 @@ fn test_create_and_delete_folder() {
   assert folder_exists == false
 }
 
-fn test_dir() {
-	$if windows {
-		assert os.dir('C:\\a\\b\\c') == 'C:\\a\\b'
-
-	} $else {
-		assert os.dir('/var/tmp/foo') == '/var/tmp'
-	}
-}
-
 fn walk_callback(file string) {
     if file == '.' || file == '..' {
         return

--- a/vlib/sdl/examples/tvintris/tvintris.v
+++ b/vlib/sdl/examples/tvintris/tvintris.v
@@ -19,7 +19,7 @@ import sdl.ttf as ttf
 
 const (
 	Title = 'tVintris'
-	BASE = os.dir( os.realpath( os.executable() ) )
+	BASE = filepath.dir( os.realpath( os.executable() ) )
 	FontName = BASE + '/fonts/RobotoMono-Regular.ttf'
 	MusicName = BASE + '/sounds/TwintrisThosenine.mod'
 	SndBlockName = BASE + '/sounds/block.wav'


### PR DESCRIPTION
## Changelog

- Moved `dir`, `basedir`, `filename` functions from `os` module to `filepath` module
- Removed `os.path_sans_ext` function
This function is not used anywhere. Let me know if it should be moved back.
- Added tests for `filepath` module
I didn't change functions; I just replaced them to `filepath` module.

The functions in `os` module are actually not removed, but are marked as deprecated. I noticed two ways to deprecate functions:
1. Mark function with `[deprecated]` line, and put `panic` call inside the function.
2. Mark funciton with `[deprecated]` line, but:
 a. Print warning message, e.g. "Use newmodule.newfunction"
 b. Forward result of `newmodule.newfunction` call.

I went with the second option. Please let me know if I was wrong, and the first option should be used.

Resolves #3179.