### PR TITLE
parser: better error on short init struct

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -813,12 +813,17 @@ pub fn (p mut Parser) expr(precedence int) ast.Expr {
 			if p.tok.kind == .string {
 				node = p.map_init()
 			} else {
+				// it should be a struct
 				if p.peek_tok.kind == .pipe {
 					node = p.assoc()
 				} else if p.peek_tok.kind == .colon || p.tok.kind == .rcbr {
 					node = p.struct_init(true)					// short_syntax: true
+				} else if p.tok.kind == .name {
+					p.next()
+					lit := if p.tok.lit != '' { p.tok.lit } else { p.tok.kind.str() }
+					p.error('unexpected ‘$lit‘, expecting ‘:‘')
 				} else {
-					p.error('unexpected {')
+					p.error('unexpected ‘$p.tok.lit‘, expecting struct key')
 				}
 			}
 			p.check(.rcbr)

--- a/vlib/v/tests/short_struct_param_syntax_test.v
+++ b/vlib/v/tests/short_struct_param_syntax_test.v
@@ -1,0 +1,18 @@
+struct TOptions {
+	a int
+}
+
+fn t(options TOptions) bool {
+	if options.a == 1 {
+	  return true
+	}
+	return false
+}
+
+fn test_short_struct_as_parameter(){
+	if t({a: 1}) {
+		assert true
+		return
+	}
+	assert false
+}


### PR DESCRIPTION
Fixes #4320

Shows:
```
abc.v:12:14: error: unexpected ‘}‘, expecting ‘:‘ 
   10| 
   11| fn main() {
   12|     test({ test })
                       ^
   13| }
```

and:
```
abc.v:12:9: error: unexpected ‘1‘, expecting struct key 
   10| 
   11| fn main() {
   12|     test({ 1 })
                  ^
   13| }
```