### PR TITLE
os.environment: ensure that setenv creates the key

### DIFF
--- a/vlib/os/environment.v
+++ b/vlib/os/environment.v
@@ -35,6 +35,12 @@ pub fn setenv(name string, value string, overwrite bool) int {
 			unsafe {
 				return C._putenv(format.str)
 			}
+		} else {
+			if getenv(name).len == 0 {
+				unsafe {
+					return C._putenv(format.str)
+				}
+			}
 		}
 		return -1
 	} $else {

--- a/vlib/os/environment_test.v
+++ b/vlib/os/environment_test.v
@@ -1,4 +1,5 @@
 import os
+import time
 
 fn test_getenv() {
 	// VEXE is set by the V builtin test runner
@@ -33,4 +34,16 @@ fn test_environ() {
 	assert all['myvar1'] == 'bar1'
 	assert all['myvar2'] == 'bar2'
 	assert all['myvar_not_defined'] == ''
+}
+
+fn test_setenv_var_not_exists(){
+	key := time.new_time(time.now()).unix
+	os.setenv('foo$key', 'bar', false)
+	assert os.getenv('foo$key') == 'bar'
+}
+
+fn test_getenv_empty_var(){
+	key := time.new_time(time.now()).unix
+	os.setenv('empty$key', '""', false)
+	assert os.getenv('empty$key') == '""'
 }


### PR DESCRIPTION
Windows only

Make sure that setenv creates a key if it is used with param overwrite=false and the key does not yet exist
Closes #6559

