### PR TITLE
cgen: fix `for match {...} {` and `for select {...} {`

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2293,6 +2293,7 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 		}
 		ast.ForStmt {
 			c.in_for_count++
+			c.expected_type = table.bool_type
 			typ := c.expr(node.cond)
 			if !node.is_inf && typ.idx() != table.bool_type_idx && !c.pref.translated {
 				c.error('non-bool used as for condition', node.pos)

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -897,13 +897,15 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 		ast.ForStmt {
 			g.write_v_source_line_info(node.pos)
 			g.is_vlines_enabled = false
-			g.write('while (')
-			if node.is_inf {
-				g.write('1')
-			} else {
+			g.writeln('while (1) {')
+			if !node.is_inf {
+				g.indent++
+				g.stmt_path_pos << g.out.len
+				g.write('if (!(')
 				g.expr(node.cond)
+				g.writeln(')) break;')
+				g.indent--
 			}
-			g.writeln(') {')
 			g.is_vlines_enabled = true
 			g.stmts(node.stmts)
 			g.writeln('}')
@@ -2888,6 +2890,7 @@ fn (mut g Gen) select_expr(node ast.SelectExpr) {
 	}
 	g.writeln('}')
 	if is_expr {
+		g.empty_line = false
 		g.write(cur_line)
 		g.write('($select_result != -2)')
 	}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -724,54 +724,6 @@ fn (mut g Gen) write_v_source_line_info(pos token.Position) {
 	}
 }
 
-fn (mut g Gen) is_simple_bool(expr ast.Expr) bool {
-	match expr {
-		ast.Ident {
-			return true
-		}
-		ast.BoolLiteral {
-			return true
-		}
-		ast.SelectorExpr {
-			return g.is_simple_bool(expr.expr)
-		}
-		ast.PrefixExpr {
-			return g.is_simple_bool(expr.right)
-		}
-		ast.CharLiteral {
-			return true
-		}
-		ast.IntegerLiteral {
-			return true
-		}
-		ast.StringLiteral {
-			return true
-		}
-		ast.StringInterLiteral {
-			return true
-		}
-		ast.SizeOf {
-			if expr.is_type {
-				return true
-			} else {
-				return g.is_simple_bool(expr.expr)
-			}
-		}
-		ast.IndexExpr {
-			return g.is_simple_bool(expr.left) && g.is_simple_bool(expr.index)
-		}
-		ast.ParExpr {
-			return g.is_simple_bool(expr.expr)
-		}
-		ast.InfixExpr {
-			return g.is_simple_bool(expr.left) && g.is_simple_bool(expr.right)
-		}
-		else {
-			return false
-		}
-	}
-}
-
 fn (mut g Gen) stmt(node ast.Stmt) {
 	g.stmt_path_pos << g.out.len
 	defer {
@@ -945,24 +897,14 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 		ast.ForStmt {
 			g.write_v_source_line_info(node.pos)
 			g.is_vlines_enabled = false
-			inf_loop := node.is_inf || !g.is_simple_bool(node.cond)
-			g.write('while (')
-			if inf_loop {
-				g.writeln('1) {')
-				if !node.is_inf {
-					g.indent++
-					g.stmt_path_pos << g.out.len
-					g.write('if (!(')
-				}
-			}
-			g.expr(node.cond)
+			g.writeln('for (;;) {')
 			if !node.is_inf {
-				if inf_loop {
-					g.writeln(')) break;')
-					g.indent--
-				} else {
-					g.writeln(') {')
-				}
+				g.indent++
+				g.stmt_path_pos << g.out.len
+				g.write('if (!(')
+				g.expr(node.cond)
+				g.writeln(')) break;')
+				g.indent--
 			}
 			g.is_vlines_enabled = true
 			g.stmts(node.stmts)

--- a/vlib/v/tests/for_loops_2_test.v
+++ b/vlib/v/tests/for_loops_2_test.v
@@ -1,0 +1,55 @@
+fn test_for_match() {
+	mut a := 2
+	mut b := 0
+	for match a {
+		2 {
+			println('a == 2')
+			a = 0
+			true
+		}
+		0 {
+			println('a == 0')
+			a = 5
+			false
+		}
+		else {
+			println('unexpected branch')
+			false
+		}
+	} {
+		b++
+		println('${b}. run')
+	}
+	assert a == 5
+	assert b == 1
+}
+
+fn test_for_select() {
+	ch1 := chan int{}
+	ch2 := chan f64{}
+	go do_send(ch1, ch2)
+	mut a := 0
+	mut b := 0
+	for select {
+		x := <-ch1 {
+			a += x
+		}
+		y := <- ch2 {
+			a += int(y)
+		}
+	} {
+		// count number of receive events
+		b++
+		println('${b}. event')
+	}
+	assert a == 10
+	assert b == 3
+}
+
+fn do_send(ch1 chan int, ch2 chan f64) {
+	ch1 <- 3
+	ch2 <- 5.0
+	ch2.close()
+	ch1 <- 2
+	ch1.close()
+}


### PR DESCRIPTION
As with `if select {...} {` which was fixed in #6434 the analogue case with `for` didn't work either. In this case the main problem is somewhat deeper and also affects `for match {...} {`.

The thing is that for complex expressions like `match` and `select`, that require the definition of temporary variables, `cgen` cuts the current output line, puts in the lines for the complex expression with the temporary variables and pastes back the saved line and inserts only the result.

In case of `for` this does not work, because the temporary variables would end up *before* the loop - and would be calculated only once - and not for every iteration.

This PR changes the C code that is generated for loops with single condition ("`for cond {...}`"):
```C
while (1) {
    if (!(cond)) break;
    ...
}
```
Temporary variables in complex `cond`-expressions are now placed before the second line and are part of the loop.

Test cases for `for select {...} {` and `for match {...} {` are added.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
