### PR TITLE
cgen: vcleanup call fix

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2683,7 +2683,9 @@ pub fn (g mut Gen) write_tests_main() {
 		g.writeln('\tBenchedTests_end_testing(&bt);')
 	}
 	g.writeln('')
-	g.writeln('\t_vcleanup();')
+	if g.autofree {
+		g.writeln('\t_vcleanup();')
+	}
 	g.writeln('\treturn g_test_fails > 0;')
 	g.writeln('}')
 }


### PR DESCRIPTION
There was no check around a call to _vcleanup.