### PR TITLE
fmt: format array elements line-by-line when nl after `[`

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1479,22 +1479,25 @@ pub fn (mut f Fmt) array_init(it ast.ArrayInit) {
 	f.write('[')
 	mut inc_indent := false
 	mut last_line_nr := it.pos.line_nr // to have the same newlines between array elements
+	mut break_after_each_element := false
 	for i, expr in it.exprs {
-		mut penalty := 3
 		line_nr := expr.position().line_nr
-		if last_line_nr < line_nr {
-			penalty--
+		if i == 0 && last_line_nr < line_nr {
+			 break_after_each_element = true
 		}
-		if i == 0 ||
-			it.exprs[i - 1] is ast.ArrayInit ||
-			it.exprs[i - 1] is ast.StructInit ||
-			it.exprs[i - 1] is ast.MapInit || it.exprs[i - 1] is ast.CallExpr {
-			penalty--
-		}
-		if expr is ast.ArrayInit ||
-			expr is ast.StructInit || expr is ast.MapInit ||
-			expr is ast.CallExpr {
-			penalty--
+		mut penalty := if break_after_each_element { 0 } else { 3 }
+		if penalty > 0 {
+			if i == 0 ||
+				it.exprs[i - 1] is ast.ArrayInit ||
+				it.exprs[i - 1] is ast.StructInit ||
+				it.exprs[i - 1] is ast.MapInit || it.exprs[i - 1] is ast.CallExpr {
+				penalty--
+			}
+			if expr is ast.ArrayInit ||
+				expr is ast.StructInit || expr is ast.MapInit ||
+				expr is ast.CallExpr {
+				penalty--
+			}
 		}
 		is_new_line := f.wrap_long_line(penalty, !inc_indent)
 		if is_new_line && !inc_indent {

--- a/vlib/v/fmt/tests/consts_expected.vv
+++ b/vlib/v/fmt/tests/consts_expected.vv
@@ -13,6 +13,12 @@ const (
 	one_line_supported  = ['windows', 'mac', 'macos', 'darwin', 'linux', 'freebsd', 'openbsd',
 		'netbsd', 'dragonfly', 'android', 'js', 'solaris', 'haiku', 'linux_or_macos']
 	another_const       = ['a', 'b', 'c', 'd', 'e', 'f']
+	multiline_const     = [
+		'first line',
+		'second line',
+		'third line',
+		'fourth line'
+	]
 )
 
 const (
@@ -24,3 +30,31 @@ const (
 pub const (
 	i_am_pub_const = true
 )
+
+fn main() {
+	a := [
+		[3, 5, 6],
+		[7, 9, 2]
+	]
+	b := [[
+		[2, 5, 8],
+		[5, 1, 3],
+		[2, 6, 0]
+	], [
+		[9, 4, 5],
+		[7, 2, 3],
+		[1, 2, 3]
+	]]
+	c := [
+		[
+			[2, 5, 8],
+			[5, 1, 3],
+			[2, 6, 0]
+		],
+		[
+			[9, 4, 5],
+			[7, 2, 3],
+			[1, 2, 3]
+		]
+	]
+}

--- a/vlib/v/fmt/tests/consts_input.vv
+++ b/vlib/v/fmt/tests/consts_input.vv
@@ -11,11 +11,13 @@ eulers=2.7182
 supported_platforms = ['windows', 'mac', 'macos', 'darwin', 'linux', 'freebsd', 'openbsd',
 		'netbsd', 'dragonfly', 'android', 'js', 'solaris', 'haiku', 'linux_or_macos']
 one_line_supported    = ['windows', 'mac', 'macos', 'darwin', 'linux', 'freebsd', 'openbsd', 'netbsd', 'dragonfly', 'android', 'js', 'solaris', 'haiku', 'linux_or_macos']
-another_const = [
-	'a', 'b'
+another_const = ['a', 'b'
 		'c', 'd', 'e'
 		'f'
 		]
+multiline_const = [
+		'first line',  'second line','third line',
+  'fourth line']		
 )
 
 const (
@@ -26,4 +28,26 @@ pub const (
 i_am_pub_const=true
 )
 
-
+fn main() {
+	a := [
+		[3,
+5,
+	6],[7,  9, 2]]
+b := [[
+[2,
+5,8],[   5,  1,
+3],[ 2, 6, 0]],[
+[9,
+4,5],[7,2,3],
+[1,
+2,3]]]
+c := [
+[
+[2,
+5,8],[   5,  1,
+3],[ 2, 6, 0]],[
+[9,
+4,5],[7,2,3],
+[1,
+2,3]]]
+}


### PR DESCRIPTION
For array formatting it should be possible for the human to influence what `vfmt` does. This PR introduces a heuristic that when in the original file there is a newline after the opening `[`, each array element will have its own line. If after the opening `[` the first element is on the same line, the normal penalty/line-length algorithm is applied. It's a "first element decides" approach analogous to the array element type inference.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
