### PR TITLE
compiler: add 'use -- instead of -= 1' message

### DIFF
--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -1606,6 +1606,13 @@ fn ($v.name mut $v.typ) ${p.cur_fn.name}(...) {
 				p.gen(' += ')
 			}
 		}
+		.minus_assign {
+				next := p.peek_token()
+				if next.tok == .number && next.lit == '1' {
+					p.error('use `--` instead of `-= 1`')
+				}
+				p.gen(' -= ')
+		}
 		else {
 			p.gen(' ' + p.tok.str() + ' ')
 		}

--- a/vlib/time/time_unix.v
+++ b/vlib/time/time_unix.v
@@ -8,7 +8,7 @@ pub fn unix(abs int) Time {
 	mut day_offset := abs / seconds_per_day
 	if abs % seconds_per_day < 0 {
 		// Compensate for round towards zero on integers as we want floored instead
-		day_offset --
+		day_offset--
 	}
 	year, month, day := calculate_date_from_offset(day_offset)
 	hr, min, sec := calculate_time_from_offset(abs % seconds_per_day)

--- a/vlib/time/time_unix.v
+++ b/vlib/time/time_unix.v
@@ -10,8 +10,8 @@ pub fn unix(abs int) Time {
 		// Compensate for round towards zero on integers as we want floored instead
 		day_offset--
 	}
-	year, month, day := calculate_date_from_offset(day_offset)
-	hr, min, sec := calculate_time_from_offset(abs % seconds_per_day)
+	year,month,day := calculate_date_from_offset(day_offset)
+	hr,min,sec := calculate_time_from_offset(abs % seconds_per_day)
 	return Time{
 		year: year
 		month: month
@@ -24,67 +24,64 @@ pub fn unix(abs int) Time {
 }
 
 [inline]
-fn calculate_date_from_offset(day_offset_ int) (int, int, int) {
+fn calculate_date_from_offset(day_offset_ int) (int,int,int) {
 	mut day_offset := day_offset_
-
 	// Move offset to year 2001 as it's the start of a new 400-year cycle
 	// Code below this rely on the fact that the day_offset is lined up with the 400-year cycle
 	// 1970-2000 (inclusive) has 31 years (8 of which are leap years)
 	mut year := 2001
-	day_offset -= 31*365 + 8
-
+	day_offset -= 31 * 365 + 8
 	// Account for 400 year cycle
 	year += (day_offset / days_per_400_years) * 400
 	day_offset %= days_per_400_years
-
 	// Account for 100 year cycle
 	if day_offset == days_per_100_years * 4 {
 		year += 300
 		day_offset -= days_per_100_years * 3
-	} else {
+	}
+	else {
 		year += (day_offset / days_per_100_years) * 100
 		day_offset %= days_per_100_years
 	}
-
 	// Account for 4 year cycle
 	if day_offset == days_per_4_years * 25 {
 		year += 96
 		day_offset -= days_per_4_years * 24
-	} else {
+	}
+	else {
 		year += (day_offset / days_per_4_years) * 4
 		day_offset %= days_per_4_years
 	}
-
 	// Account for every year
 	if day_offset == 365 * 4 {
 		year += 3
 		day_offset -= 365 * 3
-	} else {
+	}
+	else {
 		year += (day_offset / 365)
 		day_offset %= 365
 	}
-
 	if day_offset < 0 {
 		year--
 		if is_leap_year(year) {
 			day_offset += 366
-		} else {
+		}
+		else {
 			day_offset += 365
 		}
 	}
-
 	if is_leap_year(year) {
 		if day_offset > 31 + 29 - 1 {
 			// After leap day; pretend it wasn't there.
 			day_offset--
-		} else if day_offset == 31 + 29 - 1 {
+		}
+		else if day_offset == 31 + 29 - 1 {
 			// Leap day.
-			return year, 2, 29
+			return year,2,29
 		}
 	}
-
 	mut estimated_month := day_offset / 31
-	for day_offset >= days_before[estimated_month+1] {
+	for day_offset >= days_before[estimated_month + 1] {
 		estimated_month++
 	}
 	for day_offset < days_before[estimated_month] {
@@ -93,24 +90,19 @@ fn calculate_date_from_offset(day_offset_ int) (int, int, int) {
 		}
 		estimated_month--
 	}
-
 	day_offset -= days_before[estimated_month]
-
-	return year, estimated_month+1, day_offset+1
+	return year,estimated_month + 1,day_offset + 1
 }
 
 [inline]
-fn calculate_time_from_offset(second_offset_ int) (int, int, int) {
+fn calculate_time_from_offset(second_offset_ int) (int,int,int) {
 	mut second_offset := second_offset_
 	if second_offset < 0 {
 		second_offset += seconds_per_day
 	}
-
 	hour := second_offset / seconds_per_hour
 	second_offset %= seconds_per_hour
-
 	min := second_offset / seconds_per_minute
 	second_offset %= seconds_per_minute
-
-	return hour, min, second_offset
+	return hour,min,second_offset
 }

--- a/vlib/time/time_unix.v
+++ b/vlib/time/time_unix.v
@@ -8,7 +8,7 @@ pub fn unix(abs int) Time {
 	mut day_offset := abs / seconds_per_day
 	if abs % seconds_per_day < 0 {
 		// Compensate for round towards zero on integers as we want floored instead
-		day_offset -= 1
+		day_offset --
 	}
 	year, month, day := calculate_date_from_offset(day_offset)
 	hr, min, sec := calculate_time_from_offset(abs % seconds_per_day)
@@ -65,7 +65,7 @@ fn calculate_date_from_offset(day_offset_ int) (int, int, int) {
 	}
 
 	if day_offset < 0 {
-		year -= 1
+		year--
 		if is_leap_year(year) {
 			day_offset += 366
 		} else {


### PR DESCRIPTION
This PR produces the following error:
```shell
x.v:3:4: use `--` instead of `-= 1`
    1| fn main(){
    2|  mut x := 0
    3|  x-=1
          ^
    4|  println(x)
    5| }
```

<!--

Please title your PR as follows: `time: fix foo bar`. 
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v v.v
./v -o v v.v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

->