### PR TITLE
fmt: refactor `type_to_str`

### DIFF
--- a/vlib/hash/crc32/crc32_test.v
+++ b/vlib/hash/crc32/crc32_test.v
@@ -6,7 +6,6 @@ fn test_hash_crc32() {
 	assert sum1 == u32(1212124400)
 	assert sum1.hex() == '483f8cf0'
 
-	
 	c := crc32.new(int(crc32.ieee))
 	b2 := 'testing crc32 again'.bytes()
 	sum2 := c.checksum(b2)

--- a/vlib/v/fmt/tests/fn_multi_return_keep.vv
+++ b/vlib/v/fmt/tests/fn_multi_return_keep.vv
@@ -1,0 +1,13 @@
+import v.ast
+
+fn return_multiple_values() (int, int) {
+	return 0, 1
+}
+
+fn return_multiple_values_opt() ?(int, int) {
+	return none
+}
+
+fn return_multiple_values_with_type_from_other_module() (ast.File, int) {
+	return ast.File{}, 0
+}

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -797,72 +797,82 @@ pub:
 	variants []Type
 }
 
-// TODO simplify this method
 pub fn (table &Table) type_to_str(t Type) string {
 	sym := table.get_type_symbol(t)
-	mut res := sym.name
-	if sym.kind in [.array_fixed, .function] {
-		res = sym.source_name
-	} else if sym.kind == .multi_return {
-		res = '('
-		if t.has_flag(.optional) {
-			res = '?' + res
+	mut res := sym.source_name
+	match sym.kind {
+		.any_int, .i8, .i16, .int, .i64, .byte, .u16, .u32, .u64, .any_float, .f32, .f64, .char, .rune, .string, .bool, .none_, .byteptr, .voidptr, .charptr {
+			// primitive types
+			res = sym.kind.str()
 		}
-		mr_info := sym.info as MultiReturn
-		for i, typ in mr_info.types {
-			res += table.type_to_str(typ)
-			if i < mr_info.types.len - 1 {
-				res += ', '
+		.array {
+			info := sym.info as Array
+			elem_str := table.type_to_str(info.elem_type)
+			res = '[]$elem_str'
+		}
+		.array_fixed {
+			info := sym.info as ArrayFixed
+			elem_str := table.type_to_str(info.elem_type)
+			res = '[$info.size]$elem_str'
+		}
+		.chan {
+			// TODO currently the `chan` struct in builtin is not considered a struct but a chan
+			if sym.mod != 'builtin' && sym.name != 'chan' {
+				info := sym.info as Chan
+				mut elem_type := info.elem_type
+				mut mut_str := ''
+				if info.is_mut {
+					mut_str = 'mut '
+					elem_type = elem_type.set_nr_muls(elem_type.nr_muls() - 1)
+				}
+				elem_str := table.type_to_str(elem_type)
+				res = 'chan $mut_str$elem_str'
 			}
 		}
-		res += ')'
-		return res
-	}
-	if sym.kind == .array || 'array_' in res {
-		res = res.replace('array_', '[]')
-	}
-	mut map_start := ''
-	if sym.kind == .map || 'map_string_' in res {
-		res = res.replace('map_string_', 'map[string]')
-		map_start = 'map[string]'
-	}
-	if sym.kind == .chan || 'chan_' in res {
-		res = res.replace('chan_', 'chan ')
-	}
-	// mod.submod.submod2.Type => submod2.Type
-	mut parts := res.split(' ')
-	for i, _ in parts {
-		if parts[i].contains('.') {
-			vals := parts[i].split('.')
-			if vals.len > 2 {
-				parts[i] = vals[vals.len - 2] + '.' + vals[vals.len - 1]
+		.function {
+			// do nothing, source_name is sufficient
+		}
+		.map {
+			info := sym.info as Map
+			key_str := table.type_to_str(info.key_type)
+			val_str := table.type_to_str(info.value_type)
+			res = 'map[$key_str]$val_str'
+		}
+		.multi_return {
+			res = '('
+			info := sym.info as MultiReturn
+			for i, typ in info.types {
+				if i > 0 {
+					res += ', '
+				}
+				res += table.type_to_str(typ)
 			}
-			if parts[i].starts_with(table.cmod_prefix) ||
-				(sym.kind == .array && parts[i].starts_with('[]' + table.cmod_prefix)) {
-				parts[i] = parts[i].replace_once(table.cmod_prefix, '')
+			res += ')'
+			res = res
+		}
+		.void {
+			if t.has_flag(.optional) {
+				return '?'
 			}
-			if sym.kind == .array && !parts[i].starts_with('[]') {
-				parts[i] = '[]' + parts[i]
-			}
-			if sym.kind == .map && !parts[i].starts_with('map') {
-				parts[i] = map_start + parts[i]
+			return 'void'
+		}
+		else {
+			// types defined by the user
+			// mod.submod.submod2.Type => submod2.Type
+			parts := res.split('.')
+			res = if parts.len > 1 { parts[parts.len - 2..].join('.') } else { parts[0] }
+			// cur_mod.Type => Type
+			if res.starts_with(table.cmod_prefix) {
+				res = res.replace_once(table.cmod_prefix, '')
 			}
 		}
-		if parts[i].contains('_mut') {
-			parts[i] = 'mut ' + parts[i].replace('_mut', '')
-		}
-		nr_muls := t.nr_muls()
-		if nr_muls > 0 {
-			parts[i] = strings.repeat(`&`, nr_muls) + parts[i]
-		}
 	}
-	res = parts.join(' ')
+	nr_muls := t.nr_muls()
+	if nr_muls > 0 {
+		res = strings.repeat(`&`, nr_muls) + res
+	}
 	if t.has_flag(.optional) {
-		if sym.kind == .void {
-			res = '?'
-		} else {
-			res = '?' + res
-		}
+		res = '?' + res
 	}
 	return res
 }


### PR DESCRIPTION
Simplify `table.type_to_str`.
Add tests for multi-return.