### PR TITLE
cgen: minor optimization of comptime

### DIFF
--- a/vlib/v/gen/comptime.v
+++ b/vlib/v/gen/comptime.v
@@ -78,25 +78,35 @@ fn (g &Gen) comptime_call(node ast.ComptimeCall) {
 }
 
 fn (mut g Gen) comp_if(it ast.CompIf) {
+	if it.stmts.len == 0 {
+		return
+	}
 	ifdef := g.comp_if_to_ifdef(it.val, it.is_opt)
+	g.empty_line = false
 	if it.is_not {
-		g.writeln('\n// \$if !$it.val {\n#ifndef ' + ifdef)
+		g.writeln('// \$if !$it.val {\n#ifndef ' + ifdef)
 	} else {
-		g.writeln('\n// \$if  $it.val {\n#ifdef ' + ifdef)
+		g.writeln('// \$if  $it.val {\n#ifdef ' + ifdef)
 	}
 	// NOTE: g.defer_ifdef is needed for defers called witin an ifdef
 	// in v1 this code would be completely excluded
-	g.defer_ifdef = if it.is_not { '\n#ifndef ' + ifdef } else { '\n#ifdef ' + ifdef }
+	g.defer_ifdef = if it.is_not { '#ifndef ' + ifdef } else { '#ifdef ' + ifdef }
 	// println('comp if stmts $g.file.path:$it.pos.line_nr')
+	g.indent--
 	g.stmts(it.stmts)
+	g.indent++
 	g.defer_ifdef = ''
 	if it.has_else {
-		g.writeln('\n#else')
-		g.defer_ifdef = if it.is_not { '\n#ifdef ' + ifdef } else { '\n#ifndef ' + ifdef }
+		g.empty_line = false
+		g.writeln('#else')
+		g.defer_ifdef = if it.is_not { '#ifdef ' + ifdef } else { '#ifndef ' + ifdef }
+		g.indent--
 		g.stmts(it.else_stmts)
+		g.indent++
 		g.defer_ifdef = ''
 	}
-	g.writeln('\n#endif\n// } $it.val\n')
+	g.empty_line = false
+	g.writeln('#endif\n// } $it.val')
 }
 
 fn (mut g Gen) comp_for(node ast.CompFor) {

--- a/vlib/v/gen/comptime.v
+++ b/vlib/v/gen/comptime.v
@@ -78,7 +78,7 @@ fn (g &Gen) comptime_call(node ast.ComptimeCall) {
 }
 
 fn (mut g Gen) comp_if(it ast.CompIf) {
-	if it.stmts.len == 0 {
+	if it.stmts.len == 0 && it.else_stmts.len == 0 {
 		return
 	}
 	ifdef := g.comp_if_to_ifdef(it.val, it.is_opt)


### PR DESCRIPTION
This PR does minor optimization of comptime.

before:
```v
string os__user_os() {
	
// $if  linux {
#ifdef __linux__
	
#endif
// } linux

	
// $if  macos {
#ifdef __APPLE__
	
#endif
// } macos

	
// $if  windows {
#ifdef _WIN32
		return tos_lit("windows");
	
#endif
// } windows

	
// $if  freebsd {
#ifdef __FreeBSD__
	
#endif
// } freebsd

	
// $if  openbsd {
#ifdef __OpenBSD__
	
#endif
// } openbsd

	
// $if  netbsd {
#ifdef __NetBSD__
	
#endif
// } netbsd

	
// $if  dragonfly {
#ifdef __DragonFly__
	
#endif
// } dragonfly

	
// $if  android {
#ifdef __ANDROID__
	
#endif
// } android

	
// $if  solaris {
#ifdef __sun
	
#endif
// } solaris

	
// $if  haiku {
#ifdef __haiku__
	
#endif
// } haiku

	return tos_lit("unknown");
}
```
now (win10):
```v
string os__user_os() {
// $if  windows {
#ifdef _WIN32
	return tos_lit("windows");
#endif
// } windows
	return tos_lit("unknown");
}
```