### PR TITLE
parser: implement parsing of `select` block 

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -12,7 +12,7 @@ pub type TypeDecl = AliasTypeDecl | FnTypeDecl | SumTypeDecl
 pub type Expr = AnonFn | ArrayInit | AsCast | Assoc | BoolLiteral | CallExpr | CastExpr |
 	ChanInit | CharLiteral | Comment | ComptimeCall | ConcatExpr | EnumVal | FloatLiteral |
 	Ident | IfExpr | IfGuardExpr | IndexExpr | InfixExpr | IntegerLiteral | Likely | LockExpr |
-	MapInit | MatchExpr | None | OrExpr | ParExpr | PostfixExpr | PrefixExpr | RangeExpr |
+	MapInit | MatchExpr | None | OrExpr | ParExpr | PostfixExpr | PrefixExpr | RangeExpr | SelectExpr |
 	SelectorExpr | SizeOf | SqlExpr | StringInterLiteral | StringLiteral | StructInit | Type |
 	TypeOf | UnsafeExpr
 
@@ -533,6 +533,27 @@ pub:
 	pos           token.Position
 	comment       Comment // comment above `xxx {`
 	is_else       bool
+	post_comments []Comment
+}
+
+pub struct SelectExpr {
+pub:
+	branches      []SelectBranch
+	pos           token.Position
+pub mut:
+	is_expr       bool // returns a value
+	return_type   table.Type
+	expected_type table.Type // for debugging only
+}
+
+pub struct SelectBranch {
+pub:
+	stmt          Stmt // `a := <-ch` or `ch <- a`
+	stmts         []Stmt // right side
+	pos           token.Position
+	comment       Comment // comment above `select {`
+	is_else       bool
+	is_timeout    bool
 	post_comments []Comment
 }
 
@@ -1062,6 +1083,9 @@ pub fn (expr Expr) position() token.Position {
 			return expr.pos
 		}
 		// ast.ParExpr { }
+		SelectExpr {
+			return expr.pos
+		}
 		SelectorExpr {
 			return expr.pos
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2641,6 +2641,10 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 			// never happens
 			return table.void_type
 		}
+		ast.SelectExpr {
+			// TODO: to be implemented
+			return table.void_type
+		}
 		ast.SelectorExpr {
 			return c.selector_expr(mut node)
 		}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -953,6 +953,9 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 			f.write('..')
 			f.expr(node.high)
 		}
+		ast.SelectExpr {
+			// TODO: implement this
+		}
 		ast.SelectorExpr {
 			f.expr(node.expr)
 			f.write('.')

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2133,6 +2133,9 @@ fn (mut g Gen) expr(node ast.Expr) {
 		ast.RangeExpr {
 			// Only used in IndexExpr
 		}
+		ast.SelectExpr {
+			// TODO: to be implemented
+		}
 		ast.SizeOf {
 			if node.is_type {
 				node_typ := g.unwrap_generic(node.typ)

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -619,6 +619,9 @@ fn (mut g JsGen) expr(node ast.Expr) {
 		ast.RangeExpr {
 			// Only used in IndexExpr, requires index type info
 		}
+		ast.SelectExpr {
+			// TODO: to be implemented
+		}
 		ast.SelectorExpr {
 			g.gen_selector_expr(node)
 		}

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -377,7 +377,7 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 								p.error_with_pos('select key: `<-` operator expected', expr.pos)
 							}
 						} else {
-							p.error_with_pos(arrow_expect_error, stmt.right[0].position())
+							p.error_with_pos('select key: receive expression expected', stmt.right[0].position())
 						}
 					}
 				}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -859,7 +859,7 @@ fn (mut p Parser) parse_multi_expr(is_top_level bool) ast.Stmt {
 	}
 	if p.tok.kind in [.assign, .decl_assign] || p.tok.kind.is_assign() {
 		return p.partial_assign_stmt(left, left_comments)
-	} else if is_top_level && tok.kind !in [.key_if, .key_match, .key_lock, .key_rlock] &&
+	} else if is_top_level && tok.kind !in [.key_if, .key_match, .key_lock, .key_rlock, .key_select] &&
 		left0 !is ast.CallExpr && left0 !is ast.PostfixExpr && !(left0 is ast.InfixExpr &&
 		(left0 as ast.InfixExpr).op in [.left_shift, .arrow]) && left0 !is ast.ComptimeCall {
 		p.error_with_pos('expression evaluated but not used', left0.position())

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -859,8 +859,9 @@ fn (mut p Parser) parse_multi_expr(is_top_level bool) ast.Stmt {
 	}
 	if p.tok.kind in [.assign, .decl_assign] || p.tok.kind.is_assign() {
 		return p.partial_assign_stmt(left, left_comments)
-	} else if is_top_level && tok.kind !in [.key_if, .key_match, .key_lock, .key_rlock, .key_select] &&
-		left0 !is ast.CallExpr && left0 !is ast.PostfixExpr && !(left0 is ast.InfixExpr &&
+	} else if is_top_level && tok.kind !in
+		[.key_if, .key_match, .key_lock, .key_rlock, .key_select] && left0 !is ast.CallExpr &&
+		left0 !is ast.PostfixExpr && !(left0 is ast.InfixExpr &&
 		(left0 as ast.InfixExpr).op in [.left_shift, .arrow]) && left0 !is ast.ComptimeCall {
 		p.error_with_pos('expression evaluated but not used', left0.position())
 	}

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -74,6 +74,9 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 		.key_match {
 			node = p.match_expr()
 		}
+		.key_select {
+			node = p.select_expr()
+		}
 		.number {
 			node = p.parse_number_literal()
 		}

--- a/vlib/v/parser/tests/select_bad_key_1.out
+++ b/vlib/v/parser/tests/select_bad_key_1.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/select_bad_key_1.vv:39:8: error: select key: receive expression expected
+   37 | fn f3_bad(ch1 chan St) {
+   38 |     select {
+   39 |         b := 17 {
+      |              ~~
+   40 |             println(b)
+   41 |         }

--- a/vlib/v/parser/tests/select_bad_key_1.vv
+++ b/vlib/v/parser/tests/select_bad_key_1.vv
@@ -1,0 +1,47 @@
+import time
+
+struct St {
+	a int
+}
+
+fn f1_good(ch1 chan St, ch2 chan int, ch3 chan int) {
+	mut a := 5
+	select {
+		a = <- ch3 {
+			println(a)
+		}
+		b := <- ch1 {
+			println(b.a)
+		}
+		ch1 <- a {
+			a++
+		}
+		> 50 * time.millisecond {
+			println('timeout')
+		}
+	}
+	println('done')
+}
+
+fn f2_good(ch1 chan St) {
+	select {
+		b := <- ch1 {
+			println(b)
+		}
+		else {
+			println('no channel ready')
+		}
+	}
+}
+
+fn f3_bad(ch1 chan St) {
+	select {
+		b := 17 {
+			println(b)
+		}
+	}
+}
+
+fn main() {}
+
+			

--- a/vlib/v/parser/tests/select_bad_key_2.out
+++ b/vlib/v/parser/tests/select_bad_key_2.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/select_bad_key_2.vv:7:5: error: select key: `<-` operator expected
+    5 |             println(b)
+    6 |         }
+    7 |         a + 7 {
+      |           ^
+    8 |             println("shouldn't get here")
+    9 |         }

--- a/vlib/v/parser/tests/select_bad_key_2.vv
+++ b/vlib/v/parser/tests/select_bad_key_2.vv
@@ -1,0 +1,13 @@
+fn f3_bad(ch1 chan int) {
+	a := 5
+	select {
+		b := <-ch1 {
+			println(b)
+		}
+		a + 7 {
+			println("shouldn't get here")
+		}
+	}
+}
+
+fn main() {}

--- a/vlib/v/parser/tests/select_bad_key_3.out
+++ b/vlib/v/parser/tests/select_bad_key_3.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/select_bad_key_3.vv:7:3: error: select key: send expression (`ch <- x`) expected
+    5 |             println(b)
+    6 |         }
+    7 |         println(7) {
+      |         ~~~~~~~~~~
+    8 |             println("shouldn't get here")
+    9 |         }

--- a/vlib/v/parser/tests/select_bad_key_3.vv
+++ b/vlib/v/parser/tests/select_bad_key_3.vv
@@ -1,0 +1,13 @@
+fn f3_bad(ch1 chan int) {
+	a := 5
+	select {
+		b := <-ch1 {
+			println(b)
+		}
+		println(7) {
+			println("shouldn't get here")
+		}
+	}
+}
+
+fn main() {}

--- a/vlib/v/parser/tests/select_bad_key_4.out
+++ b/vlib/v/parser/tests/select_bad_key_4.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/select_bad_key_4.vv:7:8: error: select key: `<-` operator expected
+    5 |             println(b)
+    6 |         }
+    7 |         c := -a {
+      |              ^
+    8 |             println("shouldn't get here")
+    9 |         }

--- a/vlib/v/parser/tests/select_bad_key_4.vv
+++ b/vlib/v/parser/tests/select_bad_key_4.vv
@@ -1,0 +1,13 @@
+fn f3_bad(ch1 chan int) {
+	mut a := 5
+	select {
+		a = <-ch1 {
+			println(b)
+		}
+		c := -a {
+			println("shouldn't get here")
+		}
+	}
+}
+
+fn main() {}

--- a/vlib/v/parser/tests/select_else_1.out
+++ b/vlib/v/parser/tests/select_else_1.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/select_else_1.vv:12:3: error: `else` and timeout `> t` are mutually exclusive `select` keys
+   10 |             println("shouldn't get here")
+   11 |         }
+   12 |         > 30 * time.millisecond {
+      |         ^
+   13 |             println('bad')
+   14 |         }

--- a/vlib/v/parser/tests/select_else_1.vv
+++ b/vlib/v/parser/tests/select_else_1.vv
@@ -1,0 +1,18 @@
+import time
+
+fn f3_bad(ch1 chan int) {
+	a := 5
+	select {
+		b := <-ch1 {
+			println(b)
+		}
+		else {
+			println("shouldn't get here")
+		}
+		> 30 * time.millisecond {
+			println('bad')
+		}
+	}
+}
+
+fn main() {}

--- a/vlib/v/parser/tests/select_else_2.out
+++ b/vlib/v/parser/tests/select_else_2.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/select_else_2.vv:12:3: error: timeout `> t` and `else` are mutually exclusive `select` keys
+   10 |             println('bad')
+   11 |         }
+   12 |         else {
+      |         ~~~~
+   13 |             println("shouldn't get here")
+   14 |         }

--- a/vlib/v/parser/tests/select_else_2.vv
+++ b/vlib/v/parser/tests/select_else_2.vv
@@ -1,0 +1,18 @@
+import time
+
+fn f3_bad(ch1 chan int) {
+	a := 5
+	select {
+		b := <-ch1 {
+			println(b)
+		}
+		> 30 * time.millisecond {
+			println('bad')
+		}
+		else {
+			println("shouldn't get here")
+		}
+	}
+}
+
+fn main() {}


### PR DESCRIPTION
This PR enables parsing `select` blocks like
```v
select {
    a = <- ch3 {
        println(a)
    }
    b := <- ch1 {
        println(b.a)
    }
    ch1 <- a {
        a++
    }
    > 50 * time.millisecond {
        println('timeout')
    }
}
```
The timeout branch is optional. Using an `else { ... }` branch instead of a timeout is supported, too (which stands for "timeout 0s" as in Go).
So far only the parser part is implemented, but a couple of checks are already done.
Testcases are added for most of those checks.
The checker part and the code generation will follow soon.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
