### PR TITLE
checker: fix "unnecessary `()`" error position

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -163,23 +163,23 @@ pub fn (c mut Checker) struct_decl(decl ast.StructDecl) {
 		}
 		c.error('struct name must begin with capital letter', pos)
 	}
-    
+
 	for fi, _ in decl.fields {
 		if decl.fields[fi].has_default_expr {
 			c.expected_type = decl.fields[fi].typ
 			field_expr_type := c.expr(decl.fields[fi].default_expr)
-			if !c.table.check( field_expr_type, decl.fields[fi].typ ) { 
+			if !c.table.check( field_expr_type, decl.fields[fi].typ ) {
 				field_expr_type_sym := c.table.get_type_symbol( field_expr_type )
 				field_type_sym := c.table.get_type_symbol( decl.fields[fi].typ )
 				field_name := decl.fields[fi].name
 				fet_name := field_expr_type_sym.name
 				ft_name := field_type_sym.name
 				c.error('default expression for field `${field_name}` '+
-					'has type `${fet_name}`, but should be `${ft_name}`', 
-					decl.fields[fi].default_expr.position() 
+					'has type `${fet_name}`, but should be `${ft_name}`',
+					decl.fields[fi].default_expr.position()
 				)
-			}             
-		}        
+			}
+		}
 	}
 	// && (p.tok.lit[0].is_capital() || is_c || (p.builtin_mod && Sp.tok.lit in table.builtin_type_names))
 }
@@ -1630,12 +1630,8 @@ pub fn (c mut Checker) if_expr(node mut ast.IfExpr) table.Type {
 	}
 	node.typ = table.void_type
 	for i, branch in node.branches {
-		match branch.cond {
-			ast.ParExpr {
-				c.error('unnecessary `()` in an if condition. use `if expr {` instead of `if (expr) {`.',
-					node.pos)
-			}
-			else {}
+		if branch.cond is ast.ParExpr {
+			c.error('unnecessary `()` in an if condition. use `if expr {` instead of `if (expr) {`.', branch.pos)
 		}
 		typ := c.expr(branch.cond)
 		if i < node.branches.len - 1 || !node.has_else {

--- a/vlib/v/checker/tests/inout/unnecessary_parenthesis.out
+++ b/vlib/v/checker/tests/inout/unnecessary_parenthesis.out
@@ -16,5 +16,5 @@ vlib/v/checker/tests/inout/unnecessary_parenthesis.v:6:4: error: unnecessary `()
     5|         println("oh no :'(")
     6|     } else if (1 == 3) {
              ~~~~~~~~~~~~~~~~
-    7|         println('what\'s wrong with physics ????')
+    7|         println("what's wrong with physics ????")
     8|     }

--- a/vlib/v/checker/tests/inout/unnecessary_parenthesis.out
+++ b/vlib/v/checker/tests/inout/unnecessary_parenthesis.out
@@ -1,0 +1,20 @@
+vlib/v/checker/tests/inout/unnecessary_parenthesis.v:2:2: error: unnecessary `()` in an if condition. use `if expr {` instead of `if (expr) {`.
+    1| fn main() {
+    2|     if (1 == 1) {
+           ~~~~~~~~~~~
+    3|         println('yeay')
+    4|     } else if (1 == 2) {
+vlib/v/checker/tests/inout/unnecessary_parenthesis.v:4:4: error: unnecessary `()` in an if condition. use `if expr {` instead of `if (expr) {`.
+    2|     if (1 == 1) {
+    3|         println('yeay')
+    4|     } else if (1 == 2) {
+             ~~~~~~~~~~~~~~~~
+    5|         println("oh no :'(")
+    6|     } else if (1 == 3) {
+vlib/v/checker/tests/inout/unnecessary_parenthesis.v:6:4: error: unnecessary `()` in an if condition. use `if expr {` instead of `if (expr) {`.
+    4|     } else if (1 == 2) {
+    5|         println("oh no :'(")
+    6|     } else if (1 == 3) {
+             ~~~~~~~~~~~~~~~~
+    7|         println('what\'s wrong with physics ????')
+    8|     }

--- a/vlib/v/checker/tests/inout/unnecessary_parenthesis.vv
+++ b/vlib/v/checker/tests/inout/unnecessary_parenthesis.vv
@@ -1,0 +1,9 @@
+fn main() {
+	if (1 == 1) {
+		println('yeay')
+	} else if (1 == 2) {
+		println("oh no :'(")
+	} else if (1 == 3) {
+		println("what's wrong with physics ????")
+	}
+}

--- a/vlib/v/parser/if.v
+++ b/vlib/v/parser/if.v
@@ -13,7 +13,7 @@ fn (mut p Parser) if_expr() ast.IfExpr {
 	mut has_else := false
 	for p.tok.kind in [.key_if, .key_else] {
 		p.inside_if = true
-		branch_pos := p.tok.position()
+		start_pos := p.tok.position()
 		mut comment := ast.Comment{}
 		if p.tok.kind == .key_if {
 			p.check(.key_if)
@@ -28,9 +28,10 @@ fn (mut p Parser) if_expr() ast.IfExpr {
 			} else {
 				has_else = true
 				p.inside_if = false
+				end_pos := p.prev_tok.position()
 				branches << ast.IfBranch{
 					stmts: p.parse_block()
-					pos: branch_pos
+					pos: start_pos.extend(end_pos)
 					comment: comment
 				}
 				break
@@ -56,6 +57,7 @@ fn (mut p Parser) if_expr() ast.IfExpr {
 		} else {
 			cond = p.expr(0)
 		}
+		end_pos := p.prev_tok.position()
 		p.inside_if = false
 		stmts := p.parse_block()
 		if is_or {
@@ -64,7 +66,7 @@ fn (mut p Parser) if_expr() ast.IfExpr {
 		branches << ast.IfBranch{
 			cond: cond
 			stmts: stmts
-			pos: branch_pos
+			pos: start_pos.extend(end_pos)
 			comment: ast.Comment{}
 		}
 		if p.tok.kind != .key_else {


### PR DESCRIPTION
Use correct node for "unnecessary `()`" error position.
Fix IfBranch position.