### PR TITLE
v: Warn instead of error for pointer arithmetic for now

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -480,7 +480,7 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 	right_pos := infix_expr.right.position()
 	if (left_type.is_ptr() || left.is_pointer()) &&
 		infix_expr.op in [.plus, .minus] && !c.inside_unsafe {
-		c.error('pointer arithmetic is only allowed in `unsafe` blocks', left_pos)
+		c.warn('pointer arithmetic is only allowed in `unsafe` blocks', left_pos)
 	}
 	mut return_type := left_type
 	// Single side check
@@ -1632,7 +1632,7 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 		right_sym := c.table.get_type_symbol(right_type_unwrapped)
 		if (left_type.is_ptr() || left_sym.is_pointer()) &&
 			assign_stmt.op !in [.assign, .decl_assign] && !c.inside_unsafe {
-			c.error('pointer arithmetic is only allowed in `unsafe` blocks', assign_stmt.pos)
+			c.warn('pointer arithmetic is only allowed in `unsafe` blocks', assign_stmt.pos)
 		}
 		// Single side check
 		match assign_stmt.op {
@@ -2876,7 +2876,7 @@ pub fn (mut c Checker) postfix_expr(mut node ast.PostfixExpr) table.Type {
 		node.auto_locked, _ = c.fail_if_immutable(node.expr)
 	}
 	if (typ.is_ptr() || typ_sym.is_pointer()) && !c.inside_unsafe {
-		c.error('pointer arithmetic is only allowed in `unsafe` blocks', node.pos)
+		c.warn('pointer arithmetic is only allowed in `unsafe` blocks', node.pos)
 	}
 	return typ
 }


### PR DESCRIPTION
In #5581 I introduced errors for pointer arithmetic outside `unsafe`. I think we should change them to warnings so developers have some time where they can gradually migrate their code to be `unsafe` compliant, whilst still using the latest compiler for bug fixes etc. There are more things for `unsafe` that need to be enforced, these will take some time. It might annoy people to have to keep going through their code on each release (or waiting for maintainers to do that) just to be able to compile existing projects.

After at least one release, we can change the warnings back to errors.