### PR TITLE
mysql: Update code &  add a feature to get value as map

### DIFF
--- a/vlib/mysql/_cdefs.c.v
+++ b/vlib/mysql/_cdefs.c.v
@@ -25,36 +25,36 @@ struct C.MYSQL_FIELD {
 	@type            int     /* Type of field. See mysql_com.h for types */
 }
 
-fn C.mysql_init(mysql &MYSQL) &MYSQL
-fn C.mysql_real_connect(mysql &MYSQL, host byteptr, user byteptr, passwd byteptr, db byteptr, port u32, unix_socket byteptr, clientflag u64) &MYSQL
-fn C.mysql_query(mysql &MYSQL, q byteptr) int
-fn C.mysql_select_db(mysql &MYSQL, db byteptr) int
-fn C.mysql_change_user(mysql &MYSQL, user byteptr, password byteptr, db byteptr) bool
-fn C.mysql_affected_rows(mysql &MYSQL) u64
-fn C.mysql_options(mysql &MYSQL, option int, arg voidptr) int
-fn C.mysql_get_option(mysql &MYSQL, option int, arg voidptr) int
-fn C.mysql_num_fields(res &MYSQL_RES) int
+fn C.mysql_init(mysql &C.MYSQL) &C.MYSQL
+fn C.mysql_real_connect(mysql &C.MYSQL, host byteptr, user byteptr, passwd byteptr, db byteptr, port u32, unix_socket byteptr, clientflag u64) &C.MYSQL
+fn C.mysql_query(mysql &C.MYSQL, q byteptr) int
+fn C.mysql_select_db(mysql &C.MYSQL, db byteptr) int
+fn C.mysql_change_user(mysql &C.MYSQL, user byteptr, password byteptr, db byteptr) bool
+fn C.mysql_affected_rows(mysql &C.MYSQL) u64
+fn C.mysql_options(mysql &C.MYSQL, option int, arg voidptr) int
+fn C.mysql_get_option(mysql &C.MYSQL, option int, arg voidptr) int
+fn C.mysql_num_fields(res &C.MYSQL_RES) int
 fn C.mysql_autocommit(mysql MYSQL, mode bool)
 fn C.mysql_refresh(mysql MYSQL, options u32) int
 fn C.mysql_reset_connection(mysql MYSQL) int
 fn C.mysql_ping(mysql MYSQL) int
-fn C.mysql_store_result(mysql &MYSQL) &MYSQL_RES
-fn C.mysql_fetch_row(res &MYSQL_RES) &byteptr
-fn C.mysql_fetch_fields(res &MYSQL_RES) &MYSQL_FIELD
-fn C.mysql_free_result(res &MYSQL_RES)
-fn C.mysql_real_escape_string_quote(mysql &MYSQL, to byteptr, from byteptr, len u64, quote byte) u64
-fn C.mysql_close(sock &MYSQL)
+fn C.mysql_store_result(mysql &C.MYSQL) &C.MYSQL_RES
+fn C.mysql_fetch_row(res &C.MYSQL_RES) &byteptr
+fn C.mysql_fetch_fields(res &C.MYSQL_RES) &C.MYSQL_FIELD
+fn C.mysql_free_result(res &C.MYSQL_RES)
+fn C.mysql_real_escape_string_quote(mysql &C.MYSQL, to byteptr, from byteptr, len u64, quote byte) u64
+fn C.mysql_close(sock &C.MYSQL)
 
 /* INFO & VERSION */
-fn C.mysql_info(mysql &MYSQL) byteptr
-fn C.mysql_get_host_info(mysql &MYSQL) byteptr
-fn C.mysql_get_server_info(mysql &MYSQL) byteptr
-fn C.mysql_get_server_version(mysql &MYSQL) u64
+fn C.mysql_info(mysql &C.MYSQL) byteptr
+fn C.mysql_get_host_info(mysql &C.MYSQL) byteptr
+fn C.mysql_get_server_info(mysql &C.MYSQL) byteptr
+fn C.mysql_get_server_version(mysql &C.MYSQL) u64
 fn C.mysql_get_client_version() u64
 fn C.mysql_get_client_info() byteptr
 
 /* DEBUG & ERROR INFO */
-fn C.mysql_error(mysql &MYSQL) byteptr
-fn C.mysql_errno(mysql &MYSQL) int
-fn C.mysql_dump_debug_info(mysql &MYSQL) int
+fn C.mysql_error(mysql &C.MYSQL) byteptr
+fn C.mysql_errno(mysql &C.MYSQL) int
+fn C.mysql_dump_debug_info(mysql &C.MYSQL) int
 fn C.mysql_debug(debug byteptr)

--- a/vlib/mysql/mysql.v
+++ b/vlib/mysql/mysql.v
@@ -12,11 +12,11 @@ pub struct Connection {
 	dbname   string
 	flag     int
 mut:
-	conn     &MYSQL
+	conn     &C.MYSQL
 }
 
 pub fn new_connection(host, username, password, dbname string) ?Connection {
-	instance := mysql_init(0)
+	instance := C.mysql_init(0)
 	if isnil(instance) {
 		return error_with_code(get_error_msg(instance), get_errno(instance))
 	}
@@ -24,7 +24,7 @@ pub fn new_connection(host, username, password, dbname string) ?Connection {
 }
 
 pub fn (conn mut Connection) connect() ?bool {
-	mut instance := mysql_init(0)
+	mut instance := C.mysql_init(0)
 	if !isnil(conn.conn) {
 		instance = conn.conn
 	}
@@ -48,15 +48,15 @@ pub fn (conn mut Connection) connect() ?bool {
 }
 
 pub fn (conn Connection) query(q string) ?Result {
-	if mysql_query(conn.conn, q.str) != 0 {
+	if C.mysql_query(conn.conn, q.str) != 0 {
 		return error_with_code(get_error_msg(conn.conn), get_errno(conn.conn))
 	}
-	res := mysql_store_result(conn.conn)
+	res := C.mysql_store_result(conn.conn)
 	return Result{res}
 }
 
 pub fn (conn Connection) select_db(dbname string) ?bool {
-	if mysql_select_db(conn.conn, dbname.str) != 0 {
+	if C.mysql_select_db(conn.conn, dbname.str) != 0 {
 		return error_with_code(get_error_msg(conn.conn), get_errno(conn.conn))
 	}
 	return true
@@ -65,9 +65,9 @@ pub fn (conn Connection) select_db(dbname string) ?bool {
 pub fn (conn Connection) change_user(username, password, dbname string) ?bool {
 	mut ret := true
 	if dbname != '' {
-		ret = mysql_change_user(conn.conn, username.str, password.str, dbname.str)
+		ret = C.mysql_change_user(conn.conn, username.str, password.str, dbname.str)
 	} else {
-		ret = mysql_change_user(conn.conn, username.str, password.str, 0)
+		ret = C.mysql_change_user(conn.conn, username.str, password.str, 0)
 	}
 	if !ret {
 		return error_with_code(get_error_msg(conn.conn), get_errno(conn.conn))
@@ -76,94 +76,94 @@ pub fn (conn Connection) change_user(username, password, dbname string) ?bool {
 }
 
 pub fn (conn Connection) affected_rows() u64 {
-	return mysql_affected_rows(conn.conn)
+	return C.mysql_affected_rows(conn.conn)
 }
 
 pub fn (conn Connection) autocommit(mode bool) {
-	mysql_autocommit(conn.conn, mode)
+	C.mysql_autocommit(conn.conn, mode)
 }
 
 
 pub fn (conn Connection) escape_string(s string) string {
-    len := strlen(s.str)
+    len := C.strlen(s.str)
     to := malloc(2 * len + 1)
     quote := byte(39) // single quote
 
-    mysql_real_escape_string_quote(conn.conn, to, s.str, len, quote)
+    C.mysql_real_escape_string_quote(conn.conn, to, s.str, len, quote)
     return string(to)
 }
 
 pub fn (conn Connection) set_option(option_type int, val voidptr) {
-	mysql_options(conn.conn, option_type, val)
+	C.mysql_options(conn.conn, option_type, val)
 }
 
 pub fn (conn Connection) get_option(option_type int) ?voidptr {
 	ret := voidptr(0)
-	if mysql_get_option(conn.conn, option_type, &ret) != 0 {
+	if C.mysql_get_option(conn.conn, option_type, &ret) != 0 {
 		return error_with_code(get_error_msg(conn.conn), get_errno(conn.conn))
 	}
 	return ret
 }
 
 pub fn (conn Connection) refresh(options u32) ?bool {
-	if mysql_refresh(conn.conn, options) != 0 {
+	if C.mysql_refresh(conn.conn, options) != 0 {
 		return error_with_code(get_error_msg(conn.conn), get_errno(conn.conn))
 	}
 	return true
 }
 
 pub fn (conn Connection) reset_connection() ?bool {
-	if mysql_reset_connection(conn.conn) != 0 {
+	if C.mysql_reset_connection(conn.conn) != 0 {
 		return error_with_code(get_error_msg(conn.conn), get_errno(conn.conn))
 	}
 	return true
 }
 
 pub fn (conn Connection) ping() ?bool {
-	if mysql_ping(conn.conn) != 0 {
+	if C.mysql_ping(conn.conn) != 0 {
 		return error_with_code(get_error_msg(conn.conn), get_errno(conn.conn))
 	}
 	return true
 }
 
 pub fn (conn Connection) close() {
-	mysql_close(conn.conn)
+	C.mysql_close(conn.conn)
 }
 
 /* MYSQL INFO & VERSION */
 
 pub fn (conn Connection) info() string {
-	return string(mysql_info(conn.conn))
+	return string(C.mysql_info(conn.conn))
 }
 
 pub fn (conn Connection) get_host_info() string {
-	return string(mysql_get_host_info(conn.conn))
+	return string(C.mysql_get_host_info(conn.conn))
 }
 
 pub fn (conn Connection) get_server_info() string {
-	return string(mysql_get_server_info(conn.conn))
+	return string(C.mysql_get_server_info(conn.conn))
 }
 
 pub fn (conn Connection) get_server_version() u64 {
-	return mysql_get_server_version(conn.conn)
+	return C.mysql_get_server_version(conn.conn)
 }
 
 pub fn get_client_version() u64 {
-	return mysql_get_client_version()
+	return C.mysql_get_client_version()
 }
 
 pub fn get_client_info() string {
-	return string(mysql_get_client_info())
+	return string(C.mysql_get_client_info())
 }
 
 /* MYSQL DEBUG */
 pub fn (conn Connection) dump_debug_info() ?bool {
-	if mysql_dump_debug_info(conn.conn) != 0 {
+	if C.mysql_dump_debug_info(conn.conn) != 0 {
 		return error_with_code(get_error_msg(conn.conn), get_errno(conn.conn))
 	}
 	return true
 }
 
 pub fn debug(debug string) {
-	mysql_debug(debug.str)
+	C.mysql_debug(debug.str)
 }

--- a/vlib/mysql/result.v
+++ b/vlib/mysql/result.v
@@ -1,7 +1,7 @@
 module mysql
 
 pub struct Result {
-	result &MYSQL_RES
+	result &C.MYSQL_RES
 }
 
 pub struct Row {
@@ -33,11 +33,11 @@ pub struct Field {
 }
 
 pub fn (r Result) fetch_row() &byteptr {
-	return mysql_fetch_row(r.result)
+	return C.mysql_fetch_row(r.result)
 }
 
 pub fn (r Result) num_fields() int {
-	return mysql_num_fields(r.result)
+	return C.mysql_num_fields(r.result)
 }
 
 pub fn (r Result) rows() []Row {
@@ -60,7 +60,7 @@ pub fn (r Result) rows() []Row {
 pub fn (r Result) fetch_fields() []Field {
 	mut fields := []Field{}
 	nr_cols := r.num_fields()
-	orig_fields := mysql_fetch_fields(r.result)
+	orig_fields := C.mysql_fetch_fields(r.result)
 	for i in 0..nr_cols {
 		fields << Field{
 			name: string(orig_fields[i].name)
@@ -116,5 +116,5 @@ pub fn (f Field) str() string {
 }
 
 pub fn (r Result) free() {
-	mysql_free_result(r.result)
+	C.mysql_free_result(r.result)
 }

--- a/vlib/mysql/result.v
+++ b/vlib/mysql/result.v
@@ -57,6 +57,24 @@ pub fn (r Result) rows() []Row {
 	return rows
 }
 
+pub fn (r Result) maps() []map[string]string {
+	mut array_map := []map[string]string{}
+	rows := r.rows()
+	for i in 0..rows.len {
+		array_map << r.create_map_value(rows[i])
+	}
+	return array_map
+}
+
+fn (r Result) create_map_value(row Row) map[string]string {
+	mut map_ := map[string]string
+	fields := r.fetch_fields()
+	for i in 0..fields.len {
+		map_[fields[i].name] = row.vals[i]
+	}
+	return map_
+}
+
 pub fn (r Result) fetch_fields() []Field {
 	mut fields := []Field{}
 	nr_cols := r.num_fields()

--- a/vlib/mysql/utils.v
+++ b/vlib/mysql/utils.v
@@ -1,11 +1,11 @@
 module mysql
 
-fn get_error_msg(conn &MYSQL) string {
-	return string(mysql_error(conn))
+fn get_error_msg(conn &C.MYSQL) string {
+	return string(C.mysql_error(conn))
 }
 
-fn get_errno(conn &MYSQL) int {
-	return mysql_errno(conn)
+fn get_errno(conn &C.MYSQL) int {
+	return C.mysql_errno(conn)
 }
 
 fn resolve_nil_str(ptr byteptr) string {


### PR DESCRIPTION
```v
import mysql

fn main() {
	connection := mysql.new_connection('127.0.0.1', 'root', '', 'my_db') or { panic(err) }
	connection.connect() or { panic(err) }

	result := connection.query('SELECT * FROM users') or { panic(err) }

        // Get result as map, so we can access with field name
	map_results := result.maps()

       // BTW, The code below doesnt work
       println(map_results)
	
	for i in 0..map_results.len {
		id := map_results[i]['user_id']
		name := map_results[i]['name']
	}
}
```