### PR TITLE
builder: check import module not found (fix #4883)

### DIFF
--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -67,12 +67,13 @@ pub fn (mut b Builder) parse_imports() {
 				// break
 				// println('module_search_paths:')
 				// println(b.module_search_paths)
-				panic('cannot import module "$mod" (not found)')
+				verror('cannot import module "$mod" (not found)')
+				break
 			}
 			v_files := b.v_files_from_dir(import_path)
 			if v_files.len == 0 {
 				// v.parsers[i].error_with_token_index('cannot import module "$mod" (no .v files in "$import_path")', v.parsers[i].import_table.get_import_tok_idx(mod))
-				panic('cannot import module "$mod" (no .v files in "$import_path")')
+				verror('cannot import module "$mod" (no .v files in "$import_path")')
 			}
 			// Add all imports referenced by these libs
 			parsed_files := parser.parse_files(v_files, b.table, b.pref, b.global_scope)

--- a/vlib/v/checker/tests/import_not_found_err.out
+++ b/vlib/v/checker/tests/import_not_found_err.out
@@ -1,0 +1,1 @@
+builder error: cannot import module "notexist" (not found)

--- a/vlib/v/checker/tests/import_not_found_err.vv
+++ b/vlib/v/checker/tests/import_not_found_err.vv
@@ -1,0 +1,4 @@
+import notexist
+fn main() {
+	println('hello, world')
+}


### PR DESCRIPTION
This PR check import module not found (fix #4883).

- Check import module not found.
- Use `verror` instead of `panic`.
- Add test `import_not_found.vv/out`

```v
import doesnotexist

D:\test\v\tt1>v run .
builder error: cannot import module "doesnotexist" (not found)
```