### PR TITLE
cgen: fix optional_void error (fix #4896)

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -323,8 +323,9 @@ fn (g &Gen) base_type(t table.Type) string {
 fn (mut g Gen) register_optional(t table.Type, styp string) {
 	// g.typedefs2.writeln('typedef Option $x;')
 	no_ptr := styp.replace('*', '_ptr')
+	typ := if styp == 'void' { 'void*' } else { styp }
 	g.hotcode_definitions.writeln('typedef struct {
-		$styp  data;
+		$typ  data;
 		string error;
 		int    ecode;
 		bool   ok;

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -123,7 +123,10 @@ pub fn (mut p Parser) parse_type() table.Type {
 		p.next()
 		p.check(.dot)
 	}
-	mut typ := p.parse_any_type(is_c, is_js, nr_muls > 0)
+	mut typ := table.void_type
+	if p.tok.kind != .lcbr {
+		typ = p.parse_any_type(is_c, is_js, nr_muls > 0)
+	}
 	if is_optional {
 		typ = typ.set_flag(.optional)
 	}

--- a/vlib/v/tests/option_test.v
+++ b/vlib/v/tests/option_test.v
@@ -219,3 +219,16 @@ fn test_optional_void() {
 		return
 	}
 }
+
+
+fn bar() ? {
+	return error('bar error')
+}
+
+fn test_optional_void_only_question() {
+	bar() or {
+		println(err)
+		assert err == 'bar error'
+		return
+	}
+}

--- a/vlib/v/tests/option_test.v
+++ b/vlib/v/tests/option_test.v
@@ -207,3 +207,15 @@ fn test_multi_return_opt() {
 	}
 }
 */
+
+fn foo() ?void {
+	return error('something')
+}
+
+fn test_optional_void() {
+	foo() or {
+		println(err)
+		assert err == 'something'
+		return
+	}
+}


### PR DESCRIPTION
This PR fix optional_void error (fix #4896).

- Fix optional_void error.
- Add `test_optional_void()` in option_test.v.

```v
fn main() {
	foo() or { panic(err) }
}

fn foo() ?void {
	return error('something')
}

D:\test\v\tt1>v run .
V panic: something
print_backtrace_skipping_top_frames_mingw is not implemented
```