### PR TITLE
checker: disallow interfaces inside sum types

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -293,6 +293,8 @@ pub fn (mut c Checker) type_decl(node ast.TypeDecl) {
 				typ_sym := c.table.get_type_symbol(typ)
 				if typ_sym.kind == .placeholder {
 					c.error("type `$typ_sym.source_name` doesn't exist", node.pos)
+				} else if typ_sym.kind == .interface_ {
+					c.error("sum type cannot hold an interface", node.pos)
 				}
 			}
 		}


### PR DESCRIPTION
As discussed here https://canary.discordapp.com/channels/592103645835821068/592294828432424960/748315870564057142 it seems like some checks are missing for sum types. 
Since sum types holding interfaces are causing compiler errors those should be disallowed.