### PR TITLE
README: fix output name in bootstrap test

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ docker run --rm -it vlang:latest
 Make sure V can compile itself:
 
 ```
-v -o v cmd/v
+v -o v2 cmd/v
 ```
 
 ```bash


### PR DESCRIPTION
Linker couldn't overwrite running v so this PR simply changes output name from v to v2.
@vitalyster Thanks for telling this!
