### PR TITLE
cgen: fix struct with fixed array error

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3132,10 +3132,14 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp, str_fn_name string) {
 				g.auto_str_funcs.write('indents.len, indents.str, ')
 				g.auto_str_funcs.write('${field_styp_fn_name}( it->${field.name} ).len, ')
 				g.auto_str_funcs.write('${field_styp_fn_name}( it->${field.name} ).str  ')
-			} else if sym.kind in [.struct_, .array, .array_fixed] {
+			} else if sym.kind == .struct_ {
 				g.auto_str_funcs.write('indents.len, indents.str, ')
 				g.auto_str_funcs.write('${field_styp_fn_name}( it->${field.name}${second_str_param} ).len, ')
 				g.auto_str_funcs.write('${field_styp_fn_name}( it->${field.name}${second_str_param} ).str  ')
+			} else if sym.kind in [.array, .array_fixed] {
+				g.auto_str_funcs.write('indents.len, indents.str, ')
+				g.auto_str_funcs.write('${field_styp_fn_name}( it->${field.name}).len, ')
+				g.auto_str_funcs.write('${field_styp_fn_name}( it->${field.name}).str  ')
 			} else {
 				g.auto_str_funcs.write('indents.len, indents.str, it->${field.name}')
 				if field.typ == table.string_type {
@@ -3167,11 +3171,11 @@ fn (mut g Gen) gen_str_for_array(info table.Array, styp, str_fn_name string) {
 	g.auto_str_funcs.writeln('\tfor (int i = 0; i < a.len; i++) {')
 	g.auto_str_funcs.writeln('\t\t${field_styp} it = (*(${field_styp}*)array_get(a, i));')
 	if sym.kind == .struct_ && !sym.has_method('str') {
-		g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write(&sb, ${field_styp}_str(it,0));')
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, ${field_styp}_str(it,0));')
 	} else if sym.kind in [.f32, .f64] {
-		g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write(&sb, _STR("%g", it));')
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("%g", it));')
 	} else {
-		g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write(&sb, ${field_styp}_str(it));')
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, ${field_styp}_str(it));')
 	}
 	g.auto_str_funcs.writeln('\t\tif (i != a.len-1) {')
 	g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write(&sb, tos3(", "));')
@@ -3194,13 +3198,13 @@ fn (mut g Gen) gen_str_for_array_fixed(info table.ArrayFixed, styp, str_fn_name 
 	g.auto_str_funcs.writeln('\tstrings__Builder_write(&sb, tos3("["));')
 	g.auto_str_funcs.writeln('\tfor (int i = 0; i < $info.size; i++) {')
 	if sym.kind == .struct_ && !sym.has_method('str') {
-		g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write(&sb, ${field_styp}_str(a[i],0));')
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, ${field_styp}_str(a[i],0));')
 	} else if sym.kind in [.f32, .f64] {
-		g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write(&sb, _STR("%g", a[i]));')
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("%g", a[i]));')
 	} else if sym.kind == .string {
-		g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write(&sb, _STR("\\"%.*s\\"", a[i].len, a[i].str));')
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("\\"%.*s\\"", a[i].len, a[i].str));')
 	} else {
-		g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write(&sb, ${field_styp}_str(a[i]));')
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, ${field_styp}_str(a[i]));')
 	}
 	g.auto_str_funcs.writeln('\t\tif (i != $info.size-1) {')
 	g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write(&sb, tos3(", "));')

--- a/vlib/v/tests/string_interpolation_struct_test.v
+++ b/vlib/v/tests/string_interpolation_struct_test.v
@@ -18,3 +18,18 @@ fn test_default_struct_string_interpolation() {
 	assert s.contains('}')
 	// println(s)
 }
+
+struct Context {
+pub mut:
+	vb [8]f64
+}
+
+fn test_fixed_array_struct_string_interpolation() {
+	mut ctx := Context{}
+	x := 2.32
+	ctx.vb = [1.1, x, 3.3, 4.4, 5.0, 6.0, 7.0, 8.9]!!
+	s := '$ctx'
+	assert s.contains('Context {')
+	assert s.contains('vb: [1.1, 2.32, 3.3, 4.4, 5, 6, 7, 8.9]')
+	assert s.contains('}')
+}


### PR DESCRIPTION
This PR fix struct with fixed array error.

- Fix  struct with fixed array error in `gen_str_for_struct`.
- Add tests for it in `vlib\v\tests\string_interpolation_struct_test.v`.

```v
struct Context {
pub mut:
	vb [8]f64
}

fn test_fixed_array_struct_string_interpolation() {
	mut ctx := Context{}
	x := 2.32
	ctx.vb = [1.1, x, 3.3, 4.4, 5.0, 6.0, 7.0, 8.9]!!
	s := '$ctx'
	assert s.contains('Context {')
	assert s.contains('vb: [1.1, 2.32, 3.3, 4.4, 5, 6, 7, 8.9]')
	assert s.contains('}')
}
```