### PR TITLE
parser,checker,cgen: add _allow_multiple_values enum attribute

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -622,12 +622,13 @@ pub:
 
 pub struct EnumDecl {
 pub:
-	name     string
-	is_pub   bool
-	is_flag  bool // true when the enum has [flag] tag
-	comments []Comment // enum Abc { /* comments */ ... }
-	fields   []EnumField
-	pos      token.Position
+	name             string
+	is_pub           bool
+	is_flag          bool // true when the enum has [flag] tag
+	is_multi_allowed bool
+	comments         []Comment // enum Abc { /* comments */ ... }
+	fields           []EnumField
+	pos              token.Position
 }
 
 pub struct AliasTypeDecl {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1469,7 +1469,7 @@ pub fn (mut c Checker) enum_decl(decl ast.EnumDecl) {
 					val := field_expr.val.i64()
 					if val < enum_min || val > enum_max {
 						c.error('enum value `$val` overflows int', field_expr.pos)
-					} else if int(val) in seen {
+					} else if !decl.is_multi_allowed && int(val) in seen {
 						c.error('enum value `$val` already exists', field_expr.pos)
 					}
 					seen << int(val)

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -4104,7 +4104,14 @@ fn (mut g Gen) gen_str_for_enum(info table.Enum, styp, str_fn_name string) {
 	g.type_definitions.writeln('string ${str_fn_name}($styp it); // auto')
 	g.auto_str_funcs.writeln('string ${str_fn_name}($styp it) { /* gen_str_for_enum */')
 	g.auto_str_funcs.writeln('\tswitch(it) {')
+	// Only use the first multi value on the lookup
+	mut seen := []string{len:info.vals.len}
 	for val in info.vals {
+		if info.is_multi_allowed && val in seen {
+			continue
+		} else if info.is_multi_allowed {
+			seen << val
+		}
 		g.auto_str_funcs.writeln('\t\tcase ${s}_$val: return tos_lit("$val");')
 	}
 	g.auto_str_funcs.writeln('\t\tdefault: return tos_lit("unknown enum value");')

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1501,6 +1501,7 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 	p.top_level_statement_end()
 	p.check(.rcbr)
 	is_flag := 'flag' in p.attrs
+	is_multi_allowed := '_allow_multiple_values' in p.attrs
 	if is_flag {
 		if fields.len > 32 {
 			p.error('when an enum is used as bit field, it must have a max of 32 fields')
@@ -1522,12 +1523,14 @@ $pubfn (mut e  $enum_name) toggle(flag $enum_name)   { unsafe{ *e = int(*e) ^  (
 		info: table.Enum{
 			vals: vals
 			is_flag: is_flag
+			is_multi_allowed: is_multi_allowed
 		}
 	})
 	return ast.EnumDecl{
 		name: name
 		is_pub: is_pub
 		is_flag: is_flag
+		is_multi_allowed: is_multi_allowed
 		fields: fields
 		pos: start_pos.extend(end_pos)
 		comments: enum_decl_comments

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -683,6 +683,7 @@ pub struct Enum {
 pub:
 	vals    []string
 	is_flag bool
+	is_multi_allowed bool
 }
 
 pub struct Alias {


### PR DESCRIPTION
I didnt want to do this, but I do now have a concrete case for this.

## Reasoning
The protobuf standard allows multiple enum values to have the same value. This is perfectly valid. V on the other hand does not (good reasons behind it so on so forth...)

The problem is that I (as the V protobuf compiler) cannot reason about which values in an enum I should be keeping and which I shouldnt. Due to the need to keep the generated code consistent between languages I dont believe that I should just get rid of the offending values becuase then someone would have to write code in 2 languages with insonsistent enum value names.

## Result
Therefore this PR adds an `[_allow_multiple_values]` attribute that can be added to enums to make the parser, makes the checker not complain on multiple values if it sees that attribute present and also fixes cgen to only use the first value when doing an auto str for an enum (perhaps it should just not generate an auto-str for a multi value enum... not sure it matters that much).