### PR TITLE
cmd: use x64 target and v2 parser with run arg

### DIFF
--- a/cmd/v/compile.v
+++ b/cmd/v/compile.v
@@ -19,7 +19,15 @@ fn compile(command string, args []string) {
 	if command == 'run' {
 		// always recompile for now, too error prone to skip recompilation otherwise
 		// for example for -repl usage, especially when piping lines to v
-		v.compile()
+		if v.pref.x64 {
+			v.compile_x64()
+		}
+		else if v.pref.v2 {
+			v.compile2()
+		}
+		else {
+			v.compile()
+		}
 		run_compiled_executable_and_exit(v, args)
 	}
 	mut tmark := benchmark.new_benchmark()


### PR DESCRIPTION
this PR makes it possible to use the x64 target or the new parser using the `run` command.