### PR TITLE
help.v: fix 'v help' command always printing error message

### DIFF
--- a/cmd/v/help/help.v
+++ b/cmd/v/help/help.v
@@ -14,9 +14,10 @@ pub fn print_and_exit(topic string) {
 	for b in topic {
 		if (b >= `a` && b <= `z`) || b == `-` || (b >= `0` && b <= `9`) {
 			continue
+		} else {
+			println(unknown_topic)
+			exit(1)
 		}
-		println(unknown_topic)
-		exit(1)
 	}
 	target_topic := os.join_path(vroot, 'cmd', 'v', 'help', '${topic}.txt')
 	content := os.read_file(target_topic) or {


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
