### PR TITLE
os: implement os.cachedir() . Use it inside os.tmpdir() too.

### DIFF
--- a/vlib/flag/flag.v
+++ b/vlib/flag/flag.v
@@ -79,7 +79,7 @@ pub const (
 // create a new flag set for parsing command line arguments
 // TODO use INT_MAX some how
 pub fn new_flag_parser(args []string) &FlagParser {
-	return &FlagParser{args:args, max_free_args: MAX_ARGS_NUMBER}
+	return &FlagParser{args: args.clone(), max_free_args: MAX_ARGS_NUMBER}
 }
 
 // change the application name to be used in 'usage' output

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -1018,13 +1018,17 @@ pub fn cachedir() string {
 	// $XDG_CACHE_HOME defines the base directory relative to which user specific
 	// non-essential data files should be stored. If $XDG_CACHE_HOME is either not set
 	// or empty, a default equal to $HOME/.cache should be used.
-	xdg_cache_home := os.getenv('XDG_CACHE_HOME')
-	if xdg_cache_home == '' {
-		cdir := os.home_dir() + '.cache'
+	cdir := os.home_dir() + '.cache'
+	if !os.is_dir(cdir) && !os.is_link(cdir) {
 		if _ := os.mkdir(cdir) {}
-		return cdir
 	}
-	return xdg_cache_home
+	$if !windows {
+		xdg_cache_home := os.getenv('XDG_CACHE_HOME')
+		if xdg_cache_home != '' {
+			return xdg_cache_home
+		}
+	}
+	return cdir
 }
 
 // tmpdir returns the path to a folder, that is suitable for storing temporary files

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -91,6 +91,7 @@ pub fn (f mut File) read_bytes_at(size, pos int) []byte {
 }
 */
 
+
 pub fn read_bytes(path string) ?[]byte {
 	mut fp := vfopen(path, 'rb')
 	if isnil(fp) {
@@ -292,7 +293,6 @@ pub fn open_append(path string) ?File {
 	file.opened = true
 	return file
 }
-
 
 /*
 pub fn (f mut File) write_bytes_at(data voidptr, size, pos int) {
@@ -529,7 +529,6 @@ pub fn rm(path string) {
 	}
 	// C.unlink(path.cstr())
 }
-
 // rmdir removes a specified directory.
 pub fn rmdir(path string) {
 	$if !windows {
@@ -540,18 +539,22 @@ pub fn rmdir(path string) {
 }
 
 pub fn rmdir_recursive(path string) {
-	items := os.ls(path) or { panic(err)}
+	items := os.ls(path) or {
+		panic(err)
+	}
 	for item in items {
-		if os.is_dir(filepath.join(path, item)) {
-			rmdir_recursive(filepath.join(path, item))
+		if os.is_dir(filepath.join(path,item)) {
+			rmdir_recursive(filepath.join(path,item))
 		}
-		os.rm(filepath.join(path, item))
+		os.rm(filepath.join(path,item))
 	}
 	os.rmdir(path)
 }
 
 pub fn is_dir_empty(path string) bool {
-	items := os.ls(path) or { panic(err)}
+	items := os.ls(path) or {
+		panic(err)
+	}
 	return items.len == 0
 }
 
@@ -1006,6 +1009,22 @@ pub fn join(base string, dirs ...string) string {
 	return filepath.join(base,dirs)
 }
 
+// cachedir returns the path to a *writable* user specific folder, suitable for writing non-essential data.
+pub fn cachedir() string {
+	// See: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+	// There is a single base directory relative to which user-specific non-essential
+	// (cached) data should be written. This directory is defined by the environment
+	// variable $XDG_CACHE_HOME.
+	// $XDG_CACHE_HOME defines the base directory relative to which user specific
+	// non-essential data files should be stored. If $XDG_CACHE_HOME is either not set
+	// or empty, a default equal to $HOME/.cache should be used.
+	xdg_cache_home := os.getenv('XDG_CACHE_HOME')
+	if xdg_cache_home == '' {
+		return os.home_dir() + '.cache'
+	}
+	return xdg_cache_home
+}
+
 // tmpdir returns the path to a folder, that is suitable for storing temporary files
 pub fn tmpdir() string {
 	mut path := os.getenv('TMPDIR')
@@ -1022,6 +1041,9 @@ pub fn tmpdir() string {
 				path = 'C:/tmp'
 			}
 		}
+	}
+	if path == '' {
+		path = os.cachedir()
 	}
 	if path == '' {
 		path = '/tmp'

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -1018,14 +1018,16 @@ pub fn cachedir() string {
 	// $XDG_CACHE_HOME defines the base directory relative to which user specific
 	// non-essential data files should be stored. If $XDG_CACHE_HOME is either not set
 	// or empty, a default equal to $HOME/.cache should be used.
-	cdir := os.home_dir() + '.cache'
-	if !os.is_dir(cdir) && !os.is_link(cdir) {
-		if _ := os.mkdir(cdir) {}
-	}
 	$if !windows {
 		xdg_cache_home := os.getenv('XDG_CACHE_HOME')
 		if xdg_cache_home != '' {
 			return xdg_cache_home
+		}
+	}
+	cdir := os.home_dir() + '.cache'
+	if !os.is_dir(cdir) && !os.is_link(cdir) {
+		os.mkdir(cdir) or {
+			panic(err)
 		}
 	}
 	return cdir

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -1020,7 +1020,9 @@ pub fn cachedir() string {
 	// or empty, a default equal to $HOME/.cache should be used.
 	xdg_cache_home := os.getenv('XDG_CACHE_HOME')
 	if xdg_cache_home == '' {
-		return os.home_dir() + '.cache'
+		cdir := os.home_dir() + '.cache'
+		if _ := os.mkdir(cdir) {}
+		return cdir
 	}
 	return xdg_cache_home
 }


### PR DESCRIPTION
Implement XDG_CACHE_HOME from 
https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html