### PR TITLE
gen: fix compiler_test.v error on windows

### DIFF
--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -472,7 +472,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 		}
 	} else if g.pref.is_debug && node.name == 'panic' && g.fn_decl.name != '__as_cast' {
 		paline := node.pos.line_nr + 1
-		pafile := g.fn_decl.file
+		pafile := g.fn_decl.file.replace('\\', '/')
 		pafn := g.fn_decl.name.after('.')
 		mut pamod := g.fn_decl.name.all_before_last('.')
 		if pamod == pafn {


### PR DESCRIPTION
This PR fix compiler_test.v error on windows.

**Cause**
```v
panic_debug(92, tos3("C:\Users\yuyi9\v\vlib\strings\builder.c.v"), ...
```
error: incomplete universal character name `\U`.

**Solution**
```v
pafile := g.fn_decl.file.replace('\\', '/')
```