### PR TITLE
gen: bytes array print not ending prematurely when null byte

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -384,7 +384,7 @@ pub fn (b byte) str() string {
 }
 
 pub fn (b byte) str_escaped() string {
-	if b >= 20 {
+	if b >= 32 {
 		return b.str()
 	}
 	if (b > 0 && b < 7) || (b > 13 && b < 32) {

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -384,33 +384,17 @@ pub fn (b byte) str() string {
 }
 
 pub fn (b byte) str_escaped() string {
-	if b >= 32 {
-		return b.str()
-	}
-	if (b > 0 && b < 7) || (b > 13 && b < 32) {
-		return '0x' + b.hex()
-	}
-	mut str := string{
-		str: malloc(5)
-		len: 4
-	}
-	char := match b {
-		0 { `0` }
-		7 { `a` }
-		8 { `b` }
-		9 { `t` }
-		10 { `n` }
-		11 { `v` }
-		12 { `f` }
-		13 { `r` }
-		else { `0` }
-	}
-	unsafe {
-		str.str[0] = `\``
-		str.str[1] = `\\`
-		str.str[2] = char
-		str.str[3] = `\``
-		str.str[4] = `\0`
+	str := match b {
+		0 { '`\\' + '0`' } // Bug is preventing \\0 in a literal
+		7 { '`\\a`' }
+		8 { '`\\b`' }
+		9 { '`\\t`' }
+		10 { '`\\n`' }
+		11 { '`\\v`' }
+		12 { '`\\f`' }
+		13 { '`\\r`' }
+		32...126 { b.str() }
+		else { '0x' + b.hex() }
 	}
 	return str
 }

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -383,6 +383,38 @@ pub fn (b byte) str() string {
 	return str
 }
 
+pub fn (b byte) str_escaped() string {
+	if b >= 20 {
+		return b.str()
+	}
+	if (b > 0 && b < 7) || (b > 13 && b < 32) {
+		return '0x' + b.hex()
+	}
+	mut str := string{
+		str: malloc(5)
+		len: 4
+	}
+	char := match b {
+		0 { `0` }
+		7 { `a` }
+		8 { `b` }
+		9 { `t` }
+		10 { `n` }
+		11 { `v` }
+		12 { `f` }
+		13 { `r` }
+		else { `0` }
+	}
+	unsafe {
+		str.str[0] = `\``
+		str.str[1] = `\\`
+		str.str[2] = char
+		str.str[3] = `\``
+		str.str[4] = `\0`
+	}
+	return str
+}
+
 // TODO generic
 pub fn (a []byte) contains(val byte) bool {
 	for aa in a {

--- a/vlib/v/gen/auto_str_methods.v
+++ b/vlib/v/gen/auto_str_methods.v
@@ -96,6 +96,9 @@ fn (mut g Gen) gen_str_for_array(info table.Array, styp, str_fn_name string) {
 	} else if sym.kind in [.f32, .f64] {
 		g.auto_str_funcs.writeln('\t\tstring x = _STR("%g", 1, it);')
 	} else {
+		if sym.kind == .byte {
+			g.auto_str_funcs.writeln('\t\tif (it == 0) break;')
+		}
 		// There is a custom .str() method, so use it.
 		// NB: we need to take account of whether the user has defined
 		// `fn (x T) str() {` or `fn (x &T) str() {`, and convert accordingly

--- a/vlib/v/gen/auto_str_methods.v
+++ b/vlib/v/gen/auto_str_methods.v
@@ -74,6 +74,9 @@ fn (mut g Gen) gen_str_for_array(info table.Array, styp, str_fn_name string) {
 	if sym_has_str_method {
 		elem_str_fn_name = if is_elem_ptr { field_styp.replace('*', '') + '_str' } else { field_styp +
 				'_str' }
+		if sym.kind == .byte {
+			elem_str_fn_name = elem_str_fn_name + '_escaped'
+		}
 	} else {
 		elem_str_fn_name = styp_to_str_fn_name(field_styp)
 	}
@@ -96,9 +99,6 @@ fn (mut g Gen) gen_str_for_array(info table.Array, styp, str_fn_name string) {
 	} else if sym.kind in [.f32, .f64] {
 		g.auto_str_funcs.writeln('\t\tstring x = _STR("%g", 1, it);')
 	} else {
-		if sym.kind == .byte {
-			g.auto_str_funcs.writeln('\t\tif (it == 0) break;')
-		}
 		// There is a custom .str() method, so use it.
 		// NB: we need to take account of whether the user has defined
 		// `fn (x T) str() {` or `fn (x &T) str() {`, and convert accordingly

--- a/vlib/v/tests/array_to_string_test.v
+++ b/vlib/v/tests/array_to_string_test.v
@@ -14,8 +14,8 @@ fn test_array_to_string_conversion() {
 	e := [i64(1), 2, 3]
 	assert e.str() == '[1, 2, 3]'
 
-	f := [byte(66), 10, 13, 5, 18]
-	assert f.str() == '[B, `\\n`, `\\r`, 0x05, 0x12]'
+	f := [byte(66), 32, 126, 10, 13, 5, 18, 127, 255]
+	assert f.str() == '[B,  , ~, `\\n`, `\\r`, 0x05, 0x12, 0x7f, 0xff]'
 }
 
 fn test_interpolation_array_to_string() {

--- a/vlib/v/tests/array_to_string_test.v
+++ b/vlib/v/tests/array_to_string_test.v
@@ -13,6 +13,9 @@ fn test_array_to_string_conversion() {
 
 	e := [i64(1), 2, 3]
 	assert e.str() == '[1, 2, 3]'
+
+	f := [byte(66), 10, 13, 5, 18]
+	assert f.str() == '[B, `\\n`, `\\r`, 0x05, 0x12]'
 }
 
 fn test_interpolation_array_to_string() {


### PR DESCRIPTION
## Additions:
End correctly a byte array when a null byte is present
Test for this use case

## Examples:
```
println([byte(66), 10, 13, 5, 18])
```

Gives
```
[B, `\n`, `\r`, 0x05, 0x12]
```

## Notes:
Fixes #6346 

**Might need to chose a community approved way of doing it**
We might as well print something like : `[A, '\0', B]` or `[A, , B]`.
Open to discussions on what is best to solve this issue :speech_balloon: 
