### PR TITLE
gen: removes space on struct printing

### DIFF
--- a/vlib/v/gen/auto_str_methods.v
+++ b/vlib/v/gen/auto_str_methods.v
@@ -297,7 +297,7 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp, str_fn_name string) {
 	for field in info.fields {
 		sym := g.table.get_type_symbol(field.typ)
 		if !sym.has_method('str') {
-			mut typ := field.typ 
+			mut typ := field.typ
 			if typ.is_ptr() {
 				typ = typ.deref()
 			}
@@ -327,9 +327,9 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp, str_fn_name string) {
 	g.auto_str_funcs.writeln('\t\tindents = string_add(indents, tos_lit("    "));')
 	g.auto_str_funcs.writeln('\t}')
 	if info.fields.len == 0 {
-		g.auto_str_funcs.write('\treturn tos_lit("$clean_struct_v_type_name { }");')
+		g.auto_str_funcs.write('\treturn tos_lit("$clean_struct_v_type_name{}");')
 	} else {
-		g.auto_str_funcs.write('\treturn _STR("$clean_struct_v_type_name {\\n"')
+		g.auto_str_funcs.write('\treturn _STR("$clean_struct_v_type_name{\\n"')
 		for field in info.fields {
 			mut fmt := g.type_to_fmt(field.typ)
 			if field.typ.is_ptr() {

--- a/vlib/v/tests/enum_default_value_in_struct_test.v
+++ b/vlib/v/tests/enum_default_value_in_struct_test.v
@@ -1,10 +1,10 @@
-pub enum MyEnum {
+enum MyEnum {
 	first = 20
 	second
 	third
 }
 
-pub struct MyStruct {
+struct MyStruct {
 mut:
 	e MyEnum = .second
 }
@@ -31,5 +31,5 @@ fn test_generation_of_string_interpolation_method_for_pointer_to_struct_containi
 	t := &MyStruct{
 		e: .third
 	}
-	assert 't: $t' == 't: &MyStruct {\n    e: third\n}'
+	assert 't: $t' == 't: &MyStruct{\n    e: third\n}'
 }

--- a/vlib/v/tests/inout/nested_structs.out
+++ b/vlib/v/tests/inout/nested_structs.out
@@ -1,11 +1,11 @@
-Aaa {
+Aaa{
     test: false
-    b: Bbb {
+    b: Bbb{
         pass: false
         name: ''
     }
 }
-Bbb {
+Bbb{
     pass: false
     name: ''
 }

--- a/vlib/v/tests/map_to_string_test.v
+++ b/vlib/v/tests/map_to_string_test.v
@@ -31,9 +31,9 @@ fn test_interpolation_map_to_string() {
 	e['2'] = Test{true, 1, 'def'}
 	e['3'] = Test{false, 2, 'ghi'}
 	s := '$e'
-	assert s.contains("{'1': Test {")
+	assert s.contains("{'1': Test{")
 	assert s.contains('a: true')
 	assert s.contains("y: 'abc'")
-	assert s.contains("}, '2': Test {")
+	assert s.contains("}, '2': Test{")
 	assert s.contains("y: 'def'")
 }

--- a/vlib/v/tests/prod/assoc.prod.v.expected.txt
+++ b/vlib/v/tests/prod/assoc.prod.v.expected.txt
@@ -1,3 +1,3 @@
-MyStruct {
+MyStruct{
     s: '6'
 }

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -146,8 +146,8 @@ struct Wrapper {
 fn test_struct_with_string_pointer() {
 	s := 'test'
 	w := Wrapper{&s}
-	assert '$w' == 'Wrapper {\n    foo: &\'test\'\n}'
-	assert w.str() == 'Wrapper {\n    foo: &\'test\'\n}'
+	assert '$w' == 'Wrapper{\n    foo: &\'test\'\n}'
+	assert w.str() == 'Wrapper{\n    foo: &\'test\'\n}'
 }
 
 struct Wrapper2 {
@@ -156,8 +156,8 @@ struct Wrapper2 {
 fn test_struct_with_int_pointer() {
 	i := 5
 	w := Wrapper2{&i}
-	assert '$w' == 'Wrapper2 {\n    foo: &5\n}'
-	assert w.str() == 'Wrapper2 {\n    foo: &5\n}'
+	assert '$w' == 'Wrapper2{\n    foo: &5\n}'
+	assert w.str() == 'Wrapper2{\n    foo: &5\n}'
 }
 
 struct Wrapper3 {
@@ -166,8 +166,8 @@ struct Wrapper3 {
 fn test_struct_with_bool_pointer() {
 	b := true
 	w := Wrapper3{&b}
-	assert '$w' == 'Wrapper3 {\n    foo: &true\n}'
-	assert w.str() == 'Wrapper3 {\n    foo: &true\n}'
+	assert '$w' == 'Wrapper3{\n    foo: &true\n}'
+	assert w.str() == 'Wrapper3{\n    foo: &true\n}'
 }
 
 struct Foo {}
@@ -177,14 +177,14 @@ struct Wrapper4 {
 fn test_struct_with_struct_pointer() {
 	b := Foo{}
 	w := Wrapper4{&b}
-	assert '$w' == 'Wrapper4 {\n    foo: &Foo { }\n}'
-	assert w.str() == 'Wrapper4 {\n    foo: &Foo { }\n}'
+	assert '$w' == 'Wrapper4{\n    foo: &Foo{}\n}'
+	assert w.str() == 'Wrapper4{\n    foo: &Foo{}\n}'
 }
 
 fn test_struct_with_nil() {
 	w := Wrapper4{}
-	assert '$w' == 'Wrapper4 {\n    foo: &nil\n}'
-	assert w.str() == 'Wrapper4 {\n    foo: &nil\n}'
+	assert '$w' == 'Wrapper4{\n    foo: &nil\n}'
+	assert w.str() == 'Wrapper4{\n    foo: &nil\n}'
 }
 
 struct Wrapper5 {
@@ -193,8 +193,8 @@ struct Wrapper5 {
 fn test_struct_with_f32_pointer() {
 	i := f32(5.1)
 	w := Wrapper5{&i}
-	assert '$w' == 'Wrapper5 {\n    foo: &5.1\n}'
-	assert w.str() == 'Wrapper5 {\n    foo: &5.1\n}'
+	assert '$w' == 'Wrapper5{\n    foo: &5.1\n}'
+	assert w.str() == 'Wrapper5{\n    foo: &5.1\n}'
 }
 
 
@@ -206,8 +206,8 @@ struct ArrayWithStruct {
 }
 fn test_array_with_struct() {
 	a := ArrayWithStruct{[TestStruct{}]}
-	assert a.str() == 'ArrayWithStruct {\n    foo: [TestStruct {\n        x: 0\n    }]\n}'
-	assert '$a' == 'ArrayWithStruct {\n    foo: [TestStruct {\n        x: 0\n    }]\n}'
+	assert a.str() == 'ArrayWithStruct{\n    foo: [TestStruct{\n        x: 0\n    }]\n}'
+	assert '$a' == 'ArrayWithStruct{\n    foo: [TestStruct{\n        x: 0\n    }]\n}'
 }
 
 struct MapWithStruct {
@@ -215,6 +215,6 @@ struct MapWithStruct {
 }
 fn test_map_with_struct() {
 	a := MapWithStruct{{'test': TestStruct{}}}
-	assert a.str() == 'MapWithStruct {\n    foo: {\'test\': TestStruct {\n        x: 0\n    }}\n}'
-	assert '$a' == 'MapWithStruct {\n    foo: {\'test\': TestStruct {\n        x: 0\n    }}\n}'
+	assert a.str() == 'MapWithStruct{\n    foo: {\'test\': TestStruct{\n        x: 0\n    }}\n}'
+	assert '$a' == 'MapWithStruct{\n    foo: {\'test\': TestStruct{\n        x: 0\n    }}\n}'
 }

--- a/vlib/v/tests/string_interpolation_array_test.v
+++ b/vlib/v/tests/string_interpolation_array_test.v
@@ -20,11 +20,11 @@ fn test_array_of_structs_interpolation() {
 		Man{'Bilbo Baggins', 111, ['exploring', 'hiding']},
 	]
 	s := '$people' // the compiler should generate code for both a) and b)
-	assert s.contains('Man {')
+	assert s.contains('Man{')
 	assert s.contains("name: 'Superman'")
 	assert s.contains('age: 30')
 	assert s.contains("'being nice'")
-	assert s.contains('}, Man {')
+	assert s.contains('}, Man{')
 	assert s.contains("name: 'Bilbo Baggins'")
 	assert s.contains('age: 111')
 	assert s.contains("interests: ['exploring', 'hiding']")

--- a/vlib/v/tests/string_interpolation_struct_test.v
+++ b/vlib/v/tests/string_interpolation_struct_test.v
@@ -10,7 +10,7 @@ struct Man {
 fn test_default_struct_string_interpolation() {
 	superman := Man{'Superman', 30, ['flying', 'fighting evil', 'being nice']}
 	s := '$superman'
-	assert s.starts_with('Man {')
+	assert s.starts_with('Man{')
 	assert s.contains("name: 'Superman'")
 	assert s.contains('age: 30')
 	assert s.contains('interests: [')
@@ -29,7 +29,7 @@ fn test_fixed_array_struct_string_interpolation() {
 	x := 2.32
 	ctx.vb = [1.1, x, 3.3, 4.4, 5.0, 6.0, 7.0, 8.9]!!
 	s := '$ctx'
-	assert s.starts_with('Context {')
+	assert s.starts_with('Context{')
 	assert s.contains('vb: [1.1, 2.32, 3.3, 4.4, 5, 6, 7, 8.9]')
 	assert s.ends_with('}')
 }
@@ -45,7 +45,7 @@ fn test_struct_map_field_string_interpolation() {
 		dict: {'a': int(1), 'b': 2}
 	}
 	s := '$info'
-	assert s.starts_with('Info {')
+	assert s.starts_with('Info{')
 	assert s.contains("name: 'test'")
 	assert s.contains("dict: {'a': 1, 'b': 2}")
 	assert s.ends_with('}')

--- a/vlib/v/tests/string_interpolation_variadic_test.v
+++ b/vlib/v/tests/string_interpolation_variadic_test.v
@@ -16,11 +16,11 @@ fn test_vargs_string_interpolation() {
 	man := Man{'Me', 38, ['programming', 'reading', 'hiking']}
 	superman := Man{'Superman', 30, ['flying', 'fighting evil', 'being nice']}
 	results := my_variadic_function(superman, man)
-	assert results.contains('Man {')
+	assert results.contains('Man{')
 	//
 	assert results.contains("name: 'Superman'")
 	assert results.contains('age: 30')
-	assert results.contains('}, Man {')
+	assert results.contains('}, Man{')
 	//
 	assert results.contains("interests: ['programming'")
 	assert results.contains("name: 'Me'")

--- a/vlib/v/tests/sumtype_str_test.v
+++ b/vlib/v/tests/sumtype_str_test.v
@@ -72,6 +72,6 @@ struct HolaContainer {
 
 fn test_custom_str_method() {
 	h := HolaContainer{}
-	assert h.str() == 'HolaContainer {\n    h: Hola\n}'
-	assert '$h' == 'HolaContainer {\n    h: Hola\n}'
+	assert h.str() == 'HolaContainer{\n    h: Hola\n}'
+	assert '$h' == 'HolaContainer{\n    h: Hola\n}'
 }

--- a/vlib/v/tests/sumtype_str_test.v
+++ b/vlib/v/tests/sumtype_str_test.v
@@ -20,8 +20,8 @@ fn test_string_st_str() {
 
 fn test_struct_st_str() {
 	a := ST(Abc{})
-	assert '$a' == 'ST(Abc {\n    foo: 0\n    bar: false\n    str: \'\'\n})'
-	assert a.str() == 'ST(Abc {\n    foo: 0\n    bar: false\n    str: \'\'\n})'
+	assert '$a' == 'ST(Abc{\n    foo: 0\n    bar: false\n    str: \'\'\n})'
+	assert a.str() == 'ST(Abc{\n    foo: 0\n    bar: false\n    str: \'\'\n})'
 }
 
 fn test_bool_st_str() {
@@ -36,21 +36,21 @@ struct Container {
 
 fn test_in_struct() {
 	c := Container{ST(0)}
-	assert '$c' == 'Container {\n    st: ST(0)\n}'
-	assert c.str() == 'Container {\n    st: ST(0)\n}'
+	assert '$c' == 'Container{\n    st: ST(0)\n}'
+	assert c.str() == 'Container{\n    st: ST(0)\n}'
 }
 
 fn test_unknown_value() {
 	c := Container{}
-	assert '$c' == 'Container {\n    st: unknown sum type value\n}'
-	assert c.str() == 'Container {\n    st: unknown sum type value\n}'
+	assert '$c' == 'Container{\n    st: unknown sum type value\n}'
+	assert c.str() == 'Container{\n    st: unknown sum type value\n}'
 }
 
 fn test_nested_in_struct() {
 	abc := Abc{}
 	c := Container{ST(abc)}
-	assert '$c' == 'Container {\n    st: ST(Abc {\n        foo: 0\n        bar: false\n        str: \'\'\n    })\n}'
-	assert c.str() == 'Container {\n    st: ST(Abc {\n        foo: 0\n        bar: false\n        str: \'\'\n    })\n}'
+	assert '$c' == 'Container{\n    st: ST(Abc{\n        foo: 0\n        bar: false\n        str: \'\'\n    })\n}'
+	assert c.str() == 'Container{\n    st: ST(Abc{\n        foo: 0\n        bar: false\n        str: \'\'\n    })\n}'
 }
 
 fn test_pointer() {


### PR DESCRIPTION
```
struct Abc{
...
}
```
instead of
```
struct Abc {
...
}
```

Waiting for https://github.com/vlang/v/pull/6534 to be merged.