### PR TITLE
parser: check for module statement errors

### DIFF
--- a/vlib/v/checker/tests/module_multiple_names_err.out
+++ b/vlib/v/checker/tests/module_multiple_names_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/module_multiple_names_err.v:1:13: error: `module x` can only declare one module
+    1 | module main os
+      |             ~~
+    2 | fn main() {
+    3 |     println('hello, world')

--- a/vlib/v/checker/tests/module_multiple_names_err.vv
+++ b/vlib/v/checker/tests/module_multiple_names_err.vv
@@ -1,0 +1,4 @@
+module main os
+fn main() {
+	println('hello, world')
+}

--- a/vlib/v/checker/tests/module_not_at_same_line_err.out
+++ b/vlib/v/checker/tests/module_not_at_same_line_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/module_not_at_same_line_err.v:2:1: error: `module` and `main` must be at same line
+    1 | module
+    2 | main
+      | ~~~~
+    3 | fn main() {
+    4 |     println('hello, world')

--- a/vlib/v/checker/tests/module_not_at_same_line_err.vv
+++ b/vlib/v/checker/tests/module_not_at_same_line_err.vv
@@ -1,0 +1,5 @@
+module
+main
+fn main() {
+	println('hello, world')
+}

--- a/vlib/v/checker/tests/module_syntax_err.out
+++ b/vlib/v/checker/tests/module_syntax_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/module_syntax_err.v:1:12: error: `module x` syntax error
+    1 | module main.os
+      |            ^
+    2 | fn main() {
+    3 |     println('hello, world')

--- a/vlib/v/checker/tests/module_syntax_err.vv
+++ b/vlib/v/checker/tests/module_syntax_err.vv
@@ -1,0 +1,4 @@
+module main.os
+fn main() {
+	println('hello, world')
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -970,8 +970,21 @@ fn (mut p Parser) module_decl() ast.Module {
 	mut name := 'main'
 	is_skipped := p.tok.kind != .key_module
 	if !is_skipped {
+		module_pos := p.tok.position()
 		p.next()
+		mut pos := p.tok.position()
 		name = p.check_name()
+		if module_pos.line_nr != pos.line_nr {
+			p.error_with_pos('`module` and `$name` must be at same line', pos)
+		}
+		pos = p.tok.position()
+		if module_pos.line_nr == pos.line_nr {
+			if p.tok.kind != .name {
+				p.error_with_pos('`module x` syntax error', pos)
+			} else {
+				p.error_with_pos('`module x` can only declare one module', pos)
+			}
+		}
 	}
 	full_mod := p.table.qualify_module(name, p.file_name)
 	p.mod = full_mod


### PR DESCRIPTION
This PR check for module statement errors.

- Check for module statement errors.
- Add tests `module_syntax_err.vv/out` `module_not_at_same_line_err.vv/out` `module_multiple_names_err.vv/out`

```v
D:\test\v\tt1>v run .
.\tt1.v:2:1: error: `module` and `main` must be at same line
    1 | module
    2 | main
      | ~~~~
    3 | fn main() {
    4 |     println('hello, world')
```
```v
D:\test\v\tt1>v run .
.\tt1.v:1:13: error: `module x` can only declare one module
    1 | module main os
      |             ~~
    2 | fn main() {
    3 |     println('hello, world')
```
```v
D:\test\v\tt1>v run .
.\tt1.v:1:12: error: `module x` syntax error
    1 | module main.os
      |            ^
    2 | fn main() {
    3 |     println('hello, world')
```
