### PR TITLE
parser: fix string interpolation for default conversion

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -900,7 +900,7 @@ fn (mut p Parser) string_expr() ast.Expr {
 				efmt << p.tok.lit
 				p.next()
 			}
-			if p.tok.lit.len == 1 {
+			if p.tok.kind == .name && p.tok.lit.len == 1 {
 				efmt << p.tok.lit
 				p.next()
 			}

--- a/vlib/v/tests/string_interpolation_test.v
+++ b/vlib/v/tests/string_interpolation_test.v
@@ -77,6 +77,8 @@ fn test_string_interpolation_string_prefix() {
 }
 
 fn test_inttypes_string_interpolation() {
+	c := i8(-103)
+	uc := byte(217)
 	s := i16(-23456)
 	us := u16(54321)
 	i := -1622999040
@@ -86,8 +88,9 @@ fn test_inttypes_string_interpolation() {
 	assert '$s $us' == '-23456 54321'
 	assert '$ui $i' == '3421958087 -1622999040'
 	assert '$l $ul' == '-7694555558525237396 17234006112912956370'
-	assert '>${s:11}< >${us:-13}<-' == '>     -23456< >54321        <-'
-	assert '0x${ul:-19x}< >${l:22d}<-' == '0xef2b7d4001165bd2   < >  -7694555558525237396<-'
+	assert '>${s:11}:${us:-13}<' == '>     -23456:54321        <'
+	assert '0x${ul:-19x}:${l:22d}' == '0xef2b7d4001165bd2   :  -7694555558525237396'
+	assert '${c:5}${uc:-7}x' == ' -103217    x'
 }
 
 fn test_utf8_string_interpolation() {


### PR DESCRIPTION
### Problem:
String interpolation with field width but without explicit conversion specifier fails or produces unexpected results when the following string part consists of only one letter. For example `'${a:7}x'` might result in a hexadecimal conversion whereas `'${b:5}<'` fails to compile.
### Cause:
In the scanner output the closing brace is no token by itself so the parser does not "see" that the format specifier has already ended when it get's the 'x' or '<' token.
### Resolution:
The single letter token in the above examples is of kind `.string` whereas an explicit format specifier as the `'f'` in `'${c:5.2f}'` is of kind `.name`. This can be used in the parser to distinguish these two cases.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
