### PR TITLE
tools: distinguish complier args and tool args

### DIFF
--- a/v.v
+++ b/v.v
@@ -31,7 +31,7 @@ fn main() {
 	}
 	// external tool
 	if command in simple_tools {
-		compiler.launch_tool('v' + command)
+		compiler.launch_tool('v' + command, command)
 		return
 	}
 	// v run, v doc, etc
@@ -50,7 +50,7 @@ fn main() {
 	}
 	// No args? REPL
 	else if command == '' || (args.len == 2 && args[1] == '-') {
-		compiler.launch_tool('vrepl')
+		compiler.launch_tool('vrepl', '')
 		return
 	}
 	// Construct the V object from command line arguments
@@ -100,7 +100,7 @@ fn v_command(command string, args []string) {
 			println('Translating C to V will be available in V 0.3 (January)')
 		}
 		'search', 'install', 'update', 'remove' {
-			compiler.launch_tool('vpm')
+			compiler.launch_tool('vpm', command)
 		}
 		'get' {
 			println('use `v install` to install modules from vpm.vlang.io ')
@@ -109,7 +109,7 @@ fn v_command(command string, args []string) {
 			compiler.create_symlink()
 		}
 		'runrepl' {
-			compiler.launch_tool('vrepl')
+			compiler.launch_tool('vrepl', 'runrepl')
 		}
 		'doc' {
 			vexe := os.executable()

--- a/vlib/compiler/vtools.v
+++ b/vlib/compiler/vtools.v
@@ -5,17 +5,17 @@ import (
 	filepath
 )
 
-pub fn launch_tool(tname string) {
+pub fn launch_tool(tname string, cmdname string) {
   is_verbose := '-verbose' in os.args || '--verbose' in os.args
 	vexe := vexe_path()
 	vroot := filepath.dir(vexe)
 	set_vroot_folder( vroot ) // needed by tools to find back v
-	mut tname_index := os.args.index(tname[1..])
+	mut tname_index := os.args.index(cmdname)
 	if tname_index == -1 {
 		tname_index = os.args.len
 	}
 	mut compilation_options := os.args[1..tname_index].clone()
-	tool_args := os.args[tname_index..].join(' ')
+	tool_args := os.args[1..].join(' ')
 	tool_exe := os.realpath('$vroot/tools/$tname')
 	tool_source := os.realpath('$vroot/tools/${tname}.v')
 	tool_command := '"$tool_exe" $tool_args'

--- a/vlib/compiler/vtools.v
+++ b/vlib/compiler/vtools.v
@@ -10,7 +10,12 @@ pub fn launch_tool(tname string) {
 	vexe := vexe_path()
 	vroot := filepath.dir(vexe)
 	set_vroot_folder( vroot ) // needed by tools to find back v
-	tool_args := os.args[1..].join(' ')
+	mut tname_index := os.args.index(tname[1..])
+	if tname_index == -1 {
+		tname_index = os.args.len
+	}
+	mut compilation_options := os.args[1..tname_index].clone()
+	tool_args := os.args[tname_index..].join(' ')
 	tool_exe := os.realpath('$vroot/tools/$tname')
 	tool_source := os.realpath('$vroot/tools/${tname}.v')
 	tool_command := '"$tool_exe" $tool_args'
@@ -41,9 +46,9 @@ pub fn launch_tool(tname string) {
 	}
 	
 	if tool_should_be_recompiled {
-		mut compilation_options := ''
-		if tname == 'vfmt' {  compilation_options = '-d vfmt' }
-		compilation_command := '"$vexe" $compilation_options "$tool_source"'
+		if tname == 'vfmt' {  compilation_options << ['-d', 'vfmt'] }
+		compilation_args := compilation_options.join(' ')
+		compilation_command := '"$vexe" $compilation_args "$tool_source"'
 		if is_verbose {
 			eprintln('Compiling $tname with: "$compilation_command"') 
 		}


### PR DESCRIPTION
This PR modifies how commands `v` and `v [tool]` treat command line args. Previously, all args are passed to the tool command, such that it is impossible to pass args to the compiler when the tool needs to be recompiled. (e.g. `-cc gcc`)

After this PR, the args appear before the tool command are passed to compiler and still, all args are passed to the tool:
```bash
# In general
v [args_for_compiler...] [tool_command] [other_args...]
# For repl
v [args_for_compiler...]
```