### PR TITLE
cgen: fix array_init_with_default error (fix #4889)

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -37,7 +37,7 @@ fn __new_array_with_default(mylen int, cap int, elm_size int, val voidptr) array
 	}
 	if val != 0 {
 		for i in 0..arr.len {
-			C.memcpy(arr.data + i*elm_size, val, elm_size)
+			C.memcpy(charptr(arr.data) + i*elm_size, val, elm_size)
 		}
 	}
 	return arr

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -27,6 +27,22 @@ fn __new_array(mylen int, cap int, elm_size int) array {
 	return arr
 }
 
+fn __new_array_with_default(mylen int, cap int, elm_size int, val voidptr) array {
+	cap_ := if cap < mylen { mylen } else { cap }
+	arr := array{
+		len: mylen
+		cap: cap_
+		element_size: elm_size
+		data: vcalloc(cap_ * elm_size)
+	}
+	if val != 0 {
+		for i in 0..arr.len {
+			C.memcpy(arr.data + i*elm_size, val, elm_size)
+		}
+	}
+	return arr
+}
+
 // Private function, used by V (`nums := [1, 2, 3]`)
 fn new_array_from_c_array(len, cap, elm_size int, c_array voidptr) array {
 	cap_ := if cap < len { len } else { cap }

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -977,6 +977,12 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 				ast.ArrayInit {
 					is_fixed_array_init = it.is_fixed
 					has_val = it.has_val
+					if it.has_default {
+						elem_type_str := g.typ(it.elem_type)
+						g.write('$elem_type_str ${elem_type_str}_val_t = ')
+						g.expr(it.default_expr)
+						g.writeln(';')
+					}
 				}
 				else {}
 			}
@@ -1239,7 +1245,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 			g.write("'$it.val'")
 		}
 		ast.ConcatExpr {
-			g.concat_expr(it)	
+			g.concat_expr(it)
 		}
 		ast.EnumVal {
 			// g.write('${it.mod}${it.enum_name}_$it.val')
@@ -3842,7 +3848,7 @@ fn (mut g Gen) array_init(it ast.ArrayInit) {
 	// elem_sym := g.table.get_type_symbol(it.elem_type)
 	elem_type_str := g.typ(it.elem_type)
 	if it.exprs.len == 0 {
-		g.write('__new_array(')
+		g.write('__new_array_with_default(')
 		if it.has_len {
 			g.expr(it.len_expr)
 			g.write(', ')
@@ -3855,7 +3861,12 @@ fn (mut g Gen) array_init(it ast.ArrayInit) {
 		} else {
 			g.write('0, ')
 		}
-		g.write('sizeof($elem_type_str))')
+		g.write('sizeof($elem_type_str), ')
+		if it.has_default {
+			g.write('&${elem_type_str}_val_t)')
+		} else {
+			g.write('0)')
+		}
 		return
 	}
 	len := it.exprs.len

--- a/vlib/v/tests/array_init_test.v
+++ b/vlib/v/tests/array_init_test.v
@@ -14,3 +14,11 @@ fn test_array_init() {
 	d << 'bbb'
 	'$d, $d.len, $d.cap' == "['aaa', 'bbb'], 2, 3"
 }
+
+fn test_array_init_with_default() {
+	a := []int{len: 4, init: 2}
+	assert '$a' == '[2, 2, 2, 2]'
+
+	b := []string{len: 3, init: 'abc'}
+	assert '$b' == "['abc', 'abc', 'abc']"
+}


### PR DESCRIPTION
This PR fix array_init_with_default error (fix #4889).

- Fix array_init_with_default error (fix #4889).
- Add test `test_array_init_with_default()` in array_init_test.v.

```v
fn main() {
	a := []string{len: 4, init: 'abc'}
	println(a)
}

D:\test\v\tt1>v run .
['abc', 'abc', 'abc', 'abc']
```

**Solution**
Because modifying `__new_array` results in compilation errors and v.c must be updated, then increase `__new_array_with_default`，I think they should be merged to one.
