### PR TITLE
cgen: fix all -Wmissing-variable-declarations

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -786,7 +786,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 		}
 		ast.GlobalDecl {
 			styp := g.typ(node.typ)
-			g.definitions.writeln('$styp $node.name; // global')
+			g.definitions.writeln('static $styp $node.name; // global')
 		}
 		ast.GoStmt {
 			g.go_stmt(node)
@@ -2787,7 +2787,7 @@ fn (mut g Gen) const_decl(node ast.ConstDecl) {
 				}
 			}
 			ast.StringLiteral {
-				g.definitions.writeln('string _const_$name; // a string literal, inited later')
+				g.definitions.writeln('static string _const_$name; // a string literal, inited later')
 				if g.pref.build_mode != .build_module {
 					g.stringliterals.writeln('\t_const_$name = $val;')
 				}
@@ -2814,7 +2814,7 @@ fn (mut g Gen) const_decl_init_later(mod, name, val string, typ table.Type) {
 	styp := g.typ(typ)
 	//
 	cname := '_const_$name'
-	g.definitions.writeln('$styp $cname; // inited later')
+	g.definitions.writeln('static $styp $cname; // inited later')
 	g.inits[mod].writeln('\t$cname = $val;')
 	if g.pref.autofree {
 		if styp.starts_with('array_') {

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -208,7 +208,7 @@ $c_common_macros
 #endif
 
 // g_live_info is used by live.info()
-void* g_live_info = NULL;
+static void* g_live_info = NULL;
 
 //============================== HELPER C MACROS =============================*/
 //#define tos4(s, slen) ((string){.str=(s), .len=(slen)})
@@ -248,7 +248,7 @@ static inline bool _us64_lt(uint64_t a, int64_t b) { return a < INT64_MAX && (in
 
 //================================== GLOBALS =================================*/
 //byte g_str_buf[1024];
-byte* g_str_buf;
+static byte* g_str_buf;
 int load_so(byteptr);
 void reload_so();
 void _vinit();


### PR DESCRIPTION
This PR fixes 100 clang warnings of `-Wmissing-variable-declarations` by adding `static` to the declaration. 