### PR TITLE
checker: make map literals have a real type - fixes #5414

### DIFF
--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -207,3 +207,45 @@ fn test_delete_size() {
         }
     }
 }
+
+struct Mstruct1 {
+pub mut:
+	mymap map[string]int
+}
+
+struct Mstruct2 {
+pub mut:
+	mymap map[string]f64
+}
+
+struct Mstruct3 {
+pub mut:
+	mymap map[string]u16
+}
+
+fn test_map_assign() {
+	mut a := map[string]f64{}
+	mut b := map[string]int{}
+	mut c := map[string]u16{}
+	a = {
+		'x': 12.4
+		'y': 3
+	}
+	b = {
+		'u': -13
+		'v': 12
+	}
+	c = {
+		's': u16(5)
+		't': 3
+	}
+	d := Mstruct1 {
+		{ 'p': 12 }
+	}
+	e := Mstruct2 {
+		{ 'q': 1.7 }
+	}
+	f := Mstruct3 {
+		{ 'r': u16(6), 's': 5 }
+	}
+}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2515,8 +2515,8 @@ pub fn (mut c Checker) map_init(mut node ast.MapInit) table.Type {
 		return node.typ
 	}
 	// `{'age': 20}`
-	key0_type := c.expr(node.keys[0])
-	val0_type := c.expr(node.vals[0])
+	key0_type := c.table.mktyp(c.expr(node.keys[0]))
+	val0_type := c.table.mktyp(c.expr(node.vals[0]))
 	for i, key in node.keys {
 		key_i := key as ast.StringLiteral
 		for j in 0 .. i {

--- a/vlib/v/checker/tests/map_init_wrong_type.out
+++ b/vlib/v/checker/tests/map_init_wrong_type.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/map_init_wrong_type.v:3:10: error: cannot assign `map_string_f64` to `a` of type `map_string_f32` 
+    1 | fn main() {
+    2 |    mut a := map[string]f32{}
+    3 |    a = { 'x': 12.3 }
+      |          ~~~
+    4 | }

--- a/vlib/v/checker/tests/map_init_wrong_type.vv
+++ b/vlib/v/checker/tests/map_init_wrong_type.vv
@@ -1,0 +1,4 @@
+fn main() {
+   mut a := map[string]f32{}
+   a = { 'x': 12.3 }
+}


### PR DESCRIPTION
This PR fixes #5414 by making map literals have a real type based on the first element - like it is done with array literals:
```v
a = { 'x': 1, 'y': 2 } //      map[string]int
b = { 'u': u16(3), 'v': 4 } // map[string]u16
c = [1, 2, 3] //               []int
d = [u16(4), 5, 6] //          []u16
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
