### PR TITLE
builtin/string.v: Speed up string.clone()

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -128,10 +128,11 @@ fn (a string) clone_static() string {
 
 pub fn (a string) clone() string {
 	mut b := string{
-		str: unsafe {byteptr(memdup(a.str, a.len + 1))}
+		str: unsafe {malloc(a.len + 1)}
 		len: a.len
 	}
 	unsafe {
+		C.memcpy(b.str, a.str, a.len)
 		b.str[a.len] = `\0`
 	}
 	return b

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -85,9 +85,6 @@ pub fn tos(s byteptr, len int) string {
 }
 
 pub fn tos_clone(s byteptr) string {
-	if s == 0 {
-		panic('tos: nil string')
-	}
 	return tos2(s).clone()
 }
 
@@ -131,11 +128,8 @@ fn (a string) clone_static() string {
 
 pub fn (a string) clone() string {
 	mut b := string{
-		str: malloc(a.len + 1)
+		str: unsafe {byteptr(memdup(a.str, a.len + 1))}
 		len: a.len
-	}
-	for i in 0..a.len {
-		b.str[i] = a.str[i]
 	}
 	unsafe {
 		b.str[a.len] = `\0`
@@ -152,12 +146,7 @@ pub fn (s string) cstr() byteptr {
 
 // cstring_to_vstring creates a copy of cstr and turns it into a v string
 pub fn cstring_to_vstring(cstr byteptr) string {
-	unsafe {
-		slen := C.strlen(charptr(cstr))
-		mut s := byteptr(memdup(cstr, slen + 1))
-		s[slen] = `\0`
-		return tos(s, slen)
-	}
+	return tos_clone(cstr)
 }
 
 pub fn (s string) replace_once(rep, with string) string {


### PR DESCRIPTION
Use `memcpy` in `string.clone()`.
Also remove unnecessary null test (null is checked in `tos2`).
Make `cstring_to_vstring` just call `tos_clone()` - ~~this fixes copying a byte past the V string data (with `memdup`)~~ [that was just after my first commit!].