### PR TITLE
term: Add header() function

### DIFF
--- a/vlib/term/term.v
+++ b/vlib/term/term.v
@@ -43,12 +43,11 @@ pub fn h_divider(divider string) string {
 // =============== TEXT ===============
 pub fn header(text, divider string) string {
 	cols,_ := get_terminal_size()
-	text_limit := if cols > text.len + 2 + 2 * divider.len { text.len } else { cols - 3 - 2 * divider.len }
-	text_limit_alligned := if (text_limit % 2) != (cols % 2) { text_limit + 1 } else { text_limit }
-	text_start := (cols - text_limit_alligned) / 2
-	filler_line := divider.repeat(1 + cols / divider.len)[0..cols]
-	result := if text.len == 0 { filler_line } else { filler_line[0..text_start] + ' ' + text[0..text_limit] + ' ' + filler_line[text_start + text_limit + 2..cols] }
-	return result
+	tlimit := if cols > text.len + 2 + 2 * divider.len { text.len } else { cols - 3 - 2 * divider.len }
+	tlimit_alligned := if (tlimit % 2) != (cols % 2) { tlimit + 1 } else { tlimit }
+	tstart := (cols - tlimit_alligned) / 2
+	line := divider.repeat(1 + cols / divider.len)[0..cols]
+	return if text.len == 0 { line } else { line[0..tstart] + ' ' + text[0..tlimit] + ' ' + line[tstart + tlimit + 2..cols] }
 }
 
 fn supports_escape_sequences(fd int) bool {

--- a/vlib/term/term.v
+++ b/vlib/term/term.v
@@ -6,7 +6,6 @@ const (
 	default_columns_size = 80
 	default_rows_size = 25
 )
-
 // can_show_color_on_stdout returns true if colors are allowed in stdout;
 // returns false otherwise.
 pub fn can_show_color_on_stdout() bool {
@@ -34,34 +33,21 @@ pub fn fail_message(s string) string {
 // h_divider returns a horizontal divider line with a dynamic width,
 // that depends on the current terminal settings.
 pub fn h_divider(divider string) string {
-	cols, _ := get_terminal_size()
+	cols,_ := get_terminal_size()
 	result := divider.repeat(1 + (cols / divider.len))
 	return result[0..cols]
 }
 
-// header returns a horizontal divider line with text on the 
-// center of the line. 
-// e.g: term.header(" TEXT ", "=") 
+// header returns a horizontal divider line with a centered text in the middle.
+// e.g: term.header('TEXT', '=')
 // =============== TEXT ===============
 pub fn header(text, divider string) string {
-	cols, _ := get_terminal_size()
-	text_limit := if cols > text.len + 2 + 2*divider.len {
-		text.len
-	} else {
-		cols-3-2*divider.len
-	}
-	text_limit_alligned := if (text_limit % 2) != (cols % 2 ) {
-		text_limit + 1
-	} else {
-		text_limit
-	}
-	text_start := (cols - text_limit_alligned)/2
-	filler_line := divider.repeat( 1 + cols / divider.len )[0..cols]
-	result := if text.len == 0 {
-		filler_line
-	} else {
-		filler_line[0..text_start] + ' ' + text[0..text_limit] + ' ' + filler_line[text_start+text_limit+2..cols]
-	}
+	cols,_ := get_terminal_size()
+	text_limit := if cols > text.len + 2 + 2 * divider.len { text.len } else { cols - 3 - 2 * divider.len }
+	text_limit_alligned := if (text_limit % 2) != (cols % 2) { text_limit + 1 } else { text_limit }
+	text_start := (cols - text_limit_alligned) / 2
+	filler_line := divider.repeat(1 + cols / divider.len)[0..cols]
+	result := if text.len == 0 { filler_line } else { filler_line[0..text_start] + ' ' + text[0..text_limit] + ' ' + filler_line[text_start + text_limit + 2..cols] }
 	return result
 }
 

--- a/vlib/term/term.v
+++ b/vlib/term/term.v
@@ -44,9 +44,25 @@ pub fn h_divider(divider string) string {
 // e.g: term.header(" TEXT ", "=") 
 // =============== TEXT ===============
 pub fn header(text, divider string) string {
-    term_width := h_divider(divider).len - text.len
-    ln := divider.repeat(term_width / 2)
-    return ln + text + ln + (if (term_width % 2 != 0){divider} else {""})
+	cols, _ := get_terminal_size()
+	text_limit := if cols > text.len + 2 + 2*divider.len {
+		text.len
+	} else {
+		cols-3-2*divider.len
+	}
+	text_limit_alligned := if (text_limit % 2) != (cols % 2 ) {
+		text_limit + 1
+	} else {
+		text_limit
+	}
+	text_start := (cols - text_limit_alligned)/2
+	filler_line := divider.repeat( 1 + cols / divider.len )[0..cols]
+	result := if text.len == 0 {
+		filler_line
+	} else {
+		filler_line[0..text_start] + ' ' + text[0..text_limit] + ' ' + filler_line[text_start+text_limit+2..cols]
+	}
+	return result
 }
 
 fn supports_escape_sequences(fd int) bool {

--- a/vlib/term/term.v
+++ b/vlib/term/term.v
@@ -42,12 +42,15 @@ pub fn h_divider(divider string) string {
 // e.g: term.header('TEXT', '=')
 // =============== TEXT ===============
 pub fn header(text, divider string) string {
+	if text.len == 0 {
+		return h_divider(divider)
+	}
 	cols,_ := get_terminal_size()
 	tlimit := if cols > text.len + 2 + 2 * divider.len { text.len } else { cols - 3 - 2 * divider.len }
 	tlimit_alligned := if (tlimit % 2) != (cols % 2) { tlimit + 1 } else { tlimit }
 	tstart := (cols - tlimit_alligned) / 2
 	ln := divider.repeat(1 + cols / divider.len)[0..cols]
-	return if text.len == 0 { ln } else { ln[0..tstart] + ' ' + text[0..tlimit] + ' ' + ln[tstart + tlimit + 2..cols] }
+	return ln[0..tstart] + ' ' + text[0..tlimit] + ' ' + ln[tstart + tlimit + 2..cols]
 }
 
 fn supports_escape_sequences(fd int) bool {

--- a/vlib/term/term.v
+++ b/vlib/term/term.v
@@ -39,6 +39,16 @@ pub fn h_divider(divider string) string {
 	return result[0..cols]
 }
 
+// header returns a horizontal divider line with text on the 
+// center of the line. 
+// e.g: term.header(" TEXT ", "=") 
+// =============== TEXT ===============
+pub fn header(text, divider string) string {
+    term_width := h_divider(divider).len - text.len
+    ln := divider.repeat(term_width / 2)
+    return ln + text + ln + (if (term_width % 2 != 0){divider} else {""})
+}
+
 fn supports_escape_sequences(fd int) bool {
 	$if windows {
 		return (is_atty(fd) & 0x0004) > 0 && os.getenv('TERM') != 'dumb' // ENABLE_VIRTUAL_TERMINAL_PROCESSING

--- a/vlib/term/term.v
+++ b/vlib/term/term.v
@@ -46,8 +46,8 @@ pub fn header(text, divider string) string {
 	tlimit := if cols > text.len + 2 + 2 * divider.len { text.len } else { cols - 3 - 2 * divider.len }
 	tlimit_alligned := if (tlimit % 2) != (cols % 2) { tlimit + 1 } else { tlimit }
 	tstart := (cols - tlimit_alligned) / 2
-	line := divider.repeat(1 + cols / divider.len)[0..cols]
-	return if text.len == 0 { line } else { line[0..tstart] + ' ' + text[0..tlimit] + ' ' + line[tstart + tlimit + 2..cols] }
+	ln := divider.repeat(1 + cols / divider.len)[0..cols]
+	return if text.len == 0 { ln } else { ln[0..tstart] + ' ' + text[0..tlimit] + ' ' + ln[tstart + tlimit + 2..cols] }
 }
 
 fn supports_escape_sequences(fd int) bool {

--- a/vlib/term/term_test.v
+++ b/vlib/term/term_test.v
@@ -26,6 +26,7 @@ fn test_header() {
 	short_header := term.header('reasonable header', '-')
 	very_long_header := term.header(['abc'].repeat(500).join(' '), '-')
 	very_long_header_2 := term.header(['abcd'].repeat(500).join(' '), '-')
+	/*
 	eprintln(divider)
 	eprintln(empty_header)
 	eprintln(short_header)
@@ -47,8 +48,10 @@ fn test_header() {
 	eprintln(term.header('123', '_-/\\\/'))
 	eprintln(term.header('1234', '_-/\\/\\'))
 	eprintln(term.header('', '-'))
+    */
 	assert term_width == empty_header.len
 	assert term_width == short_header.len
 	assert term_width == very_long_header.len
+	assert term_width == very_long_header_2.len
 	assert term_width == term.header('1234', '_-/\\/\\').len
 }

--- a/vlib/term/term_test.v
+++ b/vlib/term/term_test.v
@@ -1,55 +1,52 @@
 import term
 
-fn test_get_terminal_size(){
-	cols, _ := term.get_terminal_size()
+fn test_get_terminal_size() {
+	cols,_ := term.get_terminal_size()
 	assert cols > 0
 }
 
-fn test_h_divider(){
+fn test_h_divider() {
 	divider := term.h_divider('-')
 	assert divider.len > 0
 	assert divider[0] == `-`
-	assert divider[divider.len-1] == `-`
+	assert divider[divider.len - 1] == `-`
 }
 
-fn test_h_divider_multiple_characters(){
+fn test_h_divider_multiple_characters() {
 	xdivider := term.h_divider('abc')
 	assert xdivider.len > 0
 	assert xdivider.contains('abcabc')
-}	
+}
 
-fn test_header(){
+fn test_header() {
 	divider := term.h_divider('-')
-	term_width := divider.len	
+	term_width := divider.len
 	assert term_width > 0
-
 	empty_header := term.header('', '-')
 	short_header := term.header('reasonable header', '-')
 	very_long_header := term.header(['abc'].repeat(500).join(' '), '-')
 	very_long_header_2 := term.header(['abcd'].repeat(500).join(' '), '-')
-
-	eprintln( divider )
-	eprintln( empty_header )
-	eprintln( short_header )
+	eprintln(divider)
+	eprintln(empty_header)
+	eprintln(short_header)
 	eprintln(term.header('another longer header', '_-/\\'))
 	eprintln(term.header('another longer header', '-'))
-	eprintln(term.header('short','-'))
-	eprintln(term.header('12345','-'))
-	eprintln(term.header('1234','-'))
-	eprintln(term.header('123','-'))
-	eprintln(term.header('12','-'))
-	eprintln(term.header('1','-'))
-	eprintln( very_long_header )
+	eprintln(term.header('short', '-'))
+	eprintln(term.header('12345', '-'))
+	eprintln(term.header('1234', '-'))
+	eprintln(term.header('123', '-'))
+	eprintln(term.header('12', '-'))
+	eprintln(term.header('1', '-'))
+	eprintln(very_long_header)
 	eprintln(divider)
-	eprintln( very_long_header_2 )
+	eprintln(very_long_header_2)
 	eprintln(term.header(['abcd'].repeat(500).join(' '), '_-/\\'))
 	eprintln(term.header(['abcd'].repeat(500).join(' '), '_-//'))
 	eprintln(term.header('1', '_-/\\\/'))
 	eprintln(term.header('12', '_-/\\\/'))
 	eprintln(term.header('123', '_-/\\\/'))
 	eprintln(term.header('1234', '_-/\\/\\'))
-	eprintln(term.header('','-'))
-	
+	eprintln(term.header('', '-'))
 	assert term_width == empty_header.len
 	assert term_width == short_header.len
 	assert term_width == very_long_header.len

--- a/vlib/term/term_test.v
+++ b/vlib/term/term_test.v
@@ -1,5 +1,10 @@
 import term
 
+fn test_get_terminal_size(){
+	cols, _ := term.get_terminal_size()
+	assert cols > 0
+}
+
 fn test_h_divider(){
 	divider := term.h_divider('-')
 	assert divider.len > 0

--- a/vlib/term/term_test.v
+++ b/vlib/term/term_test.v
@@ -1,0 +1,51 @@
+import term
+
+fn test_h_divider(){
+	divider := term.h_divider('-')
+	assert divider.len > 0
+	assert divider[0] == `-`
+	assert divider[divider.len-1] == `-`
+	
+	xdivider := term.h_divider('x')
+	assert xdivider.len > 0
+	assert xdivider[0] == `x`
+	assert xdivider[xdivider.len-1] == `x`
+}	
+
+fn test_header(){
+	divider := term.h_divider('-')
+	term_width := divider.len	
+	assert term_width > 0
+
+	empty_header := term.header('', '-')
+	short_header := term.header('reasonable header', '-')
+	very_long_header := term.header(['abc'].repeat(500).join(' '), '-')
+	very_long_header_2 := term.header(['abcd'].repeat(500).join(' '), '-')
+
+	eprintln( divider )
+	eprintln( empty_header )
+	eprintln( short_header )
+	eprintln(term.header('another longer header', '_-/\\'))
+	eprintln(term.header('another longer header', '-'))
+	eprintln(term.header('short','-'))
+	eprintln(term.header('12345','-'))
+	eprintln(term.header('1234','-'))
+	eprintln(term.header('123','-'))
+	eprintln(term.header('12','-'))
+	eprintln(term.header('1','-'))
+	eprintln( very_long_header )
+	eprintln(divider)
+	eprintln( very_long_header_2 )
+	eprintln(term.header(['abcd'].repeat(500).join(' '), '_-/\\'))
+	eprintln(term.header(['abcd'].repeat(500).join(' '), '_-//'))
+	eprintln(term.header('1', '_-/\\\/'))
+	eprintln(term.header('12', '_-/\\\/'))
+	eprintln(term.header('123', '_-/\\\/'))
+	eprintln(term.header('1234', '_-/\\/\\'))
+	eprintln(term.header('','-'))
+	
+	assert term_width == empty_header.len
+	assert term_width == short_header.len
+	assert term_width == very_long_header.len
+	assert term_width == term.header('1234', '_-/\\/\\').len
+}

--- a/vlib/term/term_test.v
+++ b/vlib/term/term_test.v
@@ -15,10 +15,7 @@ fn test_h_divider(){
 fn test_h_divider_multiple_characters(){
 	xdivider := term.h_divider('abc')
 	assert xdivider.len > 0
-	assert xdivider[0] == `a`
-	assert xdivider[1] == `b`
-	assert xdivider[2] == `c`
-	assert xdivider[xdivider.len-10..xdivider.len-1].contains('abc')
+	assert xdivider.contains('abcabc')
 }	
 
 fn test_header(){

--- a/vlib/term/term_test.v
+++ b/vlib/term/term_test.v
@@ -10,11 +10,15 @@ fn test_h_divider(){
 	assert divider.len > 0
 	assert divider[0] == `-`
 	assert divider[divider.len-1] == `-`
-	
-	xdivider := term.h_divider('x')
+}
+
+fn test_h_divider_multiple_characters(){
+	xdivider := term.h_divider('abc')
 	assert xdivider.len > 0
-	assert xdivider[0] == `x`
-	assert xdivider[xdivider.len-1] == `x`
+	assert xdivider[0] == `a`
+	assert xdivider[1] == `b`
+	assert xdivider[2] == `c`
+	assert xdivider[xdivider.len-10..xdivider.len-1].contains('abc')
 }	
 
 fn test_header(){


### PR DESCRIPTION
This function returns a horizontal divider line with the text on the center of the line.

```v
import term
fn main() {
	println(term.header('', '='))
	println(term.header('V PANIC', '='))
	println(term.header('', '='))
}
```

![Screenshot from 2020-02-07 22-44-29](https://user-images.githubusercontent.com/17797740/74038590-72cedd00-49fb-11ea-93a9-f82f06991b05.png)
