### PR TITLE
vweb: add .txt and .md mime types

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -26,10 +26,12 @@ pub const (
 		'.html': 'text/html; charset=utf-8',
 		'.jpg': 'image/jpeg',
 		'.js': 'application/javascript',
-		'.wasm': 'application/wasm',
+		'.md': 'text/markdown; charset=utf-8',
 		'.pdf': 'application/pdf',
 		'.png': 'image/png',
 		'.svg': 'image/svg+xml',
+		'.txt': 'text/plain; charset=utf-8',
+		'.wasm': 'application/wasm',
 		'.xml': 'text/xml; charset=utf-8'
 	}
 	max_http_post_size = 1024 * 1024


### PR DESCRIPTION
Markdown has an official mime type via rfc7763:
https://tools.ietf.org/html/rfc7763

Added that mime type to vweb, which allows better transfer for things
like CHANGELOG.md or README.md.

Also added the plain text `.txt` type for completeness and put the
list in alphabetical order.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
