### PR TITLE
parser: fix string position

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -164,7 +164,7 @@ pub fn (c mut Checker) infix_expr(infix_expr mut ast.InfixExpr) table.Type {
 	if infix_expr.op == .left_shift {
 		if left.kind != .array && !left.is_int() {
 			// c.error('<< can only be used with numbers and arrays', infix_expr.pos)
-			c.error('incompatible types: $left.name << $right.name', infix_expr.pos)
+			c.error('cannot shift type $right.name into $left.name', expr_pos(infix_expr.right))
 			return table.void_type
 		}
 		if left.kind == .array {
@@ -178,7 +178,7 @@ pub fn (c mut Checker) infix_expr(infix_expr mut ast.InfixExpr) table.Type {
 				// []T << []T
 				return table.void_type
 			}
-			c.error('incompatible types: $left.name << $right.name', infix_expr.pos)
+			c.error('cannot shift type $right.name into $left.name', expr_pos(infix_expr.right))
 			return table.void_type
 		}
 	}

--- a/vlib/v/checker/tests/inout/left_shift_err.out
+++ b/vlib/v/checker/tests/inout/left_shift_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/inout/left_shift_err.v:3:7: error: cannot shift type string into array_int
+    1| fn main() {
+    2|     l := []int
+    3|     l << 'test'
+                ~~~~~~
+    4| }

--- a/vlib/v/checker/tests/inout/left_shift_err.vv
+++ b/vlib/v/checker/tests/inout/left_shift_err.vv
@@ -1,0 +1,4 @@
+fn main() {
+	l := []int
+	l << 'test'
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1228,7 +1228,6 @@ fn (p mut Parser) if_expr() ast.IfExpr {
 }
 
 fn (p mut Parser) string_expr() ast.Expr {
-	first_pos := p.tok.position()
 	is_raw := p.tok.kind == .name && p.tok.lit == 'r'
 	is_cstr := p.tok.kind == .name && p.tok.lit == 'c'
 	if is_raw || is_cstr {
@@ -1236,14 +1235,9 @@ fn (p mut Parser) string_expr() ast.Expr {
 	}
 	mut node := ast.Expr{}
 	val := p.tok.lit
+	pos := p.tok.position()
 	if p.peek_tok.kind != .str_dollar {
 		p.next()
-		last_pos := p.tok.position()
-		pos := token.Position{
-			line_nr: first_pos.line_nr
-			pos: first_pos.pos
-			len: last_pos.pos - first_pos.pos
-		}
 		node = ast.StringLiteral{
 			val: val
 			is_raw: is_raw
@@ -1284,12 +1278,6 @@ fn (p mut Parser) string_expr() ast.Expr {
 			}
 		}
 		efmts << efmt.join('')
-	}
-	last_pos := p.tok.position()
-	pos := token.Position{
-		line_nr: first_pos.line_nr
-		pos: first_pos.pos
-		len: last_pos.pos - first_pos.pos
 	}
 	node = ast.StringInterLiteral{
 		vals: vals


### PR DESCRIPTION
```
vlib/v/checker/tests/inout/left_shift_err.v:3:7: error: cannot shift type string into array_int
    1| fn main() {
    2|     l := []int
    3|     l << 'test'
                ~~~~~~
    4| }
```