### PR TITLE
checker: check struct field name duplicate (fix #4634)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -203,7 +203,13 @@ pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
 		}
 		c.error('struct name must begin with capital letter', pos)
 	}
+	mut field_names := []string{}
 	for field in decl.fields {
+		if field.name in field_names {
+			c.error('field name `$field.name` duplicate', field.pos)
+		} else {
+			field_names << field.name
+		}
 		sym := c.table.get_type_symbol(field.typ)
 		if sym.kind == .placeholder && !decl.is_c && !sym.name.starts_with('C.') {
 			c.error('unknown type `$sym.name`', field.pos)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -203,12 +203,11 @@ pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
 		}
 		c.error('struct name must begin with capital letter', pos)
 	}
-	mut field_names := []string{}
-	for field in decl.fields {
-		if field.name in field_names {
-			c.error('field name `$field.name` duplicate', field.pos)
-		} else {
-			field_names << field.name
+	for i, field in decl.fields {
+		for j in 0..i {
+			if field.name == decl.fields[j].name {
+				c.error('field name `$field.name` duplicate', field.pos)
+			}
 		}
 		sym := c.table.get_type_symbol(field.typ)
 		if sym.kind == .placeholder && !decl.is_c && !sym.name.starts_with('C.') {

--- a/vlib/v/checker/tests/struct_field_name_duplicate_err.out
+++ b/vlib/v/checker/tests/struct_field_name_duplicate_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/struct_field_name_duplicate_err.v:3:4: error: field name `a` duplicate
+    1| struct A {
+    2|     a int
+    3|     a string
+             ~~~~~~
+    4| }
+    5| fn main(){}

--- a/vlib/v/checker/tests/struct_field_name_duplicate_err.v
+++ b/vlib/v/checker/tests/struct_field_name_duplicate_err.v
@@ -1,0 +1,5 @@
+struct A {
+	a int
+	a string
+}
+fn main(){}

--- a/vlib/v/checker/tests/struct_field_name_duplicate_err.vv
+++ b/vlib/v/checker/tests/struct_field_name_duplicate_err.vv
@@ -1,0 +1,5 @@
+struct A {
+	a int
+	a string
+}
+fn main(){}


### PR DESCRIPTION
This PR check struct field name duplicate (fix #4634).

- Check struct field name duplicate.
- Add tests for it.

```v
D:\test\v\tt1>v run .
.\tt1.v:3:4: error: field name `a` duplicate 
    1| struct A {
    2|     a int
    3|     a string
             ~~~~~~
    4| }
    5| fn main(){}
```