### PR TITLE
Add html() content-type method to picohttpparser

### DIFF
--- a/vlib/picohttpparser/response.v
+++ b/vlib/picohttpparser/response.v
@@ -47,6 +47,12 @@ pub fn (mut r Response) content_type(s string) &Response {
 }
 
 [inline]
+pub fn (mut r Response) html() &Response {
+	r.buf += cpy_str(r.buf, "Content-Type: text/html\r\n")
+	return r
+}
+
+[inline]
 pub fn (mut r Response) plain() &Response {
 	r.buf += cpy_str(r.buf, "Content-Type: text/plain\r\n")
 	return r


### PR DESCRIPTION
Hi!

I wanted to try Pico (because of [this](https://www.techempower.com/benchmarks/#section=data-r19&hw=ph&test=plaintext)). I noticed there were `json()` and `plain()` methods already in `Response`, so I felt it would be nice to have `html()` out-of-the-box too 😊

If this doesn't match your vision, I am very sorry and will close the pull request right away.

Thank you for your time 🙇🏼‍♀️