### PR TITLE
make.bat: remove duplicated `nologo` argument

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -70,7 +70,7 @@ if exist "%InstallDir%\Common7\Tools\vsdevcmd.bat" (
 
 set ObjFile=.v.c.obj
 
-cl.exe /nologo /w /volatile:ms /Fo%ObjFile% /O2 /MD /D_VBOOTSTRAP vc\v_win.c user32.lib kernel32.lib advapi32.lib shell32.lib /link /NOLOGO /OUT:v2.exe /INCREMENTAL:NO
+cl.exe /nologo /w /volatile:ms /Fo%ObjFile% /O2 /MD /D_VBOOTSTRAP vc\v_win.c user32.lib kernel32.lib advapi32.lib shell32.lib /link /OUT:v2.exe /INCREMENTAL:NO
 if %ERRORLEVEL% NEQ 0 (
     echo cl.exe failed to build V
     goto :compileerror


### PR DESCRIPTION
`/nologo` argument was passed to `cl.exe` twice. This PR keeps only one argument.

@vitalyster Could you verify this change does not break things? I'm not sure if it was duplicated unintentionally.