### PR TITLE
checker: stop printing errors/issues

### DIFF
--- a/vlib/v/ast/issue.v
+++ b/vlib/v/ast/issue.v
@@ -1,0 +1,24 @@
+module ast
+
+import v.token
+
+pub enum Reporter {
+	scanner
+	parser
+	checker
+	gen
+}
+
+pub enum IssueType {
+	warn
+	error
+}
+
+pub struct Issue {
+	typ       IssueType
+	message   string
+	file_path string
+	pos       token.Position
+	reporter  Reporter
+	backtrace string
+}

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -55,8 +55,8 @@ pub fn (b mut Builder) gen_c(v_files []string) string {
 	t2 := time.ticks()
 	check_time := t2 - t1
 	b.info('CHECK: ${check_time}ms')
-	if b.checker.nr_errors > 0 {
-		exit(1)
+	if b.checker.nr_issues > 0 {
+		b.print_issues(b.checker.issues)
 	}
 	// println('starting cgen...')
 	res := gen.cgen(b.parsed_files, b.table, b.pref)
@@ -265,6 +265,19 @@ pub fn (b Builder) find_module_path(mod string, fpath string) ?string {
 	}
 	smodule_lookup_paths := module_lookup_paths.join(', ')
 	return error('module "$mod" not found in:\n$smodule_lookup_paths')
+}
+
+fn (b &Builder) print_issues(issues []ast.Issue) {
+	for issue in issues {
+		kind := if b.pref.is_verbose { '$issue.reporter $issue.typ #$b.checker.nr_issues:' } else { '$issue.typ:' }
+		ferror := util.formatted_error(kind, issue.message, issue.file_path, issue.pos)
+		if issue.typ == .warn {
+			println(ferror)
+		} else {
+			eprintln(ferror)
+		}
+	}
+	exit(1)
 }
 
 fn verror(s string) {

--- a/vlib/v/scanner/error.v
+++ b/vlib/v/scanner/error.v
@@ -1,4 +1,4 @@
-module ast
+module scanner
 
 import v.token
 
@@ -9,13 +9,7 @@ pub enum Reporter {
 	gen
 }
 
-pub enum IssueType {
-	warn
-	error
-}
-
-pub struct Issue {
-	typ       IssueType
+pub struct Error {
 	message   string
 	file_path string
 	pos       token.Position

--- a/vlib/v/scanner/warning.v
+++ b/vlib/v/scanner/warning.v
@@ -1,0 +1,10 @@
+module scanner
+
+import v.token
+
+pub struct Warning {
+	message   string
+	file_path string
+	pos       token.Position
+	reporter  Reporter
+}


### PR DESCRIPTION
Currently, parser, checker and scanner are printing errors and warning directly. This is not a good behaviour when using `vlib.v` to build a lang server or other tools because it's not useful in stdout. It is needed as a variable.

This PR adds a struct called Issue in the `ast` module which is either a warning or an error. This struct will be created by the specific reporter (checker, scanner or parser) which can be used later for printing or do other stuff.