### PR TITLE
table: make Table.type_to_str generate proper function type, not fn name

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1585,7 +1585,9 @@ fn (mut c Checker) type_implements(typ table.Type, inter_typ table.Type, pos tok
 	for imethod in inter_sym.methods {
 		if method := typ_sym.find_method(imethod.name) {
 			if !imethod.is_same_method_as(method) {
-				sig := c.table.fn_signature(imethod, skip_receiver: true)
+				sig := c.table.fn_signature(imethod, {
+					skip_receiver: true
+				})
 				c.error('`$styp` incorrectly implements method `$imethod.name` of interface `$inter_sym.source_name`, expected `$sig`',
 					pos)
 				return false

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1585,7 +1585,8 @@ fn (mut c Checker) type_implements(typ table.Type, inter_typ table.Type, pos tok
 	for imethod in inter_sym.methods {
 		if method := typ_sym.find_method(imethod.name) {
 			if !imethod.is_same_method_as(method) {
-				c.error('`$styp` incorrectly implements method `$imethod.name` of interface `$inter_sym.source_name`, expected `${c.table.fn_to_str(imethod)}`',
+				sig := c.table.fn_signature(imethod, skip_receiver: true)
+				c.error('`$styp` incorrectly implements method `$imethod.name` of interface `$inter_sym.source_name`, expected `$sig`',
 					pos)
 				return false
 			}

--- a/vlib/v/checker/tests/fn_var.out
+++ b/vlib/v/checker/tests/fn_var.out
@@ -1,5 +1,5 @@
 vlib/v/checker/tests/fn_var.vv:2:5: error: cannot assign to `f`: expected `fn (int) byte`, not `any_int`
-    1 | mut f := fn(i int) byte{}
+    1 | mut f := fn(i int) byte {}
     2 | f = 4
       |     ^
     3 | mut p := &f
@@ -9,3 +9,9 @@ vlib/v/checker/tests/fn_var.vv:4:5: error: cannot assign to `p`: expected `&fn (
     3 | mut p := &f
     4 | p = &[f]
       |     ^
+    5 | f = fn(mut a []int) {}
+vlib/v/checker/tests/fn_var.vv:5:5: error: cannot assign to `f`: expected `fn (int) byte`, not `fn (mut []int)`
+    3 | mut p := &f
+    4 | p = &[f]
+    5 | f = fn(mut a []int) {}
+      |     ~~

--- a/vlib/v/checker/tests/fn_var.out
+++ b/vlib/v/checker/tests/fn_var.out
@@ -1,0 +1,11 @@
+vlib/v/checker/tests/fn_var.vv:2:5: error: cannot assign to `f`: expected `fn (int) byte`, not `any_int`
+    1 | mut f := fn(i int) byte{}
+    2 | f = 4
+      |     ^
+    3 | mut p := &f
+    4 | p = &[f]
+vlib/v/checker/tests/fn_var.vv:4:5: error: cannot assign to `p`: expected `&fn (int) byte`, not `&[]fn (int) byte`
+    2 | f = 4
+    3 | mut p := &f
+    4 | p = &[f]
+      |     ^

--- a/vlib/v/checker/tests/fn_var.vv
+++ b/vlib/v/checker/tests/fn_var.vv
@@ -1,4 +1,5 @@
-mut f := fn(i int) byte{}
+mut f := fn(i int) byte {}
 f = 4
 mut p := &f
 p = &[f]
+f = fn(mut a []int) {}

--- a/vlib/v/checker/tests/fn_var.vv
+++ b/vlib/v/checker/tests/fn_var.vv
@@ -1,0 +1,4 @@
+mut f := fn(i int) byte{}
+f = 4
+mut p := &f
+p = &[f]

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2385,21 +2385,15 @@ fn (mut g Gen) expr(node ast.Expr) {
 }
 
 // typeof(expr).name
+// Note: typeof() should be a type known at compile-time, not a string
+// sum types should not be handled dynamically
 fn (mut g Gen) typeof_name(node ast.TypeOf) {
 	mut typ := node.expr_type
 	if typ.has_flag(.generic) {
 		typ = g.cur_generic_type
 	}
-	sym := g.table.get_type_symbol(typ)
-	// TODO: fix table.type_to_str and use instead
-	if sym.kind == .function {
-		g.typeof_expr(node)
-	} else {
-		// Note: typeof() must be known at compile-time
-		// sum types should not be handled dynamically
-		s := g.table.type_to_str(typ)
-		g.write('tos_lit("${util.strip_main_name(s)}")')
-	}
+	s := g.table.type_to_str(typ)
+	g.write('tos_lit("${util.strip_main_name(s)}")')
 }
 
 fn (mut g Gen) typeof_expr(node ast.TypeOf) {

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -839,7 +839,9 @@ pub fn (table &Table) type_to_str(t Type) string {
 		}
 		.function {
 			info := sym.info as FnType
-			res = table.fn_signature(info.func, type_only: true)
+			res = table.fn_signature(info.func, {
+				type_only: true
+			})
 		}
 		.map {
 			if int(t) == map_type_idx {

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -838,7 +838,20 @@ pub fn (table &Table) type_to_str(t Type) string {
 			}
 		}
 		.function {
-			// do nothing, source_name is sufficient
+			info := sym.info as FnType
+			func := info.func
+			res = 'fn ('
+			for i, arg in func.params {
+				if i > 0 {
+					res += ', '
+				}
+				res += table.type_to_str(arg.typ)
+			}
+			res += ')'
+			if func.return_type != void_type {
+				res += ' '
+				res += table.type_to_str(func.return_type)
+			}
 		}
 		.map {
 			if int(t) == map_type_idx {

--- a/vlib/v/tests/typeof_test.v
+++ b/vlib/v/tests/typeof_test.v
@@ -115,6 +115,7 @@ fn test_typeof_on_fn() {
 	assert typeof(myfn3) == 'fn (int, string) byte'
 	assert typeof(myfn4) == 'fn () i8'
 	assert typeof(myfn).name == typeof(myfn)
+	assert typeof(&myfn).name == '&fn (int) int'
 	assert typeof(myfn2).name == typeof(myfn2)
 	assert typeof(myfn3).name == typeof(myfn3)
 	assert typeof(myfn4).name == typeof(myfn4)


### PR DESCRIPTION
~~Depends on #6712, draft until that's merged.~~

Also:
* Replace `Table.fn_to_str` with more flexible `Table.fn_signature`.
* simplify `Gen.typeof_name` now `Table.type_to_str` works.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
