### PR TITLE
fmt: use short_module for enum values

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -473,7 +473,8 @@ fn (f mut Fmt) expr(node ast.Expr) {
 			f.write('`$it.val`')
 		}
 		ast.EnumVal {
-			f.write(it.enum_name + '.' + it.val)
+      name := short_module(it.enum_name)
+			f.write(name + '.' + it.val)
 		}
 		ast.FloatLiteral {
 			f.write(it.val)


### PR DESCRIPTION
This PR fixes the bug I observe when `v fmt -w vlib/v/parser/parser.v`, where `token.Precedence.prefix` is mistakenly formatted into `v.token.Precedence.prefix`

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
