### PR TITLE
gen: change `typ()` to `type_name()`

### DIFF
--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -185,7 +185,7 @@ pub fn (g JsGen) hashes() string {
 
 
 // V type to JS type
-pub fn (mut g JsGen) typ(t table.Type) string {
+pub fn (mut g JsGen) type_name(t table.Type) string {
 	sym := g.table.get_type_symbol(t)
 	mut styp := sym.name.replace('.', '__')
 	if styp.starts_with('JS__') {
@@ -422,7 +422,7 @@ fn (mut g JsGen) expr(node ast.Expr) {
 			g.write(')')
 		}
 		ast.EnumVal {
-			styp := g.typ(it.typ)
+			styp := g.type_name(it.typ)
 			g.write('${styp}.${it.val}')
 		}
 		ast.FloatLiteral {
@@ -586,7 +586,7 @@ fn (mut g JsGen) gen_assign_stmt(it ast.AssignStmt) {
 		stmt.write('const [')
 		for i, ident in it.left {
 			ident_var_info := ident.var_info()
-			styp := g.typ(ident_var_info.typ)
+			styp := g.type_name(ident_var_info.typ)
 			jsdoc.write(styp)
 
 			stmt.write(js_name(ident.name))
@@ -608,7 +608,7 @@ fn (mut g JsGen) gen_assign_stmt(it ast.AssignStmt) {
 		for i, ident in it.left {
 			val := it.right[i]
 			ident_var_info := ident.var_info()
-			mut styp := g.typ(ident_var_info.typ)
+			mut styp := g.type_name(ident_var_info.typ)
 
 			match val {
 				ast.EnumVal {
@@ -667,7 +667,7 @@ fn (mut g JsGen) gen_const_decl(it ast.ConstDecl) {
 		g.expr(field.expr)
 		val := g.out.after(pos)
 		g.out.go_back(val.len)
-		typ := g.typ(field.typ)
+		typ := g.type_name(field.typ)
 		g.constants.write('\t')
 		g.constants.writeln(g.doc.gen_typ(typ, field.name))
 		g.constants.write('\t')
@@ -762,7 +762,7 @@ fn (mut g JsGen) gen_method_decl(it ast.FnDecl) {
 			name = util.replace_op(name)
 		}
 
-		// type_name := g.typ(it.return_type)
+		// type_name := g.type_name(it.return_type)
 
 		// generate jsdoc for the function
 		g.writeln(g.doc.gen_fn(it))
@@ -842,7 +842,7 @@ fn (mut g JsGen) gen_for_in_stmt(it ast.ForInStmt) {
 	} else if it.kind == .array || it.cond_type.flag_is(.variadic) {
 		// `for num in nums {`
 		i := if it.key_var == '' { g.new_tmp_var() } else { it.key_var }
-		// styp := g.typ(it.val_type)
+		// styp := g.type_name(it.val_type)
 		g.inside_loop = true
 		g.write('for (let $i = 0; $i < ')
 		g.expr(it.cond)
@@ -855,8 +855,8 @@ fn (mut g JsGen) gen_for_in_stmt(it ast.ForInStmt) {
 		g.writeln('}')
 	} else if it.kind == .map {
 		// `for key, val in map[string]int {`
-		// key_styp := g.typ(it.key_type)
-		// val_styp := g.typ(it.val_type)
+		// key_styp := g.type_name(it.key_type)
+		// val_styp := g.type_name(it.val_type)
 		key := if it.key_var == '' { g.new_tmp_var() } else { it.key_var }
 		g.write('for (let [$key, $it.val_var] of ')
 		g.expr(it.cond)

--- a/vlib/v/gen/js/jsdoc.v
+++ b/vlib/v/gen/js/jsdoc.v
@@ -56,7 +56,7 @@ fn (mut d JsDoc) gen_ctor(fields []ast.StructField) string {
 	d.writeln('/**')
 	d.write('* @param {{')
 	for i, field in fields {
-		d.write('$field.name: ${d.gen.typ(field.typ)}')
+		d.write('$field.name: ${d.gen.type_name(field.typ)}')
 		if i < fields.len - 1 {
 			d.write(', ')
 		}
@@ -69,13 +69,13 @@ fn (mut d JsDoc) gen_ctor(fields []ast.StructField) string {
 
 fn (mut d JsDoc) gen_fn(it ast.FnDecl) string {
 	d.reset()
-	type_name := d.gen.typ(it.return_type)
+	type_name := d.gen.type_name(it.return_type)
 	d.writeln('/**')
 	for i, arg in it.args {
 		if it.is_method && i == 0 {
 			continue
 		}
-		arg_type_name := d.gen.typ(arg.typ)
+		arg_type_name := d.gen.type_name(arg.typ)
 		is_varg := i == it.args.len - 1 && it.is_variadic
 		name := js_name(arg.name)
 		if is_varg {

--- a/vlib/v/gen/json.v
+++ b/vlib/v/gen/json.v
@@ -21,7 +21,7 @@ fn (mut g Gen) gen_json_for_type(typ table.Type) {
 	mut dec := strings.new_builder(100)
 	mut enc := strings.new_builder(100)
 	sym := g.table.get_type_symbol(typ)
-	styp := g.typ(typ)
+	styp := g.type_name(typ)
 	if sym.name in ['int', 'string', 'bool'] {
 		return
 	}
@@ -80,7 +80,7 @@ cJSON* ${enc_fn_name}($styp val) {
 					break
 				}
 			}
-			field_type := g.typ(field.typ)
+			field_type := g.type_name(field.typ)
 			enc_name := js_enc_name(field_type)
 			if 'raw' in field.attrs {
 				dec.writeln(' res . $field.name = tos2(cJSON_PrintUnformatted(' + 'js_get(root, "$name")));')
@@ -123,7 +123,7 @@ fn is_js_prim(typ string) bool {
 }
 
 fn (mut g Gen) decode_array(value_type table.Type) string {
-	styp := g.typ(value_type)
+	styp := g.type_name(value_type)
 	fn_name := js_dec_name(styp)
 	// If we have `[]Profile`, have to register a Profile en(de)coder first
 	g.gen_json_for_type(value_type)
@@ -145,7 +145,7 @@ $s
 }
 
 fn (mut g Gen) encode_array(value_type table.Type) string {
-	styp := g.typ(value_type)
+	styp := g.type_name(value_type)
 	fn_name := js_enc_name(styp)
 	return '
 o = cJSON_CreateArray();


### PR DESCRIPTION
This PR change `typ()` to `type_name()`.

- The meaning of `typ()` is not clear.
- Change `cgen.typ()` to `cgen.type_name()`.
- Change `jsgen.typ()` to `jsgen.type_name()`.