### PR TITLE
checker: improve error message for: `a := foo() or { println(err) }`

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1656,8 +1656,12 @@ pub fn (mut c Checker) check_or_expr(or_expr ast.OrExpr, ret_type table.Type) {
 				}
 				type_name := c.table.type_to_str(last_stmt.typ)
 				expected_type_name := c.table.type_to_str(ret_type.clear_flag(.optional))
-				c.error('wrong return type `$type_name` in the `or {}` block, expected `$expected_type_name`',
-					last_stmt.pos)
+				if type_name == 'void' {
+					c.error('use return/panic statements', last_stmt.pos)
+				} else {
+					c.error('wrong return type `$type_name` in the `or {}` block, expected `$expected_type_name`',
+						last_stmt.pos)
+				}
 				return
 			}
 			ast.BranchStmt {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1656,7 +1656,7 @@ pub fn (mut c Checker) check_or_expr(or_expr ast.OrExpr, ret_type table.Type) {
 				}
 				expected_type_name := c.table.type_to_str(ret_type.clear_flag(.optional))
 				if last_stmt.typ == table.void_type {
-					c.error('`or` block must provide a default value of type $expected_type_name, or return/exit/continue/break/panic',
+					c.error('`or` block must provide a default value of type `$expected_type_name`, or return/exit/continue/break/panic',
 						last_stmt.pos)
 				} else {
 					type_name := c.table.type_to_str(last_stmt.typ)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1654,11 +1654,12 @@ pub fn (mut c Checker) check_or_expr(or_expr ast.OrExpr, ret_type table.Type) {
 				if type_fits || is_panic_or_exit {
 					return
 				}
-				type_name := c.table.type_to_str(last_stmt.typ)
 				expected_type_name := c.table.type_to_str(ret_type.clear_flag(.optional))
-				if type_name == 'void' {
-					c.error('this block needs $expected_type_name or noreturn statements (panic, exit, ..)', last_stmt.pos)
+				if last_stmt.typ == table.void_type {
+					c.error('this block needs $expected_type_name or noreturn statements (panic, exit, ..)',
+						last_stmt.pos)
 				} else {
+					type_name := c.table.type_to_str(last_stmt.typ)
 					c.error('wrong return type `$type_name` in the `or {}` block, expected `$expected_type_name`',
 						last_stmt.pos)
 				}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1656,7 +1656,7 @@ pub fn (mut c Checker) check_or_expr(or_expr ast.OrExpr, ret_type table.Type) {
 				}
 				expected_type_name := c.table.type_to_str(ret_type.clear_flag(.optional))
 				if last_stmt.typ == table.void_type {
-					c.error('this block needs $expected_type_name or noreturn statements (panic, exit, ..)',
+					c.error('`or` block must provide a default value of type $expected_type_name, or return/exit/continue/break/panic',
 						last_stmt.pos)
 				} else {
 					type_name := c.table.type_to_str(last_stmt.typ)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1657,7 +1657,7 @@ pub fn (mut c Checker) check_or_expr(or_expr ast.OrExpr, ret_type table.Type) {
 				type_name := c.table.type_to_str(last_stmt.typ)
 				expected_type_name := c.table.type_to_str(ret_type.clear_flag(.optional))
 				if type_name == 'void' {
-					c.error('use return/panic statements', last_stmt.pos)
+					c.error('this block needs $expected_type_name or noreturn statements (panic, exit, ..)', last_stmt.pos)
 				} else {
 					c.error('wrong return type `$type_name` in the `or {}` block, expected `$expected_type_name`',
 						last_stmt.pos)


### PR DESCRIPTION
code
```go
fn test_optional(fail bool) ?bool {
	if fail {
		return error('false')
	}
	return true
}


fn main() {
	test_optional(true) or {
		// compiles fine
		println(err)
	}
	r := test_optional(true) or {
		// fails to compile
		println(err)
		// false
	}
}
```
before
```v
optbug.v:16:3: error: wrong return type `void` in the `or {}` block, expected `bool`
   14 |     r := test_optional(true) or {
   15 |         // fails to compile
   16 |         println(err)
      |         ~~~~~~~
   17 |     }
   18 | }
```

after

```v
optbug.v:16:3: error: this block needs bool or noreturn statements (panic, exit, ..) 
   14 |     r := test_optional(true) or {
   15 |         // fails to compile
   16 |         println(err)
      |         ~~~~~~~
   17 |     }
   18 | }
```