### PR TITLE
vweb: improve vweb example to output the cookie

### DIFF
--- a/examples/vweb/vweb_example.v
+++ b/examples/vweb/vweb_example.v
@@ -38,8 +38,6 @@ pub fn (app mut App) text() {
 }
 
 pub fn (app mut App) cookie() {
-	app.vweb.text('Headers:')
 	app.vweb.set_cookie('cookie', 'test')
-	app.vweb.text(app.vweb.headers)
-	app.vweb.text('Text: hello world')
+	app.vweb.text('Headers: $app.vweb.headers')
 }


### PR DESCRIPTION
As pointed out in issue #3613, one of the examples for vweb does not behave as expected. This doesn't change vweb, just the example.

Since `$vweb.text()` sends the response subsequent calls to it in a handler does nothing. This change ensures that the text response contains the cookies, so it can be verified that it is being populated.
