### PR TITLE
scanner: fix special case - `e` or `E` at the end

### DIFF
--- a/vlib/compiler/scanner.v
+++ b/vlib/compiler/scanner.v
@@ -223,9 +223,10 @@ fn (s mut Scanner) ident_dec_number() string {
 	// scan exponential part
 	mut has_exponential_part := false
 	if s.expect('e', s.pos) || s.expect('E', s.pos) {
-		exp_start_pos := (s.pos++)
+		s.pos++
+		exp_start_pos := s.pos
 
-		if s.text[s.pos] in [`-`, `+`] {
+		if s.pos < s.text.len && s.text[s.pos] in [`-`, `+`] {
 			s.pos++
 		}
 

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -219,8 +219,9 @@ fn (s mut Scanner) ident_dec_number() string {
 	// scan exponential part
 	mut has_exponential_part := false
 	if s.expect('e', s.pos) || s.expect('E', s.pos) {
-		exp_start_pos := (s.pos++)
-		if s.text[s.pos] in [`-`, `+`] {
+		s.pos++
+		exp_start_pos := s.pos
+		if s.pos < s.text.len && s.text[s.pos] in [`-`, `+`] {
 			s.pos++
 		}
 		for s.pos < s.text.len && s.text[s.pos].is_digit() {


### PR DESCRIPTION
This PR fixes the special case that `e` or `E` is at the end of a file.
Before this PR, e.g., ` a := 123e` in REPL is not handled.
After this PR it gives an error.

**By-product**: I also fix a wrong line `b := (a++)` and find such syntax is not forbidden in V. See #3834.
