### PR TITLE
compiler: add c headers for Solaris / Illumos

### DIFF
--- a/vlib/compiler/cheaders.v
+++ b/vlib/compiler/cheaders.v
@@ -106,6 +106,11 @@ extern char **environ;
 #include <sys/wait.h> // os__wait uses wait on nix
 #endif
 
+#ifdef __sun
+#include <sys/types.h>
+#include <sys/wait.h> // os__wait uses wait on nix
+#endif
+
 $c_common_macros
 
 #ifdef _WIN32

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -107,6 +107,11 @@ extern char **environ;
 #include <sys/wait.h> // os__wait uses wait on nix
 #endif
 
+#ifdef __sun
+#include <sys/types.h>
+#include <sys/wait.h> // os__wait uses wait on nix
+#endif
+
 $c_common_macros
 
 #ifdef _WIN32


### PR DESCRIPTION
Add c headers for Solaris / Illumos;

#ifdef __sun
#include <sys/types.h>
#include <sys/wait.h> // os__wait uses wait on nix
#endif




<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
