### PR TITLE
cgen: add gen_str_for_multi_return

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -272,7 +272,7 @@ pub fn (c &Checker) get_default_fmt(ftyp, typ table.Type) byte {
 	} else {
 		sym := c.table.get_type_symbol(ftyp)
 		if ftyp in [table.string_type, table.bool_type] || sym.kind in [.enum_, .array, .array_fixed,
-			.struct_, .map] || ftyp.has_flag(.optional) || sym.has_method('str') {
+			.struct_, .map, .multi_return] || ftyp.has_flag(.optional) || sym.has_method('str') {
 			return `s`
 		} else {
 			return `_`

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -4155,6 +4155,13 @@ fn (mut g Gen) gen_str_for_varg(styp, str_fn_name string, has_str_method bool) {
 }
 
 fn (mut g Gen) gen_str_for_multi_return(info table.MultiReturn, styp, str_fn_name string) {
+	for typ in info.types {
+		sym := g.table.get_type_symbol(typ)
+		if !sym.has_method('str') {
+			field_styp := g.typ(typ)
+			g.gen_str_for_type_with_styp(typ, field_styp)
+		}
+	}
 	g.type_definitions.writeln('string ${str_fn_name}($styp a); // auto')
 	g.auto_str_funcs.writeln('string ${str_fn_name}($styp a) {')
 	g.auto_str_funcs.writeln('\tstrings__Builder sb = strings__new_builder($info.types.len * 10);')
@@ -4169,9 +4176,6 @@ fn (mut g Gen) gen_str_for_multi_return(info table.MultiReturn, styp, str_fn_nam
 			arg_str_fn_name = if is_arg_ptr { field_styp.replace('*', '') + '_str' } else { field_styp + '_str' }
 		} else {
 			arg_str_fn_name = styp_to_str_fn_name(field_styp)
-		}
-		if !sym.has_method('str') {
-			g.gen_str_for_type_with_styp(typ, field_styp)
 		}
 		if sym.kind == .struct_ && !sym_has_str_method {
 			g.auto_str_funcs.writeln('\tstrings__Builder_write(&sb, ${str_fn_name}(a.arg$i,0));')

--- a/vlib/v/tests/string_interpolation_multi_return_test.v
+++ b/vlib/v/tests/string_interpolation_multi_return_test.v
@@ -1,22 +1,27 @@
-fn test_multi_return_interpolation() {
-	s1 := '${return_multi_1()}'
-	assert s1 == "(1, 'aaa')"
 
-	s2 := '${return_multi_2()}'
-	assert s2 == "('aaa', true, [1, 2, 3])"
+struct RetTest {}
 
-	s3 := '${return_multi_3()}'
-	assert s3 == "(2.2, false, ['a', 'b', 'c'])"
-}
-
-fn return_multi_1() (int, string) {
+fn (r RetTest) return_multi_1() (int, string) {
 	return 1, 'aaa'
 }
 
-fn return_multi_2() (string, bool, []int) {
+fn (r RetTest) return_multi_2() (string, bool, []int) {
 	return 'aaa', true, [1,2,3]
 }
 
-fn return_multi_3() (f32, bool, []string) {
+fn (r RetTest) return_multi_3() (f32, bool, []string) {
 	return 2.2, false, ['a', 'b', 'c']
+}
+
+fn test_multi_return_interpolation() {
+	r := RetTest{}
+
+	s1 := '${r.return_multi_1()}'
+	assert s1 == "(1, 'aaa')"
+
+	s2 := '${r.return_multi_2()}'
+	assert s2 == "('aaa', true, [1, 2, 3])"
+
+	s3 := '${r.return_multi_3()}'
+	assert s3 == "(2.2, false, ['a', 'b', 'c'])"
 }

--- a/vlib/v/tests/string_interpolation_multi_return_test.v
+++ b/vlib/v/tests/string_interpolation_multi_return_test.v
@@ -38,12 +38,11 @@ fn test_multi_return_interpolation() {
 	assert s3 == "(2.2, false, ['a', 'b', 'c'])"
 
 	s4 := '${return_multi_4()}'
-	assert s1 == "(1, 'aaa')"
+	assert s4 == "(1, 'aaa')"
 
 	s5 := '${return_multi_5()}'
-	assert s2 == "('aaa', true, [1, 2, 3])"
+	assert s5 == "('aaa', true, [1, 2, 3])"
 
 	s6 := '${return_multi_6()}'
-	assert s3 == "(2.2, false, ['a', 'b', 'c'])"
-
+	assert s6 == "(2.2, false, ['a', 'b', 'c'])"
 }

--- a/vlib/v/tests/string_interpolation_multi_return_test.v
+++ b/vlib/v/tests/string_interpolation_multi_return_test.v
@@ -1,0 +1,22 @@
+fn test_multi_return_interpolation() {
+	s1 := '${return_multi_1()}'
+	assert s1 == "(1, 'aaa')"
+
+	s2 := '${return_multi_2()}'
+	assert s2 == "('aaa', true, [1, 2, 3])"
+
+	s3 := '${return_multi_3()}'
+	assert s3 == "(2.2, false, ['a', 'b', 'c'])"
+}
+
+fn return_multi_1() (int, string) {
+	return 1, 'aaa'
+}
+
+fn return_multi_2() (string, bool, []int) {
+	return 'aaa', true, [1,2,3]
+}
+
+fn return_multi_3() (f32, bool, []string) {
+	return 2.2, false, ['a', 'b', 'c']
+}

--- a/vlib/v/tests/string_interpolation_multi_return_test.v
+++ b/vlib/v/tests/string_interpolation_multi_return_test.v
@@ -13,6 +13,18 @@ fn (r RetTest) return_multi_3() (f32, bool, []string) {
 	return 2.2, false, ['a', 'b', 'c']
 }
 
+fn return_multi_4() (int, string) {
+	return 1, 'aaa'
+}
+
+fn return_multi_5() (string, bool, []int) {
+	return 'aaa', true, [1,2,3]
+}
+
+fn return_multi_6() (f32, bool, []string) {
+	return 2.2, false, ['a', 'b', 'c']
+}
+
 fn test_multi_return_interpolation() {
 	r := RetTest{}
 
@@ -24,4 +36,14 @@ fn test_multi_return_interpolation() {
 
 	s3 := '${r.return_multi_3()}'
 	assert s3 == "(2.2, false, ['a', 'b', 'c'])"
+
+	s4 := '${return_multi_4()}'
+	assert s1 == "(1, 'aaa')"
+
+	s5 := '${return_multi_5()}'
+	assert s2 == "('aaa', true, [1, 2, 3])"
+
+	s6 := '${return_multi_6()}'
+	assert s3 == "(2.2, false, ['a', 'b', 'c'])"
+
 }


### PR DESCRIPTION
This PR add gen_str_for_multi_return.

- Add gen_str_for_multi_return.
- Add test `vlib\v\tests\string_interpolation_multi_return_test.v`.

```v
fn test_multi_return_interpolation() {
	s1 := '${return_multi_1()}'
	assert s1 == "(1, 'aaa')"

	s2 := '${return_multi_2()}'
	assert s2 == "('aaa', true, [1, 2, 3])"

	s3 := '${return_multi_3()}'
	assert s3 == "(2.2, false, ['a', 'b', 'c'])"
}

fn return_multi_1() (int, string) {
	return 1, 'aaa'
}

fn return_multi_2() (string, bool, []int) {
	return 'aaa', true, [1,2,3]
}

fn return_multi_3() (f32, bool, []string) {
	return 2.2, false, ['a', 'b', 'c']
}
```