### PR TITLE
parser: warn when fixed-size ArrayInit doesn't have trailing `{}`.

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -301,7 +301,7 @@ struct Foooj {
 }
 
 fn test_fixed() {
-	mut nums := [4]int
+	mut nums := [4]int{}
 	//x := nums[1..3]
 	//assert x.len == 2
 	assert nums[0] == 0
@@ -310,7 +310,7 @@ fn test_fixed() {
 	assert nums[3] == 0
 	nums[1] = 7
 	assert nums[1] == 7
-	nums2 := [5]int // c_n
+	nums2 := [5]int{} // c_n
 	assert nums2[c_n - 1] == 0
 }
 

--- a/vlib/builtin/builtin_nix.c.v
+++ b/vlib/builtin/builtin_nix.c.v
@@ -48,7 +48,7 @@ fn print_backtrace_skipping_top_frames(xskipframes int) bool {
 // so there is no need to have their twins in builtin_windows.v
 fn print_backtrace_skipping_top_frames_mac(skipframes int) bool {
 	$if macos {
-		buffer := [100]byteptr
+		buffer := [100]byteptr{}
 		nr_ptrs := C.backtrace(buffer, 100)
 		if nr_ptrs < 2 {
 			eprintln('C.backtrace returned less than 2 frames')
@@ -61,7 +61,7 @@ fn print_backtrace_skipping_top_frames_mac(skipframes int) bool {
 
 fn print_backtrace_skipping_top_frames_freebsd(skipframes int) bool {
 	$if freebsd {
-		buffer := [100]byteptr
+		buffer := [100]byteptr{}
 		nr_ptrs := C.backtrace(buffer, 100)
 		if nr_ptrs < 2 {
 			eprintln('C.backtrace returned less than 2 frames')
@@ -87,7 +87,7 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 		C.tcc_backtrace("Backtrace")
 		return false
 	}
-	buffer := [100]byteptr
+	buffer := [100]byteptr{}
 	nr_ptrs := C.backtrace(buffer, 100)
 	if nr_ptrs < 2 {
 		eprintln('C.backtrace returned less than 2 frames')
@@ -111,7 +111,7 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 			eprintln(sframe)
 			continue
 		}
-		buf := [1000]byte
+		buf := [1000]byte{}
 		mut output := ''
 		for C.fgets(charptr(buf), 1000, f) != 0 {
 			output += tos(byteptr(buf), vstrlen(byteptr(buf)))

--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -86,7 +86,7 @@ fn print_backtrace_skipping_top_frames(skipframes int) bool {
 fn print_backtrace_skipping_top_frames_msvc(skipframes int) bool {
 $if msvc {
 	mut offset := u64(0)
-	backtraces := [100]voidptr
+	backtraces := [100]voidptr{}
 	sic := SymbolInfoContainer{}
 	mut si := &sic.syminfo
 	si.f_size_of_struct = sizeof(SymbolInfo) // Note: C.SYMBOL_INFO is 88

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -271,7 +271,7 @@ pub fn (n int) hex1() string {
 [inline]
 fn u64_to_hex(nn u64, len byte) string {
 	mut n := nn
-	mut buf := [256]byte
+	mut buf := [256]byte{}
 	buf[len] = `\0`
 	mut i := 0
 	for i=len-1; i>=0; i-- {
@@ -289,7 +289,7 @@ fn u64_to_hex(nn u64, len byte) string {
 [inline]
 fn u64_to_hex_no_leading_zeros(nn u64, len byte) string {
 	mut n := nn
-	mut buf := [256]byte
+	mut buf := [256]byte{}
 	buf[len] = `\0`
 	mut i := 0
 	for i=len-1; i>=0; i-- {

--- a/vlib/gg/text_rendering.v
+++ b/vlib/gg/text_rendering.v
@@ -130,7 +130,7 @@ pub fn (ctx &Context) text_width(s string) int {
 	if !ctx.font_inited {
 		return 0
 	}
-	mut buf := [4]f32
+	mut buf := [4]f32{}
 	C.fonsTextBounds(ctx.ft.fons, 0, 0, s.str, 0, buf)
 	return int((buf[2] - buf[0]) / ctx.scale)
 }
@@ -139,7 +139,7 @@ pub fn (ctx &Context) text_height(s string) int {
 	if !ctx.font_inited {
 		return 0
 	}
-	mut buf := [4]f32
+	mut buf := [4]f32{}
 	C.fonsTextBounds(ctx.ft.fons, 0, 0, s.str, 0, buf)
 	return int((buf[3] - buf[1]) / ctx.scale)
 }
@@ -148,7 +148,7 @@ pub fn (ctx &Context) text_size(s string) (int, int) {
 	if !ctx.font_inited {
 		return 0,0
 	}
-	mut buf := [4]f32
+	mut buf := [4]f32{}
 	C.fonsTextBounds(ctx.ft.fons, 0, 0, s.str, 0, buf)
 	return int((buf[2] - buf[0]) / ctx.scale), int((buf[3] - buf[1]) / ctx.scale)
 }

--- a/vlib/net/net.v
+++ b/vlib/net/net.v
@@ -3,7 +3,7 @@ module net
 fn C.gethostname() int
 // hostname returns the host name reported by the kernel.
 pub fn hostname() ?string {
-	mut name := [256]byte
+	mut name := [256]byte{}
 	// https://www.ietf.org/rfc/rfc1035.txt
 	// The host name is returned as a null-terminated string.
 	namebp := byteptr(name)

--- a/vlib/net/socket.v
+++ b/vlib/net/socket.v
@@ -186,7 +186,7 @@ pub fn (s Socket) accept() ?Socket {
 }
 
 pub fn (s Socket) peer_ip() ?string {
-	buf := [44]byte
+	buf := [44]byte{}
 	peeraddr := C.sockaddr_in{}
 	speeraddr := sizeof(peeraddr)
 	ok := C.getpeername(s.sockfd, &C.sockaddr(&peeraddr), &speeraddr)
@@ -327,7 +327,7 @@ pub fn (s Socket) write(str string) ?int {
 
 // read_line - retrieves a line from the socket s (i.e. a string ended with \n)
 pub fn (s Socket) read_line() string {
-	mut buf := [max_read]byte // where C.recv will store the network data
+	mut buf := [max_read]byte{} // where C.recv will store the network data
 	mut res := '' // The final result, including the ending \n.
 	for {
 		mut line := '' // The current line. Can be a partial without \n in it.
@@ -373,7 +373,7 @@ pub fn (s Socket) read_line() string {
 
 // TODO
 pub fn (s Socket) read_all() string {
-	mut buf := [max_read]byte // where C.recv will store the network data
+	mut buf := [max_read]byte{} // where C.recv will store the network data
 	mut res := '' // The final result, including the ending \n.
 	for {
 		n := C.recv(s.sockfd, buf, max_read - 1, 0)

--- a/vlib/net/socket_udp_test.v
+++ b/vlib/net/socket_udp_test.v
@@ -2,7 +2,7 @@ import net
 
 fn start_socket_udp_server() {
 	bufsize := 1024
-	bytes := [1024]byte
+	bytes := [1024]byte{}
 	s := net.socket_udp() or { panic(err) }
 	s.bind( 9876 ) or { panic(err) }
 	println('Waiting for udp packets:')

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -89,7 +89,7 @@ pub fn cp(old, new string) ? {
 			C.close(fp_from)
 			return error_with_code('cp: failed to write to $new', int(fp_to))
 		}
-		mut buf := [1024]byte
+		mut buf := [1024]byte{}
 		mut count := 0
 		for {
 			// FIXME: use sizeof, bug: 'os__buf' undeclared

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -141,7 +141,7 @@ pub fn exec(cmd string) ?Result {
 	if isnil(f) {
 		return error('exec("$cmd") failed')
 	}
-	buf := [4096]byte
+	buf := [4096]byte{}
 	mut res := strings.new_builder(1024)
 	for C.fgets(charptr(buf), 4096, f) != 0 {
 		bufbp := byteptr(buf)

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -264,7 +264,7 @@ pub fn exec(cmd string) ?Result {
 		h_std_error: child_stdout_write
 		dw_flags: u32(C.STARTF_USESTDHANDLES)
 	}
-	command_line := [32768]u16
+	command_line := [32768]u16{}
 	C.ExpandEnvironmentStringsW(cmd.to_wide(), voidptr(&command_line), 32768)
 	create_process_ok := C.CreateProcessW(0, command_line, 0, 0, C.TRUE, 0, 0, 0, voidptr(&start_info), voidptr(&proc_info))
 	if !create_process_ok {
@@ -274,7 +274,7 @@ pub fn exec(cmd string) ?Result {
 	}
 	C.CloseHandle(child_stdin)
 	C.CloseHandle(child_stdout_write)
-	buf := [4096]byte
+	buf := [4096]byte{}
 	mut bytes_read := u32(0)
 	mut read_data := strings.new_builder(1024)
 	for {

--- a/vlib/strconv/format.v
+++ b/vlib/strconv/format.v
@@ -77,7 +77,7 @@ pub fn f64_to_str_lnd(f f64, dec_digit int) string {
 
 	m_sgn_flag := false
 	mut sgn        := 1
-	mut b          := [26]byte
+	mut b          := [26]byte{}
 	mut d_pos      := 1
 	mut i          := 0
 	mut i1         := 0

--- a/vlib/strconv/utilities.v
+++ b/vlib/strconv/utilities.v
@@ -242,7 +242,7 @@ pub fn f64_to_str_l(f f64) string {
 
 	m_sgn_flag := false
 	mut sgn        := 1
-	mut b          := [26]byte
+	mut b          := [26]byte{}
 	mut d_pos      := 1
 	mut i          := 0
 	mut i1         := 0

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -73,7 +73,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 				p.check(.rcbr)
 			}
 			else {
-				// p.warn_with_pos('use e.g. `x := [1]Type{}` instead of `x := [1]Type`', last_pos)
+				p.warn_with_pos('use e.g. `x := [1]Type{}` instead of `x := [1]Type`', last_pos)
 			}
 		} else {
 			if p.tok.kind == .not {

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -71,8 +71,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 				}
 				last_pos = p.tok.position()
 				p.check(.rcbr)
-			}
-			else {
+			} else {
 				p.warn_with_pos('use e.g. `x := [1]Type{}` instead of `x := [1]Type`', last_pos)
 			}
 		} else {

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -23,7 +23,7 @@ pub const (
 
 // vhash() returns the build string C.V_COMMIT_HASH . See cmd/tools/gen_vc.v .
 pub fn vhash() string {
-	mut buf := [50]byte
+	mut buf := [50]byte{}
 	buf[0] = 0
 	unsafe {
 		C.snprintf(charptr(buf), 50, '%s', C.V_COMMIT_HASH)
@@ -95,7 +95,7 @@ pub fn githash(should_get_from_filesystem bool) string {
 		}
 		break
 	}
-	mut buf := [50]byte
+	mut buf := [50]byte{}
 	buf[0] = 0
 	unsafe {
 		C.snprintf(charptr(buf), 50, '%s', C.V_CURRENT_COMMIT_HASH)


### PR DESCRIPTION
Follows on from #6114.