### PR TITLE
checker: fixes position of infix expr error

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -606,7 +606,7 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 			}
 			if left.kind != .interface_ && left.kind != .sum_type {
 				c.error('`$infix_expr.op.str()` can only be used with interfaces and sum types',
-					type_expr.pos)
+					infix_expr.pos)
 			}
 			return table.bool_type
 		}


### PR DESCRIPTION
```
vlib/v/parser/assign.v:155:17: error: `is` can only be used with interfaces and sum types 
  153 |     if p.file_name == 'main.v' {
  154 |         println(right)
  155 |         println(right is ast.AnonFn)
      |                       ~~
  156 |     }
  157 |     return ast.AssignStmt{
```

instead of
```
vlib/v/parser/assign.v:155:17: error: `is` can only be used with interfaces and sum types 
  153 |     if p.file_name == 'main.v' {
  154 |         println(right)
  155 |         println(right is ast.AnonFn)
      |                          ~~~
  156 |     }
  157 |     return ast.AssignStmt{
```