### PR TITLE
scanner: improve compile time pseudo variable `@FN` substitution by using forward lookup

### DIFF
--- a/vlib/v/scanner/scanner_test.v
+++ b/vlib/v/scanner/scanner_test.v
@@ -24,6 +24,25 @@ fn (mut t TestStruct) test_struct_w_high_order(cb fn(int)string) string {
 	return 'test'+cb(2)
 }
 
+struct TestFn { }
+
+fn (mut t TestFn) tst_1() {
+	assert @FN == 'tst_1'
+}
+
+fn (mut t TestFn) tst_2(cb fn(int)) {
+	assert @FN == 'tst_2'
+	cb(1)
+}
+
+fn fn_name_mod_level() {
+	assert @FN == 'fn_name_mod_level'
+}
+
+fn fn_name_mod_level_high_order(cb fn(int)) {
+	assert @FN == 'fn_name_mod_level_high_order'
+	cb(1)
+}
 
 fn test_scan() {
 	text := 'println(2 + 3)'
@@ -64,6 +83,19 @@ fn test_scan() {
 	// Test @FN
 	assert @FN == 'test_scan'
 
+	fn_name_mod_level()
+	fn_name_mod_level_high_order(fn(i int){
+		t := i + 1
+		assert t == 2
+	})
+
+	tfn := TestFn{}
+	tfn.tst_1()
+	tfn.tst_2(fn(i int){
+		t := i + 1
+		assert t == 2
+	})
+
 	// Test @MOD
 	assert @MOD == 'scanner'
 
@@ -79,7 +111,6 @@ fn test_scan() {
 	})
 	assert r1 == 'test'
 	assert r2 == 'test2'
-
 
 }
 


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This make the scanning go forward from `fn ` which is improving detection of the current function name in cases where high order functions are given as arguments