### PR TITLE
os api: rmdir_recursive => rmdir_all

### DIFF
--- a/cmd/tools/modules/scripting/scripting.v
+++ b/cmd/tools/modules/scripting/scripting.v
@@ -43,7 +43,7 @@ pub fn rmrf(path string) {
 	verbose_trace(@FN, 'rm -rf $path')
 	if os.exists(path) {
 		if os.is_dir(path) {
-			os.rmdir_recursive(path)
+			os.rmdir_all(path)
 		}else{
 			os.rm(path)
 		}

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -275,7 +275,7 @@ fn vpm_remove(module_names []string) {
 		}
 		println('Removing module "$name"...')
 		verbose_println('removing folder $final_module_path')
-		os.rmdir_recursive(final_module_path)
+		os.rmdir_all(final_module_path)
 		// delete author directory if it is empty
 		author := name.split('.')[0]
 		author_dir := os.realpath(filepath.join(settings.vmodules_path,author))

--- a/vlib/compiler/tests/repl/repl_test.v
+++ b/vlib/compiler/tests/repl/repl_test.v
@@ -8,7 +8,7 @@ import sync
 import filepath
 
 fn test_the_v_compiler_can_be_invoked() {
-	vexec := runner.full_path_to_v(5)	
+	vexec := runner.full_path_to_v(5)
 	println('vexecutable: $vexec')
 	assert vexec != ''
 	vcmd := '"$vexec" --version'
@@ -73,30 +73,30 @@ fn process_in_thread( session mut Session, thread_id int ){
 		session.ntask++
 		idx := session.ntask-1
 		session.ntask_mtx.unlock()
-		
+
 		if idx >= session.options.files.len { break }
 		tls_bench.cstep = idx
 
 		tfolder := filepath.join( cdir, 'vrepl_tests_$idx')
 		if os.is_dir( tfolder ) {
-			os.rmdir_recursive( tfolder )
+			os.rmdir_all( tfolder )
 		}
 		os.mkdir( tfolder ) or { panic(err) }
-		
-		file := session.options.files[ idx ] 
+
+		file := session.options.files[ idx ]
 		session.bmark.step()
 		tls_bench.step()
 		fres := runner.run_repl_file(tfolder, session.options.vexec, file) or {
 			session.bmark.fail()
 			tls_bench.fail()
-			os.rmdir_recursive( tfolder )
+			os.rmdir_all( tfolder )
 			eprintln(tls_bench.step_message_fail(err))
 			assert false
 			continue
 		}
 		session.bmark.ok()
 		tls_bench.ok()
-		os.rmdir_recursive( tfolder )
+		os.rmdir_all( tfolder )
 		println(tls_bench.step_message_ok(fres))
 		assert true
 	}

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -621,7 +621,7 @@ pub fn rmdir(path string) {
 
 [deprecated]
 pub fn rmdir_recursive(path string) {
-	panic('use `os.rmdir_all` instead of `os.rmdir_recursive`')
+	panic('Use `os.rmdir_all` instead of `os.rmdir_recursive`')
 }
 
 pub fn rmdir_all(path string) {

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -619,13 +619,18 @@ pub fn rmdir(path string) {
 	}
 }
 
+[deprecated]
 pub fn rmdir_recursive(path string) {
+	panic('use os.rmdir_all(path) instead of os.rmdir_recursive(path)')
+}
+
+pub fn rmdir_all(path string) {
 	items := os.ls(path) or {
 		return
 	}
 	for item in items {
 		if os.is_dir(filepath.join(path,item)) {
-			rmdir_recursive(filepath.join(path,item))
+			rmdir_all(filepath.join(path,item))
 		}
 		os.rm(filepath.join(path,item))
 	}

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -621,7 +621,7 @@ pub fn rmdir(path string) {
 
 [deprecated]
 pub fn rmdir_recursive(path string) {
-	panic('use os.rmdir_all(path) instead of os.rmdir_recursive(path)')
+	panic('use `os.rmdir_all` instead of `os.rmdir_recursive`')
 }
 
 pub fn rmdir_all(path string) {

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -303,8 +303,8 @@ fn cleanup_leftovers() {
 	os.rm('cp_new_example.txt')
 
 	// possible leftovers from test_cp_r
-	os.rmdir_recursive('ex')
-	os.rmdir_recursive('ex2')
+	os.rmdir_all('ex')
+	os.rmdir_all('ex2')
 	os.rm('ex1.txt')
 	os.rm('ex2.txt')
 }


### PR DESCRIPTION
This PR use `rmdir_all` instead of `rmdir_recursive` in `os` module.

- mark `rmdir_recursive` as `[deprecated]`.
- add `rmdir_all` in `os` module instead of `rmdir_recursive`.
- modified related calls.

Why not use `remove` and `remove_all`?
- `rm` `rmdir` are closer to usage habits.
- `remove` must be judged to be a file, directory, or link, and link to folder will judged error on some platforms.
- it's better just like `mkdir` `mkdir_all`.

So I think it's more appropriate.
