### PR TITLE
os: fix early termination when saving binary

### DIFF
--- a/vlib/net/http/download.v
+++ b/vlib/net/http/download.v
@@ -6,7 +6,9 @@ module http
 import os
 
 pub fn download_file(url, out string) bool {
-	println('download file url=$url out=$out')
+	$if debug_http? {
+		println('download file url=$url out=$out')
+	}
 	s := get(url) or {
 		return false
 	}

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -39,7 +39,7 @@ pub fn (mut f File) write(s string) {
 		}
 	}
 	*/
-	C.fputs(s.str, f.cfile)
+	C.fwrite(s.str, s.len, 1, f.cfile)
 }
 
 pub fn (mut f File) writeln(s string) {


### PR DESCRIPTION
This PR replaces the `fputs` call with `fwrite` in `File.write` to fix an issue where binary files are not saved properly if they have a NUL byte in it.
Also suppresses a message sent by `net.http.download_file`.