### PR TITLE
cgen: fix lots of if expressions error (fix #5158)

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -517,8 +517,13 @@ pub fn (g Gen) save() {
 
 pub fn (mut g Gen) write(s string) {
 	if g.indent > 0 && g.empty_line {
-		g.out.write(tabs[g.indent])
-		// g.line_len += g.indent * 4
+		if g.indent < tabs.len {
+			g.out.write(tabs[g.indent])
+		} else {
+			for _ in 0 .. g.indent {
+				g.out.write('\t')
+			}
+		}
 	}
 	g.out.write(s)
 	g.empty_line = false
@@ -526,7 +531,13 @@ pub fn (mut g Gen) write(s string) {
 
 pub fn (mut g Gen) writeln(s string) {
 	if g.indent > 0 && g.empty_line {
-		g.out.write(tabs[g.indent])
+		if g.indent < tabs.len {
+			g.out.write(tabs[g.indent])
+		} else {
+			for _ in 0 .. g.indent {
+				g.out.write('\t')
+			}
+		}
 	}
 	g.out.writeln(s)
 	g.empty_line = true

--- a/vlib/v/tests/if_expression_test.v
+++ b/vlib/v/tests/if_expression_test.v
@@ -128,3 +128,31 @@ fn test_complex_nested_if_expressions() {
 	}
 	assert a == false
 }
+
+fn test_lots_of_if_expressions() {
+	mut a := 0
+	if true {
+		if true {
+			if true {
+				if true {
+					if true {
+						if true {
+							if true {
+								if true {
+									if true {
+										if true {
+											if true {
+												a = 1
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	assert a == 1
+}


### PR DESCRIPTION
This PR fix lots of if expressions error (fix #5158).

- Fix lots of if expressions error.
- Add test.

```v
fn main() {
	if true {
		if true {
			if true {
				if true {
					if true {
						if true {
							if true {
								if true {
									if true {
										if true {
											if true {
												println('hello')
											}
										}
									}
								}
							}
						}
					}
				}
			}
		}
	}
}

D:\test\v\tt1>v run .
hello
```