### PR TITLE
vlib: Implement os.system for iOS and uncomment the `$if ios` blocks

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -68,6 +68,8 @@ fn C.fclose() int
 fn C.pclose() int
 
 fn C.system() int
+fn C.posix_spawn(&int, charptr, voidptr, voidptr, &charptr, voidptr) int
+fn C.waitpid(int, voidptr, int) int
 
 fn C.setenv(charptr) int
 

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -455,7 +455,7 @@ pub fn system(cmd string) int {
 	} $else {
 		$if ios {
 			unsafe {
-				arg := [ charptr('/bin/sh'.str), '-c'.str, cmd.str, 0 ]
+				arg := [ charptr(c'/bin/sh'), '-c'.str, cmd.str, 0 ]
 				pid := 0
 				ret = C.posix_spawn(&pid, '/bin/sh', 0, 0, arg.data, 0)
 				status := 0

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -455,7 +455,7 @@ pub fn system(cmd string) int {
 	} $else {
 		$if ios {
 			unsafe {
-				arg := [ c'/bin/sh', c'-c'.str, cmd.str, 0 ]
+				arg := [ c'/bin/sh', c'-c', byteptr(cmd.str), 0 ]
 				pid := 0
 				ret = C.posix_spawn(&pid, '/bin/sh', 0, 0, arg.data, 0)
 				status := 0

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -455,7 +455,7 @@ pub fn system(cmd string) int {
 	} $else {
 		$if ios {
 			unsafe {
-				arg := [ charptr(c'/bin/sh'), '-c'.str, cmd.str, 0 ]
+				arg := [ c'/bin/sh', c'-c'.str, cmd.str, 0 ]
 				pid := 0
 				ret = C.posix_spawn(&pid, '/bin/sh', 0, 0, arg.data, 0)
 				status := 0

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -453,22 +453,22 @@ pub fn system(cmd string) int {
 			ret = C._wsystem(wcmd.to_wide())
 		}
 	} $else {
-/*
-		// make
-		// make selfcompile
-		// ./v -os ios hello.v
 		$if ios {
-			// TODO: use dlsym, use posix_spawn or embed ios_system
-			eprintln('system not supported on ios')
-			ret = 1
+			unsafe {
+				arg := [ charptr('/bin/sh'.str), '-c'.str, cmd.str, 0 ]
+				pid := 0
+				ret = C.posix_spawn(&pid, '/bin/sh', 0, 0, arg.data, 0)
+				status := 0
+				ret = C.waitpid(pid, &status, 0)
+				if C.WIFEXITED(status) {
+					ret = C.WEXITSTATUS(status)
+				}
+			}
 		} $else {
-*/
 			unsafe {
 				ret = C.system(charptr(cmd.str))
 			}
-/*
 		}
-*/
 	}
 	if ret == -1 {
 		print_c_errno()

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -538,7 +538,7 @@ fn (mut v Builder) cc() {
 	if v.pref.os == .ios {
 		ret := os.system('ldid2 -S $v.pref.out_name')
 		if ret != 0 {
-			eprintln('failed to run ldid2. see https://github.com/xerub/ldid')
+			eprintln('failed to run ldid2, try: brew install ldid')
 		}
 	}
 }

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -535,6 +535,12 @@ fn (mut v Builder) cc() {
 			}
 		}
 	}
+	if v.pref.os == .ios {
+		ret := os.system('ldid2 -S $v.pref.out_name')
+		if ret != 0 {
+			eprintln('failed to run ldid2. see https://github.com/xerub/ldid')
+		}
+	}
 }
 
 fn (mut b Builder) cc_linux_cross() {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -255,6 +255,7 @@ pub fn (mut g Gen) init() {
 	}
 	if g.pref.os == .ios {
 		g.cheaders.writeln('#define __TARGET_IOS__ 1')
+		g.cheaders.writeln('#include <spawn.h>')
 	}
 	g.write_builtin_types()
 	g.write_typedef_types()

--- a/vlib/v/pref/os.v
+++ b/vlib/v/pref/os.v
@@ -121,11 +121,9 @@ pub fn get_host_os() OS {
 	$if linux {
 		return .linux
 	}
-/*
 	$if ios {
 		return .ios
 	}
-*/
 	$if macos {
 		return .mac
 	}


### PR DESCRIPTION
This PR is the 2nd step to support iOS crosscompilation for V. those are the changes done in this PR:

* Uncomment all the `$if ios` blocks now that v.c is updated
* Run ldid2 after compilation to make the final executable run on jailbroken devices
* Implement os.system using posix_spawn. system() is deprecated (and forbidden) 

proof: 

![Screenshot 2020-07-23 at 12 25 22](https://user-images.githubusercontent.com/6431515/88276593-981c8280-ccdf-11ea-9803-47fd2efb3279.png)
on iOS