### PR TITLE
vdoc: minor features + fixes

### DIFF
--- a/cmd/tools/vdoc-resources/doc.js
+++ b/cmd/tools/vdoc-resources/doc.js
@@ -6,7 +6,7 @@
             active.scrollIntoView({ block: 'center', inline: 'nearest' });
         }
     }
-    setupScrollSpy();
+    // setupScrollSpy();
     setupMobileToggle();
     setupDarkMode();
     setupSearch();

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -178,7 +178,7 @@ fn html_highlight(code string, tb &table.Table) string {
 			mut tok_typ := HighlightTokenTyp.unone
 			match tok.kind {
 				.name {
-					if tok.lit in builtin {
+					if tok.lit in builtin || tb.known_type(tok.lit) {
 						tok_typ = .builtin
 					} else if next_tok.kind == .lcbr {
 						tok_typ = .symbol

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -30,6 +30,7 @@ enum HighlightTokenTyp {
 }
 
 const (
+	css_js_assets   = ['doc.css', 'normalize.css' 'doc.js']
 	allowed_formats = ['md', 'markdown', 'json', 'text', 'stdout', 'html', 'htm']
 	exe_path        = os.executable()
 	exe_dir         = os.dir(exe_path)
@@ -284,9 +285,9 @@ fn (cfg DocConfig) gen_html(idx int) string {
 	}	// write head
 
 	// get resources
-	doc_css := cfg.get_resource('doc.css', true)
-	normalize_css := cfg.get_resource('normalize.css', true)
-	doc_js := cfg.get_resource('doc.js', false)
+	doc_css := cfg.get_resource(css_js_assets[0], true)
+	normalize_css := cfg.get_resource(css_js_assets[1], true)
+	doc_js := cfg.get_resource(css_js_assets[2], false)
 	light_icon := cfg.get_resource('light.svg', true)
 	dark_icon := cfg.get_resource('dark.svg', true)
 	menu_icon := cfg.get_resource('menu.svg', true)
@@ -572,7 +573,7 @@ fn (mut cfg DocConfig) generate_docs_from_file() {
 					panic(err)
 				}
 			} else {
-				for fname in ['doc.css', 'normalize.css' 'doc.js'] {
+				for fname in css_js_assets {
 					os.rm(os.join_path(cfg.output_path, fname))
 				}
 			}

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -245,7 +245,7 @@ fn doc_node_html(dd doc.DocNode, link string, head bool, tb &table.Table) string
 	node_id := slug(sym_name)
 	hash_link := if !head { ' <a href="#$node_id">#</a>' } else { '' }
 	dnw.writeln('<section id="$node_id" class="doc-node$is_const_class">')
-	if dd.name != 'README' {
+	if dd.name != 'README' && dd.parent_type != 'Constants' {
 		dnw.write('<div class="title"><$head_tag>$sym_name$hash_link</$head_tag>')
 		if link.len != 0 {
 			dnw.write('<a class="link" rel="noreferrer" target="_blank" href="$link">$link_svg</a>')

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -159,7 +159,13 @@ fn (cfg DocConfig) gen_json(idx int) string {
 fn html_highlight(code string, tb &table.Table) string {
 	builtin := ['bool', 'string', 'i8', 'i16', 'int', 'i64', 'i128', 'byte', 'u16', 'u32', 'u64', 'u128', 'rune', 'f32', 'f64', 'any_int', 'any_float', 'byteptr', 'voidptr', 'any']
 	highlight_code := fn (tok token.Token, typ HighlightTokenTyp) string {
-		lit := if typ in [.unone, .operator, .punctuation] { tok.kind.str() } else { tok.lit }
+		lit := if typ in [.unone, .operator, .punctuation] { 
+			tok.kind.str() 
+		} else if typ == .string { 
+			"'$tok.lit'"
+		} else if typ == .char {
+			'`$tok.lit`'
+		} else { tok.lit }
 		return if typ in [.unone, .name] { lit } else { '<span class="token $typ">$lit</span>' } 
 	}
 	s := scanner.new_scanner(code, .parse_comments)

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -167,6 +167,14 @@ pub fn new(input_path string) Doc {
 	}
 }
 
+pub fn (nodes []DocNode) index_by_name(node_name string) ?int {
+	for i, node in nodes {
+		if node.name != node_name { continue }
+		return i
+	}
+	return error('Node with the name "$node_name" was not found.')
+}
+
 pub fn (nodes []DocNode) find_children_of(parent_type string) []DocNode {
 	if parent_type.len == 0 {
 		return []DocNode{}


### PR DESCRIPTION
- Fix string and char highlighting. (Fixes #5273)
- Check type from `table` aside from builtin types for highlighting types.
- Make constants appear at the top.
- Hide title for other constants.
- Use a single const array for getting CSS/JS doc assets
- Disable Scrollspy mechanism (for now)
- Add experimental JS compressor
