### PR TITLE
vweb/assets.v: fix unix time typo

### DIFF
--- a/vlib/vweb/assets/assets.v
+++ b/vlib/vweb/assets/assets.v
@@ -87,7 +87,7 @@ fn (am mut AssetManager) combine(asset_type string, to_file bool) string {
 	}
 	// rebuild
 	for asset in am.get_assets(asset_type) {
-		mut data := os.read_file(asset.file_path) or {
+		data := os.read_file(asset.file_path) or {
 			return ''
 		}
 		out += data
@@ -118,8 +118,8 @@ fn (am mut AssetManager) get_cache_key(asset_type string) string {
 	mut latest_modified := 0
 	for asset in am.get_assets(asset_type) {
 		files_salt += asset.file_path
-		if asset.last_modified.uni > latest_modified {
-			latest_modified = asset.last_modified.uni
+		if asset.last_modified.unix > latest_modified {
+			latest_modified = asset.last_modified.unix
 		}
 	}
 	hash := md5.sum(files_salt.bytes()).hex()
@@ -159,7 +159,7 @@ fn (am mut AssetManager) add(asset_type, file string) bool {
 	}
 	asset := Asset{
 		file_path: file
-		last_modified: time.Time{uni: os.file_last_mod_unix(file)}
+		last_modified: time.Time{unix: os.file_last_mod_unix(file)}
 	}
 	if asset_type == 'css' {
 		am.css << asset


### PR DESCRIPTION
There were a couple typos in `vweb/asset.v`
`v` still compiles itself.
No new functions were added.