### PR TITLE
all/channels: make `ch.len` and `ch.cap` available as properties 

### DIFF
--- a/vlib/sync/channel_fill_test.v
+++ b/vlib/sync/channel_fill_test.v
@@ -5,18 +5,18 @@ const (
 	queue_fill = 763
 )
 
-fn do_send(mut ch sync.Channel, fin sync.Semaphore) {
+fn do_send(ch chan int, fin sync.Semaphore) {
 	for i in 0 .. queue_fill {
-		ch.push(&i)
+		ch <- i
 	}
 	fin.post()
 }
 
 fn test_channel_len_cap() {
-	mut ch := sync.new_channel<int>(queue_len)
+	ch := chan int{cap: queue_len}
 	sem := sync.new_semaphore()
-	go do_send(mut ch, sem)
+	go do_send(ch, sem)
 	sem.wait()
 	assert ch.cap == queue_len
-	assert ch.len() == queue_fill
+	assert ch.len == queue_fill
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1470,8 +1470,8 @@ pub fn (mut c Checker) selector_expr(mut selector_expr ast.SelectorExpr) table.T
 	sym := c.table.get_type_symbol(c.unwrap_generic(typ))
 	field_name := selector_expr.field_name
 	// variadic
-	if typ.has_flag(.variadic) || sym.kind == .array_fixed {
-		if field_name == 'len' {
+	if typ.has_flag(.variadic) || sym.kind == .array_fixed || sym.kind == .chan {
+		if field_name == 'len' || (sym.kind == .chan && field_name == 'cap') {
 			selector_expr.typ = table.int_type
 			return table.int_type
 		}
@@ -3262,6 +3262,9 @@ pub fn (mut c Checker) chan_init(mut node ast.ChanInit) table.Type {
 	if node.typ != 0 {
 		info := c.table.get_type_symbol(node.typ).chan_info()
 		node.elem_type = info.elem_type
+		if node.has_cap {
+			c.check_array_init_para_type('cap', node.cap_expr, node.pos)
+		}
 		return node.typ
 	} else {
 		c.error('`chan` of unknown type', node.pos)

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2107,8 +2107,14 @@ fn (mut g Gen) expr(node ast.Expr) {
 				g.write('$info.size')
 				return
 			}
+			if sym.kind == .chan && node.field_name == 'len' {
+				g.write('sync__Channel_len(')
+				g.expr(node.expr)
+				g.write(')')
+				return
+			}
 			g.expr(node.expr)
-			if node.expr_type.is_ptr() {
+			if node.expr_type.is_ptr() || sym.kind == .chan {
 				g.write('->')
 			} else {
 				// g.write('. /*typ=  $it.expr_type */') // ${g.typ(it.expr_type)} /')


### PR DESCRIPTION
This PR makes the buffer length and the number of elements in the queue available as (pseudo-) attributes for builtin channels:
```v
ch := chan int{cap: 12}
ch <- 1
ch <- 2
c := ch.cap // 12
l := ch.len // 2
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
