### PR TITLE
all: use uniform message reference format

### DIFF
--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -21,7 +21,7 @@ fn main() {
 		if !result.output.contains('Permission denied') {
 			err = '\n$result.output'
 		}
-		eprintln('cannot compile to ‘$vroot: $err')
+		eprintln('cannot compile to `$vroot`: $err')
 		exit(1)
 	}
 	if result.output.len > 0 {

--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -17,7 +17,7 @@ fn main() {
 
 	if git_result.exit_code != 0 {
 		if git_result.output.contains('Permission denied') {
-			eprintln('have no access ‘$vroot: Permission denied')
+			eprintln('have no access `$vroot`: Permission denied')
 		} else {
 			eprintln(git_result.output)
 		}
@@ -29,8 +29,8 @@ fn main() {
 	current_hash := util.githash(true)
 	// println(v_hash)
 	// println(current_hash)
-	if v_hash == current_hash { 
-		return 
+	if v_hash == current_hash {
+		return
 	}
 
 	$if windows {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -883,7 +883,7 @@ pub fn (mut c Checker) check_or_block(call_expr mut ast.CallExpr, ret_type table
 	if is_ret_used {
 		if !c.is_last_or_block_stmt_valid(last_stmt) {
 			expected_type_name := c.table.get_type_symbol(ret_type).name
-			c.error('last statement in the `or {}` block should return ‘$expected_type_name‘',
+			c.error('last statement in the `or {}` block should return `$expected_type_name`',
 				call_expr.pos)
 			return
 		}

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -113,9 +113,9 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 				} else if p.tok.kind == .name {
 					p.next()
 					lit := if p.tok.lit != '' { p.tok.lit } else { p.tok.kind.str() }
-					p.error('unexpected ‘$lit‘, expecting ‘:‘')
+					p.error('unexpected `$lit`, expecting `:`')
 				} else {
-					p.error('unexpected ‘$p.tok.lit‘, expecting struct key')
+					p.error('unexpected `$p.tok.lit`, expecting struct key')
 				}
 			}
 			p.check(.rcbr)

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -150,7 +150,7 @@ pub fn launch_tool(is_verbose bool, tool_name string) {
 			if !tool_compilation.output.contains('Permission denied') {
 				err = '\n$tool_compilation.output'
 			}
-			eprintln('cannot compile ‘$tool_source: $err‘')
+			eprintln('cannot compile `$tool_source`: $err')
 			exit(1)
 		}
 	}


### PR DESCRIPTION
This PR uniform message reference format, because under msvc2015 will make an compiler error.

