### PR TITLE
time_unix: fix error: array index out of range

### DIFF
--- a/vlib/time/time_unix.v
+++ b/vlib/time/time_unix.v
@@ -88,6 +88,9 @@ fn calculate_date_from_offset(day_offset_ int) (int, int, int) {
 		estimated_month++
 	}
 	for day_offset <= days_before[estimated_month] {
+		if estimated_month == 0 {
+			break
+		}
 		estimated_month--
 	}
 


### PR DESCRIPTION
time_unix: fix error: array index out of range, eg: 1/1/2020.