### PR TITLE
parser: fix fn(..)?{..} return error

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -256,6 +256,7 @@ pub fn mv_by_cp(source string, target string) ? {
 	os.rm(source) or {
 		return error(err)
 	}
+	return
 }
 
 // vfopen returns an opened C file, given its path and open mode.
@@ -635,8 +636,8 @@ pub fn rm(path string) ? {
 			return error(posix_get_error_msg(C.errno))
 		}
 	}
-	// C.unlink(path.cstr())
 }
+
 // rmdir removes a specified directory.
 pub fn rmdir(path string) {
 	$if !windows {

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -635,8 +635,6 @@ pub fn rm(path string) ? {
 			return error(posix_get_error_msg(C.errno))
 		}
 	}
-
-	return
 	// C.unlink(path.cstr())
 }
 // rmdir removes a specified directory.
@@ -1161,7 +1159,6 @@ pub fn walk(path string, f fn(path string)) {
 			f(p)
 		}
 	}
-	return
 }
 
 pub fn signal(signum int, handler voidptr) {

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -196,7 +196,6 @@ pub fn cp(old, new string) ? {
 			return error_with_code('failed to set permissions for $new', int(-1))
 		}
 	}
-	return
 }
 
 [deprecated]
@@ -246,7 +245,6 @@ pub fn cp_all(osource_path, odest_path string, overwrite bool) ? {
 			panic(err)
 		}
 	}
-	return
 }
 
 // mv_by_cp first copies the source file, and if it is copied successfully, deletes the source file.
@@ -258,7 +256,6 @@ pub fn mv_by_cp(source string, target string) ? {
 	os.rm(source) or {
 		return error(err)
 	}
-	return
 }
 
 // vfopen returns an opened C file, given its path and open mode.

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -270,14 +270,9 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	if p.tok.kind == .lcbr {
 		stmts = p.parse_block_no_scope(true)
 		// Add return if `fn(...) ? {...}` have no return at end
-		sym := p.table.get_type_symbol(return_type)
-		if sym.kind == .void && return_type.has_flag(.optional) &&
-					(stmts.len == 0 || stmts[stmts.len-1] !is ast.Return) {
-			stmts << ast.Return{
-				pos: p.tok.position()
-				exprs: []ast.Expr{}
-				types: []table.Type{}
-			}
+		if return_type != table.void_type && p.table.get_type_symbol(return_type).kind == .void &&
+				return_type.has_flag(.optional) && (stmts.len == 0 || stmts[stmts.len-1] !is ast.Return) {
+			stmts << ast.Return{ pos: p.tok.position() }
 		}
 	}
 	p.close_scope()

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -273,7 +273,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		sym := p.table.get_type_symbol(return_type)
 		if sym.kind == .void && return_type.has_flag(.optional) &&
 					(stmts.len == 0 || stmts[stmts.len-1] !is ast.Return) {
-			stmts << ast.Return{pos: stmts[stmts.len-1].position()}
+			stmts << ast.Return{ pos: p.tok.position() }
 		}
 	}
 	p.close_scope()

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -269,6 +269,12 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	body_start_pos := p.peek_tok.position()
 	if p.tok.kind == .lcbr {
 		stmts = p.parse_block_no_scope(true)
+		// Add return if `fn(...) ? {...}` have no return at end
+		sym := p.table.get_type_symbol(return_type)
+		if sym.kind == .void && return_type.has_flag(.optional) &&
+					(stmts.len == 0 || stmts[stmts.len-1] !is ast.Return) {
+			stmts << ast.Return{pos: stmts[stmts.len-1].position()}
+		}
 	}
 	p.close_scope()
 	return ast.FnDecl{

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -273,7 +273,11 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		sym := p.table.get_type_symbol(return_type)
 		if sym.kind == .void && return_type.has_flag(.optional) &&
 					(stmts.len == 0 || stmts[stmts.len-1] !is ast.Return) {
-			stmts << ast.Return{ pos: p.tok.position() }
+			stmts << ast.Return{
+				pos: p.tok.position()
+				exprs: []ast.Expr{}
+				types: []table.Type{}
+			}
 		}
 	}
 	p.close_scope()


### PR DESCRIPTION
This PR fix fn(..)?{..} return error.

- Fix fn(..)?{..} return error.
- Remove `return` in `os.cp` `os.cp_all` `os.mv_by_cp`.
- Fix #5157 (Not sure: because it's work on windows before).