### PR TITLE
cgen: fix mutliple_assign swap error (fix #4961)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -538,7 +538,7 @@ pub mut:
 	left_types  []table.Type
 	right_types []table.Type
 	is_static   bool // for translated code only
-	is_cross_var bool
+	has_cross_var bool
 }
 
 pub struct AsCast {

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -538,6 +538,7 @@ pub mut:
 	left_types  []table.Type
 	right_types []table.Type
 	is_static   bool // for translated code only
+	is_cross_var bool
 }
 
 pub struct AsCast {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -929,7 +929,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 			return
 		}
 	}
-	if assign_stmt.is_cross_var {
+	if assign_stmt.has_cross_var {
 		for ident in assign_stmt.left {
 			type_str := g.typ(ident.var_info().typ)
 			g.writeln('$type_str _var_$ident.pos.pos = $ident.name;')
@@ -1035,7 +1035,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 				if is_decl {
 					g.expr(val)
 				} else {
-					if assign_stmt.is_cross_var {
+					if assign_stmt.has_cross_var {
 						g.gen_cross_tmp_variable(assign_stmt.left, val)
 					} else {
 						g.expr_with_cast(val, assign_stmt.left_types[i], ident_var_info.typ)

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -75,7 +75,7 @@ fn (mut p Parser) partial_assign_stmt(known_lhs []ast.Ident) ast.Stmt {
 	pos := p.tok.position()
 	exprs := p.parse_assign_rhs()
 	is_decl := op == .decl_assign
-	mut is_cross_var := false
+	mut has_cross_var := false
 	if is_decl {
 		// a, b := a + 1, b
 		for expr in exprs {
@@ -85,7 +85,7 @@ fn (mut p Parser) partial_assign_stmt(known_lhs []ast.Ident) ast.Stmt {
 		// a, b = b, a
 		for expr in exprs {
 			if p.check_cross_variables(idents, expr) {
-				is_cross_var = true
+				has_cross_var = true
 			}
 		}
 	}
@@ -120,7 +120,7 @@ fn (mut p Parser) partial_assign_stmt(known_lhs []ast.Ident) ast.Stmt {
 		op: op
 		pos: pos
 		is_static: false // individual idents may be static
-		is_cross_var: is_cross_var
+		has_cross_var: has_cross_var
 	}
 }
 

--- a/vlib/v/tests/multiple_assign_test.v
+++ b/vlib/v/tests/multiple_assign_test.v
@@ -4,3 +4,33 @@ fn test_multiple_assign() {
 	assert b == 2
 	assert c == 3
 }
+
+fn test_multiple_assign_swap_simple() {
+	mut a := 11
+	mut b := 22
+	a, b = b, a
+	assert a == 22
+	assert b == 11
+}
+
+fn test_multiple_assign_swap_complex() {
+	mut a := 11
+	mut b := 22
+	mut c := 33
+	mut d := 44
+	a, b, c, d = b, a, d, c
+	assert a == 22
+	assert b == 11
+	assert c == 44
+	assert d == 33
+}
+
+fn test_multiple_assign_infix_expr() {
+	mut a := 11
+	mut b := 22
+	mut c := 33
+	a, b, c = b + 1, a * 2, c - a
+	assert a == 23
+	assert b == 22
+	assert c == 22
+}


### PR DESCRIPTION
This PR fix mutliple_assign swap error (fix #4961).

- Fix mutliple_assign swap error (fix #4961).
- Add tests.

```v
fn test_multiple_assign_swap_simple() {
	mut a := 11
	mut b := 22
	a, b = b, a
	assert a == 22
	assert b == 11
}

fn test_multiple_assign_swap_complex() {
	mut a := 11
	mut b := 22
	mut c := 33
	mut d := 44
	a, b, c, d = b, a, d, c
	assert a == 22
	assert b == 11
	assert c == 44
	assert d == 33
}

fn test_multiple_assign_infix_expr() {
	mut a := 11
	mut b := 22
	mut c := 33
	a, b, c = b + 1, a * 2, c - a
	assert a == 23
	assert b == 22
	assert c == 22
}
```