### PR TITLE
fmt: fix one-line-fits formatting when bitwise `&` or `|` are involved

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -145,7 +145,7 @@ fn (mut f Fmt) adjust_complete_line() {
 	for i, buf in f.expr_bufs {
 		// search for low penalties
 		if i == 0 || f.penalties[i-1] <= 1 {
-			precedence := if i == 0 { 0 } else { f.precedences[i-1] }
+			precedence := if i == 0 { -1 } else { f.precedences[i-1] }
 			mut len_sub_expr := if i == 0 { buf.len + f.line_len } else { buf.len }
 			mut sub_expr_end_idx := f.penalties.len
 			// search for next position with low penalty and same precedence to form subexpression

--- a/vlib/v/fmt/tests/expressions_expected.vv
+++ b/vlib/v/fmt/tests/expressions_expected.vv
@@ -70,3 +70,7 @@ fn (mut p Parser) name_expr() {
 		println(p.peek_tok.lit)
 	}
 }
+
+fn set_nr_muls(t table.Type, nr_muls int) table.Type {
+	return int(t) & 0xff00ffff | (nr_muls << 16)
+}

--- a/vlib/v/fmt/tests/expressions_input.vv
+++ b/vlib/v/fmt/tests/expressions_input.vv
@@ -82,3 +82,8 @@ fn (mut p Parser) name_expr() {
 		println(p.peek_tok.lit)
 	}
 }
+
+fn set_nr_muls(t table.Type, nr_muls int) table.Type {
+	return int(t) &
+		0xff00ffff | (nr_muls << 16)
+}


### PR DESCRIPTION
The algorithm to find sub-expressions compares against a lower-than-possible precedence to get the whole line. It turns out that in `token.build_precedences()` no values are assigned to `Kind.amp` and `Kind.pipe`, hence bitwise `&` and `|` have precedence `0`.

So this PR sets the lower-than-possible precedence to `-1` to be safe.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
