### PR TITLE
cgen: use `wWinMain` for Windows GUI applications

### DIFF
--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -16,10 +16,9 @@ fn (g mut Gen) gen_fn_decl(it ast.FnDecl) {
 	}
 	g.reset_tmp_count()
 	is_main := it.name == 'main'
-	is_gui_app := g.is_gui_app()
 	if is_main {
 		if g.pref.os == .windows {
-			if is_gui_app {
+			if g.is_gui_app() {
 				// GUI application
 				g.writeln('int WINAPI wWinMain(HINSTANCE instance, HINSTANCE prev_instance, LPWSTR cmd_line, int show_cmd')
 			} else {
@@ -82,7 +81,7 @@ fn (g mut Gen) gen_fn_decl(it ast.FnDecl) {
 		g.definitions.writeln(');')
 	}
 	if is_main {
-		if g.pref.os == .windows && is_gui_app {
+		if g.pref.os == .windows && g.is_gui_app() {
 			g.writeln('\ttypedef LPWSTR*(WINAPI *cmd_line_to_argv)(LPCWSTR, int*);')
 			g.writeln('\tHMODULE shell32_module = LoadLibrary(L"shell32.dll");')
 			g.writeln('\tcmd_line_to_argv CommandLineToArgvW = (cmd_line_to_argv)GetProcAddress(shell32_module, "CommandLineToArgvW");')

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -16,9 +16,16 @@ fn (g mut Gen) gen_fn_decl(it ast.FnDecl) {
 	}
 	g.reset_tmp_count()
 	is_main := it.name == 'main'
+	is_gui_app := g.is_gui_app()
 	if is_main {
 		if g.pref.os == .windows {
-			g.write('int wmain(int ___argc, wchar_t *___argv[], wchar_t *___envp[]')
+			if is_gui_app {
+				// GUI application
+				g.writeln('int WINAPI wWinMain(HINSTANCE instance, HINSTANCE prev_instance, LPWSTR cmd_line, int show_cmd')
+			} else {
+				// Console application
+				g.writeln('int wmain(int ___argc, wchar_t* ___argv[], wchar_t* ___envp[]')
+			}
 		} else {
 			g.write('int ${it.name}(int ___argc, char** ___argv')
 		}
@@ -75,6 +82,14 @@ fn (g mut Gen) gen_fn_decl(it ast.FnDecl) {
 		g.definitions.writeln(');')
 	}
 	if is_main {
+		if g.pref.os == .windows && is_gui_app {
+			g.writeln('\ttypedef LPWSTR*(WINAPI *cmd_line_to_argv)(LPCWSTR, int*);')
+			g.writeln('\tHMODULE shell32_module = LoadLibrary(L"shell32.dll");')
+			g.writeln('\tcmd_line_to_argv CommandLineToArgvW = (cmd_line_to_argv)GetProcAddress(shell32_module, "CommandLineToArgvW");')
+			g.writeln('\tint ___argc;')
+			g.writeln('\twchar_t** ___argv = CommandLineToArgvW(cmd_line, &___argc);')
+		}
+
 		g.writeln('\t_vinit();')
 		if g.is_importing_os() {
 			if g.autofree {
@@ -434,4 +449,15 @@ fn (g mut Gen) ref_or_deref_arg(arg ast.CallArg, expected_type table.Type) {
 		g.write('*/*d*/')
 	}
 	g.expr_with_cast(arg.expr, arg.typ, expected_type)
+}
+
+fn (g mut Gen) is_gui_app() bool {
+	$if windows {
+		for cf in g.table.cflags {
+			if cf.value == 'gdi32' {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Move changes from 3f0f8ba back. This way doesn't use imports to detect GUI though, but checks for `gdi32`.