### PR TITLE
fmt: simplify `IndexExpr` processing

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -402,7 +402,10 @@ fn (f mut Fmt) expr(node ast.Expr) {
 			f.expr(it.right)
 		}
 		ast.IndexExpr {
-			f.index_expr(it)
+			f.expr(it.left)
+			f.write('[')
+			f.expr(it.index)
+			f.write(']')
 		}
 		ast.IntegerLiteral {
 			f.write(it.val.str())
@@ -471,6 +474,11 @@ fn (f mut Fmt) expr(node ast.Expr) {
 			f.write(it.op.str())
 			f.expr(it.right)
 		}
+		ast.RangeExpr {
+			f.expr(it.low)
+			f.write('..')
+			f.expr(it.high)
+		}
 		ast.SelectorExpr {
 			f.expr(it.expr)
 			f.write('.')
@@ -510,27 +518,5 @@ fn (f mut Fmt) wrap_long_line() {
 	if f.line_len > max_len {
 		f.write('\n' + tabs[f.indent + 1])
 		f.line_len = 0
-	}
-}
-
-fn (f mut Fmt) index_expr(node ast.IndexExpr) {
-	mut is_range := false
-	match node.index {
-		ast.RangeExpr {
-			is_range = true
-			f.expr(node.left)
-			f.write('[')
-			f.expr(it.low)
-			f.write('..')
-			f.expr(it.high)
-			f.write(']')
-		}
-		else {}
-	}
-	if !is_range {
-		f.expr(node.left)
-		f.write('[')
-		f.expr(node.index)
-		f.write(']')
 	}
 }

--- a/vlib/v/fmt/tests/simple_expected.vv
+++ b/vlib/v/fmt/tests/simple_expected.vv
@@ -56,8 +56,14 @@ fn new_user() User {
 }
 
 [inline]
-fn fn_contains_range_expr() {
-	a := 1 in arr[0..2]
+fn fn_contains_index_expr() {
+	a := 1 in arr[0..]
+	b := 1 in arr[..2]
+	c := 1 in arr[1..3]
+	d := arr[2]
+	e := arr[2..]
+	f := arr[..2]
+	g := arr[1..3]
 }
 
 fn voidfn() {

--- a/vlib/v/fmt/tests/simple_input.vv
+++ b/vlib/v/fmt/tests/simple_input.vv
@@ -59,8 +59,14 @@ User
 
 
 [inline]
-fn fn_contains_range_expr() {
-	a:=1 in arr[0..2]
+fn fn_contains_index_expr() {
+	a := 1 in arr[0..]
+	b := 1 in arr[..2]
+	c := 1 in arr[1..3]
+	d := arr[2]
+	e := arr[2..]
+	f := arr[..2]
+	g := arr[1..3]
 }
 
 fn   voidfn(){


### PR DESCRIPTION
## Changelog

- Move code from `Fmt.index_expr` to `Fmt.expr`
- Add more tests