### PR TITLE
gen: access fields in multi-type sumtype match

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2693,8 +2693,11 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 	g.expr(node.cond)
 	g.writeln(';')
 	g.write(cur_line)
+	// TODO refactor, there are far too many indents
 	for j, branch in node.branches {
 		mut sumtype_index := 0
+		// iterates through all types in sumtype branches
+		// it loops only once for other types
 		for {
 			is_last := j == node.branches.len - 1
 			if branch.is_else || (node.is_expr && is_last) {
@@ -2720,6 +2723,8 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 					g.write('if (')
 				}
 				if node.is_sum_type && branch.exprs.len > 0 {
+					// the multiple expressions of sumtypes are treated by the immediate `for` loop
+					// TODO move sumtype match to there own function
 					g.write(cond_var)
 					sym := g.table.get_type_symbol(node.cond_type)
 					// branch_sym := g.table.get_type_symbol(branch.typ)

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2694,31 +2694,32 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 	g.writeln(';')
 	g.write(cur_line)
 	for j, branch in node.branches {
-		is_last := j == node.branches.len - 1
-		if branch.is_else || (node.is_expr && is_last) {
-			if node.branches.len > 1 {
-				if is_expr {
-					// TODO too many branches. maybe separate ?: matches
-					g.write(' : ')
-				} else {
-					g.writeln(' else {')
+		mut sumtype_index := 0
+		for {
+			is_last := j == node.branches.len - 1
+			if branch.is_else || (node.is_expr && is_last) {
+				if node.branches.len > 1 {
+					if is_expr {
+						// TODO too many branches. maybe separate ?: matches
+						g.write(' : ')
+					} else {
+						g.writeln(' else {')
+					}
 				}
-			}
-		} else {
-			if j > 0 {
-				if is_expr {
-					g.write(' : ')
-				} else {
-					g.write(' else ')
-				}
-			}
-			if is_expr {
-				g.write('(')
 			} else {
-				g.write('if (')
-			}
-			for i, expr in branch.exprs {
-				if node.is_sum_type {
+				if j > 0 {
+					if is_expr {
+						g.write(' : ')
+					} else {
+						g.write(' else ')
+					}
+				}
+				if is_expr {
+					g.write('(')
+				} else {
+					g.write('if (')
+				}
+				if node.is_sum_type && branch.exprs.len > 0 {
 					g.write(cond_var)
 					sym := g.table.get_type_symbol(node.cond_type)
 					// branch_sym := g.table.get_type_symbol(branch.typ)
@@ -2730,79 +2731,85 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 						// g.write('._interface_idx == _${sym.name}_${branch_sym} ')
 						g.write('._interface_idx == ')
 					}
-					g.expr(expr)
-				} else if type_sym.kind == .string {
-					if (expr as ast.StringLiteral).val == '' {
-						g.write('${cond_var}.len == 0')
-					} else {
-						g.write('string_eq(')
-						g.write(cond_var)
-						g.write(', ')
-						g.expr(expr)
-						g.write(')')
-					}
-				} else if expr is ast.RangeExpr {
-					// if type is unsigned and low is 0, check is unneeded
-					mut skip_low := false
-					if expr.low is ast.IntegerLiteral as expr_low {
-						if node.cond_type in [table.u16_type, table.u32_type, table.u64_type] &&
-							expr_low.val == '0' {
-							skip_low = true
+					g.expr(branch.exprs[sumtype_index])
+				} else {
+					for i, expr in branch.exprs {
+						if i > 0 {
+							g.write(' || ')
+						}
+						if type_sym.kind == .string {
+							if (expr as ast.StringLiteral).val == '' {
+								g.write('${cond_var}.len == 0')
+							} else {
+								g.write('string_eq(')
+								g.write(cond_var)
+								g.write(', ')
+								g.expr(expr)
+								g.write(')')
+							}
+						} else if expr is ast.RangeExpr {
+							// if type is unsigned and low is 0, check is unneeded
+							mut skip_low := false
+							if expr.low is ast.IntegerLiteral as expr_low {
+								if node.cond_type in [table.u16_type, table.u32_type, table.u64_type] &&
+									expr_low.val == '0' {
+									skip_low = true
+								}
+							}
+							g.write('(')
+							if !skip_low {
+								g.write(cond_var)
+								g.write(' >= ')
+								g.expr(expr.low)
+								g.write(' && ')
+							}
+							g.write(cond_var)
+							g.write(' <= ')
+							g.expr(expr.high)
+							g.write(')')
+						} else {
+							g.write(cond_var)
+							g.write(' == ')
+							g.expr(expr)
 						}
 					}
-					g.write('(')
-					if !skip_low {
-						g.write(cond_var)
-						g.write(' >= ')
-						g.expr(expr.low)
-						g.write(' && ')
-					}
-					g.write(cond_var)
-					g.write(' <= ')
-					g.expr(expr.high)
-					g.write(')')
+				}
+				if is_expr {
+					g.write(') ? ')
 				} else {
-					g.write(cond_var)
-					g.write(' == ')
-					g.expr(expr)
-				}
-				if i < branch.exprs.len - 1 {
-					g.write(' || ')
+					g.writeln(') {')
 				}
 			}
-			if is_expr {
-				g.write(') ? ')
-			} else {
-				g.writeln(') {')
-			}
-		}
-		// g.writeln('/* M sum_type=$node.is_sum_type is_expr=$node.is_expr exp_type=${g.typ(node.expected_type)}*/')
-		if node.is_sum_type && branch.exprs.len > 0 && !node.is_expr {
-			// The first node in expr is an ast.Type
-			// Use it to generate `it` variable.
-			first_expr := branch.exprs[0]
-			match first_expr {
-				ast.Type {
-					it_type := g.typ(first_expr.typ)
-					// g.writeln('$it_type* it = ($it_type*)${tmp}.obj; // ST it')
-					g.write('\t$it_type* it = ($it_type*)')
-					g.write(cond_var)
-					dot_or_ptr := if node.cond_type.is_ptr() { '->' } else { '.' }
-					g.write(dot_or_ptr)
-					g.writeln('_object; // ST it')
-					if node.var_name.len > 0 {
-						// for now we just copy it
-						g.writeln('\t$it_type* $node.var_name = it;')
+			// g.writeln('/* M sum_type=$node.is_sum_type is_expr=$node.is_expr exp_type=${g.typ(node.expected_type)}*/')
+			if node.is_sum_type && branch.exprs.len > 0 {
+				if !node.is_expr {
+					// Use the nodes in the expr to generate `it` variable.
+					type_expr := branch.exprs[sumtype_index]
+					if type_expr is ast.Type {
+						it_type := g.typ(type_expr.typ)
+						// g.writeln('$it_type* it = ($it_type*)${tmp}.obj; // ST it')
+						g.write('\t$it_type* it = ($it_type*)')
+						g.write(cond_var)
+						dot_or_ptr := if node.cond_type.is_ptr() { '->' } else { '.' }
+						g.write(dot_or_ptr)
+						g.writeln('_object; // ST it')
+						if node.var_name.len > 0 {
+							// for now we just copy it
+							g.writeln('\t$it_type* $node.var_name = it;')
+						}
+					} else {
+						verror('match sum type')
 					}
 				}
-				else {
-					verror('match sum type')
-				}
+				sumtype_index++
 			}
-		}
-		g.stmts(branch.stmts)
-		if g.inside_ternary == 0 && node.branches.len > 1 {
-			g.write('}')
+			g.stmts(branch.stmts)
+			if g.inside_ternary == 0 && node.branches.len > 1 {
+				g.write('}')
+			}
+			if !node.is_sum_type || branch.exprs.len == 0 || sumtype_index == branch.exprs.len {
+				break
+			}
 		}
 	}
 	if is_expr {

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -562,10 +562,6 @@ fn (mut p Parser) fn_args() ([]table.Param, bool, bool) {
 	return args, types_only, is_variadic
 }
 
-fn (p &Parser) fileis(s string) bool {
-	return p.file_name.contains(s)
-}
-
 fn (mut p Parser) check_fn_mutable_arguments(typ table.Type, pos token.Position) {
 	sym := p.table.get_type_symbol(typ)
 	if sym.kind !in [.array, .struct_, .map, .placeholder, .sum_type] && !typ.is_ptr() {

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -269,13 +269,6 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 
 fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 	first_pos := p.tok.position()
-	/*
-	defer {
-		if p.fileis('x.v') {
-			p.warn('end of struct init $short_syntax')
-		}
-	}
-	*/
 	typ := if short_syntax { table.void_type } else { p.parse_type() }
 	p.expr_mod = ''
 	// sym := p.table.get_type_symbol(typ)

--- a/vlib/v/tests/match_test.v
+++ b/vlib/v/tests/match_test.v
@@ -189,12 +189,11 @@ type NATOAlphabet = Alfa | Bravo | Charlie
 
 fn test_match_sum_type_multiple_type() {
 	a := Alfa{}
-	// TODO This currently works because cgen takes the first type as the type of `l`
-	// it would fail if we `a` was of type `Bravo`
 	match NATOAlphabet(a) as l {
 		Alfa, Bravo {
 			assert l.char == `a`
-			assert l.letter() == `a`
+			// TODO make methods work
+			// assert l.letter() == `a`
 		}
 		Charlie {
 			assert false


### PR DESCRIPTION
Allow generating sumtype match branch with multiple types. This only allows accessing the fields of the variable, methods don't work.

Aside: fix writing a lot of indents in some cases in fmt