### PR TITLE
anon-fn: call directly

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -211,6 +211,7 @@ pub:
 pub struct AnonFn {
 pub:
 	decl FnDecl
+	is_called bool
 pub mut:
 	typ  table.Type
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1881,7 +1881,7 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 			c.cur_fn = &node.decl
 			c.stmts(node.decl.stmts)
 			c.cur_fn = keep_fn
-			return node.typ
+			return if node.is_called { node.decl.return_type } else { node.typ }
 		}
 		ast.ArrayInit {
 			return c.array_init(mut node)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -568,7 +568,7 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl) {
 		}
 		f.write('\n')
 	}
-	// Handle comments after last field 
+	// Handle comments after last field
 	for comment in node.end_comments {
 		f.indent++
 		f.empty_line = true
@@ -621,6 +621,9 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 	match node {
 		ast.AnonFn {
 			f.fn_decl(node.decl)
+			if node.is_called {
+				f.write('()')
+			}
 		}
 		ast.ArrayInit {
 			f.array_init(node)

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1111,12 +1111,18 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					g.write('{')
 				}
 				ret_styp := g.typ(val.decl.return_type)
-				g.write('$ret_styp (*$ident.name) (')
-				def_pos := g.definitions.len
-				g.fn_args(val.decl.args, val.decl.is_variadic)
-				g.definitions.go_back(g.definitions.len - def_pos)
-				g.write(') = ')
-				g.expr(*val)
+				if val.is_called {
+					g.write('$ret_styp $ident.name = ')
+					g.expr(*val)
+					g.write('()')
+				} else {
+					g.write('$ret_styp (*$ident.name) (')
+					def_pos := g.definitions.len
+					g.fn_args(val.decl.args, val.decl.is_variadic)
+					g.definitions.go_back(g.definitions.len - def_pos)
+					g.write(') = ')
+					g.expr(*val)
+				}
 				g.writeln(';')
 				if blank_assign {
 					g.write('}')

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -329,6 +329,12 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 		return_type: return_type
 	}
 	name := 'anon_${p.tok.pos}_$func.signature()'
+	mut is_called := false
+	if p.tok.kind == .lpar {
+		is_called = true
+		p.check(.lpar)
+		p.check(.rpar)
+	}
 	func.name = name
 	idx := p.table.find_or_register_fn_type(p.mod, func, true, false)
 	typ := table.new_type(idx)
@@ -347,6 +353,7 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 			pos: pos
 			file: p.file_name
 		}
+		is_called: is_called
 		typ: typ
 	}
 }


### PR DESCRIPTION
```
fn main() {
	a := fn() string {
		return "test"
	}()
	println(a)
}
```
this works.


What doesn't work:
- Parameters: maybe someone can help here?