### PR TITLE
vmod: add scripts field

### DIFF
--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -94,8 +94,8 @@ fn main_v() {
 			mod := vmod.from_file('./v.mod') or { panic(err) }
 
 			scripts := mod.scripts
-			call_index := args[1].int()
-			script := scripts[call_index]
+			call_name := args[1]
+			script := scripts[call_name]
 
 			// println(script)
 			res := os.exec(script) or { panic(err) }

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -8,6 +8,7 @@ import os
 import v.pref
 import v.util
 import v.builder
+import v.vmod
 
 const (
 	simple_cmd = [
@@ -87,6 +88,18 @@ fn main_v() {
 		}
 		'version' {
 			println(util.full_v_version(prefs.is_verbose))
+			return
+		}
+		'run-mod' {
+			mod := vmod.from_file('./v.mod') or { panic(err) }
+
+			scripts := mod.scripts
+			call_index := args[1].int()
+			script := scripts[call_index]
+
+			// println(script)
+			res := os.exec(script) or { panic(err) }
+			println(res.output)
 			return
 		}
 		else {}

--- a/vlib/v/vmod/parser.v
+++ b/vlib/v/vmod/parser.v
@@ -26,6 +26,7 @@ pub mut:
 	license      string
 	repo_url     string
 	author       string
+	scripts    	 []string
 	unknown      map[string][]string
 }
 
@@ -241,6 +242,14 @@ fn (mut p Parser) parse() ?Manifest {
 							return error(err)
 						}
 						mn.dependencies = deps
+						i = idx
+						continue
+					}
+					'scripts' {
+						scripts, idx := get_array_content(tokens, i + 1) or {
+							return error(err)
+						}
+						mn.scripts = scripts
 						i = idx
 						continue
 					}


### PR DESCRIPTION
The v.mod file now supports a scripts field _(inspired from Node's package.json)_:
```v
Module {
  scripts: [
    'script_name': 'command to execute'
  ]
}
```

There you can create shortcuts to important project commands.
For example you could add `'dist-prod': 'v -prod path/to.v -o exe_name'`.
Then execute the command by running `v run-mod dist-prod`.

**Important:** I'm not happy with `v run-mod` but I need more opinions on how to name this.

**TODOs before merge:**
- [x] working scripts field
- [ ] agree on a good command name
- [ ] parser: more token type validation
- [ ] add help text
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
