### PR TITLE
symlink: remove broken defer

### DIFF
--- a/cmd/tools/vsymlink.v
+++ b/cmd/tools/vsymlink.v
@@ -80,10 +80,11 @@ fn setup_symlink_windows(vexe string){
 			warn_and_exit(err)
 			return
 		}
-		defer {
-			C.RegCloseKey(reg_sys_env_handle)
-		}
-
+		// TODO: Fix defers inside ifs
+		// defer {
+		// 		C.RegCloseKey(reg_sys_env_handle)
+		// }
+		
 		// if the above succeeded, and we cannot get the value, it may simply be empty
 		sys_env_path := get_reg_value(reg_sys_env_handle, 'Path') or { '' }
 
@@ -104,6 +105,7 @@ fn setup_symlink_windows(vexe string){
 			print('not configured.\nAdding symlink directory to system %PATH%...')
 			set_reg_value(reg_sys_env_handle, 'Path', new_sys_env_path) or {
 				warn_and_exit(err)
+				C.RegCloseKey(reg_sys_env_handle)
 				return
 			}
 			println('done.')
@@ -113,9 +115,11 @@ fn setup_symlink_windows(vexe string){
 		send_setting_change_msg('Environment') or {
 			eprintln('\n' + err)
 			warn_and_exit('You might need to run this again to have the `v` command in your %PATH%')
+			C.RegCloseKey(reg_sys_env_handle)
 			return
 		}
 
+		C.RegCloseKey(reg_sys_env_handle)
 		println('finished.\n\nNote: restart your shell/IDE to load the new %PATH%.')
 		println('After restarting your shell/IDE, give `v version` a try in another dir!')
 	}


### PR DESCRIPTION
The reason for needing these fixes is that each `$if` branch now has its own scope (like regular `if`s do), so defers inside them won't be able to access local variables outside that scope until we have closures.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
