### PR TITLE
examples/tetris: update README for macOS

### DIFF
--- a/examples/tetris/README.md
+++ b/examples/tetris/README.md
@@ -3,7 +3,7 @@
 Tetris has a temporary dependency on GLFW. 
 
 ## macOS
-`brew install glfw` 
+`brew install glfw freetype` 
  
 ## Ubuntu 
 `sudo apt install libglfw3 libglfw3-dev libfreetype6-dev libssl-dev`


### PR DESCRIPTION
Adds missing `freetype` dependency. Currently you'll get a missing `ft2build.h` at compile time.