### PR TITLE
checker: check array.map/filter fn or anon_fn

### DIFF
--- a/vlib/v/checker/tests/array_filter_anon_fn_err_a.out
+++ b/vlib/v/checker/tests/array_filter_anon_fn_err_a.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/array_filter_anon_fn_err_a.v:2:23: error: function needs exactly 1 argument
+    1 | fn main() {
+    2 |     a := [1,2,3,4].filter(fn(a int, b int) bool { return a > 0 })
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3 |     println(a)
+    4 | }

--- a/vlib/v/checker/tests/array_filter_anon_fn_err_a.vv
+++ b/vlib/v/checker/tests/array_filter_anon_fn_err_a.vv
@@ -1,0 +1,4 @@
+fn main() {
+	a := [1,2,3,4].filter(fn(a int, b int) bool { return a > 0 })
+	println(a)
+}

--- a/vlib/v/checker/tests/array_filter_anon_fn_err_b.out
+++ b/vlib/v/checker/tests/array_filter_anon_fn_err_b.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/array_filter_anon_fn_err_b.v:2:23: error: type mismatch, should use `fn(a int) bool {...}`
+    1 | fn main() {
+    2 |     a := [1,2,3,4].filter(fn(a string) bool { return a.len > 0 })
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3 |     println(a)
+    4 | }

--- a/vlib/v/checker/tests/array_filter_anon_fn_err_b.vv
+++ b/vlib/v/checker/tests/array_filter_anon_fn_err_b.vv
@@ -1,0 +1,4 @@
+fn main() {
+	a := [1,2,3,4].filter(fn(a string) bool { return a.len > 0 })
+	println(a)
+}

--- a/vlib/v/checker/tests/array_filter_fn_err_a.out
+++ b/vlib/v/checker/tests/array_filter_fn_err_a.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/array_filter_fn_err_a.v:5:23: error: function needs exactly 1 argument
+    3 | }
+    4 | fn main() {
+    5 |     a := [1,2,3,4].filter(fil)
+      |                          ~~~~~
+    6 |     println(a)
+    7 | }

--- a/vlib/v/checker/tests/array_filter_fn_err_a.vv
+++ b/vlib/v/checker/tests/array_filter_fn_err_a.vv
@@ -1,0 +1,7 @@
+fn fil(a int, b int) bool {
+	return a > 0
+}
+fn main() {
+	a := [1,2,3,4].filter(fil)
+	println(a)
+}

--- a/vlib/v/checker/tests/array_filter_fn_err_b.out
+++ b/vlib/v/checker/tests/array_filter_fn_err_b.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/array_filter_fn_err_b.v:5:23: error: type mismatch, should use `fn(a int) bool {...}`
+    3 | }
+    4 | fn main() {
+    5 |     a := [1,2,3,4].filter(fil)
+      |                          ~~~~~
+    6 |     println(a)
+    7 | }

--- a/vlib/v/checker/tests/array_filter_fn_err_b.vv
+++ b/vlib/v/checker/tests/array_filter_fn_err_b.vv
@@ -1,0 +1,7 @@
+fn fil(a string) bool {
+	return a.len > 0
+}
+fn main() {
+	a := [1,2,3,4].filter(fil)
+	println(a)
+}

--- a/vlib/v/checker/tests/array_map_anon_fn_err_a.out
+++ b/vlib/v/checker/tests/array_map_anon_fn_err_a.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/array_map_anon_fn_err_a.v:2:20: error: function needs exactly 1 argument
+    1 | fn main() {
+    2 |     a := [1,2,3,4].map(fn(a int, b int) int {return a + b})
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3 |     println(a)
+    4 | }

--- a/vlib/v/checker/tests/array_map_anon_fn_err_a.vv
+++ b/vlib/v/checker/tests/array_map_anon_fn_err_a.vv
@@ -1,0 +1,4 @@
+fn main() {
+	a := [1,2,3,4].map(fn(a int, b int) int {return a + b})
+	println(a)
+}

--- a/vlib/v/checker/tests/array_map_anon_fn_err_b.out
+++ b/vlib/v/checker/tests/array_map_anon_fn_err_b.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/array_map_anon_fn_err_b.v:2:20: error: type mismatch, should use `fn(a int) int {...}`
+    1 | fn main() {
+    2 |     a := [1,2,3,4].map(fn(a string) string { return a })
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3 |     println(a)
+    4 | }

--- a/vlib/v/checker/tests/array_map_anon_fn_err_b.vv
+++ b/vlib/v/checker/tests/array_map_anon_fn_err_b.vv
@@ -1,0 +1,4 @@
+fn main() {
+	a := [1,2,3,4].map(fn(a string) string { return a })
+	println(a)
+}

--- a/vlib/v/checker/tests/array_map_fn_err_a.out
+++ b/vlib/v/checker/tests/array_map_fn_err_a.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/array_map_fn_err_a.v:5:20: error: function needs exactly 1 argument
+    3 | }
+    4 | fn main() {
+    5 |     a := [1,2,3,4].map(add)
+      |                       ~~~~~
+    6 |     println(a)
+    7 | }

--- a/vlib/v/checker/tests/array_map_fn_err_a.vv
+++ b/vlib/v/checker/tests/array_map_fn_err_a.vv
@@ -1,0 +1,7 @@
+fn add(a int, b int) int {
+	return a + b
+}
+fn main() {
+	a := [1,2,3,4].map(add)
+	println(a)
+}

--- a/vlib/v/checker/tests/array_map_fn_err_b.out
+++ b/vlib/v/checker/tests/array_map_fn_err_b.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/array_map_fn_err_b.v:5:20: error: type mismatch, should use `fn(a int) int {...}`
+    3 | }
+    4 | fn main() {
+    5 |     a := [1,2,3,4].map(add)
+      |                       ~~~~~
+    6 |     println(a)
+    7 | }

--- a/vlib/v/checker/tests/array_map_fn_err_b.vv
+++ b/vlib/v/checker/tests/array_map_fn_err_b.vv
@@ -1,0 +1,7 @@
+fn add(a string) string {
+	return a
+}
+fn main() {
+	a := [1,2,3,4].map(add)
+	println(a)
+}


### PR DESCRIPTION
This PR check array.map/filter fn or anon_fn.

- Check array.map/filter fn or anon_fn.
- Add tests.

```v
fn main() {
	a := [1,2,3,4].map(fn(a string) string { return a })
	println(a)
}

D:\test\v\tt1>v run .
.\tt1.v:2:20: error: type mismatch, should use `fn(a int) int {...}`
    1 | fn main() {
    2 |     a := [1,2,3,4].map(fn(a string) string { return a })
      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    3 |     println(a)
    4 | }
```

```v
fn add(a string) string {
	return a
}
fn main() {
	a := [1,2,3,4].map(add)
	println(a)
}

D:\test\v\tt1>v run .
.\tt1.v:5:20: error: type mismatch, should use `fn(a int) int {...}`
    3 | }
    4 | fn main() {
    5 |     a := [1,2,3,4].map(add)
      |                       ~~~~~
    6 |     println(a)
    7 | }
```