### PR TITLE
fmt: fix keep anon fn call

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1456,7 +1456,6 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 		f.or_expr(node.or_block)
 	} else {
 		f.write_language_prefix(node.language)
-
 		if node.left is ast.AnonFn as anon_fn {
 			f.fn_decl(anon_fn.decl)
 		} else {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1456,12 +1456,17 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 		f.or_expr(node.or_block)
 	} else {
 		f.write_language_prefix(node.language)
-		mut name := f.short_module(node.name)
-		f.mark_module_as_used(name)
-		if node.name in f.mod2alias {
-			name = f.mod2alias[node.name]
+
+		if node.left is ast.AnonFn as anon_fn {
+			f.fn_decl(anon_fn.decl)
+		} else {
+			mut name := f.short_module(node.name)
+			f.mark_module_as_used(name)
+			if node.name in f.mod2alias {
+				name = f.mod2alias[node.name]
+			}
+			f.write('$name')
 		}
-		f.write('$name')
 		if node.generic_type != 0 && node.generic_type != table.void_type {
 			f.write('<')
 			f.write(f.type_to_str(node.generic_type))

--- a/vlib/v/fmt/tests/anon_fn_call_keep.vv
+++ b/vlib/v/fmt/tests/anon_fn_call_keep.vv
@@ -1,7 +1,7 @@
 fn main() {
-	fn() {
+	fn () {
 		for {
-			println("Hello V!")
+			println('Hello V!')
 		}
 	}()
 }

--- a/vlib/v/fmt/tests/anon_fn_call_keep.vv
+++ b/vlib/v/fmt/tests/anon_fn_call_keep.vv
@@ -1,0 +1,7 @@
+fn main() {
+	fn() {
+		for {
+			println("Hello V!")
+		}
+	}()
+}


### PR DESCRIPTION
before:
```v
fn () {}()
```
got:
```v
anon()
```