### PR TITLE
[doc] keywords appendix: Add assert, false, mut, true, unsafe

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2127,16 +2127,18 @@ fn C.WinFunction()
 
 ## Appendix I: Keywords
 
-V has 25 keywords:
+V has 29 keywords (3 are literals):
 
 ```v
 as
+assert
 break
 const
 continue
 defer
 else
 enum
+false
 fn
 for
 go
@@ -2154,8 +2156,11 @@ or
 pub
 return
 struct
+true
 type
+unsafe
 ```
+See also [Types](#types).
 
 ## Appendix II: Operators
 


### PR DESCRIPTION
I updated the keywords appendix in docs.md. I'm not sure where to update the markdown syntax highlighting for V though*. After that maybe the V documentation generator would need an update too?

\* `as` doesn't get highlighted, and `none` should be highlighted as a literal like `true` and `false` are.