### PR TITLE
[direct_array_access] tag

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2285,8 +2285,8 @@ but may impact the size of your executable.
 `[direct_array_access]` - in functions tagged with `[direct_array_access]`
 the compiler will translate array operations directly into C array operations - 
 omiting bounds checking. This may save a lot of time in a function that iterates
-over an array but at the cost of making the function unsafe
-- unless the boundries will be checked by the user.
+over an array but at the cost of making the function unsafe - unless
+the boundries will be checked by the user.
 
 `if _likely_(bool expression) {` this hints the C compiler, that the passed
 boolean expression is very likely to be true, so it can generate assembly

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2270,7 +2270,7 @@ eprintln('$vm.name $vm.version\n $vm.description')
 
 The generated C code is usually fast enough, when you compile your code
 with `-prod`. There are some situations though, where you may want to give
-additional hints to the C compiler, so that it can further optimize some
+additional hints to the compiler, so that it can further optimize some
 blocks of code.
 
 NB: These are *rarely* needed, and should not be used, unless you
@@ -2281,6 +2281,12 @@ how their programs actually perform".
 `[inline]` - you can tag functions with `[inline]`, so the C compiler will
 try to inline them, which in some cases, may be beneficial for performance,
 but may impact the size of your executable.
+
+`[direct_array_access]` - in functions tagged with `[direct_array_access]`
+the compiler will translate array operations directly into C array operations - 
+omiting bounds checking. This may save a lot of time in a function that iterates
+over an array but at the cost of making the function unsafe
+- unless the boundries will be checked by the user.
 
 `if _likely_(bool expression) {` this hints the C compiler, that the passed
 boolean expression is very likely to be true, so it can generate assembly

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1001,3 +1001,34 @@ fn test_array_string_pop() {
 	assert a.len == 0
 	assert a.cap == 3
 }
+
+
+[direct_array_access]
+fn test_direct_array_access() {
+	mut a := [11,22,33,44]
+	assert a[0] == 11
+	assert a[2] == 33
+	x := a[0]
+	a[0] = 21
+	a[1] += 2
+	a[2] = x + 3
+	a[3] -= a[1]
+	assert a == [21, 24, 14, 20]
+}
+
+[direct_array_access]
+fn test_direct_array_access_via_ptr() {
+	mut b := [11,22,33,44]
+	unsafe {
+		mut a := &b
+		assert a[0] == 11
+		assert a[2] == 33
+		x := a[0]
+		a[0] = 21
+		a[1] += 2
+		a[2] = x + 3
+		a[3] -= a[1]
+		assert a == [21, 24, 14, 20]
+	}
+}
+

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -258,6 +258,7 @@ pub:
 	body_pos      token.Position
 	file          string
 	is_generic    bool
+	is_direct_arr bool // direct array access
 	attrs         []table.Attr
 pub mut:
 	stmts         []Stmt

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2817,7 +2817,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 					is_direct_array_access := g.fn_decl != 0 && g.fn_decl.is_direct_arr
 					array_ptr_type_str := match elem_typ.kind {
 						.function { 'voidptr*' }
-						else      { '$elem_type_str*' }
+						else { '$elem_type_str*' }
 					}
 					if is_direct_array_access {
 						g.write('(($array_ptr_type_str)')
@@ -2849,7 +2849,6 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 					} else {
 						g.write(', ')
 						g.expr(node.index)
-
 						mut need_wrapper := true
 						/*
 						match node.right {
@@ -2874,7 +2873,6 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 						if g.assign_op != .assign &&
 							g.assign_op in token.assign_tokens && info.elem_type != table.string_type {
 							// TODO move this
-							
 							g.write('*($elem_type_str*)array_get(')
 							if left_is_ptr && !node.left_type.has_flag(.shared_f) {
 								g.write('*')
@@ -2908,10 +2906,9 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 					}
 				} else {
 					is_direct_array_access := g.fn_decl != 0 && g.fn_decl.is_direct_arr
-					
 					array_ptr_type_str := match elem_typ.kind {
 						.function { 'voidptr*' }
-						else      { '$elem_type_str*' }
+						else { '$elem_type_str*' }
 					}
 					if is_direct_array_access {
 						g.write('(($array_ptr_type_str)')

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -783,6 +783,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 			}
 		}
 		ast.FnDecl {
+			g.gen_attrs(node.attrs)
 			// g.tmp_count = 0 TODO
 			mut skip := false
 			pos := g.out.buf.len
@@ -2813,10 +2814,20 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 				// `(*(Val*)array_get(vals, i)).field = x;`
 				is_selector := node.left is ast.SelectorExpr
 				if g.is_assign_lhs && !is_selector && node.is_setter {
-					g.is_array_set = true
-					g.write('array_set(')
-					if !left_is_ptr || node.left_type.has_flag(.shared_f) {
-						g.write('&')
+					// --- kerbal ----------------------------------------------
+					is_direct_array_access := g.fn_decl != 0 && g.fn_decl.is_direct_arr
+					array_ptr_type_str := match elem_typ.kind {
+						.function { 'voidptr*' }
+						else      { '$elem_type_str*' }
+					}
+					if is_direct_array_access {
+						g.write('(($array_ptr_type_str)')
+					} else {
+						g.is_array_set = true // special handling of assign_op and closing with '})'
+						g.write('array_set(')
+						if !left_is_ptr || node.left_type.has_flag(.shared_f) {
+							g.write('&')
+						}
 					}
 					g.expr(node.left)
 					if node.left_type.has_flag(.shared_f) {
@@ -2826,72 +2837,91 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 							g.write('.val')
 						}
 					}
-					g.write(', ')
-					g.expr(node.index)
-					mut need_wrapper := true
-					/*
-					match node.right {
-						ast.EnumVal, ast.Ident {
-							// `&x` is enough for variables and enums
-							// `&(Foo[]){ ... }` is only needed for function calls and literals
-							need_wrapper = false
-						}
-						else {}
-					}
-					*/
-					if need_wrapper {
-						if elem_typ.kind == .function {
-							g.write(', &(voidptr[]) { ')
-						} else {
-							g.write(', &($elem_type_str[]) { ')
-						}
+					if is_direct_array_access {
+						g.write('.data)[')
+						g.expr(node.index)
+						g.write(']')
 					} else {
-						g.write(', &')
-					}
-					// `x[0] *= y`
-					if g.assign_op != .assign &&
-						g.assign_op in token.assign_tokens && info.elem_type != table.string_type {
-						// TODO move this
-						g.write('*($elem_type_str*)array_get(')
-						if left_is_ptr && !node.left_type.has_flag(.shared_f) {
-							g.write('*')
-						}
-						g.expr(node.left)
-						if node.left_type.has_flag(.shared_f) {
-							if left_is_ptr {
-								g.write('->val')
-							} else {
-								g.write('.val')
-							}
-						}
 						g.write(', ')
 						g.expr(node.index)
-						g.write(') ')
-						op := match g.assign_op {
-							.mult_assign { '*' }
-							.plus_assign { '+' }
-							.minus_assign { '-' }
-							.div_assign { '/' }
-							.xor_assign { '^' }
-							.mod_assign { '%' }
-							.or_assign { '|' }
-							.and_assign { '&' }
-							.left_shift_assign { '<<' }
-							.right_shift_assign { '>>' }
-							else { '' }
+
+						mut need_wrapper := true
+						/*
+						match node.right {
+							ast.EnumVal, ast.Ident {
+								// `&x` is enough for variables and enums
+								// `&(Foo[]){ ... }` is only needed for function calls and literals
+								need_wrapper = false
+							}
+							else {}
 						}
-						g.write(op)
+						*/
+						if need_wrapper {
+							if elem_typ.kind == .function {
+								g.write(', &(voidptr[]) { ')
+							} else {
+								g.write(', &($elem_type_str[]) { ')
+							}
+						} else {
+							g.write(', &')
+						}
+						// `x[0] *= y`
+						if g.assign_op != .assign &&
+							g.assign_op in token.assign_tokens && info.elem_type != table.string_type {
+							// TODO move this
+							
+							g.write('*($elem_type_str*)array_get(')
+							if left_is_ptr && !node.left_type.has_flag(.shared_f) {
+								g.write('*')
+							}
+							g.expr(node.left)
+							if node.left_type.has_flag(.shared_f) {
+								if left_is_ptr {
+									g.write('->val')
+								} else {
+									g.write('.val')
+								}
+							}
+							g.write(', ')
+							g.expr(node.index)
+							g.write(') ')
+							op := match g.assign_op {
+								.mult_assign { '*' }
+								.plus_assign { '+' }
+								.minus_assign { '-' }
+								.div_assign { '/' }
+								.xor_assign { '^' }
+								.mod_assign { '%' }
+								.or_assign { '|' }
+								.and_assign { '&' }
+								.left_shift_assign { '<<' }
+								.right_shift_assign { '>>' }
+								else { '' }
+							}
+							g.write(op)
+						}
 					}
 				} else {
-					if elem_typ.kind == .function {
-						g.write('(*(voidptr*)array_get(')
-					} else {
-						g.write('(*($elem_type_str*)array_get(')
+					// --- kerbal ----------------------------------------------
+					is_direct_array_access := g.fn_decl != 0 && g.fn_decl.is_direct_arr
+					
+					array_ptr_type_str := match elem_typ.kind {
+						.function { 'voidptr*' }
+						else      { '$elem_type_str*' }
 					}
+					if is_direct_array_access {
+						g.write('(($array_ptr_type_str)')
+					} else {
+						g.write('(*($array_ptr_type_str)array_get(')
+					}
+					// TODO combine ifs above and below g.expr
+					// TODO: 1 test cases - when 'shared' is implemented
+					// TODO: 1 test cases
 					if left_is_ptr && !node.left_type.has_flag(.shared_f) {
 						g.write('*')
 					}
 					g.expr(node.left)
+					// TODO: 2 test cases - when 'shared' is implemented
 					if node.left_type.has_flag(.shared_f) {
 						if left_is_ptr {
 							g.write('->val')
@@ -2899,9 +2929,16 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 							g.write('.val')
 						}
 					}
-					g.write(', ')
-					g.expr(node.index)
-					g.write('))')
+					if is_direct_array_access {
+						g.write('.data)')
+						g.write('[')
+						g.expr(node.index)
+						g.write(']')
+					} else {
+						g.write(', ')
+						g.expr(node.index)
+						g.write('))')
+					}
 				}
 			} else if sym.kind == .map {
 				info := sym.info as table.Map

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -132,6 +132,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	p.top_level_statement_start()
 	start_pos := p.tok.position()
 	is_deprecated := p.attrs.contains('deprecated')
+	is_direct_arr := p.attrs.contains('direct_array_access')
 	mut is_unsafe := p.attrs.contains('unsafe')
 	is_pub := p.tok.kind == .key_pub
 	if is_pub {
@@ -312,6 +313,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		return_type: return_type
 		args: args
 		is_deprecated: is_deprecated
+		is_direct_arr: is_direct_arr
 		is_pub: is_pub
 		is_generic: is_generic
 		is_variadic: is_variadic


### PR DESCRIPTION
New function tag, that optimizes access to arrays by replacing array_get/array_set call with direct array operations - omitting boundary checking.

The optimization was tested on [kostya bf.v benchmark](https://github.com/kostya/benchmarks/blob/master/brainfuck/bf.v).
By adding `[direct_array_access]` to Tape.get and Tape.inc methods the reduction in execution time can be observed.

```v
...
[direct_array_access]
fn (t Tape) get() int {
	return t.tape[t.pos]
}

[direct_array_access]
fn (mut t Tape) inc(x int) {
	t.tape[t.pos] += x
}
...
```

**v -cc clang -prod**:
```
C:\repo\v_sandbox\direct_array_access>hyperfine "bf_clang_prod.exe bench.b" "bf2_clang_prod.exe bench.b"
Benchmark #1: bf_clang_prod.exe bench.b                                                                                              0
  Time (mean ± σ):      6.410 s ±  0.164 s    [User: 5.9 ms, System: 9.6 ms]                                                         0
  Range (min … max):    6.097 s …  6.669 s    10 runs

Benchmark #2: bf2_clang_prod.exe bench.b
  Time (mean ± σ):      5.033 s ±  0.049 s    [User: 9.1 ms, System: 6.5 ms]                                                         0
  Range (min … max):    4.941 s …  5.082 s    10 runs

Summary
  'bf2_clang_prod.exe bench.b' ran
    1.27 ± 0.03 times faster than 'bf_clang_prod.exe bench.b'
```


**v -cc clang**:
```
C:\repo\v_sandbox\direct_array_access>hyperfine "bf_clang.exe bench.b" "bf2_clang.exe bench.b"
Benchmark #1: bf_clang.exe bench.b                                                                                                   0
  Time (mean ± σ):     12.630 s ±  0.174 s    [User: 6.5 ms, System: 10.4 ms]                                                        0
  Range (min … max):   12.356 s … 12.896 s    10 runs

Benchmark #2: bf2_clang.exe bench.b
  Time (mean ± σ):      8.807 s ±  0.219 s    [User: 7.9 ms, System: 8.9 ms]                                                         0
  Range (min … max):    8.560 s …  9.194 s    10 runs

Summary
  'bf2_clang.exe bench.b' ran
    1.43 ± 0.04 times faster than 'bf_clang.exe bench.b'
```


**v -cc tcc**:
```
C:\repo\v_sandbox\direct_array_access>hyperfine "bf_tcc.exe bench.b" "bf2_tcc.exe bench.b"
Benchmark #1: bf_tcc.exe bench.b                                                                                                     0
  Time (mean ± σ):     29.377 s ±  1.613 s    [User: 2.5 ms, System: 19.7 ms]                                                        0
  Range (min … max):   27.633 s … 32.418 s    10 runs

Benchmark #2: bf2_tcc.exe bench.b
  Time (mean ± σ):     19.227 s ±  0.644 s    [User: 6.5 ms, System: 11.8 ms]                                                        0
  Range (min … max):   18.236 s … 20.478 s    10 runs

Summary
  'bf2_tcc.exe bench.b' ran
    1.53 ± 0.10 times faster than 'bf_tcc.exe bench.b'
```


