### PR TITLE
valgrind: nicer output, when everything is fine

### DIFF
--- a/vlib/v/tests/valgrind/valgrind_test.v
+++ b/vlib/v/tests/valgrind/valgrind_test.v
@@ -1,41 +1,56 @@
 import os
 import term
+import benchmark
 
 fn test_all() {
-	$if !linux {
-		println('Valgrind tests can only be run on Linux.')
+	if os.user_os() != 'linux' && os.getenv('FORCE_VALGRIND_TEST').len == 0 {
+		eprintln('Valgrind tests can only be run reliably on Linux for now.')
+		eprintln('You can still do it by setting FORCE_VALGRIND_TEST=1 .')
 		exit(0)
 	}
-	exe := os.executable()
-	dir := os.dir(exe)
-	vexe := os.dir(os.dir(os.dir(os.dir(dir)))) + '/v'
-	println(vexe)
-	println(dir)
-	println(111)
-	// files := os.ls('$dir/vlib/v/tests/valgrind/') or {
+	bench_message := 'memory leak checking with valgrind'
+	mut bench := benchmark.new_benchmark()
+	eprintln(term.header(bench_message,'-'))
+	dir := os.resource_abs_path('')
+	vexe := os.getenv('VEXE')
 	files := os.ls(dir) or {
 		panic(err)
 	}
 	tests := files.filter(it.ends_with('.vv'))
+	bench.set_total_expected_steps(tests.len)
 	for test in tests {
-		os.system('cp $dir/$test x.v') // cant run .vv file
-		println(test)
-		res := os.exec('$vexe x.v') or {
-			println('valgrind $test failed')
-			assert false
+		bench.step()
+		full_test_path := os.real_path(test)
+		os.system('cp ${dir}/${test} x.v') // cant run .vv file
+		res := os.exec('$vexe -b v2 x.v') or {
+			bench.fail()
+			eprintln(bench.step_message_fail('valgrind $test failed'))
 			continue
 		}
-		println(res.output)
-		os.exec('valgrind ./x') or {
-			println('valgrind $test failed')
-			assert false
-			continue
-		}
-		println(res.output)
 		if res.exit_code != 0 {
-			println('valgrind $test failed')
-			assert false
+			bench.fail()
+			eprintln(bench.step_message_fail('file: $full_test_path could not be compiled.'))
+			eprintln(res.output)
+			continue
 		}
+		valgrind_res := os.exec('valgrind --error-exitcode=1 --leak-check=full ./x') or {
+			bench.fail()
+			eprintln(bench.step_message_fail('valgrind could not be executed'))
+			continue
+		}
+		if valgrind_res.exit_code != 0 {
+			bench.fail()
+			eprintln(bench.step_message_fail('failed valgrind check for $test'))
+			eprintln(valgrind_res.output)
+			continue
+		}
+		bench.ok()
+		eprintln(bench.step_message_ok('testing file: $test'))
 	}
-	println(tests)
+	bench.stop()
+	eprintln(term.h_divider('-'))
+	eprintln(bench.total_message(bench_message))
+	if bench.nfail > 0 {
+		exit(1)
+	}
 }


### PR DESCRIPTION
```shell
0[10:22:46] /v/nv LINUX $ ./v vlib/v/tests/valgrind/valgrind_test.v
----------------------------------- memory leak checking with valgrind ----------------------------------
OK    1355 ms [1/1] testing file: 1.vv
---------------------------------------------------------------------------------------------------------
    1356 ms <=== total time spent memory leak checking with valgrind
	                 ok, fail, skip, total =     1,     0,     0,     1
0[10:22:50] /v/nv LINUX $
```