### PR TITLE
compiler: handle ranges as `match` conditions

### DIFF
--- a/vlib/v/checker/tests/match_duplicate_branch.out
+++ b/vlib/v/checker/tests/match_duplicate_branch.out
@@ -33,3 +33,10 @@ vlib/v/checker/tests/match_duplicate_branch.v:43:3: error: match case `2` is han
       |         ~~~
    44 |         else { println('else') }
    45 |     }
+vlib/v/checker/tests/match_duplicate_branch.v:51:3: error: match case `3` is handled more than once
+   49 |     match i {
+   50 |         1..5 { println('1 to 4') }
+   51 |         3 { println('3') }
+      |         ~~~
+   52 |         else { println('else') }
+   53 |     }

--- a/vlib/v/checker/tests/match_duplicate_branch.vv
+++ b/vlib/v/checker/tests/match_duplicate_branch.vv
@@ -45,8 +45,17 @@ fn test_int(i int) {
 	}
 }
 
+fn test_range(i int) {
+	match i {
+		1..5 { println('1 to 4') }
+		3 { println('3') }
+		else { println('else') }
+	}
+}
+
 fn main() {
 	test_sum_type(St1{})
 	test_enum(.red)
 	test_int(2)
+	test_range(4)
 }

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2221,20 +2221,30 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 						// g.write('._interface_idx == _${sym.name}_${branch_sym} ')
 						g.write('._interface_idx == ')
 					}
+					g.expr(expr)
 				} else if type_sym.kind == .string {
 					g.write('string_eq(')
 					//
 					g.expr(node.cond)
 					g.write(', ')
 					// g.write('string_eq($tmp, ')
+					g.expr(expr)
+					g.write(')')
+				} else if expr is ast.RangeExpr {
+					g.write('(')
+					g.expr(node.cond)
+					g.write(' >= ')
+					g.expr(expr.low)
+					g.write(' && ')
+					g.expr(node.cond)
+					g.write(' < ')
+					g.expr(expr.high)
+					g.write(')')
 				} else {
 					g.expr(node.cond)
 					g.write(' == ')
 					// g.write('$tmp == ')
-				}
-				g.expr(expr)
-				if type_sym.kind == .string {
-					g.write(')')
+					g.expr(expr)
 				}
 				if i < branch.exprs.len - 1 {
 					g.write(' || ')

--- a/vlib/v/parser/if.v
+++ b/vlib/v/parser/if.v
@@ -187,7 +187,18 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 				p.inside_match_case = true
 				expr := p.expr(0)
 				p.inside_match_case = false
-				exprs << expr
+				if p.tok.kind == .dotdot {
+					p.next()
+					expr2 := p.expr(0)
+					exprs << ast.RangeExpr{
+						low: expr
+						high: expr2
+						has_low: true
+						has_high: true
+					}
+				} else {
+					exprs << expr
+				}
 				if p.tok.kind != .comma {
 					break
 				}

--- a/vlib/v/tests/match_test.v
+++ b/vlib/v/tests/match_test.v
@@ -62,6 +62,24 @@ fn test_match_integers() {
 	assert a == -2
 }
 
+fn test_match_multiple() {
+	assert match 5 {
+		1, 2, 3 { '1-3' }
+		4, 5 { '4-5' }
+		6..9, 9 { '6-9' }
+		else { 'other' }
+	} == '4-5'
+}
+
+fn test_match_range() {
+	assert match `f` {
+		`0`..`9` { 'digit' }
+		`A`..`Z` { 'uppercase' }
+		`a`..`z` { 'lowercase' }
+		else { 'other' }
+	} == 'lowercase'
+}
+
 fn test_match_enums() {
 	mut b := Color.red
 	match b {


### PR DESCRIPTION
This PR allows using a range expression as a condition in a `match`:

```v
match char {
    `0`..`9` { 'digit' }
    `A`..`Z` { 'uppercase' }
    `a`..`z` { 'lowercase' }
    else { 'other' }
}
```
