### PR TITLE
parser: optimize no main file process (fix #4871)

### DIFF
--- a/vlib/v/checker/tests/no_main_println_err.out
+++ b/vlib/v/checker/tests/no_main_println_err.out
@@ -1,0 +1,3 @@
+vlib/v/checker/tests/no_main_println_err.v:1:5: error: too few arguments in call to `println` (0 instead of 1)
+    1 |     println()
+      |     ~~~~~~~~~

--- a/vlib/v/checker/tests/no_main_println_err.vv
+++ b/vlib/v/checker/tests/no_main_println_err.vv
@@ -1,0 +1,1 @@
+    println()

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -364,9 +364,16 @@ pub fn (mut p Parser) top_stmt() ast.Stmt {
 		}
 		else {
 			if p.pref.is_script && !p.pref.is_test {
-				p.scanner.add_fn_main_and_rescan(p.tok.pos - 1)
-				p.read_first_token()
-				return p.top_stmt()
+				mut stmts := []ast.Stmt{}
+				for p.tok.kind != .eof {
+					stmts << p.stmt()
+				}
+				return ast.FnDecl{
+					name: 'main'
+					stmts: stmts
+					file: p.file_name
+					return_type: table.void_type
+				}
 			} else {
 				p.error('bad top level statement ' + p.tok.str())
 				return ast.Stmt{}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -75,21 +75,6 @@ pub fn new_scanner(text string, comments_mode CommentsMode) &Scanner {
 	return s
 }
 
-pub fn (s &Scanner) add_fn_main_and_rescan(pos int) {
-	// NB: the text may have ended in // comment, which would hide the ending }
-	// To avoid that, we need a \n right before it.
-	if pos > 0 {
-		s.text = s.text[..pos] + 'fn main() {' + s.text[pos..] + '\n}'
-		s.pos = pos
-		s.is_started = false
-	} else {
-		s.text = 'fn main() {' + s.text + '\n}'
-		s.pos = 0
-		s.line_nr = 0
-		s.is_started = false
-	}
-}
-
 fn (s &Scanner) new_token(tok_kind token.Kind, lit string, len int) token.Token {
 	return token.Token{
 		kind: tok_kind


### PR DESCRIPTION
This PR optimize no main file process (fix #4871).

- Optimize no main file process.
  1. Use adding main ast.Stmt instead of  adding `fn main()` mode.
  2. The location of the error can be pinpointed.
- Add test `no_main_println_err.vv/out`

```v
   println()

D:\test\v\tt1>v run tt1.v
tt1.v:1:4: error: too few arguments in call to `println` (0 instead of 1) 
    1 |    println()
      |    ~~~~~~~~~
```