### PR TITLE
parser: check enum name and field name errors

### DIFF
--- a/vlib/v/checker/tests/enum_field_name_err.out
+++ b/vlib/v/checker/tests/enum_field_name_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/enum_field_name_err.v:2:5: error: field name `Green` must be all lowercase
+    1 | enum Color {
+    2 |     Green
+      |     ~~~~~
+    3 |     yellow
+    4 | }

--- a/vlib/v/checker/tests/enum_field_name_err.vv
+++ b/vlib/v/checker/tests/enum_field_name_err.vv
@@ -1,0 +1,7 @@
+enum Color {
+    Green
+    yellow
+}
+fn main(){
+	println('hello')
+}

--- a/vlib/v/checker/tests/enum_name_err.out
+++ b/vlib/v/checker/tests/enum_name_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/enum_name_err.v:1:6: error: enum name `color` must begin with a capital letter
+    1 | enum color {
+      |      ~~~~~
+    2 |     green
+    3 |     yellow

--- a/vlib/v/checker/tests/enum_name_err.vv
+++ b/vlib/v/checker/tests/enum_name_err.vv
@@ -1,0 +1,7 @@
+enum color {
+    green
+    yellow
+}
+fn main(){
+	println('hello')
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1146,7 +1146,7 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 	end_pos := p.tok.position()
 	enum_name := p.check_name()
 	if enum_name.len > 0 && !enum_name[0].is_capital() {
-		verror('enum name `$enum_name` must begin with a capital letter')
+		p.error_with_pos('enum name `$enum_name` must begin with a capital letter', end_pos)
 	}
 	name := p.prepend_mod(enum_name)
 	p.check(.lcbr)
@@ -1156,6 +1156,9 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 	for p.tok.kind != .eof && p.tok.kind != .rcbr {
 		pos := p.tok.position()
 		val := p.check_name()
+		if !val.is_lower() {
+			p.error_with_pos('field name `$val` must be all lowercase', pos)
+		}
 		vals << val
 		mut expr := ast.Expr{}
 		mut has_expr := false


### PR DESCRIPTION
This PR check enum name and field name errors.

- Check enum name and field name errors.
- Add tests `enum_name_err.vv/out` `enum_field_name_err.vv/out`.

```v
D:\test\v\tt1>v run .
.\tt1.v:1:6: error: enum name `color` must begin with a capital letter
    1 | enum color {
      |      ~~~~~
    2 |     green
    3 |     red
```
```v
D:\test\v\tt1>v run .
.\tt1.v:2:2: error: field name `Green` must be all lowercase
    1 | enum Color {
    2 |     Green
      |     ~~~~~
    3 |     red
    4 | }
```