### PR TITLE
compiler errors: print array instead of [] in function names

### DIFF
--- a/vlib/compiler/compile_errors.v
+++ b/vlib/compiler/compile_errors.v
@@ -190,13 +190,20 @@ fn (p mut Parser) print_error_context() {
 }
 
 fn normalized_error(s string) string {
-	// Print `[]int` instead of `array_int` in errors
-	mut res := s.replace('array_', '[]').replace('__', '.')
-		.replace('Option_', '?').replace('main.', '').replace('ptr_', '&')
-		.replace('_dot_', '.')
+	mut res := s
+	if !res.contains('__') {
+		// `[]int` instead of `array_int`
+		res = res.replace('array_', '[]')
+	}
+	res = res.replace('__', '.')
+	res = res.replace('Option_', '?')
+	res = res.replace('main.', '')
+	res = res.replace('ptr_', '&')
+	res = res.replace('_dot_', '.')
 	if res.contains('_V_MulRet_') {
-		res = res.replace('_V_MulRet_', '(').replace('_V_', ', ')
-		res = res[..res.len - 1] + ')"'
+		res = res.replace('_V_MulRet_', '(')
+		res = res.replace('_V_', ', ')
+		res = res[..res.len - 1] + ')"' //"// quote balance comment. do not remove
 	}
 	return res
 }


### PR DESCRIPTION
Closes issue #3256 .