### PR TITLE
cgen: move back Windows fixes

### DIFF
--- a/vlib/builtin/builtin_nix.v
+++ b/vlib/builtin/builtin_nix.v
@@ -21,7 +21,7 @@ const (
 fn C.puts(charptr)
 */
 
-fn init() {
+fn builtin_init() {
 	// Do nothing
 }
 

--- a/vlib/builtin/builtin_windows.v
+++ b/vlib/builtin/builtin_windows.v
@@ -58,7 +58,7 @@ const (
 	SYMOPT_DEBUG = 0x80000000
 )
 
-fn init() {
+fn builtin_init() {
 	if is_atty(1) > 0 {
 		C.SetConsoleMode(C.GetStdHandle(C.STD_OUTPUT_HANDLE), C.ENABLE_PROCESSED_OUTPUT | 0x0004) // ENABLE_VIRTUAL_TERMINAL_PROCESSING
 		C.setbuf(C.stdout, 0)

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -594,16 +594,20 @@ fn (g mut Gen) gen_assert_stmt(a ast.AssertStmt) {
 	g.writeln('// assert')
 	g.write('if( ')
 	g.expr(a.expr)
-	s_assertion := a.expr.str().replace('"', "\'")
 	g.write(' )')
+	s_assertion := a.expr.str().replace('"', "\'")
+	mut mod_path := g.file.path
+	$if windows {
+		mod_path = g.file.path.replace('\\', '\\\\')
+	}
 	if g.is_test {
 		g.writeln('{')
 		g.writeln('	g_test_oks++;')
-		g.writeln('	cb_assertion_ok( _STR("${g.file.path}"), ${a.pos.line_nr}, _STR("assert ${s_assertion}"), _STR("${g.fn_decl.name}()") );')
-		// g.writeln('	println(_STR("OK ${g.file.path}:${a.pos.line_nr}: fn ${g.fn_decl.name}(): assert $s_assertion"));')
+		g.writeln('	cb_assertion_ok( _STR("${mod_path}"), ${a.pos.line_nr}, _STR("assert ${s_assertion}"), _STR("${g.fn_decl.name}()") );')
+		// g.writeln('	println(_STR("OK ${mod_path}:${a.pos.line_nr}: fn ${g.fn_decl.name}(): assert $s_assertion"));')
 		g.writeln('}else{')
 		g.writeln('	g_test_fails++;')
-		g.writeln('	cb_assertion_failed( _STR("${g.file.path}"), ${a.pos.line_nr}, _STR("assert ${s_assertion}"), _STR("${g.fn_decl.name}()") );')
+		g.writeln('	cb_assertion_failed( _STR("${mod_path}"), ${a.pos.line_nr}, _STR("assert ${s_assertion}"), _STR("${g.fn_decl.name}()") );')
 		g.writeln('	exit(1);')
 		g.writeln('	// TODO')
 		g.writeln('	// Maybe print all vars in a test function if it fails?')
@@ -611,7 +615,7 @@ fn (g mut Gen) gen_assert_stmt(a ast.AssertStmt) {
 		return
 	}
 	g.writeln('{}else{')
-	g.writeln('	eprintln(_STR("${g.file.path}:${a.pos.line_nr}: FAIL: fn ${g.fn_decl.name}(): assert $s_assertion"));')
+	g.writeln('	eprintln(_STR("${mod_path}:${a.pos.line_nr}: FAIL: fn ${g.fn_decl.name}(): assert $s_assertion"));')
 	g.writeln('	exit(1);')
 	g.writeln('}')
 }
@@ -2072,6 +2076,7 @@ fn verror(s string) {
 
 fn (g mut Gen) write_init_function() {
 	g.writeln('void _vinit() {')
+	g.writeln('\tbuiltin_init();')
 	g.writeln('\tvinit_string_literals();')
 	g.writeln(g.inits.str())
 	g.writeln('}')


### PR DESCRIPTION
Add changes from 6c4de001b802e47799c16460d0c75df61fa39b27.
Add changes from 6a5cc0fa1987b744fa1526da2569d14cf5905725.

Also I changed a `init` function name of a `builtin` module to `builtin_init` to prevent overriding this function in other modules.