### PR TITLE
map: fix errors of map operating directly (fix #5233 #3042)

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -359,6 +359,25 @@ fn (m map) get3(key string, zero voidptr) voidptr {
 	return zero
 }
 
+fn (mut m map) get2(key string, zero voidptr) voidptr {
+	for {
+		mut index,mut meta := m.key_to_index(key)
+		for {
+			if meta == m.metas[index] {
+				kv_index := m.metas[index + 1]
+				if fast_string_eq(key, m.key_values.keys[kv_index]) {
+					return voidptr(m.key_values.values + kv_index * u32(m.value_bytes))
+				}
+			}
+			index += 2
+			meta += probe_inc
+			if meta > m.metas[index] { break }
+		}
+		// set zero if not found
+		m.set(key, zero)
+	}
+}
+
 fn (m map) exists(key string) bool {
 	mut index,mut meta := m.key_to_index(key)
 	for {

--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -239,13 +239,40 @@ fn test_map_assign() {
 		's': u16(5)
 		't': 3
 	}
-	d := Mstruct1 {
+	_ := Mstruct1 {
 		{ 'p': 12 }
 	}
-	e := Mstruct2 {
+	_ := Mstruct2 {
 		{ 'q': 1.7 }
 	}
-	f := Mstruct3 {
+	_ := Mstruct3 {
 		{ 'r': u16(6), 's': 5 }
 	}
+}
+
+fn test_postfix_op_directly() {
+	mut a := map[string]int
+	a['aaa']++
+	assert a['aaa'] == 1
+	a['aaa']++
+	assert a['aaa'] == 2
+	a['bbb']--
+	assert a['bbb'] == -1
+	a['bbb']--
+	assert a['bbb'] == -2
+}
+
+fn test_map_push_directly() {
+	mut a := map[string][]string
+	a['aaa'] << ['a', 'b', 'c']
+	assert a['aaa'].len == 3
+	assert a['aaa'] == ['a', 'b', 'c']
+}
+
+fn test_assign_directly() {
+	mut a := map[string]int
+	a['aaa'] += 4
+	assert a['aaa'] == 4
+	a['aaa'] -= 2
+	assert a['aaa'] == 2
 }


### PR DESCRIPTION
This PR fix errors of map operating directly (fix #5233, fix #3042).
**Not sure if this is appropriate?**

- Fix errors of map operating directly.
- Add tests in map_test.v.

```v
fn test_postfix_op_directly() {
	mut a := map[string]int
	a['aaa']++
	assert a['aaa'] == 1
	a['aaa']++
	assert a['aaa'] == 2
	a['bbb']--
	assert a['bbb'] == -1
	a['bbb']--
	assert a['bbb'] == -2
}

fn test_map_push_directly() {
	mut a := map[string][]string
	a['aaa'] << ['a', 'b', 'c']
	assert a['aaa'].len == 3
	assert a['aaa'] == ['a', 'b', 'c']
}

fn test_assign_directly() {
	mut a := map[string]int
	a['aaa'] += 4
	assert a['aaa'] == 4
	a['aaa'] -= 2
	assert a['aaa'] == 2
}
```
