### PR TITLE
Fix issue #6530: Help displayed when a Command has no execute function

### DIFF
--- a/vlib/cli/command.v
+++ b/vlib/cli/command.v
@@ -188,26 +188,26 @@ fn (mut cmd Command) parse_commands() {
 	// if no further command was found, execute current command
 	if cmd.required_args > 0 {
 		if cmd.required_args > cmd.args.len {
-			println('Command `$cmd.name` needs at least $cmd.required_args arguments')
+			eprintln('Command `$cmd.name` needs at least $cmd.required_args arguments')
 			exit(1)
 		}
 	}
 	cmd.check_required_flags()
 	if int(cmd.pre_execute) > 0 {
 		cmd.pre_execute(*cmd) or {
-			println('cli preexecution error: $err')
+			eprintln('cli preexecution error: $err')
 			exit(1)
 		}
 	}
 	if int(cmd.execute) > 0 {
 		cmd.execute(*cmd) or {
-			println('cli execution error: $err')
+			eprintln('cli execution error: $err')
 			exit(1)
 		}
 	}
 	if int(cmd.post_execute) > 0 {
 		cmd.post_execute(*cmd) or {
-			println('cli postexecution error: $err')
+			eprintln('cli postexecution error: $err')
 			exit(1)
 		}
 	}

--- a/vlib/cli/command.v
+++ b/vlib/cli/command.v
@@ -186,33 +186,29 @@ fn (mut cmd Command) parse_commands() {
 		}
 	}
 	// if no further command was found, execute current command
-	if int(cmd.execute) == 0 {
-		if !cmd.disable_help {
-			cmd.execute_help()
+	if cmd.required_args > 0 {
+		if cmd.required_args > cmd.args.len {
+			println('Command `$cmd.name` needs at least $cmd.required_args arguments')
+			exit(1)
 		}
-	} else {
-		if cmd.required_args > 0 {
-			if cmd.required_args > cmd.args.len {
-				println('Command `$cmd.name` needs at least $cmd.required_args arguments')
-				exit(1)
-			}
+	}
+	cmd.check_required_flags()
+	if int(cmd.pre_execute) > 0 {
+		cmd.pre_execute(*cmd) or {
+			println('cli preexecution error: $err')
+			exit(1)
 		}
-		cmd.check_required_flags()
-		if int(cmd.pre_execute) > 0 {
-			cmd.pre_execute(*cmd) or {
-				println('cli preexecution error: $err')
-				exit(1)
-			}
-		}
+	}
+	if int(cmd.execute) > 0 {
 		cmd.execute(*cmd) or {
 			println('cli execution error: $err')
 			exit(1)
 		}
-		if int(cmd.post_execute) > 0 {
-			cmd.post_execute(*cmd) or {
-				println('cli postexecution error: $err')
-				exit(1)
-			}
+	}
+	if int(cmd.post_execute) > 0 {
+		cmd.post_execute(*cmd) or {
+			println('cli postexecution error: $err')
+			exit(1)
 		}
 	}
 }

--- a/vlib/v/tests/inout/cli_command_no_execute.vv
+++ b/vlib/v/tests/inout/cli_command_no_execute.vv
@@ -1,0 +1,7 @@
+import os
+import cli {Command}
+
+fn main() {
+	mut cmd := Command {}                                                       
+	cmd.parse(os.args)
+}


### PR DESCRIPTION
Hi! Here is my PR for the issue #6530 ("Help displayed when a Command has no execute function") that I created.
With this fix, one can create a `Command` without a `execute` function, and then usage information is not displayed any more.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
