### PR TITLE
map: remove malloc and memcpy from get

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -211,7 +211,7 @@ fn new_map_init(n, value_bytes int, keys &string, values voidptr) map {
 }
 
 [inline]
-fn (m map) key_to_index(key string) (u32,u32) {
+fn (m &map) key_to_index(key string) (u32,u32) {
 	hash := wyhash.wyhash_c(key.str, u64(key.len), 0)
 	index := hash & m.cap
 	meta := ((hash>>m.shift) & hash_mask) | probe_inc
@@ -219,7 +219,7 @@ fn (m map) key_to_index(key string) (u32,u32) {
 }
 
 [inline]
-fn (m map) meta_less(_index u32, _metas u32) (u32,u32) {
+fn (m &map) meta_less(_index u32, _metas u32) (u32,u32) {
 	mut index := _index
 	mut meta := _metas
 	for meta < m.metas[index] {
@@ -348,9 +348,7 @@ fn (m map) get3(key string, zero voidptr) voidptr {
 	for meta == m.metas[index] {
 		kv_index := m.metas[index + 1]
 		if fast_string_eq(key, m.key_values.data[kv_index].key) {
-			out := malloc(m.value_bytes)
-			C.memcpy(out, m.key_values.data[kv_index].value, m.value_bytes)
-			return out
+			return m.key_values.data[kv_index].value
 		}
 		index += 2
 		meta += probe_inc


### PR DESCRIPTION
Remove the copying of the output value. Much better performance:

Before:
```
132318         42.493ms            321ns map_get3 
```

After:
```
132296         33.781ms            255ns map_get3 
```