### PR TITLE
vdoc: plaintext fixes

### DIFF
--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -441,13 +441,13 @@ fn (cfg DocConfig) gen_plaintext(idx int) string {
 	dcs := cfg.docs[idx]
 	mut pw := strings.new_builder(200)
 	pw.writeln('${dcs.head.content}\n')
-	if dcs.head.comment.len > 0 {
+	if dcs.head.comment.trim_space().len > 0 {
 		pw.writeln('// ' + dcs.head.comment.replace('\n', '\n// ') + '\n')
 	}
 	for cn in dcs.contents {
 		pw.writeln(cn.content)
 		if cn.comment.len > 0 {
-			pw.writeln('\n' + '\/\/ ' + cn.comment.trim_space())
+			pw.writeln('\/\/ ' + cn.comment.trim_space() + '\n')
 		}
 		if cfg.show_loc {
 			pw.writeln('Location: ${cn.file_path}:${cn.pos.line}:${cn.pos.col}\n\n')

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -119,7 +119,6 @@ pub fn (mut a array) sort_with_compare(compare voidptr) {
 // In the current state only that would work:
 // i := 3
 // a.insert(0, &i)
-// ----------------------------
 pub fn (mut a array) insert(i int, val voidptr) {
 	$if !no_bounds_checking? {
 		if i < 0 || i > a.len {
@@ -135,7 +134,6 @@ pub fn (mut a array) insert(i int, val voidptr) {
 
 // TODO array.prepend is broken
 // It depends on array.insert
-// -----------------------------
 pub fn (mut a array) prepend(val voidptr) {
 	a.insert(0, val)
 }

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -298,20 +298,23 @@ pub fn (mut d Doc) generate() ?bool {
 				prev_comments << stmt
 				continue
 			}
+			// TODO: Fetch head comment once
 			if stmt is ast.Module {
 				// the previous comments were probably a copyright/license one
 				module_comment := get_comment_block_right_before(prev_comments)
 				prev_comments = []
-				if module_comment == '' {
-					continue
+				if 'vlib' !in base_path && !module_comment.starts_with('Copyright (c)') {
+					if module_comment == '' {
+						continue
+					}
+					if module_comment == d.head.comment {
+						continue
+					}
+					if d.head.comment != '' {
+						d.head.comment += '\n'
+					}
+					d.head.comment += module_comment
 				}
-				if module_comment == d.head.comment {
-					continue
-				}
-				if d.head.comment != '' {
-					d.head.comment += '\n'
-				}
-				d.head.comment += module_comment
 				continue
 			}
 			if last_import_stmt_idx > 0 && sidx == last_import_stmt_idx {


### PR DESCRIPTION
Fixes #5303.
- Creates a special case for `vlib` modules to exclude copyright comments.
- Fix spacing in for comments