### PR TITLE
memory leak in __new_array: .cap of array should not be less than .len

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -17,7 +17,7 @@ pub mut:
 
 // Internal function, used by V (`nums := []int`)
 fn __new_array(mylen int, cap int, elm_size int) array {
-	cap_ := if cap == 0 { 1 } else { cap }
+	cap_ := if cap < mylen { mylen } else { cap }
 	arr := array{
 		len: mylen
 		cap: cap_
@@ -29,7 +29,7 @@ fn __new_array(mylen int, cap int, elm_size int) array {
 
 // Private function, used by V (`nums := [1, 2, 3]`)
 fn new_array_from_c_array(len, cap, elm_size int, c_array voidptr) array {
-	cap_ := if cap == 0 { 1 } else { cap }
+	cap_ := if cap < len { len } else { cap }
 
 	arr := array{
 		len: len

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -33,7 +33,7 @@ fn new_array_from_c_array(len, cap, elm_size int, c_array voidptr) array {
 
 	arr := array{
 		len: len
-		cap: cap
+		cap: cap_
 		element_size: elm_size
 		data: vcalloc(cap_ * elm_size)
 	}

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -142,6 +142,9 @@ pub fn v_calloc(n int) byteptr {
 }
 
 pub fn vcalloc(n int) byteptr {
+	if n <= 0 {
+		return byteptr(0)
+	}
 	return C.calloc(n, 1)
 }
 

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -142,10 +142,13 @@ pub fn v_calloc(n int) byteptr {
 }
 
 pub fn vcalloc(n int) byteptr {
-	if n <= 0 {
+	if n < 0 {
+		panic('calloc(<=0)')
+	} else if n == 0 {
 		return byteptr(0)
+	} else {
+		return C.calloc(n, 1)
 	}
-	return C.calloc(n, 1)
 }
 
 [unsafe_fn]

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -142,9 +142,6 @@ pub fn v_calloc(n int) byteptr {
 }
 
 pub fn vcalloc(n int) byteptr {
-	if n <= 0 {
-		panic('calloc(<=0)')
-	}
 	return C.calloc(n, 1)
 }
 


### PR DESCRIPTION
### Problem
Programs with large arrays crash sometimes with message:  
`malloc(): invalid size (unsorted)`
Valgrind says something like:
`Address 0x4a56438 is 0 bytes after a block of size 8 alloc'd`
### Cause
Arrays are allocated with insufficient storage space.
### Solution
Make sure that that `.cap` and storage space are at least enough to store `.len` elements.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
