### PR TITLE
vfmt2: skip arg type if possible

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -29,7 +29,7 @@ pub fn fmt(file ast.File, table &table.Table) string {
 		indent: -1
 	}
 	f.stmts(file.stmts)
-	return f.out.str()
+	return f.out.str().trim_space() + '\n'
 }
 
 pub fn (f mut Fmt) write(s string) {
@@ -106,9 +106,14 @@ fn (f mut Fmt) stmt(node ast.Stmt) {
 			}
 			f.write('fn ${receiver}${it.name}(')
 			for i, arg in it.args {
-				sym := f.table.get_type_symbol(arg.typ)
-				f.write('$arg.name $sym.name')
-				if i < it.args.len - 1 {
+				is_last_arg := i == it.args.len - 1
+				should_add_type := is_last_arg || it.args[i + 1].typ != arg.typ
+				f.write(arg.name)
+				if should_add_type {
+					typ_name := f.table.get_type_symbol(arg.typ)
+					f.write(' ${typ_name.name}')
+				}
+				if !is_last_arg {
 					f.write(', ')
 				}
 			}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -110,8 +110,8 @@ fn (f mut Fmt) stmt(node ast.Stmt) {
 				should_add_type := is_last_arg || it.args[i + 1].typ != arg.typ
 				f.write(arg.name)
 				if should_add_type {
-					typ_name := f.table.get_type_symbol(arg.typ)
-					f.write(' ${typ_name.name}')
+					arg_typ_sym := f.table.get_type_symbol(arg.typ)
+					f.write(' ${arg_typ_sym.name}')
 				}
 				if !is_last_arg {
 					f.write(', ')

--- a/vlib/v/fmt/tests/simple_expected.vv
+++ b/vlib/v/fmt/tests/simple_expected.vv
@@ -45,3 +45,26 @@ fn voidfn() {
 	println('this is a function that does not return anything')
 }
 
+fn fn_with_1_arg(arg int) int {
+	return 0
+}
+
+fn fn_with_2a_args(arg1, arg2 int) int {
+	return 0
+}
+
+fn fn_with_2_args_to_be_shorten(arg1, arg2 int) int {
+	return 0
+}
+
+fn fn_with_2b_args(arg1 string, arg2 int) int {
+	return 0
+}
+
+fn fn_with_3_args(arg1 string, arg2 int, arg3 User) int {
+	return 0
+}
+
+fn (this User) fn_with_receiver() {
+	println('')
+}

--- a/vlib/v/fmt/tests/simple_input.vv
+++ b/vlib/v/fmt/tests/simple_input.vv
@@ -48,3 +48,27 @@ User
 fn   voidfn(){
  println('this is a function that does not return anything')
    }
+
+fn fn_with_1_arg(arg int) int {
+return 0
+}
+
+fn fn_with_2a_args(arg1, arg2 int) int {
+return 0
+}
+
+fn fn_with_2_args_to_be_shorten(arg1 int, arg2 int) int {
+return 0
+}
+
+fn fn_with_2b_args(arg1 string, arg2 int) int {
+return 0
+}
+
+fn fn_with_3_args(arg1 string, arg2 int, arg3 User) int {
+return 0
+}
+
+fn    (this User) fn_with_receiver() {
+println('')
+}


### PR DESCRIPTION
## Changelog

- Skip arg type if possible
vfmt will produce `fn (arg1, arg2 int)` instead of `fn (arg1 int, arg2 int)`.
- Add more test cases for vfmt
- Ensure a single EOL at the end of file
Ref https://github.com/vlang/v/commit/b991ca4ebc7e6c1eacc42c4b8b1abfeb471d1960#r37361440.