### PR TITLE
checker: add check_expected() which returns an optional error

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -278,6 +278,13 @@ pub fn (mut c Checker) check_types(got table.Type, expected table.Type) bool {
 	return true
 }
 
+pub fn (mut c Checker) check_expected(got table.Type, expected table.Type)? {
+	if c.check_types(got, expected) {return}
+	exps := c.table.type_to_str(expected)
+	gots := c.table.type_to_str(got)
+	return error('expected `$exps`, not `$gots`')
+}
+
 pub fn (mut c Checker) symmetric_check(left table.Type, right table.Type) bool {
 	// allow direct int-literal assignment for pointers for now
 	// maybe in the future optionals should be used for that

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -278,8 +278,10 @@ pub fn (mut c Checker) check_types(got table.Type, expected table.Type) bool {
 	return true
 }
 
-pub fn (mut c Checker) check_expected(got table.Type, expected table.Type)? {
-	if c.check_types(got, expected) {return}
+pub fn (mut c Checker) check_expected(got table.Type, expected table.Type) ? {
+	if c.check_types(got, expected) {
+		return
+	}
 	exps := c.table.type_to_str(expected)
 	gots := c.table.type_to_str(got)
 	return error('expected `$exps`, not `$gots`')

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -374,8 +374,7 @@ pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
 			c.expected_type = field.typ
 			field_expr_type := c.expr(field.default_expr)
 			c.check_expected(field_expr_type, field.typ) or {
-				c.error('incompatible initializer for field `$field.name`: $err',
-					field.default_expr.position())
+				c.error('incompatible initializer for field `$field.name`: $err', field.default_expr.position())
 			}
 			// Check for unnecessary inits like ` = 0` and ` = ''`
 			if field.typ.is_ptr() {
@@ -506,8 +505,7 @@ pub fn (mut c Checker) struct_init(mut struct_init ast.StructInit) table.Type {
 				expr_type_sym := c.table.get_type_symbol(expr_type)
 				if expr_type != table.void_type && expr_type_sym.kind != .placeholder {
 					c.check_expected(expr_type, info_field.typ) or {
-						c.error('cannot assign to field `$info_field.name`: $err',
-							field.pos)
+						c.error('cannot assign to field `$info_field.name`: $err', field.pos)
 					}
 				}
 				if info_field.typ.is_ptr() && !expr_type.is_ptr() && !expr_type.is_pointer() &&

--- a/vlib/v/checker/tests/arrow_op_wrong_left_type_err_b.out
+++ b/vlib/v/checker/tests/arrow_op_wrong_left_type_err_b.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/arrow_op_wrong_left_type_err_b.vv:4:8: error: cannot assign `string` to `obj` of type `int`
+vlib/v/checker/tests/arrow_op_wrong_left_type_err_b.vv:4:8: error: cannot assign to `obj`: expected `int`, not `string`
     2 |     ch := chan string{}
     3 |     mut obj := 9
     4 |     obj = <-ch

--- a/vlib/v/checker/tests/assign_expr_type_err_i.out
+++ b/vlib/v/checker/tests/assign_expr_type_err_i.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/assign_expr_type_err_i.vv:3:9: error: cannot assign `string` to `foo` of type `f64`
+vlib/v/checker/tests/assign_expr_type_err_i.vv:3:9: error: cannot assign to `foo`: expected `f64`, not `string`
     1 | fn main() {
     2 |     mut foo := 1.5
-    3 |     foo += 'hello'
+    3 |     foo += 'hello' 
       |            ~~~~~~~
     4 | }

--- a/vlib/v/checker/tests/cannot_assign_array.out
+++ b/vlib/v/checker/tests/cannot_assign_array.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/cannot_assign_array.vv:9:11: error: cannot assign `[8]f64` to `ctx.vb` of type `string`
+vlib/v/checker/tests/cannot_assign_array.vv:9:11: error: cannot assign to `ctx.vb`: expected `string`, not `[8]f64`
     7 |     mut ctx := Context{}
     8 |     x := 2.32
     9 |     ctx.vb = [1.1, x, 3.3, 4.4, 5.0, 6.0, 7.0, 8.9]!!

--- a/vlib/v/checker/tests/in_mismatch_type.out
+++ b/vlib/v/checker/tests/in_mismatch_type.out
@@ -1,74 +1,74 @@
-vlib/v/checker/tests/in_mismatch_type.vv:10:7: error: the data type on the left of `in` (`any_int`) does not match the array item type (`string`) 
+vlib/v/checker/tests/in_mismatch_type.vv:10:7: error: left operand to `in` does not match the array element type: expected `string`, not `any_int`
     8 |     }
     9 |     s := 'abcd'
    10 |     if 1 in a_s {
       |          ~~
    11 |         println('ok')
    12 |     }
-vlib/v/checker/tests/in_mismatch_type.vv:13:7: error: the data type on the left of `in` (`any_int`) does not match the map key type `string` 
+vlib/v/checker/tests/in_mismatch_type.vv:13:7: error: left operand to `in` does not match the map key type: expected `string`, not `any_int`
    11 |         println('ok')
    12 |     }
    13 |     if 2 in m {
       |          ~~
    14 |         println('yeah')
    15 |     }
-vlib/v/checker/tests/in_mismatch_type.vv:16:7: error: the data type on the left of `in` must be a string (is `any_int`) 
+vlib/v/checker/tests/in_mismatch_type.vv:16:7: error: left operand to `in` does not match: expected `string`, not `any_int`
    14 |         println('yeah')
    15 |     }
    16 |     if 3 in s {
       |          ~~
    17 |         println('dope')
    18 |     }
-vlib/v/checker/tests/in_mismatch_type.vv:19:9: error: the data type on the left of `in` must be a string (is `rune`)
+vlib/v/checker/tests/in_mismatch_type.vv:19:9: error: left operand to `in` does not match: expected `string`, not `rune`
    17 |         println('dope')
    18 |     }
    19 |     if `a` in s {
       |            ~~
    20 |         println("oh no :'(")
    21 |     }
-vlib/v/checker/tests/in_mismatch_type.vv:22:7: error: `in` can only be used with an array/map/string 
+vlib/v/checker/tests/in_mismatch_type.vv:22:7: error: `in` can only be used with an array/map/string
    20 |         println("oh no :'(")
    21 |     }
    22 |     if 1 in 12 {
       |          ~~
    23 |         println('right')
    24 |     }
-vlib/v/checker/tests/in_mismatch_type.vv:25:12: error: the data type on the left of `in` (`Int`) does not match the map key type `string` 
+vlib/v/checker/tests/in_mismatch_type.vv:25:12: error: left operand to `in` does not match the map key type: expected `string`, not `Int`
    23 |         println('right')
    24 |     }
    25 |     if Int(2) in m {
       |               ~~
    26 |         println('yeah')
    27 |     }
-vlib/v/checker/tests/in_mismatch_type.vv:28:9: error: the data type on the left of `in` (`string`) does not match the array item type (`int`) 
+vlib/v/checker/tests/in_mismatch_type.vv:28:9: error: left operand to `in` does not match the array element type: expected `int`, not `string`
    26 |         println('yeah')
    27 |     }
    28 |     if '3' in a_i {
       |            ~~
    29 |         println('sure')
    30 |     }
-vlib/v/checker/tests/in_mismatch_type.vv:31:9: error: the data type on the left of `in` (`string`) does not match the array item type (`int`) 
+vlib/v/checker/tests/in_mismatch_type.vv:31:9: error: left operand to `in` does not match the array element type: expected `int`, not `string`
    29 |         println('sure')
    30 |     }
    31 |     if '2' in a_i {
       |            ~~
    32 |         println('all right')
    33 |     }
-vlib/v/checker/tests/in_mismatch_type.vv:34:7: error: the data type on the left of `!in` (`any_int`) does not match the array item type (`string`) 
+vlib/v/checker/tests/in_mismatch_type.vv:34:7: error: left operand to `!in` does not match the array element type: expected `string`, not `any_int`
    32 |         println('all right')
    33 |     }
    34 |     if 1 !in a_s {
       |          ~~~
    35 |         println('ok')
    36 |     }
-vlib/v/checker/tests/in_mismatch_type.vv:37:9: error: the data type on the left of `!in` (`string`) does not match the array item type (`int`) 
+vlib/v/checker/tests/in_mismatch_type.vv:37:9: error: left operand to `!in` does not match the array element type: expected `int`, not `string`
    35 |         println('ok')
    36 |     }
    37 |     if '1' !in a_i {
       |            ~~~
    38 |         println('good')
    39 |     }
-vlib/v/checker/tests/in_mismatch_type.vv:41:7: error: the data type on the left of `!in` (`any_int`) does not match the map key type `string` 
+vlib/v/checker/tests/in_mismatch_type.vv:41:7: error: left operand to `!in` does not match the map key type: expected `string`, not `any_int`
    39 |     }
    40 | 
    41 |     if 5 !in m {

--- a/vlib/v/checker/tests/map_init_wrong_type.out
+++ b/vlib/v/checker/tests/map_init_wrong_type.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/map_init_wrong_type.vv:3:10: error: cannot assign `map[string]f64` to `a` of type `map[string]f32`
+vlib/v/checker/tests/map_init_wrong_type.vv:3:10: error: cannot assign to `a`: expected `map[string]f32`, not `map[string]f64`
     1 | fn main() {
     2 |    mut a := map[string]f32{}
     3 |    a = { 'x': 12.3 }

--- a/vlib/v/checker/tests/modules/overload_return_type.out
+++ b/vlib/v/checker/tests/modules/overload_return_type.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/modules/overload_return_type/main.v:8:11: error: cannot assign `int` to `two` of type `Point`
+vlib/v/checker/tests/modules/overload_return_type/main.v:8:11: error: cannot assign to `two`: expected `Point`, not `int`
     6 |     one := Point {x:1, y:2}
     7 |     mut two := Point {x:5, y:1}
     8 |     two = one + two

--- a/vlib/v/checker/tests/overload_return_type.out
+++ b/vlib/v/checker/tests/overload_return_type.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/overload_return_type.vv:14:11: error: cannot assign `int` to `two` of type `Point`
+vlib/v/checker/tests/overload_return_type.vv:14:11: error: cannot assign to `two`: expected `Point`, not `int`
    12 |     mut one := Point {x:1, y:2}
    13 |     mut two := Point {x:5, y:1}
    14 |     two = one + two

--- a/vlib/v/checker/tests/sum.out
+++ b/vlib/v/checker/tests/sum.out
@@ -13,13 +13,13 @@ vlib/v/checker/tests/sum.vv:6:8: error: cannot cast non-sum type `int` using `as
     7 | }
     8 |
 vlib/v/checker/tests/sum.vv:10:11: error: cannot cast `rune` to `Var`
-    8 |
+    8 | 
     9 | fn sum() {
    10 |     _ := Var(`J`)
       |              ~~~
    11 |     mut s2 := Var('')
    12 |     s2 = true
-vlib/v/checker/tests/sum.vv:12:7: error: cannot assign `bool` to `s2` of type `Var`
+vlib/v/checker/tests/sum.vv:12:7: error: cannot assign to `s2`: expected `Var`, not `bool`
    10 |     _ := Var(`J`)
    11 |     mut s2 := Var('')
    12 |     s2 = true


### PR DESCRIPTION
* Simplifies code in checker.v.
* Uses Table.type_to_str instead of TypeSymbol.source_name which is wrong for pointers e.g. `&int` gets printed as `int`.
* Makes expected type error messages more consistent.

I've done this for some uses of check_types - if this is OK I can do the remaining ones too.