### PR TITLE
cgen: fix error with arrays named 'new_array'

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -28,6 +28,10 @@ fn new_array(mylen int, cap int, elm_size int) array {
 	return arr
 }
 
+fn __new_array(mylen int, cap int, elm_size int) array {
+	return new_array(mylen, cap, elm_size)
+}
+
 // TODO
 pub fn make(len int, cap int, elm_size int) array {
 	return new_array(len, cap, elm_size)

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -865,7 +865,8 @@ fn (g mut Gen) expr(node ast.Expr) {
 				elem_sym := g.table.get_type_symbol(it.elem_type)
 				elem_type_str := g.typ(it.elem_type)
 				if it.exprs.len == 0 {
-					g.write('new_array($it.exprs.len, $it.exprs.len, sizeof($elem_type_str))')
+					// use __new_array to fix conflicts when the name of the variable is new_array
+					g.write('__new_array($it.exprs.len, $it.exprs.len, sizeof($elem_type_str))')
 				} else {
 					len := it.exprs.len
 					g.write('new_array_from_c_array($len, $len, sizeof($elem_type_str), ')


### PR DESCRIPTION
fixes #4407