### PR TITLE
v1&v2: more precise support for internal module tests.

### DIFF
--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -743,10 +743,11 @@ pub fn (v &V) get_user_files() []string {
 	is_test := dir.ends_with('_test.v')
 	mut is_internal_module_test := false
 	if is_test {
-		tcontent := os.read_file(dir)or{
+		mut tcontent := os.read_file(dir)or{
 			panic('$dir does not exist')
 		}
-		if tcontent.contains('module ') && !tcontent.contains('module main') {
+		tcontent = tcontent.trim_space()
+		if tcontent.starts_with('module ') && !tcontent.starts_with('module main') {
 			is_internal_module_test = true
 		}
 	}

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -35,7 +35,7 @@ enum Pass {
 
 pub struct V {
 pub mut:
-	mod_file_cacher     &ModFileCacher // used during lookup for v.mod to support @VROOT
+	mod_file_cacher     &builder.ModFileCacher // used during lookup for v.mod to support @VROOT
 	out_name_c          string // name of the temporary C file
 	files               []string // all V files that need to be parsed and compiled
 	compiled_dir        string // contains os.real_path() of the dir of the final file beeing compiled, or the dir itself when doing `v .`
@@ -68,7 +68,7 @@ pub fn new_v(pref &pref.Preferences) &V {
 	compiled_dir:=if os.is_dir(rdir) { rdir } else { os.dir(rdir) }
 
 	return &V{
-		mod_file_cacher: new_mod_file_cacher()
+		mod_file_cacher: builder.new_mod_file_cacher()
 		compiled_dir:compiled_dir// if os.is_dir(rdir) { rdir } else { os.dir(rdir) }
 		table: new_table(pref.obfuscate)
 		out_name_c: out_name_c

--- a/vlib/compiler/main.v
+++ b/vlib/compiler/main.v
@@ -743,12 +743,21 @@ pub fn (v &V) get_user_files() []string {
 	is_test := dir.ends_with('_test.v')
 	mut is_internal_module_test := false
 	if is_test {
-		mut tcontent := os.read_file(dir)or{
+		tcontent := os.read_file(dir)or{
 			panic('$dir does not exist')
 		}
-		tcontent = tcontent.trim_space()
-		if tcontent.starts_with('module ') && !tcontent.starts_with('module main') {
-			is_internal_module_test = true
+		slines := tcontent.trim_space().split_into_lines()
+		for sline in slines {
+			line := sline.trim_space()
+			if line.len > 2 {
+				if line[0] == `/` && line[1] == `/` {
+					continue
+				}
+				if line.starts_with('module ') && !line.starts_with('module main') {
+					is_internal_module_test = true
+					break
+				}
+			}
 		}
 	}
 	if is_internal_module_test {

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -14,6 +14,7 @@ import (
 
 pub struct Builder {
 pub:
+	mod_file_cacher     &ModFileCacher // used during lookup for v.mod to support @VROOT
 	pref                &pref.Preferences
 	table               &table.Table
 	checker             checker.Checker
@@ -28,6 +29,7 @@ mut:
 pub fn new_builder(pref &pref.Preferences) Builder {
 	table := table.new_table()
 	return Builder{
+		mod_file_cacher: new_mod_file_cacher()
 		pref: pref
 		table: table
 		checker: checker.new_checker(table)

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -162,16 +162,24 @@ pub fn (b &Builder) v_files_from_dir(dir string) []string {
 		if file.ends_with('_nix.v') && b.os == .windows {
 			continue
 		}
+		if file.ends_with('_android.v') && b.pref.os != .android {
+			continue
+		}
+		if file.ends_with('_freebsd.v') && b.pref.os != .freebsd {
+			continue
+		}
+		if file.ends_with('_solaris.v') && b.pref.os != .solaris {
+			continue
+		}
 		if file.ends_with('_js.v') && b.os != .js {
 			continue
 		}
 		if file.ends_with('_c.v') && b.os == .js {
 			continue
 		}
-		/*
-		if v.compile_defines_all.len > 0 && file.contains('_d_') {
+		if b.pref.compile_defines_all.len > 0 && file.contains('_d_') {
 			mut allowed := false
-			for cdefine in v.compile_defines {
+			for cdefine in b.pref.compile_defines {
 				file_postfix := '_d_${cdefine}.v'
 				if file.ends_with(file_postfix) {
 					allowed = true
@@ -182,8 +190,6 @@ pub fn (b &Builder) v_files_from_dir(dir string) []string {
 				continue
 			}
 		}
-		*/
-
 		res << os.join_path(dir,file)
 	}
 	return res

--- a/vlib/v/builder/vmod.v
+++ b/vlib/v/builder/vmod.v
@@ -1,4 +1,4 @@
-module compiler
+module builder
 
 import os
 
@@ -9,20 +9,21 @@ import os
 // ModFileCacher.get(folder) works in such a way, that given this tree:
 // examples/hanoi.v
 // vlib/v.mod
-// vlib/compiler/tests/project_with_c_code/mod1/v.mod
-// vlib/compiler/tests/project_with_c_code/mod1/wrapper.v
+// vlib/v/tests/project_with_c_code/mod1/v.mod
+// vlib/v/tests/project_with_c_code/mod1/wrapper.v
 // -----------------
 // ModFileCacher.get('examples')
 // => ModFileAndFolder{'', 'examples'}
-// ModFileCacher.get('vlib/compiler/tests')
+// ModFileCacher.get('vlib/v/tests')
 // => ModFileAndFolder{'vlib/v.mod', 'vlib'}
-// ModFileCacher.get('vlib/compiler')
+// ModFileCacher.get('vlib/v')
 // => ModFileAndFolder{'vlib/v.mod', 'vlib'}
-// ModFileCacher.get('vlib/project_with_c_code/mod1')
-// => ModFileAndFolder{'vlib/project_with_c_code/mod1/v.mod', 'vlib/project_with_c_code/mod1'}
+// ModFileCacher.get('vlib/v/test/project_with_c_code/mod1')
+// => ModFileAndFolder{'vlib/v/test/project_with_c_code/mod1/v.mod', 'vlib/v/test/project_with_c_code/mod1'}
 
 
-struct ModFileAndFolder {
+pub struct ModFileAndFolder {
+pub:
 	// vmod_file contains the full path of the found 'v.mod' file, or ''
 	// if no 'v.mod' file was found in file_path_dir, or in its parent folders.
 	vmod_file string
@@ -33,18 +34,18 @@ struct ModFileAndFolder {
 	vmod_folder string
 }
 
-struct ModFileCacher {
+pub struct ModFileCacher {
 mut:
 	cache map[string]ModFileAndFolder
 	// folder_files caches os.ls(key)
 	folder_files map[string][]string
 }
 
-fn new_mod_file_cacher() &ModFileCacher {
+pub fn new_mod_file_cacher() &ModFileCacher {
 	return &ModFileCacher{}
 }
 
-fn (mcache &ModFileCacher) dump() {
+pub fn (mcache &ModFileCacher) dump() {
 	$if debug {
 		eprintln('ModFileCacher DUMP:')
 		eprintln('	 ModFileCacher.cache:')
@@ -58,7 +59,7 @@ fn (mcache &ModFileCacher) dump() {
 	}
 }
 
-fn (mcache mut ModFileCacher) get(mfolder string) ModFileAndFolder {
+pub fn (mcache mut ModFileCacher) get(mfolder string) ModFileAndFolder {
 	if mfolder in mcache.cache {
 		return mcache.cache[ mfolder ]
 	}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2641,14 +2641,30 @@ fn (g &Gen) get_all_test_function_names() []string {
 	for _, f in g.table.fns {
 		if f.name == 'testsuite_begin' {
 			tsuite_begin = f.name
+			continue
 		}
 		if f.name == 'testsuite_end' {
 			tsuite_end = f.name
-		}
-		if !f.name.starts_with('test_') {
 			continue
 		}
-		tfuncs << f.name
+		if f.name.starts_with('test_') {
+			tfuncs << f.name
+			continue
+		}
+		// What follows is for internal module tests
+		// (they are part of a V module, NOT in main)
+		if f.name.contains('.test_') {
+			tfuncs << f.name
+			continue
+		}
+		if f.name.ends_with('.testsuite_begin') {
+			tsuite_begin = f.name
+			continue
+		}
+		if f.name.ends_with('.testsuite_end') {
+			tsuite_end = f.name
+			continue
+		}
 	}
 	mut all_tfuncs := []string
 	if tsuite_begin.len > 0 {
@@ -2658,7 +2674,7 @@ fn (g &Gen) get_all_test_function_names() []string {
 	if tsuite_end.len > 0 {
 		all_tfuncs << tsuite_end
 	}
-	return all_tfuncs
+	return all_tfuncs.map( it.replace('.', '__') )
 }
 
 fn (g &Gen) is_importing_os() bool {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2674,7 +2674,11 @@ fn (g &Gen) get_all_test_function_names() []string {
 	if tsuite_end.len > 0 {
 		all_tfuncs << tsuite_end
 	}
-	return all_tfuncs.map( it.replace('.', '__') )
+	mut all_tfuncs_c := []string
+	for f in all_tfuncs {
+		all_tfuncs_c << f.replace('.', '__')
+	}
+	return all_tfuncs_c
 }
 
 fn (g &Gen) is_importing_os() bool {

--- a/vlib/v/scanner/scanner_test.v
+++ b/vlib/v/scanner/scanner_test.v
@@ -3,9 +3,7 @@
 // that can be found in the LICENSE file.
 module scanner
 
-import (
-	v.token
-)
+import v.token
 
 fn test_scan() {
 	text := 'println(2 + 3)'
@@ -33,11 +31,11 @@ fn test_scan() {
 	c = 1000000
 	assert c == 1000000
 	// test float conversion and reading
-	d := f64(23000000e-3)
+	d := 23000000e-3
 	assert int(d) == 23000
-	mut e := f64(1.2E3) * f64(-1e-1)
+	mut e := 1.2E3 * -1e-1
 	assert e == -120.0
-	e = f64(1.2E3) * f64(1e-1)
+	e = 1.2E3 * 1e-1
 	assert e == 120.0
 	assert 1.23e+10 == 1.23e10
 	assert 1.23e+10 == 1.23e0010


### PR DESCRIPTION
For example `v -stats -b v2 vlib/v/tests/modules/simplemodule/importing_test.v` now works.

This PR also contains support for skipping _android.v, _freebsd.v,
_solaris.v, and _d_custom.v files in v2.