### PR TITLE
v2: remove redundant EOL normalization in cgen test

### DIFF
--- a/vlib/v/gen/cgen_test.v
+++ b/vlib/v/gen/cgen_test.v
@@ -22,10 +22,6 @@ fn test_c_files() {
 			panic(err)
 		}
 		ctext = ctext // unused warn
-		// normalise line endings on win
-		$if windows {
-			ctext = ctext.replace('\r', '')
-		}
 		mut b := builder.new_builder(pref.Preferences{})
 		res := b.gen_c([path])
 		if compare_texts(res, ctext) {


### PR DESCRIPTION
The EOL normalization can be removed safely:
1. Test C files are saved with LF EOLs.
2. `compare_texts` uses `string.split_into_lines` to split the file contents into lines, and it supports CRLF w/o any normalization (ref #3699).