### PR TITLE
fmt: further fixes for string interpolation and builtin macros

### DIFF
--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -185,7 +185,7 @@ fn html_highlight(code string, tb &table.Table) string {
 		} else { tok.lit }
 		return if typ in [.unone, .name] { lit } else { '<span class="token $typ">$lit</span>' } 
 	}
-	s := scanner.new_scanner(code, .parse_comments)
+	s := scanner.new_scanner(code, .parse_comments, false)
 	mut tok := s.scan()
 	mut next_tok := s.scan()
 	mut buf := strings.new_builder(200)

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -140,7 +140,7 @@ fn main() {
 
 fn (foptions &FormatOptions) format_file(file string) {
 	mut prefs := pref.new_preferences()
-	prefs.is_fmt = util.is_fmt()
+	prefs.is_fmt = true
 	if foptions.is_verbose {
 		eprintln('vfmt2 running fmt.fmt over file: $file')
 	}

--- a/vlib/v/fmt/fmt_keep_test.v
+++ b/vlib/v/fmt/fmt_keep_test.v
@@ -44,8 +44,10 @@ fn test_fmt() {
 			continue
 		}
 		table := table.new_table()
-		file_ast := parser.parse_file(ipath, table, .parse_comments, &pref.Preferences{}, &ast.Scope{
-			parent: 0
+		file_ast := parser.parse_file(ipath, table, .parse_comments, &pref.Preferences{
+				is_fmt: true
+			}, &ast.Scope{
+				parent: 0
 		})
 		result_ocontent := fmt.fmt(file_ast, table, false)
 		if expected_ocontent != result_ocontent {

--- a/vlib/v/fmt/fmt_test.v
+++ b/vlib/v/fmt/fmt_test.v
@@ -44,8 +44,10 @@ fn test_fmt() {
 			continue
 		}
 		table := table.new_table()
-		file_ast := parser.parse_file(ipath, table, .parse_comments, &pref.Preferences{}, &ast.Scope{
-			parent: 0
+		file_ast := parser.parse_file(ipath, table, .parse_comments, &pref.Preferences{
+				is_fmt: true
+			}, &ast.Scope{
+				parent: 0
 		})
 		result_ocontent := fmt.fmt(file_ast, table, false)
 		if expected_ocontent != result_ocontent {

--- a/vlib/v/fmt/fmt_vlib_test.v
+++ b/vlib/v/fmt/fmt_vlib_test.v
@@ -43,8 +43,10 @@ fn test_vlib_fmt() {
 			continue
 		}
 		table := table.new_table()
-		file_ast := parser.parse_file(ipath, table, .parse_comments, &pref.Preferences{}, &ast.Scope{
-			parent: 0
+		file_ast := parser.parse_file(ipath, table, .parse_comments, &pref.Preferences{
+				is_fmt: true
+			}, &ast.Scope{
+				parent: 0
 		})
 		result_ocontent := fmt.fmt(file_ast, table, false)
 		if expected_ocontent != result_ocontent {

--- a/vlib/v/fmt/tests/string_interpolation_expected.vv
+++ b/vlib/v/fmt/tests/string_interpolation_expected.vv
@@ -10,6 +10,14 @@ struct Cc {
 	a []Aa
 }
 
+fn (c &Cc) f() int {
+	return c.a[0].xy
+}
+
+fn (c &Cc) g(k, l int) int {
+	return c.a[k].xy + l
+}
+
 fn main() {
 	st := Bb{Aa{5}}
 	ar := Cc{[Aa{3}, Aa{-4}, Aa{12}]}
@@ -19,4 +27,6 @@ fn main() {
 	println('$st.a.xy${ar.a[2].xy}$aa.xy$z')
 	println('${st.a.xy}ya ${ar.a[2].xy}X2 ${aa.xy}.b ${z}3')
 	println('${z:-5} ${z:+5.3} ${z:+09.3f} ${z:-7.2} ${z:+09} ${z:08.3f}')
+	println('$ar.f() ${ar.g(1,2)} ${ar.a}() ${z}(')
+	println('${z>12.3*z-3} ${@VEXE} ${4*5}')
 }

--- a/vlib/v/fmt/tests/string_interpolation_input.vv
+++ b/vlib/v/fmt/tests/string_interpolation_input.vv
@@ -10,6 +10,14 @@ struct Cc {
 	a []Aa
 }
 
+fn (c &Cc) f() int {
+	return c.a[0].xy
+}
+
+fn (c &Cc) g(k, l int) int {
+	return c.a[k].xy+l
+}
+
 fn main() {
 	st := Bb{Aa{5}}
 	ar := Cc{[Aa{3}, Aa{-4}, Aa{12}]}
@@ -19,4 +27,6 @@ fn main() {
 	println('${st.a.xy}${ar.a[2].xy}${aa.xy}${z}')
 	println('${st.a.xy}ya ${ar.a[2].xy}X2 ${aa.xy}.b ${z}3')
 	println('${z:-5} ${z:+5.3} ${z:+09.3f} ${z:-07.2} ${z:+009} ${z:008.3f}')
+	println('${ar.f()} ${ar.g(1, 2)} ${ar.a}() ${z}(')
+	println('${z > 12.3 * z - 3} ${@VEXE} ${4 * 5}')
 }

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -60,7 +60,7 @@ mut:
 
 // for tests
 pub fn parse_stmt(text string, table &table.Table, scope &ast.Scope) ast.Stmt {
-	s := scanner.new_scanner(text, .skip_comments)
+	s := scanner.new_scanner(text, .skip_comments, false)
 	mut p := Parser{
 		scanner: s
 		table: table
@@ -77,7 +77,7 @@ pub fn parse_stmt(text string, table &table.Table, scope &ast.Scope) ast.Stmt {
 }
 
 pub fn parse_text(text string, b_table &table.Table, pref &pref.Preferences, scope, global_scope &ast.Scope) ast.File {
-	s := scanner.new_scanner(text, .skip_comments)
+	s := scanner.new_scanner(text, .skip_comments, pref.is_fmt)
 	mut p := Parser{
 		scanner: s
 		table: b_table
@@ -100,7 +100,7 @@ pub fn parse_file(path string, b_table &table.Table, comments_mode scanner.Comme
 	// panic(err)
 	// }
 	mut p := Parser{
-		scanner: scanner.new_scanner_file(path, comments_mode)
+		scanner: scanner.new_scanner_file(path, comments_mode, pref.is_fmt)
 		comments_mode: comments_mode
 		table: b_table
 		file_name: path

--- a/vlib/v/scanner/scanner_test.v
+++ b/vlib/v/scanner/scanner_test.v
@@ -45,7 +45,7 @@ fn fn_name_mod_level_high_order(cb fn(int)) {
 }
 
 fn scan_kinds(text string) []token.Kind {
-	mut scanner := new_scanner(text, .skip_comments)
+	mut scanner := new_scanner(text, .skip_comments, false)
 	mut token_kinds := []token.Kind{}
 	for {
 		tok := scanner.scan()

--- a/vlib/v/util/scanning.v
+++ b/vlib/v/util/scanning.v
@@ -1,7 +1,5 @@
 module util
 
-import os
-
 [inline]
 pub fn is_name_char(c byte) bool {
 	return (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || c == `_`
@@ -42,8 +40,4 @@ pub fn good_type_name(s string) bool {
 
 pub fn cescaped_path(s string) string {
 	return s.replace('\\', '\\\\')
-}
-
-pub fn is_fmt() bool {
-	return os.executable().contains('vfmt')
 }


### PR DESCRIPTION
This PR fixes several `fmt` issues:
- function calls and similar like `'$a()'` and `'${a}('` are formatted correctly
- build in macros like`println(@VEXE)` or `'${@VEXE}'` not expanded
- no spaces around operators in interpolated expressions: `${a+b>4}'

In order to for these fixes to work, the scanner must know that it `is_fmt`. For this reason (in order to make the test cases work) I have removed the "global variable" `util.is_fmt()`. Instead I have set the flag in `Parser.perf` for `vfmt.v` and the testcases and passed the flag down from `parser` to `scanner`.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
