### PR TITLE
comp_for: allow checking full mehod and arg types

### DIFF
--- a/examples/compiletime/compile-time-for.v
+++ b/examples/compiletime/compile-time-for.v
@@ -22,10 +22,10 @@ fn main() {
 		$if method.ReturnType is int {
 			println('$method.name returns int')
 		}
-		/*
-		$if method.args[0].Type is int {
-			println('${method.name}\'s first arg is int')
+		$if method.args[0].Type is string {
+			println("${method.name}'s first arg is string")
 		}
+		/*
 		$if method.Type is VoidFn {
 			println('$method.name is a void method')
 		}

--- a/examples/compiletime/compile-time-for.v
+++ b/examples/compiletime/compile-time-for.v
@@ -1,64 +1,32 @@
-module main
+struct App {}
 
-struct App {
-	test string [test]
-mut:
-	a    string
-	b    int
-}
-
-// type VoidFn = fn()
+fn (mut app App) method_one() {}
+fn (mut app App) method_two() int {	return 0 }
+fn (mut app App) method_three(s string) string { return s }
 
 fn main() {
-	println('\nAll functions')
 	$for method in App.methods {
-		// println(method)
-		// TODO: `Type.str()` should return the type name as a string, rather than the index
-
 		$if method.Type is fn(string) string {
 			println('$method.name IS `fn(string) string`')
 		} $else {
 			println('$method.name is NOT `fn(string) string`')
 		}
-		$if method.ReturnType is int {
-			println('$method.name DOES return `int`')
-		} $else {
+		$if method.ReturnType !is int {
 			println('$method.name does NOT return `int`')
+		} $else {
+			println('$method.name DOES return `int`')
 		}
 		$if method.args[0].Type !is string {
 			println("${method.name}'s first arg is NOT `string`")
 		} $else {
 			println("${method.name}'s first arg IS `string`")
 		}
-		$if method.Type !is fn() {
-			println('$method.name is NOT a void method')
-		} $else {
+		// TODO: Double inversion, should this even be allowed?
+		$if method.Type is fn() {
 			println('$method.name IS a void method')
+		} $else {
+			println('$method.name is NOT a void method')
 		}
 		println('')
 	}
-	println('\nAll fields')
-	$for field in App.fields {
-		$if field.Type is string {
-			println('Field `$field.name` is string')
-		}
-	}
-}
-
-fn (mut app App) method_one() {
-}
-
-//fn (mut app App) method_two() {
-//}
-
-fn (mut app App) method_two() int {
-	return 0
-}
-
-//fn (mut app App) method_four() int {
-//	return 1
-//}
-
-fn (mut app App) method_three(s string) string {
-	return s
 }

--- a/examples/compiletime/compile-time-for.v
+++ b/examples/compiletime/compile-time-for.v
@@ -4,35 +4,40 @@ struct App {
 	test string [test]
 mut:
 	a    string
+	b    int
 }
 
 // type VoidFn = fn()
 
 fn main() {
-	println('\n\nAll functions')
+	println('\nAll functions')
 	$for method in App.methods {
-		println('Method: $method.name')
-		println('Attributes: $method.attrs')
-		println('Return type: $method.ReturnType')
-		// TODO: `ReturnType.str()` should return the type name as a string
+		// println(method)
+		// TODO: `Type.str()` should return the type name as a string, rather than the index
 
 		$if method.Type is fn(string) string {
-			println('$method.name is fn(string) string')
+			println('$method.name IS `fn(string) string`')
+		} $else {
+			println('$method.name is NOT `fn(string) string`')
 		}
 		$if method.ReturnType is int {
-			println('$method.name returns int')
+			println('$method.name DOES return `int`')
+		} $else {
+			println('$method.name does NOT return `int`')
 		}
-		$if method.args[0].Type is string {
-			println("${method.name}'s first arg is string")
+		$if method.args[0].Type !is string {
+			println("${method.name}'s first arg is NOT `string`")
+		} $else {
+			println("${method.name}'s first arg IS `string`")
 		}
-		/*
-		$if method.Type is VoidFn {
-			println('$method.name is a void method')
+		$if method.Type !is fn() {
+			println('$method.name is NOT a void method')
+		} $else {
+			println('$method.name IS a void method')
 		}
-		*/
 		println('')
 	}
-	println('\n\nAll fields')
+	println('\nAll fields')
 	$for field in App.fields {
 		$if field.Type is string {
 			println('Field `$field.name` is string')
@@ -43,17 +48,17 @@ fn main() {
 fn (mut app App) method_one() {
 }
 
-fn (mut app App) method_two() {
-}
+//fn (mut app App) method_two() {
+//}
 
-fn (mut app App) method_three() int {
+fn (mut app App) method_two() int {
 	return 0
 }
 
-fn (mut app App) method_four() int {
-	return 1
-}
+//fn (mut app App) method_four() int {
+//	return 1
+//}
 
-fn (mut app App) method_five(s string) string {
+fn (mut app App) method_three(s string) string {
 	return s
 }

--- a/examples/compiletime/compile-time-for.v
+++ b/examples/compiletime/compile-time-for.v
@@ -6,26 +6,36 @@ mut:
 	a    string
 }
 
+// type VoidFn = fn()
+
 fn main() {
-	println('All functions')
+	println('\n\nAll functions')
 	$for method in App.methods {
-		$if method.@type is int {
-			println('hi')
+		println('Method: $method.name')
+		println('Attributes: $method.attrs')
+		println('Return type: $method.ReturnType')
+		// TODO: `ReturnType.str()` should return the type name as a string
+
+		$if method.Type is fn(string) string {
+			println('$method.name is fn(string) string')
 		}
-		println('$method.name.len')
-		println('$method.name.str')
-		println('Method: $method.name')
-		println('Attributes: $method.attrs')
-		println('Return type: $method.ret_type')
+		$if method.ReturnType is int {
+			println('$method.name returns int')
+		}
+		/*
+		$if method.args[0].Type is int {
+			println('${method.name}\'s first arg is int')
+		}
+		$if method.Type is VoidFn {
+			println('$method.name is a void method')
+		}
+		*/
+		println('')
 	}
-	println('All integer functions')
-	$for method in App.methods {
-		println('Method: $method.name')
-		println('Attributes: $method.attrs')
-	}
+	println('\n\nAll fields')
 	$for field in App.fields {
-		$if field.@type is string {
-			println(field)
+		$if field.Type is string {
+			println('Field `$field.name` is string')
 		}
 	}
 }
@@ -42,4 +52,8 @@ fn (mut app App) method_three() int {
 
 fn (mut app App) method_four() int {
 	return 1
+}
+
+fn (mut app App) method_five(s string) string {
+	return s
 }

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -291,26 +291,25 @@ fn __print_assert_failure(i &VAssertMetaInfo) {
 	}
 }
 
-pub struct MethodAttr {
+pub struct MethodArgs {
 pub:
-	value string
-	method string
+	Type int
 }
 
 pub struct FunctionData {
 pub:
-	name string
-	attrs []string
-	ret_type string
-	@type int
+	name       string
+	attrs      []string
+	args       []MethodArgs
+	ReturnType int
+	Type       int
 }
 
 pub struct FieldData {
 pub:
-	name string
-	attrs []string
-	typ string
+	name   string
+	attrs  []string
 	is_pub bool
 	is_mut bool
-	@type int
+	Type   int
 }

--- a/vlib/v/gen/comptime.v
+++ b/vlib/v/gen/comptime.v
@@ -109,7 +109,7 @@ fn (mut g Gen) comp_if(mut it ast.CompIf) {
 		mut comptime_var_type := table.Type(0)
 		if it.tchk_expr is ast.SelectorExpr {
 			se := it.tchk_expr as ast.SelectorExpr
-			x := se.expr.str()
+			x := '${se.expr}.$se.field_name'
 			comptime_var_type = g.comptime_var_type_map[x]
 		}
 		if comptime_var_type == 0 {
@@ -117,22 +117,24 @@ fn (mut g Gen) comp_if(mut it ast.CompIf) {
 				eprintln('Known compile time types: ')
 				eprintln(g.comptime_var_type_map.str())
 			}
-			verror('the compile time type of `$it.tchk_expr.str()` is unknown')
-		}
-		ret_type_name := g.table.get_type_symbol(comptime_var_type).name
-		it_type_name := g.table.get_type_symbol(it.tchk_type).name
-		types_match := comptime_var_type == it.tchk_type
-		g.writeln('{ // \$if $it.val is $it_type_name, typecheck start, $comptime_var_type == $it.tchk_type => $ret_type_name == $it_type_name => $types_match ')
-		mut stmts := it.stmts
-		if !types_match {
-			stmts = []ast.Stmt{}
-			if it.has_else {
-				stmts = it.else_stmts
+			// verror('the compile time type of `$it.tchk_expr.str()` is unknown')
+			return
+		} else {
+			ret_type_name := g.table.get_type_symbol(comptime_var_type).name
+			it_type_name := g.table.get_type_symbol(it.tchk_type).name
+			types_match := comptime_var_type == it.tchk_type
+			g.writeln('{ // \$if $it.val is $it_type_name, typecheck start, $comptime_var_type == $it.tchk_type => $ret_type_name == $it_type_name => $types_match ')
+			mut stmts := it.stmts
+			if !types_match {
+				stmts = []ast.Stmt{}
+				if it.has_else {
+					stmts = it.else_stmts
+				}
 			}
-		}
-		g.stmts(stmts)
-		g.writeln('} // typecheck end')
+			g.stmts(stmts)
+			g.writeln('} // typecheck end')
 		return
+		}
 	}
 	ifdef := g.comp_if_to_ifdef(it.val, it.is_opt)
 	g.empty_line = false
@@ -192,12 +194,27 @@ fn (mut g Gen) comp_for(node ast.CompFor) {
 				g.writeln('\t${node.val_var}.attrs = new_array_from_c_array($attrs.len, $attrs.len, sizeof(string), _MOV((string[$attrs.len]){' +
 					attrs.join(', ') + '}));')
 			}
-			method_sym := g.table.get_type_symbol(method.return_type)
-			g.writeln('\t${node.val_var}.ret_type = tos_lit("$method_sym.name");')
-			styp := int(method.return_type).str()
-			g.writeln('\t${node.val_var}.type = $styp;')
+			mut sig := 'anon_fn_'
+			// skip the first (receiver) arg
+			for j, arg in method.args[1..] {
+				// TODO: ignore mut/pts in sig for now
+				typ := arg.typ.set_nr_muls(0)
+				sig += '${typ}'
+				if j < method.args.len - 2 { sig += '_' }
+			}
+			sig += '_$method.return_type'
+
+			styp :=	g.table.find_type_idx(sig)
+			println(styp)
+			// if styp == 0 { }
+			// TODO: type aliases
+
+			ret_typ := method.return_type.idx()
+			g.writeln('\t${node.val_var}.Type = $styp;')
+			g.writeln('\t${node.val_var}.ReturnType = $ret_typ;')
 			//
-			g.comptime_var_type_map[node.val_var] = method.return_type
+			g.comptime_var_type_map['${node.val_var}.ReturnType'] = ret_typ
+			g.comptime_var_type_map['${node.val_var}.Type'] = styp
 			g.stmts(node.stmts)
 			i++
 			g.writeln('')
@@ -224,13 +241,13 @@ fn (mut g Gen) comp_for(node ast.CompFor) {
 					g.writeln('\t${node.val_var}.attrs = new_array_from_c_array($attrs.len, $attrs.len, sizeof(string), _MOV((string[$attrs.len]){' +
 						attrs.join(', ') + '}));')
 				}
-				field_sym := g.table.get_type_symbol(field.typ)
-				g.writeln('\t${node.val_var}.typ = tos_lit("$field_sym.name");')
-				styp := int(field.typ).str()
-				g.writeln('\t${node.val_var}.type = $styp;')
+				// field_sym := g.table.get_type_symbol(field.typ)
+				// g.writeln('\t${node.val_var}.typ = tos_lit("$field_sym.name");')
+				styp := field.typ
+				g.writeln('\t${node.val_var}.Type = $styp;')
 				g.writeln('\t${node.val_var}.is_pub = $field.is_pub;')
 				g.writeln('\t${node.val_var}.is_mut = $field.is_mut;')
-				g.comptime_var_type_map[node.val_var] = field.typ
+				g.comptime_var_type_map[node.val_var + '.Type'] = styp
 				g.stmts(node.stmts)
 				i++
 				g.writeln('')

--- a/vlib/v/gen/comptime.v
+++ b/vlib/v/gen/comptime.v
@@ -235,8 +235,12 @@ fn (mut g Gen) comp_for(node ast.CompFor) {
 			g.stmts(node.stmts)
 			i++
 			g.writeln('')
+			for key, _ in g.comptime_var_type_map {
+				if key.starts_with(node.val_var) {
+					g.comptime_var_type_map.delete(key)
+				}
+			}
 		}
-		g.comptime_var_type_map.delete(node.val_var)
 	} else if node.kind == .fields {
 		// TODO add fields
 		if sym.info is table.Struct {

--- a/vlib/v/gen/comptime.v
+++ b/vlib/v/gen/comptime.v
@@ -194,6 +194,22 @@ fn (mut g Gen) comp_for(node ast.CompFor) {
 				g.writeln('\t${node.val_var}.attrs = new_array_from_c_array($attrs.len, $attrs.len, sizeof(string), _MOV((string[$attrs.len]){' +
 					attrs.join(', ') + '}));')
 			}
+			if method.args.len < 2 {
+				// 0 or 1 (the receiver) args
+				g.writeln('\t${node.val_var}.args = __new_array_with_default(0, 0, sizeof(MethodArgs), 0);')
+			} else {
+				len := method.args.len - 1
+				g.write('\t${node.val_var}.args = new_array_from_c_array($len, $len, sizeof(MethodArgs), _MOV((MethodArgs[$len]){')
+				// Skip receiver arg
+				for j, arg in method.args[1..] {
+					typ := arg.typ.idx()
+					g.write(typ.str())
+					if j < len - 1 { g.write(', ') }
+					g.comptime_var_type_map['${node.val_var}.args[$j].Type'] = typ
+				}
+				g.writeln('}));')
+			}
+
 			mut sig := 'anon_fn_'
 			// skip the first (receiver) arg
 			for j, arg in method.args[1..] {

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -193,7 +193,7 @@ fn (mut p Parser) comp_if() ast.Stmt {
 	// return p.vweb()
 	// }
 	p.check(.key_if)
-	is_not := p.tok.kind == .not
+	mut is_not := p.tok.kind == .not
 	if is_not {
 		p.next()
 	}
@@ -288,7 +288,8 @@ fn (mut p Parser) comp_if() ast.Stmt {
 	if p.tok.kind == .question {
 		p.next()
 		is_opt = true
-	} else if p.tok.kind == .key_is {
+	} else if p.tok.kind in [.key_is, .not_is] {
+		if p.tok.kind == .not_is { is_not = !is_not }
 		p.next()
 		tchk_type = p.parse_type()
 		is_typecheck = true

--- a/vlib/v/tests/comptime_for_test.v
+++ b/vlib/v/tests/comptime_for_test.v
@@ -28,11 +28,14 @@ fn (mut app App) int_method2() int {
 	return 1
 }
 
+fn (mut app App) string_arg(x string) {
+}
+
 fn no_lines(s string) string { return s.replace('\n', ' ') }
 
 fn test_comptime_for() {
 	println(@FN)
-	methods := ['run', 'method2', 'int_method1', 'int_method2']
+	methods := ['run', 'method2', 'int_method1', 'int_method2', 'string_arg']
 	$for method in App.methods {
 		println('  method: $method.name | ' + no_lines('$method'))
 		assert method.name in methods
@@ -41,12 +44,16 @@ fn test_comptime_for() {
 
 fn test_comptime_for_with_if() {
 	println(@FN)
-	methods := ['int_method1', 'int_method2']
 	$for method in App.methods {
 		println('  method: ' + no_lines('$method'))
-		$if method.@type is int {
-			println(method.attrs)
-			assert method.name in methods
+		$if method.Type is fn() {
+			assert method.name in ['run', 'method2']
+		}
+		$if method.ReturnType is int {
+			assert method.name in ['int_method1', 'int_method2']
+		}
+		$if method.args[0].Type is string {
+			assert method.name == 'string_arg'
 		}
 	}
 }
@@ -55,10 +62,10 @@ fn test_comptime_for_fields() {
 	println(@FN)
 	$for field in App.fields {
 		println('  field: $field.name | ' + no_lines('$field'))
-		$if field.@type is string {
+		$if field.Type is string {
 			assert field.name in ['a', 'b', 'g']
 		}
-		$if field.@type is f32 {
+		$if field.Type is f32 {
 			assert field.name in ['d', 'e']
 		}
 		if field.is_mut {

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -370,7 +370,7 @@ fn handle_conn<T>(conn net.Socket, mut app T) {
 	mut vars := []string{cap: route_words_a.len}
 	mut action := ''
 	$for method in T.methods {
-		$if method.@type is Result {
+		$if method.ReturnType is Result {
 			attrs := method.attrs
 			route_words_a = [][]string{}
 			if attrs.len == 0 {
@@ -469,7 +469,7 @@ fn handle_conn<T>(conn net.Socket, mut app T) {
 		return
 	}
 	$for method in T.methods {
-		$if method.@type is Result {
+		$if method.ReturnType is Result {
 			// search again for method
 			if action == method.name && method.attrs.len > 0 {
 				// call action method


### PR DESCRIPTION
This PR improves compile time `if`s inside comp. `for`s, with the following features:
- [x] `$if field.Type is string {}`
- [x] `$if method.Type is fn(string) int {}`
- [x] `$if method.ReturnType is int {}`
- [x] `$if method.args[0].Type is string {}`

This differs from the previous implementation in that it:
1. Adds options 2 and 4
1. Renames `field.@type` to `field.Type`
1. Renames `method.@type` to `method.ReturnType`

Things left:
- [ ] Aliases: 
```v
type Callback = fn(string) int
$if method.Type is Callback {}
```
