### PR TITLE
compiler: fix panic when dealing with variadic functions

### DIFF
--- a/vlib/compiler/tests/fn_variadic_test.v
+++ b/vlib/compiler/tests/fn_variadic_test.v
@@ -41,3 +41,57 @@ fn variadic_forward_b(a ...string) string {
 fn test_fn_variadic_forward() {
 	assert variadic_forward_a('a', 'b', 'c') == 'abc'
 }
+
+fn variadic_test_no_args(name string, groups ...VaTestGroup) {
+  assert groups.len == 0
+
+  mut grps := []VaTestGroup
+  if groups.len != 0 {
+    for grp in groups {
+      grps << grp
+    }
+  }
+}
+
+fn test_fn_variadic_no_args() {
+  variadic_test_no_args('marko')
+}
+
+struct VaTestStruct {
+}
+
+fn (a VaTestStruct) variadic_method(name string, groups ...VaTestGroup) {
+	assert groups.len == 2
+	assert groups[0].name == 'users'
+	assert groups[1].name == 'admins'
+
+  mut grps := []VaTestGroup
+  if groups.len != 0 {
+    for grp in groups {
+      grps << grp
+    }
+  }
+}
+
+fn (a VaTestStruct) variadic_method_no_args(name string, groups ...VaTestGroup) {
+  assert groups.len == 0
+
+  mut grps := []VaTestGroup
+  if groups.len != 0 {
+    for grp in groups {
+      grps << grp
+    }
+  }
+}
+
+fn test_fn_variadic_method() {
+  a := VaTestStruct{}
+	group1 := VaTestGroup{name: 'users'}
+	group2 := VaTestGroup{name: 'admins'}
+  a.variadic_method('marko', group1, group2)
+}
+
+fn test_fn_variadic_method_no_args() {
+  a := VaTestStruct{}
+  a.variadic_method_no_args('marko')
+}

--- a/vlib/compiler/tests/fn_variadic_test.v
+++ b/vlib/compiler/tests/fn_variadic_test.v
@@ -43,18 +43,11 @@ fn test_fn_variadic_forward() {
 }
 
 fn variadic_test_no_args(name string, groups ...VaTestGroup) {
-  assert groups.len == 0
-
-  mut grps := []VaTestGroup
-  if groups.len != 0 {
-    for grp in groups {
-      grps << grp
-    }
-  }
+	assert groups.len == 0
 }
 
 fn test_fn_variadic_no_args() {
-  variadic_test_no_args('marko')
+	variadic_test_no_args('marko')
 }
 
 struct VaTestStruct {
@@ -64,34 +57,20 @@ fn (a VaTestStruct) variadic_method(name string, groups ...VaTestGroup) {
 	assert groups.len == 2
 	assert groups[0].name == 'users'
 	assert groups[1].name == 'admins'
-
-  mut grps := []VaTestGroup
-  if groups.len != 0 {
-    for grp in groups {
-      grps << grp
-    }
-  }
 }
 
 fn (a VaTestStruct) variadic_method_no_args(name string, groups ...VaTestGroup) {
-  assert groups.len == 0
-
-  mut grps := []VaTestGroup
-  if groups.len != 0 {
-    for grp in groups {
-      grps << grp
-    }
-  }
+	assert groups.len == 0
 }
 
 fn test_fn_variadic_method() {
-  a := VaTestStruct{}
+	a := VaTestStruct{}
 	group1 := VaTestGroup{name: 'users'}
 	group2 := VaTestGroup{name: 'admins'}
-  a.variadic_method('marko', group1, group2)
+	a.variadic_method('marko', group1, group2)
 }
 
 fn test_fn_variadic_method_no_args() {
-  a := VaTestStruct{}
-  a.variadic_method_no_args('marko')
+	a := VaTestStruct{}
+	a.variadic_method_no_args('marko')
 }


### PR DESCRIPTION
This fixes compiler panic when trying to compile variadic functions called with 0 arguments.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
