### PR TITLE
cgen: dereference in one place and fix

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -778,35 +778,35 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 }
 
 // use instead of expr() when you need to cast to sum type (can add other casts also)
-fn (mut g Gen) expr_with_cast(expr ast.Expr, have_type, need_type table.Type) {
+fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type, expected_type table.Type) {
 	// cast to sum type
-	if need_type != table.void_type {
-		exp_sym := g.table.get_type_symbol(need_type)
+	if expected_type != table.void_type {
+		exp_sym := g.table.get_type_symbol(expected_type)
 		if exp_sym.kind == .sum_type {
 			sum_info := exp_sym.info as table.SumType
-			if have_type in sum_info.variants {
-				have_sym := g.table.get_type_symbol(have_type)
-				have_styp := g.typ(have_type)
-				exp_styp := g.typ(need_type)
-				have_idx := have_type.idx()
-				g.write('/* sum type cast */ ($exp_styp) {.obj = memdup(&(${have_styp}[]) {')
+			if got_type in sum_info.variants {
+				got_sym := g.table.get_type_symbol(got_type)
+				got_styp := g.typ(got_type)
+				exp_styp := g.typ(expected_type)
+				got_idx := got_type.idx()
+				g.write('/* sum type cast */ ($exp_styp) {.obj = memdup(&(${got_styp}[]) {')
 				g.expr(expr)
-				g.write('}, sizeof($have_styp)), .typ = $have_idx /* $have_sym.name */}')
+				g.write('}, sizeof($got_styp)), .typ = $got_idx /* $got_sym.name */}')
 				return
 			}
 		}
 	}
 	// Generic dereferencing logic
-	need_sym := g.table.get_type_symbol(need_type)
-	have_is_ptr := have_type.is_ptr()
-	need_is_ptr := need_type.is_ptr()
-	neither_void := table.voidptr_type !in [have_type, need_type]
-	if have_is_ptr && !need_is_ptr && neither_void && need_sym.kind !in [.interface_, .placeholder] {
-		have_deref_type := have_type.deref()
-		deref_sym := g.table.get_type_symbol(have_deref_type)
-		is_opt := have_type.flag_is(.optional)
-		deref_will_match := need_type in [have_type, have_deref_type, deref_sym.parent_idx]
-		if deref_will_match || is_opt  {
+	expected_sym := g.table.get_type_symbol(expected_type)
+	got_is_ptr := got_type.is_ptr()
+	expected_is_ptr := expected_type.is_ptr()
+	neither_void := table.voidptr_type !in [got_type, expected_type]
+	if got_is_ptr && !expected_is_ptr && neither_void && expected_sym.kind !in [.interface_, .placeholder] {
+		got_deref_type := got_type.deref()
+		deref_sym := g.table.get_type_symbol(got_deref_type)
+		deref_will_match := expected_type in [got_type, got_deref_type, deref_sym.parent_idx]
+		got_is_opt := got_type.flag_is(.optional)
+		if deref_will_match || got_is_opt  {
 			g.write('*')
 		}
 	}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -801,7 +801,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, have_type, need_type table.Type) {
 	have_is_ptr := have_type.is_ptr()
 	need_is_ptr := need_type.is_ptr()
 	neither_void := table.voidptr_type !in [have_type, need_type]
-	if have_is_ptr && !need_is_ptr && neither_void && need_sym.kind != .interface_ {
+	if have_is_ptr && !need_is_ptr && neither_void && need_sym.kind !in [.interface_, .placeholder] {
 		have_deref_type := have_type.deref()
 		deref_sym := g.table.get_type_symbol(have_deref_type)
 		is_opt := have_type.flag_is(.optional)

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -797,7 +797,6 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, have_type, need_type table.Type) {
 		}
 	}
 	// Generic dereferencing logic
-	have_sym := g.table.get_type_symbol(have_type)
 	need_sym := g.table.get_type_symbol(need_type)
 	have_is_ptr := have_type.is_ptr()
 	need_is_ptr := need_type.is_ptr()

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -618,9 +618,6 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type table.Type) {
 		if !g.is_json_fn {
 			g.write('&/*qq*/')
 		}
-	} else if !arg_is_ptr && expr_is_ptr && exp_sym.kind != .interface_ {
-		// Dereference a pointer if a value is required
-		g.write('*/*d*/')
 	}
 	g.expr_with_cast(arg.expr, arg.typ, expected_type)
 }

--- a/vlib/v/tests/sum_type_test.v
+++ b/vlib/v/tests/sum_type_test.v
@@ -51,3 +51,37 @@ fn test_assignment_and_push() {
 		else {}
 	}
 }
+
+// Test moving structs between master/sub arrays
+
+type Master = Sub1 | Sub2
+struct Sub1 {
+mut:
+	val int
+	name string
+}
+struct Sub2 {
+	name string
+	val int
+}
+
+fn test_converting_down() {
+	mut out := []Master{}
+	out << Sub1 { val: 1, name: 'one' }
+	out << Sub2 { val: 2, name: 'two'}
+	out << Sub2 { val: 3, name: 'three'}
+
+	mut res := []Sub2{cap: out.len}
+	for d in out {
+		match d {
+			Sub2 { res << it }
+			else {}
+		}
+	}
+
+	assert res[0].val == 2
+	assert res[0].name == 'two'
+	assert res[1].val == 3
+	assert res[1].name == 'three'
+}
+


### PR DESCRIPTION
There is an issue where cgen creates code for `array << elem` in such way that the outcome is something like:
`array_push(&out, &(Something[]){ it });`
But `it` is a struct, so a broken struct is added to the array. This seems to happen when using sum-types for the item and array.

The fix correctly uses `*it` instead. It also handles all existing testcases correctly and adds a new case.

```
type Master = Sub1 | Sub2
struct Sub1 {
mut:
	val int
	name string
}
struct Sub2 {
	name string
	val int
}

fn test_converting_down() {
	mut out := []Master{}
	out << Sub1 { val: 1, name: 'one' }
	out << Sub2 { val: 2, name: 'two'}
	out << Sub2 { val: 3, name: 'three'}

	mut res := []Sub2{cap: out.len}
	for d in out {
		match d {
			Sub2 { res << it }
			else {}
		}
	}

	assert res[0].val == 2
	assert res[0].name == 'two'
	assert res[1].val == 3
	assert res[1].name == 'three'
}
```