### PR TITLE
net.urllib.v: remove line breaks from values submitted via web forms; line breaks prevent escaping encoded characters

### DIFF
--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -146,7 +146,7 @@ pub fn path_unescape(s string) ?string {
 // unescape unescapes a string; the mode specifies
 // which section of the URL string is being unescaped.
 fn unescape(s_ string, mode EncodingMode) ?string {
-	mut s := s_
+	mut s := s_.replace('\r\n','')
 	// Count %, check that they're well-formed.
 	mut n := 0
 	mut has_plus := false

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -494,7 +494,9 @@ fn (mut ctx Context) parse_form(s string) {
 		}
 		keyval := word.trim_space().split('=')
 		if keyval.len != 2 { continue }
-		key := keyval[0]
+		key := urllib.query_unescape(keyval[0]) or {
+			continue
+		}
 		val := urllib.query_unescape(keyval[1]) or {
 			continue
 		}


### PR DESCRIPTION
Update tldr: vweb.handle_connection() line body += line.trim_left('\r\n') should be body += line.trim('\r\n')

http.Socket.read_line() used by the vweb reads data in chunks of 400 mut buf := [max_read]byte{} where max_read is a public constant in the Socket file. At the end of this buffered read, Socket.read_line() adds a new line res += crlf where defined earlier as crlf = '\r\n'. It turns out, this crlf is never removed, however an attempt was made in vweb.handle_connection() this way: body += line.trim_left('\r\n'). I believe this code should be body += line.trim('\r\n')  as the new line was added to the right of the buffer.
------------------ end update

I'm using a web based project scheduling chart (https://dhtmlx.com/docs/products/dhtmlxGantt/) that uses JSON as data.  Saving this JSON partially or entirely (with jquery 3), via POST will fail silently . This happened regardless of the size of the JSON file. Debugging with `println` in the `urllib` `unescape` function , I've noticed that often the JSON file would be interrupted by line breaks. The form post only failed when encoded characters, such as %22, would be split, with the digits on a new line. Expanding (/unwrapping) the debugging text for the entire width of the screen (37") would still keep that line break. Removing line breaks fixed the problem. This JSON/web form has been tested with golang with no issues.

Example debugging output (sample JSON at the end):
```
%
5D%2C%22cons
``` 
This line break would not be present in the Firefox debugging tool captured prior to the request being posted.

Location of the debugging `println`:
```
if i + 2 >= s.len || !ishex(s[i + 1]) || !ishex(s[i + 2]) {
					s = s[i..]
					println(s)
					if s.len > 3 {
						s = s[..3]
					}
					return error(error_msg(err_msg_escape + ' .1', s))
				}
```

Proposed change, first line of the `fn unescape()` function:
```
// unescape unescapes a string; the mode specifies
// which section of the URL string is being unescaped.
fn unescape(s_ string, mode EncodingMode) ?string {
	mut s := s_.replace('\r\n','')
	// Count %, check that they're well-formed.
	mut n := 0
	mut has_plus := false
       // etc
```

Line breaks are however intended in plain text. If someone could review whether this line break is not one of those.

```
{
    "data": [{
        "id": "512",
        "start_date": "2018-09-29 00:00:00",
        "duration": 2,
        "text": "Lot 2",
        "progress": 1,
        "type": "project",
        "level": "0",
        "project_id": "51",
        "end_date": "2018-10-03 00:00:00",
        "owner_id": [],
        "constraint_type": "snet",
        "parent": 0,
        "constraint_date": "2018-09-29 00:00:00"
    }, {
        "id": 1598758646591,
        "start_date": "2018-09-29 00:00:00",
        "text": "New task",
        "duration": 1,
        "parent": "512",
        "constraint_type": "snet",
        "end_date": "2018-10-02 00:00:00",
        "progress": 0,
        "owner_id": [],
        "constraint_date": "2018-09-29 00:00:00"
    }, {
        "id": 1598758646598,
        "start_date": "2018-10-02 00:00:00",
        "text": "New task",
        "duration": 1,
        "parent": "1598758646591",
        "constraint_type": "snet",
        "end_date": "2018-10-03 00:00:00",
        "progress": 0,
        "owner_id": [],
        "constraint_date": "2018-10-02 00:00:00"
    }, {
        "id": 1598758646599,
        "start_date": "2018-10-02 00:00:00",
        "text": "New task",
        "duration": 1,
        "parent": "1598758646598",
        "constraint_type": "snet",
        "end_date": "2018-10-03 00:00:00",
        "progress": 0,
        "owner_id": [],
        "constraint_date": "2018-10-02 00:00:00"
    }],
    "links": [{
        "source": "1598758646591",
        "target": "1598758646598",
        "type": "1",
        "id": 1598758646600
    }, {
        "source": "1598758646598",
        "target": "1598758646599",
        "type": "1",
        "id": 1598758646601
    }]
}
```
The following is the JS code submitting the form:
```
function save() {
		let key = jQuery("#taskData2").attr("src") // "target_json.json"
		let data = {}
		data["schedule_lot2.json"] = "var taskData2 = " + JSON.stringify(gantt.serialize())
		console.log(gantt.serialize())
		console.log(JSON.stringify(gantt.serialize()))
		jQuery.ajax({
			method: "POST",
			crossDomain: true,
			url: 'http://localhost:8080/save_schedule',
			data: data,
			error: function(xhr, status, error) {
				console.log(status)
				console.log(xhr)
			},
			success: function(data,status) {
				console.log('status:',status)
			}
		})
	}
```