### PR TITLE
compiler: fix empty config struct with msvc. issue causing msvc test to fail

### DIFF
--- a/vlib/compiler/gen_c.v
+++ b/vlib/compiler/gen_c.v
@@ -503,7 +503,7 @@ fn (p mut Parser) gen_struct_init(typ string, t &Type) bool {
 	// Handle empty config ({})
 	if is_config && p.tok == .rcbr {
 		p.check(.rcbr)
-		p.gen('($typ) {}')
+		p.gen('($typ) {EMPTY_STRUCT_INITIALIZATION}')
 		return true
 	}
 	ptr := typ.contains('*')


### PR DESCRIPTION
compiler: fix empty config struct with msvc. issue causing msvc test to fail