### PR TITLE
v2: distinguish public and private constants

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -89,6 +89,7 @@ pub struct ConstDecl {
 pub:
 	fields []Field
 	exprs  []Expr
+	is_pub bool
 }
 
 pub struct StructDecl {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -127,6 +127,9 @@ fn (f mut Fmt) stmt(node ast.Stmt) {
 	}
 		}
 		ast.ConstDecl {
+			if it.is_pub {
+				f.write('pub ')
+			}
 			f.writeln('const (')
 			f.indent++
 			for i, field in it.fields {

--- a/vlib/v/fmt/tests/simple_expected.vv
+++ b/vlib/v/fmt/tests/simple_expected.vv
@@ -18,6 +18,10 @@ const (
 	pi = 3.14
 )
 
+pub const (
+	i_am_pub_const = true
+)
+
 struct User {
 	name            string
 	age             int

--- a/vlib/v/fmt/tests/simple_input.vv
+++ b/vlib/v/fmt/tests/simple_input.vv
@@ -19,6 +19,10 @@ const (
 pi=3.14
 )
 
+pub const (
+i_am_pub_const=true
+)
+
 struct User {
 	name string
 	age int

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1369,6 +1369,7 @@ fn (p mut Parser) const_decl() ast.ConstDecl {
 	return ast.ConstDecl{
 		fields: fields
 		exprs: exprs
+		is_pub: is_pub
 	}
 }
 


### PR DESCRIPTION
This change is mostly for `vfmt` tool. This also could be useful for `doc` command to list *public* constants only.