### PR TITLE
rand: Refactor rand.v and random_numbers_test.v

### DIFF
--- a/vlib/rand/rand.v
+++ b/vlib/rand/rand.v
@@ -3,10 +3,6 @@
 // that can be found in the LICENSE file.
 module rand
 
-const (
-	max_i32 = 2147483647
-)
-
 fn C.rand() int
 
 pub fn seed(s int) {
@@ -29,22 +25,30 @@ pub fn rand_r(seed &int) int {
 
 // rand_f32 return a random f32 between 0 and max
 pub fn rand_f32(max f32) f32 {
-	return f32(f64(C.rand()) / f64(C.RAND_MAX) * f64(max))
+	return rand_uniform_f32() * max
 }
 
 // rand_f32 return a random f32 in range min and max
 pub fn rand_f32_in_range(min, max f32) f32 {
-	scaled_r := f32(next(max_i32)) / max_i32
-	return min + scaled_r * (max - min)
+	return min + rand_uniform_f32() * (max - min)
 }
 
-// rand_f64 return a random f64 between 0 and max
-pub fn rand_f64(max f32) f32 {
-	return f64(C.rand()) / f64(C.RAND_MAX) * f64(max)
+// rand_f64 return a random f64 between 0 (inclusive) and max (exclusive)
+pub fn rand_f64(max f64) f64 {
+	return rand_uniform_f64() * max
 }
 
-// rand_f64 return a random f64 in range min and max
+// rand_f64 return a random f64 in range min (inclusive) and max (exclusive)
 pub fn rand_f64_in_range(min, max f64) f64 {
-	scaled_r := f64(next(max_i32)) / max_i32
-	return min + scaled_r * (max - min)
+	return min + rand_uniform_f64() * (max - min)
+}
+
+// rand_uniform_f32 returns a uniformly distributed f32 in the range 0 (inclusive) and 1 (exclusive)
+pub fn rand_uniform_f32() f32 {
+	return f32(C.rand()) / f32(C.RAND_MAX)
+}
+
+// rand_uniform_f64 returns a uniformly distributed f64 in the range 0 (inclusive) and 1 (exclusive)
+pub fn rand_uniform_f64() f64 {
+	return f64(C.rand()) / f64(C.RAND_MAX)
 }

--- a/vlib/rand/random_numbers_test.v
+++ b/vlib/rand/random_numbers_test.v
@@ -1,15 +1,14 @@
 import rand
 
 const (
-	rnd_count = 20
-	seeds = [42, 256]
+	rnd_count = 40
+	seeds     = [42, 256]
 )
 
 fn test_rand_reproducibility() {
 	for seed in seeds {
 		mut randoms1 := gen_randoms(seed)
 		mut randoms2 := gen_randoms(seed)
-
 		assert_randoms_equal(randoms1, randoms2)
 	}
 }
@@ -18,18 +17,15 @@ fn test_rand_r_reproducibility() {
 	for seed in seeds {
 		mut randoms1 := gen_randoms_r(seed)
 		mut randoms2 := gen_randoms_r(seed)
-
 		assert_randoms_equal(randoms1, randoms2)
 	}
 }
 
 fn test_rand_r_seed_update() {
 	seed := 10
-
-	for _ in 0..rnd_count {
+	for _ in 0 .. rnd_count {
 		prev_seed := seed
 		_ := rand.rand_r(&seed)
-
 		assert prev_seed != seed
 	}
 }
@@ -37,7 +33,7 @@ fn test_rand_r_seed_update() {
 fn gen_randoms(seed int) []int {
 	mut randoms := [0].repeat(rnd_count)
 	rand.seed(seed)
-	for i in 0..rnd_count {
+	for i in 0 .. rnd_count {
 		randoms[i] = rand.next(100)
 	}
 	return randoms
@@ -45,61 +41,80 @@ fn gen_randoms(seed int) []int {
 
 fn gen_randoms_r(seed int) []int {
 	mut randoms := [0].repeat(rnd_count)
-	for i in 0..rnd_count {
+	for i in 0 .. rnd_count {
 		randoms[i] = rand.rand_r(&seed)
 	}
 	return randoms
 }
 
 fn assert_randoms_equal(r1, r2 []int) {
-	for i in 0..rnd_count {
+	for i in 0 .. rnd_count {
 		assert r1[i] == r2[i]
 	}
 }
 
 fn test_rand_f32() {
-
-	mut prev_res := f32(-1.0)
-	for _ in 0..rnd_count+1 {
-		res := rand.rand_f32(1.0)
-
-		assert res >= 0.0
-		assert res <= 1.0
-
-		prev_res = res
+	for seed in seeds {
+		rand.seed(seed)
+		for _ in 0 .. rnd_count {
+			res := rand.rand_f32(100.0)
+			assert res >= 0.0
+			assert res < 100.0
+		}
 	}
 }
 
-
 fn test_rand_f32_in_range() {
-
-	for _ in 0..rnd_count+1 {
-		res := rand.rand_f32_in_range(1.0,2.0)
-
-		assert res >= 1.0
-		assert res <= 2.0
-
-		// NOTE assert res != prev_res
-		// ^- this kind of test can and WILL fail. Random numbers can be the same in subsequent runs
+	for seed in seeds {
+		rand.seed(seed)
+		for _ in 0 .. rnd_count {
+			res := rand.rand_f32_in_range(1.0, 2048.0)
+			assert res >= 1.0
+			assert res < 2048.0
+		}
 	}
 }
 
 fn test_rand_f64() {
-
-	for _ in 0..rnd_count+1 {
-		res := rand.rand_f64(1.0)
-
-		assert res >= 0.0
-		assert res <= 1.0
+	for seed in seeds {
+		rand.seed(seed)
+		for _ in 0 .. rnd_count {
+			res := rand.rand_f64(100.0)
+			assert res >= 0.0
+			assert res < 100.0
+		}
 	}
 }
 
 fn test_rand_f64_in_range() {
+	for seed in seeds {
+		rand.seed(seed)
+		for _ in 0 .. rnd_count {
+			res := rand.rand_f64_in_range(1.0, 2048.0)
+			assert res >= 1.0
+			assert res < 2048.0
+		}
+	}
+}
 
-	for _ in 0..rnd_count {
-		res := rand.rand_f64_in_range(1.0,2.0)
+fn test_rand_uniform_f32() {
+	for seed in seeds {
+		rand.seed(seed)
+		for _ in 0 .. rnd_count {
+			res := rand.rand_uniform_f32()
+			assert res >= 0.0
+			assert res < 1.0
+		}
+	}
+}
 
-		assert res >= 1.0
-		assert res <= 2.0
+fn test_rand_uniform_f64() {
+	for seed in seeds {
+		rand.seed(seed)
+		for _ in 0 .. rnd_count {
+			res := rand.rand_uniform_f64()
+			assert res >= 0.0
+			assert res < 1.0
+		}
 	}
 }


### PR DESCRIPTION
A summary of all the changes made:

1. Cleaned up `rand.v` to no longer require a redefinition of `max_i32`
2. Defined the base `rand_uniform_f[32/64]` functions that are dependent on the uniformity of `C.rand()`. They also require `C.RAND_MAX` which in practice is usually much lower than `max_i32`.
3. Set up `rand_f32`. `rand_f64`, `rand_f32_in_range` and `rand_f64_in_range` to use the respective `uniform` functions for consistent results.
4. Added tests for the new methods.
5. Made use of the `seeds` array in the tests.