### PR TITLE
doc: fix doc command error running in vroot

### DIFF
--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -56,11 +56,6 @@ fn main() {
 		launch_tool(prefs2.is_verbose, 'v' + command)
 		return
 	}
-	if command in ['run', 'build'] || command.ends_with('.v') || os.exists(command) {
-		arg := join_flags_and_argument()
-		compile.compile(command, arg)
-		return
-	}
 	match command {
 		'help' {
 			invoke_help_and_exit(args)
@@ -99,6 +94,11 @@ fn main() {
 			return
 		}
 		else {}
+	}
+	if command in ['run', 'build'] || command.ends_with('.v') || os.exists(command) {
+		arg := join_flags_and_argument()
+		compile.compile(command, arg)
+		return
 	}
 	eprintln('v $command: unknown command\nRun "v help" for usage.')
 	exit(1)


### PR DESCRIPTION
This PR fix doc command error running in vroot.

**Problem**
```
C:\Users\yuyi9\v>v doc math
V error: Expected only one file/directory to compile.
Did you perhaps put flags after the file/directory?
```
**Cause**
```v
if command in ['run', 'build'] || command.ends_with('.v') || os.exists(command) {
```
When run in vroot, os.exists('doc') is true, so judged to be a compilation command.

**Solution**
Put the compilation command process behind it.