### PR TITLE
cgen: fix v/tests/array_to_string_test.v error

### DIFF
--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -395,6 +395,13 @@ fn test_inter_format_string() {
 	assert str_string == '-abc-'
 }
 
+fn test_array_to_string() {
+	a := ['1', '2', '3']
+	assert '$a' == '["1", "2", "3"]'
+	b := ['a', 'b']
+	assert '$b' == '["a", "b"]'
+}
+
 fn test_hash() {
 	s := '10000'
 	assert s.hash() == 46730161

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -395,13 +395,6 @@ fn test_inter_format_string() {
 	assert str_string == '-abc-'
 }
 
-fn test_array_to_string() {
-	a := ['1', '2', '3']
-	assert '$a' == '["1", "2", "3"]'
-	b := ['a', 'b']
-	assert '$b' == '["a", "b"]'
-}
-
 fn test_hash() {
 	s := '10000'
 	assert s.hash() == 46730161

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2399,18 +2399,11 @@ fn (g mut Gen) string_inter_literal(node ast.StringInterLiteral) {
 				verror('only V strings can be formatted with a ${sfmt} format')
 			}
 			g.write('%' + sfmt[1..])
-		} else if node.expr_types[i] in [table.string_type, table.bool_type] || sym.kind ==
-			.enum_ {
+		} else if node.expr_types[i] in [table.string_type, table.bool_type, table.f32_type,
+				table.f64_type] || sym.kind in [.enum_, .array, .array_fixed] {
 			g.write('%.*s')
 		} else {
-			match node.exprs[i] {
-				ast.EnumVal {
-					g.write('%.*s')
-				}
-				else {
-					g.write('%d')
-				}
-			}
+			g.write('%d')
 		}
 	}
 	g.write('", ')
@@ -2422,21 +2415,25 @@ fn (g mut Gen) string_inter_literal(node ast.StringInterLiteral) {
 			if fspec == `s` && node.expr_types[i] == table.string_type {
 				g.expr(expr)
 				g.write('.str')
-			} else {
+			}
+			else {
 				g.expr(expr)
 			}
-		} else if node.expr_types[i] == table.string_type {
+		}
+		else if node.expr_types[i] == table.string_type {
 			// `name.str, name.len,`
 			g.expr(expr)
 			g.write('.len, ')
 			g.expr(expr)
 			g.write('.str')
-		} else if node.expr_types[i] == table.bool_type {
+		}
+		else if node.expr_types[i] == table.bool_type {
 			g.expr(expr)
 			g.write(' ? 4 : 5, ')
 			g.expr(expr)
 			g.write(' ? "true" : "false"')
-		} else {
+		}
+		else {
 			sym := g.table.get_type_symbol(node.expr_types[i])
 			if sym.kind == .enum_ {
 				is_var := match node.exprs[i] {
@@ -2469,7 +2466,19 @@ fn (g mut Gen) string_inter_literal(node ast.StringInterLiteral) {
 					g.enum_expr(expr)
 					g.write('"')
 				}
-			} else {
+			}
+			else if node.expr_types[i] in [table.f32_type, table.f64_type, table.array_type,
+						table.map_type] || sym.kind in [.array, .array_fixed] {
+				styp := g.typ(node.expr_types[i])
+				g.write('${styp}_str(')
+				g.expr(expr)
+				g.write(')')
+				g.write('.len, ')
+				g.write('${styp}_str(')
+				g.expr(expr)
+				g.write(').str')
+			}
+			else {
 				g.expr(expr)
 			}
 		}

--- a/vlib/v/tests/array_to_string_test.v
+++ b/vlib/v/tests/array_to_string_test.v
@@ -2,6 +2,9 @@ fn test_array_to_string_conversion() {
 	expected := '["1", "2", "3", "4"]'
 	arr := ['1', '2', '3', '4']
 	assert arr.str() == expected
+}
+
+fn test_interpolation_array_to_string() {
 	a := ['1', '2', '3']
 	assert '$a' == '["1", "2", "3"]'
 	b := ['a', 'b']

--- a/vlib/v/tests/array_to_string_test.v
+++ b/vlib/v/tests/array_to_string_test.v
@@ -2,4 +2,8 @@ fn test_array_to_string_conversion() {
 	expected := '["1", "2", "3", "4"]'
 	arr := ['1', '2', '3', '4']
 	assert arr.str() == expected
+	a := ['1', '2', '3']
+	assert '$a' == '["1", "2", "3"]'
+	b := ['a', 'b']
+	assert '$b' == '["a", "b"]'
 }


### PR DESCRIPTION
This PR fix v/tests/array_to_string_test.v error.

```
C:\Users\yuyi9\v>v test vlib/v/tests/array_to_string_test.v
---------------------------------------- Testing... --------------------------------------
OK     985 ms [1/1] vlib/v/tests/array_to_string_test.v
------------------------------------------------------------------------------------------
     985 ms <=== total time spent running V _test.v files
                 ok, fail, skip, total =     1,     0,     0,     1
```

**Solution**

Add `f32` `f64`  `array` `array_fixed` process in `string_inter_literal`.