### PR TITLE
vweb: print to console the route matching only when debug is defined

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -134,7 +134,6 @@ pub fn (mut ctx Context) set_cookie(cookie Cookie) {
 
 pub fn (mut ctx Context) set_cookie_old(key, val string) {
 	// TODO support directives, escape cookie value (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)
-	//println('Set-Cookie $key=$val')
 	//ctx.add_header('Set-Cookie', '${key}=${val};  Secure; HttpOnly')
 	ctx.add_header('Set-Cookie', '${key}=${val}; HttpOnly')
 }
@@ -344,7 +343,9 @@ fn handle_conn<T>(conn net.Socket, mut app T) {
 	app.init()
 
 	// Call the right action
-	println('route matching...')
+	$if debug {
+		println('route matching...')
+	}
 	//t := time.ticks()
 	//mut action := ''
 	mut route_words_a := [][]string{}
@@ -379,7 +380,9 @@ fn handle_conn<T>(conn net.Socket, mut app T) {
 				// For example URL `/register` matches route `/:user`, but `fn register()`
 				// should be called first.
 				if (req.method == .get && url_words[0] == method.name && url_words.len == 1) || (req.method == .post && url_words[0] + '_post' == method.name) {
-					println('easy match method=$method.name')
+					$if debug {
+						println('easy match method=$method.name')
+					}
 					app.$method(vars)
 					return
 				}


### PR DESCRIPTION
Hi all,
with this small change, route matching will be written to console only when debug if defined (so less noise in the console of vweb apps).

Hope it's good. Bye