### PR TITLE
v/fmt: Fix dropping `as ident` from `if sum is T` statement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
     - name: v fmt
       run: |
         ./v fmt -verify vlib/v/checker/checker.v
+        ./v fmt -verify vlib/v/fmt/fmt.v
         ./v fmt -verify vlib/v/parser/parser.v
         ./v fmt -verify vlib/v/gen/cgen.v
 #    - name: Test v binaries

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1316,7 +1316,8 @@ pub fn (mut f Fmt) if_expr(it ast.IfExpr) {
 		if branch.cond is ast.InfixExpr as infix {
 			if infix.op == .key_is {
 				// left_as_name is either empty, infix.left.str() or the `as` name
-				smartcast_as = branch.left_as_name.len > 0 && infix.left.str() != branch.left_as_name
+				smartcast_as = branch.left_as_name.len > 0 &&
+					infix.left.str() != branch.left_as_name
 			}
 		}
 		if i == 0 {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1311,21 +1311,19 @@ pub fn (mut f Fmt) if_expr(it ast.IfExpr) {
 		(it.is_expr || f.is_assign)
 	f.single_line_if = single_line
 	for i, branch in it.branches {
-		// NOTE: taken from checker in if_expr(). used for smartcast
-		mut is_variable := false
-		if branch.cond is ast.InfixExpr {
-			infix := branch.cond as ast.InfixExpr
-			if infix.op == .key_is &&
-				(infix.left is ast.Ident || infix.left is ast.SelectorExpr) && infix.right is ast.Type {
-				// right_expr := infix.right as ast.Type
-				is_variable = if infix.left is ast.Ident { (infix.left as ast.Ident).kind == .variable } else { true }
+		// Check `sum is T` smartcast
+		mut smartcast_as := false
+		if branch.cond is ast.InfixExpr as infix {
+			if infix.op == .key_is {
+				// left_as_name is either empty, infix.left.str() or the `as` name
+				smartcast_as = branch.left_as_name.len > 0 && infix.left.str() != branch.left_as_name
 			}
 		}
 		if i == 0 {
 			f.comments(branch.comments, {})
 			f.write('if ')
 			f.expr(branch.cond)
-			if is_variable && branch.left_as_name.len > 0 {
+			if smartcast_as {
 				f.write(' as $branch.left_as_name')
 			}
 			f.write(' {')
@@ -1338,7 +1336,7 @@ pub fn (mut f Fmt) if_expr(it ast.IfExpr) {
 			}
 			f.write('else if ')
 			f.expr(branch.cond)
-			if is_variable && branch.left_as_name.len > 0 {
+			if smartcast_as {
 				f.write(' as $branch.left_as_name')
 			}
 			f.write(' {')

--- a/vlib/v/fmt/tests/sum_smartcast_keep.vv
+++ b/vlib/v/fmt/tests/sum_smartcast_keep.vv
@@ -1,0 +1,19 @@
+struct S1 {
+}
+
+struct S2 {
+}
+
+type Sum = S1 | S2
+
+fn f(sum Sum) {
+	if sum is S1 {
+	}
+	if sum is S1 as s1 {
+	}
+	a := [sum]
+	if a[0] is S2 {
+	}
+	if a[0] is S2 as s2 {
+	}
+}


### PR DESCRIPTION
Fixes #5934.
CI: verify vlib/v/fmt/fmt.v is formatted (it has a `if sum is T as name`  smartcast).