### PR TITLE
Fix typo in docs.md

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1099,7 +1099,7 @@ fn draw_scene() {
     ...
     draw_text('hello $name1', 10, 10)
     draw_text('hello $name2', 100, 10)
-    draw_text(strings.repeat('X', 10000), 10, 50)
+    draw_text(strings.repeat(`X`, 10000), 10, 50)
     ...
 }
 ```

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1099,7 +1099,7 @@ fn draw_scene() {
     ...
     draw_text('hello $name1', 10, 10)
     draw_text('hello $name2', 100, 10)
-    draw_text(strings.repeat(`X`, 10000), 10, 50)
+    draw_text('x'.repeat(10000), 10, 50)
     ...
 }
 ```


### PR DESCRIPTION
Fixing typo in docs.md

Options to fix:

* ✅Using `'X'.repeat(10000)` because it seems the simplest
* Using backquote to pass char: ```strings.repeat(`X`, 10000)```
* Using `strings.repeat_string('X', 10000)`