### PR TITLE
cgen: fix match expr in assert

### DIFF
--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -27,7 +27,6 @@ const (
 		'vlib/v/tests/fixed_array_test.v',
 		'vlib/v/tests/fn_test.v',
 		'vlib/v/tests/fn_variadic_test.v',
-		'vlib/v/tests/match_test.v',
 		'vlib/v/tests/msvc_test.v',
 		'vlib/v/tests/mut_test.v',
 		'vlib/v/tests/num_lit_call_method_test.v',

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -628,9 +628,11 @@ fn (g mut Gen) expr_with_cast(expr ast.Expr, got_type, exp_type table.Type) {
 
 fn (g mut Gen) gen_assert_stmt(a ast.AssertStmt) {
 	g.writeln('// assert')
-	g.write('if( ')
+	g.inside_ternary = true
+	g.write('if (')
 	g.expr(a.expr)
-	g.write(' )')
+	g.write(')')
+	g.inside_ternary = false
 	s_assertion := a.expr.str().replace('"', "\'")
 	mut mod_path := g.file.path
 	$if windows {
@@ -1495,7 +1497,8 @@ fn (g mut Gen) match_expr(node ast.MatchExpr) {
 		g.writeln('// match 0')
 		return
 	}
-	is_expr := node.is_expr && node.return_type != table.void_type
+	was_inside_ternary := g.inside_ternary
+	is_expr := (node.is_expr && node.return_type != table.void_type) || was_inside_ternary
 	if is_expr {
 		g.inside_ternary = true
 		// g.write('/* EM ret type=${g.typ(node.return_type)}		expected_type=${g.typ(node.expected_type)}  */')
@@ -1513,11 +1516,13 @@ fn (g mut Gen) match_expr(node ast.MatchExpr) {
 	for j, branch in node.branches {
 		if j == node.branches.len - 1 {
 			// last block is an `else{}`
-			if is_expr {
-				// TODO too many branches. maybe separate ?: matches
-				g.write(' : ')
-			} else {
-				g.writeln('else {')
+			if node.branches.len > 1 {
+				if is_expr {
+					// TODO too many branches. maybe separate ?: matches
+					g.write(' : ')
+				} else {
+					g.writeln('else {')
+				}
 			}
 		} else {
 			if j > 0 {
@@ -1582,11 +1587,11 @@ fn (g mut Gen) match_expr(node ast.MatchExpr) {
 			}
 		}
 		g.stmts(branch.stmts)
-		if !g.inside_ternary {
+		if !g.inside_ternary && node.branches.len > 1 {
 			g.writeln('}')
 		}
 	}
-	g.inside_ternary = false
+	g.inside_ternary = was_inside_ternary
 }
 
 fn (g mut Gen) ident(node ast.Ident) {

--- a/vlib/v/tests/match_test.v
+++ b/vlib/v/tests/match_test.v
@@ -1,67 +1,93 @@
-enum Color{
-    red, green, blue
+enum Color {
+	red
+	green
+	blue
+}
+
+pub fn (c Color) str() string {
+	return 'tmp'
 }
 
 fn test_match_integers() {
 	mut a := 3
 	mut b := 0
 	match a {
-	    2 { println('two') }
-	    3 {
-            println('three')
-            b = 3
-        }
-	    4 { println('four') }
-	    else { println('???') }
-    }
+		2 {
+			println('two')
+		}
+		3 {
+			println('three')
+			b = 3
+		}
+		4 {
+			println('four')
+		}
+		else {
+			println('???')
+		}
+	}
 	assert b == 3
-
-    assert match 2 {
-        1 { 2 }
-        2 { 3 }
-        else { 5 }
-    } == 3
-
-    assert match 0 {
-        1 { 2 }
-        2 { 3 }
-        else { 5 }
-    } == 5
-
-    assert match 1 {
-        else { 5 }
-    } == 5
-
-    a = 0
-    match 2 {
-        0 { a = 1 }
-        1 { a = 2 }
-        else {
-            a = 3
-            println('a is $a')
-        }
-    }
-    assert a == 3
-
-    a = 0
-    match 1 {
-        0 { a = 1 }
-        1 {
-            a = 2
-            a = a + 2
-            a = a + 2
-        }
-       else {}
-    }
-    assert a == 6
-
-    a = 0
-    match 1 {
-        else {
-            a = -2
-        }
-    }
-    assert a == -2
+	assert match 2 {
+		1 {
+			2
+		}
+		2 {
+			3
+		}
+		else {
+			5
+		}
+	} == 3
+	assert match 0 {
+		1 {
+			2
+		}
+		2 {
+			3
+		}
+		else {
+			5
+		}
+	} == 5
+	assert match 1 {
+		else {
+			5
+		}
+	} == 5
+	a = 0
+	match 2 {
+		0 {
+			a = 1
+		}
+		1 {
+			a = 2
+		}
+		else {
+			a = 3
+			println('a is $a')
+		}
+	}
+	assert a == 3
+	a = 0
+	match 1 {
+		0 {
+			a = 1
+		}
+		1 {
+			a = 2
+			a = a + 2
+			a = a + 2
+		}
+		else {}
+	}
+	assert a == 6
+	a = 0
+	match 1 {
+		else {
+			a = -2
+		}
+	}
+	assert a == -2
 }
 
 fn test_match_enums() {


### PR DESCRIPTION
Fix match expression inside assert statements.
Enables match_test.v in the test-fixed command.