### PR TITLE
orm: fix false `no more rows available` error

### DIFF
--- a/vlib/v/gen/sql.v
+++ b/vlib/v/gen/sql.v
@@ -89,7 +89,8 @@ fn (mut g Gen) sql_stmt(node ast.SqlStmt) {
 	g.sql_buf = strings.new_builder(100)
 	g.writeln(binds)
 	g.writeln('sqlite3_step($g.sql_stmt_name);')
-	g.writeln('if (strcmp(sqlite3_errmsg(${db_name}.conn), "not an error") != 0) puts(sqlite3_errmsg(${db_name}.conn)); ')
+	g.write('if (strcmp(sqlite3_errmsg(${db_name}.conn), "not an error") != 0)')
+	g.write('if (strcmp(sqlite3_errmsg(${db_name}.conn), "no more rows available") != 0) puts(sqlite3_errmsg(${db_name}.conn));')
 	g.writeln('sqlite3_finalize($g.sql_stmt_name);')
 }
 


### PR DESCRIPTION
The error cannot be ignored by it's error code because this is not returned (see https://sqlite.org/rescode.html#misuse).
So the only way to prevent the false error is to compare the errmsg.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
