### PR TITLE
Fix version check to prevent useless rebuilds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ ifdef ANDROID
 	chmod 755 v
 endif
 	@(VC_V=`./v version | cut -f 3 -d " "`; \
-	V_V=`git rev-parse --short HEAD`; \
+	V_V=`git rev-parse --short=7 HEAD`; \
 	if [ $$VC_V != $$V_V ]; then \
 		echo "Self rebuild ($$VC_V => $$V_V)"; \
 		$(MAKE) selfcompile; \


### PR DESCRIPTION
Trivial commit to use the same shortcommit length as set in compiler/vhash (7 bytes)
This prevents useless rebuilds when the version indeed does not differ on the first 7 bytes of the hash