### PR TITLE
parser: uniform bool type variable name

### DIFF
--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -33,7 +33,7 @@ fn (p mut Parser) comp_if() ast.CompIf {
 			mut stack := 1
 			for {
 				if p.tok.kind == .key_return {
-					p.returns = true
+					p.is_returns = true
 				}
 				if p.tok.kind == .lcbr {
 					stack++

--- a/vlib/v/parser/module.v
+++ b/vlib/v/parser/module.v
@@ -11,7 +11,7 @@ fn (p &Parser) prepend_mod(name string) string {
 	if p.expr_mod != '' {
 		return p.expr_mod + '.' + name
 	}
-	if p.builtin_mod || p.mod == 'main' {
+	if p.is_builtin_mod || p.mod == 'main' {
 		return name
 	}
 	return '${p.mod}.$name'


### PR DESCRIPTION
This PR uniform bool type variable name in parser.v.
```v
struct Parser {
	scanner        &scanner.Scanner
	file_name      string
mut:
	tok            token.Token
	peek_tok       token.Token
	// vars []string
	table          &table.Table
	is_c           bool
	// prefix_parse_fns []PrefixParseFn
	is_inside_if   bool
	pref           &pref.Preferences // Preferences shared from V struct
	is_builtin_mod bool
	mod            string
	attr           string
	expr_mod       string
	scope          &ast.Scope
	imports        map[string]string
	ast_imports    []ast.Import
	is_amp         bool
	is_returns     bool
}
```