### PR TITLE
szip: make compile

### DIFF
--- a/thirdparty/zip/miniz.h
+++ b/thirdparty/zip/miniz.h
@@ -2194,7 +2194,8 @@ tinfl_status tinfl_decompress(tinfl_decompressor *r,
             } else
               tree_cur = pTable->m_tree[-tree_cur - 1];
           }
-          tree_cur -= ((rev_code >>= 1) & 1);
+          rev_code >>= 1;
+          tree_cur -= (rev_code & 1);
           pTable->m_tree[-tree_cur - 1] = (mz_int16)sym_index;
         }
         if (r->m_type == 2) {
@@ -6142,7 +6143,7 @@ mz_bool mz_zip_writer_add_mem_ex(mz_zip_archive *pZip,
   if (!mz_zip_writer_validate_archive_name(pArchive_name))
     return MZ_FALSE;
 
-#ifndef MINIZ_NO_TIME
+#if !defined(MINIZ_NO_TIME) && !defined(MINIZ_NO_ARCHIVE_WRITING_APIS)
   {
     time_t cur_time;
     time(&cur_time);
@@ -6327,9 +6328,13 @@ mz_bool mz_zip_writer_add_file(mz_zip_archive *pZip, const char *pArchive_name,
     return MZ_FALSE;
 
   memset(&file_modified_time, 0, sizeof(file_modified_time));
+#if !defined(MINIZ_NO_TIME) && !defined(MINIZ_NO_ARCHIVE_WRITING_APIS)
+#ifndef MINIZ_NO_STDIO
   if (!mz_zip_get_file_modified_time(pSrc_filename, &file_modified_time))
     return MZ_FALSE;
+#endif
   mz_zip_time_t_to_dos_time(file_modified_time, &dos_time, &dos_date);
+#endif
 
   pSrc_file = MZ_FOPEN(pSrc_filename, "rb");
   if (!pSrc_file)

--- a/thirdparty/zip/zip.h
+++ b/thirdparty/zip/zip.h
@@ -20,8 +20,9 @@ extern "C" {
 #endif
 
 #if !defined(_SSIZE_T_DEFINED) && !defined(_SSIZE_T_DEFINED_) &&               \
-    !defined(_SSIZE_T) && !defined(_SSIZE_T_) && !defined(__ssize_t_defined)
-#define _SSIZE_T
+    !defined(__DEFINED_ssize_t) && !defined(__ssize_t_defined) &&              \
+    !defined(_SSIZE_T) && !defined(_SSIZE_T_) && !defined(_SSIZE_T_DECLARED)
+
 // 64-bit Windows is the only mainstream platform
 // where sizeof(long) != sizeof(void*)
 #ifdef _WIN64
@@ -29,6 +30,15 @@ typedef long long ssize_t; /* byte count or error */
 #else
 typedef long ssize_t; /* byte count or error */
 #endif
+
+#define _SSIZE_T_DEFINED
+#define _SSIZE_T_DEFINED_
+#define __DEFINED_ssize_t
+#define __ssize_t_defined
+#define _SSIZE_T
+#define _SSIZE_T_
+#define _SSIZE_T_DECLARED
+
 #endif
 
 #ifndef MAX_PATH
@@ -80,6 +90,16 @@ extern struct zip_t *zip_open(const char *zipname, int level, char mode);
  * @param zip zip archive handler.
  */
 extern void zip_close(struct zip_t *zip);
+
+/**
+ * Determines if the archive has a zip64 end of central directory headers.
+ *
+ * @param zip zip archive handler.
+ *
+ * @return the return code - 1 (true), 0 (false), negative number (< 0) on
+ *         error.
+ */
+extern int zip_is64(struct zip_t *zip);
 
 /**
  * Opens an entry by name in the zip archive.
@@ -293,6 +313,27 @@ extern int zip_extract(const char *zipname, const char *dir,
                        int (*on_extract_entry)(const char *filename, void *arg),
                        void *arg);
 
+/**
+ * Extracts a zip archive stream into directory.
+ *
+ * If on_extract is not NULL, the callback will be called after
+ * successfully extracted each zip entry.
+ * Returning a negative value from the callback will cause abort and return an
+ * error. The last argument (void *arg) is optional, which you can use to pass
+ * data to the on_extract callback.
+ *
+ * @param stream zip archive stream.
+ * @param size stream size.
+ * @param dir output directory.
+ * @param on_extract on extract callback.
+ * @param arg opaque pointer.
+ *
+ * @return the return code - 0 on success, negative number (< 0) on error.
+ */
+extern int zip_extract_stream(const char *stream, size_t size, const char *dir,
+                              int (*on_extract)(const char *filename,
+                                                void *arg),
+                              void *arg);
 /** @} */
 
 #ifdef __cplusplus

--- a/vlib/szip/szip.v
+++ b/vlib/szip/szip.v
@@ -1,32 +1,42 @@
 module szip
 
 #flag -I @VROOT/thirdparty/zip
-
 #include "zip.c"
 #include "zip.h"
 
-type zip      C.zip_t
-type zip_ptr &zip
+struct C.zip_t {}
+
+type Zip C.zip_t
+
+fn C.zip_open(byteptr, int, byte) &Zip
+fn C.zip_close(&Zip)
+fn C.zip_entry_open(&Zip, byteptr) int
+fn C.zip_entry_close(&Zip) int
+fn C.zip_entry_name(&Zip) byteptr
+fn C.zip_entry_index(&Zip) int
+fn C.zip_entry_isdir(&Zip) int
+fn C.zip_entry_size(&Zip) u64
+fn C.zip_entry_crc32(&Zip) u32
+fn C.zip_entry_write(&Zip, voidptr, int) int
+fn C.zip_entry_fwrite(&Zip, byteptr) int
+fn C.zip_entry_read(&Zip, byteptr, int) int
+fn C.zip_entry_fread(&Zip, byteptr) int
+fn C.zip_total_entries(&Zip) int
 
 // Ref - miniz.h
 const (
-    no_compression      = 0
-    best_speed          = 1
-    best_compression    = 9
-    uber_compression    = 10
-    default_level       = 6
-    default_compression = -1
-)
-
-// Ref - zip.h
-const (
-    default_compression_level = (default_level)
+	no_compression      = 0
+	best_speed          = 1
+	best_compression    = 9
+	uber_compression    = 10
+	default_level       = 6
+	default_compression = -1
 )
 
 const (
-    m_write  = 'w'
-    m_ronly  = 'r'
-    m_append = 'a'
+	m_write  = `w`
+	m_ronly  = `r`
+	m_append = `a`
 )
 
 /*
@@ -40,34 +50,32 @@ open opens zip archive with compression level using the given mode.
         - 'a': appends to an existing archive.
 
 @return the zip archive handler or NULL on error
- */
-pub fn open(name string, level int, mode string) ?zip_ptr {
-    mut _nlevel := level
-    if (_nlevel & 0xF) > uber_compression {
-        _nlevel = default_compression_level
-    }
-    n := name.len
-    if n == 0 {
-        return error('szip: name of file empty')
-    }
-    if mode != m_write && mode != m_ronly && mode != m_append {
-        return error('szip: invalid provided open mode')
-    }
-    /* struct zip_t* */_p_zip := zip_ptr(C.zip_open(name.str,
-                                 _nlevel, mode.str))
-    if _p_zip == zip_ptr(0) {
-        return error('szip: cannot open/create/append new zip archive')
-    }
-    return _p_zip
+*/
+pub fn open(name string, level int, mode byte) ?&Zip {
+	mut nlevel := level
+	if (nlevel & 0xF) > uber_compression {
+		nlevel = default_level
+	}
+	if name.len == 0 {
+		return error('szip: name of file empty')
+	}
+	if mode !in [m_write, m_ronly, m_append] {
+		return error('szip: invalid provided open mode')
+	}
+	p_zip := &Zip(C.zip_open(name.str, nlevel, mode))
+	if isnil(p_zip) {
+		return error('szip: cannot open/create/append new zip archive')
+	}
+	return p_zip
 }
 
 /*
 close closes the zip archive, releases resources - always finalize.
 
 @param zip zip archive handler.
- */
-pub fn (mut z zip_ptr) close() {
-    C.zip_close(z)
+*/
+pub fn (mut z Zip) close() {
+	C.zip_close(z)
 }
 
 /*
@@ -81,21 +89,23 @@ in global dictionary.
 @param entryname an entry name in local dictionary.
 
 @return the return code - 0 on success, negative number (< 0) on error.
- */
-pub fn (mut zentry zip_ptr) open_entry(name string) /*?*/bool {
-    res := C.zip_entry_open(zentry, name.str)
-    return res != -1
+*/
+pub fn (mut zentry Zip) open_entry(name string) ? {
+	res := C.zip_entry_open(zentry, name.str)
+	if res == -1 {
+		return error('szip: cannot open archive entry')
+	}
 }
 
 /*
- * close_entry closes a zip entry, flushes buffer and releases resources.
+* close_entry closes a zip entry, flushes buffer and releases resources.
  *
  * @param zip zip archive handler.
  *
  * @return the return code - 0 on success, negative number (< 0) on error.
- */
-pub fn (mut zentry zip_ptr) close_entry() {
-    C.zip_entry_close(zentry)
+*/
+pub fn (mut zentry Zip) close_entry() {
+	C.zip_entry_close(zentry)
 }
 
 /*
@@ -111,13 +121,13 @@ for compatibility with Amiga and UNIX file systems etc.
 @param zip: zip archive handler.
 
 @return the pointer to the current zip entry name, or NULL on error.
- */
-pub fn (mut zentry zip_ptr) name() string {
-    _name := C.zip_entry_name(zentry)
-    if _name == 0 {
-        return ''
-    }
-    return tos_clone(_name)
+*/
+pub fn (mut zentry Zip) name() string {
+	name := C.zip_entry_name(zentry)
+	if name == 0 {
+		return ''
+	}
+	return tos_clone(name)
 }
 
 /*
@@ -126,13 +136,13 @@ index returns an index of the current zip entry.
 @param zip zip archive handler.
 
 @return the index on success, negative number (< 0) on error.
- */
-pub fn (mut zentry zip_ptr) index() ?int {
-    _index := int(C.zip_entry_index(zentry))
-    if _index == -1 {
-        return error('szip: cannot get current index of zip entry')
-    }
-    return _index // must be check for INVALID_VALUE
+*/
+pub fn (mut zentry Zip) index() ?int {
+	index := int(C.zip_entry_index(zentry))
+	if index == -1 {
+		return error('szip: cannot get current index of zip entry')
+	}
+	return index // must be check for INVALID_VALUE
 }
 
 /*
@@ -142,14 +152,13 @@ isdir determines if the current zip entry is a directory entry.
 
 @return the return code - 1 (true), 0 (false), negative number (< 0) on
          error.
- */
-pub fn (mut zentry zip_ptr) isdir() ?bool {
-    _isdir := C.zip_entry_isdir(zentry)
-    if _isdir == -1 {
-        return error('szip: cannot check entry type')
-    }
-    dir := bool(_isdir) // wtf V , unary lvalue
-    return dir
+*/
+pub fn (mut zentry Zip) isdir() ?bool {
+	isdir := C.zip_entry_isdir(zentry)
+	if isdir < 0 {
+		return error('szip: cannot check entry type')
+	}
+	return isdir == 1
 }
 
 /*
@@ -158,10 +167,9 @@ size returns an uncompressed size of the current zip entry.
 @param zip zip archive handler.
 
 @return the uncompressed size in bytes.
- */
-pub fn (mut zentry zip_ptr) size() i64 {
-    _size := i64(C.zip_entry_size(zentry))
-    return _size
+*/
+pub fn (mut zentry Zip) size() u64 {
+	return C.zip_entry_size(zentry)
 }
 
 /*
@@ -170,28 +178,29 @@ crc32 returns CRC-32 checksum of the current zip entry.
 @param zip zip archive handler.
 
 @return the CRC-32 checksum.
- */
-pub fn (mut zentry zip_ptr) crc32() u32 {
-    _checksum := u32(C.zip_entry_crc32(zentry))
-    return _checksum // 0
+*/
+pub fn (mut zentry Zip) crc32() u32 {
+	return C.zip_entry_crc32(zentry)
 }
 
 /*
- write_entry compresses an input buffer for the current zip entry.
+write_entry compresses an input buffer for the current zip entry.
 
 @param zip zip archive handler.
 @param buf input buffer.
 @param bufsize input buffer size (in bytes).
 
 @return the return code - 0 on success, negative number (< 0) on error.
- */
-pub fn (mut zentry zip_ptr) write_entry(data []byte) bool {
-    if (data[0] & 0xff) == -1 {
-        return false
-    }
-    buf := data // alias of data
-    res := C.zip_entry_write(zentry, buf.data, buf.len)
-    return res == 0
+*/
+pub fn (mut zentry Zip) write_entry(data []byte) ? {
+	if (data[0] & 0xff) == -1 {
+		return error('szip: cannot write entry')
+	}
+	buf := data // alias of data
+	res := C.zip_entry_write(zentry, buf.data, buf.len)
+	if res != 0 {
+		return error('szip: failed to write entry')
+	}
 }
 
 /*
@@ -201,10 +210,12 @@ create_entry compresses a file for the current zip entry.
 @param filename input file.
 
 @return the return code - 0 on success, negative number (< 0) on error.
- */
-pub fn (mut zentry zip_ptr) create_entry(name string) bool {
-    res := C.zip_entry_fwrite(zentry, name.str)
-    return res == 0
+*/
+pub fn (mut zentry Zip) create_entry(name string) ? {
+	res := C.zip_entry_fwrite(zentry, name.str)
+	if res != 0 {
+		return error('szip: failed to create entry')
+	}
 }
 
 /*
@@ -221,15 +232,15 @@ for large entries, please take a look at zip_entry_extract function.
 
 @return the return code - the number of bytes actually read on success.
          Otherwise a -1 on error.
- */
-pub fn (mut zentry zip_ptr) read_entry() ?voidptr {
-    mut _buf := voidptr(0)
-    mut _bsize := i64(0)
-    res := C.zip_entry_read(zentry, &_buf, &_bsize)
-    if res == -1 {
-        return error('szip: cannot read properly data from entry')
-    }
-    return _buf
+*/
+pub fn (mut zentry Zip) read_entry() ?voidptr {
+	mut buf := voidptr(0)
+	mut bsize := i64(0)
+	res := C.zip_entry_read(zentry, &buf, &bsize)
+	if res == -1 {
+		return error('szip: cannot read properly data from entry')
+	}
+	return buf
 }
 
 /*
@@ -239,14 +250,15 @@ extract_entry extracts the current zip entry into output file.
 @param filename output file.
 
 @return the return code - 0 on success, negative number (< 0) on error.
- */
-pub fn (mut zentry zip_ptr) extract_entry(path string) /*?*/bool {
-    if C.access(charptr(path.str), 0) == -1 {
-        return false
-        //return error('Cannot open file for extracting, file not exists')
-    }
-    res := C.zip_entry_fread(zentry, path.str)
-    return res == 0
+*/
+pub fn (mut zentry Zip) extract_entry(path string) ? {
+	if C.access(charptr(path.str), 0) == -1 {
+		return error('Cannot open file for extracting, file not exists')
+	}
+	res := C.zip_entry_fread(zentry, path.str)
+	if res != 0 {
+		return error('szip: failed to extract entry')
+	}
 }
 
 /*
@@ -258,16 +270,17 @@ extract extracts the current zip entry using a callback function (on_extract).
         on_extract callback)
 
 @return the return code - 0 on success, negative number (< 0) on error.
- */
-/*fn (mut zentry zip_ptr) extract(path string) bool {
+*/
+/*
+fn (mut zentry Zip) extract(path string) bool {
     if C.access(path.str, 0) == -1 {
         return false
         //return error('Cannot open directory for extracting, directory not exists')
     }
     res := C.zip_extract(zentry, path.str, 0, 0)
     return res == 0
-}*/
-
+}
+*/
 /*
 total returns the number of all entries (files and directories) in the zip archive.
 
@@ -275,11 +288,11 @@ total returns the number of all entries (files and directories) in the zip archi
 
 @return the return code - the number of entries on success, negative number
          (< 0) on error.
- */
-pub fn (mut zentry zip_ptr) total() ?int {
-    _tentry := int(C.zip_total_entries(zentry))
-    if _tentry == -1 {
-        return error('szip: cannot count total entries')
-    }
-    return _tentry
+*/
+pub fn (mut zentry Zip) total() ?int {
+	tentry := int(C.zip_total_entries(zentry))
+	if tentry == -1 {
+		return error('szip: cannot count total entries')
+	}
+	return tentry
 }

--- a/vlib/szip/szip_test.v
+++ b/vlib/szip/szip_test.v
@@ -1,0 +1,9 @@
+import szip
+import os
+
+fn test_compile() {
+	szip.open('test_compile.zip', szip.best_speed, szip.m_write) or {
+		assert false
+	}
+	os.rm('test_compile.zip') or { }
+}


### PR DESCRIPTION
Make the `szip` module compile with latest V. Adds one test to ensure that it will be updated later if necessary.
I updated the _zip_ library to the latest version available, and had to tweak some things to make it work with TCC.