### PR TITLE
pg: fix exec & exec_param_many

### DIFF
--- a/vlib/sqlite/sqlite.v
+++ b/vlib/sqlite/sqlite.v
@@ -134,6 +134,8 @@ pub fn (db DB) exec(query string) ([]Row, int) {
 		}
 		rows << row
 	}
+
+	C.sqlite3_finalize(stmt)
 	return rows, res
 }
 


### PR DESCRIPTION
This resolves an issue with the postgresql module that resulted in an exception when a query returned back results. This PR also resolves an issue with `exec_param_many` and the values that were passed into `PGexecParams`.

I also updated `exec_param` and `exec_param2` to call `exec_param_many` (these are probably redundant, but not sure if they had a purpose). All `exec` methods have been updated to return `?[]Row`.