### PR TITLE
parser: unified way to handle `struct` and `enum` name check

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -212,17 +212,6 @@ pub fn (mut c Checker) type_decl(node ast.TypeDecl) {
 }
 
 pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
-	splitted_full_name := decl.name.split('.')
-	is_builtin := splitted_full_name[0] == 'builtin'
-	name := splitted_full_name.last()
-	if !name[0].is_capital() && !decl.is_c && !is_builtin && name !in table.builtin_type_names {
-		pos := token.Position{
-			line_nr: decl.pos.line_nr
-			pos: decl.pos.pos + 7
-			len: name.len
-		}
-		c.error('struct name must begin with capital letter', pos)
-	}
 	for i, field in decl.fields {
 		for j in 0 .. i {
 			if field.name == decl.fields[j].name {
@@ -245,15 +234,12 @@ pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
 			if !c.table.check(field_expr_type, field.typ) {
 				field_expr_type_sym := c.table.get_type_symbol(field_expr_type)
 				field_type_sym := c.table.get_type_symbol(field.typ)
-				field_name := field.name
-				fet_name := field_expr_type_sym.name
-				ft_name := field_type_sym.name
-				c.error('default expression for field `${field_name}` ' + 'has type `${fet_name}`, but should be `${ft_name}`',
+				c.error('default expression for field `${field.name}` ' +
+					'has type `${field_expr_type_sym.name}`, but should be `${field_type_sym.name}`',
 					field.default_expr.position())
 			}
 		}
 	}
-	// && (p.tok.lit[0].is_capital() || is_c || (p.builtin_mod && Sp.tok.lit in table.builtin_type_names))
 }
 
 pub fn (mut c Checker) struct_init(mut struct_init ast.StructInit) table.Type {

--- a/vlib/v/checker/tests/enum_name_err.out
+++ b/vlib/v/checker/tests/enum_name_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/enum_name_err.v:1:6: error: enum name `color` must begin with a capital letter
+vlib/v/checker/tests/enum_name_err.v:1:6: error: enum name `color` must begin with capital letter
     1 | enum color {
       |      ~~~~~
     2 |     green

--- a/vlib/v/checker/tests/struct_name.out
+++ b/vlib/v/checker/tests/struct_name.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/struct_name.v:1:8: error: struct name must begin with capital letter
+vlib/v/checker/tests/struct_name.v:1:8: error: struct name `abc` must begin with capital letter
     1 | struct abc {
       |        ~~~
     2 |

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1190,7 +1190,7 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 	end_pos := p.tok.position()
 	enum_name := p.check_name()
 	if enum_name.len > 0 && !enum_name[0].is_capital() {
-		p.error_with_pos('enum name `$enum_name` must begin with a capital letter', end_pos)
+		p.error_with_pos('enum name `$enum_name` must begin with capital letter', end_pos)
 	}
 	name := p.prepend_mod(enum_name)
 	p.check(.lcbr)

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -33,6 +33,9 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 	}
 	end_pos := p.tok.position()
 	mut name := p.check_name()
+	if !is_c && !is_js && p.mod != 'builtin' && name.len > 0 && !name[0].is_capital() {
+		p.error_with_pos('struct name `$name` must begin with capital letter', end_pos)
+	}
 	// println('struct decl $name')
 	mut ast_fields := []ast.StructField{}
 	mut fields := []table.Field{}


### PR DESCRIPTION
This PR has unified way to handle `struct` and `enum` name check.

- Move struct name check from checker to parser.
   1. Increase efficiency.
   2. Can provide accurate location of errors.
- Unify the error message format.
- Minor optimization.