### PR TITLE
parser: fix function return anon_fn without parentheses (fix #5429)

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -219,7 +219,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	mut end_pos := p.prev_tok.position()
 	// Return type
 	mut return_type := table.void_type
-	if p.tok.kind.is_start_of_type() {
+	if p.tok.kind.is_start_of_type() || (p.tok.kind == .key_fn && p.tok.line_nr == p.prev_tok.line_nr) {
 		end_pos = p.tok.position()
 		return_type = p.parse_type()
 	}

--- a/vlib/v/tests/fn_test.v
+++ b/vlib/v/tests/fn_test.v
@@ -144,3 +144,14 @@ fn test_fn_type_call() {
 	}
 	assert st1.f(10) == 1010
 }
+
+fn ff() fn () int {
+	return fn () int {
+		return 22
+	}
+}
+
+fn test_fn_return_fn() {
+	f := ff()
+	assert f() == 22
+}


### PR DESCRIPTION
This PR fix function return anon_fn without parentheses (fix #5429).

- Fix function return anon_fn without parentheses.
- Add test `test_fn_return_fn()` in fn_test.v.

```v
fn f() fn () int {
	return fn () int {
		return 22
	}
}

fn main() {
	ff := f()
	assert ff() == 22
	println(ff())
}

D:\test\v\tt1>v run .
22
```