### PR TITLE
array: fix multiple array clone (fix #4873)

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -282,7 +282,16 @@ pub fn (a &array) clone() array {
 		len: a.len
 		cap: a.cap
 	}
-	C.memcpy(byteptr(arr.data), a.data, a.cap * a.element_size)
+	if a.element_size == sizeof(array) {
+		for i in 0..a.len {
+			ar := array{}
+			C.memcpy(&ar, byteptr(a.data) + i * a.element_size, sizeof(array))
+			ar_clone := ar.clone()
+			C.memcpy(byteptr(arr.data) + i * a.element_size, &ar_clone, a.element_size)
+		}
+	} else {
+		C.memcpy(byteptr(arr.data), a.data, a.cap * a.element_size)
+	}
 	return arr
 }
 

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -282,6 +282,7 @@ pub fn (a &array) clone() array {
 		len: a.len
 		cap: a.cap
 	}
+	// Recursively clone-generated elements if array element is array type
 	if a.element_size == sizeof(array) {
 		for i in 0..a.len {
 			ar := array{}

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -361,6 +361,16 @@ fn test_clone() {
 	assert nums.slice(1, 3).str() == '[2, 3]'
 }
 
+fn test_mutli_array_clone() {
+	mut array1 := [[1, 2, 3], [4, 5, 6]]
+	mut array2 := array1.clone()
+
+	array1[0][1] = 0
+
+	assert array1 == [[1, 0, 3], [4, 5, 6]]
+	assert array2 == [[1, 2, 3], [4, 5, 6]]
+}
+
 fn test_doubling() {
 	mut nums := [1, 2, 3, 4, 5]
 	for i in 0..nums.len {


### PR DESCRIPTION
This PR fix multiple array clone (fix #4873).

- Fix multiple array clone.
- Add test `test_multi_array_clone()` in array_test.v.

```v
fn test_mutli_array_clone() {
	mut array1 := [[1, 2, 3], [4, 5, 6]]
	mut array2 := array1.clone()

	array1[0][1] = 0

	assert array1 == [[1, 0, 3], [4, 5, 6]]
	assert array2 == [[1, 2, 3], [4, 5, 6]]
}
```