### PR TITLE
parser: show correct variable type in for loop error

### DIFF
--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -24,7 +24,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 			is_inf: true
 		}
 	} else if p.tok.kind in [.key_mut, .key_var] {
-		p.error('`var` is not needed in for loops')
+		p.error('`$p.tok.kind` is not needed in for loops')
 	} else if p.peek_tok.kind in [.decl_assign, .assign, .semicolon] || p.tok.kind == .semicolon {
 		// `for i := 0; i < 10; i++ {`
 		mut init := ast.Stmt{}


### PR DESCRIPTION
## Additions:
Show variable type used in "not needed in for loop" error instead of only `var`

## Example:
```
test.v:1:16: error: `mut` is not needed in for loops 
    1| for mut i := 0 ; i < 10; i++ {
                      ~~~
    2|     println(i)
    3| }
```