### PR TITLE
gen: fix error of generated `defer` code

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -850,15 +850,18 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 
 fn (mut g Gen) write_defer_stmts() {
 	for defer_stmt in g.defer_stmts {
-		g.writeln('// defer')
+		g.writeln('// Defer begin')
 		if defer_stmt.ifdef.len > 0 {
 			g.writeln(defer_stmt.ifdef)
 			g.stmts(defer_stmt.stmts)
 			g.writeln('')
 			g.writeln('#endif')
 		} else {
+			g.indent--
 			g.stmts(defer_stmt.stmts)
+			g.indent++
 		}
+		g.writeln('// Defer end')
 	}
 }
 

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -136,7 +136,9 @@ fn (mut g Gen) gen_fn_decl(it ast.FnDecl) {
 	}
 	g.stmts(it.stmts)
 	// ////////////
-	g.write_defer_stmts_when_needed()
+	if it.return_type == table.void_type {
+		g.write_defer_stmts_when_needed()
+	}
 	// /////////
 	if g.autofree {
 		// TODO: remove this, when g.write_autofree_stmts_when_needed works properly


### PR DESCRIPTION
This PR fix error of generated `defer` code.

problem:
- `defer` repeated calls.

before:
```v
Option_string os__read_file(string path) {
	string mode = tos_lit("rb");
	FILE* fp = os__vfopen(path, mode);
	if (isnil(fp)) {
		/*opt promotion*/ Option _t69 = v_error(_STR("failed to open file \"%.*s\000\"", 2, path));
		return *(Option_string*)&_t69;
	}
	fseek(fp, 0, SEEK_END);
	int fsize = ftell(fp);
	rewind(fp);
	byte* str = ((byte*)(0));
	{ // Unsafe block
		str = v_malloc(fsize + 1);
	}
	fread(str, fsize, 1, fp);
	str[fsize] = 0;
	// defer
		fclose(fp);
	Option_string _t70;
	/*:)string*/opt_ok2(&(string[]) { tos((byteptr)str, fsize) }, (OptionBase*)(&_t70), sizeof(string));
	return _t70;
// defer
	fclose(fp);
}
```
now:
```v
Option_string os__read_file(string path) {
	string mode = tos_lit("rb");
	FILE* fp = os__vfopen(path, mode);
	if (isnil(fp)) {
		/*opt promotion*/ Option _t69 = v_error(_STR("failed to open file \"%.*s\000\"", 2, path));
		return *(Option_string*)&_t69;
	}
	fseek(fp, 0, SEEK_END);
	int fsize = ftell(fp);
	rewind(fp);
	byte* str = ((byte*)(0));
	{ // Unsafe block
		str = v_malloc(fsize + 1);
	}
	fread(str, fsize, 1, fp);
	str[fsize] = 0;
	// Defer begin
	fclose(fp);
	// Defer end
	Option_string _t70;/*:)string*/opt_ok2(&(string[]) { tos((byteptr)str, fsize) }, (OptionBase*)(&_t70), sizeof(string));
	return _t70;
}
```