### PR TITLE
fmt: stop mangling reference names

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -453,7 +453,13 @@ fn (f mut Fmt) struct_decl(node ast.StructDecl) {
 }
 
 fn (f &Fmt) type_to_str(t table.Type) string {
-	res := f.table.type_to_str(t)
+	mut res := f.table.type_to_str(t)
+	// type_ptr => &type
+	if res.ends_with('_ptr') {
+		res = res[0 .. res.len-4]
+		start_pos := 2 * res.count('[]')
+		res = res[0 .. start_pos] + '&' + res[start_pos .. res.len]
+	}
 	return res.replace(f.cur_mod + '.', '')
 }
 

--- a/vlib/v/fmt/tests/type_ptr.vv
+++ b/vlib/v/fmt/tests/type_ptr.vv
@@ -1,6 +1,6 @@
 const (
-	A = &Test{}
-	B = []&Test
+	A  = &Test{}
+	B  = []&Test
 	C_ = &[]&Test
 )
 

--- a/vlib/v/fmt/tests/type_ptr.vv
+++ b/vlib/v/fmt/tests/type_ptr.vv
@@ -6,8 +6,8 @@ const (
 
 fn test_type_ptr() {
 	a := &Test{}
-	c := []&Test
-	b := &[]&Test
+	b := []&Test
+	c := &[]&Test
 }
 
 struct Test {

--- a/vlib/v/fmt/tests/type_ptr.vv
+++ b/vlib/v/fmt/tests/type_ptr.vv
@@ -1,8 +1,14 @@
-struct Test {
-}
+const (
+	A = &Test{}
+	B = []&Test
+	C_ = &[]&Test
+)
 
 fn test_type_ptr() {
 	a := &Test{}
 	c := []&Test
 	b := &[]&Test
+}
+
+struct Test {
 }

--- a/vlib/v/fmt/tests/type_ptr.vv
+++ b/vlib/v/fmt/tests/type_ptr.vv
@@ -1,0 +1,8 @@
+struct Test {
+}
+
+fn test_type_ptr() {
+	a := &Test{}
+	c := []&Test
+	b := &[]&Test
+}

--- a/vlib/v/fmt/tests/type_ptr_keep.vv
+++ b/vlib/v/fmt/tests/type_ptr_keep.vv
@@ -1,6 +1,6 @@
 const (
-	x  = &Test{}
-	y  = []&Test
+	x = &Test{}
+	y = []&Test
 	z = &[]&Test
 )
 

--- a/vlib/v/fmt/tests/type_ptr_keep.vv
+++ b/vlib/v/fmt/tests/type_ptr_keep.vv
@@ -1,7 +1,7 @@
 const (
-	A  = &Test{}
-	B  = []&Test
-	C_ = &[]&Test
+	x  = &Test{}
+	y  = []&Test
+	z = &[]&Test
 )
 
 fn test_type_ptr() {


### PR DESCRIPTION
fixes #4428

I'm not entirely sure how fmt tests work so tell me if I'm doing something wrong here. I'm assuming the code in the test is supposed to remain the same after a `v fmt`