### PR TITLE
tool: setup thirdparty 'freetype'.

### DIFF
--- a/cmd/tools/vsetup-freetype.v
+++ b/cmd/tools/vsetup-freetype.v
@@ -1,0 +1,29 @@
+module main
+
+import (
+	os
+	filepath
+	v.pref
+)
+
+fn main() {
+	$if windows {
+		println('Setup freetype...')
+		vroot := filepath.dir(pref.vexe_path())
+		os.chdir(vroot)
+
+		if os.is_dir('./thirdparty/freetype') {
+			println('Thirdparty "freetype" is already installed.')
+		}
+		else {
+			s := os.exec('git clone --depth=1 https://github.com/ubawurinna/freetype-windows-binaries ./thirdparty/freetype/') or {
+				panic(err)
+			}
+			println(s.output)
+			println('Thirdparty "freetype" installed successfully.')
+		}
+	}
+	$else {
+		println('It is only for windows to setup thirdparty "freetype".')
+	}
+}

--- a/cmd/tools/vsetup-freetype.v
+++ b/cmd/tools/vsetup-freetype.v
@@ -24,6 +24,6 @@ fn main() {
 		}
 	}
 	$else {
-		println('It is only for windows to setup thirdparty "freetype".')
+		println('It is only for Windows to setup thirdparty "freetype".')
 	}
 }

--- a/cmd/v/internal/help/doc_help.v
+++ b/cmd/v/internal/help/doc_help.v
@@ -34,6 +34,8 @@ The commands are:
    test              run all test files in the provided directory
    test-fmt          test if all files in the current directory is formatted properly
    test-compiler     run the V self-test suite to make sure V is working properly
+   
+   setup-freetype    setup thirdparty freetype on windows
 
 For a comprehensive list of options, please refer to `v help --verbose`.'
 //Use "v help <command>" for more information about a command.'
@@ -116,6 +118,7 @@ Commands:
   doc               Run vdoc over the source code and produce documentation.
   translate         Translates C to V. [wip, will be available in V 0.3]
   create            Create a new v project interactively. Answer the questions, and run it with `v run projectname`
+  setup-freetype    Setup thirdparty freetype on windows.
 
 V package management commands:
   search  keywords  Search the https://vpm.vlang.io/ module repository for matching modules and shows their details.
@@ -128,4 +131,3 @@ V package management commands:
 - To disable automatic formatting:
 v -nofmt file.v
 */
-

--- a/cmd/v/internal/help/doc_help.v
+++ b/cmd/v/internal/help/doc_help.v
@@ -34,8 +34,8 @@ The commands are:
    test              run all test files in the provided directory
    test-fmt          test if all files in the current directory is formatted properly
    test-compiler     run the V self-test suite to make sure V is working properly
-   
-   setup-freetype    setup thirdparty freetype on windows
+
+   setup-freetype    setup thirdparty freetype on Windows
 
 For a comprehensive list of options, please refer to `v help --verbose`.'
 //Use "v help <command>" for more information about a command.'
@@ -118,7 +118,7 @@ Commands:
   doc               Run vdoc over the source code and produce documentation.
   translate         Translates C to V. [wip, will be available in V 0.3]
   create            Create a new v project interactively. Answer the questions, and run it with `v run projectname`
-  setup-freetype    Setup thirdparty freetype on windows.
+  setup-freetype    Setup thirdparty freetype on Windows.
 
 V package management commands:
   search  keywords  Search the https://vpm.vlang.io/ module repository for matching modules and shows their details.

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -18,7 +18,8 @@ const (
 	'test', 'test-fmt', 'test-compiler',
 	'bin2v',
 	'repl',
-	'build-tools', 'build-examples', 'build-vbinaries']
+	'build-tools', 'build-examples', 'build-vbinaries',
+	'setup-freetype']
 )
 
 fn main() {


### PR DESCRIPTION
This PR add tool for setup thirdparty `freetype` on Windows.

Command: `v setup-freetype`.

- Add `vsetup-freetype.v` module.
- Add comment in command help doc.
