### PR TITLE
Changed Advanced Topics to h1

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1215,7 +1215,7 @@ An overview of the module must be placed in the first comment right after the mo
 To generate documentation, run `v doc path/to/module` (TODO this is
 temporarily disabled).
 
-## Advanced Topics
+# Advanced Topics
 
 ## Calling C functions from V
 


### PR DESCRIPTION
Changed `## Advanced Topics` to `# Advanced Topics` as its a title for the other headers below it. This will also make it play nicer with the TOC generator implemented in the new site: ![toc preview](https://i.imgur.com/ljQdZOz.png)