### PR TITLE
checker: fix type mismatch of `in` array (fix #4483)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -294,6 +294,12 @@ pub fn (c mut Checker) infix_expr(infix_expr mut ast.InfixExpr) table.Type {
 		if !(right.kind in [.array, .map, .string]) {
 			c.error('`in` can only be used with an array/map/string.', infix_expr.pos)
 		}
+		if right.kind == .array {
+			right_sym := c.table.get_type_symbol(right.array_info().elem_type)
+			if left.kind != .alias && left.kind != right_sym.kind {
+				c.error('the data type on the left of `in` does not match the array item type.', infix_expr.pos)
+			}
+		}
 		return table.bool_type
 	}
 	if !c.table.check(right_type, left_type) {

--- a/vlib/v/checker/tests/inout/in_array_mismatch_type.out
+++ b/vlib/v/checker/tests/inout/in_array_mismatch_type.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/inout/in_array_mismatch_type.v:2:7: error: the data type on the left of `in` does not match the array item type.
+    1| fn main() {
+    2|     if 1 in ['1', '2'] {
+                ~~
+    3|         println('ok')
+    4|     }

--- a/vlib/v/checker/tests/inout/in_array_mismatch_type.vv
+++ b/vlib/v/checker/tests/inout/in_array_mismatch_type.vv
@@ -1,0 +1,5 @@
+fn main() {
+	if 1 in ['1', '2'] {
+		println('ok')
+	}
+}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -249,12 +249,12 @@ pub fn (var g Gen) write_typedef_types() {
 				info := typ.info as table.FnType
 				func := info.func
 				if !info.has_decl {
-					fn_name := if func.is_c { 
-						func.name.replace('.', '__') 
+					fn_name := if func.is_c {
+						func.name.replace('.', '__')
 					} else if info.is_anon {
 						typ.name
-					} else { 
-						c_name(func.name) 
+					} else {
+						c_name(func.name)
 					}
 					g.definitions.write('typedef ${g.typ(func.return_type)} (*$fn_name)(')
 					for i, arg in func.args {


### PR DESCRIPTION
This PR fix type mismatch of `in` array (fix #4483).

```v
.\tt1.v:4:9: error: the data type on the left of `in` does not match the array item type.
    2|
    3| fn main() {
    4|     a := 1 in ['1', '2']
                  ~~
    5|     println(a)
    6| }
```