### PR TITLE
sync/channels: provide `.cap` and `.len()`

### DIFF
--- a/doc/upcoming.md
+++ b/doc/upcoming.md
@@ -250,6 +250,15 @@ if ch.pop(&m) {
 }
 ```
 
+There are also methods `try_push()` and `try_pop()` which return immediatelly with the return value `.not_ready` if the transaction
+cannot be performed without waiting. The return value is of type `sync.TransactionState` which can also be
+`.success` or `.closed`.
+
+To monitor a channel there is a method `len()` which returns the number of elements currently in the queue and the attribute
+`cap` for the queue length. Please be aware that in general `channel.len() > 0` does not guarantee that the next
+`pop()` will succeed without waiting, since other threads may already have "stolen" elements from the queue. Use `try_pop()` to
+accomplish this kind of task.
+
 The select call is somewhat tricky. The `channel_select()` function needs three arrays that
 contain the channels, the directions (pop/push) and the object references and
 a timeout of type `time.Duration` (`time.infinite` or `-1` to wait unlimited) as parameters. It returns the

--- a/vlib/sync/channel_fill_test.v
+++ b/vlib/sync/channel_fill_test.v
@@ -1,0 +1,22 @@
+import sync
+
+const (
+	queue_len = 1000
+	queue_fill = 763
+)
+
+fn do_send(mut ch sync.Channel, fin sync.Semaphore) {
+	for i in 0 .. queue_fill {
+		ch.push(&i)
+	}
+	fin.post()
+}
+
+fn test_channel_len_cap() {
+	mut ch := sync.new_channel<int>(queue_len)
+	sem := sync.new_semaphore()
+	go do_send(mut ch, sem)
+	sem.wait()
+	assert ch.cap == queue_len
+	assert ch.len() == queue_fill
+}


### PR DESCRIPTION
This PR implements the method `ch.len()` that returns the current number of elements in a channel queue and a public readable attribute `ch.cap` for the queue length.
In Go `len` is also an attribute but since getting the number of elements requires an atomic operation, a method call is necessary in `V` (unless some compiler magic is used in later versions).
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
