### PR TITLE
Fix mini_calculator.v end-of-line to use LF

### DIFF
--- a/examples/mini_calculator.v
+++ b/examples/mini_calculator.v
@@ -1,10 +1,9 @@
 // Q: What's this?
 // A: This is a mini "home-made" calculator. You may also regard it as a very elementary version of "interpreter".
-
 import os
 
 const (
-	numeric_char = [`0`,`1`,`2`,`3`,`4`,`5`,`6`,`7`,`8`,`9`,`.`,`e`,`E`]
+	numeric_char = [`0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, `.`, `e`, `E`]
 )
 
 // Convert expression to Reverse Polish Notation.
@@ -15,53 +14,52 @@ fn expr_to_rev_pol(expr string) ?[]string {
 	mut stack := []string{}
 	mut rev_pol := []string{}
 	mut pos := 0
-	for pos<expr.len {
+	for pos < expr.len {
 		mut end_pos := pos
-		for end_pos<expr.len && expr[end_pos] in numeric_char {
+		for end_pos < expr.len && expr[end_pos] in numeric_char {
 			end_pos++
 		}
-		if end_pos>pos {
+		if end_pos > pos {
 			stack << expr[pos..end_pos]
 			pos = end_pos
-		}
-		else if end_pos==pos {
+		} else if end_pos == pos {
 			op := expr[pos].str()
 			match op {
 				'(' {
 					stack << op
 				}
 				'*', '/' {
-					for stack.len>0 && stack.last() !in ['(', '+', '-'] {
+					for stack.len > 0 && stack.last() !in ['(', '+', '-'] {
 						rev_pol << stack.last()
-						stack.delete(stack.len-1)
+						stack.delete(stack.len - 1)
 					}
 					stack << op
 				}
 				'+', '-' {
-					for stack.len>0 && stack.last() != '(' {
+					for stack.len > 0 && stack.last() != '(' {
 						rev_pol << stack.last()
-						stack.delete(stack.len-1)
+						stack.delete(stack.len - 1)
 					}
 					stack << op
 				}
 				')' {
-					for stack.len>0 && stack.last() != '(' {
+					for stack.len > 0 && stack.last() != '(' {
 						rev_pol << stack.last()
-						stack.delete(stack.len-1)
+						stack.delete(stack.len - 1)
 					}
-					stack.delete(stack.len-1)
+					stack.delete(stack.len - 1)
 				}
 				else {
-					return error('err: invalid character `${op}`')
+					return error('err: invalid character `$op`')
 				}
 			}
 			pos++
 		}
 	}
-	for stack.len>0 {
+	for stack.len > 0 {
 		top := stack.last()
 		rev_pol << top
-		stack.delete(stack.len-1)
+		stack.delete(stack.len - 1)
 	}
 	return rev_pol
 }
@@ -72,27 +70,31 @@ fn eval_rev_pol(rev_pol []string) ?f64 {
 	for item in rev_pol {
 		if is_num_string(item) {
 			stack << item.f64()
-		}
-		else {
-			if stack.len>=2 {
+		} else {
+			if stack.len >= 2 {
 				oprand_r := stack.last()
-				stack.delete(stack.len-1)
+				stack.delete(stack.len - 1)
 				oprand_l := stack.last()
-				stack.delete(stack.len-1)
+				stack.delete(stack.len - 1)
 				match item {
-					'+' { stack << oprand_l+oprand_r }
-					'-' { stack << oprand_l-oprand_r }
-					'*' { stack << oprand_l*oprand_r }
+					'+' {
+						stack << oprand_l + oprand_r
+					}
+					'-' {
+						stack << oprand_l - oprand_r
+					}
+					'*' {
+						stack << oprand_l * oprand_r
+					}
 					'/' {
 						if oprand_r == 0 {
 							return error('err: divide by zero')
 						}
-						stack << oprand_l/oprand_r
+						stack << oprand_l / oprand_r
 					}
 					else {}
 				}
-			}
-			else {
+			} else {
 				return error('err: invalid expression')
 			}
 		}
@@ -109,10 +111,9 @@ fn is_num_string(str string) bool {
 	return true
 }
 
-
 fn main() {
 	println('Please enter the expression you want to calculate, e.g. 1e2+(3-2.5)*6/1.5 .')
-	println('Enter \'exit\' or \'EXIT\' to quit.')
+	println("Enter \'exit\' or \'EXIT\' to quit.")
 	mut expr_count := 0
 	for {
 		expr_count++


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
Very simple thing, mini_calculator.v used CRLF rather than LF. I just made it consistent with the other source files.