### PR TITLE
v/builder: use tar instead of unzip in cc_linux_cross() #6241

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -599,7 +599,7 @@ fn (mut b Builder) cc_linux_cross() {
 		println('Downloading files for Linux cross compilation (~18 MB)...')
 		zip_file := sysroot[..sysroot.len - 1] + '.zip'
 		os.system('curl -L -o $zip_file $zip_url')
-		os.system('unzip -q $zip_file -d $parent_dir')
+		os.system('tar -C $parent_dir -xf $zip_file')
 		if !os.is_dir(sysroot) {
 			println('Failed to download.')
 			exit(1)


### PR DESCRIPTION
This will use `tar` instead of `unzip` for cross-compile to linux. Fixing the #6241 