### PR TITLE
os api: cp_r => cp_all

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -172,7 +172,7 @@ pub fn cp(old, new string) ?bool {
 
 [deprecated]
 pub fn cp_r(osource_path, odest_path string, overwrite bool) ?bool {
-	panic('use os.cp_all(...) instead of os.cp_r(...)')
+	panic('use `os.cp_all` instead of `os.cp_r`')
 }
 
 pub fn cp_all(osource_path, odest_path string, overwrite bool) ?bool {

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -172,7 +172,7 @@ pub fn cp(old, new string) ?bool {
 
 [deprecated]
 pub fn cp_r(osource_path, odest_path string, overwrite bool) ?bool {
-	panic('use `os.cp_all` instead of `os.cp_r`')
+	panic('Use `os.cp_all` instead of `os.cp_r`')
 }
 
 pub fn cp_all(osource_path, odest_path string, overwrite bool) ?bool {

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -170,7 +170,12 @@ pub fn cp(old, new string) ?bool {
 	}
 }
 
+[deprecated]
 pub fn cp_r(osource_path, odest_path string, overwrite bool) ?bool {
+	panic('use os.cp_all(...) instead of os.cp_r(...)')
+}
+
+pub fn cp_all(osource_path, odest_path string, overwrite bool) ?bool {
 	source_path := os.realpath(osource_path)
 	dest_path := os.realpath(odest_path)
 	if !os.exists(source_path) {
@@ -206,7 +211,7 @@ pub fn cp_r(osource_path, odest_path string, overwrite bool) ?bool {
 				panic(err)
 			}
 		}
-		cp_r(sp, dp, overwrite) or {
+		cp_all(sp, dp, overwrite) or {
 			os.rmdir(dp)
 			panic(err)
 		}

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -171,18 +171,18 @@ fn test_cp_r() {
   // NB: clean up of the files happens inside the cleanup_leftovers function
   os.write_file('ex1.txt', 'wow!')
   os.mkdir('ex') or { panic(err) }
-  os.cp_r('ex1.txt', 'ex', false) or { panic(err) }
+  os.cp_all('ex1.txt', 'ex', false) or { panic(err) }
   old := os.read_file('ex1.txt') or { panic(err) }
   new := os.read_file('ex/ex1.txt') or { panic(err) }
   assert old == new
   os.mkdir('ex/ex2') or { panic(err) }
   os.write_file('ex2.txt', 'great!')
-  os.cp_r('ex2.txt', 'ex/ex2', false) or { panic(err) }
+  os.cp_all('ex2.txt', 'ex/ex2', false) or { panic(err) }
   old2 := os.read_file('ex2.txt') or { panic(err) }
   new2 := os.read_file('ex/ex2/ex2.txt') or { panic(err) }
   assert old2 == new2
   //recurring on dir -> local dir
-  os.cp_r('ex', './', true) or { panic(err) }
+  os.cp_all('ex', './', true) or { panic(err) }
 }
 
 fn test_tmpdir(){


### PR DESCRIPTION
This PR use `os.cp_all` instead of `os.cp_r`.

- mark `os.cp_r` as `[deprecated]`.
- add `os.cp_all` instead of `os.cp_r`.
- modified related calls.

Cause:
- it is like `mkdir_all` and `rmdir_all`.
- it is more concise and accurate.
- `cp` `mv` `rm` `ls` `rmdir` `mkdir` are closer to usage habits. 