### PR TITLE
scanner: fix scanner_test on windows

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -783,7 +783,11 @@ pub fn (mut s Scanner) scan() token.Token {
 						s.error('@VMOD_FILE can be used only in projects, that have v.mod file')
 					}
 					vmod_content := os.read_file(vmod_file_location.vmod_file) or {''}
-					s.vmod_file_content = vmod_content.replace('\r\n', '\n')
+					$if windows {
+						s.vmod_file_content = vmod_content.replace('\r\n', '\n')
+					} $else {
+						s.vmod_file_content = vmod_content
+					}
 				}
 				return s.new_token(.string, s.vmod_file_content, 10)
 			}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -852,6 +852,7 @@ pub fn (mut s Scanner) scan() token.Token {
 		}
 		0xE2 {
 			if nextc == 0x89 && s.text[s.pos + 2] == 0xA0 {
+			// case `≠`:
 				s.pos += 2
 				return s.new_token(.ne, '', 3)
 			}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -848,7 +848,6 @@ pub fn (mut s Scanner) scan() token.Token {
 		}
 		0xE2 {
 			if nextc == 0x89 && s.text[s.pos + 2] == 0xA0 {
-			// case `â‰ `:
 				s.pos += 2
 				return s.new_token(.ne, '', 3)
 			}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -783,7 +783,7 @@ pub fn (mut s Scanner) scan() token.Token {
 						s.error('@VMOD_FILE can be used only in projects, that have v.mod file')
 					}
 					vmod_content := os.read_file(vmod_file_location.vmod_file) or {''}
-					s.vmod_file_content = vmod_content
+					s.vmod_file_content = vmod_content.replace('\r\n', '\n')
 				}
 				return s.new_token(.string, s.vmod_file_content, 10)
 			}
@@ -848,7 +848,7 @@ pub fn (mut s Scanner) scan() token.Token {
 		}
 		0xE2 {
 			if nextc == 0x89 && s.text[s.pos + 2] == 0xA0 {
-			// case `≠`:
+			// case `â‰ `:
 				s.pos += 2
 				return s.new_token(.ne, '', 3)
 			}


### PR DESCRIPTION
This PR fix scanner_test on windows.

**Cause**
- v.mod file is CRLF on windows.

**Solution**
```v
s.vmod_file_content = vmod_content.replace('\r\n', '\n')
```