### PR TITLE
pg: Wrapped function in unsafe block

### DIFF
--- a/vlib/pg/pg.v
+++ b/vlib/pg/pg.v
@@ -121,16 +121,19 @@ pub fn (db DB) exec_one(query string) ?pg.Row {
 	return row
 }
 
-//
+// The entire function can be considered unsafe because of the malloc and the
+// free. This prevents warnings and doesn't seem to affect behavior.
 pub fn (db DB) exec_param_many(query string, params []string) []pg.Row {
-	mut param_vals := &byteptr( malloc( params.len * sizeof(byteptr) ) )
-	for i in 0..params.len {
-		param_vals[i] = params[i].str
+	unsafe {
+		mut param_vals := &byteptr( malloc( params.len * sizeof(byteptr) ) )
+		for i in 0..params.len {
+			param_vals[i] = params[i].str
+		}
+		res := C.PQexecParams(db.conn, query.str, params.len, 0, param_vals, 0, 0, 0)
+		free(param_vals)
+		return db.handle_error_or_result(res, 'exec_param_many')
 	}
-	res := C.PQexecParams(db.conn, query.str, params.len, 0, param_vals, 0, 0, 0)
-	unsafe{ free(param_vals) }
-	return db.handle_error_or_result(res, 'exec_param_many')
-}  
+}
 
 pub fn (db DB) exec_param2(query string, param, param2 string) []pg.Row {
 	mut param_vals := [2]byteptr


### PR DESCRIPTION
This removes warning about a malloc not being wrapped in an unsafe block.
`v test-compiler` has a few failures unrelated to this change.