### PR TITLE
voidptr.str() and byteptr.str() (fix #3122)

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -345,6 +345,14 @@ pub fn (nn i64) hex() string {
 	return u64(nn).hex()
 }
 
+pub fn (nn voidptr) str() string {
+	return u64(nn).hex()
+}
+
+pub fn (nn byteptr) str() string {
+	return u64(nn).hex()
+}
+
 // ----- utilities functions -----
 
 pub fn (a []byte) contains(val byte) bool {

--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -71,6 +71,10 @@ fn test_str_methods() {
 	assert u32(-1).str() == '4294967295'
 	assert u64(1).str() == '1'
 	assert u64(-1).str() == '18446744073709551615'
+	assert voidptr(-1).str() == 'ffffffffffffffff'
+	assert voidptr(1).str() == '1'
+	assert byteptr(-1).str() == 'ffffffffffffffff'
+	assert byteptr(1).str() == '1'
 }
 
 fn test_and_precendence() {


### PR DESCRIPTION
While this is quick fix to #3122, I not sure if this is they way we want it. There should probably be something more general for all pointers. Feel free to close this, if it should be handled elsewhere or in some other way. 