### PR TITLE
lowercase for all struct fields

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2520,10 +2520,10 @@ fn decode<T>(data string) T {
     // compile-time `for` loop
     // T.fields gives an array of a field metadata type
     $for field in T.fields {
-        $if field.Type is string {
+        $if field.typ is string {
             // $(string_expr) produces an identifier
             result.$(field.name) = get_string(data, field.name)
-        } $else $if field.Type is int {
+        } $else $if field.typ is int {
             result.$(field.name) = get_int(data, field.name)
         }
     }

--- a/examples/compiletime/compile-time-for.v
+++ b/examples/compiletime/compile-time-for.v
@@ -6,23 +6,23 @@ fn (mut app App) method_three(s string) string { return s }
 
 fn main() {
 	$for method in App.methods {
-		$if method.Type is fn(string) string {
+		$if method.typ is fn(string) string {
 			println('$method.name IS `fn(string) string`')
 		} $else {
 			println('$method.name is NOT `fn(string) string`')
 		}
-		$if method.ReturnType !is int {
+		$if method.return_type !is int {
 			println('$method.name does NOT return `int`')
 		} $else {
 			println('$method.name DOES return `int`')
 		}
-		$if method.args[0].Type !is string {
+		$if method.args[0].typ !is string {
 			println("${method.name}'s first arg is NOT `string`")
 		} $else {
 			println("${method.name}'s first arg IS `string`")
 		}
 		// TODO: Double inversion, should this even be allowed?
-		$if method.Type is fn() {
+		$if method.typ is fn() {
 			println('$method.name IS a void method')
 		} $else {
 			println('$method.name is NOT a void method')

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -273,16 +273,16 @@ fn __print_assert_failure(i &VAssertMetaInfo) {
 
 pub struct MethodArgs {
 pub:
-	Type int
+	typ int
 }
 
 pub struct FunctionData {
 pub:
-	name       string
-	attrs      []string
-	args       []MethodArgs
-	ReturnType int
-	Type       int
+	name        string
+	attrs       []string
+	args        []MethodArgs
+	return_type int
+	typ         int
 }
 
 pub struct FieldData {
@@ -291,5 +291,5 @@ pub:
 	attrs  []string
 	is_pub bool
 	is_mut bool
-	Type   int
+	typ    int
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -330,7 +330,7 @@ pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
 		c.check_valid_pascal_case(decl.name, 'struct name', decl.pos)
 	}
 	for i, field in decl.fields {
-		if !c.is_builtin_mod && decl.language == .v {
+		if decl.language == .v {
 			c.check_valid_snake_case(field.name, 'field name', field.pos)
 		}
 		for j in 0 .. i {

--- a/vlib/v/gen/comptime.v
+++ b/vlib/v/gen/comptime.v
@@ -234,7 +234,7 @@ fn (mut g Gen) comp_for(node ast.CompFor) {
 					if j < len - 1 {
 						g.write(', ')
 					}
-					g.comptime_var_type_map['${node.val_var}.args[$j].Type'] = typ
+					g.comptime_var_type_map['${node.val_var}.args[$j].typ'] = typ
 				}
 				g.writeln('}));')
 			}
@@ -254,11 +254,11 @@ fn (mut g Gen) comp_for(node ast.CompFor) {
 			// if styp == 0 { }
 			// TODO: type aliases
 			ret_typ := method.return_type.idx()
-			g.writeln('\t${node.val_var}.Type = $styp;')
-			g.writeln('\t${node.val_var}.ReturnType = $ret_typ;')
+			g.writeln('\t${node.val_var}.typ = $styp;')
+			g.writeln('\t${node.val_var}.return_type = $ret_typ;')
 			//
-			g.comptime_var_type_map['${node.val_var}.ReturnType'] = ret_typ
-			g.comptime_var_type_map['${node.val_var}.Type'] = styp
+			g.comptime_var_type_map['${node.val_var}.return_type'] = ret_typ
+			g.comptime_var_type_map['${node.val_var}.typ'] = styp
 			g.stmts(node.stmts)
 			i++
 			g.writeln('')
@@ -292,10 +292,10 @@ fn (mut g Gen) comp_for(node ast.CompFor) {
 				// field_sym := g.table.get_type_symbol(field.typ)
 				// g.writeln('\t${node.val_var}.typ = tos_lit("$field_sym.name");')
 				styp := field.typ
-				g.writeln('\t${node.val_var}.Type = $styp;')
+				g.writeln('\t${node.val_var}.typ = $styp;')
 				g.writeln('\t${node.val_var}.is_pub = $field.is_pub;')
 				g.writeln('\t${node.val_var}.is_mut = $field.is_mut;')
-				g.comptime_var_type_map[node.val_var + '.Type'] = styp
+				g.comptime_var_type_map['${node.val_var}.typ'] = styp
 				g.stmts(node.stmts)
 				i++
 				g.writeln('')

--- a/vlib/v/tests/comptime_for_test.v
+++ b/vlib/v/tests/comptime_for_test.v
@@ -46,13 +46,13 @@ fn test_comptime_for_with_if() {
 	println(@FN)
 	$for method in App.methods {
 		println('  method: ' + no_lines('$method'))
-		$if method.Type is fn() {
+		$if method.typ is fn() {
 			assert method.name in ['run', 'method2']
 		}
-		$if method.ReturnType is int {
+		$if method.return_type is int {
 			assert method.name in ['int_method1', 'int_method2']
 		}
-		$if method.args[0].Type is string {
+		$if method.args[0].typ is string {
 			assert method.name == 'string_arg'
 		}
 	}
@@ -62,10 +62,10 @@ fn test_comptime_for_fields() {
 	println(@FN)
 	$for field in App.fields {
 		println('  field: $field.name | ' + no_lines('$field'))
-		$if field.Type is string {
+		$if field.typ is string {
 			assert field.name in ['a', 'b', 'g']
 		}
-		$if field.Type is f32 {
+		$if field.typ is f32 {
 			assert field.name in ['d', 'e']
 		}
 		if field.is_mut {

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -372,7 +372,7 @@ fn handle_conn<T>(conn net.Socket, mut app T) {
 	mut vars := []string{cap: route_words_a.len}
 	mut action := ''
 	$for method in T.methods {
-		$if method.ReturnType is Result {
+		$if method.return_type is Result {
 			attrs := method.attrs
 			route_words_a = [][]string{}
 			if attrs.len == 0 {
@@ -473,7 +473,7 @@ fn handle_conn<T>(conn net.Socket, mut app T) {
 		return
 	}
 	$for method in T.methods {
-		$if method.ReturnType is Result {
+		$if method.return_type is Result {
 			// search again for method
 			if action == method.name && method.attrs.len > 0 {
 				// call action method

--- a/vlib/x/json2/json2_test.v
+++ b/vlib/x/json2/json2_test.v
@@ -24,7 +24,7 @@ fn (e Employee) to_json() string {
 	$for field in Employee.fields {
 		d := e.$(field.name)
 
-		$if field.Type is JobTitle {
+		$if field.typ is JobTitle {
 			mp[field.name] = json.encode<int>(d)
 		} $else {
 			mp[field.name] = d


### PR DESCRIPTION
```v
$if method.ReturnType is ... {}
$if method.Type is ... {}
```
is now
```v
$if method.return_type is ... {}
$if method.typ is ... {}
```