### PR TITLE
checker: add alias cast type check (closes #6705)

### DIFF
--- a/vlib/time/stopwatch.v
+++ b/vlib/time/stopwatch.v
@@ -57,11 +57,11 @@ pub fn (mut t StopWatch) pause() {
 pub fn (t StopWatch) elapsed() Duration {
 	if t.start > 0 {
 		if t.end == 0 {
-			return Duration(time.sys_mono_now() - t.start + t.elapsed)
+			return Duration(i64(time.sys_mono_now() - t.start + t.elapsed))
 		} else {
-			return Duration(t.end - t.start + t.elapsed)
+			return Duration(i64(t.end - t.start + t.elapsed))
 		}
 	}
 
-	return Duration(t.elapsed)
+	return Duration(i64(t.elapsed))
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2910,7 +2910,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) table.Type {
 	} else if to_type_sym.info is table.Alias as alias_info {
 		if !c.check_types(node.expr_type, alias_info.parent_type) {
 			parent_type_sym := c.table.get_type_symbol(alias_info.parent_type)
-			c.error('cannot cast type `$from_type_sym.source_name` to `$to_type_sym.source_name`, require `$parent_type_sym.source_name`',
+			c.error('cannot convert type `$from_type_sym.source_name` to `$to_type_sym.source_name` (alias to `$parent_type_sym.source_name`)',
 				node.pos)
 		}
 	} else if node.typ == table.string_type &&

--- a/vlib/v/checker/tests/cannot_cast_to_alias.out
+++ b/vlib/v/checker/tests/cannot_cast_to_alias.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/cannot_cast_to_alias.vv:6:7: error: cannot cast type `any_int` to `MyType`, require `string`
+vlib/v/checker/tests/cannot_cast_to_alias.vv:6:7: error: cannot convert type `any_int` to `MyType` (alias to `string`)
     4 |
     5 | fn main() {
     6 |     _ := MyType(5)

--- a/vlib/v/checker/tests/cannot_cast_to_alias.out
+++ b/vlib/v/checker/tests/cannot_cast_to_alias.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/cannot_cast_to_alias.vv:6:7: error: cannot cast type `any_int` to `MyType`, require `string`
+    4 |
+    5 | fn main() {
+    6 |     _ := MyType(5)
+      |          ~~~~~~~~~
+    7 | }

--- a/vlib/v/checker/tests/cannot_cast_to_alias.vv
+++ b/vlib/v/checker/tests/cannot_cast_to_alias.vv
@@ -1,0 +1,7 @@
+module main
+
+type MyType = string
+
+fn main() {
+	_ := MyType(5)
+}

--- a/vlib/v/checker/tests/cannot_cast_to_struct.out
+++ b/vlib/v/checker/tests/cannot_cast_to_struct.out
@@ -1,27 +1,27 @@
-vlib/v/checker/tests/cannot_cast_to_struct.vv:10:12: error: cannot convert struct `Abc` to struct `Test`
+vlib/v/checker/tests/cannot_cast_to_struct.vv:10:7: error: cannot convert struct `Abc` to struct `Test`
     8 |
     9 | fn main() {
    10 |     _ := Test(Abc{})
-      |               ~~~~~
+      |          ~~~~~~~~~~~
    11 |     sum := Alphabet(Xyz{})
    12 |     _ = Xyz(sum)
-vlib/v/checker/tests/cannot_cast_to_struct.vv:12:10: error: cannot cast `Alphabet` to struct
+vlib/v/checker/tests/cannot_cast_to_struct.vv:12:6: error: cannot cast `Alphabet` to struct
    10 |     _ := Test(Abc{})
    11 |     sum := Alphabet(Xyz{})
    12 |     _ = Xyz(sum)
-      |             ~~~
+      |         ~~~~~~~~
    13 |     _ = Xyz(5)
    14 |     s := Abc{}
-vlib/v/checker/tests/cannot_cast_to_struct.vv:13:10: error: cannot cast `any_int` to struct
+vlib/v/checker/tests/cannot_cast_to_struct.vv:13:6: error: cannot cast `any_int` to struct
    11 |     sum := Alphabet(Xyz{})
    12 |     _ = Xyz(sum)
    13 |     _ = Xyz(5)
-      |             ^
+      |         ~~~~~~
    14 |     s := Abc{}
    15 |     _ = Xyz(&s)
-vlib/v/checker/tests/cannot_cast_to_struct.vv:15:10: error: cannot cast `&Abc` to struct
+vlib/v/checker/tests/cannot_cast_to_struct.vv:15:6: error: cannot cast `&Abc` to struct
    13 |     _ = Xyz(5)
    14 |     s := Abc{}
    15 |     _ = Xyz(&s)
-      |             ^
+      |         ~~~~~~~
    16 | }

--- a/vlib/v/checker/tests/cast_err.out
+++ b/vlib/v/checker/tests/cast_err.out
@@ -1,20 +1,20 @@
-vlib/v/checker/tests/cast_err.vv:3:11: error: cannot cast to bool - use e.g. `some_int != 0` instead
+vlib/v/checker/tests/cast_err.vv:3:6: error: cannot cast to bool - use e.g. `some_int != 0` instead
     1 | fn test_bool_cast() {
     2 |     v := 3
     3 |     _ = bool(v)
-      |              ^
+      |         ~~~~~~~
     4 |     _ = bool(&v)
     5 |     _ = bool([2])
-vlib/v/checker/tests/cast_err.vv:4:11: error: cannot cast to bool - use e.g. `some_int != 0` instead
+vlib/v/checker/tests/cast_err.vv:4:6: error: cannot cast to bool - use e.g. `some_int != 0` instead
     2 |     v := 3
     3 |     _ = bool(v)
     4 |     _ = bool(&v)
-      |              ^
+      |         ~~~~~~~~
     5 |     _ = bool([2])
     6 | }
-vlib/v/checker/tests/cast_err.vv:5:11: error: cannot cast to bool - use e.g. `some_int != 0` instead
+vlib/v/checker/tests/cast_err.vv:5:6: error: cannot cast to bool - use e.g. `some_int != 0` instead
     3 |     _ = bool(v)
     4 |     _ = bool(&v)
     5 |     _ = bool([2])
-      |              ~~~
+      |         ~~~~~~~~~
     6 | }

--- a/vlib/v/checker/tests/cast_string_err.out
+++ b/vlib/v/checker/tests/cast_string_err.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/cast_string_err.vv:2:14: error: cannot cast type `any_int` to string, use `x.str()` instead 
+vlib/v/checker/tests/cast_string_err.vv:2:7: error: cannot cast type `any_int` to string, use `x.str()` instead
     1 | fn main() {
     2 |     a := string(1)
-      |                 ^
+      |          ~~~~~~~~~
     3 |     println(a)
     4 | }

--- a/vlib/v/checker/tests/cast_string_with_byte_err.out
+++ b/vlib/v/checker/tests/cast_string_with_byte_err.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/cast_string_with_byte_err.vv:2:19: error: can not cast type `byte` to string, use `by.str()` instead.
+vlib/v/checker/tests/cast_string_with_byte_err.vv:2:12: error: can not cast type `byte` to string, use `by.str()` instead.
     1 | for by in 'abc' {
     2 |    println(string(by))
-      |                   ~~
+      |            ~~~~~~~~~~
     3 | }

--- a/vlib/v/checker/tests/float_modulo_err.out
+++ b/vlib/v/checker/tests/float_modulo_err.out
@@ -1,12 +1,12 @@
-vlib/v/checker/tests/float_modulo_err.vv:2:13: error: float modulo not allowed, use math.fmod() instead 
+vlib/v/checker/tests/float_modulo_err.vv:2:13: error: float modulo not allowed, use math.fmod() instead
     1 | fn main() {
     2 |     println(3.0 % 2.0)
       |             ~~~
     3 |     println(f32(3.0) % f32(2.0))
     4 | }
-vlib/v/checker/tests/float_modulo_err.vv:3:17: error: float modulo not allowed, use math.fmod() instead
+vlib/v/checker/tests/float_modulo_err.vv:3:13: error: float modulo not allowed, use math.fmod() instead
     1 | fn main() {
     2 |     println(3.0 % 2.0)
     3 |     println(f32(3.0) % f32(2.0))
-      |                 ~~~
+      |             ~~~~~~~~
     4 | }

--- a/vlib/v/checker/tests/none_type_cast_err.out
+++ b/vlib/v/checker/tests/none_type_cast_err.out
@@ -1,75 +1,75 @@
-vlib/v/checker/tests/none_type_cast_err.vv:2:14: error: cannot cast `none` to `string`
+vlib/v/checker/tests/none_type_cast_err.vv:2:7: error: cannot cast `none` to `string`
     1 | fn main() {
     2 |     _ := string(none)
-      |                 ~~~~
+      |          ~~~~~~~~~~~~
     3 |     _ := int(none)
     4 |     _ := i8(none)
-vlib/v/checker/tests/none_type_cast_err.vv:3:11: error: cannot cast `none` to `int`
+vlib/v/checker/tests/none_type_cast_err.vv:3:7: error: cannot cast `none` to `int`
     1 | fn main() {
     2 |     _ := string(none)
     3 |     _ := int(none)
-      |              ~~~~
+      |          ~~~~~~~~~
     4 |     _ := i8(none)
     5 |     _ := i16(none)
-vlib/v/checker/tests/none_type_cast_err.vv:4:10: error: cannot cast `none` to `i8`
+vlib/v/checker/tests/none_type_cast_err.vv:4:7: error: cannot cast `none` to `i8`
     2 |     _ := string(none)
     3 |     _ := int(none)
     4 |     _ := i8(none)
-      |             ~~~~
+      |          ~~~~~~~~
     5 |     _ := i16(none)
     6 |     _ := i64(none)
-vlib/v/checker/tests/none_type_cast_err.vv:5:11: error: cannot cast `none` to `i16`
+vlib/v/checker/tests/none_type_cast_err.vv:5:7: error: cannot cast `none` to `i16`
     3 |     _ := int(none)
     4 |     _ := i8(none)
     5 |     _ := i16(none)
-      |              ~~~~
+      |          ~~~~~~~~~
     6 |     _ := i64(none)
     7 |     _ := u16(none)
-vlib/v/checker/tests/none_type_cast_err.vv:6:11: error: cannot cast `none` to `i64`
+vlib/v/checker/tests/none_type_cast_err.vv:6:7: error: cannot cast `none` to `i64`
     4 |     _ := i8(none)
     5 |     _ := i16(none)
     6 |     _ := i64(none)
-      |              ~~~~
+      |          ~~~~~~~~~
     7 |     _ := u16(none)
     8 |     _ := u32(none)
-vlib/v/checker/tests/none_type_cast_err.vv:7:11: error: cannot cast `none` to `u16`
+vlib/v/checker/tests/none_type_cast_err.vv:7:7: error: cannot cast `none` to `u16`
     5 |     _ := i16(none)
     6 |     _ := i64(none)
     7 |     _ := u16(none)
-      |              ~~~~
+      |          ~~~~~~~~~
     8 |     _ := u32(none)
     9 |     _ := u64(none)
-vlib/v/checker/tests/none_type_cast_err.vv:8:11: error: cannot cast `none` to `u32`
+vlib/v/checker/tests/none_type_cast_err.vv:8:7: error: cannot cast `none` to `u32`
     6 |     _ := i64(none)
     7 |     _ := u16(none)
     8 |     _ := u32(none)
-      |              ~~~~
+      |          ~~~~~~~~~
     9 |     _ := u64(none)
    10 |     _ := rune(none)
-vlib/v/checker/tests/none_type_cast_err.vv:9:11: error: cannot cast `none` to `u64`
+vlib/v/checker/tests/none_type_cast_err.vv:9:7: error: cannot cast `none` to `u64`
     7 |     _ := u16(none)
     8 |     _ := u32(none)
     9 |     _ := u64(none)
-      |              ~~~~
+      |          ~~~~~~~~~
    10 |     _ := rune(none)
    11 |     _ := f32(none)
-vlib/v/checker/tests/none_type_cast_err.vv:10:12: error: cannot cast `none` to `rune`
+vlib/v/checker/tests/none_type_cast_err.vv:10:7: error: cannot cast `none` to `rune`
     8 |     _ := u32(none)
     9 |     _ := u64(none)
    10 |     _ := rune(none)
-      |               ~~~~
+      |          ~~~~~~~~~~
    11 |     _ := f32(none)
    12 |     _ := f64(none)
-vlib/v/checker/tests/none_type_cast_err.vv:11:11: error: cannot cast `none` to `f32`
+vlib/v/checker/tests/none_type_cast_err.vv:11:7: error: cannot cast `none` to `f32`
     9 |     _ := u64(none)
    10 |     _ := rune(none)
    11 |     _ := f32(none)
-      |              ~~~~
+      |          ~~~~~~~~~
    12 |     _ := f64(none)
    13 | }
-vlib/v/checker/tests/none_type_cast_err.vv:12:11: error: cannot cast `none` to `f64`
+vlib/v/checker/tests/none_type_cast_err.vv:12:7: error: cannot cast `none` to `f64`
    10 |     _ := rune(none)
    11 |     _ := f32(none)
    12 |     _ := f64(none)
-      |              ~~~~
+      |          ~~~~~~~~~
    13 | }

--- a/vlib/v/checker/tests/struct_cast_to_struct_generic_err.out
+++ b/vlib/v/checker/tests/struct_cast_to_struct_generic_err.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/struct_cast_to_struct_generic_err.vv:11:11: error: cannot convert struct `Abc<int>` to struct `Xyz`
+vlib/v/checker/tests/struct_cast_to_struct_generic_err.vv:11:7: error: cannot convert struct `Abc<int>` to struct `Xyz`
     9 | fn main() {
    10 |     abc := Abc<int>{}
    11 |     _ := Xyz(abc)
-      |              ~~~
+      |          ~~~~~~~~
    12 | }

--- a/vlib/v/checker/tests/struct_cast_to_struct_mut_err_a.out
+++ b/vlib/v/checker/tests/struct_cast_to_struct_mut_err_a.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/struct_cast_to_struct_mut_err_a.vv:12:11: error: cannot convert struct `Abc` to struct `Xyz`
+vlib/v/checker/tests/struct_cast_to_struct_mut_err_a.vv:12:7: error: cannot convert struct `Abc` to struct `Xyz`
    10 | fn main() {
    11 |     abc := Abc{}
    12 |     _ := Xyz(abc)
-      |              ~~~
+      |          ~~~~~~~~
    13 | }

--- a/vlib/v/checker/tests/struct_cast_to_struct_mut_err_b.out
+++ b/vlib/v/checker/tests/struct_cast_to_struct_mut_err_b.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/struct_cast_to_struct_mut_err_b.vv:12:11: error: cannot convert struct `Abc` to struct `Xyz`
+vlib/v/checker/tests/struct_cast_to_struct_mut_err_b.vv:12:7: error: cannot convert struct `Abc` to struct `Xyz`
    10 | fn main() {
    11 |     abc := Abc{}
    12 |     _ := Xyz(abc)
-      |              ~~~
+      |          ~~~~~~~~
    13 | }

--- a/vlib/v/checker/tests/struct_cast_to_struct_pub_err_a.out
+++ b/vlib/v/checker/tests/struct_cast_to_struct_pub_err_a.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/struct_cast_to_struct_pub_err_a.vv:12:11: error: cannot convert struct `Abc` to struct `Xyz`
+vlib/v/checker/tests/struct_cast_to_struct_pub_err_a.vv:12:7: error: cannot convert struct `Abc` to struct `Xyz`
    10 | fn main() {
    11 |     abc := Abc{}
    12 |     _ := Xyz(abc)
-      |              ~~~
+      |          ~~~~~~~~
    13 | }

--- a/vlib/v/checker/tests/struct_cast_to_struct_pub_err_b.out
+++ b/vlib/v/checker/tests/struct_cast_to_struct_pub_err_b.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/struct_cast_to_struct_pub_err_b.vv:12:11: error: cannot convert struct `Abc` to struct `Xyz`
+vlib/v/checker/tests/struct_cast_to_struct_pub_err_b.vv:12:7: error: cannot convert struct `Abc` to struct `Xyz`
    10 | fn main() {
    11 |     abc := Abc{}
    12 |     _ := Xyz(abc)
-      |              ~~~
+      |          ~~~~~~~~
    13 | }

--- a/vlib/v/checker/tests/sum.out
+++ b/vlib/v/checker/tests/sum.out
@@ -12,11 +12,11 @@ vlib/v/checker/tests/sum.vv:6:8: error: cannot cast non-sum type `int` using `as
       |           ~~
     7 | }
     8 |
-vlib/v/checker/tests/sum.vv:10:11: error: cannot cast `rune` to `Var`
-    8 | 
+vlib/v/checker/tests/sum.vv:10:7: error: cannot cast `rune` to `Var`
+    8 |
     9 | fn sum() {
    10 |     _ := Var(`J`)
-      |              ~~~
+      |          ~~~~~~~~
    11 |     mut s2 := Var('')
    12 |     s2 = true
 vlib/v/checker/tests/sum.vv:12:7: error: cannot assign to `s2`: expected `Var`, not `bool`

--- a/vlib/v/checker/tests/warnings_for_string_c2v_calls.out
+++ b/vlib/v/checker/tests/warnings_for_string_c2v_calls.out
@@ -1,14 +1,14 @@
-vlib/v/checker/tests/warnings_for_string_c2v_calls.vv:8:14: error: to convert a C string buffer pointer to a V string, please use x.vstring() instead of string(x)
+vlib/v/checker/tests/warnings_for_string_c2v_calls.vv:8:7: error: to convert a C string buffer pointer to a V string, please use x.vstring() instead of string(x)
     6 |         p[2] = `z`
     7 |     }
     8 |     x := string(p)
-      |                 ^
+      |          ~~~~~~~~~
     9 |     y := string(p, 10)
    10 |     eprintln('x: $x | y: $y')
-vlib/v/checker/tests/warnings_for_string_c2v_calls.vv:9:14: error: to convert a C string buffer pointer to a V string, please use x.vstring_with_len(len) instead of string(x,len)
+vlib/v/checker/tests/warnings_for_string_c2v_calls.vv:9:7: error: to convert a C string buffer pointer to a V string, please use x.vstring_with_len(len) instead of string(x,len)
     7 |     }
     8 |     x := string(p)
     9 |     y := string(p, 10)
-      |                 ^
+      |          ~~~~~~~~~~~~~
    10 |     eprintln('x: $x | y: $y')
    11 |     eprintln('x.len: $x.len | y.len: $y.len')

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1059,6 +1059,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 			is_mod_cast || (!(name.len > 1 && name[0] == `C` && name[1] == `.`) && name[0].is_capital()) {
 			// MainLetter(x) is *always* a cast, as long as it is not `C.`
 			// TODO handle C.stat()
+			start_pos := p.tok.position()
 			mut to_typ := p.parse_type()
 			if p.is_amp {
 				// Handle `&Foo(0)`
@@ -1079,13 +1080,14 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 				arg = p.expr(0) // len
 				has_arg = true
 			}
+			end_pos := p.tok.position()
 			p.check(.rpar)
 			node = ast.CastExpr{
 				typ: to_typ
 				expr: expr
 				arg: arg
 				has_arg: has_arg
-				pos: expr.position()
+				pos: start_pos.extend(end_pos)
 			}
 			p.expr_mod = ''
 			return node


### PR DESCRIPTION
```v
type MyType = int
fn main() {
	_ := MyType('asdasd')
}
```

this results in an error now.
```
main.v:14:7: error: cannot cast type `any_int` to `MyType`, require `string`
```