### PR TITLE
scanner: add support for '@MOD'

### DIFF
--- a/vlib/v/scanner/scanner_test.v
+++ b/vlib/v/scanner/scanner_test.v
@@ -40,6 +40,10 @@ fn test_scan() {
 	assert 1.23e+10 == 1.23e10
 	assert 1.23e+10 == 1.23e0010
 	assert (-1.23e+10) == (1.23e0010 * -1.0)
+
+	// test @MOD
+	assert @MOD == 'scanner'
+
 	// test @FN
 	assert @FN == 'test_scan'
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This will add support for `@MOD` so we are able to print the name of the module we're in.
(Just like `@FN` is the current function name)