### PR TITLE
parser: check function argument mutable syntax (f mut Foo => mut f Foo)

### DIFF
--- a/vlib/v/checker/tests/mut_args_warning.out
+++ b/vlib/v/checker/tests/mut_args_warning.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/mut_args_warning.v:1:8: warning: use `mut f Foo` instead of `f mut Foo`
+    1 | fn f(x mut []int) { x[0] = 1 }
+      |        ~~~
+    2 | fn main() {
+    3 |     mut x := [0]

--- a/vlib/v/checker/tests/mut_args_warning.vv
+++ b/vlib/v/checker/tests/mut_args_warning.vv
@@ -1,0 +1,5 @@
+fn f(x mut []int) { x[0] = 1 }
+fn main() {
+	mut x := [0]
+	f(mut x)
+}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -415,6 +415,7 @@ fn (mut p Parser) fn_args() ([]table.Arg, bool) {
 			}
 			if p.tok.kind == .key_mut {
 				// TODO remove old syntax
+				p.warn_with_pos('use `mut f Foo` instead of `f mut Foo`', p.tok.position())
 				is_mut = true
 			}
 			if p.tok.kind == .ellipsis {


### PR DESCRIPTION
This PR check function argument mutable syntax (f mut Foo => mut f Foo).

- Check function argument mutable syntax (f mut Foo => mut f Foo).
- Add test `mut_args_warning.vv/out`.

```v
fn f(x mut []int) { x[0] = 1 }
fn main() {
	mut x := [0]
	f(mut x)
    println(x)
}

D:\test\v\tt1>v run .
.\tt1.v:1:8: warning: use `mut f Foo` instead of `f mut Foo`
    1 | fn f(x mut []int) { x[0] = 1 }
      |        ~~~
    2 | fn main() {
    3 |     mut x := [0]
[1]
```