### PR TITLE
compiler: don't print to stdout when compiling interfaces

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3349,7 +3349,6 @@ fn (v &Gen) interface_table() string {
 			continue
 		}
 		info := t.info as table.Interface
-		println(info.gen_types)
 		// interface_name is for example Speaker
 		interface_name := t.name.replace('.', '__')
 		mut methods := ''

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -276,7 +276,6 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 	for p.tok.kind != .rcbr && p.tok.kind != .eof {
 		line_nr := p.tok.line_nr
 		name := p.check_name()
-		println(name)
 		// field_names << name
 		args2, _ := p.fn_args()
 		mut args := [table.Arg{


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
