### PR TITLE
map: remove unused parameter from new_map

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -162,7 +162,7 @@ pub mut:
 	size        int
 }
 
-fn new_map(n, value_bytes int) map {
+fn new_map(value_bytes int) map {
 	return map{
 		value_bytes: value_bytes
 		cap: init_cap
@@ -176,7 +176,7 @@ fn new_map(n, value_bytes int) map {
 }
 
 fn new_map_init(n, value_bytes int, keys &string, values voidptr) map {
-	mut out := new_map(n, value_bytes)
+	mut out := new_map(value_bytes)
 	for i in 0 .. n {
 		out.set(keys[i], byteptr(values) + i * value_bytes)
 	}


### PR DESCRIPTION
This is a follow-up commit to #4355.