### PR TITLE
make.bat: optimize make.bat for Windows

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -3,7 +3,7 @@
 echo Building V
 
 if exist "vc" (
-    rd /s /q vc
+	rd /s /q vc
 )
 
 git version
@@ -12,80 +12,79 @@ echo Downloading v.c...
 git clone --depth 1 --quiet https://github.com/vlang/vc
 
 REM option to force msvc or gcc
-if "%~1"=="-gcc" goto :gccstrap
-if "%~1"=="-msvc" goto :msvcstrap
+if "%~1"=="-gcc" goto :gcc_strap
+if "%~1"=="-msvc" goto :msvc_strap
 
 
-:gccstrap
-
+:gcc_strap
 echo Attempting to build v.c with GCC...
 
 for /f "usebackq tokens=*" %%i in (`where gcc`) do (
-  set gccpath=%%i
+	set gcc_path=%%i
 )
 
-if not exist "%gccpath%" (
-    goto:msvcstrap
+if not exist "%gcc_path%" (
+	goto :msvc_strap
 )
 
-gcc -std=c99 -municode -w -o v2.exe vc\v_win.c
+gcc -std=c99 -municode -w -o v.exe vc\v_win.c
 if %ERRORLEVEL% NEQ 0 (
-    echo gcc failed to compile - Create an issue at 'https://github.com/vlang'
-    exit /b 1
+	echo gcc failed to compile - Create an issue at 'https://github.com/vlang'
+	rd /s /q vc
+	goto :error
 )
 
 echo Now using V to build V...
-v2.exe -o v3.exe cmd/v
-v3.exe -o v.exe -prod cmd/v
+v self -prod
 if %ERRORLEVEL% NEQ 0 (
-    echo v.exe failed to compile itself - Create an issue at 'https://github.com/vlang'
-    exit /b 1
+	echo v.exe failed to compile itself - Create an issue at 'https://github.com/vlang'
+	rd /s /q vc
+	goto :error
 )
 
-del v2.exe
-del v3.exe
 rd /s /q vc
-
 goto :success
 
-
-:msvcstrap
+:msvc_strap
 echo Attempting to build v.c  with MSVC...
 set VsWhereDir=%ProgramFiles(x86)%
 set HostArch=x64
 if "%PROCESSOR_ARCHITECTURE%" == "x86" (
-  echo Using x86 Build Tools...
-  set VsWhereDir=%ProgramFiles%
-  set HostArch=x86
+	echo Using x86 Build Tools...
+	set VsWhereDir=%ProgramFiles%
+	set HostArch=x86
 )
 for /f "usebackq tokens=*" %%i in (`"%VsWhereDir%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
-  set InstallDir=%%i
+	set InstallDir=%%i
 )
 
 if exist "%InstallDir%\Common7\Tools\vsdevcmd.bat" (
-    call "%InstallDir%\Common7\Tools\vsdevcmd.bat" -arch=%HostArch% -host_arch=%HostArch% -no_logo
+	call "%InstallDir%\Common7\Tools\vsdevcmd.bat" -arch=%HostArch% -host_arch=%HostArch% -no_logo
 ) else (
-    goto :nocompiler
+	goto :no_compiler
 )
 
 set ObjFile=.v.c.obj
 
-cl.exe /nologo /w /volatile:ms /Fo%ObjFile% /O2 /MD /D_VBOOTSTRAP vc\v_win.c user32.lib kernel32.lib advapi32.lib shell32.lib /link /NOLOGO /OUT:v2.exe /INCREMENTAL:NO
+cl.exe /nologo /w /volatile:ms /Fo%ObjFile% /O2 /MD /D_VBOOTSTRAP vc\v_win.c user32.lib kernel32.lib advapi32.lib shell32.lib /link /NOLOGO /OUT:v.exe /INCREMENTAL:NO
 if %ERRORLEVEL% NEQ 0 (
-    echo cl.exe failed to build V
-    goto :compileerror
+	echo cl.exe failed to build V
+	goto :compile_error
 )
 
 echo rebuild from source (twice, in case of C definitions changes)
-v2.exe -o v3.exe cmd/v
-v3.exe -o v -prod cmd/v
+v self -prod
 if %ERRORLEVEL% NEQ 0 (
-    echo V failed to build itself with error %ERRORLEVEL%
-    goto :compileerror
+	echo V failed to build itself with error %ERRORLEVEL%
+	rd /s /q vc
+	del v.pdb
+	del v3.ilk
+	del v3.pdb
+	del vc140.pdb
+	del %ObjFile%
+	goto :compile_error
 )
 
-del v2.exe
-del v3.exe
 rd /s /q vc
 del v.pdb
 del v3.ilk
@@ -95,7 +94,7 @@ del %ObjFile%
 
 goto :success
 
-:nocompiler
+:no_compiler
 echo You do not appear to have a GCC installation on your PATH and also do not have an MSVC installation
 echo  - this means that you cannot bootstrap a V installation at this time...
 echo.
@@ -105,7 +104,7 @@ echo   (look for the Build Tools if you don't want to install the Visual Studio 
 echo.
 goto :error
 
-:compileerror
+:compile_error
 echo Failed to compile - Create an issue at 'https://github.com/vlang' and tag '@emily33901'!
 goto :error
 


### PR DESCRIPTION
This PR optimize make.bat.

- Use `v self -prod` instead of script Instruction.
- Clean temp files and dirs when failed.
- Unify error output.
- Perfect variables and uniform format.