### PR TITLE
checker: error on ternary if type mismatch

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -157,7 +157,7 @@ fn (d mut DenseArray) zeros_to_end() {
 	}
 	d.deletes = 0
 	d.size = count
-	d.cap = if count < 8 { 8 } else { count }
+	d.cap = if count < 8 { u32(8) } else { count }
 	d.data = &KeyValue(C.realloc(d.data, sizeof(KeyValue) * d.cap))
 }
 

--- a/vlib/v/checker/tests/ternary_mismatch.out
+++ b/vlib/v/checker/tests/ternary_mismatch.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/ternary_mismatch.v:2:7: error: mismatched types `string` and `int` 
+    1| fn main() {
+    2|     s := if true { '12' } else { 12 }
+                ~~
+    3|     println(s)
+    4| }

--- a/vlib/v/checker/tests/ternary_mismatch.vv
+++ b/vlib/v/checker/tests/ternary_mismatch.vv
@@ -1,0 +1,4 @@
+fn main() {
+	s := if true { '12' } else { 12 }
+	println(s)
+}


### PR DESCRIPTION
### Additions:
Checks for types in a ternary if statement.
Checker Tests for this case.

### Notes:
Fixes #4096 and C ternary mismatch error

### Examples:
```
foo := if cond { 10 } else { '10' }
```
Gives:
```
test.v:1:19: error: mismatched types `int` and `string` 
    1| foo := if cond { 10 } else { '10' }
```