### PR TITLE
compiler: scope type alias to module except for in builtin/main

### DIFF
--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -829,12 +829,12 @@ fn (p mut Parser) type_decl() {
 		p.fspace()
 	}
 	mut parent := Type{}
+	if !p.builtin_mod && p.mod != 'main' {
+		name = p.prepend_mod(name)
+	}
 	// Sum type
 	//is_sum := p.tok == .pipe
 	if is_sum {
-		if !p.builtin_mod && p.mod != 'main' {
-			name = p.prepend_mod(name)
-		}
 		// Register the first child  (name we already parsed)
 		/*
 		p.table.register_type(Type{

--- a/vlib/os/os_windows.v
+++ b/vlib/os/os_windows.v
@@ -11,7 +11,7 @@ pub const (
 
 // Ref - https://docs.microsoft.com/en-us/windows/desktop/winprog/windows-data-types
 // A handle to an object.
-type HANDLE voidptr
+pub type HANDLE voidptr
 
 // win: FILETIME
 // https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime

--- a/vlib/os/os_windows.v
+++ b/vlib/os/os_windows.v
@@ -11,7 +11,7 @@ pub const (
 
 // Ref - https://docs.microsoft.com/en-us/windows/desktop/winprog/windows-data-types
 // A handle to an object.
-pub type HANDLE voidptr
+type HANDLE voidptr
 
 // win: FILETIME
 // https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime

--- a/vlib/term/term_windows.v
+++ b/vlib/term/term_windows.v
@@ -17,7 +17,7 @@ struct C.CONSOLE_SCREEN_BUFFER_INFO {
 	dwMaximumWindowSize C.COORD
 }
 
-fn C.GetConsoleScreenBufferInfo(handle C.HANDLE, info &CONSOLE_SCREEN_BUFFER_INFO) bool
+fn C.GetConsoleScreenBufferInfo(handle os.HANDLE, info &CONSOLE_SCREEN_BUFFER_INFO) bool
 
 // get_terminal_size returns a number of colums and rows of terminal window.
 pub fn get_terminal_size() (int, int) {

--- a/vlib/term/term_windows.v
+++ b/vlib/term/term_windows.v
@@ -17,7 +17,7 @@ struct C.CONSOLE_SCREEN_BUFFER_INFO {
 	dwMaximumWindowSize C.COORD
 }
 
-fn C.GetConsoleScreenBufferInfo(handle os.HANDLE, info &CONSOLE_SCREEN_BUFFER_INFO) bool
+fn C.GetConsoleScreenBufferInfo(handle C.HANDLE, info &CONSOLE_SCREEN_BUFFER_INFO) bool
 
 // get_terminal_size returns a number of colums and rows of terminal window.
 pub fn get_terminal_size() (int, int) {


### PR DESCRIPTION
compiler: scope type alias to module except for in builtin/main