### PR TITLE
vdoc: don't show deprecated functions

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -130,16 +130,17 @@ pub:
 
 pub struct FnDecl {
 pub:
-	name        string
-	stmts       []Stmt
-	typ         table.Type
-	args        []Arg
-	is_pub      bool
-	is_variadic bool
-	receiver    Field
-	is_method   bool
-	rec_mut     bool // is receiver mutable
-	is_c        bool
+	name          string
+	stmts         []Stmt
+	typ           table.Type
+	args          []Arg
+	is_deprecated bool
+	is_pub        bool
+	is_variadic   bool
+	receiver      Field
+	is_method     bool
+	rec_mut       bool // is receiver mutable
+	is_c          bool
 }
 
 pub struct BranchStmt {

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -100,9 +100,9 @@ fn (d Doc) get_fn_signatures(filter_fn FilterFn) []string {
 }
 
 fn is_pub_method(node ast.FnDecl) bool {
-	return node.is_pub && node.is_method
+	return node.is_pub && node.is_method && !node.is_deprecated
 }
 
 fn is_pub_function(node ast.FnDecl) bool {
-	return node.is_pub && !node.is_method
+	return node.is_pub && !node.is_method && !node.is_deprecated
 }

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -24,7 +24,7 @@ pub fn (p mut Parser) call_expr(is_c bool, mod string) ast.CallExpr {
 		args: args
 		muts: muts
 		// tok: tok
-		
+
 		pos: tok.position()
 		is_c: is_c
 		or_block: ast.OrExpr{
@@ -58,6 +58,7 @@ pub fn (p mut Parser) call_args() ([]ast.Expr,[]bool) {
 fn (p mut Parser) fn_decl() ast.FnDecl {
 	// p.table.clear_vars()
 	p.open_scope()
+	is_deprecated := p.attr == 'deprecated'
 	is_pub := p.tok.kind == .key_pub
 	if is_pub {
 		p.next()
@@ -158,11 +159,13 @@ fn (p mut Parser) fn_decl() ast.FnDecl {
 		stmts = p.parse_block()
 	}
 	p.close_scope()
+	p.attr = ''
 	return ast.FnDecl{
 		name: name
 		stmts: stmts
 		typ: typ
 		args: ast_args
+		is_deprecated: is_deprecated
 		is_pub: is_pub
 		is_variadic: is_variadic
 		receiver: ast.Field{

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -40,6 +40,7 @@ mut:
 	pref          &pref.Preferences // Preferences shared from V struct
 	builtin_mod   bool
 	mod           string
+	attr          string
 	expr_mod      string
 	scope         &ast.Scope
 	imports       map[string]string
@@ -221,10 +222,10 @@ pub fn (p mut Parser) top_stmt() ast.Stmt {
 					p.error('wrong pub keyword usage')
 					return ast.Stmt{}
 				}
-	}
+			}
 		}
 		.lsbr {
-			return p.attr()
+			return p.attribute()
 		}
 		.key_module {
 			return p.module_decl()
@@ -373,13 +374,14 @@ pub fn (p mut Parser) assign_expr(left ast.Expr) ast.AssignExpr {
 	return node
 }
 
-fn (p mut Parser) attr() ast.Attr {
+fn (p mut Parser) attribute() ast.Attr {
 	p.check(.lsbr)
 	if p.tok.kind == .key_if {
 		p.next()
 	}
 	name := p.check_name()
 	p.check(.rsbr)
+	p.attr = name
 	return ast.Attr{
 		name: name
 	}


### PR DESCRIPTION
This PR enables deprecated functions not to be displayed in `v doc`.