### PR TITLE
gen: Add a little bit of structure to x86-64 codegen

### DIFF
--- a/vlib/v/gen/x64/elf.v
+++ b/vlib/v/gen/x64/elf.v
@@ -77,8 +77,8 @@ pub fn (mut g Gen) generate_elf_header() {
 pub fn (mut g Gen) generate_elf_footer() {
 	// Return 0
 	/*
-	g.mov(.edi, 0) // ret value
-	g.mov(.eax, 60)
+	g.mov(.rdi, 0) // ret value
+	g.mov(.rax, 60)
 	g.syscall()
 	*/
 	// Strings table

--- a/vlib/v/gen/x64/gen.v
+++ b/vlib/v/gen/x64/gen.v
@@ -372,7 +372,7 @@ fn (mut g Gen) load_reg_indirect(dst Register, src Indirect) {
 	g.write8(rex_w)
 	g.write8(0x8b)
 	g.address_disp8(src, dst)
-	g.println('mov $dst,DWORD PTR[$dst-$src.var_offset.hex2()]')
+	g.println('mov $dst,DWORD PTR[$src.reg-$src.var_offset.hex2()]')
 }
 
 fn (mut g Gen) call(addr int) {

--- a/vlib/v/gen/x64/gen.v
+++ b/vlib/v/gen/x64/gen.v
@@ -64,10 +64,10 @@ enum Scale {
 }
 
 enum Mod {
-	direct = 0
+	disp0 = 0
 	disp8
-	disp16
 	disp32
+	direct
 }
 
 const (
@@ -353,8 +353,8 @@ struct Indirect {
 	var_offset int
 }
 
-fn (mut g Gen) address_disp8(ind Indirect, dir Register) {
-	g.write8(modrm(byte(Mod.disp8), dir, ind.reg))
+fn (mut g Gen) address_disp8(dir Register, ind Indirect) {
+	g.write8(modrm(Mod.disp8, dir, ind.reg))
 	if ind.reg == .rsp {
 		g.write8(sib(.scale1, .rsp, .rsp))
 	}
@@ -364,14 +364,14 @@ fn (mut g Gen) address_disp8(ind Indirect, dir Register) {
 fn (mut g Gen) store_reg_indirect(dst Indirect, src Register) {
 	g.write8(rex_w)
 	g.write8(0x89)
-	g.address_disp8(dst, src)
+	g.address_disp8(src, dst)
 	g.println('mov DWORD PTR[$dst.reg-$dst.var_offset.hex2()],$src')
 }
 
 fn (mut g Gen) load_reg_indirect(dst Register, src Indirect) {
 	g.write8(rex_w)
 	g.write8(0x8b)
-	g.address_disp8(src, dst)
+	g.address_disp8(dst, src)
 	g.println('mov $dst,DWORD PTR[$src.reg-$src.var_offset.hex2()]')
 }
 

--- a/vlib/v/gen/x64/gen.v
+++ b/vlib/v/gen/x64/gen.v
@@ -422,7 +422,7 @@ pub fn (mut g Gen) pop(reg Register) {
 }
 
 pub fn (mut g Gen) sub32(reg Register, val int) {
-	g.write8(0x48)
+	g.write8(rex_w)
 	g.write8(0x81)
 	g.write8(0xe8 + reg) // TODO rax is different?
 	g.write32(val)
@@ -430,7 +430,7 @@ pub fn (mut g Gen) sub32(reg Register, val int) {
 }
 
 pub fn (mut g Gen) sub8(reg Register, val int) {
-	g.write8(0x48)
+	g.write8(rex_w)
 	g.write8(0x83)
 	g.write8(0xe8 + reg) // TODO rax is different?
 	g.write8(val)
@@ -438,7 +438,7 @@ pub fn (mut g Gen) sub8(reg Register, val int) {
 }
 
 pub fn (mut g Gen) add(reg Register, val int) {
-	g.write8(0x48)
+	g.write8(rex_w)
 	g.write8(0x81)
 	g.write8(0xe8 + reg) // TODO rax is different?
 	g.write32(val)
@@ -446,7 +446,7 @@ pub fn (mut g Gen) add(reg Register, val int) {
 }
 
 pub fn (mut g Gen) add8(reg Register, val int) {
-	g.write8(0x48)
+	g.write8(rex_w)
 	g.write8(0x83)
 	// g.write8(0xe8 + reg) // TODO rax is different?
 	g.write8(0xc4)
@@ -455,6 +455,7 @@ pub fn (mut g Gen) add8(reg Register, val int) {
 }
 
 fn (mut g Gen) add8_var(reg Register, var_offset int) {
+	g.write8(rex_w)
 	g.write8(0x03)
 	match reg {
 		.rax { g.write8(0x45) }

--- a/vlib/v/gen/x64/gen.v
+++ b/vlib/v/gen/x64/gen.v
@@ -57,17 +57,17 @@ enum Register {
 }
 
 enum Scale {
-  scale1 = 0
-  scale2
-  scale4
-  scale8
+	scale1 = 0
+	scale2
+	scale4
+	scale8
 }
 
 enum Mod {
-  direct = 0
-  disp8
-  disp16
-  disp32
+	direct = 0
+	disp8
+	disp16
+	disp32
 }
 
 const (
@@ -75,8 +75,8 @@ const (
 )
 
 const (
-  rex = 0x40
-  rex_w = 0x48
+	rex   = 0x40
+	rex_w = 0x48
 )
 
 /*
@@ -333,43 +333,45 @@ fn (mut g Gen) mov64(reg Register, val i64) {
 }
 
 fn modrm(mod byte, reg byte, rm byte) byte {
-  return ((mod & 0x3) << 6) | ((reg & 0x7) << 3) | (rm & 0x7)
+	return ((mod & 0x3) << 6) | ((reg & 0x7) << 3) | (rm & 0x7)
 }
 
 // use Register for index and special-case rsp?
 fn sib(scale Scale, index Register, base Register) byte {
-  return ((byte(scale) & 0x3) << 6) | ((byte(index) & 0x7) << 3) | (byte(base) & 0x7)
+	return ((byte(scale) & 0x3) << 6) | ((byte(index) & 0x7) << 3) | (byte(base) & 0x7)
 }
 
 fn disp8(disp i8) byte {
-  if disp >= 0 { return byte(disp) }
-  return byte(0x100 + disp)
+	if disp >= 0 {
+		return byte(disp)
+	}
+	return byte(0x100 + disp)
 }
 
 struct Indirect {
-  reg Register
-  var_offset int
+	reg        Register
+	var_offset int
 }
 
 fn (mut g Gen) address_disp8(ind Indirect, dir Register) {
-  g.write8(modrm(byte(Mod.disp8), dir, ind.reg))
-  if ind.reg == .rsp {
-    g.write8(sib(.scale1, .rsp, .rsp))
-  }
-  g.write8(disp8(i8(ind.var_offset)))
+	g.write8(modrm(byte(Mod.disp8), dir, ind.reg))
+	if ind.reg == .rsp {
+		g.write8(sib(.scale1, .rsp, .rsp))
+	}
+	g.write8(disp8(i8(ind.var_offset)))
 }
 
 fn (mut g Gen) store_reg_indirect(dst Indirect, src Register) {
-  g.write8(rex_w)
-  g.write8(0x89)
-  g.address_disp8(dst, src)
+	g.write8(rex_w)
+	g.write8(0x89)
+	g.address_disp8(dst, src)
 	g.println('mov DWORD PTR[$dst.reg-$dst.var_offset.hex2()],$src')
 }
 
 fn (mut g Gen) load_reg_indirect(dst Register, src Indirect) {
-  g.write8(rex_w)
+	g.write8(rex_w)
 	g.write8(0x8b)
-  g.address_disp8(src, dst)
+	g.address_disp8(src, dst)
 	g.println('mov $dst,DWORD PTR[$dst-$src.var_offset.hex2()]')
 }
 
@@ -568,9 +570,9 @@ fn (mut g Gen) mov(reg Register, val int) {
 }
 
 fn (mut g Gen) mov_reg(dst Register, src Register) {
-  g.write8(rex_w)
-  g.write8(0x89)
-  g.write8(modrm(byte(Mod.direct), src, dst))
+	g.write8(rex_w)
+	g.write8(0x89)
+	g.write8(modrm(byte(Mod.direct), src, dst))
 	g.println('mov $dst, $src')
 }
 
@@ -846,7 +848,7 @@ fn (mut g Gen) fn_decl(node ast.FnDecl) {
 		g.register_function_address(node.name)
 	}
 	g.push(.rbp)
-  g.mov_reg(.rbp, .rsp)
+	g.mov_reg(.rbp, .rsp)
 	// if !is_main {
 	g.sub8(.rsp, 0x10)
 	// }


### PR DESCRIPTION
Introduce ModR/M byte, SIB byte, etc

Based loosely on https://bernsteinbear.com/blog/compiling-a-lisp-10/

I *think* this is covered by existing tests, but I am not sure. If it is not, please point me to the right codegen tests.
