### PR TITLE
os api: ext => file_ext

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -617,7 +617,7 @@ fn print_c_errno() {
 	println('errno=$e err=$se')
 }
 
-pub fn ext(path string) string {
+pub fn file_ext(path string) string {
 	pos := path.last_index('.') or {
 		return ''
 	}

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -296,8 +296,8 @@ fn test_is_executable_writable_readable() {
 }
 
 fn test_ext() {
-	assert os.ext('file.v') == '.v'
-	assert os.ext('file') == ''
+	assert os.file_ext('file.v') == '.v'
+	assert os.file_ext('file') == ''
 }
 
 fn test_is_abs() {

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -330,7 +330,7 @@ fn (ctx mut Context) scan_static_directory(directory_path, mount_path string) {
 			if os.is_dir(file) {
 				ctx.scan_static_directory(directory_path + '/' + file, mount_path + '/' + file)
 			} else if file.contains('.') && ! file.starts_with('.') && ! file.ends_with('.') {
-				ext := os.ext(file)
+				ext := os.file_ext(file)
 
 				// Rudimentary guard against adding files not in mime_types.
 				// Use serve_static directly to add non-standard mime types.


### PR DESCRIPTION
This PR change `os.ext` to `os.file_ext` in os api, that makes it clearer.