### PR TITLE
cgen: fix struct with map field str() error

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3271,7 +3271,7 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp, str_fn_name string) {
 			} else if sym.kind == .struct_ {
 				g.auto_str_funcs.write('indents, ')
 				g.auto_str_funcs.write('${field_styp_fn_name}( it->${field.name}${second_str_param} ) ')
-			} else if sym.kind in [.array, .array_fixed] {
+			} else if sym.kind in [.array, .array_fixed, .map] {
 				g.auto_str_funcs.write('indents, ')
 				g.auto_str_funcs.write('${field_styp_fn_name}( it->${field.name}) ')
 			} else {

--- a/vlib/v/tests/string_interpolation_struct_test.v
+++ b/vlib/v/tests/string_interpolation_struct_test.v
@@ -10,12 +10,12 @@ struct Man {
 fn test_default_struct_string_interpolation() {
 	superman := Man{'Superman', 30, ['flying', 'fighting evil', 'being nice']}
 	s := '$superman'
-	assert s.contains('Man {')
+	assert s.starts_with('Man {')
 	assert s.contains("name: 'Superman'")
 	assert s.contains('age: 30')
 	assert s.contains('interests: [')
 	assert s.contains("'being nice'")
-	assert s.contains('}')
+	assert s.ends_with('}')
 	// println(s)
 }
 
@@ -29,9 +29,9 @@ fn test_fixed_array_struct_string_interpolation() {
 	x := 2.32
 	ctx.vb = [1.1, x, 3.3, 4.4, 5.0, 6.0, 7.0, 8.9]!!
 	s := '$ctx'
-	assert s.contains('Context {')
+	assert s.starts_with('Context {')
 	assert s.contains('vb: [1.1, 2.32, 3.3, 4.4, 5, 6, 7, 8.9]')
-	assert s.contains('}')
+	assert s.ends_with('}')
 }
 
 struct Info {
@@ -45,8 +45,8 @@ fn test_struct_map_field_string_interpolation() {
 		dict: {'a': 1, 'b': 2}
 	}
 	s := '$info'
-	assert s.contains('Info {')
+	assert s.starts_with('Info {')
 	assert s.contains("name: 'test'")
 	assert s.contains("dict: {'a': 1, 'b': 2}")
-	assert s.contains('}')
+	assert s.ends_with('}')
 }

--- a/vlib/v/tests/string_interpolation_struct_test.v
+++ b/vlib/v/tests/string_interpolation_struct_test.v
@@ -33,3 +33,20 @@ fn test_fixed_array_struct_string_interpolation() {
 	assert s.contains('vb: [1.1, 2.32, 3.3, 4.4, 5, 6, 7, 8.9]')
 	assert s.contains('}')
 }
+
+struct Info {
+	name string
+	dict map[string]int
+}
+
+fn test_struct_map_field_string_interpolation() {
+	info := Info{
+		name: 'test'
+		dict: {'a': 1, 'b': 2}
+	}
+	s := '$info'
+	assert s.contains('Info {')
+	assert s.contains("name: 'test'")
+	assert s.contains("dict: {'a': 1, 'b': 2}")
+	assert s.contains('}')
+}


### PR DESCRIPTION
This PR fix struct with map field str() error.

- Fix struct with map field str() error.
- Add test `test_struct_map_field_string_interpolation()`.

```v
struct Info {
	name string
	dict map[string]int
}

fn main() {
	info := Info{
		name: 'test'
		dict: {'a': 1, 'b': 2}
	}
	println(info)
}

D:\test\v\tt1>v run .
Info {
    name: 'test'
    dict: {'a': 1, 'b': 2}
}
```