### PR TITLE
Fix readline input echo issue on musl-based systems

### DIFF
--- a/vlib/readline/readline_linux.c.v
+++ b/vlib/readline/readline_linux.c.v
@@ -114,6 +114,7 @@ pub fn (r mut Readline) read_line_utf8(prompt string) ?ustring {
 
   print(r.prompt)
   for {
+    C.fflush(C.stdout)
     c := r.read_char()
     a := r.analyse(c)
     if r.execute(a, c) {


### PR DESCRIPTION
Current v in alpine linux it wont work well. The interactive v prompt is not shown, and while typing the keys nothing is shown. 

This issue is fixed by calling fflush() after all the prints that are done internally in the repl loop