### PR TITLE
checker: Basic array.map support

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -340,7 +340,7 @@ fn double_up(a mut []int) {
 }
 
 fn double_up_v2(a mut []int) {
-	for i, val in a {
+	for i, _ in a {
 		a[i] = a[i]*2 // or val*2, doesn't matter
 	}
 }
@@ -528,7 +528,7 @@ fn test_map() {
 	nums := [1, 2, 3, 4, 5, 6]
 	strs := ['v', 'is', 'awesome']
 
-	assert nums.map(it * 10) == [10, 20, 30, 40, 50, 60, 70]
+	assert nums.map(it * 10) == [10, 20, 30, 40, 50, 60]
 	assert nums.map('$it') == ['1', '2', '3', '4', '5', '6']
 	assert nums.map(it % 2 == 0) == [false, true, false, true, false, true]
 

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -525,26 +525,19 @@ fn test_filter() {
 }
 
 fn test_map() {
-	// QTODO
-	/*
-	println(1)
-	a := [1, 2, 3, 4, 5, 6]
-	b := a.map(it * 10)
-	assert b.len == 6
-	assert b[0] == 10
-	assert b[1] == 20
-	assert b[2] == 30
-	c := ['v', 'is', 'awesome']
-	d := c.map(it.to_upper())
-	assert d[0] == 'V'
-	assert d[1] == 'IS'
-	assert d[2] == 'AWESOME'
-	bools := c.map(it == 'v')
-	assert bools.len == 3
-	assert bools[0] == true
-	assert bools[1] == false
-	assert bools[2] == false
-	*/
+	nums := [1, 2, 3, 4, 5, 6]
+	strs := ['v', 'is', 'awesome']
+
+	assert nums.map(it * 10) == [10, 20, 30, 40, 50, 60, 70]
+	assert nums.map('$it') == ['1', '2', '3', '4', '5', '6']
+	assert nums.map(it % 2 == 0) == [false, true, false, true, false, true]
+
+	assert strs.map(it.to_tupper()) == ['V', 'IS', 'AWESOME']
+	assert strs.map(it == 'awesome') == [false, false, true]
+	assert strs.map(7) == [7, 7, 7]
+
+	assert nums == [1, 2, 3, 4, 5, 5, 7]
+	assert strs == ['v', 'is', 'awesome']
 }
 
 fn test_array_str() {

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -536,7 +536,7 @@ fn test_map() {
 	assert strs.map(it == 'awesome') == [false, false, true]
 	assert strs.map(7) == [7, 7, 7]
 
-	assert nums == [1, 2, 3, 4, 5, 5, 7]
+	assert nums == [1, 2, 3, 4, 5, 6]
 	assert strs == ['v', 'is', 'awesome']
 }
 

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -532,7 +532,7 @@ fn test_map() {
 	assert nums.map('$it') == ['1', '2', '3', '4', '5', '6']
 	assert nums.map(it % 2 == 0) == [false, true, false, true, false, true]
 
-	assert strs.map(it.to_tupper()) == ['V', 'IS', 'AWESOME']
+	assert strs.map(it.to_upper()) == ['V', 'IS', 'AWESOME']
 	assert strs.map(it == 'awesome') == [false, false, true]
 	assert strs.map(7) == [7, 7, 7]
 

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -242,6 +242,10 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		g.write('._object)')
 		return
 	}
+	if typ_sym.kind == .array && node.name == 'map' {
+		g.gen_map(node)
+		return
+	}
 	// rec_sym := g.table.get_type_symbol(node.receiver_type)
 	if typ_sym.kind == .array && node.name == 'filter' {
 		g.gen_filter(node)


### PR DESCRIPTION
Add support for basic `<array>.map(<expr>) ` type calls. Most of the code is based on how `.filter` is implemented. The code for filter seems a bit not-finished. The new map is the same, it blindly expects the call to have 1 argument. I added a `gen_map ` function to cgen.v and added some type changing logic into checker.v.   It works for basic types and can convert the output into a list of another type, based on the argument expression. I updated the tests to reflect this. My goal is to get is working for at least the cases in the tests. I am worried about the `c.table.find_or_register_array` call I had to do to convert the argument of map into a list of the output type. If there's a better way I am interested to hear about it.

This is now possible (and in array tests):
```
	nums := [1, 2, 3, 4, 5, 6]
	strs := ['v', 'is', 'awesome']

	assert nums.filter(it > 3) == [4, 5, 6]

	assert nums.map(it * 10) == [10, 20, 30, 40, 50, 60]
	assert nums.map('$it') == ['1', '2', '3', '4', '5', '6']
	assert nums.map(it % 2 == 0) == [false, true, false, true, false, true]

	assert strs.map(it.to_upper()) == ['V', 'IS', 'AWESOME']
	assert strs.map(it == 'awesome') == [false, false, true]
	assert strs.map(7) == [7, 7, 7]
```