### PR TITLE
fmt: fixes for option syntax formatting

### DIFF
--- a/vlib/compiler/gen_c.v
+++ b/vlib/compiler/gen_c.v
@@ -99,8 +99,11 @@ fn (p mut Parser) gen_handle_option_or_else(_typ, name string, fn_call_ph int) s
 	typ = parse_pointer(typ[7..])
 	p.genln(';')
 	or_tok_idx := p.token_idx
+	p.fspace()
 	p.check(.key_orelse)
+	p.fspace()
 	p.check(.lcbr)
+	p.fspace()
 	p.register_var(Var{
 		name: 'err'
 		typ: 'string'

--- a/vlib/compiler/if_match.v
+++ b/vlib/compiler/if_match.v
@@ -208,7 +208,9 @@ fn (p mut Parser) if_statement(is_expr bool, elif_depth int) string {
 		}
 		p.open_scope()
 		p.next()
+		p.fspace()
 		p.check(.decl_assign)
+		p.fspace()
 		p.is_var_decl = true
 		option_type,expr := p.tmp_expr() // := p.bool_expression()
 		if !option_type.starts_with('Option_') {
@@ -222,6 +224,7 @@ fn (p mut Parser) if_statement(is_expr bool, elif_depth int) string {
 		// [statements]
 		// }
 		p.cgen.insert_before('$option_type $option_tmp = $expr; ')
+		p.fspace()
 		p.check(.lcbr)
 		p.genln(option_tmp + '.ok) {')
 		p.genln('$typ $var_name = *($typ*) $option_tmp . data;')


### PR DESCRIPTION
With this PR:
![if a:=opt() {](https://url4e.com/gyazo/images/5254b5ac.png)