### PR TITLE
vup: replace hardcoded string `v` with `$vexe`

### DIFF
--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -5,7 +5,8 @@ import v.pref
 import v.util
 
 fn main() {
-	vroot := os.dir(pref.vexe_path())
+	vexe := pref.vexe_path()
+	vroot := os.dir(vexe)
 	os.chdir(vroot)
 
 	println('Updating V...')
@@ -30,7 +31,7 @@ fn main() {
 	// println(v_hash)
 	// println(current_hash)
 	if v_hash == current_hash {
-		show_current_v_version()
+		show_current_v_version(vexe)
 		return
 	}
 
@@ -61,16 +62,12 @@ fn main() {
 	_ := os.exec('v cmd/tools/vup.v') or {
 		panic(err)
 	}
-	show_current_v_version()
+	show_current_v_version(vexe)
 }
 
-fn show_current_v_version(){
+fn show_current_v_version(vexe string){
 	println('Current V version:')
-	$if windows {
-		os.system('v.exe version')
-	}	$else {
-		os.system('v version')
-	}
+	os.system('$vexe version')
 }
 
 fn backup(file string) {


### PR DESCRIPTION
I rename the V executable on my system, to avoid a conflict with another executable, called `v`. This PR is meant to handle such cases. I tested the PR on my Linux system and it worked fine.

Please, be advised, I assumed that `$vexe` will be expanded correctly on a windows system too, but I'm not positive.
