### PR TITLE
Fix undefined behaviour when allocating empty structs

### DIFF
--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -177,6 +177,9 @@ pub fn free(ptr voidptr) {
 }
 
 pub fn memdup(src voidptr, sz int) voidptr {
+	if sz == 0 {
+		return vcalloc(1)
+	}
 	mem := malloc(sz)
 	return C.memcpy(mem, src, sz)
 }

--- a/vlib/compiler/tests/struct_test.v
+++ b/vlib/compiler/tests/struct_test.v
@@ -1,10 +1,10 @@
-struct A{
+struct A {
 mut:
 	val int
 	nums []int
 }
 
-struct B{
+struct B {
 mut:
 	a A
 }
@@ -24,6 +24,9 @@ struct User {
 
 struct Foo {
 	@type string
+}
+
+struct Empty {
 }
 
 //We need to make sure that this compiles with all the reserved names.
@@ -53,6 +56,12 @@ struct ReservedKeywords {
 	void     int
 	volatile int
 	while    int
+}
+
+fn test_empty_struct() {
+	d := &Empty{}
+	println(d) // != voidptr(0)
+	println(sizeof(Empty)) // == 0
 }
 
 fn test_struct_levels() {


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
