### PR TITLE
log: fix log.v example error

### DIFF
--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -58,7 +58,7 @@ pub fn (l mut Log) set_level(level int) {
 		WARN { LogLevel.warn }
 		INFO { LogLevel.info }
 		DEBUG { LogLevel.debug }
-		else { .debug }
+		else { LogLevel.debug }
 	}
 }
 

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1813,7 +1813,7 @@ fn (p mut Parser) match_expr() ast.MatchExpr {
 		}
 		// Sum type match
 		else if p.tok.kind == .name &&
-			(p.tok.lit in table.builtin_type_names || p.tok.lit[0].is_capital() || p.peek_tok.kind == .dot) {
+			(p.tok.lit in table.builtin_type_names || p.peek_tok.kind == .dot) {
 			// if sym.kind == .sum_type {
 			// p.warn('is sum')
 			// TODO `exprs << ast.Type{...}`


### PR DESCRIPTION
This PR fix log.v example error.

**Cause**
`match_expr`  is treated as Sum_type when the case of working with capital variables.

**Solution**
Dejudgment of capital variables.
```v
// Sum type match
else if p.tok.kind == .name &&
	(p.tok.lit in table.builtin_type_names || p.peek_tok.kind == .dot) {
```
And the flag.v also have this problem.