### PR TITLE
cgen: remove extra `;` from if_expr generating

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -565,7 +565,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 		}
 		ast.ExprStmt {
 			g.expr(it.expr)
-			if g.inside_ternary == 0 {
+			if g.inside_ternary == 0 && !(it.expr is ast.IfExpr) {
 				g.writeln(';')
 			}
 		}


### PR DESCRIPTION
This PR remove extra `;` from if_expr generating c code.

issues
```v
array_byte string_bytes(string s) {
    if (s.len == 0) {
        return __new_array(0, 0, sizeof(byte));
    }
    ;
    array_byte buf = array_repeat(new_array_from_c_array(1, 1, sizeof(byte), (byte[1]){
        ((byte)(0)), 
}), s.len);
    memcpy(buf.data, s.str, s.len);
    return buf;
}
```
There's going to be extra `;` coming out here, this PR remove it.