### PR TITLE
table, vfmt: fix typ_to_string + some fixes to vfmt

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1054,7 +1054,7 @@ fn (mut f Fmt) struct_init(it ast.StructInit) {
 	if it.fields.len == 0 {
 		// `Foo{}` on one line if there are no fields
 		f.write('$name{}')
-	} else if it.fields.len == 0 {
+	} else if it.is_short {
 		// `Foo{1,2,3}` (short syntax )
 		// if name != '' {
 		f.write('$name{')

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -448,7 +448,8 @@ fn (mut f Fmt) struct_decl(node ast.StructDecl) {
 		f.write(strings.repeat(` `, max - field.name.len))
 		f.write(f.type_to_str(field.typ))
 		if field.has_default_expr {
-			f.write(' = ${field.default_expr.str()}')
+			f.write(' = ')
+			f.expr(field.default_expr)
 		}
 		// f.write('// $field.pos.line_nr')
 		if field.comment.text != '' && field.comment.pos.line_nr == field.pos.line_nr {

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -624,8 +624,12 @@ pub:
 
 pub fn (table &Table) type_to_str(t Type) string {
 	sym := table.get_type_symbol(t)
+	mut res := sym.name
 	if sym.kind == .multi_return {
-		mut res := '('
+		res = '('
+		if t.flag_is(.optional) {
+			res = '?' + res
+		}
 		mr_info := sym.info as MultiReturn
 		for i, typ in mr_info.types {
 			res += table.type_to_str(typ)

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -640,10 +640,9 @@ pub fn (table &Table) type_to_str(t Type) string {
 		res += ')'
 		return res
 	}
-	mut res := sym.name
-	if sym.kind == .array {
+	if sym.kind == .array || 'array_' in res {
 		res = res.replace('array_', '[]')
-	} else if sym.kind == .map {
+	} else if sym.kind == .map || 'map_string_' in res {
 		res = res.replace('map_string_', 'map[string]')
 	}
 	// mod.submod.submod2.Type => submod2.Type


### PR DESCRIPTION
NOTE: Fixes for table and vfmt are under one PR because of the incorrect formatting of type vfmt makes that relies on the `table.type_to_str` method.

### table
- Fix printing optional multi-returns (e.g `?(string, int)`)
- Fix printing map types with arrays/maps (e.g `map[string][]Type, map[string]map[string]string`)

### vfmt
- Fix short struct init syntax (e.g `Foo{'hello', 123}`)
- Use `f.expr` for the `default_expr` of a struct field. 