### PR TITLE
checker: fix inability to access aliased struct fields

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -707,7 +707,11 @@ fn (mut c Checker) fail_if_immutable(expr ast.Expr) (string, token.Position) {
 				c.error('0 type in SelectorExpr', expr.pos)
 				return '', pos
 			}
-			typ_sym := c.table.get_type_symbol(c.unwrap_generic(expr.expr_type))
+			mut typ_sym := c.table.get_type_symbol(c.unwrap_generic(expr.expr_type))
+			if typ_sym.kind == .alias {
+				alias_info := typ_sym.info as table.Alias
+				typ_sym = c.table.get_type_symbol(alias_info.parent_type)
+			}
 			match typ_sym.kind {
 				.struct_ {
 					struct_info := typ_sym.info as table.Struct

--- a/vlib/v/tests/type_alias_test.v
+++ b/vlib/v/tests/type_alias_test.v
@@ -23,3 +23,15 @@ fn test_type_alias_v2() {
 	g := Myf64_2(10.4)
 	assert g + 0.5 == 10.9
 }
+
+struct Mystruct {
+	mut:
+	i int
+}
+type Mystruct_2 Mystruct
+
+fn test_type_alias_struct() {
+	mut s := Mystruct_2{}
+	s.i = 10
+	assert s.i + 100 == 110
+}


### PR DESCRIPTION
Assigns `typ_sym` to the parent's type symbol if it's an `alias` kind. 

Fixes #5848