### PR TITLE
all: better errors

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -127,6 +127,7 @@ pub struct StructField {
 pub:
 	name             string
 	pos              token.Position
+	type_pos         token.Position
 	comments         []Comment
 	default_expr     Expr
 	has_default_expr bool

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -326,21 +326,21 @@ pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
 		sym := c.table.get_type_symbol(field.typ)
 		if sym.kind == .placeholder && decl.language != .c && !sym.name.starts_with('C.') {
 			c.error(util.new_suggestion(sym.source_name, c.table.known_type_names()).say('unknown type `$sym.source_name`'),
-				field.pos)
+				field.type_pos)
 		}
 		if sym.kind == .array {
 			array_info := sym.array_info()
 			elem_sym := c.table.get_type_symbol(array_info.elem_type)
 			if elem_sym.kind == .placeholder {
 				c.error(util.new_suggestion(elem_sym.source_name, c.table.known_type_names()).say('unknown type `$elem_sym.source_name`'),
-					field.pos)
+					field.type_pos)
 			}
 		}
 		if sym.kind == .struct_ {
 			info := sym.info as table.Struct
 			if info.is_ref_only && !field.typ.is_ptr() {
 				c.error('`$sym.source_name` type can only be used as a reference: `&$sym.source_name`',
-					field.pos)
+					field.type_pos)
 			}
 		}
 		if sym.kind == .map {
@@ -348,10 +348,10 @@ pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
 			key_sym := c.table.get_type_symbol(info.key_type)
 			value_sym := c.table.get_type_symbol(info.value_type)
 			if key_sym.kind == .placeholder {
-				c.error('unknown type `$key_sym.source_name`', field.pos)
+				c.error('unknown type `$key_sym.source_name`', field.type_pos)
 			}
 			if value_sym.kind == .placeholder {
-				c.error('unknown type `$value_sym.source_name`', field.pos)
+				c.error('unknown type `$value_sym.source_name`', field.type_pos)
 			}
 		}
 		if field.has_default_expr {

--- a/vlib/v/checker/tests/map_unknown_value.out
+++ b/vlib/v/checker/tests/map_unknown_value.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/map_unknown_value.vv:2:5: error: unknown type `DoesNotExist`
+vlib/v/checker/tests/map_unknown_value.vv:2:23: error: unknown type `DoesNotExist`
     1 | struct App {
     2 |     my_map map[string]DoesNotExist
-      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                       ~~~~~~~~~~~~
     3 | }

--- a/vlib/v/checker/tests/unknown_array_element_type_b.out
+++ b/vlib/v/checker/tests/unknown_array_element_type_b.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/unknown_array_element_type_b.vv:2:2: error: unknown type `abc`
+vlib/v/checker/tests/unknown_array_element_type_b.vv:2:6: error: unknown type `abc`
     1 | struct Aaa {
     2 |     a []abc
-      |     ~~~~~~~
+      |         ~~~
     3 | }
     4 |

--- a/vlib/v/checker/tests/unknown_method_suggest_name.out
+++ b/vlib/v/checker/tests/unknown_method_suggest_name.out
@@ -1,3 +1,4 @@
+vlib/v/checker/tests/unknown_method_suggest_name.vv:13:12: error: unknown type `hash.crc32.Crc33`.
 Did you mean `crc32.Crc32`?
    11 |     y int
    12 |     z int

--- a/vlib/v/checker/tests/unknown_method_suggest_name.out
+++ b/vlib/v/checker/tests/unknown_method_suggest_name.out
@@ -1,9 +1,8 @@
-vlib/v/checker/tests/unknown_method_suggest_name.vv:13:2: error: unknown type `hash.crc32.Crc33`.
 Did you mean `crc32.Crc32`?
    11 |     y int
    12 |     z int
    13 |     ccc crc32.Crc33
-      |     ~~~~~~~~~~~~~~~
+      |               ~~~~~
    14 | }
    15 |
 vlib/v/checker/tests/unknown_method_suggest_name.vv:27:9: error: unknown method: `Point.tranzlate`.

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -152,12 +152,8 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 			}
 			// println(p.tok.position())
 			typ := p.parse_type()
-			// field_pos := field_start_pos.extend(p.tok.position())
-			field_pos := token.Position{
-				line_nr: field_start_pos.line_nr
-				pos: field_start_pos.pos
-				len: p.tok.position().pos - field_start_pos.pos
-			}
+			type_pos := p.prev_tok.position()
+			field_pos := field_start_pos.extend(type_pos)
 			// if name == '_net_module_s' {
 			// if name.contains('App') {
 			// s := p.table.get_type_symbol(typ)
@@ -197,6 +193,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 			ast_fields << ast.StructField{
 				name: field_name
 				pos: field_pos
+				type_pos: type_pos
 				typ: typ
 				comments: comments
 				default_expr: default_expr


### PR DESCRIPTION
```v
abc.v:4:21: error: unknown type `Tesst`
    2 |
    3 | struct Test {
    4 |     b int c map[string]Tesst a string
      |                        ~~~~~
    5 | }
    6 |
```

instead of
```v
abc.v:4:21: error: unknown type `Tesst`
    2 |
    3 | struct Test {
    4 |     b int c map[string]Tesst a string
      |           ~~~~~~~~~~~~~~~~~~~
    5 | }
    6 |
```