### PR TITLE
cgen: fix map cross assign (fix #5593)

### DIFF
--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -303,3 +303,10 @@ fn test_map_keys_to_array() {
 	assert sarr == "['a', 'c']"
 }
 
+fn test_map_cross_assign() {
+	mut a := {'one':1, 'two':2}
+	a['one'], a['two'] = a['two'], a['one']
+	println(a)
+	assert a['one'] == 2
+	assert a['two'] == 1
+}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1099,6 +1099,15 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 						g.write(', ')
 						g.expr(it.index)
 						g.writeln(');')
+					} else if sym.kind == .map {
+						info := sym.info as table.Map
+						styp := g.typ(info.value_type)
+						zero := g.type_default(info.value_type)
+						g.write('$styp _var_$left.pos.pos = *($styp*)map_get(')
+						g.expr(it.left)
+						g.write(', ')
+						g.expr(it.index)
+						g.writeln(', &($styp[]){ $zero });')
 					}
 				}
 				else {}


### PR DESCRIPTION
This PR fix map cross assign (fix #5593).

- Fix map cross assign.
- Add test `test_map_cross_assign()` in map_test.v.

```v
fn main() {
	mut a := {'one':1, 'two':2}
	a['one'], a['two'] = a['two'], a['one']
	println(a)
}

D:\test\v\tt1>v run .
{'one': 2, 'two': 1}
```