### PR TITLE
parser: fail for section redefinition in struct

### DIFF
--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -38,6 +38,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 	mut mut_pos := -1
 	mut pub_pos := -1
 	mut pub_mut_pos := -1
+	mut global_pos := -1
 	mut is_field_mut := false
 	mut is_field_pub := false
 	mut is_field_global := false
@@ -51,12 +52,18 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 			if p.tok.kind == .key_pub {
 				p.check(.key_pub)
 				if p.tok.kind == .key_mut {
+					if pub_mut_pos != -1 {
+						p.error('redefinition of `pub mut` section')
+					}
 					p.check(.key_mut)
 					pub_mut_pos = fields.len
 					is_field_pub = true
 					is_field_mut = true
 					is_field_global = false
 				} else {
+					if pub_pos != -1 {
+						p.error('redefinition of `pub` section')
+					}
 					pub_pos = fields.len
 					is_field_pub = true
 					is_field_mut = false
@@ -64,6 +71,9 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 				}
 				p.check(.colon)
 			} else if p.tok.kind == .key_mut {
+				if mut_pos != -1 {
+					p.error('redefinition of `mut` section')
+				}
 				p.check(.key_mut)
 				p.check(.colon)
 				mut_pos = fields.len
@@ -71,8 +81,12 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 				is_field_mut = true
 				is_field_global = false
 			} else if p.tok.kind == .key_global {
+				if global_pos != -1 {
+					p.error('redefinition of `global` section')
+				}
 				p.check(.key_global)
 				p.check(.colon)
+				global_pos = fields.len
 				is_field_pub = true
 				is_field_mut = true
 				is_field_global = true


### PR DESCRIPTION
Fail if a section (`mut`, `pub`, `pub mut` or `__global`) is defined twice in a struct.
I don't know how to test the parser, so no tests for this :disappointed: 