### PR TITLE
vtest: remove `pub` before main

### DIFF
--- a/cmd/tools/vtest.v
+++ b/cmd/tools/vtest.v
@@ -1,12 +1,10 @@
 module main
 
-import (
-	os
-	os.cmdline
-	testing
-)
+import os
+import os.cmdline
+import testing
 
-pub fn main() {
+fn main() {
 	args := os.args
 	if args.last() == 'test' {
 		println('Usage:')

--- a/examples/database/mysql.v
+++ b/examples/database/mysql.v
@@ -1,6 +1,6 @@
 // import mysql
 
-// pub fn main() {
+// fn main() {
 // 	conn := mysql.connect('localhost', 'root', '', 'mysql')
 // 	res := conn.query('show tables')
 // 	for row in res.rows() {

--- a/examples/pico/pico.v
+++ b/examples/pico/pico.v
@@ -36,6 +36,6 @@ pub fn callback(req picohttpparser.Request, res mut picohttpparser.Response) {
 	}
 }
 
-pub fn main() {
+fn main() {
 	picoev.new(8088, &callback).serve()
 }


### PR DESCRIPTION
Remove `pub` before `fn main` everywhere in tools and examples.
Fixes compiling vtest.