### PR TITLE
scanner: add check for `!is_raw` for null `\0`

### DIFF
--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -725,6 +725,10 @@ fn test_raw() {
 	println(lines)
 	assert lines.len == 1
 	println('raw string: "$raw"')
+
+	raw2 := r'Hello V\0'
+	assert raw2[7] == `\\`
+	assert raw2[8] == `0`
 }
 
 fn test_raw_with_quotes() {

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1217,14 +1217,14 @@ fn (mut s Scanner) ident_string() string {
 		// Don't allow \0
 		if c == `0` && s.pos > 2 && s.text[s.pos - 1] == slash {
 			if (s.pos < s.text.len - 1 && s.text[s.pos + 1].is_digit()) || s.count_symbol_before(s.pos - 1, slash) % 2 == 0 {
-			} else if !is_cstr {
+			} else if !is_cstr && !is_raw {
 				s.error('0 character in a string literal')
 			}
 		}
 		// Don't allow \x00
 		if c == `0` && s.pos > 5 && s.expect('\\x0', s.pos - 3) {
 			if s.count_symbol_before(s.pos - 3, slash) % 2 == 0 {
-			} else if !is_cstr {
+			} else if !is_cstr && !is_raw {
 				s.error('0 character in a string literal')
 			}
 		}


### PR DESCRIPTION
This works now

```
>>> r'hello\0'
hello\0
>>> exit
```

Fixes https://github.com/vlang/v/issues/6426