### PR TITLE
Use os.rmdir_recursive instead of scripting.run('rm -rf')

### DIFF
--- a/tools/oldv.v
+++ b/tools/oldv.v
@@ -99,8 +99,8 @@ fn main() {
 		context.cc = ecc
 	}
 	if context.cleanup {
-		scripting.run('rm -rf $context.path_v')
-		scripting.run('rm -rf $context.path_vc')
+		os.rmdir_recursive(context.path_v)
+		os.rmdir_recursive(context.path_vc)
 	}
 	
 	context.compile_oldv_if_needed()


### PR DESCRIPTION
* Changes behaviour, if rmdir fails. it panics, maybe vlib api
  must be changed to return an error instead of panicking.
