### PR TITLE
examples: fix sokol examples

### DIFF
--- a/examples/sokol/drawing.v
+++ b/examples/sokol/drawing.v
@@ -18,7 +18,7 @@ fn main() {
 	title := 'Sokol Drawing Template'
 	desc := C.sapp_desc{
 		user_data: state
-		init_userdata_cb: init
+		init_userdata_cb: setup
 		frame_userdata_cb: frame
 		window_title: title.str
 		html5_canvas_name: title.str
@@ -26,7 +26,7 @@ fn main() {
 	sapp.run(&desc)
 }
 
-fn init(user_data voidptr) {
+fn setup(user_data voidptr) {
 	desc := C.sg_desc{
 		mtl_device: sapp.metal_get_device()
 		mtl_renderpass_descriptor_cb: sapp.metal_get_renderpass_descriptor

--- a/examples/sokol/fonts.v
+++ b/examples/sokol/fonts.v
@@ -29,7 +29,7 @@ fn main() {
 	title := 'V Metal/GL Text Rendering'
 	desc := C.sapp_desc{
 		user_data: state
-		init_userdata_cb: init
+		init_userdata_cb: setup
 		frame_userdata_cb: frame
 		window_title: title.str
 		html5_canvas_name: title.str
@@ -37,7 +37,7 @@ fn main() {
 	sapp.run(&desc)
 }
 
-fn init(mut state AppState) {
+fn setup(mut state AppState) {
 	// dont actually alocate this on the heap in real life
 	gfx.setup(&C.sg_desc{
 		mtl_device: sapp.metal_get_device()

--- a/examples/sokol/freetype_raven.v
+++ b/examples/sokol/freetype_raven.v
@@ -79,7 +79,7 @@ fn main() {
 	title := 'V Metal/GL Text Rendering'
 	desc := C.sapp_desc{
 		user_data: state
-		init_userdata_cb: init
+		init_userdata_cb: setup
 		frame_userdata_cb: frame
 		window_title: title.str
 		html5_canvas_name: title.str
@@ -90,7 +90,7 @@ fn main() {
 	sapp.run(&desc)
 }
 
-fn init(user_data voidptr) {
+fn setup(user_data voidptr) {
 	mut state := &AppState(user_data)
 	// dont actually alocate this on the heap in real life
 	gfx.setup(&C.sg_desc{

--- a/examples/sokol/particles/main.v
+++ b/examples/sokol/particles/main.v
@@ -52,7 +52,7 @@ fn (a App) run() {
 		width: a.width
 		height: a.height
 		user_data: &a
-		init_userdata_cb: init
+		init_userdata_cb: setup
 		frame_userdata_cb: frame
 		event_userdata_cb: event
 		window_title: title.str
@@ -66,7 +66,7 @@ fn (a App) draw() {
 	a.ps.draw()
 }
 
-fn init(user_data voidptr) {
+fn setup(user_data voidptr) {
 	desc := C.sg_desc{
 		mtl_device: sapp.metal_get_device()
 		mtl_renderpass_descriptor_cb: sapp.metal_get_renderpass_descriptor


### PR DESCRIPTION
Fix compilation of the sokol examples by preventing a clash with `_vinit` - rename `init` to `setup`