### PR TITLE
gen: fixes c warning by appending U after unsigned integers

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1963,7 +1963,8 @@ fn (mut g Gen) expr(node ast.Expr) {
 				// }
 				// g.write(')(')
 				g.expr(node.expr)
-				if node.expr is ast.IntegerLiteral && node.typ in [table.u64_type, table.u32_type, table.u16_type] {
+				if node.expr is ast.IntegerLiteral &&
+					node.typ in [table.u64_type, table.u32_type, table.u16_type] {
 					g.write('U')
 				}
 				g.write('))')

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1963,6 +1963,9 @@ fn (mut g Gen) expr(node ast.Expr) {
 				// }
 				// g.write(')(')
 				g.expr(node.expr)
+				if node.expr is ast.IntegerLiteral && node.typ in [table.u64_type, table.u32_type, table.u16_type] {
+					g.write('U')
+				}
 				g.write('))')
 			}
 		}


### PR DESCRIPTION
This removes this warning:
```
abc.c:10272:38: warning: integer constant is so large that it is unsigned
  _const_math__bits__max_u64 = ((u64)(18446744073709551615));
```