### PR TITLE
Fixes: os.write_file a string array causes a C error #6238

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1372,9 +1372,12 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 		*/
 		if !c.check_types(typ, arg.typ) {
 			// str method, allow type with str method if fn arg is string
-			if arg_typ_sym.kind == .string && typ_sym.has_method('str') {
-				continue
-			}
+			// Passing an int or a string array produces a c error here
+			// Deleting this condition results in propper V error messages
+			// if arg_typ_sym.kind == .string && typ_sym.has_method('str') {
+			// 	continue
+			// }
+
 			if typ_sym.kind == .void && arg_typ_sym.kind == .string {
 				continue
 			}


### PR DESCRIPTION
It's my first PR so I don't know what to write here. 

I found that passing an int to os.write_file also crashes

```v
import os
os.write_file("out", 1)
```

![image](https://user-images.githubusercontent.com/26058964/93018259-165a1e80-f5d7-11ea-8b22-2d5e3914bc4b.png)

After the fix it shows proper v errors

![image](https://user-images.githubusercontent.com/26058964/93018292-53261580-f5d7-11ea-960e-41efe9336938.png)
