### PR TITLE
repl: fix one-liner for-loop printing

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -195,7 +195,7 @@ fn run_repl(workdir string, vrepl_prefix string) {
 				'=', '++', '--', '<<',
 				'//', '/*',
 				'fn ', 'pub ', 'mut ', 'enum ', 'const ', 'struct ', 'interface ', 'import ',
-				'#include ', ':='
+				'#include ', ':=', 'for '
 			]
 			mut is_statement := false
 			for pattern in possible_statement_patterns {


### PR DESCRIPTION
Fixes issue when writing a one-liner for-loop inside the REPL. Here is the issue message before this fix: 
```
>>> miao := [1, 2]
>>> for wang in miao {println(wang)}
error: expr(): bad token `for` 
    1 | miao := [1, 2]
    2 | println(for wang in miao {
      |         ~~~
    3 | println(wang)
    4 | })
>>> for wang in miao {
... println(wang)
... }
1
2
>>> exit
```