### PR TITLE
parser: fix script and repl error

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -320,9 +320,14 @@ pub fn (p mut Parser) top_stmt() ast.Stmt {
 			return p.comment()
 		}
 		else {
-			// #printf("");
-			p.error('bad top level statement ' + p.tok.str())
-			return ast.Stmt{}
+			if p.pref.is_script && !p.pref.is_test {
+				p.scanner.text = 'fn main() {' + p.scanner.text + '}'
+				p.scanner.is_started = false
+				p.scanner.pos = 0
+				p.next()
+				p.next()
+				return p.top_stmt()
+			}
 		}
 	}
 }

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -328,6 +328,10 @@ pub fn (p mut Parser) top_stmt() ast.Stmt {
 				p.next()
 				return p.top_stmt()
 			}
+			else {
+				p.error('bad top level statement ' + p.tok.str())
+				return ast.Stmt{}
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR fix script and repl error.

```
C:\Users\yuyi9\v\examples>v run hello_world.v
Hello, World!
```

```
C:\Users\yuyi9\v\examples>v
For usage information, quit V REPL using `exit` and use `v help`
V 0.1.26 4e01bf4.89b8340
Use Ctrl-C or `exit` to exit
>>> 2 + 3
5
>>>
```

**Solution**

```v
pub fn (p mut Parser) top_stmt() ast.Stmt {
	match p.tok.kind {
                ......
		else {
			if p.pref.is_script && !p.pref.is_test {
				p.scanner.text = 'fn main() {' + p.scanner.text + '}'
				p.scanner.is_started = false
				p.scanner.pos = 0
				p.next()
				p.next()
				return p.top_stmt()
			}
			else {
				p.error('bad top level statement ' + p.tok.str())
				return ast.Stmt{}
			}
		}
```
This is not the best solution, I hope to improve after this PR.