### PR TITLE
checker: fix checking uninitialized refs

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -330,7 +330,7 @@ pub fn (mut c Checker) struct_init(struct_init mut ast.StructInit) table.Type {
 			}
 			// Check uninitialized refs
 			for field in info.fields {
-				if field.name in inited_fields {
+				if field.has_default_expr || field.name in inited_fields {
 					continue
 				}
 				if field.typ.is_ptr() {

--- a/vlib/v/checker/tests/reference_field_must_be_initialized.out
+++ b/vlib/v/checker/tests/reference_field_must_be_initialized.out
@@ -1,7 +1,7 @@
 vlib/v/checker/tests/reference_field_must_be_initialized.v:8:7: error: reference field `Node.next` must be initialized
     6 |
     7 | fn main(){
-    8 |     n := Node{ data: 123 }    
+    8 |     n := Node{ data: 123 }
       |          ~~~~~~~~~~~~~~~~~
     9 |     eprintln('n.data: $n.data')
    10 | }

--- a/vlib/v/checker/tests/reference_field_must_be_initialized.vv
+++ b/vlib/v/checker/tests/reference_field_must_be_initialized.vv
@@ -1,10 +1,10 @@
 module main
 struct Node {
     data int
-	next &Node = 0
+	next &Node
 }
 
 fn main(){
-	n := Node{ data: 123 }    
+	n := Node{ data: 123 }
     eprintln('n.data: $n.data')
 }


### PR DESCRIPTION
```
pub struct Window {
	...
	eventbus      &eventbus.EventBus = eventbus.new() // This is initialized reference.
}
```
```
// But V still produces the warning
mut window := &Window{
	user_ptr: cfg.user_ptr
	ui: ui_ctx
	glfw_obj: ui_ctx.gg.window
	draw_fn: cfg.draw_fn
	title: cfg.title
	bg_color: cfg.bg_color
	width: cfg.width
	height: cfg.height
	children: children
	// No `eventbus` property in `StructInit.fields`, so V thinks it's not initialized.
}
```