### PR TITLE
string: optimized starts_with and ends_with

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -711,20 +711,27 @@ pub fn (s string) contains(p string) bool {
 }
 
 pub fn (s string) starts_with(p string) bool {
-	idx := s.index(p) or {
+	if p.len > s.len {
 		return false
 	}
-	return idx == 0
+	for i := 0; i < p.len; i++ {
+		if s[i] != p[i] {
+			return false
+		}
+	}
+	return true
 }
 
 pub fn (s string) ends_with(p string) bool {
 	if p.len > s.len {
 		return false
 	}
-	idx := s.last_index(p) or {
-		return false
+	for i := 0; i < p.len; i++ {
+		if p[i] != s[s.len - p.len + i] {
+			return false
+		}
 	}
-	return idx == s.len - p.len
+	return true
 }
 
 // TODO only works with ASCII


### PR DESCRIPTION
This PR is to optimize `string.starts_with` and `string.ends_with`.

- Use `index` and `last_index` is inefficiency .
- We only need to judge the beginning and the end of a few characters.

So we can improve performance.