### PR TITLE
checker: check if mut function arg is declared as mut

### DIFF
--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -155,7 +155,7 @@ fn (mut cfg DocConfig) serve_html() {
 		default_filename: def_name
 	}
 	for {
-		con := server.accept() or {
+		mut con := server.accept() or {
 			server.close() or { }
 			panic(err)
 		}

--- a/vlib/crypto/aes/aes.v
+++ b/vlib/crypto/aes/aes.v
@@ -16,6 +16,7 @@ pub const (
 
 // A cipher is an instance of AES encryption using a particular key.
 struct AesCipher {
+mut:
 	enc []u32
 	dec []u32
 }
@@ -40,7 +41,7 @@ pub fn new_cipher(key []byte) AesCipher {
 
 pub fn (c &AesCipher) block_size() int { return block_size }
 
-pub fn (c &AesCipher) encrypt(dst, src []byte) {
+pub fn (c &AesCipher) encrypt(mut dst []byte, mut src []byte) {
 	if src.len < block_size {
 		panic('crypto.aes: input not full block')
 	}
@@ -48,23 +49,23 @@ pub fn (c &AesCipher) encrypt(dst, src []byte) {
 		panic('crypto.aes: output not full block')
 	}
 	// if subtle.inexact_overlap(dst[:block_size], src[:block_size]) {
-	if subtle.inexact_overlap(dst[..block_size], src[..block_size]) {
+	if subtle.inexact_overlap((*dst)[..block_size], (*src)[..block_size]) {
 		panic('crypto.aes: invalid buffer overlap')
 	}
 	// for now use generic version
-	encrypt_block_generic(c.enc, dst, src)
+	encrypt_block_generic(c.enc, mut dst, src)
 }
 
-pub fn (c &AesCipher) decrypt(dst, src []byte) {
+pub fn (c &AesCipher) decrypt(mut dst []byte, mut src []byte) {
 	if src.len < block_size {
 		panic('crypto.aes: input not full block')
 	}
 	if dst.len < block_size {
 		panic('crypto.aes: output not full block')
 	}
-	if subtle.inexact_overlap(dst[..block_size], src[..block_size]) {
+	if subtle.inexact_overlap((*dst)[..block_size], (*src)[..block_size]) {
 		panic('crypto.aes: invalid buffer overlap')
 	}
 	// for now use generic version
-	decrypt_block_generic(c.dec, dst, src)
+	decrypt_block_generic(c.dec, mut dst, src)
 }

--- a/vlib/crypto/aes/aes_cbc.v
+++ b/vlib/crypto/aes/aes_cbc.v
@@ -54,7 +54,7 @@ pub fn (x &AesCbc) encrypt_blocks(mut dst []byte, src_ []byte) {
 	if dst.len < src.len {
 		panic('crypto.cipher: output smaller than input')
 	}
-	if subtle.inexact_overlap((*dst)[..src.len], src) {
+	if subtle.inexact_overlap((*dst)[..src.len], src_) {
 		panic('crypto.cipher: invalid buffer overlap')
 	}
 
@@ -63,7 +63,7 @@ pub fn (x &AesCbc) encrypt_blocks(mut dst []byte, src_ []byte) {
 	for src.len > 0 {
 		// Write the xor to dst, then encrypt in place.
 		cipher.xor_bytes(mut (*dst)[..x.block_size], src[..x.block_size], iv)
-		x.b.encrypt((*dst)[..x.block_size], (*dst)[..x.block_size])
+		x.b.encrypt(mut (*dst)[..x.block_size], mut (*dst)[..x.block_size])
 
 		// Move to the next block with this block as the next iv.
 		iv = (*dst)[..x.block_size]
@@ -104,7 +104,7 @@ pub fn (mut x AesCbc) decrypt_blocks(mut dst []byte, src []byte) {
 
 	// Loop over all but the first block.
 	for start > 0 {
-		x.b.decrypt((*dst).slice(start, end), src.slice(start, end))
+		x.b.decrypt(mut (*dst).slice(start, end), mut src.slice(start, end))
 		cipher.xor_bytes(mut (*dst).slice(start, end), (*dst).slice(start, end), src.slice(prev, start))
 
 		end = start
@@ -113,7 +113,7 @@ pub fn (mut x AesCbc) decrypt_blocks(mut dst []byte, src []byte) {
 	}
 
 	// The first block is special because it uses the saved iv.
-	x.b.decrypt((*dst).slice(start, end), src.slice(start, end))
+	x.b.decrypt(mut (*dst).slice(start, end), mut src.slice(start, end))
 	cipher.xor_bytes(mut (*dst).slice(start, end), (*dst).slice(start, end), x.iv)
 
 

--- a/vlib/crypto/aes/block_generic.v
+++ b/vlib/crypto/aes/block_generic.v
@@ -40,7 +40,7 @@ module aes
 import encoding.binary
 
 // Encrypt one block from src into dst, using the expanded key xk.
-fn encrypt_block_generic(xk []u32, dst, src []byte) {
+fn encrypt_block_generic(xk []u32, mut dst []byte, src []byte) {
 	_ = src[15] // early bounds check
 	mut s0 := binary.big_endian_u32(src[..4])
 	mut s1 := binary.big_endian_u32(src.slice(4, 8))
@@ -85,16 +85,16 @@ fn encrypt_block_generic(xk []u32, dst, src []byte) {
 	s3 ^= xk[k+3]
 
 	_ := dst[15] // early bounds check
-	binary.big_endian_put_u32(mut dst[..4], s0)
-	binary.big_endian_put_u32(mut dst.slice(4, 8), s1)
-	binary.big_endian_put_u32(mut dst.slice(8, 12), s2)
-	binary.big_endian_put_u32(mut dst.slice(12, 16), s3)
+	binary.big_endian_put_u32(mut (*dst)[0..4], s0)
+	binary.big_endian_put_u32(mut (*dst).slice(4, 8), s1)
+	binary.big_endian_put_u32(mut (*dst).slice(8, 12), s2)
+	binary.big_endian_put_u32(mut (*dst).slice(12, 16), s3)
 }
 
 // Decrypt one block from src into dst, using the expanded key xk.
-fn decrypt_block_generic(xk []u32, dst, src []byte) {
+fn decrypt_block_generic(xk []u32, mut dst []byte, src []byte) {
 	_ = src[15] // early bounds check
-	mut s0 := binary.big_endian_u32(src[..4])
+	mut s0 := binary.big_endian_u32(src[0..4])
 	mut s1 := binary.big_endian_u32(src.slice(4, 8))
 	mut s2 := binary.big_endian_u32(src.slice(8, 12))
 	mut s3 := binary.big_endian_u32(src.slice(12, 16))
@@ -137,10 +137,10 @@ fn decrypt_block_generic(xk []u32, dst, src []byte) {
 	s3 ^= xk[k+3]
 
 	_ = dst[15] // early bounds check
-	binary.big_endian_put_u32(mut dst[..4], s0)
-	binary.big_endian_put_u32(mut dst.slice(4, 8), s1)
-	binary.big_endian_put_u32(mut dst.slice(8, 12), s2)
-	binary.big_endian_put_u32(mut dst.slice(12, 16), s3)
+	binary.big_endian_put_u32(mut (*dst)[..4], s0)
+	binary.big_endian_put_u32(mut (*dst).slice(4, 8), s1)
+	binary.big_endian_put_u32(mut (*dst).slice(8, 12), s2)
+	binary.big_endian_put_u32(mut (*dst).slice(12, 16), s3)
 }
 
 // Apply s_box0 to each byte in w.

--- a/vlib/crypto/internal/subtle/aliasing.v
+++ b/vlib/crypto/internal/subtle/aliasing.v
@@ -26,7 +26,7 @@ pub fn any_overlap(x, y []byte) bool {
 //
 // inexact_overlap can be used to implement the requirements of the crypto/cipher
 // AEAD, Block, BlockMode and Stream interfaces.
-pub fn inexact_overlap(x, y []byte) bool {
+pub fn inexact_overlap(x []byte, y []byte) bool {
 	if x.len == 0 || y.len == 0 || &x[0] == &y[0] {
 		return false
 	}

--- a/vlib/crypto/internal/subtle/aliasing.v
+++ b/vlib/crypto/internal/subtle/aliasing.v
@@ -26,7 +26,7 @@ pub fn any_overlap(x, y []byte) bool {
 //
 // inexact_overlap can be used to implement the requirements of the crypto/cipher
 // AEAD, Block, BlockMode and Stream interfaces.
-pub fn inexact_overlap(x []byte, y []byte) bool {
+pub fn inexact_overlap(x, y []byte) bool {
 	if x.len == 0 || y.len == 0 || &x[0] == &y[0] {
 		return false
 	}

--- a/vlib/crypto/md5/md5.v
+++ b/vlib/crypto/md5/md5.v
@@ -117,7 +117,7 @@ pub fn (mut d Digest) checksum() []byte {
 		panic('d.nx != 0')
 	}
 
-    digest := []byte{len:(size)}
+	mut digest := []byte{len:(size)}
 
 	binary.little_endian_put_u32(mut digest, d.s[0])
 	binary.little_endian_put_u32(mut digest[4..], d.s[1])

--- a/vlib/crypto/rc4/rc4.v
+++ b/vlib/crypto/rc4/rc4.v
@@ -59,7 +59,7 @@ pub fn (mut c Cipher) reset() {
 
 // xor_key_stream sets dst to the result of XORing src with the key stream.
 // Dst and src must overlap entirely or not at all.
-pub fn (mut c Cipher) xor_key_stream(mut dst []byte, src []byte) {
+pub fn (mut c Cipher) xor_key_stream(mut dst, src []byte) {
 	if src.len == 0 {
 		return
 	}

--- a/vlib/crypto/sha256/sha256.v
+++ b/vlib/crypto/sha256/sha256.v
@@ -161,7 +161,7 @@ fn (mut d Digest) checksum() []byte {
 		panic('d.nx != 0')
 	}
 
-	digest := []byte{len:(size)}
+	mut digest := []byte{len:(size)}
 
 	binary.big_endian_put_u32(mut digest, d.h[0])
 	binary.big_endian_put_u32(mut digest[4..], d.h[1])

--- a/vlib/v/checker/tests/immutable_arg.out
+++ b/vlib/v/checker/tests/immutable_arg.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/immutable_arg.v:13:8: error: `a` is immutable, declare it with `mut` to make it mutable 
+   11 | fn main() {
+   12 |     a := St{e: 2}
+   13 |     f(mut a)
+      |           ^
+   14 | }

--- a/vlib/v/checker/tests/immutable_arg.vv
+++ b/vlib/v/checker/tests/immutable_arg.vv
@@ -1,0 +1,14 @@
+struct St {
+mut:
+	e int
+}
+
+fn f(mut x St) {
+	x.e++
+	println(x)
+}
+
+fn main() {
+	a := St{e: 2}
+	f(mut a)
+}

--- a/vlib/v/checker/tests/immutable_rec.out
+++ b/vlib/v/checker/tests/immutable_rec.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/immutable_rec.v:13:2: error: `a` is immutable, declare it with `mut` to make it mutable 
+   11 | fn main() {
+   12 |     a := St{e: 2}
+   13 |     a.f()
+      |     ^
+   14 | }

--- a/vlib/v/checker/tests/immutable_rec.vv
+++ b/vlib/v/checker/tests/immutable_rec.vv
@@ -1,0 +1,14 @@
+struct St {
+mut:
+	e int
+}
+
+fn (mut x St) f() {
+	x.e++
+	println(x)
+}
+
+fn main() {
+	a := St{e: 2}
+	a.f()
+}

--- a/vlib/v/tests/generics_test.v
+++ b/vlib/v/tests/generics_test.v
@@ -77,7 +77,7 @@ fn mut_arg2<T>(mut x T) T {
 fn test_create() {
 	create<User>()
 	create<City>()
-	u := User{}
+	mut u := User{}
 	mut_arg<User>(mut u)
 	mut_arg2<User>(mut u)
 }


### PR DESCRIPTION
When a function is called as `f(mut x)` is has not been checked if `x` has been declared as `mut`. This PR adds a call to `c.fail_if_immutable()` for the args and adds a `mut` to variable declarations where necessary.

Test cases for this case and for a `mut` receiver (which has already been checked before) have been added.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
