### PR TITLE
string: split into lines correctly

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -468,13 +468,27 @@ pub fn (s string) split_into_lines() []string {
 	}
 	mut start := 0
 	for i := 0; i < s.len; i++ {
-		last := i == s.len - 1
-		if s[i] == 10 || last {
-			if last {
+		is_lf := s[i] == `\n`
+		is_crlf := i != s.len - 1 && s[i] == `\r` && s[i + 1] == `\n`
+		is_eol := is_lf || is_crlf
+		is_last := if is_crlf {
+			i == s.len - 2
+		} else {
+			i == s.len - 1
+		}
+
+		if is_eol || is_last {
+			if is_last && !is_eol {
 				i++
 			}
+
 			line := s.substr(start, i)
 			res << line
+
+			if is_crlf {
+				i++
+			}
+
 			start = i + 1
 		}
 	}

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -634,3 +634,21 @@ fn test_double_quote_inter() {
 	assert '${a} ${b}' == "1 2"
 }
 
+fn test_split_into_lines() {
+	line_content := 'Line'
+	text_crlf := '${line_content}\r\n${line_content}\r\n${line_content}'
+	lines_crlf := text_crlf.split_into_lines()
+
+	assert lines_crlf.len == 3
+	for line in lines_crlf {
+		assert line == line_content
+	}
+
+	text_lf := '${line_content}\n${line_content}\n${line_content}'
+	lines_lf := text_lf.split_into_lines()
+
+	assert lines_lf.len == 3
+	for line in lines_lf {
+		assert line == line_content
+	}
+}


### PR DESCRIPTION
Fixes #3697.

Note that the function **DOES NOT** add an empty line for files have new line at the end of file. If we should have a final empty line in a result for such files, please let me know, and I will add this.