### PR TITLE
parser: correct error position on field and method errors

### DIFF
--- a/vlib/v/checker/tests/inout/unknown_field.out
+++ b/vlib/v/checker/tests/inout/unknown_field.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/inout/unknown_field.v:7:12: error: unknown field `checker.Test.sdd`
+    5| fn main() {
+    6|     t := Test{}
+    7|     println(t.sdd)
+                     ~~~
+    8| }

--- a/vlib/v/checker/tests/inout/unknown_field.vv
+++ b/vlib/v/checker/tests/inout/unknown_field.vv
@@ -1,0 +1,8 @@
+module checker
+
+struct Test {}
+
+fn main() {
+	t := Test{}
+	println(t.sdd)
+}

--- a/vlib/v/checker/tests/inout/unknown_method.out
+++ b/vlib/v/checker/tests/inout/unknown_method.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/inout/unknown_method.v:7:12: error: unknown method: checker.Test.sdd
+    5| fn main() {
+    6|     t := Test{}
+    7|     println(t.sdd())
+                     ~~~~~
+    8| }

--- a/vlib/v/checker/tests/inout/unknown_method.vv
+++ b/vlib/v/checker/tests/inout/unknown_method.vv
@@ -1,0 +1,8 @@
+module checker
+
+struct Test {}
+
+fn main() {
+	t := Test{}
+	println(t.sdd())
+}


### PR DESCRIPTION
```
vlib/v/checker/tests/inout/unknown_field.v:7:12: error: unknown field `checker.Test.sdd`
    5| fn main() {
    6|     t := Test{}
    7|     println(t.sdd)
                     ~~~
    8| }
```
```
vlib/v/checker/tests/inout/unknown_method.v:7:12: error: unknown method: checker.Test.sdd
    5| fn main() {
    6|     t := Test{}
    7|     println(t.sdd())
                     ~~~~~
    8| }
```