### PR TITLE
parser: check block syntax (use `xxx {`)

### DIFF
--- a/vlib/v/parser/tests/block_syntax_fn_warning.out
+++ b/vlib/v/parser/tests/block_syntax_fn_warning.out
@@ -1,0 +1,6 @@
+vlib/v/parser/tests/block_syntax_fn_warning.v:2:1: warning: syntax error, should use `xxx {`
+    1 | fn main()
+    2 | {
+      | ^
+    3 |     println('hello, world')
+    4 | }

--- a/vlib/v/parser/tests/block_syntax_fn_warning.vv
+++ b/vlib/v/parser/tests/block_syntax_fn_warning.vv
@@ -1,0 +1,4 @@
+fn main()
+{
+	println('hello, world')
+}

--- a/vlib/v/parser/tests/block_syntax_for_warning.out
+++ b/vlib/v/parser/tests/block_syntax_for_warning.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/block_syntax_for_warning.v:3:2: warning: syntax error, should use `xxx {`
+    1 | fn main() {
+    2 |     for i in 0..5
+    3 |     {
+      |     ^
+    4 |         println(i)
+    5 |     }

--- a/vlib/v/parser/tests/block_syntax_for_warning.vv
+++ b/vlib/v/parser/tests/block_syntax_for_warning.vv
@@ -1,0 +1,6 @@
+fn main() {
+	for i in 0..5
+	{
+		println(i)
+	}
+}

--- a/vlib/v/parser/tests/block_syntax_if_warning.out
+++ b/vlib/v/parser/tests/block_syntax_if_warning.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/block_syntax_if_warning.v:4:2: warning: syntax error, should use `xxx {`
+    2 |     a := 1
+    3 |     if a > 0
+    4 |     {
+      |     ^
+    5 |         println('hello, world')
+    6 |     }

--- a/vlib/v/parser/tests/block_syntax_if_warning.vv
+++ b/vlib/v/parser/tests/block_syntax_if_warning.vv
@@ -1,0 +1,7 @@
+fn main() {
+	a := 1
+	if a > 0
+	{
+		println('hello, world')
+	}
+}


### PR DESCRIPTION
This PR check block syntax (use `xxx {`).

- Check block syntax (use `xxx {`).
- Add tests.

```v
D:\test\v\tt1>v run .
.\tt1.v:4:2: warning: syntax error, should use `xxx {` 
    2 |     a := 1
    3 |     if a > 0
    4 |     {
      |     ^
    5 |         println('text')
    6 |     } else if a == 0 {
text
```
```v
D:\test\v\tt1>v run .
.\tt1.v:2:1: warning: syntax error, should use `xxx {` 
    1 | fn main()
    2 | {
      | ^
    3 |     println('hello, world')
    4 | }
hello, world
```
```v
D:\test\v\tt1>v run .
.\tt1.v:3:2: warning: syntax error, should use `xxx {` 
    1 | fn main() {
    2 |     for i in 0..10
    3 |     {
      |     ^
    4 |         println(i)
    5 |     }
```