### PR TITLE
repl: fix recognizing anonymous functions defs as function calls

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -54,7 +54,8 @@ fn (mut r Repl) checks() bool {
 
 fn (r &Repl) function_call(line string) bool {
 	for function in r.functions_name {
-		if line.starts_with(function) {
+		is_function_definition := line.replace(' ', '').starts_with("$function:=")
+		if line.starts_with(function) && !is_function_definition {
 			return true
 		}
 	}


### PR DESCRIPTION
Bugfix for #5006

Anonymous functions definitions was previously recognized as function calls by the REPL. This fix enables possibility of using definitions like `bar := fn() { println("foo") }` (and also `bar:=fn(...` or `bar :=fn(...`) inside the REPL.
