### PR TITLE
vlib: transfer module intro to readme; normalize comments

### DIFF
--- a/vlib/benchmark/README.md
+++ b/vlib/benchmark/README.md
@@ -1,0 +1,39 @@
+Example usage of this module:
+```
+import benchmark
+mut bmark := benchmark.new_benchmark()
+// by default the benchmark will be verbose, i.e. it will include timing information
+// if you want it to be silent, set bmark.verbose = false
+for {
+   bmark.step() // call this when you want to advance the benchmark.
+                // The timing info in bmark.step_message will be measured starting from the last call to bmark.step
+   ....
+
+   //bmark.fail() // call this if the step failed
+   //bmark.step_message(('failed')
+
+   bmark.ok() // call this when the step succeeded
+   println( bmark.step_message('ok')
+}
+bmark.stop() // call when you want to finalize the benchmark
+println( bmark.total_message('remarks about the benchmark') )
+```
+
+benchmark.start() and b.measure() are convenience methods,
+intended to be used in combination. Their goal is to make
+benchmarking of small snippets of code as *short*, easy to
+write, and then to read and analyze the results, as possible.
+Example:
+```v
+import benchmark
+b := benchmark.start()
+
+// your code 1 ...
+b.measure('code_1')
+
+// your code 2 ...
+b.measure('code_2')
+```
+... which will produce on stdout something like this:
+SPENT    17 ms in code_1
+SPENT   462 ms in code_2

--- a/vlib/benchmark/benchmark.v
+++ b/vlib/benchmark/benchmark.v
@@ -2,48 +2,6 @@ module benchmark
 
 import time
 import term
-/*
-Example usage of this module:
-```
-import benchmark
-mut bmark := benchmark.new_benchmark()
-// by default the benchmark will be verbose, i.e. it will include timing information
-// if you want it to be silent, set bmark.verbose = false
-for {
-   bmark.step() // call this when you want to advance the benchmark.
-                // The timing info in bmark.step_message will be measured starting from the last call to bmark.step
-   ....
-
-   //bmark.fail() // call this if the step failed
-   //bmark.step_message(('failed')
-
-   bmark.ok() // call this when the step succeeded
-   println( bmark.step_message('ok')
-}
-bmark.stop() // call when you want to finalize the benchmark
-println( bmark.total_message('remarks about the benchmark') )
-```
-
-benchmark.start() and b.measure() are convenience methods,
-intended to be used in combination. Their goal is to make
-benchmarking of small snippets of code as *short*, easy to
-write, and then to read and analyze the results, as possible.
-Example:
-```v
-import benchmark
-b := benchmark.start()
-
-// your code 1 ...
-b.measure('code_1')
-
-// your code 2 ...
-b.measure('code_2')
-```
-... which will produce on stdout something like this:
-SPENT    17 ms in code_1
-SPENT   462 ms in code_2
-*/
-
 
 const (
 	b_ok = term.ok_message('OK  ')

--- a/vlib/encoding/base64/base64.v
+++ b/vlib/encoding/base64/base64.v
@@ -17,11 +17,11 @@ const (
 	enc_table = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
 )
 
-/**
- * decode - expects a base64 encoded string. Returns its decoded version.
- * @param data - the encoded input string.
- * @return the decoded version of the input string data.
- * NB: if you need to decode many strings repeatedly, take a look at decode_in_buffer too.
+/*
+decode - expects a base64 encoded string. Returns its decoded version.
+@param data - the encoded input string.
+@return the decoded version of the input string data.
+NB: if you need to decode many strings repeatedly, take a look at decode_in_buffer too.
  */
 pub fn decode(data string) string {
 	size := data.len * 3 / 4
@@ -32,12 +32,12 @@ pub fn decode(data string) string {
 	return tos(buffer, decode_in_buffer(data, buffer) )
 }
 
-/**
- * decode - expects a string. Returns its base64 encoded version.
- * @param data - the input string.
- * @return the base64 encoded version of the input string.
- * NB: base64 encoding returns a string that is ~ 4/3 larger than the input.
- * NB: if you need to encode many strings repeatedly, take a look at encode_in_buffer too.
+/*
+decode - expects a string. Returns its base64 encoded version.
+@param data - the input string.
+@return the base64 encoded version of the input string.
+NB: base64 encoding returns a string that is ~ 4/3 larger than the input.
+NB: if you need to encode many strings repeatedly, take a look at encode_in_buffer too.
  */
 pub fn encode(data string) string {
 	size := 4 * ((data.len + 2) / 3)
@@ -48,13 +48,13 @@ pub fn encode(data string) string {
 	return tos(buffer, encode_in_buffer(data, buffer))
 }
 
-/**
- * decode_in_buffer - expects a string reference, and a buffer in which to store its decoded version.
- * @param data - a reference/pointer to the input string that will be decoded.
- * @param buffer - a reference/pointer to the buffer that will hold the result.
- * The buffer should be large enough (i.e. 3/4 of the data.len, or larger) to hold the decoded data.
- * @return the actual size of the decoded data in the buffer.
- * NB: this function does NOT allocate new memory, and is suitable for handling very large strings.
+/*
+decode_in_buffer - expects a string reference, and a buffer in which to store its decoded version.
+@param data - a reference/pointer to the input string that will be decoded.
+@param buffer - a reference/pointer to the buffer that will hold the result.
+The buffer should be large enough (i.e. 3/4 of the data.len, or larger) to hold the decoded data.
+@return the actual size of the decoded data in the buffer.
+NB: this function does NOT allocate new memory, and is suitable for handling very large strings.
  */
 pub fn decode_in_buffer(data &string, buffer byteptr) int {
 	mut padding := 0
@@ -109,13 +109,13 @@ pub fn decode_in_buffer(data &string, buffer byteptr) int {
 	return output_length
 }
 
-/**
- * encode_in_buffer - expects a string reference, and a buffer in which to store its base64 encoded version.
- * @param data - a reference/pointer to the input string.
- * @param buffer - a reference/pointer to the buffer that will hold the result.
- * The buffer should be large enough (i.e. 4/3 of the data.len, or larger) to hold the encoded data.
- * @return the actual size of the encoded data in the buffer.
- * NB: this function does NOT allocate new memory, and is suitable for handling very large strings.
+/*
+encode_in_buffer - expects a string reference, and a buffer in which to store its base64 encoded version.
+@param data - a reference/pointer to the input string.
+@param buffer - a reference/pointer to the buffer that will hold the result.
+The buffer should be large enough (i.e. 4/3 of the data.len, or larger) to hold the encoded data.
+@return the actual size of the encoded data in the buffer.
+NB: this function does NOT allocate new memory, and is suitable for handling very large strings.
  */
 pub fn encode_in_buffer(data &string, buffer byteptr) int {
 	input_length := data.len

--- a/vlib/encoding/utf8/utf8_util.v
+++ b/vlib/encoding/utf8/utf8_util.v
@@ -1,21 +1,21 @@
-/**********************************************************************
-*
-* utf-8 util
-*
-* Copyright (c) 2019 Dario Deledda. All rights reserved.
-* Use of this source code is governed by an MIT license
-* that can be found in the LICENSE file.
-*
-* This file contains utilities for utf8 strings
-*
-**********************************************************************/
+/*
+
+utf-8 util
+
+Copyright (c) 2019 Dario Deledda. All rights reserved.
+Use of this source code is governed by an MIT license
+that can be found in the LICENSE file.
+
+This file contains utilities for utf8 strings
+
+*/
 module utf8
 
-/**********************************************************************
-*
-* Utility functions
-*
-**********************************************************************/
+/*
+
+Utility functions
+
+*/
 
 // len return the leght as number of unicode chars from a string
 pub fn len(s string) int {
@@ -81,11 +81,11 @@ pub fn get_uchar(s string, index int) int {
 }
 
 
-/**********************************************************************
-*
-* Conversion functions
-*
-**********************************************************************/
+/*
+
+Conversion functions
+
+*/
 
 // to_upper return an uppercase string from a string
 pub fn to_upper(s string) string {
@@ -110,14 +110,14 @@ pub fn u_to_lower(s ustring) ustring {
 }
 
 
-/**********************************************************************
-*
-* Punctuation functions
-*
-* The "western" function search on a small table, that is quicker than
-* the global unicode table search. **Use only for western chars**.
-*
-**********************************************************************/
+/*
+
+Punctuation functions
+
+The "western" function search on a small table, that is quicker than
+the global unicode table search. **Use only for western chars**.
+
+*/
 
 //
 // Western
@@ -148,11 +148,11 @@ pub fn is_uchar_global_punct( uchar int ) bool {
 }
 
 
-/**********************************************************************
-*
-* Private functions
-*
-**********************************************************************/
+/*
+
+Private functions
+
+*/
 // utf8util_char_len calculate the length in bytes of a utf8 char
 fn utf8util_char_len(b byte) int {
 	return (( 0xe5000000 >> (( b >> 3 ) & 0x1e )) & 3 ) + 1
@@ -357,20 +357,20 @@ fn find_punct_in_table( in_code int , in_table []int ) int {
 }
 
 
-/*****************************************************************************
-*
-*  universal character set 2 level 1 (UCS-2 level-1) between uppercase and lowercase
-*  [Lowercase code point,	Uppercase code point,	Lowercase character description,	Uppercase character description]
-*
-*  source: https://www.ibm.com/support/knowledgecenter/ssw_ibm_i_73/nls/rbagslowtoupmaptable.htm?view=embed
-*  term of use: https://www.ibm.com/legal?lnk=flg-tous-usen
-*  license: not stated, general fair use license applied
-*
-*  regex expresion => replace from html table to V :
-*  src: ([A-F\d]+)\s+([A-F\d]+)\s+(.*)
-*  dst: 0x$1, 0x$2, // $3
-*
-*****************************************************************************/
+/*
+
+universal character set 2 level 1 (UCS-2 level-1) between uppercase and lowercase
+[Lowercase code point,	Uppercase code point,	Lowercase character description,	Uppercase character description]
+
+source: https://www.ibm.com/support/knowledgecenter/ssw_ibm_i_73/nls/rbagslowtoupmaptable.htm?view=embed
+term of use: https://www.ibm.com/legal?lnk=flg-tous-usen
+license: not stated, general fair use license applied
+
+regex expresion => replace from html table to V :
+src: ([A-F\d]+)\s+([A-F\d]+)\s+(.*)
+dst: 0x$1, 0x$2, // $3
+
+*/
 
 const(
 
@@ -1047,13 +1047,13 @@ u16(0x0041), 0x0061, //LATIN CAPITAL LETTER A	LATIN SMALL LETTER A
 ]
 )
 
-/*****************************************************************************
-*
-*  Unicode punctuation chars
-*
-*  source: http://www.unicode.org/faq/punctuation_symbols.html
-*
-*****************************************************************************/
+/*
+
+Unicode punctuation chars
+
+source: http://www.unicode.org/faq/punctuation_symbols.html
+
+*/
 const(
 
 // Western punctuation mark

--- a/vlib/flag/README.md
+++ b/vlib/flag/README.md
@@ -1,0 +1,43 @@
+module flag for command-line flag parsing
+
+- parsing flags like '--flag' or '--stuff=things' or '--things stuff'
+- handles bool, int, float and string args
+- is able to print usage
+- handled unknown arguments as error
+
+Usage example:
+
+ ```v
+ module main
+
+ import os
+ import flag
+
+ fn main() {
+ 	mut fp := flag.new_flag_parser(os.args)
+ 	fp.application('flag_example_tool')
+ 	fp.version('v0.0.0')
+ 	fp.description('This tool is only designed to show how the flag lib is working')
+
+ 	fp.skip_executable()
+
+ 	an_int := fp.int('an_int', 0, 0o666, 'some int to define 0o666 is default')
+ 	a_bool := fp.bool('a_bool', 0, false, 'some \'real\' flag')
+ 	a_float := fp.float('a_float', 0, 1.0, 'also floats')
+ 	a_string := fp.string('a_string', `a`, 'no text', 'finally, some text with "a" an abbreviation')
+
+ 	additional_args := fp.finalize() or {
+ 		eprintln(err)
+ 		println(fp.usage())
+ 		return
+ 	}
+
+ 	println('
+ 		  an_int: $an_int
+ 		  a_bool: $a_bool
+ 		 a_float: $a_float
+ 		a_string: \'$a_string\'
+ 	')
+ 	println(additional_args.join_lines())
+ }
+ ```

--- a/vlib/flag/flag.v
+++ b/vlib/flag/flag.v
@@ -1,49 +1,5 @@
 module flag
 
-// module flag for command-line flag parsing
-//
-// - parsing flags like '--flag' or '--stuff=things' or '--things stuff'
-// - handles bool, int, float and string args
-// - is able to print usage
-// - handled unknown arguments as error
-//
-// Usage example:
-//
-//  ```v
-//  module main
-//
-//  import os
-//  import flag
-//
-//  fn main() {
-//  	mut fp := flag.new_flag_parser(os.args)
-//  	fp.application('flag_example_tool')
-//  	fp.version('v0.0.0')
-//  	fp.description('This tool is only designed to show how the flag lib is working')
-//
-//  	fp.skip_executable()
-//
-//  	an_int := fp.int('an_int', 0, 0o666, 'some int to define 0o666 is default')
-//  	a_bool := fp.bool('a_bool', 0, false, 'some \'real\' flag')
-//  	a_float := fp.float('a_float', 0, 1.0, 'also floats')
-//  	a_string := fp.string('a_string', `a`, 'no text', 'finally, some text with "a" an abbreviation')
-//
-//  	additional_args := fp.finalize() or {
-//  		eprintln(err)
-//  		println(fp.usage())
-//  		return
-//  	}
-//
-//  	println('
-//  		  an_int: $an_int
-//  		  a_bool: $a_bool
-//  		 a_float: $a_float
-//  		a_string: \'$a_string\'
-//  	')
-//  	println(additional_args.join_lines())
-//  }
-//  ```
-
 // data object storing information about a defined flag
 pub struct Flag {
 	pub:

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -25,7 +25,7 @@ pub fn (f File) is_opened() bool {
 	return f.opened
 }
 
-/***************************** Write ops ****************************/
+// Write ops
 
 pub fn (mut f File) write(s string) {
 	if !f.opened {

--- a/vlib/regex/regex.v
+++ b/vlib/regex/regex.v
@@ -1,20 +1,20 @@
-/**********************************************************************
-*
-* regex 0.9e
-*
-* Copyright (c) 2019-2020 Dario Deledda. All rights reserved.
-* Use of this source code is governed by an MIT license
-* that can be found in the LICENSE file.
-*
-* This file contains regex module
-*
-* Know limitation:
-* - find is implemented in a trivial way
-* - not full compliant PCRE
-* - not compliant POSIX ERE
-*
-*
-**********************************************************************/
+/*
+
+regex 0.9e
+
+Copyright (c) 2019-2020 Dario Deledda. All rights reserved.
+Use of this source code is governed by an MIT license
+that can be found in the LICENSE file.
+
+This file contains regex module
+
+Know limitation:
+- find is implemented in a trivial way
+- not full compliant PCRE
+- not compliant POSIX ERE
+
+
+*/
 module regex
 import strings
 
@@ -76,11 +76,11 @@ const(
 	//*************************************
 )
 
-/******************************************************************************
-*
-* General Utilities
-*
-******************************************************************************/
+/*
+
+General Utilities
+
+*/
 // utf8util_char_len calculate the length in bytes of a utf8 char
 [inline]
 fn utf8util_char_len(b byte) int {
@@ -266,11 +266,11 @@ fn (mut tok Token) reset() {
 	tok.rep = 0
 }
 
-/******************************************************************************
-*
-* Regex struct
-*
-******************************************************************************/
+/*
+
+Regex struct
+
+*/
 pub const (
 	f_nl  = 0x00000001  // end the match when find a new line symbol
 	f_ms  = 0x00000002  // match true only if the match is at the start of the string
@@ -373,11 +373,11 @@ pub fn (re RE) get_group(group_name string) (int, int) {
 	return -1, -1
 }
 
-/******************************************************************************
-*
-* Backslashes chars
-*
-******************************************************************************/
+/*
+
+Backslashes chars
+
+*/
 struct BslsStruct {
 	ch u32                   // meta char
 	validator FnValidator    // validator function pointer
@@ -449,11 +449,11 @@ fn (re RE) parse_bsls(in_txt string, in_i int) (int,int){
 	return err_syntax_error, i
 }
 
-/******************************************************************************
-*
-* Char class
-*
-******************************************************************************/
+/*
+
+Char class
+
+*/
 const(
 	cc_null = 0    // empty cc token
 	cc_char = 1    // simple char: a
@@ -660,11 +660,11 @@ fn (mut re RE) parse_char_class(in_txt string, in_i int) (int, int, u32) {
 	return err_syntax_error,0,u32(0)
 }
 
-/******************************************************************************
-*
-* Re Compiler
-*
-******************************************************************************/
+/*
+
+Re Compiler
+
+*/
 //
 // Quantifier
 //
@@ -1423,11 +1423,11 @@ pub fn (re RE) get_query() string {
 	return res.str()
 }
 
-/******************************************************************************
-*
-* Matching
-*
-******************************************************************************/
+/*
+
+Matching
+
+*/
 enum Match_state{
 	start = 0
 	stop
@@ -2161,11 +2161,11 @@ pub fn (mut re RE) match_base(in_txt byteptr, in_txt_len int ) (int,int) {
 	return no_match_found, 0
 }
 
-/******************************************************************************
-*
-* Public functions
-*
-******************************************************************************/
+/*
+
+Public functions
+
+*/
 
 //
 // Inits

--- a/vlib/strconv/atof.v
+++ b/vlib/strconv/atof.v
@@ -1,23 +1,23 @@
-/**********************************************************************
-*
-* atof util
-*
-* Copyright (c) 2019 Dario Deledda. All rights reserved.
-* Use of this source code is governed by an MIT license
-* that can be found in the LICENSE file.
-*
-* This file contains utilities for convert a string in a f64 variable
-* IEEE 754 standard is used
-*
-* Know limitation:
-* - limited to 18 significant digits
-*
-* The code is inspired by:
-* Grzegorz Kraszewski krashan@teleinfo.pb.edu.pl
-* URL: http://krashan.ppa.pl/articles/stringtofloat/
-* Original license: MIT
-*
-**********************************************************************/
+/*
+
+atof util
+
+Copyright (c) 2019 Dario Deledda. All rights reserved.
+Use of this source code is governed by an MIT license
+that can be found in the LICENSE file.
+
+This file contains utilities for convert a string in a f64 variable
+IEEE 754 standard is used
+
+Know limitation:
+- limited to 18 significant digits
+
+The code is inspired by:
+Grzegorz Kraszewski krashan@teleinfo.pb.edu.pl
+URL: http://krashan.ppa.pl/articles/stringtofloat/
+Original license: MIT
+
+*/
 module strconv
 
 union Float64u {
@@ -26,12 +26,12 @@ mut:
 	u u64
 }
 
-/**********************************************************************
-*
-* 96 bit operation utilities
-* Note: when u128 will be available these function can be refactored
-*
-**********************************************************************/
+/*
+
+96 bit operation utilities
+Note: when u128 will be available these function can be refactored
+
+*/
 
 // right logical shift 96 bit
 fn lsr96(s2 u32, s1 u32, s0 u32) (u32,u32,u32) {
@@ -89,11 +89,11 @@ fn sub96(s2 u32, s1 u32, s0 u32, d2 u32, d1 u32, d0 u32) (u32,u32,u32) {
 	return r2,r1,r0
 }
 
-/**********************************************************************
-*
-* Constants
-*
-**********************************************************************/
+/*
+
+Constants
+
+*/
 
 
 const (
@@ -137,11 +137,11 @@ const (
 	c_nine = `9`
 	c_ten = u32(10)
 )
-/**********************************************************************
-*
-* Utility
-*
-**********************************************************************/
+/*
+
+Utility
+
+*/
 
 // NOTE: Modify these if working with non-ASCII encoding
 fn is_digit(x byte) bool {
@@ -156,11 +156,11 @@ fn is_exp(x byte) bool {
 	return (x == `E` || x == `e`) == true
 }
 
-/**********************************************************************
-*
-* Support struct
-*
-**********************************************************************/
+/*
+
+Support struct
+
+*/
 
 // The structure is filled by parser, then given to converter.
 pub struct PrepNumber {
@@ -169,12 +169,12 @@ pub mut:
 	exponent int // power of 10 exponent
 	mantissa u64 // integer mantissa
 }
-/**********************************************************************
-*
-* String parser
-* NOTE: #TOFIX need one char after the last char of the number
-*
-**********************************************************************/
+/*
+
+String parser
+NOTE: #TOFIX need one char after the last char of the number
+
+*/
 
 // parser return a support struct with all the parsing information for the converter
 fn parser(s string) (int,PrepNumber) {
@@ -353,11 +353,11 @@ fn parser(s string) (int,PrepNumber) {
 	return result,pn
 }
 
-/**********************************************************************
-*
-* Converter to the bit form of the f64 number
-*
-**********************************************************************/
+/*
+
+Converter to the bit form of the f64 number
+
+*/
 
 // converter return a u64 with the bit image of the f64 number
 fn converter(mut pn PrepNumber) u64 {
@@ -522,11 +522,11 @@ fn converter(mut pn PrepNumber) u64 {
 	return result
 }
 
-/**********************************************************************
-*
-* Public functions
-*
-**********************************************************************/
+/*
+
+Public functions
+
+*/
 
 // atof64 return a f64 from a string doing a parsing operation
 pub fn atof64(s string) f64 {

--- a/vlib/strconv/atofq/atofq.v
+++ b/vlib/strconv/atofq/atofq.v
@@ -1,20 +1,20 @@
-/**********************************************************************
-*
-* atof util
-*
-* Copyright (c) 2019 Dario Deledda. All rights reserved.
-* Use of this source code is governed by an MIT license
-* that can be found in the LICENSE file.
-*
-* This file contains utilities for convert a string in a f64 variable in a very quick way
-* IEEE 754 standard is used
-*
-* Know limitation:
-* - round to 0 approximation
-* - loos of precision with big exponents
-*
-*
-**********************************************************************/
+/*
+
+atof util
+
+Copyright (c) 2019 Dario Deledda. All rights reserved.
+Use of this source code is governed by an MIT license
+that can be found in the LICENSE file.
+
+This file contains utilities for convert a string in a f64 variable in a very quick way
+IEEE 754 standard is used
+
+Know limitation:
+- round to 0 approximation
+- loos of precision with big exponents
+
+
+*/
 
 module atofq
 

--- a/vlib/strconv/format.v
+++ b/vlib/strconv/format.v
@@ -1,14 +1,14 @@
-/**********************************************************************
-*
-* printf/sprintf V implementation
-*
-* Copyright (c) 2020 Dario Deledda. All rights reserved.
-* Use of this source code is governed by an MIT license
-* that can be found in the LICENSE file.
-*
-* This file contains the printf/sprintf functions
-*
-**********************************************************************/
+/*
+
+printf/sprintf V implementation
+
+Copyright (c) 2020 Dario Deledda. All rights reserved.
+Use of this source code is governed by an MIT license
+that can be found in the LICENSE file.
+
+This file contains the printf/sprintf functions
+
+*/
 module strconv
 import strconv.ftoa
 import strings
@@ -34,11 +34,11 @@ enum Align_text {
 	center
 }
 
-/******************************************************************************
-*
-* Float conversion utility
-*
-******************************************************************************/
+/*
+
+Float conversion utility
+
+*/
 const(
 	// rounding value
 	dec_round = [
@@ -197,11 +197,11 @@ pub fn f64_to_str_lnd(f f64, dec_digit int) string {
 	}
 }
 
-/******************************************************************************
-*
-* Single format functions
-*
-******************************************************************************/
+/*
+
+ Single format functions
+
+*/
 pub struct BF_param {
 	pad_ch       byte       = ` `     // padding char
 	len0         int        = -1      // default len for whole the number or string
@@ -418,11 +418,11 @@ pub fn remove_tail_zeros(s string) string {
 	return tmp
 }
 
-/******************************************************************************
-*
-* Main functions
-*
-******************************************************************************/
+/*
+
+Main functions
+
+*/
 pub fn v_printf(str string, pt ... voidptr) {
 	print(v_sprintf(str, pt))
 }

--- a/vlib/strconv/ftoa/f32_str.v
+++ b/vlib/strconv/ftoa/f32_str.v
@@ -1,22 +1,22 @@
-/**********************************************************************
-*
-* f32 to string
-*
-* Copyright (c) 2019-2020 Dario Deledda. All rights reserved.
-* Use of this source code is governed by an MIT license
-* that can be found in the LICENSE file.
-*
-* This file contains the f32 to string functions
-*
-* These functions are based on the work of:
-* Publication:PLDI 2018: Proceedings of the 39th ACM SIGPLAN
-* Conference on Programming Language Design and ImplementationJune 2018
-* Pages 270–282 https://doi.org/10.1145/3192366.3192369
-*
-* inspired by the Go version here:
-* https://github.com/cespare/ryu/tree/ba56a33f39e3bbbfa409095d0f9ae168a595feea
-*
-**********************************************************************/
+/*
+
+f32 to string
+
+Copyright (c) 2019-2020 Dario Deledda. All rights reserved.
+Use of this source code is governed by an MIT license
+that can be found in the LICENSE file.
+
+This file contains the f32 to string functions
+
+These functions are based on the work of:
+Publication:PLDI 2018: Proceedings of the 39th ACM SIGPLAN
+Conference on Programming Language Design and ImplementationJune 2018
+Pages 270–282 https://doi.org/10.1145/3192366.3192369
+
+inspired by the Go version here:
+https://github.com/cespare/ryu/tree/ba56a33f39e3bbbfa409095d0f9ae168a595feea
+
+*/
 module ftoa
 
 // dec32 is a floating decimal type representing m * 10^e.
@@ -51,11 +51,11 @@ const(
 	]
 )
 
-/******************************************************************************
-*
-* Conversion Functions
-*
-******************************************************************************/
+/*
+
+ Conversion Functions
+
+*/
 const(
 	mantbits32  = u32(23)
 	expbits32   = u32(8)

--- a/vlib/strconv/ftoa/f64_str.v
+++ b/vlib/strconv/ftoa/f64_str.v
@@ -1,22 +1,22 @@
-/**********************************************************************
-*
-* f32 to string
-*
-* Copyright (c) 2019-2020 Dario Deledda. All rights reserved.
-* Use of this source code is governed by an MIT license
-* that can be found in the LICENSE file.
-*
-* This file contains the f64 to string functions
-*
-* These functions are based on the work of:
-* Publication:PLDI 2018: Proceedings of the 39th ACM SIGPLAN
-* Conference on Programming Language Design and ImplementationJune 2018
-* Pages 270–282 https://doi.org/10.1145/3192366.3192369
-*
-* inspired by the Go version here:
-* https://github.com/cespare/ryu/tree/ba56a33f39e3bbbfa409095d0f9ae168a595feea
-*
-**********************************************************************/
+/*
+
+f32 to string
+
+Copyright (c) 2019-2020 Dario Deledda. All rights reserved.
+Use of this source code is governed by an MIT license
+that can be found in the LICENSE file.
+
+This file contains the f64 to string functions
+
+These functions are based on the work of:
+Publication:PLDI 2018: Proceedings of the 39th ACM SIGPLAN
+Conference on Programming Language Design and ImplementationJune 2018
+Pages 270–282 https://doi.org/10.1145/3192366.3192369
+
+inspired by the Go version here:
+https://github.com/cespare/ryu/tree/ba56a33f39e3bbbfa409095d0f9ae168a595feea
+
+*/
 module ftoa
 
 struct Uint128 {
@@ -65,11 +65,11 @@ const(
 	]
 )
 
-/******************************************************************************
-*
-* Conversion Functions
-*
-******************************************************************************/
+/*
+
+Conversion Functions
+
+*/
 const(
 	mantbits64  = u32(52)
 	expbits64   = u32(11)

--- a/vlib/strconv/ftoa/ftoa.v
+++ b/vlib/strconv/ftoa/ftoa.v
@@ -1,22 +1,22 @@
-/**********************************************************************
-*
-* f32/f64 ftoa functions
-*
-* Copyright (c) 2019-2020 Dario Deledda. All rights reserved.
-* Use of this source code is governed by an MIT license
-* that can be found in the LICENSE file.
-*
-* This file contains the f32/f64 ftoa functions
-*
-* These functions are based on the work of:
-* Publication:PLDI 2018: Proceedings of the 39th ACM SIGPLAN 
-* Conference on Programming Language Design and ImplementationJune 2018 
-* Pages 270–282 https://doi.org/10.1145/3192366.3192369
-*
-* inspired by the Go version here: 
-* https://github.com/cespare/ryu/tree/ba56a33f39e3bbbfa409095d0f9ae168a595feea
-*
-**********************************************************************/
+/*
+
+f32/f64 ftoa functions
+
+Copyright (c) 2019-2020 Dario Deledda. All rights reserved.
+Use of this source code is governed by an MIT license
+that can be found in the LICENSE file.
+
+This file contains the f32/f64 ftoa functions
+
+These functions are based on the work of:
+Publication:PLDI 2018: Proceedings of the 39th ACM SIGPLAN 
+Conference on Programming Language Design and ImplementationJune 2018 
+Pages 270–282 https://doi.org/10.1145/3192366.3192369
+
+inspired by the Go version here: 
+https://github.com/cespare/ryu/tree/ba56a33f39e3bbbfa409095d0f9ae168a595feea
+
+*/
 module ftoa
 
 [inline]

--- a/vlib/strconv/ftoa/utilities.v
+++ b/vlib/strconv/ftoa/utilities.v
@@ -1,33 +1,33 @@
-/**********************************************************************
-*
-* f32/f64 to string utilities
-*
-* Copyright (c) 2019-2020 Dario Deledda. All rights reserved.
-* Use of this source code is governed by an MIT license
-* that can be found in the LICENSE file.
-*
-* This file contains the f32/f64 to string utilities functions
-*
-* These functions are based on the work of:
-* Publication:PLDI 2018: Proceedings of the 39th ACM SIGPLAN
-* Conference on Programming Language Design and ImplementationJune 2018
-* Pages 270–282 https://doi.org/10.1145/3192366.3192369
-*
-* inspired by the Go version here:
-* https://github.com/cespare/ryu/tree/ba56a33f39e3bbbfa409095d0f9ae168a595feea
-*
-**********************************************************************/
+/*
+
+f32/f64 to string utilities
+
+Copyright (c) 2019-2020 Dario Deledda. All rights reserved.
+Use of this source code is governed by an MIT license
+that can be found in the LICENSE file.
+
+This file contains the f32/f64 to string utilities functions
+
+These functions are based on the work of:
+Publication:PLDI 2018: Proceedings of the 39th ACM SIGPLAN
+Conference on Programming Language Design and ImplementationJune 2018
+Pages 270–282 https://doi.org/10.1145/3192366.3192369
+
+inspired by the Go version here:
+https://github.com/cespare/ryu/tree/ba56a33f39e3bbbfa409095d0f9ae168a595feea
+
+*/
 module ftoa
 
 import math.bits
 
 //import math
 
-/******************************************************************************
-*
-* General Utilities
-*
-******************************************************************************/
+/*
+
+General Utilities
+
+*/
 fn assert1(t bool, msg string) {
 	if !t {
 		panic(msg)
@@ -75,11 +75,11 @@ fn get_string_special(neg bool, expZero bool, mantZero bool) string {
 	return "0e+00"
 }
 
-/******************************************************************************
-*
-* 32 bit functions
-*
-******************************************************************************/
+/*
+
+ 32 bit functions
+
+*/
 fn decimal_len_32(u u32) int {
 	// Function precondition: u is not a 10-digit number.
 	// (9 digits are sufficient for round-tripping.)
@@ -166,11 +166,11 @@ fn pow5_bits(e int) int {
 	return int( ((u32(e)*1217359)>>19) + 1)
 }
 
-/******************************************************************************
-*
-* 64 bit functions
-*
-******************************************************************************/
+/*
+
+ 64 bit functions
+
+*/
 fn decimal_len_64(u u64) int {
 	// http://graphics.stanford.edu/~seander/bithacks.html#IntegerLog10
 	log2 := 64 - bits.leading_zeros_64(u) - 1
@@ -220,11 +220,11 @@ fn multiple_of_power_of_two_64(v u64, p u32) bool {
 	return u32(bits.trailing_zeros_64(v)) >= p
 }
 
-/******************************************************************************
-*
-* f64 to string with string format
-*
-******************************************************************************/
+/*
+
+f64 to string with string format
+
+*/
 
 // f32_to_str_l return a string with the f32 converted in a strign in decimal notation
 pub fn f32_to_str_l(f f64) string {

--- a/vlib/szip/szip.v
+++ b/vlib/szip/szip.v
@@ -29,17 +29,17 @@ const (
     m_append = 'a'
 )
 
-/**
- * open opens zip archive with compression level using the given mode.
- *
- * @param zipname zip archive file name.
- * @param level compression level (0-9 are the standard zlib-style levels).
- * @param mode file access mode.
- *        - 'r': opens a file for reading/extracting (the file must exists).
- *        - 'w': creates an empty file for writing.
- *        - 'a': appends to an existing archive.
- *
- * @return the zip archive handler or NULL on error
+/*
+open opens zip archive with compression level using the given mode.
+
+@param zipname zip archive file name.
+@param level compression level (0-9 are the standard zlib-style levels).
+@param mode file access mode.
+        - 'r': opens a file for reading/extracting (the file must exists).
+        - 'w': creates an empty file for writing.
+        - 'a': appends to an existing archive.
+
+@return the zip archive handler or NULL on error
  */
 pub fn open(name string, level int, mode string) ?zip_ptr {
     mut _nlevel := level
@@ -61,33 +61,33 @@ pub fn open(name string, level int, mode string) ?zip_ptr {
     return _p_zip
 }
 
-/**
- * close closes the zip archive, releases resources - always finalize.
- *
- * @param zip zip archive handler.
+/*
+close closes the zip archive, releases resources - always finalize.
+
+@param zip zip archive handler.
  */
 pub fn (mut z zip_ptr) close() {
     C.zip_close(z)
 }
 
-/**
- * open_entry opens an entry by name in the zip archive.
- *
- * For zip archive opened in 'w' or 'a' mode the function will append
- * a new entry. In readonly mode the function tries to locate the entry
- * in global dictionary.
- *
- * @param zip zip archive handler.
- * @param entryname an entry name in local dictionary.
- *
- * @return the return code - 0 on success, negative number (< 0) on error.
+/*
+open_entry opens an entry by name in the zip archive.
+
+For zip archive opened in 'w' or 'a' mode the function will append
+a new entry. In readonly mode the function tries to locate the entry
+in global dictionary.
+
+@param zip zip archive handler.
+@param entryname an entry name in local dictionary.
+
+@return the return code - 0 on success, negative number (< 0) on error.
  */
 pub fn (mut zentry zip_ptr) open_entry(name string) /*?*/bool {
     res := C.zip_entry_open(zentry, name.str)
     return res != -1
 }
 
-/**
+/*
  * close_entry closes a zip entry, flushes buffer and releases resources.
  *
  * @param zip zip archive handler.
@@ -98,19 +98,19 @@ pub fn (mut zentry zip_ptr) close_entry() {
     C.zip_entry_close(zentry)
 }
 
-/**
- * name returns a local name of the current zip entry.
- *
- * The main difference between user's entry name and local entry name
- * is optional relative path.
- * Following .ZIP File Format Specification - the path stored MUST not contain
- * a drive or device letter, or a leading slash.
- * All slashes MUST be forward slashes '/' as opposed to backwards slashes '\'
- * for compatibility with Amiga and UNIX file systems etc.
- *
- * @param zip: zip archive handler.
- *
- * @return the pointer to the current zip entry name, or NULL on error.
+/*
+name returns a local name of the current zip entry.
+
+The main difference between user's entry name and local entry name
+is optional relative path.
+Following .ZIP File Format Specification - the path stored MUST not contain
+a drive or device letter, or a leading slash.
+All slashes MUST be forward slashes '/' as opposed to backwards slashes '\'
+for compatibility with Amiga and UNIX file systems etc.
+
+@param zip: zip archive handler.
+
+@return the pointer to the current zip entry name, or NULL on error.
  */
 pub fn (mut zentry zip_ptr) name() string {
     _name := C.zip_entry_name(zentry)
@@ -120,12 +120,12 @@ pub fn (mut zentry zip_ptr) name() string {
     return tos_clone(_name)
 }
 
-/**
- * index returns an index of the current zip entry.
- *
- * @param zip zip archive handler.
- *
- * @return the index on success, negative number (< 0) on error.
+/*
+index returns an index of the current zip entry.
+
+@param zip zip archive handler.
+
+@return the index on success, negative number (< 0) on error.
  */
 pub fn (mut zentry zip_ptr) index() ?int {
     _index := int(C.zip_entry_index(zentry))
@@ -135,13 +135,13 @@ pub fn (mut zentry zip_ptr) index() ?int {
     return _index // must be check for INVALID_VALUE
 }
 
-/**
- * isdir determines if the current zip entry is a directory entry.
- *
- * @param zip zip archive handler.
- *
- * @return the return code - 1 (true), 0 (false), negative number (< 0) on
- *         error.
+/*
+isdir determines if the current zip entry is a directory entry.
+
+@param zip zip archive handler.
+
+@return the return code - 1 (true), 0 (false), negative number (< 0) on
+         error.
  */
 pub fn (mut zentry zip_ptr) isdir() ?bool {
     _isdir := C.zip_entry_isdir(zentry)
@@ -152,38 +152,38 @@ pub fn (mut zentry zip_ptr) isdir() ?bool {
     return dir
 }
 
-/**
- * size returns an uncompressed size of the current zip entry.
- *
- * @param zip zip archive handler.
- *
- * @return the uncompressed size in bytes.
+/*
+size returns an uncompressed size of the current zip entry.
+
+@param zip zip archive handler.
+
+@return the uncompressed size in bytes.
  */
 pub fn (mut zentry zip_ptr) size() i64 {
     _size := i64(C.zip_entry_size(zentry))
     return _size
 }
 
-/**
- * crc32 returns CRC-32 checksum of the current zip entry.
- *
- * @param zip zip archive handler.
- *
- * @return the CRC-32 checksum.
+/*
+crc32 returns CRC-32 checksum of the current zip entry.
+
+@param zip zip archive handler.
+
+@return the CRC-32 checksum.
  */
 pub fn (mut zentry zip_ptr) crc32() u32 {
     _checksum := u32(C.zip_entry_crc32(zentry))
     return _checksum // 0
 }
 
-/**
- * write_entry compresses an input buffer for the current zip entry.
- *
- * @param zip zip archive handler.
- * @param buf input buffer.
- * @param bufsize input buffer size (in bytes).
- *
- * @return the return code - 0 on success, negative number (< 0) on error.
+/*
+ write_entry compresses an input buffer for the current zip entry.
+
+@param zip zip archive handler.
+@param buf input buffer.
+@param bufsize input buffer size (in bytes).
+
+@return the return code - 0 on success, negative number (< 0) on error.
  */
 pub fn (mut zentry zip_ptr) write_entry(data []byte) bool {
     if (data[0] & 0xff) == -1 {
@@ -194,33 +194,33 @@ pub fn (mut zentry zip_ptr) write_entry(data []byte) bool {
     return res == 0
 }
 
-/**
- * create_entry compresses a file for the current zip entry.
- *
- * @param zip zip archive handler.
- * @param filename input file.
- *
- * @return the return code - 0 on success, negative number (< 0) on error.
+/*
+create_entry compresses a file for the current zip entry.
+
+@param zip zip archive handler.
+@param filename input file.
+
+@return the return code - 0 on success, negative number (< 0) on error.
  */
 pub fn (mut zentry zip_ptr) create_entry(name string) bool {
     res := C.zip_entry_fwrite(zentry, name.str)
     return res == 0
 }
 
-/**
- * read_entry extracts the current zip entry into output buffer.
- *
- * The function allocates sufficient memory for an output buffer.
- *
- * @param zip zip archive handler.
- * @param buf output buffer.
- * @param bufsize output buffer size (in bytes).
- *
- * @note remember to release the memory allocated for an output buffer.
- *       for large entries, please take a look at zip_entry_extract function.
- *
- * @return the return code - the number of bytes actually read on success.
- *         Otherwise a -1 on error.
+/*
+read_entry extracts the current zip entry into output buffer.
+
+The function allocates sufficient memory for an output buffer.
+
+@param zip zip archive handler.
+@param buf output buffer.
+@param bufsize output buffer size (in bytes).
+
+@note remember to release the memory allocated for an output buffer.
+for large entries, please take a look at zip_entry_extract function.
+
+@return the return code - the number of bytes actually read on success.
+         Otherwise a -1 on error.
  */
 pub fn (mut zentry zip_ptr) read_entry() ?voidptr {
     mut _buf := voidptr(0)
@@ -232,13 +232,13 @@ pub fn (mut zentry zip_ptr) read_entry() ?voidptr {
     return _buf
 }
 
-/**
- * extract_entry extracts the current zip entry into output file.
- *
- * @param zip zip archive handler.
- * @param filename output file.
- *
- * @return the return code - 0 on success, negative number (< 0) on error.
+/*
+extract_entry extracts the current zip entry into output file.
+
+@param zip zip archive handler.
+@param filename output file.
+
+@return the return code - 0 on success, negative number (< 0) on error.
  */
 pub fn (mut zentry zip_ptr) extract_entry(path string) /*?*/bool {
     if C.access(path.str, 0) == -1 {
@@ -249,15 +249,15 @@ pub fn (mut zentry zip_ptr) extract_entry(path string) /*?*/bool {
     return res == 0
 }
 
-/**
- * extract extracts the current zip entry using a callback function (on_extract).
- *
- * @param zip zip archive handler.
- * @param on_extract callback function.
- * @param arg opaque pointer (optional argument, which you can pass to the
- *        on_extract callback)
- *
- * @return the return code - 0 on success, negative number (< 0) on error.
+/*
+extract extracts the current zip entry using a callback function (on_extract).
+
+@param zip zip archive handler.
+@param on_extract callback function.
+@param arg opaque pointer (optional argument, which you can pass to the
+        on_extract callback)
+
+@return the return code - 0 on success, negative number (< 0) on error.
  */
 /*fn (mut zentry zip_ptr) extract(path string) bool {
     if C.access(path.str, 0) == -1 {
@@ -268,13 +268,13 @@ pub fn (mut zentry zip_ptr) extract_entry(path string) /*?*/bool {
     return res == 0
 }*/
 
-/**
- * total returns the number of all entries (files and directories) in the zip archive.
- *
- * @param zip zip archive handler.
- *
- * @return the return code - the number of entries on success, negative number
- *         (< 0) on error.
+/*
+total returns the number of all entries (files and directories) in the zip archive.
+
+@param zip zip archive handler.
+
+@return the return code - the number of entries on success, negative number
+         (< 0) on error.
  */
 pub fn (mut zentry zip_ptr) total() ?int {
     _tentry := int(C.zip_total_entries(zentry))


### PR DESCRIPTION
- With the inclusion of #5252, it now transfers some of the module introductions to their respective README's.
- Fixed comments for better output.
