### PR TITLE
map: fix map_test.v error

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -363,10 +363,10 @@ pub fn (m mut map) delete(key string) {
 			m.size--
 			m.metas[index] = 0
 			m.key_values.deletes++
+			C.memset(&m.key_values.data[kv_index], 0, sizeof(KeyValue))
 			if m.key_values.size <= 32 {
 				return
 			}
-			C.memset(&m.key_values.data[kv_index], 0, sizeof(KeyValue))
 			// Clean up key_values if too many have been deleted
 			if m.key_values.deletes >= (m.key_values.size >> 1) {
 				m.key_values.zeros_to_end()


### PR DESCRIPTION
This PR fix map_test.v error.

```
C:\Users\yuyi9\v>v test vlib/builtin/map_test.v
---------------------------------------- Testing... --------------------------------------
OK    1047 ms [1/1] vlib/builtin/map_test.v
------------------------------------------------------------------------------------------
    1062 ms <=== total time spent running V _test.v files
                 ok, fail, skip, total =     1,     0,     0,     1
```

**Solution**
```v
pub fn (m mut map) delete(key string) {
	mut index,mut meta := m.key_to_index(key)
	index,meta = m.meta_less(index, meta)
	// Perform backwards shifting
	for meta == m.metas[index] {
		kv_index := m.metas[index + 1]
		if C.strcmp(key.str, m.key_values.data[kv_index].key.str) == 0 {
			for (m.metas[index + 2]>>hashbits) > 1 {
				m.metas[index] = m.metas[index + 2] - probe_inc
				m.metas[index + 1] = m.metas[index + 3]
				index += 2
			}
			m.size--
			m.metas[index] = 0
			m.key_values.deletes++
			C.memset(&m.key_values.data[kv_index], 0, sizeof(KeyValue))
			if m.key_values.size <= 32 {
				return
			}
			// Clean up key_values if too many have been deleted
			if m.key_values.deletes >= (m.key_values.size >> 1) {
				m.key_values.zeros_to_end()
				m.rehash()
				m.key_values.deletes = 0
			}
			return
		}
		index += 2
		meta += probe_inc
	}
}
```
The processing order of C.memset is not correct, should be in front.