### PR TITLE
Implement generic break_if_debugger_attached

### DIFF
--- a/vlib/builtin/builtin_nix.c.v
+++ b/vlib/builtin/builtin_nix.c.v
@@ -123,4 +123,8 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 }
 
 fn break_if_debugger_attached() {
+	unsafe {
+		ptr := &voidptr(0)
+		*ptr = 0
+	}
 }


### PR DESCRIPTION
In case of assert. there was no way to stop the debugger on UNIX systems. with this change, the compiler will break in that specific place. and without debugger it will segfault.

Actually on unix there's no generic way to detect if it's being debugged (we can use ptrace but will require more fine grained implementation). for simplicity i think that this behaviour is fine)