### PR TITLE
parser: check last or block expression to be valid

### DIFF
--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -31,7 +31,6 @@ fn test_open_file() {
 	}
 	mut file := os.open_file(filename, 'w+', 0o666) or {
 		panic(err)
-		os.File{}
 	}
 	file.write(hello)
 	file.close()

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -27,9 +27,11 @@ fn test_open_file() {
 	hello := 'hello world!'
 	os.open_file(filename, 'r+', 0o666) or {
 		assert err == 'No such file or directory'
+		os.File{}
 	}
 	mut file := os.open_file(filename, 'w+', 0o666) or {
 		panic(err)
+		os.File{}
 	}
 	file.write(hello)
 	file.close()
@@ -212,7 +214,7 @@ fn test_is_writable_folder() {
 	tmp := os.temp_dir()
 	f := os.is_writable_folder(tmp) or {
 		eprintln('err: $err')
-		assert false
+		false
 	}
 	assert f
 }

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -31,6 +31,7 @@ fn test_open_file() {
 	}
 	mut file := os.open_file(filename, 'w+', 0o666) or {
 		panic(err)
+		os.File{}
 	}
 	file.write(hello)
 	file.close()

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -649,7 +649,6 @@ pub struct OrExpr {
 pub:
 	stmts []Stmt
 	is_used bool // if the or{} block is written down or left out
-	last_stmt_type table.Type
 	// var_name string
 	// expr     Expr
 }

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -44,6 +44,7 @@ pub struct ExprStmt {
 pub:
 	expr Expr
 	typ  table.Type
+	pos  token.Position
 }
 
 pub struct IntegerLiteral {

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -647,6 +647,8 @@ mut:
 pub struct OrExpr {
 pub:
 	stmts []Stmt
+	is_used bool // if the or{} block is written down or left out
+	last_stmt_type table.Type
 	// var_name string
 	// expr     Expr
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -411,6 +411,11 @@ pub fn (c mut Checker) check_or_block(call_expr mut ast.CallExpr, ret_type table
 							c.error('wrong return type ‘$type_name‘ in or{} block, expected ‘$expected_type_name‘', it.pos)
 						}
 					}
+					ast.BranchStmt {
+						if !(it.tok.kind in [ .key_continue , .key_break ]) {
+							c.error('no other branch statements than break and continue are allowed to end an or {} block', it.tok.position())
+						}
+					}
 					else {}
 				}
 			} else {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -408,7 +408,7 @@ pub fn (c mut Checker) check_or_block(call_expr mut ast.CallExpr, ret_type table
 						if !type_fits && !is_panic_or_exit {
 							type_name := c.table.get_type_symbol(c.expr(it.expr)).name
 							expected_type_name := c.table.get_type_symbol(ret_type).name
-							c.error('wrong return type ‘$type_name‘ in or{} block, expected ‘$expected_type_name‘', call_expr.pos)
+							c.error('wrong return type ‘$type_name‘ in or{} block, expected ‘$expected_type_name‘', it.pos)
 						}
 					}
 					else {}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -394,6 +394,52 @@ pub fn (c mut Checker) call_expr(call_expr mut ast.CallExpr) table.Type {
 	}
 }
 
+pub fn (c mut Checker) check_or_block(call_expr mut ast.CallExpr, ret_type table.Type) {
+	if call_expr.or_block.is_used {
+		stmts_len := call_expr.or_block.stmts.len
+		if stmts_len != 0 {
+			last_stmt := call_expr.or_block.stmts[stmts_len - 1]
+
+			if c.is_or_block_stmt_valid(last_stmt) {
+				match last_stmt {
+					ast.ExprStmt {
+						type_fits := c.table.check(c.expr(it.expr), ret_type)
+						is_panic_or_exit := is_expr_panic_or_exit(it.expr)
+						if !type_fits && !is_panic_or_exit {
+							type_name := c.table.get_type_symbol(c.expr(it.expr)).name
+							expected_type_name := c.table.get_type_symbol(ret_type).name
+							c.error('wrong return type ‘$type_name‘ in or{} block, expected ‘$expected_type_name‘', call_expr.pos)
+						}
+					}
+					else {}
+				}
+			} else {
+				expected_type_name := c.table.get_type_symbol(ret_type).name
+				c.error('last statement in or{} block should return ‘$expected_type_name‘', call_expr.pos)
+			}
+		} else {
+			c.error('require a statement in or{} block', call_expr.pos)
+		}
+	}
+}
+
+fn is_expr_panic_or_exit(expr ast.Expr) bool {
+	match expr {
+		ast.CallExpr { return it.name == 'panic' || it.name == 'exit' }
+		else { return false }
+	}
+}
+
+// TODO: merge to check_or_block when v can handle it
+pub fn (c mut Checker) is_or_block_stmt_valid(stmt ast.Stmt) bool {
+	return match stmt {
+		ast.Return { true }
+		ast.BranchStmt { true }
+		ast.ExprStmt { true }
+		else { false }
+	}
+}
+
 pub fn (c mut Checker) selector_expr(selector_expr mut ast.SelectorExpr) table.Type {
 	typ := c.expr(selector_expr.expr)
 	if typ == table.void_type_idx {
@@ -795,7 +841,9 @@ pub fn (c mut Checker) expr(node ast.Expr) table.Type {
 			return it.typ
 		}
 		ast.CallExpr {
-			return c.call_expr(mut it)
+			call_ret_type := c.call_expr(mut it)
+			c.check_or_block(mut it, call_ret_type)
+			return call_ret_type
 		}
 		ast.CharLiteral {
 			return table.byte_type

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -412,8 +412,8 @@ pub fn (c mut Checker) check_or_block(call_expr mut ast.CallExpr, ret_type table
 						}
 					}
 					ast.BranchStmt {
-						if !(it.tok.kind in [ .key_continue , .key_break ]) {
-							c.error('no other branch statements than break and continue are allowed to end an or {} block', it.tok.position())
+						if !(it.tok.kind in [.key_continue, .key_break]) {
+							c.error('only break and continue are allowed as a final branch statement in an or{} block', it.tok.position())
 						}
 					}
 					else {}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -40,6 +40,8 @@ pub fn (p mut Parser) call_expr(is_c bool, mod string) ast.CallExpr {
 			match last_stmt {
 				ast.ExprStmt {}
 				ast.Return {}
+				// TODO: only in for loop, otherwise we get an error
+				ast.BranchStmt {}
 				else {
 					// TODO: line number is wrong (two lines back)
 					p.error('last or block statement is invalid, it must be a return statement or an expression')

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -40,6 +40,8 @@ pub fn (p mut Parser) call_expr(is_c bool, mod string) ast.CallExpr {
 			match last_stmt {
 				ast.ExprStmt {}
 				ast.Return {}
+				// TODO: only when panic or return type fits (checker part)
+				ast.CallExpr {}
 				// TODO: only in for loop, otherwise we get an error
 				ast.BranchStmt {}
 				else {

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -42,6 +42,8 @@ pub fn (p mut Parser) call_expr(is_c bool, mod string) ast.CallExpr {
 			match last_stmt {
 				ast.ExprStmt {}
 				ast.Return {}
+				// TODO: only in for loop, otherwise we get an error
+				ast.BranchStmt {}
 				else {
 					// TODO: line number is wrong (two lines back)
 					p.error('last or block statement is invalid, it must be a return statement or an expression')

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -42,6 +42,8 @@ pub fn (p mut Parser) call_expr(is_c bool, mod string) ast.CallExpr {
 			match last_stmt {
 				ast.ExprStmt {}
 				ast.Return {}
+				// TODO: only when panic or return type fits (checker part)
+				ast.CallExpr {}
 				// TODO: only in for loop, otherwise we get an error
 				ast.BranchStmt {}
 				else {

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -36,10 +36,12 @@ pub fn (p mut Parser) call_expr(is_c bool, mod string) ast.CallExpr {
 		or_stmts = p.parse_block_no_scope()
 		if or_stmts.len > 0 {
 			last_stmt := or_stmts[or_stmts.len - 1]
+			println(last_stmt)
 			// TODO: better if?
 			match last_stmt {
 				ast.ExprStmt {}
 				ast.Return {}
+				ast.AssertStmt {}
 				// TODO: only when panic or return type fits (checker part)
 				ast.CallExpr {}
 				// TODO: only in for loop, otherwise we get an error

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -34,6 +34,21 @@ pub fn (p mut Parser) call_expr(is_c bool, mod string) ast.CallExpr {
 			typ: table.int_type
 		})
 		or_stmts = p.parse_block_no_scope()
+		if or_stmts.len > 0 {
+			last_stmt := or_stmts[or_stmts.len - 1]
+			// TODO: better if?
+			match last_stmt {
+				ast.ExprStmt {}
+				ast.Return {}
+				else {
+					// TODO: line number is wrong (two lines back)
+					p.error('last or block statement is invalid, it must be a return statement or an expression')
+				}
+			}
+		} else {
+			// TODO: line number is wrong (two lines back)
+			p.error('or block must not be empty')
+		}
 		p.close_scope()
 	}
 	node := ast.CallExpr{

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -36,6 +36,21 @@ pub fn (p mut Parser) call_expr(is_c bool, mod string) ast.CallExpr {
 		})
 		is_or_block_used = true
 		or_stmts = p.parse_block_no_scope()
+		if or_stmts.len > 0 {
+			last_stmt := or_stmts[or_stmts.len - 1]
+			// TODO: better if?
+			match last_stmt {
+				ast.ExprStmt {}
+				ast.Return {}
+				else {
+					// TODO: line number is wrong (two lines back)
+					p.error('last or block statement is invalid, it must be a return statement or an expression')
+				}
+			}
+		} else {
+			// TODO: line number is wrong (two lines back)
+			p.error('or block must not be empty')
+		}
 		p.close_scope()
 	}
 	node := ast.CallExpr{

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -36,27 +36,6 @@ pub fn (p mut Parser) call_expr(is_c bool, mod string) ast.CallExpr {
 		})
 		is_or_block_used = true
 		or_stmts = p.parse_block_no_scope()
-		if or_stmts.len > 0 {
-			last_stmt := or_stmts[or_stmts.len - 1]
-			println(last_stmt)
-			// TODO: better if?
-			match last_stmt {
-				ast.ExprStmt {}
-				ast.Return {}
-				ast.AssertStmt {}
-				// TODO: only when panic or return type fits (checker part)
-				ast.CallExpr {}
-				// TODO: only in for loop, otherwise we get an error
-				ast.BranchStmt {}
-				else {
-					// TODO: line number is wrong (two lines back)
-					p.error('last or block statement is invalid, it must be a return statement or an expression')
-				}
-			}
-		} else {
-			// TODO: line number is wrong (two lines back)
-			p.error('or block must not be empty')
-		}
 		p.close_scope()
 	}
 	node := ast.CallExpr{

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -38,10 +38,12 @@ pub fn (p mut Parser) call_expr(is_c bool, mod string) ast.CallExpr {
 		or_stmts = p.parse_block_no_scope()
 		if or_stmts.len > 0 {
 			last_stmt := or_stmts[or_stmts.len - 1]
+			println(last_stmt)
 			// TODO: better if?
 			match last_stmt {
 				ast.ExprStmt {}
 				ast.Return {}
+				ast.AssertStmt {}
 				// TODO: only when panic or return type fits (checker part)
 				ast.CallExpr {}
 				// TODO: only in for loop, otherwise we get an error

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -943,6 +943,7 @@ fn (p mut Parser) dot_expr(left ast.Expr) ast.Expr {
 		p.next()
 		args := p.call_args()
 		mut or_stmts := []ast.Stmt
+		mut is_or_block_used := false
 		if p.tok.kind == .key_orelse {
 			p.next()
 			p.open_scope()
@@ -954,6 +955,7 @@ fn (p mut Parser) dot_expr(left ast.Expr) ast.Expr {
 				name: 'err'
 				typ: table.string_type
 			})
+			is_or_block_used = true
 			or_stmts = p.parse_block_no_scope()
 			p.close_scope()
 		}
@@ -964,8 +966,9 @@ fn (p mut Parser) dot_expr(left ast.Expr) ast.Expr {
 			pos: pos
 			is_method: true
 			or_block: ast.OrExpr{
-			stmts: or_stmts
-		}
+				stmts: or_stmts
+				is_used: is_or_block_used
+			}
 		}
 		mut node := ast.Expr{}
 		node = mcall_expr

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -434,9 +434,11 @@ pub fn (p mut Parser) stmt() ast.Stmt {
 					name: name
 				}
 			}
+			epos := p.tok.position()
 			expr := p.expr(0)
 			return ast.ExprStmt{
 				expr: expr
+				pos: epos
 			}
 		}
 	}

--- a/vlib/v/tests/defer_test.v
+++ b/vlib/v/tests/defer_test.v
@@ -56,10 +56,7 @@ fn test_defer_early_exit() {
 }
 
 fn test_defer_option() {
-	mut ok := Num{
-		0}
-	set_num_opt(mut ok) or {
-		assert false
-	}
+	mut ok := Num{0}
+	set_num_opt(mut ok)
 	assert ok.val == 1
 }


### PR DESCRIPTION
the `or{}` block needs some requirements for the last statement.

the current implementation is not finished because i don't know how to to some things. maybe take a look at my TODO comments and help me for a better solution.

they should be implemented a checker part as well to check the type of the return statement to fit.