### PR TITLE
cgen: fix math/complex_test.v

### DIFF
--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -16,7 +16,6 @@ const (
 		'vlib/eventbus/eventbus_test.v',
 		'vlib/flag/flag_test.v',
 		'vlib/json/json_test.v',
-		'vlib/math/complex/complex_test.v',
 		'vlib/net/ftp/ftp_test.v',
 		'vlib/net/http/http_httpbin_test.v',
 		'vlib/net/http/http_test.v',

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2189,9 +2189,11 @@ fn (g mut Gen) string_inter_literal(node ast.StringInterLiteral) {
 				verror('only V strings can be formatted with a ${sfmt} format')
 			}
 			g.write('%' + sfmt[1..])
-		} else if node.expr_types[i] in [table.string_type, table.bool_type, table.f32_type,
-			table.f64_type] || sym.kind in [.enum_, .array, .array_fixed] {
+		} else if node.expr_types[i] in [table.string_type, table.bool_type] ||
+						sym.kind in [.enum_, .array, .array_fixed] {
 			g.write('%.*s')
+		} else if node.expr_types[i] in [table.f32_type, table.f64_type] {
+			g.write('%f')
 		} else {
 			g.write('%d')
 		}
@@ -2219,6 +2221,8 @@ fn (g mut Gen) string_inter_literal(node ast.StringInterLiteral) {
 			g.write(' ? 4 : 5, ')
 			g.expr(expr)
 			g.write(' ? "true" : "false"')
+		} else if node.expr_types[i] in [table.f32_type, table.f64_type] {
+			g.expr(expr)
 		} else {
 			sym := g.table.get_type_symbol(node.expr_types[i])
 			if sym.kind == .enum_ {
@@ -2252,8 +2256,7 @@ fn (g mut Gen) string_inter_literal(node ast.StringInterLiteral) {
 					g.enum_expr(expr)
 					g.write('"')
 				}
-			} else if node.expr_types[i] in [table.f32_type, table.f64_type, table.array_type,
-				table.map_type] || sym.kind in [.array, .array_fixed] {
+			} else if sym.kind in [.array, .array_fixed] {
 				styp := g.typ(node.expr_types[i])
 				g.write('${styp}_str(')
 				g.expr(expr)


### PR DESCRIPTION
This PR fix math/complex_test.v.

```
......
OK    1657 ms [ 38/153] vlib\math\complex\complex_test.v
......
------------------------------------------------------------------------------------------
   82438 ms <=== total time spent testing all fixed tests
                 ok, fail, skip, total =   118,     0,    35,   153
```

Solution

- Change `f32` `f64` format from `%.*s` to `%f` in `cgen.string_inter_literal`.
- Remove `vlib\math\complex\complex_test.v` from skip list in test-fixed.