### PR TITLE
log: fix example log.v error

### DIFF
--- a/cmd/tools/gen_vc.v
+++ b/cmd/tools/gen_vc.v
@@ -143,7 +143,7 @@ fn main() {
 // new GenVC
 fn new_gen_vc(flag_options FlagOptions) &GenVC {
 	mut logger := &log.Log{}
-	logger.set_level(log.DEBUG)
+	logger.set_level(log.Level.debug)
 	if flag_options.log_to == 'file' {
 		logger.set_full_logpath( flag_options.log_file )
 	}

--- a/cmd/tools/gen_vc.v
+++ b/cmd/tools/gen_vc.v
@@ -143,7 +143,7 @@ fn main() {
 // new GenVC
 fn new_gen_vc(flag_options FlagOptions) &GenVC {
 	mut logger := &log.Log{}
-	logger.set_level(log.Level.debug)
+	logger.set_level(.debug)
 	if flag_options.log_to == 'file' {
 		logger.set_full_logpath( flag_options.log_file )
 	}

--- a/examples/log.v
+++ b/examples/log.v
@@ -2,16 +2,16 @@ import log
 
 fn main() {
 	mut l := log.Log{}
-	l.set_level(log.INFO)
+	l.set_level(log.Level.info)
 	// Make a new file called info.log in the current folder
 	l.set_full_logpath('./info.log')
 	println('Please check the file: ${l.output_file_name} after this example crashes.')
-  
+
 	l.info('info')
 	l.warn('warn')
 	l.error('error')
 	l.debug('no debug')
-	l.set_level(log.DEBUG)
+	l.set_level(log.Level.debug)
 	l.debug('debug')
 	l.fatal('fatal')
 }

--- a/examples/log.v
+++ b/examples/log.v
@@ -2,7 +2,7 @@ import log
 
 fn main() {
 	mut l := log.Log{}
-	l.set_level(log.Level.info)
+	l.set_level(.info)
 	// Make a new file called info.log in the current folder
 	l.set_full_logpath('./info.log')
 	println('Please check the file: ${l.output_file_name} after this example crashes.')
@@ -11,7 +11,7 @@ fn main() {
 	l.warn('warn')
 	l.error('error')
 	l.debug('no debug')
-	l.set_level(log.Level.debug)
+	l.set_level(.debug)
 	l.debug('debug')
 	l.fatal('fatal')
 }

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -6,7 +6,7 @@ import (
 	term
 )
 
-pub enum LogLevel {
+pub enum Level {
 	fatal = 1
 	error
 	warn
@@ -14,7 +14,7 @@ pub enum LogLevel {
 	debug
 }
 
-fn tag(l LogLevel) string {
+fn tag(l Level) string {
 	return match l {
 		.fatal { term.red('FATAL') }
 		.error { term.red('ERROR') }
@@ -24,14 +24,6 @@ fn tag(l LogLevel) string {
 		else { '     ' }
 	}
 }
-
-pub const (
-	FATAL = 1
-	ERROR = 2
-	WARN  = 3
-	INFO  = 4
-	DEBUG = 5
-)
 
 interface Logger {
 	fatal(s string)
@@ -43,7 +35,7 @@ interface Logger {
 
 pub struct Log {
 mut:
-	level            LogLevel
+	level            Level
 	output_label     string
 	ofile            os.File
 	output_to_file   bool
@@ -51,18 +43,11 @@ pub mut:
 	output_file_name string
 }
 
-pub fn (l mut Log) set_level(level int) {
-	l.level = match level {
-		FATAL { LogLevel.fatal }
-		ERROR { LogLevel.error }
-		WARN { LogLevel.warn }
-		INFO { LogLevel.info }
-		DEBUG { LogLevel.debug }
-		else { .debug }
-	}
+pub fn (l mut Log) set_level(level Level) {
+	l.level = level
 }
 
-pub fn (l mut Log) set_output_level(level LogLevel) {
+pub fn (l mut Log) set_output_level(level Level) {
 	l.level = level
 }
 
@@ -90,19 +75,19 @@ pub fn (l mut Log) close() {
   l.ofile.close()
 }
 
-fn (l mut Log) log_file(s string, level LogLevel) {
+fn (l mut Log) log_file(s string, level Level) {
 	timestamp := time.now().format_ss()
 	e := tag(level)
 	l.ofile.writeln('$timestamp [$e] $s')
 }
 
-fn (l &Log) log_cli(s string, level LogLevel) {
+fn (l &Log) log_cli(s string, level Level) {
 	f := tag(level)
 	t := time.now()
 	println('[$f ${t.format_ss()}] $s')
 }
 
-fn (l mut Log) send_output(s &string, level LogLevel) {
+fn (l mut Log) send_output(s &string, level Level) {
 	if l.output_to_file {
 		l.log_file(s, level)
 	} else {

--- a/vlib/v/tests/repl/run.v
+++ b/vlib/v/tests/repl/run.v
@@ -6,7 +6,7 @@ import benchmark
 
 fn main() {
 	mut logger := log.Log{}
-	logger.set_level(log.Level.debug)
+	logger.set_level(.debug)
 	options := runner.new_options()
 	mut bmark := benchmark.new_benchmark()
 	for file in options.files {

--- a/vlib/v/tests/repl/run.v
+++ b/vlib/v/tests/repl/run.v
@@ -6,7 +6,7 @@ import benchmark
 
 fn main() {
 	mut logger := log.Log{}
-	logger.set_level(log.DEBUG)
+	logger.set_level(log.Level.debug)
 	options := runner.new_options()
 	mut bmark := benchmark.new_benchmark()
 	for file in options.files {


### PR DESCRIPTION
This PR fix log.v example error.
**Cause**
`match_expr`  treat as Sum_type when the case of working with capital variables (DEBUG/INFO...).

**Solutions**
- Changing `set_level` interfaces.
```v
pub fn (l mut Log) set_level(level int) {
```
change to:
```v
pub fn (l mut Log) set_level(level Level) {
```
- enum `LogLevel` change to `Level`.

Use enum type as argument is better than int type.