### PR TITLE
Remove unused import in random_ips.v

### DIFF
--- a/examples/random_ips.v
+++ b/examples/random_ips.v
@@ -1,5 +1,4 @@
 import rand
-import time
 
 fn main() {
 	for _ in 0..10 {


### PR DESCRIPTION
random_ips.v:2:8: warning: module 'time' is imported but never used

This pr just removes an unused import in the random_ips example.
The script has been tested and still works.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
