### PR TITLE
assign: optimize cross assign using expr.str()

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -410,7 +410,6 @@ pub:
 pub struct IndexExpr {
 pub:
 	pos       token.Position
-	expr      string // a[0] m['a'] etc
 	left      Expr
 	index     Expr // [0], [start..end] etc
 pub mut:

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1307,13 +1307,10 @@ fn (mut g Gen) gen_cross_tmp_variable(left []ast.Expr, val ast.Expr) {
 		ast.IndexExpr {
 			mut has_var := false
 			for lx in left {
-				if lx is ast.IndexExpr {
-					inx := lx as ast.IndexExpr
-					if val.expr == inx.expr {
-						g.write('_var_$inx.pos.pos')
-						has_var = true
-						break
-					}
+				if val_.str() == lx.str() {
+					g.write('_var_${lx.position().pos}')
+					has_var = true
+					break
 				}
 			}
 			if !has_var {

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -44,12 +44,13 @@ fn (mut p Parser) check_undefined_variables(exprs []ast.Expr, val ast.Expr) {
 }
 
 fn (mut p Parser) check_cross_variables(exprs []ast.Expr, val ast.Expr) bool {
-	match val {
+	val_ := val
+	match val_ {
 		ast.Ident {
 			for expr in exprs {
 				if expr is ast.Ident {
 					ident := expr as ast.Ident
-					if ident.name == val.name {
+					if ident.name == val_.name {
 						return true
 					}
 				}
@@ -57,17 +58,14 @@ fn (mut p Parser) check_cross_variables(exprs []ast.Expr, val ast.Expr) bool {
 		}
 		ast.IndexExpr {
 			for expr in exprs {
-				if expr is ast.IndexExpr {
-					idx := expr as ast.IndexExpr
-					if idx.expr == val.expr {
-						return true
-					}
+				if expr.str() == val.str() {
+					return true
 				}
 			}
 		}
-		ast.InfixExpr { return p.check_cross_variables(exprs, val.left) || p.check_cross_variables(exprs, val.right) }
-		ast.PrefixExpr { return p.check_cross_variables(exprs, val.right) }
-		ast.PostfixExpr { return p.check_cross_variables(exprs, val.expr) }
+		ast.InfixExpr { return p.check_cross_variables(exprs, val_.left) || p.check_cross_variables(exprs, val_.right) }
+		ast.PrefixExpr { return p.check_cross_variables(exprs, val_.right) }
+		ast.PostfixExpr { return p.check_cross_variables(exprs, val_.expr) }
 		else {}
 	}
 	return false

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -985,12 +985,10 @@ fn (mut p Parser) index_expr(left ast.Expr) ast.IndexExpr {
 		}
 	}
 	// [expr]
-	end := p.tok.position()
 	p.check(.rsbr)
 	return ast.IndexExpr{
 		left: left
 		index: expr
-		expr: p.scanner.expr_string(left.position(), end).replace(' ', '')
 		pos: p.tok.position()
 	}
 }

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1379,7 +1379,3 @@ pub fn (mut s Scanner) codegen(newtext string) {
 		}
 	}
 }
-
-pub fn (s Scanner) expr_string(start, end token.Position) string {
-	return s.text[start.pos..end.pos].trim_space()
-}


### PR DESCRIPTION
This PR optimize cross assign using expr.str().

- Remove `expr` in ast.IndexExpr.
- Remove `expr_string()` in scanner.v.
- Using expr.str().