### PR TITLE
gg,os: minimize memory allocation

### DIFF
--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -416,19 +416,23 @@ pub fn (ctx &GG) draw_line(x, y, x2, y2 f32, color gx.Color) {
 }
 
 pub fn (ctx &GG) draw_arc(x, y, r, start_angle, end_angle f32, segments int, color gx.Color) {
-	ctx.use_color_shader(color)
-	mut vertices := arc_vertices(x, y, r, start_angle, end_angle, segments)
+	ctx.use_color_shader(color)	
+	vertices := arc_vertices(x, y, r, start_angle, end_angle, segments)
 	ctx.bind_vertices(vertices)
 	gl.draw_arrays(C.GL_LINE_STRIP, 0, segments + 1)
+	unsafe { vertices.free() }
 }
 
 pub fn (ctx &GG) draw_filled_arc(x, y, r, start_angle, end_angle f32, segments int, color gx.Color) {
 	ctx.use_color_shader(color)
+
+	
 	mut vertices := []f32
-	vertices << [x, y]
+	vertices << [x, y] !
 	vertices << arc_vertices(x, y, r, start_angle, end_angle, segments)
 	ctx.bind_vertices(vertices)
 	gl.draw_arrays(C.GL_TRIANGLE_FAN, 0, segments + 2)
+	unsafe { vertices.free() }
 }
 
 pub fn (ctx &GG) draw_circle(x, y, r f32, color gx.Color) {
@@ -441,16 +445,17 @@ pub fn (ctx &GG) draw_rounded_rect(x, y, w, h, r f32, color gx.Color) {
 	segments := 6 + int(r / 8)
 
 	// Create a rounded rectangle using a triangle fan mesh.
-	vertices << [x + (w/2.0), y + (h/2.0)]
+	vertices << [x + (w/2.0), y + (h/2.0)] !
 	vertices << arc_vertices(x + w - r, y + h - r, r, 0, 90, segments)
 	vertices << arc_vertices(x + r, y + h - r, r, 90, 180, segments)
 	vertices << arc_vertices(x + r, y + r, r, 180, 270, segments)
 	vertices << arc_vertices(x + w - r, y + r, r, 270, 360, segments)
 	// Finish the loop by going back to the first vertex
-	vertices << [vertices[2], vertices[3]]
+	vertices << [vertices[2], vertices[3]] !
 
 	ctx.bind_vertices(vertices)
 	gl.draw_arrays(C.GL_TRIANGLE_FAN, 0, segments * 4 + 6)
+	unsafe { vertices.free() }
 }
 
 pub fn (ctx &GG) draw_empty_rounded_rect(x, y, w, h, r f32, color gx.Color) {
@@ -465,6 +470,7 @@ pub fn (ctx &GG) draw_empty_rounded_rect(x, y, w, h, r f32, color gx.Color) {
 
 	ctx.bind_vertices(vertices)
 	gl.draw_arrays(C.GL_LINE_STRIP, 0, segments * 4 + 1)
+	unsafe { vertices.free() }
 }
 
 /*

--- a/vlib/gg/utils.v
+++ b/vlib/gg/utils.v
@@ -11,14 +11,14 @@ fn arc_vertices(x, y, r, start_angle, end_angle f32, segments int) []f32 {
 	start_rads := start_angle * 0.0174533 // deg -> rad approx
 	end_rads := end_angle * 0.0174533
 	increment := (end_rads - start_rads) / segments
-	vertices << [x + f32(math.cos(start_rads)) * r, y + f32(math.sin(start_rads)) * r]
+	vertices << [x + f32(math.cos(start_rads)) * r, y + f32(math.sin(start_rads)) * r] !
 	mut i := 1
 	for i < segments {
 		theta := f32(i) * increment + start_rads
-		vertices << [x + f32(math.cos(theta)) * r, y + f32(math.sin(theta)) * r]
+		vertices << [x + f32(math.cos(theta)) * r, y + f32(math.sin(theta)) * r] !
 		i++
 	}
-	vertices << [x + f32(math.cos(end_rads)) * r, y + f32(math.sin(end_rads)) * r]
+	vertices << [x + f32(math.cos(end_rads)) * r, y + f32(math.sin(end_rads)) * r] !
 	return vertices
 }
 

--- a/vlib/os/os_nix.v
+++ b/vlib/os/os_nix.v
@@ -1,5 +1,7 @@
 module os
 
+import strings
+
 #include <dirent.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -198,18 +200,19 @@ pub fn exec(cmd string) ?Result {
 	if isnil(f) {
 		return error('exec("$cmd") failed')
 	}
-	buf := [1000]byte
-	mut res := ''
-	for C.fgets(charptr(buf), 1000, f) != 0 {
-		res += tos(buf, vstrlen(buf))
+	buf := [4096]byte
+	mut res := strings.new_builder(1024)
+	for C.fgets(charptr(buf), 4096, f) != 0 {
+		res.write_bytes( buf, vstrlen(buf) )
 	}
-	res = res.trim_space()
+	soutput := res.str().trim_space()
+	res.free()
 	exit_code := vpclose(f)
 	// if exit_code != 0 {
 	// return error(res)
 	// }
 	return Result{
-		output: res
+		output: soutput
 		exit_code: exit_code
 	}
 }


### PR DESCRIPTION
This PR minimizes the memory usage of some frequently executed code.
In gg, that is done by using statically allocated temporary arrays of
floats for the arc vertices.
In os, that is done by using a string builder instead of iterative
string concatenation (which reduces the memory needed for storing the result
of fc-list from 39MB to ~250KB ...).

All in all, this PR makes programs that use V UI use ~8MB on linux,
instead of ~50MB.