### PR TITLE
fix misuse of tos: tos => tos3

### DIFF
--- a/vlib/compiler/string_expression.v
+++ b/vlib/compiler/string_expression.v
@@ -31,7 +31,7 @@ fn (p mut Parser) string_expr() {
 			p.gen("'$str'")
 		}
 		else if p.is_js {
-			p.gen('tos("$f")')
+			p.gen('tos3("$f")')
 		}
 		else {
 			p.gen('tos3("$f")')


### PR DESCRIPTION
This PR is minor fix misuse of `tos`, `tos3` should be used here.