### PR TITLE
checker: Disallow go'd functions taking mutable arguments

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.v linguist-language=V text=auto eol=lf
 *.vv linguist-language=V text=auto eol=lf
+*.bat text=auto eol=crlf


### PR DESCRIPTION
closes #5450 by preventing mutable arguments to go functions (since they probably should never be mutable anyway)