### PR TITLE
cgen: optimize cgen code format

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -562,17 +562,17 @@ fn (mut g Gen) decrement_inside_ternary() {
 fn (mut g Gen) stmts(stmts []ast.Stmt) {
 	g.indent++
 	if g.inside_ternary > 0 {
-		g.writeln('(')
+		g.write('(')
 	}
 	for i, stmt in stmts {
 		g.stmt(stmt)
 		if g.inside_ternary > 0 && i < stmts.len - 1 {
-			g.writeln(',')
+			g.write(',')
 		}
 	}
 	g.indent--
 	if g.inside_ternary > 0 {
-		g.writeln('')
+		g.write('')
 		g.write(')')
 	}
 }
@@ -932,7 +932,7 @@ fn (mut g Gen) gen_assert_stmt(a ast.AssertStmt) {
 		g.writeln('	g_test_oks++;')
 		metaname_ok := g.gen_assert_metainfo(a)
 		g.writeln('	cb_assertion_ok(&${metaname_ok});')
-		g.writeln('}else{')
+		g.writeln('} else {')
 		g.writeln('	g_test_fails++;')
 		metaname_fail := g.gen_assert_metainfo(a)
 		g.writeln('	cb_assertion_failed(&${metaname_fail});')
@@ -942,7 +942,7 @@ fn (mut g Gen) gen_assert_stmt(a ast.AssertStmt) {
 		g.writeln('}')
 		return
 	}
-	g.writeln('{}else{')
+	g.writeln('{} else {')
 	metaname_panic := g.gen_assert_metainfo(a)
 	g.writeln(' __print_assert_failure(&${metaname_panic});')
 	g.writeln(' v_panic(tos_lit("Assertion failed..."));')

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -113,8 +113,9 @@ fn (mut g Gen) gen_fn_decl(it ast.FnDecl) {
 				g.write('static ')
 				g.definitions.write('static ')
 			}
-			g.definitions.write('$type_name $msvc_attrs ${name}(')
-			g.write('$type_name $msvc_attrs ${name}(')
+			fn_header := if msvc_attrs.len > 0 { '$type_name $msvc_attrs ${name}(' } else { '$type_name ${name}(' }
+			g.definitions.write(fn_header)
+			g.write(fn_header)
 		}
 		fargs, fargtypes := g.fn_args(it.args, it.is_variadic)
 		if it.no_body || (g.pref.use_cache && it.is_builtin) {
@@ -777,4 +778,3 @@ fn (mut g Gen) write_fn_attr() string{
 	return msvc_attrs
 
 	}
-


### PR DESCRIPTION
This PR optimize cgen code format.

- Remove extra spaces in function head.
- Ternary expr in one line.

```v
inline static f64 f64_abs(f64 a) {
	return (a < 0 ? (-a) : (a));
}
```