### PR TITLE
checker: check enum field name duplicate

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -967,7 +967,12 @@ pub fn (mut c Checker) return_stmt(return_stmt mut ast.Return) {
 }
 
 pub fn (mut c Checker) enum_decl(decl ast.EnumDecl) {
-	for field in decl.fields {
+	for i, field in decl.fields {
+		for j in 0..i {
+			if field.name == decl.fields[j].name {
+				c.error('field name `$field.name` duplicate', field.pos)
+			}
+		}
 		if field.has_expr {
 			match field.expr {
 				ast.IntegerLiteral {}

--- a/vlib/v/checker/tests/enum_field_name_duplicate_err.out
+++ b/vlib/v/checker/tests/enum_field_name_duplicate_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/enum_field_name_duplicate_err.v:5:2: error: field name `green` duplicate
+    3|     yellow
+    4|     blue
+    5|     green
+           ~~~~~
+    6| }
+    7|

--- a/vlib/v/checker/tests/enum_field_name_duplicate_err.vv
+++ b/vlib/v/checker/tests/enum_field_name_duplicate_err.vv
@@ -1,0 +1,10 @@
+enum Color {
+    green
+    yellow
+    blue
+	green
+}
+
+fn main(){
+	println('hello')
+}


### PR DESCRIPTION
This PR check enum field name duplicate.
- Check enum field name duplicate.
- Add test `enum_field_name_duplicate_err.vv/out`.

```v
D:\test\v\tt1>v run .
.\tt1.v:2:12: error: field name `green` duplicate
    1| enum Color {
    2|     green red green
                     ~~~~~
    3| }
    4| fn main() {}
```