### PR TITLE
cmd/v: Fix argument parsing

### DIFF
--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -121,10 +121,18 @@ fn parse_args(args []string) (&pref.Preferences, string) {
 				res.out_name  = cmdline.option(args, '-o', '')
 				i++
 			}
-			'-csource', '-backend' {
-				i++ // TODO
-			}
 			else {
+				mut should_continue := false
+				for flag_with_param in list_of_flags_with_param {
+					if '-$flag_with_param' == arg {
+						should_continue = true
+						i++
+						break
+					}
+				}
+				if should_continue {
+					continue
+				}
 				if !arg.starts_with('-') && command == '' {
 					command = arg
 				}


### PR DESCRIPTION
The current argument parsing disregards the list of flags that have
arguments behind.
This PR looks through that list to make sure it is checked.
This allows flags like `-os` to work.