### PR TITLE
token: Kind.string.str() change 'STR' to 'string'

### DIFF
--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -147,7 +147,7 @@ fn build_token_str() []string {
 	s[Kind.eof] = 'eof'
 	s[Kind.name] = 'name'
 	s[Kind.number] = 'number'
-	s[Kind.string] = 'STR'
+	s[Kind.string] = 'string'
 	s[Kind.chartoken] = 'char'
 	s[Kind.plus] = '+'
 	s[Kind.minus] = '-'


### PR DESCRIPTION
This PR change 'STR' to 'string' of Kind.string.str() in token.v.

```v
error: unexpected `STR`, expecting `name`
```
I think `STR` is not easy to understand, it's more appropriate to change to `string`.

```v
error: unexpected `string`, expecting `name`
```