### PR TITLE
fonts: fix so it does not try for RobotoMonoMono-Regular.ttf

### DIFF
--- a/vlib/gg/text_rendering.v
+++ b/vlib/gg/text_rendering.v
@@ -234,7 +234,7 @@ fn get_font_path_variant(font_path string, variant FontVariant) string {
 			}
 		}
 		.mono {
-			if fpath.ends_with('-Regular') {
+			if !fpath.ends_with('Mono-Regular') && fpath.ends_with('-Regular') {
 				fpath = fpath.replace('-Regular', 'Mono-Regular')
 			} else if fpath.to_lower().starts_with('arial') {
 				// Arial has no mono variant
@@ -248,6 +248,6 @@ fn get_font_path_variant(font_path string, variant FontVariant) string {
 
 fn debug_font_println(s string) {
 	$if debug_font? {
-		println(s)    
+		println(s)
 	}
 }


### PR DESCRIPTION
Present logic was turning `RobotoMono-Regular.ttf` into `RobotoMonoMono-Regular.ttf`, so gfx programs were unable to find the font.  This fixes that problem, the font is found, and no more messages about not finding the font.