### PR TITLE
v/fmt: Fix UnsafeExpr newlines, change to unsafe(expr)

### DIFF
--- a/vlib/builtin/sorted_map.v
+++ b/vlib/builtin/sorted_map.v
@@ -217,16 +217,15 @@ fn (mut n mapnode) remove_key(k string) bool {
 		if isnil(n.children) {
 			return false
 		}
-		flag := if idx == n.len {true} else {false}
+		flag := idx == n.len
 		if unsafe {&mapnode(n.children[idx])}.len < degree {
 			n.fill(idx)
 		}
 
-		mut node := &mapnode(0)
-		if flag && idx > n.len {
-			node = unsafe {&mapnode(n.children[idx - 1])}
+		mut node := if flag && idx > n.len {
+			unsafe(&mapnode(n.children[idx - 1]))
 		} else {
-			node = unsafe {&mapnode(n.children[idx])}
+			unsafe(&mapnode(n.children[idx]))
 		}
 		return node.remove_key(k)
 	}
@@ -250,8 +249,7 @@ fn (mut n mapnode) remove_from_non_leaf(idx int) {
 		predecessor := current.keys[current.len - 1]
 		n.keys[idx] = predecessor
 		n.values[idx] = current.values[current.len - 1]
-		mut node := unsafe {&mapnode(n.children[idx])}
-		node.remove_key(predecessor)
+		unsafe(&mapnode(n.children[idx])).remove_key(predecessor)
 	} else if unsafe {&mapnode(n.children[idx + 1])}.len >= degree {
 		mut current := unsafe {&mapnode(n.children[idx + 1])}
 		for !isnil(current.children) {
@@ -260,12 +258,10 @@ fn (mut n mapnode) remove_from_non_leaf(idx int) {
 		successor := current.keys[0]
 		n.keys[idx] = successor
 		n.values[idx] = current.values[0]
-		mut node := unsafe {&mapnode(n.children[idx + 1])}
-		node.remove_key(successor)
+		unsafe(&mapnode(n.children[idx + 1])).remove_key(successor)
 	} else {
 		n.merge(idx)
-		mut node := unsafe {&mapnode(n.children[idx])}
-		node.remove_key(k)
+		unsafe(&mapnode(n.children[idx])).remove_key(k)
 	}
 }
 

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1059,9 +1059,12 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 			f.write(')')
 		}
 		ast.UnsafeExpr {
-			f.writeln('unsafe {')
-			f.stmts(node.stmts)
-			f.writeln('}')
+			// rewrite to unsafe(expr)
+			f.write('unsafe(')
+			assert node.stmts.len == 1
+			es := node.stmts[0] as ast.ExprStmt
+			f.expr(es.expr)
+			f.write(')')
 		}
 	}
 }

--- a/vlib/v/tests/ptr_arithmetic_test.v
+++ b/vlib/v/tests/ptr_arithmetic_test.v
@@ -1,24 +1,20 @@
-fn test_ptr_arithmetic(){
+fn test_ptr_arithmetic() {
+	mut v := 4
+	mut p := &v
 	unsafe {
-		// Do NOT move this outside unsafe{}.
-		// It causes too much churn in CI when new checks are implemented.
-		// If you want to implement a specific failing test, do so inside
-		// vlib/v/checker/tests/ , NOT here.
-		v := 4
-		mut p := &v
 		p++
 		p += 2
-		p = p - 1
-		assert p == &v + 2
-		p = p + 1
-		assert p == &v + 3
-		r := p++
-		assert r == &v + 3
-		assert p == &v + 4
 	}
+	p = unsafe(p - 1)
+	assert p == unsafe(&v + 2)
+	p = unsafe(p + 1)
+	assert p == unsafe(&v + 3)
+	r := unsafe(p++)
+	assert r == unsafe(&v + 3)
+	assert p == unsafe(&v + 4)
 }
 
-fn test_ptr_arithmetic_over_byteptr() {	
+fn test_ptr_arithmetic_over_byteptr() {
 	// byteptr, voidptr, charptr are handled differently
 	mut q := byteptr(10)
 	unsafe {
@@ -26,6 +22,6 @@ fn test_ptr_arithmetic_over_byteptr() {
 		q = q + 1
 	}
 	assert q == byteptr(9)
-	s := unsafe { q - 1 }
+	s := unsafe(q - 1)
 	assert s == byteptr(8)
 }

--- a/vlib/v/tests/shared_array_test.v
+++ b/vlib/v/tests/shared_array_test.v
@@ -29,10 +29,7 @@ fn test_shared_array() {
 	mut finished_threads := 0
 	for {
 		rlock foo {
-			finished_threads = unsafe {
-				foo[2]
-			}
-
+			finished_threads = unsafe(foo[2])
 		}
 		if finished_threads == 4 {
 			break
@@ -40,14 +37,8 @@ fn test_shared_array() {
 		time.sleep_ms(100)
 	}
 	rlock foo {
-		f0 := unsafe {
-			foo[0]
-		}
-
-		f1 := unsafe {
-			foo[1]
-		}
-
+		f0 := unsafe(foo[0])
+		f1 := unsafe(foo[1])
 		assert f0 == 100010
 		assert f1 == 350020
 	}


### PR DESCRIPTION
This follows on from #5973.
`unsafe {expr}` i.e. UnsafeExpr is superceded by `unsafe(expr)`, partly because that isn't confused with UnsafeStmt (`unsafe {stmts}`, see link).

vfmt wrongly formatted UnsafeExpr with newlines (my fault), so this fixes that and uses unsafe(expr) too as UnsafeExpr should be removed. Note that `unsafe(expr)` parses as a ParExpr (so it works everywhere that does).

This also restores some code in builtin/sorted_map.v now that we can call methods on an unsafe expression and use an unsafe expression as the result of an IfExpr.
