### PR TITLE
test: fix alias type errors and type_test.v

### DIFF
--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -9,7 +9,6 @@ const (
 		'vlib/v/tests/enum_bitfield_test.v',
 		'vlib/v/tests/num_lit_call_method_test.v',
 		'vlib/v/tests/pointers_test.v',
-		'vlib/v/tests/type_test.v',
 		'vlib/v/tests/pointers_str_test.v',
 		'vlib/arrays/arrays_test.v',
 		'vlib/net/http/http_httpbin_test.v',

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -308,8 +308,19 @@ pub fn (mut c Checker) struct_init(mut struct_init ast.StructInit) table.Type {
 			c.error('unknown struct: $type_sym.name', struct_init.pos)
 		}
 		// string & array are also structs but .kind of string/array
-		.struct_, .string, .array {
-			info := type_sym.info as table.Struct
+		.struct_, .string, .array, .alias {
+			mut info := table.Struct{}
+			if type_sym.kind == .alias {
+				info_t := type_sym.info as table.Alias
+				sym := c.table.get_type_symbol(info_t.parent_typ)
+				if sym.kind != .struct_ {
+					c.error('alias type name: $sym.name is not struct type', struct_init.pos)
+				}
+				info = sym.info as table.Struct
+			} else {
+				info = type_sym.info as table.Struct
+			}
+
 			if struct_init.is_short && struct_init.fields.len > info.fields.len {
 				c.error('too many fields', struct_init.pos)
 			}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -318,7 +318,7 @@ fn (g &Gen) base_type(t table.Type) string {
 	nr_muls := t.nr_muls()
 	if nr_muls > 0 {
 		styp += strings.repeat(`*`, nr_muls)
-	}    
+	}
 	return styp
 }
 

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1412,7 +1412,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		parent_idx: pid
 		mod: p.mod
 		info: table.Alias{
-			foo: ''
+			parent_typ: parent_type
 			is_c: parent_name.len > 2 && parent_name[0] == `C` && parent_name[1] == `.`
 		}
 		is_public: is_pub

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -574,8 +574,8 @@ pub:
 
 pub struct Alias {
 pub:
-	foo string
-	is_c bool
+	parent_typ  Type
+	is_c        bool
 }
 
 // NB: FExpr here is a actually an ast.Expr .

--- a/vlib/v/tests/sumtype_calls_test.v
+++ b/vlib/v/tests/sumtype_calls_test.v
@@ -1,37 +1,3 @@
-struct Human {
-	name string
-}
-
-fn (h Human) str1() string {
-	return 'Human: $h.name'
-}
-
-fn (h Human) str2() string {
-	return 'Human: $h.name'
-}
-
-type Person Human
-
-fn test_type_print() {
-	p := Person{
-		name: 'Bilbo'
-	}
-	//println(p)
-	assert p.str1() == 'Human: Bilbo'
-}
-
-fn (h Person) str2() string {
-	return 'Person: $h.name'
-}
-
-fn test_person_str() {
-	p := Person{
-		name: 'Bilbo'
-	}
-	//println(p)
-	assert p.str2() == 'Person: Bilbo'
-}
-
 struct Foo {
 }
 

--- a/vlib/v/tests/type_alias_str_method_override_test.v
+++ b/vlib/v/tests/type_alias_str_method_override_test.v
@@ -1,0 +1,29 @@
+struct Human {
+	name string
+}
+
+fn (h Human) str() string {
+	return 'Human: $h.name'
+}
+
+type Person Human
+
+fn (h Person) str() string {
+	return 'Person: $h.name'
+}
+
+fn test_type_print() {
+	p := Human{
+		name: 'Bilbo'
+	}
+	println(p)
+	assert p.str() == 'Human: Bilbo'
+}
+
+fn test_person_str() {
+	p := Person{
+		name: 'Bilbo'
+	}
+	println(p)
+	assert p.str() == 'Person: Bilbo'
+}

--- a/vlib/v/tests/type_test.v
+++ b/vlib/v/tests/type_test.v
@@ -2,7 +2,11 @@ struct Human {
 	name string
 }
 
-fn (h Human) str() string {
+fn (h Human) str1() string {
+	return 'Human: $h.name'
+}
+
+fn (h Human) str2() string {
 	return 'Human: $h.name'
 }
 
@@ -12,11 +16,11 @@ fn test_type_print() {
 	p := Person{
 		name: 'Bilbo'
 	}
-	println(p)
-	assert p.str() == 'Human: Bilbo'
+	//println(p)
+	assert p.str1() == 'Human: Bilbo'
 }
 
-fn (h Person) str() string {
+fn (h Person) str2() string {
 	return 'Person: $h.name'
 }
 
@@ -24,8 +28,8 @@ fn test_person_str() {
 	p := Person{
 		name: 'Bilbo'
 	}
-	println(p)
-	assert p.str() == 'Person: Bilbo'
+	//println(p)
+	assert p.str2() == 'Person: Bilbo'
 }
 
 struct Foo {


### PR DESCRIPTION
This PR fix alias type errors and type_test.v.

- Fix alias type errors.
- Fix type_test.v.
- Remove type_test.v from skip list.

```v
OK   [167/174]  1307.688 ms vlib\v\tests\type_test.v
------------------------------------------------------------------------------------------
               163185.588 ms <=== total time spent testing all fixed tests
                 ok, fail, skip, total =   170,     0,     4,   174
```