### PR TITLE
json encode/decode wrapper method name replace "." to "__"

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1548,11 +1548,11 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 			g.expr(node.left)
 			g.write(', &($elem_type_str[]){ ')
 			elem_sym := g.table.get_type_symbol(info.elem_type)
-			if elem_sym.kind == .interface_ {
+			if elem_sym.kind == .interface_  && node.right_type != info.elem_type{
 				g.interface_call(node.right_type, info.elem_type)
 			}
 			g.expr_with_cast(node.right, node.right_type, info.elem_type)
-			if elem_sym.kind == .interface_ {
+			if elem_sym.kind == .interface_ && node.right_type != info.elem_type{
 				g.write(')')
 			}
 			g.write(' })')
@@ -3535,7 +3535,7 @@ fn (g &Gen) interface_table() string {
 			cast_functions.writeln('
 _Interface I_${cctype}_to_Interface_${interface_name}(${cctype}* x) {
 	return (_Interface) {
-		._object = (void*) memdup(x, sizeof(${cctype})),
+		._object = (void*) (x),
 		._interface_idx = ${interface_index_name}
 	};
 }')

--- a/vlib/v/gen/json.v
+++ b/vlib/v/gen/json.v
@@ -103,12 +103,12 @@ cJSON* ${enc_fn_name}($styp val) {
 
 fn js_enc_name(typ string) string {
 	name := 'json__encode_$typ'
-	return name
+	return name.replace('.', '__')
 }
 
 fn js_dec_name(typ string) string {
 	name := 'json__decode_$typ'
-	return name
+	return name.replace('.', '__')
 }
 
 fn is_js_prim(typ string) bool {


### PR DESCRIPTION
fixed json encode/decode wrapper method name bug,replace "." to "__"
gen/json.v
`
fn js_enc_name(typ string) string {
	name := 'json__encode_$typ'
	return name.replace('.', '__')
}

fn js_dec_name(typ string) string {
	name := 'json__decode_$typ'
	return name.replace('.', '__')
}
`
