### PR TITLE
Unified handling vexe_path

### DIFF
--- a/cmd/tools/vtest-compiler.v
+++ b/cmd/tools/vtest-compiler.v
@@ -5,6 +5,7 @@ import (
 	testing
 	benchmark
 	filepath
+	v.pref
 )
 
 pub const (
@@ -18,7 +19,7 @@ fn main() {
 }
 
 fn v_test_compiler(vargs string) {
-	vexe := testing.vexe_path()
+	vexe := pref.vexe_path()
 	parent_dir := filepath.dir(vexe)
 	testing.vlib_should_be_present(parent_dir)
 	// Changing the current directory is needed for some of the compiler tests,

--- a/cmd/v/compile_options.v
+++ b/cmd/v/compile_options.v
@@ -24,7 +24,7 @@ pub fn new_v(args []string) &compiler.V {
 			panic(err)
 		}
 	}
-	vroot := filepath.dir(vexe_path())
+	vroot := filepath.dir(pref.vexe_path())
 	// optional, custom modules search path
 	user_mod_path := cmdline.option(args, '-user_mod_path', '')
 	vlib_path := cmdline.option(args, '-vlib-path', '')
@@ -108,7 +108,7 @@ pub fn new_v(args []string) &compiler.V {
 	}
 	is_repl := '-repl' in args
 	ccompiler := cmdline.option(args, '-cc', '')
-	mut pref := &pref.Preferences{
+	mut prefs := &pref.Preferences{
 		os: pref.os_from_string(target_os)
 		is_so: '-shared' in args
 		is_solive: '-solive' in args
@@ -155,20 +155,20 @@ pub fn new_v(args []string) &compiler.V {
 		compile_defines_all: compile_defines_all
 		mod: mod
 	}
-	if pref.is_verbose || pref.is_debug {
-		println('C compiler=$pref.ccompiler')
+	if prefs.is_verbose || prefs.is_debug {
+		println('C compiler=$prefs.ccompiler')
 	}
 	$if !linux {
-		if pref.is_bare && !out_name.ends_with('.c') {
+		if prefs.is_bare && !out_name.ends_with('.c') {
 			println('V error: -freestanding only works on Linux for now')
 			os.flush_stdout()
 			exit(1)
 		}
 	}
-	pref.fill_with_defaults()
+	prefs.fill_with_defaults()
 
 	// v.exe's parent directory should contain vlib
-	if !os.is_dir(pref.vlib_path) || !os.is_dir(pref.vlib_path + filepath.separator + 'builtin') {
+	if !os.is_dir(prefs.vlib_path) || !os.is_dir(prefs.vlib_path + filepath.separator + 'builtin') {
 		// println('vlib not found, downloading it...')
 		/*
 		ret := os.system('git clone --depth=1 https://github.com/vlang/v .')
@@ -180,16 +180,16 @@ pub fn new_v(args []string) &compiler.V {
 		*/
 		println('vlib not found. It should be next to the V executable.')
 		println('Go to https://vlang.io to install V.')
-		println('(os.executable=${os.executable()} vlib_path=$pref.vlib_path vexe_path=${vexe_path()}')
+		println('(os.executable=${os.executable()} vlib_path=$prefs.vlib_path vexe_path=${pref.vexe_path()}')
 		exit(1)
 	}
 
-	if pref.is_script && !os.exists(dir) {
+	if prefs.is_script && !os.exists(dir) {
 		println('`$dir` does not exist')
 		exit(1)
 	}
 
-	return compiler.new_v(pref)
+	return compiler.new_v(prefs)
 }
 
 fn find_c_compiler_thirdparty_options(args []string) string {

--- a/cmd/v/flag.v
+++ b/cmd/v/flag.v
@@ -66,13 +66,3 @@ fn join_flags_and_argument() []string {
 
 	return non_empty(os.args)
 }
-
-fn vexe_path() string {
-	vexe := os.getenv('VEXE')
-	if vexe != '' {
-		return vexe
-	}
-	real_vexe_path := os.realpath(os.executable())
-	os.setenv('VEXE', real_vexe_path, true)
-	return real_vexe_path
-}

--- a/cmd/v/simple_tool.v
+++ b/cmd/v/simple_tool.v
@@ -7,10 +7,11 @@ import (
 	compiler
 	filepath
 	os
+	v.pref
 )
 
 fn launch_tool(is_verbose bool, tname string, cmdname string) {
-	vexe := vexe_path()
+	vexe := pref.vexe_path()
 	vroot := filepath.dir(vexe)
 	compiler.set_vroot_folder(vroot)
 
@@ -55,7 +56,7 @@ fn launch_tool(is_verbose bool, tname string, cmdname string) {
 		compilation_args := compilation_options.join(' ')
 		compilation_command := '"$vexe" $compilation_args "$tool_source"'
 		if is_verbose {
-			eprintln('Compiling $tname with: "$compilation_command"') 
+			eprintln('Compiling $tname with: "$compilation_command"')
 		}
 		tool_compilation := os.exec(compilation_command) or { panic(err) }
 		if tool_compilation.exit_code != 0 {
@@ -65,6 +66,6 @@ fn launch_tool(is_verbose bool, tname string, cmdname string) {
 	if is_verbose {
 		eprintln('launch_tool running tool command: $tool_command ...')
 	}
-	
+
 	exit(os.system(tool_command))
 }

--- a/cmd/v/symlink.v
+++ b/cmd/v/symlink.v
@@ -3,13 +3,16 @@
 // that can be found in the LICENSE file.
 module main
 
-import os
+import (
+	os
+	v.pref
+)
 
 fn create_symlink() {
 	$if windows {
 		return
 	}
-	vexe := vexe_path()
+	vexe := pref.vexe_path()
 	mut link_path := '/usr/local/bin/v'
 	mut ret := os.exec('ln -sf $vexe $link_path') or { panic(err) }
 	if ret.exit_code == 0 {
@@ -28,4 +31,3 @@ fn create_symlink() {
 			println('Failed to create symlink "$link_path". Try again with sudo.')
 	}
 }
-

--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -30,7 +30,7 @@ fn (v mut V) cc() {
 		return
 	}
 	v.build_thirdparty_obj_files()
-	vexe := vexe_path()
+	vexe := pref.vexe_path()
 	vdir := filepath.dir(vexe)
 	// Just create a C/JavaScript file and exit
 	// for example: `v -o v.c compiler`

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -732,7 +732,7 @@ pub fn (v &V) get_user_files() []string {
 	mut user_files := []string
 
     // See cmd/tools/preludes/README.md for more info about what preludes are
-	vroot := filepath.dir(vexe_path())
+	vroot := filepath.dir(pref.vexe_path())
 	preludes_path := filepath.join(vroot,'cmd','tools','preludes')
 	if v.pref.is_live {
 		user_files << filepath.join(preludes_path,'live_main.v')
@@ -841,16 +841,6 @@ pub fn (v &V) log(s string) {
 		return
 	}
 	println(s)
-}
-
-pub fn vexe_path() string {
-	vexe := os.getenv('VEXE')
-	if '' != vexe {
-		return vexe
-	}
-	real_vexe_path := os.realpath(os.executable())
-	os.setenv('VEXE', real_vexe_path, true)
-	return real_vexe_path
 }
 
 pub fn verror(s string) {

--- a/vlib/compiler/module_header.v
+++ b/vlib/compiler/module_header.v
@@ -28,7 +28,7 @@ mut:
 // `mod` == "vlib/os"
 fn generate_vh(mod string) {
 	println('\n\n\n\nGenerating a V header file for module `$mod`')
-	vexe := vexe_path()
+	vexe := pref.vexe_path()
 	full_mod_path := filepath.join(filepath.dir(vexe),mod)
 	dir := if mod.starts_with('vlib') { '$compiler.v_modules_path${filepath.separator}$mod' } else { mod }
 	path := dir + '.vh'

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -3,7 +3,7 @@ module doc
 import (
 	strings
 	// v.builder
-	// v.pref
+	v.pref
 	v.table
 	v.parser
 	v.ast
@@ -25,7 +25,7 @@ pub fn doc(mod string, table &table.Table) string {
 		table: table
 		mod: mod
 	}
-	mods_path := filepath.dir(vexe_path()) + '/vlib'
+	mods_path := filepath.dir(pref.vexe_path()) + '/vlib'
 	path := filepath.join(mods_path,mod).replace('.', filepath.separator)
 	if !os.exists(path) {
 		println('module "$mod" not found')
@@ -91,14 +91,4 @@ fn (d mut Doc) print_methods() {
 			else {}
 	}
 	}
-}
-
-pub fn vexe_path() string {
-	vexe := os.getenv('VEXE')
-	if '' != vexe {
-		return vexe
-	}
-	real_vexe_path := os.realpath(os.executable())
-	os.setenv('VEXE', real_vexe_path, true)
-	return real_vexe_path
 }

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -66,8 +66,7 @@ fn default_c_compiler() string {
 	return 'cc'
 }
 
-//TODO Remove code duplication
-fn vexe_path() string {
+pub fn vexe_path() string {
 	vexe := os.getenv('VEXE')
 	if vexe != '' {
 		return vexe


### PR DESCRIPTION
This PR is unified handing vexe_path.

- Change `v.pref.vexe_path` to `pub v.pref.vexe_path`.
- Delete all the repetitive defines in other modules.
- Modify related call.

`v.pref` is fit for `vexe_path()`.
