### PR TITLE
os: fix closing opened file descriptors in cp fn (os module)

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -87,7 +87,7 @@ pub fn cp(old, new string) ? {
 		fp_to := C.open(charptr(new.str), C.O_WRONLY | C.O_CREAT | C.O_TRUNC, C.S_IWUSR | C.S_IRUSR)
 		if fp_to < 0 { // Check if file opened (permissions problems ...)
 			C.close(fp_from)
-			return error_with_code('cp: failed to write to $new', int(fp_to))
+			return error_with_code('cp (permission): failed to write to $new (fp_to: $fp_to)', int(fp_to))
 		}
 		mut buf := [1024]byte
 		mut count := 0
@@ -109,6 +109,8 @@ pub fn cp(old, new string) ? {
 		if C.chmod(charptr(new.str), from_attr.st_mode) < 0 {
 			return error_with_code('failed to set permissions for $new', int(-1))
 		}
+		C.close(fp_to)
+		C.close(fp_from)
 	}
 }
 


### PR DESCRIPTION

Using cp_all fn in vsh script leads to an error with C.open . C.open can't open a file and return an error. During my research I understood that it happens cause of open file descriptors are never closed.  I guess that  this pr can help to fix a problem.  