### PR TITLE
compiler: force .exe extension, when compiling on windows

### DIFF
--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -120,10 +120,11 @@ fn (v mut V) cc() {
 	}
 
 	if !v.pref.is_so
-	   && ( v.pref.build_mode != .build_module )
-	   && ( os.user_os() == 'windows' )
-	   && ( !v.out_name.ends_with('.exe') ) {
-		v.out_name = v.out_name + '.exe'
+		&& v.pref.build_mode != .build_module 
+		&& os.user_os() == 'windows'
+		&& !v.out_name.ends_with('.exe')
+	{
+		v.out_name += '.exe'
 	}
 	
 	// linux_host := os.user_os() == 'linux'

--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -118,6 +118,14 @@ fn (v mut V) cc() {
 			verror('-fast is only supported on Linux right now')
 		}
 	}
+
+	if !v.pref.is_so
+	   && ( v.pref.build_mode != .build_module )
+	   && ( os.user_os() == 'windows' )
+	   && ( !v.out_name.ends_with('.exe') ) {
+		v.out_name = v.out_name + '.exe'
+	}
+	
 	// linux_host := os.user_os() == 'linux'
 	v.log('cc() isprod=$v.pref.is_prod outname=$v.out_name')
 	if v.pref.is_so {


### PR DESCRIPTION
Fixes clang based gcc output with missing explicit -o file.exe .