### PR TITLE
checker: prevent from casting non-struct to struct

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2333,11 +2333,16 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 				type_name := c.table.type_to_str(node.expr_type)
 				c.error('cannot cast type `$type_name` to `byte`', node.pos)
 			} else if to_type_sym.kind == .struct_ && !node.typ.is_ptr() && !(to_type_sym.info as table.Struct).is_typedef {
-				from_type_info := from_type_sym.info as table.Struct
-				to_type_info := to_type_sym.info as table.Struct
-				if !c.check_struct_signature(from_type_info, to_type_info) {
-					c.error('cannot convert struct `$from_type_sym.name` to struct `$to_type_sym.name`',
-						node.pos)
+				if from_type_sym.kind == .struct_ {
+					from_type_info := from_type_sym.info as table.Struct
+					to_type_info := to_type_sym.info as table.Struct
+					if !c.check_struct_signature(from_type_info, to_type_info) {
+						c.error('cannot convert struct `$from_type_sym.name` to struct `$to_type_sym.name`',
+							node.pos)
+					}
+				} else {
+					type_name := c.table.type_to_str(node.expr_type)
+					c.error('cannot cast `$type_name` to struct', node.pos)
 				}
 			}
 			if node.has_arg {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2333,7 +2333,7 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 				type_name := c.table.type_to_str(node.expr_type)
 				c.error('cannot cast type `$type_name` to `byte`', node.pos)
 			} else if to_type_sym.kind == .struct_ && !node.typ.is_ptr() && !(to_type_sym.info as table.Struct).is_typedef {
-				if from_type_sym.kind == .struct_ {
+				if from_type_sym.kind == .struct_ && !node.expr_type.is_ptr() {
 					from_type_info := from_type_sym.info as table.Struct
 					to_type_info := to_type_sym.info as table.Struct
 					if !c.check_struct_signature(from_type_info, to_type_info) {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2333,6 +2333,7 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 				type_name := c.table.type_to_str(node.expr_type)
 				c.error('cannot cast type `$type_name` to `byte`', node.pos)
 			} else if to_type_sym.kind == .struct_ && !node.typ.is_ptr() && !(to_type_sym.info as table.Struct).is_typedef {
+				// For now we ignore C typedef because of `C.Window(C.None)` in vlib/clipboard
 				if from_type_sym.kind == .struct_ && !node.expr_type.is_ptr() {
 					from_type_info := from_type_sym.info as table.Struct
 					to_type_info := to_type_sym.info as table.Struct

--- a/vlib/v/checker/tests/cannot_cast_to_struct.out
+++ b/vlib/v/checker/tests/cannot_cast_to_struct.out
@@ -11,10 +11,17 @@ vlib/v/checker/tests/cannot_cast_to_struct.v:12:10: error: cannot cast `Alphabet
    12 |     _ = Xyz(sum)
       |             ~~~
    13 |     _ = Xyz(5)
-   14 | }
+   14 |     s := Abc{}
 vlib/v/checker/tests/cannot_cast_to_struct.v:13:10: error: cannot cast `any_int` to struct
    11 |     sum := Alphabet(Xyz{})
    12 |     _ = Xyz(sum)
    13 |     _ = Xyz(5)
       |             ^
-   14 | }
+   14 |     s := Abc{}
+   15 |     _ = Xyz(&s)
+vlib/v/checker/tests/cannot_cast_to_struct.v:15:10: error: cannot cast `&Abc` to struct
+   13 |     _ = Xyz(5)
+   14 |     s := Abc{}
+   15 |     _ = Xyz(&s)
+      |             ^
+   16 | }

--- a/vlib/v/checker/tests/cannot_cast_to_struct.out
+++ b/vlib/v/checker/tests/cannot_cast_to_struct.out
@@ -1,0 +1,20 @@
+vlib/v/checker/tests/cannot_cast_to_struct.v:10:12: error: cannot convert struct `Abc` to struct `Test`
+    8 |
+    9 | fn main() {
+   10 |     _ := Test(Abc{})
+      |               ~~~~~
+   11 |     sum := Alphabet(Xyz{})
+   12 |     _ = Xyz(sum)
+vlib/v/checker/tests/cannot_cast_to_struct.v:12:10: error: cannot cast `Alphabet` to struct
+   10 |     _ := Test(Abc{})
+   11 |     sum := Alphabet(Xyz{})
+   12 |     _ = Xyz(sum)
+      |             ~~~
+   13 |     _ = Xyz(5)
+   14 | }
+vlib/v/checker/tests/cannot_cast_to_struct.v:13:10: error: cannot cast `any_int` to struct
+   11 |     sum := Alphabet(Xyz{})
+   12 |     _ = Xyz(sum)
+   13 |     _ = Xyz(5)
+      |             ^
+   14 | }

--- a/vlib/v/checker/tests/cannot_cast_to_struct.vv
+++ b/vlib/v/checker/tests/cannot_cast_to_struct.vv
@@ -11,4 +11,6 @@ fn main() {
 	sum := Alphabet(Xyz{})
 	_ = Xyz(sum)
 	_ = Xyz(5)
+	s := Abc{}
+	_ = Xyz(&s)
 }

--- a/vlib/v/checker/tests/cannot_cast_to_struct.vv
+++ b/vlib/v/checker/tests/cannot_cast_to_struct.vv
@@ -1,0 +1,14 @@
+struct Abc {}
+struct Xyz {}
+type Alphabet = Abc | Xyz
+
+struct Test {
+	abc Alphabet
+}
+
+fn main() {
+	_ := Test(Abc{})
+	sum := Alphabet(Xyz{})
+	_ = Xyz(sum)
+	_ = Xyz(5)
+}


### PR DESCRIPTION
#5864 (in the end) only generates an error when casting a struct to an incompatible struct. This fixes the checks again.