### PR TITLE
Compiler: Add support for while loop, 

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -379,7 +379,7 @@ V optimizes such expressions, so both `if` statements above produce the same mac
 
 ## For loop
 
-V has only one looping construct: `for`.
+V has two looping constructs: `for` and `while`.
 
 ```v
 numbers := [1, 2, 3, 4, 5]
@@ -405,17 +405,17 @@ for i, num in numbers {
 }
 ```
 
+V also has support for ordinary while loops.
+
 ```v
 mut sum := 0
 mut i := 0
-for i <= 100 {
+while i <= 100 {
     sum += i
     i++
 }
 println(sum) // "5050"
 ```
-
-This form of the loop is similar to `while` loops in other languages.
 
 The loop will stop iterating once the boolean condition evaluates to false.
 
@@ -423,7 +423,7 @@ Again, there are no parentheses surrounding the condition, and the braces are al
 
 ```v
 mut num := 0
-for {
+while {
     num++
     if num >= 10 {
         break

--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -51,7 +51,7 @@ mut:
 	is_struct_init         bool
 	is_var_decl            bool
 	if_expr_cnt            int
-	for_expr_cnt           int // to detect whether `continue` can be used
+	loop_expr_cnt           int // to detect whether `continue` or `break` can be used
 	ptr_cast               bool
 	calling_c              bool
 	cur_fn                 Fn
@@ -1492,6 +1492,9 @@ fn (p mut Parser) statement(add_semi bool) string {
 		.key_for {
 			p.for_st()
 		}
+		.key_while {
+			p.while_st()
+		}
 		.key_switch {
 			p.switch_statement()
 		}
@@ -1521,15 +1524,15 @@ fn (p mut Parser) statement(add_semi bool) string {
 			return ''
 		}
 		.key_continue {
-			if p.for_expr_cnt == 0 {
-				p.error('`continue` statement outside `for`')
+			if p.loop_expr_cnt == 0 {
+				p.error('`continue` statement outside `for` or `while`')
 			}
 			p.genln('continue')
 			p.check(.key_continue)
 		}
 		.key_break {
-			if p.for_expr_cnt == 0 {
-				p.error('`break` statement outside `for`')
+			if p.loop_expr_cnt == 0 {
+				p.error('`break` statement outside `for` or `while`')
 			}
 			p.genln('break')
 			p.check(.key_break)

--- a/vlib/compiler/for.v
+++ b/vlib/compiler/for.v
@@ -5,7 +5,7 @@ module compiler
 
 fn (p mut Parser) for_st() {
 	p.check(.key_for)
-	p.for_expr_cnt++
+	p.loop_expr_cnt++
 	next_tok := p.peek()
 	if p.tok != .lcbr {
 		p.fspace()
@@ -218,7 +218,7 @@ fn (p mut Parser) for_st() {
 	p.genln('') // TODO why is this needed?
 	p.statements()
 	p.close_scope()
-	p.for_expr_cnt--
+	p.loop_expr_cnt--
 	p.returns = false // TODO handle loops that are guaranteed to return
 	//if label > 0 {
 		//p.x64.gen_loop_end(to, label)

--- a/vlib/compiler/tests/repl/conditional_blocks/while.repl
+++ b/vlib/compiler/tests/repl/conditional_blocks/while.repl
@@ -1,0 +1,11 @@
+mut i := 5
+while i > 0 {
+  println(i)
+  i--
+}
+===output===
+5
+4
+3
+2
+1

--- a/vlib/compiler/tests/struct_test.v
+++ b/vlib/compiler/tests/struct_test.v
@@ -52,7 +52,6 @@ struct ReservedKeywords {
 	unsigned int
 	void     int
 	volatile int
-	while    int
 }
 
 fn test_struct_levels() {
@@ -95,17 +94,15 @@ fn test_at() {
 
 fn test_reserved_keywords() {
 	//Make sure we can initialize them correctly using full syntax.
-	rk_holder := ReservedKeywords{0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3}
+	rk_holder := ReservedKeywords{0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 	//Test a few as it'll take too long to test all. If it's initialized
 	//correctly, other fields are also probably valid.
 	assert rk_holder.unix == 5
-	assert rk_holder.while == 3
 
 	rk_holder2 := ReservedKeywords{inline: 9, volatile: 11}
 	//Make sure partial initialization works too.
 	assert rk_holder2.inline == 9
 	assert rk_holder2.volatile == 11
-	assert rk_holder2.while == 0 //Zero value as not specified.
 }
 
 struct User2 {

--- a/vlib/compiler/tests/while_loop_test.v
+++ b/vlib/compiler/tests/while_loop_test.v
@@ -1,0 +1,33 @@
+fn test_while_conditional_loop() {
+  mut i := 0
+  mut arr := []int
+  while i < 5 {
+	  arr << i
+	  i++
+  }
+  assert arr.len == 5
+}
+
+fn test_while_infinite_loop_with_break() {
+  mut count := 0
+  while {
+	  if count == 5 {
+		  break
+	  }
+	  count++
+  }
+  assert count == 5
+}
+
+fn test_while_with_x_in_arr_format() {
+  mut arr := [1,5,2,5,3,6]
+  mut i := 0
+  while 5 in arr {
+	  if arr[i] == 5 {
+		  arr[i] = 0
+	  }
+	  i++
+  }
+  assert arr[1] == 0
+  assert arr[3] == 0
+}

--- a/vlib/compiler/token.v
+++ b/vlib/compiler/token.v
@@ -120,6 +120,7 @@ enum TokenKind {
 	key_pub
 	key_static
 	key_unsafe
+	key_while
 	keyword_end
 }
 
@@ -214,6 +215,7 @@ fn build_token_str() []string {
 	s[TokenKind.key_mut] = 'mut'
 	s[TokenKind.key_type] = 'type'
 	s[TokenKind.key_for] = 'for'
+	s[TokenKind.key_while] = 'while'
 	s[TokenKind.key_switch] = 'switch'
 	s[TokenKind.key_fn] = 'fn'
 	s[TokenKind.key_true] = 'true'

--- a/vlib/compiler/while.v
+++ b/vlib/compiler/while.v
@@ -1,0 +1,31 @@
+// Copyright (c) 2019-2020 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module compiler
+
+// Code generation for while loop.
+fn (p mut Parser) while_st() {
+	p.check(.key_while)
+	p.loop_expr_cnt++
+	if p.tok != .lcbr {
+		p.fspace()
+	}
+	p.open_scope()
+	if p.tok == .lcbr {
+		// Infinite loop
+		p.gen('while (1) {')
+	}
+	else {
+		// `while condition {`
+		p.gen('while (')
+		p.check_types(p.bool_expression(), 'bool')
+		p.genln(') {')
+	}
+	p.fspace()
+	p.check(.lcbr)
+	p.statements()
+	p.close_scope()
+	p.loop_expr_cnt--
+	p.returns = false // TODO handle loops that are guaranteed to return
+}
+

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -207,6 +207,9 @@ pub fn (p mut Parser) stmt() ast.Stmt {
 		.key_for {
 			return p.for_statement()
 		}
+		.key_while {
+			return p.while_statement()
+		}
 		.key_return {
 			return p.return_stmt()
 		}
@@ -584,9 +587,31 @@ fn (p mut Parser) for_statement() ast.Stmt {
 		}
 	}
 	// `for cond {`
+	p.warn('use of `for condition` will be removed in future, use `while condition {` instead')
 	cond,ti := p.expr(0)
 	if !p.table.check(types.bool_ti, ti) {
 		p.error('non-bool used as for condition')
+	}
+	stmts := p.parse_block()
+	return ast.ForStmt{
+		cond: cond
+		stmts: stmts
+	}
+}
+
+fn (p mut Parser) while_statement() ast.Stmt {
+	p.check(.key_while)
+	// Infinite loop
+	if p.tok.kind == .lcbr {
+		stmts := p.parse_block()
+		return ast.ForStmt{
+			stmts: stmts
+		}
+	}
+	// `while cond {`
+	cond,ti := p.expr(0)
+	if !p.table.check(types.bool_ti, ti) {
+		p.error('non-bool used as while condition')
 	}
 	stmts := p.parse_block()
 	return ast.ForStmt{

--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -120,6 +120,7 @@ pub enum Kind {
 	key_pub
 	key_static
 	key_unsafe
+	key_while
 	keyword_end
 }
 
@@ -220,6 +221,7 @@ fn build_token_str() []string {
 	s[Kind.key_mut] = 'mut'
 	s[Kind.key_type] = 'type'
 	s[Kind.key_for] = 'for'
+	s[Kind.key_while] = 'while'
 	s[Kind.key_switch] = 'switch'
 	s[Kind.key_fn] = 'fn'
 	s[Kind.key_true] = 'true'


### PR DESCRIPTION
This PR adds support for ordinary while loops as raised in issue #3529 . 

Please note that I haven't removed support for `for condition {` syntax as it will break so much of existing code (I have put a warning though)


<!--

Please title your PR as follows: `time: fix foo bar`. 
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v v.v
./v -o v v.v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

->
