### PR TITLE
Fix array boundary check in flag module

### DIFF
--- a/vlib/flag/flag.v
+++ b/vlib/flag/flag.v
@@ -156,7 +156,7 @@ fn (fs mut FlagParser) parse_value(longhand string, shorthand byte) []string {
 			continue
 		}
 		if (arg.len == 2 && arg[0] == `-` && arg[1] == shorthand ) || arg == full {
-			if i+1 > fs.args.len {
+			if i+1 >= fs.args.len {
 				panic("Missing argument for '$longhand'")
 			}
 			nextarg := fs.args[i+1]


### PR DESCRIPTION
with:
```
        flag_out := fp.string_('output', `o`, '', 'Output file (.py, .txt, ..)')
```
before:

```
V panic: array.get: index out of range (i == 2, a.len == 2)
0   ns-tester                           0x000000010e6b47c0 v_panic + 48
1   ns-tester                           0x000000010e6b4d58 array_get + 88
2   ns-tester                           0x000000010e6c3426 flag__FlagParser_parse_value + 646
3   ns-tester                           0x000000010e6c4989 flag__FlagParser_string_opt + 185
4   ns-tester                           0x000000010e6c4aa1 flag__FlagParser_string_ + 129
5   ns-tester                           0x000000010e6e07f3 main__main + 1187
6   ns-tester                           0x000000010e6e75fe main + 78
7   ns-tester                           0x000000010e6b43d4 start + 52
8   ???
```

after:

```
V panic: Missing argument for 'output'
0   ns-tester                           0x00000001042fc790 v_panic + 48
1   ns-tester                           0x000000010430b3c9 flag__FlagParser_parse_value + 601
2   ns-tester                           0x000000010430c989 flag__FlagParser_string_opt + 185
3   ns-tester                           0x000000010430caa1 flag__FlagParser_string_ + 129
4   ns-tester                           0x00000001043287f3 main__main + 1187
5   ns-tester                           0x000000010432f5fe main + 78
6   ns-tester                           0x00000001042fc3a4 start + 52
7   ???                                 0x0000000000000002 0x0 + 2
```