### PR TITLE
ci: removed openssl install on windows builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,6 @@ jobs:
       run: |
         .\v.exe setup-freetype
         .\.github\workflows\windows-install-sqlite.bat
-        choco install openssl
         ## .\.github\workflows\windows-install-sdl.bat
     - name: Fixed tests
       run: |
@@ -336,7 +335,6 @@ jobs:
       run: |
         .\v.exe setup-freetype
         .\.github\workflows\windows-install-sqlite.bat
-        choco install openssl
         ## .\.github\workflows\windows-install-sdl.bat
     - name: Fixed tests
       run: |
@@ -375,7 +373,6 @@ jobs:
       run: |
         .\v.exe setup-freetype
         .\.github\workflows\windows-install-sqlite.bat
-        choco install openssl
         ## .\.github\workflows\windows-install-sdl.bat
     - name: Fixed tests
       run: |


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
Removing open ssl installtion on windows builds. It adds almost 3 minutes to build time. I will look into pre-built windows contianers to build windows stuff at another time