### PR TITLE
v/parser: Support [unsafe] instead of [unsafe_fn]

### DIFF
--- a/vlib/v/checker/tests/unsafe_pointer_arithmetic_should_be_checked.vv
+++ b/vlib/v/checker/tests/unsafe_pointer_arithmetic_should_be_checked.vv
@@ -16,7 +16,7 @@ fn test_ptr_infix() {
 
 struct S1 {}
 
-[unsafe_fn]
+[unsafe]
 fn (s S1) f(){}
 
 fn test_funcs() {

--- a/vlib/v/checker/tests/unsafe_required.vv
+++ b/vlib/v/checker/tests/unsafe_required.vv
@@ -16,7 +16,7 @@ fn test_ptr_infix() {
 
 struct S1 {}
 
-[unsafe_fn]
+[unsafe]
 fn (s S1) f(){}
 
 fn test_funcs() {

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -132,7 +132,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	p.top_level_statement_start()
 	start_pos := p.tok.position()
 	is_deprecated := p.attrs.contains('deprecated')
-	mut is_unsafe := p.attrs.contains('unsafe_fn')
+	mut is_unsafe := p.attrs.contains('unsafe')
 	is_pub := p.tok.kind == .key_pub
 	if is_pub {
 		p.next()

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -725,6 +725,12 @@ fn (mut p Parser) attributes() {
 }
 
 fn (mut p Parser) parse_attr() table.Attr {
+	if p.tok.kind == .key_unsafe {
+		p.next()
+		return table.Attr{
+			name: 'unsafe'
+		}
+	}
 	mut is_ctdefine := false
 	if p.tok.kind == .key_if {
 		p.next()
@@ -737,6 +743,10 @@ fn (mut p Parser) parse_attr() table.Attr {
 		p.next()
 	} else {
 		mut name = p.check_name()
+		if name == 'unsafe_fn' {
+			//p.error_with_pos('please use `[unsafe]` instead', p.tok.position())
+			name = 'unsafe'
+		}
 		if p.tok.kind == .colon {
 			name += ':'
 			p.next()

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -744,7 +744,7 @@ fn (mut p Parser) parse_attr() table.Attr {
 	} else {
 		mut name = p.check_name()
 		if name == 'unsafe_fn' {
-			//p.error_with_pos('please use `[unsafe]` instead', p.tok.position())
+			// p.error_with_pos('please use `[unsafe]` instead', p.tok.position())
 			name = 'unsafe'
 		}
 		if p.tok.kind == .colon {

--- a/vlib/v/table/attr.v
+++ b/vlib/v/table/attr.v
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file.
 module table
 
-// e.g. `[unsafe_fn]`
+// e.g. `[unsafe]`
 pub struct Attr {
 pub:
 	name        string

--- a/vlib/v/tests/unsafe_test.v
+++ b/vlib/v/tests/unsafe_test.v
@@ -33,7 +33,7 @@ fn test_ptr_infix() {
 struct S1 {
 }
 
-[unsafe_fn]
+[unsafe]
 fn (s S1) f() {
 }
 


### PR DESCRIPTION
We already allow an `if` keyword in an attribute for `[if debug]`, so it would be good to allow `[unsafe]` which looks nicer than `[unsafe_fn]` and it's more general. `[unsafe]` could later be used for field attributes too, e.g.:
```v
struct string {
pub:
  ptr byteptr [unsafe]
  ...
}
```
`my_string.ptr` can be unsafe to dereference when `len` is 0. (Once unsafe checks are made for pointer casts, dereferencing a pointer can be allowed in memory-safe code as pointer arithmetic is also checked). Marking `ptr` with the unsafe attribute would mean the field can only be used inside `unsafe {}`.

Draft until approved, then I can make it an error to use `[unsafe_fn]`.