### PR TITLE
Makefile: optimize makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ a.out
 
 # ignore v build files
 /vc
+/tcc
 /v.c
 /v.*.c
 /v.c.out

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ a.out
 
 # ignore v build files
 /vc
-/tcc
 /v.c
 /v.*.c
 /v.c.out

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TMPDIR ?= /tmp
 
 VCFILE := v.c
 VC  := ./vc
-TCC := ./tcc
+TMPTCC := /var/tmp/tcc
 VCREPO := https://github.com/vlang/vc
 TCCREPO := https://github.com/vlang/tccbin
 GITCLEANPULL := git pull --quiet
@@ -80,25 +80,22 @@ endif
 fresh_vc:
 	$(GITFASTCLONE) $(VCREPO) $(VC)
 
-latest_tcc: $(TCC)/.git/config
+latest_tcc: $(TMPTCC)/.git/config
 ifndef ANDROID
 ifndef MAC
-ifndef local
-	cd $(TCC) && $(GITCLEANPULL)
-else
-	@echo "Using local tcc"
-endif
+	cd $(TMPTCC) && $(GITCLEANPULL)
 endif
 endif
 
 fresh_tcc:
 ifndef ANDROID
 ifndef MAC
-	$(GITFASTCLONE) $(TCCREPO) $(TCC)
+	rm -rf $(TMPTCC)
+	$(GITFASTCLONE) $(TCCREPO) $(TMPTCC)
 endif
 endif
 
-$(TCC)/.git/config:
+$(TMPTCC)/.git/config:
 ifndef MAC
 	$(MAKE) fresh_tcc
 endif

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VC  := ./vc
 TMPTCC := /var/tmp/tcc
 VCREPO := https://github.com/vlang/vc
 TCCREPO := https://github.com/vlang/tccbin
-GITCLEANPULL := git pull --quiet
+GITCLEANPULL := git clean -xf && git pull --quiet
 GITFASTCLONE := git clone --depth 1 --quiet
 
 #### Platform detections and overrides:
@@ -69,6 +69,13 @@ endif
 endif
 	@echo "V has been successfully built"
 	@./v -version
+
+#clean: clean_tmp
+#git clean -xf
+
+clean:
+	rm -rf $(TMPTCC)
+	rm -rf $(VC)
 
 latest_vc: $(VC)/.git/config
 ifndef local

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ CC ?= cc
 CFLAGS ?=
 LDFLAGS ?=
 TMPDIR ?= /tmp
+VC     ?= ./vc
 
 VCFILE := v.c
-VC  := ./vc
 TMPTCC := /var/tmp/tcc
 VCREPO := https://github.com/vlang/vc
 TCCREPO := https://github.com/vlang/tccbin
@@ -90,7 +90,11 @@ fresh_vc:
 latest_tcc: $(TMPTCC)/.git/config
 ifndef ANDROID
 ifndef MAC
+ifndef local
 	cd $(TMPTCC) && $(GITCLEANPULL)
+else
+	@echo "Using local tcc"
+endif    
 endif
 endif
 


### PR DESCRIPTION
This PR optimize Makefile.

- Keep `vc` in v root directory.
- Add `make local=1 prod=1` paras.

```v
yuyi@yuyi-PC:~/v$ make local=1 prod=1
Using local vc
Using local tcc
cc  -g -std=gnu11 -w -o v ./vc/v.c  -lm -lpthread
./v -prod self
V self compiling (-prod)...
make modules
make[1]: 进入目录“/home/yuyi/v”
#./v build module vlib/builtin > /dev/null
#./v build module vlib/strings > /dev/null
#./v build module vlib/strconv > /dev/null
make[1]: 离开目录“/home/yuyi/v”
V has been successfully built
V 0.1.27 63b2d4b
```

```v
yuyi@yuyi-PC:~/v$ make
cd ./vc && git pull --quiet
cd ./tcc && git pull --quiet
cc  -g -std=gnu11 -w -o v ./vc/v.c  -lm -lpthread
./v self
V self compiling ...
make modules
make[1]: 进入目录“/home/yuyi/v”
#./v build module vlib/builtin > /dev/null
#./v build module vlib/strings > /dev/null
#./v build module vlib/strconv > /dev/null
make[1]: 离开目录“/home/yuyi/v”
V has been successfully built
V 0.1.27 63b2d4b
```

Benefits:
- Avoid duplicate downloads.
- You can use the local `v.c` to compile.
- The default parameters are the same as the original.