### PR TITLE
compiler: stabilize the interface code generation a little

### DIFF
--- a/vlib/compiler/fn.v
+++ b/vlib/compiler/fn.v
@@ -1116,11 +1116,11 @@ fn (p mut Parser) fn_call_args(f mut Fn, generic_param_types []string) {
 			t := p.table.find_type(arg.typ)
 			if t.cat == .interface_ {
 				// NB: here concrete_type_name can be 'Dog' OR 'Dog_ptr'
-				// cgen should have generated *both* versions of the conversion
-				// functions, i.e. it should generate either:
-				// perform( _I_Dog_to_Speaker(dog) )
-				// OR
-				// perform( _I_Dog_ptr_to_Speaker(dog_ptr) )
+				// cgen should have generated a _I_Dog_to_Speaker conversion function
+				// C: perform( _I_Dog_to_Speaker((Dog){...}) )
+				// In case of _ptr, there is no need for conversion, so the generated
+				// code will be just:
+				// C: perform( dog_ptr )
 				concrete_type_name := typ.replace('*', '_ptr')
 				// concrete_type_name here can be say Dog, or ui__Group_ptr (in vui)
 				//eprintln('arg.typ: $arg.typ | concrete_type_name: $concrete_type_name ')

--- a/vlib/compiler/fn.v
+++ b/vlib/compiler/fn.v
@@ -1115,12 +1115,18 @@ fn (p mut Parser) fn_call_args(f mut Fn, generic_param_types []string) {
 		if arg.typ.ends_with('er') || arg.typ[0] == `I` {
 			t := p.table.find_type(arg.typ)
 			if t.cat == .interface_ {
-				// perform((Speaker) { ._object = &dog,
-				// _interface_idx = _Speaker_Dog_index })
-				if !f.is_method {
-					concrete_type_name := typ.replace('*', '_ptr')
-					p.cgen.set_placeholder(ph, '($arg.typ) { ._object = &')
-					p.gen(', ._interface_idx = _${arg.typ}_${concrete_type_name}_index} ')
+				// NB: here concrete_type_name can be 'Dog' OR 'Dog_ptr'
+				// cgen should have generated *both* versions of the conversion
+				// functions, i.e. it should generate either:
+				// perform( _I_Dog_to_Speaker(dog) )
+				// OR
+				// perform( _I_Dog_ptr_to_Speaker(dog_ptr) )
+				concrete_type_name := typ.replace('*', '_ptr')
+				// concrete_type_name here can be say Dog, or ui__Group_ptr (in vui)
+				//eprintln('arg.typ: $arg.typ | concrete_type_name: $concrete_type_name ')
+				if !concrete_type_name.ends_with('_ptr')  {
+					p.cgen.set_placeholder(ph, 'I_${concrete_type_name}_to_${arg.typ}(')
+					p.gen(')')
 				}
 				p.table.add_gen_type(arg.typ, typ)
 			}

--- a/vlib/compiler/tests/interfaces_map_test.v
+++ b/vlib/compiler/tests/interfaces_map_test.v
@@ -1,0 +1,49 @@
+module main
+
+interface Speaker {
+	say() string
+}
+
+struct ChatRoom {
+mut:
+	talkers map[string]Speaker
+}
+
+fn new_room() &ChatRoom {
+	return &ChatRoom{
+		talkers: map[string]Speaker
+	}
+}
+
+fn (r mut ChatRoom) add(name string, s Speaker) {
+	r.talkers[name] = s
+}
+
+fn test_using_a_map_of_speaker_interfaces(){
+	mut room := new_room()
+	room.add('my cat', Cat{name: 'Tigga'} )
+	room.add('my dog', Dog{name: 'Pirin'} )
+	room.add('stray dog', Dog{name: 'Anoni'} )
+	room.add('me', Human{name: 'Bilbo'} )
+	room.add('she', Human{name: 'Maria'} )
+	mut text := ''
+	for name, subject in room.talkers {
+		line := '${name:12s}: ${subject.say()}'
+		println(line)
+		text += line
+	}
+	assert text.contains(' meows ')
+	assert text.contains(' barks ')
+	assert text.contains(' says ')
+}
+
+//
+
+struct Cat { name string }
+fn (c &Cat) say() string { return '${c.name} meows "MEOW!"' }
+
+struct Dog { name string }
+fn (d &Dog) say() string { return '${d.name} barks "Bau Bau!"' }
+
+struct Human { name string }
+fn (h &Human) say() string { return '${h.name} says "Hello"' }


### PR DESCRIPTION
This PR adds another interface test case that regressed recently.
Also it now checks not for `if !f.is_method {` but for whether
casting from a concrete type to a interface is needed, and does
so in a generated C function, instead of inline (some compilers like
msvc seem to not like the inline version).