### PR TITLE
term: fix too long h_divider lines in CI

### DIFF
--- a/vlib/term/misc.v
+++ b/vlib/term/misc.v
@@ -1,7 +1,5 @@
 module term
 
-import os
-
 // h_divider will return a horizontal divider line with a dynamic width,
 // that depends on the current terminal settings
 pub fn h_divider(divider string) string {
@@ -10,13 +8,6 @@ pub fn h_divider(divider string) string {
   eprintln('h_divider term_cols: $term_cols')
   eprintln('h_divider term_rows: $term_rows')
   
-  if term_size := os.exec('stty size') {
-     if term_size.exit_code == 0 {
-        eprintln('stty size: $term_size.output')
-     }
-  }
- 
-
 	if term_cols > 0 {
 		cols = term_cols
 	}

--- a/vlib/term/misc.v
+++ b/vlib/term/misc.v
@@ -1,17 +1,12 @@
 module term
-
 // h_divider will return a horizontal divider line with a dynamic width,
 // that depends on the current terminal settings
 pub fn h_divider(divider string) string {
 	mut cols := 76
-	term_cols, term_rows := get_terminal_size()
-  eprintln('h_divider term_cols: $term_cols')
-  eprintln('h_divider term_rows: $term_rows')
-  
+	term_cols,_ := get_terminal_size()
 	if term_cols > 0 {
 		cols = term_cols
 	}
-
 	result := divider.repeat(1 + (cols / divider.len))
 	return result[0..cols]
 }

--- a/vlib/term/misc.v
+++ b/vlib/term/misc.v
@@ -4,7 +4,9 @@ module term
 // that depends on the current terminal settings
 pub fn h_divider(divider string) string {
 	mut cols := 76
-	term_cols, _ := get_terminal_size()
+	term_cols, term_rows := get_terminal_size()
+  eprintln('h_divider term_cols: $term_cols')
+  eprintln('h_divider term_rows: $term_rows')
 
 	if term_cols > 0 {
 		cols = term_cols

--- a/vlib/term/misc.v
+++ b/vlib/term/misc.v
@@ -1,5 +1,7 @@
 module term
 
+import os
+
 // h_divider will return a horizontal divider line with a dynamic width,
 // that depends on the current terminal settings
 pub fn h_divider(divider string) string {
@@ -7,6 +9,13 @@ pub fn h_divider(divider string) string {
 	term_cols, term_rows := get_terminal_size()
   eprintln('h_divider term_cols: $term_cols')
   eprintln('h_divider term_rows: $term_rows')
+  
+  if term_size := os.exec('stty size') {
+     if term_size.exit_code == 0 {
+        eprintln('stty size: $term_size.output')
+     }
+  }
+ 
 
 	if term_cols > 0 {
 		cols = term_cols

--- a/vlib/term/misc_nix.v
+++ b/vlib/term/misc_nix.v
@@ -2,19 +2,19 @@ module term
 
 #include <sys/ioctl.h>
 
-struct C.winsize{
-	pub:
-	ws_row int
-	ws_col int
+pub struct C.winsize {
+pub:
+	ws_row u16
+	ws_col u16
+  ws_xpixel u16
+  ws_ypixel u16
 }
 
 fn C.ioctl() int
 
 pub fn get_terminal_size() (int, int) {
-	// TODO: check for resize events
-
-	mut w := C.winsize{}
+	w := C.winsize{}
 	C.ioctl(0, C.TIOCGWINSZ, &w)
-
-	return w.ws_col, w.ws_row
+  eprintln('ws_row: $w.ws_row | ws_col: $w.ws_col | ws_xpixel: $w.ws_xpixel | ws_ypixel: $w.ws_ypixel')
+	return int(w.ws_col), int(w.ws_row)
 }

--- a/vlib/term/misc_nix.v
+++ b/vlib/term/misc_nix.v
@@ -1,5 +1,7 @@
 module term
 
+import os
+
 #include <sys/ioctl.h>
 
 pub struct C.winsize {
@@ -16,5 +18,14 @@ pub fn get_terminal_size() (int, int) {
 	w := C.winsize{}
 	C.ioctl(0, C.TIOCGWINSZ, &w)
   eprintln('ws_row: $w.ws_row | ws_col: $w.ws_col | ws_xpixel: $w.ws_xpixel | ws_ypixel: $w.ws_ypixel')
+  if cols := os.exec('tput cols') {
+     eprintln('tput cols: $cols.output')
+  }
+  if lines := os.exec('tput lines') {
+     eprintln('tput lines: $lines.output')
+  }
+  if stty := os.exec('stty -a') {
+     eprintln('stty: $stty.output')
+  }
 	return int(w.ws_col), int(w.ws_row)
 }

--- a/vlib/term/misc_nix.v
+++ b/vlib/term/misc_nix.v
@@ -10,7 +10,7 @@ pub:
   ws_ypixel u16
 }
 
-fn C.ioctl() int
+fn C.ioctl(fd int, request u64, arg voidptr) int
 
 pub fn get_terminal_size() (int, int) {
 	w := C.winsize{}

--- a/vlib/term/misc_nix.v
+++ b/vlib/term/misc_nix.v
@@ -3,29 +3,22 @@ module term
 import os
 
 #include <sys/ioctl.h>
-
 pub struct C.winsize {
 pub:
-	ws_row u16
-	ws_col u16
-  ws_xpixel u16
-  ws_ypixel u16
+	ws_row    u16
+	ws_col    u16
+	ws_xpixel u16
+	ws_ypixel u16
 }
 
 fn C.ioctl(fd int, request u64, arg voidptr) int
 
-pub fn get_terminal_size() (int, int) {
+
+pub fn get_terminal_size() (int,int) {
+	if is_atty(1) <= 0 || os.getenv('TERM') == 'dumb' {
+		return 80,25
+	}
 	w := C.winsize{}
 	C.ioctl(0, C.TIOCGWINSZ, &w)
-  eprintln('ws_row: $w.ws_row | ws_col: $w.ws_col | ws_xpixel: $w.ws_xpixel | ws_ypixel: $w.ws_ypixel')
-  if cols := os.exec('tput cols') {
-     eprintln('tput cols: $cols.output')
-  }
-  if lines := os.exec('tput lines') {
-     eprintln('tput lines: $lines.output')
-  }
-  if stty := os.exec('stty -a') {
-     eprintln('stty: $stty.output')
-  }
-	return int(w.ws_col), int(w.ws_row)
+	return int(w.ws_col),int(w.ws_row)
 }


### PR DESCRIPTION
This PR makes term.h_divider return reasonably sized lines in
CI environments, where stdout is not attached to a tty terminal.