### PR TITLE
Allow negative integers as CLI args

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -325,6 +325,10 @@ pub fn parse_args(args []string) (&Preferences, string) {
 						i++
 						continue
 					}
+					if arg[1..].int() != 0 {
+						i++
+						continue
+					}
 				} else {
 					if command == '' {
 						command = arg


### PR DESCRIPTION
Before:

```v
$ v run quicksort.v 5 2 4 -2 1 1 3 10
Unknown argument `-2` for command `run`
```

After:

```v
$ v run quicksort.v 5 2 4 -2 1 1 3 10
[-2, 1, 1, 2, 3, 4, 5, 10]
```