### PR TITLE
vpm: outdated command

### DIFF
--- a/cmd/v/help/default.txt
+++ b/cmd/v/help/default.txt
@@ -31,6 +31,7 @@ V supports the following commands:
    remove            Remove a module that was installed from VPM.
    search            Search for a module from VPM.
    update            Update an installed module from VPM.
+   outdated          List installed modules that need updates.
 * Others:
    build             Build a V code in the provided path (the default, so you can skip the word `build`).
    translate         Translate C code to V (coming soon in 0.3).

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -70,7 +70,7 @@ fn main() {
 			println('Translating C to V will be available in V 0.3')
 			return
 		}
-		'search', 'install', 'update', 'remove' {
+		'search', 'install', 'update', 'outdated', 'remove' {
 			util.launch_tool(prefs.is_verbose, 'vpm', os.args[1..])
 			return
 		}


### PR DESCRIPTION
With this PR `v outdated` can be used to list any packages that are behind their master branch.

> As I'm only used to git I haven't implemented Mercurial support yet but I might look into this at a later point.
