### PR TITLE
make.bat: optimize make.bat

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -35,7 +35,7 @@ if %ERRORLEVEL% NEQ 0 (
 )
 
 echo Now using V to build V...
-v self
+v self -prod
 if %ERRORLEVEL% NEQ 0 (
     echo v.exe failed to compile itself - Create an issue at 'https://github.com/vlang'
     rd /s /q vc
@@ -74,7 +74,7 @@ if %ERRORLEVEL% NEQ 0 (
 )
 
 echo rebuild from source (twice, in case of C definitions changes)
-v self
+v self -prod
 if %ERRORLEVEL% NEQ 0 (
     echo V failed to build itself with error %ERRORLEVEL%
     goto :compileerror

--- a/make.bat
+++ b/make.bat
@@ -54,20 +54,15 @@ if "%PROCESSOR_ARCHITECTURE%" == "x86" (
 	set HostArch=x86
 )
 
-if exist "%VsWhereDir%"\MSBuild\14.0 (
-	set VsInstallDir="%VsWhereDir%"\"Microsoft Visual Studio 14.0"
-) else if exist "%VsWhereDir%"\MSBuild\15.0 (
-	set VsInstallDir="%VsWhereDir%"\"Microsoft Visual Studio 15.0"
-) else if exist "%VsWhereDir%"\MSBuild\17.0 (
-	set VsInstallDir="%VsWhereDir%"\"Microsoft Visual Studio 17.0"
-) else if exist "%VsWhereDir%"\MSBuild\19.0 (
-	set VsInstallDir="%VsWhereDir%"\"Microsoft Visual Studio 19.0"
-) else if exist "%VsWhereDir%"\MSBuild\12.0 (
-	set VsInstallDir="%VsWhereDir%"\"Microsoft Visual Studio 12.0"
-) else (
-	goto :no_compiler
+for /f "TOKENS=*" %%i in ('dir "%VsWhereDir%"\MSBuild /b /ad') do (
+	set VS_PREFIX=Microsoft Visual Studio
+	set VS=%VS_PREFIX% %%i
+	echo %VS%
+	set VsInstallDir="%VsWhereDir%"\"%VS%"
+	goto :check_vsdevcmd
 )
 
+:check_vsdevcmd
 if exist %VsInstallDir%\Common7\Tools\vsdevcmd.bat (
 	call %VsInstallDir%\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
 ) else (

--- a/make.bat
+++ b/make.bat
@@ -15,7 +15,6 @@ REM option to force msvc or gcc
 if "%~1"=="-gcc" goto :gccstrap
 if "%~1"=="-msvc" goto :msvcstrap
 
-
 :gccstrap
 
 echo Attempting to build v.c with GCC...
@@ -28,26 +27,24 @@ if not exist "%gccpath%" (
     goto:msvcstrap
 )
 
-gcc -std=c99 -municode -w -o v2.exe vc\v_win.c
+gcc -std=c99 -municode -w -o v.exe vc\v_win.c
 if %ERRORLEVEL% NEQ 0 (
     echo gcc failed to compile - Create an issue at 'https://github.com/vlang'
+	rd /s /q vc
     exit /b 1
 )
 
 echo Now using V to build V...
-v2.exe -o v3.exe cmd/v
-v3.exe -o v.exe -prod cmd/v
+v self
 if %ERRORLEVEL% NEQ 0 (
     echo v.exe failed to compile itself - Create an issue at 'https://github.com/vlang'
+	rd /s /q vc
     exit /b 1
 )
 
-del v2.exe
-del v3.exe
 rd /s /q vc
 
 goto :success
-
 
 :msvcstrap
 echo Attempting to build v.c  with MSVC...
@@ -70,22 +67,19 @@ if exist "%InstallDir%\Common7\Tools\vsdevcmd.bat" (
 
 set ObjFile=.v.c.obj
 
-cl.exe /nologo /w /volatile:ms /Fo%ObjFile% /O2 /MD /D_VBOOTSTRAP vc\v_win.c user32.lib kernel32.lib advapi32.lib shell32.lib /link /NOLOGO /OUT:v2.exe /INCREMENTAL:NO
+cl.exe /nologo /w /volatile:ms /Fo%ObjFile% /O2 /MD /D_VBOOTSTRAP vc\v_win.c user32.lib kernel32.lib advapi32.lib shell32.lib /link /NOLOGO /OUT:v.exe /INCREMENTAL:NO
 if %ERRORLEVEL% NEQ 0 (
     echo cl.exe failed to build V
     goto :compileerror
 )
 
 echo rebuild from source (twice, in case of C definitions changes)
-v2.exe -o v3.exe cmd/v
-v3.exe -o v -prod cmd/v
+v self
 if %ERRORLEVEL% NEQ 0 (
     echo V failed to build itself with error %ERRORLEVEL%
     goto :compileerror
 )
 
-del v2.exe
-del v3.exe
 rd /s /q vc
 del v.pdb
 del v3.ilk
@@ -107,6 +101,12 @@ goto :error
 
 :compileerror
 echo Failed to compile - Create an issue at 'https://github.com/vlang' and tag '@emily33901'!
+rd /s /q vc
+del v.pdb
+del v3.ilk
+del v3.pdb
+del vc140.pdb
+del %ObjFile%
 goto :error
 
 :error

--- a/make.bat
+++ b/make.bat
@@ -3,7 +3,7 @@
 echo Building V
 
 if exist "vc" (
-    rd /s /q vc
+	rd /s /q vc
 )
 
 git version
@@ -12,84 +12,89 @@ echo Downloading v.c...
 git clone --depth 1 --quiet https://github.com/vlang/vc
 
 REM option to force msvc or gcc
-if "%~1"=="-gcc" goto :gccstrap
-if "%~1"=="-msvc" goto :msvcstrap
+if "%~1"=="-gcc" goto :gcc_strap
+if "%~1"=="-msvc" goto :msvc_strap
 
-:gccstrap
-
+:gcc_strap
 echo Attempting to build v.c with GCC...
 
 for /f "usebackq tokens=*" %%i in (`where gcc`) do (
-  set gccpath=%%i
+	set gccpath=%%i
 )
 
 if not exist "%gccpath%" (
-    goto:msvcstrap
+	goto :msvc_strap
 )
 
 gcc -std=c99 -municode -w -o v.exe vc\v_win.c
 if %ERRORLEVEL% NEQ 0 (
-    echo gcc failed to compile - Create an issue at 'https://github.com/vlang'
-    rd /s /q vc
-    exit /b 1
+	echo gcc failed to compile - Create an issue at 'https://github.com/vlang'
+	rd /s /q vc
+	goto :error
 )
 
 echo Now using V to build V...
 v self -prod
 if %ERRORLEVEL% NEQ 0 (
-    echo v.exe failed to compile itself - Create an issue at 'https://github.com/vlang'
-    rd /s /q vc
-    exit /b 1
+	echo v.exe failed to compile itself - Create an issue at 'https://github.com/vlang'
+	rd /s /q vc
+	goto :error
 )
 
 rd /s /q vc
-
 goto :success
 
-:msvcstrap
+:msvc_strap
 echo Attempting to build v.c  with MSVC...
 set VsWhereDir=%ProgramFiles(x86)%
 set HostArch=x64
 if "%PROCESSOR_ARCHITECTURE%" == "x86" (
-  echo Using x86 Build Tools...
-  set VsWhereDir=%ProgramFiles%
-  set HostArch=x86
-)
-for /f "usebackq tokens=*" %%i in (`"%VsWhereDir%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
-  set InstallDir=%%i
+	echo Using x86 Build Tools...
+	set VsWhereDir=%ProgramFiles%
+	set HostArch=x86
 )
 
-if exist "%InstallDir%\Common7\Tools\vsdevcmd.bat" (
-    call "%InstallDir%\Common7\Tools\vsdevcmd.bat" -arch=%HostArch% -host_arch=%HostArch% -no_logo
+if exist "%VsWhereDir%"\MSBuild\14.0 (
+	set VsInstallDir="%VsWhereDir%"\"Microsoft Visual Studio 14.0"
+) else if exist "%VsWhereDir%"\MSBuild\15.0 (
+	set VsInstallDir="%VsWhereDir%"\"Microsoft Visual Studio 15.0"
+) else if exist "%VsWhereDir%"\MSBuild\17.0 (
+	set VsInstallDir="%VsWhereDir%"\"Microsoft Visual Studio 17.0"
+) else if exist "%VsWhereDir%"\MSBuild\19.0 (
+	set VsInstallDir="%VsWhereDir%"\"Microsoft Visual Studio 19.0"
+) else if exist "%VsWhereDir%"\MSBuild\12.0 (
+	set VsInstallDir="%VsWhereDir%"\"Microsoft Visual Studio 12.0"
 ) else (
-    goto :nocompiler
+	goto :no_compiler
+)
+
+if exist %VsInstallDir%\Common7\Tools\vsdevcmd.bat (
+	call %VsInstallDir%\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
+) else (
+	goto :no_compiler
 )
 
 set ObjFile=.v.c.obj
 
 cl.exe /nologo /w /volatile:ms /Fo%ObjFile% /O2 /MD /D_VBOOTSTRAP vc\v_win.c user32.lib kernel32.lib advapi32.lib shell32.lib /link /NOLOGO /OUT:v.exe /INCREMENTAL:NO
 if %ERRORLEVEL% NEQ 0 (
-    echo cl.exe failed to build V
-    goto :compileerror
+	echo cl.exe failed to build V
+	goto :compile_error
 )
 
 echo rebuild from source (twice, in case of C definitions changes)
 v self -prod
 if %ERRORLEVEL% NEQ 0 (
-    echo V failed to build itself with error %ERRORLEVEL%
-    goto :compileerror
+	echo V failed to build itself with error %ERRORLEVEL%
+	goto :compile_error
 )
 
 rd /s /q vc
-del v.pdb
-del v3.ilk
-del v3.pdb
-del vc140.pdb
 del %ObjFile%
 
 goto :success
 
-:nocompiler
+:no_compiler
 echo You do not appear to have a GCC installation on your PATH and also do not have an MSVC installation
 echo  - this means that you cannot bootstrap a V installation at this time...
 echo.
@@ -99,13 +104,9 @@ echo   (look for the Build Tools if you don't want to install the Visual Studio 
 echo.
 goto :error
 
-:compileerror
+:compile_error
 echo Failed to compile - Create an issue at 'https://github.com/vlang' and tag '@emily33901'!
 rd /s /q vc
-del v.pdb
-del v3.ilk
-del v3.pdb
-del vc140.pdb
 del %ObjFile%
 goto :error
 

--- a/make.bat
+++ b/make.bat
@@ -30,7 +30,7 @@ if not exist "%gccpath%" (
 gcc -std=c99 -municode -w -o v.exe vc\v_win.c
 if %ERRORLEVEL% NEQ 0 (
     echo gcc failed to compile - Create an issue at 'https://github.com/vlang'
-	rd /s /q vc
+    rd /s /q vc
     exit /b 1
 )
 
@@ -38,7 +38,7 @@ echo Now using V to build V...
 v self
 if %ERRORLEVEL% NEQ 0 (
     echo v.exe failed to compile itself - Create an issue at 'https://github.com/vlang'
-	rd /s /q vc
+    rd /s /q vc
     exit /b 1
 )
 

--- a/make.bat
+++ b/make.bat
@@ -54,17 +54,24 @@ if "%PROCESSOR_ARCHITECTURE%" == "x86" (
 	set HostArch=x86
 )
 
-for /f "TOKENS=*" %%i in ('dir "%VsWhereDir%"\MSBuild /b /ad') do (
-	set VS_PREFIX=Microsoft Visual Studio
-	set VS=%VS_PREFIX% %%i
-	echo %VS%
-	set VsInstallDir="%VsWhereDir%"\"%VS%"
-	goto :check_vsdevcmd
-)
-
-:check_vsdevcmd
-if exist %VsInstallDir%\Common7\Tools\vsdevcmd.bat (
-	call %VsInstallDir%\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
+if exist "%VsWhereDir%"\"Microsoft Visual Studio 14.0"\Common7\Tools\vsdevcmd.bat (
+	echo Microsoft Visual Studio 14.0
+	call "%VsWhereDir%"\"Microsoft Visual Studio 14.0"\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
+) else if exist "%VsWhereDir%"\"Microsoft Visual Studio 15.0"\Common7\Tools\vsdevcmd.bat (
+	echo Microsoft Visual Studio 15.0
+	call "%VsWhereDir%"\"Microsoft Visual Studio 15.0"\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
+) else if exist "%VsWhereDir%"\"Microsoft Visual Studio 17.0"\Common7\Tools\vsdevcmd.bat (
+	echo Microsoft Visual Studio 17.0
+	call "%VsWhereDir%"\"Microsoft Visual Studio 17.0"\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
+) else if exist "%VsWhereDir%"\"Microsoft Visual Studio 19.0"\Common7\Tools\vsdevcmd.bat (
+	echo Microsoft Visual Studio 19.0
+	call "%VsWhereDir%"\"Microsoft Visual Studio 19.0"\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
+) else if exist "%VsWhereDir%"\"Microsoft Visual Studio 12.0"\Common7\Tools\vsdevcmd.bat (
+	echo Microsoft Visual Studio 12.0
+	call "%VsWhereDir%"\"Microsoft Visual Studio 12.0"\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
+) else if exist "%VsWhereDir%"\"Microsoft Visual Studio 11.0"\Common7\Tools\vsdevcmd.bat (
+	echo Microsoft Visual Studio 11.0
+	call "%VsWhereDir%"\"Microsoft Visual Studio 11.0"\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
 ) else (
 	goto :no_compiler
 )

--- a/make.bat
+++ b/make.bat
@@ -60,17 +60,29 @@ if exist "%VsWhereDir%"\"Microsoft Visual Studio 14.0"\Common7\Tools\vsdevcmd.ba
 ) else if exist "%VsWhereDir%"\"Microsoft Visual Studio 15.0"\Common7\Tools\vsdevcmd.bat (
 	echo Microsoft Visual Studio 15.0
 	call "%VsWhereDir%"\"Microsoft Visual Studio 15.0"\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
+) else if exist "%VsWhereDir%"\"Microsoft Visual Studio 16.0"\Common7\Tools\vsdevcmd.bat (
+	echo Microsoft Visual Studio 16.0
+	call "%VsWhereDir%"\"Microsoft Visual Studio 16.0"\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
 ) else if exist "%VsWhereDir%"\"Microsoft Visual Studio 17.0"\Common7\Tools\vsdevcmd.bat (
 	echo Microsoft Visual Studio 17.0
 	call "%VsWhereDir%"\"Microsoft Visual Studio 17.0"\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
+) else if exist "%VsWhereDir%"\"Microsoft Visual Studio 18.0"\Common7\Tools\vsdevcmd.bat (
+	echo Microsoft Visual Studio 18.0
+	call "%VsWhereDir%"\"Microsoft Visual Studio 18.0"\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
 ) else if exist "%VsWhereDir%"\"Microsoft Visual Studio 19.0"\Common7\Tools\vsdevcmd.bat (
 	echo Microsoft Visual Studio 19.0
 	call "%VsWhereDir%"\"Microsoft Visual Studio 19.0"\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
+) else if exist "%VsWhereDir%"\"Microsoft Visual Studio 20.0"\Common7\Tools\vsdevcmd.bat (
+	echo Microsoft Visual Studio 20.0
+	call "%VsWhereDir%"\"Microsoft Visual Studio 20.0"\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
 ) else if exist "%VsWhereDir%"\"Microsoft Visual Studio 12.0"\Common7\Tools\vsdevcmd.bat (
 	echo Microsoft Visual Studio 12.0
 	call "%VsWhereDir%"\"Microsoft Visual Studio 12.0"\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
 ) else if exist "%VsWhereDir%"\"Microsoft Visual Studio 11.0"\Common7\Tools\vsdevcmd.bat (
 	echo Microsoft Visual Studio 11.0
+	call "%VsWhereDir%"\"Microsoft Visual Studio 11.0"\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
+) else if exist "%VsWhereDir%"\"Microsoft Visual Studio 10.0"\Common7\Tools\vsdevcmd.bat (
+	echo Microsoft Visual Studio 10.0
 	call "%VsWhereDir%"\"Microsoft Visual Studio 11.0"\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
 ) else (
 	goto :no_compiler


### PR DESCRIPTION
This PR optimize make.bat, fix recurring compilation errors.
- Cancel multiple self-compiling operations.
- Use `v self` instead of script Instruction.
- Clean temp files and dirs when failed.