### PR TITLE
cgen: fix array_init temporary variables error

### DIFF
--- a/vlib/v/tests/array_init_test.v
+++ b/vlib/v/tests/array_init_test.v
@@ -189,3 +189,8 @@ fn test_multi_dimensional_array_init() {
 	f := [][]int{len:3}
 	assert '$f' == '[[], [], []]'
 }
+
+fn test_array_init_direct_call() {
+	assert []int{len: 2, init: 0}.len == 2
+	assert []int{len: 3, init: 1}.map(it*2) == [2,2,2]
+}


### PR DESCRIPTION
This PR fix array_init temporary variables error.

- Fix array_init temporary variables error.
- Add test `test_array_init_direct_call()` in array_init_test.v.

```v
fn test_array_init_direct_call() {
	assert []int{len: 2, init: 0}.len == 2
	assert []int{len: 3, init: 1}.map(it*2) == [2,2,2]
}
```
```v
fn main() {
    println([][]int{len: 2, init:[]int{len: 3, init: 22}})
}

D:\test\v\tt1>v run .
[[22, 22, 22], [22, 22, 22]]
```

Solution
- Cancel temporary variable mode.
- Use array initialization assignment mode.