### PR TITLE
parser: check `import` in the middle error

### DIFF
--- a/vlib/v/checker/tests/import_middle_err.out
+++ b/vlib/v/checker/tests/import_middle_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/import_middle_err.v:5:1: error: `import x` can only be declared at the beginning
+vlib/v/checker/tests/import_middle_err.v:5:1: error: `import x` can only be declared at the beginning of the file
     3 |     println('hello, world')
     4 | }
     5 | import os

--- a/vlib/v/checker/tests/import_middle_err.out
+++ b/vlib/v/checker/tests/import_middle_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/import_middle_err.v:5:1: error: `import x` can only be declared at the beginning
+    3 |     println('hello, world')
+    4 | }
+    5 | import os
+      | ~~~~~~
+    6 | fn main() {
+    7 |     println(time.now())

--- a/vlib/v/checker/tests/import_middle_err.vv
+++ b/vlib/v/checker/tests/import_middle_err.vv
@@ -1,0 +1,8 @@
+import time
+fn show() {
+	println('hello, world')
+}
+import os
+fn main() {
+	println(time.now())
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -317,7 +317,7 @@ pub fn (mut p Parser) top_stmt() ast.Stmt {
 			return p.interface_decl()
 		}
 		.key_import {
-			p.error_with_pos('`import x` can only be declared at the beginning', p.tok.position())
+			p.error_with_pos('`import x` can only be declared at the beginning of the file', p.tok.position())
 			return p.import_stmt()
 		}
 		.key_global {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -89,18 +89,15 @@ pub fn parse_file(path string, b_table &table.Table, comments_mode scanner.Comme
 		stmt = com
 		stmts << stmt
 	}
+	// module
 	mut mstmt := ast.Stmt{}
 	module_decl := p.module_decl()
 	mstmt = module_decl
 	stmts << mstmt
 	// imports
-	/*
-	mut imports := []ast.Import{}
 	for p.tok.kind == .key_import {
-		imports << p.import_stmt()
+		stmts << p.import_stmt()
 	}
-	*/
-	// TODO: import only mode
 	for {
 		if p.tok.kind == .eof {
 			if p.pref.is_script && !p.pref.is_test && p.mod == 'main' && !have_fn_main(stmts) {
@@ -320,6 +317,7 @@ pub fn (mut p Parser) top_stmt() ast.Stmt {
 			return p.interface_decl()
 		}
 		.key_import {
+			p.error_with_pos('`import x` can only be declared at the beginning', p.tok.position())
 			return p.import_stmt()
 		}
 		.key_global {


### PR DESCRIPTION
This PR check `import` in the middle error.

- Check `import` in the middle error.
- Add test `import_middle_err.vv/out`.

```v
D:\test\v\tt1>v run .
.\tt1.v:5:1: error: `import x` can only be declared at the beginning of the file
    3 |     println('hello, world')
    4 | }
    5 | import os
      | ~~~~~~
    6 | fn main() {
    7 |     println(time.now())
```