### PR TITLE
cgen: fix multiple array.map(anon_fn) error (fix #5301)

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -596,6 +596,18 @@ fn test_anon_fn_map() {
 	assert [1,2,3].map(add_num) == [2,3,4]
 }
 
+fn test_mutli_anon_fn_map() {
+	a := [1,2,3].map(fn (i int) int {
+		return i + 1
+	})
+
+	b := [1,2,3].map(fn (i int) int {
+		return i + 2
+	})
+	assert a == [2,3,4]
+	assert b == [3,4,5]
+}
+
 fn test_anon_fn_arg_map() {
 	a := [1,2,3].map(fn (i int) int {
 		return i + 1

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -49,7 +49,6 @@ fn (mut g Gen) gen_fn_decl(it ast.FnDecl) {
 		eprintln('INFO: compile with `v -live $g.pref.path `, if you want to use the [live] function ${it.name} .')
 	}
 	//
-	g.reset_tmp_count()
 	if is_main {
 		if g.pref.os == .windows {
 			if g.is_gui_app() {


### PR DESCRIPTION
This PR fix multiple array.map(anon_fn) error (fix #5301).

- Fix multiple array.map(anon_fn) error.
- Add test `test_mutli_anon_fn_map()` in array_test.v.

```v
fn main() {
    arr := [1, 2, 3]
    a := arr.map(it + 1) // any instruction that requires a temporary variable
    f := fn (i int) int { return i + 1 }
    b := arr.map(f) // any instruction that requires a temporary variable
	println('$a, $b')
}

D:\test\v\tt1>v run .
[2, 3, 4], [2, 3, 4]
```