### PR TITLE
cgen: fix `in` multi_array (fix #5368)

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3380,18 +3380,29 @@ fn (mut g Gen) type_of_call_expr(node ast.Expr) string {
 // `a in [1,2,3]` => `a == 1 || a == 2 || a == 3`
 fn (mut g Gen) in_optimization(left ast.Expr, right ast.ArrayInit) {
 	is_str := right.elem_type == table.string_type
+	elem_sym := g.table.get_type_symbol(right.elem_type)
+	is_ary := elem_sym.kind == .array
 	for i, array_expr in right.exprs {
 		if is_str {
 			g.write('string_eq(')
+		} else if is_ary {
+			styp := g.table.value_type(right.elem_type)
+			ptr_typ := g.typ(right.elem_type).split('_')[1]
+			if ptr_typ !in g.array_fn_definitions {
+				sym := g.table.get_type_symbol(elem_sym.array_info().elem_type)
+				g.generate_array_equality_fn(ptr_typ, styp, sym)
+			}
+			g.write('${ptr_typ}_arr_eq(')
 		}
+
 		g.expr(left)
-		if is_str {
+		if is_str || is_ary {
 			g.write(', ')
 		} else {
 			g.write(' == ')
 		}
 		g.expr(array_expr)
-		if is_str {
+		if is_str || is_ary {
 			g.write(')')
 		}
 		if i < right.exprs.len - 1 {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3381,11 +3381,11 @@ fn (mut g Gen) type_of_call_expr(node ast.Expr) string {
 fn (mut g Gen) in_optimization(left ast.Expr, right ast.ArrayInit) {
 	is_str := right.elem_type == table.string_type
 	elem_sym := g.table.get_type_symbol(right.elem_type)
-	is_ary := elem_sym.kind == .array
+	is_array := elem_sym.kind == .array
 	for i, array_expr in right.exprs {
 		if is_str {
 			g.write('string_eq(')
-		} else if is_ary {
+		} else if is_array {
 			styp := g.table.value_type(right.elem_type)
 			ptr_typ := g.typ(right.elem_type).split('_')[1]
 			if ptr_typ !in g.array_fn_definitions {
@@ -3396,13 +3396,13 @@ fn (mut g Gen) in_optimization(left ast.Expr, right ast.ArrayInit) {
 		}
 
 		g.expr(left)
-		if is_str || is_ary {
+		if is_str || is_array {
 			g.write(', ')
 		} else {
 			g.write(' == ')
 		}
 		g.expr(array_expr)
-		if is_str || is_ary {
+		if is_str || is_array {
 			g.write(')')
 		}
 		if i < right.exprs.len - 1 {

--- a/vlib/v/tests/in_expression_test.v
+++ b/vlib/v/tests/in_expression_test.v
@@ -217,4 +217,5 @@ fn test_optimized_in_expression_with_string() {
 
 fn test_in_array_init() {
 	assert 1 !in []int{}
+	assert [1] in [[1]]
 }


### PR DESCRIPTION
This PR fix `in` multi_array (fix #5368).

- Fix `in` multi_array.
- Add test.

```v
fn main() {
    println([1] in [[1]])
}

D:\test\v\tt1>v run .
true
```