### PR TITLE
cmd/v: Fix `-version` and `-v` collision

### DIFF
--- a/cmd/v/flag.v
+++ b/cmd/v/flag.v
@@ -77,8 +77,7 @@ fn parse_flags(flag string, f mut flag.Instance, prefs mut flag.MainCmdPreferenc
 			f.is_equivalent_to(['h', 'help'])
 			prefs.action = .help
 		}
-		'v', 'version' {
-			f.is_equivalent_to(['v', 'version'])
+		'version' {
 			prefs.action = .version
 		}
 		'-version', '-help' {


### PR DESCRIPTION
It would seem like `-v` is detected as a duplicate flag of `-version`.
This commit fixes it by removing the offending code.