### PR TITLE
cmdline: minor optimize

### DIFF
--- a/vlib/os/cmdline/cmdline.v
+++ b/vlib/os/cmdline/cmdline.v
@@ -39,11 +39,9 @@ pub fn option(args []string, param string, def string) string {
 // what: ['test']
 // ret: ['-stat']
 pub fn options_before(args []string, what []string) []string {
-	mut found := false
 	mut args_before := []string
 	for a in args {
 		if a in what {
-			found = true
 			break
 		}
 		args_before << a


### PR DESCRIPTION
This PR minor optimizes cmdline.

- No need to use `mut found` in `options_before`.