### PR TITLE
v/ast: Use Block instead of UnsafeStmt

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -18,7 +18,7 @@ pub type Expr = AnonFn | ArrayInit | AsCast | Assoc | BoolLiteral | CallExpr | C
 pub type Stmt = AssertStmt | AssignStmt | Attr | Block | BranchStmt | CompFor | CompIf |
 	ConstDecl | DeferStmt | EnumDecl | ExprStmt | FnDecl | ForCStmt | ForInStmt | ForStmt |
 	GlobalDecl | GoStmt | GotoLabel | GotoStmt | HashStmt | Import | InterfaceDecl | Module |
-	Return | SqlStmt | StructDecl | TypeDecl | UnsafeStmt
+	Return | SqlStmt | StructDecl | TypeDecl
 
 pub type ScopeObject = ConstField | GlobalDecl | Var
 
@@ -33,9 +33,11 @@ pub:
 	pos token.Position
 }
 
+// `{stmts}` or `unsafe {stmts}`
 pub struct Block {
 pub:
 	stmts []Stmt
+	is_unsafe bool
 }
 
 // | IncDecStmt k
@@ -719,11 +721,6 @@ pub mut:
 	ifdef string
 }
 
-pub struct UnsafeStmt {
-pub:
-	stmts []Stmt
-}
-
 // `(3+4)`
 pub struct ParExpr {
 pub:
@@ -1103,8 +1100,6 @@ pub fn (stmt Stmt) position() token.Position {
 		StructDecl { return stmt.pos }
 		/*
 		// TypeDecl {
-		// }
-		// UnsafeStmt {
 		// }
 		*/
 		//

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -294,6 +294,9 @@ pub fn (mut f Fmt) stmt(node ast.Stmt) {
 			}
 		}
 		ast.Block {
+			if node.is_unsafe {
+				f.write('unsafe ')
+			}
 			f.writeln('{')
 			f.stmts(node.stmts)
 			f.writeln('}')
@@ -511,11 +514,6 @@ pub fn (mut f Fmt) stmt(node ast.Stmt) {
 		ast.TypeDecl {
 			// already handled in f.imports
 			f.type_decl(it)
-		}
-		ast.UnsafeStmt {
-			f.writeln('unsafe {')
-			f.stmts(it.stmts)
-			f.writeln('}')
 		}
 	}
 }

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -677,7 +677,11 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 			g.writeln('// Attr: [$node.name]')
 		}
 		ast.Block {
-			g.writeln('{')
+			if node.is_unsafe {
+				g.writeln('{ // Unsafe block')
+			} else {
+				g.writeln('{')
+			}
 			g.stmts(node.stmts)
 			g.writeln('}')
 		}
@@ -879,11 +883,6 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 		}
 		ast.TypeDecl {
 			g.writeln('// TypeDecl')
-		}
-		ast.UnsafeStmt {
-			g.writeln('{ // Unsafe block')
-			g.stmts(node.stmts)
-			g.writeln('}')
 		}
 	}
 	g.stmt_path_pos.delete(g.stmt_path_pos.len - 1)

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -506,9 +506,6 @@ fn (mut g JsGen) stmt(node ast.Stmt) {
 		ast.TypeDecl {
 			// skip JS has no typedecl
 		}
-		ast.UnsafeStmt {
-			g.stmts(node.stmts)
-		}
 	}
 }
 

--- a/vlib/v/gen/x64/gen.v
+++ b/vlib/v/gen/x64/gen.v
@@ -604,6 +604,9 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 		ast.AssignStmt {
 			g.assign_stmt(node)
 		}
+		ast.Block {
+			g.stmts(node.stmts)
+		}
 		ast.ConstDecl {}
 		ast.ExprStmt {
 			g.expr(node.expr)
@@ -632,9 +635,6 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 			g.ret()
 		}
 		ast.StructDecl {}
-		ast.UnsafeStmt {
-			g.stmts(node.stmts)
-		}
 		else {
 			println('x64.stmt(): bad node: ' + typeof(node))
 		}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -602,13 +602,26 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 			}
 		}
 		.key_unsafe {
-			p.next()
-			assert !p.inside_unsafe
-			p.inside_unsafe = true
-			stmts := p.parse_block()
-			p.inside_unsafe = false
-			return ast.UnsafeStmt{
-				stmts: stmts
+			if p.peek_tok.kind == .lcbr {
+				// unsafe {
+				p.next()
+				assert !p.inside_unsafe
+				p.inside_unsafe = true
+				stmts := p.parse_block()
+				p.inside_unsafe = false
+				return ast.Block{
+					stmts: stmts
+					is_unsafe: true
+				}
+			} else {
+				p.error_with_pos('please use `unsafe {`', p.tok.position())
+			}
+			// unsafe( ; NB: this will be never reached
+			pos := p.tok.position()
+			ex := p.expr(0)
+			return ast.ExprStmt{
+				expr: ex
+				pos: pos
 			}
 		}
 		.hash {


### PR DESCRIPTION
As an UnsafeStmt is fundamentally a block statement, I think it's simpler to make it a Block. Doing this has helped to find & fix some bugs too.

Add `Block::is_unsafe` field.
checker: Fixes 'missing return' warning with `return` inside a Block.
gen/js: Fixes a bug where an unsafe block didn't introduce a scope.
gen/x64: Fixes missing Block statements.