### PR TITLE
parser: avoid duplicate module names in table.imports and ast_imports

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1523,10 +1523,10 @@ fn (mut p Parser) import_stmt() ast.Import {
 		}
 	}
 	p.imports[mod_alias] = mod_name
-	// if mod_name !in p.table.imports {
-	p.table.imports << mod_name
-	p.ast_imports << node
-	// }
+	if mod_name !in p.table.imports {
+		p.table.imports << mod_name
+		p.ast_imports << node
+	}
 	return node
 }
 


### PR DESCRIPTION
Remove commented check to avoid adding redundant names.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
