### PR TITLE
cgen: fix struct to str error

### DIFF
--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -30,7 +30,6 @@ const (
 		'vlib/v/tests/pointers_test.v',
 		'vlib/v/tests/repl/repl_test.v',
 		'vlib/v/tests/string_interpolation_array_of_structs_test.v',
-		'vlib/v/tests/string_interpolation_struct_test.v',
 		'vlib/v/tests/string_interpolation_variadic_test.v',
 		'vlib/v/tests/type_test.v',
 		'vlib/v/tests/typeof_test.v',

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2231,10 +2231,12 @@ fn (var g Gen) string_inter_literal(node ast.StringInterLiteral) {
 			}
 			g.write('%' + sfmt[1..])
 		} else if node.expr_types[i] in [table.string_type, table.bool_type] || sym.kind in
-			[.enum_, .array, .array_fixed, .struct_] {
+			[.enum_, .array, .array_fixed] {
 			g.write('%.*s')
 		} else if node.expr_types[i] in [table.f32_type, table.f64_type] {
 			g.write('%g')
+		} else if sym.kind == .struct_ && !sym.has_method('str') {
+			g.write('%.*s')
 		} else {
 			g.write('%d')
 		}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2918,7 +2918,7 @@ fn (var g Gen) gen_str_for_struct(info table.Struct, styp string) {
 		g.definitions.write(', ')
 		for i, field in info.fields {
 			sym := g.table.get_type_symbol(field.typ)
-			if sym.kind == .struct_ {
+			if sym.kind in [.struct_, .array, .array_fixed] {
 				field_styp := g.typ(field.typ)
 				second_str_param := if sym.has_method('str') { '' } else { ', indent_count + 1' }
 				g.definitions.write('indents.len, indents.str, ${field_styp}_str(it.$field.name$second_str_param).len, ${field_styp}_str(it.$field.name$second_str_param).str')
@@ -2940,7 +2940,7 @@ fn (var g Gen) gen_str_for_struct(info table.Struct, styp string) {
 
 fn (g Gen) type_to_fmt(typ table.Type) string {
 	sym := g.table.get_type_symbol(typ)
-	if sym.kind == .struct_ {
+	if sym.kind in [.struct_, .array, .array_fixed] {
 		return '%.*s'
 	} else if typ == table.string_type {
 		return "\'%.*s\'"

--- a/vlib/v/tests/string_interpolation_struct_test.v
+++ b/vlib/v/tests/string_interpolation_struct_test.v
@@ -11,7 +11,7 @@ fn test_default_struct_string_interpolation() {
 	superman := Man{'Superman', 30, ['flying', 'fighting evil', 'being nice']}
 	s := '$superman'
 	assert s.contains('Man {')
-	assert s.contains('name: Superman')
+	assert s.contains('name: "Superman"')
 	assert s.contains('age: 30')
 	assert s.contains('interests: [')
 	assert s.contains('"being nice"')


### PR DESCRIPTION
This PR fix struct to str error.
```v
module main

struct Man {
	name      string
	age       int
	interests []string
}

fn main() {
	superman := Man{'Superman', 30, ['flying', 'fighting evil', 'being nice']}
	println(superman)
}
```
**Before**
```
Man {
    name: 'Superman'
    age: 30
    interests: 6487152
}
```
**Now**
```
Man {
    name: 'Superman'
    age: 30
    interests: ["flying", "fighting evil", "being nice"]
}
```
**Solution**
Add `array` `array_fixed` field process.