### PR TITLE
checker: check missing return values in function (fix #5792)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3057,7 +3057,7 @@ fn (c &Checker) fetch_and_verify_orm_fields(info table.Struct, pos token.Positio
 }
 
 fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
-	c.returns = true
+	c.returns = false
 	if node.is_generic && c.cur_generic_type == 0 { // need the cur_generic_type check to avoid inf. recursion
 		// loop thru each generic type and generate a function
 		for gen_type in c.table.fn_gen_types[node.name] {
@@ -3147,7 +3147,7 @@ fn has_top_return(stmts []ast.Stmt) bool {
 	if stmts.filter(it is ast.Return).len > 0 {
 		return true
 	}
-	mut has_unsafe_return := false	
+	mut has_unsafe_return := false
 	for _, stmt in stmts {
 		if stmt is ast.UnsafeStmt {
 			for ustmt in stmt.stmts {

--- a/vlib/v/checker/tests/function_missing_return_type.out
+++ b/vlib/v/checker/tests/function_missing_return_type.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/function_missing_return_type.v:1:1: error: missing return at end of function `h`
+    1 | fn h() int {
+      | ~~~~~~~~~~
+    2 | }
+    3 |

--- a/vlib/v/checker/tests/function_missing_return_type.vv
+++ b/vlib/v/checker/tests/function_missing_return_type.vv
@@ -1,0 +1,7 @@
+fn h() int {
+}
+
+fn main() {
+	d := h()
+	println('$d')
+}


### PR DESCRIPTION
This PR check missing return values in function (fix #5792).

- Check missing return values in function.
- Add test `function_missing_return_type.vv/out`.

```v
module main

interface Base {
	fun() string
}

fn (b BaseHolder) fun() string {
}

struct BaseHolder {
	a Base
}

fn main() {
	a := BaseHolder{}
	eprintln(a.fun())
}

D:\test\v\tt1>v run .
.\tt1.v:7:1: error: missing return at end of function `fun`
    5 | }
    6 |
    7 | fn (b BaseHolder) fun() string {
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    8 | }
    9 |
```