### PR TITLE
vself: add -prod options

### DIFF
--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -13,12 +13,12 @@ fn main() {
 	mut cmd := '$vexe -o v2 cmd/v'
 	if os.args.len >= 3 && os.args[2] == '-prod' {
 		cmd = '$vexe -o v2 -prod cmd/v'
-		println('V Self Compiling (prod mode)...')
+		println('V Self Compiling (-prod mode)...')
 	}
 	else {
 		println('V Self Compiling...')
 	}
-	
+
 	s2 := os.exec(cmd) or { panic(err) }
 	if s2.output.len > 0 {
 		println(s2.output)

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -18,18 +18,19 @@ fn main() {
 	else {
 		println('V Self Compiling...')
 	}
-	s2 := os.exec(cmd) or {
-		panic(err)
-	}
+	
+	s2 := os.exec(cmd) or { panic(err) }
 	if s2.output.len > 0 {
 		println(s2.output)
 	}
 	if s2.exit_code != 0 {
 		exit(1)
 	}
+
 	v_file := if os.user_os() == 'windows' { 'v.exe' } else { 'v' }
 	v2_file := if os.user_os() == 'windows' { 'v2.exe' } else { 'v2' }
 	bak_file := if os.user_os() == 'windows' { 'v_old.exe' } else { 'v_old' }
+
 	if os.exists(bak_file) {
 		os.rm(bak_file)
 	}

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -6,11 +6,19 @@ import (
 )
 
 fn main() {
-	println('V Self Compiling...')
 	vexe := pref.vexe_path()
 	vroot := os.dir(vexe)
 	os.chdir(vroot)
-	s2 := os.exec('$vexe -o v2 cmd/v') or {
+
+	mut cmd := '$vexe -o v2 cmd/v'
+	if os.args.len >= 3 && os.args[2] == '-prod' {
+		cmd = '$vexe -o v2 -prod cmd/v'
+		println('V Self Compiling (prod mode)...')
+	}
+	else {
+		println('V Self Compiling...')
+	}
+	s2 := os.exec(cmd) or {
 		panic(err)
 	}
 	if s2.output.len > 0 {

--- a/cmd/v/internal/help/default.txt
+++ b/cmd/v/internal/help/default.txt
@@ -19,7 +19,7 @@ The commands are:
    test              Run all test files in the provided directory.
    translate         Translate C code to V (coming soon in 0.3).
    up                Run the V self-updater.
-   self              Run the V self-compiler.
+   self [-prod]      Run the V self-compiler, use -prod to optimize compilation.
    version           Print the version text and exits.
 
    install           Install a module from VPM.


### PR DESCRIPTION
This PR add `-prod` options in `v self` tool.
- `v self` is a regular self-compiling.
- `v self -prod` can optimize self-compiling.
- Modify help document about v self tool.