### PR TITLE
scanner: minor optimize scanner.v

### DIFF
--- a/vlib/compiler/scanner.v
+++ b/vlib/compiler/scanner.v
@@ -968,7 +968,7 @@ fn (s Scanner) line(n int) string {
 }
 
 fn is_name_char(c byte) bool {
-	return c == `_` || c.is_letter()
+	return c.is_letter() || c == `_`
 }
 
 [inline]
@@ -998,4 +998,3 @@ fn good_type_name(s string) bool {
 	}
 	return true
 }
-

--- a/vlib/compiler/scanner.v
+++ b/vlib/compiler/scanner.v
@@ -968,7 +968,7 @@ fn (s Scanner) line(n int) string {
 }
 
 fn is_name_char(c byte) bool {
-	return c.is_letter() || c == `_`
+	return (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || c == `_`
 }
 
 [inline]


### PR DESCRIPTION
This PR minor optimize scanner.
Before code:
```v
fn is_name_char(c byte) bool {
	return  c == `_` || c.is_letter()
}
```
We can optimize:
```v
fn is_name_char(c byte) bool {
	return c.is_letter() || c == `_`
}
```
Continue optimize:
```v
fn is_name_char(c byte) bool {
	return (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || c == `_`
}
```
`is_name_char` uses a higher frequency, use `is_letter` first can increase efficiency.