### PR TITLE
vdoc: minor css fix + add error message

### DIFF
--- a/cmd/tools/vdoc-resources/doc.css
+++ b/cmd/tools/vdoc-resources/doc.css
@@ -402,9 +402,7 @@ body {
 }
 
 /* Code highlight */
-.doc-content pre, 
-.doc-content code, 
-.doc-content pre code {
+pre, code, pre code {
   color: #5c6e74;
   color: var(--code-default-text-color);
   font-size: 0.9rem;
@@ -414,7 +412,7 @@ body {
   background-color: var(--code-background-color);
   border-radius: 0.25rem;
 }	
-.doc-content pre code {
+pre code {
   direction: ltr;
   text-align: left;
   white-space: pre;
@@ -432,10 +430,10 @@ body {
   overflow-x: auto;
   padding: 1rem;
 }
-.doc-content code {
+code {
   padding: 0.2rem;
 }
-.doc-content pre {
+pre {
   overflow: auto;
   margin: 0;
 }

--- a/cmd/tools/vdoc-resources/doc.css
+++ b/cmd/tools/vdoc-resources/doc.css
@@ -402,7 +402,9 @@ body {
 }
 
 /* Code highlight */
-pre, code, pre code {
+.doc-content pre, 
+.doc-content code, 
+.doc-content pre code {
   color: #5c6e74;
   color: var(--code-default-text-color);
   font-size: 0.9rem;
@@ -412,7 +414,7 @@ pre, code, pre code {
   background-color: var(--code-background-color);
   border-radius: 0.25rem;
 }	
-pre code {
+.doc-content pre code {
   direction: ltr;
   text-align: left;
   white-space: pre;
@@ -430,10 +432,10 @@ pre code {
   overflow-x: auto;
   padding: 1rem;
 }
-code {
+.doc-content code {
   padding: 0.2rem;
 }
-pre {
+.doc-content pre {
   overflow: auto;
   margin: 0;
 }

--- a/cmd/tools/vdoc-resources/doc.css
+++ b/cmd/tools/vdoc-resources/doc.css
@@ -408,6 +408,11 @@ pre, code, pre code {
   font-size: 0.9rem;
   text-shadow: none;
   font-family: monospace;
+  background-color: #edf2f7;
+  background-color: var(--code-background-color);
+  border-radius: 0.25rem;
+}	
+pre code {
   direction: ltr;
   text-align: left;
   white-space: pre;
@@ -421,14 +426,12 @@ pre, code, pre code {
   -moz-hyphens: none;
   -ms-hyphens: none;
   hyphens: none;
-  background-color: #edf2f7;
-  background-color: var(--code-background-color);
   display: block;
-  border-radius: 0.25rem;
   overflow-x: auto;
+  padding: 1rem;
 }
-code, pre code {
-	padding: 1rem;
+code {
+  padding: 0.2rem;
 }
 pre {
   overflow: auto;

--- a/cmd/tools/vdoc-resources/doc.css
+++ b/cmd/tools/vdoc-resources/doc.css
@@ -260,6 +260,9 @@ body {
 	padding: 1rem;
 	overflow: hidden;
 }
+.doc-content p {
+	line-height: 1.4;
+}
 .doc-content a {
 	color: #2779bd;
 	color: var(--link-color);
@@ -267,6 +270,9 @@ body {
 .doc-content > .doc-node {
 	padding: 5rem 0 2rem 0;
 	margin-top: -4rem;
+	overflow: hidden;
+	word-break: break-all; /* IE11 */
+	word-break: break-word;
 }
 .doc-content > .doc-node.const:not(:first-child) {
 	padding-top: 0;
@@ -432,6 +438,7 @@ pre code {
 }
 code {
   padding: 0.2rem;
+  vertical-align: middle;
 }
 pre {
   overflow: auto;

--- a/cmd/tools/vdoc-resources/normalize.css
+++ b/cmd/tools/vdoc-resources/normalize.css
@@ -39,7 +39,6 @@ strong {
 	font-weight: bolder;
 }
 
-code,
 kbd,
 samp {
 	font-family: monospace, monospace;

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -573,7 +573,12 @@ fn (mut cfg DocConfig) generate_docs_from_file() {
 	for dirpath in dirs {
 		cfg.vprintln('Generating docs for ${dirpath}...')
 		mut dcs := doc.generate(dirpath, cfg.pub_only, true) or {
-			panic(err)
+			mut err_msg := err
+			if errcode == 1 {
+				err_msg += ' Use the `-m` flag if you are generating docs of a directory with multiple modules inside.'
+			}
+			eprintln(err_msg)
+			exit(1)
 		}
 		if dcs.contents.len == 0 { continue }
 		if cfg.is_multi {

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -244,11 +244,11 @@ pub fn (mut d Doc) generate() ?bool {
 	// get all files
 	base_path := if os.is_dir(d.input_path) { d.input_path } else { os.real_path(os.base_dir(d.input_path)) }
 	project_files := os.ls(base_path) or {
-		panic(err)
+		return error_with_code(err, 0)
 	}
 	v_files := d.prefs.should_compile_filtered_files(base_path, project_files)
 	if v_files.len == 0 {
-		return error('vdoc: No valid V files were found.')
+		return error_with_code('vdoc: No valid V files were found.', 1)
 	}
 	// parse files
 	mut file_asts := []ast.File{}
@@ -383,7 +383,7 @@ pub fn generate(input_path string, pub_only, with_comments bool) ?Doc {
 	doc.pub_only = pub_only
 	doc.with_comments = with_comments
 	doc.generate() or {
-		return error(err)
+		return error_with_code(err, errcode)
 	}
 	return doc
 }


### PR DESCRIPTION
- Minor CSS fix for distinguishing inline and block `<code>` tags.
- Take advantage of `error_with_code` and add a custom error message when running vdoc on folders without V content or contains subfolders.

(Edit) Preview:
![image](https://user-images.githubusercontent.com/7358345/84144653-34b9f680-aa8b-11ea-96d7-2b04328b4620.png)
