### PR TITLE
checker: optimize check string cast error

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1579,16 +1579,12 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 			if it.typ == table.string_type && !(sym.kind in [.byte, .byteptr] || sym.kind ==
 				.array && sym.name == 'array_byte') {
 				type_name := c.table.type_to_str(it.expr_type)
-				c.error('cannot cast type `$type_name` to string', it.pos)
+				c.error('cannot cast type `$type_name` to string, use `x.str()` instead', it.pos)
 			}
 			if it.has_arg {
 				c.expr(it.arg)
 			}
 			it.typname = c.table.get_type_symbol(it.typ).name
-			if it.typ == table.string_type && !it.has_arg && it.expr_type.is_number() && !it.expr_type.is_ptr() {
-				// s := c.table.get_type_symbol(it.expr_type)
-				c.error('use `number.str()` instead of `string(number)`', it.pos)
-			}
 			return it.typ
 		}
 		ast.CallExpr {

--- a/vlib/v/checker/tests/cast_string_err.out
+++ b/vlib/v/checker/tests/cast_string_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/cast_string_err.v:2:14: error: cannot cast type `int` to string
+vlib/v/checker/tests/cast_string_err.v:2:14: error: cannot cast type `int` to string, use `x.str()` instead
     1 | fn main() {
     2 |     a := string(1)
       |                 ^


### PR DESCRIPTION
This PR optimize check string cast error.

- Remove extra check for it.
- Add `use 'x.str()' instead` in error message.

```v
D:\test\v\tt1>v run .
.\tt1.v:2:17: error: cannot cast type `[]int` to string, use `x.str()` instead
    1 | fn main() {
    2 |     println(string([1,2,3]))
      |                    ~~~~~~~
    3 | }
```