### PR TITLE
tests: support -silent flag to silence OK messages in CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,9 @@ jobs:
         sudo ln -s /var/tmp/tcc/bin/tcc /usr/local/bin/tcc
         tcc -version
         ./v -o v2 v.v # Make sure vtcc can build itself
-        ./v test-compiler
+        ./v -silent test-compiler
     - name: Test v binaries
-      run: ./v build-vbinaries
+      run: ./v -silent build-vbinaries
 
   alpine-docker-musl-gcc:
     name: alpine-musl
@@ -84,9 +84,9 @@ jobs:
         psql -d postgres -c 'create database customerdb;'
         psql -d customerdb -f examples/database/pg/mydb.sql
     - name: Test v->c
-      run: ./v test-compiler
+      run: ./v -silent test-compiler
     - name: Test v binaries
-      run: ./v build-vbinaries
+      run: ./v -silent build-vbinaries
 #    - name: Test v->js
 #      run: ./v -o hi.js examples/hello_v_js.v && node hi.js
     - name: Test symlink
@@ -110,9 +110,9 @@ jobs:
     - name: Build V
       run: make -j4 && ./v -cc gcc -o v v.v
     - name: Test V
-      run: ./v test-compiler
+      run: ./v -silent test-compiler
     - name: Test v binaries
-      run: ./v build-vbinaries
+      run: ./v -silent build-vbinaries
 #    - name: Test v->js
 #      run: ./v -o hi.js examples/hello_v_js.v && node hi.js
     - name: Build Vorum
@@ -142,7 +142,7 @@ jobs:
     - name: Download V
       run: wget https://github.com/vlang/v/releases/latest/download/v_linux.zip && unzip v_linux.zip && ./v --version
     - name: Test V
-      run: echo "TODO" # ./v examples/hello_world.v && examples/hello_world && ./v build-examples
+      run: echo "TODO" # ./v examples/hello_world.v && examples/hello_world && ./v -silent build-examples
 
 
   macos-prebuilt:
@@ -155,7 +155,7 @@ jobs:
     - name: Download V
       run: wget https://github.com/vlang/v/releases/latest/download/v_macos.zip && unzip v_macos.zip && ./v --version
     - name: Test V
-      run: echo "TODO" #./v examples/hello_world.v && examples/hello_world && ./v build-examples
+      run: echo "TODO" #./v examples/hello_world.v && examples/hello_world && ./v -silent build-examples
 
   windows-prebuilt:
     runs-on: windows-2019
@@ -176,7 +176,7 @@ jobs:
         ./v.exe -o hi.exe examples/hello_world.v
         ls
         ./hi.exe
-        ./v.exe build-examples
+        ./v.exe -silent build-examples
 
   ubuntu-musl:
     runs-on: ubuntu-18.04
@@ -192,7 +192,7 @@ jobs:
     - name: Build v
       run: echo $VFLAGS && make -j4 && ./v -cg -o v v.v
     - name: Test v binaries
-      run: ./v build-vbinaries
+      run: ./v -silent build-vbinaries
 #    - name: Test v->js
 #      run: ./v -o hi.js examples/hello_v_js.v && node hi.js
 
@@ -219,12 +219,12 @@ jobs:
         .\make.bat -gcc
     - name: Test
       run: |
-        .\v.exe test-compiler
+        .\v.exe -silent test-compiler
       ## v.js dosent work on windows
         #.\v.exe -o hi.js examples/hello_v_js.v
         #node hi.js
     - name: Test v binaries
-      run: ./v build-vbinaries
+      run: ./v -silent build-vbinaries
 
   windows-msvc:
     runs-on: windows-2019
@@ -243,10 +243,9 @@ jobs:
         .\make.bat -msvc
     - name: Test
       run: |
-        .\v.exe test-compiler
+        .\v.exe -silent test-compiler
       ## v.js dosent work on windows
         #.\v.exe -o hi.js examples/hello_v_js.v
         #node hi.js
     - name: Test v binaries
-      run: ./v build-vbinaries
-
+      run: ./v -silent build-vbinaries

--- a/tools/modules/testing/common.v
+++ b/tools/modules/testing/common.v
@@ -20,6 +20,7 @@ pub mut:
 	ntask     int // writing to this should be locked by mu.
 	ntask_mtx &sync.Mutex
 	waitgroup &sync.WaitGroup
+	show_ok_tests bool
 }
 
 pub fn new_test_session(vargs string) TestSession {
@@ -30,6 +31,8 @@ pub fn new_test_session(vargs string) TestSession {
 		ntask: 0
 		ntask_mtx: sync.new_mutex()
 		waitgroup: sync.new_waitgroup()
+		
+		show_ok_tests: !vargs.contains('-silent')
 	}
 }
 
@@ -167,7 +170,9 @@ fn (ts mut TestSession) process_files() {
 			else {
 				ts.benchmark.ok()
 				tls_bench.ok()
-				eprintln(tls_bench.step_message_ok(relative_file))
+				if ts.show_ok_tests {
+					eprintln(tls_bench.step_message_ok(relative_file))
+				}
 			}
 		}
 		if os.exists(generated_binary_fpath) {

--- a/tools/modules/testing/common.v
+++ b/tools/modules/testing/common.v
@@ -133,7 +133,7 @@ fn (ts mut TestSession) process_files() {
 		}
 		mut cmd_options := [ts.vargs]
 		if !ts.vargs.contains('fmt') {
-			cmd_options << ' -cg -o "$generated_binary_fpath"'
+			cmd_options << ' -o "$generated_binary_fpath"'
 		}
 		cmd := '"${ts.vexe}" ' + cmd_options.join(' ') + ' "${file}"'
 		// eprintln('>>> v cmd: $cmd')

--- a/tools/modules/testing/common.v
+++ b/tools/modules/testing/common.v
@@ -133,7 +133,7 @@ fn (ts mut TestSession) process_files() {
 		}
 		mut cmd_options := [ts.vargs]
 		if !ts.vargs.contains('fmt') {
-			cmd_options << ' -o "$generated_binary_fpath"'
+			cmd_options << ' -cg -o "$generated_binary_fpath"'
 		}
 		cmd := '"${ts.vexe}" ' + cmd_options.join(' ') + ' "${file}"'
 		// eprintln('>>> v cmd: $cmd')


### PR DESCRIPTION
Supports `v -silent test .` , `v -silent test-compiler` and so on. It is mainly usefull to reduce CI noise.
