### PR TITLE
cgen: fix assert `sumtype is` (fix #5704)

### DIFF
--- a/vlib/v/builder/msvc.v
+++ b/vlib/v/builder/msvc.v
@@ -142,7 +142,7 @@ fn find_vs(vswhere_dir, host_arch string) ?VsInstallation {
 	res_output := res.output.trim_right('\r\n')
 	// println('res: "$res"')
 	version := os.read_file('$res_output\\VC\\Auxiliary\\Build\\Microsoft.VCToolsVersion.default.txt') or {
-		println('Unable to find msvc version')
+		//println('Unable to find msvc version')
 		return error('Unable to find vs installation')
 	}
 	version2 := version // TODO remove. cgen option bug if expr
@@ -313,7 +313,7 @@ pub fn (mut v Builder) cc_msvc() {
 
 fn (mut v Builder) build_thirdparty_obj_file_with_msvc(path string, moduleflags []cflag.CFlag) {
 	msvc := v.cached_msvc
-	
+
 	if msvc.valid == false {
 		verror('Cannot find MSVC on this OS')
 		return
@@ -408,4 +408,3 @@ pub fn msvc_string_flags(cflags []cflag.CFlag) MsvcStringFlags {
 		other_flags: other_flags
 	}
 }
-

--- a/vlib/v/tests/assert_sumtype_test.v
+++ b/vlib/v/tests/assert_sumtype_test.v
@@ -1,0 +1,10 @@
+struct Moon {}
+struct Mars {}
+
+type World = Moon | Mars
+
+fn test_assert_sumtype() {
+	w := World(Moon{})
+	assert w is Moon
+	assert w !is Mars
+}


### PR DESCRIPTION
This PR fix assert `sumtype is` (fix #5704).

- Fix assert `sumtype is`.
- Add test `assert_sumtype_test.v`.

```v
struct Moon {}
struct Mars {}

type World = Moon | Mars

fn main() {
	w := World(Moon{})
	assert w is Moon
	assert w !is Mars
}
```