### PR TITLE
Optimized processing path separator

### DIFF
--- a/cmd/tools/modules/vgit/vgit.v
+++ b/cmd/tools/modules/vgit/vgit.v
@@ -42,7 +42,7 @@ pub fn line_to_timestamp_and_commit(line string) (int,string) {
 
 pub fn normalized_workpath_for_commit(workdir string, commit string) string {
 	nc := 'v_at_' + commit.replace('^', '_').replace('-', '_').replace('/', '_')
-	return os.realpath(workdir + os.path_separator + nc)
+	return os.realpath(workdir + filepath.separator + nc)
 }
 
 pub fn prepare_vc_source(vcdir string, cdir string, commit string) (string,string) {
@@ -73,7 +73,7 @@ pub fn clone_or_pull( remote_git_url string, local_worktree_path string ) {
 		// Clone a fresh
 		scripting.run('git clone --quiet "$remote_git_url"  "$local_worktree_path" ')
 	}
-}	
+}
 
 //
 
@@ -111,7 +111,7 @@ pub fn (vgit_context mut VGitContext) compile_oldv_if_needed() {
 	scripting.chdir(vgit_context.workdir)
 	clone_or_pull( vgit_context.v_repo_url,  vgit_context.path_v )
 	clone_or_pull( vgit_context.vc_repo_url, vgit_context.path_vc )
-	
+
 	scripting.chdir(vgit_context.path_v)
 	scripting.run('git checkout $vgit_context.commit_v')
 	v_commithash,vccommit_before := vgit.prepare_vc_source(vgit_context.path_vc, vgit_context.path_v, vgit_context.commit_v)
@@ -131,7 +131,7 @@ pub fn (vgit_context mut VGitContext) compile_oldv_if_needed() {
 	scripting.run(command_for_building_v_from_c_source)
 	build_cmd := command_for_selfbuilding.replace('{SOURCE}', vgit_context.vvlocation)
 	scripting.run(build_cmd)
-	
+
 	// At this point, there exists a file vgit_context.vexepath
 	// which should be a valid working V executable.
 }
@@ -141,8 +141,8 @@ pub fn add_common_tool_options<T>(context mut T, fp mut flag.FlagParser) []strin
 	context.workdir = os.realpath(fp.string_('workdir', `w`, tdir, 'A writable base folder. Default: $tdir'))
 	context.v_repo_url = fp.string('vrepo', vgit.remote_v_repo_url, 'The url of the V repository. You can clone it locally too. See also --vcrepo below.')
 	context.vc_repo_url = fp.string('vcrepo', vgit.remote_vc_repo_url, 'The url of the vc repository. You can clone it
-${flag.SPACE}beforehand, and then just give the local folder 
-${flag.SPACE}path here. That will eliminate the network ops 
+${flag.SPACE}beforehand, and then just give the local folder
+${flag.SPACE}path here. That will eliminate the network ops
 ${flag.SPACE}done by this tool, which is useful, if you want
 ${flag.SPACE}to script it/run it in a restrictive vps/docker.
 ')
@@ -157,11 +157,11 @@ ${flag.SPACE}to script it/run it in a restrictive vps/docker.
 	if context.verbose {
 		scripting.set_verbose(true)
 	}
-	
+
 	if os.is_dir(context.v_repo_url) {
 		context.v_repo_url = os.realpath( context.v_repo_url )
 	}
-	
+
 	if os.is_dir(context.vc_repo_url) {
 		context.vc_repo_url = os.realpath( context.vc_repo_url )
 	}
@@ -173,6 +173,6 @@ ${flag.SPACE}to script it/run it in a restrictive vps/docker.
 	for commit in commits {
 		vgit.validate_commit_exists(commit)
 	}
-	
+
 	return commits
 }

--- a/cmd/tools/performance_compare.v
+++ b/cmd/tools/performance_compare.v
@@ -43,7 +43,7 @@ fn new_context() Context {
 fn (c Context) compare_versions() {
 	// Input is validated at this point...
 	// Cleanup artifacts from previous runs of this tool:
-	scripting.chdir(c.workdir)	
+	scripting.chdir(c.workdir)
 	scripting.run('rm -rf "$c.a" "$c.b" "$c.vc" ')
 	// clone the VC source *just once per comparison*, and reuse it:
 	scripting.run('git clone --quiet "$c.vc_repo_url" "$c.vc" ')
@@ -55,7 +55,7 @@ fn (c Context) compare_versions() {
 	if c.vflags.len > 0 {
 		os.setenv('VFLAGS', c.vflags, true)
 	}
-	
+
 	// The first is the baseline, against which all the others will be compared.
 	// It is the fastest, since hello_world.v has only a single println in it,
 	mut perf_files := []string
@@ -65,7 +65,7 @@ fn (c Context) compare_versions() {
 		'v     @DEBUG@ -o source.c examples/hello_world.v',
 		'v             -o source.c examples/hello_world.v',
 	])
-			
+
 	perf_files << c.compare_v_performance('source_v', [
 		'vprod @DEBUG@ -o source.c @COMPILER@',
 		'vprod         -o source.c @COMPILER@',
@@ -77,7 +77,7 @@ fn (c Context) compare_versions() {
 		'vprod         -o hello    examples/hello_world.v',
 		'v             -o hello    examples/hello_world.v',
 	])
-	
+
 	perf_files << c.compare_v_performance('binary_v', [
 		'vprod         -o binary   @COMPILER@',
 		'v             -o binary   @COMPILER@',
@@ -124,7 +124,7 @@ fn (c &Context) prepare_v(cdir string, commit string) {
 	scripting.show_sizes_of_files(['$cdir/v', '$cdir/v_stripped', '$cdir/v_stripped_upxed'])
 	scripting.show_sizes_of_files(['$cdir/vprod', '$cdir/vprod_stripped', '$cdir/vprod_stripped_upxed'])
 	vversion := scripting.run('$cdir/v --version')
-    vcommit := scripting.run('git rev-parse --short  --verify HEAD') 
+    vcommit := scripting.run('git rev-parse --short  --verify HEAD')
 	println('V version is: ${vversion} , local source commit: ${vcommit}')
 	if vgit_context.vvlocation == 'cmd/v' {
 		println('Source lines of the compiler: ' + scripting.run('wc cmd/v/*.v vlib/compiler/*.v | tail -n -1'))
@@ -165,7 +165,7 @@ fn (c Context) compare_v_performance(label string, commands []string) string {
 		hyperfine_commands_arguments << " \'cd ${c.a:-34s} ; ./$cmd \' ".replace_each(['@COMPILER@', source_location_a, '@DEBUG@', debug_option_a])
 	}
 	// /////////////////////////////////////////////////////////////////////////////
-	cmd_stats_file := os.realpath([c.workdir, 'v_performance_stats_${label}.json'].join(os.path_separator))
+	cmd_stats_file := os.realpath([c.workdir, 'v_performance_stats_${label}.json'].join(filepath.separator))
 	comparison_cmd := 'hyperfine $c.hyperfineopts ' + '--export-json ${cmd_stats_file} ' + '--time-unit millisecond ' + '--style full --warmup $c.warmups ' + hyperfine_commands_arguments.join(' ')
 	// /////////////////////////////////////////////////////////////////////////////
 	if c.verbose {
@@ -207,6 +207,6 @@ ${flag.SPACE}--hyperfine_options "--prepare \'sync; echo 3 | sudo tee /proc/sys/
 		eprintln(msg)
 		exit(2)
 	}
-	
+
 	context.compare_versions()
 }

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -177,7 +177,7 @@ fn vpm_install(module_names []string) {
 			println('Skipping module "$name", since it uses an unsupported VCS {$vcs} .')
 			continue
 		}
-		final_module_path := os.realpath(filepath.join(settings.vmodules_path,mod.name.replace('.', os.path_separator)))
+		final_module_path := os.realpath(filepath.join(settings.vmodules_path,mod.name.replace('.', filepath.separator)))
 		if os.exists(final_module_path) {
 			vpm_update([name])
 			continue
@@ -287,7 +287,7 @@ fn vpm_remove(module_names []string) {
 }
 
 fn valid_final_path_of_existing_module(name string) ?string {
-	name_of_vmodules_folder := filepath.join(settings.vmodules_path,name.replace('.', os.path_separator))
+	name_of_vmodules_folder := filepath.join(settings.vmodules_path,name.replace('.', filepath.separator))
 	final_module_path := os.realpath(name_of_vmodules_folder)
 	if !os.exists(final_module_path) {
 		println('No module with name "$name" exists at $name_of_vmodules_folder')

--- a/cmd/tools/vtest.v
+++ b/cmd/tools/vtest.v
@@ -3,6 +3,7 @@ module main
 import (
 	os
 	os.cmdline
+	filepath
 	testing
 )
 
@@ -39,7 +40,7 @@ pub fn main() {
 		}
 		if os.is_dir(targ) {
 			// Fetch all tests from the directory
-			ts.files << os.walk_ext( targ.trim_right(os.path_separator), '_test.v')
+			ts.files << os.walk_ext( targ.trim_right(filepath.separator), '_test.v')
 			continue
 		}
 		println('Unrecognized test file $targ .')

--- a/cmd/v/compile_options.v
+++ b/cmd/v/compile_options.v
@@ -20,7 +20,7 @@ pub fn new_v(args []string) &compiler.V {
 		os.mkdir(compiler.v_modules_path)or{
 			panic(err)
 		}
-		os.mkdir('$compiler.v_modules_path${os.path_separator}cache')or{
+		os.mkdir('$compiler.v_modules_path${filepath.separator}cache')or{
 			panic(err)
 		}
 	}
@@ -47,10 +47,10 @@ pub fn new_v(args []string) &compiler.V {
 		println('use `v -o v cmd/v` instead of `v -o v v.v`')
 		exit(1)
 	}
-	if dir.ends_with(os.path_separator) {
-		dir = dir.all_before_last(os.path_separator)
+	if dir.ends_with(filepath.separator) {
+		dir = dir.all_before_last(filepath.separator)
 	}
-	if dir.starts_with('.$os.path_separator') {
+	if dir.starts_with('.$filepath.separator') {
 		dir = dir[2..]
 	}
 	if args.len < 2 {
@@ -65,8 +65,8 @@ pub fn new_v(args []string) &compiler.V {
 		build_mode = .build_module
 		os.chdir(vroot)
 		// v build module ~/v/os => os.o
-		mod_path := if dir.contains('vlib') { dir.all_after('vlib' + os.path_separator) } else if dir.starts_with('.\\') || dir.starts_with('./') { dir[2..] } else if dir.starts_with(os.path_separator) { dir.all_after(os.path_separator) } else { dir }
-		mod = mod_path.replace(os.path_separator, '.')
+		mod_path := if dir.contains('vlib') { dir.all_after('vlib' + filepath.separator) } else if dir.starts_with('.\\') || dir.starts_with('./') { dir[2..] } else if dir.starts_with(filepath.separator) { dir.all_after(filepath.separator) } else { dir }
+		mod = mod_path.replace(filepath.separator, '.')
 		println('Building module "${mod}" (dir="$dir")...')
 		// out_name = '$TmpPath/vlib/${base}.o'
 		if !out_name.ends_with('.c') {
@@ -84,8 +84,8 @@ pub fn new_v(args []string) &compiler.V {
 
 	}
 	// `v -o dir/exec`, create "dir/" if it doesn't exist
-	if out_name.contains(os.path_separator) {
-		d := out_name.all_before_last(os.path_separator)
+	if out_name.contains(filepath.separator) {
+		d := out_name.all_before_last(filepath.separator)
 		if !os.is_dir(d) {
 			println('creating a new directory "$d"')
 			os.mkdir(d)or{
@@ -168,7 +168,7 @@ pub fn new_v(args []string) &compiler.V {
 	pref.fill_with_defaults()
 
 	// v.exe's parent directory should contain vlib
-	if !os.is_dir(pref.vlib_path) || !os.is_dir(pref.vlib_path + os.path_separator + 'builtin') {
+	if !os.is_dir(pref.vlib_path) || !os.is_dir(pref.vlib_path + filepath.separator + 'builtin') {
 		// println('vlib not found, downloading it...')
 		/*
 		ret := os.system('git clone --depth=1 https://github.com/vlang/v .')

--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -182,7 +182,7 @@ fn (v mut V) new_parser_from_file(path string) Parser {
 		p |
 		file_path:path,
 		file_path_dir:filepath.dir( path ),
-		file_name:path.all_after(os.path_separator),
+		file_name:path.all_after(filepath.separator),
 		file_platform:path_platform,
 		file_pcguard:path_pcguard,
 		is_vh:path.ends_with('.vh'),

--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -47,7 +47,7 @@ fn (v mut V) cc() {
 			eprintln(format_result.output)
 		}
 	}
-	
+
 	if ends_with_c || ends_with_js {
 		// Translating V code to JS by launching vjs.
 		// Using a separate process for V.js is for performance mostly,
@@ -152,8 +152,8 @@ fn (v mut V) cc() {
 	}
 	if v.pref.build_mode == .build_module {
 		// Create the modules & out directory if it's not there.
-		mut out_dir := if v.pref.path.starts_with('vlib') { '$v_modules_path${os.path_separator}cache${os.path_separator}$v.pref.path' } else { '$v_modules_path${os.path_separator}$v.pref.path' }
-		pdir := out_dir.all_before_last(os.path_separator)
+		mut out_dir := if v.pref.path.starts_with('vlib') { '$v_modules_path${filepath.separator}cache${filepath.separator}$v.pref.path' } else { '$v_modules_path${filepath.separator}$v.pref.path' }
+		pdir := out_dir.all_before_last(filepath.separator)
 		if !os.is_dir(pdir) {
 			os.mkdir_all(pdir)
 		}
@@ -223,7 +223,7 @@ fn (v mut V) cc() {
 		}
 		else {
 			println('$builtin_o_path not found... building module builtin')
-			os.system('$vexe build module vlib${os.path_separator}builtin')
+			os.system('$vexe build module vlib${filepath.separator}builtin')
 		}
 		for imp in v.table.imports {
 			if imp.contains('vweb') {
@@ -232,8 +232,8 @@ fn (v mut V) cc() {
 			if imp == 'webview' {
 				continue
 			}
-			imp_path := imp.replace('.', os.path_separator)
-			path := '$v_modules_path${os.path_separator}cache${os.path_separator}vlib${os.path_separator}${imp_path}.o'
+			imp_path := imp.replace('.', filepath.separator)
+			path := '$v_modules_path${filepath.separator}cache${filepath.separator}vlib${filepath.separator}${imp_path}.o'
 			// println('adding ${imp_path}.o')
 			if os.exists(path) {
 				libs += ' ' + path
@@ -250,7 +250,7 @@ fn (v mut V) cc() {
 					}
 				}
 				else {
-					os.system('$vexe build module vlib${os.path_separator}$imp_path')
+					os.system('$vexe build module vlib${filepath.separator}$imp_path')
 				}
 			}
 			if path.ends_with('vlib/ui.o') {
@@ -554,4 +554,3 @@ fn missing_compiler_info() string {
 	}
 	return ''
 }
-

--- a/vlib/compiler/cgen.v
+++ b/vlib/compiler/cgen.v
@@ -285,7 +285,7 @@ fn (v &V) build_thirdparty_obj_file(path string, moduleflags []CFlag) {
 	mut cfiles := ''
 	for file in files {
 		if file.ends_with('.c') {
-			cfiles += '"' + os.realpath(parent + os.path_separator + file) + '" '
+			cfiles += '"' + os.realpath(parent + filepath.separator + file) + '" '
 		}
 	}
 	btarget := moduleflags.c_options_before_target()
@@ -503,4 +503,3 @@ fn (v &V) interface_table() string {
 	}
 	return sb.str()
 }
-

--- a/vlib/compiler/compile_errors.v
+++ b/vlib/compiler/compile_errors.v
@@ -2,6 +2,7 @@ module compiler
 
 import (
 	os
+	filepath
 	term
 )
 // ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -156,7 +157,7 @@ fn (s &Scanner) get_error_filepath() string {
 		else {
 			s.print_rel_paths_on_error}}
 	if use_relative_paths {
-		workdir := os.getwd() + os.path_separator
+		workdir := os.getwd() + filepath.separator
 		if s.file_path.starts_with(workdir) {
 			return s.file_path.replace(workdir, '')
 		}
@@ -315,4 +316,3 @@ const (
 	and_or_error = 'use `()` to make the boolean expression clear\n' + 'for example: `(a && b) || c` instead of `a && b || c`'
 	err_modify_bitfield = 'to modify a bitfield flag use the methods: set, clear, toggle. and to check for flag use: has'
 )
-

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -680,8 +680,8 @@ pub fn (v mut V) add_v_files_to_compile() {
 		}
 		// use cached built module if exists
 		if v.pref.vpath != '' && v.pref.build_mode != .build_module && !mod.contains('vweb') {
-			mod_path := mod.replace('.', os.path_separator)
-			vh_path := '$v_modules_path${os.path_separator}vlib${os.path_separator}${mod_path}.vh'
+			mod_path := mod.replace('.', filepath.separator)
+			vh_path := '$v_modules_path${filepath.separator}vlib${filepath.separator}${mod_path}.vh'
 			if v.pref.is_cache && os.exists(vh_path) {
 				eprintln('using cached module `$mod`: $vh_path')
 				v.cached_mods << mod
@@ -923,5 +923,5 @@ pub fn set_vroot_folder(vroot_path string) {
 	// VEXE env variable is needed so that compiler.vexe_path()
 	// can return it later to whoever needs it:
 	vname := if os.user_os() == 'windows' { 'v.exe' } else { 'v' }
-	os.setenv('VEXE', os.realpath([vroot_path, vname].join(os.path_separator)), true)
+	os.setenv('VEXE', os.realpath([vroot_path, vname].join(filepath.separator)), true)
 }

--- a/vlib/compiler/module_header.v
+++ b/vlib/compiler/module_header.v
@@ -30,9 +30,9 @@ fn generate_vh(mod string) {
 	println('\n\n\n\nGenerating a V header file for module `$mod`')
 	vexe := vexe_path()
 	full_mod_path := filepath.join(filepath.dir(vexe),mod)
-	dir := if mod.starts_with('vlib') { '$compiler.v_modules_path${os.path_separator}$mod' } else { mod }
+	dir := if mod.starts_with('vlib') { '$compiler.v_modules_path${filepath.separator}$mod' } else { mod }
 	path := dir + '.vh'
-	pdir := dir.all_before_last(os.path_separator)
+	pdir := dir.all_before_last(filepath.separator)
 	if !os.is_dir(pdir) {
 		os.mkdir_all(pdir)
 		// os.mkdir(os.realpath(dir)) or { panic(err) }
@@ -50,7 +50,7 @@ fn generate_vh(mod string) {
 	// mut vfiles := os.ls(full_mod_path) or {
 	// exit(1)
 	// }
-	filtered := vfiles.filter(it.ends_with('.v') && !it.ends_with('test.v') && !it.ends_with('_windows.v') && !it.ends_with('_win.v') && !it.ends_with('_lin.v') && !it.contains('${os.path_separator}examples') && !it.contains('_js.v') && !it.contains('_bare.v') && !it.contains('${os.path_separator}js')) // TODO merge once filter allows it
+	filtered := vfiles.filter(it.ends_with('.v') && !it.ends_with('test.v') && !it.ends_with('_windows.v') && !it.ends_with('_win.v') && !it.ends_with('_lin.v') && !it.contains('${filepath.separator}examples') && !it.contains('_js.v') && !it.contains('_bare.v') && !it.contains('${filepath.separator}js')) // TODO merge once filter allows it
 	// println('f:')
 	// println(filtered)
 	mut pref := &pref.Preferences {

--- a/vlib/compiler/modules.v
+++ b/vlib/compiler/modules.v
@@ -25,7 +25,7 @@ fn (table &Table) qualify_module(mod string, file_path string) string {
 	for m in table.imports {
 		if m.contains('.') && m.contains(mod) {
 			m_parts := m.split('.')
-			m_path := m_parts.join(os.path_separator)
+			m_path := m_parts.join(filepath.separator)
 			if mod == m_parts[m_parts.len - 1] && file_path.contains(m_path) {
 				return m
 			}
@@ -147,7 +147,7 @@ pub fn (graph &DepGraph) imports() []string {
 [inline]
 fn (v &V) module_path(mod string) string {
 	// submodule support
-	return mod.replace('.', os.path_separator)
+	return mod.replace('.', filepath.separator)
 }
 
 // 'strings' => 'VROOT/vlib/strings'
@@ -208,4 +208,3 @@ fn mod_gen_name(mod string) string {
 fn mod_gen_name_rev(mod string) string {
 	return mod.replace('_dot_', '.')
 }
-

--- a/vlib/compiler/msvc.v
+++ b/vlib/compiler/msvc.v
@@ -163,7 +163,7 @@ fn find_msvc() ?MsvcResult {
 			return error('Unable to find visual studio')
 		}
 		return MsvcResult{
-			full_cl_exe_path: os.realpath(vs.exe_path + os.path_separator + 'cl.exe')
+			full_cl_exe_path: os.realpath(vs.exe_path + filepath.separator + 'cl.exe')
 			exe_path: vs.exe_path
 			um_lib_path: wk.um_lib_path
 			ucrt_lib_path: wk.ucrt_lib_path
@@ -321,7 +321,7 @@ fn build_thirdparty_obj_file_with_msvc(path string, moduleflags []CFlag) {
 	mut cfiles := ''
 	for file in files {
 		if file.ends_with('.c') {
-			cfiles += '"' + os.realpath(parent + os.path_separator + file) + '" '
+			cfiles += '"' + os.realpath(parent + filepath.separator + file) + '" '
 		}
 	}
 	include_string := '-I "$msvc.ucrt_include_path" -I "$msvc.vs_include_path" -I "$msvc.um_include_path" -I "$msvc.shared_include_path"'
@@ -376,7 +376,7 @@ fn (cflags []CFlag) msvc_string_flags() MsvcStringFlags {
 		}
 		else if flag.name == '-L' {
 			lib_paths << flag.value
-			lib_paths << flag.value + os.path_separator + 'msvc'
+			lib_paths << flag.value + filepath.separator + 'msvc'
 			// The above allows putting msvc specific .lib files in a subfolder msvc/ ,
 			// where gcc will NOT find them, but cl will do...
 			// NB: gcc is smart enough to not need .lib files at all in most cases, the .dll is enough.
@@ -398,4 +398,3 @@ fn (cflags []CFlag) msvc_string_flags() MsvcStringFlags {
 	return MsvcStringFlags{
 		real_libs,inc_paths,lpaths,other_flags}
 }
-

--- a/vlib/compiler/scanner.v
+++ b/vlib/compiler/scanner.v
@@ -5,6 +5,7 @@ module compiler
 
 import (
 	os
+	filepath
 	// strings
 )
 
@@ -850,7 +851,7 @@ fn (s mut Scanner) debug_tokens() {
 	s.pos = 0
 	s.started = false
 	s.debug = true
-	fname := s.file_path.all_after(os.path_separator)
+	fname := s.file_path.all_after(filepath.separator)
 	println('\n===DEBUG TOKENS $fname===')
 	for {
 		res := s.scan()
@@ -941,4 +942,3 @@ fn (s &Scanner) validate_var_name(name string) {
 		s.error('bad variable name `$name`\n' + 'looks like you have a multi-word name without separating them with `_`' + '\nfor example, use `registration_date` instead of `registrationdate` ')
 	}
 }
-

--- a/vlib/compiler/tests/repl/runner/runner.v
+++ b/vlib/compiler/tests/repl/runner/runner.v
@@ -32,7 +32,7 @@ pub fn full_path_to_v(dirs_in int) string {
 	println('vreal   : $vreal')
 	println('myself  : $myself')
 	println('wd      : $wd')
-    */	
+    */
 	return vexec
 }
 
@@ -52,7 +52,7 @@ fn diff_files( file_result, file_expected string ) string {
 
 pub fn run_repl_file(wd string, vexec string, file string) ?string {
 	fcontent := os.read_file(file) or {	return error('Could not read file ${file}') }
-	content := fcontent.replace('\r', '')		
+	content := fcontent.replace('\r', '')
 	input := content.all_before('===output===\n')
 	output := content.all_after('===output===\n')
 
@@ -67,13 +67,13 @@ pub fn run_repl_file(wd string, vexec string, file string) ?string {
 		return error('Could not execute: $rcmd')
 	}
 	os.rm(input_temporary_filename)
-	
+
 	result := r.output.replace('\r','')
 	.replace('>>> ', '')
 	.replace('>>>', '')
 	.replace('... ', '')
 	.all_after('Use Ctrl-C or `exit` to exit\n')
-	.replace(wd  + os.path_separator, '' )
+	.replace(wd  + filepath.separator, '' )
 
 	if result != output {
 		file_result   := '${file}.result.txt'
@@ -97,7 +97,7 @@ $diff
 pub fn run_prod_file(wd string, vexec string, file string) ?string {
 	file_expected := '${file}.expected.txt'
 	f_expected_content := os.read_file(file_expected) or { return error('Could not read file ${file}') }
-	expected_content := f_expected_content.replace('\r', '')		
+	expected_content := f_expected_content.replace('\r', '')
 
 	cmd := '"$vexec" -prod run "${file}"'
 	r := os.exec(cmd) or {
@@ -160,4 +160,3 @@ pub fn new_prod_options() RunnerOptions {
 		files: files
 	}
 }
-

--- a/vlib/filepath/filepath.v
+++ b/vlib/filepath/filepath.v
@@ -24,12 +24,12 @@ pub fn join(base string, dirs ...string) string {
 	for d in dirs {
 		result << d
 	}
-	return result.join(path_separator)
+	return result.join(separator)
 }
 
 // dir returns all but the last element of path, typically the path's directory.
 pub fn dir(path string) string {
-	pos := path.last_index(path_separator) or {
+	pos := path.last_index(separator) or {
 		return '.'
 	}
 	return path[..pos]
@@ -37,7 +37,7 @@ pub fn dir(path string) string {
 
 // basedir returns a directory name from path
 pub fn basedir(path string) string {
-	pos := path.last_index(path_separator) or {
+	pos := path.last_index(separator) or {
 		return path
 	}
 	// NB: *without* terminating /
@@ -46,5 +46,5 @@ pub fn basedir(path string) string {
 
 // filename returns a file name from path
 pub fn filename(path string) string {
-	return path.all_after(path_separator)
+	return path.all_after(separator)
 }

--- a/vlib/filepath/filepath_nix.v
+++ b/vlib/filepath/filepath_nix.v
@@ -1,6 +1,5 @@
 module filepath
 
-const (
-	path_separator = '/'
+pub const (
+	separator = '/'
 )
-

--- a/vlib/filepath/filepath_windows.v
+++ b/vlib/filepath/filepath_windows.v
@@ -1,6 +1,5 @@
 module filepath
 
-const (
-	path_separator = '\\'
+pub const (
+	separator = '\\'
 )
-

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -797,7 +797,7 @@ pub fn home_dir() string {
 		}
 		home += homepath
 	}
-	home += path_separator
+	home += filepath.separator
 	return home
 }
 
@@ -1000,7 +1000,7 @@ pub fn walk_ext(path, ext string) []string {
 		panic(err)
 	}
 	mut res := []string
-	separator := if path.ends_with(path_separator) { '' } else { path_separator }
+	separator := if path.ends_with(filepath.separator) { '' } else { filepath.separator }
 	for i, file in files {
 		if file.starts_with('.') {
 			continue
@@ -1026,7 +1026,7 @@ pub fn walk(path string, f fn(path string)) {
 		panic(err)
 	}
 	for file in files {
-		p := path + os.path_separator + file
+		p := path + filepath.separator + file
 		if os.is_dir(p) && !os.is_link(p) {
 			walk(p, f)
 		}
@@ -1087,9 +1087,9 @@ pub fn flush_stdout() {
 }
 
 pub fn mkdir_all(path string) {
-	mut p := if path.starts_with(os.path_separator) { os.path_separator } else { '' }
-	for subdir in path.split(os.path_separator) {
-		p += subdir + os.path_separator
+	mut p := if path.starts_with(filepath.separator) { filepath.separator } else { '' }
+	for subdir in path.split(filepath.separator) {
+		p += subdir + filepath.separator
 		if !os.is_dir(p) {
 			os.mkdir(p) or {
 				panic(err)

--- a/vlib/os/os_nix.v
+++ b/vlib/os/os_nix.v
@@ -6,6 +6,14 @@ import strings
 #include <unistd.h>
 #include <fcntl.h>
 
+pub const (
+	/**
+	 * This constant is deprecated. Use `filepath.separator` instead.
+	 * FIXME Remove this separator, as it a part of `filepath` module.
+	 */
+	path_separator = '/'
+)
+
 const (
 	stdin_value = 0
 	stdout_value = 1

--- a/vlib/os/os_nix.v
+++ b/vlib/os/os_nix.v
@@ -6,10 +6,6 @@ import strings
 #include <unistd.h>
 #include <fcntl.h>
 
-pub const (
-	path_separator = '/'
-)
-
 const (
 	stdin_value = 0
 	stdout_value = 1
@@ -241,7 +237,7 @@ pub fn (f mut File) write_bytes(data voidptr, size int) {
 			return
 		}
 	}
-*/  
+*/
 	C.fwrite(data, 1, size, f.cfile)
 }
 

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -1,4 +1,5 @@
 import os
+import filepath
 
 fn test_aaa_setup(){
 	cleanup_leftovers()
@@ -34,7 +35,7 @@ fn test_open_file() {
   mut file := os.open_file(filename, "w+", 0666) or { panic(err) }
   file.write(hello)
   file.close()
-  
+
   assert hello.len == os.file_size(filename)
 
   read_hello := os.read_file(filename) or {
@@ -116,14 +117,14 @@ fn walk_callback(file string) {
     if file == '.' || file == '..' {
         return
     }
-    assert file == 'test_walk'+os.path_separator+'test1'
+    assert file == 'test_walk' + filepath.separator + 'test1'
 }
 
 fn test_walk() {
     folder := 'test_walk'
     os.mkdir(folder) or { panic(err) }
 
-    file1 := folder+os.path_separator+'test1'
+    file1 := folder + filepath.separator + 'test1'
 
     os.write_file(file1,'test-1')
 
@@ -172,7 +173,7 @@ fn test_tmpdir(){
 	assert t.len > 0
 	assert os.is_dir(t)
 
-	tfile := t + os.path_separator + 'tmpfile.txt'
+	tfile := t + filepath.separator + 'tmpfile.txt'
 
 	os.rm(tfile) // just in case
 
@@ -256,25 +257,25 @@ fn test_symlink() {
 }
 
 fn test_is_executable_writable_readable() {
-  file_name := os.tmpdir() + os.path_separator + 'rwxfile.exe'
+  file_name := os.tmpdir() + filepath.separator + 'rwxfile.exe'
 
   mut f := os.create(file_name) or {
     eprintln('failed to create file $file_name')
     return
   }
   f.close()
-  
+
   $if !windows {
-    os.chmod(file_name, 0600) // mark as readable && writable, but NOT executable  
+    os.chmod(file_name, 0600) // mark as readable && writable, but NOT executable
     assert os.is_writable(file_name)
     assert os.is_readable(file_name)
-    assert !os.is_executable(file_name)  
+    assert !os.is_executable(file_name)
     os.chmod(file_name, 0700) // mark as executable too
     assert os.is_executable(file_name)
   } $else {
     assert os.is_writable(file_name)
     assert os.is_readable(file_name)
-    assert os.is_executable(file_name)    
+    assert os.is_executable(file_name)
   }
 
   // We finally delete the test file.

--- a/vlib/os/os_windows.v
+++ b/vlib/os/os_windows.v
@@ -5,10 +5,6 @@ import strings
 #flag -lws2_32
 #include <winsock2.h>
 
-pub const (
-	path_separator = '\\'
-)
-
 // Ref - https://docs.microsoft.com/en-us/windows/desktop/winprog/windows-data-types
 // A handle to an object.
 pub type HANDLE voidptr

--- a/vlib/os/os_windows.v
+++ b/vlib/os/os_windows.v
@@ -5,6 +5,14 @@ import strings
 #flag -lws2_32
 #include <winsock2.h>
 
+pub const (
+	/**
+	 * This constant is deprecated. Use `filepath.separator` instead.
+	 * FIXME Remove this separator, as it a part of `filepath` module.
+	 */
+	path_separator = '\\'
+)
+
 // Ref - https://docs.microsoft.com/en-us/windows/desktop/winprog/windows-data-types
 // A handle to an object.
 pub type HANDLE voidptr

--- a/vlib/v/builder/modules.v
+++ b/vlib/v/builder/modules.v
@@ -8,7 +8,7 @@ import (
 [inline]
 fn module_path(mod string) string {
 	// submodule support
-	return mod.replace('.', os.path_separator)
+	return mod.replace('.', filepath.separator)
 }
 
 fn (b &Builder) find_module_path(mod string) ?string {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -8,6 +8,7 @@ import (
 	v.table
 	v.token
 	os
+	filepath
 )
 
 pub struct Checker {
@@ -544,7 +545,7 @@ pub fn (c &Checker) error(s string, pos token.Position) {
 	print_backtrace()
 	mut path := c.file_name
 	// Get relative path
-	workdir := os.getwd() + os.path_separator
+	workdir := os.getwd() + filepath.separator
 	if path.starts_with(workdir) {
 		path = path.replace(workdir, '')
 	}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -11,6 +11,7 @@ import (
 	v.pref
 	term
 	os
+	filepath
 )
 
 const (
@@ -56,7 +57,7 @@ pub fn parse_stmt(text string, table &table.Table, scope &ast.Scope) ast.Stmt {
 		pref: &pref.Preferences{}
 		scope: scope
 		// scope: &ast.Scope{start_pos: 0, parent: 0}
-		
+
 	}
 	p.init_parse_fns()
 	p.read_first_token()
@@ -294,7 +295,7 @@ pub fn (p mut Parser) stmt() ast.Stmt {
 			return ast.ExprStmt{
 				expr: expr
 				// typ: typ
-				
+
 			}
 		}
 	}
@@ -393,7 +394,7 @@ pub fn (p &Parser) error(s string) {
 	print_backtrace()
 	mut path := p.file_name
 	// Get relative path
-	workdir := os.getwd() + os.path_separator
+	workdir := os.getwd() + filepath.separator
 	if path.starts_with(workdir) {
 		path = path.replace(workdir, '')
 	}
@@ -462,7 +463,7 @@ pub fn (p mut Parser) parse_ident(is_c bool) (ast.Ident,table.Type) {
 			ident.info = ast.IdentVar{
 				typ: typ
 				// name: ident.name
-				
+
 			}
 			return ident,typ
 		}
@@ -473,7 +474,7 @@ pub fn (p mut Parser) parse_ident(is_c bool) (ast.Ident,table.Type) {
 			ident.info = ast.IdentVar{
 				typ: typ
 				// name: ident.name
-				
+
 			}
 			node = ident
 		}else{
@@ -484,7 +485,7 @@ pub fn (p mut Parser) parse_ident(is_c bool) (ast.Ident,table.Type) {
 					kind: .blank_ident
 					name: name
 					// pos: p.tok.position()
-					
+
 				}
 				return node,typ
 				// p.error('parse_ident: unknown identifier `$name`')
@@ -1074,10 +1075,10 @@ fn (p mut Parser) if_expr() ast.Expr {
 		stmts: stmts
 		else_stmts: else_stmts
 		// typ: typ
-		
+
 		pos: p.tok.position()
 		// left: left
-		
+
 	}
 	return node
 }
@@ -1458,10 +1459,10 @@ fn (p mut Parser) var_decl() ast.VarDecl {
 	node := ast.VarDecl{
 		name: name
 		expr: expr // p.expr(token.lowest_prec)
-		
+
 		is_mut: is_mut
 		// typ: typ
-		
+
 		pos: p.tok.position()
 	}
 	p.scope.register_var(node)
@@ -1580,7 +1581,7 @@ fn (p mut Parser) match_expr() ast.Expr {
 		blocks: blocks
 		match_exprs: match_exprs
 		// typ: typ
-		
+
 		cond: cond
 	}
 	return node

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -5,6 +5,7 @@ module scanner
 
 import (
 	os
+	filepath
 	v.token
 	// strings
 )
@@ -838,7 +839,7 @@ fn (s mut Scanner) debug_tokens() {
 	s.pos = 0
 	s.started = false
 	s.debug = true
-	fname := s.file_path.all_after(os.path_separator)
+	fname := s.file_path.all_after(filepath.separator)
 	println('\n===DEBUG TOKENS $fname===')
 	for {
 		tok := s.scan()


### PR DESCRIPTION
This PR is to optimized processing path separator.

1. delete `pub os.path_separator`.
2. change `filepath.path_separator` to `pub filepath.separator`.
3. modify related calls.

Its benefits is unified handling path separator.