### PR TITLE
string: change `index` `last_index` do not use optional

### DIFF
--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -396,7 +396,8 @@ fn parse_vmod(data string) Vmod {
 		'deps': ''
 	}
 	for key in keys {
-		mut key_index := data.index('$key:') or {
+		mut key_index := data.index('$key:')
+		if key_index < 0 {
 			continue
 		}
 		key_index += key.len + 1

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -263,7 +263,8 @@ fn print_output(s os.Result) {
 		if line.contains('.vrepl_temp.v:') {
 			// Hide the temporary file name
 			sline := line.all_after('.vrepl_temp.v:')
-			idx := sline.index(' ') or {
+			idx := sline.index(' ')
+			if idx < 0 {
 				println(sline)
 				return
 			}
@@ -271,7 +272,8 @@ fn print_output(s os.Result) {
 		} else if line.contains('.vrepl.v:') {
 			// Ensure that .vrepl.v: is at the start, ignore the path
 			// This is needed to have stable .repl tests.
-			idx := line.index('.vrepl.v:') or { return }
+			idx := line.index('.vrepl.v:')
+			if idx < 0 { return }
 			println(line[idx..])
 		} else {
 			println(line)

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -148,7 +148,8 @@ pub fn cstring_to_vstring(cstr byteptr) string {
 }
 
 pub fn (s string) replace_once(rep, with string) string {
-	index := s.index(rep) or {
+	index := s.index(rep)
+	if index < 0 {
 		return s
 	}
 	return s.substr(0, index) + with + s.substr(index + rep.len, s.len)
@@ -554,7 +555,7 @@ pub fn (s string) substr(start, end int) string {
 	return res
 }
 
-pub fn (s string) index_old(p string) int {
+pub fn (s string) index(p string) int {
 	if p.len > s.len || p.len == 0 {
 		return -1
 	}
@@ -570,24 +571,6 @@ pub fn (s string) index_old(p string) int {
 		i++
 	}
 	return -1
-}
-
-pub fn (s string) index(p string) ?int {
-	if p.len > s.len || p.len == 0 {
-		return none
-	}
-	mut i := 0
-	for i < s.len {
-		mut j := 0
-		for j < p.len && s.str[i + j] == p.str[j] {
-			j++
-		}
-		if j == p.len {
-			return i
-		}
-		i++
-	}
-	return none
 }
 
 // KMP search
@@ -623,7 +606,8 @@ fn (s string) index_kmp(p string) int {
 
 pub fn (s string) index_any(chars string) int {
 	for c in chars {
-		index := s.index(c.str()) or {
+		index := s.index(c.str())
+		if index < 0 {
 			continue
 		}
 		return index
@@ -631,9 +615,9 @@ pub fn (s string) index_any(chars string) int {
 	return -1
 }
 
-pub fn (s string) last_index(p string) ?int {
+pub fn (s string) last_index(p string) int {
 	if p.len > s.len || p.len == 0 {
-		return none
+		return -1
 	}
 	mut i := s.len - p.len
 	for i >= 0 {
@@ -646,7 +630,7 @@ pub fn (s string) last_index(p string) ?int {
 		}
 		i--
 	}
-	return none
+	return -1
 }
 
 pub fn (s string) index_after(p string, start int) int {
@@ -716,10 +700,7 @@ pub fn (s string) count(substr string) int {
 }
 
 pub fn (s string) contains(p string) bool {
-	s.index(p) or {
-		return false
-	}
-	return true
+	return s.index(p) >= 0
 }
 
 pub fn (s string) starts_with(p string) bool {
@@ -825,12 +806,14 @@ pub fn (s string) is_title() bool {
 // 'hey [man] how you doin'
 // find_between('[', ']') == 'man'
 pub fn (s string) find_between(start, end string) string {
-	start_pos := s.index(start) or {
+	start_pos := s.index(start)
+	if start_pos < 0 {
 		return ''
 	}
 	// First get everything to the right of 'start'
 	val := s.right(start_pos + start.len)
-	end_pos := val.index(end) or {
+	end_pos := val.index(end)
+	if end_pos < 0 {
 		return val
 	}
 	return val.left(end_pos)
@@ -1189,28 +1172,32 @@ pub fn (s &string) free() {
 
 // all_before('23:34:45.234', '.') == '23:34:45'
 pub fn (s string) all_before(dot string) string {
-	pos := s.index(dot) or {
+	pos := s.index(dot)
+	if pos < 0 {
 		return s
 	}
 	return s.left(pos)
 }
 
 pub fn (s string) all_before_last(dot string) string {
-	pos := s.last_index(dot) or {
+	pos := s.last_index(dot)
+	if pos < 0 {
 		return s
 	}
 	return s.left(pos)
 }
 
 pub fn (s string) all_after(dot string) string {
-	pos := s.index(dot) or {
+	pos := s.index(dot)
+	if pos < 0 {
 		return s
 	}
 	return s.right(pos + dot.len)
 }
 
 pub fn (s string) all_after_last(dot string) string {
-	pos := s.last_index(dot) or {
+	pos := s.last_index(dot)
+	if pos < 0 {
 		return s
 	}
 	return s.right(pos + dot.len)

--- a/vlib/encoding/csv/reader.v
+++ b/vlib/encoding/csv/reader.v
@@ -124,7 +124,8 @@ fn (mut r Reader) read_record() ?[]string {
 		}
 
 		if line[0] != `"` {		// not quoted
-			j := line.index(r.delimiter.str()) or {
+			j := line.index(r.delimiter.str())
+			if j < 0 {
 				// last
 				fields << line[..line.len]
 				break
@@ -134,7 +135,8 @@ fn (mut r Reader) read_record() ?[]string {
 			line = line[i+1..]
 			continue
 		} else {		// quoted
-			j := line[1..].index('"') or {
+			j := line[1..].index('"')
+			if j < 0 {
 				need_read = true
 				keep_raw = true
 				continue

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -305,7 +305,8 @@ fn parse_response(resp string) Response {
 			break
 		}
 		i++
-		pos := h.index(':') or {
+		pos := h.index(':')
+		if pos < 0 {
 			continue
 		}
 		// if h.contains('Content-Type') {

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -510,10 +510,12 @@ fn parse_url(rawurl string, via_request bool) ?URL {
 		// RFC 3986, §3.3:
 		// In addition, a URI reference (Section 4.1) may be a relative-path reference,
 		// in which case the first path segment cannot contain a colon (':') character.
-		colon := rest.index(':') or {
+		colon := rest.index(':')
+		if colon < 0 {
 			return error('there should be a : in the URL')
 		}
-		slash := rest.index('/') or {
+		slash := rest.index('/')
+		if slash < 0 {
 			return error('there should be a / in the URL')
 		}
 		if colon >= 0 && (slash < 0 || colon < slash) {
@@ -546,9 +548,7 @@ struct ParseAuthorityRes {
 }
 
 fn parse_authority(authority string) ?ParseAuthorityRes {
-	i := authority.last_index('@') or {
-		-1
-	}
+	i := authority.last_index('@')
 	mut host := ''
 	mut zuser := user('')
 	if i < 0 {
@@ -604,7 +604,8 @@ fn parse_host(host string) ?string {
 	if host.starts_with('[') {
 		// parse an IP-Literal in RFC 3986 and RFC 6874.
 		// E.g., '[fe80::1]', '[fe80::1%25en0]', '[fe80::1]:80'.
-		mut i := host.last_index(']') or {
+		mut i := host.last_index(']')
+		if i < 0 {
 			return error(error_msg("parse_host: missing \']\' in host", ''))
 		}
 		mut colon_port := host[i + 1..]
@@ -617,7 +618,8 @@ fn parse_host(host string) ?string {
 		// can only %-encode non-ASCII bytes.
 		// We do impose some restrictions on the zone, to avoid stupidity
 		// like newlines.
-		if zone:=host[..i].index('%25'){
+		zone := host[..i].index('%25')
+		if zone >= 0 {
 			host1 := unescape(host[..zone], .encode_host) or {
 				return err
 			}
@@ -629,7 +631,8 @@ fn parse_host(host string) ?string {
 			}
 			return host1 + host2 + host3
 		}
-		if idx:=host.last_index(':'){
+		idx := host.last_index(':')
+		if idx >= 0 {
 			colon_port = host[idx..]
 			if !valid_optional_port(colon_port) {
 				return error(error_msg('parse_host: invalid port $colon_port after host ', ''))
@@ -853,7 +856,8 @@ fn parse_query_values(mut m Values, query string) ?bool {
 			continue
 		}
 		mut value := ''
-		if idx:=key.index('='){
+		idx := key.index('=')
+		if idx >= 0 {
 			i = idx
 			value = key[i + 1..]
 			key = key[..i]
@@ -911,9 +915,7 @@ fn resolve_path(base, ref string) string {
 		full = base
 	}
 	else if ref[0] != `/` {
-		i := base.last_index('/') or {
-			-1
-		}
+		i := base.last_index('/')
 		full = base[..i + 1] + ref
 	}
 	else {

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -671,21 +671,24 @@ fn print_c_errno() {
 }
 
 pub fn file_ext(path string) string {
-	pos := path.last_index('.') or {
+	pos := path.last_index('.')
+	if pos < 0 {
 		return ''
 	}
 	return path[pos..]
 }
 
 pub fn dir(path string) string {
-	pos := path.last_index(path_separator) or {
+	pos := path.last_index(path_separator)
+	if pos < 0 {
 		return '.'
 	}
 	return path[..pos]
 }
 
 pub fn base_dir(path string) string {
-	posx := path.last_index(path_separator) or {
+	posx := path.last_index(path_separator)
+	if posx < 0 {
 		return path
 	}
 	// NB: *without* terminating /

--- a/vlib/time/parse.v
+++ b/vlib/time/parse.v
@@ -5,7 +5,8 @@ module time
 
 // parse returns time from a date string in "YYYY-MM-DD HH:MM:SS" format.
 pub fn parse(s string) ?Time {
-	pos := s.index(' ') or {
+	pos := s.index(' ')
+	if pos < 0 {
 		return error('Invalid time format: $s')
 	}
 	symd := s[..pos]
@@ -36,7 +37,8 @@ pub fn parse_rfc2822(s string) ?Time {
 	if fields.len < 5 {
 		return error('Invalid time format: $s')
 	}
-	pos := months_string.index(fields[2]) or {
+	pos := months_string.index(fields[2])
+	if pos < 0 {
 		return error('Invalid time format: $s')
 	}
 	mm := pos / 3 + 1

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -205,9 +205,7 @@ fn (mut c Checker) check_valid_snake_case(name, identifier string, pos token.Pos
 }
 
 fn stripped_name(name string) string {
-	idx := name.last_index('.') or {
-		-1
-	}
+	idx := name.last_index('.')
 	return name[(idx + 1)..]
 }
 
@@ -1772,7 +1770,7 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 		c.error('checker: too many expr levels: $c.expr_level ', node.position())
 		return table.void_type
 	}
-    
+
 	match mut node {
 		ast.AnonFn {
 			keep_fn := c.cur_fn

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -514,7 +514,8 @@ fn (f &Fmt) type_to_str(t table.Type) string {
 	if res.starts_with('[]fixed_') {
 		prefix := '[]fixed_'
 		res = res[prefix.len..]
-		last_underscore_idx := res.last_index('_') or {
+		last_underscore_idx := res.last_index('_')
+		if last_underscore_idx < 0 {
 			return '[]' + res.replace(f.cur_mod + '.', '')
 		}
 		limit := res[last_underscore_idx + 1..]
@@ -1039,8 +1040,9 @@ pub fn (mut f Fmt) mark_module_as_used(name string) {
 	if !name.contains('.') {
 		return
 	}
-	pos := name.last_index('.') or {
-		0
+	mut pos := name.last_index('.')
+	if pos < 0 {
+		pos = 0
 	}
 	mod := name[..pos]
 	if mod in f.used_imports {

--- a/vlib/v/gen/cgen_test.v
+++ b/vlib/v/gen/cgen_test.v
@@ -25,9 +25,7 @@ fn test_c_files() {
 		b.module_search_paths = ['$vroot/vlib/v/gen/tests/']
 		mut res := b.gen_c([path]).after('#endbuiltin')
 		if res.contains('string _STR') {
-			pos := res.index('string _STR') or {
-				-1
-			}
+			pos := res.index('string _STR')
 			end := res.index_after('endof _STR_TMP', pos)
 			res = res[..pos] + res[end + 15..]
 		}

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -381,7 +381,8 @@ pub fn (mut g JsGen) new_tmp_var() string {
 // 'fn' => ''
 [inline]
 fn get_ns(s string) string {
-	idx := s.last_index('.') or { return '' }
+	idx := s.last_index('.')
+	if idx < 0 { return '' }
 	return s.substr(0, idx)
 }
 

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -21,7 +21,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 		.name {
 			node = p.name_expr()
 			p.is_stmt_ident = is_stmt_ident
-		}
+		} 
 		.string {
 			node = p.string_expr()
 		}

--- a/vlib/v/table/cflags.v
+++ b/vlib/v/table/cflags.v
@@ -31,7 +31,8 @@ pub fn (mut table Table) parse_cflag(cflg, mod string, ctimedefines []string) ?b
 		if !flag.starts_with(os_override) {
 			continue
 		}
-		pos := flag.index(' ') or {
+		pos := flag.index(' ')
+		if pos < 0 {
 			return none
 		}
 		fos = flag[..pos].trim_space()
@@ -50,9 +51,7 @@ pub fn (mut table Table) parse_cflag(cflg, mod string, ctimedefines []string) ?b
 				}
 			}
 		}
-		mut index := flag.index(' -') or {
-			-1
-		}
+		mut index := flag.index(' -')
 		for index > -1 {
 			mut has_next := false
 			for f in allowed_flags {

--- a/vlib/vweb/tmpl/tmpl.v
+++ b/vlib/vweb/tmpl/tmpl.v
@@ -54,7 +54,8 @@ pub fn compile_template(content, fn_name string) string {
 		}
 		if line.contains('@if ') {
 			s.writeln(str_end)
-			pos := line.index('@if') or {
+			pos := line.index('@if')
+			if pos < 0 {
 				continue
 			}
 			s.writeln('if ' + line[pos + 4..] + '{')
@@ -69,7 +70,8 @@ pub fn compile_template(content, fn_name string) string {
 			s.writeln(str_start)
 		} else if line.contains('@for') {
 			s.writeln(str_end)
-			pos := line.index('@for') or {
+			pos := line.index('@for')
+			if pos < 0 {
 				continue
 			}
 			s.writeln('for ' + line[pos + 4..] + '{')


### PR DESCRIPTION
This PR change `index` `last_index` do not use optional.

Reason
- `index` `last_index` use more frequently.
- `optional` consumes resources too much, affecting performance.
- The results of `index` and `last_index`  are very clear.

```v
Option_int string_index(string s, string p) {
	if (p.len > s.len || p.len == 0) {
		/*opt promotion*/ Option _t1 = opt_none();return *(Option_int*)&_t1;
	}
	int i = 0;
	while (i < s.len) {
		int j = 0;
		while (j < p.len && s.str[i + j] == p.str[j]) {
			j++;
		}
		if (j == p.len) {
			Option_int _t2;/*:)int*/opt_ok2(&(int[]) { i }, (OptionBase*)(&_t2), sizeof(int));
			return _t2;
		}
		i++;
	}
	/*opt promotion*/ Option _t3 = opt_none();return *(Option_int*)&_t3;
}
```
```v
struct Option {
	bool ok;
	bool is_none;
	string v_error;
	int ecode;
	array_fixed_byte_400 data;
};

struct Option_int {
 bool ok;
 bool is_none;
 string v_error;
 int ecode;
 byte data[sizeof(int)];
} ;
```