### PR TITLE
pg: fix zero being used for port when not specified in pg.Config.

### DIFF
--- a/vlib/pg/pg.v
+++ b/vlib/pg/pg.v
@@ -20,7 +20,7 @@ struct C.PGResult { }
 pub struct Config {
 pub:
 	host string
-	port int
+	port int = 5432
 	user string
 	password string
 	dbname string


### PR DESCRIPTION
Huge apologies!

Looks like the port does not properly default to 5432 if not specified in `pg.Config`.

This PR defaults the port to 5432 ~~, but I'm not sure of there's a cleaner way of doing this?~~.

This is a fix for #3937 
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
