### PR TITLE
cgen: fix as cast when sumtype is the result of a function call

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -5058,7 +5058,9 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 
 fn (mut g Gen) is_expr(node ast.InfixExpr) {
 	eq := if node.op == .key_is { '==' } else { '!=' }
+	g.write('(')
 	g.expr(node.left)
+	g.write(')')
 	if node.left_type.is_ptr() {
 		g.write('->')
 	} else {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -5044,11 +5044,13 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 		g.write('.obj')
 		*/
 		dot := if node.expr_type.is_ptr() { '->' } else { '.' }
-		g.write('/* as */ ($styp*)__as_cast(')
+		g.write('/* as */ ($styp*)__as_cast((')
 		g.expr(node.expr)
+		g.write(')')
 		g.write(dot)
-		g.write('_object, ')
+		g.write('_object, (')
 		g.expr(node.expr)
+		g.write(')')
 		g.write(dot)
 		g.write('typ, /*expected:*/$node.typ)')
 	}

--- a/vlib/v/tests/as_cast_is_expr_sumtype_fn_result_test.v
+++ b/vlib/v/tests/as_cast_is_expr_sumtype_fn_result_test.v
@@ -1,0 +1,20 @@
+const( str = 'abcdefghijklmnopqrstuvwxyz' num = 1234567890 )
+struct S1 { s1 string = str }
+struct S2 { s2 int = num }
+type Sum = S1 | S2
+
+fn test_as_cast_with_sumtype_fn_result() {
+	a := [Sum(S1{}), Sum(S2{})]
+	v1 := a.first() as S1
+	assert v1.s1 == str
+	assert (a.first() as S1).s1 == str
+	v2 := a.last() as S2
+	assert v2.s2 == num
+	assert (a.last() as S2).s2 == num
+}
+
+fn test_is_expr_with_sumtype_fn_result() {
+	a := [Sum(S1{}), Sum(S2{})]
+	assert a.first() is S1
+	assert a.last() is S2
+}


### PR DESCRIPTION
this is a fix for `as` cast, for the cases where the sumtype (left part of `as`) is the result of a fn call.
this fixes issue #6497
on the go I have found that `is` expr also fails under the same circumstances. second commit fixes that.
added test `as_cast_is_expr_sumtype_fn_result_test.v `, inspired on @ntrel code on the issue.