### PR TITLE
atof: code review

### DIFF
--- a/vlib/builtin/float.v
+++ b/vlib/builtin/float.v
@@ -2,36 +2,56 @@
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module builtin
+import ftoa
 
 #include <float.h>
+
+// ----- f64 to string functions -----
+
+// str return a f64 as string in scientific notation, auto display digits limit
 pub fn (d f64) str() string {
-	buf := malloc(sizeof(double) * 5 + 1) // TODO
-	C.sprintf(charptr(buf), '%f', d)
-	return tos(buf, vstrlen(buf))
+	return ftoa.ftoa_64(d)
 }
 
-pub fn (d f32) str() string {
-	buf := malloc(sizeof(double) * 5 + 1) // TODO
-	C.sprintf((buf), '%f', d)
-	return tos(buf, vstrlen(buf))
-}
-
-// return a string of the input f64 in scientific notation with digit_num digits displayed
+// return a string of the input f64 in scientific notation with digit_num deciamals displayed, max 17 digits
 pub fn (x f64) strsci(digit_num int) string {
-	buf := malloc(digit_num * 2 + 2) // TODO
-	conf_str := '%0.' + digit_num.str() + 'e'
-	C.sprintf((buf), (conf_str.str), x)
-	tmpstr := tos(buf, vstrlen(buf))
-	return tmpstr
+	mut n_digit := digit_num
+	if n_digit < 1 {
+		n_digit = 1
+	} else if n_digit > 17 {
+		n_digit = 17
+	}
+	return ftoa.f64_to_str(x,n_digit)
 }
 
-// return a long string of the input f64, max
+// return a decimal notation of the input f64
 pub fn (x f64) strlong() string {
-	buf := malloc(18 + 32) // TODO
-	C.sprintf((buf), '%0.30lf', x)
-	tmpstr := tos(buf, vstrlen(buf))
-	return tmpstr
+	return ftoa.f64_to_str_l(x)
 }
+
+// ----- f32 to string functions -----
+
+// str return a f32 as string in scientific notation, auto display digits limit
+pub fn (d f32) str() string {
+	return ftoa.ftoa_32(d)
+}
+
+// return a string of the input f32 in scientific notation with digit_num deciamals displayed, max 8 digits
+pub fn (x f32) strsci(digit_num int) string {
+	mut n_digit := digit_num
+	if n_digit < 1 {
+		n_digit = 1
+	} else if n_digit > 8 {
+		n_digit = 8
+	}
+	return ftoa.f32_to_str(x,n_digit)
+}
+
+// return a decimal notation of the input f32
+pub fn (x f32) strlong() string {
+	return ftoa.f32_to_str_l(x)
+}
+
 
 [inline]
 fn f32_abs(a f32) f32 {

--- a/vlib/builtin/float.v
+++ b/vlib/builtin/float.v
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module builtin
-import ftoa
+import strconv.ftoa
 
 #include <float.h>
 

--- a/vlib/builtin/float.v
+++ b/vlib/builtin/float.v
@@ -9,11 +9,13 @@ import ftoa
 // ----- f64 to string functions -----
 
 // str return a f64 as string in scientific notation, auto display digits limit
+[inline]
 pub fn (d f64) str() string {
 	return ftoa.ftoa_64(d)
 }
 
 // return a string of the input f64 in scientific notation with digit_num deciamals displayed, max 17 digits
+[inline]
 pub fn (x f64) strsci(digit_num int) string {
 	mut n_digit := digit_num
 	if n_digit < 1 {
@@ -25,6 +27,7 @@ pub fn (x f64) strsci(digit_num int) string {
 }
 
 // return a decimal notation of the input f64
+[inline]
 pub fn (x f64) strlong() string {
 	return ftoa.f64_to_str_l(x)
 }
@@ -32,11 +35,13 @@ pub fn (x f64) strlong() string {
 // ----- f32 to string functions -----
 
 // str return a f32 as string in scientific notation, auto display digits limit
+[inline]
 pub fn (d f32) str() string {
 	return ftoa.ftoa_32(d)
 }
 
 // return a string of the input f32 in scientific notation with digit_num deciamals displayed, max 8 digits
+[inline]
 pub fn (x f32) strsci(digit_num int) string {
 	mut n_digit := digit_num
 	if n_digit < 1 {
@@ -48,10 +53,12 @@ pub fn (x f32) strsci(digit_num int) string {
 }
 
 // return a decimal notation of the input f32
+[inline]
 pub fn (x f32) strlong() string {
 	return ftoa.f32_to_str_l(x)
 }
 
+// ----- C functions -----
 
 [inline]
 fn f32_abs(a f32) f32 {

--- a/vlib/math/complex/complex_test.v
+++ b/vlib/math/complex/complex_test.v
@@ -1,6 +1,13 @@
 import math
 import math.complex as cmplx
 
+fn tst_res(str1 string, str2 string) bool {
+	if (math.abs(str1.f64() - str2.f64())) < 1e-5 {
+		return true
+	}
+	return false
+}
+
 fn test_complex_addition() {
 	// Test is based on and verified from practice examples of Khan Academy
 	// https://www.khanacademy.org/math/precalculus/imaginary-and-complex-numbers
@@ -177,14 +184,14 @@ fn test_complex_mod() {
 	mut c1 := cmplx.complex(5,7)
 	mut result := c1.mod()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq('8.602325')
+	assert tst_res(result.str(), '8.602325')
 	c1 = cmplx.complex(-3,4)
 	result = c1.mod()
 	assert result == 5
 	c1 = cmplx.complex(-1,-2)
 	result = c1.mod()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq('2.236068')
+	assert tst_res(result.str(), '2.236068')
 }
 
 fn test_complex_pow() {
@@ -269,17 +276,17 @@ fn test_complex_arg() {
 	mut c2 := cmplx.complex(2.152033,0.950547)
 	mut result := c1.arg()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq('0.950547')
+	assert tst_res(result.str(), '0.950547')
 	c1 = cmplx.complex(-3,4)
 	c2 = cmplx.complex(1.609438,2.214297)
 	result = c1.arg()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq('2.214297')
+	assert tst_res(result.str(), '2.214297')
 	c1 = cmplx.complex(-1,-2)
 	c2 = cmplx.complex(0.804719,-2.034444)
 	result = c1.arg()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq('-2.034444')
+	assert tst_res(result.str(), '-2.034444')
 }
 
 fn test_complex_log() {

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -38,7 +38,7 @@ fn test_erf() {
 fn test_gamma() {
 	assert gamma(1) == 1
 	assert gamma(5) == 24
-	sval := '2.453737'
+	sval := '2.4537365708424423e+00'
 	assert log_gamma(4.5).str() == sval
 	assert log(gamma(4.5)).str() == sval
 	assert abs( log_gamma(4.5) - log(gamma(4.5)) ) < 0.000001

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -1,5 +1,12 @@
 module math
 
+fn tst_res(str1 string, str2 string) bool {
+	if (math.abs(str1.f64() - str2.f64())) < 1e-5 {
+		return true
+	}
+	return false
+}
+
 fn test_gcd() {
 	assert gcd(6, 9) == 3
 	assert gcd(6, -9) == 3
@@ -38,9 +45,11 @@ fn test_erf() {
 fn test_gamma() {
 	assert gamma(1) == 1
 	assert gamma(5) == 24
-	sval := '2.4537365708424423e+00'
-	assert log_gamma(4.5).str() == sval
-	assert log(gamma(4.5)).str() == sval
+	sval := '2.453737'
+	assert tst_res(log_gamma(4.5).str(), sval) 
+	assert tst_res(log(gamma(4.5)).str(), sval) 
+	//assert log_gamma(4.5).str() == sval
+	//assert log(gamma(4.5)).str() == sval
 	assert abs( log_gamma(4.5) - log(gamma(4.5)) ) < 0.000001
 	// assert log_gamma(4.5) == log(gamma(4.5)) /* <-- fails on alpine/musl
 }

--- a/vlib/math/stats/stats_test.v
+++ b/vlib/math/stats/stats_test.v
@@ -1,4 +1,5 @@
 import math.stats as stats
+import math
 
 fn test_freq() {
 	// Tests were also verified on Wolfram Alpha
@@ -11,20 +12,27 @@ fn test_freq() {
 	assert o == 0
 }
 
+fn tst_res(str1 string, str2 string) bool {
+	if (math.abs(str1.f64() - str2.f64())) < 1e-5 {
+		return true
+	}
+	return false
+}
+
 fn test_mean() {
 	// Tests were also verified on Wolfram Alpha
 	mut data := [f64(10.0),f64(4.45),f64(5.9),f64(2.7)]
 	mut o := stats.mean(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('5.762500')
+	assert tst_res(o.str(), '5.762500')
 	data = [f64(-3.0),f64(67.31),f64(4.4),f64(1.89)]
 	o = stats.mean(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('17.650000')
+	assert tst_res(o.str(), '17.650000')
 	data = [f64(12.0),f64(7.88),f64(76.122),f64(54.83)]
 	o = stats.mean(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('37.708000')
+	assert tst_res(o.str(), '37.708000')
 }
 
 fn test_geometric_mean() {
@@ -32,7 +40,7 @@ fn test_geometric_mean() {
 	mut data := [f64(10.0),f64(4.45),f64(5.9),f64(2.7)]
 	mut o := stats.geometric_mean(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('5.159932')
+	assert tst_res(o.str(),'5.15993')
 	data = [f64(-3.0),f64(67.31),f64(4.4),f64(1.89)]
 	o = stats.geometric_mean(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
@@ -40,7 +48,7 @@ fn test_geometric_mean() {
 	data = [f64(12.0),f64(7.88),f64(76.122),f64(54.83)]
 	o = stats.geometric_mean(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('25.064496')
+	assert tst_res(o.str(),'25.064496')
 }
 
 fn test_harmonic_mean() {
@@ -48,15 +56,15 @@ fn test_harmonic_mean() {
 	mut data := [f64(10.0),f64(4.45),f64(5.9),f64(2.7)]
 	mut o := stats.harmonic_mean(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('4.626519')
+	assert tst_res(o.str(), '4.626519')
 	data = [f64(-3.0),f64(67.31),f64(4.4),f64(1.89)]
 	o = stats.harmonic_mean(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('9.134577')
+	assert tst_res(o.str(), '9.134577')
 	data = [f64(12.0),f64(7.88),f64(76.122),f64(54.83)]
 	o = stats.harmonic_mean(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('16.555477')
+	assert tst_res(o.str(), '16.555477')
 }
 
 fn test_median() {
@@ -67,15 +75,15 @@ fn test_median() {
 	mut data := [f64(2.7),f64(4.45),f64(5.9),f64(10.0)]
 	mut o := stats.median(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('5.175000')
+	assert tst_res(o.str(), '5.175000')
 	data = [f64(-3.0),f64(1.89),f64(4.4),f64(67.31)]
 	o = stats.median(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('3.145000')
+	assert tst_res(o.str(), '3.145000')
 	data = [f64(7.88),f64(12.0),f64(54.83),f64(76.122)]
 	o = stats.median(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('33.415000')
+	assert tst_res(o.str(), '33.415000')
 
 	// Odd
 	data = [f64(2.7),f64(4.45),f64(5.9),f64(10.0),f64(22)]
@@ -108,15 +116,15 @@ fn test_rms() {
 	mut data := [f64(10.0),f64(4.45),f64(5.9),f64(2.7)]
 	mut o := stats.rms(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('6.362046')
+	assert tst_res(o.str(), '6.362046')
 	data = [f64(-3.0),f64(67.31),f64(4.4),f64(1.89)]
 	o = stats.rms(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('33.773393')
+	assert tst_res(o.str(), '33.773393')
 	data = [f64(12.0),f64(7.88),f64(76.122),f64(54.83)]
 	o = stats.rms(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('47.452561')
+	assert tst_res(o.str(), '47.452561')
 }
 
 fn test_population_variance() {
@@ -124,15 +132,15 @@ fn test_population_variance() {
 	mut data := [f64(10.0),f64(4.45),f64(5.9),f64(2.7)]
 	mut o := stats.population_variance(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('7.269219')
+	assert tst_res(o.str(), '7.269219')
 	data = [f64(-3.0),f64(67.31),f64(4.4),f64(1.89)]
 	o = stats.population_variance(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('829.119550')
+	assert tst_res(o.str(), '829.119550')
 	data = [f64(12.0),f64(7.88),f64(76.122),f64(54.83)]
 	o = stats.population_variance(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('829.852282')
+	assert tst_res(o.str(), '829.852282')
 }
 
 fn test_sample_variance() {
@@ -140,15 +148,15 @@ fn test_sample_variance() {
 	mut data := [f64(10.0),f64(4.45),f64(5.9),f64(2.7)]
 	mut o := stats.sample_variance(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('9.692292')
+	assert tst_res(o.str(), '9.692292')
 	data = [f64(-3.0),f64(67.31),f64(4.4),f64(1.89)]
 	o = stats.sample_variance(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('1105.492733')
+	assert tst_res(o.str(), '1105.492733')
 	data = [f64(12.0),f64(7.88),f64(76.122),f64(54.83)]
 	o = stats.sample_variance(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('1106.469709')
+	assert tst_res(o.str(), '1106.469709')
 }
 
 fn test_population_stddev() {
@@ -156,15 +164,15 @@ fn test_population_stddev() {
 	mut data := [f64(10.0),f64(4.45),f64(5.9),f64(2.7)]
 	mut o := stats.population_stddev(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('2.696149')
+	assert tst_res(o.str(), '2.696149')
 	data = [f64(-3.0),f64(67.31),f64(4.4),f64(1.89)]
 	o = stats.population_stddev(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('28.794436')
+	assert tst_res(o.str(), '28.794436')
 	data = [f64(12.0),f64(7.88),f64(76.122),f64(54.83)]
 	o = stats.population_stddev(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('28.807157')
+	assert tst_res(o.str(), '28.807157')
 }
 
 fn test_sample_stddev() {
@@ -172,15 +180,15 @@ fn test_sample_stddev() {
 	mut data := [f64(10.0),f64(4.45),f64(5.9),f64(2.7)]
 	mut o := stats.sample_stddev(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('3.113245')
+	assert tst_res(o.str(), '3.113245')
 	data = [f64(-3.0),f64(67.31),f64(4.4),f64(1.89)]
 	o = stats.sample_stddev(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('33.248951')
+	assert tst_res(o.str(), '33.248951')
 	data = [f64(12.0),f64(7.88),f64(76.122),f64(54.83)]
 	o = stats.sample_stddev(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('33.263639')
+	assert tst_res(o.str(), '33.263639')
 }
 
 fn test_mean_absdev() {
@@ -188,15 +196,15 @@ fn test_mean_absdev() {
 	mut data := [f64(10.0),f64(4.45),f64(5.9),f64(2.7)]
 	mut o := stats.mean_absdev(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('2.187500')
+	assert tst_res(o.str(), '2.187500')
 	data = [f64(-3.0),f64(67.31),f64(4.4),f64(1.89)]
 	o = stats.mean_absdev(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('24.830000')
+	assert tst_res(o.str(), '24.830000')
 	data = [f64(12.0),f64(7.88),f64(76.122),f64(54.83)]
 	o = stats.mean_absdev(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('27.768000')
+	assert tst_res(o.str(), '27.768000')
 }
 
 fn test_min() {

--- a/vlib/strconv/atof.v
+++ b/vlib/strconv/atof.v
@@ -19,6 +19,13 @@
 *
 **********************************************************************/
 module strconv
+
+union Float64u {
+mut:
+	f f64
+	u u64 = u64(0)
+}
+
 /**********************************************************************
 *
 * 96 bit operation utilities
@@ -148,25 +155,6 @@ fn is_space(x byte) bool {
 fn is_exp(x byte) bool {
 	return (x == `E` || x == `e`) == true
 }
-
-/*
-// return a string of the input f64 in scientific notation with digit_num digits displayed
-pub fn strsci(x f64, digit_num int) string{
-	buf := malloc(digit_num*2+2)// TODO
-	conf_str := '%0.'+digit_num.str()+'e'
-	C.sprintf(charptr(buf), charptr(conf_str.str), x)
-	tmpstr := tos(buf, vstrlen(buf))
-	return tmpstr
-}
-
-// return a long string of the input f64, max
-pub fn strlong(x f64) string {
-	buf := malloc(18+32)// TODO
-	C.sprintf(charptr(buf),"%0.30lf",x)
-	tmpstr := tos(buf, vstrlen(buf))
-	return tmpstr
-}
-*/
 
 /**********************************************************************
 *
@@ -545,29 +533,30 @@ pub fn atof64(s string) f64 {
 	mut pn := PrepNumber{
 	}
 	mut res_parsing := 0
-	mut result := f64(0)
-	result = f64(0.0)
-	mut res_ptr := *u64(&result)
+	mut res  := Float64u{}
+
 	res_parsing,pn = parser(s + ' ') // TODO: need an extra char for now
 	// println(pn)
 	match res_parsing {
 		PARSER_OK {
-			*res_ptr = converter(mut pn)
+			res.u = converter(mut pn)
 		}
 		PARSER_PZERO {
-			*res_ptr = DOUBLE_PLUS_ZERO
+			res.u = DOUBLE_PLUS_ZERO
 		}
 		PARSER_MZERO {
-			*res_ptr = DOUBLE_MINUS_ZERO
+			res.u = DOUBLE_MINUS_ZERO
 		}
 		PARSER_PINF {
-			*res_ptr = DOUBLE_PLUS_INFINITY
+			res.u = DOUBLE_PLUS_INFINITY
 		}
 		PARSER_MINF {
-			*res_ptr = DOUBLE_MINUS_INFINITY
+			res.u = DOUBLE_MINUS_INFINITY
 		}
 		else {
 		}}
-	return result
+	return res.f
 }
+
+
 

--- a/vlib/strconv/atof_test.v
+++ b/vlib/strconv/atof_test.v
@@ -3,7 +3,6 @@
 * String to float Test
 *
 **********************************************************************/
-
 import (
 	strconv
 	strconv.atofq
@@ -41,15 +40,19 @@ fn test_atof() {
 		// slow atof
 		assert strconv.atof64(src_num_str[c]).strlong() == x.strlong()
 
+		
 		// quick atof
 		mut s1 := (atofq.atof_quick(src_num_str[c]).str())
-		s1 = s1[..src_num_str[c].len]
 		mut s2 := (x.str())
-		s2 = s2[..src_num_str[c].len]
-		assert s1 == s2
+		delta := s1.f64() - s2.f64()
+		//println("$s1 $s2 $delta")
+		assert delta < f64(1e-16)
 
 		// test C.atof
-		assert x.strsci(18) == f64(C.atof(src_num_str[c].str)).strsci(18)
+		n1 := x.strsci(18)
+		n2 := f64(C.atof(src_num_str[c].str)).strsci(18)
+		//println("$n1 $n2")
+		assert n1 == n2		
 	}
 
 	// check conversion case 2 string <==> f64
@@ -71,4 +74,5 @@ fn test_atof() {
 	// DOUBLE_MINUS_ZERO
 	f1=-0.0
 	assert *ptr == u64(0x8000000000000000)
+	//println("DONE!")
 }

--- a/vlib/strconv/atofq/atofq.v
+++ b/vlib/strconv/atofq/atofq.v
@@ -18,14 +18,14 @@
 
 module atofq
 
-import strconv
-
 // same used in atof, here only for references
-// const(
-// DOUBLE_PLUS_ZERO        = u64(0x0000000000000000)
-// DOUBLE_MINUS_ZERO       = 0x8000000000000000
-// DOUBLE_PLUS_INFINITY    = 0x7FF0000000000000
-// DOUBLE_MINUS_INFINITY   = 0xFFF0000000000000
+const(
+	DOUBLE_PLUS_ZERO        = u64(0x0000000000000000)
+	DOUBLE_MINUS_ZERO       = 0x8000000000000000
+	DOUBLE_PLUS_INFINITY    = 0x7FF0000000000000
+	DOUBLE_MINUS_INFINITY   = 0xFFF0000000000000
+)
+
 // atof_quick return a f64 number from a string in a quick way
 pub fn atof_quick(s string) f64 {
 	mut f := f64(0.0) // result
@@ -49,10 +49,10 @@ pub fn atof_quick(s string) f64 {
 	if s[i] == `i` && i + 2 < s.len && s[i + 1] == `n` && s[i + 2] == `f` {
 		mut d := *u64(&f)
 		if sign > 0.0 {
-			*d = strconv.DOUBLE_PLUS_INFINITY
+			*d = DOUBLE_PLUS_INFINITY
 		}
 		else {
-			*d = strconv.DOUBLE_MINUS_INFINITY
+			*d = DOUBLE_MINUS_INFINITY
 		}
 		return f
 	}
@@ -63,10 +63,10 @@ pub fn atof_quick(s string) f64 {
 		if i >= s.len {
 			mut d := *u64(&f)
 			if sign > 0.0 {
-				*d = strconv.DOUBLE_PLUS_ZERO
+				*d = DOUBLE_PLUS_ZERO
 			}
 			else {
-				*d = strconv.DOUBLE_MINUS_ZERO
+				*d = DOUBLE_MINUS_ZERO
 			}
 			return f
 		}
@@ -115,10 +115,10 @@ pub fn atof_quick(s string) f64 {
 			if exp > pos_exp.len {
 				mut d := *u64(&f)
 				if sign > 0 {
-					*d = strconv.DOUBLE_PLUS_INFINITY
+					*d = DOUBLE_PLUS_INFINITY
 				}
 				else {
-					*d = strconv.DOUBLE_MINUS_INFINITY
+					*d = DOUBLE_MINUS_INFINITY
 				}
 				return f
 			}
@@ -132,10 +132,10 @@ pub fn atof_quick(s string) f64 {
 			if exp > neg_exp.len {
 				mut d := *u64(&f)
 				if (sign > 0) {
-					*d = strconv.DOUBLE_PLUS_ZERO
+					*d = DOUBLE_PLUS_ZERO
 				}
 				else {
-					*d = strconv.DOUBLE_MINUS_ZERO
+					*d = DOUBLE_MINUS_ZERO
 				}
 				return f
 			}

--- a/vlib/strconv/atofq/atofq.v
+++ b/vlib/strconv/atofq/atofq.v
@@ -26,9 +26,15 @@ const(
 	DOUBLE_MINUS_INFINITY   = 0xFFF0000000000000
 )
 
+union Float64u {
+mut:
+	f f64
+	u u64 = u64(0)
+}
+
 // atof_quick return a f64 number from a string in a quick way
 pub fn atof_quick(s string) f64 {
-	mut f := f64(0.0) // result
+	mut f := Float64u{} // result
 	mut sign := f64(1.0) // result sign
 	mut i := 0 // index
 	// skip white spaces
@@ -47,34 +53,32 @@ pub fn atof_quick(s string) f64 {
 	}
 	// infinite
 	if s[i] == `i` && i + 2 < s.len && s[i + 1] == `n` && s[i + 2] == `f` {
-		mut d := *u64(&f)
 		if sign > 0.0 {
-			*d = DOUBLE_PLUS_INFINITY
+			f.u = DOUBLE_PLUS_INFINITY
 		}
 		else {
-			*d = DOUBLE_MINUS_INFINITY
+			f.u = DOUBLE_MINUS_INFINITY
 		}
-		return f
+		return f.f
 	}
 	// skip zeros
 	for i < s.len && s[i] == `0` {
 		i++
 		// we have a zero, manage it
 		if i >= s.len {
-			mut d := *u64(&f)
 			if sign > 0.0 {
-				*d = DOUBLE_PLUS_ZERO
+				f.u = DOUBLE_PLUS_ZERO
 			}
 			else {
-				*d = DOUBLE_MINUS_ZERO
+				f.u = DOUBLE_MINUS_ZERO
 			}
-			return f
+			return f.f
 		}
 	}
 	// integer part
 	for i < s.len && (s[i] >= `0` && s[i] <= `9`) {
-		f *= f64(10.0)
-		f += f64(s[i] - `0`)
+		f.f *= f64(10.0)
+		f.f += f64(s[i] - `0`)
 		i++
 	}
 	// decimal point
@@ -82,7 +86,7 @@ pub fn atof_quick(s string) f64 {
 		i++
 		mut frac_mul := f64(0.1)
 		for i < s.len && (s[i] >= `0` && s[i] <= `9`) {
-			f += f64(s[i] - `0`) * frac_mul
+			f.f += f64(s[i] - `0`) * frac_mul
 			frac_mul *= f64(0.1)
 			i++
 		}
@@ -113,41 +117,36 @@ pub fn atof_quick(s string) f64 {
 		}
 		if exp_sign == 1 {
 			if exp > pos_exp.len {
-				mut d := *u64(&f)
 				if sign > 0 {
-					*d = DOUBLE_PLUS_INFINITY
+					f.u = DOUBLE_PLUS_INFINITY
 				}
 				else {
-					*d = DOUBLE_MINUS_INFINITY
+					f.u = DOUBLE_MINUS_INFINITY
 				}
-				return f
+				return f.f
 			}
-			tmp_mul := f64(0.0)
-			mut ptr_d := *u64(&tmp_mul)
-			*ptr_d = pos_exp[exp]
+			tmp_mul := Float64u{u: pos_exp[exp]}
 			// C.printf("exp: %d  [0x%016llx] %f,",exp,pos_exp[exp],tmp_mul)
-			f = f * tmp_mul
+			f.f = f.f * tmp_mul.f
 		}
 		else {
 			if exp > neg_exp.len {
-				mut d := *u64(&f)
 				if (sign > 0) {
-					*d = DOUBLE_PLUS_ZERO
+					f.u = DOUBLE_PLUS_ZERO
 				}
 				else {
-					*d = DOUBLE_MINUS_ZERO
+					f.u = DOUBLE_MINUS_ZERO
 				}
-				return f
+				return f.f
 			}
-			tmp_mul := f64(0.0)
-			mut ptr_d := *u64(&tmp_mul)
-			*ptr_d = neg_exp[exp]
+			tmp_mul := Float64u{u: neg_exp[exp]}
+			
 			// C.printf("exp: %d  [0x%016llx] %f,",exp,pos_exp[exp],tmp_mul)
-			f = f * tmp_mul
+			f.f = f.f * tmp_mul.f
 		}
 	}
-	f = f * sign
-	return f
+	f.f = f.f * sign
+	return f.f
 }
 
 const (

--- a/vlib/strconv/ftoa/f32_f64_to_string_test.v
+++ b/vlib/strconv/ftoa/f32_f64_to_string_test.v
@@ -141,7 +141,7 @@ exp_result_f64 = [
 fn test_float_to_str(){
 	// test f32
 	for c,x in test_cases_f32 {
-		s := ftoa.f32_to_str(x,8)
+		s  := f32_to_str(x,8)
 		s1 := exp_result_f32[c]
 		//println("$s1 $s")
 		assert s == s1
@@ -149,7 +149,7 @@ fn test_float_to_str(){
 
 	// test f64
 	for c,x in test_cases_f64 {
-		s := ftoa.f64_to_str(x,17)
+		s  := f64_to_str(x,17)
 		s1 := exp_result_f64[c]
 		//println("$s1 $s")
 		assert s == s1
@@ -157,11 +157,11 @@ fn test_float_to_str(){
 
 	// test long format
 	for exp := 1 ; exp < 120 ; exp++ {
-		a :=ftoa.f64_to_str_l(("1e"+exp.str()).f64())
+		a := f64_to_str_l(("1e"+exp.str()).f64())
 		//println(a)
 		assert a.len == exp + 1
 
-		b :=ftoa.f64_to_str_l(("1e-"+exp.str()).f64())
+		b := f64_to_str_l(("1e-"+exp.str()).f64())
 		//println(b)
 		assert b.len == exp + 2
 	}

--- a/vlib/strconv/ftoa/f32_f64_to_string_test.v
+++ b/vlib/strconv/ftoa/f32_f64_to_string_test.v
@@ -59,8 +59,8 @@ test_cases_f32 = [
 exp_result_f32 = [
 	"0e+00",
 	"-0e+00",
-	"NaN",
-	"NaN",
+	"nan",
+	"nan",
 	"+inf",
 	"-inf",
 	"1.e+00",
@@ -111,8 +111,8 @@ test_cases_f64 = [
 exp_result_f64 = [
 	"0e+00",
 	"-0e+00",
-	"NaN",
-	"NaN",
+	"nan",
+	"nan",
 	"+inf",
 	"-inf",
 	"1.e+00",

--- a/vlib/strconv/ftoa/utilities.v
+++ b/vlib/strconv/ftoa/utilities.v
@@ -239,7 +239,7 @@ pub fn f64_to_str_l(f f64) string {
 
 	m_sgn_flag := false
 	mut sgn        := 1
-	mut b          := [32]byte
+	mut b          := [18+5]byte
 	mut d_pos      := 1
 	mut i          := 0
 	mut i1         := 0

--- a/vlib/strconv/ftoa/utilities.v
+++ b/vlib/strconv/ftoa/utilities.v
@@ -230,7 +230,7 @@ pub fn f32_to_str_l(f f64) string {
 
 // f64_to_str_l return a string with the f64 converted in a strign in decimal notation
 pub fn f64_to_str_l(f f64) string {
-	s := ftoa.f64_to_str(f,18)
+	s := f64_to_str(f,18)
 
 	// check for +inf -inf Nan
 	if s.len > 2 && (s[0] == `N` || s[1] == `i`) {

--- a/vlib/strconv/ftoa/utilities.v
+++ b/vlib/strconv/ftoa/utilities.v
@@ -239,7 +239,7 @@ pub fn f64_to_str_l(f f64) string {
 
 	m_sgn_flag := false
 	mut sgn        := 1
-	mut b          := [18+5]byte
+	mut b          := [18+8]byte
 	mut d_pos      := 1
 	mut i          := 0
 	mut i1         := 0

--- a/vlib/strconv/ftoa/utilities.v
+++ b/vlib/strconv/ftoa/utilities.v
@@ -58,7 +58,7 @@ fn bool_to_u64(b bool) u64 {
 
 fn get_string_special(neg bool, expZero bool, mantZero bool) string {
 	if !mantZero {
-		return "NaN"
+		return "nan"
 	}
 	if !expZero {
 		if neg {


### PR DESCRIPTION
**What's inside**
- code clean
- removed from all the code the use of pointers, the `union`s are used instead
- rewritten some tests for `f32/f64`
- removed all the `C.sprintf` for the floats
- various small fixes

*Now all the V code use the internal f32/f64 functions* :smile_cat: 