### PR TITLE
Fix font-size

### DIFF
--- a/cmd/tools/vdoc-resources/doc.css
+++ b/cmd/tools/vdoc-resources/doc.css
@@ -411,7 +411,7 @@ body {
 pre, code, pre code {
   color: #5c6e74;
   color: var(--code-default-text-color);
-  font-size: 0.9rem;
+  font-size: 0.948em;
   text-shadow: none;
   font-family: monospace;
   background-color: #edf2f7;


### PR DESCRIPTION
Just a quick tweak to make `font-size` relative to the parent element - I hand-picked an `em` rather than `rem` value to match the original `font-size` in `<pre>`/`<code>` blocks, and this works better in titles, where the inline `<code>` tags were very small, as you can see in the before/after GIF here:

![style-before-after](https://user-images.githubusercontent.com/103348/86568083-a000c680-bf6c-11ea-8e47-d843e724a14f.gif)
