### PR TITLE
 all: propagate optional

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -720,11 +720,17 @@ pub mut:
 	expr_type table.Type
 }
 
+pub enum OrKind {
+	absent
+	block
+	propagate
+}
+
 // `or { ... }`
 pub struct OrExpr {
 pub:
-	stmts   []Stmt
-	is_used bool // if the or{} block is written down or left out
+	stmts []Stmt
+	kind  OrKind
 }
 
 pub struct Assoc {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1024,7 +1024,8 @@ pub fn (mut c Checker) check_expr_opt_call(expr ast.Expr, ret_type table.Type, i
 			c.error('unexpected `or` block, the function `$call_expr.name` does not return an optional',
 				call_expr.pos)
 		} else if call_expr.or_block.kind == .propagate {
-			c.error('unexpected `?`, the function `$call_expr.name`, does not return an optional', call_expr.pos)
+			c.error('unexpected `?`, the function `$call_expr.name`, does not return an optional',
+				call_expr.pos)
 		}
 	}
 }
@@ -1037,7 +1038,8 @@ pub fn (mut c Checker) check_or_block(mut call_expr ast.CallExpr, ret_type table
 	}
 	if call_expr.or_block.kind == .propagate {
 		if !c.cur_fn.return_type.flag_is(.optional) {
-			c.error('to propagate the optional call, `${c.cur_fn.name}` must itself return an optional', call_expr.pos)
+			c.error('to propagate the optional call, `${c.cur_fn.name}` must itself return an optional',
+				call_expr.pos)
 		}
 		return
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1037,7 +1037,7 @@ pub fn (mut c Checker) check_or_block(mut call_expr ast.CallExpr, ret_type table
 		return
 	}
 	if call_expr.or_block.kind == .propagate {
-		if !c.cur_fn.return_type.flag_is(.optional) {
+		if !c.cur_fn.return_type.flag_is(.optional) && c.cur_fn.name != 'main' {
 			c.error('to propagate the optional call, `${c.cur_fn.name}` must itself return an optional',
 				call_expr.pos)
 		}

--- a/vlib/v/checker/tests/unexpected_or.out
+++ b/vlib/v/checker/tests/unexpected_or.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/unexpected_or.v:6:7: error: unexpected `or` block, the function `ret_zero` does not return an optional
+    4 |
+    5 | fn main() {
+    6 |     _ := ret_zero() or { 1 }
+      |          ~~~~~~~~~~
+    7 | }

--- a/vlib/v/checker/tests/unexpected_or.vv
+++ b/vlib/v/checker/tests/unexpected_or.vv
@@ -1,0 +1,7 @@
+fn ret_zero() int {
+	return 0
+}
+
+fn main() {
+	_ := ret_zero() or { 1 }
+}

--- a/vlib/v/checker/tests/unexpected_or_propagate.out
+++ b/vlib/v/checker/tests/unexpected_or_propagate.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/unexpected_or_propagate.v:6:7: error: unexpected `?`, the function `ret_zero`, does not return an optional
+    4 |
+    5 | fn opt_fn() ?int {
+    6 |     a := ret_zero()?
+      |          ~~~~~~~~~~
+    7 |     return a
+    8 | }

--- a/vlib/v/checker/tests/unexpected_or_propagate.vv
+++ b/vlib/v/checker/tests/unexpected_or_propagate.vv
@@ -1,0 +1,12 @@
+fn ret_zero() int {
+	return 0
+}
+
+fn opt_fn() ?int {
+	a := ret_zero()?
+	return a
+}
+
+fn main() {
+	opt_fn() or {}
+}

--- a/vlib/v/checker/tests/wrong_propagate_ret_type.out
+++ b/vlib/v/checker/tests/wrong_propagate_ret_type.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/wrong_propagate_ret_type.v:6:7: error: to propagate the optional call, `opt_call` must itself return an optional
+    4 |
+    5 | fn opt_call() int {
+    6 |     a := ret_none()?
+      |          ~~~~~~~~~~
+    7 |     return a
+    8 | }

--- a/vlib/v/checker/tests/wrong_propagate_ret_type.vv
+++ b/vlib/v/checker/tests/wrong_propagate_ret_type.vv
@@ -1,0 +1,8 @@
+fn ret_none() ?int {
+	return none
+}
+
+fn opt_call() int {
+	a := ret_none()?
+	return a
+}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -721,10 +721,16 @@ pub fn (mut f Fmt) call_args(args []ast.CallArg) {
 }
 
 pub fn (mut f Fmt) or_expr(or_block ast.OrExpr) {
-	if or_block.is_used {
-		f.writeln(' or {')
-		f.stmts(or_block.stmts)
-		f.write('}')
+	match or_block.kind {
+		.absent {}
+		.block {
+			f.writeln(' or {')
+			f.stmts(or_block.stmts)
+			f.write('}')
+		}
+		.propagate {
+			f.write('?')
+		}
 	}
 }
 

--- a/vlib/v/fmt/tests/optional_propagate_keep.vv
+++ b/vlib/v/fmt/tests/optional_propagate_keep.vv
@@ -1,0 +1,3 @@
+fn opt_propagate() ?int {
+	eventual_wrong_int()?
+}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2974,7 +2974,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type table.
 		}
 	} else if or_block.kind == .propagate {
 		if g.file.mod.name == 'main' && g.cur_fn.name == 'main' {
-			g.writeln('v_panic(${cvar_name}.v_error);')
+			g.writeln('\tv_panic(${cvar_name}.v_error);')
 		} else {
 			g.writeln('\treturn $cvar_name;')
 		}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2942,8 +2942,8 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type table.
 		g.writeln('\tstring err = ${cvar_name}.v_error;')
 		g.writeln('\tint errcode = ${cvar_name}.ecode;')
 		stmts := or_block.stmts
-		if stmts.len > 0 && stmts[or_block.stmts.len - 1] is ast.ExprStmt && (stmts[stmts.len - 1] as ast.ExprStmt).typ !=
-			table.void_type {
+		if stmts.len > 0 && stmts[or_block.stmts.len - 1] is ast.ExprStmt && (stmts[stmts.len -
+			1] as ast.ExprStmt).typ != table.void_type {
 			g.indent++
 			for i, stmt in stmts {
 				if i == stmts.len - 1 {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -95,6 +95,7 @@ mut:
 	is_builtin_mod       bool
 	hotcode_fn_names     []string
 	fn_main              &ast.FnDecl // the FnDecl of the main function. Needed in order to generate the main function code *last*
+	cur_fn               &ast.FnDecl
 	cur_generic_type     table.Type // `int`, `string`, etc in `foo<T>()`
 }
 
@@ -124,6 +125,7 @@ pub fn cgen(files []ast.File, table &table.Table, pref &pref.Preferences) string
 		pref: pref
 		fn_decl: 0
 		fn_main: 0
+		cur_fn: 0
 		autofree: true
 		indent: -1
 		module_built: pref.path.after('vlib/')
@@ -2971,7 +2973,11 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type table.
 			g.stmts(stmts)
 		}
 	} else if or_block.kind == .propagate {
-		g.writeln('\treturn $cvar_name;')
+		if g.file.mod.name == 'main' && g.cur_fn.name == 'main' {
+			g.writeln('v_panic(${cvar_name}.v_error);')
+		} else {
+			g.writeln('\treturn $cvar_name;')
+		}
 	}
 	g.write('}')
 }

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -12,6 +12,11 @@ fn (mut g Gen) gen_fn_decl(it ast.FnDecl) {
 		// || it.no_body {
 		return
 	}
+	former_cur_fn := g.cur_fn
+	g.cur_fn = &it
+	defer {
+		g.cur_fn = former_cur_fn
+	}
 	is_main := it.name == 'main'
 	if it.is_generic && g.cur_generic_type == 0 { // need the cur_generic_type check to avoid inf. recursion
 		// loop thru each generic type and generate a function

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -284,7 +284,7 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 	if node.should_be_skipped {
 		return
 	}
-	gen_or := node.or_block.stmts.len > 0
+	gen_or := node.or_block.kind != .absent
 	cur_line := if gen_or && g.is_assign_rhs {
 		line := g.go_before_stmt(0)
 		g.out.write(tabs[g.indent])
@@ -303,7 +303,7 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 		g.fn_call(node)
 	}
 	if gen_or {
-		g.or_block(tmp_opt, node.or_block.stmts, node.return_type)
+		g.or_block(tmp_opt, node.or_block, node.return_type)
 		g.write('\n${cur_line}${tmp_opt}')
 	}
 }

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -194,7 +194,7 @@ pub fn parse_files(paths []string, table &table.Table, pref &pref.Preferences, g
 	}
 	if false {
 		// TODO: remove this; it just prevents warnings about unused time and runtime
-		time.sleep_ms(1) 
+		time.sleep_ms(1)
 		println(runtime.nr_cpus())
 	}
 	// ///////////////
@@ -983,7 +983,7 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 		}
 		p.check(.rpar)
 		mut or_stmts := []ast.Stmt{}
-		mut is_or_block_used := false
+		mut or_kind := ast.OrKind.absent
 		if p.tok.kind == .key_orelse {
 			p.next()
 			p.open_scope()
@@ -999,9 +999,14 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 				pos: p.tok.position()
 				is_used: true
 			})
-			is_or_block_used = true
+			or_kind = .block
 			or_stmts = p.parse_block_no_scope()
 			p.close_scope()
+		}
+		if p.tok.kind == .question {
+			// `foo()?`
+			p.next()
+			or_kind = .propagate
 		}
 		end_pos := p.tok.position()
 		pos := token.Position{
@@ -1017,7 +1022,7 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 			is_method: true
 			or_block: ast.OrExpr{
 				stmts: or_stmts
-				is_used: is_or_block_used
+				kind: or_kind
 			}
 		}
 		if is_filter {

--- a/vlib/v/tests/option_test.v
+++ b/vlib/v/tests/option_test.v
@@ -93,6 +93,33 @@ fn foo_str() ?string {
 	return 'something'
 }
 
+fn propagate_optional(b bool) ?int {
+	a := err_call(b)?
+	return a
+}
+
+fn propagate_different_type(b bool) ?bool {
+	err_call(b)?
+	return true
+}
+
+fn test_propagation() {
+	a := propagate_optional(true) or {
+		0
+	}
+	assert a == 42
+	if _ := propagate_optional(false) {
+		assert false
+	}
+	b := propagate_different_type(true) or {
+		false
+	}
+	assert b == true
+	if _ := propagate_different_type(false) {
+		assert false
+	}
+}
+
 fn test_q() {
 	// assert foo_ok()? == true
 }


### PR DESCRIPTION
Allow using `?` to propagate optionals.
With this PR, `main` is handled the same as other functions, which means that you can't propagate an optional because it doesn't return an optional.