### PR TITLE
os: vfopen returns option now

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -176,7 +176,7 @@ pub fn mv_by_cp(source string, target string) ? {
 // NB: os.vfopen is useful for compatibility with C libraries, that expect `FILE *`.
 // If you write pure V code, os.create or os.open are more convenient.
 pub fn vfopen(path, mode string) ?&C.FILE {
-	mut fp = voidptr(0)
+	mut fp := voidptr(0)
 	$if windows {
 		fp = C._wfopen(path.to_wide(), mode.to_wide())
 	} $else {

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -146,10 +146,7 @@ pub fn mkdir(path string) ?bool {
 // Ref - https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/get-osfhandle?view=vs-2019
 // get_file_handle retrieves the operating-system file handle that is associated with the specified file descriptor.
 pub fn get_file_handle(path string) HANDLE {
-    cfile := vfopen(path, 'rb')
-    if cfile == voidptr(0) {
-	    return HANDLE(invalid_handle_value)
-    }
+    cfile := vfopen(path, 'rb') or { return HANDLE(invalid_handle_value) }
     handle := HANDLE(C._get_osfhandle(fileno(cfile))) // CreateFile? - hah, no -_-
     return handle
 }


### PR DESCRIPTION
os.vfopen returns option now - it limits copy pasta code after opening a file

before:
```v
	mut fp := vfopen(path, mode)
	if isnil(fp) {
		return error('failed to open file "$path"')
	}
```

after:
```v
	mut fp := vfopen(path, mode)?
```