### PR TITLE
checker, builtin: prepare for moving channel code to `builtin`

### DIFF
--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -197,7 +197,7 @@ Did you forget to add vlib to the path? (Use @vlib for default vlib)')
 }
 
 pub fn (v &Builder) get_user_files() []string {
-	if v.pref.path in ['vlib/builtin', 'vlib/strconv', 'vlib/strings', 'vlib/hash'] {
+	if v.pref.path in ['vlib/builtin', 'vlib/strconv', 'vlib/strings', 'vlib/hash', 'vlib/time'] {
 		// This means we are building a builtin module with `v build-module vlib/strings` etc
 		// get_builtin_files() has already added the files in this module,
 		// do nothing here to avoid duplicate definition errors.

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -53,6 +53,9 @@ pub fn (mut p Parser) parse_map_type() table.Type {
 
 pub fn (mut p Parser) parse_chan_type() table.Type {
 	p.next()
+	if p.tok.kind != .name && p.tok.kind != .key_mut && p.tok.kind != .amp {
+		return table.chan_type
+	}
 	elem_type := p.parse_type()
 	idx := p.table.find_or_register_chan(elem_type)
 	return table.new_type(idx)

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -13,7 +13,7 @@ pub const (
 
 // math.bits is needed by strconv.ftoa
 pub const (
-	builtin_module_parts = ['math.bits', 'strconv', 'strconv.ftoa', 'hash', 'strings', 'builtin']
+	builtin_module_parts = ['math.bits', 'strconv', 'strconv.ftoa', 'hash', 'strings', 'time', 'builtin']
 )
 
 pub const (


### PR DESCRIPTION
This PR allows defining `struct chan {...}` and writing methods in `builtin` so that the channel code can be moved there and `import sync` will not be needed any more.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
