### PR TITLE
checker: fix small JS name regression

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -247,11 +247,11 @@ pub fn (mut c Checker) interface_decl(decl ast.InterfaceDecl) {
 }
 
 pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
-	if !decl.is_c && !c.is_builtin_mod {
+	if !decl.is_c && !decl.is_js && !c.is_builtin_mod {
 		c.check_valid_pascal_case(decl.name, 'struct name', decl.pos)
 	}
 	for i, field in decl.fields {
-		if !decl.is_c {
+		if !decl.is_c && !decl.is_js {
 			c.check_valid_snake_case(field.name, 'field name', field.pos)
 		}
 		for j in 0 .. i {
@@ -1477,7 +1477,7 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 			c.check_expr_opt_call(it.expr, etype, false)
 		}
 		ast.FnDecl {
-			if !it.is_c && !c.is_builtin_mod {
+			if !it.is_c && !it.is_js && !c.is_builtin_mod {
 				c.check_valid_snake_case(it.name, 'function name', it.pos)
 			}
 			if it.is_method {


### PR DESCRIPTION
This PR fixes a small issue in #4916 which made it check the names of JS functions. 


Even though it's a fairly small change, it brings up a few, related suggestions / questions:
  - Should we add tests for the JS backend, even though it isn't completely finished, to catch this sort of thing early?
  - It may be useful to add a field `is_external` *(or something similar, not sure about the name)* to parser / checker, that equals `is_c || is_js`. This will prevent issues like this one in the future, and, if a new backend is ever implemented, we can add it there instead of changing the rest of the code. 

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
