### PR TITLE
bare: remove example

### DIFF
--- a/vlib/os/bare/bare_example_linux.v
+++ b/vlib/os/bare/bare_example_linux.v
@@ -1,7 +1,0 @@
-fn main() {
-	sys_write(1, 'hello\n'.str, 6)
-	s := 'test string\n'
-	sys_write(1, s.str, u64(s.len))
-	a := s[0]
-	println("Hello freestanding!")
-}


### PR DESCRIPTION
I think that the example of bare is not lot useful, remove it.