### PR TITLE
os api: flush_stdout => flush

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -231,7 +231,7 @@ fn main() {
 
 pub fn rerror(s string) {
 	println('V repl error: $s')
-	os.flush_stdout()
+	os.flush()
 	exit(1)
 }
 

--- a/cmd/v/compile_options.v
+++ b/cmd/v/compile_options.v
@@ -33,7 +33,7 @@ pub fn new_v(args []string) &compiler.V {
 	if target_os == 'msvc' {
 		// notice that `-os msvc` became `-cc msvc`
 		println('V error: use the flag `-cc msvc` to build using msvc')
-		os.flush_stdout()
+		os.flush()
 		exit(1)
 	}
 	mut out_name := cmdline.option(args, '-o', '')
@@ -103,7 +103,7 @@ pub fn new_v(args []string) &compiler.V {
 	rdir_name := filepath.filename(rdir)
 	if '-bare' in args {
 		println('V error: use -freestanding instead of -bare')
-		os.flush_stdout()
+		os.flush()
 		exit(1)
 	}
 	is_repl := '-repl' in args
@@ -161,7 +161,7 @@ pub fn new_v(args []string) &compiler.V {
 	$if !linux {
 		if prefs.is_bare && !out_name.ends_with('.c') {
 			println('V error: -freestanding only works on Linux for now')
-			os.flush_stdout()
+			os.flush()
 			exit(1)
 		}
 	}

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -848,7 +848,7 @@ pub fn (v &V) log(s string) {
 
 pub fn verror(s string) {
 	println('V error: $s')
-	os.flush_stdout()
+	os.flush()
 	exit(1)
 }
 

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -1069,7 +1069,12 @@ pub fn log(s string) {
 	println('os.log: ' + s)
 }
 
+[deprecated]
 pub fn flush_stdout() {
+	panic('Use `os.flush` instead of `os.flush_stdout`')
+}
+
+pub fn flush() {
 	C.fflush(stdout)
 }
 

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1028,7 +1028,7 @@ pub fn (s &Scanner) error(msg string) {
 
 pub fn verror(s string) {
 	println('V error: $s')
-	os.flush_stdout()
+	os.flush()
 	exit(1)
 }
 


### PR DESCRIPTION
This PR use `os.flush` instead of `os.flush_stdout`.

- mark `os.flush_stdout` as `[deprecated]`.
- add `os.flush` instead of `os.flush_stdout`.
- modified related calls.

Cause:
- it is like `os.clear`.
- it is more concise.