### PR TITLE
compiler: move attributes to declarations

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -15,7 +15,7 @@ pub type Expr = AnonFn | ArrayInit | AsCast | Assoc | BoolLiteral | CallExpr | C
 	None | OrExpr | ParExpr | PostfixExpr | PrefixExpr | RangeExpr | SelectorExpr | SizeOf |
 	SqlExpr | StringInterLiteral | StringLiteral | StructInit | Type | TypeOf | UnsafeExpr
 
-pub type Stmt = AssertStmt | AssignStmt | Attr | Block | BranchStmt | CompFor | CompIf |
+pub type Stmt = AssertStmt | AssignStmt | Block | BranchStmt | CompFor | CompIf |
 	ConstDecl | DeferStmt | EnumDecl | ExprStmt | FnDecl | ForCStmt | ForInStmt | ForStmt |
 	GlobalDecl | GoStmt | GotoLabel | GotoStmt | HashStmt | Import | InterfaceDecl | Module |
 	Return | SqlStmt | StructDecl | TypeDecl
@@ -129,7 +129,7 @@ pub:
 	comments         []Comment
 	default_expr     Expr
 	has_default_expr bool
-	attrs            []string
+	attrs            []table.Attr
 	is_public        bool
 pub mut:
 	typ              table.Type
@@ -174,7 +174,7 @@ pub:
 	pub_mut_pos  int // pub mut:
 	language     table.Language
 	is_union     bool
-	attrs        []string
+	attrs        []table.Attr
 	end_comments []Comment
 }
 
@@ -253,11 +253,11 @@ pub:
 	language      table.Language
 	no_body       bool // just a definition `fn C.malloc()`
 	is_builtin    bool // this function is defined in builtin/strconv
-	ctdefine      string // has [if myflag] tag
 	pos           token.Position
 	body_pos      token.Position
 	file          string
 	is_generic    bool
+	attrs         []table.Attr
 pub mut:
 	stmts         []Stmt
 	return_type   table.Type
@@ -641,21 +641,6 @@ pub mut:
 	expr_type table.Type
 }
 
-// e.g. `[unsafe_fn]`
-pub struct Attr {
-pub:
-	name      string
-	is_string bool // `['xxx']`
-}
-
-pub fn (attrs []Attr) contains(attr Attr) bool {
-	for a in attrs {
-		if attr.name == a.name {
-			return true
-		}
-	}
-	return false
-}
 
 pub struct EnumVal {
 pub:

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -15,10 +15,10 @@ pub type Expr = AnonFn | ArrayInit | AsCast | Assoc | BoolLiteral | CallExpr | C
 	None | OrExpr | ParExpr | PostfixExpr | PrefixExpr | RangeExpr | SelectorExpr | SizeOf |
 	SqlExpr | StringInterLiteral | StringLiteral | StructInit | Type | TypeOf | UnsafeExpr
 
-pub type Stmt = AssertStmt | AssignStmt | Block | BranchStmt | CompFor | CompIf |
-	ConstDecl | DeferStmt | EnumDecl | ExprStmt | FnDecl | ForCStmt | ForInStmt | ForStmt |
-	GlobalDecl | GoStmt | GotoLabel | GotoStmt | HashStmt | Import | InterfaceDecl | Module |
-	Return | SqlStmt | StructDecl | TypeDecl
+pub type Stmt = AssertStmt | AssignStmt | Block | BranchStmt | CompFor | CompIf | ConstDecl |
+	DeferStmt | EnumDecl | ExprStmt | FnDecl | ForCStmt | ForInStmt | ForStmt | GlobalDecl |
+	GoStmt | GotoLabel | GotoStmt | HashStmt | Import | InterfaceDecl | Module | Return |
+	SqlStmt | StructDecl | TypeDecl
 
 pub type ScopeObject = ConstField | GlobalDecl | Var
 
@@ -36,7 +36,7 @@ pub:
 // `{stmts}` or `unsafe {stmts}`
 pub struct Block {
 pub:
-	stmts []Stmt
+	stmts     []Stmt
 	is_unsafe bool
 }
 
@@ -224,9 +224,9 @@ pub enum ImportSymbolKind {
 
 pub struct ImportSymbol {
 pub:
-	pos    token.Position
-	name   string
-	kind   ImportSymbolKind
+	pos  token.Position
+	name string
+	kind ImportSymbolKind
 }
 
 pub struct AnonFn {
@@ -537,6 +537,7 @@ pub enum CompIfKind {
 	platform
 	typecheck
 }
+
 pub struct CompIf {
 pub:
 	val        string
@@ -640,7 +641,6 @@ pub:
 pub mut:
 	expr_type table.Type
 }
-
 
 pub struct EnumVal {
 pub:

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -199,7 +199,7 @@ fn (mut c Checker) check_file_in_main(file ast.File) bool {
 				if stmt.return_type != table.void_type {
 					for attr in stmt.attrs {
 						if attr.is_ctdefine {
-							c.error('only functions that do NOT return values can have `[if ${attr.name}]` tags',
+							c.error('only functions that do NOT return values can have `[if $attr.name]` tags',
 								stmt.pos)
 							break
 						}
@@ -3301,7 +3301,8 @@ fn (mut c Checker) sql_stmt(mut node ast.SqlStmt) table.Type {
 }
 
 fn (mut c Checker) fetch_and_verify_orm_fields(info table.Struct, pos token.Position, table_name string) []table.Field {
-	fields := info.fields.filter(it.typ in [table.string_type, table.int_type, table.bool_type] && !it.attrs.contains('skip'))
+	fields := info.fields.filter(it.typ in
+		[table.string_type, table.int_type, table.bool_type] && !it.attrs.contains('skip'))
 	if fields.len == 0 {
 		c.error('V orm: select: empty fields in `$table_name`', pos)
 	}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -286,13 +286,6 @@ pub fn (mut f Fmt) stmt(node ast.Stmt) {
 			f.expr(node.expr)
 			f.writeln('')
 		}
-		ast.Attr {
-			if node.is_string {
-				f.writeln("['$node.name']")
-			} else {
-				f.writeln('[$node.name]')
-			}
-		}
 		ast.Block {
 			if node.is_unsafe {
 				f.write('unsafe ')
@@ -589,6 +582,7 @@ pub fn (mut f Fmt) type_decl(node ast.TypeDecl) {
 }
 
 pub fn (mut f Fmt) struct_decl(node ast.StructDecl) {
+	f.attrs(node.attrs)
 	if node.is_pub {
 		f.write('pub ')
 	}
@@ -626,9 +620,7 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl) {
 			f.write('\t$field.name ')
 			f.write(strings.repeat(` `, max - field.name.len))
 			f.write(f.type_to_str(field.typ))
-			if field.attrs.len > 0 {
-				f.write(' [' + field.attrs.join(';') + ']')
-			}
+			f.inline_attrs(field.attrs)
 			if field.has_default_expr {
 				f.write(' = ')
 				f.prefix_expr_cast_expr(field.default_expr)
@@ -659,9 +651,7 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl) {
 		}
 		f.write(strings.repeat(` `, max - field.name.len - comments_len))
 		f.write(f.type_to_str(field.typ))
-		if field.attrs.len > 0 {
-			f.write(' [' + field.attrs.join(';') + ']')
-		}
+		f.inline_attrs(field.attrs)
 		if field.has_default_expr {
 			f.write(' = ')
 			f.prefix_expr_cast_expr(field.default_expr)
@@ -1118,6 +1108,37 @@ pub fn (mut f Fmt) or_expr(or_block ast.OrExpr) {
 	}
 }
 
+fn (mut f Fmt) attrs(attrs []table.Attr) {
+	for attr in attrs {
+		f.write('[')
+		if attr.is_ctdefine {
+			f.write('if ')
+		}
+		if attr.is_string {
+			f.write("'")
+		}
+		f.write(attr.name)
+		if attr.is_string {
+			f.write("'")
+		}
+		f.writeln(']')
+	}
+}
+
+fn (mut f Fmt) inline_attrs(attrs []table.Attr) {
+	if attrs.len == 0 {
+		return
+	}
+	f.write(' [')
+	for i, attr in attrs {
+		if i > 0 {
+			f.write(';')
+		}
+		f.write(attr.name)
+	}
+	f.write(']')
+}
+
 enum CommentsLevel {
 	keep
 	indent
@@ -1176,6 +1197,7 @@ pub fn (mut f Fmt) comments(comments []ast.Comment, options CommentsOptions) {
 pub fn (mut f Fmt) fn_decl(node ast.FnDecl) {
 	// println('$it.name find_comment($it.pos.line_nr)')
 	// f.find_comment(it.pos.line_nr)
+	f.attrs(node.attrs)
 	f.write(node.stringify(f.table, f.cur_mod)) // `Expr` instead of `ast.Expr` in mod ast
 	if node.language == .v {
 		f.writeln(' {')

--- a/vlib/v/fmt/tests/attrs_keep.vv
+++ b/vlib/v/fmt/tests/attrs_keep.vv
@@ -1,0 +1,5 @@
+[inline]
+[if debug]
+fn keep_attributes() {
+	println('hi !')
+}

--- a/vlib/v/gen/comptime.v
+++ b/vlib/v/gen/comptime.v
@@ -177,7 +177,7 @@ fn (mut g Gen) comp_for(node ast.CompFor) {
 			} else {
 				mut attrs := []string{}
 				for attrib in method.attrs {
-					attrs << 'tos_lit("$attrib")'
+					attrs << 'tos_lit("$attrib.name")'
 				}
 				g.writeln('\t${node.val_var}.attrs = new_array_from_c_array($attrs.len, $attrs.len, sizeof(string), _MOV((string[$attrs.len]){' +
 					attrs.join(', ') + '}));')
@@ -212,7 +212,7 @@ fn (mut g Gen) comp_for(node ast.CompFor) {
 				} else {
 					mut attrs := []string{}
 					for attrib in field.attrs {
-						attrs << 'tos_lit("$attrib")'
+						attrs << 'tos_lit("$attrib.name")'
 					}
 					g.writeln('\t${node.val_var}.attrs = new_array_from_c_array($attrs.len, $attrs.len, sizeof(string), _MOV((string[$attrs.len]){' +
 						attrs.join(', ') + '}));')

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -11,6 +11,9 @@ pub fn kek_cheburek() {
 }
 
 fn (mut g Gen) gen_fn_decl(it ast.FnDecl, skip bool) {
+	// TODO For some reason, build fails with autofree with this line
+	// as it's only informative, comment it for now
+	// g.gen_attrs(it.attrs)
 	if it.language == .c {
 		// || it.no_body {
 		return
@@ -33,9 +36,9 @@ fn (mut g Gen) gen_fn_decl(it ast.FnDecl, skip bool) {
 	}
 	// g.cur_fn = it
 	fn_start_pos := g.out.len
-	msvc_attrs := g.write_fn_attrs()
+	msvc_attrs := g.write_fn_attrs(it.attrs)
 	// Live
-	is_livefn := 'live' in g.attrs
+	is_livefn := it.attrs.contains('live')
 	is_livemain := g.pref.is_livemain && is_livefn
 	is_liveshared := g.pref.is_liveshared && is_livefn
 	is_livemode := g.pref.is_livemain || g.pref.is_liveshared
@@ -142,7 +145,7 @@ fn (mut g Gen) gen_fn_decl(it ast.FnDecl, skip bool) {
 	}
 	// Profiling mode? Start counting at the beginning of the function (save current time).
 	if g.pref.is_prof {
-		g.profile_fn(it.name)
+		g.profile_fn(it)
 	}
 	g.stmts(it.stmts)
 	//
@@ -699,10 +702,10 @@ fn (g &Gen) fileis(s string) bool {
 	return g.file.path.contains(s)
 }
 
-fn (mut g Gen) write_fn_attrs() string {
+fn (mut g Gen) write_fn_attrs(attrs []table.Attr) string {
 	mut msvc_attrs := ''
-	for attr in g.attrs {
-		match attr {
+	for attr in attrs {
+		match attr.name {
 			'inline' {
 				g.write('inline ')
 			}

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -425,9 +425,6 @@ fn (mut g JsGen) stmt(node ast.Stmt) {
 		ast.AssignStmt {
 			g.gen_assign_stmt(node)
 		}
-		ast.Attr {
-			g.gen_attr(node)
-		}
 		ast.Block {
 			g.gen_block(node)
 			g.writeln('')
@@ -740,8 +737,10 @@ fn (mut g JsGen) gen_assign_stmt(stmt ast.AssignStmt) {
 	}
 }
 
-fn (mut g JsGen) gen_attr(it ast.Attr) {
-	g.writeln('/* [$it.name] */')
+fn (mut g JsGen) gen_attrs(attrs []table.Attr) {
+	for attr in attrs {
+		g.writeln('/* [$attr.name] */')
+	}
 }
 
 fn (mut g JsGen) gen_block(it ast.Block) {
@@ -830,6 +829,7 @@ fn (mut g JsGen) gen_method_decl(it ast.FnDecl) {
 	g.fn_decl = &it
 	has_go := fn_has_go(it)
 	is_main := it.name == 'main.main'
+	g.gen_attrs(it.attrs)
 	if is_main {
 		// there is no concept of main in JS but we do have iife
 		g.writeln('/* program entry point */')
@@ -1043,6 +1043,7 @@ fn (mut g JsGen) gen_hash_stmt(it ast.HashStmt) {
 
 fn (mut g JsGen) gen_struct_decl(node ast.StructDecl) {
 	if node.name.starts_with('JS.') { return }
+	g.gen_attrs(node.attrs)
 	g.doc.gen_fac_fn(node.fields)
 	g.write('function ${g.js_name(node.name)}({ ')
 	for i, field in node.fields {

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -10,11 +10,13 @@ import v.depgraph
 const (
 	// https://ecma-international.org/ecma-262/#sec-reserved-words
 	js_reserved = ['await', 'break', 'case', 'catch', 'class', 'const', 'continue', 'debugger',
-		'default', 'delete', 'do', 'else', 'enum', 'export', 'extends', 'finally', 'for', 'function',
-		'if', 'implements', 'import', 'in', 'instanceof', 'interface', 'let', 'new', 'package', 'private',
-		'protected', 'public', 'return', 'static', 'super', 'switch', 'this', 'throw', 'try', 'typeof',
-		'var', 'void', 'while', 'with', 'yield']
-	tabs = ['', '\t', '\t\t', '\t\t\t', '\t\t\t\t', '\t\t\t\t\t', '\t\t\t\t\t\t', '\t\t\t\t\t\t\t', '\t\t\t\t\t\t\t\t']
+		'default', 'delete', 'do', 'else', 'enum', 'export', 'extends', 'finally', 'for', 'function', 'if',
+		'implements', 'import', 'in', 'instanceof', 'interface', 'let', 'new', 'package', 'private', 'protected',
+		'public', 'return', 'static', 'super', 'switch', 'this', 'throw', 'try', 'typeof', 'var', 'void',
+		'while', 'with', 'yield']
+	tabs        = ['', '\t', '\t\t', '\t\t\t', '\t\t\t\t', '\t\t\t\t\t', '\t\t\t\t\t\t', '\t\t\t\t\t\t\t',
+		'\t\t\t\t\t\t\t\t',
+	]
 )
 
 struct JsGen {
@@ -1042,7 +1044,9 @@ fn (mut g JsGen) gen_hash_stmt(it ast.HashStmt) {
 }
 
 fn (mut g JsGen) gen_struct_decl(node ast.StructDecl) {
-	if node.name.starts_with('JS.') { return }
+	if node.name.starts_with('JS.') {
+		return
+	}
 	g.gen_attrs(node.attrs)
 	g.doc.gen_fac_fn(node.fields)
 	g.write('function ${g.js_name(node.name)}({ ')

--- a/vlib/v/gen/json.v
+++ b/vlib/v/gen/json.v
@@ -78,18 +78,18 @@ $enc_fn_dec {
 		}
 		info := sym.info as table.Struct
 		for field in info.fields {
-			if 'skip' in field.attrs {
+			if field.attrs.contains('skip') {
 				continue
 			}
 			mut name := field.name
 			for attr in field.attrs {
-				if attr.starts_with('json:') {
-					name = attr[5..]
+				if attr.name.starts_with('json:') {
+					name = attr.name[5..]
 					break
 				}
 			}
 			field_type := g.typ(field.typ)
-			if 'raw' in field.attrs {
+			if field.attrs.contains('raw') {
 				dec.writeln(' res . ${c_name(field.name)} = tos2(cJSON_PrintUnformatted(' + 'js_get(root, "$name")));')
 			} else {
 				// Now generate decoders for all field types in this struct

--- a/vlib/v/gen/profile.v
+++ b/vlib/v/gen/profile.v
@@ -1,16 +1,19 @@
 module gen
 
+import v.ast
+
 pub struct ProfileCounterMeta{
 	fn_name string
 	vpc_name string
 	vpc_calls string
 }
 
-fn (mut g Gen) profile_fn(fn_name string){
-	if g.pref.profile_no_inline && 'inline' in g.attrs {
+fn (mut g Gen) profile_fn(fn_decl ast.FnDecl) {
+	if g.pref.profile_no_inline && fn_decl.attrs.contains('inline') {
 		g.defer_profile_code = ''
 		return
 	}
+	fn_name := fn_decl.name
 	if fn_name.starts_with('time.vpc_now') {
 		g.defer_profile_code = ''
 	} else {

--- a/vlib/v/gen/profile.v
+++ b/vlib/v/gen/profile.v
@@ -2,9 +2,9 @@ module gen
 
 import v.ast
 
-pub struct ProfileCounterMeta{
-	fn_name string
-	vpc_name string
+pub struct ProfileCounterMeta {
+	fn_name   string
+	vpc_name  string
 	vpc_calls string
 }
 
@@ -18,14 +18,18 @@ fn (mut g Gen) profile_fn(fn_decl ast.FnDecl) {
 		g.defer_profile_code = ''
 	} else {
 		measure_fn_name := if g.pref.os == .mac { 'time__vpc_now_darwin' } else { 'time__vpc_now' }
-		fn_profile_counter_name := 'vpc_${g.last_fn_c_name}'
+		fn_profile_counter_name := 'vpc_$g.last_fn_c_name'
 		fn_profile_counter_name_calls := '${fn_profile_counter_name}_calls'
 		g.writeln('')
-		g.writeln('\tdouble _PROF_FN_START = ${measure_fn_name}(); ${fn_profile_counter_name_calls}++; // $fn_name')
+		g.writeln('\tdouble _PROF_FN_START = ${measure_fn_name}(); $fn_profile_counter_name_calls++; // $fn_name')
 		g.writeln('')
-		g.defer_profile_code = '\t${fn_profile_counter_name} += ${measure_fn_name}() - _PROF_FN_START;'
-		g.pcs_declarations.writeln('double ${fn_profile_counter_name} = 0.0; u64 ${fn_profile_counter_name_calls} = 0;')
-		g.pcs << ProfileCounterMeta{ g.last_fn_c_name, fn_profile_counter_name, fn_profile_counter_name_calls }
+		g.defer_profile_code = '\t$fn_profile_counter_name += ${measure_fn_name}() - _PROF_FN_START;'
+		g.pcs_declarations.writeln('double $fn_profile_counter_name = 0.0; u64 $fn_profile_counter_name_calls = 0;')
+		g.pcs << ProfileCounterMeta{
+			fn_name: g.last_fn_c_name
+			vpc_name: fn_profile_counter_name
+			vpc_calls: fn_profile_counter_name_calls
+		}
 	}
 }
 
@@ -34,13 +38,13 @@ pub fn (mut g Gen) gen_vprint_profile_stats() {
 	fstring := '"%14lu %14.3fms %14.0fns %s \\n"'
 	if g.pref.profile_file == '-' {
 		for pc_meta in g.pcs {
-			g.pcs_declarations.writeln('\tif (${pc_meta.vpc_calls}) printf($fstring, ${pc_meta.vpc_calls}, ${pc_meta.vpc_name}/1000000.0, ${pc_meta.vpc_name}/${pc_meta.vpc_calls}, "${pc_meta.fn_name}" );')
+			g.pcs_declarations.writeln('\tif ($pc_meta.vpc_calls) printf($fstring, $pc_meta.vpc_calls, $pc_meta.vpc_name/1000000.0, $pc_meta.vpc_name/$pc_meta.vpc_calls, "$pc_meta.fn_name" );')
 		}
 	} else {
 		g.pcs_declarations.writeln('\tFILE * fp;')
-		g.pcs_declarations.writeln('\tfp = fopen ("${g.pref.profile_file}", "w+");')
+		g.pcs_declarations.writeln('\tfp = fopen ("$g.pref.profile_file", "w+");')
 		for pc_meta in g.pcs {
-			g.pcs_declarations.writeln('\tif (${pc_meta.vpc_calls}) fprintf(fp, $fstring, ${pc_meta.vpc_calls}, ${pc_meta.vpc_name}/1000000.0, ${pc_meta.vpc_name}/${pc_meta.vpc_calls}, "${pc_meta.fn_name}" );')
+			g.pcs_declarations.writeln('\tif ($pc_meta.vpc_calls) fprintf(fp, $fstring, $pc_meta.vpc_calls, $pc_meta.vpc_name/1000000.0, $pc_meta.vpc_name/$pc_meta.vpc_calls, "$pc_meta.fn_name" );')
 		}
 		g.pcs_declarations.writeln('\tfclose(fp);')
 	}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -244,8 +244,8 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	mut end_pos := p.prev_tok.position()
 	// Return type
 	mut return_type := table.void_type
-	if p.tok.kind.is_start_of_type() || (p.tok.kind == .key_fn &&
-		p.tok.line_nr == p.prev_tok.line_nr) {
+	if p.tok.kind.is_start_of_type() ||
+		(p.tok.kind == .key_fn && p.tok.line_nr == p.prev_tok.line_nr) {
 		end_pos = p.tok.position()
 		return_type = p.parse_type()
 	}
@@ -392,8 +392,7 @@ fn (mut p Parser) fn_args() ([]table.Arg, bool, bool) {
 	// `int, int, string` (no names, just types)
 	argname := if p.tok.kind == .name && p.tok.lit.len > 0 && p.tok.lit[0].is_capital() { p.prepend_mod(p.tok.lit) } else { p.tok.lit }
 	types_only := p.tok.kind in [.amp, .ellipsis, .key_fn] ||
-		(p.peek_tok.kind == .comma && p.table.known_type(argname)) ||
-		p.peek_tok.kind == .rpar
+		(p.peek_tok.kind == .comma && p.table.known_type(argname)) || p.peek_tok.kind == .rpar
 	// TODO copy pasta, merge 2 branches
 	if types_only {
 		// p.warn('types only')

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -131,8 +131,8 @@ pub fn (mut p Parser) call_args() []ast.CallArg {
 fn (mut p Parser) fn_decl() ast.FnDecl {
 	p.top_level_statement_start()
 	start_pos := p.tok.position()
-	is_deprecated := 'deprecated' in p.attrs
-	mut is_unsafe := 'unsafe_fn' in p.attrs
+	is_deprecated := p.attrs.contains('deprecated')
+	mut is_unsafe := p.attrs.contains('unsafe_fn')
 	is_pub := p.tok.kind == .key_pub
 	if is_pub {
 		p.next()
@@ -141,7 +141,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	p.open_scope()
 	// C. || JS.
 	language := if p.tok.kind == .name && p.tok.lit == 'C' {
-		is_unsafe = !('trusted_fn' in p.attrs)
+		is_unsafe = !p.attrs.contains('trusted_fn')
 		table.Language.c
 	} else if p.tok.kind == .name && p.tok.lit == 'JS' {
 		table.Language.js
@@ -249,7 +249,6 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		end_pos = p.tok.position()
 		return_type = p.parse_type()
 	}
-	ctdefine := p.attr_ctdefine
 	// Register
 	if is_method {
 		mut type_sym := p.table.get_type_symbol(rec_type)
@@ -263,7 +262,6 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 			is_pub: is_pub
 			is_deprecated: is_deprecated
 			is_unsafe: is_unsafe
-			ctdefine: ctdefine
 			mod: p.mod
 			attrs: p.attrs
 		})
@@ -288,8 +286,8 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 			is_pub: is_pub
 			is_deprecated: is_deprecated
 			is_unsafe: is_unsafe
-			ctdefine: ctdefine
 			mod: p.mod
+			attrs: p.attrs
 			language: language
 		})
 	}
@@ -328,7 +326,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		body_pos: body_start_pos
 		file: p.file_name
 		is_builtin: p.builtin_mod || p.mod in util.builtin_module_parts
-		ctdefine: ctdefine
+		attrs: p.attrs
 	}
 }
 

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -693,7 +693,8 @@ fn (mut p Parser) attributes() {
 		}
 		if attr.is_ctdefine {
 			if has_ctdefine {
-				p.error_with_pos('only one `[if flag]` may be applied at a time `$attr.name`', start_pos.extend(p.prev_tok.position()))
+				p.error_with_pos('only one `[if flag]` may be applied at a time `$attr.name`',
+					start_pos.extend(p.prev_tok.position()))
 			} else {
 				has_ctdefine = true
 			}

--- a/vlib/v/table/attr.v
+++ b/vlib/v/table/attr.v
@@ -19,4 +19,3 @@ pub fn (attrs []Attr) contains(str string) bool {
 	}
 	return false
 }
-

--- a/vlib/v/table/attr.v
+++ b/vlib/v/table/attr.v
@@ -1,0 +1,22 @@
+// Copyright (c) 2019-2020 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module table
+
+// e.g. `[unsafe_fn]`
+pub struct Attr {
+pub:
+	name        string
+	is_string   bool // `['xxx']`
+	is_ctdefine bool // `[if flag]`
+}
+
+pub fn (attrs []Attr) contains(str string) bool {
+	for a in attrs {
+		if a.name == str {
+			return true
+		}
+	}
+	return false
+}
+

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -687,7 +687,7 @@ pub mut:
 	default_expr     FExpr
 	has_default_expr bool
 	default_val      string
-	attrs            []string
+	attrs            []Attr
 	is_pub           bool
 	is_mut           bool
 	is_global        bool

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -527,7 +527,6 @@ pub fn (table &Table) sumtype_has_variant(parent, variant Type) bool {
 		}
 	}
 	return false
-
 }
 
 pub fn (table &Table) known_type_names() []string {

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -33,7 +33,7 @@ pub:
 	is_placeholder bool
 	mod            string
 	ctdefine       string // compile time define. myflag, when [if myflag] tag
-	attrs          []string
+	attrs          []Attr
 pub mut:
 	name           string
 }


### PR DESCRIPTION
Move attributes to FnDecl and StructDecl.
Stores the Attr struct, not just its name.
Move ast.Attr to table.Attr, as its now used by the table. There most likely is a way to remove the attributes completely from the ast, and only use the one on the table, I'll take a look at that later.
Add an error if there is more than one `[if flag]` attribute by function.

As a side effect : fixes #5985

Edit: This is more a proposal than something I expect to be merged without a second thought. I already discussed it a bit on Discord with some people, but nothing really conclusive.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
