### PR TITLE
cgen: add `gen_map_equality_fn` to compare map type (fix #5650)

### DIFF
--- a/vlib/v/tests/map_equality_test.v
+++ b/vlib/v/tests/map_equality_test.v
@@ -1,0 +1,18 @@
+fn test_map_equality() {
+	a1 := {'a':1, 'b':2}
+	b1 := {'b':2, 'a':1}
+	c1 := {'a':2, 'b':1}
+
+	assert a1 == b1
+	assert a1 != c1
+
+	a2 := {'a':1}
+	b2 := {'a':1, 'b':2}
+
+	assert a2 != b2
+
+	a3 := {'a':'1', 'b':'2'}
+	b3 := {'b':'2', 'a':'1'}
+
+	assert a3 == b3
+}


### PR DESCRIPTION
This PR add `gen_map_equality_fn` to compare map type (fix #5650).

- Add `gen_map_equality_fn` to compare map type.
- Add test `map_equality_test.v`.

```v
fn test_map_equality() {
	a1 := {'a':1, 'b':2}
	b1 := {'b':2, 'a':1}
	c1 := {'a':2, 'b':1}

	assert a1 == b1
	assert a1 != c1

	a2 := {'a':1}
	b2 := {'a':1, 'b':2}

	assert a2 != b2

	a3 := {'a':'1', 'b':'2'}
	b3 := {'b':'2', 'a':'1'}

	assert a3 == b3
}
```
There are some complex situations will be resolved later.