### PR TITLE
vpm: Use v.mod data if no args provided in `v install`

### DIFF
--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -5,6 +5,7 @@ import os.cmdline
 import net.http
 import json
 import vhelp
+import v.vmod
 
 const (
 	default_vpm_server_urls = ['https://vpm.best', 'https://vpm.vlang.io']
@@ -49,7 +50,7 @@ fn main() {
 		exit(5)
 	}
 	vpm_command := params[0]
-	module_names := params[1..]
+	mut module_names := params[1..]
 	ensure_vmodules_dir_exist()
 	// println('module names: ') println(module_names)
 	match vpm_command {
@@ -60,6 +61,15 @@ fn main() {
 			vpm_search(module_names)
 		}
 		'install' {
+			if module_names.len == 0 && os.exists('./v.mod') {
+				println('Detected v.mod file inside the project directory.')
+				manifest := vmod.from_file('./v.mod') or {
+					panic(err)
+				}
+
+				module_names = manifest.dependencies
+			}
+
 			vpm_install(module_names)
 		}
 		'update' {

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -62,7 +62,7 @@ fn main() {
 		}
 		'install' {
 			if module_names.len == 0 && os.exists('./v.mod') {
-				println('Detected v.mod file inside the project directory.')
+				println('Detected v.mod file inside the project directory. Using it...')
 				manifest := vmod.from_file('./v.mod') or {
 					panic(err)
 				}

--- a/cmd/v/help/install.txt
+++ b/cmd/v/help/install.txt
@@ -1,7 +1,13 @@
 Usage:
   v install module [module] [module] [...]
   ^^^^^^^^^^^^^ will install the modules you specified
+
+You can also do `v install` directly if you have dependencies stored 
+inside the `v.mod` file. This will automatically installs the modules 
+specified inside of it. 
+
 Options:
   -help        - Show usage info.
   -verbose     - Print more details about the performed operation.
-  -server-url  - When doing network operations, use this vpm server. Can be given multiple times.
+  -server-url  - When doing network operations, use this vpm server. 
+                 Can be given multiple times.


### PR DESCRIPTION
This allows the user to use the dependencies stated inside `v.mod` to VPM by just typing `v install`. Having no arguments supplied and at the same time no v.mod inside the directory will display the same error in the past.

![image](https://user-images.githubusercontent.com/7358345/82753443-397a7b80-9df8-11ea-9864-65f6afcd649f.png)