### PR TITLE
os: tmpdir => temp_dir

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -80,7 +80,7 @@ pub fn (ts mut TestSession) test() {
 
 fn worker_trunner(p mut sync.PoolProcessor, idx int, thread_id int) voidptr {
 	mut ts := &TestSession(p.get_shared_context())
-	tmpd := os.tmpdir()
+	tmpd := os.temp_dir()
 	show_stats := '-stats' in ts.vargs.split(' ')
 	// tls_bench is used to format the step messages/timings
 	mut tls_bench := &benchmark.Benchmark(p.get_thread_context(idx))

--- a/cmd/tools/modules/vgit/vgit.v
+++ b/cmd/tools/modules/vgit/vgit.v
@@ -136,7 +136,7 @@ pub fn (vgit_context mut VGitContext) compile_oldv_if_needed() {
 }
 
 pub fn add_common_tool_options<T>(context mut T, fp mut flag.FlagParser) []string {
-	tdir := os.tmpdir()
+	tdir := os.temp_dir()
 	context.workdir = os.realpath(fp.string_('workdir', `w`, tdir, 'A writable base folder. Default: $tdir'))
 	context.v_repo_url = fp.string('vrepo', vgit.remote_v_repo_url, 'The url of the V repository. You can clone it locally too. See also --vcrepo below.')
 	context.vc_repo_url = fp.string('vcrepo', vgit.remote_vc_repo_url, 'The url of the vc repository. You can clone it

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -155,7 +155,7 @@ fn (foptions &FormatOptions) format_file(file string) {
 		file_ast := parser.parse_file(file, table, .parse_comments)
 		formatted_content := fmt.fmt(file_ast, table)
 		file_name := os.filename(file)
-		vfmt_output_path := os.join_path(os.tmpdir(), 'vfmt_' + file_name)
+		vfmt_output_path := os.join_path(os.temp_dir(), 'vfmt_' + file_name)
 		os.write_file(vfmt_output_path, formatted_content )
 		if foptions.is_verbose {
 			eprintln('vfmt2 fmt.fmt worked and ${formatted_content.len} bytes were written to ${vfmt_output_path} .')
@@ -163,7 +163,7 @@ fn (foptions &FormatOptions) format_file(file string) {
 		eprintln('${FORMATTED_FILE_TOKEN}${vfmt_output_path}')
 		return
 	}
-	tmpfolder := os.tmpdir()
+	tmpfolder := os.temp_dir()
 	mut compiler_params := &pref.Preferences{}
 	target_os := file_to_target_os(file)
 	if target_os != '' {

--- a/vlib/compiler/vfmt.v
+++ b/vlib/compiler/vfmt.v
@@ -171,8 +171,8 @@ fn (p mut Parser) fnext() {
 		p.fgen_nl()
 		p.fmt_inc()
 	}
-	if p.token_idx >= p.tokens.len { 
-		return 
+	if p.token_idx >= p.tokens.len {
+		return
 	}
 	// Skip comments and add them to vfmt output
 	if p.tokens[p.token_idx].tok in [.line_comment, .mline_comment] {
@@ -298,7 +298,7 @@ fn (p &Parser) gen_fmt() {
 }
 
 fn write_formatted_source(file_name string, s string) string {
-	path := os.tmpdir() + '/' + file_name
+	path := os.temp_dir() + '/' + file_name
 	mut out := os.create(path) or {
 		verror('failed to create file $path')
 		return ''

--- a/vlib/compiler/vtmp.v
+++ b/vlib/compiler/vtmp.v
@@ -6,7 +6,7 @@ module compiler
 import os
 
 fn get_vtmp_folder() string {
-	vtmp := os.join_path(os.tmpdir(), 'v')
+	vtmp := os.join_path(os.temp_dir(), 'v')
 	if !os.is_dir(vtmp) {
 		os.mkdir(vtmp) or {
 			panic(err)

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -1148,7 +1148,7 @@ pub fn cache_dir() string {
 }
 
 // tmpdir returns the path to a folder, that is suitable for storing temporary files
-pub fn tmpdir() string {
+pub fn temp_dir() string {
 	mut path := os.getenv('TMPDIR')
 	$if windows {
 		if path == '' {

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -183,7 +183,7 @@ fn test_cp_r() {
 }
 
 fn test_tmpdir(){
-	t := os.tmpdir()
+	t := os.temp_dir()
 	assert t.len > 0
 	assert os.is_dir(t)
 
@@ -266,7 +266,7 @@ fn test_symlink() {
 }
 
 fn test_is_executable_writable_readable() {
-  file_name := os.tmpdir() + os.path_separator + 'rwxfile.exe'
+  file_name := os.temp_dir() + os.path_separator + 'rwxfile.exe'
 
   mut f := os.create(file_name) or {
     eprintln('failed to create file $file_name')

--- a/vlib/v/fmt/fmt_keep_test.v
+++ b/vlib/v/fmt/fmt_keep_test.v
@@ -21,7 +21,7 @@ fn test_fmt() {
 		exit(error_missing_vexe)
 	}
 	vroot := os.dir(vexe)
-	tmpfolder := os.tmpdir()
+	tmpfolder := os.temp_dir()
 	diff_cmd := find_working_diff_command() or {
 		''
 	}

--- a/vlib/v/fmt/fmt_test.v
+++ b/vlib/v/fmt/fmt_test.v
@@ -21,7 +21,7 @@ fn test_fmt() {
 		exit(error_missing_vexe)
 	}
 	vroot := os.dir(vexe)
-	tmpfolder := os.tmpdir()
+	tmpfolder := os.temp_dir()
 	diff_cmd := find_working_diff_command() or {
 		''
 	}


### PR DESCRIPTION
This PR change `os.tmpdir` to `os.temp_dir` like `os.home_dir` similar to Vlang style.

Refer to other languages:
- Golang:  `os.TempDir`.
- Python: `gettempdir`.