### PR TITLE
test: fix `test_array_init()` in array_init_test.v

### DIFF
--- a/vlib/v/tests/array_init_test.v
+++ b/vlib/v/tests/array_init_test.v
@@ -6,13 +6,13 @@ fn test_array_init() {
 	b := [1, 2, 3]
 	mut a := []int{cap: b.len}
 	a << 1
-	'$a, $a.len, $a.cap' == '[1], 1, 3'
+	assert '$a, $a.len, $a.cap' == '[1], 1, 3'
 
 	c := Init{len: 3}
 	mut d := []string{cap: c.len}
 	d << 'aaa'
 	d << 'bbb'
-	'$d, $d.len, $d.cap' == "['aaa', 'bbb'], 2, 3"
+	assert '$d, $d.len, $d.cap' == "['aaa', 'bbb'], 2, 3"
 }
 
 fn test_nested_array_init() {


### PR DESCRIPTION
This PR fix array_init_test.v.

In `test_array_init()`, add `assert` for test.
- assert '$a, $a.len, $a.cap' == '[1], 1, 3'.
- assert '$d, $d.len, $d.cap' == "['aaa', 'bbb'], 2, 3".