### PR TITLE
parser: enable module auto import (of `sync`)

### DIFF
--- a/vlib/sync/bench/channel_bench_v.v
+++ b/vlib/sync/bench/channel_bench_v.v
@@ -6,24 +6,21 @@
 // The receive threads add all received numbers and send them to the
 // main thread where the total sum is compare to the expected value.
 
-import sync
 import time
 import os
 
-fn do_rec(mut ch sync.Channel, mut resch sync.Channel, n int) {
+fn do_rec(ch chan int, resch chan i64, n int) {
 	mut sum := i64(0)
 	for _ in 0 .. n {
-		mut a := 0
-		ch.pop(&a)
-		sum += a
+		sum += <-ch
 	}
 	println(sum)
-	resch.push(&sum)
+	resch <- sum
 }
 
-fn do_send(mut ch sync.Channel, start, end int) {
+fn do_send(ch chan int, start, end int) {
 	for i in start .. end {
-		ch.push(&i)
+		ch <- i
 	}
 }
 
@@ -37,12 +34,12 @@ fn main() {
 	buflen := os.args[3].int()
 	nobj := os.args[4].int()
 	stopwatch := time.new_stopwatch({})
-	mut ch := sync.new_channel<int>(buflen)
-	mut resch := sync.new_channel<i64>(0)
+	ch := chan int{cap: buflen}
+	resch := chan i64{}
 	mut no := nobj
 	for i in 0 .. nrec {
 		n := no / (nrec - i)
-		go do_rec(mut ch, mut resch, n)
+		go do_rec(ch, resch, n)
 		no -= n
 	}
 	assert no == 0
@@ -51,14 +48,12 @@ fn main() {
 		n := no / (nsend - i)
 		end := no
 		no -= n
-		go do_send(mut ch, no, end)
+		go do_send(ch, no, end)
 	}
 	assert no == 0
 	mut sum := i64(0)
 	for _ in 0 .. nrec {
-		mut r := i64(0)
-		resch.pop(&r)
-		sum += r
+		sum += <-resch
 	}
 	elapsed := stopwatch.elapsed()
 	rate := f64(nobj)/elapsed*time.microsecond

--- a/vlib/sync/channel_1_test.v
+++ b/vlib/sync/channel_1_test.v
@@ -1,23 +1,19 @@
-import sync
-
 const (
 	num_iterations = 10000
 )
 
-fn do_send(mut ch sync.Channel) {
+fn do_send(ch chan int) {
 	for i in 0 .. num_iterations {
-		ch.push(&i)
+		ch <- i
 	}
 }
 
 fn test_channel_buffered() {
-	mut ch := sync.new_channel<int>(1000)
-	go do_send(mut ch)
+	ch := chan int{cap: 1000}
+	go do_send(ch)
 	mut sum := i64(0)
 	for _ in 0 .. num_iterations {
-		a := 0
-		ch.pop(&a)
-		sum += a
+		sum += <-ch
 	}
 	assert sum == u64(num_iterations)*(num_iterations-1)/2
 }

--- a/vlib/sync/channel_2_test.v
+++ b/vlib/sync/channel_2_test.v
@@ -1,23 +1,19 @@
-import sync
-
 const (
 	num_iterations = 10000
 )
 
-fn do_send(mut ch sync.Channel) {
+fn do_send(ch chan int) {
 	for i in 0 .. num_iterations {
-		ch.push(&i)
+		ch <- i
 	}
 }
 
 fn test_channel_unbuffered() {
-	mut ch := sync.new_channel<int>(0)
-	go do_send(mut ch)
+	ch := chan int{}
+	go do_send(ch)
 	mut sum := i64(0)
 	for _ in 0 .. num_iterations {
-		a := 0
-		ch.pop(&a)
-		sum += a
+		sum += <-ch
 	}
 	assert sum == u64(num_iterations)*(num_iterations-1)/2
 }

--- a/vlib/sync/channel_3_test.v
+++ b/vlib/sync/channel_3_test.v
@@ -1,38 +1,32 @@
-import sync
-
-fn do_rec(mut ch sync.Channel, mut resch sync.Channel) {
+fn do_rec(ch chan int, resch chan i64) {
 	mut sum := i64(0)
 	for _ in 0 .. 2000 {
-		mut a := 0
-		ch.pop(&a)
-		sum += a
+		sum += <-ch
 	}
 	println(sum)
-	resch.push(&sum)
+	resch <- sum
 }
 
-fn do_send(mut ch sync.Channel) {
+fn do_send(ch chan int) {
 	for i in 0 .. 2000 {
-		ch.push(&i)
+		ch <- i
 	}
 }
 
 fn test_channel_multi_unbuffered() {
-	mut ch := sync.new_channel<int>(0)
-	mut resch := sync.new_channel<i64>(0)
-	go do_rec(mut ch, mut resch)
-	go do_rec(mut ch, mut resch)
-	go do_rec(mut ch, mut resch)
-	go do_rec(mut ch, mut resch)
-	go do_send(mut ch)
-	go do_send(mut ch)
-	go do_send(mut ch)
-	go do_send(mut ch)
+	ch := chan int{}
+	resch := chan i64{}
+	go do_rec(ch, resch)
+	go do_rec(ch, resch)
+	go do_rec(ch, resch)
+	go do_rec(ch, resch)
+	go do_send(ch)
+	go do_send(ch)
+	go do_send(ch)
+	go do_send(ch)
 	mut sum := i64(0)
 	for _ in 0 .. 4 {
-		mut r := i64(0)
-		resch.pop(&r)
-		sum += r
+		sum += <-resch
 	}
 	assert sum == i64(4) * 2000 * (2000 - 1) / 2
 }

--- a/vlib/sync/channel_4_test.v
+++ b/vlib/sync/channel_4_test.v
@@ -1,38 +1,32 @@
-import sync
-
-fn do_rec(mut ch sync.Channel, mut resch sync.Channel) {
+fn do_rec(ch chan int, resch chan i64) {
 	mut sum := i64(0)
 	for _ in 0 .. 2000 {
-		mut a := 0
-		ch.pop(&a)
-		sum += a
+		sum += <-ch
 	}
 	println(sum)
-	resch.push(&sum)
+	resch <- sum
 }
 
-fn do_send(mut ch sync.Channel) {
+fn do_send(ch chan int) {
 	for i in 0 .. 2000 {
-		ch.push(&i)
+		ch <- i
 	}
 }
 
 fn test_channel_multi_buffered() {
-	mut ch := sync.new_channel<int>(100)
-	mut resch := sync.new_channel<i64>(0)
-	go do_rec(mut ch, mut resch)
-	go do_rec(mut ch, mut resch)
-	go do_rec(mut ch, mut resch)
-	go do_rec(mut ch, mut resch)
-	go do_send(mut ch)
-	go do_send(mut ch)
-	go do_send(mut ch)
-	go do_send(mut ch)
+	ch := chan int{cap: 100}
+	resch := chan i64{}
+	go do_rec(ch, resch)
+	go do_rec(ch, resch)
+	go do_rec(ch, resch)
+	go do_rec(ch, resch)
+	go do_send(ch)
+	go do_send(ch)
+	go do_send(ch)
+	go do_send(ch)
 	mut sum := i64(0)
 	for _ in 0 .. 4 {
-		mut r := i64(0)
-		resch.pop(&r)
-		sum += r
+		sum += <-resch
 	}
 	assert sum == i64(4) * 2000 * (2000 - 1) / 2
 }

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -174,7 +174,7 @@ pub fn (mut ch Channel) try_push(src voidptr) TransactionState {
 	return ch.try_push_priv(src, false)
 }
 
-fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) TransactionState {
+pub fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) TransactionState {
 	if C.atomic_load_u16(&ch.closed) != 0 {
 		return .closed
 	}
@@ -333,7 +333,7 @@ pub fn (mut ch Channel) try_pop(dest voidptr) TransactionState {
 	return ch.try_pop_priv(dest, false)
 }
 
-fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) TransactionState {
+pub fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) TransactionState {
 	spinloops_sem_, spinloops_ := if no_block { spinloops, spinloops_sem } else { 1, 1 }
 	mut have_swapped := false
 	mut write_in_progress := false

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -174,7 +174,7 @@ pub fn (mut ch Channel) try_push(src voidptr) TransactionState {
 	return ch.try_push_priv(src, false)
 }
 
-pub fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) TransactionState {
+fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) TransactionState {
 	if C.atomic_load_u16(&ch.closed) != 0 {
 		return .closed
 	}
@@ -333,7 +333,7 @@ pub fn (mut ch Channel) try_pop(dest voidptr) TransactionState {
 	return ch.try_pop_priv(dest, false)
 }
 
-pub fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) TransactionState {
+fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) TransactionState {
 	spinloops_sem_, spinloops_ := if no_block { spinloops, spinloops_sem } else { 1, 1 }
 	mut have_swapped := false
 	mut write_in_progress := false

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -197,7 +197,7 @@ Did you forget to add vlib to the path? (Use @vlib for default vlib)')
 }
 
 pub fn (v &Builder) get_user_files() []string {
-	if v.pref.path in ['vlib/builtin', 'vlib/strconv', 'vlib/strings', 'vlib/hash', 'vlib/time'] {
+	if v.pref.path in ['vlib/builtin', 'vlib/strconv', 'vlib/strings', 'vlib/hash'] {
 		// This means we are building a builtin module with `v build-module vlib/strings` etc
 		// get_builtin_files() has already added the files in this module,
 		// do nothing here to avoid duplicate definition errors.

--- a/vlib/v/parser/lock.v
+++ b/vlib/v/parser/lock.v
@@ -5,7 +5,7 @@ import v.table
 
 fn (mut p Parser) lock_expr() ast.LockExpr {
 	// TODO Handle aliasing sync
-	p.register_used_import('sync')
+	p.register_auto_import('sync')
 	pos := p.tok.position()
 	is_rlock := p.tok.kind == .key_rlock
 	p.next()

--- a/vlib/v/parser/module.v
+++ b/vlib/v/parser/module.v
@@ -3,6 +3,8 @@
 // that can be found in the LICENSE file.
 module parser
 
+import v.ast
+
 // return true if file being parsed imports `mod`
 pub fn (p &Parser) known_import(mod string) bool {
 	return mod in p.imports
@@ -27,6 +29,20 @@ fn (mut p Parser) register_used_import(alias string) {
 	if !p.is_used_import(alias) {
 		p.used_imports << alias
 	}
+}
+
+fn (mut p Parser) register_auto_import(alias string) {
+	if alias !in p.imports {
+		p.imports[alias] = alias
+		p.table.imports << alias
+		node := ast.Import{
+			pos:   p.tok.position()
+			mod:   alias
+			alias: alias
+		}
+		p.ast_imports << node
+	}
+	p.register_used_import(alias)
 }
 
 fn (mut p Parser) check_unused_imports() {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -52,7 +52,7 @@ pub fn (mut p Parser) parse_map_type() table.Type {
 }
 
 pub fn (mut p Parser) parse_chan_type() table.Type {
-	if p.tok.kind != .name && p.tok.kind != .key_mut && p.tok.kind != .amp {
+	if p.peek_tok.kind != .name && p.peek_tok.kind != .key_mut && p.peek_tok.kind != .amp {
 		p.next()
 		return table.chan_type
 	}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -52,11 +52,12 @@ pub fn (mut p Parser) parse_map_type() table.Type {
 }
 
 pub fn (mut p Parser) parse_chan_type() table.Type {
-	p.register_auto_import('sync')
-	p.next()
 	if p.tok.kind != .name && p.tok.kind != .key_mut && p.tok.kind != .amp {
+		p.next()
 		return table.chan_type
 	}
+	p.register_auto_import('sync')
+	p.next()
 	elem_type := p.parse_type()
 	idx := p.table.find_or_register_chan(elem_type)
 	return table.new_type(idx)

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -52,6 +52,7 @@ pub fn (mut p Parser) parse_map_type() table.Type {
 }
 
 pub fn (mut p Parser) parse_chan_type() table.Type {
+	p.register_auto_import('sync')
 	p.next()
 	if p.tok.kind != .name && p.tok.kind != .key_mut && p.tok.kind != .amp {
 		return table.chan_type

--- a/vlib/v/tests/autolock_array1_test.v
+++ b/vlib/v/tests/autolock_array1_test.v
@@ -1,4 +1,3 @@
-import sync
 import time
 
 const (

--- a/vlib/v/tests/shared_array_test.v
+++ b/vlib/v/tests/shared_array_test.v
@@ -1,4 +1,3 @@
-import sync
 import time
 
 fn incr(shared foo []int, index int) {

--- a/vlib/v/tests/shared_lock_2_test.v
+++ b/vlib/v/tests/shared_lock_2_test.v
@@ -1,4 +1,3 @@
-import sync
 import time
 
 struct St {

--- a/vlib/v/tests/shared_lock_3_test.v
+++ b/vlib/v/tests/shared_lock_3_test.v
@@ -1,4 +1,3 @@
-import sync
 import time
 
 struct St {

--- a/vlib/v/tests/shared_lock_4_test.v
+++ b/vlib/v/tests/shared_lock_4_test.v
@@ -1,4 +1,3 @@
-import sync
 import time
 
 struct St {

--- a/vlib/v/tests/shared_lock_test.v
+++ b/vlib/v/tests/shared_lock_test.v
@@ -1,4 +1,3 @@
-import sync
 import time
 
 struct St {

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -13,7 +13,7 @@ pub const (
 
 // math.bits is needed by strconv.ftoa
 pub const (
-	builtin_module_parts = ['math.bits', 'strconv', 'strconv.ftoa', 'hash', 'strings', 'time', 'builtin']
+	builtin_module_parts = ['math.bits', 'strconv', 'strconv.ftoa', 'hash', 'strings', 'builtin']
 )
 
 pub const (


### PR DESCRIPTION
This PR adds a method `p.register_auto_import()` to `parser`. It is called whenever there is one of the tokens `<-`, `chan`, `lock` or `rlock` in the parsed file in order to implicitly import the `sync` module.
So there is no need for `import sync` any more (unless other elements like `sync.Semaphore` or `sync.WaitGroup` are used).
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
