### PR TITLE
vschannel: fix `net` segfault on Windows

### DIFF
--- a/thirdparty/vschannel/vschannel.c
+++ b/thirdparty/vschannel/vschannel.c
@@ -279,7 +279,7 @@ static INT connect_to_server(TlsContext *tls_ctx, LPWSTR host, INT port_number) 
 	WCHAR service_name[10];
 	int res = wsprintf(service_name, L"%d", port_number);
 
-	if(WSAConnectByNameA(Socket,connect_name, service_name, &local_address_length, 
+	if(WSAConnectByNameW(Socket,connect_name, service_name, &local_address_length, 
 		&local_address, &remote_address_length, &remote_address, &tv, NULL) == SOCKET_ERROR) {
 		wprintf(L"Error %d connecting to \"%s\" (%s)\n", 
 			WSAGetLastError(),


### PR DESCRIPTION
This PR fixes `vschannel` on Windows, which was using the ANSI version of `WSAConnectByName` rather than the Unicode version.

Closes a bunch of issues:
 - closes #5574
 - closes #5502 
 - closes #5448 
 - closes vlang/ui#164
 - closes vlang/vpm#9
