### PR TITLE
checker, cgen: fix call of generic function returning normal type

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1116,7 +1116,7 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 	if f.is_deprecated {
 		c.warn('function `$f.name` has been deprecated', call_expr.pos)
 	}
-	if f.is_generic {
+	if f.is_generic && f.return_type.has_flag(.generic) {
 		rts := c.table.get_type_symbol(f.return_type)
 		if rts.kind == .struct_ {
 			rts_info := rts.info as table.Struct

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1785,14 +1785,15 @@ fn (mut g Gen) expr(node ast.Expr) {
 		}
 		ast.SizeOf {
 			if node.is_type {
+				node_typ := g.unwrap_generic(node.typ)
 				mut styp := node.type_name
 				if styp.starts_with('C.') {
 					styp = styp[2..]
 				}
-				if node.type_name == '' {
-					styp = g.typ(node.typ)
+				if node.type_name == '' || node.typ.has_flag(.generic) {
+					styp = g.typ(node_typ)
 				} else {
-					sym := g.table.get_type_symbol(node.typ)
+					sym := g.table.get_type_symbol(node_typ)
 					if sym.kind == .struct_ {
 						info := sym.info as table.Struct
 						if !info.is_typedef {

--- a/vlib/v/tests/sizeof_2_test.v
+++ b/vlib/v/tests/sizeof_2_test.v
@@ -1,0 +1,8 @@
+fn getsize<P>() u32 {
+	return sizeof(P)
+}
+
+fn test_sizeof_2() {
+	assert getsize<f64>() == 8
+	assert 4 == getsize<int>()
+}


### PR DESCRIPTION
This PR fixes a bugs that prevented generic functions returning a non-generic type like `fn f<P>() int` from being compiled and another one that prevented the result of this function being called from being used.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
