### PR TITLE
add file style selector to clang-format

### DIFF
--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -38,7 +38,7 @@ fn (v mut V) cc() {
 	ends_with_js := v.out_name.ends_with('.js')
 
 	if v.pref.is_pretty_c && !ends_with_js {
-		format_result := os.exec('clang-format -i "$v.out_name_c"') or {
+		format_result := os.exec('clang-format -i -style=file "$v.out_name_c"') or {
 			eprintln('clang-format not found')
 			os.Result{exit_code:-1}
 		}


### PR DESCRIPTION
This allows custom styles if a .clang-format file exists in the current directly or any parent directory. If none are present it falls back to the default style.