### PR TITLE
cgen: do not double-reference anon fn

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1374,7 +1374,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 			// TODO: dont fiddle with buffers
 			g.gen_anon_fn_decl(it)
 			fsym := g.table.get_type_symbol(it.typ)
-			g.write('&${fsym.name}')
+			g.write(fsym.name)
 		}
 		ast.ArrayInit {
 			g.array_init(it)


### PR DESCRIPTION
I'm not 100% sure but I think it's not necessary?