### PR TITLE
cgen: fix in array error (fix #5369)

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1861,13 +1861,15 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 		if right_sym.kind == .array {
 			match node.right {
 				ast.ArrayInit {
-					// `a in [1,2,3]` optimization => `a == 1 || a == 2 || a == 3`
-					// avoids an allocation
-					// g.write('/*in opt*/')
-					g.write('(')
-					g.in_optimization(node.left, it)
-					g.write(')')
-					return
+					if it.exprs.len > 0 {
+						// `a in [1,2,3]` optimization => `a == 1 || a == 2 || a == 3`
+						// avoids an allocation
+						// g.write('/*in opt*/')
+						g.write('(')
+						g.in_optimization(node.left, it)
+						g.write(')')
+						return
+					}
 				}
 				else {}
 			}

--- a/vlib/v/tests/in_expression_test.v
+++ b/vlib/v/tests/in_expression_test.v
@@ -214,3 +214,7 @@ fn test_optimized_in_expression_with_string() {
 	a = 'ab' in ['ab', 'bc'] && false
 	assert a == false
 }
+
+fn test_in_array_init() {
+	assert 1 !in []int{}
+}


### PR DESCRIPTION
This PR fix in array error (fix #5369).

- Fix in array error.
- Add test `test_in_array_init()` in `in_expression_test.v`.

```v
fn main() {
    println(1 in []int{})
}

D:\test\v\tt1>v run .
false
```