### PR TITLE
os api: realpath => abs

### DIFF
--- a/cmd/tools/check-md.v
+++ b/cmd/tools/check-md.v
@@ -1,9 +1,6 @@
 module main
 
-import (
-	os
-	filepath
-)
+import os
 
 const (
 	too_long_line_length = 100
@@ -13,7 +10,7 @@ fn main() {
 	files_paths := os.args[1..]
 	mut errors := 0
 	for file_path in files_paths {
-		real_path := filepath.abs(file_path)
+		real_path := os.abs(file_path)
 		lines := os.read_lines(real_path) or {
 			continue
 		}

--- a/cmd/tools/check-md.v
+++ b/cmd/tools/check-md.v
@@ -1,6 +1,9 @@
 module main
 
-import os
+import (
+	os
+	filepath
+)
 
 const (
 	too_long_line_length = 100
@@ -10,7 +13,7 @@ fn main() {
 	files_paths := os.args[1..]
 	mut errors := 0
 	for file_path in files_paths {
-		real_path := os.realpath(file_path)
+		real_path := filepath.abs(file_path)
 		lines := os.read_lines(real_path) or {
 			continue
 		}
@@ -22,7 +25,7 @@ fn main() {
 		}
 	}
 	// TODO: uncomment this AFTER doc/docs.md line lengths are fixed
-	/*	
+	/*
 	if errors > 0 {
 		exit(1)
 	}

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -46,7 +46,7 @@ pub fn (ts mut TestSession) test() {
 	mut remaining_files := []string
 	for dot_relative_file in ts.files {
 		relative_file := dot_relative_file.replace('./', '')
-		file := os.realpath(relative_file)
+		file := filepath.abs(relative_file)
 		$if windows {
 			if file.contains('sqlite') || file.contains('httpbin') {
 				continue
@@ -115,7 +115,7 @@ fn (ts mut TestSession) process_files() {
 
 		dot_relative_file := ts.files[ idx ]
 		relative_file := dot_relative_file.replace('./', '')
-		file := os.realpath(relative_file)
+		file := filepath.abs(relative_file)
 		// Ensure that the generated binaries will be stored in the temporary folder.
 		// Remove them after a test passes/fails.
 		fname := filepath.filename(file)

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -46,7 +46,7 @@ pub fn (ts mut TestSession) test() {
 	mut remaining_files := []string
 	for dot_relative_file in ts.files {
 		relative_file := dot_relative_file.replace('./', '')
-		file := filepath.abs(relative_file)
+		file := os.abs(relative_file)
 		$if windows {
 			if file.contains('sqlite') || file.contains('httpbin') {
 				continue
@@ -115,7 +115,7 @@ fn (ts mut TestSession) process_files() {
 
 		dot_relative_file := ts.files[ idx ]
 		relative_file := dot_relative_file.replace('./', '')
-		file := filepath.abs(relative_file)
+		file := os.abs(relative_file)
 		// Ensure that the generated binaries will be stored in the temporary folder.
 		// Remove them after a test passes/fails.
 		fname := filepath.filename(file)

--- a/cmd/tools/modules/vgit/vgit.v
+++ b/cmd/tools/modules/vgit/vgit.v
@@ -42,7 +42,7 @@ pub fn line_to_timestamp_and_commit(line string) (int,string) {
 
 pub fn normalized_workpath_for_commit(workdir string, commit string) string {
 	nc := 'v_at_' + commit.replace('^', '_').replace('-', '_').replace('/', '_')
-	return os.realpath(workdir + filepath.separator + nc)
+	return filepath.abs(workdir + filepath.separator + nc)
 }
 
 pub fn prepare_vc_source(vcdir string, cdir string, commit string) (string,string) {
@@ -97,7 +97,7 @@ pub mut:
 
 pub fn (vgit_context mut VGitContext) compile_oldv_if_needed() {
 	vgit_context.vexename = if os.user_os() == 'windows' { 'v.exe' } else { 'v' }
-	vgit_context.vexepath = os.realpath( filepath.join(vgit_context.path_v, vgit_context.vexename) )
+	vgit_context.vexepath = filepath.abs( filepath.join(vgit_context.path_v, vgit_context.vexename) )
 	mut command_for_building_v_from_c_source := ''
 	mut command_for_selfbuilding := ''
 	if 'windows' == os.user_os() {
@@ -138,7 +138,7 @@ pub fn (vgit_context mut VGitContext) compile_oldv_if_needed() {
 
 pub fn add_common_tool_options<T>(context mut T, fp mut flag.FlagParser) []string {
 	tdir := os.tmpdir()
-	context.workdir = os.realpath(fp.string_('workdir', `w`, tdir, 'A writable base folder. Default: $tdir'))
+	context.workdir = filepath.abs(fp.string_('workdir', `w`, tdir, 'A writable base folder. Default: $tdir'))
 	context.v_repo_url = fp.string('vrepo', vgit.remote_v_repo_url, 'The url of the V repository. You can clone it locally too. See also --vcrepo below.')
 	context.vc_repo_url = fp.string('vcrepo', vgit.remote_vc_repo_url, 'The url of the vc repository. You can clone it
 ${flag.SPACE}beforehand, and then just give the local folder
@@ -159,11 +159,11 @@ ${flag.SPACE}to script it/run it in a restrictive vps/docker.
 	}
 
 	if os.is_dir(context.v_repo_url) {
-		context.v_repo_url = os.realpath( context.v_repo_url )
+		context.v_repo_url = filepath.abs( context.v_repo_url )
 	}
 
 	if os.is_dir(context.vc_repo_url) {
-		context.vc_repo_url = os.realpath( context.vc_repo_url )
+		context.vc_repo_url = filepath.abs( context.vc_repo_url )
 	}
 
 	commits := fp.finalize() or {

--- a/cmd/tools/modules/vgit/vgit.v
+++ b/cmd/tools/modules/vgit/vgit.v
@@ -42,7 +42,7 @@ pub fn line_to_timestamp_and_commit(line string) (int,string) {
 
 pub fn normalized_workpath_for_commit(workdir string, commit string) string {
 	nc := 'v_at_' + commit.replace('^', '_').replace('-', '_').replace('/', '_')
-	return filepath.abs(workdir + filepath.separator + nc)
+	return os.abs(workdir + filepath.separator + nc)
 }
 
 pub fn prepare_vc_source(vcdir string, cdir string, commit string) (string,string) {
@@ -97,7 +97,7 @@ pub mut:
 
 pub fn (vgit_context mut VGitContext) compile_oldv_if_needed() {
 	vgit_context.vexename = if os.user_os() == 'windows' { 'v.exe' } else { 'v' }
-	vgit_context.vexepath = filepath.abs( filepath.join(vgit_context.path_v, vgit_context.vexename) )
+	vgit_context.vexepath = os.abs( filepath.join(vgit_context.path_v, vgit_context.vexename) )
 	mut command_for_building_v_from_c_source := ''
 	mut command_for_selfbuilding := ''
 	if 'windows' == os.user_os() {
@@ -138,7 +138,7 @@ pub fn (vgit_context mut VGitContext) compile_oldv_if_needed() {
 
 pub fn add_common_tool_options<T>(context mut T, fp mut flag.FlagParser) []string {
 	tdir := os.tmpdir()
-	context.workdir = filepath.abs(fp.string_('workdir', `w`, tdir, 'A writable base folder. Default: $tdir'))
+	context.workdir = os.abs(fp.string_('workdir', `w`, tdir, 'A writable base folder. Default: $tdir'))
 	context.v_repo_url = fp.string('vrepo', vgit.remote_v_repo_url, 'The url of the V repository. You can clone it locally too. See also --vcrepo below.')
 	context.vc_repo_url = fp.string('vcrepo', vgit.remote_vc_repo_url, 'The url of the vc repository. You can clone it
 ${flag.SPACE}beforehand, and then just give the local folder
@@ -159,11 +159,11 @@ ${flag.SPACE}to script it/run it in a restrictive vps/docker.
 	}
 
 	if os.is_dir(context.v_repo_url) {
-		context.v_repo_url = filepath.abs( context.v_repo_url )
+		context.v_repo_url = os.abs( context.v_repo_url )
 	}
 
 	if os.is_dir(context.vc_repo_url) {
-		context.vc_repo_url = filepath.abs( context.vc_repo_url )
+		context.vc_repo_url = os.abs( context.vc_repo_url )
 	}
 
 	commits := fp.finalize() or {

--- a/cmd/tools/performance_compare.v
+++ b/cmd/tools/performance_compare.v
@@ -165,7 +165,7 @@ fn (c Context) compare_v_performance(label string, commands []string) string {
 		hyperfine_commands_arguments << " \'cd ${c.a:-34s} ; ./$cmd \' ".replace_each(['@COMPILER@', source_location_a, '@DEBUG@', debug_option_a])
 	}
 	// /////////////////////////////////////////////////////////////////////////////
-	cmd_stats_file := os.realpath([c.workdir, 'v_performance_stats_${label}.json'].join(filepath.separator))
+	cmd_stats_file := filepath.abs([c.workdir, 'v_performance_stats_${label}.json'].join(filepath.separator))
 	comparison_cmd := 'hyperfine $c.hyperfineopts ' + '--export-json ${cmd_stats_file} ' + '--time-unit millisecond ' + '--style full --warmup $c.warmups ' + hyperfine_commands_arguments.join(' ')
 	// /////////////////////////////////////////////////////////////////////////////
 	if c.verbose {

--- a/cmd/tools/performance_compare.v
+++ b/cmd/tools/performance_compare.v
@@ -165,7 +165,7 @@ fn (c Context) compare_v_performance(label string, commands []string) string {
 		hyperfine_commands_arguments << " \'cd ${c.a:-34s} ; ./$cmd \' ".replace_each(['@COMPILER@', source_location_a, '@DEBUG@', debug_option_a])
 	}
 	// /////////////////////////////////////////////////////////////////////////////
-	cmd_stats_file := filepath.abs([c.workdir, 'v_performance_stats_${label}.json'].join(filepath.separator))
+	cmd_stats_file := os.abs([c.workdir, 'v_performance_stats_${label}.json'].join(filepath.separator))
 	comparison_cmd := 'hyperfine $c.hyperfineopts ' + '--export-json ${cmd_stats_file} ' + '--time-unit millisecond ' + '--style full --warmup $c.warmups ' + hyperfine_commands_arguments.join(' ')
 	// /////////////////////////////////////////////////////////////////////////////
 	if c.verbose {

--- a/cmd/tools/preludes/tests_assertions.v
+++ b/cmd/tools/preludes/tests_assertions.v
@@ -20,7 +20,7 @@ fn cb_assertion_failed(filename string, line int, sourceline string, funcname st
 		else {
 			true}
 	}
-	final_filename := if use_relative_paths { filename } else { filepath.abs(filename) }
+	final_filename := if use_relative_paths { filename } else { os.abs(filename) }
 	final_funcname := funcname.replace('main__', '').replace('__', '.')
 	mut fail_message := 'FAILED assertion'
 	if color_on {

--- a/cmd/tools/preludes/tests_assertions.v
+++ b/cmd/tools/preludes/tests_assertions.v
@@ -2,6 +2,7 @@ module main
 
 import os
 import term
+import filepath
 // //////////////////////////////////////////////////////////////////
 // / This file will get compiled as part of the main program,
 // / for a _test.v file.
@@ -19,7 +20,7 @@ fn cb_assertion_failed(filename string, line int, sourceline string, funcname st
 		else {
 			true}
 	}
-	final_filename := if use_relative_paths { filename } else { os.realpath(filename) }
+	final_filename := if use_relative_paths { filename } else { filepath.abs(filename) }
 	final_funcname := funcname.replace('main__', '').replace('__', '.')
 	mut fail_message := 'FAILED assertion'
 	if color_on {

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -105,7 +105,7 @@ fn main() {
 	}
 	mut errors := 0
 	for file in files {
-		fpath := filepath.abs(file)
+		fpath := os.abs(file)
 		mut worker_command_array := cli_args_no_files.clone()
 		worker_command_array << ['-worker', fpath]
 		worker_cmd := worker_command_array.join(' ')
@@ -381,7 +381,7 @@ fn get_compile_name_of_potential_v_project(file string) string {
 	// This function get_compile_name_of_potential_v_project returns:
 	// a) the file's folder, if file is part of a v project
 	// b) the file itself, if the file is a standalone v program
-	pfolder := filepath.abs(filepath.dir(file))
+	pfolder := os.abs(filepath.dir(file))
 	// a .v project has many 'module main' files in one folder
 	// if there is only one .v file, then it must be a standalone
 	all_files_in_pfolder := os.ls(pfolder) or {

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -105,7 +105,7 @@ fn main() {
 	}
 	mut errors := 0
 	for file in files {
-		fpath := os.realpath(file)
+		fpath := filepath.abs(file)
 		mut worker_command_array := cli_args_no_files.clone()
 		worker_command_array << ['-worker', fpath]
 		worker_cmd := worker_command_array.join(' ')
@@ -381,7 +381,7 @@ fn get_compile_name_of_potential_v_project(file string) string {
 	// This function get_compile_name_of_potential_v_project returns:
 	// a) the file's folder, if file is part of a v project
 	// b) the file itself, if the file is a standalone v program
-	pfolder := os.realpath(filepath.dir(file))
+	pfolder := filepath.abs(filepath.dir(file))
 	// a .v project has many 'module main' files in one folder
 	// if there is only one .v file, then it must be a standalone
 	all_files_in_pfolder := os.ls(pfolder) or {

--- a/cmd/tools/vnames.v
+++ b/cmd/tools/vnames.v
@@ -42,7 +42,7 @@ fn analyze_v_file(file string) {
 	for f in v.files { v.parse(f, .decl) }
 	fi := v.get_file_parser_index( file ) or { panic(err) }
 	fmod :=  v.parsers[fi].mod
-	
+
 	// output:
 	mut fns :=[]string
 	for _, f in v.table.fns {
@@ -51,7 +51,7 @@ fn analyze_v_file(file string) {
 	}
 	fns.sort()
 	for f in fns { println(f) }
-	
+
 }
 
 fn main(){
@@ -65,16 +65,16 @@ fn main(){
 	fp.arguments_description('FILE.v/FOLDER [FILE.v/FOLDER]...')
 	fp.limit_free_args_to_at_least(1)
 	fp.skip_executable()
-	show_help:=fp.bool_('help', `h`, false, 'Show this help screen\n')	
+	show_help:=fp.bool_('help', `h`, false, 'Show this help screen\n')
 	if( show_help ){
 		println( fp.usage() )
 		exit(0)
 	}
-	
+
 	mut files := []string
 	locations := fp.finalize() or { eprintln('Error: ' + err) exit(1) }
 	for xloc in locations {
-		loc := os.realpath(xloc)
+		loc := filepath.abs(xloc)
 		xfiles := if os.is_dir(loc){ os.walk_ext(loc,'.v') } else { [loc] }
 		filtered_files := xfiles.filter(!it.ends_with('_js.v'))
 		files << filtered_files

--- a/cmd/tools/vnames.v
+++ b/cmd/tools/vnames.v
@@ -74,7 +74,7 @@ fn main(){
 	mut files := []string
 	locations := fp.finalize() or { eprintln('Error: ' + err) exit(1) }
 	for xloc in locations {
-		loc := filepath.abs(xloc)
+		loc := os.abs(xloc)
 		xfiles := if os.is_dir(loc){ os.walk_ext(loc,'.v') } else { [loc] }
 		filtered_files := xfiles.filter(!it.ends_with('_js.v'))
 		files << filtered_files

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -177,7 +177,7 @@ fn vpm_install(module_names []string) {
 			println('Skipping module "$name", since it uses an unsupported VCS {$vcs} .')
 			continue
 		}
-		final_module_path := os.realpath(filepath.join(settings.vmodules_path,mod.name.replace('.', filepath.separator)))
+		final_module_path := filepath.abs(filepath.join(settings.vmodules_path,mod.name.replace('.', filepath.separator)))
 		if os.exists(final_module_path) {
 			vpm_update([name])
 			continue
@@ -278,7 +278,7 @@ fn vpm_remove(module_names []string) {
 		os.rmdir_recursive(final_module_path)
 		// delete author directory if it is empty
 		author := name.split('.')[0]
-		author_dir := os.realpath(filepath.join(settings.vmodules_path,author))
+		author_dir := filepath.abs(filepath.join(settings.vmodules_path,author))
 		if os.is_dir_empty(author_dir) {
 			verbose_println('removing author folder $author_dir')
 			os.rmdir(author_dir)
@@ -288,7 +288,7 @@ fn vpm_remove(module_names []string) {
 
 fn valid_final_path_of_existing_module(name string) ?string {
 	name_of_vmodules_folder := filepath.join(settings.vmodules_path,name.replace('.', filepath.separator))
-	final_module_path := os.realpath(name_of_vmodules_folder)
+	final_module_path := filepath.abs(name_of_vmodules_folder)
 	if !os.exists(final_module_path) {
 		println('No module with name "$name" exists at $name_of_vmodules_folder')
 		return none
@@ -326,7 +326,7 @@ fn vpm_help(module_names []string) {
 fn vcs_used_in_dir(dir string) ?[]string {
 	mut vcs := []string
 	for repo_subfolder in supported_vcs_folders {
-		checked_folder := os.realpath(filepath.join(dir,repo_subfolder))
+		checked_folder := filepath.abs(filepath.join(dir,repo_subfolder))
 		if os.is_dir(checked_folder) {
 			vcs << repo_subfolder.replace('.', '')
 		}

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -177,7 +177,7 @@ fn vpm_install(module_names []string) {
 			println('Skipping module "$name", since it uses an unsupported VCS {$vcs} .')
 			continue
 		}
-		final_module_path := filepath.abs(filepath.join(settings.vmodules_path,mod.name.replace('.', filepath.separator)))
+		final_module_path := os.abs(filepath.join(settings.vmodules_path,mod.name.replace('.', filepath.separator)))
 		if os.exists(final_module_path) {
 			vpm_update([name])
 			continue
@@ -278,7 +278,7 @@ fn vpm_remove(module_names []string) {
 		os.rmdir_recursive(final_module_path)
 		// delete author directory if it is empty
 		author := name.split('.')[0]
-		author_dir := filepath.abs(filepath.join(settings.vmodules_path,author))
+		author_dir := os.abs(filepath.join(settings.vmodules_path,author))
 		if os.is_dir_empty(author_dir) {
 			verbose_println('removing author folder $author_dir')
 			os.rmdir(author_dir)
@@ -288,7 +288,7 @@ fn vpm_remove(module_names []string) {
 
 fn valid_final_path_of_existing_module(name string) ?string {
 	name_of_vmodules_folder := filepath.join(settings.vmodules_path,name.replace('.', filepath.separator))
-	final_module_path := filepath.abs(name_of_vmodules_folder)
+	final_module_path := os.abs(name_of_vmodules_folder)
 	if !os.exists(final_module_path) {
 		println('No module with name "$name" exists at $name_of_vmodules_folder')
 		return none
@@ -326,7 +326,7 @@ fn vpm_help(module_names []string) {
 fn vcs_used_in_dir(dir string) ?[]string {
 	mut vcs := []string
 	for repo_subfolder in supported_vcs_folders {
-		checked_folder := filepath.abs(filepath.join(dir,repo_subfolder))
+		checked_folder := os.abs(filepath.join(dir,repo_subfolder))
 		if os.is_dir(checked_folder) {
 			vcs << repo_subfolder.replace('.', '')
 		}

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -217,7 +217,7 @@ fn main() {
 	// so that the repl can be launched in parallel by several different
 	// threads by the REPL test runner.
 	args := cmdline.options_after(os.args, ['repl'])
-	replfolder := filepath.abs( cmdline.option(args, '-replfolder', '.') )
+	replfolder := os.abs( cmdline.option(args, '-replfolder', '.') )
 	replprefix := cmdline.option(args, '-replprefix', 'noprefix.')
 	os.chdir( replfolder )
 	if !os.exists(os.getenv('VEXE')) {

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -217,7 +217,7 @@ fn main() {
 	// so that the repl can be launched in parallel by several different
 	// threads by the REPL test runner.
 	args := cmdline.options_after(os.args, ['repl'])
-	replfolder := os.realpath( cmdline.option(args, '-replfolder', '.') )
+	replfolder := filepath.abs( cmdline.option(args, '-replfolder', '.') )
 	replprefix := cmdline.option(args, '-replprefix', 'noprefix.')
 	os.chdir( replfolder )
 	if !os.exists(os.getenv('VEXE')) {

--- a/cmd/v/compile_options.v
+++ b/cmd/v/compile_options.v
@@ -99,7 +99,7 @@ pub fn new_v(args []string) &compiler.V {
 	defines := cmdline.options(args, '-d')
 	compile_defines, compile_defines_all := parse_defines( defines )
 
-	rdir := filepath.abs(dir)
+	rdir := os.abs(dir)
 	rdir_name := filepath.filename(rdir)
 	if '-bare' in args {
 		println('V error: use -freestanding instead of -bare')

--- a/cmd/v/compile_options.v
+++ b/cmd/v/compile_options.v
@@ -99,7 +99,7 @@ pub fn new_v(args []string) &compiler.V {
 	defines := cmdline.options(args, '-d')
 	compile_defines, compile_defines_all := parse_defines( defines )
 
-	rdir := os.realpath(dir)
+	rdir := filepath.abs(dir)
 	rdir_name := filepath.filename(rdir)
 	if '-bare' in args {
 		println('V error: use -freestanding instead of -bare')

--- a/cmd/v/simple_tool.v
+++ b/cmd/v/simple_tool.v
@@ -21,8 +21,8 @@ fn launch_tool(is_verbose bool, tname string, cmdname string) {
 	}
 	mut compilation_options := os.args[1..tname_index].clone()
 	tool_args := os.args[1..].join(' ')
-	tool_exe := path_of_executable(os.realpath('$vroot/cmd/tools/$tname'))
-	tool_source := os.realpath('$vroot/cmd/tools/${tname}.v')
+	tool_exe := path_of_executable(filepath.abs('$vroot/cmd/tools/$tname'))
+	tool_source := filepath.abs('$vroot/cmd/tools/${tname}.v')
 	tool_command := '"$tool_exe" $tool_args'
 	if is_verbose {
 		eprintln('launch_tool vexe        : $vroot')

--- a/cmd/v/simple_tool.v
+++ b/cmd/v/simple_tool.v
@@ -21,8 +21,8 @@ fn launch_tool(is_verbose bool, tname string, cmdname string) {
 	}
 	mut compilation_options := os.args[1..tname_index].clone()
 	tool_args := os.args[1..].join(' ')
-	tool_exe := path_of_executable(filepath.abs('$vroot/cmd/tools/$tname'))
-	tool_source := filepath.abs('$vroot/cmd/tools/${tname}.v')
+	tool_exe := path_of_executable(os.abs('$vroot/cmd/tools/$tname'))
+	tool_source := os.abs('$vroot/cmd/tools/${tname}.v')
 	tool_command := '"$tool_exe" $tool_args'
 	if is_verbose {
 		eprintln('launch_tool vexe        : $vroot')

--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -177,7 +177,7 @@ fn (v mut V) new_parser_from_file(path string) Parser {
 		}
 	}
 	mut p := v.new_parser(new_scanner_file(path))
-	path_dir := os.realpath(filepath.dir(path))
+	path_dir := filepath.abs(filepath.dir(path))
 	p = {
 		p |
 		file_path:path,
@@ -419,7 +419,7 @@ fn (p mut Parser) statements_from_text(text string, rcbr bool, fpath string) {
 
 fn (p mut Parser) parse(pass Pass) {
 	p.cgen.line = 0
-	p.cgen.file = cescaped_path(os.realpath(p.file_path))
+	p.cgen.file = cescaped_path(filepath.abs(p.file_path))
 	// ///////////////////////////////////
 	p.pass = pass
 	p.token_idx = 0

--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -177,7 +177,7 @@ fn (v mut V) new_parser_from_file(path string) Parser {
 		}
 	}
 	mut p := v.new_parser(new_scanner_file(path))
-	path_dir := filepath.abs(filepath.dir(path))
+	path_dir := os.abs(filepath.dir(path))
 	p = {
 		p |
 		file_path:path,
@@ -419,7 +419,7 @@ fn (p mut Parser) statements_from_text(text string, rcbr bool, fpath string) {
 
 fn (p mut Parser) parse(pass Pass) {
 	p.cgen.line = 0
-	p.cgen.file = cescaped_path(filepath.abs(p.file_path))
+	p.cgen.file = cescaped_path(os.abs(p.file_path))
 	// ///////////////////////////////////
 	p.pass = pass
 	p.token_idx = 0

--- a/vlib/compiler/cflags.v
+++ b/vlib/compiler/cflags.v
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file.
 module compiler
 
-import filepath
+import os
 
 // parsed cflag
 struct CFlag {
@@ -58,7 +58,7 @@ fn (cf &CFlag) format() string {
 	}
 	// convert to absolute path
 	if cf.name == '-I' || cf.name == '-L' || value.ends_with('.o') {
-		value = '"' + filepath.abs(value) + '"'
+		value = '"' + os.abs(value) + '"'
 	}
 	return '$cf.name $value'.trim_space()
 }

--- a/vlib/compiler/cflags.v
+++ b/vlib/compiler/cflags.v
@@ -3,7 +3,8 @@
 // that can be found in the LICENSE file.
 module compiler
 
-import os
+import filepath
+
 // parsed cflag
 struct CFlag {
 	mod   string // the module in which the flag was given
@@ -23,7 +24,7 @@ fn (v &V) get_os_cflags() []CFlag {
 	if v.pref.compile_defines.len > 0 {
 		ctimedefines << v.pref.compile_defines
 	}
-	
+
 	for flag in v.table.cflags {
 		if flag.os == '' || (flag.os == 'linux' && v.pref.os == .linux) || (flag.os == 'darwin' && v.pref.os == .mac) || (flag.os == 'freebsd' && v.pref.os == .freebsd) || (flag.os == 'windows' && v.pref.os == .windows) {
 			flags << flag
@@ -57,7 +58,7 @@ fn (cf &CFlag) format() string {
 	}
 	// convert to absolute path
 	if cf.name == '-I' || cf.name == '-L' || value.ends_with('.o') {
-		value = '"' + os.realpath(value) + '"'
+		value = '"' + filepath.abs(value) + '"'
 	}
 	return '$cf.name $value'.trim_space()
 }
@@ -198,4 +199,3 @@ fn (cflags []CFlag) c_options_only_object_files() string {
 	}
 	return args.join(' ')
 }
-

--- a/vlib/compiler/cgen.v
+++ b/vlib/compiler/cgen.v
@@ -273,7 +273,7 @@ fn (g mut CGen) add_to_main(s string) {
 }
 
 fn (v &V) build_thirdparty_obj_file(path string, moduleflags []CFlag) {
-	obj_path := os.realpath(path)
+	obj_path := filepath.abs(path)
 	if os.exists(obj_path) {
 		return
 	}
@@ -285,7 +285,7 @@ fn (v &V) build_thirdparty_obj_file(path string, moduleflags []CFlag) {
 	mut cfiles := ''
 	for file in files {
 		if file.ends_with('.c') {
-			cfiles += '"' + os.realpath(parent + filepath.separator + file) + '" '
+			cfiles += '"' + filepath.abs(parent + filepath.separator + file) + '" '
 		}
 	}
 	btarget := moduleflags.c_options_before_target()

--- a/vlib/compiler/cgen.v
+++ b/vlib/compiler/cgen.v
@@ -273,7 +273,7 @@ fn (g mut CGen) add_to_main(s string) {
 }
 
 fn (v &V) build_thirdparty_obj_file(path string, moduleflags []CFlag) {
-	obj_path := filepath.abs(path)
+	obj_path := os.abs(path)
 	if os.exists(obj_path) {
 		return
 	}
@@ -285,7 +285,7 @@ fn (v &V) build_thirdparty_obj_file(path string, moduleflags []CFlag) {
 	mut cfiles := ''
 	for file in files {
 		if file.ends_with('.c') {
-			cfiles += '"' + filepath.abs(parent + filepath.separator + file) + '" '
+			cfiles += '"' + os.abs(parent + filepath.separator + file) + '" '
 		}
 	}
 	btarget := moduleflags.c_options_before_target()

--- a/vlib/compiler/compile_errors.v
+++ b/vlib/compiler/compile_errors.v
@@ -163,7 +163,7 @@ fn (s &Scanner) get_error_filepath() string {
 		}
 		return s.file_path
 	}
-	return os.realpath(s.file_path)
+	return filepath.abs(s.file_path)
 }
 
 fn (s &Scanner) is_color_output_on() bool {

--- a/vlib/compiler/compile_errors.v
+++ b/vlib/compiler/compile_errors.v
@@ -163,7 +163,7 @@ fn (s &Scanner) get_error_filepath() string {
 		}
 		return s.file_path
 	}
-	return filepath.abs(s.file_path)
+	return os.abs(s.file_path)
 }
 
 fn (s &Scanner) is_color_output_on() bool {

--- a/vlib/compiler/live.v
+++ b/vlib/compiler/live.v
@@ -79,7 +79,7 @@ fn (v &V) generate_hot_reload_code() {
 	mut cgen := v.cgen
 	// Hot code reloading
 	if v.pref.is_live {
-		mut file := os.realpath(v.pref.path)
+		mut file := filepath.abs(v.pref.path)
 		file_base := filepath.filename(file).replace('.v', '')
 		so_name := file_base + '.so'
 		// Need to build .so file before building the live application
@@ -225,4 +225,3 @@ void reload_so() {
 		cgen.genln(' int load_so(byteptr path) { return 0; }')
 	}
 }
-

--- a/vlib/compiler/live.v
+++ b/vlib/compiler/live.v
@@ -79,7 +79,7 @@ fn (v &V) generate_hot_reload_code() {
 	mut cgen := v.cgen
 	// Hot code reloading
 	if v.pref.is_live {
-		mut file := filepath.abs(v.pref.path)
+		mut file := os.abs(v.pref.path)
 		file_base := filepath.filename(file).replace('.v', '')
 		so_name := file_base + '.so'
 		// Need to build .so file before building the live application

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -39,7 +39,7 @@ pub mut:
 	mod_file_cacher     &ModFileCacher // used during lookup for v.mod to support @VROOT
 	out_name_c          string // name of the temporary C file
 	files               []string // all V files that need to be parsed and compiled
-	compiled_dir        string // contains filepath.abs() of the dir of the final file beeing compiled, or the dir itself when doing `v .`
+	compiled_dir        string // contains os.abs() of the dir of the final file beeing compiled, or the dir itself when doing `v .`
 	table               &Table // table with types, vars, functions etc
 	cgen                &CGen // C code generator
 	//x64                 &x64.Gen
@@ -57,7 +57,7 @@ pub mut:
 }
 
 pub fn new_v(pref &pref.Preferences) &V {
-	rdir := filepath.abs(pref.path)
+	rdir := os.abs(pref.path)
 
 	mut out_name_c := get_vtmp_filename(pref.out_name, '.tmp.c')
 	if pref.is_so {
@@ -106,13 +106,13 @@ pub fn (v &V) finalize_compilation() {
 pub fn (v mut V) add_parser(parser Parser) int {
 	pidx := v.parsers.len
 	v.parsers << parser
-	file_path := if filepath.is_abs(parser.file_path) { parser.file_path } else { filepath.abs(parser.file_path) }
+	file_path := if filepath.is_abs(parser.file_path) { parser.file_path } else { os.abs(parser.file_path) }
 	v.file_parser_idx[file_path] = pidx
 	return pidx
 }
 
 pub fn (v &V) get_file_parser_index(file string) ?int {
-	file_path := if filepath.is_abs(file) { file } else { filepath.abs(file) }
+	file_path := if filepath.is_abs(file) { file } else { os.abs(file) }
 	if file_path in v.file_parser_idx {
 		return v.file_parser_idx[file_path]
 	}
@@ -473,7 +473,7 @@ pub fn (v mut V) generate_main() {
 		lines_so_far := cgen.lines.join('\n').count('\n') + 5
 		cgen.genln('')
 		cgen.genln('// Reset the file/line numbers')
-		cgen.lines << '#line $lines_so_far "${cescaped_path(filepath.abs(cgen.out_path))}"'
+		cgen.lines << '#line $lines_so_far "${cescaped_path(os.abs(cgen.out_path))}"'
 		cgen.genln('')
 	}
 	// Make sure the main function exists
@@ -762,7 +762,7 @@ pub fn (v &V) get_user_files() []string {
 	}
 	if is_internal_module_test {
 		// v volt/slack_test.v: compile all .v files to get the environment
-		single_test_v_file := filepath.abs(dir)
+		single_test_v_file := os.abs(dir)
 		if v.pref.is_verbose {
 			v.log('> Compiling an internal module _test.v file $single_test_v_file .')
 			v.log('> That brings in all other ordinary .v files in the same module too .')
@@ -921,5 +921,5 @@ pub fn set_vroot_folder(vroot_path string) {
 	// VEXE env variable is needed so that compiler.vexe_path()
 	// can return it later to whoever needs it:
 	vname := if os.user_os() == 'windows' { 'v.exe' } else { 'v' }
-	os.setenv('VEXE', filepath.abs([vroot_path, vname].join(filepath.separator)), true)
+	os.setenv('VEXE', os.abs([vroot_path, vname].join(filepath.separator)), true)
 }

--- a/vlib/compiler/module_header.v
+++ b/vlib/compiler/module_header.v
@@ -35,7 +35,7 @@ fn generate_vh(mod string) {
 	pdir := dir.all_before_last(filepath.separator)
 	if !os.is_dir(pdir) {
 		os.mkdir_all(pdir)
-		// os.mkdir(os.realpath(dir)) or { panic(err) }
+		// os.mkdir(filepath.abs(dir)) or { panic(err) }
 	}
 	mut out := os.create(path)or{
 		panic(err)

--- a/vlib/compiler/module_header.v
+++ b/vlib/compiler/module_header.v
@@ -35,7 +35,7 @@ fn generate_vh(mod string) {
 	pdir := dir.all_before_last(filepath.separator)
 	if !os.is_dir(pdir) {
 		os.mkdir_all(pdir)
-		// os.mkdir(filepath.abs(dir)) or { panic(err) }
+		// os.mkdir(os.abs(dir)) or { panic(err) }
 	}
 	mut out := os.create(path)or{
 		panic(err)

--- a/vlib/compiler/msvc.v
+++ b/vlib/compiler/msvc.v
@@ -165,7 +165,7 @@ fn find_msvc() ?MsvcResult {
 			return error('Unable to find visual studio')
 		}
 		return MsvcResult{
-			full_cl_exe_path: filepath.abs(vs.exe_path + filepath.separator + 'cl.exe')
+			full_cl_exe_path: os.abs(vs.exe_path + filepath.separator + 'cl.exe')
 			exe_path: vs.exe_path
 			um_lib_path: wk.um_lib_path
 			ucrt_lib_path: wk.ucrt_lib_path
@@ -190,7 +190,7 @@ pub fn (v mut V) cc_msvc() {
 		verror('Cannot find MSVC on this OS')
 		return
 	}
-	out_name_obj := filepath.abs(v.out_name_c + '.obj')
+	out_name_obj := os.abs(v.out_name_c + '.obj')
 	// Default arguments
 	// volatile:ms enables atomic volatile (gcc _Atomic)
 	// -w: no warnings
@@ -217,7 +217,7 @@ pub fn (v mut V) cc_msvc() {
 	else if !v.pref.out_name.ends_with('.exe') {
 		v.pref.out_name += '.exe'
 	}
-	v.pref.out_name = filepath.abs(v.pref.out_name)
+	v.pref.out_name = os.abs(v.pref.out_name)
 	// alibs := []string // builtin.o os.o http.o etc
 	if v.pref.build_mode == .build_module {
 		// Compile only
@@ -225,7 +225,7 @@ pub fn (v mut V) cc_msvc() {
 	}
 	else if v.pref.build_mode == .default_mode {
 		/*
-		b := filepath.abs( '$v_modules_path/vlib/builtin.obj' )
+		b := os.abs( '$v_modules_path/vlib/builtin.obj' )
 		alibs << '"$b"'
 		if !os.exists(b) {
 			println('`builtin.obj` not found')
@@ -235,7 +235,7 @@ pub fn (v mut V) cc_msvc() {
 			if imp == 'webview' {
 				continue
 			}
-			alibs << '"' + filepath.abs( '$v_modules_path/vlib/${imp}.obj' ) + '"'
+			alibs << '"' + os.abs( '$v_modules_path/vlib/${imp}.obj' ) + '"'
 		}
 		*/
 	}
@@ -244,7 +244,7 @@ pub fn (v mut V) cc_msvc() {
 	}
 	// The C file we are compiling
 	// a << '"$TmpPath/$v.out_name_c"'
-	a << '"' + filepath.abs(v.out_name_c) + '"'
+	a << '"' + os.abs(v.out_name_c) + '"'
 	// Emily:
 	// Not all of these are needed (but the compiler should discard them if they are not used)
 	// these are the defaults used by msbuild and visual studio
@@ -310,7 +310,7 @@ fn build_thirdparty_obj_file_with_msvc(path string, moduleflags []CFlag) {
 	}
 	// msvc expects .obj not .o
 	mut obj_path := '${path}bj'
-	obj_path = filepath.abs(obj_path)
+	obj_path = os.abs(obj_path)
 	if os.exists(obj_path) {
 		println('$obj_path already built.')
 		return
@@ -323,7 +323,7 @@ fn build_thirdparty_obj_file_with_msvc(path string, moduleflags []CFlag) {
 	mut cfiles := ''
 	for file in files {
 		if file.ends_with('.c') {
-			cfiles += '"' + filepath.abs(parent + filepath.separator + file) + '" '
+			cfiles += '"' + os.abs(parent + filepath.separator + file) + '" '
 		}
 	}
 	include_string := '-I "$msvc.ucrt_include_path" -I "$msvc.vs_include_path" -I "$msvc.um_include_path" -I "$msvc.shared_include_path"'
@@ -395,7 +395,7 @@ fn (cflags []CFlag) msvc_string_flags() MsvcStringFlags {
 	}
 	mut lpaths := []string
 	for l in lib_paths {
-		lpaths << '/LIBPATH:"' + filepath.abs(l) + '"'
+		lpaths << '/LIBPATH:"' + os.abs(l) + '"'
 	}
 	return MsvcStringFlags{
 		real_libs:real_libs

--- a/vlib/compiler/msvc.v
+++ b/vlib/compiler/msvc.v
@@ -165,7 +165,7 @@ fn find_msvc() ?MsvcResult {
 			return error('Unable to find visual studio')
 		}
 		return MsvcResult{
-			full_cl_exe_path: os.realpath(vs.exe_path + filepath.separator + 'cl.exe')
+			full_cl_exe_path: filepath.abs(vs.exe_path + filepath.separator + 'cl.exe')
 			exe_path: vs.exe_path
 			um_lib_path: wk.um_lib_path
 			ucrt_lib_path: wk.ucrt_lib_path
@@ -190,7 +190,7 @@ pub fn (v mut V) cc_msvc() {
 		verror('Cannot find MSVC on this OS')
 		return
 	}
-	out_name_obj := os.realpath(v.out_name_c + '.obj')
+	out_name_obj := filepath.abs(v.out_name_c + '.obj')
 	// Default arguments
 	// volatile:ms enables atomic volatile (gcc _Atomic)
 	// -w: no warnings
@@ -217,7 +217,7 @@ pub fn (v mut V) cc_msvc() {
 	else if !v.pref.out_name.ends_with('.exe') {
 		v.pref.out_name += '.exe'
 	}
-	v.pref.out_name = os.realpath(v.pref.out_name)
+	v.pref.out_name = filepath.abs(v.pref.out_name)
 	// alibs := []string // builtin.o os.o http.o etc
 	if v.pref.build_mode == .build_module {
 		// Compile only
@@ -225,7 +225,7 @@ pub fn (v mut V) cc_msvc() {
 	}
 	else if v.pref.build_mode == .default_mode {
 		/*
-		b := os.realpath( '$v_modules_path/vlib/builtin.obj' )
+		b := filepath.abs( '$v_modules_path/vlib/builtin.obj' )
 		alibs << '"$b"'
 		if !os.exists(b) {
 			println('`builtin.obj` not found')
@@ -235,7 +235,7 @@ pub fn (v mut V) cc_msvc() {
 			if imp == 'webview' {
 				continue
 			}
-			alibs << '"' + os.realpath( '$v_modules_path/vlib/${imp}.obj' ) + '"'
+			alibs << '"' + filepath.abs( '$v_modules_path/vlib/${imp}.obj' ) + '"'
 		}
 		*/
 	}
@@ -244,7 +244,7 @@ pub fn (v mut V) cc_msvc() {
 	}
 	// The C file we are compiling
 	// a << '"$TmpPath/$v.out_name_c"'
-	a << '"' + os.realpath(v.out_name_c) + '"'
+	a << '"' + filepath.abs(v.out_name_c) + '"'
 	// Emily:
 	// Not all of these are needed (but the compiler should discard them if they are not used)
 	// these are the defaults used by msbuild and visual studio
@@ -310,7 +310,7 @@ fn build_thirdparty_obj_file_with_msvc(path string, moduleflags []CFlag) {
 	}
 	// msvc expects .obj not .o
 	mut obj_path := '${path}bj'
-	obj_path = os.realpath(obj_path)
+	obj_path = filepath.abs(obj_path)
 	if os.exists(obj_path) {
 		println('$obj_path already built.')
 		return
@@ -323,7 +323,7 @@ fn build_thirdparty_obj_file_with_msvc(path string, moduleflags []CFlag) {
 	mut cfiles := ''
 	for file in files {
 		if file.ends_with('.c') {
-			cfiles += '"' + os.realpath(parent + filepath.separator + file) + '" '
+			cfiles += '"' + filepath.abs(parent + filepath.separator + file) + '" '
 		}
 	}
 	include_string := '-I "$msvc.ucrt_include_path" -I "$msvc.vs_include_path" -I "$msvc.um_include_path" -I "$msvc.shared_include_path"'
@@ -395,7 +395,7 @@ fn (cflags []CFlag) msvc_string_flags() MsvcStringFlags {
 	}
 	mut lpaths := []string
 	for l in lib_paths {
-		lpaths << '/LIBPATH:"' + os.realpath(l) + '"'
+		lpaths << '/LIBPATH:"' + filepath.abs(l) + '"'
 	}
 	return MsvcStringFlags{
 		real_libs:real_libs

--- a/vlib/compiler/scanner.v
+++ b/vlib/compiler/scanner.v
@@ -565,7 +565,7 @@ fn (s mut Scanner) scan() ScanRes {
 				return scan_res(.str, s.fn_name)
 			}
 			if name == 'FILE' {
-				return scan_res(.str, cescaped_path(os.realpath(s.file_path)))
+				return scan_res(.str, cescaped_path(filepath.abs(s.file_path)))
 			}
 			if name == 'LINE' {
 				return scan_res(.str, (s.line_nr + 1).str())

--- a/vlib/compiler/scanner.v
+++ b/vlib/compiler/scanner.v
@@ -565,7 +565,7 @@ fn (s mut Scanner) scan() ScanRes {
 				return scan_res(.str, s.fn_name)
 			}
 			if name == 'FILE' {
-				return scan_res(.str, cescaped_path(filepath.abs(s.file_path)))
+				return scan_res(.str, cescaped_path(os.abs(s.file_path)))
 			}
 			if name == 'LINE' {
 				return scan_res(.str, (s.line_nr + 1).str())

--- a/vlib/compiler/tests/repl/runner/runner.v
+++ b/vlib/compiler/tests/repl/runner/runner.v
@@ -25,8 +25,8 @@ pub fn full_path_to_v(dirs_in int) string {
 	vexec := filepath.join( path, vname )
 	/*
 	args := os.args
-	vreal  := filepath.abs('v')
-	myself := filepath.abs( os.executable() )
+	vreal  := os.abs('v')
+	myself := os.abs( os.executable() )
 	wd := os.getwd()
 	println('args are: $args')
 	println('vreal   : $vreal')
@@ -59,9 +59,9 @@ pub fn run_repl_file(wd string, vexec string, file string) ?string {
 
 	fname := filepath.filename( file )
 
-	input_temporary_filename := filepath.abs(filepath.join( wd, 'input_temporary_filename.txt'))
+	input_temporary_filename := os.abs(filepath.join( wd, 'input_temporary_filename.txt'))
 	os.write_file(input_temporary_filename, input)
-	os.write_file( filepath.abs(filepath.join( wd, 'original.txt' ) ), fcontent )
+	os.write_file( os.abs(filepath.join( wd, 'original.txt' ) ), fcontent )
 	rcmd := '"$vexec" repl -replfolder "$wd" -replprefix "${fname}." < $input_temporary_filename'
 	r := os.exec(rcmd) or {
 		os.rm(input_temporary_filename)

--- a/vlib/compiler/tests/repl/runner/runner.v
+++ b/vlib/compiler/tests/repl/runner/runner.v
@@ -25,8 +25,8 @@ pub fn full_path_to_v(dirs_in int) string {
 	vexec := filepath.join( path, vname )
 	/*
 	args := os.args
-	vreal  := os.realpath('v')
-	myself := os.realpath( os.executable() )
+	vreal  := filepath.abs('v')
+	myself := filepath.abs( os.executable() )
 	wd := os.getwd()
 	println('args are: $args')
 	println('vreal   : $vreal')
@@ -59,9 +59,9 @@ pub fn run_repl_file(wd string, vexec string, file string) ?string {
 
 	fname := filepath.filename( file )
 
-	input_temporary_filename := os.realpath(filepath.join( wd, 'input_temporary_filename.txt'))
+	input_temporary_filename := filepath.abs(filepath.join( wd, 'input_temporary_filename.txt'))
 	os.write_file(input_temporary_filename, input)
-	os.write_file(  os.realpath(filepath.join( wd, 'original.txt' ) ), fcontent )
+	os.write_file( filepath.abs(filepath.join( wd, 'original.txt' ) ), fcontent )
 	rcmd := '"$vexec" repl -replfolder "$wd" -replprefix "${fname}." < $input_temporary_filename'
 	r := os.exec(rcmd) or {
 		os.rm(input_temporary_filename)

--- a/vlib/compiler/vtmp.v
+++ b/vlib/compiler/vtmp.v
@@ -18,5 +18,5 @@ fn get_vtmp_folder() string {
 
 fn get_vtmp_filename(base_file_name string, postfix string) string {
 	vtmp := get_vtmp_folder()
-	return filepath.abs(filepath.join(vtmp,filepath.filename(filepath.abs(base_file_name)) + postfix))
+	return os.abs(filepath.join(vtmp,filepath.filename(os.abs(base_file_name)) + postfix))
 }

--- a/vlib/compiler/vtmp.v
+++ b/vlib/compiler/vtmp.v
@@ -18,5 +18,5 @@ fn get_vtmp_folder() string {
 
 fn get_vtmp_filename(base_file_name string, postfix string) string {
 	vtmp := get_vtmp_folder()
-	return os.realpath(filepath.join(vtmp,filepath.filename(os.realpath(base_file_name)) + postfix))
+	return filepath.abs(filepath.join(vtmp,filepath.filename(filepath.abs(base_file_name)) + postfix))
 }

--- a/vlib/filepath/filepath.v
+++ b/vlib/filepath/filepath.v
@@ -1,9 +1,5 @@
 module filepath
 
-pub const (
-	MAX_PATH = 4096
-)
-
 // ext returns the extension in the file `path`.
 pub fn ext(path string) string {
 	pos := path.last_index('.') or {

--- a/vlib/filepath/filepath.v
+++ b/vlib/filepath/filepath.v
@@ -1,5 +1,9 @@
 module filepath
 
+pub const (
+	MAX_PATH = 4096
+)
+
 // ext returns the extension in the file `path`.
 pub fn ext(path string) string {
 	pos := path.last_index('.') or {
@@ -42,6 +46,28 @@ pub fn basedir(path string) string {
 	}
 	// NB: *without* terminating /
 	return path[..pos]
+}
+
+// Returns the full absolute path for fpath, with all relative ../../, symlinks and so on resolved.
+// See http://pubs.opengroup.org/onlinepubs/9699919799/functions/realpath.html
+// Also https://insanecoding.blogspot.com/2007/11/pathmax-simply-isnt.html
+// and https://insanecoding.blogspot.com/2007/11/implementing-realpath-in-c.html
+// NB: this particular rabbit hole is *deep* ...
+pub fn abs(fpath string) string {
+	mut fullpath := calloc(MAX_PATH)
+	mut ret := charptr(0)
+	$if windows {
+		ret = C._fullpath(fullpath, fpath.str, MAX_PATH)
+		if ret == 0 {
+			return fpath
+		}
+	} $else {
+		ret = C.realpath(fpath.str, fullpath)
+		if ret == 0 {
+			return fpath
+		}
+	}
+	return string(fullpath)
 }
 
 // filename returns a file name from path

--- a/vlib/filepath/filepath.v
+++ b/vlib/filepath/filepath.v
@@ -48,28 +48,6 @@ pub fn basedir(path string) string {
 	return path[..pos]
 }
 
-// Returns the full absolute path for fpath, with all relative ../../, symlinks and so on resolved.
-// See http://pubs.opengroup.org/onlinepubs/9699919799/functions/realpath.html
-// Also https://insanecoding.blogspot.com/2007/11/pathmax-simply-isnt.html
-// and https://insanecoding.blogspot.com/2007/11/implementing-realpath-in-c.html
-// NB: this particular rabbit hole is *deep* ...
-pub fn abs(fpath string) string {
-	mut fullpath := calloc(MAX_PATH)
-	mut ret := charptr(0)
-	$if windows {
-		ret = C._fullpath(fullpath, fpath.str, MAX_PATH)
-		if ret == 0 {
-			return fpath
-		}
-	} $else {
-		ret = C.realpath(fpath.str, fullpath)
-		if ret == 0 {
-			return fpath
-		}
-	}
-	return string(fullpath)
-}
-
 // filename returns a file name from path
 pub fn filename(path string) string {
 	return path.all_after(separator)

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -68,7 +68,7 @@ pub fn (l mut Log) set_output_level(level LogLevel) {
 }
 
 pub fn (l mut Log) set_full_logpath(full_log_path string) {
-	rlog_file := os.realpath( full_log_path )
+	rlog_file := filepath.abs( full_log_path )
 	l.set_output_label( filepath.filename( rlog_file ) )
 	l.set_output_path( filepath.basedir( rlog_file ) )
 }
@@ -80,7 +80,7 @@ pub fn (l mut Log) set_output_label(label string){
 pub fn (l mut Log) set_output_path(output_file_path string) {
 	if l.ofile.is_opened() { l.ofile.close() }
 	l.output_to_file = true
-	l.output_file_name = filepath.join( os.realpath( output_file_path ) , l.output_label )
+	l.output_file_name = filepath.join( filepath.abs( output_file_path ) , l.output_label )
 	ofile := os.open_append( l.output_file_name ) or {
 		panic('error while opening log file ${l.output_file_name} for appending')
 	}
@@ -137,4 +137,3 @@ pub fn (l mut Log) debug(s string) {
 	if l.level < .debug { return }
 	l.send_output(s, .debug)
 }
-

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -68,7 +68,7 @@ pub fn (l mut Log) set_output_level(level LogLevel) {
 }
 
 pub fn (l mut Log) set_full_logpath(full_log_path string) {
-	rlog_file := filepath.abs( full_log_path )
+	rlog_file := os.abs( full_log_path )
 	l.set_output_label( filepath.filename( rlog_file ) )
 	l.set_output_path( filepath.basedir( rlog_file ) )
 }
@@ -80,7 +80,7 @@ pub fn (l mut Log) set_output_label(label string){
 pub fn (l mut Log) set_output_path(output_file_path string) {
 	if l.ofile.is_opened() { l.ofile.close() }
 	l.output_to_file = true
-	l.output_file_name = filepath.join( filepath.abs( output_file_path ) , l.output_label )
+	l.output_file_name = filepath.join( os.abs( output_file_path ) , l.output_label )
 	ofile := os.open_append( l.output_file_name ) or {
 		panic('error while opening log file ${l.output_file_name} for appending')
 	}

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -176,8 +176,8 @@ pub fn cp_r(osource_path, odest_path string, overwrite bool) ?bool {
 }
 
 pub fn cp_all(osource_path, odest_path string, overwrite bool) ?bool {
-	source_path := os.realpath(osource_path)
-	dest_path := os.realpath(odest_path)
+	source_path := os.abs(osource_path)
+	dest_path := os.abs(odest_path)
 	if !os.exists(source_path) {
 		return error("Source path doesn\'t exist")
 	}
@@ -574,7 +574,7 @@ pub fn is_executable(path string) bool {
     // 02 Write-only
     // 04 Read-only
     // 06 Read and write
-    p := os.realpath( path )
+    p := filepath.abs( path )
     return ( os.exists( p ) && p.ends_with('.exe') )
   } $else {
     return C.access(path.str, X_OK) != -1
@@ -961,26 +961,9 @@ pub fn getwd() string {
 	}
 }
 
-// Returns the full absolute path for fpath, with all relative ../../, symlinks and so on resolved.
-// See http://pubs.opengroup.org/onlinepubs/9699919799/functions/realpath.html
-// Also https://insanecoding.blogspot.com/2007/11/pathmax-simply-isnt.html
-// and https://insanecoding.blogspot.com/2007/11/implementing-realpath-in-c.html
-// NB: this particular rabbit hole is *deep* ...
+[deprecated]
 pub fn realpath(fpath string) string {
-	mut fullpath := calloc(MAX_PATH)
-	mut ret := charptr(0)
-	$if windows {
-		ret = C._fullpath(fullpath, fpath.str, MAX_PATH)
-		if ret == 0 {
-			return fpath
-		}
-	} $else {
-		ret = C.realpath(fpath.str, fullpath)
-		if ret == 0 {
-			return fpath
-		}
-	}
-	return string(fullpath)
+	panic('Use `filepath.abs` instead of `os.realpath`')
 }
 
 // walk_ext returns a recursive list of all file paths ending with `ext`.
@@ -1164,10 +1147,10 @@ pub const (
 // It gives a convenient way to access program resources like images, fonts, sounds and so on,
 // *no matter* how the program was started, and what is the current working directory.
 pub fn resource_abs_path(path string) string {
-	mut base_path := os.realpath(filepath.dir(os.executable()))
+	mut base_path := filepath.abs(filepath.dir(os.executable()))
 	vresource := os.getenv('V_RESOURCE_PATH')
 	if vresource.len != 0 {
 		base_path = vresource
 	}
-	return os.realpath( filepath.join( base_path, path ) )
+	return filepath.abs( filepath.join( base_path, path ) )
 }

--- a/vlib/os/os_nix.v
+++ b/vlib/os/os_nix.v
@@ -1,6 +1,9 @@
 module os
 
-import strings
+import (
+	strings
+	filepath
+)
 
 #include <dirent.h>
 #include <unistd.h>
@@ -175,7 +178,7 @@ pub fn mkdir(path string) ?bool {
 	if path == '.' {
 		return true
 	}
-	apath := os.realpath(path)
+	apath := filepath.abs(path)
   /*
 	$if linux {
 		$if !android {

--- a/vlib/os/os_nix.v
+++ b/vlib/os/os_nix.v
@@ -178,7 +178,7 @@ pub fn mkdir(path string) ?bool {
 	if path == '.' {
 		return true
 	}
-	apath := filepath.abs(path)
+	apath := os.abs(path)
   /*
 	$if linux {
 		$if !android {

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -84,7 +84,7 @@ fn test_write_and_read_bytes() {
         file_name :=  './byte_reader_writer.tst'
         payload   :=  [`I`, `D`, `D`, `Q`, `D`]
 
-        mut file_write := os.create(filepath.abs(file_name)) or {
+        mut file_write := os.create(os.abs(file_name)) or {
                 eprintln('failed to create file $file_name')
                 return
         }
@@ -97,7 +97,7 @@ fn test_write_and_read_bytes() {
 
         assert payload.len == os.file_size(file_name)
 
-        mut file_read := os.open(filepath.abs(file_name)) or {
+        mut file_read := os.open(os.abs(file_name)) or {
           eprintln('failed to open file $file_name')
           return
         }

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -84,7 +84,7 @@ fn test_write_and_read_bytes() {
         file_name :=  './byte_reader_writer.tst'
         payload   :=  [`I`, `D`, `D`, `Q`, `D`]
 
-        mut file_write := os.create(os.realpath(file_name)) or {
+        mut file_write := os.create(filepath.abs(file_name)) or {
                 eprintln('failed to create file $file_name')
                 return
         }
@@ -97,7 +97,7 @@ fn test_write_and_read_bytes() {
 
         assert payload.len == os.file_size(file_name)
 
-        mut file_read := os.open(os.realpath(file_name)) or {
+        mut file_read := os.open(filepath.abs(file_name)) or {
           eprintln('failed to open file $file_name')
           return
         }

--- a/vlib/os/os_windows.v
+++ b/vlib/os/os_windows.v
@@ -1,9 +1,6 @@
 module os
 
-import (
-	strings
-	filepath
-)
+import strings
 
 #flag -lws2_32
 #include <winsock2.h>
@@ -180,7 +177,7 @@ pub fn (f mut File) writeln(s string) {
 // mkdir creates a new directory with the specified path.
 pub fn mkdir(path string) ?bool {
 	if path == '.' { return true }
-	apath := filepath.abs( path )
+	apath := os.abs( path )
 	if !C.CreateDirectory(apath.to_wide(), 0) {
 		return error('mkdir failed for "$apath", because CreateDirectory returned ' + get_error_msg(int(C.GetLastError())))
 	}

--- a/vlib/os/os_windows.v
+++ b/vlib/os/os_windows.v
@@ -1,6 +1,9 @@
 module os
 
-import strings
+import (
+	strings
+	filepath
+)
 
 #flag -lws2_32
 #include <winsock2.h>
@@ -177,7 +180,7 @@ pub fn (f mut File) writeln(s string) {
 // mkdir creates a new directory with the specified path.
 pub fn mkdir(path string) ?bool {
 	if path == '.' { return true }
-	apath := os.realpath( path )
+	apath := filepath.abs( path )
 	if !C.CreateDirectory(apath.to_wide(), 0) {
 		return error('mkdir failed for "$apath", because CreateDirectory returned ' + get_error_msg(int(C.GetLastError())))
 	}

--- a/vlib/sdl/examples/tvintris/tvintris.v
+++ b/vlib/sdl/examples/tvintris/tvintris.v
@@ -20,7 +20,7 @@ import sdl.ttf as ttf
 
 const (
 	Title = 'tVintris'
-	BASE = filepath.dir( os.realpath( os.executable() ) )
+	BASE = filepath.dir( filepath.abs( os.executable() ) )
 	FontName = BASE + '/fonts/RobotoMono-Regular.ttf'
 	MusicName = BASE + '/sounds/TwintrisThosenine.mod'
 	SndBlockName = BASE + '/sounds/block.wav'

--- a/vlib/sdl/examples/tvintris/tvintris.v
+++ b/vlib/sdl/examples/tvintris/tvintris.v
@@ -20,7 +20,7 @@ import sdl.ttf as ttf
 
 const (
 	Title = 'tVintris'
-	BASE = filepath.dir( filepath.abs( os.executable() ) )
+	BASE = filepath.dir( os.abs( os.executable() ) )
 	FontName = BASE + '/fonts/RobotoMono-Regular.ttf'
 	MusicName = BASE + '/sounds/TwintrisThosenine.mod'
 	SndBlockName = BASE + '/sounds/block.wav'

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -19,7 +19,7 @@ pub:
 	table               &table.Table
 	checker             checker.Checker
 	os                  pref.OS // the OS to build for
-	compiled_dir        string // contains filepath.abs() of the dir of the final file beeing compiled, or the dir itself when doing `v .`
+	compiled_dir        string // contains os.abs() of the dir of the final file beeing compiled, or the dir itself when doing `v .`
 	module_path         string
 mut:
 	module_search_paths []string

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -19,7 +19,7 @@ pub:
 	table               &table.Table
 	checker             checker.Checker
 	os                  pref.OS // the OS to build for
-	compiled_dir        string // contains os.realpath() of the dir of the final file beeing compiled, or the dir itself when doing `v .`
+	compiled_dir        string // contains filepath.abs() of the dir of the final file beeing compiled, or the dir itself when doing `v .`
 	module_path         string
 mut:
 	module_search_paths []string

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -24,7 +24,7 @@ pub fn (p mut Preferences) fill_with_defaults() {
 		p.vpath = default_module_path
 	}
 	if p.out_name == ''{
-		rpath := filepath.abs(p.path)
+		rpath := os.abs(p.path)
 		filename := filepath.filename(rpath).trim_space()
 		mut base := filename.all_before_last('.')
 		if base == '' {
@@ -71,7 +71,7 @@ pub fn vexe_path() string {
 	if vexe != '' {
 		return vexe
 	}
-	real_vexe_path := filepath.abs(os.executable())
+	real_vexe_path := os.abs(os.executable())
 	os.setenv('VEXE', real_vexe_path, true)
 	return real_vexe_path
 }

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -24,7 +24,7 @@ pub fn (p mut Preferences) fill_with_defaults() {
 		p.vpath = default_module_path
 	}
 	if p.out_name == ''{
-		rpath := os.realpath(p.path)
+		rpath := filepath.abs(p.path)
 		filename := filepath.filename(rpath).trim_space()
 		mut base := filename.all_before_last('.')
 		if base == '' {
@@ -71,7 +71,7 @@ pub fn vexe_path() string {
 	if vexe != '' {
 		return vexe
 	}
-	real_vexe_path := os.realpath(os.executable())
+	real_vexe_path := filepath.abs(os.executable())
 	os.setenv('VEXE', real_vexe_path, true)
 	return real_vexe_path
 }

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -573,7 +573,7 @@ pub fn (s mut Scanner) scan() token.Token {
 				return s.scan_res(.str, s.fn_name)
 			}
 			if name == 'FILE' {
-				return s.scan_res(.str, cescaped_path(filepath.abs(s.file_path)))
+				return s.scan_res(.str, cescaped_path(os.abs(s.file_path)))
 			}
 			if name == 'LINE' {
 				return s.scan_res(.str, (s.line_nr + 1).str())

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -573,7 +573,7 @@ pub fn (s mut Scanner) scan() token.Token {
 				return s.scan_res(.str, s.fn_name)
 			}
 			if name == 'FILE' {
-				return s.scan_res(.str, cescaped_path(os.realpath(s.file_path)))
+				return s.scan_res(.str, cescaped_path(filepath.abs(s.file_path)))
 			}
 			if name == 'LINE' {
 				return s.scan_res(.str, (s.line_nr + 1).str())


### PR DESCRIPTION
This PR use `filepath.abs` instead of `os.realpath`.

- mark `os.realpath` as `[deprecated]`.
- add `filepath.abs` instead of `os.realpath`.
- modified related calls.

Cause:
- it is like golang do in `filepath.abs`.
- there is `is_abs` in `filepath` module.
- it is more concise and accurate.