### PR TITLE
vweb: Cater for trailing slashes being used in handle_static call.

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -348,14 +348,15 @@ pub fn (ctx mut Context) handle_static(directory_path string) bool {
 		return false
 	}
 
-	dir_path := directory_path.trim_space()
+	dir_path := directory_path.trim_space().trim_right('/')
 	mut mount_path := ''
 
 	if dir_path != '.' && os.is_dir(dir_path) {
-		mount_path = '/' + dir_path
+		// Mount point hygene, "./assets" => "/assets".
+		mount_path = '/' + dir_path.trim_left('.').trim('/')
 	}
 
-	ctx.scan_static_directory(directory_path, mount_path)
+	ctx.scan_static_directory(dir_path, mount_path)
 
 	return true
 }


### PR DESCRIPTION
Someone might inadvertently add a trailing slash to the directory path supplied to `vweb.handle_static(directory_path)`, this cleans up such an input to convert e.g. `'./'` => `'.'`, and `'./assets/'` => `'/assets'`.

Thanks @elimisteve for the heads-up.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
