### PR TITLE
net: fix check if socket descriptor is valid

### DIFF
--- a/vlib/net/socket.v
+++ b/vlib/net/socket.v
@@ -90,7 +90,7 @@ pub fn new_socket(family int, _type int, proto int) ?Socket {
 	// This is needed so that there are no problems with reusing the
 	// same port after the application exits.
 	C.setsockopt(sockfd, C.SOL_SOCKET, C.SO_REUSEADDR, &one, sizeof(int))
-	if sockfd == 0 {
+	if sockfd == -1 {
 		return error('net.socket: failed')
 	}
 	s := Socket{


### PR DESCRIPTION
Ref http://man7.org/linux/man-pages/man2/socket.2.html.
Ref https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-socket.

Windows, provides an `INVALID_SOCKET` constant, which is -1, but there's no constant on Linux, so I kept a magic number. :) We can define our own constant in the `socket` module, though.