### PR TITLE
ci: extract "prebuilt" jobs to separate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,47 +171,6 @@ jobs:
 #      with:
 #        github-token: ${{ secrets.GITHUB_TOKEN }}
 
-
-  ubuntu-prebuilt:
-    runs-on: ubuntu-18.04
-    steps:
-    - name: Install dependencies
-      run: sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list; sudo apt-get update; sudo apt-get install --quiet -y postgresql libpq-dev libglfw3 libglfw3-dev libfreetype6-dev libssl-dev sqlite3 libsqlite3-dev libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev valgrind
-    - name: Download V
-      run: wget https://github.com/vlang/v/releases/latest/download/v_linux.zip && unzip v_linux.zip && ./v -version
-    - name: Test V
-      run: ./v examples/hello_world.v && examples/hello_world #&& ./v -silent build-examples
-
-
-  macos-prebuilt:
-    runs-on: macOS-latest
-    steps:
-    - name: Install dependencies
-      run: |
-        brew install freetype glfw openssl sdl2 sdl2_ttf sdl2_mixer sdl2_image
-        export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/openssl/lib/"
-    - name: Download V
-      run: wget https://github.com/vlang/v/releases/latest/download/v_macos.zip && unzip v_macos.zip && ./v -version
-    - name: Test V
-      run: ./v examples/hello_world.v && examples/hello_world #&& ./v -silent build-examples
-
-  windows-prebuilt:
-    runs-on: windows-2019
-    steps:
-    - name: Download V
-      shell: cmd
-      run: |
-        echo Downloading V...
-        curl -L https://github.com/vlang/v/releases/latest/download/v_windows.zip -o v_windows.zip
-        echo Unzipping...
-        unzip v_windows.zip
-        v.exe -version
-        echo Done
-        dir
-    - name: Test V
-      shell: cmd
-      run: v.exe examples\hello_world.v && examples\hello_world.exe
-
   ubuntu-musl:
     runs-on: ubuntu-18.04
     env:

--- a/.github/workflows/prebuit.yml
+++ b/.github/workflows/prebuit.yml
@@ -1,0 +1,51 @@
+name: Test prebuilt binaries
+on:
+  release:
+    types: [edited, published]
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install --quiet -y postgresql libpq-dev libglfw3 libglfw3-dev libfreetype6-dev libssl-dev sqlite3 libsqlite3-dev libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev valgrind
+    - name: Download V
+      run: |
+        tag=${GITHUB_REF##*/}
+        wget https://github.com/vlang/v/releases/download/$tag/v_linux.zip
+        unzip v_linux.zip
+        ./v -version
+    - name: Test V
+      run: |
+        ./v run examples/hello_world.v
+
+  macos:
+    runs-on: macOS-latest
+    steps:
+    - name: Install dependencies
+      run: |
+        brew install freetype glfw openssl sdl2 sdl2_ttf sdl2_mixer sdl2_image
+        export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/openssl/lib/"
+    - name: Download V
+      run: |
+        tag=${GITHUB_REF##*/}
+        wget https://github.com/vlang/v/releases/download/$tag/v_macos.zip
+        unzip v_macos.zip
+        ./v -version
+    - name: Test V
+      run: |
+        ./v run examples/hello_world.v
+
+  windows:
+    runs-on: windows-latest
+    steps:
+    - name: Download V
+      run: |
+        Set-Variable -Name "tag" -Value $env:GITHUB_REF.split("/", 3)[-1]
+        & curl -L https://github.com/vlang/v/releases/download/$tag/v_windows.zip -o v_windows.zip
+        & unzip .\v_windows.zip
+        & .\v.exe -version
+    - name: Test V
+      run: |
+        & .\v.exe run .\examples\hello_world.v


### PR DESCRIPTION
The new workflow is triggered when a release is created or edited. As Alex noticed, it's makes no sense to run these jobs on every commit.

Tested this workflow on a separate repository (not my fork, as GitHub does not trigger `release` event for forks), works fine. https://github.com/alexesprit/test-release/actions

The basic release workflow is the following:
1. A developer pushes a new tag and create a new release for this tag.
2. GitHub runs the `prebuilt` workflow, which downloads and tests zipballs attached to the given release.
3. If a zipball is not valid, e.g. contains no binaries, the developer just edits release and attaches the proper zipballs.
4. Then GitHub runs the workflow again.

I don't know how to name the workflow properly, so suggestions are welcome. :)