### PR TITLE
mysql: Using `int.str()` instead of `string(int)`

### DIFF
--- a/vlib/mysql/result.v
+++ b/vlib/mysql/result.v
@@ -49,7 +49,7 @@ pub fn (r Result) rows() []Row {
 			if rr[i] == 0 {
 				row.vals << ''
 			} else {
-				row.vals << string(rr[i])
+				row.vals << rr[i].str()
 			}
 		}
 		rows << row

--- a/vlib/mysql/result.v
+++ b/vlib/mysql/result.v
@@ -49,7 +49,7 @@ pub fn (r Result) rows() []Row {
 			if rr[i] == 0 {
 				row.vals << ''
 			} else {
-				row.vals << rr[i].str()
+				row.vals << string(&byte(rr[i]))
 			}
 		}
 		rows << row


### PR DESCRIPTION
Got a warning after update V compiler
```
vlib/mysql/result.v:53:4: error: use `number.str()` instead of `string(number)`
```
The problem after updating is this

### BEFORE
![V Programming Language](https://user-images.githubusercontent.com/17797740/81148118-3edd6680-8fae-11ea-9406-9fec9bee76ec.png)

### AFTER
![V Programming Language](https://user-images.githubusercontent.com/17797740/81148143-4bfa5580-8fae-11ea-9361-1f459d7be95f.png)
