### PR TITLE
scanner: support `$a[expr]` interpolated string

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -925,7 +925,7 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 			if sym.kind != elem_sym.kind &&
 				((elem_sym.kind == .int && sym.kind != .any_int) ||
 				(elem_sym.kind == .f64 && sym.kind != .any_float)) {
-				c.error('type mismatch, should use `$elem_sym.name[]`', arg_expr.position())
+				c.error('type mismatch, should use `$elem_sym.name\[]`', arg_expr.position())
 			}
 		} else {
 			if arg_sym.kind != elem_sym.kind &&

--- a/vlib/v/gen/auto_str_methods.v
+++ b/vlib/v/gen/auto_str_methods.v
@@ -192,7 +192,7 @@ fn (mut g Gen) gen_str_for_map(info table.Map, styp, str_fn_name string) {
 	g.auto_str_funcs.write('\t$val_styp it = (*($val_styp*)map_get(')
 	g.auto_str_funcs.write('m, (*(string*)DenseArray_get(m.key_values, i))')
 	g.auto_str_funcs.write(', ')
-	g.auto_str_funcs.writeln(' &($val_styp[]) { $zero }));')
+	g.auto_str_funcs.writeln(' &($val_styp\[]) { $zero }));')
 	if val_sym.kind == .string {
 		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("\'%.*s\\000\'", 2, it));')
 	} else if val_sym.kind == .struct_ && !val_sym.has_method('str') {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1004,7 +1004,7 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 				g.write_fn_ptr_decl(val_sym.info as table.FnType, c_name(it.val_var))
 				g.writeln(' = (*(voidptr*)map_get($atmp, $key, &(voidptr[]){ $zero }));')
 			} else {
-				g.writeln('\t$val_styp ${c_name(it.val_var)} = (*($val_styp*)map_get($atmp, $key, &($val_styp[]){ $zero }));')
+				g.writeln('\t$val_styp ${c_name(it.val_var)} = (*($val_styp*)map_get($atmp, $key, &($val_styp\[]){ $zero }));')
 			}
 		}
 		g.stmts(it.stmts)
@@ -1062,7 +1062,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type, expected_type table.Type)
 				g.write(', .typ = $got_idx /* $got_sym.name */}, sizeof($exp_der_styp))')
 			} else if expected_is_ptr {
 				exp_der_styp := g.typ(expected_deref_type)
-				g.write('/* sum type cast */ ($exp_styp) memdup(&($exp_der_styp){.obj = memdup(&($got_styp[]) {')
+				g.write('/* sum type cast */ ($exp_styp) memdup(&($exp_der_styp){.obj = memdup(&($got_styp\[]) {')
 				g.expr(expr)
 				g.write('}, sizeof($got_styp)), .typ = $got_idx /* $got_sym.name */}, sizeof($exp_der_styp))')
 			} else if got_is_ptr {
@@ -1070,7 +1070,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type, expected_type table.Type)
 				g.expr(expr)
 				g.write(', .typ = $got_idx /* $got_sym.name */}')
 			} else {
-				g.write('/* sum type cast */ ($exp_styp) {.obj = memdup(&($got_styp[]) {')
+				g.write('/* sum type cast */ ($exp_styp) {.obj = memdup(&($got_styp\[]) {')
 				g.expr(expr)
 				g.write('}, sizeof($got_styp)), .typ = $got_idx /* $got_sym.name */}')
 			}
@@ -1328,7 +1328,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 						if val_typ.kind == .function {
 							g.writeln(', &(voidptr[]){ $zero });')
 						} else {
-							g.writeln(', &($styp[]){ $zero });')
+							g.writeln(', &($styp\[]){ $zero });')
 						}
 					}
 				}
@@ -1887,9 +1887,9 @@ fn (mut g Gen) expr(node ast.Expr) {
 			size := node.vals.len
 			if size > 0 {
 				if value_typ.kind == .function {
-					g.write('new_map_init($size, sizeof(voidptr), _MOV(($key_typ_str[$size]){')
+					g.write('new_map_init($size, sizeof(voidptr), _MOV(($key_typ_str\[$size]){')
 				} else {
-					g.write('new_map_init($size, sizeof($value_typ_str), _MOV(($key_typ_str[$size]){')
+					g.write('new_map_init($size, sizeof($value_typ_str), _MOV(($key_typ_str\[$size]){')
 				}
 				for expr in node.keys {
 					g.expr(expr)
@@ -1898,7 +1898,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 				if value_typ.kind == .function {
 					g.write('}), _MOV((voidptr[$size]){')
 				} else {
-					g.write('}), _MOV(($value_typ_str[$size]){')
+					g.write('}), _MOV(($value_typ_str\[$size]){')
 				}
 				for expr in node.vals {
 					g.expr(expr)
@@ -2283,7 +2283,7 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 			if elem_sym.kind == .function {
 				g.write(', _MOV((voidptr[]){ ')
 			} else {
-				g.write(', _MOV(($elem_type_str[]){ ')
+				g.write(', _MOV(($elem_type_str\[]){ ')
 			}
 			if elem_sym.kind == .interface_ && node.right_type != info.elem_type {
 				g.interface_call(node.right_type, info.elem_type)
@@ -2763,7 +2763,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 						if elem_typ.kind == .function {
 							g.write(', &(voidptr[]) { ')
 						} else {
-							g.write(', &($elem_type_str[]) { ')
+							g.write(', &($elem_type_str\[]) { ')
 						}
 					} else {
 						g.write(', &')
@@ -2839,7 +2839,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 					if elem_typ.kind == .function {
 						g.write(', &(voidptr[]) { ')
 					} else {
-						g.write(', &($elem_type_str[]) { ')
+						g.write(', &($elem_type_str\[]) { ')
 					}
 				} else if g.inside_map_postfix || g.inside_map_infix {
 					zero := g.type_default(info.value_type)
@@ -2850,7 +2850,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 					g.expr(node.left)
 					g.write(', ')
 					g.expr(node.index)
-					g.write(', &($elem_type_str[]){ $zero }))')
+					g.write(', &($elem_type_str\[]){ $zero }))')
 				} else {
 					zero := g.type_default(info.value_type)
 					if elem_typ.kind == .function {
@@ -2867,7 +2867,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 					if elem_typ.kind == .function {
 						g.write(', &(voidptr[]){ $zero }))')
 					} else {
-						g.write(', &($elem_type_str[]){ $zero }))')
+						g.write(', &($elem_type_str\[]){ $zero }))')
 					}
 				}
 			} else if sym.kind == .string && !node.left_type.is_ptr() {
@@ -3025,7 +3025,7 @@ fn (mut g Gen) return_statement(node ast.Return) {
 			// Create a tmp for this option
 			opt_tmp := g.new_tmp_var()
 			g.writeln('$opt_type $opt_tmp;')
-			g.write('opt_ok2(&($styp[]) { ')
+			g.write('opt_ok2(&($styp\[]) { ')
 			if !g.fn_decl.return_type.is_ptr() && node.types[0].is_ptr() {
 				// Automatic Dereference for optional
 				g.write('*')
@@ -3431,12 +3431,12 @@ fn (mut g Gen) gen_map_equality_fn(left table.Type) string {
 		}
 		g.definitions.writeln(') = (*(voidptr*)map_get(a, k, &(voidptr[]){ 0 }));')
 	} else {
-		g.definitions.writeln('\t\t$value_typ v = (*($value_typ*)map_get(a, k, &($value_typ[]){ 0 }));')
+		g.definitions.writeln('\t\t$value_typ v = (*($value_typ*)map_get(a, k, &($value_typ\[]){ 0 }));')
 	}
 	match value_sym.kind {
-		.string { g.definitions.writeln('\t\tif (!map_exists(b, k) || string_ne((*($value_typ*)map_get(b, k, &($value_typ[]){tos_lit("")})), v)) {') }
+		.string { g.definitions.writeln('\t\tif (!map_exists(b, k) || string_ne((*($value_typ*)map_get(b, k, &($value_typ\[]){tos_lit("")})), v)) {') }
 		.function { g.definitions.writeln('\t\tif (!map_exists(b, k) || (*(voidptr*)map_get(b, k, &(voidptr[]){ 0 })) != v) {') }
-		else { g.definitions.writeln('\t\tif (!map_exists(b, k) || (*($value_typ*)map_get(b, k, &($value_typ[]){ 0 })) != v) {') }
+		else { g.definitions.writeln('\t\tif (!map_exists(b, k) || (*($value_typ*)map_get(b, k, &($value_typ\[]){ 0 })) != v) {') }
 	}
 	g.definitions.writeln('\t\t\treturn false;')
 	g.definitions.writeln('\t\t}')
@@ -3996,7 +3996,7 @@ fn (mut g Gen) gen_array_insert(node ast.CallExpr) {
 		g.expr(node.args[1].expr)
 		g.write('.len)')
 	} else {
-		g.write(', &($elem_type_str[]){')
+		g.write(', &($elem_type_str\[]){')
 		g.expr(node.args[1].expr)
 		g.write('})')
 	}
@@ -4022,7 +4022,7 @@ fn (mut g Gen) gen_array_prepend(node ast.CallExpr) {
 		g.expr(node.args[0].expr)
 		g.write('.len)')
 	} else {
-		g.write(', &($elem_type_str[]){')
+		g.write(', &($elem_type_str\[]){')
 		g.expr(node.args[0].expr)
 		g.write('})')
 	}
@@ -4809,15 +4809,15 @@ fn (mut g Gen) array_init(it ast.ArrayInit) {
 			g.write('sizeof($elem_type_str), ')
 		}
 		if is_default_array {
-			g.write('($elem_type_str[]){')
+			g.write('($elem_type_str\[]){')
 			g.expr(it.default_expr)
 			g.write('}[0])')
 		} else if it.has_default {
-			g.write('&($elem_type_str[]){')
+			g.write('&($elem_type_str\[]){')
 			g.expr(it.default_expr)
 			g.write('})')
 		} else if it.has_len && it.elem_type == table.string_type {
-			g.write('&($elem_type_str[]){')
+			g.write('&($elem_type_str\[]){')
 			g.write('tos_lit("")')
 			g.write('})')
 		} else {
@@ -4830,7 +4830,7 @@ fn (mut g Gen) array_init(it ast.ArrayInit) {
 	if elem_sym.kind == .function {
 		g.write('new_array_from_c_array($len, $len, sizeof(voidptr), _MOV((voidptr[$len]){')
 	} else {
-		g.write('new_array_from_c_array($len, $len, sizeof($elem_type_str), _MOV(($elem_type_str[$len]){')
+		g.write('new_array_from_c_array($len, $len, sizeof($elem_type_str), _MOV(($elem_type_str\[$len]){')
 	}
 	if len > 8 {
 		g.writeln('')

--- a/vlib/v/gen/json.v
+++ b/vlib/v/gen/json.v
@@ -256,7 +256,7 @@ fn (mut g Gen) encode_map(key_type, value_type table.Type) string {
 	array_$styp $keys_tmp = map_keys(&val);
 	for (int i = 0; i < ${keys_tmp}.len; ++i) {
 		$key
-		cJSON_AddItemToObject(o, (char*) key.str, $fn_name_v ( *($styp_v*) map_get(val, key, &($styp_v[]) { $zero } ) ) );
+		cJSON_AddItemToObject(o, (char*) key.str, $fn_name_v ( *($styp_v*) map_get(val, key, &($styp_v\[]) { $zero } ) ) );
 	}
 	array_free(&$keys_tmp);
 '

--- a/vlib/v/gen/sql.v
+++ b/vlib/v/gen/sql.v
@@ -230,7 +230,7 @@ fn (mut g Gen) sql_select_expr(node ast.SqlExpr) {
 			}
 		}
 		if node.is_array {
-			g.writeln('\t array_push(&${tmp}_array, _MOV(($elem_type_str[]){ $tmp }));')
+			g.writeln('\t array_push(&${tmp}_array, _MOV(($elem_type_str\[]){ $tmp }));')
 		}
 		g.writeln('}')
 		g.writeln('sqlite3_finalize($g.sql_stmt_name);')

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -130,7 +130,7 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr, left_comments []ast.Comme
 			}
 			ast.IndexExpr {
 				if op == .decl_assign {
-					p.error_with_pos('non-name `$lx.left[$lx.index]` on left side of `:=`',
+					p.error_with_pos('non-name `$lx.left\[$lx.index]` on left side of `:=`',
 						lx.pos)
 				}
 				lx.is_setter = true

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -724,8 +724,8 @@ fn (mut s Scanner) text_scan() token.Token {
 				}
 			}
 			// end of `$expr`
-			// allow `'$a.b'` and `'$a.c()'`
-			if s.is_inter_start && next_char != `.` && next_char != `(` {
+			// allow `$a.b`, `$f()`, `$a[expr]`, `$s.m()`, `$s.a[expr]`
+			if s.is_inter_start && next_char !in [`.`, `(`, `[`] {
 				s.is_inter_end = true
 				s.is_inter_start = false
 			}
@@ -753,8 +753,8 @@ fn (mut s Scanner) text_scan() token.Token {
 			num := s.ident_number()
 			return s.new_token(.number, num, num.len)
 		}
-		// Handle `'$fn()'`
-		if c == `)` && s.is_inter_start {
+		// Handle `$fn()`, `$a[expr]`
+		if c in [`)`, `]`] && s.is_inter_start {
 			next_char := s.look_ahead(1)
 			if next_char != `.` {
 				s.is_inter_end = true
@@ -762,7 +762,10 @@ fn (mut s Scanner) text_scan() token.Token {
 				if next_char == s.quote {
 					s.is_inside_string = false
 				}
-				return s.new_token(.rpar, '', 1)
+				if c == `)` {
+					return s.new_token(.rpar, '', 1)
+				}
+				return s.new_token(.rsbr, '', 1)
 			}
 		}
 		// all other tokens

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -724,7 +724,7 @@ fn (mut s Scanner) text_scan() token.Token {
 				}
 			}
 			// end of `$expr`
-			// allow `$a.b`, `$f()`, `$a[expr]`, `$s.m()`, `$s.a[expr]`
+			// allow `$a.b`, `$f()`, `$a[expr]`
 			if s.is_inter_start && next_char !in [`.`, `(`, `[`] {
 				s.is_inter_end = true
 				s.is_inter_start = false
@@ -756,7 +756,8 @@ fn (mut s Scanner) text_scan() token.Token {
 		// Handle `$fn()`, `$a[expr]`
 		if c in [`)`, `]`] && s.is_inter_start {
 			next_char := s.look_ahead(1)
-			if next_char != `.` {
+			// allow `$s.m()`, `$s.a[expr]`, `$f()[expr]` etc
+			if next_char !in [`.`, `(`, `[`] {
 				s.is_inter_end = true
 				s.is_inter_start = false
 				if next_char == s.quote {

--- a/vlib/v/tests/string_interpolation_struct_test.v
+++ b/vlib/v/tests/string_interpolation_struct_test.v
@@ -19,6 +19,27 @@ fn test_default_struct_string_interpolation() {
 	// println(s)
 }
 
+struct S1 {
+mut:
+	a []int = [7]
+}
+
+fn (s S1) m() int {
+	return s.a[0]
+}
+
+fn test_array_interpolation() {
+	a := [2,3]
+	assert '$a[1]' == '3'
+	mut s := S1{}
+	assert '$s.a[0]' == '7'
+	assert '$s.m()' == '7'
+	b := [s]
+	assert '$b[0].a' == '[7]'
+	s.a[0]++
+	assert '$b[0].a[0]' == '8'
+}
+
 struct Context {
 pub mut:
 	vb [8]f64

--- a/vlib/v/tests/string_interpolation_struct_test.v
+++ b/vlib/v/tests/string_interpolation_struct_test.v
@@ -24,19 +24,22 @@ mut:
 	a []int = [7]
 }
 
-fn (s S1) m() int {
-	return s.a[0]
+fn (s S1) m() []int {
+	return s.a
 }
 
 fn test_array_interpolation() {
 	a := [2,3]
 	assert '$a[1]' == '3'
+	
 	mut s := S1{}
 	assert '$s.a[0]' == '7'
-	assert '$s.m()' == '7'
-	b := [s]
-	assert '$b[0].a' == '[7]'
+	assert '$s.m()' == '[7]'
+	assert '$s.m()[0]' == '7'
+	
 	s.a[0]++
+	b := [s]
+	assert '$b[0].a' == '[8]'
 	assert '$b[0].a[0]' == '8'
 }
 


### PR DESCRIPTION
Fixes #6162. Given that calling a function with `'$f(expr)'` works, indexing should too.

Also supports `'$s.a[expr]'`, `'$s.m()[expr]'` and other combinations.