### PR TITLE
[WIP] fixed arrays: implement basic functionality

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -296,6 +296,57 @@ fn test_fixed() {
 	assert nums2[N - 1] == 0
 }
 
+
+fn test_fixed_array_for_in() {
+	mut arr := [8]int
+	for val in arr {
+		assert val == 0 
+	}
+}
+
+fn test_fixed_array_len() {
+	mut arr := [8]int
+	assert arr.len == 8
+}
+
+fn test_fixed_array_index() {
+	mut arr := [8]int
+	assert arr[0] == 0
+}
+
+fn test_fixed_array_assignment() {
+	mut arr := [8]int
+	arr[1] = 5
+	assert arr[1] == 5
+}
+
+
+fn double_each(arr mut [8]int) {
+	for i, v in arr {
+		// throws: error: invalid operands to binary * (have 'array_fixed_int_8' and 'int')
+		// make sure that we dereference
+		arr[i] *= 2
+	}
+}
+
+fn get_len(arr mut[8]int) int {
+	return arr.len
+}
+
+// will fail miserably
+fn test_fixed_array_as_mutable_arg() {
+	mut arr := [8]int
+	// temporary hack?
+	for i, val in arr {
+		arr[i] = i
+	}
+	assert get_len(arr) == 8
+	double_each(mut arr)
+	for i, val in arr {
+		assert (i * 2) == val
+	}
+}
+
 fn modify(numbers mut []int) {
 	numbers[0] = 777
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -382,6 +382,12 @@ pub fn (c mut Checker) selector_expr(selector_expr mut ast.SelectorExpr) table.T
 	// println('sel expr line_nr=$selector_expr.pos.line_nr typ=$selector_expr.expr_type')
 	typ_sym := c.table.get_type_symbol(typ)
 	field_name := selector_expr.field
+	// hack for fixed arrays so .len doesn't throw
+	if typ_sym.kind == .array_fixed {
+		if field_name == 'len' {
+			return table.int_type
+		}
+	}
 	// variadic
 	if table.type_is(typ, .variadic) {
 		if field_name == 'len' {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1149,6 +1149,15 @@ fn (g mut Gen) expr(node ast.Expr) {
 			g.struct_init(it)
 		}
 		ast.SelectorExpr {
+			// if we try to access .len no fixed array just return it's size
+			sym := g.table.get_type_symbol(it.expr_type)
+			if sym.kind == .array_fixed {
+				if it.field == 'len' {
+					info := sym.array_fixed_info()
+					g.write('$info.size')
+					return
+				}
+			}
 			g.expr(it.expr)
 			// if table.type_nr_muls(it.expr_type) > 0 {
 			if table.type_is_ptr(it.expr_type) {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2017,18 +2017,19 @@ fn (g mut Gen) ref_or_deref_arg(arg ast.CallArg, expected_type table.Type) {
 	if arg.is_mut && !arg_is_ptr {
 		g.write('&/*mut*/')
 	} else if arg_is_ptr && !expr_is_ptr {
-		if arg.is_mut {
-			sym := g.table.get_type_symbol(expected_type)
-			if sym.kind == .array {
-				// Special case for mutable arrays. We can't `&` function
-				// results,	have to use `(array[]){ expr }[0]` hack.
-				g.write('&/*111*/(array[]){')
-				g.expr(arg.expr)
-				g.write('}[0]')
-				return
-			}
+        sym := g.table.get_type_symbol(expected_type)
+        if arg.is_mut {
+            if sym.kind == .array {
+                // Special case for mutable arrays. We can't `&` function
+                // results,    have to use `(array[]){ expr }[0]` hack.
+                g.write('&/*111*/(array[]){')
+                g.expr(arg.expr)
+                g.write('}[0]')
+                return
+            }
+        } else if sym.kind != .array_fixed {
+			g.write('&/*qq*/')
 		}
-		g.write('&/*qq*/')
 	} else if !arg_is_ptr && expr_is_ptr {
 		// Dereference a pointer if a value is required
 		g.write('*/*d*/')

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1163,7 +1163,7 @@ fn (g mut Gen) expr(node ast.Expr) {
 			g.struct_init(it)
 		}
 		ast.SelectorExpr {
-			// if we try to access .len no fixed array just return it's size
+			// if we try to access .len on fixed array just return it's size
 			sym := g.table.get_type_symbol(it.expr_type)
 			if sym.kind == .array_fixed {
 				if it.field == 'len' {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -522,6 +522,20 @@ fn (g mut Gen) for_in(it ast.ForInStmt) {
 		g.write('data)[$i];')
 		g.stmts(it.stmts)
 		g.writeln('}')
+	} else if it.kind == .array_fixed {
+		g.writeln('// FOR IN')
+		i := if it.key_var == '' { g.new_tmp_var() } else { it.key_var }
+		sym := g.table.get_type_symbol(it.cond_type)
+		info := sym.array_fixed_info()
+		len := info.size
+		styp := g.typ(it.val_type)
+		deref := if table.type_is_ptr(it.cond_type) { '*'} else { '' }
+		g.writeln('for (int $i = 0; $i < $len /* FIXED ARRAY\'S LEN */; $i++) {')
+		g.write('\t$styp $it.val_var = ($deref')
+		g.expr(it.cond)
+		g.writeln(')[$i];')
+		g.stmts(it.stmts)
+		g.writeln('}')
 	} else if it.kind == .map {
 		// `for num in nums {`
 		g.writeln('// FOR IN')


### PR DESCRIPTION
Fixed arrays in V are _under implemented_. In this pull request, I try to add proper functionality.

## To be done:
- [x] implement .len on fixed arrays
- [x] make fixed arrays work in a "for ... in" loop
- [x] add some tests
- [ ] make fixed arrays work properly when passed as mutable to a function
- [ ] make fixed arrays work under JS backend*
- [ ] add more things to be done
_*I didn't test if they work yet._

## Notes:  
`make fixed arrays work properly when passed as mutable to a function`
Fixed arrays are already pointers, do they need to be passed as pointers to pointers? If they don't need to be passed as pointers then the whole thing would be easier.
_update_:
![](https://i.imgur.com/XIq7fuz.png)
Must modify fn_args and ref_or_deref_arg in cgen.