### PR TITLE
checker: change error msg for str assign

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3091,7 +3091,7 @@ pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) table.Type {
 		c.error('type `$typ_sym.name` does not support indexing', node.pos)
 	}
 	if typ_sym.kind == .string && !typ.is_ptr() && node.is_setter {
-		c.error('cannot assign to s[i] (strings are immutable)', node.pos)
+		c.error('variables may be mutable but string values are always immutable', node.pos)
 	}
 	if !c.inside_unsafe && (typ.is_ptr() || typ.is_pointer()) {
 		mut is_ok := false

--- a/vlib/v/checker/tests/string_index_assign_error.out
+++ b/vlib/v/checker/tests/string_index_assign_error.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/string_index_assign_error.v:3:6: error: cannot assign to s[i] (strings are immutable)
+vlib/v/checker/tests/string_index_assign_error.v:3:6: error: variables may be mutable but string values are always immutable
     1 | fn main() {
     2 |     mut a := 'V is great!!'
     3 |     a[0] = `R`


### PR DESCRIPTION
As per discused in the discord server. The message is now changed to `variables may be mutable but string values are always immutable` to avoid confusions.