### PR TITLE
vpm: use only `-v` for verbose output

### DIFF
--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -443,7 +443,7 @@ fn init_settings() {
 		s = settings
 	}
 	s.is_help = '-h' in os.args || '--help' in os.args || 'help' in os.args
-	s.is_verbose = '-verbose' in os.args || '--verbose' in os.args || '-v' in os.args
+	s.is_verbose = '-v' in os.args
 	s.server_urls = cmdline.options(os.args, '-server-url')
 	s.vmodules_path = os.home_dir() + '.vmodules'
 }

--- a/cmd/v/help/install.txt
+++ b/cmd/v/help/install.txt
@@ -2,12 +2,11 @@ Usage:
   v install module [module] [module] [...]
   ^^^^^^^^^^^^^ will install the modules you specified
 
-You can also do `v install` directly if you have dependencies stored 
-inside the `v.mod` file. This will automatically installs the modules 
-specified inside of it. 
+You can also do `v install` directly if you have dependencies stored
+inside the `v.mod` file. This will automatically installs the modules
+specified inside of it.
 
 Options:
-  -help        - Show usage info.
-  -verbose     - Print more details about the performed operation.
-  -server-url  - When doing network operations, use this vpm server. 
-                 Can be given multiple times.
+  -help         - Show usage info.
+  -v            - Print more details about the performed operation.
+  -server-url   - When doing network operations, use this vpm server. Can be given multiple times.

--- a/cmd/v/help/remove.txt
+++ b/cmd/v/help/remove.txt
@@ -5,5 +5,5 @@ Usage:
     ^^^^^^^^^^^^ will remove ALL installed modules
 Options:
   -help        - Show usage info.
-  -verbose     - Print more details about the performed operation.
+  -v           - Print more details about the performed operation.
   -server-url  - When doing network operations, use this vpm server. Can be given multiple times.

--- a/cmd/v/help/search.txt
+++ b/cmd/v/help/search.txt
@@ -3,6 +3,6 @@ Usage:
   ^^^^^^^^^^^^^^^^^ will search https://vpm.vlang.io/ for matching modules,
                     and will show details about them
 Options:
-  -help        - Show usage info.
-  -verbose     - Print more details about the performed operation.
-  -server-url  - When doing network operations, use this vpm server. Can be given multiple times.
+  -help         - Show usage info.
+  -v            - Print more details about the performed operation.
+  -server-url   - When doing network operations, use this vpm server. Can be given multiple times.

--- a/cmd/v/help/update.txt
+++ b/cmd/v/help/update.txt
@@ -5,5 +5,5 @@ Usage:
     ^^^^^^^^^^^^ will update ALL installed modules to their latest versions.
 Options:
   -help        - Show usage info.
-  -verbose     - Print more details about the performed operation.
+  -v           - Print more details about the performed operation.
   -server-url  - When doing network operations, use this vpm server. Can be given multiple times.

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -10,7 +10,7 @@ import v.util
 import v.builder
 
 const (
-	simple_cmd                          = [
+	simple_cmd = [
 		'fmt', 'up',
 		'self', 'symlink', 'bin2v',
 		'test', 'test-fmt', 'test-compiler', 'test-fixed',

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -33,7 +33,7 @@ pub enum Backend {
 }
 
 const (
-	list_of_flags_with_param            = [
+	list_of_flags_with_param = [
 		'o'
 		'output', 'd', 'define', 'b', 'backend', 'cc', 'os', 'target-os', 'arch', 'csource'
 		'cf', 'cflags', 'path']


### PR DESCRIPTION
Remove all other flags and update the help texts.

Close #5148 
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
