### PR TITLE
os.cp: Fix returning false error on Windows

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -167,9 +167,8 @@ pub fn cp(old, new string) ? {
 	$if windows {
 		w_old := old.replace('/', '\\')
 		w_new := new.replace('/', '\\')
-		C.CopyFile(w_old.to_wide(), w_new.to_wide(), false)
-		result := C.GetLastError()
-		if result != 0 {
+		if C.CopyFile(w_old.to_wide(), w_new.to_wide(), false) == 0 {
+			result := C.GetLastError()
 			return error_with_code('failed to copy $old to $new', int(result))
 		}
 	} $else {


### PR DESCRIPTION
Fixes #5974.

* CopyFile returns zero if there was an error:
https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-copyfile#return-value
* GetLastError should only be called if CopyFile failed.
