### PR TITLE
android: enable autofree

### DIFF
--- a/vlib/v/gen/cmain.v
+++ b/vlib/v/gen/cmain.v
@@ -90,20 +90,48 @@ pub fn (mut g Gen) gen_c_main_footer() {
 }
 
 pub fn (mut g Gen) gen_c_android_sokol_main() {
-	// TODO get autofree weaved into android lifecycle somehow
-	/*
+	// Weave autofree into sokol lifecycle callback(s)
 	if g.autofree {
-		g.writeln('\t_vcleanup();')
+		g.writeln('// Wrapping cleanup/free callbacks for sokol to include _vcleanup()
+void (*_vsokol_user_cleanup_ptr)(void);
+void (*_vsokol_user_cleanup_cb_ptr)(void *);
+
+void (_vsokol_cleanup_cb)(void) {
+	if (_vsokol_user_cleanup_ptr) {
+		_vsokol_user_cleanup_ptr();
 	}
-	*/
-	// TODO do proper check for the global g_desc field we need
-	g.writeln('sapp_desc sokol_main(int argc, char* argv[]) {')
-	g.writeln('\t(void)argc; (void)argv;')
-	g.writeln('')
-	g.writeln('\t_vinit();')
-	g.writeln('\tmain__main();')
-	g.writeln('')
-	g.writeln('\treturn g_desc;')
+	_vcleanup();
+}
+
+void (_vsokol_cleanup_userdata_cb)(void* user_data) {
+	if (_vsokol_user_cleanup_cb_ptr) {
+		_vsokol_user_cleanup_cb_ptr(g_desc.user_data);
+	}
+	_vcleanup();
+}
+')
+	}
+
+	g.writeln('// The sokol_main entry point on Android
+sapp_desc sokol_main(int argc, char* argv[]) {
+	(void)argc; (void)argv;
+
+	_vinit();
+	main__main();
+')
+	if g.autofree {
+		g.writeln('	// Wrap user provided cleanup/free functions for sokol to be able to call _vcleanup()
+	if (g_desc.cleanup_cb) {
+		_vsokol_user_cleanup_ptr = g_desc.cleanup_cb;
+		g_desc.cleanup_cb = _vsokol_cleanup_cb;
+	}
+	else if (g_desc.cleanup_userdata_cb) {
+		_vsokol_user_cleanup_cb_ptr = g_desc.cleanup_userdata_cb;
+		g_desc.cleanup_userdata_cb = _vsokol_cleanup_userdata_cb;
+	}
+')
+	}
+	g.writeln('	return g_desc;')
 	g.writeln('}')
 }
 


### PR DESCRIPTION
Contents of this PR will wrap any user provided "cleanup" callbacks from the sokol `sapp_desc` 
in order to be able to include/append the `_vcleanup()` call required for `-autofree` to work.

Callbacks are only triggered and wrapped if they're available in the `sapp_desc`.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
