### PR TITLE
Protect against failing tests in macos and windows gcc in pool.process_in_thread .

### DIFF
--- a/vlib/sync/pool.v
+++ b/vlib/sync/pool.v
@@ -135,6 +135,9 @@ fn process_in_thread(pool mut PoolProcessor, task_id int) {
 		idx = pool.ntask
 		pool.ntask++
 		pool.ntask_mtx.unlock()
+		if idx >= ilen {
+			break
+		}
 		pool.results[idx] = cb(pool, idx, task_id)
 	}
 	pool.waitgroup.done()


### PR DESCRIPTION
This PR makes pool.process_in_thread more robust by checking that the
item index is valid right before calling the worker callback.

It should fix sporadic failing CI tests in mostly latest macos and windows gcc.