### PR TITLE
parser: reimplement [flag] enum support, add p.scanner.codegen

### DIFF
--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -6,7 +6,6 @@ import v.pref
 
 const (
 	skip_test_files     = [
-		'vlib/v/tests/enum_bitfield_test.v',
 		'vlib/net/http/http_httpbin_test.v',
 	]
 	skip_on_musl        = [

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -577,6 +577,7 @@ pub struct EnumDecl {
 pub:
 	name   string
 	is_pub bool
+	is_flag bool // true when the enum has [flag] tag
 	fields []EnumField
 	pos    token.Position
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1401,7 +1401,7 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) table.Type {
 				// scope := c.file.scope.innermost(array_init.pos.pos)
 				// eprintln('scope: ${scope.str()}')
 				// scope.find(it.name) or {
-				// c.error('undefined: `$it.name`', array_init.pos)
+				// c.error('undefined ident: `$it.name`', array_init.pos)
 				// }
 				mut full_const_name := if it.mod == 'main' { it.name } else { it.mod + '.' +
 						it.name }
@@ -1951,7 +1951,7 @@ pub fn (mut c Checker) ident(mut ident ast.Ident) table.Type {
 		return table.int_type
 	}
 	if ident.name != '_' {
-		c.error('undefined: `$ident.name`', ident.pos)
+		c.error('undefined ident: `$ident.name`', ident.pos)
 	}
 	if c.table.known_type(ident.name) {
 		// e.g. `User`  in `json.decode(User, '...')`

--- a/vlib/v/checker/tests/assign_expr_undefined_err_a.out
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_a.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/assign_expr_undefined_err_a.v:2:7: error: undefined: `a`
+vlib/v/checker/tests/assign_expr_undefined_err_a.v:2:7: error: undefined variable: `a`
     1 | fn main() {
     2 |     a := a
       |          ^

--- a/vlib/v/checker/tests/assign_expr_undefined_err_b.out
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_b.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/assign_expr_undefined_err_b.v:2:10: error: undefined: `a`
+vlib/v/checker/tests/assign_expr_undefined_err_b.v:2:10: error: undefined variable: `a`
     1 | fn main() {
     2 |     a, b := a, b
       |             ^

--- a/vlib/v/checker/tests/assign_expr_undefined_err_c.out
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_c.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/assign_expr_undefined_err_c.v:2:10: error: undefined: `a`
+vlib/v/checker/tests/assign_expr_undefined_err_c.v:2:10: error: undefined variable: `a`
     1 | fn main() {
     2 |     a, b := a + 1, b * 3
       |             ^

--- a/vlib/v/checker/tests/assign_expr_undefined_err_d.out
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_d.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/assign_expr_undefined_err_d.v:2:9: error: undefined: `s`
+vlib/v/checker/tests/assign_expr_undefined_err_d.v:2:9: error: undefined variable: `s`
     1 | fn main() {
     2 |     s := '$s'
       |            ^

--- a/vlib/v/checker/tests/match_undefined_cond.out
+++ b/vlib/v/checker/tests/match_undefined_cond.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/match_undefined_cond.v:4:15: error: undefined: `Asd`
+vlib/v/checker/tests/match_undefined_cond.v:4:15: error: undefined ident: `Asd`
     2 |
     3 | fn main() {
     4 |     res := match Asd {

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -14,7 +14,7 @@ fn (mut p Parser) check_undefined_variables(idents []ast.Ident, expr ast.Expr) {
 		ast.Ident {
 			for ident in idents {
 				if ident.name == it.name {
-					p.error_with_pos('undefined: `$it.name`', it.pos)
+					p.error_with_pos('undefined variable: `$it.name`', it.pos)
 				}
 			}
 		}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1121,3 +1121,15 @@ pub fn (s &Scanner) error(msg string) {
 pub fn verror(s string) {
 	util.verror('scanner error', s)
 }
+
+pub fn (mut s Scanner) codegen(newtext string) {
+	// codegen makes sense only during normal compilation
+	// feeding code generated V code to vfmt or vdoc will
+	// cause them to output/document ephemeral stuff.
+	if s.comments_mode == .skip_comments {
+		s.text += newtext
+		$if debug_codegen ? {
+			eprintln('scanner.codegen:\n $newtext')
+		}
+	}
+}

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -611,6 +611,7 @@ pub mut:
 pub struct Enum {
 pub:
 	vals []string
+	is_flag bool
 }
 
 pub struct Alias {

--- a/vlib/v/tests/repl/error.repl
+++ b/vlib/v/tests/repl/error.repl
@@ -1,6 +1,6 @@
 println(a)
 ===output===
-.vrepl.v:2:9: error: undefined: `a` 
+.vrepl.v:2:9: error: undefined ident: `a` 
     1 | 
     2 | println(a)
       |         ^


### PR DESCRIPTION
This PR fixes vlib/v/tests/enum_bitfield_test.v .
It does so, by autogenerating the needed V methods, 
at the end of the current file (it appends to the scanner's text).