### PR TITLE
time: improve tests

### DIFF
--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -1,237 +1,179 @@
 import time
 
+const (
+	time_to_test = time.new_time(time.Time {
+		year: 1980, month:	7, day: 11,
+		hour: 21, minute: 23, second: 42
+	})
+)
+
 fn test_is_leap_year() {
-    assert time.is_leap_year(1700) == false
-    assert time.is_leap_year(1800) == false
-    assert time.is_leap_year(1900) == false
+	// 1996 % 4 = 0 and 1996 % 100 > 0
+	assert time.is_leap_year(1996) == true
 
-    assert time.is_leap_year(1600) == true
-    assert time.is_leap_year(2000) == true
+	// 2000 % 4 = 0 and 2000 % 400 = 0
+	assert time.is_leap_year(2000) == true
 
-    assert time.is_leap_year(2100) == false
-    assert time.is_leap_year(2200) == false
-    assert time.is_leap_year(2300) == false
+	// 1996 % 4 > 0
+	assert time.is_leap_year(1997) == false
 
-    assert time.is_leap_year(1996) == true
-    assert time.is_leap_year(1997) == false
+	// 2000 % 4 = 0 and 2000 % 100 = 0
+	assert time.is_leap_year(2100) == false
 }
 
-fn check(month, year, expected int) bool {
+fn check_days_in_month(month, year, expected int) bool {
 	res := time.days_in_month(month, year) or {
 		return false
 	}
-	return res == expected 
+	return res == expected
 }
 
 fn test_days_in_month() {
-	assert check(1, 2001, 31) // January
-	assert check(2, 2001, 28) // February
-	assert check(2, 2000, 29) // February (leap)
-	assert check(3, 2001, 31) // March
-	assert check(4, 2001, 30) // April
-	assert check(5, 2001, 31) // May
-	assert check(6, 2001, 30) // June
-	assert check(7, 2001, 31) // July
-	assert check(8, 2001, 31) // August
-	assert check(9, 2001, 30) // September
-	assert check(10, 2001, 31) // October
-	assert check(11, 2001, 30) // November
-	assert check(12, 2001, 31) // December
+	days_in_month := [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+	for i, days in days_in_month {
+		month := i + 1
+
+		assert check_days_in_month(month, 2001, days)
+	}
 }
 
-
 fn test_unix() {
-	t := time.unix(1564366499) 
+	t := time.unix(1564366499)
 	assert t.year == 2019
-	assert t.month == 7 
-	assert t.day == 29 
-	assert t.hour == 2 
-	assert t.minute == 14 
-	//assert t.second == 32  // TODO broken 
-} 
+	assert t.month == 7
+	assert t.day == 29
+	assert t.hour == 2
+	assert t.minute == 14
+	assert t.second == 59
+}
 
 fn test_format_ss() {
-        t :=    time.Time{  year:     1980,
-                            month:    7,
-                            day:      11,
-                            hour:     21,
-                            minute:   23,
-                            second:   42,
-                            uni:      0 }
+	assert '11.07.1980 21:23:42' == time_to_test.get_fmt_str(.dot, .hhmmss24, .ddmmyyyy)
+}
 
-        assert  '11.07.1980 21:23:42' == t.get_fmt_str(.dot,
-                                                       .hhmmss24,
-                                                       .ddmmyyyy)
+fn test_smonth() {
+	month_names := [
+		'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+		'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+	]
+
+	for i, name in month_names {
+		month_num := i + 1
+
+		t := time.Time {
+			year: 1980, month: month_num, day: 1,
+			hour: 0, minute: 0, second: 0, uni: 0
+		}
+
+		assert t.smonth() == name
+	}
 }
 
 fn test_format() {
-        t :=    time.Time{  year:     1980,
-                            month:    7,
-                            day:      11,
-                            hour:     21,
-                            minute:   23,
-                            second:   42,
-                            uni:      0 }
-
-        assert  '11.07.1980 21:23' == t.get_fmt_str(.dot,
-                                                    .hhmm24,
-                                                    .ddmmyyyy)
+	assert '11.07.1980 21:23' == time_to_test.get_fmt_str(.dot, .hhmm24, .ddmmyyyy)
 }
 
 fn test_hhmm() {
-        t :=    time.Time{  year:     1980,
-                            month:    7,
-                            day:      11,
-                            hour:     21,
-                            minute:   23,
-                            second:   42,
-                            uni:      0 }
-
-        assert  '21:23' == t.get_fmt_time_str(.hhmm24)
+	assert '21:23' == time_to_test.hhmm()
 }
 
 fn test_hhmm12() {
-        t :=    time.Time{  year:     1980,
-                            month:    7,
-                            day:      11,
-                            hour:     21,
-                            minute:   23,
-                            second:   42,
-                            uni:      0 }
-
-        assert  '9:23 p.m.' == t.get_fmt_time_str(.hhmm12)
+	assert '9:23 p.m.' == time_to_test.hhmm12()
 }
 
 fn test_hhmmss() {
-        t :=    time.Time{  year:     1980,
-                            month:    7,
-                            day:      11,
-                            hour:     21,
-                            minute:   23,
-                            second:   42,
-                            uni:      0 }
-
-        assert  '21:23:42' == t.get_fmt_time_str(.hhmmss24)
+	assert '21:23:42' == time_to_test.hhmmss()
 }
 
 fn test_ymmdd() {
-        t :=    time.Time{  year:     1980,
-                            month:    7,
-                            day:      11,
-                            hour:     21,
-                            minute:   23,
-                            second:   42,
-                            uni:      0 }
-
-        assert  '1980-07-11' == t.get_fmt_date_str(.hyphen,
-                                                   .yyyymmdd)
+	assert '1980-07-11' == time_to_test.ymmdd()
 }
 
 fn test_ddmmy() {
-        t :=    time.Time{  year:     1980,
-                            month:    7,
-                            day:      11,
-                            hour:     21,
-                            minute:   23,
-                            second:   42,
-                            uni:      0 }
-
-        assert  '11.07.1980' == t.get_fmt_date_str(.dot,
-                                                   .ddmmyyyy)
+	assert '11.07.1980' == time_to_test.ddmmy()
 }
 
 fn test_md() {
-        t :=    time.Time{  year:     1980,
-                            month:    7,
-                            day:      11,
-                            hour:     21,
-                            minute:   23,
-                            second:   42,
-                            uni:      0 }
+	assert 'Jul 11' == time_to_test.md()
+}
 
-        assert 'Jul 11' == t.get_fmt_date_str(.space,
-                                              .mmmd)
+fn test_day_of_week() {
+	for i := 0; i < 7; i++ {
+		day_of_week := i + 1
+
+		// 2 Dec 2019 is Monday
+		t := time.Time {
+			year: 2019, month: 12, day: 2 + i,
+			hour: 0, minute: 0, second: 0, uni: 0
+		}
+
+		assert day_of_week == t.day_of_week()
+	}
+}
+
+fn test_weekday_str() {
+	day_names := ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+	for i, name in day_names {
+		// 2 Dec 2019 is Monday
+		t := time.Time {
+			year: 2019, month: 12, day: 2 + i,
+			hour: 0, minute: 0, second: 0, uni: 0
+		}
+
+		assert t.weekday_str() == name
+	}
+}
+
+fn test_add_days() {
+	num_of_days := 3
+	t := time_to_test.add_days(num_of_days)
+
+	assert t.day == time_to_test.day + num_of_days
 }
 
 fn test_get_fmt_time_str() {
-        t :=    time.Time{  year:     1980,
-                            month:    7,
-                            day:      11,
-                            hour:     21,
-                            minute:   23,
-                            second:   42,
-                            uni:      0 }
-
-        assert  '21:23:42' == t.get_fmt_time_str(.hhmmss24)
-        assert  '21:23' == t.get_fmt_time_str(.hhmm24)
-        assert  '9:23:42 p.m.' == t.get_fmt_time_str(.hhmmss12)
-        assert  '9:23 p.m.' == t.get_fmt_time_str(.hhmm12)
+	assert '21:23:42' == time_to_test.get_fmt_time_str(.hhmmss24)
+	assert '21:23' == time_to_test.get_fmt_time_str(.hhmm24)
+	assert '9:23:42 p.m.' == time_to_test.get_fmt_time_str(.hhmmss12)
+	assert '9:23 p.m.' == time_to_test.get_fmt_time_str(.hhmm12)
 }
 
 fn test_get_fmt_date_str() {
-        t :=    time.Time{  year:     1980,
-                            month:    7,
-                            day:      11,
-                            hour:     21,
-                            minute:   23,
-                            second:   42,
-                            uni:      0 }
+	assert '11.07.1980' == time_to_test.get_fmt_date_str(.dot, .ddmmyyyy)
+	assert '11/07/1980' == time_to_test.get_fmt_date_str(.slash, .ddmmyyyy)
+	assert '11-07-1980' == time_to_test.get_fmt_date_str(.hyphen, .ddmmyyyy)
+	assert '11 07 1980' == time_to_test.get_fmt_date_str(.space, .ddmmyyyy)
 
-        assert  '11.07.1980' == t.get_fmt_date_str(.dot,
-                                                   .ddmmyyyy)
-        assert  '11/07/1980' == t.get_fmt_date_str(.slash,
-                                                   .ddmmyyyy)
-        assert  '11-07-1980' == t.get_fmt_date_str(.hyphen,
-                                                   .ddmmyyyy)
-        assert  '11 07 1980' == t.get_fmt_date_str(.space,
-                                                   .ddmmyyyy)
-        assert  '07.11.1980' == t.get_fmt_date_str(.dot,
-                                                   .mmddyyyy)
-        assert  '07/11/1980' == t.get_fmt_date_str(.slash,
-                                                   .mmddyyyy)
-        assert  '07-11-1980' == t.get_fmt_date_str(.hyphen,
-                                                   .mmddyyyy)
-        assert  '07 11 1980' == t.get_fmt_date_str(.space,
-                                                   .mmddyyyy)
-        assert  '11.07.80'   == t.get_fmt_date_str(.dot,
-                                                   .ddmmyy)
-        assert  '11/07/80'   == t.get_fmt_date_str(.slash,
-                                                   .ddmmyy)
-        assert  '11-07-80'   == t.get_fmt_date_str(.hyphen,
-                                                   .ddmmyy)
-        assert  '11 07 80'   == t.get_fmt_date_str(.space,
-                                                   .ddmmyy)
-        assert  '07.11.80'   == t.get_fmt_date_str(.dot,
-                                                   .mmddyy)
-        assert  '07/11/80'   == t.get_fmt_date_str(.slash,
-                                                   .mmddyy)
-        assert  '07-11-80'   == t.get_fmt_date_str(.hyphen,
-                                                   .mmddyy)
-        assert  '07 11 80'   == t.get_fmt_date_str(.space,
-                                                   .mmddyy)
-        assert  'Jul 11'     == t.get_fmt_date_str(.space,
-                                                   .mmmd)
-        assert  'Jul 11'     == t.get_fmt_date_str(.space,
-                                                   .mmmdd)
-        assert  'Jul 11 1980' == t.get_fmt_date_str(.space,
-                                                    .mmmddyyyy)
-        assert  '1980-07-11'  == t.get_fmt_date_str(.hyphen,
-                                                    .yyyymmdd)
+	assert '07.11.1980' == time_to_test.get_fmt_date_str(.dot, .mmddyyyy)
+	assert '07/11/1980' == time_to_test.get_fmt_date_str(.slash, .mmddyyyy)
+	assert '07-11-1980' == time_to_test.get_fmt_date_str(.hyphen,	.mmddyyyy)
+	assert '07 11 1980' == time_to_test.get_fmt_date_str(.space, .mmddyyyy)
+
+	assert '11.07.80' == time_to_test.get_fmt_date_str(.dot, .ddmmyy)
+	assert '11/07/80' == time_to_test.get_fmt_date_str(.slash, .ddmmyy)
+	assert '11-07-80' == time_to_test.get_fmt_date_str(.hyphen, .ddmmyy)
+	assert '11 07 80' == time_to_test.get_fmt_date_str(.space, .ddmmyy)
+
+	assert '07.11.80' == time_to_test.get_fmt_date_str(.dot, .mmddyy)
+	assert '07/11/80' == time_to_test.get_fmt_date_str(.slash, .mmddyy)
+	assert '07-11-80' == time_to_test.get_fmt_date_str(.hyphen, .mmddyy)
+	assert '07 11 80' == time_to_test.get_fmt_date_str(.space, .mmddyy)
+
+	assert 'Jul 11' == time_to_test.get_fmt_date_str(.space, .mmmd)
+	assert 'Jul 11' == time_to_test.get_fmt_date_str(.space, .mmmdd)
+
+	assert 'Jul 11 1980' == time_to_test.get_fmt_date_str(.space, .mmmddyyyy)
+
+	assert '1980-07-11' == time_to_test.get_fmt_date_str(.hyphen, .yyyymmdd)
 }
 
 fn test_get_fmt_str() {
-        t :=    time.Time{  year:     1980,
-                            month:    7,
-                            day:      11,
-                            hour:     21,
-                            minute:   23,
-                            second:   42,
-                            uni:      0 }
-
-        // Since get_fmt_time_str and get_fmt_date_str do have comprehensive
-        // tests I don't want to exaggerate here with all possible
-        // combinations.
-        assert  '11.07.1980 21:23:42' == t.get_fmt_str(.dot,
-                                                       .hhmmss24,
-                                                       .ddmmyyyy)
+	// Since get_fmt_time_str and get_fmt_date_str do have comprehensive
+	// tests I don't want to exaggerate here with all possible
+	// combinations.
+	assert '11.07.1980 21:23:42' == time_to_test.get_fmt_str(
+		.dot, .hhmmss24, .ddmmyyyy
+	)
 }


### PR DESCRIPTION
## Changelog

- Added more tests
Added tests for `smonth`, `day_of_week`, `weekday_str` functions.
- Defined time object as const
- Formatted test module
Removed multiple spaces.
Used consistent tab indentation instead of mixed tabs and spaces.
- Removed redundant cases in `test_is_leap_year`
Keep 4 cases only to check all conditions in `is_leap_year` function.
Using multiple cases is redundant.
- Updated several tests
Use the respective functions in `test_hhmm`, `test_hhmm12` and similar tests instead of calling `get_fmt_date_str` function.