### PR TITLE
Update cflags.v: mut` is not needed in for loops.

### DIFF
--- a/vlib/v/builder/cflags.v
+++ b/vlib/v/builder/cflags.v
@@ -10,7 +10,7 @@ fn (mut v Builder) get_os_cflags() []cflag.CFlag {
 	if v.pref.compile_defines.len > 0 {
 		ctimedefines << v.pref.compile_defines
 	}
-	for mut flag in v.table.cflags {
+	for flag in v.table.cflags {
 		if flag.value.ends_with('.o') {
 			flag.cached = v.pref.cache_manager.postfix_with_key2cpath('.o', os.real_path(flag.value))
 		}


### PR DESCRIPTION
Error: `mut` is not needed in for loops.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
