### PR TITLE
vfmt: Added gdiff to list to fix diff detection on bsd systems.

### DIFF
--- a/vlib/v/util/errors.v
+++ b/vlib/v/util/errors.v
@@ -151,7 +151,7 @@ pub fn verror(kind, s string) {
 }
 
 pub fn find_working_diff_command() ?string {
-	for diffcmd in ['colordiff', 'diff', 'colordiff.exe', 'diff.exe'] {
+	for diffcmd in ['colordiff', 'gdiff', 'diff', 'colordiff.exe', 'diff.exe'] {
 		p := os.exec('$diffcmd --version') or {
 			continue
 		}


### PR DESCRIPTION
This PR simply adds 'gdiff' to the list of diff tools in vlib/v/util/errors.v on line 154
in the definition for find_working_diff_command()

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
