### PR TITLE
tool: fix cmd/tools/performance_compare.v

### DIFF
--- a/cmd/tools/performance_compare.v
+++ b/cmd/tools/performance_compare.v
@@ -190,8 +190,8 @@ fn main() {
 	context.vflags = fp.string('vflags', 0, '', 'Additional options to pass to the v commands, for example "-cc tcc"')
 	context.hyperfineopts = fp.string('hyperfine_options', 0, '',
 		'Additional options passed to hyperfine.
-${flag.SPACE}For example on linux, you may want to pass:
-${flag.SPACE}--hyperfine_options "--prepare \'sync; echo 3 | sudo tee /proc/sys/vm/drop_caches\'"
+${flag.space}For example on linux, you may want to pass:
+${flag.space}--hyperfine_options "--prepare \'sync; echo 3 | sudo tee /proc/sys/vm/drop_caches\'"
 ')
 	commits := vgit.add_common_tool_options(mut context, mut fp)
 	context.commit_before = commits[0]


### PR DESCRIPTION
This PR minor fix cmd/tools/performance_compare.v.

`flag.SPACE` => `flag.space`, This is due to modifications to the flag library.