### PR TITLE
v.util: split bom checking to a separate fn

### DIFF
--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -223,9 +223,14 @@ pub fn path_of_executable(path string) string {
 }
 
 pub fn read_file(file_path string) ?string {
-	mut raw_text := os.read_file(file_path) or {
+	raw_text := os.read_file(file_path) or {
 		return error('failed to open $file_path')
 	}
+	return skip_bom(raw_text)
+}
+
+pub fn skip_bom(file_content string) string {
+	mut raw_text := file_content
 	// BOM check
 	if raw_text.len >= 3 {
 		unsafe {


### PR DESCRIPTION
Same reasoning with PR #6693 , the custom parsing strategy used by [VLS2](https://github.com/nedpals/vls2).