### PR TITLE
Add trim_trailing_whitespace = true to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,7 @@ insert_final_newline = true
 [*.v]
 indent_style = tab
 indent_size = 4
+trim_trailing_whitespace = true
 
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
trim_trailing_whitespace is documented in https://editorconfig.org/ :
> set to "true" to remove any whitespace characters preceding newline
characters and "false" to ensure it doesn't.