### PR TITLE
test: fix vlib/math/big/big_test.v

### DIFF
--- a/vlib/math/big/big.v
+++ b/vlib/math/big/big.v
@@ -2,13 +2,9 @@ module big
 
 // Wrapper for https://github.com/kokke/tiny-bignum-c
 
-#flag -I @VROOT/thirdparty/bignum
-#flag @VROOT/thirdparty/bignum/bn.o
+#flag -I thirdparty/bignum
+#flag thirdparty/bignum/bn.o
 #include "bn.h"
-
-const (
-	STRING_BUFFER_SIZE = 8192
-)
 
 pub struct Number {
 	array [32]u32
@@ -77,8 +73,8 @@ pub fn (n Number) str() string {
 }
 
 pub fn (n Number) hexstr() string {
-	mut buf := [STRING_BUFFER_SIZE]byte
-	C.bignum_to_string( &n, buf, STRING_BUFFER_SIZE)
+	mut buf := [8192]byte
+	C.bignum_to_string( &n, buf, 8192)
 	// NB: bignum_to_string , returns the HEXADECIMAL representation of the bignum n
 	s := tos_clone( buf )
 	if s.len == 0 { return '0' }

--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -6,81 +6,81 @@ fn test_new_big(){
 	assert n.hexstr() == '0'
 }
 
-fn test_from_int(){
-	assert big.from_int(255).hexstr() == 'ff'
-	assert big.from_int(127).hexstr() == '7f'
-	assert big.from_int(1024).hexstr() == '400'
-	assert big.from_int(2147483647).hexstr() == '7fffffff'
-	assert big.from_int(-1).hexstr() == 'ffffffffffffffff'
-}
+// fn test_from_int(){
+// 	assert big.from_int(255).hexstr() == 'ff'
+// 	assert big.from_int(127).hexstr() == '7f'
+// 	assert big.from_int(1024).hexstr() == '400'
+// 	assert big.from_int(2147483647).hexstr() == '7fffffff'
+// 	assert big.from_int(-1).hexstr() == 'ffffffffffffffff'
+// }
 
-fn test_from_u64(){
-	assert big.from_u64(255).hexstr() == 'ff'
-	assert big.from_u64(127).hexstr() == '7f'
-	assert big.from_u64(1024).hexstr() == '400'
-	assert big.from_u64(4294967295).hexstr() == 'ffffffff'
-	assert big.from_u64(4398046511104).hexstr() == '40000000000'
-	assert big.from_u64(-1).hexstr() == 'ffffffffffffffff'
-}
+// fn test_from_u64(){
+// 	assert big.from_u64(255).hexstr() == 'ff'
+// 	assert big.from_u64(127).hexstr() == '7f'
+// 	assert big.from_u64(1024).hexstr() == '400'
+// 	assert big.from_u64(4294967295).hexstr() == 'ffffffff'
+// 	assert big.from_u64(4398046511104).hexstr() == '40000000000'
+// 	assert big.from_u64(-1).hexstr() == 'ffffffffffffffff'
+// }
 
-fn test_plus(){
-	a := big.from_u64(2)
-	b := big.from_u64(3)
-	c := a + b
-	assert c.hexstr() == '5'
-	assert (big.from_u64(1024) + big.from_u64(1024)).hexstr() == '800'
-}
+// fn test_plus(){
+// 	a := big.from_u64(2)
+// 	b := big.from_u64(3)
+// 	c := a + b
+// 	assert c.hexstr() == '5'
+// 	assert (big.from_u64(1024) + big.from_u64(1024)).hexstr() == '800'
+// }
 
-fn test_minus(){
-	a := big.from_u64(2)
-	b := big.from_u64(3)
-	c := b - a
-	assert c.hexstr() == '1'
-	e := big.from_u64(1024)
-	ee := e - e
-	assert ee.hexstr() == '0'
-}
+// fn test_minus(){
+// 	a := big.from_u64(2)
+// 	b := big.from_u64(3)
+// 	c := b - a
+// 	assert c.hexstr() == '1'
+// 	e := big.from_u64(1024)
+// 	ee := e - e
+// 	assert ee.hexstr() == '0'
+// }
 
-fn test_divide(){
-	a := big.from_u64(2)
-	b := big.from_u64(3)
-	c := b / a
-	assert c.hexstr() == '1'
-	assert (b % a ).hexstr() == '1'
-	e := big.from_u64(1024) // dec(1024) == hex(0x400)
-	ee := e / e
-	assert ee.hexstr() == '1'
-	assert (e / a).hexstr() == '200'
-	assert (e / (a*a)).hexstr() == '100'
-}
+// fn test_divide(){
+// 	a := big.from_u64(2)
+// 	b := big.from_u64(3)
+// 	c := b / a
+// 	assert c.hexstr() == '1'
+// 	assert (b % a ).hexstr() == '1'
+// 	e := big.from_u64(1024) // dec(1024) == hex(0x400)
+// 	ee := e / e
+// 	assert ee.hexstr() == '1'
+// 	assert (e / a).hexstr() == '200'
+// 	assert (e / (a*a)).hexstr() == '100'
+// }
 
-fn test_multiply(){
-	a := big.from_u64(2)
-	b := big.from_u64(3)
-	c := b * a
-	assert c.hexstr() == '6'
-	e := big.from_u64(1024)
-	e2 := e * e
-	e4 := e2 * e2
-	e8 := e2 * e2 * e2 * e2
-	e9 := e8 + big.from_u64(1)
-	d  := ((e9 * e9) + b) * c
-	assert e4.hexstr() == '10000000000'
-	assert e8.hexstr() == '100000000000000000000'
-	assert e9.hexstr() == '100000000000000000001'
-	assert d.hexstr() == '60000000000000000000c00000000000000000018'
-}
+// fn test_multiply(){
+// 	a := big.from_u64(2)
+// 	b := big.from_u64(3)
+// 	c := b * a
+// 	assert c.hexstr() == '6'
+// 	e := big.from_u64(1024)
+// 	e2 := e * e
+// 	e4 := e2 * e2
+// 	e8 := e2 * e2 * e2 * e2
+// 	e9 := e8 + big.from_u64(1)
+// 	d  := ((e9 * e9) + b) * c
+// 	assert e4.hexstr() == '10000000000'
+// 	assert e8.hexstr() == '100000000000000000000'
+// 	assert e9.hexstr() == '100000000000000000001'
+// 	assert d.hexstr() == '60000000000000000000c00000000000000000018'
+// }
 
-fn test_mod(){
-	assert (big.from_u64(13) % big.from_u64(10) ).int() == 3
-	assert (big.from_u64(13) % big.from_u64(9) ).int()  == 4
-	assert (big.from_u64(7) % big.from_u64(5) ).int() == 2
-}
+// fn test_mod(){
+// 	assert (big.from_u64(13) % big.from_u64(10) ).int() == 3
+// 	assert (big.from_u64(13) % big.from_u64(9) ).int()  == 4
+// 	assert (big.from_u64(7) % big.from_u64(5) ).int() == 2
+// }
 
 
-fn test_factorial(){
-	f5 := big.factorial( big.from_u64(5) )
-	assert f5.hexstr() == '78'
-	f100 := big.factorial( big.from_u64(100) )
-	assert f100.hexstr() == '1b30964ec395dc24069528d54bbda40d16e966ef9a70eb21b5b2943a321cdf10391745570cca9420c6ecb3b72ed2ee8b02ea2735c61a000000000000000000000000'
-}
+// fn test_factorial(){
+// 	f5 := big.factorial( big.from_u64(5) )
+// 	assert f5.hexstr() == '78'
+// 	f100 := big.factorial( big.from_u64(100) )
+// 	assert f100.hexstr() == '1b30964ec395dc24069528d54bbda40d16e966ef9a70eb21b5b2943a321cdf10391745570cca9420c6ecb3b72ed2ee8b02ea2735c61a000000000000000000000000'
+// }

--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -6,81 +6,81 @@ fn test_new_big(){
 	assert n.hexstr() == '0'
 }
 
-// fn test_from_int(){
-// 	assert big.from_int(255).hexstr() == 'ff'
-// 	assert big.from_int(127).hexstr() == '7f'
-// 	assert big.from_int(1024).hexstr() == '400'
-// 	assert big.from_int(2147483647).hexstr() == '7fffffff'
-// 	assert big.from_int(-1).hexstr() == 'ffffffffffffffff'
-// }
+fn test_from_int(){
+	assert big.from_int(255).hexstr() == 'ff'
+	assert big.from_int(127).hexstr() == '7f'
+	assert big.from_int(1024).hexstr() == '400'
+	assert big.from_int(2147483647).hexstr() == '7fffffff'
+	assert big.from_int(-1).hexstr() == 'ffffffffffffffff'
+}
 
-// fn test_from_u64(){
-// 	assert big.from_u64(255).hexstr() == 'ff'
-// 	assert big.from_u64(127).hexstr() == '7f'
-// 	assert big.from_u64(1024).hexstr() == '400'
-// 	assert big.from_u64(4294967295).hexstr() == 'ffffffff'
-// 	assert big.from_u64(4398046511104).hexstr() == '40000000000'
-// 	assert big.from_u64(-1).hexstr() == 'ffffffffffffffff'
-// }
+fn test_from_u64(){
+	assert big.from_u64(255).hexstr() == 'ff'
+	assert big.from_u64(127).hexstr() == '7f'
+	assert big.from_u64(1024).hexstr() == '400'
+	assert big.from_u64(4294967295).hexstr() == 'ffffffff'
+	assert big.from_u64(4398046511104).hexstr() == '40000000000'
+	assert big.from_u64(-1).hexstr() == 'ffffffffffffffff'
+}
 
-// fn test_plus(){
-// 	a := big.from_u64(2)
-// 	b := big.from_u64(3)
-// 	c := a + b
-// 	assert c.hexstr() == '5'
-// 	assert (big.from_u64(1024) + big.from_u64(1024)).hexstr() == '800'
-// }
+fn test_plus(){
+	a := big.from_u64(2)
+	b := big.from_u64(3)
+	c := a + b
+	assert c.hexstr() == '5'
+	assert (big.from_u64(1024) + big.from_u64(1024)).hexstr() == '800'
+}
 
-// fn test_minus(){
-// 	a := big.from_u64(2)
-// 	b := big.from_u64(3)
-// 	c := b - a
-// 	assert c.hexstr() == '1'
-// 	e := big.from_u64(1024)
-// 	ee := e - e
-// 	assert ee.hexstr() == '0'
-// }
+fn test_minus(){
+	a := big.from_u64(2)
+	b := big.from_u64(3)
+	c := b - a
+	assert c.hexstr() == '1'
+	e := big.from_u64(1024)
+	ee := e - e
+	assert ee.hexstr() == '0'
+}
 
-// fn test_divide(){
-// 	a := big.from_u64(2)
-// 	b := big.from_u64(3)
-// 	c := b / a
-// 	assert c.hexstr() == '1'
-// 	assert (b % a ).hexstr() == '1'
-// 	e := big.from_u64(1024) // dec(1024) == hex(0x400)
-// 	ee := e / e
-// 	assert ee.hexstr() == '1'
-// 	assert (e / a).hexstr() == '200'
-// 	assert (e / (a*a)).hexstr() == '100'
-// }
+fn test_divide(){
+	a := big.from_u64(2)
+	b := big.from_u64(3)
+	c := b / a
+	assert c.hexstr() == '1'
+	assert (b % a ).hexstr() == '1'
+	e := big.from_u64(1024) // dec(1024) == hex(0x400)
+	ee := e / e
+	assert ee.hexstr() == '1'
+	assert (e / a).hexstr() == '200'
+	assert (e / (a*a)).hexstr() == '100'
+}
 
-// fn test_multiply(){
-// 	a := big.from_u64(2)
-// 	b := big.from_u64(3)
-// 	c := b * a
-// 	assert c.hexstr() == '6'
-// 	e := big.from_u64(1024)
-// 	e2 := e * e
-// 	e4 := e2 * e2
-// 	e8 := e2 * e2 * e2 * e2
-// 	e9 := e8 + big.from_u64(1)
-// 	d  := ((e9 * e9) + b) * c
-// 	assert e4.hexstr() == '10000000000'
-// 	assert e8.hexstr() == '100000000000000000000'
-// 	assert e9.hexstr() == '100000000000000000001'
-// 	assert d.hexstr() == '60000000000000000000c00000000000000000018'
-// }
+fn test_multiply(){
+	a := big.from_u64(2)
+	b := big.from_u64(3)
+	c := b * a
+	assert c.hexstr() == '6'
+	e := big.from_u64(1024)
+	e2 := e * e
+	e4 := e2 * e2
+	e8 := e2 * e2 * e2 * e2
+	e9 := e8 + big.from_u64(1)
+	d  := ((e9 * e9) + b) * c
+	assert e4.hexstr() == '10000000000'
+	assert e8.hexstr() == '100000000000000000000'
+	assert e9.hexstr() == '100000000000000000001'
+	assert d.hexstr() == '60000000000000000000c00000000000000000018'
+}
 
-// fn test_mod(){
-// 	assert (big.from_u64(13) % big.from_u64(10) ).int() == 3
-// 	assert (big.from_u64(13) % big.from_u64(9) ).int()  == 4
-// 	assert (big.from_u64(7) % big.from_u64(5) ).int() == 2
-// }
+fn test_mod(){
+	assert (big.from_u64(13) % big.from_u64(10) ).int() == 3
+	assert (big.from_u64(13) % big.from_u64(9) ).int()  == 4
+	assert (big.from_u64(7) % big.from_u64(5) ).int() == 2
+}
 
 
-// fn test_factorial(){
-// 	f5 := big.factorial( big.from_u64(5) )
-// 	assert f5.hexstr() == '78'
-// 	f100 := big.factorial( big.from_u64(100) )
-// 	assert f100.hexstr() == '1b30964ec395dc24069528d54bbda40d16e966ef9a70eb21b5b2943a321cdf10391745570cca9420c6ecb3b72ed2ee8b02ea2735c61a000000000000000000000000'
-// }
+fn test_factorial(){
+	f5 := big.factorial( big.from_u64(5) )
+	assert f5.hexstr() == '78'
+	f100 := big.factorial( big.from_u64(100) )
+	assert f100.hexstr() == '1b30964ec395dc24069528d54bbda40d16e966ef9a70eb21b5b2943a321cdf10391745570cca9420c6ecb3b72ed2ee8b02ea2735c61a000000000000000000000000'
+}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -796,7 +796,7 @@ fn (g mut Gen) gen_fn_decl(it ast.FnDecl) {
 	} else {
 		mut name := it.name
 		c := name[0]
-		if c in [`+`, `-`, `*`, `/`] {
+		if c in [`+`, `-`, `*`, `/`, `%`] {
 			name = util.replace_op(name)
 		}
 		if it.is_method {
@@ -1436,7 +1436,7 @@ fn (g mut Gen) infix_expr(node ast.InfixExpr) {
 		g.write(',')
 		g.expr(node.right)
 		g.write(')')
-	} else if node.op in [.plus, .minus, .mul, .div] && (left_sym.name[0].is_capital() || left_sym.name.contains('.')) &&
+	} else if node.op in [.plus, .minus, .mul, .div, .mod] && (left_sym.name[0].is_capital() || left_sym.name.contains('.')) &&
 		left_sym.kind != .alias {
 		// !left_sym.is_number() {
 		g.write(g.typ(node.left_type))

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -211,6 +211,9 @@ fn replace_op(s string) string {
 		`/` {
 			'_div'
 		}
+		`%` {
+			'_mod'
+		}
 		else {
 			''
 		}


### PR DESCRIPTION
This PR fix vlib/math/big/big_test.v.

```
C:\Users\yuyi9\v>v test vlib/math/big
---------------------------------------- Testing... --------------------------------------
OK    1016 ms [1/1] vlib/math/big\big_test.v
------------------------------------------------------------------------------------------
    1016 ms <=== total time spent running V _test.v files
                 ok, fail, skip, total =     1,     0,     0,     1
```

**Solution**

- Add missing `%` process in cgen.v and util.v.
- Temporarily specify the flag path, and then solve the VROOT problem.