### PR TITLE
compiler: fix redefinition error message for consts

### DIFF
--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -720,12 +720,16 @@ fn (p mut Parser) const_decl() {
 			// }
 			continue
 		}
+    var_token_idx := p.cur_tok_index()
 		mut name := p.check_name() // `Age = 20`
 		// if !p.pref.building_v && p.mod != 'os' && contains_capital(name) {
 		// p.warn('const names cannot contain uppercase letters, use snake_case instead')
 		// }
 		name = p.prepend_mod(name)
 		mut typ := ''
+		if p.first_pass() && p.table.known_const(name) {
+			p.error_with_token_index('redefinition of `$name`', var_token_idx)
+		}
 		if p.is_vh {
 			// println('CONST VH $p.file_path')
 			// .vh files may not have const values, just types: `const (a int)`
@@ -748,9 +752,6 @@ fn (p mut Parser) const_decl() {
 		else {
 			p.check_space(.assign)
 			typ = p.expression()
-		}
-		if p.first_pass() && p.table.known_const(name) {
-			p.error('redefinition of `$name`')
 		}
 		if p.first_pass() {
 			p.table.register_const(name, typ, p.mod, is_pub)


### PR DESCRIPTION
```v
const(
a=1
a=2
)
println(a)
```
Before this PR, the code above caused error that states
```
filename.v:4:1: redefinition of `a`
    2| a=1
    3| a=2
    4| )
       ^
    5| println(a)
```
This PR sets the error message as follows
```
filename.v:3:1: redefinition of `a`
    1| const (
    2| a=1
    3| a=2
       ^
    4| )
    5| println(a)
```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
