### PR TITLE
checker: check for_in variable name

### DIFF
--- a/vlib/encoding/csv/writer.v
+++ b/vlib/encoding/csv/writer.v
@@ -27,8 +27,8 @@ pub fn (mut w Writer) write(record []string) ?bool {
 		return err_invalid_delim
 	}
 	le := if w.use_crlf { '\r\n' } else { '\n' }
-	for n, _field in record {
-		mut field := _field
+	for n, field_ in record {
+		mut field := field_
 		if n > 0 {
 			w.sb.write(w.delimiter.str())
 		}

--- a/vlib/net/http/cookie.v
+++ b/vlib/net/http/cookie.v
@@ -153,8 +153,8 @@ pub fn read_cookies(h map[string][]string, filter string) []&Cookie {
 		return []
 	}
 	mut cookies := []&Cookie{}
-	for _, _line in lines {
-		mut line := _line.trim_space()
+	for _, line_ in lines {
+		mut line := line_.trim_space()
 		mut part := ''
 		for line.len > 0 {
 			if line.index_any(';') > 0 {

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -156,9 +156,9 @@ pub fn get_text(url string) string {
 
 pub fn url_encode_form_data(data map[string]string) string {
 	mut pieces := []string{}
-	for _key, _value in data {
-		key := urllib.query_escape(_key)
-		value := urllib.query_escape(_value)
+	for key_, value_ in data {
+		key := urllib.query_escape(key_)
+		value := urllib.query_escape(value_)
 		pieces << '$key=$value'
 	}
 	return pieces.join('&')

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1904,6 +1904,12 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 			c.in_for_count++
 			typ := c.expr(node.cond)
 			typ_idx := typ.idx()
+			if node.key_var.len > 0 && node.key_var != '_' {
+				c.check_valid_snake_case(node.key_var, 'variable name', node.pos)
+			}
+			if node.val_var.len > 0 && node.val_var != '_' {
+				c.check_valid_snake_case(node.val_var, 'variable name', node.pos)
+			}
 			if node.is_range {
 				high_type := c.expr(node.high)
 				high_type_idx := high_type.idx()

--- a/vlib/v/checker/tests/incorrect_for_in_name_variable.out
+++ b/vlib/v/checker/tests/incorrect_for_in_name_variable.out
@@ -1,0 +1,8 @@
+vlib/v/checker/tests/incorrect_for_in_name_variable.v:3:6: error: variable name `_aa` cannot start with `_`
+    1 | fn main() {
+    2 |     a := [1,2,3]
+    3 |     for _aa in a {
+      |         ~~~
+    4 |         println(_aa)
+    5 |     }
+	

--- a/vlib/v/checker/tests/incorrect_for_in_name_variable.vv
+++ b/vlib/v/checker/tests/incorrect_for_in_name_variable.vv
@@ -1,0 +1,6 @@
+fn main() {
+	a := [1,2,3]
+	for _aa in a {
+		println(_aa)
+	}
+}


### PR DESCRIPTION
This PR check for_in variable name. (fix #5672)

- Check for_in variable name.
- Add test `incorrect_for_in_name_variable.vv/out`.
- Modify related error.

```v
fn main() {
	a := [1,2,3]
	for _aa in a {
		println(_aa)
	}
}

D:\test\v\tt1>v run .
.\tt1.v:3:6: error: variable name `_aa` cannot start with `_` 
    1 | fn main() {
    2 |     a := [1,2,3]
    3 |     for _aa in a {
      |         ~~~
    4 |         println(_aa)
    5 |     }
```

The CI test error is because the `vid` module is in violation of this rule.