### PR TITLE
os: add new function exists_in_path

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -946,8 +946,8 @@ pub fn find_abs_path_of_executable(exepath string) ?string {
 	return error('failed to find executable')
 }
 
-// exists_in_path returns true if prog exists in the system's path
-fn exists_in_path(prog string) bool {
+// exists_in_system_path returns true if prog exists in the system's path
+fn exists_in_system_path(prog string) bool {
 	os.find_abs_path_of_executable(prog) or {
 		return false
 	}

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -946,6 +946,14 @@ pub fn find_abs_path_of_executable(exepath string) ?string {
 	return error('failed to find executable')
 }
 
+// exists_in_path returns true if prog exists in the system's path
+fn exists_in_path(prog string) bool {
+	os.find_abs_path_of_executable(prog) or {
+		return false
+	}
+	return true
+}
+
 [deprecated]
 pub fn dir_exists(path string) bool {
 	panic('Use `os.is_dir` instead of `os.dir_exists`')


### PR DESCRIPTION
This functions returns true or false based on whether a program exists in the system's PATH

## The reason for this:
checking for the existence of two programs or more in the PATH can't be easily done due to the fact that `find_abs_path_of_executable()` returns ?string and that in V you have to handle the error using `or {}`

I mentioned this problem I stumbled with on #4859:

"It allows for `if !(exists_in_path('wl-copy') && exists_in_path('wl-paste'))` which I needed for this and may be needed by someone else. I couldn't find any easy way to do this but for a new function"

## Reason there's no test: 
The function `find_abs_path_of_executable` has no test as well and this is just a simple wrapper on it which only return true or false and has no errors

