### PR TITLE
scanner: prevent panic with string starting on first character

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -833,7 +833,7 @@ fn (s &Scanner) count_symbol_before(p int, sym byte) int {
 fn (s mut Scanner) ident_string() string {
 	q := s.text[s.pos]
 	is_quote := q == single_quote || q == double_quote
-	is_raw := is_quote && s.text[s.pos - 1] == `r`
+	is_raw := is_quote && s.pos > 0 && s.text[s.pos - 1] == `r`
 	if is_quote && !s.is_inside_string {
 		s.quote = q
 	}


### PR DESCRIPTION
Prevent a panic due to scanner checking for [pos - 1] when string starts, causing a crash in compilation with a string starting on pos 0

### Example:
```
'a'
```