### PR TITLE
vlib: add inode/mode information functionality

### DIFF
--- a/vlib/os/inode.v
+++ b/vlib/os/inode.v
@@ -1,0 +1,90 @@
+// Copyright (c) 2019-2020 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module os
+
+enum FileType {
+	regular
+	directory
+	character_device
+	block_device
+	fifo
+	symbolic_link
+	socket
+}
+
+struct FilePermission {
+	read bool
+	write bool
+	execute bool
+}
+
+struct FileMode {
+	typ FileType
+	owner FilePermission
+	group FilePermission
+	others FilePermission
+}
+
+pub fn inode(path string) FileMode {
+	mut attr := C.stat{}
+	C.stat(path.str, &attr)
+
+	mut typ := FileType.regular
+	if attr.st_mode & C.S_IFMT == C.S_IFDIR {
+		typ = .directory
+	}
+	$if !windows {
+		if attr.st_mode & C.S_IFMT == C.S_IFCHR {
+			typ = .character_device
+		} else if attr.st_mode & C.S_IFMT == C.S_IFBLK {
+			typ = .block_device
+		} else if attr.st_mode & C.S_IFMT == C.S_IFIFO {
+			typ = .fifo
+		} else if attr.st_mode & C.S_IFMT == C.S_IFLNK {
+			typ = .symbolic_link
+		} else if attr.st_mode & C.S_IFMT == C.S_IFSOCK {
+			typ = .socket
+		}
+	}
+
+	$if windows {
+		return FileMode{
+			typ: typ
+			owner: FilePermission{
+				read: bool(attr.st_mode & C.S_IREAD)
+				write: bool(attr.st_mode & C.S_IWRITE)
+				execute: bool(attr.st_mode & C.S_IEXEC)
+			}
+			group: FilePermission{
+				read: bool(attr.st_mode & C.S_IREAD)
+				write: bool(attr.st_mode & C.S_IWRITE)
+				execute: bool(attr.st_mode & C.S_IEXEC)
+			}
+			others: FilePermission{
+				read: bool(attr.st_mode & C.S_IREAD)
+				write: bool(attr.st_mode & C.S_IWRITE)
+				execute: bool(attr.st_mode & C.S_IEXEC)
+			}
+		}
+	} $else {
+		return FileMode{
+			typ: typ
+			owner: FilePermission{
+				read: bool(attr.st_mode & C.S_IRUSR)
+				write: bool(attr.st_mode & C.S_IWUSR)
+				execute: bool(attr.st_mode & C.S_IXUSR)
+			}
+			group: FilePermission{
+				read: bool(attr.st_mode & C.S_IRGRP)
+				write: bool(attr.st_mode & C.S_IWGRP)
+				execute: bool(attr.st_mode & C.S_IXGRP)
+			}
+			others: FilePermission{
+				read: bool(attr.st_mode & C.S_IROTH)
+				write: bool(attr.st_mode & C.S_IWOTH)
+				execute: bool(attr.st_mode & C.S_IXOTH)
+			}
+		}
+	}
+}

--- a/vlib/os/inode.v
+++ b/vlib/os/inode.v
@@ -26,6 +26,8 @@ struct FileMode {
 	others FilePermission
 }
 
+// inode returns the mode of the file/inode containing inode type and permission information
+// it supports windows for regular files but it doesn't matter if you use owner, group or others when checking permissions on windows
 pub fn inode(path string) FileMode {
 	mut attr := C.stat{}
 	C.stat(path.str, &attr)

--- a/vlib/os/inode_test.v
+++ b/vlib/os/inode_test.v
@@ -1,0 +1,43 @@
+import os
+
+const (
+	// tfolder will contain all the temporary files/subfolders made by
+	// the different tests. It would be removed in testsuite_end(), so
+	// individual os tests do not need to clean up after themselves.
+	tfolder = os.join_path(os.temp_dir(), 'v', 'tests', 'inode_test')
+)
+
+fn testsuite_begin() {
+	eprintln('testsuite_begin, tfolder = $tfolder')
+	os.rmdir_all(tfolder)
+	assert !os.is_dir(tfolder)
+	os.mkdir_all(tfolder)
+	os.chdir(tfolder)
+	assert os.is_dir(tfolder)
+}
+
+fn testsuite_end() {
+	os.chdir(os.wd_at_startup)
+	os.rmdir_all(tfolder)
+	assert !os.is_dir(tfolder)
+}
+
+fn test_inode_file_type() {
+	filename := './test1.txt'
+	mut file := os.open_file(filename, 'w', 0o600)
+	file.close()
+	mode := os.inode(filename)
+	os.rm(filename)
+	assert mode.typ == .regular
+}
+
+fn test_inode_file_owner_permission() {
+	filename := './test2.txt'
+	mut file := os.open_file(filename, 'w', 0o600)
+	file.close()
+	mode := os.inode(filename)
+	os.rm(filename)
+	assert mode.owner.read
+	assert mode.owner.write
+	assert !mode.owner.execute
+}


### PR DESCRIPTION
I wanted the functionality to check the file mode (if it is readble/writeable).

because `os.v` is already very bloated i created a new file called `inode.v`... inode is a file in linux. but i also add windows support for the C.stat function.

The next thing what i want to do with it is to find out if v needs to be run with `sudo` rights. To find that out it should check any necessary file for the correct permission.