### PR TITLE
Enable 0oxx to handle octal

### DIFF
--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -113,3 +113,10 @@ fn test_hex() {
 	x := u64(10)
 	assert x.hex() == '0xa'
 }
+
+fn test_oct() {
+	x1 := 0o12
+	assert x1 == 10
+	x2 := 012
+	assert x2 == 10
+}

--- a/vlib/compiler/scanner.v
+++ b/vlib/compiler/scanner.v
@@ -122,7 +122,7 @@ fn filter_num_sep(txt byteptr, start int, end int) string {
 	mut i := start
 	mut i1 := 0
 	for i < end {
-		if txt[i] != num_sep {
+		if txt[i] != num_sep && txt[i] != `o` {
 			b[i1]=txt[i]
 			i1++
 		}
@@ -172,17 +172,13 @@ fn (s mut Scanner) ident_hex_number() string {
 
 fn (s mut Scanner) ident_oct_number() string {
 	start_pos := s.pos
+	s.pos += 2 // skip '0o'
 	for {
 		if s.pos >= s.text.len {
 			break
 		}
 		c := s.text[s.pos]
-		if c.is_digit() {
-			if !c.is_oct_digit() && c != num_sep {
-				s.error('malformed octal constant')
-			}
-		}
-		else {
+		if !c.is_oct_digit() && c != num_sep {
 			break
 		}
 		s.pos++
@@ -253,11 +249,11 @@ fn (s mut Scanner) ident_number() string {
 	if s.expect('0x', s.pos) {
 		return s.ident_hex_number()
 	}
+	if s.expect('0o', s.pos) {
+		return s.ident_oct_number()
+	}
 	if s.expect('0.', s.pos) || s.expect('0e', s.pos) {
 		return s.ident_dec_number()
-	}
-	if s.text[s.pos] == `0` {
-		return s.ident_oct_number()
 	}
 	return s.ident_dec_number()
 }

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -116,7 +116,7 @@ fn filter_num_sep(txt byteptr, start int, end int) string {
 		mut i := start
 		mut i1 := 0
 		for i < end {
-			if txt[i] != num_sep {
+			if txt[i] != num_sep && txt[i] != `o` {
 				b[i1] = txt[i]
 				i1++
 			}
@@ -168,17 +168,13 @@ fn (s mut Scanner) ident_hex_number() string {
 
 fn (s mut Scanner) ident_oct_number() string {
 	start_pos := s.pos
+	s.pos += 2 // skip '0o'
 	for {
 		if s.pos >= s.text.len {
 			break
 		}
 		c := s.text[s.pos]
-		if c.is_digit() {
-			if !c.is_oct_digit() && c != num_sep {
-				s.error('malformed octal constant')
-			}
-		}
-		else {
+		if !c.is_oct_digit() && c != num_sep {
 			break
 		}
 		s.pos++
@@ -247,11 +243,11 @@ fn (s mut Scanner) ident_number() string {
 	if s.expect('0x', s.pos) {
 		return s.ident_hex_number()
 	}
+	if s.expect('0o', s.pos) {
+		return s.ident_oct_number()
+	}
 	if s.expect('0.', s.pos) || s.expect('0e', s.pos) {
 		return s.ident_dec_number()
-	}
-	if s.text[s.pos] == `0` {
-		return s.ident_oct_number()
 	}
 	return s.ident_dec_number()
 }


### PR DESCRIPTION
This PR enable `0oxxx` to handle octal.

*issue:*

```
num := 0o012
```

Its show error at compile time.

To solve this issue:
- add related octal process.
- add test in `int_test.v`.
