### PR TITLE
Fix crash in 'v run' without arguments

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -271,7 +271,7 @@ pub fn parse_args(args []string) (&Preferences, string) {
 		res.path = command
 	} else if command == 'run' {
 		res.is_run = true
-		if command_pos > args.len {
+		if command_pos + 2 > args.len {
 			eprintln('v run: no v files listed')
 			exit(1)
 		}


### PR DESCRIPTION
```
$ v run
V panic: array.get: index out of range (i == 1, a.len == 1)
0   v                                   0x000000010c815e6f array_get + 95
1   v                                   0x000000010c835e1f v__pref__parse_args + 7311
2   v                                   0x000000010c8c7164 main_v + 468
3   v                                   0x000000010c8915fe main + 78
4   v                                   0x000000010c812374 start + 52
5   ???                                 0x0000000000000002 0x0 + 2
```