### PR TITLE
parser: fix nested amp

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1925,6 +1925,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 				// &Foo(0) => ((Foo*)0)
 				g.out.go_back(1)
 			}
+			g.is_amp = false
 			sym := g.table.get_type_symbol(node.typ)
 			if sym.kind == .string && !node.typ.is_ptr() {
 				// `string(x)` needs `tos()`, but not `&string(x)
@@ -1954,14 +1955,8 @@ fn (mut g Gen) expr(node ast.Expr) {
 				g.expr(node.expr)
 				g.write('))')
 			} else {
-				// styp := g.table.Type_to_str(it.typ)
 				styp := g.typ(node.typ)
-				// g.write('($styp)(')
 				g.write('(($styp)(')
-				// if g.is_amp {
-				// g.write('*')
-				// }
-				// g.write(')(')
 				g.expr(node.expr)
 				if node.expr is ast.IntegerLiteral &&
 					node.typ in [table.u64_type, table.u32_type, table.u16_type] {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1056,6 +1056,10 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 				// Handle `&Foo(0)`
 				to_typ = to_typ.to_ptr()
 			}
+			// this prevents inner casts to also have an `&`
+			// example: &Foo(malloc(int(num)))
+			// without the next line int would result in int*
+			p.is_amp = false
 			p.check(.lpar)
 			mut expr := ast.Expr{}
 			mut arg := ast.Expr{}

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -325,7 +325,7 @@ fn (mut p Parser) prefix_expr() ast.PrefixExpr {
 	p.next()
 	mut right := if op == .minus { p.expr(token.Precedence.call) } else { p.expr(token.Precedence.prefix) }
 	p.is_amp = false
-	if mut right is ast.CastExpr {
+	if right is ast.CastExpr {
 		right.in_prexpr = true
 	}
 	mut or_stmts := []ast.Stmt{}


### PR DESCRIPTION
this resulted in:
```
&Foo(malloc(int(0)))
```

before:
```
((Foo*)malloc((int*)(0)))
```

after:
```
((Foo*)malloc((int)(0)))
```