### PR TITLE
make.bat: quote paths when cloning `tcc`

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -4,7 +4,7 @@ echo Building V
 
 REM default tcc
 set tcc_url=https://github.com/vlang/tccbin_win
-set tcc_dir=%~dp0thirdparty\tcc
+set tcc_dir="%~dp0thirdparty\tcc"
 
 REM let a particular environment specify their own tcc
 if "%TCC_GIT%" =="" goto :init
@@ -108,10 +108,10 @@ if %ERRORLEVEL% NEQ 0 goto :compile_error
 goto :success
 
 :fresh_tcc
-rd /s /q %tcc_dir%
+rd /s /q "%tcc_dir%"
 
 :clone_tcc
-git clone --depth 1 --quiet %tcc_url% %tcc_dir%
+git clone --depth 1 --quiet "%tcc_url%" "%tcc_dir%"
 set cloned_tcc=1
 goto :tcc_strap
 
@@ -122,7 +122,7 @@ echo Attempting to build v.c with TCC...
 where /q tcc
 if %ERRORLEVEL% NEQ 0 (
 	if exist "%tcc_dir%" (
-		set tcc_exe=%tcc_dir%\tcc.exe
+		set tcc_exe="%tcc_dir%\tcc.exe"
 	) else if "%cloned_tcc%"=="" (
 		echo  ^> TCC not found
 		echo  ^> Downloading TCC from %tcc_url%
@@ -143,8 +143,7 @@ if exist "%tcc_dir%" (
 		popd
 	)
 )
-
-%tcc_exe% -std=c99 -municode -lws2_32 -lshell32 -ladvapi32 -bt10 -w -o v.exe vc\v_win.c
+"%tcc_exe%" -std=c99 -municode -lws2_32 -lshell32 -ladvapi32 -bt10 -w -o v.exe vc\v_win.c
 if %ERRORLEVEL% NEQ 0 goto :compile_error
 
 echo  ^> Compiling with .\v.exe self


### PR DESCRIPTION
This avoids escaping issues if V is installed on a directory with spaces in its name, and should also fix #6207.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
