### PR TITLE
parser: check for import errors

### DIFF
--- a/vlib/v/checker/tests/import_multiple_modules_err.out
+++ b/vlib/v/checker/tests/import_multiple_modules_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/import_multiple_modules_err.v:1:13: error: cannot import multiple modules at a time
+    1 | import time math
+      |             ~~~~
+    2 | fn main() {
+    3 |     println(time.now().unix_time())

--- a/vlib/v/checker/tests/import_multiple_modules_err.vv
+++ b/vlib/v/checker/tests/import_multiple_modules_err.vv
@@ -1,0 +1,4 @@
+import time math
+fn main() {
+	println(time.now().unix_time())
+}

--- a/vlib/v/checker/tests/import_not_same_line_err.out
+++ b/vlib/v/checker/tests/import_not_same_line_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/import_not_same_line_err.v:2:2: error: `import` and `module` must be at same line
+    1 | import
+    2 |  time
+      |  ~~~~
+    3 | fn main() {
+    4 |     println(time.now())

--- a/vlib/v/checker/tests/import_not_same_line_err.vv
+++ b/vlib/v/checker/tests/import_not_same_line_err.vv
@@ -1,0 +1,5 @@
+import
+ time
+fn main() {
+	println(time.now())
+}

--- a/vlib/v/checker/tests/import_syntax_err.out
+++ b/vlib/v/checker/tests/import_syntax_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/import_syntax_err.v:1:12: error: module syntax error, please use `x.y.z`
+    1 | import time, os
+      |            ^
+    2 | fn main() {
+    3 |     println(time.now())

--- a/vlib/v/checker/tests/import_syntax_err.vv
+++ b/vlib/v/checker/tests/import_syntax_err.vv
@@ -1,0 +1,4 @@
+import time, os
+fn main() {
+	println(time.now())
+}


### PR DESCRIPTION
This PR check for import errors.

- Check for import errors.
- Add tests `import_not_at_same_line_err.vv/out` `import_syntax_err.vv/out` `import_multiple_err.vv/out`

```v
D:\test\v\tt1>v run .
.\tt1.v:2:1: error: `import` and `module` must be at same line
    1 | import
    2 | time
      | ~~~~
    3 | fn main() {
    4 |     println(time.now())
```
```v
D:\test\v\tt1>v run .
.\tt1.v:1:13: error: cannot import multiple modules at a time
    1 | import time os
      |             ~~
    2 | fn main() {
    3 |     println(time.now())
```
```v
D:\test\v\tt1>v run .
.\tt1.v:1:12: error: module syntax error, please use `x.y.z`
    1 | import time, os
      |            ^
    2 | fn main() {
    3 |     println(time.now())
```