### PR TITLE
glfw freetype: remove the display of general information

### DIFF
--- a/vlib/freetype/freetype.v
+++ b/vlib/freetype/freetype.v
@@ -212,7 +212,7 @@ pub fn new_context(cfg gg.Cfg) &FreeType {
 		println('failed to load $font_path')
 		return 0
 	}
-	// println('Trying to load font from $font_path')
+	println('Trying to load font from $font_path')
 	face := C.FT_Face{}
 	ret = int(C.FT_New_Face(ft, font_path.str, 0, &face))
 	if ret != 0	{

--- a/vlib/freetype/freetype.v
+++ b/vlib/freetype/freetype.v
@@ -49,13 +49,13 @@ pub const (
 
 struct Character {
 	code i64
-	
+
 	texture_id u32
 	size       gg.Vec2
-	
+
 	horizontal_bearing_px gg.Vec2
 	horizontal_advance_px u32
-	
+
 	vertical_bearing_px   gg.Vec2
 	vertical_advance_px   u32
 }
@@ -112,7 +112,7 @@ struct C.Glyph {
 	bitmap_left int
 	bitmap_top int
 	advance Advance
-	metrics FT_Glyph_Metrics 
+	metrics FT_Glyph_Metrics
 }
 
 [typedef]
@@ -155,10 +155,10 @@ fn ft_load_char(face C.FT_Face, code i64) Character {
 		size:    gg.vec2(fgwidth, fgrows)
 
 		// Note: advance is number of 1/64 pixels
-		// Bitshift by 6 to get value in pixels (2^6 = 64 (divide amount of 1/64th pixels by 64 to get amount of pixels))		
+		// Bitshift by 6 to get value in pixels (2^6 = 64 (divide amount of 1/64th pixels by 64 to get amount of pixels))
 		horizontal_bearing_px:  gg.vec2(face.glyph.metrics.horiBearingX >> 6, face.glyph.metrics.horiBearingY >> 6)
 		vertical_bearing_px:    gg.vec2(face.glyph.metrics.vertBearingX >> 6, face.glyph.metrics.vertBearingY >> 6) // not used for now
-		
+
 		horizontal_advance_px:  face.glyph.metrics.horiAdvance >> 6
 		vertical_advance_px:    face.glyph.metrics.vertAdvance >> 6
 	}
@@ -212,7 +212,7 @@ pub fn new_context(cfg gg.Cfg) &FreeType {
 		println('failed to load $font_path')
 		return 0
 	}
-	println('Trying to load font from $font_path')
+	// println('Trying to load font from $font_path')
 	face := C.FT_Face{}
 	ret = int(C.FT_New_Face(ft, font_path.str, 0, &face))
 	if ret != 0	{
@@ -408,7 +408,7 @@ pub fn (ctx mut FreeType) text_size(s string) (int, int) {
 	mut ch := Character{}
 	for i in 0..utext.len {
 		_rune = utext.at(i)
-		ch = Character{}		
+		ch = Character{}
 		mut found := false
 		if _rune.len == 1 {
 			idx := _rune[0]
@@ -444,7 +444,7 @@ pub fn (ctx mut FreeType) text_size(s string) (int, int) {
 	//scaled_x := x
 	//scaled_y := maxy
 	scaled_x := int(f64(x)/ctx.scale)
-	scaled_y := int(f64(maxy)/ctx.scale)	
+	scaled_y := int(f64(maxy)/ctx.scale)
 	//println('text_size of "${s}" | x,y: $x,$maxy | scaled_x: ${scaled_x:3d} | scaled_y: ${scaled_y:3d} ')
 	return scaled_x, scaled_y
 }

--- a/vlib/glfw/glfw.v
+++ b/vlib/glfw/glfw.v
@@ -131,7 +131,7 @@ pub fn create_window(c WinCfg) &glfw.Window {
 		println('failed to create a glfw window, make sure you have a GPU driver installed')
 		C.glfwTerminate()
 	}
-	println('create window wnd=$cwindow ptr==$c.ptr')
+	// println('create window wnd=$cwindow ptr==$c.ptr')
 	C.glfwSetWindowUserPointer(cwindow, c.ptr)
 	window := &glfw.Window {
 		data: cwindow,
@@ -305,4 +305,3 @@ pub fn (size Size) str() string {
 pub fn get_window_user_pointer(gwnd voidptr) voidptr {
 	return C.glfwGetWindowUserPointer(gwnd)
 }
-


### PR DESCRIPTION
This PR remove the display of general information in `glfw` and `freetype` modules.

Cause:
```
create window wnd=00000000034A02D0 ptr==0000000000000000
Trying to load font from C:\Windows\Fonts\arial.ttf
```
Non-warning or exception information do not appear in V UI or others UI programs.