### PR TITLE
builtin: temporally use format specifier instead of macro in int hex methods

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -157,7 +157,7 @@ pub fn (n i64) hex() string {
 	hex := malloc(len)
 	// QTODO
 	//count := C.sprintf(charptr(hex), '0x%'C.PRIx64, n)
-	count := C.sprintf('%x', n)
+	count := C.sprintf(charptr(hex), '0x%llx', n)
 	return tos(hex, count)
 }
 
@@ -165,7 +165,7 @@ pub fn (n u64) hex() string {
 	len := if n >= u64(0) { n.str().len + 3 } else { 19 }
 	hex := malloc(len)
 	//count := C.sprintf(charptr(hex), '0x%'C.PRIx64, n)
-	count := C.sprintf('%x', n)
+	count := C.sprintf(charptr(hex), '0x%llx', n)
 	return tos(hex, count)
 }
 


### PR DESCRIPTION
builtin: temporally use format specifier instead of macro in int hex methods