### PR TITLE
all: remove redundant parentheses in `if` statements

### DIFF
--- a/cmd/tools/modules/vgit/vgit.v
+++ b/cmd/tools/modules/vgit/vgit.v
@@ -148,7 +148,7 @@ ${flag.SPACE}to script it/run it in a restrictive vps/docker.
 	context.show_help = fp.bool('help', `h`, false, 'Show this help screen.')
 	context.verbose = fp.bool('verbose', `v`, false, 'Be more verbose.')
 
-	if (context.show_help) {
+	if context.show_help {
 		println(fp.usage())
 		exit(0)
 	}

--- a/cmd/tools/vbin2v.v
+++ b/cmd/tools/vbin2v.v
@@ -72,7 +72,7 @@ fn main() {
 	context.show_help = fp.bool('help', `h`, false, 'Show this help screen.')
 	context.module_name = fp.string('module', `m`, 'binary', 'Name of the generated module.\n')
 	context.prefix = fp.string('prefix', `p`, '', 'A prefix put before each resource name.\n')
-	if (context.show_help) {
+	if context.show_help {
 		println(fp.usage())
 		exit(0)
 	}

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -469,7 +469,7 @@ fn get_module_meta_info(name string) ?Mod {
 			errors << 'Skipping module "$name", since its information is not in json format.'
 			continue
 		}
-		if ('' == mod.url || '' == mod.name) {
+		if '' == mod.url || '' == mod.name {
 			errors << 'Skipping module "$name", since it is missing name or url information.'
 			continue
 		}

--- a/examples/sdl/tvintris/tvintris.v
+++ b/examples/sdl/tvintris/tvintris.v
@@ -269,7 +269,7 @@ fn (sdlc mut SdlContext) set_sdl_context(w int, h int, title string) {
 	}
 	flags := C.IMG_INIT_PNG
 	imgres := img.img_init(flags)
-	if ((imgres & flags) != flags) {
+	if (imgres & flags) != flags {
 		println('error initializing image library.')
 	}
 	println('opening logo $VLogo')

--- a/vlib/bitfield/bitfield.v
+++ b/vlib/bitfield/bitfield.v
@@ -509,7 +509,7 @@ pub fn (instance BitField) rotate(offset int) BitField {
 	// removing extra rotations
 
 	mut offset_internal := offset % size
-	if (offset_internal == 0) {
+	if offset_internal == 0 {
 		// nothing to shift
 		return instance
 	}

--- a/vlib/builtin/bare/string_bare.v
+++ b/vlib/builtin/bare/string_bare.v
@@ -101,7 +101,7 @@ pub fn i64_tos(buf byteptr, len int, n0 i64, base int) string {
 		n /= base
 		if n < 1 {break}
 	}
-	if (neg) {
+	if neg {
 		if i < 0 { panic ("buffer to small") }
 		b[i--] = 45
 	}
@@ -132,4 +132,3 @@ pub fn (a string) clone() string {
 	b[a.len] = `\0`
 	return b
 }
-

--- a/vlib/clipboard/clipboard_linux.v
+++ b/vlib/clipboard/clipboard_linux.v
@@ -237,7 +237,7 @@ fn (cb mut Clipboard) start_listener(){
 	mut to_be_requested := Atom(0)
 	for {
 		XNextEvent(cb.display, &event)
-		if (event.@type == 0) {
+		if event.@type == 0 {
 			println("error")
            	continue
         }

--- a/vlib/darwin/darwin.v
+++ b/vlib/darwin/darwin.v
@@ -34,7 +34,7 @@ pub fn resource_path() string {
 
 	main_bundle := C.CFBundleGetMainBundle()
 	resource_dir_url := C.CFBundleCopyResourcesDirectoryURL(main_bundle)
-	if (isnil(resource_dir_url)) {
+	if isnil(resource_dir_url) {
 		panic('CFBundleCopyResourcesDirectoryURL failed')
 	}
 	buffer_size := 4096
@@ -48,4 +48,3 @@ pub fn resource_path() string {
 	C.CFRelease(resource_dir_url)
 	return result
 }
-

--- a/vlib/mysql/mysql.v
+++ b/vlib/mysql/mysql.v
@@ -64,7 +64,7 @@ pub fn (conn Connection) select_db(dbname string) ?bool {
 
 pub fn (conn Connection) change_user(username, password, dbname string) ?bool {
 	mut ret := true
-	if (dbname != '') {
+	if dbname != '' {
 		ret = mysql_change_user(conn.conn, username.str, password.str, dbname.str)
 	} else {
 		ret = mysql_change_user(conn.conn, username.str, password.str, 0)

--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -121,11 +121,11 @@ fn rw_callback(loop *C.picoev_loop, fd, events int, cb_arg voidptr) {
 		buf := (p.buf + fd * MAX_READ)
 		idx := p.idx[fd]
 		mut r := myread(fd, buf, MAX_READ, idx)
-		if (r == 0) {
+		if r == 0 {
 			close_conn(loop, fd)
 			p.idx[fd] = 0
 			return
-		} else if (r == -1) {
+		} else if r == -1 {
 			if errno == C.EAGAIN || errno == C.EWOULDBLOCK {
 				//
 			} else {

--- a/vlib/readline/readline_linux.v
+++ b/vlib/readline/readline_linux.v
@@ -62,7 +62,7 @@ pub fn (r mut Readline) enable_raw_mode() {
 // Enable the raw mode of the terminal
 // Does not catch the SIGUSER (CTRL+C) Signal
 pub fn (r mut Readline) enable_raw_mode_nosig() {
-  if ( C.tcgetattr(0, &r.orig_termios) == -1 ) {
+  if C.tcgetattr(0, &r.orig_termios) == -1 {
     r.is_tty = false
     r.is_raw = false
     return
@@ -319,7 +319,7 @@ fn calculate_screen_position(x_in int, y_in int, screen_columns int, char_count 
   out[0] = x
   out[1] = y
   for chars_remaining := char_count; chars_remaining > 0; {
-    chars_this_row := if ( (x + chars_remaining) < screen_columns) { chars_remaining } else { screen_columns - x }
+    chars_this_row := if (x + chars_remaining) < screen_columns { chars_remaining } else { screen_columns - x }
     out[0] = x + chars_this_row
     out[1] = y
     chars_remaining -= chars_this_row

--- a/vlib/strconv/atofq/atofq.v
+++ b/vlib/strconv/atofq/atofq.v
@@ -131,7 +131,7 @@ pub fn atof_quick(s string) f64 {
 		}
 		else {
 			if exp > neg_exp.len {
-				if (sign > 0) {
+				if sign > 0 {
 					f.u = DOUBLE_PLUS_ZERO
 				}
 				else {
@@ -140,7 +140,7 @@ pub fn atof_quick(s string) f64 {
 				return f.f
 			}
 			tmp_mul := Float64u{u: neg_exp[exp]}
-			
+
 			// C.printf("exp: %d  [0x%016llx] %f,",exp,pos_exp[exp],tmp_mul)
 			f.f = f.f * tmp_mul.f
 		}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -498,7 +498,7 @@ fn (f mut Fmt) expr(node ast.Expr) {
 				else {
 					f.write('else')
 				}
-				if (branch.stmts.len == 0) {
+				if branch.stmts.len == 0 {
 					f.writeln(' {}')
 				}
 				else {


### PR DESCRIPTION
Since using parentheses in `if` statements is an error in new v2 checker, they should be omitted.