### PR TITLE
cgen,option: fix using C constants in enums, none optional propogation

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -66,8 +66,8 @@ mut:
 	pcs_declarations     strings.Builder // -prof profile counter declarations for each function
 	hotcode_definitions  strings.Builder // -live declarations & functions
 	options              strings.Builder // `Option_xxxx` types
-	json_forward_decls   strings.Builder // `Option_xxxx` types
-	enum_typedefs        strings.Builder // `Option_xxxx` types
+	json_forward_decls   strings.Builder // json type forward decls
+	enum_typedefs        strings.Builder // enum types
 	file                 ast.File
 	fn_decl              &ast.FnDecl // pointer to the FnDecl we are currently inside otherwise 0
 	last_fn_c_name       string


### PR DESCRIPTION
This PR does 2 things 
1. It allows for propgating (or in this case not) void optionals properly.
Whereas before if we expected `void` but were given `none` then V would attempt to propogate the error. This PR changes the behaviour such that if we are expecting `void` and we are given `none` (shown by `is_none == true` which is only set for the `none` value and therefore cannot be an error) then we know we can safely ignore the `ok == false` check that takes place.
Otherwise behaviour is the same.

2. It changes cgen behaviour to write the enum definitions after the `#include`s which allows for using C constants in enum definitions.
e.g.
```go
pub enum SocketType {
	udp = C.SOCK_DGRAM
	tcp = C.SOCK_STREAM
}

pub enum SocketFamily {
	inet = C. AF_INET
}
```
or
```go
enum SocketOption {
	// TODO: SO_ACCEPT_CONN is not here becuase windows doesnt support it
	// and there is no easy way to define it

	broadcast = C.SO_BROADCAST
	debug = C.SO_DEBUG
	dont_route = C.SO_DONTROUTE
	error = C.SO_ERROR
	keep_alive = C.SO_KEEPALIVE
	linger = C.SO_LINGER
	oob_inline = C.SO_OOBINLINE

	reuse_addr = C.SO_REUSEADDR

	recieve_buf_size = C.SO_RCVBUF
	recieve_low_size = C.SO_RCVLOWAT
	recieve_timeout = C.SO_RCVTIMEO

	send_buf_size = C.SO_SNDBUF
	send_low_size = C.SO_SNDLOWAT
	send_timeout = C.SO_SNDTIMEO

	socket_type = C.SO_TYPE
}
```

Which allows for grouping the values into one type and all of the `str()`, (in the future) reflection and so on to work for what would otherwise be free floating constants.