### PR TITLE
cgen: fix string_interpolation_array_of_structs_test.v error

### DIFF
--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -28,7 +28,6 @@ const (
 		'vlib/v/tests/option_test.v',
 		'vlib/v/tests/pointers_test.v',
 		'vlib/v/tests/repl/repl_test.v',
-		'vlib/v/tests/string_interpolation_array_of_structs_test.v',
 		'vlib/v/tests/string_interpolation_variadic_test.v',
 		'vlib/v/tests/type_test.v',
 		'vlib/v/tests/valgrind/valgrind_test.v', // ubuntu-musl only

--- a/vlib/v/tests/string_interpolation_array_of_structs_test.v
+++ b/vlib/v/tests/string_interpolation_array_of_structs_test.v
@@ -21,11 +21,11 @@ fn test_default_struct_array_of_structs_interpolation() {
 	]
 	s := '$people' // the compiler should generate code for both a) and b)
 	assert s.contains('Man {')
-	assert s.contains('name: Superman')
+	assert s.contains("name: 'Superman'")
 	assert s.contains('age: 30')
 	assert s.contains('"being nice"')
 	assert s.contains('}, Man {')
-	assert s.contains('name: Bilbo Baggins')
+	assert s.contains("name: 'Bilbo Baggins'")
 	assert s.contains('age: 111')
 	assert s.contains('interests: ["exploring", "hiding"]')
 	assert s.contains('}]')


### PR DESCRIPTION
This PR fix string_interpolation_array_of_structs_test.v error.
```v
OK    1297 ms [138/155] vlib\v\tests\string_interpolation_array_of_structs_test.v
OK    1281 ms [139/155] vlib\v\tests\string_interpolation_struct_test.v
------------------------------------------------------------------------------------------
   80344 ms <=== total time spent testing all fixed tests
                 ok, fail, skip, total =   126,     0,    29,   155
```
**Solution**
- Add `gen_str_for_array()` to process array to string.
- Modify related called.
- Remove string_interpolation_array_of_structs_test.v from skip list.