### PR TITLE
ast: move position from token to ast

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -37,13 +37,13 @@ pub struct ExprStmt {
 pub:
 	expr Expr
 	typ  table.Type
-	pos  token.Position
+	pos  Position
 }
 
 pub struct IntegerLiteral {
 pub:
 	val string
-	pos token.Position
+	pos Position
 }
 
 pub struct FloatLiteral {
@@ -56,7 +56,7 @@ pub:
 	val    string
 	is_raw bool
 	is_c   bool
-	pos    token.Position
+	pos    Position
 }
 
 // 'name: $name'
@@ -65,7 +65,7 @@ pub:
 	vals       []string
 	exprs      []Expr
 	expr_fmts  []string
-	pos        token.Position
+	pos        Position
 mut:
 	expr_types []table.Type
 }
@@ -83,7 +83,7 @@ pub:
 // `foo.bar`
 pub struct SelectorExpr {
 pub:
-	pos       token.Position
+	pos       Position
 	expr      Expr
 	field     string
 mut:
@@ -102,7 +102,7 @@ pub:
 pub struct StructField {
 pub:
 	name             string
-	pos              token.Position
+	pos              Position
 	comment          Comment
 	default_expr     Expr
 	has_default_expr bool
@@ -114,7 +114,7 @@ mut:
 pub struct Field {
 pub:
 	name string
-	pos  token.Position
+	pos  Position
 mut:
 	typ  table.Type
 }
@@ -124,7 +124,7 @@ pub:
 	name   string
 	expr   Expr
 	is_pub bool
-	pos    token.Position
+	pos    Position
 mut:
 	typ    table.Type
 }
@@ -133,12 +133,12 @@ pub struct ConstDecl {
 pub:
 	fields []ConstField
 	is_pub bool
-	pos    token.Position
+	pos    Position
 }
 
 pub struct StructDecl {
 pub:
-	pos         token.Position
+	pos         Position
 	name        string
 	fields      []StructField
 	is_pub      bool
@@ -157,7 +157,7 @@ pub:
 
 pub struct StructInit {
 pub:
-	pos            token.Position
+	pos            Position
 	fields         []string
 	exprs          []Expr
 mut:
@@ -169,7 +169,7 @@ mut:
 // import statement
 pub struct Import {
 pub:
-	pos   token.Position
+	pos   Position
 	mod   string
 	alias string
 }
@@ -189,7 +189,7 @@ pub:
 	is_c          bool
 	no_body       bool // just a definition `fn C.malloc()`
 	is_builtin    bool // this function is defined in builtin/strconv
-	pos           token.Position
+	pos           Position
 }
 
 pub struct BranchStmt {
@@ -199,7 +199,7 @@ pub:
 
 pub struct CallExpr {
 pub:
-	pos                token.Position
+	pos                Position
 	left               Expr // `user` in `user.register()`
 	is_method          bool
 	mod                string
@@ -224,7 +224,7 @@ mut:
 
 pub struct Return {
 pub:
-	pos   token.Position
+	pos   Position
 	exprs []Expr
 mut:
 	types []table.Type
@@ -250,7 +250,7 @@ pub:
 	is_mut bool
 mut:
 	typ    table.Type
-	pos    token.Position
+	pos    Position
 }
 
 pub struct GlobalDecl {
@@ -303,7 +303,7 @@ pub:
 	is_c     bool
 	tok_kind token.Kind
 	mod      string
-	pos      token.Position
+	pos      Position
 	is_mut bool
 mut:
 	name     string
@@ -326,7 +326,7 @@ pub fn (i &Ident) var_info() IdentVar {
 pub struct InfixExpr {
 pub:
 	op         token.Kind
-	pos        token.Position
+	pos        Position
 	left       Expr
 	right      Expr
 mut:
@@ -338,19 +338,19 @@ pub struct PostfixExpr {
 pub:
 	op   token.Kind
 	expr Expr
-	pos  token.Position
+	pos  Position
 }
 
 pub struct PrefixExpr {
 pub:
 	op    token.Kind
 	right Expr
-	pos   token.Position
+	pos   Position
 }
 
 pub struct IndexExpr {
 pub:
-	pos       token.Position
+	pos       Position
 	left      Expr
 	index     Expr // [0], [start..end] etc
 mut:
@@ -363,7 +363,7 @@ pub:
 	tok_kind token.Kind
 	branches []IfBranch
 	left     Expr // `a` in `a := if ...`
-	pos      token.Position
+	pos      Position
 mut:
 	is_expr  bool
 	typ      table.Type
@@ -374,7 +374,7 @@ pub struct IfBranch {
 pub:
 	cond    Expr
 	stmts   []Stmt
-	pos     token.Position
+	pos     Position
 	comment Comment
 }
 
@@ -383,7 +383,7 @@ pub:
 	tok_kind      token.Kind
 	cond          Expr
 	branches      []MatchBranch
-	pos           token.Position
+	pos           Position
 	is_mut        bool // `match mut ast_node {`
 mut:
 	is_expr       bool // returns a value
@@ -397,7 +397,7 @@ pub struct MatchBranch {
 pub:
 	exprs   []Expr
 	stmts   []Stmt
-	pos     token.Position
+	pos     Position
 	comment Comment // comment above `xxx {`
 }
 
@@ -406,7 +406,7 @@ pub:
 	val        string
 	stmts      []Stmt
 	is_not     bool
-	pos        token.Position
+	pos        Position
 mut:
 	has_else   bool
 	else_stmts []Stmt
@@ -417,7 +417,7 @@ pub:
 	cond   Expr
 	stmts  []Stmt
 	is_inf bool // `for {}`
-	pos    token.Position
+	pos    Position
 }
 
 pub struct ForInStmt {
@@ -428,7 +428,7 @@ pub:
 	is_range  bool
 	high      Expr // `10` in `for i in 0..10 {`
 	stmts     []Stmt
-	pos       token.Position
+	pos       Position
 mut:
 	key_type  table.Type
 	val_type  table.Type
@@ -445,14 +445,14 @@ pub:
 	inc      Expr // i++;
 	has_inc  bool
 	stmts    []Stmt
-	pos      token.Position
+	pos      Position
 }
 
 pub struct ReturnStmt {
 pub:
 	tok_kind token.Kind // or pos
 	results  []Expr
-	pos      token.Position
+	pos      Position
 }
 
 // #include etc
@@ -472,7 +472,7 @@ pub:
 	left        []Ident
 	right       []Expr
 	op          token.Kind
-	pos         token.Position
+	pos         Position
 mut:
 	left_types  []table.Type
 	right_types []table.Type
@@ -483,7 +483,7 @@ pub struct AsCast {
 pub:
 	expr      Expr
 	typ       table.Type
-	pos       token.Position
+	pos       Position
 mut:
 	expr_type table.Type
 }
@@ -499,14 +499,14 @@ pub:
 	enum_name string
 	val       string
 	mod       string // for full path `mod_Enum_val`
-	pos       token.Position
+	pos       Position
 mut:
 	typ       table.Type
 }
 
 pub struct EnumField {
 	name     string
-	pos      token.Position
+	pos      Position
 	expr     Expr
 	has_expr bool
 }
@@ -565,7 +565,7 @@ pub:
 pub struct AssignExpr {
 pub:
 	op         token.Kind
-	pos        token.Position
+	pos        Position
 	left       Expr
 	val        Expr
 mut:
@@ -590,7 +590,7 @@ pub:
 
 pub struct ArrayInit {
 pub:
-	pos       token.Position
+	pos       Position
 	exprs     []Expr
 	is_fixed  bool
 	mod       string
@@ -601,7 +601,7 @@ mut:
 
 pub struct MapInit {
 pub:
-	pos        token.Position
+	pos        Position
 	keys       []Expr
 	vals       []Expr
 mut:
@@ -633,7 +633,7 @@ mut:
 pub struct AssertStmt {
 pub:
 	expr Expr
-	pos  token.Position
+	pos  Position
 }
 
 // `if [x := opt()] {`
@@ -657,7 +657,7 @@ pub:
 	var_name string
 	fields   []string
 	exprs    []Expr
-	pos      token.Position
+	pos      Position
 mut:
 	typ      table.Type
 }
@@ -680,7 +680,7 @@ pub:
 	text     string
 	is_multi bool
 	line_nr  int
-	pos      token.Position
+	pos      Position
 }
 
 pub struct ConcatExpr {

--- a/vlib/v/ast/position.v
+++ b/vlib/v/ast/position.v
@@ -1,7 +1,9 @@
 // Copyright (c) 2019-2020 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
-module token
+module ast
+
+import v.token
 
 pub struct Position {
 pub:
@@ -15,7 +17,7 @@ pub fn (pos Position) str() string {
 }
 
 [inline]
-pub fn (tok &Token) position() Position {
+pub fn (tok &token.Token) position() Position {
 	return Position{
 		line_nr: tok.line_nr - 1
 		pos: tok.pos

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1125,7 +1125,7 @@ pub fn (c mut Checker) expr(node ast.Expr) table.Type {
 	return table.void_type
 }
 
-fn expr_pos(node ast.Expr) token.Position {
+fn expr_pos(node ast.Expr) ast.Position {
 	// all uncommented have to be implemented
 	match mut node {
 		ast.ArrayInit {
@@ -1164,7 +1164,7 @@ fn expr_pos(node ast.Expr) token.Position {
 			if left_pos.pos == 0 || right_pos.pos == 0 {
 				return it.pos
 			}
-			return token.Position{
+			return ast.Position{
 				line_nr: it.pos.line_nr
 				pos: left_pos.pos
 				len: right_pos.pos - left_pos.pos + right_pos.len
@@ -1203,7 +1203,7 @@ fn expr_pos(node ast.Expr) token.Position {
 		}
 		// ast.TypeOf { }
 		else {
-			return token.Position{}
+			return ast.Position{}
 		}
 	}
 }
@@ -1537,16 +1537,16 @@ pub fn (c mut Checker) map_init(node mut ast.MapInit) table.Type {
 	return map_type
 }
 
-pub fn (c mut Checker) warn(s string, pos token.Position) {
+pub fn (c mut Checker) warn(s string, pos ast.Position) {
 	allow_warnings := !c.pref.is_prod	// allow warnings only in dev builds
 	c.warn_or_error(s, pos, allow_warnings)	// allow warnings only in dev builds
 }
 
-pub fn (c mut Checker) error(s string, pos token.Position) {
+pub fn (c mut Checker) error(s string, pos ast.Position) {
 	c.warn_or_error(s, pos, false)
 }
 
-fn (c mut Checker) warn_or_error(s string, pos token.Position, warn bool) {
+fn (c mut Checker) warn_or_error(s string, pos ast.Position, warn bool) {
 	if !warn {
 		c.nr_errors++
 	}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -25,7 +25,7 @@ pub fn (p mut Parser) call_expr(is_c bool, mod string) ast.CallExpr {
 	args := p.call_args()
 	last_pos := p.tok.position()
 	p.check(.rpar)
-	pos := token.Position{
+	pos := ast.Position{
 		line_nr: first_pos.line_nr
 		pos: first_pos.pos
 		len: last_pos.pos - first_pos.pos + last_pos.len

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -528,7 +528,7 @@ pub fn (p &Parser) warn(s string) {
 	p.warn_with_pos(s, p.tok.position())
 }
 
-pub fn (p &Parser) error_with_pos(s string, pos token.Position) {
+pub fn (p &Parser) error_with_pos(s string, pos ast.Position) {
 	mut kind := 'error:'
 	if p.pref.is_verbose {
 		print_backtrace()
@@ -539,7 +539,7 @@ pub fn (p &Parser) error_with_pos(s string, pos token.Position) {
 	exit(1)
 }
 
-pub fn (p &Parser) warn_with_pos(s string, pos token.Position) {
+pub fn (p &Parser) warn_with_pos(s string, pos ast.Position) {
 	ferror := util.formatted_error('warning:', s, p.file_name, pos)
 	eprintln(ferror)
 }
@@ -997,7 +997,7 @@ fn (p mut Parser) dot_expr(left ast.Expr) ast.Expr {
 			p.close_scope()
 		}
 		end_pos := p.tok.position()
-		pos := token.Position{
+		pos := ast.Position{
 			line_nr: name_pos.line_nr
 			pos: name_pos.pos
 			len: end_pos.pos - name_pos.pos
@@ -1362,7 +1362,7 @@ fn (p mut Parser) array_init() ast.ArrayInit {
 	}
 	last_pos := p.tok.position()
 	len := last_pos.pos - first_pos.pos
-	pos := token.Position{
+	pos := ast.Position{
 		line_nr: first_pos.line_nr
 		pos: first_pos.pos
 		len: len

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -8,6 +8,7 @@ import (
 	v.token
 	v.pref
 	v.util
+	v.ast
 )
 
 const (
@@ -1033,7 +1034,7 @@ fn good_type_name(s string) bool {
 }
 
 pub fn (s &Scanner) error(msg string) {
-	pos := token.Position{
+	pos := ast.Position{
 		line_nr: s.line_nr
 		pos: s.pos
 	}

--- a/vlib/v/util/errors.v
+++ b/vlib/v/util/errors.v
@@ -5,7 +5,7 @@ module util
 
 import os
 import term
-import v.token
+import v.ast
 
 // The filepath:line:col: format is the default C compiler error output format.
 // It allows editors and IDE's like emacs to quickly find the errors in the
@@ -41,7 +41,7 @@ pub fn new_error_manager() &EManager {
 	return &EManager{ support_color: term.can_show_color_on_stderr() }
 }
 
-pub fn formatted_error(kind string /*error or warn*/, emsg string, filepath string, pos token.Position) string {
+pub fn formatted_error(kind string /*error or warn*/, emsg string, filepath string, pos ast.Position) string {
 	mut path := filepath
 	verror_paths_override := os.getenv('VERROR_PATHS')
 	if verror_paths_override == 'absolute' {


### PR DESCRIPTION
Position struct is used in scanner and parser. But because it's mostly used in Stmts and Exprs (besides Tokens) it should be moved to a more generic module. I considered moving it to it's own module but that would be defragment everything too much. So i thought the ast module would be the best for it.