### PR TITLE
pg: Add port to Config

### DIFF
--- a/vlib/pg/pg.v
+++ b/vlib/pg/pg.v
@@ -20,6 +20,7 @@ struct C.PGResult { }
 pub struct Config {
 pub:
 	host string
+	port int
 	user string
 	password string
 	dbname string
@@ -35,7 +36,7 @@ fn C.PQexec(voidptr) voidptr
 fn C.PQexecParams(voidptr) voidptr
 
 pub fn connect(config pg.Config) ?DB {
-	conninfo := 'host=$config.host user=$config.user dbname=$config.dbname password=$config.password'
+	conninfo := 'host=$config.host port=$config.port user=$config.user dbname=$config.dbname password=$config.password'
 	conn := C.PQconnectdb(conninfo.str)
 	status := C.PQstatus(conn)
 	println("status=$status")


### PR DESCRIPTION
Resolves #3936 

This allows for the use a different port than the standard 5432.

For example, for CockroachDB...

```
db := pg.connect(pg.Config{
    host: 'localhost'
    port: 26257
    user: 'root'
    dbname: 'mydb'
}) or {
    println('failed to connect')
    println(err)
    return
}
```

`port` is optional (like all other fields), and connection will default to using port 5432 if no `port` added to `pg.Config`.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
