### PR TITLE
interface: support arguments in methods

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -930,7 +930,7 @@ fn (stmt Stmt) position() token.Position {
 }
 
 // TODO: remove this fugly hack :-|
-// fe2ex/1 and ex2fe/1 are used to convert back and forth from 
+// fe2ex/1 and ex2fe/1 are used to convert back and forth from
 // table.FExpr to ast.Expr , which in turn is needed to break
 // a dependency cycle between v.ast and v.table, for the single
 // field table.Field.default_expr, which should be ast.Expr

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3425,7 +3425,7 @@ _Interface I_${cctype}_to_Interface(${cctype} x) {
 		._interface_idx = ${interface_index_name}
 	};
 }')
-			methods_struct.writeln('\t($methods_struct_name) {')
+			methods_struct.writeln('\t{')
 			for method in ityp.methods {
 				// .speak = Cat_speak
 				mut method_call := '${cctype}_${method.name}'

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3382,6 +3382,9 @@ fn (g &Gen) interface_table() string {
 			continue
 		}
 		inter_info := ityp.info as table.Interface
+		if inter_info.types.len == 0 {
+			continue
+		}
 		sb.writeln('// NR interfaced types= $inter_info.types.len')
 		// interface_name is for example Speaker
 		interface_name := c_name(ityp.name)

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3422,9 +3422,9 @@ fn (g &Gen) interface_table() string {
 			// Speaker_Cat_index = 0
 			interface_index_name := '_${interface_name}_${cctype}_index'
 			cast_functions.writeln('
-_Interface I_${cctype}_to_Interface(${cctype} x) {
+_Interface I_${cctype}_to_Interface(${cctype}* x) {
 	return (_Interface) {
-		._object = (void*) memdup(&x, sizeof(${cctype})),
+		._object = (void*) memdup(x, sizeof(${cctype})),
 		._interface_idx = ${interface_index_name}
 	};
 }')
@@ -3529,8 +3529,7 @@ fn (g &Gen) interface_call(typ, interface_type table.Type) {
 	interface_styp := g.cc_type(interface_type)
 	styp := g.cc_type(typ)
 	g.write('/* $interface_styp */ I_${styp}_to_Interface(')
-	// TODO Find out why this was here
-	// if !typ.is_ptr() {
-	// g.write('&')
-	// }
+	if !typ.is_ptr() {
+		g.write('&')
+	}
 }

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -278,7 +278,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	if node.left_type == 0 {
 		verror('method receiver type is 0, this means there are some uchecked exprs')
 	}
-	mut receiver_type_name := g.cc_typ(node.receiver_type)
+	mut receiver_type_name := g.cc_type(node.receiver_type)
 	typ_sym := g.table.get_type_symbol(node.receiver_type)
 	if typ_sym.kind == .interface_ {
 		// Speaker_name_table[s._interface_idx].speak(s._object)

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -135,7 +135,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 			fields << table.Field{
 				name: field_name
 				typ: typ
-				default_expr: ast.ex2fe( default_expr )
+				default_expr: ast.ex2fe(default_expr)
 				has_default_expr: has_default_expr
 				is_pub: is_field_pub
 				is_mut: is_field_mut

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -265,8 +265,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		kind: .interface_
 		name: interface_name
 		info: table.Interface{
-			gen_types: []
-			foo: 'foo'
+			types: []
 		}
 	}
 	typ := table.new_type(p.table.register_type_symbol(t))

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -58,7 +58,7 @@ pub fn (t Type) nr_muls() int {
 // return true if `t` is a pointer (nr_muls>0)
 [inline]
 pub fn (t Type) is_ptr() bool {
-	return (int(t) >> 16) & 0xff > 0
+	return t.nr_muls() > 0
 }
 
 // set nr_muls on `t` and return it

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -58,7 +58,7 @@ pub fn (t Type) nr_muls() int {
 // return true if `t` is a pointer (nr_muls>0)
 [inline]
 pub fn (t Type) is_ptr() bool {
-	return t.nr_muls() > 0
+	return (int(t) >> 16) & 0xff > 0
 }
 
 // set nr_muls on `t` and return it
@@ -180,23 +180,23 @@ pub const (
 )
 
 pub const (
-	integer_type_idxs = [i8_type_idx, i16_type_idx, int_type_idx, i64_type_idx, byte_type_idx,
+	integer_type_idxs          = [i8_type_idx, i16_type_idx, int_type_idx, i64_type_idx, byte_type_idx,
 		u16_type_idx,
 		u32_type_idx,
 		u64_type_idx
 	]
-	signed_integer_type_idxs = [i8_type_idx, i16_type_idx, int_type_idx, i64_type_idx]
+	signed_integer_type_idxs   = [i8_type_idx, i16_type_idx, int_type_idx, i64_type_idx]
 	unsigned_integer_type_idxs = [byte_type_idx, u16_type_idx, u32_type_idx, u64_type_idx]
-	float_type_idxs   = [f32_type_idx, f64_type_idx]
-	number_type_idxs  = [i8_type_idx, i16_type_idx, int_type_idx, i64_type_idx, byte_type_idx,
+	float_type_idxs            = [f32_type_idx, f64_type_idx]
+	number_type_idxs           = [i8_type_idx, i16_type_idx, int_type_idx, i64_type_idx, byte_type_idx,
 		u16_type_idx,
 		u32_type_idx,
 		u64_type_idx,
 		f32_type_idx,
 		f64_type_idx
 	]
-	pointer_type_idxs = [voidptr_type_idx, byteptr_type_idx, charptr_type_idx]
-	string_type_idxs  = [string_type_idx, ustring_type_idx]
+	pointer_type_idxs          = [voidptr_type_idx, byteptr_type_idx, charptr_type_idx]
+	string_type_idxs           = [string_type_idx, ustring_type_idx]
 )
 
 pub const (
@@ -546,7 +546,7 @@ pub:
 // NB: FExpr here is a actually an ast.Expr .
 // It should always be used by casting to ast.Expr, using ast.fe2ex()/ast.ex2fe()
 // That hack is needed to break an import cycle between v.ast and v.table .
-type FExpr = voidptr | byteptr
+type FExpr = byteptr | voidptr
 
 pub struct Field {
 pub:

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -530,8 +530,7 @@ pub mut:
 
 pub struct Interface {
 mut:
-	gen_types []string
-	foo       string
+	types []Type
 }
 
 pub struct Enum {
@@ -632,6 +631,22 @@ pub fn (table &Table) type_to_str(t Type) string {
 	}
 	*/
 	return res
+}
+
+pub fn (t &TypeSymbol) has_method(name string) bool {
+	t.find_method(name) or {
+		return false
+	}
+	return true
+}
+
+pub fn (t &TypeSymbol) find_method(name string) ?Fn {
+	for method in t.methods {
+		if method.name == name {
+			return method
+		}
+	}
+	return none
 }
 
 pub fn (s Struct) find_field(name string) ?Field {

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -148,6 +148,7 @@ pub fn (t &Table) struct_find_field(s &TypeSymbol, name string) ?Field {
 }
 
 pub fn (t &Table) interface_add_type(inter mut Interface, typ Type) bool {
+	// TODO Verify `typ` implements `inter`
 	typ_sym := t.get_type_symbol(typ)
 	if typ !in inter.types && typ_sym.kind != .interface_ {
 		inter.types << typ

--- a/vlib/v/tests/interface_test.v
+++ b/vlib/v/tests/interface_test.v
@@ -16,6 +16,7 @@ fn (d Cat) speak() {
 }
 
 fn (d Dog) speak() {
+	assert d.breed == 'Labrador Retriever'
 	println('woof')
 }
 
@@ -42,7 +43,7 @@ fn perform_speak(s Speaker) {
 }
 
 fn test_perform_speak() {
-	dog := Dog{}
+	dog := Dog{breed: 'Labrador Retriever'}
 	perform_speak(dog)
 	cat := Cat{}
 	perform_speak(cat)

--- a/vlib/v/tests/interface_test.v
+++ b/vlib/v/tests/interface_test.v
@@ -11,16 +11,18 @@ fn (d Cat) name() string {
 	return 'Cat'
 }
 
-fn (d Cat) speak() {
+fn (d Cat) speak(s string) {
+	assert s == 'Hi !'
 	println('meow')
 }
 
-fn (d Dog) speak() {
-	assert d.breed == 'Labrador Retriever'
+fn (d Dog) speak(s string) {
+	assert s == 'Hi !'
 	println('woof')
 }
 
 fn (d Dog) name() string {
+	assert d.breed == 'Labrador Retriever'
 	return 'Dog'
 }
 
@@ -32,7 +34,7 @@ fn test_todo() {
 
 
 fn perform_speak(s Speaker) {
-	s.speak()
+	s.speak('Hi !')
 	assert true
 	name := s.name()
 	assert name == 'Dog' || name == 'Cat'
@@ -89,7 +91,7 @@ struct Foo {
 
 interface Speaker {
 	name() string
-	speak()
+	speak(s string)
 }
 
 


### PR DESCRIPTION
Add support for arguments in interfaced structs methods.
This contains a huge refactor of C generated code for interfaces. It was initially to fix the problems about arguments, but didn't help... However, generated C is a bit cleaner, and we get better C errors is some case, so it's worth keeping it in my opinion.