### PR TITLE
cgen: fix assigning ArrayInit to fixed array: `a = [3]int`

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -735,11 +735,11 @@ pub:
 	elem_type_pos   token.Position
 	exprs           []Expr
 	is_fixed        bool
-	has_val         bool
+	has_val         bool // fixed size literal `[expr, expr]!!`
 	mod             string
 	len_expr        Expr
 	cap_expr        Expr
-	default_expr    Expr
+	default_expr    Expr // init: expr
 	has_len         bool
 	has_cap         bool
 	has_default     bool

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -177,7 +177,7 @@ pub fn (lit &StringInterLiteral) get_fspec_braces(i int) (string, bool) {
 	return res.join(''), needs_braces
 }
 
-// string representaiton of expr
+// string representation of expr
 pub fn (x Expr) str() string {
 	match x {
 		BoolLiteral {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1917,7 +1917,7 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) table.Type {
 						fixed_size = cint
 					}
 				} else {
-					c.error('non existant integer const $full_const_name while initializing the size of a static array',
+					c.error('non existent integer const $full_const_name while initializing the size of a static array',
 						array_init.pos)
 				}
 			}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1401,11 +1401,25 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 			}
 		} else if right_sym.kind == .array_fixed && assign_stmt.op == .assign {
 			right := val as ast.ArrayInit
-			for j, expr in right.exprs {
-				g.expr(left)
-				g.write('[$j] = ')
-				g.expr(expr)
-				g.writeln(';')
+			if right.has_val {
+				for j, expr in right.exprs {
+					g.expr(left)
+					g.write('[$j] = ')
+					g.expr(expr)
+					g.writeln(';')
+				}
+			} else {
+				af := right_sym.info as table.ArrayFixed
+				for j in 0 .. af.size {
+					g.expr(left)
+					g.write('[$j] = ')
+					if right.has_default {
+						g.expr(right.default_expr)
+					} else {
+						g.write(g.type_default(right.elem_type))
+					}
+					g.writeln(';')
+				}
 			}
 		} else {
 			g.assign_op = assign_stmt.op

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1409,8 +1409,8 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					g.writeln(';')
 				}
 			} else {
-				af := right_sym.info as table.ArrayFixed
-				for j in 0 .. af.size {
+				fixed_array := right_sym.info as table.ArrayFixed
+				for j in 0 .. fixed_array.size {
 					g.expr(left)
 					g.write('[$j] = ')
 					if right.has_default {

--- a/vlib/v/tests/fixed_array_test.v
+++ b/vlib/v/tests/fixed_array_test.v
@@ -1,8 +1,11 @@
 fn test_fixed_array_can_be_assigned() {
 	x := 2.32
 	mut v := [8]f64
+	assert v[1] == 0
 	v = [1.0, x, 3.0,4.0,5.0,6.0,7.0,8.0]!!
 	assert v[1] == x
+	v = [8]f64
+	assert v[1] == 0
 }
 
 fn test_fixed_array_can_be_used_in_declaration() {


### PR DESCRIPTION
Before `a = [3]int` generated `a[0] = 3`, with this pull `a` is set to `[0,0,0]`.