### PR TITLE
checker: check match for exhaustation

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -399,6 +399,7 @@ pub:
 	stmts   []Stmt
 	pos     token.Position
 	comment Comment // comment above `xxx {`
+	is_else bool
 }
 
 pub struct CompIf {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1323,6 +1323,18 @@ pub fn (c mut Checker) match_expr(node mut ast.MatchExpr) table.Type {
 	if cond_type == 0 {
 		c.error('match 0 cond type', node.pos)
 	}
+	// check for exhaustion when match is expr
+	if node.is_sum_type && node.is_expr && !node.branches[node.branches.len - 1].is_else {
+		type_sym := c.table.get_type_symbol(cond_type)
+		info := type_sym.info as table.SumType
+		mut used_sum_types_count := 0
+		for branch in node.branches {
+			used_sum_types_count += branch.exprs.len
+		}
+		if used_sum_types_count < info.variants.len {
+			c.error('match must be exhaustive', node.pos)
+		}
+	}
 	c.expected_type = cond_type
 	mut ret_type := table.void_type
 	for branch in node.branches {

--- a/vlib/v/checker/tests/inout/match_expr_else.out
+++ b/vlib/v/checker/tests/inout/match_expr_else.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/inout/match_expr_else.v:5:9: error: match must be exhaustive
+    3| fn main() {
+    4|     x := A('test')
+    5|     res := match x {
+                  ~~~~~~~~~
+    6|         int {
+    7|             'int'

--- a/vlib/v/checker/tests/inout/match_expr_else.vv
+++ b/vlib/v/checker/tests/inout/match_expr_else.vv
@@ -1,0 +1,13 @@
+type A = int | string | f64
+
+fn main() {
+	x := A('test')
+	res := match x {
+		int {
+			'int'
+		}
+		string {
+			'string'
+		}
+	}
+}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -563,7 +563,7 @@ fn (f mut Fmt) expr(node ast.Expr) {
 				if branch.comment.text != '' {
 					f.comment(branch.comment)
 				}
-				if i < it.branches.len - 1 {
+				if !branch.is_else {
 					// normal branch
 					for j, expr in branch.exprs {
 						f.expr(expr)

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1514,8 +1514,8 @@ fn (g mut Gen) match_expr(node ast.MatchExpr) {
 	// g.writeln(';') // $it.blocks.len')
 	// mut sum_type_str = ''
 	for j, branch in node.branches {
-		if j == node.branches.len - 1 {
-			// last block is an `else{}`
+		is_last := j == node.branches.len - 1
+		if branch.is_else || node.is_expr && is_last {
 			if node.branches.len > 1 {
 				if is_expr {
 					// TODO too many branches. maybe separate ?: matches
@@ -1588,7 +1588,7 @@ fn (g mut Gen) match_expr(node ast.MatchExpr) {
 		}
 		g.stmts(branch.stmts)
 		if !g.inside_ternary && node.branches.len > 1 {
-			g.writeln('}')
+			g.write('}')
 		}
 	}
 	g.inside_ternary = was_inside_ternary

--- a/vlib/v/util/errors.v
+++ b/vlib/v/util/errors.v
@@ -96,7 +96,9 @@ pub fn formatted_error(kind string /*error or warn*/, emsg string, filepath stri
 					continue
 				}
 				if pos.len > 1 {
-					underline := '~'.repeat(pos.len)
+					max_len := sline.len - pointerline.len // rest of the line
+					len := if pos.len > max_len { max_len } else { pos.len }
+					underline := '~'.repeat(len)
 					pointerline << if emanager.support_color { term.bold(term.blue(underline)) } else { underline }
 				}else{
 					pointerline << if emanager.support_color { term.bold(term.blue('^')) } else { '^' }


### PR DESCRIPTION
a match errors a "match must be exhaustive" when
- it's an expression
- it has no else branch

when it's not an expr it doesn't fail.

on expressions (and all sumtype possibilities are given) the last sumtype variant is in the "ternary else" in C.

Produced error:
```
vlib/v/checker/tests/inout/match_expr_else.v:5:9: error: match must be exhaustive
    3| fn main() {
    4|     x := A('test')
    5|     res := match x {
                  ~~~~~~~~~
    6|         int {
    7|             'int'
```