### PR TITLE
parser: remove unnecessary repetitive judgments

### DIFF
--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -83,7 +83,7 @@ fn (mut p Parser) parse_assign_lhs() []ast.Ident {
 		}
 		is_static := p.tok.kind == .key_static
 		if is_static {
-			p.check(.key_static)
+			p.next()
 		}
 		mut ident := p.parse_ident(false, false)
 		ident.is_mut = is_mut
@@ -93,7 +93,7 @@ fn (mut p Parser) parse_assign_lhs() []ast.Ident {
 		}
 		idents << ident
 		if p.tok.kind == .comma {
-			p.check(.comma)
+			p.next()
 		} else {
 			break
 		}
@@ -108,7 +108,7 @@ fn (mut p Parser) parse_assign_rhs() []ast.Expr {
 		expr := p.expr(0)
 		exprs << expr
 		if p.tok.kind == .comma {
-			p.check(.comma)
+			p.next()
 		} else {
 			break
 		}

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -113,7 +113,7 @@ fn (mut p Parser) comp_if() ast.CompIf {
 	}
 	if p.tok.kind == .dollar && p.peek_tok.kind == .key_else {
 		p.next()
-		p.check(.key_else)
+		p.next()
 		node.has_else = true
 		node.else_stmts = p.parse_block()
 	}

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -21,7 +21,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 	if p.tok.kind == .rsbr {
 		// []typ => `[]` and `typ` must be on the same line
 		line_nr := p.tok.line_nr
-		p.check(.rsbr)
+		p.next()
 		// []string
 		if p.tok.kind in [.name, .amp] && p.tok.line_nr == line_nr {
 			elem_type = p.parse_type()
@@ -37,7 +37,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 			expr := p.expr(0)
 			exprs << expr
 			if p.tok.kind == .comma {
-				p.check(.comma)
+				p.next()
 			}
 			// p.check_comment()
 		}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -75,7 +75,7 @@ pub fn (mut p Parser) call_args() []ast.CallArg {
 	for p.tok.kind != .rpar {
 		mut is_mut := false
 		if p.tok.kind == .key_mut {
-			p.check(.key_mut)
+			p.next()
 			is_mut = true
 		}
 		e := p.expr(0)
@@ -335,10 +335,10 @@ fn (mut p Parser) fn_args() ([]table.Arg, bool) {
 			arg_name := 'arg_$arg_no'
 			is_mut := p.tok.kind == .key_mut
 			if is_mut {
-				p.check(.key_mut)
+				p.next()
 			}
 			if p.tok.kind == .ellipsis {
-				p.check(.ellipsis)
+				p.next()
 				is_variadic = true
 			}
 			mut arg_type := p.parse_type()
@@ -367,7 +367,7 @@ fn (mut p Parser) fn_args() ([]table.Arg, bool) {
 			mut arg_names := [p.check_name()]
 			// `a, b, c int`
 			for p.tok.kind == .comma {
-				p.check(.comma)
+				p.next()
 				arg_names << p.check_name()
 			}
 			if p.tok.kind == .key_mut {
@@ -375,7 +375,7 @@ fn (mut p Parser) fn_args() ([]table.Arg, bool) {
 				is_mut = true
 			}
 			if p.tok.kind == .ellipsis {
-				p.check(.ellipsis)
+				p.next()
 				is_variadic = true
 			}
 			mut typ := p.parse_type()

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -71,7 +71,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		mut key_var_name := ''
 		mut val_var_name := p.check_name()
 		if p.tok.kind == .comma {
-			p.check(.comma)
+			p.next()
 			key_var_pos := val_var_pos
 			val_var_pos = p.tok.position()
 			key_var_name = val_var_name
@@ -103,7 +103,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		mut is_range := false
 		if p.tok.kind == .dotdot {
 			is_range = true
-			p.check(.dotdot)
+			p.next()
 			high_expr = p.expr(0)
 			p.scope.register(val_var_name, ast.Var{
 				name: val_var_name

--- a/vlib/v/parser/if.v
+++ b/vlib/v/parser/if.v
@@ -16,7 +16,7 @@ fn (mut p Parser) if_expr() ast.IfExpr {
 		start_pos := p.tok.position()
 		mut comment := ast.Comment{}
 		if p.tok.kind == .key_if {
-			p.check(.key_if)
+			p.next()
 		} else {
 			// if p.tok.kind == .comment {
 			// p.error('place comments inside {}')
@@ -24,7 +24,7 @@ fn (mut p Parser) if_expr() ast.IfExpr {
 			// comment = p.check_comment()
 			p.check(.key_else)
 			if p.tok.kind == .key_if {
-				p.check(.key_if)
+				p.next()
 			} else {
 				has_else = true
 				p.inside_if = false

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -21,7 +21,7 @@ pub fn (mut p Parser) parse_array_type() table.Type {
 	elem_type := p.parse_type()
 	mut nr_dims := 1
 	for p.tok.kind == .lsbr {
-		p.check(.lsbr)
+		p.next()
 		p.check(.rsbr)
 		nr_dims++
 	}
@@ -54,7 +54,7 @@ pub fn (mut p Parser) parse_multi_return_type() table.Type {
 		mr_type := p.parse_type()
 		mr_types << mr_type
 		if p.tok.kind == .comma {
-			p.check(.comma)
+			p.next()
 		} else {
 			break
 		}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -464,7 +464,7 @@ pub fn (mut p Parser) stmt() ast.Stmt {
 			} else if p.tok.kind == .name && p.peek_tok.kind == .colon {
 				// `label:`
 				name := p.check_name()
-				p.check(.colon)
+				p.next()
 				return ast.GotoLabel{
 					name: name
 				}
@@ -659,7 +659,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 			expr = p.expr(0)
 			// TODO, string(b, len)
 			if p.tok.kind == .comma && to_typ.idx() == table.string_type_idx {
-				p.check(.comma)
+				p.next()
 				arg = p.expr(0) // len
 				has_arg = true
 			}
@@ -735,7 +735,7 @@ fn (mut p Parser) index_expr(left ast.Expr) ast.IndexExpr {
 	mut has_high := false
 	if p.tok.kind == .dotdot {
 		// [start..end] or [start..]
-		p.check(.dotdot)
+		p.next()
 		mut high := ast.Expr{}
 		if p.tok.kind != .rsbr {
 			has_high = true
@@ -890,7 +890,7 @@ fn (mut p Parser) string_expr() ast.Expr {
 		if p.tok.kind != .str_dollar {
 			continue
 		}
-		p.check(.str_dollar)
+		p.next()
 		exprs << p.expr(0)
 		mut efmt := []string{}
 		if p.tok.kind == .colon {
@@ -945,7 +945,7 @@ fn (mut p Parser) module_decl() ast.Module {
 	mut name := 'main'
 	is_skipped := p.tok.kind != .key_module
 	if !is_skipped {
-		p.check(.key_module)
+		p.next()
 		name = p.check_name()
 	}
 	full_mod := p.table.qualify_module(name, p.file_name)
@@ -966,13 +966,13 @@ fn (mut p Parser) import_stmt() ast.Import {
 	mut mod_name := p.check_name()
 	mut mod_alias := mod_name
 	for p.tok.kind == .dot {
-		p.check(.dot)
+		p.next()
 		submod_name := p.check_name()
 		mod_name += '.' + submod_name
 		mod_alias = submod_name
 	}
 	if p.tok.kind == .key_as {
-		p.check(.key_as)
+		p.next()
 		mod_alias = p.check_name()
 	}
 	p.imports[mod_alias] = mod_name
@@ -1039,7 +1039,7 @@ fn (mut p Parser) return_stmt() ast.Return {
 		expr := p.expr(0)
 		exprs << expr
 		if p.tok.kind == .comma {
-			p.check(.comma)
+			p.next()
 		} else {
 			break
 		}
@@ -1171,7 +1171,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 	}
 	first_type := p.parse_type() // need to parse the first type before we can check if it's `type A = X | Y`
 	if p.tok.kind == .pipe {
-		p.check(.pipe)
+		p.next()
 		sum_variants << first_type
 		// type SumType = A | B | c
 		for {
@@ -1235,7 +1235,7 @@ fn (mut p Parser) assoc() ast.Assoc {
 		expr := p.expr(0)
 		vals << expr
 		if p.tok.kind == .comma {
-			p.check(.comma)
+			p.next()
 		}
 		if p.tok.kind == .rcbr {
 			break

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -16,7 +16,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 	}
 	is_union := p.tok.kind == .key_union
 	if p.tok.kind == .key_struct {
-		p.check(.key_struct)
+		p.next()
 	} else {
 		p.check(.key_union)
 	}
@@ -51,12 +51,12 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 				comment = p.comment()
 			}
 			if p.tok.kind == .key_pub {
-				p.check(.key_pub)
+				p.next()
 				if p.tok.kind == .key_mut {
 					if pub_mut_pos != -1 {
 						p.error('redefinition of `pub mut` section')
 					}
-					p.check(.key_mut)
+					p.next()
 					pub_mut_pos = fields.len
 					is_field_pub = true
 					is_field_mut = true
@@ -75,7 +75,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 				if mut_pos != -1 {
 					p.error('redefinition of `mut` section')
 				}
-				p.check(.key_mut)
+				p.next()
 				p.check(.colon)
 				mut_pos = fields.len
 				is_field_pub = false
@@ -85,7 +85,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 				if global_pos != -1 {
 					p.error('redefinition of `global` section')
 				}
-				p.check(.key_global)
+				p.next()
 				p.check(.colon)
 				global_pos = fields.len
 				is_field_pub = true
@@ -234,7 +234,7 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 		}
 		i++
 		if p.tok.kind == .comma {
-			p.check(.comma)
+			p.next()
 		}
 		p.check_comment()
 	}


### PR DESCRIPTION
This PR remove unnecessary repetitive judgments.

For examples:
```v
if p.tok.kind == .key_as {
		p.check(.key_as)
                ...
```
We should use `p.next()` instead of `p.check(.key_as)`.