### PR TITLE
makefile: show v version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ ifdef V_ALWAYS_CLEAN_TMP
 	$(MAKE) clean_tmp
 endif
 	@echo "V has been successfully built"
+	@v -version
 
 clean: clean_tmp
 	git clean -xf

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ ifdef V_ALWAYS_CLEAN_TMP
 	$(MAKE) clean_tmp
 endif
 	@echo "V has been successfully built"
-	@v -version
+	@./v -version
 
 clean: clean_tmp
 	git clean -xf


### PR DESCRIPTION
This PR increase the display version after compilation is successful.

```
yuyi@yuyi-PC:~/v$ make
cd /tmp/vc && git clean -xf && git pull --quiet
cd /var/tmp/tcc && git clean -xf && git pull --quiet
cc  -std=gnu11 -w -o v /tmp/vc/v.c  -lm
./v self
V self compiling...
warning: import cycle detected between the following modules: 

 * v.table -> v.ast
 * v.ast -> v.table
make modules
make[1]: 进入目录“/home/yuyi/v”
#./v build module vlib/builtin > /dev/null
#./v build module vlib/strings > /dev/null
#./v build module vlib/strconv > /dev/null
make[1]: 离开目录“/home/yuyi/v”
V has been successfully built
V 0.1.26 717e26b.dc81997
```