### PR TITLE
checker: check optional type call (fix #5458)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -735,6 +735,11 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 	call_expr.left_type = left_type
 	left_type_sym := c.table.get_type_symbol(c.unwrap_generic(left_type))
 	method_name := call_expr.name
+
+	if left_type.has_flag(.optional) {
+		c.error('optional type cannot be called directly', call_expr.left.position())
+		return table.void_type
+	}
 	// TODO: remove this for actual methods, use only for compiler magic
 	// FIXME: Argument count != 1 will break these
 	if left_type_sym.kind == .array && method_name in ['filter', 'clone', 'repeat', 'reverse',

--- a/vlib/v/checker/tests/optional_type_call_err.out
+++ b/vlib/v/checker/tests/optional_type_call_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/optional_type_call_err.v:4:5: error: optional type cannot be called directly
+    2 |
+    3 | fn main() {
+    4 |     os.ls('.').filter(it.ends_with('.v')) or { return }
+      |        ~~~~~~~
+    5 | }

--- a/vlib/v/checker/tests/optional_type_call_err.vv
+++ b/vlib/v/checker/tests/optional_type_call_err.vv
@@ -1,0 +1,5 @@
+import os
+
+fn main() {
+	os.ls('.').filter(it.ends_with('.v')) or { return }
+}


### PR DESCRIPTION
This PR check optional type call (fix #5458).

- Check optional type call.
- Add test `optional_type_call_err.vv/out`.

```v
import os

fn main() {
	os.ls('.').filter(it.ends_with('.v')) or { return }
}

D:\test\v\tt1>v run .
.\tt1.v:4:5: error: optional type cannot be called directly
    2 |
    3 | fn main() {
    4 |     os.ls('.').filter(it.ends_with('.v')) or { return }
      |        ~~~~~~~
    5 | }
```