### PR TITLE
Fix cmd/tools/vfmt.v

### DIFF
--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -71,11 +71,13 @@ fn main() {
 	}
 	mut files := []string
 	for file in possible_files {
-		if !os.exists(file) {
-			compiler.verror('"$file" does not exist.')
-		}
 		if !file.ends_with('.v') {
 			compiler.verror('v fmt can only be used on .v files.\nOffending file: "$file" .')
+			continue
+		}
+		if !os.exists(file) {
+			compiler.verror('"$file" does not exist.')
+			continue
 		}
 		files << file
 	}

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -62,7 +62,7 @@ fn main() {
 		exit(0)
 	}
 	// we are NOT a worker at this stage, i.e. we are a parent vfmt process
-	possible_files := cmdline.only_non_options(cmdline.after(args, ['fmt']))
+	possible_files := cmdline.only_non_options(cmdline.after_options(args, ['fmt']))
 	if foptions.is_verbose {
 		eprintln('vfmt toolexe: $toolexe')
 		eprintln('vfmt args: ' + os.args.str())
@@ -170,7 +170,7 @@ fn (foptions &FormatOptions) format_file(file string) {
 	compiler_params.path = cfile
 	compiler_params.mod = mod_name
 	compiler_params.is_test = is_test_file
-	compiler_params.is_script = file.ends_with('.v') || file.ends_with('.vsh')  
+	compiler_params.is_script = file.ends_with('.v') || file.ends_with('.vsh')
 	if foptions.is_verbose {
 		eprintln('vfmt format_file: file: $file')
 		eprintln('vfmt format_file: cfile: $cfile')

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -62,7 +62,7 @@ fn main() {
 		exit(0)
 	}
 	// we are NOT a worker at this stage, i.e. we are a parent vfmt process
-	possible_files := cmdline.only_non_options(cmdline.after_options(args, ['fmt']))
+	possible_files := cmdline.only_non_options(cmdline.options_after(args, ['fmt']))
 	if foptions.is_verbose {
 		eprintln('vfmt toolexe: $toolexe')
 		eprintln('vfmt args: ' + os.args.str())

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -478,7 +478,7 @@ fn init_settings() {
 	}
 	s.is_help = '-h' in os.args || '--help' in os.args || 'help' in os.args
 	s.is_verbose = '-verbose' in os.args || '--verbose' in os.args
-	s.server_urls = cmdline.many_values(os.args, '-server-url')
+	s.server_urls = cmdline.options(os.args, '-server-url')
 	s.vmodules_path = os.home_dir() + '.vmodules'
 }
 

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -77,10 +77,10 @@ pub fn run_repl(workdir string, vrepl_prefix string) []string {
 	version := v_version()
 	println(version)
 	println('Use Ctrl-C or `exit` to exit')
-	
+
 	file := filepath.join( workdir, '.${vrepl_prefix}vrepl.v' )
-	temp_file := filepath.join( workdir, '.${vrepl_prefix}vrepl_temp.v')	
-	mut prompt := '>>> '	
+	temp_file := filepath.join( workdir, '.${vrepl_prefix}vrepl_temp.v')
+	mut prompt := '>>> '
 	defer {
 		os.rm(file)
 		os.rm(temp_file)
@@ -155,12 +155,12 @@ pub fn run_repl(workdir string, vrepl_prefix string) []string {
 			mut temp_flag := false
 			func_call := r.function_call(r.line)
 			if !(
-				r.line.contains(' ') || 
-				r.line.contains(':') || 
-				r.line.contains('=') || 
-				r.line.contains(',') || 
-				r.line.ends_with('++') || 
-				r.line.ends_with('--') || 
+				r.line.contains(' ') ||
+				r.line.contains(':') ||
+				r.line.contains('=') ||
+				r.line.contains(',') ||
+				r.line.ends_with('++') ||
+				r.line.ends_with('--') ||
 				r.line == '') && !func_call {
 				temp_line = 'println($r.line)'
 				temp_flag = true
@@ -219,7 +219,7 @@ fn main() {
 	// Support for the parameters replfolder and replprefix is needed
 	// so that the repl can be launched in parallel by several different
 	// threads by the REPL test runner.
-	args := cmdline.after(os.args, ['repl'])
+	args := cmdline.after_options(os.args, ['repl'])
 	replfolder := os.realpath( cmdline.option(args, '-replfolder', '.') )
 	replprefix := cmdline.option(args, '-replprefix', 'noprefix.')
 	os.chdir( replfolder )

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -219,7 +219,7 @@ fn main() {
 	// Support for the parameters replfolder and replprefix is needed
 	// so that the repl can be launched in parallel by several different
 	// threads by the REPL test runner.
-	args := cmdline.after_options(os.args, ['repl'])
+	args := cmdline.options_after(os.args, ['repl'])
 	replfolder := os.realpath( cmdline.option(args, '-replfolder', '.') )
 	replprefix := cmdline.option(args, '-replprefix', 'noprefix.')
 	os.chdir( replfolder )

--- a/cmd/tools/vtest.v
+++ b/cmd/tools/vtest.v
@@ -22,8 +22,8 @@ pub fn main() {
 	}
 
 	args_to_executable := args[1..]
-	args_before := cmdline.before_options(args_to_executable, ['test'])
-	args_after := cmdline.after_options(args_to_executable, ['test'])
+	args_before := cmdline.options_before(args_to_executable, ['test'])
+	args_after := cmdline.options_after(args_to_executable, ['test'])
 
 	if args_after.join(' ') == 'v' {
 		eprintln('`v test v` has been deprecated.')
@@ -53,4 +53,3 @@ pub fn main() {
 		exit(1)
 	}
 }
-

--- a/cmd/tools/vtest.v
+++ b/cmd/tools/vtest.v
@@ -22,8 +22,8 @@ pub fn main() {
 	}
 
 	args_to_executable := args[1..]
-	args_before := cmdline.before(args_to_executable, ['test'])
-	args_after := cmdline.after(args_to_executable, ['test'])
+	args_before := cmdline.before_options(args_to_executable, ['test'])
+	args_after := cmdline.after_options(args_to_executable, ['test'])
 
 	if args_after.join(' ') == 'v' {
 		eprintln('`v test v` has been deprecated.')

--- a/cmd/v/compile.v
+++ b/cmd/v/compile.v
@@ -46,7 +46,7 @@ pub fn run_compiled_executable_and_exit(v &compiler.V, args []string) {
 		println('============ running $v.pref.out_name ============')
 	}
 	mut cmd := '"${v.pref.out_name}"'
-	args_after_no_options := cmdline.only_non_options( cmdline.after(args,['run','test']) )
+	args_after_no_options := cmdline.only_non_options( cmdline.after_options(args,['run','test']) )
 	if args_after_no_options.len > 1 {
 		cmd += ' ' + args_after_no_options[1..].join(' ')
 	}

--- a/cmd/v/compile.v
+++ b/cmd/v/compile.v
@@ -46,7 +46,7 @@ pub fn run_compiled_executable_and_exit(v &compiler.V, args []string) {
 		println('============ running $v.pref.out_name ============')
 	}
 	mut cmd := '"${v.pref.out_name}"'
-	args_after_no_options := cmdline.only_non_options( cmdline.after_options(args,['run','test']) )
+	args_after_no_options := cmdline.only_non_options( cmdline.options_after(args,['run','test']) )
 	if args_after_no_options.len > 1 {
 		cmd += ' ' + args_after_no_options[1..].join(' ')
 	}

--- a/cmd/v/compile_options.v
+++ b/cmd/v/compile_options.v
@@ -39,7 +39,7 @@ pub fn new_v(args []string) &compiler.V {
 	mut out_name := cmdline.option(args, '-o', '')
 	mut dir := args.last()
 	if 'run' in args {
-		args_after_run := cmdline.only_non_options( cmdline.after(args,['run']) )
+		args_after_run := cmdline.only_non_options( cmdline.after_options(args,['run']) )
 		dir = if args_after_run.len>0 { args_after_run[0] } else { '' }
 	}
 	if dir == 'v.v' {
@@ -95,9 +95,8 @@ pub fn new_v(args []string) &compiler.V {
 	}
 
 	// println('VROOT=$vroot')
-	cflags := cmdline.many_values(args, '-cflags').join(' ')
-
-	defines := cmdline.many_values(args, '-d')
+	cflags := cmdline.options(args, '-cflags').join(' ')
+	defines := cmdline.options(args, '-d')
 	compile_defines, compile_defines_all := parse_defines( defines )
 
 	rdir := os.realpath(dir)
@@ -194,7 +193,7 @@ pub fn new_v(args []string) &compiler.V {
 }
 
 fn find_c_compiler_thirdparty_options(args []string) string {
-	mut cflags := cmdline.many_values(args,'-cflags')
+	mut cflags := cmdline.options(args, '-cflags')
 	$if !windows {
 		cflags << '-fPIC'
 	}

--- a/cmd/v/compile_options.v
+++ b/cmd/v/compile_options.v
@@ -39,7 +39,7 @@ pub fn new_v(args []string) &compiler.V {
 	mut out_name := cmdline.option(args, '-o', '')
 	mut dir := args.last()
 	if 'run' in args {
-		args_after_run := cmdline.only_non_options( cmdline.after_options(args,['run']) )
+		args_after_run := cmdline.only_non_options( cmdline.options_after(args,['run']) )
 		dir = if args_after_run.len>0 { args_after_run[0] } else { '' }
 	}
 	if dir == 'v.v' {
@@ -225,4 +225,3 @@ fn parse_defines(defines []string) ([]string,[]string) {
 	}
 	return compile_defines, compile_defines_all
 }
-

--- a/vlib/os/cmdline/cmdline.v
+++ b/vlib/os/cmdline/cmdline.v
@@ -38,7 +38,7 @@ pub fn option(args []string, param string, def string) string {
 // args: ['-stat', 'test', 'aaa.v']
 // what: ['test']
 // ret: ['-stat']
-pub fn before_options(args []string, what []string) []string {
+pub fn options_before(args []string, what []string) []string {
 	mut found := false
 	mut args_before := []string
 	for a in args {
@@ -55,7 +55,7 @@ pub fn before_options(args []string, what []string) []string {
 // args: ['-stat', 'test', 'aaa.v']
 // what: ['test']
 // ret: ['aaa.v']
-pub fn after_options(args []string, what []string) []string {
+pub fn options_after(args []string, what []string) []string {
 	mut found := false
 	mut args_after := []string
 	for a in args {

--- a/vlib/os/cmdline/cmdline.v
+++ b/vlib/os/cmdline/cmdline.v
@@ -1,17 +1,26 @@
 module cmdline
 
-pub fn many_values(args []string, optname string) []string {
+// Fetch multiple option by param, e.g.
+// args: ['v', '-d', 'aa', '-d', 'bb', '-d', 'cc']
+// param: '-d'
+// ret: ['aa', 'bb', 'cc']
+pub fn options(args []string, param string) []string {
 	mut flags := []string
-	for ci, cv in args {
-		if cv == optname {
-			if ci + 1 < args.len {
-				flags << args[ci + 1]
+	for i, v in args {
+		if v == param {
+			if i + 1 < args.len {
+				flags << args[i + 1]
 			}
 		}
 	}
 	return flags
 }
 
+// Fetch option by param, e.g.
+// args: ['v', '-d', 'aa']
+// param: '-d'
+// def: ''
+// ret: 'aa'
 pub fn option(args []string, param string, def string) string {
 	mut found := false
 	for arg in args {
@@ -25,7 +34,11 @@ pub fn option(args []string, param string, def string) string {
 	return def
 }
 
-pub fn before(args []string, what []string) []string {
+// Fetch all options before what params, e.g.
+// args: ['-stat', 'test', 'aaa.v']
+// what: ['test']
+// ret: ['-stat']
+pub fn before_options(args []string, what []string) []string {
 	mut found := false
 	mut args_before := []string
 	for a in args {
@@ -38,7 +51,11 @@ pub fn before(args []string, what []string) []string {
 	return args_before
 }
 
-pub fn after(args []string, what []string) []string {
+// Fetch all options after what params, e.g.
+// args: ['-stat', 'test', 'aaa.v']
+// what: ['test']
+// ret: ['aaa.v']
+pub fn after_options(args []string, what []string) []string {
 	mut found := false
 	mut args_after := []string
 	for a in args {
@@ -53,10 +70,16 @@ pub fn after(args []string, what []string) []string {
 	return args_after
 }
 
+// Fetch all options not start with '-', e.g.
+// args: ['-d', 'aa', '--help', 'bb']
+// ret: ['aa', 'bb']
 pub fn only_non_options(args []string) []string {
 	return args.filter(!it.starts_with('-'))
 }
 
+// Fetch all options start with '-', e.g.
+// args: ['-d', 'aa', '--help', 'bb']
+// ret: ['-d', '--help']
 pub fn only_options(args []string) []string {
 	return args.filter(it.starts_with('-'))
 }

--- a/vlib/os/cmdline/cmdline_test.v
+++ b/vlib/os/cmdline/cmdline_test.v
@@ -1,0 +1,37 @@
+import os.cmdline
+
+fn test_options() {
+	args := ['v', '-d', 'aa', '-d', 'bb', '-d', 'cc']
+	ret := cmdline.options(args, '-d')
+	assert ret.eq(['aa', 'bb', 'cc'])
+}
+
+fn test_option() {
+	args := ['v', '-d', 'aa']
+	ret := cmdline.option(args, '-d', '')
+	assert ret == 'aa'
+}
+
+fn test_before_options() {
+	args := ['-stat', 'test', 'aaa.v']
+	ret := cmdline.before_options(args, ['test'])
+	assert ret.eq(['-stat'])
+}
+
+fn test_after_options() {
+	args := ['-stat', 'test', 'aaa.v']
+	ret := cmdline.after_options(args, ['test'])
+	assert ret.eq(['aaa.v'])
+}
+
+fn test_only_non_options() {
+	args := ['-d', 'aa', '--help', 'bb']
+	ret := cmdline.only_non_options(args)
+	assert ret.eq(['aa', 'bb'])
+}
+
+fn test_only_options() {
+	args := ['-d', 'aa', '--help', 'bb']
+	ret := cmdline.only_options(args)
+	assert ret.eq(['-d', '--help'])
+}

--- a/vlib/os/cmdline/cmdline_test.v
+++ b/vlib/os/cmdline/cmdline_test.v
@@ -12,15 +12,15 @@ fn test_option() {
 	assert ret == 'aa'
 }
 
-fn test_before_options() {
+fn test_options_before() {
 	args := ['-stat', 'test', 'aaa.v']
-	ret := cmdline.before_options(args, ['test'])
+	ret := cmdline.options_before(args, ['test'])
 	assert ret.eq(['-stat'])
 }
 
-fn test_after_options() {
+fn test_options_after() {
 	args := ['-stat', 'test', 'aaa.v']
-	ret := cmdline.after_options(args, ['test'])
+	ret := cmdline.options_after(args, ['test'])
 	assert ret.eq(['aaa.v'])
 }
 


### PR DESCRIPTION
This PR is to Fix cmd/tools/vfmt.v
```
	for file in possible_files {
		if !file.ends_with('.v') {
			compiler.verror('v fmt can only be used on .v files.\nOffending file: "$file" .')
			continue
		}
		if !os.exists(file) {
			compiler.verror('"$file" does not exist.')
			continue
		}
		files << file
	}
```
Add `continue` and the file type judgment is handled first.
