### PR TITLE
encoding.binary: Removed not needed castings, rename function.

### DIFF
--- a/vlib/encoding/binary/binary.v
+++ b/vlib/encoding/binary/binary.v
@@ -4,9 +4,9 @@
 module binary
 // Little Endian
 [inline]
-pub fn little_endian_endian_u16(b []byte) u16 {
+pub fn little_endian_u16(b []byte) u16 {
 	_ = b[1] // bounds check
-	return u16(b[0]) | u16(u16(b[1])<<u16(8))
+	return u16(b[0]) | (u16(b[1])<<u16(8))
 }
 
 [inline]
@@ -19,7 +19,7 @@ pub fn little_endian_put_u16(b mut []byte, v u16) {
 [inline]
 pub fn little_endian_u32(b []byte) u32 {
 	_ = b[3] // bounds check
-	return u32(b[0]) | u32(u32(b[1])<<u32(8)) | u32(u32(b[2])<<u32(16)) | u32(u32(b[3])<<u32(24))
+	return u32(b[0]) | (u32(b[1])<<u32(8)) | (u32(b[2])<<u32(16)) | (u32(b[3])<<u32(24))
 }
 
 [inline]
@@ -34,7 +34,7 @@ pub fn little_endian_put_u32(b mut []byte, v u32) {
 [inline]
 pub fn little_endian_u64(b []byte) u64 {
 	_ = b[7] // bounds check
-	return u64(b[0]) | u64(u64(b[1])<<u64(8)) | u64(u64(b[2])<<u64(16)) | u64(u64(b[3])<<u64(24)) | u64(u64(b[4])<<u64(32)) | u64(u64(b[5])<<u64(40)) | u64(u64(b[6])<<u64(48)) | u64(u64(b[7])<<u64(56))
+	return u64(b[0]) | (u64(b[1])<<u64(8)) | (u64(b[2])<<u64(16)) | (u64(b[3])<<u64(24)) | (u64(b[4])<<u64(32)) | (u64(b[5])<<u64(40)) | (u64(b[6])<<u64(48)) | (u64(b[7])<<u64(56))
 }
 
 [inline]
@@ -54,7 +54,7 @@ pub fn little_endian_put_u64(b mut []byte, v u64) {
 [inline]
 pub fn big_endian_u16(b []byte) u16 {
 	_ = b[1] // bounds check
-	return u16(b[1]) | u16(u16(b[0])<<u16(8))
+	return u16(b[1]) | (u16(b[0])<<u16(8))
 }
 
 [inline]
@@ -67,7 +67,7 @@ pub fn big_endian_put_u16(b mut []byte, v u16) {
 [inline]
 pub fn big_endian_u32(b []byte) u32 {
 	_ = b[3] // bounds check
-	return u32(b[3]) | u32(u32(b[2])<<u32(8)) | u32(u32(b[1])<<u32(16)) | u32(u32(b[0])<<u32(24))
+	return u32(b[3]) | (u32(b[2])<<u32(8)) | (u32(b[1])<<u32(16)) | (u32(b[0])<<u32(24))
 }
 
 [inline]
@@ -82,7 +82,7 @@ pub fn big_endian_put_u32(b mut []byte, v u32) {
 [inline]
 pub fn big_endian_u64(b []byte) u64 {
 	_ = b[7] // bounds check
-	return u64(b[7]) | u64(u64(b[6])<<u64(8)) | u64(u64(b[5])<<u64(16)) | u64(u64(b[4])<<u64(24)) | u64(u64(b[3])<<u64(32)) | u64(u64(b[2])<<u64(40)) | u64(u64(b[1])<<u64(48)) | u64(u64(b[0])<<u64(56))
+	return u64(b[7]) | (u64(b[6])<<u64(8))| (u64(b[5])<<u64(16)) | (u64(b[4])<<u64(24)) | (u64(b[3])<<u64(32)) | (u64(b[2])<<u64(40)) | (u64(b[1])<<u64(48)) | (u64(b[0])<<u64(56))
 }
 
 [inline]


### PR DESCRIPTION
In past there are were conversions to the same type and compiler gave the output when you compile program with imported binary.v:
```warning: v/vlib/encoding/binary/binary.v:9:42: casting u16 to u16 is not needed
warning: v/vlib/encoding/binary/binary.v:22:42: casting u32 to u32 is not needed
warning: v/vlib/encoding/binary/binary.v:22:68: casting u32 to u32 is not needed
...
```
Also renamed function from _little_endian_endian_u16_ to _little_endian_u16_.