### PR TITLE
cgen: fix cross assign of struct fields (fix #5594)

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1108,6 +1108,12 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 						g.writeln(', &($styp[]){ $zero });')
 					}
 				}
+				ast.SelectorExpr {
+					styp := g.typ(left.typ)
+					g.write('$styp _var_$left.pos.pos = ')
+					g.expr(left.expr)
+					g.writeln('.$left.field_name;')
+				}
 				else {}
 			}
 		}
@@ -1330,6 +1336,19 @@ fn (mut g Gen) gen_cross_tmp_variable(left []ast.Expr, val ast.Expr) {
 		ast.PostfixExpr {
 			g.gen_cross_tmp_variable(left, val.expr)
 			g.write(val.op.str())
+		}
+		ast.SelectorExpr {
+			mut has_var := false
+			for lx in left {
+				if val_.str() == lx.str() {
+					g.write('_var_${lx.position().pos}')
+					has_var = true
+					break
+				}
+			}
+			if !has_var {
+				g.expr(val_)
+			}
 		}
 		else {
 			g.expr(val_)

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -66,6 +66,13 @@ fn (mut p Parser) check_cross_variables(exprs []ast.Expr, val ast.Expr) bool {
 		ast.InfixExpr { return p.check_cross_variables(exprs, val_.left) || p.check_cross_variables(exprs, val_.right) }
 		ast.PrefixExpr { return p.check_cross_variables(exprs, val_.right) }
 		ast.PostfixExpr { return p.check_cross_variables(exprs, val_.expr) }
+		ast.SelectorExpr {
+			for expr in exprs {
+				if expr.str() == val.str() {
+					return true
+				}
+			}
+		}
 		else {}
 	}
 	return false

--- a/vlib/v/tests/struct_test.v
+++ b/vlib/v/tests/struct_test.v
@@ -313,3 +313,17 @@ fn test_struct_with_default_values_no_init() {
 	assert s2.field_optional == 3
 	assert s3.field_optional == 2
 }
+
+struct Zoo {
+mut:
+	a int
+	b int
+}
+
+fn test_struct_field_cross_assign() {
+	mut x := Zoo{a:1, b:2}
+	x.a, x.b = x.b, x.a
+	//println(x)
+	assert x.a == 2
+	assert x.b == 1
+}


### PR DESCRIPTION
This PR fix cross assign of struct fields (fix #5594).

- Fix cross assign of struct fields.
- Add test `test_struct_field_cross_assign()` in struct_test.v.

```v
struct Foo {
mut:
	a int
	b int
}

fn main() {
	mut x := Foo{a:1, b:2}
	x.a, x.b = x.b, x.a
	println(x)
}

D:\test\v\tt1>v run .
Foo {
    a: 2
    b: 1
}
```