### PR TITLE
pg: add windows include and lib flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ thirdparty/SDL2_ttf/
 cachegrind.out.*
 
 .gdb_history
+/thirdparty/pg

--- a/vlib/pg/pg.v
+++ b/vlib/pg/pg.v
@@ -3,6 +3,8 @@ module pg
 #flag -lpq
 #flag linux -I/usr/include/postgresql
 #flag darwin -I/opt/local/include/postgresql11
+#flag windows -I @VROOT/thirdparty/pg/include
+#flag windows -L @VROOT/thirdparty/pg/win64
 #include <libpq-fe.h>
 
 pub struct DB {


### PR DESCRIPTION
This PR add include and lib flag for postgresql on Windows.
- The directory structure of the pg library: 
  ```v
  thirdparty/pg/include
  thirdparty/pg/win32
  thirdparty/pg/win64
  ```
- Add `#flag windows -I @VROOT/thirdparty/pg/include`  in pg.v 
- Add `#flag windows -L @VROOT/thirdparty/pg/win64`  in pg.v    