### PR TITLE
sync/semaphores: use dispatch semaphores on MacOS

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -437,6 +437,13 @@ fn C.sem_trywait(voidptr) int
 fn C.sem_timedwait(voidptr, voidptr) int
 fn C.sem_destroy(voidptr) int
 
+// MacOS semaphore functions
+fn C.dispatch_semaphore_create(i64) voidptr
+fn C.dispatch_semaphore_signal(voidptr) i64
+fn C.dispatch_semaphore_wait(voidptr, u64) i64
+fn C.dispatch_time(u64, i64) u64
+fn C.dispatch_release(voidptr)
+
 fn C.read(fd int, buf voidptr, count size_t) int
 fn C.write(fd int, buf voidptr, count size_t) int
 fn C.close(fd int) int

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -330,7 +330,7 @@ pub fn (mut ch Channel) try_pop(dest voidptr) TransactionState {
 }
 
 fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) TransactionState {
-	mut spinloops_sem_, spinloops_ := if no_block { spinloops, spinloops_sem } else { 1, 1 }
+	spinloops_sem_, spinloops_ := if no_block { spinloops, spinloops_sem } else { 1, 1 }
 	mut have_swapped := false
 	mut write_in_progress := false
 	for {

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -174,10 +174,7 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) TransactionState {
 	if C.atomic_load_u16(&ch.closed) != 0 {
 		return .closed
 	}
-	mut spinloops_sem_, spinloops_ := if no_block { spinloops, spinloops_sem } else { 1, 1 }
-	$if macos {
-		spinloops_sem_ = 1
-	}
+	spinloops_sem_, spinloops_ := if no_block { spinloops, spinloops_sem } else { 1, 1 }
 	mut have_swapped := false
 	for {
 		mut got_sem := false
@@ -334,9 +331,6 @@ pub fn (mut ch Channel) try_pop(dest voidptr) TransactionState {
 
 fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) TransactionState {
 	mut spinloops_sem_, spinloops_ := if no_block { spinloops, spinloops_sem } else { 1, 1 }
-	$if macos {
-		spinloops_sem_ = 1
-	}
 	mut have_swapped := false
 	mut write_in_progress := false
 	for {

--- a/vlib/sync/sync_nix.c.v
+++ b/vlib/sync/sync_nix.c.v
@@ -120,7 +120,7 @@ pub fn (s Semaphore) post() {
 
 pub fn (s Semaphore) wait() {
 	$if macos {
-		C.dispatch_semaphore_wait(s.sem, C.DISPATCH_TIME_FOREVER);
+		C.dispatch_semaphore_wait(s.sem, C.DISPATCH_TIME_FOREVER)
 	} $else {
 		unsafe { C.sem_wait(&&PosixSemaphore(s.sem).sem) }
 	}

--- a/vlib/sync/sync_nix.c.v
+++ b/vlib/sync/sync_nix.c.v
@@ -6,7 +6,19 @@ module sync
 import time
 
 #flag -lpthread
-#include <semaphore.h>
+#include <pthread.h>
+$if macos {
+	#include <dispatch/dispatch.h>
+} $else {
+	#include <semaphore.h>
+}
+
+// These are specific to MacOS
+fn C.dispatch_semaphore_create(i64) voidptr
+fn C.dispatch_semaphore_signal(voidptr) i64
+fn C.dispatch_semaphore_wait(voidptr, u64) i64
+fn C.dispatch_time(u64, i64) u64
+fn C.dispatch_release(voidptr)
 
 // [init_with=new_mutex] // TODO: implement support for this struct attribute, and disallow Mutex{} from outside the sync.new_mutex() function.
 [ref_only]
@@ -26,14 +38,10 @@ struct RwMutexAttr {
 
 /* MacOSX has no unnamed semaphores and no `timed_wait()` at all
    so we emulate the behaviour with other devices */
-[ref_only]
-struct MacOSX_Semaphore {
-	mtx C.pthread_mutex_t
-	cond C.pthread_cond_t
-	attr C.pthread_condattr_t
-mut:
-	count u32
-}
+// [ref_only]
+// struct MacOSX_Semaphore {
+// 	sem C.dispatch_semaphore_t
+// }
 
 [ref_only]
 struct PosixSemaphore {
@@ -42,7 +50,7 @@ struct PosixSemaphore {
 
 pub struct Semaphore {
 mut:
-	sem voidptr // since the above does not work, yet
+	sem voidptr
 }
 
 pub fn new_mutex() &Mutex {
@@ -98,12 +106,8 @@ pub fn new_semaphore() Semaphore {
 pub fn new_semaphore_init(n u32) Semaphore {
 	$if macos {
 		s := Semaphore{
-			sem: &MacOSX_Semaphore{count: n}
+			sem: C.dispatch_semaphore_create(n)
 		}
-		C.pthread_mutex_init(&&MacOSX_Semaphore(s.sem).mtx, C.NULL)
-		C.pthread_condattr_init(&&MacOSX_Semaphore(s.sem).attr)
-		C.pthread_condattr_setpshared(&&MacOSX_Semaphore(s.sem).attr, C.PTHREAD_PROCESS_PRIVATE)
-		C.pthread_cond_init(&&MacOSX_Semaphore(s.sem).cond, &&MacOSX_Semaphore(s.sem).attr)
 		return s
 	} $else {
 		s := Semaphore{
@@ -116,10 +120,7 @@ pub fn new_semaphore_init(n u32) Semaphore {
 
 pub fn (s Semaphore) post() {
 	$if macos {
-		C.pthread_mutex_lock(&&MacOSX_Semaphore(s.sem).mtx)
-		(&MacOSX_Semaphore(s.sem)).count++
-		C.pthread_cond_signal(&&MacOSX_Semaphore(s.sem).cond)
-		C.pthread_mutex_unlock(&&MacOSX_Semaphore(s.sem).mtx)
+		C.dispatch_semaphore_signal(s.sem)
 	} $else {
 		unsafe { C.sem_post(&&PosixSemaphore(s.sem).sem) }
 	}
@@ -127,12 +128,7 @@ pub fn (s Semaphore) post() {
 
 pub fn (s Semaphore) wait() {
 	$if macos {
-		C.pthread_mutex_lock(&&MacOSX_Semaphore(s.sem).mtx)
-		for &MacOSX_Semaphore(s.sem).count == 0 {
-			C.pthread_cond_wait(&&MacOSX_Semaphore(s.sem).cond, &&MacOSX_Semaphore(s.sem).mtx)
-		}
-		(&MacOSX_Semaphore(s.sem)).count--
-		C.pthread_mutex_unlock(&&MacOSX_Semaphore(s.sem).mtx)
+		C.dispatch_semaphore_wait(s.sem, C.DISPATCH_TIME_FOREVER);
 	} $else {
 		unsafe { C.sem_wait(&&PosixSemaphore(s.sem).sem) }
 	}
@@ -140,53 +136,26 @@ pub fn (s Semaphore) wait() {
 
 pub fn (s Semaphore) try_wait() bool {
 	$if macos {
-		t_spec := time.zero_timespec()
-		C.pthread_mutex_lock(&&MacOSX_Semaphore(s.sem).mtx)
-		for &MacOSX_Semaphore(s.sem).count == 0 {
-			res := C.pthread_cond_timedwait(&&MacOSX_Semaphore(s.sem).cond, &&MacOSX_Semaphore(s.sem).mtx, &t_spec)
-			if res == C.ETIMEDOUT {
-				break
-			}
-		}
-		mut res := false
-		if &MacOSX_Semaphore(s.sem).count > 0 { // success
-			(&MacOSX_Semaphore(s.sem)).count--
-			res = true
-		}
-		C.pthread_mutex_unlock(&&MacOSX_Semaphore(s.sem).mtx)
-		return res
+		return C.dispatch_semaphore_wait(s.sem, C.DISPATCH_TIME_NOW) == 0
 	} $else {
 		return unsafe { C.sem_trywait(&&PosixSemaphore(s.sem).sem) == 0 }
 	}
 }
 
 pub fn (s Semaphore) timed_wait(timeout time.Duration) bool {
-	t_spec := timeout.timespec()
 	$if macos {
-		C.pthread_mutex_lock(&&MacOSX_Semaphore(s.sem).mtx)
-		for &MacOSX_Semaphore(s.sem).count == 0 {
-			res := C.pthread_cond_timedwait(&&MacOSX_Semaphore(s.sem).cond, &&MacOSX_Semaphore(s.sem).mtx, &t_spec)
-			if res == C.ETIMEDOUT {
-				break
-			}
-		}
-		mut res := false
-		if &MacOSX_Semaphore(s.sem).count > 0 { // success
-			(&MacOSX_Semaphore(s.sem)).count--
-			res = true
-		}
-		C.pthread_mutex_unlock(&&MacOSX_Semaphore(s.sem).mtx)
-		return res
+		return C.dispatch_semaphore_wait(s.sem, C.dispatch_time(C.DISPATCH_TIME_NOW, i64(timeout))) == 0
 	} $else {
+		t_spec := timeout.timespec()
 		return unsafe { C.sem_timedwait(&&PosixSemaphore(s.sem).sem, &t_spec) == 0 }
 	}
 }
 
 pub fn (s Semaphore) destroy() bool {
 	$if macos {
-		return C.pthread_cond_destroy(&&MacOSX_Semaphore(s.sem).cond) == 0 &&
-			C.pthread_condattr_destroy(&&MacOSX_Semaphore(s.sem).attr) == 0 &&
-			C.pthread_mutex_destroy(&&MacOSX_Semaphore(s.sem).mtx) == 0
+		for s.try_wait() {}
+		C.dispatch_release(s.sem)
+		return true
 	} $else {
 		return unsafe { C.sem_destroy(&&PosixSemaphore(s.sem).sem) == 0 }
 	}

--- a/vlib/sync/sync_nix.c.v
+++ b/vlib/sync/sync_nix.c.v
@@ -6,19 +6,11 @@ module sync
 import time
 
 #flag -lpthread
-#include <pthread.h>
 $if macos {
 	#include <dispatch/dispatch.h>
 } $else {
 	#include <semaphore.h>
 }
-
-// These are specific to MacOS
-fn C.dispatch_semaphore_create(i64) voidptr
-fn C.dispatch_semaphore_signal(voidptr) i64
-fn C.dispatch_semaphore_wait(voidptr, u64) i64
-fn C.dispatch_time(u64, i64) u64
-fn C.dispatch_release(voidptr)
 
 // [init_with=new_mutex] // TODO: implement support for this struct attribute, and disallow Mutex{} from outside the sync.new_mutex() function.
 [ref_only]


### PR DESCRIPTION
Due to the lack of unnamed POSIX semaphores on MacOSX, I had implemented a (probably slow) emulation based on a condition variable and a mutex. It turned out that there *are* so called *dispatch semaphores* that have an interface quite similar to POSIX semaphores.

This PR replaces the emulation with a dispatch semaphore which significantly simplifies the implementation. Unfortunately, I cannot test this on real hardware (due to lack of ownership ;-) but the test cases seem ok.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
