### PR TITLE
parser: require `(` on same line as name token for fn call or cast

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -958,9 +958,9 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 			typ: map_type
 		}
 	}
+	first_pos := p.tok.position()
 	// `chan typ{...}`
 	if p.tok.lit == 'chan' {
-		first_pos := p.tok.position()
 		mut last_pos := p.tok.position()
 		chan_type := p.parse_chan_type()
 		mut has_cap := false
@@ -987,13 +987,8 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 			last_pos = p.tok.position()
 			p.check(.rcbr)
 		}
-		pos := token.Position{
-			line_nr: first_pos.line_nr
-			pos: first_pos.pos
-			len: last_pos.pos - first_pos.pos + last_pos.len
-		}
 		return ast.ChanInit{
-			pos: pos
+			pos: first_pos.extend(last_pos)
 			has_cap: has_cap
 			cap_expr: cap_expr
 			typ: chan_type

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1024,10 +1024,13 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 	}
 	lit0_is_capital := p.tok.lit[0].is_capital()
 	// p.warn('name expr  $p.tok.lit $p.peek_tok.str()')
-	// fn call or type cast
-	if p.peek_tok.kind == .lpar ||
+	same_line := first_pos.line_nr + 1 == p.peek_tok.line_nr
+	// `(` must be on same line as name token otherwise it's a ParExpr
+	if !same_line && p.peek_tok.kind == .lpar {
+		node = p.parse_ident(language)
+	} else if p.peek_tok.kind == .lpar ||
 		(p.peek_tok.kind == .lt && !lit0_is_capital && p.peek_tok2.kind == .name && p.peek_tok3.kind == .gt) {
-		// foo() or foo<int>()
+		// foo(), foo<int>() or type() cast
 		mut name := p.tok.lit
 		if mod.len > 0 {
 			name = '${mod}.$name'

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -958,10 +958,10 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 			typ: map_type
 		}
 	}
-	first_pos := p.tok.position()
 	// `chan typ{...}`
 	if p.tok.lit == 'chan' {
-		mut last_pos := p.tok.position()
+		first_pos := p.tok.position()
+		mut last_pos := first_pos
 		chan_type := p.parse_chan_type()
 		mut has_cap := false
 		mut cap_expr := ast.Expr{}
@@ -1024,7 +1024,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 	}
 	lit0_is_capital := p.tok.lit[0].is_capital()
 	// p.warn('name expr  $p.tok.lit $p.peek_tok.str()')
-	same_line := first_pos.line_nr + 1 == p.peek_tok.line_nr
+	same_line := p.tok.line_nr == p.peek_tok.line_nr
 	// `(` must be on same line as name token otherwise it's a ParExpr
 	if !same_line && p.peek_tok.kind == .lpar {
 		node = p.parse_ident(language)

--- a/vlib/v/tests/parser_line_test.v
+++ b/vlib/v/tests/parser_line_test.v
@@ -1,0 +1,9 @@
+fn test_name_lpar() {
+	mut v := 2
+	// check ParExpr is parsed, not CallExpr
+	mut p := &v
+	(*p)++
+	_ = v
+	(*p)++
+	assert v == 4
+}


### PR DESCRIPTION
This allows correct parsing of a `ParExpr` on the next line when the previous line ends with an `Ident` expression. Currently the following code errors:
```v
mut v := 2
mut p := &v // error: unknown function: v
(*p)++
_ = v // error: unknown function: v
(*p)++
```

Also use Position.extend for `ChanInit` instead of manual `Position{...}`.