### PR TITLE
cgen: optimize gen c code format

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2240,7 +2240,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 				}
 				*/
 				if need_wrapper {
-					g.write(', &($elem_type_str[]) { \n')
+					g.write(', &($elem_type_str[]) { ')
 				} else {
 					g.write(', &')
 				}
@@ -2292,7 +2292,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 				g.expr(node.left)
 				g.write(', ')
 				g.expr(node.index)
-				g.write(', &($elem_type_str[]) { \n')
+				g.write(', &($elem_type_str[]) { ')
 			} else {
 				/*
 				g.write('(*($elem_type_str*)map_get2(')

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -252,7 +252,13 @@ fn (mut g Gen) gen_fn_decl(it ast.FnDecl) {
 	if g.pref.is_prof {
 		g.profile_fn(it.name, is_main)
 	}
+	if is_main {
+		g.indent++
+	}
 	g.stmts(it.stmts)
+	if is_main {
+		g.indent--
+	}
 	// ////////////
 	if is_main {
 		if g.autofree {


### PR DESCRIPTION
This PR optimize gen c code format.

- Correct the main function indentation problem.
- Optimize `array_set` code in one line.
- Optimize `map_set` code in one line.

`fn main()`
```v
int wmain(int ___argc, wchar_t* ___argv[], wchar_t* ___envp[]){
	_vinit();
	Foo* f = (Foo*)memdup(&(Foo){	.size = ((u32)(0)),
	}, sizeof(Foo));
	println(Foo_str(*f, 0));
	return 0;
}
```
`array_set`
```v
	if (neg) {
		array_set(&buf, i, &(byte[]) { '-' });
		i++;
	}
```
`map_set`
```v
	for (int i = 0; i < n; i++) {
		map_set(&out, keys[i], ((byteptr)(values)) + i * value_bytes);
	}
```