### PR TITLE
cgen: produce cleaner error on missing C headers

### DIFF
--- a/vlib/net/openssl/c.v
+++ b/vlib/net/openssl/c.v
@@ -15,7 +15,7 @@ module openssl
 // Brew
 #flag darwin -I/usr/local/opt/openssl/include
 #flag darwin -L/usr/local/opt/openssl/lib
-#include <openssl/rand.h>
+#include <openssl/rand.h> # Please install OpenSSL
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -628,8 +628,10 @@ pub:
 	mod  string
 	pos  token.Position
 pub mut:
-	val  string
-	kind string
+	val  string // example: 'include <openssl/rand.h> # please install openssl // comment'
+	kind string // : 'include'
+	main string // : '<openssl/rand.h>'
+	msg  string // : 'please install openssl'
 }
 
 /*

--- a/vlib/v/builder/msvc.v
+++ b/vlib/v/builder/msvc.v
@@ -308,9 +308,7 @@ pub fn (mut v Builder) cc_msvc() {
 	}
 	diff := time.ticks() - ticks
 	v.timing_message('C msvc', diff)
-	if res.exit_code != 0 {
-		verror(res.output)
-	}
+	v.post_process_c_compiler_output(res)
 	// println(res)
 	// println('C OUTPUT:')
 	// Always remove the object file - it is completely unnecessary

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2459,7 +2459,7 @@ fn (mut c Checker) hash_stmt(mut node ast.HashStmt) {
 		return
 	}
 	if node.kind == 'include' {
-		mut flag := node.val[8..]
+		mut flag := node.main
 		if flag.contains('@VROOT') {
 			vroot := util.resolve_vroot(flag, c.file.path) or {
 				c.error(err, node.pos)
@@ -2475,7 +2475,7 @@ fn (mut c Checker) hash_stmt(mut node ast.HashStmt) {
 		}
 	} else if node.kind == 'flag' {
 		// #flag linux -lm
-		mut flag := node.val[5..]
+		mut flag := node.main
 		// expand `@VROOT` to its absolute path
 		if flag.contains('@VROOT') {
 			flag = util.resolve_vroot(flag, c.file.path) or {

--- a/vlib/v/checker/tests/missing_c_lib_header_1.out
+++ b/vlib/v/checker/tests/missing_c_lib_header_1.out
@@ -1,0 +1,1 @@
+builder error: Header file <missing/folder/header1.h>, needed for module `main` was not found. Please install the corresponding development headers.

--- a/vlib/v/checker/tests/missing_c_lib_header_1.vv
+++ b/vlib/v/checker/tests/missing_c_lib_header_1.vv
@@ -1,0 +1,6 @@
+module main
+
+// The following header file is intentionally missing.
+// The #include does not have the optional explanation part
+// after a `#` sign:
+#include <missing/folder/header1.h>

--- a/vlib/v/checker/tests/missing_c_lib_header_with_explanation_2.out
+++ b/vlib/v/checker/tests/missing_c_lib_header_with_explanation_2.out
@@ -1,0 +1,1 @@
+builder error: Header file <missing/folder/header.h>, needed for module `main` was not found. Please install missing C library.

--- a/vlib/v/checker/tests/missing_c_lib_header_with_explanation_2.vv
+++ b/vlib/v/checker/tests/missing_c_lib_header_with_explanation_2.vv
@@ -1,0 +1,6 @@
+module main
+
+// The following header file is intentionally missing.
+// The part after `#` is an explanation message, that V will
+// show, when it is not found:
+#include <missing/folder/header.h> # Please install missing C library

--- a/vlib/v/compiler_errors_test.v
+++ b/vlib/v/compiler_errors_test.v
@@ -85,6 +85,13 @@ fn (mut tasks []TaskDescription) run() {
 	$if noskip ? {
 		m_skip_files = []
 	}
+	$if tinyc {
+		// NB: tcc does not support __has_include, so the detection mechanism
+		// used for the other compilers does not work. It still provides a
+		// cleaner error message, than a generic C error, but without the explanation.
+		m_skip_files << 'vlib/v/checker/tests/missing_c_lib_header_1.vv'
+		m_skip_files << 'vlib/v/checker/tests/missing_c_lib_header_with_explanation_2.vv'
+	}
 	for i in 0 .. tasks.len {
 		if tasks[i].path in m_skip_files {
 			tasks[i].is_skipped = true

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -22,11 +22,23 @@ fn (mut p Parser) hash() ast.HashStmt {
 	val := p.tok.lit
 	kind := val.all_before(' ')
 	p.next()
+	mut main := ''
+	mut msg := ''
+	content := val.all_after('$kind ').all_before('//')
+	if content.contains(' #') {
+		main = content.all_before(' #').trim_space()
+		msg = content.all_after(' #').trim_space()
+	} else {
+		main = content.trim_space()
+		msg = ''
+	}
 	// p.trace('a.v', 'kind: ${kind:-10s} | pos: ${pos:-45s} | hash: $val')
 	return ast.HashStmt{
 		mod: p.mod
 		val: val
 		kind: kind
+		main: main
+		msg: msg
 		pos: pos
 	}
 }

--- a/vlib/vweb/tests/vweb_test_server.v
+++ b/vlib/vweb/tests/vweb_test_server.v
@@ -70,7 +70,7 @@ pub fn (mut app App) settings(username string) vweb.Result {
 }
 
 ['/:user/:repo/settings']
-pub fn (mut app App) user_repo_settings(username, repository string) vweb.Result {
+pub fn (mut app App) user_repo_settings(username string, repository string) vweb.Result {
 	if username !in known_users {
 		return app.vweb.not_found()
 	}


### PR DESCRIPTION
This PR implements this syntax:
`#include <openssl/rand.h> # Please install OpenSSL`

When the C header is missing, the C compiler will produce a custom message, that V will detect and show to the user,
filtering out the rest of the C compiler output, and adding the explanation/tip specified after the `#` sign.

It also unifies the MSVC and other C compilers output handling, so msvc users will also get shortened messages etc.