### PR TITLE
fmt: fix formatting enum with attributes

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -686,6 +686,7 @@ pub:
 	is_multi_allowed bool
 	comments         []Comment // enum Abc { /* comments */ ... }
 	fields           []EnumField
+	attrs            []table.Attr
 	pos              token.Position
 }
 

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -319,6 +319,7 @@ pub fn (mut f Fmt) stmt(node ast.Stmt) {
 			f.writeln('}')
 		}
 		ast.EnumDecl {
+			f.attrs(it.attrs)
 			if it.is_pub {
 				f.write('pub ')
 			}

--- a/vlib/v/fmt/tests/attrs_keep.vv
+++ b/vlib/v/fmt/tests/attrs_keep.vv
@@ -14,3 +14,9 @@ struct User {
 	typ           int    [json: 'type']
 	pets          string [raw; json: 'pet_animals']
 }
+
+[_allow_multiple_values]
+enum Example {
+	value1 = 1
+	value1_again = 1
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1804,6 +1804,7 @@ $pubfn (mut e  $enum_name) toggle(flag $enum_name)   { unsafe{ *e = int(*e) ^  (
 		is_multi_allowed: is_multi_allowed
 		fields: fields
 		pos: start_pos.extend(end_pos)
+		attrs: p.attrs
 		comments: enum_decl_comments
 	}
 }


### PR DESCRIPTION
Adds an `attrs` field to `ast.EnumDecl`.