### PR TITLE
checker: fix typo in infix_expr

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -400,7 +400,7 @@ pub fn (mut c Checker) infix_expr(infix_expr mut ast.InfixExpr) table.Type {
 					return table.void_type
 				}
 				s := left.name.replace('array_', '[]')
-				c.error('cannot append `$right.name` to `$s', infix_expr.right.position())
+				c.error('cannot append `$right.name` to `$s`', infix_expr.right.position())
 				return table.void_type
 			} else if !left.is_int() {
 				c.error('cannot shift type $right.name into non-integer type $left.name', infix_expr.left.position())


### PR DESCRIPTION
This PR fix typo in infix_expr.