### PR TITLE
compiler: fix unused import warnings

### DIFF
--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -103,6 +103,7 @@ const (
 )
 
 struct ParserState {
+	scanner_file_path string
 	scanner_line_nr   int
 	scanner_text      string
 	scanner_pos       int
@@ -323,6 +324,7 @@ fn (p &Parser) log(s string) {
 
 pub fn (p &Parser) save_state() ParserState {
 	return ParserState{
+		scanner_file_path: p.scanner.file_path
 		scanner_line_nr: p.scanner.line_nr
 		scanner_text: p.scanner.text
 		scanner_pos: p.scanner.pos
@@ -343,6 +345,7 @@ pub fn (p &Parser) save_state() ParserState {
 
 pub fn (p mut Parser) restore_state(state ParserState, scanner bool, cgen bool) {
 	if scanner {
+		p.scanner.file_path = state.scanner_file_path
 		p.scanner.line_nr = state.scanner_line_nr
 		p.scanner.text = state.scanner_text
 		p.scanner.pos = state.scanner_pos
@@ -390,9 +393,12 @@ pub fn (p mut Parser) add_text(text string) {
 	p.scan_tokens()
 }
 
-fn (p mut Parser) statements_from_text(text string, rcbr bool) {
+fn (p mut Parser) statements_from_text(text string, rcbr bool, fpath string) {
 	saved_state := p.save_state()
 	p.clear_state(true, false)
+	if fpath != '' {
+		p.scanner.file_path = fpath
+	}
 	p.add_text(text)
 	p.next()
 	if rcbr {

--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -3077,7 +3077,10 @@ fn (p mut Parser) check_and_register_used_imported_type(typ_name string) {
 	us_idx := typ_name.index('__') or {
 		return
 	}
-	arg_mod := typ_name[..us_idx]
+	mut arg_mod := typ_name[..us_idx]
+	if arg_mod.contains('_dot_') {
+		arg_mod = arg_mod.all_after('_dot_')
+	}
 	if p.import_table.known_alias(arg_mod) {
 		p.import_table.register_used_import(arg_mod)
 	}
@@ -3098,11 +3101,13 @@ fn (p mut Parser) check_unused_imports() {
 	if output == '' {
 		return
 	}
+	
 	// the imports are usually at the start of the file
 	//p.production_error_with_token_index('the following imports were never used: $output', 0)
-	if !p.file_path.contains ('vlib/v/') {
-	p.warn('the following imports were never used: $output')
+	if p.pref.is_verbose {
+		eprintln('Used imports table: ${p.import_table.used_imports.str()}')
 	}
+	p.warn('the following imports were never used: $output')		
 }
 
 fn (p &Parser) is_expr_fn_call(start_tok_idx int) (bool,string) {

--- a/vlib/compiler/comptime.v
+++ b/vlib/compiler/comptime.v
@@ -195,9 +195,7 @@ fn (p mut Parser) comp_time() {
 		}
 		p.import_table.register_used_import('strings')
 		p.genln('/////////////////// tmpl start')
-		p.scanner.file_path = path
-		p.scanner.line_nr = 0
-		p.statements_from_text(v_code, false)
+		p.statements_from_text(v_code, false, path)
 		p.genln('/////////////////// tmpl end')
 		receiver := p.cur_fn.args[0]
 		dot := if receiver.is_mut || receiver.ptr || receiver.typ.ends_with('*') { '->' } else { '.' }

--- a/vlib/compiler/comptime.v
+++ b/vlib/compiler/comptime.v
@@ -159,13 +159,13 @@ fn (p mut Parser) comp_time() {
 		p.check(.rcbr)
 		// }
 	}
-	// $vweb.html()
-	// Compile vweb html template to V code, parse that V code and embed the resulting V functions
-	// that returns an html string
 	else if p.tok == .name && p.lit == 'vweb' {
+		// $vweb.html()
+		// Compile vweb html template to V code, parse that V code and embed the resulting V functions
+		// that returns an html string
 		mut path := p.cur_fn.name + '.html'
 		if p.pref.is_debug {
-			println('compiling tmpl $path')
+			println('>>> compiling vweb HTML template "$path"')
 		}
 		if !os.exists(path) {
 			// Can't find the template file in current directory,
@@ -183,8 +183,11 @@ fn (p mut Parser) comp_time() {
 		p.check(.rpar)
 		v_code := tmpl.compile_template(path)
 		if p.pref.is_verbose {
-			println('vweb template:')
+			println('\n\n')
+			println('>>> vweb template for ${path}:')
 			println(v_code)
+			println('>>> vweb template END')
+			println('\n\n')
 		}
 		is_strings_imorted := p.import_table.known_import('strings')
 		if !is_strings_imorted {
@@ -201,7 +204,7 @@ fn (p mut Parser) comp_time() {
 		p.genln('vweb__Context_html( & $receiver.name /*!*/$dot vweb, tmpl_res)')
 	}
 	else {
-		p.error('bad comptime expr')
+		p.error('bad comp_time expression')
 	}
 }
 

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -4,7 +4,6 @@ import (
 	strings
 	v.ast
 	v.table
-	v.types
 	term
 )
 

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -4,13 +4,9 @@
 module parser
 
 import (
-	v.scanner
 	v.ast
-	v.token
 	v.table
 	v.types
-	term
-	os
 )
 
 pub fn (p mut Parser) call_expr() (ast.CallExpr,types.TypeIdent) {

--- a/vlib/vweb/tmpl/tmpl.v
+++ b/vlib/vweb/tmpl/tmpl.v
@@ -19,7 +19,7 @@ pub fn compile_template(path string) string {
 	mut header := ''
 	if os.exists('header.html') {
 		h := os.read_file('header.html')or{
-			panic('html failed')
+			panic('reading file header.html failed')
 		}
 		header = h.replace("\'", '"')
 		html = header + html


### PR DESCRIPTION
This PR makes vpm compile with no misleading warnings.
It fixes:
a) a struct field declared as having a type from another module did not marked the other module as used.
b) paths in unused import warnings, when compiling code that uses vweb templates, were wrongly mentioning the .html file, instead of the .v file that used the vweb template.
