### PR TITLE
arrays: improve `range` function

### DIFF
--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -1,6 +1,6 @@
 module arrays
 
-fn range<T>(start, end T) []T {
+pub fn range<T>(start, end T) []T {
 	mut res := []T
 	for i := start; i < end; i++ {
 		res << i

--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -1,10 +1,9 @@
 module arrays
 
 fn range<T>(start, end T) []T {
-	mut res := [start]
-	for i := start + 1; i < end; i++ {
+	mut res := []T
+	for i := start; i < end; i++ {
 		res << i
-	}	
+	}
 	return res
-}	
-
+}

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -1,10 +1,28 @@
 import arrays
 
 fn test_range() {
-	/*
-	TODO
-	a := arrays.range(1, 10)
-	assert a[0] == 1
-	println(a)
-	*/
-}	
+	start_pos := 3
+	end_pos := 10
+
+	arr1 := arrays.range<int>(start_pos, end_pos)
+	assert arr1.len == end_pos - start_pos
+	for i, c in arr1 {
+		assert c == i + start_pos
+	}
+
+	arr2 := arrays.range<f32>(start_pos, end_pos)
+	assert arr2.len == end_pos - start_pos
+	for i, c in arr2 {
+		assert c == f32(i + start_pos)
+	}
+
+	arr3 := arrays.range<int>(start_pos, 0)
+	assert arr3.len == 0
+
+	arr4 := arrays.range<int>(start_pos, start_pos)
+	assert arr4.len == 0
+
+	arr5 := arrays.range<int>(start_pos, start_pos + 1)
+	assert arr5.len == 1
+	assert arr5[0] == start_pos
+}

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -16,7 +16,7 @@ fn test_range() {
 		assert c == f32(i + start_pos)
 	}
 
-	arr3 := arrays.range<int>(start_pos, 0)
+	arr3 := arrays.range<int>(start_pos, start_pos - 1)
 	assert arr3.len == 0
 
 	arr4 := arrays.range<int>(start_pos, start_pos)


### PR DESCRIPTION
## Changelog

- Added tests for `range` function
- Made `range` function public
- Updated `range` algorithm
It's odd for me that `arrays.range` returns non-empty array, if `end` is less than `start`. This behavior differs from similar functions in other languages. Behavior proposed in the PR is the following:
  - `range(start, start - 1)` returns an empty array.
  - `range(start, start)` returns an empty array.
  - `range(start, start + count)` returns an array with `count` length.

I think new behavior is more clear and more expected for users. Please let me know if we should leave it as is. I'll update the PR to include tests only.