### PR TITLE
all: import individual symbols feature

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -29,7 +29,7 @@ you can do in V.
     * [Numbers](#numbers)
     * [Arrays](#arrays)
     * [Maps](#maps)
-* [Imports](#imports)
+* [Module Imports](#module-imports)
 * [Statements & Expressions](#statements--expressions)
     * [If](#if)
     * [In Operator](#in-operator)
@@ -547,7 +547,13 @@ numbers := {
 }
 ```
 
-## Imports
+## Module Imports
+
+For information about creating a module, see [Modules](#modules)
+
+### Importing a Module
+
+Modules can be imported using keyword `import`.
 
 ```v
 import os
@@ -558,7 +564,48 @@ fn main() {
 }
 ```
 
-Modules can be imported using keyword `import`. When using types, functions, and constants from other modules, the full path must be specified. In the example above, `name := input()` wouldn't work. That means that it's always clear from which module a function is called.
+When using constants from other modules, the module name must be prefixed. However,
+you can import functions and types from other modules directly:
+
+```v
+import os { input }
+import crypto.sha256 { sum }
+import time { Time }
+```
+
+### Module Import Aliasing
+
+Any imported module name can be aliased using the `as` keyword:
+
+NOTE: this example will not compile unless you have created `mymod/sha256.v`
+```v
+import crypto.sha256
+import mymod.sha256 as mysha256
+
+fn main() {
+    v_hash := sha256.sum('hi'.bytes()).hex()
+    my_hash := mysha256.sum('hi'.bytes()).hex()
+    assert my_hash == v_hash
+}
+```
+
+You cannot alias an imported function or type.
+However, you _can_ redeclare a type.
+
+```v
+import time
+
+type MyTime time.Time
+
+fn main() {
+    my_time := MyTime{
+        year: 2020,
+        month: 12,
+        day: 25
+    }
+    println(my_time.unix_time())
+}
+```
 
 ## Statements & Expressions
 

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -211,6 +211,20 @@ pub:
 	pos   token.Position
 	mod   string
 	alias string
+pub mut:
+	syms  []ImportSymbol
+}
+
+pub enum ImportSymbolKind {
+	fn_
+	type_
+}
+
+pub struct ImportSymbol {
+pub:
+	pos    token.Position
+	name   string
+	kind   ImportSymbolKind
 }
 
 pub struct AnonFn {

--- a/vlib/v/checker/tests/import_not_same_line_err.out
+++ b/vlib/v/checker/tests/import_not_same_line_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/import_not_same_line_err.v:2:2: error: `import` and `module` must be at same line
+vlib/v/checker/tests/import_not_same_line_err.v:2:2: error: `import` statements must be a single line
     1 | import
     2 |  time
       |  ~~~~

--- a/vlib/v/checker/tests/import_symbol_empty.out
+++ b/vlib/v/checker/tests/import_symbol_empty.out
@@ -1,0 +1,3 @@
+vlib/v/checker/tests/import_symbol_empty.v:1:12: error: empty `os` import set, remove `{}`
+    1 | import os {}
+      |            ^

--- a/vlib/v/checker/tests/import_symbol_empty.vv
+++ b/vlib/v/checker/tests/import_symbol_empty.vv
@@ -1,0 +1,1 @@
+import os {}

--- a/vlib/v/checker/tests/import_symbol_fn_err.out
+++ b/vlib/v/checker/tests/import_symbol_fn_err.out
@@ -1,0 +1,11 @@
+vlib/v/checker/tests/import_symbol_fn_err.v:1:17: error: module `crypto` has no public fn named `userper()`
+    1 | import crypto { userper }
+      |                 ~~~~~~~
+    2 | fn main() {
+    3 |   usurper()
+vlib/v/checker/tests/import_symbol_fn_err.v:3:3: error: unknown function: usurper
+    1 | import crypto { userper }
+    2 | fn main() {
+    3 |   usurper()
+      |   ~~~~~~~~~
+    4 | }

--- a/vlib/v/checker/tests/import_symbol_fn_err.vv
+++ b/vlib/v/checker/tests/import_symbol_fn_err.vv
@@ -1,0 +1,4 @@
+import crypto { userper }
+fn main() {
+  usurper()
+}

--- a/vlib/v/checker/tests/import_symbol_invalid.out
+++ b/vlib/v/checker/tests/import_symbol_invalid.out
@@ -1,0 +1,3 @@
+vlib/v/checker/tests/import_symbol_invalid.v:1:17: error: import syntax error, please specify a valid fn or type name
+    1 | import crypto { *_v }
+      |                 ^

--- a/vlib/v/checker/tests/import_symbol_invalid.vv
+++ b/vlib/v/checker/tests/import_symbol_invalid.vv
@@ -1,0 +1,1 @@
+import crypto { *_v }

--- a/vlib/v/checker/tests/import_symbol_type_err.out
+++ b/vlib/v/checker/tests/import_symbol_type_err.out
@@ -1,0 +1,11 @@
+vlib/v/checker/tests/import_symbol_type_err.v:1:17: error: module `crypto` has no public type `Coin{}`
+    1 | import crypto { Coin }
+      |                 ~~~~
+    2 | fn main() {
+    3 |   println(Coin{})
+vlib/v/checker/tests/import_symbol_type_err.v:3:11: error: unknown struct: Coin
+    1 | import crypto { Coin }
+    2 | fn main() {
+    3 |   println(Coin{})
+      |           ~~~~~~
+    4 | }

--- a/vlib/v/checker/tests/import_symbol_type_err.vv
+++ b/vlib/v/checker/tests/import_symbol_type_err.vv
@@ -1,0 +1,4 @@
+import crypto { Coin }
+fn main() {
+  println(Coin{})
+}

--- a/vlib/v/checker/tests/import_symbol_unclosed.out
+++ b/vlib/v/checker/tests/import_symbol_unclosed.out
@@ -1,0 +1,3 @@
+vlib/v/checker/tests/import_symbol_unclosed.v:1:28: error: import syntax error, no closing `}`
+    1 | import crypto.sha256 { sum ]
+      |                            ^

--- a/vlib/v/checker/tests/import_symbol_unclosed.vv
+++ b/vlib/v/checker/tests/import_symbol_unclosed.vv
@@ -1,0 +1,1 @@
+import crypto.sha256 { sum ]

--- a/vlib/v/checker/tests/import_syntax_err.out
+++ b/vlib/v/checker/tests/import_syntax_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/import_syntax_err.v:1:12: error: module syntax error, please use `x.y.z`
+vlib/v/checker/tests/import_syntax_err.v:1:12: error: cannot import multiple modules at a time
     1 | import time, os
       |            ^
     2 | fn main() {

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -84,7 +84,6 @@ pub fn (mut p Parser) call_expr(language table.Language, mod string) ast.CallExp
 	mut fn_mod := p.mod
 	if registered := p.table.find_fn(fn_name) {
 		if registered.is_placeholder {
-			p.table.fns.delete(fn_name)
 			fn_mod = registered.mod
 			fn_name = registered.name
 		}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -10,7 +10,7 @@ import v.util
 
 pub fn (mut p Parser) call_expr(language table.Language, mod string) ast.CallExpr {
 	first_pos := p.tok.position()
-	fn_name := if language == .c {
+	mut fn_name := if language == .c {
 		'C.$p.check_name()'
 	} else if language == .js {
 		'JS.$p.check_js_name()'
@@ -81,10 +81,18 @@ pub fn (mut p Parser) call_expr(language table.Language, mod string) ast.CallExp
 		p.next()
 		or_kind = .propagate
 	}
+	mut fn_mod := p.mod
+	if registered := p.table.find_fn(fn_name) {
+		if registered.is_placeholder {
+			p.table.fns.delete(fn_name)
+			fn_mod = registered.mod
+			fn_name = registered.name
+		}
+	}
 	node := ast.CallExpr{
 		name: fn_name
 		args: args
-		mod: p.mod
+		mod: fn_mod
 		pos: pos
 		language: language
 		or_block: ast.OrExpr{

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -22,19 +22,20 @@ pub mut:
 
 pub struct Fn {
 pub:
-	args          []Arg
-	return_type   Type
-	is_variadic   bool
-	language      Language
-	is_generic    bool
-	is_pub        bool
-	is_deprecated bool
-	is_unsafe     bool
-	mod           string
-	ctdefine      string // compile time define. myflag, when [if myflag] tag
-	attrs []string
+	args           []Arg
+	return_type    Type
+	is_variadic    bool
+	language       Language
+	is_generic     bool
+	is_pub         bool
+	is_deprecated  bool
+	is_unsafe      bool
+	is_placeholder bool
+	mod            string
+	ctdefine       string // compile time define. myflag, when [if myflag] tag
+	attrs          []string
 pub mut:
-	name        string
+	name           string
 }
 
 pub struct Arg {

--- a/vlib/v/tests/module_test.v
+++ b/vlib/v/tests/module_test.v
@@ -1,8 +1,10 @@
 import os
-import time as t
 import crypto.sha256
-import math
+import term { white }
+import crypto.md5 { sum }
 import log as l
+import time as t { now, utc, Time }
+import math
 import crypto.sha512
 
 struct TestAliasInStruct {
@@ -11,8 +13,15 @@ struct TestAliasInStruct {
 
 fn test_import() {
 	info := l.Level.info
-	assert os.o_rdonly == os.o_rdonly && t.month_days[0] == t.month_days[0] && sha256.size ==
-		sha256.size && math.pi == math.pi && info == .info && sha512.size == sha512.size
+	assert info == .info
+	assert term.white('INFO') == white('INFO')
+	assert os.o_rdonly == os.o_rdonly
+	assert t.month_days[0] == t.month_days[0]
+	assert sha256.size == sha256.size
+	assert math.pi == math.pi
+	assert sha512.size == sha512.size
+	assert md5.sum('module'.bytes()).hex() == sum('module'.bytes()).hex()
+	assert t.utc().unix_time() == utc().unix_time()
 }
 
 fn test_alias_in_struct_field() {


### PR DESCRIPTION
Implements the `fn` and `struct` import features from #5747 

- Clarify the options available in the docs
- `v fmt` opts for shortest syntax based on the `import` statement (basic)
- Added AST sub-statements for error/warning output accuracy
- Various tests for error messages and usage options