### PR TITLE
cgen: fix array.map(anon_fn) error (fix #5264 #4911)

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -589,6 +589,13 @@ fn test_map() {
 	assert strs == ['v', 'is', 'awesome']
 }
 
+fn test_anon_fn_map() {
+	add_num := fn (i int) int {
+		return i + 1
+	}
+	assert [1,2,3].map(add_num) == [2,3,4]
+}
+
 fn test_array_str() {
 	numbers := [1, 2, 3]
 	assert numbers == [1,2,3]

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3175,7 +3175,15 @@ fn (mut g Gen) gen_map(node ast.CallExpr) {
 	match node.args[0].expr {
 		ast.Ident {
 			if it.kind == .function {
-				g.writeln('${it.name}(it)')
+				g.write('${it.name}(it)')
+			} else if it.kind == .variable {
+				var_info := it.var_info()
+				sym := g.table.get_type_symbol(var_info.typ)
+				if sym.kind == .function {
+					g.write('${it.name}(it)')
+				} else {
+					g.expr(node.args[0].expr)
+				}
 			} else {
 				g.expr(node.args[0].expr)
 			}


### PR DESCRIPTION
This PR fix array.map(anon_fn) error (fix #5264 fix #4911).

- Fix array.map(anon_fn) error.
- Add test `test_anon_fn_map()` in array_test.v.

```v
fn custom_map(arr []int, op fn(int) int) []int {
  return arr.map(op)
}

fn main() {
  a := custom_map([1,2,3], fn (i int) int {
    return i + 1
  })
  println(a)
}

D:\test\v\tt1>v run .
[2, 3, 4]
```

```v
fn main() {
	x := ['pop', 'foo', 'var']
	bar := fn (b string) string {
		return b[1..]
	}
	println(x.map(bar))
}

D:\test\v\tt1>v run .
['op', 'oo', 'ar']
```