### PR TITLE
fmt: avoid breaking lines <= 100 characters

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -12,7 +12,7 @@ const (
 		'\t\t\t\t\t\t\t\t'
 	]
 	// when to break a line dependant on penalty
-	max_len = [0, 30, 85, 100]
+	max_len = [0, 30, 85, 100, 105]
 )
 
 pub struct Fmt {
@@ -21,9 +21,13 @@ pub:
 pub mut:
 	out_imports       strings.Builder
 	out               strings.Builder
+	out_save          strings.Builder
 	indent            int
 	empty_line        bool
 	line_len          int
+	expr_recursion    int
+	expr_bufs         []string
+	penalties         []int
 	single_line_if    bool
 	cur_mod           string
 	file              ast.File
@@ -80,31 +84,55 @@ fn (mut f Fmt) find_comment(line_nr int) {
 	}
 }
 */
+
 pub fn (mut f Fmt) write(s string) {
-	if f.indent > 0 && f.empty_line {
-		if f.indent < tabs.len {
-			f.out.write(tabs[f.indent])
-		} else {
-			// too many indents, do it the slow way:
-			for _ in 0 .. f.indent {
-				f.out.write('\t')
+	if f.expr_recursion == 0 || f.is_inside_interp {
+		if f.indent > 0 && f.empty_line {
+			if f.indent < tabs.len {
+				f.out.write(tabs[f.indent])
+			} else {
+				// too many indents, do it the slow way:
+				for _ in 0 .. f.indent {
+					f.out.write('\t')
+				}
 			}
+			f.line_len += f.indent * 4
 		}
-		f.line_len += f.indent * 4
+		f.out.write(s)
+		f.line_len += s.len
+		f.empty_line = false
+	} else {
+		f.out.write(s)
 	}
-	f.out.write(s)
-	f.line_len += s.len
-	f.empty_line = false
 }
 
 pub fn (mut f Fmt) writeln(s string) {
-	if f.indent > 0 && f.empty_line {
-		// println(f.indent.str() + s)
-		f.out.write(tabs[f.indent])
+	if f.expr_recursion == 0 || f.is_inside_interp {
+		if f.indent > 0 && f.empty_line {
+			// println(f.indent.str() + s)
+			f.out.write(tabs[f.indent])
+		}
+		f.out.writeln(s)
+		f.empty_line = true
+		f.line_len = 0
+	} else {
+		f.out.writeln(s)
 	}
-	f.out.writeln(s)
-	f.empty_line = true
-	f.line_len = 0
+}
+
+// adjustments that can only be done after full line is processed. For now
+// only prevents line breaks if everything fits in max_len[last] by increasing
+// penalties to maximum
+fn (mut f Fmt) adjust_complete_line() {
+	mut l := 0
+	for s in f.expr_bufs {
+		l += s.len
+	}
+	if f.line_len + l <= max_len[max_len.len-1] {
+		for i, _ in f.penalties {
+			f.penalties[i] = max_len.len-1
+		}
+	}
 }
 
 pub fn (mut f Fmt) mod(mod ast.Module) {
@@ -625,11 +653,19 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 			f.expr(node.expr)
 		}
 		ast.InfixExpr {
-			f.expr(node.left)
 			if f.is_inside_interp {
+				f.expr(node.left)
 				f.write('$node.op.str()')
+				f.expr(node.right)
 			} else {
+				rec_save := f.expr_recursion
+				f.expr(node.left)
 				f.write(' $node.op.str() ')
+				if f.expr_recursion == 0 {
+					f.out_save = f.out
+				} else {
+					f.expr_bufs << f.out.str()
+				}
 				mut penalty := 3
 				if node.left is ast.InfixExpr || node.left is ast.ParExpr {
 					penalty--
@@ -637,9 +673,24 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 				if node.right is ast.InfixExpr || node.right is ast.ParExpr {
 					penalty--
 				}
-				f.wrap_long_line(penalty, true)
+				f.penalties << penalty
+				f.expr_recursion++
+				f.out = strings.new_builder(60)
+				f.expr(node.right)
+				if rec_save == 0 { // now decide if and where to break
+					f.expr_bufs << f.out.str()
+					f.out = f.out_save
+					f.expr_recursion = 0
+					f.adjust_complete_line()
+					for i, p in f.penalties {
+						f.wrap_long_line(p, true)
+						f.write(f.expr_bufs[i])
+					}
+					// f.write(f.expr_bufs[f.expr_bufs.len-1])
+					f.expr_bufs = []string{}
+					f.penalties = []int{}
+				}
 			}
-			f.expr(node.right)
 		}
 		ast.IndexExpr {
 			f.expr(node.left)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -12,7 +12,7 @@ const (
 		'\t\t\t\t\t\t\t\t'
 	]
 	// when to break a line dependant on penalty
-	max_len = [0, 30, 85, 100, 100]
+	max_len = [0, 30, 85, 95, 100]
 )
 
 pub struct Fmt {

--- a/vlib/v/fmt/tests/expressions_expected.vv
+++ b/vlib/v/fmt/tests/expressions_expected.vv
@@ -39,3 +39,10 @@ fn get_some_val(a_test, b_test, c_test, d_test, e_test, f_test f64) {
 		e_test * f_test * a_test * d_test +
 		a_test * b_test * c_test
 }
+
+fn main() {
+	a, b, r, d := 5.3, 7.5, 4.4, 6.6
+	if a + b + r * d + a + b + r * d > a + b + r * d + a * b + r {
+		println('ok')
+	}
+}

--- a/vlib/v/fmt/tests/expressions_input.vv
+++ b/vlib/v/fmt/tests/expressions_input.vv
@@ -45,3 +45,13 @@ fn get_some_val(a_test, b_test, c_test, d_test, e_test, f_test f64) {
 		d_test+e_test*f_test*a_test*d_test+a_test*
 		b_test*c_test
 }
+
+fn main() {
+	a, b, r, d := 5.3, 7.5, 4.4, 6.6
+	if a+b+
+		r*d+a+b+r*
+		d > a+b+r*d+
+		a*b+r {
+		println('ok')
+	}
+}


### PR DESCRIPTION
The line breaking algorithm introduced in [0338d41](https://github.com/vlang/v/commit/0338d4153accf79e3e8bd6b8b6bfbe098e9d27b4) tends to break hierarchical expressions even if the complete line would fit in 100 characters. Unfortunately this is not trivial to fix since `f.wrap_long_lines()` does not know in advance how long a line will become.

Therefore this PR introduces a FIFO buffer `f.expr_bufs[]` that is filled with the expression parts. This allows introducing a further step of analysis in `f.adjust_complete_line()` before the parts are actually written. For now `f.adjust_complete_line()` just rises all penalties to maximum if if the complete line fits in 100 characters, however more sophisticated adjustments would be possible if it seems reasonable. 
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
