### PR TITLE
cstrings_test.v: fix vlib/v/tests/cstrings_test.v

### DIFF
--- a/vlib/v/tests/cstrings_test.v
+++ b/vlib/v/tests/cstrings_test.v
@@ -1,4 +1,4 @@
-fn C.strlen() int
+// fn C.strlen() int
 
 fn test_cstring() {
 	w := c'world'


### PR DESCRIPTION
This PR fix vlib/v/tests/cstrings_test.v.

C.strlen is already define, so don't define it in vlib/v/tests/cstrings_test.v.