### PR TITLE
cgen: fix map_in error (fix #5495)

### DIFF
--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -276,3 +276,10 @@ fn test_assign_directly() {
 	a['aaa'] -= 2
 	assert a['aaa'] == 2
 }
+
+fn test_map_in_directly() {
+	for k, v in {'aa': 1} {
+		assert k == 'aa'
+		assert v == 1
+	}
+}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -832,14 +832,16 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		idx := g.new_tmp_var()
 		key := if it.key_var in ['', '_'] { g.new_tmp_var() } else { it.key_var }
 		zero := g.type_default(it.val_type)
-		g.write('array_$key_styp $keys_tmp = map_keys(&')
+		atmp := g.new_tmp_var()
+		atmp_styp := g.typ(it.cond_type)
+		g.write('$atmp_styp $atmp = ')
 		g.expr(it.cond)
-		g.writeln(');')
+		g.writeln(';')
+		g.writeln('array_$key_styp $keys_tmp = map_keys(&$atmp);')
 		g.writeln('for (int $idx = 0; $idx < ${keys_tmp}.len; $idx++) {')
 		g.writeln('\t$key_styp $key = (($key_styp*)${keys_tmp}.data)[$idx];')
 		if it.val_var != '_' {
-			g.write('\t$val_styp ${c_name(it.val_var)} = (*($val_styp*)map_get(')
-			g.expr(it.cond)
+			g.write('\t$val_styp ${c_name(it.val_var)} = (*($val_styp*)map_get($atmp')
 			g.writeln(', $key, &($val_styp[]){ $zero }));')
 		}
 		g.stmts(it.stmts)


### PR DESCRIPTION
This PR fix map_in error (fix #5495).

- Fix map_in error.
- Add test `test_map_in_directly()` in map_test.v.

```v
fn mymap() map[string]int {
  return {
    'one': 1
    'two': 2
  }
}

fn main() {
  for k, v in mymap() {
    println('$k -> $v')
  }
}

D:\test\v\tt1>v run .
one -> 1
two -> 2
```