### PR TITLE
Fix deprecated os.dir to work as advertised

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -616,7 +616,7 @@ pub fn ext(path string) string {
 [deprecated]
 pub fn dir(path string) string {
 	println('Use filepath.dir')
-	return filepath.ext(path)
+	return filepath.dir(path)
 }
 
 [deprecated]


### PR DESCRIPTION
Trivial fix to os.dir that did not work as advertised (result of horrible copy-pasta)