### PR TITLE
net.ftp: make ftp's tests just compile (not run) on CI

### DIFF
--- a/tools/vtest-fmt.v
+++ b/tools/vtest-fmt.v
@@ -59,6 +59,9 @@ fn v_files() []string {
 		if tfile in known_failing_exceptions {
 			continue
 		}
+		if tfile.starts_with('./vlib/v/cgen/tests') {
+			continue
+		}
 		files_that_can_be_formatted << tfile
 	}
 	return files_that_can_be_formatted

--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -3019,6 +3019,7 @@ fn (p mut Parser) attribute() {
 	if p.tok == .key_if {
 		// [if vfmt]
 		p.next()
+		p.fspace()
 		p.attr = 'if ' + p.check_name()
 	}
 	else {

--- a/vlib/compiler/vfmt.v
+++ b/vlib/compiler/vfmt.v
@@ -259,7 +259,7 @@ fn (p &Parser) gen_fmt() {
 	//s := p.scanner.fmt_out.str().replace('\n\n\n', '\n').trim_space()
 	//s := p.scanner.fmt_out.str().trim_space()
 	//p.scanner.fgenln('// nice')
-	s1 := p.scanner.fmt_lines.join('')
+	mut s := p.scanner.fmt_lines.join('')
 /*.replace_each([
 		'\n\n\n\n', '\n\n',
 		' \n', '\n',
@@ -268,13 +268,12 @@ fn (p &Parser) gen_fmt() {
 	*/
 	//.replace('\n\n\n\n', '\n\n')
 
-	s2 := s1.replace(' \n', '\n')
-	s3 := s2.replace(') or{', ') or {')
-	s4 := s3.replace(')or{', ') or {')
-	s5 := s4.replace('or{', 'or {')
-	s6 := s5.replace('}}\n', '}\n\t}\n')
-
-	s := s6
+	s = s.replace(' \n', '\n')
+	s = s.replace(')  or {', ') or {')
+	s = s.replace(') or{', ') or {')
+	s = s.replace(')or{', ') or {')
+	s = s.replace('or{', 'or {')
+	s = s.replace('}}\n', '}\n\t}\n')
 
 	if s == '' {
 		return

--- a/vlib/net/ftp/ftp_test.v
+++ b/vlib/net/ftp/ftp_test.v
@@ -2,7 +2,7 @@ module main
 
 import net.ftp
 
-fn test_client() {
+fn test_ftp_client() {
 	make_client_connection()
 	assert true
 }
@@ -10,7 +10,7 @@ fn test_client() {
 // NB: this function makes network calls to external servers,
 // that is why it is not a very good idea to run it in CI.
 // If you want to run it manually, use `v -d network vlib/net/ftp/ftp_test.v`
-[ifnetwork]
+[if network]
 fn make_client_connection() {
 	mut ftp := ftp.new()
 	defer {

--- a/vlib/net/ftp/ftp_test.v
+++ b/vlib/net/ftp/ftp_test.v
@@ -2,7 +2,12 @@ module main
 
 import net.ftp
 
-fn test_all() {
+fn test_client(){
+  make_client_connection()
+}
+
+[if network]
+fn make_client_connection() {
 	mut ftp := ftp.new()
 	defer {
 		ftp.close()
@@ -12,6 +17,7 @@ fn test_all() {
 	assert ftp.login('ftp','ftp')
 
 	pwd := ftp.pwd()
+  assert pwd.len > 0
 
 	ftp.cd('/')
 	dir_list1 := ftp.dir() or {

--- a/vlib/net/ftp/ftp_test.v
+++ b/vlib/net/ftp/ftp_test.v
@@ -21,18 +21,18 @@ fn make_client_connection() {
 	pwd := ftp.pwd()
 	assert pwd.len > 0
 	ftp.cd('/')
-	dir_list1 := ftp.dir()  or {
+	dir_list1 := ftp.dir() or {
 		assert false
 		return
 	}
 	assert dir_list1.len > 0
 	ftp.cd('/suse/linux/enterprise/11Server/en/SAT-TOOLS/SRPMS/')
-	dir_list2 := ftp.dir()  or {
+	dir_list2 := ftp.dir() or {
 		assert false
 		return
 	}
 	assert dir_list2.len > 0
-	blob := ftp.get('katello-host-tools-3.3.5-8.sles11_4sat.src.rpm')  or {
+	blob := ftp.get('katello-host-tools-3.3.5-8.sles11_4sat.src.rpm') or {
 		assert false
 		return
 	}

--- a/vlib/net/ftp/ftp_test.v
+++ b/vlib/net/ftp/ftp_test.v
@@ -3,9 +3,14 @@ module main
 import net.ftp
 
 fn test_client(){
-  make_client_connection()
+	make_client_connection()
+	assert true
 }
 
+
+// NB: this function makes network calls to external servers,
+// that is why it is not a very good idea to run it in CI.
+// If you want to run it manually, use `v -d network vlib/net/ftp/ftp_test.v`
 [if network]
 fn make_client_connection() {
 	mut ftp := ftp.new()

--- a/vlib/net/ftp/ftp_test.v
+++ b/vlib/net/ftp/ftp_test.v
@@ -2,43 +2,37 @@ module main
 
 import net.ftp
 
-fn test_client(){
+fn test_client() {
 	make_client_connection()
 	assert true
 }
 
-
 // NB: this function makes network calls to external servers,
 // that is why it is not a very good idea to run it in CI.
 // If you want to run it manually, use `v -d network vlib/net/ftp/ftp_test.v`
-[if network]
+[ifnetwork]
 fn make_client_connection() {
 	mut ftp := ftp.new()
 	defer {
 		ftp.close()
 	}
-
 	assert ftp.connect('ftp.redhat.com')
-	assert ftp.login('ftp','ftp')
-
+	assert ftp.login('ftp', 'ftp')
 	pwd := ftp.pwd()
-  assert pwd.len > 0
-
+	assert pwd.len > 0
 	ftp.cd('/')
-	dir_list1 := ftp.dir() or {
+	dir_list1 := ftp.dir()  or {
 		assert false
 		return
 	}
 	assert dir_list1.len > 0
-
 	ftp.cd('/suse/linux/enterprise/11Server/en/SAT-TOOLS/SRPMS/')
-	dir_list2 := ftp.dir() or {
+	dir_list2 := ftp.dir()  or {
 		assert false
 		return
 	}
 	assert dir_list2.len > 0
-
-	blob := ftp.get('katello-host-tools-3.3.5-8.sles11_4sat.src.rpm') or {
+	blob := ftp.get('katello-host-tools-3.3.5-8.sles11_4sat.src.rpm')  or {
 		assert false
 		return
 	}

--- a/vlib/v/cgen/cgen_test.v
+++ b/vlib/v/cgen/cgen_test.v
@@ -13,15 +13,13 @@ const (
 
 fn test_c_files() {
 	println('Running V => C tests')
-	eprintln('executable: ' + os.executable())
-	eprintln('  work dir: ' + os.getwd())
-	dir := filepath.dir(os.executable())
-	eprintln('parent dir: ' + dir)
+	vexe := os.getenv('VEXE')
+	vroot := filepath.dir(vexe)
 	for i in 1 .. nr_tests + 1 {
-		text := os.read_file('$dir/tests/${i}.v') or {
+		text := os.read_file('$vroot/vlib/v/cgen/tests/${i}.v') or {
 			panic(err)
 		}
-		ctext := os.read_file('$dir/tests/${i}.c') or {
+		ctext := os.read_file('$vroot/vlib/v/cgen/tests/${i}.c') or {
 			panic(err)
 		}
 		table := &table.Table{}

--- a/vlib/v/cgen/cgen_test.v
+++ b/vlib/v/cgen/cgen_test.v
@@ -13,7 +13,10 @@ const (
 
 fn test_c_files() {
 	println('Running V => C tests')
+	eprintln('executable: ' + os.executable())
+	eprintln('  work dir: ' + os.getwd())
 	dir := filepath.dir(os.executable())
+	eprintln('parent dir: ' + dir)
 	for i in 1 .. nr_tests + 1 {
 		text := os.read_file('$dir/tests/${i}.v') or {
 			panic(err)


### PR DESCRIPTION
This PR keeps the test compilable, but since on CI network is not passed to the tests, they will not run and make network connections to external servers.