### PR TITLE
parser: minor optimization in `parse_multi_expr()`.

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -753,10 +753,10 @@ fn (mut p Parser) parse_multi_expr(is_top_level bool) ast.Stmt {
 	if p.tok.kind in [.assign, .decl_assign] || p.tok.kind.is_assign() {
 		return p.partial_assign_stmt(left)
 	}
-	else if is_top_level && left.len > 0 &&
+	else if is_top_level && tok.kind !in [.key_if, .key_match] &&
 			left0 !is ast.CallExpr && left0 !is ast.PostfixExpr &&
 			!(left0 is ast.InfixExpr && (left0 as ast.InfixExpr).op == .left_shift) &&
-			left0 !is ast.ComptimeCall && tok.kind !in [.key_if, .key_match] {
+			left0 !is ast.ComptimeCall {
 		p.error_with_pos('expression evaluated but not used', left0.position())
 	}
 	if left.len == 1 {


### PR DESCRIPTION
This PR does minor optimization in `parse_multi_expr()`.

- Remove redundant judgment.
- Increase the priority of handling situations that occur frequently.