### PR TITLE
Fix string.capitalize

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -752,6 +752,9 @@ pub fn (s string) to_upper() string {
 }
 
 pub fn (s string) capitalize() string {
+	if s.len == 0 {
+		return ''
+	}
 	sl := s.to_lower()
 	cap := sl[0].str().to_upper() + sl.right(1)
 	return cap

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -503,6 +503,8 @@ fn test_capitalize() {
 	assert s.capitalize() == 'Test'
     s = 'i am ray'
 	assert s.capitalize() == 'I am ray'
+	s = ''
+	assert s.capitalize() == ''
 }
 
 fn test_title() {


### PR DESCRIPTION
This PR is to fix string.capitalize error when string is empty.

- It's memory access out of bounds when string is empty.

So add string empty process.