### PR TITLE
checker, cgen: many checks for shared/lock, 1st autolock

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -396,6 +396,7 @@ pub:
 pub mut:
 	left_type    table.Type
 	right_type   table.Type
+	auto_locked  string
 }
 
 pub struct PostfixExpr {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -17,14 +17,6 @@ const (
 	enum_max      = 0x7FFFFFFF
 )
 
-enum LockNeeded {
-	no_lock
-	auto_rlock
-	auto_lock
-	explicit_rlock
-	explicit_lock
-}
-
 pub struct Checker {
 pub mut:
 	table            &table.Table

--- a/vlib/v/checker/tests/lock_already_locked.out
+++ b/vlib/v/checker/tests/lock_already_locked.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/lock_already_locked.v:11:9: error: `a` is already locked 
+    9 |     }
+   10 |     lock a {
+   11 |         rlock a {
+      |               ^
+   12 |             a.x++
+   13 |         }

--- a/vlib/v/checker/tests/lock_already_locked.vv
+++ b/vlib/v/checker/tests/lock_already_locked.vv
@@ -1,0 +1,16 @@
+struct St {
+mut:
+	x int
+}
+
+fn main() {
+	shared a := &St{
+		x: 5
+	}
+	lock a {
+		rlock a {
+			a.x++
+		}
+	}
+	println(a.x)
+}

--- a/vlib/v/checker/tests/lock_already_rlocked.out
+++ b/vlib/v/checker/tests/lock_already_rlocked.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/lock_already_rlocked.v:11:8: error: `a` is already read-locked 
+    9 |     }
+   10 |     rlock a {
+   11 |         lock a {
+      |              ^
+   12 |             a.x++
+   13 |         }

--- a/vlib/v/checker/tests/lock_already_rlocked.vv
+++ b/vlib/v/checker/tests/lock_already_rlocked.vv
@@ -1,0 +1,16 @@
+struct St {
+mut:
+	x int
+}
+
+fn main() {
+	shared a := &St{
+		x: 5
+	}
+	rlock a {
+		lock a {
+			a.x++
+		}
+	}
+	println(a.x)
+}

--- a/vlib/v/checker/tests/lock_const.out
+++ b/vlib/v/checker/tests/lock_const.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/lock_const.v:7:8: error: `a` is not a variable and cannot be locked 
+    5 | fn main() {
+    6 |     mut c := 0
+    7 |     rlock a {
+      |           ^
+    8 |         c = a
+    9 |     }

--- a/vlib/v/checker/tests/lock_const.vv
+++ b/vlib/v/checker/tests/lock_const.vv
@@ -1,0 +1,11 @@
+const (
+	a = 5
+)
+
+fn main() {
+	mut c := 0
+	rlock a {
+		c = a
+	}
+	println(c)
+}

--- a/vlib/v/checker/tests/lock_needed.out
+++ b/vlib/v/checker/tests/lock_needed.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/lock_needed.v:10:2: error: base of `v.ast.SelectorExpr` is `shared` - must be explicitely locked 
+    8 |         x: 5
+    9 |     }
+   10 |     abc.x++
+      |     ~~~
+   11 |     println(abc.x)
+   12 | }

--- a/vlib/v/checker/tests/lock_needed.out
+++ b/vlib/v/checker/tests/lock_needed.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/lock_needed.v:10:2: error: base of `v.ast.SelectorExpr` is `shared` - must be explicitely locked 
+vlib/v/checker/tests/lock_needed.v:10:2: error: `abc` is `shared` and needs explicit lock for `v.ast.SelectorExpr` 
     8 |         x: 5
     9 |     }
    10 |     abc.x++

--- a/vlib/v/checker/tests/lock_needed.vv
+++ b/vlib/v/checker/tests/lock_needed.vv
@@ -1,0 +1,12 @@
+struct St {
+mut:
+	x int
+}
+
+fn main() {
+	shared abc := &St{
+		x: 5
+	}
+	abc.x++
+	println(abc.x)
+}

--- a/vlib/v/checker/tests/lock_nonshared.out
+++ b/vlib/v/checker/tests/lock_nonshared.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/lock_nonshared.v:10:7: error: `a` must be declared `shared` to be locked 
+    8 |         x: 5
+    9 |     }
+   10 |     lock a {
+      |          ^
+   11 |         a.x++
+   12 |     }

--- a/vlib/v/checker/tests/lock_nonshared.vv
+++ b/vlib/v/checker/tests/lock_nonshared.vv
@@ -1,0 +1,14 @@
+struct St {
+mut:
+	x int
+}
+
+fn main() {
+	mut a := &St{
+		x: 5
+	}
+	lock a {
+		a.x++
+	}
+	println(a)
+}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1892,6 +1892,9 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 	// }
 	// string + string, string == string etc
 	// g.infix_op = node.op
+	if node.auto_locked != '' {
+		g.writeln('sync__RwMutex_w_lock($node.auto_locked->mtx);')
+	}
 	left_type := g.unwrap_generic(node.left_type)
 	left_sym := g.table.get_type_symbol(left_type)
 	unaliased_left := if left_sym.kind == .alias { (left_sym.info as table.Alias).parent_type } else { left_type }
@@ -2120,6 +2123,10 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 				g.write(')')
 			}
 		}
+	}
+	if node.auto_locked != '' {
+		g.writeln(';')
+		g.write('sync__RwMutex_w_unlock($node.auto_locked->mtx)')
 	}
 }
 

--- a/vlib/v/tests/autolock_array_1.v
+++ b/vlib/v/tests/autolock_array_1.v
@@ -1,0 +1,52 @@
+import sync
+import time
+
+const (
+	iterations_per_thread = 100000
+)
+
+fn add_elements(shared foo []int, n int) {
+	for _ in 0 .. iterations_per_thread {
+		foo << n
+	}
+	// automatic lock is not yet implemented for this...
+	lock foo {
+		foo[0]++
+	}
+}
+
+fn test_autolocked_array() {
+	shared abc := &[0]
+	go add_elements(shared abc, 1)
+	go add_elements(shared abc, 3)
+	for _ in 0 .. iterations_per_thread {
+		abc << 0
+	}
+	// wait for coroutines to finish - that should really be
+	// done by channels, yield, semaphore...
+	for {
+		mut finished_threads := 0
+		rlock abc {
+			finished_threads = abc[0]
+		}
+		if finished_threads == 2 {
+			break
+		}
+		time.sleep_ms(100)
+	}
+	// create histogram of results
+	mut result := [0, 0, 0, 0]
+	rlock abc {
+		// automatic rlock for iteration is also not implemented, yet
+		for v in abc {
+			if v > 3 {
+				panic('unexpected element on array')
+			}
+			result[v]++
+		}
+	}
+	assert result[0] == iterations_per_thread
+	assert result[1] == iterations_per_thread
+	assert result[2] == 1 // number of non-main threads
+	assert result[3] == iterations_per_thread
+}


### PR DESCRIPTION
This PR implements a couple of checks that make sure that:
- `shared` objects are `locked` when accessed
- objects have been declared `shared` when a `lock` is tried on them
- objects that are to be locked are not already locked in the same thread

Furthermore a very first implementation of an automatic `lock` for the case `array << elem` is included.
Test cases for this feature and for the above checks are also included..
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
