### PR TITLE
tool: v self-compiler

### DIFF
--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -11,27 +11,26 @@ fn main() {
 	vroot := filepath.dir(pref.vexe_path())
 	os.chdir(vroot)
 
+	s2 := os.exec('v -o v2 cmd/v') or {
+		panic(err)
+	}
+	println(s2.output)
+
 	$if windows {
 		bak_file := 'v_old.exe'
 		if os.exists(bak_file) {
 			os.rm(bak_file)
 		}
 		os.mv('v.exe', bak_file)
+		os.mv('v2.exe', 'v.exe')
 
-		s2 := os.exec('v_old -o v cmd/v') or {
-			panic(err)
-		}
-		println(s2.output)
+
 	} $else {
 		bak_file := 'v_old'
 		if os.exists(bak_file) {
 			os.rm(bak_file)
 		}
 		os.mv('v', bak_file)
-
-		s2 := os.exec('v_old -o v cmd/v') or {
-			panic(err)
-		}
-		println(s2.output)
+		os.mv('v2', 'v')
 	}
 }

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -1,0 +1,37 @@
+module main
+
+import (
+	os
+	filepath
+	v.pref
+)
+
+fn main() {
+	println('V Self Compiling...')
+	vroot := filepath.dir(pref.vexe_path())
+	os.chdir(vroot)
+
+	$if windows {
+		bak_file := 'v_old.exe'
+		if os.exists(bak_file) {
+			os.rm(bak_file)
+		}
+		os.mv('v.exe', bak_file)
+
+		s2 := os.exec('v_old -o v cmd/v') or {
+			panic(err)
+		}
+		println(s2.output)
+	} $else {
+		bak_file := 'v_old'
+		if os.exists(bak_file) {
+			os.rm(bak_file)
+		}
+		os.mv('v', bak_file)
+
+		s2 := os.exec('v_old -o v cmd/v') or {
+			panic(err)
+		}
+		println(s2.output)
+	}
+}

--- a/cmd/v/internal/help/doc_help.v
+++ b/cmd/v/internal/help/doc_help.v
@@ -20,6 +20,7 @@ The commands are:
    symlink           create a symbolic link for V
    translate         translate C code to V (coming soon in 0.3)
    up                run the V self-updater
+   self              run the V self-compiler
    version           prints the version text and exits
 
    install           installs a module from VPM
@@ -110,6 +111,7 @@ Commands:
   up                Update V. Run `v up` at least once per day, since V development is rapid and features/bugfixes are added constantly.
   run <file.v>      Build and execute the V program in file.v. You can add arguments for the V program *after* the file name.
   build <module>    Compile a module into an object file.
+  self              Self-compile V from local source files.
   repl              Run the V REPL. If V is running in a tty terminal, the REPL is interactive, otherwise it just reads from stdin.
   symlink           Useful on Unix systems. Symlinks the current V executable to /usr/local/bin/v, so that V is globally available.
   test-compiler     Run all V test files, and compile all V examples.

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -13,7 +13,7 @@ import (
 
 const (
 	simple_cmd = ['fmt',
-	'up',
+	'up', 'self',
 	'create',
 	'test', 'test-fmt', 'test-compiler',
 	'bin2v',


### PR DESCRIPTION
This PR add tool for v self-compiler from local source files.

Command: `v self`.

Add `vself.v` module.
Add comment in command help doc.

