### PR TITLE
Support for @VMODULE relative paths in #flag lines.

### DIFF
--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -14,6 +14,7 @@ import (
 
 struct Parser {
 	file_path              string // "/home/user/hello.v"
+	file_path_dir          string // "/home/user"
 	file_name              string // "hello.v"
 	file_platform          string // ".v", "_windows.v", "_nix.v", "_darwin.v", "_linux.v" ...
 	// When p.file_pcguard != '', it contains a
@@ -180,6 +181,7 @@ fn (v mut V) new_parser_from_file(path string) Parser {
 	p = {
 		p |
 		file_path:path,
+		file_path_dir:filepath.dir( path ),
 		file_name:path.all_after(os.path_separator),
 		file_platform:path_platform,
 		file_pcguard:path_pcguard,

--- a/vlib/compiler/comptime.v
+++ b/vlib/compiler/comptime.v
@@ -243,6 +243,7 @@ fn (p mut Parser) chash() {
 		if p.first_pass() {
 			mut flag := hash[5..]
 			// expand `@VROOT` `@VMOD` to absolute path
+			flag = flag.replace('@VMODULE', p.file_path_dir)
 			flag = flag.replace('@VROOT', p.vroot)
 			flag = flag.replace('@VPATH', p.pref.vpath)
 			flag = flag.replace('@VLIB_PATH', p.pref.vlib_path)

--- a/vlib/compiler/tests/project_with_c_code/.gitignore
+++ b/vlib/compiler/tests/project_with_c_code/.gitignore
@@ -1,0 +1,3 @@
+main
+mod1/c/implementation.o
+main_test

--- a/vlib/compiler/tests/project_with_c_code/main.v
+++ b/vlib/compiler/tests/project_with_c_code/main.v
@@ -1,0 +1,8 @@
+module main
+
+import mod1
+
+fn main(){
+	res := mod1.vadd(1,2)
+	println( res )
+}

--- a/vlib/compiler/tests/project_with_c_code/main_test.v
+++ b/vlib/compiler/tests/project_with_c_code/main_test.v
@@ -1,0 +1,5 @@
+import mod1
+
+fn test_using_c_code_in_the_same_module_works(){
+	assert 1003 == mod1.vadd(1,2)
+}

--- a/vlib/compiler/tests/project_with_c_code/mod1/c/header.h
+++ b/vlib/compiler/tests/project_with_c_code/mod1/c/header.h
@@ -1,0 +1,6 @@
+#ifndef ADD_H
+#define ADD_H
+
+int cadd(int a, int b);
+
+#endif

--- a/vlib/compiler/tests/project_with_c_code/mod1/c/implementation.c
+++ b/vlib/compiler/tests/project_with_c_code/mod1/c/implementation.c
@@ -1,0 +1,5 @@
+#include "header.h"
+
+int cadd(int a, int b) {
+    return a + b;
+}

--- a/vlib/compiler/tests/project_with_c_code/mod1/wrapper.v
+++ b/vlib/compiler/tests/project_with_c_code/mod1/wrapper.v
@@ -1,0 +1,12 @@
+module mod1
+
+#flag -I @VMODULE/c
+#flag @VMODULE/c/implementation.o
+
+#include "header.h"
+
+fn C.cadd(int,int) int
+
+pub fn vadd(a int, b int) int {
+	return 1000 + C.cadd(a,b)
+}


### PR DESCRIPTION
This PR enables V modules to refer to C code that is *inside* them,
without needing the C code to be in a system specific path, or in 
a known location such as @VROOT/thirdparty/ .

![project with local module containing C code](https://url4e.com/gyazo/images/8ddfc0bf.png)

The goal is for the V module to be more self contained in that way,
without needing users of the module to do manual operations like
adding custom -cflags to their project.