### PR TITLE
csv: fix empty line error (fix #4797)

### DIFF
--- a/vlib/encoding/csv/reader.v
+++ b/vlib/encoding/csv/reader.v
@@ -103,6 +103,9 @@ fn (r mut Reader) read_record() ?[]string {
 		l := r.read_line() or {
 			return error(err)
 		}
+		if l.len <= 0 {
+			continue
+		}
 		line = l
 		// skip commented lines
 		if line[0] == r.comment {

--- a/vlib/encoding/csv/reader_test.v
+++ b/vlib/encoding/csv/reader_test.v
@@ -147,3 +147,30 @@ fn test_last_field_empty() {
 		}
 	}
 }
+
+fn test_empty_line() {
+	data := '"name","description","value"\n\n\n"one","first","1"\n\n"two","second",\n'
+	mut csv_reader := csv.new_reader(data)
+
+	mut row_count := 0
+	for {
+    	row := csv_reader.read() or {
+        	break
+    	}
+    	row_count++
+		if row_count == 1 {
+			assert row[0] == 'name'
+			assert row[1] == 'description'
+			assert row[2] == 'value'
+		}
+		if row_count == 2 {
+			assert row[0] == 'one'
+			assert row[1] == 'first'
+			assert row[2] == '1'
+		}
+		if row_count == 3 {
+			assert row[0] == 'two'
+			assert row[1] == 'second'
+		}
+	}
+}


### PR DESCRIPTION
This PR fix empty line error in csv (fix #4797).

- Fix empty line error.
- Add test `test_empty_line()` in `reader_test.v`.

```v
D:\test\v\tt1>v run .
[ 1] ['', 's string', 'Yes', 'strip_margin_custom(del byte) string', '', '', 'FAUX', 'builtin/string.v:1330', '']
[ 2] ['', 's string', 'Yes', 'strip_margin() string']
[ 3] ['before a delimeter. by default | is used.']
[ 4] ['Note: the delimiter has to be a byte at this time. That means surrounding']
[ 5] ['the value in ``.']
[ 6] ['Example:']
[ 7] ['st := 'Hello there,']
[ 8] ['|this is a string,']
[ 9] ['| Everything before the first | is removed'.strip_margin()']
[10] ['Returns:']
[11] ['Hello there,']
[12] ['this is a string,']
[13] ['Everything before the first | is removed"', '', 'FAUX', 'builtin/string.v:1327', '']
[14] ['', '', 'Yes', 'strlen(s byteptr) int', '', '', 'FAUX', 'builtin/bare/string_bare.v:9', ';']
```