### PR TITLE
float: make default string representations for floats become alike

### DIFF
--- a/vlib/builtin/float.v
+++ b/vlib/builtin/float.v
@@ -42,7 +42,7 @@ pub fn (x f64) strlong() string {
 }
 
 // ----- f32 to string functions -----
-// str return a f32 as string in suitable  notation
+// str return a f32 as string in suitable notation
 [inline]
 pub fn (x f32) str() string {
 	abs_x := f32_abs(x)

--- a/vlib/builtin/float.v
+++ b/vlib/builtin/float.v
@@ -9,19 +9,18 @@ import strconv.ftoa
 // ----- f64 to string functions -----
 // str return a f64 as string in scientific notation, auto display digits limit
 [inline]
-pub fn (d f64) str() string {
-	return ftoa.ftoa_64(d)
-}
-
-[inline]
-pub fn (d any_float) str() string {
-	x := f64(d)
+pub fn (x f64) str() string {
 	abs_x := f64_abs(x)
-	if abs_x >= 0.01 && abs_x < 1.0e16 {
+	if abs_x >= 0.0001 && abs_x < 1.0e6 {
 		return ftoa.f64_to_str_l(x)
 	} else {
 		return ftoa.ftoa_64(x)
 	}
+}
+
+[inline]
+pub fn (d any_float) str() string {
+	return f64(d).str()
 }
 
 // return a string of the input f64 in scientific notation with digit_num deciamals displayed, max 17 digits
@@ -45,8 +44,13 @@ pub fn (x f64) strlong() string {
 // ----- f32 to string functions -----
 // str return a f32 as string in scientific notation, auto display digits limit
 [inline]
-pub fn (d f32) str() string {
-	return ftoa.ftoa_32(d)
+pub fn (x f32) str() string {
+	abs_x := f32_abs(x)
+	if abs_x >= 0.0001 && abs_x < 1.0e6 {
+		return ftoa.f32_to_str_l(x)
+	} else {
+		return ftoa.ftoa_32(x)
+	}
 }
 
 // return a string of the input f32 in scientific notation with digit_num deciamals displayed, max 8 digits
@@ -69,7 +73,7 @@ pub fn (x f32) strlong() string {
 
 // ----- C functions -----
 [inline]
-fn f32_abs(a f32) f32 {
+pub fn f32_abs(a f32) f32 {
 	return if a < 0 {
 		-a
 	} else {
@@ -88,7 +92,7 @@ fn f64_abs(a f64) f64 {
 
 
 [inline]
-fn f32_max(a, b f32) f32 {
+pub fn f32_max(a, b f32) f32 {
 	return if a > b {
 		a
 	} else {
@@ -97,7 +101,7 @@ fn f32_max(a, b f32) f32 {
 }
 
 [inline]
-fn f32_min(a, b f32) f32 {
+pub fn f32_min(a, b f32) f32 {
 	return if a < b {
 		a
 	} else {
@@ -106,7 +110,7 @@ fn f32_min(a, b f32) f32 {
 }
 
 [inline]
-fn f64_max(a, b f64) f64 {
+pub fn f64_max(a, b f64) f64 {
 	return if a > b {
 		a
 	} else {

--- a/vlib/builtin/float.v
+++ b/vlib/builtin/float.v
@@ -7,7 +7,7 @@ import strconv.ftoa
 
 #include <float.h>
 // ----- f64 to string functions -----
-// str return a f64 as string in scientific notation, auto display digits limit
+// str return a f64 as string in suitable notation
 [inline]
 pub fn (x f64) str() string {
 	abs_x := f64_abs(x)
@@ -42,7 +42,7 @@ pub fn (x f64) strlong() string {
 }
 
 // ----- f32 to string functions -----
-// str return a f32 as string in scientific notation, auto display digits limit
+// str return a f32 as string in suitable  notation
 [inline]
 pub fn (x f32) str() string {
 	abs_x := f32_abs(x)

--- a/vlib/v/tests/num_lit_call_method_test.v
+++ b/vlib/v/tests/num_lit_call_method_test.v
@@ -21,8 +21,17 @@ fn test_float_lit_call_method() {
 	x4 := .003e2.str()
 	assert x4 == '0.3'
 	x5 := 2.e-3.str()
-	assert x5 == '2.e-03'
+	assert x5 == '0.002'
 	x6 := 5.0.str()
 	assert x6 == '5.'
 	// x7 := 5..str()    Syntax `5.` is allowed, but do not call method on it (`5..str()` is parsed as a range). Use `5.0.str()` instead.
+	x8 := 7.345e-7.str()
+	assert x8 == '7.345e-07'
+	x9 := 5.725e6.str()
+	assert x9 == '5.725e+06'
+
+	a := f32(12.3).str()
+	assert a[0..4] == '12.3' // there is still trailing garbage
+	assert f32(7.345e-7).str() == '7.345e-07'
+	assert f32(5.725e6).str() == '5.725e+06'
 }


### PR DESCRIPTION
String interpolation `'$x'`, methods calls `x.str()` for `f64` and `f32` and method calls `13.5.str()` for literals have had somewhat different criteria if and when to use scientific notation and when "float" notation.

This PR makes the behavior somewhat more consistent by using the convention that is used by `C.printf()`'s `%g` everywhere.

While there, make `f{32,64}_{min,max,abs}` public as these functions might be useful in general. 
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
