### PR TITLE
When building as shared library make vinit() a constructor

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2651,6 +2651,9 @@ fn (mut g Gen) write_init_function() {
 		return
 	}
 	fn_vinit_start_pos := g.out.len
+	g.pref.is_shared {
+		g.writeln('__attribute__ ((constructor))')
+	}
 	g.writeln('void _vinit() {')
 	if g.pref.autofree {
 		// Pre-allocate the string buffer

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2651,12 +2651,13 @@ fn (mut g Gen) write_init_function() {
 		return
 	}
 	fn_vinit_start_pos := g.out.len
-	g.pref.is_shared {
+	needs_constructor := g.pref.is_shared && g.pref.os != .windows
+	if needs_constructor {
 		g.writeln('__attribute__ ((constructor))')
-	}
-	g.writeln('void _vinit() {')
-	g.pref.is_shared {
+		g.writeln('void _vinit() {')
 		g.writeln('static bool once = false; if (once) {return;} once = true;')
+	} else {
+		g.writeln('void _vinit() {')
 	}
 	if g.pref.autofree {
 		// Pre-allocate the string buffer

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2655,6 +2655,9 @@ fn (mut g Gen) write_init_function() {
 		g.writeln('__attribute__ ((constructor))')
 	}
 	g.writeln('void _vinit() {')
+	g.pref.is_shared {
+		g.writeln('static bool once = false; if (once) {return} once = true;')
+	}
 	if g.pref.autofree {
 		// Pre-allocate the string buffer
 		// TODO make it configurable

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2656,7 +2656,7 @@ fn (mut g Gen) write_init_function() {
 	}
 	g.writeln('void _vinit() {')
 	g.pref.is_shared {
-		g.writeln('static bool once = false; if (once) {return} once = true;')
+		g.writeln('static bool once = false; if (once) {return;} once = true;')
 	}
 	if g.pref.autofree {
 		// Pre-allocate the string buffer

--- a/vlib/v/tests/const_test.v
+++ b/vlib/v/tests/const_test.v
@@ -9,5 +9,5 @@ pub const (
 fn test_const() {
 	assert a == 1
 	assert d == 11
-	assert c == 2
+	assert c == 1
 }

--- a/vlib/v/tests/const_test.v
+++ b/vlib/v/tests/const_test.v
@@ -9,5 +9,5 @@ pub const (
 fn test_const() {
 	assert a == 1
 	assert d == 11
-	assert c == 1
+	assert c == 2
 }


### PR DESCRIPTION
Related to #5094
