### PR TITLE
cgen: Panic on assertion failed when not in test file to print backtrace

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -886,6 +886,7 @@ fn (mut g Gen) gen_assert_stmt(a ast.AssertStmt) {
 	}
 	g.writeln('{}else{')
 	g.writeln('	eprintln( tos_lit("${mod_path}:${a.pos.line_nr+1}: FAIL: fn ${g.fn_decl.name}(): assert $s_assertion"));')
+	g.writeln(' v_panic(tos_lit("Assertion failed..."));')
 	g.writeln('	exit(1);')
 	g.writeln('}')
 }


### PR DESCRIPTION
This adds a line to all assertion fails when not in a test file to call `v_panic` which will print out a callstack of what led up to the assertion in question. I feel it adds some nice ease-of-use especially when tracking down bugs that could have come from anywhere.