### PR TITLE
test: run all tests even if some fail

### DIFF
--- a/cmd/tools/preludes/tests_assertions.v
+++ b/cmd/tools/preludes/tests_assertions.v
@@ -20,6 +20,7 @@ fn cb_assertion_failed(i &VAssertMetaInfo) {
 	}
 	final_filename := if use_relative_paths { i.fpath } else { os.real_path(i.fpath) }
 	final_funcname := i.fn_name.replace('main__', '').replace('__', '.')
+	eprintln('')
 	eprintln('$final_filename:${i.line_nr+1}: failed assert in ${final_funcname}')
 	eprintln('Source  : ${i.src}')
 	if i.op != 'call' {

--- a/cmd/tools/preludes/tests_assertions.v
+++ b/cmd/tools/preludes/tests_assertions.v
@@ -23,7 +23,7 @@ fn cb_assertion_failed(i &VAssertMetaInfo) {
 	eprintln('')
 	eprintln('$final_filename:${i.line_nr+1}: failed assert in ${final_funcname}')
 	eprintln('Source  : ${i.src}')
-	if i.op != 'call' {
+	if i.op.len > 0 && i.op != 'call' {
 		eprintln('   left value: ${i.llabel} = ${i.lvalue}')
 		eprintln('  right value: ${i.rlabel} = ${i.rvalue}')
 	}

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -237,7 +237,7 @@ pub:
 }
 fn __print_assert_failure(i &VAssertMetaInfo) {
 	eprintln('${i.fpath}:${i.line_nr+1}: FAIL: fn ${i.fn_name}: assert ${i.src}')
-	if i.op != 'call' {
+	if i.op.len > 0 && i.op != 'call' {
 		eprintln('   left value: ${i.llabel} = ${i.lvalue}')
 		eprintln('  right value: ${i.rlabel} = ${i.rvalue}')
 	}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -942,7 +942,7 @@ fn (mut g Gen) gen_assert_stmt(a ast.AssertStmt) {
 		g.writeln('	g_test_fails++;')
 		metaname_fail := g.gen_assert_metainfo(a)
 		g.writeln('	cb_assertion_failed(&${metaname_fail});')
-		g.writeln('	exit(1);')
+		g.writeln('	longjmp(g_jump_buffer, 1);')
 		g.writeln('	// TODO')
 		g.writeln('	// Maybe print all vars in a test function if it fails?')
 		g.writeln('}')
@@ -3607,6 +3607,7 @@ fn (g Gen) type_default(typ table.Type) string {
 pub fn (mut g Gen) write_tests_main() {
 	g.definitions.writeln('int g_test_oks = 0;')
 	g.definitions.writeln('int g_test_fails = 0;')
+	g.writeln('static jmp_buf g_jump_buffer;')
 	$if windows {
 		g.writeln('int wmain() {')
 	} $else {
@@ -3623,7 +3624,7 @@ pub fn (mut g Gen) write_tests_main() {
 		if g.pref.is_stats {
 			g.writeln('\tBenchedTests_testing_step_start(&bt, tos_lit("$t"));')
 		}
-		g.writeln('\t${t}();')
+		g.writeln('\tif (!setjmp(g_jump_buffer)) ${t}();')
 		if g.pref.is_stats {
 			g.writeln('\tBenchedTests_testing_step_end(&bt);')
 		}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3605,10 +3605,10 @@ fn (g Gen) type_default(typ table.Type) string {
 }
 
 pub fn (mut g Gen) write_tests_main() {
+	g.includes.writeln('#include <setjmp.h> // write_tests_main')
 	g.definitions.writeln('int g_test_oks = 0;')
 	g.definitions.writeln('int g_test_fails = 0;')
-	g.includes.writeln('#include <setjmp.h> // write_tests_main')
-	g.writeln('static jmp_buf g_jump_buffer;')
+	g.definitions.writeln('jmp_buf g_jump_buffer;')
 	$if windows {
 		g.writeln('int wmain() {')
 	} $else {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3607,6 +3607,7 @@ fn (g Gen) type_default(typ table.Type) string {
 pub fn (mut g Gen) write_tests_main() {
 	g.definitions.writeln('int g_test_oks = 0;')
 	g.definitions.writeln('int g_test_fails = 0;')
+	g.includes.writeln('#include <setjmp.h> // write_tests_main')
 	g.writeln('static jmp_buf g_jump_buffer;')
 	$if windows {
 		g.writeln('int wmain() {')


### PR DESCRIPTION
I use technique that simulates try/catch described in https://web.archive.org/web/20091104065428/http://www.di.unipi.it/~nids/docs/longjump_try_trow_catch.html to support running all tests even if single one fails (`exit(1)` is called only in non-test environment).

Now that multiple assertion failures can happen within single test file, I've also added empty line above each test failure for readability (#5365 is needed to preserve first new line).