### PR TITLE
flag: fix flag_test.v

### DIFF
--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -11,7 +11,6 @@ const (
 		'vlib/crypto/rc4/rc4_test.v',
 		'vlib/encoding/utf8/utf8_util_test.v',
 		'vlib/eventbus/eventbus_test.v',
-		'vlib/flag/flag_test.v',
 		'vlib/json/json_test.v',
 		'vlib/net/ftp/ftp_test.v',
 		'vlib/net/http/http_httpbin_test.v',

--- a/vlib/flag/flag.v
+++ b/vlib/flag/flag.v
@@ -291,25 +291,25 @@ pub fn (fs mut FlagParser) int(name string, abbr byte, idefault int, usage strin
 
 // float_multi returns all instances of values associated with the flags provided
 // In the case that none were found, it returns an empty array.
-pub fn (fs mut FlagParser) float_multi(name string, abbr byte, usage string) []f32 {
+pub fn (fs mut FlagParser) float_multi(name string, abbr byte, usage string) []f64 {
 	fs.add_flag(name, abbr, usage, '<multiple floats>')
 	parsed := fs.parse_value(name, abbr)
-	mut value := []f32
+	mut value := []f64
 	for val in parsed {
-		value << val.f32()
+		value << val.f64()
 	}
 	return value
 }
 
 // float_opt returns an optional that returns the value associated with the flag.
 // In the situation that the flag was not provided, it returns null.
-pub fn (fs mut FlagParser) float_opt(name string, abbr byte, usage string) ?f32 {
+pub fn (fs mut FlagParser) float_opt(name string, abbr byte, usage string) ?f64 {
 	fs.add_flag(name, abbr, usage, '<float>')
 	parsed := fs.parse_value(name, abbr)
 	if parsed.len == 0 {
 		return error("parameter '$name' not provided")
 	}
-	return parsed[0].f32()
+	return parsed[0].f64()
 }
 
 // defining and parsing a float flag
@@ -319,7 +319,7 @@ pub fn (fs mut FlagParser) float_opt(name string, abbr byte, usage string) ?f32 
 //      the default value is returned
 // version with abbr
 //TODO error handling for invalid string to float conversion
-pub fn (fs mut FlagParser) float(name string, abbr byte, fdefault f32, usage string) f32 {
+pub fn (fs mut FlagParser) float(name string, abbr byte, fdefault f64, usage string) f64 {
 	value := fs.float_opt(name, abbr, usage) or {
 		return fdefault
 	}

--- a/vlib/flag/flag_test.v
+++ b/vlib/flag/flag_test.v
@@ -276,8 +276,11 @@ fn test_not_provided_option_is_not_returned() {
 					//Everything should not return
 					return
 				}
+				return
 			}
+			return
 		}
+		return
 	}
 	//If we reach here, one of them returned a value.
 	assert false


### PR DESCRIPTION
This PR fix flag_test.v error.
- Change `f32` to `f64` of `float_opt`...
- Fix optional error of test.
- Remove `flag_test.v` from skip list.

```v
OK    1265 ms [ 30/157] vlib\flag\flag_test.v
------------------------------------------------------------------------------------------
   96156 ms <=== total time spent testing all fixed tests
                 ok, fail, skip, total =   134,     0,    23,   157
```