### PR TITLE
vrepl: fix cleanup on windows

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -81,8 +81,13 @@ pub fn run_repl(workdir string, vrepl_prefix string) []string {
 		println('')
 		os.rm(file)
 		os.rm(temp_file)
-		os.rm(file[..file.len - 2])
-		os.rm(temp_file[..temp_file.len - 2])
+		$if windows {
+			os.rm(file[..file.len - 2] + '.exe')
+			os.rm(temp_file[..temp_file.len - 2] + '.exe')
+		} $else {
+			os.rm(file[..file.len - 2])
+			os.rm(temp_file[..temp_file.len - 2])
+		}
 	}
 	mut r := Repl{}
 	mut readline := readline.Readline{}

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -84,6 +84,12 @@ pub fn run_repl(workdir string, vrepl_prefix string) []string {
 		$if windows {
 			os.rm(file[..file.len - 2] + '.exe')
 			os.rm(temp_file[..temp_file.len - 2] + '.exe')
+			$if msvc {
+				os.rm(file[..file.len - 2] + '.ilk')
+				os.rm(file[..file.len - 2] + '.pdb')
+				os.rm(temp_file[..temp_file.len - 2] + '.ilk')
+				os.rm(temp_file[..temp_file.len - 2] + '.pdb')
+			}
 		} $else {
 			os.rm(file[..file.len - 2])
 			os.rm(temp_file[..temp_file.len - 2])


### PR DESCRIPTION
This PR fix vrepl cleanup on windows.

```v
defer {
	println('')
	os.rm(file)
	os.rm(temp_file)
	$if windows {
		os.rm(file[..file.len - 2] + '.exe')
		os.rm(temp_file[..temp_file.len - 2] + '.exe')
	} $else {
		os.rm(file[..file.len - 2])
		os.rm(temp_file[..temp_file.len - 2])
	}
}
```
