### PR TITLE
checker: require binary operands for &&, ||

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -771,6 +771,14 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 			return table.void_type
 		}
 		else {
+			if infix_expr.op in [.and, .logical_or] {
+				if infix_expr.left_type != table.bool_type_idx {
+					c.error('left operand for `$infix_expr.op` is not a boolean', infix_expr.left.position())
+				}
+				if infix_expr.right_type != table.bool_type_idx {
+					c.error('right operand for `$infix_expr.op` is not a boolean', infix_expr.right.position())
+				}
+			}
 			// use `()` to make the boolean expression clear error
 			// for example: `(a && b) || c` instead of `a && b || c`
 			if infix_expr.op in [.logical_or, .and] {

--- a/vlib/v/checker/tests/infix_err.out
+++ b/vlib/v/checker/tests/infix_err.out
@@ -32,8 +32,22 @@ vlib/v/checker/tests/infix_err.vv:13:9: error: `+` cannot be used with `?int`
    13 | _ = g() + int(3)
       |         ^
    14 | _ = g() + 3
+   15 |
 vlib/v/checker/tests/infix_err.vv:14:9: error: `+` cannot be used with `?int`
    12 | _ = int(0) + g() // FIXME not detected
    13 | _ = g() + int(3)
    14 | _ = g() + 3
       |         ^
+   15 |
+   16 | // binary operands
+vlib/v/checker/tests/infix_err.vv:17:5: error: left operand for `&&` is not a boolean
+   15 |
+   16 | // binary operands
+   17 | _ = 1 && 2
+      |     ^
+   18 | _ = true || 2
+vlib/v/checker/tests/infix_err.vv:18:13: error: right operand for `||` is not a boolean
+   16 | // binary operands
+   17 | _ = 1 && 2
+   18 | _ = true || 2
+      |             ^

--- a/vlib/v/checker/tests/infix_err.vv
+++ b/vlib/v/checker/tests/infix_err.vv
@@ -12,3 +12,7 @@ _ = 4 + g()
 _ = int(0) + g() // FIXME not detected
 _ = g() + int(3)
 _ = g() + 3
+
+// binary operands
+_ = 1 && 2
+_ = true || 2


### PR DESCRIPTION
This follows Go and Rust.
Fixes #6438.
