### PR TITLE
glfw: fix mutable "scale"

### DIFF
--- a/vlib/glfw/glfw.v
+++ b/vlib/glfw/glfw.v
@@ -147,7 +147,7 @@ pub fn create_window(c WinCfg) &glfw.Window {
 	// println('create window wnd=$cwindow ptr==$c.ptr')
 	C.glfwSetWindowUserPointer(cwindow, c.ptr)
 
-	mut scale := 1.0
+	scale := 1.0
 	$if windows {
 		C.glfwGetWindowContentScale(cwindow, &scale, &scale)
 	}
@@ -257,7 +257,7 @@ pub fn get_cursor_pos(cwindow voidptr) (f64, f64) {
 	y := f64(0)
 	C.glfwGetCursorPos(cwindow, &x, &y)
 
-	mut scale := 1.0
+	scale := 1.0
 	$if windows {
 		C.glfwGetWindowContentScale(cwindow, &scale, &scale)
 	}


### PR DESCRIPTION
Changing local, mutable variable "scale" to immutable.
Declaring them as mutable, prevents the use of this library, since the compiler notices, that they won't change in during runtime.