### PR TITLE
add C fn memfreedup to cheaders.v

### DIFF
--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -407,6 +407,11 @@ void _vcleanup();
 		return ((r&0x1fffff)+((r>>21)&0x1fffff)+((r>>42)&0x1fffff))*_wynorm-3.0;
 	}
 #endif
+
+voidptr memfreedup(voidptr ptr, voidptr src, int sz) {
+	free(ptr);
+	return memdup(src, sz);
+}
 '
 	c_builtin_types = '
 //================================== builtin types ================================*/

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -408,6 +408,7 @@ void _vcleanup();
 	}
 #endif
 
+voidptr memdup(voidptr src, int sz);
 voidptr memfreedup(voidptr ptr, voidptr src, int sz) {
 	free(ptr);
 	return memdup(src, sz);


### PR DESCRIPTION
this adds the C fn `voidptr memfreedup(voidptr ptr, voidptr src, int sz)` to cheaders.v, for it to be available to be called by the C generated code at cgen.
use is: `ptr = memfreedup(ptr, scr, sz);`
its use is almost identical to `memdup` with the difference being that it frees `ptr` (meant to be the assignee), before allocating a new block of memory for the same `ptr`.
the specific motivation for this fn is for those cases when the programmer needs to free and allocate new memory in a single instruction because there is no room for 2 (for instance, as an arg of another fn call). `memdup` only allocates the new memory, leaving the old one without freeing.