### PR TITLE
sokol: add missing `C` prefixes

### DIFF
--- a/examples/sokol/drawing.v
+++ b/examples/sokol/drawing.v
@@ -4,7 +4,7 @@ import sokol.gfx
 import sokol.sgl
 
 struct AppState {
-	pass_action sg_pass_action
+	pass_action C.sg_pass_action
 }
 
 const (
@@ -16,7 +16,7 @@ fn main() {
 		pass_action: gfx.create_clear_pass(0.1, 0.1, 0.1, 1.0)
 	}
 	title := 'Sokol Drawing Template'
-	desc := sapp_desc{
+	desc := C.sapp_desc{
 		user_data: state
 		init_userdata_cb: init
 		frame_userdata_cb: frame
@@ -27,7 +27,7 @@ fn main() {
 }
 
 fn init(user_data voidptr) {
-	desc := sg_desc{
+	desc := C.sg_desc{
 		mtl_device: sapp.metal_get_device()
 		mtl_renderpass_descriptor_cb: sapp.metal_get_renderpass_descriptor
 		mtl_drawable_cb: sapp.metal_get_drawable
@@ -37,7 +37,7 @@ fn init(user_data voidptr) {
 		d3d11_depth_stencil_view_cb: sapp.d3d11_get_depth_stencil_view
 	}
 	gfx.setup(&desc)
-	sgl_desc := sgl_desc_t{}
+	sgl_desc := C.sgl_desc_t{}
 	sgl.setup(&sgl_desc)
 }
 

--- a/vlib/sokol/gfx/gfx.v
+++ b/vlib/sokol/gfx/gfx.v
@@ -167,27 +167,27 @@ pub fn query_pixelformat(fmt PixelFormat) C.sg_pixelformat_info {
 /* get current state of a resource (INITIAL, ALLOC, VALID, FAILED, INVALID) */
 [inline]
 pub fn query_buffer_state(buf C.sg_buffer) C.sg_resource_state {
-	return sg_query_buffer_state(buf)
+	return C.sg_query_buffer_state(buf)
 }
 
 [inline]
 pub fn query_image_state(img C.sg_image) C.sg_resource_state {
-	return sg_query_image_state(img)
+	return C.sg_query_image_state(img)
 }
 
 [inline]
 pub fn query_shader_state(shd C.sg_shader) C.sg_resource_state {
-	return sg_query_shader_state(shd)
+	return C.sg_query_shader_state(shd)
 }
 
 [inline]
 pub fn query_pipeline_state(pip C.sg_pipeline) C.sg_resource_state {
-	return sg_query_pipeline_state(pip)
+	return C.sg_query_pipeline_state(pip)
 }
 
 [inline]
 pub fn query_pass_state(pass C.sg_pass) C.sg_resource_state {
-	return sg_query_pass_state(pass)
+	return C.sg_query_pass_state(pass)
 }
 
 // get runtime information about a resource

--- a/vlib/sokol/gfx/gfx_structs.v
+++ b/vlib/sokol/gfx/gfx_structs.v
@@ -46,50 +46,50 @@ pub struct C.sg_pipeline {
 pub:
     id u32
 }
-pub fn (p C.sg_pipeline) free() { sg_destroy_pipeline(p) }
+pub fn (p C.sg_pipeline) free() { C.sg_destroy_pipeline(p) }
 
 
 pub struct C.sg_bindings {
 pub mut:
     _start_canary u32
-    vertex_buffers [8]sg_buffer
+    vertex_buffers [8]C.sg_buffer
     vertex_buffer_offsets [8]int
-    index_buffer sg_buffer
+    index_buffer C.sg_buffer
     index_buffer_offset int
-    vs_images [8]sg_image
-    fs_images [8]sg_image
+    vs_images [8]C.sg_image
+    fs_images [8]C.sg_image
     _end_canary u32
 }
 
-pub fn (b mut sg_bindings) set_vert_image(index int, img C.sg_image) {
+pub fn (b mut C.sg_bindings) set_vert_image(index int, img C.sg_image) {
     b.vs_images[index] = img
 }
 
-pub fn (b mut sg_bindings) set_frag_image(index int, img C.sg_image) {
+pub fn (b mut C.sg_bindings) set_frag_image(index int, img C.sg_image) {
     b.fs_images[index] = img
 }
 
 pub fn (b &C.sg_bindings) update_vert_buffer(index int, data voidptr, element_size int, element_count int) {
-    sg_update_buffer(b.vertex_buffers[index], data, element_size * element_count)
+    C.sg_update_buffer(b.vertex_buffers[index], data, element_size * element_count)
 }
 
 pub fn (b &C.sg_bindings) append_vert_buffer(index int, data voidptr, element_size int, element_count int) int {
-    return sg_append_buffer(b.vertex_buffers[index], data, element_size * element_count)
+    return C.sg_append_buffer(b.vertex_buffers[index], data, element_size * element_count)
 }
 
 pub fn (b &C.sg_bindings) update_index_buffer(data voidptr, element_size int, element_count int) {
-    sg_update_buffer(b.index_buffer, data, element_size * element_count)
+    C.sg_update_buffer(b.index_buffer, data, element_size * element_count)
 }
 
 pub fn (b &C.sg_bindings) append_index_buffer(data voidptr, element_size int, element_count int) int {
-    return sg_append_buffer(b.index_buffer, data, element_size * element_count)
+    return C.sg_append_buffer(b.index_buffer, data, element_size * element_count)
 }
 
 
 pub struct C.sg_shader_desc {
 pub mut:
     _start_canary u32
-    attrs [16]sg_shader_attr_desc
+    attrs [16]C.sg_shader_attr_desc
     vs C.sg_shader_stage_desc
     fs C.sg_shader_stage_desc
     label byteptr
@@ -141,7 +141,7 @@ pub fn (desc mut C.sg_shader_desc) set_frag_uniform(block_index int, uniform_ind
 }
 
 pub fn (desc &C.sg_shader_desc) make_shader() C.sg_shader {
-    return sg_make_shader(desc)
+    return C.sg_make_shader(desc)
 }
 
 
@@ -158,8 +158,8 @@ pub mut:
     byte_code &byte
     byte_code_size int
     entry byteptr
-    uniform_blocks [4]sg_shader_uniform_block_desc
-    images [12]sg_shader_image_desc
+    uniform_blocks [4]C.sg_shader_uniform_block_desc
+    images [12]C.sg_shader_image_desc
 }
 
 pub fn (desc mut C.sg_shader_stage_desc) set_image(index int, name string) C.sg_shader_stage_desc {
@@ -172,7 +172,7 @@ pub fn (desc mut C.sg_shader_stage_desc) set_image(index int, name string) C.sg_
 pub struct C.sg_shader_uniform_block_desc {
 pub mut:
     size int
-    uniforms [16]sg_shader_uniform_desc
+    uniforms [16]C.sg_shader_uniform_desc
 }
 
 pub struct C.sg_shader_uniform_desc {
@@ -198,13 +198,13 @@ pub struct C.sg_shader {
 pub:
     id u32
 }
-pub fn (s C.sg_shader) free() { sg_destroy_shader(s) }
+pub fn (s C.sg_shader) free() { C.sg_destroy_shader(s) }
 
 
 pub struct C.sg_pass_desc {
 pub mut:
     _start_canary u32
-    color_attachments [4]sg_attachment_desc
+    color_attachments [4]C.sg_attachment_desc
     depth_stencil_attachment C.sg_attachment_desc
     label byteptr
     _end_canary u32
@@ -217,16 +217,16 @@ pub struct C.sg_pass_info {
 pub struct C.sg_pass_action {
 pub mut:
     _start_canary u32
-    colors [4]sg_color_attachment_action
-    depth sg_depth_attachment_action
-    stencil sg_stencil_attachment_action
+    colors [4]C.sg_color_attachment_action
+    depth C.sg_depth_attachment_action
+    stencil C.sg_stencil_attachment_action
     _end_canary u32
 }
 
 pub struct C.sg_pass {
     id u32
 }
-pub fn (p C.sg_pass) free() { sg_destroy_pass(p) }
+pub fn (p C.sg_pass) free() { C.sg_destroy_pass(p) }
 
 
 pub struct C.sg_buffer_desc {
@@ -251,7 +251,7 @@ pub struct C.sg_buffer_info {}
 pub struct C.sg_buffer {
     id u32
 }
-pub fn (b C.sg_buffer) free() { sg_destroy_buffer(b) }
+pub fn (b C.sg_buffer) free() { C.sg_destroy_buffer(b) }
 
 
 pub union DepthLayers {
@@ -309,12 +309,12 @@ pub struct C.sg_image {
 pub:
     id u32
 }
-pub fn (i C.sg_image) free() { sg_destroy_image(i) }
+pub fn (i C.sg_image) free() { C.sg_destroy_image(i) }
 
 
 pub struct C.sg_image_content {
 pub mut:
-    subimage [6][16]sg_subimage_content
+    subimage [6][16]C.sg_subimage_content
 }
 
 pub struct C.sg_subimage_content {
@@ -346,8 +346,8 @@ pub:
 
 pub struct C.sg_layout_desc {
 pub mut:
-    buffers [8]sg_buffer_layout_desc
-    attrs [16]sg_vertex_attr_desc
+    buffers [8]C.sg_buffer_layout_desc
+    attrs [16]C.sg_vertex_attr_desc
 }
 
 pub struct C.sg_buffer_layout_desc {

--- a/vlib/sokol/gfx/gfx_utils.v
+++ b/vlib/sokol/gfx/gfx_utils.v
@@ -1,12 +1,12 @@
 module gfx
 
 pub fn create_clear_pass(r, g, b, a f32) C.sg_pass_action {
-	mut color_action := sg_color_attachment_action {
+	mut color_action := C.sg_color_attachment_action {
 		action: C.SG_ACTION_CLEAR
 	}
 	color_action.set_color_values(r, g, b, a)
 
-	mut pass_action := sg_pass_action{}
+	mut pass_action := C.sg_pass_action{}
 	pass_action.colors[0] = color_action
 	return pass_action
 }

--- a/vlib/sokol/sapp/sapp_structs.v
+++ b/vlib/sokol/sapp/sapp_structs.v
@@ -50,7 +50,7 @@ pub:
     scroll_x f32
     scroll_y f32
     num_touches int
-    touches [8]sapp_touchpoint
+    touches [8]C.sapp_touchpoint
     window_width int
     window_height int
     framebuffer_width int


### PR DESCRIPTION
Still cannot be compiled, but now all C structures have the `C` prefix.