### PR TITLE
checker: fix `&` on pointers

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2865,6 +2865,8 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 					}
 				}
 				return right_type.to_ptr()
+			} else if node.op == .amp && node.right !is ast.CastExpr {
+				return right_type.to_ptr()
 			}
 			if node.op == .mul {
 				if right_type.is_ptr() {

--- a/vlib/v/tests/unsafe_test.v
+++ b/vlib/v/tests/unsafe_test.v
@@ -15,12 +15,23 @@ fn test_ptr_assign() {
 }
 
 fn test_double_ptr() {
+	i := 5
+	j := 7
+	unsafe {
+		mut x := &i
+		mut p := &x
+		(*p) = &j
+		assert x == &j
+	}
+
+	/////////
+
 	mut x := &int(0)
 	unsafe {
 		mut p := &x
 		(*p) = &int(1)
 	}
-	assert x == &int(1)
+	assert ptr_str(x) == ptr_str(&int(1))
 }
 
 fn test_ptr_infix() {

--- a/vlib/v/tests/unsafe_test.v
+++ b/vlib/v/tests/unsafe_test.v
@@ -14,6 +14,15 @@ fn test_ptr_assign() {
 	assert v[3] == 31
 }
 
+fn test_double_ptr() {
+	mut x := &int(0)
+	unsafe {
+		mut p := &x
+		(*p) = &int(1)
+	}
+	assert x == &int(1)
+}
+
 fn test_ptr_infix() {
 	v := 4
 	mut q := unsafe {&v - 1}


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
