### PR TITLE
parser: warning unused `import module`

### DIFF
--- a/cmd/tools/preludes/tests_assertions.v
+++ b/cmd/tools/preludes/tests_assertions.v
@@ -1,7 +1,6 @@
 module main
 
 import os
-import term
 // //////////////////////////////////////////////////////////////////
 // / This file will get compiled as part of the main program,
 // / for a _test.v file.

--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -4,7 +4,6 @@
 module ast
 
 import v.table
-import v.token
 
 pub struct Scope {
 //mut:

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -1,7 +1,6 @@
 module builder
 
 import os
-import time
 import v.ast
 import v.table
 import v.pref
@@ -9,10 +8,6 @@ import v.util
 import v.vmod
 import v.checker
 import v.parser
-import v.errors
-import v.gen
-import v.gen.js
-import v.gen.x64
 import v.depgraph
 
 const (

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -6,8 +6,6 @@ module builder
 import time
 import os
 import v.pref
-import v.util
-import strings
 
 fn get_vtmp_folder() string {
 	vtmp := os.join_path(os.temp_dir(), 'v')

--- a/vlib/v/builder/x64.v
+++ b/vlib/v/builder/x64.v
@@ -1,7 +1,6 @@
 module builder
 
 import time
-import os
 import v.parser
 import v.pref
 import v.gen

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4,13 +4,11 @@
 module checker
 
 import v.ast
-import v.depgraph
 import v.table
 import v.token
 import v.pref
 import v.util
 import v.errors
-import os
 
 const (
 	max_nr_errors = 300

--- a/vlib/v/checker/tests/import_not_found_err.vv
+++ b/vlib/v/checker/tests/import_not_found_err.vv
@@ -1,4 +1,4 @@
 import notexist
 fn main() {
-	println('hello, world')
+	println(notexist.name)
 }

--- a/vlib/v/checker/tests/import_unused_warning.out
+++ b/vlib/v/checker/tests/import_unused_warning.out
@@ -1,0 +1,3 @@
+vlib/v/checker/tests/import_unused_warning.v:6:1: warning: the following imports were never used:
+ * time
+    4 | }

--- a/vlib/v/checker/tests/import_unused_warning.out
+++ b/vlib/v/checker/tests/import_unused_warning.out
@@ -1,3 +1,1 @@
-vlib/v/checker/tests/import_unused_warning.v:6:1: warning: the following imports were never used:
- * time
-    4 | }
+`vlib/v/checker/tests/import_unused_warning.v` warning: the following imports were never used: time

--- a/vlib/v/checker/tests/import_unused_warning.out
+++ b/vlib/v/checker/tests/import_unused_warning.out
@@ -1,1 +1,2 @@
-`vlib/v/checker/tests/import_unused_warning.v` warning: the following imports were never used: time
+`vlib/v/checker/tests/import_unused_warning.v` warning: the following imports were never used:
+ * time

--- a/vlib/v/checker/tests/import_unused_warning.vv
+++ b/vlib/v/checker/tests/import_unused_warning.vv
@@ -1,0 +1,4 @@
+import time
+fn main() {
+	println('hello, world')
+}

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -1,7 +1,5 @@
 module gen
 
-import v.util
-
 // NB: @@@ here serve as placeholders.
 // They will be replaced with correct strings
 // for each constant, during C code generation.

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -3,8 +3,6 @@ module js
 import strings
 import v.ast
 import v.table
-import v.depgraph
-import v.token
 import v.pref
 import term
 import v.util

--- a/vlib/v/gen/live.v
+++ b/vlib/v/gen/live.v
@@ -1,7 +1,5 @@
 module gen
 
-import os
-import time
 import v.pref
 import v.util
 

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -4,8 +4,6 @@
 module parser
 
 import v.ast
-import v.table
-import v.token
 
 fn (mut p Parser) assign_stmt() ast.Stmt {
 	is_static := p.tok.kind == .key_static

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -5,7 +5,6 @@ module parser
 
 import v.ast
 import v.table
-import v.token
 
 fn (mut p Parser) for_stmt() ast.Stmt {
 	p.check(.key_for)

--- a/vlib/v/parser/module.v
+++ b/vlib/v/parser/module.v
@@ -17,3 +17,27 @@ fn (p &Parser) prepend_mod(name string) string {
 	}
 	return '${p.mod}.$name'
 }
+
+fn (p &Parser) is_used_import(alias string) bool {
+	return alias in p.used_imports
+}
+
+fn (mut p Parser) register_used_import(alias string) {
+	if alias !in p.used_imports {
+		p.used_imports << alias
+	}
+}
+
+fn (p mut Parser) check_unused_imports() {
+	mut output := ''
+	for alias, mod in p.imports {
+		if !p.is_used_import(alias) {
+			mod_alias := if alias == mod { alias } else { '$alias ($mod)' }
+			output += '\n * $mod_alias'
+		}
+	}
+	if output == '' {
+		return
+	}
+	p.warn('the following imports were never used: $output')
+}

--- a/vlib/v/parser/module.v
+++ b/vlib/v/parser/module.v
@@ -33,7 +33,7 @@ fn (p mut Parser) check_unused_imports() {
 	for alias, mod in p.imports {
 		if !p.is_used_import(alias) {
 			mod_alias := if alias == mod { alias } else { '$alias ($mod)' }
-			output += '$mod_alias '
+			output += '\n * $mod_alias'
 		}
 	}
 	if output == '' {

--- a/vlib/v/parser/module.v
+++ b/vlib/v/parser/module.v
@@ -33,11 +33,11 @@ fn (p mut Parser) check_unused_imports() {
 	for alias, mod in p.imports {
 		if !p.is_used_import(alias) {
 			mod_alias := if alias == mod { alias } else { '$alias ($mod)' }
-			output += '\n * $mod_alias'
+			output += '$mod_alias '
 		}
 	}
 	if output == '' {
 		return
 	}
-	p.warn('the following imports were never used: $output')
+	eprintln('`$p.file_name` warning: the following imports were never used: $output')
 }

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -23,7 +23,7 @@ pub fn (mut p Parser) parse_array_type() table.Type {
 
 	// detect attr
 	not_attr := p.peek_tok.kind != .name && p.peek_tok2.kind !in [.semicolon, .rsbr]
-	
+
 	for p.tok.kind == .lsbr && not_attr {
 		p.next()
 		p.check(.rsbr)
@@ -145,6 +145,9 @@ pub fn (mut p Parser) parse_any_type(is_c, is_js, is_ptr bool) table.Type {
 		if !p.known_import(name) {
 			println(p.table.imports)
 			p.error('unknown module `$p.tok.lit`')
+		}
+		if p.tok.lit in p.imports {
+			p.register_used_import(p.tok.lit)
 		}
 		p.next()
 		p.check(.dot)

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -4,7 +4,6 @@
 module pref
 
 import os
-import term
 
 pub const (
 	default_module_path = mpath()


### PR DESCRIPTION
This PR warning unused `import module` in parser.v.

- Warning unused `import module`.
- Add test `import_unused_warning.vv/out`
- Modify related existing module warnings.

```v
import time
fn main() {
	println('hello, world')
}

D:\test\v\tt1>v run .
.\tt1.v:5:2: warning: the following imports were never used: 
 * time
    3 |     println('hello, world')
    4 | }
hello, world
```