### PR TITLE
vfmt: fix formatting of 'import mod as alias'

### DIFF
--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -1171,7 +1171,7 @@ fn (p mut Parser) get_type() string {
 			}
 			t = p.table.find_type(typ)
 			if t.name == '' && !p.pref.translated && !p.first_pass() && !typ.starts_with('[') {
-				println('get_type() bad type')
+				// println('get_type() bad type')
 				// println('all registered types:')
 				// for q in p.table.types {
 				// println(q.name)
@@ -1180,7 +1180,8 @@ fn (p mut Parser) get_type() string {
 				if t_suggest.len > 0 {
 					t_suggest = '. did you mean: ($tc_suggest) `$t_suggest`'
 				}
-				p.error('unknown type `$typ`$t_suggest')
+				econtext := if p.pref.is_debug { '('+@FILE+':'+@LINE+')' } else {''}
+				p.error('unknown type `$typ`$t_suggest $econtext')
 			}
 		}
 		else if !t.is_public && t.mod != p.mod && !p.is_vgen && t.name != '' && !p.first_pass() {

--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -658,7 +658,9 @@ fn (p mut Parser) import_statement() {
 	}
 	// aliasing (import encoding.base64 as b64)
 	if p.tok == .key_as && p.peek() == .name {
+		p.fspace()
 		p.check(.key_as)
+		p.fspace()
 		mod_alias = p.check_name()
 	}
 	// add import to file scope import table

--- a/vlib/compiler/get_type.v
+++ b/vlib/compiler/get_type.v
@@ -164,7 +164,7 @@ fn (p mut Parser) get_type2() Type {
 			}
 			t = p.table.find_type(typ)
 			if t.name == '' && !p.pref.translated && !p.first_pass() && !typ.starts_with('[') {
-				println('get_type() bad type')
+				//println('get_type() bad type')
 				// println('all registered types:')
 				// for q in p.table.types {
 				// println(q.name)
@@ -173,7 +173,8 @@ fn (p mut Parser) get_type2() Type {
 				if t_suggest.len > 0 {
 					t_suggest = '. did you mean: ($tc_suggest) `$t_suggest`'
 				}
-				p.error('unknown type `$typ`$t_suggest')
+				econtext := if p.pref.is_debug { '('+@FILE+':'+@LINE+')' } else {''}
+				p.error('unknown type `$typ`$t_suggest $econtext')
 			}
 		}
 		else if !t.is_public && t.mod != p.mod && !p.is_vgen && t.name != '' && !p.first_pass() {

--- a/vlib/compiler/vfmt.v
+++ b/vlib/compiler/vfmt.v
@@ -171,7 +171,9 @@ fn (p mut Parser) fnext() {
 		p.fgen_nl()
 		p.fmt_inc()
 	}
-
+	if p.token_idx >= p.tokens.len { 
+		return 
+	}
 	// Skip comments and add them to vfmt output
 	if p.tokens[p.token_idx].tok in [.line_comment, .mline_comment] {
 		// Newline before the comment and after consts and closing }


### PR DESCRIPTION
Fixes this:
> Before: import miniaudio as ma
> After: import miniaudioasma

