### PR TITLE
cgen: fix variable shadowing of "i" when .map() nested in "for i, _ in ..."

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2576,10 +2576,11 @@ fn (mut g Gen) gen_map(node ast.CallExpr) {
 	g.expr(node.left)
 	g.writeln('.len;')
 	g.writeln('$ret_typ $tmp = __new_array(0, ${tmp}_len, sizeof($ret_elem_type));')
-	g.writeln('for (int i = 0; i < ${tmp}_len; i++) {')
+	i := g.new_tmp_var()
+	g.writeln('for (int $i = 0; $i < ${tmp}_len; $i++) {')
 	g.write('\t$inp_elem_type it = (($inp_elem_type*) ')
 	g.expr(node.left)
-	g.writeln('.data)[i];')
+	g.writeln('.data)[$i];')
 	g.write('\t$ret_elem_type ti = ')
 	g.expr(node.args[0].expr) // the first arg is the filter condition
 	g.writeln(';')


### PR DESCRIPTION
By hardcoding `i` as the index variable, this would sometimes conflict with a variable also called `i` by the user, such as

```v
mut mapped := [][]int{}
for i, _ in my_nums {
    mapped << my_nums[i].map(it + 5)
}
```

which is how I found this bug in the first place.

I can add tests.