### PR TITLE
checker: fail if else isn't the last branch of match

### DIFF
--- a/vlib/v/checker/tests/inout/match_else_last_expr.out
+++ b/vlib/v/checker/tests/inout/match_else_last_expr.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/inout/match_else_last_expr.v:4:3: error: `else` must be the last branch of `match`
+    2|     match 1 {
+    3|         1 { println('1') }
+    4|         else { println('else') }
+               ~~~~~~
+    5|         4 { println('4') }
+    6|     }

--- a/vlib/v/checker/tests/inout/match_else_last_expr.vv
+++ b/vlib/v/checker/tests/inout/match_else_last_expr.vv
@@ -1,0 +1,7 @@
+fn main() {
+	match 1 {
+		1 { println('1') }
+		else { println('else') }
+		4 { println('4') }
+	}
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1919,8 +1919,8 @@ fn (p mut Parser) match_expr() ast.MatchExpr {
 		// p.warn('match block')
 		stmts := p.parse_block()
 		pos := token.Position{
-			line_nr: match_first_pos.line_nr
-			pos: match_first_pos.pos
+			line_nr: branch_first_pos.line_nr
+			pos: branch_first_pos.pos
 			len: branch_last_pos.pos - branch_first_pos.pos + branch_last_pos.len
 		}
 		branches << ast.MatchBranch{


### PR DESCRIPTION
Add an error if the `else` branch isn't the last of a `match` expression.
