### PR TITLE
checker: error on `mut name =`

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2621,6 +2621,9 @@ pub fn (mut c Checker) ident(mut ident ast.Ident) table.Type {
 		return info.typ
 	} else if ident.kind == .unresolved {
 		// first use
+		if ident.tok_kind == .assign && ident.is_mut {
+			c.error('`mut` not allowed with `=` (use `:=` to declare a variable)', ident.pos)
+		}
 		start_scope := c.file.scope.innermost(ident.pos.pos)
 		if obj1 := start_scope.find(ident.name) {
 			match mut obj1 as obj {
@@ -2731,7 +2734,7 @@ pub fn (mut c Checker) ident(mut ident ast.Ident) table.Type {
 			ident.mod = saved_mod
 		}
 		if ident.tok_kind == .assign {
-			c.error('undefined ident: `$ident.name` (use `:=` to assign a variable)',
+			c.error('undefined ident: `$ident.name` (use `:=` to declare a variable)',
 				ident.pos)
 		} else {
 			c.error('undefined ident: `$ident.name`', ident.pos)

--- a/vlib/v/checker/tests/assign_mut.out
+++ b/vlib/v/checker/tests/assign_mut.out
@@ -1,0 +1,13 @@
+vlib/v/checker/tests/assign_mut.vv:3:9: error: `mut` not allowed with `=` (use `:=` to declare a variable)
+    1 | fn main() {
+    2 |     mut z := 1
+    3 |     mut z = 1
+      |         ^
+    4 |     mut i := 2
+    5 |     i, mut z = 2,3
+vlib/v/checker/tests/assign_mut.vv:5:12: error: `mut` not allowed with `=` (use `:=` to declare a variable)
+    3 |     mut z = 1
+    4 |     mut i := 2
+    5 |     i, mut z = 2,3
+      |            ^
+    6 | }

--- a/vlib/v/checker/tests/assign_mut.vv
+++ b/vlib/v/checker/tests/assign_mut.vv
@@ -1,0 +1,6 @@
+fn main() {
+    mut z := 1
+    mut z = 1
+    mut i := 2
+    i, mut z = 2,3
+}

--- a/vlib/v/checker/tests/error_with_several_comments_with_crlf_ending.out
+++ b/vlib/v/checker/tests/error_with_several_comments_with_crlf_ending.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/error_with_several_comments_with_crlf_ending.vv:9:2: error: undefined ident: `a` (use `:=` to assign a variable)
+vlib/v/checker/tests/error_with_several_comments_with_crlf_ending.vv:9:2: error: undefined ident: `a` (use `:=` to declare a variable)
     7 | fn main() {
     8 |     func1()
     9 |     a = 2

--- a/vlib/v/checker/tests/unknown_var_assign.out
+++ b/vlib/v/checker/tests/unknown_var_assign.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/unknown_var_assign.vv:2:5: error: undefined ident: `x` (use `:=` to assign a variable)
+vlib/v/checker/tests/unknown_var_assign.vv:2:5: error: undefined ident: `x` (use `:=` to declare a variable)
     1 | fn main() {
     2 |     x = 'hello v'
       |     ^

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -30,7 +30,7 @@ pub fn (mut p Parser) call_expr(language table.Language, mod string) ast.CallExp
 		// `foo<int>(10)`
 		p.next() // `<`
 		p.expr_mod = ''
-		mut generic_type = p.parse_type()
+		generic_type = p.parse_type()
 		p.check(.gt) // `>`
 		// In case of `foo<T>()`
 		// T is unwrapped and registered in the checker.


### PR DESCRIPTION
Suggest `:=` instead.
Change an existing error message 'use `:=` to assign a variable' -> 'use `:=` to declare a variable'.
Fix one accidental(?) use of `mut x =`.
