### PR TITLE
parser: warn about ambiguous infix/prefix op token

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -421,6 +421,8 @@ pub fn (i &Ident) var_info() IdentVar {
 	}
 }
 
+// left op right
+// See: token.Kind.is_infix
 pub struct InfixExpr {
 pub:
 	op          token.Kind
@@ -433,6 +435,7 @@ pub mut:
 	auto_locked string
 }
 
+// ++, --
 pub struct PostfixExpr {
 pub:
 	op          token.Kind
@@ -442,6 +445,7 @@ pub mut:
 	auto_locked string
 }
 
+// See: token.Kind.is_prefix
 pub struct PrefixExpr {
 pub:
 	op         token.Kind

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -269,11 +269,13 @@ pub fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_iden
 				pos: pos
 			}
 		} else if p.tok.kind.is_infix() {
-			// return early for deref assign `*x = 2` goes to prefix expr
-			if p.tok.kind == .mul &&
-				p.tok.line_nr != p.prev_tok.line_nr &&
-				p.peek_tok2.kind == .assign {
-				return node
+			if p.tok.kind.is_prefix() && p.tok.line_nr != p.prev_tok.line_nr {
+				// return early for deref assign `*x = 2` goes to prefix expr
+				if p.tok.kind == .mul && p.peek_tok2.kind == .assign {
+					return node
+				}
+				// later this will be parsed as PrefixExpr instead
+				p.warn_with_pos('move infix `$p.tok.kind` operator before new line if infix intended', p.tok.position())
 			}
 			// continue on infix expr
 			node = p.infix_expr(node)

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -274,8 +274,8 @@ pub fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_iden
 				if p.tok.kind == .mul && p.peek_tok2.kind == .assign {
 					return node
 				}
-				// later this will be parsed as PrefixExpr instead
-				p.warn_with_pos('move infix `$p.tok.kind` operator before new line if infix intended', p.tok.position())
+				// added 10/2020: LATER this will be parsed as PrefixExpr instead
+				p.warn_with_pos('move infix `$p.tok.kind` operator before new line (if infix intended) or use brackets for a prefix expression', p.tok.position())
 			}
 			// continue on infix expr
 			node = p.infix_expr(node)

--- a/vlib/v/parser/tests/prefix_first.out
+++ b/vlib/v/parser/tests/prefix_first.out
@@ -1,0 +1,28 @@
+vlib/v/parser/tests/prefix_first.vv:15:3: warning: move infix `-` operator before new line (if infix intended) or use brackets for a prefix expression
+   13 |     _ = if true {
+   14 |         v = 1
+   15 |         -1
+      |         ^
+   16 |     } else {1}
+   17 | }
+vlib/v/parser/tests/prefix_first.vv:26:3: warning: move infix `&` operator before new line (if infix intended) or use brackets for a prefix expression
+   24 |     _ = opt() or {
+   25 |         _ = 1
+   26 |         &v
+      |         ^
+   27 |     }
+   28 | }
+vlib/v/parser/tests/prefix_first.vv:13:6: error: `if` expression requires an expression as the last statement of every branch
+   11 |
+   12 |     // later this should compile correctly
+   13 |     _ = if true {
+      |         ~~~~~~~
+   14 |         v = 1
+   15 |         -1
+vlib/v/parser/tests/prefix_first.vv:24:6: error: last statement in the `or {}` block should be an expression of type `&int` or exit parent scope
+   22 |     // later this should compile correctly
+   23 |     v := 3
+   24 |     _ = opt() or {
+      |         ~~~~~
+   25 |         _ = 1
+   26 |         &v

--- a/vlib/v/parser/tests/prefix_first.vv
+++ b/vlib/v/parser/tests/prefix_first.vv
@@ -1,0 +1,28 @@
+// a prefix op can be parsed as an infix op if there's an expression on the line before
+// https://github.com/vlang/v/pull/6491
+fn test_prefix() {
+	mut v := 1
+	mut p := &v
+	// OK, special workaround
+	unsafe {
+		v = 1
+		*p = 2
+	}
+
+	// later this should compile correctly
+	_ = if true {
+		v = 1
+		-1
+	} else {1}
+}
+
+fn opt() ?&int {return none}
+
+fn test_prefix_or() {
+	// later this should compile correctly
+	v := 3
+	_ = opt() or {
+		_ = 1
+		&v
+	}
+}

--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -409,6 +409,10 @@ pub fn (k Kind) is_start_of_type() bool {
 	return k in [.name, .lpar, .amp, .lsbr, .question]
 }
 
+pub fn (kind Kind) is_prefix() bool {
+	return kind in [.minus, .amp, .mul, .not, .bit_not]
+}
+
 pub fn (kind Kind) is_infix() bool {
 	return kind in [.plus, .minus, .mod, .mul, .div, .eq, .ne, .gt, .lt, .key_in,
 	//


### PR DESCRIPTION
The user may write a prefix expression that is parsed as an infix expression when the previous line ends in an expression. This pull will detect that case and print a warning. 

This gives time for users to fix any code that is intentionally using an infix op with the op token on the following line by moving it to the same line. Then after a time, this case can be changed to parse as a prefix expression.

* Fixes #6388 - see discussion.
* Add method `table.Kind.is_prefix`.

This warning now helps the user understand the errors here:
```v
fn f() ?&int {return none}

_ = if true {
	_ = 1
	-1
} else {1}

v := 3
_ = f() or {
	_ = 1
	&v
}
```
```
prefix.v:5:2: warning: move infix `-` operator before new line (if infix intended) or use brackets for prefix `&` op
    3 | _ = if true {
    4 |     _ = 1
    5 |     -1
      |     ^
    6 | } else {1}
    7 |
prefix.v:11:2: warning: move infix `&` operator before new line (if infix intended) or use brackets for prefix `&` op
    9 | _ = f() or {
   10 |     _ = 1
   11 |     &v
      |     ^
   12 | }
prefix.v:3:5: error: `if` expression requires an expression as the last statement of every branch
    1 | fn f()?int {return 4}
    2 |
    3 | _ = if true {
      |     ~~~~~~~
    4 |     _ = 1
    5 |     -1
prefix.v:9:5: error: last statement in the `or {}` block should be an expression of type `&int` or exit parent scope
    7 |
    8 | v := 3
    9 | _ = f() or {
      |     ~~~
   10 |     _ = 1
   11 |     &v
```
Note: V currently causes a C error when using the parens workaround for the `if` expression above.