### PR TITLE
parser: fix string interpolation for expressions ending `c`, `r`, `js`

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -812,8 +812,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 		}
 	}
 	// Raw string (`s := r'hello \n ')
-	if p.tok.lit in ['r', 'c', 'js'] && p.peek_tok.kind == .string
-		&& !p.inside_str_interp && p.prev_tok.kind != .str_dollar {
+	if p.tok.lit in ['r', 'c', 'js'] && p.peek_tok.kind == .string && !p.inside_str_interp {
 		return p.string_expr()
 	}
 	mut known_var := false

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -32,6 +32,7 @@ mut:
 	inside_or_expr    bool
 	inside_for        bool
 	inside_fn         bool
+	inside_str_interp bool
 	pref              &pref.Preferences
 	builtin_mod       bool // are we in the `builtin` module?
 	mod               string // current module name
@@ -811,7 +812,8 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 		}
 	}
 	// Raw string (`s := r'hello \n ')
-	if p.tok.lit in ['r', 'c', 'js'] && p.peek_tok.kind == .string && p.prev_tok.kind != .str_dollar {
+	if p.tok.lit in ['r', 'c', 'js'] && p.peek_tok.kind == .string
+		&& !p.inside_str_interp && p.prev_tok.kind != .str_dollar {
 		return p.string_expr()
 	}
 	mut known_var := false
@@ -1106,6 +1108,7 @@ fn (mut p Parser) string_expr() ast.Expr {
 	mut vals := []string{}
 	mut efmts := []string{}
 	// Handle $ interpolation
+	p.inside_str_interp = true
 	for p.tok.kind == .string {
 		vals << p.tok.lit
 		p.next()
@@ -1141,6 +1144,7 @@ fn (mut p Parser) string_expr() ast.Expr {
 		expr_fmts: efmts
 		pos: pos
 	}
+	p.inside_str_interp = false
 	return node
 }
 

--- a/vlib/v/tests/string_interpolation_test.v
+++ b/vlib/v/tests/string_interpolation_test.v
@@ -76,6 +76,15 @@ fn test_string_interpolation_string_prefix() {
 	assert jsjs == 'jsjs'
 }
 
+fn test_interpolation_string_prefix_expr() {
+	r := 1
+	c := 2
+	js := 1
+	assert '>${3+r}<' == '>4<'
+	assert '${r == js} $js' == 'true 1'
+	assert '>${js+c} ${js+r==c}<' == '>3 true<'
+}
+
 fn test_inttypes_string_interpolation() {
 	c := i8(-103)
 	uc := byte(217)


### PR DESCRIPTION
For certain expressions like `'${a+c} x'` or `${b==js}y'` string interpolation fails because the variable name is interpreted as prefix for the following string part.
This PR fixes this problem by suppressing the special handling of those tokens when inside an interpolation.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
