### PR TITLE
Simplify vup module

### DIFF
--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -3,24 +3,34 @@ module main
 import (
 	os
 	filepath
+	v.pref
 )
 
 fn main() {
 	println('Updating V...')
-	vroot := filepath.dir(os.getenv('VEXE'))
+	vroot := filepath.dir(pref.vexe_path())
 	os.chdir(vroot)
-	s := os.exec('git -C "$vroot" pull --rebase origin master') or { panic(err) }
+	// git pull
+	s := os.exec('git pull --rebase origin master') or {
+		panic(err)
+	}
 	println(s.output)
+
 	$if windows {
-		v_backup_file := '$vroot/v_old.exe'
-		if os.exists( v_backup_file ) {
-			os.rm( v_backup_file )
+		v_backup_file := 'v_old.exe'
+		if os.exists(v_backup_file) {
+			os.rm(v_backup_file)
 		}
-		os.mv('$vroot/v.exe', v_backup_file)
-		s2 := os.exec('"$vroot/make.bat"') or { panic(err) }
+		os.mv('v.exe', v_backup_file)
+		
+		s2 := os.exec('make.bat') or {
+			panic(err)
+		}
 		println(s2.output)
 	} $else {
-		s2 := os.exec('make -C "$vroot"') or { panic(err) }
+		s2 := os.exec('make') or {
+			panic(err)
+		}
 		println(s2.output)
 	}
 }


### PR DESCRIPTION
This PR simplify `vup` tool.

Use `os.chdir(vroot)` before, so we can :
- Omit `-C "$vroot"` in git command.
- Omit absolute path in `os.mv` `os.rm` `os.exec` etc.

Become simple and clear.

And use `pref.vexe_path` instead of `os.getenv('VEXE').