### PR TITLE
string: fix contains error (fix #5371)

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -716,6 +716,9 @@ pub fn (s string) count(substr string) int {
 }
 
 pub fn (s string) contains(p string) bool {
+	if p.len == 0 {
+		return true
+	}
 	s.index(p) or {
 		return false
 	}

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -357,6 +357,8 @@ fn test_contains() {
 	s := 'view.v'
 	assert s.contains('vi')
 	assert !s.contains('random')
+	assert ''.contains('')
+	assert 'abc'.contains('')
 }
 
 fn test_arr_contains() {


### PR DESCRIPTION
This PR fix contains error (fix #5371).

- Fix contains error.
- Add test.

```v
fn main() {
    println('' in '')
    println('' in 'hello')
}

D:\test\v\tt1>v run .
true
true
```