### PR TITLE
playground: fix "Advanced const" example

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -758,7 +758,7 @@ struct Color {
         b int
 }
 
-fn (c Color) str() string { return '{$c.r, $c.g, $c.b}' }
+pub fn (c Color) str() string { return '{$c.r, $c.g, $c.b}' }
 
 fn rgb(r, g, b int) Color { return Color{r: r, g: g, b: b} }
 


### PR DESCRIPTION
This current PR fixes the bug returned by the playground example "Advanced const".

**What did I see ?**

![image](https://user-images.githubusercontent.com/26305730/73182420-57212800-4119-11ea-9255-9f94d5bd3ac2.png)

**What should I see ?**
```
[1, 2, 3]
{255, 0, 0}
{0, 0, 255}
```
instead of this :
```
.str() methods must be declared as public
    7| }
```

**How did I fix it ?**

By adding a `pub` in front of the `str()` function in the _docs/docs.md_ file :

Before :
```v
struct Color {
        r int
        g int
        b int
}

fn (c Color) str() string { return '{$c.r, $c.g, $c.b}' }

fn rgb(r, g, b int) Color { return Color{r: r, g: g, b: b} }

const (
    numbers = [1, 2, 3]

    red  = Color{r: 255, g: 0, b: 0}
    blue = rgb(0, 0, 255)
)
```


After :
```v
struct Color {
        r int
        g int
        b int
}

pub fn (c Color) str() string { return '{$c.r, $c.g, $c.b}' }

fn rgb(r, g, b int) Color { return Color{r: r, g: g, b: b} }

const (
    numbers = [1, 2, 3]

    red  = Color{r: 255, g: 0, b: 0}
    blue = rgb(0, 0, 255)
)
```