### PR TITLE
tests: fix cleanup of compiler_test.v on windows

### DIFF
--- a/vlib/v/tests/inout/compiler_test.v
+++ b/vlib/v/tests/inout/compiler_test.v
@@ -23,18 +23,26 @@ fn test_all() {
 		os.cp(path, program) or {
 			panic(err)
 		}
-		compilation := os.exec('$vexe -o exe -cflags "-w" -cg $program') or {
+		compilation := os.exec('$vexe -o test -cflags "-w" -cg $program') or {
 			panic(err)
 		}
 		if compilation.exit_code != 0 {
 			panic('compilation failed: $compilation.output')
 		}
 		// os.rm(program)
-		res := os.exec('./exe') or {
+		res := os.exec('./test') or {
 			println('nope')
 			panic(err)
 		}
-		os.rm('./exe')
+		$if windows {
+			os.rm('./test.exe')
+			$if msvc {
+				os.rm('./test.ilk')
+				os.rm('./test.pdb')
+			}
+		} $else {
+			os.rm('./test')
+		}
 		// println('============')
 		// println(res.output)
 		// println('============')


### PR DESCRIPTION
This PR fix cleanup of compiler_test.v on windows.

**Problem**
- Residual `exe.exe` file after `compiler_test.v` testing.

**Solution**
- Change `exe` to `test` and:
```v
$if windows {
	os.rm('./test.exe')
	$if msvc {
		os.rm('./test.ilk')
		os.rm('./test.pdb')
	}
} $else {
	os.rm('./test')
}
```