### PR TITLE
compiler: fix compile order of sources files (fix #5216 #5266)

### DIFF
--- a/vlib/math/bits/bits_test.v
+++ b/vlib/math/bits/bits_test.v
@@ -1,7 +1,7 @@
 //
 // test suite for bits and bits math functions
 //
-module bits
+import math.bits
 
 fn test_bits(){
 	mut i := 0
@@ -15,28 +15,28 @@ fn test_bits(){
 	i = 1
 	for x in 0..8 {
 		//C.printf("x:%02x lz: %d cmp: %d\n", i << x, leading_zeros_8(i << x), 7-x)
-		assert leading_zeros_8(byte(i << x)) == 7 - x
+		assert bits.leading_zeros_8(byte(i << x)) == 7 - x
 	}
 
 	// 16 bit
 	i = 1
 	for x in 0..16 {
 		//C.printf("x:%04x lz: %d cmp: %d\n", u16(i) << x, leading_zeros_16(u16(i) << x), 15-x)
-		assert leading_zeros_16(u16(i) << x) == 15 - x
+		assert bits.leading_zeros_16(u16(i) << x) == 15 - x
 	}
 
 	// 32 bit
 	i = 1
 	for x in 0..32 {
 		//C.printf("x:%08x lz: %d cmp: %d\n", u32(i) << x, leading_zeros_32(u32(i) << x), 31-x)
-		assert leading_zeros_32(u32(i) << x) == 31 - x
+		assert bits.leading_zeros_32(u32(i) << x) == 31 - x
 	}
 
 	// 64 bit
 	i = 1
 	for x in 0..64 {
 		//C.printf("x:%016llx lz: %llu cmp: %d\n", u64(i) << x, leading_zeros_64(u64(i) << x), 63-x)
-		assert leading_zeros_64(u64(i) << x) == 63 - x
+		assert bits.leading_zeros_64(u64(i) << x) == 63 - x
 	}
 
 	//
@@ -47,7 +47,7 @@ fn test_bits(){
 	i = 0
 	for x in 0..9 {
 		//C.printf("x:%02x lz: %llu cmp: %d\n", byte(i), ones_count_8(byte(i)), x)
-		assert ones_count_8(byte(i)) == x
+		assert bits.ones_count_8(byte(i)) == x
 		i = (i << 1) + 1
 	}
 
@@ -55,7 +55,7 @@ fn test_bits(){
 	i = 0
 	for x in 0..17 {
 		//C.printf("x:%04x lz: %llu cmp: %d\n", u16(i), ones_count_16(u16(i)), x)
-		assert ones_count_16(u16(i)) == x
+		assert bits.ones_count_16(u16(i)) == x
 		i = (i << 1) + 1
 	}
 
@@ -63,7 +63,7 @@ fn test_bits(){
 	i = 0
 	for x in 0..33 {
 		//C.printf("x:%08x lz: %llu cmp: %d\n", u32(i), ones_count_32(u32(i)), x)
-		assert ones_count_32(u32(i)) == x
+		assert bits.ones_count_32(u32(i)) == x
 		i = (i << 1) + 1
 	}
 
@@ -71,17 +71,17 @@ fn test_bits(){
 	i1 = 0
 	for x in 0..65 {
 		//C.printf("x:%016llx lz: %llu cmp: %d\n", u64(i1), ones_count_64(u64(i1)), x)
-		assert ones_count_64(i1) == x
+		assert bits.ones_count_64(i1) == x
 		i1 = (i1 << 1) + 1
 	}
 
 	//
 	// --- rotate_left/right ---
 	//
-	assert rotate_left_8( 0x12 , 4) == 0x21
-	assert rotate_left_16( 0x1234 , 8) == 0x3412
-	assert rotate_left_32( 0x12345678 , 16) == 0x56781234
-	assert rotate_left_64( 0x1234567887654321 , 32) == 0x8765432112345678
+	assert bits.rotate_left_8( 0x12 , 4) == 0x21
+	assert bits.rotate_left_16( 0x1234 , 8) == 0x3412
+	assert bits.rotate_left_32( 0x12345678 , 16) == 0x56781234
+	assert bits.rotate_left_64( 0x1234567887654321 , 32) == 0x8765432112345678
 
 	//
 	// --- reverse ---
@@ -99,7 +99,7 @@ fn test_bits(){
 			n = n >> 1
 		}
 		//C.printf("x:%02x lz: %llu cmp: %d\n", byte(i), reverse_8(byte(i)), rv)
-		assert reverse_8(byte(i)) == rv
+		assert bits.reverse_8(byte(i)) == rv
 		i = (i << 1) + 1
 	}
 
@@ -115,7 +115,7 @@ fn test_bits(){
 			n = n >> 1
 		}
 		//C.printf("x:%04x lz: %llu cmp: %d\n", u16(i), reverse_16(u16(i)), rv)
-		assert reverse_16(u16(i)) == rv
+		assert bits.reverse_16(u16(i)) == rv
 		i = (i << 1) + 1
 	}
 
@@ -131,7 +131,7 @@ fn test_bits(){
 			n = n >> 1
 		}
 		//C.printf("x:%08x lz: %llu cmp: %d\n", u32(i), reverse_32(u32(i)), rv)
-		assert reverse_32(u32(i)) == rv
+		assert bits.reverse_32(u32(i)) == rv
 		i = (i << 1) + 1
 	}
 
@@ -147,7 +147,7 @@ fn test_bits(){
 			n = n >> 1
 		}
 		//C.printf("x:%016llx lz: %016llx cmp: %016llx\n", u64(i1), reverse_64(u64(i1)), rv)
-		assert reverse_64(i1) == rv
+		assert bits.reverse_64(i1) == rv
 		i1 = (i1 << 1) + 1
 	}
 
@@ -159,15 +159,15 @@ fn test_bits(){
 	i = 1
 	for x in 0..32 {
 		v := u32(i) << x
-		sum,carry := add_32(v, v, u32(0))
+		sum,carry := bits.add_32(v, v, u32(0))
 		//C.printf("x:%08x [%llu,%llu] %llu\n", u32(i) << x, sum, carry, u64(v) + u64(v))
 		assert ((u64(carry) << 32) | u64(sum)) == u64(v) + u64(v)
 	}
-	mut sum_32t, mut carry_32t := add_32(0x8000_0000, 0x8000_0000, u32(0))
+	mut sum_32t, mut carry_32t := bits.add_32(0x8000_0000, 0x8000_0000, u32(0))
 	assert sum_32t == u32(0)
 	assert carry_32t == u32(1)
 
-	sum_32t, carry_32t = add_32(0xFFFF_FFFF, 0xFFFF_FFFF, u32(1))
+	sum_32t, carry_32t = bits.add_32(0xFFFF_FFFF, 0xFFFF_FFFF, u32(1))
 	assert sum_32t == 0xFFFF_FFFF
 	assert carry_32t == u32(1)
 
@@ -175,15 +175,15 @@ fn test_bits(){
 	i = 1
 	for x in 0..63 {
 		v := u64(i) << x
-		sum,carry := add_64(v, v, u64(0))
+		sum,carry := bits.add_64(v, v, u64(0))
 		//C.printf("x:%16x [%llu,%llu] %llu\n", u64(i) << x, sum, carry, u64(v >> 32) + u64(v >> 32))
 		assert ((carry << 32) | sum) == v + v
 	}
-	mut sum_64t, mut carry_64t := add_64(0x8000_0000_0000_0000, 0x8000_0000_0000_0000, u64(0))
+	mut sum_64t, mut carry_64t := bits.add_64(0x8000_0000_0000_0000, 0x8000_0000_0000_0000, u64(0))
 	assert sum_64t == u64(0)
 	assert carry_64t == u64(1)
 
-	sum_64t, carry_64t = add_64(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF, u64(1))
+	sum_64t, carry_64t = bits.add_64(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF, u64(1))
 	assert sum_64t == 0xFFFF_FFFF_FFFF_FFFF
 	assert carry_64t == u64(1)
 
@@ -196,16 +196,16 @@ fn test_bits(){
 	for x in 1..32 {
 		v0 := u32(i) << x
 		v1 := v0 >> 1
-		mut diff, mut borrow_out := sub_32(v0, v1, u32(0))
+		mut diff, mut borrow_out := bits.sub_32(v0, v1, u32(0))
 		//C.printf("x:%08x [%llu,%llu] %08x\n", u32(i) << x, diff, borrow_out, v0 - v1)
 		assert diff == v1
 
-		diff, borrow_out = sub_32(v0, v1, u32(1))
+		diff, borrow_out = bits.sub_32(v0, v1, u32(1))
 		//C.printf("x:%08x [%llu,%llu] %08x\n", u32(i) << x, diff, borrow_out, v0 - v1)
 		assert diff == (v1 - 1)
 		assert borrow_out == u32(0)
 
-		diff, borrow_out = sub_32(v1, v0, u32(1))
+		diff, borrow_out = bits.sub_32(v1, v0, u32(1))
 		//C.printf("x:%08x [%llu,%llu] %08x\n", u32(i) << x, diff, borrow_out, v1 - v0)
 		assert borrow_out == u32(1)
 	}
@@ -215,16 +215,16 @@ fn test_bits(){
 	for x in 1..64 {
 		v0 := u64(i) << x
 		v1 := v0 >> 1
-		mut diff, mut borrow_out := sub_64(v0, v1, u64(0))
+		mut diff, mut borrow_out := bits.sub_64(v0, v1, u64(0))
 		//C.printf("x:%08x [%llu,%llu] %08x\n", u64(i) << x, diff, borrow_out, v0 - v1)
 		assert diff == v1
 
-		diff, borrow_out = sub_64(v0, v1, u64(1))
+		diff, borrow_out = bits.sub_64(v0, v1, u64(1))
 		//C.printf("x:%08x [%llu,%llu] %08x\n", u64(i) << x, diff, borrow_out, v0 - v1)
 		assert diff == (v1 - 1)
 		assert borrow_out == u64(0)
 
-		diff, borrow_out = sub_64(v1, v0, u64(1))
+		diff, borrow_out = bits.sub_64(v1, v0, u64(1))
 		//C.printf("x:%08x [%llu,%llu] %08x\n",u64(i) << x, diff, borrow_out, v1 - v0)
 		assert borrow_out == u64(1)
 	}
@@ -238,7 +238,7 @@ fn test_bits(){
 	for x in 0..32 {
 		v0 := u32(i) << x
 		v1 := v0 - 1
-		hi, lo := mul_32(v0, v1)
+		hi, lo := bits.mul_32(v0, v1)
 		assert (u64(hi) << 32) | (u64(lo)) == u64(v0) * u64(v1)
 	}
 
@@ -247,7 +247,7 @@ fn test_bits(){
 	for x in 0..64 {
 		v0 := u64(i) << x
 		v1 := v0 - 1
-		hi, lo := mul_64(v0, v1)
+		hi, lo := bits.mul_64(v0, v1)
 		//C.printf("v0: %llu v1: %llu [%llu,%llu] tt: %llu\n", v0, v1, hi, lo, (v0 >> 32) * (v1 >> 32))
 		assert (hi & 0xFFFF_FFFF_0000_0000) == (((v0 >> 32)*(v1 >> 32)) & 0xFFFF_FFFF_0000_0000)
 		assert (lo & 0x0000_0000_FFFF_FFFF) == (((v0 & 0x0000_0000_FFFF_FFFF) * (v1 & 0x0000_0000_FFFF_FFFF)) & 0x0000_0000_FFFF_FFFF)
@@ -263,12 +263,12 @@ fn test_bits(){
 		hi := u32(i) << x
 		lo := hi - 1
 		y  := u32(3) << x
-		quo, rem := div_32(hi, lo, y)
+		quo, rem := bits.div_32(hi, lo, y)
 		//C.printf("[%08x_%08x] %08x (%08x,%08x)\n", hi, lo, y, quo, rem)
 		tst := ((u64(hi) << 32) | u64(lo))
 		assert quo == (tst / u64(y))
 		assert rem == (tst % u64(y))
-		assert rem == rem_32(hi, lo, y)
+		assert rem == bits.rem_32(hi, lo, y)
 	}
 
 	// 64 bit
@@ -277,12 +277,12 @@ fn test_bits(){
 		hi := u64(i) << x
 		lo := u64(2) //hi - 1
 		y  := u64(0x4000_0000_0000_0000)
-		quo, rem := div_64(hi, lo, y)
+		quo, rem := bits.div_64(hi, lo, y)
 		//C.printf("[%016llx_%016llx] %016llx (%016llx,%016llx)\n", hi, lo, y, quo, rem)
 		assert quo == u64(2)<<(x+1)
-		_, rem1 := div_64(hi%y, lo, y)
+		_, rem1 := bits.div_64(hi%y, lo, y)
 		assert rem == rem1
-		assert rem == rem_64(hi, lo, y)
+		assert rem == bits.rem_64(hi, lo, y)
 	}
 
 }

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -5,9 +5,7 @@ import v.ast
 import v.table
 import v.pref
 import v.util
-import v.vmod
 import v.checker
-import v.parser
 import v.depgraph
 
 pub struct Builder {
@@ -17,14 +15,13 @@ pub:
 	module_path         string
 mut:
 	checker             checker.Checker
-	pref                &pref.Preferences
 	parsed_files        []ast.File
 	global_scope        &ast.Scope
 	out_name_c          string
 	out_name_js         string
 	max_nr_errors       int = 100
 pub mut:
-	module_search_paths []string
+	pref                &pref.Preferences
 }
 
 pub fn new_builder(pref &pref.Preferences) Builder {
@@ -56,47 +53,7 @@ pub fn new_builder(pref &pref.Preferences) Builder {
 
 // parse all deps from already parsed files
 pub fn (mut b Builder) parse_imports() {
-	mut done_imports := []string{}
-	// NB: b.parsed_files is appended in the loop,
-	// so we can not use the shorter `for in` form.
-	for i := 0; i < b.parsed_files.len; i++ {
-		ast_file := b.parsed_files[i]
-		for _, imp in ast_file.imports {
-			mod := imp.mod
-			if mod == 'builtin' {
-				verror('cannot import module "$mod"')
-				break
-			}
-			if mod in done_imports {
-				continue
-			}
-			import_path := b.find_module_path(mod, ast_file.path) or {
-				// v.parsers[i].error_with_token_index('cannot import module "$mod" (not found)', v.parsers[i].import_table.get_import_tok_idx(mod))
-				// break
-				// println('module_search_paths:')
-				// println(b.module_search_paths)
-				verror('cannot import module "$mod" (not found)')
-				break
-			}
-			v_files := b.v_files_from_dir(import_path)
-			if v_files.len == 0 {
-				// v.parsers[i].error_with_token_index('cannot import module "$mod" (no .v files in "$import_path")', v.parsers[i].import_table.get_import_tok_idx(mod))
-				verror('cannot import module "$mod" (no .v files in "$import_path")')
-			}
-			// Add all imports referenced by these libs
-			parsed_files := parser.parse_files(v_files, b.table, b.pref, b.global_scope)
-			for file in parsed_files {
-				if file.mod.name != mod {
-					// v.parsers[pidx].error_with_token_index('bad module definition: ${v.parsers[pidx].file_path} imports module "$mod" but $file is defined as module `$p_mod`', 1
-					verror('bad module definition: ${ast_file.path} imports module "$mod" but $file.path is defined as module `$file.mod.name`')
-				}
-			}
-			b.parsed_files << parsed_files
-			done_imports << mod
-		}
-	}
 	b.resolve_deps()
-	//
 	if b.pref.print_v_files {
 		for p in b.parsed_files {
 			println(p.path)
@@ -158,25 +115,6 @@ pub fn (b &Builder) import_graph() &depgraph.DepGraph {
 	return graph
 }
 
-pub fn (b Builder) v_files_from_dir(dir string) []string {
-	if !os.exists(dir) {
-		if dir == 'compiler' && os.is_dir('vlib') {
-			println('looks like you are trying to build V with an old command')
-			println('use `v -o v cmd/v` instead of `v -o v compiler`')
-		}
-		verror("$dir doesn't exist")
-	} else if !os.is_dir(dir) {
-		verror("$dir isn't a directory!")
-	}
-	mut files := os.ls(dir) or {
-		panic(err)
-	}
-	if b.pref.is_verbose {
-		println('v_files_from_dir ("$dir")')
-	}
-	return b.pref.should_compile_filtered_files(dir, files)
-}
-
 pub fn (b Builder) log(s string) {
 	if b.pref.is_verbose {
 		println(s)
@@ -187,38 +125,6 @@ pub fn (b Builder) info(s string) {
 	if b.pref.is_verbose {
 		println(s)
 	}
-}
-
-[inline]
-fn module_path(mod string) string {
-	// submodule support
-	return mod.replace('.', os.path_separator)
-}
-
-pub fn (b Builder) find_module_path(mod, fpath string) ?string {
-	// support @VROOT/v.mod relative paths:
-	mcache := vmod.get_cache()
-	vmod_file_location := mcache.get_by_file(fpath)
-	mod_path := module_path(mod)
-	mut module_lookup_paths := []string{}
-	if vmod_file_location.vmod_file.len != 0 && vmod_file_location.vmod_folder !in b.module_search_paths {
-		module_lookup_paths << vmod_file_location.vmod_folder
-	}
-	module_lookup_paths << b.module_search_paths
-	for search_path in module_lookup_paths {
-		try_path := os.join_path(search_path, mod_path)
-		if b.pref.is_verbose {
-			println('  >> trying to find $mod in $try_path ..')
-		}
-		if os.is_dir(try_path) {
-			if b.pref.is_verbose {
-				println('  << found $try_path .')
-			}
-			return try_path
-		}
-	}
-	smodule_lookup_paths := module_lookup_paths.join(', ')
-	return error('module "$mod" not found in:\n$smodule_lookup_paths')
 }
 
 fn (b &Builder) print_warnings_and_errors() {

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -59,9 +59,9 @@ fn (mut b Builder) run_compiled_executable_and_exit() {
 	if b.pref.is_verbose {
 		println('============ running $b.pref.out_name ============')
 	}
-	
+
 	mut cmd := '"${b.pref.out_name}"'
-	
+
 	if b.pref.backend == .js {
 		cmd = 'node "${b.pref.out_name}.js"'
 	}
@@ -108,20 +108,20 @@ fn (mut v Builder) set_module_lookup_paths() {
 	// By default, these are what (3) contains:
 	// 3.1) search in vlib/
 	// 3.2) search in ~/.vmodules/ (i.e. modules installed with vpm)
-	v.module_search_paths = []
+	v.pref.module_search_paths = []
 	if v.pref.is_test {
-		v.module_search_paths << os.base_dir(v.compiled_dir) // pdir of _test.v
+		v.pref.module_search_paths << os.base_dir(v.compiled_dir) // pdir of _test.v
 	}
-	v.module_search_paths << v.compiled_dir
+	v.pref.module_search_paths << v.compiled_dir
 	x := os.join_path(v.compiled_dir, 'modules')
 	if v.pref.is_verbose {
 		println('x: "$x"')
 	}
-	v.module_search_paths << os.join_path(v.compiled_dir, 'modules')
-	v.module_search_paths << v.pref.lookup_path
+	v.pref.module_search_paths << os.join_path(v.compiled_dir, 'modules')
+	v.pref.module_search_paths << v.pref.lookup_path
 	if v.pref.is_verbose {
 		v.log('v.module_search_paths:')
-		println(v.module_search_paths)
+		println(v.pref.module_search_paths)
 	}
 }
 
@@ -142,12 +142,12 @@ pub fn (v Builder) get_builtin_files() []string {
 			continue
 		}
 		if v.pref.is_bare {
-			return v.v_files_from_dir(os.join_path(location, 'builtin', 'bare'))
+			return v.pref.v_files_from_dir(os.join_path(location, 'builtin', 'bare'))
 		}
 		if v.pref.backend == .js {
-			return v.v_files_from_dir(os.join_path(location, 'builtin', 'js'))
+			return v.pref.v_files_from_dir(os.join_path(location, 'builtin', 'js'))
 		}
-		return v.v_files_from_dir(os.join_path(location, 'builtin'))
+		return v.pref.v_files_from_dir(os.join_path(location, 'builtin'))
 	}
 	// Panic. We couldn't find the folder.
 	verror('`builtin/` not included on module lookup path.
@@ -230,7 +230,7 @@ pub fn (v Builder) get_user_files() []string {
 			v.log('> add all .v files from directory "${dir}" ...')
 		}
 		// Add .v files from the directory being compiled
-		user_files << v.v_files_from_dir(dir)
+		user_files << v.pref.v_files_from_dir(dir)
 	}
 	if user_files.len == 0 {
 		println('No input .v files')

--- a/vlib/v/builder/x64.v
+++ b/vlib/v/builder/x64.v
@@ -28,7 +28,7 @@ pub fn (mut b Builder) build_x64(v_files []string, out_file string) {
 }
 
 pub fn (mut b Builder) compile_x64() {
-	// v.files << v.v_files_from_dir(os.join_path(v.pref.vlib_path,'builtin','bare'))
+	// v.files << v.pref.v_files_from_dir(os.join_path(v.pref.vlib_path,'builtin','bare'))
 	files := [b.pref.path]
 	b.set_module_lookup_paths()
 	b.build_x64(files, b.pref.out_name)

--- a/vlib/v/checker/tests/import_not_found_err.out
+++ b/vlib/v/checker/tests/import_not_found_err.out
@@ -1,1 +1,5 @@
-builder error: cannot import module "notexist" (not found)
+vlib/v/checker/tests/import_not_found_err.v:1:8: error: cannot import module "notexist" (not found)
+    1 | import notexist
+      |        ~~~~~~~~
+    2 | fn main() {
+    3 |     println(notexist.name)

--- a/vlib/v/gen/cgen_test.v
+++ b/vlib/v/gen/cgen_test.v
@@ -22,7 +22,7 @@ fn test_c_files() {
 			panic(err)
 		}
 		mut b := builder.new_builder(pref.Preferences{})
-		b.module_search_paths = ['$vroot/vlib/v/gen/tests/']
+		b.pref.module_search_paths = ['$vroot/vlib/v/gen/tests/']
 		mut res := b.gen_c([path]).after('#endbuiltin')
 		if res.contains('string _STR') {
 			pos := res.index('string _STR') or {

--- a/vlib/v/pref/module.v
+++ b/vlib/v/pref/module.v
@@ -1,0 +1,45 @@
+module pref
+
+import v.vmod
+import os
+
+pub fn (mut p Preferences) find_module_path(mod, fpath string) ?string {
+	// support @VROOT/v.mod relative paths:
+	mcache := vmod.get_cache()
+	vmod_file_location := mcache.get_by_file(fpath)
+	mod_path := mod.replace('.', os.path_separator)
+	mut module_lookup_paths := []string{}
+	if vmod_file_location.vmod_file.len != 0 && vmod_file_location.vmod_folder !in p.module_search_paths {
+		module_lookup_paths << vmod_file_location.vmod_folder
+	}
+	module_lookup_paths << p.module_search_paths
+	for search_path in module_lookup_paths {
+		try_path := os.join_path(search_path, mod_path)
+		if os.is_dir(try_path) {
+			return try_path
+		}
+	}
+	smodule_lookup_paths := module_lookup_paths.join(', ')
+	return error('module "$mod" not found in:\n$smodule_lookup_paths')
+}
+
+pub fn (p Preferences) v_files_from_dir(dir string) []string {
+	if !os.exists(dir) {
+		if dir == 'compiler' && os.is_dir('vlib') {
+			println('looks like you are trying to build V with an old command')
+			println('use `v -o v cmd/v` instead of `v -o v compiler`')
+		}
+		eprintln("$dir doesn't exist")
+		exit(1)
+	} else if !os.is_dir(dir) {
+		eprintln("$dir isn't a directory!")
+		exit(1)
+	}
+	mut files := os.ls(dir) or {
+		panic(err)
+	}
+	if p.is_verbose {
+		println('v_files_from_dir ("$dir")')
+	}
+	return p.should_compile_filtered_files(dir, files)
+}

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -104,14 +104,15 @@ pub mut:
 	compile_defines_all []string // contains both: ['vfmt','another']
 
 	mod                 string
+	module_search_paths []string
 	run_args            []string // `v run x.v 1 2 3` => `1 2 3`
 	printfn_list        []string // a list of generated function names, whose source should be shown, for debugging
 	print_v_files       bool     // when true, just print the list of all parsed .v files then stop.
 	skip_running        bool     // when true, do no try to run the produced file (set by b.cc(), when -o x.c or -o x.js)
 	skip_warnings       bool     // like C's "-w"
 	use_color           ColorOutput // whether the warnings/errors should use ANSI color escapes.
-	is_parallel bool
-	error_limit int
+	is_parallel         bool
+	error_limit         int
 }
 
 pub fn parse_args(args []string) (&Preferences, string) {

--- a/vlib/v/tests/module_type_cast_test.v
+++ b/vlib/v/tests/module_type_cast_test.v
@@ -1,0 +1,8 @@
+import time
+
+fn test_module_type_cast() {
+	a := time.Duration(5)
+	b := time.Duration(6)
+	//println(a+b)
+	assert a+b == 11
+}

--- a/vlib/v/tests/repl/entire_commented_module.repl
+++ b/vlib/v/tests/repl/entire_commented_module.repl
@@ -1,3 +1,0 @@
-import v.tests.modules.acommentedmodule
-===output===
-builder error: bad module definition: .entire_commented_module.repl.vrepl_temp.v imports module "v.tests.modules.acommentedmodule" but vlib/v/tests/modules/acommentedmodule/commentedfile.v is defined as module `main`

--- a/vlib/v/tests/repl/entire_commented_module.skip
+++ b/vlib/v/tests/repl/entire_commented_module.skip
@@ -1,0 +1,7 @@
+import v.tests.modules.acommentedmodule
+===output===
+vlib/v/tests/modules/acommentedmodule/commentedfile.v:1:1: error: imports module `v.tests.modules.acommentedmodule` but `vlib/v/tests/modules/acommentedmodule/commentedfile.v` is defined as module `main`
+    1 | /*
+      | ^
+    2 | module acommentedmodule
+    3 |

--- a/vlib/v/tests/repl/repl_test.v
+++ b/vlib/v/tests/repl/repl_test.v
@@ -21,7 +21,7 @@ fn test_the_v_compiler_can_be_invoked() {
 	}
 	// println('"$vcmd_error" exit_code: $r_error.exit_code | output: $r_error.output')
 	assert r_error.exit_code == 1
-	assert r_error.output == "builder error: nonexisting.v doesn't exist"
+	assert r_error.output == "nonexisting.v doesn't exist"
 }
 
 struct Session {


### PR DESCRIPTION
This PR fix compiler order of sources files (fix #5216 fix #5266).

- Fix compiler order of sources files.
- Add test `module_type_cast_test.v`.

```v
import time

fn main() {
	a := time.Duration(5)
	b := time.Duration(6)
	println(a+b)
}

D:\test\v\tt1>v run .
11
```

Solution
- Add `parse_file_by_mod()` to parse dependences files in advance, previously, it was all files analysis and then dependency analysis.
- There will be some impact on parallel analysis, but it should be able to resolve.
