### PR TITLE
compiler: fix #3973 by dealing with name mangling problem

### DIFF
--- a/examples/sokol/drawing.v
+++ b/examples/sokol/drawing.v
@@ -28,13 +28,13 @@ fn main() {
 
 fn init(user_data voidptr) {
 	desc := sg_desc{
-		mtl_device: C.sapp_metal_get_device()
-		mtl_renderpass_descriptor_cb: C.sapp_metal_get_renderpass_descriptor
-		mtl_drawable_cb: C.sapp_metal_get_drawable
-		d3d11_device: C.sapp_d3d11_get_device()
-		d3d11_device_context: C.sapp_d3d11_get_device_context()
-		d3d11_render_target_view_cb: C.sapp_d3d11_get_render_target_view
-		d3d11_depth_stencil_view_cb: C.sapp_d3d11_get_depth_stencil_view
+		mtl_device: sapp.metal_get_device()
+		mtl_renderpass_descriptor_cb: sapp.metal_get_renderpass_descriptor
+		mtl_drawable_cb: sapp.metal_get_drawable
+		d3d11_device: sapp.d3d11_get_device()
+		d3d11_device_context: sapp.d3d11_get_device_context()
+		d3d11_render_target_view_cb: sapp.d3d11_get_render_target_view
+		d3d11_depth_stencil_view_cb: sapp.d3d11_get_depth_stencil_view
 	}
 	gfx.setup(&desc)
 	sgl_desc := sgl_desc_t{}
@@ -75,9 +75,9 @@ fn draw_hollow_rect(x, y, w, h f32) {
 
 fn draw_filled_rect(x, y, w, h f32) {
 	sgl.begin_quads()
-	C.sgl_v2f(x, y)
-	C.sgl_v2f(x + w, y)
-	C.sgl_v2f(x + w, y + h)
-	C.sgl_v2f(x, y + h)
+	sgl.v2f(x, y)
+	sgl.v2f(x + w, y)
+	sgl.v2f(x + w, y + h)
+	sgl.v2f(x, y + h)
 	sgl.end()
 }

--- a/examples/sokol/drawing.v
+++ b/examples/sokol/drawing.v
@@ -29,12 +29,12 @@ fn main() {
 fn init(user_data voidptr) {
 	desc := sg_desc{
 		mtl_device: C.sapp_metal_get_device()
-		mtl_renderpass_descriptor_cb: sapp_metal_get_renderpass_descriptor
-		mtl_drawable_cb: sapp_metal_get_drawable
-		d3d11_device: sapp_d3d11_get_device()
-		d3d11_device_context: sapp_d3d11_get_device_context()
-		d3d11_render_target_view_cb: sapp_d3d11_get_render_target_view
-		d3d11_depth_stencil_view_cb: sapp_d3d11_get_depth_stencil_view
+		mtl_renderpass_descriptor_cb: C.sapp_metal_get_renderpass_descriptor
+		mtl_drawable_cb: C.sapp_metal_get_drawable
+		d3d11_device: C.sapp_d3d11_get_device()
+		d3d11_device_context: C.sapp_d3d11_get_device_context()
+		d3d11_render_target_view_cb: C.sapp_d3d11_get_render_target_view
+		d3d11_depth_stencil_view_cb: C.sapp_d3d11_get_depth_stencil_view
 	}
 	gfx.setup(&desc)
 	sgl_desc := sgl_desc_t{}
@@ -75,9 +75,9 @@ fn draw_hollow_rect(x, y, w, h f32) {
 
 fn draw_filled_rect(x, y, w, h f32) {
 	sgl.begin_quads()
-	sgl_v2f(x, y)
-	sgl_v2f(x + w, y)
-	sgl_v2f(x + w, y + h)
-	sgl_v2f(x, y + h)
+	C.sgl_v2f(x, y)
+	C.sgl_v2f(x + w, y)
+	C.sgl_v2f(x + w, y + h)
+	C.sgl_v2f(x, y + h)
 	sgl.end()
 }

--- a/examples/sokol/fonts.v
+++ b/examples/sokol/fonts.v
@@ -42,13 +42,13 @@ fn init(user_data voidptr) {
 	mut state := &AppState(user_data)
 	// dont actually alocate this on the heap in real life
 	gfx.setup(&sg_desc{
-		mtl_device: C.sapp_metal_get_device()
-		mtl_renderpass_descriptor_cb: sapp_metal_get_renderpass_descriptor
-		mtl_drawable_cb: sapp_metal_get_drawable
-		d3d11_device: sapp_d3d11_get_device()
-		d3d11_device_context: sapp_d3d11_get_device_context()
-		d3d11_render_target_view_cb: sapp_d3d11_get_render_target_view
-		d3d11_depth_stencil_view_cb: sapp_d3d11_get_depth_stencil_view
+		mtl_device: sapp.metal_get_device()
+		mtl_renderpass_descriptor_cb: sapp.metal_get_renderpass_descriptor
+		mtl_drawable_cb: sapp.metal_get_drawable
+		d3d11_device: sapp.d3d11_get_device()
+		d3d11_device_context: sapp.d3d11_get_device_context()
+		d3d11_render_target_view_cb: sapp.d3d11_get_render_target_view
+		d3d11_depth_stencil_view_cb: sapp.d3d11_get_depth_stencil_view
 	})
 	s := &C.sgl_desc_t{}
 	C.sgl_setup(s)
@@ -64,7 +64,7 @@ fn frame(user_data voidptr) {
 	t := time.ticks()
 	mut state := &AppState(user_data)
 	state.render_font()
-	gfx.begin_default_pass(&state.pass_action, sapp_width(), sapp_height())
+	gfx.begin_default_pass(&state.pass_action, sapp.width(), sapp.height())
 	sgl.draw()
 	gfx.end_pass()
 	gfx.commit()
@@ -98,43 +98,43 @@ fn (state &AppState) render_font() {
 	dy += lh
 	C.fonsSetColor(state.fons, white)
 	dx = C.fonsDrawText(state.fons, dx, dy, c'The quick ', C.NULL)
-	fonsSetFont(state.fons, state.font_normal)
-	fonsSetSize(state.fons, 48.0)
-	fonsSetColor(state.fons, brown)
-	dx = fonsDrawText(state.fons, dx, dy, c'brown ', C.NULL)
-	fonsSetFont(state.fons, state.font_normal)
-	fonsSetSize(state.fons, 24.0)
-	fonsSetColor(state.fons, white)
-	dx = fonsDrawText(state.fons, dx, dy, c'fox ', C.NULL)
+	C.fonsSetFont(state.fons, state.font_normal)
+	C.fonsSetSize(state.fons, 48.0)
+	C.fonsSetColor(state.fons, brown)
+	dx = C.fonsDrawText(state.fons, dx, dy, c'brown ', C.NULL)
+	C.fonsSetFont(state.fons, state.font_normal)
+	C.fonsSetSize(state.fons, 24.0)
+	C.fonsSetColor(state.fons, white)
+	dx = C.fonsDrawText(state.fons, dx, dy, c'fox ', C.NULL)
 	dx = sx
 	dy += lh * 1.2
-	fonsSetSize(state.fons, 20.0)
-	fonsSetFont(state.fons, state.font_normal)
-	fonsSetColor(state.fons, blue)
-	fonsDrawText(state.fons, dx, dy, c'Now is the time for all good men to come to the aid of the party.', C.NULL)
+	C.fonsSetSize(state.fons, 20.0)
+	C.fonsSetFont(state.fons, state.font_normal)
+	C.fonsSetColor(state.fons, blue)
+	C.fonsDrawText(state.fons, dx, dy, c'Now is the time for all good men to come to the aid of the party.', C.NULL)
 	dx = 300
 	dy = 350
-	fonsSetAlign(state.fons, C.FONS_ALIGN_LEFT | C.FONS_ALIGN_BASELINE)
-	fonsSetSize(state.fons, 60.0)
-	fonsSetFont(state.fons, state.font_normal)
-	fonsSetColor(state.fons, white)
-	fonsSetSpacing(state.fons, 5.0)
-	fonsSetBlur(state.fons, 6.0)
-	fonsDrawText(state.fons, dx, dy, c'Blurry...', C.NULL)
+	C.fonsSetAlign(state.fons, C.FONS_ALIGN_LEFT | C.FONS_ALIGN_BASELINE)
+	C.fonsSetSize(state.fons, 60.0)
+	C.fonsSetFont(state.fons, state.font_normal)
+	C.fonsSetColor(state.fons, white)
+	C.fonsSetSpacing(state.fons, 5.0)
+	C.fonsSetBlur(state.fons, 6.0)
+	C.fonsDrawText(state.fons, dx, dy, c'Blurry...', C.NULL)
 	dx = 300
 	dy += 50.0
-	fonsSetSize(state.fons, 28.0)
-	fonsSetFont(state.fons, state.font_normal)
-	fonsSetColor(state.fons, white)
-	fonsSetSpacing(state.fons, 0.0)
-	fonsSetBlur(state.fons, 3.0)
-	fonsDrawText(state.fons, dx, dy + 2, c'DROP SHADOW', C.NULL)
-	fonsSetColor(state.fons, black)
-	fonsSetBlur(state.fons, 0)
-	fonsDrawText(state.fons, dx, dy, c'DROP SHADOW', C.NULL)
-	fonsSetSize(state.fons, 18.0)
-	fonsSetFont(state.fons, state.font_normal)
-	fonsSetColor(state.fons, white)
+	C.fonsSetSize(state.fons, 28.0)
+	C.fonsSetFont(state.fons, state.font_normal)
+	C.fonsSetColor(state.fons, white)
+	C.fonsSetSpacing(state.fons, 0.0)
+	C.fonsSetBlur(state.fons, 3.0)
+	C.fonsDrawText(state.fons, dx, dy + 2, c'DROP SHADOW', C.NULL)
+	C.fonsSetColor(state.fons, black)
+	C.fonsSetBlur(state.fons, 0)
+	C.fonsDrawText(state.fons, dx, dy, c'DROP SHADOW', C.NULL)
+	C.fonsSetSize(state.fons, 18.0)
+	C.fonsSetFont(state.fons, state.font_normal)
+	C.fonsSetColor(state.fons, white)
 	dx = 50
 	dy = 350
 	line(dx - 10, dy, dx + 250, dy)

--- a/vlib/compiler/expression.v
+++ b/vlib/compiler/expression.v
@@ -366,7 +366,7 @@ fn (p mut Parser) name_expr() string {
 	}
 	// Unknown name, try prepending the module name to it
 	// TODO perf
-	else if !p.table.known_type(name) && !p.table.known_fn(name) && !p.table.known_const(name) && !is_c {
+	else if !p.table.known_type(name) && !p.known_fn_in_mod(name) && !p.table.known_const(name) && !is_c {
 		name = p.prepend_mod(name)
 	}
 	// re-check

--- a/vlib/compiler/table.v
+++ b/vlib/compiler/table.v
@@ -384,6 +384,16 @@ fn (t &Table) known_fn(name string) bool {
 	return true
 }
 
+fn (p &Parser) known_fn_in_mod(name string) bool {
+	existing_fn := p.table.find_fn(name) or {
+		return false
+	}
+	if (existing_fn.mod == p.mod || existing_fn.mod == 'builtin') {
+		return true
+	}
+	return false
+}
+
 fn (t &Table) known_const(name string) bool {
 	_ = t.find_const(name) or {
 		return false

--- a/vlib/gg2/gg.v
+++ b/vlib/gg2/gg.v
@@ -57,12 +57,12 @@ __global g_font_path string
 fn init_sokol_window() {
 	desc := sg_desc{
 		mtl_device: C.sapp_metal_get_device()
-		mtl_renderpass_descriptor_cb: sapp_metal_get_renderpass_descriptor
-		mtl_drawable_cb: sapp_metal_get_drawable
-		d3d11_device: sapp_d3d11_get_device()
-		d3d11_device_context: sapp_d3d11_get_device_context()
-		d3d11_render_target_view_cb: sapp_d3d11_get_render_target_view
-		d3d11_depth_stencil_view_cb: sapp_d3d11_get_depth_stencil_view
+		mtl_renderpass_descriptor_cb: C.sapp_metal_get_renderpass_descriptor
+		mtl_drawable_cb: C.sapp_metal_get_drawable
+		d3d11_device: C.sapp_d3d11_get_device()
+		d3d11_device_context: C.sapp_d3d11_get_device_context()
+		d3d11_render_target_view_cb: C.sapp_d3d11_get_render_target_view
+		d3d11_depth_stencil_view_cb: C.sapp_d3d11_get_depth_stencil_view
 	}
 	gfx.setup(&desc)
 	sgl_desc := sgl_desc_t{}
@@ -138,20 +138,20 @@ pub fn (gg &GG) run() {
 pub fn (ctx &GG) draw_rect(x, y, w, h f32, c gx.Color) {
 	sgl.c4b(c.r, c.g, c.b, 128)
 	sgl.begin_quads()
-	sgl_v2f(x, y)
-	sgl_v2f(x + w, y)
-	sgl_v2f(x + w, y + h)
-	sgl_v2f(x, y + h)
+	C.sgl_v2f(x, y)
+	C.sgl_v2f(x + w, y)
+	C.sgl_v2f(x + w, y + h)
+	C.sgl_v2f(x, y + h)
 	sgl.end()
 }
 
 pub fn draw_rect(x, y, w, h f32, c gx.Color) {
 	sgl.c4b(c.r, c.g, c.b, 128)
 	sgl.begin_quads()
-	sgl_v2f(x, y)
-	sgl_v2f(x + w, y)
-	sgl_v2f(x + w, y + h)
-	sgl_v2f(x, y + h)
+	C.sgl_v2f(x, y)
+	C.sgl_v2f(x + w, y)
+	C.sgl_v2f(x + w, y + h)
+	C.sgl_v2f(x, y + h)
 	sgl.end()
 }
 

--- a/vlib/gg2/gg.v
+++ b/vlib/gg2/gg.v
@@ -56,13 +56,13 @@ __global g_font_path string
 
 fn init_sokol_window() {
 	desc := sg_desc{
-		mtl_device: C.sapp_metal_get_device()
-		mtl_renderpass_descriptor_cb: C.sapp_metal_get_renderpass_descriptor
-		mtl_drawable_cb: C.sapp_metal_get_drawable
-		d3d11_device: C.sapp_d3d11_get_device()
-		d3d11_device_context: C.sapp_d3d11_get_device_context()
-		d3d11_render_target_view_cb: C.sapp_d3d11_get_render_target_view
-		d3d11_depth_stencil_view_cb: C.sapp_d3d11_get_depth_stencil_view
+		mtl_device: sapp.metal_get_device()
+		mtl_renderpass_descriptor_cb: sapp.metal_get_renderpass_descriptor
+		mtl_drawable_cb: sapp.metal_get_drawable
+		d3d11_device: sapp.d3d11_get_device()
+		d3d11_device_context: sapp.d3d11_get_device_context()
+		d3d11_render_target_view_cb: sapp.d3d11_get_render_target_view
+		d3d11_depth_stencil_view_cb: sapp.d3d11_get_depth_stencil_view
 	}
 	gfx.setup(&desc)
 	sgl_desc := sgl_desc_t{}
@@ -138,20 +138,20 @@ pub fn (gg &GG) run() {
 pub fn (ctx &GG) draw_rect(x, y, w, h f32, c gx.Color) {
 	sgl.c4b(c.r, c.g, c.b, 128)
 	sgl.begin_quads()
-	C.sgl_v2f(x, y)
-	C.sgl_v2f(x + w, y)
-	C.sgl_v2f(x + w, y + h)
-	C.sgl_v2f(x, y + h)
+	sgl.v2f(x, y)
+	sgl.v2f(x + w, y)
+	sgl.v2f(x + w, y + h)
+	sgl.v2f(x, y + h)
 	sgl.end()
 }
 
 pub fn draw_rect(x, y, w, h f32, c gx.Color) {
 	sgl.c4b(c.r, c.g, c.b, 128)
 	sgl.begin_quads()
-	C.sgl_v2f(x, y)
-	C.sgl_v2f(x + w, y)
-	C.sgl_v2f(x + w, y + h)
-	C.sgl_v2f(x, y + h)
+	sgl.v2f(x, y)
+	sgl.v2f(x + w, y)
+	sgl.v2f(x + w, y + h)
+	sgl.v2f(x, y + h)
 	sgl.end()
 }
 


### PR DESCRIPTION
 Bug in #3973 is caused by current V seeing functions with the same name as the same functions, regardless of what module each of them belongs to. `known_fn_in_mod` in this PR checks whether the function at hand belongs to the same module as the found one, except for builtin functions.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
