### PR TITLE
time: change unix timestamp to u64

### DIFF
--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -31,7 +31,7 @@ pub:
 	hour   int
 	minute int
 	second int
-	unix int
+	unix   u64
 }
 
 pub enum FormatTime {


### PR DESCRIPTION
according to https://github.com/vlang/v/issues/4258 unix timestmap should be 64 bit.

changed `int` to `u64`

 Closes #4258