### PR TITLE
fmt: insert space in front of `?` for propagation

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1635,7 +1635,7 @@ propagate the error:
 import net.http
 
 fn f(url string) ?string {
-    resp := http.get(url)?
+    resp := http.get(url) ?
     return resp.text
 }
 ```

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1136,7 +1136,7 @@ pub fn (mut f Fmt) or_expr(or_block ast.OrExpr) {
 			}
 		}
 		.propagate {
-			f.write('?')
+			f.write(' ?')
 		}
 	}
 }

--- a/vlib/v/fmt/tests/optional_propagate_keep.vv
+++ b/vlib/v/fmt/tests/optional_propagate_keep.vv
@@ -1,3 +1,3 @@
 fn opt_propagate() ?int {
-	eventual_wrong_int()?
+	eventual_wrong_int() ?
 }

--- a/vlib/v/fmt/tests/orm_keep.vv
+++ b/vlib/v/fmt/tests/orm_keep.vv
@@ -14,7 +14,7 @@ fn find_all_customers(db sqlite.DB) []Customer {
 }
 
 fn main() {
-	db := sqlite.connect('customers.db')?
+	db := sqlite.connect('customers.db') ?
 	// select count(*) from Customer
 	nr_customers := sql db {
 		select count from Customer


### PR DESCRIPTION
This was just discussed on Discord #syntax. It is more readable if there is a space between the closing `)` and the `?` for error propagation:
```v
fn f() ?X {
    y := g() ?
    ...
}
```
This PR changes `docs.md`, `vfmt` and the test cases.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
