### PR TITLE
fmt: process RangeExpr properly

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -425,9 +425,11 @@ fn (f mut Fmt) index_expr(node ast.IndexExpr) {
 		ast.RangeExpr {
 			is_range = true
 			f.expr(node.left)
+			f.write('[')
+			f.expr(it.low)
 			f.write('..')
 			f.expr(it.high)
-			f.write(')')
+			f.write(']')
 		}
 		else {}
 	}

--- a/vlib/v/fmt/tests/simple_expected.vv
+++ b/vlib/v/fmt/tests/simple_expected.vv
@@ -41,6 +41,10 @@ fn new_user() User {
 	}
 }
 
+fn fn_contains_range_expr() {
+	a := 1 in arr[0..2]
+}
+
 fn voidfn() {
 	println('this is a function that does not return anything')
 }

--- a/vlib/v/fmt/tests/simple_input.vv
+++ b/vlib/v/fmt/tests/simple_input.vv
@@ -45,6 +45,10 @@ User
            }
 }
 
+fn fn_contains_range_expr() {
+	a:=1 in arr[0..2]
+}
+
 fn   voidfn(){
  println('this is a function that does not return anything')
    }
@@ -103,4 +107,3 @@ reserved_types = {
          'i128': true
 }
 )
-


### PR DESCRIPTION
Previously fmt processed `arr[0..3]` to `arr..3)`.