### PR TITLE
v2: fix version

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -98,7 +98,7 @@ pub fn cgen(files []ast.File, table &table.Table, pref &pref.Preferences) string
 	if g.is_test {
 		g.write_tests_main()
 	}
-	return g.typedefs.str() + g.definitions.str() + g.out.str()
+	return c_commit_hash_default + g.typedefs.str() + g.definitions.str() + g.out.str()
 }
 
 pub fn (g mut Gen) init() {

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -1,8 +1,13 @@
 module gen
 
 const (
-	c_common_macros = '
+	c_commit_hash_default = '
+#ifndef V_COMMIT_HASH
+#define V_COMMIT_HASH "$vhash()"
+#endif
 
+'
+	c_common_macros = '
 #define EMPTY_STRUCT_DECLARATION
 #define EMPTY_STRUCT_INITIALIZATION 0
 // Due to a tcc bug, the length of an array needs to be specified, but GCC crashes if it is...
@@ -39,8 +44,6 @@ const (
 #define V64_PRINTFORMAT "0x%llx"
 #endif
 #endif
-
-#define V_COMMIT_HASH "TODO"
 
 '
 	c_headers = '


### PR DESCRIPTION
This PR fixes `v version` (the proper one will be put in by cmd/tools/gen_vc.v).