### PR TITLE
cgen: fix array and map printing

### DIFF
--- a/vlib/v/gen/auto_str_methods.v
+++ b/vlib/v/gen/auto_str_methods.v
@@ -387,6 +387,9 @@ fn struct_auto_str_func(sym table.TypeSymbol, field_type table.Type, fn_name, fi
 			return 'indent_${fn_name}($obj, indent_count + 1)'
 		}
 	} else if sym.kind in [.array, .array_fixed, .map] {
+		if has_custom_str {
+			return '${fn_name}(it->${c_name(field_name)})'
+		}
 		return 'indent_${fn_name}(it->${c_name(field_name)}, indent_count + 1)'
 	} else if sym.kind == .sum_type {
 		return 'indent_${fn_name}(it->${c_name(field_name)}, indent_count + 1)'

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -196,3 +196,25 @@ fn test_struct_with_f32_pointer() {
 	assert '$w' == 'Wrapper5 {\n    foo: &5.1\n}'
 	assert w.str() == 'Wrapper5 {\n    foo: &5.1\n}'
 }
+
+
+struct TestStruct {
+	x int
+}
+struct ArrayWithStruct {
+	foo []TestStruct
+}
+fn test_array_with_struct() {
+	a := ArrayWithStruct{[TestStruct{}]}
+	assert a.str() == 'ArrayWithStruct {\n    foo: [TestStruct {\n        x: 0\n    }]\n}'
+	assert '$a' == 'ArrayWithStruct {\n    foo: [TestStruct {\n        x: 0\n    }]\n}'
+}
+
+struct MapWithStruct {
+	foo map[string]TestStruct
+}
+fn test_map_with_struct() {
+	a := MapWithStruct{{'test': TestStruct{}}}
+	assert a.str() == 'MapWithStruct {\n    foo: {\'test\': TestStruct {\n        x: 0\n    }}\n}'
+	assert '$a' == 'MapWithStruct {\n    foo: {\'test\': TestStruct {\n        x: 0\n    }}\n}'
+}


### PR DESCRIPTION
```
Abc {
    foos: [Foo {
        name: 'test'
    }, Foo {
        name: 'test'
    }]
    st: 0
}
Xyz {
    bars: {'test': Foo {
        name: ''
    }}
}
```