### PR TITLE
checker: fix for in range type mismatch (fix #4484)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1054,13 +1054,13 @@ fn (c mut Checker) stmt(node ast.Stmt) {
 			if it.is_range {
 				high_type := c.expr(it.high)
 				if typ in table.integer_type_idxs && high_type !in table.integer_type_idxs {
-					c.error('range type is not match.', it.cond.position())
+					c.error('range type do not match', it.cond.position())
 				} else if typ in table.float_type_idxs || high_type in table.float_type_idxs {
-					c.error('range type can not be float.', it.cond.position())
+					c.error('range type can not be float', it.cond.position())
 				} else if typ == table.bool_type_idx || high_type == table.bool_type_idx {
-					c.error('range type can not be bool.', it.cond.position())
+					c.error('range type can not be bool', it.cond.position())
 				} else if typ == table.string_type_idx || high_type == table.string_type_idx {
-					c.error('range type can not be string.', it.cond.position())
+					c.error('range type can not be string', it.cond.position())
 				}
 				c.expr(it.high)
 			} else {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1052,6 +1052,16 @@ fn (c mut Checker) stmt(node ast.Stmt) {
 			c.in_for_count++
 			typ := c.expr(it.cond)
 			if it.is_range {
+				high_type := c.expr(it.high)
+				if typ in table.integer_type_idxs && high_type !in table.integer_type_idxs {
+					c.error('range type is not match.', it.cond.position())
+				} else if typ in table.float_type_idxs || high_type in table.float_type_idxs {
+					c.error('range type can not be float.', it.cond.position())
+				} else if typ == table.bool_type_idx || high_type == table.bool_type_idx {
+					c.error('range type can not be bool.', it.cond.position())
+				} else if typ == table.string_type_idx || high_type == table.string_type_idx {
+					c.error('range type can not be string.', it.cond.position())
+				}
 				c.expr(it.high)
 			} else {
 				mut scope := c.file.scope.innermost(it.pos.pos)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1054,7 +1054,7 @@ fn (c mut Checker) stmt(node ast.Stmt) {
 			if it.is_range {
 				high_type := c.expr(it.high)
 				if typ in table.integer_type_idxs && high_type !in table.integer_type_idxs {
-					c.error('range type do not match', it.cond.position())
+					c.error('range types do not match', it.cond.position())
 				} else if typ in table.float_type_idxs || high_type in table.float_type_idxs {
 					c.error('range type can not be float', it.cond.position())
 				} else if typ == table.bool_type_idx || high_type == table.bool_type_idx {

--- a/vlib/v/checker/tests/inout/for_in_range_not_match_type.out
+++ b/vlib/v/checker/tests/inout/for_in_range_not_match_type.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/inout/for_in_range_not_match_type.v:2:11: error: range type do not match
+vlib/v/checker/tests/inout/for_in_range_not_match_type.v:2:11: error: range types do not match
     1| fn main() {
     2|     for i in 10..10.5 {
                     ~~

--- a/vlib/v/checker/tests/inout/for_in_range_not_match_type.out
+++ b/vlib/v/checker/tests/inout/for_in_range_not_match_type.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/inout/for_in_range_not_match_type.v:2:11: error: range type is not match.
+vlib/v/checker/tests/inout/for_in_range_not_match_type.v:2:11: error: range type do not match
     1| fn main() {
     2|     for i in 10..10.5 {
                     ~~

--- a/vlib/v/checker/tests/inout/for_in_range_not_match_type.out
+++ b/vlib/v/checker/tests/inout/for_in_range_not_match_type.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/inout/for_in_range_no_match_type.v:2:11: error: range type is not match.
+vlib/v/checker/tests/inout/for_in_range_not_match_type.v:2:11: error: range type is not match.
     1| fn main() {
     2|     for i in 10..10.5 {
                     ~~

--- a/vlib/v/checker/tests/inout/for_in_range_not_match_type.out
+++ b/vlib/v/checker/tests/inout/for_in_range_not_match_type.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/inout/for_in_range_no_match_type.v:2:11: error: range type is not match.
+    1| fn main() {
+    2|     for i in 10..10.5 {
+                    ~~
+    3|         println(i)
+    4|     }

--- a/vlib/v/checker/tests/inout/for_in_range_not_match_type.vv
+++ b/vlib/v/checker/tests/inout/for_in_range_not_match_type.vv
@@ -1,0 +1,5 @@
+fn main() {
+	for i in 10..10.5 {
+		println(i)
+	}
+}

--- a/vlib/v/checker/tests/inout/for_in_range_string_type.out
+++ b/vlib/v/checker/tests/inout/for_in_range_string_type.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/inout/for_in_range_string_type.v:2:11: error: range type can not be string.
+vlib/v/checker/tests/inout/for_in_range_string_type.v:2:11: error: range type can not be string
     1| fn main() {
     2|     for i in 'a'..'b' {
                     ~~~

--- a/vlib/v/checker/tests/inout/for_in_range_string_type.out
+++ b/vlib/v/checker/tests/inout/for_in_range_string_type.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/inout/for_in_range_string_type.v:2:11: error: range type can not be string.
+    1| fn main() {
+    2|     for i in 'a'..'b' {
+                    ~~~
+    3|         println(i)
+    4|     }

--- a/vlib/v/checker/tests/inout/for_in_range_string_type.vv
+++ b/vlib/v/checker/tests/inout/for_in_range_string_type.vv
@@ -1,0 +1,5 @@
+fn main() {
+	for i in 'a'..'b' {
+		println(i)
+	}
+}


### PR DESCRIPTION
This PR fix for in range type mismatch (fix #4484).

```v
D:\test\v\tt1>v run .
.\tt1.v:4:11: error: range type is not match. 
    2| 
    3| fn main() {
    4|     for i in 10..10.5 { println(i) }
                    ~~
    5| }
```

```v
D:\test\v\tt1>v run .
.\tt1.v:5:11: error: range type can not be string.
    3| fn main() {
    4|     //for i in 10..10.5 { println(i) }
    5|     for i in 'a'..'b' { println(i) }
                    ~~~
    6| }
```