### PR TITLE
vweb: set request data with body text to allow use in actions.

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -235,6 +235,7 @@ fn handle_conn<T>(conn net.Socket, app mut T) {
 	}
 	req := http.Request{
 		headers: http.parse_headers(headers) //s.split_into_lines())
+		data: strip(body)
 		ws_func: 0
 		user_ptr: 0
 		method: vals[0]
@@ -243,6 +244,7 @@ fn handle_conn<T>(conn net.Socket, app mut T) {
 	$if debug {
 		println('req.headers = ')
 		println(req.headers)
+		println('req.data="$req.data"' )
 		println('vweb action = "$action"')
 	}
 	//mut app := T{
@@ -255,9 +257,7 @@ fn handle_conn<T>(conn net.Socket, app mut T) {
 	}
 	//}
 	if req.method in methods_with_form {
-		body = strip(body)
-		println('body="$body"' )
-		app.vweb.parse_form(body)
+		app.vweb.parse_form(req.data)
 	}
 	if vals.len < 2 {
 		$if debug {


### PR DESCRIPTION
At the moment it's impossible to use a POST request's data unless form encoded.

This means it's not possible to post JSON data to be used in an action.

This PR sets vweb.req.data to the body text, enabling access to that data in a vweb action.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
