### PR TITLE
sizeof(C.struct) generate error

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1264,6 +1264,14 @@ fn (mut g Gen) expr(node ast.Expr) {
 			mut styp := it.type_name
 			if it.type_name == '' {
 				styp = g.typ(it.typ)
+            } else {
+			    sym := g.table.get_type_symbol(it.typ)
+			    if sym.kind == .struct_ {
+			        info := sym.info as table.Struct
+			        if !info.is_typedef {
+			           styp = 'struct ' + styp
+			        }
+			    }
 			}
 			/*
 			if styp.starts_with('C__') {

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -76,14 +76,15 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 		.key_sizeof {
 			p.next() // sizeof
 			p.check(.lpar)
+			sizeof_type := p.parse_type()
 			if p.tok.lit == 'C' {
 				p.next()
 				p.check(.dot)
 				node = ast.SizeOf{
 					type_name: p.check_name()
+					typ: sizeof_type
 				}
 			} else {
-				sizeof_type := p.parse_type()
 				node = ast.SizeOf{
 					typ: sizeof_type
 				}


### PR DESCRIPTION
2020-05-14: fix sizeof(C.struct) generate error
use the no typedef struct , sizeof() add struct prefix
