### PR TITLE
vlib: fix incompatible pointer

### DIFF
--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -70,7 +70,7 @@ fn restore_codepage() {
 
 fn builtin_init() {
 	g_original_codepage = C.GetConsoleOutputCP()
-	C.SetConsoleOutputCP(C.CP_UTF8)	
+	C.SetConsoleOutputCP(C.CP_UTF8)
 	C.atexit(restore_codepage)
 	if is_atty(1) > 0 {
 		C.SetConsoleMode(C.GetStdHandle(C.STD_OUTPUT_HANDLE), C.ENABLE_PROCESSED_OUTPUT | 0x0004) // enable_virtual_terminal_processing
@@ -201,9 +201,9 @@ pub:
 
 type VectoredExceptionHandler fn(&ExceptionPointers)u32
 
-fn C.AddVectoredExceptionHandler(u32, VectoredExceptionHandler)
+fn C.AddVectoredExceptionHandler(u32, C.PVECTORED_EXCEPTION_HANDLER)
 fn add_vectored_exception_handler(handler VectoredExceptionHandler) {
-	C.AddVectoredExceptionHandler(1, handler)
+	C.AddVectoredExceptionHandler(1, C.PVECTORED_EXCEPTION_HANDLER(handler))
 }
 
 [windows_stdcall]

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -345,7 +345,7 @@ pub type VectoredExceptionHandler fn(&ExceptionPointers)u32
 // fn C.AddVectoredExceptionHandler(u32, VectoredExceptionHandler)
 
 pub fn add_vectored_exception_handler(first bool, handler VectoredExceptionHandler) {
-	C.AddVectoredExceptionHandler(u32(first), handler)
+	C.AddVectoredExceptionHandler(u32(first), C.PVECTORED_EXCEPTION_HANDLER(handler))
 }
 
 // this is defined in builtin_windows.c.v in builtin


### PR DESCRIPTION
This fixes:
```
abc.c: In function 'add_vectored_exception_handler':
abc.c:5567:33: warning: passing argument 2 of 'AddVectoredExceptionHandler' from incompatible pointer type [-Wincompatible-pointer-types]
  AddVectoredExceptionHandler(1, handler);
                                 ^~~~~~~
```

It fixes the warning, but we should raise an error to not compile the code if it results in a C warning.

Any idea how to implement it?