### PR TITLE
glfw: remove excess `glfw.` in module glfw

### DIFF
--- a/vlib/glfw/glfw.v
+++ b/vlib/glfw/glfw.v
@@ -109,7 +109,7 @@ pub fn init_glfw() {
 	C.glfwWindowHint(C.GLFW_OPENGL_PROFILE, C.GLFW_OPENGL_CORE_PROFILE)
 }
 
-pub fn (w &glfw.Window) destroy() {
+pub fn (w &Window) destroy() {
 	C.glfwDestroyWindow(w.data)
 }
 
@@ -126,7 +126,7 @@ pub fn window_hint(key, val int) {
 	C.glfwWindowHint(key, val)
 }
 
-pub fn create_window(c WinCfg) &glfw.Window {
+pub fn create_window(c WinCfg) &Window {
 	if c.borderless {
 		window_hint(C.GLFW_RESIZABLE, 0)
 		window_hint(C.GLFW_DECORATED, 0)
@@ -155,7 +155,7 @@ pub fn create_window(c WinCfg) &glfw.Window {
 		scale = 1.0
 	}
 
-	window := &glfw.Window {
+	window := &Window {
 		data: cwindow,
 		title: c.title,
 		scale_: scale
@@ -163,15 +163,15 @@ pub fn create_window(c WinCfg) &glfw.Window {
 	return window
 }
 
-pub fn (w &glfw.Window) set_title(title string) {
+pub fn (w &Window) set_title(title string) {
 	C.glfwSetWindowTitle(w.data, title.str)
 }
 
-pub fn (w &glfw.Window) make_context_current() {
+pub fn (w &Window) make_context_current() {
 	C.glfwMakeContextCurrent(w.data)
 }
 
-pub fn (w &glfw.Window) scale() f32 {
+pub fn (w &Window) scale() f32 {
 	return w.scale_
 }
 
@@ -191,39 +191,39 @@ pub fn set_should_close(w voidptr, close bool) {
 	C.glfwSetWindowShouldClose(w, close)
 }
 
-pub fn (w &glfw.Window) set_should_close(close bool) {
+pub fn (w &Window) set_should_close(close bool) {
 	C.glfwSetWindowShouldClose(w.data, close)
 }
 
-pub fn (w &glfw.Window) should_close() bool {
+pub fn (w &Window) should_close() bool {
 	return C.glfwWindowShouldClose(w.data)
 }
 
-pub fn (w &glfw.Window) swap_buffers() {
+pub fn (w &Window) swap_buffers() {
 	C.glfwSwapBuffers(w.data)
 }
 
-pub fn (w mut glfw.Window) onmousemove(cb voidptr) {
+pub fn (w mut Window) onmousemove(cb voidptr) {
 	C.glfwSetCursorPosCallback(w.data, cb)
 }
 
-pub fn (w mut glfw.Window) set_mouse_button_callback(cb voidptr) {
+pub fn (w mut Window) set_mouse_button_callback(cb voidptr) {
 	C.glfwSetMouseButtonCallback(w.data, cb)
 }
 
-pub fn (w mut glfw.Window) on_resize(cb voidptr) {
+pub fn (w mut Window) on_resize(cb voidptr) {
 	C.glfwSetWindowSizeCallback(w.data, cb)
 }
 
-pub fn (w mut glfw.Window) on_click(cb voidptr) {
+pub fn (w mut Window) on_click(cb voidptr) {
 	C.glfwSetMouseButtonCallback(w.data, cb)
 }
 
-pub fn (w &glfw.Window) set_scroll_callback(cb voidptr) {
+pub fn (w &Window) set_scroll_callback(cb voidptr) {
 	C.glfwSetScrollCallback(w.data, cb)
 }
 
-pub fn (w &glfw.Window) on_scroll(cb voidptr) {
+pub fn (w &Window) on_scroll(cb voidptr) {
 	C.glfwSetScrollCallback(w.data, cb)
 }
 
@@ -231,11 +231,11 @@ pub fn post_empty_event() {
 	C.glfwPostEmptyEvent()
 }
 
-pub fn (w mut glfw.Window) onkeydown(cb voidptr) {
+pub fn (w mut Window) onkeydown(cb voidptr) {
 	C.glfwSetKeyCallback(w.data, cb)
 }
 
-pub fn (w mut glfw.Window) onchar(cb voidptr) {
+pub fn (w mut Window) onchar(cb voidptr) {
 	C.glfwSetCharModsCallback(w.data, cb)
 }
 
@@ -247,11 +247,11 @@ pub fn key_pressed(wnd voidptr, key int) bool {
 	return int(C.glfwGetKey(wnd, key)) == C.GLFW_PRESS
 }
 
-pub fn (w &glfw.Window) get_clipboard_text() string {
+pub fn (w &Window) get_clipboard_text() string {
 	return string(byteptr(C.glfwGetClipboardString(w.data)))
 }
 
-pub fn (w &glfw.Window) set_clipboard_text(s string) {
+pub fn (w &Window) set_clipboard_text(s string) {
 	C.glfwSetClipboardString(w.data, s.str)
 }
 
@@ -270,7 +270,7 @@ pub fn get_cursor_pos(cwindow voidptr) (f64, f64) {
 	return x/scale, y/scale
 }
 
-pub fn (w &glfw.Window) get_cursor_pos() Pos {
+pub fn (w &Window) get_cursor_pos() Pos {
 	x := f64(0)
 	y := f64(0)
 	C.glfwGetCursorPos(w.data, &x, &y)
@@ -291,16 +291,16 @@ pub fn set_cursor(c Cursor) {
 	C.glfwSetCursor(0, C.GLFW_IBEAM_CURSOR)
 }
 
-pub fn (w &glfw.Window) set_cursor(c Cursor) {
+pub fn (w &Window) set_cursor(c Cursor) {
 	C.glfwSetCursor(w.data, C.GLFW_IBEAM_CURSOR)
 
 }
 
-pub fn (w &glfw.Window) user_ptr() voidptr {
+pub fn (w &Window) user_ptr() voidptr {
 	return C.glfwGetWindowUserPointer(w.data)
 }
 
-pub fn (w &glfw.Window) set_user_ptr(ptr voidptr) {
+pub fn (w &Window) set_user_ptr(ptr voidptr) {
 	C.glfwSetWindowUserPointer(w.data, ptr)
 }
 
@@ -317,18 +317,18 @@ pub fn get_monitor_size() Size {
 	return Size{mode.width, mode.height}
 }
 
-fn C.glfwGetWindowSize(window &glfw.Window, width &int, height &int) // screen coordinates
-fn C.glfwGetFramebufferSize(window &glfw.Window, width &int, height &int) // pixels
+fn C.glfwGetWindowSize(window &Window, width &int, height &int) // screen coordinates
+fn C.glfwGetFramebufferSize(window &Window, width &int, height &int) // pixels
 
 // get_window_size in screen coordinates
-pub fn (w &glfw.Window) get_window_size() Size {
+pub fn (w &Window) get_window_size() Size {
 	res := Size {0, 0}
 	C.glfwGetWindowSize(w.data, &res.width, &res.height)
 	return res
 }
 
 // get_framebuffer_size in pixels
-pub fn (w &glfw.Window) get_framebuffer_size() Size {
+pub fn (w &Window) get_framebuffer_size() Size {
 	res := Size {0, 0}
 	C.glfwGetFramebufferSize(w.data, &res.width, &res.height)
 	return res


### PR DESCRIPTION
This PR remove excess `glfw.` in module glfw.

* In the module glfw, there is no need to use `glfw.`.
* This makes it look clearer.

**For example**
----
Before:
```v
pub fn (w mut glfw.Window) on_click(cb voidptr) {
	C.glfwSetMouseButtonCallback(w.data, cb)
}
```
Changed:
```v
pub fn (w mut Window) on_click(cb voidptr) {
	C.glfwSetMouseButtonCallback(w.data, cb)
}
```