### PR TITLE
Makefile: simplify makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,6 @@ GITFASTCLONE := git clone --depth 1 --quiet
 
 #### Platform detections and overrides:
 _SYS := $(shell uname 2>/dev/null || echo Unknown)
-_SYS := $(patsubst MSYS%,MSYS,$(_SYS))
-_SYS := $(patsubst MINGW%,MinGW,$(_SYS))
-
-ifneq ($(filter $(_SYS),MSYS MinGW),)
-WIN32 := 1
-endif
 
 ifeq ($(_SYS),Linux)
 LINUX := 1
@@ -38,25 +32,13 @@ undefine LINUX
 endif
 #####
 
-ifdef WIN32
-TCCREPO := https://github.com/vlang/tccbin_win
-VCFILE := v_win.c
-endif
-
 all: latest_vc latest_tcc
-ifdef WIN32
-	$(CC) $(CFLAGS) -std=c99 -municode -w -o v.exe $(TMPVC)/$(VCFILE) $(LDFLAGS)
-	./v.exe self
-else
 	$(CC) $(CFLAGS) -std=gnu11 -w -o v $(TMPVC)/$(VCFILE) $(LDFLAGS) -lm
 ifdef ANDROID
 	chmod 755 v
 endif
-	./v self
-ifndef ANDROID
-	$(MAKE) modules
-endif
-endif
+	@./v self
+
 ifdef V_ALWAYS_CLEAN_TMP
 	$(MAKE) clean_tmp
 endif
@@ -64,27 +46,30 @@ endif
 	@./v -version
 
 clean: clean_tmp
-	git clean -xf
+	@git clean -xf
 
 clean_tmp:
-	rm -rf $(TMPTCC)
-	rm -rf $(TMPVC)
+	@rm -rf $(TMPTCC)
+	@rm -rf $(TMPVC)
 
 latest_vc: $(TMPVC)/.git/config
-	cd $(TMPVC) && $(GITCLEANPULL)
+	@echo "Building V"
+	@git version
+	@echo "Downloading v.c..."
+	@cd $(TMPVC) $(GITCLEANPULL)
 
 fresh_vc:
-	rm -rf $(TMPVC)
+	@rm -rf $(TMPVC)
 	$(GITFASTCLONE) $(VCREPO) $(TMPVC)
 
 latest_tcc: $(TMPTCC)/.git/config
 ifndef ANDROID
-	cd $(TMPTCC) && $(GITCLEANPULL)
+	@cd $(TMPTCC) && $(GITCLEANPULL)
 endif
 
 fresh_tcc:
 ifndef ANDROID
-	rm -rf $(TMPTCC)
+	@rm -rf $(TMPTCC)
 	$(GITFASTCLONE) $(TCCREPO) $(TMPTCC)
 endif
 
@@ -99,11 +84,3 @@ selfcompile:
 
 selfcompile-static:
 	./v -keepc -cg -cflags '--static' -o v-static cmd/v
-
-modules: module_builtin module_strings module_strconv
-module_builtin:
-	#./v build module vlib/builtin > /dev/null
-module_strings:
-	#./v build module vlib/strings > /dev/null
-module_strconv:
-	#./v build module vlib/strconv > /dev/null


### PR DESCRIPTION
This PR simplify makefile.
- Remove Windows compile process.
- Remove make modules.
- Show more process information.

```v
yuyi@yuyi-PC:~/v$ make
Building V
git version 2.20.1
Downloading v.c...
cc  -std=gnu11 -w -o v /tmp/vc/v.c  -lm
V self compiling...
warning: import cycle detected between the following modules: 

 * v.table -> v.ast
 * v.ast -> v.table
V has been successfully built
V 0.1.26 be40de3.ee2e83f
```