### PR TITLE
atof: fix is_space

### DIFF
--- a/vlib/strconv/atof.v
+++ b/vlib/strconv/atof.v
@@ -149,7 +149,7 @@ fn is_digit(x byte) bool {
 }
 
 fn is_space(x byte) bool {
-	return ((x >= 0x89 && x <= 0x13) || x == 0x20) == true
+	return (x == `\t` || x == `\n` || x == `\v` || x == `\f` || x == `\r` || x == ` `)
 }
 
 fn is_exp(x byte) bool {


### PR DESCRIPTION
This fixes overlapping comparisons in the `is_space` function. 

The following comparisons overlap and will always evaluate to false:
`(x >= 0x89 && x <= 0x13)`

I have conversed with the author (@penguindark) about the fix. 