### PR TITLE
net.http: Fix a bug where fetch ignored user-agent

### DIFF
--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -107,7 +107,7 @@ pub fn fetch(_url string, config FetchConfig) ?Response {
 		data: data
 		headers: config.headers
 		cookies: config.cookies
-		user_agent: 'v'
+		user_agent: config.user_agent
 		ws_func: 0
 		user_ptr: 0
 		verbose: config.verbose


### PR DESCRIPTION

This PR fixes a problem where `net.http.fetch` function ignores `FetchConfig.user_agent`.