### PR TITLE
cc: Use response files to avoid command line length limits

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -395,10 +395,15 @@ fn (mut v Builder) cc() {
 		println('cc args=$args')
 		println(a)
 	}
+	// write args to response file
+	response_file := '${v.out_name_c}.rsp'
+	os.write_file(response_file, args.replace('\\', '\\\\')) or {
+		verror('Unable to write response file "$response_file"')
+	}
 	start:
 	todo()
 	// TODO remove
-	cmd := '${ccompiler} $args'
+	cmd := '${ccompiler} @$response_file'
 	// Run
 	if v.pref.is_verbose || v.pref.show_cc {
 		println('\n==========')

--- a/vlib/v/builder/msvc.v
+++ b/vlib/v/builder/msvc.v
@@ -199,6 +199,7 @@ pub fn (mut v Builder) cc_msvc() {
 	}
 	out_name_obj := os.real_path(v.out_name_c + '.obj')
 	out_name_pdb := os.real_path(v.out_name_c + '.pdb')
+	out_name_cmd_line := os.real_path(v.out_name_c + '.rsp')
 	// Default arguments
 	// volatile:ms enables atomic volatile (gcc _Atomic)
 	// -w: no warnings
@@ -288,7 +289,11 @@ pub fn (mut v Builder) cc_msvc() {
 	}
 	a << lib_paths
 	args := a.join(' ')
-	cmd := '"$r.full_cl_exe_path" $args'
+	// write args to a file so that we dont smash createprocess
+	os.write_file(out_name_cmd_line, args) or {
+		verror('Unable to write response file to "$out_name_cmd_line"')
+	}
+	cmd := '"$r.full_cl_exe_path" @$out_name_cmd_line'
 	// It is hard to see it at first, but the quotes above ARE balanced :-| ...
 	// Also the double quotes at the start ARE needed.
 	if v.pref.is_verbose {


### PR DESCRIPTION
This PR changes CC's behaviour to write all arguments to a response file and then telling the compilers to read from that. This allows us to get around limits like the windows command line limit or `CreateProcess*`'s limit of a command line for 32k characters (which I serendipitously smashed just now). As @spytheman pointed out this is supported across clang, gcc, msvc and tcc so it covers nearly all bases.