### PR TITLE
os api: cachedir => cache_dir, tmpdir => tmp_dir just like home_dir

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -80,7 +80,7 @@ pub fn (ts mut TestSession) test() {
 
 fn worker_trunner(p mut sync.PoolProcessor, idx int, thread_id int) voidptr {
 	mut ts := &TestSession(p.get_shared_context())
-	tmpd := os.tmpdir()
+	tmpd := os.tmp_dir()
 	show_stats := '-stats' in ts.vargs.split(' ')
 	// tls_bench is used to format the step messages/timings
 	mut tls_bench := &benchmark.Benchmark(p.get_thread_context(idx))

--- a/cmd/tools/modules/vgit/vgit.v
+++ b/cmd/tools/modules/vgit/vgit.v
@@ -137,7 +137,7 @@ pub fn (vgit_context mut VGitContext) compile_oldv_if_needed() {
 }
 
 pub fn add_common_tool_options<T>(context mut T, fp mut flag.FlagParser) []string {
-	tdir := os.tmpdir()
+	tdir := os.tmp_dir()
 	context.workdir = os.realpath(fp.string_('workdir', `w`, tdir, 'A writable base folder. Default: $tdir'))
 	context.v_repo_url = fp.string('vrepo', vgit.remote_v_repo_url, 'The url of the V repository. You can clone it locally too. See also --vcrepo below.')
 	context.vc_repo_url = fp.string('vcrepo', vgit.remote_vc_repo_url, 'The url of the vc repository. You can clone it

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -156,7 +156,7 @@ fn (foptions &FormatOptions) format_file(file string) {
 		file_ast := parser.parse_file(file, table, .parse_comments)
 		formatted_content := fmt.fmt(file_ast, table)
 		file_name := filepath.filename(file)
-		vfmt_output_path := filepath.join(os.tmpdir(), 'vfmt_' + file_name)
+		vfmt_output_path := filepath.join(os.tmp_dir(), 'vfmt_' + file_name)
 		os.write_file(vfmt_output_path, formatted_content )
 		if foptions.is_verbose {
 			eprintln('vfmt2 fmt.fmt worked and ${formatted_content.len} bytes were written to ${vfmt_output_path} .')
@@ -164,7 +164,7 @@ fn (foptions &FormatOptions) format_file(file string) {
 		eprintln('${FORMATTED_FILE_TOKEN}${vfmt_output_path}')
 		return
 	}
-	tmpfolder := os.tmpdir()
+	tmpfolder := os.tmp_dir()
 	mut compiler_params := &pref.Preferences{}
 	target_os := file_to_target_os(file)
 	if target_os != '' {

--- a/vlib/compiler/tests/repl/repl_test.v
+++ b/vlib/compiler/tests/repl/repl_test.v
@@ -37,7 +37,7 @@ fn test_all_v_repl_files() {
 		bmark: benchmark.new_benchmark()
 	}
 	// warmup, and ensure that the vrepl is compiled in single threaded mode if it does not exist
-	runner.run_repl_file(os.cachedir(), session.options.vexec, 'vlib/compiler/tests/repl/nothing.repl') or {
+	runner.run_repl_file(os.cache_dir(), session.options.vexec, 'vlib/compiler/tests/repl/nothing.repl') or {
 		panic(err)
 	}
 	session.bmark.set_total_expected_steps(session.options.files.len)
@@ -55,7 +55,7 @@ fn test_all_v_repl_files() {
 }
 
 fn worker_repl(p mut sync.PoolProcessor, idx int, thread_id int) voidptr {
-	cdir := os.cachedir()
+	cdir := os.cache_dir()
 	mut session := &Session(p.get_shared_context())
 	mut tls_bench := &benchmark.Benchmark(p.get_thread_context(idx))
 	if isnil(tls_bench) {

--- a/vlib/compiler/vfmt.v
+++ b/vlib/compiler/vfmt.v
@@ -171,8 +171,8 @@ fn (p mut Parser) fnext() {
 		p.fgen_nl()
 		p.fmt_inc()
 	}
-	if p.token_idx >= p.tokens.len { 
-		return 
+	if p.token_idx >= p.tokens.len {
+		return
 	}
 	// Skip comments and add them to vfmt output
 	if p.tokens[p.token_idx].tok in [.line_comment, .mline_comment] {
@@ -298,7 +298,7 @@ fn (p &Parser) gen_fmt() {
 }
 
 fn write_formatted_source(file_name string, s string) string {
-	path := os.tmpdir() + '/' + file_name
+	path := os.tmp_dir() + '/' + file_name
 	mut out := os.create(path) or {
 		verror('failed to create file $path')
 		return ''

--- a/vlib/compiler/vtmp.v
+++ b/vlib/compiler/vtmp.v
@@ -7,7 +7,7 @@ import os
 import filepath
 
 fn get_vtmp_folder() string {
-	vtmp := filepath.join(os.tmpdir(),'v')
+	vtmp := filepath.join(os.tmp_dir(),'v')
 	if !os.is_dir(vtmp) {
 		os.mkdir(vtmp)or{
 			panic(err)

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -1105,8 +1105,13 @@ pub fn join(base string, dirs ...string) string {
 	panic('Use `filepath.join` instead of `os.join`')
 }
 
-// cachedir returns the path to a *writable* user specific folder, suitable for writing non-essential data.
+[deprecated]
 pub fn cachedir() string {
+	panic('Use `os.cache_dir` instead of `os.cachedir`')
+}
+
+// cache_dir returns the path to a *writable* user specific folder, suitable for writing non-essential data.
+pub fn cache_dir() string {
 	// See: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 	// There is a single base directory relative to which user-specific non-essential
 	// (cached) data should be written. This directory is defined by the environment
@@ -1129,8 +1134,13 @@ pub fn cachedir() string {
 	return cdir
 }
 
-// tmpdir returns the path to a folder, that is suitable for storing temporary files
+[deprecated]
 pub fn tmpdir() string {
+	panic('Use `os.tmp_dir` instead of `os.tmpdir`')
+}
+
+// tmp_dir returns the path to a folder, that is suitable for storing temporary files
+pub fn tmp_dir() string {
 	mut path := os.getenv('TMPDIR')
 	$if windows {
 		if path == '' {
@@ -1147,7 +1157,7 @@ pub fn tmpdir() string {
 		}
 	}
 	if path == '' {
-		path = os.cachedir()
+		path = os.cache_dir()
 	}
 	if path == '' {
 		path = '/tmp'

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -186,7 +186,7 @@ fn test_cp_r() {
 }
 
 fn test_tmpdir(){
-	t := os.tmpdir()
+	t := os.tmp_dir()
 	assert t.len > 0
 	assert os.is_dir(t)
 
@@ -269,7 +269,7 @@ fn test_symlink() {
 }
 
 fn test_is_executable_writable_readable() {
-  file_name := os.tmpdir() + filepath.separator + 'rwxfile.exe'
+  file_name := os.tmp_dir() + filepath.separator + 'rwxfile.exe'
 
   mut f := os.create(file_name) or {
     eprintln('failed to create file $file_name')

--- a/vlib/v/fmt/fmt_test.v
+++ b/vlib/v/fmt/fmt_test.v
@@ -22,7 +22,7 @@ fn test_fmt() {
 		exit(error_missing_vexe)
 	}
 	vroot := filepath.dir(vexe)
-	tmpfolder := os.tmpdir()
+	tmpfolder := os.tmp_dir()
 	diff_cmd := find_working_diff_command() or {
 		''
 	}


### PR DESCRIPTION
This PR use `os.cache_dir` instead of `os.cachedir` and `os.tmp_dir` instead of `os.tmpdir`.

- mark `os.cachedir` as `[deprecated]`.
- add `os.cache_dir` instead of `os.cachedir`.
- mark `os.tmpdir` as `[deprecated]`.
- add `os.tmp_dir` instead of `os.tmpdir`.
- modified related calls.

Cause:
- it is like `home_dir`.
- this can be consistent.