### PR TITLE
vweb, add set_status

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -42,6 +42,7 @@ mut:
 	static_files map[string]string
 	static_mime_types map[string]string
 	content_type string = 'text/plain'
+	status string = '200 OK'
 pub:
 	req http.Request
 	conn net.Socket
@@ -71,8 +72,9 @@ fn (mut ctx Context) send_response_to_client(mimetype string, res string) bool {
 	ctx.done = true
 	mut sb := strings.new_builder(1024)
 	defer { sb.free() }
-	sb.write('HTTP/1.1 200 OK\r\nContent-Type: ') sb.write(mimetype)
-	sb.write('\r\nContent-Length: ')              sb.write(res.len.str())
+	sb.write('HTTP/1.1 ${ctx.status}')
+	sb.write('\r\nContent-Type: ${mimetype}')
+	sb.write('\r\nContent-Length: ${res.len}')
 	sb.write(ctx.headers)
 	sb.write('\r\n')
 	sb.write(headers_close)
@@ -162,6 +164,14 @@ pub fn (ctx &Context) get_cookie(key string) ?string { // TODO refactor
 		return cookie.trim_space()
 	}
 	return error('Cookie not found')
+}
+
+pub fn (mut ctx Context) set_status(code int, desc string) {
+	if code < 100 || code > 599 {
+		ctx.status = '500 Internal Server Error'
+	} else {
+		ctx.status = '$code $desc'
+	}
 }
 
 pub fn (mut ctx Context) add_header(key, val string) {


### PR DESCRIPTION
Implementation of feature request [6085](https://github.com/vlang/v/issues/6085).
By default HTTP response is the usual "200 OK"

In V code didn't found unit tests for vweb, anyway I tested it with without calling this function (to avoid regressions):
- normal reply (with both text, json reply)
- error reply (404, 500, etc)
To test its usage it's enough:
```
pub fn (mut app App) mystatus() vweb.Result {
	app.vweb.set_status(406, 'My error message') // 406 Not Acceptable, as a sample I change here its description in the reply
	return app.vweb.json('{"msg":"My HTTP status code and message"}')
}
```

Note that I added a check on the given status code, not sure if my manage of error here is the best.

Hope it's good.
Bye
