### PR TITLE
cgen: fix string interpolation for autofree

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3054,7 +3054,7 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 			// TODO: better check this case
 			g.write('${fmt}"PRId32"')
 		}
-		if i < node.exprs.len - 1 && !g.pref.autofree {
+		if i < node.exprs.len - 1 {
 			g.write('\\000')
 		}
 	}

--- a/vlib/v/gen/str.v
+++ b/vlib/v/gen/str.v
@@ -18,7 +18,7 @@ void _STR_PRINT_ARG(const char *fmt, char** refbufp, int *nbytes, int *memsize, 
 			guess = vsnprintf(*refbufp + *nbytes, *memsize - *nbytes, fmt, args);
 			if (guess < *memsize - *nbytes) { // result did fit into buffer
 				*nbytes += guess;
-				return;
+				break;
 			}
 		}
 		// increase buffer (somewhat exponentially)


### PR DESCRIPTION
this should fix certain segv crashes when autofree is active
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
