### PR TITLE
checker: fix array init []type{cap: x.len} error (fix #4686)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1093,6 +1093,18 @@ pub fn (mut c Checker) array_init(array_init mut ast.ArrayInit) table.Type {
 	mut elem_type := table.void_type
 	// []string - was set in parser
 	if array_init.typ != table.void_type {
+		if array_init.exprs.len == 0 {
+			if array_init.has_cap {
+				if c.expr(array_init.cap_expr) != table.int_type {
+					c.error('array cap needs to be an int', array_init.pos)
+				}
+			}
+			if array_init.has_len {
+				if c.expr(array_init.len_expr) != table.int_type {
+					c.error('array len needs to be an int', array_init.pos)
+				}
+			}
+		}
 		return array_init.typ
 	}
 	// a = []

--- a/vlib/v/tests/array_init_test.v
+++ b/vlib/v/tests/array_init_test.v
@@ -1,0 +1,16 @@
+struct Init {
+	len int
+}
+
+fn test_array_init() {
+	b := [1, 2, 3]
+	mut a := []int{cap: b.len}
+	a << 1
+	'$a, $a.len, $a.cap' == '[1], 1, 3'
+
+	c := Init{len: 3}
+	mut d := []string{cap: c.len}
+	d << 'aaa'
+	d << 'bbb'
+	'$d, $d.len, $d.cap' == "['aaa', 'bbb'], 2, 3"
+}


### PR DESCRIPTION
This PR fix array init []type{cap: x.len} error (fix #4686).

- Fix array init []type{cap: x.len} error.
- Add test `array_init_test.v`.

```v
struct Init {
	len int
}
fn test_array_init() {
	b := [1, 2, 3]
	mut a := []int{cap: b.len}
	a << 1
	'$a, $a.len, $a.cap' == '[1], 1, 3'

	c := Init{len: 3}
	mut d := []string{cap: c.len}
	d << 'aaa'
	d << 'bbb'
	'$d, $d.len, $d.cap' == "['aaa', 'bbb'], 2, 3"
}
```