### PR TITLE
vrepl: minor optimization for import

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -242,9 +242,7 @@ fn run_repl(workdir string, vrepl_prefix string) {
 					r.temp_lines.delete(0)
 				}
 				if r.line.starts_with('import ') || r.line.starts_with('#include ') {
-					mut imports := r.imports
-					r.imports = [r.line]
-					r.imports << imports
+					r.imports << r.line
 				} else {
 					r.lines << r.line
 				}


### PR DESCRIPTION
This PR does minor optimization for import.

The new `import xxx` doesn't have to be put in the front.

```v
mut imports := r.imports
r.imports = [r.line]
r.imports << imports
```
change to
```v
r.imports << r.line
```
