### PR TITLE
cgen: fix assignment for sumtypes with pointers #6

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -973,12 +973,26 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type, expected_type table.Type) {
 	// cast to sum type
 	if expected_type != table.void_type {
-		if g.table.sumtype_has_variant(expected_type, got_type) {
-			got_sym := g.table.get_type_symbol(got_type)
-			got_styp := g.typ(got_type)
+		expected_is_ptr := expected_type.is_ptr()
+		expected_deref_type := if expected_is_ptr { expected_type.deref() } else { expected_type }
+		got_is_ptr := got_type.is_ptr()
+		got_deref_type := if got_is_ptr { got_type.deref() } else { got_type }
+		if g.table.sumtype_has_variant(expected_deref_type, got_deref_type) {
 			exp_styp := g.typ(expected_type)
+			got_styp := g.typ(got_type)
 			got_idx := got_type.idx()
-			if got_type.is_ptr() {
+			got_sym := g.table.get_type_symbol(got_type)
+			if expected_is_ptr && got_is_ptr {
+				exp_der_styp := g.typ(expected_deref_type)
+				g.write('/* sum type cast */ ($exp_styp) memdup(&($exp_der_styp){.obj = ')
+				g.expr(expr)
+				g.write(', .typ = $got_idx /* $got_sym.name */}, sizeof($exp_der_styp))')
+			} else if expected_is_ptr {
+				exp_der_styp := g.typ(expected_deref_type)
+				g.write('/* sum type cast */ ($exp_styp) memdup(&($exp_der_styp){.obj = memdup(&($got_styp[]) {')
+				g.expr(expr)
+				g.write('}, sizeof($got_styp)), .typ = $got_idx /* $got_sym.name */}, sizeof($exp_der_styp))')
+			} else if got_is_ptr {
 				g.write('/* sum type cast */ ($exp_styp) {.obj = ')
 				g.expr(expr)
 				g.write(', .typ = $got_idx /* $got_sym.name */}')
@@ -2222,7 +2236,9 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 					sym := g.table.get_type_symbol(node.cond_type)
 					// branch_sym := g.table.get_type_symbol(branch.typ)
 					if sym.kind == .sum_type {
-						g.write('.typ == ')
+						dot_or_ptr := if node.cond_type.is_ptr() { '->' } else { '.' }
+						g.write(dot_or_ptr)
+						g.write('typ == ')
 					} else if sym.kind == .interface_ {
 						// g.write('._interface_idx == _${sym.name}_${branch_sym} ')
 						g.write('._interface_idx == ')
@@ -2273,7 +2289,9 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 					// g.writeln('$it_type* it = ($it_type*)${tmp}.obj; // ST it')
 					g.write('\t$it_type* it = ($it_type*)')
 					g.expr(node.cond)
-					g.writeln('.obj; // ST it')
+					dot_or_ptr := if node.cond_type.is_ptr() { '->' } else { '.' }
+					g.write(dot_or_ptr)
+					g.writeln('obj; // ST it')
 					if node.var_name.len > 0 {
 						// for now we just copy it
 						g.writeln('\t$it_type* $node.var_name = it;')

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -652,7 +652,9 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type table.Type) {
 		}
 		if !g.is_json_fn {
 			arg_typ_sym := g.table.get_type_symbol(arg.typ)
-			if arg_typ_sym.kind != .function {
+			expected_deref_type := if expected_type.is_ptr() { expected_type.deref() } else { expected_type }
+			is_sum_type := g.table.get_type_symbol(expected_deref_type).kind == .sum_type
+			if !((arg_typ_sym.kind == .function) || is_sum_type) {
 				g.write('(voidptr)&/*qq*/')
 			}
 		}


### PR DESCRIPTION
This is my 6th attempt :-) to try to fix assignments for sum types, when either the sum type or the variant is a pointer. While JoeC is still cooking his new struct & sum type implementation, I will keep trying ;-)
The reason I want to fix this so badly is because I need to use it in a piece of code where pointers with sum types are crucial;

Cases:
The way I see, it is necessary to treat 4 different cases:
   1. sum type is pointer & variant is pointer
   2. sum type is pointer & variant is not
   3. sum type is not and variant is pointer
   4. sum type is not and variant is not
Presently, V covers #3 and #4. This fix intends to extend to #1 and #2.

Difficulties:
1. assignment needs to be done in a single statement. this is an assumption (fair one) in the several places where it is called (match, array, etc.);
2. because of #1, for the case the sum type is a pointer previously allocated, I just cannot use the current allocation, by doing 2 assignments in C (`st->obj = something;` and then `st->typ = something_else;`);
3. the only solution for #2 (sum type is pointer), and being compliant with #1, is to do a new allocation, like in the initialization (with memdup). that is how this fix is doing;
4. the drawback to this single statement approach is that there is no way to free the previous allocation, neither to the sum type nor to the obj;

Implementation:
1. there is NO shallow copy of variant pointers. the sum type .obj just points directly to it
2. when variants are not pointers, a copy of it is made on heap (memdup) and the sum type .obj points to it (V already is doing this);

this fixes #5306 and for the first time passes all my tests (assignments to and from sum types, arrays of sum types, recursive fn, and pointers to pointers)