### PR TITLE
scanner: add support for `@STRUCT` compile time substitution

### DIFF
--- a/vlib/v/scanner/scanner_test.v
+++ b/vlib/v/scanner/scanner_test.v
@@ -5,6 +5,26 @@ module scanner
 
 import v.token
 
+
+struct TestStruct {
+	test	string
+}
+
+fn (mut t TestStruct) test_struct() {
+	assert @STRUCT == 'TestStruct'
+}
+
+fn (mut t TestStruct) test_struct_w_return() string {
+	assert @STRUCT == 'TestStruct'
+	return t.test
+}
+
+fn (mut t TestStruct) test_struct_w_high_order(cb fn(int)string) string {
+	assert @STRUCT == 'TestStruct'
+	return 'test'+cb(2)
+}
+
+
 fn test_scan() {
 	text := 'println(2 + 3)'
 	mut scanner := new_scanner(text, .skip_comments)
@@ -41,9 +61,24 @@ fn test_scan() {
 	assert 1.23e+10 == 1.23e0010
 	assert (-1.23e+10) == (1.23e0010 * -1.0)
 
-	// test @MOD
+	// Test @FN
+	assert @FN == 'test_scan'
+
+	// Test @MOD
 	assert @MOD == 'scanner'
 
-	// test @FN
-	assert @FN == 'test_scan'
+	// Test @STRUCT
+	assert @STRUCT == ''
+
+	ts := TestStruct { test: "test" }
+	ts.test_struct()
+	r1 := ts.test_struct_w_return()
+	r2 := ts.test_struct_w_high_order(fn(i int)string{
+		assert @STRUCT == ''
+		return i.str()
+	})
+	assert r1 == 'test'
+	assert r2 == 'test2'
+
+
 }


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Add support + tests for compile time substitution of `@STRUCT` to let us get the name of the current struct.
It's left blank in `main`, module level functions and anonymous/high order functions.

I personally find it useful in large projects when debugging with print statements - to show me where the call is coming from.