### PR TITLE
os: prevent win builds from depending on ws2_32 lib always

### DIFF
--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -2,8 +2,8 @@ module os
 
 import strings
 
-#flag -lws2_32
-#include <winsock2.h>
+// #flag -lws2_32
+// #include <winsock2.h>
 #include <process.h>
 pub const (
 	path_separator = '\\'


### PR DESCRIPTION
On windows: Currently when importing the os module ws2_32 lib and winsock2.h are added as dependencies even if it does not use network related code.

fixes #6739