### PR TITLE
sync.pool: simplify usages of pool.work_on_items

### DIFF
--- a/examples/news_fetcher.v
+++ b/examples/news_fetcher.v
@@ -45,5 +45,5 @@ fn main() {
 	// cases is what you want anyway... You can override the automatic choice
 	// by setting the VJOBS environment variable too.
 	// fetcher_pool.set_max_jobs( 4 )
-	fetcher_pool.work_on_items<int>(ids)
+	fetcher_pool.work_on_items(ids)
 }

--- a/vlib/compiler/tests/repl/repl_test.v
+++ b/vlib/compiler/tests/repl/repl_test.v
@@ -49,7 +49,7 @@ fn test_all_v_repl_files() {
 		// See: https://docs.microsoft.com/en-us/cpp/build/reference/fs-force-synchronous-pdb-writes?view=vs-2019
 		pool_repl.set_max_jobs(1)
 	}
-	pool_repl.work_on_items<string>(session.options.files)
+	pool_repl.work_on_items(session.options.files)
 	session.bmark.stop()
 	println(session.bmark.total_message('total time spent running REPL files'))
 }

--- a/vlib/sync/pool.v
+++ b/vlib/sync/pool.v
@@ -3,12 +3,17 @@ module sync
 // * of items in parallel, without worrying about waitgroups, mutexes and so on.
 // *
 // * Usage example:
-// *   pool := sync.new_pool_processor({ callback: worker_cb })
-// *   //pool.work_on_items<string>(['a','b','c']) // TODO: vfmt and generics
-// *   pool.work_on_pointers(['a','b','c'].pointers())
+// *   struct SResult{ s string }
+// *   fn sprocess(p &sync.PoolProcessor, idx, wid int) voidptr {
+// *       item := p.get_item<string>(idx)
+// *       println('idx: $idx, wid: $wid, item: ' + item)
+// *       return &SResult{ item.reverse() }
+// *   }
+// *   pool := sync.new_pool_processor({ callback: sprocess })
+// *   pool.work_on_items(['a','b','c','d','e','f','g'])
 // *   // optionally, you can iterate over the results too:
-// *   for x in pool.get_results<IResult>() {
-// *       // do stuff with x
+// *   for x in pool.get_results<SResult>() {
+// *       println('result: $x.s')
 // *   }
 // *
 // * See https://github.com/vlang/v/blob/master/vlib/sync/pool_test.v for a

--- a/vlib/sync/pool_test.v
+++ b/vlib/sync/pool_test.v
@@ -35,7 +35,7 @@ fn test_work_on_strings() {
 		callback: worker_s
 		maxjobs: 8
 	})
-	pool_s.work_on_items<string>(['a','b','c','d','e','f','g','h','i','j'])
+	pool_s.work_on_items(['a','b','c','d','e','f','g','h','i','j'])
 	for x in pool_s.get_results<SResult>() {
 		println( x.s )
 		assert x.s.len > 1
@@ -50,7 +50,7 @@ fn test_work_on_ints() {
 	mut pool_i := sync.new_pool_processor({
 		callback: worker_i
 	})
-	pool_i.work_on_items<int>([1,2,3,4,5,6,7,8])
+	pool_i.work_on_items([1,2,3,4,5,6,7,8])
 	for x in pool_i.get_results<IResult>() {
 		println( x.i )
 		assert x.i > 100


### PR DESCRIPTION
This PR just cleans up the pool.work_on_items, i.e. use `pool.work_on_items(ids)` instead of `pool.work_on_items<int>(ids)`