### PR TITLE
csv: fix field multiple lines error (fix #4808)

### DIFF
--- a/vlib/encoding/csv/reader.v
+++ b/vlib/encoding/csv/reader.v
@@ -98,27 +98,32 @@ fn (r mut Reader) read_record() ?[]string {
 	if !valid_delim(r.delimiter) {
 		return err_invalid_delim
 	}
+	mut need_read := true
+	mut keep_raw := false
 	mut line := ''
-	for {
-		l := r.read_line() or {
-			return error(err)
-		}
-		if l.len <= 0 {
-			continue
-		}
-		line = l
-		// skip commented lines
-		if line[0] == r.comment {
-			continue
-		}
-		break
-	}
 	mut fields := []string{}
 	mut i := -1
+
 	for {
-		// not quoted
-		if line[0] != `"` {
-			// QTODO i = ...
+		if need_read {
+			l := r.read_line() or {
+				return error(err)
+			}
+			if l.len <= 0 {
+				if keep_raw { line += '\n'}
+				continue
+			} else if l[0] == r.comment {
+				if keep_raw { line += '\n' + l }
+				continue
+			} else {
+				if keep_raw { line += '\n'}
+				line += l
+			}
+			need_read = false
+			keep_raw = false
+		}
+
+		if line[0] != `"` {		// not quoted
 			j := line.index(r.delimiter.str()) or {
 				// last
 				fields << line[..line.len]
@@ -128,13 +133,13 @@ fn (r mut Reader) read_record() ?[]string {
 			fields << line[..i]
 			line = line[i+1..]
 			continue
-		}
-		// quoted
-		else {
-			line = line[1..]
-			j := line.index('"') or {
-				break
+		} else {		// quoted
+			j := line[1..].index('"') or {
+				need_read = true
+				keep_raw = true
+				continue
 			}
+			line = line[1..]
 			if j+1 == line.len {
 				// last record
 				fields << line[..j]

--- a/vlib/encoding/csv/reader_test.v
+++ b/vlib/encoding/csv/reader_test.v
@@ -174,3 +174,28 @@ fn test_empty_line() {
 		}
 	}
 }
+
+fn test_field_multiple_line() {
+	data := '"name","multiple
+
+ line","value"\n"one","first","1"'
+	mut csv_reader := csv.new_reader(data)
+
+	mut row_count := 0
+	for {
+    	row := csv_reader.read() or {
+        	break
+    	}
+    	row_count++
+		if row_count == 1 {
+			assert row[0] == 'name'
+			assert row[1] == 'multiple\n\n line'
+			assert row[2] == 'value'
+		}
+		if row_count == 2 {
+			assert row[0] == 'one'
+			assert row[1] == 'first'
+			assert row[2] == '1'
+		}
+	}
+}


### PR DESCRIPTION
This PR fix field multiple lines error (fix #4808).

- Fix field multiple lines error (fix #4808).
- Add test `test_field_multiple_line()`.

```v
D:\test\v\tt1>v run .
[ 1] ['', 's string', 'Yes', 'strip_margin_custom(del byte) string', '', '', 'FAUX', 'builtin/string.v:1330', '']
[ 2] ['', 's string', 'Yes', 'strip_margin() string', 'Allows multi-line strings to be formatted in a way that removes white-space
before a delimeter. by default | is used.
Note: the delimiter has to be a byte at this time. That means surrounding
the value in ``.

Example:
st := 'Hello there,
|this is a string,
| Everything before the first | is removed'.strip_margin()
Returns:
Hello there,
this is a string,
Everything before the first | is removed', '', 'FAUX', 'builtin/string.v:1327', '']
[ 3] ['', '', 'Yes', 'strlen(s byteptr) int', '', '', 'FAUX', 'builtin/bare/string_bare.v:9', ';']
```