### PR TITLE
checker: add checks for byte casting

### DIFF
--- a/vlib/net/websocket/ws.v
+++ b/vlib/net/websocket/ws.v
@@ -247,7 +247,7 @@ pub fn (mut ws Client) write(payload byteptr, payload_len int, code OPCode) int 
 	fbdata := byteptr( frame_buf.data )
 	masking_key := create_masking_key()
 	mut header := [`0`].repeat(header_len)
-	header[0] = byte(code) | 0x80
+	header[0] = byte(int(code)) | 0x80
 	if payload_len <= 125 {
 		header[1] = byte(payload_len | 0x80)
 		header[2] = masking_key[0]
@@ -592,7 +592,7 @@ fn (mut ws Client) send_control_frame(code OPCode, frame_typ string, payload []b
 	frame_len := header_len + payload.len
 	mut control_frame := [`0`].repeat(frame_len)
 	masking_key := create_masking_key()
-	control_frame[0] = byte(code | 0x80)
+	control_frame[0] = byte(int(code) | 0x80)
 	control_frame[1] = byte(payload.len | 0x80)
 	control_frame[2] = masking_key[0]
 	control_frame[3] = masking_key[1]

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -766,7 +766,7 @@ pub:
 
 pub struct CastExpr {
 pub:
-	expr      Expr // `buf`
+	expr      Expr // `buf` in `string(buf, n)`
 	arg       Expr // `n` in `string(buf, n)`
 	typ       table.Type // `string` TODO rename to `type_to_cast_to`
 	pos       token.Position

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2235,7 +2235,7 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 					}
 					c.error(error_msg, node.pos)
 				}
-			} else if !node.expr_type.is_int() && node.expr_type != table.voidptr_type && to_type_sym.kind == .byte  {
+			} else if !node.expr_type.is_int() && node.expr_type != table.voidptr_type && !node.expr_type.is_ptr() && to_type_sym.kind == .byte  {
 				type_name := c.table.type_to_str(node.expr_type)
 				c.error('cannot cast type `$type_name` to `byte`', node.pos)
 			}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2235,6 +2235,9 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 					}
 					c.error(error_msg, node.pos)
 				}
+			} else if !node.expr_type.is_int() && node.expr_type != table.voidptr_type && to_type_sym.kind == .byte  {
+				type_name := c.table.type_to_str(node.expr_type)
+				c.error('cannot cast type `$type_name` to `byte`', node.pos)
 			}
 			if node.has_arg {
 				c.expr(node.arg)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2235,7 +2235,9 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 					}
 					c.error(error_msg, node.pos)
 				}
-			} else if !node.expr_type.is_int() && node.expr_type != table.voidptr_type && !node.expr_type.is_ptr() && to_type_sym.kind == .byte  {
+			} else if !node.expr_type.is_int() && node.expr_type != table.voidptr_type &&
+				!node.expr_type.is_ptr() &&
+				to_type_sym.kind == .byte {
 				type_name := c.table.type_to_str(node.expr_type)
 				c.error('cannot cast type `$type_name` to `byte`', node.pos)
 			}


### PR DESCRIPTION
This gives an error now:

```
>>> byte([2])
error: cannot case type `[]int` to byte 
    5 | import math
    6 |
    7 | println(byte([2]))
      |              ~~~
>>> byte([2, 3])
error: cannot case type `[]int` to byte
    5 | import math
    6 |
    7 | println(byte([2, 3]))
      |              ~~~~~~
```