### PR TITLE
vlib/cli: improvements to help and error messages

### DIFF
--- a/examples/cli.v
+++ b/examples/cli.v
@@ -12,6 +12,7 @@ fn main() {
 	mut greet_cmd := Command{
 		name: 'greet'
 		description: 'Prints greeting in different languages.'
+		usage: '<name>'
 		required_args: 1
 		pre_execute: greet_pre_func
 		execute: greet_func
@@ -44,13 +45,13 @@ fn greet_func(cmd Command) {
 	name := cmd.args[0]
 	for _ in 0 .. times {
 		match language {
-			'english' {
+			'english', 'en' {
 				println('Welcome $name')
 			}
-			'german' {
+			'german', 'de' {
 				println('Willkommen $name')
 			}
-			'dutch' {
+			'dutch', 'nl' {
 				println('Welkom $name')
 			}
 			else {

--- a/vlib/cli/command.v
+++ b/vlib/cli/command.v
@@ -269,7 +269,7 @@ fn (cmds []Command) get(name string) ?Command {
 			return cmd
 		}
 	}
-	return error('Command `$name` not found')
+	return error('Command `$name` not found in $cmds')
 }
 
 fn (cmds []Command) contains(name string) bool {

--- a/vlib/cli/command_test.v
+++ b/vlib/cli/command_test.v
@@ -52,7 +52,7 @@ fn test_if_command_has_default_version_subcommand_if_version_is_set() {
 }
 
 fn flag_should_be_set(cmd cli.Command) ? {
-	flag := cmd.flags.get_string('flag')?
+	flag := cmd.flags.get_string('flag') ?
 	assert flag == 'value'
 }
 
@@ -83,9 +83,9 @@ fn test_if_flag_gets_set_with_abbrev() {
 }
 
 fn flag_should_have_value_of_42(cmd cli.Command) ? {
-	flag := cmd.flags.get_string('flag')?
+	flag := cmd.flags.get_string('flag') ?
 	assert flag == 'value'
-	value := cmd.flags.get_int('value')?
+	value := cmd.flags.get_int('value') ?
 	assert value == 42
 }
 

--- a/vlib/cli/flag.v
+++ b/vlib/cli/flag.v
@@ -32,7 +32,7 @@ pub fn (flag Flag) get_bool() ?bool {
 }
 
 pub fn (flags []Flag) get_bool(name string) ?bool {
-	flag := flags.get(name)?
+	flag := flags.get(name) ?
 	return flag.get_bool()
 }
 
@@ -51,7 +51,7 @@ pub fn (flag Flag) get_int() ?int {
 }
 
 pub fn (flags []Flag) get_int(name string) ?int {
-	flag := flags.get(name)?
+	flag := flags.get(name) ?
 	return flag.get_int()
 }
 
@@ -70,7 +70,7 @@ pub fn (flag Flag) get_float() ?f64 {
 }
 
 pub fn (flags []Flag) get_float(name string) ?f64 {
-	flag := flags.get(name)?
+	flag := flags.get(name) ?
 	return flag.get_float()
 }
 
@@ -89,7 +89,7 @@ pub fn (flag Flag) get_string() ?string {
 }
 
 pub fn (flags []Flag) get_string(name string) ?string {
-	flag := flags.get(name)?
+	flag := flags.get(name) ?
 	return flag.get_string()
 }
 
@@ -104,10 +104,10 @@ pub fn (flags []Flag) get_string_or(name, or_value string) string {
 fn (mut flag Flag) parse(args []string, with_abbrev bool) ?[]string {
 	if flag.matches(args, with_abbrev) {
 		if flag.flag == .bool {
-			new_args := flag.parse_bool(args)?
+			new_args := flag.parse_bool(args) ?
 			return new_args
 		} else {
-			new_args := flag.parse_raw(args)?
+			new_args := flag.parse_raw(args) ?
 			return new_args
 		}
 	} else {

--- a/vlib/cli/flag.v
+++ b/vlib/cli/flag.v
@@ -26,7 +26,7 @@ pub fn (flags []Flag) get_all_found() []Flag {
 
 pub fn (flag Flag) get_bool() ?bool {
 	if flag.flag != .bool {
-		return error('Invalid flag type')
+		return error('$flag.name: Invalid flag type `$flag.flag`, expected `bool`')
 	}
 	return flag.value == 'true'
 }
@@ -45,7 +45,7 @@ pub fn (flags []Flag) get_bool_or(name string, or_value bool) bool {
 
 pub fn (flag Flag) get_int() ?int {
 	if flag.flag != .int {
-		return error('Invalid flag type')
+		return error('$flag.name: Invalid flag type `$flag.flag`, expected `int`')
 	}
 	return flag.value.int()
 }
@@ -64,7 +64,7 @@ pub fn (flags []Flag) get_int_or(name string, or_value int) int {
 
 pub fn (flag Flag) get_float() ?f64 {
 	if flag.flag != .float {
-		return error('Invalid flag type')
+		return error('$flag.name: Invalid flag type `$flag.flag`, expected `float`')
 	}
 	return flag.value.f64()
 }
@@ -83,7 +83,7 @@ pub fn (flags []Flag) get_float_or(name string, or_value f64) f64 {
 
 pub fn (flag Flag) get_string() ?string {
 	if flag.flag != .string {
-		return error('Invalid flag type')
+		return error('$flag.name: Invalid flag type `$flag.flag`, expected `string`')
 	}
 	return flag.value
 }
@@ -159,7 +159,7 @@ fn (flags []Flag) get(name string) ?Flag {
 			return flag
 		}
 	}
-	return error('Flag `$name` not found')
+	return error('Flag `$name` not found in $flags')
 }
 
 fn (flags []Flag) contains(name string) bool {

--- a/vlib/cli/help.v
+++ b/vlib/cli/help.v
@@ -63,11 +63,12 @@ fn (cmd Command) help_message() string {
 	if cmd.commands.len > 0 {
 		help += ' [commands]'
 	}
-	for i in 0 .. cmd.required_args {
-		help += ' <arg$i>'
-	}
 	if cmd.usage.len > 0 {
 		help += ' $cmd.usage'
+	} else {
+		for i in 0 .. cmd.required_args {
+			help += ' <arg$i>'
+		}
 	}
 	help += '\n\n'
 	if cmd.description != '' {

--- a/vlib/cli/help.v
+++ b/vlib/cli/help.v
@@ -70,9 +70,9 @@ fn (cmd Command) help_message() string {
 			help += ' <arg$i>'
 		}
 	}
-	help += '\n\n'
+	help += '\n'
 	if cmd.description != '' {
-		help += '$cmd.description\n\n'
+		help += '\n$cmd.description\n'
 	}
 	mut abbrev_len := 0
 	mut name_len := min_description_indent_len
@@ -93,7 +93,7 @@ fn (cmd Command) help_message() string {
 		}
 	}
 	if cmd.flags.len > 0 {
-		help += 'Flags:\n'
+		help += '\nFlags:\n'
 		for flag in cmd.flags {
 			mut flag_name := ''
 			if flag.abbrev != '' && cmd.flags.have_abbrev() {
@@ -114,17 +114,15 @@ fn (cmd Command) help_message() string {
 			help += '$base_indent$flag_name$description_indent' + pretty_description(flag.description +
 				required, base_indent_len + name_len) + '\n'
 		}
-		help += '\n'
 	}
 	if cmd.commands.len > 0 {
-		help += 'Commands:\n'
+		help += '\nCommands:\n'
 		for command in cmd.commands {
 			base_indent := ' '.repeat(base_indent_len)
 			description_indent := ' '.repeat(name_len - command.name.len)
 			help += '$base_indent$command.name$description_indent' + pretty_description(command.description, name_len) +
 				'\n'
 		}
-		help += '\n'
 	}
 	return help
 }


### PR DESCRIPTION
- Providing custom `usage` for commands with required args will overwrite the generic args usage
    `... <arg0> <arg1>` --> `... <custom> <usage> <...>`
- cli example: allow ISO 639-1 (two-char) language shortcodes
- Remove trailing new lines in generated help message
- Increase the helpfulness of a few error messages