### PR TITLE
compiler: bugfix for raw'"'

### DIFF
--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -585,6 +585,13 @@ fn test_raw() {
 	println('raw string: "$raw"')
 }
 
+fn test_raw_with_quotes() {
+	raw := r"some'" + r'"thing' // " should be escaped in the generated C code
+	assert raw[0] == `s`
+	assert raw[5] == `"`
+	assert raw[6] == `t`
+}
+
 fn test_escape() {
 	// TODO
 	//a := 10

--- a/vlib/compiler/string_expression.v
+++ b/vlib/compiler/string_expression.v
@@ -12,7 +12,7 @@ fn (p mut Parser) string_expr() {
 	str := p.lit
 	// No ${}, just return a simple string
 	if p.peek() != .str_dollar || is_raw {
-		f := if is_raw { cescaped_path(str) } else { format_str(str) }
+		f := if is_raw { cescaped_path(str).replace('"', '\\"') } else { format_str(str) }
 		// `C.puts('hi')` => `puts("hi");`
 		/*
 		Calling a C function sometimes requires a call to a string method


### PR DESCRIPTION
Closes #3703.

`raw = r"some'" + r'"thing'` now works properly, by escaping the quote
signs in the generated C code.