### PR TITLE
make.bat: optimize vc download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ a.out
 .noprefix.vrepl_temp
 
 # ignore v build files
+/vc
 /v.c
 /v.*.c
 /v.c.out

--- a/make.bat
+++ b/make.bat
@@ -5,11 +5,14 @@ echo Building V
 pushd %~dp0
 
 if exist "vc" (
-	rd /s /q vc
+	echo Updating vc...
+	cd vc
+	git pull
+	cd ..
+) else (
+	echo Cloning vc...
+	git clone --depth 1 --quiet https://github.com/vlang/vc
 )
-
-echo Downloading v.c...
-git clone --depth 1 --quiet https://github.com/vlang/vc
 
 REM option to force msvc or gcc
 if "%~1"=="-gcc" goto :gcc_strap
@@ -39,11 +42,9 @@ REM and it will be restored when v is a stable version.
 v.exe self
 if %ERRORLEVEL% NEQ 0 (
 	echo v.exe failed to compile itself - Create an issue at 'https://github.com/vlang'
-	rd /s /q vc
 	goto :error
 )
 
-rd /s /q vc
 del v_old.exe
 goto :success
 
@@ -81,12 +82,10 @@ REM and it will be restored when v is a stable version.
 v.exe self
 if %ERRORLEVEL% NEQ 0 (
 	echo V failed to build itself with error %ERRORLEVEL%
-	rd /s /q vc
 	del %ObjFile%
 	goto :compile_error
 )
 
-rd /s /q vc
 del v_old.exe
 del %ObjFile%
 


### PR DESCRIPTION
This PR optimize vc download of make.bat.

Keep downloaded `vc`, use `git pull` to avoid duplicate downloads, and we can use local `vc` when no need to download with flag.

```v
if exist "vc" (
	echo Updating vc...
	cd vc
	git pull
	cd ..
) else (
	echo Cloning vc...
	git clone --depth 1 --quiet https://github.com/vlang/vc
)
```
