### PR TITLE
parser, fmt: allow parsing files without `fn main()`

### DIFF
--- a/vlib/v/fmt/tests/no_main_expected.vv
+++ b/vlib/v/fmt/tests/no_main_expected.vv
@@ -1,0 +1,3 @@
+fn main() {
+	println('Hello, world!')
+}

--- a/vlib/v/fmt/tests/no_main_input.vv
+++ b/vlib/v/fmt/tests/no_main_input.vv
@@ -1,0 +1,1 @@
+println("Hello, world!")

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -434,7 +434,7 @@ pub fn (mut p Parser) top_stmt() ast.Stmt {
 			return p.comment()
 		}
 		else {
-			if p.pref.is_script && !p.pref.is_test {
+			if (p.pref.is_script || p.pref.is_fmt) && !p.pref.is_test {
 				mut stmts := []ast.Stmt{}
 				for p.tok.kind != .eof {
 					stmts << p.stmt(false)


### PR DESCRIPTION
This PR fixes parsing and formatting of files without `fn main()`.

Closes #4025.

Note: this fix has the side-effect of adding `fn main` automatically in these cases, since that's how the parser/ast handles it internally. It's definitely better than current behavior but I'm not sure if it's ideal. Fixing it would require much larger changes, so that would be done in the future.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
