### PR TITLE
time api: usleep => sleep_us

### DIFF
--- a/vlib/clipboard/clipboard_linux.v
+++ b/vlib/clipboard/clipboard_linux.v
@@ -209,7 +209,7 @@ fn (cb mut Clipboard) get_text() string {
 	mut retries := 5
 	for {
 		if cb.got_text || retries == 0 {break}
-		time.usleep(50000)
+		time.sleep_us(50000)
 		retries--
 	}
 	return cb.text

--- a/vlib/sync/waitgroup.v
+++ b/vlib/sync/waitgroup.v
@@ -37,4 +37,3 @@ pub fn (wg &WaitGroup) wait() {
 		}
 	}
 }
-

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -221,8 +221,8 @@ pub fn sleep_ms(milliseconds int) {
 	}
 }
 
-// usleep makes the calling thread sleep for a given number of microseconds.
-pub fn usleep(microseconds int) {
+// sleep_us makes the calling thread sleep for a given number of microseconds.
+pub fn sleep_us(microseconds int) {
 	$if windows {
 		milliseconds := microseconds / 1000
 		C.Sleep(milliseconds)


### PR DESCRIPTION
This PR change `usleep` to `sleep_us` in `time` API like `sleep_ms` similar to Vlang style.

`sleep` `sleep_ms` `sleep_us` are more unified style.