### PR TITLE
vrepl: fix import_middle and comment error

### DIFF
--- a/vlib/v/tests/repl/comment.repl
+++ b/vlib/v/tests/repl/comment.repl
@@ -1,0 +1,6 @@
+mut a := [1,2,3] // comment
+// test comment
+a << 4
+a
+===output===
+[1, 2, 3, 4]

--- a/vlib/v/tests/repl/import_middle.repl
+++ b/vlib/v/tests/repl/import_middle.repl
@@ -1,0 +1,6 @@
+mut a := [1,2,3]
+a << 4
+import time
+time.now().unix_time() > 160000
+===output===
+true


### PR DESCRIPTION
This PR fix import_middle and comment error.

- Fix import_middle and comment error.
- Add tests `import_middle.repl` `comment.repl`.

```v
C:\Users\yuyi9\v>v
For usage information, quit V REPL using `exit` and use `v help`
V 0.1.27 722a2c7
Use Ctrl-C or `exit` to exit
>>> mut a := [1,2,3] // test a
>>> a << 4
>>> // test comment
>>> import time
>>> time.now()
2020-05-08 14:20:01
>>> a
[1, 2, 3, 4]
>>>
```