### PR TITLE
compiler: add support for -pretty_c option

### DIFF
--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -34,12 +34,19 @@ fn (v mut V) cc() {
 	vdir := filepath.dir(vexe)
 	// Just create a C/JavaScript file and exit
 	// for example: `v -o v.c compiler`
-	if v.out_name.ends_with('.c') || v.out_name.ends_with('.js') {
+	ends_with_c := v.out_name.ends_with('.c')
+	ends_with_js := v.out_name.ends_with('.js')
+
+	if v.pref.is_pretty_c && !ends_with_js {
+		os.exec('clang-format -i "$v.out_name_c"') or { os.Result{exit_code:-1} }
+	}
+	
+	if ends_with_c || ends_with_js {
 		// Translating V code to JS by launching vjs.
 		// Using a separate process for V.js is for performance mostly,
 		// to avoid constant is_js checks.
 		$if !js {
-			if v.out_name.ends_with('.js') {
+			if ends_with_js {
 				vjs_path := vexe + 'js'
 				if !os.exists(vjs_path) {
 					println('V.js compiler not found, building...')

--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -38,7 +38,14 @@ fn (v mut V) cc() {
 	ends_with_js := v.out_name.ends_with('.js')
 
 	if v.pref.is_pretty_c && !ends_with_js {
-		os.exec('clang-format -i "$v.out_name_c"') or { os.Result{exit_code:-1} }
+		format_result := os.exec('clang-format -i "$v.out_name_c"') or {
+			eprintln('clang-format not found')
+			os.Result{exit_code:-1}
+		}
+		if format_result.exit_code > 0 {
+			eprintln('clang-format failed to format $v.out_name_c')
+			eprintln(format_result.output)
+		}
 	}
 	
 	if ends_with_c || ends_with_js {

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -111,6 +111,7 @@ pub mut:
 	is_keep_c       bool // -keep_c , tell v to leave the generated .tmp.c alone (since by default v will delete them after c backend finishes)
 	// NB: passing -cg instead of -g will set is_vlines to false and is_g to true, thus making v generate cleaner C files,
 	// which are sometimes easier to debug / inspect manually than the .tmp.c files by plain -g (when/if v line number generation breaks).
+	is_pretty_c     bool // -pretty_c , tell v to run clang-format -i over the produced C file, before it is compiled. Use with -keep_c or with -o x.c .
 	is_cache        bool // turns on v usage of the module cache to speed up compilation.
 	is_stats        bool // `v -stats file_test.v` will produce more detailed statistics for the tests that were run
 	no_auto_free    bool // `v -nofree` disable automatic `free()` insertion for better performance in some applications  (e.g. compilers)
@@ -1087,6 +1088,7 @@ pub fn new_v(args []string) &V {
 		is_debug: '-g' in args || '-cg' in args
 		is_vlines: '-g' in args && !('-cg' in args)
 		is_keep_c: '-keep_c' in args
+		is_pretty_c: '-pretty_c' in args
 		is_cache: '-cache' in args
 		is_stats: '-stats' in args
 		obfuscate: obfuscate

--- a/vlib/compiler/vhelp.v
+++ b/vlib/compiler/vhelp.v
@@ -58,6 +58,7 @@ Options for debugging/troubleshooting v programs:
   -cg               Same as -g, but add *C* line numbers to the generated executable instead of *V* line numbers.
   -keep_c           Do NOT remove the generated .tmp.c files after compilation.
                     It is useful when using debuggers like gdb/visual studio, when given after `-g` / `-cg`.
+  -pretty_c         Run clang-format over the generated C file, so that it looks nicer. Requires you to have clang-format.
   -show_c_cmd       Print the full C compilation command and how much time it took. See also `-verbose`.
   -cc <ccompiler>   Specify which C compiler you want to use as a C backend.
                     The C backend compiler should be able to handle C99 compatible C code.


### PR DESCRIPTION
It runs clang-format -i over the generated C file.

Useful with -cg -keep_c so that gdb can show nicer looking source.

Also useful with -o x.c, so that the generated code can be more
readable and thus more easily analyzable.