### PR TITLE
checker: fix error declaration on a value

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1846,7 +1846,7 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 			}
 			else {
 				if is_decl {
-					c.error('unexpected expression `${typeof(left)}`', left.position())
+					c.error('non-name `$left` on left side of `:=`', left.position())
 				}
 			}
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1844,7 +1844,11 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 						assign_stmt.pos)
 				}
 			}
-			else {}
+			else {
+				if is_decl {
+					c.error('unexpected expression `${typeof(left)}`', left.position())
+				}
+			}
 		}
 		left_type_unwrapped := c.unwrap_generic(left_type)
 		right_type_unwrapped := c.unwrap_generic(right_type)


### PR DESCRIPTION
## Additions:
Fix error on declaring on a value (`1 := 1`) to look like the error when trying to assign on a value (`1 = 1`)

## Notes:
Fixes #6389 

## Examples:
```
1 := 1
"a" := 1
```
Gives :
```
test.v:1:1: error: non-name `1` on left side of `:=`
    1 | 1 := 1
      | ^
    2 | "a" := 1
test.v:2:1: error: non-name `"a"` on left side of `:=`
    1 | 1 := 1
    2 | "a" := 1
      | ~~~
``` 