### PR TITLE
v repl: fix println regression on linux

### DIFF
--- a/vlib/builtin/builtin_nix.v
+++ b/vlib/builtin/builtin_nix.v
@@ -21,14 +21,16 @@ const (
 fn C.puts(charptr)
 */
 
-pub fn println(s string) {	
-	$if linux {
-		$if !android {
-			snl := s + '\n'
-			C.syscall(/* sys_write */ 1, /* stdout_value */ 1, snl.str, s.len+1)
-			return
-		}
-	} 
+pub fn println(s string) {
+	//  TODO: a syscall sys_write on linux works, except for the v repl.
+	//  Probably it is a stdio buffering issue. Needs more testing...
+	//	$if linux {
+	//		$if !android {
+	//			snl := s + '\n'
+	//			C.syscall(/* sys_write */ 1, /* stdout_value */ 1, snl.str, s.len+1)
+	//			return
+	//		}
+	//	} 
 	C.printf('%.*s\n', s.len, s.str)
 }
 

--- a/vlib/os/os_nix.v
+++ b/vlib/os/os_nix.v
@@ -71,7 +71,7 @@ pub fn is_dir(path string) bool {
 
 pub fn open(path string) ?File {
 	mut file := File{}
-	$if linux_or_macos {
+	$if linux {
 		$if !android {
 			fd := C.syscall(sys_open, path.str, 511)
 			if fd == -1 {
@@ -101,14 +101,14 @@ pub fn create(path string) ?File {
 	// NB: android/termux/bionic is also a kind of linux,
 	// but linux syscalls there sometimes fail,
 	// while the libc version should work.
-	$if linux_or_macos {
+	$if linux {
 		$if !android {
-			$if macos {
-				fd = C.syscall(398, path.str, 0x601, 0x1b6)
-			}
-			$if linux {
-				fd = C.syscall(sys_creat, path.str, 511)
-			}
+			//$if macos {
+			//	fd = C.syscall(398, path.str, 0x601, 0x1b6)
+			//}
+			//$if linux {
+			fd = C.syscall(sys_creat, path.str, 511)
+			//}
 			if fd == -1 {
 				return error('failed to create file "$path"')
 			}
@@ -139,7 +139,7 @@ pub fn (f mut File) write(s string) {
 	if !f.opened {
 		return
 	}
-	$if linux_or_macos {
+	$if linux {
 		$if !android {
 			C.syscall(sys_write, f.fd, s.str, s.len)
 			return
@@ -153,7 +153,7 @@ pub fn (f mut File) writeln(s string) {
 	if !f.opened {
 		return
 	}
-	$if linux_or_macos {
+	$if linux {
 		$if !android {
 			snl := s + '\n'
 			C.syscall(sys_write, f.fd, snl.str, snl.len)
@@ -174,7 +174,7 @@ pub fn mkdir(path string) ?bool {
 		return true
 	}
 	apath := os.realpath(path)
-	$if linux_or_macos {
+	$if linux {
 		$if !android {
 			ret := C.syscall(sys_mkdir, apath.str, 511)
 			if ret == -1 {
@@ -228,7 +228,7 @@ pub fn symlink(origin, target string) ?bool {
 // for example if we have write(7, 4), "07 00 00 00" gets written
 // write(0x1234, 2) => "34 12"
 pub fn (f mut File) write_bytes(data voidptr, size int) {
-	$if linux_or_macos {
+	$if linux {
 		$if !android {
 			C.syscall(sys_write, f.fd, data, 1)
 			return
@@ -242,7 +242,7 @@ pub fn (f mut File) close() {
 		return
 	}
 	f.opened = false
-	$if linux_or_macos {
+	$if linux {
 		$if !android {
 			C.syscall(sys_close, f.fd)
 			return

--- a/vlib/os/os_nix.v
+++ b/vlib/os/os_nix.v
@@ -82,14 +82,15 @@ pub fn open(path string) ?File {
 				opened: true
 			}
 		}
-	}
-	cpath := path.str
-	file = File{
-		cfile: C.fopen(charptr(cpath), 'rb')
-		opened: true
-	}
-	if isnil(file.cfile) {
-		return error('failed to open file "$path"')
+	} $else {
+		cpath := path.str
+		file = File{
+			cfile: C.fopen(charptr(cpath), 'rb')
+			opened: true
+		}
+		if isnil(file.cfile) {
+			return error('failed to open file "$path"')
+		}
 	}
 	return file
 }
@@ -118,13 +119,14 @@ pub fn create(path string) ?File {
 			}
 			return file
 		}
-	}
-	file = File{
-		cfile: C.fopen(charptr(path.str), 'wb')
-		opened: true
-	}
-	if isnil(file.cfile) {
-		return error('failed to create file "$path"')
+	} $else {
+		file = File{
+			cfile: C.fopen(charptr(path.str), 'wb')
+			opened: true
+		}
+		if isnil(file.cfile) {
+			return error('failed to create file "$path"')
+		}
 	}
 	return file
 }
@@ -144,9 +146,10 @@ pub fn (f mut File) write(s string) {
 			C.syscall(sys_write, f.fd, s.str, s.len)
 			return
 		}
+	} $else {
+		C.fputs(s.str, f.cfile)
+		// C.fwrite(s.str, 1, s.len, f.cfile)
 	}
-	C.fputs(s.str, f.cfile)
-	// C.fwrite(s.str, 1, s.len, f.cfile)
 }
 
 pub fn (f mut File) writeln(s string) {
@@ -159,13 +162,14 @@ pub fn (f mut File) writeln(s string) {
 			C.syscall(sys_write, f.fd, snl.str, snl.len)
 			return
 		}
+	} $else {
+		// C.fwrite(s.str, 1, s.len, f.cfile)
+		// ss := s.clone()
+		// TODO perf
+		C.fputs(s.str, f.cfile)
+		// ss.free()
+		C.fputs('\n', f.cfile)
 	}
-	// C.fwrite(s.str, 1, s.len, f.cfile)
-	// ss := s.clone()
-	// TODO perf
-	C.fputs(s.str, f.cfile)
-	// ss.free()
-	C.fputs('\n', f.cfile)
 }
 
 // mkdir creates a new directory with the specified path.
@@ -182,10 +186,11 @@ pub fn mkdir(path string) ?bool {
 			}
 			return true
 		}
-	}
-	r := C.mkdir(apath.str, 511)
-	if r == -1 {
-		return error(get_error_msg(C.errno))
+	} $else {
+		r := C.mkdir(apath.str, 511)
+		if r == -1 {
+			return error(get_error_msg(C.errno))
+		}
 	}
 	return true
 }
@@ -233,8 +238,9 @@ pub fn (f mut File) write_bytes(data voidptr, size int) {
 			C.syscall(sys_write, f.fd, data, 1)
 			return
 		}
+	} $else {
+		C.fwrite(data, 1, size, f.cfile)
 	}
-	C.fwrite(data, 1, size, f.cfile)
 }
 
 pub fn (f mut File) close() {
@@ -247,7 +253,8 @@ pub fn (f mut File) close() {
 			C.syscall(sys_close, f.fd)
 			return
 		}
+	} $else {
+		C.fflush(f.cfile)
+		C.fclose(f.cfile)
 	}
-	C.fflush(f.cfile)
-	C.fclose(f.cfile)
 }

--- a/vlib/os/os_nix.v
+++ b/vlib/os/os_nix.v
@@ -82,8 +82,7 @@ pub fn open(path string) ?File {
 				opened: true
 			}
 		}
-	}
-	$if !linux {
+	} $else {
 		cpath := path.str
 		file = File{
 			cfile: C.fopen(charptr(cpath), 'rb')
@@ -105,12 +104,12 @@ pub fn create(path string) ?File {
 	// while the libc version should work.
 	$if linux {
 		$if !android {
-			// $if macos {
-			// fd = C.syscall(398, path.str, 0x601, 0x1b6)
-			// }
-			// $if linux {
+			//$if macos {
+			//	fd = C.syscall(398, path.str, 0x601, 0x1b6)
+			//}
+			//$if linux {
 			fd = C.syscall(sys_creat, path.str, 511)
-			// }
+			//}
 			if fd == -1 {
 				return error('failed to create file "$path"')
 			}
@@ -120,8 +119,7 @@ pub fn create(path string) ?File {
 			}
 			return file
 		}
-	}
-	$if !linux {
+	} $else {
 		file = File{
 			cfile: C.fopen(charptr(path.str), 'wb')
 			opened: true
@@ -148,8 +146,7 @@ pub fn (f mut File) write(s string) {
 			C.syscall(sys_write, f.fd, s.str, s.len)
 			return
 		}
-	}
-	$if !linux {
+	} $else {
 		C.fputs(s.str, f.cfile)
 		// C.fwrite(s.str, 1, s.len, f.cfile)
 	}
@@ -165,8 +162,7 @@ pub fn (f mut File) writeln(s string) {
 			C.syscall(sys_write, f.fd, snl.str, snl.len)
 			return
 		}
-	}
-	$if !linux {
+	} $else {
 		// C.fwrite(s.str, 1, s.len, f.cfile)
 		// ss := s.clone()
 		// TODO perf
@@ -190,8 +186,7 @@ pub fn mkdir(path string) ?bool {
 			}
 			return true
 		}
-	}
-	$if !linux {
+	} $else {
 		r := C.mkdir(apath.str, 511)
 		if r == -1 {
 			return error(get_error_msg(C.errno))
@@ -243,8 +238,7 @@ pub fn (f mut File) write_bytes(data voidptr, size int) {
 			C.syscall(sys_write, f.fd, data, 1)
 			return
 		}
-	}
-	$if !linux {
+	} $else {
 		C.fwrite(data, 1, size, f.cfile)
 	}
 }
@@ -259,8 +253,7 @@ pub fn (f mut File) close() {
 			C.syscall(sys_close, f.fd)
 			return
 		}
-	}
-	$if !linux {
+	} $else {
 		C.fflush(f.cfile)
 		C.fclose(f.cfile)
 	}

--- a/vlib/os/os_nix.v
+++ b/vlib/os/os_nix.v
@@ -82,7 +82,8 @@ pub fn open(path string) ?File {
 				opened: true
 			}
 		}
-	} $else {
+	}
+	$if !linux {
 		cpath := path.str
 		file = File{
 			cfile: C.fopen(charptr(cpath), 'rb')
@@ -104,12 +105,12 @@ pub fn create(path string) ?File {
 	// while the libc version should work.
 	$if linux {
 		$if !android {
-			//$if macos {
-			//	fd = C.syscall(398, path.str, 0x601, 0x1b6)
-			//}
-			//$if linux {
+			// $if macos {
+			// fd = C.syscall(398, path.str, 0x601, 0x1b6)
+			// }
+			// $if linux {
 			fd = C.syscall(sys_creat, path.str, 511)
-			//}
+			// }
 			if fd == -1 {
 				return error('failed to create file "$path"')
 			}
@@ -119,7 +120,8 @@ pub fn create(path string) ?File {
 			}
 			return file
 		}
-	} $else {
+	}
+	$if !linux {
 		file = File{
 			cfile: C.fopen(charptr(path.str), 'wb')
 			opened: true
@@ -146,7 +148,8 @@ pub fn (f mut File) write(s string) {
 			C.syscall(sys_write, f.fd, s.str, s.len)
 			return
 		}
-	} $else {
+	}
+	$if !linux {
 		C.fputs(s.str, f.cfile)
 		// C.fwrite(s.str, 1, s.len, f.cfile)
 	}
@@ -162,7 +165,8 @@ pub fn (f mut File) writeln(s string) {
 			C.syscall(sys_write, f.fd, snl.str, snl.len)
 			return
 		}
-	} $else {
+	}
+	$if !linux {
 		// C.fwrite(s.str, 1, s.len, f.cfile)
 		// ss := s.clone()
 		// TODO perf
@@ -186,7 +190,8 @@ pub fn mkdir(path string) ?bool {
 			}
 			return true
 		}
-	} $else {
+	}
+	$if !linux {
 		r := C.mkdir(apath.str, 511)
 		if r == -1 {
 			return error(get_error_msg(C.errno))
@@ -238,7 +243,8 @@ pub fn (f mut File) write_bytes(data voidptr, size int) {
 			C.syscall(sys_write, f.fd, data, 1)
 			return
 		}
-	} $else {
+	}
+	$if !linux {
 		C.fwrite(data, 1, size, f.cfile)
 	}
 }
@@ -253,7 +259,8 @@ pub fn (f mut File) close() {
 			C.syscall(sys_close, f.fd)
 			return
 		}
-	} $else {
+	}
+	$if !linux {
 		C.fflush(f.cfile)
 		C.fclose(f.cfile)
 	}

--- a/vlib/os/os_nix.v
+++ b/vlib/os/os_nix.v
@@ -82,15 +82,14 @@ pub fn open(path string) ?File {
 				opened: true
 			}
 		}
-	} $else {
-		cpath := path.str
-		file = File{
-			cfile: C.fopen(charptr(cpath), 'rb')
-			opened: true
-		}
-		if isnil(file.cfile) {
-			return error('failed to open file "$path"')
-		}
+	}
+	cpath := path.str
+	file = File{
+		cfile: C.fopen(charptr(cpath), 'rb')
+		opened: true
+	}
+	if isnil(file.cfile) {
+		return error('failed to open file "$path"')
 	}
 	return file
 }
@@ -119,14 +118,13 @@ pub fn create(path string) ?File {
 			}
 			return file
 		}
-	} $else {
-		file = File{
-			cfile: C.fopen(charptr(path.str), 'wb')
-			opened: true
-		}
-		if isnil(file.cfile) {
-			return error('failed to create file "$path"')
-		}
+	}
+	file = File{
+		cfile: C.fopen(charptr(path.str), 'wb')
+		opened: true
+	}
+	if isnil(file.cfile) {
+		return error('failed to create file "$path"')
 	}
 	return file
 }
@@ -146,10 +144,9 @@ pub fn (f mut File) write(s string) {
 			C.syscall(sys_write, f.fd, s.str, s.len)
 			return
 		}
-	} $else {
-		C.fputs(s.str, f.cfile)
-		// C.fwrite(s.str, 1, s.len, f.cfile)
 	}
+	C.fputs(s.str, f.cfile)
+	// C.fwrite(s.str, 1, s.len, f.cfile)
 }
 
 pub fn (f mut File) writeln(s string) {
@@ -162,14 +159,13 @@ pub fn (f mut File) writeln(s string) {
 			C.syscall(sys_write, f.fd, snl.str, snl.len)
 			return
 		}
-	} $else {
-		// C.fwrite(s.str, 1, s.len, f.cfile)
-		// ss := s.clone()
-		// TODO perf
-		C.fputs(s.str, f.cfile)
-		// ss.free()
-		C.fputs('\n', f.cfile)
 	}
+	// C.fwrite(s.str, 1, s.len, f.cfile)
+	// ss := s.clone()
+	// TODO perf
+	C.fputs(s.str, f.cfile)
+	// ss.free()
+	C.fputs('\n', f.cfile)
 }
 
 // mkdir creates a new directory with the specified path.
@@ -186,11 +182,10 @@ pub fn mkdir(path string) ?bool {
 			}
 			return true
 		}
-	} $else {
-		r := C.mkdir(apath.str, 511)
-		if r == -1 {
-			return error(get_error_msg(C.errno))
-		}
+	}
+	r := C.mkdir(apath.str, 511)
+	if r == -1 {
+		return error(get_error_msg(C.errno))
 	}
 	return true
 }
@@ -238,9 +233,8 @@ pub fn (f mut File) write_bytes(data voidptr, size int) {
 			C.syscall(sys_write, f.fd, data, 1)
 			return
 		}
-	} $else {
-		C.fwrite(data, 1, size, f.cfile)
 	}
+	C.fwrite(data, 1, size, f.cfile)
 }
 
 pub fn (f mut File) close() {
@@ -253,8 +247,7 @@ pub fn (f mut File) close() {
 			C.syscall(sys_close, f.fd)
 			return
 		}
-	} $else {
-		C.fflush(f.cfile)
-		C.fclose(f.cfile)
 	}
+	C.fflush(f.cfile)
+	C.fclose(f.cfile)
 }


### PR DESCRIPTION
This PR causes println on linux to use again printf. 

Using syscalls directly works in the v tests, but NOT when the v repl is run manually in an interactive terminal (the output seems not properly aligned, and disappears when a key is pressed).
