### PR TITLE
cgen: fix `map` `fixed-array` .str() error

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -647,12 +647,7 @@ pub fn (mut c Checker) call_method(call_expr mut ast.CallExpr) table.Type {
 		return method.return_type
 	}
 	// TODO: str methods
-	if left_type_sym.kind == .map && method_name == 'str' {
-		call_expr.receiver_type = table.new_type(c.table.type_idxs['map_string'])
-		call_expr.return_type = table.string_type
-		return table.string_type
-	}
-	if left_type_sym.kind == .array && method_name == 'str' {
+	if method_name == 'str' {
 		call_expr.receiver_type = left_type
 		call_expr.return_type = table.string_type
 		return table.string_type

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -244,16 +244,12 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		return
 	}
 	if node.name == 'str' {
-		typ := node.receiver_type
-		mut styp := g.typ(typ)
-		if typ.is_ptr() {
+		mut styp := g.typ(node.receiver_type)
+		if node.receiver_type.is_ptr() {
 			styp = styp.replace('*', '')
 		}
-		g.gen_str_for_type_with_styp(typ, styp)
+		g.gen_str_for_type_with_styp(node.receiver_type, styp)
 	}
-	// if node.name == 'str' && !typ_sym.has_method('str') {
-	// 	g.gen_str_for_type(node.receiver_type)
-	// }
 	// TODO performance, detect `array` method differently
 	if typ_sym.kind == .array && node.name in ['repeat', 'sort_with_compare', 'free', 'push_many',
 		'trim',

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -243,9 +243,17 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		g.gen_filter(node)
 		return
 	}
-	if node.name == 'str' && !typ_sym.has_method('str') {
-		g.gen_str_for_type(node.receiver_type)
+	if node.name == 'str' {
+		typ := node.receiver_type
+		mut styp := g.typ(typ)
+		if typ.is_ptr() {
+			styp = styp.replace('*', '')
+		}
+		g.gen_str_for_type_with_styp(typ, styp)
 	}
+	// if node.name == 'str' && !typ_sym.has_method('str') {
+	// 	g.gen_str_for_type(node.receiver_type)
+	// }
 	// TODO performance, detect `array` method differently
 	if typ_sym.kind == .array && node.name in ['repeat', 'sort_with_compare', 'free', 'push_many',
 		'trim',

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -53,3 +53,89 @@ fn test_array_of_strings() {
 	assert aa.str() == "['aa', 'bb', 'cc']"
 	assert '$aa' == "['aa', 'bb', 'cc']"
 }
+
+fn test_map_of_ints() {
+	aa := {'a': 1, 'b': 2, 'c': 3}
+	assert aa.str() == "{'a': 1, 'b': 2, 'c': 3}"
+	assert '$aa' == "{'a': 1, 'b': 2, 'c': 3}"
+}
+
+fn test_map_of_strings() {
+	aa := {'a': '1', 'b': '2', 'c': '3'}
+	assert aa.str() == "{'a': '1', 'b': '2', 'c': '3'}"
+	assert '$aa' == "{'a': '1', 'b': '2', 'c': '3'}"
+}
+
+fn test_map_of_floats() {
+	aa := {'a': 1.1, 'b': 2.2, 'c': 3.3}
+	assert aa.str() == "{'a': 1.1, 'b': 2.2, 'c': 3.3}"
+	assert '$aa' == "{'a': 1.1, 'b': 2.2, 'c': 3.3}"
+}
+
+fn test_map_of_bytes() {
+	aa := {'a': `a`, 'b': `b`, 'c': `c`}
+	assert aa.str() == "{'a': a, 'b': b, 'c': c}"
+	assert '$aa' == "{'a': a, 'b': b, 'c': c}"
+}
+
+fn test_map_of_bools() {
+	aa := {'a': true, 'b': false, 'c': true}
+	assert aa.str() == "{'a': true, 'b': false, 'c': true}"
+	assert '$aa' == "{'a': true, 'b': false, 'c': true}"
+}
+
+fn test_fixed_array_of_floats() {
+	// f64 array
+	aa := [1.2, 3.4, 5.67]!!
+	assert aa.str() == '[1.2, 3.4, 5.67]'
+	assert '$aa' == '[1.2, 3.4, 5.67]'
+	// f32 array
+	bb := [f32(1.2), 3.4, 5.67]!!
+	assert bb.str() == '[1.2, 3.4, 5.67]'
+	assert '$bb' == '[1.2, 3.4, 5.67]'
+}
+
+fn test_fixed_array_of_bools() {
+	aa := [true, false, true]!!
+	assert aa.str() == '[true, false, true]'
+	assert '$aa' == '[true, false, true]'
+}
+
+fn test_fixed_array_of_ints() {
+	// int
+	a1 := [11, 22, 33]!!
+	assert a1.str() == '[11, 22, 33]'
+	assert '$a1' == '[11, 22, 33]'
+	// u32
+	a2 := [u32(11), 22, 33]!!
+	assert a2.str() == '[11, 22, 33]'
+	assert '$a2' == '[11, 22, 33]'
+	// i16
+	b1 := [i16(11), 22, 33]!!
+	assert b1.str() == '[11, 22, 33]'
+	assert '$b1' == '[11, 22, 33]'
+	// u16
+	b2 := [u16(11), 22, 33]!!
+	assert b2.str() == '[11, 22, 33]'
+	assert '$b2' == '[11, 22, 33]'
+	// i64
+	c1 := [i64(11), 22, 33]!!
+	assert c1.str() == '[11, 22, 33]'
+	assert '$c1' == '[11, 22, 33]'
+	// u64
+	c2 := [u64(11), 22, 33]!!
+	assert c2.str() == '[11, 22, 33]'
+	assert '$c2' == '[11, 22, 33]'
+}
+
+fn test_fixed_array_of_bytes() {
+	aa := [`a`, `b`, `c`]!!
+	assert aa.str() == '[a, b, c]'
+	assert '$aa' == '[a, b, c]'
+}
+
+fn test_fixed_array_of_strings() {
+	aa := ['aa', 'bb', 'cc']!!
+	assert aa.str() == "['aa', 'bb', 'cc']"
+	assert '$aa' == "['aa', 'bb', 'cc']"
+}


### PR DESCRIPTION
This PR fix `map` `fixed-array` .str() error.

- Fix `map` `fixed-array` .str() error.
- Add tests in str_gen_test.v.

```v
fn test_map_of_ints() {
	aa := {'a': 1, 'b': 2, 'c': 3}
	assert aa.str() == "{'a': 1, 'b': 2, 'c': 3}"
	assert '$aa' == "{'a': 1, 'b': 2, 'c': 3}"
}
```
```v
fn test_fixed_array_of_floats() {
	// f64 array
	aa := [1.2, 3.4, 5.67]!!
	assert aa.str() == '[1.2, 3.4, 5.67]'
	assert '$aa' == '[1.2, 3.4, 5.67]'
	// f32 array
	bb := [f32(1.2), 3.4, 5.67]!!
	assert bb.str() == '[1.2, 3.4, 5.67]'
	assert '$bb' == '[1.2, 3.4, 5.67]'
}
```