### PR TITLE
Docs for looping over map items

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -727,6 +727,21 @@ for key, value in m {
 }                              //         two -> 2
 ```
 
+Either key or value can be ignored by using a single underscore as the identifer.
+```v
+mut m := {'one':1, 'two':2}
+
+// iterate over keys
+for key, _ in m {
+    println(key)  // Output: one
+}                 //         two
+
+// iterate over values
+for _, value in m {
+    println(value)  // Output: 1
+}                   //         2
+```
+
 #### Range `for`
 
 ```v

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -721,7 +721,7 @@ When an identifier is just a single underscore, it is ignored.
 #### Map `for`
 
 ```v
-mut m := {'one':1, 'two':2}
+m := {'one':1, 'two':2}
 for key, value in m {
     println("$key -> $value")  // Output: one -> 1
 }                              //         two -> 2
@@ -729,7 +729,7 @@ for key, value in m {
 
 Either key or value can be ignored by using a single underscore as the identifer.
 ```v
-mut m := {'one':1, 'two':2}
+m := {'one':1, 'two':2}
 
 // iterate over keys
 for key, _ in m {

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -723,7 +723,7 @@ When an identifier is just a single underscore, it is ignored.
 ```v
 mut m := {'one':1, 'two':2}
 for key, value in m {
-	println("$key -> $value")  // Output: one -> 1
+    println("$key -> $value")  // Output: one -> 1
 }                              //         two -> 2
 ```
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -718,6 +718,15 @@ println(numbers) // [1, 2, 3]
 ```
 When an identifier is just a single underscore, it is ignored.
 
+#### Map `for`
+
+```v
+mut m := {'one':1, 'two':2}
+for key, value in m {
+	println("$key -> $value")  // Output: one -> 1
+}                              //         two -> 2
+```
+
 #### Range `for`
 
 ```v


### PR DESCRIPTION
There was no information in the docs about the ability to iterate over map items (key,value pairs).

I've added a simple example:
```v
mut m := {'one':1, 'two':2}
for key, value in m {
    println("$key -> $value")  // Output: one -> 1
}                              //         two -> 2
```

