### PR TITLE
scanner: allow escape on null character

### DIFF
--- a/vlib/v/checker/tests/string_char_null_err.out
+++ b/vlib/v/checker/tests/string_char_null_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/string_char_null_err.vv:2:31: error: 0 character in a string literal
+    1 | fn main() {
+    2 |     println('Null character: \0')
+      |                               ^
+    3 | }

--- a/vlib/v/checker/tests/string_char_null_err.vv
+++ b/vlib/v/checker/tests/string_char_null_err.vv
@@ -1,0 +1,3 @@
+fn main() {
+    println('Null character: \0')
+}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1216,14 +1216,15 @@ fn (mut s Scanner) ident_string() string {
 		}
 		// Don't allow \0
 		if c == `0` && s.pos > 2 && s.text[s.pos - 1] == slash {
-			if s.pos < s.text.len - 1 && s.text[s.pos + 1].is_digit() {
+			if (s.pos < s.text.len - 1 && s.text[s.pos + 1].is_digit()) || s.count_symbol_before(s.pos - 1, slash) % 2 == 0 {
 			} else if !is_cstr {
 				s.error('0 character in a string literal')
 			}
 		}
 		// Don't allow \x00
 		if c == `0` && s.pos > 5 && s.expect('\\x0', s.pos - 3) {
-			if !is_cstr {
+			if s.count_symbol_before(s.pos - 3, slash) % 2 == 0 {
+			} else if !is_cstr {
 				s.error('0 character in a string literal')
 			}
 		}


### PR DESCRIPTION
## Additions:
Allow escaping a null character \0
Test for this use case

## Notes:
Fixes #6403 

## Examples:
```
println('Null character: \\0')
```

Gives:
```
Null character \0
```