### PR TITLE
time: move time.random() to time.misc module

### DIFF
--- a/vlib/compiler/tests/fn_expecting_ref_but_returning_struct_time_module_test.v
+++ b/vlib/compiler/tests/fn_expecting_ref_but_returning_struct_time_module_test.v
@@ -1,21 +1,18 @@
-/*
-// TODO: Fix this.
-import time
-
+import time.misc as tmisc
 // using a manual temporary intermediate variable should always work:
-fn test_call_fn_that_requires_reference_with_function_that_returns_a_struct_manual(){
-	t1 := time.random()
+fn test_call_fn_that_requires_reference_with_function_that_returns_a_struct_manual() {
+	t1 := tmisc.random()
 	t2 := t1.calc_unix()
-	println('tmp: $t2')
+	println('res: $t2')
 	assert true
 }
 
+/*
+// TODO: Fix this.
 // v should produce temporary intermediate variables in chained calls:
 fn test_call_fn_that_requires_reference_with_function_that_returns_a_struct_chained(){
-	res := (time.random().calc_unix())
+	res := (tmisc.random().calc_unix())
 	println('res: $res')
 	assert true
 }
 */
-
-fn test_dummy(){}

--- a/vlib/time/misc/misc.v
+++ b/vlib/time/misc/misc.v
@@ -1,0 +1,12 @@
+module misc
+
+import rand
+import time
+
+const (
+	start_time_unix = time.now().unix
+)
+// random will return a random time.Time in *the past*
+pub fn random() time.Time {
+	return time.unix(rand.next(start_time_unix))
+}

--- a/vlib/time/misc/misc_test.v
+++ b/vlib/time/misc/misc_test.v
@@ -1,0 +1,17 @@
+import time.misc as tmisc
+import rand
+
+fn test_random() {
+	// guarantee CI test stability, by seeding the random number generator with a known seed
+	rand.seed(0)
+	t1 := tmisc.random()
+	t2 := tmisc.random()
+	t3 := tmisc.random()
+	t4 := tmisc.random()
+	assert t1.unix != t2.unix
+	assert t1.unix != t3.unix
+	assert t1.unix != t4.unix
+	assert t2.unix != t3.unix
+	assert t2.unix != t4.unix
+	assert t3.unix != t4.unix
+}

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -341,26 +341,26 @@ pub fn ticks() i64 {
 pub fn sleep(seconds int) {
 	$if windows {
 		C.Sleep(seconds * 1000)
-		return
+	} $else {
+		C.sleep(seconds)
 	}
-	C.sleep(seconds)
 }
 
 pub fn sleep_ms(milliseconds int) {
 	$if windows {
 		C.Sleep(milliseconds)
-		return
+	} $else {
+		C.usleep(milliseconds * 1000)
 	}
-	C.usleep(milliseconds * 1000)
 }
 
 pub fn usleep(microseconds int) {
 	$if windows {
 		milliseconds := microseconds / 1000
 		C.Sleep(milliseconds)
-		return
+	} $else {
+		C.usleep(microseconds)
 	}
-	C.usleep(microseconds)
 }
 
 // Determine whether a year is a leap year.

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -3,8 +3,6 @@
 // that can be found in the LICENSE file.
 module time
 
-import rand
-
 const (
 	days_string = 'MonTueWedThuFriSatSun'
 	month_days = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
@@ -32,7 +30,7 @@ pub:
 	hour   int
 	minute int
 	second int
-	unix   int
+	unix int
 }
 
 pub enum FormatTime {
@@ -65,12 +63,7 @@ pub enum FormatDelimiter {
 fn C.localtime(int) &C.tm
 
 
-fn remove_me_when_c_bug_is_fixed() {
-	// TODO
-}
-
-pub struct C.time_t {
-}
+pub struct C.time_t {}
 
 fn C.time(int) C.time_t
 
@@ -80,12 +73,6 @@ pub fn now() Time {
 	mut now := &C.tm(0)
 	now = C.localtime(&t)
 	return convert_ctime(now)
-}
-
-pub fn random() Time {
-	now_unix := now().unix
-	rand_unix := rand.next(now_unix)
-	return time.unix(rand_unix)
 }
 
 // format_ss  returns a string for t in a given format YYYY-MM-DD HH:MM:SS in
@@ -224,34 +211,33 @@ pub fn parse_iso(s string) Time {
 	if fields.len < 5 {
 		return Time{}
 	}
-
-	pos := months_string.index(fields[2]) or { return Time{} }
-	mm := pos/3 + 1
-
-	tmstr := malloc(s.len*2)
-	count := int(C.sprintf(charptr(tmstr), '%s-%02d-%s %s'.str,
-		fields[3].str, mm, fields[1].str, fields[4].str))
+	pos := months_string.index(fields[2]) or {
+		return Time{}
+	}
+	mm := pos / 3 + 1
+	tmstr := malloc(s.len * 2)
+	count := int(C.sprintf(charptr(tmstr), '%s-%02d-%s %s'.str, fields[3].str, mm, fields[1].str, fields[4].str))
 	return parse(tos(tmstr, count))
 }
 
 pub fn new_time(t Time) Time {
 	return Time{
-		year: t.year,
-		month: t.month,
-		day: t.day,
-		hour: t.hour,
-		minute: t.minute,
-		second: t.second,
+		year: t.year
+		month: t.month
+		day: t.day
+		hour: t.hour
+		minute: t.minute
+		second: t.second
 		unix: t.calc_unix()
 	}
-
-	//TODO: Use the syntax below when it works with reserved keywords like `unix`
+	// TODO: Use the syntax below when it works with reserved keywords like `unix`
 	/*
 	return {
 		t |
 		unix:t.calc_unix()
 	}
 	*/
+
 }
 
 pub fn (t &Time) calc_unix() int {
@@ -340,8 +326,7 @@ pub fn ticks() i64 {
 	$if windows {
 		return C.GetTickCount()
 	} $else {
-		ts := C.timeval{
-		}
+		ts := C.timeval{}
 		C.gettimeofday(&ts, 0)
 		return i64(ts.tv_sec * u64(1000) + (ts.tv_usec / u64(1000)))
 	}
@@ -356,25 +341,26 @@ pub fn ticks() i64 {
 pub fn sleep(seconds int) {
 	$if windows {
 		C.Sleep(seconds * 1000)
-	} $else {
-		C.sleep(seconds)
+		return
 	}
+	C.sleep(seconds)
 }
 
-pub fn usleep(n int) {
+pub fn sleep_ms(milliseconds int) {
 	$if windows {
-		// C._usleep(n)
-	} $else {
-		C.usleep(n)
+		C.Sleep(milliseconds)
+		return
 	}
+	C.usleep(milliseconds * 1000)
 }
 
-pub fn sleep_ms(n int) {
+pub fn usleep(microseconds int) {
 	$if windows {
-		C.Sleep(n)
-	} $else {
-		C.usleep(n * 1000)
+		milliseconds := microseconds / 1000
+		C.Sleep(milliseconds)
+		return
 	}
+	C.usleep(microseconds)
 }
 
 // Determine whether a year is a leap year.
@@ -416,7 +402,8 @@ pub fn (t Time) get_fmt_time_str(fmt_time FormatTime) string {
 			'${t.hour:02d}:${t.minute:02d}:${t.second:02d}'
 		}
 		else {
-			'unknown enumeration $fmt_time'}}
+			'unknown enumeration $fmt_time'}
+	}
 }
 
 // get_fmt_date_str   returns a string for t in a given date format
@@ -496,4 +483,3 @@ pub fn (t Time) get_fmt_str(fmt_dlmtr FormatDelimiter, fmt_time FormatTime, fmt_
 		}
 	}
 }
-


### PR DESCRIPTION
This avoids importing rand by proxy of time module, to programs that do not need pseudo random generation, like for example to v itself.
This makes generated C source from v.v slightly smaller (~2KB), and thus slightly faster to compile.
