### PR TITLE
vrepl: fix working path has spaces error (fix #5256)

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -184,7 +184,7 @@ fn run_repl(workdir string, vrepl_prefix string) {
 		if r.line.starts_with('print') {
 			source_code := r.current_source_code(false) + '\n${r.line}\n'
 			os.write_file(file, source_code)
-			s := os.exec('"$vexe" -repl run $file') or {
+			s := os.exec('"$vexe" -repl run "$file"') or {
 				rerror(err)
 				return
 			}
@@ -229,7 +229,7 @@ fn run_repl(workdir string, vrepl_prefix string) {
 				temp_source_code = r.current_source_code(true) + '\n${temp_line}\n'
 			}
 			os.write_file(temp_file, temp_source_code)
-			s := os.exec('"$vexe" -repl run $temp_file') or {
+			s := os.exec('"$vexe" -repl run "$temp_file"') or {
 				rerror(err)
 				return
 			}


### PR DESCRIPTION
This PR fix working path has spaces error (fix #5256).

- Fix working path has spaces error.
- Just double quotes around the path name in the command string.
- It's not clear how this situation increases test cases, so there's no additional testing.

```v
C:\Users\yuyi9\test v>v
For usage information, quit V REPL using `exit` and use `v help`
V 0.1.27 11b7b97
Use Ctrl-C or `exit` to exit
>>> 2+2
4
>>>
```