### PR TITLE
parser: fix position of array init

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -246,7 +246,7 @@ fn (c mut Checker) assign_expr(assign_expr mut ast.AssignExpr) {
 	if !c.table.check(right_type, left_type) {
 		left_type_sym := c.table.get_type_symbol(left_type)
 		right_type_sym := c.table.get_type_symbol(right_type)
-		c.error('cannot assign `$right_type_sym.name` to variable `${assign_expr.left.str()}` of type `$left_type_sym.name` ',
+		c.error('cannot assign `$right_type_sym.name` to variable `${assign_expr.left.str()}` of type `$left_type_sym.name`',
 			expr_pos(assign_expr.val))
 	}
 	c.check_expr_opt_call(assign_expr.val, right_type, true)

--- a/vlib/v/checker/tests/inout/cannot_assign_array.out
+++ b/vlib/v/checker/tests/inout/cannot_assign_array.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/inout/cannot_assign_array.v:9:11: error: cannot assign `array_f64` to variable `ctx.vb` of type `string`
+    7|     mut ctx := Context{}
+    8|     x := 2.32
+    9|     ctx.vb = [1.1, x, 3.3, 4.4, 5.0, 6.0, 7.0, 8.9]!!
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   10| }

--- a/vlib/v/checker/tests/inout/cannot_assign_array.vv
+++ b/vlib/v/checker/tests/inout/cannot_assign_array.vv
@@ -1,0 +1,10 @@
+struct Context {
+	pub mut:
+	vb string
+}
+
+fn main() {
+	mut ctx := Context{}
+	x := 2.32
+	ctx.vb = [1.1, x, 3.3, 4.4, 5.0, 6.0, 7.0, 8.9]!!
+}

--- a/vlib/v/checker/tests/inout/void_function_assign_to_string.out
+++ b/vlib/v/checker/tests/inout/void_function_assign_to_string.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/inout/void_function_assign_to_string.v:6:6: error: cannot assign `void` to variable `a` of type `string`  
+vlib/v/checker/tests/inout/void_function_assign_to_string.v:6:6: error: cannot assign `void` to variable `a` of type `string`
     4| fn main(){
     5|     mut a := ''
     6|     a = x(1,2) // hello

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1317,6 +1317,7 @@ fn (p mut Parser) string_expr() ast.Expr {
 
 fn (p mut Parser) array_init() ast.ArrayInit {
 	first_pos := p.tok.position()
+	mut last_pos := token.Position{}
 	p.check(.lsbr)
 	// p.warn('array_init() exp=$p.expected_type')
 	mut array_type := table.void_type
@@ -1346,6 +1347,8 @@ fn (p mut Parser) array_init() ast.ArrayInit {
 			// p.check_comment()
 		}
 		line_nr := p.tok.line_nr
+
+		last_pos = p.tok.position()
 		p.check(.rsbr)
 		// [100]byte
 		if exprs.len == 1 && p.tok.kind in [.name, .amp] && p.tok.line_nr == line_nr {
@@ -1355,17 +1358,17 @@ fn (p mut Parser) array_init() ast.ArrayInit {
 	}
 	// !
 	if p.tok.kind == .not {
+		last_pos = p.tok.position()
 		p.next()
 	}
 	if p.tok.kind == .not {
+		last_pos = p.tok.position()
 		p.next()
 	}
-	last_pos := p.tok.position()
-	len := last_pos.pos - first_pos.pos
 	pos := token.Position{
 		line_nr: first_pos.line_nr
 		pos: first_pos.pos
-		len: len
+		len: last_pos.pos - first_pos.pos + last_pos.len
 	}
 	return ast.ArrayInit{
 		is_fixed: is_fixed


### PR DESCRIPTION
```
vlib/v/checker/tests/inout/cannot_assign_array.v:9:11: error: cannot assign `array_f64` to variable `ctx.vb` of type `string`
    7|     mut ctx := Context{}
    8|     x := 2.32
    9|     ctx.vb = [1.1, x, 3.3, 4.4, 5.0, 6.0, 7.0, 8.9]!!
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   10| }
```