### PR TITLE
repl: fix for-loop/if statement printing bug

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -220,7 +220,7 @@ fn run_repl(workdir string, vrepl_prefix string) {
 				temp_source_code = '${temp_line}\n' + r.current_source_code(false)
 			} else {
 				for i, l in r.lines {
-					if l.starts_with('for ') && l.contains('println') {
+					if (l.starts_with('for ') || l.starts_with('if ')) && l.contains('println') {
 						r.lines.delete(i)
 						break
 					}

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -219,6 +219,13 @@ fn run_repl(workdir string, vrepl_prefix string) {
 			if temp_line.starts_with('import ') || temp_line.starts_with('#include ') {
 				temp_source_code = '${temp_line}\n' + r.current_source_code(false)
 			} else {
+				for i, l in r.lines {
+					if l.starts_with('for ') && l.contains('println') {
+						r.lines.delete(i)
+						break
+					}
+				}
+
 				temp_source_code = r.current_source_code(true) + '\n${temp_line}\n'
 			}
 			os.write_file(temp_file, temp_source_code)


### PR DESCRIPTION
Fixes #3136. REPL checks for existing lines if there is an invoked `println` function inside the for-loops and if statements.
```
For usage information, quit V REPL using `exit` and use `v help`
V 0.1.27 1b36d7a
Use Ctrl-C or `exit` to exit
>>> for n in 0..2 { println(n) }
0
1
>>> for p in 0..5 { println(p) }
0
1
2
3
4
>>> name := 'bob'
>>> if name == 'bob' { println('im bob') } 
im bob
>>> if name == 'rob' { println('im bob') } 
>>> 
```

