### PR TITLE
cgen: fix typeof(expr).name for generic type, pointers, etc

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2364,7 +2364,7 @@ fn (mut g Gen) typeof_name(node ast.TypeOf) {
 	}
 	sym := g.table.get_type_symbol(typ)
 	// TODO: fix table.type_to_str and use instead
-	if sym.kind in [.array_fixed, .function] {
+	if sym.kind == .function {
 		g.typeof_expr(node)
 	} else {
 		// Note: typeof() must be known at compile-time

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2358,7 +2358,14 @@ fn (mut g Gen) expr(node ast.Expr) {
 
 // typeof(expr).name
 fn (mut g Gen) typeof_name(node ast.TypeOf) {
-	sym := g.table.get_type_symbol(node.expr_type)
+	typ := node.expr_type
+	if typ.has_flag(.generic) {
+		s := g.table.type_to_str(g.cur_generic_type)
+		g.write('tos_lit("$s")')
+		return
+	}
+	// TODO: update & use table.type_to_str instead
+	sym := g.table.get_type_symbol(typ)
 	if sym.kind == .array {
 		info := sym.info as table.Array
 		mut s := g.table.get_type_name(info.elem_type)

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2358,24 +2358,17 @@ fn (mut g Gen) expr(node ast.Expr) {
 
 // typeof(expr).name
 fn (mut g Gen) typeof_name(node ast.TypeOf) {
-	typ := node.expr_type
+	mut typ := node.expr_type
 	if typ.has_flag(.generic) {
-		s := g.table.type_to_str(g.cur_generic_type)
-		g.write('tos_lit("$s")')
-		return
+		typ = g.cur_generic_type
 	}
-	// TODO: update & use table.type_to_str instead
 	sym := g.table.get_type_symbol(typ)
-	if sym.kind == .array {
-		info := sym.info as table.Array
-		mut s := g.table.get_type_name(info.elem_type)
-		s = util.strip_main_name(s)
-		g.write('tos_lit("[]$s")')
-	} else if sym.kind == .sum_type {
-		// new typeof() must be known at compile-time
-		g.write('tos_lit("${util.strip_main_name(sym.name)}")')
-	} else {
+	// TODO: fix table.type_to_str and use instead
+	if sym.kind in [.array_fixed, .function] {
 		g.typeof_expr(node)
+	} else {
+		s := g.table.type_to_str(typ)
+		g.write('tos_lit("${util.strip_main_name(s)}")')
 	}
 }
 

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2367,6 +2367,8 @@ fn (mut g Gen) typeof_name(node ast.TypeOf) {
 	if sym.kind in [.array_fixed, .function] {
 		g.typeof_expr(node)
 	} else {
+		// Note: typeof() must be known at compile-time
+		// sum types should not be handled dynamically
 		s := g.table.type_to_str(typ)
 		g.write('tos_lit("${util.strip_main_name(s)}")')
 	}

--- a/vlib/v/tests/typeof_test.v
+++ b/vlib/v/tests/typeof_test.v
@@ -29,7 +29,8 @@ fn test_type_constructors() {
 	assert typeof(&v).name == '&rune'
 	assert typeof(&[v]).name == '&[]rune'
 	assert typeof([v]!!).name == '[1]rune'
-	//assert typeof(&[v]!!).name == '&[1]rune' //FIXME
+	assert typeof(&[v]!!).name == '&[1]rune'
+	assert typeof(&FooBar{}).name == '&FooBar'
 }
 
 struct FooBar {

--- a/vlib/v/tests/typeof_test.v
+++ b/vlib/v/tests/typeof_test.v
@@ -124,6 +124,7 @@ fn test_generic_type() {
 	//assert type_name([v]!!) == '[1]int'
 	assert type_name([v]) == '[]int'
 	assert type_name([[v]]) == '[][]int'
+	assert type_name(FooBar{}) == 'FooBar'
 	
 	assert array_item_type([v]) == 'int'
 	assert array_item_type([[v]]) == '[]int'

--- a/vlib/v/tests/typeof_test.v
+++ b/vlib/v/tests/typeof_test.v
@@ -55,6 +55,7 @@ fn test_typeof_on_sumtypes() {
 	assert typeof(a) == 'int'
 	assert typeof(b) == 'f32'
 	assert typeof(c) == 'FooBar'
+	// typeof should be known at compile-time for all types
 	assert typeof(a).name == 'MySumType'
 	assert typeof(b).name == 'MySumType'
 	assert typeof(c).name == 'MySumType'

--- a/vlib/v/tests/typeof_test.v
+++ b/vlib/v/tests/typeof_test.v
@@ -108,3 +108,24 @@ fn test_typeof_on_fn() {
 	assert typeof(myfn3).name == typeof(myfn3)
 	assert typeof(myfn4).name == typeof(myfn4)
 }
+
+fn type_name<T>(v T) string {
+	return typeof(v).name
+}
+
+fn array_item_type<T>(v []T) string {
+	return typeof(v[0]).name
+}
+
+fn test_generic_type() {
+	v := 5
+	assert type_name(v) == 'int'
+	//assert type_name(&v) == '&int'
+	//assert type_name([v]!!) == '[1]int'
+	assert type_name([v]) == '[]int'
+	assert type_name([[v]]) == '[][]int'
+	
+	assert array_item_type([v]) == 'int'
+	assert array_item_type([[v]]) == '[]int'
+	//assert array_item_type([&v]) == '&int'
+}

--- a/vlib/v/tests/typeof_test.v
+++ b/vlib/v/tests/typeof_test.v
@@ -15,12 +15,21 @@ fn test_typeof_on_simple_expressions() {
 	// assert typeof(1.0 * 12.2) == 'any_float'
 }
 
-fn test_typeof_on_atypes() {
+fn test_arrays() {
 	aint := []int{}
 	astring := []string{}
 	assert typeof(aint) == 'array_int'
 	assert typeof(astring) == 'array_string'
+	assert typeof(aint).name == '[]int'
 	assert typeof(astring).name == '[]string'
+}
+
+fn test_type_constructors() {
+	v := `c`
+	assert typeof(&v).name == '&rune'
+	assert typeof(&[v]).name == '&[]rune'
+	assert typeof([v]!!).name == '[1]rune'
+	//assert typeof(&[v]!!).name == '&[1]rune' //FIXME
 }
 
 struct FooBar {


### PR DESCRIPTION
Note: `typeof(expr).name` is the replacement for `typeof(expr)`, which should produce a usable type (e.g. for casting), not a string.

Fixes #6704 - when `expr` is a generic type.

Also simplify the implementation of `Gen.typeof_name` using `Table.type_to_str`. This fixes typeof() with a pointer expression, and other type constructors (see tests).