### PR TITLE
bin2v: specify custom filename for write

### DIFF
--- a/cmd/tools/vbin2v.v
+++ b/cmd/tools/vbin2v.v
@@ -15,7 +15,7 @@ mut:
 	prefix      string
 	show_help   bool
 	module_name string
-	write_file  bool
+	write_file  string
 }
 
 fn (context Context) header() string {
@@ -31,8 +31,8 @@ fn (context Context) header() string {
 	if context.module_name.len > 0 {
 		options << '-m ${context.module_name}'
 	}
-	if context.write_file {
-		options << '-w'
+	if context.write_file.len > 0 {
+		options << '-w ${context.write_file}'
 	}
 	soptions := options.join(' ')
 
@@ -85,7 +85,7 @@ fn main() {
 	context.show_help = fp.bool('help', `h`, false, 'Show this help screen.')
 	context.module_name = fp.string('module', `m`, 'binary', 'Name of the generated module.')
 	context.prefix = fp.string('prefix', `p`, '', 'A prefix put before each resource name.')
-	context.write_file = fp.bool('write', `w`, false, 'Write directly to a file. The module name is used as filename.')
+	context.write_file = fp.string('write', `w`, '', 'Write directly to a file with the given name.')
 	if context.show_help {
 		println(fp.usage())
 		exit(0)
@@ -101,8 +101,8 @@ fn main() {
 	}
 	context.files = real_files
 
-	if context.write_file {
-		mut out_file := os.create('${context.module_name}.v') or { panic(err) }
+	if context.write_file.len > 0 {
+		mut out_file := os.create('${context.write_file}.v') or { panic(err) }
 		out_file.write(context.header())
 		for file in real_files {
 			out_file.write(context.file2v(file))

--- a/cmd/v/help/bin2v.txt
+++ b/cmd/v/help/bin2v.txt
@@ -11,4 +11,4 @@ Options:
   -h, --help                Show this help screen.
   -m, --module <string>     Name of the generated module.
   -p, --prefix <string>     A prefix put before each resource name.
-  -w, --write               Write directly to a file. The module name is used as filename.
+  -w, --write <string>      Write directly to a file with the given name.


### PR DESCRIPTION
Increase the flexibility of bin2v file output by specifying a filename. The extension `.v` is appended automatically.

`bin2v test.png -w filename`
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
