### PR TITLE
http: fix "`req` is declared as mutable, but it was never changed" message

### DIFF
--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -163,11 +163,11 @@ fn build_url_from_fetch(_url string, config FetchConfig) ?string {
 	return url.str()
 }
 
-fn (req mut Request) free() {
+fn (req Request) free() {
 	req.headers.free()
 }
 
-fn (resp mut Response) free() {
+fn (resp Response) free() {
 	resp.headers.free()
 }
 


### PR DESCRIPTION
Resolves #4075 

@medvednikov & @joe-conigliaro I'm not sure if this is the correct solution or not.

If `resp.headers.free()` doesn't count as mutating `resp`, then cool, this PR is fine.

However, if it does count as mutating, then something is wrong in the compiler's recognition of the fact that freeing a member of a struct has caused a mutation. And that's not something I'm equipped to fix!



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
