### PR TITLE
cgen: optimize the format of the generated code

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -4312,7 +4312,9 @@ fn (mut g Gen) array_init(it ast.ArrayInit) {
 	}
 	len := it.exprs.len
 	g.write('new_array_from_c_array($len, $len, sizeof($elem_type_str), _MOV(($elem_type_str[$len]){')
-	g.writeln('')
+	if len > 8 {
+		g.writeln('')
+	}
 	for i, expr in it.exprs {
 		if it.is_interface {
 			// sym := g.table.get_type_symbol(it.interface_types[i])
@@ -4323,9 +4325,13 @@ fn (mut g Gen) array_init(it ast.ArrayInit) {
 		if it.is_interface {
 			g.write(')')
 		}
-		g.write(', ')
+		if i != len - 1 {
+			g.write(', ')
+		}
 	}
-	g.writeln('')
+	if len > 8 {
+		g.writeln('')
+	}
 	g.write('}))')
 }
 


### PR DESCRIPTION
This PR optimize the format of the generated code.

Before:
```v
	array_int a = new_array_from_c_array(3, 3, sizeof(int), _MOV((int[3]){
        1, 2, 3,
        }));
```
Now:
```v
	array_int a = new_array_from_c_array(3, 3, sizeof(int), _MOV((int[3]){1, 2, 3}));
```

- Remove the comma of the last array element that is redundant.
- Single-line display with few array elements.