### PR TITLE
checker: fix error pos on default value

### DIFF
--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -96,14 +96,14 @@ enum OutputType {
 struct DocConfig {
 mut:
 	pub_only       bool = true
-	show_loc       bool = false // for plaintext
-	serve_http     bool = false // for html
-	is_multi       bool = false
-	is_verbose     bool = false
-	include_readme bool = false
-	open_docs      bool = false
+	show_loc       bool        // for plaintext
+	serve_http     bool        // for html
+	is_multi       bool
+	is_verbose     bool
+	include_readme bool
+	open_docs      bool
 	server_port    int  = 8046
-	inline_assets  bool = false
+	inline_assets  bool
 	output_path    string
 	input_path     string
 	output_type    OutputType = .unset

--- a/vlib/net/html/dom.v
+++ b/vlib/net/html/dom.v
@@ -5,7 +5,7 @@ import os
 pub struct DocumentObjectModel {
 mut:
 	root           &Tag
-	constructed    bool = false
+	constructed    bool
 	btree          BTree
 	all_tags       []&Tag
 	all_attributes map[string][]&Tag

--- a/vlib/net/html/parser.v
+++ b/vlib/net/html/parser.v
@@ -5,11 +5,11 @@ import os
 struct LexycalAttributes {
 mut:
 	current_tag      &Tag
-	open_tag         bool = false
-	open_code        bool = false
+	open_tag         bool
+	open_code        bool
 	open_string      int
-	open_comment     bool = false
-	is_attribute     bool = false
+	open_comment     bool
+	is_attribute     bool
 	opened_code_type string
 	line_count       int
 	lexeme_builder   string
@@ -32,7 +32,7 @@ mut:
 		current_tag: &Tag{}
 	}
 	filename           string = 'direct-parse'
-	initialized        bool = false
+	initialized        bool
 	tags               []&Tag
 	debug_file         os.File
 }

--- a/vlib/net/html/tag.v
+++ b/vlib/net/html/tag.v
@@ -16,7 +16,7 @@ mut:
 	last_attribute     string
 	parent             &Tag = C.NULL
 	position_in_parent int
-	closed             bool = false
+	closed             bool
 	close_type         CloseTagType = .in_name
 }
 

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -35,7 +35,7 @@ pub mut:
 	headers    map[string]string
 	cookies    map[string]string
 	user_agent string = 'v.http'
-	verbose    bool = false
+	verbose    bool
 }
 
 pub struct Response {

--- a/vlib/rand/mt19937/mt19937.v
+++ b/vlib/rand/mt19937/mt19937.v
@@ -62,7 +62,7 @@ mut:
 	state    []u64 = calculate_state(util.time_seed_array(2), mut []u64{len: nn})
 	mti      int = nn
 	next_rnd u32
-	has_next bool = false
+	has_next bool
 }
 
 fn calculate_state(seed_data []u32, mut state []u64) []u64 {

--- a/vlib/rand/splitmix64/splitmix64.v
+++ b/vlib/rand/splitmix64/splitmix64.v
@@ -9,7 +9,7 @@ import rand.util
 pub struct SplitMix64RNG {
 mut:
 	state     u64 = util.time_seed_64()
-	has_extra bool = false
+	has_extra bool
 	extra     u32
 }
 

--- a/vlib/rand/wyrand/wyrand.v
+++ b/vlib/rand/wyrand/wyrand.v
@@ -17,7 +17,7 @@ const (
 pub struct WyRandRNG {
 mut:
 	state     u64 = util.time_seed_64()
-	has_extra bool = false
+	has_extra bool
 	extra     u32
 }
 

--- a/vlib/regex/regex.v
+++ b/vlib/regex/regex.v
@@ -1482,7 +1482,7 @@ fn state_str(s Match_state) string {
 
 struct StateObj {
 pub mut:
-	match_flag bool = false
+	match_flag bool
 	match_index int = -1
 	match_first int = -1
 }

--- a/vlib/strconv/format.v
+++ b/vlib/strconv/format.v
@@ -207,9 +207,9 @@ pub struct BF_param {
 	len0         int        = -1      // default len for whole the number or string
 	len1         int        = 6       // number of decimal digits, if needed
 	positive     bool       = true    // mandatory: the sign of the number passed
-	sign_flag    bool       = false   // flag for print sign as prefix in padding
+	sign_flag    bool                 // flag for print sign as prefix in padding
 	allign       Align_text = .right  // alignment of the string
-	rm_tail_zero bool       = false   // remove the tail zeros from floats
+	rm_tail_zero bool                 // remove the tail zeros from floats
 }
 
 pub fn format_str(s string, p BF_param) string {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -368,15 +368,20 @@ pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
 			if field.typ.is_ptr() {
 				continue
 			}
-			if field.default_expr is ast.IntegerLiteral as x {
-				if x.val == '0' {
+			if field.default_expr is ast.IntegerLiteral as lit {
+				if lit.val == '0' {
 					c.error('unnecessary default value of `0`: struct fields are zeroed by default',
-						x.pos)
+						lit.pos)
 				}
-			} else if field.default_expr is ast.StringLiteral as x {
-				if x.val == '' {
+			} else if field.default_expr is ast.StringLiteral as lit {
+				if lit.val == '' {
 					c.error("unnecessary default value of '': struct fields are zeroed by default",
-						x.pos)
+						lit.pos)
+				}
+			} else if field.default_expr is ast.BoolLiteral as lit {
+				if lit.val == false {
+					c.error("unnecessary default value of `false`: struct fields are zeroed by default",
+						lit.pos)
 				}
 			}
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -380,7 +380,7 @@ pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
 				}
 			} else if field.default_expr is ast.BoolLiteral as lit {
 				if lit.val == false {
-					c.error("unnecessary default value of `false`: struct fields are zeroed by default",
+					c.error('unnecessary default value `false`: struct fields are zeroed by default',
 						lit.pos)
 				}
 			}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -371,12 +371,12 @@ pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
 			if field.default_expr is ast.IntegerLiteral as x {
 				if x.val == '0' {
 					c.error('unnecessary default value of `0`: struct fields are zeroed by default',
-						field.pos)
+						x.pos)
 				}
 			} else if field.default_expr is ast.StringLiteral as x {
 				if x.val == '' {
 					c.error("unnecessary default value of '': struct fields are zeroed by default",
-						field.pos)
+						x.pos)
 				}
 			}
 		}

--- a/vlib/v/checker/tests/struct_unneeded_default.out
+++ b/vlib/v/checker/tests/struct_unneeded_default.out
@@ -11,7 +11,7 @@ vlib/v/checker/tests/struct_unneeded_default.vv:3:13: error: unnecessary default
       |                ~~
     4 |     b bool = false
     5 | }
-vlib/v/checker/tests/struct_unneeded_default.vv:4:11: error: unnecessary default value of `false`: struct fields are zeroed by default
+vlib/v/checker/tests/struct_unneeded_default.vv:4:11: error: unnecessary default value `false`: struct fields are zeroed by default
     2 |     n int = 0
     3 |     s string = ''
     4 |     b bool = false

--- a/vlib/v/checker/tests/struct_unneeded_default.out
+++ b/vlib/v/checker/tests/struct_unneeded_default.out
@@ -1,13 +1,20 @@
-vlib/v/checker/tests/struct_unneeded_default.vv:2:2: error: unnecessary default value of `0`: struct fields are zeroed by default
+vlib/v/checker/tests/struct_unneeded_default.vv:2:10: error: unnecessary default value of `0`: struct fields are zeroed by default
     1 | struct Test {
     2 |     n int = 0
-      |     ~~~~~~
+      |             ^
     3 |     s string = ''
-    4 | }
-vlib/v/checker/tests/struct_unneeded_default.vv:3:2: error: unnecessary default value of '': struct fields are zeroed by default
+    4 |     b bool = false
+vlib/v/checker/tests/struct_unneeded_default.vv:3:13: error: unnecessary default value of '': struct fields are zeroed by default
     1 | struct Test {
     2 |     n int = 0
     3 |     s string = ''
-      |     ~~~~~~~~~
-    4 | }
-    5 |
+      |                ~~
+    4 |     b bool = false
+    5 | }
+vlib/v/checker/tests/struct_unneeded_default.vv:4:11: error: unnecessary default value of `false`: struct fields are zeroed by default
+    2 |     n int = 0
+    3 |     s string = ''
+    4 |     b bool = false
+      |              ~~~~~
+    5 | }
+    6 |

--- a/vlib/v/checker/tests/struct_unneeded_default.vv
+++ b/vlib/v/checker/tests/struct_unneeded_default.vv
@@ -1,6 +1,7 @@
 struct Test {
 	n int = 0
 	s string = ''
+	b bool = false
 }
 
 fn main() {

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -44,7 +44,7 @@ pub mut:
 	is_fmt                      bool // Used only for skipping ${} in strings, since we need literal
 	// string values when generating formatted code.
 	comments_mode               CommentsMode
-	is_inside_toplvl_statement  bool = false // *only* used in comments_mode: .toplevel_comments, toggled by parser
+	is_inside_toplvl_statement  bool          // *only* used in comments_mode: .toplevel_comments, toggled by parser
 	all_tokens                  []token.Token // *only* used in comments_mode: .toplevel_comments, contains all tokens
 	tidx                        int
 	eofs                        int
@@ -1099,7 +1099,7 @@ fn (mut s Scanner) text_scan() token.Token {
 						// fix line_nr, \n was read; the comment is marked on the next line
 						s.pos--
 						s.line_nr--
-					}                    
+					}
 					if s.should_parse_comment() {
 						s.line_comment = s.text[start + 1..comment_line_end]
 						mut comment := s.line_comment.trim_space()

--- a/vlib/x/websocket/events.v
+++ b/vlib/x/websocket/events.v
@@ -4,28 +4,28 @@ module websocket
 struct MessageEventHandler {
 	handler  SocketMessageFn
 	handler2 SocketMessageFn2
-	is_ref   bool = false
+	is_ref   bool
 	ref      voidptr
 }
 
 struct ErrorEventHandler {
 	handler  SocketErrorFn
 	handler2 SocketErrorFn2
-	is_ref   bool = false
+	is_ref   bool
 	ref      voidptr
 }
 
 struct OpenEventHandler {
 	handler  SocketOpenFn
 	handler2 SocketOpenFn2
-	is_ref   bool = false
+	is_ref   bool
 	ref      voidptr
 }
 
 struct CloseEventHandler {
 	handler  SocketCloseFn
 	handler2 SocketCloseFn2
-	is_ref   bool = false
+	is_ref   bool
 	ref      voidptr
 }
 

--- a/vlib/x/websocket/websocket_client.v
+++ b/vlib/x/websocket/websocket_client.v
@@ -21,7 +21,7 @@ const (
 
 // Client represents websocket client state
 pub struct Client {
-	is_server         bool = false
+	is_server         bool
 mut:
 	ssl_conn          &openssl.SSLConn
 	flags             []Flag
@@ -38,7 +38,7 @@ pub:
 pub mut:
 	conn              net.TcpConn
 	nonce_size        int = 16 // you can try 18 too
-	panic_on_callback bool = false
+	panic_on_callback bool
 	state             State
 	resource_name     string
 	last_pong_ut      u64

--- a/vlib/x/websocket/websocket_server.v
+++ b/vlib/x/websocket/websocket_server.v
@@ -18,7 +18,7 @@ mut:
 	close_callbacks         []CloseEventHandler
 pub:
 	port                    int
-	is_ssl                  bool = false
+	is_ssl                  bool
 pub mut:
 	ping_interval           int = 30 // in seconds
 	state                   State


### PR DESCRIPTION
```
abc.v:2:10: error: unnecessary default value of `0`: struct fields are zeroed by default
    1 | struct Test {
    2 |     n int = 0
      |             ^
    3 |     s string = ''
    4 | }
abc.v:3:13: error: unnecessary default value of '': struct fields are zeroed by default
    2 |     n int = 0
    3 |     s string = ''
      |                ~~
    4 | }
    5 |
```