### PR TITLE
checker: fn assignment more than one var

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1536,7 +1536,9 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 		}
 		if assign_stmt.right_types.len < assign_stmt.left.len { // first type or multi return types added above
 			right_type := c.expr(assign_stmt.right[i])
-			assign_stmt.right_types << c.check_expr_opt_call(assign_stmt.right[i], right_type)
+			if assign_stmt.right_types.len == i {
+				assign_stmt.right_types << c.check_expr_opt_call(assign_stmt.right[i], right_type)
+			}
 		}
 		right := if i < assign_stmt.right.len { assign_stmt.right[i] } else { assign_stmt.right[0] }
 		right_type := assign_stmt.right_types[i]

--- a/vlib/v/tests/fn_assignment_test.v
+++ b/vlib/v/tests/fn_assignment_test.v
@@ -1,0 +1,55 @@
+fn test() int {
+	return 10
+}
+
+fn test1() int {
+	return 11
+}
+
+fn test_fn_assignment_var() {
+	mut a := 0
+	mut b := 0
+	a , b = test(), test1()
+	
+	assert a == 10 
+	assert b == 11
+
+	a, b = test(), test()
+	assert a == 10
+	assert b == 10
+
+	a, b = test(), 12
+
+	assert a == 10 
+	assert b == 12
+
+	a, b = 12, test()
+
+	assert a == 12
+	assert b == 10 
+}
+
+fn test_fn_assignment_array() {
+	mut a := [0, 1]
+
+	a[0], a[1] = test(), test1()
+
+	assert a[0] == 10 
+	assert a[1] == 11
+
+	a[0], a[1] = test() , test()
+
+	assert a[0] == 10 
+	assert a[1] == 10 
+
+	a[0], a[1] = test(), 12
+
+	assert a[0] == 10 
+	assert a[1] == 12 
+
+	a[0], a[1] = 12 , test() 
+	assert a[0] == 12 
+	assert a[1] == 10
+}
+
+


### PR DESCRIPTION
Fix for issue #5715 
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
