### PR TITLE
parser: check error that do not define const in the top-level module

### DIFF
--- a/vlib/v/checker/tests/const_define_in_function_err.out
+++ b/vlib/v/checker/tests/const_define_in_function_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/const_define_in_function_err.v:2:2: error: const can only be defined at the module level (outside of functions)
+    1 | fn main() {
+    2 |     const (a = 1)
+      |     ~~~~~
+    3 |     println(a)
+    4 | }

--- a/vlib/v/checker/tests/const_define_in_function_err.out
+++ b/vlib/v/checker/tests/const_define_in_function_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/const_define_in_function_err.v:2:2: error: const can only be defined at the module level (outside of functions)
+vlib/v/checker/tests/const_define_in_function_err.v:2:2: error: const can only be defined at the top level (outside of functions)
     1 | fn main() {
     2 |     const (a = 1)
       |     ~~~~~

--- a/vlib/v/checker/tests/const_define_in_function_err.vv
+++ b/vlib/v/checker/tests/const_define_in_function_err.vv
@@ -1,0 +1,4 @@
+fn main() {
+	const (a = 1)
+	println(a)
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -505,7 +505,7 @@ pub fn (mut p Parser) stmt() ast.Stmt {
 		}
 		else {
 			if p.tok.kind == .key_const {
-				p.error_with_pos('const can only be defined at the module level (outside of functions)', p.tok.position())
+				p.error_with_pos('const can only be defined at the top level (outside of functions)', p.tok.position())
 			}
 			epos := p.tok.position()
 			return ast.ExprStmt{

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -504,6 +504,9 @@ pub fn (mut p Parser) stmt() ast.Stmt {
 			}
 		}
 		else {
+			if p.tok.kind == .key_const {
+				p.error_with_pos('const can only be defined at the module level (outside of functions)', p.tok.position())
+			}
 			epos := p.tok.position()
 			return ast.ExprStmt{
 				expr: p.expr(0)


### PR DESCRIPTION
This PR check error that do not define const in the top-level module.

- Check error that do not define const in the top-level module.
- Add test `const_define_in_function_err.vv/oust`.

```v
D:\test\v\tt1>v run .
.\tt1.v:2:2: error: const can only be defined at the top level (outside of functions) 
    1 | fn main() {
    2 |     const (a = 1)
      |     ~~~~~
    3 |     println(a)
    4 | }
```