### PR TITLE
tests: test call of variadic function with no arguments

### DIFF
--- a/vlib/v/tests/fn_variadic_test.v
+++ b/vlib/v/tests/fn_variadic_test.v
@@ -49,12 +49,20 @@ fn test_fn_variadic_forward() {
 	assert variadic_forward_a('a','b','c') == 'abc'
 }
 
-fn variadic_test_no_args(name string, groups ...VaTestGroup) {
+fn fn_variadic_with_arg_no_vargs(name string, groups ...VaTestGroup) {
 	assert groups.len == 0
 }
 
-fn test_fn_variadic_no_args() {
-	variadic_test_no_args('marko')
+fn test_fn_variadic_with_arg_no_vargs() {
+	fn_variadic_with_arg_no_vargs('marko')
+}
+
+fn fn_variadic_only_with_no_vargs(groups ...VaTestGroup) {
+	assert groups.len == 0
+}
+
+fn test_variadic_only_with_no_vargs() {
+	fn_variadic_only_with_no_vargs()
 }
 
 struct VaTestStruct {}


### PR DESCRIPTION
Add a test case from #2698.

Although the whole `fn_variadic_test` test is not passed right now due to broken vargs forwarding, this test case is passed.

Note that there's a similar case, but that function contains a required argument.