### PR TITLE
checker: fix declare assign unresolved variables error (fix #4981)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -31,7 +31,6 @@ pub mut:
 	pref             &pref.Preferences // Preferences shared from V struct
 	in_for_count     int // if checker is currently in an for loop
 	// checked_ident  string // to avoid infinit checker loops
-	var_decl_name    string
 	returns          bool
 	scope_returns    bool
 	mod              string // current module name
@@ -1258,9 +1257,6 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 		if is_decl && ident.name != '_' {
 			c.check_valid_snake_case(ident.name, 'variable name', ident.pos)
 		}
-		if assign_stmt.op == .decl_assign {
-			c.var_decl_name = ident.name
-		}
 		mut ident_var_info := ident.var_info()
 		// c.assigned_var_name = ident.name
 		if assign_stmt.op == .assign {
@@ -1282,7 +1278,6 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 			c.check_expr_opt_call(assign_stmt.right[i], assign_stmt.right_types[i], true)
 		}
 	}
-	c.var_decl_name = ''
 	c.expected_type = table.void_type
 	// c.assigned_var_name = ''
 }
@@ -1823,11 +1818,6 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 }
 
 pub fn (mut c Checker) ident(mut ident ast.Ident) table.Type {
-	if ident.name == c.var_decl_name { // c.checked_ident {
-		// Do not allow `x := x`
-		c.error('unresolved: `$ident.name`', ident.pos)
-		return table.void_type
-	}
 	// TODO: move this
 	if c.const_deps.len > 0 {
 		mut name := ident.name

--- a/vlib/v/checker/tests/assign_expr_unresolved_variables_err_a.out
+++ b/vlib/v/checker/tests/assign_expr_unresolved_variables_err_a.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/assign_expr_unresolved_variables_err_a.v:2:7: error: unresolved variables `a`
+    1 | fn main() {
+    2 |     a := a
+      |          ^
+    3 |     println(a)
+    4 | }

--- a/vlib/v/checker/tests/assign_expr_unresolved_variables_err_a.vv
+++ b/vlib/v/checker/tests/assign_expr_unresolved_variables_err_a.vv
@@ -1,0 +1,4 @@
+fn main() {
+	a := a
+	println(a)
+}

--- a/vlib/v/checker/tests/assign_expr_unresolved_variables_err_b.out
+++ b/vlib/v/checker/tests/assign_expr_unresolved_variables_err_b.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/assign_expr_unresolved_variables_err_b.v:2:10: error: unresolved variables `a`
+    1 | fn main() {
+    2 |     a, b := a, b
+      |             ^
+    3 |     println('$a, $b')
+    4 | }

--- a/vlib/v/checker/tests/assign_expr_unresolved_variables_err_b.vv
+++ b/vlib/v/checker/tests/assign_expr_unresolved_variables_err_b.vv
@@ -1,0 +1,4 @@
+fn main() {
+	a, b := a, b
+	println('$a, $b')
+}

--- a/vlib/v/checker/tests/assign_expr_unresolved_variables_err_c.out
+++ b/vlib/v/checker/tests/assign_expr_unresolved_variables_err_c.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/assign_expr_unresolved_variables_err_c.v:2:10: error: unresolved variables `a`
+    1 | fn main() {
+    2 |     a, b := a + 1, b * 3
+      |             ^
+    3 |     println('$a, $b')
+    4 | }

--- a/vlib/v/checker/tests/assign_expr_unresolved_variables_err_c.vv
+++ b/vlib/v/checker/tests/assign_expr_unresolved_variables_err_c.vv
@@ -1,0 +1,4 @@
+fn main() {
+	a, b := a + 1, b * 3
+	println('$a, $b')
+}


### PR DESCRIPTION
This PR fix declare assign unresolved variables error (fix #4981).
- Fix declare assign unresolved variables error.
- Add tests.

```v
D:\test\v\tt1>v run .
.\tt1.v:2:13: error: unresolved variables `a` 
    1 | fn main() {
    2 |     a, b := 1, a + 1
      |                ^
    3 |     println('$a, $b')
    4 | }


D:\test\v\tt1>v run .
.\tt1.v:2:10: error: unresolved variables `b`
    1 | fn main() {
    2 |     a, b := b, a
      |             ^
    3 |     println('$a, $b')
    4 | }
```