### PR TITLE
builtin, string: fix hash method for `gcc -O2`

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1326,13 +1326,13 @@ pub fn (c byte) is_white() bool {
 
 pub fn (s string) hash() int {
 	// mut h := s.hash_cache
-	mut h := 0
+	mut h := u32(0)
 	if h == 0 && s.len > 0 {
 		for c in s {
-			h = h * 31 + int(c)
+			h = h * 31 + u32(c)
 		}
 	}
-	return h
+	return int(h)
 }
 
 pub fn (s string) bytes() []byte {


### PR DESCRIPTION
### Problem
`string.hash()` is broken, when compiled with `gcc -O2` as backend (OS: ubuntu 20.04).
### How to reproduce 
```
export VFLAGS="-cc gcc-9 -cflags -O2"
v test vlib/builtin/string_test.v
```
### Expected Result
Pass
### Observed Result
```
FAIL 3881.461 ms vlib/builtin/string_test.v
6

/home/uwe/soft/vv/vlib/builtin/string_test.v:414: failed assert in function test_hash
Source  : `s4.hash() == -346636507`
	 left value: *unknown value* <= `s4.hash()`
	right value: *unknown value* <= `-346636507`
testing double quotes
['raw\nstring']
raw string: "raw\nstring"
world
42
50
123
1 2
original.len = 5
a[0] = I
a[1] = f
a[2] = m
a[3] = m
a[4] = p
a.len = 5


---------------------------------------------------------------------------------------------------------------------------------------------------------------------
     3881.742 ms <=== total time spent running V _test.v files
                 ok, fail, skip, total =     0,     1,     0,     1
```
### Reason
The `hash()` algorithm has used `int` arithmetic with possible overflow. In terms of the C standard the behaviour of a signed integer overflow is undefined! For this reason `gcc` is allowed to make optimizations that give a different result as with `-O0` in the overflow case.
### Solution
This PR changes the type used for the hash calculation to `u32` since the behaviour of *unsigned integer* overflow is well defined by the C standard. The result is converted to `int` at return to match the existing function interface.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
