### PR TITLE
string: consume matched string length when using `string`.replace_each

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -292,7 +292,7 @@ pub fn (s string) replace_each(vals []string) string {
 				idx:idx
 				val_idx:rep_i
 			}
-			idx++
+			idx += rep.len
 			new_len += with.len - rep.len
 		}
 	}

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -285,6 +285,11 @@ fn test_replace_each() {
 		'[b]', '<b>',
 		'[/b]', '</b>',
 	]) == '<b>cool</b>'
+	t := 'aaaaaaaa'
+	y := t.replace_each([
+		'aa', 'b'
+	])
+	assert y == 'bbbb'
 }
 
 fn test_itoa() {

--- a/vlib/net/http/http_httpbin_test.v
+++ b/vlib/net/http/http_httpbin_test.v
@@ -8,7 +8,7 @@ struct HttpbinResponseBody {
 	files   map[string]string
 	form    map[string]string
 	headers map[string]string
-	json    ?map[string]string
+	json    map[string]string
 	origin  string
 	url     string
 }
@@ -22,7 +22,7 @@ fn http_fetch_mock(_methods []string, _config FetchConfig) ?[]Response {
 	// Note: httpbin doesn't support head
 	for method in methods {
 		lmethod := method.to_lower()
-		config.method = method
+		config.method = method_from_str(method)
 		res := fetch(url + lmethod, config)?
 		// TODO
 		// body := json.decode(HttpbinResponseBody,res.text)?


### PR DESCRIPTION
This is the behaviour of `string`.replace and thus, the same behaviour should apply here

Resolves: #6348