### PR TITLE
sync/channels: really use references for `chan mut X` testcase

### DIFF
--- a/vlib/sync/channel_array_mut_test.v
+++ b/vlib/sync/channel_array_mut_test.v
@@ -11,11 +11,9 @@ mut:
 
 // this function gets an array of channels for `St` references
 fn do_rec_calc_send(chs0, chs1 chan mut St, sem sync.Semaphore) {
-	mut s := St{}
-	for {
-		if !(&sync.Channel(chs0)).pop(&s) {
-			break
-		}
+	mut s := &St(0)
+	for _ in 0 .. num_iterations {
+		(&sync.Channel(chs0)).pop(&s)
 		s.n++
 		(&sync.Channel(chs1)).push(&s)
 	}
@@ -27,14 +25,14 @@ fn test_channel_array_mut() {
 	mut chs1 := chan mut St{}
 	sem := sync.new_semaphore()
 	go do_rec_calc_send(chs0, chs1, sem)
-	mut t := St{
+	mut t := &St{
 		n: 100
 	}
 	for _ in 0 .. num_iterations {
 		(&sync.Channel(chs0)).push(&t)
 		(&sync.Channel(chs1)).pop(&t)
 	}
-	(&sync.Channel(chs0)).close()
+	// (&sync.Channel(chs0)).close()
 	sem.wait()
 	assert t.n == 100 + num_iterations
 }

--- a/vlib/sync/channel_array_mut_test.v
+++ b/vlib/sync/channel_array_mut_test.v
@@ -23,7 +23,7 @@ fn do_rec_calc_send(chs []chan mut St, sem sync.Semaphore) {
 }
 
 fn test_channel_array_mut() {
-	mut chs := [chan mut St{cap: 1}, chan mut St{}]
+	mut chs := [chan mut St{cap: 0}, chan mut St{}]
 	sem := sync.new_semaphore()
 	go do_rec_calc_send(chs, sem)
 	mut t := St{

--- a/vlib/sync/channel_array_mut_test.v
+++ b/vlib/sync/channel_array_mut_test.v
@@ -6,7 +6,11 @@ const (
 
 struct St {
 mut:
-	n int
+	dummy  i64
+	dummy2 u32
+	dummy3 i64
+	n      int
+	dummy4 int
 }
 
 // this function gets an array of channels for `St` references

--- a/vlib/sync/channel_array_mut_test.v
+++ b/vlib/sync/channel_array_mut_test.v
@@ -10,30 +10,31 @@ mut:
 }
 
 // this function gets an array of channels for `St` references
-fn do_rec_calc_send(chs []chan mut St, sem sync.Semaphore) {
+fn do_rec_calc_send(chs0, chs1 chan mut St, sem sync.Semaphore) {
 	mut s := St{}
 	for {
-		if !(&sync.Channel(chs[0])).pop(&s) {
+		if !(&sync.Channel(chs0)).pop(&s) {
 			break
 		}
 		s.n++
-		(&sync.Channel(chs[1])).push(&s)
+		(&sync.Channel(chs1)).push(&s)
 	}
 	sem.post()
 }
 
 fn test_channel_array_mut() {
-	mut chs := [chan mut St{cap: 0}, chan mut St{}]
+	mut chs0 := chan mut St{cap: 1}
+	mut chs1 := chan mut St{}
 	sem := sync.new_semaphore()
-	go do_rec_calc_send(chs, sem)
+	go do_rec_calc_send(chs0, chs1, sem)
 	mut t := St{
 		n: 100
 	}
 	for _ in 0 .. num_iterations {
-		(&sync.Channel(chs[0])).push(&t)
-		(&sync.Channel(chs[1])).pop(&t)
+		(&sync.Channel(chs0)).push(&t)
+		(&sync.Channel(chs1)).pop(&t)
 	}
-	(&sync.Channel(chs[0])).close()
+	(&sync.Channel(chs0)).close()
 	sem.wait()
 	assert t.n == 100 + num_iterations
 }


### PR DESCRIPTION
It turned out that the testcase for channels that should send references thru the channel actually did send values (which passed in most but not all cases because the structure is small enough). This PR fixes the issue by defining the passed object as reference and adds some dummy elements to the structure to better expose this kind of misbehavior.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
