### PR TITLE
glfw: implement auto fit high-score screen

### DIFF
--- a/vlib/glfw/glfw.v
+++ b/vlib/glfw/glfw.v
@@ -120,6 +120,8 @@ pub fn window_hint(key, val int) {
 	C.glfwWindowHint(key, val)
 }
 
+fn C.glfwGetWindowContentScale(window &glfw.Window, scale_x &f32, scale_y &f32) // scale
+
 pub fn create_window(c WinCfg) &glfw.Window {
 	if c.borderless {
 		window_hint(C.GLFW_RESIZABLE, 0)
@@ -257,7 +259,7 @@ pub fn (w &glfw.Window) get_cursor_pos() Pos {
 	x := f64(0)
 	y := f64(0)
 	C.glfwGetCursorPos(w.data, &x, &y)
-	
+
 	return Pos {
 		x: int(x/w.scale_)
 		y: int(y/w.scale_)

--- a/vlib/glfw/glfw.v
+++ b/vlib/glfw/glfw.v
@@ -121,8 +121,6 @@ pub fn window_hint(key, val int) {
 	C.glfwWindowHint(key, val)
 }
 
-fn C.glfwGetWindowContentScale(window &glfw.Window, scale_x &f32, scale_y &f32) // scale
-
 pub fn create_window(c WinCfg) &glfw.Window {
 	if c.borderless {
 		window_hint(C.GLFW_RESIZABLE, 0)
@@ -132,7 +130,9 @@ pub fn create_window(c WinCfg) &glfw.Window {
 		window_hint(C.GLFW_FLOATING, 1)
 	}
 	if c.scale_to_monitor {
-		window_hint(C.GLFW_SCALE_TO_MONITOR, 1)
+		$if windows {
+			window_hint(C.GLFW_SCALE_TO_MONITOR, 1)
+		}
 	}
 	cwindow := C.glfwCreateWindow(c.width, c.height, c.title.str, 0, 0)
 	if isnil(cwindow) {
@@ -141,7 +141,13 @@ pub fn create_window(c WinCfg) &glfw.Window {
 	}
 	// println('create window wnd=$cwindow ptr==$c.ptr')
 	C.glfwSetWindowUserPointer(cwindow, c.ptr)
-	C.glfwGetWindowContentScale(cwindow, &monitor_scale, &monitor_scale)
+	
+	$if windows {
+		C.glfwGetWindowContentScale(cwindow, &monitor_scale, &monitor_scale)
+	}
+	$else {
+		monitor_scale = 1.0
+	}
 
 	window := &glfw.Window {
 		data: cwindow,

--- a/vlib/glfw/glfw.v
+++ b/vlib/glfw/glfw.v
@@ -45,6 +45,8 @@ pub const (
 	KeyDown  = 264
 )
 
+__global monitor_scale f32
+
 // joe-c: fix & remove
 struct TmpGlImportHack {
 	hack gl.TmpGlImportHack
@@ -70,7 +72,6 @@ pub struct Window {
 	title   string
 	mx      int
 	my      int
-	scale_  f64
 }
 
 pub struct Size {
@@ -140,13 +141,11 @@ pub fn create_window(c WinCfg) &glfw.Window {
 	}
 	// println('create window wnd=$cwindow ptr==$c.ptr')
 	C.glfwSetWindowUserPointer(cwindow, c.ptr)
-	scale_x := f32(1)
-	scale_y := f32(1)
-	C.glfwGetWindowContentScale(cwindow, &scale_x, &scale_y)
+	C.glfwGetWindowContentScale(cwindow, &monitor_scale, &monitor_scale)
+
 	window := &glfw.Window {
 		data: cwindow,
 		title: c.title,
-		scale_: scale_x,
 	}
 	return window
 }
@@ -160,7 +159,7 @@ pub fn (w &glfw.Window) make_context_current() {
 }
 
 pub fn (w &glfw.Window) scale() f64 {
-	return w.scale_
+	return monitor_scale
 }
 
 pub fn swap_interval(interval int) {
@@ -248,11 +247,7 @@ pub fn get_cursor_pos(glfw_window voidptr) (f64, f64) {
 	y := f64(0)
 	C.glfwGetCursorPos(glfw_window, &x, &y)
 
-	scale_x := f32(1)
-	scale_y := f32(1)
-	C.glfwGetWindowContentScale(glfw_window, &scale_x, &scale_y)
-
-	return x/scale_x, y/scale_y
+	return x/monitor_scale, y/monitor_scale
 }
 
 pub fn (w &glfw.Window) get_cursor_pos() Pos {
@@ -261,8 +256,8 @@ pub fn (w &glfw.Window) get_cursor_pos() Pos {
 	C.glfwGetCursorPos(w.data, &x, &y)
 
 	return Pos {
-		x: int(x/w.scale_)
-		y: int(y/w.scale_)
+		x: int(x/monitor_scale)
+		y: int(y/monitor_scale)
 	}
 }
 


### PR DESCRIPTION
This PR implement auto fit high-score screen.

**Solution:**
- Use `GLFW_SCALE_TO_MONITOR` in `glfw`.
- `get_current_pos` modify the mouse pointer map address by `scale`.

**Snapshot:**
![users](https://user-images.githubusercontent.com/6949593/76140240-1232ce80-6093-11ea-9d9c-c5947a060bb4.PNG)
