### PR TITLE
Fix symlink for Termux on Android

### DIFF
--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -1199,14 +1199,23 @@ pub fn create_symlink() {
 		return
 	}
 	vexe := vexe_path()
-	link_path := '/usr/local/bin/v'
-	ret := os.system('ln -sf $vexe $link_path')
+	mut link_path := '/usr/local/bin/v'
+	mut ret := os.system('ln -sf $vexe $link_path')
 	if ret == 0 {
 		println('Symlink "$link_path" has been created')
 	}
-	else {
-		println('Failed to create symlink "$link_path". Try again with sudo.')
-	}
+	else if os.system('uname -o | grep [A/a]ndroid') == 0 {
+		println('Failed to create symlink "$link_path". Trying again with Termux path for Android.')
+    link_path = '/data/data/com.termux/files/usr/bin/v'
+  	ret = os.system('ln -sf $vexe $link_path')
+  	if ret == 0 {
+  		println('Symlink "$link_path" has been created')
+  	} else {
+		  println('Failed to create symlink "$link_path". Try again with sudo.')
+    }
+	} else {
+		  println('Failed to create symlink "$link_path". Try again with sudo.')
+  }
 }
 
 pub fn vexe_path() string {

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -1206,16 +1206,16 @@ pub fn create_symlink() {
 	}
 	else if os.system('uname -o | grep [A/a]ndroid') == 0 {
 		println('Failed to create symlink "$link_path". Trying again with Termux path for Android.')
-    link_path = '/data/data/com.termux/files/usr/bin/v'
-  	ret = os.system('ln -sf $vexe $link_path')
-  	if ret == 0 {
-  		println('Symlink "$link_path" has been created')
-  	} else {
-		  println('Failed to create symlink "$link_path". Try again with sudo.')
-    }
+		link_path = '/data/data/com.termux/files/usr/bin/v'
+		ret = os.system('ln -sf $vexe $link_path')
+		if ret == 0 {
+			println('Symlink "$link_path" has been created')
+		} else {
+			println('Failed to create symlink "$link_path". Try again with sudo.')
+		}
 	} else {
-		  println('Failed to create symlink "$link_path". Try again with sudo.')
-  }
+			println('Failed to create symlink "$link_path". Try again with sudo.')
+	}
 }
 
 pub fn vexe_path() string {


### PR DESCRIPTION
On Termux inside Android, the directory /usr/bin/local/ doesn't exist, so I check for /data/data/com.termux/files/usr/bin/v in case uname -o returns "Android"