### PR TITLE
fmt: fix weird bug with tabs in string interpolation

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -88,7 +88,7 @@ fn (mut f Fmt) find_comment(line_nr int) {
 }
 */
 pub fn (mut f Fmt) write(s string) {
-	if !f.buffering || f.is_inside_interp {
+	if !f.buffering {
 		if f.indent > 0 && f.empty_line {
 			if f.indent < tabs.len {
 				f.out.write(tabs[f.indent])
@@ -152,6 +152,10 @@ fn (mut f Fmt) adjust_complete_line() {
 			for j in i..f.penalties.len {
 				if f.penalties[j] <= 1 && f.precedences[j] == precedence {
 					sub_expr_end_idx = j
+					break
+				} else if f.precedences[j] < precedence {
+					// we cannot form a sensible subexpression
+					len_sub_expr = C.INT32_MAX
 					break
 				} else {
 					len_sub_expr += f.expr_bufs[j+1].len

--- a/vlib/v/fmt/tests/expressions_expected.vv
+++ b/vlib/v/fmt/tests/expressions_expected.vv
@@ -46,6 +46,10 @@ fn main() {
 	if a + b + r * d + a + b + r * d > a + b + r * d + a * b + r {
 		println('ok')
 	}
+	v_str := 'v'
+	s := []string{}
+	s << '	`$v_str`'
+	println(s)
 }
 
 fn gen_str_for_multi_return(mut g gen.Gen, info table.MultiReturn, styp, str_fn_name string) {

--- a/vlib/v/fmt/tests/expressions_input.vv
+++ b/vlib/v/fmt/tests/expressions_input.vv
@@ -56,6 +56,10 @@ fn main() {
 		a*b+r {
 		println('ok')
 	}
+	v_str := 'v'
+	s := []string{}
+	s << '	`$v_str`'
+	println(s)
 }
 
 fn gen_str_for_multi_return(mut g gen.Gen,


### PR DESCRIPTION
This PR fixes a bug the was exposed in [e918f8f](https://github.com/vlang/v/commit/e918f8faf27af25a9fa39eb35f91d0759c71c759). Furthermore the sub-expression finding algorithm in `adjust_complete_line()` is prevented from finding certain false-positive occurrences.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
