### PR TITLE
test: fix const_embed_test.v error

### DIFF
--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -20,7 +20,6 @@ const (
 		'vlib/net/http/http_httpbin_test.v',
 		'vlib/net/http/http_test.v',
 		'vlib/regex/regex_test.v',
-		'vlib/v/tests/const_embed_test.v',
 		'vlib/v/tests/enum_bitfield_test.v',
 		'vlib/v/tests/fixed_array_test.v',
 		'vlib/v/tests/fn_test.v',

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -34,11 +34,10 @@ pub fn compile(command string, pref &pref.Preferences) {
 		// println(pref)
 	}
 	mut tmark := benchmark.new_benchmark()
-	mut files := []string
 	match pref.backend {
-		.c { b.compile_c(files, pref) }
-		.js { b.compile_js(files, pref) }
-		.x64 { b.compile_x64(files, pref) }
+		.c { b.compile_c(pref) }
+		.js { b.compile_js(pref) }
+		.x64 { b.compile_x64(pref) }
 		else {
 			eprintln('backend not implemented `$pref.backend`')
 			exit(1)

--- a/vlib/v/builder/js.v
+++ b/vlib/v/builder/js.v
@@ -3,51 +3,58 @@ module builder
 import (
 	time
 	os
+	v.ast
 	v.parser
 	v.pref
 	v.gen
 	v.gen.js
 )
 
-pub fn (b mut Builder) gen_js(v_files []string) string {
+pub fn (b mut Builder) gen_js(builtin_files, user_files []string) string {
 	t0 := time.ticks()
-	b.parsed_files = parser.parse_files(v_files, b.table, b.pref, b.global_scope)
+	b.builtin_parsed_files = parser.parse_files(builtin_files, b.table, b.pref, b.global_scope)
+	b.user_parsed_files = parser.parse_files(user_files, b.table, b.pref, b.global_scope)
 	b.parse_imports()
 	t1 := time.ticks()
 	parse_time := t1 - t0
 	b.info('PARSE: ${parse_time}ms')
-	b.checker.check_files(b.parsed_files)
+	mut parsed_files := []ast.File
+	parsed_files << b.builtin_parsed_files
+	parsed_files << b.import_parsed_files
+	parsed_files << b.user_parsed_files
+	b.checker.check_files(parsed_files)
 	t2 := time.ticks()
 	check_time := t2 - t1
 	b.info('CHECK: ${check_time}ms')
 	if b.checker.nr_errors > 0 {
 		exit(1)
 	}
-	res := js.gen(b.parsed_files, b.table, b.pref)
+	res := js.gen(parsed_files, b.table, b.pref)
 	t3 := time.ticks()
 	gen_time := t3 - t2
 	b.info('JS GEN: ${gen_time}ms')
 	return res
 }
 
-pub fn (b mut Builder) build_js(v_files []string, out_file string) {
+pub fn (b mut Builder) build_js(builtin_files, user_files []string, out_file string) {
 	b.out_name_js = out_file
 	b.info('build_js($out_file)')
 	mut f := os.create(out_file) or {
 		panic(err)
 	}
-	f.writeln(b.gen_js(v_files))
+	f.writeln(b.gen_js(builtin_files, user_files))
 	f.close()
 }
 
-pub fn (b mut Builder) compile_js(files []string, pref &pref.Preferences) {
+pub fn (b mut Builder) compile_js(pref &pref.Preferences) {
 	//TODO files << b.get_builtin_files()
-	files << b.get_user_files()
+	builtin_files := []string
+	user_files := b.get_user_files()
 	b.set_module_lookup_paths()
 	if pref.is_verbose {
 		println('all .v files:')
-		println(files)
+		println(user_files)
 	}
-	b.build_js(files, pref.out_name + '.js')
+	b.build_js(builtin_files, user_files, pref.out_name + '.js')
 	//TODO run the file
 }

--- a/vlib/v/builder/x64.v
+++ b/vlib/v/builder/x64.v
@@ -3,36 +3,44 @@ module builder
 import (
 	time
 	os
+	v.ast
 	v.parser
 	v.pref
 	v.gen
 	v.gen.x64
 )
 
-pub fn (b mut Builder) build_x64(v_files []string, out_file string) {
+pub fn (b mut Builder) build_x64(builtin_files, user_files []string, out_file string) {
 	$if !linux {
 		println('v -x64 can only generate Linux binaries for now')
 		println('You are not on a Linux system, so you will not ' + 'be able to run the resulting executable')
 	}
 	t0 := time.ticks()
-	b.parsed_files = parser.parse_files(v_files, b.table, b.pref, b.global_scope)
+	b.builtin_parsed_files = parser.parse_files(builtin_files, b.table, b.pref, b.global_scope)
+	b.user_parsed_files = parser.parse_files(user_files, b.table, b.pref, b.global_scope)
 	b.parse_imports()
 	t1 := time.ticks()
 	parse_time := t1 - t0
 	b.info('PARSE: ${parse_time}ms')
-	b.checker.check_files(b.parsed_files)
+	mut parsed_files := []ast.File
+	parsed_files << b.builtin_parsed_files
+	parsed_files << b.import_parsed_files
+	parsed_files << b.user_parsed_files
+	b.checker.check_files(parsed_files)
 	t2 := time.ticks()
 	check_time := t2 - t1
 	b.info('CHECK: ${check_time}ms')
-	x64.gen(b.parsed_files, out_file)
+	x64.gen(parsed_files, out_file)
 	t3 := time.ticks()
 	gen_time := t3 - t2
 	b.info('x64 GEN: ${gen_time}ms')
 }
 
-pub fn (b mut Builder) compile_x64(files []string, pref &pref.Preferences) {
+pub fn (b mut Builder) compile_x64(pref &pref.Preferences) {
+	builtin_files := []string
+	user_files := []string
 	// v.files << v.v_files_from_dir(os.join_path(v.pref.vlib_path,'builtin','bare'))
-	files << pref.path
+	user_files << pref.path
 	b.set_module_lookup_paths()
-	b.build_x64(files, pref.out_name)	
+	b.build_x64(builtin_files, user_files, pref.out_name)
 }

--- a/vlib/v/gen/cgen_test.v
+++ b/vlib/v/gen/cgen_test.v
@@ -25,7 +25,7 @@ fn test_c_files() {
 		}
 		mut b := builder.new_builder(pref.Preferences{})
 		b.module_search_paths = ['$vroot/vlib/v/gen/tests/']
-		mut res := b.gen_c([path]).after('#endbuiltin')
+		mut res := b.gen_c([path], []).after('#endbuiltin')
 		if res.contains('string _STR') {
 			pos := res.index('string _STR') or {
 				-1


### PR DESCRIPTION
This PR fix const_embed_test.v error.

```v
......
OK    1172 ms [ 85/154] vlib\v\tests\const_embed_test.v
......
--------------------------------------------------------------------------------------------------------------------------------------------
   71266 ms <=== total time spent testing all fixed tests
                 ok, fail, skip, total =   120,     0,    34,   154
```

**Cause**
Due to file resolution and cgen order is not correct.

**Solution**
Resolving file groups is divided into `builtin_files` `user_files` and `import_files`.
Cgen order:  `builtin_files` -> `import_files`  -> `user_files`.
