### PR TITLE
checker: don't error when the last statement in a match branch is an if/match expression

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3018,7 +3018,11 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) table.Type {
 	for branch in node.branches {
 		c.stmts(branch.stmts)
 		if node.is_expr {
-			for st in branch.stmts {
+			// ignore last statement - workaround
+			// currently the last statement in a match branch does not have an
+			// expected value set, so e.g. IfExpr.is_expr is not set.
+			// probably any mismatch will be caught by not producing a value instead
+			for st in branch.stmts[0..branch.stmts.len - 1] {
 				st.check_c_expr() or {
 					c.error('`match` expression branch has $err', st.position())
 				}

--- a/vlib/v/checker/tests/if_match_expr.out
+++ b/vlib/v/checker/tests/if_match_expr.out
@@ -1,28 +1,42 @@
 vlib/v/checker/tests/if_match_expr.vv:8:6: error: `if` expression branch has unsupported statement (`v.ast.ForStmt`)
-    6 |     if true {1} else {-1} // OK
+    6 |     if true {1} else {-1} // result
     7 | } else {
     8 |     for {break}
       |         ^
     9 |     {}
-   10 |     -1
+   10 |     match true {true {} else {}} // statement not expression
 vlib/v/checker/tests/if_match_expr.vv:9:2: error: `if` expression branch has unsupported statement (`v.ast.Block`)
     7 | } else {
     8 |     for {break}
     9 |     {}
       |     ^
-   10 |     -1
-   11 | }
-vlib/v/checker/tests/if_match_expr.vv:15:10: error: `match` expression branch has unsupported statement (`v.ast.AssertStmt`)
-   13 | _ = match true {
-   14 |     true {
-   15 |         assert true
-      |                ~~~~
-   16 |         1
-   17 |     }
-vlib/v/checker/tests/if_match_expr.vv:19:3: error: `match` expression branch has unsupported statement (`v.ast.IfExpr`)
-   17 |     }
-   18 |     else {
-   19 |         if true {} // statement not expression
+   10 |     match true {true {} else {}} // statement not expression
+   11 |     _ = match true {true {1} else {-1}} // OK
+vlib/v/checker/tests/if_match_expr.vv:10:2: error: `if` expression branch has unsupported statement (`v.ast.MatchExpr`)
+    8 |     for {break}
+    9 |     {}
+   10 |     match true {true {} else {}} // statement not expression
+      |     ~~~~~
+   11 |     _ = match true {true {1} else {-1}} // OK
+   12 |     match true {true {1} else {-1}} // result
+vlib/v/checker/tests/if_match_expr.vv:17:3: error: `match` expression branch has unsupported statement (`v.ast.IfExpr`)
+   15 | _ = match true {
+   16 |     true {
+   17 |         if true {} // statement not expression
       |         ~~
-   20 |         (-1) // parens needed ATM due to bug
-   21 |     }
+   18 |         _ = if true {1} else {-1} // OK
+   19 |         if true {1} else {-1} // result
+vlib/v/checker/tests/if_match_expr.vv:22:10: error: `match` expression branch has unsupported statement (`v.ast.AssertStmt`)
+   20 |     }
+   21 |     else {
+   22 |         assert true
+      |                ~~~~
+   23 |         match true {true {} else {}} // statement not expression
+   24 |         _ = match true {true {1} else {-1}} // OK
+vlib/v/checker/tests/if_match_expr.vv:23:3: error: `match` expression branch has unsupported statement (`v.ast.MatchExpr`)
+   21 |     else {
+   22 |         assert true
+   23 |         match true {true {} else {}} // statement not expression
+      |         ~~~~~
+   24 |         _ = match true {true {1} else {-1}} // OK
+   25 |         match true {true {1} else {-1}} // result

--- a/vlib/v/checker/tests/if_match_expr.vv
+++ b/vlib/v/checker/tests/if_match_expr.vv
@@ -3,20 +3,25 @@
 _ = if true {
 	if true {} // FIXME should error, if statement
 	_ = if true {1} else {-1} // OK
-	if true {1} else {-1} // OK
+	if true {1} else {-1} // result
 } else {
 	for {break}
 	{}
-	-1
+	match true {true {} else {}} // statement not expression
+	_ = match true {true {1} else {-1}} // OK
+	match true {true {1} else {-1}} // result
 }
 
 _ = match true {
 	true {
-		assert true
-		1
+		if true {} // statement not expression
+		_ = if true {1} else {-1} // OK
+		if true {1} else {-1} // result
 	}
 	else {
-		if true {} // statement not expression
-		(-1) // parens needed ATM due to bug
+		assert true
+		match true {true {} else {}} // statement not expression
+		_ = match true {true {1} else {-1}} // OK
+		match true {true {1} else {-1}} // result
 	}
 }


### PR DESCRIPTION
Part of #6518.
Also expand related tests for IfExpr.

The last statement in a match branch currently isn't marked as expecting a value so if/match there isn't parsed as an expression.
Please see comments in diff for details.