### PR TITLE
fn: pass around fn's (fix #4687)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1609,8 +1609,10 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 			return table.string_type
 		}
 		ast.AnonFn {
+			keep_ret_type := c.fn_return_type
 			c.fn_return_type = it.decl.return_type
 			c.stmts(it.decl.stmts)
+			c.fn_return_type = keep_ret_type
 			return it.typ
 		}
 		else {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -359,11 +359,7 @@ typedef struct {
 				info := typ.info as table.FnType
 				func := info.func
 				sym := g.table.get_type_symbol(func.return_type)
-				is_multi := match sym.kind {
-					.multi_return { true }
-					else { false }
-				}
-
+				is_multi :=  sym.kind == .multi_return
 				is_fn_sig := func.name == ''
 				if !info.has_decl && (!info.is_anon || is_fn_sig) && !is_multi {
 					fn_name := if func.is_c {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1933,7 +1933,7 @@ fn (mut g Gen) return_statement(node ast.Return) {
 
 	// got to do a correct check for multireturn
 	sym := g.table.get_type_symbol(g.fn_decl.return_type)
-	mut fn_return_is_multi := sym.kind == .multi_return
+	fn_return_is_multi := sym.kind == .multi_return
 
 	// optional multi not supported
 	if fn_return_is_multi && !fn_return_is_optional {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1933,11 +1933,7 @@ fn (mut g Gen) return_statement(node ast.Return) {
 
 	// got to do a correct check for multireturn
 	sym := g.table.get_type_symbol(g.fn_decl.return_type)
-	mut fn_return_is_multi := match sym.kind {
-		.multi_return { true }
-		else { false }
-	}
-	fn_return_is_multi = fn_return_is_multi
+	mut fn_return_is_multi := sym.kind == .multi_return
 
 	// optional multi not supported
 	if fn_return_is_multi && !fn_return_is_optional {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1963,7 +1963,7 @@ fn (mut g Gen) return_statement(node ast.Return) {
 		if fn_return_is_optional {
 			g.write(' }, sizeof($styp))')
 		}
-	} else if node.exprs.len == 1 {
+	} else if node.exprs.len >= 1 {
 		// normal return
 		g.write(' ')
 		return_sym := g.table.get_type_symbol(node.types[0])

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -369,11 +369,12 @@ pub fn (mut t Table) find_or_register_multi_return(mr_typs []Type) int {
 
 pub fn (mut t Table) find_or_register_fn_type(f Fn, is_anon, has_decl bool) int {
 	name := if f.name.len == 0 { 'anon_fn_$f.signature()' } else { f.name }
+	anon := f.name.len == 0 || is_anon
 	return t.register_type_symbol(TypeSymbol{
 		kind: .function
 		name: name
 		info: FnType{
-			is_anon: f.name.len == 0 || is_anon
+			is_anon: anon
 			has_decl: has_decl
 			func: f
 		}

--- a/vlib/v/tests/fn_test.v
+++ b/vlib/v/tests/fn_test.v
@@ -120,6 +120,58 @@ fn high_fn_multi_return(a int, b fn (c []int, d []string) ([]int, []string)) {
 
 }
 
+fn high_fn_return_single_anon() (fn(int)f32) {
+	_ := 1
+	correct := fn(n int)f32 {
+		return n * n
+	}
+	return correct
+}
+fn high_fn_return_multi_anons() (fn(int)f32, fn(int)string) {
+	// parsing trap
+	_ := fn(n int)byte {
+		return 0x00
+	}
+	correct_second := fn(n int)string {
+		return '$n'
+	}
+	correct_first := fn(n int)f32 {
+		return n * n
+	}
+	// parsing trap
+	_ := fn(n int)[]int {
+		return [n]
+	}
+	return correct_first, correct_second
+}
+fn high_fn_return_named_fn() (fn(int)int) {
+	return sqr
+}
+fn test_high_fn_ret_anons() {
+	param := 13
+	func_sqr1 := high_fn_return_single_anon()
+	assert func_sqr1(param) == param * param
+
+	func_sqr2, func_repr := high_fn_return_multi_anons()
+	assert func_sqr2(param) == (param * param)
+	assert func_repr(param) == '$param'
+
+	top_lvl_sqr := high_fn_return_named_fn()
+	assert top_lvl_sqr(param) == param * param
+}
+
+fn high_fn_applier(arg int, func fn(a int)string) string {
+	return func(arg)
+}
+fn test_high_fn_applier() {
+	arg := 13
+	expect := '$arg $arg'
+	func := fn (arg int) string {
+		return '$arg $arg'
+	}
+	assert expect == high_fn_applier(arg, func)
+}
+
 fn sqr(x int) int {
 	return x * x
 }


### PR DESCRIPTION
Fixing codegen and parser for anon fn's and signatures. It's possible to to return anonymous/named functions from functions. It's possible to pass functions as arguments. There are probably some corner cases that need more work.

This fixes issue #4687:
```
fn foo() (fn(int)int ) {
	double_fn := fn(n int) int {
		return  n + n
        }
	return double_fn
}

fn main() {
	df := foo()
	x := df(3)
	println(x)	// expect 6
}
```