### PR TITLE
cgen,map: Fix leaks in keys() and for x in y construct

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -448,7 +448,7 @@ pub fn (mut m map) delete(key string) {
 // Returns all keys in the map.
 // TODO: add optimization in case of no deletes
 pub fn (m &map) keys() []string {
-	mut keys := [''].repeat(m.len)
+	mut keys := []string{ len:m.len }
 	mut j := 0
 	for i := u32(0); i < m.key_values.len; i++ {
 		if m.key_values.keys[i].str == 0 {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -841,8 +841,10 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 			g.writeln(', $key, &($val_styp[]){ $zero }));')
 		}
 		g.stmts(it.stmts)
+		g.writeln('/* for in map cleanup*/ string_free(&$key);')
 		g.writeln('}')
-		g.writeln('array_free(&$keys_tmp)')
+		g.writeln('/*for in map cleanup*/')
+		g.writeln('array_free(&$keys_tmp);')
 	} else if it.cond_type.has_flag(.variadic) {
 		g.writeln('// FOR IN cond_type/variadic')
 		i := if it.key_var in ['', '_'] { g.new_tmp_var() } else { it.key_var }

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -842,6 +842,7 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		}
 		g.stmts(it.stmts)
 		g.writeln('}')
+		g.writeln('array_free(&$keys_tmp)')
 	} else if it.cond_type.has_flag(.variadic) {
 		g.writeln('// FOR IN cond_type/variadic')
 		i := if it.key_var in ['', '_'] { g.new_tmp_var() } else { it.key_var }


### PR DESCRIPTION
keys was leaking an array temporary, so the `.repeat` construct has been replaced with an array initialisation.

`for x in y` was not cleaning up its temporary keys array and any of the keys in it when it was being generated. This has been fixed.