### PR TITLE
checker: Fix panic on match expression without results (oops)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3062,12 +3062,13 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) table.Type {
 	mut branch_without_return := false
 	for branch in node.branches {
 		c.stmts(branch.stmts)
-		if node.is_expr {
+		if node.is_expr && branch.stmts.len > 0 {
 			// ignore last statement - workaround
 			// currently the last statement in a match branch does not have an
 			// expected value set, so e.g. IfExpr.is_expr is not set.
 			// probably any mismatch will be caught by not producing a value instead
 			for st in branch.stmts[0..branch.stmts.len - 1] {
+				// must not contain C statements
 				st.check_c_expr() or {
 					c.error('`match` expression branch has $err', st.position())
 				}
@@ -3476,6 +3477,7 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) table.Type {
 					branch.pos)
 			}
 			for st in branch.stmts {
+				// must not contain C statements
 				st.check_c_expr() or {
 					c.error('`if` expression branch has $err', st.position())
 				}

--- a/vlib/v/checker/tests/if_match_result.out
+++ b/vlib/v/checker/tests/if_match_result.out
@@ -1,0 +1,34 @@
+vlib/v/checker/tests/if_match_result.vv:2:3: error: assignment mismatch: 1 variable(s) 0 value(s)
+    1 | // missing results
+    2 | _ = match 4 {
+      |   ^
+    3 |     1 {}
+    4 |     else {}
+vlib/v/checker/tests/if_match_result.vv:6:5: error: `if` expression requires an expression as the last statement of every branch
+    4 |     else {}
+    5 | }
+    6 | _ = if true {
+      |     ~~~~~~~
+    7 | } else {
+    8 | }
+vlib/v/checker/tests/if_match_result.vv:7:3: error: `if` expression requires an expression as the last statement of every branch
+    5 | }
+    6 | _ = if true {
+    7 | } else {
+      |   ~~~~
+    8 | }
+    9 |
+vlib/v/checker/tests/if_match_result.vv:11:3: error: assignment mismatch: 1 variable(s) 0 value(s)
+    9 |
+   10 | // void results
+   11 | _ = match 4 {
+      |   ^
+   12 |     1 {println('')}
+   13 |     else {exit(0)}
+vlib/v/checker/tests/if_match_result.vv:15:3: error: assignment mismatch: 1 variable(s) 0 value(s)
+   13 |     else {exit(0)}
+   14 | }
+   15 | _ = if true {
+      |   ^
+   16 |     println('')
+   17 | } else {

--- a/vlib/v/checker/tests/if_match_result.vv
+++ b/vlib/v/checker/tests/if_match_result.vv
@@ -1,0 +1,19 @@
+// missing results
+_ = match 4 {
+	1 {}
+	else {}
+}
+_ = if true {
+} else {
+}
+
+// void results
+_ = match 4 {
+	1 {println('')}
+	else {exit(0)}
+}
+_ = if true {
+	println('')
+} else {
+	exit(0)
+}


### PR DESCRIPTION
Fixes #6589.
Add tests for missing expressions and also void expressions on the last statement of if/match branches.