### PR TITLE
js: fix wrong filename and invalid backend selected when using -o .js

### DIFF
--- a/vlib/v/builder/js.v
+++ b/vlib/v/builder/js.v
@@ -45,7 +45,11 @@ pub fn (mut b Builder) compile_js() {
 		println('all .v files:')
 		println(files)
 	}
-	b.build_js(files, b.pref.out_name + '.js')
+	mut name := b.pref.out_name
+	if !name.ends_with('.js') {
+		name += '.js'
+	}
+	b.build_js(files, name)
 }
 
 fn (mut b Builder) run_js() {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -316,6 +316,9 @@ pub fn parse_args(args []string) (&Preferences, string) {
 			}
 			'-o' {
 				res.out_name = cmdline.option(current_args, '-o', '')
+				if res.out_name.ends_with('.js') {
+					res.backend = .js
+				}
 				i++
 			}
 			'-b' {


### PR DESCRIPTION
![Screenshot 2020-11-07 at 00 59 11](https://user-images.githubusercontent.com/6431515/98454042-3c77e700-2160-11eb-98b9-4da2ab5dcfe2.png)
