### PR TITLE
tools/oldv: fix default behaviour (regression caused by 760448a).

### DIFF
--- a/tools/modules/scripting/scripting.v
+++ b/tools/modules/scripting/scripting.v
@@ -39,6 +39,17 @@ pub fn chdir(path string) {
 	os.chdir(path)
 }
 
+pub fn rmrf(path string) {
+	verbose_trace(@FN, 'rm -rf $path')
+	if os.exists(path) {
+		if os.is_dir(path) {
+			os.rmdir_recursive(path)
+		}else{
+			os.rm(path)
+		}
+	}
+}
+
 pub fn run(cmd string) string {
 	verbose_trace(@FN, cmd)
 	x := os.exec(cmd) or {

--- a/tools/oldv.v
+++ b/tools/oldv.v
@@ -1,6 +1,5 @@
 import (
 	os
-	os.cmdline
 	flag
 	filepath
 	scripting
@@ -100,8 +99,8 @@ fn main() {
 		context.cc = ecc
 	}
 	if context.cleanup {
-		os.rmdir_recursive(context.path_v)
-		os.rmdir_recursive(context.path_vc)
+		scripting.rmrf(context.path_v)
+		scripting.rmrf(context.path_vc)
 	}
 	
 	context.compile_oldv_if_needed()


### PR DESCRIPTION
This PR fixes a bug when running `tools/oldv commitish` vs
`tools/oldv --clean false commitish` .