### PR TITLE
msvc: add workaround to fix backtrace

### DIFF
--- a/vlib/builtin/builtin_windows.v
+++ b/vlib/builtin/builtin_windows.v
@@ -84,12 +84,14 @@ $if msvc {
 	frames := int( C.CaptureStackBackTrace(skipframes + 1, 100, backtraces, 0) )
 	for i:=0; i < frames; i++ {
 		// fugly pointer arithmetics follows ...
-		s := voidptr( u64(backtraces) + u64(i*sizeof(voidptr)) )
-		symfa_ok := C.SymFromAddr( handle, s, &offset, si )
+		// FIXME Remove temp variable
+		tmp := u64(backtraces) + u64(i * sizeof(voidptr))
+		s := &voidptr(tmp)
+		symfa_ok := C.SymFromAddr( handle, *s, &offset, si )
 		if symfa_ok == 1 {
 			nframe := frames - i - 1
 			mut lineinfo := ''
-			symglfa_ok := C.SymGetLineFromAddr64(handle, s, &offset, &sline64)
+			symglfa_ok := C.SymGetLineFromAddr64(handle, *s, &offset, &sline64)
 			if symglfa_ok == 1 {
 				lineinfo = ' ${sline64.f_file_name}:${sline64.f_line_number}'
 			}


### PR DESCRIPTION
Fixed an issue introduced in #4196.

```sh
# v with this PR applied
$ v run test4.v  
V panic: this should show a backtrace
7 : v_panic                     1689897672:1702
6 : wmain                       1689897672:4574
5 : invoke_main                 1689897672:91
4 : __scrt_common_main_seh      1689897672:288
3 : __scrt_common_main          1689897672:331
2 : wmainCRTStartup             1689897672:17
1 : BaseThreadInitThunk         ?? : address= 573566912
0 : RtlUserThreadStart          ?? : address= 573566912
```