### PR TITLE
editorconfig: extend rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,17 +1,21 @@
-# top-most EditorConfig file
 root = true
 
-# Unix-style newlines with a newline ending every file
 [*]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 
-# Matches multiple files with brace expansion notation
 [*.v]
 indent_style = tab
 indent_size = 4
-trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
 
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
## Changelog

- Added a rule for YAML files
Ensure we all use the same settings.
- Enabled `trim_trailing_whitespace` for all files, except Markdown ones
- Removed unused comments
Some of them are even irrelevant.
