### PR TITLE
cgen: fix map_in mut (fix #5634)

### DIFF
--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -301,3 +301,15 @@ fn test_map_keys_to_array() {
 	println(sarr)
 	assert sarr == "['a', 'c']"
 }
+
+fn map_in_mut(mut m map[string]int) {
+	if 'one' in m {
+		m['one'] = 2
+	}
+}
+
+fn test_map_in_mut() {
+	mut m := {'one': 1}
+	map_in_mut(mut m)
+	assert m['one'] == 2
+}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1912,6 +1912,9 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 			g.write('_IN_MAP(')
 			g.expr(node.left)
 			g.write(', ')
+			if node.right_type.is_ptr() {
+				g.write('*')
+			}
 			g.expr(node.right)
 			g.write(')')
 		} else if right_sym.kind == .string {


### PR DESCRIPTION
This PR fix map_in mut (fix #5634).

- Fix map_in mut.
- Add test `test_map_in_mut()` in map_test.v.

```v
fn map_in_mut(mut m map[string]int) {
	if 'one' in m {
		m['one'] = 2
	}
}

fn test_map_in_mut() {
	mut m := {'one': 1}
	map_in_mut(mut m)
	assert m['one'] == 2
}
```