### PR TITLE
vfmt: fix raw string support

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -660,6 +660,9 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 			f.write(')')
 		}
 		ast.StringLiteral {
+			if it.is_raw {
+				f.write('r')
+			}
 			if it.val.contains("'") && !it.val.contains('"') {
 				f.write('"$it.val"')
 			} else {

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -94,7 +94,7 @@ pub fn githash(should_get_from_filesystem bool) string {
 }
 
 //
-fn set_vroot_folder(vroot_path string) {
+pub fn set_vroot_folder(vroot_path string) {
 	// Preparation for the compiler module:
 	// VEXE env variable is needed so that compiler.vexe_path()
 	// can return it later to whoever needs it:
@@ -205,7 +205,7 @@ pub fn read_file(file_path string) ?string {
 }
 
 [inline]
-fn imin(a, b int) int {
+pub fn imin(a, b int) int {
 	return if a < b {
 		a
 	} else {
@@ -214,7 +214,7 @@ fn imin(a, b int) int {
 }
 
 [inline]
-fn imax(a, b int) int {
+pub fn imax(a, b int) int {
 	return if a > b {
 		a
 	} else {


### PR DESCRIPTION
Fixes #5055.

- Fixes support for raw strings.
- Expose some functions of `util` to the public to suppress warnings.