### PR TITLE
Make byte.hex() two digits format

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -268,35 +268,51 @@ pub fn (n int) hex1() string {
 }
 */
 
+[inline]
+fn u64_to_hex(nn u64, len byte) string {
+	mut n := nn
+	mut buf := [256]byte
+	buf[len] = `\0`
+	mut i := 0    
+	for i=len-1; i>=0; i-- {
+		d := byte(n & 0xF)
+		x := if d < 10 { d + `0` } else { d + 87 }        
+		buf[i] = x
+		n = n >> 4
+	}
+	return string{
+		str: memdup(buf, len + 1)
+		len: len
+	}
+}
+
+[inline]
+fn u64_to_hex_no_leading_zeros(nn u64, len byte) string {
+	mut n := nn
+	mut buf := [256]byte
+	buf[len] = `\0`
+	mut i := 0
+	for i=len-1; i>=0; i-- {
+		d := byte(n & 0xF)
+		x := if d < 10 { d + `0` } else { d + 87 }        
+		buf[i] = x
+		n = n >> 4
+		if n == 0 {
+			break
+		}
+	}
+	res_len := len - i
+	return string{
+		str: memdup(&buf[i], res_len + 1)
+		len: res_len
+	}
+}
+
 pub fn (nn byte) hex() string {
 	if nn == 0 {
 		return '00'
 	}
-
-	mut n := nn
-	max := 2
-	mut buf := malloc(max + 1)
-
-	mut index := max
-	unsafe {
-		buf[index--] = `\0`
-	}
-	for n > 0 {
-		d := n & 0xF
-		n = n >> 4
-		unsafe {
-			buf[index--] = if d < 10 { d + `0` } else { d + 87 }
-		}
-	}
-	if index == 0 {
-		unsafe {
-			buf[index] = `0`
-		}
-	}
-
-	unsafe {
-		return tos(buf, max)
-	}
+	return u64_to_hex(nn, 2)
 }
 
 pub fn (nn i8) hex() string {
@@ -307,29 +323,7 @@ pub fn (nn u16) hex() string {
 	if nn == 0 {
 		return '0'
 	}
-
-	mut n := nn
-	max := 5
-	mut buf := malloc(max + 1)
-
-	mut index := max
-	unsafe {
-		buf[index--] = `\0`
-	}
-	for n > 0 {
-		d := byte(n & 0xF)
-		n = n >> 4
-		unsafe {
-			buf[index--] = if d < 10 { d + `0` } else { d + 87 }
-		}
-	}
-	//buf[index--] = `x`
-	//buf[index]   = `0`
-	index++
-
-	unsafe {
-		return tos(buf + index, (max - index))
-	}
+	return u64_to_hex_no_leading_zeros(nn, 4)
 }
 
 pub fn (nn i16) hex() string {
@@ -340,29 +334,7 @@ pub fn (nn u32) hex() string {
 	if nn == 0 {
 		return '0'
 	}
-
-	mut n := nn
-	max := 10
-	mut buf := malloc(max + 1)
-
-	mut index := max
-	unsafe {
-		buf[index--] = `\0`
-	}
-	for n > 0 {
-		d := byte(n & 0xF)
-		n = n >> 4
-		unsafe {
-			buf[index--] = if d < 10 { d + `0` } else { d + 87 }
-		}
-	}
-	//buf[index--] = `x`
-	//buf[index]   = `0`
-	index++
-
-	unsafe {
-		return tos(buf + index, (max - index))
-	}
+	return u64_to_hex_no_leading_zeros(nn, 8)
 }
 
 pub fn (nn int) hex() string {
@@ -377,31 +349,7 @@ pub fn (nn u64) hex() string {
 	if nn == 0 {
 		return '0'
 	}
-
-	mut n := nn
-	max := 18
-	mut buf := malloc(max + 1)
-
-	mut index := max
-	unsafe {
-		buf[index--] = `\0`
-	}
-	for n > 0 {
-		d := byte(n & 0xF)
-		n = n >> 4
-		unsafe {
-			buf[index--] = if d < 10 { d + `0` } else { d + 87 }
-		}
-	}
-	//buf[index--] = `x`
-	//buf[index]   = `0`
-	index++
-
-	unsafe {
-		C.memmove(buf,buf+index, (max-index)+1 )
-		return tos(buf, (max-index))
-	}
-	//return tos(buf + index, (max-index))
+	return u64_to_hex_no_leading_zeros(nn, 16)
 }
 
 pub fn (nn i64) hex() string {

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -270,7 +270,7 @@ pub fn (n int) hex1() string {
 
 pub fn (nn byte) hex() string {
 	if nn == 0 {
-		return '0'
+		return '00'
 	}
 
 	mut n := nn
@@ -288,12 +288,14 @@ pub fn (nn byte) hex() string {
 			buf[index--] = if d < 10 { d + `0` } else { d + 87 }
 		}
 	}
-	//buf[index--] = `x`
-	//buf[index]   = `0`
-	index++
+	if index == 0 {
+		unsafe {
+			buf[index] = `0`
+		}
+	}
 
 	unsafe {
-		return tos(buf + index, (max - index))
+		return tos(buf, max)
 	}
 }
 

--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -199,9 +199,9 @@ fn test_int_to_hex() {
 	// --- int to hex tests
 	c0 := 12
 	// 8Bit
-	assert byte(0).hex() == '0'
-	assert byte(c0).hex() == 'c'
-	assert i8(c0).hex() == 'c'
+	assert byte(0).hex() == '00'
+	assert byte(c0).hex() == '0c'
+	assert i8(c0).hex() == '0c'
 	assert byte(127).hex() == '7f'
 	assert i8(127).hex() == '7f'
 	assert byte(255).hex() == 'ff'


### PR DESCRIPTION
I was playing around with [whirlpool](https://en.wikipedia.org/wiki/Whirlpool_(hash_function)) and noticed that the byte.hex() function did not return the second digit for anything below 15 (F).

Proposing to have it always return in the double digit (0F) hex format to be consistent.