### PR TITLE
compiler: fix whitespace in error message

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -442,7 +442,7 @@ fn parse_define(mut prefs Preferences, define string) {
 			}
 			else {
 				println('V error: Unknown define argument value `${define_parts[1]}` for ${define_parts[0]}.' +
-					'Expected `0` or `1`.')
+					' Expected `0` or `1`.')
 				exit(1)
 			}
 		}


### PR DESCRIPTION
Trivial fix for a missing whitespace in compiler error message