### PR TITLE
os: let temp_dir adhere to posix/fhs on linux and mac

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -1256,8 +1256,11 @@ pub fn temp_dir() string {
 			}
 		}
 	}
-	if path == '' {
-		path = os.cache_dir()
+	$if android {
+		// TODO test+use '/data/local/tmp' on Android before using cache_dir()
+		if path == '' {
+			path = os.cache_dir()
+		}
 	}
 	if path == '' {
 		path = '/tmp'


### PR DESCRIPTION
This PR will let `os.temp_dir` return a "truly" temporary location on Linux and Mac OS.

Previously `os.cache_dir` directory was used before using/trying `/tmp` on said systems (because of Android not having a standard tmp location if I recall correctly).

I think it'd be more sane to let V adhere to Linux Foundation's Filesystem Hierarchy Standard version 3.0 specs in this case,
 to let V be as compliant as possible: https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html#tmpTemporaryFiles

* `/home` [is optional](https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html#homeUserHomeDirectories) on some Linux variants so using `os.cache_dir` could fail on these setups.
* `/tmp` is [cleared](https://serverfault.com/a/377349) on major distros - so it is "truly" a temporary location (in contrary to `~/.cache` which is not cleared in any predictable patterns)
* `~/.cache/v` on my machine is currently 3.3MB - how much of this is actually cached data and how much is temporary? I don't know. But I'd like to be able to distinguish between cached data and temporary data. I'd expect *cached* data to be longer lived than *temporary* data

I've also added a TODO to find a (more correct?) temporary dir on Android as [this post](https://stackoverflow.com/a/41105574/1904615) suggests is possible.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
