### PR TITLE
parser: fix type_only fns starting with varargs

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -359,7 +359,7 @@ fn (mut p Parser) fn_args() ([]table.Arg, bool) {
 	mut args := []table.Arg{}
 	mut is_variadic := false
 	// `int, int, string` (no names, just types)
-	types_only := p.tok.kind in [.amp, .and] || (p.peek_tok.kind == .comma && p.table.known_type(p.tok.lit)) ||
+	types_only := p.tok.kind in [.amp, .and, .ellipsis] || (p.peek_tok.kind == .comma && p.table.known_type(p.tok.lit)) ||
 		p.peek_tok.kind == .rpar
 	// TODO copy pasta, merge 2 branches
 	if types_only {

--- a/vlib/v/tests/interop_test.v
+++ b/vlib/v/tests/interop_test.v
@@ -1,0 +1,16 @@
+// Not real external functions, so we won't call them
+// We just want to make sure they compile
+
+struct Foo {}
+
+fn C.a(a string, b int) f32
+fn C.b(a &voidptr)
+fn C.c(a string, b ...string) string
+fn C.d(a ...int)
+
+fn JS.e(a string, b ...string) int
+fn JS.f(a &Foo) // TODO: Should this be allowed?
+
+fn C.g(string, ...int)
+fn C.h(&int)
+fn JS.i(...string)


### PR DESCRIPTION
This PR fixes type_only functions starting with varargs:
```
fn C.foo(...string)
```

It also adds relevant tests to `tests/interop_test.v`.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
