### PR TITLE
gen: implement type_name method for sum type instances

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1623,8 +1623,6 @@ println(sum)
 The built-in method `type_name` returns the name of the currently held 
 type.
 
-#### Sum type operators
-
 To check whether a sum type instance holds a certain type, use `sum is Type`.
 To cast a sum type to one of its variants you can use `sum as Type`:
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1617,8 +1617,13 @@ struct Venus {}
 type World = Moon | Mars | Venus
 
 sum := World(Moon{})
+assert sum.type_name() == 'Moon'
 println(sum)
 ```
+The built-in method `type_name` returns the name of the currently held 
+type.
+
+#### Sum type operators
 
 To check whether a sum type instance holds a certain type, use `sum is Type`.
 To cast a sum type to one of its variants you can use `sum as Type`:

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -292,7 +292,7 @@ pub:
 	left               Expr // `user` in `user.register()`
 	mod                string
 pub mut:
-	name               string
+	name               string // left.name()
 	is_method          bool
 	is_field           bool // temp hack, remove ASAP when re-impl CallExpr / Selector (joe)
 	args               []CallArg

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1079,6 +1079,9 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 		c.error('optional type cannot be called directly', call_expr.left.position())
 		return table.void_type
 	}
+	if left_type_sym.kind == .sum_type && method_name == 'type_name' {
+		return table.string_type
+	}
 	// TODO: remove this for actual methods, use only for compiler magic
 	// FIXME: Argument count != 1 will break these
 	if left_type_sym.kind == .array &&

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4253,6 +4253,9 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 		if sym.kind == .interface_ {
 			c.error('interfaces cannot be used as method receiver', node.receiver_pos)
 		}
+		if sym.kind == .sum_type && node.name == 'type_name' {
+			c.error('method overrides built-in sum type method', node.pos)
+		}
 		// if sym.has_method(node.name) {
 		// c.warn('duplicate method `$node.name`', node.pos)
 		// }

--- a/vlib/v/checker/tests/incorrect_name_sum_type.out
+++ b/vlib/v/checker/tests/incorrect_name_sum_type.out
@@ -1,3 +1,12 @@
 vlib/v/checker/tests/incorrect_name_sum_type.vv:1:1: error: sum type `integer` must begin with capital letter
     1 | type integer = i8 | i16 | int | i64
       | ~~~~~~~~~~~~
+    2 | type Integer = i8 | i16 | int | i64
+    3 |
+vlib/v/checker/tests/incorrect_name_sum_type.vv:4:1: error: method overrides built-in sum type method
+    2 | type Integer = i8 | i16 | int | i64
+    3 | 
+    4 | fn (i Integer) type_name() {
+      | ~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5 | }
+    6 |

--- a/vlib/v/checker/tests/incorrect_name_sum_type.vv
+++ b/vlib/v/checker/tests/incorrect_name_sum_type.vv
@@ -1,1 +1,6 @@
 type integer = i8 | i16 | int | i64
+type Integer = i8 | i16 | int | i64
+
+fn (i Integer) type_name() {
+}
+

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -380,6 +380,12 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			else {}
 		}
 	}
+	if left_sym.kind == .sum_type && node.name == 'type_name' {
+		g.write('tos3( /* $left_sym.name */ v_typeof_sumtype_${node.receiver_type}( (')
+		g.expr(node.left)
+		g.write(').typ ))')
+		return
+	}
 	if node.name == 'str' {
 		mut styp := g.typ(node.receiver_type)
 		if node.receiver_type.is_ptr() {

--- a/vlib/v/tests/typeof_test.v
+++ b/vlib/v/tests/typeof_test.v
@@ -62,6 +62,9 @@ fn test_typeof_on_sumtypes() {
 	a := MySumType(int(32))
 	b := MySumType(f32(123.0))
 	c := MySumType(FooBar{x:43})
+	assert typeof(a) == 'int'
+	assert typeof(b) == 'f32'
+	assert typeof(c) == 'FooBar'
 	assert a.type_name() == 'int'
 	assert b.type_name() == 'f32'
 	assert c.type_name() == 'FooBar'
@@ -92,6 +95,10 @@ fn test_typeof_on_sumtypes_of_structs() {
 	b := fexpr(2)
 	c := fexpr(3)
 	d := ExprType(UnaryExpr{})
+	assert typeof(a) == 'UnaryExpr'
+	assert typeof(b) == 'BinExpr'
+	assert typeof(c) == 'BoolExpr'
+	assert typeof(d) == 'UnaryExpr'
 	assert a.type_name() == 'UnaryExpr'
 	assert b.type_name() == 'BinExpr'
 	assert c.type_name() == 'BoolExpr'

--- a/vlib/v/tests/typeof_test.v
+++ b/vlib/v/tests/typeof_test.v
@@ -62,9 +62,9 @@ fn test_typeof_on_sumtypes() {
 	a := MySumType(int(32))
 	b := MySumType(f32(123.0))
 	c := MySumType(FooBar{x:43})
-	assert typeof(a) == 'int'
-	assert typeof(b) == 'f32'
-	assert typeof(c) == 'FooBar'
+	assert a.type_name() == 'int'
+	assert b.type_name() == 'f32'
+	assert c.type_name() == 'FooBar'
 	// typeof should be known at compile-time for all types
 	assert typeof(a).name == 'MySumType'
 	assert typeof(b).name == 'MySumType'
@@ -92,10 +92,10 @@ fn test_typeof_on_sumtypes_of_structs() {
 	b := fexpr(2)
 	c := fexpr(3)
 	d := ExprType(UnaryExpr{})
-	assert typeof(a) == 'UnaryExpr'
-	assert typeof(b) == 'BinExpr'
-	assert typeof(c) == 'BoolExpr'
-	assert typeof(d) == 'UnaryExpr'
+	assert a.type_name() == 'UnaryExpr'
+	assert b.type_name() == 'BinExpr'
+	assert c.type_name() == 'BoolExpr'
+	assert d.type_name() == 'UnaryExpr'
 }
 
 fn myfn(i int) int {


### PR DESCRIPTION
`typeof(expr)` is planned to produce a type known at compile-time, not a string.
`typeof(expr).name` is the replacement for compile-time known types.

`sum.type_name()` is implemented here to get the name of the dynamic type held by sum type instance `sum`. Using a method makes it clear it's a runtime operation.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
