### PR TITLE
checker: check main function called error (fix #4621)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -677,6 +677,9 @@ pub fn (mut c Checker) call_fn(call_expr mut ast.CallExpr) table.Type {
 		c.returns = true
 	}
 	fn_name := call_expr.name
+	if fn_name == 'main' {
+		c.error('the `main` function cannot be called in the program', call_expr.pos)
+	}
 	if fn_name == 'typeof' {
 		// TODO: impl typeof properly (probably not going to be a fn call)
 		return table.string_type

--- a/vlib/v/checker/tests/main_called_err.out
+++ b/vlib/v/checker/tests/main_called_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/main_called_err.v:2:2: error: the `main` function cannot be called in the program
+    1| fn main() {
+    2|     main()
+           ~~~~~~
+    3| }

--- a/vlib/v/checker/tests/main_called_err.v
+++ b/vlib/v/checker/tests/main_called_err.v
@@ -1,0 +1,3 @@
+fn main() {
+	main()
+}

--- a/vlib/v/checker/tests/main_called_err.vv
+++ b/vlib/v/checker/tests/main_called_err.vv
@@ -1,0 +1,3 @@
+fn main() {
+	main()
+}


### PR DESCRIPTION
This PR check main function called error (fix #4621).

- Check main function called.
- Add `main_called_err.vv` tests.

```v
D:\test\v\tt1>v run .
.\tt1.v:2:2: error: the `main` function cannot be called in the program
    1| fn main() {
    2|     main()
           ~~~~~~
    3| }
```