### PR TITLE
gg: faster math in draw_arc

### DIFF
--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -425,10 +425,12 @@ pub fn (ctx &GG) draw_arc(x, y, r, start_angle, end_angle f32, segments int, col
 	end_rads := end_angle * 0.0174533
 	rad_increment := end_rads / segments
 	mut vertices := []f32
-	mut i := 0
+	// Add the first vertex at the first arc angle with normal cos and sin for accuracy.
+	vertices << [x + f32(math.cos(start_rads)) * r, y + f32(math.sin(start_rads)) * r]
+	mut i := 1
 	for i < segments {
 		theta := f32(i) * rad_increment - start_rads 
-		vertices << [x + f32(math.fast_cos(theta)) * r, y + f32(math.fast_sin(theta)) * r]
+		vertices << [x + f32(math.aprox_cos(theta)) * r, y + f32(math.aprox_sin(theta)) * r]
 		i++
 	}
 	// Add the last vertex at the final arc angle with normal cos and sin for accuracy.

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -428,10 +428,10 @@ pub fn (ctx &GG) draw_arc(x, y, r, start_angle, end_angle f32, segments int, col
 	mut i := 0
 	for i < segments {
 		theta := f32(i) * rad_increment - start_rads 
-		vertices << [x + f32(math.cos(theta)) * r, y + f32(math.sin(theta)) * r]
+		vertices << [x + f32(math.fast_cos(theta)) * r, y + f32(math.fast_sin(theta)) * r]
 		i++
 	}
-	// Add the last vertex at the final arc angle.
+	// Add the last vertex at the final arc angle with normal cos and sin for accuracy.
 	vertices << [x + f32(math.cos(end_rads)) * r, y + f32(math.sin(end_rads)) * r]
 	gl.bind_vao(ctx.vao)
 	gl.set_vbo(ctx.vbo, vertices, C.GL_STATIC_DRAW)

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -425,15 +425,15 @@ pub fn (ctx &GG) draw_arc(x, y, r, start_angle, end_angle f32, segments int, col
 	end_rads := end_angle * 0.0174533
 	rad_increment := end_rads / segments
 	mut vertices := []f32
-	// Add the first vertex at the first arc angle with normal cos and sin for accuracy.
+	// Add the first vertex at the first arc angle.
 	vertices << [x + f32(math.cos(start_rads)) * r, y + f32(math.sin(start_rads)) * r]
 	mut i := 1
 	for i < segments {
 		theta := f32(i) * rad_increment - start_rads 
-		vertices << [x + f32(math.aprox_cos(theta)) * r, y + f32(math.aprox_sin(theta)) * r]
+		vertices << [x + f32(math.cos(theta)) * r, y + f32(math.sin(theta)) * r]
 		i++
 	}
-	// Add the last vertex at the final arc angle with normal cos and sin for accuracy.
+	// Add the last vertex at the final arc angle.
 	vertices << [x + f32(math.cos(end_rads)) * r, y + f32(math.sin(end_rads)) * r]
 	gl.bind_vao(ctx.vao)
 	gl.set_vbo(ctx.vbo, vertices, C.GL_STATIC_DRAW)

--- a/vlib/math/const.v
+++ b/vlib/math/const.v
@@ -27,6 +27,11 @@ pub const (
 	max_f64 = 1.797693134862315708145274237317043567981e+308 // 2**1023 * (2**53 - 1) / 2**52
 	smallest_non_zero_f64 = 4.940656458412465441765687928682213723651e-324 // 1 / 2**(1023 - 1 + 52)
 )
+// Function accuracy ranges
+pub const (
+	aprox_sin_and_cos_lower = -pi*2
+	aprox_sin_and_cos_upper = pi*2
+)
 // Integer limit values
 pub const (
 	max_i8 = 127


### PR DESCRIPTION
Becomes very inaccurate after around 2pi (720 deg), a check will be added in math to fall back to normal cos and sin if outside range