### PR TITLE
sync/select: allow push of literals and calculated expressions

### DIFF
--- a/vlib/sync/channel_select_2_test.v
+++ b/vlib/sync/channel_select_2_test.v
@@ -36,31 +36,22 @@ fn test_select() {
 	go do_send_int(chi)
 	go do_send_byte(chb)
 	go do_send_i64(chl)
-	mut channels := [&sync.Channel(chi), &sync.Channel(recch), &sync.Channel(chl), &sync.Channel(chb)]
-	directions := [sync.Direction.pop, .push, .pop, .pop]
 	mut sum := i64(0)
 	mut rl := i64(0)
-	mut ri := int(0)
-	mut rb := byte(0)
 	mut sl := i64(0)
-	mut objs := [voidptr(&ri), &sl, &rl, &rb]
 	for _ in 0 .. 1200 {
-		idx := sync.channel_select(mut channels, directions, mut objs, -1)
-		match idx {
-			0 {
+		select {
+			ri := <-chi {
 				sum += ri
 			}
-			1 {
+			recch <- sl {
 				sl++
 			}
-			2 {
+			rl = <-chl {
 				sum += rl
 			}
-			3 {
+			rb := <-chb {
 				sum += rb
-			}
-			else {
-				println('got $idx (timeout)')
 			}
 		}
 	}

--- a/vlib/sync/channel_select_3_test.v
+++ b/vlib/sync/channel_select_3_test.v
@@ -5,9 +5,12 @@ struct St {
 	a int
 }
 
-fn f1(ch1 chan int, ch2 chan St, ch3 chan int, sem sync.Semaphore) {
+fn getint() int {
+	return 8
+}
+
+fn f1(ch1 chan int, ch2 chan St, ch3 chan int, ch4 chan int, ch5 chan int, sem sync.Semaphore) {
 	mut a := 5
-	st := St{}
 	select {
 		a = <-ch3 {
 			a = 0
@@ -15,8 +18,17 @@ fn f1(ch1 chan int, ch2 chan St, ch3 chan int, sem sync.Semaphore) {
 		b := <-ch2 {
 			a = b.a
 		}
-		ch2 <- st {
+		ch3 <- 5 {
+			a = 1
+		}
+		ch2 <- St{a: 37} {
 			a = 2
+		}
+		ch4 <- (6 + 7 * 9) {
+			a = 8
+		}
+		ch5 <- getint() {
+			a = 9
 		}
 		> 300 * time.millisecond {
 			a = 3
@@ -30,7 +42,7 @@ fn f2(ch1 chan St, ch2 chan int, sem sync.Semaphore) {
 	mut r := 23
 	for i in 0 .. 2 {
 		select {
-			b := <- ch1 {
+			b := <-ch1 {
 				r = b.a
 			}
 			ch2 <- r {
@@ -50,6 +62,8 @@ fn test_select_blocks() {
 	ch1 := chan int{cap: 1}
 	ch2 := chan St{}
 	ch3 := chan int{}
+	ch4 := chan int{}
+	ch5 := chan int{}
 	sem := sync.new_semaphore()
 	mut r := false
 	t := select {
@@ -69,7 +83,7 @@ fn test_select_blocks() {
 	ch2 <- St{a: 13}
 	sem.wait()
 	stopwatch := time.new_stopwatch({})
-	go f1(ch1, ch2, ch3, sem)
+	go f1(ch1, ch2, ch3, ch4, ch5, sem)
 	sem.wait()
 	elapsed_ms := f64(stopwatch.elapsed()) / time.millisecond
 	assert elapsed_ms >= 295.0

--- a/vlib/sync/channel_select_test.v
+++ b/vlib/sync/channel_select_test.v
@@ -1,3 +1,11 @@
+/*
+ * ATTENTION! Do not use this file as an example!
+ * For that, please look at `channel_select_2_test.v` or `channel_select_3_test.v`
+ *
+ * This test case uses the implementation in `sync/channels.v` directly
+ * in order to test it independently from the support in the core language
+ */
+
 import sync
 
 fn do_rec_i64(mut ch sync.Channel) {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3069,25 +3069,25 @@ pub fn (mut c Checker) select_expr(mut node ast.SelectExpr) table.Type {
 				if branch.is_timeout {
 					if !stmt.typ.is_int() {
 						tsym := c.table.get_type_symbol(stmt.typ)
-						c.error('invalid type `$tsym.name` for timeout - expected integer type aka `time.Duration`', stmt.pos)
+						c.error('invalid type `$tsym.name` for timeout - expected integer type aka `time.Duration`',
+							stmt.pos)
 					}
 				} else {
-					match stmt.expr as expr {
-						ast.InfixExpr {
-							if expr.left !is ast.Ident && expr.right !is ast.SelectorExpr && expr.right !is ast.IndexExpr {
-								c.error('channel in `select` key must be predefined', expr.right.position())
-							}
+					if stmt.expr is ast.InfixExpr as expr {
+						if expr.left !is ast.Ident &&
+							expr.left !is ast.SelectorExpr && expr.left !is ast.IndexExpr {
+							c.error('channel in `select` key must be predefined', expr.left.position())
 						}
-						else {
-							c.error('invalid expression for `select` key', stmt.expr.position())
-						}
+					} else {
+						c.error('invalid expression for `select` key', stmt.expr.position())
 					}
 				}
 			}
 			ast.AssignStmt {
 				match stmt.right[0] as expr {
 					ast.PrefixExpr {
-						if expr.right !is ast.Ident && expr.right !is ast.SelectorExpr && expr.right !is ast.IndexExpr {
+						if expr.right !is ast.Ident &&
+							expr.right !is ast.SelectorExpr && expr.right !is ast.IndexExpr {
 							c.error('channel in `select` key must be predefined', expr.right.position())
 						}
 						if expr.or_block.kind != .absent {

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -358,6 +358,7 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 			}
 		} else {
 			p.inside_match = true
+			p.inside_select = true
 			exprs, comments := p.expr_list()
 			if exprs.len != 1 {
 				p.error('only one expression allowed as `select` key')
@@ -373,6 +374,7 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 				}
 			}
 			p.inside_match = false
+			p.inside_select = false
 			match stmt {
 				ast.ExprStmt {
 					if !stmt.is_expr {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1075,7 +1075,8 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 		}
 	} else if (p.peek_tok.kind == .lcbr ||
 		(p.peek_tok.kind == .lt && lit0_is_capital)) &&
-		(!p.inside_match || (p.inside_select && prev_tok_kind == .arrow && lit0_is_capital)) && !p.inside_match_case && !p.inside_if && !p.inside_for { // && (p.tok.lit[0].is_capital() || p.builtin_mod) {
+		(!p.inside_match || (p.inside_select && prev_tok_kind == .arrow && lit0_is_capital)) && !p.inside_match_case &&
+		!p.inside_if && !p.inside_for { // && (p.tok.lit[0].is_capital() || p.builtin_mod) {
 		return p.struct_init(false) // short_syntax: false
 	} else if p.peek_tok.kind == .dot && (lit0_is_capital && !known_var && language == .v) {
 		// `Color.green`


### PR DESCRIPTION
This PR allows literals, calculated expressions, function calls, etc to be pushed in `select` keys, i.e. expressions from which the address cannot be taken. This is done by evaluating these expressions in advance and assigning them to temporary variables (Go uses the same approach - with the same potential side effects). So this is now possible:
```v
select {
    ch <- 3 {
        ...
    }
    ch2 <- (7 + 8 * 4) {
        ...
    }
    ch3 <- Struct{a: 7} {
        ...
    }
    ch4 <- get_some_value(arg1, arg2) {
        ...
    }
}
```
The channels themselves must still be predefined (and I think it's not worth changing this), but index expressions (`chs[i]`) or selector expressions (`st.ch`) should work.
`checker` has been updated to do more sophisticated checks on the `select` keys.
Some test cases have been updated to use the new syntax and to check more syntax variants.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
