### PR TITLE
symlink: no longer truncate PATH to 1024 characters on windows

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -202,6 +202,10 @@ fn C.SetHandleInformation(hObject voidptr, dwMask u32, dw_flags u32) bool
 fn C.ExpandEnvironmentStringsW(lpSrc &u16, lpDst &u16, nSize u32) u32
 
 
+fn C.SendMessageTimeout() u32
+fn C.SendMessageTimeoutW(hWnd voidptr, Msg u32, wParam &u16, lParam &u32, fuFlags u32, uTimeout u32, lpdwResult &u64) u32
+
+
 fn C.CreateProcessW(lpApplicationName &u16, lpCommandLine &u16, lpProcessAttributes voidptr, lpThreadAttributes voidptr, bInheritHandles bool, dwCreationFlags u32, lpEnvironment voidptr, lpCurrentDirectory &u16, lpStartupInfo voidptr, lpProcessInformation voidptr) bool
 
 
@@ -211,16 +215,19 @@ fn C.ReadFile(hFile voidptr, lpBuffer voidptr, nNumberOfBytesToRead u32, lpNumbe
 fn C.GetFileAttributesW(lpFileName byteptr) u32
 
 
+fn C.RegQueryValueEx() voidptr
 fn C.RegQueryValueExW(hKey voidptr, lpValueName &u16, lp_reserved &u32, lpType &u32, lpData byteptr, lpcbData &u32) int
 
 
+fn C.RegOpenKeyEx() voidptr
 fn C.RegOpenKeyExW(hKey voidptr, lpSubKey &u16, ulOptions u32, samDesired u32, phkResult voidptr) int
 
 
+fn C.RegSetValueEx() voidptr
+fn C.RegSetValueExW(hKey voidptr, lpValueName &u16, Reserved u32, dwType u32, lpData byteptr, lpcbData u32) int
+
+
 fn C.RegCloseKey()
-
-
-fn C.RegQueryValueEx() voidptr
 
 
 fn C.RemoveDirectory() int
@@ -338,7 +345,6 @@ fn C.CloseHandle()
 fn C.GetExitCodeProcess()
 
 
-fn C.RegOpenKeyEx() voidptr
 
 
 fn C.GetTickCount() i64

--- a/vlib/v/builder/msvc.v
+++ b/vlib/v/builder/msvc.v
@@ -118,7 +118,7 @@ fn find_windows_kit_root(host_arch string) ?WindowsKit {
 			shared_include_path: kit_include_highest + '\\shared'
 		}
 	}
-	return error('Host OS does not support funding a windows kit')
+	return error('Host OS does not support finding a windows kit')
 }
 
 struct VsInstallation {
@@ -129,7 +129,7 @@ struct VsInstallation {
 
 fn find_vs(vswhere_dir, host_arch string) ?VsInstallation {
 	$if !windows {
-		return error('Host OS does not support finding a Vs installation')
+		return error('Host OS does not support finding a Visual Studio installation')
 	}
 	// Emily:
 	// VSWhere is guaranteed to be installed at this location now


### PR DESCRIPTION
Problem: https://superuser.com/questions/387619/overcoming-the-1024-character-limit-with-setx
Solution: https://stackoverflow.com/a/8358361

This PR implements the solution from that SO answer for `v symlink`.

Goal:
* Running `v symlink` updates system PATH on windows _without_ truncating it when the resulting value is longer than 1024 characters

Summary of updates:
* Use native Windows C API to add to the system PATH variable in the Windows Registry directly instead of using the `setx /M` command
* Use native Windows C API to broadcast a setting change window message
* Grouped a few `cfns.c.v` declarations from the Win32 API into <name>/<name>W pairs
* A few typos

I'm not entirely sure how I'd write tests for this code that proves it does what it does without creating a new win32 window that listens for `WM_SETTINGCHANGED`, so I have opted to leave that out for now.
No doc changes are necessary.

I appreciate any feedback you can give me :)