### PR TITLE
x64: fix NUL at end of strings, and length

### DIFF
--- a/vlib/v/gen/x64/elf.v
+++ b/vlib/v/gen/x64/elf.v
@@ -90,7 +90,7 @@ pub fn (mut g Gen) generate_elf_footer() {
 	for i, s in g.strings {
 		g.write64_at(segment_start + g.buf.len, int(g.str_pos[i]))
 		g.write_string(s)
-		g.write8(6)
+		g.write8(0)
 	}
 	// Now we know the file size, set it
 	file_size := g.buf.len

--- a/vlib/v/gen/x64/gen.v
+++ b/vlib/v/gen/x64/gen.v
@@ -413,14 +413,14 @@ pub fn (mut g Gen) gen_print(s string) {
 	//
 	// qq := s + '\n'
 	//
-	g.strings << s // + '\n'
+	g.strings << s
 	// g.string_addr[s] = str_pos
 	g.mov(.eax, 1)
 	g.mov(.edi, 1)
 	str_pos := g.buf.len + 2
 	g.str_pos << str_pos
 	g.mov64(.rsi, 0) // segment_start +  0x9f) // str pos // PLACEHOLDER
-	g.mov(.edx, s.len + 1) // len
+	g.mov(.edx, s.len) // len
 	g.syscall()
 }
 

--- a/vlib/v/gen/x64/tests/x64_test.v
+++ b/vlib/v/gen/x64/tests/x64_test.v
@@ -50,10 +50,6 @@ fn test_x64() {
 		}
 		expected = expected.trim_space().trim('\n').replace('\r\n', '\n')
 		mut found := res.output.trim_space().trim('\n').replace('\r\n', '\n')
-		// remove ACK char TODO fix this in x64
-		buf := [byte(0x06)]
-		ack := string(buf)
-		found = found.replace(ack, '')
 		found = found.trim_space()
 		if expected != found {
 			println(term.red('FAIL'))


### PR DESCRIPTION
Fixes #4762 by putting NUL at end of strings instead of ACK, and fixing len calculation.

Also removed no longer needed code from tests.