### PR TITLE
builtin/channels: add methods to builtin channels 

### DIFF
--- a/vlib/builtin/chan.v
+++ b/vlib/builtin/chan.v
@@ -1,0 +1,20 @@
+module builtin
+
+enum ChanState {
+	success
+	not_ready // push()/pop() would have to wait, but no_block was requested
+	closed
+}
+
+// The following methods are only stubs. The real implementation
+// is in `vlib/sync/channels.v`
+
+pub fn (ch chan) close() {}
+
+pub fn (ch chan) try_pop(obj voidptr) ChanState {
+	return .success
+}
+
+pub fn (ch chan) try_push(obj voidptr) ChanState {
+	return .success
+}

--- a/vlib/sync/channel_array_mut_test.v
+++ b/vlib/sync/channel_array_mut_test.v
@@ -1,5 +1,3 @@
-import sync
-
 const (
 	num_iterations = 10000
 )
@@ -34,6 +32,6 @@ fn test_channel_array_mut() {
 		chs[0] <- t
 		t = <-chs[1]
 	}
-	(&sync.Channel(chs[0])).close()
+	chs[0].close()
 	assert t.n == 100 + num_iterations
 }

--- a/vlib/sync/channel_polling_test.v
+++ b/vlib/sync/channel_polling_test.v
@@ -1,0 +1,53 @@
+// Channel Benchmark
+//
+// `nobj` integers are sent thru a channel with queue length`buflen`
+// using `nsend` sender threads and `nrec` receiver threads.
+//
+// The receive threads add all received numbers and send them to the
+// main thread where the total sum is compare to the expected value.
+
+const (
+	nsend = 2
+	nrec = 2
+	buflen = 100
+	nobj = 10000
+	objs_per_thread = 5000
+)
+
+fn do_rec(ch chan int, resch chan i64, n int) {
+	mut sum := i64(0)
+	for _ in 0 .. n {
+		mut r := 0
+		for ch.try_pop(mut r) != .success {}
+		sum += r
+	}
+	println(sum)
+	resch <- sum
+}
+
+fn do_send(ch chan int, start, end int) {
+	for i in start .. end {
+		for ch.try_push(i) != .success {}
+	}
+}
+
+fn test_channel_polling() {
+	ch := chan int{cap: buflen}
+	resch := chan i64{}
+	for i in 0 .. nrec {
+		go do_rec(ch, resch, objs_per_thread)
+	}
+	mut n := nobj
+	for i in 0 .. nsend {
+		end := n
+		n -= objs_per_thread
+		go do_send(ch, n, end)
+	}
+	mut sum := i64(0)
+	for _ in 0 .. nrec {
+		sum += <-resch
+	}
+	// use sum formula by Gauß to calculate the expected result
+	expected_sum := i64(nobj)*(nobj-1)/2
+	assert sum == expected_sum
+}

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -391,6 +391,11 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		}
 	}
 	mut name := util.no_dots('${receiver_type_name}_$node.name')
+	if left_sym.kind == .chan {
+		if node.name in ['close', 'try_pop', 'try_push'] {
+			name = 'sync__Channel_$node.name'
+		}
+	}
 	// Check if expression is: arr[a..b].clone(), arr[a..].clone()
 	// if so, then instead of calling array_clone(&array_slice(...))
 	// call array_clone_static(array_slice(...))


### PR DESCRIPTION
This PR makes the methods `close()`, `try_pop()` and `try_push()` from `vlib/sync` available for builtin channels:
```v
fn main() {
    ch := chan int{cap: 1}
    a := 5
    res1 := ch.try_push(a)
    assert res1 == .success
    mut b := 0
    if ch.try_pop(mut b) == .not_ready {
        println('no object queued')
    }
    ch.close()
    assert ch.try_pop(mut b) == .closed
}
```

- method stubs are defined in `vlib/builtin/chan.v` so these methods become known to the checker
- `gen/cgen.v` replaces the function names with those from `vlib/sync`

More sophisticated checks (object types, `mut` state, ...) are not implemented, yet. I'll add them in following PRs...
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
