### PR TITLE
compiler: fix function name typo in attribute test

### DIFF
--- a/vlib/compiler/tests/attribute_test.v
+++ b/vlib/compiler/tests/attribute_test.v
@@ -23,11 +23,11 @@ pub enum PubEnumAttrTest {
 }
 
 [testing]
-fn test_fn_attribte() {
+fn test_fn_attribute() {
 	assert true
 }
 
 [testing]
-pub fn test_pub_fn_attribte() {
+pub fn test_pub_fn_attribute() {
 	assert true
 }


### PR DESCRIPTION
compiler: fix function name typo in attribute test