### PR TITLE
eventbus: removed check on publish

### DIFF
--- a/vlib/eventbus/eventbus.v
+++ b/vlib/eventbus/eventbus.v
@@ -20,7 +20,7 @@ mut:
 struct EventHandler {
 	name string
 	handler EventHandlerFn
-	receiver voidptr
+	receiver voidptr = voidptr(0)
 	once bool
 }
 

--- a/vlib/eventbus/eventbus.v
+++ b/vlib/eventbus/eventbus.v
@@ -1,6 +1,6 @@
 module eventbus
 
-pub type EventHandlerFn fn(voidptr, voidptr, voidptr)
+pub type EventHandlerFn fn(receiver voidptr, args voidptr, sender voidptr)
 
 pub struct Publisher {
 mut:
@@ -64,7 +64,7 @@ fn (mut pb Publisher) publish(name string, sender voidptr, args voidptr) {
 			if event.once {
 				pb.registry.events.delete(i)
 			}
-			event.handler(sender, args, event.receiver)
+			event.handler(event.receiver, args, sender)
 		}
 	}
 }

--- a/vlib/eventbus/eventbus.v
+++ b/vlib/eventbus/eventbus.v
@@ -83,7 +83,6 @@ pub fn (mut s Subscriber) subscribe(name string, handler EventHandlerFn) {
 	s.registry.events << EventHandler {
 		name: name
 		handler: handler
-		receiver: voidptr(0)
 	}
 }
 
@@ -99,7 +98,6 @@ pub fn (mut s Subscriber) subscribe_once(name string, handler EventHandlerFn) {
 	s.registry.events << EventHandler {
 		name: name
 		handler: handler
-		receiver: voidptr(0)
 		once: true
 	}
 }

--- a/vlib/eventbus/eventbus.v
+++ b/vlib/eventbus/eventbus.v
@@ -64,11 +64,7 @@ fn (mut pb Publisher) publish(name string, sender voidptr, args voidptr) {
 			if event.once {
 				pb.registry.events.delete(i)
 			}
-			if event.receiver != 0 {
-				event.handler(event.receiver, args, sender)
-			} else {
-				event.handler(sender, args, voidptr(0))
-			}
+			event.handler(sender, args, event.receiver)
 		}
 	}
 }

--- a/vlib/net/websocket/ws_test.v
+++ b/vlib/net/websocket/ws_test.v
@@ -4,8 +4,8 @@ import time
 struct Test {
 mut:
 	connected    bool = false
-	sended_msg   []string = []
-	recieved_msg []string = []
+	sent_messages     []string = []
+	received_messages []string = []
 }
 
 fn test_ws() {
@@ -25,7 +25,7 @@ fn ws_test(uri string) {
 	go ws.listen()
 	text := ['ws test', '{"vlang": "test0\n192"}']
 	for msg in text {
-		test.sended_msg << msg
+		test.sent_messages << msg
 		len := ws.write(msg.str, msg.len, .text_frame)
 		assert msg.len <= len
 		// sleep to give time to recieve response before send a new one
@@ -35,28 +35,28 @@ fn ws_test(uri string) {
 	time.sleep_ms(500)
 
 	assert test.connected == true
-	assert test.sended_msg.len == test.recieved_msg.len
-	for x, msg in test.sended_msg {
-		assert msg == test.recieved_msg[x]
+	assert test.sent_messages.len == test.received_messages.len
+	for x, msg in test.sent_messages {
+		assert msg == test.received_messages[x]
 	}
 }
 
-fn on_open(mut test Test, y voidptr, ws &websocket.Client) {
+fn on_open(ws &websocket.Client, x voidptr, mut test Test) {
 	println('websocket opened.')
 	test.connected = true
 }
 
-fn on_message(mut test Test, msg &websocket.Message, ws &websocket.Client) {
+fn on_message(ws &websocket.Client, msg &websocket.Message, mut test Test) {
 	typ := msg.opcode
 	if typ == .text_frame {
 		println('Message: ${cstring_to_vstring(msg.payload)}')
-		test.recieved_msg << cstring_to_vstring(msg.payload)
+		test.received_messages << cstring_to_vstring(msg.payload)
 	} else {
 		println('Binary message: $msg')
 	}
 }
 
-fn on_close(mut test Test, y voidptr, ws &websocket.Client) {
+fn on_close(ws &websocket.Client, x, y voidptr) {
 	println('websocket closed.')
 }
 

--- a/vlib/net/websocket/ws_test.v
+++ b/vlib/net/websocket/ws_test.v
@@ -41,12 +41,12 @@ fn ws_test(uri string) {
 	}
 }
 
-fn on_open(ws &websocket.Client, x voidptr, mut test Test) {
+fn on_open(mut test Test, x voidptr, ws &websocket.Client) {
 	println('websocket opened.')
 	test.connected = true
 }
 
-fn on_message(ws &websocket.Client, msg &websocket.Message, mut test Test) {
+fn on_message(mut test Test, msg &websocket.Message, ws &websocket.Client) {
 	typ := msg.opcode
 	if typ == .text_frame {
 		println('Message: ${cstring_to_vstring(msg.payload)}')
@@ -56,11 +56,11 @@ fn on_message(ws &websocket.Client, msg &websocket.Message, mut test Test) {
 	}
 }
 
-fn on_close(ws &websocket.Client, x, y voidptr) {
+fn on_close(x, y voidptr, ws &websocket.Client) {
 	println('websocket closed.')
 }
 
-fn on_error(ws &websocket.Client, x, y voidptr) {
+fn on_error(x, y voidptr, ws &websocket.Client) {
 	println('we have an error.')
 	assert false
 }


### PR DESCRIPTION
**Warning, this can break existing code**

I don't know why the order changes if the event.receiver not exists, that it's a little bit confusing.
In huge event system that can act as tiny optimization.

Please give your opinion.