### PR TITLE
Adds get_terminal_size function and a string argument to h_divider

### DIFF
--- a/tools/modules/testing/common.v
+++ b/tools/modules/testing/common.v
@@ -95,7 +95,7 @@ pub fn (ts mut TestSession) test() {
 	}
 	ts.waitgroup.wait()
 	ts.benchmark.stop()
-	eprintln(term.h_divider())
+	eprintln(term.h_divider('-'))
 }
 
 
@@ -258,7 +258,7 @@ pub fn building_any_v_binaries_failed() bool {
 		eprintln(bmark.step_message_ok('command: ${cmd}'))
 	}
 	bmark.stop()
-	eprintln(term.h_divider())
+	eprintln(term.h_divider('-'))
 	eprintln(bmark.total_message('building v binaries'))
 	return failed
 }

--- a/vlib/readline/readline_linux.v
+++ b/vlib/readline/readline_linux.v
@@ -36,7 +36,7 @@ enum Action {
 
 fn C.tcgetattr() int
 fn C.tcsetattr() int
-fn C.ioctl() int
+//fn C.ioctl() int
 fn C.raise()
 
 // Toggle raw mode of the terminal by changing its attributes

--- a/vlib/term/can_show_color.v
+++ b/vlib/term/can_show_color.v
@@ -26,18 +26,3 @@ pub fn ok_message(s string) string {
 pub fn fail_message(s string) string {
 	return if can_show_color_on_stdout() { red(s) } else { s }
 }
-
-// h_divider will return a horizontal divider line with a dynamic width,
-// that depends on the current terminal settings
-pub fn h_divider() string {
-	mut cols := 76
-	if term_size := os.exec('stty size') {
-		if term_size.exit_code == 0 {
-			term_cols := term_size.output.split(' ')[1].int()
-			if term_cols > 0 {
-				cols = term_cols
-      }
-		}
-	}
-	return '-'.repeat(cols)
-}  

--- a/vlib/term/misc.v
+++ b/vlib/term/misc.v
@@ -4,7 +4,7 @@ module term
 // that depends on the current terminal settings
 pub fn h_divider(divider string) string {
 	mut cols := 76
-	term_cols, _ := get_term_size()
+	term_cols, _ := get_terminal_size()
 
 	if term_cols > 0 {
 		cols = term_cols

--- a/vlib/term/misc.v
+++ b/vlib/term/misc.v
@@ -1,0 +1,15 @@
+module term
+
+// h_divider will return a horizontal divider line with a dynamic width,
+// that depends on the current terminal settings
+pub fn h_divider(divider string) string {
+	mut cols := 76
+	term_cols, _ := get_term_size()
+
+	if term_cols > 0 {
+		cols = term_cols
+	}
+
+	result := divider.repeat(1 + (cols / divider.len))
+	return result[0..cols]
+}

--- a/vlib/term/misc_js.v
+++ b/vlib/term/misc_js.v
@@ -1,0 +1,6 @@
+module term
+
+pub fn get_terminal_size() (int, int) { 
+   // TODO: find a way to get proper width&height of the terminal on a Javascript environment
+   return 80, 25  
+}

--- a/vlib/term/misc_nix.v
+++ b/vlib/term/misc_nix.v
@@ -8,7 +8,7 @@ struct C.winsize{
 	ws_col int
 }
 
-fn C.ioctl()
+fn C.ioctl() int
 
 pub fn get_term_size() (int, int) {
 	// TODO: check for resize events

--- a/vlib/term/misc_nix.v
+++ b/vlib/term/misc_nix.v
@@ -1,0 +1,19 @@
+module term
+
+#include <sys/ioctl.h>
+
+struct C.winsize{
+	pub:
+	ws_row int
+	ws_col int
+}
+
+fn C.ioctl()
+
+pub fn get_term_size() (int, int) {
+
+	mut w := C.winsize{}
+	C.ioctl(0, C.TIOCGWINSZ, &w)
+
+	return w.ws_col, w.ws_row
+}

--- a/vlib/term/misc_nix.v
+++ b/vlib/term/misc_nix.v
@@ -11,6 +11,7 @@ struct C.winsize{
 fn C.ioctl()
 
 pub fn get_term_size() (int, int) {
+	// TODO: check for resize events
 
 	mut w := C.winsize{}
 	C.ioctl(0, C.TIOCGWINSZ, &w)

--- a/vlib/term/misc_nix.v
+++ b/vlib/term/misc_nix.v
@@ -10,7 +10,7 @@ struct C.winsize{
 
 fn C.ioctl() int
 
-pub fn get_term_size() (int, int) {
+pub fn get_terminal_size() (int, int) {
 	// TODO: check for resize events
 
 	mut w := C.winsize{}

--- a/vlib/term/misc_windows.v
+++ b/vlib/term/misc_windows.v
@@ -1,0 +1,6 @@
+module term
+
+pub fn get_terminal_size() (int, int) { 
+   // TODO: find a way to get proper width&height of the terminal on windows, probably using Winapis
+   return 80, 25  
+}


### PR DESCRIPTION
```V
term.get_terminal_size()
```
Returns a `V (int, int)` whith the maximum rows and columns in the terminal