### PR TITLE
cgen: fix assignment for sumtypes with pointers

### DIFF
--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -652,7 +652,9 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type table.Type) {
 		}
 		if !g.is_json_fn {
 			arg_typ_sym := g.table.get_type_symbol(arg.typ)
-			if arg_typ_sym.kind != .function {
+			expected_deref_type := if expected_type.is_ptr() { expected_type.deref() } else { expected_type }
+			is_sum_type := g.table.get_type_symbol(expected_deref_type).kind == .sum_type
+			if !((arg_typ_sym.kind == .function) || is_sum_type) {
 				g.write('(voidptr)&/*qq*/')
 			}
 		}


### PR DESCRIPTION
@medvednikov I am trying again a solution for dealing with pointer structs for sum types. Sorry, the other attemps were horribly wrong, that's why I have closed prior PRs.
I understand I am touching the guts of V and code quality is a must, so, of course, therer is no problem if you refuse this, it will not hurt my feelings at all.

V already handles assignments to sum types, when both sum type and variant are not pointers. This PR intends to cover the other 3 cases:
1. sum type is pointer and variant is pointer
2. sum type is pointer and variant is not
3. sum type is not and variant is pointer

the other way around (from sum type to variant, with `as`) should be no problem.

Assumption:
1. in all cases, an assignment to a sum type means sum type will have a shallow copy of the variant

Observation:
1. did not free sumtype.obj and sumtype itself (if ptr), before new assignment.

this fixes #5306