### PR TITLE
interface: update tests

### DIFF
--- a/vlib/v/tests/interface_test.v
+++ b/vlib/v/tests/interface_test.v
@@ -430,7 +430,8 @@ fn get_animal_name(mut a Animal2) string {
 	return a.get_name()
 }
 
-fn main() {
+fn test_aa() {
+	println('---- ${@FN} ----')
 	mut aa := AA{}
 	mut ii := II(aa)
 	assert ii.my_field == 0

--- a/vlib/v/tests/interface_test.v
+++ b/vlib/v/tests/interface_test.v
@@ -59,6 +59,10 @@ fn (mut d Dog) set_breed(new string) {
 
 // do not add to Dog the utility function 'str', so the default one will be used, as a sample
 
+struct Bird {
+	breed string
+}
+
 fn (a Bird) speak(s string) {
 	println('tweet')
 }
@@ -68,7 +72,7 @@ fn (a Bird) name() string {
 }
 
 fn (a Bird) name_detailed(pet_name string) string {
-	return '$pet_name the ${typeof(a)}, breed:${a.breed}'
+	return '$pet_name the ${typeof(a).name}, breed:${a.breed}'
 }
 
 fn (mut d Bird) set_breed(new string) {
@@ -102,6 +106,7 @@ fn perform_speak(a Animal) {
 	println(a.name())
 	println('Got animal of type: ${typeof(a).name}') // TODO: get implementation type (if possible)
 	assert a is Dog || a is Cat
+	assert is_dog_or_cat(a) // TODO: fix compiler error
 }
 
 fn perform_speak_on_ptr(a &Animal) {
@@ -116,6 +121,7 @@ fn perform_speak_on_ptr(a &Animal) {
 	println(a.name())
 	println('Got animal of type: ${typeof(a).name}') // TODO: get implementation type (if possible)
 	assert a is Dog || a is Cat
+	assert is_dog_or_cat(a) // TODO: fix compiler error
 }
 
 fn test_perform_speak() {
@@ -139,11 +145,6 @@ fn test_perform_speak() {
 	})
 	perform_speak_on_ptr(new_cat('Persian'))
 	handle_animals([dog, cat])
-	/*
-	f := Foo {
-		speaker: dog
-	}
-	*/
 }
 
 fn change_animal_breed(mut a Animal, new string) {
@@ -331,15 +332,18 @@ fn test_is_bool() {
 	println('---- ${@FN} ----')
 	dog := Dog{}
 	assert is_dog(dog) == true
+	assert is_dog_or_cat(dog) // TODO: fix compiler error
 	cat := Cat{}
 	assert is_dog(cat) == false
+	assert is_dog_or_cat(cat) // TODO: fix compiler error
 	bird := Bird{}
 	assert is_dog(bird) == false
+	assert !is_dog_or_cat(bird) // TODO: fix compiler error
 }
 
 fn is_dog(a Animal) bool {
 	println("Got animal: '$a'")  // implicit call to 'str' function of implementations
-	println("with type: ${typeof(a)}")  // get implementation type (if possible)
+	println("with type: ${typeof(a).name}")  // get implementation type (if possible)
 
 	// sample (additional checks) here
 	is_dog_or_cat := if (a is Dog) || (a is Cat) { true } else { false }

--- a/vlib/v/tests/interface_test.v
+++ b/vlib/v/tests/interface_test.v
@@ -60,23 +60,25 @@ fn (mut d Dog) set_breed(new string) {
 // do not add to Dog the utility function 'str', so the default one will be used, as a sample
 
 struct Bird {
+mut:
 	breed string
 }
 
-fn (a Bird) speak(s string) {
+fn (b Bird) speak(s string) {
 	println('tweet')
 }
 
-fn (a Bird) name() string {
-	return a.breed
+fn (b Bird) name() string {
+	return b.breed
 }
 
-fn (a Bird) name_detailed(pet_name string) string {
-	return '$pet_name the ${typeof(a).name}, breed:${a.breed}'
+fn (b Bird) name_detailed(pet_name string) string {
+	return '$pet_name the ${typeof(b).name}, breed:$b.breed'
 }
 
-fn (mut d Bird) set_breed(new string) {
+fn (mut b Bird) set_breed(new string) {
 	println('canary')
+	b.breed = new
 }
 
 // do not add to Bird the utility function 'str', so the default one will be used, as a sample
@@ -92,8 +94,14 @@ fn is_dog_or_cat(a Animal) bool {
 	return is_dog_or_cat
 }
 
+fn is_dog_or_cat_or_bird(a Animal) bool {
+	ret := a is Dog || a is Cat || a is Bird
+	println('Animal is Dog or Cat or Bird: $ret')
+	return ret
+}
+
 fn perform_speak(a Animal) {
-	println('---- ${@FN} ----')
+	println('---- ${@FN}, given Animal: $a ----')
 	a.speak('Hi !')
 	assert true
 	name := a.name()
@@ -106,11 +114,11 @@ fn perform_speak(a Animal) {
 	println(a.name())
 	println('Got animal of type: ${typeof(a).name}') // TODO: get implementation type (if possible)
 	assert a is Dog || a is Cat
-	assert is_dog_or_cat(a) // TODO: fix compiler error
+	assert is_dog_or_cat(a)
 }
 
 fn perform_speak_on_ptr(a &Animal) {
-	println('---- ${@FN} ----')
+	println('---- ${@FN}, given &Animal: $a ----')
 	a.speak('Hi !')
 	assert true
 	name := a.name()
@@ -121,7 +129,7 @@ fn perform_speak_on_ptr(a &Animal) {
 	println(a.name())
 	println('Got animal of type: ${typeof(a).name}') // TODO: get implementation type (if possible)
 	assert a is Dog || a is Cat
-	assert is_dog_or_cat(a) // TODO: fix compiler error
+	assert is_dog_or_cat(a)
 }
 
 fn test_perform_speak() {
@@ -156,7 +164,6 @@ fn test_interface_ptr_modification() {
 	mut cat := Cat{
 		breed: 'Persian'
 	}
-	// TODO Should fail and require `mut cat`
 	change_animal_breed(mut cat, 'Siamese')
 	assert cat.breed == 'Siamese'
 }
@@ -296,10 +303,11 @@ fn test_interface_array() {
 	assert true
 	animals << Cat{}
 	assert true
-	// TODO .str() from the real types should be called
+	animals << Bird{}
+	assert true
 	// println('Animals array contains: ${animals.str()}') // explicit call to 'str' function
-	// println('Animals array contains: ${animals}') // implicit call to 'str' function
-	assert animals.len == 3
+	println('Animals array contains: $animals') // implicit call to 'str' function
+	assert animals.len == 4
 }
 
 fn test_interface_ptr_array() {
@@ -311,16 +319,20 @@ fn test_interface_ptr_array() {
 	assert true
 	animals << Cat{}
 	assert true
-	assert animals.len == 3
+	animals << Bird{}
+	assert true
+	// println('Animals array contains: ${animals.str()}') // explicit call to 'str' function
+	println('Animals array contains: $animals') // implicit call to 'str' function
+	assert animals.len == 4
 }
 
 fn test_is() {
 	println('---- ${@FN} ----')
 	dog := Dog{}
-	assert foo2(dog) == 1
+	assert is_dog_int(dog) == 1
 }
 
-fn foo2(a Animal) int {
+fn is_dog_int(a Animal) int {
 	if a is Dog {
 		return 1
 	} else {
@@ -332,23 +344,25 @@ fn test_is_bool() {
 	println('---- ${@FN} ----')
 	dog := Dog{}
 	assert is_dog(dog) == true
-	assert is_dog_or_cat(dog) // TODO: fix compiler error
+	assert is_dog_or_cat(dog)
 	cat := Cat{}
 	assert is_dog(cat) == false
-	assert is_dog_or_cat(cat) // TODO: fix compiler error
+	assert is_dog_or_cat(cat)
 	bird := Bird{}
 	assert is_dog(bird) == false
-	assert !is_dog_or_cat(bird) // TODO: fix compiler error
+	assert !is_dog_or_cat(bird)
+	assert is_dog_or_cat_or_bird(bird)
 }
 
 fn is_dog(a Animal) bool {
-	println("Got animal: '$a'")  // implicit call to 'str' function of implementations
-	println("with type: ${typeof(a).name}")  // get implementation type (if possible)
+	println("Got animal: '$a'") // implicit call to 'str' function of implementations
+	println('with type: ${typeof(a).name}') // get implementation type (if possible)
 
 	// sample (additional checks) here
 	is_dog_or_cat := if (a is Dog) || (a is Cat) { true } else { false }
 	println('Animal is Dog or Cat: $is_dog_or_cat')
 
+	// use/test even another syntax
 	if a is Dog {
 		return true
 	} else {

--- a/vlib/v/tests/interface_test.v
+++ b/vlib/v/tests/interface_test.v
@@ -58,13 +58,38 @@ fn (mut d Dog) set_breed(new string) {
 }
 
 // do not add to Dog the utility function 'str', so the default one will be used, as a sample
-fn test_todo() {
-	if true {
-	} else {
-	}
+
+fn (a Bird) speak(s string) {
+	println('tweet')
+}
+
+fn (a Bird) name() string {
+	return a.breed
+}
+
+fn (a Bird) name_detailed(pet_name string) string {
+	return '$pet_name the ${typeof(a)}, breed:${a.breed}'
+}
+
+fn (mut d Bird) set_breed(new string) {
+	println('canary')
+}
+
+// do not add to Bird the utility function 'str', so the default one will be used, as a sample
+
+fn is_dog_or_cat(a Animal) bool {
+	is_dog := a is Dog
+	is_cat := a is Cat
+	println('Animal is Dog or Cat: is a Dog: $is_dog, is a Cat: $is_cat')
+	// return is_dog || is_cat
+	// shorter syntax
+	is_dog_or_cat := if (a is Dog) || (a is Cat) { true } else { false }
+	println('Animal is Dog or Cat: $is_dog_or_cat')
+	return is_dog_or_cat
 }
 
 fn perform_speak(a Animal) {
+	println('---- ${@FN} ----')
 	a.speak('Hi !')
 	assert true
 	name := a.name()
@@ -80,6 +105,7 @@ fn perform_speak(a Animal) {
 }
 
 fn perform_speak_on_ptr(a &Animal) {
+	println('---- ${@FN} ----')
 	a.speak('Hi !')
 	assert true
 	name := a.name()
@@ -93,6 +119,7 @@ fn perform_speak_on_ptr(a &Animal) {
 }
 
 fn test_perform_speak() {
+	println('---- ${@FN} ----')
 	dog := Dog{
 		breed: 'Labrador Retriever'
 	}
@@ -124,6 +151,7 @@ fn change_animal_breed(mut a Animal, new string) {
 }
 
 fn test_interface_ptr_modification() {
+	println('---- ${@FN} ----')
 	mut cat := Cat{
 		breed: 'Persian'
 	}
@@ -139,6 +167,7 @@ fn perform_name_detailed(a Animal) {
 }
 
 fn test_perform_name_detailed() {
+	println('---- ${@FN} ----')
 	dog := Dog{
 		breed: 'Labrador Retriever'
 	}
@@ -187,6 +216,7 @@ fn handle_reg(r Register) {
 }
 
 fn test_register() {
+	println('---- ${@FN} ----')
 	f := RegTest{}
 	f.register()
 	handle_reg(f)
@@ -256,6 +286,7 @@ mut:
 }
 
 fn test_interface_array() {
+	println('---- ${@FN} ----')
 	println('Test on array of animals ...')
 	mut animals := []Animal{}
 	animals = [Cat{}, Dog{
@@ -271,6 +302,7 @@ fn test_interface_array() {
 }
 
 fn test_interface_ptr_array() {
+	println('---- ${@FN} ----')
 	mut animals := []&Animal{}
 	animals = [Cat{}, Dog{
 		breed: 'Labrador Retriever'
@@ -282,6 +314,7 @@ fn test_interface_ptr_array() {
 }
 
 fn test_is() {
+	println('---- ${@FN} ----')
 	dog := Dog{}
 	assert foo2(dog) == 1
 }
@@ -291,6 +324,31 @@ fn foo2(a Animal) int {
 		return 1
 	} else {
 		return 0
+	}
+}
+
+fn test_is_bool() {
+	println('---- ${@FN} ----')
+	dog := Dog{}
+	assert is_dog(dog) == true
+	cat := Cat{}
+	assert is_dog(cat) == false
+	bird := Bird{}
+	assert is_dog(bird) == false
+}
+
+fn is_dog(a Animal) bool {
+	println("Got animal: '$a'")  // implicit call to 'str' function of implementations
+	println("with type: ${typeof(a)}")  // get implementation type (if possible)
+
+	// sample (additional checks) here
+	is_dog_or_cat := if (a is Dog) || (a is Cat) { true } else { false }
+	println('Animal is Dog or Cat: $is_dog_or_cat')
+
+	if a is Dog {
+		return true
+	} else {
+		return false
 	}
 }
 
@@ -309,7 +367,7 @@ fn animal_match(a Animal) {
 	match a {
 		Dog { println('(dog)') }
 		Cat { println('(cat)') }
-		else {}
+		else { println('(other)' }
 	}
 }
 */


### PR DESCRIPTION
UPDATE:

no more runtime error with current V, see updated comments under.

----

OLD (original) subject for this PR:

and clean-up TODO resolved now.

In this PR you can see that if I call a function with an interface as argument and then I call another function with that interface argument (see related two new lines enabled in this PR) I got a runtime error:

```
==================
interface_test.tmp.c: In function ‘perform_speak’:
interface_test.tmp.c:10178:20: error: implicit declaration of function ‘I_Animal_to_Interface_Animal’; did you mean ‘I_Bird_to_Interface_Animal’? [-Werror=implicit-function-declaration]
10178 |  if (is_dog_or_cat(I_Animal_to_Interface_Animal(&a))){
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                    I_Bird_to_Interface_Animal
interface_test.tmp.c:10178:20: error: incompatible type for argument 1 of ‘is_dog_or_cat’
10178 |  if (is_dog_or_cat(I_Animal_to_Interface_Animal(&a))){
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                    |
      |                    int
interface_test.tmp.c:10038:34: note: expected ‘Animal’ {aka ‘struct <anonymous>’} but argument is of type ‘int’
10038 | static bool is_dog_or_cat(Animal a) {
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang
```

It seems something not propagated in the right way in functions using interfaces.
Disabling (comment) those 2 lines all is good.
Hope this helps; if you need more info/changes tell me.
Thanks for now.