### PR TITLE
tcc: support tcc on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ fns.txt
 cachegrind.out.*
 .gdb_history
 *.dSYM
+*.def
 
 # ignore system files
 .DS_Store

--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -71,6 +71,9 @@ fn print_backtrace_skipping_top_frames(skipframes int) bool {
 	$if msvc {
 		return print_backtrace_skipping_top_frames_msvc(skipframes)
 	}
+	$if tinyc {
+		return print_backtrace_skipping_top_frames_tcc(skipframes)
+	}
 	$if mingw {
 		return print_backtrace_skipping_top_frames_mingw(skipframes)
 	}
@@ -141,6 +144,16 @@ fn print_backtrace_skipping_top_frames_mingw(skipframes int) bool {
 	return false
 }
 
+fn C.tcc_backtrace(fmt charptr, other ...charptr) int
+fn print_backtrace_skipping_top_frames_tcc(skipframes int) bool {
+	$if tinyc {
+		C.tcc_backtrace("Backtrace")
+		return false
+	} $else {
+		eprintln('print_backtrace_skipping_top_frames_tcc must be called only when the compiler is tcc')
+		return false
+	}
+}
 
 //TODO copypaste from os
 // we want to be able to use this here without having to `import os`
@@ -198,7 +211,14 @@ fn C.IsDebuggerPresent() bool
 fn C.__debugbreak()
 
 fn break_if_debugger_attached() {
-	if C.IsDebuggerPresent() {
-		C.__debugbreak()
+	$if tinyc {
+		unsafe {
+			ptr := &voidptr(0)
+			*ptr = 0
+		}
+	} $else {
+		if C.IsDebuggerPresent() {
+			C.__debugbreak()
+		}
 	}
 }

--- a/vlib/time/time_windows.c.v
+++ b/vlib/time/time_windows.c.v
@@ -4,7 +4,7 @@
 module time
 
 #include <time.h>
-#include <sysinfoapi.h>
+// #include <sysinfoapi.h>
 
 struct C.tm {
 	tm_year int

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -44,7 +44,7 @@ const (
 #define __IRQHANDLER
 #undef TCCSKIP
 #define TCCSKIP(x)
-#include <byteswap.h>
+// #include <byteswap.h>
 #endif
 
 // for __offset_of


### PR DESCRIPTION
This PR allows `tcc` to be used as a C compiler on Windows. To get it to build I've commented out  two headers, `sysinfoapi.h` and `byteswap.h`, but CI is passing without them so it should be fine.

Related: vlang/tccbin_win#1

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
