### PR TITLE
vfmt: select diff tool with env and detect more tools

### DIFF
--- a/cmd/tools/modules/vhelp/vhelp.v
+++ b/cmd/tools/modules/vhelp/vhelp.v
@@ -5,7 +5,7 @@ import os
 pub fn show_topic(topic string) {
 	vexe := os.real_path(os.getenv('VEXE'))
 	vroot := os.dir(vexe)
-	target_topic := os.join_path(vroot,'cmd','v','internal','help','${topic}.txt')
+	target_topic := os.join_path(vroot, 'cmd', 'v', 'help', '${topic}.txt')
 	content := os.read_file(target_topic) or {
 		eprintln('Unknown topic: $topic')
 		exit(1)

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -24,10 +24,10 @@ struct FormatOptions {
 	is_debug   bool
 	is_noerror bool
 	is_verify  bool // exit(1) if the file is not vfmt'ed
-	difftool   string
 }
 
 const (
+	formatted_file_token         = '\@\@\@' + 'FORMATTED_FILE: '
 	platform_and_file_extensions = [
 		['windows', '_windows.v'],
 		['linux', '_lin.v', '_linux.v', '_nix.v'],
@@ -39,7 +39,6 @@ const (
 		['haiku', '_haiku.v'],
 		['qnx', '_qnx.v']
 	]
-	formatted_file_token         = '\@\@\@' + 'FORMATTED_FILE: '
 )
 
 fn main() {
@@ -49,17 +48,7 @@ fn main() {
 	// }
 	toolexe := os.executable()
 	util.set_vroot_folder(os.dir(os.dir(os.dir(toolexe))))
-	mut args := util.join_env_vflags_and_os_args()
-	mut diff_tool := ''
-	str_opts := args.filter(it.contains('='))
-	if str_opts.len > 0 {
-		for sopt in str_opts {
-			if sopt.starts_with('-diff') {
-				args << '-diff'
-				diff_tool = sopt.after('=')
-			}
-		}
-	}
+	args := util.join_env_vflags_and_os_args()
 	foptions := FormatOptions{
 		is_c: '-c' in args
 		is_l: '-l' in args
@@ -71,7 +60,6 @@ fn main() {
 		is_debug: '-debug' in args
 		is_noerror: '-noerror' in args
 		is_verify: '-verify' in args
-		difftool: diff_tool
 	}
 	if foptions.is_verbose {
 		eprintln('vfmt foptions: $foptions')
@@ -199,16 +187,8 @@ fn (foptions &FormatOptions) post_process_file(file, formatted_file_path string)
 		return
 	}
 	if foptions.is_diff {
-		if foptions.difftool.len > 0 {
-			diff_cmd := '$foptions.difftool "$file" "$formatted_file_path"'
-			os.exec(diff_cmd) or {
-				eprintln('could not execute $diff_cmd\nerror: $err')
-				return
-			}
-			return
-		}
 		diff_cmd := util.find_working_diff_command() or {
-			eprintln('No working "diff" CLI command found.')
+			eprintln(err)
 			return
 		}
 		if foptions.is_verbose {
@@ -219,7 +199,7 @@ fn (foptions &FormatOptions) post_process_file(file, formatted_file_path string)
 	}
 	if foptions.is_verify {
 		diff_cmd := util.find_working_diff_command() or {
-			eprintln('No working "diff" CLI command found.')
+			eprintln(err)
 			return
 		}
 		x := util.color_compare_files(diff_cmd, file, formatted_file_path)
@@ -267,7 +247,7 @@ fn (foptions &FormatOptions) post_process_file(file, formatted_file_path string)
 fn (f FormatOptions) str() string {
 	return 'FormatOptions{ is_l: $f.is_l, is_w: $f.is_w, is_diff: $f.is_diff, is_verbose: $f.is_verbose,' +
 		' is_all: $f.is_all, is_worker: $f.is_worker, is_debug: $f.is_debug, is_noerror: $f.is_noerror,' +
-		' is_verify: $f.is_verify, difftool: "$f.difftool" }'
+		' is_verify: $f.is_verify" }'
 }
 
 fn file_to_target_os(file string) string {

--- a/cmd/v/help/fmt.txt
+++ b/cmd/v/help/fmt.txt
@@ -1,15 +1,31 @@
 Usage:
-  v [flags] fmt path_to_source.v [path_to_other_source.v]
+  v fmt [options] path_to_source.v [path_to_other_source.v]
 
 Formats the given V source files, then prints their formatted source to stdout.
 
 Options:
-  -c    Check if file is already formatted.
-        If it is not, print filepath, and exit with code 2.
-  -diff Display only diffs between the formatted source and the original source.
-  -l    List files whose formatting differs from vfmt.
-  -w    Write result to (source) file(s) instead of to stdout.
- -debug Print the kinds of encountered AST statements/expressions on stderr.
+  -c      Check if file is already formatted.
+          If it is not, print filepath, and exit with code 2.
+
+  -diff   Display the differences between the formatted source(s) and the original source(s).
+          This will attempt to find a working `diff` command automatically unless you
+          specify one with the VDIFF_TOOL environment variable.
+
+  -l      List files whose formatting differs from vfmt.
+
+  -w      Write result to (source) file(s) instead of to stdout.
+
+  -debug  Print the kinds of encountered AST statements/expressions on stderr.
+
+Environment Variables:
+  VDIFF_TOOL      A command-line tool that will be executed with the original file path
+                  and a temporary formatted file path as arguments. e.g.
+                  `VDIFF_TOOL=opendiff v fmt -diff path/to/file.v` will become:
+                  opendiff path/to/file.v /tmp/v/vfmt_file.v
+
+  VDIFF_OPTIONS   A set of command-line options to be sent immediately after the
+                  `diff` command. e.g.
+                  VDIFF_OPTIONS="-W 80 -y" v fmt -diff path/to/file.v /tmp/v/vfmt_file.v
 
 NB: vfmt after 2020/04/01 is based on the new AST compiler code, and
 thus is much faster, and more flexible than before.

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1768,16 +1768,16 @@ To generate documentation use vdoc, for example `v doc net.http`.
 
 ## Tools
 
-### vfmt
+### v fmt
 
 You don't need to worry about formatting your code or setting style guidelines.
-`vfmt` takes care of that:
+`v fmt` takes care of that:
 
 ```v
 v fmt file.v
 ```
 
-It's recommended to set up your editor, so that vfmt runs on every save.
+It's recommended to set up your editor, so that `v fmt -w` runs on every save.
 A vfmt run is usually pretty cheap (takes <30ms).
 
 Always run `v fmt -w file.v` before pushing your code.

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -265,8 +265,9 @@ pub fn exec(cmd string) ?Result {
 	C.ExpandEnvironmentStringsW(cmd.to_wide(), voidptr(&command_line), 32768)
 	create_process_ok := C.CreateProcessW(0, command_line, 0, 0, C.TRUE, 0, 0, 0, voidptr(&start_info), voidptr(&proc_info))
 	if !create_process_ok {
-		error_msg := get_error_msg(int(C.GetLastError()))
-		return error('exec failed (CreateProcess): $error_msg cmd: $cmd')
+		error_num := int(C.GetLastError())
+		error_msg := get_error_msg(error_num)
+		return error('exec failed (CreateProcess) with code $error_num: $error_msg cmd: $cmd')
 	}
 	C.CloseHandle(child_stdin)
 	C.CloseHandle(child_stdout_write)

--- a/vlib/v/util/diff.v
+++ b/vlib/v/util/diff.v
@@ -3,50 +3,49 @@ module util
 import os
 import time
 
-pub const (
-	cmd_opendiff = 'opendiff'
-)
-
-// iterate through a list of known diff cli commands
+// iterates through a list of known diff cli commands
+// and returns it with basic options
 pub fn find_working_diff_command() ?string {
-	mut cmd_codediff := 'code'
-	$if windows {
-		cmd_codediff = 'code.cmd'
-	}
-	for diffcmd in ['colordiff', 'gdiff', 'diff', 'colordiff.exe', 'diff.exe', cmd_opendiff, cmd_codediff] {
-		if diffcmd == cmd_opendiff {
-			// opendiff has no `--version` option
+	env_difftool := os.getenv('VDIFF_TOOL')
+	env_diffopts := os.getenv('VDIFF_OPTIONS')
+	known_diff_tools := [
+		env_difftool,
+		'colordiff', 'gdiff', 'diff', 'colordiff.exe',
+	    'diff.exe', 'opendiff', 'code', 'code.cmd'
+	] // NOTE: code.cmd is the Windows variant of the `code` cli tool
+	for diffcmd in known_diff_tools {
+		if diffcmd == 'opendiff' { // opendiff has no `--version` option
 			if opendiff_exists() {
 				return diffcmd
-			} else { // process next item
-				continue
 			}
-		}
-		diff_version_check := '$diffcmd --version'
-		p := os.exec(diff_version_check) or {
 			continue
 		}
+		p := os.exec('$diffcmd --version') or {
+			continue
+		}
+		if p.exit_code == 127 && diffcmd == env_difftool {
+			// user setup is wonky, fix it
+			return error('could not find specified VDIFF_TOOL $diffcmd')
+		}
 		if p.exit_code == 0 { // success
-			if diffcmd == cmd_codediff {
-				return '$diffcmd -d'
+			if diffcmd in ['code', 'code.cmd'] {
+				// there is no guarantee that the env opts exist
+				// or include `-d`, so (harmlessly) add it
+				return '$diffcmd $env_diffopts -d'
 			}
-			return diffcmd
+			return '$diffcmd $env_diffopts'
 		}
 	}
-	return error('no working diff command found')
+	return error('No working "diff" command found')
 }
 
 // determine if the FileMerge opendiff tool is available
 fn opendiff_exists() bool {
-	o := os.exec(cmd_opendiff) or {
+	o := os.exec('opendiff') or {
 		return false
 	}
-	// not needed, kept for vebosity
-	// if o.exit_code == 127 { // command not found
-	// return false
-	// }
-	if o.exit_code == 1 { // failed, but found
-		if o.output.contains('too few arguments') { // got a match
+	if o.exit_code == 1 { // failed (expected), but found (i.e. not 127)
+		if o.output.contains('too few arguments') { // got some exptected output
 			return true
 		}
 	}
@@ -55,9 +54,8 @@ fn opendiff_exists() bool {
 
 pub fn color_compare_files(diff_cmd, file1, file2 string) string {
 	if diff_cmd != '' {
-		mut other_options := os.getenv('VDIFF_OPTIONS')
 		full_cmd := '$diff_cmd --minimal --text --unified=2 ' +
-			' --show-function-line="fn " $other_options "$file1" "$file2" '
+			' --show-function-line="fn " "$file1" "$file2" '
 		x := os.exec(full_cmd) or {
 			return 'comparison command: `$full_cmd` failed'
 		}

--- a/vlib/v/util/diff.v
+++ b/vlib/v/util/diff.v
@@ -8,11 +8,15 @@ import time
 pub fn find_working_diff_command() ?string {
 	env_difftool := os.getenv('VDIFF_TOOL')
 	env_diffopts := os.getenv('VDIFF_OPTIONS')
-	known_diff_tools := [
-		env_difftool,
+	mut known_diff_tools := []string{}
+	if env_difftool.len > 0 {
+		known_diff_tools << env_difftool
+	}
+	known_diff_tools << [
 		'colordiff', 'gdiff', 'diff', 'colordiff.exe',
-	    'diff.exe', 'opendiff', 'code', 'code.cmd'
-	] // NOTE: code.cmd is the Windows variant of the `code` cli tool
+		'diff.exe', 'opendiff', 'code', 'code.cmd'
+	]
+	// NOTE: code.cmd is the Windows variant of the `code` cli tool
 	for diffcmd in known_diff_tools {
 		if diffcmd == 'opendiff' { // opendiff has no `--version` option
 			if opendiff_exists() {

--- a/vlib/v/util/diff.v
+++ b/vlib/v/util/diff.v
@@ -1,0 +1,80 @@
+module util
+
+import os
+import time
+
+pub const (
+	cmd_opendiff = 'opendiff'
+)
+
+// iterate through a list of known diff cli commands
+pub fn find_working_diff_command() ?string {
+	mut cmd_codediff := 'code'
+	$if windows {
+		cmd_codediff = 'code.cmd'
+	}
+	for diffcmd in ['colordiff', 'gdiff', 'diff', 'colordiff.exe', 'diff.exe', cmd_opendiff, cmd_codediff] {
+		if diffcmd == cmd_opendiff {
+			// opendiff has no `--version` option
+			if opendiff_exists() {
+				return diffcmd
+			} else { // process next item
+				continue
+			}
+		}
+		diff_version_check := '$diffcmd --version'
+		p := os.exec(diff_version_check) or {
+			continue
+		}
+		if p.exit_code == 0 { // success
+			if diffcmd == cmd_codediff {
+				return '$diffcmd -d'
+			}
+			return diffcmd
+		}
+	}
+	return error('no working diff command found')
+}
+
+// determine if the FileMerge opendiff tool is available
+fn opendiff_exists() bool {
+	o := os.exec(cmd_opendiff) or {
+		return false
+	}
+	// not needed, kept for vebosity
+	// if o.exit_code == 127 { // command not found
+	// return false
+	// }
+	if o.exit_code == 1 { // failed, but found
+		if o.output.contains('too few arguments') { // got a match
+			return true
+		}
+	}
+	return false
+}
+
+pub fn color_compare_files(diff_cmd, file1, file2 string) string {
+	if diff_cmd != '' {
+		mut other_options := os.getenv('VDIFF_OPTIONS')
+		full_cmd := '$diff_cmd --minimal --text --unified=2 ' +
+			' --show-function-line="fn " $other_options "$file1" "$file2" '
+		x := os.exec(full_cmd) or {
+			return 'comparison command: `$full_cmd` failed'
+		}
+		return x.output.trim_right('\r\n')
+	}
+	return ''
+}
+
+pub fn color_compare_strings(diff_cmd, expected, found string) string {
+	cdir := os.cache_dir()
+	ctime := time.sys_mono_now()
+	e_file := os.join_path(cdir, '${ctime}.expected.txt')
+	f_file := os.join_path(cdir, '${ctime}.found.txt')
+	os.write_file(e_file, expected)
+	os.write_file(f_file, found)
+	res := color_compare_files(diff_cmd, e_file, f_file)
+	os.rm(e_file)
+	os.rm(f_file)
+	return res
+}

--- a/vlib/v/util/errors.v
+++ b/vlib/v/util/errors.v
@@ -6,7 +6,6 @@ module util
 import os
 import term
 import v.token
-import time
 
 // The filepath:line:col: format is the default C compiler error output format.
 // It allows editors and IDE's like emacs to quickly find the errors in the
@@ -89,7 +88,7 @@ pub fn formatted_error(kind, omsg, filepath string, pos token.Position) string {
 		}
 	}
 	column := imax(0, pos.pos - p - 1)
-	position := '${path}:${pos.line_nr+1}:${util.imax(1,column+1)}:'
+	position := '$path:${pos.line_nr+1}:${imax(1,column+1)}:'
 	scontext := source_context(kind, source, column, pos).join('\n')
 	final_position := bold(position)
 	final_kind := bold(color(kind, kind))
@@ -112,11 +111,8 @@ pub fn source_context(kind, source string, column int, pos token.Position) []str
 		sline := source_lines[iline]
 		start_column := imax(0, imin(column, sline.len))
 		end_column := imax(0, imin(column + imax(0, pos.len), sline.len))
-		cline := if iline == pos.line_nr {
-			sline[..start_column] + color(kind, sline[start_column..end_column]) + sline[end_column..]
-		} else {
-			sline
-		}
+		cline := if iline == pos.line_nr { sline[..start_column] + color(kind, sline[start_column..end_column]) +
+				sline[end_column..] } else { sline }
 		clines << '${iline+1:5d} | ' + cline.replace('\t', tab_spaces)
 		//
 		if iline == pos.line_nr {
@@ -126,18 +122,10 @@ pub fn source_context(kind, source string, column int, pos token.Position) []str
 			// use strings.repeat(` `, col) to form it.
 			mut pointerline := ''
 			for bchar in sline[..start_column] {
-				x := if bchar.is_space() {
-					bchar
-				} else {
-					` `
-				}
+				x := if bchar.is_space() { bchar } else { ` ` }
 				pointerline += x.str()
 			}
-			underline := if pos.len > 1 {
-				'~'.repeat(end_column - start_column)
-			} else {
-				'^'
-			}
+			underline := if pos.len > 1 { '~'.repeat(end_column - start_column) } else { '^' }
 			pointerline += bold(color(kind, underline))
 			clines << '      | ' + pointerline.replace('\t', tab_spaces)
 		}
@@ -147,44 +135,6 @@ pub fn source_context(kind, source string, column int, pos token.Position) []str
 
 pub fn verror(kind, s string) {
 	final_kind := bold(color(kind, kind))
-	eprintln('${final_kind}: $s')
+	eprintln('$final_kind: $s')
 	exit(1)
-}
-
-pub fn find_working_diff_command() ?string {
-	for diffcmd in ['colordiff', 'gdiff', 'diff', 'colordiff.exe', 'diff.exe'] {
-		p := os.exec('$diffcmd --version') or {
-			continue
-		}
-		if p.exit_code == 0 {
-			return diffcmd
-		}
-	}
-	return error('no working diff command found')
-}
-
-pub fn color_compare_files(diff_cmd, file1, file2 string) string {
-	if diff_cmd != '' {    	
-		mut other_options := os.getenv('VDIFF_OPTIONS')
-		full_cmd := '$diff_cmd --minimal --text --unified=2 ' +
-		        ' --show-function-line="fn " $other_options "$file1" "$file2" '
-		x := os.exec(full_cmd) or {
-			return 'comparison command: `${full_cmd}` failed'
-		}
-		return x.output.trim_right('\r\n')
-    }
-    return ''
-}
-
-pub fn color_compare_strings(diff_cmd string, expected string, found string) string {
-	cdir := os.cache_dir()
-	ctime := time.sys_mono_now()
-	e_file := os.join_path(cdir, '${ctime}.expected.txt')
-	f_file := os.join_path(cdir, '${ctime}.found.txt')
-	os.write_file( e_file, expected)
-	os.write_file( f_file, found)
-	res := util.color_compare_files(diff_cmd, e_file, f_file)
-	os.rm( e_file )
-	os.rm( f_file )
-	return res
 }

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -12,9 +12,7 @@ pub const (
 
 // math.bits is needed by strconv.ftoa
 pub const (
-	builtin_module_parts = ['math.bits', 'strconv', 'strconv.ftoa', 'hash.wyhash', 'strings',
-		'builtin'
-	]
+	builtin_module_parts = ['math.bits', 'strconv', 'strconv.ftoa', 'hash.wyhash', 'strings', 'builtin']
 )
 
 pub const (
@@ -167,7 +165,7 @@ pub fn launch_tool(is_verbose bool, tool_name string, args []string) {
 		}
 		if tool_compilation.exit_code != 0 {
 			mut err := 'Permission denied'
-			if !tool_compilation.output.contains('Permission denied') {
+			if !tool_compilation.output.contains(err) {
 				err = '\n$tool_compilation.output'
 			}
 			eprintln('cannot compile `$tool_source`: $err')


### PR DESCRIPTION
- Moved diff-related utility code into it's own file within the same module (`vlib/v/util/diff.v`)
- Added a ` VDIFF_TOOL` environment variable to `v fmt`
- Add the ability to find VSCode's `code -d` and Xcode's `opendiff` (FileMerge)
- Adjusts the doc to alleviate any confusion over `vfmt` vs `v fmt`
- Fix `v help`

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
