### PR TITLE
gen: fix multiple call of expression in match

### DIFF
--- a/cmd/tools/vbuild-examples.v
+++ b/cmd/tools/vbuild-examples.v
@@ -7,13 +7,10 @@ fn main() {
 	args := os.args
 	args_string := args[1..].join(' ')
 	params := args_string.all_before('build-examples')
-
-	if testing.v_build_failing(params, 'examples'){
+	if testing.v_build_failing(params, 'examples') {
 		exit(1)
 	}
-
-	if testing.v_build_failing(params + '-live', os.join_path( 'examples', 'hot_reload')){
+	if testing.v_build_failing(params + '-live', os.join_path('examples', 'hot_reload')) {
 		exit(1)
 	}
-
 }

--- a/examples/2048/2048.v
+++ b/examples/2048/2048.v
@@ -94,7 +94,7 @@ fn new_board(sb []string) Board {
 	mut b := Board{}
 	for y := 0; y < 4; y++ {
 		for x := 0; x < 4; x++ {
-		b.field[y][x] = sb[y][x] - 64
+			b.field[y][x] = sb[y][x] - 64
 		}
 	}
 	return b
@@ -180,7 +180,9 @@ fn (t TileLine) to_left() TileLine {
 fn (b Board) to_left() Board {
 	mut res := b
 	for y := 0; y < 4; y++ {
-		mut hline := TileLine{ypos: y}
+		mut hline := TileLine{
+			ypos: y
+		}
 		for x := 0; x < 4; x++ {
 			hline.field[x] = b.field[y][x]
 		}
@@ -264,8 +266,8 @@ fn (app &App) draw() {
 
 fn (app &App) draw_background() {
 	tw, th := 128, 128
-	for y := 30; y <= window_height; y+=tw {
-		for x := 0; x <= window_width; x+=th {
+	for y := 30; y <= window_height; y += tw {
+		for x := 0; x <= window_width; x += th {
 			app.gg.draw_image(x, y, tw, th, app.tiles[0].image)
 		}
 	}
@@ -379,7 +381,8 @@ fn (mut app App) game_over() {
 	app.state = .over
 }
 
-type BoardMoveFN fn(b Board) Board
+type BoardMoveFN = fn (b Board) Board
+
 fn (mut app App) move(move_fn BoardMoveFN) {
 	old := app.board
 	new := move_fn(old)
@@ -400,7 +403,7 @@ fn (mut app App) on_key_down(key sapp.KeyCode) {
 		.n {
 			app.new_game()
 		}
-		//.t {/* fast setup for a victory situation: */ app.board = new_board(['JJ@@', '@@@@', '@@@@', '@@@@'])}
+		// .t {/* fast setup for a victory situation: */ app.board = new_board(['JJ@@', '@@@@', '@@@@', '@@@@'])}
 		.backspace {
 			if app.undo.len > 0 {
 				app.state = .play

--- a/examples/sokol/particles/particles.v
+++ b/examples/sokol/particles/particles.v
@@ -36,7 +36,10 @@ mut:
 fn (mut a App) init() {
 	a.frame = 0
 	a.last = time.ticks()
-	a.ps = particle.System{width: a.width, height: a.height}
+	a.ps = particle.System{
+		width: a.width
+		height: a.height
+	}
 	a.ps.init(particle.SystemConfig{
 		pool: 20000
 	})
@@ -59,7 +62,6 @@ fn (mut a App) run() {
 		html5_canvas_name: title.str
 		cleanup_userdata_cb: cleanup
 	}
-
 	sapp.run(&desc)
 }
 
@@ -119,13 +121,10 @@ fn event(ev &C.sapp_event, user_data voidptr) {
 			}
 		}
 	}
-
 	if ev.@type == .touches_began || ev.@type == .touches_moved {
 		if ev.num_touches > 0 {
-
 			touch_point := ev.touches[0]
 			app.ps.explode(touch_point.pos_x, touch_point.pos_y)
-
 		}
 	}
 }

--- a/examples/vweb/vweb_assets/vweb_assets.v
+++ b/examples/vweb/vweb_assets/vweb_assets.v
@@ -24,21 +24,20 @@ pub fn (mut app App) init_once() {
 	app.vweb.handle_static('assets')
 	// This would make available all known static mime types from current
 	// directory and below.
-	//app.vweb.handle_static('.')
+	// app.vweb.handle_static('.')
 }
 
-pub fn (mut app App) init() {}
+pub fn (mut app App) init() {
+}
 
 pub fn (mut app App) index() {
 	// We can dynamically specify which assets are to be used in template.
 	mut am := assets.new_manager()
 	am.add_css('assets/index.css')
-
 	css := am.include_css(false)
 	title := 'VWeb Assets Example'
 	subtitle := 'VWeb can serve static assets too!'
 	message := 'It also has an Assets Manager that allows dynamically specifying which CSS and JS files to be used.'
-
 	$vweb.html()
 }
 

--- a/vlib/v/tests/match_test.v
+++ b/vlib/v/tests/match_test.v
@@ -118,6 +118,28 @@ fn test_match_enums() {
 	assert b == .blue
 }
 
+struct Counter {
+mut:
+	val int
+}
+
+fn (mut c Counter) next() int {
+	c.val++
+	return c.val
+}
+
+fn test_method_call() {
+	mut c := Counter{
+		val: 1
+	}
+	assert match c.next() {
+		1 { false }
+		2 { true }
+		3 { false }
+		else { false }
+	}
+}
+
 type Sum = A1 | B1
 
 struct A1 {


### PR DESCRIPTION
Fixes #6261

I had to rename the examples that had the same name (`main.v`), because the tests randomly failed (are the test run concurrently ?).
That's not a bad thing in my opinion, as it fits more with the convention saying "the main file of a module is named after the module", but it may be worth investigating.