### PR TITLE
array: fix multiple array.repeat index error

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -119,7 +119,14 @@ pub fn (a array) repeat(count int) array {
 		cap: count * a.len
 	}
 	for i in 0..count {
-		C.memcpy(byteptr(arr.data) + i * a.len * a.element_size, byteptr(a.data), a.len * a.element_size)
+		if a.len > 0 && a.element_size == sizeof(array) {
+			ary := array{}
+			C.memcpy(&ary, a.data, sizeof(array))
+			ary_clone := ary.clone()
+			C.memcpy(byteptr(arr.data) + i * a.len * a.element_size, &ary_clone, a.len * a.element_size)
+		} else {
+			C.memcpy(byteptr(arr.data) + i * a.len * a.element_size, byteptr(a.data), a.len * a.element_size)
+		}
 	}
 	return arr
 }

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -821,4 +821,8 @@ fn test_mutli_array_index() {
 	mut a := [][]int{len:2, init: []int{len:3, init:0}}
 	a[0][0] = 1
 	assert '$a' == '[[1, 0, 0], [0, 0, 0]]'
+
+	mut b := [[0].repeat(3)].repeat(2)
+	b[0][0] = 1
+	assert '$b' == '[[1, 0, 0], [0, 0, 0]]'
 }


### PR DESCRIPTION
This PR fix multiple array.repeat index error.

- Fix multiple array.repeat index error.
- Add test in array_test.v.

```v
fn main() {
    // define a 3*3 zero matrix and then modify [0][0] to 1
	mut a := [[0].repeat(3)].repeat(3)  // method 1
	println(a)
	a[0][0] = 1
	println(a)
	mut b := [][]int{len:3, init: []int{len:3, init:0}}  // method 2
	println(b)
	b[0][0] = 1
	println(b)
}

D:\test\v\tt1>v run .
[[0, 0, 0], [0, 0, 0], [0, 0, 0]]
[[1, 0, 0], [0, 0, 0], [0, 0, 0]]
[[0, 0, 0], [0, 0, 0], [0, 0, 0]]
[[1, 0, 0], [0, 0, 0], [0, 0, 0]]
```