### PR TITLE
checker: fix string cast to sumtype (fix #5690)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2122,7 +2122,7 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 			}
 			if node.expr_type == table.string_type {
 				cast_to_type_sym := c.table.get_type_symbol(node.typ)
-				if cast_to_type_sym.kind != .alias {
+				if cast_to_type_sym.kind !in [.alias, .sum_type] {
 					mut error_msg := 'cannot cast a string'
 					if node.expr is ast.StringLiteral {
 						str_lit := node.expr as ast.StringLiteral

--- a/vlib/v/checker/tests/match_expr_else.out
+++ b/vlib/v/checker/tests/match_expr_else.out
@@ -1,10 +1,3 @@
-vlib/v/checker/tests/match_expr_else.v:4:10: error: cannot cast a string
-    2 |
-    3 | fn main() {
-    4 |     x := AA('test')
-      |             ~~~~~~
-    5 |     _ = match x {
-    6 |         int {
 vlib/v/checker/tests/match_expr_else.v:5:6: error: match must be exhaustive (add match branches for: `f64` or `else {}` at the end)
     3 | fn main() {
     4 |     x := AA('test')

--- a/vlib/v/tests/sum_type_test.v
+++ b/vlib/v/tests/sum_type_test.v
@@ -128,3 +128,17 @@ fn test_nested_sumtype() {
 		assert false
 	}
 }
+
+type Abc = int | string
+
+fn test_string_cast_to_sumtype() {
+	a := Abc('test')
+	match a {
+		string {
+			assert true
+		}
+		int {
+			assert false
+		}
+	}
+}


### PR DESCRIPTION
This PR fix string cast to sumtype (fix #5690).

- Fix string cast to sumtype.
- Modify test `match_expr_else.out`.
- Add test `test_string_cast_to_sumtype()` in sum_type_test.v. 

```v
type Abc = int | string

fn main() {
    a := Abc('test')
	match a {
		string {
			println('test')
		}
		else {}
	}
}

D:\test\v\tt1>v run .
test
```