### PR TITLE
stbi: speed up compilation by generating a stbi.o file

### DIFF
--- a/thirdparty/stb_image/stbi.c
+++ b/thirdparty/stb_image/stbi.c
@@ -1,0 +1,3 @@
+
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"

--- a/vlib/stbi/stbi.v
+++ b/vlib/stbi/stbi.v
@@ -7,10 +7,10 @@ module stbi
 // note we might need special case for this
 // import gl
 
-#flag   -I @VROOT/thirdparty/stb_image
-
-#define STB_IMAGE_IMPLEMENTATION
+#flag -I @VROOT/thirdparty/stb_image
 #include "stb_image.h"
+#flag @VROOT/thirdparty/stb_image/stbi.o
+
 pub struct Image {
 mut:
 	width       int


### PR DESCRIPTION
This PR speeds up compilation of stbi, and subsequently of modules that
use it like gg and ui by ~0.5s with gcc-9 on i3.