### PR TITLE
js: move int division to parseInt

### DIFF
--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -1327,6 +1327,12 @@ fn (mut g JsGen) gen_infix_expr(it ast.InfixExpr) {
 		g.write(g.typ(it.right_type))
 		if it.op == .not_is { g.write(')') }
 	} else {
+		both_are_int := int(it.left_type) in table.integer_type_idxs && int(it.right_type) in table.integer_type_idxs
+
+		if it.op == .div && both_are_int {
+			g.write('parseInt(')
+		}
+
 		g.expr(it.left)
 
 		// in js == is non-strict & === is strict, always do strict
@@ -1341,8 +1347,8 @@ fn (mut g JsGen) gen_infix_expr(it ast.InfixExpr) {
 		g.expr(it.right)
 
 		// Int division: 2.5 -> 2 by prepending |0
-		if it.op == .div && it.left_type == table.any_int_type_idx && it.right_type == table.any_int_type_idx {
-			g.write('|0')
+		if it.op == .div && both_are_int {
+			g.write(',10)')
 		}
 	}
 }


### PR DESCRIPTION
`|0` is limited to i32 and parseInt is almost exactly as fast