### PR TITLE
token.v: optimize vlib/v/token/token.v

### DIFF
--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -121,13 +121,15 @@ pub enum Kind {
 	key_static
 	key_unsafe
 	keyword_end
+
+	_end_
 }
 
 const (
 	assign_tokens = [Kind.assign, .plus_assign, .minus_assign, .mult_assign,
 	.div_assign, .xor_assign, .mod_assign, .or_assign, .and_assign,
 	.right_shift_assign, .left_shift_assign]
-	nr_tokens = 141
+	nr_tokens = int(Kind._end_)
 )
 // build_keys genereates a map with keywords' string values:
 // Keywords['return'] == .key_return


### PR DESCRIPTION
This PR optimize vlib/v/token/token.v.

**Before**
```v
const  nr_tokens = 141
```

**Change**
```v
pub enum Kind {
        ...
	_end_
}

const nr_tokens  = int(Kind._end_)
```

This avoids allocating too much useless memory and increases efficiency, and avoid cross-border problems.