### PR TITLE
vv: make warns/errors usable in emacs/vim

### DIFF
--- a/vlib/v/gen/cgen_test.v
+++ b/vlib/v/gen/cgen_test.v
@@ -19,6 +19,8 @@ fn test_c_files() {
 	println('Running V => C tests')
 	vexe := os.getenv('VEXE')
 	vroot := filepath.dir(vexe)
+	term_ok := term.ok_message('OK')
+	term_fail := term.fail_message('FAIL')
 	for i in 1 .. nr_tests + 1 {
 		path := '$vroot/vlib/v/gen/tests/${i}.vv'
 		ctext := os.read_file('$vroot/vlib/v/gen/tests/${i}.c') or {
@@ -28,12 +30,11 @@ fn test_c_files() {
 		program := parser.parse_file(path, table)
 		res := gen.cgen([program], table)
 		if compare_texts(res, ctext) {
-			eprintln('${i}... ' + term.green('OK'))
+			eprintln('${term_ok} ${i}')
 		}
 		else {
-			eprintln('${i}... ' + term.red('FAIL'))
-			eprintln(path)
-			eprintln('got:\n$res')
+			eprintln('${term_fail} ${i}')
+			eprintln('${path}: got\n{$res}')
 			assert false
 		}
 	}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -12,6 +12,9 @@ import (
 	term
 	os
 )
+const (
+	colored_output = term.can_show_color_on_stderr()
+)
 
 type PrefixParseFn fn()ast.Expr
 
@@ -249,17 +252,32 @@ pub fn (p mut Parser) assign_stmt() ast.AssignStmt {
 
 pub fn (p &Parser) error(s string) {
 	print_backtrace()
-	println(term.bold(term.red('$p.file_name:$p.tok.line_nr: $s')))
+	final_msg_line := '$p.file_name:$p.tok.line_nr: error: $s'
+	if colored_output {
+		eprintln(term.bold(term.red(final_msg_line)))
+	}else{
+		eprintln(final_msg_line)
+	}
 	exit(1)
 }
 
 pub fn (p &Parser) error_at_line(s string, line_nr int) {
-	println(term.bold(term.red('$p.file_name:$line_nr: $s')))
+	final_msg_line := '$p.file_name:$line_nr: error: $s'
+	if colored_output {
+		eprintln(term.bold(term.red(final_msg_line)))
+	}else{
+		eprintln(final_msg_line)
+	}
 	exit(1)
 }
 
 pub fn (p &Parser) warn(s string) {
-	println(term.blue('$p.file_name:$p.tok.line_nr: $s'))
+	final_msg_line := '$p.file_name:$p.tok.line_nr: warning: $s'
+	if colored_output {
+		eprintln(term.bold(term.blue(final_msg_line)))
+	}else{
+		eprintln(final_msg_line)
+	}
 }
 
 pub fn (p mut Parser) name_expr() (ast.Expr,types.TypeIdent) {

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -245,7 +245,8 @@ pub fn (t mut Table) register_type(typ types.Type, name string, idx int) {
 	}
 	t.type_idxs[name] = idx
 	t.types << typ
-	t.methods << []Fn // TODO [] breaks V
+	efn := []Fn
+	t.methods << efn // TODO [] breaks V
 }
 
 pub fn (t mut Table) register_struct(typ types.Struct) int {


### PR DESCRIPTION
This PR enables integration of warn/error lines produced by the new parser with emacs/vim default modes (jump to error after make/run).