### PR TITLE
cgen: fix const_embed_test.v error

### DIFF
--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -20,7 +20,6 @@ const (
 		'vlib/net/http/http_httpbin_test.v',
 		'vlib/net/http/http_test.v',
 		'vlib/regex/regex_test.v',
-		'vlib/v/tests/const_embed_test.v',
 		'vlib/v/tests/enum_bitfield_test.v',
 		'vlib/v/tests/fixed_array_test.v',
 		'vlib/v/tests/fn_test.v',

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1841,10 +1841,10 @@ fn (g mut Gen) const_decl(node ast.ConstDecl) {
 			ast.CharLiteral {
 				g.const_decl_simple_define(name, val)
 			}
-			ast.IntegerLiteral {
+			ast.FloatLiteral {
 				g.const_decl_simple_define(name, val)
 			}
-			ast.FloatLiteral {
+			ast.IntegerLiteral {
 				g.const_decl_simple_define(name, val)
 			}
 			ast.StringLiteral {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1844,6 +1844,9 @@ fn (g mut Gen) const_decl(node ast.ConstDecl) {
 			ast.IntegerLiteral {
 				g.const_decl_simple_define(name, val)
 			}
+			ast.FloatLiteral {
+				g.const_decl_simple_define(name, val)
+			}
 			ast.StringLiteral {
 				g.definitions.writeln('string _const_$name; // a string literal, inited later')
 				if g.pref.build_mode != .build_module {


### PR DESCRIPTION
This PR fix const_embed_test.v error.

```v
......
OK    1172 ms [ 85/154] vlib\v\tests\const_embed_test.v
......
--------------------------------------------------------------------------------------------------------------------------------------------
   71266 ms <=== total time spent testing all fixed tests
                 ok, fail, skip, total =   120,     0,    34,   154
```

**Solution**
```v
       ...
	ast.FloatLiteral {
		g.const_decl_simple_define(name, val)
	}
```
Use the float type of const in the define way instead of init later.