### PR TITLE
fast: fix unused var, use Stopwatch, ignore more

### DIFF
--- a/cmd/tools/fast/.gitignore
+++ b/cmd/tools/fast/.gitignore
@@ -1,3 +1,5 @@
 fast
-v2
 index.html
+table.html
+v.c
+v2

--- a/cmd/tools/fast/fast.v
+++ b/cmd/tools/fast/fast.v
@@ -76,11 +76,11 @@ fn exec(s string) string {
 // returns milliseconds
 fn measure(cmd string) int {
 	println('Warming up...')
-	for i in 0..3 {
+	for _ in 0..3 {
 		exec(cmd)
 	}
 	println('Building...')
-	ticks := time.ticks()
+	sw := time.new_stopwatch()
 	exec(cmd)
-	return int(time.ticks() - ticks)
+	return int(sw.elapsed().milliseconds())
 }


### PR DESCRIPTION
- Fixed unused variable warning
- Use Stopwatch instead of time.ticks
- Add more generated files to .gitignore

Just did this because I've been annoyed at the unused variable warning every time I run it, and I can use the practice with v.