### PR TITLE
all: use `a !in b` instead of `!(a in b)`

### DIFF
--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -92,7 +92,7 @@ fn main() {
 	}
 	mut cli_args_no_files := []string
 	for a in os.args {
-		if !(a in files) {
+		if a !in files {
 			cli_args_no_files << a
 		}
 	}

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -364,7 +364,7 @@ fn resolve_dependencies(name, module_path string, module_names []string) {
 	mut deps := []string
 	// filter out dependencies that were already specified by the user
 	for d in vmod.deps {
-		if !(d in module_names) {
+		if d !in module_names {
 			deps << d
 		}
 	}

--- a/examples/mini_calculator.v
+++ b/examples/mini_calculator.v
@@ -7,7 +7,7 @@ const (
 	NUMERIC_CHAR = [`0`,`1`,`2`,`3`,`4`,`5`,`6`,`7`,`8`,`9`,`.`,`e`,`E`]
 )
 
-// Convert expression to Reverse Polish Notation. 
+// Convert expression to Reverse Polish Notation.
 fn expr_to_rev_pol(expr string) ?[]string {
 	if expr == '' {
 		return error('err: empty expression')
@@ -27,11 +27,11 @@ fn expr_to_rev_pol(expr string) ?[]string {
 		else if end_pos==pos {
 			op := expr[pos].str()
 			match op {
-				'(' { 
+				'(' {
 					stack << op
 				}
 				'*', '/' {
-					for stack.len>0 && !(stack.last() in ['(', '+', '-']) {
+					for stack.len>0 && stack.last() !in ['(', '+', '-'] {
 						rev_pol << stack.last()
 						stack.delete(stack.len-1)
 					}
@@ -60,7 +60,7 @@ fn expr_to_rev_pol(expr string) ?[]string {
 	}
 	for stack.len>0 {
 		top := stack.last()
-		rev_pol << top 
+		rev_pol << top
 		stack.delete(stack.len-1)
 	}
 	return rev_pol
@@ -83,7 +83,7 @@ fn eval_rev_pol(rev_pol []string) ?f64 {
 					'+' { stack << oprand_l+oprand_r }
 					'-' { stack << oprand_l-oprand_r }
 					'*' { stack << oprand_l*oprand_r }
-					'/' { 
+					'/' {
 						if oprand_r == 0 {
 							return error('err: divide by zero')
 						}
@@ -102,7 +102,7 @@ fn eval_rev_pol(rev_pol []string) ?f64 {
 
 fn is_num_string(str string) bool {
 	for c in str {
-		if !(c in NUMERIC_CHAR) {
+		if c !in NUMERIC_CHAR {
 			return false
 		}
 	}
@@ -125,7 +125,7 @@ fn main() {
 			eprintln(err)
 			continue
 		}
-		res := eval_rev_pol(rev_pol) or { 
+		res := eval_rev_pol(rev_pol) or {
 			eprintln(err)
 			continue
 		}

--- a/vlib/clipboard/clipboard_linux.c.v
+++ b/vlib/clipboard/clipboard_linux.c.v
@@ -123,7 +123,7 @@ fn new_clipboard() &Clipboard {
 // Initialize a new clipboard of the given selection type.
 // We can initialize multiple clipboard instances and use them separately
 fn new_x11_clipboard(selection AtomType) &Clipboard {
-	if !(selection in [.clipboard, .primary, .secondary]) {
+	if selection !in [.clipboard, .primary, .secondary] {
 		panic("Wrong AtomType. Must be one of .primary, .secondary or .clipboard.")
 	}
 

--- a/vlib/crypto/rand/rand_test.v
+++ b/vlib/crypto/rand/rand_test.v
@@ -18,7 +18,7 @@ fn test_crypto_rand_read() {
 		return
 	}
 	assert r2.len == no_bytes
-	
+
 	mut difference := 0
 	for i, _ in r1 {
 		difference += if r1[i] == r2[i] {0} else {1}
@@ -42,7 +42,7 @@ fn test_crypto_rand_int_u64() {
 			return
 		}
 		n := int(r)
-		if !(n in unique) {
+		if n !in unique {
 			unique << n
 		}
 	}

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -207,7 +207,7 @@ pub fn (req &Request) do() ?Response {
 			return error(err)
 		}
 		resp = qresp
-		if !(resp.status_code in [301, 302, 303, 307, 308]) {
+		if resp.status_code !in [301, 302, 303, 307, 308] {
 			break
 		}
 		// follow any redirects
@@ -315,13 +315,13 @@ fn parse_response(resp string) Response {
 fn (req &Request) build_request_headers(method, host_name, path string) string {
 	ua := req.user_agent
 	mut uheaders := []string
-	if !('Host' in req.headers) {
+	if 'Host' !in req.headers {
 		uheaders << 'Host: $host_name\r\n'
 	}
-	if !('User-Agent' in req.headers) {
+	if 'User-Agent' !in req.headers {
 		uheaders << 'User-Agent: $ua\r\n'
 	}
-	if req.data.len > 0 && !('Content-Length' in req.headers) {
+	if req.data.len > 0 && 'Content-Length' !in req.headers {
 		uheaders << 'Content-Length: ${req.data.len}\r\n'
 	}
 	for key, val in req.headers {

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -247,7 +247,7 @@ pub fn (b Builder) find_module_path(mod, fpath string) ?string {
 	vmod_file_location := vmod.mod_file_cacher.get(fpath)
 	mod_path := module_path(mod)
 	mut module_lookup_paths := []string
-	if vmod_file_location.vmod_file.len != 0 && !(vmod_file_location.vmod_folder in b.module_search_paths) {
+	if vmod_file_location.vmod_file.len != 0 && vmod_file_location.vmod_folder !in b.module_search_paths {
 		module_lookup_paths << vmod_file_location.vmod_folder
 	}
 	module_lookup_paths << b.module_search_paths

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -376,10 +376,10 @@ pub fn (mut c Checker) infix_expr(infix_expr mut ast.InfixExpr) table.Type {
 		else { }
 	}
 	// TODO: Absorb this block into the above single side check block to accelerate.
-	if left_type == table.bool_type && !(infix_expr.op in [.eq, .ne, .logical_or, .and]) {
+	if left_type == table.bool_type && infix_expr.op !in [.eq, .ne, .logical_or, .and] {
 		c.error('bool types only have the following operators defined: `==`, `!=`, `||`, and `&&`',
 			infix_expr.pos)
-	} else if left_type == table.string_type && !(infix_expr.op in [.plus, .eq, .ne, .lt, .gt, .le, .ge]) {
+	} else if left_type == table.string_type && infix_expr.op !in [.plus, .eq, .ne, .lt, .gt, .le, .ge] {
 		// TODO broken !in
 		c.error('string types only have the following operators defined: `==`, `!=`, `<`, `>`, `<=`, `>=`, and `&&`',
 			infix_expr.pos)
@@ -602,7 +602,7 @@ pub fn (mut c Checker) call_fn(call_expr mut ast.CallExpr) table.Type {
 	mut f := table.Fn{}
 	mut found := false
 	// try prefix with current module as it would have never gotten prefixed
-	if !fn_name.contains('.') && !(call_expr.mod in ['builtin', 'main']) {
+	if !fn_name.contains('.') && call_expr.mod !in ['builtin', 'main'] {
 		name_prefixed := '${call_expr.mod}.$fn_name'
 		if f1 := c.table.find_fn(name_prefixed) {
 			call_expr.name = name_prefixed
@@ -746,7 +746,7 @@ pub fn (mut c Checker) check_or_block(call_expr mut ast.CallExpr, ret_type table
 				return
 			}
 			ast.BranchStmt {
-				if !(it.tok.kind in [.key_continue, .key_break]) {
+				if it.tok.kind !in [.key_continue, .key_break] {
 					c.error('only break/continue is allowed as a branch statement in the end of an `or {}` block',
 						it.tok.position())
 					return
@@ -1115,7 +1115,7 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 				it.fields[i].typ = typ
 				for cd in c.const_deps {
 					for j, f in it.fields {
-						if j != i && cd in field_names && cd == f.name && !(j in done_fields) {
+						if j != i && cd in field_names && cd == f.name && j !in done_fields {
 							needs_order = true
 							x := field_order[j]
 							field_order[j] = field_order[i]
@@ -1157,7 +1157,7 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 			c.fn_return_type = it.return_type
 			c.stmts(it.stmts)
 			if !it.is_c && !it.is_js && !it.no_body && it.return_type != table.void_type &&
-				!c.returns && !(it.name in ['panic', 'exit']) {
+				!c.returns && it.name !in ['panic', 'exit'] {
 				c.error('missing return at end of function `$it.name`', it.pos)
 			}
 			c.returns = false
@@ -1278,7 +1278,7 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 			type_sym := c.table.get_type_symbol(it.typ)
 			if expr_type_sym.kind == .sum_type {
 				info := expr_type_sym.info as table.SumType
-				if !(it.typ in info.variants) {
+				if it.typ !in info.variants {
 					c.error('cannot cast `$expr_type_sym.name` to `$type_sym.name`', it.pos)
 					// c.error('only $info.variants can be casted to `$typ`', it.pos)
 				}
@@ -1429,7 +1429,7 @@ pub fn (mut c Checker) ident(ident mut ast.Ident) table.Type {
 	// TODO: move this
 	if c.const_deps.len > 0 {
 		mut name := ident.name
-		if !name.contains('.') && !(ident.mod in ['builtin', 'main']) {
+		if !name.contains('.') && ident.mod !in ['builtin', 'main'] {
 			name = '${ident.mod}.$ident.name'
 		}
 		if name == c.const_decl {
@@ -1479,7 +1479,7 @@ pub fn (mut c Checker) ident(ident mut ast.Ident) table.Type {
 		}
 		// prepend mod to look for fn call or const
 		mut name := ident.name
-		if !name.contains('.') && !(ident.mod in ['builtin', 'main']) {
+		if !name.contains('.') && ident.mod !in ['builtin', 'main'] {
 			name = '${ident.mod}.$ident.name'
 		}
 		if obj := c.file.global_scope.find(name) {
@@ -1783,7 +1783,7 @@ pub fn (mut c Checker) enum_val(node mut ast.EnumVal) table.Type {
 	info := typ_sym.enum_info()
 	// rintln('checker: x = $info.x enum val $c.expected_type $typ_sym.name')
 	// println(info.vals)
-	if !(node.val in info.vals) {
+	if node.val !in info.vals {
 		c.error('enum `$typ_sym.name` does not have a value `$node.val`', node.pos)
 	}
 	node.typ = typ
@@ -1854,7 +1854,7 @@ fn (mut c Checker) warn_or_error(message string, pos token.Position, warn bool) 
 		}
 	} else {
 		c.nr_errors++
-		if !(pos.line_nr in c.error_lines) {
+		if pos.line_nr !in c.error_lines {
 			c.errors << scanner.Error{
 				reporter: scanner.Reporter.checker
 				pos: pos

--- a/vlib/v/depgraph/depgraph.v
+++ b/vlib/v/depgraph/depgraph.v
@@ -24,7 +24,7 @@ mut:
 }
 
 pub fn (o mut OrderedDepMap) set(name string, deps []string) {
-	if !(name in o.data) {
+	if name !in o.data {
 		o.keys << name
 	}
 	o.data[name] = deps
@@ -33,7 +33,7 @@ pub fn (o mut OrderedDepMap) set(name string, deps []string) {
 pub fn (o mut OrderedDepMap) add(name string, deps []string) {
 	mut d := o.data[name]
 	for dep in deps {
-		if !(dep in d) {
+		if dep !in d {
 			d << dep
 		}
 	}
@@ -45,7 +45,7 @@ pub fn (o &OrderedDepMap) get(name string) []string {
 }
 
 pub fn (o mut OrderedDepMap) delete(name string) {
-	if !(name in o.data) {
+	if name !in o.data {
 		panic('delete: no such key: $name')
 	}
 	for i, _ in o.keys {
@@ -60,7 +60,7 @@ pub fn (o mut OrderedDepMap) delete(name string) {
 pub fn (o mut OrderedDepMap) apply_diff(name string, deps []string) {
 	mut diff := []string
 	for dep in o.data[name] {
-		if !(dep in deps) {
+		if dep !in deps {
 			diff << dep
 		}
 	}
@@ -141,7 +141,7 @@ pub fn (graph &DepGraph) display_cycles() string {
 	mut out := '\n'
 	for node in graph.nodes {
 		for dep in node.deps {
-			if !(dep in node_names) {
+			if dep !in node_names {
 				continue
 			}
 			dn := node_names[dep]

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -109,7 +109,7 @@ fn (mut f Fmt) imports(imports []ast.Import) {
 	*/
 	// f.out_imports.writeln('import (')
 	for imp in imports {
-		if !(imp.mod in f.used_imports) {
+		if imp.mod !in f.used_imports {
 			// TODO bring back once only unused imports are removed
 			// continue
 		}
@@ -886,7 +886,7 @@ fn (mut f Fmt) call_expr(node ast.CallExpr) {
 			// a `node.left` expression. Import `time` automatically.
 			// TODO fetch all available modules
 			if it.name in ['time', 'os', 'strings', 'math', 'json', 'base64'] {
-				if !(it.name in f.auto_imports) {
+				if it.name !in f.auto_imports {
 					f.auto_imports << it.name
 					f.file.imports << ast.Import{
 						mod: it.name

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -271,7 +271,7 @@ pub fn (mut g Gen) typ(t table.Type) string {
 		if t.is_ptr() {
 			styp = styp.replace('*', '_ptr')
 		}
-		if !(styp in g.optionals) {
+		if styp !in g.optionals {
 			// println(styp)
 			x := styp // .replace('*', '_ptr')			// handle option ptrs
 			g.typedefs2.writeln('typedef Option $x;')
@@ -1377,7 +1377,7 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 	} else if node.op in [.eq, .ne] && left_sym.kind == .array && right_sym.kind == .array {
 		styp := g.table.value_type(node.left_type)
 		ptr_typ := g.typ(node.left_type).split('_')[1]
-		if !(ptr_typ in g.array_fn_definitions) {
+		if ptr_typ !in g.array_fn_definitions {
 			sym := g.table.get_type_symbol(left_sym.array_info().elem_type)
 			g.generate_array_equality_fn(ptr_typ, styp, sym)
 		}
@@ -2197,7 +2197,7 @@ fn (mut g Gen) write_builtin_types() {
 fn (mut g Gen) write_sorted_types() {
 	mut types := []table.TypeSymbol // structs that need to be sorted
 	for typ in g.table.types {
-		if !(typ.name in builtins) {
+		if typ.name !in builtins {
 			types << typ
 		}
 	}
@@ -2294,7 +2294,7 @@ fn (g Gen) sort_structs(typesa []table.TypeSymbol) []table.TypeSymbol {
 				for field in info.fields {
 					dep := g.table.get_type_symbol(field.typ).name
 					// skip if not in types list or already in deps
-					if !(dep in type_names) || dep in field_deps || field.typ.is_ptr() {
+					if dep !in type_names || dep in field_deps || field.typ.is_ptr() {
 						continue
 					}
 					field_deps << dep
@@ -3016,7 +3016,7 @@ fn (mut g Gen) gen_str_for_type_with_styp(typ table.Type, styp string) string {
 	str_fn_name := styp_to_str_fn_name(styp)
 	already_generated_key := '${styp}:${str_fn_name}'
 	// generate for type
-	if !sym.has_method('str') && !(already_generated_key in g.str_types) {
+	if !sym.has_method('str') && already_generated_key !in g.str_types {
 		g.str_types << already_generated_key
 		match sym.info {
 			table.Alias { g.gen_str_default(sym, styp, str_fn_name) }
@@ -3031,7 +3031,7 @@ fn (mut g Gen) gen_str_for_type_with_styp(typ table.Type, styp string) string {
 	// if varg, generate str for varg
 	if typ.flag_is(.variadic) {
 		varg_already_generated_key := 'varg_$already_generated_key'
-		if !(varg_already_generated_key in g.str_types) {
+		if varg_already_generated_key !in g.str_types {
 			g.gen_str_for_varg(styp, str_fn_name)
 			g.str_types << varg_already_generated_key
 		}

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -180,7 +180,7 @@ fn (mut g Gen) fn_args(args []table.Arg, is_variadic bool) {
 		is_varg := i == args.len - 1 && is_variadic
 		if is_varg {
 			varg_type_str := int(arg.typ).str()
-			if !(varg_type_str in g.variadic_args) {
+			if varg_type_str !in g.variadic_args {
 				g.variadic_args[varg_type_str] = 0
 			}
 			arg_type_name = 'varg_' + g.typ(arg.typ).replace('*', '_ptr')

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -71,7 +71,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 		for p.tok.kind != .rcbr {
 			key := p.check_name()
 			p.check(.colon)
-			if !(key in ['len', 'cap', 'init']) {
+			if key !in ['len', 'cap', 'init'] {
 				p.error('wrong field `$key`, expecting `len`, `cap`, or `init`')
 			}
 			p.expr(0)

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -148,7 +148,7 @@ pub fn (mut p Parser) parse_any_type(is_c, is_js, is_ptr bool) table.Type {
 		name = '${p.imports[name]}.$p.tok.lit'
 	} else if p.expr_mod != '' {
 		name = p.expr_mod + '.' + name
-	} else if !(p.mod in ['builtin', 'main']) && !(name in table.builtin_type_names) {
+	} else if p.mod !in ['builtin', 'main'] && name !in table.builtin_type_names {
 		// `Foo` in module `mod` means `mod.Foo`
 		name = p.mod + '.' + name
 	}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -638,7 +638,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 		// type cast. TODO: finish
 		// if name in table.builtin_type_names {
 		if !known_var && (name in p.table.type_idxs || name_w_mod in p.table.type_idxs) &&
-			!(name in ['C.stat', 'C.sigaction']) {
+			name !in ['C.stat', 'C.sigaction'] {
 			// TODO handle C.stat()
 			mut to_typ := p.parse_type()
 			if p.is_amp {

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -269,7 +269,7 @@ fn (s mut Scanner) ident_dec_number() string {
 			}
 			// 5.
 			else if s.text[s.pos] != `)` {
-				is_float_without_fraction = true 
+				is_float_without_fraction = true
 				s.pos--
 			}
 		}
@@ -761,7 +761,7 @@ pub fn (s mut Scanner) scan() token.Token {
 					// Find out if this comment is on its own line (for vfmt)
 					mut is_separate_line_comment := true
 					for j := start-2; j >= 0 && s.text[j] != `\n`; j-- {
-						if !(s.text[j] in [`\t`, ` `]) {
+						if s.text[j] !in [`\t`, ` `] {
 							is_separate_line_comment = false
 						}
 					}

--- a/vlib/v/tests/in_expression_test.v
+++ b/vlib/v/tests/in_expression_test.v
@@ -21,14 +21,14 @@ fn test_in_expression() {
 	assert a == false
 	a = true && 3 in arr1
 	assert a == false
-	a = true && !(2 in arr2)
+	a = true && 2 !in arr2
 	assert a == false
-	a = true && !(3 in arr2)
+	a = true && 3 !in arr2
 	assert a == true
 
-	a = true && (2 !in arr2)
+	a = true && 2 !in arr2
 	assert a == false
-	a = true && (3 !in arr2)
+	a = true && 3 !in arr2
 	assert a == true
 
 	a = 1 in arr1 && true
@@ -88,14 +88,14 @@ fn test_in_expression_with_string() {
 	assert a == false
 	a = true && 'abc' in arr1
 	assert a == false
-	a = true && !('bc' in arr2)
+	a = true && 'bc' !in arr2
 	assert a == false
-	a = true && !('abc' in arr2)
+	a = true && 'abc' !in arr2
 	assert a == true
 
-	a = true && ('bc' !in arr2)
+	a = true && 'bc' !in arr2
 	assert a == false
-	a = true && ('abc' !in arr2)
+	a = true && 'abc' !in arr2
 	assert a == true
 
 	a = 'ab' in arr1 && true
@@ -137,14 +137,14 @@ fn test_optimized_in_expression() {
 	assert a == false
 	a = true && 3 in [1, 2]
 	assert a == false
-	a = true && !(2 in [0, 2])
+	a = true && 2 !in [0, 2]
 	assert a == false
-	a = true && !(3 in [0, 2])
+	a = true && 3 !in [0, 2]
 	assert a == true
 
-	a = true && (2 !in [0, 2])
+	a = true && 2 !in [0, 2]
 	assert a == false
-	a = true && (3 !in [0, 2])
+	a = true && 3 !in [0, 2]
 	assert a == true
 
 	a = 1 in [1, 2] && true
@@ -168,14 +168,14 @@ fn test_optimized_in_expression_with_enum() {
 	assert a == false
 	a = true && Colors.yellow in [.green, .blue]
 	assert a == false
-	a = true && !(Colors.blue in [.red, .blue])
+	a = true && Colors.blue !in [.red, .blue]
 	assert a == false
-	a = true && !(Colors.yellow in [.red, .blue])
+	a = true && Colors.yellow !in [.red, .blue]
 	assert a == true
 
-	a = true && (Colors.blue !in [.red, .blue])
+	a = true && Colors.blue !in [.red, .blue]
 	assert a == false
-	a = true && (Colors.yellow !in [.red, .blue])
+	a = true && Colors.yellow !in [.red, .blue]
 	assert a == true
 
 	a = Colors.green in [.green, .blue] && true
@@ -199,14 +199,14 @@ fn test_optimized_in_expression_with_string() {
 	assert a == false
 	a = true && 'abc' in ['ab', 'bc']
 	assert a == false
-	a = true && !('bc' in ['', 'bc'])
+	a = true && 'bc' !in ['', 'bc']
 	assert a == false
-	a = true && !('abc' in ['', 'bc'])
+	a = true && 'abc' !in ['', 'bc']
 	assert a == true
 
-	a = true && ('bc' !in ['', 'bc'])
+	a = true && 'bc' !in ['', 'bc']
 	assert a == false
-	a = true && ('abc' !in ['', 'bc'])
+	a = true && 'abc' !in ['', 'bc']
 	assert a == true
 
 	a = 'ab' in ['ab', 'bc'] && true

--- a/vlib/v/tests/live_test.v
+++ b/vlib/v/tests/live_test.v
@@ -29,7 +29,7 @@ fn main() {
 
 //
 fn testsuite_begin() {
-	if !(os.user_os() in ['linux', 'solaris']) && os.getenv('FORCE_LIVE_TEST').len == 0 {
+	if os.user_os() !in ['linux', 'solaris'] && os.getenv('FORCE_LIVE_TEST').len == 0 {
 		eprintln('Testing the runtime behaviour of -live mode,')
 		eprintln('is reliable only on Linux for now.')
 		eprintln('You can still do it by setting FORCE_LIVE_TEST=1 .')

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -293,7 +293,7 @@ fn handle_conn<T>(conn net.Socket, app mut T) {
 }
 
 fn (ctx mut Context) parse_form(s string) {
-	if !(ctx.req.method in methods_with_form) {
+	if ctx.req.method !in methods_with_form {
 		return
 	}
 	//pos := s.index('\r\n\r\n')


### PR DESCRIPTION
This PR use `a !in b` instead of `!(a in b)` in all related files.

- It looks more natural.