### PR TITLE
builder: only include `os` when building `.vsh` files

### DIFF
--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -67,7 +67,7 @@ pub fn new_builder(pref &pref.Preferences) Builder {
 // parse all deps from already parsed files
 pub fn (mut b Builder) parse_imports() {
 	mut done_imports := []string{}
-	if b.pref.is_script {
+	if b.pref.is_vsh {
 		done_imports << 'os'
 	}
 	// TODO (joe): decide if this is correct solution.
@@ -178,7 +178,7 @@ pub fn (b &Builder) import_graph() &depgraph.DepGraph {
 			deps << 'builtin'
 			if b.pref.backend == .c {
 				// TODO JavaScript backend doesn't handle os for now
-				if b.pref.is_script && p.mod.name != 'os' {
+				if b.pref.is_vsh && p.mod.name != 'os' {
 					deps << 'os'
 				}
 			}

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -184,7 +184,7 @@ pub fn (v Builder) get_builtin_files() []string {
 			}
 			if v.pref.backend == .c {
 				// TODO JavaScript backend doesn't handle os for now
-				if v.pref.is_script && os.exists(os.join_path(location, 'os')) {
+				if v.pref.is_vsh && os.exists(os.join_path(location, 'os')) {
 					builtin_files << v.v_files_from_dir(os.join_path(location, 'os'))
 				}
 			}

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -60,7 +60,8 @@ pub fn (mut p Preferences) fill_with_defaults() {
 		p.ccompiler = default_c_compiler()
 	}
 	p.is_test = p.path.ends_with('_test.v') || p.path.ends_with('.vv')
-	p.is_script = p.path.ends_with('.v') || p.path.ends_with('.vsh')
+	p.is_vsh = p.path.ends_with('.vsh')
+	p.is_script = p.is_vsh || p.path.ends_with('.v')
 	if p.third_party_option == '' {
 		p.third_party_option = p.cflags
 		$if !windows {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -55,6 +55,7 @@ pub mut:
 	// nofmt            bool   // disable vfmt
 	is_test             bool // `v test string_test.v`
 	is_script           bool // single file mode (`v program.v`), main function can be skipped
+	is_vsh              bool // v script (`file.vsh`) file, the `os` module should be made global
 	is_livemain         bool // main program that contains live/hot code
 	is_liveshared       bool // a shared library, that will be used in a -live main program
 	is_shared           bool // an ordinary shared library, -shared, no matter if it is live or not


### PR DESCRIPTION


<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
