### PR TITLE
checker: move capital var check from parser to checker

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -652,6 +652,12 @@ pub fn (c mut Checker) enum_decl(decl ast.EnumDecl) {
 
 pub fn (c mut Checker) assign_stmt(assign_stmt mut ast.AssignStmt) {
 	c.expected_type = table.none_type	// TODO a hack to make `x := if ... work`
+	// check variablename for beginning with capital letter 'Abc'
+	for ident in assign_stmt.left {
+		if assign_stmt.op == .decl_assign && scanner.contains_capital(ident.name) {
+			c.error('variable names cannot contain uppercase letters, use snake_case instead', ident.pos)
+		}
+	}
 	if assign_stmt.left.len > assign_stmt.right.len {
 		// multi return
 		match assign_stmt.right[0] {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -692,7 +692,8 @@ pub fn (p mut Parser) name_expr() ast.Expr {
 			node = x
 		}
 	} else if p.peek_tok.kind == .lcbr && (p.tok.lit[0].is_capital() || is_c || (p.builtin_mod &&
-		p.tok.lit in table.builtin_type_names)) && !p.inside_match && !p.inside_match_case && !p.inside_if && !p.inside_for {
+		p.tok.lit in table.builtin_type_names)) && !p.inside_match && !p.inside_match_case && !p.inside_if &&
+		!p.inside_for {
 		// (p.tok.lit.len in [1, 2] || !p.tok.lit[p.tok.lit.len - 1].is_capital()) &&
 		// || p.table.known_type(p.tok.lit)) {
 		return p.struct_init(false)		// short_syntax: false
@@ -1785,10 +1786,6 @@ fn (p mut Parser) assign_stmt() ast.Stmt {
 	exprs := p.parse_assign_rhs()
 	is_decl := op == .decl_assign
 	for i, ident in idents {
-		if op == .decl_assign && scanner.contains_capital(ident.name) {
-			p.error_with_pos('variable names cannot contain uppercase letters, use snake_case instead',
-				ident.pos)
-		}
 		known_var := p.scope.known_var(ident.name)
 		if !is_decl && !known_var {
 			p.error('unknown variable `$ident.name`')


### PR DESCRIPTION
```
abc.v:4:2: error: variable names cannot contain uppercase letters, use snake_case instead 
    2| 
    3| fn main() {
    4|     Abc := 1
           ~~~
    5| }
```