### PR TITLE
bugfix: v should not panic when encountering a module file that consists only of comments.

### DIFF
--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -828,7 +828,7 @@ pub fn (v mut V) parse_lib_imports() {
 				pidx := v.parse(file, .imports)
 				p_mod := v.parsers[pidx].mod
 				if p_mod != mod {
-					v.parsers[pidx].error_with_token_index('bad module definition: ${v.parsers[pidx].file_path} imports module "$mod" but $file is defined as module `$p_mod`', 1)
+					v.parsers[pidx].error_with_token_index('bad module definition: ${v.parsers[pidx].file_path} imports module "$mod" but $file is defined as module `$p_mod`', 0)
 				}
 			}
 			done_imports << mod

--- a/vlib/compiler/tests/modules/acommentedmodule/commentedfile.v
+++ b/vlib/compiler/tests/modules/acommentedmodule/commentedfile.v
@@ -1,0 +1,5 @@
+/*
+module acommentedmodule
+
+
+*/

--- a/vlib/compiler/tests/repl/entire_commented_module.repl
+++ b/vlib/compiler/tests/repl/entire_commented_module.repl
@@ -1,0 +1,3 @@
+import compiler.tests.modules.acommentedmodule
+===output===
+vlib/compiler/tests/modules/acommentedmodule/commentedfile.v:7:1: bad module definition: vlib/compiler/tests/modules/acommentedmodule/commentedfile.v imports module "compiler.tests.modules.acommentedmodule" but vlib/compiler/tests/modules/acommentedmodule/commentedfile.v is defined as module `main`

--- a/vlib/compiler/tests/repl/runner/runner.v
+++ b/vlib/compiler/tests/repl/runner/runner.v
@@ -76,6 +76,7 @@ pub fn run_repl_file(wd string, vexec string, file string) ?string {
 	.all_after('Use Ctrl-C or `exit` to exit\n')
 	.replace(wd  + filepath.separator, '' )
 	.replace(vexec_folder, '')
+	.replace('\\', '/')
 
 	if result != output {
 		file_result   := '${file}.result.txt'

--- a/vlib/compiler/tests/repl/runner/runner.v
+++ b/vlib/compiler/tests/repl/runner/runner.v
@@ -51,6 +51,7 @@ fn diff_files( file_result, file_expected string ) string {
 }
 
 pub fn run_repl_file(wd string, vexec string, file string) ?string {
+	vexec_folder := filepath.dir(vexec) + filepath.separator
 	fcontent := os.read_file(file) or {	return error('Could not read file ${file}') }
 	content := fcontent.replace('\r', '')
 	input := content.all_before('===output===\n')
@@ -74,6 +75,7 @@ pub fn run_repl_file(wd string, vexec string, file string) ?string {
 	.replace('... ', '')
 	.all_after('Use Ctrl-C or `exit` to exit\n')
 	.replace(wd  + filepath.separator, '' )
+	.replace(vexec_folder, '')
 
 	if result != output {
 		file_result   := '${file}.result.txt'


### PR DESCRIPTION
This PR makes V print an error when it sees a module file that has a
giant /* */ comment that encompasses the whole file, including the
`module name` line.

Previously, V panic-ed with:
```text
================ V panic ================
   module: builtin
   function: get()
   file: /v/nv/vlib/builtin/array.v
   line: 166
   message: array.get: index out of range (i == 1, a.len == 1)
=========================================
```