### PR TITLE
builtin/array.v: Wrap pointer addition with get_unsafe, set_unsafe functions

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -169,8 +169,9 @@ pub fn (mut a array) insert_many(i int, val voidptr, size int) {
 	a.ensure_cap(a.len + size)
 	elem_size := a.element_size
 	unsafe {
-		C.memmove(a.get_unsafe(i + size), a.get_unsafe(i), (a.len - i) * elem_size)
-		C.memcpy(a.get_unsafe(i), val, size * elem_size)
+		iptr := a.get_unsafe(i)
+		C.memmove(a.get_unsafe(i + size), iptr, (a.len - i) * elem_size)
+		C.memcpy(iptr, val, size * elem_size)
 	}
 	a.len += size
 }


### PR DESCRIPTION
This follows on from #5581. This pull is part of the preparation for the next stage of disallowing pointer arithmetic for `InfixExpr` outside `unsafe {}`. I'm submitting this separately as the refactoring is independent of that change.

* Instead of pointer addition to find the address of an array element, use `get_unsafe(index)`.
* Instead of `memcpy` with pointer addition to set a single element, use `set_unsafe(index, val)`.

These functions also make it easier to read and understand the code too.

* Add `unsafe {}` blocks for pointer addition (my `InfixExpr` pull will require that).
* Add some `unsafe {}` blocks for calling functions marked `[unsafe_fn]`. I didn't do this consistently, but I kept these changes (from my WIP) as I think this should be required in future (I might work on that too later).

I think these changes may be covered by existing tests, please let me know of any exceptions and I can update the tests.