### PR TITLE
vrepl: pre-imported common modules

### DIFF
--- a/vlib/v/tests/repl/error.repl
+++ b/vlib/v/tests/repl/error.repl
@@ -1,6 +1,7 @@
 println(a)
 ===output===
-.vrepl.v:2:9: error: undefined ident: `a` 
-    1 | 
-    2 | println(a)
+.vrepl.v:7:9: error: undefined ident: `a` 
+    5 | import math
+    6 | 
+    7 | println(a)
       |         ^

--- a/vlib/v/tests/repl/import_middle.repl
+++ b/vlib/v/tests/repl/import_middle.repl
@@ -1,6 +1,0 @@
-mut a := [1,2,3]
-a << 4
-import time
-time.now().unix_time() > 160000
-===output===
-true


### PR DESCRIPTION
This PR pre-imported common modules in vrepl. (realize #5597)

```v
C:\Users\yuyi9\v>v
For usage information, quit V REPL using `exit` and use `v help`
V 0.1.28 b7175b5.652380c
Use Ctrl-C or `exit` to exit
>>> time.now().add_days(10)
2020-07-13 23:57:30
>>> os.home_dir()
C:\Users\yuyi9\
>>>
```