### PR TITLE
gen: fix str gen for pointers in structs

### DIFF
--- a/vlib/v/gen/auto_str_methods.v
+++ b/vlib/v/gen/auto_str_methods.v
@@ -291,7 +291,11 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp, str_fn_name string) {
 	for field in info.fields {
 		sym := g.table.get_type_symbol(field.typ)
 		if !sym.has_method('str') {
-			field_styp := g.typ(field.typ).replace('*', '')
+			mut typ := field.typ 
+			if typ.is_ptr() {
+				typ = typ.deref()
+			}
+			field_styp := g.typ(typ)
 			field_fn_name := g.gen_str_for_type_with_styp(field.typ, field_styp)
 			fnames2strfunc[field_styp] = field_fn_name
 		}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -5062,7 +5062,9 @@ fn (mut g Gen) gen_str_default(sym table.TypeSymbol, styp, str_fn_name string) {
 
 fn (g &Gen) type_to_fmt(typ table.Type) string {
 	sym := g.table.get_type_symbol(typ)
-	if sym.kind in [.struct_, .array, .array_fixed, .map] {
+	if (typ.is_int() || typ.is_float()) && typ.is_ptr() {
+		return '%.*s\\000'
+	} else if sym.kind in [.struct_, .array, .array_fixed, .map] {
 		return '%.*s\\000'
 	} else if sym.kind == .string {
 		return "\'%.*s\\000\'"

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -5064,15 +5064,15 @@ fn (g &Gen) type_to_fmt(typ table.Type) string {
 	sym := g.table.get_type_symbol(typ)
 	if sym.kind in [.struct_, .array, .array_fixed, .map] {
 		return '%.*s\\000'
-	} else if typ == table.string_type {
+	} else if sym.kind == .string {
 		return "\'%.*s\\000\'"
-	} else if typ == table.bool_type {
+	} else if sym.kind == .bool {
 		return '%.*s\\000'
 	} else if sym.kind == .enum_ {
 		return '%.*s\\000'
-	} else if typ in [table.f32_type, table.f64_type] {
+	} else if sym.kind in [.f32, .f64] {
 		return '%g\\000' // g removes trailing zeros unlike %f
-	} else if typ == table.u64_type {
+	} else if sym.kind == .u64 {
 		return '%lld\\000'
 	} else if sym.kind == .sum_type {
 		return '%.*s\\000'

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -180,3 +180,19 @@ fn test_struct_with_struct_pointer() {
 	assert '$w' == 'Wrapper4 {\n    foo: &Foo {\n    }\n}'
 	assert w.str() == 'Wrapper4 {\n    foo: &Foo {\n    }\n}'
 }
+
+fn test_struct_with_nil() {
+	w := Wrapper4{}
+	assert '$w' == 'Wrapper4 {\n    foo: &nil\n}'
+	assert w.str() == 'Wrapper4 {\n    foo: &nil\n}'
+}
+
+struct Wrapper5 {
+	foo &f32
+}
+fn test_struct_with_f32_pointer() {
+	i := f32(5.1)
+	w := Wrapper5{&i}
+	assert '$w' == 'Wrapper5 {\n    foo: &5.1\n}'
+	assert w.str() == 'Wrapper5 {\n    foo: &5.1\n}'
+}

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -139,3 +139,44 @@ fn test_fixed_array_of_strings() {
 	assert aa.str() == "['aa', 'bb', 'cc']"
 	assert '$aa' == "['aa', 'bb', 'cc']"
 }
+
+struct Wrapper {
+	foo &string
+}
+fn test_struct_with_string_pointer() {
+	s := 'test'
+	w := Wrapper{&s}
+	assert '$w' == 'Wrapper {\n    foo: &\'test\'\n}'
+	assert w.str() == 'Wrapper {\n    foo: &\'test\'\n}'
+}
+
+struct Wrapper2 {
+	foo &int
+}
+fn test_struct_with_int_pointer() {
+	i := 5
+	w := Wrapper2{&i}
+	assert '$w' == 'Wrapper2 {\n    foo: &5\n}'
+	assert w.str() == 'Wrapper2 {\n    foo: &5\n}'
+}
+
+struct Wrapper3 {
+	foo &bool
+}
+fn test_struct_with_bool_pointer() {
+	b := true
+	w := Wrapper3{&b}
+	assert '$w' == 'Wrapper3 {\n    foo: &true\n}'
+	assert w.str() == 'Wrapper3 {\n    foo: &true\n}'
+}
+
+struct Foo {}
+struct Wrapper4 {
+	foo &Foo
+}
+fn test_struct_with_struct_pointer() {
+	b := Foo{}
+	w := Wrapper4{&b}
+	assert '$w' == 'Wrapper4 {\n    foo: &Foo {\n    }\n}'
+	assert w.str() == 'Wrapper4 {\n    foo: &Foo {\n    }\n}'
+}

--- a/vlib/v/tests/sumtype_str_test.v
+++ b/vlib/v/tests/sumtype_str_test.v
@@ -9,25 +9,24 @@ type ST = int | string | bool | Abc
 fn test_int_st_str() {
 	a := ST(0)
 	assert '$a' == 'ST(0)'
+	assert a.str() == 'ST(0)'
 }
 
 fn test_string_st_str() {
 	a := ST('test')
 	assert '$a' == 'ST(\'test\')'
+	assert a.str() == 'ST(\'test\')'
 }
 
 fn test_struct_st_str() {
 	a := ST(Abc{})
 	assert '$a' == 'ST(Abc {\n    foo: 0\n    bar: false\n    str: \'\'\n})'
+	assert a.str() == 'ST(Abc {\n    foo: 0\n    bar: false\n    str: \'\'\n})'
 }
 
 fn test_bool_st_str() {
 	a := ST(false)
 	assert '$a' == 'ST(false)'
-}
-
-fn test_str() {
-	a := ST(false)
 	assert a.str() == 'ST(false)'
 }
 
@@ -38,17 +37,20 @@ struct Container {
 fn test_in_struct() {
 	c := Container{ST(0)}
 	assert '$c' == 'Container {\n    st: ST(0)\n}'
+	assert c.str() == 'Container {\n    st: ST(0)\n}'
 }
 
 fn test_unknown_value() {
 	c := Container{}
 	assert '$c' == 'Container {\n    st: unknown sum type value\n}'
+	assert c.str() == 'Container {\n    st: unknown sum type value\n}'
 }
 
 fn test_nested_in_struct() {
 	abc := Abc{}
 	c := Container{ST(abc)}
 	assert '$c' == 'Container {\n    st: ST(Abc {\n        foo: 0\n        bar: false\n        str: \'\'\n    })\n}'
+	assert c.str() == 'Container {\n    st: ST(Abc {\n        foo: 0\n        bar: false\n        str: \'\'\n    })\n}'
 }
 
 fn test_pointer() {


### PR DESCRIPTION
```v
struct Abc {

}

struct Test {
	st &Abc
}

fn main() {
	s := Abc{}
	t := Test{&s}
	println(t)
}
```

this works now! :)