### PR TITLE
checker: forbid non-reference mut arg or receiver of go function

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1826,6 +1826,19 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 				c.error('expression in `go` must be a function call', it.call_expr.position())
 			}
 			c.expr(it.call_expr)
+			if it.call_expr is ast.CallExpr {
+				call_expr := it.call_expr as ast.CallExpr
+
+				// Make sure there are no mutable arguments
+				for arg in call_expr.args {
+					if arg.is_mut && !arg.typ.is_ptr() {
+						c.error('function in `go` statement cannot contain mutable non-reference arguments', arg.expr.position())
+					}
+				}
+				if call_expr.is_method && call_expr.receiver_type.is_ptr() && !call_expr.left_type.is_ptr() {
+					c.error('method in `go` statement cannot have non-reference mutable receiver', call_expr.left.position())
+				}
+			}
 		}
 		// ast.HashStmt {}
 		ast.Import {}

--- a/vlib/v/checker/tests/go_mut_arg.out
+++ b/vlib/v/checker/tests/go_mut_arg.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/go_mut_arg.v:14:16: error: function in `go` statement cannot contain mutable non-reference arguments 
+   12 |         a: 0
+   13 |     }
+   14 |     go change(mut x)
+      |                   ^
+   15 | }

--- a/vlib/v/checker/tests/go_mut_arg.vv
+++ b/vlib/v/checker/tests/go_mut_arg.vv
@@ -1,0 +1,15 @@
+struct St {
+mut:
+	a int
+}
+
+fn change(mut a St) {
+	a.a++
+}
+
+fn main() {
+	mut x := St{
+		a: 0
+	}
+	go change(mut x)
+}

--- a/vlib/v/checker/tests/go_mut_receiver.out
+++ b/vlib/v/checker/tests/go_mut_receiver.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/go_mut_receiver.v:14:5: error: method in `go` statement cannot have non-reference mutable receiver 
+   12 |         a: 0
+   13 |     }
+   14 |     go x.change()
+      |        ^
+   15 | }

--- a/vlib/v/checker/tests/go_mut_receiver.vv
+++ b/vlib/v/checker/tests/go_mut_receiver.vv
@@ -1,0 +1,15 @@
+struct St {
+mut:
+	a int
+}
+
+fn (mut a St) change() {
+	a.a++
+}
+
+fn main() {
+	mut x := St{
+		a: 0
+	}
+	go x.change()
+}


### PR DESCRIPTION
This PR is based on original ideas by @emily33901 discussed in #5450 and #5061 

In  case of a `mut` argument or a `mut` receiver of a `go` function the V compiler has produced illegal `C` code if that `mut` object is no reference by itself. This PR fixes the issue by forbidding these cases.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
