### PR TITLE
array: reverse empty arrays correctly

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -328,6 +328,9 @@ pub fn (a mut array) push_many(val voidptr, size int) {
 // array.reverse returns a new array with the elements of
 // the original array in reverse order.
 pub fn (a array) reverse() array {
+	if a.len == 0 {
+		return a
+	}
 	arr := array{
 		len: a.len
 		cap: a.cap

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -328,7 +328,7 @@ pub fn (a mut array) push_many(val voidptr, size int) {
 // array.reverse returns a new array with the elements of
 // the original array in reverse order.
 pub fn (a array) reverse() array {
-	if a.len == 0 {
+	if a.len < 2 {
 		return a
 	}
 	arr := array{

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -266,6 +266,10 @@ fn test_reverse() {
 	for i, _ in d {
 		assert d[i] == b[b.len - i - 1]
 	}
+
+	e := []int
+	f := e.reverse()
+	assert f.len == 0
 }
 
 const (


### PR DESCRIPTION
Return the same array if array is empty.

Previously, calling `reverse` for an empty array was failed because of `calloc` zero bytes. :) Also, added a test.