### PR TITLE
benchmark: make measuring small snippets of code less verbose/easier to use.

### DIFF
--- a/vlib/benchmark/benchmark.v
+++ b/vlib/benchmark/benchmark.v
@@ -23,12 +23,32 @@ for {
 bmark.stop() // call when you want to finalize the benchmark
 println( bmark.total_message('remarks about the benchmark') )
 ```
+
+benchmark.start() and b.measure() are convenience methods, 
+intended to be used in combination. Their goal is to make
+benchmarking of small snippets of code as *short*, easy to
+write, and then to read and analyze the results, as possible.
+Example:
+```v
+import benchmark
+b := benchmark.start()
+
+// your code 1 ...
+b.measure('code_1')
+
+// your code 2 ...
+b.measure('code_2')
+```
+... which will produce on stdout something like this:
+SPENT    17 ms in code_1
+SPENT   462 ms in code_2
 */
 
 
 const (
 	BOK = term.ok_message('OK')
 	BFAIL = term.fail_message('FAIL')
+	BSPENT = term.ok_message('SPENT')
 )
 
 pub struct Benchmark {
@@ -93,6 +113,20 @@ pub fn (b mut Benchmark) ok_many(n int) {
 
 pub fn (b mut Benchmark) neither_fail_nor_ok() {
 	b.step_end_time = benchmark.now()
+}
+
+pub fn start() Benchmark {
+	mut b := new_benchmark()
+	b.step()
+	return b
+}
+
+pub fn (b mut Benchmark) measure(label string) i64 {
+	b.ok()
+	res := b.step_end_time - b.step_start_time
+	println(b.step_message_with_label(BSPENT, 'in $label'))
+	b.step()
+	return res
 }
 
 pub fn (b &Benchmark) step_message_with_label(label string, msg string) string {


### PR DESCRIPTION
This PR makes possible the following short program:
```v
import strings
import benchmark
const ( MAX_REPEATS = 1000 MAX_ITERATIONS = 50000 )
fn main() {
  mut b := benchmark.start()
  for _ in 0 .. MAX_ITERATIONS {  strings.repeat(a, MAX_REPEATS) }
  b.measure('strings.repeat')
  for _ in 0 .. MAX_ITERATIONS {  strings.repeat_string('a', MAX_REPEATS) }
  b.measure('strings.repeat_string')
}
```

... which will produce the following on stdout:
```
SPENT    20 ms in strings.repeat
SPENT   477 ms in strings.repeat_string
```

NB: the user have to remember/do just 3 things:
1) `import benchmark`
2) add `mut b := benchmark.start()`
3) add `b.measure('custom_label')` after each block of code.

All of the formatting/stepping is done internally.

(The output is on stdout, so that it can be easily piped to for example `sort -n` for further processing.)