### PR TITLE
v update: add verbose output like `v -v up`

### DIFF
--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -215,7 +215,7 @@ fn vpm_update(m []string) {
 			continue
 		}
 		vcs_cmd := supported_vcs_update_cmds[vcs[0]]
-		verbose_println('      command: $vcs_cmd')
+		verbose_println('    command: $vcs_cmd')
 		vcs_res := os.exec('$vcs_cmd') or {
 			errors++
 			println('Could not update module "$name".')
@@ -229,6 +229,8 @@ fn vpm_update(m []string) {
 			verbose_println('Failed command: $vcs_cmd')
 			verbose_println('Failed details:\n$vcs_res.output')
 			continue
+		} else {
+			verbose_println('    ${vcs_res.output.trim_space()}')
 		}
 		resolve_dependencies(name, final_module_path, module_names)
 	}
@@ -289,8 +291,9 @@ fn vpm_list() {
 		println('You have no modules installed.')
 		exit(0)
 	}
+	println('Installed modules:')
 	for mod in module_names {
-		println(mod)
+		println('  $mod')
 	}
 }
 

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -230,7 +230,7 @@ fn vpm_update(m []string) {
 			verbose_println('Failed details:\n$vcs_res.output')
 			continue
 		} else {
-			verbose_println('    ${vcs_res.output.trim_space()}')
+			verbose_println('    $vcs_res.output.trim_space()')
 		}
 		resolve_dependencies(name, final_module_path, module_names)
 	}

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -537,7 +537,8 @@ fn get_module_meta_info(name string) ?Mod {
 			continue
 		}
 		if r.status_code == 404 || r.text.contains('404') {
-			errors << 'Skipping module "$name", since $server_url reported that "$name" does not exist.'
+			errors <<
+				'Skipping module "$name", since $server_url reported that "$name" does not exist.'
 			continue
 		}
 		if r.status_code != 200 {


### PR DESCRIPTION
Print the output of the vcs command if `-v` is specified just like `v -v up` does.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
