### PR TITLE
parser: uniform handling of enum field format

### DIFF
--- a/vlib/v/checker/tests/enum_err.out
+++ b/vlib/v/checker/tests/enum_err.out
@@ -1,14 +1,14 @@
 vlib/v/checker/tests/enum_err.v:4:13: error: default value for enum has to be an integer
     2|
     3| enum Color {
-    4|     green = 'green',
+    4|     green = 'green'
                    ~~~~~~~
-    5|     yellow = 1+1,
-    6|     blue,
+    5|     yellow = 1+1
+    6|     blue
 vlib/v/checker/tests/enum_err.v:5:14: error: default value for enum has to be an integer
     3| enum Color {
-    4|     green = 'green',
-    5|     yellow = 1+1,
+    4|     green = 'green'
+    5|     yellow = 1+1
                     ~~~
-    6|     blue,
+    6|     blue
     7| }

--- a/vlib/v/checker/tests/enum_err.vv
+++ b/vlib/v/checker/tests/enum_err.vv
@@ -1,9 +1,9 @@
 module main
 
 enum Color {
-    green = 'green',
-    yellow = 1+1,
-    blue,
+    green = 'green'
+    yellow = 1+1
+    blue
 }
 
 fn main(){

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1125,13 +1125,6 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 			expr: expr
 			has_expr: has_expr
 		}
-		// Allow commas after enum, helpful for
-		// enum Color {
-		// r,g,b
-		// }
-		if p.tok.kind == .comma {
-			p.next()
-		}
 	}
 	p.check(.rcbr)
 	p.table.register_type_symbol(table.TypeSymbol{


### PR DESCRIPTION
This PR uniform handling of enum field format.
- Uniform handling of enum field format.
- Use comma between field will be error.

```v
D:\test\v\tt1>v run .
.\tt1.v:2:5: error: unexpected `,`, expecting `name`
    1| enum Color {
    2|     red,
              ^
    3|     green,
    4|     blue,
```