### PR TITLE
scanner: add check for bin/oct/hex with wrong digits

### DIFF
--- a/vlib/compiler/scanner.v
+++ b/vlib/compiler/scanner.v
@@ -135,6 +135,8 @@ len:i1}
 }
 
 fn (s mut Scanner) ident_bin_number() string {
+	mut has_wrong_digit := false
+	mut first_wrong_digit := `\0`
 	start_pos := s.pos
 	s.pos += 2 // skip '0b'
 	for {
@@ -142,13 +144,20 @@ fn (s mut Scanner) ident_bin_number() string {
 			break
 		}
 		c := s.text[s.pos]
-		if !c.is_bin_digit() && c != num_sep {
+		if !c.is_digit() && !c.is_letter() && c != num_sep {
 			break
+		}
+		if !has_wrong_digit && !c.is_bin_digit() {
+			has_wrong_digit = true
+			first_wrong_digit = c
 		}
 		s.pos++
 	}
 	if start_pos + 2 == s.pos {
 		s.error('number part of this binary is not provided')
+	}
+	if has_wrong_digit {
+		s.error('this binary number has unsuitable digit `${first_wrong_digit.str()}`')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
 	s.pos--
@@ -156,6 +165,8 @@ fn (s mut Scanner) ident_bin_number() string {
 }
 
 fn (s mut Scanner) ident_hex_number() string {
+	mut has_wrong_digit := false
+	mut first_wrong_digit := `\0`
 	start_pos := s.pos
 	s.pos += 2 // skip '0x'
 	for {
@@ -163,13 +174,20 @@ fn (s mut Scanner) ident_hex_number() string {
 			break
 		}
 		c := s.text[s.pos]
-		if !c.is_hex_digit() && c != num_sep {
+		if !c.is_digit() && !c.is_letter() && c != num_sep {
 			break
+		}
+		if !has_wrong_digit && !c.is_hex_digit() {
+			has_wrong_digit = true
+			first_wrong_digit = c
 		}
 		s.pos++
 	}
 	if start_pos + 2 == s.pos {
 		s.error('number part of this hexadecimal is not provided')
+	}
+	if has_wrong_digit {
+		s.error('this hexadecimal number has unsuitable digit `${first_wrong_digit.str()}`')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
 	s.pos--
@@ -177,6 +195,8 @@ fn (s mut Scanner) ident_hex_number() string {
 }
 
 fn (s mut Scanner) ident_oct_number() string {
+	mut has_wrong_digit := false
+	mut first_wrong_digit := `\0`
 	start_pos := s.pos
 	s.pos += 2 // skip '0o'
 	for {
@@ -184,13 +204,20 @@ fn (s mut Scanner) ident_oct_number() string {
 			break
 		}
 		c := s.text[s.pos]
-		if !c.is_oct_digit() && c != num_sep {
+		if !c.is_digit() && !c.is_letter() && c != num_sep {
 			break
+		}
+		if !has_wrong_digit && !c.is_oct_digit() {
+			has_wrong_digit = true
+			first_wrong_digit = c
 		}
 		s.pos++
 	}
 	if start_pos + 2 == s.pos {
 		s.error('number part of this octal is not provided')
+	}
+	if has_wrong_digit {
+		s.error('this octal number has unsuitable digit `${first_wrong_digit.str()}`')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
 	s.pos--

--- a/vlib/compiler/scanner.v
+++ b/vlib/compiler/scanner.v
@@ -156,7 +156,7 @@ fn (s mut Scanner) ident_bin_number() string {
 	if start_pos + 2 == s.pos {
 		s.error('number part of this binary is not provided')
 	}
-	if has_wrong_digit {
+	else if has_wrong_digit {
 		s.error('this binary number has unsuitable digit `${first_wrong_digit.str()}`')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
@@ -186,7 +186,7 @@ fn (s mut Scanner) ident_hex_number() string {
 	if start_pos + 2 == s.pos {
 		s.error('number part of this hexadecimal is not provided')
 	}
-	if has_wrong_digit {
+	else if has_wrong_digit {
 		s.error('this hexadecimal number has unsuitable digit `${first_wrong_digit.str()}`')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
@@ -216,7 +216,7 @@ fn (s mut Scanner) ident_oct_number() string {
 	if start_pos + 2 == s.pos {
 		s.error('number part of this octal is not provided')
 	}
-	if has_wrong_digit {
+	else if has_wrong_digit {
 		s.error('this octal number has unsuitable digit `${first_wrong_digit.str()}`')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)

--- a/vlib/compiler/scanner.v
+++ b/vlib/compiler/scanner.v
@@ -144,12 +144,14 @@ fn (s mut Scanner) ident_bin_number() string {
 			break
 		}
 		c := s.text[s.pos]
-		if !c.is_digit() && !c.is_letter() && c != num_sep {
-			break
-		}
-		if !has_wrong_digit && !c.is_bin_digit() {
-			has_wrong_digit = true
-			first_wrong_digit = c
+		if !c.is_bin_digit() && c != num_sep {
+			if !c.is_digit() && !c.is_letter() {
+				break
+			} 
+			else if !has_wrong_digit {
+				has_wrong_digit = true
+				first_wrong_digit = c
+			}
 		}
 		s.pos++
 	}
@@ -174,12 +176,14 @@ fn (s mut Scanner) ident_hex_number() string {
 			break
 		}
 		c := s.text[s.pos]
-		if !c.is_digit() && !c.is_letter() && c != num_sep {
-			break
-		}
-		if !has_wrong_digit && !c.is_hex_digit() {
-			has_wrong_digit = true
-			first_wrong_digit = c
+		if !c.is_hex_digit() && c != num_sep {
+			if !c.is_letter() {
+				break
+			} 
+			else if !has_wrong_digit {
+				has_wrong_digit = true
+				first_wrong_digit = c
+			}
 		}
 		s.pos++
 	}
@@ -204,12 +208,14 @@ fn (s mut Scanner) ident_oct_number() string {
 			break
 		}
 		c := s.text[s.pos]
-		if !c.is_digit() && !c.is_letter() && c != num_sep {
-			break
-		}
-		if !has_wrong_digit && !c.is_oct_digit() {
-			has_wrong_digit = true
-			first_wrong_digit = c
+		if !c.is_oct_digit() && c != num_sep {
+			if !c.is_digit() && !c.is_letter() {
+				break
+			} 
+			else if !has_wrong_digit {
+				has_wrong_digit = true
+				first_wrong_digit = c
+			}
 		}
 		s.pos++
 	}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -140,12 +140,14 @@ fn (s mut Scanner) ident_bin_number() string {
 			break
 		}
 		c := s.text[s.pos]
-		if !c.is_digit() && !c.is_letter() && c != num_sep {
-			break
-		}
-		if !has_wrong_digit && !c.is_bin_digit() {
-			has_wrong_digit = true
-			first_wrong_digit = c
+		if !c.is_bin_digit() && c != num_sep {
+			if !c.is_digit() && !c.is_letter() {
+				break
+			} 
+			else if !has_wrong_digit {
+				has_wrong_digit = true
+				first_wrong_digit = c
+			}
 		}
 		s.pos++
 	}
@@ -170,12 +172,14 @@ fn (s mut Scanner) ident_hex_number() string {
 			break
 		}
 		c := s.text[s.pos]
-		if !c.is_digit() && !c.is_letter() && c != num_sep {
-			break
-		}
-		if !has_wrong_digit && !c.is_hex_digit() {
-			has_wrong_digit = true
-			first_wrong_digit = c
+		if !c.is_hex_digit() && c != num_sep {
+			if !c.is_letter() {
+				break
+			} 
+			else if !has_wrong_digit {
+				has_wrong_digit = true
+				first_wrong_digit = c
+			}
 		}
 		s.pos++
 	}
@@ -200,12 +204,14 @@ fn (s mut Scanner) ident_oct_number() string {
 			break
 		}
 		c := s.text[s.pos]
-		if !c.is_digit() && !c.is_letter() && c != num_sep {
-			break
-		}
-		if !has_wrong_digit && !c.is_oct_digit() {
-			has_wrong_digit = true
-			first_wrong_digit = c
+		if !c.is_oct_digit() && c != num_sep {
+			if !c.is_digit() && !c.is_letter() {
+				break
+			} 
+			else if !has_wrong_digit {
+				has_wrong_digit = true
+				first_wrong_digit = c
+			}
 		}
 		s.pos++
 	}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -131,6 +131,8 @@ fn filter_num_sep(txt byteptr, start int, end int) string {
 }
 
 fn (s mut Scanner) ident_bin_number() string {
+	mut has_wrong_digit := false
+	mut first_wrong_digit := `\0`
 	start_pos := s.pos
 	s.pos += 2 // skip '0b'
 	for {
@@ -138,13 +140,20 @@ fn (s mut Scanner) ident_bin_number() string {
 			break
 		}
 		c := s.text[s.pos]
-		if !c.is_bin_digit() && c != num_sep {
+		if !c.is_digit() && !c.is_letter() && c != num_sep {
 			break
+		}
+		if !has_wrong_digit && !c.is_bin_digit() {
+			has_wrong_digit = true
+			first_wrong_digit = c
 		}
 		s.pos++
 	}
 	if start_pos + 2 == s.pos {
 		s.error('number part of this binary is not provided')
+	}
+	else if has_wrong_digit {
+		s.error('this binary number has unsuitable digit `${first_wrong_digit.str()}`')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
 	s.pos--
@@ -152,6 +161,8 @@ fn (s mut Scanner) ident_bin_number() string {
 }
 
 fn (s mut Scanner) ident_hex_number() string {
+	mut has_wrong_digit := false
+	mut first_wrong_digit := `\0`
 	start_pos := s.pos
 	s.pos += 2 // skip '0x'
 	for {
@@ -159,13 +170,20 @@ fn (s mut Scanner) ident_hex_number() string {
 			break
 		}
 		c := s.text[s.pos]
-		if !c.is_hex_digit() && c != num_sep {
+		if !c.is_digit() && !c.is_letter() && c != num_sep {
 			break
+		}
+		if !has_wrong_digit && !c.is_hex_digit() {
+			has_wrong_digit = true
+			first_wrong_digit = c
 		}
 		s.pos++
 	}
 	if start_pos + 2 == s.pos {
 		s.error('number part of this hexadecimal is not provided')
+	}
+	else if has_wrong_digit {
+		s.error('this hexadecimal number has unsuitable digit `${first_wrong_digit.str()}`')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
 	s.pos--
@@ -173,6 +191,8 @@ fn (s mut Scanner) ident_hex_number() string {
 }
 
 fn (s mut Scanner) ident_oct_number() string {
+	mut has_wrong_digit := false
+	mut first_wrong_digit := `\0`
 	start_pos := s.pos
 	s.pos += 2 // skip '0o'
 	for {
@@ -180,13 +200,20 @@ fn (s mut Scanner) ident_oct_number() string {
 			break
 		}
 		c := s.text[s.pos]
-		if !c.is_oct_digit() && c != num_sep {
+		if !c.is_digit() && !c.is_letter() && c != num_sep {
 			break
+		}
+		if !has_wrong_digit && !c.is_oct_digit() {
+			has_wrong_digit = true
+			first_wrong_digit = c
 		}
 		s.pos++
 	}
 	if start_pos + 2 == s.pos {
 		s.error('number part of this octal is not provided')
+	}
+	else if has_wrong_digit {
+		s.error('this octal number has unsuitable digit `${first_wrong_digit.str()}`')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
 	s.pos--


### PR DESCRIPTION
Before this PR, wrong numbers such as `0b3`, `0o1119`, `0xfffg` are not handled.
After this PR they result in errors.