### PR TITLE
cgen: print results of failed callexprs in `assert fn() == fn2()`

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -192,7 +192,7 @@ pub fn (x Expr) str() string {
 				return '${x.left.str()}.${x.name}($sargs)'
 			}
 			if x.name.starts_with('${x.mod}.') {
-				return '${x.name}($sargs)'
+				return util.strip_main_name('${x.name}($sargs)')
 			}
 			return '${x.mod}.${x.name}($sargs)'
 		}

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -177,6 +177,9 @@ pub fn (lit &StringInterLiteral) get_fspec_braces(i int) (string, bool) {
 // string representation of expr
 pub fn (x Expr) str() string {
 	match x {
+		CTempVar {
+			return x.orig.str()
+		}
 		BoolLiteral {
 			return x.val.str()
 		}
@@ -187,6 +190,9 @@ pub fn (x Expr) str() string {
 			sargs := args2str(x.args)
 			if x.is_method {
 				return '${x.left.str()}.${x.name}($sargs)'
+			}
+			if x.name.starts_with('${x.mod}.') {
+				return '${x.name}($sargs)'
 			}
 			return '${x.mod}.${x.name}($sargs)'
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2560,6 +2560,9 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 		return table.void_type
 	}
 	match mut node {
+		ast.CTempVar {
+			return node.typ
+		}
 		ast.AnonFn {
 			keep_fn := c.cur_fn
 			c.cur_fn = &node.decl

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -711,6 +711,9 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 		eprintln('expr: ${node.position():-42} | node: ${typeof(node):-20} | $node.str()')
 	}
 	match mut node {
+		ast.CTempVar {
+			eprintln('ast.CTempVar of $node.orig.str() should be generated/used only in cgen')
+		}
 		ast.AnonFn {
 			f.fn_decl(node.decl)
 		}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1996,7 +1996,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 	// println('cgen expr() line_nr=$node.pos.line_nr')
 	match node {
 		ast.CTempVar {
-			//g.write('/*ctmp .orig: $node.orig.str() , .typ: $node.typ, .is_ptr: $node.is_ptr */ ')
+			// g.write('/*ctmp .orig: $node.orig.str() , .typ: $node.typ, .is_ptr: $node.is_ptr */ ')
 			g.write(node.name)
 		}
 		ast.AnonFn {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1994,11 +1994,8 @@ fn (mut g Gen) gen_anon_fn_decl(it ast.AnonFn) {
 
 fn (mut g Gen) expr(node ast.Expr) {
 	// println('cgen expr() line_nr=$node.pos.line_nr')
+	// NB: please keep the type names in the match here in alphabetical order:
 	match node {
-		ast.CTempVar {
-			// g.write('/*ctmp .orig: $node.orig.str() , .typ: $node.typ, .is_ptr: $node.is_ptr */ ')
-			g.write(node.name)
-		}
 		ast.AnonFn {
 			// TODO: dont fiddle with buffers
 			g.gen_anon_fn_decl(node)
@@ -2119,6 +2116,10 @@ fn (mut g Gen) expr(node ast.Expr) {
 		ast.Comment {}
 		ast.ConcatExpr {
 			g.concat_expr(node)
+		}
+		ast.CTempVar {
+			// g.write('/*ctmp .orig: $node.orig.str() , .typ: $node.typ, .is_ptr: $node.is_ptr */ ')
+			g.write(node.name)
 		}
 		ast.EnumVal {
 			// g.write('${it.mod}${it.enum_name}_$it.val')

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1272,8 +1272,40 @@ fn (mut g Gen) gen_attrs(attrs []table.Attr) {
 	}
 }
 
-fn (mut g Gen) gen_assert_stmt(a ast.AssertStmt) {
+fn (mut g Gen) gen_assert_stmt(original_assert_statement ast.AssertStmt) {
+	mut a := original_assert_statement
 	g.writeln('// assert')
+	mut tl_name := ''
+	mut tr_name := ''
+	if a.expr is ast.InfixExpr {
+		mut aie := a.expr as ast.InfixExpr
+		if aie.left is ast.CallExpr {
+			tl_styp := g.typ(aie.left_type)
+			tl_name = g.new_tmp_var()
+			g.write('$tl_styp $tl_name = ')
+			g.expr(aie.left)
+			g.writeln(';')
+			aie.left = ast.Expr(ast.CTempVar{
+				name: tl_name
+				typ: aie.left_type
+				is_ptr: aie.left_type.is_ptr()
+				orig: aie.left
+			})
+		}
+		if aie.right is ast.CallExpr {
+			tr_styp := g.typ(aie.right_type)
+			tr_name = g.new_tmp_var()
+			g.write('$tr_styp $tr_name = ')
+			g.expr(aie.right)
+			g.writeln(';')
+			aie.right = ast.Expr(ast.CTempVar{
+				name: tr_name
+				typ: aie.right_type
+				is_ptr: aie.right_type.is_ptr()
+				orig: aie.right
+			})
+		}
+	}
 	g.inside_ternary++
 	g.write('if (')
 	g.expr(a.expr)
@@ -1338,7 +1370,7 @@ fn (mut g Gen) gen_assert_metainfo(a ast.AssertStmt) string {
 fn (mut g Gen) gen_assert_single_expr(e ast.Expr, t table.Type) {
 	unknown_value := '*unknown value*'
 	match e {
-		ast.CallExpr, ast.CastExpr, ast.IndexExpr, ast.PrefixExpr, ast.MatchExpr {
+		ast.CastExpr, ast.IndexExpr, ast.PrefixExpr, ast.MatchExpr {
 			g.write(ctoslit(unknown_value))
 		}
 		ast.Type {
@@ -1963,6 +1995,10 @@ fn (mut g Gen) gen_anon_fn_decl(it ast.AnonFn) {
 fn (mut g Gen) expr(node ast.Expr) {
 	// println('cgen expr() line_nr=$node.pos.line_nr')
 	match node {
+		ast.CTempVar {
+			//g.write('/*ctmp .orig: $node.orig.str() , .typ: $node.typ, .is_ptr: $node.is_ptr */ ')
+			g.write(node.name)
+		}
 		ast.AnonFn {
 			// TODO: dont fiddle with buffers
 			g.gen_anon_fn_decl(node)
@@ -4364,6 +4400,11 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype table.Type) ?bool {
 			if expr.is_fixed {
 				s := g.typ(expr.typ)
 				g.write('($s)')
+			}
+		}
+		if expr is ast.CTempVar {
+			if expr.is_ptr {
+				g.write('*')
 			}
 		}
 		g.expr(expr)

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -520,6 +520,9 @@ fn (mut g JsGen) stmt(node ast.Stmt) {
 
 fn (mut g JsGen) expr(node ast.Expr) {
 	match node {
+		ast.CTempVar {
+			g.write('/* ast.CTempVar: node.name */')
+		}
 		ast.AnonFn {
 			g.gen_fn_decl(node.decl)
 		}
@@ -673,17 +676,17 @@ fn (mut g JsGen) gen_assert_stmt(a ast.AssertStmt) {
 	mut mod_path := g.file.path.replace('\\', '\\\\')
 	if g.is_test {
 		g.writeln('	g_test_oks++;')
-		g.writeln('	cb_assertion_ok("$mod_path", ${a.pos.line_nr+1}, "assert $s_assertion", "${g.fn_decl.name}()" );')
+		g.writeln('	cb_assertion_ok("$mod_path", ${a.pos.line_nr + 1}, "assert $s_assertion", "${g.fn_decl.name}()" );')
 		g.writeln('} else {')
 		g.writeln('	g_test_fails++;')
-		g.writeln('	cb_assertion_failed("$mod_path", ${a.pos.line_nr+1}, "assert $s_assertion", "${g.fn_decl.name}()" );')
+		g.writeln('	cb_assertion_failed("$mod_path", ${a.pos.line_nr + 1}, "assert $s_assertion", "${g.fn_decl.name}()" );')
 		g.writeln('	exit(1);')
 		g.writeln('}')
 		return
 	}
 	g.writeln('} else {')
 	g.inc_indent()
-	g.writeln('builtin.eprintln("$mod_path:${a.pos.line_nr+1}: FAIL: fn ${g.fn_decl.name}(): assert $s_assertion");')
+	g.writeln('builtin.eprintln("$mod_path:${a.pos.line_nr + 1}: FAIL: fn ${g.fn_decl.name}(): assert $s_assertion");')
 	g.writeln('builtin.exit(1);')
 	g.dec_indent()
 	g.writeln('}')


### PR DESCRIPTION
Fixes #6662 .

With this PR:
```v
fn get_string() string { return 'NOT hello' }
fn test_get_string() {  assert get_string() == 'hello' }
```
... produces:

```
y_test.v:2: failed assert in function test_get_string
Source  : `main.get_string() == 'hello'`
         left value: NOT hello <= `main.get_string()`
        right value: hello <= `'hello'`
```

The result of get_string() is printed now. Before it was always `*unknown value*`.