### PR TITLE
compiler: when compiling a single .v file, check that it is not a folder.

### DIFF
--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -782,7 +782,7 @@ pub fn (v &V) get_user_files() []string {
 		user_files << single_test_v_file
 		dir = os.base_dir(single_test_v_file)
 	}
-	if dir.ends_with('.v') || dir.ends_with('.vsh') {
+	if ( os.exists(dir) && !os.is_dir(dir) ) && ( dir.ends_with('.v') || dir.ends_with('.vsh') ) {
 		single_v_file := dir
 		// Just compile one file and get parent dir
 		user_files << single_v_file

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -782,7 +782,8 @@ pub fn (v &V) get_user_files() []string {
 		user_files << single_test_v_file
 		dir = os.base_dir(single_test_v_file)
 	}
-	if ( os.exists(dir) && !os.is_dir(dir) ) && ( dir.ends_with('.v') || dir.ends_with('.vsh') ) {
+	is_real_file := os.exists(dir) && !os.is_dir(dir)
+	if is_real_file && ( dir.ends_with('.v') || dir.ends_with('.vsh') ) {
 		single_v_file := dir
 		// Just compile one file and get parent dir
 		user_files << single_v_file


### PR DESCRIPTION
This PR fixes the case when you have a module in a folder named XYZ.v .
Previously v decided that you wanted to compile the folder itself in
single file compilation mode, since it had the .v extension.

Now, it correctly checks that in fact, that is not a file, but a folder,
and compiles all the files inside as parts of a module, as it should.

Closes #4043