### PR TITLE
jsgen: export namespace being compiled through commonjs

### DIFF
--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -87,8 +87,9 @@ pub fn gen(files []ast.File, table &table.Table, pref &pref.Preferences) string 
 	}
 	// resolve imports
 	deps_resolved := graph.resolve()
+	nodes := deps_resolved.nodes
 	mut out := g.hashes() + g.definitions.str()
-	for node in deps_resolved.nodes {
+	for node in nodes {
 		name := g.js_name(node.name).replace('.', '_')
 		if g.enable_doc {
 			out += '/** @namespace $name */\n'
@@ -128,6 +129,11 @@ pub fn gen(files []ast.File, table &table.Table, pref &pref.Preferences) string 
 			out += key.replace('.', '_')
 		}
 		out += ');\n\n'
+	}
+	if pref.is_shared {
+		// Export, through CommonJS, the module of the entry file if `-shared` was passed
+		export := nodes[nodes.len - 1].name
+		out += 'if (typeof module === "object" && module.exports) module.exports = $export;'
 	}
 	return out
 }


### PR DESCRIPTION
This is needed as part of [the V webpack plugin](https://github.com/spaceface777/vlang-loader), to allow other (JS, TS, etc) modules to import and use functions from V modules compiled with `-shared`. 

For more details see the plugin repo, but with this fix, something like this now works:

`src/mod1/mod1.v`
```v
module mod1

pub fn foo() string { return 'foo' }
pub fn bar() string { return 'bar' }
    fn baz() string { return 'baz' }  // not `pub`, so not exported
```

`src/main.js`
```js
import mod1 from './mod1/mod1.v'    // Imports the whole V namespace, or
import { bar } from './mod1/mod1.v' // Imports a specific function

console.log(mod1.foo()) // prints 'foo'
console.log(bar())      // prints 'bar'
```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
