### PR TITLE
gen: removes struct name from list which shouldn't be initialized

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3445,9 +3445,17 @@ fn (mut g Gen) go_back_out(n int) {
 	g.out.go_back(n)
 }
 
+const (
+	skip_struct_init = ['strconv__ftoa__Uf32', 'strconv__ftoa__Uf64', 'struct stat', 'struct addrinfo']
+)
+
 fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 	styp := g.typ(struct_init.typ)
 	mut shared_styp := '' // only needed for shared &St{...
+	if styp in skip_struct_init {
+		g.go_back_out(3)
+		return
+	}
 	sym := g.table.get_final_type_symbol(struct_init.typ)
 	is_amp := g.is_amp
 	is_multiline := struct_init.fields.len > 5

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3446,9 +3446,7 @@ fn (mut g Gen) go_back_out(n int) {
 }
 
 const (
-	skip_struct_init = ['strconv__ftoa__Uf32', 'strconv__ftoa__Uf64', 'struct stat',
-		'struct addrinfo',
-	]
+	skip_struct_init = ['strconv__ftoa__Uf32', 'strconv__ftoa__Uf64', 'struct stat', 'struct addrinfo']
 )
 
 fn (mut g Gen) struct_init(struct_init ast.StructInit) {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3453,7 +3453,7 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 	styp := g.typ(struct_init.typ)
 	mut shared_styp := '' // only needed for shared &St{...
 	if styp in skip_struct_init {
-		// needed for c++ compilers    
+		// needed for c++ compilers
 		g.go_back_out(3)
 		return
 	}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3446,7 +3446,7 @@ fn (mut g Gen) go_back_out(n int) {
 }
 
 const (
-	skip_struct_init = ['strconv__ftoa__Uf32', 'strconv__ftoa__Uf64', 'strconv__Float64u', 'struct stat',
+	skip_struct_init = ['strconv__ftoa__Uf32', 'strconv__ftoa__Uf64', 'struct stat',
 		'struct addrinfo',
 	]
 )

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3446,13 +3446,14 @@ fn (mut g Gen) go_back_out(n int) {
 }
 
 const (
-	skip_struct_init = ['strconv__ftoa__Uf32', 'strconv__ftoa__Uf64', 'struct stat', 'struct addrinfo']
+	skip_struct_init = ['struct stat', 'struct addrinfo']
 )
 
 fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 	styp := g.typ(struct_init.typ)
 	mut shared_styp := '' // only needed for shared &St{...
 	if styp in skip_struct_init {
+		// needed for c++ compilers    
 		g.go_back_out(3)
 		return
 	}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3445,17 +3445,9 @@ fn (mut g Gen) go_back_out(n int) {
 	g.out.go_back(n)
 }
 
-const (
-	skip_struct_init = ['strconv__ftoa__Uf32', 'strconv__ftoa__Uf64', 'struct stat', 'struct addrinfo']
-)
-
 fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 	styp := g.typ(struct_init.typ)
 	mut shared_styp := '' // only needed for shared &St{...
-	if styp in skip_struct_init {
-		g.go_back_out(3)
-		return
-	}
 	sym := g.table.get_final_type_symbol(struct_init.typ)
 	is_amp := g.is_amp
 	is_multiline := struct_init.fields.len > 5


### PR DESCRIPTION
Fixes:
```
C:\Users\dd\AppData\Local\Temp\v\abc.tmp.c:2513:23: warning: 'tmp_mul.f' may be used uninitialized in this function [-Wmaybe-uninitialized]
    f.f = f.f * tmp_mul.f;
                ~~~~~~~^~
```

![image](https://user-images.githubusercontent.com/30751516/93594255-cbb11b80-f9b5-11ea-9e13-4ad8aa3d3d05.png)
generated:
![image](https://user-images.githubusercontent.com/30751516/93594271-d10e6600-f9b5-11ea-989b-fe73ea4e569d.png)
