### PR TITLE
cgen: fix string interpolation float type

### DIFF
--- a/vlib/math/complex/complex.v
+++ b/vlib/math/complex/complex.v
@@ -18,12 +18,12 @@ pub fn complex(re f64, im f64) Complex {
 
 // To String method
 pub fn (c Complex) str() string {
-	mut out := '$c.re'
+	mut out := '${c.re:f}'
 	out += if c.im >= 0 {
-		'+$c.im'
+		'+${c.im:f}'
 	}
 	else {
-		'$c.im'
+		'${c.im:f}'
 	}
 	out += 'i'
 	return out

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2222,7 +2222,7 @@ fn (g mut Gen) string_inter_literal(node ast.StringInterLiteral) {
 			[.enum_, .array, .array_fixed] {
 			g.write('%.*s')
 		} else if node.expr_types[i] in [table.f32_type, table.f64_type] {
-			g.write('%f')
+			g.write('%g')
 		} else {
 			g.write('%d')
 		}


### PR DESCRIPTION
This PR fix string interpolation float type.

```v
a := 3.45
println('$a')
```

Before
```v
3.450000
```

Now
```v
3.45
```
