### PR TITLE
time: reorganize module

### DIFF
--- a/vlib/time/format.v
+++ b/vlib/time/format.v
@@ -1,0 +1,177 @@
+// Copyright (c) 2019-2020 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module time
+
+// format returns a date string in "YYYY-MM-DD HH:MM" format (24h).
+pub fn (t Time) format() string {
+	return t.get_fmt_str(.hyphen, .hhmm24, .yyyymmdd)
+}
+
+// format_ss returns a date string in "YYYY-MM-DD HH:MM:SS" format (24h).
+pub fn (t Time) format_ss() string {
+	return t.get_fmt_str(.hyphen, .hhmmss24, .yyyymmdd)
+}
+
+// hhmm returns a date string in "HH:MM" format (24h).
+pub fn (t Time) hhmm() string {
+	return t.get_fmt_time_str(.hhmm24)
+}
+
+// hhmmss returns a date string in "HH:MM:SS" format (24h).
+pub fn (t Time) hhmmss() string {
+	return t.get_fmt_time_str(.hhmmss24)
+}
+
+// hhmm12 returns a date string in "HH:MM" format (12h).
+pub fn (t Time) hhmm12() string {
+	return t.get_fmt_time_str(.hhmm12)
+}
+
+// ymmdd returns a date string in "YYYY-MM-DD" format.
+pub fn (t Time) ymmdd() string {
+	return t.get_fmt_date_str(.hyphen, .yyyymmdd)
+}
+
+// ddmmy returns a date string in "DD.MM.YYYY" format.
+pub fn (t Time) ddmmy() string {
+	return t.get_fmt_date_str(.dot, .ddmmyyyy)
+}
+
+// md returns a date string in "MMM D" format.
+pub fn (t Time) md() string {
+	return t.get_fmt_date_str(.space, .mmmd)
+}
+
+// clean returns a date string in a following format:
+//  - a date string in "HH:MM" format (24h) for current day
+//  - a date string in "MMM D HH:MM" format (24h) for date of current year
+//  - a date string formatted with format function for other dates
+pub fn (t Time) clean() string {
+	now := time.now()
+	// Today
+	if t.month == now.month && t.year == now.year && t.day == now.day {
+		return t.get_fmt_time_str(.hhmm24)
+	}
+	// This year
+	if t.year == now.year {
+		return t.get_fmt_str(.space, .hhmm24, .mmmd)
+	}
+	return t.format()
+}
+
+// clean12 returns a date string in a following format:
+//  - a date string in "HH:MM" format (12h) for current day
+//  - a date string in "MMM D HH:MM" format (12h) for date of current year
+//  - a date string formatted with format function for other dates
+pub fn (t Time) clean12() string {
+	now := time.now()
+	// Today
+	if t.month == now.month && t.year == now.year && t.day == now.day {
+		return t.get_fmt_time_str(.hhmm12)
+	}
+	// This year
+	if t.year == now.year {
+		return t.get_fmt_str(.space, .hhmm12, .mmmd)
+	}
+	return t.format()
+}
+
+// get_fmt_time_str returns a date string with specified FormatTime type.
+pub fn (t Time) get_fmt_time_str(fmt_time FormatTime) string {
+	if fmt_time == .no_time {
+		return ''
+	}
+	tp := if t.hour > 11 { 'p.m.' } else { 'a.m.' }
+	hour := if t.hour > 12 { t.hour - 12 } else if t.hour == 0 { 12 } else { t.hour }
+	return match fmt_time {
+		.hhmm12{
+			'$hour:${t.minute:02d} $tp'
+		}
+		.hhmm24{
+			'${t.hour:02d}:${t.minute:02d}'
+		}
+		.hhmmss12{
+			'$hour:${t.minute:02d}:${t.second:02d} $tp'
+		}
+		.hhmmss24{
+			'${t.hour:02d}:${t.minute:02d}:${t.second:02d}'
+		}
+		else {
+			'unknown enumeration $fmt_time'}
+	}
+}
+
+// get_fmt_time_str returns a date string with specified
+// FormatDelimiter and FormatDate type.
+pub fn (t Time) get_fmt_date_str(fmt_dlmtr FormatDelimiter, fmt_date FormatDate) string {
+	if fmt_date == .no_date {
+		return ''
+	}
+	month := '${t.smonth()}'
+	year := t.year.str()[2..]
+	return match fmt_date {
+		.ddmmyy{
+			'${t.day:02d}|${t.month:02d}|$year'
+		}
+		.ddmmyyyy{
+			'${t.day:02d}|${t.month:02d}|${t.year}'
+		}
+		.mmddyy{
+			'${t.month:02d}|${t.day:02d}|$year'
+		}
+		.mmddyyyy{
+			'${t.month:02d}|${t.day:02d}|${t.year}'
+		}
+		.mmmd{
+			'$month|${t.day}'
+		}
+		.mmmdd{
+			'$month|${t.day:02d}'
+		}
+		.mmmddyyyy{
+			'$month|${t.day:02d}|${t.year}'
+		}
+		.yyyymmdd{
+			'${t.year}|${t.month:02d}|${t.day:02d}'
+		}
+		else {
+			'unknown enumeration $fmt_date'}}.replace('|', match fmt_dlmtr {
+		.dot{
+			'.'
+		}
+		.hyphen{
+			'-'
+		}
+		.slash{
+			'/'
+		}
+		.space{
+			' '
+		}
+		else {
+			'unknown enumeration $fmt_dlmtr'}})
+}
+
+// get_fmt_str returns a date string with specified FormatDelimiter,
+// FormatTime type, and FormatDate type.
+pub fn (t Time) get_fmt_str(fmt_dlmtr FormatDelimiter, fmt_time FormatTime, fmt_date FormatDate) string {
+	if fmt_date == .no_date {
+		if fmt_time == .no_time {
+			// saving one function call although it's checked in
+			// t.get_fmt_time_str(fmt_time) in the beginning
+			return ''
+		}
+		else {
+			return t.get_fmt_time_str(fmt_time)
+		}
+	}
+	else {
+		if fmt_time != .no_time {
+			return t.get_fmt_date_str(fmt_dlmtr, fmt_date) + ' ' + t.get_fmt_time_str(fmt_time)
+		}
+		else {
+			return t.get_fmt_date_str(fmt_dlmtr, fmt_date)
+		}
+	}
+}

--- a/vlib/time/format_test.v
+++ b/vlib/time/format_test.v
@@ -1,0 +1,84 @@
+import time
+
+const (
+	time_to_test = time.Time{
+		year: 1980
+		month: 7
+		day: 11
+		hour: 21
+		minute: 23
+		second: 42
+		unix: 332198622
+	}
+)
+
+fn test_now_format() {
+	t := time.now()
+	u := t.unix
+	assert t.format() == time.unix(u).format()
+}
+
+fn test_format() {
+	assert '11.07.1980 21:23' == time_to_test.get_fmt_str(.dot, .hhmm24, .ddmmyyyy)
+}
+
+fn test_hhmm() {
+	assert '21:23' == time_to_test.hhmm()
+}
+
+fn test_hhmm12() {
+	assert '9:23 p.m.' == time_to_test.hhmm12()
+}
+
+fn test_hhmmss() {
+	assert '21:23:42' == time_to_test.hhmmss()
+}
+
+fn test_ymmdd() {
+	assert '1980-07-11' == time_to_test.ymmdd()
+}
+
+fn test_ddmmy() {
+	assert '11.07.1980' == time_to_test.ddmmy()
+}
+
+fn test_md() {
+	assert 'Jul 11' == time_to_test.md()
+}
+
+fn test_get_fmt_time_str() {
+	assert '21:23:42' == time_to_test.get_fmt_time_str(.hhmmss24)
+	assert '21:23' == time_to_test.get_fmt_time_str(.hhmm24)
+	assert '9:23:42 p.m.' == time_to_test.get_fmt_time_str(.hhmmss12)
+	assert '9:23 p.m.' == time_to_test.get_fmt_time_str(.hhmm12)
+}
+
+fn test_get_fmt_date_str() {
+	assert '11.07.1980' == time_to_test.get_fmt_date_str(.dot, .ddmmyyyy)
+	assert '11/07/1980' == time_to_test.get_fmt_date_str(.slash, .ddmmyyyy)
+	assert '11-07-1980' == time_to_test.get_fmt_date_str(.hyphen, .ddmmyyyy)
+	assert '11 07 1980' == time_to_test.get_fmt_date_str(.space, .ddmmyyyy)
+	assert '07.11.1980' == time_to_test.get_fmt_date_str(.dot, .mmddyyyy)
+	assert '07/11/1980' == time_to_test.get_fmt_date_str(.slash, .mmddyyyy)
+	assert '07-11-1980' == time_to_test.get_fmt_date_str(.hyphen, .mmddyyyy)
+	assert '07 11 1980' == time_to_test.get_fmt_date_str(.space, .mmddyyyy)
+	assert '11.07.80' == time_to_test.get_fmt_date_str(.dot, .ddmmyy)
+	assert '11/07/80' == time_to_test.get_fmt_date_str(.slash, .ddmmyy)
+	assert '11-07-80' == time_to_test.get_fmt_date_str(.hyphen, .ddmmyy)
+	assert '11 07 80' == time_to_test.get_fmt_date_str(.space, .ddmmyy)
+	assert '07.11.80' == time_to_test.get_fmt_date_str(.dot, .mmddyy)
+	assert '07/11/80' == time_to_test.get_fmt_date_str(.slash, .mmddyy)
+	assert '07-11-80' == time_to_test.get_fmt_date_str(.hyphen, .mmddyy)
+	assert '07 11 80' == time_to_test.get_fmt_date_str(.space, .mmddyy)
+	assert 'Jul 11' == time_to_test.get_fmt_date_str(.space, .mmmd)
+	assert 'Jul 11' == time_to_test.get_fmt_date_str(.space, .mmmdd)
+	assert 'Jul 11 1980' == time_to_test.get_fmt_date_str(.space, .mmmddyyyy)
+	assert '1980-07-11' == time_to_test.get_fmt_date_str(.hyphen, .yyyymmdd)
+}
+
+fn test_get_fmt_str() {
+	// Since get_fmt_time_str and get_fmt_date_str do have comprehensive
+	// tests I don't want to exaggerate here with all possible
+	// combinations.
+	assert '11.07.1980 21:23:42' == time_to_test.get_fmt_str(.dot, .hhmmss24, .ddmmyyyy)
+}

--- a/vlib/time/misc/misc.v
+++ b/vlib/time/misc/misc.v
@@ -6,7 +6,7 @@ import time
 const (
 	start_time_unix = time.now().unix
 )
-// random will return a random time.Time in *the past*
+// random returns a random time struct in *the past*.
 pub fn random() time.Time {
 	return time.unix(rand.next(start_time_unix))
 }

--- a/vlib/time/parse.v
+++ b/vlib/time/parse.v
@@ -1,0 +1,52 @@
+// Copyright (c) 2019-2020 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module time
+
+// parse returns time from a date string in "YYYY-MM-DD HH:MM:SS" format.
+pub fn parse(s string) ?Time {
+	pos := s.index(' ') or {
+		return error('Invalid time format: $s')
+	}
+	symd := s[..pos]
+	ymd := symd.split('-')
+	if ymd.len != 3 {
+		return error('Invalid time format: $s')
+	}
+	shms := s[pos..]
+	hms := shms.split(':')
+	hour := hms[0][1..]
+	minute := hms[1]
+	second := hms[2]
+
+	return new_time(Time{
+		year: ymd[0].int()
+		month: ymd[1].int()
+		day: ymd[2].int()
+		hour: hour.int()
+		minute: minute.int()
+		second: second.int()
+	})
+}
+
+// parse_iso returns time from a date string in RFC 2822 datetime format.
+pub fn parse_iso(s string) ?Time {
+	fields := s.split(' ')
+	if fields.len < 5 {
+		return error('Invalid time format: $s')
+	}
+	pos := months_string.index(fields[2]) or {
+		return error('Invalid time format: $s')
+	}
+	mm := pos / 3 + 1
+	tmstr := malloc(s.len * 2)
+	count := C.sprintf(charptr(tmstr), '%s-%02d-%s %s'.str, fields[3].str, mm,
+		fields[1].str, fields[4].str)
+
+	t := parse(tos(tmstr, count)) or {
+		// FIXME Remove this when optional forwarding is fixed.
+		return error('Invalid time format: $s')
+	}
+
+	return t
+}

--- a/vlib/time/parse.v
+++ b/vlib/time/parse.v
@@ -39,7 +39,8 @@ pub fn parse_iso(s string) ?Time {
 		return error('Invalid time format: $s')
 	}
 	mm := pos / 3 + 1
-	tmstr := malloc(s.len * 2)
+	mut tmstr := byteptr(0)
+	unsafe { tmstr = malloc(s.len * 2) }
 	count := C.sprintf(charptr(tmstr), '%s-%02d-%s %s'.str, fields[3].str, mm,
 		fields[1].str, fields[4].str)
 

--- a/vlib/time/parse.v
+++ b/vlib/time/parse.v
@@ -29,8 +29,8 @@ pub fn parse(s string) ?Time {
 	})
 }
 
-// parse_iso returns time from a date string in RFC 2822 datetime format.
-pub fn parse_iso(s string) ?Time {
+// parse_rfc2822 returns time from a date string in RFC 2822 datetime format.
+pub fn parse_rfc2822(s string) ?Time {
 	fields := s.split(' ')
 	if fields.len < 5 {
 		return error('Invalid time format: $s')

--- a/vlib/time/parse_test.v
+++ b/vlib/time/parse_test.v
@@ -1,0 +1,46 @@
+import time
+
+fn test_parse() {
+	s := '2018-01-27 12:48:34'
+	t := time.parse(s) or {
+		assert false
+		return
+	}
+	assert t.year == 2018 && t.month == 1 && t.day == 27 && t.hour == 12 && t.minute == 48 && t.second == 34
+	assert t.unix == 1517057314
+}
+
+fn test_parse_invalid() {
+	s := 'Invalid time string'
+	t := time.parse(s) or {
+		assert true
+		return
+	}
+	assert false
+}
+
+fn test_parse_rfc2822() {
+	s1 := 'Thu, 12 Dec 2019 06:07:45 GMT'
+	t1 := time.parse_rfc2822(s1) or {
+		assert false
+		return
+	}
+	assert t1.year == 2019 && t1.month == 12 && t1.day == 12 && t1.hour == 6 && t1.minute == 7 && t1.second == 45
+	assert t1.unix == 1576130865
+	s2 := 'Thu 12 Dec 2019 06:07:45 +0800'
+	t2 := time.parse_rfc2822(s2) or {
+		assert false
+		return
+	}
+	assert t2.year == 2019 && t2.month == 12 && t2.day == 12 && t2.hour == 6 && t2.minute == 7 && t2.second == 45
+	assert t2.unix == 1576130865
+}
+
+fn test_parse_rfc2822_invalid() {
+	s3 := 'Thu 12 Foo 2019 06:07:45 +0800'
+	t3 := time.parse_rfc2822(s3) or {
+		assert true
+		return
+	}
+	assert false
+}

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -1,14 +1,15 @@
 import time
 
 const (
-	time_to_test = time.new_time(time.Time{
+	time_to_test = time.Time{
 		year: 1980
 		month: 7
 		day: 11
 		hour: 21
 		minute: 23
 		second: 42
-	})
+		unix: 332198622
+	}
 )
 
 fn test_is_leap_year() {
@@ -20,15 +21,6 @@ fn test_is_leap_year() {
 	assert time.is_leap_year(1997) == false
 	// 2000 % 4 = 0 and 2000 % 100 = 0
 	assert time.is_leap_year(2100) == false
-}
-
-fn test_now_format() {
-	t := time.now()
-	u := t.unix
-	println(u)
-	println(t.format())
-	println(time.unix(u).format())
-	assert t.format() == time.unix(u).format()
 }
 
 fn check_days_in_month(month, year, expected int) bool {
@@ -113,34 +105,6 @@ fn test_smonth() {
 	}
 }
 
-fn test_format() {
-	assert '11.07.1980 21:23' == time_to_test.get_fmt_str(.dot, .hhmm24, .ddmmyyyy)
-}
-
-fn test_hhmm() {
-	assert '21:23' == time_to_test.hhmm()
-}
-
-fn test_hhmm12() {
-	assert '9:23 p.m.' == time_to_test.hhmm12()
-}
-
-fn test_hhmmss() {
-	assert '21:23:42' == time_to_test.hhmmss()
-}
-
-fn test_ymmdd() {
-	assert '1980-07-11' == time_to_test.ymmdd()
-}
-
-fn test_ddmmy() {
-	assert '11.07.1980' == time_to_test.ddmmy()
-}
-
-fn test_md() {
-	assert 'Jul 11' == time_to_test.md()
-}
-
 fn test_day_of_week() {
 	for i := 0; i < 7; i++ {
 		day_of_week := i + 1
@@ -180,88 +144,6 @@ fn test_add_days() {
 	t := time_to_test.add_days(num_of_days)
 	assert t.day == time_to_test.day + num_of_days
 	assert t.unix == time_to_test.unix + 86400 * num_of_days
-}
-
-fn test_get_fmt_time_str() {
-	assert '21:23:42' == time_to_test.get_fmt_time_str(.hhmmss24)
-	assert '21:23' == time_to_test.get_fmt_time_str(.hhmm24)
-	assert '9:23:42 p.m.' == time_to_test.get_fmt_time_str(.hhmmss12)
-	assert '9:23 p.m.' == time_to_test.get_fmt_time_str(.hhmm12)
-}
-
-fn test_get_fmt_date_str() {
-	assert '11.07.1980' == time_to_test.get_fmt_date_str(.dot, .ddmmyyyy)
-	assert '11/07/1980' == time_to_test.get_fmt_date_str(.slash, .ddmmyyyy)
-	assert '11-07-1980' == time_to_test.get_fmt_date_str(.hyphen, .ddmmyyyy)
-	assert '11 07 1980' == time_to_test.get_fmt_date_str(.space, .ddmmyyyy)
-	assert '07.11.1980' == time_to_test.get_fmt_date_str(.dot, .mmddyyyy)
-	assert '07/11/1980' == time_to_test.get_fmt_date_str(.slash, .mmddyyyy)
-	assert '07-11-1980' == time_to_test.get_fmt_date_str(.hyphen, .mmddyyyy)
-	assert '07 11 1980' == time_to_test.get_fmt_date_str(.space, .mmddyyyy)
-	assert '11.07.80' == time_to_test.get_fmt_date_str(.dot, .ddmmyy)
-	assert '11/07/80' == time_to_test.get_fmt_date_str(.slash, .ddmmyy)
-	assert '11-07-80' == time_to_test.get_fmt_date_str(.hyphen, .ddmmyy)
-	assert '11 07 80' == time_to_test.get_fmt_date_str(.space, .ddmmyy)
-	assert '07.11.80' == time_to_test.get_fmt_date_str(.dot, .mmddyy)
-	assert '07/11/80' == time_to_test.get_fmt_date_str(.slash, .mmddyy)
-	assert '07-11-80' == time_to_test.get_fmt_date_str(.hyphen, .mmddyy)
-	assert '07 11 80' == time_to_test.get_fmt_date_str(.space, .mmddyy)
-	assert 'Jul 11' == time_to_test.get_fmt_date_str(.space, .mmmd)
-	assert 'Jul 11' == time_to_test.get_fmt_date_str(.space, .mmmdd)
-	assert 'Jul 11 1980' == time_to_test.get_fmt_date_str(.space, .mmmddyyyy)
-	assert '1980-07-11' == time_to_test.get_fmt_date_str(.hyphen, .yyyymmdd)
-}
-
-fn test_get_fmt_str() {
-	// Since get_fmt_time_str and get_fmt_date_str do have comprehensive
-	// tests I don't want to exaggerate here with all possible
-	// combinations.
-	assert '11.07.1980 21:23:42' == time_to_test.get_fmt_str(.dot, .hhmmss24, .ddmmyyyy)
-}
-
-fn test_parse() {
-	s := '2018-01-27 12:48:34'
-	t := time.parse(s) or {
-		assert false
-		return
-	}
-	assert t.year == 2018 && t.month == 1 && t.day == 27 && t.hour == 12 && t.minute == 48 && t.second == 34
-	assert t.unix == 1517057314
-}
-
-fn test_parse_invalid() {
-	s := 'Invalid time string'
-	t := time.parse(s) or {
-		assert true
-		return
-	}
-	assert false
-}
-
-fn test_parse_rfc2822() {
-	s1 := 'Thu, 12 Dec 2019 06:07:45 GMT'
-	t1 := time.parse_rfc2822(s1) or {
-		assert false
-		return
-	}
-	assert t1.year == 2019 && t1.month == 12 && t1.day == 12 && t1.hour == 6 && t1.minute == 7 && t1.second == 45
-	assert t1.unix == 1576130865
-	s2 := 'Thu 12 Dec 2019 06:07:45 +0800'
-	t2 := time.parse_rfc2822(s2) or {
-		assert false
-		return
-	}
-	assert t2.year == 2019 && t2.month == 12 && t2.day == 12 && t2.hour == 6 && t2.minute == 7 && t2.second == 45
-	assert t2.unix == 1576130865
-}
-
-fn test_parse_rfc2822_invalid() {
-	s3 := 'Thu 12 Foo 2019 06:07:45 +0800'
-	t3 := time.parse_rfc2822(s3) or {
-		assert true
-		return
-	}
-	assert false
 }
 
 fn test_str() {

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -238,16 +238,16 @@ fn test_parse_invalid() {
 	assert false
 }
 
-fn test_parse_iso() {
+fn test_parse_rfc2822() {
 	s1 := 'Thu, 12 Dec 2019 06:07:45 GMT'
-	t1 := time.parse_iso(s1) or {
+	t1 := time.parse_rfc2822(s1) or {
 		assert false
 		return
 	}
 	assert t1.year == 2019 && t1.month == 12 && t1.day == 12 && t1.hour == 6 && t1.minute == 7 && t1.second == 45
 	assert t1.unix == 1576130865
 	s2 := 'Thu 12 Dec 2019 06:07:45 +0800'
-	t2 := time.parse_iso(s2) or {
+	t2 := time.parse_rfc2822(s2) or {
 		assert false
 		return
 	}
@@ -255,9 +255,9 @@ fn test_parse_iso() {
 	assert t2.unix == 1576130865
 }
 
-fn test_parse_iso_invalid() {
+fn test_parse_rfc2822_invalid() {
 	s3 := 'Thu 12 Foo 2019 06:07:45 +0800'
-	t3 := time.parse_iso(s3) or {
+	t3 := time.parse_rfc2822(s3) or {
 		assert true
 		return
 	}

--- a/vlib/time/unix.v
+++ b/vlib/time/unix.v
@@ -3,6 +3,7 @@
 // that can be found in the LICENSE file.
 module time
 
+// unix returns a time struct from Unix time.
 pub fn unix(abs int) Time {
 	// Split into day and time
 	mut day_offset := abs / seconds_per_day


### PR DESCRIPTION
Resolves #2659 and brings other useful things. Please let me know if I should add/update anything related to this issue.

## Changelog

- Added documentation
- Splitted code and tests to separate files
- Renamed `time_unix.v` to `unix.v`
`time_unix.v` can be confused with `time_nix.v`.
- Renamed `parse_iso` function to `parse_rfc2822`
This function parses date strings in RFC 2822 datetime format, but not in ISO (8601?) format.
- Fixed `unsafe` warning