### PR TITLE
x.websocket: Fixes autobahn test to always use latest v

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,38 +518,38 @@ jobs:
         ../v -autofree -experimental .
         cd ..
 
-  # websocket_autobahn:
-  #   name: Autobahn integrations tests
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
+  websocket_autobahn:
+    name: Autobahn integrations tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-  #     - name: Run autobahn services
-  #       run: docker-compose -f ${{github.workspace}}/vlib/x/websocket/tests/autobahn/docker-compose.yml up -d
-  #     - name: Build client test
-  #       run: docker exec autobahn_client "v" "/src/tests/autobahn/autobahn_client.v"
-  #     - name: Run client test
-  #       run: docker exec autobahn_client "/src/tests/autobahn/autobahn_client"
-  #     - name: Run server test
-  #       run: docker exec autobahn_server "wstest" "-m" "fuzzingclient" "-s" "/config/fuzzingclient.json"
-  #     - name: Copy reports
-  #       run: docker cp autobahn_server:/reports ${{github.workspace}}/reports
-  #     - name: Test success
-  #       run: docker exec autobahn_server "python" "/check_results.py"
+      - name: Run autobahn services
+        run: docker-compose -f ${{github.workspace}}/vlib/x/websocket/tests/autobahn/docker-compose.yml up -d
+      - name: Build client test
+        run: docker exec autobahn_client "/src/v" "/src/vlib/x/websocket/tests/autobahn/autobahn_client.v"
+      - name: Run client test
+        run: docker exec autobahn_client "/src/vlib/x/websocket/tests/autobahn/autobahn_client"
+      - name: Run server test
+        run: docker exec autobahn_server "wstest" "-m" "fuzzingclient" "-s" "/config/fuzzingclient.json"
+      - name: Copy reports
+        run: docker cp autobahn_server:/reports ${{github.workspace}}/reports
+      - name: Test success
+        run: docker exec autobahn_server "python" "/check_results.py"
 
-  #     - name: Publish all reports
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #           name: full report
-  #           path: ${{github.workspace}}/reports
-  #     - name: Publish report client
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #           name: client
-  #           path: ${{github.workspace}}/reports/clients/index.html
-  #     - name: Publish report server
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #           name: server
-  #           path: ${{github.workspace}}/reports/servers/index.html
+      - name: Publish all reports
+        uses: actions/upload-artifact@v2
+        with:
+            name: full report
+            path: ${{github.workspace}}/reports
+      - name: Publish report client
+        uses: actions/upload-artifact@v2
+        with:
+            name: client
+            path: ${{github.workspace}}/reports/clients/index.html
+      - name: Publish report server
+        uses: actions/upload-artifact@v2
+        with:
+            name: server
+            path: ${{github.workspace}}/reports/servers/index.html

--- a/vlib/x/websocket/tests/autobahn/docker-compose.yml
+++ b/vlib/x/websocket/tests/autobahn/docker-compose.yml
@@ -11,8 +11,8 @@ services:
     container_name: autobahn_client
     build: 
       #vlib/x/websocket/tests/autobahn/ws_test/Dockerfile
-      dockerfile: tests/autobahn/ws_test/Dockerfile 
-      context: ../../
+      dockerfile: vlib/x/websocket/tests/autobahn/ws_test/Dockerfile 
+      context: ../../../../../
     # volumes: 
     #   - ../../:/src
 #   redis:

--- a/vlib/x/websocket/tests/autobahn/ws_test/Dockerfile
+++ b/vlib/x/websocket/tests/autobahn/ws_test/Dockerfile
@@ -1,11 +1,12 @@
-FROM thevlang/vlang:buster-dev
+FROM thevlang/vlang:buster-build
 
-# ARG WORKSPACE_ROOT
 
-# WORKDIR ${WORKSPACE_ROOT}
 COPY ./ /src/
-# COPY tests/autobahn/ws_test/run.sh /run.sh
-# RUN chmod +x /run.sh
-RUN v /src/tests/autobahn/autobahn_server.v
-RUN chmod +x /src/tests/autobahn/autobahn_server
-ENTRYPOINT [ "/src/tests/autobahn/autobahn_server" ]
+
+WORKDIR /src
+
+RUN make CC=clang 
+
+RUN /src/v /src/vlib/x/websocket/tests/autobahn/autobahn_server.v
+RUN chmod +x /src/vlib/x/websocket/tests/autobahn/autobahn_server
+ENTRYPOINT [ "/src/vlib/x/websocket/tests/autobahn/autobahn_server" ]


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
This PR fixes the autobahn tests. It was a design flaw in the tests that did not use the current PR v code so there were a delay finding errors until next release of nightly build of official v containers. 

- This PR fix so it compiles the V that are in the current branch and use that version running tests

More PR to come to document how to setup autobahn tests locally if needed 