### PR TITLE
sync: make sync.new_mutex() and sync.new_waitgroup() return &Mutex and &Waitgroup.

### DIFF
--- a/examples/news_fetcher.v
+++ b/examples/news_fetcher.v
@@ -63,15 +63,11 @@ fn main() {
 		}
 		ids = tmp
 	}
-	wg := sync.new_waitgroup()
-	mtx := sync.new_mutex()
 	mut fetcher := &Fetcher{
 		ids: ids
-		mu: 0
-		wg: 0
+		mu: sync.new_mutex()
+		wg: sync.new_waitgroup()
 	}
-	fetcher.mu = &mtx
-	fetcher.wg = &wg
 	fetcher.wg.add(ids.len)
 	for i := 0; i < nr_threads; i++ {
 		go fetcher.fetch()

--- a/vlib/clipboard/clipboard_linux.v
+++ b/vlib/clipboard/clipboard_linux.v
@@ -103,7 +103,7 @@ pub struct Clipboard {
 	selection Atom //the selection atom
 	window Window
 	atoms []Atom
-	mutex sync.Mutex
+	mutex &sync.Mutex
 	text string // text data sent or received
 	got_text bool // used to confirm that we have got the text
 	is_owner bool // to save selection owner state
@@ -137,7 +137,7 @@ fn new_x11_clipboard(selection atom_type) &Clipboard {
 
 	if display == C.NULL {
 		println("ERROR: No X Server running. Clipboard cannot be used.")
-		return &Clipboard{ display: 0 }
+		return &Clipboard{ display: 0 mutex: sync.new_mutex() }
 	}
 
 	mut cb := &Clipboard{

--- a/vlib/sync/sync_nix.v
+++ b/vlib/sync/sync_nix.v
@@ -16,9 +16,8 @@ pub struct Mutex {
 	mutex C.pthread_mutex_t
 }
 
-pub fn new_mutex() Mutex {
-	m := Mutex{
-	}
+pub fn new_mutex() &Mutex {
+	m := &Mutex{}
 	C.pthread_mutex_init(&m.mutex, C.NULL)
 	return m
 }

--- a/vlib/sync/sync_windows.v
+++ b/vlib/sync/sync_windows.v
@@ -39,8 +39,8 @@ const (
 	WAIT_FAILED        = 0xFFFFFFFF
 )
 
-pub fn new_mutex() Mutex {
-	sm := Mutex{}
+pub fn new_mutex() &Mutex {
+	sm := &Mutex{}
 	unsafe {
 		mut m := sm		
 		m.mx = C.CreateMutex(0, false, 0)
@@ -48,8 +48,8 @@ pub fn new_mutex() Mutex {
 			m.state = .broken // handle broken and mutex state are broken
 			return sm
 		}		
-		return sm
 	}
+	return sm
 }
 
 pub fn (m mut Mutex) lock() {

--- a/vlib/sync/waitgroup.v
+++ b/vlib/sync/waitgroup.v
@@ -5,15 +5,12 @@ module sync
 // [init_with=new_waitgroup] // TODO: implement support for init_with struct attribute, and disallow WaitGroup{} from outside the sync.new_waitgroup() function.
 pub struct WaitGroup {
 mut:
-	mu     Mutex
+	mu     &Mutex = &Mutex(0)
 	active int
 }
 
-pub fn new_waitgroup() WaitGroup {
-	mut w := WaitGroup{
-	}
-	w.mu = sync.new_mutex()
-	return w
+pub fn new_waitgroup() &WaitGroup {
+	return &WaitGroup{mu: sync.new_mutex() }
 }
 
 pub fn (wg mut WaitGroup) add(delta int) {


### PR DESCRIPTION
This PR makes using mutexes and waitgroups more consistent
(and avoids C errors when there is a mismatch)