### PR TITLE
ci: fix `windows-prebuilt` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
     - name: Download V
       shell: cmd
       run: |
-        echo "Downloading v.exe..."
+        echo Downloading V...
         curl -L https://github.com/vlang/v/releases/latest/download/v_windows.zip -o v_windows.zip
         echo Unzipping...
         unzip v_windows.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,26 +165,18 @@ jobs:
     runs-on: windows-2019
     steps:
     - name: Download V
-      shell: bash
+      shell: cmd
       run: |
         echo "Downloading v.exe..."
-        curl -L https://github.com/vbinaries/vbinaries/releases/download/latest/v_windows.zip -o v_windows.zip
-        echo "Unzipping..."
+        curl -L https://github.com/vlang/v/releases/latest/download/v_windows.zip -o v_windows.zip
+        echo Unzipping...
         unzip v_windows.zip
-        echo "version:"
-        ./v.exe --version
-        echo "Done"
-        ls
+        v.exe --version
+        echo Done
+        dir
     - name: Test V
-      shell: bash
-      run: |
-        echo "ls:"
-        ls
-        echo "ls examples/:"
-        ls examples
-        .\v.exe -o hi.exe examples/hello_world.v
-        .\hi.exe
-        #./v.exe -silent build-examples
+      shell: cmd
+      run: v.exe examples\hello_world.v && examples\hello_world.exe
 
   ubuntu-musl:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
## Changelog

- Use URL from GitHub to get prebuilt V executable
- Use `cmd` shell
- Remove redundant quotes in echo messages
- Remove `ls` calls