### PR TITLE
fmt: process assignment statement correctly

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -106,10 +106,11 @@ fn (f mut Fmt) stmt(node ast.Stmt) {
 					f.write(', ')
 				}
 			}
-			f.write(' = ')
+			f.write(' $it.op.str() ')
 			for right in it.right {
 				f.expr(right)
 			}
+			f.writeln('')
 		}
 		ast.BranchStmt {
 			match it.tok.kind {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1450,11 +1450,13 @@ pub fn (p mut Parser) assign_stmt() ast.AssignStmt {
 			break
 		}
 	}
+	op := p.tok.kind
 	p.next() // :=, =
 	expr,_ := p.expr(0)
 	return ast.AssignStmt{
 		left: idents
 		right: [expr]
+		op: op
 	}
 }
 


### PR DESCRIPTION
Use proper operator in assignment statement.
Add EOL at the end of assignment statement.