### PR TITLE
cgen: fix multi dimensional array init error

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1212,6 +1212,7 @@ fn (mut g Gen) gen_default_init_value(val ast.Expr) (bool, bool) {
 			has_val = it.has_val
 			elem_type_str := g.typ(it.elem_type)
 			if it.has_default {
+				g.gen_default_init_value(it.default_expr)
 				g.write('$elem_type_str _val_$it.pos.pos = ')
 				g.expr(it.default_expr)
 				g.writeln(';')

--- a/vlib/v/tests/array_init_test.v
+++ b/vlib/v/tests/array_init_test.v
@@ -169,3 +169,14 @@ fn test_array_init_cast_type_in_struct_field() {
 	println(st)
 	assert st.a.str() == '[0, 0, 0, 0, 0]'
 }
+
+fn test_multi_dimensional_array_init() {
+	a := [][]int{len:2, init:[]int{len:4, init:2}}
+	assert '$a' == '[[2, 2, 2, 2], [2, 2, 2, 2]]'
+
+	b := [][]string{len:3, init:[]string{len:2, init:'abc'}}
+	assert '$b' == "[['abc', 'abc'], ['abc', 'abc'], ['abc', 'abc']]"
+
+	c := [][]f64{len:2, init:[]f64{len:2, init:2.2}}
+	assert '$c' == '[[2.2, 2.2], [2.2, 2.2]]'
+}


### PR DESCRIPTION
This PR fix multi dimensional array init error.

- Fix multi dimensional array init error.
- Add test `test_multi_dimensional_array_init` in array_init_test.v.

```v
fn test_multi_dimensional_array_init() {
	a := [][]int{len:2, init:[]int{len:4, init:2}}
	assert '$a' == '[[2, 2, 2, 2], [2, 2, 2, 2]]'

	b := [][]string{len:3, init:[]string{len:2, init:'abc'}}
	assert '$b' == "[['abc', 'abc'], ['abc', 'abc'], ['abc', 'abc']]"

	c := [][]f64{len:2, init:[]f64{len:2, init:2.2}}
	assert '$c' == '[[2.2, 2.2], [2.2, 2.2]]'
}
```