### PR TITLE
vdoc: fix v doc error

### DIFF
--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -42,7 +42,7 @@ pub fn doc(mod string, table &table.Table) string {
 		if !file.ends_with('.v') {
 			continue
 		}
-		if file.ends_with('_test.v') || file.ends_with('_windows.v') || file.ends_with('_macos.v') {
+		if file.ends_with('_test.v') || file.ends_with('_windows.c.v') || file.ends_with('_macos.c.v') {
 			continue
 		}
 		file_ast := parser.parse_file(os.join_path(path,file), table, .skip_comments,	&pref.Preferences{}, &ast.Scope{parent: 0})


### PR DESCRIPTION
This PR fix v doc error.

Error occurred because the file extension was modified without correcting the judgment in it.

