### PR TITLE
cgen: fix gen_str_for_array_fixed error

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3046,6 +3046,8 @@ fn (mut g Gen) gen_str_for_array_fixed(info table.ArrayFixed, styp, str_fn_name 
 		g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write(&sb, ${field_styp}_str(a[i],0));')
 	} else if sym.kind in [.f32, .f64] {
 		g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write(&sb, _STR("%g", a[i]));')
+	} else if sym.kind == .string {
+		g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write(&sb, _STR("\\"%.*s\\"", a[i].len, a[i].str));')
 	} else {
 		g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write(&sb, ${field_styp}_str(a[i]));')
 	}

--- a/vlib/v/tests/fixed_array_to_string_test.v
+++ b/vlib/v/tests/fixed_array_to_string_test.v
@@ -1,17 +1,48 @@
-fn test_fixed_array_to_string_conversion() {
-	a := ['1', '2', '3', '4']!!
-	assert a.str() == '["1", "2", "3", "4"]'
-	b := [1, 2, 3, 4]!!
-	assert b.str() == '[1, 2, 3, 4]'
-}
+fn test_fixed_array_to_string() {
+	mut a1 := [3]string
+	a1[0] = '1'
+	a1[1] = '2'
+	a1[2] = '3'
+	assert '$a1' == '["1", "2", "3"]'
 
-fn test_interpolation_fixed_array_to_string() {
-	a := ['1', '2', '3']!!
-	assert '$a' == '["1", "2", "3"]'
-	b := ['a', 'b']!!
-	assert '$b' == '["a", "b"]'
-	c := [1, 2, 3]!!
-	assert '$c' == '[1, 2, 3]'
-	d := [1.1, 2.2, 3.3]!!
-	assert '$d' == '[1.1, 2.2, 3.3]'
+	mut a2 := [2]string
+	a2[0] = 'a'
+	a2[1] = 'b'
+	assert '$a2' == '["a", "b"]'
+
+	mut c1 := [3]int
+	c1[0] = 1
+	c1[1] = 2
+	c1[2] = 3
+	assert '$c1' == '[1, 2, 3]'
+
+	mut c2 := [3]i16
+	c2[0] = 1
+	c2[1] = 2
+	c2[2] = 3
+	assert '$c2' == '[1, 2, 3]'
+
+	mut c3 := [3]i64
+	c3[0] = 1
+	c3[1] = 2
+	c3[2] = 3
+	assert '$c3' == '[1, 2, 3]'
+
+	mut c4 := [3]u64
+	c4[0] = 1
+	c4[1] = 2
+	c4[2] = 3
+	assert '$c4' == '[1, 2, 3]'
+
+	mut d1 := [3]f64
+	d1[0] = 1.1
+	d1[1] = 2.2
+	d1[2] = 3.3
+	assert '$d1' == '[1.1, 2.2, 3.3]'
+
+	mut d2 := [3]f32
+	d2[0] = 1.1
+	d2[1] = 2.2
+	d2[2] = 3.3
+	assert '$d2' == '[1.1, 2.2, 3.3]'
 }


### PR DESCRIPTION
This PR fix gen_str_for_array_fixed error.

- Compilation errors occur when using string type fixed-array.
- There's still a problem when using `[...]!!` to create fixed-array.

Solution
- Add string type process in gen_str_for_array_fixed.
-  Modify the fixed array creation method in the test.