### PR TITLE
vdoc: show variadic args correctly

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -25,12 +25,11 @@ pub fn (node &FnDecl) str(t &table.Table) string {
 	f.write('fn ${receiver}${name}(')
 	for i, arg in node.args {
 		is_last_arg := i == node.args.len - 1
-		is_variadic_last_arg := node.is_variadic && is_last_arg
 		should_add_type := is_last_arg || node.args[i + 1].typ != arg.typ ||
 									(node.is_variadic && i == node.args.len - 2)
 		f.write(arg.name)
 		if should_add_type {
-			if is_variadic_last_arg {
+			if node.is_variadic && is_last_arg {
 				f.write(' ...' + t.type_to_str(arg.typ))
 			}
 			else {

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -19,16 +19,23 @@ pub fn (node &FnDecl) str(t &table.Table) string {
 		sym := t.get_type_symbol(node.receiver.typ)
 		name := sym.name.after('.')
 		m := if node.rec_mut { 'mut ' } else { '' }
-		receiver = '($node.receiver.name ${m}$name) '
+		receiver = '($node.receiver.name $m$name) '
 	}
 	name := node.name.after('.')
 	f.write('fn ${receiver}${name}(')
 	for i, arg in node.args {
 		is_last_arg := i == node.args.len - 1
-		should_add_type := is_last_arg || node.args[i + 1].typ != arg.typ
+		is_variadic_last_arg := node.is_variadic && is_last_arg
+		should_add_type := is_last_arg || node.args[i + 1].typ != arg.typ ||
+									(node.is_variadic && i == node.args.len - 2)
 		f.write(arg.name)
 		if should_add_type {
-			f.write(' ' + t.type_to_str(arg.typ))
+			if is_variadic_last_arg {
+				f.write(' ...' + t.type_to_str(arg.typ))
+			}
+			else {
+				f.write(' ' + t.type_to_str(arg.typ))
+			}
 		}
 		if !is_last_arg {
 			f.write(', ')


### PR DESCRIPTION
This PR fix `vlib/v/ast/str.v` to show variadic args correctly.

e.g.
- `fn join(base string, dirs ...string) string` in `v doc filepath` command.
- `fn open_file(path, mode string, options ...int) ?File` in `v doc os` command.

