### PR TITLE
make.bat: fix make error not at root dir

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -2,6 +2,7 @@
 
 echo Building V
 
+set origin_dir=%cd%
 cd /d %~dp0
 
 if exist "vc" (
@@ -112,8 +113,10 @@ goto :error
 
 :error
 echo Exiting from error
+cd %origin_dir%
 exit /b 1
 
 :success
 echo V build OK!
 v -version
+cd %origin_dir%

--- a/make.bat
+++ b/make.bat
@@ -2,6 +2,8 @@
 
 echo Building V
 
+cd /d %~dp0
+
 if exist "vc" (
 	rd /s /q vc
 )

--- a/make.bat
+++ b/make.bat
@@ -2,8 +2,7 @@
 
 echo Building V
 
-set origin_dir=%cd%
-cd /d %~dp0
+pushd %~dp0
 
 if exist "vc" (
 	rd /s /q vc
@@ -113,10 +112,10 @@ goto :error
 
 :error
 echo Exiting from error
-cd %origin_dir%
+popd
 exit /b 1
 
 :success
 echo V build OK!
 v -version
-cd %origin_dir%
+popd


### PR DESCRIPTION
This PR fixes make error not at vroot dir.

**Problem**
When the make command is not executed under `vroot`, a compilation error occurs, but the v.exe file is generated under the current directory, This file will affect the normal use of V, causing inexplicable problems.

**Solution**
Automatically set the current directory as the directory where the script is located in `vroot`, this also compiles successfully.