### PR TITLE
make.bat: minor optimizes

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -8,8 +8,6 @@ if exist "vc" (
 	rd /s /q vc
 )
 
-git version
-
 echo Downloading v.c...
 git clone --depth 1 --quiet https://github.com/vlang/vc
 
@@ -36,7 +34,9 @@ if %ERRORLEVEL% NEQ 0 (
 	goto :error
 )
 
-v self -prod
+REM remove the -prod parameter to shorten compilation time,
+REM and it will be restored when v is a stable version.
+v self
 if %ERRORLEVEL% NEQ 0 (
 	echo v.exe failed to compile itself - Create an issue at 'https://github.com/vlang'
 	rd /s /q vc
@@ -73,7 +73,9 @@ if %ERRORLEVEL% NEQ 0 (
 	goto :compile_error
 )
 
-v self -prod
+REM remove the -prod parameter to shorten compilation time,
+REM and it will be restored when v is a stable version.
+v self
 if %ERRORLEVEL% NEQ 0 (
 	echo V failed to build itself with error %ERRORLEVEL%
 	rd /s /q vc


### PR DESCRIPTION
This PR minor optimizes make.bat.

- Remove `git version`.
- Remove `-prod` to shorten compilation time, and will be restored when v is a stable version.