### PR TITLE
parser: check undefined variable of assign_expr

### DIFF
--- a/vlib/v/checker/tests/assign_expr_undefined_err_e.out
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_e.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/assign_expr_undefined_err_e.v:2:11: error: undefined variable: `a`
+    1 | fn main() {
+    2 |     a, b := -a, -b
+      |              ^
+    3 |     println(s)
+    4 | }

--- a/vlib/v/checker/tests/assign_expr_undefined_err_e.vv
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_e.vv
@@ -1,0 +1,4 @@
+fn main() {
+	a, b := -a, -b
+	println(s)
+}

--- a/vlib/v/checker/tests/assign_expr_undefined_err_f.out
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_f.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/assign_expr_undefined_err_f.v:2:12: error: undefined variable: `a`
+    1 | fn main() {
+    2 |     a, b := (-a + 1), 1
+      |               ^
+    3 |     println('$a, $b')
+    4 | }

--- a/vlib/v/checker/tests/assign_expr_undefined_err_f.vv
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_f.vv
@@ -1,0 +1,4 @@
+fn main() {
+	a, b := (-a + 1), 1
+	println('$a, $b')
+}

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -22,10 +22,19 @@ fn (mut p Parser) check_undefined_variables(idents []ast.Ident, expr ast.Expr) {
 			p.check_undefined_variables(idents, it.left)
 			p.check_undefined_variables(idents, it.right)
 		}
+		ast.PrefixExpr {
+			p.check_undefined_variables(idents, it.right)
+		}
+		ast.PostfixExpr {
+			p.check_undefined_variables(idents, it.expr)
+		}
 		ast.StringInterLiteral {
 			for expr_ in it.exprs {
 				p.check_undefined_variables(idents, expr_)
 			}
+		}
+		ast.ParExpr {
+			p.check_undefined_variables(idents, it.expr)
 		}
 		else {}
 	}

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -22,19 +22,19 @@ fn (mut p Parser) check_undefined_variables(idents []ast.Ident, expr ast.Expr) {
 			p.check_undefined_variables(idents, it.left)
 			p.check_undefined_variables(idents, it.right)
 		}
-		ast.PrefixExpr {
-			p.check_undefined_variables(idents, it.right)
+		ast.ParExpr {
+			p.check_undefined_variables(idents, it.expr)
 		}
 		ast.PostfixExpr {
 			p.check_undefined_variables(idents, it.expr)
+		}
+		ast.PrefixExpr {
+			p.check_undefined_variables(idents, it.right)
 		}
 		ast.StringInterLiteral {
 			for expr_ in it.exprs {
 				p.check_undefined_variables(idents, expr_)
 			}
-		}
-		ast.ParExpr {
-			p.check_undefined_variables(idents, it.expr)
 		}
 		else {}
 	}


### PR DESCRIPTION
This PR check undefined variable of assign_expr.

- Add check for prefix_expr.
- Add check for postfix_expr.
- Add check for par_expr.
- Add tests.

```v
D:\test\v\tt1>v run .
.\tt1.v:2:12: error: undefined variable: `a`
    1 | fn main() {
    2 |     a, b := (-a + 1), 1
      |               ^
    3 |     println('$a, $b')
    4 | }
```