### PR TITLE
doc: sort function names

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -22,7 +22,7 @@ pub fn (node &FnDecl) str(t &table.Table) string {
 		receiver = '($node.receiver.name ${m}$name) '
 	}
 	name := node.name.after('.')
-	f.write(' fn ${receiver}${name}(')
+	f.write('fn ${receiver}${name}(')
 	for i, arg in node.args {
 		is_last_arg := i == node.args.len - 1
 		should_add_type := is_last_arg || node.args[i + 1].typ != arg.typ

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -22,7 +22,7 @@ pub fn (node &FnDecl) str(t &table.Table) string {
 		receiver = '($node.receiver.name ${m}$name) '
 	}
 	name := node.name.after('.')
-	f.write('fn ${receiver}${name}(')
+	f.write(' fn ${receiver}${name}(')
 	for i, arg in node.args {
 		is_last_arg := i == node.args.len - 1
 		should_add_type := is_last_arg || node.args[i + 1].typ != arg.typ

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -47,7 +47,7 @@ pub fn doc(mod string, table &table.Table) string {
 		d.stmts << file_ast.stmts
 	}
 	d.print_fns()
-	d.writeln('')
+	d.out.writeln('')
 	d.print_methods()
 	/*
 		for stmt in file_ast.stmts {
@@ -59,36 +59,44 @@ pub fn doc(mod string, table &table.Table) string {
 	return d.out.str()
 }
 
-fn (d mut Doc) writeln(s string) {
-	d.out.writeln(s)
-}
-
-fn (d mut Doc) write_fn_node(f ast.FnDecl) {
-	d.writeln(f.str(d.table).replace(d.mod + '.', ''))
+fn (d &Doc) write_fn_node(f ast.FnDecl) string {
+	return f.str(d.table).replace(d.mod + '.', '')
 }
 
 fn (d mut Doc) print_fns() {
+	mut fn_names := []string
 	for stmt in d.stmts {
 		match stmt {
 			ast.FnDecl {
 				if it.is_pub && !it.is_method {
-					d.write_fn_node(it)
+					name := d.write_fn_node(it)
+					fn_names << name
 				}
 			}
 			else {}
+		}
 	}
+	fn_names.sort()
+	for s in fn_names {
+		d.out.writeln(s)
 	}
 }
 
 fn (d mut Doc) print_methods() {
+	mut fn_names := []string
 	for stmt in d.stmts {
 		match stmt {
 			ast.FnDecl {
 				if it.is_pub && it.is_method {
-					d.write_fn_node(it)
+					name := d.write_fn_node(it)
+					fn_names << name
 				}
 			}
 			else {}
+		}
 	}
+	fn_names.sort()
+	for s in fn_names {
+		d.out.writeln(s)
 	}
 }

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -59,7 +59,7 @@ pub fn doc(mod string, table &table.Table) string {
 	return d.out.str()
 }
 
-fn (d &Doc) write_fn_node(f ast.FnDecl) string {
+fn (d &Doc) get_fn_node(f ast.FnDecl) string {
 	return f.str(d.table).replace(d.mod + '.', '')
 }
 
@@ -69,7 +69,7 @@ fn (d mut Doc) print_fns() {
 		match stmt {
 			ast.FnDecl {
 				if it.is_pub && !it.is_method {
-					name := d.write_fn_node(it)
+					name := d.get_fn_node(it)
 					fn_names << name
 				}
 			}
@@ -88,7 +88,7 @@ fn (d mut Doc) print_methods() {
 		match stmt {
 			ast.FnDecl {
 				if it.is_pub && it.is_method {
-					name := d.write_fn_node(it)
+					name := d.get_fn_node(it)
 					fn_names << name
 				}
 			}


### PR DESCRIPTION
This PR is to sort `function` and `method` names in doc command.

![doc](https://user-images.githubusercontent.com/6949593/75267218-edd42800-5830-11ea-92e1-a2194a5958c1.png)

