### PR TITLE
checker: fix return optional error (fix #5121)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1258,6 +1258,11 @@ pub fn (mut c Checker) return_stmt(mut return_stmt ast.Return) {
 	}
 	for i, exp_type in expected_types {
 		got_typ := got_types[i]
+		if got_typ.flag_is(.optional) &&
+			(!exp_type.flag_is(.optional) || c.table.type_to_str(got_typ) != c.table.type_to_str(exp_type)) {
+			pos := return_stmt.exprs[i].position()
+			c.error('cannot use `${c.table.type_to_str(got_typ)}` as type `${c.table.type_to_str(exp_type)}` in return argument', pos)
+		}
 		is_generic := exp_type == table.t_type
 		ok := if is_generic { c.check_types(got_typ, c.cur_generic_type) || got_typ == exp_type } else { c.check_types(got_typ,
 				exp_type) }

--- a/vlib/v/checker/tests/return_optional_err.out
+++ b/vlib/v/checker/tests/return_optional_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/return_optional_err.v:4:13: error: cannot use `?string` as type `string` in return argument
+    2 |
+    3 | fn my_func() string {
+    4 |   return os.read_file('/some/file/that/exists.txt') or {panic(err)}
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5 | }
+    6 |

--- a/vlib/v/checker/tests/return_optional_err.vv
+++ b/vlib/v/checker/tests/return_optional_err.vv
@@ -1,0 +1,10 @@
+import os
+
+fn my_func() string {
+  return os.read_file('/some/file/that/exists.txt') or {panic(err)}
+}
+
+fn main() {
+	aa := my_func()
+	println(aa)
+}


### PR DESCRIPTION
This PR fix return optional error (fix #5121).

- Fix return optional error.
- Add test `return_optional_err.vv/out`.

```v
D:\test\v\tt1>v run .
.\tt1.v:4:13: error: cannot use `?string` as type `string` in return argument 
    2 | 
    3 | fn my_func() string {
    4 |   return os.read_file('/some/file/that/exists.txt') or {panic(err)}
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    5 | }
    6 |
```
Not placed in the `table.check_types` because it affects other calls, `check_types` need to re-optimize.
