### PR TITLE
use type `unresolved` for unresolved consts

### DIFF
--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -756,7 +756,7 @@ fn (p mut Parser) const_decl() {
 		if p.first_pass() {
 			p.table.register_const(name, typ, p.mod, is_pub)
 		}
-		// Check to see if this constant exists, and is void. If so, try and get the type again:
+		// Check to see if this constant exists, and is unresolved. If so, try and get the type again:
 		if my_const := p.v.table.find_const(name) {
 			if my_const.typ == 'unresolved' {
 				for i, v in p.v.table.consts {

--- a/vlib/compiler/aparser.v
+++ b/vlib/compiler/aparser.v
@@ -758,7 +758,7 @@ fn (p mut Parser) const_decl() {
 		}
 		// Check to see if this constant exists, and is void. If so, try and get the type again:
 		if my_const := p.v.table.find_const(name) {
-			if my_const.typ == 'void' {
+			if my_const.typ == 'unresolved' {
 				for i, v in p.v.table.consts {
 					if v.name == name {
 						p.v.table.consts[i].typ = typ

--- a/vlib/compiler/expression.v
+++ b/vlib/compiler/expression.v
@@ -457,7 +457,7 @@ fn (p mut Parser) name_expr() string {
 		// First pass, the function can be defined later.
 		if p.first_pass() {
 			p.next()
-			return 'void'
+			return 'unresolved'
 		}
 		// exhaused all options type,enum,const,mod,var,fn etc
 		// so show undefined error (also checks typos)
@@ -680,7 +680,7 @@ fn (p mut Parser) handle_operator(op string, typ string,cpostfix string, ph int,
 		p.cgen.set_placeholder(ph, '${typ}_${cpostfix}(')
 		p.gen(')')
 	}
-	else {
+	else if typ != 'unresolved' {
 		p.error('operator $op not defined on `$typ`')
 	}
 }

--- a/vlib/compiler/expression.v
+++ b/vlib/compiler/expression.v
@@ -454,11 +454,6 @@ fn (p mut Parser) name_expr() string {
 	// TODO: V script? Try os module.
 	// Function (not method, methods are handled in `.dot()`)
 	mut f := p.table.find_fn_is_script(name, p.v_script) or {
-		// First pass, the function can be defined later.
-		if p.first_pass() {
-			p.next()
-			return 'void'
-		}
 		// exhaused all options type,enum,const,mod,var,fn etc
 		// so show undefined error (also checks typos)
 		p.undefined_error(name, orig_name)

--- a/vlib/compiler/expression.v
+++ b/vlib/compiler/expression.v
@@ -454,6 +454,11 @@ fn (p mut Parser) name_expr() string {
 	// TODO: V script? Try os module.
 	// Function (not method, methods are handled in `.dot()`)
 	mut f := p.table.find_fn_is_script(name, p.v_script) or {
+		// First pass, the function can be defined later.
+		if p.first_pass() {
+			p.next()
+			return 'void'
+		}
 		// exhaused all options type,enum,const,mod,var,fn etc
 		// so show undefined error (also checks typos)
 		p.undefined_error(name, orig_name)

--- a/vlib/v/tests/const_test.v
+++ b/vlib/v/tests/const_test.v
@@ -2,6 +2,8 @@ pub const (
 	// c = a // TODO
 	a = b
 	b = 1
+	d = (e / 2) + 7
+	e = 9
 )
 
 struct Foo {
@@ -10,5 +12,6 @@ struct Foo {
 
 fn test_const() {
 	assert a == 1
+	assert d == 11
 	// assert c == 1 // TODO: This will not build yet
 }


### PR DESCRIPTION
#4154 is caused by current V setting the type of unresolved constants `void`
Type `void` has no rules for `+` and `-` operators and this raises the error.
This PR adds new type `unresolved` and exempts unresolved constants from operator validity checks.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
