### PR TITLE
os: make "os.mv()" behave more like Unix "mv" command. This will close #6255.

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -58,10 +58,14 @@ pub fn file_size(path string) int {
 
 // mv moves files or folders from `src` to `dst`.
 pub fn mv(src, dst string) {
+	mut rdst := dst
+	if is_dir(rdst) {
+		rdst = join_path(rdst,file_name(src.trim_right(path_separator)))
+	}
 	$if windows {
-		C._wrename(src.to_wide(), dst.to_wide())
+		C._wrename(src.to_wide(), rdst.to_wide())
 	} $else {
-		C.rename(charptr(src.str), charptr(dst.str))
+		C.rename(charptr(src.str), charptr(rdst.str))
 	}
 }
 

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -156,6 +156,52 @@ fn test_cp() {
 	os.rm(new_file_name)
 }
 
+/*
+fn test_mv() {
+	work_dir := os.join_path(os.temp_dir(),'v','mv_test')
+	if os.exists(work_dir) {
+		os.rmdir_all(work_dir)
+	}
+	mkdir_all(work_dir)
+	// Setup test files
+	tfile1 := os.join_path(work_dir,'file')
+	tfile2 := os.join_path(work_dir,'file.test')
+	tfile3 := os.join_path(work_dir,'file.3')
+	tfile_content := 'temporary file'
+	os.write_file(tfile1, tfile_content)
+	os.write_file(tfile2, tfile_content)
+	// Setup test dirs
+	tdir1 := os.join_path(work_dir,'dir')
+	tdir2 := os.join_path(work_dir,'dir2')
+	tdir3 := os.join_path(work_dir,'dir3')
+	mkdir(tdir1)
+	mkdir(tdir2)
+	// Move file with no extension to dir
+	os.mv(tfile1,tdir1)
+	mut expected := os.join_path(tdir1,'file')
+	assert os.exists(expected) && !is_dir(expected) == true
+	// Move dir with contents to other dir
+	os.mv(tdir1,tdir2)
+	expected = os.join_path(tdir2,'dir')
+	assert os.exists(expected) && is_dir(expected) == true
+	expected = os.join_path(tdir2,'dir','file')
+	assert os.exists(expected) && !is_dir(expected) == true
+	// Move dir with contents to other dir (by renaming)
+	os.mv(os.join_path(tdir2,'dir'),tdir3)
+	expected = tdir3
+	assert os.exists(expected) && is_dir(expected) == true
+	assert os.is_dir_empty(tdir2) == true
+	// Move file with extension to dir
+	os.mv(tfile2,tdir2)
+	expected = os.join_path(tdir2,'file.test')
+	assert os.exists(expected) && !is_dir(expected) == true
+	// Move file to dir (by renaming)
+	os.mv(os.join_path(tdir2,'file.test'),tfile3)
+	expected = tfile3
+	assert os.exists(expected) && !is_dir(expected) == true
+}
+*/
+
 fn test_cp_r() {
 	// fileX -> dir/fileX
 	// NB: clean up of the files happens inside the cleanup_leftovers function


### PR DESCRIPTION
This will make `os.mv` behave more like the Unix `mv` command-line application.

As `os.mv()` uses `C._wrename/C.rename` it requires the user to explicitly include a filename to "rename" to in the `dst` path argument. With this PR the name of the `dst` will be automatically resolved. If `dst` dir doesn't exist it will behave just like before by simply moving-by-renaming. This behaviour is also found with the Unix `mv` command.

Passing tests are included but commented out. Separate PR will come afterwards to enable these tests.

This should then close #6255.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
