### PR TITLE
test: fix const_embed_test.v error

### DIFF
--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -20,7 +20,6 @@ const (
 		'vlib/net/http/http_httpbin_test.v',
 		'vlib/net/http/http_test.v',
 		'vlib/regex/regex_test.v',
-		'vlib/v/tests/const_embed_test.v',
 		'vlib/v/tests/enum_bitfield_test.v',
 		'vlib/v/tests/fixed_array_test.v',
 		'vlib/v/tests/fn_test.v',

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -34,12 +34,13 @@ pub fn compile(command string, pref &pref.Preferences) {
 		// println(pref)
 	}
 	mut tmark := benchmark.new_benchmark()
-	mut files := []string
 	if pref.backend == .x64 {
+		builtin_files := []string
+		user_files := []string
 		// v.files << v.v_files_from_dir(os.join_path(v.pref.vlib_path,'builtin','bare'))
-		files << pref.path
+		user_files << pref.path
 		b.set_module_lookup_paths()
-		b.build_x64(files, pref.out_name)
+		b.build_x64(builtin_files, user_files, pref.out_name)
 	} else {
 		if os.user_os() != 'windows' && pref.ccompiler == 'msvc' {
 			verror('Cannot build with msvc on ${os.user_os()}')
@@ -48,25 +49,26 @@ pub fn compile(command string, pref &pref.Preferences) {
 		// println('compile2()')
 		if pref.is_verbose {
 			println('all .v files before:')
-			println(files)
+			//println(files)
 		}
 		// v1 compiler files
 		// v.add_v_files_to_compile()
 		// v.files << v.dir
 		// v2 compiler
 		// b.set_module_lookup_paths()
-		files << b.get_builtin_files()
-		files << b.get_user_files()
+		builtin_files := b.get_builtin_files()
+		user_files := b.get_user_files()
 		b.set_module_lookup_paths()
 		if pref.is_verbose {
 			println('all .v files:')
-			println(files)
+			println(builtin_files)
+			println(user_files)
 		}
 		mut out_name_c := get_vtmp_filename(pref.out_name, '.tmp.c')
 		if pref.is_so {
 			out_name_c = get_vtmp_filename(pref.out_name, '.tmp.so.c')
 		}
-		b.build_c(files, out_name_c)
+		b.build_c(builtin_files, user_files, out_name_c)
 		b.cc()
 	}
 	if pref.is_stats {

--- a/vlib/v/gen/cgen_test.v
+++ b/vlib/v/gen/cgen_test.v
@@ -25,7 +25,7 @@ fn test_c_files() {
 		}
 		mut b := builder.new_builder(pref.Preferences{})
 		b.module_search_paths = ['$vroot/vlib/v/gen/tests/']
-		mut res := b.gen_c([path]).after('#endbuiltin')
+		mut res := b.gen_c([path], []).after('#endbuiltin')
 		if res.contains('string _STR') {
 			pos := res.index('string _STR') or {
 				-1


### PR DESCRIPTION
This PR fix const_embed_test.v error.

```v
......
OK    1172 ms [ 85/154] vlib\v\tests\const_embed_test.v
......
--------------------------------------------------------------------------------------------------------------------------------------------
   71266 ms <=== total time spent testing all fixed tests
                 ok, fail, skip, total =   120,     0,    34,   154
```

**Cause**
Due to file resolution and cgen order.

**Solution**
Resolving file groups is divided into `builtin_files` `user_files` and `import_files`.
Cgen order:  `builtin_files` -> `import_files`  -> `user_files`.
