### PR TITLE
parser: fix function mutable argument error (fix #5123)

### DIFF
--- a/vlib/v/checker/tests/function_arg_mutable_err.out
+++ b/vlib/v/checker/tests/function_arg_mutable_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/function_arg_mutable_err.v:1:18: error: mutable arguments are only allowed for arrays, maps, and structs
+return values instead: `fn foo(n mut int) {` => `fn foo(n int) int {`
+    1 | fn mod_ptr(mut a int) {
+      |                  ~~~
+    2 |     a = 77
+    3 | }

--- a/vlib/v/checker/tests/function_arg_mutable_err.vv
+++ b/vlib/v/checker/tests/function_arg_mutable_err.vv
@@ -1,0 +1,8 @@
+fn mod_ptr(mut a int) {
+	a = 77
+}
+
+fn main() {
+  println('hello')
+}
+

--- a/vlib/v/checker/tests/mut_int.out
+++ b/vlib/v/checker/tests/mut_int.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/mut_int.v:1:12: error: mutable arguments are only allowed for arrays, maps, and structs
+vlib/v/checker/tests/mut_int.v:1:14: error: mutable arguments are only allowed for arrays, maps, and structs
 return values instead: `fn foo(n mut int) {` => `fn foo(n int) int {`
     1 | fn foo(mut x int) {
-      |            ^
+      |              ~~~
     2 | }
     3 |


### PR DESCRIPTION
This PR fix function mutable argument error (fix #5123).

- Fix function mutable argument error.
- Add test `function_arg_mutable_err.vv/out`.

```v
fn mod_ptr(mut a int) {
	a = 77
}

fn main() {
  println('hello')
}

D:\test\v\tt1>v run .
.\tt1.v:1:18: error: mutable arguments are only allowed for arrays, maps, and structs
return values instead: `fn foo(n mut int) {` => `fn foo(n int) int {` 
    1 | fn mod_ptr(mut a int) {
      |                  ~~~
    2 |     a = 77
    3 | }
```