### PR TITLE
vfmt2: fix literal integer number formatting

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -40,7 +40,7 @@ pub:
 
 pub struct IntegerLiteral {
 pub:
-	val int
+	val string
 }
 
 pub struct FloatLiteral {

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -69,9 +69,9 @@ pub fn (x Expr) str() string {
 		*/
 
 		IntegerLiteral {
-			return it.val.str()
+			return it.val
 		}
-		IntegerLiteral {
+		StringLiteral {
 			return '"$it.val"'
 		}
 		else {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -492,12 +492,12 @@ pub fn (c mut Checker) array_init(array_init mut ast.ArrayInit) table.Type {
 		mut fixed_size := 1
 		match array_init.exprs[0] {
 			ast.IntegerLiteral {
-				fixed_size = it.val
+				fixed_size = it.val.int()
 			}
 			else {
 				c.error('expecting `int` for fixed size', array_init.pos)
 			}
-	}
+		}
 		idx := c.table.find_or_register_array_fixed(array_init.elem_type, fixed_size, 1)
 		array_type := table.new_type(idx)
 		array_init.typ = array_type

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -433,7 +433,7 @@ fn (f mut Fmt) expr(node ast.Expr) {
 			f.write(']')
 		}
 		ast.IntegerLiteral {
-			f.write(it.val.str())
+			f.write(it.val)
 		}
 		ast.MapInit {
 			f.writeln('{')

--- a/vlib/v/fmt/tests/integer_literal_keep.vv
+++ b/vlib/v/fmt/tests/integer_literal_keep.vv
@@ -1,0 +1,4 @@
+fn main() {
+	x := 0xdeadbeef
+	u := 9978654321
+}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -747,7 +747,7 @@ fn (g mut Gen) expr(node ast.Expr) {
 			g.infix_expr(it)
 		}
 		ast.IntegerLiteral {
-			g.write(it.val.str())
+			g.write(it.val)
 		}
 		ast.MatchExpr {
 			g.match_expr(it)

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -747,7 +747,7 @@ fn (g mut Gen) expr(node ast.Expr) {
 			g.infix_expr(it)
 		}
 		ast.IntegerLiteral {
-			g.write(it.val)
+			g.write(it.val.int().str())
 		}
 		ast.MatchExpr {
 			g.match_expr(it)

--- a/vlib/v/gen/jsgen.v
+++ b/vlib/v/gen/jsgen.v
@@ -108,7 +108,7 @@ fn (g mut JsGen) expr(node ast.Expr) {
 	// println('cgen expr()')
 	match node {
 		ast.IntegerLiteral {
-			g.write(it.val.str())
+			g.write(it.val)
 		}
 		ast.FloatLiteral {
 			g.write(it.val)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1310,7 +1310,7 @@ fn (p mut Parser) parse_number_literal() ast.Expr {
 	}
 	else {
 		node = ast.IntegerLiteral{
-			val: lit.int()
+			val: lit
 		}
 	}
 	p.next()


### PR DESCRIPTION
This PR closes #4026 .

Now the v2 parser keeps the original string value of the literal in IntegerLiteral,
not its .int() value. It is converted to .int() only when that is needed instead.