### PR TITLE
all: remove `rwshared` keyword, make its semantics default for `shared`

### DIFF
--- a/doc/upcoming.md
+++ b/doc/upcoming.md
@@ -35,10 +35,17 @@ atomic d := ...
 - `c` can be passed to coroutines an accessed
   *concurrently*.<sup>2</sup> In order to avoid data races it has to
   be locked before access can occur and unlocked to allow access to
-  other coroutines. This is done by the following block structure:
+  other coroutines. This is done by one the following block structures:
   ```v
   lock c {
       // read, modify, write c
+      ...
+  }
+  ```
+  
+  ```v
+  rlock c {
+      // read c
       ...
   }
   ```

--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -402,6 +402,7 @@ fn C.pthread_mutex_unlock(voidptr) int
 
 fn C.pthread_rwlockattr_init(voidptr) int
 fn C.pthread_rwlockattr_setkind_np(voidptr, int) int
+fn C.pthread_rwlockattr_setpshared(voidptr, int) int
 fn C.pthread_rwlock_init(voidptr, voidptr) int
 fn C.pthread_rwlock_rdlock(voidptr) int
 fn C.pthread_rwlock_wrlock(voidptr) int

--- a/vlib/sync/sync_nix.c.v
+++ b/vlib/sync/sync_nix.c.v
@@ -33,6 +33,7 @@ pub fn new_rwmutex() &RwMutex {
 	C.pthread_rwlockattr_init(&a.attr)
 	// Give writer priority over readers
 	C.pthread_rwlockattr_setkind_np(&a.attr, C.PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP)
+	C.pthread_rwlockattr_setpshared(&a.attr, C.PTHREAD_PROCESS_PRIVATE)
 	C.pthread_rwlock_init(&m.mutex, &a.attr)
 	return m
 }

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -450,7 +450,6 @@ pub:
 pub mut:
 	lockeds  []Ident // `x`, `y` in `lock x, y {`
 	is_expr  bool
-	is_rw    bool // `rwshared` needs special special handling even in `lock` case
 	typ      table.Type
 }
 

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1158,9 +1158,6 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 				if call_arg.share == .shared_t {
 					words = 'shared'
 					tok = 'shared'
-				} else if call_arg.share == .rwshared_t {
-					words = 'read/write shared'
-					tok = 'rwshared'
 				} else if call_arg.share == .atomic_t {
 					words = 'atomic'
 					tok = 'atomic'
@@ -1176,9 +1173,6 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 				if arg.typ.share() == .shared_t {
 					words = ' shared'
 					tok = 'shared'
-				} else if arg.typ.share() == .rwshared_t {
-					words = ' read/write shared'
-					tok = 'rwshared'
 				} else if arg.typ.share() == .atomic_t {
 					words = 'n atomic'
 					tok = 'atomic'
@@ -1572,11 +1566,11 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 					}
 					mut scope := c.file.scope.innermost(assign_stmt.pos.pos)
 					mut ident_var_info := left.var_info()
-					if ident_var_info.share in [.shared_t, .rwshared_t] {
+					if ident_var_info.share == .shared_t {
 						left_type = left_type.set_flag(.shared_f)
 					}
-					if ident_var_info.share in [.atomic_t, .rwshared_t] {
-						left_type = left_type.set_flag(.atomic_or_rw)
+					if ident_var_info.share == .atomic_t {
+						left_type = left_type.set_flag(.atomic_f)
 					}
 					assign_stmt.left_types[i] = left_type
 					ident_var_info.typ = left_type

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -133,11 +133,11 @@ pub fn (mut p Parser) parse_type() table.Type {
 			return typ
 		}
 	}
-	is_shared := p.tok.kind in [.key_shared, .key_rwshared]
-	is_atomic_or_rw := p.tok.kind in [.key_rwshared, .key_atomic]
+	is_shared := p.tok.kind == .key_shared
+	is_atomic := p.tok.kind == .key_atomic
 
 	mut nr_muls := 0
-	if p.tok.kind == .key_mut || is_shared || is_atomic_or_rw {
+	if p.tok.kind == .key_mut || is_shared || is_atomic {
 		nr_muls++
 		p.next()
 	}
@@ -161,8 +161,8 @@ pub fn (mut p Parser) parse_type() table.Type {
 	if is_shared {
 		typ = typ.set_flag(.shared_f)
 	}
-	if is_atomic_or_rw {
-		typ = typ.set_flag(.atomic_or_rw)
+	if is_atomic {
+		typ = typ.set_flag(.atomic_f)
 	}
 	if nr_muls > 0 {
 		typ = typ.set_nr_muls(nr_muls)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -514,7 +514,7 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 		.key_for {
 			return p.for_stmt()
 		}
-		.name, .key_mut, .key_shared, .key_atomic, .key_rwshared, .key_static, .mul {
+		.name, .key_mut, .key_shared, .key_atomic, .key_static, .mul {
 			if p.tok.kind == .name {
 				if p.tok.lit == 'sql' {
 					return p.sql_stmt()
@@ -783,9 +783,9 @@ fn (mut p Parser) parse_multi_expr(is_top_level bool) ast.Stmt {
 
 pub fn (mut p Parser) parse_ident(language table.Language) ast.Ident {
 	// p.warn('name ')
-	is_shared := p.tok.kind in [.key_shared, .key_rwshared]
-	is_atomic_or_rw := p.tok.kind in [.key_rwshared, .key_atomic]
-	is_mut := p.tok.kind == .key_mut || is_shared || is_atomic_or_rw
+	is_shared := p.tok.kind == .key_shared
+	is_atomic := p.tok.kind == .key_atomic
+	is_mut := p.tok.kind == .key_mut || is_shared || is_atomic
 	if is_mut {
 		p.next()
 	}
@@ -823,7 +823,7 @@ pub fn (mut p Parser) parse_ident(language table.Language) ast.Ident {
 			info: ast.IdentVar{
 				is_mut: is_mut
 				is_static: is_static
-				share: table.sharetype_from_flags(is_shared, is_atomic_or_rw)
+				share: table.sharetype_from_flags(is_shared, is_atomic)
 			}
 		}
 	} else {

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -16,7 +16,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 	p.eat_comments()
 	// Prefix
 	match p.tok.kind {
-		.key_mut, .key_shared, .key_rwshared, .key_atomic, .key_static {
+		.key_mut, .key_shared, .key_atomic, .key_static {
 			node = p.name_expr()
 			p.is_stmt_ident = is_stmt_ident
 		}

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -42,7 +42,7 @@ pub enum TypeFlag {
 	variadic
 	generic
 	shared_f
-	atomic_or_rw
+	atomic_f
 }
 
 /* 
@@ -54,7 +54,6 @@ pub enum ShareType {
 	mut_t
 	shared_t
 	atomic_t
-	rwshared_t
 }
 
 pub fn (t ShareType) str() string {
@@ -62,7 +61,6 @@ pub fn (t ShareType) str() string {
 		.mut_t { return 'mut' }
 		.shared_t { return 'shared' }
 		.atomic_t { return 'atomic' }
-		.rwshared_t { return 'rwshared' }
 	}
 }
 
@@ -78,12 +76,12 @@ pub fn (t Type) atomic_typename() string {
 	}
 }
 
-pub fn sharetype_from_flags(is_shared, is_atomic_or_rw bool) ShareType {
-	return ShareType((int(is_atomic_or_rw) << 1) | int(is_shared))
+pub fn sharetype_from_flags(is_shared, is_atomic bool) ShareType {
+	return ShareType((int(is_atomic) << 1) | int(is_shared))
 }
 
 pub fn (t Type) share() ShareType {
-	return sharetype_from_flags(t.has_flag(.shared_f), t.has_flag(.atomic_or_rw))
+	return sharetype_from_flags(t.has_flag(.shared_f), t.has_flag(.atomic_f))
 }
 
 pub fn (types []Type) contains(typ Type) bool {

--- a/vlib/v/tests/shared_lock_3_test.v
+++ b/vlib/v/tests/shared_lock_3_test.v
@@ -6,7 +6,7 @@ mut:
 	a int
 }
 
-fn f(rwshared x St, shared z St) {
+fn f(shared x St, shared z St) {
 	for _ in 0..reads_per_thread {
 		rlock x { // other instances may read at the same time
 			time.sleep_ms(1)
@@ -26,14 +26,14 @@ const (
 
 fn test_shared_lock() {
 	// object with separate read/write lock
-	rwshared x := &St{
+	shared x := &St{
 		a: 5
 	}
 	shared z := &St{
 		a: read_threads
 	}
 	for _ in 0..read_threads {
-		go f(rwshared x, shared z)
+		go f(shared x, shared z)
 	}
 	for i in 0..writes {
 		lock x { // wait for ongoing reads to finish, don't start new ones

--- a/vlib/v/tests/shared_lock_4_test.v
+++ b/vlib/v/tests/shared_lock_4_test.v
@@ -6,7 +6,7 @@ mut:
 	a int
 }
 
-fn (rwshared x St) f(shared z St) {
+fn (shared x St) f(shared z St) {
 	for _ in 0..reads_per_thread {
 		rlock x { // other instances may read at the same time
 			time.sleep_ms(1)
@@ -26,7 +26,7 @@ const (
 
 fn test_shared_lock() {
 	// object with separate read/write lock
-	rwshared x := &St{
+	shared x := &St{
 		a: 5
 	}
 	shared z := &St{

--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -109,7 +109,6 @@ pub enum Kind {
 	key_module
 	key_mut
 	key_shared
-	key_rwshared
 	key_lock
 	key_rlock
 	key_none
@@ -231,7 +230,6 @@ fn build_token_str() []string {
 	s[Kind.key_const] = 'const'
 	s[Kind.key_mut] = 'mut'
 	s[Kind.key_shared] = 'shared'
-	s[Kind.key_rwshared] = 'rwshared'
 	s[Kind.key_lock] = 'lock'
 	s[Kind.key_rlock] = 'rlock'
 	s[Kind.key_type] = 'type'


### PR DESCRIPTION
Doing performance tests on real hardware has indicated that the benefit of having two different keywords `shared` and `rwshared` is negligible in most scenarios. So this PR removes the `rwshared` keyword and makes its `lock`/`rlock` semantics available for `shared` objects, thus simplifying the language a bit.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
