### PR TITLE
windows: Do not link gdi32/shell32 to console applications

### DIFF
--- a/v.v
+++ b/v.v
@@ -119,8 +119,7 @@ fn v_command(command string, args []string) {
 			// v.gen_doc_html_for_module(args.last())
 		}
 		else {
-			println('v $command: unknown command')
-			println('Run "v help" for usage.')
+			panic('v $command: unknown command\nRun "v help" for usage.')
 		}
 	}
 	exit(0)

--- a/vlib/builtin/cfns.v
+++ b/vlib/builtin/cfns.v
@@ -324,9 +324,6 @@ fn C._fullpath() int
 fn C.GetCommandLine() voidptr
 
 
-fn C.CommandLineToArgvW() &voidptr
-
-
 fn C.LocalFree()
 
 

--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -263,6 +263,9 @@ fn (v mut V) cc() {
 	if v.os == .mac {
 		a << '-mmacosx-version-min=10.7'
 	}
+	if v.os == .windows {
+		a << '-municode'
+	}
 	cflags := v.get_os_cflags()
 	// add .o files
 	a << cflags.c_options_only_object_files()

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -557,10 +557,42 @@ pub fn (v mut V) generate_main() {
 }
 
 pub fn (v mut V) gen_main_start(add_os_args bool) {
-	v.cgen.genln('int main(int argc, char** argv) { ')
+	if (v.os == .windows) {
+		if 'glfw' in v.table.imports {
+			v.cgen.genln('#ifdef V_BOOTSTRAP')
+			v.cgen.genln('int main(int argc, char** argv) { ')
+			v.cgen.genln('#else')
+			// GUI application
+			v.cgen.genln('int WINAPI wWinMain(HINSTANCE instance, HINSTANCE prev_instance, LPWSTR cmd_line, int show_cmd) { ')
+			v.cgen.genln('    typedef LPWSTR*(WINAPI *cmd_line_to_argv)(LPCWSTR, int*);')
+			v.cgen.genln('    HMODULE shell32_module = LoadLibrary(L"shell32.dll");')
+			v.cgen.genln('    cmd_line_to_argv CommandLineToArgvW = (cmd_line_to_argv)GetProcAddress(shell32_module, "CommandLineToArgvW");')
+			v.cgen.genln('    int argc;')
+			v.cgen.genln('    wchar_t** argv = CommandLineToArgvW(cmd_line, &argc);')
+			v.cgen.genln('    os__args = os__init_os_args_wide(argc, argv);')			
+			v.cgen.genln('#endif')
+		} else {
+			v.cgen.genln('#ifdef V_BOOTSTRAP')
+			v.cgen.genln('int main(int argc, char** argv) { ')
+			v.cgen.genln('#else')			
+			// Console application
+			v.cgen.genln('int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) { ')			
+			v.cgen.genln('#endif')
+		}
+	} else {
+		v.cgen.genln('int main(int argc, char** argv) { ')
+	}
 	v.cgen.genln('  init();')
 	if add_os_args && 'os' in v.table.imports {
-		v.cgen.genln('  os__args = os__init_os_args(argc, (byteptr*)argv);')
+		if v.os == .windows {
+			v.cgen.genln('#ifdef V_BOOTSTRAP')
+			v.cgen.genln('  os__args = os__init_os_args(argc, (byteptr*)argv);')
+			v.cgen.genln('#else')
+			v.cgen.genln('  os__args = os__init_os_args_wide(argc, argv);')
+			v.cgen.genln('#endif')
+		} else {
+			v.cgen.genln('  os__args = os__init_os_args(argc, (byteptr*)argv);')
+		}
 	}
 	v.generate_hotcode_reloading_main_caller()
 	v.cgen.genln('')

--- a/vlib/compiler/msvc.v
+++ b/vlib/compiler/msvc.v
@@ -246,7 +246,7 @@ pub fn (v mut V) cc_msvc() {
 	// Emily:
 	// Not all of these are needed (but the compiler should discard them if they are not used)
 	// these are the defaults used by msbuild and visual studio
-	mut real_libs := ['kernel32.lib', 'user32.lib', 'gdi32.lib', 'winspool.lib', 'comdlg32.lib', 'advapi32.lib', 'shell32.lib', 'ole32.lib', 'oleaut32.lib', 'uuid.lib', 'odbc32.lib', 'odbccp32.lib']
+	mut real_libs := ['kernel32.lib', 'user32.lib', 'advapi32.lib']
 	sflags := v.get_os_cflags().msvc_string_flags()
 	real_libs << sflags.real_libs
 	inc_paths := sflags.inc_paths

--- a/vlib/glfw/glfw.v
+++ b/vlib/glfw/glfw.v
@@ -21,7 +21,7 @@ import gl
 #flag freebsd -I/usr/local/include
 #flag freebsd -Wl,-L/usr/local/lib,-lglfw
 #flag linux -lglfw
-#flag windows -lglfw3
+#flag windows -lgdi32 -lshell32 -lglfw3
 #include <GLFW/glfw3.h>
 // #flag darwin -framework Carbon
 // #flag darwin -framework Cocoa

--- a/vlib/os/os_windows.v
+++ b/vlib/os/os_windows.v
@@ -74,15 +74,19 @@ mut:
 	bInheritHandle bool
 }
 
-fn init_os_args(argc int, argv &byteptr) []string {
+fn init_os_args(argc int, argv &byteptr) []string {	
 	mut args := []string
-	mut args_list := &voidptr(0)
-	mut args_count := 0
-	args_list = C.CommandLineToArgvW(C.GetCommandLine(), &args_count)
-	for i := 0; i < args_count; i++ {
-		args << string_from_wide(&u16(args_list[i]))
+	for i := 0; i < argc; i++ {
+		args << string(argv[i])
 	}
-	C.LocalFree(args_list)
+	return args
+}
+
+fn init_os_args_wide(argc int, argv &byteptr) []string {	
+	mut args := []string
+	for i := 0; i < argc; i++ {
+		args << string_from_wide(&u16(argv[i]))
+	}
 	return args
 }
 


### PR DESCRIPTION
* This speeds `v test-compiler` up on 6-10%
* glfw examples does not have console anymore :)
* temporary make.bat hacks will be removed in next PR