### PR TITLE
checker: check division by zero error (fix #4620)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -355,8 +355,8 @@ pub fn (mut c Checker) infix_expr(infix_expr mut ast.InfixExpr) table.Type {
 			return table.bool_type
 		}
 		.plus, .minus, .mul, .div {
-			if infix_expr.op == .div && right.is_int() &&
-				infix_expr.right is ast.IntegerLiteral && infix_expr.right.str().int() == 0 {
+			if infix_expr.op == .div && infix_expr.right is ast.IntegerLiteral &&
+				 infix_expr.right.str().int() == 0 {
 				c.error('division by zero', infix_expr.right.position())
 			}
 			if left.kind in [.array, .array_fixed, .map, .struct_] && !left.has_method(infix_expr.op.str()) {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -355,6 +355,10 @@ pub fn (mut c Checker) infix_expr(infix_expr mut ast.InfixExpr) table.Type {
 			return table.bool_type
 		}
 		.plus, .minus, .mul, .div {
+			if infix_expr.op == .div && right.is_int() &&
+				infix_expr.right is ast.IntegerLiteral && infix_expr.right.str().int() == 0 {
+				c.error('the integer division by zero is not allowed', infix_expr.right.position())
+			}
 			if left.kind in [.array, .array_fixed, .map, .struct_] && !left.has_method(infix_expr.op.str()) {
 				c.error('mismatched types `$left.name` and `$right.name`', infix_expr.left.position())
 			} else if right.kind in [.array, .array_fixed, .map, .struct_] && !right.has_method(infix_expr.op.str()) {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -357,7 +357,7 @@ pub fn (mut c Checker) infix_expr(infix_expr mut ast.InfixExpr) table.Type {
 		.plus, .minus, .mul, .div {
 			if infix_expr.op == .div && right.is_int() &&
 				infix_expr.right is ast.IntegerLiteral && infix_expr.right.str().int() == 0 {
-				c.error('the integer division by zero is not allowed', infix_expr.right.position())
+				c.error('division by zero', infix_expr.right.position())
 			}
 			if left.kind in [.array, .array_fixed, .map, .struct_] && !left.has_method(infix_expr.op.str()) {
 				c.error('mismatched types `$left.name` and `$right.name`', infix_expr.left.position())

--- a/vlib/v/checker/tests/division_by_zero_err.out
+++ b/vlib/v/checker/tests/division_by_zero_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/division_by_zero_err.v:2:12: error: the integer division by zero is not allowed
+    1| fn main() {
+    2|     println(1/0)
+                     ^
+    3| }

--- a/vlib/v/checker/tests/division_by_zero_err.out
+++ b/vlib/v/checker/tests/division_by_zero_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/division_by_zero_err.v:2:12: error: the integer division by zero is not allowed
+vlib/v/checker/tests/division_by_zero_err.v:2:12: error: division by zero
     1| fn main() {
     2|     println(1/0)
                      ^

--- a/vlib/v/checker/tests/division_by_zero_err.vv
+++ b/vlib/v/checker/tests/division_by_zero_err.vv
@@ -1,0 +1,3 @@
+fn main() {
+	println(1/0)
+}


### PR DESCRIPTION
This PR check division by zero error (fix #4620).

- Check division by zero error.
- Add tests in `devision_by_zero_err.vv`.

```v
D:\test\v\tt1>v run .
.\tt1.v:2:12: error: the integer division by zero is not allowed
    1| fn main() {
    2|     println(1/0)
                     ^
    3| }
```