### PR TITLE
parser: fix error about multiple modules showing when eof

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1523,7 +1523,7 @@ fn (mut p Parser) import_stmt() ast.Import {
 	}
 	pos_t := p.tok.position()
 	if import_pos.line_nr == pos_t.line_nr {
-		if p.tok.kind != .lcbr {
+		if p.tok.kind != .lcbr && p.tok.kind != .eof {
 			p.error_with_pos('cannot import multiple modules at a time', pos_t)
 		}
 	}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1523,7 +1523,7 @@ fn (mut p Parser) import_stmt() ast.Import {
 	}
 	pos_t := p.tok.position()
 	if import_pos.line_nr == pos_t.line_nr {
-		if p.tok.kind != .lcbr && p.tok.kind != .eof {
+		if p.tok.kind !in [.lcbr, .eof] {
 			p.error_with_pos('cannot import multiple modules at a time', pos_t)
 		}
 	}


### PR DESCRIPTION
**Additions**:
Fix the error showing an error about multiple imports when having a single line with an import ending in EOF

**Notes**:
Fixes #6422 