### PR TITLE
table: rename Arg to Param

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -242,7 +242,7 @@ pub struct FnDecl {
 pub:
 	name          string
 	mod           string
-	args          []table.Arg // parameters
+	args          []table.Param
 	is_deprecated bool
 	is_pub        bool
 	is_variadic   bool

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -199,7 +199,7 @@ fn (mut g Gen) write_defer_stmts_when_needed() {
 }
 
 // fn decl args
-fn (mut g Gen) fn_args(args []table.Arg, is_variadic bool) ([]string, []string) {
+fn (mut g Gen) fn_args(args []table.Param, is_variadic bool) ([]string, []string) {
 	mut fargs := []string{}
 	mut fargtypes := []string{}
 	no_names := args.len > 0 && args[0].name == 'arg_1'

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -296,7 +296,7 @@ pub fn (mut g JsGen) typ(t table.Type) string {
 	return styp
 }
 
-fn (mut g JsGen) fn_typ(args []table.Arg, return_type table.Type) string {
+fn (mut g JsGen) fn_typ(args []table.Param, return_type table.Type) string {
 	mut res := '('
 	for i, arg in args {
 		res += '$arg.name: ${g.typ(arg.typ)}'
@@ -897,7 +897,7 @@ fn (mut g JsGen) gen_method_decl(it ast.FnDecl) {
 	g.fn_decl = voidptr(0)
 }
 
-fn (mut g JsGen) fn_args(args []table.Arg, is_variadic bool) {
+fn (mut g JsGen) fn_args(args []table.Param, is_variadic bool) {
 	// no_names := args.len > 0 && args[0].name == 'arg_1'
 	for i, arg in args {
 		name := g.js_name(arg.name)

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -158,7 +158,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	mut receiver_pos := token.Position{}
 	mut rec_type := table.void_type
 	mut rec_mut := false
-	mut args := []table.Arg{}
+	mut args := []table.Param{}
 	if p.tok.kind == .lpar {
 		p.next() // (
 		is_method = true
@@ -197,7 +197,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 			rec_type = rec_type.set_flag(.atomic_f)
 		}
 		sym := p.table.get_type_symbol(rec_type)
-		args << table.Arg{
+		args << table.Param{
 			pos: rec_start_pos
 			name: rec_name
 			is_mut: rec_mut
@@ -397,9 +397,9 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 }
 
 // part of fn declaration
-fn (mut p Parser) fn_args() ([]table.Arg, bool, bool) {
+fn (mut p Parser) fn_args() ([]table.Param, bool, bool) {
 	p.check(.lpar)
-	mut args := []table.Arg{}
+	mut args := []table.Param{}
 	mut is_variadic := false
 	// `int, int, string` (no names, just types)
 	argname := if p.tok.kind == .name && p.tok.lit.len > 0 && p.tok.lit[0].is_capital() { p.prepend_mod(p.tok.lit) } else { p.tok.lit }
@@ -458,7 +458,7 @@ fn (mut p Parser) fn_args() ([]table.Arg, bool, bool) {
 				p.next()
 			}
 			sym := p.table.get_type_symbol(arg_type)
-			args << table.Arg{
+			args << table.Param{
 				pos: pos
 				name: arg_name
 				is_mut: is_mut
@@ -520,7 +520,7 @@ fn (mut p Parser) fn_args() ([]table.Arg, bool, bool) {
 			}
 			for i, arg_name in arg_names {
 				sym := p.table.get_type_symbol(typ)
-				args << table.Arg{
+				args << table.Param{
 					pos: arg_pos[i]
 					name: arg_name
 					is_mut: is_mut

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -387,9 +387,9 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			p.error('interface methods cannot contain uppercase letters, use snake_case instead')
 		}
 		// field_names << name
-		args2, _, _ := p.fn_args() // TODO merge table.Arg and ast.Arg to avoid this
+		args2, _, _ := p.fn_args() // TODO merge table.Param and ast.Arg to avoid this
 		sym := p.table.get_type_symbol(typ)
-		mut args := [table.Arg{
+		mut args := [table.Param{
 			name: 'x'
 			typ: typ
 			type_source_name: sym.source_name

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -22,7 +22,7 @@ pub mut:
 
 pub struct Fn {
 pub:
-	args                    []Arg // parameters
+	args                    []Param
 	return_type             Type
 	return_type_source_name string
 	is_variadic             bool
@@ -39,8 +39,7 @@ pub mut:
 	name                    string
 }
 
-// parameter
-pub struct Arg {
+pub struct Param {
 pub:
 	pos              token.Position
 	name             string


### PR DESCRIPTION
'Argument' means what is passed to a function. 'Parameter' is what a function declares it accepts.
See https://github.com/vlang/v/pull/6321#issuecomment-688930387.

This just renames the type. Really the field names should be renamed too:
* `FnDecl.args` -> `params`
* `Fn.args` -> `params`

But that is quite a lot of changes.