### PR TITLE
vfmt: fix generation on C idents, fixed arrays

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -490,6 +490,15 @@ fn (f &Fmt) type_to_str(t table.Type) string {
 		start_pos := 2 * res.count('[]')
 		res = res[0..start_pos] + '&' + res[start_pos..res.len]
 	}
+	if res.starts_with('[]fixed_') {
+		prefix := '[]fixed_'
+		res = res[prefix.len..]
+		last_underscore_idx := res.last_index('_') or {
+			return '[]' + res
+		}
+		limit := res[last_underscore_idx + 1..]
+		res = '[' + limit + ']' + res[..last_underscore_idx]
+	}
 	return res.replace(f.cur_mod + '.', '')
 }
 

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -570,8 +570,14 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 			f.if_expr(it)
 		}
 		ast.Ident {
-			if it.language == .c {
-				f.write('C.')
+			match it.language {
+				.c {
+					f.write('C.')
+				}
+				.js {
+					f.write('JS.')
+				}
+				else {}
 			}
 			if it.kind == .blank_ident {
 				f.write('_')
@@ -894,8 +900,14 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 		f.write(')')
 		f.or_expr(node.or_block)
 	} else {
-		if node.language == .c {
-			f.write('C.')
+		match node.language {
+			.c {
+				f.write('C.')
+			}
+			.js {
+				f.write('JS.')
+			}
+			else {}
 		}
 		name := f.short_module(node.name)
 		f.mark_module_as_used(name)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -570,15 +570,7 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 			f.if_expr(it)
 		}
 		ast.Ident {
-			match it.language {
-				.c {
-					f.write('C.')
-				}
-				.js {
-					f.write('JS.')
-				}
-				else {}
-			}
+			f.write_language_prefix(it.language)
 			if it.kind == .blank_ident {
 				f.write('_')
 			} else {
@@ -900,15 +892,7 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 		f.write(')')
 		f.or_expr(node.or_block)
 	} else {
-		match node.language {
-			.c {
-				f.write('C.')
-			}
-			.js {
-				f.write('JS.')
-			}
-			else {}
-		}
+		f.write_language_prefix(node.language)
 		name := f.short_module(node.name)
 		f.mark_module_as_used(name)
 		f.write('${name}')
@@ -1023,6 +1007,18 @@ pub fn (mut f Fmt) mark_module_as_used(name string) {
 	}
 	f.used_imports << mod
 	// println('marking module $mod as used')
+}
+
+fn (mut f Fmt) write_language_prefix(lang table.Language) {
+	match lang {
+		.c {
+			f.write('C.')
+		}
+		.js {
+			f.write('JS.')
+		}
+		else {}
+	}
 }
 
 fn expr_is_single_line(expr ast.Expr) bool {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -561,6 +561,9 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 			f.if_expr(it)
 		}
 		ast.Ident {
+			if it.language == .c {
+				f.write('C.')
+			}
 			if it.kind == .blank_ident {
 				f.write('_')
 			} else {
@@ -601,6 +604,7 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 					ktyp = minfo.key_type
 					vtyp = minfo.value_type
 				}
+				
 				f.write('map[')
 				f.write(f.type_to_str(ktyp))
 				f.write(']')

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -494,7 +494,7 @@ fn (f &Fmt) type_to_str(t table.Type) string {
 		prefix := '[]fixed_'
 		res = res[prefix.len..]
 		last_underscore_idx := res.last_index('_') or {
-			return '[]' + res
+			return '[]' + res.replace(f.cur_mod + '.', '')
 		}
 		limit := res[last_underscore_idx + 1..]
 		res = '[' + limit + ']' + res[..last_underscore_idx]


### PR DESCRIPTION
- Fixes fixed array generation. Fixes #5070.
- Fixes C idents (such as `C.RAND_MAX`) generation.
- Add support for JS idents. (Thanks @Delta456) 