### PR TITLE
[docs] General tweaks

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -254,7 +254,7 @@ fn main() {
 }
 ```
 
-### Errors
+### Declaration errors
 
 In development mode the compiler will warn you that you haven't used the variable (you'll get an "unused variable" warning).
 In production mode (enabled by passing the `-prod` flag to v – `v -prod foo.v`) it will not compile at all (like in Go).


### PR DESCRIPTION
* Fix typos, tweak wording
* Add 'Declaration errors' subheading under 'Variables' (not in TOC)
* Tweak for/in array index assign example
* Add link to 'references'
* Mention `_` identifier is ignored
* Mention `--enable-globals` flag
* Add subheading 'Mutable arguments'
* Move `Color.str()` function to println example (it distracts from
  the constants example)
* Remove unused `CallExpr` struct