### PR TITLE
v: `if` guard optional: Define `err` and `errcode` in `else` branch

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -433,7 +433,7 @@ pub:
 	left     Expr // `a` in `a := if ...`
 	pos      token.Position
 pub mut:
-	branches []IfBranch
+	branches []IfBranch // includes all `else if` branches
 	is_expr  bool
 	typ      table.Type
 	has_else bool

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2392,8 +2392,9 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 			g.writeln('{')
 			// define `err` only for simple `if val := opt {...} else {`
 			if is_guard && guard_idx == i - 1 {
-				var_name := guard_vars[guard_idx]
-				g.writeln('string err = ${var_name}.v_error;')
+				cvar_name := guard_vars[guard_idx]
+				g.writeln('\tstring err = ${cvar_name}.v_error;')
+				g.writeln('\tint errcode = ${cvar_name}.ecode;')
 			}
 		} else {
 			match branch.cond as cond {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2367,12 +2367,13 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 		return
 	}
 	mut is_guard := false
-	mut guard_vars := []string{len: node.branches.len}
+	mut guard_vars := []string{}
 	for i, branch in node.branches {
 		cond := branch.cond
 		if cond is ast.IfGuardExpr {
 			if !is_guard {
 				is_guard = true
+				guard_vars = []string{ len: node.branches.len }
 				g.writeln('{ /* if guard */ ')
 			}
 			var_name := g.new_tmp_var()

--- a/vlib/v/parser/if.v
+++ b/vlib/v/parser/if.v
@@ -37,6 +37,12 @@ fn (mut p Parser) if_expr() ast.IfExpr {
 				// only declare `err` if previous branch was an `if` guard
 				if prev_guard {
 					p.open_scope()
+					p.scope.register('errcode', ast.Var{
+						name: 'errcode'
+						typ: table.int_type
+						pos: body_pos
+						is_used: true
+					})
 					p.scope.register('err', ast.Var{
 						name: 'err'
 						typ: table.string_type

--- a/vlib/v/parser/if.v
+++ b/vlib/v/parser/if.v
@@ -28,6 +28,7 @@ fn (mut p Parser) if_expr() ast.IfExpr {
 			if p.tok.kind == .key_if {
 				p.next()
 			} else {
+				// else {
 				has_else = true
 				p.inside_if = false
 				end_pos := p.prev_tok.position()
@@ -65,9 +66,7 @@ fn (mut p Parser) if_expr() ast.IfExpr {
 			cond = p.expr(0)
 		}
 		mut left_as_name := ''
-		is_infix := cond is ast.InfixExpr
-		if is_infix {
-			infix := cond as ast.InfixExpr
+		if cond is ast.InfixExpr as infix {
 			is_is_cast := infix.op == .key_is
 			is_ident := infix.left is ast.Ident
 			left_as_name = if is_is_cast && p.tok.kind == .key_as {

--- a/vlib/v/tests/option_test.v
+++ b/vlib/v/tests/option_test.v
@@ -3,13 +3,20 @@ fn opt_err_with_code() ?string {
 }
 
 fn test_err_with_code() {
+	if w := opt_err_with_code() {
+		assert false
+		_ := w
+	} else {
+		assert err == 'hi'
+		assert errcode == 137
+	}
 	v := opt_err_with_code() or {
 		assert err == 'hi'
 		assert errcode == 137
 		return
 	}
 	assert false
-	println(v) // suppress not used error
+	_ := v
 }
 
 fn opt_err() ?string {

--- a/vlib/v/tests/option_test.v
+++ b/vlib/v/tests/option_test.v
@@ -69,7 +69,7 @@ fn test_if_else_opt() {
 	if _ := err_call(false) {
 		assert false
 	} else {
-		assert true
+		assert err.len != 0
 	}
 }
 
@@ -150,12 +150,12 @@ fn test_or_return() {
 	if _ := or_return_error() {
 		assert false
 	} else {
-		assert true
+		assert err.len != 0
 	}
 	if _ := or_return_none() {
 		assert false
 	} else {
-		assert true
+		assert err.len == 0
 	}
 }
 


### PR DESCRIPTION
Also:
* cgen: Don't allocate `guard_vars` array until there's a guard
* parser: Use `if sum is T` instead of `sum as T`
* parser: Rename `is_or` variable to `is_guard`