### PR TITLE
scanner: Fix checking `!in` token

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -720,7 +720,7 @@ pub fn (s mut Scanner) scan() token.Token {
 				s.pos++
 				return s.new_token(.ne, '', 2)
 			}
-			else if nextc == `i` && s.text[s.pos+2] == `n` && !s.text[s.pos+3].is_letter() {
+			else if nextc == `i` && s.text[s.pos+2] == `n` && s.text[s.pos+3] == ` ` {
 				s.pos += 2
 				return s.new_token(.not_in, '', 3)
 			}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -720,7 +720,7 @@ pub fn (s mut Scanner) scan() token.Token {
 				s.pos++
 				return s.new_token(.ne, '', 2)
 			}
-			else if nextc == `i` && s.text[s.pos+2] == `n` && s.text[s.pos+3] == ` ` {
+			else if nextc == `i` && s.text[s.pos+2] == `n` && s.text[s.pos+3].is_space() {
 				s.pos += 2
 				return s.new_token(.not_in, '', 3)
 			}


### PR DESCRIPTION
Checks space instead of alphanumeric characters. This will fix boolean variables starting with `in_`. In relation to that, it fixes the compilation of `vrepl` which emits an error (before the patch):

```
For usage information, quit V REPL using `exit` and use `v help`
cannot compile ‘C:\Users\admin\Documents\Coding\v\cmd\tools\vrepl.v:
   31|     for i := 0; i < r.line.len; i++ {
   32|         if r.line[i] == `\'` && (i == 0 || r.line[i - 1] != `\\`) {
   33|             in_string = !in_string
                               ~~~
   34|         }
   35|         if r.line[i] == `{` && !in_string {‘
```