### PR TITLE
scanner: assignments of floats without fraction should be allowed (#5262)

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -474,7 +474,6 @@ fn (mut s Scanner) ident_dec_number() string {
 	}
 	mut call_method := false // true for, e.g., 5.str(), 5.5.str(), 5e5.str()
 	mut is_range := false // true for, e.g., 5..10
-	mut is_float_without_fraction := false // true for, e.g. 5.
 	// scan fractional part
 	if s.pos < s.text.len && s.text[s.pos] == `.` {
 		s.pos++
@@ -508,10 +507,8 @@ fn (mut s Scanner) ident_dec_number() string {
 				// 5.str()
 				call_method = true
 				s.pos--
-			} else if s.text[s.pos] != `)` {
+			} else {
 				// 5.
-				is_float_without_fraction = true
-				s.pos--
 			}
 		}
 	}
@@ -550,7 +547,7 @@ fn (mut s Scanner) ident_dec_number() string {
 		s.pos-- // adjust error position
 		s.error('exponent has no digits')
 	} else if s.pos < s.text.len &&
-		s.text[s.pos] == `.` && !is_range && !is_float_without_fraction && !call_method {
+		s.text[s.pos] == `.` && !is_range && !call_method {
 		// error check: 1.23.4, 123.e+3.4
 		if has_exp {
 			s.error('exponential part should be integer')

--- a/vlib/v/scanner/scanner_test.v
+++ b/vlib/v/scanner/scanner_test.v
@@ -45,10 +45,34 @@ fn test_float_conversion_and_reading() {
 	mut e := 1.2E3 * -1e-1
 	assert e == -120.0
 	e = 1.2E3 * 1e-1
+	x := 55.
 	assert e == 120.0
 	assert 1.23e+10 == 1.23e10
 	assert 1.23e+10 == 1.23e0010
 	assert (-1.23e+10) == (1.23e0010 * -1.0)
+	assert x == 55.0
+}
+
+fn test_float_without_fraction() {
+	mut result := scan_kinds('x := 10.')
+	assert result.len == 3
+	assert result[0] == .name
+	assert result[1] == .decl_assign
+	assert result[2] == .number
+
+	result = scan_kinds('return 3., 4.')
+	assert result.len == 4
+	assert result[0] == .key_return
+	assert result[1] == .number
+	assert result[2] == .comma
+	assert result[3] == .number
+
+	result = scan_kinds('fun(5.)')
+	assert result.len == 4
+	assert result[0] == .name
+	assert result[1] == .lpar
+	assert result[2] == .number
+	assert result[3] == .rpar
 }
 
 fn test_reference_bools() {


### PR DESCRIPTION
Bugfix for #5262 

Assignments like `x := 10.` should be allowed