### PR TITLE
checker: fix array_init cast type error (fix #5103)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1331,12 +1331,14 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) table.Type {
 	if array_init.typ != table.void_type {
 		if array_init.exprs.len == 0 {
 			if array_init.has_cap {
-				if c.expr(array_init.cap_expr) !in [table.int_type, table.any_int_type] {
+				sym := c.table.get_type_symbol(c.expr(array_init.cap_expr))
+				if sym.kind !in [.int, .any_int] {
 					c.error('array cap needs to be an int', array_init.pos)
 				}
 			}
 			if array_init.has_len {
-				if c.expr(array_init.len_expr) !in [table.int_type, table.any_int_type] {
+				sym := c.table.get_type_symbol(c.expr(array_init.len_expr))
+				if sym.kind !in [.int, .any_int] {
 					c.error('array len needs to be an int', array_init.pos)
 				}
 			}
@@ -1347,15 +1349,17 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) table.Type {
 		}
 		return array_init.typ
 	}
-	// a = []
+	// a = []type{}
 	if array_init.exprs.len == 0 {
 		if array_init.has_cap {
-			if c.expr(array_init.cap_expr) !in [table.int_type, table.any_int_type] {
+			sym := c.table.get_type_symbol(c.expr(array_init.cap_expr))
+			if sym.kind !in [.int, .any_int] {
 				c.error('array cap needs to be an int', array_init.pos)
 			}
 		}
 		if array_init.has_len {
-			if c.expr(array_init.len_expr) !in [table.int_type, table.any_int_type] {
+			sym := c.table.get_type_symbol(c.expr(array_init.len_expr))
+			if sym.kind !in [.int, .any_int] {
 				c.error('array len needs to be an int', array_init.pos)
 			}
 		}

--- a/vlib/v/tests/array_init_test.v
+++ b/vlib/v/tests/array_init_test.v
@@ -155,3 +155,17 @@ fn test_array_init_in_struct_field() {
 	println(m)
 	assert m.ar.str() == '[1.2, 1.2, 1.2, 1.2]'
 }
+
+struct Aaa {
+pub mut:
+	a []int
+}
+
+fn test_array_init_cast_type_in_struct_field() {
+	size := u32(5)
+	st := &Aaa{
+		a: []int{len: int(size)}
+	}
+	println(st)
+	assert st.a.str() == '[0, 0, 0, 0, 0]'
+}


### PR DESCRIPTION
This PR fix array_init cast type error (fix #5103).

- Fix array_init cast type error.
- Add test `test_array_init_cast_type_in_struct_field()` in array_init_test.v.

```v
struct Struct {
pub mut:
	s u32
	a []int
}

fn main() {
	size := u32(5)
	st := &Struct{
		s: size
		a: []int{len: int(size)}
	}
	println(st)
}

D:\test\v\tt1>v run .
Struct {
    s: 5
    a: [0, 0, 0, 0, 0]
}
```