### PR TITLE
parser: change error message of mut in for loops

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1084,7 +1084,7 @@ fn (p mut Parser) for_stmt() ast.Stmt {
 			is_inf: true
 		}
 	} else if p.tok.kind in [.key_mut, .key_var] {
-		p.error('`mut` is forbidden in for loops')
+		p.error('`mut` is not needed in for loops')
 	} else if p.peek_tok.kind in [.decl_assign, .assign, .semicolon] || p.tok.kind == .semicolon {
 		// `for i := 0; i < 10; i++ {`
 		var init := ast.Stmt{}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1084,7 +1084,7 @@ fn (p mut Parser) for_stmt() ast.Stmt {
 			is_inf: true
 		}
 	} else if p.tok.kind in [.key_mut, .key_var] {
-		p.error('`mut` is not required in for loops')
+		p.error('`mut` is forbidden in for loops')
 	} else if p.peek_tok.kind in [.decl_assign, .assign, .semicolon] || p.tok.kind == .semicolon {
 		// `for i := 0; i < 10; i++ {`
 		var init := ast.Stmt{}


### PR DESCRIPTION
when it's not required it sounds like it's optional, but in real it's forbidden.

maybe forbidden sounds like you can't make that variable mutable, but this error messages is at least better than the previous. 