### PR TITLE
array: adds array.clear

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -143,6 +143,11 @@ pub fn (a mut array) delete(i int) {
 	a.len--
 }
 
+// clears the array without deallocating the allocated data
+pub fn (a mut array) clear() {
+	a.len = 0
+}
+
 // Private function. Used to implement array[] operator
 fn (a array) get(i int) voidptr {
 	if i < 0 || i >= a.len {

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -576,4 +576,17 @@ fn test_clear() {
 	assert arr.len == 3
 	arr.clear()
 	assert arr.len == 0
+	
+	arr << 3
+	arr << 2
+	arr << 1
+	arr << 0
+	assert arr.len == 4
+	assert arr[0] == 3
+	assert arr[1] == 2
+	assert arr[2] == 1
+	assert arr[3] == 0
+	
+	arr.clear()
+	assert arr.len == 0
 }

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -570,3 +570,10 @@ fn test_for() {
 	}
 	assert sum == 6
 }
+
+fn test_clear() {
+	mut arr := [1,2,3]
+	assert arr.len == 3
+	arr.clear()
+	assert arr.len == 0
+}


### PR DESCRIPTION
Adds an efficient `array.clear` method that keeps the allocated data intact but sets the array `len` to 0.
