### PR TITLE
[READY] scanner: fix err pos related to num literal (2)

### DIFF
--- a/vlib/v/checker/tests/bin_lit_without_digit_err.out
+++ b/vlib/v/checker/tests/bin_lit_without_digit_err.out
@@ -1,5 +1,5 @@
 vlib/v/checker/tests/bin_lit_without_digit_err.v:2:14: error: number part of this binary is not provided
     1 | fn main() {
-    2 |     println(0b)
+    2 |     println(0b**)
       |              ^
     3 | }

--- a/vlib/v/checker/tests/bin_lit_without_digit_err.vv
+++ b/vlib/v/checker/tests/bin_lit_without_digit_err.vv
@@ -1,3 +1,3 @@
 fn main() {
-    println(0b)
+    println(0b**)
 }

--- a/vlib/v/checker/tests/dec_lit_wrong_digit_err.out
+++ b/vlib/v/checker/tests/dec_lit_wrong_digit_err.out
@@ -1,5 +1,5 @@
 vlib/v/checker/tests/dec_lit_wrong_digit_err.v:2:18: error: this number has unsuitable digit `q`
     1 | fn main() {
-    2 |     println(12345q)
+    2 |     println(12345qrst+10)
       |                  ^
     3 | }

--- a/vlib/v/checker/tests/dec_lit_wrong_digit_err.vv
+++ b/vlib/v/checker/tests/dec_lit_wrong_digit_err.vv
@@ -1,3 +1,3 @@
 fn main() {
-    println(12345q)
+    println(12345qrst+10)
 }

--- a/vlib/v/checker/tests/hex_lit_wrong_digit_err.out
+++ b/vlib/v/checker/tests/hex_lit_wrong_digit_err.out
@@ -1,5 +1,5 @@
 vlib/v/checker/tests/hex_lit_wrong_digit_err.v:2:18: error: this hexadecimal number has unsuitable digit `g`
     1 | fn main() {
-    2 |     println(0x111g)
+    2 |     println(0x111ghi)
       |                  ^
     3 | }

--- a/vlib/v/checker/tests/hex_lit_wrong_digit_err.vv
+++ b/vlib/v/checker/tests/hex_lit_wrong_digit_err.vv
@@ -1,3 +1,3 @@
 fn main() {
-    println(0x111g)
+    println(0x111ghi)
 }

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -157,6 +157,7 @@ fn filter_num_sep(txt byteptr, start int, end int) string {
 
 fn (mut s Scanner) ident_bin_number() string {
 	mut has_wrong_digit := false
+	mut first_wrong_digit_pos := 0
 	mut first_wrong_digit := `\0`
 	start_pos := s.pos
 	s.pos += 2 // skip '0b'
@@ -168,6 +169,7 @@ fn (mut s Scanner) ident_bin_number() string {
 			}
 			else if !has_wrong_digit {
 				has_wrong_digit = true
+				first_wrong_digit_pos = s.pos
 				first_wrong_digit = c
 			}
 		}
@@ -178,7 +180,7 @@ fn (mut s Scanner) ident_bin_number() string {
 		s.error('number part of this binary is not provided')
 	}
 	else if has_wrong_digit {
-		s.pos-- // adjust error position
+		s.pos = first_wrong_digit_pos // adjust error position
 		s.error('this binary number has unsuitable digit `${first_wrong_digit.str()}`')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
@@ -188,6 +190,7 @@ fn (mut s Scanner) ident_bin_number() string {
 
 fn (mut s Scanner) ident_hex_number() string {
 	mut has_wrong_digit := false
+	mut first_wrong_digit_pos := 0
 	mut first_wrong_digit := `\0`
 	start_pos := s.pos
 	s.pos += 2 // skip '0x'
@@ -199,6 +202,7 @@ fn (mut s Scanner) ident_hex_number() string {
 			}
 			else if !has_wrong_digit {
 				has_wrong_digit = true
+				first_wrong_digit_pos = s.pos
 				first_wrong_digit = c
 			}
 		}
@@ -209,7 +213,7 @@ fn (mut s Scanner) ident_hex_number() string {
 		s.error('number part of this hexadecimal is not provided')
 	}
 	else if has_wrong_digit {
-		s.pos-- // adjust error position
+		s.pos = first_wrong_digit_pos // adjust error position
 		s.error('this hexadecimal number has unsuitable digit `${first_wrong_digit.str()}`')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
@@ -219,6 +223,7 @@ fn (mut s Scanner) ident_hex_number() string {
 
 fn (mut s Scanner) ident_oct_number() string {
 	mut has_wrong_digit := false
+	mut first_wrong_digit_pos := 0
 	mut first_wrong_digit := `\0`
 	start_pos := s.pos
 	s.pos += 2 // skip '0o'
@@ -230,6 +235,7 @@ fn (mut s Scanner) ident_oct_number() string {
 			}
 			else if !has_wrong_digit {
 				has_wrong_digit = true
+				first_wrong_digit_pos = s.pos
 				first_wrong_digit = c
 			}
 		}
@@ -240,7 +246,7 @@ fn (mut s Scanner) ident_oct_number() string {
 		s.error('number part of this octal is not provided')
 	}
 	else if has_wrong_digit {
-		s.pos-- // adjust error position
+		s.pos = first_wrong_digit_pos // adjust error position
 		s.error('this octal number has unsuitable digit `${first_wrong_digit.str()}`')
 	}
 	number := filter_num_sep(s.text.str, start_pos, s.pos)
@@ -250,6 +256,7 @@ fn (mut s Scanner) ident_oct_number() string {
 
 fn (mut s Scanner) ident_dec_number() string {
 	mut has_wrong_digit := false
+	mut first_wrong_digit_pos := 0
 	mut first_wrong_digit := `\0`
 	start_pos := s.pos
 	// scan integer part
@@ -261,6 +268,7 @@ fn (mut s Scanner) ident_dec_number() string {
 			}
 			else if !has_wrong_digit {
 				has_wrong_digit = true
+				first_wrong_digit_pos = s.pos
 				first_wrong_digit = c
 			}
 		}
@@ -287,6 +295,7 @@ fn (mut s Scanner) ident_dec_number() string {
 						}
 						else if !has_wrong_digit {
 							has_wrong_digit = true
+							first_wrong_digit_pos = s.pos
 							first_wrong_digit = c
 						}
 					}
@@ -333,6 +342,7 @@ fn (mut s Scanner) ident_dec_number() string {
 				}
 				else if !has_wrong_digit {
 					has_wrong_digit = true
+					first_wrong_digit_pos = s.pos
 					first_wrong_digit = c
 				}
 			}
@@ -341,7 +351,7 @@ fn (mut s Scanner) ident_dec_number() string {
 	}
 	if has_wrong_digit {
 	// error check: wrong digit
-		s.pos-- // adjust error position
+		s.pos = first_wrong_digit_pos // adjust error position
 		s.error('this number has unsuitable digit `${first_wrong_digit.str()}`')
 	}
 	else if s.text[s.pos - 1] in [`e`, `E`] {


### PR DESCRIPTION
Small fix so that more complicated cases could be handled.

BTW:
Error system of scanner still needs more work so these err handling are preliminary.
Now, unlike error system of checker, scanner
1. stops at first error
2. needs explicitly adjusting s.pos to error position 
3. lacks error parts coloring
4. can only position on one char

![image](https://user-images.githubusercontent.com/47302112/82574338-8290bc80-9bb9-11ea-9890-71cd7f50a628.png)