### PR TITLE
cgen: generate static C functions

### DIFF
--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -52,9 +52,9 @@ fn (mut g Gen) gen_fn_decl(it ast.FnDecl) {
 		// }
 		// type_name := g.table.Type_to_str(it.return_type)
 		type_name := g.typ(it.return_type)
-		g.write('$type_name ${name}(')
+		g.write('static $type_name ${name}(')
 		g.last_fn_c_name = name
-		g.definitions.write('$type_name ${name}(')
+		g.definitions.write('static $type_name ${name}(')
 	}
 	// Receiver is the first argument
 	/*


### PR DESCRIPTION
I'm not 100% sure about this change but the hello world binary size goes from 176.9kB to 167.4kB and it seems more correct to me.

Is there support for calling V from C? Because this change would break that.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
