### PR TITLE
term: fix divide by 0 error on empty delimiter

### DIFF
--- a/vlib/term/term.v
+++ b/vlib/term/term.v
@@ -32,9 +32,10 @@ pub fn fail_message(s string) string {
 
 // h_divider returns a horizontal divider line with a dynamic width,
 // that depends on the current terminal settings.
+// If an empty string is passed in, print enough spaces to make a new line
 pub fn h_divider(divider string) string {
 	cols,_ := get_terminal_size()
-	result := divider.repeat(1 + (cols / divider.len))
+	result := if divider.len > 0 { divider.repeat(1 + (cols / divider.len)) } else { " ".repeat(1 + cols) }
 	return result[0..cols]
 }
 
@@ -49,7 +50,7 @@ pub fn header(text, divider string) string {
 	tlimit := if cols > text.len + 2 + 2 * divider.len { text.len } else { cols - 3 - 2 * divider.len }
 	tlimit_alligned := if (tlimit % 2) != (cols % 2) { tlimit + 1 } else { tlimit }
 	tstart := (cols - tlimit_alligned) / 2
-	ln := divider.repeat(1 + cols / divider.len)[0..cols]
+	ln := if divider.len > 0 { divider.repeat(1 + cols / divider.len)[0..cols] } else { " ".repeat(1 + cols) }
 	return ln[0..tstart] + ' ' + text[0..tlimit] + ' ' + ln[tstart + tlimit + 2..cols]
 }
 


### PR DESCRIPTION
If an empty delimiter was provided to `header` or `h_divider`, we would get a divide by 0 floating point error. This checks for that case now.