### PR TITLE
fmt: further improvements by taking precedence into account for subexpressions

### DIFF
--- a/vlib/v/fmt/tests/expressions_expected.vv
+++ b/vlib/v/fmt/tests/expressions_expected.vv
@@ -2,6 +2,7 @@ import v.checker
 import v.ast
 import v.table
 import v.gen
+import v.token
 
 fn string_inter_lit(mut c checker.Checker, mut node ast.StringInterLiteral) table.Type {
 	for i, expr in node.exprs {
@@ -25,8 +26,7 @@ fn string_inter_lit(mut c checker.Checker, mut node ast.StringInterLiteral) tabl
 			(typ.is_float() && fmt !in [`E`, `F`, `G`, `e`, `f`, `g`]) ||
 			(typ.is_pointer() && fmt !in [`p`, `x`, `X`]) ||
 			(typ.is_string() && fmt != `s`) ||
-			(typ.idx() in [table.i64_type_idx, table.f64_type_idx] &&
-			fmt == `c`) {
+			(typ.idx() in [table.i64_type_idx, table.f64_type_idx] && fmt == `c`) {
 			c.error('illegal format specifier `${fmt:c}` for type `${c.table.get_type_name(ftyp)}`',
 				node.fmt_poss[i])
 		}
@@ -51,5 +51,18 @@ fn main() {
 fn gen_str_for_multi_return(mut g gen.Gen, info table.MultiReturn, styp, str_fn_name string) {
 	for i, _ in info.types {
 		println('\tstrings__Builder_write(&sb, _STR("\'%.*s\\000\'", 2, a.arg$i));')
+	}
+}
+
+struct Parser {
+	peek_tok  token.Token
+	peek_tok2 token.Token
+	peek_tok3 token.Token
+}
+
+fn (mut p Parser) name_expr() {
+	if p.peek_tok.kind == .lpar ||
+		(p.peek_tok.kind == .lt && p.peek_tok2.kind == .name && p.peek_tok3.kind == .gt) {
+		println(p.peek_tok.lit)
 	}
 }

--- a/vlib/v/fmt/tests/expressions_input.vv
+++ b/vlib/v/fmt/tests/expressions_input.vv
@@ -2,6 +2,7 @@ import v.checker
 import v.ast
 import v.table
 import v.gen
+import v.token
 
 fn string_inter_lit(mut c checker.Checker, mut node ast.StringInterLiteral) table.Type {
 	for i, expr in node.exprs {
@@ -61,5 +62,19 @@ fn gen_str_for_multi_return(mut g gen.Gen,
     info table.MultiReturn, styp, str_fn_name string) {
 for i, _ in info.types {
 		println('\tstrings__Builder_write(&sb, _STR("\'%.*s\\000\'", 2, a.arg$i));')
+	}
+}
+
+struct Parser {
+	peek_tok token.Token
+	peek_tok2 token.Token
+	peek_tok3 token.Token
+}
+
+fn (mut p Parser) name_expr() {
+	if p.peek_tok.kind ==
+		.lpar || (p.peek_tok.kind == .lt && p.peek_tok2.kind == .name &&
+		p.peek_tok3.kind == .gt) {
+		println(p.peek_tok.lit)
 	}
 }


### PR DESCRIPTION
This PR generalizes the approach of commit [000eaca](https://github.com/vlang/v/commit/000eaca6be41a1e784f9a70174d5d8b4b7e8a7eb) by extending it to subexpressions <= 100 characters that are enclosed by operator of equal precedences.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
