### PR TITLE
msvc: Unique names for pdb files, remove test job limit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.v linguist-language=V text=auto eol=lf
 *.vv linguist-language=V text=auto eol=lf
+*.bat text=auto eol=crlf

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -96,14 +96,6 @@ pub fn (mut ts TestSession) test() {
 		mtx: sync.new_mutex()
 	}
 	pool_of_test_runners.set_shared_context(ts)
-	$if msvc {
-		// NB: MSVC can not be launched in parallel, without giving it
-		// the option /FS because it uses a shared PDB file, which should
-		// be locked, but that makes writing slower...
-		// See: https://docs.microsoft.com/en-us/cpp/build/reference/fs-force-synchronous-pdb-writes?view=vs-2019
-		// Instead, just run tests on 1 core for now.
-		pool_of_test_runners.set_max_jobs(1)
-	}
 	pool_of_test_runners.work_on_pointers(remaining_files.pointers())
 	ts.benchmark.stop()
 	eprintln(term.h_divider('-'))

--- a/vlib/v/builder/msvc.v
+++ b/vlib/v/builder/msvc.v
@@ -343,7 +343,7 @@ fn build_thirdparty_obj_file_with_msvc(path string, moduleflags []cflag.CFlag) {
 	// println('cfiles: $cfiles')
 	btarget := moduleflags.c_options_before_target_msvc()
 	atarget := moduleflags.c_options_after_target_msvc()
-	cmd := '"$msvc.full_cl_exe_path" /volatile:ms /Zi /DNDEBUG $include_string /c $btarget $cfiles $atarget /Fo"$obj_path"'
+	cmd := '"$msvc.full_cl_exe_path" /volatile:ms /DNDEBUG $include_string /c $btarget $cfiles $atarget /Fo"$obj_path"'
 	// NB: the quotes above ARE balanced.
 	println('thirdparty cmd line: $cmd')
 	res := os.exec(cmd) or {

--- a/vlib/v/builder/msvc.v
+++ b/vlib/v/builder/msvc.v
@@ -200,12 +200,14 @@ pub fn (mut v Builder) cc_msvc() {
 		return
 	}
 	out_name_obj := os.real_path(v.out_name_c + '.obj')
+	out_name_pdb := os.real_path(v.out_name_c + '.pdb')
 	// Default arguments
 	// volatile:ms enables atomic volatile (gcc _Atomic)
 	// -w: no warnings
 	// 2 unicode defines
 	// /Fo sets the object file name - needed so we can clean up after ourselves properly
-	mut a := ['-w', '/we4013', '/volatile:ms', '/Fo"$out_name_obj"']
+	// /Fd sets the pdb file name (so its not just vc140 all the time)
+	mut a := ['-w', '/we4013', '/volatile:ms', '/Fo"$out_name_obj"', '/Fd"$out_name_pdb"']
 	if v.pref.is_prod {
 		a << '/O2'
 		a << '/MD'

--- a/vlib/v/builder/msvc.v
+++ b/vlib/v/builder/msvc.v
@@ -206,17 +206,21 @@ pub fn (mut v Builder) cc_msvc() {
 	// -w: no warnings
 	// 2 unicode defines
 	// /Fo sets the object file name - needed so we can clean up after ourselves properly
-	// /Fd sets the pdb file name (so its not just vc140 all the time)
-	mut a := ['-w', '/we4013', '/volatile:ms', '/Fo"$out_name_obj"', '/Fd"$out_name_pdb"']
+	mut a := ['-w', '/we4013', '/volatile:ms', '/Fo"$out_name_obj"']
 	if v.pref.is_prod {
 		a << '/O2'
 		a << '/MD'
-		a << '/Zi'
 		a << '/DNDEBUG'
 	} else {
-		a << '/Zi'
 		a << '/MDd'
 	}
+
+	if v.pref.is_debug {
+		// /Zi generates a .pdb
+		// /Fd sets the pdb file name (so its not just vc140 all the time)
+		a << ['/Zi', '/Fd"$out_name_pdb"']
+	}
+
 	if v.pref.is_shared {
 		if !v.pref.out_name.ends_with('.dll') {
 			v.pref.out_name += '.dll'


### PR DESCRIPTION
Ran into this the other day attempting to do `.\make.bat -msvc` at which point it threw its hands in the air and told me that `msvc_strap` was not a valid label when it clearly is.

Quick search led to [this stackoverflow page](https://stackoverflow.com/questions/232651/why-the-system-cannot-find-the-batch-label-specified-is-thrown-even-if-label-e), which suggests that having LF in the file could be the issue. When I renormalized the line endings this issue went away.