### PR TITLE
gen: fix pointers_str_test.v

### DIFF
--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -8,7 +8,6 @@ const (
 	skip_test_files     = [
 		'vlib/v/tests/enum_bitfield_test.v',
 		'vlib/v/tests/pointers_test.v',
-		'vlib/v/tests/pointers_str_test.v',
 		'vlib/net/http/http_httpbin_test.v',
 	]
 	skip_on_musl        = [

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -364,13 +364,17 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	// g.write('/*${g.typ(node.receiver_type)}*/')
 	// g.write('/*expr_type=${g.typ(node.left_type)} rec type=${g.typ(node.receiver_type)}*/')
 	// }
-	g.write('${name}(')
+	if !node.receiver_type.is_ptr() && node.left_type.is_ptr() && node.name == 'str' {
+		g.write('ptr_str(')
+	} else {
+		g.write('${name}(')
+	}
 	if node.receiver_type.is_ptr() && !node.left_type.is_ptr() {
 		// The receiver is a reference, but the caller provided a value
 		// Add `&` automatically.
 		// TODO same logic in call_args()
 		g.write('&')
-	} else if !node.receiver_type.is_ptr() && node.left_type.is_ptr() {
+	} else if !node.receiver_type.is_ptr() && node.left_type.is_ptr() && node.name != 'str' {
 		g.write('/*rec*/*')
 	}
 	g.expr(node.left)


### PR DESCRIPTION
This PR fix pointer_str_test.v.

- Fix pointer_str_test.v.
- Remove `pointer_str_test.v` from skip list.

```v
OK   [142/175]  1237.701 ms vlib\v\tests\pointers_str_test.v
------------------------------------------------------------------------------------------
               156744.959 ms <=== total time spent testing all fixed tests
                 ok, fail, skip, total =   173,     0,     2,   175
```

pointer.str() example
```v
fn main() {
	a := 22.22
	p := &a
	println(p.str())
}

D:\test\v\tt1>v run .
63fdf8
```