### PR TITLE
parser: parse func<T>() when T is a map or array type

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1031,24 +1031,21 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 	}
 	lit0_is_capital := p.tok.lit[0].is_capital()
 	// use heuristics to detect `func<T>()` from `var < expr`
-	mut is_generic_call := !lit0_is_capital && p.peek_tok.kind == .lt
-	if is_generic_call {
-		is_generic_call = match p.peek_tok2.kind {
-			.name {
-				// maybe `f<int>`, `f<map[`
-				(p.peek_tok2.kind == .name &&
-					p.peek_tok3.kind == .gt) ||
-					(p.peek_tok2.lit == 'map' && p.peek_tok3.kind == .lsbr)
-			}
-			.lsbr {
-				// maybe `f<[]T>`, assume `var < []` is invalid
-				p.peek_tok3.kind == .rsbr
-			}
-			else {
-				false
-			}
+	is_generic_call := !lit0_is_capital && p.peek_tok.kind == .lt && (match p.peek_tok2.kind {
+		.name {
+			// maybe `f<int>`, `f<map[`
+			(p.peek_tok2.kind == .name &&
+				p.peek_tok3.kind == .gt) ||
+				(p.peek_tok2.lit == 'map' && p.peek_tok3.kind == .lsbr)
 		}
-	}
+		.lsbr {
+			// maybe `f<[]T>`, assume `var < []` is invalid
+			p.peek_tok3.kind == .rsbr
+		}
+		else {
+			false
+		}
+	})
 	// p.warn('name expr  $p.tok.lit $p.peek_tok.str()')
 	same_line := p.tok.line_nr == p.peek_tok.line_nr
 	// `(` must be on same line as name token otherwise it's a ParExpr

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1030,13 +1030,25 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 		p.expr_mod = mod
 	}
 	lit0_is_capital := p.tok.lit[0].is_capital()
+	// use heuristics to detect `func<T>()` from `var < expr`
+	is_generic_call := !lit0_is_capital && p.peek_tok.kind == .lt && match p.peek_tok2.kind {
+		.name {
+			// maybe `f<int>`, `f<map[`
+			(p.peek_tok2.kind == .name && p.peek_tok3.kind == .gt) ||
+				(p.peek_tok2.lit == 'map' && p.peek_tok3.kind == .lsbr)
+		}
+		.lsbr {
+			// maybe `f<[]T>`, assume `var < []` is invalid
+			p.peek_tok3.kind == .rsbr
+		}
+		else {false}
+	}
 	// p.warn('name expr  $p.tok.lit $p.peek_tok.str()')
 	same_line := p.tok.line_nr == p.peek_tok.line_nr
 	// `(` must be on same line as name token otherwise it's a ParExpr
 	if !same_line && p.peek_tok.kind == .lpar {
 		node = p.parse_ident(language)
-	} else if p.peek_tok.kind == .lpar ||
-		(p.peek_tok.kind == .lt && !lit0_is_capital && p.peek_tok2.kind == .name && p.peek_tok3.kind == .gt) {
+	} else if p.peek_tok.kind == .lpar || is_generic_call {
 		// foo(), foo<int>() or type() cast
 		mut name := p.tok.lit
 		if mod.len > 0 {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1036,14 +1036,17 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 		is_generic_call = match p.peek_tok2.kind {
 			.name {
 				// maybe `f<int>`, `f<map[`
-				(p.peek_tok2.kind == .name && p.peek_tok3.kind == .gt) ||
+				(p.peek_tok2.kind == .name &&
+					p.peek_tok3.kind == .gt) ||
 					(p.peek_tok2.lit == 'map' && p.peek_tok3.kind == .lsbr)
 			}
 			.lsbr {
 				// maybe `f<[]T>`, assume `var < []` is invalid
 				p.peek_tok3.kind == .rsbr
 			}
-			else {false}
+			else {
+				false
+			}
 		}
 	}
 	// p.warn('name expr  $p.tok.lit $p.peek_tok.str()')

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1031,17 +1031,20 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 	}
 	lit0_is_capital := p.tok.lit[0].is_capital()
 	// use heuristics to detect `func<T>()` from `var < expr`
-	is_generic_call := !lit0_is_capital && p.peek_tok.kind == .lt && match p.peek_tok2.kind {
-		.name {
-			// maybe `f<int>`, `f<map[`
-			(p.peek_tok2.kind == .name && p.peek_tok3.kind == .gt) ||
-				(p.peek_tok2.lit == 'map' && p.peek_tok3.kind == .lsbr)
+	mut is_generic_call := !lit0_is_capital && p.peek_tok.kind == .lt
+	if is_generic_call {
+		is_generic_call = match p.peek_tok2.kind {
+			.name {
+				// maybe `f<int>`, `f<map[`
+				(p.peek_tok2.kind == .name && p.peek_tok3.kind == .gt) ||
+					(p.peek_tok2.lit == 'map' && p.peek_tok3.kind == .lsbr)
+			}
+			.lsbr {
+				// maybe `f<[]T>`, assume `var < []` is invalid
+				p.peek_tok3.kind == .rsbr
+			}
+			else {false}
 		}
-		.lsbr {
-			// maybe `f<[]T>`, assume `var < []` is invalid
-			p.peek_tok3.kind == .rsbr
-		}
-		else {false}
 	}
 	// p.warn('name expr  $p.tok.lit $p.peek_tok.str()')
 	same_line := p.tok.line_nr == p.peek_tok.line_nr

--- a/vlib/v/tests/generics_test.v
+++ b/vlib/v/tests/generics_test.v
@@ -13,11 +13,17 @@ fn plus<T>(xxx T, b T) T {
 	return xxx + b
 }
 
-fn test_generic_fn() {
+fn test_identity() {
 	assert simple<int>(1) == 1
 	assert simple<int>(1 + 0) == 1
 	assert simple<string>('g') == 'g'
 	assert simple<string>('g') + 'h' == 'gh'
+	
+	assert simple<[]int>([1])[0] == 1
+	assert simple<map[string]string>({'a':'b'})['a'] == 'b'
+}
+
+fn test_plus() {
 	a := plus<int>(2, 3)
 	println(a)
 	assert a == 5


### PR DESCRIPTION
Parse:
* `func<map[string]string>`
* `func<[]string>`

Note: Parsing is a bit tricky because it could be a variable infix expression: `var < expr`. We only have a few tokens to peek ahead to tell the difference.

Fixes #6721.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
