### PR TITLE
make.bat: add default msvc2015 config when there is no vswhere.exe

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -49,7 +49,6 @@ goto :success
 :msvc_strap
 echo Attempting to build v.c  with MSVC...
 set VsWhereDir=%ProgramFiles(x86)%
-set Vs2015InstallDir="%VsWhereDir%\Microsoft Visual Studio 14.0"
 set HostArch=x64
 if "%PROCESSOR_ARCHITECTURE%" == "x86" (
 	echo Using x86 Build Tools...
@@ -62,8 +61,8 @@ for /f "usebackq tokens=*" %%i in (`"%VsWhereDir%\Microsoft Visual Studio\Instal
 
 if exist %InstallDir%\Common7\Tools\vsdevcmd.bat (
 	call %InstallDir%\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
-) else if exist %Vs2015InstallDir%\Common7\Tools\vsdevcmd.bat (
-	call %Vs2015InstallDir%\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
+) else if exist "%VsWhereDir%\Microsoft Visual Studio 14.0\Common7\Tools\vsdevcmd.bat" (
+	call "%VsWhereDir%\Microsoft Visual Studio 14.0\Common7\Tools\vsdevcmd.bat" -arch=%HostArch% -host_arch=%HostArch% -no_logo
 ) else (
 	goto :no_compiler
 )

--- a/make.bat
+++ b/make.bat
@@ -61,8 +61,8 @@ for /f "usebackq tokens=*" %%i in (`"%VsWhereDir%\Microsoft Visual Studio\Instal
 
 if exist %InstallDir%\Common7\Tools\vsdevcmd.bat (
 	call %InstallDir%\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
-) else if exist "%VsWhereDir%\Microsoft Visual Studio 14.0\Common7\Tools\vsdevcmd.bat" (
-	call "%VsWhereDir%\Microsoft Visual Studio 14.0\Common7\Tools\vsdevcmd.bat" -arch=%HostArch% -host_arch=%HostArch% -no_logo
+) else if exist "%VsWhereDir%/Microsoft Visual Studio 14.0/Common7/Tools/vsdevcmd.bat" (
+	call "%VsWhereDir%/Microsoft Visual Studio 14.0/Common7/Tools/vsdevcmd.bat" -arch=%HostArch% -host_arch=%HostArch% -no_logo
 ) else (
 	goto :no_compiler
 )

--- a/make.bat
+++ b/make.bat
@@ -49,6 +49,7 @@ goto :success
 :msvc_strap
 echo Attempting to build v.c  with MSVC...
 set VsWhereDir=%ProgramFiles(x86)%
+set Vs2015InstallDir="%VsWhereDir%\Microsoft Visual Studio 14.0"
 set HostArch=x64
 if "%PROCESSOR_ARCHITECTURE%" == "x86" (
 	echo Using x86 Build Tools...
@@ -59,8 +60,10 @@ for /f "usebackq tokens=*" %%i in (`"%VsWhereDir%\Microsoft Visual Studio\Instal
 	set InstallDir=%%i
 )
 
-if exist "%InstallDir%\Common7\Tools\vsdevcmd.bat" (
-	call "%InstallDir%\Common7\Tools\vsdevcmd.bat" -arch=%HostArch% -host_arch=%HostArch% -no_logo
+if exist %InstallDir%\Common7\Tools\vsdevcmd.bat (
+	call %InstallDir%\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
+) else if exist %Vs2015InstallDir%\Common7\Tools\vsdevcmd.bat (
+	call %Vs2015InstallDir%\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
 ) else (
 	goto :no_compiler
 )
@@ -80,7 +83,6 @@ if %ERRORLEVEL% NEQ 0 (
 	echo V failed to build itself with error %ERRORLEVEL%
 	rd /s /q vc
 	del v_old.exe
-	del v2.pdb
 	del vc140.pdb
 	del %ObjFile%
 	goto :compile_error
@@ -88,7 +90,6 @@ if %ERRORLEVEL% NEQ 0 (
 
 rd /s /q vc
 del v_old.exe
-del v2.pdb
 del vc140.pdb
 del %ObjFile%
 

--- a/make.bat
+++ b/make.bat
@@ -59,10 +59,10 @@ for /f "usebackq tokens=*" %%i in (`"%VsWhereDir%\Microsoft Visual Studio\Instal
 	set InstallDir=%%i
 )
 
-if exist %InstallDir%\Common7\Tools\vsdevcmd.bat (
-	call %InstallDir%\Common7\Tools\vsdevcmd.bat -arch=%HostArch% -host_arch=%HostArch% -no_logo
-) else if exist "%VsWhereDir%/Microsoft Visual Studio 14.0/Common7/Tools/vsdevcmd.bat" (
-	call "%VsWhereDir%/Microsoft Visual Studio 14.0/Common7/Tools/vsdevcmd.bat" -arch=%HostArch% -host_arch=%HostArch% -no_logo
+if exist "%InstallDir%\Common7\Tools\vsdevcmd.bat" (
+	call "%InstallDir%\Common7\Tools\vsdevcmd.bat" -arch=%HostArch% -host_arch=%HostArch% -no_logo
+) else if exist "%VsWhereDir%\Microsoft Visual Studio 14.0\Common7\Tools\vsdevcmd.bat" (
+	call "%VsWhereDir%\Microsoft Visual Studio 14.0\Common7\Tools\vsdevcmd.bat" -arch=%HostArch% -host_arch=%HostArch% -no_logo
 ) else (
 	goto :no_compiler
 )


### PR DESCRIPTION
This PR add default msvc2015 config when there is no `vswhere.exe`.