### PR TITLE
sync.atomic: own submodule for atomic

### DIFF
--- a/vlib/sync/atomic2/atomic.v
+++ b/vlib/sync/atomic2/atomic.v
@@ -1,4 +1,4 @@
-module sync
+module atomic2
 
 /*
 Implements the atomic operations. For now TCC does not support

--- a/vlib/sync/atomic2/atomic_test.v
+++ b/vlib/sync/atomic2/atomic_test.v
@@ -19,16 +19,16 @@ fn test_count_100_milion_should_result_100_million() {
 }
 
 // This test just to make sure that we have an anti-test to prove it works
-fn test_count_100_milion_should_fail_100_million_without_sync() {
-	mut wg := sync.new_waitgroup()
-	mut counter := &Counter{}
-	wg.add(10)
-	for i := 0; i < 10; i++ {
-		go count_ten_million_without_sync(mut counter, mut wg)
-	}
-	wg.wait()
-	assert counter.counter != 10000000
-}
+// fn test_count_100_milion_should_fail_100_million_without_sync() {
+// 	mut wg := sync.new_waitgroup()
+// 	mut counter := &Counter{}
+// 	wg.add(10)
+// 	for i := 0; i < 10; i++ {
+// 		go count_ten_million_without_sync(mut counter, mut wg)
+// 	}
+// 	wg.wait()
+// 	assert counter.counter != 10000000
+// }
 
 fn test_count_plus_one_u64() {
 	mut c := u64(0)
@@ -86,10 +86,10 @@ fn count_ten_million(mut counter Counter, mut group sync.WaitGroup) {
 	group.done()
 }
 
-// count_ten_million_without_sync counts the common counter 10 million times in none thread-safe way
-fn count_ten_million_without_sync(mut counter Counter, mut group sync.WaitGroup) {
-	for i := 0; i < 1000000; i++ {
-		counter.counter++
-	}
-	group.done()
-}
+// // count_ten_million_without_sync counts the common counter 10 million times in none thread-safe way
+// fn count_ten_million_without_sync(mut counter Counter, mut group sync.WaitGroup) {
+// 	for i := 0; i < 1000000; i++ {
+// 		counter.counter++
+// 	}
+// 	group.done()
+// }

--- a/vlib/sync/atomic2/atomic_test.v
+++ b/vlib/sync/atomic2/atomic_test.v
@@ -1,3 +1,4 @@
+import atomic2
 import sync
 
 struct Counter {
@@ -31,56 +32,56 @@ fn test_count_100_milion_should_fail_100_million_without_sync() {
 
 fn test_count_plus_one_u64() {
 	mut c := u64(0)
-	sync.add_u64(&c, 1)
+	atomic2.add_u64(&c, 1)
 	assert c == 1
 }
 
 fn test_count_plus_one_i64() {
 	mut c := i64(0)
-	sync.add_i64(&c, 1)
+	atomic2.add_i64(&c, 1)
 	assert c == 1
 }
 
 fn test_count_plus_greater_than_one_u64() {
 	mut c := u64(0)
-	sync.add_u64(&c, 10)
+	atomic2.add_u64(&c, 10)
 	assert c == 10
 }
 
 fn test_count_plus_greater_than_one_i64() {
 	mut c := i64(0)
-	sync.add_i64(&c, 10)
+	atomic2.add_i64(&c, 10)
 	assert c == 10
 }
 
 fn test_count_minus_one_u64() {
 	mut c := u64(1)
-	sync.sub_u64(&c, 1)
+	atomic2.sub_u64(&c, 1)
 	assert c == 0
 }
 
 fn test_count_minus_one_i64() {
 	mut c := i64(0)
-	sync.sub_i64(&c, 1)
+	atomic2.sub_i64(&c, 1)
 	assert c == -1
 }
 
 fn test_count_minus_greater_than_one_u64() {
 	mut c := u64(10)
-	sync.sub_u64(&c, 10)
+	atomic2.sub_u64(&c, 10)
 	assert c == 0
 }
 
 fn test_count_minus_greater_than_one_i64() {
 	mut c := i64(10)
-	sync.sub_i64(&c, 20)
+	atomic2.sub_i64(&c, 20)
 	assert c == -10
 }
 
 // count_ten_million counts the common counter 10 million times in thread-safe way
 fn count_ten_million(mut counter Counter, mut group sync.WaitGroup) {
 	for i := 0; i < 1000000; i++ {
-		sync.add_u64(&counter.counter, 1)
+		atomic2.add_u64(&counter.counter, 1)
 	}
 	group.done()
 }


### PR DESCRIPTION
Moved atomic functions to own module under sync.atomic2

It will be renamed to atomic after "compiler fix".

After fix the call will be `atomic.add_u64(&counter.counter, 1)`

Removed anti-tests cause in rare cases there are no problems with concurrency and we do not want failing tests cause of it. I commented it out for now cause it can be useful while developing.