### PR TITLE
fix #4066 - 'a b zz'.trim(' a') gets empty string, under shell

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -152,7 +152,14 @@ pub fn run_repl(workdir string, vrepl_prefix string) []string {
 			mut temp_line := r.line
 			mut temp_flag := false
 			func_call := r.function_call(r.line)
-			if !(r.line.contains(':=') || r.line.starts_with('import') || r.line == '') && !func_call {
+			filter_line := r.line.replace(r.line.find_between('\'', '\''), '').replace(r.line.find_between('"', '"'), '')
+			if !(filter_line.contains(':') ||
+					filter_line.contains('=') ||
+					filter_line.contains(',') ||
+					filter_line.contains('++') ||
+					filter_line.contains('--') ||
+					filter_line.starts_with('import') ||
+					r.line == '') && !func_call {
 				temp_line = 'println($r.line)'
 				temp_flag = true
 			}

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -152,7 +152,7 @@ pub fn run_repl(workdir string, vrepl_prefix string) []string {
 			mut temp_line := r.line
 			mut temp_flag := false
 			func_call := r.function_call(r.line)
-			if !(r.line.contains(':=') || r.line == '') && !func_call {
+			if !(r.line.contains(':=') || r.line.starts_with('import') || r.line == '') && !func_call {
 				temp_line = 'println($r.line)'
 				temp_flag = true
 			}

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -152,14 +152,7 @@ pub fn run_repl(workdir string, vrepl_prefix string) []string {
 			mut temp_line := r.line
 			mut temp_flag := false
 			func_call := r.function_call(r.line)
-			if !(
-				r.line.contains(' ') ||
-				r.line.contains(':') ||
-				r.line.contains('=') ||
-				r.line.contains(',') ||
-				r.line.ends_with('++') ||
-				r.line.ends_with('--') ||
-				r.line == '') && !func_call {
+			if !(r.line.contains(':=') || r.line == '') && !func_call {
 				temp_line = 'println($r.line)'
 				temp_flag = true
 			}


### PR DESCRIPTION
This PR fix #4066 - 'a b zz'.trim(' a') gets empty string, under shell.

```
>>> 2 + 3
5
```
Originally because there are spaces, so the results can not be displayed.
