### PR TITLE
base64: fix warning

### DIFF
--- a/vlib/encoding/base64/base64.v
+++ b/vlib/encoding/base64/base64.v
@@ -128,9 +128,9 @@ pub fn encode_in_buffer(data &string, buffer byteptr) int {
 	mut b	   := &byte(0)
 	mut etable := &byte(0)
 	unsafe{
-		d = &byte(data.str)
-		b = &byte(buffer)
-		etable = &byte(EncodingTable.str)
+		d = data.str
+		b = buffer
+		etable = EncodingTable.str
 	}
 
 	for i < input_length {
@@ -151,7 +151,7 @@ pub fn encode_in_buffer(data &string, buffer byteptr) int {
 			i++
 		}
 
-		triple := ((int(octet_a) << 0x10) + (int(octet_b) << 0x08) + int(octet_c))
+		triple := ((octet_a << 0x10) + (octet_b << 0x08) + octet_c)
 
 		b[j]   = etable[ (triple >> 3 * 6) & 63 ]  // 63 is 0x3F
 		b[j+1] = etable[ (triple >> 2 * 6) & 63 ]


### PR DESCRIPTION
base64: fix warning: 'casting `type` to `type` is not needed'.