### PR TITLE
builtin: improve backtrace

### DIFF
--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -21,26 +21,6 @@ fn on_panic(f fn(int)int) {
 }
 */
 
-pub fn print_backtrace_skipping_top_frames(skipframes int) {
-	$if windows {
-		$if msvc {
-			if print_backtrace_skipping_top_frames_msvc(skipframes) {
-				return
-			}
-		}
-		$if mingw {
-			if print_backtrace_skipping_top_frames_mingw(skipframes) {
-				return
-			}
-		}
-	} $else {
-		if print_backtrace_skipping_top_frames_nix(skipframes) {
-			return
-		}
-	}
-	println('print_backtrace_skipping_top_frames is not implemented on this platform for now...\n')
-}
-
 pub fn print_backtrace() {
 	// at the time of backtrace_symbols_fd call, the C stack would look something like this:
 	// 1 frame for print_backtrace_skipping_top_frames

--- a/vlib/builtin/builtin_nix.c.v
+++ b/vlib/builtin/builtin_nix.c.v
@@ -38,17 +38,7 @@ pub fn println(s string) {
 	C.printf('%.*s\n', s.len, s.str)
 }
 
-fn print_backtrace_skipping_top_frames_msvc(skipframes int) bool {
-	println('not implemented, see builtin_windows.v')
-	return false
-}
-
-fn print_backtrace_skipping_top_frames_mingw(skipframes int) bool {
-	println('not implemented, see builtin_windows.v')
-	return false
-}
-
-fn print_backtrace_skipping_top_frames_nix(xskipframes int) bool {
+fn print_backtrace_skipping_top_frames(xskipframes int) bool {
 	skipframes := xskipframes + 2
 	$if macos {
 		return print_backtrace_skipping_top_frames_mac(skipframes)
@@ -65,6 +55,7 @@ fn print_backtrace_skipping_top_frames_nix(xskipframes int) bool {
 	$if openbsd {
 		return print_backtrace_skipping_top_frames_freebsd(skipframes)
 	}
+	println('print_backtrace_skipping_top_frames is not implemented')
 	return false
 }
 


### PR DESCRIPTION
This change is mostly for Windows.

## Changelog

- Improved backtrace on Windows
Print a file name instead of pointer to a char array.
Removed pointer arithmetic and temp hack.
- Simplified `print_backtrace_skipping_top_frames` function
This function now is plaform-dependend and is implemented for each platform in respective files.

Backtrace on Windows (before)
```
$ vself && vrun test4.v
V panic: aaa
7 : eprintln                    -615023288:3484
6 : wmain                       -615023288:6484
5 : invoke_main                 -615023288:91
4 : __scrt_common_main_seh      -615023288:288
3 : __scrt_common_main          -615023288:331
2 : wmainCRTStartup             -615023288:17
1 : BaseThreadInitThunk         ?? : address= 1590685760
0 : RtlUserThreadStart          ?? : address= 1590685760
```

Backtrace on Windows (after)
```
$ vself && vrun test4.v
V panic: aaa
7 : v_panic                    C:\Users\esprit\AppData\Local\Temp\v\test4.tmp.c:3453
6 : wmain                      C:\Users\esprit\AppData\Local\Temp\v\test4.tmp.c:6443
5 : invoke_main                d:\agent\_work\5\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:91
4 : __scrt_common_main_seh     d:\agent\_work\5\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
3 : __scrt_common_main         d:\agent\_work\5\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:331
2 : wmainCRTStartup            d:\agent\_work\5\s\src\vctools\crt\vcstartup\src\startup\exe_wmain.cpp:17
1 : BaseThreadInitThunk        ?? : address = 0x1dd8f248
0 : RtlUserThreadStart         ?? : address = 0x1dd8f248
```