### PR TITLE
fmt: fix handling of double quotes inside single quotes in string interpol…

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -844,6 +844,12 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 					break
 				}
 			}
+			for val in node.vals {
+				if val.contains('"') {
+					contains_single_quote = false
+					break
+				}
+			}
 			if contains_single_quote {
 				f.write('"')
 			} else {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -841,10 +841,7 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 			for val in node.vals {
 				if val.contains("'") {
 					contains_single_quote = true
-					break
 				}
-			}
-			for val in node.vals {
 				if val.contains('"') {
 					contains_single_quote = false
 					break

--- a/vlib/v/fmt/tests/expressions_expected.vv
+++ b/vlib/v/fmt/tests/expressions_expected.vv
@@ -1,8 +1,9 @@
 import v.checker
 import v.ast
 import v.table
+import v.gen
 
-pub fn string_inter_lit(mut c checker.Checker, mut node ast.StringInterLiteral) table.Type {
+fn string_inter_lit(mut c checker.Checker, mut node ast.StringInterLiteral) table.Type {
 	for i, expr in node.exprs {
 		ftyp := c.expr(expr)
 		node.expr_types << ftyp
@@ -34,7 +35,7 @@ pub fn string_inter_lit(mut c checker.Checker, mut node ast.StringInterLiteral) 
 	return table.string_type
 }
 
-fn get_some_val(a_test, b_test, c_test, d_test, e_test, f_test f64) {
+fn get_some_val(a_test, b_test, c_test, d_test, e_test, f_test f64) f64 {
 	return a_test * b_test * c_test * d_test +
 		e_test * f_test * a_test * d_test +
 		a_test * b_test * c_test
@@ -44,5 +45,11 @@ fn main() {
 	a, b, r, d := 5.3, 7.5, 4.4, 6.6
 	if a + b + r * d + a + b + r * d > a + b + r * d + a * b + r {
 		println('ok')
+	}
+}
+
+fn gen_str_for_multi_return(mut g gen.Gen, info table.MultiReturn, styp, str_fn_name string) {
+	for i, _ in info.types {
+		println('\tstrings__Builder_write(&sb, _STR("\'%.*s\\000\'", 2, a.arg$i));')
 	}
 }

--- a/vlib/v/fmt/tests/expressions_input.vv
+++ b/vlib/v/fmt/tests/expressions_input.vv
@@ -1,8 +1,9 @@
 import v.checker
 import v.ast
 import v.table
+import v.gen
 
-pub fn string_inter_lit(mut c checker.Checker, mut node ast.StringInterLiteral) table.Type {
+fn string_inter_lit(mut c checker.Checker, mut node ast.StringInterLiteral) table.Type {
 	for i, expr in node.exprs {
 		ftyp := c.expr(expr)
 		node.expr_types << ftyp
@@ -40,7 +41,7 @@ pub fn string_inter_lit(mut c checker.Checker, mut node ast.StringInterLiteral) 
 	return table.string_type
 }
 
-fn get_some_val(a_test, b_test, c_test, d_test, e_test, f_test f64) {
+fn get_some_val(a_test, b_test, c_test, d_test, e_test, f_test f64) f64 {
 	return a_test*b_test*c_test*
 		d_test+e_test*f_test*a_test*d_test+a_test*
 		b_test*c_test
@@ -53,5 +54,12 @@ fn main() {
 		d > a+b+r*d+
 		a*b+r {
 		println('ok')
+	}
+}
+
+fn gen_str_for_multi_return(mut g gen.Gen,
+    info table.MultiReturn, styp, str_fn_name string) {
+for i, _ in info.types {
+		println('\tstrings__Builder_write(&sb, _STR("\'%.*s\\000\'", 2, a.arg$i));')
 	}
 }


### PR DESCRIPTION
This PR uses a heuristic for `StringInterLiteral` equivalent that used for `StringLiteral` to decide which quotes to use.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
