### PR TITLE
vrepl: fix optional call (fix #5465)

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -198,7 +198,7 @@ fn run_repl(workdir string, vrepl_prefix string) {
 				'=', '++', '--', '<<',
 				'//', '/*',
 				'fn ', 'pub ', 'mut ', 'enum ', 'const ', 'struct ', 'interface ', 'import ',
-				'#include ', ':=', 'for '
+				'#include ', ':=', 'for ', 'or '
 			]
 			mut is_statement := false
 			for pattern in possible_statement_patterns {

--- a/vlib/v/tests/repl/optional_call.repl
+++ b/vlib/v/tests/repl/optional_call.repl
@@ -1,0 +1,3 @@
+import os
+os.cp('', '') or {return} 
+===output===


### PR DESCRIPTION
This PR fix optional call in vrepl (fix #5465).

- Fix optional call in vrepl.
- Add test `optional_call.repl`.

```v
C:\Users\yuyi9\v>v
For usage information, quit V REPL using `exit` and use `v help`
V 0.1.28 d4f0fe1
Use Ctrl-C or `exit` to exit
>>> import os
>>> os.cp('./aaaaa', './bbbbb') or {panic(err)}
V panic: failed to copy ./aaaaa to ./bbbbb
print_backtrace_skipping_top_frames is not implemented
>>>
```