### PR TITLE
checker: improve & simplify invalid function argument errors

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1534,7 +1534,7 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 			return true
 		}
 		*/
-		if !c.check_types(typ, arg.typ) {
+		c.check_expected(typ, arg.typ) or {
 			// str method, allow type with str method if fn arg is string
 			// Passing an int or a string array produces a c error here
 			// Deleting this condition results in propper V error messages
@@ -1547,16 +1547,7 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 			if f.is_generic {
 				continue
 			}
-			if typ_sym.kind == .array_fixed {
-			}
-			if typ_sym.kind == .function && arg_typ_sym.kind == .function {
-				candidate_fn_name := if typ_sym.source_name.starts_with('anon_') { 'anonymous function' } else { 'fn `$typ_sym.source_name`' }
-				c.error('cannot use $candidate_fn_name as function type `$arg_typ_sym.str()` in argument ${i +
-					1} to `$fn_name`', call_expr.pos)
-			} else {
-				c.error('cannot use type `$typ_sym.source_name` as type `$arg_typ_sym.source_name` in argument ${i +
-					1} to `$fn_name`', call_expr.pos)
-			}
+			c.error('invalid argument ${i + 1} to `$fn_name`: $err', call_arg.pos)
 		}
 	}
 	if f.is_generic && call_expr.generic_type == table.void_type {

--- a/vlib/v/checker/tests/fn_args.out
+++ b/vlib/v/checker/tests/fn_args.out
@@ -1,0 +1,19 @@
+vlib/v/checker/tests/fn_args.vv:6:7: error: invalid argument 1 to `ptr`: expected `byte`, not `&int`
+    4 | 
+    5 | v := 4
+    6 | ptr(&v)
+      |       ^
+    7 | arr([5]!!)
+    8 | fun(fn(i &int){})
+vlib/v/checker/tests/fn_args.vv:7:10: error: invalid argument 1 to `arr`: expected `[]int`, not `[1]int`
+    5 | v := 4
+    6 | ptr(&v)
+    7 | arr([5]!!)
+      |          ^
+    8 | fun(fn(i &int){})
+vlib/v/checker/tests/fn_args.vv:8:17: error: invalid argument 1 to `fun`: expected `fn (int)`, not `fn (&int)`
+    6 | ptr(&v)
+    7 | arr([5]!!)
+    8 | fun(fn(i &int){})
+      |                 ^
+details: ``'s expected fn argument: `` is NOT a pointer, but the passed fn argument: `i` is a pointer

--- a/vlib/v/checker/tests/fn_args.vv
+++ b/vlib/v/checker/tests/fn_args.vv
@@ -1,0 +1,8 @@
+fn ptr(a byte) {}
+fn arr(a []int) {}
+fn fun(a fn(int)) {}
+
+v := 4
+ptr(&v)
+arr([5]!!)
+fun(fn(i &int){})

--- a/vlib/v/checker/tests/function_wrong_arg_type.out
+++ b/vlib/v/checker/tests/function_wrong_arg_type.out
@@ -1,7 +1,7 @@
-vlib/v/checker/tests/function_wrong_arg_type.vv:7:7: error: cannot use type `f64` as type `int` in argument 1 to `f`
+vlib/v/checker/tests/function_wrong_arg_type.vv:7:10: error: invalid argument 1 to `f`: expected `int`, not `f64`
     5 | fn main() {
     6 |     a := 12.3
     7 |     q := f(a)
-      |          ~~~~
+      |             ^
     8 |     println('$q')
     9 | }

--- a/vlib/v/checker/tests/is_type_not_exist.out
+++ b/vlib/v/checker/tests/is_type_not_exist.out
@@ -1,12 +1,12 @@
-vlib/v/checker/tests/is_type_not_exist.vv:4:2: error: cannot use type `any_int` as type `Integer` in argument 1 to `fn_with_sum_type_param`
-    2 |
+vlib/v/checker/tests/is_type_not_exist.vv:4:26: error: invalid argument 1 to `fn_with_sum_type_param`: expected `Integer`, not `any_int`
+    2 | 
     3 | fn main() {
     4 |     fn_with_sum_type_param(1)
-      |     ~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                             ^
     5 | }
     6 |
 vlib/v/checker/tests/is_type_not_exist.vv:8:10: error: is: type `SomethingThatDontExist` does not exist
-    6 |
+    6 | 
     7 | fn fn_with_sum_type_param(i Integer) {
     8 |     if i is SomethingThatDontExist {
       |             ~~~~~~~~~~~~~~~~~~~~~~

--- a/vlib/v/checker/tests/non_matching_functional_args.out
+++ b/vlib/v/checker/tests/non_matching_functional_args.out
@@ -1,16 +1,16 @@
-vlib/v/checker/tests/non_matching_functional_args.vv:27:2: error: cannot use anonymous function as function type `MyFn` in argument 1 to `sum` 
-   25 | 
-   26 | fn main() {
-   27 |     sum(fn (mut t Table) {
-      |     ~~~~~~~~~~~~~~~~~~~~~~
+vlib/v/checker/tests/non_matching_functional_args.vv:30:3: error: invalid argument 1 to `sum`: expected `fn (Table)`, not `fn (mut Table)`
    28 |         t.rename()
    29 |         println(t.name)
+   30 |     })
+      |      ^
+   31 |     sum(xxx)
+   32 |     sum(yyy)
 details: `main.MyFn`'s expected fn argument: `zzzz` is NOT a pointer, but the passed fn argument: `t` is a pointer
-vlib/v/checker/tests/non_matching_functional_args.vv:31:2: error: cannot use fn `xxx` as function type `MyFn` in argument 1 to `sum` 
+vlib/v/checker/tests/non_matching_functional_args.vv:31:9: error: invalid argument 1 to `sum`: expected `fn (Table)`, not `fn (mut Table)`
    29 |         println(t.name)
    30 |     })
    31 |     sum(xxx)
-      |     ~~~~~~~~
+      |            ^
    32 |     sum(yyy)
    33 | }
 details: `main.MyFn`'s expected fn argument: `zzzz` is NOT a pointer, but the passed fn argument: `mytable` is a pointer


### PR DESCRIPTION
This fixes showing pointer types correctly when there is an invalid argument.
This fixes showing the type of an anonymous function when passed as an invalid argument. It no longer prints 'anonymous function' but that doesn't seem important (it should be clear from the code).

The error now shows the invalid argument position instead of the whole function call.
Add test for invalid argument with a fixed size array (and remove related dead code).
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
