### PR TITLE
cgen: fix setting field in map of structs compile error

### DIFF
--- a/cmd/tools/vdoc.v
+++ b/cmd/tools/vdoc.v
@@ -750,27 +750,21 @@ fn (mut cfg DocConfig) generate_docs_from_file() {
 				readme_contents := cfg.get_readme(dirpath)
 				dcs.head.comment = readme_contents
 			}
-			mut new_contents := map[string]doc.DocNode{}
 			if cfg.pub_only {
-				for name, oc in dcs.contents {
-					mut c := oc
-					c.content = c.content.all_after('pub ')
-					for i, cc in c.children {
-						c.children[i].content = cc.content.all_after('pub ')
+				for name, dc in dcs.contents {
+					dcs.contents[name].content = dc.content.all_after('pub ')
+					for i, cc in dc.children {
+						dcs.contents[name].children[i].content = cc.content.all_after('pub ')
 					}
-					new_contents[name] = c
 				}
 			}
 			if !cfg.is_multi && cfg.symbol_name.len > 0 {
 				if cfg.symbol_name in dcs.contents {
-					new_contents[cfg.symbol_name] = dcs.contents[cfg.symbol_name]
-					children := dcs.contents[cfg.symbol_name].children
-					for _, c in children {
-						new_contents[c.name] = c
+					for _, c in dcs.contents[cfg.symbol_name].children {
+						dcs.contents[c.name] = c
 					}
 				}
 			}
-			dcs.contents = new_contents
 		}
 		cfg.docs << dcs
 	}

--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -1,6 +1,7 @@
 // import time
 
 struct User {
+mut:
 	name string
 }
 
@@ -54,6 +55,10 @@ fn test_map() {
 	a.users['Bob'] = User{'Bob'}
 	q := a.users['Bob']
 	assert q.name == 'Bob'
+	// test struct field change
+	a.users['Bob'].name = 'bob'
+	q2 := a.users['Bob']
+	assert q2.name == 'bob'
 	a.m['one'] = 1
 	a.set('two', 2)
 	assert a.m['one'] == 1
@@ -308,19 +313,19 @@ fn mut_map_with_relation_op_in_fn(mut m map[string]int) {
 		m['three'] = 3
 	}
 	if m['two'] != 1 {
-		m['four'] = 4	
+		m['four'] = 4
 	}
 	if m['one'] > 0 {
-		m['five'] = 5	
+		m['five'] = 5
 	}
 	if m['one'] < 2 {
-		m['six'] = 6	
+		m['six'] = 6
 	}
 	if m['two'] >= 2 {
-		m['seven'] = 7	
+		m['seven'] = 7
 	}
 	if m['two'] <= 2 {
-		m['eight'] = 8	
+		m['eight'] = 8
 	}
 }
 

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3505,7 +3505,8 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 					} else {
 						g.write(', &($elem_type_str[]) { ')
 					}
-				} else if (g.inside_map_postfix || g.inside_map_infix) || (g.is_assign_lhs && !g.is_array_set && elem_typ.kind == .struct_) {
+				} else if (g.inside_map_postfix || g.inside_map_infix) ||
+					(g.is_assign_lhs && !g.is_array_set && elem_typ.kind == .struct_) {
 					zero := g.type_default(info.value_type)
 					g.write('(*($elem_type_str*)map_get_and_set(')
 					if !left_is_ptr {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3505,7 +3505,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 					} else {
 						g.write(', &($elem_type_str[]) { ')
 					}
-				} else if g.inside_map_postfix || g.inside_map_infix {
+				} else if (g.inside_map_postfix || g.inside_map_infix) || (g.is_assign_lhs && !g.is_array_set && elem_typ.kind == .struct_) {
 					zero := g.type_default(info.value_type)
 					g.write('(*($elem_type_str*)map_get_and_set(')
 					if !left_is_ptr {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3488,7 +3488,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 				info := sym.info as table.Map
 				elem_type_str := g.typ(info.value_type)
 				elem_typ := g.table.get_type_symbol(info.value_type)
-				if g.is_assign_lhs && !g.is_array_set {
+				if g.is_assign_lhs && !g.is_array_set && elem_typ.kind != .struct_ {
 					g.is_array_set = true
 					g.write('map_set(')
 					if !left_is_ptr {


### PR DESCRIPTION
Fixes a cgen error when changing a specific struct field of an entry of a map of structs.
```v
module main

struct Foo {
mut:
  name string
}

fn main() {
  mut foos := map[string]Foo{}
  foos['bob'] = Foo{'bob'}
  foos['bob'].name = 'bob'

  println(foos)
}
```