### PR TITLE
fmt: fix formatting backtick char literal

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -40,14 +40,10 @@ pub fn fmt(file ast.File, table &table.Table) string {
 	}
 	f.cur_mod = 'main'
 	for stmt in file.stmts {
-		// TODO `if stmt is ast.Import`
-		match stmt {
-			ast.Import {
-				// Just remember the position of the imports for now
-				f.import_pos = f.out.len
-				// f.imports(f.file.imports)
-			}
-			else {}
+		if stmt is ast.Import {
+			// Just remember the position of the imports for now
+			f.import_pos = f.out.len
+			// f.imports(f.file.imports)
 		}
 		f.stmt(stmt)
 	}

--- a/vlib/v/fmt/tests/char_literal_backtick_keep.vv
+++ b/vlib/v/fmt/tests/char_literal_backtick_keep.vv
@@ -1,0 +1,3 @@
+fn char_backtick() {
+	`\``
+}

--- a/vlib/v/fmt/tests/functions_expected.vv
+++ b/vlib/v/fmt/tests/functions_expected.vv
@@ -5,7 +5,7 @@ fn fn_variadic(arg int, args ...string) {
 }
 
 fn fn_with_assign_stmts() {
-	a, b := fn_with_multi_return()
+	_, _ := fn_with_multi_return()
 }
 
 fn fn_with_multi_return() (int, string) {

--- a/vlib/v/fmt/tests/functions_input.vv
+++ b/vlib/v/fmt/tests/functions_input.vv
@@ -5,7 +5,7 @@ fn fn_variadic(arg int, args... string) {
 }
 
 fn fn_with_assign_stmts() {
-	a,b := fn_with_multi_return()
+	_,_ := fn_with_multi_return()
 }
 
 fn fn_with_multi_return() (int,string) {

--- a/vlib/v/fmt/tests/loops_expected.vv
+++ b/vlib/v/fmt/tests/loops_expected.vv
@@ -6,6 +6,7 @@ fn for_in_loop() {
 
 fn for_in_loop_with_counter() {
 	for i, item in arr {
+		println(i)
 		println(item)
 	}
 }

--- a/vlib/v/fmt/tests/loops_input.vv
+++ b/vlib/v/fmt/tests/loops_input.vv
@@ -6,6 +6,7 @@ fn for_in_loop() {
 
 fn for_in_loop_with_counter() {
 	for i, item in arr {
+		println(i)
 		println(item)
 	}
 }

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -929,9 +929,6 @@ fn (s mut Scanner) ident_char() string {
 			s.error('invalid character literal (more than one character)\n' + 'use quotes for strings, backticks for characters')
 		}
 	}
-	if c == '\\`' {
-		return '`'
-	}
 	// Escapes a `'` character
 	return if c == "\'" { '\\' + c } else { c }
 }


### PR DESCRIPTION
Fix formatting backtick char literal.
Make some fmt tests pass.