### PR TITLE
v/parser: Support `unsafe(expr)`

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1907,10 +1907,10 @@ To mark potentially memory-unsafe operations, enclose them in an `unsafe` block:
 
 ```v
 // allocate 2 uninitialized bytes & return a reference to them
-mut p := unsafe { &byte(malloc(2)) }
+mut p := unsafe(&byte(malloc(2)))
 p[0] = `h` // Error: pointer indexing is only allowed in `unsafe` blocks
 unsafe {
-    p[0] = `h`
+    p[0] = `h` // OK
     p[1] = `i`
 }
 p++ // Error: pointer arithmetic is only allowed in `unsafe` blocks
@@ -1920,13 +1920,12 @@ unsafe {
 assert *p == `i`
 ```
 
-Best practice is to avoid putting memory-safe expressions inside an `unsafe` block,
+Best practice is to avoid putting memory-safe expressions inside an `unsafe` expression/block,
 so that the reason for using `unsafe` is as clear as possible. Generally any code 
-you think is memory-safe should not be inside an `unsafe` block, so the compiler 
-can verify it.
+you think is memory-safe should be verified by the compiler.
 
 If you suspect your program does violate memory-safety, you have a head start on 
-finding the cause: look at the `unsafe` blocks (and how they interact with 
+finding the cause: look for the `unsafe` keyword (and how it affects the
 surrounding code).
 
 * Note: This is work in progress.

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -728,6 +728,7 @@ pub:
 pub struct ParExpr {
 pub:
 	expr Expr
+	is_unsafe bool // unsafe(expr)
 }
 
 pub struct GoStmt {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2369,7 +2369,14 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 			return table.void_type
 		}
 		ast.ParExpr {
-			return c.expr(node.expr)
+			if !node.is_unsafe {
+				return c.expr(node.expr)
+			}
+			assert !c.inside_unsafe
+			c.inside_unsafe = true
+			t := c.expr(node.expr)
+			c.inside_unsafe = false
+			return t
 		}
 		ast.RangeExpr {
 			// never happens

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -902,6 +902,9 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 			panic('fmt: OrExpr should to linked to CallExpr')
 		}
 		ast.ParExpr {
+			if node.is_unsafe {
+				f.write('unsafe')
+			}
 			f.write('(')
 			f.par_level++
 			f.expr(node.expr)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -602,13 +602,22 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 			}
 		}
 		.key_unsafe {
-			p.next()
-			assert !p.inside_unsafe
-			p.inside_unsafe = true
-			stmts := p.parse_block()
-			p.inside_unsafe = false
-			return ast.UnsafeStmt{
-				stmts: stmts
+			// unsafe {
+			if p.peek_tok.kind == .lcbr {
+				p.next()
+				assert !p.inside_unsafe
+				p.inside_unsafe = true
+				stmts := p.parse_block()
+				p.inside_unsafe = false
+				return ast.UnsafeStmt{
+					stmts: stmts
+				}
+			}
+			// unsafe(
+			pos := p.tok.position()
+			return ast.ExprStmt{
+				expr: p.expr(0)
+				pos: pos
 			}
 		}
 		.hash {

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -93,12 +93,23 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			pos := p.tok.position()
 			assert !p.inside_unsafe
 			p.inside_unsafe = true
-			stmts := p.parse_block()
-			p.inside_unsafe = false
-			node = ast.UnsafeExpr{
-				stmts: stmts
-				pos: pos
+			if p.tok.kind == .lpar {
+				// unsafe(
+				p.check(.lpar)
+				node = ast.ParExpr{
+					expr: p.expr(0)
+					is_unsafe: true
+				}
+				p.check(.rpar)
+			} else {
+				// unsafe {
+				// old syntax, UnsafeExpr can be removed later
+				node = ast.UnsafeExpr{
+					stmts: p.parse_block()
+					pos: pos
+				}
 			}
+			p.inside_unsafe = false
 		}
 		.key_lock, .key_rlock {
 			node = p.lock_expr()

--- a/vlib/v/tests/unsafe_test.v
+++ b/vlib/v/tests/unsafe_test.v
@@ -3,17 +3,9 @@ fn test_ptr_assign() {
 	mut p := &v[0]
 	unsafe {
 		(*p)++
-	}
-	unsafe {
-		p++
-	} // p now points to v[1]
-	unsafe {
+		p++ // p now points to v[1]
 		(*p) += 2
-	}
-	unsafe {
-		p += 2
-	} // p now points to v[3]
-	unsafe {
+		p += 2 // p now points to v[3]
 		*p = 31
 	}
 	assert v[0] == 6
@@ -24,16 +16,9 @@ fn test_ptr_assign() {
 
 fn test_ptr_infix() {
 	v := 4
-	mut q := unsafe {
-		&v - 1
-	}
-	
-	q = unsafe {
-		q + 3
-	}
-	
-	_ := q
-	_ := v
+	mut q := unsafe(&v - 1)
+	q = unsafe(q + 3)
+	assert q == unsafe(&v + 2)
 }
 
 struct S1 {


### PR DESCRIPTION
#5793 implemented `unsafe {expr}` as an expression with the intention to extend it to `unsafe {statements expr}`. There are some problems with that though:

* It's not simple to tell an `unsafe {` expression from an `unsafe {` block when it's the first expression on a line, e.g. `unsafe {*p}++` - this currently gives an error 'bad token `++`'. It also looks a bit weird. Because of this, things like `foo := if cond {unsafe{expr}} else {unsafe{expr}}` currently error too.
* Supporting multiple statements inside an unsafe expression is quite difficult to implement the cgen correctly when there are order-of-evaluation issues. E.g. `func(x, unsafe {x++ x++})` - the only way I've found (to do it correctly) is to lower the unsafe expression to a nested anonymous function call `fn(){x++ return x++}()` - but nested functions aren't supported yet. That would also mean that unsafe expressions were inefficient if the optimizer doesn't inline the function call.

I think it's better to just use `unsafe(expr)`. `foo := unsafe {statements expr}` could be supported later but as an `UnsafeStmt`, discuss that here: https://github.com/vlang/v/issues/5655#issuecomment-662574287.

This pull actually uses `ParExpr` with a new field `is_unsafe`, which means `unsafe(*p)++` and `foo := if cond {unsafe(expr)} else ...` example now work without updating anything :-)

After this is merged, I plan to make a pull for `vfmt` to change any `unsafe {` expressions into `unsafe(expr)`, leaving unsafe blocks as is. Then when people have updated their code we can remove `UnsafeExpr`.