### PR TITLE
compiler: avoid redeclaration of var during reassignment with optiona…

### DIFF
--- a/vlib/compiler/gen_c.v
+++ b/vlib/compiler/gen_c.v
@@ -116,7 +116,7 @@ fn (p mut Parser) gen_handle_option_or_else(_typ, name string, fn_call_ph int) s
 		is_mut: false
 		is_used: true
 	})
-	if is_assign && !name.contains('.') {
+	if is_assign && !name.contains('.') && !p.is_var_decl {
 		// don't initialize struct fields
 		p.genln('$typ $name;')
 	}
@@ -717,4 +717,3 @@ fn (p mut Parser) gen_array_push(ph int, typ, expr_type, tmp, elm_type string) {
 		p.gen('), $tmp, $elm_type)')
 	}
 }
-


### PR DESCRIPTION
Fixes #3324

Prevents redeclaration of variable when calling `gen_handle_option_or_else`:

```
mut s := ''
s = os.read_file("mike.dat") or { 'nada' }
```

Before:

```c
string s = tos3("") ;
Option_string tmp1 = os__read_file(tos3("mike.dat"));
string s;
if (!tmp1 .ok) { ...
```

With this patch:

```c
string s = tos3("") ;
Option_string tmp1 = os__read_file(tos3("mike.dat"));
if (!tmp1 .ok) { ...
```

All tests pass with `v test-compiler`.