### PR TITLE
parser: fix fn attributes empty error (fix #5345)

### DIFF
--- a/vlib/v/checker/tests/fn_attributes_empty_err.out
+++ b/vlib/v/checker/tests/fn_attributes_empty_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/fn_attributes_empty_err.v:1:1: error: attributes cannot be empty
+    1 | [] fn tt() {
+      | ~~
+    2 |     println('text')
+    3 | }

--- a/vlib/v/checker/tests/fn_attributes_empty_err.vv
+++ b/vlib/v/checker/tests/fn_attributes_empty_err.vv
@@ -1,0 +1,6 @@
+[] fn tt() {
+	println('text')
+}
+fn main() {
+	tt()
+}

--- a/vlib/v/checker/tests/multiple_fn_attributes.out
+++ b/vlib/v/checker/tests/multiple_fn_attributes.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/multiple_fn_attributes.v:2:1: error: multiple attributes detected 
+vlib/v/checker/tests/multiple_fn_attributes.v:1:1: error: multiple attributes detected
     1 | [inline;deprecated]
+      | ~~~~~~~~~~~~~~~~~~~
     2 | fn foo(name string) string {}
-      | ~~

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -407,9 +407,14 @@ pub fn (mut p Parser) top_stmt() ast.Stmt {
 			}
 		}
 		.lsbr {
+			start_pos := p.tok.position()
 			attrs := p.attributes()
 			if attrs.len > 1 {
-				p.error('multiple attributes detected')
+				end_pos := p.tok.position()
+				p.error_with_pos('multiple attributes detected', start_pos.extend(end_pos))
+			} else if attrs.len == 0 {
+				end_pos := p.tok.position()
+				p.error_with_pos('attributes cannot be empty', start_pos.extend(end_pos))
 			}
 			return attrs[0]
 		}


### PR DESCRIPTION
This PR fix fn attributes empty error (fix #5345).

- Fix fn attributes empty error.
- Add test `fn_attributes_empty_err.vv/out`.

```v
[] fn tt() {
	println('text')
}
fn main() {
	tt()
}

D:\test\v\tt1>v run .
.\tt1.v:1:1: error: attributes cannot be empty 
    1 | [] fn tt() {
      | ~~
    2 |     println('text')
    3 | }
```