### PR TITLE
Parser forbid to assign main

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -606,7 +606,7 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 			}
 			if left.kind != .interface_ && left.kind != .sum_type {
 				c.error('`$infix_expr.op.str()` can only be used with interfaces and sum types',
-					type_expr.pos)
+					infix_expr.pos)
 			}
 			return table.bool_type
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -606,7 +606,7 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 			}
 			if left.kind != .interface_ && left.kind != .sum_type {
 				c.error('`$infix_expr.op.str()` can only be used with interfaces and sum types',
-					infix_expr.pos)
+					type_expr.pos)
 			}
 			return table.bool_type
 		}

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -150,6 +150,16 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr) ast.Stmt {
 			}
 		}
 	}
+	for expr in right {
+		match expr {
+			ast.Ident {
+				if expr.mod == 'main' && expr.name == 'main' {
+					p.error_with_pos('function `main` cannot be assigned', expr.pos)
+				}
+			}
+			else {}
+		}
+	}
 	return ast.AssignStmt{
 		op: op
 		left: left

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -151,13 +151,11 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr) ast.Stmt {
 		}
 	}
 	for expr in right {
-		match expr {
-			ast.Ident {
-				if expr.mod == 'main' && expr.name == 'main' {
-					p.error_with_pos('function `main` cannot be assigned', expr.pos)
-				}
+		if expr is ast.Ident {
+			ident := expr as ast.Ident
+			if ident.mod == 'main' && ident.name == 'main' {
+				p.error_with_pos('function `main` cannot be assigned', ident.pos)
 			}
-			else {}
 		}
 	}
 	return ast.AssignStmt{

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -107,6 +107,12 @@ pub fn (mut p Parser) call_args() []ast.CallArg {
 			p.next()
 		}
 		e := p.expr(0)
+		if e is ast.Ident {
+			ident := e as ast.Ident
+			if ident.mod == 'main' && ident.name == 'main' {
+				p.error_with_pos('function `main` cannot be passed as an argument', ident.pos)
+			}
+		}
 		args << ast.CallArg{
 			is_mut: is_mut
 			share: table.sharetype_from_flags(is_shared, is_atomic_or_rw)


### PR DESCRIPTION
Fixes #5333

```
main.v:2:7: error: function `main` cannot be assigned 
    1 | fn main() {
    2 |     a := main
      |          ~~~~
    3 |     a()
    4 | }
```