### PR TITLE
WIP: Add Interface string in interpolations

### DIFF
--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -150,6 +150,12 @@ pub fn (typ Type) is_float() bool {
 }
 
 [inline]
+pub fn (typ Type) is_interface(table Table) bool {
+	sym := table.get_type_symbol(typ)
+	return sym.info is Interface // typ.idx() in interface_type_idxs
+}
+
+[inline]
 pub fn (typ Type) is_int() bool {
 	return typ.idx() in integer_type_idxs
 }

--- a/vlib/v/tests/interface_test.v
+++ b/vlib/v/tests/interface_test.v
@@ -257,3 +257,16 @@ fn animal_match(a Animal) {
 	}
 }
 */
+
+struct Bar { }
+
+fn (b Bar)register() { }
+
+fn get_register() Register {
+	return Bar{}
+}
+
+fn test_interface_string() {
+	a := get_register()
+	assert('$a' == 'Register')
+}


### PR DESCRIPTION
This PR fixes two issues, one that i cannot find a small reproducer which causes this error:

`cgen error: could not generate string method XXX for type 'XXX'`

and the other one which is stringifying an interface like this:

```go
interface Foo {
	foo()
}

struct Bar {

}

fn (b Bar)foo() {
	println('$b')
}

fn get_foo() Foo {
	return Bar{}
}

fn main() {
	a := get_foo()
	assert('$a' == 'Foo')
}
```

for some reason the test is crashing, but putting the code in a main() works as expected. comments are welcome