### PR TITLE
Use .dylib for -shared builds in macOS

### DIFF
--- a/cmd/tools/vcreate.v
+++ b/cmd/tools/vcreate.v
@@ -44,6 +44,7 @@ fn gen_gitignore(name string) string {
 		'main',
 		'$name',
 		'*.so',
+		'*.dylib',
 		'*.dll'
 	].join('\n')
 }

--- a/vlib/dl/dl_nix.c.v
+++ b/vlib/dl/dl_nix.c.v
@@ -5,7 +5,7 @@ module dl
 pub const (
 	rtld_now = C.RTLD_NOW
 	rtld_lazy = C.RTLD_LAZY
-	dl_ext   = '.so'
+	dl_ext = '.so'
 )
 
 fn C.dlopen(filename charptr, flags int) voidptr

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -147,7 +147,11 @@ fn (mut v Builder) cc() {
 	if v.pref.is_shared {
 		linker_flags << '-shared'
 		a << '-fPIC' // -Wl,-z,defs'
-		v.pref.out_name += '.so'
+		$if macos {
+			v.pref.out_name += '.dylib'
+		} $else {
+			v.pref.out_name += '.so'
+		}
 	}
 	if v.pref.is_bare {
 		a << '-fno-stack-protector'


### PR DESCRIPTION
When building shared libraries in `V`, it always appends `.so` to the binary file. This extension is not the same for all the unixes, in Darwin this is `dylib`.. But there's no such `darwin` $if yet, so i just sticked to macOS.

Will be good to introduce this `$if darwin` to support iOS and OpenDarwin too