### PR TITLE
time.format: optimize time format api

### DIFF
--- a/cmd/tools/fast/fast.v
+++ b/cmd/tools/fast/fast.v
@@ -49,7 +49,7 @@ fn main() {
 	// Place the new row on top
 	table =
 '<tr>
-	<td>${date.format_ymd_hm()}</td>
+	<td>${date.format(.hyphen, .hhmm24, .yyyymmdd)}</td>
 	<td><a target=_blank href="https://github.com/vlang/v/commit/$commit_hash">$commit_hash</a></td>
 	<td>$message</td>
 	<td>${diff1}ms</td>

--- a/cmd/tools/fast/fast.v
+++ b/cmd/tools/fast/fast.v
@@ -49,7 +49,7 @@ fn main() {
 	// Place the new row on top
 	table =
 '<tr>
-	<td>${date.format()}</td>
+	<td>${date.format_ymd_hm()}</td>
 	<td><a target=_blank href="https://github.com/vlang/v/commit/$commit_hash">$commit_hash</a></td>
 	<td>$message</td>
 	<td>${diff1}ms</td>

--- a/cmd/tools/gen_vc.v
+++ b/cmd/tools/gen_vc.v
@@ -271,8 +271,8 @@ fn (gen_vc mut GenVC) generate() {
 	last_commit_subject := git_log_v.find_between('Subject:', '\n').trim_space().replace('"', '\\"')
 
 	// log some info
-	gen_vc.logger.debug('last commit time ($git_repo_v): ' + last_commit_time_v.format_ymd_hms())
-	gen_vc.logger.debug('last commit time ($git_repo_vc): ' + last_commit_time_vc.format_ymd_hms())
+	gen_vc.logger.debug('last commit time ($git_repo_v): ' + last_commit_time_v.format(.hyphen, .hhmmss24, .yyyymmdd))
+	gen_vc.logger.debug('last commit time ($git_repo_vc): ' + last_commit_time_vc.format(.hyphen, .hhmmss24, .yyyymmdd))
 	gen_vc.logger.debug('last commit hash ($git_repo_v): $last_commit_hash_v')
 	gen_vc.logger.debug('last commit subject ($git_repo_v): $last_commit_subject')
 

--- a/cmd/tools/gen_vc.v
+++ b/cmd/tools/gen_vc.v
@@ -271,8 +271,8 @@ fn (gen_vc mut GenVC) generate() {
 	last_commit_subject := git_log_v.find_between('Subject:', '\n').trim_space().replace('"', '\\"')
 
 	// log some info
-	gen_vc.logger.debug('last commit time ($git_repo_v): ' + last_commit_time_v.format_ss())
-	gen_vc.logger.debug('last commit time ($git_repo_vc): ' + last_commit_time_vc.format_ss())
+	gen_vc.logger.debug('last commit time ($git_repo_v): ' + last_commit_time_v.format_ymd_hms())
+	gen_vc.logger.debug('last commit time ($git_repo_vc): ' + last_commit_time_vc.format_ymd_hms())
 	gen_vc.logger.debug('last commit hash ($git_repo_v): $last_commit_hash_v')
 	gen_vc.logger.debug('last commit subject ($git_repo_v): $last_commit_subject')
 

--- a/examples/vweb/vweb_assets/main.v
+++ b/examples/vweb/vweb_assets/main.v
@@ -49,5 +49,5 @@ fn (app mut App) text() {
 }
 
 fn (app mut App) time() {
-	app.vweb.text(time.now().format_ymd_hm())
+	app.vweb.text(time.now().format(.hyphen, .hhmm24, .yyyymmdd))
 }

--- a/examples/vweb/vweb_assets/main.v
+++ b/examples/vweb/vweb_assets/main.v
@@ -49,5 +49,5 @@ fn (app mut App) text() {
 }
 
 fn (app mut App) time() {
-	app.vweb.text(time.now().format())
+	app.vweb.text(time.now().format_ymd_hm())
 }

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -91,7 +91,7 @@ pub fn (l mut Log) close() {
 }
 
 fn (l mut Log) log_file(s string, level LogLevel) {
-	timestamp := time.now().format_ss()
+	timestamp := time.now().format_ymd_hms()
 	e := tag(level)
 	l.ofile.writeln('$timestamp [$e] $s')
 }
@@ -99,7 +99,7 @@ fn (l mut Log) log_file(s string, level LogLevel) {
 fn (l &Log) log_cli(s string, level LogLevel) {
 	f := tag(level)
 	t := time.now()
-	println('[$f ${t.format_ss()}] $s')
+	println('[$f ${t.format_ymd_hms()}] $s')
 }
 
 fn (l mut Log) send_output(s &string, level LogLevel) {

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -91,7 +91,7 @@ pub fn (l mut Log) close() {
 }
 
 fn (l mut Log) log_file(s string, level LogLevel) {
-	timestamp := time.now().format_ymd_hms()
+	timestamp := time.now().format(.hyphen, .hhmmss24, .yyyymmdd)
 	e := tag(level)
 	l.ofile.writeln('$timestamp [$e] $s')
 }
@@ -99,7 +99,7 @@ fn (l mut Log) log_file(s string, level LogLevel) {
 fn (l &Log) log_cli(s string, level LogLevel) {
 	f := tag(level)
 	t := time.now()
-	println('[$f ${t.format_ymd_hms()}] $s')
+	println('[$f ${t.format(.hyphen, .hhmmss24, .yyyymmdd)}] $s')
 }
 
 fn (l mut Log) send_output(s &string, level LogLevel) {

--- a/vlib/time/format.v
+++ b/vlib/time/format.v
@@ -3,82 +3,82 @@
 // that can be found in the LICENSE file.
 module time
 
-// format returns a date string in "YYYY-MM-DD HH:MM" format (24h).
-pub fn (t Time) format() string {
-	return t.get_fmt_str(.hyphen, .hhmm24, .yyyymmdd)
+// format_ymd_hm returns a date string in "YYYY-MM-DD HH:MM" format (24h).
+pub fn (t Time) format_ymd_hm() string {
+	return t.format(.hyphen, .hhmm24, .yyyymmdd)
 }
 
-// format_ss returns a date string in "YYYY-MM-DD HH:MM:SS" format (24h).
-pub fn (t Time) format_ss() string {
-	return t.get_fmt_str(.hyphen, .hhmmss24, .yyyymmdd)
+// format_ymd_hms returns a date string in "YYYY-MM-DD HH:MM:SS" format (24h).
+pub fn (t Time) format_ymd_hms() string {
+	return t.format(.hyphen, .hhmmss24, .yyyymmdd)
 }
 
-// hhmm returns a date string in "HH:MM" format (24h).
-pub fn (t Time) hhmm() string {
-	return t.get_fmt_time_str(.hhmm24)
+// format_hm returns a date string in "HH:MM" format (24h).
+pub fn (t Time) format_hm() string {
+	return t.format_time(.hhmm24)
 }
 
-// hhmmss returns a date string in "HH:MM:SS" format (24h).
-pub fn (t Time) hhmmss() string {
-	return t.get_fmt_time_str(.hhmmss24)
+// format_hms returns a date string in "HH:MM:SS" format (24h).
+pub fn (t Time) format_hms() string {
+	return t.format_time(.hhmmss24)
 }
 
-// hhmm12 returns a date string in "HH:MM" format (12h).
-pub fn (t Time) hhmm12() string {
-	return t.get_fmt_time_str(.hhmm12)
+// format_hm12 returns a date string in "HH:MM" format (12h).
+pub fn (t Time) format_hm12() string {
+	return t.format_time(.hhmm12)
 }
 
-// ymmdd returns a date string in "YYYY-MM-DD" format.
-pub fn (t Time) ymmdd() string {
-	return t.get_fmt_date_str(.hyphen, .yyyymmdd)
+// format_ymd returns a date string in "YYYY-MM-DD" format.
+pub fn (t Time) format_ymd() string {
+	return t.format_date(.hyphen, .yyyymmdd)
 }
 
-// ddmmy returns a date string in "DD.MM.YYYY" format.
-pub fn (t Time) ddmmy() string {
-	return t.get_fmt_date_str(.dot, .ddmmyyyy)
+// format_dmy returns a date string in "DD.MM.YYYY" format.
+pub fn (t Time) format_dmy() string {
+	return t.format_date(.dot, .ddmmyyyy)
 }
 
-// md returns a date string in "MMM D" format.
-pub fn (t Time) md() string {
-	return t.get_fmt_date_str(.space, .mmmd)
+// format_md returns a date string in "MMM D" format.
+pub fn (t Time) format_md() string {
+	return t.format_date(.space, .mmmd)
 }
 
-// clean returns a date string in a following format:
+// format_clean returns a date string in a following format:
 //  - a date string in "HH:MM" format (24h) for current day
 //  - a date string in "MMM D HH:MM" format (24h) for date of current year
 //  - a date string formatted with format function for other dates
-pub fn (t Time) clean() string {
+pub fn (t Time) format_clean() string {
 	now := time.now()
 	// Today
 	if t.month == now.month && t.year == now.year && t.day == now.day {
-		return t.get_fmt_time_str(.hhmm24)
+		return t.format_time(.hhmm24)
 	}
 	// This year
 	if t.year == now.year {
-		return t.get_fmt_str(.space, .hhmm24, .mmmd)
+		return t.format(.space, .hhmm24, .mmmd)
 	}
-	return t.format()
+	return t.format_ymd_hm()
 }
 
-// clean12 returns a date string in a following format:
+// format_clean12 returns a date string in a following format:
 //  - a date string in "HH:MM" format (12h) for current day
 //  - a date string in "MMM D HH:MM" format (12h) for date of current year
 //  - a date string formatted with format function for other dates
-pub fn (t Time) clean12() string {
+pub fn (t Time) format_clean12() string {
 	now := time.now()
 	// Today
 	if t.month == now.month && t.year == now.year && t.day == now.day {
-		return t.get_fmt_time_str(.hhmm12)
+		return t.format_time(.hhmm12)
 	}
 	// This year
 	if t.year == now.year {
-		return t.get_fmt_str(.space, .hhmm12, .mmmd)
+		return t.format(.space, .hhmm12, .mmmd)
 	}
-	return t.format()
+	return t.format_ymd_hm()
 }
 
-// get_fmt_time_str returns a date string with specified FormatTime type.
-pub fn (t Time) get_fmt_time_str(fmt_time FormatTime) string {
+// format_time returns a date string with specified FormatTime type.
+pub fn (t Time) format_time(fmt_time FormatTime) string {
 	if fmt_time == .no_time {
 		return ''
 	}
@@ -102,9 +102,9 @@ pub fn (t Time) get_fmt_time_str(fmt_time FormatTime) string {
 	}
 }
 
-// get_fmt_time_str returns a date string with specified
+// format_date returns a date string with specified
 // FormatDelimiter and FormatDate type.
-pub fn (t Time) get_fmt_date_str(fmt_dlmtr FormatDelimiter, fmt_date FormatDate) string {
+pub fn (t Time) format_date(fmt_dlmtr FormatDelimiter, fmt_date FormatDate) string {
 	if fmt_date == .no_date {
 		return ''
 	}
@@ -155,9 +155,9 @@ mut 	res := match fmt_date {
 	return res
 }
 
-// get_fmt_str returns a date string with specified FormatDelimiter,
+// format returns a date string with specified FormatDelimiter,
 // FormatTime type, and FormatDate type.
-pub fn (t Time) get_fmt_str(fmt_dlmtr FormatDelimiter, fmt_time FormatTime, fmt_date FormatDate) string {
+pub fn (t Time) format(fmt_dlmtr FormatDelimiter, fmt_time FormatTime, fmt_date FormatDate) string {
 	if fmt_date == .no_date {
 		if fmt_time == .no_time {
 			// saving one function call although it's checked in
@@ -165,15 +165,15 @@ pub fn (t Time) get_fmt_str(fmt_dlmtr FormatDelimiter, fmt_time FormatTime, fmt_
 			return ''
 		}
 		else {
-			return t.get_fmt_time_str(fmt_time)
+			return t.format_time(fmt_time)
 		}
 	}
 	else {
 		if fmt_time != .no_time {
-			return t.get_fmt_date_str(fmt_dlmtr, fmt_date) + ' ' + t.get_fmt_time_str(fmt_time)
+			return t.format_date(fmt_dlmtr, fmt_date) + ' ' + t.format_time(fmt_time)
 		}
 		else {
-			return t.get_fmt_date_str(fmt_dlmtr, fmt_date)
+			return t.format_date(fmt_dlmtr, fmt_date)
 		}
 	}
 }

--- a/vlib/time/format.v
+++ b/vlib/time/format.v
@@ -3,46 +3,6 @@
 // that can be found in the LICENSE file.
 module time
 
-// format_ymd_hm returns a date string in "YYYY-MM-DD HH:MM" format (24h).
-pub fn (t Time) format_ymd_hm() string {
-	return t.format(.hyphen, .hhmm24, .yyyymmdd)
-}
-
-// format_ymd_hms returns a date string in "YYYY-MM-DD HH:MM:SS" format (24h).
-pub fn (t Time) format_ymd_hms() string {
-	return t.format(.hyphen, .hhmmss24, .yyyymmdd)
-}
-
-// format_hm returns a date string in "HH:MM" format (24h).
-pub fn (t Time) format_hm() string {
-	return t.format_time(.hhmm24)
-}
-
-// format_hms returns a date string in "HH:MM:SS" format (24h).
-pub fn (t Time) format_hms() string {
-	return t.format_time(.hhmmss24)
-}
-
-// format_hm12 returns a date string in "HH:MM" format (12h).
-pub fn (t Time) format_hm12() string {
-	return t.format_time(.hhmm12)
-}
-
-// format_ymd returns a date string in "YYYY-MM-DD" format.
-pub fn (t Time) format_ymd() string {
-	return t.format_date(.hyphen, .yyyymmdd)
-}
-
-// format_dmy returns a date string in "DD.MM.YYYY" format.
-pub fn (t Time) format_dmy() string {
-	return t.format_date(.dot, .ddmmyyyy)
-}
-
-// format_md returns a date string in "MMM D" format.
-pub fn (t Time) format_md() string {
-	return t.format_date(.space, .mmmd)
-}
-
 // format_clean returns a date string in a following format:
 //  - a date string in "HH:MM" format (24h) for current day
 //  - a date string in "MMM D HH:MM" format (24h) for date of current year
@@ -57,7 +17,7 @@ pub fn (t Time) format_clean() string {
 	if t.year == now.year {
 		return t.format(.space, .hhmm24, .mmmd)
 	}
-	return t.format_ymd_hm()
+	return t.format(.hyphen, .hhmm24, .yyyymmdd)
 }
 
 // format_clean12 returns a date string in a following format:
@@ -74,7 +34,7 @@ pub fn (t Time) format_clean12() string {
 	if t.year == now.year {
 		return t.format(.space, .hhmm12, .mmmd)
 	}
-	return t.format_ymd_hm()
+	return t.format(.hyphen, .hhmm24, .yyyymmdd)
 }
 
 // format_time returns a date string with specified FormatTime type.

--- a/vlib/time/format.v
+++ b/vlib/time/format.v
@@ -70,44 +70,44 @@ pub fn (t Time) format_date(fmt_dlmtr FormatDelimiter, fmt_date FormatDate) stri
 	}
 	month := '${t.smonth()}'
 	year := t.year.str()[2..]
-mut 	res := match fmt_date {
-		.ddmmyy{
+	mut res := match fmt_date {
+		.ddmmyy {
 			'${t.day:02d}|${t.month:02d}|$year'
 		}
-		.ddmmyyyy{
+		.ddmmyyyy {
 			'${t.day:02d}|${t.month:02d}|${t.year}'
 		}
-		.mmddyy{
+		.mmddyy {
 			'${t.month:02d}|${t.day:02d}|$year'
 		}
-		.mmddyyyy{
+		.mmddyyyy {
 			'${t.month:02d}|${t.day:02d}|${t.year}'
 		}
-		.mmmd{
+		.mmmd {
 			'$month|${t.day}'
 		}
-		.mmmdd{
+		.mmmdd {
 			'$month|${t.day:02d}'
 		}
-		.mmmddyyyy{
+		.mmmddyyyy {
 			'$month|${t.day:02d}|${t.year}'
 		}
-		.yyyymmdd{
+		.yyyymmdd {
 			'${t.year}|${t.month:02d}|${t.day:02d}'
 		}
 		else {
 			'unknown enumeration $fmt_date'}}
 	res = res.replace('|', match fmt_dlmtr {
-		.dot{
+		.dot {
 			'.'
 		}
-		.hyphen{
+		.hyphen {
 			'-'
 		}
-		.slash{
+		.slash {
 			'/'
 		}
-		.space{
+		.space {
 			' '
 		}
 		else {

--- a/vlib/time/format_test.v
+++ b/vlib/time/format_test.v
@@ -12,38 +12,8 @@ const (
 	}
 )
 
-fn test_now_format_ymd_hm() {
-	t := time.now()
-	u := t.unix
-	assert t.format_ymd_hm() == time.unix(u).format_ymd_hm()
-}
-
 fn test_format_ymd_hm() {
 	assert '11.07.1980 21:23' == time_to_test.format(.dot, .hhmm24, .ddmmyyyy)
-}
-
-fn test_format_hm() {
-	assert '21:23' == time_to_test.format_hm()
-}
-
-fn test_format_hm12() {
-	assert '9:23 p.m.' == time_to_test.format_hm12()
-}
-
-fn test_format_hms() {
-	assert '21:23:42' == time_to_test.format_hms()
-}
-
-fn test_format_ymd() {
-	assert '1980-07-11' == time_to_test.format_ymd()
-}
-
-fn test_format_dmy() {
-	assert '11.07.1980' == time_to_test.format_dmy()
-}
-
-fn test_format_md() {
-	assert 'Jul 11' == time_to_test.format_md()
 }
 
 fn test_format_time() {

--- a/vlib/time/format_test.v
+++ b/vlib/time/format_test.v
@@ -12,73 +12,73 @@ const (
 	}
 )
 
-fn test_now_format() {
+fn test_now_format_ymd_hm() {
 	t := time.now()
 	u := t.unix
-	assert t.format() == time.unix(u).format()
+	assert t.format_ymd_hm() == time.unix(u).format_ymd_hm()
+}
+
+fn test_format_ymd_hm() {
+	assert '11.07.1980 21:23' == time_to_test.format(.dot, .hhmm24, .ddmmyyyy)
+}
+
+fn test_format_hm() {
+	assert '21:23' == time_to_test.format_hm()
+}
+
+fn test_format_hm12() {
+	assert '9:23 p.m.' == time_to_test.format_hm12()
+}
+
+fn test_format_hms() {
+	assert '21:23:42' == time_to_test.format_hms()
+}
+
+fn test_format_ymd() {
+	assert '1980-07-11' == time_to_test.format_ymd()
+}
+
+fn test_format_dmy() {
+	assert '11.07.1980' == time_to_test.format_dmy()
+}
+
+fn test_format_md() {
+	assert 'Jul 11' == time_to_test.format_md()
+}
+
+fn test_format_time() {
+	assert '21:23:42' == time_to_test.format_time(.hhmmss24)
+	assert '21:23' == time_to_test.format_time(.hhmm24)
+	assert '9:23:42 p.m.' == time_to_test.format_time(.hhmmss12)
+	assert '9:23 p.m.' == time_to_test.format_time(.hhmm12)
+}
+
+fn test_format_date() {
+	assert '11.07.1980' == time_to_test.format_date(.dot, .ddmmyyyy)
+	assert '11/07/1980' == time_to_test.format_date(.slash, .ddmmyyyy)
+	assert '11-07-1980' == time_to_test.format_date(.hyphen, .ddmmyyyy)
+	assert '11 07 1980' == time_to_test.format_date(.space, .ddmmyyyy)
+	assert '07.11.1980' == time_to_test.format_date(.dot, .mmddyyyy)
+	assert '07/11/1980' == time_to_test.format_date(.slash, .mmddyyyy)
+	assert '07-11-1980' == time_to_test.format_date(.hyphen, .mmddyyyy)
+	assert '07 11 1980' == time_to_test.format_date(.space, .mmddyyyy)
+	assert '11.07.80' == time_to_test.format_date(.dot, .ddmmyy)
+	assert '11/07/80' == time_to_test.format_date(.slash, .ddmmyy)
+	assert '11-07-80' == time_to_test.format_date(.hyphen, .ddmmyy)
+	assert '11 07 80' == time_to_test.format_date(.space, .ddmmyy)
+	assert '07.11.80' == time_to_test.format_date(.dot, .mmddyy)
+	assert '07/11/80' == time_to_test.format_date(.slash, .mmddyy)
+	assert '07-11-80' == time_to_test.format_date(.hyphen, .mmddyy)
+	assert '07 11 80' == time_to_test.format_date(.space, .mmddyy)
+	assert 'Jul 11' == time_to_test.format_date(.space, .mmmd)
+	assert 'Jul 11' == time_to_test.format_date(.space, .mmmdd)
+	assert 'Jul 11 1980' == time_to_test.format_date(.space, .mmmddyyyy)
+	assert '1980-07-11' == time_to_test.format_date(.hyphen, .yyyymmdd)
 }
 
 fn test_format() {
-	assert '11.07.1980 21:23' == time_to_test.get_fmt_str(.dot, .hhmm24, .ddmmyyyy)
-}
-
-fn test_hhmm() {
-	assert '21:23' == time_to_test.hhmm()
-}
-
-fn test_hhmm12() {
-	assert '9:23 p.m.' == time_to_test.hhmm12()
-}
-
-fn test_hhmmss() {
-	assert '21:23:42' == time_to_test.hhmmss()
-}
-
-fn test_ymmdd() {
-	assert '1980-07-11' == time_to_test.ymmdd()
-}
-
-fn test_ddmmy() {
-	assert '11.07.1980' == time_to_test.ddmmy()
-}
-
-fn test_md() {
-	assert 'Jul 11' == time_to_test.md()
-}
-
-fn test_get_fmt_time_str() {
-	assert '21:23:42' == time_to_test.get_fmt_time_str(.hhmmss24)
-	assert '21:23' == time_to_test.get_fmt_time_str(.hhmm24)
-	assert '9:23:42 p.m.' == time_to_test.get_fmt_time_str(.hhmmss12)
-	assert '9:23 p.m.' == time_to_test.get_fmt_time_str(.hhmm12)
-}
-
-fn test_get_fmt_date_str() {
-	assert '11.07.1980' == time_to_test.get_fmt_date_str(.dot, .ddmmyyyy)
-	assert '11/07/1980' == time_to_test.get_fmt_date_str(.slash, .ddmmyyyy)
-	assert '11-07-1980' == time_to_test.get_fmt_date_str(.hyphen, .ddmmyyyy)
-	assert '11 07 1980' == time_to_test.get_fmt_date_str(.space, .ddmmyyyy)
-	assert '07.11.1980' == time_to_test.get_fmt_date_str(.dot, .mmddyyyy)
-	assert '07/11/1980' == time_to_test.get_fmt_date_str(.slash, .mmddyyyy)
-	assert '07-11-1980' == time_to_test.get_fmt_date_str(.hyphen, .mmddyyyy)
-	assert '07 11 1980' == time_to_test.get_fmt_date_str(.space, .mmddyyyy)
-	assert '11.07.80' == time_to_test.get_fmt_date_str(.dot, .ddmmyy)
-	assert '11/07/80' == time_to_test.get_fmt_date_str(.slash, .ddmmyy)
-	assert '11-07-80' == time_to_test.get_fmt_date_str(.hyphen, .ddmmyy)
-	assert '11 07 80' == time_to_test.get_fmt_date_str(.space, .ddmmyy)
-	assert '07.11.80' == time_to_test.get_fmt_date_str(.dot, .mmddyy)
-	assert '07/11/80' == time_to_test.get_fmt_date_str(.slash, .mmddyy)
-	assert '07-11-80' == time_to_test.get_fmt_date_str(.hyphen, .mmddyy)
-	assert '07 11 80' == time_to_test.get_fmt_date_str(.space, .mmddyy)
-	assert 'Jul 11' == time_to_test.get_fmt_date_str(.space, .mmmd)
-	assert 'Jul 11' == time_to_test.get_fmt_date_str(.space, .mmmdd)
-	assert 'Jul 11 1980' == time_to_test.get_fmt_date_str(.space, .mmmddyyyy)
-	assert '1980-07-11' == time_to_test.get_fmt_date_str(.hyphen, .yyyymmdd)
-}
-
-fn test_get_fmt_str() {
 	// Since get_fmt_time_str and get_fmt_date_str do have comprehensive
 	// tests I don't want to exaggerate here with all possible
 	// combinations.
-	assert '11.07.1980 21:23:42' == time_to_test.get_fmt_str(.dot, .hhmmss24, .ddmmyyyy)
+	assert '11.07.1980 21:23:42' == time_to_test.format(.dot, .hhmmss24, .ddmmyyyy)
 }

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -162,7 +162,7 @@ pub fn (t Time) relative() string {
 	if secs > 3600 * 24 * 10000 {
 		return ''
 	}
-	return t.md()
+	return t.format_md()
 }
 
 // day_of_week returns the current day of a given year, month, and day,
@@ -250,7 +250,7 @@ pub fn days_in_month(month, year int) ?int {
 pub fn (t Time) str() string {
 	// TODO Define common default format for
 	// `str` and `parse` and use it in both ways
-	return t.format_ss()
+	return t.format_ymd_hms()
 }
 
 fn convert_ctime(t C.tm) Time {

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -162,7 +162,7 @@ pub fn (t Time) relative() string {
 	if secs > 3600 * 24 * 10000 {
 		return ''
 	}
-	return t.format_md()
+	return t.format_date(.space, .mmmd)
 }
 
 // day_of_week returns the current day of a given year, month, and day,
@@ -250,7 +250,7 @@ pub fn days_in_month(month, year int) ?int {
 pub fn (t Time) str() string {
 	// TODO Define common default format for
 	// `str` and `parse` and use it in both ways
-	return t.format_ymd_hms()
+	return t.format(.hyphen, .hhmmss24, .yyyymmdd)
 }
 
 fn convert_ctime(t C.tm) Time {

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -84,7 +84,7 @@ fn test_unix() {
 }
 
 fn test_format_ss() {
-	assert '11.07.1980 21:23:42' == time_to_test.get_fmt_str(.dot, .hhmmss24, .ddmmyyyy)
+	assert '11.07.1980 21:23:42' == time_to_test.format(.dot, .hhmmss24, .ddmmyyyy)
 }
 
 fn test_smonth() {


### PR DESCRIPTION
This PR optimize time format api.
```v
fn (t Time) format(fmt_dlmtr FormatDelimiter, fmt_time FormatTime, fmt_date FormatDate) string

fn (t Time) format_date(fmt_dlmtr FormatDelimiter, fmt_date FormatDate) string
fn (t Time) format_time(fmt_time FormatTime) string

fn (t Time) format_ymd() string
fn (t Time) format_dmy() string

fn (t Time) format_ymd_hm() string
fn (t Time) format_ymd_hms() string

fn (t Time) format_hm() string
fn (t Time) format_hm12() string
fn (t Time) format_hms() string
fn (t Time) format_md() string

fn (t Time) format_clean() string
fn (t Time) format_clean12() string
```

**Change:**
```v
get_fmt_str => format
get_fmt_date_str  =>  format_date
get_fmt_time_str  =>  format_time

format   =>  format_ymd_hm
format_ss  => format_ymd_hms
hhmm  => format_hm
hhmmss  => format_hms
hhmm12  => format_hm12
ymmdd   =>  format_ymd
ddmmy   =>  format_dmy
md   =>  format_md
clean   =>  format_clean
clean12   =>  format_clean12
```
