### PR TITLE
builtin/string: Fix trim_prefix and trim_suffix methods

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -921,14 +921,14 @@ pub fn (s string) trim_right(cutset string) string {
 
 pub fn (s string) trim_prefix(str string) string {
 	if s.starts_with(str) {
-		return s.replace(str, "")
+		return s[str.len..]
 	}
 	return s
 }
 
 pub fn (s string) trim_suffix(str string) string {
 	if s.ends_with(str) {
-		return s.replace(str, "")
+		return s[..s.len-str.len]
 	}
 	return s
 }

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -669,6 +669,14 @@ fn test_trim_prefix() {
 	assert s.trim_prefix('V ') == 'Programming Language'
 	assert s.trim_prefix('V Programming ') == 'Language'
 	assert s.trim_prefix('Language') == s
+
+	s2 := 'TestTestTest'
+	assert s2.trim_prefix('Test') == 'TestTest'
+	assert s2.trim_prefix('TestTest') == 'Test'
+
+	s3 := '123Test123Test'
+	assert s3.trim_prefix('123') == 'Test123Test'
+	assert s3.trim_prefix('123Test') == '123Test'
 }
 
 fn test_trim_suffix() {
@@ -676,6 +684,14 @@ fn test_trim_suffix() {
 	assert s.trim_suffix(' Language') == 'V Programming'
 	assert s.trim_suffix(' Programming Language') == 'V'
 	assert s.trim_suffix('V') == s
+
+	s2 := 'TestTestTest'
+	assert s2.trim_suffix('Test') == 'TestTest'
+	assert s2.trim_suffix('TestTest') == 'Test'
+
+	s3 := '123Test123Test'
+	assert s3.trim_suffix('123') == s3
+	assert s3.trim_suffix('123Test') == '123Test'
 }
 
 fn test_raw() {


### PR DESCRIPTION
I think I've stumbled upon [a rather critical issue](https://twitter.com/nyaascii/status/1277755410053767168) with `trim_prefix` and `trim_suffix`, so there is a fix for it. I've tested my _solution_ and now it works, and I also wrote a few new tests for this particular case 😊

Thank you for your time 🙇‍♀️ 