### PR TITLE
string: update `string.repeat` behavior

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1251,7 +1251,11 @@ pub fn (s string) bytes() []byte {
 
 // repeat returns a new string with a specified number of copies of the string it was called on.
 pub fn (s string) repeat(count int) string {
-	if count <= 1 {
+	if count < 0 {
+		panic('string.repeat: count is negative: $count')
+	} else if count == 0 {
+		return ''
+	} else if count == 1 {
 		return s
 	}
 	mut ret := malloc(s.len * count + 1)

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -603,11 +603,15 @@ fn test_limit() {
 }
 
 fn test_repeat() {
-	s := 'V! '
-	assert s.repeat(5) == 'V! V! V! V! V! '
-	assert s.repeat(1) == s
-	assert s.repeat(0) == s
-	assert s.repeat(-1) == s
+	s1 := 'V! '
+	assert s1.repeat(5) == 'V! V! V! V! V! '
+	assert s1.repeat(1) == s1
+	assert s1.repeat(0) == ''
+	s2 := ''
+	assert s2.repeat(5) == s2
+	assert s2.repeat(1) == s2
+	assert s2.repeat(0) == s2
+	// TODO Add test for negative values
 }
 
 fn test_raw() {


### PR DESCRIPTION
Panic if a repeat count is negative.
Return an empty string if a repeat count is zero.