### PR TITLE
parser: fix comment error

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -220,12 +220,10 @@ fn (p mut Parser) next_with_comment() {
 fn (p mut Parser) next() {
 	p.tok = p.peek_tok
 	p.peek_tok = p.scanner.scan()
-	/*
-	if p.tok.kind==.comment {
-		p.comments << ast.Comment{text:p.tok.lit, line_nr:p.tok.line_nr}
-		p.next()
+	
+	for p.peek_tok.kind == .comment {
+		p.peek_tok = p.scanner.scan()
 	}
-*/
 }
 
 fn (p mut Parser) check(expected token.Kind) {
@@ -603,7 +601,7 @@ pub fn (p mut Parser) name_expr() ast.Expr {
 		return p.string_expr()
 	}
 	known_var := p.scope.known_var(p.tok.lit)
-	if p.peek_tok.kind == .dot && !known_var && (is_c || p.known_import(p.tok.lit) || p.mod.all_after('.') == 
+	if p.peek_tok.kind == .dot && !known_var && (is_c || p.known_import(p.tok.lit) || p.mod.all_after('.') ==
 		p.tok.lit) {
 		if is_c {
 			mod = 'C'
@@ -658,8 +656,8 @@ pub fn (p mut Parser) name_expr() ast.Expr {
 			x := p.call_expr(is_c, mod)			// TODO `node,typ :=` should work
 			node = x
 		}
-	} else if p.peek_tok.kind == .lcbr && (p.tok.lit[0].is_capital() || is_c || (p.builtin_mod && p.tok.lit in 
-		table.builtin_type_names)) && (p.tok.lit.len in [1, 2] || !p.tok.lit[p.tok.lit.len - 1].is_capital()) && 
+	} else if p.peek_tok.kind == .lcbr && (p.tok.lit[0].is_capital() || is_c || (p.builtin_mod && p.tok.lit in
+		table.builtin_type_names)) && (p.tok.lit.len in [1, 2] || !p.tok.lit[p.tok.lit.len - 1].is_capital()) &&
 		!p.inside_match_case {
 		// || p.table.known_type(p.tok.lit)) {
 		return p.struct_init(false)		// short_syntax: false
@@ -1281,7 +1279,7 @@ fn (p mut Parser) array_init() ast.ArrayInit {
 		}
 	} else {
 		// [1,2,3]
-		for i := 0; p.tok.kind != .rsbr; i++{ 
+		for i := 0; p.tok.kind != .rsbr; i++{
 			expr := p.expr(0)
 			exprs << expr
 			if p.tok.kind == .comma {
@@ -1709,7 +1707,7 @@ fn (p mut Parser) hash() ast.HashStmt {
 }
 
 fn (p mut Parser) global_decl() ast.GlobalDecl {
-	if !p.pref.translated && !p.pref.is_live && !p.builtin_mod && !p.pref.building_v && p.mod != 'ui' && 
+	if !p.pref.translated && !p.pref.is_live && !p.builtin_mod && !p.pref.building_v && p.mod != 'ui' &&
 		p.mod != 'gg2' && p.mod != 'uiold' && !os.getwd().contains('/volt') && !p.pref.enable_globals {
 		p.error('use `v --enable-globals ...` to enable globals')
 	}
@@ -1765,7 +1763,7 @@ fn (p mut Parser) match_expr() ast.MatchExpr {
 		if p.tok.kind == .key_else {
 			have_final_else = true
 			p.next()
-		} else if p.tok.kind == .name && (p.tok.lit in table.builtin_type_names || p.tok.lit[0].is_capital() || 
+		} else if p.tok.kind == .name && (p.tok.lit in table.builtin_type_names || p.tok.lit[0].is_capital() ||
 			p.peek_tok.kind == .dot) {
 			// Sum type match
 			// if sym.kind == .sum_type {


### PR DESCRIPTION
This PR fix comment error in parser.v.

**Solution**
```v
fn (p mut Parser) next() {
	p.tok = p.peek_tok
	p.peek_tok = p.scanner.scan()
	
	for p.peek_tok.kind == .comment {
		p.peek_tok = p.scanner.scan()
	}
}
```
Ignore all comments in the middle when compiling.