### PR TITLE
sync/channels: implement `close()` method

### DIFF
--- a/vlib/sync/channel_close_test.v
+++ b/vlib/sync/channel_close_test.v
@@ -1,0 +1,80 @@
+import sync
+import time
+
+fn do_rec(mut ch sync.Channel, mut resch sync.Channel) {
+	mut sum := i64(0)
+	for  {
+		mut a := 0
+		if !ch.pop(&a) {
+			break
+		}
+		sum += a
+	}
+	println(sum)
+	resch.push(&sum)
+}
+
+fn do_send(mut ch sync.Channel) {
+	for i in 0 .. 8000 {
+		ch.push(&i)
+	}
+	ch.close()
+}
+
+fn test_channel_close_buffered_multi() {
+	mut ch := sync.new_channel<int>(0)
+	mut resch := sync.new_channel<i64>(100)
+	go do_rec(mut ch, mut resch)
+	go do_rec(mut ch, mut resch)
+	go do_rec(mut ch, mut resch)
+	go do_rec(mut ch, mut resch)
+	go do_send(mut ch)
+	mut sum := i64(0)
+	for _ in 0 .. 4 {
+		mut r := i64(0)
+		resch.pop(&r)
+		sum += r
+	}
+	assert sum == i64(8000) * (8000 - 1) / 2
+}
+
+fn test_channel_close_unbuffered_multi() {
+	mut ch := sync.new_channel<int>(0)
+	mut resch := sync.new_channel<i64>(100)
+	go do_rec(mut ch, mut resch)
+	go do_rec(mut ch, mut resch)
+	go do_rec(mut ch, mut resch)
+	go do_rec(mut ch, mut resch)
+	go do_send(mut ch)
+	mut sum := i64(0)
+	for _ in 0 .. 4 {
+		mut r := i64(0)
+		resch.pop(&r)
+		sum += r
+	}
+	assert sum == i64(8000) * (8000 - 1) / 2
+}
+
+fn test_channel_close_buffered() {
+	mut ch := sync.new_channel<int>(0)
+	mut resch := sync.new_channel<i64>(100)
+	go do_rec(mut ch, mut resch)
+	go do_send(mut ch)
+	mut sum := i64(0)
+	mut r := i64(0)
+	resch.pop(&r)
+	sum += r
+	assert sum == i64(8000) * (8000 - 1) / 2
+}
+
+fn test_channel_close_unbuffered() {
+	mut ch := sync.new_channel<int>(0)
+	mut resch := sync.new_channel<i64>(100)
+	go do_rec(mut ch, mut resch)
+	go do_send(mut ch)
+	mut sum := i64(0)
+	mut r := i64(0)
+	resch.pop(&r)
+	sum += r
+	assert sum == i64(8000) * (8000 - 1) / 2
+}

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -512,7 +512,7 @@ pub fn channel_select(mut channels []&Channel, dir []Direction, mut objrefs []vo
 			}
 		}
 		if num_closed == channels.len {
-			event_idx == -2
+			event_idx = -2
 			goto restore
 		}
 		if timeout > 0 {

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -128,12 +128,10 @@ pub fn new_channel<T>(n u32) &Channel {
 
 pub fn (mut ch Channel) close() {
 	C.atomic_store_u16(&ch.closed, 1)
-	println('about to prepare close')
 	mut nulladr := voidptr(0)
 	for !C.atomic_compare_exchange_weak_ptr(&ch.adr_written, &nulladr, voidptr(-1)) {
 		nulladr = voidptr(0)
 	}
-	println('close prepared')
 	ch.readsem_im.post()
 	ch.readsem.post()
 }

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -76,6 +76,12 @@ enum Direction {
 	push
 }
 
+enum TransactionState {
+	success
+	not_ready // push()/pop() would have to wait, but no_block was requested
+	closed
+}
+
 struct Channel {
 	writesem           Semaphore // to wake thread that wanted to write, but buffer was full
 	readsem            Semaphore // to wake thread that wanted to read, but buffer was empty
@@ -99,6 +105,7 @@ mut: // atomic
 	read_subscriber    &Subscription
 	write_sub_mtx      u16
 	read_sub_mtx       u16
+	closed             u16
 }
 
 pub fn new_channel<T>(n u32) &Channel {
@@ -119,11 +126,28 @@ pub fn new_channel<T>(n u32) &Channel {
 	}
 }
 
-pub fn (mut ch Channel) push(src voidptr) {
-	ch.try_push(src, false)
+pub fn (mut ch Channel) close() {
+	C.atomic_store_u16(&ch.closed, 1)
+	println('about to prepare close')
+	mut nulladr := voidptr(0)
+	for !C.atomic_compare_exchange_weak_ptr(&ch.adr_written, &nulladr, voidptr(-1)) {
+		nulladr = voidptr(0)
+	}
+	println('close prepared')
+	ch.readsem_im.post()
+	ch.readsem.post()
 }
 
-fn (mut ch Channel) try_push(src voidptr, no_block bool) bool {
+pub fn (mut ch Channel) push(src voidptr) {
+	if ch.try_push(src, false) == .closed {
+		panic('push on closed channel')
+	}
+}
+
+fn (mut ch Channel) try_push(src voidptr, no_block bool) TransactionState {
+	if C.atomic_load_u16(&ch.closed) != 0 {
+		return .closed
+	}
 	spinloops_, spinloops_sem_ := if no_block { 1, 1 } else { spinloops, spinloops_sem }
 	mut have_swapped := false
 	for {
@@ -138,11 +162,11 @@ fn (mut ch Channel) try_push(src voidptr, no_block bool) bool {
 					nulladr = voidptr(0)
 				}
 				ch.readsem_im.post()
-				return true
+				return .success
 			}
 		}
 		if no_block && ch.queue_length == 0 {
-			return false
+			return .not_ready
 		}
 		// get token to read
 		for _ in 0 .. spinloops_sem_ {
@@ -206,10 +230,14 @@ fn (mut ch Channel) try_push(src voidptr, no_block bool) bool {
 				} else {
 					// this semaphore was not for us - repost in
 					ch.writesem_im.post()
+					if src2 == voidptr(-1) {
+						ch.readsem.post()
+						return .closed
+					}
 					src2 = src
 				}
 			}
-			return true
+			return .success
 		} else {
 			// buffered channel
 			mut space_in_queue := false
@@ -257,7 +285,7 @@ fn (mut ch Channel) try_push(src voidptr, no_block bool) bool {
 					}
 					C.atomic_store_u16(&ch.read_sub_mtx, u16(0))
 				}
-				return true
+				return .success
 			} else {
 				ch.writesem.post()
 			}
@@ -265,11 +293,11 @@ fn (mut ch Channel) try_push(src voidptr, no_block bool) bool {
 	}
 }
 
-pub fn (mut ch Channel) pop(dest voidptr) {
-	ch.try_pop(dest, false)
+pub fn (mut ch Channel) pop(dest voidptr) bool {
+	return ch.try_pop(dest, false) == .success
 }
 
-fn (mut ch Channel) try_pop(dest voidptr, no_block bool) bool {
+fn (mut ch Channel) try_pop(dest voidptr, no_block bool) TransactionState  {
 	spinloops_, spinloops_sem_ := if no_block { 1, 1 } else { spinloops, spinloops_sem }
 	mut have_swapped := false
 	mut write_in_progress := false
@@ -287,11 +315,11 @@ fn (mut ch Channel) try_pop(dest voidptr, no_block bool) bool {
 						nulladr = voidptr(0)
 					}
 					ch.writesem_im.post()
-					return true
+					return .success
 				}
 			}
 			if no_block {
-				return false
+				return if C.atomic_load_u16(&ch.closed) == 0 { TransactionState.not_ready } else { TransactionState.closed }
 			}
 		}
 		// get token to read
@@ -303,7 +331,7 @@ fn (mut ch Channel) try_pop(dest voidptr, no_block bool) bool {
 		}
 		if !got_sem {
 			if no_block {
-				return false
+				return if C.atomic_load_u16(&ch.closed) == 0 { TransactionState.not_ready } else { TransactionState.closed }
 			}
 			ch.readsem.wait()
 		}
@@ -354,7 +382,7 @@ fn (mut ch Channel) try_pop(dest voidptr, no_block bool) bool {
 					}
 					C.atomic_store_u16(&ch.write_sub_mtx, u16(0))
 				}
-				return true
+				return .success
 			}
 		}
 		// try to advertise `dest` as writable
@@ -386,6 +414,9 @@ fn (mut ch Channel) try_pop(dest voidptr, no_block bool) bool {
 			if C.atomic_compare_exchange_strong_ptr(&ch.adr_written, &dest2, voidptr(0)) {
 				have_swapped = true
 				break
+			} else if dest2 == voidptr(-1) {
+				ch.readsem.post()
+				return .closed
 			}
 			dest2 = dest
 		}
@@ -408,10 +439,14 @@ fn (mut ch Channel) try_pop(dest voidptr, no_block bool) bool {
 			} else {
 				// this semaphore was not for us - repost in
 				ch.readsem_im.post()
+				if dest2 == voidptr(-1) {
+					ch.readsem.post()
+					return .closed
+				}
 				dest2 = dest
 			}
 		}
-		return true
+		return .success
 	}
 }
 
@@ -460,12 +495,12 @@ pub fn channel_select(mut channels []&Channel, dir []Direction, mut objrefs []vo
 				i -= channels.len
 			}
 			if dir[i] == .push {
-				if channels[i].try_push(objrefs[i], true) {
+				if channels[i].try_push(objrefs[i], true) == .success {
 					event_idx = i
 					goto restore
 				}
 			} else {
-				if channels[i].try_pop(objrefs[i], true) {
+				if channels[i].try_pop(objrefs[i], true) == .success {
 					event_idx = i
 					goto restore
 				}

--- a/vlib/sync/select_close_test.v
+++ b/vlib/sync/select_close_test.v
@@ -1,0 +1,92 @@
+import sync
+
+fn do_rec_i64(mut ch sync.Channel) {
+	mut sum := i64(0)
+	for i in 0 .. 300 {
+		if i == 200 {
+			ch.close()
+		}
+		mut a := i64(0)
+		if ch.pop(&a) {
+			sum += a
+		}
+	}
+	assert sum == 200 * (200 - 1) / 2
+}
+
+fn do_send_int(mut ch sync.Channel) {
+	for i in 0 .. 300 {
+		ch.push(&i)
+	}
+	ch.close()
+}
+
+fn do_send_byte(mut ch sync.Channel) {
+	for i in 0 .. 300 {
+		ii := byte(i)
+		ch.push(&ii)
+	}
+	ch.close()
+}
+
+fn do_send_i64(mut ch sync.Channel) {
+	for i in 0 .. 300 {
+		ii := i64(i)
+		ch.push(&ii)
+	}
+	ch.close()
+}
+
+fn test_select() {
+	mut chi := sync.new_channel<int>(0)
+	mut chl := sync.new_channel<i64>(1)
+	mut chb := sync.new_channel<byte>(10)
+	mut recch := sync.new_channel<i64>(0)
+	go do_rec_i64(mut recch)
+	go do_send_int(mut chi)
+	go do_send_byte(mut chb)
+	go do_send_i64(mut chl)
+	mut channels := [chi, recch, chl, chb]
+	directions := [sync.Direction.pop, .push, .pop, .pop]
+	mut sum := i64(0)
+	mut rl := i64(0)
+	mut ri := int(0)
+	mut rb := byte(0)
+	mut sl := i64(0)
+	mut objs := [voidptr(&ri), &sl, &rl, &rb]
+	for j in 0 .. 1101 {
+		idx := sync.channel_select(mut channels, directions, mut objs, 0)
+		match idx {
+			0 {
+				sum += ri
+			}
+			1 {
+				sl++
+			}
+			2 {
+				sum += rl
+			}
+			3 {
+				sum += rb
+			}
+			-2 {
+				// channel was closed - last item
+				assert j == 1100
+			}
+			else {
+				println('got $idx (timeout)')
+				assert false
+			}
+		}
+		if j == 1100 {
+			// check also in other direction
+			assert idx == -2
+		}
+	}
+	// Use Gauß' formula for the first 2 contributions
+	expected_sum :=  2 * (300 * (300 - 1) / 2) +
+		// the 3rd contribution is `byte` and must be seen modulo 256
+		256 * (256 - 1) / 2 +
+		44 * (44 - 1) / 2
+	assert sum == expected_sum
+}


### PR DESCRIPTION
This PR implements a call `ch.close()` for channels. After the close any further attempt to write with a standard `push()` command will result in a runtime panic (as in `Go`, `try_push() returns `.closed`). Already queued elements can still be `pop()`ed, afterwards any `pop()` does not change the referenced argument, and returns false.

A `select` returns `-2` if all channels have been closed.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
