### PR TITLE
fmt: make formatter know about new keywords `shared`, `rlock`

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -32,7 +32,7 @@ pub fn (node &FnDecl) stringify(t &table.Table) string {
 	mut receiver := ''
 	if node.is_method {
 		mut styp := t.type_to_str(node.receiver.typ)
-		mut m := if node.rec_mut { 'mut ' } else { '' }
+		mut m := if node.rec_mut { node.receiver.typ.share().str() + ' ' } else { '' }
 		if node.rec_mut {
 			styp = styp[1..] // remove &
 		}
@@ -72,7 +72,7 @@ pub fn (node &FnDecl) stringify(t &table.Table) string {
 		should_add_type := is_last_arg || node.args[i + 1].typ != arg.typ || (node.is_variadic &&
 			i == node.args.len - 2)
 		if arg.is_mut {
-			f.write('mut ')
+			f.write(arg.typ.share().str() + ' ')
 		}
 		f.write(arg.name)
 		mut s := t.type_to_str(arg.typ)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -248,7 +248,7 @@ pub fn (mut f Fmt) stmt(node ast.Stmt) {
 				if left is ast.Ident {
 					var_info := left.var_info()
 					if var_info.is_mut {
-						f.write('mut ')
+						f.write(var_info.share.str() + ' ')
 					}
 					f.expr(left)
 					if i < node.left.len - 1 {
@@ -515,7 +515,7 @@ pub fn (mut f Fmt) type_decl(node ast.TypeDecl) {
 				f.write(arg.name)
 				mut s := f.table.type_to_str(arg.typ).replace(f.cur_mod + '.', '')
 				if arg.is_mut {
-					f.write('mut ')
+					f.write(arg.typ.share().str() + ' ')
 					if s.starts_with('&') {
 						s = s[1..]
 					}
@@ -1052,7 +1052,7 @@ pub fn (mut f Fmt) wrap_long_line(penalty int, add_indent bool) bool {
 pub fn (mut f Fmt) call_args(args []ast.CallArg) {
 	for i, arg in args {
 		if arg.is_mut {
-			f.write('mut ')
+			f.write(arg.share.str() + ' ')
 		}
 		if i > 0 {
 			f.wrap_long_line(2, true)
@@ -1171,7 +1171,11 @@ pub fn (mut f Fmt) short_module(name string) string {
 }
 
 pub fn (mut f Fmt) lock_expr(lex ast.LockExpr) {
-	f.write('lock ')
+	f.write(if lex.is_rlock {
+		'rlock '
+	} else {
+		'lock '
+	})
 	for i, v in lex.lockeds {
 		if i > 0 {
 			f.write(', ')

--- a/vlib/v/fmt/tests/shared_expected.vv
+++ b/vlib/v/fmt/tests/shared_expected.vv
@@ -1,0 +1,58 @@
+import sync
+import time
+
+struct St {
+mut:
+	a int
+}
+
+fn (shared x St) f(shared z St) {
+	for _ in 0 .. reads_per_thread {
+		rlock x { // other instances may read at the same time
+			time.sleep_ms(1)
+			assert x.a == 7 || x.a == 5
+		}
+	}
+	lock z {
+		z.a--
+	}
+}
+
+const (
+	reads_per_thread = 30
+	read_threads     = 10
+	writes           = 5
+)
+
+fn test_shared_lock() {
+	// object with separate read/write lock
+	shared x := &St{
+		a: 5
+	}
+	shared z := &St{
+		a: read_threads
+	}
+	for _ in 0 .. read_threads {
+		go x.f(shared z)
+	}
+	for i in 0 .. writes {
+		lock x { // wait for ongoing reads to finish, don't start new ones
+			x.a = 17 // this value should never be read
+			time.sleep_ms(50)
+			x.a = if (i & 1) == 0 { 7 } else { 5 }
+		} // now new reads are possible again
+		time.sleep_ms(20)
+	}
+	// wait until all read threads are finished
+	for finished := false; true; {
+		mut rr := 0
+		rlock z {
+			rr = z.a
+			finished = z.a == 0
+		}
+		if finished {
+			break
+		}
+		time.sleep_ms(100)
+	}
+}

--- a/vlib/v/fmt/tests/shared_input.vv
+++ b/vlib/v/fmt/tests/shared_input.vv
@@ -1,0 +1,60 @@
+import sync
+import time
+
+struct St {
+mut:
+	a int
+}
+
+fn (shared x St) f(shared z St) {
+	for _ in 0 .. reads_per_thread {
+		rlock x { // other instances may read at the same time
+			time.sleep_ms(1)
+			assert x.a == 7 || x.a == 5
+		}
+	}
+	lock z {
+		z.a--
+	}
+}
+
+const (
+	reads_per_thread = 30
+	read_threads     = 10
+	writes           = 5
+)
+
+fn test_shared_lock() {
+	// object with separate read/write lock
+shared x := &St {
+a: 5
+}
+	shared z :=
+&St{
+		a: read_threads
+      	}
+	for  _  in 0.. read_threads {
+		go x.f(shared z)
+	}
+  	for  i in 0..writes {
+ lock x { // wait for ongoing reads to finish, don't start new ones
+			 x.a = 17 // this value should never be read
+	time.sleep_ms(50)
+	x.a = if (i & 1) == 0 {
+7} else {5}
+	} // now new reads are possible again
+time.sleep_ms(20)
+	}
+	// wait until all read threads are finished
+for finished:=false;; {
+	mut rr := 0
+		  rlock z {
+  rr = z.a
+	  finished = z.a == 0
+}
+if finished {
+		break
+		     }
+			time.sleep_ms(100)
+			}
+}


### PR DESCRIPTION
Automatic formatting of `shared` testcases is a lot easier if the formatter knows the keywords...
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
