### PR TITLE
string: add is_upper/is_lower and fix parser.match_expr error

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -770,7 +770,7 @@ pub fn (s string) is_upper() bool {
 	return true
 }
 
-pub fn (s string) to_capital() string {
+pub fn (s string) capitalize() string {
 	if s.len == 0 {
 		return ''
 	}
@@ -779,7 +779,7 @@ pub fn (s string) to_capital() string {
 	return cap
 }
 
-pub fn (s string) is_capital() bool {
+pub fn (s string) is_capitalized() bool {
 	if s.len == 0 || !(s[0] >= `A` && s[0] <= `Z`) {
 		return false
 	}
@@ -791,20 +791,20 @@ pub fn (s string) is_capital() bool {
 	return true
 }
 
-pub fn (s string) to_title() string {
+pub fn (s string) title() string {
 	words := s.split(' ')
 	mut tit := []string
 	for word in words {
-		tit << word.to_capital()
+		tit << word.capitalize()
 	}
 	title := tit.join(' ')
 	return title
 }
 
-pub fn (s string) is_title() bool {
+pub fn (s string) is_titled() bool {
 	words := s.split(' ')
 	for word in words {
-		if !word.is_capital() {
+		if !word.is_capitalized() {
 			return false
 		}
 	}

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -744,6 +744,15 @@ pub fn (s string) to_lower() string {
 	return tos(b, s.len)
 }
 
+pub fn (s string) is_lower() bool {
+	for i in 0..s.len {
+		if s[i] >= `A` && s[i] <= `Z` {
+			return false
+		}
+	}
+	return true
+}
+
 pub fn (s string) to_upper() string {
 	mut b := malloc(s.len + 1)
 	for i in 0..s.len {
@@ -752,7 +761,16 @@ pub fn (s string) to_upper() string {
 	return tos(b, s.len)
 }
 
-pub fn (s string) capitalize() string {
+pub fn (s string) is_upper() bool {
+	for i in 0..s.len {
+		if s[i] >= `a` && s[i] <= `z` {
+			return false
+		}
+	}
+	return true
+}
+
+pub fn (s string) to_capital() string {
 	if s.len == 0 {
 		return ''
 	}
@@ -761,14 +779,36 @@ pub fn (s string) capitalize() string {
 	return cap
 }
 
-pub fn (s string) title() string {
+pub fn (s string) is_capital() bool {
+	if s.len == 0 || !(s[0] >= `A` && s[0] <= `Z`) {
+		return false
+	}
+	for i in 1..s.len {
+		if s[i] >= `A` && s[i] <= `Z` {
+			return false
+		}
+	}
+	return true
+}
+
+pub fn (s string) to_title() string {
 	words := s.split(' ')
 	mut tit := []string
 	for word in words {
-		tit << word.capitalize()
+		tit << word.to_capital()
 	}
 	title := tit.join(' ')
 	return title
+}
+
+pub fn (s string) is_title() bool {
+	words := s.split(' ')
+	for word in words {
+		if !word.is_capital() {
+			return false
+		}
+	}
+	return true
 }
 
 // 'hey [man] how you doin'

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -779,7 +779,7 @@ pub fn (s string) capitalize() string {
 	return cap
 }
 
-pub fn (s string) is_capitalized() bool {
+pub fn (s string) is_capital() bool {
 	if s.len == 0 || !(s[0] >= `A` && s[0] <= `Z`) {
 		return false
 	}
@@ -801,10 +801,10 @@ pub fn (s string) title() string {
 	return title
 }
 
-pub fn (s string) is_titled() bool {
+pub fn (s string) is_title() bool {
 	words := s.split(' ')
 	for word in words {
-		if !word.is_capitalized() {
+		if !word.is_capital() {
 			return false
 		}
 	}

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -530,37 +530,37 @@ fn test_upper() {
 	assert s.to_upper() == 'HI'
 }
 
-fn test_capital() {
+fn test_capitalize() {
 	mut s := 'hello'
-	assert !s.is_capital()
-	assert s.to_capital() == 'Hello'
+	assert !s.is_capitalized()
+	assert s.capitalize() == 'Hello'
 	s = 'test'
-	assert !s.is_capital()
-	assert s.to_capital() == 'Test'
+	assert !s.is_capitalized()
+	assert s.capitalize() == 'Test'
     s = 'i am ray'
-	assert !s.is_capital()
-	assert s.to_capital() == 'I am ray'
+	assert !s.is_capitalized()
+	assert s.capitalize() == 'I am ray'
 	s = ''
-	assert !s.is_capital()
-	assert s.to_capital() == ''
+	assert !s.is_capitalized()
+	assert s.capitalize() == ''
 	s = 'TEST IT'
-	assert !s.is_capital()
-	assert s.to_capital() == 'Test it'
+	assert !s.is_capitalized()
+	assert s.capitalize() == 'Test it'
 	s = 'Test it'
-	assert s.is_capital()
-	assert s.to_capital() == 'Test it'
+	assert s.is_capitalized()
+	assert s.capitalize() == 'Test it'
 }
 
 fn test_title() {
 	mut s := 'hello world'
-	assert !s.is_title()
-	assert s.to_title() == 'Hello World'
+	assert !s.is_titled()
+	assert s.title() == 'Hello World'
 	s = 'HELLO WORLD'
-	assert !s.is_title()
-	assert s.to_title() == 'Hello World'
+	assert !s.is_titled()
+	assert s.title() == 'Hello World'
 	s = 'Hello World'
-	assert s.is_title()
-	assert s.to_title() == 'Hello World'
+	assert s.is_titled()
+	assert s.title() == 'Hello World'
 }
 
 fn test_for_loop() {

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -331,38 +331,6 @@ fn test_runes() {
 	assert last.len == 2
 }
 
-fn test_lower() {
-	mut s := 'A'
-	assert s.to_lower() == 'a'
-	assert s.to_lower().len == 1
-	s = 'HELLO'
-	assert s.to_lower() == 'hello'
-	assert s.to_lower().len == 5
-	s = 'Aloha'
-	assert s.to_lower() == 'aloha'
-	s = 'Have A nice Day!'
-	assert s.to_lower() == 'have a nice day!'
-	s = 'hi'
-	assert s.to_lower() == 'hi'
-	assert 'aloha!'[0] == `a`
-	assert 'aloha!'[5] == `!`
-}
-
-fn test_upper() {
-	mut s := 'a'
-	assert s.to_upper() == 'A'
-	assert s.to_upper().len == 1
-	s = 'hello'
-	assert s.to_upper() == 'HELLO'
-	assert s.to_upper().len == 5
-	s = 'Aloha'
-	assert s.to_upper() == 'ALOHA'
-	s = 'have a nice day!'
-	assert s.to_upper() == 'HAVE A NICE DAY!'
-	s = 'hi'
-	assert s.to_upper() == 'HI'
-}
-
 fn test_left_right() {
 	s := 'ALOHA'
 	assert s.left(3) == 'ALO'
@@ -520,24 +488,79 @@ fn test_count() {
 	assert 'bbaabb'.count('aa') == 1
 }
 
-fn test_capitalize() {
+fn test_lower() {
+	mut s := 'A'
+	assert !s.is_lower()
+	assert s.to_lower() == 'a'
+	assert s.to_lower().len == 1
+	s = 'HELLO'
+	assert !s.is_lower()
+	assert s.to_lower() == 'hello'
+	assert s.to_lower().len == 5
+	s = 'Aloha'
+	assert !s.is_lower()
+	assert s.to_lower() == 'aloha'
+	s = 'Have A nice Day!'
+	assert !s.is_lower()
+	assert s.to_lower() == 'have a nice day!'
+	s = 'hi'
+	assert s.is_lower()
+	assert s.to_lower() == 'hi'
+	assert 'aloha!'[0] == `a`
+	assert 'aloha!'[5] == `!`
+}
+
+fn test_upper() {
+	mut s := 'a'
+	assert !s.is_upper()
+	assert s.to_upper() == 'A'
+	assert s.to_upper().len == 1
+	s = 'hello'
+	assert !s.is_upper()
+	assert s.to_upper() == 'HELLO'
+	assert s.to_upper().len == 5
+	s = 'Aloha'
+	assert !s.is_upper()
+	assert s.to_upper() == 'ALOHA'
+	s = 'have a nice day!'
+	assert !s.is_upper()
+	assert s.to_upper() == 'HAVE A NICE DAY!'
+	s = 'HI'
+	assert s.is_upper()
+	assert s.to_upper() == 'HI'
+}
+
+fn test_capital() {
 	mut s := 'hello'
-	assert s.capitalize() == 'Hello'
+	assert !s.is_capital()
+	assert s.to_capital() == 'Hello'
 	s = 'test'
-	assert s.capitalize() == 'Test'
+	assert !s.is_capital()
+	assert s.to_capital() == 'Test'
     s = 'i am ray'
-	assert s.capitalize() == 'I am ray'
+	assert !s.is_capital()
+	assert s.to_capital() == 'I am ray'
 	s = ''
-	assert s.capitalize() == ''
+	assert !s.is_capital()
+	assert s.to_capital() == ''
+	s = 'TEST IT'
+	assert !s.is_capital()
+	assert s.to_capital() == 'Test it'
+	s = 'Test it'
+	assert s.is_capital()
+	assert s.to_capital() == 'Test it'
 }
 
 fn test_title() {
-	s := 'hello world'
-	assert s.title() == 'Hello World'
-	s.to_upper()
-	assert s.title() == 'Hello World'
-	s.to_lower()
-	assert s.title() == 'Hello World'
+	mut s := 'hello world'
+	assert !s.is_title()
+	assert s.to_title() == 'Hello World'
+	s = 'HELLO WORLD'
+	assert !s.is_title()
+	assert s.to_title() == 'Hello World'
+	s = 'Hello World'
+	assert s.is_title()
+	assert s.to_title() == 'Hello World'
 }
 
 fn test_for_loop() {

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -532,34 +532,34 @@ fn test_upper() {
 
 fn test_capitalize() {
 	mut s := 'hello'
-	assert !s.is_capitalized()
+	assert !s.is_capital()
 	assert s.capitalize() == 'Hello'
 	s = 'test'
-	assert !s.is_capitalized()
+	assert !s.is_capital()
 	assert s.capitalize() == 'Test'
     s = 'i am ray'
-	assert !s.is_capitalized()
+	assert !s.is_capital()
 	assert s.capitalize() == 'I am ray'
 	s = ''
-	assert !s.is_capitalized()
+	assert !s.is_capital()
 	assert s.capitalize() == ''
 	s = 'TEST IT'
-	assert !s.is_capitalized()
+	assert !s.is_capital()
 	assert s.capitalize() == 'Test it'
 	s = 'Test it'
-	assert s.is_capitalized()
+	assert s.is_capital()
 	assert s.capitalize() == 'Test it'
 }
 
 fn test_title() {
 	mut s := 'hello world'
-	assert !s.is_titled()
+	assert !s.is_title()
 	assert s.title() == 'Hello World'
 	s = 'HELLO WORLD'
-	assert !s.is_titled()
+	assert !s.is_title()
 	assert s.title() == 'Hello World'
 	s = 'Hello World'
-	assert s.is_titled()
+	assert s.is_title()
 	assert s.title() == 'Hello World'
 }
 

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1821,8 +1821,8 @@ fn (p mut Parser) match_expr() ast.MatchExpr {
 		if p.tok.kind == .key_else {
 			have_final_else = true
 			p.next()
-		} else if p.tok.kind == .name && (p.tok.lit in table.builtin_type_names || p.tok.lit[0].is_capital() ||
-			p.peek_tok.kind == .dot) {
+		} else if p.tok.kind == .name && (p.tok.lit in table.builtin_type_names ||
+				(p.tok.lit[0].is_capital() && !p.tok.lit.is_upper()) || p.peek_tok.kind == .dot) {
 			// Sum type match
 			// if sym.kind == .sum_type {
 			// p.warn('is sum')


### PR DESCRIPTION
This PR add is_upper in string.v and fix parser.match_expr error when process all capital const value.

- Add `is_upper` in string.v and add `test_upper` in string_test.v.
- Add `is_lower` in strng.v and add `test_lower` in string_test.v.
- Add `is_capital` in string.v and add `test_capital` in string_test.v.
- Add `is_title` in string.v and add `test_title` in string_test.v.
- Fix `match_expr` in parser.v error, solve the problem that all of the const values are in capitals are judged to be Sum_type using string.is_upper.