### PR TITLE
vup: change dir correctly

### DIFF
--- a/tools/vup.v
+++ b/tools/vup.v
@@ -7,7 +7,7 @@ import (
 
 fn main() {
 	println('Updating V...')
-	vroot := os.getenv('VEXE')
+	vroot := filepath.dir(os.getenv('VEXE'))
 	os.chdir(vroot)
 	s := os.exec('git -C "$vroot" pull --rebase origin master') or { panic(err) }
 	println(s.output)


### PR DESCRIPTION
`VEXE` is a path to a file, so `os.chdir` does not work.

The solution is to get a directory name from `VEXE` path and apply it to `os.chdir`.