### PR TITLE
vpm search: mark modules that are already installed

### DIFF
--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -115,6 +115,7 @@ fn vpm_search(keywords []string) {
 		exit(2)
 	}
 	modules := get_all_modules()
+	installed_modules := get_installed_modules()
 	joined := search_keys.join(', ')
 	mut index := 0
 	for mod in modules {
@@ -135,14 +136,15 @@ fn vpm_search(keywords []string) {
 			} else {
 				parts[0] = ' by ${parts[0]} '
 			}
-			println('${index}. ${parts[1]}${parts[0]}[$mod]')
+			installed := if mod in installed_modules { ' (installed)' } else { '' }
+			println('${index}. ${parts[1]}${parts[0]}[$mod]$installed')
 			break
 		}
 	}
 	if index == 0 {
 		println('No module(s) found for "$joined"')
 	} else {
-		println('\nUse "v install author_name.module_name" to install the module')
+		println('\nUse "v install author_name.module_name" to install the module.')
 	}
 }
 

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -131,9 +131,11 @@ fn vpm_search(keywords []string) {
 			// in case the author isn't present
 			if parts.len == 1 {
 				parts << parts[0]
-				parts[0] = ''
+				parts[0] = ' '
+			} else {
+				parts[0] = ' by ${parts[0]} '
 			}
-			println('${index}. ${parts[1]} by ${parts[0]} [$mod]')
+			println('${index}. ${parts[1]}${parts[0]}[$mod]')
 			break
 		}
 	}


### PR DESCRIPTION
- mark modules already installed: `1. ui [ui] (installed)`

- remove 'by' and extra space if no author is found:   `1. ui by  [ui]` --> `1. ui [ui]`
