### PR TITLE
checker: modify error messages for ptrs

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -580,23 +580,23 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 				if left.has_method(infix_expr.op.str()) {
 					return_type = left_type
 				} else {
-					left_name := if left_type.is_ptr() { '`&$left.name`' } else { '`$left.name`' }
-					right_name := if right_type.is_ptr() { '`&$right.name`' } else { '`$right.name`' }
+					left_name := c.table.type_to_str(left_type)
+					right_name := c.table.type_to_str(right_type)
 					c.error('mismatched types $left_name and $right_name', left_pos)
 				}
 			} else if right.kind in [.array, .array_fixed, .map, .struct_] {
 				if right.has_method(infix_expr.op.str()) {
 					return_type = right_type
 				} else {
-					left_name := if left_type.is_ptr() { '`&$left.name`' } else { '`$left.name`' }
-					right_name := if right_type.is_ptr() { '`&$right.name`' } else { '`$right.name`' }
+					left_name := c.table.type_to_str(left_type)
+					right_name := c.table.type_to_str(right_type)
 					c.error('mismatched types $left_name and $right_name', right_pos)
 				}
 			} else {
 				promoted_type := c.promote(c.table.unalias_num_type(left_type), c.table.unalias_num_type(right_type))
 				if promoted_type.idx() == table.void_type_idx {
-					left_name := if left_type.is_ptr() { '`&$left.name`' } else { '`$left.name`' }
-					right_name := if right_type.is_ptr() { '`&$right.name`' } else { '`$right.name`' }
+					left_name := c.table.type_to_str(left_type)
+					right_name := c.table.type_to_str(right_type)
 					c.error('mismatched types $left_name and $right_name', infix_expr.pos)
 				} else if promoted_type.is_float() {
 					if infix_expr.op in [.mod, .xor, .amp, .pipe] {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -582,7 +582,7 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 				} else {
 					left_name := c.table.type_to_str(left_type)
 					right_name := c.table.type_to_str(right_type)
-					c.error('mismatched types $left_name and $right_name', left_pos)
+					c.error('mismatched types `$left_name` and `$right_name`', left_pos)
 				}
 			} else if right.kind in [.array, .array_fixed, .map, .struct_] {
 				if right.has_method(infix_expr.op.str()) {
@@ -590,14 +590,14 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 				} else {
 					left_name := c.table.type_to_str(left_type)
 					right_name := c.table.type_to_str(right_type)
-					c.error('mismatched types $left_name and $right_name', right_pos)
+					c.error('mismatched types `$left_name` and `$right_name`', right_pos)
 				}
 			} else {
 				promoted_type := c.promote(c.table.unalias_num_type(left_type), c.table.unalias_num_type(right_type))
 				if promoted_type.idx() == table.void_type_idx {
 					left_name := c.table.type_to_str(left_type)
 					right_name := c.table.type_to_str(right_type)
-					c.error('mismatched types $left_name and $right_name', infix_expr.pos)
+					c.error('mismatched types `$left_name` and `$right_name`', infix_expr.pos)
 				} else if promoted_type.is_float() {
 					if infix_expr.op in [.mod, .xor, .amp, .pipe] {
 						side := if left_type == promoted_type { 'left' } else { 'right' }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -580,23 +580,23 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 				if left.has_method(infix_expr.op.str()) {
 					return_type = left_type
 				} else {
-					left_name := if left_type.is_ptr() {'`*${left.name}`'} else { '`$left.name`' }
-					right_name := if right_type.is_ptr() {'`*${right.name}`'} else { '`$right.name`' }
+					left_name := if left_type.is_ptr() { '`*$left.name`' } else { '`$left.name`' }
+					right_name := if right_type.is_ptr() { '`*$right.name`' } else { '`$right.name`' }
 					c.error('mismatched types $left_name and $right_name', left_pos)
 				}
 			} else if right.kind in [.array, .array_fixed, .map, .struct_] {
 				if right.has_method(infix_expr.op.str()) {
 					return_type = right_type
 				} else {
-					left_name := if left_type.is_ptr() {'`*${left.name}`'} else { '`$left.name`' }
-					right_name := if right_type.is_ptr() {'`*${right.name}`'} else { '`$right.name`' }
+					left_name := if left_type.is_ptr() { '`*$left.name`' } else { '`$left.name`' }
+					right_name := if right_type.is_ptr() { '`*$right.name`' } else { '`$right.name`' }
 					c.error('mismatched types $left_name and $right_name', right_pos)
 				}
 			} else {
 				promoted_type := c.promote(c.table.unalias_num_type(left_type), c.table.unalias_num_type(right_type))
 				if promoted_type.idx() == table.void_type_idx {
-					left_name := if left_type.is_ptr() {'`*${left.name}`'} else { '`$left.name`' }
-					right_name := if right_type.is_ptr() {'`*${right.name}`'} else { '`$right.name`' }
+					left_name := if left_type.is_ptr() { '`*$left.name`' } else { '`$left.name`' }
+					right_name := if right_type.is_ptr() { '`*$right.name`' } else { '`$right.name`' }
 					c.error('mismatched types $left_name and $right_name', infix_expr.pos)
 				} else if promoted_type.is_float() {
 					if infix_expr.op in [.mod, .xor, .amp, .pipe] {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -580,18 +580,24 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 				if left.has_method(infix_expr.op.str()) {
 					return_type = left_type
 				} else {
-					c.error('mismatched types `$left.name` and `$right.name`', left_pos)
+					left_name := if left_type.is_ptr() {'`*${left.name}`'} else { '`$left.name`' }
+					right_name := if right_type.is_ptr() {'`*${right.name}`'} else { '`$right.name`' }
+					c.error('mismatched types $left_name and $right_name', left_pos)
 				}
 			} else if right.kind in [.array, .array_fixed, .map, .struct_] {
 				if right.has_method(infix_expr.op.str()) {
 					return_type = right_type
 				} else {
-					c.error('mismatched types `$left.name` and `$right.name`', right_pos)
+					left_name := if left_type.is_ptr() {'`*${left.name}`'} else { '`$left.name`' }
+					right_name := if right_type.is_ptr() {'`*${right.name}`'} else { '`$right.name`' }
+					c.error('mismatched types $left_name and $right_name', right_pos)
 				}
 			} else {
 				promoted_type := c.promote(c.table.unalias_num_type(left_type), c.table.unalias_num_type(right_type))
 				if promoted_type.idx() == table.void_type_idx {
-					c.error('mismatched types `$left.name` and `$right.name`', infix_expr.pos)
+					left_name := if left_type.is_ptr() {'`*${left.name}`'} else { '`$left.name`' }
+					right_name := if right_type.is_ptr() {'`*${right.name}`'} else { '`$right.name`' }
+					c.error('mismatched types $left_name and $right_name', infix_expr.pos)
 				} else if promoted_type.is_float() {
 					if infix_expr.op in [.mod, .xor, .amp, .pipe] {
 						side := if left_type == promoted_type { 'left' } else { 'right' }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -580,23 +580,23 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 				if left.has_method(infix_expr.op.str()) {
 					return_type = left_type
 				} else {
-					left_name := if left_type.is_ptr() { '`*$left.name`' } else { '`$left.name`' }
-					right_name := if right_type.is_ptr() { '`*$right.name`' } else { '`$right.name`' }
+					left_name := if left_type.is_ptr() { '`&$left.name`' } else { '`$left.name`' }
+					right_name := if right_type.is_ptr() { '`&$right.name`' } else { '`$right.name`' }
 					c.error('mismatched types $left_name and $right_name', left_pos)
 				}
 			} else if right.kind in [.array, .array_fixed, .map, .struct_] {
 				if right.has_method(infix_expr.op.str()) {
 					return_type = right_type
 				} else {
-					left_name := if left_type.is_ptr() { '`*$left.name`' } else { '`$left.name`' }
-					right_name := if right_type.is_ptr() { '`*$right.name`' } else { '`$right.name`' }
+					left_name := if left_type.is_ptr() { '`&$left.name`' } else { '`$left.name`' }
+					right_name := if right_type.is_ptr() { '`&$right.name`' } else { '`$right.name`' }
 					c.error('mismatched types $left_name and $right_name', right_pos)
 				}
 			} else {
 				promoted_type := c.promote(c.table.unalias_num_type(left_type), c.table.unalias_num_type(right_type))
 				if promoted_type.idx() == table.void_type_idx {
-					left_name := if left_type.is_ptr() { '`*$left.name`' } else { '`$left.name`' }
-					right_name := if right_type.is_ptr() { '`*$right.name`' } else { '`$right.name`' }
+					left_name := if left_type.is_ptr() { '`&$left.name`' } else { '`$left.name`' }
+					right_name := if right_type.is_ptr() { '`&$right.name`' } else { '`$right.name`' }
 					c.error('mismatched types $left_name and $right_name', infix_expr.pos)
 				} else if promoted_type.is_float() {
 					if infix_expr.op in [.mod, .xor, .amp, .pipe] {

--- a/vlib/v/checker/tests/add_op_wrong_left_type_err_c.out
+++ b/vlib/v/checker/tests/add_op_wrong_left_type_err_c.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/add_op_wrong_left_type_err_c.vv:3:13: error: mismatched types `map_string_int` and `any_int`
+vlib/v/checker/tests/add_op_wrong_left_type_err_c.vv:3:13: error: mismatched types `map[string]int` and `any_int`
     1 | fn main() {
     2 |     a := map[string]int
     3 |     println(a + 10)

--- a/vlib/v/checker/tests/add_op_wrong_right_type_err_c.out
+++ b/vlib/v/checker/tests/add_op_wrong_right_type_err_c.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/add_op_wrong_right_type_err_c.vv:3:18: error: mismatched types `any_int` and `map_string_int`
+vlib/v/checker/tests/add_op_wrong_right_type_err_c.vv:3:18: error: mismatched types `any_int` and `map[string]int`
     1 | fn main() {
     2 |     a := map[string]int
     3 |     println(10 + a)

--- a/vlib/v/checker/tests/div_op_wrong_left_type_err_c.out
+++ b/vlib/v/checker/tests/div_op_wrong_left_type_err_c.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/div_op_wrong_left_type_err_c.vv:3:13: error: mismatched types `map_string_int` and `any_int`
+vlib/v/checker/tests/div_op_wrong_left_type_err_c.vv:3:13: error: mismatched types `map[string]int` and `any_int`
     1 | fn main() {
     2 |     a := map[string]int
     3 |     println(a / 10)

--- a/vlib/v/checker/tests/div_op_wrong_right_type_err_c.out
+++ b/vlib/v/checker/tests/div_op_wrong_right_type_err_c.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/div_op_wrong_right_type_err_c.vv:3:18: error: mismatched types `any_int` and `map_string_int`
+vlib/v/checker/tests/div_op_wrong_right_type_err_c.vv:3:18: error: mismatched types `any_int` and `map[string]int`
     1 | fn main() {
     2 |     a := map[string]int
     3 |     println(10 / a)

--- a/vlib/v/checker/tests/minus_op_wrong_left_type_err_c.out
+++ b/vlib/v/checker/tests/minus_op_wrong_left_type_err_c.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/minus_op_wrong_left_type_err_c.vv:3:13: error: mismatched types `map_string_int` and `any_int`
+vlib/v/checker/tests/minus_op_wrong_left_type_err_c.vv:3:13: error: mismatched types `map[string]int` and `any_int`
     1 | fn main() {
     2 |     a := map[string]int
     3 |     println(a - 10)

--- a/vlib/v/checker/tests/minus_op_wrong_right_type_err_c.out
+++ b/vlib/v/checker/tests/minus_op_wrong_right_type_err_c.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/minus_op_wrong_right_type_err_c.vv:3:18: error: mismatched types `any_int` and `map_string_int`
+vlib/v/checker/tests/minus_op_wrong_right_type_err_c.vv:3:18: error: mismatched types `any_int` and `map[string]int`
     1 | fn main() {
     2 |     a := map[string]int
     3 |     println(10 - a)

--- a/vlib/v/checker/tests/mismatched_ptr_op_ptr.out
+++ b/vlib/v/checker/tests/mismatched_ptr_op_ptr.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/mismatched_ptr_op_ptr.vv:5:18: error: mismatched types `&string` and `string`
+    3 |     unsafe {
+    4 |         b := &a
+    5 |         println(b+*b)
+      |                  ^
+    6 |         println(b+b)
+    7 |     }
+vlib/v/checker/tests/mismatched_ptr_op_ptr.vv:6:18: error: mismatched types `&string` and `&string`
+    4 |         b := &a
+    5 |         println(b+*b)
+    6 |         println(b+b)
+      |                  ^
+    7 |     }
+    8 | }

--- a/vlib/v/checker/tests/mismatched_ptr_op_ptr.vv
+++ b/vlib/v/checker/tests/mismatched_ptr_op_ptr.vv
@@ -1,0 +1,8 @@
+fn main() {
+    a := '1'
+    unsafe {
+        b := &a
+        println(b+*b)
+        println(b+b)
+    }
+}

--- a/vlib/v/checker/tests/mod_op_wrong_left_type_err_d.out
+++ b/vlib/v/checker/tests/mod_op_wrong_left_type_err_d.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/mod_op_wrong_left_type_err_d.vv:3:10: error: mismatched types `map_string_int` and `any_int`
+vlib/v/checker/tests/mod_op_wrong_left_type_err_d.vv:3:10: error: mismatched types `map[string]int` and `any_int`
     1 | fn main() {
     2 |     a := map[string]int
     3 |     println(a % 1)

--- a/vlib/v/checker/tests/mod_op_wrong_right_type_err_d.out
+++ b/vlib/v/checker/tests/mod_op_wrong_right_type_err_d.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/mod_op_wrong_right_type_err_d.vv:3:14: error: mismatched types `any_int` and `map_string_int`
+vlib/v/checker/tests/mod_op_wrong_right_type_err_d.vv:3:14: error: mismatched types `any_int` and `map[string]int`
     1 | fn main() {
     2 |     a := map[string]int
     3 |     println(1 % a)

--- a/vlib/v/checker/tests/mul_op_wrong_left_type_err_c.out
+++ b/vlib/v/checker/tests/mul_op_wrong_left_type_err_c.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/mul_op_wrong_left_type_err_c.vv:3:13: error: mismatched types `map_string_int` and `any_int`
+vlib/v/checker/tests/mul_op_wrong_left_type_err_c.vv:3:13: error: mismatched types `map[string]int` and `any_int`
     1 | fn main() {
     2 |     a := map[string]int
     3 |     println(a * 10)

--- a/vlib/v/checker/tests/mul_op_wrong_right_type_err_c.out
+++ b/vlib/v/checker/tests/mul_op_wrong_right_type_err_c.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/mul_op_wrong_right_type_err_c.vv:3:18: error: mismatched types `any_int` and `map_string_int`
+vlib/v/checker/tests/mul_op_wrong_right_type_err_c.vv:3:18: error: mismatched types `any_int` and `map[string]int`
     1 | fn main() {
     2 |     a := map[string]int
     3 |     println(10 * a)


### PR DESCRIPTION
Fix https://github.com/vlang/v/issues/3048


Earlier:
```v
foo.v:5:18: error: mismatched types `string` and `string`
    3 |      unsafe {
    4 |         b := &a
    5 |         println(b+*b)
      |                  ^
    6 |     }
    7 | }
```

```v
foo.v:5:18: error: mismatched types `string` and `string`
    3 |      unsafe {
    4 |         b := &a
    5 |         println(*b+*b)
      |                  ^
    6 |     }
    7 | }
```


Now:
```v
foo.v:5:18: error: mismatched types `&string` and `string`
    3 |      unsafe {
    4 |         b := &a
    5 |         println(b+*b)
      |                  ^
    6 |     }
    7 | }
```

```v
foo.v:5:18: error: mismatched types `&string` and `&string`
    3 |      unsafe {
    4 |         b := &a
    5 |         println(b+b)
      |                  ^
    6 | 
    7 |      }
```
