### PR TITLE
v2: fix Windows errors

### DIFF
--- a/vlib/builtin/builtin_windows.v
+++ b/vlib/builtin/builtin_windows.v
@@ -103,10 +103,10 @@ $if msvc {
 		else {
 			// https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes
 			cerr := int(C.GetLastError())
-			if (cerr == 87) {
+			if cerr == 87 {
 				println('SymFromAddr failure: $cerr = The parameter is incorrect)')
 			}
-			else if (cerr == 487) {
+			else if cerr == 487 {
 				// probably caused because the .pdb isn't in the executable folder
 				println('SymFromAddr failure: $cerr = Attempt to access invalid address (Verify that you have the .pdb file in the right folder.)')
 			}
@@ -137,4 +137,3 @@ fn print_backtrace_skipping_top_frames_nix(skipframes int) bool {
 pub fn println(s string) {
 	print('$s\n')
 }
-

--- a/vlib/builtin/cfns.v
+++ b/vlib/builtin/cfns.v
@@ -337,7 +337,7 @@ fn C.FindFirstFileW() voidptr
 fn C.FindFirstFile() voidptr
 
 
-fn C.FindNextFile() voidptr
+fn C.FindNextFile() int
 
 
 fn C.FindClose()

--- a/vlib/compiler/msvc.v
+++ b/vlib/compiler/msvc.v
@@ -49,7 +49,7 @@ fn find_windows_kit_internal(key RegKey, versions []string) ?string {
 				}
 				// We might need to manually null terminate this thing
 				// So just make sure that we do that
-				if (value[length - 1] != u16(0)) {
+				if value[length - 1] != u16(0) {
 					value[length] = u16(0)
 				}
 				return string_from_wide(value)

--- a/vlib/os/os_windows.v
+++ b/vlib/os/os_windows.v
@@ -106,7 +106,7 @@ pub fn ls(path string) ?[]string {
 	if first_filename != '.' && first_filename != '..' {
 		dir_files << first_filename
 	}
-	for C.FindNextFile(h_find_files, voidptr(&find_file_data)) {
+	for C.FindNextFile(h_find_files, voidptr(&find_file_data)) > 0 {
 		filename := string_from_wide(&u16(find_file_data.cFileName))
 		if filename != '.' && filename != '..' {
 			dir_files << filename.clone()

--- a/vlib/time/time_windows.v
+++ b/vlib/time/time_windows.v
@@ -12,8 +12,8 @@ struct C.tm {
 	tm_sec  int
 }
 
-fn C._mkgmtime(&tm) time_t
+fn C._mkgmtime(&C.tm) time_t
 
-fn make_unix_time(t tm) int {
+fn make_unix_time(t C.tm) int {
 	return int(C._mkgmtime(&t))
 }


### PR DESCRIPTION
The v2 self compilation is still failing for Windows because of issues in `term_windows.v`. Unfortunately, I don't know how to fix them.