### PR TITLE
vdoc: replace hardcoded `v` with `@VEXE`

### DIFF
--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -451,7 +451,7 @@ fn main() {
 	opts := cmdline.only_options(os.args[1..])
 	args := cmdline.only_non_options(args_after_doc)
 	if args.len == 0 || args[0] == 'help' {
-		os.system('v help doc')
+		os.system('${@VEXE} help doc')
 		exit(0)
 	}
 	mut config := DocConfig{


### PR DESCRIPTION
This fixes `v doc` on a system where V's executable is named other than `v`.
