### PR TITLE
vfmt2: process imports and module name

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -26,10 +26,9 @@ pub fn fmt(file ast.File, table &table.Table) string {
 	mut f := Fmt{
 		out: strings.new_builder(1000)
 		table: table
-		indent: -1
+		indent: 0
 	}
-	f.stmts(file.stmts)
-	return f.out.str().trim_space() + '\n'
+	return f.process(file)
 }
 
 pub fn (f mut Fmt) write(s string) {
@@ -47,6 +46,45 @@ pub fn (f mut Fmt) writeln(s string) {
 	}
 	f.out.writeln(s)
 	f.empty_line = true
+}
+
+fn (f mut Fmt) process(file ast.File) string {
+	f.mod(file.mod)
+	f.imports(file.imports)
+	for stmt in file.stmts {
+		f.stmt(stmt)
+	}
+	return f.out.str().trim_space() + '\n'
+}
+
+fn (f mut Fmt) mod(mod ast.Module) {
+	if mod.name != 'main' {
+		f.writeln('module ${mod.name}\n')
+	}
+}
+
+fn (f mut Fmt) imports(imports []ast.Import) {
+	if imports.len == 1 {
+		imp_stmt_str := f.imp_stmt_str(imports[0])
+		f.writeln('import ${imp_stmt_str}\n')
+	} else if imports.len > 1 {
+		f.writeln('import (')
+		f.indent++
+		for imp in imports {
+			f.writeln(f.imp_stmt_str(imp))
+		}
+		f.indent--
+		f.writeln(')\n')
+	}
+}
+
+fn (f Fmt) imp_stmt_str(imp ast.Import) string {
+	imp_alias_suffix := if imp.alias != imp.mod {
+		' as ${imp.alias}'
+	} else {
+		''
+	}
+	return '${imp.mod}${imp_alias_suffix}'
 }
 
 fn (f mut Fmt) stmts(stmts []ast.Stmt) {

--- a/vlib/v/fmt/tests/import_multiple_expected.vv
+++ b/vlib/v/fmt/tests/import_multiple_expected.vv
@@ -1,0 +1,4 @@
+import (
+	filepath
+	os
+)

--- a/vlib/v/fmt/tests/import_multiple_input.vv
+++ b/vlib/v/fmt/tests/import_multiple_input.vv
@@ -1,0 +1,2 @@
+import filepath
+import os

--- a/vlib/v/fmt/tests/import_single_expected.vv
+++ b/vlib/v/fmt/tests/import_single_expected.vv
@@ -1,0 +1,1 @@
+import os

--- a/vlib/v/fmt/tests/import_single_input.vv
+++ b/vlib/v/fmt/tests/import_single_input.vv
@@ -1,0 +1,1 @@
+import os


### PR DESCRIPTION
This PR adds processing a module name and a list of imports. 

The `fmt` behavior in this PR:
- `fmt` uses `import a` for a single module, and `import (a b c)` for multiple imports
- `fmt` skips `module a` if module name is "main"

Few notes about changes I made:
- I changed the initial value of indent to 0. This made to avoid hacky changes of indentation inside `Fmt.imports` function:
```v
fn (f mut Fmt) imports(imports []ast.Import) {
	// If `f.indent` is -1 by default, we should increase its value
	// before processing imports, like we did in `Fmt.stmts` before.
	// It looks quite odd and hacky for me; that's why I did these changes.
	if imports.len == 1 {
		// There're no issues here, as `f.indent` is not actually used in this case.
		...
	} else if imports.len > 1 {
		f.writeln('import (')
		// `f.indent` could be 0 if its default value is -1.
		// Now it equals 1, so indentation is proper here.
		f.indent++
		...
	}
}
```
- Since the indent value is zero by default, we *should not* use `Fmt.stmts` for 1-st level statements to avoid increasing its value.
- Zero value makes more sense, and is more readable.