### PR TITLE
ftoa: fix strconv/ftoa/f32_f64_to_string_test.v

### DIFF
--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -21,7 +21,6 @@ const (
 		'vlib/net/http/http_httpbin_test.v',
 		'vlib/net/http/http_test.v',
 		'vlib/regex/regex_test.v',
-		'vlib/strconv/ftoa/f32_f64_to_string_test.v',
 		'vlib/v/tests/const_embed_test.v',
 		'vlib/v/tests/enum_bitfield_test.v',
 		'vlib/v/tests/fixed_array_test.v',

--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -22,6 +22,7 @@ const (
 		'vlib/net/http/http_test.v',
 		'vlib/regex/regex_test.v',
 		'vlib/strconv/ftoa/f32_f64_to_string_test.v',
+		'vlib/v/tests/const_embed_test.v',
 		'vlib/v/tests/enum_bitfield_test.v',
 		'vlib/v/tests/fixed_array_test.v',
 		'vlib/v/tests/fn_test.v',

--- a/vlib/strconv/ftoa/f32_f64_to_string_test.v
+++ b/vlib/strconv/ftoa/f32_f64_to_string_test.v
@@ -3,7 +3,7 @@
 * Float to string Test
 *
 **********************************************************************/
-module ftoa
+import strconv.ftoa
 import math
 
 union Ufloat32 {
@@ -32,124 +32,123 @@ fn f32_from_bits1(b u32) f32 {
 	return x.f
 }
 
-const(
-test_cases_f32 = [
-	f32_from_bits1(0x0000_0000), // +0
-	f32_from_bits1(0x8000_0000), // -0
-	f32_from_bits1(0xFFC0_0001), // sNan
-	f32_from_bits1(0xFF80_0001), // qNan
-	f32_from_bits1(0x7F80_0000), // +inf
-	f32_from_bits1(0xFF80_0000), // -inf
-	1,
-	-1,
-	10,
-	-10,
-	0.3,
-	-0.3,
-	1000000,
-	123456.7,
-	123e35,
-	-123.45,
-	1e23,
-	f32_from_bits1(0x0080_0000), // smallest float32
-	math.max_f32,
-	383260575764816448,
-]
+fn test_float_to_str() {
+	test_cases_f32 := [
+		f32_from_bits1(0x0000_0000), // +0
+		f32_from_bits1(0x8000_0000), // -0
+		f32_from_bits1(0xFFC0_0001), // sNan
+		f32_from_bits1(0xFF80_0001), // qNan
+		f32_from_bits1(0x7F80_0000), // +inf
+		f32_from_bits1(0xFF80_0000), // -inf
+		1,
+		-1,
+		10,
+		-10,
+		0.3,
+		-0.3,
+		1000000,
+		123456.7,
+		123e35,
+		-123.45,
+		1e23,
+		f32_from_bits1(0x0080_0000), // smallest float32
+		math.max_f32,
+		383260575764816448,
+	]
 
-exp_result_f32 = [
-	"0e+00",
-	"-0e+00",
-	"nan",
-	"nan",
-	"+inf",
-	"-inf",
-	"1.e+00",
-	"-1.e+00",
-	"1.e+01",
-	"-1.e+01",
-	"3.e-01",
-	"-3.e-01",
-	"1.e+06",
-	"1.234567e+05",
-	"1.23e+37",
-	"-1.2345e+02",
-	"1.e+23",
-	"1.1754944e-38", // aprox from 1.1754943508 × 10−38, 
-	"3.4028235e+38",
-	"3.8326058e+17",
-]
+	exp_result_f32 := [
+		"0e+00",
+		"-0e+00",
+		"nan",
+		"nan",
+		"+inf",
+		"-inf",
+		"1.e+00",
+		"-1.e+00",
+		"1.e+01",
+		"-1.e+01",
+		"3.e-01",
+		"-3.e-01",
+		"1.e+06",
+		"1.234567e+05",
+		"1.23e+37",
+		"-1.2345e+02",
+		"1.e+23",
+		"1.1754944e-38", // aprox from 1.1754943508 × 10−38,
+		"3.4028235e+38",
+		"3.8326058e+17",
+	]
 
-test_cases_f64 = [
-	f64_from_bits1(0x0000_0000_0000_0000), // +0
-	f64_from_bits1(0x8000_0000_0000_0000), // -0
-	f64_from_bits1(0x7FF0_0000_0000_0001), // sNan
-	f64_from_bits1(0x7FF8_0000_0000_0001), // qNan
-	f64_from_bits1(0x7FF0_0000_0000_0000), // +inf
-	f64_from_bits1(0xFFF0_0000_0000_0000), // -inf
-	1,
-	-1,
-	10,
-	-10,
-	0.3,
-	-0.3,
-	1000000,
-	123456.7,
-	123e45,
-	-123.45,
-	1e23,
-	f64_from_bits1(0x0010_0000_0000_0000), // smallest float64
-	math.max_f32,
-	383260575764816448,
-	383260575764816448,
-	// C failing cases
-	123e300,
-	123e-300,
-	5.e-324,
-	-5.e-324,
-]
+	test_cases_f64 := [
+		f64_from_bits1(0x0000_0000_0000_0000), // +0
+		f64_from_bits1(0x8000_0000_0000_0000), // -0
+		f64_from_bits1(0x7FF0_0000_0000_0001), // sNan
+		f64_from_bits1(0x7FF8_0000_0000_0001), // qNan
+		f64_from_bits1(0x7FF0_0000_0000_0000), // +inf
+		f64_from_bits1(0xFFF0_0000_0000_0000), // -inf
+		1,
+		-1,
+		10,
+		-10,
+		0.3,
+		-0.3,
+		1000000,
+		123456.7,
+		123e45,
+		-123.45,
+		1e23,
+		f64_from_bits1(0x0010_0000_0000_0000), // smallest float64
+		math.max_f32,
+		383260575764816448,
+		383260575764816448,
+		// C failing cases
+		123e300,
+		123e-300,
+		5.e-324,
+		-5.e-324,
+	]
 
-exp_result_f64 = [
-	"0e+00",
-	"-0e+00",
-	"nan",
-	"nan",
-	"+inf",
-	"-inf",
-	"1.e+00",
-	"-1.e+00",
-	"1.e+01",
-	"-1.e+01",
-	"3.e-01",
-	"-3.e-01",
-	"1.e+06",
-	"1.234567e+05",
-	"1.23e+47",
-	"-1.2345e+02",
-	"1.e+23",
-	"2.2250738585072014e-308",
-	"3.4028234663852886e+38",
-	"3.8326057576481645e+17",
-	"3.8326057576481645e+17",
+	exp_result_f64 := [
+		"0e+00",
+		"-0e+00",
+		"nan",
+		"nan",
+		"+inf",
+		"-inf",
+		"1.e+00",
+		"-1.e+00",
+		"1.e+01",
+		"-1.e+01",
+		"3.e-01",
+		"-3.e-01",
+		"1.e+06",
+		"1.234567e+05",
+		"1.23e+47",
+		"-1.2345e+02",
+		"1.e+23",
+		"2.2250738585072014e-308",
+		"3.4028234663852886e+38",
+		"3.8326057576481645e+17",
+		"3.8326057576481645e+17",
 
-	"1.23e+302", // this test is failed from C sprintf!!
-	"1.23e-298",
-	"5.e-324",
-	"-5.e-324",
-]
-)
+		"1.23e+302", // this test is failed from C sprintf!!
+		"1.23e-298",
+		"5.e-324",
+		"-5.e-324",
+	]
 
-fn test_float_to_str(){
 	// test f32
 	for c,x in test_cases_f32 {
-		s  := f32_to_str(x,8)
+		println(x)
+		s  := ftoa.f32_to_str(x,8)
 		s1 := exp_result_f32[c]
-		//println("$s1 $s")
+		println("$s1 $s")
 		assert s == s1
 	}
 
 	// test f64
 	for c,x in test_cases_f64 {
-		s  := f64_to_str(x,17)
+		s  := ftoa.f64_to_str(x,17)
 		s1 := exp_result_f64[c]
 		//println("$s1 $s")
 		assert s == s1
@@ -157,16 +156,16 @@ fn test_float_to_str(){
 
 	// test long format
 	for exp := 1 ; exp < 120 ; exp++ {
-		a := f64_to_str_l(("1e"+exp.str()).f64())
+		a := ftoa.f64_to_str_l(("1e"+exp.str()).f64())
 		//println(a)
 		assert a.len == exp + 1
 
-		b := f64_to_str_l(("1e-"+exp.str()).f64())
+		b := ftoa.f64_to_str_l(("1e-"+exp.str()).f64())
 		//println(b)
 		assert b.len == exp + 2
 	}
 
 	// test rounding str conversion
-	assert f64_to_str(0.3456789123456, 4)=="3.4568e-01"
-	assert f32_to_str(0.345678, 3)=="3.457e-01"
+	assert ftoa.f64_to_str(0.3456789123456, 4)=="3.4568e-01"
+	assert ftoa.f32_to_str(0.345678, 3)=="3.457e-01"
 }

--- a/vlib/v/tests/const_embed_test.v
+++ b/vlib/v/tests/const_embed_test.v
@@ -1,0 +1,11 @@
+import math
+
+const (
+	max_float = math.max_f32
+)
+
+fn test_const_embed() {
+	println(max_float)
+	println(math.max_f32)
+	assert max_float == math.max_f32
+}


### PR DESCRIPTION
This PR fix strconv/ftoa/f32_f64_to_string_test.v error.

```
C:\Users\yuyi9\v>v test vlib/strconv/ftoa
---------------------------------------- Testing... --------------------------------------
OK    1062 ms [1/1] vlib/strconv/ftoa\f32_f64_to_string_test.v
------------------------------------------------------------------------------------------
    1062 ms <=== total time spent running V _test.v files
                 ok, fail, skip, total =     1,     0,     0,     1
```

**Solution**

- Modify import.
```v
import strconv.ftoa
import math
```
- Change `test_cases_f32` from const to local variable.
```v
const test_cases_f32 = [
                ...,
                math.max_f32,
                ...,
```       
Because the const resolution order is not sure, the math.max_f32 is 0, change to local variable can resolve the problem.     