### PR TITLE
compiler: add very simple nameof token to get type name as string

### DIFF
--- a/vlib/compiler/expression.v
+++ b/vlib/compiler/expression.v
@@ -813,6 +813,15 @@ fn (p mut Parser) factor() string {
 			// p.fgen('$sizeof_typ)')
 			return 'int'
 		}
+		.key_nameof {
+			p.next()
+			p.check(.lpar)
+			mut nameof_typ := p.get_type()
+			p.check(.rpar)
+			p.gen('tos3("$nameof_typ")')
+//			return 'byteptr'
+			return 'string'
+		}
 		.key_offsetof {
 			p.next()
 			p.check(.lpar)

--- a/vlib/compiler/tests/nameof_test.v
+++ b/vlib/compiler/tests/nameof_test.v
@@ -1,0 +1,16 @@
+
+fn simple<T>(p T) string {
+	tname := nameof(T)
+	println("Hello generic, I'm an [$tname]")
+	return tname
+}
+
+struct FunkyStruct{ }
+
+fn test_nameof_on_various_types_in_generic() {
+	assert simple(42) == "int"
+	assert simple(3.14) == "f32"
+	assert simple("FuBar") == "string"
+	assert simple(FunkyStruct{}) == "FunkyStruct"
+	assert simple(test_nameof_on_various_types_in_generic) == "fn ()"
+}

--- a/vlib/compiler/token.v
+++ b/vlib/compiler/token.v
@@ -110,6 +110,7 @@ enum TokenKind {
 	key_select
 	key_sizeof
 	key_offsetof
+	key_nameof
 	key_struct
 	key_switch
 	key_true
@@ -240,6 +241,7 @@ fn build_token_str() []string {
 	s[TokenKind.key_select] = 'select'
 	s[TokenKind.key_none] = 'none'
 	s[TokenKind.key_offsetof] = '__offsetof'
+	s[TokenKind.key_nameof] = 'nameof'
 	return s
 }
 


### PR DESCRIPTION
Trivial addition of a new token 'nameof()'
which returns the type name as a V string,
providing a very crude "introspection" functionality

See nameof_test.v example :
```
fn simple<T>(p T) string {
    tname := nameof(T)
    println("Hello generic, I'm an [$tname]")
    return tname
}
```