### PR TITLE
windows: println using WriteFile/WriteConsole

### DIFF
--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -112,7 +112,15 @@ pub fn eprint(s string) {
 
 pub fn print(s string) {
 	$if windows {
-		C.wprintf(s.to_wide())
+		output_handle := C.GetStdHandle(C.STD_OUTPUT_HANDLE)
+		mut bytes_written := 0
+		if is_atty(1) > 0 {
+			wide_str := s.to_wide()
+			wide_len := C.wcslen(wide_str)
+			C.WriteConsole(output_handle, wide_str, wide_len, &bytes_written, 0)
+		} else {
+			C.WriteFile(output_handle, s.str, s.len, &bytes_written, 0)
+		}
 	} $else {
 		C.printf('%.*s', s.len, s.str)
 	}

--- a/vlib/builtin/builtin_windows.v
+++ b/vlib/builtin/builtin_windows.v
@@ -135,6 +135,6 @@ fn print_backtrace_skipping_top_frames_nix(skipframes int) bool {
 }
 
 pub fn println(s string) {
-	C._putws(s.to_wide())
+	print('$s\n')
 }
 

--- a/vlib/builtin/cfns.v
+++ b/vlib/builtin/cfns.v
@@ -303,7 +303,13 @@ fn C._waccess() int
 fn C._wremove()
 
 
-fn C.ReadConsole()
+fn C.ReadConsole() voidptr
+
+
+fn C.WriteConsole() voidptr
+
+
+fn C.WriteFile() voidptr
 
 
 fn C.fgetws() voidptr


### PR DESCRIPTION
`_putws`/`wprintf` does not work correctly on old C runtimes, this fixes output on Windows 7/MinGW