### PR TITLE
make: fix building v with msys2's make.exe on windows.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ endif
 
 all: latest_vc latest_tcc
 ifdef WIN32
-	$(CC) $(CFLAGS) -std=c99 -municode -w -o v2.exe $(TMPVC)/$(VCFILE) $(LDFLAGS)
+	$(CC) $(CFLAGS) -std=c99 -municode -w -o v.exe $(TMPVC)/$(VCFILE) $(LDFLAGS)
 	./v.exe self
 else
 	$(CC) $(CFLAGS) -std=gnu11 -w -o v $(TMPVC)/$(VCFILE) $(LDFLAGS) -lm


### PR DESCRIPTION
This PR fixes running make in a msys2 shell on windows, 
after a clean git clone (when v.exe is missing).