### PR TITLE
parser: fix empty import error

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -302,6 +302,9 @@ pub fn (mut p Parser) top_stmt() ast.Stmt {
 		}
 		.key_import {
 			node := p.import_stmt()
+			if node.len == 0 {
+				return p.top_stmt()
+			}
 			p.ast_imports << node
 			return node[0]
 		}

--- a/vlib/v/tests/inout/empty_import.out
+++ b/vlib/v/tests/inout/empty_import.out
@@ -1,0 +1,1 @@
+empty import

--- a/vlib/v/tests/inout/empty_import.vv
+++ b/vlib/v/tests/inout/empty_import.vv
@@ -1,0 +1,7 @@
+import (
+	// no module
+)
+
+fn main() {
+	println('empty import')
+}


### PR DESCRIPTION
This PR fix empty import error.

Errors are reported when import-empty modules like `import ()`.
```v
V panic: array.get: index out of range (i == 0, a.len == 0)
```
Solution:
- Ignore the import module when it is empty.
- Add tests.