### PR TITLE
v2: process `or` block for `CallExpr`

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -8,14 +8,14 @@ import (
 	v.table
 )
 
-pub type Expr = InfixExpr | IfExpr | StringLiteral | IntegerLiteral | CharLiteral | 	
-FloatLiteral | Ident | CallExpr | BoolLiteral | StructInit | ArrayInit | SelectorExpr | PostfixExpr | 	
-AssignExpr | PrefixExpr | MethodCallExpr | IndexExpr | RangeExpr | MatchExpr | 	
+pub type Expr = InfixExpr | IfExpr | StringLiteral | IntegerLiteral | CharLiteral |
+FloatLiteral | Ident | CallExpr | BoolLiteral | StructInit | ArrayInit | SelectorExpr | PostfixExpr |
+AssignExpr | PrefixExpr | MethodCallExpr | IndexExpr | RangeExpr | MatchExpr |
 CastExpr | EnumVal | Assoc | SizeOf | None | MapInit | IfGuardExpr | ParExpr | OrExpr
 
-pub type Stmt = VarDecl | GlobalDecl | FnDecl | Return | Module | Import | ExprStmt | 	
-ForStmt | StructDecl | ForCStmt | ForInStmt | CompIf | ConstDecl | Attr | BranchStmt | 	
-HashStmt | AssignStmt | EnumDecl | TypeDecl | DeferStmt | GotoLabel | GotoStmt | 	
+pub type Stmt = VarDecl | GlobalDecl | FnDecl | Return | Module | Import | ExprStmt |
+ForStmt | StructDecl | ForCStmt | ForInStmt | CompIf | ConstDecl | Attr | BranchStmt |
+HashStmt | AssignStmt | EnumDecl | TypeDecl | DeferStmt | GotoLabel | GotoStmt |
 LineComment | MultiLineComment | AssertStmt | UnsafeStmt
 
 pub type Type = StructType | ArrayType
@@ -154,6 +154,7 @@ mut:
 	args []Expr
 	is_c bool
 	muts []bool
+	or_block OrExpr
 }
 
 pub struct MethodCallExpr {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -319,18 +319,33 @@ fn (f mut Fmt) expr(node ast.Expr) {
 			f.expr(it.expr)
 			f.write(')')
 		}
-		ast.CallExpr {
+		ast.MethodCallExpr, ast.CallExpr {
+			match node {
+				ast.MethodCallExpr {
+					f.expr(it.expr)
+					f.write('.')
+				}
+				else{}
+			}
 			f.write('${it.name}(')
-			for i, expr in it.args {
+			for i, arg in it.args {
 				if it.muts[i] {
 					f.write('mut ')
 				}
-				f.expr(expr)
-				if i != it.args.len - 1 {
+				if i > 0 {
+					f.wrap_long_line()
+				}
+				f.expr(arg)
+				if i < it.args.len - 1 {
 					f.write(', ')
 				}
 			}
 			f.write(')')
+			if it.or_block.stmts.len > 0 {
+				f.writeln(' or {')
+				f.stmts(it.or_block.stmts)
+				f.write('}')
+			}
 		}
 		ast.CharLiteral {
 			f.write('`$it.val`')
@@ -417,28 +432,6 @@ fn (f mut Fmt) expr(node ast.Expr) {
 			}
 			f.indent--
 			f.write('}')
-		}
-		ast.MethodCallExpr {
-			f.expr(it.expr)
-			f.write('.' + it.name + '(')
-			for i, arg in it.args {
-				if it.muts[i] {
-					f.write('mut ')
-				}
-				if i > 0 {
-					f.wrap_long_line()
-				}
-				f.expr(arg)
-				if i < it.args.len - 1 {
-					f.write(', ')
-				}
-			}
-			f.write(')')
-			if it.or_block.stmts.len > 0 {
-				f.writeln(' or {')
-				f.stmts(it.or_block.stmts)
-				f.write('}')
-			}
 		}
 		ast.None {
 			f.write('none')

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -319,14 +319,7 @@ fn (f mut Fmt) expr(node ast.Expr) {
 			f.expr(it.expr)
 			f.write(')')
 		}
-		ast.MethodCallExpr, ast.CallExpr {
-			match node {
-				ast.MethodCallExpr {
-					f.expr(it.expr)
-					f.write('.')
-				}
-				else{}
-			}
+		ast.CallExpr {
 			f.write('${it.name}(')
 			for i, arg in it.args {
 				if it.muts[i] {
@@ -432,6 +425,28 @@ fn (f mut Fmt) expr(node ast.Expr) {
 			}
 			f.indent--
 			f.write('}')
+		}
+		ast.MethodCallExpr {
+			f.expr(it.expr)
+			f.write('.' + it.name + '(')
+			for i, arg in it.args {
+				if it.muts[i] {
+					f.write('mut ')
+				}
+				if i > 0 {
+					f.wrap_long_line()
+				}
+				f.expr(arg)
+				if i < it.args.len - 1 {
+					f.write(', ')
+				}
+			}
+			f.write(')')
+			if it.or_block.stmts.len > 0 {
+				f.writeln(' or {')
+				f.stmts(it.or_block.stmts)
+				f.write('}')
+			}
 		}
 		ast.None {
 			f.write('none')

--- a/vlib/v/fmt/tests/simple_expected.vv
+++ b/vlib/v/fmt/tests/simple_expected.vv
@@ -137,7 +137,7 @@ fn fn_with_or() int {
 }
 
 fn (f Foo) method_with_or() int {
-	fn_with_optional() or {
+	f.fn_with_optional() or {
 		return 10
 	}
 	return 20

--- a/vlib/v/fmt/tests/simple_expected.vv
+++ b/vlib/v/fmt/tests/simple_expected.vv
@@ -128,3 +128,17 @@ fn unsafe_fn() {
 		malloc(2)
 	}
 }
+
+fn fn_with_or() int {
+	fn_with_optional() or {
+		return 10
+	}
+	return 20
+}
+
+fn (f Foo) method_with_or() int {
+	fn_with_optional() or {
+		return 10
+	}
+	return 20
+}

--- a/vlib/v/fmt/tests/simple_input.vv
+++ b/vlib/v/fmt/tests/simple_input.vv
@@ -130,3 +130,17 @@ fn fn_with_multi_return() (int,string) {
 fn unsafe_fn() {
 unsafe { malloc(2) }
 }
+
+fn fn_with_or() int {
+	fn_with_optional() or {
+		return 10
+	}
+	return 20
+}
+
+fn (f Foo) method_with_or() int {
+	fn_with_optional() or {
+		return 10
+	}
+	return 20
+}

--- a/vlib/v/fmt/tests/simple_input.vv
+++ b/vlib/v/fmt/tests/simple_input.vv
@@ -139,7 +139,7 @@ fn fn_with_or() int {
 }
 
 fn (f Foo) method_with_or() int {
-	fn_with_optional() or {
+	f.fn_with_optional() or {
 		return 10
 	}
 	return 20

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -14,6 +14,11 @@ pub fn (p mut Parser) call_expr(is_c bool, mod string) ast.CallExpr {
 	fn_name := if is_c {'C.$name' } else if mod.len > 0 { '${mod}.$name' } else { name }
 	p.check(.lpar)
 	args, muts := p.call_args()
+	mut or_stmts := []ast.Stmt
+	if p.tok.kind == .key_orelse {
+		p.next()
+		or_stmts = p.parse_block()
+	}
 	node := ast.CallExpr{
 		name: fn_name
 		args: args
@@ -22,10 +27,9 @@ pub fn (p mut Parser) call_expr(is_c bool, mod string) ast.CallExpr {
 
 		pos: tok.position()
 		is_c: is_c
-	}
-	if p.tok.kind == .key_orelse {
-		p.next()
-		p.parse_block()
+		or_block: ast.OrExpr{
+			stmts: or_stmts
+		}
 	}
 	return node
 }


### PR DESCRIPTION
## Changelog

- Add `or_block` property for `ast.CallExpr`
- Add `or` processing for `ast.CallExpr` in `fmt`
- Add relevant tests for `fmt`