### PR TITLE
checker: fix underline return

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -644,11 +644,7 @@ pub fn (c mut Checker) return_stmt(return_stmt mut ast.Return) {
 		if !c.table.check(got_typ, exp_typ) {
 			got_typ_sym := c.table.get_type_symbol(got_typ)
 			exp_typ_sym := c.table.get_type_symbol(exp_typ)
-			pos := token.Position{
-				line_nr: return_stmt.pos.line_nr
-				pos: return_stmt.pos.pos + 7
-				len: return_stmt.pos.len - 7
-			}
+			pos := return_stmt.exprs[i].position()
 			c.error('cannot use `$got_typ_sym.name` as type `$exp_typ_sym.name` in return argument', pos)
 		}
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -644,8 +644,12 @@ pub fn (c mut Checker) return_stmt(return_stmt mut ast.Return) {
 		if !c.table.check(got_typ, exp_typ) {
 			got_typ_sym := c.table.get_type_symbol(got_typ)
 			exp_typ_sym := c.table.get_type_symbol(exp_typ)
-			c.error('cannot use `$got_typ_sym.name` as type `$exp_typ_sym.name` in return argument',
-				return_stmt.pos)
+			pos := token.Position{
+				line_nr: return_stmt.pos.line_nr
+				pos: return_stmt.pos.pos + 7
+				len: return_stmt.pos.len - 7
+			}
+			c.error('cannot use `$got_typ_sym.name` as type `$exp_typ_sym.name` in return argument', pos)
 		}
 	}
 }

--- a/vlib/v/checker/tests/inout/return_type.out
+++ b/vlib/v/checker/tests/inout/return_type.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/inout/return_type.v:2:9: error: cannot use `int` as type `bool` in return argument
+    1| fn test() bool {
+    2|     return 100
+                  ~~~
+    3| }
+    4|

--- a/vlib/v/checker/tests/inout/return_type.vv
+++ b/vlib/v/checker/tests/inout/return_type.vv
@@ -1,0 +1,5 @@
+fn test() bool {
+	return 100
+}
+
+fn main() {}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1748,12 +1748,13 @@ fn (var p Parser) interface_decl() ast.InterfaceDecl {
 }
 
 fn (var p Parser) return_stmt() ast.Return {
+	first_pos := p.tok.position()
 	p.next()
 	// return expressions
 	var exprs := []ast.Expr
 	if p.tok.kind == .rcbr {
 		return ast.Return{
-			pos: p.tok.position()
+			pos: first_pos
 		}
 	}
 	for {
@@ -1765,11 +1766,15 @@ fn (var p Parser) return_stmt() ast.Return {
 			break
 		}
 	}
-	stmt := ast.Return{
+	last_pos := exprs.last().position()
+	return ast.Return{
 		exprs: exprs
-		pos: p.tok.position()
+		pos: token.Position{
+			line_nr: first_pos.line_nr
+			pos: first_pos.pos
+			len: last_pos.pos - first_pos.pos + last_pos.len
+		}
 	}
-	return stmt
 }
 
 // left hand side of `=` or `:=` in `a,b,c := 1,2,3`


### PR DESCRIPTION
```
vlib/v/checker/tests/inout/return_type.v:2:9: error: cannot use `int` as type `bool` in return argument
    1| fn test() bool {
    2|     return 100
                  ~~~
    3| }
    4|
```
replaces #4450 