### PR TITLE
enum: check enum name and modify related files

### DIFF
--- a/vlib/builtin/bare/.checks/forkedtest/forkedtest.v
+++ b/vlib/builtin/bare/.checks/forkedtest/forkedtest.v
@@ -1,23 +1,23 @@
 module forkedtest
 
-pub fn run (op fn(), label string, code wi_si_code, status int) int {
+pub fn run (op fn(), label string, code Wi_si_code, status int) int {
 	child := sys_fork()
 	if child == 0 {
 		op()
 		sys_exit(0)
 	}
 
-	siginfo := [0].repeat(int(sig_index.si_size))
+	siginfo := [0].repeat(int(Sig_index.si_size))
 
 	e := sys_waitid(.p_pid, child, intptr(&siginfo[0]), .wexited, 0)
 
 	assert e == .enoerror
-	assert siginfo[int(sig_index.si_pid)] == child
-	assert siginfo[int(sig_index.si_signo)] == int(signo.sigchld)
-	assert siginfo[int(sig_index.si_uid)] == sys_getuid()
+	assert siginfo[int(Sig_index.si_pid)] == child
+	assert siginfo[int(Sig_index.si_signo)] == int(Signo.sigchld)
+	assert siginfo[int(Sig_index.si_uid)] == sys_getuid()
 
-	r_code := siginfo[sig_index.si_code]
-	r_status := siginfo[sig_index.si_status]
+	r_code := siginfo[Sig_index.si_code]
+	r_status := siginfo[Sig_index.si_status]
 
 	print("+++ ")
 	print(label)
@@ -47,4 +47,3 @@ pub fn run (op fn(), label string, code wi_si_code, status int) int {
 pub fn normal_run (op fn(), label string) int {
 	return run (op, label, .cld_exited, 0)
 }
-

--- a/vlib/builtin/bare/.checks/linuxsys/linuxsys.v
+++ b/vlib/builtin/bare/.checks/linuxsys/linuxsys.v
@@ -25,12 +25,12 @@ fn check_fork_minimal () {
 	e := sys_waitid(.p_pid, child, intptr(siginfo.data) , .wexited, 0)
 
 	assert e == .enoerror
-	//println(i64_tos(buffer0,80,siginfo[sig_index.si_code],16))
-	assert siginfo[sig_index.si_code] == int(wi_si_code.cld_exited)
-	assert siginfo[sig_index.si_pid] == child
-	assert siginfo[sig_index.si_status] == ec
-	assert siginfo[sig_index.si_signo] == int(signo.sigchld)
-	assert siginfo[sig_index.si_uid] == sys_getuid()
+	//println(i64_tos(buffer0,80,siginfo[Sig_index.si_code],16))
+	assert siginfo[Sig_index.si_code] == int(Wi_si_code.cld_exited)
+	assert siginfo[Sig_index.si_pid] == child
+	assert siginfo[Sig_index.si_status] == ec
+	assert siginfo[Sig_index.si_signo] == int(Signo.sigchld)
+	assert siginfo[Sig_index.si_uid] == sys_getuid()
 }
 
 fn check_read_write_pipe() {
@@ -131,36 +131,36 @@ fn check_munmap_fail() {
 }
 
 fn check_mmap_one_page() {
-	mp := int(mm_prot.prot_read) | int(mm_prot.prot_write)
-	mf := int(map_flags.map_private) | int(map_flags.map_anonymous)
-	mut a, e := sys_mmap(0, u64(linux_mem.page_size), mm_prot(mp), map_flags(mf), -1, 0)
+	mp := int(Mm_prot.prot_read) | int(Mm_prot.prot_write)
+	mf := int(Map_flags.map_private) | int(Map_flags.map_anonymous)
+	mut a, e := sys_mmap(0, u64(Linux_mem.page_size), Mm_prot(mp), Map_flags(mf), -1, 0)
 
 	assert e == .enoerror
 	assert a != byteptr(-1)
 
-	for i in 0..int(linux_mem.page_size) {
+	for i in 0..int(Linux_mem.page_size) {
 		b := i & 0xFF
 		a[i] = b
 		assert a[i] == b
 	}
 
-	ec := sys_munmap(a, u64(linux_mem.page_size))
+	ec := sys_munmap(a, u64(Linux_mem.page_size))
 	assert ec == .enoerror
 }
 
 fn check_mm_pages() {
-	for i in 0 .. int(linux_mem.page_size)-4 {
+	for i in 0 .. int(Linux_mem.page_size)-4 {
 		assert u32(1) == mm_pages(u64(i))
 	}
-	for i in int(linux_mem.page_size)-3 .. (int(linux_mem.page_size)*2)-4 {
+	for i in int(Linux_mem.page_size)-3 .. (int(Linux_mem.page_size)*2)-4 {
 		assert u32(2) == mm_pages(u64(i))
 	}
-	for i in (int(linux_mem.page_size)*2)-3 .. (int(linux_mem.page_size)*3)-4 {
+	for i in (int(Linux_mem.page_size)*2)-3 .. (int(Linux_mem.page_size)*3)-4 {
 		assert u32(3) == mm_pages(u64(i))
 	}
 }
 
-//pub fn mm_alloc(size u64) (voidptr, errno)
+//pub fn mm_alloc(size u64) (voidptr, Errno)
 
 fn check_mm_alloc() {
 	for i in 1 .. 2000 {

--- a/vlib/builtin/bare/linuxsys_bare.v
+++ b/vlib/builtin/bare/linuxsys_bare.v
@@ -1,10 +1,10 @@
 module builtin
 
-pub enum linux_mem {
+pub enum Linux_mem {
 	page_size = 4096
 }
 
-pub enum wp_sys {
+pub enum Wp_sys {
 	wnohang = 0x00000001
 	wuntraced = 0x00000002
 	wstopped = 0x00000002
@@ -17,13 +17,13 @@ pub enum wp_sys {
 }
 
 // First argument to waitid:
-pub enum wi_which {
+pub enum Wi_which {
 	p_all = 0
 	p_pid = 1
 	p_pgid = 2
 }
 
-pub enum wi_si_code {
+pub enum Wi_si_code {
 	cld_exited = 1 // child has exited
 	cld_killed = 2 // child was killed
 	cld_dumped = 3 // child terminated abnormally
@@ -55,7 +55,7 @@ pub enum wi_si_code {
 		3 The si_code field can be used to determine how to
 			interpret this field.
 
-	si_code, set to one of (enum wi_si_code), offset 0x08, int index 0x02:
+	si_code, set to one of (enum Wi_si_code), offset 0x08, int index 0x02:
 		CLD_EXITED (child called _exit(2));
 		CLD_KILLED (child killed by signal);
 		CLD_DUMPED (child  killed by signal, and dumped core);
@@ -64,7 +64,7 @@ pub enum wi_si_code {
 		CLD_CONTINUED (child continued by SIGCONT).
 */
 
-pub enum sig_index {
+pub enum Sig_index {
 	si_signo = 0x00
 	si_code = 0x02
 	si_pid = 0x04
@@ -73,7 +73,7 @@ pub enum sig_index {
 	si_size = 0x80
 }
 
-pub enum signo {
+pub enum Signo {
 	sigint = 2	// Interactive attention signal.
 	sigill = 4	// Illegal instruction.
 	sigabrt = 6	// Abnormal termination.
@@ -108,7 +108,7 @@ pub enum signo {
 }
 
 
-pub enum fcntl {
+pub enum Fcntl {
 	fd_cloexec = 0x00000001
 	f_dupfd = 0x00000000
 	f_exlck = 0x00000004
@@ -168,7 +168,7 @@ pub enum fcntl {
 	o_wronly = 0x00000001
 }
 
-pub enum errno {
+pub enum Errno {
 	enoerror = 0x00000000
 	e2big = 0x00000007
 	eacces = 0x0000000d
@@ -206,7 +206,7 @@ pub enum errno {
 	exdev = 0x00000012
 }
 
-pub enum mm_prot {
+pub enum Mm_prot {
 	prot_read = 0x1
 	prot_write = 0x2
 	prot_exec = 0x4
@@ -215,7 +215,7 @@ pub enum mm_prot {
 	prot_growsup = 0x02000000
 }
 
-pub enum map_flags {
+pub enum Map_flags {
 	map_shared = 0x01
 	map_private = 0x02
 	map_shared_validate = 0x03
@@ -322,59 +322,59 @@ fn sys_call5(scn, arg1, arg2, arg3, arg4, arg5 u64) u64
 fn sys_call6(scn, arg1, arg2, arg3, arg4, arg5, arg6 u64) u64
 
 
-fn split_int_errno(rc_in u64) (i64, errno) {
+fn split_int_errno(rc_in u64) (i64, Errno) {
 	rc := i64(rc_in)
 	if rc < 0 {
-		return i64(-1), errno(-rc)
+		return i64(-1), Errno(-rc)
 	}
-	return rc, errno.enoerror
+	return rc, Errno.enoerror
 }
 
 // 0 sys_read unsigned int fd char *buf size_t count
-pub fn sys_read (fd i64, buf byteptr, count u64) (i64, errno) {
+pub fn sys_read (fd i64, buf byteptr, count u64) (i64, Errno) {
 	return split_int_errno(sys_call3(0, u64(fd), u64(buf), count))
 }
 
 // 1 sys_write unsigned int fd, const char *buf, size_t count
-pub fn sys_write(fd i64, buf byteptr, count u64) (i64, errno) {
+pub fn sys_write(fd i64, buf byteptr, count u64) (i64, Errno) {
 	return split_int_errno(sys_call3(1, u64(fd), u64(buf), count))
 }
 
-pub fn sys_open(filename byteptr, flags fcntl, mode int) (i64, errno) {
+pub fn sys_open(filename byteptr, flags Fcntl, mode int) (i64, Errno) {
 	//2 sys_open  const char *filename  int flags int mode
 	return split_int_errno(sys_call3(2, u64(filename), u64(flags), u64(mode)))
 }
 
-pub fn sys_close(fd i64) errno {
+pub fn sys_close(fd i64) Errno {
 	// 3 sys_close unsigned int fd
-	return errno(-i64(sys_call1(3, u64(fd))))
+	return Errno(-i64(sys_call1(3, u64(fd))))
 }
 
 // 9 sys_mmap unsigned long addr  unsigned long len unsigned long prot  unsigned long flags unsigned long fd  unsigned long off
-pub fn sys_mmap(addr byteptr, len u64, prot mm_prot, flags map_flags, fildes u64, off u64) (byteptr, errno) {
+pub fn sys_mmap(addr byteptr, len u64, prot Mm_prot, flags Map_flags, fildes u64, off u64) (byteptr, Errno) {
 	rc := sys_call6(9, u64(addr), len, u64(prot), u64(flags), fildes, off)
 	a, e := split_int_errno(rc)
 	return byteptr(a), e
 }
 
-pub fn sys_munmap(addr voidptr, len u64) errno {
+pub fn sys_munmap(addr voidptr, len u64) Errno {
 	// 11 sys_munmap  unsigned long addr  size_t len
-	return errno(-sys_call2(11, u64(addr), len))
+	return Errno(-sys_call2(11, u64(addr), len))
 }
 
 // 22  sys_pipe  int *filedes
-pub fn sys_pipe(filedes &int) errno {
-	return errno(sys_call1(22, u64(filedes)))
+pub fn sys_pipe(filedes &int) Errno {
+	return Errno(sys_call1(22, u64(filedes)))
 }
 
 // 24 sys_sched_yield
-pub fn sys_sched_yield() errno {
-	return errno(sys_call0(24))
+pub fn sys_sched_yield() Errno {
+	return Errno(sys_call0(24))
 }
 
-pub fn sys_madvise(addr voidptr, len u64, advice int) errno {
+pub fn sys_madvise(addr voidptr, len u64, advice int) Errno {
 	// 28 sys_madvise unsigned long start size_t len_in int behavior
-	return errno(sys_call3(28, u64(addr), len, u64(advice)))
+	return Errno(sys_call3(28, u64(addr), len, u64(advice)))
 }
 
 // 39 sys_getpid
@@ -393,7 +393,7 @@ pub fn sys_vfork() int {
 }
 
 // 33  sys_dup2  unsigned int oldfd  unsigned int newfd
-pub fn sys_dup2 (oldfd, newfd int) (i64, errno) {
+pub fn sys_dup2 (oldfd, newfd int) (i64, Errno) {
 	return split_int_errno(sys_call2(33, u64(oldfd),u64(newfd)))
 }
 
@@ -415,8 +415,8 @@ pub fn sys_getuid() int {
 }
 
 // 247 sys_waitid  int which pid_t upid  struct siginfo *infop int options struct rusage *ru
-pub fn sys_waitid (which wi_which, pid int, infop &int, options wp_sys, ru voidptr) errno {
-	return errno(sys_call5(247, u64(which), u64(pid), u64(infop), u64(options), u64(ru)))
+pub fn sys_waitid (which Wi_which, pid int, infop &int, options Wp_sys, ru voidptr) Errno {
+	return Errno(sys_call5(247, u64(which), u64(pid), u64(infop), u64(options), u64(ru)))
 }
 
 

--- a/vlib/builtin/bare/mm_bare.v
+++ b/vlib/builtin/bare/mm_bare.v
@@ -1,9 +1,9 @@
 module builtin
 
 const (
-	mem_prot = mm_prot(int(mm_prot.prot_read) | int(mm_prot.prot_write))
-	mem_flags = map_flags(int(map_flags.map_private) | int(map_flags.map_anonymous))
-	page_size = u64(linux_mem.page_size)
+	mem_prot = Mm_prot(int(Mm_prot.prot_read) | int(Mm_prot.prot_write))
+	mem_flags = Map_flags(int(Map_flags.map_private) | int(Map_flags.map_anonymous))
+	page_size = u64(Linux_mem.page_size)
 )
 
 pub fn mm_pages(size u64) u32 {
@@ -11,9 +11,9 @@ pub fn mm_pages(size u64) u32 {
 	return u32(pages)
 }
 
-pub fn mm_alloc(size u64) (byteptr, errno) {
+pub fn mm_alloc(size u64) (byteptr, Errno) {
 	pages := mm_pages(size)
-	n_bytes := u64(pages*u32(linux_mem.page_size))
+	n_bytes := u64(pages*u32(Linux_mem.page_size))
 
 	a, e := sys_mmap(0, n_bytes, mem_prot, mem_flags, -1, 0)
 	if e == .enoerror {
@@ -24,9 +24,9 @@ pub fn mm_alloc(size u64) (byteptr, errno) {
 	return byteptr(0), e
 }
 
-pub fn mm_free(addr byteptr) errno {
+pub fn mm_free(addr byteptr) Errno {
 	ap := &int(addr-4)
-	size := u64(*ap) * u64(linux_mem.page_size)
+	size := u64(*ap) * u64(Linux_mem.page_size)
 
 	return sys_munmap(ap, size)
 }

--- a/vlib/regex/regex.v
+++ b/vlib/regex/regex.v
@@ -1413,7 +1413,7 @@ pub fn (re RE) get_query() string {
 * Matching
 *
 ******************************************************************************/
-enum match_state{
+enum Match_state{
 	start = 0
 	stop
 	end
@@ -1428,7 +1428,7 @@ enum match_state{
 	ist_quant_ng // match negative ,group quantifier check
 }
 
-fn state_str(s match_state) string {
+fn state_str(s Match_state) string {
 	match s{
 		.start        { return "start" }
 		.stop         { return "stop" }
@@ -1461,7 +1461,7 @@ pub fn (re mut RE) match_base(in_txt byteptr, in_txt_len int ) (int,int) {
 	mut i := 0                       // source string index
 	mut ch := u32(0)                 // examinated char
 	mut char_len := 0                // utf8 examinated char len
-	mut m_state := match_state.start // start point for the matcher FSM
+	mut m_state := Match_state.start // start point for the matcher FSM
 
 	mut pc := -1                     // program counter
 	mut state := StateObj{}          // actual state

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1083,7 +1083,12 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 	}
 	p.check(.key_enum)
 	end_pos := p.tok.position()
-	name := p.prepend_mod(p.check_name())
+
+	enum_name := p.check_name()
+	if enum_name.len > 0 && !enum_name[0].is_capital() {
+		verror('enum name `$enum_name` must begin with a capital letter')
+	}
+	name := p.prepend_mod(enum_name)
 	p.check(.lcbr)
 	mut vals := []string
 	// mut default_exprs := []ast.Expr


### PR DESCRIPTION
This PR check enum name and modify related files.
- v2 requires enum type name to start with capital letter.
- Add check for enum type name.

before
```v
C:\Users\yuyi9\v>v test vlib/regex
---------------------------------------- Testing... --------------------------------------
FAIL    63 ms [1/1] vlib/regex\regex_test.v
V panic: TypeSymbol.enum_info(): no enum info for type: void
```
now
```v
C:\Users\yuyi9\v>v test vlib/regex
---------------------------------------- Testing... --------------------------------------
FAIL    47 ms [1/1] vlib/regex\regex_test.v
parser error: enum name `match_state` must begin with a capital letter
```
- Modify related files.

Not placed in checker.v for processing because errors have been reported at the time of parse files.