### PR TITLE
parser: fix string array initialization with interpolation

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1166,7 +1166,7 @@ fn (mut p Parser) string_expr() ast.Expr {
 		vals << p.tok.lit
 		p.next()
 		if p.tok.kind != .str_dollar {
-			continue
+			break
 		}
 		p.next()
 		exprs << p.expr(0)

--- a/vlib/v/tests/string_interpolation_array_test.v
+++ b/vlib/v/tests/string_interpolation_array_test.v
@@ -83,3 +83,22 @@ fn test_array_of_map_interpolation() {
 	a << {'c': int(3), 'd': 4}
 	assert '$a' == "[{'a': 1, 'b': 2}, {'c': 3, 'd': 4}]"
 }
+
+fn test_array_initialization_with_interpolation() {
+	sysroot := '/usr'
+	a := [
+		'abcd'
+		'$sysroot/xyz'
+		'u$sysroot/vw'
+		'/rr$sysroot'
+		'lmno'
+	]
+	assert '$a' == "['abcd', '/usr/xyz', 'u/usr/vw', '/rr/usr', 'lmno']"
+	b := [
+		'a${sysroot:5}/r'
+		'ert'
+	]
+	assert '$b' == "['a /usr/r', 'ert']"
+	c := ['xy', 'r$sysroot', '$sysroot/t', '>$sysroot<']
+	assert '$c' == "['xy', 'r/usr', '/usr/t', '>/usr<']"
+}


### PR DESCRIPTION
This PR fixes the initialization of string arrays for cases where interpolation is used and the initializers are not separated by commas.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
