### PR TITLE
docs: fix typo

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -349,7 +349,7 @@ fn main() {
 }
 ```
 
-Modules can be imported using keyword `import`. When using types, functions, and constants from other modules, the full path must be specified. In the example above, `name := get_line()` wouldn't work. That means that it's always clear from which module a function is called
+Modules can be imported using keyword `import`. When using types, functions, and constants from other modules, the full path must be specified. In the example above, `name := input()` wouldn't work. That means that it's always clear from which module a function is called
 
 ## Arrays
 


### PR DESCRIPTION
Use `input` instead of `get_line()`