### PR TITLE
builtin: test left/right shift precendence

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -691,3 +691,16 @@ fn test_hex(){
 	st1 := [byte(0x41)].repeat(100)
 	assert st1.hex() == "41".repeat(100)
 }
+
+fn test_left_shift_precendence() {
+	mut arr := []int
+	arr << 1 + 1
+	arr << 1 - 1
+	arr << 2 / 1
+	arr << 2 * 1
+
+	assert arr[0] == 2
+	assert arr[1] == 0
+	assert arr[2] == 2
+	assert arr[3] == 2
+}

--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -100,6 +100,16 @@ fn test_xor_precendence() {
 	assert (1 ^ 0 > 1) == ((1 ^ 0) > 1)
 }
 
+fn test_left_shift_precendence() {
+	assert (2 << 4 | 3) == ((2 << 4) | 3)
+	assert (2 << 4 | 3) != (2 << (4 | 3))
+}
+
+fn test_right_shift_precendence() {
+	assert (256 >> 4 | 3) == ((256 >> 4) | 3)
+	assert (256 >> 4 | 3) != (256 >> (4 | 3))
+}
+
 fn test_i8_print() {
 	b := i8(0)
 	println(b)


### PR DESCRIPTION
Test precedence of a left/right shift operator over a bitwise OR operator.
Test precedence of other operators over a left/right shift operator when adding items to an array.