### PR TITLE
Bug/fix correct underline wrong return type

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -169,15 +169,11 @@ mut:
 
 pub struct StructInit {
 pub:
-	pos            token.Position
-	_fields        []StructInitField
-	fields         []string
-	exprs          []Expr
-	is_short       bool
+	pos      token.Position
+	fields   []StructInitField
+	is_short bool
 mut:
-	typ            table.Type
-	expr_types     []table.Type
-	expected_types []table.Type
+	typ      table.Type
 }
 
 // import statement

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -157,11 +157,23 @@ pub:
 	field_names []string
 }
 
+pub struct StructInitField {
+pub:
+	name          string
+	expr          Expr
+	pos			  token.Position
+mut:
+	typ           table.Type
+	expected_type table.Type
+}
+
 pub struct StructInit {
 pub:
 	pos            token.Position
+	_fields        []StructInitField
 	fields         []string
 	exprs          []Expr
+	is_short       bool
 mut:
 	typ            table.Type
 	expr_types     []table.Type
@@ -720,6 +732,89 @@ pub fn expr_is_call(expr Expr) bool {
 		}
 		else {
 			false
+		}
+	}
+}
+
+fn (expr Expr) position() token.Position {
+	// all uncommented have to be implemented
+	match mut expr {
+		ArrayInit {
+			return it.pos
+		}
+		AsCast {
+			return it.pos
+		}
+		// ast.Ident { }
+		AssignExpr {
+			return it.pos
+		}
+		// ast.CastExpr { }
+		Assoc {
+			return it.pos
+		}
+		// ast.BoolLiteral { }
+		CallExpr {
+			return it.pos
+		}
+		// ast.CharLiteral { }
+		EnumVal {
+			return it.pos
+		}
+		// ast.FloatLiteral { }
+		IfExpr {
+			return it.pos
+		}
+		// ast.IfGuardExpr { }
+		IndexExpr {
+			return it.pos
+		}
+		InfixExpr {
+			left_pos := it.left.position()
+			right_pos := it.right.position()
+			if left_pos.pos == 0 || right_pos.pos == 0 {
+				return it.pos
+			}
+			return token.Position{
+				line_nr: it.pos.line_nr
+				pos: left_pos.pos
+				len: right_pos.pos - left_pos.pos + right_pos.len
+			}
+		}
+		IntegerLiteral {
+			return it.pos
+		}
+		MapInit {
+			return it.pos
+		}
+		MatchExpr {
+			return it.pos
+		}
+		PostfixExpr {
+			return it.pos
+		}
+		// ast.None { }
+		PrefixExpr {
+			return it.pos
+		}
+		// ast.ParExpr { }
+		SelectorExpr {
+			return it.pos
+		}
+		// ast.SizeOf { }
+		StringLiteral {
+			return it.pos
+		}
+		StringInterLiteral {
+			return it.pos
+		}
+		// ast.Type { }
+		StructInit {
+			return it.pos
+		}
+		// ast.TypeOf { }
+		else {
+			return token.Position{}
 		}
 	}
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -644,8 +644,12 @@ pub fn (c mut Checker) return_stmt(return_stmt mut ast.Return) {
 		if !c.table.check(got_typ, exp_typ) {
 			got_typ_sym := c.table.get_type_symbol(got_typ)
 			exp_typ_sym := c.table.get_type_symbol(exp_typ)
-			c.error('cannot use `$got_typ_sym.name` as type `$exp_typ_sym.name` in return argument',
-				return_stmt.pos)
+			pos := token.Position{
+				line_nr: return_stmt.pos.line_nr
+				pos: return_stmt.pos.pos + 7
+				len: return_stmt.pos.len - 7
+			}
+			c.error('cannot use `$got_typ_sym.name` as type `$exp_typ_sym.name` in return argument', pos)
 		}
 	}
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -127,7 +127,7 @@ pub fn (c mut Checker) struct_init(struct_init mut ast.StructInit) table.Type {
 				c.error('too many fields', struct_init.pos)
 			}
 			mut inited_fields := []string
-			for i, field in struct_init._fields {
+			for i, field in struct_init.fields {
 				mut info_field := table.Field{}
 				mut field_name := ''
 				if struct_init.is_short {
@@ -138,7 +138,7 @@ pub fn (c mut Checker) struct_init(struct_init mut ast.StructInit) table.Type {
 					}
 					info_field = info.fields[i]
 					field_name = info_field.name
-					struct_init._fields[i].name = field_name
+					struct_init.fields[i].name = field_name
 				} else {
 					field_name = field.name
 					mut exists := false
@@ -166,8 +166,8 @@ pub fn (c mut Checker) struct_init(struct_init mut ast.StructInit) table.Type {
 				if !c.table.check(expr_type, info_field.typ) {
 					c.error('cannot assign `$expr_type_sym.name` as `$field_type_sym.name` for field `$info_field.name`', field.pos)
 				}
-				struct_init._fields[i].typ = expr_type
-				struct_init._fields[i].expected_type = info_field.typ
+				struct_init.fields[i].typ = expr_type
+				struct_init.fields[i].expected_type = info_field.typ
 			}
 			// Check uninitialized refs
 			for field in info.fields {

--- a/vlib/v/checker/tests/inout/return_type.out
+++ b/vlib/v/checker/tests/inout/return_type.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/inout/return_type.v:2:9: error: cannot use `int` as type `bool` in return argument
+    1| fn test() bool {
+    2|     return 100
+                  ~~~
+    3| }
+    4|

--- a/vlib/v/checker/tests/inout/return_type.vv
+++ b/vlib/v/checker/tests/inout/return_type.vv
@@ -1,0 +1,5 @@
+fn test() bool {
+	return 100
+}
+
+fn main() {}

--- a/vlib/v/checker/tests/inout/short_struct_too_many.out
+++ b/vlib/v/checker/tests/inout/short_struct_too_many.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/inout/short_struct_too_many.v:6:7: error: too many fields
+    4|
+    5| fn main() {
+    6|     t := Test{true, false}
+                ~~~~~~~~~~~~~~~~~
+    7| }

--- a/vlib/v/checker/tests/inout/short_struct_too_many.vv
+++ b/vlib/v/checker/tests/inout/short_struct_too_many.vv
@@ -1,0 +1,7 @@
+struct Test {
+	foo bool
+}
+
+fn main() {
+	t := Test{true, false}
+}

--- a/vlib/v/checker/tests/inout/struct_unknown_field.out
+++ b/vlib/v/checker/tests/inout/struct_unknown_field.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/inout/struct_unknown_field.v:8:9: error: struct init: no such field `bar` for struct `Test`
+    6|     t := Test{
+    7|         foo: true
+    8|         bar: false
+               ^
+    9|     }
+   10| }

--- a/vlib/v/checker/tests/inout/struct_unknown_field.vv
+++ b/vlib/v/checker/tests/inout/struct_unknown_field.vv
@@ -1,0 +1,10 @@
+struct Test {
+	foo bool
+}
+
+fn main() {
+	t := Test{
+        foo: true
+        bar: false
+    }
+}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -695,15 +695,15 @@ fn (f mut Fmt) expr(node ast.Expr) {
 			if name == 'void' {
 				name = ''
 			}
-			if it.fields.len == 0 && it.exprs.len == 0 {
+			if it.fields.len == 0 {
 				// `Foo{}` on one line if there are no fields
 				f.write('$name{}')
 			} else if it.fields.len == 0 {
 				// `Foo{1,2,3}` (short syntax )
 				f.write('$name{')
-				for i, expr in it.exprs {
-					f.expr(expr)
-					if i < it.exprs.len - 1 {
+				for i, field in it.fields {
+					f.expr(field.expr)
+					if i < it.fields.len - 1 {
 						f.write(', ')
 					}
 				}
@@ -712,8 +712,8 @@ fn (f mut Fmt) expr(node ast.Expr) {
 				f.writeln('$name{')
 				f.indent++
 				for i, field in it.fields {
-					f.write('$field: ')
-					f.expr(it.exprs[i])
+					f.write('$field.name: ')
+					f.expr(field.expr)
 					f.writeln('')
 				}
 				f.indent--

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1900,22 +1900,22 @@ fn (var g Gen) struct_init(struct_init ast.StructInit) {
 	} else {
 		g.writeln('($styp){')
 	}
-	var fields := []string
+	// var fields := []string
 	var inited_fields := []string	// TODO this is done in checker, move to ast node
-	if struct_init.fields.len == 0 && struct_init.exprs.len > 0 {
+	/*if struct_init.fields.len == 0 && struct_init.exprs.len > 0 {
 		// Get fields for {a,b} short syntax. Fields array wasn't set in the parser.
 		for f in info.fields {
 			fields << f.name
 		}
 	} else {
 		fields = struct_init.fields
-	}
+	}*/
 	// User set fields
-	for i, field in fields {
-		field_name := c_name(field)
-		inited_fields << field
+	for i, field in struct_init._fields {
+		field_name := c_name(field.name)
+		inited_fields << field.name
 		g.write('\t.$field_name = ')
-		g.expr_with_cast(struct_init.exprs[i], struct_init.expr_types[i], struct_init.expected_types[i])
+		g.expr_with_cast(field.expr, field.typ, field.expected_type)
 		g.writeln(',')
 	}
 	// The rest of the fields are zeroed.

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1911,7 +1911,7 @@ fn (var g Gen) struct_init(struct_init ast.StructInit) {
 		fields = struct_init.fields
 	}*/
 	// User set fields
-	for i, field in struct_init._fields {
+	for i, field in struct_init.fields {
 		field_name := c_name(field.name)
 		inited_fields << field.name
 		g.write('\t.$field_name = ')

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -27,7 +27,7 @@ struct JsGen {
 	pref            &pref.Preferences
 	doc				&JsDoc
 	mut:
-	constants		strings.Builder // all global V constants 
+	constants		strings.Builder // all global V constants
 	file			ast.File
 	tmp_count		int
 	inside_ternary  bool
@@ -178,7 +178,7 @@ fn (g mut JsGen) to_js_typ(typ string) string {
 		}
 		'voidptr' {
 			styp = 'Object'
-		} 
+		}
 		'byteptr' {
 			styp = 'string'
 		}
@@ -196,7 +196,7 @@ fn (g mut JsGen) to_js_typ(typ string) string {
 		}
 	}
 	return styp
-} 
+}
 
 pub fn (g &JsGen) save() {}
 
@@ -385,12 +385,12 @@ fn (g mut JsGen) expr(node ast.Expr) {
 		}
 		ast.InfixExpr {
 			g.expr(it.left)
-			
+
 			mut op := it.op.str()
 			// in js == is non-strict & === is strict, always do strict
 			if op == '==' { op = '===' }
 			else if op == '!=' { op = '!==' }
-			
+
 			g.write(' $op ')
 			g.expr(it.right)
 		}
@@ -461,7 +461,7 @@ fn (g mut JsGen) gen_string_inter_literal(it ast.StringInterLiteral) {
 				.struct_ {
 					g.expr(expr)
 					if sym.has_method('str') {
-						g.write('.str()')					
+						g.write('.str()')
 					}
 				}
 				else {
@@ -543,7 +543,7 @@ fn (g mut JsGen) gen_assign_stmt(it ast.AssignStmt) {
 			val := it.right[i]
 			ident_var_info := ident.var_info()
 			mut styp := g.typ(ident_var_info.typ)
-		
+
 			match val {
 				ast.EnumVal {
 					// we want the type of the enum value not the enum
@@ -554,11 +554,11 @@ fn (g mut JsGen) gen_assign_stmt(it ast.AssignStmt) {
 					styp = ''
 				} else {}
 			}
-			
+
 			if !g.inside_loop && styp.len > 0 {
 				g.writeln(g.doc.gen_typ(styp, ident.name))
 			}
-			
+
 			if g.inside_loop || ident.is_mut {
 				g.write('let ')
 			} else {
@@ -726,7 +726,7 @@ fn (g mut JsGen) gen_method_decl(it ast.FnDecl) {
 		g.write(')();')
 	}
 	g.writeln('')
-	
+
 	g.fn_decl = 0
 }
 
@@ -835,7 +835,7 @@ fn (g mut JsGen) fn_args(args []table.Arg, is_variadic bool) {
 fn (g mut JsGen) gen_go_stmt(node ast.GoStmt) {
 	// x := node.call_expr as ast.CallEpxr // TODO
 	match node.call_expr {
-		ast.CallExpr { 
+		ast.CallExpr {
 			mut name := it.name
 			if it.is_method {
 				receiver_sym := g.table.get_type_symbol(it.receiver_type)
@@ -964,10 +964,10 @@ fn (g mut JsGen) gen_struct_init(it ast.StructInit) {
 	g.writeln('new ${type_sym.name}({')
 	g.inc_indent()
 	for i, field in it.fields {
-		g.write('$field: ')
-		g.expr(it.exprs[i])
+		g.write('$field.name: ')
+		g.expr(field.expr)
 		if i < it.fields.len - 1 {
-			g.write(', ')				
+			g.write(', ')
 		}
 		g.writeln('')
 	}
@@ -975,7 +975,7 @@ fn (g mut JsGen) gen_struct_init(it ast.StructInit) {
 	g.write('})')
 }
 
-fn (g mut JsGen) gen_ident(node ast.Ident) {	
+fn (g mut JsGen) gen_ident(node ast.Ident) {
 	if node.kind == .constant {
 		g.write('CONSTANTS.')
 	}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -570,6 +570,7 @@ pub fn (var p Parser) parse_ident(is_c, is_js bool) ast.Ident {
 }
 
 fn (var p Parser) struct_init(short_syntax bool) ast.StructInit {
+	first_pos := p.tok.position()
 	typ := if short_syntax { table.void_type } else { p.parse_type() }
 	p.expr_mod = ''
 	// sym := p.table.get_type_symbol(typ)
@@ -614,14 +615,18 @@ fn (var p Parser) struct_init(short_syntax bool) ast.StructInit {
 		}
 		p.check_comment()
 	}
-	pos := p.tok.position()
+	last_pos := p.tok.position()
 	if !short_syntax {
 		p.check(.rcbr)
 	}
 	node := ast.StructInit{
 		typ: typ
-		_fields: fields
-		pos: pos
+		fields: fields
+		pos: token.Position{
+			line_nr: first_pos.line_nr
+			pos: first_pos.pos
+			len: last_pos.pos - first_pos.pos + last_pos.len
+		}
 		is_short: is_short_syntax
 	}
 	return node

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1748,12 +1748,13 @@ fn (var p Parser) interface_decl() ast.InterfaceDecl {
 }
 
 fn (var p Parser) return_stmt() ast.Return {
+	first_pos := p.tok.position()
 	p.next()
 	// return expressions
 	var exprs := []ast.Expr
 	if p.tok.kind == .rcbr {
 		return ast.Return{
-			pos: p.tok.position()
+			pos: first_pos
 		}
 	}
 	for {
@@ -1765,11 +1766,15 @@ fn (var p Parser) return_stmt() ast.Return {
 			break
 		}
 	}
-	stmt := ast.Return{
+	last_pos := exprs.last().position()
+	return ast.Return{
 		exprs: exprs
-		pos: p.tok.position()
+		pos: token.Position{
+			line_nr: first_pos.line_nr
+			pos: first_pos.pos
+			len: last_pos.pos - first_pos.pos + last_pos.len
+		}
 	}
-	return stmt
 }
 
 // left hand side of `=` or `:=` in `a,b,c := 1,2,3`


### PR DESCRIPTION
```
vlib/v/checker/tests/inout/return_type.v:2:9: error: cannot use `int` as type `bool` in return argument
    1| fn test() bool {
    2|     return 100
                  ~~~
    3| }
    4|
```

merge after #4449 

i needed some code from the other branch