### PR TITLE
fmt: allow parsing files without `fn main()` (v2)

### DIFF
--- a/vlib/v/fmt/tests/no_main_expected.vv
+++ b/vlib/v/fmt/tests/no_main_expected.vv
@@ -1,0 +1,1 @@
+println('hello world')

--- a/vlib/v/fmt/tests/no_main_input.vv
+++ b/vlib/v/fmt/tests/no_main_input.vv
@@ -1,0 +1,1 @@
+println('hello world')

--- a/vlib/v/fmt/tests/no_main_input.vv
+++ b/vlib/v/fmt/tests/no_main_input.vv
@@ -1,1 +1,1 @@
-println('hello world')
+println( "hello world" )

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -452,6 +452,8 @@ pub fn (mut p Parser) top_stmt() ast.Stmt {
 					file: p.file_name
 					return_type: table.void_type
 				}
+			} else if p.pref.is_fmt {
+				return p.stmt(false)
 			} else {
 				p.error('bad top level statement ' + p.tok.str())
 				return ast.Stmt{}


### PR DESCRIPTION
This PR is a follow-up from #5644, but without the side-effect of adding `fn main()` automatically.

```v
fn foo() {}
println("hello world")
```
=>
```v
fn foo() {
}

println('hello world')
```

Closes #4025. 

EDIT: Also closes #5680 (opened 5 minutes before pushing) :-)

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
