### PR TITLE
parser: make .parse method public

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -157,7 +157,7 @@ pub fn parse_vet_file(path string, table_ &table.Table, pref &pref.Preferences) 
 	return file, p.vet_errors
 }
 
-fn (mut p Parser) parse() ast.File {
+pub fn (mut p Parser) parse() ast.File {
 	// comments_mode: comments_mode
 	p.init_parse_fns()
 	p.read_first_token()


### PR DESCRIPTION
`v.parser`'s `Parser.parse` must be exposed to the public due to the custom parsing strategy used by the [VLS2](https://github.com/nedpals/vls2) language server.