### PR TITLE
hotreload: fix compilation of .so file on macos

### DIFF
--- a/cmd/v/flag.v
+++ b/cmd/v/flag.v
@@ -9,8 +9,9 @@ import (
 )
 
 const (
+	list_of_flags_that_allow_duplicates = ['cc','d','define','cf','cflags']
 	//list_of_flags contains a list of flags where an argument is expected past it.
-	list_of_flags = [
+	list_of_flags_with_param = [
 		'o', 'output', 'd', 'define', 'b', 'backend', 'cc', 'os', 'target-os', 'arch',
 			'csource', 'cf', 'cflags', 'path'
 	]
@@ -85,8 +86,11 @@ fn parse_flags(flag string, f mut flag.Instance, prefs mut flag.MainCmdPreferenc
 			exit(1)
 		}
 		else {
-			prefs.unknown_flag = '-$flag'
-			if !(flag in list_of_flags) {
+			if flag in list_of_flags_that_allow_duplicates {
+				f.allow_duplicate()			   
+			}
+			prefs.unknown_flag = '-$flag'			 
+			if !(flag in list_of_flags_with_param) {
 				return
 			}
 			f.string() or {

--- a/cmd/v/internal/compile/compile_c_options.v
+++ b/cmd/v/internal/compile/compile_c_options.v
@@ -16,6 +16,7 @@ import (
 fn parse_c_options(flag string, f mut flag.Instance, prefs mut pref.Preferences) {
 	match flag {
 		'cc', 'compiler' {
+			f.allow_duplicate() // needed to enable CI compiling of -live examples.
 			f.is_equivalent_to(['cc', 'compiler'])
 			//TODO Remove `tmp` variable when it doesn't error out in C.
 			tmp := f.string() or {

--- a/cmd/v/internal/compile/compile_c_options.v
+++ b/cmd/v/internal/compile/compile_c_options.v
@@ -12,11 +12,9 @@ import (
 	v.pref
 )
 
-[inline]
 fn parse_c_options(flag string, f mut flag.Instance, prefs mut pref.Preferences) {
 	match flag {
 		'cc', 'compiler' {
-			f.allow_duplicate() // needed to enable CI compiling of -live examples.
 			f.is_equivalent_to(['cc', 'compiler'])
 			//TODO Remove `tmp` variable when it doesn't error out in C.
 			tmp := f.string() or {
@@ -24,6 +22,8 @@ fn parse_c_options(flag string, f mut flag.Instance, prefs mut pref.Preferences)
 				exit(1)
 			}
 			prefs.ccompiler = tmp
+			// needed to enable CI compiling of -live examples.
+			f.allow_duplicate() 
 		}
 		'cg', 'cdebug' {
 			f.is_equivalent_to(['cg', 'cdebug', 'g', 'debug'])

--- a/cmd/v/internal/compile/compile_options.v
+++ b/cmd/v/internal/compile/compile_options.v
@@ -32,6 +32,8 @@ fn parse_arguments(args []string) (pref.Preferences, []string) {
 	mut remaining := flag.parse_pref(args, parse_options, &p) or {
 		println('V error: Error while parsing flags.')
 		println(err)
+		println('Args:')
+		println(args)
 		exit(1)
 	}
 	match remaining[0] {

--- a/cmd/v/internal/flag/flag_workaround.v
+++ b/cmd/v/internal/flag/flag_workaround.v
@@ -16,8 +16,7 @@ pub fn parse_pref(args []string, callback fn(string, &Instance, &pref.Preference
 		args: args
 		current_pos: 0
 	}
-	casted_callback := *(&void_cb(&callback))
-	tmp := p.parse_impl(args, voidptr(obj), casted_callback) or {
+	tmp := p.parse_impl(args, voidptr(obj), void_cb(callback)) or {
 		return error(err)
 	}
 	return tmp
@@ -41,8 +40,7 @@ pub fn parse_main_cmd(args []string, callback fn(string, &Instance, &MainCmdPref
 		args: args
 		current_pos: 0
 	}
-	casted_callback := *(&void_cb(&callback))
-	tmp := p.parse_impl(args, voidptr(obj), casted_callback) or {
+	tmp := p.parse_impl(args, voidptr(obj), void_cb(callback)) or {
 		return error(err)
 	}
 	return tmp

--- a/vlib/compiler/live.v
+++ b/vlib/compiler/live.v
@@ -98,11 +98,14 @@ fn (v &V) generate_hot_reload_code() {
 			println(cmd_compile_shared_library)
 		}
 		ticks := time.ticks()
-		os.system(cmd_compile_shared_library)
+		so_compilation_result := os.system(cmd_compile_shared_library)
 		if v.pref.verbosity.is_higher_or_equal(.level_two) {
 			diff := time.ticks() - ticks
 			println('compiling shared library took $diff ms')
 			println('=========\n')
+		}
+		if so_compilation_result != 0 {
+			exit(1)
 		}
 		cgen.genln('
 

--- a/vlib/compiler/live.v
+++ b/vlib/compiler/live.v
@@ -202,7 +202,6 @@ void reload_so() {
 			pthread_mutex_lock(&live_fn_mutex);
 			lfnmutex_print("reload_so locked");
 
-			live_lib = 0; // hack: force skipping dlclose/1, the code may be still used...
 			load_so(new_so_name);
 			#ifndef _WIN32
 			unlink(new_so_name); // removing the .so file from the filesystem after dlopen-ing it is safe, since it will still be mapped in memory.

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -422,41 +422,10 @@ $consts_init_body
 builtin__init();
 $call_mod_init
 }')
-			// _STR function can't be defined in vlib
-			v.cgen.genln('
-string _STR(const char *fmt, ...) {
-	va_list argptr;
-	va_start(argptr, fmt);
-	size_t len = vsnprintf(0, 0, fmt, argptr) + 1;
-	va_end(argptr);
-	byte* buf = malloc(len);
-	va_start(argptr, fmt);
-	vsprintf((char *)buf, fmt, argptr);
-	va_end(argptr);
-#ifdef DEBUG_ALLOC
-	puts("_STR:");
-	puts(buf);
-#endif
-	return tos2(buf);
-}
-
-string _STR_TMP(const char *fmt, ...) {
-	va_list argptr;
-	va_start(argptr, fmt);
-	//size_t len = vsnprintf(0, 0, fmt, argptr) + 1;
-	va_end(argptr);
-	va_start(argptr, fmt);
-	vsprintf((char *)g_str_buf, fmt, argptr);
-	va_end(argptr);
-#ifdef DEBUG_ALLOC
-	//puts("_STR_TMP:");
-	//puts(g_str_buf);
-#endif
-	return tos2(g_str_buf);
-}
-
-')
 		}
+		if !v.pref.is_bare {
+			v.generate_str_definitions()
+        }
 	}
 }
 
@@ -935,4 +904,41 @@ pub fn set_vroot_folder(vroot_path string) {
 	// can return it later to whoever needs it:
 	vname := if os.user_os() == 'windows' { 'v.exe' } else { 'v' }
 	os.setenv('VEXE', os.realpath([vroot_path, vname].join(os.path_separator)), true)
+}
+
+pub fn (v mut V) generate_str_definitions() {
+	// _STR function can't be defined in vlib
+	v.cgen.genln('
+string _STR(const char *fmt, ...) {
+	va_list argptr;
+	va_start(argptr, fmt);
+	size_t len = vsnprintf(0, 0, fmt, argptr) + 1;
+	va_end(argptr);
+	byte* buf = malloc(len);
+	va_start(argptr, fmt);
+	vsprintf((char *)buf, fmt, argptr);
+	va_end(argptr);
+#ifdef DEBUG_ALLOC
+	puts("_STR:");
+	puts(buf);
+#endif
+	return tos2(buf);
+}
+
+string _STR_TMP(const char *fmt, ...) {
+	va_list argptr;
+	va_start(argptr, fmt);
+	//size_t len = vsnprintf(0, 0, fmt, argptr) + 1;
+	va_end(argptr);
+	va_start(argptr, fmt);
+	vsprintf((char *)g_str_buf, fmt, argptr);
+	va_end(argptr);
+#ifdef DEBUG_ALLOC
+	//puts("_STR_TMP:");
+	//puts(g_str_buf);
+#endif
+	return tos2(g_str_buf);
+}
+
+')
 }


### PR DESCRIPTION
This PR also makes the build-example / test-compiler tests more
sensitive, by forcing v to exit with 1 error code when the sub
compilation of the .so file fails for any reason. Previously,
the compilation of the .so file could fail, but v will continue to 
compile the main program, without complaining, thus the test runner
will think that everything is ok.

It also allows the `-cc` v flag to be given multiple times, which is needed for the msvc CI.