### PR TITLE
atypes: remove name from MultiReturn type

### DIFF
--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -277,8 +277,6 @@ pub const (
 )
 
 pub struct MultiReturn {
-pub:
-	name  string
 pub mut:
 	types []Type
 }


### PR DESCRIPTION
name fields seems not used in MultiReturn