### PR TITLE
27-05-2020T12.13: Fix #5041

### DIFF
--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -449,6 +449,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			idx := (node.left as ast.IndexExpr).index
 			if idx is ast.RangeExpr {
 				// expr is arr[range].clone()
+				// use array_clone_static instead of array_clone
 				name = '${receiver_type_name}_${node.name}_static'.replace('.', '__')
 				is_range_slice = true
 			}

--- a/vlib/v/tests/array_slice_clone_test.v
+++ b/vlib/v/tests/array_slice_clone_test.v
@@ -1,0 +1,11 @@
+fn test_array_slice_clone() {
+	arr := [1, 2, 3, 4, 5]
+	cl := arr[1..].clone()
+	assert cl == [2, 3, 4, 5]
+}
+
+fn test_array_slice_clone2() {
+	arr := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+	cl := arr[1..].clone()[2..].clone()
+	assert cl == [4, 5, 6, 7, 8, 9, 10]
+}


### PR DESCRIPTION
Closes #5041 
When we call clone on a slice, the generated C output is `array_clone(&array_slice(...))` which is invalid.

Sample Code:
```
x := ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
y := x[1..].clone()
```

Original Output:
```
array_string y = array_clone(&array_slice(x, 1, x.len));
```

Output after Fix:
```
array_string y = array_clone_static(array_slice(x, 1, x.len));
```

Test Cases
```
fn test_array_slice_clone() {
	arr := [1, 2, 3, 4, 5]
	cl := arr[1..].clone()
	assert cl == [2, 3, 4, 5]
}

fn test_array_slice_clone2() {
	arr := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
	cl := arr[1..].clone()[2..].clone()
	assert cl == [4, 5, 6, 7, 8, 9, 10]
}
```