### PR TITLE
vweb: add mime type for json static content

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -25,6 +25,7 @@ pub const (
 		'.html': 'text/html; charset=utf-8',
 		'.jpg': 'image/jpeg',
 		'.js': 'application/javascript',
+		'.json': 'application/json',
 		'.md': 'text/markdown; charset=utf-8',
 		'.pdf': 'application/pdf',
 		'.png': 'image/png',


### PR DESCRIPTION
Hi,
with this little change it should be possible to serve even JSON files as static content (sometimes it's useful when client side apps need some configuration etc).
Bye
