### PR TITLE
doc: split out `perform` from interface example

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1570,25 +1570,33 @@ interface Speaker {
     speak() string
 }
 
-fn perform(s Speaker) string {
-    if s is Dog { // use `is` to check the underlying type of an interface
-        println('perform(dog)')
-        println(s.breed) // `s` is automatically cast to `Dog` (smart cast)
-    } else if s is Cat {
-        println('perform(cat)')
-    }
-    return s.speak()
-}
-
 dog := Dog{'Leonberger'}
 cat := Cat{}
 
-println(perform(dog)) // "woof"
-println(perform(cat)) // "meow"
+mut arr := []Speaker{}
+arr << dog
+arr << cat
+for item in arr {
+    item.speak()
+}
 ```
 
 A type implements an interface by implementing its methods.
 There is no explicit declaration of intent, no "implements" keyword.
+
+We can test the underlying type of an interface using dynamic cast operators:
+```v oksyntax
+fn announce(s Speaker) {
+    if s is Dog {
+        println('a $s.breed') // `s` is automatically cast to `Dog` (smart cast)
+    } else if s is Cat {
+        println('a cat')
+    } else {
+        println('something else')
+    }
+}
+```
+For more information, see [Dynamic casts](#dynamic-casts).
 
 ### Enums
 
@@ -1628,6 +1636,8 @@ type World = Moon | Mars | Venus
 sum := World(Moon{})
 println(sum)
 ```
+
+#### Dynamic casts
 
 To check whether a sum type instance holds a certain type, use `sum is Type`.
 To cast a sum type to one of its variants you can use `sum as Type`:


### PR DESCRIPTION
This is simpler to understand, moving smart casts out of the main example.

Use array of `Speaker` for main example.
Simplify `perform` and use as extra example.
Add link to sum type dynamic casts.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
