### PR TITLE
ftp: flatten tests

### DIFF
--- a/vlib/net/ftp/ftp_test.v
+++ b/vlib/net/ftp/ftp_test.v
@@ -12,35 +12,24 @@ fn test_all() {
 	assert ftp.login('ftp','ftp')
 
 	pwd := ftp.pwd()
-	println('pwd: $pwd')
 
 	ftp.cd('/')
-	folder := ftp.dir() or {
+	dir_list1 := ftp.dir() or {
 		assert false
 		return
 	}
-	for file in folder {
-		println(file)
-	}
+	assert dir_list1.len > 0
 
 	ftp.cd('/suse/linux/enterprise/11Server/en/SAT-TOOLS/SRPMS/')
-
-	dir_list := ftp.dir() or {
+	dir_list2 := ftp.dir() or {
 		assert false
 		return
 	}
-
-	assert dir_list.len > 5
-	println('$dir_list.len files')
-	for file in dir_list {
-		println('$file')
-	}
+	assert dir_list2.len > 0
 
 	blob := ftp.get('katello-host-tools-3.3.5-8.sles11_4sat.src.rpm') or {
 		assert false
 		return
 	}
-
-	assert blob.len > 1024
-	println('downloaded $blob.len bytes')
+	assert blob.len > 0
 }

--- a/vlib/net/ftp/ftp_test.v
+++ b/vlib/net/ftp/ftp_test.v
@@ -1,57 +1,46 @@
 module main
 
-
-import ftp
+import net.ftp
 
 fn test_all() {
 	mut ftp := ftp.new()
-
-	// ftp.rediris.org
-	connected := ftp.connect('ftp.redhat.com')
-	assert connected
-	if connected { 
-		println("connected")
-
-		loggedin :=  ftp.login('ftp','ftp') 
-		assert loggedin
-		if loggedin {
-			println('logged-in')
-
-			pwd := ftp.pwd()
-			println('pwd: $pwd')
-
-			ftp.cd('/')
-
-			folder := ftp.dir() or {
-				eprintln('cannot list folder')
-				return
-			}	
-			for file in folder {
-				println(file)
-			}
-
-			ftp.cd('/suse/linux/enterprise/11Server/en/SAT-TOOLS/SRPMS/')
-				
-			dir_list := ftp.dir() or {
-				eprintln('cannot list folder')
-				return
-			}
-			
-			assert dir_list.len > 5
-			println('$dir_list.len files:')
-			for file in dir_list {
-				println('$file')
-			}
-
-			blob := ftp.get('katello-host-tools-3.3.5-8.sles11_4sat.src.rpm') or {
-				eprintln("couldn't download it")
-				return
-			}
-
-			assert blob.len > 1024
-
-			println('downloaded $blob.len bytes')
-		} 
+	defer {
 		ftp.close()
 	}
+
+	assert ftp.connect('ftp.redhat.com')
+	assert ftp.login('ftp','ftp')
+
+	pwd := ftp.pwd()
+	println('pwd: $pwd')
+
+	ftp.cd('/')
+	folder := ftp.dir() or {
+		assert false
+		return
+	}
+	for file in folder {
+		println(file)
+	}
+
+	ftp.cd('/suse/linux/enterprise/11Server/en/SAT-TOOLS/SRPMS/')
+
+	dir_list := ftp.dir() or {
+		assert false
+		return
+	}
+
+	assert dir_list.len > 5
+	println('$dir_list.len files')
+	for file in dir_list {
+		println('$file')
+	}
+
+	blob := ftp.get('katello-host-tools-3.3.5-8.sles11_4sat.src.rpm') or {
+		assert false
+		return
+	}
+
+	assert blob.len > 1024
+	println('downloaded $blob.len bytes')
 }


### PR DESCRIPTION
Nested statements are redundant: tests are stopped if an assertion is failed, so it makes no sense to check a result and continue if it's positive only.