### PR TITLE
defer before propagate bug

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3296,6 +3296,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type table.
 			g.stmts(stmts)
 		}
 	} else if or_block.kind == .propagate {
+		g.write_defer_stmts()
 		if g.file.mod.name == 'main' && g.cur_fn.name == 'main' {
 			if g.pref.is_debug {
 				paline, pafile, pamod, pafn := g.panic_debug_info(or_block.pos)


### PR DESCRIPTION
defer before propagate the optional call,the  propagate statement don't add the defer statement
```
fn test2() int {
	defer {println('test2 end')}
	return 1
}

fn test1(v bool)?string {
	if v {
		return 'hello'
	}
	return error('it is error')
}
fn main() {
	defer {println('this is defer 1')}
	str := test1(false)?
	println(test2())
	defer {[println('this is defer 2')]}
	println(str)
}
```
generate code is:
```
	Option_string _t1 = test1(false);
	if (!_t1.ok) {
	// defer
		println(tos_lit("this is defer 1"));
		v_panic(_t1.v_error);
	}
```
```