### PR TITLE
builtin: add V64_PRINTFORMAT (part 2)

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -158,7 +158,7 @@ pub fn (n i64) hex() string {
 	hex := malloc(len)
 	// TODO
 	//count := C.sprintf(charptr(hex), '0x%'C.PRIx64, n)
-	count := C.sprintf(charptr(hex), '0x%llx', n)
+	count := C.sprintf(charptr(hex), C.V64_PRINTFORMAT, n)
 	return tos(hex, count)
 }
 
@@ -166,7 +166,7 @@ pub fn (n u64) hex() string {
 	len := if n > 0 { n.str().len + 3 } else { 19 }
 	hex := malloc(len)
 	//count := C.sprintf(charptr(hex), '0x%'C.PRIx64, n)
-	count := C.sprintf(charptr(hex), '0x%llx', n)
+	count := C.sprintf(charptr(hex), C.V64_PRINTFORMAT, n)
 	//count := C.sprintf(charptr(hex), '0x%lx', n)
 	return tos(hex, count)
 }

--- a/vlib/compiler/cheaders.v
+++ b/vlib/compiler/cheaders.v
@@ -27,6 +27,19 @@ const (
 #endif
 
 #define OPTION_CAST(x) (x)
+
+#ifndef V64_PRINTFORMAT
+#ifdef PRIx64
+#define V64_PRINTFORMAT "0x%"PRIx64
+#elif defined(__WIN32__)
+#define V64_PRINTFORMAT "0x%I64x"
+#elif defined(__LINUX__) && defined(__LP64__)
+#define V64_PRINTFORMAT "0x%lx"
+#else
+#define V64_PRINTFORMAT "0x%llx"
+#endif
+#endif
+
 '
 	c_headers = '
 


### PR DESCRIPTION
This PR uses V64_PRINTFORMAT inside vlib/builtin/int.v

It should be merged after #3893 .