### PR TITLE
doc: Add memory safety section & unsafe {...} example

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1723,7 +1723,7 @@ Examples of memory-unsafe operations are:
 * Pointer arithmetic
 * Pointer indexing
 * Conversion to pointer from an incompatible type
-* Calling a C function
+* Calling certain C functions, e.g. `strlen`, `strncmp`, `free`.
 
 To mark potentially memory-unsafe operations, enclose them in an `unsafe` block:
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1730,7 +1730,7 @@ To mark potentially memory-unsafe operations, enclose them in an `unsafe` block:
 
 ```v
 // allocate 2 uninitialized bytes & return a reference to them
-mut p := unsafe { &byte(C.malloc(2)) }
+mut p := unsafe { &byte(malloc(2)) }
 p[0] = `h` // Error: pointer indexing is only allowed in `unsafe` blocks
 unsafe {
     p[0] = `h`

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1711,19 +1711,20 @@ fn main(){
 
 ## Memory-unsafe code
 
-Sometimes for efficiency you may want to write low-level code that may potentially
-corrupt memory. V supports that, but not by default.
+Sometimes for efficiency you may want to write low-level code that can potentially
+corrupt memory or be vulnerable to security exploits. V supports writing such code, 
+but not by default.
 
 V requires that any potentially memory-unsafe operations are marked intentionally.
-Marking them also indicates to anyone reading the code that there could be memory 
-corruption if there was a mistake. 
+Marking them also indicates to anyone reading the code that there could be
+memory-safety violations if there was a mistake.
 
-Examples of memory-unsafe operations are:
+Examples of potentially memory-unsafe operations are:
 
 * Pointer arithmetic
 * Pointer indexing
 * Conversion to pointer from an incompatible type
-* Calling certain C functions, e.g. `strlen`, `strncmp`, `free`.
+* Calling certain C functions, e.g. `free`, `strlen` and `strncmp`.
 
 To mark potentially memory-unsafe operations, enclose them in an `unsafe` block:
 
@@ -1742,12 +1743,12 @@ unsafe {
 assert *p == `i`
 ```
 
-Best practice is to avoid putting any memory-safe expressions inside an `unsafe` block,
+Best practice is to avoid putting memory-safe expressions inside an `unsafe` block,
 so that the reason for using `unsafe` is as clear as possible. Generally any code 
 you think is memory-safe should not be inside an `unsafe` block, so the compiler 
 can verify it.
 
-If you suspect your program does have memory corruption, you have a head start on 
+If you suspect your program does violate memory-safety, you have a head start on 
 finding the cause: look at the `unsafe` blocks (and how they interact with 
 surrounding code).
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -69,6 +69,7 @@ you can do in V.
 </td><td valign=top>
 
 * [Advanced](#advanced)
+    * [Memory safety](#memory-safety)
     * [Calling C functions from V](#calling-c-functions-from-v)
     * [Conditional compilation](#conditional-compilation)
     * [Compile time pseudo variables](#compile-time-pseudo-variables)
@@ -1707,6 +1708,47 @@ fn main(){
 ```
 
 # Advanced Topics
+
+## Memory safety
+
+Sometimes for efficiency you may want to write low-level code that may potentially
+corrupt memory. V supports that, but not by default.
+
+V requires that any potentially memory-unsafe operations are marked, as they could 
+otherwise be unintentional. Marking them also indicates to anyone reading the code
+that there could be memory corruption if there was a mistake. If you suspect your
+program does have memory corruption, you have a head start on finding the cause: look
+at the `unsafe` blocks (and how they interact with surrounding code).
+
+Examples of memory-unsafe operations are:
+
+* Pointer arithmetic
+* Pointer indexing
+* Conversion to pointer from an incompatible type
+* Calling a C function
+
+To mark potentially memory-unsafe operations, enclose them in an `unsafe` block:
+
+```v
+// allocate 2 uninitialized bytes & return a reference to them
+mut p := unsafe { &byte(C.malloc(2)) }
+p[0] = `h` // Error: pointer indexing is only allowed in `unsafe` blocks
+unsafe {
+    p[0] = `h`
+    p[1] = `i`
+}
+p++ // Error: pointer arithmetic is only allowed in `unsafe` blocks
+unsafe {
+    p++ // OK
+}
+assert *p == `i`
+```
+
+Best practice is to avoid putting any memory-safe expressions inside an `unsafe` block,
+so that the reason for using `unsafe` is as clear as possible. Any code you think is
+memory-safe should not be inside an `unsafe` block, so the compiler can verify it.
+
+* Note: This is work in progress.
 
 ## Calling C functions from V
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -69,7 +69,7 @@ you can do in V.
 </td><td valign=top>
 
 * [Advanced](#advanced)
-    * [Memory safety](#memory-safety)
+    * [Memory-unsafe code](#memory-unsafe-code)
     * [Calling C functions from V](#calling-c-functions-from-v)
     * [Conditional compilation](#conditional-compilation)
     * [Compile time pseudo variables](#compile-time-pseudo-variables)
@@ -1709,7 +1709,7 @@ fn main(){
 
 # Advanced Topics
 
-## Memory safety
+## Memory-unsafe code
 
 Sometimes for efficiency you may want to write low-level code that may potentially
 corrupt memory. V supports that, but not by default.

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1716,9 +1716,7 @@ corrupt memory. V supports that, but not by default.
 
 V requires that any potentially memory-unsafe operations are marked intentionally.
 Marking them also indicates to anyone reading the code that there could be memory 
-corruption if there was a mistake. If you suspect your program does have memory 
-corruption, you have a head start on finding the cause: look at the `unsafe` blocks 
-(and how they interact with surrounding code).
+corruption if there was a mistake. 
 
 Examples of memory-unsafe operations are:
 
@@ -1748,6 +1746,10 @@ Best practice is to avoid putting any memory-safe expressions inside an `unsafe`
 so that the reason for using `unsafe` is as clear as possible. Generally any code 
 you think is memory-safe should not be inside an `unsafe` block, so the compiler 
 can verify it.
+
+If you suspect your program does have memory corruption, you have a head start on 
+finding the cause: look at the `unsafe` blocks (and how they interact with 
+surrounding code).
 
 * Note: This is work in progress.
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1714,11 +1714,11 @@ fn main(){
 Sometimes for efficiency you may want to write low-level code that may potentially
 corrupt memory. V supports that, but not by default.
 
-V requires that any potentially memory-unsafe operations are marked, as they could 
-otherwise be unintentional. Marking them also indicates to anyone reading the code
-that there could be memory corruption if there was a mistake. If you suspect your
-program does have memory corruption, you have a head start on finding the cause: look
-at the `unsafe` blocks (and how they interact with surrounding code).
+V requires that any potentially memory-unsafe operations are marked intentionally.
+Marking them also indicates to anyone reading the code that there could be memory 
+corruption if there was a mistake. If you suspect your program does have memory 
+corruption, you have a head start on finding the cause: look at the `unsafe` blocks 
+(and how they interact with surrounding code).
 
 Examples of memory-unsafe operations are:
 
@@ -1745,8 +1745,9 @@ assert *p == `i`
 ```
 
 Best practice is to avoid putting any memory-safe expressions inside an `unsafe` block,
-so that the reason for using `unsafe` is as clear as possible. Any code you think is
-memory-safe should not be inside an `unsafe` block, so the compiler can verify it.
+so that the reason for using `unsafe` is as clear as possible. Generally any code 
+you think is memory-safe should not be inside an `unsafe` block, so the compiler 
+can verify it.
 
 * Note: This is work in progress.
 


### PR DESCRIPTION
Notes:
* Only the pointer arithmetic error is implemented in git ATM (#5581), hence the WIP note. (I'll finish the pointer indexing error soon).
* `r := unsafe {...}` is implemented in #5793.
* Once V detects all the ways to make invalid pointers, I think dereferencing a pointer is actually a memory-safe operation, so in the example `*p` is not inside an `unsafe` block. Currently `unsafe` is required.