### PR TITLE
malloc: fix use &empty_struct compile error

### DIFF
--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -163,14 +163,16 @@ TODO
 
 pub fn calloc(n int) byteptr {
 	if n <= 0 {
-		panic('calloc(<=0)')
+		return 0
 	}
 	return C.calloc(n, 1)
 }
 
 [unsafe_fn]
 pub fn free(ptr voidptr) {
-	C.free(ptr)
+	if ptr != 0 {
+		C.free(ptr)
+	}
 }
 
 pub fn memdup(src voidptr, sz int) voidptr {

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -131,7 +131,7 @@ fn looo(){} // TODO remove, [ pratt
 [unsafe_fn]
 pub fn malloc(n int) byteptr {
 	if n <= 0 {
-		panic('malloc(<=0)')
+		return 0
 	}
 	$if prealloc {
 		res := g_m2_ptr
@@ -215,5 +215,3 @@ C.va_end(argptr)
         return tos2(buf)
 }
 */
-
-

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -170,9 +170,7 @@ pub fn calloc(n int) byteptr {
 
 [unsafe_fn]
 pub fn free(ptr voidptr) {
-	if ptr != 0 {
-		C.free(ptr)
-	}
+	C.free(ptr)
 }
 
 pub fn memdup(src voidptr, sz int) voidptr {


### PR DESCRIPTION
This PR is to fix use `&empty_struct` compiling error.

Issue:
```
module main

struct Info {}

fn (n Info) show() {
    println('output...')
}

fn main() {
    info := &Info{}
    info.show()
}
```
Compile result
```
V panic: malloc(<=0)
TODO: print_backtrace_skipping_top_frames_mingw(2)
print_backtrace_skipping_top_frames is not implemented on this platform for now...
```

Solution:
Modify `malloc` function, just return 0 when n <= 0.
