### PR TITLE
Fix crash in term.header when divider.len < 2

### DIFF
--- a/vlib/term/term.v
+++ b/vlib/term/term.v
@@ -49,7 +49,7 @@ pub fn h_divider(divider string) string {
 // e.g: term.header('TEXT', '=')
 // =============== TEXT ===============
 pub fn header(text, divider string) string {
-	if text.len == 0 {
+	if text.len == 0 || divider.len < 2 {
 		return h_divider(divider)
 	}
 	cols,_ := get_terminal_size()


### PR DESCRIPTION
when running `v test .` on a test that crashes, v fails in this line, so it makes it harder to understand who is really crashing. this pr fixes this problem

```go
(lldb) r
Process 68537 launched: '/Users/pancake/prg/v/v' (x86_64)

FAIL  623.199 ms objc_test.v
Terminated by signal 11 (SIGSEGV)



      623.753 ms <=== total time spent running V _test.v files
                 ok, fail, skip, total =     0,     1,     0,     1
Process 68537 exited with status = 1 (0x00000001)
(lldb) r
Process 68590 launched: '/Users/pancake/prg/v/v' (x86_64)
V panic: substr(0, 2) out of bounds (len=0)
0   vtest                               0x0000000100004590 string_substr + 128
1   vtest                               0x00000001000240fa term__header + 394
2   vtest                               0x000000010002dc39 testing__header + 57
3   vtest                               0x000000010003169b main__main + 1819
4   vtest                               0x000000010002ec31 main + 81
5   vtest                               0x0000000100001664 start + 52
Terminated by signal 11 (SIGSEGV)
Process 68590 exited with status = 11 (0x0000000b)
(lldb)
```