### PR TITLE
all: automatic error propagation in place of "or { return(err) }"

### DIFF
--- a/vlib/cli/flag.v
+++ b/vlib/cli/flag.v
@@ -32,9 +32,7 @@ pub fn (flag Flag) get_bool() ?bool {
 }
 
 pub fn (flags []Flag) get_bool(name string) ?bool {
-	flag := flags.get(name) or {
-		return error(err)
-	}
+	flag := flags.get(name)?
 	return flag.get_bool()
 }
 
@@ -53,9 +51,7 @@ pub fn (flag Flag) get_int() ?int {
 }
 
 pub fn (flags []Flag) get_int(name string) ?int {
-	flag := flags.get(name) or {
-		return error(err)
-	}
+	flag := flags.get(name)?
 	return flag.get_int()
 }
 
@@ -74,9 +70,7 @@ pub fn (flag Flag) get_float() ?f64 {
 }
 
 pub fn (flags []Flag) get_float(name string) ?f64 {
-	flag := flags.get(name) or {
-		return error(err)
-	}
+	flag := flags.get(name)?
 	return flag.get_float()
 }
 
@@ -95,9 +89,7 @@ pub fn (flag Flag) get_string() ?string {
 }
 
 pub fn (flags []Flag) get_string(name string) ?string {
-	flag := flags.get(name) or {
-		return error(err)
-	}
+	flag := flags.get(name)?
 	return flag.get_string()
 }
 
@@ -112,14 +104,10 @@ pub fn (flags []Flag) get_string_or(name, or_value string) string {
 fn (mut flag Flag) parse(args []string, with_abbrev bool) ?[]string {
 	if flag.matches(args, with_abbrev) {
 		if flag.flag == .bool {
-			new_args := flag.parse_bool(args) or {
-				return error(err)
-			}
+			new_args := flag.parse_bool(args)?
 			return new_args
 		} else {
-			new_args := flag.parse_raw(args) or {
-				return error(err)
-			}
+			new_args := flag.parse_raw(args)?
 			return new_args
 		}
 	} else {

--- a/vlib/crypto/rand/utils.v
+++ b/vlib/crypto/rand/utils.v
@@ -19,9 +19,7 @@ pub fn int_u64(max u64) ?u64 {
 	}
 	mut n := u64(0)
 	for {
-		mut bytes := read(k) or {
-			return error(err)
-		}
+		mut bytes := read(k)?
 		bytes[0] &= byte(int(u64(1)<<b) - 1)
 		x := bytes_to_u64(bytes)
 		n = x[0]

--- a/vlib/encoding/csv/reader.v
+++ b/vlib/encoding/csv/reader.v
@@ -38,9 +38,7 @@ pub fn new_reader(data string) &Reader {
 
 // read() reads one row from the csv file
 pub fn (mut r Reader) read() ?[]string {
-	l := r.read_record() or {
-		return error(err)
-	}
+	l := r.read_record()?
 	return l
 }
 
@@ -106,9 +104,7 @@ fn (mut r Reader) read_record() ?[]string {
 
 	for {
 		if need_read {
-			l := r.read_line() or {
-				return error(err)
-			}
+			l := r.read_line()?
 			if l.len <= 0 {
 				if keep_raw { line += '\n'}
 				continue

--- a/vlib/net/ftp/ftp.v
+++ b/vlib/net/ftp/ftp.v
@@ -210,9 +210,7 @@ fn (ftp FTP) pasv() ?DTP {
 	if code != passive_mode {
 		return error('pasive mode not allowed')
 	}
-	dtp := new_dtp(data) or {
-		return error(err)
-	}
+	dtp := new_dtp(data)?
 	return dtp
 }
 

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -147,9 +147,7 @@ pub fn fetch(_url string, config FetchConfig) ?Response {
 		user_ptr: 0
 		verbose: config.verbose
 	}
-	res := req.do() or {
-		return error(err)
-	}
+	res := req.do()?
 	return res
 }
 
@@ -179,9 +177,7 @@ fn fetch_with_method(method Method, url string, _config FetchConfig) ?Response {
 }
 
 fn build_url_from_fetch(_url string, config FetchConfig) ?string {
-	mut url := urllib.parse(_url) or {
-		return error(err)
-	}
+	mut url := urllib.parse(_url)?
 	params := config.params
 	if params.keys().len == 0 {
 		return url.str()
@@ -242,9 +238,7 @@ pub fn (req &Request) do() ?Response {
 		if no_redirects == max_redirects {
 			return error('http.request.do: maximum number of redirects reached ($max_redirects)')
 		}
-		qresp := req.method_and_url_to_response(req.method, rurl) or {
-			return error(err)
-		}
+		qresp := req.method_and_url_to_response(req.method, rurl)?
 		resp = qresp
 		if resp.status_code !in [301, 302, 303, 307, 308] {
 			break
@@ -283,15 +277,11 @@ fn (req &Request) method_and_url_to_response(method Method, url urllib.URL) ?Res
 	// println('fetch $method, $scheme, $host_name, $nport, $path ')
 	if scheme == 'https' {
 		// println('ssl_do( $nport, $method, $host_name, $path )')
-		res := req.ssl_do(nport, method, host_name, path) or {
-			return error(err)
-		}
+		res := req.ssl_do(nport, method, host_name, path)?
 		return res
 	} else if scheme == 'http' {
 		// println('http_do( $nport, $method, $host_name, $path )')
-		res := req.http_do(nport, method, host_name, path) or {
-			return error(err)
-		}
+		res := req.http_do(nport, method, host_name, path)?
 		return res
 	}
 	return error('http.request.method_and_url_to_response: unsupported scheme: "$scheme"')
@@ -413,9 +403,7 @@ fn (req &Request) http_do(port int, method Method, host_name, path string) ?Resp
 	rbuffer := [bufsize]byte{}
 	mut sb := strings.new_builder(100)
 	s := req.build_request_headers(method, host_name, path)
-	client := net.dial(host_name, port) or {
-		return error(err)
-	}
+	client := net.dial(host_name, port)?
 	client.send(s.str, s.len) or {
 	}
 	for {

--- a/vlib/net/http/http_httpbin_test.v
+++ b/vlib/net/http/http_httpbin_test.v
@@ -23,13 +23,9 @@ fn http_fetch_mock(_methods []string, _config FetchConfig) ?[]Response {
 	for method in methods {
 		lmethod := method.to_lower()
 		config.method = method
-		res := fetch(url + lmethod, config) or {
-			return error(err)
-		}
+		res := fetch(url + lmethod, config)?
 		// TODO
-		// body := json.decode(HttpbinResponseBody,res.text) or {
-		// return error(err)
-		// }
+		// body := json.decode(HttpbinResponseBody,res.text)?
 		result << res
 	}
 	return result

--- a/vlib/net/socket.v
+++ b/vlib/net/socket.v
@@ -153,15 +153,9 @@ pub fn listen(port int) ?Socket {
 	$if debug {
 		println('net.listen($port)')
 	}
-	s := new_socket(C.AF_INET, C.SOCK_STREAM, 0) or {
-		return error(err)
-	}
-	s.bind(port) or {
-		return error(err)
-	}
-	s.listen() or {
-		return error(err)
-	}
+	s := new_socket(C.AF_INET, C.SOCK_STREAM, 0)?
+	s.bind(port)?
+	s.listen()?
 	return s
 }
 
@@ -228,12 +222,8 @@ pub fn (s Socket) connect(address string, port int) ?int {
 
 // helper method to create socket and connect
 pub fn dial(address string, port int) ?Socket {
-	s := new_socket(C.AF_INET, C.SOCK_STREAM, 0) or {
-		return error(err)
-	}
-	s.connect(address, port) or {
-		return error(err)
-	}
+	s := new_socket(C.AF_INET, C.SOCK_STREAM, 0)?
+	s.connect(address, port)?
 	return s
 }
 

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -479,9 +479,7 @@ fn parse_url(rawurl string, via_request bool) ?URL {
 	}
 	// Split off possible leading 'http:', 'mailto:', etc.
 	// Cannot contain escaped characters.
-	p := split_by_scheme(rawurl) or {
-		return error(err)
-	}
+	p := split_by_scheme(rawurl)?
 	url.scheme = p[0]
 	mut rest := p[1]
 	url.scheme = url.scheme.to_lower()
@@ -524,9 +522,7 @@ fn parse_url(rawurl string, via_request bool) ?URL {
 	if ((url.scheme != '' || !via_request) && !rest.starts_with('///')) && rest.starts_with('//') {
 		authority,r := split(rest[2..], `/`, false)
 		rest = r
-		a := parse_authority(authority) or {
-			return error(err)
-		}
+		a := parse_authority(authority)?
 		url.user = a.user
 		url.host = a.host
 	}
@@ -534,9 +530,7 @@ fn parse_url(rawurl string, via_request bool) ?URL {
 	// raw_path is a hint of the encoding of path. We don't want to set it if
 	// the default escaping of path is equivalent, to help make sure that people
 	// don't rely on it in general.
-	url.set_path(rest) or {
-		return error(err)
-	}
+	url.set_path(rest)?
 	return url
 }
 
@@ -552,15 +546,11 @@ fn parse_authority(authority string) ?ParseAuthorityRes {
 	mut host := ''
 	mut zuser := user('')
 	if i < 0 {
-		h := parse_host(authority) or {
-			return error(err)
-		}
+		h := parse_host(authority)?
 		host = h
 	}
 	else {
-		h := parse_host(authority[i + 1..]) or {
-			return error(err)
-		}
+		h := parse_host(authority[i + 1..])?
 		host = h
 	}
 	if i < 0 {
@@ -574,21 +564,15 @@ fn parse_authority(authority string) ?ParseAuthorityRes {
 		return error(error_msg('parse_authority: invalid userinfo', ''))
 	}
 	if !userinfo.contains(':') {
-		u := unescape(userinfo, .encode_user_password) or {
-			return error(err)
-		}
+		u := unescape(userinfo, .encode_user_password)?
 		userinfo = u
 		zuser = user(userinfo)
 	}
 	else {
 		mut username,mut password := split(userinfo, `:`, true)
-		u := unescape(username, .encode_user_password) or {
-			return error(err)
-		}
+		u := unescape(username, .encode_user_password)?
 		username = u
-		p := unescape(password, .encode_user_password) or {
-			return error(err)
-		}
+		p := unescape(password, .encode_user_password)?
 		password = p
 		zuser = user_password(username, password)
 	}
@@ -652,9 +636,7 @@ fn parse_host(host string) ?string {
 // set_path will return an error only if the provided path contains an invalid
 // escaping.
 pub fn (mut u URL) set_path(p string) ?bool {
-	path := unescape(p, .encode_path) or {
-		return error(err)
-	}
+	path := unescape(p, .encode_path)?
 	u.path = path
 	escp := escape(path, .encode_path)
 	if p == escp {
@@ -822,9 +804,7 @@ pub fn (u URL) str() string {
 // interpreted as a key set to an empty value.
 pub fn parse_query(query string) ?Values {
 	mut m := new_values()
-	parse_query_values(mut m, query) or {
-		return error(err)
-	}
+	parse_query_values(mut m, query)?
 	return m
 }
 
@@ -956,9 +936,7 @@ pub fn (u &URL) is_abs() bool {
 // may be relative or absolute. parse returns nil, err on parse
 // failure, otherwise its return value is the same as resolve_reference.
 pub fn (u &URL) parse(ref string) ?URL {
-	refurl := parse(ref) or {
-		return error(err)
-	}
+	refurl := parse(ref)?
 	return u.resolve_reference(refurl)
 }
 
@@ -977,9 +955,7 @@ pub fn (u &URL) resolve_reference(ref &URL) ?URL {
 		// The 'absoluteURI' or 'net_path' cases.
 		// We can ignore the error from set_path since we know we provided a
 		// validly-escaped path.
-		url.set_path(resolve_path(ref.escaped_path(), '')) or {
-			return error(err)
-		}
+		url.set_path(resolve_path(ref.escaped_path(), ''))?
 		return url
 	}
 	if ref.opaque != '' {
@@ -997,9 +973,7 @@ pub fn (u &URL) resolve_reference(ref &URL) ?URL {
 	// The 'abs_path' or 'rel_path' cases.
 	url.host = u.host
 	url.user = u.user
-	url.set_path(resolve_path(u.escaped_path(), ref.escaped_path())) or {
-		return error(err)
-	}
+	url.set_path(resolve_path(u.escaped_path(), ref.escaped_path()))?
 	return url
 }
 

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -141,24 +141,18 @@ os.join_path(dest_path,os.file_name(source_path)) } else { dest_path }
 				return error('Destination file path already exist')
 			}
 		}
-		os.cp(source_path, adjusted_path) or {
-			return error(err)
-		}
+		os.cp(source_path, adjusted_path)?
 		return
 	}
 	if !os.is_dir(dest_path) {
 		return error('Destination path is not a valid directory')
 	}
-	files := os.ls(source_path) or {
-		return error(err)
-	}
+	files := os.ls(source_path)?
 	for file in files {
 		sp := os.join_path(source_path, file)
 		dp := os.join_path(dest_path, file)
 		if os.is_dir(sp) {
-			os.mkdir(dp) or {
-				return error(err)
-			}
+			os.mkdir(dp)?
 		}
 		cp_all(sp, dp, overwrite) or {
 			os.rmdir(dp)
@@ -170,12 +164,8 @@ os.join_path(dest_path,os.file_name(source_path)) } else { dest_path }
 // mv_by_cp first copies the source file, and if it is copied successfully, deletes the source file.
 // may be used when you are not sure that the source and target are on the same mount/partition.
 pub fn mv_by_cp(source string, target string) ? {
-	os.cp(source, target) or {
-		return error(err)
-	}
-	os.rm(source) or {
-		return error(err)
-	}
+	os.cp(source, target)?
+	os.rm(source)?
 }
 
 // vfopen returns an opened C file, given its path and open mode.
@@ -204,17 +194,13 @@ pub fn fileno(cfile voidptr) int {
 
 // read_lines reads the file in `path` into an array of lines.
 pub fn read_lines(path string) ?[]string {
-	buf := read_file(path) or {
-		return error(err)
-	}
+	buf := read_file(path)?
 	return buf.split_into_lines()
 }
 
 // read_ulines reads the file in `path` into an array of ustring lines.
 fn read_ulines(path string) ?[]ustring {
-	lines := read_lines(path) or {
-		return error(err)
-	}
+	lines := read_lines(path)?
 	// mut ulines := new_array(0, lines.len, sizeof(ustring))
 	mut ulines := []ustring{}
 	for myline in lines {
@@ -590,9 +576,7 @@ pub fn rmdir_recursive(path string) {
 // rmdir_all recursively removes the specified directory.
 pub fn rmdir_all(path string) ? {
 	mut ret_err := ''
-	items := os.ls(path) or {
-		return error(err)
-	}
+	items := os.ls(path)?
 	for item in items {
 		if os.is_dir(os.join_path(path, item)) {
 			rmdir_all(os.join_path(path, item))
@@ -822,18 +806,14 @@ pub fn home_dir() string {
 
 // write_file writes `text` data to a file in `path`.
 pub fn write_file(path, text string) ? {
-	mut f := os.create(path) or {
-		return error(err)
-	}
+	mut f := os.create(path)?
 	f.write(text)
 	f.close()
 }
 
 // write_file_array writes the data in `buffer` to a file in `path`.
 pub fn write_file_array(path string, buffer array) ? {
-	mut f := os.create(path) or {
-		return error(err)
-	}
+	mut f := os.create(path)?
 	f.write_bytes_at(buffer.data, (buffer.len * buffer.element_size), 0)
 	f.close()
 }

--- a/vlib/pg/pg.v
+++ b/vlib/pg/pg.v
@@ -123,7 +123,7 @@ pub fn (db DB) exec_one(query string) ?Row {
 	if e != '' {
 		return error('pg exec error: "$e"')
 	}
-	row := rows_first_or_empty( res_to_rows(res) ) or { return error(err) }
+	row := rows_first_or_empty( res_to_rows(res) )?
 	return row
 }
 

--- a/vlib/readline/readline.js.v
+++ b/vlib/readline/readline.js.v
@@ -39,9 +39,7 @@ pub fn (mut r Readline) read_line_utf8(prompt string) ?ustring {
 
 // Returns the string from the utf8 ustring
 pub fn (mut r Readline) read_line(prompt string) ?string {
-  s := r.read_line_utf8(prompt) or {
-    return error(err)
-  }
+  s := r.read_line_utf8(prompt)?
   return s.s
 }
 
@@ -49,9 +47,7 @@ pub fn (mut r Readline) read_line(prompt string) ?string {
 // Returns utf8 based ustring
 pub fn read_line_utf8(prompt string) ?ustring {
   mut r := Readline{}
-  s := r.read_line_utf8(prompt) or {
-    return error(err)
-  }
+  s := r.read_line_utf8(prompt)?
   return s
 }
 
@@ -59,8 +55,6 @@ pub fn read_line_utf8(prompt string) ?ustring {
 // Return string from utf8 ustring
 pub fn read_line(prompt string) ?string {
   mut r := Readline{}
-  s := r.read_line(prompt) or {
-    return error(err)
-  }
+  s := r.read_line(prompt)?
   return s
 }

--- a/vlib/readline/readline_darwin.c.v
+++ b/vlib/readline/readline_darwin.c.v
@@ -44,9 +44,7 @@ pub fn (mut r Readline) read_line_utf8(prompt string) ?ustring {
 
 // Returns the string from the utf8 ustring
 pub fn (mut r Readline) read_line(prompt string) ?string {
-  s := r.read_line_utf8(prompt) or {
-    return error(err)
-  }
+  s := r.read_line_utf8(prompt)?
   return s.s
 }
 
@@ -54,9 +52,7 @@ pub fn (mut r Readline) read_line(prompt string) ?string {
 // Returns utf8 based ustring
 pub fn read_line_utf8(prompt string) ?ustring {
   mut r := Readline{}
-  s := r.read_line_utf8(prompt) or {
-    return error(err)
-  }
+  s := r.read_line_utf8(prompt)?
   return s
 }
 
@@ -64,8 +60,6 @@ pub fn read_line_utf8(prompt string) ?ustring {
 // Return string from utf8 ustring
 pub fn read_line(prompt string) ?string {
   mut r := Readline{}
-  s := r.read_line(prompt) or {
-    return error(err)
-  }
+  s := r.read_line(prompt)?
   return s
 }

--- a/vlib/readline/readline_dragonfly.c.v
+++ b/vlib/readline/readline_dragonfly.c.v
@@ -44,9 +44,7 @@ pub fn (mut r Readline) read_line_utf8(prompt string) ?ustring {
 
 // Returns the string from the utf8 ustring
 pub fn (mut r Readline) read_line(prompt string) ?string {
-  s := r.read_line_utf8(prompt) or {
-    return error(err)
-  }
+  s := r.read_line_utf8(prompt)?
   return s.s
 }
 
@@ -54,9 +52,7 @@ pub fn (mut r Readline) read_line(prompt string) ?string {
 // Returns utf8 based ustring
 pub fn read_line_utf8(prompt string) ?ustring {
   mut r := Readline{}
-  s := r.read_line_utf8(prompt) or {
-    return error(err)
-  }
+  s := r.read_line_utf8(prompt)?
   return s
 }
 
@@ -64,8 +60,6 @@ pub fn read_line_utf8(prompt string) ?ustring {
 // Return string from utf8 ustring
 pub fn read_line(prompt string) ?string {
   mut r := Readline{}
-  s := r.read_line(prompt) or {
-    return error(err)
-  }
+  s := r.read_line(prompt)?
   return s
 }

--- a/vlib/readline/readline_freebsd.c.v
+++ b/vlib/readline/readline_freebsd.c.v
@@ -44,9 +44,7 @@ pub fn (mut r Readline) read_line_utf8(prompt string) ?ustring {
 
 // Returns the string from the utf8 ustring
 pub fn (mut r Readline) read_line(prompt string) ?string {
-  s := r.read_line_utf8(prompt) or {
-    return error(err)
-  }
+  s := r.read_line_utf8(prompt)?
   return s.s
 }
 
@@ -54,9 +52,7 @@ pub fn (mut r Readline) read_line(prompt string) ?string {
 // Returns utf8 based ustring
 pub fn read_line_utf8(prompt string) ?ustring {
   mut r := Readline{}
-  s := r.read_line_utf8(prompt) or {
-    return error(err)
-  }
+  s := r.read_line_utf8(prompt)?
   return s
 }
 
@@ -64,8 +60,6 @@ pub fn read_line_utf8(prompt string) ?ustring {
 // Return string from utf8 ustring
 pub fn read_line(prompt string) ?string {
   mut r := Readline{}
-  s := r.read_line(prompt) or {
-    return error(err)
-  }
+  s := r.read_line(prompt)?
   return s
 }

--- a/vlib/readline/readline_linux.c.v
+++ b/vlib/readline/readline_linux.c.v
@@ -129,9 +129,7 @@ pub fn (mut r Readline) read_line_utf8(prompt string) ?ustring {
 
 // Returns the string from the utf8 ustring
 pub fn (mut r Readline) read_line(prompt string) ?string {
-	s := r.read_line_utf8(prompt) or {
-		return error(err)
-	}
+	s := r.read_line_utf8(prompt)?
 	return s.s
 }
 
@@ -139,9 +137,7 @@ pub fn (mut r Readline) read_line(prompt string) ?string {
 // Returns utf8 based ustring
 pub fn read_line_utf8(prompt string) ?ustring {
 	mut r := Readline{}
-	s := r.read_line_utf8(prompt) or {
-		return error(err)
-	}
+	s := r.read_line_utf8(prompt)?
 	return s
 }
 
@@ -149,9 +145,7 @@ pub fn read_line_utf8(prompt string) ?ustring {
 // Return string from utf8 ustring
 pub fn read_line(prompt string) ?string {
 	mut r := Readline{}
-	s := r.read_line(prompt) or {
-		return error(err)
-	}
+	s := r.read_line(prompt)?
 	return s
 }
 

--- a/vlib/readline/readline_netbsd.c.v
+++ b/vlib/readline/readline_netbsd.c.v
@@ -44,9 +44,7 @@ pub fn (mut r Readline) read_line_utf8(prompt string) ?ustring {
 
 // Returns the string from the utf8 ustring
 pub fn (mut r Readline) read_line(prompt string) ?string {
-  s := r.read_line_utf8(prompt) or {
-    return error(err)
-  }
+  s := r.read_line_utf8(prompt)?
   return s.s
 }
 
@@ -54,9 +52,7 @@ pub fn (mut r Readline) read_line(prompt string) ?string {
 // Returns utf8 based ustring
 pub fn read_line_utf8(prompt string) ?ustring {
   mut r := Readline{}
-  s := r.read_line_utf8(prompt) or {
-    return error(err)
-  }
+  s := r.read_line_utf8(prompt)?
   return s
 }
 
@@ -64,8 +60,6 @@ pub fn read_line_utf8(prompt string) ?ustring {
 // Return string from utf8 ustring
 pub fn read_line(prompt string) ?string {
   mut r := Readline{}
-  s := r.read_line(prompt) or {
-    return error(err)
-  }
+  s := r.read_line(prompt)?
   return s
 }

--- a/vlib/readline/readline_openbsd.c.v
+++ b/vlib/readline/readline_openbsd.c.v
@@ -44,9 +44,7 @@ pub fn (mut r Readline) read_line_utf8(prompt string) ?ustring {
 
 // Returns the string from the utf8 ustring
 pub fn (mut r Readline) read_line(prompt string) ?string {
-  s := r.read_line_utf8(prompt) or {
-    return error(err)
-  }
+  s := r.read_line_utf8(prompt)?
   return s.s
 }
 
@@ -54,9 +52,7 @@ pub fn (mut r Readline) read_line(prompt string) ?string {
 // Returns utf8 based ustring
 pub fn read_line_utf8(prompt string) ?ustring {
   mut r := Readline{}
-  s := r.read_line_utf8(prompt) or {
-    return error(err)
-  }
+  s := r.read_line_utf8(prompt)?
   return s
 }
 
@@ -64,8 +60,6 @@ pub fn read_line_utf8(prompt string) ?ustring {
 // Return string from utf8 ustring
 pub fn read_line(prompt string) ?string {
   mut r := Readline{}
-  s := r.read_line(prompt) or {
-    return error(err)
-  }
+  s := r.read_line(prompt)?
   return s
 }

--- a/vlib/readline/readline_solaris.c.v
+++ b/vlib/readline/readline_solaris.c.v
@@ -44,9 +44,7 @@ pub fn (mut r Readline) read_line_utf8(prompt string) ?ustring {
 
 // Returns the string from the utf8 ustring
 pub fn (mut r Readline) read_line(prompt string) ?string {
-  s := r.read_line_utf8(prompt) or {
-    return error(err)
-  }
+  s := r.read_line_utf8(prompt)?
   return s.s
 }
 
@@ -54,9 +52,7 @@ pub fn (mut r Readline) read_line(prompt string) ?string {
 // Returns utf8 based ustring
 pub fn read_line_utf8(prompt string) ?ustring {
   mut r := Readline{}
-  s := r.read_line_utf8(prompt) or {
-    return error(err)
-  }
+  s := r.read_line_utf8(prompt)?
   return s
 }
 
@@ -64,8 +60,6 @@ pub fn read_line_utf8(prompt string) ?ustring {
 // Return string from utf8 ustring
 pub fn read_line(prompt string) ?string {
   mut r := Readline{}
-  s := r.read_line(prompt) or {
-    return error(err)
-  }
+  s := r.read_line(prompt)?
   return s
 }

--- a/vlib/readline/readline_windows.c.v
+++ b/vlib/readline/readline_windows.c.v
@@ -39,9 +39,7 @@ pub fn (mut r Readline) read_line_utf8(prompt string) ?ustring {
 
 // Returns the string from the utf8 ustring
 pub fn (mut r Readline) read_line(prompt string) ?string {
-  s := r.read_line_utf8(prompt) or {
-    return error(err)
-  }
+  s := r.read_line_utf8(prompt)?
   return s.s
 }
 
@@ -49,9 +47,7 @@ pub fn (mut r Readline) read_line(prompt string) ?string {
 // Returns utf8 based ustring
 pub fn read_line_utf8(prompt string) ?ustring {
   mut r := Readline{}
-  s := r.read_line_utf8(prompt) or {
-    return error(err)
-  }
+  s := r.read_line_utf8(prompt)?
   return s
 }
 
@@ -59,8 +55,6 @@ pub fn read_line_utf8(prompt string) ?ustring {
 // Return string from utf8 ustring
 pub fn read_line(prompt string) ?string {
   mut r := Readline{}
-  s := r.read_line(prompt) or {
-    return error(err)
-  }
+  s := r.read_line(prompt)?
   return s
 }

--- a/vlib/v/builder/msvc.v
+++ b/vlib/v/builder/msvc.v
@@ -135,9 +135,7 @@ fn find_vs(vswhere_dir, host_arch string) ?VsInstallation {
 	// VSWhere is guaranteed to be installed at this location now
 	// If its not there then end user needs to update their visual studio
 	// installation!
-	res := os.exec('"$vswhere_dir\\Microsoft Visual Studio\\Installer\\vswhere.exe" -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath') or {
-		return error(err)
-	}
+	res := os.exec('"$vswhere_dir\\Microsoft Visual Studio\\Installer\\vswhere.exe" -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath')?
 	res_output := res.output.trim_right('\r\n')
 	// println('res: "$res"')
 	version := os.read_file('$res_output\\VC\\Auxiliary\\Build\\Microsoft.VCToolsVersion.default.txt') or {

--- a/vlib/v/vmod/parser.v
+++ b/vlib/v/vmod/parser.v
@@ -233,18 +233,14 @@ fn (mut p Parser) parse() ?Manifest {
 						mn.author = field_value
 					}
 					'dependencies' {
-						deps, idx := get_array_content(tokens, i + 1) or {
-							return error(err)
-						}
+						deps, idx := get_array_content(tokens, i + 1)?
 						mn.dependencies = deps
 						i = idx
 						continue
 					}
 					else {
 						if tokens[i + 1].typ == .labr {
-							vals, idx := get_array_content(tokens, i + 1) or {
-								return error(err)
-							}
+							vals, idx := get_array_content(tokens, i + 1)?
 							mn.unknown[field_name] = vals
 							i = idx
 							continue

--- a/vlib/vweb/tests/vweb_test.v
+++ b/vlib/vweb/tests/vweb_test.v
@@ -261,9 +261,7 @@ $config.content'
 	$if debug_net_socket_client ? {
 		eprintln('sending:\n$message')
 	}
-	client.send(message.str, message.len) or {
-		return error(err)
-	}
+	client.send(message.str, message.len)?
 	bytes, blen := client.recv(4096)
 	received := unsafe {bytes.vstring_with_len(blen)}
 	$if debug_net_socket_client ? {

--- a/vlib/x/websocket/websocket_client.v
+++ b/vlib/x/websocket/websocket_client.v
@@ -447,9 +447,7 @@ fn (mut ws Client) send_control_frame(code OPCode, frame_typ string, payload []b
 // parse_uri, parses the url string to it's components
 // todo: support not using port to default ones
 fn parse_uri(url string) ?&Uri {
-	u := urllib.parse(url) or {
-		return error(err)
-	}
+	u := urllib.parse(url)?
 	v := u.request_uri().split('?')
 	querystring := if v.len > 1 { '?' + v[1] } else { '' }
 	return &Uri{


### PR DESCRIPTION
Every occurence of ` or { return error(err) }` in vlib changed.

before:
```v
l := r.read_record() or {
    return error(err)
}
```

after:
```v
l := r.read_record()?
```
