### PR TITLE
cgen: fix string_interpolation_struct_test.v error

### DIFF
--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -29,7 +29,6 @@ const (
 		'vlib/v/tests/pointers_test.v',
 		'vlib/v/tests/repl/repl_test.v',
 		'vlib/v/tests/string_interpolation_array_of_structs_test.v',
-		'vlib/v/tests/string_interpolation_struct_test.v',
 		'vlib/v/tests/string_interpolation_variadic_test.v',
 		'vlib/v/tests/type_test.v',
 		'vlib/v/tests/valgrind/valgrind_test.v', // ubuntu-musl only

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2973,7 +2973,7 @@ fn (g Gen) type_to_fmt(typ table.Type) string {
 	if sym.kind in [.struct_, .array, .array_fixed] {
 		return '%.*s'
 	} else if typ == table.string_type {
-		return '\\"%.*s\\"'
+		return "\'%.*s\'"
 	} else if typ == table.bool_type {
 		return '%.*s'
 	} else if typ in [table.f32_type, table.f64_type] {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2253,6 +2253,8 @@ fn (var g Gen) string_inter_literal(node ast.StringInterLiteral) {
 			g.write('%.*s')
 		} else if node.expr_types[i] in [table.f32_type, table.f64_type] {
 			g.write('%g')
+		} else if sym.kind == .struct_ && !sym.has_method('str') {
+			g.write('%.*s')
 		} else {
 			g.write('%d')
 		}
@@ -2324,6 +2326,16 @@ fn (var g Gen) string_inter_literal(node ast.StringInterLiteral) {
 				g.write('${styp}_str(')
 				g.expr(expr)
 				g.write(').str')
+			} else if sym.kind == .struct_ && !sym.has_method('str') {
+				styp := g.typ(node.expr_types[i])
+				g.gen_str_for_type(sym, styp)
+				g.write('${styp}_str(')
+				g.expr(expr)
+				g.write(',0)')
+				g.write('.len, ')
+				g.write('${styp}_str(')
+				g.expr(expr)
+				g.write(',0).str')
 			} else {
 				g.expr(expr)
 			}
@@ -2936,7 +2948,7 @@ fn (var g Gen) gen_str_for_struct(info table.Struct, styp string) {
 		g.definitions.write(', ')
 		for i, field in info.fields {
 			sym := g.table.get_type_symbol(field.typ)
-			if sym.kind == .struct_ {
+			if sym.kind in [.struct_, .array, .array_fixed] {
 				field_styp := g.typ(field.typ)
 				second_str_param := if sym.has_method('str') { '' } else { ', indent_count + 1' }
 				g.definitions.write('indents.len, indents.str, ${field_styp}_str(it.$field.name$second_str_param).len, ${field_styp}_str(it.$field.name$second_str_param).str')
@@ -2958,10 +2970,10 @@ fn (var g Gen) gen_str_for_struct(info table.Struct, styp string) {
 
 fn (g Gen) type_to_fmt(typ table.Type) string {
 	sym := g.table.get_type_symbol(typ)
-	if sym.kind == .struct_ {
+	if sym.kind in [.struct_, .array, .array_fixed] {
 		return '%.*s'
 	} else if typ == table.string_type {
-		return "\'%.*s\'"
+		return '\\"%.*s\\"'
 	} else if typ == table.bool_type {
 		return '%.*s'
 	} else if typ in [table.f32_type, table.f64_type] {

--- a/vlib/v/tests/string_interpolation_struct_test.v
+++ b/vlib/v/tests/string_interpolation_struct_test.v
@@ -11,7 +11,7 @@ fn test_default_struct_string_interpolation() {
 	superman := Man{'Superman', 30, ['flying', 'fighting evil', 'being nice']}
 	s := '$superman'
 	assert s.contains('Man {')
-	assert s.contains('name: "Superman"')
+	assert s.contains('name: \'Superman\'')
 	assert s.contains('age: 30')
 	assert s.contains('interests: [')
 	assert s.contains('"being nice"')

--- a/vlib/v/tests/string_interpolation_struct_test.v
+++ b/vlib/v/tests/string_interpolation_struct_test.v
@@ -11,7 +11,7 @@ fn test_default_struct_string_interpolation() {
 	superman := Man{'Superman', 30, ['flying', 'fighting evil', 'being nice']}
 	s := '$superman'
 	assert s.contains('Man {')
-	assert s.contains('name: Superman')
+	assert s.contains('name: "Superman"')
 	assert s.contains('age: 30')
 	assert s.contains('interests: [')
 	assert s.contains('"being nice"')


### PR DESCRIPTION
This PR fix string_interpolation_struct_test.v error.
```
...
OK    1156 ms [139/155] vlib\v\tests\string_interpolation_struct_test.v
...
------------------------------------------------------------------------------------------
   74719 ms <=== total time spent testing all fixed tests
                 ok, fail, skip, total =   125,     0,    30,   155
```
**Solution**
- Add `array` `array_fixed` fields process in struct.
- Add `struct` process in `string_inter_literal`.
- Remove `string_interpolation_struct_test.v` from skip list of test-fixed.