### PR TITLE
checker: implement implicit conversions/promotions to `rune`

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -217,8 +217,8 @@ fn (c &Checker) promote_num(left_type, right_type table.Type) table.Type {
 		}
 	} else if idx_lo >= table.byte_type_idx { // both operands are unsigned
 		return type_hi
-	} else if idx_lo >= table.i8_type_idx && idx_hi <= table.i64_type_idx { // both signed
-		return type_hi
+	} else if idx_lo >= table.i8_type_idx && (idx_hi <= table.i64_type_idx || idx_hi == table.rune_type_idx) { // both signed
+		return if idx_lo == table.i64_type_idx { type_lo } else { type_hi }
 	} else if idx_hi - idx_lo < (table.byte_type_idx - table.i8_type_idx) {
 		return type_lo // conversion unsigned -> signed if signed type is larger
 	} else {

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -255,12 +255,11 @@ pub const (
 	array_type_idx   = 20
 	map_type_idx     = 21
 	chan_type_idx    = 22
-	any_type_idx     = 23
-	// t_type_idx       = 23
-	any_flt_type_idx = 24
-	any_int_type_idx = 25
-	sizet_type_idx   = 26
-	rune_type_idx    = 27
+	sizet_type_idx   = 23
+	rune_type_idx    = 24
+	any_type_idx     = 25
+	any_flt_type_idx = 26
+	any_int_type_idx = 27
 )
 
 pub const (
@@ -300,11 +299,10 @@ pub const (
 	array_type   = new_type(array_type_idx)
 	map_type     = new_type(map_type_idx)
 	chan_type    = new_type(chan_type_idx)
+	rune_type    = new_type(rune_type_idx)
 	any_type     = new_type(any_type_idx)
-	// t_type       = new_type(t_type_idx)
 	any_flt_type = new_type(any_flt_type_idx)
 	any_int_type = new_type(any_int_type_idx)
-	rune_type    = new_type(rune_type_idx)
 )
 
 pub const (
@@ -570,17 +568,23 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
+		kind: .size_t
+		name: 'size_t'
+		source_name: 'size_t'
+		mod: 'builtin'
+	})
+	t.register_type_symbol({
+		kind: .rune
+		name: 'rune'
+		source_name: 'rune'
+		mod: 'builtin'
+	})
+	t.register_type_symbol({
 		kind: .any
 		name: 'any'
 		source_name: 'any'
 		mod: 'builtin'
 	})
-	// t.register_type_symbol({
-	// kind: .any
-	// name: 'T'
-	// mod: 'builtin'
-	// is_public: true
-	// })
 	t.register_type_symbol({
 		kind: .any_float
 		name: 'any_float'
@@ -591,18 +595,6 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 		kind: .any_int
 		name: 'any_int'
 		source_name: 'any_int'
-		mod: 'builtin'
-	})
-	t.register_type_symbol({
-		kind: .size_t
-		name: 'size_t'
-		source_name: 'size_t'
-		mod: 'builtin'
-	})
-	t.register_type_symbol({
-		kind: .size_t
-		name: 'rune'
-		source_name: 'rune'
 		mod: 'builtin'
 	})
 	// TODO: remove. for v1 map compatibility

--- a/vlib/v/tests/type_promotion_test.v
+++ b/vlib/v/tests/type_promotion_test.v
@@ -80,3 +80,21 @@ fn test_f32_int() {
 	d := u64(300)
 	assert d + c == 316.75
 }
+
+fn test_rune() {
+	a := 3
+	mut b := rune(67)
+	b = a
+	assert b == rune(3)
+	b = rune(67)
+	mut x := 5
+	x = int(b)
+	assert x == 67
+	c := b + a
+	assert c == rune(70)
+	assert typeof(c) == 'rune'
+	d := i64(12)
+	e := b + d
+	assert e == i64(79)
+	assert typeof(e) == 'i64'
+}


### PR DESCRIPTION
This PR enables some implicit conversion to/from `rune`:
```v
x := rune(65) + 1 // -> rune(66)
b := i64(3)
c := b + x // c will be of type `i64`
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
