### PR TITLE
cgen: fix using brackets for match expression

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2803,12 +2803,17 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 	g.expr(node.cond)
 	g.writeln(';')
 	g.write(cur_line)
+	if is_expr {
+		// brackets needed otherwise '?' will apply to everything on the left
+		g.write('(')
+	}
 	if node.is_sum_type {
 		g.match_expr_sumtype(node, is_expr, cond_var)
 	} else {
 		g.match_expr_classic(node, is_expr, cond_var)
 	}
 	if is_expr {
+		g.write(')')
 		g.decrement_inside_ternary()
 	}
 }

--- a/vlib/v/tests/match_test.v
+++ b/vlib/v/tests/match_test.v
@@ -222,3 +222,10 @@ fn test_match_sumtype_multiple_types() {
 		}
 	}
 }
+
+fn test_sub_expression() {
+	b := false && match 1 {0 {true} else {true}}
+	assert !b
+	c := true || match 1 {0 {false} else {false}}
+	assert c
+}


### PR DESCRIPTION
This currently evaluates to `true`:
```v
false && match 1 {0 {true} else {true}}
```
Match expressions need brackets to prevent this.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
