### PR TITLE
vup: preserve v on nix so no full make on v up

### DIFF
--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -4,10 +4,13 @@ import os
 import v.pref
 import v.util
 
+const (
+	vexe = pref.vexe_path()
+	vhome = os.dir(vexe)
+)
+
 fn main() {
-	vexe := pref.vexe_path()
-	vroot := os.dir(vexe)
-	os.chdir(vroot)
+	os.chdir(vhome)
 
 	println('Updating V...')
 
@@ -17,7 +20,7 @@ fn main() {
 		git_command('remote add origin https://github.com/vlang/v')
 		git_command('fetch')
 		git_command('reset --hard origin/master')
-		git_command('clean --quiet -xdf --exclude v.exe --exclude cmd/tools/vup.exe')
+		git_command('clean --quiet -xdf --exclude v --exclude v.exe --exclude cmd/tools/vup.exe')
 	} else {
 		// pull latest
 		git_command('pull origin master')
@@ -76,16 +79,13 @@ fn backup(file string) {
 }
 
 fn git_command(command string) {
-	vexe := pref.vexe_path()
-	vroot := os.dir(vexe)
-
 	git_result := os.exec('git $command') or {
 		panic(err)
 	}
 
 	if git_result.exit_code != 0 {
 		if git_result.output.contains('Permission denied') {
-			eprintln('have no access `$vroot`: Permission denied')
+			eprintln('have no access `$vhome`: Permission denied')
 		} else {
 			eprintln(git_result.output)
 		}


### PR DESCRIPTION
This PR makes `v up` work cleanly from a release archive (where `.git` dir is not included) on *nix.

Now users can just use `v up` whether they extracted from the archive or used `git clone` to start.

The previous PR made this work on Windows, and it  _did_ work on *nix, but because the `git clean` was removing the `v` executable, this was the output:
```
Updating V...
sh: 1: ./v: not found
v self failed, running make...
cd ./vc && git clean -xf && git pull --quiet
cd /var/tmp/tcc && git clean -xf && git pull --quiet
cc  -g -std=gnu11 -w -o v ./vc/v.c  -lm -lpthread
./v self
V self compiling ...
make modules
make[1]: Entering directory '/home/jalon/git/v'
#./v build module vlib/builtin > /dev/null
#./v build module vlib/strings > /dev/null
#./v build module vlib/strconv > /dev/null
make[1]: Leaving directory '/home/jalon/git/v'
V has been successfully built
V 0.1.27 11b7b97
Current V version:
V 0.1.27 11b7b97
```

The main change here is to add the `--exclude v` to t `git clean` to avoid the full `make` - it can just do `v self`.