### PR TITLE
vup: fix 'v up' on windows

### DIFF
--- a/tools/vup.v
+++ b/tools/vup.v
@@ -1,3 +1,5 @@
+module main
+
 import os
 
 fn main() {
@@ -11,7 +13,7 @@ fn main() {
 		if os.exists( v_backup_file ) {
 			os.rm( v_backup_file )
 		}
-		os.mv_by_cp('$vroot/v.exe', v_backup_file) or { panic(err) }
+		os.mv('$vroot/v.exe', v_backup_file)
 		s2 := os.exec('"$vroot/make.bat"') or { panic(err) }
 		println(s2.output)
 	} $else {


### PR DESCRIPTION
This PR fixes #3148, which is a regression caused by changes in tools/vup.v:
```diff
-		os.mv('$vroot/v.exe', v_backup_file)
+		os.mv_by_cp('$vroot/v.exe', v_backup_file)
```

`os.mv_by_cp` calls `_wremove` for removing `v.exe` and fails because it requires that all handles to v.exe must be closed before it can be deleted but there is an open one since v.exe runs the tool vup.exe as a subprocess. 

`os.mv` on the other hand calls `_wrename` which has no such a requirement and allows to rename a file with open handle.
