### PR TITLE
REPL fix on BSD

### DIFF
--- a/vlib/readline/readline_dragonfly.c.v
+++ b/vlib/readline/readline_dragonfly.c.v
@@ -1,0 +1,71 @@
+// Copyright (c) 2019-2020 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+// Mac version
+// Need to be implemented
+// Will serve as more advanced input method
+// Based on the work of https://github.com/AmokHuginnsson/replxx
+
+module readline
+
+import os
+
+#include <termios.h>
+
+// Only use standard os.get_line
+// Need implementation for readline capabilities
+pub fn (mut r Readline) read_line_utf8(prompt string) ?ustring {
+  r.current = ''.ustring()
+  r.cursor = 0
+  r.prompt = prompt
+  r.search_index = 0
+  if r.previous_lines.len <= 1 {
+    r.previous_lines << ''.ustring()
+    r.previous_lines << ''.ustring()
+  }
+  else {
+    r.previous_lines[0] = ''.ustring()
+  }
+
+  print(r.prompt)
+  line := os.get_raw_line()
+
+  if line.len >= 0 {
+    r.current = line.ustring()
+  }
+  r.previous_lines[0] = ''.ustring()
+  r.search_index = 0
+  if r.current.s == '' {
+    return error('empty line')
+  }
+  return r.current
+}
+
+// Returns the string from the utf8 ustring
+pub fn (mut r Readline) read_line(prompt string) ?string {
+  s := r.read_line_utf8(prompt) or {
+    return error(err)
+  }
+  return s.s
+}
+
+// Standalone function without persistent functionnalities (eg: history)
+// Returns utf8 based ustring
+pub fn read_line_utf8(prompt string) ?ustring {
+  mut r := Readline{}
+  s := r.read_line_utf8(prompt) or {
+    return error(err)
+  }
+  return s
+}
+
+// Standalone function without persistent functionnalities (eg: history)
+// Return string from utf8 ustring
+pub fn read_line(prompt string) ?string {
+  mut r := Readline{}
+  s := r.read_line(prompt) or {
+    return error(err)
+  }
+  return s
+}

--- a/vlib/readline/readline_freebsd.c.v
+++ b/vlib/readline/readline_freebsd.c.v
@@ -1,0 +1,71 @@
+// Copyright (c) 2019-2020 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+// Mac version
+// Need to be implemented
+// Will serve as more advanced input method
+// Based on the work of https://github.com/AmokHuginnsson/replxx
+
+module readline
+
+import os
+
+#include <sys/termios.h>
+
+// Only use standard os.get_line
+// Need implementation for readline capabilities
+pub fn (mut r Readline) read_line_utf8(prompt string) ?ustring {
+  r.current = ''.ustring()
+  r.cursor = 0
+  r.prompt = prompt
+  r.search_index = 0
+  if r.previous_lines.len <= 1 {
+    r.previous_lines << ''.ustring()
+    r.previous_lines << ''.ustring()
+  }
+  else {
+    r.previous_lines[0] = ''.ustring()
+  }
+
+  print(r.prompt)
+  line := os.get_raw_line()
+
+  if line.len >= 0 {
+    r.current = line.ustring()
+  }
+  r.previous_lines[0] = ''.ustring()
+  r.search_index = 0
+  if r.current.s == '' {
+    return error('empty line')
+  }
+  return r.current
+}
+
+// Returns the string from the utf8 ustring
+pub fn (mut r Readline) read_line(prompt string) ?string {
+  s := r.read_line_utf8(prompt) or {
+    return error(err)
+  }
+  return s.s
+}
+
+// Standalone function without persistent functionnalities (eg: history)
+// Returns utf8 based ustring
+pub fn read_line_utf8(prompt string) ?ustring {
+  mut r := Readline{}
+  s := r.read_line_utf8(prompt) or {
+    return error(err)
+  }
+  return s
+}
+
+// Standalone function without persistent functionnalities (eg: history)
+// Return string from utf8 ustring
+pub fn read_line(prompt string) ?string {
+  mut r := Readline{}
+  s := r.read_line(prompt) or {
+    return error(err)
+  }
+  return s
+}

--- a/vlib/readline/readline_netbsd.c.v
+++ b/vlib/readline/readline_netbsd.c.v
@@ -1,0 +1,71 @@
+// Copyright (c) 2019-2020 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+// Mac version
+// Need to be implemented
+// Will serve as more advanced input method
+// Based on the work of https://github.com/AmokHuginnsson/replxx
+
+module readline
+
+import os
+
+#include <sys/termios.h>
+
+// Only use standard os.get_line
+// Need implementation for readline capabilities
+pub fn (mut r Readline) read_line_utf8(prompt string) ?ustring {
+  r.current = ''.ustring()
+  r.cursor = 0
+  r.prompt = prompt
+  r.search_index = 0
+  if r.previous_lines.len <= 1 {
+    r.previous_lines << ''.ustring()
+    r.previous_lines << ''.ustring()
+  }
+  else {
+    r.previous_lines[0] = ''.ustring()
+  }
+
+  print(r.prompt)
+  line := os.get_raw_line()
+
+  if line.len >= 0 {
+    r.current = line.ustring()
+  }
+  r.previous_lines[0] = ''.ustring()
+  r.search_index = 0
+  if r.current.s == '' {
+    return error('empty line')
+  }
+  return r.current
+}
+
+// Returns the string from the utf8 ustring
+pub fn (mut r Readline) read_line(prompt string) ?string {
+  s := r.read_line_utf8(prompt) or {
+    return error(err)
+  }
+  return s.s
+}
+
+// Standalone function without persistent functionnalities (eg: history)
+// Returns utf8 based ustring
+pub fn read_line_utf8(prompt string) ?ustring {
+  mut r := Readline{}
+  s := r.read_line_utf8(prompt) or {
+    return error(err)
+  }
+  return s
+}
+
+// Standalone function without persistent functionnalities (eg: history)
+// Return string from utf8 ustring
+pub fn read_line(prompt string) ?string {
+  mut r := Readline{}
+  s := r.read_line(prompt) or {
+    return error(err)
+  }
+  return s
+}

--- a/vlib/readline/readline_openbsd.c.v
+++ b/vlib/readline/readline_openbsd.c.v
@@ -1,0 +1,71 @@
+// Copyright (c) 2019-2020 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+// Mac version
+// Need to be implemented
+// Will serve as more advanced input method
+// Based on the work of https://github.com/AmokHuginnsson/replxx
+
+module readline
+
+import os
+
+#include <sys/termios.h>
+
+// Only use standard os.get_line
+// Need implementation for readline capabilities
+pub fn (mut r Readline) read_line_utf8(prompt string) ?ustring {
+  r.current = ''.ustring()
+  r.cursor = 0
+  r.prompt = prompt
+  r.search_index = 0
+  if r.previous_lines.len <= 1 {
+    r.previous_lines << ''.ustring()
+    r.previous_lines << ''.ustring()
+  }
+  else {
+    r.previous_lines[0] = ''.ustring()
+  }
+
+  print(r.prompt)
+  line := os.get_raw_line()
+
+  if line.len >= 0 {
+    r.current = line.ustring()
+  }
+  r.previous_lines[0] = ''.ustring()
+  r.search_index = 0
+  if r.current.s == '' {
+    return error('empty line')
+  }
+  return r.current
+}
+
+// Returns the string from the utf8 ustring
+pub fn (mut r Readline) read_line(prompt string) ?string {
+  s := r.read_line_utf8(prompt) or {
+    return error(err)
+  }
+  return s.s
+}
+
+// Standalone function without persistent functionnalities (eg: history)
+// Returns utf8 based ustring
+pub fn read_line_utf8(prompt string) ?ustring {
+  mut r := Readline{}
+  s := r.read_line_utf8(prompt) or {
+    return error(err)
+  }
+  return s
+}
+
+// Standalone function without persistent functionnalities (eg: history)
+// Return string from utf8 ustring
+pub fn read_line(prompt string) ?string {
+  mut r := Readline{}
+  s := r.read_line(prompt) or {
+    return error(err)
+  }
+  return s
+}

--- a/vlib/v/pref/should_compile.v
+++ b/vlib/v/pref/should_compile.v
@@ -60,6 +60,15 @@ pub fn (prefs &Preferences) should_compile_c(file string) bool {
 	if file.ends_with('_freebsd.c.v') && prefs.os != .freebsd {
 		return false
 	}
+	if file.ends_with('_openbsd.c.v') && prefs.os != .openbsd {
+		return false
+	}
+	if file.ends_with('_netbsd.c.v') && prefs.os != .netbsd {
+		return false
+	}
+	if file.ends_with('_dragonfly.c.v') && prefs.os != .dragonfly {
+		return false
+	}
 	if file.ends_with('_solaris.c.v') && prefs.os != .solaris {
 		return false
 	}


### PR DESCRIPTION
Adding the extra cases to should_compile_c() and copying the _solaris.c.v to _<platform>.c.v works as far as compiling the repl against readline, and doing simple assingment, prints and loops.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
