### PR TITLE
fmt: force break in front of long unbreakable parts, avoid very small sub-expressions

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -13,7 +13,7 @@ const (
 		'\t\t\t\t\t\t\t\t'
 	]
 	// when to break a line dependant on penalty
-	max_len = [0, 30, 85, 95, 100]
+	max_len = [0, 35, 85, 93, 100]
 )
 
 pub struct Fmt {
@@ -150,7 +150,7 @@ fn (mut f Fmt) adjust_complete_line() {
 			mut sub_expr_end_idx := f.penalties.len
 			// search for next position with low penalty and same precedence to form subexpression
 			for j in i..f.penalties.len {
-				if f.penalties[j] <= 1 && f.precedences[j] == precedence {
+				if f.penalties[j] <= 1 && f.precedences[j] == precedence && len_sub_expr >= max_len[1] {
 					sub_expr_end_idx = j
 					break
 				} else if f.precedences[j] < precedence {
@@ -164,7 +164,7 @@ fn (mut f Fmt) adjust_complete_line() {
 			// if subexpression would fit in single line adjust penalties to actually do so
 			if len_sub_expr <= max_len[max_len.len-1] {
 				for j in i..sub_expr_end_idx {
-						f.penalties[j] = max_len.len-1
+					f.penalties[j] = max_len.len-1
 				}
 				if i > 0 {
 					f.penalties[i-1] = 0
@@ -173,6 +173,10 @@ fn (mut f Fmt) adjust_complete_line() {
 					f.penalties[sub_expr_end_idx] = 0
 				}
 			}
+		}
+		// emergency fallback: decrease penalty in front of long unbreakable parts 
+		if i > 0 && buf.len > max_len[3] - max_len[1] && f.penalties[i-1] > 0 {
+			f.penalties[i-1] = if buf.len >= max_len[2] { 0 } else { 1 }
 		}
 	}
 }

--- a/vlib/v/fmt/tests/consts_expected.vv
+++ b/vlib/v/fmt/tests/consts_expected.vv
@@ -10,8 +10,8 @@ const (
 	eulers              = 2.7182
 	supported_platforms = ['windows', 'mac', 'macos', 'darwin', 'linux', 'freebsd', 'openbsd',
 		'netbsd', 'dragonfly', 'android', 'js', 'solaris', 'haiku', 'linux_or_macos']
-	one_line_supported  = ['windows', 'mac', 'macos', 'darwin', 'linux', 'freebsd', 'openbsd', 'netbsd',
-		'dragonfly', 'android', 'js', 'solaris', 'haiku', 'linux_or_macos']
+	one_line_supported  = ['windows', 'mac', 'macos', 'darwin', 'linux', 'freebsd', 'openbsd',
+		'netbsd', 'dragonfly', 'android', 'js', 'solaris', 'haiku', 'linux_or_macos']
 	another_const       = ['a', 'b', 'c', 'd', 'e', 'f']
 )
 

--- a/vlib/v/fmt/tests/expressions_expected.vv
+++ b/vlib/v/fmt/tests/expressions_expected.vv
@@ -50,6 +50,13 @@ fn main() {
 	s := []string{}
 	s << '	`$v_str`'
 	println(s)
+	println('this is quite a long string' +
+		' that is followd by an even longer part that should go to another line')
+	if (a == b && b > r) ||
+		(d > r) || (a < b) || (b < d && a + b > r) ||
+		(a + b + d >= 0 && r < 0) || (a > b && d - r < b) {
+		println('ok')
+	}
 }
 
 fn gen_str_for_multi_return(mut g gen.Gen, info table.MultiReturn, styp, str_fn_name string) {

--- a/vlib/v/fmt/tests/expressions_input.vv
+++ b/vlib/v/fmt/tests/expressions_input.vv
@@ -60,6 +60,10 @@ fn main() {
 	s := []string{}
 	s << '	`$v_str`'
 	println(s)
+	println('this is quite a long string' + ' that is followd by an even longer part that should go to another line')
+	if (a == b && b > r) || (d > r) || (a < b) || (b< d && a+b > r) || (a+b+d >= 0 && r < 0) || (a > b && d-r < b) {
+		println('ok')
+	}
 }
 
 fn gen_str_for_multi_return(mut g gen.Gen,


### PR DESCRIPTION
This PR fixes some corner cases in `fmt`.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
