### PR TITLE
v2: stage 2 for enhancing 'v version' with the current git commit hash.

### DIFF
--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -20,12 +20,7 @@ pub fn vhash() string {
 pub fn full_hash() string {
 	build_hash := vhash()
 	current_hash := githash(false)
-	final_hash := if build_hash == current_hash {
-		build_hash
-	} else {
-		'${build_hash}.${current_hash}'
-	}
-	return final_hash
+	return '${build_hash}.${current_hash}'
 }
 
 // full_v_version() returns the full version of the V compiler

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -75,10 +75,8 @@ pub fn githash(should_get_from_filesystem bool) string {
 		}
 		break
 	}
-	// TODO: use C.V_CURRENT_COMMIT_HASH at stage 2, after v.c is regenerated
-	// mut buf := [50]byte
-	// buf[0] = 0
-	// C.snprintf(charptr(buf), 50, '%s', C.V_CURRENT_COMMIT_HASH)
-	// return tos_clone(buf)
-	return 'unknown'
+	mut buf := [50]byte
+	buf[0] = 0
+	C.snprintf(charptr(buf), 50, '%s', C.V_CURRENT_COMMIT_HASH)
+	return tos_clone(buf)
 }


### PR DESCRIPTION
After this PR:

```shell
0[16:21:41] /v/nv LINUX $ make selfcompile
./v -csource keep -cg -o v cmd/v
0[16:21:46] /v/nv LINUX $ ./v version
V 0.1.26 1178bfa.1c0734d
0[16:21:48] /v/nv LINUX $ git rev-parse --short @
1c0734d6
0[16:22:00] /v/nv LINUX $
```