### PR TITLE
parser: fix nested array_init syntax

### DIFF
--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -24,7 +24,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 		line_nr := p.tok.line_nr
 		p.next()
 		// []string
-		if p.tok.kind in [.name, .amp] && p.tok.line_nr == line_nr {
+		if p.tok.kind in [.name, .amp, .lsbr] && p.tok.line_nr == line_nr {
 			elem_type_pos = p.tok.position()
 			elem_type = p.parse_type()
 			// this is set here becasue its a known type, others could be the

--- a/vlib/v/tests/array_init_test.v
+++ b/vlib/v/tests/array_init_test.v
@@ -15,6 +15,21 @@ fn test_array_init() {
 	'$d, $d.len, $d.cap' == "['aaa', 'bbb'], 2, 3"
 }
 
+fn test_nested_array_init() {
+	mut a := [][]int{}
+	mut b := [][][]string{cap: 10}
+	mut c := [][][]string{len: 3, init: [][]string{len: 2}}
+	// mut c := [][][]string{len: 2, init: [][]string{len: 2, init: []string{len: 2, init: 'hello'}}}
+	a << [1, 2]
+	a << [3, 4]
+	b << [['foo', 'bar'], ['baz']]
+	b << [['qux']]
+
+	assert '$a' == '[[1, 2], [3, 4]]'
+	assert '$b' == "[[['foo', 'bar'], ['baz']], [['qux']]]"
+	assert '$c' == '[[[], []], [[], []], [[], []]]'
+}
+
 fn test_array_init_with_default() {
 	a1 := []int{len: 4, init: 2}
 	assert '$a1' == '[2, 2, 2, 2]'


### PR DESCRIPTION
This PR fixes nested array initialization and adds relevant tests.

Example:
```v
mut c := [][][]string{len: 3, init: [][]string{len: 2}}
assert '$c' == '[[[], []], [[], []], [[], []]]'
```


<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
