### PR TITLE
term: implement `get_terminal_size` for Windows

### DIFF
--- a/vlib/term/misc_windows.v
+++ b/vlib/term/misc_windows.v
@@ -1,6 +1,33 @@
 module term
 
-pub fn get_terminal_size() (int, int) { 
-   // TODO: find a way to get proper width&height of the terminal on windows, probably using Winapis
-   return 80, 25  
+import os
+
+struct C.SMALL_RECT {
+	Left   i16
+	Top    i16
+	Right  i16
+	Bottom i16
+}
+
+struct C.CONSOLE_SCREEN_BUFFER_INFO {
+	dwSize              C.COORD
+	dwCursorPosition    C.COORD
+	wAttributes         C.COORD
+	srWindow            C.SMALL_RECT
+	dwMaximumWindowSize C.COORD
+}
+
+fn C.GetConsoleScreenBufferInfo(handle C.HANDLE, info &CONSOLE_SCREEN_BUFFER_INFO) bool
+
+// get_terminal_size returns a number of colums and rows of terminal window.
+pub fn get_terminal_size() (int, int) {
+	if is_atty(1) <= 0 || os.getenv('TERM') == 'dumb' {
+		return 80, 25
+	}
+
+	info := CONSOLE_SCREEN_BUFFER_INFO{}
+	C.GetConsoleScreenBufferInfo(C.GetStdHandle(C.STD_OUTPUT_HANDLE), &info)
+	columns := (info.srWindow.Right - info.srWindow.Left + 1) as int
+	rows := (info.srWindow.Bottom - info.srWindow.Top + 1) as int
+	return columns, rows
 }

--- a/vlib/term/misc_windows.v
+++ b/vlib/term/misc_windows.v
@@ -21,13 +21,15 @@ fn C.GetConsoleScreenBufferInfo(handle C.HANDLE, info &CONSOLE_SCREEN_BUFFER_INF
 
 // get_terminal_size returns a number of colums and rows of terminal window.
 pub fn get_terminal_size() (int, int) {
-	if is_atty(1) <= 0 || os.getenv('TERM') == 'dumb' {
-		return 80, 25
+	if is_atty(1) > 0 && os.getenv('TERM') != 'dumb' {
+		info := CONSOLE_SCREEN_BUFFER_INFO{}
+
+		if C.GetConsoleScreenBufferInfo(C.GetStdHandle(C.STD_OUTPUT_HANDLE), &info) {
+			columns := (info.srWindow.Right - info.srWindow.Left + 1) as int
+			rows := (info.srWindow.Bottom - info.srWindow.Top + 1) as int
+			return columns, rows
+		}
 	}
 
-	info := CONSOLE_SCREEN_BUFFER_INFO{}
-	C.GetConsoleScreenBufferInfo(C.GetStdHandle(C.STD_OUTPUT_HANDLE), &info)
-	columns := (info.srWindow.Right - info.srWindow.Left + 1) as int
-	rows := (info.srWindow.Bottom - info.srWindow.Top + 1) as int
-	return columns, rows
+	return 80, 25
 }


### PR DESCRIPTION
Here's a screenshot with the output of the function result.

You can see the actual terminal size in the bottom right corner and the function result are the same.

![image](https://user-images.githubusercontent.com/1119267/73291246-d9404800-4210-11ea-915e-293f73104849.png)