### PR TITLE
checker: check `in` left type

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -312,16 +312,16 @@ pub fn (c mut Checker) infix_expr(infix_expr mut ast.InfixExpr) table.Type {
 	if infix_expr.op in [.key_in, .not_in] {
 		if right.kind == .array {
 			right_sym := c.table.get_type_symbol(right.array_info().elem_type)
-			if left.kind != .alias && left.kind != right_sym.kind {
+			if left.kind != right_sym.kind {
 				c.error('the data type on the left of `in` does not match the array item type', infix_expr.pos)
 			}
 		} else if right.kind == .map {
 			key_sym := c.table.get_type_symbol(right.map_info().key_type)
-			if left.kind != .alias && left.kind != key_sym.kind {
+			if left.kind != key_sym.kind {
 				c.error('the data type on the left of `in` does not match the map key type', infix_expr.pos)
 			}
 		} else if right.kind == .string {
-			if left.kind != .alias && left.kind != .string {
+			if left.kind != .string {
 				c.error('the data type on the left of `in` must be a string', infix_expr.pos)
 			}
 		} else {
@@ -1164,15 +1164,16 @@ fn (c mut Checker) stmt(node ast.Stmt) {
 		ast.ForInStmt {
 			c.in_for_count++
 			typ := c.expr(it.cond)
+			typ_idx := table.type_idx(typ)
 			if it.is_range {
-				high_type := c.expr(it.high)
-				if typ in table.integer_type_idxs && high_type !in table.integer_type_idxs {
+				high_type_idx := table.type_idx(c.expr(it.high))
+				if typ_idx in table.integer_type_idxs && high_type_idx !in table.integer_type_idxs {
 					c.error('range types do not match', it.cond.position())
-				} else if typ in table.float_type_idxs || high_type in table.float_type_idxs {
+				} else if typ_idx in table.float_type_idxs || high_type_idx in table.float_type_idxs {
 					c.error('range type can not be float', it.cond.position())
-				} else if typ == table.bool_type_idx || high_type == table.bool_type_idx {
+				} else if typ_idx == table.bool_type_idx || high_type_idx == table.bool_type_idx {
 					c.error('range type can not be bool', it.cond.position())
-				} else if typ == table.string_type_idx || high_type == table.string_type_idx {
+				} else if typ_idx == table.string_type_idx || high_type_idx == table.string_type_idx {
 					c.error('range type can not be string', it.cond.position())
 				}
 				c.expr(it.high)

--- a/vlib/v/checker/tests/inout/in_array_mismatch_type.out
+++ b/vlib/v/checker/tests/inout/in_array_mismatch_type.out
@@ -1,6 +1,0 @@
-vlib/v/checker/tests/inout/in_array_mismatch_type.v:2:7: error: the data type on the left of `in` does not match the array item type
-    1| fn main() {
-    2|     if 1 in ['1', '2'] {
-                ~~
-    3|         println('ok')
-    4|     }

--- a/vlib/v/checker/tests/inout/in_array_mismatch_type.vv
+++ b/vlib/v/checker/tests/inout/in_array_mismatch_type.vv
@@ -1,5 +1,0 @@
-fn main() {
-	if 1 in ['1', '2'] {
-		println('ok')
-	}
-}

--- a/vlib/v/checker/tests/inout/in_mismatch_type.out
+++ b/vlib/v/checker/tests/inout/in_mismatch_type.out
@@ -1,34 +1,56 @@
-vlib/v/checker/tests/inout/in_mismatch_type.v:2:7: error: the data type on the left of `in` does not match the array item type
-    1| fn main() {
-    2|     if 1 in ['1', '2'] {
+vlib/v/checker/tests/inout/in_mismatch_type.v:13:7: error: the data type on the left of `in` does not match the array item type
+   11|     }
+   12|     s := 'abcd'
+   13|     if 1 in a_s {
                 ~~
-    3|         println('ok')
-    4|     }
-vlib/v/checker/tests/inout/in_mismatch_type.v:8:7: error: the data type on the left of `in` does not match the map key type
-    6|         'test': 1
-    7|     }
-    8|     if 2 in m {
+   14|         println('ok')
+   15|     }
+vlib/v/checker/tests/inout/in_mismatch_type.v:16:7: error: the data type on the left of `in` does not match the map key type
+   14|         println('ok')
+   15|     }
+   16|     if 2 in m {
                 ~~
-    9|         println('yeah')
-   10|     }
-vlib/v/checker/tests/inout/in_mismatch_type.v:11:7: error: the data type on the left of `in` must be a string
-    9|         println('yeah')
-   10|     }
-   11|     if 3 in 'test' {
+   17|         println('yeah')
+   18|     }
+vlib/v/checker/tests/inout/in_mismatch_type.v:19:7: error: the data type on the left of `in` must be a string
+   17|         println('yeah')
+   18|     }
+   19|     if 3 in s {
                 ~~
-   12|         println('dope')
-   13|     }
-vlib/v/checker/tests/inout/in_mismatch_type.v:14:9: error: the data type on the left of `in` must be a string
-   12|         println('dope')
-   13|     }
-   14|     if `a` in 'abcd' {
+   20|         println('dope')
+   21|     }
+vlib/v/checker/tests/inout/in_mismatch_type.v:22:9: error: the data type on the left of `in` must be a string
+   20|         println('dope')
+   21|     }
+   22|     if `a` in s {
                   ~~
-   15|         println("oh no :'(")
-   16|     }
-vlib/v/checker/tests/inout/in_mismatch_type.v:17:7: error: `in` can only be used with an array/map/string
-   15|         println("oh no :'(")
-   16|     }
-   17|     if 1 in 12 {
+   23|         println("oh no :'(")
+   24|     }
+vlib/v/checker/tests/inout/in_mismatch_type.v:25:7: error: `in` can only be used with an array/map/string
+   23|         println("oh no :'(")
+   24|     }
+   25|     if 1 in 12 {
                 ~~
-   18|         println('right')
-   19|     }
+   26|         println('right')
+   27|     }
+vlib/v/checker/tests/inout/in_mismatch_type.v:28:12: error: the data type on the left of `in` does not match the map key type
+   26|         println('right')
+   27|     }
+   28|     if Int(2) in m {
+                     ~~
+   29|         println('yeah')
+   30|     }
+vlib/v/checker/tests/inout/in_mismatch_type.v:31:15: error: the data type on the left of `in` does not match the array item type
+   29|         println('yeah')
+   30|     }
+   31|     if Str2('3') in a_i {
+                        ~~
+   32|         println('sure')
+   33|     }
+vlib/v/checker/tests/inout/in_mismatch_type.v:34:15: error: the data type on the left of `in` does not match the array item type
+   32|         println('sure')
+   33|     }
+   34|     if Str3('2') in a_i {
+                        ~~
+   35|         println('all right')
+   36|     }

--- a/vlib/v/checker/tests/inout/in_mismatch_type.out
+++ b/vlib/v/checker/tests/inout/in_mismatch_type.out
@@ -1,0 +1,34 @@
+vlib/v/checker/tests/inout/in_mismatch_type.v:2:7: error: the data type on the left of `in` does not match the array item type
+    1| fn main() {
+    2|     if 1 in ['1', '2'] {
+                ~~
+    3|         println('ok')
+    4|     }
+vlib/v/checker/tests/inout/in_mismatch_type.v:8:7: error: the data type on the left of `in` does not match the map key type
+    6|         'test': 1
+    7|     }
+    8|     if 2 in m {
+                ~~
+    9|         println('yeah')
+   10|     }
+vlib/v/checker/tests/inout/in_mismatch_type.v:11:7: error: the data type on the left of `in` must be a string
+    9|         println('yeah')
+   10|     }
+   11|     if 3 in 'test' {
+                ~~
+   12|         println('dope')
+   13|     }
+vlib/v/checker/tests/inout/in_mismatch_type.v:14:9: error: the data type on the left of `in` must be a string
+   12|         println('dope')
+   13|     }
+   14|     if `a` in 'abcd' {
+                  ~~
+   15|         println("oh no :'(")
+   16|     }
+vlib/v/checker/tests/inout/in_mismatch_type.v:17:7: error: `in` can only be used with an array/map/string
+   15|         println("oh no :'(")
+   16|     }
+   17|     if 1 in 12 {
+                ~~
+   18|         println('right')
+   19|     }

--- a/vlib/v/checker/tests/inout/in_mismatch_type.vv
+++ b/vlib/v/checker/tests/inout/in_mismatch_type.vv
@@ -1,0 +1,20 @@
+fn main() {
+	if 1 in ['1', '2'] {
+		println('ok')
+	}
+	m := {
+		'test': 1
+	}
+	if 2 in m {
+		println('yeah')
+	}
+	if 3 in 'test' {
+		println('dope')
+	}
+	if `a` in 'abcd' {
+		println("oh no :'(")
+	}
+	if 1 in 12 {
+		println('right')
+	}
+}

--- a/vlib/v/checker/tests/inout/in_mismatch_type.vv
+++ b/vlib/v/checker/tests/inout/in_mismatch_type.vv
@@ -1,20 +1,37 @@
+type Int = int
+
+type Str2 = string
+type Str3 = Str2
+
 fn main() {
-	if 1 in ['1', '2'] {
-		println('ok')
-	}
+	a_i := [1, 2, 3]
+	a_s := ['1', '2', '3']
 	m := {
 		'test': 1
+	}
+	s := 'abcd'
+	if 1 in a_s {
+		println('ok')
 	}
 	if 2 in m {
 		println('yeah')
 	}
-	if 3 in 'test' {
+	if 3 in s {
 		println('dope')
 	}
-	if `a` in 'abcd' {
+	if `a` in s {
 		println("oh no :'(")
 	}
 	if 1 in 12 {
 		println('right')
+	}
+	if Int(2) in m {
+		println('yeah')
+	}
+	if Str2('3') in a_i {
+		println('sure')
+	}
+	if Str3('2') in a_i {
+		println('all right')
 	}
 }

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1397,9 +1397,7 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 			g.expr_with_cast(node.right, node.right_type, info.elem_type)
 			g.write(' })')
 		}
-	} else if (node.left_type == node.right_type) && node.left_type in [table.f32_type_idx,
-		table.f64_type_idx
-	] && node.op in [.eq, .ne] {
+	} else if (node.left_type == node.right_type) && table.is_float(node.left_type) && node.op in [.eq, .ne] {
 		// floats should be compared with epsilon
 		if node.left_type == table.f64_type_idx {
 			if node.op == .eq {

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -130,6 +130,17 @@ pub fn new_type_ptr(idx, nr_muls int) Type {
 	return (nr_muls << 16) | u16(idx)
 }
 
+[inline]
+pub fn is_float(typ Type) bool {
+	return type_idx(typ) in float_type_idxs
+}
+
+[inline]
+pub fn is_int(typ Type) bool {
+	return type_idx(typ) in integer_type_idxs
+}
+
+[inline]
 pub fn is_number(typ Type) bool {
 	return type_idx(typ) in number_type_idxs
 }

--- a/vlib/v/tests/in_expression_test.v
+++ b/vlib/v/tests/in_expression_test.v
@@ -104,6 +104,24 @@ fn test_in_expression_with_string() {
 	assert a == false
 }
 
+fn test_in_expression_in_map() {
+	m := {
+		'one': 1
+		'two': 2
+		'three': 3
+	}
+	assert 'one' in m
+	assert 'four' !in m
+}
+
+fn test_in_expression_in_string() {
+	s := 'abcd'
+	assert 'a' in s
+	assert 'ab' in s
+	assert 'abcd' in s
+	assert 'dbca' !in s
+}
+
 fn test_optimized_in_expression() {
 	mut a := false
 	a = true && 2 in [1, 2]


### PR DESCRIPTION
Check that types are coherent for maps and strings.
I removed the fact that aliases where unaffected by the check, as I didn't understand why it was here, but let me know if I was wrong, and what's the expected behavior if so.