### PR TITLE
test: fix project_with_c_code/main_test.v error

### DIFF
--- a/vlib/v/tests/project_with_c_code/mod1/wrapper.v
+++ b/vlib/v/tests/project_with_c_code/mod1/wrapper.v
@@ -1,7 +1,7 @@
 module mod1
 
-#flag -I @VROOT/c
-#flag @VROOT/c/implementation.o
+#flag -I vlib/v/tests/project_with_c_code/mod1/c
+#flag vlib/v/tests/project_with_c_code/mod1/c/implementation.o
 
 #include "header.h"
 


### PR DESCRIPTION
This PR fix project_with_c_code/main_test.v error.

```
C:\Users\yuyi9\v>v test vlib/v/tests/project_with_c_code
---------------------------------------- Testing... --------------------------------------
OK     953 ms [1/1] vlib/v/tests/project_with_c_code\main_test.v
------------------------------------------------------------------------------------------
     953 ms <=== total time spent running V _test.v files
                 ok, fail, skip, total =     1,     0,     0,     1
```

**Solution**

```v
#flag -I vlib/v/tests/project_with_c_code/mod1/c
#flag vlib/v/tests/project_with_c_code/mod1/c/implementation.o
```
Specify the actual path of flag.