### PR TITLE
cmd: store outfile of run command in temp dir

### DIFF
--- a/cmd/v/compile_options.v
+++ b/cmd/v/compile_options.v
@@ -39,6 +39,7 @@ pub fn new_v(args []string) &compiler.V {
 	mut out_name := cmdline.option(args, '-o', '')
 	mut dir := args[args.len-1]//.last()
 	if 'run' in args {
+		out_name = '$os.tmpdir()/v-build'
 		args_after_run := cmdline.only_non_options( cmdline.options_after(args,['run']) )
 		dir = if args_after_run.len>0 { args_after_run[0] } else { '' }
 	}


### PR DESCRIPTION
Currently the outfile of the `run` command is stored in the working directory.
I thought it would be better to store it in temp folder.

Golang adds a random number after `go-build`. It wasn't necessary yet, but maybe consider adding it in the future.