### PR TITLE
v2: support -stats for _test.v files.

### DIFF
--- a/cmd/tools/preludes/tests_with_stats.v
+++ b/cmd/tools/preludes/tests_with_stats.v
@@ -85,20 +85,8 @@ fn (b mut BenchedTests) end_testing() {
 
 // ///////////////////////////////////////////////////////////////////
 fn nasserts(n int) string {
-	if n == 0 {
-		return '${n:2d} asserts | '
-	}
 	if n == 1 {
-		return '${n:2d} assert  | '
-	}
-	if n < 10 {
-		return '${n:2d} asserts | '
-	}
-	if n < 100 {
-		return '${n:3d} asserts | '
-	}
-	if n < 1000 {
-		return '${n:4d} asserts | '
+		return '${n:5d} assert  | '
 	}
 	return '${n:5d} asserts | '
 }

--- a/vlib/benchmark/benchmark.v
+++ b/vlib/benchmark/benchmark.v
@@ -197,7 +197,7 @@ pub fn (b &Benchmark) total_duration() i64 {
 fn (b &Benchmark) tdiff_in_ms(s string, sticks i64, eticks i64) string {
 	if b.verbose {
 		tdiff := (eticks - sticks)
-		return '${tdiff:6lld} ms $s'
+		return '${tdiff:6d} ms $s'
 	}
 	return s
 }

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -50,7 +50,7 @@ pub fn (b mut Builder) gen_c(v_files []string) string {
 		exit(1)
 	}
 	// println('starting cgen...')
-	res := gen.cgen(b.parsed_files, b.table)
+	res := gen.cgen(b.parsed_files, b.table, b.pref)
 	t3 := time.ticks()
 	gen_time := t3 - t2
 	println('C GEN: ${gen_time}ms')

--- a/vlib/v/parser/parser_test.v
+++ b/vlib/v/parser/parser_test.v
@@ -5,7 +5,7 @@ import (
 	v.gen
 	v.table
 	v.checker
-	v.eval
+	//	v.eval
 	v.pref
 	term
 )
@@ -77,10 +77,11 @@ x := 10
 8+4
 '
 	table := &table.Table{}
-	prog := parse_file(s, table, .skip_comments, &pref.Preferences{})
+	vpref := &pref.Preferences{}
+	prog := parse_file(s, table, .skip_comments, vpref)
 	mut checker := checker.new_checker(table)
 	checker.check(prog)
-	res := gen.cgen([prog], table)
+	res := gen.cgen([prog], table, vpref)
 	println(res)
 }
 
@@ -97,7 +98,8 @@ fn test_one() {
 	]
 	expected := 'int a = 10;int b = -a;int c = 20;'
 	table := table.new_table()
-	mut scope := &ast.Scope{
+	vpref := &pref.Preferences{}
+	scope := &ast.Scope{
 		start_pos: 0
 		parent: 0
 	}
@@ -111,7 +113,7 @@ fn test_one() {
 	}
 	mut checker := checker.new_checker(table)
 	checker.check(program)
-	res := gen.cgen([program], table).replace('\n', '').trim_space().after('#endif')
+	res := gen.cgen([program], table, vpref).replace('\n', '').trim_space().after('#endif')
 	println(res)
 	ok := expected == res
 	println(res)
@@ -193,8 +195,9 @@ fn test_parse_expr() {
 	]
 	mut e := []ast.Stmt
 	table := table.new_table()
+	vpref := &pref.Preferences{}
 	mut checker := checker.new_checker(table)
-	mut scope := &ast.Scope{
+	scope := &ast.Scope{
 		start_pos: 0
 		parent: 0
 	}
@@ -207,7 +210,7 @@ fn test_parse_expr() {
 		scope: scope
 	}
 	checker.check(program)
-	res := gen.cgen([program], table).after('#endif')
+	res := gen.cgen([program], table, vpref).after('#endif')
 	println('========')
 	println(res)
 	println('========')


### PR DESCRIPTION
With this PR, you can run for example this:
`./v -stats -b v2 vlib/v/fmt/fmt_test.v`
... just as well as this:
`./v -stats       vlib/v/fmt/fmt_test.v`

(edit: probably `vlib/time/time_test.v` is a better example, since `fmt_test.v` has only one `test_` function in it, which loops over the fmt test files)