### PR TITLE
parser: warn if PostfixExpr followed by `]` or `)` token

### DIFF
--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -262,7 +262,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 		} else if p.tok.kind in [.inc, .dec] {
 			// Postfix
 			if p.peek_tok.kind in [.comma, .rpar, .rsbr] &&
-				p.mod !in ['builtin', 'strconv'] { // temp
+				p.mod !in ['builtin', 'regex', 'strconv'] { // temp
 				p.warn_with_pos('`$p.tok.kind` operator can only be used as a statement', p.peek_tok.position())
 			}
 			node = ast.PostfixExpr{

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -261,6 +261,10 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			}
 		} else if p.tok.kind in [.inc, .dec] {
 			// Postfix
+			if p.peek_tok.kind in [.comma, .rpar, .rsbr] &&
+				p.mod !in ['builtin', 'strconv'] { // temp
+				p.warn_with_pos('`$p.tok.kind` operator can only be used as a statement', p.peek_tok.position())
+			}
 			node = ast.PostfixExpr{
 				op: p.tok.kind
 				expr: node

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -261,7 +261,8 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			}
 		} else if p.tok.kind in [.inc, .dec] {
 			// Postfix
-			if p.peek_tok.kind in [.comma, .rpar, .rsbr] &&
+			// detect `f(x++)`, `a[x++]`
+			if p.peek_tok.kind in [.rpar, .rsbr] &&
 				p.mod !in ['builtin', 'regex', 'strconv'] { // temp
 				p.warn_with_pos('`$p.tok.kind` operator can only be used as a statement', p.peek_tok.position())
 			}

--- a/vlib/v/parser/tests/postfix_err.out
+++ b/vlib/v/parser/tests/postfix_err.out
@@ -1,0 +1,28 @@
+vlib/v/parser/tests/postfix_err.v:5:10: warning: `++` operator can only be used as a statement
+    3 | fn test_postfix() {
+    4 |     mut x := 1
+    5 |     _ = (x++)
+      |             ^
+    6 |     f(x--, x)
+    7 |     f(x, x++)
+vlib/v/parser/tests/postfix_err.v:6:7: warning: `--` operator can only be used as a statement
+    4 |     mut x := 1
+    5 |     _ = (x++)
+    6 |     f(x--, x)
+      |          ^
+    7 |     f(x, x++)
+    8 |     a := [x]
+vlib/v/parser/tests/postfix_err.v:7:10: warning: `++` operator can only be used as a statement
+    5 |     _ = (x++)
+    6 |     f(x--, x)
+    7 |     f(x, x++)
+      |             ^
+    8 |     a := [x]
+    9 |     _ = a[x--]
+vlib/v/parser/tests/postfix_err.v:9:11: warning: `--` operator can only be used as a statement
+    7 |     f(x, x++)
+    8 |     a := [x]
+    9 |     _ = a[x--]
+      |              ^
+   10 | }
+   11 |

--- a/vlib/v/parser/tests/postfix_err.out
+++ b/vlib/v/parser/tests/postfix_err.out
@@ -3,24 +3,17 @@ vlib/v/parser/tests/postfix_err.v:5:10: warning: `++` operator can only be used 
     4 |     mut x := 1
     5 |     _ = (x++)
       |             ^
-    6 |     f(x--, x)
-    7 |     f(x, x++)
-vlib/v/parser/tests/postfix_err.v:6:7: warning: `--` operator can only be used as a statement
-    4 |     mut x := 1
+    6 |     x--, x-- // OK
+    7 |     f(x++)
+vlib/v/parser/tests/postfix_err.v:7:7: warning: `++` operator can only be used as a statement
     5 |     _ = (x++)
-    6 |     f(x--, x)
+    6 |     x--, x-- // OK
+    7 |     f(x++)
       |          ^
-    7 |     f(x, x++)
-    8 |     a := [x]
-vlib/v/parser/tests/postfix_err.v:7:10: warning: `++` operator can only be used as a statement
-    5 |     _ = (x++)
-    6 |     f(x--, x)
-    7 |     f(x, x++)
-      |             ^
     8 |     a := [x]
     9 |     _ = a[x--]
 vlib/v/parser/tests/postfix_err.v:9:11: warning: `--` operator can only be used as a statement
-    7 |     f(x, x++)
+    7 |     f(x++)
     8 |     a := [x]
     9 |     _ = a[x--]
       |              ^

--- a/vlib/v/parser/tests/postfix_err.vv
+++ b/vlib/v/parser/tests/postfix_err.vv
@@ -1,0 +1,11 @@
+fn f(i, j int) {}
+
+fn test_postfix() {
+	mut x := 1
+	_ = (x++)
+	f(x--, x)
+	f(x, x++)
+	a := [x]
+	_ = a[x--]
+}
+

--- a/vlib/v/parser/tests/postfix_err.vv
+++ b/vlib/v/parser/tests/postfix_err.vv
@@ -1,10 +1,10 @@
-fn f(i, j int) {}
+fn f(i int) {}
 
 fn test_postfix() {
 	mut x := 1
 	_ = (x++)
-	f(x--, x)
-	f(x, x++)
+	x--, x-- // OK
+	f(x++)
 	a := [x]
 	_ = a[x--]
 }


### PR DESCRIPTION
Warning is the first step to making `PostfixExpr` produce a void result,
which would fix #3834.