### PR TITLE
checker: check for_in_map using one variable error (fix #4782)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1468,7 +1468,7 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 			} else {
 				mut scope := c.file.scope.innermost(it.pos.pos)
 				sym := c.table.get_type_symbol(typ)
-				if sym.kind == .map && !it.key_var.contains(',') {
+				if sym.kind == .map && !(it.key_var.len > 0 && it.val_var.len > 0) {
 					c.error('for in: cannot use one variable in map', it.pos)
 				}
 				if it.key_var.len > 0 {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1468,6 +1468,9 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 			} else {
 				mut scope := c.file.scope.innermost(it.pos.pos)
 				sym := c.table.get_type_symbol(typ)
+				if sym.kind == .map && !it.key_var.contains(',') {
+					c.error('for in: cannot use one variable in map', it.pos)
+				}
 				if it.key_var.len > 0 {
 					key_type := match sym.kind {
 						.map { sym.map_info().key_type }

--- a/vlib/v/checker/tests/for_in_map_one_variable_err.out
+++ b/vlib/v/checker/tests/for_in_map_one_variable_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/for_in_map_one_variable_err.v:3:6: error: for in: cannot use one variable in map
+    1 | fn main() {
+    2 |     kvs := {'foo':'bar'}
+    3 |     for k in kvs {
+      |         ^
+    4 |         println('$k')
+    5 |     }

--- a/vlib/v/checker/tests/for_in_map_one_variable_err.vv
+++ b/vlib/v/checker/tests/for_in_map_one_variable_err.vv
@@ -1,0 +1,6 @@
+fn main() {
+	kvs := {'foo':'bar'}
+	for k in kvs {
+		println('$k')
+	}
+}


### PR DESCRIPTION
This PR check for_in_map using one variable error (fix #4782).

- Check for_in_map using one variable error.
- Add `for_in_map_one_variable_err.vv/out`.

```v
D:\test\v\tt1>v run .
.\tt1.v:2:6: error: for in: cannot use one variable in map 
    1 | fn test(kvs map[string]string) {
    2 |     for k in kvs {
      |         ^
    3 |         println('$k')
    4 |     }
```