### PR TITLE
vlib: Use `unsafe` for pointer indexing

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -488,12 +488,18 @@ pub fn (b []byte) hex() string {
 	mut dst_i := 0
 	for i in b {
 		n0 := i >> 4
-		hex[dst_i++] = if n0 < 10 { n0 + `0` } else { n0 + byte(87) }
+		unsafe {
+			hex[dst_i++] = if n0 < 10 { n0 + `0` } else { n0 + byte(87) }
+		}
 		n1 := i & 0xF
-		hex[dst_i++] = if n1 < 10 { n1 + `0` } else { n1 + byte(87) }
+		unsafe {
+			hex[dst_i++] = if n1 < 10 { n1 + `0` } else { n1 + byte(87) }
+		}
 	}
-	hex[dst_i] = `\0`
-	return tos(hex,dst_i)
+	unsafe {
+		hex[dst_i] = `\0`
+		return tos(hex,dst_i)
+	}
 }
 
 // copy copies the `src` byte array elements to the `dst` byte array.

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -72,13 +72,17 @@ pub fn (nn int) str_l(max int) string {
 	}
 
 	mut index := max
-	buf[index--] = `\0`
+	unsafe {
+		buf[index--] = `\0`
+	}
 	for n > 0 {
 		n1 := n / 100
 		d = ((n - (n1 * 100)) << 1)
 		n = n1
-		buf[index--] = digit_pairs.str[d++]
-		buf[index--] = digit_pairs.str[d]
+		unsafe {
+			buf[index--] = digit_pairs.str[d++]
+			buf[index--] = digit_pairs.str[d]
+		}
 	}
 	index++
 
@@ -90,13 +94,15 @@ pub fn (nn int) str_l(max int) string {
 	// Prepend - if it's negative
 	if is_neg {
 		index--
-		buf[index] = `-`
+		unsafe {
+			buf[index] = `-`
+		}
 	}
 
 	unsafe {
 		C.memmove(buf,buf+index, (max-index)+1 )
+		return tos(buf, (max-index))
 	}
-	return tos(buf, (max-index))
 	//return tos(buf + index, (max-index))
 }
 
@@ -126,13 +132,17 @@ pub fn (nn u32) str() string {
 	mut buf := malloc(max + 1)
 
 	mut index := max
-	buf[index--] = `\0`
+	unsafe {
+		buf[index--] = `\0`
+	}
 	for n > 0 {
 		n1 := n / u32(100)
 		d = ((n - (n1 * u32(100))) << u32(1))
 		n = n1
-		buf[index--] = digit_pairs[d++]
-		buf[index--] = digit_pairs[d]
+		unsafe {
+			buf[index--] = digit_pairs[d++]
+			buf[index--] = digit_pairs[d]
+		}
 	}
 	index++
 
@@ -143,8 +153,8 @@ pub fn (nn u32) str() string {
 
 	unsafe {
 		C.memmove(buf,buf+index, (max-index)+1 )
+		return tos(buf, (max-index))
 	}
-	return tos(buf, (max-index))
 	//return tos(buf + index, (max-index))
 }
 
@@ -169,13 +179,17 @@ pub fn (nn i64) str() string {
 	}
 
 	mut index := max
-	buf[index--] = `\0`
+	unsafe {
+		buf[index--] = `\0`
+	}
 	for n > 0 {
 		n1 := n / i64(100)
 		d = ((n - (n1 * i64(100))) << i64(1))
 		n = n1
-		buf[index--] = digit_pairs[d++]
-		buf[index--] = digit_pairs[d]
+		unsafe {
+			buf[index--] = digit_pairs[d++]
+			buf[index--] = digit_pairs[d]
+		}
 	}
 	index++
 
@@ -187,13 +201,15 @@ pub fn (nn i64) str() string {
 	// Prepend - if it's negative
 	if is_neg {
 		index--
-		buf[index] = `-`
+		unsafe {
+			buf[index] = `-`
+		}
 	}
 
 	unsafe {
 		C.memmove(buf,buf+index, (max-index)+1 )
+		return tos(buf, (max-index))
 	}
-	return tos(buf, (max-index))
 	//return tos(buf + index, (max-index))
 }
 
@@ -207,13 +223,17 @@ pub fn (nn u64) str() string {
 	mut buf := vcalloc(max + 1)
 
 	mut index := max
-	buf[index--] = `\0`
+	unsafe {
+		buf[index--] = `\0`
+	}
 	for n > 0 {
 		n1 := n / 100
 		d = ((n - (n1 * 100)) << 1)
 		n = n1
-		buf[index--] = digit_pairs[d++]
-		buf[index--] = digit_pairs[d]
+		unsafe {
+			buf[index--] = digit_pairs[d++]
+			buf[index--] = digit_pairs[d]
+		}
 	}
 	index++
 
@@ -224,8 +244,8 @@ pub fn (nn u64) str() string {
 
 	unsafe {
 		C.memmove(buf,buf+index, (max-index)+1 )
+		return tos(buf, (max-index))
 	}
-	return tos(buf, (max-index))
 	//return tos(buf + index, (max-index))
 }
 
@@ -258,11 +278,15 @@ pub fn (nn byte) hex() string {
 	mut buf := malloc(max + 1)
 
 	mut index := max
-	buf[index--] = `\0`
+	unsafe {
+		buf[index--] = `\0`
+	}
 	for n > 0 {
 		d := n & 0xF
 		n = n >> 4
-		buf[index--] = if d < 10 { d + `0` } else { d + 87 }
+		unsafe {
+			buf[index--] = if d < 10 { d + `0` } else { d + 87 }
+		}
 	}
 	//buf[index--] = `x`
 	//buf[index]   = `0`
@@ -287,11 +311,15 @@ pub fn (nn u16) hex() string {
 	mut buf := malloc(max + 1)
 
 	mut index := max
-	buf[index--] = `\0`
+	unsafe {
+		buf[index--] = `\0`
+	}
 	for n > 0 {
 		d := byte(n & 0xF)
 		n = n >> 4
-		buf[index--] = if d < 10 { d + `0` } else { d + 87 }
+		unsafe {
+			buf[index--] = if d < 10 { d + `0` } else { d + 87 }
+		}
 	}
 	//buf[index--] = `x`
 	//buf[index]   = `0`
@@ -316,11 +344,15 @@ pub fn (nn u32) hex() string {
 	mut buf := malloc(max + 1)
 
 	mut index := max
-	buf[index--] = `\0`
+	unsafe {
+		buf[index--] = `\0`
+	}
 	for n > 0 {
 		d := byte(n & 0xF)
 		n = n >> 4
-		buf[index--] = if d < 10 { d + `0` } else { d + 87 }
+		unsafe {
+			buf[index--] = if d < 10 { d + `0` } else { d + 87 }
+		}
 	}
 	//buf[index--] = `x`
 	//buf[index]   = `0`
@@ -349,11 +381,15 @@ pub fn (nn u64) hex() string {
 	mut buf := malloc(max + 1)
 
 	mut index := max
-	buf[index--] = `\0`
+	unsafe {
+		buf[index--] = `\0`
+	}
 	for n > 0 {
 		d := byte(n & 0xF)
 		n = n >> 4
-		buf[index--] = if d < 10 { d + `0` } else { d + 87 }
+		unsafe {
+			buf[index--] = if d < 10 { d + `0` } else { d + 87 }
+		}
 	}
 	//buf[index--] = `x`
 	//buf[index]   = `0`
@@ -361,8 +397,8 @@ pub fn (nn u64) hex() string {
 
 	unsafe {
 		C.memmove(buf,buf+index, (max-index)+1 )
+		return tos(buf, (max-index))
 	}
-	return tos(buf, (max-index))
 	//return tos(buf + index, (max-index))
 }
 
@@ -405,8 +441,10 @@ pub fn (c byte) str() string {
 		str: malloc(2)
 		len: 1
 	}
-	str.str[0] = c
-	str.str[1] = `\0`
+	unsafe {
+		str.str[0] = c
+		str.str[1] = `\0`
+	}
 	return str
 }
 

--- a/vlib/hash/wyhash/wyhash.v
+++ b/vlib/hash/wyhash/wyhash.v
@@ -48,7 +48,7 @@ fn wyhash64(key byteptr, len, seed_ u64) u64 {
 	if len == 0 {
 		return 0
 	}
-	mut p := &key[0]
+	mut p := key
 	mut seed := seed_
 	mut i := len & 63
 	unsafe {
@@ -119,15 +119,21 @@ pub fn wymum(a, b u64) u64 {
 
 [inline]
 fn wyr3(p byteptr, k u64) u64 {
-	return (u64(p[0])<<16) | (u64(p[k>>1])<<8) | u64(p[k - 1])
+	unsafe {
+		return (u64(p[0])<<16) | (u64(p[k>>1])<<8) | u64(p[k - 1])
+	}
 }
 
 [inline]
 fn wyr4(p byteptr) u64 {
-	return u32(p[0]) | (u32(p[1])<<u32(8)) | (u32(p[2])<<u32(16)) | (u32(p[3])<<u32(24))
+	unsafe {
+		return u32(p[0]) | (u32(p[1])<<u32(8)) | (u32(p[2])<<u32(16)) | (u32(p[3])<<u32(24))
+	}
 }
 
 [inline]
 fn wyr8(p byteptr) u64 {
-	return u64(p[0]) | (u64(p[1])<<8) | (u64(p[2])<<16) | (u64(p[3])<<24) | (u64(p[4])<<32) | (u64(p[5])<<40) | (u64(p[6])<<48) | (u64(p[7])<<56)
+	unsafe {
+		return u64(p[0]) | (u64(p[1])<<8) | (u64(p[2])<<16) | (u64(p[3])<<24) | (u64(p[4])<<32) | (u64(p[5])<<40) | (u64(p[6])<<48) | (u64(p[7])<<56)
+	}
 }

--- a/vlib/strconv/format.v
+++ b/vlib/strconv/format.v
@@ -384,7 +384,7 @@ pub fn remove_tail_zeros(s string) string {
 	mut in_decimal := false
 	mut prev_ch := byte(0)
 	for i < s.len {
-		ch := s.str[i]
+		ch := unsafe {s.str[i]}
 		if ch == `.` {
 			in_decimal = true
 			dot_pos = i
@@ -405,14 +405,14 @@ pub fn remove_tail_zeros(s string) string {
 	mut tmp := ""
 	if last_zero_start > 0 {
 		if last_zero_start == dot_pos+1 {
-			tmp = s[..dot_pos] + s [i..]
+			tmp = s[..dot_pos] + s[i..]
 		}else {
-			tmp = s[..last_zero_start] + s [i..]
+			tmp = s[..last_zero_start] + s[i..]
 		}
 	} else {
 		tmp = s
 	}
-	if tmp.str[tmp.len-1] == `.` {
+	if unsafe {tmp.str[tmp.len-1]} == `.` {
 		return tmp[..tmp.len-1]
 	}
 	return tmp
@@ -474,7 +474,7 @@ pub fn v_sprintf(str string, pt ... voidptr) string{
 
 		// single char, manage it here
 		if ch == `c` && status == .field_char {
-			d1 := *(&byte(pt[p_index]))
+			d1 := unsafe {*(&byte(pt[p_index]))}
 			res.write_b(d1)
 			status = .reset_params
 			p_index++
@@ -484,7 +484,8 @@ pub fn v_sprintf(str string, pt ... voidptr) string{
 
 		// pointer, manage it here
 		if ch == `p` && status == .field_char {
-			res.write("0x"+ptr_str(pt[p_index]))
+			res.write("0x")
+			res.write(ptr_str(unsafe {pt[p_index]}))
 			status = .reset_params
 			p_index++
 			i++
@@ -525,9 +526,9 @@ pub fn v_sprintf(str string, pt ... voidptr) string{
 			} 
 			// manage "%.*s" precision field
 			else if ch == `.` && fc_ch1 == `*` && fc_ch2 == `s` {
-				len := *(&int(pt[p_index]))
+				len := unsafe {*(&int(pt[p_index]))}
 				p_index++
-				mut s := *(&string(pt[p_index]))
+				mut s := unsafe {*(&string(pt[p_index]))}
 				s = s[..len]
 				p_index++
 				res.write(s)
@@ -629,11 +630,11 @@ pub fn v_sprintf(str string, pt ... voidptr) string{
 					// hh fot 8 bit int
 					`h` {
 						if ch2 == `h` {
-							x := *(&i8(pt[p_index]))
+							x := unsafe {*(&i8(pt[p_index]))}
 							positive = if x >= 0 { true } else { false }
 							d1 = if positive { u64(x) } else { u64(-x) }
 						} else {
-							x := *(&i16(pt[p_index]))
+							x := unsafe {*(&i16(pt[p_index]))}
 							positive = if x >= 0 { true } else { false }
 							d1 = if positive { u64(x) } else { u64(-x) }
 						}
@@ -653,13 +654,13 @@ pub fn v_sprintf(str string, pt ... voidptr) string{
 							d1 = if positive { u64(x) } else { u64(-x) }
 						}
 						*/
-						x := *(&i64(pt[p_index]))
+						x := unsafe {*(&i64(pt[p_index]))}
 						positive = if x >= 0 { true } else { false }
 						d1 = if positive { u64(x) } else { u64(-x) }
 					}
-					// defualt int
+					// default int
 					else {
-						x := *(&int(pt[p_index]))
+						x := unsafe {*(&int(pt[p_index]))}
 						positive = if x >= 0 { true } else { false }
 						d1 = if positive { u64(x) } else { u64(-x) }
 					}
@@ -685,9 +686,9 @@ pub fn v_sprintf(str string, pt ... voidptr) string{
 					// hh fot 8 bit unsigned int
 					`h` {
 						if ch2 == `h` {
-							d1 = u64(*(&byte(pt[p_index])))
+							d1 = u64(unsafe {*(&byte(pt[p_index]))})
 						} else {
-							d1 = u64(*(&u16(pt[p_index])))
+							d1 = u64(unsafe {*(&u16(pt[p_index]))})
 						}
 					}
 					// l  u64
@@ -701,11 +702,11 @@ pub fn v_sprintf(str string, pt ... voidptr) string{
 							d1 = u64(*(&u64(pt[p_index])))
 						}
 						*/
-						d1 = u64(*(&u64(pt[p_index])))
+						d1 = u64(unsafe {*(&u64(pt[p_index]))})
 					}
 					// defualt int
 					else {
-						d1 = u64(*(&u32(pt[p_index])))
+						d1 = u64(unsafe {*(&u32(pt[p_index]))})
 					}
 				}
 
@@ -725,10 +726,10 @@ pub fn v_sprintf(str string, pt ... voidptr) string{
 					// hh fot 8 bit int
 					`h` {
 						if ch2 == `h` {
-							x := *(&i8(pt[p_index]))
+							x := unsafe {*(&i8(pt[p_index]))}
 							s = x.hex()
 						} else {
-							x := *(&i16(pt[p_index]))
+							x := unsafe {*(&i16(pt[p_index]))}
 							s = x.hex()
 						}
 					}
@@ -745,11 +746,11 @@ pub fn v_sprintf(str string, pt ... voidptr) string{
 							s = x.hex()
 						}
 						*/
-						x := *(&i64(pt[p_index]))
+						x := unsafe {*(&i64(pt[p_index]))}
 						s = x.hex()
 					} 
 					else {
-						x := *(&int(pt[p_index]))
+						x := unsafe {*(&int(pt[p_index]))}
 						s = x.hex()
 					}
 				}
@@ -767,7 +768,7 @@ pub fn v_sprintf(str string, pt ... voidptr) string{
 
 			// float and double
 			if ch in [`f`, `F`] {
-				x := *(&f64(pt[p_index]))
+				x := unsafe {*(&f64(pt[p_index]))}
 				mut positive := x >= f64(0.0)
 				len1 = if len1 >= 0 { len1 } else { def_len1 }
 				s := format_fl(f64(x), {pad_ch: pad_ch, len0: len0, len1: len1, positive: positive, sign_flag: sign, allign: allign})
@@ -778,7 +779,7 @@ pub fn v_sprintf(str string, pt ... voidptr) string{
 				continue
 			}
 			else if ch in [`e`, `E`] {
-				x := *(&f64(pt[p_index]))
+				x := unsafe {*(&f64(pt[p_index]))}
 				mut positive := x >= f64(0.0)
 				len1 = if len1 >= 0 { len1 } else { def_len1 }
 				s := format_es(f64(x), {pad_ch: pad_ch, len0: len0, len1: len1, positive: positive, sign_flag: sign, allign: allign})
@@ -789,7 +790,7 @@ pub fn v_sprintf(str string, pt ... voidptr) string{
 				continue
 			}
 			else if ch in [`g`, `G`] {
-				x := *(&f64(pt[p_index]))
+				x := unsafe {*(&f64(pt[p_index]))}
 				mut positive := x >= f64(0.0)
 				mut s := ""
 				tx := fabs(x)
@@ -810,7 +811,7 @@ pub fn v_sprintf(str string, pt ... voidptr) string{
 
 			// string
 			else if ch == `s` {
-				s1 := *(&string(pt[p_index]))
+				s1 := unsafe{*(&string(pt[p_index]))}
 				pad_ch = ` `
 				res.write(format_str(s1, {pad_ch: pad_ch, len0: len0, len1: 0, positive: true, sign_flag: false, allign: allign}))
 				status = .reset_params

--- a/vlib/strings/strings.c.v
+++ b/vlib/strings/strings.c.v
@@ -5,10 +5,11 @@ pub fn repeat(c byte, n int) string {
 	if n <= 0 {
 		return ''
 	}
-	mut bytes := &byte(0)
-	unsafe { bytes = malloc(n + 1) }
-	C.memset( bytes, c, n )
-	bytes[n] = `0`
+	mut bytes := unsafe {malloc(n + 1)}
+	unsafe {
+		C.memset( bytes, c, n )
+		bytes[n] = `0`
+	}
 	return string( bytes, n )
 }
 
@@ -21,14 +22,17 @@ pub fn repeat_string(s string, n int) string {
 	}
 	slen := s.len
 	blen := slen*n
-	mut bytes := &byte(0)
-	unsafe { bytes = malloc(blen + 1) }
+	mut bytes := unsafe {malloc(blen + 1)}
 	for bi in 0..n {
 		bislen := bi*slen
 		for si in 0..slen {
-			bytes[bislen+si] = s[si]
+			unsafe {
+				bytes[bislen+si] = s[si]
+			}
 		}
 	}
-	bytes[blen] = `0`
+	unsafe {
+		bytes[blen] = `0`
+	}
 	return string( bytes, blen )
 }


### PR DESCRIPTION
I'm working on making an error for using pointer indexing outside an `unsafe` block. I've done most of the work to update `vlib` for this, but I think it's worth submitting my changes so far in case I don't finish it for a while. (To avoid fixing conflicts on rebase).

Whilst doing this, I also put some nearby unsafe statements into an `unsafe` block too. E.g. calling C voidptr functions or `tos` etc.

*Edit:* This follows on from #5581 and others.