### PR TITLE
Fix os_test.v

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1069,6 +1069,12 @@ fn test_hello() {
 
 All test functions have to be placed in `*_test.v` files and begin with `test_`.
 
+You can also define a special test function: `testsuite_begin`, which will be 
+run *before* all other test functions in a `_test.v` file.
+
+You can also define a special test function: `testsuite_end`, which will be 
+run *after* all other test functions in a `_test.v` file.
+
 To run the tests do `v hello_test.v`.
 
 To test an entire module, do `v test mymodule`.
@@ -1076,12 +1082,6 @@ To test an entire module, do `v test mymodule`.
 You can also do `v test .` to test everything inside your curent folder (and underneath it).
 
 You can pass `-stats` to v test, to see more details about the individual tests in each _test.v file.
-
-You can define a special test function: `testsuite_begin`, which will be 
-run *before* all other test functions in a _test.v file.
-
-You can also define a special test function: `testsuite_end`, which will be 
-run *after* all other test functions in a _test.v file.
 
 ## Memory management
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1077,6 +1077,12 @@ You can also do `v test .` to test everything inside your curent folder (and und
 
 You can pass `-stats` to v test, to see more details about the individual tests in each _test.v file.
 
+You can define a special test function: `testsuite_begin`, which will be 
+run *before* all other test functions in a _test.v file.
+
+You can also define a special test function: `testsuite_end`, which will be 
+run *after* all other test functions in a _test.v file.
+
 ## Memory management
 
 (Work in progress)

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -494,7 +494,7 @@ pub fn (v mut V) generate_main() {
 			if v.table.main_exists() {
 				verror('test files cannot have function `main`')
 			}
-			testsuite_begin_name, test_fn_names, testsuite_end_name := v.table.all_test_function_names()
+			test_fn_names := v.table.all_test_function_names()
 			if test_fn_names.len == 0 {
 				verror('test files need to have at least one test function')
 			}
@@ -502,9 +502,6 @@ pub fn (v mut V) generate_main() {
 			v.gen_main_start(false)
 			if v.pref.is_stats {
 				cgen.genln('BenchedTests bt = main__start_testing(${test_fn_names.len},tos3("$v.pref.path"));')
-			}
-			if testsuite_begin_name.len > 0 {
-				cgen.genln('${testsuite_begin_name}();')
 			}
 			for tfname in test_fn_names {
 				if v.pref.is_stats {
@@ -515,9 +512,6 @@ pub fn (v mut V) generate_main() {
 					cgen.genln('BenchedTests_testing_step_end(&bt);')
 				}
 			}
-			if testsuite_end_name.len > 0 {
-				cgen.genln('${testsuite_end_name}();')
-			}			
 			if v.pref.is_stats {
 				cgen.genln('BenchedTests_end_testing(&bt);')
 			}

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -494,7 +494,7 @@ pub fn (v mut V) generate_main() {
 			if v.table.main_exists() {
 				verror('test files cannot have function `main`')
 			}
-			test_fn_names := v.table.all_test_function_names()
+			testsuite_begin_name, test_fn_names, testsuite_end_name := v.table.all_test_function_names()
 			if test_fn_names.len == 0 {
 				verror('test files need to have at least one test function')
 			}
@@ -502,6 +502,9 @@ pub fn (v mut V) generate_main() {
 			v.gen_main_start(false)
 			if v.pref.is_stats {
 				cgen.genln('BenchedTests bt = main__start_testing(${test_fn_names.len},tos3("$v.pref.path"));')
+			}
+			if testsuite_begin_name.len > 0 {
+				cgen.genln('${testsuite_begin_name}();')
 			}
 			for tfname in test_fn_names {
 				if v.pref.is_stats {
@@ -512,6 +515,9 @@ pub fn (v mut V) generate_main() {
 					cgen.genln('BenchedTests_testing_step_end(&bt);')
 				}
 			}
+			if testsuite_end_name.len > 0 {
+				cgen.genln('${testsuite_end_name}();')
+			}			
 			if v.pref.is_stats {
 				cgen.genln('BenchedTests_end_testing(&bt);')
 			}

--- a/vlib/compiler/table.v
+++ b/vlib/compiler/table.v
@@ -828,11 +828,9 @@ fn (t &Table) all_test_function_names() []string {
 			fn_test_names << f.name
 		}
 		else if f.name.contains('__testsuite_begin') {
-			is_begin_test = true
 			fn_begin_test_name = f.name
 		}
 		else if f.name.contains('__testsuite_end') {
-			is_end_test = true
 			fn_end_test_name = f.name
 		}
 	}

--- a/vlib/compiler/table.v
+++ b/vlib/compiler/table.v
@@ -825,6 +825,7 @@ fn (t &Table) all_test_function_names() []string {
 			res << f.name
 		}
 	}
+	res.sort()
 	return res
 }
 
@@ -1142,4 +1143,3 @@ fn type_cat_str(tc TypeCategory) string {
 			'unknown'}}
 	return tc_str
 }
-

--- a/vlib/compiler/table.v
+++ b/vlib/compiler/table.v
@@ -819,14 +819,42 @@ fn (t &Table) main_exists() bool {
 }
 
 fn (t &Table) all_test_function_names() []string {
-	mut res := []string
+	mut is_begin_test := false
+	mut fn_begin_test_name := ''
+	mut is_end_test := false
+	mut fn_end_test_name := ''
+
+	mut fn_test_names := []string
 	for _, f in t.fns {
 		if f.name.contains('__test_') {
-			res << f.name
+			fn_test_names << f.name
+		}
+		else if f.name.contains('__begin_test') {
+			is_begin_test = true
+			fn_begin_test_name = f.name
+		}
+		else if f.name.contains('__end_test') {
+			is_end_test = true
+			fn_end_test_name = f.name
 		}
 	}
-	res.sort()
-	return res
+
+	if is_begin_test {
+		mut fn_names := []string
+		fn_names << fn_begin_test_name
+		fn_names << fn_test_names
+		if is_end_test {
+			fn_names << fn_end_test_name
+		}
+
+		return fn_names
+	}
+	else {
+		if is_end_test {
+			fn_test_names << fn_end_test_name
+		}
+		return fn_test_names
+	}
 }
 
 fn (t &Table) find_const(name string) ?Var {

--- a/vlib/compiler/table.v
+++ b/vlib/compiler/table.v
@@ -818,8 +818,10 @@ fn (t &Table) main_exists() bool {
 	return false
 }
 
-fn (t &Table) all_test_function_names() (string, []string, string) {
+fn (t &Table) all_test_function_names() []string {
+	mut is_begin_test := false
 	mut fn_begin_test_name := ''
+	mut is_end_test := false
 	mut fn_end_test_name := ''
 
 	mut fn_test_names := []string
@@ -828,13 +830,31 @@ fn (t &Table) all_test_function_names() (string, []string, string) {
 			fn_test_names << f.name
 		}
 		else if f.name.contains('__testsuite_begin') {
+			is_begin_test = true
 			fn_begin_test_name = f.name
 		}
 		else if f.name.contains('__testsuite_end') {
+			is_end_test = true
 			fn_end_test_name = f.name
 		}
 	}
-	return fn_begin_test_name, fn_test_names, fn_end_test_name
+
+	if is_begin_test {
+		mut fn_names := []string
+		fn_names << fn_begin_test_name
+		fn_names << fn_test_names
+		if is_end_test {
+			fn_names << fn_end_test_name
+		}
+
+		return fn_names
+	}
+	else {
+		if is_end_test {
+			fn_test_names << fn_end_test_name
+		}
+		return fn_test_names
+	}
 }
 
 fn (t &Table) find_const(name string) ?Var {

--- a/vlib/compiler/table.v
+++ b/vlib/compiler/table.v
@@ -818,10 +818,8 @@ fn (t &Table) main_exists() bool {
 	return false
 }
 
-fn (t &Table) all_test_function_names() []string {
-	mut is_begin_test := false
+fn (t &Table) all_test_function_names() (string, []string, string) {
 	mut fn_begin_test_name := ''
-	mut is_end_test := false
 	mut fn_end_test_name := ''
 
 	mut fn_test_names := []string
@@ -830,31 +828,13 @@ fn (t &Table) all_test_function_names() []string {
 			fn_test_names << f.name
 		}
 		else if f.name.contains('__testsuite_begin') {
-			is_begin_test = true
 			fn_begin_test_name = f.name
 		}
 		else if f.name.contains('__testsuite_end') {
-			is_end_test = true
 			fn_end_test_name = f.name
 		}
 	}
-
-	if is_begin_test {
-		mut fn_names := []string
-		fn_names << fn_begin_test_name
-		fn_names << fn_test_names
-		if is_end_test {
-			fn_names << fn_end_test_name
-		}
-
-		return fn_names
-	}
-	else {
-		if is_end_test {
-			fn_test_names << fn_end_test_name
-		}
-		return fn_test_names
-	}
+	return fn_begin_test_name, fn_test_names, fn_end_test_name
 }
 
 fn (t &Table) find_const(name string) ?Var {

--- a/vlib/compiler/table.v
+++ b/vlib/compiler/table.v
@@ -829,11 +829,11 @@ fn (t &Table) all_test_function_names() []string {
 		if f.name.contains('__test_') {
 			fn_test_names << f.name
 		}
-		else if f.name.contains('__begin_test') {
+		else if f.name.contains('__testsuite_begin') {
 			is_begin_test = true
 			fn_begin_test_name = f.name
 		}
-		else if f.name.contains('__end_test') {
+		else if f.name.contains('__testsuite_end') {
 			is_end_test = true
 			fn_end_test_name = f.name
 		}

--- a/vlib/compiler/table.v
+++ b/vlib/compiler/table.v
@@ -821,7 +821,7 @@ fn (t &Table) main_exists() bool {
 fn (t &Table) all_test_function_names() []string {
 	mut fn_begin_test_name := ''
 	mut fn_end_test_name := ''
-	
+
 	mut fn_test_names := []string
 	for _, f in t.fns {
 		if f.name.contains('__test_') {
@@ -843,7 +843,7 @@ fn (t &Table) all_test_function_names() []string {
 		res << fn_end_test_name
 	}
 	return res
-}  
+}
 
 fn (t &Table) find_const(name string) ?Var {
 	// println('find const l=$t.consts.len')

--- a/vlib/compiler/table.v
+++ b/vlib/compiler/table.v
@@ -819,11 +819,9 @@ fn (t &Table) main_exists() bool {
 }
 
 fn (t &Table) all_test_function_names() []string {
-	mut is_begin_test := false
 	mut fn_begin_test_name := ''
-	mut is_end_test := false
 	mut fn_end_test_name := ''
-
+	
 	mut fn_test_names := []string
 	for _, f in t.fns {
 		if f.name.contains('__test_') {
@@ -838,24 +836,16 @@ fn (t &Table) all_test_function_names() []string {
 			fn_end_test_name = f.name
 		}
 	}
-
-	if is_begin_test {
-		mut fn_names := []string
-		fn_names << fn_begin_test_name
-		fn_names << fn_test_names
-		if is_end_test {
-			fn_names << fn_end_test_name
-		}
-
-		return fn_names
+	mut res := []string
+	if fn_begin_test_name.len > 0 {
+		res << fn_begin_test_name
 	}
-	else {
-		if is_end_test {
-			fn_test_names << fn_end_test_name
-		}
-		return fn_test_names
+	res << fn_test_names
+	if fn_end_test_name.len > 0 {
+		res << fn_end_test_name
 	}
-}
+	return res
+}  
 
 fn (t &Table) find_const(name string) ?Var {
 	// println('find const l=$t.consts.len')

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -624,7 +624,7 @@ pub fn rmdir(path string) {
 
 pub fn rmdir_recursive(path string) {
 	items := os.ls(path) or {
-		panic(err)
+		return
 	}
 	for item in items {
 		if os.is_dir(filepath.join(path,item)) {
@@ -637,7 +637,7 @@ pub fn rmdir_recursive(path string) {
 
 pub fn is_dir_empty(path string) bool {
 	items := os.ls(path) or {
-		panic(err)
+		return true
 	}
 	return items.len == 0
 }

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -3,14 +3,12 @@ import (
 	filepath
 )
 
-fn test_aaa_setup() {
+fn begin_test() {
 	cleanup_leftovers()
-	assert true
 }
 
-fn test_zzz_cleanup() {
+fn end_test() {
 	cleanup_leftovers()
-	assert true
 }
 
 fn test_setenv() {

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -3,11 +3,11 @@ import (
 	filepath
 )
 
-fn begin_test() {
+fn testsuite_begin() {
 	cleanup_leftovers()
 }
 
-fn end_test() {
+fn testsuite_end() {
 	cleanup_leftovers()
 }
 

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -1,10 +1,14 @@
 import (
 	os
 	filepath
-	time
 )
 
 fn test_aaa_setup() {
+	cleanup_leftovers()
+	assert true
+}
+
+fn test_zzz_cleanup() {
 	cleanup_leftovers()
 	assert true
 }
@@ -293,10 +297,4 @@ fn cleanup_leftovers() {
 	os.rmdir_recursive('ex2')
 	os.rm('ex1.txt')
 	os.rm('ex2.txt')
-}
-
-fn test_zzz_cleanup() {
-	time.sleep(1)
-	cleanup_leftovers()
-	assert true
 }

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -1,7 +1,10 @@
-import os
-import filepath
+import (
+	os
+	filepath
+	time
+)
 
-fn test_aaa_setup(){
+fn test_aaa_setup() {
 	cleanup_leftovers()
 	assert true
 }
@@ -240,11 +243,6 @@ fn test_make_symlink_check_is_link_and_remove_symlink() {
 //  }
 //}
 
-fn test_zzz_cleanup(){
-	cleanup_leftovers() assert true
-}
-
-
 fn test_symlink() {
   $if windows { return }
   os.mkdir('symlink') or { panic(err) }
@@ -285,18 +283,20 @@ fn test_is_executable_writable_readable() {
 // this function is called by both test_aaa_setup & test_zzz_cleanup
 // it ensures that os tests do not polute the filesystem with leftover
 // files so that they can be run several times in a row.
-fn cleanup_leftovers(){
+fn cleanup_leftovers() {
 	// possible leftovers from test_cp
 	os.rm('cp_example.txt')
 	os.rm('cp_new_example.txt')
 
 	// possible leftovers from test_cp_r
-	os.rm('ex/ex2/ex2.txt')
-	os.rmdir('ex/ex2')
-	os.rm('ex/ex1.txt')
-	os.rmdir('ex')
-	os.rm('ex2/ex2.txt')
-	os.rmdir('ex2')
+	os.rmdir_recursive('ex')
+	os.rmdir_recursive('ex2')
 	os.rm('ex1.txt')
 	os.rm('ex2.txt')
+}
+
+fn test_zzz_cleanup() {
+	time.sleep(1)
+	cleanup_leftovers()
+	assert true
 }


### PR DESCRIPTION
This PR fix os_test.v.

Issue:
- After run `v test-compiler`, temp directories `ex` `ex2` and files will not clear up.

Analyze the cause:
- `os_test.v` use `test_aaa_setup()` to clear up temp dirs and files at first.
- `os_test.v` use `test_zzz_cleanup()` to clear up temp dirs and files at end.
- But map change to `hashmap`, so `table.fns` is not sorted.

To solve this issue, sort `[]fns.name` in `table.all_test_function_names()`.

Others:
- Use `os.rmdir_recursive` to clear up temp dirs.
- `rmdir_recursive` just return when dir is not exists.
- `os.is_dir_empty` never panic when dir is not exists, just return `true`.
