### PR TITLE
checker: use `else` for last branch of exhaustive match

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -581,8 +581,9 @@ pub:
 	stmts         []Stmt // right side
 	pos           token.Position
 	comments      []Comment // comment above `xxx {`
-	is_else       bool
 	post_comments []Comment
+pub mut:
+	is_else       bool
 }
 
 pub struct SelectExpr {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3617,9 +3617,9 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, type_sym table.TypeSymbol
 		return
 	}
 	if is_exhaustive {
-		// avoid checking last condition
+		// optimization: avoid checking last condition
 		mut a := node.branches
-		if a.len > 1 {
+		if a.len > 1 && c.table.type_kind(node.cond_type) !in [.sum_type, .union_sum_type] {
 			a[a.len - 1].is_else = true
 		}
 		return

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3610,13 +3610,18 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, type_sym table.TypeSymbol
 			}
 		}
 	}
-	if is_exhaustive {
-		if has_else {
+	if has_else {
+		if is_exhaustive {
 			c.error('match expression is exhaustive, `else` is unnecessary', else_branch.pos)
 		}
 		return
 	}
-	if has_else {
+	if is_exhaustive {
+		// avoid checking last condition
+		mut a := node.branches
+		if a.len > 1 {
+			a[a.len - 1].is_else = true
+		}
 		return
 	}
 	mut err_details := 'match must be exhaustive'

--- a/vlib/v/tests/match_test.v
+++ b/vlib/v/tests/match_test.v
@@ -118,6 +118,18 @@ fn test_match_enums() {
 	assert b == .blue
 }
 
+// optimization to avoid testing last branch condition
+fn test_exhaustive_else() {
+	inv := Color(5) // invalid value
+	mut ok := false
+	match inv {
+		.red {}
+		.green {}
+		.blue {ok = true}
+	}
+	assert ok
+}
+
 struct Counter {
 mut:
 	val int


### PR DESCRIPTION
For an exhaustive match (without an `else` branch), there is no need to test the condition for the last branch. We can just generate an `else` branch instead. (See: https://github.com/vlang/v/issues/6677#issuecomment-719968648).

This is a small optimization but it also helps avoid generating a C warning in a function returning a value when each match branch returns. (`warning: control reaches end of non-void function`).

Fixes #6677.




<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
