### PR TITLE
cgen: Support for auto str on enum pointer

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3976,7 +3976,7 @@ fn (mut g Gen) gen_str_for_type_with_styp(typ table.Type, styp string) string {
 			table.Alias { g.gen_str_default(sym, styp, str_fn_name) }
 			table.Array { g.gen_str_for_array(it, styp, str_fn_name) }
 			table.ArrayFixed { g.gen_str_for_array_fixed(it, styp, str_fn_name) }
-			table.Enum { g.gen_str_for_enum(it, styp, str_fn_name) }
+			table.Enum { g.gen_str_for_enum(it, typ, styp, str_fn_name) }
 			table.Struct { g.gen_str_for_struct(it, styp, str_fn_name) }
 			table.Map { g.gen_str_for_map(it, styp, str_fn_name) }
 			table.MultiReturn { g.gen_str_for_multi_return(it, styp, str_fn_name) }
@@ -4026,11 +4026,15 @@ fn (mut g Gen) gen_str_default(sym table.TypeSymbol, styp, str_fn_name string) {
 	g.auto_str_funcs.writeln('}')
 }
 
-fn (mut g Gen) gen_str_for_enum(info table.Enum, styp, str_fn_name string) {
-	s := util.no_dots(styp)
+fn (mut g Gen) gen_str_for_enum(info table.Enum, typ table.Type, styp, str_fn_name string) {
+	s, derefs := if !typ.is_ptr() { 
+		util.no_dots(styp), ''
+	} else {
+		util.no_dots(g.typ(typ.set_nr_muls(0))), '*'.repeat(typ.nr_muls())
+	}
 	g.type_definitions.writeln('string ${str_fn_name}($styp it); // auto')
 	g.auto_str_funcs.writeln('string ${str_fn_name}($styp it) { /* gen_str_for_enum */')
-	g.auto_str_funcs.writeln('\tswitch(it) {')
+	g.auto_str_funcs.writeln('\tswitch(${derefs}it) {')
 	for val in info.vals {
 		g.auto_str_funcs.writeln('\t\tcase ${s}_$val: return tos_lit("$val");')
 	}


### PR DESCRIPTION
Right now it tries to switch on `it` which is the address of the enum not the enum and it also generates the switch cases as (for example) 
```v
		case main__AM*_update_user_ban_request: return tos_lit("update_user_ban_request");
		case main__AM*_add_license: return tos_lit("add_license");
		case main__AM*_send_system_im_to_user: return tos_lit("send_system_im_to_user");
		case main__AM*_extend_license: return tos_lit("extend_license");
		case main__AM*_add_minutes_to_license: return tos_lit("add_minutes_to_license");
		case main__AM*_cancel_license: return tos_lit("cancel_license");
		case main__AM*_init_purchase: return tos_lit("init_purchase");
		case main__AM*_purchase_response: return tos_lit("purchase_response");
		case main__AM*_get_final_price: return tos_lit("get_final_price");
		case main__AM*_get_final_price_response: return tos_lit("get_final_price_response");
		case main__AM*_get_legacy_game_key: return tos_lit("get_legacy_game_key");
```

which is not ideal.

This PR fixes this behaviour.