### PR TITLE
ci: remove "quick debug"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,8 +291,6 @@ jobs:
       run: |
         .\v.exe setup-freetype
         .\.github\workflows\windows-install-sdl.bat
-    - name: quick debug
-      run: ./v -stats vlib/strconv/format_test.v
     - name: Fixed tests
       run: |
         ./v -cg cmd\tools\vtest-fixed.v


### PR DESCRIPTION
I think we don't need this anymore. :)