### PR TITLE
map: fast_string_eq and improved comments

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -177,7 +177,7 @@ pub mut:
 	size        int
 }
 
-fn new_map(value_bytes int) map {
+fn new_map(n, value_bytes int) map {
 	return map{
 		value_bytes: value_bytes
 		cap: init_cap
@@ -191,7 +191,7 @@ fn new_map(value_bytes int) map {
 }
 
 fn new_map_init(n, value_bytes int, keys &string, values voidptr) map {
-	mut out := new_map(value_bytes)
+	mut out := new_map(n, value_bytes)
 	for i in 0 .. n {
 		out.set(keys[i], byteptr(values) + i * value_bytes)
 	}

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -30,7 +30,7 @@ nt is larger than that of the key at the current position.
 namic array with a very low volume of unused memory, at the cost of more rea-
 llocations when inserting elements. It also preserves the order of the key-v-
 alues. This array is named `key_values`. Instead of probing a new key-value,
-this map probes two 32-bit numbers collectively.  The first number has its 8
+this map probes two 32-bit numbers collectively. The first number has its 8
 most significant bits reserved for the probe-count and the remaining 24 bits
 are cached bits from the hash which are utilized for faster re-hashing. This
 number is often referred to as `meta`. The other 32-bit number is the index
@@ -55,7 +55,7 @@ cking since the extra meta memory ensures that a meta will never go beyond
 the last index.
 
 6. Cached rehashing. When the `load_factor` of the map exceeds the `max_load_
-factor` the size of metas is doubled and all the key-values are "rehashed" to 
+factor` the size of metas is doubled and all the key-values are "rehashed" to
 find the index for their meta's in the new array. Instead of rehashing compl-
 etely, it simply uses the cached-hashbits stored in the meta, resulting in
 much faster rehashing.

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -177,7 +177,7 @@ pub mut:
 	size        int
 }
 
-fn new_map(n, value_bytes int) map {
+fn new_map(value_bytes int) map {
 	return map{
 		value_bytes: value_bytes
 		cap: init_cap
@@ -191,7 +191,7 @@ fn new_map(n, value_bytes int) map {
 }
 
 fn new_map_init(n, value_bytes int, keys &string, values voidptr) map {
-	mut out := new_map(n, value_bytes)
+	mut out := new_map(value_bytes)
 	for i in 0 .. n {
 		out.set(keys[i], byteptr(values) + i * value_bytes)
 	}

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -177,7 +177,11 @@ pub mut:
 	size        int
 }
 
-fn new_map(value_bytes int) map {
+// TODO: remove this after vc is regenerated.
+fn new_map(n, value_bytes int) map {
+   return new_map_1(value_bytes)
+}
+fn new_map_1(value_bytes int) map {
 	return map{
 		value_bytes: value_bytes
 		cap: init_cap
@@ -191,7 +195,7 @@ fn new_map(value_bytes int) map {
 }
 
 fn new_map_init(n, value_bytes int, keys &string, values voidptr) map {
-	mut out := new_map(value_bytes)
+	mut out := new_map_1(value_bytes)
 	for i in 0 .. n {
 		out.set(keys[i], byteptr(values) + i * value_bytes)
 	}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1127,7 +1127,7 @@ fn (g mut Gen) expr(node ast.Expr) {
 				}
 				g.write('})')
 			} else {
-				g.write('new_map(sizeof($value_typ_str))')
+				g.write('new_map_1(sizeof($value_typ_str))')
 			}
 		}
 		ast.None {
@@ -2902,7 +2902,7 @@ fn (g Gen) type_default(typ table.Type) string {
 	}
 	if sym.kind == .map {
 		value_type_str := g.typ(sym.map_info().value_type)
-		return 'new_map(sizeof($value_type_str))'
+		return 'new_map_1(sizeof($value_type_str))'
 	}
 	// Always set pointers to 0
 	if table.type_is_ptr(typ) {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1127,7 +1127,7 @@ fn (g mut Gen) expr(node ast.Expr) {
 				}
 				g.write('})')
 			} else {
-				g.write('new_map(1, sizeof($value_typ_str))')
+				g.write('new_map(sizeof($value_typ_str))')
 			}
 		}
 		ast.None {
@@ -2902,7 +2902,7 @@ fn (g Gen) type_default(typ table.Type) string {
 	}
 	if sym.kind == .map {
 		value_type_str := g.typ(sym.map_info().value_type)
-		return 'new_map(1, sizeof($value_type_str))'
+		return 'new_map(sizeof($value_type_str))'
 	}
 	// Always set pointers to 0
 	if table.type_is_ptr(typ) {

--- a/vlib/v/gen/tests/4.c
+++ b/vlib/v/gen/tests/4.c
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
 	});
 	Foo af_idx_el = (*(Foo*)array_get(arr_foo, 0));
 	string foo_a = af_idx_el.a;
-    map_string_string m1 = new_map(1, sizeof(string));
+    map_string_string m1 = new_map(sizeof(string));
     map_string_int m2 = new_map_init(2, sizeof(int), (string[2]){tos3("v"), tos3("lang"), }, (int[2]){1, 2, });
     string ma1 = tos3("hello");
     string ma2 = tos3("vlang");


### PR DESCRIPTION
I ran a benchmark of `C.memcmp` and `C.strcmp` in isolation and `C.memcmp` is a bit faster when the strings are equal, which they almost always will be when compared in the map since their hashes have matched before that.  I also improved the explanation of how the map works to make it easier for people to understand. Furthermore, I removed an unused argument from `new_map` and other unnecessary stuff dating from the old compiler.  This commit needs a follow-up commit #4364:
