### PR TITLE
compiler: fix check restricted names in for..in statement

### DIFF
--- a/vlib/compiler/for.v
+++ b/vlib/compiler/for.v
@@ -129,6 +129,7 @@ fn (p mut Parser) for_st() {
 	}
 	// `for val in vals`
 	else if p.peek() == .key_in || p.peek() == .left_arrow {
+		p.check_not_reserved()
 		val := p.check_name()
 		p.fspace()
 		//p.check(.key_in)


### PR DESCRIPTION
**Additions**:
Checks for restricted names in for..in statement

**Examples**:
This now throws an error during compilation:
```
for byte in { ... }
```

**Notes**:
Fixes #3527 