### PR TITLE
os api: unified processing deprecated function expression format

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -603,7 +603,7 @@ pub fn is_readable(path string) bool {
 
 [deprecated]
 pub fn file_exists(_path string) bool {
-	panic('use os.exists(path) instead of os.file_exists(path)')
+	panic('Use `os.exists` instead of `os.file_exists`')
 }
 
 // rm removes file in `path`.


### PR DESCRIPTION
This PR unified processing deprecated function expression format on `os.file_exists`.

Change into:
```v
[deprecated]
pub fn file_exists(_path string) bool {
    panic('Use `os.exists` instead of `os.file_exists`')
}
```