### PR TITLE
os: fix os.mv edge case and Windows style paths

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -60,10 +60,12 @@ pub fn file_size(path string) int {
 pub fn mv(src, dst string) {
 	mut rdst := dst
 	if is_dir(rdst) {
-		rdst = join_path(rdst,file_name(src.trim_right(path_separator)))
+		rdst = join_path(rdst.trim_right(path_separator),file_name(src.trim_right(path_separator)))
 	}
 	$if windows {
-		C._wrename(src.to_wide(), rdst.to_wide())
+		w_src := src.replace('/', '\\')
+		w_dst := rdst.replace('/', '\\')
+		C._wrename(w_src.to_wide(), w_dst.to_wide())
 	} $else {
 		C.rename(charptr(src.str), charptr(rdst.str))
 	}

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -155,14 +155,10 @@ fn test_cp() {
 	os.rm(old_file_name)
 	os.rm(new_file_name)
 }
-
 /*
 fn test_mv() {
-	work_dir := os.join_path(os.temp_dir(),'v','mv_test')
-	if os.exists(work_dir) {
-		os.rmdir_all(work_dir)
-	}
-	mkdir_all(work_dir)
+	work_dir := os.join_path(os.getwd(),'mv_test')
+	os.mkdir_all(work_dir)
 	// Setup test files
 	tfile1 := os.join_path(work_dir,'file')
 	tfile2 := os.join_path(work_dir,'file.test')
@@ -201,7 +197,6 @@ fn test_mv() {
 	assert os.exists(expected) && !is_dir(expected) == true
 }
 */
-
 fn test_cp_r() {
 	// fileX -> dir/fileX
 	// NB: clean up of the files happens inside the cleanup_leftovers function

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -155,7 +155,7 @@ fn test_cp() {
 	os.rm(old_file_name)
 	os.rm(new_file_name)
 }
-/*
+
 fn test_mv() {
 	work_dir := os.join_path(os.getwd(),'mv_test')
 	os.mkdir_all(work_dir)
@@ -196,7 +196,7 @@ fn test_mv() {
 	expected = tfile3
 	assert os.exists(expected) && !is_dir(expected) == true
 }
-*/
+
 fn test_cp_r() {
 	// fileX -> dir/fileX
 	// NB: clean up of the files happens inside the cleanup_leftovers function


### PR DESCRIPTION
This PR will ensure that no double path separators slips through to the rename calls.
It will also correct any Unix-style path separators on Windows - tests should then also pass on this platform.
(Will be enabled in PR after this - as they depend on this PR).
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
