### PR TITLE
v/ast: Fix ParExpr.str(), RangeExpr.str(), SizeOf.str()

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -215,13 +215,22 @@ pub fn (x Expr) str() string {
 			return '${it.left.str()} $it.op.str() ${it.right.str()}'
 		}
 		ParExpr {
-			return it.expr.str()
+			return '($it.expr)'
 		}
 		PrefixExpr {
 			return it.op.str() + it.right.str()
 		}
+		RangeExpr {
+			mut s := '..'
+			if it.has_low {s = '$it.low ' + s}
+			if it.has_high {s = s + ' $it.high'}
+			return s
+		}
 		SelectorExpr {
 			return '${it.expr.str()}.${it.field_name}'
+		}
+		SizeOf {
+			return 'sizeof($it.expr)'
 		}
 		StringInterLiteral {
 			mut res := []string{}
@@ -257,10 +266,9 @@ pub fn (x Expr) str() string {
 		UnsafeExpr {
 			return 'unsafe { $it.stmts.len stmts }'
 		}
-		else {
-			return '[unhandled expr type ${typeof(x)}]'
-		}
+		else {}
 	}
+	return '[unhandled expr type ${typeof(x)}]'
 }
 
 pub fn (a CallArg) str() string {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -903,7 +903,7 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 		ast.OrExpr {
 			// shouldn't happen, an or expression
 			// is always linked to a call expr
-			panic('fmt: OrExpr should to linked to CallExpr')
+			panic('fmt: OrExpr should be linked to CallExpr')
 		}
 		ast.ParExpr {
 			f.write('(')


### PR DESCRIPTION
Also:
Return 'unhandled' string if missing `return` in match branch.
~~v/fmt: Fix `RangeExpr`~~

~~fmt test not done yet.~~ Not sure if there are any tests for Expr.str()?

