### PR TITLE
fmt: process C function declarations correctly

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -25,6 +25,9 @@ pub fn (node &FnDecl) str(t &table.Table) string {
 		receiver = '($node.receiver.name $m$name) '
 	}
 	name := node.name.after('.')
+	if node.is_c {
+		name = 'C.$name'
+	}
 	f.write('fn ${receiver}${name}(')
 	for i, arg in node.args {
 		// skip receiver

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -173,9 +173,13 @@ fn (f mut Fmt) stmt(node ast.Stmt) {
 			s := it.str(f.table)
 			// f.write(it.str(f.table))
 			f.write(s.replace(f.cur_mod + '.', '')) // `Expr` instead of `ast.Expr` in mod ast
-			f.writeln(' {')
-			f.stmts(it.stmts)
-			f.writeln('}\n')
+			if !it.is_c {
+				f.writeln(' {')
+				f.stmts(it.stmts)
+				f.writeln('}\n')
+			} else {
+				f.writeln('\n')
+			}
 		}
 		ast.ForInStmt {
 			f.write('for ')

--- a/vlib/v/fmt/fmt_keep_test.v
+++ b/vlib/v/fmt/fmt_keep_test.v
@@ -2,6 +2,7 @@ import (
 	os
 	term
 	benchmark
+	v.ast
 	v.fmt
 	v.parser
 	v.table
@@ -44,7 +45,7 @@ fn test_fmt() {
 			continue
 		}
 		table := table.new_table()
-		file_ast := parser.parse_file(ipath, table, .parse_comments, &pref.Preferences{})
+		file_ast := parser.parse_file(ipath, table, .parse_comments, &pref.Preferences{}, &ast.Scope{parent: 0})
 		result_ocontent := fmt.fmt(file_ast, table)
 		if expected_ocontent != result_ocontent {
 			fmt_bench.fail()

--- a/vlib/v/fmt/tests/functions_expected.vv
+++ b/vlib/v/fmt/tests/functions_expected.vv
@@ -1,3 +1,5 @@
+fn C.func(arg int) int
+
 fn fn_variadic(arg int, args ...string) {
 	println('Do nothing')
 }

--- a/vlib/v/fmt/tests/functions_input.vv
+++ b/vlib/v/fmt/tests/functions_input.vv
@@ -1,3 +1,5 @@
+fn C.func(arg int) int
+
 fn fn_variadic(arg int, args... string) {
 	println('Do nothing')
 }


### PR DESCRIPTION
```
$ v test vlib\v\fmt
----------------------------------- Testing... ---------------------------------

OK     1859 ms [1/2] vlib\v\fmt\fmt_keep_test.v
OK     2266 ms [2/2] vlib\v\fmt\fmt_test.v
--------------------------------------------------------------------------------

    4125 ms <=== total time spent running V _test.v files
                 ok, fail, skip, total =     2,     0,     0,     2
```

Also added a missing argument to `parser.parse_file` file in `fmt_keep_test.v`.