### PR TITLE
vlib/v/checker: Remove hack and enforce type checking

### DIFF
--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -151,9 +151,10 @@ TODO
 */
 
 }
+
 pub fn v_calloc(n int) byteptr {
 	return C.calloc(n, 1)
-	}
+}
 
 pub fn vcalloc(n int) byteptr {
 	if n <= 0 {

--- a/vlib/builtin/cfns.v
+++ b/vlib/builtin/cfns.v
@@ -1,12 +1,15 @@
 module builtin
+
 // <string.h>
 fn C.memcpy(byteptr, byteptr, int) voidptr
 
 
 fn C.memmove(byteptr, byteptr, int) voidptr
 fn C.calloc(int)  byteptr
-// fn C.malloc(int) byteptr
+fn C.malloc(int) byteptr
 fn C.realloc(a byteptr, b int) byteptr
+fn C.free(ptr voidptr)
+fn C.exit(code int)
 
 
 fn C.qsort(voidptr, int, int, voidptr)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -277,17 +277,6 @@ pub fn (c mut Checker) call_expr(call_expr mut ast.CallExpr) table.Type {
 		if fn_name == 'typeof' {
 			return table.string_type
 		}
-		// start hack: until v1 is fixed and c definitions are added for these
-		if fn_name in ['C.calloc', 'C.malloc', 'C.exit', 'C.free'] {
-			for arg in call_expr.args {
-				c.expr(arg.expr)
-			}
-			if fn_name in ['C.calloc', 'C.malloc'] {
-				return table.byteptr_type
-			}
-			return table.void_type
-		}
-		// end hack
 		// look for function in format `mod.fn` or `fn` (main/builtin)
 		mut f := table.Fn{}
 		mut found := false

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -148,11 +148,15 @@ pub fn (c mut Checker) infix_expr(infix_expr mut ast.InfixExpr) table.Type {
 		if left.kind == .array {
 			// `array << elm`
 			// the expressions have different types (array_x and x)
-			if right.kind == .array && !c.table.check(c.table.value_type(left_type), c.table.value_type(right_type)) {
-				c.error('incompatible types: $left.name << $right.name', infix_expr.pos)
-			} else if right.kind != .array && !c.table.check(c.table.value_type(left_type), right_type) {
-				c.error('incompatible types: $left.name << $right.name', infix_expr.pos)
+			if c.table.check(c.table.value_type(left_type), right_type) {
+				// []T << T
+				return table.void_type
 			}
+			if right.kind == .array && c.table.check(c.table.value_type(left_type), c.table.value_type(right_type)) {
+				// []T << []T
+				return table.void_type
+			}
+			c.error('incompatible types: $left.name << $right.name', infix_expr.pos)
 			return table.void_type
 		}
 	}


### PR DESCRIPTION
This PR:
- Enforces type checking for `array << array` to make sure int array is not appended to a string array
- Removes `C.free`, `C.calloc`, `C.malloc` and `C.exit` hack as they're no longer needed with the removal of V1

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->