### PR TITLE
tests: add map['aa']+='str' test in map_test.v

### DIFF
--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -283,3 +283,10 @@ fn test_map_in_directly() {
 		assert v == 1
 	}
 }
+
+fn test_plus_assign_string() {
+	mut m := {'one': ''}
+	m['one'] += '1'
+	assert m.len == 1
+	assert m['one'] == '1'
+}


### PR DESCRIPTION
This PR add map['aa']+='str' test in map_test.v (#5545 fix this error).

```v
fn test_plus_assign_string() {
	mut m := {'one': ''}
	m['one'] += '1'
	assert m.len == 1
	assert m['one'] == '1'
}
```

