### PR TITLE
cgen: fix swap assign of prefix and postfix expr

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1078,6 +1078,14 @@ fn (mut g Gen) gen_cross_tmp_variable(idents []ast.Ident, val ast.Expr) {
 			g.write(it.op.str())
 			g.gen_cross_tmp_variable(idents, it.right)
 		}
+		ast.PrefixExpr {
+			g.write(it.op.str())
+			g.gen_cross_tmp_variable(idents, it.right)
+		}
+		ast.PostfixExpr {
+			g.gen_cross_tmp_variable(idents, it.expr)
+			g.write(it.op.str())
+		}
 		else {
 			g.expr(val)
 		}
@@ -2200,7 +2208,7 @@ fn (g Gen) expr_is_multi_return_call(expr ast.Expr) bool {
 		else {
 			return false
 		}
-	} 
+	}
 
 }
 
@@ -2245,7 +2253,7 @@ fn (mut g Gen) return_statement(node ast.Return) {
 
 
 		g.write('($styp){')
-		
+
 		mut arg_idx := 0
 		for i, expr in node.exprs {
 			// Check if we are dealing with a multi return and handle it seperately

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -35,25 +35,18 @@ fn (mut p Parser) check_cross_variables(idents []ast.Ident, expr ast.Expr) bool 
 	match expr {
 		ast.Ident {
 			for ident in idents {
-				if ident.name == it.name {
-					return true
-				}
+				if ident.name == it.name { return true }
 			}
 		}
 		ast.InfixExpr {
-			if p.check_cross_variables(idents, it.left) {
-				return true
-			}
-			if p.check_cross_variables(idents, it.right) {
-				return true
-			}
+			if p.check_cross_variables(idents, it.left) { return true }
+			if p.check_cross_variables(idents, it.right) { return true }
 		}
-		ast.StringInterLiteral {
-			for expr_ in it.exprs {
-				if p.check_cross_variables(idents, expr_) {
-					return true
-				}
-			}
+		ast.PrefixExpr {
+			if p.check_cross_variables(idents, it.right) { return true }
+		}
+		ast.PostfixExpr {
+			if p.check_cross_variables(idents, it.expr) { return true }
 		}
 		else {}
 	}

--- a/vlib/v/tests/multiple_assign_test.v
+++ b/vlib/v/tests/multiple_assign_test.v
@@ -34,3 +34,33 @@ fn test_multiple_assign_infix_expr() {
 	assert b == 22
 	assert c == 22
 }
+
+fn test_multiple_assign_prefix_expr() {
+	mut a := 11
+	mut b := 22
+	mut c := 33
+	a, b, c = -b, -c, -a
+	assert a == -22
+	assert b == -33
+	assert c == -11
+}
+
+fn test_multiple_assign_postfix_expr() {
+	mut a := 11
+	mut b := 22
+	mut c := 33
+	a, b, c = b++, c++, a--
+	assert a == 22
+	assert b == 33
+	assert c == 11
+}
+
+fn test_multiple_assign_complex_expr() {
+	mut a := 11
+	mut b := 22
+	mut c := 33
+	a, b, c = -b + 1, -c * 2, a++
+	assert a == -21
+	assert b == -66
+	assert c == 11
+}


### PR DESCRIPTION
This PR fix swap assign of prefix and postfix expr.

- Fix swap assign of prefix and postfix expr.
- Add tests.

```v
fn test_multiple_assign_prefix_expr() {
	mut a := 11
	mut b := 22
	mut c := 33
	a, b, c = -b, -c, -a
	assert a == -22
	assert b == -33
	assert c == -11
}

fn test_multiple_assign_postfix_expr() {
	mut a := 11
	mut b := 22
	mut c := 33
	a, b, c = b++, c++, a--
	assert a == 22
	assert b == 33
	assert c == 11
}

fn test_multiple_assign_complex_expr() {
	mut a := 11
	mut b := 22
	mut c := 33
	a, b, c = -b + 1, -c * 2, a++
	assert a == -21
	assert b == -66
	assert c == 11
}
```