### PR TITLE
v2: enable compilation of short programs with no 'import os' .

### DIFF
--- a/vlib/v/gen/cgen_test.v
+++ b/vlib/v/gen/cgen_test.v
@@ -62,9 +62,9 @@ fn compare_texts(a, b, path string) bool {
 		line_b := lines_b[i]
 		if line_a.trim_space() != line_b.trim_space() {
 			println('${path}: Got\n$a')
-			println('${term_fail} near line: ${i}')
-			println(term.red('actual  :${line_a}'))
-			println(term.red('expected:${line_b}'))
+			println('${path}:${i}: ${term_fail}')
+			println(term.bold(term.bright_yellow('actual  : ')) + line_a)
+			println(term.green('expected: ') + line_b)
 			println(lines_b[i + 1])
 			println(lines_b[i + 2])
 			// exit(1)

--- a/vlib/v/gen/tests/1.c
+++ b/vlib/v/gen/tests/1.c
@@ -48,7 +48,6 @@ struct varg_int {
 //
 int main(int argc, char** argv) {
 	_vinit();
-	_const_os__args = os__init_os_args(argc, (byteptr*)argv);
 	int a = 10;
 	a++;
 	int negative = -a;

--- a/vlib/v/gen/tests/2.c
+++ b/vlib/v/gen/tests/2.c
@@ -78,7 +78,6 @@ void end() {
 
 int main(int argc, char** argv) {
 	_vinit();
-	_const_os__args = os__init_os_args(argc, (byteptr*)argv);
 	return 0;
 }
 

--- a/vlib/v/gen/tests/3.c
+++ b/vlib/v/gen/tests/3.c
@@ -64,7 +64,6 @@ void handle_expr(Expr e) {
 
 int main(int argc, char** argv) {
 	_vinit();
-	_const_os__args = os__init_os_args(argc, (byteptr*)argv);
 	User user = (User){
 		.age = 0,
 		.name = tos3(""),

--- a/vlib/v/gen/tests/4.c
+++ b/vlib/v/gen/tests/4.c
@@ -24,7 +24,6 @@ int Bar_testa(Bar* b);
 
 int main(int argc, char** argv) {
 	_vinit();
-	_const_os__args = os__init_os_args(argc, (byteptr*)argv);
     Bar b = (Bar){
         .a = 122,
     };


### PR DESCRIPTION
With this PR, the following short program compiles:
```v
fn main() {
	println('hello')
}
```

Previously, it required `import os`, even if the `os` module was not 
used inside the program source.