### PR TITLE
v/fmt: Don't add newlines for UnsafeExpr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         ./v fmt -verify vlib/v/checker/checker.v
         ./v fmt -verify vlib/v/parser/parser.v
         ./v fmt -verify vlib/v/gen/cgen.v
+        ./v fmt -verify vlib/v/gen/x64/gen.v
 #    - name: Test v binaries
 #      run: ./v -silent build-vbinaries
 

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1060,9 +1060,10 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 			f.write(')')
 		}
 		ast.UnsafeExpr {
-			f.writeln('unsafe {')
-			f.stmts(node.stmts)
-			f.writeln('}')
+			f.write('unsafe {')
+			es := node.stmts[0] as ast.ExprStmt
+			f.expr(es.expr)
+			f.write('}')
 		}
 	}
 }

--- a/vlib/v/fmt/tests/blocks_expected.vv
+++ b/vlib/v/fmt/tests/blocks_expected.vv
@@ -1,6 +1,6 @@
 fn unsafe_fn() {
 	unsafe {
-		malloc(2)
+		_ = malloc(2)
 	}
 }
 

--- a/vlib/v/fmt/tests/blocks_input.vv
+++ b/vlib/v/fmt/tests/blocks_input.vv
@@ -1,5 +1,5 @@
 fn unsafe_fn() {
-unsafe { malloc(2) }
+unsafe { _ = malloc(2) }
 }
 
 fn fn_with_defer() {

--- a/vlib/v/tests/unsafe_test.v
+++ b/vlib/v/tests/unsafe_test.v
@@ -24,14 +24,8 @@ fn test_ptr_assign() {
 
 fn test_ptr_infix() {
 	v := 4
-	mut q := unsafe {
-		&v - 1
-	}
-	
-	q = unsafe {
-		q + 3
-	}
-	
+	mut q := unsafe {&v - 1}
+	q = unsafe {q + 3}
 	_ := q
 	_ := v
 }


### PR DESCRIPTION
* Add `.github/workflows/ci.yml` to vfmt verification (is has an UnsafeExpr to test this pull).
* Update `v/fmt/tests/blocks_input.v` to use an unsafe *statement* (Note: currently the unsafe expression is parsed as an unsafe statement anyway - fix pending in #6032).
* Run vfmt on `v/tests/unsafe_test.v`.