### PR TITLE
cgen: fix warnings

### DIFF
--- a/vlib/builtin/builtin_nix.c.v
+++ b/vlib/builtin/builtin_nix.c.v
@@ -94,7 +94,7 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 		beforeaddr := sframe.all_before('[')
 		cmd := 'addr2line -e $executable $addr'
 		// taken from os, to avoid depending on the os module inside builtin.v
-		f := C.popen(cmd.str, 'r')
+		f := C.popen(charptr(cmd.str), 'r')
 		if isnil(f) {
 			eprintln(sframe)
 			continue

--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -24,7 +24,7 @@ fn C.sscanf(byteptr, byteptr,...byteptr) int
 
 fn C.isdigit(s byteptr) bool
 // stdio.h
-fn C.popen(c byteptr, t byteptr) voidptr
+fn C.popen(c charptr, t charptr) voidptr
 
 // <execinfo.h>
 fn C.backtrace(a &voidptr, size int) int
@@ -35,7 +35,7 @@ fn C.backtrace_symbols_fd(a &voidptr, size int, fd int)
 pub fn proc_pidpath(int, voidptr, int) int
 
 
-fn C.realpath(byteptr, byteptr) &char
+fn C.realpath(charptr, charptr) &char
 
 
 fn C.chmod(byteptr, int) int
@@ -71,10 +71,10 @@ fn C.pclose() int
 fn C.system() int
 
 
-fn C.setenv() int
+fn C.setenv(charptr) int
 
 
-fn C.unsetenv() int
+fn C.unsetenv(charptr) int
 
 
 fn C.access() int
@@ -95,7 +95,7 @@ fn C.fread() int
 fn C.rewind() int
 
 
-fn C.stat() int
+fn C.stat(charptr) int
 
 
 fn C.lstat() int

--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -3,7 +3,7 @@ module builtin
 // <string.h>
 fn C.memcpy(byteptr, byteptr, int) voidptr
 
-
+fn C.memcmp(byteptr, byteptr, int) int
 fn C.memmove(byteptr, byteptr, int) voidptr
 fn C.calloc(int)  byteptr
 fn C.malloc(int) byteptr

--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -18,7 +18,7 @@ fn C.qsort(voidptr, int, int, qsort_callback_func)
 fn C.sprintf(a ...voidptr) int
 
 
-fn C.strlen(s byteptr) int
+fn C.strlen(s charptr) int
 
 fn C.sscanf(byteptr, byteptr,...byteptr) int
 

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -6,8 +6,6 @@ module builtin
 import strings
 import hash.wyhash
 
-fn C.memcmp(byteptr, byteptr, int) int
-
 /*
 This is a highly optimized hashmap implementation. It has several traits that
 in combination makes it very fast and memory efficient. Here is a short expl-

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -149,7 +149,7 @@ pub fn (s string) cstr() byteptr {
 
 // cstring_to_vstring creates a copy of cstr and turns it into a v string
 pub fn cstring_to_vstring(cstr byteptr) string {
-	slen := C.strlen(cstr)
+	slen := C.strlen(charptr(cstr))
 	mut s := byteptr(memdup(cstr, slen + 1))
 	s[slen] = `\0`
 	return tos(s, slen)

--- a/vlib/os/environment.v
+++ b/vlib/os/environment.v
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file.
 module os
 
-fn C.getenv(byteptr) &char
+fn C.getenv(charptr) &char
 // C.GetEnvironmentStringsW & C.FreeEnvironmentStringsW are defined only on windows
 fn C.GetEnvironmentStringsW() &u16
 
@@ -18,7 +18,7 @@ pub fn getenv(key string) string {
 		}
 		return string_from_wide(s)
 	} $else {
-		s := C.getenv(key.str)
+		s := C.getenv(charptr(key.str))
 		if s == voidptr(0) {
 			return ''
 		}
@@ -36,7 +36,7 @@ pub fn setenv(name string, value string, overwrite bool) int {
 		}
 		return -1
 	} $else {
-		return C.setenv(name.str, value.str, overwrite)
+		return C.setenv(charptr(name.str), charptr(value.str), overwrite)
 	}
 }
 
@@ -46,7 +46,7 @@ pub fn unsetenv(name string) int {
 		format := '${name}='
 		return C._putenv(format.str)
 	} $else {
-		return C.unsetenv(name.str)
+		return C.unsetenv(charptr(name.str))
 	}
 }
 
@@ -73,7 +73,7 @@ pub fn environ() map[string]string {
 	} $else {
 		e := &charptr(C.environ)
 		for i := 0; !isnil(e[i]); i++ {
-			eline := cstring_to_vstring(e[i])
+			eline := cstring_to_vstring(byteptr(e[i]))
 			eq_index := eline.index_byte(`=`)
 			if eq_index > 0 {
 				res[eline[0..eq_index]] = eline[eq_index + 1..]

--- a/vlib/os/inode.v
+++ b/vlib/os/inode.v
@@ -32,7 +32,7 @@ pub:
 // it supports windows for regular files but it doesn't matter if you use owner, group or others when checking permissions on windows
 pub fn inode(path string) FileMode {
 	mut attr := C.stat{}
-	C.stat(path.str, &attr)
+	C.stat(charptr(path.str), &attr)
 
 	mut typ := FileType.regular
 	if attr.st_mode & u32(C.S_IFMT) == u32(C.S_IFDIR) {

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -34,11 +34,11 @@ pub fn uname() Uname {
 	mut u := Uname{}
 	d := &C.utsname( malloc(int(sizeof(C.utsname))) )
 	if C.uname(d) == 0 {
-		u.sysname = cstring_to_vstring(d.sysname)
-		u.nodename = cstring_to_vstring(d.nodename)
-		u.release = cstring_to_vstring(d.release)
-		u.version = cstring_to_vstring(d.version)
-		u.machine = cstring_to_vstring(d.machine)
+		u.sysname = cstring_to_vstring(byteptr(d.sysname))
+		u.nodename = cstring_to_vstring(byteptr(d.nodename))
+		u.release = cstring_to_vstring(byteptr(d.release))
+		u.version = cstring_to_vstring(byteptr(d.version))
+		u.machine = cstring_to_vstring(byteptr(d.machine))
 	}
 	free(d)
 	return u

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -58,7 +58,7 @@ fn init_os_args(argc int, argv &&byte) []string {
 
 pub fn ls(path string) ?[]string {
 	mut res := []string{}
-	dir := C.opendir(path.str)
+	dir := C.opendir(charptr(path.str))
 	if isnil(dir) {
 		return error('ls() couldnt open dir "$path"')
 	}
@@ -121,7 +121,7 @@ pub fn mkdir(path string) ?bool {
 		}
 	}
   */
-	r := C.mkdir(apath.str, 511)
+	r := C.mkdir(charptr(apath.str), 511)
 	if r == -1 {
 		return error(posix_get_error_msg(C.errno))
 	}
@@ -157,7 +157,7 @@ pub fn exec(cmd string) ?Result {
 }
 
 pub fn symlink(origin, target string) ?bool {
-	res := C.symlink(origin.str, target.str)
+	res := C.symlink(charptr(origin.str), charptr(target.str))
 	if res == 0 {
 		return true
 	}

--- a/vlib/szip/szip.v
+++ b/vlib/szip/szip.v
@@ -241,7 +241,7 @@ extract_entry extracts the current zip entry into output file.
 @return the return code - 0 on success, negative number (< 0) on error.
  */
 pub fn (mut zentry zip_ptr) extract_entry(path string) /*?*/bool {
-    if C.access(path.str, 0) == -1 {
+    if C.access(charptr(path.str), 0) == -1 {
         return false
         //return error('Cannot open file for extracting, file not exists')
     }

--- a/vlib/time/parse.v
+++ b/vlib/time/parse.v
@@ -67,7 +67,7 @@ pub fn parse_iso8601(s string) ?Time {
 	mut offset_hour := 0
 	mut offset_min  := 0
 
-	count := C.sscanf(s.str, "%4d-%2d-%2d%c%2d:%2d:%2d.%6d%c%2d:%2d", &year, &month, &day,
+	count := C.sscanf(charptr(s.str), "%4d-%2d-%2d%c%2d:%2d:%2d.%6d%c%2d:%2d", &year, &month, &day,
 													  &time_char, &hour, &minute,
 													  &second, &mic_second, &plus_min,
 													  &offset_hour, &offset_min)

--- a/vlib/time/time_nix.c.v
+++ b/vlib/time/time_nix.c.v
@@ -26,7 +26,7 @@ fn make_unix_time(t C.tm) int {
 
 fn to_local_time(t Time) Time {
 	loc_tm := C.tm{}
-	C.localtime_r(&t.unix, &loc_tm)
+	C.localtime_r(time_t(&t.unix), &loc_tm)
 
 	return convert_ctime(loc_tm, t.microsecond)
 }

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3907,7 +3907,13 @@ fn (g Gen) type_default(typ table.Type) string {
 		'rune' { return '0' }
 		else {}
 	}
-	return '0'
+	
+	return match sym.kind  {
+		.sum_type { '{0}' }
+		.array_fixed { '{0}' }
+		else { '0' }
+	}
+
 	// TODO this results in
 	// error: expected a field designator, such as '.field = 4'
 	// - Empty ee= (Empty) { . =  {0}  } ;

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3903,7 +3903,7 @@ fn (g Gen) type_default(typ table.Type) string {
 	}
 	*/
 	match sym.name {
-		'string' { return '(string){.str=""}' }
+		'string' { return '(string){.str=(unsigned char*)""}' }
 		'rune' { return '0' }
 		else {}
 	}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3903,7 +3903,7 @@ fn (g Gen) type_default(typ table.Type) string {
 	}
 	*/
 	match sym.name {
-		'string' { return '(string){.str=(unsigned char*)""}' }
+		'string' { return '(string){.str=(byteptr)""}' }
 		'rune' { return '0' }
 		else {}
 	}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3907,7 +3907,7 @@ fn (g Gen) type_default(typ table.Type) string {
 		'rune' { return '0' }
 		else {}
 	}
-	return '{0}'
+	return '0'
 	// TODO this results in
 	// error: expected a field designator, such as '.field = 4'
 	// - Empty ee= (Empty) { . =  {0}  } ;

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -212,7 +212,7 @@ static void* g_live_info = NULL;
 
 //============================== HELPER C MACROS =============================*/
 //#define tos4(s, slen) ((string){.str=(s), .len=(slen)})
-#define _SLIT(s) ((string){.str=(s), .len=(strlen(s))})
+#define _SLIT(s) ((string){.str=(byteptr)(s), .len=(strlen(s))})
 #define _PUSH_MANY(arr, val, tmp, tmp_typ) {tmp_typ tmp = (val); array_push_many(arr, tmp.data, tmp.len);}
 #define _IN(typ, val, arr) array_##typ##_contains(arr, val)
 #define _IN_MAP(val, m) map_exists(m, val)

--- a/vlib/v/gen/x64/gen.v
+++ b/vlib/v/gen/x64/gen.v
@@ -620,7 +620,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 				if word.len != 2 {
 					verror('opcodes format: xx xx xx xx')
 				}
-				b := C.strtol(word.str, 0, 16)
+				b := C.strtol(charptr(word.str), 0, 16)
 				// b := word.byte()
 				// println('"$word" $b')
 				g.write8(b)


### PR DESCRIPTION
This fixes:
187 warnings of -Wpointer-sign.
136 warnings of -Wbraced-scalar-init.

With this we are down to 38 warnings from clang without additional warnings from flags such as `-Weverything` and `-Wall`