### PR TITLE
fix primitive type variants for sumtypes

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -504,6 +504,7 @@ pub mut:
 	expected_type table.Type // for debugging only
 	is_sum_type   bool
 	is_interface  bool
+	smartcast     bool	= false	// indicates smartcast for sumtypes, for checker and cgen
 }
 
 pub struct MatchBranch {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2237,7 +2237,7 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 				//
 				c.error('cannot cast non sum type `$type_sym.name` using `as`', node.pos)
 			}
-			return node.typ.to_ptr()
+			return node.typ
 			// return node.typ
 		}
 		ast.Assoc {
@@ -2643,6 +2643,17 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) table.Type {
 				}
 			}
 		}
+		if node.is_sum_type && branch.stmts.len > 0 && node.cond is ast.Ident {
+			var_name := (node.cond as ast.Ident).name
+			mut scope := c.file.scope.innermost(branch.stmts[0].position().pos)
+			scope.register(var_name, ast.Var{
+				name: var_name
+				typ: (branch.exprs[0] as ast.Type).typ
+				pos: branch.stmts[0].position()
+				is_used: true
+				is_mut: node.is_mut
+			})
+		}
 		c.stmts(branch.stmts)
 		// If the last statement is an expression, return its type
 		if branch.stmts.len > 0 {
@@ -2907,7 +2918,7 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) table.Type {
 						mut scope := c.file.scope.innermost(branch.body_pos.pos)
 						scope.register(branch.left_as_name, ast.Var{
 							name: branch.left_as_name
-							typ: right_expr.typ.to_ptr()
+							typ: right_expr.typ
 							pos: infix.left.position()
 							is_used: true
 							is_mut: is_mut

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2643,16 +2643,17 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) table.Type {
 				}
 			}
 		}
-		if node.is_sum_type && branch.stmts.len > 0 && node.cond is ast.Ident {
-			var_name := (node.cond as ast.Ident).name
+		if node.is_sum_type && branch.stmts.len > 0 && branch.exprs.len > 0
+			&& node.cond is ast.Ident && (node.cond as ast.Ident).kind == .variable {
 			mut scope := c.file.scope.innermost(branch.stmts[0].position().pos)
-			scope.register(var_name, ast.Var{
-				name: var_name
-				typ: (branch.exprs[0] as ast.Type).typ
+			scope.register(node.var_name, ast.Var{
+				name: node.var_name
+				typ: c.expr(branch.exprs[0])
 				pos: branch.stmts[0].position()
 				is_used: true
 				is_mut: node.is_mut
 			})
+			node.smartcast = true
 		}
 		c.stmts(branch.stmts)
 		// If the last statement is an expression, return its type

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2368,7 +2368,7 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 			}
 		}
 		// g.writeln('/* M sum_type=$node.is_sum_type is_expr=$node.is_expr exp_type=${g.typ(node.expected_type)}*/')
-		if node.is_sum_type && branch.exprs.len > 0 && !node.is_expr {
+		if node.is_sum_type && node.smartcast && branch.exprs.len > 0 && !node.is_expr {
 			// The first node in expr is an ast.Type
 			// Use it to generate `it` variable.
 			first_expr := branch.exprs[0]

--- a/vlib/v/tests/sumtype_primitives_test.v
+++ b/vlib/v/tests/sumtype_primitives_test.v
@@ -1,0 +1,83 @@
+struct Consts { 
+	str string = 'the quick brown fox jumps over the lazy dog.'
+	itg int = -1234567890
+	flt64 f64 = 3.1415926535897932384
+	usg32 u32 = 4294967296
+	boo bool = true
+	arr []string = []string{ len: 7, init: 'in the beginning ...' }
+}
+
+const ( 
+	constants = Consts{}
+)
+
+struct CellTree {
+	content string
+	up voidptr
+	down voidptr
+	left voidptr
+	right voidptr
+}
+
+type Cell = string | int | f64 | u32 | bool | CellTree
+
+// arg is not pointer
+fn check(cell Cell) {
+	match cell {
+		string { assert cell == constants.str }
+		int { assert cell == constants.itg }
+		f64 { assert cell == constants.flt64 }
+		u32 { assert cell == constants.usg32 }
+		bool { assert cell == constants.boo }
+		CellTree { assert cell.content == constants.str }
+	}
+}
+
+// direct assginments, direct asserts and asserts through fn with match
+fn test_sumtype_of_string() {
+	mut cell := Cell{}
+	cell = constants.str
+	check(cell)
+	str := cell as string
+	assert str == constants.str
+}
+
+fn test_sumtype_of_int() {
+	mut cell := Cell{}
+	cell = constants.itg
+	check(cell)
+	itg := cell as int
+	assert itg == constants.itg
+}
+
+fn test_sumtype_of_f64() {
+	mut cell := Cell{}
+	cell = constants.flt64
+	check(cell)
+	flt64 := cell as f64
+	assert flt64 == constants.flt64
+}
+
+fn test_sumtype_of_u32() {
+	mut cell := Cell{}
+	cell = constants.usg32
+	check(cell)
+	usg32 := cell as u32
+	assert usg32 == constants.usg32
+}
+
+fn test_sumtype_of_boolean() {
+	mut cell := Cell{}
+	cell = constants.boo
+	check(cell)
+	boo := cell as bool
+	assert boo == constants.boo
+}
+
+fn test_sumtype_of_struct_with_string_field() {
+	mut cell := Cell{}
+	cell = CellTree{ content: constants.str }
+	check(cell)
+	mut cell_tree := cell as CellTree
+	assert cell_tree.content == constants.str
+}


### PR DESCRIPTION
type PrimTypes = string | int | f64 | u32 | bool

Presently V supports struct as variants for sumtypes. Support for primitive types are not fully implemented. Sumtypes can be assigned primitive types variants but cannot cast back to the variant types with the `as` cast or using match smartcasting, mainly because the type being returned is always a pointer.
This PR aims to fix the unwrapping of variants in such a way they will have the exact same type they had by the wrapping time. As a consequence, primitives will be unwrapped correctly.

Observations:
1. this PR makes smartcasts for sumtypes in mach expressions to work only when the condition is an identifier (ast.Ident). would like to know if for selectors (ast.SelectorExpr) this should be implemented;
2. would also like to know how sumtypes should behave when assigned to other sumtypes (of the same type, of course), if like structs (referencing or dereferencing, according to the need) or in a normal (strict) way. besides assignment, this is important for fn arg passing;
3. should `[]string` be allowed as a variant ? or, better asking, what should be allowed as variants ?
4. since for structs, StructType and &StructType are cast automatically, should `&` be allowed together with a variant type, for sumtype definitions or not ?

attached below goes a test. sorry, didn't know where to put it.