### PR TITLE
os api: symlink => link

### DIFF
--- a/vlib/os/os_nix.v
+++ b/vlib/os/os_nix.v
@@ -221,7 +221,12 @@ pub fn exec(cmd string) ?Result {
 	}
 }
 
+[deprecated]
 pub fn symlink(origin, target string) ?bool {
+	panic('use os.link() instead of os.symlink()')
+}
+
+pub fn link(origin, target string) ?bool {
 	res := C.symlink(origin.str, target.str)
 	if res == 0 {
 		return true

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -260,7 +260,7 @@ fn test_make_symlink_check_is_link_and_remove_symlink() {
 fn test_symlink() {
   $if windows { return }
   os.mkdir('symlink') or { panic(err) }
-  os.symlink('symlink', 'symlink2') or { panic(err) }
+  os.link('symlink', 'symlink2') or { panic(err) }
   assert os.exists('symlink2')
 
   // cleanup

--- a/vlib/os/os_windows.v
+++ b/vlib/os/os_windows.v
@@ -335,7 +335,12 @@ pub fn exec(cmd string) ?Result {
 
 fn C.CreateSymbolicLinkW(&u16, &u16, u32) int
 
+[deprecated]
 pub fn symlink(origin, target string) ?bool {
+	panic('use os.link() instead of os.symlink()')
+}
+
+pub fn link(origin, target string) ?bool {
 	flags := if os.is_dir(origin) { 1 } else { 0 }
 	if C.CreateSymbolicLinkW(origin.to_wide(), target.to_wide(), u32(flags)) != 0 {
 		return true


### PR DESCRIPTION
This PR use `os.link` instead of `os.symlink`.

- mark `os.symlink` as `[deprecated]`.
- add `os.link` instead of `os.symlink`.
- modified related calls.

Cause:
- it is like `Link` in golang.
- it is more concise and accurate.