### PR TITLE
compiler: fix generation of default .str() methods in interpolation

### DIFF
--- a/vlib/compiler/comptime.v
+++ b/vlib/compiler/comptime.v
@@ -413,7 +413,8 @@ fn (p mut Parser) gen_struct_str(typ Type) {
 	})
 	mut sb := strings.new_builder(typ.fields.len * 20)
 	sb.writeln('pub fn (a $typ.name) str() string {\nreturn')
-	sb.writeln("'{")
+	short_struct_name := typ.name.all_after('__')
+	sb.writeln("'$short_struct_name {")
 	for field in typ.fields {
 		sb.writeln('\t$field.name: $' + 'a.${field.name}')
 	}

--- a/vlib/compiler/string_expression.v
+++ b/vlib/compiler/string_expression.v
@@ -114,36 +114,7 @@ fn (p mut Parser) string_expr() {
 		else {
 			f := p.typ_to_fmt(typ, 0)
 			if f == '' {
-				typ2 := p.table.find_type(typ)
-				is_varg := typ.starts_with('varg_')
-				is_array := typ.starts_with('array_')
-				is_struct := typ2.cat == .struct_
-				mut has_str_method := p.table.type_has_method(typ2, 'str')
-				mut styp := typ
-				if !has_str_method {
-					if is_varg {
-						p.gen_varg_str(typ2)
-						has_str_method = true
-					}
-					else if is_array {
-						p.gen_array_str(typ2)
-						has_str_method = true
-					}
-					else if is_struct {
-						p.gen_struct_str(typ2)
-						has_str_method = true
-					}
-					else {
-						btypename := p.base_type(typ2.name)
-						if btypename != typ2.name {
-							base_type := p.find_type(btypename)
-							if base_type.has_method('str'){
-								styp = base_type.name
-								has_str_method = true
-							}
-						}
-					}
-				}
+				has_str_method, styp := p.gen_default_str_method_if_missing( typ )
 				if has_str_method {
 					tmp_var := p.get_tmp()
 					p.cgen.insert_before('string $tmp_var = ${styp}_str(${val});')

--- a/vlib/compiler/tests/prod/assoc.prod.v.expected.txt
+++ b/vlib/compiler/tests/prod/assoc.prod.v.expected.txt
@@ -1,3 +1,3 @@
-{
+MyStruct {
 	s: 6
 }

--- a/vlib/compiler/tests/string_interpolation_array_of_structs_test.v
+++ b/vlib/compiler/tests/string_interpolation_array_of_structs_test.v
@@ -1,0 +1,34 @@
+// This file tests whether v can generate default string methods for both:
+// a) an array of custom structs,
+// b) also for the custom struct itself (when the .str() for it is missing).
+//
+// NB: this is very simillar to string_interpolation_struct_test.v
+// but they should NOT be merged into 1 file.  If you merge it with
+// string_interpolation_struct_test.v, which tests whether the compiler
+// can generate the default method for a struct, then the b) case of
+// this test will be done by *that* test, and so the testing will
+// be incomplete.
+
+struct Man {
+	name string
+	age int
+	interests []string
+}
+
+fn test_default_struct_array_of_structs_interpolation(){
+	people := [
+		Man{'Superman', 30, ['flying','fighting evil','being nice']},
+		Man{'Bilbo Baggins', 111, ['exploring', 'hiding']},
+	]
+	s := '$people' // the compiler should generate code for both a) and b)
+	assert s.contains('Man {')
+	assert s.contains('name: Superman')
+	assert s.contains('age: 30')
+	assert s.contains('"being nice"')
+	assert s.contains('}, Man {')
+	assert s.contains('name: Bilbo Baggins')
+	assert s.contains('age: 111')
+	assert s.contains('interests: ["exploring", "hiding"]')
+	assert s.contains('}]')
+	//println(s)
+}

--- a/vlib/compiler/tests/string_interpolation_complex_test.v
+++ b/vlib/compiler/tests/string_interpolation_complex_test.v
@@ -1,0 +1,17 @@
+struct Man {
+  name string
+  age int
+  interests []string
+}
+
+fn test_default_struct_string_interpolation(){
+	superman := Man{'Superman', 30, ['flying','fighting evil','being nice']}
+	s := '$superman'
+	assert s.contains('Man {')
+	assert s.contains('name: Superman')
+	assert s.contains('age: 30')
+	assert s.contains('interests: [')
+	assert s.contains('"being nice"')
+	assert s.contains('}')
+	println(s)
+}

--- a/vlib/compiler/tests/string_interpolation_struct_test.v
+++ b/vlib/compiler/tests/string_interpolation_struct_test.v
@@ -1,7 +1,11 @@
+// This file tests whether V can generate a convenience default .str() method
+// for a custom struct, when the developer has not defined one himself.
+// The .str() methods are used for string interpolation and for println() calls.
+
 struct Man {
-  name string
-  age int
-  interests []string
+	name string
+	age int
+	interests []string
 }
 
 fn test_default_struct_string_interpolation(){
@@ -13,5 +17,5 @@ fn test_default_struct_string_interpolation(){
 	assert s.contains('interests: [')
 	assert s.contains('"being nice"')
 	assert s.contains('}')
-	println(s)
+	//println(s)
 }

--- a/vlib/compiler/tests/string_interpolation_variadic_test.v
+++ b/vlib/compiler/tests/string_interpolation_variadic_test.v
@@ -1,0 +1,34 @@
+// This file tests whether V can generate a convenience default .str() method
+// for var args of a custom type, when the developer has NOT defined one.
+// Although similar to string_interpolation_struct_test.v, they should not be
+// merged.
+
+struct Man {
+	name string
+	age int
+	interests []string
+}
+
+fn my_variadic_function(x ...Man) string {
+	return '$x' // this interpolation should generate .str() methods for Man
+}
+
+fn test_vargs_string_interpolation(){
+	man := Man{'Me', 38, ['programming', 'reading', 'hiking']}
+	superman := Man{'Superman', 30, ['flying','fighting evil','being nice']}
+
+	results := my_variadic_function(superman, man)
+
+	assert results.contains('Man {')
+	//
+	assert results.contains('name: Superman')
+	assert results.contains('age: 30')
+	assert results.contains('}, Man {')
+	//
+	assert results.contains('interests: ["programming"')
+	assert results.contains('name: Me')
+	//
+	assert results.contains('}]')
+	//
+	println(results)
+}


### PR DESCRIPTION
This PR makes this possible:
```v
struct Abc{ x int }
fn main(){
  a := Abc{123}
  s := '$a'
  println(s)
}  
```

which now prints:
```
Abc {
        x: 123
}
```

Previously, that produced:
```shell
x.v:4:11: unhandled sprintf format "Abc"
    4|   s := '$a'
                 ^
```                 

This PR also handles interpolation of []Abc as well as ...Abc .