### PR TITLE
os: added os.uname() and os.Uname struct

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -8,6 +8,15 @@ pub const (
 	max_path_len = 4096
 )
 
+pub struct Uname {
+pub:
+	sysname  string
+	nodename string
+	release  string
+	version  string
+	machine  string
+}
+
 pub struct File {
 	cfile  voidptr // Using void* instead of FILE*
 pub:
@@ -19,6 +28,20 @@ mut:
 struct FileInfo {
 	name string
 	size int
+}
+
+pub fn uname() Uname {
+	d := &C.utsname{}
+	if C.uname(d) == 0 {
+		return Uname{
+			sysname: cstring_to_vstring(&d.sysname),
+			nodename: cstring_to_vstring(&d.nodename),
+			release: cstring_to_vstring(&d.release),
+			version: cstring_to_vstring(&d.version),
+			machine: cstring_to_vstring(&d.machine)
+		}
+	}
+	return Uname{}
 }
 
 pub fn (f File) is_opened() bool {

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -8,15 +8,6 @@ pub const (
 	max_path_len = 4096
 )
 
-pub struct Uname {
-pub:
-	sysname  string
-	nodename string
-	release  string
-	version  string
-	machine  string
-}
-
 pub struct File {
 	cfile  voidptr // Using void* instead of FILE*
 pub:
@@ -28,20 +19,6 @@ mut:
 struct FileInfo {
 	name string
 	size int
-}
-
-pub fn uname() Uname {
-	d := &C.utsname{}
-	if C.uname(d) == 0 {
-		return Uname{
-			sysname: cstring_to_vstring(&d.sysname),
-			nodename: cstring_to_vstring(&d.nodename),
-			release: cstring_to_vstring(&d.release),
-			version: cstring_to_vstring(&d.version),
-			machine: cstring_to_vstring(&d.machine)
-		}
-	}
-	return Uname{}
 }
 
 pub fn (f File) is_opened() bool {

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -1358,3 +1358,12 @@ pub fn create(path string) ?File {
 		opened: true
 	}
 }
+
+pub struct Uname {
+pub mut:
+	sysname  string
+	nodename string
+	release  string
+	version  string
+	machine  string
+}

--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -2,7 +2,6 @@ module os
 
 #include <sys/stat.h> // #include <signal.h>
 #include <errno.h>
-#include <sys/utsname.h>
 
 fn C.readdir(voidptr) C.dirent
 fn C.getpid() int
@@ -16,7 +15,6 @@ fn C.CopyFile(&u32, &u32, int) int
 fn C.fork() int
 fn C.wait() int
 //fn C.proc_pidpath(int, byteptr, int) int
-fn C.uname(name voidptr) int
 
 struct C.stat {
 	st_size  int
@@ -25,15 +23,6 @@ struct C.stat {
 }
 
 struct C.DIR {}
-
-struct C.utsname {
-mut:
-	sysname  [256]char
-	nodename [256]char
-	release  [256]char
-	version  [256]char
-	machine  [256]char
-}
 
 struct C.sigaction {
 mut:

--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -2,6 +2,7 @@ module os
 
 #include <sys/stat.h> // #include <signal.h>
 #include <errno.h>
+#include <sys/utsname.h>
 
 fn C.readdir(voidptr) C.dirent
 fn C.getpid() int
@@ -15,6 +16,7 @@ fn C.CopyFile(&u32, &u32, int) int
 fn C.fork() int
 fn C.wait() int
 //fn C.proc_pidpath(int, byteptr, int) int
+fn C.uname(name voidptr) int
 
 struct C.stat {
 	st_size  int
@@ -23,6 +25,15 @@ struct C.stat {
 }
 
 struct C.DIR {}
+
+struct C.utsname {
+mut:
+	sysname  [256]char
+	nodename [256]char
+	release  [256]char
+	version  [256]char
+	machine  [256]char
+}
 
 struct C.sigaction {
 mut:

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -27,30 +27,21 @@ mut:
 	machine  charptr
 }
 
-pub struct Uname {
-pub:
-	sysname  string
-	nodename string
-	release  string
-	version  string
-	machine  string
-}
-
 fn C.uname(name voidptr) int
 fn C.symlink(charptr, charptr) int
 
 pub fn uname() Uname {
-	d := &C.utsname{}
+	mut u := Uname{}
+	d := &C.utsname( malloc(int(sizeof(C.utsname))) )
 	if C.uname(d) == 0 {
-		return Uname{
-			sysname: cstring_to_vstring(&d.sysname),
-			nodename: cstring_to_vstring(&d.nodename),
-			release: cstring_to_vstring(&d.release),
-			version: cstring_to_vstring(&d.version),
-			machine: cstring_to_vstring(&d.machine)
-		}
+		u.sysname = cstring_to_vstring(d.sysname)
+		u.nodename = cstring_to_vstring(d.nodename)
+		u.release = cstring_to_vstring(d.release)
+		u.version = cstring_to_vstring(d.version)
+		u.machine = cstring_to_vstring(d.machine)
 	}
-	return Uname{}
+	free(d)
+	return u
 }
 
 fn init_os_args(argc int, argv &&byte) []string {

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -20,11 +20,11 @@ const (
 
 struct C.utsname {
 mut:
-	sysname  [256]char
-	nodename [256]char
-	release  [256]char
-	version  [256]char
-	machine  [256]char
+	sysname  charptr
+	nodename charptr
+	release  charptr
+	version  charptr
+	machine  charptr
 }
 
 pub struct Uname {

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -27,8 +27,31 @@ mut:
 	machine  [256]char
 }
 
+pub struct Uname {
+pub:
+	sysname  string
+	nodename string
+	release  string
+	version  string
+	machine  string
+}
+
 fn C.uname(name voidptr) int
 fn C.symlink(charptr, charptr) int
+
+pub fn uname() Uname {
+	d := &C.utsname{}
+	if C.uname(d) == 0 {
+		return Uname{
+			sysname: cstring_to_vstring(&d.sysname),
+			nodename: cstring_to_vstring(&d.nodename),
+			release: cstring_to_vstring(&d.release),
+			version: cstring_to_vstring(&d.version),
+			machine: cstring_to_vstring(&d.machine)
+		}
+	}
+	return Uname{}
+}
 
 fn init_os_args(argc int, argv &&byte) []string {
 	mut args := []string{}

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -5,6 +5,7 @@ import strings
 #include <dirent.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/utsname.h>
 
 pub const (
 	path_separator = '/'
@@ -17,6 +18,16 @@ const (
 	stderr_value = 2
 )
 
+struct C.utsname {
+mut:
+	sysname  [256]char
+	nodename [256]char
+	release  [256]char
+	version  [256]char
+	machine  [256]char
+}
+
+fn C.uname(name voidptr) int
 fn C.symlink(charptr, charptr) int
 
 fn init_os_args(argc int, argv &&byte) []string {

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -343,3 +343,12 @@ fn test_basedir() {
 	}
 	assert os.base_dir('filename') == 'filename'
 }
+
+fn test_uname() {
+	u := os.uname()
+	assert u.sysname.len > 0
+	assert u.nodename.len > 0
+	assert u.release.len > 0
+	assert u.version.len > 0
+	assert u.machine.len > 0
+}

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -317,7 +317,7 @@ pub:
 	// status_ constants
 	code u32
 	flags u32
-	
+
 	record &ExceptionRecord
 	address voidptr
 	param_count u32
@@ -352,4 +352,16 @@ pub fn add_vectored_exception_handler(first bool, handler VectoredExceptionHandl
 
 pub fn debugger_present() bool {
 	return C.IsDebuggerPresent()
+}
+
+pub fn uname() Uname {
+	// TODO: implement `os.uname()` for windows
+	unknown := 'unknown'
+	return Uname{
+		sysname: unknown
+		nodename: unknown
+		release: unknown
+		version: unknown
+		machine: unknown
+	}
 }


### PR DESCRIPTION
Added definition for os.Uname struct and os.uname() function to return the info from the libc call.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
