### PR TITLE
all: add builtin channel type `chan elem_type`

### DIFF
--- a/vlib/sync/channel_array_mut_test.v
+++ b/vlib/sync/channel_array_mut_test.v
@@ -1,0 +1,36 @@
+import sync
+
+const (
+	num_iterations = 10000
+)
+
+struct St {
+mut:
+	n int
+}
+
+// this function gets an array of channels for `St` references
+fn do_rec_calc_send(chs []chan mut St) {
+	mut s := St{}
+	for {
+		if !(&sync.Channel(chs[0])).pop(&s) {
+			break
+		}
+		s.n++
+		(&sync.Channel(chs[1])).push(&s)
+	}
+}
+
+fn test_channel_array_mut() {
+	mut chs := [chan mut St{cap: 1}, chan mut St{}]
+	go do_rec_calc_send(chs)
+	mut t := St{
+		n: 100
+	}
+	for _ in 0 .. num_iterations {
+		(&sync.Channel(chs[0])).push(&t)
+		(&sync.Channel(chs[1])).pop(&t)
+	}
+	(&sync.Channel(chs[0])).close()
+	assert t.n == 100 + num_iterations
+}

--- a/vlib/sync/channel_select_2_test.v
+++ b/vlib/sync/channel_select_2_test.v
@@ -1,6 +1,6 @@
 import sync
 
-fn do_rec_i64(ch chan[i64]) {
+fn do_rec_i64(ch chan i64) {
 	mut sum := i64(0)
 	for _ in 0 .. 300 {
 		mut a := i64(0)
@@ -10,13 +10,13 @@ fn do_rec_i64(ch chan[i64]) {
 	assert sum == 300 * (300 - 1) / 2
 }
 
-fn do_send_int(ch chan[int]) {
+fn do_send_int(ch chan int) {
 	for i in 0 .. 300 {
 		(&sync.Channel(ch)).push(&i)
 	}
 }
 
-fn do_send_byte(ch chan[byte]) {
+fn do_send_byte(ch chan byte) {
 	for i in 0 .. 300 {
 		ii := byte(i)
 		(&sync.Channel(ch)).push(&ii)
@@ -31,10 +31,10 @@ fn do_send_i64(mut ch sync.Channel) {
 }
 
 fn test_select() {
-	chi := chan[int]{}
+	chi := chan int{}
 	mut chl := sync.new_channel<i64>(1)
-	chb := chan[byte]{cap: 10}
-	recch := chan[i64]{cap: 0}
+	chb := chan byte{cap: 10}
+	recch := chan i64{cap: 0}
 	go do_rec_i64(recch)
 	go do_send_int(chi)
 	go do_send_byte(chb)

--- a/vlib/sync/channel_select_2_test.v
+++ b/vlib/sync/channel_select_2_test.v
@@ -1,0 +1,76 @@
+import sync
+
+fn do_rec_i64(ch chan[i64]) {
+	mut sum := i64(0)
+	for _ in 0 .. 300 {
+		mut a := i64(0)
+		(&sync.Channel(ch)).pop(&a)
+		sum += a
+	}
+	assert sum == 300 * (300 - 1) / 2
+}
+
+fn do_send_int(ch chan[int]) {
+	for i in 0 .. 300 {
+		(&sync.Channel(ch)).push(&i)
+	}
+}
+
+fn do_send_byte(ch chan[byte]) {
+	for i in 0 .. 300 {
+		ii := byte(i)
+		(&sync.Channel(ch)).push(&ii)
+	}
+}
+
+fn do_send_i64(mut ch sync.Channel) {
+	for i in 0 .. 300 {
+		ii := i64(i)
+		ch.push(&ii)
+	}
+}
+
+fn test_select() {
+	chi := chan[int]{}
+	mut chl := sync.new_channel<i64>(1)
+	chb := chan[byte]{cap: 10}
+	recch := chan[i64]{cap: 0}
+	go do_rec_i64(recch)
+	go do_send_int(chi)
+	go do_send_byte(chb)
+	go do_send_i64(mut chl)
+	mut channels := [&sync.Channel(chi), &sync.Channel(recch), chl, &sync.Channel(chb)]
+	directions := [sync.Direction.pop, .push, .pop, .pop]
+	mut sum := i64(0)
+	mut rl := i64(0)
+	mut ri := int(0)
+	mut rb := byte(0)
+	mut sl := i64(0)
+	mut objs := [voidptr(&ri), &sl, &rl, &rb]
+	for _ in 0 .. 1200 {
+		idx := sync.channel_select(mut channels, directions, mut objs, -1)
+		match idx {
+			0 {
+				sum += ri
+			}
+			1 {
+				sl++
+			}
+			2 {
+				sum += rl
+			}
+			3 {
+				sum += rb
+			}
+			else {
+				println('got $idx (timeout)')
+			}
+		}
+	}
+	// Use Gauß' formula for the first 2 contributions
+	expected_sum :=  2 * (300 * (300 - 1) / 2) +
+		// the 3rd contribution is `byte` and must be seen modulo 256
+		256 * (256 - 1) / 2 +
+		44 * (44 - 1) / 2
+	assert sum == expected_sum
+}

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -111,6 +111,10 @@ pub:
 
 pub fn new_channel<T>(n u32) &Channel {
 	st := sizeof(T)
+	return new_channel_st(n, st)
+}
+
+fn new_channel_st(n u32, st u32) &Channel {
 	return &Channel{
 		writesem: new_semaphore_init(if n > 0 { n + 1 } else { 1 })
 		readsem:  new_semaphore_init(if n > 0 { u32(0) } else { 1 })

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -10,7 +10,7 @@ import v.errors
 pub type TypeDecl = AliasTypeDecl | FnTypeDecl | SumTypeDecl
 
 pub type Expr = AnonFn | ArrayInit | AsCast | Assoc | BoolLiteral | CallExpr | CastExpr |
-	CharLiteral | Comment | ComptimeCall | ConcatExpr | EnumVal | FloatLiteral | Ident | IfExpr |
+	CharLiteral | ChanInit | Comment | ComptimeCall | ConcatExpr | EnumVal | FloatLiteral | Ident | IfExpr |
 	IfGuardExpr | IndexExpr | InfixExpr | IntegerLiteral | Likely | LockExpr | MapInit | MatchExpr |
 	None | OrExpr | ParExpr | PostfixExpr | PrefixExpr | RangeExpr | SelectorExpr | SizeOf |
 	SqlExpr | StringInterLiteral | StringLiteral | StructInit | Type | TypeOf | UnsafeExpr
@@ -749,6 +749,16 @@ pub mut:
 	interface_type  table.Type // Animal
 	elem_type       table.Type
 	typ             table.Type
+}
+
+pub struct ChanInit {
+pub:
+	pos        token.Position
+	cap_expr   Expr
+	has_cap    bool
+pub mut:
+	typ        table.Type
+	elem_type  table.Type
 }
 
 pub struct MapInit {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2338,6 +2338,9 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 		ast.CallExpr {
 			return c.call_expr(mut node)
 		}
+		ast.ChanInit {
+			return c.chan_init(mut node)
+		}
 		ast.CharLiteral {
 			return table.byte_type
 		}
@@ -3187,6 +3190,17 @@ pub fn (mut c Checker) enum_val(mut node ast.EnumVal) table.Type {
 	}
 	node.typ = typ
 	return typ
+}
+
+pub fn (mut c Checker) chan_init(mut node ast.ChanInit) table.Type {
+	if node.typ != 0 {
+		info := c.table.get_type_symbol(node.typ).chan_info()
+		node.elem_type = info.elem_type
+		return node.typ
+	} else {
+		c.error('`chan` of unknown type', node.pos)
+		return node.typ
+	}
 }
 
 pub fn (mut c Checker) map_init(mut node ast.MapInit) table.Type {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -799,6 +799,16 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 		ast.CallExpr {
 			f.call_expr(node)
 		}
+		ast.ChanInit {
+			f.write('chan[')
+			f.write(f.type_to_str(node.elem_type))
+			f.write(']{')
+			if node.has_cap {
+				f.write('cap: ')
+				f.expr(it.cap_expr)
+			}
+			f.write('}')
+		}
 		ast.CharLiteral {
 			f.write('`$node.val`')
 		}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -805,7 +805,7 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 			f.write(']{')
 			if node.has_cap {
 				f.write('cap: ')
-				f.expr(it.cap_expr)
+				f.expr(node.cap_expr)
 			}
 			f.write('}')
 		}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -497,6 +497,10 @@ typedef struct {
 			.interface_ {
 				g.type_definitions.writeln('typedef _Interface ${c_name(typ.name)};')
 			}
+			.chan {
+				styp := util.no_dots(typ.name)
+				g.type_definitions.writeln('typedef chan $styp;')
+			}
 			.map {
 				styp := util.no_dots(typ.name)
 				g.type_definitions.writeln('typedef map $styp;')
@@ -1769,6 +1773,18 @@ fn (mut g Gen) expr(node ast.Expr) {
 				g.expr(node.expr)
 				g.write('))')
 			}
+		}
+		ast.ChanInit {
+			elem_typ_str := g.typ(node.elem_type)
+			g.write('sync__new_channel_st(')
+			if node.has_cap {
+				g.expr(node.cap_expr)
+			} else {
+				g.write('0')
+			}
+			g.write(', sizeof(')
+			g.write(elem_typ_str)
+			g.write('))')
 		}
 		ast.CharLiteral {
 			g.write("'$node.val'")

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -415,6 +415,8 @@ typedef map map_string;
 typedef byte array_fixed_byte_300 [300];
 typedef byte array_fixed_byte_400 [400];
 
+typedef struct sync__Channel* chan;
+
 #ifndef __cplusplus
 	#ifndef bool
 		typedef int bool;

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -232,6 +232,9 @@ pub fn (mut g JsGen) typ(t table.Type) string {
 			info := sym.info as table.ArrayFixed
 			styp = g.typ(info.elem_type) + '[]'
 		}
+		.chan {
+			styp = 'chan'
+		}
 		// 'map[string]int' => 'Map<string, number>'
 		.map {
 			info := sym.info as table.Map
@@ -532,6 +535,9 @@ fn (mut g JsGen) expr(node ast.Expr) {
 		}
 		ast.CallExpr {
 			g.gen_call_expr(node)
+		}
+		ast.ChanInit {
+			// TODO
 		}
 		ast.CastExpr {
 			// JS has no types, so no need to cast

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -53,12 +53,7 @@ pub fn (mut p Parser) parse_map_type() table.Type {
 
 pub fn (mut p Parser) parse_chan_type() table.Type {
 	p.next()
-	if p.tok.kind != .lsbr {
-		return table.chan_type
-	}
-	p.check(.lsbr)
 	elem_type := p.parse_type()
-	p.check(.rsbr)
 	idx := p.table.find_or_register_chan(elem_type)
 	return table.new_type(idx)
 }

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -51,6 +51,18 @@ pub fn (mut p Parser) parse_map_type() table.Type {
 	return table.new_type(idx)
 }
 
+pub fn (mut p Parser) parse_chan_type() table.Type {
+	p.next()
+	if p.tok.kind != .lsbr {
+		return table.chan_type
+	}
+	p.check(.lsbr)
+	elem_type := p.parse_type()
+	p.check(.rsbr)
+	idx := p.table.find_or_register_chan(elem_type)
+	return table.new_type(idx)
+}
+
 pub fn (mut p Parser) parse_multi_return_type() table.Type {
 	p.check(.lpar)
 	mut mr_types := []table.Type{}
@@ -210,6 +222,9 @@ pub fn (mut p Parser) parse_any_type(language table.Language, is_ptr, check_dot 
 			// no defer
 			if name == 'map' {
 				return p.parse_map_type()
+			}
+			if name == 'chan' {
+				return p.parse_chan_type()
 			}
 			defer {
 				p.next()

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -959,7 +959,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 		}
 	}
 	// `chan[typ]{...}`
-	if p.tok.lit == 'chan' && p.peek_tok.kind == .lsbr {
+	if p.tok.lit == 'chan' {
 		first_pos := p.tok.position()
 		mut last_pos := p.tok.position()
 		chan_type := p.parse_chan_type()

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -958,7 +958,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 			typ: map_type
 		}
 	}
-	// `chan[typ]{...}`
+	// `chan typ{...}`
 	if p.tok.lit == 'chan' {
 		first_pos := p.tok.position()
 		mut last_pos := p.tok.position()

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -15,7 +15,7 @@ import strings
 
 pub type Type int
 
-pub type TypeInfo = Alias | Array | ArrayFixed | Enum | FnType | GenericStructInst | Interface |
+pub type TypeInfo = Alias | Array | ArrayFixed | Chan | Enum | FnType | GenericStructInst | Interface |
 	Map | MultiReturn | Struct | SumType
 
 pub enum Language {
@@ -253,10 +253,11 @@ pub const (
 	ustring_type_idx = 19
 	array_type_idx   = 20
 	map_type_idx     = 21
-	any_type_idx     = 22
+	chan_type_idx    = 22
+	any_type_idx     = 23
 	// t_type_idx       = 23
-	any_flt_type_idx = 23
-	any_int_type_idx = 24
+	any_flt_type_idx = 24
+	any_int_type_idx = 25
 )
 
 pub const (
@@ -293,6 +294,7 @@ pub const (
 	ustring_type = new_type(ustring_type_idx)
 	array_type   = new_type(array_type_idx)
 	map_type     = new_type(map_type_idx)
+	chan_type    = new_type(chan_type_idx)
 	any_type     = new_type(any_type_idx)
 	// t_type       = new_type(t_type_idx)
 	any_flt_type = new_type(any_flt_type_idx)
@@ -302,7 +304,7 @@ pub const (
 pub const (
 	builtin_type_names = ['void', 'voidptr', 'charptr', 'byteptr', 'i8', 'i16', 'int', 'i64', 'u16',
 		'u32', 'u64', 'any_int', 'f32', 'f64', 'any_float', 'string', 'ustring', 'char', 'byte', 'bool',
-		'none', 'array', 'array_fixed', 'map', 'any', 'struct', 'mapnode', 'size_t']
+		'none', 'array', 'array_fixed', 'map', 'chan', 'any', 'struct', 'mapnode', 'size_t']
 )
 
 pub struct MultiReturn {
@@ -342,6 +344,7 @@ pub enum Kind {
 	array
 	array_fixed
 	map
+	chan
 	any
 	struct_
 	generic_struct_inst
@@ -388,6 +391,14 @@ pub fn (t &TypeSymbol) array_fixed_info() ArrayFixed {
 	match t.info {
 		ArrayFixed { return *it }
 		else { panic('TypeSymbol.array_fixed(): no array fixed info for type: $t.name') }
+	}
+}
+
+[inline]
+pub fn (t &TypeSymbol) chan_info() Chan {
+	match t.info {
+		Chan { return *it }
+		else { panic('TypeSymbol.chan_info(): no chan info for type: $t.name') }
 	}
 }
 
@@ -525,6 +536,11 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
+		kind: .chan
+		name: 'chan'
+		mod: 'builtin'
+	})
+	t.register_type_symbol({
 		kind: .any
 		name: 'any'
 		mod: 'builtin'
@@ -616,6 +632,7 @@ pub fn (k Kind) str() string {
 		.array { 'array' }
 		.array_fixed { 'array_fixed' }
 		.map { 'map' }
+		.chan { 'chan' }
 		.multi_return { 'multi_return' }
 		.sum_type { 'sum_type' }
 		.alias { 'alias' }
@@ -706,6 +723,11 @@ pub:
 	size      int
 pub mut:
 	elem_type Type
+}
+
+pub struct Chan {
+pub mut:
+	elem_type   Type
 }
 
 pub struct Map {

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -321,12 +321,38 @@ pub fn (t &Table) array_fixed_name(elem_type Type, size, nr_dims int) string {
 }
 
 [inline]
+pub fn (t &Table) chan_name(elem_type Type) string {
+	elem_type_sym := t.get_type_symbol(elem_type)
+	suffix := if elem_type.is_ptr() { '_ptr' } else { '' }
+	return 'chan_$elem_type_sym.name' + suffix
+}
+
+[inline]
 pub fn (t &Table) map_name(key_type, value_type Type) string {
 	key_type_sym := t.get_type_symbol(key_type)
 	value_type_sym := t.get_type_symbol(value_type)
 	suffix := if value_type.is_ptr() { '_ptr' } else { '' }
 	return 'map_${key_type_sym.name}_$value_type_sym.name' + suffix
 	// return 'map_${value_type_sym.name}' + suffix
+}
+
+pub fn (mut t Table) find_or_register_chan(elem_type Type) int {
+	name := t.chan_name(elem_type)
+	// existing
+	existing_idx := t.type_idxs[name]
+	if existing_idx > 0 {
+		return existing_idx
+	}
+	// register
+	chan_typ := TypeSymbol{
+		parent_idx: chan_type_idx
+		kind: .chan
+		name: name
+		info: Chan{
+			elem_type: elem_type
+		}
+	}
+	return t.register_type_symbol(chan_typ)
 }
 
 pub fn (mut t Table) find_or_register_map(key_type, value_type Type) int {


### PR DESCRIPTION
This PR is step 1.1 towards channel support in the `V` core language. The original syntax proposal leading to a hot discussion can be found below. Now the PR introduces:

- a new type class `chan elem_type` is available (similar to Go's channels)
- a channel can be initialized as
    ```v
    ch1 := chan int{}           // unbuffered
    ch2 := chan St{cap: 100}    // buffer queue of 100 elements
    ch3 := chan string{cap: 0}  // unbuffered
    chs := chan mut St{cap: 10} // buffered channels of `St` references
    ```
    There is no `mut` keyword in the declaration for the channel itself (but internally a channel is a reference like in `Go`)
- in an argument list the type is used without `cap` specification:
    ```v
    fn f(ch chan int) { ... }
    fn g(chs []chan mut St) { ... } // array of channels of `St` references
    ```
- in a call expression like a simple variable
    ```v
    go f(ch1)
   ```
- since methods for channels are not builtin, yet, every call requires an explicit conversion like `(&sync.Channel(ch)).push(&x)` for now. This is going to change, of cause.


#### Syntax proposal of original PR (outdated, but the discussion refers to this):

- a new type class `chan[elem_type]` is available (similar to `map[key_type]val_type`)
- a channel can be initialized as
    ```v
    ch1 := chan[int]{}          // unbuffered
    ch2 := chan[St]{cap: 100}   // buffer queue of 100 elements
    ch3 := chan[string]{cap: 0} // unbuffered
    ```
    There is no `mut` keyword in the declaration (but internally a channel is a reference like in `Go`)
- in an argument list the type is used without `cap` specification:
    ```v
    fn f(ch chan[int]) { ... }
    ```
- in a call expression like a simple variable
    ```v
    go f(ch1)
   ```
- since methods for channels are not builtin, yet, every call requires an explicit conversion like `(&sync.Channel(ch)).push(&x)` for now. This is going to change, of cause.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
