### PR TITLE
WIP: Initial support for string to enum

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1870,6 +1870,12 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 				type_name := c.table.type_to_str(it.expr_type)
 				c.error('cannot cast type `$type_name` to string, use `x.str()` instead', it.pos)
 			}
+			ts := c.table.get_type_symbol(it.typ)
+			if ts.kind == .enum_ && it.expr_type == table.string_type {
+				tn := c.table.type_to_str(it.typ)
+				c.error('todo: string to `$tn` enum', it.pos)
+				return it.typ
+			}
 			if it.expr_type == table.string_type {
 				mut error_msg := 'cannot cast a string'
 				if it.expr is ast.StringLiteral {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1872,7 +1872,16 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 			}
 			ts := c.table.get_type_symbol(it.typ)
 			if ts.kind == .enum_ && it.expr_type == table.string_type {
+				// Handle enum CastExpr from string
 				tn := c.table.type_to_str(it.typ)
+			    	ts = c.table.get_type_symbol(it.typ)
+				e := ts.info as table.Enum
+				if e.vals.len > 0 {
+					arg := e.vals[0]
+					eprintln('$tn "$arg"')
+				}
+c.call_fn(ce)
+//eprintln('$ts')
 				c.error('todo: string to `$tn` enum', it.pos)
 				return it.typ
 			}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -921,15 +921,56 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 				has_arg = true
 			}
 			p.check(.rpar)
-			node = ast.CastExpr{
-				typ: to_typ
-				expr: expr
-				arg: arg
-				has_arg: has_arg
-				pos: expr.position()
+			if name == 'Foo' {
+				eprintln('castexpr $name $to_typ')
+ts := p.table.find_type(name) or {
+	table.TypeSymbol{}
+}
+enm := ts.info as table.Enum
+				eprintln('castexpr $enm')
+
+lname := name.to_lower()
+mut body := ''
+for e in enm.vals {
+	body += 'if s == "$e" { return ${name}.${e} }\n'
+}
+		pubfn := if p.mod == 'main' { 'fn' } else { 'pub fn' }
+		p.scanner.codegen('
+$pubfn (e ${name})fromstr(s string) ?$name {
+	$body
+	return error("invalid enum")
+}
+$pubfn ${lname}_from_string(s string) ?$name {
+	$body
+	return error("invalid enum")
+}
+')
+mname := '${lname}.from_string'
+		//	node = p.call_expr(language, mod)
+/*
+		nede := ast.CallExpr{
+			left: left
+			name: mname
+			args: args
+			pos: pos
+			is_method: true
+			or_block: ast.OrExpr{
+				stmts: or_stmts
+				kind: or_kind
+				pos: pos
 			}
-			p.expr_mod = ''
-			return node
+		}
+*/
+			} else {
+// non Foo
+				node = ast.CastExpr{
+					typ: to_typ
+					expr: expr
+					arg: arg
+					has_arg: has_arg
+					pos: expr.position()
+				}
+			}
 		} else {
 			// fn call
 			// println('calling $p.tok.lit')

--- a/vlib/v/tests/enum_test.v
+++ b/vlib/v/tests/enum_test.v
@@ -74,6 +74,20 @@ fn test_nums() {
 	assert d == -10
 }
 
+fn test_enumstr() {
+	a := Foo.a
+	assert '$a' == 'a'
+	b := Foo.b
+	assert '$b' == 'b'
+/*
+	// not yet implemented
+	c := Foo('c')     // making enums also a function?
+	assert c == Foo.c
+	d := Foo['d']     // making enums accessible as arrays
+	assert d == Foo.d
+*/
+}
+
 /*
 enum Expr {
 	BoolExpr(bool)

--- a/vlib/v/tests/enum_test.v
+++ b/vlib/v/tests/enum_test.v
@@ -79,6 +79,8 @@ fn test_enumstr() {
 	assert '$a' == 'a'
 	b := Foo.b
 	assert '$b' == 'b'
+	b2 := Foo(2)
+	assert b2.str() == 'b'
 /*
 	// not yet implemented
 	c := Foo('c')     // making enums also a function?


### PR DESCRIPTION
I'm still learning the compiler internals to make this work. feel free to comment, add suggestions, or even implement it before me and close the pr.

Ideally it will be good if the compiler can provide V-level meta function definitions instead of having to depend on the cgen to bake the autogenerated methods.

```go
enum Foo {
	foo
	bar
	cow
}

fn foo_string_to_enum(a string) ?Foo {
	if a == 'foo' { return Foo.foo }
	if a == 'bar' { return Foo.bar }
	if a == 'cow' { return Foo.cow }
	return error('invalid enum name')
}

fn main() {
	a := Foo('foo') or { println('damn') }
	println('$a')
}
```

this is how the autogenerated function may work, i assume the next step will be to tell the compiler that calling an enum type returns optional because the current code fails with this error:  `error: expr(): bad token 'or'`.

This patch adds just a check to have a better error messaging when trying to use this unexistent feature: `todo: string to 'Foo' enum`.