### PR TITLE
compile.v: remove duplicate references

### DIFF
--- a/cmd/v/internal/compile/compile.v
+++ b/cmd/v/internal/compile/compile.v
@@ -7,7 +7,6 @@ import (
 	benchmark
 	compiler
 	os
-	compiler
 )
 
 pub fn compile(command string, args []string) {


### PR DESCRIPTION
This PR remove duplicate `import compiler` in cmd/v/internal/compile/compile.v.

It is recommended that duplicate imports can be checked.