### PR TITLE
Deprecate `v runrepl` in favour of `v repl`.

### DIFF
--- a/v.v
+++ b/v.v
@@ -8,15 +8,19 @@ import (
 	benchmark
 	os
 	filepath
-	//v.types
+	// v.types
 	// time
 )
 
 const (
 	known_commands = ['run', 'build', 'version', 'doc']
-	simple_tools = ['fmt', 'up', 'create', 'test', 'test-fmt', 'test-compiler', 'build-tools',
-  'bin2v',
-	'build-examples', 'build-vbinaries']
+	simple_tools = ['fmt',
+	'up',
+	'create',
+	'test', 'test-fmt', 'test-compiler',
+	'bin2v',
+	'repl',
+	'build-tools', 'build-examples', 'build-vbinaries']
 )
 
 fn main() {
@@ -110,6 +114,8 @@ fn v_command(command string, args []string) {
 			compiler.create_symlink()
 		}
 		'runrepl' {
+			//TODO: remove this after 2020/02/01
+			eprintln('`v runrepl` has been deprecated. Please use `v repl` instead.')
 			compiler.launch_tool('vrepl', 'runrepl')
 		}
 		'doc' {

--- a/vlib/compiler/tests/repl/runner/runner.v
+++ b/vlib/compiler/tests/repl/runner/runner.v
@@ -58,10 +58,10 @@ pub fn run_repl_file(wd string, vexec string, file string) ?string {
 	
 	input_temporary_filename := 'input_temporary_filename.txt'
 	os.write_file(input_temporary_filename, input)
-
-	r := os.exec('"$vexec" runrepl < $input_temporary_filename') or {
+	rcmd := '"$vexec" repl < $input_temporary_filename'
+	r := os.exec(rcmd) or {
 		os.rm(input_temporary_filename)
-		return error('Could not execute "$vexec runrepl < $input_temporary_filename" ')
+		return error('Could not execute: $rcmd')
 	}
 	os.rm(input_temporary_filename)
 

--- a/vlib/compiler/vhelp.v
+++ b/vlib/compiler/vhelp.v
@@ -51,7 +51,7 @@ Options/commands:
 
   -obf              Obfuscate the resulting binary.
   -compress         Compress the resulting binary.
-  -                 Shorthand for `v runrepl`.
+  -                 Shorthand for `v repl`.
 
 Options for debugging/troubleshooting v programs:
   -g                Generate debugging information in the backtraces. Add *V* line numbers to the generated executable.
@@ -69,7 +69,7 @@ Commands:
   up                Update V. Run `v up` at least once per day, since V development is rapid and features/bugfixes are added constantly.
   run <file.v>      Build and execute the V program in file.v. You can add arguments for the V program *after* the file name.
   build <module>    Compile a module into an object file.
-  runrepl           Run the V REPL. If V is running in a tty terminal, the REPL is interactive, otherwise it just reads from stdin.
+  repl              Run the V REPL. If V is running in a tty terminal, the REPL is interactive, otherwise it just reads from stdin.
   symlink           Useful on Unix systems. Symlinks the current V executable to /usr/local/bin/v, so that V is globally available.
   test v            Run all V test files, and compile all V examples.
   test folder/      Run all V test files located in the folder and its subfolders. You can also pass individual _test.v files too.

--- a/vlib/sokol/sokol.v
+++ b/vlib/sokol/sokol.v
@@ -32,6 +32,7 @@ module sokol
 #define SOKOL_GL_IMPL
 #include "util/sokol_gl.h"
 
+#define FONS_USE_FREETYPE
 #define FONTSTASH_IMPLEMENTATION
 #include "fontstash.h"
 #define SOKOL_FONTSTASH_IMPL

--- a/vlib/sokol/sokol.v
+++ b/vlib/sokol/sokol.v
@@ -32,7 +32,6 @@ module sokol
 #define SOKOL_GL_IMPL
 #include "util/sokol_gl.h"
 
-#define FONS_USE_FREETYPE
 #define FONTSTASH_IMPLEMENTATION
 #include "fontstash.h"
 #define SOKOL_FONTSTASH_IMPL


### PR DESCRIPTION
`v runrepl` still works for now, but prints a deprecation message first.

The REPL tests are now run using the new `v repl` command.

The name in the help screen is updated to `repl` too.

In the next few weeks, the `v runrepl` will be removed completely from v.v .