### PR TITLE
parser: fix inter literal format error

### DIFF
--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -397,16 +397,32 @@ fn test_to_num() {
 	f := '71.5 hasdf'
 	// QTODO
 	//assert f.f32() == 71.5
-	b := 1.52345
-	mut a := '${b:.03f}'
-	assert a == '1.523'
-	num := 7
-	a = '${num:03d}'
 	vals := ['9']
 	assert vals[0].int() == 9
 	big := '93993993939322'
 	assert big.u64() == 93993993939322
 	assert big.i64() == 93993993939322
+}
+
+fn test_inter_format_string() {
+	float_num := 1.52345
+	float_num_string := '-${float_num:.03f}-'
+	assert float_num_string == '-1.523-'
+	int_num := 7
+	int_num_string := '-${int_num:03d}-'
+	assert int_num_string == '-007-'
+	ch := `a`
+	ch_string := '-${ch:c}-'
+	assert ch_string == '-a-'
+	hex_n := 192
+	hex_n_string := '-${hex_n:x}-'
+	assert hex_n_string == '-c0-'
+	oct_n := 192
+	oct_n_string := '-${oct_n:o}-'
+	assert oct_n_string == '-300-'
+	str := 'abc'
+	str_string := '-${str:s}-'
+	assert str_string == '-abc-'
 }
 
 fn test_hash() {
@@ -687,4 +703,3 @@ fn test_split_into_lines() {
 		assert line == line_content
 	}
 }
-

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1274,16 +1274,17 @@ fn (p mut Parser) string_expr() ast.Expr {
 		if p.tok.kind == .colon {
 			efmt << ':'
 			p.next()
-		}
-		// ${num:-2d}
-		if p.tok.kind == .minus {
-			efmt << '-'
-			p.next()
-		}
-		// ${num:2d}
-		if p.tok.kind == .number {
-			efmt << p.tok.lit
-			p.next()
+
+			// ${num:-2d}
+			if p.tok.kind == .minus {
+				efmt << '-'
+				p.next()
+			}
+			// ${num:2d}
+			if p.tok.kind == .number {
+				efmt << p.tok.lit
+				p.next()
+			}
 			if p.tok.lit.len == 1 {
 				efmt << p.tok.lit
 				p.next()


### PR DESCRIPTION
This PR fix inter literal format error.

- Fix `'${num:c}'` similar situation.
- Add `fn test_inter_format_string()` in string_test.v.
