### PR TITLE
Fix interface error and UI can work now

### DIFF
--- a/vlib/compiler/fn.v
+++ b/vlib/compiler/fn.v
@@ -1117,9 +1117,9 @@ fn (p mut Parser) fn_call_args(f mut Fn, generic_param_types []string) {
 			if t.cat == .interface_ {
 				// perform((Speaker) { ._object = &dog,
 				// _interface_idx = _Speaker_Dog_index })
-				concrete_type_name := typ.replace('*', '_ptr')
-				p.cgen.set_placeholder(ph, '($arg.typ) { ._object = &')
-				p.gen(', /*OLD*/ ._interface_idx = _${arg.typ}_${concrete_type_name}_index} /* i. arg*/')
+				// concrete_type_name := typ.replace('*', '_ptr')
+				// p.cgen.set_placeholder(ph, '($arg.typ) { ._object = &')
+				// p.gen(', /*OLD*/ ._interface_idx = _${arg.typ}_${concrete_type_name}_index} /* i. arg*/')
 				p.table.add_gen_type(arg.typ, typ)
 			}
 		}
@@ -1706,4 +1706,3 @@ pub fn (f &Fn) str_for_error() string {
 	}
 	return s + ')'
 }
-


### PR DESCRIPTION
This PR is to fix `interface` error.

fix: `#3848` and `#3784`

`UI` module can work now!

