### PR TITLE
string: add map method

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1354,6 +1354,10 @@ pub fn (s string) fields() []string {
 	return s.replace('\t', ' ').split(' ')
 }
 
+pub fn (s string) map(func fn(byte) byte) string {
+	return string(s.bytes().map(func(it)))
+}
+
 // Allows multi-line strings to be formatted in a way that removes white-space
 // before a delimeter. by default `|` is used.
 // Note: the delimiter has to be a byte at this time. That means surrounding

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -742,6 +742,19 @@ fn test_double_quote_inter() {
 	assert '${a} ${b}' == "1 2"
 }
 
+fn test_string_map() {
+	a := 'Hello'.map(fn (b byte) byte {
+		return b + 1
+	}) 
+	assert a == 'Ifmmp'
+
+	assert 'foo'.map(foo) == r'\ee'
+}
+
+fn foo(b byte) byte {
+	return b - 10 
+}
+
 fn test_split_into_lines() {
 	line_content := 'Line'
 	text_crlf := '${line_content}\r\n${line_content}\r\n${line_content}'


### PR DESCRIPTION
`string.map(func)` is similar or is inspired from Go's `strings.Map(str, func)` which maps the every element of the string. I think it will be rarely used but having would be great!

Usage:
```v
fn test_string_map() {
	a := 'Hello'.map(fn (b byte) byte {
		return b + 1
	}) 
	assert a == 'Ifmmp'

	assert 'foo'.map(foo) == r'\ee'
}

fn foo(b byte) byte {
	return b - 10 
}
```

**NOTE**: the function takes `byte` not `rune` type because `rune` is not implemented yet so it will only work for ASCII characters. This will be changed when `rune` comes.
 