### PR TITLE
public the ast.IdentInfo

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -229,7 +229,7 @@ pub mut:
 	is_mut bool
 }
 
-type IdentInfo = IdentFunc | IdentVar
+pub type IdentInfo = IdentFunc | IdentVar
 
 pub enum IdentKind {
 	unresolved


### PR DESCRIPTION
when I write the  vast tool,I need ast.IdentInfo to be public
