### PR TITLE
checker: add checks for fns on left side

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1619,6 +1619,9 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 	//
 	is_decl := assign_stmt.op == .decl_assign
 	for i, left in assign_stmt.left {
+		if left is ast.CallExpr {
+			c.error('cannot use ${left.name}() on the left side', left.pos)
+		}
 		is_blank_ident := left.is_blank_ident()
 		mut left_type := table.void_type
 		if !is_decl && !is_blank_ident {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1620,7 +1620,7 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 	is_decl := assign_stmt.op == .decl_assign
 	for i, left in assign_stmt.left {
 		if left is ast.CallExpr {
-			c.error('cannot use ${left.name}() on the left side', left.pos)
+			c.error('cannot call a function ${left.name}() on the left side of an assignment', left.pos)
 		}
 		is_blank_ident := left.is_blank_ident()
 		mut left_type := table.void_type

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1620,7 +1620,8 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 	is_decl := assign_stmt.op == .decl_assign
 	for i, left in assign_stmt.left {
 		if left is ast.CallExpr {
-			c.error('cannot call a function ${left.name}() on the left side of an assignment', left.pos)
+			c.error('cannot call function `${left.name}()` on the left side of an assignment',
+				left.pos)
 		}
 		is_blank_ident := left.is_blank_ident()
 		mut left_type := table.void_type

--- a/vlib/v/checker/tests/assign_fn_call_on_left_side_err.out
+++ b/vlib/v/checker/tests/assign_fn_call_on_left_side_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/assign_fn_call_on_left_side_err.v:6:2: error: cannot call a function foo() on the left side of an assignment 
+vlib/v/checker/tests/assign_fn_call_on_left_side_err.v:6:2: error: cannot call function `foo()` on the left side of an assignment
     4 | 
     5 | fn main() {
     6 |     foo('s') = 1

--- a/vlib/v/checker/tests/assign_fn_call_on_left_side_err.out
+++ b/vlib/v/checker/tests/assign_fn_call_on_left_side_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/assign_fn_call_on_left_side_err.v:6:2: error: cannot call a function foo() on the left side of an assignment 
+    4 | 
+    5 | fn main() {
+    6 |     foo('s') = 1
+      |     ~~~~~~~~
+    7 | }

--- a/vlib/v/checker/tests/assign_fn_call_on_left_side_err.vv
+++ b/vlib/v/checker/tests/assign_fn_call_on_left_side_err.vv
@@ -1,0 +1,7 @@
+fn foo(s string) int {
+	return 1
+}
+
+fn main() {
+	foo('s') = 1
+}


### PR DESCRIPTION
Now it gives an error like this:

```
foo.v:4:2: error: cannot use foo() on the left side 
    2 |
    3 | fn main() {
    4 |     foo('s') = 1
      |     ~~~~~~~~
    5 | }
```