### PR TITLE
csv: fix last-field-empty error (fix #4643)

### DIFF
--- a/vlib/encoding/csv/reader.v
+++ b/vlib/encoding/csv/reader.v
@@ -129,18 +129,19 @@ fn (r mut Reader) read_record() ?[]string {
 		// quoted
 		else {
 			line = line[1..]
-			if j := line.index('"') {
-				if j+1 == line.len {
-					// last record
-					fields << line[..j]
-					break
-				}
-				next := line[j+1]
-				if next == r.delimiter {
-					fields << line[..j]
-					line = line[j..]
-					continue
-				}
+			j := line.index('"') or {
+				break
+			}
+			if j+1 == line.len {
+				// last record
+				fields << line[..j]
+				break
+			}
+			next := line[j+1]
+			if next == r.delimiter {
+				fields << line[..j]
+				line = line[j..]
+				continue
 			}
 			line = line[1..]
 		}

--- a/vlib/encoding/csv/reader_test.v
+++ b/vlib/encoding/csv/reader_test.v
@@ -120,3 +120,30 @@ fn test_no_line_ending() {
 
 	assert row_count == 2
 }
+
+fn test_last_field_empty() {
+	data := '"name","description","value"\n"one","first","1"\n"two","second",\n'
+	mut csv_reader := csv.new_reader(data)
+
+	mut row_count := 0
+	for {
+    	row := csv_reader.read() or {
+        	break
+    	}
+    	row_count++
+		if row_count == 1 {
+			assert row[0] == 'name'
+			assert row[1] == 'description'
+			assert row[2] == 'value'
+		}
+		if row_count == 2 {
+			assert row[0] == 'one'
+			assert row[1] == 'first'
+			assert row[2] == '1'
+		}
+		if row_count == 3 {
+			assert row[0] == 'two'
+			assert row[1] == 'second'
+		}
+	}
+}


### PR DESCRIPTION
This PR fix last-field-empty error (fix #4643).

- Fix last-field-empty error.
- Add `test_last_field_empty` in csv/reader_test.v.

#4643 Result:
```v
D:\test\v\tt1>v run .
[ 1] ['name', 'description', 'value']
[ 2] ['one', 'first', '1']
[ 3] ['two', 'second']
-----------------
```