### PR TITLE
v bugfix: launch_tool now use .exe extension on windows

### DIFF
--- a/cmd/v/simple_tool.v
+++ b/cmd/v/simple_tool.v
@@ -20,7 +20,7 @@ fn launch_tool(is_verbose bool, tname string, cmdname string) {
 	}
 	mut compilation_options := os.args[1..tname_index].clone()
 	tool_args := os.args[1..].join(' ')
-	tool_exe := os.realpath('$vroot/cmd/tools/$tname')
+	tool_exe := path_of_executable(os.realpath('$vroot/cmd/tools/$tname'))
 	tool_source := os.realpath('$vroot/cmd/tools/${tname}.v')
 	tool_command := '"$tool_exe" $tool_args'
 	if is_verbose {
@@ -67,4 +67,11 @@ fn launch_tool(is_verbose bool, tname string, cmdname string) {
 	}
 	
 	exit(os.system(tool_command))
+}
+
+fn path_of_executable(path string) string {
+	$if windows {
+		return path + '.exe'
+	}
+	return path
 }


### PR DESCRIPTION
This PR speeds up launching of v tools (like v repl and v fmt) on windows.
Before this, v recompiled the tool each time, even if the tool source was not changed.
