### PR TITLE
cli: show help for empty root command

### DIFF
--- a/vlib/cli/command.v
+++ b/vlib/cli/command.v
@@ -185,6 +185,12 @@ fn (mut cmd Command) parse_commands() {
 			}
 		}
 	}
+	if cmd.is_root() && int(cmd.execute) == 0 {
+		if !cmd.disable_help {
+			cmd.execute_help()
+			return
+		}
+	}
 	// if no further command was found, execute current command
 	if cmd.required_args > 0 {
 		if cmd.required_args > cmd.args.len {

--- a/vlib/v/tests/inout/cli_command_no_execute.vv
+++ b/vlib/v/tests/inout/cli_command_no_execute.vv
@@ -1,7 +1,11 @@
-import os
 import cli {Command}
 
 fn main() {
-	mut cmd := Command {}                                                       
-	cmd.parse(os.args)
+	mut cmd := Command {
+		name: 'cmd'
+	}
+	cmd.add_command({
+		name: 'foo'
+	})
+	cmd.parse(['', 'cmd', 'foo'])
 }

--- a/vlib/v/tests/inout/cli_root_default_help.out
+++ b/vlib/v/tests/inout/cli_root_default_help.out
@@ -1,0 +1,7 @@
+Usage:  [flags] [commands]
+
+Flags:
+  -help               Prints help information.
+
+Commands:
+  help                Prints help information.

--- a/vlib/v/tests/inout/cli_root_default_help.vv
+++ b/vlib/v/tests/inout/cli_root_default_help.vv
@@ -1,0 +1,7 @@
+import cli {Command}
+import os
+
+fn main() {
+	mut cmd := Command {}
+	cmd.parse(os.args)
+}


### PR DESCRIPTION
The help will show again by default, but only for the root command.
This behaviour is quite common in a lot of cli tools.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
