### PR TITLE
vweb: include directive

### DIFF
--- a/vlib/vweb/tmpl/tmpl.v
+++ b/vlib/vweb/tmpl/tmpl.v
@@ -58,10 +58,7 @@ pub fn compile_template(content, fn_name string) string {
 				continue
 			}
 			mut file_name := line[pos + 9..]
-			if !file_name.ends_with('.html') && !file_name.ends_with('.htm') {
-				file_name = '${file_name}.html'
-			}
-			file_path := os.join_path('templates', file_name)
+			file_path := os.join_path('templates', '${file_name}.html')
 			mut file_content := os.read_file(file_path) or {
 				panic('reading file $file_name failed')
 			}


### PR DESCRIPTION
```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <title>Document</title>
</head>
<body>
    @include test/header.html
</body>
</html>
```