### PR TITLE
pref: do not check arguments after 'run' command

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -337,8 +337,8 @@ pub fn parse_args(args []string) (&Preferences, string) {
 					command_pos = i
 					continue
 				}
-				if command !in ['', 'run', 'build', 'build-module'] {
-					// arguments for e.g. fmt are checked elsewhere
+				if command !in ['', 'build', 'build-module'] {
+					// arguments for e.g. fmt should be checked elsewhere
 					continue
 				}
 				eprint('Unknown argument `$arg`')


### PR DESCRIPTION
Arguments after the `run foo.v` command should be checked by the `foo` program itself.