### PR TITLE
os: fix compiler warnings when just importing os

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,5 +1,6 @@
 /cli
 /hello_world
+/hanoi
 /json
 /links_scraper
 /log


### PR DESCRIPTION
After this PR, `./v examples/fibonacci.v` no longer produces warnings.

Before:
```shell
0[11:56:45]delian@nemesis: /v/nv $ ./v examples/fibonacci.v                
warning: vlib/os/os.v:126:18: you are calling an unsafe function outside of an unsafe block
warning: vlib/os/os.v:711:23: you are calling an unsafe function outside of an unsafe block
0[11:56:49]delian@nemesis: /v/nv $
```