### PR TITLE
checker: prompt error on script expression while inside a file with main

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -180,6 +180,9 @@ fn (mut c Checker) check_file_in_main(file ast.File) bool {
 			}
 			ast.FnDecl {
 				if stmt.name == 'main.main' {
+					if has_main_fn {
+						c.error('function `main` is already defined', stmt.pos)
+					}
 					has_main_fn = true
 					if stmt.is_pub {
 						c.error('function `main` cannot be declared public', stmt.pos)

--- a/vlib/v/checker/tests/main_and_script_err.out
+++ b/vlib/v/checker/tests/main_and_script_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/main_and_script_err.vv:1:1: error: function `main` is already defined
+    1 | fn main() {
+      | ^
+    2 |     println('main')
+    3 | }

--- a/vlib/v/checker/tests/main_and_script_err.vv
+++ b/vlib/v/checker/tests/main_and_script_err.vv
@@ -1,0 +1,4 @@
+fn main() {
+	println('main')
+}
+println('out')


### PR DESCRIPTION
## Additions:
Have an error when there are script expressions and a main function in the same file

## Notes:
Fixes #6383 
 
## Examples:

```
fn main() {
	println('in main')
}
println('outside main')
```

Gives
```
test.v:1:1: error: function `main` is already defined
    1 | fn main() {
      | ^
    2 |     println('in main')
    3 | }
```