### PR TITLE
checker: check for enum value dup/overflow 

### DIFF
--- a/vlib/v/checker/tests/enum_field_overflow.out
+++ b/vlib/v/checker/tests/enum_field_overflow.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/enum_field_overflow.v:4:2: error: enum value overflows
+    2 |     red
+    3 |     green = 2147483647
+    4 |     blue
+      |     ~~~~
+    5 | }

--- a/vlib/v/checker/tests/enum_field_overflow.vv
+++ b/vlib/v/checker/tests/enum_field_overflow.vv
@@ -1,0 +1,5 @@
+enum Color {
+	red
+	green = 2147483647
+	blue
+}

--- a/vlib/v/checker/tests/enum_field_value_duplicate_err.out
+++ b/vlib/v/checker/tests/enum_field_value_duplicate_err.out
@@ -1,0 +1,13 @@
+vlib/v/checker/tests/enum_field_value_duplicate_err.v:3:10: error: enum value `0` already exists
+    1 | enum Color {
+    2 |     red
+    3 |     green = 0
+      |             ^
+    4 |     blue  = 1
+    5 |     alpha = 1
+vlib/v/checker/tests/enum_field_value_duplicate_err.v:5:10: error: enum value `1` already exists
+    3 |     green = 0
+    4 |     blue  = 1
+    5 |     alpha = 1
+      |             ^
+    6 | }

--- a/vlib/v/checker/tests/enum_field_value_duplicate_err.vv
+++ b/vlib/v/checker/tests/enum_field_value_duplicate_err.vv
@@ -1,0 +1,6 @@
+enum Color {
+	red
+	green = 0
+	blue  = 1
+	alpha = 1
+}

--- a/vlib/v/checker/tests/enum_field_value_overflow.out
+++ b/vlib/v/checker/tests/enum_field_value_overflow.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/enum_field_value_overflow.v:3:10: error: enum value `2147483648` overflows int
+    1 | enum Color {
+    2 |     red
+    3 |     green = 2147483648
+      |             ~~~~~~~~~~
+    4 |     blue
+    5 | }

--- a/vlib/v/checker/tests/enum_field_value_overflow.vv
+++ b/vlib/v/checker/tests/enum_field_value_overflow.vv
@@ -1,0 +1,5 @@
+enum Color {
+	red
+	green = 2147483648
+	blue
+}


### PR DESCRIPTION
This PR adds checks to the checker to check overflows and dups in enum field values.
Closes #4183
Closes #4184
@medvednikov Sorry, accidentally invalidated my old PR. I did the changes you requested.