### PR TITLE
cgen: fix optional void return error (fix #5472)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1259,7 +1259,8 @@ pub fn (mut c Checker) return_stmt(mut return_stmt ast.Return) {
 		c.error('too many arguments to return, current function does not return anything',
 			return_stmt.pos)
 		return
-	} else if return_stmt.exprs.len == 0 && c.expected_type != table.void_type {
+	} else if return_stmt.exprs.len == 0 && !(c.expected_type == table.void_type ||
+			c.table.get_type_symbol(c.expected_type).kind == .void) {
 		c.error('too few arguments to return', return_stmt.pos)
 		return
 	}

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -330,7 +330,7 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 	}
 	if gen_or {
 		g.or_block(tmp_opt, node.or_block, node.return_type)
-		g.write('\n${cur_line}${tmp_opt}')
+		g.write('\n\t${cur_line}${tmp_opt}')
 	}
 }
 

--- a/vlib/v/tests/option_test.v
+++ b/vlib/v/tests/option_test.v
@@ -274,34 +274,6 @@ fn test_multi_return_opt() {
 	}
 }
 */
-fn foo() ? {
-	return error('something')
-}
-
-fn test_optional_void() {
-	foo() or {
-		println(err)
-		assert err == 'something'
-		return
-	}
-}
-
-fn bar() ? {
-	return error('bar error')
-}
-
-fn test_optional_void_only_question() {
-	bar() or {
-		println(err)
-		assert err == 'bar error'
-		return
-	}
-}
-
-fn test_optional_void_with_empty_or() {
-	foo() or {}
-	assert true
-}
 
 fn test_optional_val_with_empty_or() {
 	ret_none() or {}

--- a/vlib/v/tests/option_void_test.v
+++ b/vlib/v/tests/option_void_test.v
@@ -1,0 +1,50 @@
+fn foo() ? {
+	return error('something')
+}
+
+fn test_optional_void() {
+	foo() or {
+		println(err)
+		assert err == 'something'
+		return
+	}
+}
+
+fn bar() ? {
+	return error('bar error')
+}
+
+fn test_optional_void_only_question() {
+	bar() or {
+		println(err)
+		assert err == 'bar error'
+		return
+	}
+}
+
+fn test_optional_void_with_empty_or() {
+	foo() or {}
+	assert true
+}
+
+fn option_void(a int) ? {
+	if a != 0 {
+		return
+	} else {
+		return error('zero error')
+	}
+}
+
+fn test_optional_void_with_return() {
+	option_void(0) or {
+		println(err)
+		assert err == 'zero error'
+		return
+	}
+	option_void(-1) or {
+		println(err)
+		assert err == 'zero error'
+		return
+	}
+	assert true
+}


### PR DESCRIPTION
This PR fix optional void return error (fix #5472).

- Fix optional void return error.
- Add test `option_void_test.v`.

```v
fn main() {
	option_void(0) or {
		println(err)
		return
	}
}

fn option_void(a int) ? {
	if a != 0 {
		return
	} else {
		return error('zero error')
	}
}

D:\test\v\tt1>v run .
zero error
```