### PR TITLE
cgen: fix array_push for_in keys (fix #5562)

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -877,3 +877,12 @@ fn test_plus_assign_string() {
 	a[0] += 'abc'
 	assert a == ['abc']
 }
+
+fn test_push_for_in_keys() {
+	m := {'a': 'b', 'c': 'd'}
+	mut arr := []string{}
+	for k, _ in m {
+		arr << k
+	}
+	assert arr == ['a', 'c']
+}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -683,7 +683,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 					println('build module `$g.module_built` fn `$node.name`')
 				}
 			}
-			keep_fn_decl := g.fn_decl            
+			keep_fn_decl := g.fn_decl
 			g.fn_decl = node
 			if node.name == 'main.main' {
 				g.has_main = true
@@ -1864,7 +1864,13 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 			if elem_sym.kind == .interface_ && node.right_type != info.elem_type {
 				g.interface_call(node.right_type, info.elem_type)
 			}
-			g.expr_with_cast(node.right, node.right_type, info.elem_type)
+			if elem_sym.kind == .string {
+				g.write('string_clone(')
+				g.expr_with_cast(node.right, node.right_type, info.elem_type)
+				g.write(')')
+			} else {
+				g.expr_with_cast(node.right, node.right_type, info.elem_type)
+			}
 			if elem_sym.kind == .interface_ && node.right_type != info.elem_type {
 				g.write(')')
 			}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1864,7 +1864,7 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 			if elem_sym.kind == .interface_ && node.right_type != info.elem_type {
 				g.interface_call(node.right_type, info.elem_type)
 			}
-			if elem_sym.kind == .string {
+			if elem_sym.kind == .string && node.right !is ast.StringLiteral {
 				g.write('string_clone(')
 				g.expr_with_cast(node.right, node.right_type, info.elem_type)
 				g.write(')')


### PR DESCRIPTION
This PR fix array_push for_in keys (fix #5562).

- Fix array_push for_in keys.
- Add test `test_push_for_in_keys()` in array_test.v.

```v
fn main() {
	m := {'a': 'b', 'c': 'd'}
	mut arr := []string{}
	for k, _ in m {
		arr << k
	}
	println(arr)
}

D:\test\v\tt1>v run .
['a', 'c']
```