### PR TITLE
Float "exponent without sign" support added

### DIFF
--- a/vlib/compiler/scanner.v
+++ b/vlib/compiler/scanner.v
@@ -228,8 +228,6 @@ fn (s mut Scanner) ident_dec_number() string {
 		}
 		has_exponential_part = true
 	}
-
-
 	// error check: 1.23.4, 123.e+3.4
 	if s.pos < s.text.len && s.text[s.pos] == `.` {
 		if has_exponential_part {

--- a/vlib/compiler/scanner.v
+++ b/vlib/compiler/scanner.v
@@ -213,8 +213,13 @@ fn (s mut Scanner) ident_dec_number() string {
 	}
 	// scan exponential part
 	mut has_exponential_part := false
-	if s.expect('e+', s.pos) || s.expect('e-', s.pos) {
-		exp_start_pos := s.pos += 2
+	if s.expect('e', s.pos) || s.expect('E', s.pos) {
+		exp_start_pos := (s.pos++)
+
+		if s.text[s.pos] in [`-`, `+`] {
+			s.pos++
+		}
+
 		for s.pos < s.text.len && s.text[s.pos].is_digit() {
 			s.pos++
 		}
@@ -223,6 +228,8 @@ fn (s mut Scanner) ident_dec_number() string {
 		}
 		has_exponential_part = true
 	}
+
+
 	// error check: 1.23.4, 123.e+3.4
 	if s.pos < s.text.len && s.text[s.pos] == `.` {
 		if has_exponential_part {

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -223,7 +223,6 @@ fn (s mut Scanner) ident_dec_number() string {
 		}
 		has_exponential_part = true
 	}
-
 	// error check: 1.23.4, 123.e+3.4
 	if s.pos < s.text.len && s.text[s.pos] == `.` {
 		if has_exponential_part {

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -208,8 +208,13 @@ fn (s mut Scanner) ident_dec_number() string {
 	}
 	// scan exponential part
 	mut has_exponential_part := false
-	if s.expect('e+', s.pos) || s.expect('e-', s.pos) {
-		exp_start_pos := s.pos += 2
+	if s.expect('e', s.pos) || s.expect('E', s.pos) {
+		exp_start_pos := (s.pos++)
+
+		if s.text[s.pos] in [`-`, `+`] {
+			s.pos++
+		}
+
 		for s.pos < s.text.len && s.text[s.pos].is_digit() {
 			s.pos++
 		}
@@ -218,6 +223,7 @@ fn (s mut Scanner) ident_dec_number() string {
 		}
 		has_exponential_part = true
 	}
+
 	// error check: 1.23.4, 123.e+3.4
 	if s.pos < s.text.len && s.text[s.pos] == `.` {
 		if has_exponential_part {

--- a/vlib/v/scanner/scanner_test.v
+++ b/vlib/v/scanner/scanner_test.v
@@ -33,9 +33,15 @@ fn test_scan() {
 	assert c == 9
 	c = 1_000_000
 	assert c == 1000000
+	// test float conversion and reading
 	d := f64(23_000_000e-3)
 	assert int(d) == 23000 
-	e := f64(1.2E3) * f64(-1e-1)
+	mut e := f64(1.2E3) * f64(-1e-1)
 	assert e == -120.0
+	e = f64(1.2E3) * f64(1e-1)
+	assert e == 120.0
+	assert 1.23e+10 == 1.23e10
+	assert 1.23e+10 == 1.23e0010
+	assert -1.23e+10 == 1.23e0010*-1.0
 }
 

--- a/vlib/v/scanner/scanner_test.v
+++ b/vlib/v/scanner/scanner_test.v
@@ -35,5 +35,7 @@ fn test_scan() {
 	assert c == 1000000
 	d := f64(23_000_000e-3)
 	assert int(d) == 23000 
+	e := f64(1.2E3) * f64(-1e-1)
+	assert e == -120.0
 }
 

--- a/vlib/v/scanner/scanner_test.v
+++ b/vlib/v/scanner/scanner_test.v
@@ -33,6 +33,7 @@ fn test_scan() {
 	assert c == 9
 	c = 1_000_000
 	assert c == 1000000
+	
 	// test float conversion and reading
 	d := f64(23_000_000e-3)
 	assert int(d) == 23000 


### PR DESCRIPTION
**What's inside**
- This PR add support for float without mandatory sign in the exponential part.
with this PR `10e2` or `10E2` are now accepted by the compiler.
Previously the sign after the e was mandatory.
Writing long code with a lot of float numbers with this limitation was a nuisance.

- Added further tests on float parsing.