### PR TITLE
v and v2: support @VEXE .

### DIFF
--- a/vlib/compiler/scanner.v
+++ b/vlib/compiler/scanner.v
@@ -4,6 +4,7 @@
 module compiler
 
 import os
+import v.pref
 
 const (
 	single_quote = `\'`
@@ -550,6 +551,7 @@ fn (s mut Scanner) scan() ScanRes {
 			s.pos++
 			name := s.ident_name()
 			// @FN => will be substituted with the name of the current V function
+			// @VEXE => will be substituted with the path to the V compiler
 			// @FILE => will be substituted with the path of the V source file
 			// @LINE => will be substituted with the V line number where it appears (as a string).
 			// @COLUMN => will be substituted with the column where it appears (as a string).
@@ -559,6 +561,10 @@ fn (s mut Scanner) scan() ScanRes {
 			// ... which is useful while debugging/tracing
 			if name == 'FN' {
 				return scan_res(.string, s.fn_name)
+			}
+			if name == 'VEXE' {
+				vexe := pref.vexe_path()
+				return scan_res(.string, cescaped_path( vexe ) )
 			}
 			if name == 'FILE' {
 				return scan_res(.string, cescaped_path(os.real_path(s.file_path)))

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -6,6 +6,7 @@ module scanner
 import (
 	os
 	v.token
+	v.pref
 )
 
 const (
@@ -560,6 +561,7 @@ pub fn (s mut Scanner) scan() token.Token {
 			s.pos++
 			name := s.ident_name()
 			// @FN => will be substituted with the name of the current V function
+			// @VEXE => will be substituted with the path to the V compiler
 			// @FILE => will be substituted with the path of the V source file
 			// @LINE => will be substituted with the V line number where it appears (as a string).
 			// @COLUMN => will be substituted with the column where it appears (as a string).
@@ -569,6 +571,10 @@ pub fn (s mut Scanner) scan() token.Token {
 			// ... which is useful while debugging/tracing
 			if name == 'FN' {
 				return s.scan_res(.string, s.fn_name)
+			}
+			if name == 'VEXE' {
+				vexe := pref.vexe_path()
+				return s.scan_res(.string, cescaped_path( vexe ) )
 			}
 			if name == 'FILE' {
 				return s.scan_res(.string, cescaped_path(os.real_path(s.file_path)))


### PR DESCRIPTION
This PR allows V programs to know the path to the V compiler
used to compile them, by embedding its path to the compiled binary.

That in turn allows programs to easily recompile themselves, if they
are determined to do it, and will be also useful when caching for v 
scripts is implemented.