### PR TITLE
checker: check string(1) cast error (fix #4714)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -678,7 +678,7 @@ pub:
 	expr      Expr // `buf`
 	arg       Expr // `n` in `string(buf, n)`
 	typ       table.Type // `string`
-	pos token.Position
+	pos       token.Position
 mut:
 	typname   string
 	expr_type table.Type // `byteptr`
@@ -777,7 +777,9 @@ fn (expr Expr) position() token.Position {
 		AssignExpr {
 			return it.pos
 		}
-		// ast.CastExpr { }
+		CastExpr {
+			return it.pos
+		}
 		Assoc {
 			return it.pos
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1512,6 +1512,10 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 		}
 		ast.CastExpr {
 			it.expr_type = c.expr(it.expr)
+			sym := c.table.get_type_symbol(it.expr_type)
+			if it.typ == table.string_type && sym.name !in ['byte', 'array_byte', 'byteptr'] {
+				c.error('cannot cast type `$sym.name` to string', it.pos)
+			}
 			if it.has_arg {
 				c.expr(it.arg)
 			}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1514,7 +1514,8 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 			it.expr_type = c.expr(it.expr)
 			sym := c.table.get_type_symbol(it.expr_type)
 			if it.typ == table.string_type && sym.name !in ['byte', 'array_byte', 'byteptr'] {
-				c.error('cannot cast type `$sym.name` to string', it.pos)
+				type_name := c.table.type_to_str(it.expr_type)
+				c.error('cannot cast type `$type_name` to string', it.pos)
 			}
 			if it.has_arg {
 				c.expr(it.arg)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1513,7 +1513,8 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 		ast.CastExpr {
 			it.expr_type = c.expr(it.expr)
 			sym := c.table.get_type_symbol(it.expr_type)
-			if it.typ == table.string_type && sym.name !in ['byte', 'array_byte', 'byteptr'] {
+			if it.typ == table.string_type && !(sym.kind in [.byte, .byteptr] ||
+				sym.kind == .array && sym.name == 'array_byte') {
 				type_name := c.table.type_to_str(it.expr_type)
 				c.error('cannot cast type `$type_name` to string', it.pos)
 			}

--- a/vlib/v/checker/tests/cast_string_err.out
+++ b/vlib/v/checker/tests/cast_string_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/cast_string_err.v:2:14: error: cannot cast type `int` to string
+    1 | fn main() {
+    2 |     a := string(1)
+      |                 ^
+    3 |     println(a)
+    4 | }

--- a/vlib/v/checker/tests/cast_string_err.vv
+++ b/vlib/v/checker/tests/cast_string_err.vv
@@ -1,0 +1,4 @@
+fn main() {
+	a := string(1)
+	println(a)
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -674,7 +674,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 				expr: expr
 				arg: arg
 				has_arg: has_arg
-				pos: p.tok.position()
+				pos: expr.position()
 			}
 			p.expr_mod = ''
 			return node


### PR DESCRIPTION
This PR check string(1) cast error.

- Check string(x) cast error.
- Add test `cast_string_err.vv/out`.

```v
D:\test\v\tt1>v run .
.\tt1.v:2:14: error: cannot cast type `f64` to string 
    1 | fn main() {
    2 |     a := string(1.1)
      |                 ~~~
    3 |     println(a)
    4 | }
```