### PR TITLE
checker: infer generic fn parameter T from parameter of type `[]T`

### DIFF
--- a/vlib/v/tests/generic_fn_infer_modifier_test.v
+++ b/vlib/v/tests/generic_fn_infer_modifier_test.v
@@ -1,0 +1,16 @@
+fn f_array<T>(a []T) T {
+	return a[0]
+}
+
+fn g_array<T>(mut a []T) {
+	a[0] = a[1]
+}
+
+fn test_array() {
+	mut a := [7, 8]
+	r := f_array(a)
+	assert r == 7
+	
+	g_array(mut a)
+	assert a[0] == 8
+}


### PR DESCRIPTION
Fixes #5860.
Related: #6216.