### PR TITLE
v doc: don't show 'pub' at the beginning

### DIFF
--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -92,8 +92,9 @@ fn (d Doc) get_fn_signatures(filter_fn FilterFn) []string {
 					fn_signatures << d.get_fn_node(it)
 				}
 			}
-			else {}
-	}
+			else {
+			}
+		}
 	}
 	fn_signatures.sort()
 	return fn_signatures

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -63,7 +63,7 @@ pub fn doc(mod string, table &table.Table) string {
 }
 
 fn (d &Doc) get_fn_node(f ast.FnDecl) string {
-	return f.str(d.table).replace(d.mod + '.', '')
+	return f.str(d.table).replace_each([d.mod + '.', '', 'pub ', ''])
 }
 
 fn (d mut Doc) print_fns() {


### PR DESCRIPTION
This PR remove `pub` at the beginning of the functions.
