### PR TITLE
doc: concurency example with WaitGroup

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1651,6 +1651,32 @@ user := users_repo.find_by_id(1)?
 post := posts_repo.find_by_id(1)?
 ```
 
+Another example:
+```v
+fn compare<T>(a, b T) int {
+    if a < b {
+        return -1
+    }
+    if a > b {
+        return 1
+    }
+    return 0
+}
+
+println(compare<int>(1,0)) // Outputs: 1
+println(compare<int>(1,1)) //          0
+println(compare<int>(1,2)) //         -1
+
+println(compare<string>('1','0')) // Outputs: 1
+println(compare<string>('1','1')) //          0
+println(compare<string>('1','2')) //         -1
+
+println(compare<float>(1.1, 1.0)) // Outputs: 1 
+println(compare<float>(1.1, 1.1)) //          0
+println(compare<float>(1.1, 1.2)) //         -1
+```
+
+
 ## Concurrency
 
 V's model of concurrency is very similar to Go's. To run `foo()` concurrently, just

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1683,6 +1683,36 @@ V's model of concurrency is very similar to Go's. To run `foo()` concurrently, j
 call it with `go foo()`. Right now, it launches the function on a new system
 thread. Soon coroutines and a scheduler will be implemented.
 
+```v
+import sync
+import time
+
+fn task(id, duration int, mut wg sync.WaitGroup) {
+    println("task ${id} begin")
+    time.sleep_ms(duration)
+    println("task ${id} end")
+    wg.done()
+}
+
+fn main() {
+    mut wg := sync.new_waitgroup()
+    wg.add(3)
+    go task(1, 500, mut wg)
+    go task(2, 900, mut wg)
+    go task(3, 100, mut wg)
+    wg.wait()
+    println('done')
+}
+
+// Output: task 1 begin
+//         task 2 begin
+//         task 3 begin
+//         task 3 end
+//         task 1 end
+//         task 2 end
+//         done
+```
+
 Unlike Go, V has no channels (yet). Nevertheless, data can be exchanged between a coroutine
 and the calling thread via a shared variable. This variable should be created as reference and passed to
 the coroutine as `mut`. The underlying `struct` should also contain a `mutex` to lock concurrent access:


### PR DESCRIPTION
I've added another example about concurrency based on the examples\concurrency\concurrency.v

It illustrates the simple case with no data exchange between workers:

```v
import sync
import time

fn task(id, duration int, mut wg sync.WaitGroup) {
    println("task ${id} begin")
    time.sleep_ms(duration)
    println("task ${id} end")
    wg.done()
}

fn main() {
    mut wg := sync.new_waitgroup()
    wg.add(3)
    go task(1, 500, mut wg)
    go task(2, 900, mut wg)
    go task(3, 100, mut wg)
    wg.wait()
    println('done')
}

// Output: task 1 begin
//         task 2 begin
//         task 3 begin
//         task 3 end
//         task 1 end
//         task 2 end
//         done
```
