### PR TITLE
parser: clean error when nesting `unsafe`

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2012,7 +2012,9 @@ fn (mut p Parser) unsafe_stmt() ast.Stmt {
 		p.error_with_pos('please use `unsafe {`', p.tok.position())
 	}
 	p.next()
-	assert !p.inside_unsafe
+	if p.inside_unsafe {
+		p.error_with_pos('already inside `unsafe` block', pos)
+	}
 	if p.tok.kind == .rcbr {
 		// `unsafe {}`
 		p.next()

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -92,9 +92,11 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 		}
 		.key_unsafe {
 			// unsafe {
-			p.next()
 			pos := p.tok.position()
-			assert !p.inside_unsafe
+			p.next()
+			if p.inside_unsafe {
+				p.error_with_pos('already inside `unsafe` block', pos)
+			}
 			p.inside_unsafe = true
 			p.check(.lcbr)
 			node = ast.UnsafeExpr{

--- a/vlib/v/parser/tests/nested_unsafe_expr.out
+++ b/vlib/v/parser/tests/nested_unsafe_expr.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/nested_unsafe_expr.vv:4:8: error: already inside `unsafe` block
+    2 |     a := 0
+    3 |     unsafe {
+    4 |         a += unsafe{2}
+      |              ~~~~~~
+    5 |     }
+    6 |     println(a)

--- a/vlib/v/parser/tests/nested_unsafe_expr.vv
+++ b/vlib/v/parser/tests/nested_unsafe_expr.vv
@@ -1,0 +1,7 @@
+fn main() {
+	a := 0
+	unsafe {
+		a += unsafe{2}
+	}
+	println(a)
+}

--- a/vlib/v/parser/tests/nested_unsafe_stmt.out
+++ b/vlib/v/parser/tests/nested_unsafe_stmt.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/nested_unsafe_stmt.vv:4:3: error: already inside `unsafe` block
+    2 |     a := 0
+    3 |     unsafe {
+    4 |         unsafe {
+      |         ~~~~~~
+    5 |             a++
+    6 |         }

--- a/vlib/v/parser/tests/nested_unsafe_stmt.vv
+++ b/vlib/v/parser/tests/nested_unsafe_stmt.vv
@@ -1,0 +1,9 @@
+fn main() {
+	a := 0
+	unsafe {
+		unsafe {
+			a++
+		}
+	}
+	println(a)
+}


### PR DESCRIPTION
Nesting unsafe blocks or expressions used to make the compiler panic.