### PR TITLE
interpolation: fix error on windows_gcc (fix #4679)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,9 @@ jobs:
       run: |
         gcc --version
         .\make.bat -gcc
+    - name: Fixed tests
+      run: |
+        .\v.exe test-fixed
 #    - name: Test
 #      run: |
 #        .\v.exe -silent test-compiler

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -203,6 +203,21 @@ extern wchar_t **_wenviron;
 #define macro_f32_gt(a, b) (a >  b)
 #define macro_f32_ge(a, b) (a >= b)
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#undef PRId64
+#undef PRIi64
+#undef PRIo64
+#undef PRIu64
+#undef PRIx64
+#undef PRIX64
+#define PRId64 "lld"
+#define PRIi64 "lli"
+#define PRIo64 "llo"
+#define PRIu64 "llu"
+#define PRIx64 "llx"
+#define PRIX64 "llX"
+#endif
+
 //================================== GLOBALS =================================*/
 byte g_str_buf[1024];
 int load_so(byteptr);


### PR DESCRIPTION
This PR fix interpolation error on windows_gcc (fix #4679).

- Add defines in `cheaders.v`.
```v
#if defined(_UCRT) || __USE_MINGW_ANSI_STDIO
#define PRId64 "lld"
#define PRIi64 "lli"
#define PRIo64 "llo"
#define PRIu64 "llu"
#define PRIx64 "llx"
#define PRIX64 "llX"
#else
#define PRId64 "I64d"
#define PRIi64 "I64i"
#define PRIo64 "I64o"
#define PRIu64 "I64u"
#define PRIx64 "I64x"
#define PRIX64 "I64X"
#endif
```
- Enable windows_gcc test-fixed in ci.yml.