### PR TITLE
gitattributes: add Dockerfile.* to Dockerfile linguist language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.v linguist-language=V text=auto eol=lf
 *.vv linguist-language=V text=auto eol=lf
 *.bat text=auto eol=crlf
+ Dockerfile.* linguist-language=Dockerfile


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR adds `Dockerfile.*`-Files to the `Dockerfile`-language.

GitHub just mark files as this language if, it has the `.dockerfile` extension or the explicit name `Dockerfile`. [(View)](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L1209)

This line in the `.gitattributes`-File will also mark `Dockerfile.*`-Files as Dockerfiles.
