### PR TITLE
gen: add prefix when printing type aliases

### DIFF
--- a/vlib/v/gen/auto_str_methods.v
+++ b/vlib/v/gen/auto_str_methods.v
@@ -12,8 +12,8 @@ fn (mut g Gen) gen_str_for_type_with_styp(typ table.Type, styp string) string {
 	mut str_fn_name := styp_to_str_fn_name(styp)
 	if sym.info is table.Alias as sym_info {
 		if sym_info.is_import {
-			sym = g.table.get_type_symbol((sym.info as table.Alias).parent_type)	
-			str_fn_name = styp_to_str_fn_name(sym.name.replace('.', '__'))	
+			sym = g.table.get_type_symbol((sym.info as table.Alias).parent_type)
+			str_fn_name = styp_to_str_fn_name(sym.name.replace('.', '__'))
 		}
 	}
 	sym_has_str_method, str_method_expects_ptr, str_nr_args := sym.str_method_info()
@@ -55,14 +55,30 @@ fn (mut g Gen) gen_str_for_type_with_styp(typ table.Type, styp string) string {
 					g.gen_str_for_alias(sym_info, styp, str_fn_name)
 				}
 			}
-			table.Array { g.gen_str_for_array(it, styp, str_fn_name) }
-			table.ArrayFixed { g.gen_str_for_array_fixed(it, styp, str_fn_name) }
-			table.Enum { g.gen_str_for_enum(it, styp, str_fn_name) }
-			table.Struct { g.gen_str_for_struct(it, styp, str_fn_name) }
-			table.Map { g.gen_str_for_map(it, styp, str_fn_name) }
-			table.MultiReturn { g.gen_str_for_multi_return(it, styp, str_fn_name) }
-			table.SumType { g.gen_str_for_sum_type(it, styp, str_fn_name) }
-			else { verror("could not generate string method $str_fn_name for type \'$styp\'") }
+			table.Array {
+				g.gen_str_for_array(it, styp, str_fn_name)
+			}
+			table.ArrayFixed {
+				g.gen_str_for_array_fixed(it, styp, str_fn_name)
+			}
+			table.Enum {
+				g.gen_str_for_enum(it, styp, str_fn_name)
+			}
+			table.Struct {
+				g.gen_str_for_struct(it, styp, str_fn_name)
+			}
+			table.Map {
+				g.gen_str_for_map(it, styp, str_fn_name)
+			}
+			table.MultiReturn {
+				g.gen_str_for_multi_return(it, styp, str_fn_name)
+			}
+			table.SumType {
+				g.gen_str_for_sum_type(it, styp, str_fn_name)
+			}
+			else {
+				verror("could not generate string method $str_fn_name for type \'$styp\'")
+			}
 		}
 	}
 	// if varg, generate str for varg

--- a/vlib/v/gen/auto_str_methods.v
+++ b/vlib/v/gen/auto_str_methods.v
@@ -130,7 +130,7 @@ fn (mut g Gen) gen_str_for_array(info table.Array, styp string, str_fn_name stri
 		elem_str_fn_name = styp_to_str_fn_name(field_styp)
 	}
 	if !sym_has_str_method {
-		g.gen_str_for_type_with_styp(info.elem_type, field_styp)
+		elem_str_fn_name = g.gen_str_for_type_with_styp(info.elem_type, field_styp)
 	}
 	g.type_definitions.writeln('string ${str_fn_name}($styp a); // auto')
 	g.auto_str_funcs.writeln('string ${str_fn_name}($styp a) { return indent_${str_fn_name}(a, 0);}')
@@ -191,8 +191,8 @@ fn (mut g Gen) gen_str_for_array_fixed(info table.ArrayFixed, styp string, str_f
 	} else {
 		elem_str_fn_name = styp_to_str_fn_name(field_styp)
 	}
-	if !sym_has_str_method {
-		g.gen_str_for_type_with_styp(info.elem_type, field_styp)
+	if !sym.has_method('str') {
+		elem_str_fn_name = g.gen_str_for_type_with_styp(info.elem_type, field_styp)
 	}
 	g.type_definitions.writeln('string ${str_fn_name}($styp a); // auto')
 	g.auto_str_funcs.writeln('string ${str_fn_name}($styp a) { return indent_${str_fn_name}(a, 0);}')
@@ -207,8 +207,6 @@ fn (mut g Gen) gen_str_for_array_fixed(info table.ArrayFixed, styp string, str_f
 		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("%g", 1, a[i]));')
 	} else if sym.kind == .string {
 		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("\'%.*s\\000\'", 2, a[i]));')
-	} else if sym.kind == .alias {
-		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, indent_${elem_str_fn_name}(a[i], indent_count));')
 	} else {
 		if (str_method_expects_ptr && is_elem_ptr) || (!str_method_expects_ptr && !is_elem_ptr) {
 			g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, ${elem_str_fn_name}(a[i]));')

--- a/vlib/v/gen/auto_str_methods.v
+++ b/vlib/v/gen/auto_str_methods.v
@@ -149,9 +149,7 @@ fn (mut g Gen) gen_str_for_array(info table.Array, styp string, str_fn_name stri
 	} else if sym.kind in [.f32, .f64] {
 		g.auto_str_funcs.writeln('\t\tstring x = _STR("%g", 1, it);')
 	} else if sym.kind == .alias {
-		alias_sym := g.table.get_type_symbol((sym.info as table.Alias).parent_type)
-		alias_str_fn_name := styp_to_str_fn_name(alias_sym.name.replace('.', '__'))
-		g.auto_str_funcs.writeln('\t\tstring x = ${alias_str_fn_name}(it);')
+		g.auto_str_funcs.writeln('\t\tstring x = indent_${elem_str_fn_name}(it, indent_count);')
 	} else {
 		// There is a custom .str() method, so use it.
 		// NB: we need to take account of whether the user has defined
@@ -193,7 +191,7 @@ fn (mut g Gen) gen_str_for_array_fixed(info table.ArrayFixed, styp string, str_f
 	} else {
 		elem_str_fn_name = styp_to_str_fn_name(field_styp)
 	}
-	if !sym.has_method('str') {
+	if !sym_has_str_method {
 		g.gen_str_for_type_with_styp(info.elem_type, field_styp)
 	}
 	g.type_definitions.writeln('string ${str_fn_name}($styp a); // auto')
@@ -210,9 +208,7 @@ fn (mut g Gen) gen_str_for_array_fixed(info table.ArrayFixed, styp string, str_f
 	} else if sym.kind == .string {
 		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("\'%.*s\\000\'", 2, a[i]));')
 	} else if sym.kind == .alias {
-		alias_sym := g.table.get_type_symbol((sym.info as table.Alias).parent_type)
-		alias_str_fn_name := styp_to_str_fn_name(alias_sym.name.replace('.', '__'))
-		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, ${alias_str_fn_name}(a[i]));')
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, indent_${elem_str_fn_name}(a[i], indent_count));')
 	} else {
 		if (str_method_expects_ptr && is_elem_ptr) || (!str_method_expects_ptr && !is_elem_ptr) {
 			g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, ${elem_str_fn_name}(a[i]));')

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -4484,7 +4484,10 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype table.Type) ?bool {
 		g.expr(expr)
 		g.write(')')
 	} else {
-		return error('cannot convert to string')
+		str_fn_name := g.gen_str_for_type(typ)
+		g.write('${str_fn_name}(')
+		g.expr(expr)
+		g.write(')')
 	}
 	return true
 }

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -4437,16 +4437,16 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype table.Type) ?bool {
 		val_type := if is_p { etype.deref() } else { etype }
 		str_fn_name := g.gen_str_for_type(val_type)
 		if is_p && str_method_expects_ptr {
-			g.write('string_add(_SLIT("&"), ${str_fn_name}(  (')
+			g.write('string_add(_SLIT("&"), ${str_fn_name}((')
 		}
 		if is_p && !str_method_expects_ptr {
-			g.write('string_add(_SLIT("&"), ${str_fn_name}( *(')
+			g.write('string_add(_SLIT("&"), ${str_fn_name}(*(')
 		}
 		if !is_p && !str_method_expects_ptr {
-			g.write('${str_fn_name}(  ')
+			g.write('${str_fn_name}(')
 		}
 		if !is_p && str_method_expects_ptr {
-			g.write('${str_fn_name}( &')
+			g.write('${str_fn_name}(&')
 		}
 		if expr is ast.ArrayInit {
 			if expr.is_fixed {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2090,7 +2090,11 @@ fn (mut g Gen) expr(node ast.Expr) {
 				g.write('))')
 			} else {
 				styp := g.typ(node.typ)
-				g.write('(($styp)(')
+				mut cast_label := ''
+				if sym.kind != .alias || (sym.info as table.Alias).parent_type != node.expr_type {
+					cast_label = '($styp)'
+				}
+				g.write('(${cast_label}(')
 				g.expr(node.expr)
 				if node.expr is ast.IntegerLiteral &&
 					node.typ in [table.u64_type, table.u32_type, table.u16_type] {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -4417,8 +4417,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype table.Type) ?bool {
 		g.write('${str_fn_name}(')
 		g.expr(expr)
 		g.write(')')
-	} else if sym.kind == .alias && (sym.info as table.Alias).parent_type == table.string_type {
-		// handle string aliases
+	} else if typ == table.string_type {
 		g.expr(expr)
 		return true
 	} else if sym.kind == .enum_ {

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -549,12 +549,16 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 	// g.generate_tmp_autofree_arg_vars(node, name)
 	// Handle `print(x)`
 	if is_print && node.args[0].typ != table.string_type { // && !free_tmp_arg_vars {
-		typ := node.args[0].typ
+		mut typ := node.args[0].typ
 		if typ == 0 {
 			g.checker_bug('print arg.typ is 0', node.pos)
 		}
+		mut sym := g.table.get_type_symbol(typ)
+		if sym.info is table.Alias as alias_info {
+			typ = alias_info.parent_type
+			sym = g.table.get_type_symbol(alias_info.parent_type)
+		}
 		mut styp := g.typ(typ)
-		sym := g.table.get_type_symbol(typ)
 		if typ.is_ptr() {
 			styp = styp.replace('*', '')
 		}

--- a/vlib/v/gen/str.v
+++ b/vlib/v/gen/str.v
@@ -266,15 +266,8 @@ fn (mut g Gen) string_inter_literal_sb_optimized(call_expr ast.CallExpr) {
 		g.expr(call_expr.left)
 		g.write(', ')
 		typ := node.expr_types[i]
-		sym := g.table.get_type_symbol(typ)
-		// if typ.is_number() {
-		if sym.kind == .alias && (sym.info as table.Alias).parent_type.is_number() {
-			// Handle number aliases TODO this must be more generic, handled by g.typ()?
-			g.write('int_str(')
-		} else {
-			g.write(g.typ(typ))
-			g.write('_str(')
-		}
+		g.write(g.typ(typ))
+		g.write('_str(')
 		g.expr(node.exprs[i])
 		g.writeln('));')
 	}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1571,6 +1571,7 @@ fn (mut p Parser) import_syms(mut parent ast.Import) {
 				info: table.Alias{
 					parent_type: typ
 					language: table.Language.v
+					is_import: true
 				}
 				is_public: false
 			})

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -732,6 +732,7 @@ pub struct Alias {
 pub:
 	parent_type Type
 	language    Language
+	is_import   bool
 }
 
 pub struct Aggregate {

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -223,9 +223,11 @@ struct ForGeneric {}
 fn generic_fn_interpolation<T>(p T) string {
 	return '$p'
 }
+
 fn generic_fn_str<T>(p T) string {
 	return p.str()
 }
+
 fn test_generic_auto_str() {
 	s := ForGeneric{}
 	assert generic_fn_interpolation(s) == 'ForGeneric{}'
@@ -235,22 +237,28 @@ fn test_generic_auto_str() {
 type Alias1 = int
 fn test_alias_in_array() {
 	t := [Alias1(1)]
-	assert t.str() == '[1]'
-	assert '$t' == '[1]'
+	assert t.str() == '[Alias1(1)]'
+	assert '$t' == '[Alias1(1)]'
 }
 
 type Alias2 = int
 fn test_alias_in_fixed_array() {
 	t := [Alias1(1)]!!
-	assert t.str() == '[1]'  // should be [Alias1(1)]
-	assert '$t' == '[1]'
+	assert t.str() == '[Alias1(1)]'
+	assert '$t' == '[Alias1(1)]'
 }
 
-// TODO fix
 fn test_alias_int() {
 	a := Alias1(1)
-	assert a.str() == '1' // should be Alias1(1)
-	assert '$a' == '1'
+	assert a.str() == 'Alias1(1)'
+	assert '$a' == 'Alias1(1)'
+}
+
+type Alias3 = string
+fn test_alias_string() {
+	a := Alias3('test')
+	assert a.str() == 'Alias3(test)'
+	assert '$a' == 'Alias3(test)'
 }
 
 type TestAlias = TestStruct

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -182,7 +182,7 @@ fn test_struct_with_struct_pointer() {
 }
 
 fn test_struct_with_nil() {
-	w := Wrapper4{}
+	w := Wrapper4{0}
 	assert '$w' == 'Wrapper4{\n    foo: &nil\n}'
 	assert w.str() == 'Wrapper4{\n    foo: &nil\n}'
 }

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -231,3 +231,31 @@ fn test_generic_auto_str() {
 	assert generic_fn_interpolation(s) == 'ForGeneric{}'
 	assert generic_fn_str(s) == 'ForGeneric{}'
 }
+
+type Alias1 = int
+fn test_alias_in_array() {
+	t := [Alias1(1)]
+	assert t.str() == '[1]'
+	assert '$t' == '[1]'
+}
+
+type Alias2 = int
+fn test_alias_in_fixed_array() {
+	t := [Alias1(1)]!!
+	assert t.str() == '[1]'  // should be [Alias1(1)]
+	assert '$t' == '[1]'
+}
+
+// TODO fix
+fn test_alias_int() {
+	a := Alias1(1)
+	assert a.str() == '1' // should be Alias1(1)
+	assert '$a' == '1'
+}
+
+type TestAlias = TestStruct
+fn test_alias_struct() {
+	t := TestAlias(TestStruct{})
+	assert t.str() == 'TestAlias(TestStruct{\n    x: 0\n})'
+	assert '$t' == 'TestAlias(TestStruct{\n    x: 0\n})'
+}

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -237,28 +237,28 @@ fn test_generic_auto_str() {
 type Alias1 = int
 fn test_alias_in_array() {
 	t := [Alias1(1)]
-	assert t.str() == '[Alias1(1)]'
-	assert '$t' == '[Alias1(1)]'
+	assert t.str() == '[1]'
+	assert '$t' == '[1]'
 }
 
 type Alias2 = int
 fn test_alias_in_fixed_array() {
 	t := [Alias1(1)]!!
-	assert t.str() == '[Alias1(1)]'
-	assert '$t' == '[Alias1(1)]'
+	assert t.str() == '[1]'
+	assert '$t' == '[1]'
 }
 
 fn test_alias_int() {
 	a := Alias1(1)
-	assert a.str() == 'Alias1(1)'
-	assert '$a' == 'Alias1(1)'
+	assert a.str() == '1'
+	assert '$a' == '1'
 }
 
 type Alias3 = string
 fn test_alias_string() {
 	a := Alias3('test')
-	assert a.str() == 'Alias3(test)'
-	assert '$a' == 'Alias3(test)'
+	assert a.str() == 'test'
+	assert '$a' == 'test'
 }
 
 type TestAlias = TestStruct

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -256,14 +256,16 @@ fn test_alias_int() {
 
 type Alias3 = string
 fn test_alias_string() {
-	a := Alias3('test')
-	assert a.str() == 'test'
-	assert '$a' == 'test'
+	s := 'test'
+	a := Alias3(s)
+	assert a.str() == s
+	assert '$a' == s
 }
 
 type TestAlias = TestStruct
 fn test_alias_struct() {
-	t := TestAlias(TestStruct{})
-	assert t.str() == 'TestAlias(TestStruct{\n    x: 0\n})'
+	ts := TestStruct{}
+	t := TestAlias(ts)
+	assert t.str() == 'TestAlias($ts)'
 	assert '$t' == 'TestAlias(TestStruct{\n    x: 0\n})'
 }


### PR DESCRIPTION
```v
struct Foo {}
type Type = Foo
type Type2 = int
fn main() {
	t := Type(Foo{})
        t2 := Type2(0)
	println(t)
        println(t2)
}
```

prints: `Type(Foo{})` & `0`