### PR TITLE
v2 fmt: add support for _keep.vv files, that v fmt should keep without changes.

### DIFF
--- a/vlib/v/fmt/fmt_keep_test.v
+++ b/vlib/v/fmt/fmt_keep_test.v
@@ -2,7 +2,6 @@ import (
 	os
 	term
 	benchmark
-	filepath
 	v.fmt
 	v.parser
 	v.table
@@ -21,7 +20,7 @@ fn test_fmt() {
 		eprintln('VEXE must be set')
 		exit(error_missing_vexe)
 	}
-	vroot := filepath.dir(vexe)
+	vroot := os.dir(vexe)
 	tmpfolder := os.tmpdir()
 	diff_cmd := find_working_diff_command() or {
 		''
@@ -36,7 +35,7 @@ fn test_fmt() {
 	for istep, ipath in input_files {
 		fmt_bench.cstep = istep
 		fmt_bench.step()
-		ifilename := filepath.filename(ipath)
+		ifilename := os.filename(ipath)
 		opath := ipath
 		expected_ocontent := os.read_file(opath) or {
 			fmt_bench.fail()
@@ -53,7 +52,7 @@ fn test_fmt() {
 				eprintln('>> sorry, but no working "diff" CLI command can be found')
 				continue
 			}
-			vfmt_result_file := filepath.join(tmpfolder,'vfmt_run_over_${ifilename}')
+			vfmt_result_file := os.join(tmpfolder,'vfmt_run_over_${ifilename}')
 			os.write_file(vfmt_result_file, result_ocontent)
 			os.system('$diff_cmd --minimal  --text   --unified=2 --show-function-line="fn " "$opath" "$vfmt_result_file"')
 			continue

--- a/vlib/v/fmt/fmt_keep_test.v
+++ b/vlib/v/fmt/fmt_keep_test.v
@@ -1,0 +1,82 @@
+import (
+	os
+	term
+	benchmark
+	filepath
+	v.fmt
+	v.parser
+	v.table
+)
+
+const (
+	error_missing_vexe = 1
+	error_failed_tests = 2
+)
+
+fn test_fmt() {
+	fmt_message := 'checking that v fmt keeps already formatted files *unchanged*'
+	eprintln(term.header(fmt_message, '-'))
+	vexe := os.getenv('VEXE')
+	if vexe.len == 0 || !os.exists(vexe) {
+		eprintln('VEXE must be set')
+		exit(error_missing_vexe)
+	}
+	vroot := filepath.dir(vexe)
+	tmpfolder := os.tmpdir()
+	diff_cmd := find_working_diff_command() or {
+		''
+	}
+	mut fmt_bench := benchmark.new_benchmark()
+	keep_input_files := os.walk_ext('$vroot/vlib/v/fmt/tests', '_keep.vv')
+	expected_input_files := os.walk_ext('$vroot/vlib/v/fmt/tests', '_expected.vv')
+	mut input_files := []string
+	input_files << keep_input_files
+	input_files << expected_input_files
+	fmt_bench.set_total_expected_steps(input_files.len)
+	for istep, ipath in input_files {
+		fmt_bench.cstep = istep
+		fmt_bench.step()
+		ifilename := filepath.filename(ipath)
+		opath := ipath
+		expected_ocontent := os.read_file(opath) or {
+			fmt_bench.fail()
+			eprintln(fmt_bench.step_message_fail('cannot read from ${opath}'))
+			continue
+		}
+		table := table.new_table()
+		file_ast := parser.parse_file(ipath, table, .parse_comments)
+		result_ocontent := fmt.fmt(file_ast, table)
+		if expected_ocontent != result_ocontent {
+			fmt_bench.fail()
+			eprintln(fmt_bench.step_message_fail('file ${ipath} after formatting, does not look as expected.'))
+			if diff_cmd == '' {
+				eprintln('>> sorry, but no working "diff" CLI command can be found')
+				continue
+			}
+			vfmt_result_file := filepath.join(tmpfolder,'vfmt_run_over_${ifilename}')
+			os.write_file(vfmt_result_file, result_ocontent)
+			os.system('$diff_cmd --minimal  --text   --unified=2 --show-function-line="fn " "$opath" "$vfmt_result_file"')
+			continue
+		}
+		fmt_bench.ok()
+		eprintln(fmt_bench.step_message_ok('${ipath}'))
+	}
+	fmt_bench.stop()
+	eprintln(term.h_divider('-'))
+	eprintln(fmt_bench.total_message(fmt_message))
+	if fmt_bench.nfail > 0 {
+		exit(error_failed_tests)
+	}
+}
+
+fn find_working_diff_command() ?string {
+	for diffcmd in ['colordiff', 'diff', 'colordiff.exe', 'diff.exe'] {
+		p := os.exec('$diffcmd --version') or {
+			continue
+		}
+		if p.exit_code == 0 {
+			return diffcmd
+		}
+	}
+	return error('no working diff command found')
+}


### PR DESCRIPTION
This PR adds `vlib/v/fmt/fmt_keep_test.v` , which checks that 
the existing `vlib/v/fmt/tests/*_expected.vv` files, and also a new kind
of files: `vlib/v/fmt/tests/*_keep.vv` files for stability, i.e. that 
running v fmt over them does not change them.
This will allow for quicker checking/making more tests, because now
you need to add/change a single _keep.vv file, instead of keeping 
2 files _input.vv and _expected.vv in synchron.

NB: the _input.vv and _expected.vv files are needed and useful for checking 
that v fmt works over unformatted or badly formatted v files, or that
v fmt can update obsolete code to a newer version, like changing the old
slice syntax to the new one, where the input != output.