### PR TITLE
os: fix os.cp() spaces in files names

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -160,7 +160,7 @@ pub fn cp(old, new string) ?bool {
 			return error_with_code('failed to copy $old to $new', int(result))
 		}
 	} $else {
-		os.system('cp $old $new')
+		os.system('cp "$old" "$new"')
 		return true // TODO make it return true or error when cp for linux is implemented
 	}
 }


### PR DESCRIPTION
I know it's something tiny and silly but it took me a while to find out the reason. The title says what this is clearly I guess.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
