### PR TITLE
checker: for in index type error position

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -951,7 +951,7 @@ fn (c mut Checker) stmt(node ast.Stmt) {
 				value_type := c.table.value_type(typ)
 				if value_type == table.void_type {
 					typ_sym := c.table.get_type_symbol(typ)
-					c.error('for in: cannot index `$typ_sym.name`', it.pos)
+					c.error('for in: cannot index `$typ_sym.name`', expr_pos(it.cond))
 				}
 				it.cond_type = typ
 				it.kind = sym.kind

--- a/vlib/v/checker/tests/inout/for-in-index-type.out
+++ b/vlib/v/checker/tests/inout/for-in-index-type.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/inout/for-in-index-type.v:2:11: error: for in: cannot index `int`
+    1| fn main() {
+    2|     for a in 52 {
+                    ~~
+    3|         println(a)
+    4|     }

--- a/vlib/v/checker/tests/inout/for-in-index-type.vv
+++ b/vlib/v/checker/tests/inout/for-in-index-type.vv
@@ -1,0 +1,5 @@
+fn main() {
+	for a in 52 {
+		println(a)
+	}
+}


### PR DESCRIPTION
```
vlib/v/checker/tests/inout/for-in-index-type.v:2:11: error: for in: cannot index `int`
    1| fn main() {
    2|     for a in 52 {
                    ~~
    3|         println(a)
    4|     }
```