### PR TITLE
make: clean tmp directory after compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,12 +57,15 @@ ifndef ANDROID
 	$(MAKE) modules
 endif
 endif
+	$(MAKE) clean_tmp
 	@echo "V has been successfully built"
 
-clean:
+clean: clean_tmp
+	git clean -xf
+
+clean_tmp:
 	rm -rf $(TMPTCC)
 	rm -rf $(TMPVC)
-	git clean -xf
 
 latest_vc: $(TMPVC)/.git/config
 	cd $(TMPVC) && $(GITCLEANPULL)

--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,10 @@ endif
 	@echo "V has been successfully built"
 
 clean: clean_tmp
+	rm -rf $(TMPTCC)
 	git clean -xf
 
 clean_tmp:
-	rm -rf $(TMPTCC)
 	rm -rf $(TMPVC)
 
 latest_vc: $(TMPVC)/.git/config

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ ifndef ANDROID
 	$(MAKE) modules
 endif
 endif
-ifdef ALWAYS_CLEAN_TMP
+ifdef V_ALWAYS_CLEAN_TMP
 	$(MAKE) clean_tmp
 endif
 	@echo "V has been successfully built"

--- a/Makefile
+++ b/Makefile
@@ -57,14 +57,16 @@ ifndef ANDROID
 	$(MAKE) modules
 endif
 endif
+ifdef ALWAYS_CLEAN_TMP
 	$(MAKE) clean_tmp
+endif
 	@echo "V has been successfully built"
 
 clean: clean_tmp
-	rm -rf $(TMPTCC)
 	git clean -xf
 
 clean_tmp:
+	rm -rf $(TMPTCC)
 	rm -rf $(TMPVC)
 
 latest_vc: $(TMPVC)/.git/config


### PR DESCRIPTION
I have two v instances on my computer:
- a globally installed one in /usr/local/share
- a local one in my Projects directory where i make modifications

To build or update the global one i have to use `sudo`.
The problem is, that when i build the global one and after that build the local one, the local one can't build because there is a `vc` directory in `/tmp` which was created with `sudo` rights. I either have to delete that tmp dir manually or run the local update with `sudo` too.

The best solution imo was to delete that `vc` dir after the build is done.