### PR TITLE
string: fix trim_right, added tests

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -857,7 +857,7 @@ pub fn (s string) trim_left(cutset string) string {
 	}
 	cs_arr := cutset.bytes()
 	mut pos := 0
-	for pos <= s.len && s[pos] in cs_arr {
+	for pos < s.len && s[pos] in cs_arr {
 		pos++
 	}
 	return s.right(pos)
@@ -869,10 +869,10 @@ pub fn (s string) trim_right(cutset string) string {
 	}
 	cs_arr := cutset.bytes()
 	mut pos := s.len - 1
-	for pos >= -1 && s[pos] in cs_arr {
+	for pos >= 0 && s[pos] in cs_arr {
 		pos--
 	}
-	return s.left(pos + 1)
+	return if pos < 0 { '' } else { s.left(pos + 1) }
 }
 
 // fn print_cur_thread() {

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -438,6 +438,7 @@ fn test_trim_left() {
 	// test cutset
 	s = 'banana'
 	assert s.trim_left('ba') == 'nana'
+	assert s.trim_left('ban') == ''
 }
 
 fn test_trim_right() {
@@ -448,6 +449,7 @@ fn test_trim_right() {
 	// test cutset
 	s = 'banana'
 	assert s.trim_right('na') == 'b'
+	assert s.trim_right('ban') == ''
 }
 
 fn test_all_before() {


### PR DESCRIPTION
This fixes an issue when `trim_right` trims the entire string. This happens with `os.get_line` on an empty input. Without this fix, the entire string is trimmed and we end up indexing `str` with -1.
This also fixes `trim_left` so it doesn't index at the length of the array.

Essentially, fixing off-by-1 errors.