### PR TITLE
parser: add const no group error friendly tips

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1514,6 +1514,9 @@ fn (p mut Parser) const_decl() ast.ConstDecl {
 	}
 	pos := p.tok.position()
 	p.check(.key_const)
+	if p.tok.kind != .lpar {
+		p.error('`const` must use group mode, e.g., const (a = 2)')
+	}
 	p.check(.lpar)
 	var fields := []ast.ConstField
 	for p.tok.kind != .rpar {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1515,9 +1515,9 @@ fn (p mut Parser) const_decl() ast.ConstDecl {
 	pos := p.tok.position()
 	p.check(.key_const)
 	if p.tok.kind != .lpar {
-		p.error('`const` must use group mode, e.g., const (a = 2)')
+		p.error('consts must be grouped, e.g.\nconst (\n\ta = 1\n)')
 	}
-	p.check(.lpar)
+	p.next() // (
 	var fields := []ast.ConstField
 	for p.tok.kind != .rpar {
 		if p.tok.kind == .comment {


### PR DESCRIPTION
This PR add const no group error friendly tips.

```v
const aa = math.e
```
Prompt:
```v
.\tt1.v:5:7: error: `const` must use group mode, e.g., const (a = 2)
    3| import math
    4|
    5| const aa = math.e
             ~~
```

Before is `error: unexpected 'name', expecting '('`, It's not easy to understand.