### PR TITLE
parser: check variable names as non-reserved identifiers (fix #5708)

### DIFF
--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -102,6 +102,9 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr) ast.Stmt {
 		match lx {
 			ast.Ident {
 				if op == .decl_assign {
+					if p.table.is_reserved_ident(lx.name) {
+						p.error_with_pos('`$lx.name` is reserved identifier', lx.pos)
+					}
 					if p.scope.known_var(lx.name) {
 						p.error_with_pos('redefinition of `$lx.name`', lx.pos)
 					}

--- a/vlib/v/parser/tests/variable_name_is_reserved.out
+++ b/vlib/v/parser/tests/variable_name_is_reserved.out
@@ -1,0 +1,6 @@
+vlib/v/parser/tests/variable_name_is_reserved.v:2:2: error: `byte` is reserved identifier
+    1 | fn main() {
+    2 |     byte := 1
+      |     ~~~~
+    3 |     println(byte)
+    4 | }

--- a/vlib/v/parser/tests/variable_name_is_reserved.vv
+++ b/vlib/v/parser/tests/variable_name_is_reserved.vv
@@ -1,0 +1,4 @@
+fn main() {
+	byte := 1
+	println(byte)
+}

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -9,14 +9,15 @@ import v.token
 
 pub struct Table {
 pub mut:
-	types         []TypeSymbol
-	type_idxs     map[string]int
-	fns           map[string]Fn
-	imports       []string // List of all imports
-	modules       []string // Topologically sorted list of all modules registered by the application
-	cflags        []cflag.CFlag
-	redefined_fns []string
-	fn_gen_types  map[string][]Type // for generic functions
+	types           []TypeSymbol
+	type_idxs       map[string]int
+	fns             map[string]Fn
+	imports         []string // List of all imports
+	modules         []string // Topologically sorted list of all modules registered by the application
+	cflags          []cflag.CFlag
+	redefined_fns   []string
+	fn_gen_types    map[string][]Type // for generic functions
+	reserved_idents map[string]int    // reserved identifiers
 }
 
 pub struct Fn {
@@ -30,9 +31,9 @@ pub:
 	is_deprecated bool
 	mod           string
 	ctdefine      string // compile time define. myflag, when [if myflag] tag
-	attrs []string
+	attrs         []string
 pub mut:
-	name        string
+	name          string
 }
 
 pub struct Arg {
@@ -53,7 +54,11 @@ mut:
 }
 
 pub fn new_table() &Table {
-	mut t := &Table{}
+	mut t := &Table{
+		reserved_idents: {'byte':1, 'int':1, 'string':1, 'rune':1, 'bool':1, 'i8':1,
+			'i16':1, 'u16':1, 'u32':1, 'i64':1, 'u64':1, 'f32':1, 'f64':1, 'any':1,
+			'voidptr':1, 'byteptr':1, 'charptr':1, 'size_t':1}
+	}
 	t.register_builtin_type_symbols()
 	return t
 }
@@ -99,6 +104,11 @@ pub fn (t &Table) find_fn(name string) ?Fn {
 		return f
 	}
 	return none
+}
+
+[inline]
+pub fn (t &Table) is_reserved_ident(name string) bool {
+	return t.reserved_idents.exists(name)
 }
 
 pub fn (t &Table) known_fn(name string) bool {

--- a/vlib/v/tests/repl/default_printing.repl
+++ b/vlib/v/tests/repl/default_printing.repl
@@ -1,6 +1,6 @@
-num := 1 string := 'Hello'
+num := 1 str := 'Hello'
 num
-string
+str
 ===output===
 1
 Hello


### PR DESCRIPTION
This PR check variable names as non-reserved identifiers (fix #5708).

- Check variable names as non-reserved identifiers.
- Add test `variable_name_is_reserved.vv/out`.

```v
fn main() {
	byte := 22
	println(sizeof(byte))
}

D:\test\v\tt1>v run .
.\tt1.v:2:2: error: `byte` is reserved identifier
    1 | fn main() {
    2 |     byte := 22
      |     ~~~~
    3 |     println(sizeof(byte))
    4 | }
```