### PR TITLE
log: Longer logging level names when printed

### DIFF
--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -1,9 +1,11 @@
 module log
 
-import os
-import time
-import term
-import filepath
+import (
+	os
+	time
+	term
+	filepath
+)
 
 pub enum LogLevel {
 	fatal = 1
@@ -15,12 +17,12 @@ pub enum LogLevel {
 
 fn tag(l LogLevel) string {
 	return match l {
-		.fatal { term.red('F') }
-		.error { term.red('E') }
-		.warn  { term.yellow('W') }
-		.info  { term.white('I') }
-		.debug { term.blue('D') }
-		else { ' ' }
+		.fatal { term.red('FATAL') }
+		.error { term.red('ERROR') }
+		.warn  { term.yellow('WARN ') }
+		.info  { term.white('INFO ') }
+		.debug { term.blue('DEBUG') }
+		else { '     ' }
 	}
 }
 
@@ -42,15 +44,15 @@ interface Logger {
 
 pub struct Log {
 mut:
-	level LogLevel
-	output_label string
-	ofile os.File
-	output_to_file bool
+	level            LogLevel
+	output_label     string
+	ofile            os.File
+	output_to_file   bool
 pub mut:
 	output_file_name string
 }
 
-pub fn (l mut Log) set_level(level int){
+pub fn (l mut Log) set_level(level int) {
 	l.level = match level {
 		FATAL { LogLevel.fatal }
 		ERROR { LogLevel.error }
@@ -61,7 +63,7 @@ pub fn (l mut Log) set_level(level int){
 	}
 }
 
-pub fn (l mut Log) set_output_level(level LogLevel){
+pub fn (l mut Log) set_output_level(level LogLevel) {
 	l.level = level
 }
 
@@ -79,13 +81,13 @@ pub fn (l mut Log) set_output_path(output_file_path string) {
 	if l.ofile.is_opened() { l.ofile.close() }
 	l.output_to_file = true
 	l.output_file_name = filepath.join( os.realpath( output_file_path ) , l.output_label )
-	ofile := os.open_append( l.output_file_name  ) or {
+	ofile := os.open_append( l.output_file_name ) or {
 		panic('error while opening log file ${l.output_file_name} for appending')
 	}
 	l.ofile = ofile
 }
 
-pub fn (l mut Log) close(){
+pub fn (l mut Log) close() {
   l.ofile.close()
 }
 
@@ -101,7 +103,7 @@ fn (l &Log) log_cli(s string, level LogLevel) {
 	println('[$f ${t.format_ss()}] $s')
 }
 
-fn (l mut Log) send_output(s &string, level LogLevel){
+fn (l mut Log) send_output(s &string, level LogLevel) {
 	if l.output_to_file {
 		l.log_file(s, level)
 	} else {
@@ -116,23 +118,23 @@ pub fn (l mut Log) fatal(s string){
 	panic('$l.output_label: $s')
 }
 
-pub fn (l mut Log) error(s string){
+pub fn (l mut Log) error(s string) {
 	if l.level < .error { return }
 	l.send_output(s, .error)
 }
 
-pub fn (l mut Log) warn(s string){
+pub fn (l mut Log) warn(s string) {
 	if l.level < .warn { return }
 	l.send_output(s, .warn)
 }
 
-pub fn (l mut Log) info(s string){
+pub fn (l mut Log) info(s string) {
 	if l.level < .info { return }
 	l.send_output(s, .info)
 }
 
-pub fn (l mut Log) debug(s string){
-	if l.level < .debug { return	}
+pub fn (l mut Log) debug(s string) {
+	if l.level < .debug { return }
 	l.send_output(s, .debug)
 }
 


### PR DESCRIPTION
Instead of only printing one character, logging now prints the entire
word describing the log level.

Also, minor boy-scouting.