### PR TITLE
checker: CallExpr with handled optional returns plain type

### DIFF
--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -822,7 +822,7 @@ pub fn (u URL) str() string {
 // interpreted as a key set to an empty value.
 pub fn parse_query(query string) ?Values {
 	mut m := new_values()
-	_ = parse_query_values(mut m, query) or {
+	parse_query_values(mut m, query) or {
 		return error(err)
 	}
 	return m
@@ -832,7 +832,7 @@ pub fn parse_query(query string) ?Values {
 // but any errors will be silent
 fn parse_query_silent(query string) Values {
 	mut m := new_values()
-	_ = parse_query_values(mut m, query)
+	parse_query_values(mut m, query)
 	return m
 }
 

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1019,7 +1019,7 @@ fn (mut c Checker) type_implements(typ, inter_typ table.Type, pos token.Position
 	}
 }
 
-// return `true` is the expression is a call expr with handled optional
+// return the actual type of the expression, once the optional is handled
 pub fn (mut c Checker) check_expr_opt_call(expr ast.Expr, ret_type table.Type) table.Type {
 	if expr is ast.CallExpr {
 		call_expr := expr as ast.CallExpr

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -306,7 +306,7 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 	}
 	tmp_opt := if gen_or { g.new_tmp_var() } else { '' }
 	if gen_or {
-		styp := g.typ(node.return_type)
+		styp := g.typ(node.return_type.set_flag(.optional))
 		g.write('$styp $tmp_opt = ')
 	}
 	if node.is_method {


### PR DESCRIPTION
Changes the behavior of call expressions to return type `int` instead of `?int` if the optional is handled by an `or` expression.

This is purely a refactor, and doesn't add any feature nor fixes a bug. The modification is required by some work I'm doing on multiple statements if expressions.
I preferred to submit this change before in case there was problems with it.