### PR TITLE
checker: check `array_insert` `array_prepend` type mismatch

### DIFF
--- a/vlib/v/checker/tests/array_insert_type_mismatch_a.out
+++ b/vlib/v/checker/tests/array_insert_type_mismatch_a.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/array_insert_type_mismatch_a.v:3:14: error: type mismatch, should use `int`
+    1 | fn main() {
+    2 |     mut a := [1, 2]
+    3 |     a.insert(1, 2.3)
+      |                 ~~~
+    4 |     println(a)
+    5 | }

--- a/vlib/v/checker/tests/array_insert_type_mismatch_a.vv
+++ b/vlib/v/checker/tests/array_insert_type_mismatch_a.vv
@@ -1,0 +1,5 @@
+fn main() {
+	mut a := [1, 2]
+	a.insert(1, 2.3)
+	println(a)
+}

--- a/vlib/v/checker/tests/array_insert_type_mismatch_b.out
+++ b/vlib/v/checker/tests/array_insert_type_mismatch_b.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/array_insert_type_mismatch_b.v:3:14: error: type mismatch, should use `int`
+    1 | fn main() {
+    2 |     mut a := [1, 2]
+    3 |     a.insert(1, 'abc')
+      |                 ~~~~~
+    4 |     println(a)
+    5 | }

--- a/vlib/v/checker/tests/array_insert_type_mismatch_b.vv
+++ b/vlib/v/checker/tests/array_insert_type_mismatch_b.vv
@@ -1,0 +1,5 @@
+fn main() {
+	mut a := [1, 2]
+	a.insert(1, 'abc')
+	println(a)
+}

--- a/vlib/v/checker/tests/array_insert_type_mismatch_c.out
+++ b/vlib/v/checker/tests/array_insert_type_mismatch_c.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/array_insert_type_mismatch_c.v:3:14: error: type mismatch, should use `f64[]`
+    1 | fn main() {
+    2 |     mut a := [1.1, 2.2]
+    3 |     a.insert(1, [2, 3])
+      |                 ~~~~~~
+    4 |     println(a)
+    5 | }

--- a/vlib/v/checker/tests/array_insert_type_mismatch_c.vv
+++ b/vlib/v/checker/tests/array_insert_type_mismatch_c.vv
@@ -1,0 +1,5 @@
+fn main() {
+	mut a := [1.1, 2.2]
+	a.insert(1, [2, 3])
+	println(a)
+}

--- a/vlib/v/checker/tests/array_insert_type_mismatch_d.out
+++ b/vlib/v/checker/tests/array_insert_type_mismatch_d.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/array_insert_type_mismatch_d.v:3:14: error: type mismatch, should use `int[]`
+    1 | fn main() {
+    2 |     mut a := [1, 2]
+    3 |     a.insert(1, ['aa', 'bb', 'cc'])
+      |                 ~~~~~~~~~~~~~~~~~~
+    4 |     println(a)
+    5 | }

--- a/vlib/v/checker/tests/array_insert_type_mismatch_d.vv
+++ b/vlib/v/checker/tests/array_insert_type_mismatch_d.vv
@@ -1,0 +1,5 @@
+fn main() {
+	mut a := [1, 2]
+	a.insert(1, ['aa', 'bb', 'cc'])
+	println(a)
+}

--- a/vlib/v/checker/tests/array_prepend_type_mismatch_a.out
+++ b/vlib/v/checker/tests/array_prepend_type_mismatch_a.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/array_prepend_type_mismatch_a.v:3:12: error: type mismatch, should use `int`
+    1 | fn main() {
+    2 |     mut a := [1, 2]
+    3 |     a.prepend(2.3)
+      |               ~~~
+    4 |     println(a)
+    5 | }

--- a/vlib/v/checker/tests/array_prepend_type_mismatch_a.vv
+++ b/vlib/v/checker/tests/array_prepend_type_mismatch_a.vv
@@ -1,0 +1,5 @@
+fn main() {
+	mut a := [1, 2]
+	a.prepend(2.3)
+	println(a)
+}

--- a/vlib/v/checker/tests/array_prepend_type_mismatch_b.out
+++ b/vlib/v/checker/tests/array_prepend_type_mismatch_b.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/array_prepend_type_mismatch_b.v:3:12: error: type mismatch, should use `int`
+    1 | fn main() {
+    2 |     mut a := [1, 2]
+    3 |     a.prepend('abc')
+      |               ~~~~~
+    4 |     println(a)
+    5 | }

--- a/vlib/v/checker/tests/array_prepend_type_mismatch_b.vv
+++ b/vlib/v/checker/tests/array_prepend_type_mismatch_b.vv
@@ -1,0 +1,5 @@
+fn main() {
+	mut a := [1, 2]
+	a.prepend('abc')
+	println(a)
+}

--- a/vlib/v/checker/tests/array_prepend_type_mismatch_c.out
+++ b/vlib/v/checker/tests/array_prepend_type_mismatch_c.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/array_prepend_type_mismatch_c.v:3:12: error: type mismatch, should use `f64[]`
+    1 | fn main() {
+    2 |     mut a := [1.1, 2.2]
+    3 |     a.prepend([2, 3])
+      |               ~~~~~~
+    4 |     println(a)
+    5 | }

--- a/vlib/v/checker/tests/array_prepend_type_mismatch_c.vv
+++ b/vlib/v/checker/tests/array_prepend_type_mismatch_c.vv
@@ -1,0 +1,5 @@
+fn main() {
+	mut a := [1.1, 2.2]
+	a.prepend([2, 3])
+	println(a)
+}

--- a/vlib/v/checker/tests/array_prepend_type_mismatch_d.out
+++ b/vlib/v/checker/tests/array_prepend_type_mismatch_d.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/array_prepend_type_mismatch_d.v:3:12: error: type mismatch, should use `int[]`
+    1 | fn main() {
+    2 |     mut a := [1, 2]
+    3 |     a.prepend(['aa', 'bb', 'cc'])
+      |               ~~~~~~~~~~~~~~~~~~
+    4 |     println(a)
+    5 | }

--- a/vlib/v/checker/tests/array_prepend_type_mismatch_d.vv
+++ b/vlib/v/checker/tests/array_prepend_type_mismatch_d.vv
@@ -1,0 +1,5 @@
+fn main() {
+	mut a := [1, 2]
+	a.prepend(['aa', 'bb', 'cc'])
+	println(a)
+}


### PR DESCRIPTION
This PR check `array_insert` `array_prepend` type mismatch.

- Check `array_insert` `array_prepend` type mismatch.
- Add tests `array_insert_type_mismatch.vv/out` `array_prepend_type_mismatch.vv/out`.

```v
fn main() {
	mut a := [1, 2]
	a.insert(1, 2.3)
	println(a)
}

D:\test\v\tt1>v run .
.\tt1.v:3:14: error: type mismatch, should use `int` 
    1 | fn main() {
    2 |     mut a := [1, 2]
    3 |     a.insert(1, 2.3)
      |                 ~~~
    4 |     println(a)
    5 | }
```

```v
fn main() {
	mut a := [1, 2]
	a.prepend(['aa', 'bb'])
	println(a)
}

D:\test\v\tt1>v run .
.\tt1.v:3:12: error: type mismatch, should use `int[]`
    1 | fn main() {
    2 |     mut a := [1, 2]
    3 |     a.prepend(['aa', 'bb'])
      |               ~~~~~~~~~~~~
    4 |     println(a)
    5 | }
```