### PR TITLE
all: unify expr and stmt type names

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -7,33 +7,33 @@ import v.token
 import v.table
 import v.errors
 
-pub type TypeDecl = AliasTypeDecl | FnTypeDecl | SumTypeDecl
+pub type TypeDeclStmt = AliasTypeDecl | FnTypeDecl | SumTypeDecl
 
-pub type Expr = AnonFn | ArrayInit | AsCast | AssignExpr | Assoc | BoolLiteral | CallExpr |
-	CastExpr | CharLiteral | ComptimeCall | ConcatExpr | EnumVal | FloatLiteral | Ident | IfExpr |
-	IfGuardExpr | IndexExpr | InfixExpr | IntegerLiteral | MapInit | MatchExpr | None | OrExpr |
-	ParExpr | PostfixExpr | PrefixExpr | RangeExpr | SelectorExpr | SizeOf | StringInterLiteral |
-	StringLiteral | StructInit | Type | TypeOf
+pub type Expr = AnonFnExpr | ArrayInitExpr | AsCastExpr | AssignExpr | AssocExpr | BoolLiteralExpr | CallExpr |
+	CastExpr | CharLiteralExpr | ComptimeCallExpr | ConcatExpr | EnumValExpr | FloatLiteralExpr | IdentExpr | IfExpr |
+	IfGuardExpr | IndexExpr | InfixExpr | IntegerLiteralExpr | MapInitExpr | MatchExpr | NoneExpr | OrExpr |
+	ParExpr | PostfixExpr | PrefixExpr | RangeExpr | SelectorExpr | SizeOfExpr | StringInterLiteralExpr |
+	StringLiteralExpr | StructInitExpr | TypeExpr | TypeOfExpr
 
-pub type Stmt = AssertStmt | AssignStmt | Attr | Block | BranchStmt | Comment | CompIf | ConstDecl |
-	DeferStmt | EnumDecl | ExprStmt | FnDecl | ForCStmt | ForInStmt | ForStmt | GlobalDecl | GoStmt |
-	GotoLabel | GotoStmt | HashStmt | Import | InterfaceDecl | Module | Return | StructDecl | TypeDecl |
+pub type Stmt = AssertStmt | AssignStmt | AttrStmt | BlockStmt | BranchStmt | CommentStmt | CompIfStmt | ConstDeclStmt |
+	DeferStmt | EnumDeclStmt | ExprStmt | FnDeclStmt | ForCStmt | ForInStmt | ForStmt | GlobalDeclStmt | GoStmt |
+	GotoLabelStmt | GotoStmt | HashStmt | ImportStmt | InterfaceDeclStmt | ModuleStmt | ReturnStmt | StructDeclStmt | TypeDeclStmt |
 	UnsafeStmt
 
-pub type ScopeObject = ConstField | GlobalDecl | Var
+pub type ScopeObject = ConstField | GlobalDeclStmt | Var
 
 // pub type Type = StructType | ArrayType
 // pub struct StructType {
 // fields []Field
 // }
 // pub struct ArrayType {}
-pub struct Type {
+pub struct TypeExpr {
 pub:
 	typ table.Type
 	pos token.Position
 }
 
-pub struct Block {
+pub struct BlockStmt {
 pub:
 	stmts []Stmt
 }
@@ -48,19 +48,19 @@ pub mut:
 	typ  table.Type
 }
 
-pub struct IntegerLiteral {
+pub struct IntegerLiteralExpr {
 pub:
 	val string
 	pos token.Position
 }
 
-pub struct FloatLiteral {
+pub struct FloatLiteralExpr {
 pub:
 	val string
 	pos token.Position
 }
 
-pub struct StringLiteral {
+pub struct StringLiteralExpr {
 pub:
 	val      string
 	is_raw   bool
@@ -69,7 +69,7 @@ pub:
 }
 
 // 'name: $name'
-pub struct StringInterLiteral {
+pub struct StringInterLiteralExpr {
 pub:
 	vals       []string
 	exprs      []Expr
@@ -79,13 +79,13 @@ pub mut:
 	expr_types []table.Type
 }
 
-pub struct CharLiteral {
+pub struct CharLiteralExpr {
 pub:
 	val string
 	pos token.Position
 }
 
-pub struct BoolLiteral {
+pub struct BoolLiteralExpr {
 pub:
 	val bool
 	pos token.Position
@@ -102,7 +102,7 @@ pub mut:
 }
 
 // module declaration
-pub struct Module {
+pub struct ModuleStmt {
 pub:
 	name       string
 	path       string
@@ -115,7 +115,7 @@ pub struct StructField {
 pub:
 	name             string
 	pos              token.Position
-	comment          Comment
+	comment          CommentStmt
 	default_expr     Expr
 	has_default_expr bool
 	attrs            []string
@@ -140,10 +140,10 @@ pub:
 	pos     token.Position
 pub mut:
 	typ     table.Type
-	comment Comment
+	comment CommentStmt
 }
 
-pub struct ConstDecl {
+pub struct ConstDeclStmt {
 pub:
 	is_pub bool
 	pos    token.Position
@@ -151,7 +151,7 @@ pub mut:
 	fields []ConstField
 }
 
-pub struct StructDecl {
+pub struct StructDeclStmt {
 pub:
 	pos         token.Position
 	name        string
@@ -165,11 +165,11 @@ pub:
 	attr        string
 }
 
-pub struct InterfaceDecl {
+pub struct InterfaceDeclStmt {
 pub:
 	name        string
 	field_names []string
-	methods     []FnDecl
+	methods     []FnDeclStmt
 	pos         token.Position
 }
 
@@ -183,7 +183,7 @@ pub mut:
 	expected_type table.Type
 }
 
-pub struct StructInit {
+pub struct StructInitExpr {
 pub:
 	pos      token.Position
 	is_short bool
@@ -193,21 +193,21 @@ pub mut:
 }
 
 // import statement
-pub struct Import {
+pub struct ImportStmt {
 pub:
 	pos   token.Position
 	mod   string
 	alias string
 }
 
-pub struct AnonFn {
+pub struct AnonFnExpr {
 pub:
-	decl FnDecl
+	decl FnDeclStmt
 pub mut:
 	typ  table.Type
 }
 
-pub struct FnDecl {
+pub struct FnDeclStmt {
 pub:
 	name          string
 	stmts         []Stmt
@@ -264,7 +264,7 @@ pub mut:
 	typ    table.Type
 }
 
-pub struct Return {
+pub struct ReturnStmt {
 pub:
 	pos   token.Position
 	exprs []Expr
@@ -297,7 +297,7 @@ pub mut:
 	is_used bool
 }
 
-pub struct GlobalDecl {
+pub struct GlobalDeclStmt {
 pub:
 	name     string
 	expr     Expr
@@ -310,12 +310,12 @@ pub mut:
 pub struct File {
 pub:
 	path         string
-	mod          Module
+	mod          ModuleStmt
 	stmts        []Stmt
 	scope        &Scope
 	global_scope &Scope
 pub mut:
-	imports      []Import
+	imports      []ImportStmt
 	errors       []errors.Error
 	warnings     []errors.Warning
 }
@@ -345,7 +345,7 @@ pub enum IdentKind {
 }
 
 // A single identifier
-pub struct Ident {
+pub struct IdentExpr {
 pub:
 	value    string
 	language table.Language
@@ -359,14 +359,14 @@ pub mut:
 	is_mut   bool
 }
 
-pub fn (i &Ident) var_info() IdentVar {
+pub fn (i &IdentExpr) var_info() IdentVar {
 	match i.info {
 		IdentVar {
 			return it
 		}
 		else {
 			// return IdentVar{}
-			panic('Ident.var_info(): info is not IdentVar variant')
+			panic('IdentExpr.var_info(): info is not IdentVar variant')
 		}
 	}
 }
@@ -423,7 +423,7 @@ pub:
 	cond    Expr
 	stmts   []Stmt
 	pos     token.Position
-	comment Comment
+	comment CommentStmt
 }
 
 pub struct MatchExpr {
@@ -446,12 +446,12 @@ pub:
 	exprs   []Expr // left side
 	stmts   []Stmt // right side
 	pos     token.Position
-	comment Comment // comment above `xxx {`
+	comment CommentStmt // comment above `xxx {`
 	is_else bool
 }
 
 /*
-CompIf.is_opt:
+CompIfStmt.is_opt:
 `$if xyz? {}` => this compile time `if` is optional,
 and .is_opt reflects the presence of ? at the end.
 When .is_opt is true, the code should compile, even
@@ -459,7 +459,7 @@ if `xyz` is NOT defined.
 If .is_opt is false, then when `xyz` is not defined,
 the compilation will fail.
 */
-pub struct CompIf {
+pub struct CompIfStmt {
 pub:
 	val        string
 	stmts      []Stmt
@@ -534,14 +534,14 @@ pub:
 	op            token.Kind
 	pos           token.Position
 pub mut:
-	left          []Ident
+	left          []IdentExpr
 	left_types    []table.Type
 	right_types   []table.Type
 	is_static     bool // for translated code only
 	has_cross_var bool
 }
 
-pub struct AsCast {
+pub struct AsCastExpr {
 pub:
 	expr      Expr
 	typ       table.Type
@@ -551,12 +551,12 @@ pub mut:
 }
 
 // e.g. `[unsafe_fn]`
-pub struct Attr {
+pub struct AttrStmt {
 pub:
 	name string
 }
 
-pub struct EnumVal {
+pub struct EnumValExpr {
 pub:
 	enum_name string
 	val       string
@@ -574,7 +574,7 @@ pub:
 	has_expr bool
 }
 
-pub struct EnumDecl {
+pub struct EnumDeclStmt {
 pub:
 	name    string
 	is_pub  bool
@@ -644,7 +644,7 @@ pub:
 	call_expr Expr
 }
 
-pub struct GotoLabel {
+pub struct GotoLabelStmt {
 pub:
 	name string
 }
@@ -654,7 +654,7 @@ pub:
 	name string
 }
 
-pub struct ArrayInit {
+pub struct ArrayInitExpr {
 pub:
 	pos             token.Position
 	elem_type_pos	token.Position
@@ -676,7 +676,7 @@ pub mut:
 	typ             table.Type
 }
 
-pub struct MapInit {
+pub struct MapInitExpr {
 pub:
 	pos        token.Position
 	keys       []Expr
@@ -737,7 +737,7 @@ pub:
 	pos   token.Position
 }
 
-pub struct Assoc {
+pub struct AssocExpr {
 pub:
 	var_name string
 	fields   []string
@@ -747,20 +747,20 @@ pub mut:
 	typ      table.Type
 }
 
-pub struct SizeOf {
+pub struct SizeOfExpr {
 pub:
 	typ       table.Type
 	type_name string
 }
 
-pub struct TypeOf {
+pub struct TypeOfExpr {
 pub:
 	expr      Expr
 pub mut:
 	expr_type table.Type
 }
 
-pub struct Comment {
+pub struct CommentStmt {
 pub:
 	text     string
 	is_multi bool
@@ -775,12 +775,12 @@ pub mut:
 	return_type table.Type
 }
 
-pub struct ComptimeCall {
+pub struct ComptimeCallExpr {
 	name string
 	left Expr
 }
 
-pub struct None {
+pub struct NoneExpr {
 pub:
 	foo int // todo
 }
@@ -788,7 +788,7 @@ pub:
 [inline]
 pub fn expr_is_blank_ident(expr Expr) bool {
 	match expr {
-		Ident { return it.kind == .blank_ident }
+		IdentExpr { return it.kind == .blank_ident }
 		else { return false }
 	}
 }
@@ -804,38 +804,38 @@ pub fn expr_is_call(expr Expr) bool {
 pub fn (expr Expr) position() token.Position {
 	// all uncommented have to be implemented
 	match mut expr {
-		ArrayInit {
+		ArrayInitExpr {
 			return it.pos
 		}
-		AsCast {
+		AsCastExpr {
 			return it.pos
 		}
-		// ast.Ident { }
+		// ast.IdentExpr { }
 		AssignExpr {
 			return it.pos
 		}
 		CastExpr {
 			return it.pos
 		}
-		Assoc {
+		AssocExpr {
 			return it.pos
 		}
-		BoolLiteral {
+		BoolLiteralExpr {
 			return it.pos
 		}
 		CallExpr {
 			return it.pos
 		}
-		CharLiteral {
+		CharLiteralExpr {
 			return it.pos
 		}
-		EnumVal {
+		EnumValExpr {
 			return it.pos
 		}
-		FloatLiteral {
+		FloatLiteralExpr {
 			return it.pos
 		}
-		Ident {
+		IdentExpr {
 			return it.pos
 		}
 		IfExpr {
@@ -857,10 +857,10 @@ pub fn (expr Expr) position() token.Position {
 				len: right_pos.pos - left_pos.pos + right_pos.len
 			}
 		}
-		IntegerLiteral {
+		IntegerLiteralExpr {
 			return it.pos
 		}
-		MapInit {
+		MapInitExpr {
 			return it.pos
 		}
 		MatchExpr {
@@ -869,7 +869,7 @@ pub fn (expr Expr) position() token.Position {
 		PostfixExpr {
 			return it.pos
 		}
-		// ast.None { }
+		// ast.NoneExpr { }
 		PrefixExpr {
 			return it.pos
 		}
@@ -877,18 +877,18 @@ pub fn (expr Expr) position() token.Position {
 		SelectorExpr {
 			return it.pos
 		}
-		// ast.SizeOf { }
-		StringLiteral {
+		// ast.SizeOfExpr { }
+		StringLiteralExpr {
 			return it.pos
 		}
-		StringInterLiteral {
+		StringInterLiteralExpr {
 			return it.pos
 		}
-		// ast.Type { }
-		StructInit {
+		// ast.TypeExpr { }
+		StructInitExpr {
 			return it.pos
 		}
-		// ast.TypeOf { }
+		// ast.TypeOfExpr { }
 		else {
 			return token.Position{}
 		}
@@ -900,49 +900,49 @@ pub fn (stmt Stmt) position() token.Position {
 		AssertStmt { return it.pos }
 		AssignStmt { return it.pos }
 		/*
-		// Attr {
+		// AttrStmt {
 		// }
 		// Block {
 		// }
 		// BranchStmt {
 		// }
 		*/
-		Comment { return it.pos }
-		CompIf { return it.pos }
-		ConstDecl { return it.pos }
+		CommentStmt { return it.pos }
+		CompIfStmt { return it.pos }
+		ConstDeclStmt { return it.pos }
 		/*
 		// DeferStmt {
 		// }
 		*/
-		EnumDecl { return it.pos }
+		EnumDeclStmt { return it.pos }
 		ExprStmt { return it.pos }
-		FnDecl { return it.pos }
+		FnDeclStmt { return it.pos }
 		ForCStmt { return it.pos }
 		ForInStmt { return it.pos }
 		ForStmt { return it.pos }
 		/*
-		// GlobalDecl {
+		// GlobalDeclStmt {
 		// }
 		// GoStmt {
 		// }
-		// GotoLabel {
+		// GotoLabelStmt {
 		// }
 		// GotoStmt {
 		// }
 		// HashStmt {
 		// }
 		*/
-		Import { return it.pos }
+		ImportStmt { return it.pos }
 		/*
-		// InterfaceDecl {
+		// InterfaceDeclStmt {
 		// }
 		// Module {
 		// }
 		*/
-		Return { return it.pos }
-		StructDecl { return it.pos }
+		ReturnStmt { return it.pos }
+		StructDeclStmt { return it.pos }
 		/*
-		// TypeDecl {
+		// TypeDeclStmt {
 		// }
 		// UnsafeStmt {
 		// }

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -7,7 +7,7 @@ module ast
 import v.table
 import strings
 
-pub fn (node &FnDecl) str(t &table.Table) string {
+pub fn (node &FnDeclStmt) str(t &table.Table) string {
 	mut f := strings.new_builder(30)
 	if node.is_pub {
 		f.write('pub ')
@@ -88,7 +88,7 @@ pub fn (node &FnDecl) str(t &table.Table) string {
 // string representaiton of expr
 pub fn (x Expr) str() string {
 	match x {
-		BoolLiteral {
+		BoolLiteralExpr {
 			return it.val.str()
 		}
 		CastExpr {
@@ -101,22 +101,22 @@ pub fn (x Expr) str() string {
 			}
 			return '${it.mod}.${it.name}($sargs)'
 		}
-		CharLiteral {
+		CharLiteralExpr {
 			return '`$it.val`'
 		}
-		EnumVal {
+		EnumValExpr {
 			return '.${it.val}'
 		}
-		FloatLiteral {
+		FloatLiteralExpr {
 			return it.val
 		}
-		Ident {
+		IdentExpr {
 			return it.name
 		}
 		IndexExpr {
 			return '${it.left.str()}[${it.index.str()}]'
 		}
-		IntegerLiteral {
+		IntegerLiteralExpr {
 			return it.val
 		}
 		InfixExpr {
@@ -131,7 +131,7 @@ pub fn (x Expr) str() string {
 		SelectorExpr {
 			return '${it.expr.str()}.${it.field_name}'
 		}
-		StringInterLiteral {
+		StringInterLiteralExpr {
 			mut res := []string{}
 			res << "'"
 			for i, val in it.vals {
@@ -152,10 +152,10 @@ pub fn (x Expr) str() string {
 			res << "'"
 			return res.join('')
 		}
-		StringLiteral {
+		StringLiteralExpr {
 			return '"$it.val"'
 		}
-		TypeOf {
+		TypeOfExpr {
 			return 'typeof(${it.expr.str()})'
 		}
 		else {
@@ -205,7 +205,7 @@ pub fn (node Stmt) str() string {
 		ExprStmt {
 			return it.expr.str()
 		}
-		FnDecl {
+		FnDeclStmt {
 			return 'fn ${it.name}() { $it.stmts.len stmts }'
 		}
 		else {

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -264,8 +264,8 @@ fn (b &Builder) print_warnings_and_errors() {
 			// Find where this function was already declared
 			for file in b.parsed_files {
 				for stmt in file.stmts {
-					if stmt is ast.FnDecl {
-						f := stmt as ast.FnDecl
+					if stmt is ast.FnDeclStmt {
+						f := stmt as ast.FnDeclStmt
 						if f.name == fn_name {
 							fline := f.pos.line_nr
 							println('${file.path}:${fline}:')

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -15,7 +15,7 @@ mut:
 	stmts []ast.Stmt // all module statements from all files
 }
 
-type FilterFn = fn (node ast.FnDecl) bool
+type FilterFn = fn (node ast.FnDeclStmt) bool
 
 pub fn doc(mod string, table &table.Table, prefs &pref.Preferences) string {
 	mut d := Doc{
@@ -71,7 +71,7 @@ pub fn doc(mod string, table &table.Table, prefs &pref.Preferences) string {
 	return d.out.str().trim_space()
 }
 
-fn (d &Doc) get_fn_node(f ast.FnDecl) string {
+fn (d &Doc) get_fn_node(f ast.FnDeclStmt) string {
 	return f.str(d.table).replace_each([d.mod + '.', '', 'pub ', ''])
 }
 
@@ -96,7 +96,7 @@ fn (d Doc) get_fn_signatures(filter_fn FilterFn) []string {
 	mut fn_signatures := []string{}
 	for stmt in d.stmts {
 		match stmt {
-			ast.FnDecl {
+			ast.FnDeclStmt {
 				if filter_fn(it) {
 					fn_signatures << d.get_fn_node(it)
 				}
@@ -108,11 +108,11 @@ fn (d Doc) get_fn_signatures(filter_fn FilterFn) []string {
 	return fn_signatures
 }
 
-fn is_pub_method(node ast.FnDecl) bool {
+fn is_pub_method(node ast.FnDeclStmt) bool {
 	return node.is_pub && node.is_method && !node.is_deprecated
 }
 
-fn is_pub_function(node ast.FnDecl) bool {
+fn is_pub_function(node ast.FnDeclStmt) bool {
 	return node.is_pub && !node.is_method && !node.is_deprecated
 }
 

--- a/vlib/v/eval/eval.v
+++ b/vlib/v/eval/eval.v
@@ -58,7 +58,7 @@ fn (mut e Eval) stmt(node ast.Stmt) string {
 			print_object(o)
 			return o.str()
 		}
-		// ast.StructDecl {
+		// ast.StructDeclStmt {
 		//	println('s decl')
 		// }
 		// ast.VarDecl {
@@ -73,10 +73,10 @@ fn (mut e Eval) stmt(node ast.Stmt) string {
 
 fn (mut e Eval) expr(node ast.Expr) Object {
 	match node {
-		ast.IntegerLiteral {
+		ast.IntegerLiteralExpr {
 			return it.val
 		}
-		ast.Ident {
+		ast.IdentExpr {
 			print_object(it.value)
 			// Find the variable
 			v := e.vars[it.name]

--- a/vlib/v/fmt/tests/struct_keep.vv
+++ b/vlib/v/fmt/tests/struct_keep.vv
@@ -15,7 +15,7 @@ fn handle_users(users []User) {
 fn (u &User) foo(u2 &User) {
 }
 
-type Expr = IfExpr | IntegerLiteral
+type Expr = IfExpr | IntegerLiteralExpr
 
 fn exprs(e []Expr) {
 	println(e.len)

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -7,7 +7,7 @@ import v.ast
 import v.table
 import v.util
 
-fn (mut g Gen) gen_fn_decl(it ast.FnDecl) {
+fn (mut g Gen) gen_fn_decl(it ast.FnDeclStmt) {
 	if it.language == .c {
 		// || it.no_body {
 		return
@@ -278,7 +278,7 @@ fn (mut g Gen) gen_fn_decl(it ast.FnDecl) {
 	}
 }
 
-fn (mut g Gen) write_autofree_stmts_when_needed(r ast.Return) {
+fn (mut g Gen) write_autofree_stmts_when_needed(r ast.ReturnStmt) {
 	// TODO: write_autofree_stmts_when_needed should account for the current local scope vars.
 	// TODO: write_autofree_stmts_when_needed should not free the returned variables.
 	// It may require rewriting g.return_statement to assign the expressions
@@ -546,7 +546,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 			json_type_str = g.table.get_type_symbol(node.args[0].typ).name
 		} else {
 			g.insert_before_stmt('// json.decode')
-			ast_type := node.args[0].expr as ast.Type
+			ast_type := node.args[0].expr as ast.TypeExpr
 			// `json.decode(User, s)` => json.decode_User(s)
 			sym := g.table.get_type_symbol(ast_type.typ)
 			name += '_' + sym.name
@@ -600,7 +600,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 			expr := node.args[0].expr
 			is_var := match expr {
 				ast.SelectorExpr { true }
-				ast.Ident { true }
+				ast.IdentExpr { true }
 				else { false }
 			}
 			if typ.is_ptr() && sym.kind != .struct_ {

--- a/vlib/v/gen/js/jsdoc.v
+++ b/vlib/v/gen/js/jsdoc.v
@@ -70,7 +70,7 @@ fn (mut d JsDoc) gen_fac_fn(fields []ast.StructField) string {
 	return d.out.str()
 }
 
-fn (mut d JsDoc) gen_fn(it ast.FnDecl) string {
+fn (mut d JsDoc) gen_fn(it ast.FnDeclStmt) string {
 	d.reset()
 	type_name := d.gen.typ(it.return_type)
 	d.writeln('/**')

--- a/vlib/v/gen/tests/3.c
+++ b/vlib/v/gen/tests/3.c
@@ -1,7 +1,7 @@
 struct IfExpr {
 };
 
-struct IntegerLiteral {
+struct IntegerLiteralExpr {
 };
 
 // Sum type
@@ -23,11 +23,11 @@ void User_foo(User* u);
 void println(string s);
 void handle_expr(Expr e);
 // >> typeof() support for sum types
-char * v_typeof_sumtype_28(int sidx) { /* Expr */ 
+char * v_typeof_sumtype_28(int sidx) { /* Expr */
 	switch(sidx) {
 		case 28: return "Expr";
 		case 26: return "IfExpr";
-		case 27: return "IntegerLiteral";
+		case 27: return "IntegerLiteralExpr";
 		default: return "unknown Expr";
 	}
 }
@@ -63,8 +63,8 @@ void handle_expr(Expr e) {
 		IfExpr* it = (IfExpr*)e.obj; // ST it
 		println(tos3("if"));
 	}
-	else if (e.typ == 27 /* IntegerLiteral */) {
-		IntegerLiteral* it = (IntegerLiteral*)e.obj; // ST it
+	else if (e.typ == 27 /* IntegerLiteralExpr */) {
+		IntegerLiteralExpr* it = (IntegerLiteralExpr*)e.obj; // ST it
 		println(tos3("integer"));
 	}
 	else {

--- a/vlib/v/gen/tests/3.vv
+++ b/vlib/v/gen/tests/3.vv
@@ -1,7 +1,7 @@
-type Expr = IfExpr | IntegerLiteral
+type Expr = IfExpr | IntegerLiteralExpr
 
 struct IfExpr{}
-struct IntegerLiteral{}
+struct IntegerLiteralExpr{}
 
 struct User {
 	age int
@@ -46,7 +46,7 @@ fn handle_expr(e Expr) {
 
 
 		}
-		IntegerLiteral {
+		IntegerLiteralExpr {
 			println('integer')
 
 		}

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -9,9 +9,9 @@ fn (mut p Parser) assign_stmt() ast.Stmt {
 	return p.partial_assign_stmt([])
 }
 
-fn (mut p Parser) check_undefined_variables(idents []ast.Ident, expr ast.Expr) {
+fn (mut p Parser) check_undefined_variables(idents []ast.IdentExpr, expr ast.Expr) {
 	match expr {
-		ast.Ident {
+		ast.IdentExpr {
 			for ident in idents {
 				if ident.name == it.name {
 					p.error_with_pos('undefined variable: `$it.name`', it.pos)
@@ -31,7 +31,7 @@ fn (mut p Parser) check_undefined_variables(idents []ast.Ident, expr ast.Expr) {
 		ast.PrefixExpr {
 			p.check_undefined_variables(idents, it.right)
 		}
-		ast.StringInterLiteral {
+		ast.StringInterLiteralExpr {
 			for expr_ in it.exprs {
 				p.check_undefined_variables(idents, expr_)
 			}
@@ -40,9 +40,9 @@ fn (mut p Parser) check_undefined_variables(idents []ast.Ident, expr ast.Expr) {
 	}
 }
 
-fn (mut p Parser) check_cross_variables(idents []ast.Ident, expr ast.Expr) bool {
+fn (mut p Parser) check_cross_variables(idents []ast.IdentExpr, expr ast.Expr) bool {
 	match expr {
-		ast.Ident {
+		ast.IdentExpr {
 			for ident in idents {
 				if ident.name == it.name { return true }
 			}
@@ -62,7 +62,7 @@ fn (mut p Parser) check_cross_variables(idents []ast.Ident, expr ast.Expr) bool 
 	return false
 }
 
-fn (mut p Parser) partial_assign_stmt(known_lhs []ast.Ident) ast.Stmt {
+fn (mut p Parser) partial_assign_stmt(known_lhs []ast.IdentExpr) ast.Stmt {
 	mut idents := known_lhs
 	mut op := p.tok.kind
 	// read (more) idents until assignment sign
@@ -148,7 +148,7 @@ pub fn (mut p Parser) assign_expr(left ast.Expr) ast.AssignExpr {
 	return node
 }
 
-fn (mut p Parser) parse_assign_ident() ast.Ident {
+fn (mut p Parser) parse_assign_ident() ast.IdentExpr {
 	/// returns a single parsed ident
 	return p.parse_ident(.v)
 }

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -75,14 +75,14 @@ fn (mut p Parser) hash() ast.HashStmt {
 	}
 }
 
-fn (mut p Parser) vweb() ast.ComptimeCall {
+fn (mut p Parser) vweb() ast.ComptimeCallExpr {
 	p.check(.dollar)
 	p.check(.name) // skip `vweb.html()` TODO
 	p.check(.dot)
 	p.check(.name)
 	p.check(.lpar)
 	p.check(.rpar)
-	return ast.ComptimeCall{}
+	return ast.ComptimeCallExpr{}
 }
 
 fn (mut p Parser) comp_if() ast.Stmt {
@@ -139,7 +139,7 @@ fn (mut p Parser) comp_if() ast.Stmt {
 	if !skip_os {
 		stmts = p.parse_block()
 	}
-	mut node := ast.CompIf{
+	mut node := ast.CompIfStmt{
 		is_not: is_not
 		is_opt: is_opt
 		pos: pos
@@ -215,8 +215,8 @@ fn os_from_string(os string) pref.OS {
 
 // `app.$action()` (`action` is a string)
 // `typ` is `App` in this example
-// fn (mut p Parser) comptime_method_call(typ table.Type) ast.ComptimeCall {
-fn (mut p Parser) comptime_method_call(left ast.Expr) ast.ComptimeCall {
+// fn (mut p Parser) comptime_method_call(typ table.Type) ast.ComptimeCallExpr {
+fn (mut p Parser) comptime_method_call(left ast.Expr) ast.ComptimeCallExpr {
 	p.check(.dollar)
 	method_name := p.check_name()
 	_ = method_name
@@ -253,7 +253,7 @@ fn (mut p Parser) comptime_method_call(left ast.Expr) ast.ComptimeCall {
 		p.check(.lcbr)
 		// p.statements()
 	}
-	return ast.ComptimeCall{
+	return ast.ComptimeCallExpr{
 		left: left
 		name: method_name
 	}

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -7,7 +7,7 @@ import v.ast
 import v.table
 import v.token
 
-fn (mut p Parser) array_init() ast.ArrayInit {
+fn (mut p Parser) array_init() ast.ArrayInitExpr {
 	first_pos := p.tok.position()
 	mut last_pos := p.tok.position()
 	p.check(.lsbr)
@@ -113,7 +113,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 		pos: first_pos.pos
 		len: last_pos.pos - first_pos.pos + last_pos.len
 	}
-	return ast.ArrayInit{
+	return ast.ArrayInitExpr{
 		is_fixed: is_fixed
 		has_val: has_val
 		mod: p.mod
@@ -131,7 +131,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 	}
 }
 
-fn (mut p Parser) map_init() ast.MapInit {
+fn (mut p Parser) map_init() ast.MapInitExpr {
 	pos := p.tok.position()
 	mut keys := []ast.Expr{}
 	mut vals := []ast.Expr{}
@@ -146,7 +146,7 @@ fn (mut p Parser) map_init() ast.MapInit {
 			p.next()
 		}
 	}
-	return ast.MapInit{
+	return ast.MapInitExpr{
 		keys: keys
 		vals: vals
 		pos: pos

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -112,7 +112,7 @@ pub fn (mut p Parser) call_args() []ast.CallArg {
 	return args
 }
 
-fn (mut p Parser) fn_decl() ast.FnDecl {
+fn (mut p Parser) fn_decl() ast.FnDeclStmt {
 	start_pos := p.tok.position()
 	is_deprecated := p.attr == 'deprecated'
 	is_pub := p.tok.kind == .key_pub
@@ -281,7 +281,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	p.close_scope()
 	p.attr = ''
 	p.attr_ctdefine = ''
-	return ast.FnDecl{
+	return ast.FnDeclStmt{
 		name: name
 		stmts: stmts
 		return_type: return_type
@@ -307,7 +307,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	}
 }
 
-fn (mut p Parser) anon_fn() ast.AnonFn {
+fn (mut p Parser) anon_fn() ast.AnonFnExpr {
 	pos := p.tok.position()
 	p.check(.key_fn)
 	p.open_scope()
@@ -342,8 +342,8 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 	idx := p.table.find_or_register_fn_type(p.mod, func, true, false)
 	typ := table.new_type(idx)
 	// name := p.table.get_type_name(typ)
-	return ast.AnonFn{
-		decl: ast.FnDecl{
+	return ast.AnonFnExpr{
+		decl: ast.FnDeclStmt{
 			name: name
 			stmts: stmts
 			return_type: return_type
@@ -475,7 +475,7 @@ fn have_fn_main(stmts []ast.Stmt) bool {
 	mut has_main_fn := false
 	for stmt in stmts {
 		match stmt {
-			ast.FnDecl {
+			ast.FnDeclStmt {
 				if it.name == 'main' {
 					has_main_fn = true
 				}

--- a/vlib/v/parser/if.v
+++ b/vlib/v/parser/if.v
@@ -19,7 +19,7 @@ fn (mut p Parser) if_expr() ast.IfExpr {
 	for p.tok.kind in [.key_if, .key_else] {
 		p.inside_if = true
 		start_pos := p.tok.position()
-		mut comment := ast.Comment{}
+		mut comment := ast.CommentStmt{}
 		if p.tok.kind == .key_if {
 			p.next()
 		} else {
@@ -74,7 +74,7 @@ fn (mut p Parser) if_expr() ast.IfExpr {
 			cond: cond
 			stmts: stmts
 			pos: start_pos.extend(end_pos)
-			comment: ast.Comment{}
+			comment: ast.CommentStmt{}
 		}
 		if p.tok.kind != .key_else {
 			break
@@ -116,7 +116,7 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 			p.peek_tok.kind == .dot) {
 			// Sum type match
 			typ := p.parse_type()
-			exprs << ast.Type{
+			exprs << ast.TypeExpr{
 				typ: typ
 			}
 			p.scope.register('it', ast.Var{
@@ -135,7 +135,7 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 			// Make sure a variable used for the sum type match
 			mut var_name := ''
 			match cond {
-				ast.Ident {
+				ast.IdentExpr {
 					var_name = it.name
 				}
 				else {

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -30,7 +30,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			node = p.enum_val()
 		}
 		.chartoken {
-			node = ast.CharLiteral{
+			node = ast.CharLiteralExpr{
 				val: p.tok.lit
 				pos: p.tok.position()
 			}
@@ -41,7 +41,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			node = p.prefix_expr()
 		}
 		.key_true, .key_false {
-			node = ast.BoolLiteral{
+			node = ast.BoolLiteralExpr{
 				val: p.tok.kind == .key_true
 				pos: p.tok.position()
 			}
@@ -74,7 +74,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 		}
 		.key_none {
 			p.next()
-			node = ast.None{}
+			node = ast.NoneExpr{}
 		}
 		.key_sizeof {
 			p.next() // sizeof
@@ -83,12 +83,12 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			if p.tok.lit == 'C' {
 				p.next()
 				p.check(.dot)
-				node = ast.SizeOf{
+				node = ast.SizeOfExpr{
 					type_name: p.check_name()
 					typ: sizeof_type
 				}
 			} else {
-				node = ast.SizeOf{
+				node = ast.SizeOfExpr{
 					typ: sizeof_type
 				}
 			}
@@ -99,7 +99,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			p.check(.lpar)
 			expr := p.expr(0)
 			p.check(.rpar)
-			node = ast.TypeOf{
+			node = ast.TypeOfExpr{
 				expr: expr
 			}
 		}
@@ -149,7 +149,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			pos := p.tok.position()
 			p.next()
 			typ = p.parse_type()
-			node = ast.AsCast{
+			node = ast.AsCastExpr{
 				expr: node
 				typ: typ
 				pos: pos

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -8,7 +8,7 @@ import v.table
 import v.token
 import v.util
 
-fn (mut p Parser) struct_decl() ast.StructDecl {
+fn (mut p Parser) struct_decl() ast.StructDeclStmt {
 	start_pos := p.tok.position()
 	is_pub := p.tok.kind == .key_pub
 	if is_pub {
@@ -57,7 +57,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 	if !no_body {
 		p.check(.lcbr)
 		for p.tok.kind != .rcbr {
-			mut comment := ast.Comment{}
+			mut comment := ast.CommentStmt{}
 			if p.tok.kind == .comment {
 				comment = p.comment()
 			}
@@ -130,7 +130,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 				// p.expr(0)
 				default_expr = p.expr(0)
 				match default_expr {
-					ast.EnumVal { it.typ = typ }
+					ast.EnumValExpr { it.typ = typ }
 					// TODO: implement all types??
 					else {}
 				}
@@ -196,7 +196,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 		p.error('cannot register type `$name`, another type with this name exists')
 	}
 	p.expr_mod = ''
-	return ast.StructDecl{
+	return ast.StructDeclStmt{
 		name: name
 		is_pub: is_pub
 		fields: ast_fields
@@ -210,7 +210,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 	}
 }
 
-fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
+fn (mut p Parser) struct_init(short_syntax bool) ast.StructInitExpr {
 	first_pos := p.tok.position()
 	typ := if short_syntax { table.void_type } else { p.parse_type() }
 	p.expr_mod = ''
@@ -260,7 +260,7 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 	if !short_syntax {
 		p.check(.rcbr)
 	}
-	node := ast.StructInit{
+	node := ast.StructInitExpr{
 		typ: typ
 		fields: fields
 		pos: token.Position{
@@ -273,7 +273,7 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 	return node
 }
 
-fn (mut p Parser) interface_decl() ast.InterfaceDecl {
+fn (mut p Parser) interface_decl() ast.InterfaceDeclStmt {
 	start_pos := p.tok.position()
 	is_pub := p.tok.kind == .key_pub
 	if is_pub {
@@ -295,7 +295,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 	typ := table.new_type(p.table.register_type_symbol(t))
 	ts := p.table.get_type_symbol(typ) // TODO t vs ts
 	// Parse methods
-	mut methods := []ast.FnDecl{}
+	mut methods := []ast.FnDeclStmt{}
 	for p.tok.kind != .rcbr && p.tok.kind != .eof {
 		method_start_pos := p.tok.position()
 		line_nr := p.tok.line_nr
@@ -311,7 +311,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			is_hidden: true
 		}]
 		args << args2
-		mut method := ast.FnDecl{
+		mut method := ast.FnDeclStmt{
 			name: name
 			args: args
 			file: p.file_name
@@ -332,7 +332,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		})
 	}
 	p.check(.rcbr)
-	return ast.InterfaceDecl{
+	return ast.InterfaceDeclStmt{
 		name: interface_name
 		methods: methods
 		pos: start_pos

--- a/vlib/v/tests/sum_type_test.v
+++ b/vlib/v/tests/sum_type_test.v
@@ -1,20 +1,20 @@
-type Expr = IfExpr | IntegerLiteral
+type Expr = IfExpr | IntegerLiteralExpr
 
 struct IfExpr {
 	pos int
 }
 
-struct IntegerLiteral {
+struct IntegerLiteralExpr {
 	val string
 }
 
 fn handle(e Expr) string {
-	assert e is IntegerLiteral
-	if e is IntegerLiteral {
+	assert e is IntegerLiteralExpr
+	if e is IntegerLiteralExpr {
 		println('int')
 	}
 	match e {
-		IntegerLiteral {
+		IntegerLiteralExpr {
 			assert it.val == '12'
 			// assert e.val == '12' // TODO
 			return 'int'
@@ -27,22 +27,22 @@ fn handle(e Expr) string {
 }
 
 fn test_expr() {
-	expr := IntegerLiteral{
+	expr := IntegerLiteralExpr{
 		val: '12'
 	}
 	assert handle(expr) == 'int'
-	// assert expr is IntegerLiteral // TODO
+	// assert expr is IntegerLiteralExpr // TODO
 }
 
 fn test_assignment_and_push() {
 	mut expr1 := Expr{}
 	mut arr1 := []Expr{}
-	expr := IntegerLiteral{
+	expr := IntegerLiteralExpr{
         val: '111'
     }
 	arr1 << expr
 	match arr1[0] {
-		IntegerLiteral {
+		IntegerLiteralExpr {
 			arr1 << it
 			// should ref/dereference on assignent be made automatic?
 			// currently it is done for return stmt and fn args
@@ -84,4 +84,3 @@ fn test_converting_down() {
 	assert res[1].val == 3
 	assert res[1].name == 'three'
 }
-


### PR DESCRIPTION
This PR unify expr and stmt type names.

```v
pub type Expr = AnonFnExpr | ArrayInitExpr | AsCastExpr | AssignExpr | AssocExpr | BoolLiteralExpr | CallExpr |
	CastExpr | CharLiteralExpr | ComptimeCallExpr | ConcatExpr | EnumValExpr | FloatLiteralExpr | IdentExpr | IfExpr |
	IfGuardExpr | IndexExpr | InfixExpr | IntegerLiteralExpr | MapInitExpr | MatchExpr | NoneExpr | OrExpr |
	ParExpr | PostfixExpr | PrefixExpr | RangeExpr | SelectorExpr | SizeOfExpr | StringInterLiteralExpr |
	StringLiteralExpr | StructInitExpr | TypeExpr | TypeOfExpr

pub type Stmt = AssertStmt | AssignStmt | AttrStmt | BlockStmt | BranchStmt | CommentStmt | CompIfStmt | ConstDeclStmt |
	DeferStmt | EnumDeclStmt | ExprStmt | FnDeclStmt | ForCStmt | ForInStmt | ForStmt | GlobalDeclStmt | GoStmt |
	GotoLabelStmt | GotoStmt | HashStmt | ImportStmt | InterfaceDeclStmt | ModuleStmt | ReturnStmt | StructDeclStmt | TypeDeclStmt |
	UnsafeStmt
```