### PR TITLE
compiler: rename is_so to is_shared

### DIFF
--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -123,8 +123,8 @@ fn parse_args(args []string) (&pref.Preferences, string) {
 			'-v' {	res.is_verbose = true	}
 			'-cg' {	res.is_debug = true	}
 			'-live' { res.is_live = true }
-			'-solive' {	res.is_solive = true res.is_so = true }
-			'-shared' { res.is_so = true }
+			'-sharedlive' {	res.is_live = true res.is_shared = true }
+			'-shared' { res.is_shared = true }
 			'-autofree' {	res.autofree = true	}
 			'-compress' {	res.compress = true	}
 			'-freestanding' {	res.is_bare = true	}

--- a/vlib/v/builder/c.v
+++ b/vlib/v/builder/c.v
@@ -69,7 +69,7 @@ pub fn (b mut Builder) compile_c() {
 		println(files)
 	}
 	mut out_name_c := get_vtmp_filename(b.pref.out_name, '.tmp.c')
-	if b.pref.is_so {
+	if b.pref.is_shared {
 		out_name_c = get_vtmp_filename(b.pref.out_name, '.tmp.so.c')
 	}
 	b.build_c(files, out_name_c)

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -125,7 +125,7 @@ fn (v mut Builder) cc() {
 		}
 	}
 
-	if !v.pref.is_so
+	if !v.pref.is_shared
 		&& v.pref.build_mode != .build_module
 		&& os.user_os() == 'windows'
 		&& !v.pref.out_name.ends_with('.exe')
@@ -135,7 +135,7 @@ fn (v mut Builder) cc() {
 
 	// linux_host := os.user_os() == 'linux'
 	v.log('cc() isprod=$v.pref.is_prod outname=$v.pref.out_name')
-	if v.pref.is_so {
+	if v.pref.is_shared {
 		a << '-shared -fPIC ' // -Wl,-z,defs'
 		v.pref.out_name += '.so'
 	}
@@ -209,8 +209,13 @@ fn (v mut Builder) cc() {
 	if v.pref.ccompiler != 'msvc' && v.pref.os != .freebsd {
 		a << '-Werror=implicit-function-declaration'
 	}
-	for f in v.generate_hotcode_reloading_compiler_flags() {
-		a << f
+	if v.pref.is_shared || v.pref.is_live {
+		if v.pref.os == .linux || os.user_os() == 'linux' {
+			a << '-rdynamic'
+		}
+		if v.pref.os == .mac || os.user_os() == 'mac' {
+			a << '-flat_namespace'
+		}
 	}
 	mut libs := '' // builtin.o os.o http.o etc
 	if v.pref.build_mode == .build_module {

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -160,7 +160,7 @@ pub fn (v Builder) get_user_files() []string {
 	if v.pref.is_live {
 		user_files << os.join_path(preludes_path, 'live_main.v')
 	}
-	if v.pref.is_solive {
+	if v.pref.is_live && v.pref.is_shared {
 		user_files << os.join_path(preludes_path, 'live_shared.v')
 	}
 	if v.pref.is_test {

--- a/vlib/v/builder/live.v
+++ b/vlib/v/builder/live.v
@@ -5,20 +5,6 @@ import (
 	time
 )
 
-fn (v &Builder) generate_hotcode_reloading_compiler_flags() []string {
-	mut a := []string
-	if v.pref.is_live || v.pref.is_so {
-		// See 'man dlopen', and test running a GUI program compiled with -live
-		if v.pref.os == .linux || os.user_os() == 'linux' {
-			a << '-rdynamic'
-		}
-		if v.pref.os == .mac || os.user_os() == 'mac' {
-			a << '-flat_namespace'
-		}
-	}
-	return a
-}
-
 fn (v &Builder) generate_hotcode_reloading_declarations() {
 	/*
 	QTODO

--- a/vlib/v/builder/msvc.v
+++ b/vlib/v/builder/msvc.v
@@ -208,7 +208,7 @@ pub fn (v mut Builder) cc_msvc() {
 		a << '/Zi'
 		a << '/MDd'
 	}
-	if v.pref.is_so {
+	if v.pref.is_shared {
 		if !v.pref.out_name.ends_with('.dll') {
 			v.pref.out_name += '.dll'
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -78,7 +78,7 @@ pub fn (c mut Checker) check_files(ast_files []ast.File) {
 	if c.pref.build_mode == .build_module || c.pref.is_test {
 		return
 	}
-	if c.pref.is_so {
+	if c.pref.is_shared {
 		// shared libs do not need to have a main
 		return
 	}

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -29,8 +29,7 @@ pub mut:
 	is_test             bool // `v test string_test.v`
 	is_script           bool // single file mode (`v program.v`), main function can be skipped
 	is_live             bool // main program that contains live/hot code
-	is_solive           bool // a shared library, that will be used in a -live main program
-	is_so               bool // an ordinary shared library, -shared, no matter if it is live or not
+	is_shared               bool // an ordinary shared library, -shared, no matter if it is live or not
 	is_prof             bool // benchmark every function
 	translated          bool // `v translate doom.v` are we running V code translated from C? allow globals, ++ expressions, etc
 	is_prod             bool // use "-O2"


### PR DESCRIPTION
Reason:
- improves consistency because on shared libraries are dll's
- `-solive` can be accomplished by `-live -shared`, therefore uneccessay
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
