### PR TITLE
builder,cflags: cache msvc, msvc handles cflag defines, only ever pass 1 .c to be turned into an object file

### DIFF
--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -25,6 +25,7 @@ mut:
 pub mut:
 	module_search_paths []string
 	parsed_files        []ast.File
+	cached_msvc			MsvcResult
 }
 
 pub fn new_builder(pref &pref.Preferences) Builder {
@@ -36,6 +37,12 @@ pub fn new_builder(pref &pref.Preferences) Builder {
 	}
 	if pref.use_color == .never {
 		util.emanager.set_support_color(false)
+	}
+	msvc := find_msvc() or {
+		if pref.ccompiler == 'msvc' {
+			verror('Cannot find MSVC on this OS')
+		}
+		MsvcResult { valid: false }
 	}
 	return Builder{
 		pref: pref
@@ -50,6 +57,7 @@ pub fn new_builder(pref &pref.Preferences) Builder {
 		} else {
 			100
 		}
+		cached_msvc: msvc
 	}
 	// max_nr_errors: pref.error_limit ?? 100 TODO potential syntax?
 }

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -661,7 +661,7 @@ fn (c &Builder) build_thirdparty_obj_files() {
 		if flag.value.ends_with('.o') {
 			rest_of_module_flags := c.get_rest_of_module_cflags(flag)
 			if c.pref.ccompiler == 'msvc' {
-				build_thirdparty_obj_file_with_msvc(flag.value, rest_of_module_flags)
+				c.build_thirdparty_obj_file_with_msvc(flag.value, rest_of_module_flags)
 			} else {
 				c.build_thirdparty_obj_file(flag.value, rest_of_module_flags)
 			}
@@ -684,16 +684,7 @@ fn (mut v Builder) build_thirdparty_obj_file(path string, moduleflags []cflag.CF
 		return
 	}
 	println('$obj_path not found, building it...')
-	parent := os.dir(obj_path)
-	files := os.ls(parent) or {
-		panic(err)
-	}
-	mut cfiles := ''
-	for file in files {
-		if file.ends_with('.c') {
-			cfiles += '"' + os.real_path(parent + os.path_separator + file) + '" '
-		}
-	}
+	cfiles := '${path[..path.len-2]}.c'
 	btarget := moduleflags.c_options_before_target()
 	atarget := moduleflags.c_options_after_target()
 	cppoptions := if v.pref.ccompiler.contains('++') { ' -fpermissive -w ' } else { '' }

--- a/vlib/v/cflag/cflags.v
+++ b/vlib/v/cflag/cflags.v
@@ -44,7 +44,7 @@ pub fn (cflags []CFlag) c_options_before_target() string {
 	// -I flags, optimization flags and so on
 	mut args := []string{}
 	for flag in cflags {
-		if flag.name != '-l' {
+		if flag.name != '-l' && !flag.value.ends_with('.o') {
 			args << flag.format()
 		}
 	}


### PR DESCRIPTION
number of fixes for bugs i encountered trying to get `tomcrpyt` to compile correctly.

Caching msvc is fairly straight forwards and means that trying to compile large numbers of thirdparty object files is fast (dont have to call `vswhere` with a ps_open every time you want to compile one of them.

Only passing 1 c file for thirdparty object files fixes when there are multiple in the same directory (msvc will only ever accept one of them and with gcc it was just passing them as extra flags in the command line which made gcc throw its hands in the air in dispair)