### PR TITLE
cgen: fix typeof union sum type

### DIFF
--- a/vlib/v/tests/union_sum_type_test.v
+++ b/vlib/v/tests/union_sum_type_test.v
@@ -302,11 +302,13 @@ fn test_nested_if_is() {
 fn test_casted_sum_type_selector_reassign() {
 	mut b := InnerStruct{Inner(0)}
 	if b.x is int {
+		assert typeof(b.x) == 'int'
 		// this check works only if x is castet
 		assert b.x == 0
 		b.x = 'test'
 		// this check works only if x is castet
 		assert b.x[0] == `t`
+		assert typeof(b.x) == 'string'
 	}
 	// this check works only if x is not castet
 	assert b.x is string
@@ -317,9 +319,11 @@ fn test_casted_sum_type_ident_reassign() {
 	if x is int {
 		// this check works only if x is castet
 		assert x == 0
+		assert typeof(x) == 'int'
 		x = 'test'
 		// this check works only if x is castet
 		assert x[0] == `t`
+		assert typeof(x) == 'string'
 	}
 	// this check works only if x is not castet
 	assert x is string

--- a/vlib/v/tests/union_sum_type_test.v
+++ b/vlib/v/tests/union_sum_type_test.v
@@ -24,7 +24,7 @@ fn handle(e Expr) string {
 	assert is_literal
 	assert !(e !is IntegerLiteral)
 	if e is IntegerLiteral {
-		println('int')
+		assert typeof(e.val) == 'string'
 	}
 	match union e {
 		IntegerLiteral {
@@ -294,7 +294,7 @@ fn test_nested_if_is() {
 	mut b := Outer(InnerStruct{Inner(0)})
 	if b is InnerStruct {
 		if b.x is int {
-			println(b.x)
+			assert b.x == 0
 		}
 	}
 }
@@ -302,21 +302,27 @@ fn test_nested_if_is() {
 fn test_casted_sum_type_selector_reassign() {
 	mut b := InnerStruct{Inner(0)}
 	if b.x is int {
-		assert typeof(b.x) == 'int'
+		// this check works only if x is castet
+		assert b.x == 0
 		b.x = 'test'
-		assert typeof(b.x) == 'string'
+		// this check works only if x is castet
+		assert b.x[0] == `t`
 	}
-	assert typeof(b.x) == 'Inner'
+	// this check works only if x is not castet
+	assert b.x is string
 }
 
 fn test_casted_sum_type_ident_reassign() {
 	mut x := Inner(0)
 	if x is int {
-		assert typeof(x) == 'int'
+		// this check works only if x is castet
+		assert x == 0
 		x = 'test'
-		assert typeof(x) == 'string'
+		// this check works only if x is castet
+		assert x[0] == `t`
 	}
-	assert typeof(x) == 'Inner'
+	// this check works only if x is not castet
+	assert x is string
 }
 
 __type Expr2 = int | string
@@ -427,9 +433,15 @@ fn test_match_multi_branch() {
 	mut y := ''
 	match union f {
 		CallExpr2, CTempVarExpr {
-			assert typeof(f) == 'Expr4'
+			// this check works only if f is not castet
+			assert f is CTempVarExpr
 		}
 	}
+}
+
+fn test_typeof() {
+    x := Expr4(CTempVarExpr{})
+	assert typeof(x) == 'CTempVarExpr'
 }
 
 fn test_sum_type_match() {


### PR DESCRIPTION
```
x := ast.Expr(0)
typeof(x) // => ast.Expr instead of the internal type
```

This PR fixes it.