### PR TITLE
builtin:fix array push_many memory leak

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -385,7 +385,7 @@ fn (mut a array) push(val voidptr) {
 pub fn (mut a3 array) push_many(val voidptr, size int) {
 	if a3.data == val {
 		// handle `arr << arr`
-		copy := a3.clone()
+		//copy := a3.clone()
 		a3.ensure_cap(a3.len + size)
 		unsafe {
 			//C.memcpy(a.data, copy.data, copy.element_size * copy.len)


### PR DESCRIPTION
copy no used.
it will cause memory leak for cgen output code



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
