### PR TITLE
v2: process unsafe statements

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -13,10 +13,10 @@ FloatLiteral | Ident | CallExpr | BoolLiteral | StructInit | ArrayInit | Selecto
 AssignExpr | PrefixExpr | MethodCallExpr | IndexExpr | RangeExpr | MatchExpr | 	
 CastExpr | EnumVal | Assoc | SizeOf | None | MapInit
 
-pub type Stmt = VarDecl | GlobalDecl | FnDecl | Return | Module | Import | ExprStmt | 	
-ForStmt | StructDecl | ForCStmt | ForInStmt | CompIf | ConstDecl | Attr | BranchStmt | 	
-HashStmt | AssignStmt | EnumDecl | TypeDecl | DeferStmt | GotoLabel | GotoStmt | 	
-LineComment | MultiLineComment | AssertStmt
+pub type Stmt = VarDecl | GlobalDecl | FnDecl | Return | Module | Import | ExprStmt |
+ForStmt | StructDecl | ForCStmt | ForInStmt | CompIf | ConstDecl | Attr | BranchStmt |
+HashStmt | AssignStmt | EnumDecl | TypeDecl | DeferStmt | GotoLabel | GotoStmt |
+LineComment | MultiLineComment | AssertStmt | UnsafeStmt
 
 pub type Type = StructType | ArrayType
 
@@ -417,6 +417,11 @@ pub:
 }
 
 pub struct DeferStmt {
+pub:
+	stmts []Stmt
+}
+
+pub struct UnsafeStmt {
 pub:
 	stmts []Stmt
 }

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -186,6 +186,11 @@ fn (f mut Fmt) stmt(node ast.Stmt) {
 		ast.StructDecl {
 			f.struct_decl(it)
 		}
+		ast.UnsafeStmt {
+			f.writeln('unsafe {')
+			f.stmts(it.stmts)
+			f.writeln('}')
+		}
 		ast.VarDecl {
 			// type_sym := f.table.get_type_symbol(it.typ)
 			if it.is_mut {

--- a/vlib/v/fmt/tests/simple_expected.vv
+++ b/vlib/v/fmt/tests/simple_expected.vv
@@ -112,3 +112,9 @@ fn fn_with_assign_stmts() {
 fn fn_with_multi_return() (int, string) {
 	return 0, 'test'
 }
+
+fn unsafe_fn() {
+	unsafe {
+		malloc(2)
+	}
+}

--- a/vlib/v/fmt/tests/simple_input.vv
+++ b/vlib/v/fmt/tests/simple_input.vv
@@ -118,3 +118,6 @@ fn fn_with_multi_return() (int,string) {
 	return 0,'test'
 }
 
+fn unsafe_fn() {
+unsafe { malloc(2) }
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -291,8 +291,10 @@ pub fn (p mut Parser) stmt() ast.Stmt {
 		}
 		.key_unsafe {
 			p.next()
-			p.parse_block()
-			return ast.Stmt{}
+			stmts := p.parse_block()
+			return ast.UnsafeStmt{
+				stmts: stmts
+			}
 		}
 		.key_defer {
 			p.next()


### PR DESCRIPTION
Add a separate structure to represent `unsafe` statements.
Process `unsafe` statements in `fmt` module.