### PR TITLE
parser: fix name error of match (fix #5676)

### DIFF
--- a/vlib/v/parser/if.v
+++ b/vlib/v/parser/if.v
@@ -115,10 +115,9 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 		if p.tok.kind == .key_else {
 			is_else = true
 			p.next()
-		} else if p.tok.kind == .name && !(p.tok.lit == 'C' &&
-			p.peek_tok.kind == .dot) && (p.tok.lit in table.builtin_type_names ||
-			(p.tok.lit[0].is_capital() && !p.tok.lit.is_upper()) ||
-			(p.peek_tok.kind == .dot && p.peek_tok2.lit[0].is_capital())) {
+		} else if p.tok.kind == .name && !(p.tok.lit == 'C' && p.peek_tok.kind == .dot) &&
+				(p.tok.lit in table.builtin_type_names || p.tok.lit[0].is_capital() ||
+				(p.peek_tok.kind == .dot && p.peek_tok2.lit[0].is_capital())) {
 			if var_name.len == 0 {
 				match cond {
 					ast.Ident {

--- a/vlib/v/tests/match_test.v
+++ b/vlib/v/tests/match_test.v
@@ -82,3 +82,29 @@ fn test_match_enums() {
 	}
 	assert b == .blue
 }
+
+type Sum = A1 | B1
+
+struct A1 {
+	pos int
+}
+struct B1 {
+	val string
+}
+
+fn f(s Sum) string {
+    match s {
+        A1 {
+            return typeof(s)
+        }
+        B1 {
+			return ''
+		}
+    }
+	return ''
+}
+
+fn test_sum_type_name() {
+	a := A1{pos: 22}
+	assert f(a) == 'A1'
+}


### PR DESCRIPTION
This PR fix name error of match (fix #5676).

- Fix name error of match.
- Add test `test_sum_type_name()` in match_test.v.

```v
type Sum = A1 | B1

struct A1 {
	pos int
}
struct B1 {
	val string
}

fn f(s Sum) string {
    match s {
        A1 {
            return typeof(s)
        }
        B1 {
			return ''
		}
    }
	return ''
}

fn main() {
	a := A1{pos: 22}
	println(f(a))
	assert f(a) == 'A1'
}

D:\test\v\tt1>v run .
A1
```