### PR TITLE
checker: check unusual main function (fix #4636)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -115,6 +115,12 @@ fn (mut c Checker) check_file_in_main(file ast.File) bool {
 					if it.is_pub {
 						c.error('function `main` cannot be declared public', it.pos)
 					}
+					if it.args.len > 0 {
+						c.error('function `main` cannot have arguments', it.pos)
+					}
+					if it.return_type != table.void_type {
+						c.error('function `main` cannot return values', it.pos)
+					}
 				} else {
 					if it.is_pub {
 						c.warn('function `$it.name` $no_pub_in_main_warning', it.pos)

--- a/vlib/v/checker/tests/main_args_err.out
+++ b/vlib/v/checker/tests/main_args_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/main_args_err.v:1:1: error: function `main` cannot have arguments
+    1| fn main(a string) {
+       ~~~~~~~~~~~~~~~~~
+    2|     println(a)
+    3| }

--- a/vlib/v/checker/tests/main_args_err.vv
+++ b/vlib/v/checker/tests/main_args_err.vv
@@ -1,0 +1,3 @@
+fn main(a string) {
+	println(a)
+}

--- a/vlib/v/checker/tests/main_return_err.out
+++ b/vlib/v/checker/tests/main_return_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/main_return_err.v:1:1: error: function `main` cannot return values
+    1| fn main() f64 {
+       ~~~~~~~~~~~~~
+    2|     return 1.23
+    3| }

--- a/vlib/v/checker/tests/main_return_err.vv
+++ b/vlib/v/checker/tests/main_return_err.vv
@@ -1,0 +1,3 @@
+fn main() f64 {
+	return 1.23
+}


### PR DESCRIPTION
This PR check unusual main function (fix #4636).
- Check unusual main function.
- Add tests `main_args_err.vv` and `main_return_err.vv`.
```v
D:\test\v\tt1>v run .
.\tt1.v:1:1: error: function `main` cannot have arguments
    1| fn main(a int) int {
       ~~~~~~~~~~~~~~~~~~
    2|     return a
    3| }
```
```v
D:\test\v\tt1>v run .
.\tt1.v:1:1: error: function `main` cannot return values 
    1| fn main() string {
       ~~~~~~~~~~~~~~~~
    2|     return 'aa'
    3| }
```