### PR TITLE
checker: check import duplicate error

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -48,6 +48,13 @@ pub fn new_checker(table &table.Table, pref &pref.Preferences) Checker {
 
 pub fn (mut c Checker) check(ast_file ast.File) {
 	c.file = ast_file
+	for i, ast_import in ast_file.imports {
+		for j in 0..i {
+			if ast_import.mod == ast_file.imports[j].mod {
+				c.error('module name `$ast_import.mod` duplicate', ast_import.pos)
+			}
+		}
+	}
 	for stmt in ast_file.stmts {
 		c.stmt(stmt)
 	}

--- a/vlib/v/checker/tests/import_duplicate_err.out
+++ b/vlib/v/checker/tests/import_duplicate_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/import_duplicate_err.v:2:8: error: module name `time` duplicate
+    1| import time
+    2| import time
+              ~~~~
+    3| fn main() {
+    4|     println(time.now().unix_time())

--- a/vlib/v/checker/tests/import_duplicate_err.vv
+++ b/vlib/v/checker/tests/import_duplicate_err.vv
@@ -1,0 +1,5 @@
+import time
+import time
+fn main() {
+	println(time.now().unix_time())
+}


### PR DESCRIPTION
This PR check import duplicate error.

- Check import module name duplicate error.
- Add tests `import_duplicate_err.vv/out`.

```v
D:\test\v\tt1>v run .
.\tt1.v:2:8: error: module name `time` duplicate
    1| import time
    2| import time
              ~~~~
    3| fn main() {
    4|     println(time.now().unix_time())
```