### PR TITLE
time: use `_mkgmtime` and `timegm` to calculate unix time

### DIFF
--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -490,3 +490,15 @@ pub fn (t Time) get_fmt_str(fmt_dlmtr FormatDelimiter, fmt_time FormatTime, fmt_
 pub fn (t Time) str() string {
 	return t.format_ss()
 }
+
+fn convert_ctime(t C.tm) Time {
+	return Time{
+		year: t.tm_year + 1900
+		month: t.tm_mon + 1
+		day: t.tm_mday
+		hour: t.tm_hour
+		minute: t.tm_min
+		second: t.tm_sec
+		unix: make_unix_time(t)
+	}
+}

--- a/vlib/time/time_nix.v
+++ b/vlib/time/time_nix.v
@@ -13,19 +13,8 @@ struct C.tm {
 	tm_gmtoff int // seconds
 }
 
-pub fn convert_ctime(t tm) Time {
-	return Time{
-		year: t.tm_year + 1900
-		month: t.tm_mon + 1
-		day: t.tm_mday
-		hour: t.tm_hour
-		minute: t.tm_min
-		second: t.tm_sec
-		unix: make_unix_time(t)
-	}
-}
+fn C.timegm(&tm) time_t
 
-[inline]
 fn make_unix_time(t tm) int {
-	return C.mktime(&t) + t.tm_gmtoff
+	return C.timegm(&t) as int
 }

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -223,15 +223,18 @@ fn test_parse() {
 	s := '2018-01-27 12:48:34'
 	t := time.parse(s)
 	assert t.year == 2018 && t.month == 1 && t.day == 27 && t.hour == 12 && t.minute == 48 && t.second == 34
+	assert t.unix == 1517057314
 }
 
 fn test_parse_iso() {
 	s1 := 'Thu, 12 Dec 2019 06:07:45 GMT'
 	t1 := time.parse_iso(s1)
 	assert t1.year == 2019 && t1.month == 12 && t1.day == 12 && t1.hour == 6 && t1.minute == 7 && t1.second == 45
+	assert t1.unix == 1576130865
 	s2 := 'Thu 12 Dec 2019 06:07:45 +0800'
 	t2 := time.parse_iso(s2)
 	assert t2.year == 2019 && t2.month == 12 && t2.day == 12 && t2.hour == 6 && t2.minute == 7 && t2.second == 45
+	assert t2.unix == 1576130865
 	s3 := 'Thu 12 Foo 2019 06:07:45 +0800'
 	t3 := time.parse_iso(s3)
 	assert t3.year == 0 && t3.month == 0 && t3.day == 0 && t3.hour == 0 && t3.minute == 0 && t3.second == 0

--- a/vlib/time/time_windows.v
+++ b/vlib/time/time_windows.v
@@ -12,19 +12,8 @@ struct C.tm {
 	tm_sec  int
 }
 
-pub fn convert_ctime(t tm) Time {
-	return Time{
-		year: t.tm_year + 1900
-		month: t.tm_mon + 1
-		day: t.tm_mday
-		hour: t.tm_hour
-		minute: t.tm_min
-		second: t.tm_sec
-		unix: make_unix_time(t)
-	}
-}
+fn C._mkgmtime(&tm) time_t
 
-[inline]
 fn make_unix_time(t tm) int {
-	return C.mktime(&t) - C._timezone
+	return C._mkgmtime(&t) as int
 }


### PR DESCRIPTION
## Changelog

- Used `_mkgmtime` and `timegm` to get Unix time
This way is more clear than using timezone offset directly to calculate Unix time.
- Added test cases to check if Unix time is calculated correctly