### PR TITLE
os: is_abs => is_abs_path

### DIFF
--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -105,13 +105,13 @@ pub fn (v &V) finalize_compilation() {
 pub fn (v mut V) add_parser(parser Parser) int {
 	pidx := v.parsers.len
 	v.parsers << parser
-	file_path := if os.is_abs(parser.file_path) { parser.file_path } else { os.realpath(parser.file_path) }
+	file_path := if os.is_abspath(parser.file_path) { parser.file_path } else { os.realpath(parser.file_path) }
 	v.file_parser_idx[file_path] = pidx
 	return pidx
 }
 
 pub fn (v &V) get_file_parser_index(file string) ?int {
-	file_path := if os.is_abs(file) { file } else { os.realpath(file) }
+	file_path := if os.is_abspath(file) { file } else { os.realpath(file) }
 	if file_path in v.file_parser_idx {
 		return v.file_parser_idx[file_path]
 	}

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -105,13 +105,13 @@ pub fn (v &V) finalize_compilation() {
 pub fn (v mut V) add_parser(parser Parser) int {
 	pidx := v.parsers.len
 	v.parsers << parser
-	file_path := if os.is_abspath(parser.file_path) { parser.file_path } else { os.realpath(parser.file_path) }
+	file_path := if os.is_abs_path(parser.file_path) { parser.file_path } else { os.realpath(parser.file_path) }
 	v.file_parser_idx[file_path] = pidx
 	return pidx
 }
 
 pub fn (v &V) get_file_parser_index(file string) ?int {
-	file_path := if os.is_abspath(file) { file } else { os.realpath(file) }
+	file_path := if os.is_abs_path(file) { file } else { os.realpath(file) }
 	if file_path in v.file_parser_idx {
 		return v.file_parser_idx[file_path]
 	}

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -992,8 +992,8 @@ pub fn realpath(fpath string) string {
 	return string(fullpath)
 }
 
-// is_abs returns true if `path` is absolute.
-pub fn is_abs(path string) bool {
+// is_abspath returns true if `path` is absolute.
+pub fn is_abspath(path string) bool {
 	$if windows {
 		return path[0] == `/` || // incase we're in MingGW bash
 		(path[0].is_letter() && path[1] == `:`)

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -992,8 +992,8 @@ pub fn realpath(fpath string) string {
 	return string(fullpath)
 }
 
-// is_abspath returns true if `path` is absolute.
-pub fn is_abspath(path string) bool {
+// is_abs_path returns true if `path` is absolute.
+pub fn is_abs_path(path string) bool {
 	$if windows {
 		return path[0] == `/` || // incase we're in MingGW bash
 		(path[0].is_letter() && path[1] == `:`)

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -297,11 +297,11 @@ fn test_ext() {
 }
 
 fn test_is_abs() {
-	assert os.is_abs('/home/user') == true
-	assert os.is_abs('v/vlib') == false
+	assert os.is_abspath('/home/user') == true
+	assert os.is_abspath('v/vlib') == false
 
 	$if windows {
-		assert os.is_abs('C:\\Windows\\') == true
+		assert os.is_abspath('C:\\Windows\\') == true
 	}
 }
 

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -297,11 +297,11 @@ fn test_ext() {
 }
 
 fn test_is_abs() {
-	assert os.is_abspath('/home/user') == true
-	assert os.is_abspath('v/vlib') == false
+	assert os.is_abs_path('/home/user') == true
+	assert os.is_abs_path('v/vlib') == false
 
 	$if windows {
-		assert os.is_abspath('C:\\Windows\\') == true
+		assert os.is_abs_path('C:\\Windows\\') == true
 	}
 }
 


### PR DESCRIPTION
This PR change `os.is_abs` to `os.is_abspath`.

The meaning of `os.is_abs` is not clear enough, `os.is_abspath` is more appropriate.