### PR TITLE
cgen: remove extra `\n` of map.get

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2349,14 +2349,14 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 					g.expr(node.left)
 					g.write(', ')
 					g.expr(node.index)
-					g.write(', &($elem_type_str[]){ $zero }))\n')
+					g.write(', &($elem_type_str[]){ $zero }))')
 				} else {
 					zero := g.type_default(info.value_type)
 					g.write('(*($elem_type_str*)map_get(')
 					g.expr(node.left)
 					g.write(', ')
 					g.expr(node.index)
-					g.write(', &($elem_type_str[]){ $zero }))\n')
+					g.write(', &($elem_type_str[]){ $zero }))')
 				}
 			} else if sym.kind == .string && !node.left_type.is_ptr() {
 				g.write('string_at(')


### PR DESCRIPTION
This PR remove extra `\n` of `map.get` and `map.get_and_set`.

Generated c code before:
```v
	for (int i = 0; i < a.len - 1; ++i) {
		string bigram = string_substr(a, i, i + 2);
		int q = (_IN_MAP(bigram, first_bigrams) ? ((*(int*)map_get(first_bigrams, bigram, &(int[]){ 0 }))
 + 1) : (1));
		map_set(&first_bigrams, bigram, &(int[]) { q });
	}
```

Generated c code now:
```v
	for (int i = 0; i < a.len - 1; ++i) {
		string bigram = string_substr(a, i, i + 2);
		int q = (_IN_MAP(bigram, first_bigrams) ? ((*(int*)map_get(first_bigrams, bigram, &(int[]){ 0 })) + 1) : (1));
		map_set(&first_bigrams, bigram, &(int[]) { q });
	}
```