### PR TITLE
builtin: Add parenthesis around frame_addr as a workaround

### DIFF
--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -111,7 +111,7 @@ $if msvc {
 				lineinfo = '${file_name}:${sline64.f_line_number}'
 			} else {
 				addr :
-				lineinfo = '?? : address = 0x${&frame_addr:x}'
+				lineinfo = '?? : address = 0x${(&frame_addr):x}'
 			}
 			sfunc := tos3(fname)
 			eprintln('${nframe:-2d}: ${sfunc:-25s}  $lineinfo')


### PR DESCRIPTION
Fixes #4719. Add workaround fix for compiling V programs on Windows. Before the fix, it outputs this:
```
For usage information, quit V REPL using `exit` and use `v help`
cannot compile ‘C:\Users\admin\Documents\Coding\v\cmd\tools\vrepl.v:
  113 |                 addr :
  114 |                 lineinfo = '?? : address = 0x${&frame_addr:x}'
      |                                                              ^
  115 |             }
```