### PR TITLE
checker: check using deprecated function (fix #5452)

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1307,7 +1307,8 @@ pub fn (s string) limit(max int) string {
 
 [deprecated]
 pub fn (c byte) is_white() bool {
-	panic('Use `string.is_space` instead of `string.is_white')
+	eprintln('warning: `string.is_white` has been deprecated, use `string.is_space` instead')
+	return c.is_space()
 }
 
 pub fn (s string) hash() int {

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -204,7 +204,8 @@ pub fn cp(old, new string) ?bool {
 
 [deprecated]
 pub fn cp_r(osource_path, odest_path string, overwrite bool) ?bool {
-	panic('Use `os.cp_all` instead of `os.cp_r`')
+	eprintln('warning: `os.cp_r` has been deprecated, use `os.cp_all` instead')
+	return cp_all(osource_path, odest_path, overwrite)
 }
 
 pub fn cp_all(osource_path, odest_path string, overwrite bool) ?bool {
@@ -622,7 +623,8 @@ pub fn is_readable(path string) bool {
 
 [deprecated]
 pub fn file_exists(_path string) bool {
-	panic('Use `os.exists` instead of `os.file_exists`')
+	eprintln('warning: `os.file_exists` has been deprecated, use `os.exists` instead')
+	return exists(_path)
 }
 
 // rm removes file in `path`.
@@ -645,7 +647,8 @@ pub fn rmdir(path string) {
 
 [deprecated]
 pub fn rmdir_recursive(path string) {
-	panic('Use `os.rmdir_all` instead of `os.rmdir_recursive`')
+	eprintln('warning: `os.rmdir_recursive` has been deprecated, use `os.rmdir_all` instead')
+	rmdir_all(path)
 }
 
 pub fn rmdir_all(path string) {
@@ -1004,7 +1007,8 @@ pub fn exists_in_system_path(prog string) bool {
 
 [deprecated]
 pub fn dir_exists(path string) bool {
-	panic('Use `os.is_dir` instead of `os.dir_exists`')
+	eprintln('warning: `os.dir_exists` has been deprecated, use `os.is_dir` instead')
+	return is_dir(path)
 }
 
 // is_dir returns a boolean indicating whether the given path is a directory.
@@ -1198,7 +1202,8 @@ pub fn log(s string) {
 
 [deprecated]
 pub fn flush_stdout() {
-	panic('Use `os.flush` instead of `os.flush_stdout`')
+	eprintln('warning: `os.flush_stdout` has been deprecated, use `os.flush` instead')
+	flush()
 }
 
 pub fn flush() {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -999,6 +999,9 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 	if !f.is_pub && f.language == .v && f.name.len > 0 && f.mod.len > 0 && f.mod != c.mod {
 		c.error('function `$f.name` is private. curmod=$c.mod fmod=$f.mod', call_expr.pos)
 	}
+	if f.is_deprecated {
+		c.warn('function `$f.name` has been deprecated', call_expr.pos)
+	}
 	call_expr.return_type = f.return_type
 	if f.return_type == table.void_type && f.ctdefine.len > 0 && f.ctdefine !in c.pref.compile_defines {
 		call_expr.should_be_skipped = true

--- a/vlib/v/checker/tests/use_deprecated_function_warning.out
+++ b/vlib/v/checker/tests/use_deprecated_function_warning.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/use_deprecated_function_warning.v:3:5: error: function `os.cp_r` has been deprecated
+    1 | import os
+    2 | fn main() {
+    3 |     os.cp_r('./aa', './bb', true)
+      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4 | }

--- a/vlib/v/checker/tests/use_deprecated_function_warning.vv
+++ b/vlib/v/checker/tests/use_deprecated_function_warning.vv
@@ -1,0 +1,4 @@
+import os
+fn main() {
+	os.cp_r('./aa', './bb', true)
+}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -235,6 +235,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 			is_variadic: is_variadic
 			is_generic: is_generic
 			is_pub: is_pub
+			is_deprecated: is_deprecated
 			ctdefine: ctdefine
 		})
 	} else {
@@ -256,6 +257,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 			language: language
 			is_generic: is_generic
 			is_pub: is_pub
+			is_deprecated: is_deprecated
 			ctdefine: ctdefine
 			mod: p.mod
 		})

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -21,14 +21,15 @@ pub mut:
 
 pub struct Fn {
 pub:
-	args        []Arg
-	return_type Type
-	is_variadic bool
-	language    Language
-	is_generic  bool
-	is_pub      bool
-	mod         string
-	ctdefine    string // compile time define. myflag, when [if myflag] tag
+	args          []Arg
+	return_type   Type
+	is_variadic   bool
+	language      Language
+	is_generic    bool
+	is_pub        bool
+	is_deprecated bool
+	mod           string
+	ctdefine      string // compile time define. myflag, when [if myflag] tag
 pub mut:
 	name        string
 }


### PR DESCRIPTION
This PR check using deprecated function (fix #5452).

- Check using deprecated function.
- Add test `use_deprecated_function_warning.vv/out`.
- Change `panic` to `warning`.

```v
import os
fn main() {
	os.flush_stdout()
}

D:\test\v\tt1>v run .
.\tt1.v:4:5: warning: function `os.cp_r` has been deprecated 
    2 | 
    3 | fn main() {
    4 |     os.cp_r('./aa', './bb', true)
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~
    5 | }
warning: `os.cp_r` has been deprecated, use `os.cp_all` instead
```