### PR TITLE
builder: slightly more helpful message if module is not found

### DIFF
--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -86,7 +86,7 @@ pub fn (mut b Builder) parse_imports() {
 				// break
 				// println('module_search_paths:')
 				// println(b.module_search_paths)
-				verror('cannot import module "$mod" (not found)')
+				verror('cannot import module "$mod" (not found locally or in ${b.module_search_paths.last()})')
 				break
 			}
 			v_files := b.v_files_from_dir(import_path)


### PR DESCRIPTION
With this PR the message that a module was not found contains a little bit more information by default.

_A message like this would have given me enough info to not open https://github.com/vlang/v/issues/5877_
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
