### PR TITLE
Http, remove warnings on fixed arrays and fix error on strings in windows

### DIFF
--- a/vlib/net/http/backend_nix.c.v
+++ b/vlib/net/http/backend_nix.c.v
@@ -41,7 +41,7 @@ fn (req &Request) ssl_do(port int, method Method, host_name, path string) ?Respo
 	//println(req_headers)
 	C.BIO_puts(web, req_headers.str)
 	mut content := strings.new_builder(100)
-	mut buff := [bufsize]byte
+	mut buff := [bufsize]byte{}
 	mut readcounter := 0
 	for {
 		readcounter++

--- a/vlib/net/http/backend_windows.c.v
+++ b/vlib/net/http/backend_windows.c.v
@@ -21,5 +21,5 @@ fn (req &Request) ssl_do(port int, method Method, host_name, path string) ?Respo
 	length := int(C.request(&ctx, port, addr.to_wide(), sdata.str, &buff))
 
 	C.vschannel_cleanup(&ctx)
-	return parse_response(string(buff, length))
+	return parse_response(buff.vstring_with_len(length))
 }

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -410,7 +410,7 @@ pub fn escape(s string) string {
 }
 
 fn (req &Request) http_do(port int, method Method, host_name, path string) ?Response {
-	rbuffer := [bufsize]byte
+	rbuffer := [bufsize]byte{}
 	mut sb := strings.new_builder(100)
 	s := req.build_request_headers(method, host_name, path)
 	client := net.dial(host_name, port) or {


### PR DESCRIPTION
With latest V (from updated sources), since yesterday I have the following warning and error (building in Windows):
```
hello-web>v -prod -o ./hello-web-v hello-web.v
C:\opt\vlang_v\vlib\net\http\http.v:413:21: warning: use e.g. `x := [1]Type{}` instead of `x := [1]Type`
  411 |
  412 | fn (req &Request) http_do(port int, method Method, host_name, path string) ?Response {
  413 |     rbuffer := [bufsize]byte
      |                        ^
  414 |     mut sb := strings.new_builder(100)
  415 |     s := req.build_request_headers(method, host_name, path)
C:\opt\vlang_v\vlib\net\http\backend_windows.c.v:24:31: error: to convert a C string buffer pointer to a V string, please use x.vstring_with_len(len) instead of string(x,len)
   22 |
   23 |     C.vschannel_cleanup(&ctx)
   24 |     return parse_response(string(buff, length))
      |                                  ~~~~
   25 | }

Current V version:
V 0.1.29 191c908
```

Now building in Linux I found another warning, fixed in this PR.

Bye
