### PR TITLE
builtin/channels: make `sync` available for `vlib/builtin`

### DIFF
--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -1,7 +1,6 @@
 module sync
 
 import time
-import rand
 
 #flag windows -I @VROOT/thirdparty/stdatomic/win
 #flag linux -I @VROOT/thirdparty/stdatomic/nix
@@ -528,7 +527,8 @@ pub fn channel_select(mut channels []&Channel, dir []Direction, mut objrefs []vo
 	stopwatch := if timeout <= 0 { time.StopWatch{} } else { time.new_stopwatch({}) }
 	mut event_idx := -1 // negative index means `timed out`
 	for {
-		rnd := rand.u32_in_range(0, u32(channels.len))
+		// this will be replaced with something more random
+		rnd := time.now().unix % u32(channels.len)
 		mut num_closed := 0
 		for j, _ in channels {
 			mut i := j + int(rnd)

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -197,7 +197,7 @@ Did you forget to add vlib to the path? (Use @vlib for default vlib)')
 }
 
 pub fn (v &Builder) get_user_files() []string {
-	if v.pref.path in ['vlib/builtin', 'vlib/strconv', 'vlib/strings', 'vlib/hash', 'vlib/time'] {
+	if v.pref.path in ['vlib/builtin', 'vlib/strconv', 'vlib/strings', 'vlib/hash', 'vlib/time', 'vlib/os', 'vlib/runtime', 'vlib/sync'] {
 		// This means we are building a builtin module with `v build-module vlib/strings` etc
 		// get_builtin_files() has already added the files in this module,
 		// do nothing here to avoid duplicate definition errors.

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -13,7 +13,7 @@ pub const (
 
 // math.bits is needed by strconv.ftoa
 pub const (
-	builtin_module_parts = ['math.bits', 'strconv', 'strconv.ftoa', 'hash', 'strings', 'time', 'builtin']
+	builtin_module_parts = ['math.bits', 'strconv', 'strconv.ftoa', 'hash', 'strings', 'time', 'os', 'runtime', 'sync', 'builtin']
 )
 
 pub const (


### PR DESCRIPTION
This is a further step for making channels (and `lock`) available without importing `sync`. I've removed the dependency to `rand` in `channels.v` and added `sync` and its remaining dependencies to the builtin-lists.

Actually only semaphores, mutexes and channels themselves are needed by `builtin`. But `vlib/sync` has grown somewhat so there are now dependencies to `os` and `runtime`.

Maybe in the future `vlib/sync` could be split into `sync_lowlevel` for things that are imported by `builtin` and `sync_highlevel` for things like waitgroups.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
