### PR TITLE
parser: require assign on type alias

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -652,7 +652,7 @@ However, you _can_ redeclare a type.
 ```v
 import time
 
-type MyTime time.Time
+type MyTime = time.Time
 
 fn (mut t MyTime) century() int {
     return 1 + t.year % 100
@@ -2220,7 +2220,7 @@ surrounding code).
 struct C.sqlite3{}
 struct C.sqlite3_stmt{}
 
-type FnSqlite3Callback fn(voidptr, int, &charptr, &charptr) int
+type FnSqlite3Callback = fn(voidptr, int, &charptr, &charptr) int
 
 fn C.sqlite3_open(charptr, &&C.sqlite3) int
 fn C.sqlite3_close(&C.sqlite3) int
@@ -2403,7 +2403,7 @@ $if option ? {
 }
 ```
 
-If you want an `if` to be evaluated at compile time it must be prefixed with a `$` sign. 
+If you want an `if` to be evaluated at compile time it must be prefixed with a `$` sign.
 Right now it can be used to detect an OS, compiler, platform or compilation options.
 `$if debug` is a special option like `$if windows` or `$if x32`.
 If you're using a custom ifdef, then you do need `$if option ? {}` and compile with`v -d option`.

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -6,7 +6,7 @@ module builtin
 __global g_m2_buf byteptr
 __global g_m2_ptr byteptr
 
-type FnExitCb fn()
+type FnExitCb = fn()
 fn C.atexit(f FnExitCb) int
 
 pub fn exit(code int) {
@@ -71,8 +71,8 @@ pub fn eprintln(s string) {
 	}
 	C.fflush(C.stdout)
 	C.fflush(C.stderr)
-	C.write(2, s.str, s.len)	
-	C.write(2, c'\n', 1)	
+	C.write(2, s.str, s.len)
+	C.write(2, c'\n', 1)
 	C.fflush(C.stderr)
 }
 
@@ -82,12 +82,12 @@ pub fn eprint(s string) {
 	}
 	C.fflush(C.stdout)
 	C.fflush(C.stderr)
-	C.write(2, s.str, s.len)	
+	C.write(2, s.str, s.len)
 	C.fflush(C.stderr)
 }
 
 pub fn print(s string) {
-	C.write(1, s.str, s.len)	
+	C.write(1, s.str, s.len)
 }
 
 const (

--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -199,7 +199,7 @@ pub:
 	context_record &ContextRecord
 }
 
-type VectoredExceptionHandler fn(&ExceptionPointers)u32
+type VectoredExceptionHandler = fn(&ExceptionPointers)u32
 
 fn C.AddVectoredExceptionHandler(u32, C.PVECTORED_EXCEPTION_HANDLER)
 fn add_vectored_exception_handler(handler VectoredExceptionHandler) {

--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -91,7 +91,7 @@ fn test_cmp() {
 	assert 1 ⩾ 0
 }
 */
-type MyInt int
+type MyInt = int
 
 fn test_int_alias() {
 	i := MyInt(2)
@@ -168,7 +168,7 @@ fn test_num_separator() {
 	// f32 or f64
 	assert 312_2.55 == 3122.55
 	assert 312_2.55 == 3122.55
-	
+
 }
 
 fn test_int_decl() {

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -734,7 +734,7 @@ fn test_raw() {
 	assert raw3[7] == `\\`
 	assert raw3[8] == `x`
 	assert raw3[9] == `0`
-	assert raw3[10] == `0`	
+	assert raw3[10] == `0`
 }
 
 fn test_raw_with_quotes() {
@@ -862,7 +862,7 @@ fn test_string_literal_with_backslash(){
 }
 
 /*
-type MyString string
+type MyString = string
 
 fn test_string_alias() {
 	s := MyString('hi')

--- a/vlib/eventbus/eventbus.v
+++ b/vlib/eventbus/eventbus.v
@@ -1,6 +1,6 @@
 module eventbus
 
-pub type EventHandlerFn fn(receiver voidptr, args voidptr, sender voidptr)
+pub type EventHandlerFn = fn (receiver voidptr, args voidptr, sender voidptr)
 
 pub struct Publisher {
 mut:

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -13,7 +13,7 @@ pub const (
 
 // Ref - https://docs.microsoft.com/en-us/windows/desktop/winprog/windows-data-types
 // A handle to an object.
-pub type HANDLE voidptr
+pub type HANDLE = voidptr
 
 // win: FILETIME
 // https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime
@@ -335,7 +335,7 @@ pub:
 	context_record &ContextRecord
 }
 
-pub type VectoredExceptionHandler fn(&ExceptionPointers)u32
+pub type VectoredExceptionHandler = fn (&ExceptionPointers) u32
 
 // This is defined in builtin because we use vectored exception handling
 // for our unhandled exception handler on windows

--- a/vlib/rand/sys/system_rng.js.v
+++ b/vlib/rand/sys/system_rng.js.v
@@ -6,7 +6,7 @@ module sys
 // Until there's a portable, JS has a seeded way to produce random numbers
 // and not just Math.random(), use any of the existing implementations
 // as the System's RNG
-type SysRNG WyRandRNG
+type SysRNG = WyRandRNG
 
 // In the JS version, we simply return the same int as is normally generated.
 [inline]

--- a/vlib/regex/regex.v
+++ b/vlib/regex/regex.v
@@ -230,7 +230,7 @@ fn simple_log(txt string) {
 * Token Structs
 *
 ******************************************************************************/
-pub type FnValidator fn (byte) bool
+pub type FnValidator = fn (byte) bool
 struct Token{
 mut:
 	ist rune
@@ -293,7 +293,7 @@ mut:
 	group_stack_index int = -1  // continuous save on capturing groups
 }
 
-pub type FnLog fn (string)
+pub type FnLog = fn (string)
 
 pub
 struct RE {

--- a/vlib/sync/pool.v
+++ b/vlib/sync/pool.v
@@ -57,7 +57,7 @@ mut:
 	thread_contexts []voidptr
 }
 
-pub type ThreadCB fn(p &PoolProcessor, idx int, task_id int)voidptr
+pub type ThreadCB = fn (p &PoolProcessor, idx int, task_id int) voidptr
 
 pub struct PoolProcessorConfig {
 	maxjobs  int

--- a/vlib/sync/sync_windows.c.v
+++ b/vlib/sync/sync_windows.c.v
@@ -9,9 +9,9 @@ import time
 // was discussed. Needs consideration.
 
 // Mutex HANDLE
-type MHANDLE voidptr
+type MHANDLE = voidptr
 // Semaphore HANDLE
-type SHANDLE voidptr
+type SHANDLE = voidptr
 
 //[init_with=new_mutex] // TODO: implement support for this struct attribute, and disallow Mutex{} from outside the sync.new_mutex() function.
 

--- a/vlib/szip/szip.v
+++ b/vlib/szip/szip.v
@@ -6,7 +6,7 @@ module szip
 
 struct C.zip_t {}
 
-type Zip C.zip_t
+type Zip = C.zip_t
 
 fn C.zip_open(byteptr, int, byte) &Zip
 fn C.zip_close(&Zip)

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -360,7 +360,7 @@ fn convert_ctime(t C.tm, microsecond int) Time {
 }
 
 // A lot of these are taken from the Go library
-pub type Duration i64
+pub type Duration = i64
 
 pub const(
 	nanosecond  = Duration(1)

--- a/vlib/time/time_nix.c.v
+++ b/vlib/time/time_nix.c.v
@@ -31,7 +31,7 @@ fn to_local_time(t Time) Time {
 	return convert_ctime(loc_tm, t.microsecond)
 }
 
-type time_t voidptr
+type time_t = voidptr
 
 // in most systems, these are __quad_t, which is an i64
 struct C.timespec {

--- a/vlib/v/builder/msvc.v
+++ b/vlib/v/builder/msvc.v
@@ -23,7 +23,7 @@ struct MsvcResult {
 
 // shell32 for RegOpenKeyExW etc
 // Mimics a HKEY
-type RegKey voidptr
+type RegKey = voidptr
 
 // Taken from the windows SDK
 const (

--- a/vlib/v/checker/tests/alias_type_exists.out
+++ b/vlib/v/checker/tests/alias_type_exists.out
@@ -1,5 +1,5 @@
 vlib/v/checker/tests/alias_type_exists.vv:1:1: error: type `Bird` doesn't exist
-    1 | type Pigeon Bird
+    1 | type Pigeon = Bird
       | ~~~~~~~~~~~
     2 |
     3 | fn main() {

--- a/vlib/v/checker/tests/alias_type_exists.vv
+++ b/vlib/v/checker/tests/alias_type_exists.vv
@@ -1,4 +1,4 @@
-type Pigeon Bird
+type Pigeon = Bird
 
 fn main() {
 

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -496,7 +496,7 @@ pub fn (mut f Fmt) type_decl(node ast.TypeDecl) {
 				f.write('pub ')
 			}
 			ptype := f.type_to_str(node.parent_type)
-			f.write('type $node.name $ptype')
+			f.write('type $node.name = $ptype')
 		}
 		ast.FnTypeDecl {
 			if node.is_pub {

--- a/vlib/v/fmt/tests/types_expected.vv
+++ b/vlib/v/fmt/tests/types_expected.vv
@@ -8,9 +8,9 @@ type Uint = byte | u16 | u32 | u64
 type Float = f32 | f64
 
 // Alias type
-type MyInt int
+type MyInt = int
 
-pub type Abc f32
+pub type Abc = f32
 
 // Fn type decl
 type EmptyFn = fn ()

--- a/vlib/v/fmt/tests/types_input.vv
+++ b/vlib/v/fmt/tests/types_input.vv
@@ -13,9 +13,9 @@ Float =
 	f64
 
  // Alias type
-     type  MyInt    int
+     type  MyInt  =  int
 
- pub type Abc f32
+ pub type Abc = f32
 
 
 // Fn type decl

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1802,9 +1802,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 			decl_pos)
 	}
 	mut sum_variants := []table.Type{}
-	if p.tok.kind == .assign {
-		p.next() // TODO require `=`
-	}
+	p.check(.assign)
 	if p.tok.kind == .key_fn {
 		// function type: `type mycallback fn(string, int)`
 		fn_name := p.prepend_mod(name)

--- a/vlib/v/parser/tests/expecting_assign_type_alias.out
+++ b/vlib/v/parser/tests/expecting_assign_type_alias.out
@@ -1,0 +1,5 @@
+vlib/v/parser/tests/expecting_assign_type_alias.vv:1:10: error: unexpected name `int`, expecting `=`
+    1 | type Ttt int
+      |          ~~~
+    2 |
+    3 | fn main() {}

--- a/vlib/v/parser/tests/expecting_assign_type_alias.vv
+++ b/vlib/v/parser/tests/expecting_assign_type_alias.vv
@@ -1,0 +1,3 @@
+type Ttt int
+
+fn main() {}

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -13,7 +13,7 @@ module table
 
 import strings
 
-pub type Type int
+pub type Type = int
 
 pub type TypeInfo = Alias | Array | ArrayFixed | Chan | Enum | FnType | GenericStructInst |
 	Interface | Map | MultiReturn | Struct | SumType

--- a/vlib/v/tests/shift_test.v
+++ b/vlib/v/tests/shift_test.v
@@ -1,4 +1,4 @@
-type MyInt int
+type MyInt = int
 
 fn test_shift_operators() {
 	// check that shift works with all integer types

--- a/vlib/v/tests/type_alias_str_method_override_test.v
+++ b/vlib/v/tests/type_alias_str_method_override_test.v
@@ -6,7 +6,7 @@ fn (h Human) str() string {
 	return 'Human: $h.name'
 }
 
-type Person Human
+type Person = Human
 
 fn (h Person) str() string {
 	return 'Person: $h.name'

--- a/vlib/v/tests/type_alias_test.v
+++ b/vlib/v/tests/type_alias_test.v
@@ -1,6 +1,6 @@
-type Myint int
-type Myf32 f32
-type Myf64 f64
+type Myint = int
+type Myf32 = f32
+type Myf64 = f64
 
 fn test_type_alias() {
 	i := Myint(10)
@@ -28,7 +28,7 @@ struct Mystruct {
 	mut:
 	i int
 }
-type Mystruct_2 Mystruct
+type Mystruct_2 = Mystruct
 
 fn test_type_alias_struct() {
 	mut s := Mystruct_2{}


### PR DESCRIPTION
```v
type MyInt int
```
is no longer valid

it has to be
```v
type MyInt = int
```