### PR TITLE
compiler: remove --lzma option from upx call

### DIFF
--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -395,7 +395,7 @@ start:
 			println('strip failed')
 			return
 		}
-		ret2 := os.system('upx --lzma -qqq $v.out_name')
+		ret2 := os.system('upx -qqq $v.out_name')
 		if ret2 != 0 {
 			println('upx failed')
 			$if macos {

--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -395,7 +395,12 @@ start:
 			println('strip failed')
 			return
 		}
-		ret2 := os.system('upx -qqq $v.out_name')
+		// NB: upx --lzma can sometimes fail with NotCompressibleException
+		// See https://github.com/vlang/v/pull/3528
+		mut ret2 := os.system('upx --lzma -qqq $v.out_name')
+		if ret2 != 0 {
+			ret2 = os.system('upx -qqq $v.out_name')
+		}
 		if ret2 != 0 {
 			println('upx failed')
 			$if macos {


### PR DESCRIPTION
UPX can throw NotCompressibleException for some reasons, in this case compiler says that we haven't installed it and willn't use compression at all. Without using --lzma flag I've succesfully compressed the same binary file.
I'm not sure about what to do with tests, at this time I haven't removed --lzma from test code.

Maybe we need public discussion about default preferences for UPX.