### PR TITLE
map: cleanup useless `get2()` and `get3()`

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -267,7 +267,7 @@ fn (mut m map) ensure_extra_metas(probe_count u32) {
 	}
 }
 
-// Insert new element to the map. The element is inserted if its key is 
+// Insert new element to the map. The element is inserted if its key is
 // not equivalent to the key of any other element already in the container.
 // If the key already exists, its value is changed to the value of the new element.
 fn (mut m map) set(k string, value voidptr) {
@@ -309,9 +309,9 @@ fn (mut m map) expand() {
 	}
 }
 
-// A rehash is the reconstruction of the hash table: 
-// All the elements in the container are rearranged according 
-// to their hash value into the newly sized key-value container. 
+// A rehash is the reconstruction of the hash table:
+// All the elements in the container are rearranged according
+// to their hash value into the newly sized key-value container.
 // Rehashes are performed when the load_factor is going to surpass
 // the max_load_factor in an operation.
 fn (mut m map) rehash() {
@@ -329,7 +329,7 @@ fn (mut m map) rehash() {
 }
 
 // This method works like rehash. However, instead of rehashing the
-// key completely, it uses the bits cached in `metas`. 
+// key completely, it uses the bits cached in `metas`.
 fn (mut m map) cached_rehash(old_cap u32) {
 	old_metas := m.metas
 	m.metas = &u32(vcalloc(int(sizeof(u32) * (m.cap + 2 + m.extra_metas))))
@@ -354,7 +354,7 @@ fn (mut m map) cached_rehash(old_cap u32) {
 
 // This method is used for assignment operators. If the argument-key
 // does not exist in the map, it's added to the map along with the zero/dafault value.
-// If the key exists, its respective value is returned. 
+// If the key exists, its respective value is returned.
 fn (mut m map) get_and_set(key string, zero voidptr) voidptr {
 	for {
 		mut index,mut meta := m.key_to_index(key)
@@ -369,16 +369,12 @@ fn (mut m map) get_and_set(key string, zero voidptr) voidptr {
 			meta += probe_inc
 			if meta > m.metas[index] { break }
 		}
-		// Key not found, insert key with zero-value 
+		// Key not found, insert key with zero-value
 		m.set(key, zero)
 	}
 }
-// Delete this (was used for bootstrap)
-fn (mut m map) get2(key string, zero voidptr) voidptr {
-	return m.get_and_set(key, zero)
-}
 
-// If `key` matches the key of an element in the container, 
+// If `key` matches the key of an element in the container,
 // the method returns a reference to its mapped value.
 // If not, a zero/default value is returned.
 fn (m map) get(key string, zero voidptr) voidptr {
@@ -395,10 +391,6 @@ fn (m map) get(key string, zero voidptr) voidptr {
 		if meta > m.metas[index] { break }
 	}
 	return zero
-}
-// Delete this (was used for bootstrap)
-fn (m map) get3(key string, zero voidptr) voidptr {
-	return m.get(key, zero)
 }
 
 // Checks whether a particular key exists in the map.


### PR DESCRIPTION
This PR cleanup useless `get2()` and `get3()` in map.v.