### PR TITLE
fmt: improve indenting

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -8,7 +8,7 @@ import v.table
 import strings
 
 const (
-	tabs    = ['', '\t', '\t\t', '\t\t\t', '\t\t\t\t', '\t\t\t\t\t', '\t\t\t\t\t\t', '\t\t\t\t\t\t\t']
+	level_indent = '\t'
 	max_len = 90
 )
 
@@ -65,14 +65,7 @@ fn (f mut Fmt) find_comment(line_nr int) {
 */
 pub fn (mut f Fmt) write(s string) {
 	if f.indent > 0 && f.empty_line {
-		if f.indent < tabs.len {
-			f.out.write(tabs[f.indent])
-		} else {
-			// too many indents, do it the slow way:
-			for _ in 0 .. f.indent {
-				f.out.write('\t')
-			}
-		}
+		f.out.write(level_indent.repeat(f.indent))
 		f.line_len += f.indent * 4
 	}
 	f.out.write(s)
@@ -82,8 +75,7 @@ pub fn (mut f Fmt) write(s string) {
 
 pub fn (mut f Fmt) writeln(s string) {
 	if f.indent > 0 && f.empty_line {
-		// println(f.indent.str() + s)
-		f.out.write(tabs[f.indent])
+		f.out.write(level_indent.repeat(f.indent))
 	}
 	f.out.writeln(s)
 	f.empty_line = true
@@ -724,7 +716,7 @@ fn (mut f Fmt) wrap_long_line() bool {
 	if f.out.buf[f.out.buf.len - 1] == ` ` {
 		f.out.go_back(1)
 	}
-	f.write('\n' + tabs[f.indent + 1])
+	f.write('\n' + level_indent.repeat(f.indent + 1))
 	f.line_len = 0
 	return true
 }

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -92,9 +92,7 @@ mut:
 }
 
 const (
-	tabs = ['', '\t', '\t\t', '\t\t\t', '\t\t\t\t', '\t\t\t\t\t', '\t\t\t\t\t\t', '\t\t\t\t\t\t\t',
-		'\t\t\t\t\t\t\t\t'
-	]
+	level_indent = '\t'
 )
 
 pub fn cgen(files []ast.File, table &table.Table, pref &pref.Preferences) string {
@@ -395,7 +393,7 @@ pub fn (g Gen) save() {
 
 pub fn (mut g Gen) write(s string) {
 	if g.indent > 0 && g.empty_line {
-		g.out.write(tabs[g.indent])
+		g.out.write(level_indent.repeat(g.indent))
 		// g.line_len += g.indent * 4
 	}
 	g.out.write(s)
@@ -404,7 +402,7 @@ pub fn (mut g Gen) write(s string) {
 
 pub fn (mut g Gen) writeln(s string) {
 	if g.indent > 0 && g.empty_line {
-		g.out.write(tabs[g.indent])
+		g.out.write(level_indent.repeat(g.indent))
 	}
 	g.out.writeln(s)
 	g.empty_line = true

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -12,7 +12,7 @@ import v.util
 const (
 	//TODO
 	js_reserved = ['delete', 'const', 'let', 'var', 'function', 'continue', 'break', 'switch', 'for', 'in', 'of', 'instanceof', 'typeof', 'do']
-	tabs = ['', '\t', '\t\t', '\t\t\t', '\t\t\t\t', '\t\t\t\t\t', '\t\t\t\t\t\t', '\t\t\t\t\t\t\t', '\t\t\t\t\t\t\t\t']
+	level_indent = '\t'
 )
 
 struct JsGen {
@@ -203,7 +203,7 @@ pub fn (g &JsGen) save() {}
 
 pub fn (g mut JsGen) gen_indent() {
 	if g.indents[g.namespace] > 0 && g.empty_line {
-		g.out.write(tabs[g.indents[g.namespace]])
+		g.out.write(level_indent.repeat(g.indents[g.namespace]))
 	}
 	g.empty_line = false
 }

--- a/vlib/v/gen/js/jsdoc.v
+++ b/vlib/v/gen/js/jsdoc.v
@@ -19,7 +19,7 @@ fn new_jsdoc(gen &JsGen) &JsDoc {
 
 fn (mut d JsDoc) gen_indent() {
 	if d.gen.indents[d.gen.namespace] > 0 && d.empty_line {
-		d.out.write(tabs[d.gen.indents[d.gen.namespace]])
+		d.out.write(level_indent.repeat(d.gen.indents[d.gen.namespace]))
 	}
 	d.empty_line = false
 }


### PR DESCRIPTION
This changes the way indents are created.  Instead of a fixed array of strings of tabs, a single tab is repeated as much as necessary.  This allows unlimited indent depths without having to manually add extra tab-strings to the array, or adding an extra check on indent depth and falling back to a repeat if you need more strings than the array has.

It seems like building a string every time would be slower than indexing an array of fixed strings, but that is not the case.

Run the following example code.  Out of the many times I ran the code here, there was one time the loops ran at the same speed.  Every other time, the 2nd loop (repeating a single tab) was faster.  So yes, the speed does vary, but the repeat is never slower.

```
import time

const (
	tabs = [
		''
		'\t'
		'\t\t'
		'\t\t\t'
		'\t\t\t\t'
		'\t\t\t\t\t'
		'\t\t\t\t\t\t'
		'\t\t\t\t\t\t\t'
	]
)

fn main() {
	println('Array of strings of tabs')
	mut start := time.sys_mono_now()
	for i:=0; i<8; i++ {
		print(tabs[i] + '!')
	}
	mut end := time.sys_mono_now()
	println(end - start)

	println('Repeats of single tab')
	start = time.sys_mono_now()
	for i:=0; i<8; i++ {
		print('\t'.repeat(i) + '!')
	}
	end = time.sys_mono_now()
	println(end - start)
}
```
