### PR TITLE
cgen: add support for shared arrays

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -4500,9 +4500,9 @@ fn (mut g Gen) array_init(it ast.ArrayInit) {
 		if g.is_shared {
 			mut shared_typ := it.typ.set_flag(.shared_f)
 			shared_styp = g.typ(shared_typ)
-			g.writeln('($shared_styp*)memdup(&($shared_styp){.val = *($styp*)&')
+			g.writeln('($shared_styp*)memdup(&($shared_styp){.val = ')
 		} else {
-			g.write('($styp*)memdup(&')
+			g.write('($styp*)memdup(&') // TODO: doesn't work with every compiler
 		}
 	} else {
 		if g.is_shared {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2355,10 +2355,17 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 				if g.is_assign_lhs && !is_selector && node.is_setter {
 					g.is_array_set = true
 					g.write('array_set(')
-					if !left_is_ptr {
+					if !left_is_ptr || node.left_type.has_flag(.shared_f) {
 						g.write('&')
 					}
 					g.expr(node.left)
+					if node.left_type.has_flag(.shared_f) {
+						if left_is_ptr {
+							g.write('->val')
+						} else {
+							g.write('.val')
+						}
+					}
 					g.write(', ')
 					g.expr(node.index)
 					mut need_wrapper := true
@@ -2383,10 +2390,17 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 						info.elem_type != table.string_type {
 						// TODO move this
 						g.write('*($elem_type_str*)array_get(')
-						if left_is_ptr {
+						if left_is_ptr && !node.left_type.has_flag(.shared_f) {
 							g.write('*')
 						}
 						g.expr(node.left)
+						if node.left_type.has_flag(.shared_f) {
+							if left_is_ptr {
+								g.write('->val')
+							} else {
+								g.write('.val')
+							}
+						}
 						g.write(', ')
 						g.expr(node.index)
 						g.write(') ')
@@ -2407,10 +2421,17 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 					}
 				} else {
 					g.write('(*($elem_type_str*)array_get(')
-					if left_is_ptr {
+					if left_is_ptr && !node.left_type.has_flag(.shared_f) {
 						g.write('*')
 					}
 					g.expr(node.left)
+					if node.left_type.has_flag(.shared_f) {
+						if left_is_ptr {
+							g.write('->val')
+						} else {
+							g.write('.val')
+						}
+					}
 					g.write(', ')
 					g.expr(node.index)
 					g.write('))')
@@ -4470,6 +4491,24 @@ _Interface* I_${cctype}_to_Interface_${interface_name}_ptr($cctype* x) {
 
 fn (mut g Gen) array_init(it ast.ArrayInit) {
 	type_sym := g.table.get_type_symbol(it.typ)
+	styp := g.typ(it.typ)
+	mut shared_styp := '' // only needed for shared &[]{...}
+	is_amp := g.is_amp
+	g.is_amp = false
+	if is_amp {
+		g.out.go_back(1) // delete the `&` already generated in `prefix_expr()
+		if g.is_shared {
+			mut shared_typ := it.typ.set_flag(.shared_f)
+			shared_styp = g.typ(shared_typ)
+			g.writeln('($shared_styp*)memdup(&($shared_styp){.val = ($styp)')
+		} else {
+			g.write('($styp*)memdup(')
+		}
+	} else {
+		if g.is_shared {
+			g.writeln('{.val = ($styp*)')
+		}
+	}
 	if type_sym.kind == .array_fixed {
 		g.write('{')
 		for i, expr in it.exprs {
@@ -4541,6 +4580,14 @@ fn (mut g Gen) array_init(it ast.ArrayInit) {
 		}
 	}
 	g.write('}))')
+	if g.is_shared {
+		g.write(', .mtx = sync__new_rwmutex()}')
+		if is_amp {
+			g.write(', sizeof($shared_styp))')
+		}
+	} else if is_amp {
+		g.write(', sizeof($styp))')
+	}
 }
 
 // `ui.foo(button)` =>

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -4500,9 +4500,9 @@ fn (mut g Gen) array_init(it ast.ArrayInit) {
 		if g.is_shared {
 			mut shared_typ := it.typ.set_flag(.shared_f)
 			shared_styp = g.typ(shared_typ)
-			g.writeln('($shared_styp*)memdup(&($shared_styp){.val = ($styp)')
+			g.writeln('($shared_styp*)memdup(&($shared_styp){.val = *($styp*)&')
 		} else {
-			g.write('($styp*)memdup(')
+			g.write('($styp*)memdup(&')
 		}
 	} else {
 		if g.is_shared {

--- a/vlib/v/tests/shared_array_test.v
+++ b/vlib/v/tests/shared_array_test.v
@@ -34,12 +34,8 @@ fn test_shared_array(){
 		}
 		time.sleep_ms(100)
 	}
-	mut s := 0
-	mut t := 0
 	rlock foo {
-		s = foo[0]
-		t = foo[1]
+		assert foo[0] == 100010
+		assert foo[1] == 350020
 	}
-	assert s == 100010
-	assert t == 350020
 }

--- a/vlib/v/tests/shared_array_test.v
+++ b/vlib/v/tests/shared_array_test.v
@@ -1,0 +1,41 @@
+import sync
+import time
+
+fn incr(shared foo []int, index int) {
+    for _ in 0..100000 {
+		lock foo {
+			foo[index] = foo[index] + 1
+		}
+    }
+	lock foo {
+		foo[2]++
+	}
+}
+
+fn test_shared_array(){
+    shared foo := &[10, 20, 0]
+    go incr(shared foo, 0)
+    go incr(shared foo, 1)
+    go incr(shared foo, 0)
+    go incr(shared foo, 1)
+	for _ in 0..50000 {
+		lock foo {
+			foo[0] -= 2
+			foo[1] += 3
+		}
+	}
+	mut finished_threads := 0
+	for {
+		rlock foo {
+			finished_threads = foo[2]
+		}
+		if finished_threads == 4 {
+			break
+		}
+		time.sleep_ms(100)
+	}
+	rlock foo {
+		assert foo[0] == 100010
+		assert foo[1] == 350020
+	}
+}

--- a/vlib/v/tests/shared_array_test.v
+++ b/vlib/v/tests/shared_array_test.v
@@ -34,8 +34,12 @@ fn test_shared_array(){
 		}
 		time.sleep_ms(100)
 	}
+	mut s := 0
+	mut t := 0
 	rlock foo {
-		assert foo[0] == 100010
-		assert foo[1] == 350020
+		s = foo[0]
+		t = foo[1]
 	}
+	assert s == 100010
+	assert t == 350020
 }

--- a/vlib/v/tests/shared_array_test.v
+++ b/vlib/v/tests/shared_array_test.v
@@ -2,23 +2,23 @@ import sync
 import time
 
 fn incr(shared foo []int, index int) {
-    for _ in 0..100000 {
+	for _ in 0 .. 100000 {
 		lock foo {
 			foo[index] = foo[index] + 1
 		}
-    }
+	}
 	lock foo {
 		foo[2]++
 	}
 }
 
-fn test_shared_array(){
-    shared foo := &[10, 20, 0]
-    go incr(shared foo, 0)
-    go incr(shared foo, 1)
-    go incr(shared foo, 0)
-    go incr(shared foo, 1)
-	for _ in 0..50000 {
+fn test_shared_array() {
+	shared foo := &[10, 20, 0]
+	go incr(shared foo, 0)
+	go incr(shared foo, 1)
+	go incr(shared foo, 0)
+	go incr(shared foo, 1)
+	for _ in 0 .. 50000 {
 		lock foo {
 			foo[0] -= 2
 			foo[1] += 3

--- a/vlib/v/tests/shared_lock_2_test.v
+++ b/vlib/v/tests/shared_lock_2_test.v
@@ -7,7 +7,7 @@ mut:
 }
 
 fn (shared x St) f(shared y St, shared z St) {
-	for _ in 0..101 {
+	for _ in 0 .. 101 {
 		lock x, y {
 			tmp := y.a
 			y.a = x.a
@@ -30,7 +30,7 @@ fn test_shared_receiver_lock() {
 		a: 1
 	}
 	go x.f(shared y, shared z)
-	for _ in 0..100 {
+	for _ in 0 .. 100 {
 		lock x, y {
 			tmp := x.a
 			x.a = y.a
@@ -38,8 +38,8 @@ fn test_shared_receiver_lock() {
 		}
 	}
 	// the following would be a good application for a channel
-	for finished := false; ; {
-		lock z {
+	for finished := false; true; {
+		rlock z {
 			finished = z.a == 0
 		}
 		if finished {
@@ -47,7 +47,7 @@ fn test_shared_receiver_lock() {
 		}
 		time.sleep_ms(100)
 	}
-	lock x, y {
+	rlock x, y {
 		assert x.a == 7 && y.a == 5
 	}
 }

--- a/vlib/v/tests/shared_lock_3_test.v
+++ b/vlib/v/tests/shared_lock_3_test.v
@@ -7,7 +7,7 @@ mut:
 }
 
 fn f(shared x St, shared z St) {
-	for _ in 0..reads_per_thread {
+	for _ in 0 .. reads_per_thread {
 		rlock x { // other instances may read at the same time
 			time.sleep_ms(1)
 			assert x.a == 7 || x.a == 5
@@ -20,8 +20,8 @@ fn f(shared x St, shared z St) {
 
 const (
 	reads_per_thread = 30
-	read_threads = 10
-	writes = 5
+	read_threads     = 10
+	writes           = 5
 )
 
 fn test_shared_lock() {
@@ -32,21 +32,21 @@ fn test_shared_lock() {
 	shared z := &St{
 		a: read_threads
 	}
-	for _ in 0..read_threads {
+	for _ in 0 .. read_threads {
 		go f(shared x, shared z)
 	}
-	for i in 0..writes {
+	for i in 0 .. writes {
 		lock x { // wait for ongoing reads to finish, don't start new ones
 			x.a = 17 // this should never be read
 			time.sleep_ms(50)
-			x.a = if (i&1) == 0 { 7 } else { 5 }
+			x.a = if (i & 1) == 0 { 7 } else { 5 }
 		} // now new reads are possible again
 		time.sleep_ms(20)
 	}
 	// wait until all read threads are finished
-	for finished := false; ; {
+	for finished := false; true; {
 		mut rr := 0
-		lock z {
+		rlock z {
 			rr = z.a
 			finished = z.a == 0
 		}

--- a/vlib/v/tests/shared_lock_4_test.v
+++ b/vlib/v/tests/shared_lock_4_test.v
@@ -7,7 +7,7 @@ mut:
 }
 
 fn (shared x St) f(shared z St) {
-	for _ in 0..reads_per_thread {
+	for _ in 0 .. reads_per_thread {
 		rlock x { // other instances may read at the same time
 			time.sleep_ms(1)
 			assert x.a == 7 || x.a == 5
@@ -20,8 +20,8 @@ fn (shared x St) f(shared z St) {
 
 const (
 	reads_per_thread = 30
-	read_threads = 10
-	writes = 5
+	read_threads     = 10
+	writes           = 5
 )
 
 fn test_shared_lock() {
@@ -32,21 +32,21 @@ fn test_shared_lock() {
 	shared z := &St{
 		a: read_threads
 	}
-	for _ in 0..read_threads {
+	for _ in 0 .. read_threads {
 		go x.f(shared z)
 	}
-	for i in 0..writes {
+	for i in 0 .. writes {
 		lock x { // wait for ongoing reads to finish, don't start new ones
 			x.a = 17 // this value should never be read
 			time.sleep_ms(50)
-			x.a = if (i&1) == 0 { 7 } else { 5 }
+			x.a = if (i & 1) == 0 { 7 } else { 5 }
 		} // now new reads are possible again
 		time.sleep_ms(20)
 	}
 	// wait until all read threads are finished
-	for finished := false; ; {
+	for finished := false; true; {
 		mut rr := 0
-		lock z {
+		rlock z {
 			rr = z.a
 			finished = z.a == 0
 		}

--- a/vlib/v/tests/shared_lock_test.v
+++ b/vlib/v/tests/shared_lock_test.v
@@ -7,7 +7,7 @@ mut:
 }
 
 fn f(shared x St, shared y St, shared z St) {
-	for _ in 0..101 {
+	for _ in 0 .. 101 {
 		lock x, y {
 			tmp := y.a
 			y.a = x.a
@@ -30,7 +30,7 @@ fn test_shared_lock() {
 		a: 1
 	}
 	go f(shared x, shared y, shared z)
-	for _ in 0..100 {
+	for _ in 0 .. 100 {
 		lock x, y {
 			tmp := x.a
 			x.a = y.a
@@ -38,8 +38,8 @@ fn test_shared_lock() {
 		}
 	}
 	// the following would be a good application for a channel
-	for finished := false; ; {
-		lock z {
+	for finished := false; true; {
+		rlock z {
 			finished = z.a == 0
 		}
 		if finished {
@@ -47,7 +47,7 @@ fn test_shared_lock() {
 		}
 		time.sleep_ms(100)
 	}
-	lock x, y {
+	rlock x, y {
 		assert x.a == 7 && y.a == 5
 	}
 }


### PR DESCRIPTION
This PR enables support for locking on arrays:
```v
fn main() {
    shared a := &[10, 20, 0]
    go f(shared a)
    lock a {
        a[1] += 5
    }
    ...
    rlock a { // read only access
        println('${a[0]}')
    }
}

fn f(shared x) {
    lock x {
        x[0] = x[1] +3
    }
}
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
