### PR TITLE
cmd: correct the error message

### DIFF
--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -105,7 +105,7 @@ fn (app App) git_command(command string) {
 	}
 	if git_result.exit_code != 0 {
 		if git_result.output.contains('Permission denied') {
-			eprintln('have no access `$app.vroot`: Permission denied')
+			eprintln('No access to `$app.vroot`: Permission denied')
 		} else {
 			eprintln(git_result.output)
 		}


### PR DESCRIPTION
"have no access `/usr/lib/vlang/`: Permission denied" doesn't seem right. This PR changes it to "No access to…".
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->