### PR TITLE
Extract array_slices_input.vv from simple_input.vv .

### DIFF
--- a/vlib/sync/pool.v
+++ b/vlib/sync/pool.v
@@ -135,6 +135,9 @@ fn process_in_thread(pool mut PoolProcessor, task_id int) {
 		idx = pool.ntask
 		pool.ntask++
 		pool.ntask_mtx.unlock()
+		if idx >= ilen {
+			break
+		}
 		pool.results[idx] = cb(pool, idx, task_id)
 	}
 	pool.waitgroup.done()

--- a/vlib/v/fmt/tests/array_slices_expected.vv
+++ b/vlib/v/fmt/tests/array_slices_expected.vv
@@ -1,0 +1,11 @@
+[inline]
+fn fn_contains_index_expr() {
+	arr := [1, 2, 3, 4, 5]
+	a := 1 in arr[0..]
+	b := 1 in arr[..2]
+	c := 1 in arr[1..3]
+	d := arr[2]
+	e := arr[2..]
+	f := arr[..2]
+	g := arr[1..3]
+}

--- a/vlib/v/fmt/tests/array_slices_input.vv
+++ b/vlib/v/fmt/tests/array_slices_input.vv
@@ -1,0 +1,12 @@
+
+
+[inline]  fn    fn_contains_index_expr()  {
+ arr := [1, 2, 3, 4,   5]
+    a := 1 in arr[ 0.. ]
+  b  := 1  in arr[ ..2  ]
+      c := 1 in arr[1..3]
+   d :=  arr[2]
+     e := arr[2 ..]
+ f := arr[.. 2 ]
+   g := arr[ 1 .. 3]
+}

--- a/vlib/v/fmt/tests/simple_expected.vv
+++ b/vlib/v/fmt/tests/simple_expected.vv
@@ -58,18 +58,6 @@ fn new_user() User {
 	}
 }
 
-[inline]
-fn fn_contains_index_expr() {
-	arr := [1, 2, 3, 4, 5]
-	a := 1 in arr[0..]
-	b := 1 in arr[..2]
-	c := 1 in arr[1..3]
-	d := arr[2]
-	e := arr[2..]
-	f := arr[..2]
-	g := arr[1..3]
-}
-
 fn voidfn() {
 	println('this is a function that does not return anything')
 }

--- a/vlib/v/fmt/tests/simple_input.vv
+++ b/vlib/v/fmt/tests/simple_input.vv
@@ -60,19 +60,6 @@ User
            }
 }
 
-
-[inline]
-fn fn_contains_index_expr() {
-	arr := [1, 2, 3, 4, 5]
-	a := 1 in arr[0..]
-	b := 1 in arr[..2]
-	c := 1 in arr[1..3]
-	d := arr[2]
-	e := arr[2..]
-	f := arr[..2]
-	g := arr[1..3]
-}
-
 fn   voidfn(){
  println('this is a function that does not return anything')
    }


### PR DESCRIPTION
This PR makes simple_input.vv slightly smaller and simpler,
by extracting the part that generated the 
`fmt expr: unhandled node v_dot_ast__Expr`
lines into a new file: array_slices_input.vv .