### PR TITLE
builtin_windows.c.v: cast unhandled execption handler function

### DIFF
--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -224,7 +224,7 @@ fn unhandled_exception_handler(e &ExceptionPointers) int {
 }
 
 fn add_unhandled_exception_handler() {
-	add_vectored_exception_handler(unhandled_exception_handler)
+	add_vectored_exception_handler(VectoredExceptionHandler(voidptr(unhandled_exception_handler)))
 }
 
 fn C.IsDebuggerPresent() bool


### PR DESCRIPTION
Windows only fix.
Cast unhandled execption function to make x86 build work.
Closes #6513