### PR TITLE
cgen, string interpolation: fix utf-8 string length calculation for combining characters

### DIFF
--- a/vlib/builtin/utf8.v
+++ b/vlib/builtin/utf8.v
@@ -174,8 +174,23 @@ fn utf8_len(c byte) int {
 	return b
 }
 
-// Calculate string length for formatting, i.e. number of "characters"
+// Calculate string length for in number of codepoints
 fn utf8_str_len(s string) int {
+	mut l := 0
+	for i := 0; i < s.len; i++ {
+		l++
+		c := s.str[i]
+		if (c & (1 << 7)) != 0 {
+			for t := byte(1 << 6); (c & t) != 0; t >>= 1 {
+				i++
+			}
+		}
+	}
+	return l
+}
+
+// Calculate string length for formatting, i.e. number of "characters"
+fn utf8_str_visible_length(s string) int {
 	mut l := 0
 	mut ul := 1
 	for i := 0; i < s.len; i+=ul {

--- a/vlib/builtin/utf8.v
+++ b/vlib/builtin/utf8.v
@@ -177,12 +177,32 @@ fn utf8_len(c byte) int {
 // Calculate string length for formatting, i.e. number of "characters"
 fn utf8_str_len(s string) int {
 	mut l := 0
-	for i := 0; i < s.len; i++ {
-		l++
+	mut ul := 1
+	for i := 0; i < s.len; i+=ul {
+		ul = 1
 		c := s.str[i]
 		if (c & (1 << 7)) != 0 {
 			for t := byte(1 << 6); (c & t) != 0; t >>= 1 {
-				i++
+				ul++
+			}
+		}
+		if i + ul > s.len { // incomplete UTF-8 sequence
+			return l
+		}
+		l++
+		// recognize combining characters
+		if c == 0xcc || c == 0xcd {
+			r := (u16(c) << 8) | s.str[i+1]
+			if r >= 0xcc80 && r < 0xcdb0 { // diacritical marks
+				l--
+			}
+		} else if c == 0xe1 || c == 0xe2 || c == 0xef {
+			r := (u32(c) << 16) | (u32(s.str[i+1]) << 8) | s.str[i+2]
+			if r >= 0xe1aab0 && r < 0xe1ac80 // diacritical marks extended
+			|| r >= 0xe1b780 && r < 0xe1b880 // diacritical marks supplement
+			|| r >= 0xe28390 && r < 0xe28480 // diacritical marks for symbols
+			|| r >= 0xefb8a0 && r < 0xefb8b0 { // half marks
+				l--
 			}
 		}
 	}

--- a/vlib/v/gen/str.v
+++ b/vlib/v/gen/str.v
@@ -57,9 +57,9 @@ string _STR(const char *fmt, int nfmts, ...) {
 				if (fmt[k-4] == '*') { // %*.*s
 					int fwidth = va_arg(argptr, int);
 					if (fwidth < 0)
-						fwidth -= (s.len - utf8_str_len(s));
+						fwidth -= (s.len - utf8_str_visible_length(s));
 					else
-						fwidth += (s.len - utf8_str_len(s));
+						fwidth += (s.len - utf8_str_visible_length(s));
 					_STR_PRINT_ARG(fmt, &buf, &nbytes, &memsize, k+fwidth-4, fwidth, s.len, s.str);
 				} else { // %.*s
 					_STR_PRINT_ARG(fmt, &buf, &nbytes, &memsize, k+s.len-4, s.len, s.str);

--- a/vlib/v/tests/string_interpolation_test.v
+++ b/vlib/v/tests/string_interpolation_test.v
@@ -102,6 +102,9 @@ fn test_utf8_string_interpolation() {
 	e := '\u20AC' // Eurosign
 	// TODO: this fails with MSVC and tcc
 	// assert '100.00 $e' == '100.00 €'
+	m2 := 'Москва́' // cyrillic а́: combination of U+0430 and U+0301, UTF-8: d0 b0 cc 81
+	d := 'Antonín Dvořák' // latin á: U+00E1, UTF-8: c3 a1
+	assert ':${m2:7}:${d:-15}:' == ': Москва́:Antonín Dvořák :'
 }
 
 struct S {

--- a/vlib/v/tests/string_interpolation_test.v
+++ b/vlib/v/tests/string_interpolation_test.v
@@ -105,6 +105,8 @@ fn test_utf8_string_interpolation() {
 	m2 := 'Москва́' // cyrillic а́: combination of U+0430 and U+0301, UTF-8: d0 b0 cc 81
 	d := 'Antonín Dvořák' // latin á: U+00E1, UTF-8: c3 a1
 	assert ':${m2:7}:${d:-15}:' == ': Москва́:Antonín Dvořák :'
+	g := 'Πελοπόννησος'
+	assert '>${g:-13}<' == '>Πελοπόννησος <'
 }
 
 struct S {


### PR DESCRIPTION
### Problem
Field adjustment for string interpolation is broken for some non-latin accented characters
### Cause
The current length calculation of UTF-8 strings counts the number of coded unicode codepoints (i.e. number of runes). However, there are certain "combining characters" that have their own indipendent codepoint (and UTF-8 sequence) but add just diacritical marks (accents, ...) to the previous character without occupying space on their own.
### Solution
The code in this PR identifies those combining characters and doesn't count them to the length.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
