### PR TITLE
parser: allow C struct declaration that lacks body

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1472,65 +1472,65 @@ fn (p mut Parser) struct_decl() ast.StructDecl {
 	mut pub_pos := -1
 	mut pub_mut_pos := -1
 	if !no_body {
-	p.check(.lcbr)
-	for p.tok.kind != .rcbr {
-		mut comment := ast.Comment{}
-		if p.tok.kind == .comment {
-			comment = p.comment()
-		}
-		if p.tok.kind == .key_pub {
-			p.check(.key_pub)
-			if p.tok.kind == .key_mut {
-				p.check(.key_mut)
-				pub_mut_pos = fields.len
-			} else {
-				pub_pos = fields.len
+		p.check(.lcbr)
+		for p.tok.kind != .rcbr {
+			mut comment := ast.Comment{}
+			if p.tok.kind == .comment {
+				comment = p.comment()
 			}
-			p.check(.colon)
-		} else if p.tok.kind == .key_mut {
-			p.check(.key_mut)
-			p.check(.colon)
-			mut_pos = fields.len
-		} else if p.tok.kind == .key_global {
-			p.check(.key_global)
-			p.check(.colon)
-		}
-		field_name := p.check_name()
-		field_pos := p.tok.position()
-		// p.warn('field $field_name')
-		typ := p.parse_type()
-		/*
-		if name == '_net_module_s' {
+			if p.tok.kind == .key_pub {
+				p.check(.key_pub)
+				if p.tok.kind == .key_mut {
+					p.check(.key_mut)
+					pub_mut_pos = fields.len
+				} else {
+					pub_pos = fields.len
+				}
+				p.check(.colon)
+			} else if p.tok.kind == .key_mut {
+				p.check(.key_mut)
+				p.check(.colon)
+				mut_pos = fields.len
+			} else if p.tok.kind == .key_global {
+				p.check(.key_global)
+				p.check(.colon)
+			}
+			field_name := p.check_name()
+			field_pos := p.tok.position()
+			// p.warn('field $field_name')
+			typ := p.parse_type()
+			/*
+			if name == '_net_module_s' {
 			s := p.table.get_type_symbol(typ)
 			println('XXXX' + s.str())
 		}
 */
-		mut default_expr := ''		// ast.Expr{}
-		if p.tok.kind == .assign {
-			// Default value
-			p.next()
-			default_expr = p.tok.lit
-			p.expr(0)
-			// default_expr = p.expr(0)
+			mut default_expr := ''			// ast.Expr{}
+			if p.tok.kind == .assign {
+				// Default value
+				p.next()
+				default_expr = p.tok.lit
+				p.expr(0)
+				// default_expr = p.expr(0)
+			}
+			if p.tok.kind == .comment {
+				comment = p.comment()
+			}
+			ast_fields << ast.StructField{
+				name: field_name
+				pos: field_pos
+				typ: typ
+				comment: comment
+				default_expr: default_expr
+			}
+			fields << table.Field{
+				name: field_name
+				typ: typ
+				default_val: default_expr
+			}
+			// println('struct field $ti.name $field_name')
 		}
-		if p.tok.kind == .comment {
-			comment = p.comment()
-		}
-		ast_fields << ast.StructField{
-			name: field_name
-			pos: field_pos
-			typ: typ
-			comment: comment
-			default_expr: default_expr
-		}
-		fields << table.Field{
-			name: field_name
-			typ: typ
-			default_val: default_expr
-		}
-		// println('struct field $ti.name $field_name')
-	}
-	p.check(.rcbr)
+		p.check(.rcbr)
 	}
 	if is_c {
 		name = 'C.$name'

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1460,14 +1460,19 @@ fn (p mut Parser) struct_decl() ast.StructDecl {
 		p.next()		// .
 	}
 	is_typedef := p.attr == 'typedef'
+	no_body := p.peek_tok.kind != .lcbr
+	if !is_c && no_body {
+		p.error('`$p.tok.lit` lacks body')
+	}
 	mut name := p.check_name()
 	// println('struct decl $name')
-	p.check(.lcbr)
 	mut ast_fields := []ast.StructField
 	mut fields := []table.Field
 	mut mut_pos := -1
 	mut pub_pos := -1
 	mut pub_mut_pos := -1
+	if !no_body {
+	p.check(.lcbr)
 	for p.tok.kind != .rcbr {
 		mut comment := ast.Comment{}
 		if p.tok.kind == .comment {
@@ -1526,6 +1531,7 @@ fn (p mut Parser) struct_decl() ast.StructDecl {
 		// println('struct field $ti.name $field_name')
 	}
 	p.check(.rcbr)
+	}
 	if is_c {
 		name = 'C.$name'
 	} else {


### PR DESCRIPTION
Many V libraries currently available are dependent on this type of struct declaration

ex. (from `vlib/clipboard/clipboard_linux.v`)
```v
struct C.Display
struct C.Atom
struct C.Window
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
