### PR TITLE
Support for C.environ & C._wenviron in cheaders.v (part 1/2).

### DIFF
--- a/vlib/compiler/cheaders.v
+++ b/vlib/compiler/cheaders.v
@@ -73,6 +73,7 @@ const (
 #include <locale.h> // tolower
 #include <sys/time.h>
 #include <unistd.h> // sleep
+extern char **environ;
 #endif
 
 #if defined(__CYGWIN__) && !defined(_WIN32)
@@ -135,6 +136,8 @@ $c_common_macros
 
 #include <dbghelp.h>
 #pragma comment(lib, "Dbghelp.lib")
+
+extern wchar_t **_wenviron;
 
 #endif
 
@@ -334,4 +337,3 @@ void sys_exit (int);
 
 '
 )
-

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -73,6 +73,7 @@ const (
 #include <locale.h> // tolower
 #include <sys/time.h>
 #include <unistd.h> // sleep
+extern char **environ;
 #endif
 
 #if defined(__CYGWIN__) && !defined(_WIN32)
@@ -135,6 +136,8 @@ $c_common_macros
 
 #include <dbghelp.h>
 #pragma comment(lib, "Dbghelp.lib")
+
+extern wchar_t **_wenviron;
 
 #endif
 


### PR DESCRIPTION
Stage 1 of implementing os.environ() without using globals. Needed in VC so that the CI tests for the PR that implements stage 2, which uses these platform specific externs can be compiled without errors.
(see #3386 for the motivation)
