### PR TITLE
fmt: fix processing ForInStmt

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -178,9 +178,15 @@ fn (f mut Fmt) stmt(node ast.Stmt) {
 			f.writeln('}\n')
 		}
 		ast.ForInStmt {
-			f.write('for $it.key_var')
+			f.write('for ')
+			if it.key_var != '' {
+				f.write(it.key_var)
+			}
 			if it.val_var != '' {
-				f.write(', $it.val_var')
+				if it.key_var != '' {
+					f.write(', ')
+				}
+				f.write(it.val_var)
 			}
 			f.write(' in ')
 			f.expr(it.cond)

--- a/vlib/v/fmt/tests/loops_expected.vv
+++ b/vlib/v/fmt/tests/loops_expected.vv
@@ -1,0 +1,17 @@
+fn for_in_loop() {
+	for item in arr {
+		println(item)
+	}
+}
+
+fn for_in_loop_with_counter() {
+	for i, item in arr {
+		println(item)
+	}
+}
+
+fn for_in_loop_with_index_expr() {
+	for i in 0 .. 10 {
+		println(i)
+	}
+}

--- a/vlib/v/fmt/tests/loops_input.vv
+++ b/vlib/v/fmt/tests/loops_input.vv
@@ -1,0 +1,17 @@
+fn for_in_loop() {
+	for item in arr {
+		println(item)
+	}
+}
+
+fn for_in_loop_with_counter() {
+	for i, item in arr {
+		println(item)
+	}
+}
+
+fn for_in_loop_with_index_expr() {
+	for i in 0..10 {
+		println(i)
+	}
+}


### PR DESCRIPTION
This PR fixes formatting for-in loops with no counter variable. Also, added tests for loops.

Before PR:
```v
fn for_in_loop() {
	for , item in arr {
		println(item)
	}
}

fn for_in_loop_with_counter() {
	for i, item in arr {
		println(item)
	}
}

fn for_in_loop_with_index_expr() {
	for , i in 0 .. 10 {
		println(i)
	}
}
```

After the PR:
```v
fn for_in_loop() {
	for item in arr {
		println(item)
	}
}

fn for_in_loop_with_counter() {
	for i, item in arr {
		println(item)
	}
}

fn for_in_loop_with_index_expr() {
	for i in 0 .. 10 {
		println(i)
	}
}
```