### PR TITLE
fmt: don't remove `mut` from `if mut` smart cast

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -472,9 +472,10 @@ pub:
 	pos          token.Position
 	body_pos     token.Position
 	comments     []Comment
+	left_as_name string // `name` in `if cond is SumType as name`
+	mut_name     bool // `if mut name is`
 pub mut:
-	smartcast    bool // should only be true if cond is `x is sumtype`, it will be set in checker - if_expr
-	left_as_name string // only used in x is SumType check
+	smartcast    bool // true when cond is `x is SumType`, set in checker.if_expr
 }
 
 pub struct UnsafeExpr {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1357,35 +1357,30 @@ pub fn (mut f Fmt) if_expr(it ast.IfExpr) {
 			}
 		}
 		if i == 0 {
+			// first `if`
 			f.comments(branch.comments, {})
-			f.write('if ')
-			f.expr(branch.cond)
-			if smartcast_as {
-				f.write(' as $branch.left_as_name')
-			}
-			f.write(' {')
-		} else if i < it.branches.len - 1 || !it.has_else {
+		} else {
+			// `else`, close previous branch
 			if branch.comments.len > 0 {
 				f.writeln('}')
 				f.comments(branch.comments, {})
 			} else {
 				f.write('} ')
 			}
-			f.write('else if ')
-			f.expr(branch.cond)
-			if smartcast_as {
-				f.write(' as $branch.left_as_name')
-			}
-			f.write(' {')
-		} else if i == it.branches.len - 1 && it.has_else {
-			if branch.comments.len > 0 {
-				f.writeln('}')
-				f.comments(branch.comments, {})
-			} else {
-				f.write('} ')
-			}
-			f.write('else {')
+			f.write('else ')
 		}
+		if i < it.branches.len - 1 || !it.has_else {
+			f.write('if ')
+			if branch.mut_name {
+				f.write('mut ')
+			}
+			f.expr(branch.cond)
+			if smartcast_as {
+				f.write(' as $branch.left_as_name')
+			}
+			f.write(' ')
+		}
+		f.write('{')
 		if single_line {
 			f.write(' ')
 		} else {

--- a/vlib/v/fmt/tests/sum_smartcast_keep.vv
+++ b/vlib/v/fmt/tests/sum_smartcast_keep.vv
@@ -1,4 +1,6 @@
 struct S1 {
+mut:
+	i int
 }
 
 struct S2 {
@@ -7,7 +9,8 @@ struct S2 {
 type Sum = S1 | S2
 
 fn f(sum Sum) {
-	if sum is S1 {
+	if mut sum is S1 {
+		sum.i++
 	}
 	if sum is S1 as s1 {
 	}


### PR DESCRIPTION
Also refactor to avoid code duplication.

Note: `if mut` is not currently enforced for mutation of a sum instance element AFAICT, but it is already used in `parser/pratt.v`.