### PR TITLE
vup: do v self then make on Windows

### DIFF
--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -42,26 +42,24 @@ fn main() {
 		app.show_current_v_version()
 		return
 	}
+	mut vself := 'v self'
+	mut make := 'make'
 	$if windows {
-		app.backup('v.exe')
-		make_result := os.exec('make.bat') or {
+		vself = 'v self'
+		make = 'make.bat'
+		app.backup('cmd/tools/vup.exe')
+	}
+	self_result := os.exec(vself) or {
+		panic(err)
+	}
+	println(self_result.output)
+	if self_result.exit_code != 0 {
+		// v self failed, have to use make
+		println('v self failed, running make...')
+		make_result := os.exec(make) or {
 			panic(err)
 		}
 		println(make_result.output)
-		app.backup('cmd/tools/vup.exe')
-	} $else {
-		self_result := os.exec('./v self') or {
-			panic(err)
-		}
-		println(self_result.output)
-		if self_result.exit_code != 0 {
-			// v self failed, have to use make
-			println('v self failed, running make...')
-			make_result := os.exec('make') or {
-				panic(err)
-			}
-			println(make_result.output)
-		}
 	}
 	os.exec('v cmd/tools/vup.v') or {
 		panic(err)

--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -45,7 +45,7 @@ fn main() {
 	mut vself := 'v self'
 	mut make := 'make'
 	$if windows {
-		vself = 'v self'
+		vself = 'v.exe self'
 		make = 'make.bat'
 		app.backup('cmd/tools/vup.exe')
 	}


### PR DESCRIPTION
This PR makes `v up` work the same on Windows as Linux - attempts `v self` first, then if that fails, run `make(.bat)`.