### PR TITLE
compiler: use thirdparty/tcc/tcc.exe by default, when no explicit -cc is given

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-18.04
     timeout-minutes: 30
     env:
-      VFLAGS: -cc /var/tmp/tcc/bin/tcc -cflags -bt10
+      VFLAGS: -cc tcc -cflags -bt10
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -87,8 +87,7 @@ jobs:
         ./v -cg -o v cmd/v
     - name: Test v->c
       run: |
-        sudo ln -s /var/tmp/tcc/bin/tcc /usr/local/bin/tcc
-        tcc -version
+        thirdparty/tcc/tcc.exe -version
         ./v -cg -o v cmd/v # Make sure vtcc can build itself twice
 #        ./v -silent test-compiler
     - name: v self compilation
@@ -112,7 +111,7 @@ jobs:
       image: thevlang/vlang:alpine-build
       env:
         V_CI_MUSL: 1
-
+        VFLAGS: -cc gcc
       volumes:
         - ${{github.workspace}}:/opt/vlang
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         ## brew install sdl2 sdl2_ttf sdl2_mixer sdl2_image
         export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/openssl/lib/"
     - name: Build V
-      run:  make -j4 && ./v -cg -o v cmd/v
+      run:  make -j4 && ./v -o v cmd/v
     - name: Build V using V
       run:  ./v -o v2 cmd/v && ./v2 -o v3 cmd/v
     - name: Test symlink

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-18.04
     timeout-minutes: 30
     env:
-      VFLAGS: -cc tcc
+      VFLAGS: -cc /var/tmp/tcc/bin/tcc -cflags -bt10
     steps:
     - uses: actions/checkout@v2
     - name: Environment info
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-18.04
     timeout-minutes: 30
     env:
-      VFLAGS: -cc tcc
+      VFLAGS: -cc /var/tmp/tcc/bin/tcc -cflags -bt10
     steps:
     - uses: actions/checkout@v2
     - name: Environment info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
     - name: Build v
       run: |
         echo $VFLAGS
+        sudo ln -s $PWD/thirdparty/tcc/tcc.exe /usr/local/bin/tcc ## TODO: remove
         make -j4
         ./v -cg -o v cmd/v
     - name: Test v->c

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
     - name: Build V using V
       run:  ./v -o v2 cmd/v && ./v2 -o v3 cmd/v
     - name: Test symlink
-      run:  sudo ./v symlink
+      run:  ./v symlink
 #    - name: Set up pg database
 #      run: |
 #        pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log start
@@ -162,8 +162,6 @@ jobs:
 #      run: ./v -silent build-vbinaries
 ##    - name: Test v->js
 ##      run: ./v -o hi.js examples/hello_v_js.v && node hi.js
-    - name: Test symlink
-      run:  ./v symlink && v -o v2 cmd/v
     - name: Fixed tests
       run: VJOBS=1 ./v -silent test-fixed
     - name: Build examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-18.04
     timeout-minutes: 30
     env:
-      VFLAGS: -cc /var/tmp/tcc/bin/tcc -cflags -bt10
+      VFLAGS: -cc tcc
     steps:
     - uses: actions/checkout@v2
     - name: Environment info
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-18.04
     timeout-minutes: 30
     env:
-      VFLAGS: -cc /var/tmp/tcc/bin/tcc -cflags -bt10
+      VFLAGS: -cc tcc
     steps:
     - uses: actions/checkout@v2
     - name: Environment info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,11 +127,10 @@ jobs:
           v -silent test-fixed
 
   macos:
-    runs-on: ${{ matrix.os }}
+    runs-on: macOS-latest
     timeout-minutes: 30
-    strategy:
-      matrix:
-        os: [macOS-latest]
+    env:
+      VFLAGS: -cc clang
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1

--- a/Makefile
+++ b/Makefile
@@ -96,28 +96,21 @@ fresh_vc:
 
 latest_tcc: $(TMPTCC)/.git/config
 ifndef ANDROID
-ifndef MAC
 ifndef local
 	cd $(TMPTCC) && $(GITCLEANPULL)
 else
 	@echo "Using local tcc"
 endif
 endif
-endif
 
 fresh_tcc:
 ifndef ANDROID
-ifndef MAC
 	rm -rf $(TMPTCC)
 	$(GITFASTCLONE) --branch $(TCCBRANCH) $(TCCREPO) $(TMPTCC)
-	rm -rf /var/tmp/tcc && git clone https://github.com/vlang/tccbin /var/tmp/tcc ## TODO: remove
-endif
 endif
 
 $(TMPTCC)/.git/config:
-ifndef MAC
 	$(MAKE) fresh_tcc
-endif
 
 $(VC)/.git/config:
 	$(MAKE) fresh_vc

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,18 @@ CC ?= cc
 CFLAGS ?=
 LDFLAGS ?=
 TMPDIR ?= /tmp
+VROOT  ?= .
 VC     ?= ./vc
-V      := ./v
+V      ?= ./v
+=======
+VCREPO ?= https://github.com/vlang/vc
+TCCREPO ?= https://github.com/vlang/tccbin
 
 VCFILE := v.c
-TMPTCC := /var/tmp/tcc
-VCREPO := https://github.com/vlang/vc
-TCCREPO := https://github.com/vlang/tccbin
+TMPTCC := $(VROOT)/thirdparty/tcc
+TCCBRANCH := thirdparty-linux-amd64
 GITCLEANPULL := git clean -xf && git pull --quiet
-GITFASTCLONE := git clone --depth 1 --quiet
+GITFASTCLONE := git clone --depth 1 --quiet --single-branch
 
 #### Platform detections and overrides:
 _SYS := $(shell uname 2>/dev/null || echo Unknown)
@@ -24,10 +27,12 @@ endif
 
 ifeq ($(_SYS),Linux)
 LINUX := 1
+TCCBRANCH := thirdparty-linux-amd64
 endif
 
 ifeq ($(_SYS),Darwin)
 MAC := 1
+TCCBRANCH := thirdparty-macos-amd64
 endif
 
 ifeq ($(_SYS),FreeBSD)
@@ -37,11 +42,12 @@ endif
 ifdef ANDROID_ROOT
 ANDROID := 1
 undefine LINUX
+TCCBRANCH := thirdparty-linux-arm64
 endif
 #####
 
 ifdef WIN32
-TCCREPO := https://github.com/vlang/tccbin_win
+TCCBRANCH := thirdparty-windows-amd64
 VCFILE := v_win.c
 endif
 
@@ -104,7 +110,7 @@ fresh_tcc:
 ifndef ANDROID
 ifndef MAC
 	rm -rf $(TMPTCC)
-	$(GITFASTCLONE) $(TCCREPO) $(TMPTCC)
+	$(GITFASTCLONE) --branch $(TCCBRANCH) $(TCCREPO) $(TMPTCC)
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,10 @@ endif
 
 fresh_tcc:
 ifndef ANDROID
+ifdef LINUX
+	rm -rf /var/tmp/tcc
+	git clone https://github.com/vlang/tccbin /var/tmp/tcc
+endif    
 	rm -rf $(TMPTCC)
 	$(GITFASTCLONE) --branch $(TCCBRANCH) $(TCCREPO) $(TMPTCC)
 endif

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TCCREPO ?= https://github.com/vlang/tccbin
 
 VCFILE := v.c
 TMPTCC := $(VROOT)/thirdparty/tcc
-TCCBRANCH := thirdparty-linux-amd64
+TCCBRANCH := thirdparty-unknown-unknown
 GITCLEANPULL := git clean -xf && git pull --quiet
 GITFASTCLONE := git clone --depth 1 --quiet --single-branch
 
@@ -111,6 +111,7 @@ ifndef ANDROID
 ifndef MAC
 	rm -rf $(TMPTCC)
 	$(GITFASTCLONE) --branch $(TCCBRANCH) $(TCCREPO) $(TMPTCC)
+	rm -rf /var/tmp/tcc && git clone https://github.com/vlang/tccbin /var/tmp/tcc ## TODO: remove
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ TMPDIR ?= /tmp
 VROOT  ?= .
 VC     ?= ./vc
 V      ?= ./v
-=======
 VCREPO ?= https://github.com/vlang/vc
 TCCREPO ?= https://github.com/vlang/tccbin
 

--- a/cmd/tools/vdoctor.v
+++ b/cmd/tools/vdoctor.v
@@ -122,9 +122,6 @@ fn (mut a App) collect_info() {
 	a.line('Git vroot status', a.git_info())
 	a.line('.git/config present', os.is_file('.git/config').str())
 	//
-	if os_kind == 'linux' {
-		a.report_tcc_version('/var/tmp/tcc')
-	}
 	a.report_tcc_version('thirdparty/tcc')
 }
 

--- a/make.bat
+++ b/make.bat
@@ -14,13 +14,17 @@ set subcmd=
 set target=build
 
 REM TCC variables
-set "tcc_url=https://github.com/vlang/tccbin_win.git"
+set "tcc_url=https://github.com/vlang/tccbin"
 set "tcc_dir=%~dp0thirdparty\tcc"
-set "vc_url=https://github.com/vlang/vc.git"
+set "tcc_branch=thirdparty-windows-amd64"
+
+REM VC settings
+set "vc_url=https://github.com/vlang/vc"
 set "vc_dir=%~dp0vc"
 
 REM Let a particular environment specify their own TCC repo
 if /I not ["%TCC_GIT%"] == [""] set "tcc_url=%TCC_GIT%"
+if /I not ["%TCC_BRANCH%"] == [""] set "tcc_branch=%TCC_BRANCH%"
 
 pushd %~dp0
 
@@ -227,7 +231,7 @@ if %ERRORLEVEL% NEQ 0 (
     if not exist %tcc_dir% (
         echo  ^> TCC not found
         echo  ^> Downloading TCC from %tcc_url%
-        call :buildcmd "git clone --depth 1 --quiet "!tcc_url!" "%tcc_dir%"" "  "
+        call :buildcmd "git clone --depth 1 --quiet --single-branch --branch "!tcc_branch!" "!tcc_url!" "%tcc_dir%"" "  "
     )
     pushd %tcc_dir% || (
         echo  ^> TCC not found, even after cloning

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -217,6 +217,12 @@ fn (mut v Builder) cc() {
 			return
 		}
 	}
+	//
+	mut tried_compilation_commands := []string{}
+	original_pwd := os.getwd()
+	// TODO remove the start: goto start construct;
+	// use a labeled for break instead
+	start:
 	mut ccompiler := v.pref.ccompiler
 	$if windows {
 		if ccompiler == 'msvc' {
@@ -508,12 +514,7 @@ fn (mut v Builder) cc() {
 		v.pref.cleanup_files << v.out_name_c
 		v.pref.cleanup_files << response_file
 	}
-	original_pwd := os.getwd()
-	mut tried_compilation_commands := []string{}
 	//
-	// TODO remove the start: goto start construct;
-	// use a labeled for break instead
-	start:
 	todo()
 	os.chdir(vdir)
 	cmd := '$ccompiler @$response_file'
@@ -554,7 +555,6 @@ fn (mut v Builder) cc() {
 			}
 			eprintln('recompilation with tcc failed; retrying with cc ...')
 			v.pref.ccompiler = pref.default_c_compiler()
-			eprintln('>>> v.pref.ccompiler: $v.pref.ccompiler')
 			goto start
 		}
 		if res.exit_code == 127 {

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -330,9 +330,9 @@ fn (mut v Builder) cc() {
 	}
 	if debug_mode {
 		args << debug_options
-		$if macos {
-			args << ' -ferror-limit=5000 '
-		}
+		// $if macos {
+		// args << ' -ferror-limit=5000 '
+		// }
 	}
 	if v.pref.is_prod {
 		args << optimization_options

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -125,7 +125,7 @@ fn (mut v Builder) post_process_c_compiler_output(res os.Result) {
 }
 
 fn (mut v Builder) rebuild_cached_module(vexe string, imp_path string) string {
-	res := v.pref.cache_manager.exists('.o', imp_path) or {
+	res2 := v.pref.cache_manager.exists('.o', imp_path) or {
 		println('Cached $imp_path .o file not found... Building .o file for $imp_path')
 		// do run `v build-module x` always in main vfolder; x can be a relative path
 		pwd := os.getwd()
@@ -141,7 +141,7 @@ fn (mut v Builder) rebuild_cached_module(vexe string, imp_path string) string {
 		os.chdir(pwd)
 		return rebuilded_o
 	}
-	return res
+	return res2
 }
 
 fn (mut v Builder) show_cc(cmd string, response_file string, response_file_content string) {
@@ -257,7 +257,8 @@ fn (mut v Builder) cc() {
 			v.pref.ccompiler = tcc_path
 		}
 	}
-	if !v.pref.is_shared && v.pref.build_mode != .build_module && os.user_os() == 'windows' &&
+	if !v.pref.is_shared && v.pref.build_mode != .build_module && 
+		os.user_os() == 'windows' &&
 		!v.pref.out_name.ends_with('.exe') {
 		v.pref.out_name += '.exe'
 	}
@@ -288,8 +289,8 @@ fn (mut v Builder) cc() {
 		// println(v.table.imports)
 	}
 	debug_mode := v.pref.is_debug
-	mut debug_options := '-g3'
-	mut optimization_options := '-O2'
+	mut debug_options2 := '-g3'
+	mut optimization_options2 := '-O2'
 	mut guessed_compiler := v.pref.ccompiler
 	if guessed_compiler == 'cc' && v.pref.is_prod {
 		// deliberately guessing only for -prod builds for performance reasons
@@ -314,31 +315,31 @@ fn (mut v Builder) cc() {
 	//
 	if is_cc_clang {
 		if debug_mode {
-			debug_options = '-g3 -O0 -no-pie'
+			debug_options2 = '-g3 -O0 -no-pie'
 		}
-		optimization_options = '-O3'
+		optimization_options2 = '-O3'
 		mut have_flto := true
 		$if openbsd {
 			have_flto = false
 		}
 		if have_flto {
-			optimization_options += ' -flto'
+			optimization_options2 += ' -flto'
 		}
 	}
 	if is_cc_gcc {
 		if debug_mode {
-			debug_options = '-g3 -no-pie'
+			debug_options2 = '-g3 -no-pie'
 		}
-		optimization_options = '-O3 -fno-strict-aliasing -flto'
+		optimization_options2 = '-O3 -fno-strict-aliasing -flto'
 	}
 	if debug_mode {
-		args << debug_options
+		args << debug_options2
 		$if macos {
 			args << ' -ferror-limit=5000 '
 		}
 	}
 	if v.pref.is_prod {
-		args << optimization_options
+		args << optimization_options2
 	}
 	if v.pref.is_prod && !debug_mode {
 		// sokol and other C libraries that use asserts
@@ -360,13 +361,13 @@ fn (mut v Builder) cc() {
 			args << '-flat_namespace'
 		}
 	}
-	mut libs := '' // builtin.o os.o http.o etc
+	mut libs2 := '' // builtin.o os.o http.o etc
 	if v.pref.build_mode == .build_module {
 		args << '-c'
 	} else if v.pref.use_cache {
 		mut built_modules := []string{}
 		builtin_obj_path := v.rebuild_cached_module(vexe, 'vlib/builtin')
-		libs += ' ' + builtin_obj_path
+		libs2 += ' ' + builtin_obj_path
 		for ast_file in v.parsed_files {
 			for imp_stmt in ast_file.imports {
 				imp := imp_stmt.mod
@@ -396,7 +397,7 @@ fn (mut v Builder) cc() {
 				// }
 				imp_path := os.join_path('vlib', mod_path)
 				obj_path := v.rebuild_cached_module(vexe, imp_path)
-				libs += ' ' + obj_path
+				libs2 += ' ' + obj_path
 				if obj_path.ends_with('vlib/ui.o') {
 					args << '-framework Cocoa -framework Carbon'
 				}
@@ -445,12 +446,12 @@ fn (mut v Builder) cc() {
 	if v.pref.os == .windows {
 		args << '-municode'
 	}
-	osflags := v.get_os_cflags()
+	osflags3 := v.get_os_cflags()
 	// add .o files
-	args << osflags.c_options_only_object_files()
+	args << osflags3.c_options_only_object_files()
 	// add all flags (-I -l -L etc) not .o files
-	args << osflags.c_options_without_object_files()
-	args << libs
+	args << osflags3.c_options_without_object_files()
+	args << libs2
 	// For C++ we must be very tolerant
 	if guessed_compiler.contains('++') {
 		args << '-fpermissive'
@@ -524,7 +525,7 @@ fn (mut v Builder) cc() {
 	v.show_cc(cmd, response_file, response_file_content)
 	// Run
 	ticks := time.ticks()
-	res := os.exec(cmd) or {
+	res3 := os.exec(cmd) or {
 		// C compilation failed.
 		// If we are on Windows, try msvc
 		println('C compilation failed.')
@@ -542,11 +543,11 @@ fn (mut v Builder) cc() {
 	diff := time.ticks() - ticks
 	v.timing_message('C ${ccompiler:3}', diff)
 	if v.pref.show_c_output {
-		v.show_c_compiler_output(res)
+		v.show_c_compiler_output(res3)
 	}
-	if res.exit_code == 127 {
+	if res3.exit_code == 127 {
 	os.chdir(original_pwd)
-	if res.exit_code != 0 {
+	if res3.exit_code != 0 {
 		// the command could not be found by the system
 		$if linux {
 			// TCC problems on linux? Try GCC.
@@ -561,7 +562,7 @@ fn (mut v Builder) cc() {
 			'Please reinstall it, or make it available in your PATH.\n\n' + missing_compiler_info())
 	}
 	if !v.pref.show_c_output {
-		v.post_process_c_compiler_output(res)
+		v.post_process_c_compiler_output(res3)
 	}
 	// Print the C command
 	if v.pref.is_verbose {
@@ -649,8 +650,8 @@ fn (mut b Builder) cc_linux_cross() {
 	}
 	obj_file := b.out_name_c + '.o'
 	mut cc_args := '-fPIC -w -c -target x86_64-linux-gnu -c -o $obj_file $b.out_name_c -I $sysroot/include '
-	osflags := b.get_os_cflags()
-	cc_args += osflags.c_options_without_object_files()
+	osflags1 := b.get_os_cflags()
+	cc_args += osflags1.c_options_without_object_files()
 	cc_cmd := 'cc $cc_args'
 	if b.pref.show_cc {
 		println(cc_cmd)
@@ -666,7 +667,7 @@ fn (mut b Builder) cc_linux_cross() {
 	}
 	linker_args := ['-L $sysroot/usr/lib/x86_64-linux-gnu/', '--sysroot=$sysroot -v -o $b.pref.out_name -m elf_x86_64',
 		'-dynamic-linker /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2', '$sysroot/crt1.o $sysroot/crti.o $obj_file',
-		'-lc', '-lcrypto', '-lssl', '-lpthread', '$sysroot/crtn.o', osflags.c_options_only_object_files()]
+		'-lc', '-lcrypto', '-lssl', '-lpthread', '$sysroot/crtn.o', osflags1.c_options_only_object_files()]
 	// -ldl
 	linker_args_str := linker_args.join(' ')
 	linker_cmd := '$sysroot/ld.lld $linker_args_str'
@@ -675,14 +676,14 @@ fn (mut b Builder) cc_linux_cross() {
 	if b.pref.show_cc {
 		println(linker_cmd)
 	}
-	res := os.exec(linker_cmd) or {
+	res4 := os.exec(linker_cmd) or {
 		println('Cross compilation for Linux failed (second step, lld).')
 		verror(err)
 		return
 	}
-	if res.exit_code != 0 {
+	if res4.exit_code != 0 {
 		println('Cross compilation for Linux failed (second step, lld).')
-		verror(res.output)
+		verror(res4.output)
 	}
 	println(b.pref.out_name + ' has been successfully compiled')
 }
@@ -692,10 +693,10 @@ fn (mut c Builder) cc_windows_cross() {
 	if !c.pref.out_name.ends_with('.exe') {
 		c.pref.out_name += '.exe'
 	}
-	mut args := '-o $c.pref.out_name -w -L. '
-	osflags := c.get_os_cflags()
+	mut args2 := '-o $c.pref.out_name -w -L. '
+	osflags2 := c.get_os_cflags()
 	// -I flags
-	args += if c.pref.ccompiler == 'msvc' { osflags.c_options_before_target_msvc() } else { osflags.c_options_before_target() }
+	args2 += if c.pref.ccompiler == 'msvc' { osflags2.c_options_before_target_msvc() } else { osflags2.c_options_before_target() }
 	mut optimization_options := ''
 	mut debug_options := ''
 	if c.pref.is_prod {
@@ -714,8 +715,8 @@ fn (mut c Builder) cc_windows_cross() {
 			libs += ' "$pref.default_module_path/vlib/${imp}.o"'
 		}
 	}
-	args += ' $c.out_name_c '
-	args += if c.pref.ccompiler == 'msvc' { osflags.c_options_after_target_msvc() } else { osflags.c_options_after_target() }
+	args2 += ' $c.out_name_c '
+	args2 += if c.pref.ccompiler == 'msvc' { osflags2.c_options_after_target_msvc() } else { osflags2.c_options_after_target() }
 	/*
 	winroot := '${pref.default_module_path}/winroot'
 	if !os.is_dir(winroot) {
@@ -735,12 +736,12 @@ fn (mut c Builder) cc_windows_cross() {
 		println(os.user_os())
 		panic('your platform is not supported yet')
 	}
-	mut cmd := '$mingw_cc $optimization_options $debug_options -std=gnu11 $args -municode'
-	// cmd := 'clang -o $obj_name -w $include -m32 -c -target x86_64-win32 ${pref.default_module_path}/$c.out_name_c'
+	mut cmd2 := '$mingw_cc $optimization_options $debug_options -std=gnu11 $args2 -municode'
+	// cmd2 := 'clang -o $obj_name -w $include -m32 -c -target x86_64-win32 ${pref.default_module_path}/$c.out_name_c'
 	if c.pref.is_verbose || c.pref.show_cc {
-		println(cmd)
+		println(cmd2)
 	}
-	if os.system(cmd) != 0 {
+	if os.system(cmd2) != 0 {
 		println('Cross compilation for Windows failed. Make sure you have mingw-w64 installed.')
 		$if macos {
 			println('brew install mingw-w64')
@@ -806,18 +807,18 @@ fn (mut v Builder) build_thirdparty_obj_file(path string, moduleflags []cflag.CF
 	atarget := moduleflags.c_options_after_target()
 	cppoptions := if v.pref.ccompiler.contains('++') { ' -fpermissive -w ' } else { '' }
 	cmd := '$v.pref.ccompiler $cppoptions $v.pref.third_party_option $btarget -o "$opath" -c "$cfile" $atarget'
-	res := os.exec(cmd) or {
+	res1 := os.exec(cmd) or {
 		eprintln('exec failed for thirdparty object build cmd:\n$cmd')
 		verror(err)
 		return
 	}
-	if res.exit_code != 0 {
+	if res1.exit_code != 0 {
 		eprintln('failed thirdparty object build cmd:\n$cmd')
-		verror(res.output)
+		verror(res1.output)
 		return
 	}
 	v.pref.cache_manager.save('.description.txt', obj_path, '${obj_path:-30} @ $cmd\n')
-	println(res.output)
+	println(res1.output)
 }
 
 fn missing_compiler_info() string {

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -445,11 +445,11 @@ fn (mut v Builder) cc() {
 	if v.pref.os == .windows {
 		args << '-municode'
 	}
-	cflags := v.get_os_cflags()
+	os_cflags := v.get_os_cflags()
 	// add .o files
-	args << cflags.c_options_only_object_files()
+	args << os_cflags.c_options_only_object_files()
 	// add all flags (-I -l -L etc) not .o files
-	args << cflags.c_options_without_object_files()
+	args << os_cflags.c_options_without_object_files()
 	args << libs
 	// For C++ we must be very tolerant
 	if guessed_compiler.contains('++') {
@@ -649,8 +649,8 @@ fn (mut b Builder) cc_linux_cross() {
 	}
 	obj_file := b.out_name_c + '.o'
 	mut cc_args := '-fPIC -w -c -target x86_64-linux-gnu -c -o $obj_file $b.out_name_c -I $sysroot/include '
-	cflags := b.get_os_cflags()
-	cc_args += cflags.c_options_without_object_files()
+	os_cflags := b.get_os_cflags()
+	cc_args += os_cflags.c_options_without_object_files()
 	cc_cmd := 'cc $cc_args'
 	if b.pref.show_cc {
 		println(cc_cmd)
@@ -666,7 +666,7 @@ fn (mut b Builder) cc_linux_cross() {
 	}
 	linker_args := ['-L $sysroot/usr/lib/x86_64-linux-gnu/', '--sysroot=$sysroot -v -o $b.pref.out_name -m elf_x86_64',
 		'-dynamic-linker /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2', '$sysroot/crt1.o $sysroot/crti.o $obj_file',
-		'-lc', '-lcrypto', '-lssl', '-lpthread', '$sysroot/crtn.o', cflags.c_options_only_object_files()]
+		'-lc', '-lcrypto', '-lssl', '-lpthread', '$sysroot/crtn.o', os_cflags.c_options_only_object_files()]
 	// -ldl
 	linker_args_str := linker_args.join(' ')
 	linker_cmd := '$sysroot/ld.lld $linker_args_str'
@@ -693,9 +693,9 @@ fn (mut c Builder) cc_windows_cross() {
 		c.pref.out_name += '.exe'
 	}
 	mut args := '-o $c.pref.out_name -w -L. '
-	cflags := c.get_os_cflags()
+	os_cflags := c.get_os_cflags()
 	// -I flags
-	args += if c.pref.ccompiler == 'msvc' { cflags.c_options_before_target_msvc() } else { cflags.c_options_before_target() }
+	args += if c.pref.ccompiler == 'msvc' { os_cflags.c_options_before_target_msvc() } else { os_cflags.c_options_before_target() }
 	mut optimization_options := ''
 	mut debug_options := ''
 	if c.pref.is_prod {
@@ -715,7 +715,7 @@ fn (mut c Builder) cc_windows_cross() {
 		}
 	}
 	args += ' $c.out_name_c '
-	args += if c.pref.ccompiler == 'msvc' { cflags.c_options_after_target_msvc() } else { cflags.c_options_after_target() }
+	args += if c.pref.ccompiler == 'msvc' { os_cflags.c_options_after_target_msvc() } else { os_cflags.c_options_after_target() }
 	/*
 	winroot := '${pref.default_module_path}/winroot'
 	if !os.is_dir(winroot) {

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -445,11 +445,11 @@ fn (mut v Builder) cc() {
 	if v.pref.os == .windows {
 		args << '-municode'
 	}
-	os_cflags := v.get_os_cflags()
+	osflags := v.get_os_cflags()
 	// add .o files
-	args << os_cflags.c_options_only_object_files()
+	args << osflags.c_options_only_object_files()
 	// add all flags (-I -l -L etc) not .o files
-	args << os_cflags.c_options_without_object_files()
+	args << osflags.c_options_without_object_files()
 	args << libs
 	// For C++ we must be very tolerant
 	if guessed_compiler.contains('++') {
@@ -649,8 +649,8 @@ fn (mut b Builder) cc_linux_cross() {
 	}
 	obj_file := b.out_name_c + '.o'
 	mut cc_args := '-fPIC -w -c -target x86_64-linux-gnu -c -o $obj_file $b.out_name_c -I $sysroot/include '
-	os_cflags := b.get_os_cflags()
-	cc_args += os_cflags.c_options_without_object_files()
+	osflags := b.get_os_cflags()
+	cc_args += osflags.c_options_without_object_files()
 	cc_cmd := 'cc $cc_args'
 	if b.pref.show_cc {
 		println(cc_cmd)
@@ -666,7 +666,7 @@ fn (mut b Builder) cc_linux_cross() {
 	}
 	linker_args := ['-L $sysroot/usr/lib/x86_64-linux-gnu/', '--sysroot=$sysroot -v -o $b.pref.out_name -m elf_x86_64',
 		'-dynamic-linker /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2', '$sysroot/crt1.o $sysroot/crti.o $obj_file',
-		'-lc', '-lcrypto', '-lssl', '-lpthread', '$sysroot/crtn.o', os_cflags.c_options_only_object_files()]
+		'-lc', '-lcrypto', '-lssl', '-lpthread', '$sysroot/crtn.o', osflags.c_options_only_object_files()]
 	// -ldl
 	linker_args_str := linker_args.join(' ')
 	linker_cmd := '$sysroot/ld.lld $linker_args_str'
@@ -693,9 +693,9 @@ fn (mut c Builder) cc_windows_cross() {
 		c.pref.out_name += '.exe'
 	}
 	mut args := '-o $c.pref.out_name -w -L. '
-	os_cflags := c.get_os_cflags()
+	osflags := c.get_os_cflags()
 	// -I flags
-	args += if c.pref.ccompiler == 'msvc' { os_cflags.c_options_before_target_msvc() } else { os_cflags.c_options_before_target() }
+	args += if c.pref.ccompiler == 'msvc' { osflags.c_options_before_target_msvc() } else { osflags.c_options_before_target() }
 	mut optimization_options := ''
 	mut debug_options := ''
 	if c.pref.is_prod {
@@ -715,7 +715,7 @@ fn (mut c Builder) cc_windows_cross() {
 		}
 	}
 	args += ' $c.out_name_c '
-	args += if c.pref.ccompiler == 'msvc' { os_cflags.c_options_after_target_msvc() } else { os_cflags.c_options_after_target() }
+	args += if c.pref.ccompiler == 'msvc' { osflags.c_options_after_target_msvc() } else { osflags.c_options_after_target() }
 	/*
 	winroot := '${pref.default_module_path}/winroot'
 	if !os.is_dir(winroot) {

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -419,7 +419,9 @@ fn (mut v Builder) cc() {
 	}
 	// macOS code can include objective C  TODO remove once objective C is replaced with C
 	if v.pref.os == .macos || v.pref.os == .ios {
-		args << '-x objective-c'
+		if !is_cc_tcc {
+			args << '-x objective-c'
+		}
 	}
 	// The C file we are compiling
 	args << '"$v.out_name_c"'

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -124,6 +124,11 @@ typedef int (*qsort_callback_func)(const void*, const void*);
 	#define _MOV
 #endif
 
+#if defined(__TINYC__) && defined(__has_include)
+// tcc does not support has_include properly yet, turn it off completely
+#undef __has_include
+#endif
+
 #ifndef _WIN32
 	#if defined __has_include
 		#if __has_include (<execinfo.h>)

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -54,7 +54,7 @@ pub fn (mut p Preferences) fill_with_defaults() {
 		p.os = get_host_os()
 	}
 	//
-	p.try_to_use_tcc_by_default()    
+	p.try_to_use_tcc_by_default()
 	if p.ccompiler == '' {
 		p.ccompiler = default_c_compiler()
 	}
@@ -107,7 +107,6 @@ pub fn default_tcc_compiler() string {
 	if os.exists(vtccexe) {
 		return vtccexe
 	}
-	eprintln('Your platform does not have yet a `$vtccexe` file')
 	return ''
 }
 

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -86,16 +86,16 @@ pub fn (mut p Preferences) fill_with_defaults() {
 }
 
 fn (mut p Preferences) try_to_use_tcc_by_default() {
-	// / tcc is known to fail several tests on macos, so do not
-	// / try to use it by default, only when it is explicitly set
-	$if macos {
-		return
-	}
 	if p.ccompiler == 'tcc' {
 		p.ccompiler = default_tcc_compiler()
 		return
 	}
 	if p.ccompiler == '' {
+		// tcc is known to fail several tests on macos, so do not
+		// try to use it by default, only when it is explicitly set
+		$if macos {
+			return
+		}
 		p.ccompiler = default_tcc_compiler()
 		return
 	}

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -53,7 +53,7 @@ pub fn (mut p Preferences) fill_with_defaults() {
 		// No OS specifed? Use current system
 		p.os = get_host_os()
 	}
-	if p.ccompiler == '' {
+	if p.ccompiler == '' || p.ccompiler == 'tcc' {
 		p.ccompiler = default_c_compiler()
 	}
 	p.ccompiler_type = cc_from_string(p.ccompiler)
@@ -84,6 +84,12 @@ pub fn (mut p Preferences) fill_with_defaults() {
 }
 
 fn default_c_compiler() string {
+	vexe := vexe_path()
+	vroot := os.dir(vexe)
+	vtccexe := os.join_path(vroot, 'thirdparty', 'tcc', 'tcc.exe')
+	if os.exists(vtccexe) {
+		return vtccexe
+	}
 	// fast_clang := '/usr/local/Cellar/llvm/8.0.0/bin/clang'
 	// if os.exists(fast_clang) {
 	// return fast_clang

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -86,6 +86,11 @@ pub fn (mut p Preferences) fill_with_defaults() {
 }
 
 fn (mut p Preferences) try_to_use_tcc_by_default() {
+	/// tcc is known to fail several tests on macos, so do not
+	/// try to use it by default, only when it is explicitly set
+	$if macos {
+		return
+	}
 	if p.ccompiler == 'tcc' {
 		p.ccompiler = default_tcc_compiler()
 		return
@@ -94,11 +99,6 @@ fn (mut p Preferences) try_to_use_tcc_by_default() {
 		p.ccompiler = default_tcc_compiler()
 		return
 	}
-	// /// tcc is known to fail several tests on macos, so do not
-	// /// try to use it by default, only when it is explicitly set
-	// $if macos {
-	// return
-	// }
 }
 
 pub fn default_tcc_compiler() string {

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -53,7 +53,9 @@ pub fn (mut p Preferences) fill_with_defaults() {
 		// No OS specifed? Use current system
 		p.os = get_host_os()
 	}
-	if p.ccompiler == '' || p.ccompiler == 'tcc' {
+	//
+	p.try_to_use_tcc_by_default()    
+	if p.ccompiler == '' {
 		p.ccompiler = default_c_compiler()
 	}
 	p.ccompiler_type = cc_from_string(p.ccompiler)
@@ -83,13 +85,33 @@ pub fn (mut p Preferences) fill_with_defaults() {
 	// eprintln('prefs.cache_manager: $p')
 }
 
-fn default_c_compiler() string {
+fn (mut p Preferences) try_to_use_tcc_by_default() {
+	if p.ccompiler == 'tcc' {
+		p.ccompiler = default_tcc_compiler()
+	}
+	$if macos {
+		// tcc is known to fail several tests on macos, so do not
+		// try to use it by default, only when it is explicitly set
+		return
+	}
+	if p.ccompiler == '' {
+		p.ccompiler = default_tcc_compiler()
+	}
+}
+
+
+pub fn default_tcc_compiler() string {
 	vexe := vexe_path()
 	vroot := os.dir(vexe)
 	vtccexe := os.join_path(vroot, 'thirdparty', 'tcc', 'tcc.exe')
 	if os.exists(vtccexe) {
 		return vtccexe
 	}
+	eprintln('Your platform does not have yet a `$vtccexe` file')
+	return ''
+}
+
+pub fn default_c_compiler() string {
 	// fast_clang := '/usr/local/Cellar/llvm/8.0.0/bin/clang'
 	// if os.exists(fast_clang) {
 	// return fast_clang

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -86,8 +86,8 @@ pub fn (mut p Preferences) fill_with_defaults() {
 }
 
 fn (mut p Preferences) try_to_use_tcc_by_default() {
-	/// tcc is known to fail several tests on macos, so do not
-	/// try to use it by default, only when it is explicitly set
+	// / tcc is known to fail several tests on macos, so do not
+	// / try to use it by default, only when it is explicitly set
 	$if macos {
 		return
 	}

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -99,7 +99,6 @@ fn (mut p Preferences) try_to_use_tcc_by_default() {
 	}
 }
 
-
 pub fn default_tcc_compiler() string {
 	vexe := vexe_path()
 	vroot := os.dir(vexe)

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -88,15 +88,17 @@ pub fn (mut p Preferences) fill_with_defaults() {
 fn (mut p Preferences) try_to_use_tcc_by_default() {
 	if p.ccompiler == 'tcc' {
 		p.ccompiler = default_tcc_compiler()
-	}
-	$if macos {
-		// tcc is known to fail several tests on macos, so do not
-		// try to use it by default, only when it is explicitly set
 		return
 	}
 	if p.ccompiler == '' {
 		p.ccompiler = default_tcc_compiler()
+		return
 	}
+	// /// tcc is known to fail several tests on macos, so do not
+	// /// try to use it by default, only when it is explicitly set
+	// $if macos {
+	// return
+	// }
 }
 
 pub fn default_tcc_compiler() string {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -97,7 +97,6 @@ pub mut:
 	// This is on by default, since a vast majority of users do not
 	// work on the builtin module itself.
 	// generating_vh    bool
-	fast                bool // use tcc/x64 codegen
 	enable_globals      bool // allow __global for low level code
 	is_fmt              bool
 	is_vet              bool

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -328,6 +328,9 @@ pub fn parse_args(args []string) (&Preferences, string) {
 				if res.out_name.ends_with('.js') {
 					res.backend = .js
 				}
+				if !os.is_abs_path(res.out_name) {
+					res.out_name = os.join_path(os.getwd(), res.out_name)
+				}
 				i++
 			}
 			'-b' {


### PR DESCRIPTION
With this PR, V will try to use `thirdparty/tcc/tcc.exe` which is a prebuild platform dependent executable, when an explicit C compiler is not specified with `-cc `.

TODO: use `cc/gcc/msvc` in turn, if/when tcc fails to compile a given file (that may happen mainly on macos).