### PR TITLE
fmt: make linebreak smarter by algorithm based on penalty

### DIFF
--- a/vlib/v/fmt/tests/consts_expected.vv
+++ b/vlib/v/fmt/tests/consts_expected.vv
@@ -6,13 +6,9 @@ const (
 	eulers              = 2.7182
 	supported_platforms = ['windows', 'mac', 'macos', 'darwin', 'linux', 'freebsd', 'openbsd',
 		'netbsd', 'dragonfly', 'android', 'js', 'solaris', 'haiku', 'linux_or_macos']
-	one_line_supported  = ['windows', 'mac', 'macos', 'darwin', 'linux', 'freebsd', 'openbsd',
-		'netbsd', 'dragonfly', 'android', 'js', 'solaris', 'haiku', 'linux_or_macos']
-	another_const       = [
-		'a', 'b',
-		'c', 'd', 'e',
-		'f'
-	]
+	one_line_supported  = ['windows', 'mac', 'macos', 'darwin', 'linux', 'freebsd', 'openbsd', 'netbsd',
+		'dragonfly', 'android', 'js', 'solaris', 'haiku', 'linux_or_macos']
+	another_const       = ['a', 'b', 'c', 'd', 'e', 'f']
 )
 
 const (

--- a/vlib/v/fmt/tests/expressions_expected.vv
+++ b/vlib/v/fmt/tests/expressions_expected.vv
@@ -1,0 +1,41 @@
+import v.checker
+import v.ast
+import v.table
+
+pub fn string_inter_lit(mut c checker.Checker, mut node ast.StringInterLiteral) table.Type {
+	for i, expr in node.exprs {
+		ftyp := c.expr(expr)
+		node.expr_types << ftyp
+		typ := c.table.unalias_num_type(ftyp)
+		mut fmt := node.fmts[i]
+		// analyze and validate format specifier
+		if fmt !in [`E`, `F`, `G`, `e`, `f`, `g`, `d`, `u`, `x`, `X`, `o`, `c`, `s`, `p`, `_`] {
+			c.error('unknown format specifier `${fmt:c}`', node.fmt_poss[i])
+		}
+		if node.precisions[i] != 0 && !typ.is_float() {
+			c.error('precision specification only valid for float types', node.fmt_poss[i])
+		}
+		if node.pluss[i] && !typ.is_number() {
+			c.error('plus prefix only allowd for numbers', node.fmt_poss[i])
+		}
+		if (typ.is_unsigned() && fmt !in [`u`, `x`, `X`, `o`, `c`]) ||
+			(typ.is_signed() && fmt !in [`d`, `x`, `X`, `o`, `c`]) ||
+			(typ.is_any_int() && fmt !in [`d`, `c`, `x`, `X`, `o`, `u`, `x`, `X`, `o`]) ||
+			(typ.is_float() && fmt !in [`E`, `F`, `G`, `e`, `f`, `g`]) ||
+			(typ.is_pointer() && fmt !in [`p`, `x`, `X`]) ||
+			(typ.is_string() && fmt != `s`) ||
+			(typ.idx() in [table.i64_type_idx, table.f64_type_idx] &&
+			fmt == `c`) {
+			c.error('illegal format specifier `${fmt:c}` for type `${c.table.get_type_name(ftyp)}`',
+				node.fmt_poss[i])
+		}
+		node.need_fmts[i] = fmt != c.get_default_fmt(ftyp, typ)
+	}
+	return table.string_type
+}
+
+fn get_some_val(a_test, b_test, c_test, d_test, e_test, f_test f64) {
+	return a_test * b_test * c_test * d_test +
+		e_test * f_test * a_test * d_test +
+		a_test * b_test * c_test
+}

--- a/vlib/v/fmt/tests/expressions_input.vv
+++ b/vlib/v/fmt/tests/expressions_input.vv
@@ -1,0 +1,47 @@
+import v.checker
+import v.ast
+import v.table
+
+pub fn string_inter_lit(mut c checker.Checker, mut node ast.StringInterLiteral) table.Type {
+	for i, expr in node.exprs {
+		ftyp := c.expr(expr)
+		node.expr_types << ftyp
+		typ := c.table.unalias_num_type(ftyp)
+		mut fmt := node.fmts[i]
+		// analyze and validate format specifier
+		if fmt !in [`E`, `F`, `G`, `e`, `f`, `g`,
+			`d`, `u`, `x`, `X`, `o`, `c`, `s`, `p`, `_`] {
+				c.error('unknown format specifier `${fmt:c}`',
+					node.fmt_poss[i])
+		}
+			if node.precisions[i] != 0 &&
+				!typ.is_float() {
+				c.error('precision specification only valid for float types',
+					node.fmt_poss[i])
+			}
+			if node.pluss[i] && !typ.is_number() {
+				c.error('plus prefix only allowd for numbers', node.fmt_poss[i])
+			}
+			if (typ.is_unsigned() && fmt !in [`u`, `x`, `X`, `o`, `c`]) || (typ.is_signed() &&
+			   		fmt !in [`d`, `x`, `X`, `o`, `c`]) || (typ.is_any_int()
+				&& fmt !in [`d`, `c`, `x`, `X`, `o`,
+		`u`, `x`, `X`, `o`]) || (typ.is_float() && fmt !in [`E`, `F`,
+				`G`, `e`, `f`, `g`]) || (typ.is_pointer() &&
+			fmt !in [`p`, `x`, `X`]) || (typ.is_string() && fmt != `s`)
+				|| (typ.idx() in [table.i64_type_idx,
+				table.f64_type_idx
+			] && fmt == `c`) {
+				c.error('illegal format specifier `${fmt:c}` for type `${c.table.get_type_name(ftyp)}`',
+					node.fmt_poss[i])
+			}
+			node.need_fmts[i] = fmt != c.get_default_fmt(ftyp, typ)
+		}
+
+	return table.string_type
+}
+
+fn get_some_val(a_test, b_test, c_test, d_test, e_test, f_test f64) {
+	return a_test*b_test*c_test*
+		d_test+e_test*f_test*a_test*d_test+a_test*
+		b_test*c_test
+}


### PR DESCRIPTION
This PR is a suggestion to make `fmt`'s line breaks somewhat smarter by taking the structure of expressions into account.

The idea is to make `max_len` depend on a _penalty_. (This word and the very basic idea are actually taken from Knuth's `TeX` engine.) When `fmt` processes an expression and calls `wrap_long_line()` it passes a penalty the describes if this would be a good position (low penalty) or a bad position (high penalty) for a break.

IMHO the result is significantly more readable than if only the line length was taken into account. 
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
