### PR TITLE
all: fix most C warnings

### DIFF
--- a/vlib/builtin/builtin_nix.c.v
+++ b/vlib/builtin/builtin_nix.c.v
@@ -88,7 +88,7 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 		return false
 	}
 	buffer := [100]byteptr{}
-	nr_ptrs := C.backtrace(buffer, 100)
+	nr_ptrs := C.backtrace(voidptr(buffer), 100)
 	if nr_ptrs < 2 {
 		eprintln('C.backtrace returned less than 2 frames')
 		return false
@@ -96,7 +96,7 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 	nr_actual_frames := nr_ptrs - skipframes
 	mut sframes := []string{}
 	//////csymbols := backtrace_symbols(*voidptr(&buffer[skipframes]), nr_actual_frames)
-	csymbols := C.backtrace_symbols(&buffer[skipframes], nr_actual_frames)
+	csymbols := C.backtrace_symbols(voidptr(&buffer[skipframes]), nr_actual_frames)
 	for i in 0 .. nr_actual_frames {
 		sframes << unsafe {tos2( byteptr(csymbols[i]) )}
 	}

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -153,7 +153,7 @@ fn (d DenseArray) get(i int) voidptr {
 fn (mut d DenseArray) zeros_to_end() {
 	mut tmp_value := malloc(d.value_bytes)
 	mut count := u32(0)
-	for i in 0 .. d.len {
+	for i in 0 .. int(d.len) {
 		if unsafe {d.keys[i]}.str != 0 {
 			// swap keys
 			unsafe {

--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -19,7 +19,7 @@ struct OptionBase {
 	ecode   int
 
 	// Data is trailing after ecode
-	// and is not included in here but in the 
+	// and is not included in here but in the
 	// derived Option_xxx types
 }
 
@@ -51,32 +51,16 @@ struct Option {
 	is_none bool
 	error   string
 	ecode   int
-
-	data    [400]byte
 }
 
 pub fn (o Option) str() string {
    if o.ok && !o.is_none {
-	  return 'Option{ data: ' + o.data[0..32].hex() + ' }'
+	  return 'Option{ ok }'
    }
    if o.is_none {
 	  return 'Option{ none }'
    }
    return 'Option{ error: "${o.error}" }'
-}
-
-// `fn foo() ?Foo { return foo }` => `fn foo() ?Foo { return opt_ok(foo); }`
-fn opt_ok(data voidptr, size int) Option {
-	if size >= 400 {
-		panic('option size too big: $size (max is 400), this is a temporary limit')
-	}
-	res := Option{
-		ok: true
-	}
-	unsafe {
-		C.memcpy(res.data, data, size)
-	}
-	return res
 }
 
 // used internally when returning `none`

--- a/vlib/math/big/big.v
+++ b/vlib/math/big/big.v
@@ -7,11 +7,9 @@ module big
 #include "bn.h"
 
 [typedef]
-struct C.bn {
+struct Number {
 	array [32]u32
 }
-
-type Number = C.bn
 
 fn C.bignum_init( n &Number )
 fn C.bignum_from_int( n &Number, i u64 )

--- a/vlib/math/big/big.v
+++ b/vlib/math/big/big.v
@@ -7,9 +7,11 @@ module big
 #include "bn.h"
 
 [typedef]
-struct Number {
+struct C.bn {
 	array [32]u32
 }
+
+type Number = C.bn
 
 fn C.bignum_init( n &Number )
 fn C.bignum_from_int( n &Number, i u64 )

--- a/vlib/os/file.v
+++ b/vlib/os/file.v
@@ -142,7 +142,7 @@ pub fn (mut f File) get_line() ?string {
 		mut zblen := size_t(0)
 		mut zx := 0
 		unsafe {
-			zx = C.getline(&zbuf, &zblen, f.cfile)
+			zx = C.getline(&charptr(&zbuf), &zblen, f.cfile)
 			if zx == -1 {
 				C.free(zbuf)
 				if C.errno == 0 {
@@ -160,7 +160,7 @@ pub fn (mut f File) get_line() ?string {
 	//
 	buf := [4096]byte{}
 	mut res := strings.new_builder(1024)
-	mut x := 0
+	mut x := charptr(0)
 	for {
 		unsafe {
 			x = C.fgets(charptr(buf), 4096, f.cfile)

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -252,7 +252,7 @@ pub fn is_writable_folder(folder string) ?bool {
 	}
 	tmp_perm_check := os.join_path(folder, 'XXXXXX')
 	unsafe {
-		x := C.mkstemp(tmp_perm_check.str)
+		x := C.mkstemp(charptr(tmp_perm_check.str))
 		if -1 == x {
 			return error('folder `$folder` is not writable')
 		}

--- a/vlib/strconv/format.v
+++ b/vlib/strconv/format.v
@@ -439,7 +439,6 @@ pub fn v_sprintf(str string, pt ... voidptr) string{
 	mut len1         := -1               // decimal part for floats
 	def_len1         := 6                // default value for len1
 	mut pad_ch       := byte(` `)              // pad char
-	mut th_separator := false            // thousands separator flag
 
 	// prefix chars for Length field
 	mut ch1 := `0`  // +1 char if present else `0`
@@ -453,7 +452,6 @@ pub fn v_sprintf(str string, pt ... voidptr) string{
 			len0         = -1
 			len1         = -1
 			pad_ch       = ` `
-			th_separator = false
 			status = .norm_char
 			ch1 = `0`
 			ch2 = `0`
@@ -518,7 +516,6 @@ pub fn v_sprintf(str string, pt ... voidptr) string{
 				i++
 				continue
 			} else if ch == `'` {
-				th_separator = true
 				i++
 				continue
 			} else if ch == `.` && fc_ch1 >= `1` && fc_ch1 <= `9` {

--- a/vlib/time/parse.v
+++ b/vlib/time/parse.v
@@ -66,7 +66,7 @@ pub fn parse_iso8601(s string) ?Time {
 	offset_hour := 0
 	offset_min := 0
 	count := unsafe {C.sscanf(charptr(s.str), '%4d-%2d-%2d%c%2d:%2d:%2d.%6d%c%2d:%2d',
-		&year, &month, &day, &time_char, &hour, &minute, &second, &mic_second, &plus_min, &offset_hour,
+		&year, &month, &day, charptr(&time_char), &hour, &minute, &second, &mic_second, charptr(&plus_min), &offset_hour,
 		&offset_min)}
 	if count != 11 {
 		return error('Invalid 8601 format')

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -552,7 +552,7 @@ fn (mut v Builder) cc() {
 	diff := time.ticks() - ticks
 	v.timing_message('C ${ccompiler:3}', diff)
 	if v.pref.show_c_output {
-		v.show_c_compiler_output(res)    
+		v.show_c_compiler_output(res)
 	}
 	if res.exit_code == 127 {
 		// the command could not be found by the system
@@ -570,7 +570,7 @@ fn (mut v Builder) cc() {
 	}
 	if !v.pref.show_c_output {
 		v.post_process_c_compiler_output(res)
-	}        
+	}
 	// Print the C command
 	if v.pref.is_verbose {
 		println('$ccompiler took $diff ms')

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -76,6 +76,12 @@ fn (mut v Builder) find_win_cc() ? {
 	v.pref.ccompiler_type = pref.cc_from_string(v.pref.ccompiler)
 }
 
+fn (mut v Builder) show_c_compiler_output(res os.Result) {
+	println('======== C Compiler output ========')
+	println(res.output)
+	println('=================================')
+}
+
 fn (mut v Builder) post_process_c_compiler_output(res os.Result) {
 	if res.exit_code == 0 {
 		if v.pref.reuse_tmpc {
@@ -546,9 +552,7 @@ fn (mut v Builder) cc() {
 	diff := time.ticks() - ticks
 	v.timing_message('C ${ccompiler:3}', diff)
 	if v.pref.show_c_output {
-		println('\n======== Compiler output ========')
-		println(res.output)
-		println('=================================')
+		v.show_c_compiler_output(res)    
 	}
 	if res.exit_code == 127 {
 		// the command could not be found by the system

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -560,6 +560,11 @@ fn (mut v Builder) cc() {
 			'Please reinstall it, or make it available in your PATH.\n\n' + missing_compiler_info())
 	}
 	v.post_process_c_compiler_output(res)
+	if v.pref.show_c_output {
+		println('\n\n======== Compiler output ========')
+		println(res.output)
+		println('=================================')
+	}
 	// Print the C command
 	if v.pref.is_verbose {
 		println('$ccompiler took $diff ms')

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -545,6 +545,11 @@ fn (mut v Builder) cc() {
 	}
 	diff := time.ticks() - ticks
 	v.timing_message('C ${ccompiler:3}', diff)
+	if v.pref.show_c_output {
+		println('\n======== Compiler output ========')
+		println(res.output)
+		println('=================================')
+	}
 	if res.exit_code == 127 {
 		// the command could not be found by the system
 		$if linux {
@@ -559,12 +564,9 @@ fn (mut v Builder) cc() {
 			'-----------------------------------------------------------\n' + 'Probably your C compiler is missing. \n' +
 			'Please reinstall it, or make it available in your PATH.\n\n' + missing_compiler_info())
 	}
-	v.post_process_c_compiler_output(res)
-	if v.pref.show_c_output {
-		println('\n\n======== Compiler output ========')
-		println(res.output)
-		println('=================================')
-	}
+	if !v.pref.show_c_output {
+		v.post_process_c_compiler_output(res)
+	}        
 	// Print the C command
 	if v.pref.is_verbose {
 		println('$ccompiler took $diff ms')

--- a/vlib/v/builder/msvc.v
+++ b/vlib/v/builder/msvc.v
@@ -303,7 +303,11 @@ pub fn (mut v Builder) cc_msvc() {
 	}
 	diff := time.ticks() - ticks
 	v.timing_message('C msvc', diff)
-	v.post_process_c_compiler_output(res)
+	if v.pref.show_c_output {
+		v.show_c_compiler_output(res)    
+	} else {
+		v.post_process_c_compiler_output(res)
+	}        
 	// println(res)
 	// println('C OUTPUT:')
 	// Always remove the object file - it is completely unnecessary

--- a/vlib/v/builder/msvc.v
+++ b/vlib/v/builder/msvc.v
@@ -304,10 +304,10 @@ pub fn (mut v Builder) cc_msvc() {
 	diff := time.ticks() - ticks
 	v.timing_message('C msvc', diff)
 	if v.pref.show_c_output {
-		v.show_c_compiler_output(res)    
+		v.show_c_compiler_output(res)
 	} else {
 		v.post_process_c_compiler_output(res)
-	}        
+	}
 	// println(res)
 	// println('C OUTPUT:')
 	// Always remove the object file - it is completely unnecessary

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -5104,10 +5104,7 @@ fn (mut g Gen) type_default(typ_ table.Type) string {
 	}
 	return match sym.kind {
 		.interface_, .sum_type, .array_fixed, .multi_return { '{0}' }
-		.alias {
-			alias_info := sym.info as table.Alias
-			g.type_default(alias_info.parent_type)
-		}
+		.alias { g.type_default((sym.info as table.Alias).parent_type) }
 		else { '0' }
 	}
 	// TODO this results in

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -5054,7 +5054,8 @@ fn c_name(name_ string) string {
 	return name
 }
 
-fn (mut g Gen) type_default(typ table.Type) string {
+fn (mut g Gen) type_default(typ_ table.Type) string {
+	typ := g.unwrap_generic(typ_)
 	if typ.has_flag(.optional) {
 		return '{0}'
 	}
@@ -5103,6 +5104,10 @@ fn (mut g Gen) type_default(typ table.Type) string {
 	}
 	return match sym.kind {
 		.interface_, .sum_type, .array_fixed, .multi_return { '{0}' }
+		.alias {
+			alias_info := sym.info as table.Alias
+			g.type_default(alias_info.parent_type)
+		}
 		else { '0' }
 	}
 	// TODO this results in

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -123,7 +123,6 @@ typedef int (*qsort_callback_func)(const void*, const void*);
 #include <signal.h>
 #include <stdarg.h> // for va_list
 #include <string.h> // memcpy
-#include <assert.h>
 
 #if INTPTR_MAX == INT32_MAX
 	#define TARGET_IS_32BIT 1

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -67,6 +67,10 @@ const (
 	#undef TCCSKIP
 	#define TCCSKIP(x)
 	// #include <byteswap.h>
+	#ifndef _WIN32
+		#include <execinfo.h>
+		int tcc_backtrace(const char *fmt, ...);
+	#endif
 #endif
 
 // for __offset_of
@@ -119,6 +123,7 @@ typedef int (*qsort_callback_func)(const void*, const void*);
 #include <signal.h>
 #include <stdarg.h> // for va_list
 #include <string.h> // memcpy
+#include <assert.h>
 
 #if INTPTR_MAX == INT32_MAX
 	#define TARGET_IS_32BIT 1
@@ -431,20 +436,7 @@ typedef double any_float;
 typedef unsigned char* byteptr;
 typedef void* voidptr;
 typedef char* charptr;
-typedef struct array array;
-typedef struct map map;
-typedef array array_int;
-typedef array array_f32;
-typedef array array_f64;
-typedef array array_u16;
-typedef array array_u32;
-typedef array array_u64;
-//typedef map map_int;
-//typedef map map_string;
-//typedef array array_string;
-//typedef array array_byte;
 typedef byte array_fixed_byte_300 [300];
-typedef byte array_fixed_byte_400 [400];
 
 typedef struct sync__Channel* chan;
 

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -161,12 +161,12 @@ fn (mut g Gen) gen_fn_decl(it ast.FnDecl, skip bool) {
 	if it.return_type != table.void_type {
 		return_sym := g.table.get_type_symbol(it.return_type)
 		mut default_expr := g.type_default(it.return_type)
-		g.write('\treturn /* $return_sym.kind */')
-
-		if default_expr == '{0}' { // return_sym.kind in [.struct_, .multi_return] || {
-			g.write('($type_name)')
+		// TODO: perf?
+		if default_expr == '{0}' {
+			g.writeln('\treturn ($type_name)$default_expr;')
+		} else {
+			g.writeln('\treturn $default_expr;')
 		}
-		g.writeln('$default_expr;')
 	}
 	g.writeln('}')
 	g.defer_stmts = []

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -240,15 +240,7 @@ fn (mut g Gen) fn_args(args []table.Param, is_variadic bool) ([]string, []string
 				g.definitions.write(')')
 			}
 		} else {
-			mut nr_muls := arg.typ.nr_muls()
 			s := arg_type_name + ' ' + caname
-			if arg.is_mut {
-				// mut arg needs one *
-				nr_muls = 1
-			}
-			// if nr_muls > 0 && !is_varg {
-			// s = arg_type_name + strings.repeat(`*`, nr_muls) + ' ' + caname
-			// }
 			g.write(s)
 			g.definitions.write(s)
 			fargs << caname
@@ -615,12 +607,16 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 		}
 	}
 	if !print_auto_str {
-		if g.pref.is_debug && node.name == 'panic' {
-			paline, pafile, pamod, pafn := g.panic_debug_info(node.pos)
-			g.write('panic_debug($paline, tos3("$pafile"), tos3("$pamod"), tos3("$pafn"),  ')
+		if node.name == 'panic' {
+			if g.pref.is_debug {
+				paline, pafile, pamod, pafn := g.panic_debug_info(node.pos)
+				g.write('panic_debug($paline, tos3("$pafile"), tos3("$pamod"), tos3("$pafn"),  ')
+			} else {
+				g.write('\tv_panic(')
+			}
 			// g.call_args(node.args, node.expected_arg_types) // , [])
 			g.call_args(node)
-			g.write(')')
+			g.write('); assert(0)')
 		} else {
 			// Simple function call
 			// if free_tmp_arg_vars {

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -159,7 +159,6 @@ fn (mut g Gen) gen_fn_decl(it ast.FnDecl, skip bool) {
 		g.autofree_scope_vars(it.body_pos.pos)
 	}
 	if it.return_type != table.void_type {
-		return_sym := g.table.get_type_symbol(it.return_type)
 		mut default_expr := g.type_default(it.return_type)
 		// TODO: perf?
 		if default_expr == '{0}' {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -922,6 +922,7 @@ pub fn (mut p Parser) parse_ident(language table.Language) ast.Ident {
 	} else {
 		p.error('unexpected token `$p.tok.lit`')
 	}
+	return ast.Ident{}
 }
 
 pub fn (mut p Parser) name_expr() ast.Expr {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -73,6 +73,7 @@ pub mut:
 	is_debug            bool // false by default, turned on by -g or -cg, it tells v to pass -g to the C backend compiler.
 	is_vlines           bool // turned on by -g, false by default (it slows down .tmp.c generation slightly).
 	show_cc             bool // -showcc, print cc command
+	show_c_output       bool // -show-c-output, print all cc output even if the code was compiled correctly
 	// NB: passing -cg instead of -g will set is_vlines to false and is_debug to true, thus making v generate cleaner C files,
 	// which are sometimes easier to debug / inspect manually than the .tmp.c files by plain -g (when/if v line number generation breaks).
 	use_cache           bool // turns on v usage of the module cache to speed up compilation.
@@ -243,6 +244,9 @@ pub fn parse_args(args []string) (&Preferences, string) {
 			'-showcc' {
 				res.show_cc = true
 			}
+			'-show-c-output' {
+				res.show_c_output = true
+			}
 			'-experimental' {
 				res.experimental = true
 			}
@@ -252,9 +256,6 @@ pub fn parse_args(args []string) (&Preferences, string) {
 			'-prealloc' {
 				res.prealloc = true
 				res.build_options << arg
-			}
-			'-keepc' {
-				eprintln('-keepc is deprecated. V always keeps the generated .tmp.c files now.')
 			}
 			'-parallel' {
 				res.is_parallel = true

--- a/vlib/v/table/atypes.v
+++ b/vlib/v/table/atypes.v
@@ -863,7 +863,6 @@ pub fn (table &Table) type_to_str(t Type) string {
 				res += table.type_to_str(typ)
 			}
 			res += ')'
-			res = res
 		}
 		.void {
 			if t.has_flag(.optional) {


### PR DESCRIPTION
- `hello_world` and `cmd/v` now compile with 0 warnings

I also added a `-show-c-output` flag, that makes printing warnings much simpler and more convenient

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
