### PR TITLE
websocket: eventbus and other cleanup

### DIFF
--- a/vlib/net/websocket/README.md
+++ b/vlib/net/websocket/README.md
@@ -4,14 +4,15 @@ Originally located at [thecodrr/vws](https://github.com/thecodrr/vws) (contains 
 
 **This is still work-in-progress!**
 
-Heavily inspired (and used **very** liberally) from [cwebsockets](https://github.com/jeremyhahn/cwebsocket). 
+Heavily inspired from [cwebsockets](https://github.com/jeremyhahn/cwebsocket).
 
 The websockets library itself is ready and working (passes all tests of AutoBahn). What's left:
 
 1. It needs to be updated and made to run with latest V.
 2. No Windows Support (SSL issues)
-3. No proper AutoBahn test client (a prototype is in the main.v but nothing clean and neat).
+3. No proper AutoBahn test client (a prototype is in the main.v but nothing proper).
 4. No Websocket Server.
+5. Remove the `logger` and move to `log`
 
 ## What's needed for Windows support:
 

--- a/vlib/net/websocket/events.v
+++ b/vlib/net/websocket/events.v
@@ -1,40 +1,21 @@
 module websocket
 
-import (
-	eventbus
-)
-
-fn (ws &Client) send_message_event(msg Message){
-	mut params := eventbus.Params{}
-	mut typ := ""
-	if msg.opcode == .text_frame {
-		params.put_string("payload", string(byteptr(msg.payload)))
-		typ = 'string'
-	} else if msg.opcode == .binary_frame {
-		params.put_custom("payload", "binary", msg.payload)
-		typ = 'binary'
-	}
-	params.put_string("type", typ)
-	params.put_int("len", msg.payload_len)
-	ws.eb.publish("on_message", params, ws)
-	l.d("sending on_message event")
+fn (ws &Client) send_message_event(msg Message) {
+	ws.eb.publish('on_message', ws, msg)
+	l.d('sending on_message event')
 }
 
 fn (ws &Client) send_error_event(err string) {
-	mut params := eventbus.Params{}
-	params.put_string("error", err)
-	ws.eb.publish("on_error", params, ws)
-	l.d("sending on_error event")
+	ws.eb.publish('on_error', ws, err)
+	l.d('sending on_error event')
 }
 
 fn (ws &Client) send_close_event() {
-	params := eventbus.Params{}
-	ws.eb.publish("on_close", params, ws)
-	l.d("sending on_close event")
+	ws.eb.publish('on_close', ws, voidptr(0))
+	l.d('sending on_close event')
 }
 
 fn (ws &Client) send_open_event() {
-	params := eventbus.Params{}
-	ws.eb.publish("on_open", params, ws)
-	l.d("sending on_open event")
+	ws.eb.publish('on_open', ws, voidptr(0))
+	l.d('sending on_open event')
 }

--- a/vlib/net/websocket/ws.v
+++ b/vlib/net/websocket/ws.v
@@ -117,12 +117,18 @@ fn (ws &Client) parse_uri() &Uri {
 }
 
 pub fn (ws mut Client) connect() int {
-	if ws.state == .connected {
-		l.f("connect: websocket already connected")
-	} else if ws.state == .connecting {
-		l.f("connect: websocket already connecting")
-	} else if ws.state == .open {
-		l.f("connect: websocket already open")
+	match ws.state {
+		.connected {
+			l.f("connect: websocket already connected")
+		}
+		.connecting {
+			l.f("connect: websocket already connecting")
+		}
+		.open {
+			l.f("connect: websocket already open")
+		} else {
+			// do nothing
+		}
 	}
 
 	ws.lock.lock()

--- a/vlib/net/websocket/ws.v
+++ b/vlib/net/websocket/ws.v
@@ -40,7 +40,8 @@ struct Fragment {
 	code OPCode
 }
 
-struct Message {
+pub struct Message {
+	pub:
 	opcode OPCode
 	payload voidptr
 	payload_len int


### PR DESCRIPTION
`websocket` should not be compilable on the old V compiler (but with the current vlib). Still can't compile with the new one of course.