### PR TITLE
bugfix: 'v test vlib/v/tests' works too.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,12 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Build V
-      uses: spytheman/docker_alpine_v@v6.0
+      uses: spytheman/docker_alpine_v@v7.0
       with:
         entrypoint: .github/workflows/alpine.build.sh
 
     - name: Test V
-      uses: spytheman/docker_alpine_v@v6.0
+      uses: spytheman/docker_alpine_v@v7.0
       with:
         entrypoint: .github/workflows/alpine.test.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
-      run: sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list; sudo apt-get update; sudo apt-get install --quiet -y libglfw3 libglfw3-dev libfreetype6-dev libssl-dev sqlite3 libsqlite3-dev libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
+      run: sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list; sudo apt-get update; sudo apt-get install --quiet -y libglfw3 libglfw3-dev libfreetype6-dev libssl-dev sqlite3 libsqlite3-dev libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev valgrind
     - name: Build v
       run: echo $VFLAGS && make -j4 && ./v -cg -o v cmd/v
     - name: Test v->c
@@ -108,7 +108,7 @@ jobs:
       with:
         node-version: 12.x
     - name: Install dependencies
-      run: sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list; sudo apt-get update; sudo apt-get install --quiet -y postgresql libpq-dev libglfw3 libglfw3-dev libfreetype6-dev libssl-dev sqlite3 libsqlite3-dev libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
+      run: sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list; sudo apt-get update; sudo apt-get install --quiet -y postgresql libpq-dev libglfw3 libglfw3-dev libfreetype6-dev libssl-dev sqlite3 libsqlite3-dev libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev valgrind
     - name: Build V
       run: make -j4 && ./v -cc gcc -o v cmd/v
     - name: Test V
@@ -146,7 +146,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Install dependencies
-      run: sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list; sudo apt-get update; sudo apt-get install --quiet -y postgresql libpq-dev libglfw3 libglfw3-dev libfreetype6-dev libssl-dev sqlite3 libsqlite3-dev libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
+      run: sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list; sudo apt-get update; sudo apt-get install --quiet -y postgresql libpq-dev libglfw3 libglfw3-dev libfreetype6-dev libssl-dev sqlite3 libsqlite3-dev libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev valgrind
     - name: Download V
       run: wget https://github.com/vlang/v/releases/latest/download/v_linux.zip && unzip v_linux.zip && ./v -version
     - name: Test V
@@ -192,7 +192,7 @@ jobs:
       with:
         node-version: 12.x
     - name: Install dependencies
-      run: sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list; sudo apt-get update; sudo apt-get install --quiet -y musl musl-tools libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
+      run: sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list; sudo apt-get update; sudo apt-get install --quiet -y musl musl-tools libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev valgrind
     - name: Build v
       run: echo $VFLAGS && make -j4 && ./v -cg -o v cmd/v
     - name: Test v binaries

--- a/vlib/v/tests/valgrind/valgrind_test.v
+++ b/vlib/v/tests/valgrind/valgrind_test.v
@@ -3,6 +3,10 @@ import term
 import benchmark
 
 fn test_all() {
+	$if tinyc {
+		eprintln('Temporarily disabled for tcc, till the generated C code works with tcc.')
+		exit(0)
+	}
 	if os.user_os() != 'linux' && os.getenv('FORCE_VALGRIND_TEST').len == 0 {
 		eprintln('Valgrind tests can only be run reliably on Linux for now.')
 		eprintln('You can still do it by setting FORCE_VALGRIND_TEST=1 .')

--- a/vlib/v/tests/valgrind/valgrind_test.v
+++ b/vlib/v/tests/valgrind/valgrind_test.v
@@ -17,13 +17,18 @@ fn test_all() {
 	files := os.ls(dir) or {
 		panic(err)
 	}
+	//
+	wrkdir := os.join_path(os.temp_dir(), 'vtests', 'valgrind')
+	os.mkdir_all(wrkdir)
+	os.chdir(wrkdir)
+	//
 	tests := files.filter(it.ends_with('.vv'))
 	bench.set_total_expected_steps(tests.len)
 	for test in tests {
 		bench.step()
 		full_test_path := os.real_path(test)
-		os.system('cp ${dir}/${test} x.v') // cant run .vv file
-		res := os.exec('$vexe -b v2 x.v') or {
+		os.system('cp ${dir}/${test} $wrkdir/x.v') // cant run .vv file
+		res := os.exec('$vexe -b v2 $wrkdir/x.v') or {
 			bench.fail()
 			eprintln(bench.step_message_fail('valgrind $test failed'))
 			continue
@@ -34,7 +39,7 @@ fn test_all() {
 			eprintln(res.output)
 			continue
 		}
-		valgrind_res := os.exec('valgrind --error-exitcode=1 --leak-check=full ./x') or {
+		valgrind_res := os.exec('valgrind --error-exitcode=1 --leak-check=full $wrkdir/x') or {
 			bench.fail()
 			eprintln(bench.step_message_fail('valgrind could not be executed'))
 			continue

--- a/vlib/v/tests/valgrind/valgrind_test.v
+++ b/vlib/v/tests/valgrind/valgrind_test.v
@@ -11,8 +11,9 @@ fn test_all() {
 	bench_message := 'memory leak checking with valgrind'
 	mut bench := benchmark.new_benchmark()
 	eprintln(term.header(bench_message,'-'))
-	dir := os.resource_abs_path('')
 	vexe := os.getenv('VEXE')
+	vroot := os.dir(vexe)
+	dir := os.join_path(vroot, 'vlib/v/tests/valgrind')
 	files := os.ls(dir) or {
 		panic(err)
 	}


### PR DESCRIPTION
This PR fixes running vlib/v/tests/valgrind/valgrind_test.v 
with `v test` .

Previously it tried to run over ~/.cache which contained other
.vv files (left behind vlib/v/fmt/fmt_test.v), that could not
be compiled, which created false failures.