### PR TITLE
log: add flush to log file

### DIFF
--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -16,8 +16,8 @@ fn tag(l Level) string {
 	return match l {
 		.fatal { term.red('FATAL') }
 		.error { term.red('ERROR') }
-		.warn  { term.yellow('WARN ') }
-		.info  { term.white('INFO ') }
+		.warn { term.yellow('WARN ') }
+		.info { term.white('INFO ') }
 		.debug { term.blue('DEBUG') }
 	}
 }
@@ -49,32 +49,34 @@ pub fn (mut l Log) set_output_level(level Level) {
 }
 
 pub fn (mut l Log) set_full_logpath(full_log_path string) {
-	rlog_file := os.real_path( full_log_path )
-	l.set_output_label( os.file_name( rlog_file ) )
-	l.set_output_path( os.base_dir( rlog_file ) )
+	rlog_file := os.real_path(full_log_path)
+	l.set_output_label(os.file_name(rlog_file))
+	l.set_output_path(os.base_dir(rlog_file))
 }
 
-pub fn (mut l Log) set_output_label(label string){
+pub fn (mut l Log) set_output_label(label string) {
 	l.output_label = label
 }
 
 pub fn (mut l Log) set_output_path(output_file_path string) {
-	if l.ofile.is_opened() { l.ofile.close() }
+	if l.ofile.is_opened() {
+		l.ofile.close()
+	}
 	l.output_to_file = true
-	l.output_file_name = os.join_path( os.real_path( output_file_path ) , l.output_label )
-	ofile := os.open_append( l.output_file_name ) or {
-		panic('error while opening log file ${l.output_file_name} for appending')
+	l.output_file_name = os.join_path(os.real_path(output_file_path), l.output_label)
+	ofile := os.open_append(l.output_file_name) or {
+		panic('error while opening log file $l.output_file_name for appending')
 	}
 	l.ofile = ofile
 }
 
-//Writes the log file content to disk
+// Writes the log file content to disk
 pub fn (mut l Log) flush() {
-  l.ofile.flush()
+	l.ofile.flush()
 }
 
 pub fn (mut l Log) close() {
-  l.ofile.close()
+	l.ofile.close()
 }
 
 fn (mut l Log) log_file(s string, level Level) {
@@ -86,7 +88,7 @@ fn (mut l Log) log_file(s string, level Level) {
 fn (l &Log) log_cli(s string, level Level) {
 	f := tag(level)
 	t := time.now()
-	println('[$f ${t.format_ss()}] $s')
+	println('[$f $t.format_ss()] $s')
 }
 
 fn (mut l Log) send_output(s &string, level Level) {
@@ -97,29 +99,39 @@ fn (mut l Log) send_output(s &string, level Level) {
 	}
 }
 
-pub fn (mut l Log) fatal(s string){
-	if l.level < .fatal { return }
+pub fn (mut l Log) fatal(s string) {
+	if l.level < .fatal {
+		return
+	}
 	l.send_output(s, .fatal)
 	l.ofile.close()
 	panic('$l.output_label: $s')
 }
 
 pub fn (mut l Log) error(s string) {
-	if l.level < .error { return }
+	if l.level < .error {
+		return
+	}
 	l.send_output(s, .error)
 }
 
 pub fn (mut l Log) warn(s string) {
-	if l.level < .warn { return }
+	if l.level < .warn {
+		return
+	}
 	l.send_output(s, .warn)
 }
 
 pub fn (mut l Log) info(s string) {
-	if l.level < .info { return }
+	if l.level < .info {
+		return
+	}
 	l.send_output(s, .info)
 }
 
 pub fn (mut l Log) debug(s string) {
-	if l.level < .debug { return }
+	if l.level < .debug {
+		return
+	}
 	l.send_output(s, .debug)
 }

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -68,6 +68,10 @@ pub fn (mut l Log) set_output_path(output_file_path string) {
 	l.ofile = ofile
 }
 
+pub fn (mut l Log) flush() {
+  l.ofile.flush()
+}
+
 pub fn (mut l Log) close() {
   l.ofile.close()
 }

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -68,6 +68,7 @@ pub fn (mut l Log) set_output_path(output_file_path string) {
 	l.ofile = ofile
 }
 
+//Writes the log file content to disk
 pub fn (mut l Log) flush() {
   l.ofile.flush()
 }


### PR DESCRIPTION
For long running time programs, the log file is never written.

This make public the fn flush to write the log file content to disk.