### PR TITLE
docs: `Compile-time reflection` section with *new features*

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2150,7 +2150,7 @@ the boolean expression is highly improbable. In the JS backend, that does nothin
 ## Compile-time reflection
 
 Having built-in JSON support is nice, but V also allows you to create efficient
-serializers for any data format. V has compile-time `assert`, `if` and `for` constructs:
+serializers for any data format. V has compile-time `if` and `for` constructs:
 
 ```v
 // TODO: not implemented yet
@@ -2160,16 +2160,11 @@ struct User {
     age  int
 }
 
-// StructName.fields gives a compile-time array of a field metadata type
-$assert User.fields.len == 2
-// Check a field identifier:
-$assert User.fields[1].name == 'age'
-// Check the field type:
-$assert User.fields[0].Type is string
-
+// Note: T should be passed a struct name only
 fn decode<T>(data string) T {
     mut result := T{}
     // compile-time `for` loop
+    // T.fields gives an array of a field metadata type
     $for field in T.fields {
         $if field.Type is string {
             // $(string_expr) produces an identifier


### PR DESCRIPTION
Change section heading.
~~New feature: compile-time asserts.~~ - postponed for now.
Use `$for`, `$if` for compile-time statements (already agreed).

See example for following features:
* New feature: ~~`Struct.fields[0].Type`~~ `field.Type` is an actual type, so it can be compared with `field.Type is T`. See #5972 for more info & current status. Note: `field is T` was already approved [here](https://github.com/vlang/website/pull/4/files#diff-bf9556ebe651f71df890a9a2f75d9e1fR1244-R1248) but that needs special handling of `is` and is less flexible - `typeof(field)` is a metadata struct, it's not the same as `field.Type`.
* New feature: `$(string_expr)` produces an identifier - This is now implemented in #5968. This is more flexible than `$field` to produce an identifier. E.g.:
  * `$(field.name)` -> `my_field_name`
  * `$('get_' + field.name)` -> `get_my_field_name`
  * `$('get_$field.Type.name')` -> `get_int` for an `int` field.

The above features are a bit longer to type but they are clearer and more flexible. In compile-time code, it's important to be clear rather than have the shortest syntax. The user can just learn the general compile-time constructs rather than remembering more special cases that are less powerful.

Draft until new features are approved.