### PR TITLE
cgen: minor optimization of `struct_init` generated code

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2888,7 +2888,7 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 		}
 		// g.zero_struct_fields(info, inited_fields)
 		// nr_fields = info.fields.len
-		for i, field in info.fields {
+		for field in info.fields {
 			if field.name in inited_fields {
 				sfield := struct_init.fields[inited_fields[field.name]]
 				field_name := c_name(sfield.name)
@@ -2907,7 +2907,12 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 					}
 					g.expr_with_cast(sfield.expr, sfield.typ, sfield.expected_type)
 				}
-				g.write_struct_field_comma(i, info.fields.len, is_multiline)
+				if is_multiline {
+					g.writeln(',')
+				} else {
+					g.write(',')
+				}
+
 				initialized = true
 				continue
 			}
@@ -2920,7 +2925,12 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 				continue
 			}
 			g.zero_struct_field(field)
-			g.write_struct_field_comma(i, info.fields.len, is_multiline)
+			if is_multiline {
+				g.writeln(',')
+			} else {
+				g.write(',')
+			}
+
 			initialized = true
 		}
 	}
@@ -2937,20 +2947,6 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 		}
 	} else if is_amp {
 		g.write(', sizeof($styp))')
-	}
-}
-
-fn (mut g Gen) write_struct_field_comma(idx, count int, is_multiline bool) {
-	if idx != count-1 {
-		if is_multiline {
-			g.writeln(',')
-		} else {
-			g.write(', ')
-		}
-	} else {
-		if is_multiline {
-			g.writeln('')
-		}
 	}
 }
 

--- a/vlib/v/gen/sql.v
+++ b/vlib/v/gen/sql.v
@@ -183,8 +183,11 @@ fn (mut g Gen) sql_select_expr(node ast.SqlExpr) {
 			//
 			sym := g.table.get_type_symbol(array_info.elem_type)
 			info := sym.info as table.Struct
-			for field in info.fields {
+			for i, field in info.fields {
 				g.zero_struct_field(field)
+				if i != info.fields.len-1 {
+					g.write(', ')
+				}
 			}
 			g.writeln('};')
 		} else {
@@ -195,8 +198,11 @@ fn (mut g Gen) sql_select_expr(node ast.SqlExpr) {
 			// by the db engine.
 			sym := g.table.get_type_symbol(node.typ)
 			info := sym.info as table.Struct
-			for field in info.fields {
+			for i, field in info.fields {
 				g.zero_struct_field(field)
+				if i != info.fields.len-1 {
+					g.write(', ')
+				}
 			}
 			g.writeln('};')
 		}


### PR DESCRIPTION
This PR does minor optimization of `struct_init` generated code.

- Genarated multi-lines when more than 5 struct fields.
- Improved indentation.
- Remove the comma of the last field.

```v
	os__ProcessInformation proc_info = (os__ProcessInformation){.h_process = 0, .h_thread = 0, .dw_process_id = 0, .dw_thread_id = 0};
	os__StartupInfo start_info = (os__StartupInfo){
		.cb = /*SizeOfType*/ sizeof(PROCESS_INFORMATION),
		.lp_reserved = 0,
		.lp_desktop = 0,
		.lp_title = 0,
		.dw_x = 0,
		.dw_y = 0,
		.dw_x_size = 0,
		.dw_y_size = 0,
		.dw_x_count_chars = 0,
		.dw_y_count_chars = 0,
		.dw_fill_attributes = 0,
		.dw_flags = ((u32)(STARTF_USESTDHANDLES)),
		.w_show_window = 0,
		.cb_reserved2 = 0,
		.lp_reserved2 = 0,
		.h_std_input = child_stdin,
		.h_std_output = child_stdout_write,
		.h_std_error = child_stdout_write
	};
```