### PR TITLE
csv: fix missing last column

### DIFF
--- a/vlib/encoding/csv/csv_test.v
+++ b/vlib/encoding/csv/csv_test.v
@@ -1,7 +1,7 @@
 import encoding.csv
 
 fn test_encoding_csv_reader() {
-	data := 'name,email,phone,other\njoe,joe@blow.com,0400000000,test\nsam,sam@likesham.com,0433000000,"test quoted field"\n#chris,chris@nomail.com,94444444,"commented row"\nmike,mike@mikesbikes.com,98888888,"bike store"\n'
+	data := 'name,email,phone,other\njoe,joe@blow.com,0400000000,test\nsam,sam@likesham.com,0433000000,"test quoted field"\n#chris,chris@nomail.com,94444444,"commented row"\n'
 	mut csv_reader := csv.new_reader(data)
 
 	mut row_count := 0
@@ -12,21 +12,26 @@ fn test_encoding_csv_reader() {
 		row_count++
 		if row_count== 1 {
 			assert row[0] == 'name'
+			assert row[1] == 'email'
+			assert row[2] == 'phone'
+			assert row[3] == 'other'
 		}
 		if row_count == 2 {
 			assert row[0] == 'joe'
+			assert row[1] == 'joe@blow.com'
+			assert row[2] == '0400000000'
+			assert row[3] == 'test'
 		}
 		if row_count == 3 {
 			assert row[0] == 'sam'
+			assert row[1] == 'sam@likesham.com'
+			assert row[2] == '0433000000'
 			// quoted field
 			assert row[3] == 'test quoted field'
 		}
-		if row_count == 4 {
-			assert row[0] == 'mike'
-		}
 	}
 
-	assert row_count == 4
+	assert row_count == 3
 }
 
 fn test_encoding_csv_writer() {

--- a/vlib/encoding/csv/reader.v
+++ b/vlib/encoding/csv/reader.v
@@ -115,6 +115,7 @@ fn (r mut Reader) read_record() ?[]string {
 			// QTODO i = ...
 			j := line.index(r.delimiter.str()) or {
 				// last
+				fields << line[..line.len]
 				break
 			}
 			i = j


### PR DESCRIPTION
Changes:
- Add insert for final elment of csv row
- Expand CSV reader tests to cover all logic

I was doing some benchmarking with the csv module when I noticed some odd behaviour.  It turns out, the reader function isn't inserting the final column in the unquoted path.  The test only had a case for the final column under the quoted condition so it was never caught!

I padded out the test cases to cover more behaviour, and trimmed off the last line since the point is pretty clear then (Sorry to Mike if that's a real person).

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
