### PR TITLE
vmod: Add v.mod parser

### DIFF
--- a/cmd/tools/vcreate.v
+++ b/cmd/tools/vcreate.v
@@ -22,7 +22,6 @@ fn cerror(e string){
 
 fn vmod_content(name, desc string) string {
 	return  [
-		'#V Project#\n',
 		'Module {',
 		'	name: \'${name}\',',
 		'	description: \'${desc}\',',

--- a/v.mod
+++ b/v.mod
@@ -1,5 +1,3 @@
-#V Project#
-
 Module {
 	name: 'V',
 	description: 'The V programming language.',

--- a/vlib/v/tests/project_with_c_code/mod1/v.mod
+++ b/vlib/v/tests/project_with_c_code/mod1/v.mod
@@ -1,5 +1,3 @@
-#V Module#
-
 Module {
 	name: 'mod1',
 	description: 'A simple module, containing C code.',

--- a/vlib/v/tests/vmod_parser_test.v
+++ b/vlib/v/tests/vmod_parser_test.v
@@ -1,0 +1,39 @@
+import vmod
+
+fn test_from_file() {
+	data := vmod.from_file('./v.mod') or {
+		panic(err)
+	}
+
+	assert data.name == 'V'
+	assert data.description == 'The V programming language.'
+	assert data.version == '0.1.27'
+	assert data.dependencies.len == 0
+}
+
+fn test_decode() {
+	content := '
+	  Module {
+		name: \'foobar\',
+		description: \'Just a sample module\'
+		version: \'0.2.0\',
+		repo_url: \'https://gitlab.com\',
+		author: \'Fooz Bar\',
+		license: \'GPL-2.0\',
+		dependencies: [\'hello\']
+	  }
+	'
+
+	data := vmod.decode(content) or {
+		println(err)
+		exit(1)
+	}
+
+	assert data.name == 'foobar'
+	assert data.version == '0.2.0'
+	assert data.description == 'Just a sample module'
+	assert data.repo_url == 'https://gitlab.com'
+	assert data.author == 'Fooz Bar'
+	assert data.license == 'GPL-2.0'
+	assert data.dependencies[0] == 'hello'
+}

--- a/vlib/v/tests/vmod_parser_test.v
+++ b/vlib/v/tests/vmod_parser_test.v
@@ -36,4 +36,9 @@ fn test_decode() {
 	assert data.author == 'Fooz Bar'
 	assert data.license == 'GPL-2.0'
 	assert data.dependencies[0] == 'hello'
+
+	_ := vmod.decode('') or {
+		assert err == 'vmod: no content.'
+		exit(0)
+	}
 }

--- a/vlib/v/tests/vmod_parser_test.v
+++ b/vlib/v/tests/vmod_parser_test.v
@@ -4,7 +4,6 @@ fn test_from_file() {
 	data := vmod.from_file('./v.mod') or {
 		panic(err)
 	}
-
 	assert data.name == 'V'
 	assert data.description == 'The V programming language.'
 	assert data.version == '0.1.27'
@@ -12,7 +11,7 @@ fn test_from_file() {
 }
 
 fn test_decode() {
-	content := '
+	content := "
 	  Module {
 		name: \'foobar\',
 		description: \'Just a sample module\'
@@ -23,13 +22,11 @@ fn test_decode() {
 		dependencies: [\'hello\'],
 		test: \'foo\'
 	  }
-	'
-
+	"
 	data := vmod.decode(content) or {
 		println(err)
 		exit(1)
 	}
-
 	assert data.name == 'foobar'
 	assert data.version == '0.2.0'
 	assert data.description == 'Just a sample module'
@@ -38,7 +35,6 @@ fn test_decode() {
 	assert data.license == 'GPL-2.0'
 	assert data.dependencies[0] == 'hello'
 	assert data.unknown['test'][0] == 'foo'
-
 	_ := vmod.decode('') or {
 		assert err == 'vmod: no content.'
 		exit(0)

--- a/vlib/v/tests/vmod_parser_test.v
+++ b/vlib/v/tests/vmod_parser_test.v
@@ -20,7 +20,8 @@ fn test_decode() {
 		repo_url: \'https://gitlab.com\',
 		author: \'Fooz Bar\',
 		license: \'GPL-2.0\',
-		dependencies: [\'hello\']
+		dependencies: [\'hello\'],
+		test: \'foo\'
 	  }
 	'
 
@@ -36,6 +37,7 @@ fn test_decode() {
 	assert data.author == 'Fooz Bar'
 	assert data.license == 'GPL-2.0'
 	assert data.dependencies[0] == 'hello'
+	assert data.unknown['test'][0] == 'foo'
 
 	_ := vmod.decode('') or {
 		assert err == 'vmod: no content.'

--- a/vlib/v/vmod/parser.v
+++ b/vlib/v/vmod/parser.v
@@ -90,9 +90,9 @@ fn (mut s Scanner) create_string(q byte) string {
 			str += s.text[s.pos..s.pos+1]
 			s.pos += 2
 		} else {
-        str += s.text[s.pos].str()
-        s.pos++
-    }
+			str += s.text[s.pos].str()
+			s.pos++
+		}
     }
     return str
 }
@@ -197,10 +197,14 @@ fn get_array_content(tokens []Token, st_idx int) ?([]string, int) {
 }
 
 fn (mut p Parser) parse() ?Manifest {
+    err_label := 'vmod:'
+	if p.scanner.text.len == 0 {
+		return error('$err_label no content.')
+	}
+
     p.scanner.scan_all()
     tokens := p.scanner.tokens
     mut mn := Manifest{}
-    err_label := 'vmod:'
 
     if tokens[0].typ != .module_keyword {
         panic('not a valid v.mod')

--- a/vlib/v/vmod/parser.v
+++ b/vlib/v/vmod/parser.v
@@ -83,12 +83,16 @@ fn is_name_alpha(chr byte) bool {
     return chr.is_letter() || chr == `_`
 }
 
-fn (mut s Scanner) create_string() string {
+fn (mut s Scanner) create_string(q byte) string {
     mut str := ''
-
-    for s.text[s.pos] != `\'` {
+    for s.text[s.pos] != q {
+        if s.text[s.pos] == `\\` && s.text[s.pos+1] == q {
+			str += s.text[s.pos..s.pos+1]
+			s.pos += 2
+		} else {
         str += s.text[s.pos].str()
         s.pos++
+    }
     }
     return str
 }
@@ -135,9 +139,9 @@ fn (mut s Scanner) scan_all() {
             }
         }
 
-        if c == `\'` && !s.peek_char(`\\`) {
+        if c in [`\'`, `\"`] && !s.peek_char(`\\`) {
             s.pos++
-            str := s.create_string()
+            str := s.create_string(c)
             s.tokenize(.str, str)
             s.pos++
             continue

--- a/vlib/v/vmod/parser.v
+++ b/vlib/v/vmod/parser.v
@@ -1,0 +1,263 @@
+module vmod
+import os
+
+enum TokenKind {
+    module_keyword 
+    field_key
+    lcbr 
+    rcbr 
+    labr 
+    rabr 
+    comma 
+    colon 
+    eof 
+    str 
+    ident
+}
+
+pub struct Manifest {
+pub mut:
+    name string
+    version string
+	description string
+    dependencies []string
+    license string
+    repo_url string
+    author string
+}
+
+struct Scanner {
+mut:
+    pos int
+    text string
+    inside_text bool
+    started bool
+    tokens []Token = []Token{}
+}
+
+struct Parser {
+mut: 
+    file_path string
+    scanner Scanner
+}
+
+struct Token {
+    typ TokenKind
+    val string
+}
+
+pub fn from_file(vmod_path string) ?Manifest {
+    if !os.exists(vmod_path) {
+        return error('v.mod: v.mod file not found.')
+    }
+
+    contents := os.read_file(vmod_path) or {
+        panic('v.mod: cannot parse v.mod')
+    }
+
+    return decode(contents)
+}
+
+pub fn decode(contents string) ?Manifest {
+    mut parser := Parser{
+        scanner: Scanner{
+            pos: 0,
+            text: contents
+        }
+    }
+
+    return parser.parse()
+}
+
+fn (mut s Scanner) tokenize(t_type TokenKind, val string) {
+    s.tokens << Token{t_type, val}
+}
+
+fn (mut s Scanner) skip_whitespace() {
+	for s.pos < s.text.len && s.text[s.pos].is_space() {
+		s.pos++
+	}
+}
+
+fn is_name_alpha(chr byte) bool {
+    return chr.is_letter() || chr == `_`
+}
+
+fn (mut s Scanner) create_string() string {
+    mut str := ''
+
+    for s.text[s.pos] != `\'` {
+        str += s.text[s.pos].str()
+        s.pos++
+    }
+    return str
+}
+
+fn (mut s Scanner) create_ident() string {
+    mut text := ''
+
+    for is_name_alpha(s.text[s.pos]) {
+        text += s.text[s.pos].str()
+        s.pos++
+    }
+
+    return text
+}
+
+fn (s Scanner) peek_char(c byte) bool {
+    return s.pos-1 < s.text.len && s.text[s.pos-1] == c
+}
+
+fn (mut s Scanner) scan_all() {
+    for s.pos < s.text.len {
+        c := s.text[s.pos]
+
+        if c.is_space() || c == `\\` {
+            s.pos++
+            continue
+        }
+
+        if is_name_alpha(c) {
+            name := s.create_ident()
+
+            if name == 'Module' {
+                s.tokenize(.module_keyword, name)
+                s.pos++
+                continue
+            } else if s.text[s.pos] == `:` {
+                s.tokenize(.field_key, name + ':')
+                s.pos += 2
+                continue
+            } else {
+                s.tokenize(.ident, name)
+                s.pos++
+                continue
+            }
+        }
+
+        if c == `\'` && !s.peek_char(`\\`) {
+            s.pos++
+            str := s.create_string()
+            s.tokenize(.str, str)
+            s.pos++
+            continue
+        }
+
+        match c {
+            `{` { s.tokenize(.lcbr, c.str()) }
+            `}` { s.tokenize(.rcbr, c.str()) }
+            `[` { s.tokenize(.labr, c.str()) }
+            `]` { s.tokenize(.rabr, c.str()) }
+            `:` { s.tokenize(.colon, c.str()) }
+            `,` { s.tokenize(.comma, c.str()) }
+            else { s.tokenize(.eof, 'eof') }
+        }
+
+        s.pos++
+    }
+}
+
+fn get_array_content(tokens []Token, st_idx int) ?([]string, int) {
+    mut vals := []string{}
+    mut idx := st_idx
+
+    if tokens[idx].typ != .labr {
+        return error('vmod: not a valid array')
+    }
+
+    idx++
+
+    for {
+        tok := tokens[idx]
+        match tok.typ {
+            .str {
+                vals << tok.val
+
+                if tokens[idx+1].typ !in [.comma, .rabr] {
+                    return error('vmod: invalid separator "${tokens[idx+1].val}"')
+                }
+
+                idx += if tokens[idx+1].typ == .comma { 2 } else { 1 }
+            }
+            .rabr {
+                idx++
+                break
+            }
+            else { 
+                return error('vmod: invalid token "$tok.val"') 
+            }
+        }
+    }
+
+    return vals, idx
+}
+
+fn (mut p Parser) parse() ?Manifest {
+    p.scanner.scan_all()
+    tokens := p.scanner.tokens
+    mut mn := Manifest{}
+    err_label := 'vmod:'
+
+    if tokens[0].typ != .module_keyword {
+        panic('not a valid v.mod')
+    }
+
+    mut i := 1
+    for i < tokens.len {
+        tok := tokens[i]
+        match tok.typ {
+            .lcbr { 
+                if tokens[i+1].typ !in [.field_key, .rcbr] {
+                    return error('$err_label invalid content after opening brace')
+                }
+                i++
+                continue 
+            }
+            .rcbr { break }
+            .field_key { 
+                field_name := tok.val.trim_right(':')
+                if tokens[i+1].typ !in [.str, .labr] {
+                    return error('$err_label value of field "$field_name" must be either string or an array of strings')
+                }
+                
+                field_value := tokens[i+1].val
+                match field_name {
+                    'name' { mn.name = field_value }
+                    'version' { mn.version = field_value }
+                    'license' { mn.license = field_value }
+                    'repo_url' { mn.repo_url = field_value }
+					'description' { mn.description = field_value }
+                    'author' { mn.author = field_value }
+                    'dependencies' { 
+                        deps, idx := get_array_content(tokens, i + 1) or {
+                            return error(err)
+                        }
+                        mn.dependencies = deps
+                        i = idx
+                        continue
+                    }
+                    else {
+                        // Ignore the field?
+                        // return error('$err_label invalid field "$field_name"')
+                    }
+                }
+
+                i += 2
+                continue
+            }
+            .comma { 
+                if tokens[i-1].typ !in [.str, .rabr] || tokens[i+1].typ != .field_key {
+                    return error('$err_label invalid comma placement')
+                }
+
+                i++
+                continue
+            }
+            else {
+                return error('$err_label invalid token "$tok.val"')
+            }
+        }
+    }
+
+    return mn
+}

--- a/vlib/v/vmod/parser.v
+++ b/vlib/v/vmod/parser.v
@@ -34,8 +34,7 @@ mut:
 	pos         int
 	text        string
 	inside_text bool
-	started     bool
-	tokens      []Token = []Token{}
+	tokens      []Token
 }
 
 struct Parser {

--- a/vlib/v/vmod/parser.v
+++ b/vlib/v/vmod/parser.v
@@ -13,6 +13,7 @@ enum TokenKind {
     eof 
     str 
     ident
+	unknown
 }
 
 pub struct Manifest {
@@ -154,11 +155,13 @@ fn (mut s Scanner) scan_all() {
             `]` { s.tokenize(.rabr, c.str()) }
             `:` { s.tokenize(.colon, c.str()) }
             `,` { s.tokenize(.comma, c.str()) }
-            else { s.tokenize(.eof, 'eof') }
+            else { s.tokenize(.unknown, c.str()) }
         }
 
         s.pos++
     }
+
+	s.tokenize(.eof, 'eof')
 }
 
 fn get_array_content(tokens []Token, st_idx int) ?([]string, int) {

--- a/vlib/v/vmod/parser.v
+++ b/vlib/v/vmod/parser.v
@@ -1,78 +1,79 @@
 module vmod
+
 import os
 
 enum TokenKind {
-    module_keyword 
-    field_key
-    lcbr 
-    rcbr 
-    labr 
-    rabr 
-    comma 
-    colon 
-    eof 
-    str 
-    ident
+	module_keyword
+	field_key
+	lcbr
+	rcbr
+	labr
+	rabr
+	comma
+	colon
+	eof
+	str
+	ident
 	unknown
 }
 
 pub struct Manifest {
 pub mut:
-    name string
-    version string
-	description string
-    dependencies []string
-    license string
-    repo_url string
-    author string
-    unknown map[string][]string
+	name         string
+	version      string
+	description  string
+	dependencies []string
+	license      string
+	repo_url     string
+	author       string
+	unknown      map[string]array_string
 }
 
 struct Scanner {
 mut:
-    pos int
-    text string
-    inside_text bool
-    started bool
-    tokens []Token = []Token{}
+	pos         int
+	text        string
+	inside_text bool
+	started     bool
+	tokens      []Token = [unhandled expr type v.ast.ArrayInit]
 }
 
 struct Parser {
-mut: 
-    file_path string
-    scanner Scanner
+mut:
+	file_path string
+	scanner   Scanner
 }
 
 struct Token {
-    typ TokenKind
-    val string
+	typ TokenKind
+	val string
 }
 
 pub fn from_file(vmod_path string) ?Manifest {
-    if !os.exists(vmod_path) {
-        return error('v.mod: v.mod file not found.')
-    }
-
-    contents := os.read_file(vmod_path) or {
-        panic('v.mod: cannot parse v.mod')
-    }
-
-    return decode(contents)
+	if !os.exists(vmod_path) {
+		return error('v.mod: v.mod file not found.')
+	}
+	contents := os.read_file(vmod_path) or {
+		panic('v.mod: cannot parse v.mod')
+	}
+	return decode(contents)
 }
 
 pub fn decode(contents string) ?Manifest {
-    mut parser := Parser{
-        scanner: Scanner{
-            pos: 0,
-            text: contents
-        }
-    }
-
-    return parser.parse()
+	mut parser := Parser{
+		scanner: Scanner{
+			pos: 0
+			text: contents
+		}
+	}
+	return parser.parse()
 }
 
 fn (mut s Scanner) tokenize(t_type TokenKind, val string) {
-    s.tokens << Token{t_type, val}
+	s.tokens << Token{
+		: t_type
+		: val
+	}
 }
 
 fn (mut s Scanner) skip_whitespace() {
@@ -82,203 +83,197 @@ fn (mut s Scanner) skip_whitespace() {
 }
 
 fn is_name_alpha(chr byte) bool {
-    return chr.is_letter() || chr == `_`
+	return chr.is_letter() || chr == `_`
 }
 
 fn (mut s Scanner) create_string(q byte) string {
-    mut str := ''
-    for s.text[s.pos] != q {
-        if s.text[s.pos] == `\\` && s.text[s.pos+1] == q {
-			str += s.text[s.pos..s.pos+1]
+	mut str := ''
+	for s.text[s.pos] != q {
+		if s.text[s.pos] == `\\` && s.text[s.pos + 1] == q {
+			str += s.text[s.pos..s.pos + 1]
 			s.pos += 2
 		} else {
 			str += s.text[s.pos].str()
 			s.pos++
 		}
-    }
-    return str
+	}
+	return str
 }
 
 fn (mut s Scanner) create_ident() string {
-    mut text := ''
-
-    for is_name_alpha(s.text[s.pos]) {
-        text += s.text[s.pos].str()
-        s.pos++
-    }
-
-    return text
+	mut text := ''
+	for is_name_alpha(s.text[s.pos]) {
+		text += s.text[s.pos].str()
+		s.pos++
+	}
+	return text
 }
 
 fn (s Scanner) peek_char(c byte) bool {
-    return s.pos-1 < s.text.len && s.text[s.pos-1] == c
+	return s.pos - 1 < s.text.len && s.text[s.pos - 1] == c
 }
 
 fn (mut s Scanner) scan_all() {
-    for s.pos < s.text.len {
-        c := s.text[s.pos]
-
-        if c.is_space() || c == `\\` {
-            s.pos++
-            continue
-        }
-
-        if is_name_alpha(c) {
-            name := s.create_ident()
-
-            if name == 'Module' {
-                s.tokenize(.module_keyword, name)
-                s.pos++
-                continue
-            } else if s.text[s.pos] == `:` {
-                s.tokenize(.field_key, name + ':')
-                s.pos += 2
-                continue
-            } else {
-                s.tokenize(.ident, name)
-                s.pos++
-                continue
-            }
-        }
-
-        if c in [`\'`, `\"`] && !s.peek_char(`\\`) {
-            s.pos++
-            str := s.create_string(c)
-            s.tokenize(.str, str)
-            s.pos++
-            continue
-        }
-
-        match c {
-            `{` { s.tokenize(.lcbr, c.str()) }
-            `}` { s.tokenize(.rcbr, c.str()) }
-            `[` { s.tokenize(.labr, c.str()) }
-            `]` { s.tokenize(.rabr, c.str()) }
-            `:` { s.tokenize(.colon, c.str()) }
-            `,` { s.tokenize(.comma, c.str()) }
-            else { s.tokenize(.unknown, c.str()) }
-        }
-
-        s.pos++
-    }
-
+	for s.pos < s.text.len {
+		c := s.text[s.pos]
+		if c.is_space() || c == `\\` {
+			s.pos++
+			continue
+		}
+		if is_name_alpha(c) {
+			name := s.create_ident()
+			if name == 'Module' {
+				s.tokenize(.module_keyword, name)
+				s.pos++
+				continue
+			} else if s.text[s.pos] == `:` {
+				s.tokenize(.field_key, name + ':')
+				s.pos += 2
+				continue
+			} else {
+				s.tokenize(.ident, name)
+				s.pos++
+				continue
+			}
+		}
+		if c in [`\'`, `\"`] && !s.peek_char(`\\`) {
+			s.pos++
+			str := s.create_string(c)
+			s.tokenize(.str, str)
+			s.pos++
+			continue
+		}
+		match c {
+			`{` { s.tokenize(.lcbr, c.str()) }
+			`}` { s.tokenize(.rcbr, c.str()) }
+			`[` { s.tokenize(.labr, c.str()) }
+			`]` { s.tokenize(.rabr, c.str()) }
+			`:` { s.tokenize(.colon, c.str()) }
+			`,` { s.tokenize(.comma, c.str()) }
+			else { s.tokenize(.unknown, c.str()) }
+		}
+		s.pos++
+	}
 	s.tokenize(.eof, 'eof')
 }
 
-fn get_array_content(tokens []Token, st_idx int) ?([]string, int) {
-    mut vals := []string{}
-    mut idx := st_idx
-
-    if tokens[idx].typ != .labr {
-        return error('vmod: not a valid array')
-    }
-
-    idx++
-
-    for {
-        tok := tokens[idx]
-        match tok.typ {
-            .str {
-                vals << tok.val
-
-                if tokens[idx+1].typ !in [.comma, .rabr] {
-                    return error('vmod: invalid separator "${tokens[idx+1].val}"')
-                }
-
-                idx += if tokens[idx+1].typ == .comma { 2 } else { 1 }
-            }
-            .rabr {
-                idx++
-                break
-            }
-            else { 
-                return error('vmod: invalid token "$tok.val"') 
-            }
-        }
-    }
-
-    return vals, idx
+fn get_array_content(tokens []Token, st_idx int) ([]string, int) {
+	mut vals := []string{}
+	mut idx := st_idx
+	if tokens[idx].typ != .labr {
+		return error('vmod: not a valid array')
+	}
+	idx++
+	for {
+		tok := tokens[idx]
+		match tok.typ {
+			.str {
+				vals << tok.val
+				if tokens[idx + 1].typ !in [.comma, .rabr] {
+					return error('vmod: invalid separator "${tokens[idx+1].val}"')
+				}
+				idx += if tokens[idx + 1].typ == .comma {
+					2
+				} else {
+					1
+				}
+			}
+			.rabr {
+				idx++
+				break
+			}
+			else {
+				return error('vmod: invalid token "$tok.val"')
+			}
+		}
+	}
+	return vals, idx
 }
 
 fn (mut p Parser) parse() ?Manifest {
-    err_label := 'vmod:'
+	err_label := 'vmod:'
 	if p.scanner.text.len == 0 {
 		return error('$err_label no content.')
 	}
-
-    p.scanner.scan_all()
-    tokens := p.scanner.tokens
-    mut mn := Manifest{}
-
-    if tokens[0].typ != .module_keyword {
-        panic('not a valid v.mod')
-    }
-
-    mut i := 1
-    for i < tokens.len {
-        tok := tokens[i]
-        match tok.typ {
-            .lcbr { 
-                if tokens[i+1].typ !in [.field_key, .rcbr] {
-                    return error('$err_label invalid content after opening brace')
-                }
-                i++
-                continue 
-            }
-            .rcbr { break }
-            .field_key { 
-                field_name := tok.val.trim_right(':')
-                if tokens[i+1].typ !in [.str, .labr] {
-                    return error('$err_label value of field "$field_name" must be either string or an array of strings')
-                }
-                
-                field_value := tokens[i+1].val
-                match field_name {
-                    'name' { mn.name = field_value }
-                    'version' { mn.version = field_value }
-                    'license' { mn.license = field_value }
-                    'repo_url' { mn.repo_url = field_value }
-					'description' { mn.description = field_value }
-                    'author' { mn.author = field_value }
-                    'dependencies' { 
-                        deps, idx := get_array_content(tokens, i + 1) or {
-                            return error(err)
-                        }
-                        mn.dependencies = deps
-                        i = idx
-                        continue
-                    }
-                    else {
-                        if tokens[i+1].typ == .labr {
-                            vals, idx := get_array_content(tokens, i + 1) or {
-                                return error(err)
-                            }
-                            
-                            mn.unknown[field_name] = vals
-                            i = idx
-                            continue
-                        }
-
-                        mn.unknown[field_name] = [field_value]
-                    }
-                }
-
-                i += 2
-                continue
-            }
-            .comma { 
-                if tokens[i-1].typ !in [.str, .rabr] || tokens[i+1].typ != .field_key {
-                    return error('$err_label invalid comma placement')
-                }
-
-                i++
-                continue
-            }
-            else {
-                return error('$err_label invalid token "$tok.val"')
-            }
-        }
-    }
-
-    return mn
+	p.scanner.scan_all()
+	tokens := p.scanner.tokens
+	mut mn := Manifest{}
+	if tokens[0].typ != .module_keyword {
+		panic('not a valid v.mod')
+	}
+	mut i := 1
+	for i < tokens.len {
+		tok := tokens[i]
+		match tok.typ {
+			.lcbr {
+				if tokens[i + 1].typ !in [.field_key, .rcbr] {
+					return error('$err_label invalid content after opening brace')
+				}
+				i++
+				continue
+			}
+			.rcbr {
+				break
+			}
+			.field_key {
+				field_name := tok.val.trim_right(':')
+				if tokens[i + 1].typ !in [.str, .labr] {
+					return error('$err_label value of field "$field_name" must be either string or an array of strings')
+				}
+				field_value := tokens[i + 1].val
+				match field_name {
+					'name' {
+						mn.name = field_value
+					}
+					'version' {
+						mn.version = field_value
+					}
+					'license' {
+						mn.license = field_value
+					}
+					'repo_url' {
+						mn.repo_url = field_value
+					}
+					'description' {
+						mn.description = field_value
+					}
+					'author' {
+						mn.author = field_value
+					}
+					'dependencies' {
+						deps, idx := get_array_content(tokens, i + 1) or {
+							return error(err)
+						}
+						mn.dependencies = deps
+						i = idx
+						continue
+					}
+					else {
+						if tokens[i + 1].typ == .labr {
+							vals, idx := get_array_content(tokens, i + 1) or {
+								return error(err)
+							}
+							mn.unknown[field_name] = vals
+							i = idx
+							continue
+						}
+						mn.unknown[field_name] = [field_value]
+					}
+				}
+				i += 2
+				continue
+			}
+			.comma {
+				if tokens[i - 1].typ !in [.str, .rabr] || tokens[i + 1].typ != .field_key {
+					return error('$err_label invalid comma placement')
+				}
+				i++
+				continue
+			}
+			else {
+				return error('$err_label invalid token "$tok.val"')
+			}
+		}
+	}
+	return mn
 }

--- a/vlib/v/vmod/parser.v
+++ b/vlib/v/vmod/parser.v
@@ -26,7 +26,7 @@ pub mut:
 	license      string
 	repo_url     string
 	author       string
-	unknown      map[string]array_string
+	unknown      map[string][]string
 }
 
 struct Scanner {
@@ -35,7 +35,7 @@ mut:
 	text        string
 	inside_text bool
 	started     bool
-	tokens      []Token = [unhandled expr type v.ast.ArrayInit]
+	tokens      []Token = []Token{}
 }
 
 struct Parser {
@@ -70,10 +70,7 @@ pub fn decode(contents string) ?Manifest {
 }
 
 fn (mut s Scanner) tokenize(t_type TokenKind, val string) {
-	s.tokens << Token{
-		: t_type
-		: val
-	}
+	s.tokens << Token{t_type, val}
 }
 
 fn (mut s Scanner) skip_whitespace() {
@@ -157,7 +154,7 @@ fn (mut s Scanner) scan_all() {
 	s.tokenize(.eof, 'eof')
 }
 
-fn get_array_content(tokens []Token, st_idx int) ([]string, int) {
+fn get_array_content(tokens []Token, st_idx int) ?([]string, int) {
 	mut vals := []string{}
 	mut idx := st_idx
 	if tokens[idx].typ != .labr {

--- a/vlib/v/vmod/parser.v
+++ b/vlib/v/vmod/parser.v
@@ -25,6 +25,7 @@ pub mut:
     license string
     repo_url string
     author string
+    unknown map[string][]string
 }
 
 struct Scanner {
@@ -248,8 +249,17 @@ fn (mut p Parser) parse() ?Manifest {
                         continue
                     }
                     else {
-                        // Ignore the field?
-                        // return error('$err_label invalid field "$field_name"')
+                        if tokens[i+1].typ == .labr {
+                            vals, idx := get_array_content(tokens, i + 1) or {
+                                return error(err)
+                            }
+                            
+                            mn.unknown[field_name] = vals
+                            i = idx
+                            continue
+                        }
+
+                        mn.unknown[field_name] = [field_value]
                     }
                 }
 


### PR DESCRIPTION
Part of #4900

This PR includes the ability to parse `v.mod` file in order to get the metadata of a specific project or module.

## Usage
```v
import v.vmod

fn main() {
   // decode from file
   mni := vmod.from_file('./v.mod') or {
       panic(err)
   }

   content := 'Module { name: "hello" }'
   mni2 := vmod.decode(content) or {
       panic(err)
   }

   println(mni)
   println(mni2)
}
```
## Spec
There has been no formal spec formally agreed for the `v.mod` discussed on #299 yet so I decided so I based this parser based on the existing `v.mod` files with some additional ones that are commonly found in other languages.

Here's the initial spec I implemented in a nutshell:
- The contents of the `v.mod` is like declaring a regular V struct: `Module` keyword, followed by an opening curly bracket, then KV fields optionally separated with a comma and a closing curly bracket in the end.
- Strings can be contained in single or in double quotes like in V.
- Fields that are allowed in v.mod are `author`, `dependencies`, `description`, `license`, `name`, `repo_url`, and `version`. Fields that are not included in this are ~~ignored~~ (edit: stored inside an `unknown` field) instead of raising a parser error.
- A field value can only be a string or an array of strings.

## Additional notes
- The return value of `decode` function is `vmod.Manifest` and not `vmod.Module`. Manifest makes sense to me since `v.mod` is just a manifest containing metadata for a specific V project/module.
- Comments are **strictly** not allowed inside `v.mod`. That's why I removed the `# V Project #` heading on some files and in `vcreate.v`