### PR TITLE
checker: check for map_init key duplicate (fix #4787)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2139,6 +2139,13 @@ pub fn (mut c Checker) map_init(node mut ast.MapInit) table.Type {
 	key0_type := c.expr(node.keys[0])
 	val0_type := c.expr(node.vals[0])
 	for i, key in node.keys {
+		key_i := key as ast.StringLiteral
+		for j in 0..i {
+			key_j := node.keys[j] as ast.StringLiteral
+			if key_i.val == key_j.val {
+				c.error('key value duplicate', key.position())
+			}
+		}
 		if i == 0 {
 			continue
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2143,7 +2143,7 @@ pub fn (mut c Checker) map_init(node mut ast.MapInit) table.Type {
 		for j in 0..i {
 			key_j := node.keys[j] as ast.StringLiteral
 			if key_i.val == key_j.val {
-				c.error('key value duplicate', key.position())
+				c.error('duplicate key "$key_i.val" in map literal', key.position())
 			}
 		}
 		if i == 0 {

--- a/vlib/v/checker/tests/map_init_key_duplicate_err.out
+++ b/vlib/v/checker/tests/map_init_key_duplicate_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/map_init_key_duplicate_err.v:5:3: error: key value duplicate
+vlib/v/checker/tests/map_init_key_duplicate_err.v:5:3: error: duplicate key "foo" in map literal
     3 |         'foo': 'bar'
     4 |         'abc': 'abc'
     5 |         'foo': 'bar'

--- a/vlib/v/checker/tests/map_init_key_duplicate_err.out
+++ b/vlib/v/checker/tests/map_init_key_duplicate_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/map_init_key_duplicate_err.v:5:3: error: key value duplicate
+    3 |         'foo': 'bar'
+    4 |         'abc': 'abc'
+    5 |         'foo': 'bar'
+      |         ~~~~~
+    6 |     }
+    7 |     println(a)

--- a/vlib/v/checker/tests/map_init_key_duplicate_err.vv
+++ b/vlib/v/checker/tests/map_init_key_duplicate_err.vv
@@ -1,0 +1,8 @@
+fn main() {
+	a := {
+		'foo': 'bar'
+		'abc': 'abc'
+		'foo': 'bar'
+	}
+	println(a)
+}


### PR DESCRIPTION
This PR check for map_init key duplicate (fix #4787).

- Check for map_init key duplicate (fix #4787).
- Add test `map_init_key_duplicate_err.vv/out`.

```v
D:\test\v\tt1>v run .
.\tt1.v:5:3: error: key value duplicate 
    3 |         'foo': 'bar'
    4 |         'abc': 'abc'
    5 |         'foo': 'bar'
      |         ~~~~~
    6 |     }
    7 |     println(a)
```