### PR TITLE
tools/modules/testing: Make testing run in parallel

### DIFF
--- a/tools/modules/testing/common.v
+++ b/tools/modules/testing/common.v
@@ -70,7 +70,12 @@ pub fn (ts mut TestSession) test() {
 	}
 	ts.benchmark.set_total_expected_steps(remaining_files.len)
 	ts.files = remaining_files
-	for i in 1..runtime.nr_cpus() {
+	mut ncpus := runtime.nr_cpus
+	$if msvc {
+		// See: https://docs.microsoft.com/en-us/cpp/build/reference/fs-force-synchronous-pdb-writes?view=vs-2019
+		ncpus = 1
+	}
+	for i in 1..ncpus {
 		go ts.build_instance(tmpd, show_stats)
 	}
 	ts.build_instance(tmpd, show_stats)

--- a/tools/modules/testing/common.v
+++ b/tools/modules/testing/common.v
@@ -70,12 +70,12 @@ pub fn (ts mut TestSession) test() {
 	}
 	ts.benchmark.set_total_expected_steps(remaining_files.len)
 	ts.files = remaining_files
-	mut ncpus := runtime.nr_cpus
+	mut ncpus := runtime.nr_cpus()
 	$if msvc {
 		// See: https://docs.microsoft.com/en-us/cpp/build/reference/fs-force-synchronous-pdb-writes?view=vs-2019
 		ncpus = 1
 	}
-	for i in 1..ncpus {
+	for _ in 1..ncpus {
 		go ts.build_instance(tmpd, show_stats)
 	}
 	ts.build_instance(tmpd, show_stats)

--- a/vlib/benchmark/abenchmark_single.v
+++ b/vlib/benchmark/abenchmark_single.v
@@ -1,0 +1,103 @@
+module benchmark
+
+pub struct Benchmark {
+	//TODO Change this to an embedded struct when it works properly
+pub mut:
+	concurrent ConcurrentBenchmark
+	instance   ?ConcurrentInstance
+}
+
+pub fn new_benchmark() Benchmark {
+	return Benchmark{
+		concurrent: new_concurrent_benchmark()
+		instance: none
+	}
+}
+
+pub fn (b mut Benchmark) set_total_expected_steps(n int) {
+	b.concurrent.set_total_expected_steps(n)
+}
+
+pub fn (b mut Benchmark) stop() {
+	b.concurrent.stop()
+}
+
+pub fn (b mut Benchmark) step() {
+	b.instance = b.concurrent.step()
+}
+
+pub fn (b mut Benchmark) fail() {
+	mut instance := b.instance or {
+		panic("could not fail when there's no step")
+	}
+	instance.fail()
+}
+
+pub fn (b mut Benchmark) ok() {
+	mut instance := b.instance or {
+		panic("could not ok when there's no step")
+	}
+	instance.ok()
+}
+
+pub fn (b mut Benchmark) fail_many(n int) {
+	mut instance := b.instance or {
+		panic("could not fail when there's no step")
+	}
+	instance.fail_many(n)
+}
+
+pub fn (b mut Benchmark) ok_many(n int) {
+	mut instance := b.instance or {
+		panic("could not ok when there's no step")
+	}
+	instance.ok_many(n)
+}
+
+pub fn (b mut Benchmark) neither_fail_nor_ok() {
+	mut instance := b.instance or {
+		panic("could not set status when there's no step")
+	}
+	instance.neither_fail_nor_ok()
+}
+
+pub fn (b &Benchmark) step_message_with_label(label string, msg string) string {
+	mut instance := b.instance or {
+		panic("could not print step message when there's no step")
+	}
+	return instance.step_message_with_label(label, msg)
+}
+
+pub fn (b &Benchmark) step_message(msg string) string {
+	mut instance := b.instance or {
+		panic("could not print step message when there's no step")
+	}
+	return instance.step_message(msg)
+}
+
+pub fn (b &Benchmark) step_message_ok(msg string) string {
+	mut instance := b.instance or {
+		panic("could not print step message when there's no step")
+	}
+	return instance.step_message_ok(msg)
+}
+
+pub fn (b &Benchmark) step_message_fail(msg string) string {
+	mut instance := b.instance or {
+		panic("could not print step message when there's no step")
+	}
+	return instance.step_message_fail(msg)
+}
+
+pub fn (b &Benchmark) total_message(msg string) string {
+	return b.concurrent.total_message(msg)
+}
+
+pub fn (b &Benchmark) total_duration() i64 {
+	return b.concurrent.total_duration()
+}
+
+// //////////////////////////////////////////////////////////////////
+fn (b &Benchmark) tdiff_in_ms(s string, sticks i64, eticks i64) string {
+	return b.concurrent.tdiff_in_ms(s, sticks, eticks)
+}

--- a/vlib/benchmark/abenchmark_single.v
+++ b/vlib/benchmark/abenchmark_single.v
@@ -26,35 +26,35 @@ pub fn (b mut Benchmark) step() {
 	b.instance = b.concurrent.step()
 }
 
-pub fn (b mut Benchmark) fail() {
+pub fn (b &Benchmark) fail() {
 	mut instance := b.instance or {
 		panic("could not fail when there's no step")
 	}
 	instance.fail()
 }
 
-pub fn (b mut Benchmark) ok() {
+pub fn (b &Benchmark) ok() {
 	mut instance := b.instance or {
 		panic("could not ok when there's no step")
 	}
 	instance.ok()
 }
 
-pub fn (b mut Benchmark) fail_many(n int) {
+pub fn (b &Benchmark) fail_many(n int) {
 	mut instance := b.instance or {
 		panic("could not fail when there's no step")
 	}
 	instance.fail_many(n)
 }
 
-pub fn (b mut Benchmark) ok_many(n int) {
+pub fn (b &Benchmark) ok_many(n int) {
 	mut instance := b.instance or {
 		panic("could not ok when there's no step")
 	}
 	instance.ok_many(n)
 }
 
-pub fn (b mut Benchmark) neither_fail_nor_ok() {
+pub fn (b &Benchmark) neither_fail_nor_ok() {
 	mut instance := b.instance or {
 		panic("could not set status when there's no step")
 	}
@@ -62,28 +62,28 @@ pub fn (b mut Benchmark) neither_fail_nor_ok() {
 }
 
 pub fn (b &Benchmark) step_message_with_label(label string, msg string) string {
-	mut instance := b.instance or {
+	instance := b.instance or {
 		panic("could not print step message when there's no step")
 	}
 	return instance.step_message_with_label(label, msg)
 }
 
 pub fn (b &Benchmark) step_message(msg string) string {
-	mut instance := b.instance or {
+	instance := b.instance or {
 		panic("could not print step message when there's no step")
 	}
 	return instance.step_message(msg)
 }
 
 pub fn (b &Benchmark) step_message_ok(msg string) string {
-	mut instance := b.instance or {
+	instance := b.instance or {
 		panic("could not print step message when there's no step")
 	}
 	return instance.step_message_ok(msg)
 }
 
 pub fn (b &Benchmark) step_message_fail(msg string) string {
-	mut instance := b.instance or {
+	instance := b.instance or {
 		panic("could not print step message when there's no step")
 	}
 	return instance.step_message_fail(msg)

--- a/vlib/benchmark/benchmark.v
+++ b/vlib/benchmark/benchmark.v
@@ -2,6 +2,7 @@ module benchmark
 
 import time
 import term
+
 /*
 Example usage of this module:
 ```
@@ -25,110 +26,124 @@ println( bmark.total_message('remarks about the benchmark') )
 ```
 */
 
-
 const (
 	BOK = term.ok_message('OK')
 	BFAIL = term.fail_message('FAIL')
 )
 
-pub struct Benchmark {
+pub struct ConcurrentBenchmark {
 pub mut:
 	bench_start_time i64
 	bench_end_time   i64
-	step_start_time  i64
-	step_end_time    i64
 	ntotal           int
 	nok              int
 	nfail            int
 	verbose          bool
 	nexpected_steps  int
-	cstep            int
 	bok              string
 	bfail            string
 }
 
-pub fn new_benchmark() Benchmark {
-	return Benchmark{
+pub struct ConcurrentInstance {
+pub mut:
+	benchmark       &ConcurrentBenchmark
+	step_start_time i64
+	step_end_time   i64
+	step_number     int
+}
+
+pub fn new_concurrent_benchmark() ConcurrentBenchmark {
+	return ConcurrentBenchmark{
 		bench_start_time: benchmark.now()
 		verbose: true
 	}
 }
 
-pub fn (b mut Benchmark) set_total_expected_steps(n int) {
+pub fn (b mut ConcurrentBenchmark) set_total_expected_steps(n int) {
 	b.nexpected_steps = n
 }
 
-pub fn (b mut Benchmark) stop() {
+pub fn (b mut ConcurrentBenchmark) stop() {
 	b.bench_end_time = benchmark.now()
 }
 
-pub fn (b mut Benchmark) step() {
-	b.step_start_time = benchmark.now()
-	b.cstep++
+pub fn (b &ConcurrentBenchmark) step() ConcurrentInstance {
+	return ConcurrentInstance {
+		benchmark: b
+		step_start_time: benchmark.now()
+	}
 }
 
-pub fn (b mut Benchmark) fail() {
+pub fn (b mut ConcurrentInstance) fail() {
 	b.step_end_time = benchmark.now()
-	b.ntotal++
-	b.nfail++
+	b.benchmark.ntotal++
+	b.benchmark.nfail++
+	b.step_number = b.benchmark.ntotal
 }
 
-pub fn (b mut Benchmark) ok() {
+pub fn (b mut ConcurrentInstance) ok() {
 	b.step_end_time = benchmark.now()
-	b.ntotal++
-	b.nok++
+	b.benchmark.ntotal++
+	b.benchmark.nok++
+	b.step_number = b.benchmark.ntotal
 }
 
-pub fn (b mut Benchmark) fail_many(n int) {
+pub fn (b mut ConcurrentInstance) fail_many(n int) {
 	b.step_end_time = benchmark.now()
-	b.ntotal += n
-	b.nfail += n
+	b.benchmark.ntotal += n
+	b.benchmark.nfail += n
+	b.step_number = b.benchmark.ntotal
 }
 
-pub fn (b mut Benchmark) ok_many(n int) {
+pub fn (b mut ConcurrentInstance) ok_many(n int) {
 	b.step_end_time = benchmark.now()
-	b.ntotal += n
-	b.nok += n
+	b.benchmark.ntotal += n
+	b.benchmark.nok += n
+	b.step_number = b.benchmark.ntotal
 }
 
-pub fn (b mut Benchmark) neither_fail_nor_ok() {
+pub fn (b mut ConcurrentInstance) neither_fail_nor_ok() {
 	b.step_end_time = benchmark.now()
+	b.benchmark.ntotal++
+	b.step_number = b.benchmark.ntotal
 }
 
-pub fn (b &Benchmark) step_message_with_label(label string, msg string) string {
+pub fn (b &ConcurrentInstance) step_message_with_label(label string, msg string) string {
 	mut timed_line := ''
-	if b.nexpected_steps > 0 {
+	expected_steps := b.benchmark.nexpected_steps
+
+	if expected_steps > 0 {
 		mut sprogress := ''
-		if b.nexpected_steps < 10 {
-			sprogress = '${b.cstep:1d}/${b.nexpected_steps:1d}'
+		if expected_steps < 10 {
+			sprogress = '${b.step_number:1d}/${expected_steps:1d}'
 		}
-		if b.nexpected_steps >= 10 && b.nexpected_steps < 100 {
-			sprogress = '${b.cstep:2d}/${b.nexpected_steps:2d}'
+		if expected_steps >= 10 && expected_steps < 100 {
+			sprogress = '${b.step_number:2d}/${expected_steps:2d}'
 		}
-		if b.nexpected_steps >= 100 && b.nexpected_steps < 1000 {
-			sprogress = '${b.cstep:3d}/${b.nexpected_steps:3d}'
+		if expected_steps >= 100 && expected_steps < 1000 {
+			sprogress = '${b.step_number:3d}/${expected_steps:3d}'
 		}
-		timed_line = b.tdiff_in_ms('[${sprogress}] $msg', b.step_start_time, b.step_end_time)
+		timed_line = b.benchmark.tdiff_in_ms('[${sprogress}] $msg', b.step_start_time, b.step_end_time)
 	}
 	else {
-		timed_line = b.tdiff_in_ms(msg, b.step_start_time, b.step_end_time)
+		timed_line = b.benchmark.tdiff_in_ms(msg, b.step_start_time, b.step_end_time)
 	}
 	return '${label:-5s}${timed_line}'
 }
 
-pub fn (b &Benchmark) step_message(msg string) string {
+pub fn (b &ConcurrentInstance) step_message(msg string) string {
 	return b.step_message_with_label('', msg)
 }
 
-pub fn (b &Benchmark) step_message_ok(msg string) string {
+pub fn (b &ConcurrentInstance) step_message_ok(msg string) string {
 	return b.step_message_with_label(BOK, msg)
 }
 
-pub fn (b &Benchmark) step_message_fail(msg string) string {
+pub fn (b &ConcurrentInstance) step_message_fail(msg string) string {
 	return b.step_message_with_label(BFAIL, msg)
 }
 
-pub fn (b &Benchmark) total_message(msg string) string {
+pub fn (b &ConcurrentBenchmark) total_message(msg string) string {
 	mut tmsg := '${msg}\n                 ok, fail, total = ' + term.ok_message('${b.nok:5d}') + ', ' + if b.nfail > 0 { term.fail_message('${b.nfail:5d}') } else { '${b.nfail:5d}' } + ', ' + '${b.ntotal:5d}'
 	if b.verbose {
 		tmsg = '<=== total time spent $tmsg'
@@ -136,12 +151,12 @@ pub fn (b &Benchmark) total_message(msg string) string {
 	return '  ' + b.tdiff_in_ms(tmsg, b.bench_start_time, b.bench_end_time)
 }
 
-pub fn (b &Benchmark) total_duration() i64 {
+pub fn (b &ConcurrentBenchmark) total_duration() i64 {
 	return (b.bench_end_time - b.bench_start_time)
 }
 
 // //////////////////////////////////////////////////////////////////
-fn (b &Benchmark) tdiff_in_ms(s string, sticks i64, eticks i64) string {
+fn (b &ConcurrentBenchmark) tdiff_in_ms(s string, sticks i64, eticks i64) string {
 	if b.verbose {
 		tdiff := (eticks - sticks)
 		return '${tdiff:6lld} ms $s'


### PR DESCRIPTION
This PR does two things:
- Make a concurrent friendly version of `vlib/benchmark`
- Make testing (ie. vtest-compiler) run with multiple cores

This allows testing to be completed faster before V compiling is properly multi-threaded.

Before (on commit `b1602c72`):
```
$ time (make && v test-compiler)
   20542 ms <=== total time spent building tools
  130889 ms <=== total time spent running V tests
   29244 ms <=== total time spent building examples
    7874 ms <=== total time spent building examples/hot_reload
Installing a v module took: 7081ms
( make && v test-compiler; )  180.77s user 14.91s system 94% cpu 3:26.69 total
```

After (my CPU has 4 cores):
```
$ time (make && v test-compiler)
    6692 ms <=== total time spent building tools
   59377 ms <=== total time spent running V tests
    8225 ms <=== total time spent building examples
    3502 ms <=== total time spent building examples/hot_reload
Installing a v module took: 6664ms
( make && v test-compiler; )  304.95s user 20.79s system 345% cpu 1:34.17 total
```

While individual test time is longer, it doesn't matter as 8 threads are working on it concurrently.
What I've noticed is that `repl_test.v` was the bottleneck in both cases, using up 42347ms (before) and 48910ms (after, causing only one CPU to be used as other test finished).
Therefore, if we wanted to make tests more parallel, `repl_test.v` is the target to optimize. 