### PR TITLE
compiler: update cheaders.v for NetBSD support

### DIFF
--- a/vlib/compiler/cheaders.v
+++ b/vlib/compiler/cheaders.v
@@ -88,6 +88,10 @@ const (
 #include <sys/wait.h> // os__wait uses wait on nix
 #endif
 
+#ifdef __NetBSD__
+#include <sys/wait.h> // os__wait uses wait on nix
+#endif
+
 $c_common_macros
 
 #ifdef _WIN32


### PR DESCRIPTION
To avoid following errors under NetBSD
```
/var/tmp//ccyQ2FLB.o: In function `os__posix_wait4_to_exit_status':
v.c:(.text+0xb185): undefined reference to `WIFEXITED'
v.c:(.text+0xb198): undefined reference to `WEXITSTATUS'
v.c:(.text+0xb1b3): undefined reference to `WIFSIGNALED'
v.c:(.text+0xb1c6): undefined reference to `WTERMSIG'
```