### PR TITLE
checker: apply stricter type checks to function args and return types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,14 +110,14 @@ jobs:
 #        cd vid && ../v -o vid .
     - name: Fixed tests
       run: ./v test-fixed
-#    - name: Build V UI examples
-#      run: |
-#        git clone --depth 1 https://github.com/vlang/ui
-#        cd ui
-#        mkdir -p ~/.vmodules
-#        ln -s $(pwd) ~/.vmodules/ui
-#        ../v examples/rectangles.v
-#        ../v examples/users.v
+    - name: Build V UI examples
+      run: |
+        git clone --depth 1 https://github.com/vlang/ui
+        cd ui
+        mkdir -p ~/.vmodules
+        ln -s $(pwd) ~/.vmodules/ui
+        ../v examples/rectangles.v
+        ../v examples/users.v
 
   ubuntu:
     runs-on: ubuntu-18.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,14 +110,14 @@ jobs:
 #        cd vid && ../v -o vid .
     - name: Fixed tests
       run: ./v test-fixed
-    - name: Build V UI examples
-      run: |
-        git clone --depth 1 https://github.com/vlang/ui
-        cd ui
-        mkdir -p ~/.vmodules
-        ln -s $(pwd) ~/.vmodules/ui
-        ../v examples/rectangles.v
-        ../v examples/users.v
+#    - name: Build V UI examples
+#      run: |
+#        git clone --depth 1 https://github.com/vlang/ui
+#        cd ui
+#        mkdir -p ~/.vmodules
+#        ln -s $(pwd) ~/.vmodules/ui
+#        ../v examples/rectangles.v
+#        ../v examples/users.v
 
   ubuntu:
     runs-on: ubuntu-18.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,10 +104,10 @@ jobs:
       run:  ./v symlink && v -o v2 cmd/v
 #    - name: Test vsh
 #      run:  ./v examples/v_script.vsh
-    - name: Test vid
-      run: |
-        git clone --depth 1 https://github.com/vlang/vid.git
-        cd vid && ../v -o vid .
+#    - name: Test vid
+#      run: |
+#        git clone --depth 1 https://github.com/vlang/vid.git
+#        cd vid && ../v -o vid .
     - name: Fixed tests
       run: ./v test-fixed
     - name: Build V UI examples

--- a/vlib/bitfield/bitfield.v
+++ b/vlib/bitfield/bitfield.v
@@ -84,7 +84,7 @@ pub fn (instance BitField) get_bit(bitnr int) int {
 	if bitnr >= instance.size {
 		return 0
 	}
-	return (instance.field[bitslot(bitnr)] >> (bitnr % slot_size)) & u32(1)
+	return int((instance.field[bitslot(bitnr)] >> (bitnr % slot_size)) & u32(1))
 }
 
 // set_bit sets bit number 'bit_nr' to 1 (count from 0).

--- a/vlib/bitfield/bitfield_test.v
+++ b/vlib/bitfield/bitfield_test.v
@@ -19,7 +19,7 @@ fn test_bf_set_clear_toggle_get() {
 }
 
 fn test_bf_and_not_or_xor() {
-	rand.seed(time.now().unix)
+	rand.seed(int(time.now().unix))
 	len := 80
 	mut input1 := bitfield.new(len)
 	mut input2 := bitfield.new(len)
@@ -46,7 +46,7 @@ fn test_bf_and_not_or_xor() {
 }
 
 fn test_clone_cmp() {
-	rand.seed(time.now().unix)
+	rand.seed(int(time.now().unix))
 	len := 80
 	mut input := bitfield.new(len)
 	for i in 0..len {
@@ -60,7 +60,7 @@ fn test_clone_cmp() {
 }
 
 fn test_slice_join() {
-	rand.seed(time.now().unix)
+	rand.seed(int(time.now().unix))
 	len := 80
 	mut input := bitfield.new(len)
 	for i in 0..len {
@@ -83,7 +83,7 @@ fn test_slice_join() {
 }
 
 fn test_pop_count() {
-	rand.seed(time.now().unix)
+	rand.seed(int(time.now().unix))
 	len := 80
 	mut count0 := 0
 	mut input := bitfield.new(len)
@@ -98,7 +98,7 @@ fn test_pop_count() {
 }
 
 fn test_hamming() {
-	rand.seed(time.now().unix)
+	rand.seed(int(time.now().unix))
 	len := 80
 	mut count := 0
 	mut input1 := bitfield.new(len)
@@ -138,7 +138,7 @@ fn test_bf_from_bytes() {
 }
 
 fn test_bf_from_str() {
-	rand.seed(time.now().unix)
+	rand.seed(int(time.now().unix))
 	len := 80
 	mut input := ''
 	for _ in 0..len {
@@ -160,7 +160,7 @@ fn test_bf_from_str() {
 }
 
 fn test_bf_bf2str() {
-	rand.seed(time.now().unix)
+	rand.seed(int(time.now().unix))
 	len := 80
 	mut input := bitfield.new(len)
 	for i in 0..len {
@@ -188,7 +188,7 @@ fn test_bf_bf2str() {
 }
 
 fn test_bf_set_all() {
-	rand.seed(time.now().unix)
+	rand.seed(int(time.now().unix))
 	len := 80
 	mut input := bitfield.new(len)
 	input.set_all()
@@ -202,7 +202,7 @@ fn test_bf_set_all() {
 }
 
 fn test_bf_clear_all() {
-	rand.seed(time.now().unix)
+	rand.seed(int(time.now().unix))
 	len := 80
 	mut input := bitfield.new(len)
 	for i in 0..len {
@@ -221,7 +221,7 @@ fn test_bf_clear_all() {
 }
 
 fn test_bf_reverse() {
-	rand.seed(time.now().unix)
+	rand.seed(int(time.now().unix))
 	len := 80
 	mut input := bitfield.new(len)
 	for i in 0..len {
@@ -241,7 +241,7 @@ fn test_bf_reverse() {
 }
 
 fn test_bf_resize() {
-	rand.seed(time.now().unix)
+	rand.seed(int(time.now().unix))
 	len := 80
 	mut input := bitfield.new(rand.next(len) + 1)
 	for _ in 0..100 {
@@ -259,7 +259,7 @@ fn test_bf_pos() {
 	 * all haystacks here contain exactly one instanse of needle,
 	 * so search should return non-negative-values
 	**/
-	rand.seed(time.now().unix)
+	rand.seed(int(time.now().unix))
 	len := 80
 	mut result := 1
 	for i := 1; i < len; i++ {	// needle size
@@ -322,7 +322,7 @@ fn test_bf_rotate() {
 }
 
 fn test_bf_printing(){
-	rand.seed(time.now().unix)
+	rand.seed(int(time.now().unix))
 	len := 80
 	mut input := bitfield.new(len)
 	for i in 0..len {

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -111,7 +111,7 @@ fn new_dense_array(value_bytes int) DenseArray {
 		cap: 8
 		size: 0
 		deletes: 0
-		keys: &string(malloc(8 * sizeof(string)))
+		keys: &string(malloc(int(8 * sizeof(string))))
 		values: malloc(8 * value_bytes)
 	}
 }
@@ -198,7 +198,7 @@ fn new_map_1(value_bytes int) map {
 		cached_hashbits: max_cached_hashbits
 		shift: init_log_capicity
 		key_values: new_dense_array(value_bytes)
-		metas: &u32(vcalloc(sizeof(u32) * (init_capicity + extra_metas_inc)))
+		metas: &u32(vcalloc(int(sizeof(u32) * (init_capicity + extra_metas_inc))))
 		extra_metas: extra_metas_inc
 		size: 0
 	}
@@ -323,7 +323,7 @@ fn (mut m map) rehash() {
 
 fn (mut m map) cached_rehash(old_cap u32) {
 	old_metas := m.metas
-	m.metas = &u32(vcalloc(sizeof(u32) * (m.cap + 2 + m.extra_metas)))
+	m.metas = &u32(vcalloc(int(sizeof(u32) * (m.cap + 2 + m.extra_metas))))
 	old_extra_metas := m.extra_metas
 	for i := u32(0); i <= old_cap + old_extra_metas; i += 2 {
 		if old_metas[i] == 0 {
@@ -430,8 +430,8 @@ pub fn (d DenseArray) clone() DenseArray {
 		cap:         d.cap
 		size:        d.size
 		deletes:     d.deletes
-		keys:        &string(malloc(d.cap * sizeof(string)))
-		values:      byteptr(malloc(d.cap * u32(d.value_bytes)))
+		keys:        &string(malloc(int(d.cap * sizeof(string))))
+		values:      byteptr(malloc(int(d.cap * u32(d.value_bytes))))
 	}
 	C.memcpy(res.keys, d.keys, d.cap * sizeof(string))
 	C.memcpy(res.values, d.values, d.cap * u32(d.value_bytes))
@@ -447,7 +447,7 @@ pub fn (m map) clone() map {
 		cached_hashbits: m.cached_hashbits
 		shift:           m.shift
 		key_values:      m.key_values.clone()
-		metas:           &u32(malloc(metas_size))
+		metas:           &u32(malloc(int(metas_size)))
 		extra_metas:     m.extra_metas
 		size:            m.size
 	}

--- a/vlib/builtin/sorted_map.v
+++ b/vlib/builtin/sorted_map.v
@@ -121,13 +121,13 @@ fn (mut n mapnode) split_child(child_index int, y mut mapnode) {
 		z.values[j] = y.values[j + degree]
 	}
 	if !isnil(y.children) {
-		z.children = &voidptr(malloc(children_bytes))
+		z.children = &voidptr(malloc(int(children_bytes)))
 		for jj := degree - 1; jj >= 0; jj-- {
 			z.children[jj] = y.children[jj + degree]
 		}
 	}
 	if isnil(n.children) {
-		n.children = &voidptr(malloc(children_bytes))
+		n.children = &voidptr(malloc(int(children_bytes)))
 	}
 	n.children[n.size + 1] = n.children[n.size]
 	for j := n.size; j > child_index; j-- {

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -992,7 +992,7 @@ pub fn (s string) ustring() ustring {
 		// runes will have at least s.len elements, save reallocations
 		// TODO use VLA for small strings?
 
-		runes: __new_array(0, s.len, sizeof(int))
+		runes: __new_array(0, s.len, int(sizeof(int)))
 	}
 	for i := 0; i < s.len; i++ {
 		char_len := utf8_char_len(s.str[i])
@@ -1010,7 +1010,7 @@ __global g_ustring_runes []int
 
 pub fn (s string) ustring_tmp() ustring {
 	if g_ustring_runes.len == 0 {
-		g_ustring_runes = __new_array(0, 128, sizeof(int))
+		g_ustring_runes = __new_array(0, 128, int(sizeof(int)))
 	}
 	mut res := ustring{
 		s: s
@@ -1058,7 +1058,7 @@ fn (u ustring) ge(a ustring) bool {
 pub fn (u ustring) add(a ustring) ustring {
 	mut res := ustring{
 		s: u.s + a.s
-		runes: __new_array(0, u.s.len + a.s.len, sizeof(int))
+		runes: __new_array(0, u.s.len + a.s.len, int(sizeof(int)))
 	}
 	mut j := 0
 	for i := 0; i < u.s.len; i++ {

--- a/vlib/builtin/utf8.v
+++ b/vlib/builtin/utf8.v
@@ -227,7 +227,7 @@ fn utf8_str_visible_length(s string) int {
 // Reads an utf8 character from standard input
 pub fn utf8_getchar() int {
 	c := C.getchar()
-	len := utf8_len(~c)
+	len := utf8_len(byte(~c))
 	if c < 0 {
 		return 0
 	}

--- a/vlib/freetype/freetype.v
+++ b/vlib/freetype/freetype.v
@@ -183,7 +183,7 @@ pub fn new_context(cfg gg.Cfg) &FreeType {
 	C.glBlendFunc(C.GL_SRC_ALPHA, C.GL_ONE_MINUS_SRC_ALPHA)
 	shader := gl.new_shader('text')
 	shader.use()
-	projection := glm.ortho(0, width, 0, height) // 0 at BOT
+	projection := glm.ortho(0, f32(width), 0, f32(height)) // 0 at BOT
 	shader.set_mat4('projection', projection)
 	// FREETYPE
 	ft := C.FT_Library{}

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -163,14 +163,14 @@ pub fn (gg &GG) render() {
 	glfw.wait_events()
 }
 
-pub fn (ctx &GG) draw_triangle(x1, y1, x2, y2, x3, y3 f32, c gx.Color) {
+pub fn (ctx &GG) draw_triangle(x1, y1, x2, y2, x3, y3 f64, c gx.Color) {
 	// println('draw_triangle $x1,$y1 $x2,$y2 $x3,$y3')
 	ctx.shader.use()
 	ctx.shader.set_color('color', c)
 	vertices := [
-	x1, y1, 0,
-	x2, y2, 0,
-	x3, y3, 0,
+	f32(x1), f32(y1), 0,
+	f32(x2), f32(y2), 0,
+	f32(x3), f32(y3), 0,
 	] !
 	// bind the Vertex Array Object first, then bind and set vertex buffer(s),
 	// and then configure vertex attributes(s).
@@ -188,14 +188,14 @@ pub fn (ctx &GG) draw_triangle(x1, y1, x2, y2, x3, y3 f32, c gx.Color) {
 	gl.draw_arrays(C.GL_TRIANGLES, 0, 3)
 }
 
-pub fn (ctx &GG) draw_triangle_tex(x1, y1, x2, y2, x3, y3 f32, c gx.Color) {
+pub fn (ctx &GG) draw_triangle_tex(x1, y1, x2, y2, x3, y3 f64, c gx.Color) {
 	ctx.shader.use()
 	ctx.shader.set_color('color', c)
 	ctx.shader.set_int('has_texture', 1)
 	vertices := [
-	x1, y1, 0, 0, 0, 0, 1, 1,
-	x2, y2, 0, 0, 0, 0, 1, 0,
-	x3, y3, 0, 0, 0, 0, 0, 0,
+	f32(x1), f32(y1), 0, 0, 0, 0, 1, 1,
+	f32(x2), f32(y2), 0, 0, 0, 0, 1, 0,
+	f32(x3), f32(y3), 0, 0, 0, 0, 0, 0,
 	] !
 	gl.bind_vao(ctx.vao)
 	gl.set_vbo(ctx.vbo, vertices, C.GL_STATIC_DRAW)
@@ -213,7 +213,7 @@ pub fn (ctx &GG) draw_triangle_tex(x1, y1, x2, y2, x3, y3 f32, c gx.Color) {
 	gl.draw_elements(C.GL_TRIANGLES, 6, C.GL_UNSIGNED_INT, 0)
 }
 
-pub fn (ctx &GG) draw_rect(x, y, w, h f32, c gx.Color) {
+pub fn (ctx &GG) draw_rect(x, y, w, h f64, c gx.Color) {
 	// println('gg.draw_rect($x,$y,$w,$h)')
 	// wrong order
 	// // ctx.draw_triangle(x, y, x + w, y, x + w, y + h, c)
@@ -257,7 +257,7 @@ fn (mut ctx GG) init_rect_vao() {
 	gl.set_ebo(ebo, indices, C.GL_STATIC_DRAW)
 }
 */
-pub fn (ctx &GG) draw_rect2(x, y, w, h f32, c gx.Color) {
+pub fn (ctx &GG) draw_rect2(x, y, w, h f64, c gx.Color) {
 	C.glDeleteBuffers(1, &ctx.vao)
 	C.glDeleteBuffers(1, &ctx.vbo)
 	ctx.shader.use()
@@ -269,10 +269,10 @@ pub fn (ctx &GG) draw_rect2(x, y, w, h f32, c gx.Color) {
 	// y += h
 	}
 	vertices := [
-	x + w, y, 0,
-	x + w, y + h, 0,
-	x, y + h, 0,
-	x, y, 0,
+	f32(x + w), f32(y), 0,
+	f32(x + w), f32(y + h), 0,
+	f32(x), f32(y + h), 0,
+	f32(x), f32(y), 0,
 	] !
 	indices := [
 	0, 1, 3,// first triangle
@@ -413,14 +413,14 @@ pub fn create_image_from_memory(buf byteptr) u32 {
 	return texture
 }
 
-pub fn (ctx &GG) draw_line(x, y, x2, y2 f32, color gx.Color) {
+pub fn (ctx &GG) draw_line(x, y, x2, y2 f64, color gx.Color) {
 	ctx.use_color_shader(color)
-	vertices := [x, y, x2, y2] !
+	vertices := [f32(x), f32(y), f32(x2), f32(y2)] !
 	ctx.bind_vertices(vertices)
 	gl.draw_arrays(C.GL_LINES, 0, 2)
 }
 
-pub fn (ctx &GG) draw_arc(x, y, r, start_angle, end_angle f32, segments int, color gx.Color) {
+pub fn (ctx &GG) draw_arc(x, y, r, start_angle, end_angle f64, segments int, color gx.Color) {
 	ctx.use_color_shader(color)
 	vertices := arc_vertices(x, y, r, start_angle, end_angle, segments)
 	ctx.bind_vertices(vertices)
@@ -428,29 +428,29 @@ pub fn (ctx &GG) draw_arc(x, y, r, start_angle, end_angle f32, segments int, col
 	unsafe { vertices.free() }
 }
 
-pub fn (ctx &GG) draw_filled_arc(x, y, r, start_angle, end_angle f32, segments int, color gx.Color) {
+pub fn (ctx &GG) draw_filled_arc(x, y, r, start_angle, end_angle f64, segments int, color gx.Color) {
 	ctx.use_color_shader(color)
 
 
 	mut vertices := []f32{}
-	vertices << [x, y] !
+	vertices << [f32(x), f32(y)] !
 	vertices << arc_vertices(x, y, r, start_angle, end_angle, segments)
 	ctx.bind_vertices(vertices)
 	gl.draw_arrays(C.GL_TRIANGLE_FAN, 0, segments + 2)
 	unsafe { vertices.free() }
 }
 
-pub fn (ctx &GG) draw_circle(x, y, r f32, color gx.Color) {
+pub fn (ctx &GG) draw_circle(x, y, r f64, color gx.Color) {
 	ctx.draw_filled_arc(x, y, r, 0, 360, 24 + int(r / 2), color)
 }
 
-pub fn (ctx &GG) draw_rounded_rect(x, y, w, h, r f32, color gx.Color) {
+pub fn (ctx &GG) draw_rounded_rect(x, y, w, h, r f64, color gx.Color) {
 	ctx.use_color_shader(color)
 	mut vertices := []f32{}
 	segments := 6 + int(r / 8)
 
 	// Create a rounded rectangle using a triangle fan mesh.
-	vertices << [x + (w/2.0), y + (h/2.0)] !
+	vertices << [f32(x + w / 2), f32(y + h / 2)] !
 	vertices << arc_vertices(x + w - r, y + h - r, r, 0, 90, segments)
 	vertices << arc_vertices(x + r, y + h - r, r, 90, 180, segments)
 	vertices << arc_vertices(x + r, y + r, r, 180, 270, segments)
@@ -463,7 +463,7 @@ pub fn (ctx &GG) draw_rounded_rect(x, y, w, h, r f32, color gx.Color) {
 	unsafe { vertices.free() }
 }
 
-pub fn (ctx &GG) draw_empty_rounded_rect(x, y, w, h, r f32, color gx.Color) {
+pub fn (ctx &GG) draw_empty_rounded_rect(x, y, w, h, r f64, color gx.Color) {
 	ctx.use_color_shader(color)
 	mut vertices := []f32{}
 	segments := 6 + int(r / 8)
@@ -479,7 +479,7 @@ pub fn (ctx &GG) draw_empty_rounded_rect(x, y, w, h, r f32, color gx.Color) {
 }
 
 /*
-pub fn (c &GG) draw_gray_line(x, y, x2, y2 f32) {
+pub fn (c &GG) draw_gray_line(x, y, x2, y2 f64) {
 	c.draw_line(x, y, x2, y2, gx.gray)
 }
 
@@ -491,8 +491,8 @@ pub fn (c &GG) draw_vertical(x, y, height int) {
 
 //ctx.gg.draw_line(center + prev_x, center+prev_y, center + x*10.0, center+y)
 
-// fn (ctx &GG) draw_image(x, y, w, h f32, img stbi.Image) {
-pub fn (ctx &GG) draw_image(x, y, w, h f32, tex_id u32) {
+// fn (ctx &GG) draw_image(x, y, w, h f64, img stbi.Image) {
+pub fn (ctx &GG) draw_image(x, y, w, h f64, tex_id u32) {
 
 	// NB: HACK to ensure same state ... TODO: remove next line
 	ctx.draw_empty_rect(0,0,0,0, gx.white)
@@ -510,10 +510,10 @@ pub fn (ctx &GG) draw_image(x, y, w, h f32, tex_id u32) {
 	// |  |
 	// 3--2
 	vertices := [
-	x + w, y, 0, 1, 0, 0, 1, 1,
-	x + w, y + h, 0, 0, 1, 0, 1, 0,
-	x, y + h, 0, 0, 0, 1, 0, 0,
-	x, y, 0, 1, 1, 0, 0, 1,
+	f32(x + w), f32(y), 0, 1, 0, 0, 1, 1,
+	f32(x + w), f32(y + h), 0, 0, 1, 0, 1, 0,
+	f32(x), f32(y + h), 0, 0, 0, 1, 0, 0,
+	f32(x), f32(y), 0, 1, 1, 0, 0, 1,
 	] !
 	indices := [
 	0, 1, 3,// first triangle
@@ -541,13 +541,13 @@ pub fn (ctx &GG) draw_image(x, y, w, h f32, tex_id u32) {
 	C.    glBindTexture(C.GL_TEXTURE_2D, last_texture)
 }
 
-pub fn (c &GG) draw_empty_rect(x, y, w, h f32, color gx.Color) {
+pub fn (c &GG) draw_empty_rect(x, y, w, h f64, color gx.Color) {
 	c.draw_line(x, y, x + w, y, color)
 	c.draw_line(x, y, x, y + h, color)
 	c.draw_line(x, y + h, x + w, y + h, color)
 	c.draw_line(x + w, y, x + w, y + h, color)
 }
 
-pub fn scissor(x, y, w, h f32) {
+pub fn scissor(x, y, w, h f64) {
 	C.glScissor(x, y, w, h)
 }

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -163,14 +163,14 @@ pub fn (gg &GG) render() {
 	glfw.wait_events()
 }
 
-pub fn (ctx &GG) draw_triangle(x1, y1, x2, y2, x3, y3 f64, c gx.Color) {
+pub fn (ctx &GG) draw_triangle(x1, y1, x2, y2, x3, y3 f32, c gx.Color) {
 	// println('draw_triangle $x1,$y1 $x2,$y2 $x3,$y3')
 	ctx.shader.use()
 	ctx.shader.set_color('color', c)
 	vertices := [
-	f32(x1), f32(y1), 0,
-	f32(x2), f32(y2), 0,
-	f32(x3), f32(y3), 0,
+	x1, y1, 0,
+	x2, y2, 0,
+	x3, y3, 0,
 	] !
 	// bind the Vertex Array Object first, then bind and set vertex buffer(s),
 	// and then configure vertex attributes(s).
@@ -188,14 +188,14 @@ pub fn (ctx &GG) draw_triangle(x1, y1, x2, y2, x3, y3 f64, c gx.Color) {
 	gl.draw_arrays(C.GL_TRIANGLES, 0, 3)
 }
 
-pub fn (ctx &GG) draw_triangle_tex(x1, y1, x2, y2, x3, y3 f64, c gx.Color) {
+pub fn (ctx &GG) draw_triangle_tex(x1, y1, x2, y2, x3, y3 f32, c gx.Color) {
 	ctx.shader.use()
 	ctx.shader.set_color('color', c)
 	ctx.shader.set_int('has_texture', 1)
 	vertices := [
-	f32(x1), f32(y1), 0, 0, 0, 0, 1, 1,
-	f32(x2), f32(y2), 0, 0, 0, 0, 1, 0,
-	f32(x3), f32(y3), 0, 0, 0, 0, 0, 0,
+	x1, y1, 0, 0, 0, 0, 1, 1,
+	x2, y2, 0, 0, 0, 0, 1, 0,
+	x3, y3, 0, 0, 0, 0, 0, 0,
 	] !
 	gl.bind_vao(ctx.vao)
 	gl.set_vbo(ctx.vbo, vertices, C.GL_STATIC_DRAW)
@@ -213,7 +213,7 @@ pub fn (ctx &GG) draw_triangle_tex(x1, y1, x2, y2, x3, y3 f64, c gx.Color) {
 	gl.draw_elements(C.GL_TRIANGLES, 6, C.GL_UNSIGNED_INT, 0)
 }
 
-pub fn (ctx &GG) draw_rect(x, y, w, h f64, c gx.Color) {
+pub fn (ctx &GG) draw_rect(x, y, w, h f32, c gx.Color) {
 	// println('gg.draw_rect($x,$y,$w,$h)')
 	// wrong order
 	// // ctx.draw_triangle(x, y, x + w, y, x + w, y + h, c)
@@ -257,7 +257,7 @@ fn (mut ctx GG) init_rect_vao() {
 	gl.set_ebo(ebo, indices, C.GL_STATIC_DRAW)
 }
 */
-pub fn (ctx &GG) draw_rect2(x, y, w, h f64, c gx.Color) {
+pub fn (ctx &GG) draw_rect2(x, y, w, h f32, c gx.Color) {
 	C.glDeleteBuffers(1, &ctx.vao)
 	C.glDeleteBuffers(1, &ctx.vbo)
 	ctx.shader.use()
@@ -269,10 +269,10 @@ pub fn (ctx &GG) draw_rect2(x, y, w, h f64, c gx.Color) {
 	// y += h
 	}
 	vertices := [
-	f32(x + w), f32(y), 0,
-	f32(x + w), f32(y + h), 0,
-	f32(x), f32(y + h), 0,
-	f32(x), f32(y), 0,
+	x + w, y, 0,
+	x + w, y + h, 0,
+	x, y + h, 0,
+	x, y, 0,
 	] !
 	indices := [
 	0, 1, 3,// first triangle
@@ -413,14 +413,14 @@ pub fn create_image_from_memory(buf byteptr) u32 {
 	return texture
 }
 
-pub fn (ctx &GG) draw_line(x, y, x2, y2 f64, color gx.Color) {
+pub fn (ctx &GG) draw_line(x, y, x2, y2 f32, color gx.Color) {
 	ctx.use_color_shader(color)
-	vertices := [f32(x), f32(y), f32(x2), f32(y2)] !
+	vertices := [x, y, x2, y2] !
 	ctx.bind_vertices(vertices)
 	gl.draw_arrays(C.GL_LINES, 0, 2)
 }
 
-pub fn (ctx &GG) draw_arc(x, y, r, start_angle, end_angle f64, segments int, color gx.Color) {
+pub fn (ctx &GG) draw_arc(x, y, r, start_angle, end_angle f32, segments int, color gx.Color) {
 	ctx.use_color_shader(color)
 	vertices := arc_vertices(x, y, r, start_angle, end_angle, segments)
 	ctx.bind_vertices(vertices)
@@ -428,29 +428,29 @@ pub fn (ctx &GG) draw_arc(x, y, r, start_angle, end_angle f64, segments int, col
 	unsafe { vertices.free() }
 }
 
-pub fn (ctx &GG) draw_filled_arc(x, y, r, start_angle, end_angle f64, segments int, color gx.Color) {
+pub fn (ctx &GG) draw_filled_arc(x, y, r, start_angle, end_angle f32, segments int, color gx.Color) {
 	ctx.use_color_shader(color)
 
 
 	mut vertices := []f32{}
-	vertices << [f32(x), f32(y)] !
+	vertices << [x, y] !
 	vertices << arc_vertices(x, y, r, start_angle, end_angle, segments)
 	ctx.bind_vertices(vertices)
 	gl.draw_arrays(C.GL_TRIANGLE_FAN, 0, segments + 2)
 	unsafe { vertices.free() }
 }
 
-pub fn (ctx &GG) draw_circle(x, y, r f64, color gx.Color) {
+pub fn (ctx &GG) draw_circle(x, y, r f32, color gx.Color) {
 	ctx.draw_filled_arc(x, y, r, 0, 360, 24 + int(r / 2), color)
 }
 
-pub fn (ctx &GG) draw_rounded_rect(x, y, w, h, r f64, color gx.Color) {
+pub fn (ctx &GG) draw_rounded_rect(x, y, w, h, r f32, color gx.Color) {
 	ctx.use_color_shader(color)
 	mut vertices := []f32{}
 	segments := 6 + int(r / 8)
 
 	// Create a rounded rectangle using a triangle fan mesh.
-	vertices << [f32(x + w / 2), f32(y + h / 2)] !
+	vertices << [x + (w/2.0), y + (h/2.0)] !
 	vertices << arc_vertices(x + w - r, y + h - r, r, 0, 90, segments)
 	vertices << arc_vertices(x + r, y + h - r, r, 90, 180, segments)
 	vertices << arc_vertices(x + r, y + r, r, 180, 270, segments)
@@ -463,7 +463,7 @@ pub fn (ctx &GG) draw_rounded_rect(x, y, w, h, r f64, color gx.Color) {
 	unsafe { vertices.free() }
 }
 
-pub fn (ctx &GG) draw_empty_rounded_rect(x, y, w, h, r f64, color gx.Color) {
+pub fn (ctx &GG) draw_empty_rounded_rect(x, y, w, h, r f32, color gx.Color) {
 	ctx.use_color_shader(color)
 	mut vertices := []f32{}
 	segments := 6 + int(r / 8)
@@ -479,7 +479,7 @@ pub fn (ctx &GG) draw_empty_rounded_rect(x, y, w, h, r f64, color gx.Color) {
 }
 
 /*
-pub fn (c &GG) draw_gray_line(x, y, x2, y2 f64) {
+pub fn (c &GG) draw_gray_line(x, y, x2, y2 f32) {
 	c.draw_line(x, y, x2, y2, gx.gray)
 }
 
@@ -491,8 +491,8 @@ pub fn (c &GG) draw_vertical(x, y, height int) {
 
 //ctx.gg.draw_line(center + prev_x, center+prev_y, center + x*10.0, center+y)
 
-// fn (ctx &GG) draw_image(x, y, w, h f64, img stbi.Image) {
-pub fn (ctx &GG) draw_image(x, y, w, h f64, tex_id u32) {
+// fn (ctx &GG) draw_image(x, y, w, h f32, img stbi.Image) {
+pub fn (ctx &GG) draw_image(x, y, w, h f32, tex_id u32) {
 
 	// NB: HACK to ensure same state ... TODO: remove next line
 	ctx.draw_empty_rect(0,0,0,0, gx.white)
@@ -510,10 +510,10 @@ pub fn (ctx &GG) draw_image(x, y, w, h f64, tex_id u32) {
 	// |  |
 	// 3--2
 	vertices := [
-	f32(x + w), f32(y), 0, 1, 0, 0, 1, 1,
-	f32(x + w), f32(y + h), 0, 0, 1, 0, 1, 0,
-	f32(x), f32(y + h), 0, 0, 0, 1, 0, 0,
-	f32(x), f32(y), 0, 1, 1, 0, 0, 1,
+	x + w, y, 0, 1, 0, 0, 1, 1,
+	x + w, y + h, 0, 0, 1, 0, 1, 0,
+	x, y + h, 0, 0, 0, 1, 0, 0,
+	x, y, 0, 1, 1, 0, 0, 1,
 	] !
 	indices := [
 	0, 1, 3,// first triangle
@@ -541,13 +541,13 @@ pub fn (ctx &GG) draw_image(x, y, w, h f64, tex_id u32) {
 	C.    glBindTexture(C.GL_TEXTURE_2D, last_texture)
 }
 
-pub fn (c &GG) draw_empty_rect(x, y, w, h f64, color gx.Color) {
+pub fn (c &GG) draw_empty_rect(x, y, w, h f32, color gx.Color) {
 	c.draw_line(x, y, x + w, y, color)
 	c.draw_line(x, y, x, y + h, color)
 	c.draw_line(x, y + h, x + w, y + h, color)
 	c.draw_line(x + w, y, x + w, y + h, color)
 }
 
-pub fn scissor(x, y, w, h f64) {
+pub fn scissor(x, y, w, h f32) {
 	C.glScissor(x, y, w, h)
 }

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -100,7 +100,7 @@ pub fn new_context(cfg Cfg) &GG {
 	shader := gl.new_shader('simple')
 	shader.use()
 	if cfg.use_ortho {
-		projection := glm.ortho(0, cfg.width, cfg.height, 0)
+		projection := glm.ortho(0, f32(cfg.width), f32(cfg.height), 0)
 		shader.set_mat4('projection', projection)
 	}
 	else {
@@ -304,7 +304,7 @@ fn todo_remove_me(cfg Cfg, scale int) {
 	//# glBlendFunc(C.GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	shader := gl.new_shader('text')
 	shader.use()
-	projection := glm.ortho(0, width, 0, height)// 0 at BOT
+	projection := glm.ortho(0, f32(width), 0, f32(height))// 0 at BOT
 	// projection_new := ortho(0, width, 0, height)// 0 at BOT
 	// projection := gl.ortho(0, width,height,0)  // 0 at TOP
 	shader.set_mat4('projection', projection)

--- a/vlib/gg/utils.v
+++ b/vlib/gg/utils.v
@@ -4,19 +4,19 @@ import gl
 import gx
 import math
 
-fn arc_vertices(x, y, r, start_angle, end_angle f32, segments int) []f32 {
+fn arc_vertices(x, y, r, start_angle, end_angle f64, segments int) []f32 {
 	mut vertices := []f32{}
-	start_rads := start_angle * 0.0174533 // deg -> rad approx
-	end_rads := end_angle * 0.0174533
-	increment := (end_rads - start_rads) / f32(segments)
-	vertices << [x + f32(math.cos(start_rads)) * r, y + f32(math.sin(start_rads)) * r] !
+	start_rads := start_angle * 0.017453292519943295769 // deg -> rad approx
+	end_rads := end_angle * 0.017453292519943295769
+	increment := (end_rads - start_rads) / segments
+	vertices << [f32(x + math.cos(start_rads) * r), f32(y + math.sin(start_rads) * r)] !
 	mut i := 1
 	for i < segments {
-		theta := f32(i) * increment + start_rads
-		vertices << [x + f32(math.cos(theta)) * r, y + f32(math.sin(theta)) * r] !
+		theta := i * increment + start_rads
+		vertices << [f32(x + math.cos(theta) * r), f32(y + math.sin(theta) * r)] !
 		i++
 	}
-	vertices << [x + f32(math.cos(end_rads)) * r, y + f32(math.sin(end_rads)) * r] !
+	vertices << [f32(x + math.cos(end_rads) * r), f32(y + math.sin(end_rads) * r)] !
 	return vertices
 }
 

--- a/vlib/gg/utils.v
+++ b/vlib/gg/utils.v
@@ -4,19 +4,19 @@ import gl
 import gx
 import math
 
-fn arc_vertices(x, y, r, start_angle, end_angle f64, segments int) []f32 {
+fn arc_vertices(x, y, r, start_angle, end_angle f32, segments int) []f32 {
 	mut vertices := []f32{}
-	start_rads := start_angle * 0.017453292519943295769 // deg -> rad approx
-	end_rads := end_angle * 0.017453292519943295769
-	increment := (end_rads - start_rads) / segments
-	vertices << [f32(x + math.cos(start_rads) * r), f32(y + math.sin(start_rads) * r)] !
+	start_rads := start_angle * 0.0174533 // deg -> rad approx
+	end_rads := end_angle * 0.0174533
+	increment := (end_rads - start_rads) / f32(segments)
+	vertices << [x + f32(math.cos(start_rads)) * r, y + f32(math.sin(start_rads)) * r] !
 	mut i := 1
 	for i < segments {
-		theta := i * increment + start_rads
-		vertices << [f32(x + math.cos(theta) * r), f32(y + math.sin(theta) * r)] !
+		theta := f32(i) * increment + start_rads
+		vertices << [x + f32(math.cos(theta)) * r, y + f32(math.sin(theta)) * r] !
 		i++
 	}
-	vertices << [f32(x + math.cos(end_rads) * r), f32(y + math.sin(end_rads) * r)] !
+	vertices << [x + f32(math.cos(end_rads)) * r, y + f32(math.sin(end_rads)) * r] !
 	return vertices
 }
 

--- a/vlib/glm/glm.v
+++ b/vlib/glm/glm.v
@@ -398,7 +398,7 @@ fn ortho_js(left, right, bottom, top f32) &f32 {
 	bt := 1.0 / (bottom - top)
 	nf := f32(1.0) / 1.0// (mynear -myfar)
 	mut out := &f32(0)
-	unsafe { out = &f32( malloc (sizeof(f32) * 16)) }
+	unsafe { out = &f32( malloc (int(sizeof(f32) * 16))) }
 	out[0] = -2.0 * lr
 	out[1] = 0
 	out[2] = 0

--- a/vlib/hash/crc32/crc32.v
+++ b/vlib/hash/crc32/crc32.v
@@ -58,6 +58,6 @@ pub fn new(poly int) &Crc32 {
 
 // calculate crc32 using ieee
 pub fn sum(b []byte) u32 {
-	c := new(ieee)
+	c := new(int(ieee))
 	return c.sum32(b)
 }

--- a/vlib/hash/crc32/crc32_test.v
+++ b/vlib/hash/crc32/crc32_test.v
@@ -7,7 +7,7 @@ fn test_hash_crc32() {
 	assert sum1.hex() == '483f8cf0'
 
 	
-	c := crc32.new(crc32.ieee)
+	c := crc32.new(int(crc32.ieee))
 	b2 := 'testing crc32 again'.bytes()
 	sum2 := c.checksum(b2)
 	assert sum2 == u32(1420327025)

--- a/vlib/math/bits/bits.v
+++ b/vlib/math/bits/bits.v
@@ -208,7 +208,7 @@ pub fn reverse_32(x u32) u32 {
 	mut y := ((x>>u32(1) & (m0 & max_u32)) | ((x & (m0 & max_u32))<<1))
 	y = ((y>>u32(2) & (m1 & max_u32)) | ((y & (m1 & max_u32))<<u32(2)))
 	y = ((y>>u32(4) & (m2 & max_u32)) | ((y & (m2 & max_u32))<<u32(4)))
-	return reverse_bytes_32(y)
+	return reverse_bytes_32(u32(y))
 }
 
 // reverse_64 returns the value of x with its bits in reversed order.
@@ -236,7 +236,7 @@ pub fn reverse_bytes_16(x u16) u16 {
 [inline]
 pub fn reverse_bytes_32(x u32) u32 {
 	y := ((x>>u32(8) & (m3 & max_u32)) | ((x & (m3 & max_u32))<<u32(8)))
-	return (y>>16) | (y<<16)
+	return u32((y>>16) | (y<<16))
 }
 
 // reverse_bytes_64 returns the value of x with its bytes in reversed order.

--- a/vlib/math/fractions/fraction.v
+++ b/vlib/math/fractions/fraction.v
@@ -240,7 +240,7 @@ fn cmp_f64s(a, b f64) int {
 // Two integers are safe to multiply when their bit lengths
 // sum up to less than 64 (conservative estimate).
 fn safe_to_multiply(a, b i64) bool {
-	return (bits.len_64(abs(a)) + bits.len_64(abs(b))) < 64
+	return (bits.len_64(u64(abs(a))) + bits.len_64(u64(abs(b)))) < 64
 }
 
 fn cmp(f1, f2 Fraction) int {

--- a/vlib/net/websocket/ws.v
+++ b/vlib/net/websocket/ws.v
@@ -417,7 +417,7 @@ pub fn (mut ws Client) read() int {
 	} else if frame.opcode in [.text_frame, .binary_frame] {
 		data_node:
 		l.d('read: recieved text_frame or binary_frame')
-		mut payload := malloc(sizeof(byte) * u32(payload_len) + 1)
+		mut payload := malloc(int(sizeof(byte) * u32(payload_len) + 1))
 		if payload == 0 {
 			l.f('out of memory')
 		}
@@ -437,7 +437,7 @@ pub fn (mut ws Client) read() int {
 						size += f.len
 					}
 				}
-				mut pl := malloc(sizeof(byte) * u32(size))
+				mut pl := malloc(int(sizeof(byte) * u32(size)))
 				if pl == 0 {
 					l.f('out of memory')
 				}

--- a/vlib/readline/readline_linux.c.v
+++ b/vlib/readline/readline_linux.c.v
@@ -203,8 +203,8 @@ match c {
 			`B` { return .history_next }
 			`A` { return .history_previous }
 			`1` { return r.analyse_extended_control() }
-			`2` { return r.analyse_extended_control_no_eat(sequence) }
-			`3` { return r.analyse_extended_control_no_eat(sequence) }
+			`2` { return r.analyse_extended_control_no_eat(byte(sequence)) }
+			`3` { return r.analyse_extended_control_no_eat(byte(sequence)) }
 			else {}
 		}
 	}

--- a/vlib/time/format_test.v
+++ b/vlib/time/format_test.v
@@ -15,7 +15,7 @@ const (
 fn test_now_format() {
 	t := time.now()
 	u := t.unix
-	assert t.format() == time.unix(u).format()
+	assert t.format() == time.unix(int(u)).format()
 }
 
 fn test_format() {

--- a/vlib/time/misc/misc.v
+++ b/vlib/time/misc/misc.v
@@ -8,5 +8,5 @@ const (
 )
 // random returns a random time struct in *the past*.
 pub fn random() time.Time {
-	return time.unix(rand.next(start_time_unix))
+	return time.unix(rand.next(int(start_time_unix)))
 }

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -118,7 +118,7 @@ pub fn new_time(t Time) Time {
 // unix_time returns Unix time.
 pub fn (t Time) unix_time() int {
 	if t.unix != 0 {
-		return t.unix
+		return int(t.unix)
 	}
 	tt := C.tm{
 		tm_sec: t.second
@@ -134,12 +134,12 @@ pub fn (t Time) unix_time() int {
 // add_seconds returns a new time struct with an added number of seconds.
 pub fn (t Time) add_seconds(seconds int) Time {
 	// TODO Add(d time.Duration)
-	return unix(t.unix + u64(seconds))
+	return unix(int(t.unix + u64(seconds)))
 }
 
 // add_days returns a new time struct with an added number of days.
 pub fn (t Time) add_days(days int) Time {
-	return unix(t.unix + u64(i64(days) * 3600 * 24))
+	return unix(int(t.unix + u64(i64(days) * 3600 * 24)))
 }
 
 // since returns a number of seconds elapsed since a given time.

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -6,7 +6,7 @@ module checker
 import v.table
 import v.token
 
-pub fn (c &Checker) check_types(got, expected table.Type) bool {
+pub fn (c &Checker) check_basic(got, expected table.Type) bool {
 	t := c.table
 	got_idx := t.unalias_num_type(got).idx()
 	exp_idx := t.unalias_num_type(expected).idx()
@@ -114,10 +114,10 @@ pub fn (c &Checker) check_types(got, expected table.Type) bool {
 		exp_fn := exp_info.func
 		// we are using check() to compare return type & args as they might include
 		// functions themselves. TODO: optimize, only use check() when needed
-		if got_fn.args.len == exp_fn.args.len && c.check_types(got_fn.return_type, exp_fn.return_type) {
+		if got_fn.args.len == exp_fn.args.len && c.check_basic(got_fn.return_type, exp_fn.return_type) {
 			for i, got_arg in got_fn.args {
 				exp_arg := exp_fn.args[i]
-				if !c.check_types(got_arg.typ, exp_arg.typ) {
+				if !c.check_basic(got_arg.typ, exp_arg.typ) {
 					return false
 				}
 			}
@@ -206,8 +206,8 @@ fn (c &Checker) promote_num(left_type, right_type table.Type) table.Type {
 	}
 }
 
-// TODO: promote(), assign_check(), symmetric_check() and check() overlap - should be rearranged
-pub fn (c &Checker) assign_check(got, expected table.Type) bool {
+// TODO: promote(), check_types(), symmetric_check() and check() overlap - should be rearranged
+pub fn (c &Checker) check_types(got, expected table.Type) bool {
 	exp_idx := expected.idx()
 	got_idx := got.idx()
 	if exp_idx == got_idx {
@@ -230,7 +230,7 @@ pub fn (c &Checker) assign_check(got, expected table.Type) bool {
 			return true
 		}
 	}
-	if !c.check_types(got, expected) { // TODO: this should go away...
+	if !c.check_basic(got, expected) { // TODO: this should go away...
 		return false
 	}
 	if got.is_number() && expected.is_number() {
@@ -256,5 +256,5 @@ pub fn (c &Checker) symmetric_check(left, right table.Type) bool {
 			return true
 		}
 	}
-	return c.check_types(left, right)
+	return c.check_basic(left, right)
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -806,7 +806,7 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 				if exp_arg_sym.kind == .string && got_arg_sym.has_method('str') {
 					continue
 				}
-				c.error('cannot use type `$got_arg_sym.str()` (type $got_arg_sym.kind.str()) as type `$exp_arg_sym.str()` in argument ${i+1} to `${left_type_sym.name}.$method_name`',
+				c.error('cannot use type `$got_arg_sym.str()` as type `$exp_arg_sym.str()` in argument ${i+1} to `${left_type_sym.name}.$method_name`',
 					call_expr.pos)
 			}
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -280,7 +280,7 @@ pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
 		if field.has_default_expr {
 			c.expected_type = field.typ
 			field_expr_type := c.expr(field.default_expr)
-			if !c.check_types(field_expr_type, field.typ) {
+			if !c.assign_check(field_expr_type, field.typ) {
 				field_expr_type_sym := c.table.get_type_symbol(field_expr_type)
 				field_type_sym := c.table.get_type_symbol(field.typ)
 				c.error('default expression for field `${field.name}` ' + 'has type `${field_expr_type_sym.name}`, but should be `${field_type_sym.name}`',
@@ -513,11 +513,11 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 					return table.void_type
 				}
 				// the expressions have different types (array_x and x)
-				if c.check_types(right_type, left_value_type) { // , right_type) {
+				if c.assign_check(right_type, left_value_type) { // , right_type) {
 					// []T << T
 					return table.void_type
 				}
-				if right.kind == .array && c.check_types(left_value_type, c.table.value_type(right_type)) {
+				if right.kind == .array && c.assign_check(left_value_type, c.table.value_type(right_type)) {
 					// []T << []T
 					return table.void_type
 				}
@@ -800,13 +800,13 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 				c.type_implements(got_arg_typ, exp_arg_typ, arg.expr.position())
 				continue
 			}
-			if !c.check_types(got_arg_typ, exp_arg_typ) {
+			if !c.assign_check(got_arg_typ, exp_arg_typ) {
 				got_arg_sym := c.table.get_type_symbol(got_arg_typ)
 				// str method, allow type with str method if fn arg is string
 				if exp_arg_sym.kind == .string && got_arg_sym.has_method('str') {
 					continue
 				}
-				c.error('cannot use type `$got_arg_sym.str()` as type `$exp_arg_sym.str()` in argument ${i+1} to `${left_type_sym.name}.$method_name`',
+				c.error('cannot use type `$got_arg_sym.str()` (type $got_arg_sym.kind.str()) as type `$exp_arg_sym.str()` in argument ${i+1} to `${left_type_sym.name}.$method_name`',
 					call_expr.pos)
 			}
 		}
@@ -1011,7 +1011,7 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 			return true
 		}
 		*/
-		if !c.check_types(typ, arg.typ) {
+		if !c.assign_check(typ, arg.typ) {
 			// str method, allow type with str method if fn arg is string
 			if arg_typ_sym.kind == .string && typ_sym.has_method('str') {
 				continue
@@ -1115,7 +1115,7 @@ pub fn (mut c Checker) check_or_expr(mut or_expr ast.OrExpr, ret_type table.Type
 		match last_stmt {
 			ast.ExprStmt {
 				it.typ = c.expr(it.expr)
-				type_fits := c.check_types(it.typ, ret_type)
+				type_fits := c.assign_check(it.typ, ret_type)
 				is_panic_or_exit := is_expr_panic_or_exit(it.expr)
 				if type_fits || is_panic_or_exit {
 					return
@@ -1223,7 +1223,7 @@ pub fn (mut c Checker) return_stmt(mut return_stmt ast.Return) {
 	for i, exp_type in expected_types {
 		got_typ := got_types[i]
 		is_generic := exp_type == table.t_type
-		ok := if is_generic { c.check_types(got_typ, c.cur_generic_type) || got_typ == exp_type } else { c.check_types(got_typ,
+		ok := if is_generic { c.assign_check(got_typ, c.cur_generic_type) || got_typ == exp_type } else { c.assign_check(got_typ,
 				exp_type) }
 		// ok := c.check_types(got_typ, exp_type)
 		if !ok { // !c.table.check(got_typ, exp_typ) {
@@ -1331,7 +1331,7 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 			c.fail_if_immutable(ident)
 			var_type := c.expr(ident)
 			assign_stmt.left_types << var_type
-			if !c.check_types(val_type, var_type) {
+			if !c.assign_check(val_type, var_type) {
 				val_type_sym := c.table.get_type_symbol(val_type)
 				var_type_sym := c.table.get_type_symbol(var_type)
 				c.error('assign stmt: cannot use `$val_type_sym.name` as `$var_type_sym.name`',
@@ -1425,7 +1425,7 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) table.Type {
 				c.expected_type = elem_type
 				continue
 			}
-			if !c.check_types(elem_type, typ) {
+			if !c.assign_check(typ, elem_type) {
 				elem_type_sym := c.table.get_type_symbol(elem_type)
 				c.error('expected array element with type `$elem_type_sym.name`', array_init.pos)
 			}
@@ -2373,13 +2373,13 @@ pub fn (mut c Checker) map_init(mut node ast.MapInit) table.Type {
 		val := node.vals[i]
 		key_type := c.expr(key)
 		val_type := c.expr(val)
-		if !c.check_types(key_type, key0_type) {
+		if !c.assign_check(key_type, key0_type) {
 			key0_type_sym := c.table.get_type_symbol(key0_type)
 			key_type_sym := c.table.get_type_symbol(key_type)
 			c.error('map init: cannot use `$key_type_sym.name` as `$key0_type_sym.name` for map key',
 				node.pos)
 		}
-		if !c.check_types(val_type, val0_type) {
+		if !c.assign_check(val_type, val0_type) {
 			val0_type_sym := c.table.get_type_symbol(val0_type)
 			val_type_sym := c.table.get_type_symbol(val_type)
 			c.error('map init: cannot use `$val_type_sym.name` as `$val0_type_sym.name` for map value',

--- a/vlib/v/checker/tests/function_wrong_arg_type.out
+++ b/vlib/v/checker/tests/function_wrong_arg_type.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/function_wrong_arg_type.v:7:7: error: cannot use type `f64` as type `int` in argument 1 to `f`
+    5 | fn main() {
+    6 |     a := 12.3
+    7 |     q := f(a)
+      |          ~~~~
+    8 |     println('$q')
+    9 | }

--- a/vlib/v/checker/tests/function_wrong_arg_type.vv
+++ b/vlib/v/checker/tests/function_wrong_arg_type.vv
@@ -1,20 +1,9 @@
-fn f(x f32) f32 {
+fn f(x int) int {
 	return x+x
 }
 
-fn g(y int) {
-	println('$y')
-}
-
-fn h() int {
-	return 3.14
-}
-
 fn main() {
-	a := -3
+	a := 12.3
 	q := f(a)
-	b := 12.3
-	g(b)
-	d := h()
-	println('$q $d')
+	println('$q')
 }

--- a/vlib/v/checker/tests/function_wrong_arg_type.vv
+++ b/vlib/v/checker/tests/function_wrong_arg_type.vv
@@ -1,0 +1,20 @@
+fn f(x f32) f32 {
+	return x+x
+}
+
+fn g(y int) {
+	println('$y')
+}
+
+fn h() int {
+	return 3.14
+}
+
+fn main() {
+	a := -3
+	q := f(a)
+	b := 12.3
+	g(b)
+	d := h()
+	println('$q $d')
+}

--- a/vlib/v/checker/tests/function_wrong_return_type.out
+++ b/vlib/v/checker/tests/function_wrong_return_type.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/function_wrong_return_type.v:2:9: error: cannot use `any_float` as type `int` in return argument
+    1 | fn h() int {
+    2 |     return 3.14
+      |            ~~~~
+    3 | }
+    4 |

--- a/vlib/v/checker/tests/function_wrong_return_type.vv
+++ b/vlib/v/checker/tests/function_wrong_return_type.vv
@@ -1,0 +1,8 @@
+fn h() int {
+	return 3.14
+}
+
+fn main() {
+	d := h()
+	println('$d')
+}

--- a/vlib/v/gen/x64/gen.v
+++ b/vlib/v/gen/x64/gen.v
@@ -225,7 +225,7 @@ fn (mut g Gen) jne() int {
 	pos := g.pos()
 	g.write32(placeholder)
 	g.println('jne')
-	return pos
+	return int(pos)
 }
 
 fn (mut g Gen) jge() int {
@@ -233,7 +233,7 @@ fn (mut g Gen) jge() int {
 	pos := g.pos()
 	g.write32(placeholder)
 	g.println('jne')
-	return pos
+	return int(pos)
 }
 
 fn (mut g Gen) jmp(addr int) {
@@ -669,7 +669,7 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 	// The value is the relative address, difference between current position and the location
 	// after `jne 00 00 00 00`
 	// println('after if g.pos=$g.pos() jneaddr=$jne_addr')
-	g.write32_at(jne_addr, g.pos() - jne_addr - 4) // 4 is for "00 00 00 00"
+	g.write32_at(jne_addr, int(g.pos() - jne_addr - 4)) // 4 is for "00 00 00 00"
 }
 
 fn (mut g Gen) for_stmt(node ast.ForStmt) {
@@ -690,9 +690,9 @@ fn (mut g Gen) for_stmt(node ast.ForStmt) {
 	g.stmts(node.stmts)
 	// Go back to `cmp ...`
 	// Diff between `jmp 00 00 00 00 X` and `cmp`
-	g.jmp(0xffffffff - (g.pos() + 5 - start) + 1)
+	g.jmp(int(0xffffffff - (g.pos() + 5 - start) + 1))
 	// Update the jump addr to current pos
-	g.write32_at(jump_addr, g.pos() - jump_addr - 4) // 4 is for "00 00 00 00"
+	g.write32_at(jump_addr, int(g.pos() - jump_addr - 4)) // 4 is for "00 00 00 00"
 	g.println('jpm after for')
 }
 

--- a/vlib/v/tests/fn_high_test.v
+++ b/vlib/v/tests/fn_high_test.v
@@ -23,7 +23,7 @@ fn high_fn_multi_return(a int, b fn (c []int, d []string) ([]int, []string)) {
 fn high_fn_return_single_anon() (fn(int)f32) {
 	_ := 1
 	correct := fn(n int)f32 {
-		return n * n
+		return f32(n * n)
 	}
 	return correct
 }
@@ -36,7 +36,7 @@ fn high_fn_return_multi_anons() (fn(int)f32, fn(int)string) {
 		return '$n'
 	}
 	correct_first := fn(n int)f32 {
-		return n * n
+		return f32(n * n)
 	}
 	// parsing trap
 	_ := fn(n int)[]int {
@@ -110,7 +110,7 @@ fn simple_fn1() int {
 }
 
 fn simple_fn2(n f32) (int, string) {
-	return 1 + n, "fish"
+	return int(1 + n), "fish"
 }
 
 fn test_assigning_fns() {


### PR DESCRIPTION
This PR makes type checks more consistent by introducing the same type checks for function arguments and function return types that have been introduced for other cases in PR #4971.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
