### PR TITLE
tests: update assert output

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -156,7 +156,7 @@ fn worker_trunner(p mut sync.PoolProcessor, idx int, thread_id int) voidptr {
 			ts.failed = true
 			ts.benchmark.fail()
 			tls_bench.fail()
-			eprintln(tls_bench.step_message_fail('${relative_file}\n`$file`\n (\n$r.output\n)'))
+			eprintln(tls_bench.step_message_fail('${relative_file}\n$r.output\n'))
 		}
 		else {
 			ts.benchmark.ok()

--- a/cmd/tools/preludes/tests_assertions.v
+++ b/cmd/tools/preludes/tests_assertions.v
@@ -21,11 +21,7 @@ fn cb_assertion_failed(filename string, line int, sourceline string, funcname st
 	}
 	final_filename := if use_relative_paths { filename } else { os.real_path(filename) }
 	final_funcname := funcname.replace('main__', '').replace('__', '.')
-	mut fail_message := 'FAILED assertion'
-	if color_on {
-		fail_message = term.bold(term.red(fail_message))
-	}
-	eprintln('$final_filename:$line: $fail_message')
+	eprintln('File    : $final_filename:$line')
 	eprintln('Function: $final_funcname')
 	eprintln('Source  : $sourceline')
 }

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -557,16 +557,20 @@ fn (g mut Gen) gen_assert_stmt(a ast.AssertStmt) {
 	g.writeln('// assert')
 	g.write('if( ')
 	g.expr(a.expr)
-	s_assertion := a.expr.str().replace('"', "\'")
 	g.write(' )')
+	s_assertion := a.expr.str().replace('"', "\'")
+	mut mod_path := g.file.path
+	$if windows {
+		mod_path = g.file.path.replace('\\', '\\\\')
+	}
 	if g.is_test {
 		g.writeln('{')
 		g.writeln('	g_test_oks++;')
-		g.writeln('	cb_assertion_ok( _STR("${g.file.path}"), ${a.pos.line_nr}, _STR("assert ${s_assertion}"), _STR("${g.fn_decl.name}()") );')
+		g.writeln('	cb_assertion_ok( _STR("${mod_path}"), ${a.pos.line_nr}, _STR("assert ${s_assertion}"), _STR("${g.fn_decl.name}()") );')
 		// g.writeln('	println(_STR("OK ${g.file.path}:${a.pos.line_nr}: fn ${g.fn_decl.name}(): assert $s_assertion"));')
 		g.writeln('}else{')
 		g.writeln('	g_test_fails++;')
-		g.writeln('	cb_assertion_failed( _STR("${g.file.path}"), ${a.pos.line_nr}, _STR("assert ${s_assertion}"), _STR("${g.fn_decl.name}()") );')
+		g.writeln('	cb_assertion_failed( _STR("${mod_path}"), ${a.pos.line_nr}, _STR("assert ${s_assertion}"), _STR("${g.fn_decl.name}()") );')
 		g.writeln('	exit(1);')
 		g.writeln('	// TODO')
 		g.writeln('	// Maybe print all vars in a test function if it fails?')
@@ -574,7 +578,7 @@ fn (g mut Gen) gen_assert_stmt(a ast.AssertStmt) {
 		return
 	}
 	g.writeln('{}else{')
-	g.writeln('	eprintln(_STR("${g.file.path}:${a.pos.line_nr}: FAIL: fn ${g.fn_decl.name}(): assert $s_assertion"));')
+	g.writeln('	println(_STR("${mod_path}:${a.pos.line_nr}: FAIL: fn ${g.fn_decl.name}(): assert $s_assertion"));')
 	g.writeln('	exit(1);')
 	g.writeln('}')
 }


### PR DESCRIPTION
## Changelog

- Fixed displaying a path to a test module
A `\` character should be escaped before using
```
FAIL   1140 ms [ 4/11] vlib\builtin\float_test.v
`C:\Users\esprit\Development\v\vlib\builtin\float_test.v`
 (
C:UsersespritDevelopment

                        liuiltin
                                loat_test.v:6: FAILED assertion
```
- Updated assertion output to display a path to a module one time
This is mostly visual change. Let me know if it's should be reverted.
The new output looks like:
```
FAIL    985 ms [ 4/11] vlib\builtin\float_test.v
File    : C:\Users\esprit\Development\v\vlib\builtin\float_test.v:6
Function: test_float_decl()
Source  : assert ([unhandled expr type v.ast.TypeOf] == 'f64')
```