### PR TITLE
strconv.ftoa: fix on ftoa string decimal approximation, 'nan' string fix

### DIFF
--- a/vlib/strconv/ftoa/f32_f64_to_string_test.v
+++ b/vlib/strconv/ftoa/f32_f64_to_string_test.v
@@ -165,4 +165,8 @@ fn test_float_to_str(){
 		//println(b)
 		assert b.len == exp + 2
 	}
+
+	// test rounding str conversion
+	assert f64_to_str(0.3456789123456, 4)=="3.4568e-01"
+	assert f32_to_str(0.345678, 3)=="3.457e-01"
 }

--- a/vlib/strconv/ftoa/utilities.v
+++ b/vlib/strconv/ftoa/utilities.v
@@ -233,7 +233,7 @@ pub fn f64_to_str_l(f f64) string {
 	s := f64_to_str(f,18)
 
 	// check for +inf -inf Nan
-	if s.len > 2 && (s[0] == `N` || s[1] == `i`) {
+	if s.len > 2 && (s[0] == `n` || s[1] == `i`) {
 		return s
 	} 
 


### PR DESCRIPTION
**What's inside**
- fix for digit cuts in itoa functions
- fix on a particular "nan" case string conversion
- added tests