### PR TITLE
gx: Add hex to rgb color

### DIFF
--- a/vlib/gx/gx.v
+++ b/vlib/gx/gx.v
@@ -93,6 +93,15 @@ pub fn rgb(r, g, b int) Color {
 	return res
 }
 
+pub fn hex(color int) Color {
+  res := Color {
+    r: (color >> 16) & 0xFF
+    g: (color >> 8) & 0xFF
+    b: color & 0xFF
+  }
+  return res
+}
+
 // fn text_width_char(c char) int {
 // return text_width(char2string(c))
 // // return C.text_width_char(c)

--- a/vlib/gx/gx_test.v
+++ b/vlib/gx/gx_test.v
@@ -1,0 +1,13 @@
+import gx
+
+fn test_hex() {
+  // valid colors
+  color_a := gx.hex(0x6c5ce7)
+  color_b := gx.rgb(108, 92, 231)
+  assert color_a.eq(color_b) == true
+
+  // doesn't give right value with short hex value
+  short_color := gx.hex(0xfff)
+  white_color := gx.rgb(255, 255, 255)
+  assert short_color.eq(white_color) == false
+}


### PR DESCRIPTION
This PR add support for hex color for gx lib. Example:

```
import gx

fn main() {
  color_a = gx.hex(0x6c5ce7)
  color_b = gx.rgb(108, 92, 231)

  println(color_a.eq(color_b)) // true
}
```