### PR TITLE
Add .no_delimiter time.format option

### DIFF
--- a/vlib/time/format.v
+++ b/vlib/time/format.v
@@ -150,6 +150,9 @@ mut 	res := match fmt_date {
 		.space{
 			' '
 		}
+		.no_delimiter{
+			''
+		}
 	})
 	return res
 }

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -73,6 +73,7 @@ pub enum FormatDelimiter {
 	hyphen
 	slash
 	space
+	no_delimiter
 }
 
 // TODO: C.time_t. works in v2


### PR DESCRIPTION
I want to be able to create YYYYMMDD and hhmmss formats wiithout colons, dots or whatever, but seems like there's no such option for date and time can't be configured.