### PR TITLE
Fix Double ln error and grep result

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Bug report
 title: ''
-labels: bug
+labels: 'Type: Bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: feature request
+labels: 'Type: Feature Request'
 assignees: ''
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,9 @@ $(TMPVC)/.git/config:
 selfcompile:
 	./v -cg -o v v.v
 
+selfcompile-static:
+	./v -cg -cflags '--static' -o v-static v.v
+
 modules: module_builtin module_strings module_strconv
 module_builtin:
 	#./v build module vlib/builtin > /dev/null

--- a/examples/hot_reload/bounce.v
+++ b/examples/hot_reload/bounce.v
@@ -56,6 +56,9 @@ fn main() {
 	println('Starting the game loop...')
 	go game.run()
 	for {
+		if window.should_close() {
+			break
+		}
 		gl.clear()
 		gl.clear_color(255, 255, 255, 255)
 		game.draw()
@@ -101,5 +104,3 @@ fn (game mut Game) run() {
 		time.sleep_ms(17)
 	}
 }
-
-

--- a/examples/hot_reload/graph.v
+++ b/examples/hot_reload/graph.v
@@ -30,7 +30,10 @@ fn main() {
 		})
 	} 
 	go update() // update the scene in the background in case the window isn't focused 
-	for { 
+	for {
+		if ctx.gg.window.should_close() {
+			break
+		}
 		gg.clear(gx.White) 
 		ctx.draw()
 		ctx.gg.render() 

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -298,6 +298,14 @@ pub fn (s string) i64() i64 {
 	return strconv.common_parse_int(s, 0, 64, false, false)
 }
 
+pub fn (s string) i8() i8 {
+	return i8(strconv.common_parse_int(s, 0, 8, false, false))
+}
+
+pub fn (s string) i16() i16 {
+	return i16(strconv.common_parse_int(s, 0, 16, false, false))
+}
+
 pub fn (s string) f32() f32 {
 	// return C.atof(charptr(s.str))
 	return f32(strconv.atof64(s))
@@ -306,6 +314,10 @@ pub fn (s string) f32() f32 {
 pub fn (s string) f64() f64 {
 	// return C.atof(charptr(s.str))
 	return strconv.atof64(s)
+}
+
+pub fn (s string) u16() u16 {
+	return u16(strconv.common_parse_uint(s, 0, 16, false, false))
 }
 
 pub fn (s string) u32() u32 {
@@ -1201,4 +1213,3 @@ pub fn (s string) repeat(count int) string {
 	ret[s.len * count] = 0
 	return string(ret)
 }
-

--- a/vlib/builtin/string_int_test.v
+++ b/vlib/builtin/string_int_test.v
@@ -25,3 +25,162 @@ fn test_common_atoi() {
 		assert s.int() == n
 	}
 }
+
+fn test_unsigned_cast() {
+	// tests for u16
+
+    // test common cases
+	assert "70zzz".u16() == 70
+	assert "2901issue".u16() == 2901
+	assert '0y'.u16() == 0
+	
+	// test lead zeros
+	assert '0000012'.u16() == 12
+	assert '0x001F'.u16() == 31
+	assert '0x001f'.u16() == 31
+	assert '0o00011'.u16() == 9
+	assert '0b00001001'.u16() == 9
+
+	// tests for u32
+
+    // test common cases
+	assert "70zzz".u32() == 70
+	assert "2901issue".u32() == 2901
+	assert '234232w'.u32() == 234232
+	assert '-9009x'.u32() == 0
+	assert '0y'.u32() == 0
+	
+	// test lead zeros
+	assert '0000012'.u32() == 12
+	assert '-0000012'.u32() == 0
+	assert '0x001F'.u32() == 31
+	assert '-0x001F'.u32() == 0
+	assert '0x001f'.u32() == 31
+	assert '0o00011'.u32() == 9
+	assert '0b00001001'.u32() == 9
+
+	// test underscore in string
+	assert '-10_000'.u32() == 0
+	assert '-0x00_0_f_ff'.u32() == 0
+	assert '10_000_000'.u32() == 10000000
+
+	for n in 0 .. 100 {
+		s := n.str()+"z"
+		assert s.u32() == n
+	}
+
+	// tests for u64
+
+    // test common cases
+	assert "70zzz".u64() == 70
+	assert "2901issue".u64() == 2901
+	assert '234232w'.u64() == 234232
+	assert '-9009x'.u64() == 0
+	assert '0y'.u64() == 0
+	
+	// test lead zeros
+	assert '0000012'.u64() == 12
+	assert '-0000012'.u64() == 0
+	assert '0x001F'.u64() == 31
+	assert '-0x001F'.u64() == 0
+	assert '0x001f'.u64() == 31
+	assert '0o00011'.u64() == 9
+	assert '0b00001001'.u64() == 9
+
+	// test underscore in string
+	assert '-10_000'.u64() == 0
+	assert '-0x00_0_f_ff'.u64() == 0
+	assert '10_000_000'.u64() == 10000000
+
+	for n in 0 .. 10000 {
+		s := n.str()+"z"
+		assert s.u64() == n
+	}
+
+}
+
+fn test_signed_cast() {
+	// tests for i64
+
+    // test common cases
+	assert "70zzz".i64() == 70
+	assert "2901issue".i64() == 2901
+	assert '234232w'.i64() == 234232
+	assert '-9009x'.i64() == -9009
+	assert '0y'.i64() == 0
+	
+	// test lead zeros
+	assert '0000012'.i64() == 12
+	assert '-0000012'.i64() == -12
+	assert '0x001F'.i64() == 31
+	assert '-0x001F'.i64() == -31
+	assert '0x001f'.i64() == 31
+	assert '0o00011'.i64() == 9
+	assert '0b00001001'.i64() == 9
+
+	// test underscore in string
+	assert '-10_000'.i64() == -10000
+	assert '-0x00_0_f_ff'.i64() == -0xfff
+	assert '10_000_000'.i64() == 10000000
+
+	for n in -10000 .. 100000 {
+		s := n.str()+"z"
+		assert s.i64() == n
+	}
+
+	// tests for i8
+
+    // test common cases
+	assert "70zzz".i8() == 70
+	assert "29issue".i8() == 29
+	assert '22w'.i8() == 22
+	assert '-90x'.i8() == -90
+	assert '0y'.i8() == 0
+	
+	// test lead zeros
+	assert '0000012'.i8() == 12
+	assert '-0000012'.i8() == -12
+	assert '0x001F'.i8() == 31
+	assert '-0x001F'.i8() == -31
+	assert '0x001f'.i8() == 31
+	assert '0o00011'.i8() == 9
+	assert '0b000011'.i8() == 3
+
+	// test underscore in string
+	assert '-10_0'.i8() == -100
+	assert '-0x0_0_f'.i8() == -0xf
+	assert '10_0'.i8() == 100
+
+	for n in -10 .. 100 {
+		s := n.str()+"z"
+		assert s.i8() == n
+	}
+
+	// tests for i16
+
+    // test common cases
+	assert "70zzz".i16() == 70
+	assert "2901issue".i16() == 2901
+	assert '2342w'.i16() == 2342
+	assert '-9009x'.i16() == -9009
+	assert '0y'.i16() == 0
+	
+	// test lead zeros
+	assert '0000012'.i16() == 12
+	assert '-0000012'.i16() == -12
+	assert '0x001F'.i16() == 31
+	assert '-0x001F'.i16() == -31
+	assert '0x001f'.i16() == 31
+	assert '0o00011'.i16() == 9
+	assert '0b00001001'.i16() == 9
+
+	// test underscore in string
+	assert '-10_0'.i16() == -100
+	assert '-0x00_0_fff'.i16() == -0xfff
+	assert '10_0'.i16() == 100
+
+	for n in -100 .. 100 {
+		s := n.str()+"z"
+		assert s.i16() == n
+	}
+}

--- a/vlib/compiler/expression.v
+++ b/vlib/compiler/expression.v
@@ -902,6 +902,13 @@ fn (p mut Parser) factor() string {
 			if p.peek() == .str {
 				return p.map_init()
 			}
+			peek2 := p.tokens[p.token_idx + 1]
+			if p.peek() == .name && peek2.tok == .colon {
+				if !p.expected_type.ends_with('Config') {
+					p.error('short struct initialization syntax only works with structs that end with `Config`')
+				}
+				return p.struct_init(p.expected_type)
+			}
 			// { user | name :'new name' }
 			return p.assoc()
 		}

--- a/vlib/compiler/gen_c.v
+++ b/vlib/compiler/gen_c.v
@@ -54,6 +54,11 @@ fn (p mut Parser) gen_fn_decl(f Fn, typ, str_args string) {
 	dll_export_linkage := if p.pref.ccompiler == 'msvc' && p.attr == 'live' && p.pref.is_so { '__declspec(dllexport) ' } else if p.attr == 'inline' { 'static inline ' } else { '' }
 	fn_name_cgen := p.table.fn_gen_name(f)
 	// str_args := f.str_args(p.table)
+	
+	if p.attr == 'live' && p.pref.is_so {
+		// See fn.v for details about impl_live_ functions
+		p.genln('$typ impl_live_${fn_name_cgen} ($str_args);')
+	}
 	p.genln('$dll_export_linkage$typ $fn_name_cgen ($str_args) {')
 }
 

--- a/vlib/compiler/gen_c.v
+++ b/vlib/compiler/gen_c.v
@@ -488,7 +488,9 @@ fn (p mut Parser) gen_struct_init(typ string, t &Type) bool {
 	if typ == 'tm' {
 		p.cgen.lines[p.cgen.lines.len - 1] = ''
 	}
-	p.next()
+	if p.tok != .lcbr {
+		p.next()
+	}
 	p.check(.lcbr)
 	ptr := typ.contains('*')
 	// `user := User{foo:bar}` => `User user = (User){ .foo = bar}`

--- a/vlib/compiler/gen_c.v
+++ b/vlib/compiler/gen_c.v
@@ -628,6 +628,9 @@ fn type_default(typ string) string {
 	if typ.contains('__') {
 		return '{0}'
 	}
+	if typ.ends_with('Fn') { // TODO
+		return '0'
+	}
 	// Default values for other types are not needed because of mandatory initialization
 	match typ {
 		'bool' {

--- a/vlib/compiler/live.v
+++ b/vlib/compiler/live.v
@@ -100,9 +100,11 @@ fn (v &V) generate_hot_reload_code() {
 		}
 		ticks := time.ticks()
 		os.system(cmd_compile_shared_library)
-		diff := time.ticks() - ticks
-		println('compiling shared library took $diff ms')
-		println('=========\n')
+		if v.pref.is_verbose {
+			diff := time.ticks() - ticks
+			println('compiling shared library took $diff ms')
+			println('=========\n')
+		}
 		cgen.genln('
 
 void lfnmutex_print(char *s){

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -472,7 +472,7 @@ fn (v mut V) generate_init() {
           }
       ')
 		}
-		if !v.pref.is_bare {
+		if !v.pref.is_bare && !v.pref.is_so {
 			// vlib can't have `init_consts()`
 			v.cgen.genln('void init() {
 #if VPREALLOC
@@ -581,7 +581,7 @@ pub fn (v mut V) generate_main() {
 			}
 			v.gen_main_end('return g_test_fails > 0')
 		}
-		else if v.table.main_exists() {
+		else if v.table.main_exists() && !v.pref.is_so {
 			v.gen_main_start(true)
 			cgen.genln('  main__main();')
 			if !v.pref.is_bare {

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -1200,14 +1200,14 @@ pub fn create_symlink() {
 	}
 	vexe := vexe_path()
 	mut link_path := '/usr/local/bin/v'
-	mut ret := os.system('ln -sf $vexe $link_path')
+	mut ret := os.system('ln -sf $vexe $link_path 2> /dev/null')
 	if ret == 0 {
 		println('Symlink "$link_path" has been created')
 	}
-	else if os.system('uname -o | grep [A/a]ndroid') == 0 {
+	else if os.system('uname -o | grep -q \'[A/a]ndroid\'') == 0 {
 		println('Failed to create symlink "$link_path". Trying again with Termux path for Android.')
 		link_path = '/data/data/com.termux/files/usr/bin/v'
-		ret = os.system('ln -sf $vexe $link_path')
+		ret = os.system('ln -sf $vexe $link_path 2> /dev/null')
 		if ret == 0 {
 			println('Symlink "$link_path" has been created')
 		} else {

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -1200,15 +1200,14 @@ pub fn create_symlink() {
 	}
 	vexe := vexe_path()
 	mut link_path := '/usr/local/bin/v'
-	mut ret := os.system('ln -sf $vexe $link_path 2> /dev/null')
-	if ret == 0 {
+	mut ret := os.exec('ln -sf $vexe $link_path') or { panic(err) }
+	if ret.exit_code == 0 {
 		println('Symlink "$link_path" has been created')
-	}
-	else if os.system('uname -o | grep -q \'[A/a]ndroid\'') == 0 {
+	} else if os.system('uname -o | grep -q \'[A/a]ndroid\'') == 0 {
 		println('Failed to create symlink "$link_path". Trying again with Termux path for Android.')
 		link_path = '/data/data/com.termux/files/usr/bin/v'
-		ret = os.system('ln -sf $vexe $link_path 2> /dev/null')
-		if ret == 0 {
+		ret = os.exec('ln -sf $vexe $link_path') or { panic(err) }
+		if ret.exit_code == 0 {
 			println('Symlink "$link_path" has been created')
 		} else {
 			println('Failed to create symlink "$link_path". Try again with sudo.')

--- a/vlib/compiler/struct.v
+++ b/vlib/compiler/struct.v
@@ -337,6 +337,7 @@ fn (p mut Parser) struct_decl(generic_param_types []string) {
 	// p.fgenln('//kek')
 }
 // `User{ foo: bar }`
+// tok == struct name
 fn (p mut Parser) struct_init(typ_ string) string {
 	p.is_struct_init = true
 	mut typ := typ_

--- a/vlib/compiler/table.v
+++ b/vlib/compiler/table.v
@@ -621,6 +621,10 @@ fn (p mut Parser) check_types2(got_, expected_ string, throw bool) bool {
 	if got.starts_with('varg_') {
 		got = got[5..]
 	}
+	// fn == 0 temporary
+	if got == 'int' && expected.ends_with('Fn') {
+		return true
+	}
 	// Allow ints to be used as floats
 	if got == 'int' && expected == 'f32' {
 		return true

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -34,14 +34,24 @@ pub:
 	status_code int
 }
 
-pub fn get(url string) ?Response {
-	req := new_request('GET', url, '') or {
-		return error(err)
-	}
-	res := req.do() or {
-		return error(err)
-	}
-	return res
+pub fn get(url string) ?Response { 
+	return method('GET', url, '') 
+}
+
+pub fn head(url string) ?Response {
+	return method('HEAD', url, '')
+}
+
+pub fn delete(url string) ?Response {
+	return method('DELETE', url, '')
+}
+
+pub fn patch(url string) ?Response {
+	return method('PATCH', url, '')
+}
+
+pub fn put(url string) ?Response {
+	return method('PUT', url, '')
 }
 
 pub fn post(url, data string) ?Response {
@@ -54,13 +64,9 @@ pub fn post(url, data string) ?Response {
 	return res
 }
 
-pub fn head(url string) ?Response {
-	req := new_request('HEAD', url, '') or {
-		return error(err)
-	}
-	res := req.do() or {
-		return error(err)
-	}
+pub fn method(mname string, url string, data string) ?Response {
+	req := new_request(mname, url, data) or { return error(err) }
+	res := req.do() or { return error(err)}
 	return res
 }
 

--- a/vlib/time/time_unix.v
+++ b/vlib/time/time_unix.v
@@ -84,10 +84,10 @@ fn calculate_date_from_offset(day_offset_ int) (int, int, int) {
 	}
 
 	mut estimated_month := day_offset / 31
-	for day_offset > days_before[estimated_month+1] {
+	for day_offset >= days_before[estimated_month+1] {
 		estimated_month++
 	}
-	for day_offset <= days_before[estimated_month] {
+	for day_offset < days_before[estimated_month] {
 		if estimated_month == 0 {
 			break
 		}


### PR DESCRIPTION
Ln writes on stderr when it fails, so even if I printed something as a error message, it also prints ln default error message, I'm sending it to /dev/null to avoid displaying 2 times the same error. Also I'm running grep in quiet mode so it doesn't write anything on screen if it does match.