### PR TITLE
fmt: fix ?void format error

### DIFF
--- a/vlib/v/fmt/tests/void_optional_keep.vv
+++ b/vlib/v/fmt/tests/void_optional_keep.vv
@@ -1,0 +1,9 @@
+fn tt() ? {
+	return error('error')
+}
+
+fn main() {
+	tt() or {
+		panic('$err')
+	}
+}

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -707,7 +707,11 @@ pub fn (table &Table) type_to_str(t Type) string {
 		res = strings.repeat(`&`, nr_muls) + res
 	}
 	if t.flag_is(.optional) {
-		res = '?' + res
+		if sym.kind == .void {
+			res = '?'
+		} else {
+			res = '?' + res
+		}
 	}
 	/*
 	if res.starts_with(cur_mod +'.') {


### PR DESCRIPTION
This PR fix ?void format error.

- Fix ?void format error.
- Add test `void_optional_keep.vv`.

```v
fn tt() ? {
	return error('error')
}

fn main() {
	tt() or {
		panic('$err')
	}
}
```