### PR TITLE
Keep the generated C file after compiling

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -81,14 +81,6 @@ fn (mut v Builder) post_process_c_compiler_output(res os.Result) {
 		if v.pref.reuse_tmpc {
 			return
 		}
-		for tmpfile in v.pref.cleanup_files {
-			if os.is_file(tmpfile) {
-				if v.pref.is_verbose {
-					eprintln('>> remove tmp file: $tmpfile')
-				}
-				os.rm(tmpfile)
-			}
-		}
 		return
 	}
 	for emsg_marker in [c_verror_message_marker, 'error: include file '] {


### PR DESCRIPTION
I removed the function that removes the generated C file after compiling because it could be useful for some people, like me. Maybe we should make an cli option for that. I couldn't find the build options stuff so I couldn't do it.