### PR TITLE
term: fix `get_terminal_size` on Windows

### DIFF
--- a/vlib/term/term_windows.v
+++ b/vlib/term/term_windows.v
@@ -2,29 +2,32 @@ module term
 
 import os
 
-struct C.SMALL_RECT {
+struct Coord {
+	x i16
+	y i16
+}
+
+struct SmallRect {
 	Left   i16
 	Top    i16
 	Right  i16
 	Bottom i16
 }
 
-struct C.CONSOLE_SCREEN_BUFFER_INFO {
-	dwSize              C.COORD
-	dwCursorPosition    C.COORD
-	wAttributes         C.COORD
-	srWindow            C.SMALL_RECT
-	dwMaximumWindowSize C.COORD
+struct ConsoleScreenBufferInfo {
+	dwSize              Coord
+	dwCursorPosition    Coord
+	wAttributes         u16
+	srWindow            SmallRect
+	dwMaximumWindowSize Coord
 }
 
-fn C.GetConsoleScreenBufferInfo(handle os.HANDLE, info &CONSOLE_SCREEN_BUFFER_INFO) bool
+fn C.GetConsoleScreenBufferInfo(handle os.HANDLE, info &ConsoleScreenBufferInfo) bool
 
 // get_terminal_size returns a number of colums and rows of terminal window.
 pub fn get_terminal_size() (int, int) {
-	return 80, 40 // QTODO
-	/*
 	if is_atty(1) > 0 && os.getenv('TERM') != 'dumb' {
-		info := CONSOLE_SCREEN_BUFFER_INFO{}
+		info := ConsoleScreenBufferInfo{}
 
 		if C.GetConsoleScreenBufferInfo(C.GetStdHandle(C.STD_OUTPUT_HANDLE), &info) {
 			columns := int(info.srWindow.Right - info.srWindow.Left + 1)
@@ -34,5 +37,4 @@ pub fn get_terminal_size() (int, int) {
 	}
 
 	return default_columns_size, default_rows_size
-	*/
 }


### PR DESCRIPTION
I went with a way where structs are declared directly (like it's done in `os_windows`).