### PR TITLE
vfmt: Add -w flag to example command

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1463,7 +1463,7 @@ v fmt file.v
 It's recommended to set up your editor, so that vfmt runs on every save.
 A vfmt run is usually pretty cheap (takes <30ms).
 
-Always run `v fmt file.v` before pushing your code.
+Always run `v fmt -w file.v` before pushing your code.
 
 ## Writing Documentation
 


### PR DESCRIPTION
Include the `-w` flag to the example vfmt command so users know it's possible to overwrite the original file with the formatted output.