### PR TITLE
bug: printing pointer should print the address

### DIFF
--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -55,7 +55,6 @@ const (
 		'vlib/v/tests/type_test.v',
 		'vlib/v/tests/typeof_test.v',
 		'vlib/v/tests/valgrind/valgrind_test.v', // ubuntu-musl only
-		'vlib/v/tests/pointers_str_test.v',
 		'vlib/vweb/assets/assets_test.v',
 	]
 )

--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -55,6 +55,7 @@ const (
 		'vlib/v/tests/type_test.v',
 		'vlib/v/tests/typeof_test.v',
 		'vlib/v/tests/valgrind/valgrind_test.v', // ubuntu-musl only
+		'vlib/v/tests/pointers_str_test.v',
 		'vlib/vweb/assets/assets_test.v',
 	]
 )

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2561,18 +2561,15 @@ fn (g mut Gen) fn_call(node ast.CallExpr) {
 			g.expr(node.args[0].expr)
 			g.writeln('); ${print_method}($tmp); string_free($tmp); //MEM2 $styp')
 		} else {
-			// println(var) or println println(str.var)
 			expr := node.args[0].expr
 			is_var := match expr {
 				ast.SelectorExpr { true }
 				ast.Ident { true }
 				else { false }
 			}
-			// `println(int_str(10))`
-			// sym := g.table.get_type_symbol(node.args[0].typ)
-			if table.type_is_ptr(typ) {
+			if table.type_is_ptr(typ) && sym.kind != .struct_ {
 				// ptr_str() for pointers
-				// styp = 'ptr'
+				styp = 'ptr'
 			}
 			if sym.kind == .enum_ {
 				if is_var {
@@ -2592,7 +2589,7 @@ fn (g mut Gen) fn_call(node ast.CallExpr) {
 				}
 			} else {
 				g.write('${print_method}(${styp}_str(')
-				if table.type_is_ptr(typ) {
+				if table.type_is_ptr(typ) && sym.kind == .struct_ {
 					// dereference
 					g.write('*')
 				}

--- a/vlib/v/tests/inout/enum_print.out
+++ b/vlib/v/tests/inout/enum_print.out
@@ -4,4 +4,3 @@ green
 green
 interp: green
 interp: green
-orange

--- a/vlib/v/tests/inout/enum_print.vv
+++ b/vlib/v/tests/inout/enum_print.vv
@@ -11,10 +11,6 @@ struct A{
 	color Color
 }
 
-fn (c &Color) test() {
-	println(c)
-}
-
 fn main() {
 	col := Color.green
 	a := A{color: col}
@@ -25,5 +21,4 @@ fn main() {
 	println(a.color)
 	println('interp: ${col}')
 	println('interp: ${a.color}')
-	orange.test()
 }

--- a/vlib/v/tests/pointers_str_test.v
+++ b/vlib/v/tests/pointers_str_test.v
@@ -1,0 +1,8 @@
+struct A {
+	foo int
+}
+
+fn test_pointer_to_string() {
+	a := A{}
+	assert a.foo.str() != (&a.foo).str()
+}


### PR DESCRIPTION
when the pointer is explicitly given it should print the address instead of the value
```
fn main() {
   b := 5
   println(&b)
}
```