### PR TITLE
Remove malloc unsafe warning

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -681,28 +681,30 @@ pub fn get_line() string {
 // get_raw_line returns a one-line string from stdin along with '\n' if there is any
 pub fn get_raw_line() string {
 	$if windows {
-		max_line_chars := 256
-		buf := malloc(max_line_chars * 2)
-		h_input := C.GetStdHandle(STD_INPUT_HANDLE)
-		mut bytes_read := 0
-		if is_atty(0) > 0 {
-			C.ReadConsole(h_input, buf, max_line_chars * 2, &bytes_read, 0)
-			return string_from_wide2(&u16(buf), bytes_read)
-		}
-		mut offset := 0
-		for {
-			pos := buf + offset
-			res := C.ReadFile(h_input, pos, 1, &bytes_read, 0)
-			if !res || bytes_read == 0 {
-           			break
+		unsafe {
+			max_line_chars := 256
+			buf := malloc(max_line_chars * 2)
+			h_input := C.GetStdHandle(STD_INPUT_HANDLE)
+			mut bytes_read := 0
+			if is_atty(0) > 0 {
+				C.ReadConsole(h_input, buf, max_line_chars * 2, &bytes_read, 0)
+				return string_from_wide2(&u16(buf), bytes_read)
 			}
-			if *pos == `\n` || *pos == `\r` {
+			mut offset := 0
+			for {
+				pos := buf + offset
+				res := C.ReadFile(h_input, pos, 1, &bytes_read, 0)
+				if !res || bytes_read == 0 {
+						break
+				}
+				if *pos == `\n` || *pos == `\r` {
+					offset++
+					break
+				}
 				offset++
-				break
 			}
-			offset++
+			return string(buf, offset)
 		}
-		return string(buf, offset)
 	} $else {
 		max := size_t(0)
 		mut buf := byteptr(0)

--- a/vlib/os/os_windows.v
+++ b/vlib/os/os_windows.v
@@ -207,21 +207,23 @@ pub fn get_file_handle(path string) HANDLE {
 // get_module_filename retrieves the fully qualified path for the file that contains the specified module.
 // The module must have been loaded by the current process.
 pub fn get_module_filename(handle HANDLE) ?string {
-    mut sz := 4096 // Optimized length
-    mut buf := &u16(malloc(4096))
-    for {
-        status := int(C.GetModuleFileNameW(handle, voidptr(&buf), sz))
-        match status {
-            SUCCESS {
-                _filename := string_from_wide2(buf, sz)
-                return _filename
-            }
-            else {
-                // Must handled with GetLastError and converted by FormatMessage
-                return error('Cannot get file name from handle')
-            }
-        }
-    }
+	unsafe {
+		mut sz := 4096 // Optimized length
+		mut buf := &u16(malloc(4096))
+		for {
+			status := int(C.GetModuleFileNameW(handle, voidptr(&buf), sz))
+			match status {
+				SUCCESS {
+					_filename := string_from_wide2(buf, sz)
+					return _filename
+				}
+				else {
+					// Must handled with GetLastError and converted by FormatMessage
+					return error('Cannot get file name from handle')
+				}
+			}
+		}
+	}
     panic('this should be unreachable') // TODO remove unreachable after loop
 }
 


### PR DESCRIPTION
This PR is to remove malloc unsafe warning.

- Add `unsafe{}` in `vlib/os.v` (`get_raw_line()`).
- Add `unsafe{}` in `vlib/os_windows.v` (`get_module_filename()`).
- Add `unsafe{}` in `vlib/compiler/msvc.v` ( `find_windows_kit_internal()`).