### PR TITLE
array: sort for all numeric types

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -528,21 +528,57 @@ pub fn copy(dst, src []byte) int {
 	return 0
 }
 
-// Private function. Comparator for int type.
-fn compare_ints(a, b &int) int {
-	if *a < *b {
-		return -1
-	}
-	if *a > *b {
-		return 1
-	}
-	return 0
+
+// []i64.sort sorts array of i64 in place in ascending order.
+pub fn (mut a []i64) sort() {
+	a.sort_with_compare(compare_i64)
 }
 
 // []int.sort sorts array of int in place in ascending order.
 pub fn (mut a []int) sort() {
-	a.sort_with_compare(compare_ints)
+	a.sort_with_compare(compare_int)
 }
+
+// []i16.sort sorts array of i16 in place in ascending order.
+pub fn (mut a []i16) sort() {
+	a.sort_with_compare(compare_i16)
+}
+
+// []i8.sort sorts array of i8 in place in ascending order.
+pub fn (mut a []i8) sort() {
+	a.sort_with_compare(compare_i8)
+}
+
+// []u64.sort sorts array of u64 in place in ascending order.
+pub fn (mut a []u64) sort() {
+	a.sort_with_compare(compare_u64)
+}
+
+// []u32.sort sorts array of u32 in place in ascending order.
+pub fn (mut a []u32) sort() {
+	a.sort_with_compare(compare_u32)
+}
+
+// []u16.sort sorts array of u32 in place in ascending order.
+pub fn (mut a []u16) sort() {
+	a.sort_with_compare(compare_u16)
+}
+
+// []byte.sort sorts array of byte in place in ascending order.
+pub fn (mut a []byte) sort() {
+	a.sort_with_compare(compare_byte)
+}
+
+// []f64.sort sorts array of f64 in place in ascending order.
+pub fn (mut a []f64) sort() {
+	a.sort_with_compare(compare_f64)
+}
+
+// []f32.sort sorts array of f32 in place in ascending order.
+pub fn (mut a []f32) sort() {
+	a.sort_with_compare(compare_f32)
+}
+
 
 // []string.index returns the index of the first element equal to the given value,
 // or -1 if the value is not found in the array.
@@ -655,6 +691,90 @@ pub fn (a1 []string) eq(a2 []string) bool {
 // output:
 // [10, 28, 70, 92, 100]
 pub fn compare_i64(a, b &i64) int {
+	if *a < *b {
+		return -1
+	}
+	if *a > *b {
+		return 1
+	}
+	return 0
+}
+
+// compare_int for []int sort_with_compare()
+// ref. compare_i64(...)
+pub fn compare_int(a, b &int) int {
+	if *a < *b {
+		return -1
+	}
+	if *a > *b {
+		return 1
+	}
+	return 0
+}
+
+// compare_i16 for []i16 sort_with_compare()
+// ref. compare_i64(...)
+pub fn compare_i16(a, b &i16) int {
+	if *a < *b {
+		return -1
+	}
+	if *a > *b {
+		return 1
+	}
+	return 0
+}
+
+// compare_i8 for []i8 sort_with_compare()
+// ref. compare_i64(...)
+pub fn compare_i8(a, b &i8) int {
+	if *a < *b {
+		return -1
+	}
+	if *a > *b {
+		return 1
+	}
+	return 0
+}
+
+// compare_u64 for []u64 sort_with_compare()
+// ref. compare_i64(...)
+pub fn compare_u64(a, b &u64) int {
+	if *a < *b {
+		return -1
+	}
+	if *a > *b {
+		return 1
+	}
+	return 0
+}
+
+// compare_u32 for []u32 sort_with_compare()
+// ref. compare_i64(...)
+pub fn compare_u32(a, b &u32) int {
+	if *a < *b {
+		return -1
+	}
+	if *a > *b {
+		return 1
+	}
+	return 0
+}
+
+// compare_u16 for []u16 sort_with_compare()
+// ref. compare_i64(...)
+pub fn compare_u16(a, b &u16) int {
+	if *a < *b {
+		return -1
+	}
+	if *a > *b {
+		return 1
+	}
+	return 0
+}
+
+// compare_byte for []byte sort_with_compare()
+// ref. compare_i64(...)
+pub fn compare_byte(a, b &byte) int {
 	if *a < *b {
 		return -1
 	}

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -171,16 +171,16 @@ fn test_strings() {
 }
 
 /*
-fn test_compare_ints() {
-    assert compare_ints(1, 2) == -1
-    assert compare_ints(2, 1) == 1
-    assert compare_ints(0, 0) == 0
+fn test_compare_int() {
+    assert compare_int(1, 2) == -1
+    assert compare_int(2, 1) == 1
+    assert compare_int(0, 0) == 0
 
     a := 1
     b := 2
-    assert compare_ints(a, b) == -1
-    assert compare_ints(b, a) == 1
-    assert compare_ints(a, a) == 0
+    assert compare_int(a, b) == -1
+    assert compare_int(b, a) == 1
+    assert compare_int(a, a) == 0
 }
 */
 
@@ -695,46 +695,208 @@ fn test_eq() {
 	*/
 }
 
-fn test_sort() {
+fn test_string_sort() {
 	mut a := ['hi', '1', '5', '3']
 	a.sort()
 	assert a[0] == '1'
 	assert a[1] == '3'
 	assert a[2] == '5'
 	assert a[3] == 'hi'
-	//
-	mut nums := [67, -3, 108, 42, 7]
-	nums.sort()
-	assert nums[0] == -3
-	assert nums[1] == 7
-	assert nums[2] == 42
-	assert nums[3] == 67
-	assert nums[4] == 108
-}
-
-fn test_f32_sort() {
-	mut f := [f32(50.0), 15, 1, 79, 38, 0, 27]
-	f.sort_with_compare(compare_f32)
-	assert f[0] == 0.0
-	assert f[1] == 1.0
-	assert f[6] == 79.0
-}
-
-fn test_f64_sort() {
-	mut f := [50.0, 15, 1, 79, 38, 0, 27]
-	f.sort_with_compare(compare_f64)
-	assert f[0] == 0.0
-	assert f[1] == 1.0
-	assert f[6] == 79.0
 }
 
 fn test_i64_sort() {
-	mut f := [i64(50), 15, 1, 79, 38, 0, 27]
-	f.sort_with_compare(compare_i64)
-	assert f[0] == 0
-	assert f[1] == 1
-	assert f[6] == 79
+	mut a := [i64(67), -3, 108, 42, 7]
+	a.sort()
+	assert a[0] == -3
+	assert a[1] == 7
+	assert a[2] == 42
+	assert a[3] == 67
+	assert a[4] == 108
 }
+
+fn test_int_sort() {
+	mut a := [67, -3, 108, 42, 7]
+	a.sort()
+	assert a[0] == -3
+	assert a[1] == 7
+	assert a[2] == 42
+	assert a[3] == 67
+	assert a[4] == 108
+}
+
+fn test_i16_sort() {
+	mut a := [i16(67), -3, 108, 42, 7]
+	a.sort()
+	assert a[0] == -3
+	assert a[1] == 7
+	assert a[2] == 42
+	assert a[3] == 67
+	assert a[4] == 108
+}
+
+fn test_i8_sort() {
+	mut a := [i8(67), -3, 108, 42, 7]
+	a.sort()
+	assert a[0] == -3
+	assert a[1] == 7
+	assert a[2] == 42
+	assert a[3] == 67
+	assert a[4] == 108
+}
+
+fn test_u64_sort() {
+	mut a := [u64(67), 3, 108, 42, 7]
+	a.sort()
+	assert a[0] == 3
+	assert a[1] == 7
+	assert a[2] == 42
+	assert a[3] == 67
+	assert a[4] == 108
+}
+
+fn test_u32_sort() {
+	mut a := [u32(67), 3, 108, 42, 7]
+	a.sort()
+	assert a[0] == 3
+	assert a[1] == 7
+	assert a[2] == 42
+	assert a[3] == 67
+	assert a[4] == 108
+}
+
+fn test_u16_sort() {
+	mut a := [u16(67), 3, 108, 42, 7]
+	a.sort()
+	assert a[0] == 3
+	assert a[1] == 7
+	assert a[2] == 42
+	assert a[3] == 67
+	assert a[4] == 108
+}
+
+fn test_byte_sort() {
+	mut a := [byte(67), 3, 108, 42, 7]
+	a.sort()
+	assert a[0] == 3
+	assert a[1] == 7
+	assert a[2] == 42
+	assert a[3] == 67
+	assert a[4] == 108
+}
+
+fn test_f64_sort() {
+	mut a := [50.0, 15, 1, 79, 38, 0, 27]
+	a.sort()
+	assert a[0] == 0.0
+	assert a[1] == 1.0
+	assert a[6] == 79.0
+}
+
+fn test_f32_sort() {
+	mut a := [f32(50.0), 15, 1, 79, 38, 0, 27]
+	a.sort()
+	assert a[0] == 0.0
+	assert a[1] == 1.0
+	assert a[6] == 79.0
+}
+
+
+fn test_i64_sort_with_compare() {
+	mut a := [i64(67), -3, 108, 42, 7]
+	a.sort_with_compare(compare_i64)
+	assert a[0] == -3
+	assert a[1] == 7
+	assert a[2] == 42
+	assert a[3] == 67
+	assert a[4] == 108
+}
+
+fn test_int_sort_with_compare() {
+	mut a := [67, -3, 108, 42, 7]
+	a.sort_with_compare(compare_int)
+	assert a[0] == -3
+	assert a[1] == 7
+	assert a[2] == 42
+	assert a[3] == 67
+	assert a[4] == 108
+}
+
+fn test_i16_sort_with_compare() {
+	mut a := [i16(67), -3, 108, 42, 7]
+	a.sort_with_compare(compare_i16)
+	assert a[0] == -3
+	assert a[1] == 7
+	assert a[2] == 42
+	assert a[3] == 67
+	assert a[4] == 108
+}
+
+fn test_i8_sort_with_compare() {
+	mut a := [i8(67), -3, 108, 42, 7]
+	a.sort_with_compare(compare_i8)
+	assert a[0] == -3
+	assert a[1] == 7
+	assert a[2] == 42
+	assert a[3] == 67
+	assert a[4] == 108
+}
+
+fn test_u64_sort_with_compare() {
+	mut a := [u64(67), 3, 108, 42, 7]
+	a.sort_with_compare(compare_u64)
+	assert a[0] == 3
+	assert a[1] == 7
+	assert a[2] == 42
+	assert a[3] == 67
+	assert a[4] == 108
+}
+
+fn test_u32_sort_with_compare() {
+	mut a := [u32(67), 3, 108, 42, 7]
+	a.sort_with_compare(compare_u32)
+	assert a[0] == 3
+	assert a[1] == 7
+	assert a[2] == 42
+	assert a[3] == 67
+	assert a[4] == 108
+}
+
+fn test_u16_sort_with_compare() {
+	mut a := [u16(67), 3, 108, 42, 7]
+	a.sort_with_compare(compare_u16)
+	assert a[0] == 3
+	assert a[1] == 7
+	assert a[2] == 42
+	assert a[3] == 67
+	assert a[4] == 108
+}
+
+fn test_byte_sort_with_compare() {
+	mut a := [byte(67), 3, 108, 42, 7]
+	a.sort_with_compare(compare_byte)
+	assert a[0] == 3
+	assert a[1] == 7
+	assert a[2] == 42
+	assert a[3] == 67
+	assert a[4] == 108
+}
+
+fn test_f64_sort_with_compare() {
+	mut a := [50.0, 15, 1, 79, 38, 0, 27]
+	a.sort_with_compare(compare_f64)
+	assert a[0] == 0.0
+	assert a[1] == 1.0
+	assert a[6] == 79.0
+}
+
+fn test_f32_sort_with_compare() {
+	mut a := [f32(50.0), 15, 1, 79, 38, 0, 27]
+	a.sort_with_compare(compare_f32)
+	assert a[0] == 0.0
+	assert a[1] == 1.0
+	assert a[6] == 79.0
+}
+
 
 /*
 fn test_for_last() {


### PR DESCRIPTION
I've added array.sort for all numeric types (without using generics).
All unit tests included.
