### PR TITLE
fmt: add support for `chan` types and operations

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1636,12 +1636,17 @@ fn expr_is_single_line(expr ast.Expr) bool {
 }
 
 pub fn (mut f Fmt) chan_init(mut it ast.ChanInit) {
+	info := f.table.get_type_symbol(it.typ).chan_info()
 	if it.elem_type == 0 && it.typ > 0 {
-		info := f.table.get_type_symbol(it.typ).chan_info()
 		it.elem_type = info.elem_type
 	}
+	is_mut := info.is_mut
+	el_typ := if is_mut { it.elem_type.set_nr_muls(it.elem_type.nr_muls() - 1) } else { it.elem_type }
 	f.write('chan ')
-	f.write(f.type_to_str(it.elem_type))
+	if is_mut {
+		f.write('mut ')
+	}
+	f.write(f.type_to_str(el_typ))
 	f.write('{')
 	if it.has_cap {
 		f.write('cap: ')

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -717,9 +717,17 @@ pub fn (mut f Fmt) prefix_expr_cast_expr(fexpr ast.Expr) {
 			is_pe_amp_ce = true
 			f.expr(ce)
 		}
+	} else if fexpr is ast.CastExpr {
+		last := f.out.cut_last(1)
+		if last != '&' {
+			f.out.write(last)
+		}
 	}
 	if !is_pe_amp_ce {
 		f.expr(fexpr)
+		if fexpr is ast.PrefixExpr {
+			f.or_expr(fexpr.or_block)
+		}
 	}
 }
 

--- a/vlib/v/fmt/tests/chan_ops_keep.vv
+++ b/vlib/v/fmt/tests/chan_ops_keep.vv
@@ -4,6 +4,10 @@ const (
 	num_iterations = 10000
 )
 
+struct St {
+	a int
+}
+
 fn get_val_from_chan(ch chan i64) ?i64 {
 	r := <-ch ?
 	return r
@@ -52,4 +56,10 @@ fn test_channel_array_mut() {
 	d := ch[o].len
 	sem.wait()
 	assert t == 100 + num_iterations
+	ch2 := chan mut St{cap: 10}
+	go g(ch2)
+}
+
+fn g(ch chan mut St) {
+	return
 }

--- a/vlib/v/fmt/tests/chan_ops_keep.vv
+++ b/vlib/v/fmt/tests/chan_ops_keep.vv
@@ -9,6 +9,14 @@ fn get_val_from_chan(ch chan i64) ?i64 {
 	return r
 }
 
+fn get_val_from_chan2(ch chan i64) ?i64 {
+	r := <-ch or {
+		println('error')
+		return error(err)
+	}
+	return r
+}
+
 // this function gets an array of channels for `i64`
 fn do_rec_calc_send(chs []chan i64, sem sync.Semaphore) {
 	mut msg := ''
@@ -33,7 +41,15 @@ fn test_channel_array_mut() {
 		chs[0] <- t
 		t = <-chs[1]
 	}
-	chs[0].close()
+	(&sync.Channel(chs[0])).close()
+	orr := &sync.Channel(chs[0])
+	chs[1].close()
+	ch := chan int{}
+	ch.close()
+	a := ch.cap
+	b := ch.len
+	c := ch[1].cap
+	d := ch[o].len
 	sem.wait()
 	assert t == 100 + num_iterations
 }

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -804,32 +804,33 @@ pub fn (table &Table) type_to_str(t Type) string {
 		map_start = 'map[string]'
 	}
 	if sym.kind == .chan || 'chan_' in res {
-		res = res.replace('chan_', '')
+		res = res.replace('chan_', 'chan ')
 	}
 	// mod.submod.submod2.Type => submod2.Type
-	if res.contains('.') {
-		vals := res.split('.')
-		if vals.len > 2 {
-			res = vals[vals.len - 2] + '.' + vals[vals.len - 1]
+	mut parts := res.split(' ')
+	for i, _ in parts {
+		if parts[i].contains('.') {
+			vals := parts[i].split('.')
+			if vals.len > 2 {
+				parts[i] = vals[vals.len - 2] + '.' + vals[vals.len - 1]
+			}
+			if parts[i].starts_with(table.cmod_prefix) ||
+				(sym.kind == .array && parts[i].starts_with('[]' + table.cmod_prefix)) {
+				parts[i] = parts[i].replace_once(table.cmod_prefix, '')
+			}
+			if sym.kind == .array && !parts[i].starts_with('[]') {
+				parts[i] = '[]' + parts[i]
+			}
+			if sym.kind == .map && !parts[i].starts_with('map') {
+				parts[i] = map_start + parts[i]
+			}
 		}
-		if res.starts_with(table.cmod_prefix) ||
-			(sym.kind == .array && res.starts_with('[]' + table.cmod_prefix)) {
-			res = res.replace_once(table.cmod_prefix, '')
-		}
-		if sym.kind == .array && !res.starts_with('[]') {
-			res = '[]' + res
-		}
-		if sym.kind == .map && !res.starts_with('map') {
-			res = map_start + res
-		}
-		if sym.kind == .chan && !res.starts_with('chan') {
-			res = 'chan ' + res
+		nr_muls := t.nr_muls()
+		if nr_muls > 0 {
+			parts[i] = strings.repeat(`&`, nr_muls) + parts[i]
 		}
 	}
-	nr_muls := t.nr_muls()
-	if nr_muls > 0 {
-		res = strings.repeat(`&`, nr_muls) + res
-	}
+	res = parts.join(' ')
 	if t.has_flag(.optional) {
 		if sym.kind == .void {
 			res = '?'

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -825,6 +825,9 @@ pub fn (table &Table) type_to_str(t Type) string {
 				parts[i] = map_start + parts[i]
 			}
 		}
+		if parts[i].contains('_mut') {
+			parts[i] = 'mut ' + parts[i].replace('_mut', '')
+		}
 		nr_muls := t.nr_muls()
 		if nr_muls > 0 {
 			parts[i] = strings.repeat(`&`, nr_muls) + parts[i]


### PR DESCRIPTION
This PR enables `vfmt` to handle more channel types and channel operations - including error (or-block) handling.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
