### PR TITLE
v/parser: Support parsing unsafe (as first token) as UnsafeExpr

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2075,7 +2075,7 @@ To mark potentially memory-unsafe operations, enclose them in an `unsafe` block:
 mut p := unsafe { &byte(malloc(2)) }
 p[0] = `h` // Error: pointer indexing is only allowed in `unsafe` blocks
 unsafe {
-    p[0] = `h`
+    p[0] = `h` // OK
     p[1] = `i`
 }
 p++ // Error: pointer arithmetic is only allowed in `unsafe` blocks

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -491,7 +491,7 @@ pub mut:
 
 pub struct UnsafeExpr {
 pub:
-	stmts []Stmt
+	expr  Expr
 	pos   token.Position
 }
 
@@ -1080,6 +1080,15 @@ pub fn (expr Expr) is_lvalue() bool {
 		else {}
 	}
 	return false
+}
+
+pub fn (expr Expr) is_expr() bool {
+	match expr {
+		IfExpr {return expr.is_expr}
+		MatchExpr {return expr.is_expr}
+		else {}
+	}
+	return true
 }
 
 pub fn (stmt Stmt) position() token.Position {

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -264,7 +264,7 @@ pub fn (x Expr) str() string {
 			return '_likely_(${it.expr.str()})'
 		}
 		UnsafeExpr {
-			return 'unsafe { $it.stmts.len stmts }'
+			return 'unsafe { $it.expr }'
 		}
 		else {}
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3101,30 +3101,11 @@ pub fn (mut c Checker) lock_expr(mut node ast.LockExpr) table.Type {
 }
 
 pub fn (mut c Checker) unsafe_expr(mut node ast.UnsafeExpr) table.Type {
-	slen := node.stmts.len
-	if slen > 1 {
-		c.error('FIXME: unsafe expression block should support multiple statements', node.pos)
-		return table.none_type
-	}
-	if slen == 0 {
-		c.error('unsafe expression does not yield an expression', node.pos)
-		return table.none_type
-	}
 	assert !c.inside_unsafe
 	c.inside_unsafe = true
-	defer {
-		c.inside_unsafe = false
-	}
-	if slen > 1 {
-		c.stmts(node.stmts[0..slen - 1])
-	}
-	last := node.stmts[0]
-	if last is ast.ExprStmt {
-		t := c.expr(last.expr)
-		return t
-	}
-	c.error('unsafe expression does not yield an expression', node.pos)
-	return table.none_type
+	t := c.expr(node.expr)
+	c.inside_unsafe = false
+	return t
 }
 
 pub fn (mut c Checker) if_expr(mut node ast.IfExpr) table.Type {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1075,8 +1075,7 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 		}
 		ast.UnsafeExpr {
 			f.write('unsafe {')
-			es := node.stmts[0] as ast.ExprStmt
-			f.expr(es.expr)
+			f.expr(node.expr)
 			f.write('}')
 		}
 	}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2224,8 +2224,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 			g.write(')')
 		}
 		ast.UnsafeExpr {
-			es := node.stmts[0] as ast.ExprStmt
-			g.expr(es.expr)
+			g.expr(node.expr)
 		}
 	}
 }

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -655,8 +655,7 @@ fn (mut g JsGen) expr(node ast.Expr) {
 			// TODO
 		}
 		ast.UnsafeExpr {
-			es := node.stmts[0] as ast.ExprStmt
-			g.expr(es.expr)
+			g.expr(node.expr)
 		}
 	}
 }

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1995,7 +1995,7 @@ fn (mut p Parser) unsafe_stmt() ast.Stmt {
 				}
 				// parse e.g. `unsafe {expr}.foo()`
 				expr := p.expr_with_left(ue, 0, p.is_stmt_ident)
-				return ast.ExprStmt {
+				return ast.ExprStmt{
 					expr: expr
 					pos: pos
 				}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -623,27 +623,7 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 			}
 		}
 		.key_unsafe {
-			if p.peek_tok.kind == .lcbr {
-				// unsafe {
-				p.next()
-				assert !p.inside_unsafe
-				p.inside_unsafe = true
-				stmts := p.parse_block()
-				p.inside_unsafe = false
-				return ast.Block{
-					stmts: stmts
-					is_unsafe: true
-				}
-			} else {
-				p.error_with_pos('please use `unsafe {`', p.tok.position())
-			}
-			// unsafe( ; NB: this will be never reached
-			pos := p.tok.position()
-			ex := p.expr(0)
-			return ast.ExprStmt{
-				expr: ex
-				pos: pos
-			}
+			return p.unsafe_stmt()
 		}
 		.hash {
 			return p.hash()
@@ -1987,4 +1967,49 @@ pub fn (mut p Parser) mark_var_as_used(varname string) bool {
 		}
 	}
 	return false
+}
+
+fn (mut p Parser) unsafe_stmt() ast.Stmt {
+	pos := p.tok.position()
+	p.next()
+	if p.tok.kind != .lcbr {
+		p.error_with_pos('please use `unsafe {`', p.tok.position())
+	}
+	p.next()
+	assert !p.inside_unsafe
+	p.inside_unsafe = true
+	p.open_scope() // needed in case of `unsafe {stmt}`
+	defer {
+		p.inside_unsafe = false
+		p.close_scope()
+	}
+	stmt := p.stmt(false)
+	if p.tok.kind == .rcbr {
+		if stmt is ast.ExprStmt {
+			// `unsafe {expr}`
+			if stmt.expr.is_expr() {
+				p.next()
+				ue := ast.UnsafeExpr{
+					expr: stmt.expr
+					pos: pos
+				}
+				// parse e.g. `unsafe {expr}.foo()`
+				expr := p.expr_with_left(ue, 0, p.is_stmt_ident)
+				return ast.ExprStmt {
+					expr: expr
+					pos: pos
+				}
+			}
+		}
+	}
+	// unsafe {stmts}
+	mut stmts := [stmt]
+	for p.tok.kind != .rcbr {
+		stmts << p.stmt(false)
+	}
+	p.next()
+	return ast.Block{
+		stmts: stmts
+		is_unsafe: true
+	}
 }

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1977,6 +1977,13 @@ fn (mut p Parser) unsafe_stmt() ast.Stmt {
 	}
 	p.next()
 	assert !p.inside_unsafe
+	if p.tok.kind == .rcbr {
+		// `unsafe {}`
+		p.next()
+		return ast.Block{
+			is_unsafe: true
+		}
+	}
 	p.inside_unsafe = true
 	p.open_scope() // needed in case of `unsafe {stmt}`
 	defer {

--- a/vlib/v/tests/unsafe_test.v
+++ b/vlib/v/tests/unsafe_test.v
@@ -3,17 +3,9 @@ fn test_ptr_assign() {
 	mut p := &v[0]
 	unsafe {
 		(*p)++
-	}
-	unsafe {
-		p++
-	} // p now points to v[1]
-	unsafe {
+		p++ // p now points to v[1]
 		(*p) += 2
-	}
-	unsafe {
-		p += 2
-	} // p now points to v[3]
-	unsafe {
+		p += 2 // p now points to v[3]
 		*p = 31
 	}
 	assert v[0] == 6
@@ -26,8 +18,7 @@ fn test_ptr_infix() {
 	v := 4
 	mut q := unsafe {&v - 1}
 	q = unsafe {q + 3}
-	_ := q
-	_ := v
+	assert q == unsafe {&v + 2}
 }
 
 struct S1 {
@@ -43,4 +34,23 @@ fn test_funcs() {
 		s.f()
 	}
 	_ = C.strerror(0) // [trusted] function prototype in builtin/cfns.c.v
+}
+
+fn test_if_expr_unsafe() {
+	i := 4
+	p := if true {
+		unsafe {&i}
+	}
+	else {unsafe {&i}}
+	assert *p == 4
+}
+
+fn test_unsafe_if_stmt() int {
+	i := 4
+	unsafe {
+		if true {
+			return (&i)[0]
+		}
+	}
+	return i
 }


### PR DESCRIPTION
Part of #5655.
This is the first part of the fixes in #5973 which was reverted due to `unsafe(expr)` syntax.
Currently if the first token on a line is `unsafe`, then it gets parsed as UnsafeStmt. Instead for `unsafe {expr}` we should parse it as UnsafeExpr. This fixes parsing:
```v
foo := if cond {
  unsafe {expr}
} else {
  unsafe {expr}
}
```
It also is a necessary step towards parsing `unsafe {expr}.foo()` (which I'll do in another pull).

Replace UnsafeExpr.stmts with .expr.
Add method Expr.is_expr().
Add method Parser.expr_with_left() to continue parsing an expression after the first expression.