### PR TITLE
github: Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Bug report
 title: ''
-labels: bug
+labels: 'Type: Bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: feature request
+labels: 'Type: Feature Request'
 assignees: ''
 
 ---


### PR DESCRIPTION
After the recent renaming of tags, the issue templates no longer apply the tag properly.
This commit fixes this by configuring config files to use the new tag names.
