### PR TITLE
v: small fix for imported symbols

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -956,6 +956,10 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 				// if exp_arg_sym.kind == .string && got_arg_sym.has_method('str') {
 				// continue
 				// }
+				// same ancestor? let it be
+				if exp_arg_sym.parent_idx == got_arg_sym.parent_idx {
+					continue
+				}
 				if got_arg_typ != table.void_type {
 					c.error('cannot use type `$got_arg_sym.str()` as type `$exp_arg_sym.str()` in argument ${i+1} to `${left_type_sym.name}.$method_name`',
 						call_expr.pos)

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2996,7 +2996,7 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 		g.go_back_out(3)
 		return
 	}
-	sym := g.table.get_type_symbol(struct_init.typ)
+	sym := g.table.get_final_type_symbol(struct_init.typ)
 	is_amp := g.is_amp
 	is_multiline := struct_init.fields.len > 5
 	g.is_amp = false // reset the flag immediately so that other struct inits in this expr are handled correctly

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -924,12 +924,14 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 	mut is_mod_cast := false
 	if p.peek_tok.kind == .dot && !known_var &&
 		(language != .v || p.known_import(p.tok.lit) || p.mod.all_after_last('.') == p.tok.lit) {
+		// p.tok.lit has been recognized as a module
 		if language == .c {
 			mod = 'C'
 		} else if language == .js {
 			mod = 'JS'
 		} else {
 			if p.tok.lit in p.imports {
+				// mark the imported module as used
 				p.register_used_import(p.tok.lit)
 				if p.peek_tok.kind == .dot && p.peek_tok2.lit[0].is_capital() {
 					is_mod_cast = true

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -210,7 +210,7 @@ pub fn (t &Table) get_final_type_symbol(typ Type) &TypeSymbol {
 		return &t.types[idx]
 	}
 	// this should never happen
-	panic('get_type_symbol: invalid type (typ=$typ idx=${idx}). Compiler bug. This should never happen')
+	panic('get_final_type_symbol: invalid type (typ=$typ idx=${idx}). Compiler bug. This should never happen')
 }
 
 [inline]

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -197,6 +197,22 @@ pub fn (t &Table) get_type_symbol(typ Type) &TypeSymbol {
 	panic('get_type_symbol: invalid type (typ=$typ idx=${idx}). Compiler bug. This should never happen')
 }
 
+// get_final_type_symbol follows aliases until it gets to a "real" Type
+[inline]
+pub fn (t &Table) get_final_type_symbol(typ Type) &TypeSymbol {
+	idx := typ.idx()
+	if idx > 0 {
+		current_type := t.types[idx]
+		if current_type.kind == .alias {
+			alias_info := current_type.info as Alias
+			return t.get_final_type_symbol(alias_info.parent_type)
+		}
+		return &t.types[idx]
+	}
+	// this should never happen
+	panic('get_type_symbol: invalid type (typ=$typ idx=${idx}). Compiler bug. This should never happen')
+}
+
 [inline]
 pub fn (t &Table) get_type_name(typ Type) string {
 	typ_sym := t.get_type_symbol(typ)

--- a/vlib/v/tests/module_test.v
+++ b/vlib/v/tests/module_test.v
@@ -6,6 +6,7 @@ import log as l
 import time as t { now, utc, Time }
 import math
 import crypto.sha512
+import cli { Command }
 
 struct TestAliasInStruct {
 	time t.Time
@@ -22,6 +23,17 @@ fn test_import() {
 	assert sha512.size == sha512.size
 	assert md5.sum('module'.bytes()).hex() == sum('module'.bytes()).hex()
 	assert t.utc().unix_time() == utc().unix_time()
+}
+
+fn test_imports_array_as_fn_arg() {
+	mut cmd := Command {
+		name: 'module test'
+	}
+	c1 := Command{}
+	c2 := Command{
+		name: 'cmd2'
+	}
+	cmd.add_commands([c1, c2])
 }
 
 fn test_alias_in_struct_field() {


### PR DESCRIPTION
Fixes #5876.

- Adds a new function (`v.table.get_final_type_symbol`), that is covered by the existing tests, and is specific to `cgen` for now. It _could_ be used elsewhere in the future for multi-level type aliasing or in the `checker`.