### PR TITLE
tests: run vfmt

### DIFF
--- a/vlib/v/tests/array_equality_test.v
+++ b/vlib/v/tests/array_equality_test.v
@@ -8,13 +8,13 @@ enum Color {
 }
 
 fn test_array_equality() {
-	strs := ["a", "b", "c"]
-	assert strs == ["a", "b", "c"]
-	assert strs != ["a", "c", "b"]
-	assert strs != ["b", "c", "a"]
-	assert strs != ["b", "a", "c"]
-	assert strs != ["c", "b", "a"]
-	assert strs != ["c", "a", "b"]
+	strs := ['a', 'b', 'c']
+	assert strs == ['a', 'b', 'c']
+	assert strs != ['a', 'c', 'b']
+	assert strs != ['b', 'c', 'a']
+	assert strs != ['b', 'a', 'c']
+	assert strs != ['c', 'b', 'a']
+	assert strs != ['c', 'a', 'b']
 	bools := [true, true, false]
 	assert bools == [true, true, false]
 	assert bools != [true, false, false]

--- a/vlib/v/tests/array_to_string_test.v
+++ b/vlib/v/tests/array_to_string_test.v
@@ -1,5 +1,5 @@
 fn test_array_to_string_conversion() {
-  expected := '["1", "2", "3", "4"] '
-  arr := ['1', '2', '3', '4']
-  assert '$arr' == expected
+	expected := '["1", "2", "3", "4"]'
+	arr := ['1', '2', '3', '4']
+	assert arr.str() == expected
 }

--- a/vlib/v/tests/backtrace_test.v
+++ b/vlib/v/tests/backtrace_test.v
@@ -2,10 +2,10 @@
  Test for backtrace capability
 */
 fn a_method() {
-	print_backtrace() 
+	print_backtrace()
 }
 
 fn test_backtrace() {
 	a_method()
-	//panic('hi')
+	// panic('hi')
 }

--- a/vlib/v/tests/comptime_bittness_and_endianess_test.v
+++ b/vlib/v/tests/comptime_bittness_and_endianess_test.v
@@ -1,26 +1,25 @@
-
-fn test_bitness(){
-  mut x := 0
-  $if x32 {
-    println('system is 32 bit')
-    x = 1
-  }
-  $if x64 {
-    println('system is 64 bit')
-    x = 2
-  }
-  assert x > 0
+fn test_bitness() {
+	mut x := 0
+	$if x32 {
+		println('system is 32 bit')
+		x = 1
+	}
+	$if x64 {
+		println('system is 64 bit')
+		x = 2
+	}
+	assert x > 0
 }
 
-fn test_endianness(){
-  mut x := 0
-  $if little_endian {
-    println('system is little endian')
-    x = 1
-  }
-  $if big_endian {
-    println('system is big endian')
-    x = 2
-  }
-  assert x > 0
+fn test_endianness() {
+	mut x := 0
+	$if little_endian {
+		println('system is little endian')
+		x = 1
+	}
+	$if big_endian {
+		println('system is big endian')
+		x = 2
+	}
+	assert x > 0
 }

--- a/vlib/v/tests/const_test.v
+++ b/vlib/v/tests/const_test.v
@@ -6,10 +6,6 @@ pub const (
 	e = 9
 )
 
-struct Foo {
-	
-}	
-
 fn test_const() {
 	assert a == 1
 	assert d == 11

--- a/vlib/v/tests/differently_named_structs_test.v
+++ b/vlib/v/tests/differently_named_structs_test.v
@@ -5,12 +5,12 @@ struct DeclExprA { name string }
 struct AStructWithAVeryLongName { name string }
 
 fn test_struct_names_can_be_used_for_creating_them() {
-   a := DB{}
-   assert true
-   b := DxB{}
-   assert true
-   c := DeclExprA{}
-   assert true
-   d := AStructWithAVeryLongName{}
-   assert true
+	a := DB{}
+	assert true
+	b := DxB{}
+	assert true
+	c := DeclExprA{}
+	assert true
+	d := AStructWithAVeryLongName{}
+	assert true
 }

--- a/vlib/v/tests/enum_bitfield_test.v
+++ b/vlib/v/tests/enum_bitfield_test.v
@@ -17,14 +17,12 @@ fn test_enum_bitfield() {
 	a.perm.set(.write)
 	a.perm.toggle(.execute)
 	a.perm.clear(.write)
-	//a.perm.set(.other)
-
+	// a.perm.set(.other)
 	assert a.perm.has(.read)
 	assert a.perm.has(.execute)
 	assert !a.perm.has(.write)
 	assert !a.perm.has(.other)
-
-	mut b := BfPermission.read // TODO:  this does nothing currenty just sets the type
+	mut b := BfPermission.read	// TODO:  this does nothing currenty just sets the type
 	b.set(.write)
 	b.set(.other)
 	assert b.has(.write)

--- a/vlib/v/tests/enum_test.v
+++ b/vlib/v/tests/enum_test.v
@@ -34,7 +34,7 @@ fn test_enum() {
 
 fn test_in() {
 	color := Color.red
-	num := 3 // used to be an expr bug before `in`
+	num := 3	// used to be an expr bug before `in`
 	assert color in [.red, .green]
 	assert num == 3
 	println(color)
@@ -103,9 +103,7 @@ fn test_typed_enum() {
 	*/
 }
 */
-
 /*
-
 fn test_typed_enum() {
 	Expr i = { .obj = 10, .typ = IntExpr_type };
 	Expr expr = { .obj = true, .typ = BoolExpr_type };

--- a/vlib/v/tests/fixed_array_test.v
+++ b/vlib/v/tests/fixed_array_test.v
@@ -1,12 +1,11 @@
-
-fn test_fixed_array_can_be_assigned(){
+fn test_fixed_array_can_be_assigned() {
 	x := 2.32
 	mut v := [8]f64
 	v = [1.0, x, 3.0,4.0,5.0,6.0,7.0,8.0]!!
 	assert v[1] == x
 }
 
-fn test_fixed_array_can_be_used_in_declaration(){
+fn test_fixed_array_can_be_used_in_declaration() {
 	x := 2.32
 	v := [1.0, x, 3.0,4.0,5.0,6.0,7.0,8.0]!!
 	assert v[1] == x
@@ -17,7 +16,8 @@ struct Context {
 	pub mut:
 	vb [8]f64
 }
-fn test_fixed_array_can_be_assigned_to_a_struct_field(){
+
+fn test_fixed_array_can_be_assigned_to_a_struct_field() {
 	mut ctx := Context{}
 	x := 2.32
 	ctx.vb = [1.1, x, 3.3, 4.4, 5.0, 6.0, 7.0, 8.9]!!

--- a/vlib/v/tests/fn_expecting_ref_but_returning_struct_test.v
+++ b/vlib/v/tests/fn_expecting_ref_but_returning_struct_test.v
@@ -1,5 +1,7 @@
 struct Foo {
-   x int
+	x int
+}
+
 }
 pub fn (f Foo) str() string { return 'Foo{}' }
 
@@ -21,4 +23,4 @@ fn test_ref_fn_arg() {
 }
 */
 
-fn test_dummy(){}
+fn test_dummy() {}

--- a/vlib/v/tests/fn_expecting_ref_but_returning_struct_test.v
+++ b/vlib/v/tests/fn_expecting_ref_but_returning_struct_test.v
@@ -2,7 +2,6 @@ struct Foo {
 	x int
 }
 
-}
 pub fn (f Foo) str() string { return 'Foo{}' }
 
 fn process_foo(foo &Foo) {

--- a/vlib/v/tests/fn_expecting_ref_but_returning_struct_time_module_test.v
+++ b/vlib/v/tests/fn_expecting_ref_but_returning_struct_time_module_test.v
@@ -1,4 +1,5 @@
 import time.misc as tmisc
+
 // using a manual temporary intermediate variable should always work:
 fn test_call_fn_that_requires_reference_with_function_that_returns_a_struct_manual() {
 	t1 := tmisc.random()
@@ -10,7 +11,7 @@ fn test_call_fn_that_requires_reference_with_function_that_returns_a_struct_manu
 /*
 // TODO: Fix this.
 // v should produce temporary intermediate variables in chained calls:
-fn test_call_fn_that_requires_reference_with_function_that_returns_a_struct_chained(){
+fn test_call_fn_that_requires_reference_with_function_that_returns_a_struct_chained() {
 	res := (tmisc.random().unix_time())
 	println('res: $res')
 	assert true

--- a/vlib/v/tests/fn_multiple_returns_test.v
+++ b/vlib/v/tests/fn_multiple_returns_test.v
@@ -6,7 +6,7 @@ fn test_fn_multiple_returns() {
 	name, age, groups, data := fn_mr_get_user()
 	assert name == 'joe'
 	assert age == 34
-	assert groups[0] == 'admins' 
+	assert groups[0] == 'admins'
 	assert groups[1] == 'users'
 	assert data.test == 'Test Data'
 	println('name: $name | age: $age | groups: ' + groups.join(',') + ' | data: $data.test')
@@ -15,5 +15,5 @@ fn test_fn_multiple_returns() {
 fn fn_mr_get_user() (string, int, []string, UserData) {
 	groups := ['admins', 'users']
 	data := UserData{test: 'Test Data'}
-	return 'joe',34,groups,data
+	return 'joe', 34, groups, data
 }

--- a/vlib/v/tests/fn_test.v
+++ b/vlib/v/tests/fn_test.v
@@ -59,21 +59,21 @@ type actionf_p2 fn (voidptr, voidptr)
 // TODO
 fn modify_array(a mut []int) {
 	a[0] = 10
-	for i in 0..a.len {
+	for i in 0 .. a.len {
 		a[i] = a[i] * 2
 	}
-	//a << 888
+	// a << 888
 }
 
 fn test_mut_array() {
 	mut nums := [1, 2, 3]
 	modify_array(mut nums)
-	//assert nums.len == 4
+	// assert nums.len == 4
 	// println(nums)
 	assert nums[0] == 20
 	assert nums[1] == 4
 	assert nums[2] == 6
-	//assert nums[3] == 888
+	// assert nums[3] == 888
 	// workaround for // [91, 32, -33686272] windows bug
 	println(nums.clone())
 }
@@ -124,14 +124,13 @@ fn test_fns() {
 	high_fn(sqr)
 }
 
-
 fn test_anon_fn() {
 	/*
 	high_fn(fn (x int) int {
 		println('hello')
 		return x + 1
 	})
-	*/
+*/
 }
 
 fn assert_in_bool_fn(v int) bool {
@@ -145,10 +144,11 @@ fn test_assert_in_bool_fn() {
 
 type MyFn fn (int) int
 fn test(n int) int {
-    return n + 1000
+	return n + 1000
 }
+
 struct MySt {
-    f MyFn
+	f MyFn
 }
 fn test_fn_type_call() {
     mut arr := []MyFn
@@ -161,6 +161,3 @@ fn test_fn_type_call() {
 	st1 := &MySt{f:test}
     assert st1.f(10) == 1010
 }
-
-
-

--- a/vlib/v/tests/fn_variadic_test.v
+++ b/vlib/v/tests/fn_variadic_test.v
@@ -16,7 +16,7 @@ fn test_fn_variadic() {
 	group2 := VaTestGroup{
 		name: 'admins'
 	}
-	variadic_test('joe',group1,group2)
+	variadic_test('joe', group1, group2)
 }
 
 /*
@@ -32,7 +32,6 @@ fn test_fn_variadic_generic() {
 	assert variadic_test_generic(111, 'hello', 'v') == '111 hello v'
 }
 */
-
 // forwarding
 fn variadic_forward_a(a ...string) string {
 	return variadic_forward_b(a)
@@ -46,7 +45,7 @@ fn variadic_forward_b(a ...string) string {
 }
 
 fn test_fn_variadic_forward() {
-	assert variadic_forward_a('a','b','c') == 'abc'
+	assert variadic_forward_a('a', 'b', 'c') == 'abc'
 }
 
 fn variadic_test_no_args(name string, groups ...VaTestGroup) {
@@ -77,7 +76,7 @@ fn test_fn_variadic_method() {
 	group2 := VaTestGroup{
 		name: 'admins'
 	}
-	a.variadic_method('marko',group1,group2)
+	a.variadic_method('marko', group1, group2)
 }
 
 fn test_fn_variadic_method_no_args() {

--- a/vlib/v/tests/if_expression_test.v
+++ b/vlib/v/tests/if_expression_test.v
@@ -1,12 +1,11 @@
-
-fn test_if_expression_precedence_false_condition(){
+fn test_if_expression_precedence_false_condition() {
 	b := 10
 	c := 20
 	res := 1 + if b > c { b } else { c } + 1
 	assert res == c + 2
 }
 
-fn test_if_expression_precedence_true_condition(){
+fn test_if_expression_precedence_true_condition() {
 	b := 20
 	c := 10
 	res := 1 + if b > c { b } else { c } + 1

--- a/vlib/v/tests/in_expression_test.v
+++ b/vlib/v/tests/in_expression_test.v
@@ -2,7 +2,7 @@ enum Colors {
 	red green blue yellow
 }
 
-fn test_in_expression(){
+fn test_in_expression() {
 	mut a := false
 	arr1 := [1, 2]
 	arr2 := [0, 2]
@@ -15,24 +15,23 @@ fn test_in_expression(){
 	assert a == true
 	a = false && 0 in arr3
 	assert a == false
-
 	a = true && 0 in arr1
 	assert a == false
 	a = true && 3 in arr1
 	assert a == false
-
 	a = true && !(2 in arr2)
 	assert a == false
 	a = true && !(3 in arr2)
 	assert a == true
-
 	a = 1 in arr1 && true
 	assert a == true
 	a = 1 in arr1 && false
 	assert a == false
 }
-/* not implemented
-fn test_in_expression_with_enum(){
+
+/*
+not implemented
+fn test_in_expression_with_enum() {
 	mut a := false
 	arr1 := [Colors.green, .blue]
 	arr2 := [Colors.red, .blue]
@@ -62,7 +61,7 @@ fn test_in_expression_with_enum(){
 	assert a == false
 }
 */
-fn test_in_expression_with_string(){
+fn test_in_expression_with_string() {
 	mut a := false
 	arr1 := ['ab', 'bc']
 	arr2 := ['', 'bc']
@@ -75,24 +74,21 @@ fn test_in_expression_with_string(){
 	assert a == true
 	a = false && '' in arr3
 	assert a == false
-
 	a = true && '' in arr1
 	assert a == false
 	a = true && 'abc' in arr1
 	assert a == false
-
 	a = true && !('bc' in arr2)
 	assert a == false
 	a = true && !('abc' in arr2)
 	assert a == true
-
 	a = 'ab' in arr1 && true
 	assert a == true
 	a = 'ab' in arr1 && false
 	assert a == false
 }
 
-fn test_optimized_in_expression(){
+fn test_optimized_in_expression() {
 	mut a := false
 	a = true && 2 in [1, 2]
 	assert a == true
@@ -102,24 +98,21 @@ fn test_optimized_in_expression(){
 	assert a == true
 	a = false && 0 in [1, 0]
 	assert a == false
-
 	a = true && 0 in [1, 2]
 	assert a == false
 	a = true && 3 in [1, 2]
 	assert a == false
-
 	a = true && !(2 in [0, 2])
 	assert a == false
 	a = true && !(3 in [0, 2])
 	assert a == true
-
 	a = 1 in [1, 2] && true
 	assert a == true
 	a = 1 in [1, 2] && false
 	assert a == false
 }
 
-fn test_optimized_in_expression_with_enum(){
+fn test_optimized_in_expression_with_enum() {
 	mut a := false
 	a = true && Colors.blue in [.green, .blue]
 	assert a == true
@@ -129,24 +122,21 @@ fn test_optimized_in_expression_with_enum(){
 	assert a == true
 	a = false && Colors.red in [.green, .red]
 	assert a == false
-
 	a = true && Colors.red in [.green, .blue]
 	assert a == false
 	a = true && Colors.yellow in [.green, .blue]
 	assert a == false
-
 	a = true && !(Colors.blue in [.red, .blue])
 	assert a == false
 	a = true && !(Colors.yellow in [.red, .blue])
 	assert a == true
-
 	a = Colors.green in [.green, .blue] && true
 	assert a == true
 	a = Colors.green in [.green, .blue] && false
 	assert a == false
 }
 
-fn test_optimized_in_expression_with_string(){
+fn test_optimized_in_expression_with_string() {
 	mut a := false
 	a = true && 'bc' in ['ab', 'bc']
 	assert a == true
@@ -156,17 +146,14 @@ fn test_optimized_in_expression_with_string(){
 	assert a == true
 	a = false && '' in ['ab', '']
 	assert a == false
-
 	a = true && '' in ['ab', 'bc']
 	assert a == false
 	a = true && 'abc' in ['ab', 'bc']
 	assert a == false
-
 	a = true && !('bc' in ['', 'bc'])
 	assert a == false
 	a = true && !('abc' in ['', 'bc'])
 	assert a == true
-
 	a = 'ab' in ['ab', 'bc'] && true
 	assert a == true
 	a = 'ab' in ['ab', 'bc'] && false

--- a/vlib/v/tests/interfaces_map_test.v
+++ b/vlib/v/tests/interfaces_map_test.v
@@ -1,7 +1,7 @@
 module main
 
 interface Speaker {
-	say()string
+	say() string
 }
 
 fn test_todo() {}
@@ -23,7 +23,7 @@ fn (r mut ChatRoom) add(name string, s Speaker) {
 	r.talkers[name] = s
 }
 
-fn test_using_a_map_of_speaker_interfaces(){
+fn test_using_a_map_of_speaker_interfaces() {
 	mut room := new_room()
 	room.add('my cat', Cat{name: 'Tigga'} )
 	room.add('my dog', Dog{name: 'Pirin'} )

--- a/vlib/v/tests/live_test.v
+++ b/vlib/v/tests/live_test.v
@@ -1,10 +1,12 @@
-import os
-import time
+import (
+	os
+	time
+)
 
 const (
-	vexe = os.getenv('VEXE')
-	source_file = os.join_path(os.temp_dir(), 'generated_live_program.v')
-	output_file = os.join_path(os.temp_dir(), 'generated_live_program.output.txt')
+	vexe                = os.getenv('VEXE')
+	source_file         = os.join_path(os.temp_dir(), 'generated_live_program.v')
+	output_file         = os.join_path(os.temp_dir(), 'generated_live_program.output.txt')
 	live_program_source = "
 module main
 import time
@@ -26,8 +28,7 @@ fn main() {
 )
 
 //
-
-fn testsuite_begin(){
+fn testsuite_begin() {
 	if !(os.user_os() in ['linux', 'solaris']) && os.getenv('FORCE_LIVE_TEST').len == 0 {
 		eprintln('Testing the runtime behaviour of -live mode,')
 		eprintln('is reliable only on Linux for now.')
@@ -37,22 +38,22 @@ fn testsuite_begin(){
 	os.write_file(source_file, live_program_source)
 }
 
-fn testsuite_end(){
-	os.rm( source_file )
+fn testsuite_end() {
+	os.rm(source_file)
 	eprintln('source: $source_file')
 	eprintln('output: $output_file')
 	$if !windows {
 		os.system('cat $output_file')
 	}
 	println('---------------------------------------------------------------------------')
-	output_lines := os.read_lines( output_file ) or {
+	output_lines := os.read_lines(output_file) or {
 		return
 	}
 	mut histogram := map[string]int
 	for line in output_lines {
 		histogram[line] = histogram[line] + 1
 	}
-	for k,v in histogram {
+	for k, v in histogram {
 		println('> found ${k} $v times.')
 	}
 	println('---------------------------------------------------------------------------')
@@ -62,17 +63,16 @@ fn testsuite_end(){
 	assert histogram['ORIGINAL'] > 0
 }
 
-fn change_source(new string){
+fn change_source(new string) {
 	time.sleep_ms(250)
 	eprintln('> change ORIGINAL to: $new')
-	os.write_file(source_file,live_program_source.replace('ORIGINAL', new))
+	os.write_file(source_file, live_program_source.replace('ORIGINAL', new))
 	time.sleep_ms(1000)
 	eprintln('> done.')
 }
 
 //
-
-fn test_live_program_can_be_compiled(){
+fn test_live_program_can_be_compiled() {
 	cmd := '$vexe -live run $source_file > $output_file &'
 	eprintln('Compiling and running with: $cmd')
 	res := os.system(cmd)
@@ -81,17 +81,17 @@ fn test_live_program_can_be_compiled(){
 	assert res == 0
 }
 
-fn test_live_program_can_be_changed_1(){
+fn test_live_program_can_be_changed_1() {
 	change_source('CHANGED')
 	assert true
 }
 
-fn test_live_program_can_be_changed_2(){
+fn test_live_program_can_be_changed_2() {
 	change_source('ANOTHER')
 	assert true
 }
 
-fn test_live_program_has_ended(){
-	time.sleep_ms(10*1000)
+fn test_live_program_has_ended() {
+	time.sleep_ms(10 * 1000)
 	assert true
 }

--- a/vlib/v/tests/local_test.v
+++ b/vlib/v/tests/local_test.v
@@ -1,7 +1,5 @@
-
 import v.tests.local
 
 fn test_local_module_is_callable() {
-  assert local.local_fn()
+	assert local.local_fn()
 }
-

--- a/vlib/v/tests/match_test.v
+++ b/vlib/v/tests/match_test.v
@@ -64,30 +64,29 @@ fn test_match_integers() {
     assert a == -2
 }
 
-fn test_match_enums(){
-    mut b := Color.red
-    match b{
-        .red {
-            b = .green
-        }
-        .green {
-            b = .blue
-        }
-        else {
-            println('b is ${b.str()}')
-            b = .red
-        }
-    }
-    assert b == .green
-
-    match b{
-        .red {
-            b = .green
-        }
-        else {
-            println('b is ${b.str()}')
-            b = .blue
-        }
-    }
-    assert b == .blue
+fn test_match_enums() {
+	mut b := Color.red
+	match b {
+		.red {
+			b = .green
+		}
+		.green {
+			b = .blue
+		}
+		else {
+			println('b is ${b.str()}')
+			b = .red
+		}
+	}
+	assert b == .green
+	match b {
+		.red {
+			b = .green
+		}
+		else {
+			println('b is ${b.str()}')
+			b = .blue
+		}
+	}
+	assert b == .blue
 }

--- a/vlib/v/tests/multiret_with_ptrtype_test.v
+++ b/vlib/v/tests/multiret_with_ptrtype_test.v
@@ -10,9 +10,7 @@ fn test_multi_ptrtype_ret() {
 	a, b := multi_voidptr_ret()
 	assert a == voidptr(0)
 	assert b == true
-
 	c, d := multi_byteptr_ret()
 	assert c == byteptr(0)
 	assert d == true
 }
-

--- a/vlib/v/tests/mut_test.v
+++ b/vlib/v/tests/mut_test.v
@@ -10,17 +10,17 @@ pub mut:
 
 fn foo(b int, a mut []int) {
 	a[0] = 7
-	//a << 4
+	// a << 4
 }
 
 fn test_mut() {
-	mut numbers := [1,2,3]
+	mut numbers := [1, 2, 3]
 	foo(7, mut numbers)
 	assert numbers.len == 3
 	// TODO bring back once << works with mutable args
-	//assert numbers.len == 4
-	//assert numbers[0] == 7
-	//assert numbers[3] == 4
+	// assert numbers.len == 4
+	// assert numbers[0] == 7
+	// assert numbers[3] == 4
 	println(numbers)
 	n := 1
 	mut b := &n
@@ -31,19 +31,14 @@ fn test_mut() {
 
 fn test_mut_2() {
 	zero := 0
-
 	mut b := B{}
 	b.a << A{}
-
 	b.a[0].v = [9, 8, 7]
-
 	b.a[0].v << 6
 	b.a[zero].v << 5
-
 	b.a[0].v[zero] = 3
-	b.a[0].v[b.a[zero].v[zero]]+= 2 -1 // TODO
-	b.a[0].v[b.a[0].v[zero]]+= 2 - 1 // TODO
-
+	b.a[0].v[b.a[zero].v[zero]] += 2 - 1	// TODO
+	b.a[0].v[b.a[0].v[zero]] += 2 - 1	// TODO
 	assert b.a[0].v.len == 5
 	assert b.a[0].v[0] == 3
 	assert b.a[0].v[1] == 8

--- a/vlib/v/tests/num_lit_call_method_test.v
+++ b/vlib/v/tests/num_lit_call_method_test.v
@@ -1,28 +1,28 @@
 fn test_int_lit_call_method() {
-    x1 := 1234.str()
-    assert x1 == '1234'
-    x2 := -0xffff.str()
-    assert x2 == '-65535'
-    x3 := 0b1001001.str()
-    assert x3 == '73'
-    x4 := 0o653262.str()
-    assert x4 == '218802'
-    x5 := 0.str()
-    assert x5 == '0'
+	x1 := 1234.str()
+	assert x1 == '1234'
+	x2 := -0xffff.str()
+	assert x2 == '-65535'
+	x3 := 0b1001001.str()
+	assert x3 == '73'
+	x4 := 0o653262.str()
+	assert x4 == '218802'
+	x5 := 0.str()
+	assert x5 == '0'
 }
 
 fn test_float_lit_call_method() {
-    x1 := -123.66.str()
-    assert x1 == '-1.2366e+02'
-    x2 := 12.5e-2.str()
-    assert x2 == '1.25e-01'
-    x3 := .789.str()
-    assert x3 == '7.89e-01'
-    x4 := .003e2.str()
-    assert x4 == '3.e-01'
-    x5 := 2.e-3.str() 
-    assert x5 == '2.e-03'
-    x6 := 5.0.str()
-    assert x6 == '5.e+00'
-    // x7 := 5..str()    Syntax `5.` is allowed, but do not call method on it (`5..str()` is parsed as a range). Use `5.0.str()` instead.
+	x1 := -123.66.str()
+	assert x1 == '-1.2366e+02'
+	x2 := 12.5e-2.str()
+	assert x2 == '1.25e-01'
+	x3 := .789.str()
+	assert x3 == '7.89e-01'
+	x4 := .003e2.str()
+	assert x4 == '3.e-01'
+	x5 := 2.e-3.str()
+	assert x5 == '2.e-03'
+	x6 := 5.0.str()
+	assert x6 == '5.e+00'
+	// x7 := 5..str()    Syntax `5.` is allowed, but do not call method on it (`5..str()` is parsed as a range). Use `5.0.str()` instead.
 }

--- a/vlib/v/tests/operator_overloading_with_string_interpolation_test.v
+++ b/vlib/v/tests/operator_overloading_with_string_interpolation_test.v
@@ -7,69 +7,47 @@ pub fn (a Vec) str() string {
 	return '{$a.x, $a.y}'
 }
 
-fn (a Vec) + (b Vec) Vec {
-	return Vec {
-		a.x + b.x,
-		a.y + b.y
-	}
+fn (a Vec) +(b Vec) Vec {
+	return Vec{a.x + b.x, a.y + b.y}
 }
 
-fn (a Vec) - (b Vec) Vec {
-	return Vec {
-		a.x - b.x,
-		a.y - b.y
-	}
+fn (a Vec) -(b Vec) Vec {
+	return Vec{a.x - b.x, a.y - b.y}
 }
 
-fn (a Vec) * (b Vec) Vec {
-	return Vec {
-		a.x * b.x,
-		a.y * b.y
-	}
+fn (a Vec) *(b Vec) Vec {
+	return Vec{a.x * b.x, a.y * b.y}
 }
 
-fn (a Vec) / (b Vec) Vec {
-	return Vec {
-		a.x / b.x,
-		a.y / b.y
-	}
+fn (a Vec) /(b Vec) Vec {
+	return Vec{a.x / b.x, a.y / b.y}
 }
 
-fn (a Vec) % (b Vec) Vec {
-	return Vec {
-		a.x % b.x,
-		a.y % b.y
-	}
+fn (a Vec) %(b Vec) Vec {
+	return Vec{a.x % b.x, a.y % b.y}
 }
 
 fn test_operator_overloading_with_string_interpolation() {
 	a := Vec{2, 3}
 	b := Vec{4, 5}
-	    
-    c := a + b
-    assert a.x + b.x == c.x
-    assert a.y + b.y == c.y
-    
-    d := a - b
-    assert a.x - b.x == d.x
-    assert a.y - b.y == d.y
-    
-    e := a * b
-    assert a.x * b.x == e.x
-    assert a.y * b.y == e.y
-    
-    f := a / b
-    assert a.x / b.x == f.x
-    assert a.y / b.y == f.y
-    
-    g := a % b
-    assert a.x % b.x == g.x
-    assert a.y % b.y == g.y
-    
-    assert c.str() == '{6, 8}'
-    assert d.str() == '{-2, -2}'
-    assert e.str() == '{8, 15}'
-    assert f.str() == '{0, 0}'
-    assert g.str() == '{2, 3}'
- 
+	c := a + b
+	assert a.x + b.x == c.x
+	assert a.y + b.y == c.y
+	d := a - b
+	assert a.x - b.x == d.x
+	assert a.y - b.y == d.y
+	e := a * b
+	assert a.x * b.x == e.x
+	assert a.y * b.y == e.y
+	f := a / b
+	assert a.x / b.x == f.x
+	assert a.y / b.y == f.y
+	g := a % b
+	assert a.x % b.x == g.x
+	assert a.y % b.y == g.y
+	assert c.str() == '{6, 8}'
+	assert d.str() == '{-2, -2}'
+	assert e.str() == '{8, 15}'
+	assert f.str() == '{0, 0}'
+	assert g.str() == '{2, 3}'
 }

--- a/vlib/v/tests/operator_overloading_with_string_interpolation_test.v
+++ b/vlib/v/tests/operator_overloading_with_string_interpolation_test.v
@@ -30,21 +30,27 @@ fn (a Vec) %(b Vec) Vec {
 fn test_operator_overloading_with_string_interpolation() {
 	a := Vec{2, 3}
 	b := Vec{4, 5}
+
 	c := a + b
 	assert a.x + b.x == c.x
 	assert a.y + b.y == c.y
+
 	d := a - b
 	assert a.x - b.x == d.x
 	assert a.y - b.y == d.y
+
 	e := a * b
 	assert a.x * b.x == e.x
 	assert a.y * b.y == e.y
+
 	f := a / b
 	assert a.x / b.x == f.x
 	assert a.y / b.y == f.y
+
 	g := a % b
 	assert a.x % b.x == g.x
 	assert a.y % b.y == g.y
+
 	assert c.str() == '{6, 8}'
 	assert d.str() == '{-2, -2}'
 	assert e.str() == '{8, 15}'

--- a/vlib/v/tests/pointers_test.v
+++ b/vlib/v/tests/pointers_test.v
@@ -1,6 +1,5 @@
-
 fn test_pointer_arithmetic() {
-	arr := [1,2,3,4]
+	arr := [1, 2, 3, 4]
 	unsafe {
 		mut parr := *int(arr.data)
 		parr++
@@ -15,13 +14,11 @@ fn test_multi_level_pointer_dereferencing() {
 	n := 100
 	pn := &n
 	ppn := &pn
-
 	unsafe {
 		mut pppn := &ppn
 		***pppn = 300
 		pppa := ***int(pppn)
 		assert 300 == ***pppa
 	}
-
-	assert n == 300 // updated by the unsafe pointer manipulation
+	assert n == 300	// updated by the unsafe pointer manipulation
 }

--- a/vlib/v/tests/print_test.v
+++ b/vlib/v/tests/print_test.v
@@ -1,3 +1,3 @@
 fn test_print() {
-    println(2.0)
+	println(2.0)
 }

--- a/vlib/v/tests/prod_test.v
+++ b/vlib/v/tests/prod_test.v
@@ -1,8 +1,10 @@
 // Build and run files in ./prod/ folder, comparing their output to *.expected.txt files.
 // (Similar to REPL tests, but in -prod mode.)
 // import os
-import v.tests.repl.runner
-import benchmark
+import (
+	v.tests.repl.runner
+	benchmark
+)
 
 fn test_all_v_prod_files() {
 	// TODO: Fix running this test on Windows:

--- a/vlib/v/tests/repeated_multiret_values_test.v
+++ b/vlib/v/tests/repeated_multiret_values_test.v
@@ -1,15 +1,13 @@
 // verify fix for #2913
-
-fn some_multiret_fn(a int, b int) (int, int) {
-	return a+1, b+1
+fn some_multiret_fn(a, b int) (int, int) {
+	return a + 1, b + 1
 }
 
 fn test_repeated_multiple_multiret() {
-	a, b := some_multiret_fn(1,2)
+	a, b := some_multiret_fn(1, 2)
 	assert a == 2
 	assert b == 3
-
-	c, d := some_multiret_fn(3,4)
+	c, d := some_multiret_fn(3, 4)
 	assert c == 4
 	assert d == 5
 }

--- a/vlib/v/tests/reusable_mut_multiret_values_test.v
+++ b/vlib/v/tests/reusable_mut_multiret_values_test.v
@@ -1,27 +1,23 @@
 // verify fix for #2913
-
-fn some_multiret_fn(a int, b int) (int, int) {
-	return a+1, b+1
+fn some_multiret_fn(a, b int) (int, int) {
+	return a + 1, b + 1
 }
 
 fn test_reuse_multiple_multiret() {
-	mut c, mut d := some_multiret_fn(4,10)
-
-	mut a, mut b := some_multiret_fn(c,d)
-	assert a == c+1
-	assert b == d+1
-
-	for i in 1..10 {
+	mut c, mut d := some_multiret_fn(4, 10)
+	mut a, mut b := some_multiret_fn(c, d)
+	assert a == c + 1
+	assert b == d + 1
+	for i in 1 .. 10 {
 		c += i
 		d += i
-		a, b = some_multiret_fn(c,d)
-		assert a == c+1
-		assert b == d+1
-
-		c += i+1
-		d += i+1
-		a, b = some_multiret_fn(c,d)
-		assert a == c+1
-		assert b == d+1
+		a, b = some_multiret_fn(c, d)
+		assert a == c + 1
+		assert b == d + 1
+		c += i + 1
+		d += i + 1
+		a, b = some_multiret_fn(c, d)
+		assert a == c + 1
+		assert b == d + 1
 	}
 }

--- a/vlib/v/tests/shift_test.v
+++ b/vlib/v/tests/shift_test.v
@@ -1,11 +1,9 @@
 fn test_shift_operators() {
-
-	// check that shift works with all integer types 
+	// check that shift works with all integer types
 	// as the right-hand side operand
 	a := 1
 	b := 1024
 	i := 10
-
 	assert b == a << i8(i)
 	assert b == a << byte(i)
 	assert b == a << i16(i)
@@ -14,7 +12,6 @@ fn test_shift_operators() {
 	assert b == a << u32(i)
 	assert b == a << i64(i)
 	assert b == a << u64(i)
-
 	assert a == b >> i8(i)
 	assert a == b >> byte(i)
 	assert a == b >> i16(i)
@@ -23,14 +20,12 @@ fn test_shift_operators() {
 	assert a == b >> u32(i)
 	assert a == b >> i64(i)
 	assert a == b >> u64(i)
-
 	// check that shift operation result type is
 	// the same as the type of the left-hand side operand
 	mut c := u64(0)
 	d := u64(1)
 	c = d << i8(63)
 	assert c == 9223372036854775808
-
 	// check that shift-assign works with all types
 	// of integers on the right-hand side
 	mut e := 1

--- a/vlib/v/tests/short_struct_param_syntax_test.v
+++ b/vlib/v/tests/short_struct_param_syntax_test.v
@@ -4,13 +4,15 @@ struct TOptions {
 
 fn t(options TOptions) bool {
 	if options.a == 1 {
-	  return true
+		return true
 	}
 	return false
 }
 
-fn test_short_struct_as_parameter(){
-	if t({a: 1}) {
+fn test_short_struct_as_parameter() {
+	if t({
+		a: 1
+	}) {
 		assert true
 		return
 	}

--- a/vlib/v/tests/static_arrays_using_const_for_size_test.v
+++ b/vlib/v/tests/static_arrays_using_const_for_size_test.v
@@ -2,38 +2,38 @@ const (
 	sbuffer_size = 10
 )
 
-fn test_hardcoded_static_arr(){
-	myints := [10]int
-	size := sizeof( myints )
+fn test_hardcoded_static_arr() {
+	myints := [10]
+	size := sizeof(myints)
 	assert size == 40
 }
 
-fn test_const_based_static_arr(){
-	myints := [sbuffer_size]int
-	size := sizeof( myints )
+fn test_const_based_static_arr() {
+	myints := [sbuffer_size]
+	size := sizeof(myints)
 	assert size == 40
 }
 
-fn test_const_based_static_arr_of_f64(){
-	myf64 := [sbuffer_size]f64
-	size := sizeof( myf64 )
+fn test_const_based_static_arr_of_f64() {
+	myf64 := [sbuffer_size]
+	size := sizeof(myf64)
 	assert size == 80
 }
 
-fn test_const_based_static_arr_of_f32(){
-	myf32 := [sbuffer_size]f32
-	size := sizeof( myf32 )
+fn test_const_based_static_arr_of_f32() {
+	myf32 := [sbuffer_size]
+	size := sizeof(myf32)
 	assert size == 40
 }
 
-fn test_const_based_static_arr_of_i8(){
-	myi8 := [sbuffer_size]i8
-	size := sizeof( myi8 )
+fn test_const_based_static_arr_of_i8() {
+	myi8 := [sbuffer_size]
+	size := sizeof(myi8)
 	assert size == 10
 }
 
-fn test_const_based_static_arr_of_i16(){
-	myi16 := [sbuffer_size]i16
-	size := sizeof( myi16 )
+fn test_const_based_static_arr_of_i16() {
+	myi16 := [sbuffer_size]
+	size := sizeof(myi16)
 	assert size == 20
 }

--- a/vlib/v/tests/static_arrays_using_const_for_size_test.v
+++ b/vlib/v/tests/static_arrays_using_const_for_size_test.v
@@ -3,37 +3,37 @@ const (
 )
 
 fn test_hardcoded_static_arr() {
-	myints := [10]
+	myints := [10]int
 	size := sizeof(myints)
 	assert size == 40
 }
 
 fn test_const_based_static_arr() {
-	myints := [sbuffer_size]
+	myints := [sbuffer_size]int
 	size := sizeof(myints)
 	assert size == 40
 }
 
 fn test_const_based_static_arr_of_f64() {
-	myf64 := [sbuffer_size]
+	myf64 := [sbuffer_size]f64
 	size := sizeof(myf64)
 	assert size == 80
 }
 
 fn test_const_based_static_arr_of_f32() {
-	myf32 := [sbuffer_size]
+	myf32 := [sbuffer_size]f32
 	size := sizeof(myf32)
 	assert size == 40
 }
 
 fn test_const_based_static_arr_of_i8() {
-	myi8 := [sbuffer_size]
+	myi8 := [sbuffer_size]i8
 	size := sizeof(myi8)
 	assert size == 10
 }
 
 fn test_const_based_static_arr_of_i16() {
-	myi16 := [sbuffer_size]
+	myi16 := [sbuffer_size]i16
 	size := sizeof(myi16)
 	assert size == 20
 }

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -1,18 +1,18 @@
 struct Foo {
 	number int
-	str string
-	f f64
+	str    string
+	f      f64
 }
 
 fn test_array_str() {
 	f := Foo{34, 'hello', 1.2}
 	println(f)
-	//s := f.str()
-	//println(s)
+	// s := f.str()
+	// println(s)
 	n := [1, 2, 3]
 	assert n.str() == '[1, 2, 3]'
-	println(n)  // make sure the array is printable
-	n2 := [4,5,6]
-	//assert n2.str() == '[4, 5, 6]'
+	println(n)	// make sure the array is printable
+	n2 := [4, 5, 6]
+	// assert n2.str() == '[4, 5, 6]'
 	println(n2)
 }

--- a/vlib/v/tests/string_interpolation_array_of_structs_test.v
+++ b/vlib/v/tests/string_interpolation_array_of_structs_test.v
@@ -8,14 +8,13 @@
 // can generate the default method for a struct, then the b) case of
 // this test will be done by *that* test, and so the testing will
 // be incomplete.
-
 struct Man {
-	name string
-	age int
+	name      string
+	age       int
 	interests []string
 }
 
-fn test_default_struct_array_of_structs_interpolation(){
+fn test_default_struct_array_of_structs_interpolation() {
 	people := [
 		Man{'Superman', 30, ['flying','fighting evil','being nice']},
 		Man{'Bilbo Baggins', 111, ['exploring', 'hiding']},
@@ -30,5 +29,5 @@ fn test_default_struct_array_of_structs_interpolation(){
 	assert s.contains('age: 111')
 	assert s.contains('interests: ["exploring", "hiding"]')
 	assert s.contains('}]')
-	//println(s)
+	// println(s)
 }

--- a/vlib/v/tests/string_interpolation_struct_test.v
+++ b/vlib/v/tests/string_interpolation_struct_test.v
@@ -1,15 +1,14 @@
 // This file tests whether V can generate a convenience default .str() method
 // for a custom struct, when the developer has not defined one himself.
 // The .str() methods are used for string interpolation and for println() calls.
-
 struct Man {
-	name string
-	age int
+	name      string
+	age       int
 	interests []string
 }
 
-fn test_default_struct_string_interpolation(){
-	superman := Man{'Superman', 30, ['flying','fighting evil','being nice']}
+fn test_default_struct_string_interpolation() {
+	superman := Man{'Superman', 30, ['flying', 'fighting evil', 'being nice']}
 	s := '$superman'
 	assert s.contains('Man {')
 	assert s.contains('name: Superman')
@@ -17,5 +16,5 @@ fn test_default_struct_string_interpolation(){
 	assert s.contains('interests: [')
 	assert s.contains('"being nice"')
 	assert s.contains('}')
-	//println(s)
+	// println(s)
 }

--- a/vlib/v/tests/string_interpolation_variadic_test.v
+++ b/vlib/v/tests/string_interpolation_variadic_test.v
@@ -2,23 +2,20 @@
 // for var args of a custom type, when the developer has NOT defined one.
 // Although similar to string_interpolation_struct_test.v, they should not be
 // merged.
-
 struct Man {
-	name string
-	age int
+	name      string
+	age       int
 	interests []string
 }
 
 fn my_variadic_function(x ...Man) string {
-	return '$x' // this interpolation should generate .str() methods for Man
+	return '$x'	// this interpolation should generate .str() methods for Man
 }
 
-fn test_vargs_string_interpolation(){
+fn test_vargs_string_interpolation() {
 	man := Man{'Me', 38, ['programming', 'reading', 'hiking']}
-	superman := Man{'Superman', 30, ['flying','fighting evil','being nice']}
-
+	superman := Man{'Superman', 30, ['flying', 'fighting evil', 'being nice']}
 	results := my_variadic_function(superman, man)
-
 	assert results.contains('Man {')
 	//
 	assert results.contains('name: Superman')

--- a/vlib/v/tests/string_struct_interpolation_test.v
+++ b/vlib/v/tests/string_struct_interpolation_test.v
@@ -1,4 +1,3 @@
-
 struct Foo {
 	bar int
 mut:
@@ -20,6 +19,6 @@ fn test_adding_to_mutable_string_field() {
 	assert foo.bar == 10
 	assert foo.str == 'hi'
 	foo.str += '!'
-	eprintln( foo.str )
+	eprintln(foo.str)
 	assert foo.str == 'hi!'
 }

--- a/vlib/v/tests/struct_chained_fields_correct_test.v
+++ b/vlib/v/tests/struct_chained_fields_correct_test.v
@@ -1,26 +1,26 @@
 
-struct Axx { mut: v int } 
-struct Bxx {      a Axx } 
-struct Cxx { mut: b Bxx }  
-struct Dxx { mut: c Cxx } 
-struct Exx { mut: v []int } 
+struct Axx { mut: v int }
+struct Bxx {      a Axx }
+struct Cxx { mut: b Bxx }
+struct Dxx { mut: c Cxx }
+struct Exx { mut: v []int }
 struct Fxx { e []Exx }
 
-fn test_chained_string(){
-	mut b := Bxx{} b = Bxx{Axx{2}} 
+fn test_chained_string() {
+	mut b := Bxx{} b = Bxx{Axx{2}}
 	assert 'b is: ' + b.a.v.str() == 'b is: 2'
 }
 
-fn test_chained_assignments(){
-  mut c := Cxx{} 
-  c.b = Bxx{}
-  mut d := Dxx{} 
-  d.c.b = Bxx{}
-  assert true
-}  
+fn test_chained_assignments() {
+	mut c := Cxx{}
+	c.b = Bxx{}
+	mut d := Dxx{}
+	d.c.b = Bxx{}
+	assert true
+}
 
-fn test_chained_array_access(){
-  f := Fxx{[Exx{[10,20,30]},Exx{[100,200,300,400]}]}
-  assert 'f.e[0].v.len: 3' == 'f.e[0].v.len: ${f.e[0].v.len}'
-  assert 'f.e[1].v.len: 4' == 'f.e[1].v.len: ${f.e[1].v.len}'
+fn test_chained_array_access() {
+	f := Fxx{[Exx{[10, 20, 30]}, Exx{[100, 200, 300, 400]}]}
+	assert 'f.e[0].v.len: 3' == 'f.e[0].v.len: ${f.e[0].v.len}'
+	assert 'f.e[1].v.len: 4' == 'f.e[1].v.len: ${f.e[1].v.len}'
 }

--- a/vlib/v/tests/type_alias_test.v
+++ b/vlib/v/tests/type_alias_test.v
@@ -1,15 +1,10 @@
-
 type Myint int
 type Myf32 f32
 type Myf64 f64
 
 fn test_type_alias() {
-	i := Myint(10) 
+	i := Myint(10)
 	assert i + 100 == 110
-	
 	f := Myf64(10.4)
-	assert f + 0.5 == 10.9  
-
-
-
+	assert f + 0.5 == 10.9
 }

--- a/vlib/v/tests/type_test.v
+++ b/vlib/v/tests/type_test.v
@@ -20,13 +20,12 @@ fn test_person_str() {
 
 struct Foo {}
 
-type Expr = Foo | BoolExpr |  BinExpr | UnaryExpr | DeclExprA | DeclExprB
+type Expr = Foo | BoolExpr | BinExpr | UnaryExpr | DeclExprA | DeclExprB
 
 type DeclExpr = DeclExprA | DeclExprB
 
 struct BoolExpr {
 	foo int
-
 }
 
 struct BinExpr {
@@ -45,7 +44,7 @@ fn expr1() Expr {
 	mut e := Expr{}
 	e = BinExpr{'binexpr'}
 	return e
-	//return BinExpr{}
+	// return BinExpr{}
 }
 
 fn expr() Expr {
@@ -53,15 +52,12 @@ fn expr() Expr {
 }
 
 struct UnaryExpr {
-
 }
 
 fn handle_expr(e Expr) {
-
 }
 
 fn handle_decl_expr(de DeclExpr) {
-
 }
 
 fn parse_bool() BoolExpr {
@@ -77,7 +73,6 @@ fn test_sum_type_cast() {
 fn test_sum_types() {
 	b := parse_bool()
 	handle_expr(b)
-
 	de := DeclExprA{}
 	handle_expr(de)
 	handle_decl_expr(de)

--- a/vlib/v/tests/typeof_test.v
+++ b/vlib/v/tests/typeof_test.v
@@ -1,4 +1,3 @@
-
 fn test_typeof_on_simple_expressions() {
 	a := 123
 	assert typeof(42) == 'int'
@@ -8,7 +7,7 @@ fn test_typeof_on_simple_expressions() {
 	assert typeof(a) == 'int'
 }
 
-fn test_typeof_on_atypes(){
+fn test_typeof_on_atypes() {
 	aint := []int
 	astring := []string
 	assert typeof(aint) == 'array_int'
@@ -19,15 +18,16 @@ struct FooBar {
 	x int
 }
 
-fn test_typeof_on_structs(){
-	assert typeof(FooBar{}) == "FooBar"
-	astruct_static := [2]FooBar
+fn test_typeof_on_structs() {
+	assert typeof(FooBar{}) == 'FooBar'
+	astruct_static := [2]
 	astruct_dynamic := [FooBar{}, FooBar{}]
 	assert typeof(astruct_static) == '[2]FooBar'
 	assert typeof(astruct_dynamic) == 'array_FooBar'
 }
 
 type MySumType = int | f32 | FooBar
+
 pub fn (ms MySumType) str() string {
 	match ms {
 		int { return it.str() }
@@ -37,7 +37,7 @@ pub fn (ms MySumType) str() string {
 	}
 }
 
-fn test_typeof_on_sumtypes(){
+fn test_typeof_on_sumtypes() {
 	a := MySumType(32)
 	b := MySumType(f32(123.0))
 	c := MySumType(FooBar{x:43})
@@ -66,7 +66,7 @@ fn test_typeof_on_sumtypes_of_structs() {
 	a := fexpr(1)
 	b := fexpr(2)
 	c := fexpr(3)
-	d := ExprType( UnaryExpr{} )
+	d := ExprType(UnaryExpr{})
 	assert typeof(a) == 'UnaryExpr'
 	assert typeof(b) == 'BinExpr'
 	assert typeof(c) == 'BoolExpr'

--- a/vlib/v/tests/voidptr_to_u64_cast_a_test.v
+++ b/vlib/v/tests/voidptr_to_u64_cast_a_test.v
@@ -1,4 +1,4 @@
-fn receive_addr_return_u64 (addr voidptr) u64 {
+fn receive_addr_return_u64(addr voidptr) u64 {
 	return u64(addr)
 }
 
@@ -8,4 +8,3 @@ fn test_void_pointer_to_u64_cast_via_fn_call() {
 	c := receive_addr_return_u64(b)
 	assert (a == c)
 }
-

--- a/vlib/v/tests/voidptr_to_u64_cast_b_test.v
+++ b/vlib/v/tests/voidptr_to_u64_cast_b_test.v
@@ -1,4 +1,4 @@
-fn receive_u64_return_addr (something u64) voidptr {
+fn receive_u64_return_addr(something u64) voidptr {
 	return voidptr(something)
 }
 
@@ -8,4 +8,3 @@ fn test_u64_to_void_pointer_cast_via_fn_call() {
 	c := u64(b)
 	assert (a == c)
 }
-

--- a/vlib/v/tests/working_with_an_empty_struct_test.v
+++ b/vlib/v/tests/working_with_an_empty_struct_test.v
@@ -5,7 +5,7 @@ fn new_s() EmptyStruct {
 	return EmptyStruct{}
 }
 
-fn test_using_an_empty_struct_compiles_and_works(){
+fn test_using_an_empty_struct_compiles_and_works() {
 	s := new_s()
 	eprintln('s: $s')
 	assert true


### PR DESCRIPTION
Some formatting was done manually due to issues with vfmt. This fixes indentation inconsistency style consistency and several other issues in vlib/v/tests