### PR TITLE
v/checker.v: Disallow pointer arithmetic for InfixExpr outside unsafe {}

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -169,8 +169,9 @@ pub fn (mut a array) insert_many(i int, val voidptr, size int) {
 	a.ensure_cap(a.len + size)
 	elem_size := a.element_size
 	unsafe {
-		C.memmove(a.get_unsafe(i + size), a.get_unsafe(i), (a.len - i) * elem_size)
-		C.memcpy(a.get_unsafe(i), val, size * elem_size)
+		iptr := a.get_unsafe(i)
+		C.memmove(a.get_unsafe(i + size), iptr, (a.len - i) * elem_size)
+		C.memcpy(iptr, val, size * elem_size)
 	}
 	a.len += size
 }

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -93,7 +93,9 @@ pub fn (nn int) str_l(max int) string {
 		buf[index] = `-`
 	}
 
-	C.memmove(buf,buf+index, (max-index)+1 )
+	unsafe {
+		C.memmove(buf,buf+index, (max-index)+1 )
+	}
 	return tos(buf, (max-index))
 	//return tos(buf + index, (max-index))
 }
@@ -139,7 +141,9 @@ pub fn (nn u32) str() string {
 		index++
 	}
 
-	C.memmove(buf,buf+index, (max-index)+1 )
+	unsafe {
+		C.memmove(buf,buf+index, (max-index)+1 )
+	}
 	return tos(buf, (max-index))
 	//return tos(buf + index, (max-index))
 }
@@ -186,7 +190,9 @@ pub fn (nn i64) str() string {
 		buf[index] = `-`
 	}
 
-	C.memmove(buf,buf+index, (max-index)+1 )
+	unsafe {
+		C.memmove(buf,buf+index, (max-index)+1 )
+	}
 	return tos(buf, (max-index))
 	//return tos(buf + index, (max-index))
 }
@@ -216,7 +222,9 @@ pub fn (nn u64) str() string {
 		index++
 	}
 
-	C.memmove(buf,buf+index, (max-index)+1 )
+	unsafe {
+		C.memmove(buf,buf+index, (max-index)+1 )
+	}
 	return tos(buf, (max-index))
 	//return tos(buf + index, (max-index))
 }
@@ -260,7 +268,9 @@ pub fn (nn byte) hex() string {
 	//buf[index]   = `0`
 	index++
 
-	return tos(buf + index, (max - index))
+	unsafe {
+		return tos(buf + index, (max - index))
+	}
 }
 
 pub fn (nn i8) hex() string {
@@ -287,7 +297,9 @@ pub fn (nn u16) hex() string {
 	//buf[index]   = `0`
 	index++
 
-	return tos(buf + index, (max - index))
+	unsafe {
+		return tos(buf + index, (max - index))
+	}
 }
 
 pub fn (nn i16) hex() string {
@@ -314,7 +326,9 @@ pub fn (nn u32) hex() string {
 	//buf[index]   = `0`
 	index++
 
-	return tos(buf + index, (max - index))
+	unsafe {
+		return tos(buf + index, (max - index))
+	}
 }
 
 pub fn (nn int) hex() string {
@@ -345,7 +359,9 @@ pub fn (nn u64) hex() string {
 	//buf[index]   = `0`
 	index++
 
-	C.memmove(buf,buf+index, (max-index)+1 )
+	unsafe {
+		C.memmove(buf,buf+index, (max-index)+1 )
+	}
 	return tos(buf, (max-index))
 	//return tos(buf + index, (max-index))
 }

--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -39,10 +39,10 @@ fn opt_ok2(data voidptr, mut option &OptionBase, size int) {
 		*option = OptionBase {
 			ok: true
 		}
-	}
 
-	// use ecode to get the end of OptionBase and then memcpy into it
-	C.memcpy(byteptr(&option.ecode) + sizeof(int), data, size)
+		// use ecode to get the end of OptionBase and then memcpy into it
+		C.memcpy(byteptr(&option.ecode) + sizeof(int), data, size)
+	}
 }
 
 // Old option type used for bootstrapping

--- a/vlib/builtin/sorted_map.v
+++ b/vlib/builtin/sorted_map.v
@@ -48,7 +48,9 @@ fn new_sorted_map(n, value_bytes int) SortedMap { // TODO: Remove `n`
 fn new_sorted_map_init(n, value_bytes int, keys &string, values voidptr) SortedMap {
 	mut out := new_sorted_map(n, value_bytes)
 	for i in 0 .. n {
-		out.set(keys[i], byteptr(values) + i * value_bytes)
+		unsafe {
+			out.set(keys[i], byteptr(values) + i * value_bytes)
+		}
 	}
 	return out
 }

--- a/vlib/builtin/utf8.v
+++ b/vlib/builtin/utf8.v
@@ -118,7 +118,9 @@ pub fn (_str string) to_wide() &u16 {
 		mut wstr := &u16(malloc((num_chars + 1) * 2)) // sizeof(wchar_t)
 		if wstr != 0 {
 			C.MultiByteToWideChar(cp_utf8, 0, _str.str, _str.len, wstr, num_chars)
-			C.memset(&byte(wstr) + num_chars * 2, 0, 2)
+			unsafe {
+				C.memset(&byte(wstr) + num_chars * 2, 0, 2)
+			}
 		}
 		return wstr
 	} $else {
@@ -141,7 +143,9 @@ pub fn string_from_wide2(_wstr &u16, len int) string {
 		mut str_to := malloc(num_chars + 1)
 		if str_to != 0 {
 			C.WideCharToMultiByte(cp_utf8, 0, _wstr, len, str_to, num_chars, 0, 0)
-			C.memset(str_to + num_chars, 0, 1)
+			unsafe {
+				C.memset(str_to + num_chars, 0, 1)
+			}
 		}
 		return tos2(str_to)
 	} $else {

--- a/vlib/hash/wyhash/wyhash.v
+++ b/vlib/hash/wyhash/wyhash.v
@@ -51,23 +51,25 @@ fn wyhash64(key byteptr, len, seed_ u64) u64 {
 	mut p := &key[0]
 	mut seed := seed_
 	mut i := len & 63
-	if i < 4 {
-		seed = wymum(wyr3(p, i) ^ seed ^ wyp0, seed ^ wyp1)
-	}
-	else if i <= 8 {
-		seed = wymum(wyr4(p) ^ seed ^ wyp0, wyr4(p + i - 4) ^ seed ^ wyp1)
-	}
-	else if i <= 16 {
-		seed = wymum(wyr8(p) ^ seed ^ wyp0, wyr8(p + i - 8) ^ seed ^ wyp1)
-	}
-	else if i <= 24 {
-		seed = wymum(wyr8(p) ^ seed ^ wyp0, wyr8(p + 8) ^ seed ^ wyp1) ^ wymum(wyr8(p + i - 8) ^ seed ^ wyp2, seed ^ wyp3)
-	}
-	else if i <= 32 {
-		seed = wymum(wyr8(p) ^ seed ^ wyp0, wyr8(p + 8) ^ seed ^ wyp1) ^ wymum(wyr8(p + 16) ^ seed ^ wyp2, wyr8(p + i - 8) ^ seed ^ wyp3)
-	}
-	else {
-		seed = wymum(wyr8(p) ^ seed ^ wyp0, wyr8(p + 8) ^ seed ^ wyp1) ^ wymum(wyr8(p + 16) ^ seed ^ wyp2, wyr8(p + 24) ^ seed ^ wyp3) ^ wymum(wyr8(p + i - 32) ^ seed ^ wyp1, wyr8(p + i - 24) ^ seed ^ wyp2) ^ wymum(wyr8(p + i - 16) ^ seed ^ wyp3, wyr8(p + i - 8) ^ seed ^ wyp0)
+	unsafe {
+		if i < 4 {
+			seed = wymum(wyr3(p, i) ^ seed ^ wyp0, seed ^ wyp1)
+		}
+		else if i <= 8 {
+			seed = wymum(wyr4(p) ^ seed ^ wyp0, wyr4(p + i - 4) ^ seed ^ wyp1)
+		}
+		else if i <= 16 {
+			seed = wymum(wyr8(p) ^ seed ^ wyp0, wyr8(p + i - 8) ^ seed ^ wyp1)
+		}
+		else if i <= 24 {
+			seed = wymum(wyr8(p) ^ seed ^ wyp0, wyr8(p + 8) ^ seed ^ wyp1) ^ wymum(wyr8(p + i - 8) ^ seed ^ wyp2, seed ^ wyp3)
+		}
+		else if i <= 32 {
+			seed = wymum(wyr8(p) ^ seed ^ wyp0, wyr8(p + 8) ^ seed ^ wyp1) ^ wymum(wyr8(p + 16) ^ seed ^ wyp2, wyr8(p + i - 8) ^ seed ^ wyp3)
+		}
+		else {
+			seed = wymum(wyr8(p) ^ seed ^ wyp0, wyr8(p + 8) ^ seed ^ wyp1) ^ wymum(wyr8(p + 16) ^ seed ^ wyp2, wyr8(p + 24) ^ seed ^ wyp3) ^ wymum(wyr8(p + i - 32) ^ seed ^ wyp1, wyr8(p + i - 24) ^ seed ^ wyp2) ^ wymum(wyr8(p + i - 16) ^ seed ^ wyp3, wyr8(p + i - 8) ^ seed ^ wyp0)
+		}
 	}
 	if i == len {
 		return wymum(seed, len ^ wyp4)
@@ -75,13 +77,15 @@ fn wyhash64(key byteptr, len, seed_ u64) u64 {
 	mut see1 := seed
 	mut see2 := seed
 	mut see3 := seed
-	p = p + i
-	for i = len - i; i >= 64; i -= 64 {
-		seed = wymum(wyr8(p) ^ seed ^ wyp0, wyr8(p + 8) ^ seed ^ wyp1)
-		see1 = wymum(wyr8(p + 16) ^ see1 ^ wyp2, wyr8(p + 24) ^ see1 ^ wyp3)
-		see2 = wymum(wyr8(p + 32) ^ see2 ^ wyp1, wyr8(p + 40) ^ see2 ^ wyp2)
-		see3 = wymum(wyr8(p + 48) ^ see3 ^ wyp3, wyr8(p + 56) ^ see3 ^ wyp0)
-		p = p + 64
+	unsafe {
+		p = p + i
+		for i = len - i; i >= 64; i -= 64 {
+			seed = wymum(wyr8(p) ^ seed ^ wyp0, wyr8(p + 8) ^ seed ^ wyp1)
+			see1 = wymum(wyr8(p + 16) ^ see1 ^ wyp2, wyr8(p + 24) ^ see1 ^ wyp3)
+			see2 = wymum(wyr8(p + 32) ^ see2 ^ wyp1, wyr8(p + 40) ^ see2 ^ wyp2)
+			see3 = wymum(wyr8(p + 48) ^ see3 ^ wyp3, wyr8(p + 56) ^ see3 ^ wyp0)
+			p = p + 64
+		}
 	}
 	return wymum(seed ^ see1 ^ see2, see3 ^ len ^ wyp4)
 }

--- a/vlib/net/websocket/handshake.v
+++ b/vlib/net/websocket/handshake.v
@@ -7,7 +7,10 @@ fn (mut ws Client) read_handshake(seckey string) {
 	buffer_size := 1
 	mut buffer := malloc(max_buffer)
 	for bytes_read <= max_buffer {
-		res := ws.read_from_server(buffer + bytes_read, buffer_size)
+		mut res := 0
+		unsafe {
+			res = ws.read_from_server(buffer + bytes_read, buffer_size)
+		}
 		if res == 0 || res == -1 {
 			l.f('read_handshake: Failed to read handshake.')
 		}

--- a/vlib/os/environment.v
+++ b/vlib/os/environment.v
@@ -58,11 +58,15 @@ pub fn environ() map[string]string {
 	$if windows {
 		mut estrings := C.GetEnvironmentStringsW()
 		mut eline := ''
-		for c := estrings; *c != 0; c = c + eline.len + 1 {
+		for c := estrings; *c != 0; {
 			eline = string_from_wide(c)
 			eq_index := eline.index_byte(`=`)
 			if eq_index > 0 {
 				res[eline[0..eq_index]] = eline[eq_index + 1..]
+			}
+			unsafe 
+			{
+				c = c + eline.len + 1
 			}
 		}
 		C.FreeEnvironmentStringsW(estrings)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -480,6 +480,10 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 	left_default := c.table.get_type_symbol(c.table.mktyp(left_type))
 	left_pos := infix_expr.left.position()
 	right_pos := infix_expr.right.position()
+	if (left_type.is_ptr() || left.is_pointer()) &&
+		infix_expr.op in [.plus, .minus] && !c.inside_unsafe {
+		c.error('pointer arithmetic is only allowed in `unsafe` blocks', left_pos)
+	}
 	mut return_type := left_type
 	// Single side check
 	// Place these branches according to ops' usage frequency to accelerate.

--- a/vlib/v/tests/ptr_arithmetic_test.v
+++ b/vlib/v/tests/ptr_arithmetic_test.v
@@ -4,13 +4,13 @@ fn test_ptr_arithmetic(){
 	unsafe {
 		p++
 		p += 2
+		p = p - 1
 	}
-	p = p - 1 // not caught yet
 	
 	// byteptr, voidptr, charptr are handled differently
 	mut q := byteptr(1)
 	unsafe {
 		q -= 2
+		q = q + 1
 	}
-	q = q + 1 // not caught yet
 }


### PR DESCRIPTION
Follows on from #5581.
Currently depends on #5619, but I can workaround that if necessary.

Require pointer arithmetic in `ptr op rhs` to be inside an unsafe block.