### PR TITLE
array initialization: add more tests (for int and string arrays)

### DIFF
--- a/vlib/v/tests/array_init_test.v
+++ b/vlib/v/tests/array_init_test.v
@@ -39,3 +39,91 @@ fn test_array_init_with_len_no_default() {
 	a3 := []bool{len: 3}
 	assert '$a3' == '[false, false, false]'
 }
+
+fn test_array_int_full_options() {
+	println('Test array of int values')
+
+	a := []int{len: 2, cap: 10} // this creates an array with 2 items, initial capacity 10, default value of array type
+	println('array a: length: ${a.len}, capacity: ${a.cap}, content: $a')
+	assert a.len == 2
+	assert a.cap == 10
+	assert a.cap >= a.len
+	assert a.str() == "[0, 0]"
+
+	b := []int{len: 10, cap: 100, init: 1} // this creates an array with 10 one and initial capacity 100 elements, value given
+	_ := b.clone() // discard result variable, sample
+	println('array b: length: ${b.len}, capacity: ${b.cap}, content: $b')
+	assert b.len == 10
+	assert b.cap == 100
+	assert b.cap >= b.len
+	assert b.str() == "[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]"
+
+	mut c := []int{len: 2, cap: 10, init: 1} // this creates an array with 2 one and initial capacity 10 elements, value given
+	_ := c.clone() // discard result variable, sample
+	println('array c: length: ${c.len}, capacity: ${c.cap}, content: $c')
+	assert c.len == 2
+	assert c.cap == 10
+	assert c.cap >= c.len
+	assert c.str() == "[1, 1]"
+	// add some items to the array, to check limits
+	c << [3, 4, 5, 6, 7, 8, 9, 10] // add 8 items, from another array
+	// update one item, to have the right number in the sequence ...
+	c[1] = 2
+	println('array c: length: ${c.len}, capacity: ${c.cap}, content now: $c')
+	assert c.len == 10
+	assert c.cap == 10
+	assert c.cap >= c.len
+	assert c.str() == "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
+	// add some more item after initial capacity, to ensure it's expandable
+	c << [11, 12, 13, 14, 15, 16]
+	println('array c: length: ${c.len}, capacity: ${c.cap}, content now: $c')
+	assert c.len == 16
+	assert c.cap >= c.len
+	assert c.str() == "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]"
+}
+
+fn test_array_string_full_options() {
+	println('Test array of string values')
+
+	a := []string{len: 2, cap: 10} // this creates an array with 2 items, initial capacity 10, default value of array type
+	println('array a: length: ${a.len}, capacity: ${a.cap}') // ok
+	println('array a: length: ${a.len}, capacity: ${a.cap}, content: "$a"')
+	assert a.len == 2
+	assert a.cap == 10
+	assert a.cap >= a.len
+	assert a.str() == "['', '']"
+
+	b := []string{len: 10, cap: 100, init: 'b'} // this creates an array with 10 'b', initial capacity 100 elements, value given
+	_ := b.clone() // discard result variable, sample
+	println('array b: length: ${b.len}, capacity: ${b.cap}') // ok
+	println('array b: length: ${b.len}, capacity: ${b.cap}, content: $b')
+	assert b.len == 10
+	assert b.cap == 100
+	assert b.cap >= b.len
+	assert b.str() == "['b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b']"
+
+	mut c := []string{len: 2, cap: 10, init: 'c'} // this creates an array with 2 'c' and initial capacity 10 elements, value given
+	_ := c.clone() // discard result variable, sample
+	println('array c: length: ${c.len}, capacity: ${c.cap}, content: $c')
+	assert c.len == 2
+	assert c.cap == 10
+	assert c.cap >= c.len
+	assert c.str() == "['c', 'c']"
+	// add some items to the array, to check limits
+	c << ['c', 'c', 'c', 'c', 'c', 'c', 'c', 'c'] // add 8 items, from another array
+	// update some items, to have the right number in the sequence ...
+	c[0] = 'a'
+	c[1] = 'b'
+	println('array c: length: ${c.len}, capacity: ${c.cap}, content now: $c')
+	assert c.len == 10
+	assert c.cap == 10
+	assert c.cap >= c.len
+	assert c.str() == "['a', 'b', 'c', 'c', 'c', 'c', 'c', 'c', 'c', 'c']"
+	// add some more item after initial capacity, to ensure all is good
+	c << ['11', '12', '13', '14', '15', '16']
+	// c << ['11', nil, '13', '14', '15', '16'] // check later if/how to handle this ...
+	println('array c: length: ${c.len}, capacity: ${c.cap}, content now: $c')
+	assert c.len == 16
+	assert c.cap >= c.len
+	assert c.str() == "['a', 'b', 'c', 'c', 'c', 'c', 'c', 'c', 'c', 'c', '11', '12', '13', '14', '15', '16']"
+}


### PR DESCRIPTION
Hi,
note that **tests added here currently are failing**, but I think because array items are not properly initialized with the given 'init' value (but only with the default one of the type.

On string arrays default nil value is breaking even the conversion to string of the array, so not sure if my test without init value it makes sense, or if possible in that case to print a literal `nil` (or `null` or other similar) instead for a safe conversion to string (like in Java, Node.js, etc)  ...

I added a TODO comment in any test that's failing (to identify in a simpler way); before the merge tell me so I can remove those comments.

Tell me.
Thanks