### PR TITLE
fmt: fix formatting of anon args

### DIFF
--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -28,7 +28,7 @@ mut:
 
 fn C.uname(name voidptr) int
 
-fn C.symlink(arg_1, arg_2 charptr) int
+fn C.symlink(charptr, charptr) int
 
 pub fn uname() Uname {
 	mut u := Uname{}
@@ -124,7 +124,7 @@ pub fn mkdir(path string) ?bool {
 	r := unsafe {
 		C.mkdir(charptr(apath.str), 511)
 	}
-	
+
 	if r == -1 {
 		return error(posix_get_error_msg(C.errno))
 	}

--- a/vlib/pg/pg.v
+++ b/vlib/pg/pg.v
@@ -30,23 +30,23 @@ pub:
 
 fn C.PQconnectdb(a byteptr) &C.PGconn
 
-fn C.PQerrorMessage(arg_1 voidptr) byteptr
+fn C.PQerrorMessage(voidptr) byteptr
 
-fn C.PQgetvalue(arg_1 voidptr, arg_2, arg_3 int) byteptr
+fn C.PQgetvalue(voidptr, int, int) byteptr
 
-fn C.PQstatus(arg_1 voidptr) int
+fn C.PQstatus(voidptr) int
 
-fn C.PQntuples(arg_1 voidptr) int
+fn C.PQntuples(voidptr) int
 
-fn C.PQnfields(arg_1 voidptr) int
+fn C.PQnfields(voidptr) int
 
-fn C.PQexec(arg_1 voidptr) voidptr
+fn C.PQexec(voidptr) voidptr
 
-fn C.PQexecParams(arg_1 voidptr) voidptr
+fn C.PQexecParams(voidptr) voidptr
 
-fn C.PQclear(arg_1 voidptr) voidptr
+fn C.PQclear(voidptr) voidptr
 
-fn C.PQfinish(arg_1 voidptr)
+fn C.PQfinish(voidptr)
 
 // Makes a new connection to the database server using
 // the parameters from the `Config` structure, returning

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -64,7 +64,8 @@ pub fn (node &FnDecl) stringify(t &table.Table, cur_mod string) string {
 			continue
 		}
 		is_last_arg := i == node.params.len - 1
-		should_add_type := is_last_arg || node.params[i + 1].typ != arg.typ ||
+		is_type_only := arg.name == ''
+		should_add_type := is_last_arg || is_type_only || node.params[i + 1].typ != arg.typ ||
 			(node.is_variadic && i == node.params.len - 2)
 		if arg.is_mut {
 			f.write(arg.typ.share().str() + ' ')
@@ -79,11 +80,13 @@ pub fn (node &FnDecl) stringify(t &table.Table, cur_mod string) string {
 		}
 		s = util.no_cur_mod(s, cur_mod)
 		if should_add_type {
-			if node.is_variadic && is_last_arg {
-				f.write(' ...' + s)
-			} else {
-				f.write(' ' + s)
+			if !is_type_only {
+				f.write(' ')
 			}
+			if node.is_variadic && is_last_arg {
+				f.write('...')
+			}
+			f.write(s)
 		}
 		if !is_last_arg {
 			f.write(', ')

--- a/vlib/v/fmt/tests/fn_with_anon_params_keep.vv
+++ b/vlib/v/fmt/tests/fn_with_anon_params_keep.vv
@@ -1,0 +1,1 @@
+fn C.PQgetvalue(voidptr, int, int) byteptr

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -208,7 +208,6 @@ fn (mut g Gen) write_defer_stmts_when_needed() {
 fn (mut g Gen) fn_args(args []table.Param, is_variadic bool) ([]string, []string) {
 	mut fargs := []string{}
 	mut fargtypes := []string{}
-	no_names := args.len > 0 && args[0].name == 'arg_1'
 	for i, arg in args {
 		caname := c_name(arg.name)
 		typ := g.unwrap_generic(arg.typ)
@@ -245,11 +244,6 @@ fn (mut g Gen) fn_args(args []table.Param, is_variadic bool) ([]string, []string
 				g.write(')')
 				g.definitions.write(')')
 			}
-		} else if no_names {
-			g.write(arg_type_name)
-			g.definitions.write(arg_type_name)
-			fargs << ''
-			fargtypes << arg_type_name
 		} else {
 			mut nr_muls := arg.typ.nr_muls()
 			s := arg_type_name + ' ' + caname

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -900,7 +900,6 @@ fn (mut g JsGen) gen_method_decl(it ast.FnDecl) {
 }
 
 fn (mut g JsGen) fn_args(args []table.Param, is_variadic bool) {
-	// no_names := args.len > 0 && args[0].name == 'arg_1'
 	for i, arg in args {
 		name := g.js_name(arg.name)
 		is_varg := i == args.len - 1 && is_variadic


### PR DESCRIPTION
Fix formatting type only args in C or JS definitions.

I removed some code that apparently isn't used, or at least isn't tested, in https://github.com/vlang/v/commit/724fc08356abec4fa09657deadf2284c10b61c97
I couldn't really understand what could it have been used for, so this deserves a double check...