### PR TITLE
vfmt2: allow running the new vfmt with 'v fmt -2' .

### DIFF
--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -76,9 +76,16 @@ fn main() {
 	}
 	mut files := []string
 	for file in possible_files {
-		if !file.ends_with('.v') && !file.ends_with('.vv') {
-			compiler.verror('v fmt can only be used on .v or .vv files.\nOffending file: "$file" .')
-			continue
+		if foptions.is_2 {
+			if !file.ends_with('.v') && !file.ends_with('.vv') {
+				compiler.verror('v fmt -2 can only be used on .v or .vv files.\nOffending file: "$file" .')
+				continue
+			}
+		} else {
+			if !file.ends_with('.v') {
+				compiler.verror('v fmt can only be used on .v files.\nOffending file: "$file" .')
+				continue
+			}
 		}
 		if !os.exists(file) {
 			compiler.verror('"$file" does not exist.')

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -76,8 +76,8 @@ fn main() {
 	}
 	mut files := []string
 	for file in possible_files {
-		if !file.ends_with('.v') {
-			compiler.verror('v fmt can only be used on .v files.\nOffending file: "$file" .')
+		if !file.ends_with('.v') && !file.ends_with('.vv') {
+			compiler.verror('v fmt can only be used on .v or .vv files.\nOffending file: "$file" .')
 			continue
 		}
 		if !os.exists(file) {

--- a/vlib/v/fmt/fmt_test.v
+++ b/vlib/v/fmt/fmt_test.v
@@ -10,8 +10,7 @@ import (
 
 const (
 	error_missing_vexe = 1
-	error_missing_diff = 2
-	error_failed_tests = 3
+	error_failed_tests = 2
 )
 
 fn test_fmt() {


### PR DESCRIPTION
This PR makes possible stuff like:
`./v fmt -2 -diff vlib/v/fmt/tests/simple_input.vv`
or
`./v fmt -2 -diff vlib/os/*.v`

NB: this is only for easier testing of vfmt2 !!!

*DO NOT USE -2 for your production code!*