### PR TITLE
parser: fix inconsistent fn args behaviour 

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -365,7 +365,7 @@ fn (mut p Parser) fn_args() ([]table.Arg, bool) {
 	mut is_variadic := false
 	// `int, int, string` (no names, just types)
 	types_only := p.tok.kind in [.amp, .ellipsis, .key_fn] || (p.peek_tok.kind == .comma && p.table.known_type(p.tok.lit)) ||
-		p.peek_tok.kind == .rpar
+		(p.peek_tok.kind == .rpar && p.table.known_type(p.tok.lit))
 	// TODO copy pasta, merge 2 branches
 	if types_only {
 		// p.warn('types only')


### PR DESCRIPTION
parser show inconsistent behaviour without params type.

Code: 
```
fn test(a) {}

fn main() {
	test(0)
}
```
Error: 

```
vlib/strings/similarity.v:5:1: error: unknown type `a` 
    3 | // use levenshtein distance algorithm to calculate
    4 | // the distance between between two strings (lower is closer)
    5 | pub fn levenshtein_distance(a, b string) int {
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    6 |     mut f := [0].repeat(b.len + 1)
    7 |     for j in 0..f.len {
vlib/strings/similarity.v:6:22: error: undefined ident: `b` 
    4 | // the distance between between two strings (lower is closer)
    5 | pub fn levenshtein_distance(a, b string) int {
    6 |     mut f := [0].repeat(b.len + 1)
      |                         ^
    7 |     for j in 0..f.len {
    8 |         f[j] = j
vlib/strings/similarity.v:10:12: error: undefined ident: `a` 
    8 |         f[j] = j
    9 |     }
   10 |     for ca in a {
      |               ^
   11 |         mut j := 1
   12 |         mut fj1 := f[0]
vlib/strings/similarity.v:14:13: error: undefined ident: `b` 
   12 |         mut fj1 := f[0]
   13 |         f[0]++
   14 |         for cb in b {
      |                   ^
   15 |             mut mn := if f[j] + 1 <= f[j - 1] + 1 { f[j] + 1 } else { f[j - 1] + 1 }
   16 |             if cb != ca {
vlib/strings/similarity.v:32:1: error: unknown type `a` 
   30 | // use levenshtein distance algorithm to calculate
   31 | // how similar two strings are as a percentage (higher is closer)
   32 | pub fn levenshtein_distance_percentage(a, b string) f32 {
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   33 |     d := levenshtein_distance(a, b)
   34 |     l := if a.len >= b.len { a.len } else { b.len }
```
Code: 
```
fn test(params) {}

fn main() {
	test(0)
}
```
Error: 
```
error: unknown type `params` 
    1 | fn test(params) {}
      | ~~~~~~~~~~~~~~
    2 | 
    3 | fn main() {
```
results in different error.