### PR TITLE
cgen: fix `arr.insert(0, [1,2,3])` `arr.prepend([1,2,3])`

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -136,11 +136,7 @@ pub fn (mut a array) sort_with_compare(compare voidptr) {
 	C.qsort(a.data, a.len, a.element_size, compare)
 }
 
-// TODO array.insert is broken
-// Cannot pass literal or primitive type as it cannot be cast to voidptr.
-// In the current state only that would work:
-// i := 3
-// a.insert(0, &i)
+// array.insert
 pub fn (mut a array) insert(i int, val voidptr) {
 	$if !no_bounds_checking? {
 		if i < 0 || i > a.len {
@@ -154,10 +150,28 @@ pub fn (mut a array) insert(i int, val voidptr) {
 	a.len++
 }
 
-// TODO array.prepend is broken
-// It depends on array.insert
+// array.insert_many
+pub fn (mut a array) insert_many(i int, val voidptr, size int) {
+	$if !no_bounds_checking? {
+		if i < 0 || i > a.len {
+			panic('array.insert_many: index out of range (i == $i, a.len == $a.len)')
+		}
+	}
+	a.ensure_cap(a.len + size)
+	elem_size := a.element_size
+	C.memmove(byteptr(a.data) + (i + size) * elem_size, byteptr(a.data) + i * elem_size, (a.len - i) * elem_size)
+	C.memcpy(byteptr(a.data) + i * elem_size, val, size * elem_size)
+	a.len += size
+}
+
+// array.prepend
 pub fn (mut a array) prepend(val voidptr) {
 	a.insert(0, val)
+}
+
+// array.prepend_many
+pub fn (mut a array) prepend_many(val voidptr, size int) {
+	a.insert_many(0, val, size)
 }
 
 // array.delete deletes array element at the given index

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -134,6 +134,15 @@ fn test_insert() {
 	assert b[0] == f64(1.1)
 }
 
+fn test_insert_many() {
+	mut a := [3, 4]
+	a.insert(0, [1, 2])
+	assert a == [1,2,3,4]
+	b := [5,6]
+	a.insert(1, b)
+	assert a == [1,5,6,2,3,4]
+}
+
 fn test_prepend() {
 	mut a := []int{}
 	assert a.len == 0
@@ -145,6 +154,15 @@ fn test_prepend() {
 	b.prepend(f64(1.1))
 	assert b.len == 1
 	assert b[0] == f64(1.1)
+}
+
+fn test_prepend_many() {
+	mut a := [3,4]
+	a.prepend([1,2])
+	assert a == [1,2,3,4]
+	b := [5,6]
+	a.prepend(b)
+	assert a == [5,6,1,2,3,4]
 }
 
 fn test_strings() {
@@ -165,7 +183,6 @@ fn test_compare_ints() {
     assert compare_ints(a, a) == 0
 }
 */
-
 
 fn test_repeat() {
 	{


### PR DESCRIPTION
This PR fix `arr.insert(0, [1,2,3])` `arr.prepend([1,2,3])`.

- Fix `arr.insert(0, [1,2,3])` `arr.prepend([1,2,3])`.
- Add tests `test_insert_many()` `test_prepend_many()` in array_test.v.

```v
fn test_insert_many() {
	mut a := [3, 4]
	a.insert(0, [1, 2])
	assert a == [1,2,3,4]
	b := [5,6]
	a.insert(1, b)
	assert a == [1,5,6,2,3,4]
}

fn test_prepend_many() {
	mut a := [3,4]
	a.prepend([1,2])
	assert a == [1,2,3,4]
	b := [5,6]
	a.prepend(b)
	assert a == [5,6,1,2,3,4]
}
```