### PR TITLE
checker: forbid aliasing an alias

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -268,7 +268,7 @@ pub fn (mut c Checker) type_decl(node ast.TypeDecl) {
 				c.error("type `$typ_sym.name` doesn't exist", node.pos)
 			} else if typ_sym.kind == .alias {
 				orig_sym := c.table.get_type_symbol((typ_sym.info as table.Alias).parent_type)
-				c.error('type `$typ_sym.name` is an alias, alias original type `$orig_sym.name` instead',
+				c.error('type `$typ_sym.name` is an alias, use the original alias type `$orig_sym.name` instead',
 					node.pos)
 			}
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -266,6 +266,10 @@ pub fn (mut c Checker) type_decl(node ast.TypeDecl) {
 			typ_sym := c.table.get_type_symbol(node.parent_type)
 			if typ_sym.kind == .placeholder {
 				c.error("type `$typ_sym.name` doesn't exist", node.pos)
+			} else if typ_sym.kind == .alias {
+				orig_sym := c.table.get_type_symbol((typ_sym.info as table.Alias).parent_type)
+				c.error('type `$typ_sym.name` is an alias, alias original type `$orig_sym.name` instead',
+					node.pos)
 			}
 		}
 		ast.FnTypeDecl {

--- a/vlib/v/checker/tests/nested_aliases.out
+++ b/vlib/v/checker/tests/nested_aliases.out
@@ -1,0 +1,4 @@
+vlib/v/checker/tests/nested_aliases.v:2:1: error: type `MyInt` is an alias, alias original type `int` instead
+    1 | type MyInt = int
+    2 | type MyMyInt = MyInt
+      | ~~~~~~~~~~~~

--- a/vlib/v/checker/tests/nested_aliases.out
+++ b/vlib/v/checker/tests/nested_aliases.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/nested_aliases.v:2:1: error: type `MyInt` is an alias, alias original type `int` instead
+vlib/v/checker/tests/nested_aliases.v:2:1: error: type `MyInt` is an alias, use the original alias type `int` instead
     1 | type MyInt = int
     2 | type MyMyInt = MyInt
       | ~~~~~~~~~~~~

--- a/vlib/v/checker/tests/nested_aliases.vv
+++ b/vlib/v/checker/tests/nested_aliases.vv
@@ -1,0 +1,2 @@
+type MyInt = int
+type MyMyInt = MyInt


### PR DESCRIPTION
~~This PR allows multiple "layers" of aliases.~~
```
type MyInt int
type MyMyint MyInt
```
~~`MyMyInt` will still be considered an `int`, its `str` method will be correctly generated, and operations can be made on it.~~

Add an error when aliasing a type that is already an alias.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
