### PR TITLE
checker: wrong type mismatch in function argument for struct reference init

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -168,7 +168,7 @@ pub fn (c &Checker) promote(left_type, right_type table.Type) table.Type {
 				if idx_lo in [table.int_type_idx, table.i64_type_idx, table.u32_type_idx, table.u64_type_idx] {
 					return table.void_type
 				} else {
-					return idx_hi
+					return type_hi
 				}
 			} else { // f64, any_flt
 				if idx_lo in [table.i64_type_idx, table.u64_type_idx] {

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -223,6 +223,8 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 	mut i := 0
 	no_keys := p.peek_tok.kind != .colon && p.tok.kind != .rcbr // `Vec{a,b,c}
 	// p.warn(is_short_syntax.str())
+	saved_is_amp := p.is_amp
+	p.is_amp = false
 	for p.tok.kind != .rcbr && p.tok.kind != .rpar {
 		p.check_comment()
 		mut field_name := ''
@@ -260,6 +262,7 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 	if !short_syntax {
 		p.check(.rcbr)
 	}
+	p.is_amp = saved_is_amp
 	node := ast.StructInit{
 		typ: typ
 		fields: fields

--- a/vlib/v/tests/type_promotion_test.v
+++ b/vlib/v/tests/type_promotion_test.v
@@ -1,0 +1,69 @@
+fn test_anyfloat() {
+	a := f64(5.765) + 45.75
+	b := 12.3 + f64(3)
+	c := f32(6.75) / 3.0
+	d := 16.5 / f32(2)
+	assert a == 51.515
+	assert typeof(a) == 'f64'
+	assert b == f64(15.3)
+	assert typeof(b) == 'f64'
+	assert c == 2.25
+	assert typeof(c) == 'f32'
+	assert d == 8.25
+	assert typeof(d) == 'f32'
+}
+
+fn g(x f32) f32 {
+	return x*x
+}
+
+fn fabs(x f32) f32 {
+	return if x >= 0.0 { x } else { -x }
+}
+
+fn test_call() {
+	c := 503
+	r := g(f32(c) / 255.0)
+	assert fabs(r - 3.890949634755863) <= 1.e-6
+}
+		
+struct Tx {
+	x f32
+}
+
+fn (s Tx) get() f32 {
+	return s.x
+}
+
+fn test_struct_init() {
+	c := 503
+	d := Tx {
+		x:  g(f32(c) / 255.0)
+	}
+	assert fabs(d.get() - 3.890949634755863) < 1.e-6
+}
+
+fn struct_init_return() Tx {
+	c := 503
+	return Tx {
+		x:  g(f32(c) / 255.0)
+	}
+}
+
+fn test_struct_init_return() {
+	x := struct_init_return()
+	assert fabs(fabs(x.get()) - 3.890949634755863) < 1.e-6
+}
+
+fn struct_init_ref_return() &Tx {
+	c := 503
+	return &Tx {
+		x:  g(f32(c) / 255.0)
+	}
+}
+
+fn test_struct_init_ref_return() {
+	x := struct_init_ref_return()
+	assert fabs(fabs(x.get()) - 3.890949634755863) < 1.e-6
+}
+


### PR DESCRIPTION
There seems to be a weird bug in the type checker. If an element of a struct reference is initialized with a function and a function argument is a binary expressions and one of the operands of this expression is explicitly type-converted the checker might report a false type mismatch.

The issue is fixed by turning off `is_mut` while parsing `struct` initialization expressions.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
