### PR TITLE
parser: check multiple names error (fix #4654)

### DIFF
--- a/vlib/v/checker/tests/multi_names_err.out
+++ b/vlib/v/checker/tests/multi_names_err.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/multi_names_err.v:2:2: error: multiple names is not allowed
+vlib/v/checker/tests/multi_names_err.v:2:2: error: unexpected name `a`
     1 | fn main() {
     2 |     a a a a := 1
-      |     ^
+      |       ^
     3 | }

--- a/vlib/v/checker/tests/multi_names_err.out
+++ b/vlib/v/checker/tests/multi_names_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/multi_names_err.v:2:2: error: unexpected name `a`
+vlib/v/checker/tests/multi_names_err.v:2:4: error: unexpected name `a`
     1 | fn main() {
     2 |     a a a a := 1
       |       ^

--- a/vlib/v/checker/tests/multi_names_err.out
+++ b/vlib/v/checker/tests/multi_names_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/multi_names_err.v:2:2: error: multiple names is not allowed
+    1 | fn main() {
+    2 |     a a a a := 1
+      |     ^
+    3 | }

--- a/vlib/v/checker/tests/multi_names_err.vv
+++ b/vlib/v/checker/tests/multi_names_err.vv
@@ -1,0 +1,3 @@
+fn main() {
+	a a a a := 1
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -468,6 +468,8 @@ pub fn (mut p Parser) stmt() ast.Stmt {
 				return ast.GotoLabel{
 					name: name
 				}
+			} else if p.tok.kind == .name && p.peek_tok.kind == .name {
+				p.error_with_pos('multiple names is not allowed', p.tok.position())
 			}
 			epos := p.tok.position()
 			expr := p.expr(0)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -469,7 +469,7 @@ pub fn (mut p Parser) stmt() ast.Stmt {
 					name: name
 				}
 			} else if p.tok.kind == .name && p.peek_tok.kind == .name {
-				p.error_with_pos('multiple names is not allowed', p.tok.position())
+				p.error_with_pos('unexpected name `$p.peek_tok.lit`', p.peek_tok.position())
 			}
 			epos := p.tok.position()
 			expr := p.expr(0)


### PR DESCRIPTION
This PR check multiple names error (fix #4654).

- Check multiple names error.
- Add test `multi_names_err.vv/out`.

```v
D:\test\v\tt1>v run .
.\tt1.v:2:2: error: multiple names is not allowed 
    1 | fn main() {
    2 |     a a a a := 1
      |     ^
    3 | }
```