### PR TITLE
Fix name of isnil function to match V convention

### DIFF
--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -11,7 +11,7 @@ pub fn exit(code int) {
 }
 
 // isnil returns true if an object is nil (only for C objects).
-pub fn isnil(v voidptr) bool {
+pub fn is_nil(v voidptr) bool {
 	return v == 0
 }
 


### PR DESCRIPTION
Changed the name of `isnil` to `is_nil` to match V naming convention.