### PR TITLE
parser: dont allow single letter enums

### DIFF
--- a/vlib/v/checker/tests/enum_single_letter.out
+++ b/vlib/v/checker/tests/enum_single_letter.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/enum_single_letter.vv:1:6: error: single letter capital names are reserved for generic template types.
+    1 | enum E {
+      |      ^
+    2 |     v w
+    3 | }

--- a/vlib/v/checker/tests/enum_single_letter.vv
+++ b/vlib/v/checker/tests/enum_single_letter.vv
@@ -1,0 +1,4 @@
+enum E {
+    v w
+}
+println(E.v)

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -206,7 +206,7 @@ pub fn (mut p Parser) parse_any_type(language table.Language, is_ptr, check_dot 
 		}
 	} else if p.expr_mod != '' {
 		name = p.expr_mod + '.' + name
-	} else if p.mod != 'builtin' && ((name.len > 1 && name !in p.table.type_idxs) || (name.len == 1 && p.mod + '.' + name in p.table.type_idxs)) {
+	} else if p.mod != 'builtin' && name.len > 1 && name !in p.table.type_idxs {
 		// `Foo` in module `mod` means `mod.Foo`
 		name = p.mod + '.' + name
 	}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -206,7 +206,7 @@ pub fn (mut p Parser) parse_any_type(language table.Language, is_ptr, check_dot 
 		}
 	} else if p.expr_mod != '' {
 		name = p.expr_mod + '.' + name
-	} else if p.mod != 'builtin' && name !in p.table.type_idxs && name.len > 1 {
+	} else if p.mod != 'builtin' && ((name.len > 1 && name !in p.table.type_idxs) || (name.len == 1 && p.mod + '.' + name in p.table.type_idxs)) {
 		// `Foo` in module `mod` means `mod.Foo`
 		name = p.mod + '.' + name
 	}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1723,6 +1723,10 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 	p.check(.key_enum)
 	end_pos := p.tok.position()
 	enum_name := p.check_name()
+	if enum_name.len == 1 {
+		p.error_with_pos('single letter capital names are reserved for generic template types.',
+			end_pos)
+	}
 	name := p.prepend_mod(enum_name)
 	p.check(.lcbr)
 	enum_decl_comments := p.eat_comments()

--- a/vlib/v/tests/enum_test.v
+++ b/vlib/v/tests/enum_test.v
@@ -74,24 +74,6 @@ fn test_nums() {
 	assert d == -10
 }
 
-enum E {
-	v w
-}
-
-fn single_return() E {
-	return .v
-}
-fn single_opt_return() ?E {
-	return none
-}
-
-fn test_single_letter() {
-	a := single_return()
-	b := single_opt_return() or { E.w }
-	assert a == .v
-	assert b == .w
-}
-
 /*
 enum Expr {
 	BoolExpr(bool)

--- a/vlib/v/tests/enum_test.v
+++ b/vlib/v/tests/enum_test.v
@@ -74,6 +74,24 @@ fn test_nums() {
 	assert d == -10
 }
 
+enum E {
+	v w
+}
+
+fn single_return() E {
+	return .v
+}
+fn single_opt_return() ?E {
+	return none
+}
+
+fn test_single_letter() {
+	a := single_return()
+	b := single_opt_return() or { E.w }
+	assert a == .v
+	assert b == .w
+}
+
 /*
 enum Expr {
 	BoolExpr(bool)


### PR DESCRIPTION
**Additions**:
Displays an error when a single letter enum is defined

**Notes**:
Fixes #6493 

**Example**:
```
enum E {
    v w
}
println(E.v)
```
Gives:
```
test.v:1:6: error: single letter capital names are reserved for generic template types.
    1 | enum E {
      |      ^
    2 |     v w
    3 | }
```