### PR TITLE
cli: fix warning.

### DIFF
--- a/examples/cli.v
+++ b/examples/cli.v
@@ -10,12 +10,14 @@ fn main() {
 		name: 'cli', 
 		description: 'An example of the cli library',
 		version: '1.0.0',
+		parent: 0
 	}
 
 	mut greet_cmd := cli.Command{
 		name: 'greet',
 		description: 'Prints greeting in different languages',
 		execute: greet_func,
+		parent: 0
 	}
 	greet_cmd.add_flag(cli.Flag{
 		flag: .string, 

--- a/vlib/cli/help.v
+++ b/vlib/cli/help.v
@@ -20,6 +20,7 @@ fn help_cmd() Command {
 		name: 'help',
 		description: 'Prints help information',
 		execute: help_func,
+		parent: 0
 	}
 }
 

--- a/vlib/cli/version.v
+++ b/vlib/cli/version.v
@@ -14,6 +14,7 @@ fn version_cmd() Command {
 		name: 'version'
 		description: 'Prints version information',
 		execute: version_func,
+		parent: 0
 	}
 }
 


### PR DESCRIPTION
cli: fix warning: 'reference field `cli.Command.parent` must be initialized'.