### PR TITLE
script: optimize script and repl processing

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -324,11 +324,8 @@ pub fn (p mut Parser) top_stmt() ast.Stmt {
 		}
 		else {
 			if p.pref.is_script && !p.pref.is_test {
-				p.scanner.text = 'fn main() {' + p.scanner.text + '}'
-				p.scanner.is_started = false
-				p.scanner.pos = 0
-				p.next()
-				p.next()
+				p.scanner.add_fn_main_and_rescan()
+				p.read_first_token()
 				return p.top_stmt()
 			} else {
 				p.error('bad top level statement ' + p.tok.str())

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -77,6 +77,14 @@ pub fn new_scanner(text string, comments_mode CommentsMode) &Scanner {
 	}
 }
 
+pub fn (s &Scanner) add_fn_main_and_rescan() {
+	s.text = 'fn main() {' + s.text + '}'
+	s.is_started = false
+	s.pos = 0
+	s.line_nr = 0
+	s.last_nl_pos = 0
+}
+
 fn (s &Scanner) new_token(tok_kind token.Kind, lit string, len int) token.Token {
 	return token.Token{
 		kind: tok_kind


### PR DESCRIPTION
This PR optimize script and repl processing.

```v
        ...
	if p.pref.is_script && !p.pref.is_test {
		p.scanner.add_fn_main_and_rescan()
		p.read_first_token()
		return p.top_stmt()
         ...
```

- Add `add_fn_main_and_rescan` in scanner.v to avoid operate scanner.text parameter directly.
- Use `read_first_token` instead of calling `next` twice.