### PR TITLE
readline: make some functions public

### DIFF
--- a/vlib/readline/readline_linux.v
+++ b/vlib/readline/readline_linux.v
@@ -39,9 +39,10 @@ fn C.tcsetattr() int
 //fn C.ioctl() int
 fn C.raise()
 
-// Toggle raw mode of the terminal by changing its attributes
-// Catches SIGUSER (CTRL+C) Signal to reset tty
-fn (r mut Readline) enable_raw_mode() {
+// Enable the raw mode of the terminal
+// In raw mode all keypresses are directly sent to the program and no interpretation is done
+// Catches the SIGUSER (CTRL+C) Signal
+pub fn (r mut Readline) enable_raw_mode() {
   if C.tcgetattr(0, &r.orig_termios) == -1 {
     r.is_tty = false
     r.is_raw = false
@@ -58,8 +59,9 @@ fn (r mut Readline) enable_raw_mode() {
   r.is_tty = true
 }
 
-// Not catching the SIGUSER (CTRL+C) Signal
-fn (r mut Readline) enable_raw_mode_nosig() {
+// Enable the raw mode of the terminal
+// Does not catch the SIGUSER (CTRL+C) Signal
+pub fn (r mut Readline) enable_raw_mode_nosig() {
   if ( C.tcgetattr(0, &r.orig_termios) == -1 ) {
     r.is_tty = false
     r.is_raw = false
@@ -76,16 +78,16 @@ fn (r mut Readline) enable_raw_mode_nosig() {
   r.is_tty = true
 }
 
-// Reset back the terminal to its default value
-fn (r mut Readline) disable_raw_mode() {
+// Disable the raw mode of the terminal
+pub fn (r mut Readline) disable_raw_mode() {
   if r.is_raw {
     C.tcsetattr(0, C.TCSADRAIN, &r.orig_termios)
     r.is_raw = false
   }
 }
 
-// Read single char
-fn (r Readline) read_char() int {
+// Read a single char
+pub fn (r Readline) read_char() int {
   return utf8_getchar()
 }
 


### PR DESCRIPTION
This makes some of `readline`'s functions public and improves their documentation. I would like to use them for direct keypress input (without the need of pressing Enter).