### PR TITLE
Fix backtrace for OpenBSD and NetBSD

### DIFF
--- a/vlib/builtin/builtin_nix.v
+++ b/vlib/builtin/builtin_nix.v
@@ -55,6 +55,12 @@ fn print_backtrace_skipping_top_frames_nix(xskipframes int) bool {
 	$if freebsd {
 		return print_backtrace_skipping_top_frames_freebsd(skipframes)
 	}
+	$if netbsd {
+		return print_backtrace_skipping_top_frames_freebsd(skipframes)
+	}
+	$if openbsd {
+		return print_backtrace_skipping_top_frames_freebsd(skipframes)
+	}
 	return false
 }
 


### PR DESCRIPTION
without this patch, v segfaults when trying to compile:

<img width="369" alt="Screenshot 2020-03-16 at 11 35 15" src="https://user-images.githubusercontent.com/917142/76747955-45075180-677a-11ea-8035-0f89262123c4.png">


<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
