### PR TITLE
fmt: repeat tabs instead of using fixed array of strings of tabs

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -8,8 +8,8 @@ import v.table
 import strings
 
 const (
-	tabs    = ['', '\t', '\t\t', '\t\t\t', '\t\t\t\t', '\t\t\t\t\t', '\t\t\t\t\t\t', '\t\t\t\t\t\t\t']
-	max_len = 90
+	level_indent = '\t'
+	max_len      = 90
 )
 
 struct Fmt {
@@ -69,15 +69,9 @@ fn (f mut Fmt) find_comment(line_nr int) {
 */
 pub fn (mut f Fmt) write(s string) {
 	if f.indent > 0 && f.empty_line {
-		if f.indent < tabs.len {
-			f.out.write(tabs[f.indent])
-		} else {
-			// too many indents, do it the slow way:
-			for _ in 0 .. f.indent {
-				f.out.write('\t')
-			}
-		}
-		f.line_len += f.indent * 4
+		indent := level_indent.repeat(f.indent)
+		f.out.write(indent)
+		f.line_len += indent.len * 4
 	}
 	f.out.write(s)
 	f.line_len += s.len
@@ -86,8 +80,7 @@ pub fn (mut f Fmt) write(s string) {
 
 pub fn (mut f Fmt) writeln(s string) {
 	if f.indent > 0 && f.empty_line {
-		// println(f.indent.str() + s)
-		f.out.write(tabs[f.indent])
+		f.out.write(level_indent.repeat(f.indent))
 	}
 	f.out.writeln(s)
 	f.empty_line = true
@@ -728,7 +721,7 @@ fn (mut f Fmt) wrap_long_line() bool {
 	if f.out.buf[f.out.buf.len - 1] == ` ` {
 		f.out.go_back(1)
 	}
-	f.write('\n' + tabs[f.indent + 1])
+	f.write('\n' + level_indent.repeat(f.indent + 1))
 	f.line_len = 0
 	return true
 }

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -92,9 +92,7 @@ mut:
 }
 
 const (
-	tabs = ['', '\t', '\t\t', '\t\t\t', '\t\t\t\t', '\t\t\t\t\t', '\t\t\t\t\t\t', '\t\t\t\t\t\t\t',
-		'\t\t\t\t\t\t\t\t'
-	]
+	level_indent = '\t'
 )
 
 pub fn cgen(files []ast.File, table &table.Table, pref &pref.Preferences) string {
@@ -395,7 +393,7 @@ pub fn (g Gen) save() {
 
 pub fn (mut g Gen) write(s string) {
 	if g.indent > 0 && g.empty_line {
-		g.out.write(tabs[g.indent])
+		g.out.write(level_indent.repeat(g.indent))
 		// g.line_len += g.indent * 4
 	}
 	g.out.write(s)
@@ -404,7 +402,7 @@ pub fn (mut g Gen) write(s string) {
 
 pub fn (mut g Gen) writeln(s string) {
 	if g.indent > 0 && g.empty_line {
-		g.out.write(tabs[g.indent])
+		g.out.write(level_indent.repeat(g.indent))
 	}
 	g.out.writeln(s)
 	g.empty_line = true

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -12,7 +12,7 @@ import v.util
 const (
 	//TODO
 	js_reserved = ['delete', 'const', 'let', 'var', 'function', 'continue', 'break', 'switch', 'for', 'in', 'of', 'instanceof', 'typeof', 'do']
-	tabs = ['', '\t', '\t\t', '\t\t\t', '\t\t\t\t', '\t\t\t\t\t', '\t\t\t\t\t\t', '\t\t\t\t\t\t\t', '\t\t\t\t\t\t\t\t']
+	level_indent = '\t'
 )
 
 struct JsGen {
@@ -203,7 +203,7 @@ pub fn (g &JsGen) save() {}
 
 pub fn (g mut JsGen) gen_indent() {
 	if g.indents[g.namespace] > 0 && g.empty_line {
-		g.out.write(tabs[g.indents[g.namespace]])
+		g.out.write(level_indent.repeat(g.indents[g.namespace]))
 	}
 	g.empty_line = false
 }

--- a/vlib/v/gen/js/jsdoc.v
+++ b/vlib/v/gen/js/jsdoc.v
@@ -19,7 +19,7 @@ fn new_jsdoc(gen &JsGen) &JsDoc {
 
 fn (mut d JsDoc) gen_indent() {
 	if d.gen.indents[d.gen.namespace] > 0 && d.empty_line {
-		d.out.write(tabs[d.gen.indents[d.gen.namespace]])
+		d.out.write(level_indent.repeat(d.gen.indents[d.gen.namespace]))
 	}
 	d.empty_line = false
 }


### PR DESCRIPTION
Avoids extra checks to see if you ran out of tab strings,
etc.
