### PR TITLE
docs: an int value can promoted to f32

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -312,9 +312,8 @@ These are the allowed possibilities:
       ↘     ↘     ↘      ptr
    i8 → i16 → int → i64 ⬏
 ```
-An `int` value for example can be automatically promoted to `f64`
-or `i64` but not to `f32` or `u32`. (`f32` would mean precision
-loss for large values and `u32` would mean loss of the sign for
+An `int` value for example can be automatically promoted to `f32` or `f64`
+or `i64` but not to `u32`. (`u32` would mean loss of the sign for
 negative values).
 
 ### Strings


### PR DESCRIPTION
In documentation section 'Types', it said an int value cannot be automatically promoted to f32. It's wrong.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
