### PR TITLE
cgen: support `==`, `!=` on FixedArray

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2117,6 +2117,23 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 		}
 		g.expr(node.right)
 		g.write(')')
+	} else if node.op in [.eq, .ne] &&
+		left_sym.kind == .array_fixed && right_sym.kind == .array_fixed {
+		g.write('(memcmp(')
+		g.expr(node.left)
+		g.write(', ')
+		if node.right is ast.ArrayInit {
+			verror('`==` with fixed array initializer/literal not supported yet')
+		}
+		g.expr(node.right)
+		g.write(', sizeof(')
+		g.expr(node.left)
+		if node.op == .eq {
+			g.write(')) == 0')
+		} else if node.op == .ne {
+			g.write(')) != 0')
+		}
+		g.write(')')
 	} else if node.op in [.eq, .ne] && left_sym.kind == .map && right_sym.kind == .map {
 		ptr_typ := g.gen_map_equality_fn(left_type)
 		if node.op == .eq {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2119,6 +2119,11 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 		g.write(')')
 	} else if node.op in [.eq, .ne] &&
 		left_sym.kind == .array_fixed && right_sym.kind == .array_fixed {
+		af := left_sym.info as table.ArrayFixed
+		et := af.elem_type
+		if !et.is_ptr() && !et.is_pointer() && !et.is_number() && et.idx() !in [table.bool_type_idx, table.char_type_idx] {
+			verror('`==` on fixed array only supported with POD element types ATM')
+		}
 		g.write('(memcmp(')
 		g.expr(node.left)
 		g.write(', ')

--- a/vlib/v/tests/fixed_array_init_test.v
+++ b/vlib/v/tests/fixed_array_init_test.v
@@ -31,3 +31,14 @@ fn test_fixed_array_init() {
 	assert typeof(d2) == '[3]f32'
 	assert '$d2' == '[1.1, 2.2, 3.3]'
 }
+
+fn test_fixed_type_init() {
+	a := [2]int
+	assert typeof(a) == '[2]int'
+	lit := [0,0]!!
+	assert a == lit
+	b := [2]int
+	assert a == b
+	c := [3,3]!!
+	assert b != c
+}

--- a/vlib/v/tests/fixed_array_init_test.v
+++ b/vlib/v/tests/fixed_array_init_test.v
@@ -34,11 +34,9 @@ fn test_fixed_array_init() {
 
 fn test_fixed_type_init() {
 	a := [2]int
-	assert typeof(a) == '[2]int'
-	lit := [0,0]!!
-	assert a == lit
-	b := [2]int
-	assert a == b
+	assert a == [2]int
+	assert a == [0,0]!!
+	assert a == a
 	c := [3,3]!!
-	assert b != c
+	assert a != c
 }

--- a/vlib/v/tests/fixed_array_init_test.v
+++ b/vlib/v/tests/fixed_array_init_test.v
@@ -39,4 +39,5 @@ fn test_fixed_type_init() {
 	assert a == a
 	c := [3,3]!!
 	assert a != c
+	assert c == [3,3]!!
 }

--- a/vlib/v/tests/fixed_array_test.v
+++ b/vlib/v/tests/fixed_array_test.v
@@ -23,6 +23,7 @@ fn test_fixed_array_can_be_assigned_to_a_struct_field() {
 	ctx.vb = [1.1, x, 3.3, 4.4, 5.0, 6.0, 7.0, 8.9]!!
 	assert ctx.vb[1] == x
 	assert ctx.vb[7] == 8.9
+	assert ctx.vb == ctx.vb
 	/*
 	println( ctx.vb[0] )
 	println( ctx.vb[1] )


### PR DESCRIPTION
This pull only supports element types that can be compared bit-for-bit, otherwise an error is printed.