### PR TITLE
cgen: optimize generated code format of for_c_stmt

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -709,6 +709,12 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 				g.write('; ')
 			} else {
 				g.stmt(node.init)
+				// Remove excess return and add space
+				if g.out.last_n(1) == '\n' {
+					g.out.go_back(1)
+					g.empty_line = false
+					g.write(' ')
+				}
 			}
 			if node.has_cond {
 				g.expr(node.cond)


### PR DESCRIPTION
This PR optimize generated code format of for_c_stmt.

c code before:
```v
static void mapnode_split_child(mapnode* n, int child_index, mapnode* y) {
	mapnode* z = new_node();
	z->len = _const_mid_index;
	y->len = _const_mid_index;
	for (int j = _const_mid_index - 1;
	j >= 0; j--) {
		z->keys[j] = y->keys[j + _const_degree];
		z->values[j] = y->values[j + _const_degree];
	}
	if (!isnil(y->children)) {
		z->children = ((voidptr*)(v_malloc(((int*)(_const_children_bytes)))));
		for (int jj = _const_degree - 1;
		jj >= 0; jj--) {
			z->children[jj] = y->children[jj + _const_degree];
		}
	}
	if (isnil(n->children)) {
		n->children = ((voidptr*)(v_malloc(((int*)(_const_children_bytes)))));
	}
	n->children[n->len + 1] = n->children[n->len];
	for (int j = n->len;
	j > child_index; j--) {
		n->keys[j] = n->keys[j - 1];
		n->values[j] = n->values[j - 1];
		n->children[j] = n->children[j - 1];
	}
	n->keys[child_index] = y->keys[_const_mid_index];
	n->values[child_index] = y->values[_const_mid_index];
	n->children[child_index] = ((voidptr)(y));
	n->children[child_index + 1] = ((voidptr)(z));
	n->len++;
}
```

c code now:
```v
static void mapnode_split_child(mapnode* n, int child_index, mapnode* y) {
	mapnode* z = new_node();
	z->len = _const_mid_index;
	y->len = _const_mid_index;
	for (int j = _const_mid_index - 1; j >= 0; j--) {
		z->keys[j] = y->keys[j + _const_degree];
		z->values[j] = y->values[j + _const_degree];
	}
	if (!isnil(y->children)) {
		z->children = ((voidptr*)(v_malloc(((int*)(_const_children_bytes)))));
		for (int jj = _const_degree - 1; jj >= 0; jj--) {
			z->children[jj] = y->children[jj + _const_degree];
		}
	}
	if (isnil(n->children)) {
		n->children = ((voidptr*)(v_malloc(((int*)(_const_children_bytes)))));
	}
	n->children[n->len + 1] = n->children[n->len];
	for (int j = n->len; j > child_index; j--) {
		n->keys[j] = n->keys[j - 1];
		n->values[j] = n->values[j - 1];
		n->children[j] = n->children[j - 1];
	}
	n->keys[child_index] = y->keys[_const_mid_index];
	n->values[child_index] = y->values[_const_mid_index];
	n->children[child_index] = ((voidptr)(y));
	n->children[child_index + 1] = ((voidptr)(z));
	n->len++;
}
```