### PR TITLE
android: initial support for C output using sokol_main

### DIFF
--- a/examples/sokol/particles/main.v
+++ b/examples/sokol/particles/main.v
@@ -46,12 +46,12 @@ fn (mut a App) cleanup() {
 	a.ps.free()
 }
 
-fn (a App) run() {
+fn (mut a App) run() {
 	title := 'V Particle Example'
 	desc := C.sapp_desc{
 		width: a.width
 		height: a.height
-		user_data: &a
+		user_data: a
 		init_userdata_cb: init
 		frame_userdata_cb: frame
 		event_userdata_cb: event
@@ -59,6 +59,7 @@ fn (a App) run() {
 		html5_canvas_name: title.str
 		cleanup_userdata_cb: cleanup
 	}
+
 	sapp.run(&desc)
 }
 
@@ -124,6 +125,15 @@ fn event(ev &C.sapp_event, user_data voidptr) {
 			if is_pressed {
 				app.ps.reset()
 			}
+		}
+	}
+
+	if ev.@type == .touches_began || ev.@type == .touches_moved {
+		if ev.num_touches > 0 {
+
+			touch_point := ev.touches[0]
+			app.ps.explode(touch_point.pos_x, touch_point.pos_y)
+
 		}
 	}
 }

--- a/vlib/sokol/c/declaration.c.v
+++ b/vlib/sokol/c/declaration.c.v
@@ -27,7 +27,16 @@ pub const (
 // for simplicity, all header includes are here because import order matters and we dont have any way
 // to ensure import order with V yet
 #define SOKOL_IMPL
-#define SOKOL_NO_ENTRY
+
+// TODO should not be defined for android graphic (apk/aab using sokol) builds, but we have no ways to undefine
+//#define SOKOL_NO_ENTRY
+#flag linux   -DSOKOL_NO_ENTRY
+#flag darwin  -DSOKOL_NO_ENTRY
+#flag windows -DSOKOL_NO_ENTRY
+#flag freebsd -DSOKOL_NO_ENTRY
+#flag solaris -DSOKOL_NO_ENTRY
+// TODO end
+
 #include "sokol_app.h"
 
 #define SOKOL_IMPL

--- a/vlib/v/gen/cmain.v
+++ b/vlib/v/gen/cmain.v
@@ -11,7 +11,6 @@ pub fn (mut g Gen) gen_c_main() {
 	}
 	g.out.writeln('')
 	main_fn_start_pos := g.out.len
-
 	if g.pref.os == .android && g.pref.is_apk {
 		g.gen_c_android_sokol_main()
 	} else {
@@ -90,26 +89,20 @@ pub fn (mut g Gen) gen_c_main_footer() {
 }
 
 pub fn (mut g Gen) gen_c_android_sokol_main() {
-
-
 	// TODO get autofree weaved into android lifecycle somehow
 	/*
 	if g.autofree {
 		g.writeln('\t_vcleanup();')
 	}
 	*/
-
 	// TODO do proper check for the global g_desc field we need
-
 	g.writeln('sapp_desc sokol_main(int argc, char* argv[]) {')
 	g.writeln('\t(void)argc; (void)argv;')
 	g.writeln('')
-    g.writeln('\t_vinit();')
+	g.writeln('\t_vinit();')
 	g.writeln('\tmain__main();')
 	g.writeln('')
-
 	g.writeln('\treturn g_desc;')
-
 	g.writeln('}')
 }
 

--- a/vlib/v/gen/cmain.v
+++ b/vlib/v/gen/cmain.v
@@ -11,11 +11,16 @@ pub fn (mut g Gen) gen_c_main() {
 	}
 	g.out.writeln('')
 	main_fn_start_pos := g.out.len
-	g.gen_c_main_header()
-	g.writeln('\tmain__main();')
-	g.gen_c_main_footer()
-	if g.pref.printfn_list.len > 0 && 'main' in g.pref.printfn_list {
-		println(g.out.after(main_fn_start_pos))
+
+	if g.pref.os == .android && g.pref.is_apk {
+		g.gen_c_android_sokol_main()
+	} else {
+		g.gen_c_main_header()
+		g.writeln('\tmain__main();')
+		g.gen_c_main_footer()
+		if g.pref.printfn_list.len > 0 && 'main' in g.pref.printfn_list {
+			println(g.out.after(main_fn_start_pos))
+		}
 	}
 }
 
@@ -81,6 +86,30 @@ pub fn (mut g Gen) gen_c_main_footer() {
 		g.writeln('\t_vcleanup();')
 	}
 	g.writeln('\treturn 0;')
+	g.writeln('}')
+}
+
+pub fn (mut g Gen) gen_c_android_sokol_main() {
+
+
+	// TODO get autofree weaved into android lifecycle somehow
+	/*
+	if g.autofree {
+		g.writeln('\t_vcleanup();')
+	}
+	*/
+
+	// TODO do proper check for the global g_desc field we need
+
+	g.writeln('sapp_desc sokol_main(int argc, char* argv[]) {')
+	g.writeln('\t(void)argc; (void)argv;')
+	g.writeln('')
+    g.writeln('\t_vinit();')
+	g.writeln('\tmain__main();')
+	g.writeln('')
+
+	g.writeln('\treturn g_desc;')
+
 	g.writeln('}')
 }
 

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -123,6 +123,7 @@ pub mut:
 	experimental        bool // enable experimental features
 	show_timings        bool // show how much time each compiler stage took
 	is_ios_simulator    bool
+	is_apk              bool // build as Android .apk format
 }
 
 pub fn parse_args(args []string) (&Preferences, string) {
@@ -134,6 +135,9 @@ pub fn parse_args(args []string) (&Preferences, string) {
 		arg := args[i]
 		current_args := args[i..]
 		match arg {
+			'-apk' {
+				res.is_apk = true
+			}
 			'-show-timings' {
 				res.show_timings = true
 			}


### PR DESCRIPTION
This will bring in support for running graphical V apps on Android via APK or AAB packages.
It's currently needed for @spaceface777 's PR #6161 to work.

Emitting Android APK/AAB compatible C output is thus currently:
`v -os android -apk -packagename "<org.package.name>" -appname "<app name>" -appicon "path/to/icon.png" file.v`

Also see https://github.com/Larpon/v-android-bootstrap for the current way of building and bundling with Android from a Linux host.

Better integrated support and more host platforms will come later.


<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
