### PR TITLE
optimize os_windows.v

### DIFF
--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -51,6 +51,18 @@ fn test_open_file() {
   os.rm(filename)
 }
 
+fn test_create_file() {
+	filename := './test1.txt'
+	hello := 'hello world!'
+	mut f := os.create(filename) or { panic(err)}
+	f.write(hello)
+	f.close()
+
+	assert hello.len == os.file_size(filename)
+
+	os.rm(filename)
+}
+
 fn test_write_and_read_string_to_file() {
   filename := './test1.txt'
   hello := 'hello world!'

--- a/vlib/os/os_windows.v
+++ b/vlib/os/os_windows.v
@@ -135,27 +135,20 @@ pub fn is_dir(path string) bool {
 */
 
 pub fn open(path string) ?File {
-	mut file := File{}
-	wpath := path.to_wide()
-	mode := 'rb'
-	file = File{
-		cfile: C._wfopen(wpath, mode.to_wide())
+	file := File {
+		cfile: C._wfopen(path.to_wide(), 'rb'.to_wide())
+		opened: true
 	}
 	if isnil(file.cfile) {
 		return error('failed to open file "$path"')
 	}
-	file.opened = true
 	return file
 }
 
-
-
 // create creates a file at a specified location and returns a writable `File` object.
 pub fn create(path string) ?File {
-	wpath := path.replace('/', '\\').to_wide()
-	mode := 'wb'
-	file := File{
-		cfile: C._wfopen(wpath, mode.to_wide())
+	file := File {
+		cfile: C._wfopen(path.to_wide(), 'wb'.to_wide())
 		opened: true
 	}
 	if isnil(file.cfile) {


### PR DESCRIPTION
This PR is to optimize `os_windows.v`.

- simplify `os.open()` and `os.create()` in windows platform.
- remove filepath separator replacement, no need to do it.

