### PR TITLE
cgen: don't generate a default expr if a function ends with `return`

### DIFF
--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -158,7 +158,7 @@ fn (mut g Gen) gen_fn_decl(it ast.FnDecl, skip bool) {
 		// TODO: remove this, when g.write_autofree_stmts_when_needed works properly
 		g.autofree_scope_vars(it.body_pos.pos)
 	}
-	if it.return_type != table.void_type {
+	if it.return_type != table.void_type && it.stmts.len > 0 && it.stmts.last() !is ast.Return {
 		mut default_expr := g.type_default(it.return_type)
 		// TODO: perf?
 		if default_expr == '{0}' {

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -159,7 +159,7 @@ fn (mut g Gen) gen_fn_decl(it ast.FnDecl, skip bool) {
 		g.autofree_scope_vars(it.body_pos.pos)
 	}
 	if it.return_type != table.void_type && it.stmts.len > 0 && it.stmts.last() !is ast.Return {
-		mut default_expr := g.type_default(it.return_type)
+		default_expr := g.type_default(it.return_type)
 		// TODO: perf?
 		if default_expr == '{0}' {
 			g.writeln('\treturn ($type_name)$default_expr;')


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
