### PR TITLE
table: Make `size_t` an internal alias for u32 or u64; add `isize`, `usize`

### DIFF
--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -33,6 +33,7 @@ pub fn new_builder(pref &pref.Preferences) Builder {
 	compiled_dir := if os.is_dir(rdir) { rdir } else { os.dir(rdir) }
 	mut table := table.new_table()
 	table.is_fmt = false
+	table.m64 = pref.m64
 	if pref.use_color == .always {
 		util.emanager.set_support_color(true)
 	}

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -209,7 +209,7 @@ pub fn (mut g JsGen) typ(t table.Type) string {
 		.byteptr, .charptr {
 			styp = 'string'
 		}
-		.i8, .i16, .int, .i64, .byte, .u16, .u32, .u64, .f32, .f64, .any_int, .any_float, .size_t {
+		.i8, .i16, .int, .i64, .byte, .u16, .u32, .u64, .f32, .f64, .any_int, .any_float {
 			// TODO: Should u64 and i64 use BigInt rather than number?
 			styp = 'number'
 		}
@@ -330,7 +330,7 @@ fn (mut g JsGen) to_js_typ_val(t table.Type) string {
 	sym := g.table.get_type_symbol(t)
 	mut styp := ''
 	match sym.kind {
-		.i8, .i16, .int, .i64, .byte, .u16, .u32, .u64, .f32, .f64, .any_int, .any_float, .size_t {
+		.i8, .i16, .int, .i64, .byte, .u16, .u32, .u64, .f32, .f64, .any_int, .any_float {
 			styp = '0'
 		}
 		.bool {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -272,6 +272,12 @@ pub fn (mut p Parser) parse_any_type(language table.Language, is_ptr bool, check
 				'i64' {
 					return table.i64_type
 				}
+				'isize' {
+					if p.pref.m64 {
+						return table.i64_type
+					}
+					return table.int_type
+				}
 				'byte' {
 					return table.byte_type
 				}
@@ -283,6 +289,12 @@ pub fn (mut p Parser) parse_any_type(language table.Language, is_ptr bool, check
 				}
 				'u64' {
 					return table.u64_type
+				}
+				'usize', 'size_t' {
+					if p.pref.m64 {
+						return table.u64_type
+					}
+					return table.u32_type
 				}
 				'f32' {
 					return table.f32_type

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -20,6 +20,7 @@ pub mut:
 	fn_gen_types  map[string][]Type // for generic functions
 	cmod_prefix   string // needed for table.type_to_str(Type) while vfmt; contains `os.`
 	is_fmt        bool
+	m64           bool // 64-bit code
 }
 
 pub struct Fn {

--- a/vlib/v/table/types.v
+++ b/vlib/v/table/types.v
@@ -366,7 +366,7 @@ pub const (
 pub const (
 	builtin_type_names = ['void', 'voidptr', 'charptr', 'byteptr', 'i8', 'i16', 'int', 'i64', 'u16',
 		'u32', 'u64', 'any_int', 'f32', 'f64', 'any_float', 'string', 'ustring', 'char', 'byte', 'bool',
-		'none', 'array', 'array_fixed', 'map', 'chan', 'any', 'struct', 'mapnode', 'size_t', 'rune']
+		'none', 'array', 'array_fixed', 'map', 'chan', 'any', 'struct', 'mapnode', 'rune']
 )
 
 pub struct MultiReturn {
@@ -406,7 +406,6 @@ pub enum Kind {
 	f32
 	f64
 	char
-	size_t
 	rune
 	bool
 	none_
@@ -656,11 +655,15 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 		cname: 'chan'
 		mod: 'builtin'
 	})
+	mut size_kind := Kind.u32
+	if t.m64 {
+		size_kind = .u64
+	}
 	t.register_type_symbol({
-		kind: .size_t
-		name: 'size_t'
-		source_name: 'size_t'
-		cname: 'size_t'
+		kind: size_kind
+		name: 'usize'
+		source_name: 'usize'
+		cname: 'usize'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
@@ -710,6 +713,25 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 		mod: 'builtin'
 		parent_idx: map_string_int_idx
 	})
+	// currently used for C interop
+	t.register_type_symbol({
+		kind: size_kind
+		name: 'size_t'
+		source_name: 'size_t'
+		cname: 'size_t'
+		mod: 'builtin'
+	})
+	size_kind = .int
+	if t.m64 {
+		size_kind = .i64
+	}
+	t.register_type_symbol({
+		kind: size_kind
+		name: 'isize'
+		source_name: 'isize'
+		cname: 'isize'
+		mod: 'builtin'
+	})
 }
 
 [inline]
@@ -756,7 +778,6 @@ pub fn (k Kind) str() string {
 		.string { 'string' }
 		.char { 'char' }
 		.bool { 'bool' }
-		.size_t { 'size_t' }
 		.none_ { 'none' }
 		.array { 'array' }
 		.array_fixed { 'array_fixed' }

--- a/vlib/v/tests/integer_size_test.v
+++ b/vlib/v/tests/integer_size_test.v
@@ -1,0 +1,20 @@
+fn f(u usize) usize
+fn g(i isize) isize
+
+fn test_size() {
+	mut u := usize(3)
+	u += u32(1)
+	assert u == 4
+	u = 4
+	u++
+	assert u == 5
+	assert u.str() == '5'
+
+	mut i := isize(-3)
+	i -= int(1)
+	assert i == -4
+	i = -4
+	i += 2
+	assert i == -2
+	assert i.str() == '-2'
+}


### PR DESCRIPTION
Fixes #6139.

This makes `size_t` behave as an integer for operators, methods etc. It's not ideal as error messages may show the underlying type rather than `size_t`, but a step forward anyway.

*Update:*
Add `isize` for signed sizes (like C `ptrdiff_t`).
Add `usize` for unsigned sizes (like C `size_t`).
`size_t` is kept for interfacing with C.

Add `-m32`, `-m64` command-line switches. The default is to follow the `x64` constant.