### PR TITLE
vpm: add support for other VCS for modules, like hg

### DIFF
--- a/tools/vpm.v
+++ b/tools/vpm.v
@@ -11,15 +11,15 @@ import (
 const (
 	default_vpm_server_urls = ['https://vpm.best', 'https://vpm.vlang.io']
 	valid_vpm_commands = ['help', 'search', 'install', 'update', 'remove']
-	supported_vcs_systems = ['git','hg']
+	supported_vcs_systems = ['git', 'hg']
 	supported_vcs_folders = ['.git', '.hg']
 	supported_vcs_update_cmds = {
 		'git': 'git pull --depth=1'
-		'hg':  'hg pull --update'
+		'hg': 'hg pull --update'
 	}
 	supported_vcs_install_cmds = {
 		'git': 'git clone --depth=1'
-		'hg':  'hg clone'
+		'hg': 'hg clone'
 	}
 )
 

--- a/tools/vpm.v
+++ b/tools/vpm.v
@@ -11,6 +11,7 @@ import (
 const (
 	default_vpm_server_urls = ['https://vpm.best', 'https://vpm.vlang.io']
 	valid_vpm_commands = ['help', 'search', 'install', 'update', 'remove']
+	excluded_dirs = ['cache', 'vlib']
 	supported_vcs_systems = ['git', 'hg']
 	supported_vcs_folders = ['.git', '.hg']
 	supported_vcs_update_cmds = {
@@ -173,7 +174,6 @@ fn vpm_install(module_names []string) {
 		}
 		if !vcs in supported_vcs_systems {
 			errors++
-			// a possible 404 error, which means a missing module?
 			println('Skipping module "$name", since it uses an unsupported VCS {$vcs} .')
 			continue
 		}
@@ -344,7 +344,7 @@ fn get_installed_modules() []string {
 	mut modules := []string
 	for dir in dirs {
 		adir := filepath.join(settings.vmodules_path,dir)
-		if dir in ['cache', 'vlib'] || !os.is_dir(adir) {
+		if dir in excluded_dirs || !os.is_dir(adir) {
 			continue
 		}
 		author := dir
@@ -449,7 +449,7 @@ fn get_working_server_url() string {
 	server_urls := if settings.server_urls.len > 0 { settings.server_urls } else { default_vpm_server_urls }
 	for url in server_urls {
 		verbose_println('Trying server url: $url')
-		http.get(url) or {
+		http.head(url) or {
 			verbose_println('                   $url failed.')
 			continue
 		}

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -54,6 +54,16 @@ pub fn post(url, data string) ?Response {
 	return res
 }
 
+pub fn head(url string) ?Response {
+	req := new_request('HEAD', url, '') or {
+		return error(err)
+	}
+	res := req.do() or {
+		return error(err)
+	}
+	return res
+}
+
 // new_request creates a new HTTP request
 pub fn new_request(typ, _url, _data string) ?Request {
 	if _url == '' {


### PR DESCRIPTION
This PR also adds the ability to pass CLI flags to vpm.
It implements the following flags for now:
```
 -help - Show usage info
 -verbose - Print more details about each performed operation
 -server-url - When doing network operations, use this vpm server. 
               Can be given multiple times.
```
... with the goal of enabling easier diagnostics and testing with a local vpm server.