### PR TITLE
checker: detect correct len expression for multidimensional array init

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1032,3 +1032,18 @@ fn test_direct_array_access_via_ptr() {
 	}
 }
 
+const (
+	grid_size_1 = 2
+	grid_size_2 = 3
+	grid_size_3 = 4
+	cell_value = 123
+)
+
+fn test_multidimensional_array_initialization_with_consts() {
+	mut data := [][][]int{ len: grid_size_1, init: [][]int{ len: grid_size_2, init: []int{ len: grid_size_3, init: cell_value } } }
+	assert data.len == grid_size_1
+	assert data[0].len == grid_size_2
+	assert data[0][0].len == grid_size_3
+	assert data[0][0][0] == cell_value
+	assert data[1][1][1] == cell_value
+}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2065,6 +2065,9 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) table.Type {
 			}
 		}
 		sym := c.table.get_type_symbol(array_init.elem_type)
+		if array_init.has_default {
+			c.expr(array_init.default_expr)
+		}
 		if sym.kind == .placeholder {
 			c.error('unknown type `$sym.source_name`', array_init.elem_type_pos)
 		}


### PR DESCRIPTION
**Additions**:
Fix multidimensional array init with identifier length

**Notes**:
Fixes #6459 

**Example**:
```
const (
	grid_size	= 2
)

fn main() {
	mut data := [][][]int{ len: grid_size, init: [][]int{ len: grid_size, init: []int{ len: grid_size } } }
	println(data)
}
```
Gives
```
[[[0, 0], [0, 0]], [[0, 0], [0, 0]]]
```