### PR TITLE
cgen: fix array.map(fn...) error

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -596,6 +596,14 @@ fn test_anon_fn_map() {
 	assert [1,2,3].map(add_num) == [2,3,4]
 }
 
+fn test_anon_fn_arg_map() {
+	a := [1,2,3].map(fn (i int) int {
+		return i + 1
+	})
+
+	assert a == [2,3,4]
+}
+
 fn test_array_str() {
 	numbers := [1, 2, 3]
 	assert numbers == [1,2,3]

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3188,6 +3188,16 @@ fn (mut g Gen) gen_map(node ast.CallExpr) {
 				g.expr(node.args[0].expr)
 			}
 		}
+		ast.AnonFn {
+			pos := g.out.len
+			def_pos := g.definitions.len
+			g.stmt(it.decl)
+			fn_body := g.out.after(pos)
+			g.out.go_back(fn_body.len)
+			g.definitions.go_back(g.definitions.len - def_pos)
+			g.definitions.write(fn_body)
+			g.write('${it.decl.name}(it)')
+		}
 		else {
 			g.expr(node.args[0].expr)
 		}


### PR DESCRIPTION
This PR fix array.map(fn...) error.

- Fix array.map(fn...) error.
- Add test `test_anon_fn_arg_map()` in array_test.v.

```v
fn main() {
	a := [1,2,3].map(fn (i int) int {
		return i + 1
	})

	println(a)
}

D:\test\v\tt1>v run .
[2, 3, 4]
```