### PR TITLE
cgen: optimize array_init

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -37,7 +37,7 @@ fn __new_array_with_default(mylen int, cap int, elm_size int, val voidptr) array
 	}
 	if val != 0 {
 		for i in 0..arr.len {
-			C.memcpy(byteptr(arr.data) + i*elm_size, val, elm_size)
+			C.memcpy(charptr(arr.data) + i*elm_size, val, elm_size)
 		}
 	}
 	return arr
@@ -53,7 +53,7 @@ fn __new_array_with_array_default(mylen int, cap int, elm_size int, val array) a
 	}
 	for i in 0..arr.len {
 		val_clone := val.clone()
-		C.memcpy(byteptr(arr.data) + i*elm_size, &val_clone, elm_size)
+		C.memcpy(charptr(arr.data) + i*elm_size, &val_clone, elm_size)
 	}
 	return arr
 }

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -37,7 +37,7 @@ fn __new_array_with_default(mylen int, cap int, elm_size int, val voidptr) array
 	}
 	if val != 0 {
 		for i in 0..arr.len {
-			C.memcpy(charptr(arr.data) + i*elm_size, val, elm_size)
+			C.memcpy(byteptr(arr.data) + i*elm_size, val, elm_size)
 		}
 	}
 	return arr
@@ -53,7 +53,7 @@ fn __new_array_with_array_default(mylen int, cap int, elm_size int, val array) a
 	}
 	for i in 0..arr.len {
 		val_clone := val.clone()
-		C.memcpy(charptr(arr.data) + i*elm_size, &val_clone, elm_size)
+		C.memcpy(byteptr(arr.data) + i*elm_size, &val_clone, elm_size)
 	}
 	return arr
 }

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -4345,12 +4345,10 @@ fn (mut g Gen) array_init(it ast.ArrayInit) {
 		g.write('sizeof($elem_type_str), ')
 		if is_default_array {
 			g.write('_val_$it.pos.pos)')
+		} else if it.has_default || (it.has_len && it.elem_type == table.string_type) {
+			g.write('&_val_$it.pos.pos)')
 		} else {
-			if it.has_default || (it.has_len && it.elem_type == table.string_type) {
-				g.write('&_val_$it.pos.pos)')
-			} else {
-				g.write('0)')
-			}
+			g.write('0)')
 		}
 		return
 	}


### PR DESCRIPTION
This PR optimize array_init.

- `charptr` => `byteptr` in `__new_array_with_default()`.
- Change `else` at one level.