### PR TITLE
cmd/v: detect when non integers are given after flags expecting ints.

### DIFF
--- a/cmd/v/internal/flag/flag.v
+++ b/cmd/v/internal/flag/flag.v
@@ -72,6 +72,9 @@ pub fn (p mut Instance) int() ?int {
 	val := p.string() or {
 		return error(err)
 	}
+	if !val[0].is_digit() {
+		return error('an integer number was expected, but "$val" was found instead.')
+	}
 	return val.int()
 }
 


### PR DESCRIPTION
With this PR:
```shell
0[15:04:57]delian@nemesis: /v/nv $ ./v -verbose examples/hello_world.v
V error: Expected 0, 1, 2 or 3 as argument to -verbose to specify verbosity level.
1[15:05:00]delian@nemesis: /v/nv $
```

Previously `./v -verbose examples/hello_world.v` launched a REPL.