### PR TITLE
Fix v/parser: Failure to parse structs with fields typed as anonymous functions returning having an optional void (`?`) return type.

### DIFF
--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -98,6 +98,25 @@ pub fn (mut p Parser) parse_type_with_mut(is_mut bool) table.Type {
 	return typ
 }
 
+// Parses any language indicators on a type.
+pub fn (mut p Parser) parse_language() table.Language {
+
+	language := if p.tok.lit == 'C' {
+		table.Language.c
+	} else if p.tok.lit == 'JS' {
+		table.Language.js
+	} else {
+		table.Language.v
+	}
+
+	if language != .v {
+		p.next()
+		p.check(.dot)
+	}
+
+	return language
+}
+
 pub fn (mut p Parser) parse_type() table.Type {
 	// optional
 	mut is_optional := false
@@ -127,19 +146,7 @@ pub fn (mut p Parser) parse_type() table.Type {
 		nr_muls++
 		p.next()
 	}
-
-	language := if p.tok.lit == 'C' {
-		table.Language.c
-	} else if p.tok.lit == 'JS' {
-		table.Language.js
-	} else {
-		table.Language.v
-	}
-
-	if language != .v {
-		p.next()
-		p.check(.dot)
-	}
+	language := p.parse_language()
 	mut typ := table.void_type
 	if p.tok.kind != .lcbr {
 		pos := p.tok.position()

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -126,9 +126,9 @@ pub fn (mut p Parser) parse_type() table.Type {
 		is_optional = true
 
 		if p.tok.line_nr > line_nr {
-			typ := table.void_type
+			mut typ := table.void_type
 			if is_optional {
-				typ.set_flag(.optional)
+				typ = typ.set_flag(.optional)
 			}
 			return typ
 		}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -102,11 +102,21 @@ pub fn (mut p Parser) parse_type() table.Type {
 	// optional
 	mut is_optional := false
 	if p.tok.kind == .question {
+		line_nr := p.tok.line_nr
 		p.next()
 		is_optional = true
+
+		if p.tok.line_nr > line_nr {
+			typ := table.void_type
+			if is_optional {
+				typ.set_flag(.optional)
+			}
+			return typ
+		}
 	}
 	is_shared := p.tok.kind in [.key_shared, .key_rwshared]
 	is_atomic_or_rw := p.tok.kind in [.key_rwshared, .key_atomic]
+
 	mut nr_muls := 0
 	if p.tok.kind == .key_mut || is_shared || is_atomic_or_rw {
 		nr_muls++

--- a/vlib/v/tests/option_test.v
+++ b/vlib/v/tests/option_test.v
@@ -279,3 +279,40 @@ fn test_optional_val_with_empty_or() {
 	ret_none() or {}
 	assert true
 }
+
+fn test_optional_void_return_types_of_anon_fn() {
+	f := fn(i int) ? {
+		if i == 0 {
+			return error("0")
+		}
+
+		return
+	}
+
+	f(0) or {
+		assert err == "0"
+		return
+	}
+}
+
+struct Foo {
+	f fn(int) ?
+}
+
+fn test_option_void_return_types_of_anon_fn_in_struct() {
+	foo := Foo {
+		f: fn(i int) ? {
+			if i == 0 {
+				return error("0")
+			}
+
+			return
+		}
+	}
+
+	foo.f(0) or {
+		assert err == "0"
+		return
+	}
+}
+

--- a/vlib/v/tests/struct_test.v
+++ b/vlib/v/tests/struct_test.v
@@ -314,18 +314,27 @@ fn test_struct_with_default_values_no_init() {
 	assert s3.field_optional == 2
 }
 
-struct StructWithFnTypesWithVoidOptionReturnType {
+struct FieldsWithOptionalVoidReturnType {
 	f fn() ?
+	g fn() ?
 }
 
-fn test_struct_with_fn_types_with_optional_void_return() ? {
-	s := StructWithFnTypesWithVoidOptionReturnType {
+fn test_fields_anon_fn_with_optional_void_return_type() {
+	foo := FieldsWithOptionalVoidReturnType {
 		f: fn() ? {
-			assert true
-			return none
+			return error("oops")
+		}
+		g: fn() ? {
+			return
 		}
 	}
 
-	s.f()
+	foo.f() or {
+		assert err == "oops"
+	}
+
+	foo.g() or {
+		assert false
+	}
 }
 

--- a/vlib/v/tests/struct_test.v
+++ b/vlib/v/tests/struct_test.v
@@ -313,3 +313,19 @@ fn test_struct_with_default_values_no_init() {
 	assert s2.field_optional == 3
 	assert s3.field_optional == 2
 }
+
+struct StructWithFnTypesWithVoidOptionReturnType {
+	f fn() ?
+}
+
+fn test_struct_with_fn_types_with_optional_void_return() ? {
+	s := StructWithFnTypesWithVoidOptionReturnType {
+		f: fn() ? {
+			assert true
+			return none
+		}
+	}
+
+	s.f()
+}
+


### PR DESCRIPTION
Fixes #5585. Where fields of a struct defined as anonymous function types with return type `?` where not parsing properly.

I also created a new function for parsing the (possible) language token and moved that code out of parse_type function.