### PR TITLE
vdoc: Add .vdocignore + minor fixes

### DIFF
--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -778,7 +778,11 @@ fn (cfg DocConfig) get_resource(name string, minify bool) string {
 	path := os.join_path(res_path, name)
 	mut res := os.read_file(path) or { panic('could not read $path') }
 	if minify {
-		res = if name.ends_with('.js') { js_compress(res) } else { res.replace('\n', ' ') }
+		if name.ends_with('.js') {
+			res = js_compress(res) 
+		} else { 
+			res = res.split_into_lines().map(it.trim_space()).join('')
+		}
 	}
 	// TODO: Make SVG inline for now
 	if cfg.inline_assets || path.ends_with('.svg') {

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -514,16 +514,17 @@ fn (cfg DocConfig) gen_plaintext(idx int) string {
 	dcs := cfg.docs[idx]
 	mut pw := strings.new_builder(200)
 	pw.writeln('${dcs.head.content}\n')
-	if dcs.head.comment.trim_space().len > 0 {
-		pw.writeln('// ' + dcs.head.comment.replace('\n', '\n// ') + '\n')
+	if dcs.head.comment.trim_space().len > 0 && !cfg.pub_only {
+		pw.writeln(dcs.head.comment.split_into_lines().map('    ' + it).join('\n'))
 	}
 	for cn in dcs.contents {
 		pw.writeln(cn.content)
-		if cn.comment.len > 0 {
-			pw.writeln('\/\/ ' + cn.comment.trim_space() + '\n')
+		if cn.comment.len > 0 && !cfg.pub_only {
+			pw.writeln(cn.comment.trim_space().split_into_lines().map('    ' + it).join('\n'))
 		}
 		if cfg.show_loc {
-			pw.writeln('Location: ${cn.file_path}:${cn.pos.line}:${cn.pos.col}\n\n')
+			pw.writeln('Location: ${cn.file_path}:${cn.pos.line}')
+			pw.write('\n')
 		}
 	}
 	return pw.str()

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -632,8 +632,7 @@ fn (mut cfg DocConfig) generate_docs_from_file() {
 		readme_contents := cfg.get_readme(dir_path)
         if cfg.output_type == .stdout {
 			println(markdown.to_plain(readme_contents))
-        }
-        if cfg.output_type == .html {
+        } else if cfg.output_type == .html && cfg.is_multi {
 			cfg.docs << doc.Doc{
 				head: doc.DocNode{
 					name: 'README',
@@ -660,7 +659,7 @@ fn (mut cfg DocConfig) generate_docs_from_file() {
 			exit(1)
 		}
 		if dcs.contents.len == 0 { continue }
-		if cfg.is_multi {
+		if cfg.is_multi || (!cfg.is_multi && cfg.include_readme) {
 			readme_contents := cfg.get_readme(dirpath)
 			dcs.head.comment = readme_contents
 		}

--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -353,14 +353,15 @@ fn doc_node_html(dd doc.DocNode, link string, head bool, tb &table.Table) string
 	head_tag := if head { 'h1' } else { 'h2' }
 	md_content := markdown.to_html(dd.comment)
 	hlighted_code := html_highlight(dd.content, tb)
-	is_const_class := if dd.name == 'Constants' { ' const' } else { '' }
-	mut sym_name := dd.name
-	if dd.attrs.exists('parent') && dd.attrs['parent'] !in ['void', '', 'Constants'] { 
-		sym_name = dd.attrs['parent'] + '.' + sym_name
+	node_class := if dd.name == 'Constants' { ' const' } else { '' }
+	sym_name := if dd.attrs.exists('parent') && dd.attrs['parent'] !in ['void', '', 'Constants'] { 
+		dd.attrs['parent'] + '.' + dd.name
+	} else {
+		dd.name
 	}
 	node_id := slug(sym_name)
 	hash_link := if !head { ' <a href="#$node_id">#</a>' } else { '' }
-	dnw.writeln('<section id="$node_id" class="doc-node$is_const_class">')
+	dnw.writeln('<section id="$node_id" class="doc-node$node_class">')
 	if dd.name != 'README' && dd.attrs['parent'] != 'Constants' {
 		dnw.write('<div class="title"><$head_tag>$sym_name$hash_link</$head_tag>')
 		if link.len != 0 {

--- a/cmd/v/help/doc.txt
+++ b/cmd/v/help/doc.txt
@@ -13,13 +13,17 @@ or Markdown format.
 Options:
   -all            Includes private and public functions/methods/structs/consts/enums.
   -f              Specifies the output format to be used.
-  -inline-assets  Embeds the contents of the CSS and JS assets into the webpage directly.
-  -l              Show the locations of the generated signatures. (For plaintext only)
   -m              Generate docs for modules listed in that folder.
-  -o              Specifies the output file/folder path where to store the generated docs.
+  -h, -help       Prints this help text.
+  -readme         Include README.md to docs if present.
+  -v              Enables verbose logging. For debugging purposes.
+
+For HTML mode:
+  -inline-assets  Embeds the contents of the CSS and JS assets into the webpage directly.
   -open           Launches the browser when the server docs has started.
   -p              Specifies the port to be used for the docs server.
   -s              Serve HTML-generated docs via HTTP.
-  -readme         Include README.md to docs if present.
-  -v              Enables verbose logging. For debugging purposes.
-  -h, -help       Prints this help text.
+
+For plain text mode:
+  -l              Show the locations of the generated signatures.
+  -o              Specifies the output file/folder path where to store the generated docs.

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -79,7 +79,7 @@ fn main_v() {
 			return
 		}
 		'vlib-docs' {
-			util.launch_tool(prefs.is_verbose, 'vdoc', ['doc', '-m', '-s', os.join_path(os.base_dir(@VEXE), 'vlib')])
+			util.launch_tool(prefs.is_verbose, 'vdoc', ['doc', 'vlib'])
 		}
 		'get' {
 			println('V Error: Use `v install` to install modules from vpm.vlang.io')

--- a/vlib/.vdocignore
+++ b/vlib/.vdocignore
@@ -1,0 +1,11 @@
+builtin/bare
+builtin/js
+oldgg/
+os/bare
+os2/
+uiold/
+v/tests/
+v/checker/tests/
+v/gen/js/
+v/gen/x64/
+v/gen/tests/

--- a/vlib/.vdocignore
+++ b/vlib/.vdocignore
@@ -3,6 +3,7 @@ builtin/js
 oldgg/
 os/bare
 os2/
+net/websocket/examples
 uiold/
 v/tests/
 v/checker/tests/

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -127,6 +127,7 @@ pub fn read_file(path string) ?string {
 }
 
 /***************************** Utility  ops ************************/
+
 pub fn (mut f File) flush() {
 	if !f.opened {
 		return

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -376,6 +376,9 @@ fn (mut d Doc) generate() ?Doc {
 			}
 			if stmt is ast.FnDecl {
 				fnd := stmt as ast.FnDecl
+				if fnd.is_deprecated {
+					continue
+				}
 				if fnd.receiver.typ != 0 {
 					node.attrs['parent'] = d.fmt.type_to_str(fnd.receiver.typ).trim_left('&')
 					p_idx := d.contents.index_by_name(node.attrs['parent'])


### PR DESCRIPTION
- Ignore deprecated functions.
- Make `builtin` use `index.html` instead.
- Add ability to ignore specific directories via `.vdocignore`. Remove hard-coded list.
- Update help text.
- Fix gen HTML when included readme in single module mode.
- Improve file minification.
- Point `v vlib-docs` to `v docs vlib`.