### PR TITLE
checker: check return_duplicate_with_none (fix #5363)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -798,7 +798,8 @@ pub mut:
 
 pub struct None {
 pub:
-	foo int // todo
+	pos  token.Position
+	foo  int // todo
 }
 
 [inline]
@@ -872,6 +873,9 @@ pub fn (expr Expr) position() token.Position {
 			return it.pos
 		}
 		MatchExpr {
+			return it.pos
+		}
+		None {
 			return it.pos
 		}
 		PostfixExpr {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1793,7 +1793,7 @@ fn (mut c Checker) stmts(stmts []ast.Stmt) {
 		c.stmt(stmt)
 	}
 	if unreachable.line_nr >= 0 {
-		c.warn('unreachable code', unreachable)
+		c.error('unreachable code', unreachable)
 	}
 	c.scope_returns = false
 	c.expected_type = table.void_type

--- a/vlib/v/checker/tests/return_duplicate_with_none_err_a.out
+++ b/vlib/v/checker/tests/return_duplicate_with_none_err_a.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/return_duplicate_with_none_err_a.v:3:2: error: unreachable code
+    1 | fn f() ?bool {
+    2 |     return true
+    3 |     return none
+      |     ~~~~~~~~~~~
+    4 | }
+    5 | fn main() {

--- a/vlib/v/checker/tests/return_duplicate_with_none_err_a.vv
+++ b/vlib/v/checker/tests/return_duplicate_with_none_err_a.vv
@@ -1,0 +1,9 @@
+fn f() ?bool {
+	return true
+	return none
+}
+fn main() {
+	f() or {
+		println('fail')
+	}
+}

--- a/vlib/v/checker/tests/return_duplicate_with_none_err_b.out
+++ b/vlib/v/checker/tests/return_duplicate_with_none_err_b.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/return_duplicate_with_none_err_b.v:3:2: error: unreachable code
+    1 | fn f() ?bool {
+    2 |     return none
+    3 |     return true
+      |     ~~~~~~~~~~~
+    4 | }
+    5 | fn main() {

--- a/vlib/v/checker/tests/return_duplicate_with_none_err_b.vv
+++ b/vlib/v/checker/tests/return_duplicate_with_none_err_b.vv
@@ -1,0 +1,9 @@
+fn f() ?bool {
+	return none
+	return true
+}
+fn main() {
+	f() or {
+		println('fail')
+	}
+}

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -73,8 +73,11 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			}
 		}
 		.key_none {
+			pos := p.tok.position()
 			p.next()
-			node = ast.None{}
+			node = ast.None{
+				pos: pos
+			}
 		}
 		.key_sizeof {
 			p.next() // sizeof


### PR DESCRIPTION
This PR check return_duplicate_with_none (fix #5363).

- Check return_duplicate_with_none.
- Add test `return_duplicate_with_none_err.vv/out`.

```v
fn f() ?bool {
	return true
	return none
}
fn main() {
	f() or {
		println('fail')
	}
}

D:\test\v\tt1>v run .
.\tt1.v:3:2: error: unreachable code
    1 | fn f() ?bool {
    2 |     return true
    3 |     return none
      |     ~~~~~~~~~~~
    4 | }
    5 | fn main() {
```