### PR TITLE
os: introduce `os.is_file()` function

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -1024,6 +1024,11 @@ pub fn is_dir(path string) bool {
 	}
 }
 
+// is_file returns a `bool` indicating whether the given `path` is a file.
+pub fn is_file(path string) bool {
+	return exists(path) && !is_dir(path)
+}
+
 // is_link returns a boolean indicating whether `path` is a link.
 pub fn is_link(path string) bool {
 	$if windows {

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -54,7 +54,37 @@ fn test_create_file() {
 	assert hello.len == os.file_size(filename)
 	os.rm(filename)
 }
-
+/*
+fn test_is_file() {
+	// Setup
+	work_dir := os.join_path(os.getwd(),'is_file_test')
+	os.mkdir_all(work_dir)
+	tfile := os.join_path(work_dir,'tmp_file')
+	// Test things that shouldn't be a file
+	assert os.is_file(work_dir) == false
+	assert os.is_file('non-existent_file.tmp') == false
+	// Test file
+	tfile_content := 'temporary file'
+	os.write_file(tfile, tfile_content)
+	assert os.is_file(tfile)
+	// Test dir symlinks
+	$if windows {
+		assert true
+	} $else {
+		dsymlink := os.join_path(work_dir,'dir_symlink')
+		os.system('ln -s $work_dir $dsymlink')
+		assert os.is_file(dsymlink) == false
+	}
+	// Test file symlinks
+	$if windows {
+		assert true
+	} $else {
+		fsymlink := os.join_path(work_dir,'file_symlink')
+		os.system('ln -s $tfile $fsymlink')
+		assert os.is_file(fsymlink)
+	}
+}
+*/
 fn test_write_and_read_string_to_file() {
 	filename := './test1.txt'
 	hello := 'hello world!'


### PR DESCRIPTION
Add a way to check if a given path is a file or not.
On Unix-like systems symbolic links are followed - as this is the current behaviour of `os.is_dir(...)`
Passing tests are included but commented out. Separate PR will come afterwards to enable these tests.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
