### PR TITLE
fn: optional multiple return values (fix #4734)

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1998,10 +1998,8 @@ fn (mut g Gen) return_statement(node ast.Return) {
 		optional_none := node.exprs[0] is ast.None
 		mut optional_error := false
 		match node.exprs[0] {
-			ast.CallExpr {
-				optional_error = it.name == 'error'
-			}
-			else {false}
+			ast.CallExpr { optional_error = it.name == 'error' }
+			else { false }
 		}
 		if optional_none || optional_error {
 			g.expr_with_cast(node.exprs[0], node.types[0], g.fn_decl.return_type)

--- a/vlib/v/tests/fn_high_test.v
+++ b/vlib/v/tests/fn_high_test.v
@@ -133,15 +133,3 @@ fn test_assigning_fns() {
 //
 // End assigning functions (IdentFn)
 //
-
-
-
-
-
-
-
-
-
-
-
-

--- a/vlib/v/tests/fn_multiple_returns_test.v
+++ b/vlib/v/tests/fn_multiple_returns_test.v
@@ -17,3 +17,58 @@ fn fn_mr_get_user() (string, int, []string, UserData) {
 	data := UserData{test: 'Test Data'}
 	return 'joe', 34, groups, data
 }
+
+fn split_to_two(s string) ?(string, string) {
+	mut tokens := s.split_nth(' ', 2)
+	if s.len == 0 {
+		return none
+	}
+	if tokens.len != 2 {
+		return error('error')
+	}
+	return tokens[0], tokens[1]
+}
+
+fn returnable_fail() string {
+	_,_ := split_to_two('bad') or {
+		return 'ok'
+	}
+	return 'nok'
+}
+
+fn test_multiple_ret() {
+	// returnable test
+	assert returnable_fail() == 'ok'
+
+	// good case
+	res1_1, res1_2 := split_to_two("fish house") or {
+		assert false
+		return
+	}
+	assert res1_1 == 'fish'
+	assert res1_2 == 'house'
+
+	// none case
+	wrapper1 := fn()(string, string){
+		res2_1, res2_2 := split_to_two("") or {
+			assert err == ''
+			return 'replaced', 'val'
+		}
+		return res2_1, res2_2
+	}
+	res2_1, res2_2 := wrapper1()
+	assert res2_1 == 'replaced'
+	assert res2_2 == 'val'
+
+	// error case
+	wrapper2 := fn()(string, string){
+		res3_1, res3_2 := split_to_two('fishhouse') or {
+			assert err == 'error'
+			return 'replaced', 'val'
+		}
+		return res3_1, res3_2
+	}
+	res3_1, res3_2 := wrapper2()
+	assert res3_1 == 'replaced'
+	assert res3_2 == 'val'
+}


### PR DESCRIPTION
Optional multi-returns are broken. This PR fixes them and adds tests.

Fixes issue #4734:
```
fn kv(s string) ?(string,string) {
        kw := s.split_nth(':', 2)
        if kw.len != 2 {
                return error('invalid token')
        }
        return kw[0].trim_space(),kw[1].trim_space()
}
fn main() {
	a := 'foo: bar'
	k, v := kv(a) or {
		return
	}
	println('k $k')
	println('v $v')
}
```