### PR TITLE
WIP: Initial work to support for-in-enum

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2045,7 +2045,20 @@ pub fn (mut c Checker) ident(mut ident ast.Ident) table.Type {
 		return table.int_type
 	}
 	if ident.name != '_' {
-		c.error('undefined ident: `$ident.name`', ident.pos)
+		et := c.table.find_type(ident.name) or { table.TypeSymbol{} }
+		if et.kind == .enum_ {
+			enum_type := et.info as table.Enum
+			mut items := []string{}
+			for a in enum_type.vals {
+				items << '${ident.name}.$a, '
+			}
+			itemstr := items.join(', ')
+			eprintln('todo: substitute enum for in [${itemstr}]')
+			ident.kind = .constant
+			return table.array_type
+		} else {
+			c.error('undefined ident: `$ident.name`', ident.pos)
+		}
 	}
 	if c.table.known_type(ident.name) {
 		// e.g. `User`  in `json.decode(User, '...')`

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1651,6 +1651,7 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 				}
 				if it.key_var.len > 0 {
 					key_type := match sym.kind {
+						// XXX if uncommented // .enum_{ sym.enum_info().vals }
 						.map { sym.map_info().key_type }
 						else { table.int_type }
 					}
@@ -2050,19 +2051,19 @@ pub fn (mut c Checker) ident(mut ident ast.Ident) table.Type {
 			enum_type := et.info as table.Enum
 			mut items := []string{}
 			for a in enum_type.vals {
-				items << '${ident.name}.$a, '
+				items << '${ident.name}.$a'
 			}
 			itemstr := items.join(', ')
 			eprintln('todo: substitute enum for in [${itemstr}]')
 			ident.kind = .constant
+			idx := c.table.find_or_register_array_fixed(table.int_type, enum_type.vals.len, 1)
+			array_type := table.new_type(idx)
+			// array_init.typ = array_type
+			// TODO: fill array with enum elements
 			return table.array_type
 		} else {
 			c.error('undefined ident: `$ident.name`', ident.pos)
 		}
-	}
-	if c.table.known_type(ident.name) {
-		// e.g. `User`  in `json.decode(User, '...')`
-		return table.void_type
 	}
 	return table.void_type
 }

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -856,6 +856,9 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		g.writeln('.args[$i];')
 		g.stmts(it.stmts)
 		g.writeln('}')
+	} else if it.kind == .enum_ {
+		// `for x in enum {`
+		eprintln('for-in-enum-todo')
 	} else if it.kind == .string {
 		i := if it.key_var in ['', '_'] { g.new_tmp_var() } else { it.key_var }
 		g.write('for (int $i = 0; $i < ')

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -64,6 +64,8 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 			inc: inc
 			pos: pos
 		}
+	} else if p.peek_tok.kind == .key_enum {
+		eprintln('ENUM FORIN')
 	} else if p.peek_tok.kind in [.key_in, .comma] {
 		// `for i in vals`, `for i in start .. end`
 		key_var_pos := p.tok.position()


### PR DESCRIPTION
I need to replace the enum name for the array of enum values (don't know yet how to do that), i dont think checker is the place to do so, but it's where i catch this case.

```
$ cat e.v
enum Foo { foo bar cow }

fn main() {
	for a in Foo {
		println('${a}')
	}
}

$ v run e.v
todo: substitute enum for in [Foo.foo, Foo.bar, Foo.cow, ]
e.v:4:11: error: for in: cannot index `array`
    2 |
    3 | fn main() {
    4 |     for a in Foo {
      |              ~~~
    5 |         println('${a}')
    6 |     }
```

