### PR TITLE
vdoc: Fix sorting + other minor improvements

### DIFF
--- a/cmd/tools/vdoc-resources/doc.css
+++ b/cmd/tools/vdoc-resources/doc.css
@@ -275,10 +275,10 @@ body {
 	word-break: break-word;
 }
 .doc-content > .doc-node.const:not(:first-child) {
-	padding-top: 0;
+	padding-top: 4rem;
 }
 .doc-content > .doc-node.const:not(:last-child) {
-	padding-bottom: 1rem;
+	padding-bottom: 2rem;
 }
 .doc-content > .timestamp {
 	font-size: 0.8rem;
@@ -556,7 +556,12 @@ pre {
 	.doc-nav .content.hidden {
 		display: flex;
 	}
-
+	.doc-content > .doc-node.const:not(:first-child) {
+		padding-top: 0;
+	}
+	.doc-content > .doc-node.const:not(:last-child) {
+		padding-bottom: 1rem;
+	}
 	.doc-container {
 		margin-top: 0;
 		margin-left: 300px;
@@ -565,7 +570,6 @@ pre {
 		padding-top: 1rem !important;
 		margin-top: 0 !important;
 	}
-
 	.doc-toc {
 		top: 0;
 	}

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -613,6 +613,11 @@ fn (mut cfg DocConfig) generate_docs_from_file() {
 		if !os.is_dir(cfg.output_path) {
 			cfg.output_path = os.real_path('.')
 		}
+		if !os.exists(cfg.output_path) {
+			os.mkdir(cfg.output_path) or {
+				panic(err)
+			}
+		}
 		if cfg.is_multi {
 			cfg.output_path = os.join_path(cfg.output_path, '_docs')
 			if !os.exists(cfg.output_path) {

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -482,13 +482,14 @@ fn (cfg DocConfig) gen_markdown(idx int, with_toc bool) string {
 
 fn (cfg DocConfig) render() map[string]string {
 	mut docs := map[string]string
-
 	for i, doc in cfg.docs {
 		// since builtin is generated first, ignore it
-		mut name := if doc.head.name == 'README' {
+		mut name := if doc.head.name == 'README' || cfg.docs.len == 1 {
 			'index'
 		} else if !cfg.is_multi && !os.is_dir(cfg.output_path) {
 			os.file_name(cfg.output_path)
+		} else if i-1 >= 0 && cfg.readme_idx() != -1 && cfg.docs.len == 2 {
+			'docs'
 		} else {
 			doc.head.name
 		}

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -806,7 +806,7 @@ fn main() {
 					cfg.output_type = .html
 				}
 			}
-			'-r' {
+			'-readme' {
 				cfg.include_readme = true
 			}
 			'-v' {

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -127,9 +127,6 @@ fn get_src_link(repo_url string, file_name string, line_nr int) string {
 		'git.sir.ht' { '/tree/master/$file_name' }
 		else { '' }
 	}
-	if repo_url.starts_with('https://github.com/vlang/v') && !url.path.contains('master/vlib')  {
-		url.path = url.path.replace('/blob/master/$file_name', '/blob/master/vlib/$file_name')
-	}
 	if url.path == '/' { return '' }
 	url.fragment = 'L$line_nr'
 	return url.str()
@@ -295,7 +292,7 @@ fn write_toc(cn doc.DocNode, nodes []doc.DocNode, toc &strings.Builder) {
 
 fn (cfg DocConfig) write_content(cn &doc.DocNode, dcs &doc.Doc, hw &strings.Builder) {
 	base_dir := os.base_dir(os.real_path(cfg.input_path))
-	file_path_name := cn.file_path.replace('$base_dir/', '')
+	file_path_name := if cfg.is_multi { cn.file_path.replace('$base_dir/', '') } else { os.file_name(cn.file_path) }
 	src_link := get_src_link(cfg.manifest.repo_url, file_path_name, cn.pos.line)
 	children := dcs.contents.find_children_of(cn.name)
 	hw.write(doc_node_html(cn, src_link, false, dcs.table))

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -710,7 +710,7 @@ fn get_modules_list(path string) []string {
 	files := os.walk_ext(path, 'v')
 	mut dirs := []string{}
 	for file in files {
-		if 'test' in file || 'js' in file || 'x64' in file || 'bare' in file || 'uiold' in file || 'vweb' in file { continue }
+		if 'vlib' in path && ('examples' in file || 'test' in file || 'js' in file || 'x64' in file || 'bare' in file || 'uiold' in file || 'vweb' in file) { continue }
 		dirname := os.base_dir(file)
 		if dirname in dirs { continue }
 		dirs << dirname

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -784,6 +784,11 @@ fn main() {
 		eprintln('vdoc: No input path found.')
 		exit(1)
 	}
+	$if windows {
+		cfg.input_path = cfg.input_path.replace('/', os.path_separator)
+	} $else {
+		cfg.input_path = cfg.input_path.replace('\\', os.path_separator)
+	}
 	is_path := cfg.input_path.ends_with('.v') || cfg.input_path.split(os.path_separator).len > 1 || cfg.input_path == '.'
 	if cfg.input_path == 'vlib' {
 		cfg.is_multi = true

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -605,7 +605,12 @@ fn (mut cfg DocConfig) generate_docs_from_file() {
 		mut dcs := doc.generate(dirpath, cfg.pub_only, true) or {
 			mut err_msg := err
 			if errcode == 1 {
-				err_msg += ' Use the `-m` flag if you are generating docs of a directory with multiple modules inside.'
+				mod_list := get_modules_list(cfg.input_path)
+				println('Available modules:\n==================')
+				for mod in mod_list {
+					println(mod.all_after('vlib/').all_after('modules/').replace('/', '.'))
+				}
+				err_msg += ' Use the `-m` flag if you are generating docs of a directory containing multiple modules.'
 			}
 			eprintln(err_msg)
 			exit(1)

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -766,7 +766,9 @@ fn main() {
 			'-s' {
 				cfg.inline_assets = true
 				cfg.serve_http = true
-				cfg.output_type = .html
+				if cfg.output_type == .unset {
+					cfg.output_type = .html
+				}
 			}
 			'-r' {
 				cfg.include_readme = true

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -135,12 +135,12 @@ fn get_src_link(repo_url string, file_name string, line_nr int) string {
 fn js_compress(str string) string {
 	mut js := strings.new_builder(200)
 	lines := str.split_into_lines()
-	rules := [') {', ' = ', ', ', '{ ', ' }', ' (', '; ', ' + ', ' < ']
-	clean := ['){', '=', ',', '{', '}', '(', ';', '+', '<']
+	rules := [') {', ' = ', ', ', '{ ', ' }', ' (', '; ', ' + ', ' < ', ' - ', ' || ', ' var', ': ', ' >= ', ' && ', ' else if', ' === ', ' !== ', ' else ']
+	clean := ['){', '=', ',', '{', '}', '(', ';', '+', '<', '-', '||', 'var', ':', '>=', '&&', 'else if', '===', '!==', 'else']
 	for line in lines {
 		mut trimmed := line.trim_space()
 		if trimmed.starts_with('//') || (trimmed.starts_with('/*') && trimmed.ends_with('*/')) { continue }
-		for i, _ in rules {
+		for i in 0..rules.len-1 {
 			trimmed = trimmed.replace(rules[i], clean[i])
 		}
 		js.write(trimmed)

--- a/cmd/v/help/doc.txt
+++ b/cmd/v/help/doc.txt
@@ -20,6 +20,6 @@ Options:
   -open           Launches the browser when the server docs has started.
   -p              Specifies the port to be used for the docs server.
   -s              Serve HTML-generated docs via HTTP.
-  -r              Include README.md to docs if present.
+  -readme         Include README.md to docs if present.
   -v              Enables verbose logging. For debugging purposes.
   -h, -help       Prints this help text.

--- a/vlib/net/ftp/ftp.v
+++ b/vlib/net/ftp/ftp.v
@@ -123,7 +123,7 @@ pub fn (ftp FTP) login(user, passwd string) bool {
 		}
 		return false
 	}
-	mut code, mut data := ftp.read()
+	mut code, _ := ftp.read()
 	if code == logged_in {
 		return true
 	}

--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -19,11 +19,11 @@ import picohttpparser
 #include "src/picoev.h"
 
 const (
-	MAX_FDS = 1024
-	TIMEOUT_SECS = 8
-	MAX_TIMEOUT = 10
-	MAX_READ = 4096
-	MAX_WRITE = 8192
+	max_fds = 1024
+	timeout_secs = 8
+	max_timeout = 10
+	max_read = 4096
+	max_write = 8192
 )
 
 struct C.in_addr {
@@ -122,10 +122,10 @@ fn rw_callback(loop &C.picoev_loop, fd, events int, cb_arg voidptr) {
 		return
 	}
 	else if (events & C.PICOEV_READ) != 0 {
-		C.picoev_set_timeout(loop, fd, TIMEOUT_SECS)
-		buf := (p.buf + fd * MAX_READ)
+		C.picoev_set_timeout(loop, fd, timeout_secs)
+		buf := (p.buf + fd * max_read)
 		idx := p.idx[fd]
-		mut r := myread(fd, buf, MAX_READ, idx)
+		mut r := myread(fd, buf, max_read, idx)
 		if r == 0 {
 			close_conn(loop, fd)
 			p.idx[fd] = 0
@@ -141,7 +141,7 @@ fn rw_callback(loop &C.picoev_loop, fd, events int, cb_arg voidptr) {
 		} else {
 			r += idx
 			mut s := tos(buf, r)
-			out := (p.out + fd * MAX_WRITE)
+			out := (p.out + fd * max_write)
 			mut res := picohttpparser.Response{
 				fd: fd
 				date: p.date
@@ -191,7 +191,7 @@ fn accept_callback(loop &C.picoev_loop, fd, events int, cb_arg voidptr) {
 	newfd := C.accept(fd, 0, 0)
 	if newfd != -1 {
 		setup_sock(newfd)
-		C.picoev_add(loop, newfd, C.PICOEV_READ, TIMEOUT_SECS, rw_callback, cb_arg)
+		C.picoev_add(loop, newfd, C.PICOEV_READ, timeout_secs, rw_callback, cb_arg)
 	}
 }
 
@@ -223,14 +223,14 @@ pub fn new(port int, cb voidptr) &Picoev {
 
 	setup_sock(fd)
 
-	C.picoev_init(MAX_FDS)
-	loop := C.picoev_create_loop(MAX_TIMEOUT)
+	C.picoev_init(max_fds)
+	loop := C.picoev_create_loop(max_timeout)
 	pv := &Picoev{
 		loop: loop
 		cb: cb
 		date: C.get_date()
-		buf: malloc(MAX_FDS * MAX_READ + 1)
-		out: malloc(MAX_FDS * MAX_WRITE + 1)
+		buf: malloc(max_fds * max_read + 1)
+		out: malloc(max_fds * max_write + 1)
 	}
 	C.picoev_add(loop, fd, C.PICOEV_READ, 0, accept_callback, pv)
 

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -239,7 +239,7 @@ fn get_parent_mod(dir string) ?string {
 	return file_ast.mod.name
 }
 
-pub fn (mut d Doc) generate() ?bool {
+fn (mut d Doc) generate() ?Doc {
 	// get all files
 	base_path := if os.is_dir(d.input_path) { d.input_path } else { os.real_path(os.base_dir(d.input_path)) }
 	project_files := os.ls(base_path) or {
@@ -381,15 +381,12 @@ pub fn (mut d Doc) generate() ?bool {
 		d.fmt.mod2alias = map[string]string{}
 	}
 	d.time_generated = time.now()
-	return true
+	return d
 }
 
 pub fn generate(input_path string, pub_only, with_comments bool) ?Doc {
 	mut doc := new(input_path)
 	doc.pub_only = pub_only
 	doc.with_comments = with_comments
-	doc.generate() or {
-		return error_with_code(err, errcode)
-	}
-	return doc
+	return doc.generate()
 }

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -116,45 +116,45 @@ fn convert_pos(file_path string, pos token.Position) DocPos {
 pub fn (mut d Doc) get_signature(stmt ast.Stmt, file &ast.File) string {
 	match stmt {
 		ast.Module {
-			return 'module $it.name'
+			return 'module $stmt.name'
 		}
 		ast.FnDecl {
-			return it.str(d.table).replace(f.cur_mod + '.', '')
+			return stmt.str(d.table).replace(d.fmt.cur_mod + '.', '')
 		}
 		else {
-			f.stmt(stmt)
-			return f.out.str().trim_space()
+			d.fmt.out = strings.new_builder(1000)
+			d.fmt.stmt(stmt)
+			return d.fmt.out.str().trim_space()
 		}
 	}
 }
 
 pub fn (d Doc) get_pos(stmt ast.Stmt) token.Position {
 	match stmt {
-		ast.FnDecl { return it.pos }
-		ast.StructDecl { return it.pos }
-		ast.EnumDecl { return it.pos }
-		ast.InterfaceDecl { return it.pos }
-		ast.ConstDecl { return it.pos }
+		ast.FnDecl { return stmt.pos }
+		ast.StructDecl { return stmt.pos }
+		ast.EnumDecl { return stmt.pos }
+		ast.InterfaceDecl { return stmt.pos }
+		ast.ConstDecl { return stmt.pos }
 		else { return token.Position{} }
 	}
 }
 
 pub fn (d Doc) get_type_name(decl ast.TypeDecl) string {
 	match decl {
-		ast.SumTypeDecl { return it.name }
-		ast.FnTypeDecl { return it.name }
-		ast.AliasTypeDecl { return it.name }
+		ast.SumTypeDecl { return decl.name }
+		ast.FnTypeDecl { return decl.name }
+		ast.AliasTypeDecl { return decl.name }
 	}
 }
 
 pub fn (d Doc) get_name(stmt ast.Stmt) string {
-	cur_mod := d.head.name.split('.').last()
 	match stmt {
-		ast.FnDecl { return it.name }
-		ast.StructDecl { return it.name }
-		ast.EnumDecl { return it.name }
-		ast.InterfaceDecl { return it.name }
-		ast.TypeDecl { return d.get_type_name(it).replace('&' + cur_mod + '.', '').replace(cur_mod + '.', '') }
+		ast.FnDecl { return stmt.name }
+		ast.StructDecl { return stmt.name }
+		ast.EnumDecl { return stmt.name }
+		ast.InterfaceDecl { return stmt.name }
+		ast.TypeDecl { return d.get_type_name(stmt) }
 		ast.ConstDecl { return 'Constants' }
 		else { return '' }
 	}

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -177,11 +177,34 @@ pub fn new(input_path string) Doc {
 	return d
 }
 
-pub fn (nodes []DocNode) index_by_name(node_name string) ?int {
+pub fn (mut nodes []DocNode) sort_by_name() {
+	nodes.sort_with_compare(compare_nodes_by_name)
+}
+
+pub fn (mut nodes []DocNode) sort_by_category() {
+	nodes.sort_with_compare(compare_nodes_by_category)
+}
+
+fn compare_nodes_by_name(a, b &DocNode) int {
+	al := a.name.to_lower()
+	bl := b.name.to_lower()
+	return compare_strings(al, bl)
+}
+
+fn compare_nodes_by_category(a, b &DocNode) int {
+	al := a.attrs['category']
+	bl := b.attrs['category']
+	return compare_strings(al, bl)
+}
+
+pub fn (nodes []DocNode) index_by_name(node_name string) int {
 	for i, node in nodes {
 		if node.name != node_name { continue }
 		return i
 	}
+	return -1
+}
+
 pub fn (nodes []DocNode) find_children_of(parent string) []DocNode {
 	return nodes.find_nodes_with_attr('parent', parent)
 }
@@ -197,6 +220,7 @@ pub fn (nodes []DocNode) find_nodes_with_attr(attr_name string, value string) []
 		}
 		subgroup << node
 	}
+	subgroup.sort_by_name()
 	return subgroup
 }
 
@@ -399,6 +423,8 @@ fn (mut d Doc) generate() ?Doc {
 		d.fmt.mod2alias = map[string]string{}
 	}
 	d.time_generated = time.now()
+	d.contents.sort_by_name()
+	d.contents.sort_by_category()
 	return d
 }
 

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -514,7 +514,7 @@ pub fn (mut f Fmt) struct_field_expr(fexpr ast.Expr) {
 	}
 }
 
-fn (f &Fmt) type_to_str(t table.Type) string {
+pub fn (f &Fmt) type_to_str(t table.Type) string {
 	mut res := f.table.type_to_str(t)
 	for res.ends_with('_ptr') {
 		// type_ptr => &type

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -282,6 +282,7 @@ fn os_from_string(os string) pref.OS {
 
 // Helper function to convert string names to CC enum
 pub fn cc_from_string(cc_str string) pref.CompilerType {
+	if cc_str.len == 0 { return .gcc }
 	cc := cc_str.replace('\\', '/').split('/').last().all_before('.')
 	if 'tcc'   in cc { return .tinyc }
 	if 'tinyc' in cc { return .tinyc }


### PR DESCRIPTION
## `Doc` module
- Fix sorting of methods alphabetically and by type category ala GoDoc.
- Use a single instance of `fmt` struct. Expose `type_to_string` to public.
- Replace `parent_type` with flexible `attrs` (attributes) field.
- Categorize each statement for sorting.
- Use new match sum type syntax
- `Doc.generate` now returns itself.

## `vdoc`
- Set content-type header for server mode if output type is specified.
- Fix get_src_link for multi-module mode. Remove vlib-only hack.
- Replace input path separators with system path separators.
- Add specific behaviors when using `-r` (including readme) in single module mode.
- Create output directory if it does not exist.
- Updated JS compressor rules.
- Fix CSS styling on `consts` .
- Add HTML template and use string substitution instead.

## Others
- Fix `cc_from_string` panic when input is empty.
- Fix parser warnings on `ftp` and `picoev` modules.