### PR TITLE
compiler: fix module alias resolution

### DIFF
--- a/examples/gg2.v
+++ b/examples/gg2.v
@@ -1,6 +1,6 @@
 module main
 
-import gg2 // as gg
+import gg2 as gg
 import gx
 
 const (
@@ -10,12 +10,12 @@ const (
 
 struct App {
 mut:
-	gg &gg2.GG
+	gg &gg.GG
 }
 
 fn main() {
 	mut app := &App{}
-	app.gg = gg2.new_context({
+	app.gg = gg.new_context({
 		bg_color: gx.white
 		width: win_width
 		height: win_height

--- a/vlib/compiler/get_type.v
+++ b/vlib/compiler/get_type.v
@@ -147,8 +147,10 @@ fn (p mut Parser) get_type2() Type {
 			// try resolve full submodule
 			if !p.builtin_mod && p.import_table.known_alias(typ) {
 				mod := p.import_table.resolve_alias(typ)
-				if mod.contains('.') {
-					typ = mod_gen_name(mod)
+				typ = if mod.contains('.') {
+					mod_gen_name(mod)
+				} else {
+					mod
 				}
 			}
 			p.next()

--- a/vlib/compiler/tests/module_test.v
+++ b/vlib/compiler/tests/module_test.v
@@ -1,18 +1,25 @@
 import os
 import time as t
 import crypto.sha256 as s2
-
 import (
 	math
 	log as l
 	crypto.sha512 as s5
 )
 
+struct TestAliasInStruct {
+	time t.Time
+}
+
 fn test_import() {
-	assert os.O_RDONLY == os.O_RDONLY &&
-		t.month_days[0] == t.month_days[0] &&
-		s2.size == s2.size &&
-		math.pi == math.pi &&
-		l.INFO == l.INFO &&
-		s5.size == s5.size
+	assert os.O_RDONLY == os.O_RDONLY && t.month_days[0] == t.month_days[0] && s2.size == s2.size && math.pi == math.pi && l.INFO == l.INFO && s5.size == s5.size
+}
+
+fn test_alias_in_struct_field() {
+	a := TestAliasInStruct{
+		time: t.Time{
+			year: 2020
+		}
+	}
+	assert a.time.year == 2020
 }


### PR DESCRIPTION
compiler: fix module alias resolution

This fixes the use of module alias in some cases such as in struct fields