### PR TITLE
parser/checker: make `if select { ... } {` work

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1891,6 +1891,8 @@ if select {
     ch <- a {
         ...
     }
+} {
+    // channel was open
 } else {
     // channel is closed
 }

--- a/vlib/sync/channel_select_3_test.v
+++ b/vlib/sync/channel_select_3_test.v
@@ -91,7 +91,8 @@ fn test_select_blocks() {
 	ch1.close()
 	ch2.close()
 	mut h := 7
-	u := select {
+	mut is_open := true
+	if select {
 		b := <- ch2 {
 			h = 0
 		}
@@ -101,11 +102,15 @@ fn test_select_blocks() {
 		else {
 			h = 2
 		}
+	} {
+		panic('channel is still open')
+	} else {
+		is_open = false
 	}
 	// no branch should have run
 	assert h == 7
 	// since all channels are closed `select` should return `false`
-	assert u == false
+	assert is_open == false
 }
 
 			

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3220,6 +3220,7 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) table.Type {
 				should_skip = c.comp_if_branch(branch.cond, branch.pos)
 			} else {
 				// check condition type is boolean
+				c.expected_type = table.bool_type
 				cond_typ := c.expr(branch.cond)
 				if cond_typ.idx() !in [table.bool_type_idx, table.void_type_idx] && !c.pref.translated {
 					// void types are skipped, because they mean the var was initialized incorrectly

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1076,7 +1076,8 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 	} else if (p.peek_tok.kind == .lcbr ||
 		(p.peek_tok.kind == .lt && lit0_is_capital)) &&
 		(!p.inside_match || (p.inside_select && prev_tok_kind == .arrow && lit0_is_capital)) && !p.inside_match_case &&
-		!p.inside_if && !p.inside_for { // && (p.tok.lit[0].is_capital() || p.builtin_mod) {
+		(!p.inside_if || p.inside_select) &&
+		(!p.inside_for || p.inside_select) { // && (p.tok.lit[0].is_capital() || p.builtin_mod) {
 		return p.struct_init(false) // short_syntax: false
 	} else if p.peek_tok.kind == .dot && (lit0_is_capital && !known_var && language == .v) {
 		// `Color.green`


### PR DESCRIPTION
This is a fix that makes the following actually compile:
```v
if select {
    ch <- x {
        ...
    }
} {
    // `select` was successful 
} else {
    // all channels have been closed
}
```
The test case is updated to check this syntax. Also the description of this syntax in `docs.md` is fixed.
Before only `x := select { ... }` was working and tested.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
