### PR TITLE
Fix CI macOS-latest (failing postgresql brew install)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,9 @@ jobs:
         node-version: 12.x
     - name: Install dependencies
       run: |
-        brew install libpq
-        ##brew install openssl freetype ### these are already installed on Catalina ...
+        ##brew install libpq openssl freetype ### these are *already installed* on Catalina ...
+        brew remove libpq
+        breq install postgresql
         brew install glfw sdl2 sdl2_ttf sdl2_mixer sdl2_image
         export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/openssl/lib/"
     - name: Build V

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       run: |
         ##brew install libpq openssl freetype ### these are *already installed* on Catalina ...
         brew uninstall --ignore-dependencies libpq ## libpq is a dependency of PHP
-        breq install postgresql
+        brew install postgresql
         brew install glfw sdl2 sdl2_ttf sdl2_mixer sdl2_image
         export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/openssl/lib/"
     - name: Build V

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,9 @@ jobs:
         node-version: 12.x
     - name: Install dependencies
       run: |
-        brew install freetype glfw openssl postgres sdl2 sdl2_ttf sdl2_mixer sdl2_image
+        brew install postgresql
+        ##brew install openssl freetype ### these are already installed on Catalina ...
+        brew install glfw sdl2 sdl2_ttf sdl2_mixer sdl2_image
         export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/openssl/lib/"
     - name: Build V
       run:  make -j4 && ./v -cg -o v cmd/v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Install dependencies
       run: |
         ##brew install libpq openssl freetype ### these are *already installed* on Catalina ...
-        brew remove libpq
+        brew uninstall --ignore-dependencies libpq ## libpq is a dependency of PHP
         breq install postgresql
         brew install glfw sdl2 sdl2_ttf sdl2_mixer sdl2_image
         export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/openssl/lib/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         node-version: 12.x
     - name: Install dependencies
       run: |
-        brew install postgresql
+        brew install libpq
         ##brew install openssl freetype ### these are already installed on Catalina ...
         brew install glfw sdl2 sdl2_ttf sdl2_mixer sdl2_image
         export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/openssl/lib/"

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -38,7 +38,10 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install dependencies
       run: |
-        brew install freetype glfw openssl postgres sdl2 sdl2_ttf sdl2_mixer sdl2_image
+        ##brew install libpq openssl freetype ### these are *already installed* on Catalina ...
+        brew uninstall --ignore-dependencies libpq ## libpq is a dependency of PHP
+        brew install postgresql
+        brew install glfw sdl2 sdl2_ttf sdl2_mixer sdl2_image
         export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/openssl/lib/"
     - name: Build V
       run:  make -j4 && ./v -cg -o v cmd/v


### PR DESCRIPTION
This fixes failing CI by uninstalling libpq and installing full
postgresql package instead.