### PR TITLE
cgen: optimize map_to_string format

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3204,17 +3204,17 @@ fn (mut g Gen) gen_str_for_map(info table.Map, styp, str_fn_name string) {
 	g.definitions.writeln('string ${str_fn_name}($styp m); // auto')
 	g.auto_str_funcs.writeln('string ${str_fn_name}($styp m) { /* gen_str_for_map */')
 	g.auto_str_funcs.writeln('\tstrings__Builder sb = strings__new_builder(m.key_values.size*10);')
-	g.auto_str_funcs.writeln('\tstrings__Builder_write(&sb, tos3("$styp"));')
 	g.auto_str_funcs.writeln('\tstrings__Builder_write(&sb, tos3("{"));')
 	g.auto_str_funcs.writeln('\tfor (unsigned int i = 0; i < m.key_values.size; i++) {')
-	g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, (*(string*)DenseArray_get(m.key_values, i)));')
+	g.auto_str_funcs.writeln('\t\tstring key = (*(string*)DenseArray_get(m.key_values, i));')
+	g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("\\"%.*s\\"", key.len, key.str));')
 	g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, tos3(": "));')
 	g.auto_str_funcs.write('\t$val_styp it = (*($val_styp*)map_get3(')
 	g.auto_str_funcs.write('m, (*(string*)DenseArray_get(m.key_values, i))')
 	g.auto_str_funcs.write(', ')
 	g.auto_str_funcs.writeln(' &($val_styp[]) { $zero }));')
 	if val_sym.kind == .string {
-		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, it);')
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("\\"%.*s\\"", it.len, it.str));')
 	} else if val_sym.kind == .struct_ && !val_sym.has_method('str') {
 		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, ${val_styp}_str(it,0));')
 	} else if val_sym.kind in [.f32, .f64] {

--- a/vlib/v/tests/map_to_string_test.v
+++ b/vlib/v/tests/map_to_string_test.v
@@ -5,28 +5,34 @@ struct Test {
 }
 
 fn test_interpolation_map_to_string() {
-	if true {
-
-	}
-	//
-	else{}
 	mut a := map[string]string
 	a['1'] = 'one'
 	a['2'] = 'two'
 	a['3'] = 'three'
-	assert '$a' == 'map_string_string{1: one, 2: two, 3: three}'
+	assert '$a' == '{"1": "one", "2": "two", "3": "three"}'
+
 	mut b := map[string]int
 	b['1'] = 1
 	b['2'] = 2
 	b['3'] = 3
-	assert '$b' == 'map_string_int{1: 1, 2: 2, 3: 3}'
+	assert '$b' == '{"1": 1, "2": 2, "3": 3}'
+
 	mut c := map[string]bool
 	c['1'] = true
 	c['2'] = false
-	assert '$c' == 'map_string_bool{1: true, 2: false}'
-	mut d := map[string]Test
-	d['1'] = Test{true, 0, 'abc'}
-	d['2'] = Test{true, 1, 'def'}
-	d['3'] = Test{false, 2, 'ghi'}
-	assert '$d'.replace('\n', '').replace('\'', '"') == 'map_string_Test{1: Test {    a: true    b: 0    y: "abc"}, 2: Test {    a: true    b: 1    y: "def"}, 3: Test {    a: false    b: 2    y: "ghi"}}'
+	assert '$c' == '{"1": true, "2": false}'
+
+	d := {'f1': 1.1, 'f2': 2.2, 'f3': 3.3, 'f4': 4.4}
+	assert '$d' == '{"f1": 1.1, "f2": 2.2, "f3": 3.3, "f4": 4.4}'
+
+	mut e := map[string]Test
+	e['1'] = Test{true, 0, 'abc'}
+	e['2'] = Test{true, 1, 'def'}
+	e['3'] = Test{false, 2, 'ghi'}
+	s := '$e'
+	assert s.contains('{"1": Test {')
+	assert s.contains('a: true')
+	assert s.contains("y: 'abc'")
+	assert s.contains('}, "2": Test {')
+	assert s.contains("y: 'def'")
 }


### PR DESCRIPTION
This PR optimize map_to_string format.

```v
d := {'f1': 1.1, 'f2': 2.2, 'f3': 3.3, 'f4': 4.4}
assert '$d' == '{"f1": 1.1, "f2": 2.2, "f3": 3.3, "f4": 4.4}'
```
```v
mut a := map[string]string
a['1'] = 'one'
a['2'] = 'two'
a['3'] = 'three'
assert '$a' == '{"1": "one", "2": "two", "3": "three"}'
```