### PR TITLE
scanner: fix bin/oct/hex without number parts

### DIFF
--- a/vlib/compiler/scanner.v
+++ b/vlib/compiler/scanner.v
@@ -148,7 +148,7 @@ fn (s mut Scanner) ident_bin_number() string {
 		s.pos++
 	}
 	if start_pos + 2 == s.pos {
-		s.error('Number part of this binary is not provided.')
+		s.error('number part of this binary is not provided')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
 	s.pos--
@@ -169,7 +169,7 @@ fn (s mut Scanner) ident_hex_number() string {
 		s.pos++
 	}
 	if start_pos + 2 == s.pos {
-		s.error('Number part of this hexadecimal is not provided.')
+		s.error('number part of this hexadecimal is not provided')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
 	s.pos--
@@ -190,7 +190,7 @@ fn (s mut Scanner) ident_oct_number() string {
 		s.pos++
 	}
 	if start_pos + 2 == s.pos {
-		s.error('Number part of this octal is not provided.')
+		s.error('number part of this octal is not provided')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
 	s.pos--

--- a/vlib/compiler/scanner.v
+++ b/vlib/compiler/scanner.v
@@ -147,6 +147,9 @@ fn (s mut Scanner) ident_bin_number() string {
 		}
 		s.pos++
 	}
+	if start_pos + 2 == s.pos {
+		s.error('Number part of this binary is not provided.')
+	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
 	s.pos--
 	return number
@@ -165,6 +168,9 @@ fn (s mut Scanner) ident_hex_number() string {
 		}
 		s.pos++
 	}
+	if start_pos + 2 == s.pos {
+		s.error('Number part of this hexadecimal is not provided.')
+	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
 	s.pos--
 	return number
@@ -182,6 +188,9 @@ fn (s mut Scanner) ident_oct_number() string {
 			break
 		}
 		s.pos++
+	}
+	if start_pos + 2 == s.pos {
+		s.error('Number part of this octal is not provided.')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
 	s.pos--

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -143,6 +143,9 @@ fn (s mut Scanner) ident_bin_number() string {
 		}
 		s.pos++
 	}
+	if start_pos + 2 == s.pos {
+		s.error('Number part of this binary is not provided.')
+	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
 	s.pos--
 	return number
@@ -161,6 +164,9 @@ fn (s mut Scanner) ident_hex_number() string {
 		}
 		s.pos++
 	}
+	if start_pos + 2 == s.pos {
+		s.error('Number part of this hexadecimal is not provided.')
+	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
 	s.pos--
 	return number
@@ -178,6 +184,9 @@ fn (s mut Scanner) ident_oct_number() string {
 			break
 		}
 		s.pos++
+	}
+	if start_pos + 2 == s.pos {
+		s.error('Number part of this octal is not provided.')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
 	s.pos--

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -144,7 +144,7 @@ fn (s mut Scanner) ident_bin_number() string {
 		s.pos++
 	}
 	if start_pos + 2 == s.pos {
-		s.error('Number part of this binary is not provided.')
+		s.error('number part of this binary is not provided')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
 	s.pos--
@@ -165,7 +165,7 @@ fn (s mut Scanner) ident_hex_number() string {
 		s.pos++
 	}
 	if start_pos + 2 == s.pos {
-		s.error('Number part of this hexadecimal is not provided.')
+		s.error('number part of this hexadecimal is not provided')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
 	s.pos--
@@ -186,7 +186,7 @@ fn (s mut Scanner) ident_oct_number() string {
 		s.pos++
 	}
 	if start_pos + 2 == s.pos {
-		s.error('Number part of this octal is not provided.')
+		s.error('number part of this octal is not provided')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
 	s.pos--


### PR DESCRIPTION
This PR fixes bin/oct/hex without any number part, i.e. the bare `0b`, `0o`, `0x`.
Before this PR `0b` and `0x` give C code error and `0o` wrongly gives 0.
After this PR they all result in errors.
