### PR TITLE
checker: require `mut` with `if` smart cast

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2991,10 +2991,18 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) table.Type {
 					if left_sym.kind == .sum_type && branch.left_as_name.len > 0 {
 						mut scope := c.file.scope.innermost(branch.body_pos.pos)
 						if branch.mut_name {
-							left := infix.left as ast.Ident
-							if var := scope.find_var(left.name) {
-								if !var.is_mut {
-									c.error('`mut` used with immutable `$left.name`', left.pos)
+							if infix.left is ast.Ident as left {
+								if var := scope.find_var(left.name) {
+									if !var.is_mut {
+										c.error('`mut` used with immutable `$left.name`', left.pos)
+									}
+								}
+							} else if infix.left is ast.SelectorExpr as selector {
+								if field := c.table.struct_find_field(left_sym, selector.field_name) {
+									if !field.is_mut {
+										c.error('`mut` used with immutable `$selector`', selector.pos)
+
+									}
 								}
 							}
 						}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1371,12 +1371,18 @@ pub fn (mut f Fmt) if_expr(it ast.IfExpr) {
 		}
 		if i < it.branches.len - 1 || !it.has_else {
 			f.write('if ')
-			if branch.mut_name {
-				f.write('mut ')
-			}
-			f.expr(branch.cond)
 			if smartcast_as {
-				f.write(' as $branch.left_as_name')
+				f.expr(branch.cond)
+				f.write(' as ')
+				if branch.mut_name {
+					f.write('mut ')
+				}
+				f.write('$branch.left_as_name')
+			} else {
+				if branch.mut_name {
+					f.write('mut ')
+				}
+				f.expr(branch.cond)
 			}
 			f.write(' ')
 		}

--- a/vlib/v/fmt/tests/sum_smartcast_keep.vv
+++ b/vlib/v/fmt/tests/sum_smartcast_keep.vv
@@ -8,15 +8,16 @@ struct S2 {
 
 type Sum = S1 | S2
 
-fn f(sum Sum) {
+fn f() {
+	mut sum := Sum(S1{})
 	if mut sum is S1 {
 		sum.i++
 	}
 	if sum is S1 as s1 {
 	}
-	a := [sum]
+	mut a := [sum]
 	if a[0] is S2 {
 	}
-	if a[0] is S2 as s2 {
+	if a[0] is S2 as mut s2 {
 	}
 }

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -100,16 +100,17 @@ fn (mut p Parser) if_expr() ast.IfExpr {
 		mut left_as_name := ''
 		if cond is ast.InfixExpr as infix {
 			// if sum is T
-			is_is_cast := infix.op == .key_is
-			is_ident := infix.left is ast.Ident
-			left_as_name = if is_is_cast && p.tok.kind == .key_as {
+			if infix.op == .key_is && p.tok.kind == .key_as {
 				p.next()
-				p.check_name()
-			} else if is_ident {
-				ident := infix.left as ast.Ident
-				ident.name
-			} else {
-				''
+				comments << p.eat_comments()
+				if p.tok.kind == .key_mut {
+					p.next()
+					comments << p.eat_comments()
+					mut_name = true
+				}
+				left_as_name = p.check_name()
+			} else if infix.left is ast.Ident as ident {
+				left_as_name = ident.name
 			}
 		}
 		end_pos := p.prev_tok.position()


### PR DESCRIPTION
Require `mut` to mutate `name` with `if mut name is T`. (`vfmt` already updated in #6188).
Require `mut` to mutate `name` with `if expr is T as mut name`, update `vfmt`.

Draft as it needs error tests.