### PR TITLE
checker: do not allow aliases of `chan` types

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -269,6 +269,8 @@ pub fn (mut c Checker) type_decl(node ast.TypeDecl) {
 				orig_sym := c.table.get_type_symbol((typ_sym.info as table.Alias).parent_type)
 				c.error('type `$typ_sym.str()` is an alias, use the original alias type `$orig_sym.source_name` instead',
 					node.pos)
+			} else if typ_sym.kind == .chan {
+				c.error('aliases of `chan` types are not allowed.', node.pos)
 			}
 		}
 		ast.FnTypeDecl {


### PR DESCRIPTION
Aliases of `chan` types do not work. It turns out that supporting this feature properly would be harder than expected because of all the compiler builtin handling for these special types (`<-` operator, `or` block/error propagation, automatic import of `sync`, future `select` syntax, builtin (pseudo) attributes, ...).
The benefit of `chan` aliases on the other hand seems to be negligible (actually they might even be confusing). But at least, the `V` user deserves a proper error message - so this PR just emits one if a `chan` type is tried to be aliased.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
