### PR TITLE
examples: fix sokol/particles to start up faster

### DIFF
--- a/examples/sokol/particles/modules/particle/system.v
+++ b/examples/sokol/particles/modules/particle/system.v
@@ -21,7 +21,7 @@ mut:
 pub fn (mut s System) init(sc SystemConfig) {
 	for i := 0; i < sc.pool; i++ {
 		p := new(vec2.Vec2{f32(s.width) * 0.5, f32(s.height) * 0.5})
-		s.pool << p
+		s.bin << p
 	}
 }
 


### PR DESCRIPTION
Minor tweak to sokol particles example that makes it start up faster.
Before, the example couldn't spawn any particles immediately as all particles where spawned in the active pool,
making us wait for particles to become available.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
