### PR TITLE
cgen: fix multiple assign error (fix #4831)

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -845,7 +845,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 	}
 	mut is_multi := false
 	// json_test failed w/o this check
-	if return_type != 0 {
+	if return_type != table.void_type && return_type != 0 {
 		sym := g.table.get_type_symbol(return_type)
 		// the left vs. right is ugly and should be removed
 		is_multi = sym.kind == .multi_return || assign_stmt.left.len > assign_stmt.right.len ||

--- a/vlib/v/tests/multiple_assign_test.v
+++ b/vlib/v/tests/multiple_assign_test.v
@@ -1,0 +1,6 @@
+fn test_multiple_assign() {
+	a, b, c := 1, 2, 3
+	assert a == 1
+	assert b == 2
+	assert c == 3
+}


### PR DESCRIPTION
This PR fix multiple assign error (fix #4831).

- Fix multiple assign error.
- Add test `multiple_assign_test.v`

```v
fn main() {
	a, b, c := 1, 2, 3
	println('$a, $b, $c')
}

D:\test\v\tt1>v run .
1, 2, 3
```