### PR TITLE
vdoc: trim result value

### DIFF
--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -56,7 +56,7 @@ pub fn doc(mod string, table &table.Table) string {
 	println(path)
 	*/
 
-	return d.out.str()
+	return d.out.str().trim_space()
 }
 
 fn (d &Doc) get_fn_node(f ast.FnDecl) string {


### PR DESCRIPTION
This change fixes two issues:
1. We have an empty line as a separator between a list of public functions and a list of public methods. In case when at least of of these lists is empty, we have additional empty lines that should not be in result value.
2. Every function signature is added to a result value with `writeln` function, so the result value has a final newline. In addition, the result value is used as an argument of `println` function, which also adds an EOL. In this case we have two EOLs.