### PR TITLE
Meaningful error when trying to return on interfaces

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1232,6 +1232,9 @@ pub fn (mut c Checker) return_stmt(mut return_stmt ast.Return) {
 			if is_generic {
 				exp_typ_sym = c.table.get_type_symbol(c.cur_generic_type)
 			}
+			if exp_typ_sym.kind == .interface_ {
+				c.error('returning structs as interfaces is not yet supported', pos)
+			}
 			c.error('cannot use `$got_typ_sym.name` as type `$exp_typ_sym.name` in return argument',
 				pos)
 		}


### PR DESCRIPTION
related to #5135

Change this error for a 'TODO' one, i tried to add the error eariler when defining a function but didn't find the place to check for this. Any way this is just a toy PR because #5135 should be fixed instead of providing such errors. I would appreciate some feedback on this so I can learn more about the compiler internals and maybe help more in future contributions.

```
error: cannot use DriverType as type Driver in return argument
```

For a TODO one:

```
$ v run a.v
a.v:20:9: error: returning structs as interfaces is not yet supported
   18 | fn new() Driver {
   19 |     d := DriverType{}
   20 |     return d
      |            ^
   21 | }
   22 |
```