### PR TITLE
pref: error if unknown argument passed to `v`

### DIFF
--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -35,10 +35,6 @@ fn main() {
 	}
 	args_and_flags := util.join_env_vflags_and_os_args()[1..]
 	prefs, command := pref.parse_args(args_and_flags)
-	if command == 'version' {
-		println(util.full_v_version(prefs.is_verbose))
-		return
-	}
 	if prefs.is_verbose {
 		// println('args= ')
 		// println(args) // QTODO

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -35,13 +35,7 @@ fn main() {
 	}
 	args_and_flags := util.join_env_vflags_and_os_args()[1..]
 	prefs, command := pref.parse_args(args_and_flags)
-	// if prefs.is_verbose {
-	// println('command = "$command"')
-	// println(util.full_v_version(prefs.is_verbose))
-	// }
-	if args.len > 0 && (args[0] in ['version', '-V', '-version', '--version'] || (args[0] ==
-		'-v' && args.len == 1)) {
-		// `-v` flag is for setting verbosity, but without any args it prints the version, like Clang
+	if command == 'version' {
 		println(util.full_v_version(prefs.is_verbose))
 		return
 	}

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -337,6 +337,10 @@ pub fn parse_args(args []string) (&Preferences, string) {
 					command_pos = i
 					continue
 				}
+				if command !in ['', 'run', 'build', 'build-module'] {
+					// arguments for e.g. fmt are checked elsewhere
+					continue
+				}
 				eprint('Unknown argument `$arg`')
 				eprintln(if command.len == 0 {''} else {' for command `$command`'})
 				exit(1)

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -313,21 +313,19 @@ pub fn parse_args(args []string) (&Preferences, string) {
 				i++
 			}
 			else {
-				mut should_continue := false
-				for flag_with_param in list_of_flags_with_param {
-					if '-$flag_with_param' == arg {
-						should_continue = true
+				if arg[0] == `-` {
+					if arg[1..] in list_of_flags_with_param {
 						i++
-						break
+						continue
 					}
-				}
-				if should_continue {
-					continue
-				}
-				if !arg.starts_with('-') && command == '' {
+				} else if command == '' {
 					command = arg
 					command_pos = i
+					continue
 				}
+				eprint('Unknown argument `$arg`')
+				eprintln(if command.len == 0 {''} else {' for command `$command`'})
+				exit(1)
 			}
 		}
 	}

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -325,9 +325,11 @@ pub fn parse_args(args []string) (&Preferences, string) {
 						i++
 						continue
 					}
-				} else if command == '' {
-					command = arg
-					command_pos = i
+				} else {
+					if command == '' {
+						command = arg
+						command_pos = i
+					}
 					continue
 				}
 				if arg in ['-V', '-version', '--version'] {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -147,7 +147,13 @@ pub fn parse_args(args []string) (&Preferences, string) {
 				res.only_check_syntax = true
 			}
 			'-v' {
-				res.is_verbose = true
+				// `-v` flag is for setting verbosity, but without any args it prints the version, like Clang
+				if args.len > 1 {
+					res.is_verbose = true
+				} else {
+					command = 'version'
+					command_pos = i
+				}
 			}
 			'-silent' {
 				res.output_mode = .silent
@@ -315,11 +321,17 @@ pub fn parse_args(args []string) (&Preferences, string) {
 			else {
 				if arg[0] == `-` {
 					if arg[1..] in list_of_flags_with_param {
+						// skip parameter
 						i++
 						continue
 					}
 				} else if command == '' {
 					command = arg
+					command_pos = i
+					continue
+				}
+				if arg in ['-V', '-version', '--version'] {
+					command = 'version'
 					command_pos = i
 					continue
 				}


### PR DESCRIPTION
Useful if there's a typo in an option or malformed parameter syntax, e.g.:
* `-cc=gcc` not `-cc gcc`
* `-show-cc` not `-showcc`

I'm not sure where a test would go, please let me know how.