### PR TITLE
scanner: fix special case - 0 at the end 

### DIFF
--- a/vlib/compiler/scanner.v
+++ b/vlib/compiler/scanner.v
@@ -354,7 +354,7 @@ fn (s mut Scanner) scan() ScanRes {
 			}
 			mut prefix_zero_num := start_pos - s.pos  // how many prefix zeros should be jumped
 			// for 0b, 0o, 0x the heading zero shouldn't be jumped
-			if c == `0` && start_pos < s.text.len && !s.text[start_pos].is_digit() {
+			if start_pos == s.text.len || (c == `0` && !s.text[start_pos].is_digit()) {
 				prefix_zero_num--
 			}
 			s.pos += prefix_zero_num  // jump these zeros

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -348,7 +348,7 @@ pub fn (s mut Scanner) scan() token.Token {
 			}
 			mut prefix_zero_num := start_pos - s.pos  // how many prefix zeros should be jumped
 			// for 0b, 0o, 0x the heading zero shouldn't be jumped
-			if c == `0` && start_pos < s.text.len && !s.text[start_pos].is_digit() {
+			if start_pos == s.text.len || (c == `0` && !s.text[start_pos].is_digit()) {
 				prefix_zero_num--
 			}
 			s.pos += prefix_zero_num  // jump these zeros


### PR DESCRIPTION
This PR is a minor fix of #3816 (scanner: make `0o` prefix the only way to define octals).
It targets the special case that `0` is at the end of a file.
