### PR TITLE
Fix Windows/msys2 build by replicating flags from make.bat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,10 @@ endif
 
 all: latest_vc latest_tcc
 ifdef WIN32
-	$(CC) -std=c99 -w -o v0.exe $(TMPVC)/$(VCFILE) $(LDFLAGS)
-	./v0.exe -o v.exe v.v
-	rm -f v0.exe
+	$(CC) -std=c99 -municode -w -o v2.exe $(TMPVC)/$(VCFILE) $(LDFLAGS)
+	./v2.exe -o v3.exe v.v
+	./v3.exe -o v.exe -prod v.v
+	rm -f v2.exe v3.exe
 else
 	$(CC) -std=gnu11 -w -o v $(TMPVC)/$(VCFILE) $(LDFLAGS) -lm
 ifdef ANDROID


### PR DESCRIPTION
Replicate gcc flags/sequence from make.bat in Makefile,
to fix the Windows/MSYS2 build of V