### PR TITLE
cgen: Edge case for multi-returns with 1 expr which is a multi-return

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2373,6 +2373,14 @@ fn (mut g Gen) return_statement(node ast.Return) {
 			g.write('return ')
 			styp = g.typ(g.fn_decl.return_type)
 		}
+		// Edge case handling for 2 multi returns of the same type
+		if node.exprs.len == 1 && g.expr_is_multi_return_call(node.exprs[0]) {
+			g.go_before_stmt(0)
+			g.write('return ')
+			g.expr(node.exprs[0])
+			g.writeln(';')
+			return
+		}
 		// Use this to keep the tmp assignments in order
 		mut multi_unpack := ''
 		g.write('($styp){')


### PR DESCRIPTION
Fixes a bug i ran into where i was returning an optional multi return from an optional multi return which wasnt working because it doesnt know how to handle that properly! (and that code is far to complicated right now to just keep adding more edge cases - someone (probably me) needs to go in and try and fix it!)