### PR TITLE
tests: fix num_lit_call_method_test.v

### DIFF
--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -7,7 +7,6 @@ import v.pref
 const (
 	skip_test_files     = [
 		'vlib/v/tests/enum_bitfield_test.v',
-		'vlib/v/tests/num_lit_call_method_test.v',
 		'vlib/v/tests/pointers_test.v',
 		'vlib/v/tests/pointers_str_test.v',
 		'vlib/arrays/arrays_test.v',

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -220,7 +220,12 @@ fn (mut p Parser) prefix_expr() ast.PrefixExpr {
 	// p.warn('unsafe')
 	// }
 	p.next()
-	right := p.expr(token.Precedence.prefix)
+	mut right := ast.Expr{}
+	if op == .minus {
+		right = p.expr(token.Precedence.call)
+	} else {
+		right = p.expr(token.Precedence.prefix)
+	}
 	p.is_amp = false
 	return ast.PrefixExpr{
 		op: op

--- a/vlib/v/tests/num_lit_call_method_test.v
+++ b/vlib/v/tests/num_lit_call_method_test.v
@@ -1,7 +1,7 @@
 fn test_int_lit_call_method() {
 	x1 := 1234.str()
 	assert x1 == '1234'
-	x2 := -0xffff.str()
+	x2 := (-0xffff).str()
 	assert x2 == '-65535'
 	x3 := 0b1001001.str()
 	assert x3 == '73'
@@ -12,7 +12,7 @@ fn test_int_lit_call_method() {
 }
 
 fn test_float_lit_call_method() {
-	x1 := -123.66.str()
+	x1 := (-123.66).str()
 	assert x1 == '-1.2366e+02'
 	x2 := 12.5e-2.str()
 	assert x2 == '1.25e-01'

--- a/vlib/v/tests/num_lit_call_method_test.v
+++ b/vlib/v/tests/num_lit_call_method_test.v
@@ -1,7 +1,7 @@
 fn test_int_lit_call_method() {
 	x1 := 1234.str()
 	assert x1 == '1234'
-	x2 := (-0xffff).str()
+	x2 := -0xffff.str()
 	assert x2 == '-65535'
 	x3 := 0b1001001.str()
 	assert x3 == '73'
@@ -12,7 +12,7 @@ fn test_int_lit_call_method() {
 }
 
 fn test_float_lit_call_method() {
-	x1 := (-123.66).str()
+	x1 := -123.66.str()
 	assert x1 == '-1.2366e+02'
 	x2 := 12.5e-2.str()
 	assert x2 == '1.25e-01'


### PR DESCRIPTION
This PR fix num_lit_call_method_test.v.

- Fix num_lit_call_method_test.v.
- Remove `num_lit_call_method_test.v` from skip list.

```v
OK   [135/175]  1272.267 ms vlib\v\tests\num_lit_call_method_test.v
------------------------------------------------------------------------------------------
               158622.001 ms <=== total time spent testing all fixed tests
                 ok, fail, skip, total =   172,     0,     3,   175
```

Solution
Because `prefix` has a lower precedence than `call`, so `x2 := -0xffff.str()` => `x2 := -(0xffff.str())`, that's not what we need. 
We can add parenthesis like `x2 := (-0xffff).str()` to resolve it. 
If this is not in line with the habit, we must change scanner.v to scan negative, I don't know if this is the right way.