### PR TITLE
checker: simplify argument qualifier errors

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -242,7 +242,7 @@ pub struct FnDecl {
 pub:
 	name          string
 	mod           string
-	args          []table.Arg
+	args          []table.Arg // parameters
 	is_deprecated bool
 	is_pub        bool
 	is_variadic   bool

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1331,31 +1331,15 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 		if call_arg.is_mut {
 			c.fail_if_immutable(call_arg.expr)
 			if !arg.is_mut {
-				mut words := 'mutable'
-				mut tok := 'mut'
-				if call_arg.share == .shared_t {
-					words = 'shared'
-					tok = 'shared'
-				} else if call_arg.share == .atomic_t {
-					words = 'atomic'
-					tok = 'atomic'
-				}
-				c.error('`$arg.name` argument is not $words, `$tok` is not needed`', call_arg.expr.position())
+				tok := call_arg.share.str()
+				c.error('`$call_expr.name` parameter `$arg.name` is not `$tok`, `$tok` is not needed`', call_arg.expr.position())
 			} else if arg.typ.share() != call_arg.share {
 				c.error('wrong shared type', call_arg.expr.position())
 			}
 		} else {
 			if arg.is_mut && (!call_arg.is_mut || arg.typ.share() != call_arg.share) {
-				mut words := ' mutable'
-				mut tok := 'mut'
-				if arg.typ.share() == .shared_t {
-					words = ' shared'
-					tok = 'shared'
-				} else if arg.typ.share() == .atomic_t {
-					words = 'n atomic'
-					tok = 'atomic'
-				}
-				c.error('`$arg.name` is a$words argument, you need to provide `$tok`: `${call_expr.name}($tok ...)`',
+				tok := call_arg.share.str()
+				c.error('`$call_expr.name` parameter `$arg.name` is `$tok`, you need to provide `$tok` e.g. `$tok arg${i+1}`',
 					call_arg.expr.position())
 			}
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1332,7 +1332,8 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 			c.fail_if_immutable(call_arg.expr)
 			if !arg.is_mut {
 				tok := call_arg.share.str()
-				c.error('`$call_expr.name` parameter `$arg.name` is not `$tok`, `$tok` is not needed`', call_arg.expr.position())
+				c.error('`$call_expr.name` parameter `$arg.name` is not `$tok`, `$tok` is not needed`',
+					call_arg.expr.position())
 			} else if arg.typ.share() != call_arg.share {
 				c.error('wrong shared type', call_arg.expr.position())
 			}

--- a/vlib/v/checker/tests/mut_arg.out
+++ b/vlib/v/checker/tests/mut_arg.out
@@ -1,0 +1,25 @@
+vlib/v/checker/tests/mut_arg.vv:6:3: error: `f` parameter `par` is `mut`, you need to provide `mut` e.g. `mut arg1`
+    4 | }
+    5 |
+    6 | f([3,4])
+      |   ~~~~~
+    7 | mut a := [1,2]
+    8 | f(a)
+vlib/v/checker/tests/mut_arg.vv:8:3: error: `f` parameter `par` is `mut`, you need to provide `mut` e.g. `mut arg1`
+    6 | f([3,4])
+    7 | mut a := [1,2]
+    8 | f(a)
+      |   ^
+    9 |
+   10 | g(mut [3,4])
+vlib/v/checker/tests/mut_arg.vv:10:7: error: `g` parameter `par` is not `mut`, `mut` is not needed`
+    8 | f(a)
+    9 |
+   10 | g(mut [3,4])
+      |       ~~~~~
+   11 | g(mut a)
+vlib/v/checker/tests/mut_arg.vv:11:7: error: `g` parameter `par` is not `mut`, `mut` is not needed`
+    9 |
+   10 | g(mut [3,4])
+   11 | g(mut a)
+      |       ^

--- a/vlib/v/checker/tests/mut_arg.vv
+++ b/vlib/v/checker/tests/mut_arg.vv
@@ -1,0 +1,11 @@
+fn f(mut par []int) {
+}
+fn g(par []int) {
+}
+
+f([3,4])
+mut a := [1,2]
+f(a)
+
+g(mut [3,4])
+g(mut a)

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -22,7 +22,7 @@ pub mut:
 
 pub struct Fn {
 pub:
-	args                    []Arg
+	args                    []Arg // parameters
 	return_type             Type
 	return_type_source_name string
 	is_variadic             bool
@@ -39,6 +39,7 @@ pub mut:
 	name                    string
 }
 
+// parameter
 pub struct Arg {
 pub:
 	pos              token.Position


### PR DESCRIPTION
Tweak error messages.
Use 'parameter' in messages instead of 'argument' for function parameter.
Add test for `mut` at call site.
