### PR TITLE
all: fix unused variable warning or error (fix #4862)

### DIFF
--- a/examples/nbody.v
+++ b/examples/nbody.v
@@ -124,7 +124,7 @@ sys := &System {arr_momentum(), arr_position()}
 offsetmomentum(mut sys)
 
 println('${energy(sys):.9f}')  //-0.169075164
-for i in 0..50000000 {
+for _ in 0..50000000 {
     advance(mut sys, 0.01)
 }
 println('${energy(sys):.9f}') //-0.169059907

--- a/examples/tetris/tetris.v
+++ b/examples/tetris/tetris.v
@@ -189,7 +189,7 @@ fn (g mut Game) init_game() {
 	g.generate_tetro()
 	g.field = [] // TODO: g.field = [][]int
 	// Generate the field, fill it with 0's, add -1's on each edge
-	for i in 0..FieldHeight + 2 {
+	for _ in 0..FieldHeight + 2 {
 		mut row := [0].repeat(FieldWidth + 2)
 		row[0] = - 1
 		row[FieldWidth + 1] = - 1


### PR DESCRIPTION
This PR fix unused variable warning or error (fix #4862).

- Just use `_` instead of unused variable.