### PR TITLE
util: fix col on error

### DIFF
--- a/vlib/v/util/errors.v
+++ b/vlib/v/util/errors.v
@@ -64,7 +64,7 @@ pub fn formatted_error(kind string /*error or warn*/, emsg string, filepath stri
 		}
 	}
 	column := util.imax(0, pos.pos - p - 1)
-	position := '${path}:${pos.line_nr+1}:${util.imax(1,column+1)}:'
+	position := '${path}:${pos.line_nr+1}:${util.imax(1,column)}:'
 	//
 	bline := util.imax(0, pos.line_nr - error_context_before)
 	aline := util.imin(source_lines.len-1, pos.line_nr + error_context_after)


### PR DESCRIPTION
```
fn main() {
	l := []int
	l << 'test'
}
```

previous:
```
abc.v:6:7: error: cannot shift type string into array_int
```
![image](https://user-images.githubusercontent.com/30751516/78993217-81da2480-7b3d-11ea-9439-0b37f6cbf7e1.png)

now:
```
abc.v:6:6: error: cannot shift type string into array_int 
```