### PR TITLE
vpm: bugfix; Install and check all modules as lowercase modules.

### DIFF
--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -170,7 +170,7 @@ fn vpm_install(module_names []string) {
 			println('Skipping module "$name", since it uses an unsupported VCS {$vcs} .')
 			continue
 		}
-		mod_name_as_path := mod.name.replace('.', os.path_separator).replace('-', '_')
+		mod_name_as_path := mod.name.replace('.', os.path_separator).replace('-', '_').to_lower()
 		final_module_path := os.real_path(os.join_path(settings.vmodules_path, mod_name_as_path))
 		if os.exists(final_module_path) {
 			vpm_update([name])
@@ -340,7 +340,7 @@ fn vpm_remove(module_names []string) {
 }
 
 fn valid_final_path_of_existing_module(name string) ?string {
-	mod_name_as_path := name.replace('.', os.path_separator).replace('-', '_')
+	mod_name_as_path := name.replace('.', os.path_separator).replace('-', '_').to_lower()
 	name_of_vmodules_folder := os.join_path(settings.vmodules_path, mod_name_as_path)
 	final_module_path := os.real_path(name_of_vmodules_folder)
 	if !os.exists(final_module_path) {


### PR DESCRIPTION
This PR resolves #6442.

I have tested the following cases:

+ Install a new module
+ Update an existing module
+ Remove existing modules
+ List modules

Of course, I have tested all these functionalities with uppercase letters, as well as without. 

```bash
bowero@bow-pc:pts/2->/home/bowero (0) 
> v install Bowero.owmw
Installing module "Bowero.owmw" from https://github.com/Bowero/owmw to /home/bowero/.vmodules/bowero/owmw ...
```

As you see, the uppercase module name is transformed to lowercase. Because of this, you can now use:

```v
import bowero.owmw
```

Because of this, the problems, as described in #6442 are now resolved.