### PR TITLE
os api: executable => exe

### DIFF
--- a/cmd/tools/fast/fast.v
+++ b/cmd/tools/fast/fast.v
@@ -9,7 +9,7 @@ import (
 )
 
 fn main() {
-	exe := os.executable()
+	exe := os.exe()
 	dir := filepath.dir(exe)
 	vdir := filepath.dir(filepath.dir(filepath.dir(dir)))
 	if !os.exists('$vdir/v') && !os.is_dir('$vdir/vlib') {

--- a/cmd/tools/oldv.v
+++ b/cmd/tools/oldv.v
@@ -70,16 +70,16 @@ fn main() {
 	scripting.used_tools_must_exist(['git', 'cc'])
 	mut context := Context{}
 	mut fp := flag.new_flag_parser(os.args)
-	fp.application(filepath.filename(os.executable()))
+	fp.application(filepath.filename(os.exe()))
 	fp.version(tool_version)
 	fp.description(tool_description)
 	fp.arguments_description('VCOMMIT')
 	fp.skip_executable()
 	fp.limit_free_args(1, 1)
-	
+
 	context.cleanup = fp.bool('clean', true, 'Clean before running (slower).')
 	context.cmd_to_run = fp.string_('command', `c`, '', 'Command to run in the old V repo.\n')
-	
+
 	commits := vgit.add_common_tool_options(mut context, mut fp)
 	if commits.len > 0 {
 		context.commit_v = commits[0]
@@ -102,9 +102,9 @@ fn main() {
 		scripting.rmrf(context.path_v)
 		scripting.rmrf(context.path_vc)
 	}
-	
+
 	context.compile_oldv_if_needed()
-	
+
 	scripting.chdir(context.path_v)
 	println('#     v commit hash: $context.commit_v_hash')
 	println('#   checkout folder: $context.path_v')
@@ -116,5 +116,5 @@ fn main() {
 		println(cmdres.output)
 		exit(cmdres.exit_code)
 	}
-	
+
 }

--- a/cmd/tools/performance_compare.v
+++ b/cmd/tools/performance_compare.v
@@ -181,7 +181,7 @@ fn main() {
 	scripting.used_tools_must_exist(['cp', 'rm', 'strip', 'make', 'git', 'upx', 'cc', 'wc', 'tail', 'hyperfine'])
 	mut context := new_context()
 	mut fp := flag.new_flag_parser(os.args)
-	fp.application(filepath.filename(os.executable()))
+	fp.application(filepath.filename(os.exe()))
 	fp.version(tool_version)
 	fp.description(tool_description)
 	fp.arguments_description('COMMIT_BEFORE [COMMIT_AFTER]')

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -39,7 +39,7 @@ const (
 )
 
 fn main() {
-	toolexe := os.executable()
+	toolexe := os.exe()
 	compiler.set_vroot_folder(filepath.dir(filepath.dir(filepath.dir(toolexe))))
 	args := join_flags_and_argument()
 	foptions := FormatOptions{

--- a/cmd/tools/vnames.v
+++ b/cmd/tools/vnames.v
@@ -42,7 +42,7 @@ fn analyze_v_file(file string) {
 	for f in v.files { v.parse(f, .decl) }
 	fi := v.get_file_parser_index( file ) or { panic(err) }
 	fmod :=  v.parsers[fi].mod
-	
+
 	// output:
 	mut fns :=[]string
 	for _, f in v.table.fns {
@@ -51,11 +51,11 @@ fn analyze_v_file(file string) {
 	}
 	fns.sort()
 	for f in fns { println(f) }
-	
+
 }
 
 fn main(){
-	toolexe := os.executable()
+	toolexe := os.exe()
 	compiler.set_vroot_folder(filepath.dir(filepath.dir(filepath.dir(toolexe))))
 
 	mut fp := flag.new_flag_parser(os.args)
@@ -65,12 +65,12 @@ fn main(){
 	fp.arguments_description('FILE.v/FOLDER [FILE.v/FOLDER]...')
 	fp.limit_free_args_to_at_least(1)
 	fp.skip_executable()
-	show_help:=fp.bool_('help', `h`, false, 'Show this help screen\n')	
+	show_help:=fp.bool_('help', `h`, false, 'Show this help screen\n')
 	if( show_help ){
 		println( fp.usage() )
 		exit(0)
 	}
-	
+
 	mut files := []string
 	locations := fp.finalize() or { eprintln('Error: ' + err) exit(1) }
 	for xloc in locations {

--- a/cmd/v/compile_options.v
+++ b/cmd/v/compile_options.v
@@ -180,7 +180,7 @@ pub fn new_v(args []string) &compiler.V {
 		*/
 		println('vlib not found. It should be next to the V executable.')
 		println('Go to https://vlang.io to install V.')
-		println('(os.executable=${os.executable()} vlib_path=$prefs.vlib_path vexe_path=${pref.vexe_path()}')
+		println('(os.exe=${os.exe()} vlib_path=$prefs.vlib_path vexe_path=${pref.vexe_path()}')
 		exit(1)
 	}
 

--- a/vlib/builtin/bare/syscallwrapper_test.v
+++ b/vlib/builtin/bare/syscallwrapper_test.v
@@ -7,7 +7,7 @@ fn test_syscallwrappers() {
 	if true { return }
 	$if linux {
 		$if x64 {
-			exe := os.executable()
+			exe := os.exe()
 			vdir := filepath.dir(exe)
 			if vdir.len > 1 {
 				dot_checks := vdir + "/.checks"

--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -27,7 +27,7 @@ fn (v &V) no_cc_installed() bool {
 }
 
 fn (v mut V) cc() {
-	if os.executable().contains('vfmt') {
+	if os.exe().contains('vfmt') {
 		return
 	}
 	v.build_thirdparty_obj_files()

--- a/vlib/compiler/tests/repl/runner/runner.v
+++ b/vlib/compiler/tests/repl/runner/runner.v
@@ -18,7 +18,7 @@ pub fn full_path_to_v(dirs_in int) string {
 		return vexe_from_env
 	}
 	vname := if os.user_os() == 'windows' { 'v.exe' } else { 'v' }
-	mut path := os.executable()
+	mut path := os.exe()
 	for i := 0; i < dirs_in; i++ {
 		path = filepath.dir(path)
 	}
@@ -26,7 +26,7 @@ pub fn full_path_to_v(dirs_in int) string {
 	/*
 	args := os.args
 	vreal  := os.realpath('v')
-	myself := os.realpath( os.executable() )
+	myself := os.realpath( os.exe() )
 	wd := os.getwd()
 	println('args are: $args')
 	println('vreal   : $vreal')

--- a/vlib/freetype/freetype.v
+++ b/vlib/freetype/freetype.v
@@ -204,7 +204,7 @@ pub fn new_context(cfg gg.Cfg) &FreeType {
 		font_path = 'RobotoMono-Regular.ttf'
 	}
 	if !os.exists(font_path) {
-		exe_path := os.executable()
+		exe_path := os.exe()
 		exe_dir := filepath.basedir(exe_path)
 		font_path = '$exe_dir/$font_path'
 	}

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -836,14 +836,19 @@ fn C.proc_pidpath(int, byteptr, int) int
 
 
 fn C.readlink() int
-// executable returns the path name of the executable that started the current
-// process.
+
+[deprecated]
 pub fn executable() string {
+	panic('Use `os.exe` instead of `os.executable`')
+}
+
+// exe returns the path name of the executable that started the current process.
+pub fn exe() string {
 	$if linux {
 		mut result := calloc(MAX_PATH)
 		count := C.readlink('/proc/self/exe', result, MAX_PATH)
 		if count < 0 {
-			eprintln('os.executable() failed at reading /proc/self/exe to get exe path')
+			eprintln('os.exe() failed at reading /proc/self/exe to get exe path')
 			return os.args[0]
 		}
 		return string(result)
@@ -859,7 +864,7 @@ pub fn executable() string {
 		pid := C.getpid()
 		ret := proc_pidpath(pid, result, MAX_PATH)
 		if ret <= 0 {
-			eprintln('os.executable() failed at calling proc_pidpath with pid: $pid . proc_pidpath returned $ret ')
+			eprintln('os.exe() failed at calling proc_pidpath with pid: $pid . proc_pidpath returned $ret ')
 			return os.args[0]
 		}
 		return string(result)
@@ -882,7 +887,7 @@ pub fn executable() string {
 		mut result := calloc(MAX_PATH)
 		count := C.readlink('/proc/curproc/exe', result, MAX_PATH)
 		if count < 0 {
-			eprintln('os.executable() failed at reading /proc/curproc/exe to get exe path')
+			eprintln('os.exe() failed at reading /proc/curproc/exe to get exe path')
 			return os.args[0]
 		}
 		return string(result,count)
@@ -891,7 +896,7 @@ pub fn executable() string {
 		mut result := calloc(MAX_PATH)
 		count := C.readlink('/proc/curproc/file', result, MAX_PATH)
 		if count < 0 {
-			eprintln('os.executable() failed at reading /proc/curproc/file to get exe path')
+			eprintln('os.exe() failed at reading /proc/curproc/file to get exe path')
 			return os.args[0]
 		}
 		return string(result,count)
@@ -1169,7 +1174,7 @@ pub const (
 // It gives a convenient way to access program resources like images, fonts, sounds and so on,
 // *no matter* how the program was started, and what is the current working directory.
 pub fn resource_abs_path(path string) string {
-	mut base_path := os.realpath(filepath.dir(os.executable()))
+	mut base_path := os.realpath(filepath.dir(os.exe()))
 	vresource := os.getenv('V_RESOURCE_PATH')
 	if vresource.len != 0 {
 		base_path = vresource

--- a/vlib/sdl/examples/tvintris/tvintris.v
+++ b/vlib/sdl/examples/tvintris/tvintris.v
@@ -20,7 +20,7 @@ import sdl.ttf as ttf
 
 const (
 	Title = 'tVintris'
-	BASE = filepath.dir( os.realpath( os.executable() ) )
+	BASE = filepath.dir( os.realpath( os.exe() ) )
 	FontName = BASE + '/fonts/RobotoMono-Regular.ttf'
 	MusicName = BASE + '/sounds/TwintrisThosenine.mod'
 	SndBlockName = BASE + '/sounds/block.wav'

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -71,7 +71,7 @@ pub fn vexe_path() string {
 	if vexe != '' {
 		return vexe
 	}
-	real_vexe_path := os.realpath(os.executable())
+	real_vexe_path := os.realpath(os.exe())
 	os.setenv('VEXE', real_vexe_path, true)
 	return real_vexe_path
 }


### PR DESCRIPTION
This PR use `os.exe` instead of `os.executable`.

- mark `os.executable` as `[deprecated]`.
- add `os.exe` instead of `os.executable`.
- modified related calls.

Cause:
- it like `os.dir`.
- it is more concise.