### PR TITLE
os: executable => exe_path

### DIFF
--- a/cmd/tools/fast/fast.v
+++ b/cmd/tools/fast/fast.v
@@ -8,7 +8,7 @@ import (
 )
 
 fn main() {
-	exe := os.executable()
+	exe := os.exe_path()
 	dir := os.dir(exe)
 	vdir := os.dir(os.dir(os.dir(dir)))
 	if !os.exists('$vdir/v') && !os.is_dir('$vdir/vlib') {

--- a/cmd/tools/oldv.v
+++ b/cmd/tools/oldv.v
@@ -69,7 +69,7 @@ fn main() {
 	scripting.used_tools_must_exist(['git', 'cc'])
 	mut context := Context{}
 	mut fp := flag.new_flag_parser(os.args)
-	fp.application(os.filename(os.executable()))
+	fp.application(os.filename(os.exe_path()))
 	fp.version(tool_version)
 	fp.description(tool_description)
 	fp.arguments_description('VCOMMIT')

--- a/cmd/tools/performance_compare.v
+++ b/cmd/tools/performance_compare.v
@@ -180,7 +180,7 @@ fn main() {
 	scripting.used_tools_must_exist(['cp', 'rm', 'strip', 'make', 'git', 'upx', 'cc', 'wc', 'tail', 'hyperfine'])
 	mut context := new_context()
 	mut fp := flag.new_flag_parser(os.args)
-	fp.application(os.filename(os.executable()))
+	fp.application(os.filename(os.exe_path()))
 	fp.version(tool_version)
 	fp.description(tool_description)
 	fp.arguments_description('COMMIT_BEFORE [COMMIT_AFTER]')

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -39,7 +39,7 @@ const (
 )
 
 fn main() {
-	toolexe := os.executable()
+	toolexe := os.exe_path()
 	compiler.set_vroot_folder(os.dir(os.dir(os.dir(toolexe))))
 	args := join_flags_and_argument()
 	foptions := FormatOptions{

--- a/cmd/tools/vnames.v
+++ b/cmd/tools/vnames.v
@@ -54,7 +54,7 @@ fn analyze_v_file(file string) {
 }
 
 fn main(){
-	toolexe := os.executable()
+	toolexe := os.exe_path()
 	compiler.set_vroot_folder(os.dir(os.dir(os.dir(toolexe))))
 
 	mut fp := flag.new_flag_parser(os.args)

--- a/examples/sdl/tvintris/tvintris.v
+++ b/examples/sdl/tvintris/tvintris.v
@@ -19,7 +19,7 @@ import sdl.ttf as ttf
 
 const (
 	Title = 'tVintris'
-	BASE = os.dir( os.realpath( os.executable() ) )
+	BASE = os.dir( os.realpath( os.exe_path() ) )
 	FontName = BASE + '/../../assets/fonts/RobotoMono-Regular.ttf'
 	MusicName = BASE + '/sounds/TwintrisThosenine.mod'
 	SndBlockName = BASE + '/sounds/block.wav'

--- a/vlib/builtin/bare/syscallwrapper_test.v
+++ b/vlib/builtin/bare/syscallwrapper_test.v
@@ -6,7 +6,7 @@ fn test_syscallwrappers() {
 	if true { return }
 	$if linux {
 		$if x64 {
-			exe := os.executable()
+			exe := os.exe_path()
 			vdir := os.dir(exe)
 			if vdir.len > 1 {
 				dot_checks := vdir + "/.checks"

--- a/vlib/compiler/cc.v
+++ b/vlib/compiler/cc.v
@@ -26,7 +26,7 @@ fn (v &V) no_cc_installed() bool {
 }
 
 fn (v mut V) cc() {
-	if os.executable().contains('vfmt') {
+	if os.exe_path().contains('vfmt') {
 		return
 	}
 	v.build_thirdparty_obj_files()

--- a/vlib/compiler/tests/repl/runner/runner.v
+++ b/vlib/compiler/tests/repl/runner/runner.v
@@ -15,7 +15,7 @@ pub fn full_path_to_v(dirs_in int) string {
 		return vexe_from_env
 	}
 	vname := if os.user_os() == 'windows' { 'v.exe' } else { 'v' }
-	mut path := os.executable()
+	mut path := os.exe_path()
 	for i := 0; i < dirs_in; i++ {
 		path = os.dir(path)
 	}
@@ -23,7 +23,7 @@ pub fn full_path_to_v(dirs_in int) string {
 	/*
 	args := os.args
 	vreal  := os.realpath('v')
-	myself := os.realpath( os.executable() )
+	myself := os.realpath( os.exe_path() )
 	wd := os.getwd()
 	println('args are: $args')
 	println('vreal   : $vreal')

--- a/vlib/freetype/freetype.v
+++ b/vlib/freetype/freetype.v
@@ -203,7 +203,7 @@ pub fn new_context(cfg gg.Cfg) &FreeType {
 		font_path = 'RobotoMono-Regular.ttf'
 	}
 	if !os.exists(font_path) {
-		exe_path := os.executable()
+		exe_path := os.exe_path()
 		exe_dir := os.base_dir(exe_path)
 		font_path = '$exe_dir/$font_path'
 	}

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -812,7 +812,7 @@ pub fn exe_path() string {
 		count := C.readlink('/proc/self/exe', result, MAX_PATH)
 		if count < 0 {
 			eprintln('os.exe_path() failed at reading /proc/self/exe to get exe path')
-			return executable_fallback()
+			return exe_path_fallback()
 		}
 		return string(result)
 	}
@@ -828,7 +828,7 @@ pub fn exe_path() string {
 		ret := proc_pidpath(pid, result, MAX_PATH)
 		if ret <= 0 {
 			eprintln('os.exe_path() failed at calling proc_pidpath with pid: $pid . proc_pidpath returned $ret ')
-			return executable_fallback()
+			return exe_path_fallback()
 		}
 		return string(result)
 	}

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -79,7 +79,7 @@ pub fn vexe_path() string {
 	if vexe != '' {
 		return vexe
 	}
-	real_vexe_path := os.realpath(os.executable())
+	real_vexe_path := os.realpath(os.exe_path())
 	os.setenv('VEXE', real_vexe_path, true)
 	return real_vexe_path
 }


### PR DESCRIPTION
This PR change `os.executable` to `os.exe_path` in `os` api.

The meaning of `os.executable` is not clear enough, `os.exe_path` is more appropriate.