### PR TITLE
string: add trim_prefix and trim_suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 *.lib
 *.bak
 a.out
+.noprefix.vrepl_temp
 
 # ignore v build files
 /v.c
@@ -22,6 +23,7 @@ a.out
 /v.c.out
 .vrepl_temp.v
 fns.txt
+.noprefix.vrepl_temp.v
 
 # ignore temp directories
 /temp

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -926,6 +926,20 @@ pub fn (s string) trim_right(cutset string) string {
 	return if pos < 0 { '' } else { s.left(pos + 1) }
 }
 
+pub fn (s string) trim_prefix(str string) string {
+	if s.starts_with(str) {
+		return s.replace(str, "")
+	}
+	return s
+}
+
+pub fn (s string) trim_suffix(str string) string {
+	if s.ends_with(str) {
+		return s.replace(str, "")
+	}
+	return s
+}
+
 // fn print_cur_thread() {
 // //C.printf("tid = %08x \n", pthread_self());
 // }

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -25,6 +25,12 @@ fn test_add() {
 fn test_ends_with() {
 	a := 'browser.v'
 	assert a.ends_with('.v')
+
+	s := 'V Programming Language'
+	assert s.ends_with('guage') == true
+	assert s.ends_with('Language') == true
+	assert s.ends_with('Programming Language') == true
+	assert s.ends_with('V') == false
 }
 
 fn test_between() {
@@ -644,6 +650,27 @@ fn test_repeat() {
 	assert s2.repeat(1) == s2
 	assert s2.repeat(0) == s2
 	// TODO Add test for negative values
+}
+
+fn test_starts_with() {
+	s := 'V Programming Language'
+	assert s.starts_with('V') == true
+	assert s.starts_with('V Programming') == true
+	assert s.starts_with('Language') == false
+}
+
+fn test_trim_prefix() {
+	s := 'V Programming Language'
+	assert s.trim_prefix('V ') == 'Programming Language'
+	assert s.trim_prefix('V Programming ') == 'Language'
+	assert s.trim_prefix('Language') == s
+}
+
+fn test_trim_suffix() {
+	s := 'V Programming Language'
+	assert s.trim_suffix(' Language') == 'V Programming'
+	assert s.trim_suffix(' Programming Language') == 'V'
+	assert s.trim_suffix('V') == s
 }
 
 fn test_raw() {


### PR DESCRIPTION
Pretty Self Explanatory

```v
fn test_trim_prefix() {
	s := 'V Programming Language'
	assert s.trim_prefix('V ') == 'Programming Language'
	assert s.trim_prefix('V Programming ') == 'Language'
	assert s.trim_prefix('Language') == s
}

fn test_trim_suffix() {
	s := 'V Programming Language'
	assert s.trim_suffix(' Language') == 'V Programming'
	assert s.trim_suffix(' Programming Language') == 'V'
	assert s.trim_suffix('V') == s
}
``` 