### PR TITLE
builtin: add V64_PRINTFORMAT (part 1)

### DIFF
--- a/vlib/compiler/cheaders.v
+++ b/vlib/compiler/cheaders.v
@@ -27,6 +27,19 @@ const (
 #endif
 
 #define OPTION_CAST(x) (x)
+
+#ifndef V64_PRINTFORMAT
+#ifdef PRIx64
+#define V64_PRINTFORMAT "0x%"PRIx64
+#elif defined(__WIN32__)
+#define V64_PRINTFORMAT "0x%I64x"
+#elif defined(__LINUX__) && defined(__LP64__)
+#define V64_PRINTFORMAT "0x%lx"
+#else
+#define V64_PRINTFORMAT "0x%llx"
+#endif
+#endif
+
 '
 	c_headers = '
 


### PR DESCRIPTION
This is part 1 of using C.V64_PRINTFORMAT instead of '0x%'C.PRIx64 .
It does not affect vlib/builtin/int.v yet, just defines
V64_PRINTFORMAT in vlib/compiler/cheaders.v .