### PR TITLE
docs: add missing links to ToC

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -66,18 +66,22 @@ you can do in V.
 		<td><a href='#writing-documentation'>Writing documentation</a></td>
 		</tr>
 	<tr>
+		<td><a href='#profiling'>Profiling</a></td>
 		<td><a href='#calling-c-functions-from-v'>Calling C functions from V</a></td>
 		<td><a href='#conditional-compilation'>Conditional compilation</a></td>
+		<td><a href='#compile-time-pseudo-variables'>Compile time pseudo variables</a></td>
 		<td><a href='#reflection-via-codegen'>Reflection via codegen</a></td>
 		<td><a href='#limited-operator-overloading'>Limited operator overloading</a></td>
+	</tr>
+	<tr>
 		<td><a href='#inline-assembly'>Inline assembly</a></td>
 		<td><a href='#translating-cc-to-v'>Translating C/C++ to V</a></td>
-		</tr>
-	<tr>
 		<td><a href='#hot-code-reloading'>Hot code reloading</a></td>
 		<td><a href='#cross-compilation'>Cross compilation</a></td>
 		<td><a href='#cross-platform-shell-scripts-in-v'>Cross-platform shell scripts in V</a></td>
 		<td><a href='#appendix-i-keywords'>Appendix I: Keywords</a></td>
+	</tr>
+	<tr>
 		<td><a href='#appendix-ii-operators'>Appendix II: Operators</a></td>
 	</tr>
 </table>


### PR DESCRIPTION
Add links for `Profiling` and `Compile time pseudo variables` to the docs ToC.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
