### PR TITLE
checker: disallow casting to bool, use `some_int != 0` instead 

### DIFF
--- a/vlib/os/inode.v
+++ b/vlib/os/inode.v
@@ -58,38 +58,38 @@ pub fn inode(path string) FileMode {
 		return FileMode{
 			typ: typ
 			owner: FilePermission{
-				read: bool(attr.st_mode & u32(C.S_IREAD))
-				write: bool(attr.st_mode & u32(C.S_IWRITE))
-				execute: bool(attr.st_mode & u32(C.S_IEXEC))
+				read: (attr.st_mode & u32(C.S_IREAD)) != 0
+				write: (attr.st_mode & u32(C.S_IWRITE)) != 0
+				execute: (attr.st_mode & u32(C.S_IEXEC)) != 0
 			}
 			group: FilePermission{
-				read: bool(attr.st_mode & u32(C.S_IREAD))
-				write: bool(attr.st_mode & u32(C.S_IWRITE))
-				execute: bool(attr.st_mode & u32(C.S_IEXEC))
+				read: (attr.st_mode & u32(C.S_IREAD)) != 0
+				write: (attr.st_mode & u32(C.S_IWRITE)) != 0
+				execute: (attr.st_mode & u32(C.S_IEXEC)) != 0
 			}
 			others: FilePermission{
-				read: bool(attr.st_mode & u32(C.S_IREAD))
-				write: bool(attr.st_mode & u32(C.S_IWRITE))
-				execute: bool(attr.st_mode & u32(C.S_IEXEC))
+				read: (attr.st_mode & u32(C.S_IREAD)) != 0
+				write: (attr.st_mode & u32(C.S_IWRITE)) != 0
+				execute: (attr.st_mode & u32(C.S_IEXEC)) != 0
 			}
 		}
 	} $else {
 		return FileMode{
 			typ: typ
 			owner: FilePermission{
-				read: bool(attr.st_mode & u32(C.S_IRUSR))
-				write: bool(attr.st_mode & u32(C.S_IWUSR))
-				execute: bool(attr.st_mode & u32(C.S_IXUSR))
+				read: (attr.st_mode & u32(C.S_IRUSR)) != 0
+				write: (attr.st_mode & u32(C.S_IWUSR)) != 0
+				execute: (attr.st_mode & u32(C.S_IXUSR)) != 0
 			}
 			group: FilePermission{
-				read: bool(attr.st_mode & u32(C.S_IRGRP))
-				write: bool(attr.st_mode & u32(C.S_IWGRP))
-				execute: bool(attr.st_mode & u32(C.S_IXGRP))
+				read: (attr.st_mode & u32(C.S_IRGRP)) != 0
+				write: (attr.st_mode & u32(C.S_IWGRP)) != 0
+				execute: (attr.st_mode & u32(C.S_IXGRP)) != 0
 			}
 			others: FilePermission{
-				read: bool(attr.st_mode & u32(C.S_IROTH))
-				write: bool(attr.st_mode & u32(C.S_IWOTH))
-				execute: bool(attr.st_mode & u32(C.S_IXOTH))
+				read: (attr.st_mode & u32(C.S_IROTH)) != 0
+				write: (attr.st_mode & u32(C.S_IWOTH)) != 0
+				execute: (attr.st_mode & u32(C.S_IXOTH)) != 0
 			}
 		}
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2335,6 +2335,8 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 					c.error('cannot convert struct `$from_type_sym.name` to struct `$to_type_sym.name`',
 						node.pos)
 				}
+			} else if node.typ == table.bool_type {
+				c.error('cannot cast to bool - use e.g. `some_int != 0` instead', node.pos)
 			}
 			if node.has_arg {
 				c.expr(node.arg)

--- a/vlib/v/checker/tests/cast_err.out
+++ b/vlib/v/checker/tests/cast_err.out
@@ -1,0 +1,20 @@
+vlib/v/checker/tests/cast_err.v:3:11: error: cannot cast to bool - use e.g. `some_int != 0` instead
+    1 | fn test_bool_cast() {
+    2 |     v := 3
+    3 |     _ = bool(v)
+      |              ^
+    4 |     _ = bool(&v)
+    5 |     _ = bool([2])
+vlib/v/checker/tests/cast_err.v:4:11: error: cannot cast to bool - use e.g. `some_int != 0` instead
+    2 |     v := 3
+    3 |     _ = bool(v)
+    4 |     _ = bool(&v)
+      |              ^
+    5 |     _ = bool([2])
+    6 | }
+vlib/v/checker/tests/cast_err.v:5:11: error: cannot cast to bool - use e.g. `some_int != 0` instead
+    3 |     _ = bool(v)
+    4 |     _ = bool(&v)
+    5 |     _ = bool([2])
+      |              ~~~
+    6 | }

--- a/vlib/v/checker/tests/cast_err.vv
+++ b/vlib/v/checker/tests/cast_err.vv
@@ -1,0 +1,6 @@
+fn test_bool_cast() {
+	v := 3
+	_ = bool(v)
+	_ = bool(&v)
+	_ = bool([2])
+}

--- a/vlib/v/tests/conversions_test.v
+++ b/vlib/v/tests/conversions_test.v
@@ -4,4 +4,13 @@ fn test_conv_to_bool() {
 	assert !b
 	b = u64(&v) != 0
 	assert b
+	// check true -> 1
+	assert int(b) == 1
+	
+	// branchless tests (can be important for manual optimization)
+	arr := [7,8]!!
+	e := arr[int(b)]
+	assert e == 8
+	b = e < 0
+	assert arr[int(b)] == 7
 }

--- a/vlib/v/tests/conversions_test.v
+++ b/vlib/v/tests/conversions_test.v
@@ -1,0 +1,7 @@
+fn test_conv_to_bool() {
+	v := 0
+	mut b := v != 0
+	assert !b
+	b = u64(&v) != 0
+	assert b
+}


### PR DESCRIPTION
This fixes #5945 by preventing a bool from having a bit pattern other than 0 or 1 in safe code (`sizeof(bool)` is 4 on my machine). >1 can still occur with `b = *&bool(&my_int)` but that will need to be in `unsafe` code.

An alternative fix would be to allow other bit patterns (as now) but make casting to integer e.g. `int(b)` actually generate `b != 0` in C, so the result is only 0 or 1.

Also add branchless tests in `tests/conversions_test.v`.