### PR TITLE
ci: don't run `backtrace_test` twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,6 @@ jobs:
       run: ./v -o v2 cmd/v && ./v2 -o v3 cmd/v && ./v3 -o v4 cmd/v
     - name: Fixed tests
       run: |
-        ./v vlib/v/tests/backtrace_test.v
         ./v test-fixed
     - name: x64 machine code generation
       run: |
@@ -273,7 +272,6 @@ jobs:
         .\make.bat -msvc
     - name: Fixed tests
       run: |
-        ./v vlib/v/tests/backtrace_test.v
         ./v test-fixed
 #    - name: Test
 #      run: |


### PR DESCRIPTION
`backtrace_test` is actually run via `v test-fixed`.