### PR TITLE
fmt: Fixed vfmt check

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -280,7 +280,7 @@ fn (f mut Fmt) expr(node ast.Expr) {
 			f.write(')')
 		}
 		ast.EnumVal {
-			f.write('.' + it.name)
+			f.write('.' + it.enum_name)
 		}
 		ast.FloatLiteral {
 			f.write(it.val)


### PR DESCRIPTION
`EnumVal` had it's member change from `name` to `enum_name`, but not everyplace
got changed. This should fix CI tests from being broken. Just a one-liner.