### PR TITLE
make and vself: cleanup make based on the new 'v self'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,29 @@
 fns.txt
 *.dSYM
 *_test
+
 /v
 /v2
+/v3
 /vprod
+/v-static
+/v_old
+/v_g
+/v_cg
+/v_prod
+/v_prod_cg
+/v_prod_g
+/vjs
+
 /v.c
 /v.*.c
 /v.c.out
+
 /cmd/tools/check-md
 /cmd/tools/performance_compare
 /cmd/tools/oldv
 /cmd/tools/vrepl
+/cmd/tools/vself
 /cmd/tools/vtest
 /cmd/tools/vtest-compiler
 /cmd/tools/vtest-fmt
@@ -22,17 +35,12 @@ fns.txt
 /cmd/tools/vbuild-examples
 /cmd/tools/vbuild-tools
 /cmd/tools/vbuild-vbinaries
-/v_g
-/v_cg
-/v_prod
-/v_prod_cg
-/v_prod_g
+
 *.exe
 *.o
 *.so
 .*.c
 *.tmp.c
-vjs
 *.obj
 *.exp
 *.ilk
@@ -57,5 +65,8 @@ info.log
 
 # vim/emacs editor backup files
 *~
+
 thirdparty/freetype/
 cachegrind.out.*
+
+.gdb_history

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,7 @@ endif
 all: latest_vc latest_tcc
 ifdef WIN32
 	$(CC) $(CFLAGS) -std=c99 -municode -w -o v2.exe $(TMPVC)/$(VCFILE) $(LDFLAGS)
-	./v2.exe -o v3.exe cmd/v
-	./v3.exe -o v.exe -prod cmd/v
-	rm -f v2.exe v3.exe
+	./v.exe self
 else
 	$(CC) $(CFLAGS) -std=gnu11 -w -o v $(TMPVC)/$(VCFILE) $(LDFLAGS) -lm
 ifdef ANDROID
@@ -58,7 +56,7 @@ endif
 	V_V=`git rev-parse --short=7 HEAD`; \
 	if [ $$VC_V != $$V_V ]; then \
 		echo "Self rebuild ($$VC_V => $$V_V)"; \
-		$(MAKE) selfcompile; \
+		./v self; \
 	fi)
 ifndef ANDROID
 	$(MAKE) modules
@@ -96,10 +94,10 @@ $(TMPVC)/.git/config:
 	$(MAKE) fresh_vc
 
 selfcompile:
-	./v -cg -o v cmd/v
+	./v self
 
 selfcompile-static:
-	./v -cg -cflags '--static' -o v-static cmd/v
+	./v -keep_c -cg -cflags '--static' -o v-static cmd/v
 
 modules: module_builtin module_strings module_strconv
 module_builtin:

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ $(TMPVC)/.git/config:
 	$(MAKE) fresh_vc
 
 selfcompile:
-	./v self
+	./v -keep_c -cg -cflags -o v cmd/v
 
 selfcompile-static:
 	./v -keep_c -cg -cflags '--static' -o v-static cmd/v

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ $(TMPVC)/.git/config:
 	$(MAKE) fresh_vc
 
 selfcompile:
-	./v -keep_c -cg -cflags -o v cmd/v
+	./v -keep_c -cg -o v cmd/v
 
 selfcompile-static:
 	./v -keep_c -cg -cflags '--static' -o v-static cmd/v

--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,7 @@ else
 ifdef ANDROID
 	chmod 755 v
 endif
-	@(VC_V=`./v version | cut -f 3 -d " "`; \
-	V_V=`git rev-parse --short=7 HEAD`; \
-	if [ $$VC_V != $$V_V ]; then \
-		echo "Self rebuild ($$VC_V => $$V_V)"; \
-		./v self; \
-	fi)
+	./v self
 ifndef ANDROID
 	$(MAKE) modules
 endif

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -11,7 +11,7 @@ fn main() {
 	vexe := pref.vexe_path()
 	vroot := filepath.dir(vexe)
 	os.chdir(vroot)
-	s2 := os.exec('$vexe -keep_c -cg -o v2 cmd/v') or {
+	s2 := os.exec('$vexe -o v2 cmd/v') or {
 		panic(err)
 	}
 	if s2.output.len > 0 {

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -10,27 +10,21 @@ fn main() {
 	println('V Self Compiling...')
 	vroot := filepath.dir(pref.vexe_path())
 	os.chdir(vroot)
-
-	s2 := os.exec('v -o v2 cmd/v') or {
+	s2 := os.exec('v -keep_c -cg -o v2 cmd/v') or {
 		panic(err)
 	}
-	println(s2.output)
-
-	$if windows {
-		bak_file := 'v_old.exe'
-		if os.exists(bak_file) {
-			os.rm(bak_file)
-		}
-		os.mv('v.exe', bak_file)
-		os.mv('v2.exe', 'v.exe')
-
-
-	} $else {
-		bak_file := 'v_old'
-		if os.exists(bak_file) {
-			os.rm(bak_file)
-		}
-		os.mv('v', bak_file)
-		os.mv('v2', 'v')
+	if s2.output.len > 0 {
+		println(s2.output)
 	}
+	if s2.exit_code != 0 {
+		exit(1)
+	}
+	v_file := if os.user_os() == 'windows' { 'v.exe' } else { 'v' }
+	v2_file := if os.user_os() == 'windows' { 'v2.exe' } else { 'v2' }
+	bak_file := if os.user_os() == 'windows' { 'v_old.exe' } else { 'v_old' }
+	if os.exists(bak_file) {
+		os.rm(bak_file)
+	}
+	os.mv(v_file, bak_file)
+	os.mv(v2_file, v_file)
 }

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -8,9 +8,10 @@ import (
 
 fn main() {
 	println('V Self Compiling...')
-	vroot := filepath.dir(pref.vexe_path())
+	vexe := pref.vexe_path()
+	vroot := filepath.dir(vexe)
 	os.chdir(vroot)
-	s2 := os.exec('v -keep_c -cg -o v2 cmd/v') or {
+	s2 := os.exec('$vexe -keep_c -cg -o v2 cmd/v') or {
 		panic(err)
 	}
 	if s2.output.len > 0 {

--- a/cmd/v/simple_tool.v
+++ b/cmd/v/simple_tool.v
@@ -39,9 +39,18 @@ fn launch_tool(is_verbose bool, tname string, cmdname string) {
 			// v was recompiled, maybe after v up ...
 			// rebuild the tool too just in case
 			should_compile = true
+
+			if tname == 'vself' || tname == 'vup' {
+				// The purpose of vself/up is to update and recompile v itself.
+				// After the first 'v self' execution, v will be modified, so
+				// then a second 'v self' will detect, that v is newer than the
+				// vself executable, and try to recompile vself/up again, which
+				// will slow down the next v recompilation needlessly.
+				should_compile = false
+			}
 		}
 		if os.file_last_mod_unix(tool_exe) <= os.file_last_mod_unix(tool_source) {
-			// the user changed the source code of the tool
+			// the user changed the source code of the tool, or git updated it:
 			should_compile = true
 		}
 	}


### PR DESCRIPTION
This PR also speeds up 'v up' and 'v self' in most cases.

It also adds '-keep_c -cg' to 'v self' flags, so that the produced executables will be easier to debug by default. 

edit: -keep_c -cg by default slows down CI tests too much.
