### PR TITLE
vpm: fixes with underscores for install and search

### DIFF
--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -88,20 +88,21 @@ fn main() {
 }
 
 fn vpm_search(keywords []string) {
+	search_keys := keywords.map(it.replace('_', '-'))
 	if settings.is_help {
 		vhelp.show_topic('search')
 		exit(0)
 	}
-	if keywords.len == 0 {
+	if search_keys.len == 0 {
 		println('  v search requires *at least one* keyword')
 		exit(2)
 	}
 	modules := get_all_modules()
-	joined := keywords.join(', ')
+	joined := search_keys.join(', ')
 	mut index := 0
 	for mod in modules {
 		// TODO for some reason .filter results in substr error, so do it manually
-		for k in keywords {
+		for k in search_keys {
 			if !mod.contains(k) {
 				continue
 			}
@@ -138,7 +139,7 @@ fn vpm_install(module_names []string) {
 	}
 	mut errors := 0
 	for n in module_names {
-		name := n.trim_space()
+		name := n.trim_space().replace('_', '-')
 		mod := get_module_meta_info(name) or {
 			errors++
 			println('Errors while retrieving meta data for module $name:')

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -119,9 +119,11 @@ fn vpm_search(keywords []string) {
 			break
 		}
 	}
-	println('\nUse "v install author_name.module_name" to install the module')
+
 	if index == 0 {
 		println('No module(s) found for "$joined"')
+	} else {
+		println('\nUse "v install author_name.module_name" to install the module')
 	}
 }
 


### PR DESCRIPTION
Internally convert underscores back to a hyphen to work as url.

Also hide the hint how to install modules at zero search results.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
