### PR TITLE
cgen: add `builtin.init` call inside of `_vinit`

### DIFF
--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -6,15 +6,6 @@ module builtin
 __global g_m2_buf byteptr
 __global g_m2_ptr byteptr
 
-fn init() {
-	$if windows {
-		if is_atty(1) > 0 {
-			C.SetConsoleMode(C.GetStdHandle(C.STD_OUTPUT_HANDLE), C.ENABLE_PROCESSED_OUTPUT | 0x0004) // ENABLE_VIRTUAL_TERMINAL_PROCESSING
-			C.setbuf(C.stdout, 0)
-		}
-	}
-}
-
 pub fn exit(code int) {
 	C.exit(code)
 }

--- a/vlib/builtin/builtin_nix.v
+++ b/vlib/builtin/builtin_nix.v
@@ -21,6 +21,10 @@ const (
 fn C.puts(charptr)
 */
 
+fn init() {
+	// Do nothing
+}
+
 pub fn println(s string) {
 	//  TODO: a syscall sys_write on linux works, except for the v repl.
 	//  Probably it is a stdio buffering issue. Needs more testing...

--- a/vlib/builtin/builtin_windows.v
+++ b/vlib/builtin/builtin_windows.v
@@ -58,6 +58,13 @@ const (
 	SYMOPT_DEBUG = 0x80000000
 )
 
+fn init() {
+	if is_atty(1) > 0 {
+		C.SetConsoleMode(C.GetStdHandle(C.STD_OUTPUT_HANDLE), C.ENABLE_PROCESSED_OUTPUT | 0x0004) // ENABLE_VIRTUAL_TERMINAL_PROCESSING
+		C.setbuf(C.stdout, 0)
+	}
+}
+
 fn print_backtrace_skipping_top_frames_msvc(skipframes int) bool {
 
 $if msvc {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2024,6 +2024,7 @@ fn verror(s string) {
 
 fn (g mut Gen) write_init_function() {
 	g.writeln('void _vinit() {')
+	g.writeln('init(); // builtin.init')
 	g.writeln(g.inits.str())
 	g.writeln('}')
 	if g.autofree {


### PR DESCRIPTION
This PR brings back colors in a terminal in Windows.