### PR TITLE
string: optimize eq

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -340,12 +340,7 @@ fn (s string) eq(a string) bool {
 	if s.len != a.len {
 		return false
 	}
-	for i in 0..s.len {
-		if s[i] != a[i] {
-			return false
-		}
-	}
-	return true
+	return C.memcmp(s.str, a.str, a.len) == 0
 }
 
 // !=


### PR DESCRIPTION
Using the new profiler I saw that `string_eq` was taking up the most time, so I had to optimize it. It now makes use of `C.memcmp`, since it is much faster due to SSE-instructions. This sped up many other functions as well as the compiler. Look at the second field of each "how many nanoseconds in total it took. The 3 listed lines are those who take up most time.

Before:
```
60241 162046369.000000 2689.968111 array_string_contains 
2152817 197131911.000000 91.569284 string_eq 
1 3971074066.000000 3971074066.000000 main 
```

After:
```
60241 136179637.000000 2260.580618 array_string_contains 
2152808 144819343.000000 67.269976 string_eq 
1 3915295253.000000 3915295253.000000 main 
```