### PR TITLE
time api: calc_unix => unix_time

### DIFF
--- a/vlib/compiler/tests/fn_expecting_ref_but_returning_struct_time_module_test.v
+++ b/vlib/compiler/tests/fn_expecting_ref_but_returning_struct_time_module_test.v
@@ -2,7 +2,7 @@ import time.misc as tmisc
 // using a manual temporary intermediate variable should always work:
 fn test_call_fn_that_requires_reference_with_function_that_returns_a_struct_manual() {
 	t1 := tmisc.random()
-	t2 := t1.calc_unix()
+	t2 := t1.unix_time()
 	println('res: $t2')
 	assert true
 }
@@ -11,7 +11,7 @@ fn test_call_fn_that_requires_reference_with_function_that_returns_a_struct_manu
 // TODO: Fix this.
 // v should produce temporary intermediate variables in chained calls:
 fn test_call_fn_that_requires_reference_with_function_that_returns_a_struct_chained(){
-	res := (tmisc.random().calc_unix())
+	res := (tmisc.random().unix_time())
 	println('res: $res')
 	assert true
 }

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -95,17 +95,17 @@ pub fn new_time(t Time) Time {
 		hour: t.hour
 		minute: t.minute
 		second: t.second
-		unix: t.calc_unix()
+		unix: t.unix_time()
 	}
 	// TODO Use the syntax below when it works with reserved keywords like `unix`
 	// return {
 	// 	t |
-	// 	unix:t.calc_unix()
+	// 	unix:t.unix_time()
 	// }
 }
 
-// calc_unix returns Unix time.
-pub fn (t &Time) calc_unix() int {
+// unix_time returns Unix time.
+pub fn (t &Time) unix_time() int {
 	if t.unix != 0 {
 		return t.unix
 	}


### PR DESCRIPTION
This PR change `calc_unix` to `unix_time` in `time` API similar to Vlang style.