### PR TITLE
sync/channels: fix bug that caused 100% CPU on block 

### DIFF
--- a/vlib/sync/bench/results.md
+++ b/vlib/sync/bench/results.md
@@ -18,7 +18,7 @@ nobj .... number of objects to pass thru the channel
 
 10000000 Objects transfered, results in Objects/µs
 
-| nsend | nrec | buflen | **V (gcc -O2)** | **V (clang)** | **V (tcc)** | **Go (glang)** | **Go (gccgo -O2)** |
+| nsend | nrec | buflen | **V (gcc -O2)** | **V (clang)** | **V (tcc)** | **Go (golang)** | **Go (gccgo -O2)** |
 | :---: | :---:| :---:  |      :---:      |    :---:      |    :---:    |     :---:      |      :---:         |
 |   1   |   1  |    0   |      1.97       |    1.63       |    2.08     |      4.65      |       0.56         |
 |   1   |   1  |   100  |      3.05       |    2.29       |    1.93     |     18.90      |       6.08         |
@@ -38,7 +38,7 @@ nobj .... number of objects to pass thru the channel
 
 10000000 Objects transfered, results in Objects/µs
 
-| nsend | nrec | buflen | **V (gcc -O2)** | **Go (glang)** |
+| nsend | nrec | buflen | **V (gcc -O2)** | **Go (golang)** |
 | :---: | :---:| :---:  |      :---:      |     :---:      |
 |   1   |   1  |    0   |      0.37       |     0.21       |
 |   1   |   1  |   100  |      1.03       |     0.74       |

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -110,7 +110,7 @@ pub fn new_channel<T>(n u32) &Channel {
 
 fn new_channel_st(n u32, st u32) &Channel {
 	return &Channel{
-		writesem: new_semaphore_init(if n > 0 { n + 1 } else { 1 })
+		writesem: new_semaphore_init(if n > 0 { n } else { 1 })
 		readsem:  new_semaphore_init(if n > 0 { u32(0) } else { 1 })
 		writesem_im: new_semaphore()
 		readsem_im: new_semaphore()


### PR DESCRIPTION
This PR fixes a bug that caused 100% CPU usage while waiting in case of pushing on a channel with full queue.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
