### PR TITLE
checker: fix multiple assign immutable error (fix #4995)

### DIFF
--- a/vlib/net/ftp/ftp.v
+++ b/vlib/net/ftp/ftp.v
@@ -20,17 +20,17 @@ module ftp
 import net
 
 const (
-	Connected           = 220
-	SpecifyPassword     = 331
-	LoggedIn            = 230
-	LoginFirst          = 503
-	Anonymous           = 530
-	OpenDataConnection  = 150
-	CloseDataConnection = 226
-	CommandOk           = 200
-	denied              = 550
-	PassiveMode         = 227
-	complete            = 226
+	connected             = 220
+	specify_password      = 331
+	logged_in             = 230
+	login_first           = 503
+	anonymous             = 530
+	open_data_connection  = 150
+	close_data_connection = 226
+	command_ok            = 200
+	denied                = 550
+	passive_mode          = 227
+	complete              = 226
 )
 
 struct DTP {
@@ -110,7 +110,7 @@ pub fn (mut ftp FTP) connect(ip string) bool {
 	}
 	ftp.sock = sock
 	code, _ := ftp.read()
-	if code == Connected {
+	if code == connected {
 		return true
 	}
 	return false
@@ -123,11 +123,11 @@ pub fn (ftp FTP) login(user, passwd string) bool {
 		}
 		return false
 	}
-	mut code, data := ftp.read()
-	if code == LoggedIn {
+	mut code, mut data := ftp.read()
+	if code == logged_in {
 		return true
 	}
-	if code != SpecifyPassword {
+	if code != specify_password {
 		return false
 	}
 	ftp.write('PASS $passwd') or {
@@ -139,7 +139,7 @@ pub fn (ftp FTP) login(user, passwd string) bool {
 	code, data = ftp.read()
 	// TODO Replace `data` with `_`
 	_ := data
-	if code == LoggedIn {
+	if code == logged_in {
 		return true
 	}
 	return false
@@ -209,7 +209,7 @@ fn (ftp FTP) pasv() ?DTP {
 	$if debug {
 		println('pass: $data')
 	}
-	if code != PassiveMode {
+	if code != passive_mode {
 		return error('pasive mode not allowed')
 	}
 	dtp := new_dtp(data) or {
@@ -228,12 +228,12 @@ pub fn (ftp FTP) dir() ?[]string {
 	if code == denied {
 		return error('LIST denied')
 	}
-	if code != OpenDataConnection {
+	if code != open_data_connection {
 		return error('data channel empty')
 	}
 	list_dir := dtp.read()
 	result, _ := ftp.read()
-	if result != CloseDataConnection {
+	if result != close_data_connection {
 		println('LIST not ok')
 	}
 	dtp.close()
@@ -258,7 +258,7 @@ pub fn (ftp FTP) get(file string) ?[]byte {
 	if code == denied {
 		return error('Permission denied')
 	}
-	if code != OpenDataConnection {
+	if code != open_data_connection {
 		return error('Data connection not ready')
 	}
 	blob := dtp.read()

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1261,6 +1261,7 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 		mut ident_var_info := ident.var_info()
 		// c.assigned_var_name = ident.name
 		if assign_stmt.op == .assign {
+			c.fail_if_immutable(ident)
 			var_type := c.expr(ident)
 			assign_stmt.left_types << var_type
 			if !c.table.check(val_type, var_type) {

--- a/vlib/v/checker/tests/assign_multi_immutable_err.out
+++ b/vlib/v/checker/tests/assign_multi_immutable_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/assign_multi_immutable_err.v:4:2: error: `a` is immutable, declare it with `mut` to make it mutable
+    2 |     a := 10
+    3 |     b := 20
+    4 |     a, b = 1, 2
+      |     ^
+    5 |
+    6 |     println('$a, $b')

--- a/vlib/v/checker/tests/assign_multi_immutable_err.vv
+++ b/vlib/v/checker/tests/assign_multi_immutable_err.vv
@@ -1,0 +1,7 @@
+fn main() {
+	a := 10
+	b := 20
+	a, b = 1, 2
+
+	println('$a, $b')
+}


### PR DESCRIPTION
This PR fix multiple assign immutable error (fix #4995).

- Fix multiple assign immutable error.
- Add test `assign_multi_assign_immutable_err.vv/out`.
- Fix `ftp.v` error like this.
- Fix `ftp.v` const names warnings.

```v
D:\test\v\tt1>v run .
.\tt1.v:4:2: error: `a` is immutable, declare it with `mut` to make it mutable
    2 |     a := 10
    3 |     b := 20
    4 |     a, b = 1, 2
      |     ^
    5 |
    6 |     println('$a, $b')
```