### PR TITLE
all: fix struct names error

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -89,7 +89,7 @@ struct Chunk {
 	val string
 }
 
-struct K {
+struct Kkk {
 	q []Chunk
 }
 

--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -4,13 +4,13 @@ struct User {
 	name string
 }
 
-struct A {
+struct Aaa {
 mut:
 	m map[string]int
 	users map[string]User
 }
 
-fn (mut a A) set(key string, val int) {
+fn (mut a Aaa) set(key string, val int) {
 	a.m[key] = val
 }
 
@@ -47,7 +47,7 @@ fn test_map() {
 	users['1'] = User{'Peter'}
 	peter := users['1']
 	assert  peter.name == 'Peter'
-	mut a := A{
+	mut a := Aaa{
 		m: map[string]int
 		users: map[string]User
 	}

--- a/vlib/v/checker/tests/add_op_wrong_left_type_err_a.out
+++ b/vlib/v/checker/tests/add_op_wrong_left_type_err_a.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/add_op_wrong_left_type_err_a.v:3:5: error: mismatched types `A` and `any_int` 
-    1 | struct A{}
+vlib/v/checker/tests/add_op_wrong_left_type_err_a.v:3:5: error: mismatched types `Aaa` and `any_int`
+    1 | struct Aaa{}
     2 | fn main() {
-    3 |     A{} + 10
-      |     ~~~
+    3 |     Aaa{} + 10
+      |     ~~~~~
     4 | }

--- a/vlib/v/checker/tests/add_op_wrong_left_type_err_a.vv
+++ b/vlib/v/checker/tests/add_op_wrong_left_type_err_a.vv
@@ -1,4 +1,4 @@
-struct A{}
+struct Aaa{}
 fn main() {
-    A{} + 10
+    Aaa{} + 10
 }

--- a/vlib/v/checker/tests/add_op_wrong_right_type_err_a.out
+++ b/vlib/v/checker/tests/add_op_wrong_right_type_err_a.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/add_op_wrong_right_type_err_a.v:3:10: error: mismatched types `any_int` and `A` 
-    1 | struct A{}
+vlib/v/checker/tests/add_op_wrong_right_type_err_a.v:3:10: error: mismatched types `any_int` and `Aaa`
+    1 | struct Aaa{}
     2 | fn main() {
-    3 |     10 + A{}
-      |          ~~~
+    3 |     10 + Aaa{}
+      |          ~~~~~
     4 | }

--- a/vlib/v/checker/tests/add_op_wrong_right_type_err_a.vv
+++ b/vlib/v/checker/tests/add_op_wrong_right_type_err_a.vv
@@ -1,4 +1,4 @@
-struct A{}
+struct Aaa{}
 fn main() {
-    10 + A{}
+    10 + Aaa{}
 }

--- a/vlib/v/checker/tests/div_op_wrong_left_type_err_a.out
+++ b/vlib/v/checker/tests/div_op_wrong_left_type_err_a.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/div_op_wrong_left_type_err_a.v:3:5: error: mismatched types `A` and `any_int` 
-    1 | struct A{}
+vlib/v/checker/tests/div_op_wrong_left_type_err_a.v:3:5: error: mismatched types `Aaa` and `any_int`
+    1 | struct Aaa{}
     2 | fn main() {
-    3 |     A{} / 10
-      |     ~~~
+    3 |     Aaa{} / 10
+      |     ~~~~~
     4 | }

--- a/vlib/v/checker/tests/div_op_wrong_left_type_err_a.vv
+++ b/vlib/v/checker/tests/div_op_wrong_left_type_err_a.vv
@@ -1,4 +1,4 @@
-struct A{}
+struct Aaa{}
 fn main() {
-    A{} / 10
+    Aaa{} / 10
 }

--- a/vlib/v/checker/tests/div_op_wrong_right_type_err_a.out
+++ b/vlib/v/checker/tests/div_op_wrong_right_type_err_a.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/div_op_wrong_right_type_err_a.v:3:10: error: mismatched types `any_int` and `A` 
-    1 | struct A{}
+vlib/v/checker/tests/div_op_wrong_right_type_err_a.v:3:10: error: mismatched types `any_int` and `Aaa`
+    1 | struct Aaa{}
     2 | fn main() {
-    3 |     10 / A{}
-      |          ~~~
+    3 |     10 / Aaa{}
+      |          ~~~~~
     4 | }

--- a/vlib/v/checker/tests/div_op_wrong_right_type_err_a.vv
+++ b/vlib/v/checker/tests/div_op_wrong_right_type_err_a.vv
@@ -1,4 +1,4 @@
-struct A{}
+struct Aaa{}
 fn main() {
-    10 / A{}
+    10 / Aaa{}
 }

--- a/vlib/v/checker/tests/immutable_array_field_assign.out
+++ b/vlib/v/checker/tests/immutable_array_field_assign.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/immutable_array_field_assign.v:9:4: error: field `i` of struct `A` is immutable
+vlib/v/checker/tests/immutable_array_field_assign.v:9:4: error: field `i` of struct `Aaa` is immutable
     7 |         i: [0]
     8 |     }
     9 |     a.i[0] = 3

--- a/vlib/v/checker/tests/immutable_array_field_assign.vv
+++ b/vlib/v/checker/tests/immutable_array_field_assign.vv
@@ -1,9 +1,9 @@
-struct A {
+struct Aaa {
 	i []int
 }
 
 fn main() {
-	mut a := A{
+	mut a := Aaa{
 		i: [0]
 	}
 	a.i[0] = 3

--- a/vlib/v/checker/tests/immutable_array_field_shift.out
+++ b/vlib/v/checker/tests/immutable_array_field_shift.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/immutable_array_field_shift.v:14:4: error: field `a` of struct `B` is immutable
-   12 |         a: A{}
+vlib/v/checker/tests/immutable_array_field_shift.v:14:4: error: field `a` of struct `Bbb` is immutable
+   12 |         a: Aaa{}
    13 |     }
    14 |     b.a.i << 3
       |       ^

--- a/vlib/v/checker/tests/immutable_array_field_shift.vv
+++ b/vlib/v/checker/tests/immutable_array_field_shift.vv
@@ -1,15 +1,15 @@
-struct A {
+struct Aaa {
 mut:
 	i []int
 }
 
-struct B {
-	a A
+struct Bbb {
+	a Aaa
 }
 
 fn main() {
-	mut b := B{
-		a: A{}
+	mut b := Bbb{
+		a: Aaa{}
 	}
 	b.a.i << 3
 }

--- a/vlib/v/checker/tests/immutable_array_struct_assign.out
+++ b/vlib/v/checker/tests/immutable_array_struct_assign.out
@@ -1,6 +1,6 @@
 vlib/v/checker/tests/immutable_array_struct_assign.v:8:2: error: `a` is immutable, declare it with `mut` to make it mutable
     6 | fn main() {
-    7 |     a := A{}
+    7 |     a := Aaa{}
     8 |     a.i[0] += 3
       |     ^
     9 | }

--- a/vlib/v/checker/tests/immutable_array_struct_assign.vv
+++ b/vlib/v/checker/tests/immutable_array_struct_assign.vv
@@ -1,9 +1,9 @@
-struct A {
+struct Aaa {
 pub mut:
 	i []int
 }
 
 fn main() {
-	a := A{}
+	a := Aaa{}
 	a.i[0] += 3
 }

--- a/vlib/v/checker/tests/immutable_array_struct_shift.out
+++ b/vlib/v/checker/tests/immutable_array_struct_shift.out
@@ -1,6 +1,6 @@
 vlib/v/checker/tests/immutable_array_struct_shift.v:8:2: error: `a` is immutable, declare it with `mut` to make it mutable
     6 | fn main() {
-    7 |     a := []A{}
+    7 |     a := []Aaa{}
     8 |     a[0].i << 3
       |     ^
     9 | }

--- a/vlib/v/checker/tests/immutable_array_struct_shift.vv
+++ b/vlib/v/checker/tests/immutable_array_struct_shift.vv
@@ -1,9 +1,9 @@
-struct A {
+struct Aaa {
 pub mut:
 	i []int
 }
 
 fn main() {
-	a := []A{}
+	a := []Aaa{}
 	a[0].i << 3
 }

--- a/vlib/v/checker/tests/immutable_field.out
+++ b/vlib/v/checker/tests/immutable_field.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/immutable_field.v:8:4: error: field `i1` of struct `A` is immutable
+vlib/v/checker/tests/immutable_field.v:8:4: error: field `i1` of struct `Aaa` is immutable
     6 | fn main() {
-    7 |     a := A{1}
+    7 |     a := Aaa{1}
     8 |     a.i1 = 2
       |       ~~
     9 | }

--- a/vlib/v/checker/tests/immutable_field.vv
+++ b/vlib/v/checker/tests/immutable_field.vv
@@ -1,9 +1,9 @@
-struct A {
+struct Aaa {
 pub:
 	i1 int
 }
 
 fn main() {
-	a := A{1}
+	a := Aaa{1}
 	a.i1 = 2
 }

--- a/vlib/v/checker/tests/immutable_field_postfix.out
+++ b/vlib/v/checker/tests/immutable_field_postfix.out
@@ -1,12 +1,12 @@
-vlib/v/checker/tests/immutable_field_postfix.v:7:4: error: field `i` of struct `A` is immutable
+vlib/v/checker/tests/immutable_field_postfix.v:7:4: error: field `i` of struct `Aaa` is immutable
     5 | fn main() {
-    6 |     mut a := A{}
+    6 |     mut a := Aaa{}
     7 |     a.i++
       |       ^
     8 |     a.i--
     9 | }
-vlib/v/checker/tests/immutable_field_postfix.v:8:4: error: field `i` of struct `A` is immutable
-    6 |     mut a := A{}
+vlib/v/checker/tests/immutable_field_postfix.v:8:4: error: field `i` of struct `Aaa` is immutable
+    6 |     mut a := Aaa{}
     7 |     a.i++
     8 |     a.i--
       |       ^

--- a/vlib/v/checker/tests/immutable_field_postfix.vv
+++ b/vlib/v/checker/tests/immutable_field_postfix.vv
@@ -1,9 +1,9 @@
-struct A {
+struct Aaa {
 	i int
 }
 
 fn main() {
-	mut a := A{}
+	mut a := Aaa{}
 	a.i++
 	a.i--
 }

--- a/vlib/v/checker/tests/immutable_struct_postfix.out
+++ b/vlib/v/checker/tests/immutable_struct_postfix.out
@@ -1,12 +1,12 @@
 vlib/v/checker/tests/immutable_struct_postfix.v:8:2: error: `a` is immutable, declare it with `mut` to make it mutable
     6 | fn main() {
-    7 |     a := A{}
+    7 |     a := Aaa{}
     8 |     a.i++
       |     ^
     9 |     a.i--
    10 | }
 vlib/v/checker/tests/immutable_struct_postfix.v:9:2: error: `a` is immutable, declare it with `mut` to make it mutable
-    7 |     a := A{}
+    7 |     a := Aaa{}
     8 |     a.i++
     9 |     a.i--
       |     ^

--- a/vlib/v/checker/tests/immutable_struct_postfix.vv
+++ b/vlib/v/checker/tests/immutable_struct_postfix.vv
@@ -1,10 +1,10 @@
-struct A {
+struct Aaa {
 mut:
 	i int
 }
 
 fn main() {
-	a := A{}
+	a := Aaa{}
 	a.i++
 	a.i--
 }

--- a/vlib/v/checker/tests/minus_op_wrong_left_type_err_a.out
+++ b/vlib/v/checker/tests/minus_op_wrong_left_type_err_a.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/minus_op_wrong_left_type_err_a.v:3:5: error: mismatched types `A` and `any_int` 
-    1 | struct A{}
+vlib/v/checker/tests/minus_op_wrong_left_type_err_a.v:3:5: error: mismatched types `Aaa` and `any_int`
+    1 | struct Aaa{}
     2 | fn main() {
-    3 |     A{} - 10
-      |     ~~~
+    3 |     Aaa{} - 10
+      |     ~~~~~
     4 | }

--- a/vlib/v/checker/tests/minus_op_wrong_left_type_err_a.vv
+++ b/vlib/v/checker/tests/minus_op_wrong_left_type_err_a.vv
@@ -1,4 +1,4 @@
-struct A{}
+struct Aaa{}
 fn main() {
-    A{} - 10
+    Aaa{} - 10
 }

--- a/vlib/v/checker/tests/minus_op_wrong_right_type_err_a.out
+++ b/vlib/v/checker/tests/minus_op_wrong_right_type_err_a.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/minus_op_wrong_right_type_err_a.v:3:10: error: mismatched types `any_int` and `A` 
-    1 | struct A{}
+vlib/v/checker/tests/minus_op_wrong_right_type_err_a.v:3:10: error: mismatched types `any_int` and `Aaa`
+    1 | struct Aaa{}
     2 | fn main() {
-    3 |     10 - A{}
-      |          ~~~
+    3 |     10 - Aaa{}
+      |          ~~~~~
     4 | }

--- a/vlib/v/checker/tests/minus_op_wrong_right_type_err_a.vv
+++ b/vlib/v/checker/tests/minus_op_wrong_right_type_err_a.vv
@@ -1,4 +1,4 @@
-struct A{}
+struct Aaa{}
 fn main() {
-    10 - A{}
+    10 - Aaa{}
 }

--- a/vlib/v/checker/tests/mod_op_wrong_left_type_err_c.out
+++ b/vlib/v/checker/tests/mod_op_wrong_left_type_err_c.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/mod_op_wrong_left_type_err_c.v:4:2: error: mismatched types `A` and `any_int` 
+vlib/v/checker/tests/mod_op_wrong_left_type_err_c.v:4:2: error: mismatched types `Aaa` and `any_int`
     2 | fn main() {
-    3 |     a := A{}
+    3 |     a := Aaa{}
     4 |     a % 1
       |     ^
     5 | }

--- a/vlib/v/checker/tests/mod_op_wrong_left_type_err_c.vv
+++ b/vlib/v/checker/tests/mod_op_wrong_left_type_err_c.vv
@@ -1,5 +1,5 @@
-struct A{}
+struct Aaa{}
 fn main() {
-	a := A{}
+	a := Aaa{}
 	a % 1
 }

--- a/vlib/v/checker/tests/mod_op_wrong_right_type_err_c.out
+++ b/vlib/v/checker/tests/mod_op_wrong_right_type_err_c.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/mod_op_wrong_right_type_err_c.v:4:6: error: mismatched types `any_int` and `A` 
+vlib/v/checker/tests/mod_op_wrong_right_type_err_c.v:4:6: error: mismatched types `any_int` and `Aaa`
     2 | fn main() {
-    3 |     a := A{}
+    3 |     a := Aaa{}
     4 |     1 % a
       |         ^
     5 | }

--- a/vlib/v/checker/tests/mod_op_wrong_right_type_err_c.vv
+++ b/vlib/v/checker/tests/mod_op_wrong_right_type_err_c.vv
@@ -1,5 +1,5 @@
-struct A{}
+struct Aaa{}
 fn main() {
-	a := A{}
+	a := Aaa{}
 	1 % a
 }

--- a/vlib/v/checker/tests/mul_op_wrong_left_type_err_a.out
+++ b/vlib/v/checker/tests/mul_op_wrong_left_type_err_a.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/mul_op_wrong_left_type_err_a.v:3:5: error: mismatched types `A` and `any_int` 
-    1 | struct A{}
+vlib/v/checker/tests/mul_op_wrong_left_type_err_a.v:3:5: error: mismatched types `Aaa` and `any_int`
+    1 | struct Aaa{}
     2 | fn main() {
-    3 |     A{} * 10
-      |     ~~~
+    3 |     Aaa{} * 10
+      |     ~~~~~
     4 | }

--- a/vlib/v/checker/tests/mul_op_wrong_left_type_err_a.vv
+++ b/vlib/v/checker/tests/mul_op_wrong_left_type_err_a.vv
@@ -1,4 +1,4 @@
-struct A{}
+struct Aaa{}
 fn main() {
-    A{} * 10
+    Aaa{} * 10
 }

--- a/vlib/v/checker/tests/mul_op_wrong_right_type_err_a.out
+++ b/vlib/v/checker/tests/mul_op_wrong_right_type_err_a.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/mul_op_wrong_right_type_err_a.v:3:10: error: mismatched types `any_int` and `A` 
-    1 | struct A{}
+vlib/v/checker/tests/mul_op_wrong_right_type_err_a.v:3:10: error: mismatched types `any_int` and `Aaa`
+    1 | struct Aaa{}
     2 | fn main() {
-    3 |     10 * A{}
-      |          ~~~
+    3 |     10 * Aaa{}
+      |          ~~~~~
     4 | }

--- a/vlib/v/checker/tests/mul_op_wrong_right_type_err_a.vv
+++ b/vlib/v/checker/tests/mul_op_wrong_right_type_err_a.vv
@@ -1,4 +1,4 @@
-struct A{}
+struct Aaa{}
 fn main() {
-    10 * A{}
+    10 * Aaa{}
 }

--- a/vlib/v/checker/tests/struct_field_name_duplicate_err.out
+++ b/vlib/v/checker/tests/struct_field_name_duplicate_err.out
@@ -1,5 +1,5 @@
 vlib/v/checker/tests/struct_field_name_duplicate_err.v:3:2: error: field name `a` duplicate
-    1 | struct A {
+    1 | struct Aaa {
     2 |     a int
     3 |     a string
       |     ~~~~~~~~

--- a/vlib/v/checker/tests/struct_field_name_duplicate_err.vv
+++ b/vlib/v/checker/tests/struct_field_name_duplicate_err.vv
@@ -1,4 +1,4 @@
-struct A {
+struct Aaa {
 	a int
 	a string
 }

--- a/vlib/v/checker/tests/unknown_field.out
+++ b/vlib/v/checker/tests/unknown_field.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/unknown_field.v:7:12: error: unknown field `Test.sdd`
+vlib/v/checker/tests/unknown_field.v:7:12: error: type `Test` has no field or method `sdd`
     5 | fn main() {
     6 |     t := Test{}
     7 |     println(t.sdd)

--- a/vlib/v/gen/js/tests/hello/hello.v
+++ b/vlib/v/gen/js/tests/hello/hello.v
@@ -7,21 +7,21 @@ pub const (
 )
 */
 
-pub struct A {
+pub struct Aaa {
 pub mut:
 	foo string
 }
 
-pub fn (mut a A) update(s string) {
+pub fn (mut a Aaa) update(s string) {
 	a.foo = s
 }
 
-struct B {}
+struct Bbb {}
 
-pub enum C {}
+pub enum Ccc {}
 
 pub fn debugger() string {
-	v := B{}
+	v := Bbb{}
 	return 'Hello'
 }
 

--- a/vlib/v/tests/inout/enum_print.vv
+++ b/vlib/v/tests/inout/enum_print.vv
@@ -7,13 +7,13 @@ enum Color {
 	yellow = 3
 }
 
-struct A{
+struct Aaa{
 	color Color
 }
 
 fn main() {
 	col := Color.green
-	a := A{color: col}
+	a := Aaa{color: col}
 	orange := Color.orange
 	println(orange)
 	println(Color.yellow)

--- a/vlib/v/tests/inout/nested_structs.out
+++ b/vlib/v/tests/inout/nested_structs.out
@@ -1,11 +1,11 @@
-A {
+Aaa {
     test: false
-    b: B {
+    b: Bbb {
         pass: false
         name: ''
     }
 }
-B {
+Bbb {
     pass: false
     name: ''
 }

--- a/vlib/v/tests/inout/nested_structs.vv
+++ b/vlib/v/tests/inout/nested_structs.vv
@@ -1,22 +1,22 @@
 module main
 
-struct B {
+struct Bbb {
 	pass bool
 	name string
 }
 
-fn (b &B) print() {
+fn (b &Bbb) print() {
 	println(b)
 }
 
-struct A {
+struct Aaa {
 	test bool
-	b B
+	b Bbb
 }
 
 fn main() {
-	a := A{}
+	a := Aaa{}
 	println(a)
-	b := B{}
+	b := Bbb{}
 	b.print()
 }

--- a/vlib/v/tests/mut_test.v
+++ b/vlib/v/tests/mut_test.v
@@ -1,11 +1,11 @@
-struct A {
+struct Aaa {
 pub mut:
 	v []int
 }
 
-struct B {
+struct Bbb {
 pub mut:
-	a []A
+	a []Aaa
 }
 
 fn foo(b int, a mut []int) {
@@ -32,8 +32,8 @@ fn test_mut() {
 
 fn test_mut_2() {
 	zero := 0
-	mut b := B{}
-	b.a << A{}
+	mut b := Bbb{}
+	b.a << Aaa{}
 	b.a[0].v = [9, 8, 7]
 	b.a[0].v << 6
 	b.a[zero].v << 5

--- a/vlib/v/tests/pointers_str_test.v
+++ b/vlib/v/tests/pointers_str_test.v
@@ -1,8 +1,8 @@
-struct A {
+struct Aaa {
 	foo int
 }
 
 fn test_pointer_to_string() {
-	a := A{}
+	a := Aaa{}
 	assert a.foo.str() != (&a.foo).str()
 }

--- a/vlib/v/tests/repl/chained_fields/bd.repl.skip
+++ b/vlib/v/tests/repl/chained_fields/bd.repl.skip
@@ -1,17 +1,17 @@
-struct A { mut: v int }  struct B { a A }  struct C { mut: b B } struct D { mut: c C }
-mut b := B{} b = B{A{2}}
+struct Aaa { mut: v int }  struct Bbb { a Aaa }  struct Ccc { mut: b Bbb } struct Ddd { mut: c Ccc }
+mut b := Bbb{} b = Bbb{Aaa{2}}
 b.a.v = 1   // Error (field a immutable)
-b.a = A{}   // Error (field a immutable)
+b.a = Aaa{}   // Error (field a immutable)
 ===output===
-cannot modify immutable field `a` (type `B`)
+cannot modify immutable field `a` (type `Bbb`)
 declare the field with `mut:`
-struct B {
+struct Bbb {
 mut:
-	a A
+	a Aaa
 }
-cannot modify immutable field `a` (type `B`)
+cannot modify immutable field `a` (type `Bbb`)
 declare the field with `mut:`
-struct B {
+struct Bbb {
 mut:
-	a A
+	a Aaa
 }

--- a/vlib/v/tests/repl/chained_fields/c.repl.skip
+++ b/vlib/v/tests/repl/chained_fields/c.repl.skip
@@ -1,17 +1,17 @@
-struct A { mut: v int }  struct B { a A }  struct C { mut: b B } struct D { mut: c C } 
-mut c := C{} c.b = B{}
-c.b.a = A{} // Error (field a immutable)
+struct Aaa { mut: v int }  struct Bbb { a Aaa }  struct Ccc { mut: b Bbb } struct Ddd { mut: c Ccc }
+mut c := Ccc{} c.b = Bbb{}
+c.b.a = Aaa{} // Error (field a immutable)
 c.b.a.v = 1 // Error (field a immutable)
 ===output===
-cannot modify immutable field `a` (type `B`)
+cannot modify immutable field `a` (type `Bbb`)
 declare the field with `mut:`
-struct B {
+struct Bbb {
 mut:
-	a A
+	a Aaa
 }
-cannot modify immutable field `a` (type `B`)
+cannot modify immutable field `a` (type `Bbb`)
 declare the field with `mut:`
-struct B {
+struct Bbb {
 mut:
-	a A
+	a Aaa
 }

--- a/vlib/v/tests/repl/chained_fields/c2.repl.skip
+++ b/vlib/v/tests/repl/chained_fields/c2.repl.skip
@@ -1,5 +1,5 @@
-struct A { mut: v int }  struct B { a A }  struct C { mut: b B } struct D { mut: c C } 
-c2 := C{}
-c2.b = B{}  // Error (c2 immutable)
+struct Aaa { mut: v int }  struct Bbb { a Aaa }  struct Ccc { mut: b Bbb } struct Ddd { mut: c Ccc }
+c2 := Ccc{}
+c2.b = Bbb{}  // Error (c2 immutable)
 ===output===
 `c2` is immutable

--- a/vlib/v/tests/repl/chained_fields/d.repl.skip
+++ b/vlib/v/tests/repl/chained_fields/d.repl.skip
@@ -1,5 +1,5 @@
-struct A { mut: v int }  struct B { a A }  struct C { mut: b B } struct D { mut: c C }
-mut d := D{} d.c.b = B{}
+struct Aaa { mut: v int }  struct Bbb { a Aaa }  struct Ccc { mut: b Bbb } struct Ddd { mut: c Ccc }
+mut d := Ddd{} d.c.b = Bbb{}
 'OK'
 ===output===
 OK

--- a/vlib/v/tests/string_interpolation_test.v
+++ b/vlib/v/tests/string_interpolation_test.v
@@ -126,17 +126,17 @@ fn test_utf8_string_interpolation() {
 	assert '>${g:-13}<' == '>Πελοπόννησος <'
 }
 
-struct S {
+struct Sss {
 	v1 int
 	v2 f64
 }
 
-fn (s S) str() string {
+fn (s Sss) str() string {
 	return '[${s.v1}, ${s.v2:.3f}]'
 }
 
 fn test_string_interpolation_str_evaluation() {
-	mut x := S{17, 13.455893}
+	mut x := Sss{17, 13.455893}
 	assert '$x' == '[17, 13.456]'
 }
 


### PR DESCRIPTION
This PR fix struct names error.

- `struct A`  => `struct Aaa`
- `struct B`  => `struct Bbb`
- ......
- Modify related tests.