### PR TITLE
net.http: more robust handling of relative /path URL redirects.

### DIFF
--- a/vlib/net/ftp/ftp.v
+++ b/vlib/net/ftp/ftp.v
@@ -50,6 +50,7 @@ fn (dtp DTP) read() []byte {
 		for i := 0; i < len; i++ {
 			data << buf[i]
 		}
+		unsafe { free(buf) }
 	}
 
 	return data

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -193,7 +193,7 @@ pub fn parse_headers(lines []string) map[string]string {
 
 // do will send the HTTP request and returns `http.Response` as soon as the response is recevied
 pub fn (req &Request) do() ?Response {
-	url := urllib.parse(req.url) or {
+	mut url := urllib.parse(req.url) or {
 		return error('http.Request.do: invalid url ${req.url}')
 	}
 	mut rurl := url
@@ -211,7 +211,13 @@ pub fn (req &Request) do() ?Response {
 			break
 		}
 		// follow any redirects
-		redirect_url := resp.headers['Location']
+		mut redirect_url := resp.headers['Location']
+		if redirect_url.len>0 && redirect_url[0] == `/` {
+			url.set_path( redirect_url ) or {
+				return error('http.request.do: invalid path in redirect: "$redirect_url"')
+			}
+			redirect_url = url.str()
+		}		
 		qrurl := urllib.parse(redirect_url) or {
 			return error('http.request.do: invalid URL in redirect "$redirect_url"')
 		}

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -212,12 +212,12 @@ pub fn (req &Request) do() ?Response {
 		}
 		// follow any redirects
 		mut redirect_url := resp.headers['Location']
-		if redirect_url.len>0 && redirect_url[0] == `/` {
-			url.set_path( redirect_url ) or {
+		if redirect_url.len > 0 && redirect_url[0] == `/` {
+			url.set_path(redirect_url) or {
 				return error('http.request.do: invalid path in redirect: "$redirect_url"')
 			}
 			redirect_url = url.str()
-		}		
+		}
 		qrurl := urllib.parse(redirect_url) or {
 			return error('http.request.do: invalid URL in redirect "$redirect_url"')
 		}

--- a/vlib/net/http/http_test.v
+++ b/vlib/net/http/http_test.v
@@ -43,6 +43,5 @@ fn test_relative_redirects() {
 	assert 200 == res.status_code
 	assert res.text.len > 0
 	assert res.text.contains('"abc": "xyz"')
-	eprintln( res.text )
 }
 

--- a/vlib/net/http/http_test.v
+++ b/vlib/net/http/http_test.v
@@ -36,3 +36,13 @@ fn test_public_servers() {
 		assert res.text.len > 0
 	}
 }
+
+fn test_relative_redirects() {
+	$if !network ? { return }
+	res := http.get('https://httpbin.org/relative-redirect/3?abc=xyz') or { panic(err) }
+	assert 200 == res.status_code
+	assert res.text.len > 0
+	assert res.text.contains('"abc": "xyz"')
+	eprintln( res.text )
+}
+

--- a/vlib/net/socket.v
+++ b/vlib/net/socket.v
@@ -255,9 +255,10 @@ pub fn (s Socket) send_string(sdata string) ?int {
 	return s.send(sdata.str, sdata.len)
 }
 
-// receive string data from socket
+// receive string data from socket. NB: you are responsible for freeing the returned byteptr
 pub fn (s Socket) recv(bufsize int) (byteptr,int) {
-	buf := malloc(bufsize)
+	mut buf := byteptr(0)
+  unsafe { buf = malloc(bufsize) }
 	res := C.recv(s.sockfd, buf, bufsize, 0)
 	return buf,res
 }

--- a/vlib/net/socket.v
+++ b/vlib/net/socket.v
@@ -258,7 +258,7 @@ pub fn (s Socket) send_string(sdata string) ?int {
 // receive string data from socket. NB: you are responsible for freeing the returned byteptr
 pub fn (s Socket) recv(bufsize int) (byteptr,int) {
 	mut buf := byteptr(0)
-  unsafe { buf = malloc(bufsize) }
+	unsafe { buf = malloc(bufsize) }
 	res := C.recv(s.sockfd, buf, bufsize, 0)
 	return buf,res
 }

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -756,7 +756,7 @@ fn valid_optional_port(port string) bool {
 // the form host/path does not add its own /.
 // - if u.raw_query is empty, ?query is omitted.
 // - if u.fragment is empty, #fragment is omitted.
-pub fn (u &URL) str() string {
+pub fn (u URL) str() string {
 	mut buf := strings.new_builder(200)
 	if u.scheme != '' {
 		buf.write(u.scheme)

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -326,6 +326,7 @@ pub mut:
 	raw_query   string // encoded query values, without '?'
 	fragment    string // fragment for references, without '#'
 }
+
 // user returns a Userinfo containing the provided username
 // and no password set.
 pub fn user(username string) &Userinfo {
@@ -650,7 +651,7 @@ fn parse_host(host string) ?string {
 // - set_path('/foo%2fbar') will set path='/foo/bar' and raw_path='/foo%2fbar'
 // set_path will return an error only if the provided path contains an invalid
 // escaping.
-fn (u mut URL) set_path(p string) ?bool {
+pub fn (u mut URL) set_path(p string) ?bool {
 	path := unescape(p, .encode_path) or {
 		return error(err)
 	}
@@ -765,7 +766,7 @@ pub fn (u &URL) str() string {
 		buf.write(u.opaque)
 	}
 	else {
-		if u.scheme != '' || u.host != '' || !u.user.empty() {
+		if u.scheme != '' || u.host != '' || (u.user != 0 && !u.user.empty()) {
 			if u.host != '' || u.path != '' || !u.user.empty() {
 				buf.write('//')
 			}


### PR DESCRIPTION
This PR follow redirects that contain just /path instead of full URLs.

For example 
https://www.theguardian.com/crosswords/series/quiptic/latest
... returns a 302 redirect header:
`location: /crosswords/quiptic/1056`
which previously did not work.