### PR TITLE
parser: Fix parsing with comments

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -156,6 +156,7 @@ pub struct StructDecl {
 pub:
 	pos         token.Position
 	name        string
+	comments	[]Comment
 	fields      []StructField
 	is_pub      bool
 	mut_pos     int // mut:

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -170,6 +170,7 @@ pub:
 pub struct InterfaceDecl {
 pub:
 	name        string
+	comments	[]Comment
 	field_names []string
 	methods     []FnDecl
 	pos         token.Position
@@ -573,6 +574,7 @@ pub:
 	pos      token.Position
 	expr     Expr
 	has_expr bool
+	comment  Comment
 }
 
 pub struct EnumDecl {
@@ -581,6 +583,8 @@ pub:
 	is_pub bool
 	fields []EnumField
 	pos    token.Position
+mut:
+	comments []Comment
 }
 
 pub struct AliasTypeDecl {

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -148,6 +148,7 @@ pub:
 	is_pub bool
 	pos    token.Position
 pub mut:
+	comments []Comment
 	fields []ConstField
 }
 

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1226,16 +1226,21 @@ fn (mut p Parser) const_decl() ast.ConstDecl {
 	}
 	p.next() // (
 	mut fields := []ast.ConstField{}
+	mut comments := []ast.Comment{}
 	for p.tok.kind != .rpar {
+		if p.tok.kind == .comment {
+			comments << p.comment()
+			continue
+		}
+
+		pos := p.tok.position()
+		name := p.prepend_mod(p.check_name())
 		mut comment := ast.Comment{}
+ 
+		p.check(.assign)
 		if p.tok.kind == .comment {
 			comment = p.comment()
 		}
-		pos := p.tok.position()
-		name := p.prepend_mod(p.check_name())
-		// name := p.check_name()
-		// println('!!const: $name')
-		p.check(.assign)
 		expr := p.expr(0)
 		field := ast.ConstField{
 			name: name
@@ -1250,6 +1255,7 @@ fn (mut p Parser) const_decl() ast.ConstDecl {
 	return ast.ConstDecl{
 		pos: start_pos.extend(end_pos)
 		fields: fields
+		comments: comments
 		is_pub: is_pub
 	}
 }

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1342,13 +1342,19 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 	name := p.prepend_mod(enum_name)
 	p.check(.lcbr)
 	mut vals := []string{}
+	mut comments := []ast.Comment{}
 	// mut default_exprs := []ast.Expr{}
 	mut fields := []ast.EnumField{}
 	for p.tok.kind != .eof && p.tok.kind != .rcbr {
+		if p.tok.kind == .comment {
+			comments << p.comment()
+			continue
+		}
 		pos := p.tok.position()
 		val := p.check_name()
 		vals << val
 		mut expr := ast.Expr{}
+		mut comment := ast.Comment{}
 		mut has_expr := false
 		// p.warn('enum val $val')
 		if p.tok.kind == .assign {
@@ -1356,11 +1362,15 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 			expr = p.expr(0)
 			has_expr = true
 		}
+		if p.tok.kind == .comment {
+			comment = p.comment()
+		}
 		fields << ast.EnumField{
 			name: val
 			pos: pos
 			expr: expr
 			has_expr: has_expr
+			comment: comment
 		}
 	}
 	p.check(.rcbr)
@@ -1377,6 +1387,7 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 		is_pub: is_pub
 		fields: fields
 		pos: start_pos.extend(end_pos)
+		comments: comments
 	}
 }
 

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -44,6 +44,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 	// println('struct decl $name')
 	mut ast_fields := []ast.StructField{}
 	mut fields := []table.Field{}
+	mut comments := []ast.Comment{}
 	mut mut_pos := -1
 	mut pub_pos := -1
 	mut pub_mut_pos := -1
@@ -54,9 +55,9 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 	if !no_body {
 		p.check(.lcbr)
 		for p.tok.kind != .rcbr {
-			mut comment := ast.Comment{}
 			if p.tok.kind == .comment {
-				comment = p.comment()
+				comments << p.comment()
+				continue
 			}
 			if p.tok.kind == .key_pub {
 				p.next()
@@ -79,6 +80,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 					is_field_global = false
 				}
 				p.check(.colon)
+				continue
 			} else if p.tok.kind == .key_mut {
 				if mut_pos != -1 {
 					p.error('redefinition of `mut` section')
@@ -89,6 +91,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 				is_field_pub = false
 				is_field_mut = true
 				is_field_global = false
+				continue
 			} else if p.tok.kind == .key_global {
 				if global_pos != -1 {
 					p.error('redefinition of `global` section')
@@ -99,18 +102,12 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 				is_field_pub = true
 				is_field_mut = true
 				is_field_global = true
+				continue
 			}
 			field_start_pos := p.tok.position()
 			field_name := p.check_name()
 			field_pos := field_start_pos.extend(p.tok.position())
-			// p.warn('field $field_name')
 			typ := p.parse_type()
-			/*
-			if name == '_net_module_s' {
-			s := p.table.get_type_symbol(typ)
-			println('XXXX' + s.str())
-		}
-			*/
 			mut default_expr := ast.Expr{}
 			mut has_default_expr := false
 			if p.tok.kind == .assign {
@@ -133,6 +130,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 					attrs << attr.name
 				}
 			}
+			mut comment := ast.Comment{}
 			if p.tok.kind == .comment {
 				comment = p.comment()
 			}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -268,6 +268,7 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 }
 
 fn (mut p Parser) interface_decl() ast.InterfaceDecl {
+	mut comments := []ast.Comment{}
 	start_pos := p.tok.position()
 	is_pub := p.tok.kind == .key_pub
 	if is_pub {
@@ -291,6 +292,10 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 	// Parse methods
 	mut methods := []ast.FnDecl{}
 	for p.tok.kind != .rcbr && p.tok.kind != .eof {
+		if p.tok.kind == .comment {
+			comments << p.comment()
+			continue
+		}
 		method_start_pos := p.tok.position()
 		line_nr := p.tok.line_nr
 		name := p.check_name()


### PR DESCRIPTION
Part of #4900. In progress.

This eliminates all the issues the parser is currently experiencing when parsing V files with comments. Will add tests soon.

So far (Will update):
- [x] Structs
- [x] Enums
- [x] Interfaces
- [x] Consts