### PR TITLE
tooling: use term.header for tests. Support VJOBS=1 v test .

### DIFF
--- a/tools/modules/testing/common.v
+++ b/tools/modules/testing/common.v
@@ -88,7 +88,12 @@ pub fn (ts mut TestSession) test() {
 		// See: https://docs.microsoft.com/en-us/cpp/build/reference/fs-force-synchronous-pdb-writes?view=vs-2019
 		// Instead, just run tests on 1 core for now.
 		ncpus = 1
-	}	
+	}
+	// allow for overrides using `VJOBS=32 ./v test .`
+	vjobs := os.getenv('VJOBS').int()
+	if vjobs > 0 {
+		ncpus = vjobs
+	}
 	ts.waitgroup.add( ncpus )
 	for i:=0; i < ncpus; i++ {
 		go process_in_thread(ts)

--- a/tools/modules/testing/common.v
+++ b/tools/modules/testing/common.v
@@ -197,7 +197,7 @@ pub fn v_build_failing(zargs string, folder string) bool {
 	vlib_should_be_present(parent_dir)
 	vargs := zargs.replace(vexe, '')
 	eheader(main_label)
-	eheader('v compiler args: "$vargs"')
+	eprintln('v compiler args: "$vargs"')
 	mut session := new_test_session(vargs)
 	files := os.walk_ext(filepath.join(parent_dir,folder), '.v')
 	mut mains := files.filter(!it.contains('modules') && !it.contains('preludes'))
@@ -232,7 +232,7 @@ pub fn build_v_cmd_failed(cmd string) bool {
 
 pub fn building_any_v_binaries_failed() bool {
 	eheader('Building V binaries...')
-	eheader('VFLAGS is: "' + os.getenv('VFLAGS') + '"')
+	eprintln('VFLAGS is: "' + os.getenv('VFLAGS') + '"')
 	vexe := testing.vexe_path()
 	parent_dir := filepath.dir(vexe)
 	testing.vlib_should_be_present(parent_dir)

--- a/tools/modules/testing/common.v
+++ b/tools/modules/testing/common.v
@@ -140,7 +140,7 @@ fn (ts mut TestSession) process_files() {
 		ts.benchmark.step()
 		tls_bench.step()
 		if show_stats {
-			eprintln('-------------------------------------------------')
+			eprintln(term.h_divider('-'))
 			status := os.system(cmd)
 			if status == 0 {
 				ts.benchmark.ok()
@@ -196,8 +196,8 @@ pub fn v_build_failing(zargs string, folder string) bool {
 	parent_dir := filepath.dir(vexe)
 	vlib_should_be_present(parent_dir)
 	vargs := zargs.replace(vexe, '')
-	eprintln(main_label)
-	eprintln('   v compiler args: "$vargs"')
+	eheader(main_label)
+	eheader('v compiler args: "$vargs"')
 	mut session := new_test_session(vargs)
 	files := os.walk_ext(filepath.join(parent_dir,folder), '.v')
 	mut mains := files.filter(!it.contains('modules') && !it.contains('preludes'))
@@ -231,8 +231,8 @@ pub fn build_v_cmd_failed(cmd string) bool {
 }
 
 pub fn building_any_v_binaries_failed() bool {
-	eprintln('Building V binaries...')
-	eprintln('VFLAGS is: "' + os.getenv('VFLAGS') + '"')
+	eheader('Building V binaries...')
+	eheader('VFLAGS is: "' + os.getenv('VFLAGS') + '"')
 	vexe := testing.vexe_path()
 	parent_dir := filepath.dir(vexe)
 	testing.vlib_should_be_present(parent_dir)
@@ -261,4 +261,12 @@ pub fn building_any_v_binaries_failed() bool {
 	eprintln(term.h_divider('-'))
 	eprintln(bmark.total_message('building v binaries'))
 	return failed
+}
+
+pub fn eheader(msg string) {
+	eprintln(term.header(msg,'-'))
+}
+
+pub fn header(msg string) {
+	println(term.header(msg,'-'))
 }

--- a/tools/vtest-compiler.v
+++ b/tools/vtest-compiler.v
@@ -43,7 +43,8 @@ fn v_test_compiler(vargs string) {
 		}
 	}
 	building_tools_failed := testing.v_build_failing(vargs, 'tools')
-	eprintln('\nTesting all _test.v files...')
+	eprintln('')
+	testing.eheader('Testing all _test.v files...')
 	mut compiler_test_session := testing.new_test_session(vargs)
 	compiler_test_session.files << os.walk_ext(parent_dir, '_test.v')
 	compiler_test_session.test()
@@ -54,7 +55,8 @@ fn v_test_compiler(vargs string) {
 	building_live_failed := testing.v_build_failing(vargs + '-live', filepath.join('examples','hot_reload'))
 	eprintln('')
 	v_module_install_cmd := '$vexe install nedpals.args'
-	eprintln('\nInstalling a v module with: $v_module_install_cmd ')
+	eprintln('')
+	testing.eheader('Installing a v module with: $v_module_install_cmd')
 	mut vmark := benchmark.new_benchmark()
 	ret := os.system(v_module_install_cmd)
 	if ret != 0 {

--- a/tools/vtest-fmt.v
+++ b/tools/vtest-fmt.v
@@ -8,13 +8,13 @@ import (
 const (
 	known_failing_exceptions = ['./examples/vweb/vweb_example.v',
 	'./tools/gen_vc.v',
-  './tools/modules/vgit/vgit.v', // generics
+	'./tools/modules/vgit/vgit.v', // generics
 	'./tools/preludes/live_main.v',
 	'./tools/preludes/live_shared.v',
 	'./tools/preludes/tests_assertions.v',
 	'./tools/preludes/tests_with_stats.v',
-  './tools/performance_compare.v', // generics
-  './tools/oldv.v', // generics
+	'./tools/performance_compare.v', // generics
+	'./tools/oldv.v', // generics
 	'./tutorials/code/blog/article.v',
 	'./tutorials/code/blog/blog.v',
 	'./vlib/arrays/arrays.v',
@@ -45,7 +45,7 @@ fn main() {
 
 fn v_test_formatting(vargs string) {
 	all_v_files := v_files()
-	eprintln('Run "v fmt" over all .v files')
+	testing.eheader('Run "v fmt" over all .v files')
 	mut vfmt_test_session := testing.new_test_session('$vargs fmt -worker')
 	vfmt_test_session.files << all_v_files
 	vfmt_test_session.test()

--- a/tools/vtest.v
+++ b/tools/vtest.v
@@ -45,7 +45,7 @@ pub fn main() {
 		println('Unrecognized test file $targ .')
 	}
 
-	println('Testing...')
+	testing.header('Testing...')
 	ts.test()
 
 	println( ts.benchmark.total_message('running V _test.v files') )

--- a/vlib/runtime/runtime.v
+++ b/vlib/runtime/runtime.v
@@ -4,6 +4,8 @@
 
 module runtime
 
+import os
+
 //$if linux {
 fn C.sysconf(name int) i64
 //}
@@ -17,6 +19,16 @@ pub fn nr_cpus() int {
 		return nr_cpus_win()
 	}
 	return nr_cpus_nix()
+}
+
+pub fn nr_jobs() int {
+	mut cpus := nr_cpus()
+	// allow for overrides, for example using `VJOBS=32 ./v test .`
+	vjobs := os.getenv('VJOBS').int()
+	if vjobs > 0 {
+		cpus = vjobs
+	}
+	return cpus
 }
 
 pub fn is_32bit() bool {


### PR DESCRIPTION
This PR makes tests use term.header for nicer looking output.

It also adds support for `VJOBS=1 ./v test .` when you want to run tests sequentially.