### PR TITLE
atoi.v: common_parse_uint2 with error code return values

### DIFF
--- a/vlib/strconv/atoi_test.v
+++ b/vlib/strconv/atoi_test.v
@@ -26,3 +26,37 @@ fn test_parse_int() {
 	assert strconv.parse_int('123', 10, 65) == 0
 	assert strconv.parse_int('123', 10, -1) == 0
 }
+
+fn test_common_parse_uint2() {
+	mut result, mut error := strconv.common_parse_uint2('1', 10, 8)
+	assert result == 1
+	assert error == 0
+
+	result, error = strconv.common_parse_uint2('123', 10, 8)
+	assert result == 123
+	assert error == 0
+
+	result, error = strconv.common_parse_uint2('123', 10, 65)
+	assert result == 0
+	assert error == -2
+
+	result, error = strconv.common_parse_uint2('123', 10, -1)
+	assert result == 0
+	assert error == -2
+
+	result, error = strconv.common_parse_uint2('', 10, 8)
+	assert result == 0
+	assert error == 1
+
+	result, error = strconv.common_parse_uint2('1a', 10, 8)
+	assert result == 1
+	assert error == 2
+
+	result, error = strconv.common_parse_uint2('12a', 10, 8)
+	assert result == 12
+	assert error == 3
+
+	result, error = strconv.common_parse_uint2('123a', 10, 8)
+	assert result == 123
+	assert error == 4
+}


### PR DESCRIPTION
Signed-off-by: vmcrash <vmcrash@users.noreply.github.com>



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
