### PR TITLE
jsgen: move struct methods from prototype to class 

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -32,7 +32,7 @@ pub fn (node &FnDecl) str(t &table.Table) string {
 		receiver = '($node.receiver.name $m$name) '
 */
 	}
-	name := node.name.after('.')
+	mut name := node.name.after('.')
 	if node.is_c {
 		name = 'C.$name'
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -567,7 +567,7 @@ pub fn (c mut Checker) enum_decl(decl ast.EnumDecl) {
 				ast.IntegerLiteral {}
 				ast.PrefixExpr {}
 				else {
-					pos := expr_pos(field.expr)
+					mut pos := expr_pos(field.expr)
 					if pos.pos == 0 {
 						pos = field.pos
 					}

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -830,9 +830,6 @@ fn (g mut JsGen) gen_struct_decl(node ast.StructDecl) {
 				// generate function in class
 				g.fn_decl = it
 
-				if it.no_body {
-					continue
-				}
 				has_go := fn_has_go(it)
 
 				mut name := it.name
@@ -845,7 +842,7 @@ fn (g mut JsGen) gen_struct_decl(node ast.StructDecl) {
 
 				// generate jsdoc for the function
 				g.writeln(g.doc.gen_fn(it))
-				
+
 				if has_go {
 					g.write('async ')
 				}

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -78,7 +78,6 @@ pub fn (g mut JsGen) find_class_methods(stmts []ast.Stmt) {
 					// Found struct method, store it to be generated along with the class.
 					className :=  g.table.get_type_symbol(it.receiver.typ).name
 					// Workaround until `map[key] << val` works.
-					println('found fn for class $className')
 					arr := g.method_fn_decls[className]
 					arr << stmt
 					g.method_fn_decls[className] = arr
@@ -165,7 +164,6 @@ pub fn (g mut JsGen) new_tmp_var() string {
 fn (g mut JsGen) stmts(stmts []ast.Stmt) {
 	g.indent++
 	for stmt in stmts {
-		println(stmt)
 		g.stmt(stmt)
 	}
 	g.indent--
@@ -258,7 +256,6 @@ fn (g mut JsGen) stmt(node ast.Stmt) {
 }
 
 fn (g mut JsGen) expr(node ast.Expr) {
-	// println('cgen expr()')
 	match node {
 		ast.ArrayInit {
 			g.gen_array_init_expr(it)
@@ -838,7 +835,6 @@ fn (g mut JsGen) gen_struct_decl(node ast.StructDecl) {
 	g.indent--
 	g.writeln('}')
 
-	println(node.name)
 	fns := g.method_fn_decls[node.name]
 	for cfn in fns {
 		// TODO: Fix this hack for type conversion
@@ -847,6 +843,8 @@ fn (g mut JsGen) gen_struct_decl(node ast.StructDecl) {
 		match cfn {
 			ast.FnDecl {
 				// generate function in class
+				g.fn_decl = it
+
 				if it.no_body {
 					continue
 				}
@@ -880,7 +878,6 @@ fn (g mut JsGen) gen_struct_decl(node ast.StructDecl) {
 				g.write('${name}(')
 				g.fn_args(it.args, it.is_variadic)
 				g.writeln(') {')
-				println('gen body')
 				g.stmts(it.stmts)
 				g.writeln('}')
 			}

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -590,7 +590,7 @@ fn (g mut JsGen) gen_fn_decl(it ast.FnDecl) {
 		type_name := g.typ(it.return_type)
 
 		// generate jsdoc for the function
-		g.writeln(g.doc.gen_fn(it))
+		g.write(g.doc.gen_fn(it))
 
 		if has_go {
 			g.write('async ')
@@ -830,22 +830,19 @@ fn (g mut JsGen) gen_struct_decl(node ast.StructDecl) {
 				// generate function in class
 				g.fn_decl = it
 
-				has_go := fn_has_go(it)
-
 				mut name := it.name
 				c := name[0]
 				if c in [`+`, `-`, `*`, `/`] {
 					name = util.replace_op(name)
 				}
 
-				type_name := g.typ(it.return_type)
-
 				// generate jsdoc for the function
 				g.writeln(g.doc.gen_fn(it))
 
-				if has_go {
+				if fn_has_go(it) {
 					g.write('async ')
 				}
+
 				g.write('${name}(')
 				g.fn_args(it.args, it.is_variadic)
 				g.writeln(') {')

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -98,7 +98,7 @@ pub fn (g mut JsGen) finish() {
 }
 
 pub fn (g JsGen) hashes() string {
-	res := '// V_COMMIT_HASH ${util.vhash()}\n'
+	mut res := '// V_COMMIT_HASH ${util.vhash()}\n'
 	res += '// V_CURRENT_COMMIT_HASH ${util.githash(g.pref.building_v)}\n\n'
 	return res
 }

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -590,18 +590,7 @@ fn (g mut JsGen) gen_fn_decl(it ast.FnDecl) {
 		type_name := g.typ(it.return_type)
 
 		// generate jsdoc for the function
-		g.writeln('/**')
-		for i, arg in it.args {
-			arg_type_name := g.typ(arg.typ)
-			is_varg := i == it.args.len - 1 && it.is_variadic
-			if is_varg {
-				g.writeln('* @param {...$arg_type_name} $arg.name')
-			} else {
-				g.writeln('* @param {$arg_type_name} $arg.name')
-			}
-		}
-		g.writeln('* @return {$type_name}')
-		g.writeln('*/')
+		g.writeln(g.doc.gen_fn(it))
 
 		if has_go {
 			g.write('async ')
@@ -616,11 +605,7 @@ fn (g mut JsGen) gen_fn_decl(it ast.FnDecl) {
 	}
 
 	g.stmts(it.stmts)
-	if it.is_method {
-		g.write('};')
-	} else {
-		g.writeln('}')
-	}
+	g.writeln('}')
 	if is_main {
 		g.writeln(')();')
 	}
@@ -859,19 +844,8 @@ fn (g mut JsGen) gen_struct_decl(node ast.StructDecl) {
 				type_name := g.typ(it.return_type)
 
 				// generate jsdoc for the function
-				g.writeln('/**')
-				for i, arg in it.args {
-					arg_type_name := g.typ(arg.typ)
-					is_varg := i == it.args.len - 1 && it.is_variadic
-					if is_varg {
-						g.writeln('* @param {...$arg_type_name} $arg.name')
-					} else {
-						g.writeln('* @param {$arg_type_name} $arg.name')
-					}
-				}
-				g.writeln('* @return {$type_name}')
-				g.writeln('*/')
-
+				g.writeln(g.doc.gen_fn(it))
+				
 				if has_go {
 					g.write('async ')
 				}

--- a/vlib/v/gen/js/jsdoc.v
+++ b/vlib/v/gen/js/jsdoc.v
@@ -66,3 +66,20 @@ fn (d mut JsDoc) gen_ctor(fields []ast.StructField) string {
 	d.write('*/')
 	return d.out.str()
 }
+
+fn (d mut JsDoc) gen_fn(it ast.FnDecl) {
+	d.reset()
+	d.writeln('/**')
+	for i, arg in it.args {
+		arg_type_name := d.gen.typ(arg.typ)
+		is_varg := i == it.args.len - 1 && it.is_variadic
+		if is_varg {
+			d.writeln('* @param {...$arg_type_name} $arg.name')
+		} else {
+			d.writeln('* @param {$arg_type_name} $arg.name')
+		}
+	}
+	d.writeln('* @return {$type_name}')
+	d.writeln('*/')
+	return d.out.str()
+}

--- a/vlib/v/gen/js/jsdoc.v
+++ b/vlib/v/gen/js/jsdoc.v
@@ -67,8 +67,9 @@ fn (d mut JsDoc) gen_ctor(fields []ast.StructField) string {
 	return d.out.str()
 }
 
-fn (d mut JsDoc) gen_fn(it ast.FnDecl) {
+fn (d mut JsDoc) gen_fn(it ast.FnDecl) string {
 	d.reset()
+	type_name := d.gen.typ(it.return_type)
 	d.writeln('/**')
 	for i, arg in it.args {
 		arg_type_name := d.gen.typ(arg.typ)
@@ -80,6 +81,6 @@ fn (d mut JsDoc) gen_fn(it ast.FnDecl) {
 		}
 	}
 	d.writeln('* @return {$type_name}')
-	d.writeln('*/')
+	d.write('*/')
 	return d.out.str()
 }

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -728,7 +728,7 @@ pub fn (s mut Scanner) scan() token.Token {
 				start := s.pos + 1
 				s.ignore_line()
 				s.line_comment = s.text[start + 1..s.pos]
-				comment := s.line_comment.trim_space()
+				mut comment := s.line_comment.trim_space()
 				s.pos--
 				// fix line_nr, \n was read, and the comment is marked
 				// on the next line


### PR DESCRIPTION
Struct methods now get directly attached to the class instead of being spread out throughout the code as prototype declarations.
Example:
```v
struct Hello {
	i int
}

fn (h Hello) str() string {
	return "hello"
}
```
generates
```js
class Hello {
	/**
	* @param {{i: number}} values - values for this class fields
	* @constructor
	*/
	constructor(values) {
		/** @type {number} - i */
		this.i = values.i
	}
	/**
	* @param {Hello} h
	* @return {string}
	*/
	str(h) {
		return "hello";
	}
}
```