### PR TITLE
cli: prevent need for unsafe block

### DIFF
--- a/vlib/cli/help.v
+++ b/vlib/cli/help.v
@@ -144,8 +144,10 @@ fn pretty_description(s string, indent_len int) string {
 		mut i := chars_per_line - 2
 		mut j := 0
 		for ; i < line.len; i += chars_per_line - 2 {
-			for line.str[i] != ` ` {
-				i--
+			unsafe {
+				for line.str[i] != ` ` {
+					i--
+				}
 			}
 			// indent was already done the first iteration
 			if j != 0 {

--- a/vlib/cli/help.v
+++ b/vlib/cli/help.v
@@ -144,10 +144,8 @@ fn pretty_description(s string, indent_len int) string {
 		mut i := chars_per_line - 2
 		mut j := 0
 		for ; i < line.len; i += chars_per_line - 2 {
-			unsafe {
-				for line.str[i] != ` ` {
-					i--
-				}
+			for line[i] != ` ` {
+				i--
 			}
 			// indent was already done the first iteration
 			if j != 0 {


### PR DESCRIPTION
Add a missing unsafe block for `cli` module
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
