### PR TITLE
builtin/cheaders: fix `in` for various numeric types

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -394,6 +394,16 @@ pub fn (a []byte) contains(val byte) bool {
 }
 
 // TODO generic
+pub fn (a []u16) contains(val u16) bool {
+	for aa in a {
+		if aa == val {
+			return true
+		}
+	}
+	return false
+}
+
+// TODO generic
 fn (ar []int) contains(val int) bool {
 	for s in ar {
 		if s == val {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2392,9 +2392,10 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 				else {}
 			}
 			if left_sym.kind == .function {
-				g.write('_IN(u64, ')
+				g.write('_IN(voidptr, ')
 			} else {
-				styp := g.typ(g.table.mktyp(left_type))
+				elem_type := right_sym.array_info().elem_type
+				styp := g.typ(g.table.mktyp(elem_type))
 				g.write('_IN($styp, ')
 			}
 			g.expr(node.left)

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -242,17 +242,17 @@ void* g_live_info = NULL;
 #define _IN_MAP(val, m) map_exists(m, val)
 
 // these macros have corresponding implementations in builtin/int.v with different signedness
-#define array_i8_contains(a, b) array_byte_contains((array_byte)(a), (byte)(b))
-#define array_i16_contains(a, b) array_u16_contains((array_u16)(a), (u16)(b))
-#define array_u32_contains(a, b) array_int_contains((array_int)(a), (int)(b))
-#define array_i64_contains(a, b) array_u64_contains((array_u64)(a), (u64)(b))
-#define array_rune_contains(a, b) array_int_contains((array_int)(a), (int)(b))
-#define array_f32_contains(a, b) array_int_contains((array_int)(a), *(int*)&((f32[]){(b)}))
-#define array_f64_contains(a, b) array_u64_contains((array_u64)(a), *(u64*)&((f64[]){(b)}))
+#define array_i8_contains(a, b) array_byte_contains(a, (byte)(b))
+#define array_i16_contains(a, b) array_u16_contains(a, (u16)(b))
+#define array_u32_contains(a, b) array_int_contains(a, (int)(b))
+#define array_i64_contains(a, b) array_u64_contains(a, (u64)(b))
+#define array_rune_contains(a, b) array_int_contains(a, (int)(b))
+#define array_f32_contains(a, b) array_int_contains(a, *(int*)&((f32[]){(b)}))
+#define array_f64_contains(a, b) array_u64_contains(a, *(u64*)&((f64[]){(b)}))
 #ifdef TARGET_IS_64BIT
-#define array_voidptr_contains(a, b) array_u64_contains((array_u64)(a), (u64)(b))
+#define array_voidptr_contains(a, b) array_u64_contains(a, (u64)(b))
 #else
-#define array_voidptr_contains(a, b) array_int_contains((array_int)(a), (int)(b))
+#define array_voidptr_contains(a, b) array_int_contains(a, (int)(b))
 #endif
 
 // unsigned/signed comparisons

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -246,8 +246,8 @@ void* g_live_info = NULL;
 #define array_i16_contains(a, b) array_u16_contains((array_u16)(a), (u16)(b))
 #define array_u32_contains(a, b) array_int_contains((array_int)(a), (int)(b))
 #define array_i64_contains(a, b) array_u64_contains((array_u64)(a), (u64)(b))
-#define array_f32_contains(a, b) array_int_contains((array_int)(a), (int)(b))
-#define array_f64_contains(a, b) array_u64_contains((array_u64)(a), (u64)(b))
+#define array_f32_contains(a, b) array_int_contains((array_int)(a), *(int*)&((f32[]){(b)}))
+#define array_f64_contains(a, b) array_u64_contains((array_u64)(a), *(u64*)&((f64[]){(b)}))
 
 // unsigned/signed comparisons
 static inline bool _us32_gt(uint32_t a, int32_t b) { return a > INT32_MAX || (int32_t)a > b; }

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -246,8 +246,14 @@ void* g_live_info = NULL;
 #define array_i16_contains(a, b) array_u16_contains((array_u16)(a), (u16)(b))
 #define array_u32_contains(a, b) array_int_contains((array_int)(a), (int)(b))
 #define array_i64_contains(a, b) array_u64_contains((array_u64)(a), (u64)(b))
+#define array_rune_contains(a, b) array_int_contains((array_int)(a), (int)(b))
 #define array_f32_contains(a, b) array_int_contains((array_int)(a), *(int*)&((f32[]){(b)}))
 #define array_f64_contains(a, b) array_u64_contains((array_u64)(a), *(u64*)&((f64[]){(b)}))
+#ifdef TARGET_IS_64BIT
+#define array_voidptr_contains(a, b) array_u64_contains((array_u64)(a), (u64)(b))
+#else
+#define array_voidptr_contains(a, b) array_int_contains((array_int)(a), (int)(b))
+#endif
 
 // unsigned/signed comparisons
 static inline bool _us32_gt(uint32_t a, int32_t b) { return a > INT32_MAX || (int32_t)a > b; }

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -241,6 +241,14 @@ void* g_live_info = NULL;
 #define _IN(typ, val, arr) array_##typ##_contains(arr, val)
 #define _IN_MAP(val, m) map_exists(m, val)
 
+// these macros have corresponding implementations in builtin/int.v with different signedness
+#define array_i8_contains(a, b) array_byte_contains((array_byte)(a), (byte)(b))
+#define array_i16_contains(a, b) array_u16_contains((array_u16)(a), (u16)(b))
+#define array_u32_contains(a, b) array_int_contains((array_int)(a), (int)(b))
+#define array_i64_contains(a, b) array_u64_contains((array_u64)(a), (u64)(b))
+#define array_f32_contains(a, b) array_int_contains((array_int)(a), (int)(b))
+#define array_f64_contains(a, b) array_u64_contains((array_u64)(a), (u64)(b))
+
 // unsigned/signed comparisons
 static inline bool _us32_gt(uint32_t a, int32_t b) { return a > INT32_MAX || (int32_t)a > b; }
 static inline bool _us32_ge(uint32_t a, int32_t b) { return a >= INT32_MAX || (int32_t)a >= b; }

--- a/vlib/v/tests/in_expression_test.v
+++ b/vlib/v/tests/in_expression_test.v
@@ -219,3 +219,36 @@ fn test_in_array_init() {
 	assert 1 !in []int{}
 	assert [1] in [[1], [2]]
 }
+
+fn test_in_expression_numeric() {
+	b := [byte(2), 4, 7]
+	b2 := [i8(3), -4, 9]
+	s := [u16(6), 1, 0]
+	s2 := [i16(34), -17, 45]
+	i := [5, 7, 9]
+	i2 := [u32(65), 12, 9]
+	l := [u64(54), 23, 1]
+	l2 := [i64(-45), 8, 2]
+	f := [f32(12.5), 0, -17.25]
+	f2 := [1.0625, 3, 17.125]
+	assert byte(4) in b
+	assert byte(3) !in b
+	assert i8(-4) in b2
+	assert i8(5) !in b2
+	assert u16(1) in s
+	assert u16(3) !in s
+	assert i16(45) in s2
+	assert i16(0) !in s2
+	assert 7 in i
+	assert 8 !in i
+	assert u32(12) in i2
+	assert u32(13) !in i2
+	assert u64(1) in l
+	assert u64(2) !in l
+	assert i64(-45) in l2
+	assert i64(-17) !in l2
+	assert f32(-17.25) in f
+	assert f32(1) !in f
+	assert 1.0625 in f2
+	assert 3.5 !in f2
+}

--- a/vlib/v/tests/in_expression_test.v
+++ b/vlib/v/tests/in_expression_test.v
@@ -232,22 +232,22 @@ fn test_in_expression_numeric() {
 	f := [f32(12.5), 0, -17.25]
 	f2 := [1.0625, 3, 17.125]
 	assert byte(4) in b
-	assert byte(3) !in b
-	assert i8(-4) in b2
+	assert 3 !in b
+	assert -4 in b2
 	assert i8(5) !in b2
-	assert u16(1) in s
+	assert 1 in s
 	assert u16(3) !in s
-	assert i16(45) in s2
+	assert 45 in s2
 	assert i16(0) !in s2
 	assert 7 in i
 	assert 8 !in i
-	assert u32(12) in i2
+	assert 12 in i2
 	assert u32(13) !in i2
 	assert u64(1) in l
-	assert u64(2) !in l
-	assert i64(-45) in l2
+	assert 2 !in l
+	assert -45 in l2
 	assert i64(-17) !in l2
-	assert f32(-17.25) in f
+	assert -17.25 in f
 	assert f32(1) !in f
 	assert 1.0625 in f2
 	assert 3.5 !in f2


### PR DESCRIPTION
This PR makes `in` available for all types of numeric arrays and fixes some little issues:
- C macros are defined that use existing implementations for element types of the same data size (so code doubling in the executable is avoided)
- The decision which implementation to use is now based on the array element type (and not the type of the element to test)
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
