### PR TITLE
checker: check if imported variable is public

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2363,7 +2363,7 @@ fn (mut c Checker) import_stmt(imp ast.Import) {
 		}
 		if sym.kind == .type_ {
 			if type_sym := c.table.find_type(name) {
-				if type_sym.kind == .placeholder {
+				if type_sym.kind == .placeholder || !type_sym.is_public {
 					c.error('module `$imp.mod` has no public type `$sym.name\{}`', sym.pos)
 				}
 			} else {


### PR DESCRIPTION
**Additions**:
Check if the explicitely imported variable is public

**Notes**:
Partial fix of #6420
Partial fix of #6421