### PR TITLE
make.bat: small tcc self-compilation cleanup

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -122,12 +122,6 @@ if exist "%tcc_path%" (
 call "%tcc_exe%" -std=c99 -municode -lws2_32 -lshell32 -ladvapi32 -bt10 -w -o v.exe vc\v_win.c
 if %ERRORLEVEL% NEQ 0 goto :compile_error
 
-REM TODO: delete this when the tcc bootstrapping logic is merged to master
-v.exe -o vtcc.c cmd\v
-call "%tcc_exe%" -std=c99 -municode -lws2_32 -lshell32 -ladvapi32 -bt10 -w -o v.exe vtcc.c
-if %ERRORLEVEL% NEQ 0 goto :compile_error
-del vtcc.c
-
 v.exe -cc "%tcc_exe%" self > NUL
 if %ERRORLEVEL% NEQ 0 goto :compile_error
 goto :success


### PR DESCRIPTION
Small cleanup in `make.bat`, that was added so that v could compile itself using tcc, because the logic to find a C compiler was not in `v.c` previously.

Basically, this reverts e0e330c from #5387.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
