### PR TITLE
fmt: fix writing ConcatExpr

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -819,7 +819,7 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 		ast.ConcatExpr {
 			for i, val in node.vals {
 				if i != 0 {
-					f.write(' + ')
+					f.write(', ')
 				}
 				f.expr(val)
 			}

--- a/vlib/v/fmt/tests/assign_keep.vv
+++ b/vlib/v/fmt/tests/assign_keep.vv
@@ -1,0 +1,3 @@
+a, b := if true { 'a', 'b' } else { 'b', 'a' }
+println(a)
+println(b)


### PR DESCRIPTION
Fix #6451.

Note: `ConcatExpr` is confusingly named, perhaps we should rename it. It's used for multiple expressions.