### PR TITLE
README: add build method when git not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Download both V source and its auto-translated C source from https://github.com/
 
 Unzip both and place all unzipped files together in any directory.
 
-Open `make.bat` with any txt editor, locate `vc\v_win.c` and replace it with full directory, e.g. `C:\vlang\vc\v_win.c`.
+Open `make.bat` with any text editor, locate `vc\v_win.c` and replace it with full directory, e.g. `C:\vlang\vc\v_win.c`.
 
 Save and then run make. All done!
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ A stable 0.2 release is planned for February 2020. Right now V is in an alpha st
 
 ### Linux, macOS, Windows, *BSD, Solaris, WSL, Android, Raspbian
 
+1. If you have Git installed 
+
 ```bash
 git clone https://github.com/vlang/v
 cd v
@@ -59,6 +61,17 @@ V is being constantly updated. To update V, simply run:
 ```
 v up
 ```
+
+2. If you do not have Git installed
+
+Download both V source and its auto-translated C source from https://github.com/vlang/v/archive/master.zip and https://github.com/vlang/vc/archive/master.zip.
+
+Unzip both and place all unzipped files together in any directory.
+
+Open `make.bat` with any txt editor, locate `vc\v_win.c` and replace it with full directory, e.g. `C:\vlang\vc\v_win.c`.
+
+Save and then run make. All done!
+
 
 ### C compiler
 


### PR DESCRIPTION
This PR adds build method for people without git installed on computer.
I believe there're also many non-professionals or programmers unfamiliar with github (so they probably do not have git) but willing to try V.
This PR is just a start for this. I tested on windows and it worked.

