### PR TITLE
pratt: allow using `+` as prefix for numbers

### DIFF
--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -228,3 +228,23 @@ fn test_int_to_hex() {
 	assert i64(-1).hex() == 'ffffffffffffffff'
 	assert u64(18446744073709551615).hex() == 'ffffffffffffffff'
 }
+
+fn test_pos_and_neg_sign() {
+	a := +1
+	assert a == 1
+	assert -a == -1
+	assert a.str() == '1'
+	assert -a.str() == '-1'
+
+	b := -1
+	assert b == -1
+	assert -b == 1
+	assert b.str() == '-1'
+	assert -b.str() == '1'
+
+	c := -+a
+	assert c == -1
+	assert c.str() == '-1'
+	assert -c == 1
+	assert -c.str() == '1'
+}

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -59,8 +59,8 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			}
 			p.next()
 		}
-		.minus, .amp, .mul, .not, .bit_not, .arrow {
-			// -1, -a, !x, &x, ~x, <-a
+		.minus, .amp, .mul, .not, .bit_not, .arrow, .plus {
+			// -1, -a, !x, &x, ~x, <-a, +a
 			node = p.prefix_expr()
 		}
 		.key_true, .key_false {
@@ -345,7 +345,7 @@ fn (mut p Parser) prefix_expr() ast.PrefixExpr {
 	// p.warn('unsafe')
 	// }
 	p.next()
-	mut right := if op == .minus { p.expr(token.Precedence.call) } else { p.expr(token.Precedence.prefix) }
+	mut right := if op in [.minus, .plus]  { p.expr(token.Precedence.call) } else { p.expr(token.Precedence.prefix) }
 	p.is_amp = false
 	if right is ast.CastExpr {
 		right.in_prexpr = true

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -60,7 +60,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			p.next()
 		}
 		.minus, .amp, .mul, .not, .bit_not, .arrow, .plus {
-			// -1, -a, !x, &x, ~x, <-a, +a
+			// -1, -a, !x, &x, ~x, <-a, +1
 			node = p.prefix_expr()
 		}
 		.key_true, .key_false {

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -345,7 +345,7 @@ fn (mut p Parser) prefix_expr() ast.PrefixExpr {
 	// p.warn('unsafe')
 	// }
 	p.next()
-	mut right := if op in [.minus, .plus]  { p.expr(token.Precedence.call) } else { p.expr(token.Precedence.prefix) }
+	mut right := if op in [.minus, .plus] { p.expr(token.Precedence.call) } else { p.expr(token.Precedence.prefix) }
 	p.is_amp = false
 	if right is ast.CastExpr {
 		right.in_prexpr = true


### PR DESCRIPTION
This PR implements https://github.com/vlang/v/issues/6663