### PR TITLE
gitignore: git ignore symlink dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,7 @@ cachegrind.out.*
 .DS_Store
 ._*
 thumbs.db
-/.symlink/*
-/.bin/*
+/.symlink
+/.bin
 
 _docs


### PR DESCRIPTION
This PR ignore symlink dir in `.gitignore`.

- Ignore `/.symlink` dir on nix.
- Ignore `/.bin` dir on windows.