### PR TITLE
v.mod: correct version number

### DIFF
--- a/v.mod
+++ b/v.mod
@@ -3,6 +3,6 @@
 Module {
 	name: 'V',
 	description: 'The V programming language.',
-	version: '0.1.25'
+	version: '0.1.27'
 	dependencies: []
 }


### PR DESCRIPTION
Change version in v.mod to `0.1.27` instead of `0.1.25`.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
