### PR TITLE
Fix -prod on OpenBSD

### DIFF
--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -181,7 +181,14 @@ fn (v mut V) cc() {
 		if debug_mode {
 			debug_options = '-g -O0 -no-pie'
 		}
-		optimization_options = '-O3 -flto'
+		optimization_options = '-O3'
+		mut have_flto := true
+		$if openbsd {
+			have_flto = false
+		}
+		if have_flto {
+			optimization_options += ' -flto'
+		}
 	}
 	if v.pref.ccompiler.contains('gcc') || guessed_compiler == 'gcc' {
 		if debug_mode {


### PR DESCRIPTION
Building in OpenBSD only works when no -prod flag is passed, otherwise we get something like this:

<img width="725" alt="Screenshot 2020-02-10 at 00 15 20" src="https://user-images.githubusercontent.com/917142/74112147-6d5bc900-4b9a-11ea-80a5-8699b4a70a88.png">

Digging down in the rabbit hole i end up finding the lfto flag doesn't works in OpenBSD (even if clang from llvm8 shows it in the help message (cc --help | grep flto)9
<img width="721" alt="Screenshot 2020-02-10 at 00 13 22" src="https://user-images.githubusercontent.com/917142/74112099-28379700-4b9a-11ea-9bc1-a738fb40b721.png">


