### PR TITLE
os api: join => join_path

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -97,7 +97,7 @@ fn worker_trunner(p mut sync.PoolProcessor, idx int, thread_id int) voidptr {
 	// Remove them after a test passes/fails.
 	fname := os.filename(file)
 	generated_binary_fname := if os.user_os() == 'windows' { fname.replace('.v', '.exe') } else { fname.replace('.v', '') }
-	generated_binary_fpath := os.join(tmpd,generated_binary_fname)
+	generated_binary_fpath := os.path_join(tmpd,generated_binary_fname)
 	if os.exists(generated_binary_fpath) {
 		os.rm(generated_binary_fpath)
 	}
@@ -152,7 +152,7 @@ fn worker_trunner(p mut sync.PoolProcessor, idx int, thread_id int) voidptr {
 }
 
 pub fn vlib_should_be_present(parent_dir string) {
-	vlib_dir := os.join(parent_dir,'vlib')
+	vlib_dir := os.path_join(parent_dir,'vlib')
 	if !os.is_dir(vlib_dir) {
 		eprintln('$vlib_dir is missing, it must be next to the V executable')
 		exit(1)
@@ -169,7 +169,7 @@ pub fn v_build_failing(zargs string, folder string) bool {
 	eheader(main_label)
 	eprintln('v compiler args: "$vargs"')
 	mut session := new_test_session(vargs)
-	files := os.walk_ext(os.join(parent_dir,folder), '.v')
+	files := os.walk_ext(os.path_join(parent_dir,folder), '.v')
 	mut mains := []string
 	for f in files {
 		if !f.contains('modules') && !f.contains('preludes') {

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -97,7 +97,7 @@ fn worker_trunner(p mut sync.PoolProcessor, idx int, thread_id int) voidptr {
 	// Remove them after a test passes/fails.
 	fname := os.filename(file)
 	generated_binary_fname := if os.user_os() == 'windows' { fname.replace('.v', '.exe') } else { fname.replace('.v', '') }
-	generated_binary_fpath := os.path_join(tmpd,generated_binary_fname)
+	generated_binary_fpath := os.path_join(tmpd, generated_binary_fname)
 	if os.exists(generated_binary_fpath) {
 		os.rm(generated_binary_fpath)
 	}
@@ -169,7 +169,7 @@ pub fn v_build_failing(zargs string, folder string) bool {
 	eheader(main_label)
 	eprintln('v compiler args: "$vargs"')
 	mut session := new_test_session(vargs)
-	files := os.walk_ext(os.path_join(parent_dir,folder), '.v')
+	files := os.walk_ext(os.path_join(parent_dir, folder), '.v')
 	mut mains := []string
 	for f in files {
 		if !f.contains('modules') && !f.contains('preludes') {

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -97,7 +97,7 @@ fn worker_trunner(p mut sync.PoolProcessor, idx int, thread_id int) voidptr {
 	// Remove them after a test passes/fails.
 	fname := os.filename(file)
 	generated_binary_fname := if os.user_os() == 'windows' { fname.replace('.v', '.exe') } else { fname.replace('.v', '') }
-	generated_binary_fpath := os.path_join(tmpd, generated_binary_fname)
+	generated_binary_fpath := os.join_path(tmpd, generated_binary_fname)
 	if os.exists(generated_binary_fpath) {
 		os.rm(generated_binary_fpath)
 	}
@@ -152,7 +152,7 @@ fn worker_trunner(p mut sync.PoolProcessor, idx int, thread_id int) voidptr {
 }
 
 pub fn vlib_should_be_present(parent_dir string) {
-	vlib_dir := os.path_join(parent_dir,'vlib')
+	vlib_dir := os.join_path(parent_dir,'vlib')
 	if !os.is_dir(vlib_dir) {
 		eprintln('$vlib_dir is missing, it must be next to the V executable')
 		exit(1)
@@ -169,7 +169,7 @@ pub fn v_build_failing(zargs string, folder string) bool {
 	eheader(main_label)
 	eprintln('v compiler args: "$vargs"')
 	mut session := new_test_session(vargs)
-	files := os.walk_ext(os.path_join(parent_dir, folder), '.v')
+	files := os.walk_ext(os.join_path(parent_dir, folder), '.v')
 	mut mains := []string
 	for f in files {
 		if !f.contains('modules') && !f.contains('preludes') {

--- a/cmd/tools/modules/vgit/vgit.v
+++ b/cmd/tools/modules/vgit/vgit.v
@@ -64,7 +64,7 @@ pub fn prepare_vc_source(vcdir string, cdir string, commit string) (string,strin
 
 pub fn clone_or_pull( remote_git_url string, local_worktree_path string ) {
 	// NB: after clone_or_pull, the current repo branch is === HEAD === master
-	if os.is_dir(local_worktree_path) && os.is_dir(os.path_join(local_worktree_path, '.git')) {
+	if os.is_dir(local_worktree_path) && os.is_dir(os.join_path(local_worktree_path, '.git')) {
 		// Already existing ... Just pulling in this case is faster usually.
 		scripting.run('git -C "$local_worktree_path"  checkout --quiet master')
 		scripting.run('git -C "$local_worktree_path"  pull     --quiet ')
@@ -96,7 +96,7 @@ pub mut:
 
 pub fn (vgit_context mut VGitContext) compile_oldv_if_needed() {
 	vgit_context.vexename = if os.user_os() == 'windows' { 'v.exe' } else { 'v' }
-	vgit_context.vexepath = os.realpath(os.path_join(vgit_context.path_v, vgit_context.vexename))
+	vgit_context.vexepath = os.realpath(os.join_path(vgit_context.path_v, vgit_context.vexename))
 	mut command_for_building_v_from_c_source := ''
 	mut command_for_selfbuilding := ''
 	if 'windows' == os.user_os() {

--- a/cmd/tools/modules/vgit/vgit.v
+++ b/cmd/tools/modules/vgit/vgit.v
@@ -64,7 +64,7 @@ pub fn prepare_vc_source(vcdir string, cdir string, commit string) (string,strin
 
 pub fn clone_or_pull( remote_git_url string, local_worktree_path string ) {
 	// NB: after clone_or_pull, the current repo branch is === HEAD === master
-	if os.is_dir( local_worktree_path ) && os.is_dir(os.join(local_worktree_path,'.git')) {
+	if os.is_dir( local_worktree_path ) && os.is_dir(os.path_join(local_worktree_path,'.git')) {
 		// Already existing ... Just pulling in this case is faster usually.
 		scripting.run('git -C "$local_worktree_path"  checkout --quiet master')
 		scripting.run('git -C "$local_worktree_path"  pull     --quiet ')
@@ -96,7 +96,7 @@ pub mut:
 
 pub fn (vgit_context mut VGitContext) compile_oldv_if_needed() {
 	vgit_context.vexename = if os.user_os() == 'windows' { 'v.exe' } else { 'v' }
-	vgit_context.vexepath = os.realpath( os.join(vgit_context.path_v, vgit_context.vexename) )
+	vgit_context.vexepath = os.realpath( os.path_join(vgit_context.path_v, vgit_context.vexename) )
 	mut command_for_building_v_from_c_source := ''
 	mut command_for_selfbuilding := ''
 	if 'windows' == os.user_os() {

--- a/cmd/tools/modules/vgit/vgit.v
+++ b/cmd/tools/modules/vgit/vgit.v
@@ -64,7 +64,7 @@ pub fn prepare_vc_source(vcdir string, cdir string, commit string) (string,strin
 
 pub fn clone_or_pull( remote_git_url string, local_worktree_path string ) {
 	// NB: after clone_or_pull, the current repo branch is === HEAD === master
-	if os.is_dir( local_worktree_path ) && os.is_dir(os.path_join(local_worktree_path,'.git')) {
+	if os.is_dir(local_worktree_path) && os.is_dir(os.path_join(local_worktree_path, '.git')) {
 		// Already existing ... Just pulling in this case is faster usually.
 		scripting.run('git -C "$local_worktree_path"  checkout --quiet master')
 		scripting.run('git -C "$local_worktree_path"  pull     --quiet ')
@@ -96,7 +96,7 @@ pub mut:
 
 pub fn (vgit_context mut VGitContext) compile_oldv_if_needed() {
 	vgit_context.vexename = if os.user_os() == 'windows' { 'v.exe' } else { 'v' }
-	vgit_context.vexepath = os.realpath( os.path_join(vgit_context.path_v, vgit_context.vexename) )
+	vgit_context.vexepath = os.realpath(os.path_join(vgit_context.path_v, vgit_context.vexename))
 	mut command_for_building_v_from_c_source := ''
 	mut command_for_selfbuilding := ''
 	if 'windows' == os.user_os() {

--- a/cmd/tools/vbuild-examples.v
+++ b/cmd/tools/vbuild-examples.v
@@ -14,7 +14,7 @@ fn main() {
 		exit(1)
 	}
 
-	if testing.v_build_failing(params + '-live', os.join( 'examples', 'hot_reload')){
+	if testing.v_build_failing(params + '-live', os.path_join( 'examples', 'hot_reload')){
 		exit(1)
 	}
 

--- a/cmd/tools/vbuild-examples.v
+++ b/cmd/tools/vbuild-examples.v
@@ -14,7 +14,7 @@ fn main() {
 		exit(1)
 	}
 
-	if testing.v_build_failing(params + '-live', os.path_join( 'examples', 'hot_reload')){
+	if testing.v_build_failing(params + '-live', os.join_path( 'examples', 'hot_reload')){
 		exit(1)
 	}
 

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -391,7 +391,7 @@ fn get_compile_name_of_potential_v_project(file string) string {
 	}
 	mut vfiles := []string
 	for f in all_files_in_pfolder {
-		vf := os.path_join(pfolder,f)
+		vf := os.path_join(pfolder, f)
 		if f.starts_with('.') || !f.ends_with('.v') || os.is_dir(vf) {
 			continue
 		}

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -155,7 +155,7 @@ fn (foptions &FormatOptions) format_file(file string) {
 		file_ast := parser.parse_file(file, table, .parse_comments)
 		formatted_content := fmt.fmt(file_ast, table)
 		file_name := os.filename(file)
-		vfmt_output_path := os.join(os.tmpdir(), 'vfmt_' + file_name)
+		vfmt_output_path := os.path_join(os.tmpdir(), 'vfmt_' + file_name)
 		os.write_file(vfmt_output_path, formatted_content )
 		if foptions.is_verbose {
 			eprintln('vfmt2 fmt.fmt worked and ${formatted_content.len} bytes were written to ${vfmt_output_path} .')
@@ -187,7 +187,7 @@ fn (foptions &FormatOptions) format_file(file string) {
 		// vfmt implementation.
 		mod_folder_parent = os.base_dir(mod_folder)
 		mut main_program_content := if mod_name == 'builtin' || mod_name == 'main' { 'fn main(){}\n' } else { 'import ${mod_name}\n' + 'fn main(){}\n' }
-		main_program_file := os.join(tmpfolder,'vfmt_tmp_${mod_name}_program.v')
+		main_program_file := os.path_join(tmpfolder,'vfmt_tmp_${mod_name}_program.v')
 		if os.exists(main_program_file) {
 			os.rm(main_program_file)
 		}
@@ -391,7 +391,7 @@ fn get_compile_name_of_potential_v_project(file string) string {
 	}
 	mut vfiles := []string
 	for f in all_files_in_pfolder {
-		vf := os.join(pfolder,f)
+		vf := os.path_join(pfolder,f)
 		if f.starts_with('.') || !f.ends_with('.v') || os.is_dir(vf) {
 			continue
 		}

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -155,7 +155,7 @@ fn (foptions &FormatOptions) format_file(file string) {
 		file_ast := parser.parse_file(file, table, .parse_comments)
 		formatted_content := fmt.fmt(file_ast, table)
 		file_name := os.filename(file)
-		vfmt_output_path := os.path_join(os.tmpdir(), 'vfmt_' + file_name)
+		vfmt_output_path := os.join_path(os.tmpdir(), 'vfmt_' + file_name)
 		os.write_file(vfmt_output_path, formatted_content )
 		if foptions.is_verbose {
 			eprintln('vfmt2 fmt.fmt worked and ${formatted_content.len} bytes were written to ${vfmt_output_path} .')
@@ -187,7 +187,7 @@ fn (foptions &FormatOptions) format_file(file string) {
 		// vfmt implementation.
 		mod_folder_parent = os.base_dir(mod_folder)
 		mut main_program_content := if mod_name == 'builtin' || mod_name == 'main' { 'fn main(){}\n' } else { 'import ${mod_name}\n' + 'fn main(){}\n' }
-		main_program_file := os.path_join(tmpfolder,'vfmt_tmp_${mod_name}_program.v')
+		main_program_file := os.join_path(tmpfolder,'vfmt_tmp_${mod_name}_program.v')
 		if os.exists(main_program_file) {
 			os.rm(main_program_file)
 		}
@@ -391,7 +391,7 @@ fn get_compile_name_of_potential_v_project(file string) string {
 	}
 	mut vfiles := []string
 	for f in all_files_in_pfolder {
-		vf := os.path_join(pfolder, f)
+		vf := os.join_path(pfolder, f)
 		if f.starts_with('.') || !f.ends_with('.v') || os.is_dir(vf) {
 			continue
 		}

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -176,7 +176,7 @@ fn vpm_install(module_names []string) {
 			println('Skipping module "$name", since it uses an unsupported VCS {$vcs} .')
 			continue
 		}
-		final_module_path := os.realpath(os.join(settings.vmodules_path,mod.name.replace('.', os.path_separator)))
+		final_module_path := os.realpath(os.path_join(settings.vmodules_path,mod.name.replace('.', os.path_separator)))
 		if os.exists(final_module_path) {
 			vpm_update([name])
 			continue
@@ -277,7 +277,7 @@ fn vpm_remove(module_names []string) {
 		os.rmdir_all(final_module_path)
 		// delete author directory if it is empty
 		author := name.split('.')[0]
-		author_dir := os.realpath(os.join(settings.vmodules_path,author))
+		author_dir := os.realpath(os.path_join(settings.vmodules_path,author))
 		if os.is_dir_empty(author_dir) {
 			verbose_println('removing author folder $author_dir')
 			os.rmdir(author_dir)
@@ -286,7 +286,7 @@ fn vpm_remove(module_names []string) {
 }
 
 fn valid_final_path_of_existing_module(name string) ?string {
-	name_of_vmodules_folder := os.join(settings.vmodules_path,name.replace('.', os.path_separator))
+	name_of_vmodules_folder := os.path_join(settings.vmodules_path,name.replace('.', os.path_separator))
 	final_module_path := os.realpath(name_of_vmodules_folder)
 	if !os.exists(final_module_path) {
 		println('No module with name "$name" exists at $name_of_vmodules_folder')
@@ -325,7 +325,7 @@ fn vpm_help(module_names []string) {
 fn vcs_used_in_dir(dir string) ?[]string {
 	mut vcs := []string
 	for repo_subfolder in supported_vcs_folders {
-		checked_folder := os.realpath(os.join(dir,repo_subfolder))
+		checked_folder := os.realpath(os.path_join(dir,repo_subfolder))
 		if os.is_dir(checked_folder) {
 			vcs << repo_subfolder.replace('.', '')
 		}
@@ -342,7 +342,7 @@ fn get_installed_modules() []string {
 	}
 	mut modules := []string
 	for dir in dirs {
-		adir := os.join(settings.vmodules_path,dir)
+		adir := os.path_join(settings.vmodules_path,dir)
 		if dir in excluded_dirs || !os.is_dir(adir) {
 			continue
 		}
@@ -351,7 +351,7 @@ fn get_installed_modules() []string {
 			continue
 		}
 		for m in mods {
-			vcs_used_in_dir(os.join(adir,m)) or {
+			vcs_used_in_dir(os.path_join(adir,m)) or {
 				continue
 			}
 			modules << '${author}.$m'
@@ -399,7 +399,7 @@ fn get_all_modules() []string {
 }
 
 fn resolve_dependencies(name, module_path string, module_names []string) {
-	vmod_path := os.join(module_path,'v.mod')
+	vmod_path := os.path_join(module_path,'v.mod')
 	if !os.exists(vmod_path) {
 		return
 	}

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -176,7 +176,7 @@ fn vpm_install(module_names []string) {
 			println('Skipping module "$name", since it uses an unsupported VCS {$vcs} .')
 			continue
 		}
-		final_module_path := os.realpath(os.path_join(settings.vmodules_path,mod.name.replace('.', os.path_separator)))
+		final_module_path := os.realpath(os.join_path(settings.vmodules_path,mod.name.replace('.', os.path_separator)))
 		if os.exists(final_module_path) {
 			vpm_update([name])
 			continue
@@ -277,7 +277,7 @@ fn vpm_remove(module_names []string) {
 		os.rmdir_all(final_module_path)
 		// delete author directory if it is empty
 		author := name.split('.')[0]
-		author_dir := os.realpath(os.path_join(settings.vmodules_path,author))
+		author_dir := os.realpath(os.join_path(settings.vmodules_path,author))
 		if os.is_dir_empty(author_dir) {
 			verbose_println('removing author folder $author_dir')
 			os.rmdir(author_dir)
@@ -286,7 +286,7 @@ fn vpm_remove(module_names []string) {
 }
 
 fn valid_final_path_of_existing_module(name string) ?string {
-	name_of_vmodules_folder := os.path_join(settings.vmodules_path,name.replace('.', os.path_separator))
+	name_of_vmodules_folder := os.join_path(settings.vmodules_path,name.replace('.', os.path_separator))
 	final_module_path := os.realpath(name_of_vmodules_folder)
 	if !os.exists(final_module_path) {
 		println('No module with name "$name" exists at $name_of_vmodules_folder')
@@ -325,7 +325,7 @@ fn vpm_help(module_names []string) {
 fn vcs_used_in_dir(dir string) ?[]string {
 	mut vcs := []string
 	for repo_subfolder in supported_vcs_folders {
-		checked_folder := os.realpath(os.path_join(dir,repo_subfolder))
+		checked_folder := os.realpath(os.join_path(dir,repo_subfolder))
 		if os.is_dir(checked_folder) {
 			vcs << repo_subfolder.replace('.', '')
 		}
@@ -342,7 +342,7 @@ fn get_installed_modules() []string {
 	}
 	mut modules := []string
 	for dir in dirs {
-		adir := os.path_join(settings.vmodules_path, dir)
+		adir := os.join_path(settings.vmodules_path, dir)
 		if dir in excluded_dirs || !os.is_dir(adir) {
 			continue
 		}
@@ -351,7 +351,7 @@ fn get_installed_modules() []string {
 			continue
 		}
 		for m in mods {
-			vcs_used_in_dir(os.path_join(adir, m)) or {
+			vcs_used_in_dir(os.join_path(adir, m)) or {
 				continue
 			}
 			modules << '${author}.$m'
@@ -399,7 +399,7 @@ fn get_all_modules() []string {
 }
 
 fn resolve_dependencies(name, module_path string, module_names []string) {
-	vmod_path := os.path_join(module_path, 'v.mod')
+	vmod_path := os.join_path(module_path, 'v.mod')
 	if !os.exists(vmod_path) {
 		return
 	}

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -342,7 +342,7 @@ fn get_installed_modules() []string {
 	}
 	mut modules := []string
 	for dir in dirs {
-		adir := os.path_join(settings.vmodules_path,dir)
+		adir := os.path_join(settings.vmodules_path, dir)
 		if dir in excluded_dirs || !os.is_dir(adir) {
 			continue
 		}
@@ -351,7 +351,7 @@ fn get_installed_modules() []string {
 			continue
 		}
 		for m in mods {
-			vcs_used_in_dir(os.path_join(adir,m)) or {
+			vcs_used_in_dir(os.path_join(adir, m)) or {
 				continue
 			}
 			modules << '${author}.$m'
@@ -399,7 +399,7 @@ fn get_all_modules() []string {
 }
 
 fn resolve_dependencies(name, module_path string, module_names []string) {
-	vmod_path := os.path_join(module_path,'v.mod')
+	vmod_path := os.path_join(module_path, 'v.mod')
 	if !os.exists(vmod_path) {
 		return
 	}

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -77,8 +77,8 @@ pub fn run_repl(workdir string, vrepl_prefix string) []string {
 	println(version)
 	println('Use Ctrl-C or `exit` to exit')
 
-	file := os.path_join(workdir, '.${vrepl_prefix}vrepl.v')
-	temp_file := os.path_join(workdir, '.${vrepl_prefix}vrepl_temp.v')
+	file := os.join_path(workdir, '.${vrepl_prefix}vrepl.v')
+	temp_file := os.join_path(workdir, '.${vrepl_prefix}vrepl_temp.v')
 	mut prompt := '>>> '
 	defer {
 		println('')

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -77,8 +77,8 @@ pub fn run_repl(workdir string, vrepl_prefix string) []string {
 	println(version)
 	println('Use Ctrl-C or `exit` to exit')
 
-	file := os.join( workdir, '.${vrepl_prefix}vrepl.v' )
-	temp_file := os.join( workdir, '.${vrepl_prefix}vrepl_temp.v')
+	file := os.path_join( workdir, '.${vrepl_prefix}vrepl.v' )
+	temp_file := os.path_join( workdir, '.${vrepl_prefix}vrepl_temp.v')
 	mut prompt := '>>> '
 	defer {
 		println('')

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -77,8 +77,8 @@ pub fn run_repl(workdir string, vrepl_prefix string) []string {
 	println(version)
 	println('Use Ctrl-C or `exit` to exit')
 
-	file := os.path_join( workdir, '.${vrepl_prefix}vrepl.v' )
-	temp_file := os.path_join( workdir, '.${vrepl_prefix}vrepl_temp.v')
+	file := os.path_join(workdir, '.${vrepl_prefix}vrepl.v')
+	temp_file := os.path_join(workdir, '.${vrepl_prefix}vrepl_temp.v')
 	mut prompt := '>>> '
 	defer {
 		println('')

--- a/cmd/tools/vtest-compiler.v
+++ b/cmd/tools/vtest-compiler.v
@@ -52,7 +52,7 @@ fn v_test_compiler(vargs string) {
 	eprintln('')
 	building_examples_failed := testing.v_build_failing(vargs, 'examples')
 	eprintln('')
-	building_live_failed := testing.v_build_failing(vargs + '-live', os.path_join('examples','hot_reload'))
+	building_live_failed := testing.v_build_failing(vargs + '-live', os.path_join('examples', 'hot_reload'))
 	eprintln('')
 	v_module_install_cmd := '$vexe install nedpals.args'
 	eprintln('')

--- a/cmd/tools/vtest-compiler.v
+++ b/cmd/tools/vtest-compiler.v
@@ -52,7 +52,7 @@ fn v_test_compiler(vargs string) {
 	eprintln('')
 	building_examples_failed := testing.v_build_failing(vargs, 'examples')
 	eprintln('')
-	building_live_failed := testing.v_build_failing(vargs + '-live', os.join('examples','hot_reload'))
+	building_live_failed := testing.v_build_failing(vargs + '-live', os.path_join('examples','hot_reload'))
 	eprintln('')
 	v_module_install_cmd := '$vexe install nedpals.args'
 	eprintln('')

--- a/cmd/tools/vtest-compiler.v
+++ b/cmd/tools/vtest-compiler.v
@@ -52,7 +52,7 @@ fn v_test_compiler(vargs string) {
 	eprintln('')
 	building_examples_failed := testing.v_build_failing(vargs, 'examples')
 	eprintln('')
-	building_live_failed := testing.v_build_failing(vargs + '-live', os.path_join('examples', 'hot_reload'))
+	building_live_failed := testing.v_build_failing(vargs + '-live', os.join_path('examples', 'hot_reload'))
 	eprintln('')
 	v_module_install_cmd := '$vexe install nedpals.args'
 	eprintln('')

--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -219,7 +219,7 @@ fn (v mut V) cc() {
 		a << '-c'
 	}
 	else if v.pref.is_cache {
-		builtin_o_path := os.path_join(v_modules_path,'cache','vlib','builtin.o')
+		builtin_o_path := os.path_join(v_modules_path, 'cache', 'vlib', 'builtin.o')
 		a << builtin_o_path.replace('builtin.o', 'strconv.o') // TODO hack no idea why this is needed
 		if os.exists(builtin_o_path) {
 			libs = builtin_o_path

--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -219,7 +219,7 @@ fn (v mut V) cc() {
 		a << '-c'
 	}
 	else if v.pref.is_cache {
-		builtin_o_path := os.join(v_modules_path,'cache','vlib','builtin.o')
+		builtin_o_path := os.path_join(v_modules_path,'cache','vlib','builtin.o')
 		a << builtin_o_path.replace('builtin.o', 'strconv.o') // TODO hack no idea why this is needed
 		if os.exists(builtin_o_path) {
 			libs = builtin_o_path

--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -219,7 +219,7 @@ fn (v mut V) cc() {
 		a << '-c'
 	}
 	else if v.pref.is_cache {
-		builtin_o_path := os.path_join(v_modules_path, 'cache', 'vlib', 'builtin.o')
+		builtin_o_path := os.join_path(v_modules_path, 'cache', 'vlib', 'builtin.o')
 		a << builtin_o_path.replace('builtin.o', 'strconv.o') // TODO hack no idea why this is needed
 		if os.exists(builtin_o_path) {
 			libs = builtin_o_path

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -348,7 +348,7 @@ pub fn (v mut V) compile_x64() {
 		println('v -x64 can only generate Linux binaries for now')
 		println('You are not on a Linux system, so you will not ' + 'be able to run the resulting executable')
 	}
-	//v.files << v.v_files_from_dir(os.join(v.pref.vlib_path,'builtin','bare'))
+	//v.files << v.v_files_from_dir(os.path_join(v.pref.vlib_path,'builtin','bare'))
 	v.files << v.pref.path
 	v.set_module_lookup_paths()
 	mut b := v.new_v2()
@@ -624,7 +624,7 @@ pub fn (v &V) v_files_from_dir(dir string) []string {
 				continue
 			}
 		}
-		res << os.join(dir,file)
+		res << os.path_join(dir,file)
 	}
 	return res
 }
@@ -638,7 +638,7 @@ pub fn (v mut V) add_v_files_to_compile() {
 	}
 	// Builtin cache exists? Use it.
 	if v.pref.is_cache {
-		builtin_vh := os.join(v_modules_path,'vlib','builtin.vh')
+		builtin_vh := os.path_join(v_modules_path,'vlib','builtin.vh')
 		if os.exists(builtin_vh) {
 			v.cached_mods << 'builtin'
 			builtin_files = [builtin_vh]
@@ -721,16 +721,16 @@ pub fn (v &V) get_builtin_files() []string {
 	// Lookup for built-in folder in lookup path.
 	// Assumption: `builtin/` folder implies usable implementation of builtin
 	for location in v.pref.lookup_path {
-		if !os.exists(os.join(location, 'builtin')) {
+		if !os.exists(os.path_join(location, 'builtin')) {
 			continue
 		}
 		if v.pref.is_bare {
-			return v.v_files_from_dir(os.join(location, 'builtin', 'bare'))
+			return v.v_files_from_dir(os.path_join(location, 'builtin', 'bare'))
 		}
 		$if js {
-			return v.v_files_from_dir(os.join(location, 'builtin','js'))
+			return v.v_files_from_dir(os.path_join(location, 'builtin','js'))
 		}
-		return v.v_files_from_dir(os.join(location, 'builtin'))
+		return v.v_files_from_dir(os.path_join(location, 'builtin'))
 	}
 	// Panic. We couldn't find the folder.
 	verror('`builtin/` not included on module lookup path.
@@ -748,18 +748,18 @@ pub fn (v &V) get_user_files() []string {
 
     // See cmd/tools/preludes/README.md for more info about what preludes are
 	vroot := os.dir(pref.vexe_path())
-	preludes_path := os.join(vroot,'cmd','tools','preludes')
+	preludes_path := os.path_join(vroot,'cmd','tools','preludes')
 	if v.pref.is_live {
-		user_files << os.join(preludes_path,'live_main.v')
+		user_files << os.path_join(preludes_path,'live_main.v')
 	}
 	if v.pref.is_solive {
-		user_files << os.join(preludes_path,'live_shared.v')
+		user_files << os.path_join(preludes_path,'live_shared.v')
 	}
 	if v.pref.is_test {
-		user_files << os.join(preludes_path,'tests_assertions.v')
+		user_files << os.path_join(preludes_path,'tests_assertions.v')
 	}
 	if v.pref.is_test && v.pref.is_stats {
-		user_files << os.join(preludes_path,'tests_with_stats.v')
+		user_files << os.path_join(preludes_path,'tests_with_stats.v')
 	}
 
 	is_test := dir.ends_with('_test.v')

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -624,7 +624,7 @@ pub fn (v &V) v_files_from_dir(dir string) []string {
 				continue
 			}
 		}
-		res << os.path_join(dir,file)
+		res << os.path_join(dir, file)
 	}
 	return res
 }
@@ -638,7 +638,7 @@ pub fn (v mut V) add_v_files_to_compile() {
 	}
 	// Builtin cache exists? Use it.
 	if v.pref.is_cache {
-		builtin_vh := os.path_join(v_modules_path,'vlib','builtin.vh')
+		builtin_vh := os.path_join(v_modules_path, 'vlib', 'builtin.vh')
 		if os.exists(builtin_vh) {
 			v.cached_mods << 'builtin'
 			builtin_files = [builtin_vh]
@@ -728,7 +728,7 @@ pub fn (v &V) get_builtin_files() []string {
 			return v.v_files_from_dir(os.path_join(location, 'builtin', 'bare'))
 		}
 		$if js {
-			return v.v_files_from_dir(os.path_join(location, 'builtin','js'))
+			return v.v_files_from_dir(os.path_join(location, 'builtin', 'js'))
 		}
 		return v.v_files_from_dir(os.path_join(location, 'builtin'))
 	}
@@ -748,18 +748,18 @@ pub fn (v &V) get_user_files() []string {
 
     // See cmd/tools/preludes/README.md for more info about what preludes are
 	vroot := os.dir(pref.vexe_path())
-	preludes_path := os.path_join(vroot,'cmd','tools','preludes')
+	preludes_path := os.path_join(vroot, 'cmd', 'tools', 'preludes')
 	if v.pref.is_live {
-		user_files << os.path_join(preludes_path,'live_main.v')
+		user_files << os.path_join(preludes_path, 'live_main.v')
 	}
 	if v.pref.is_solive {
-		user_files << os.path_join(preludes_path,'live_shared.v')
+		user_files << os.path_join(preludes_path, 'live_shared.v')
 	}
 	if v.pref.is_test {
-		user_files << os.path_join(preludes_path,'tests_assertions.v')
+		user_files << os.path_join(preludes_path, 'tests_assertions.v')
 	}
 	if v.pref.is_test && v.pref.is_stats {
-		user_files << os.path_join(preludes_path,'tests_with_stats.v')
+		user_files << os.path_join(preludes_path, 'tests_with_stats.v')
 	}
 
 	is_test := dir.ends_with('_test.v')

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -348,7 +348,7 @@ pub fn (v mut V) compile_x64() {
 		println('v -x64 can only generate Linux binaries for now')
 		println('You are not on a Linux system, so you will not ' + 'be able to run the resulting executable')
 	}
-	//v.files << v.v_files_from_dir(os.path_join(v.pref.vlib_path,'builtin','bare'))
+	//v.files << v.v_files_from_dir(os.join_path(v.pref.vlib_path,'builtin','bare'))
 	v.files << v.pref.path
 	v.set_module_lookup_paths()
 	mut b := v.new_v2()
@@ -624,7 +624,7 @@ pub fn (v &V) v_files_from_dir(dir string) []string {
 				continue
 			}
 		}
-		res << os.path_join(dir, file)
+		res << os.join_path(dir, file)
 	}
 	return res
 }
@@ -638,7 +638,7 @@ pub fn (v mut V) add_v_files_to_compile() {
 	}
 	// Builtin cache exists? Use it.
 	if v.pref.is_cache {
-		builtin_vh := os.path_join(v_modules_path, 'vlib', 'builtin.vh')
+		builtin_vh := os.join_path(v_modules_path, 'vlib', 'builtin.vh')
 		if os.exists(builtin_vh) {
 			v.cached_mods << 'builtin'
 			builtin_files = [builtin_vh]
@@ -721,16 +721,16 @@ pub fn (v &V) get_builtin_files() []string {
 	// Lookup for built-in folder in lookup path.
 	// Assumption: `builtin/` folder implies usable implementation of builtin
 	for location in v.pref.lookup_path {
-		if !os.exists(os.path_join(location, 'builtin')) {
+		if !os.exists(os.join_path(location, 'builtin')) {
 			continue
 		}
 		if v.pref.is_bare {
-			return v.v_files_from_dir(os.path_join(location, 'builtin', 'bare'))
+			return v.v_files_from_dir(os.join_path(location, 'builtin', 'bare'))
 		}
 		$if js {
-			return v.v_files_from_dir(os.path_join(location, 'builtin', 'js'))
+			return v.v_files_from_dir(os.join_path(location, 'builtin', 'js'))
 		}
-		return v.v_files_from_dir(os.path_join(location, 'builtin'))
+		return v.v_files_from_dir(os.join_path(location, 'builtin'))
 	}
 	// Panic. We couldn't find the folder.
 	verror('`builtin/` not included on module lookup path.
@@ -748,18 +748,18 @@ pub fn (v &V) get_user_files() []string {
 
     // See cmd/tools/preludes/README.md for more info about what preludes are
 	vroot := os.dir(pref.vexe_path())
-	preludes_path := os.path_join(vroot, 'cmd', 'tools', 'preludes')
+	preludes_path := os.join_path(vroot, 'cmd', 'tools', 'preludes')
 	if v.pref.is_live {
-		user_files << os.path_join(preludes_path, 'live_main.v')
+		user_files << os.join_path(preludes_path, 'live_main.v')
 	}
 	if v.pref.is_solive {
-		user_files << os.path_join(preludes_path, 'live_shared.v')
+		user_files << os.join_path(preludes_path, 'live_shared.v')
 	}
 	if v.pref.is_test {
-		user_files << os.path_join(preludes_path, 'tests_assertions.v')
+		user_files << os.join_path(preludes_path, 'tests_assertions.v')
 	}
 	if v.pref.is_test && v.pref.is_stats {
-		user_files << os.path_join(preludes_path, 'tests_with_stats.v')
+		user_files << os.join_path(preludes_path, 'tests_with_stats.v')
 	}
 
 	is_test := dir.ends_with('_test.v')

--- a/vlib/compiler/module_header.v
+++ b/vlib/compiler/module_header.v
@@ -28,7 +28,7 @@ mut:
 fn generate_vh(mod string) {
 	println('\n\n\n\nGenerating a V header file for module `$mod`')
 	vexe := pref.vexe_path()
-	full_mod_path := os.path_join(os.dir(vexe), mod)
+	full_mod_path := os.join_path(os.dir(vexe), mod)
 	dir := if mod.starts_with('vlib') { '$compiler.v_modules_path${os.path_separator}$mod' } else { mod }
 	path := dir + '.vh'
 	pdir := dir.all_before_last(os.path_separator)

--- a/vlib/compiler/module_header.v
+++ b/vlib/compiler/module_header.v
@@ -28,7 +28,7 @@ mut:
 fn generate_vh(mod string) {
 	println('\n\n\n\nGenerating a V header file for module `$mod`')
 	vexe := pref.vexe_path()
-	full_mod_path := os.join(os.dir(vexe),mod)
+	full_mod_path := os.path_join(os.dir(vexe),mod)
 	dir := if mod.starts_with('vlib') { '$compiler.v_modules_path${os.path_separator}$mod' } else { mod }
 	path := dir + '.vh'
 	pdir := dir.all_before_last(os.path_separator)

--- a/vlib/compiler/module_header.v
+++ b/vlib/compiler/module_header.v
@@ -28,7 +28,7 @@ mut:
 fn generate_vh(mod string) {
 	println('\n\n\n\nGenerating a V header file for module `$mod`')
 	vexe := pref.vexe_path()
-	full_mod_path := os.path_join(os.dir(vexe),mod)
+	full_mod_path := os.path_join(os.dir(vexe), mod)
 	dir := if mod.starts_with('vlib') { '$compiler.v_modules_path${os.path_separator}$mod' } else { mod }
 	path := dir + '.vh'
 	pdir := dir.all_before_last(os.path_separator)

--- a/vlib/compiler/modules.v
+++ b/vlib/compiler/modules.v
@@ -170,7 +170,7 @@ fn (v mut V) set_module_lookup_paths() {
 		v.module_lookup_paths << os.base_dir(v.compiled_dir) // pdir of _test.v
 	}
 	v.module_lookup_paths << v.compiled_dir
-	v.module_lookup_paths << os.path_join(v.compiled_dir, 'modules')
+	v.module_lookup_paths << os.join_path(v.compiled_dir, 'modules')
 	v.module_lookup_paths << v.pref.lookup_path
 	if v.pref.verbosity.is_higher_or_equal(.level_two) {
 		v.log('v.module_lookup_paths: $v.module_lookup_paths')
@@ -189,7 +189,7 @@ fn (p mut Parser) find_module_path(mod string) ?string {
 
 	mod_path := p.v.module_path(mod)
 	for lookup_path in module_lookup_paths {
-		try_path := os.path_join(lookup_path, mod_path)
+		try_path := os.join_path(lookup_path, mod_path)
 		if p.v.pref.verbosity.is_higher_or_equal(.level_three) {
 			println('  >> trying to find $mod in $try_path ...')
 		}

--- a/vlib/compiler/modules.v
+++ b/vlib/compiler/modules.v
@@ -170,7 +170,7 @@ fn (v mut V) set_module_lookup_paths() {
 		v.module_lookup_paths << os.base_dir(v.compiled_dir) // pdir of _test.v
 	}
 	v.module_lookup_paths << v.compiled_dir
-	v.module_lookup_paths << os.path_join(v.compiled_dir,'modules')
+	v.module_lookup_paths << os.path_join(v.compiled_dir, 'modules')
 	v.module_lookup_paths << v.pref.lookup_path
 	if v.pref.verbosity.is_higher_or_equal(.level_two) {
 		v.log('v.module_lookup_paths: $v.module_lookup_paths')
@@ -189,7 +189,7 @@ fn (p mut Parser) find_module_path(mod string) ?string {
 
 	mod_path := p.v.module_path(mod)
 	for lookup_path in module_lookup_paths {
-		try_path := os.path_join(lookup_path,mod_path)
+		try_path := os.path_join(lookup_path, mod_path)
 		if p.v.pref.verbosity.is_higher_or_equal(.level_three) {
 			println('  >> trying to find $mod in $try_path ...')
 		}

--- a/vlib/compiler/modules.v
+++ b/vlib/compiler/modules.v
@@ -170,7 +170,7 @@ fn (v mut V) set_module_lookup_paths() {
 		v.module_lookup_paths << os.base_dir(v.compiled_dir) // pdir of _test.v
 	}
 	v.module_lookup_paths << v.compiled_dir
-	v.module_lookup_paths << os.join(v.compiled_dir,'modules')
+	v.module_lookup_paths << os.path_join(v.compiled_dir,'modules')
 	v.module_lookup_paths << v.pref.lookup_path
 	if v.pref.verbosity.is_higher_or_equal(.level_two) {
 		v.log('v.module_lookup_paths: $v.module_lookup_paths')
@@ -189,7 +189,7 @@ fn (p mut Parser) find_module_path(mod string) ?string {
 
 	mod_path := p.v.module_path(mod)
 	for lookup_path in module_lookup_paths {
-		try_path := os.join(lookup_path,mod_path)
+		try_path := os.path_join(lookup_path,mod_path)
 		if p.v.pref.verbosity.is_higher_or_equal(.level_three) {
 			println('  >> trying to find $mod in $try_path ...')
 		}

--- a/vlib/compiler/tests/repl/repl_test.v
+++ b/vlib/compiler/tests/repl/repl_test.v
@@ -63,7 +63,7 @@ fn worker_repl(p mut sync.PoolProcessor, idx int, thread_id int) voidptr {
 		p.set_thread_context(idx, tls_bench)
 	}
 	tls_bench.cstep = idx
-	tfolder := os.join(cdir,'vrepl_tests_$idx')
+	tfolder := os.path_join(cdir,'vrepl_tests_$idx')
 	if os.is_dir(tfolder) {
 		os.rmdir_all(tfolder)
 	}

--- a/vlib/compiler/tests/repl/repl_test.v
+++ b/vlib/compiler/tests/repl/repl_test.v
@@ -63,7 +63,7 @@ fn worker_repl(p mut sync.PoolProcessor, idx int, thread_id int) voidptr {
 		p.set_thread_context(idx, tls_bench)
 	}
 	tls_bench.cstep = idx
-	tfolder := os.path_join(cdir, 'vrepl_tests_$idx')
+	tfolder := os.join_path(cdir, 'vrepl_tests_$idx')
 	if os.is_dir(tfolder) {
 		os.rmdir_all(tfolder)
 	}

--- a/vlib/compiler/tests/repl/repl_test.v
+++ b/vlib/compiler/tests/repl/repl_test.v
@@ -63,7 +63,7 @@ fn worker_repl(p mut sync.PoolProcessor, idx int, thread_id int) voidptr {
 		p.set_thread_context(idx, tls_bench)
 	}
 	tls_bench.cstep = idx
-	tfolder := os.path_join(cdir,'vrepl_tests_$idx')
+	tfolder := os.path_join(cdir, 'vrepl_tests_$idx')
 	if os.is_dir(tfolder) {
 		os.rmdir_all(tfolder)
 	}

--- a/vlib/compiler/tests/repl/runner/runner.v
+++ b/vlib/compiler/tests/repl/runner/runner.v
@@ -19,7 +19,7 @@ pub fn full_path_to_v(dirs_in int) string {
 	for i := 0; i < dirs_in; i++ {
 		path = os.dir(path)
 	}
-	vexec := os.join( path, vname )
+	vexec := os.path_join( path, vname )
 	/*
 	args := os.args
 	vreal  := os.realpath('v')
@@ -56,9 +56,9 @@ pub fn run_repl_file(wd string, vexec string, file string) ?string {
 
 	fname := os.filename( file )
 
-	input_temporary_filename := os.realpath(os.join( wd, 'input_temporary_filename.txt'))
+	input_temporary_filename := os.realpath(os.path_join( wd, 'input_temporary_filename.txt'))
 	os.write_file(input_temporary_filename, input)
-	os.write_file(  os.realpath(os.join( wd, 'original.txt' ) ), fcontent )
+	os.write_file(  os.realpath(os.path_join( wd, 'original.txt' ) ), fcontent )
 	rcmd := '"$vexec" repl -replfolder "$wd" -replprefix "${fname}." < $input_temporary_filename'
 	r := os.exec(rcmd) or {
 		os.rm(input_temporary_filename)

--- a/vlib/compiler/tests/repl/runner/runner.v
+++ b/vlib/compiler/tests/repl/runner/runner.v
@@ -19,7 +19,7 @@ pub fn full_path_to_v(dirs_in int) string {
 	for i := 0; i < dirs_in; i++ {
 		path = os.dir(path)
 	}
-	vexec := os.path_join( path, vname )
+	vexec := os.path_join(path, vname)
 	/*
 	args := os.args
 	vreal  := os.realpath('v')

--- a/vlib/compiler/tests/repl/runner/runner.v
+++ b/vlib/compiler/tests/repl/runner/runner.v
@@ -19,7 +19,7 @@ pub fn full_path_to_v(dirs_in int) string {
 	for i := 0; i < dirs_in; i++ {
 		path = os.dir(path)
 	}
-	vexec := os.path_join(path, vname)
+	vexec := os.join_path(path, vname)
 	/*
 	args := os.args
 	vreal  := os.realpath('v')
@@ -56,9 +56,9 @@ pub fn run_repl_file(wd string, vexec string, file string) ?string {
 
 	fname := os.filename( file )
 
-	input_temporary_filename := os.realpath(os.path_join( wd, 'input_temporary_filename.txt'))
+	input_temporary_filename := os.realpath(os.join_path( wd, 'input_temporary_filename.txt'))
 	os.write_file(input_temporary_filename, input)
-	os.write_file(  os.realpath(os.path_join( wd, 'original.txt' ) ), fcontent )
+	os.write_file(  os.realpath(os.join_path( wd, 'original.txt' ) ), fcontent )
 	rcmd := '"$vexec" repl -replfolder "$wd" -replprefix "${fname}." < $input_temporary_filename'
 	r := os.exec(rcmd) or {
 		os.rm(input_temporary_filename)

--- a/vlib/compiler/v_mod_cache.v
+++ b/vlib/compiler/v_mod_cache.v
@@ -97,7 +97,7 @@ fn (mcache mut ModFileCacher) traverse(mfolder string) ([]string, ModFileAndFold
 		if 'v.mod' in files {
 			// TODO: actually read the v.mod file and parse its contents to see
 			// if its source folder is different
-			res := ModFileAndFolder{ vmod_file: os.join( cfolder, 'v.mod'), vmod_folder: cfolder }
+			res := ModFileAndFolder{ vmod_file: os.path_join( cfolder, 'v.mod'), vmod_folder: cfolder }
 			return folders_so_far, res
 		}
 		if mcache.check_for_stop( cfolder, files ) {

--- a/vlib/compiler/v_mod_cache.v
+++ b/vlib/compiler/v_mod_cache.v
@@ -97,7 +97,7 @@ fn (mcache mut ModFileCacher) traverse(mfolder string) ([]string, ModFileAndFold
 		if 'v.mod' in files {
 			// TODO: actually read the v.mod file and parse its contents to see
 			// if its source folder is different
-			res := ModFileAndFolder{ vmod_file: os.path_join( cfolder, 'v.mod'), vmod_folder: cfolder }
+			res := ModFileAndFolder{ vmod_file: os.join_path( cfolder, 'v.mod'), vmod_folder: cfolder }
 			return folders_so_far, res
 		}
 		if mcache.check_for_stop( cfolder, files ) {

--- a/vlib/compiler/vtmp.v
+++ b/vlib/compiler/vtmp.v
@@ -6,7 +6,7 @@ module compiler
 import os
 
 fn get_vtmp_folder() string {
-	vtmp := os.join(os.tmpdir(),'v')
+	vtmp := os.path_join(os.tmpdir(),'v')
 	if !os.is_dir(vtmp) {
 		os.mkdir(vtmp)or{
 			panic(err)
@@ -17,5 +17,5 @@ fn get_vtmp_folder() string {
 
 fn get_vtmp_filename(base_file_name string, postfix string) string {
 	vtmp := get_vtmp_folder()
-	return os.realpath(os.join(vtmp,os.filename(os.realpath(base_file_name)) + postfix))
+	return os.realpath(os.path_join(vtmp,os.filename(os.realpath(base_file_name)) + postfix))
 }

--- a/vlib/compiler/vtmp.v
+++ b/vlib/compiler/vtmp.v
@@ -6,9 +6,9 @@ module compiler
 import os
 
 fn get_vtmp_folder() string {
-	vtmp := os.path_join(os.tmpdir(),'v')
+	vtmp := os.path_join(os.tmpdir(), 'v')
 	if !os.is_dir(vtmp) {
-		os.mkdir(vtmp)or{
+		os.mkdir(vtmp) or {
 			panic(err)
 		}
 	}
@@ -17,5 +17,5 @@ fn get_vtmp_folder() string {
 
 fn get_vtmp_filename(base_file_name string, postfix string) string {
 	vtmp := get_vtmp_folder()
-	return os.realpath(os.path_join(vtmp,os.filename(os.realpath(base_file_name)) + postfix))
+	return os.realpath(os.path_join(vtmp, os.filename(os.realpath(base_file_name)) + postfix))
 }

--- a/vlib/compiler/vtmp.v
+++ b/vlib/compiler/vtmp.v
@@ -6,7 +6,7 @@ module compiler
 import os
 
 fn get_vtmp_folder() string {
-	vtmp := os.path_join(os.tmpdir(), 'v')
+	vtmp := os.join_path(os.tmpdir(), 'v')
 	if !os.is_dir(vtmp) {
 		os.mkdir(vtmp) or {
 			panic(err)
@@ -17,5 +17,5 @@ fn get_vtmp_folder() string {
 
 fn get_vtmp_filename(base_file_name string, postfix string) string {
 	vtmp := get_vtmp_folder()
-	return os.realpath(os.path_join(vtmp, os.filename(os.realpath(base_file_name)) + postfix))
+	return os.realpath(os.join_path(vtmp, os.filename(os.realpath(base_file_name)) + postfix))
 }

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -79,7 +79,7 @@ pub fn (l mut Log) set_output_label(label string){
 pub fn (l mut Log) set_output_path(output_file_path string) {
 	if l.ofile.is_opened() { l.ofile.close() }
 	l.output_to_file = true
-	l.output_file_name = os.join( os.realpath( output_file_path ) , l.output_label )
+	l.output_file_name = os.path_join( os.realpath( output_file_path ) , l.output_label )
 	ofile := os.open_append( l.output_file_name ) or {
 		panic('error while opening log file ${l.output_file_name} for appending')
 	}

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -79,7 +79,7 @@ pub fn (l mut Log) set_output_label(label string){
 pub fn (l mut Log) set_output_path(output_file_path string) {
 	if l.ofile.is_opened() { l.ofile.close() }
 	l.output_to_file = true
-	l.output_file_name = os.path_join( os.realpath( output_file_path ) , l.output_label )
+	l.output_file_name = os.join_path( os.realpath( output_file_path ) , l.output_label )
 	ofile := os.open_append( l.output_file_name ) or {
 		panic('error while opening log file ${l.output_file_name} for appending')
 	}

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -181,7 +181,7 @@ pub fn cp_all(osource_path, odest_path string, overwrite bool) ?bool {
 	}
 	// single file copy
 	if !os.is_dir(source_path) {
-		adjasted_path := if os.is_dir(dest_path) { os.path_join(dest_path,os.filename(source_path)) } else { dest_path }
+		adjasted_path := if os.is_dir(dest_path) { os.join_path(dest_path,os.filename(source_path)) } else { dest_path }
 		if os.exists(adjasted_path) {
 			if overwrite {
 				os.rm(adjasted_path)
@@ -202,8 +202,8 @@ pub fn cp_all(osource_path, odest_path string, overwrite bool) ?bool {
 		return error(err)
 	}
 	for file in files {
-		sp := os.path_join(source_path, file)
-		dp := os.path_join(dest_path, file)
+		sp := os.join_path(source_path, file)
+		dp := os.join_path(dest_path, file)
 		if os.is_dir(sp) {
 			os.mkdir(dp) or {
 				panic(err)
@@ -632,10 +632,10 @@ pub fn rmdir_all(path string) {
 		return
 	}
 	for item in items {
-		if os.is_dir(os.path_join(path, item)) {
-			rmdir_all(os.path_join(path, item))
+		if os.is_dir(os.join_path(path, item)) {
+			rmdir_all(os.join_path(path, item))
 		}
-		os.rm(os.path_join(path, item))
+		os.rm(os.join_path(path, item))
 	}
 	os.rmdir(path)
 }
@@ -1002,7 +1002,7 @@ pub fn is_abs(path string) bool {
 }
 
 // join returns path as string from string parameter(s).
-pub fn path_join(base string, dirs ...string) string {
+pub fn join_path(base string, dirs ...string) string {
 	mut result := []string
 	result << base.trim_right('\\/')
 	for d in dirs {
@@ -1192,5 +1192,5 @@ pub fn resource_abs_path(path string) string {
 	if vresource.len != 0 {
 		base_path = vresource
 	}
-	return os.realpath(os.path_join(base_path, path))
+	return os.realpath(os.join_path(base_path, path))
 }

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -202,8 +202,8 @@ pub fn cp_all(osource_path, odest_path string, overwrite bool) ?bool {
 		return error(err)
 	}
 	for file in files {
-		sp := os.path_join(source_path,file)
-		dp := os.path_join(dest_path,file)
+		sp := os.path_join(source_path, file)
+		dp := os.path_join(dest_path, file)
 		if os.is_dir(sp) {
 			os.mkdir(dp) or {
 				panic(err)
@@ -632,10 +632,10 @@ pub fn rmdir_all(path string) {
 		return
 	}
 	for item in items {
-		if os.is_dir(os.path_join(path,item)) {
-			rmdir_all(os.path_join(path,item))
+		if os.is_dir(os.path_join(path, item)) {
+			rmdir_all(os.path_join(path, item))
 		}
-		os.rm(os.path_join(path,item))
+		os.rm(os.path_join(path, item))
 	}
 	os.rmdir(path)
 }
@@ -1192,5 +1192,5 @@ pub fn resource_abs_path(path string) string {
 	if vresource.len != 0 {
 		base_path = vresource
 	}
-	return os.realpath( os.path_join( base_path, path ) )
+	return os.realpath(os.path_join(base_path, path))
 }

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -181,7 +181,7 @@ pub fn cp_all(osource_path, odest_path string, overwrite bool) ?bool {
 	}
 	// single file copy
 	if !os.is_dir(source_path) {
-		adjasted_path := if os.is_dir(dest_path) { os.join(dest_path,os.filename(source_path)) } else { dest_path }
+		adjasted_path := if os.is_dir(dest_path) { os.path_join(dest_path,os.filename(source_path)) } else { dest_path }
 		if os.exists(adjasted_path) {
 			if overwrite {
 				os.rm(adjasted_path)
@@ -202,8 +202,8 @@ pub fn cp_all(osource_path, odest_path string, overwrite bool) ?bool {
 		return error(err)
 	}
 	for file in files {
-		sp := os.join(source_path,file)
-		dp := os.join(dest_path,file)
+		sp := os.path_join(source_path,file)
+		dp := os.path_join(dest_path,file)
 		if os.is_dir(sp) {
 			os.mkdir(dp) or {
 				panic(err)
@@ -632,10 +632,10 @@ pub fn rmdir_all(path string) {
 		return
 	}
 	for item in items {
-		if os.is_dir(os.join(path,item)) {
-			rmdir_all(os.join(path,item))
+		if os.is_dir(os.path_join(path,item)) {
+			rmdir_all(os.path_join(path,item))
 		}
-		os.rm(os.join(path,item))
+		os.rm(os.path_join(path,item))
 	}
 	os.rmdir(path)
 }
@@ -1002,7 +1002,7 @@ pub fn is_abs(path string) bool {
 }
 
 // join returns path as string from string parameter(s).
-pub fn join(base string, dirs ...string) string {
+pub fn path_join(base string, dirs ...string) string {
 	mut result := []string
 	result << base.trim_right('\\/')
 	for d in dirs {
@@ -1192,5 +1192,5 @@ pub fn resource_abs_path(path string) string {
 	if vresource.len != 0 {
 		base_path = vresource
 	}
-	return os.realpath( os.join( base_path, path ) )
+	return os.realpath( os.path_join( base_path, path ) )
 }

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -307,9 +307,9 @@ fn test_is_abs() {
 
 fn test_join() {
 	$if windows {
-		assert os.join('v', 'vlib', 'os') == 'v\\vlib\\os'
+		assert os.path_join('v', 'vlib', 'os') == 'v\\vlib\\os'
 	} $else {
-		assert os.join('v', 'vlib', 'os') == 'v/vlib/os'
+		assert os.path_join('v', 'vlib', 'os') == 'v/vlib/os'
 	}
 }
 

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -307,9 +307,9 @@ fn test_is_abs() {
 
 fn test_join() {
 	$if windows {
-		assert os.path_join('v', 'vlib', 'os') == 'v\\vlib\\os'
+		assert os.join_path('v', 'vlib', 'os') == 'v\\vlib\\os'
 	} $else {
-		assert os.path_join('v', 'vlib', 'os') == 'v/vlib/os'
+		assert os.join_path('v', 'vlib', 'os') == 'v/vlib/os'
 	}
 }
 

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -182,7 +182,7 @@ pub fn (b &Builder) v_files_from_dir(dir string) []string {
 		}
 		*/
 
-		res << os.path_join(dir,file)
+		res << os.join_path(dir,file)
 	}
 	return res
 }
@@ -206,7 +206,7 @@ fn module_path(mod string) string {
 pub fn (b &Builder) find_module_path(mod string) ?string {
 	mod_path := module_path(mod)
 	for search_path in b.module_search_paths {
-		try_path := os.path_join(search_path, mod_path)
+		try_path := os.join_path(search_path, mod_path)
 		if b.pref.verbosity.is_higher_or_equal(.level_three) {
 			println('  >> trying to find $mod in $try_path ..')
 		}

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -182,7 +182,7 @@ pub fn (b &Builder) v_files_from_dir(dir string) []string {
 		}
 		*/
 
-		res << os.join(dir,file)
+		res << os.path_join(dir,file)
 	}
 	return res
 }
@@ -206,7 +206,7 @@ fn module_path(mod string) string {
 pub fn (b &Builder) find_module_path(mod string) ?string {
 	mod_path := module_path(mod)
 	for search_path in b.module_search_paths {
-		try_path := os.join(search_path,mod_path)
+		try_path := os.path_join(search_path,mod_path)
 		if b.pref.verbosity.is_higher_or_equal(.level_three) {
 			println('  >> trying to find $mod in $try_path ..')
 		}

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -206,7 +206,7 @@ fn module_path(mod string) string {
 pub fn (b &Builder) find_module_path(mod string) ?string {
 	mod_path := module_path(mod)
 	for search_path in b.module_search_paths {
-		try_path := os.path_join(search_path,mod_path)
+		try_path := os.path_join(search_path, mod_path)
 		if b.pref.verbosity.is_higher_or_equal(.level_three) {
 			println('  >> trying to find $mod in $try_path ..')
 		}

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -28,7 +28,7 @@ pub fn doc(mod string, table &table.Table) string {
 	}
 	vlib_path := os.dir(pref.vexe_path()) + '/vlib'
 	mod_path := mod.replace('.', os.path_separator)
-	path := os.join(vlib_path, mod_path)
+	path := os.path_join(vlib_path, mod_path)
 	if !os.exists(path) {
 		println('module "$mod" not found')
 		println(path)
@@ -45,7 +45,7 @@ pub fn doc(mod string, table &table.Table) string {
 		if file.ends_with('_test.v') || file.ends_with('_windows.v') || file.ends_with('_macos.v') {
 			continue
 		}
-		file_ast := parser.parse_file(os.join(path,file), table, .skip_comments)
+		file_ast := parser.parse_file(os.path_join(path,file), table, .skip_comments)
 		d.stmts << file_ast.stmts
 	}
 	d.print_fns()

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -28,7 +28,7 @@ pub fn doc(mod string, table &table.Table) string {
 	}
 	vlib_path := os.dir(pref.vexe_path()) + '/vlib'
 	mod_path := mod.replace('.', os.path_separator)
-	path := os.path_join(vlib_path, mod_path)
+	path := os.join_path(vlib_path, mod_path)
 	if !os.exists(path) {
 		println('module "$mod" not found')
 		println(path)
@@ -45,7 +45,7 @@ pub fn doc(mod string, table &table.Table) string {
 		if file.ends_with('_test.v') || file.ends_with('_windows.v') || file.ends_with('_macos.v') {
 			continue
 		}
-		file_ast := parser.parse_file(os.path_join(path,file), table, .skip_comments)
+		file_ast := parser.parse_file(os.join_path(path,file), table, .skip_comments)
 		d.stmts << file_ast.stmts
 	}
 	d.print_fns()

--- a/vlib/v/fmt/fmt_keep_test.v
+++ b/vlib/v/fmt/fmt_keep_test.v
@@ -52,7 +52,7 @@ fn test_fmt() {
 				eprintln('>> sorry, but no working "diff" CLI command can be found')
 				continue
 			}
-			vfmt_result_file := os.join(tmpfolder,'vfmt_run_over_${ifilename}')
+			vfmt_result_file := os.join_path(tmpfolder,'vfmt_run_over_${ifilename}')
 			os.write_file(vfmt_result_file, result_ocontent)
 			os.system('$diff_cmd --minimal  --text   --unified=2 --show-function-line="fn " "$opath" "$vfmt_result_file"')
 			continue

--- a/vlib/v/fmt/fmt_test.v
+++ b/vlib/v/fmt/fmt_test.v
@@ -54,7 +54,7 @@ fn test_fmt() {
 				eprintln('>> sorry, but no working "diff" CLI command can be found')
 				continue
 			}
-			vfmt_result_file := os.path_join(tmpfolder, 'vfmt_run_over_${ifilename}')
+			vfmt_result_file := os.join_path(tmpfolder, 'vfmt_run_over_${ifilename}')
 			os.write_file(vfmt_result_file, result_ocontent)
 			os.system('$diff_cmd --minimal  --text   --unified=2 --show-function-line="fn " "$opath" "$vfmt_result_file"')
 			continue

--- a/vlib/v/fmt/fmt_test.v
+++ b/vlib/v/fmt/fmt_test.v
@@ -54,7 +54,7 @@ fn test_fmt() {
 				eprintln('>> sorry, but no working "diff" CLI command can be found')
 				continue
 			}
-			vfmt_result_file := os.path_join(tmpfolder,'vfmt_run_over_${ifilename}')
+			vfmt_result_file := os.path_join(tmpfolder, 'vfmt_run_over_${ifilename}')
 			os.write_file(vfmt_result_file, result_ocontent)
 			os.system('$diff_cmd --minimal  --text   --unified=2 --show-function-line="fn " "$opath" "$vfmt_result_file"')
 			continue

--- a/vlib/v/fmt/fmt_test.v
+++ b/vlib/v/fmt/fmt_test.v
@@ -54,7 +54,7 @@ fn test_fmt() {
 				eprintln('>> sorry, but no working "diff" CLI command can be found')
 				continue
 			}
-			vfmt_result_file := os.join(tmpfolder,'vfmt_run_over_${ifilename}')
+			vfmt_result_file := os.path_join(tmpfolder,'vfmt_run_over_${ifilename}')
 			os.write_file(vfmt_result_file, result_ocontent)
 			os.system('$diff_cmd --minimal  --text   --unified=2 --show-function-line="fn " "$opath" "$vfmt_result_file"')
 			continue

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -14,7 +14,7 @@ pub fn (p mut Preferences) fill_with_defaults() {
 		// Location of all vlib files
 		p.vroot = os.dir(vexe_path())
 	}
-	vlib_path := os.path_join(p.vroot, 'vlib')
+	vlib_path := os.join_path(p.vroot, 'vlib')
 	if p.lookup_path.len == 0 {
 		p.lookup_path = ['@vlib', '@vmodules']
 	}
@@ -30,7 +30,7 @@ pub fn (p mut Preferences) fill_with_defaults() {
 			base = filename
 		}
 		target_dir := if os.is_dir(rpath) { rpath } else { os.dir(rpath) }
-		p.out_name = os.path_join(target_dir, base)
+		p.out_name = os.join_path(target_dir, base)
 
 		if rpath == '$p.vroot/cmd/v' && os.is_dir('vlib/compiler') {
 			// Building V? Use v2, since we can't overwrite a running

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -14,7 +14,7 @@ pub fn (p mut Preferences) fill_with_defaults() {
 		// Location of all vlib files
 		p.vroot = os.dir(vexe_path())
 	}
-	vlib_path := os.join(p.vroot, 'vlib')
+	vlib_path := os.path_join(p.vroot, 'vlib')
 	if p.lookup_path.len == 0 {
 		p.lookup_path = ['@vlib', '@vmodules']
 	}
@@ -30,7 +30,7 @@ pub fn (p mut Preferences) fill_with_defaults() {
 			base = filename
 		}
 		target_dir := if os.is_dir(rpath) { rpath } else { os.dir(rpath) }
-		p.out_name = os.join(target_dir, base)
+		p.out_name = os.path_join(target_dir, base)
 
 		if rpath == '$p.vroot/cmd/v' && os.is_dir('vlib/compiler') {
 			// Building V? Use v2, since we can't overwrite a running


### PR DESCRIPTION
This PR change `os.join` to `os.path_join` in `os` api.

The meaning of `os.join` is not clear enough, `os.path_join` is more appropriate.