### PR TITLE
cgen: fix default value init for union sum types

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -5295,7 +5295,7 @@ fn (mut g Gen) type_default(typ_ table.Type) string {
 		else {}
 	}
 	return match sym.kind {
-		.interface_, .sum_type, .array_fixed, .multi_return { '{0}' }
+		.interface_, .union_sum_type, .sum_type, .array_fixed, .multi_return { '{0}' }
 		.alias { g.type_default((sym.info as table.Alias).parent_type) }
 		else { '0' }
 	}

--- a/vlib/v/tests/union_sum_type_test.v
+++ b/vlib/v/tests/union_sum_type_test.v
@@ -432,6 +432,15 @@ fn test_match_multi_branch() {
 	}
 }
 
+struct Outer2 {
+    e Expr4
+}
+
+fn test_zero_value_init() {
+	// no c compiler error then it's successful
+    o := Outer2{}
+}
+
 fn test_sum_type_match() {
 	// TODO: Remove these casts
 	assert is_gt_simple('3', int(2))

--- a/vlib/v/tests/union_sum_type_test.v
+++ b/vlib/v/tests/union_sum_type_test.v
@@ -433,7 +433,7 @@ fn test_match_multi_branch() {
 }
 
 struct Outer2 {
-    e Expr4
+	e Expr4
 }
 
 fn test_zero_value_init() {

--- a/vlib/v/tests/union_sum_type_test.v
+++ b/vlib/v/tests/union_sum_type_test.v
@@ -438,7 +438,7 @@ struct Outer2 {
 
 fn test_zero_value_init() {
 	// no c compiler error then it's successful
-    o := Outer2{}
+	o := Outer2{}
 }
 
 fn test_sum_type_match() {


### PR DESCRIPTION
```v
__type Expr = SelectorExpr | AnotherExpr

struct SelectorExpr {}
struct AnotherExpr {}

struct Outer {
    e Expr
}

fn main() {
    o := Outer{}
    println(o)
}
```

resulted in an error before.
this PR fixes that. :)