### PR TITLE
compiler: fix stuck parsing of 'enum{}' . Show an error instead.

### DIFF
--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -504,6 +504,8 @@ Please create a GitHub issue: https://github.com/vlang/v/issues/new/choose .
 					// (for example, by DOOM). such fields are
 					// basically int consts
 					p.enum_decl(true)
+				} else {
+					p.error('Nameless enums are not allowed.')
 				}
 			}
 			.key_pub {

--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -465,15 +465,15 @@ fn (p mut Parser) parse(pass Pass) {
 	
 	parsing_start_ticks := time.ticks()
 	compile_cycles_stuck_mask := u64( 0x1FFFFFFF ) // 2^29-1 cycles
-	mut c := u64(1)
+	mut parsing_cycle := u64(1)
 	mut old_token_index := p.token_idx
 	// Go through every top level token or throw a compilation error if a non-top level token is met
 	for {
-		c++
-		if compile_cycles_stuck_mask == (c & compile_cycles_stuck_mask) {
+		parsing_cycle++
+		if compile_cycles_stuck_mask == (parsing_cycle & compile_cycles_stuck_mask) {
 			if old_token_index == p.token_idx {
 				// many many cycles have passed with no progress :-( ...
-				eprintln('Parsing is [probably] stuck. Cycle: ${c:12ld} .')
+				eprintln('Parsing is [probably] stuck. Cycle: ${parsing_cycle:12ld} .')
 				eprintln('  parsing file: ${p.file_path} | pass: ${p.pass} | mod: ${p.mod} | fn: ${p.cur_fn.name}')
 				p.print_current_tokens('  source')
 				if time.ticks() > parsing_start_ticks + 10*1000{

--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -471,7 +471,7 @@ fn (p mut Parser) parse(pass Pass) {
 		if compile_cycles_stuck_mask == (c & compile_cycles_stuck_mask) {
 			if old_token_index == p.token_idx {
 				// many many cycles have passed with no progress :-( ...
-				eprintln('V compilation has probably stucked :-|')
+				eprintln('V compilation is [probably] stuck.')
 				eprintln('  parsing file: ${p.file_path} | pass: ${p.pass} | mod: ${p.mod} | fn: ${p.cur_fn.name}')
 				p.print_current_tokens('  cycle: $c')
 			}

--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -8,7 +8,7 @@ import (
 	strings
 	filepath
 	//compiler.x64
-	// time
+	time
 )
 
 struct Parser {
@@ -462,6 +462,8 @@ fn (p mut Parser) parse(pass Pass) {
 		}
 		return
 	}
+	
+	parsing_start_ticks := time.ticks()
 	compile_cycles_stuck_mask := u64( 0x1FFFFFFF ) // 2^29-1 cycles
 	mut c := u64(1)
 	mut old_token_index := p.token_idx
@@ -471,9 +473,18 @@ fn (p mut Parser) parse(pass Pass) {
 		if compile_cycles_stuck_mask == (c & compile_cycles_stuck_mask) {
 			if old_token_index == p.token_idx {
 				// many many cycles have passed with no progress :-( ...
-				eprintln('V compilation is [probably] stuck.')
+				eprintln('Parsing is [probably] stuck. Cycle: ${c:12ld} .')
 				eprintln('  parsing file: ${p.file_path} | pass: ${p.pass} | mod: ${p.mod} | fn: ${p.cur_fn.name}')
-				p.print_current_tokens('  cycle: $c')
+				p.print_current_tokens('  source')
+				if time.ticks() > parsing_start_ticks + 10*1000{
+					p.warn('V compiling is too slow.')
+				}
+				if time.ticks() > parsing_start_ticks + 30*1000{
+					p.error('
+V took more than 30 seconds to compile this file.
+Please create a GitHub issue: https://github.com/vlang/v/issues/new/choose .
+')
+				}
 			}
 			old_token_index = p.token_idx
 		}

--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -504,7 +504,7 @@ Please create a GitHub issue: https://github.com/vlang/v/issues/new/choose .
 					// (for example, by DOOM). such fields are
 					// basically int consts
 					p.enum_decl(true)
-				}				
+				}
 			}
 			.key_pub {
 				next := p.peek()

--- a/vlib/compiler/enum.v
+++ b/vlib/compiler/enum.v
@@ -106,13 +106,16 @@ int typ;
 } $enum_name;
 '
 	}
-	// Skip empty enums
+	// Skip nameless enums
 	else if !no_name && !p.first_pass() {
 		p.cgen.typedefs << 'typedef int $enum_name;'
-	}
+	}	
 	p.check(.rcbr)
 	p.fgen_nl()
 	p.fgen_nl()
+	if !no_name && fields.len == 0 {
+		p.error('Empty enums are not allowed.')
+	}
 }
 
 fn (p mut Parser) check_enum_member_access() {

--- a/vlib/gl/gl.v
+++ b/vlib/gl/gl.v
@@ -9,7 +9,7 @@ module gl
 #flag @VROOT/thirdparty/glad/glad.o
 
 // joe-c: fix & remove
-pub enum TmpGlImportHack{}
+pub enum TmpGlImportHack{ non_empty }
 
 pub fn init_glad() {
 	ok := C.gladLoadGL()


### PR DESCRIPTION
This PR fixes stuck parsing of a file containing just 'enum{}' .

It also implements a simple counter based detector for simillar situations (stuck parsing).