### PR TITLE
Fix assert when running 'v run' without any argument

### DIFF
--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -184,12 +184,17 @@ fn parse_args(args []string) (&pref.Preferences, string) {
 	}
 	else if command == 'run' {
 		res.is_run = true
-		res.path = args[command_pos+1]
-		res.run_args = if command_pos+1 < args.len { args[command_pos+2..] } else { []string }
+		if command_pos + 1 < args.len {
+			res.path = args[command_pos + 1]
+			res.run_args = args[command_pos+2..]
+		} else {
+			eprintln('v run: no v files listed')
+			exit(1)
+		}
 	}
 	if command == 'build-module' {
 		res.build_mode = .build_module
-		res.path = args[command_pos+1]
+		res.path = args[command_pos + 1]
 	}
 	if res.is_verbose {
 		println('setting pref.path to "$res.path"')


### PR DESCRIPTION
Running this results in a crash:
```
$ v run
V panic: array.get: index out of range (i == 1, a.len == 1)
0   v                                   0x0000000107d892d0 v_panic + 64
1   v                                   0x0000000107d895e8 array_get + 88
2   v                                   0x0000000107d98dcd parse_args + 3853
3   v                                   0x0000000107d96e82 main + 1186
4   v                                   0x0000000107d87844 start + 52
5   ???                                 0x0000000000000002 0x0 + 2
```

this patch fixes the issue by making it behave like `v run .`