### PR TITLE
array: add `array.trim()`

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -152,6 +152,14 @@ pub fn (a mut array) clear() {
 	a.len = 0
 }
 
+// trims the array length to "index" without modifying the allocated data. If "index" is greater
+// than len nothing will be changed
+pub fn (a mut array) trim(index int) {
+	if index < a.len {
+		a.len = index
+	}
+}
+
 // Private function. Used to implement array[] operator
 fn (a array) get(i int) voidptr {
 	$if !no_bounds_checking? {

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -595,13 +595,17 @@ fn test_clear() {
 
 fn test_trim() {
 	mut arr := [1,2,3,4,5,6,7,8,9]
-	assert arr.len == 10
+	assert arr.len == 9
 	
 	arr.trim(9)
 	assert arr.len == 9
-	assert arr.last() == 8
+	assert arr.last() == 9
 	
-	arr.trim(9)
-	assert arr.len == 10
-	assert arr.last() == 8
+	arr.trim(7)
+	assert arr.len == 7
+	assert arr.last() == 7
+	
+	arr.trim(2)
+	assert arr.len == 2
+	assert arr.last() == 2
 }

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -592,3 +592,16 @@ fn test_clear() {
 	arr.clear()
 	assert arr.len == 0
 }
+
+fn test_trim() {
+	mut arr := [1,2,3,4,5,6,7,8,9]
+	assert arr.len == 10
+	
+	arr.trim(9)
+	assert arr.len == 9
+	assert arr.last() == 8
+	
+	arr.trim(9)
+	assert arr.len == 10
+	assert arr.last() == 8
+}


### PR DESCRIPTION
Adds `array.trim()` method that lets you trim an array's `len` to a specific value without affecting the array buffer or cap.