### PR TITLE
ci: go back to github actions/checkout@v1 for most of the CI - fixes macos CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       VFLAGS: -cc tcc
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     - name: Install dependencies
       run: sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list; sudo apt-get update; sudo apt-get install --quiet -y libglfw3 libglfw3-dev libfreetype6-dev libssl-dev sqlite3 libsqlite3-dev libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
     - name: Build v
@@ -44,7 +44,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v1
 
     - name: Build V
       uses: spytheman/docker_alpine_v@v6.0
@@ -62,7 +62,7 @@ jobs:
       matrix:
         os: [macOS-10.14, macOS-latest]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
         node-version: 12.x
@@ -101,7 +101,7 @@ jobs:
   ubuntu:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
         node-version: 12.x
@@ -162,7 +162,7 @@ jobs:
     env:
       VFLAGS: -cc musl-gcc
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
         node-version: 12.x
@@ -187,7 +187,7 @@ jobs:
     env:
         VFLAGS: -cc gcc
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     #- uses: actions/setup-node@v1
     #  with:
     #    node-version: 12.x
@@ -210,7 +210,7 @@ jobs:
     env:
         VFLAGS: -cc msvc
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     #- uses: actions/setup-node@v1
     #  with:
     #    node-version: 12.x


### PR DESCRIPTION
Github Actions CI is fixed by reverting back to actions/checkout@v1 .