### PR TITLE
vdoc: group constants + minor fixes

### DIFF
--- a/cmd/tools/vdoc-resources/doc.css
+++ b/cmd/tools/vdoc-resources/doc.css
@@ -396,7 +396,8 @@ body {
 
 /* Code highlight */
 pre[class*="language-"],
-code[class*="language-"] {
+code[class*="language-"],
+pre code {
   color: #5c6e74;
   color: var(--code-default-text-color);
   font-size: 0.8rem;
@@ -421,7 +422,8 @@ code[class*="language-"] {
   border-radius: 0.25rem;
   overflow-x: auto;
 }
-code[class*="language-"] {
+code[class*="language-"],
+pre code {
 	padding: 1rem;
 }
 pre[class*="language-"] {

--- a/cmd/tools/vdoc-resources/doc.css
+++ b/cmd/tools/vdoc-resources/doc.css
@@ -266,6 +266,12 @@ body {
 .doc-content > .doc-node:not(:last-child) {
 	padding: 1rem 0 3rem 0;
 }
+.doc-content > .doc-node.const:not(:first-child) {
+	padding-top: 0;
+}
+.doc-content > .doc-node.const:not(:last-child) {
+	padding-bottom: 1rem;
+}
 .doc-content > .timestamp {
 	font-size: 0.8rem;
 	color: #b8c2cc;

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -237,7 +237,7 @@ fn doc_node_html(dd doc.DocNode, link string, head bool, tb &table.Table) string
 		sym_name = '${dd.parent_type}.' + sym_name
 	}
 	node_id := slug(sym_name)
-	hash_link := if head_tag != 'h1' { ' <a href="#$node_id">#</a>' } else { '' }
+	hash_link := if !head { ' <a href="#$node_id">#</a>' } else { '' }
 	dnw.writeln('<section id="$node_id" class="doc-node$is_const_class">')
 	if dd.name != 'README' {
 		dnw.write('<div class="title"><$head_tag>$sym_name$hash_link</$head_tag>')

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -54,7 +54,7 @@ mut:
 	is_multi       bool = false
 	is_verbose     bool = false
 	include_readme bool = false
-	open_docs      bool = true
+	open_docs      bool = false
 	server_port    int  = 8046
 	inline_assets  bool = false
 	output_path    string
@@ -688,13 +688,13 @@ fn main() {
 			'-m' {
 				cfg.is_multi = true
 			}
-			'-no-open' {
-				cfg.open_docs = false
-			}
 			'-o' {
 				opath := cmdline.option(current_args, '-o', '')
 				cfg.output_path = os.real_path(opath)
 				i++
+			}
+			'-open' {
+				cfg.open_docs = true
 			}
 			'-p' {
 				s_port := cmdline.option(current_args, '-o', '')

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -566,7 +566,7 @@ fn (mut cfg DocConfig) generate_docs_from_file() {
 					panic(err)
 				}
 			} else {
-				for fname in ['doc.css', 'v-prism.css', 'doc.js'] {
+				for fname in ['doc.css', 'normalize.css' 'doc.js'] {
 					os.rm(os.join_path(cfg.output_path, fname))
 				}
 			}

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -258,7 +258,7 @@ fn doc_node_html(dd doc.DocNode, link string, head bool, tb &table.Table) string
 
 fn (cfg DocConfig) gen_html(idx int) string {
 	dcs := cfg.docs[idx]
-	time_gen := dcs.time_generated.day.str() + ' ' + dcs.time_generated.smonth() + ' ' + dcs.time_generated.year.str() + ' ' + dcs.time_generated.hhmmss()
+	time_gen := '$dcs.time_generated.day $dcs.time_generated.smonth() $dcs.time_generated.year $dcs.time_generated.hhmmss()'
 	mut hw := strings.new_builder(200)
 	mut toc := strings.new_builder(200)
 	// generate toc first

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -231,13 +231,14 @@ fn doc_node_html(dd doc.DocNode, link string, head bool, tb &table.Table) string
 	head_tag := if head { 'h1' } else { 'h2' }
 	md_content := markdown.to_html(dd.comment)
 	hlighted_code := html_highlight(dd.content, tb)
+	is_const_class := if dd.name == 'Constants' { ' const' } else { '' }
 	mut sym_name := dd.name
-	if dd.parent_type !in ['void', ''] { 
+	if dd.parent_type !in ['void', '', 'Constants'] { 
 		sym_name = '${dd.parent_type}.' + sym_name
 	}
 	node_id := slug(sym_name)
-	dnw.writeln('<section id="$node_id" class="doc-node">')
-	if dd.name != 'README' {
+	dnw.writeln('<section id="$node_id" class="doc-node$is_const_class">')
+	if dd.name != 'README' && dd.parent_type != 'Constants' {
 		dnw.write('<div class="title"><$head_tag>$sym_name <a href="#$node_id">#</a></$head_tag>')
 		if link.len != 0 {
 			dnw.write('<a class="link" rel="noreferrer" target="_blank" href="$link">$link_svg</a>')
@@ -264,7 +265,7 @@ fn (cfg DocConfig) gen_html(idx int) string {
 		if cn.parent_type !in ['void', ''] { continue }
 		toc.write('<li><a href="#${slug(cn.name)}">${cn.name}</a>')
 		children := dcs.contents.find_children_of(cn.name)
-		if children.len != 0 {
+		if children.len != 0 && cn.name != 'Constants' {
 			toc.writeln('        <ul>')
 			for child in children {
 				cname := cn.name + '.' + child.name

--- a/cmd/v/help/doc.txt
+++ b/cmd/v/help/doc.txt
@@ -16,7 +16,9 @@ Options:
   -inline-assets  Embeds the contents of the CSS and JS assets into the webpage directly.
   -l              Show the locations of the generated signatures. (For plaintext only)
   -m              Generate docs for modules listed in that folder.
+  -no-open        Disable automatic launching of browser when the server docs has started.
   -o              Specifies the output file/folder path where to store the generated docs.
+  -p              Specifies the port to be used for the docs server.
   -s              Serve HTML-generated docs via HTTP.
   -r              Include README.md to docs if present.
   -v              Enables verbose logging. For debugging purposes.

--- a/cmd/v/help/doc.txt
+++ b/cmd/v/help/doc.txt
@@ -16,8 +16,8 @@ Options:
   -inline-assets  Embeds the contents of the CSS and JS assets into the webpage directly.
   -l              Show the locations of the generated signatures. (For plaintext only)
   -m              Generate docs for modules listed in that folder.
-  -no-open        Disable automatic launching of browser when the server docs has started.
   -o              Specifies the output file/folder path where to store the generated docs.
+  -open           Launches the browser when the server docs has started.
   -p              Specifies the port to be used for the docs server.
   -s              Serve HTML-generated docs via HTTP.
   -r              Include README.md to docs if present.

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -259,7 +259,8 @@ pub fn (mut d Doc) generate() ?bool {
 			}
 			signature := d.get_signature(stmt)
 			pos := d.get_pos(stmt)
-			if !signature.starts_with('pub') && d.pub_only {
+			mut name := d.get_name(stmt)
+			if (!signature.starts_with('pub') && d.pub_only) || stmt is ast.GlobalDecl {
 				prev_comments = []
 				continue
 			}

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -96,7 +96,7 @@ pub fn (d Doc) get_signature(stmt ast.Stmt) string {
 			return 'module $it.name'
 		}
 		ast.FnDecl {
-			return it.str(d.table).replace(d.head.name.split('.').last() + '.', '')
+			return it.str(d.table).replace(f.cur_mod + '.', '')
 		}
 		else {
 			f.stmt(stmt)
@@ -125,12 +125,13 @@ pub fn (d Doc) get_type_name(decl ast.TypeDecl) string {
 }
 
 pub fn (d Doc) get_name(stmt ast.Stmt) string {
+	cur_mod := d.head.name.split('.').last()
 	match stmt {
 		ast.FnDecl { return it.name }
 		ast.StructDecl { return it.name }
 		ast.EnumDecl { return it.name }
 		ast.InterfaceDecl { return it.name }
-		ast.TypeDecl { return d.get_type_name(it).replace('&${d.head.name}.', '').replace(d.head.name + '.', '') }
+		ast.TypeDecl { return d.get_type_name(it).replace('&' + cur_mod + '.', '').replace(cur_mod + '.', '') }
 		ast.ConstDecl { return 'Constants' }
 		else { return '' }
 	}

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -87,6 +87,7 @@ pub fn (d Doc) get_signature(stmt ast.Stmt) string {
 		out: strings.new_builder(1000)
 		out_imports: strings.new_builder(200)
 		table: d.table
+		cur_mod: d.head.name.split('.').last()
 		indent: 0
 		is_debug: false
 	}
@@ -95,7 +96,7 @@ pub fn (d Doc) get_signature(stmt ast.Stmt) string {
 			return 'module $it.name'
 		}
 		ast.FnDecl {
-			return it.str(d.table)
+			return it.str(d.table).replace(d.head.name.split('.').last() + '.', '')
 		}
 		else {
 			f.stmt(stmt)

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -115,12 +115,21 @@ pub fn (d Doc) get_pos(stmt ast.Stmt) token.Position {
 	}
 }
 
+pub fn (d Doc) get_type_name(decl ast.TypeDecl) string {
+	match decl {
+		ast.SumTypeDecl { return it.name }
+		ast.FnTypeDecl { return it.name }
+		ast.AliasTypeDecl { return it.name }
+	}
+}
+
 pub fn (d Doc) get_name(stmt ast.Stmt) string {
 	match stmt {
 		ast.FnDecl { return it.name }
 		ast.StructDecl { return it.name }
 		ast.EnumDecl { return it.name }
 		ast.InterfaceDecl { return it.name }
+		ast.TypeDecl { return d.get_type_name(it).replace('&${d.head.name}.', '').replace(d.head.name + '.', '') }
 		ast.ConstDecl { return 'Constants' }
 		else { return '' }
 	}

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -214,6 +214,7 @@ pub fn (mut d Doc) generate() ?bool {
 	mut module_name := ''
 	mut parent_mod_name := ''
 	mut orig_mod_name := ''
+	mut const_idx := -1
 	for i, file_ast in file_asts {
 		if i == 0 {
 			parent_mod_name = get_parent_mod(base_path) or {
@@ -234,7 +235,7 @@ pub fn (mut d Doc) generate() ?bool {
 		}
 		mut prev_comments := []ast.Stmt{}
 		stmts := file_ast.stmts
-		for _, stmt in stmts {
+		for o, stmt in stmts {
 			//eprintln('stmt typeof: ' + typeof(stmt))
 			if stmt is ast.Comment {
 				prev_comments << stmt
@@ -256,8 +257,6 @@ pub fn (mut d Doc) generate() ?bool {
 				d.head.comment += module_comment
 				continue
 			}
-			// todo: accumulate consts
-			mut name := d.get_name(stmt)
 			signature := d.get_signature(stmt)
 			pos := d.get_pos(stmt)
 			if !signature.starts_with('pub') && d.pub_only {
@@ -283,7 +282,13 @@ pub fn (mut d Doc) generate() ?bool {
 					}
 					node.parent_type = parent_type
 				}
-
+			}
+			if stmt is ast.ConstDecl {
+				if const_idx == -1 {
+					const_idx = o
+				} else {
+					node.parent_type = 'Constants'
+				}
 			}
 			if node.name.len == 0 && node.comment.len == 0 && node.content.len == 0 {
 				continue

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -57,10 +57,29 @@ pub fn get_comment_block_right_before(stmts []ast.Stmt) string {
 			// located right above the top level statement.
 			//			break
 		}
-		cmt_content := cmt.text.trim_left('|')
-		if cmt_content.len == cmt.text.len {
+		mut cmt_content := cmt.text.trim_left('|')
+		if cmt_content.len == cmt.text.len || cmt.is_multi {
 			// ignore /* */ style comments for now
 			continue
+			// if cmt_content.len == 0 {
+			// 	continue
+			// }
+			// mut new_cmt_content := ''
+			// mut is_codeblock := false
+			// // println(cmt_content)
+			// lines := cmt_content.split_into_lines()
+			// for j, line in lines {
+			// 	trimmed := line.trim_space().trim_left(cmt_prefix)
+			// 	if trimmed.starts_with('- ') || (trimmed.len >= 2 && trimmed[0].is_digit() && trimmed[1] == `.`) || is_codeblock {
+			// 		new_cmt_content += line + '\n'
+			// 	} else if line.starts_with('```') {
+			// 		is_codeblock = !is_codeblock
+			// 		new_cmt_content += line + '\n'
+			// 	} else {
+			// 		new_cmt_content += trimmed + '\n'
+			// 	}
+			// }
+			// return new_cmt_content
 		}
 		//eprintln('cmt: $cmt')
 		cseparator := if cmt_content.starts_with('```') {'\n'} else {' '}


### PR DESCRIPTION
Fixes #5248 .
1. Group constants into one place + remove redundant constant links.
2. Support for custom server doc port and ability to disable auto-open link.
3. Fix footer time interpolation
4. Skip `GlobalDecl` node when generating docs.
5. Fix vfmt in vdoc not removing module prefixes
6. Fix missing names in TypeDecl node
7. Fix styling on some codeblocks with no defined language
8. Include README.md on each module if found