### PR TITLE
compiler: pass -shared to build a .so file from a module.

### DIFF
--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -487,7 +487,7 @@ pub fn (v mut V) generate_main() {
 				cgen.genln('$cgen.fn_main;')
 				v.gen_main_end('return 0')
 			}
-			else if v.v_fmt_file=='' && !v.pref.is_repl {
+			else if v.v_fmt_file=='' && !v.pref.is_repl && !v.pref.is_so {
 				verror('function `main` is not declared in the main module\nPlease add: \nfn main(){\n}\n... to your main program .v file, and try again.')
 			}
 		}


### PR DESCRIPTION
This allows building a shared library from a module, that does not contain fn main() .