### PR TITLE
term.ui: render to the alternate buffer

### DIFF
--- a/examples/term.ui/cursor_chaser.v
+++ b/examples/term.ui/cursor_chaser.v
@@ -1,10 +1,5 @@
 import term.ui as tui
 
-struct Point {
-	x int
-	y int
-}
-
 const (
 	colors = [
 		tui.Color{33, 150, 243}
@@ -15,6 +10,11 @@ const (
 		tui.Color{156, 39, 176}
 	]
 )
+
+struct Point {
+	x int
+	y int
+}
 
 struct App {
 mut:
@@ -33,11 +33,11 @@ fn frame(x voidptr) {
 	if app.points.len > 0 {
 		app.tui.set_bg_color(app.color)
 		mut last := app.points[0]
-		for segment in app.points {
-			// if the cursor moveds quickly enough, different events are not
+		for point in app.points {
+			// if the cursor moves quickly enough, different events are not
 			// necessarily touching, so we need to draw a line between them
-			app.tui.draw_line(last.x, last.y, segment.x, segment.y)
-			last = segment
+			app.tui.draw_line(last.x, last.y, point.x, point.y)
+			last = point
 		}
 		app.tui.reset()
 
@@ -62,8 +62,6 @@ fn event(e &tui.Event, x voidptr) {
 		.key_down {
 			match e.code {
 				.escape {
-					app.tui.set_cursor_position(0, 0)
-					app.tui.flush()
 					exit(0)
 				}
 				.space, .enter {

--- a/examples/term.ui/event_viewer.v
+++ b/examples/term.ui/event_viewer.v
@@ -32,6 +32,7 @@ app.tui = tui.init(
 	hide_cursor: true
 	capture_events: true
 	frame_rate: 60
+	use_alternate_buffer: false
 )
 
 println('V term.ui event viewer (press `esc` to exit)\n\n')

--- a/examples/term.ui/term_drawing.v
+++ b/examples/term.ui/term_drawing.v
@@ -303,7 +303,7 @@ fn (mut app App) set_pixel(x_ int, y_ int, c tui.Color) {
 }
 
 fn (mut app App) paint(event &tui.Event) {
-	if event.y < 0 || app.tui.window_height - event.y < 3 {
+	if event.y < 4 || app.tui.window_height - event.y < 4 {
 		return
 	}
 	x_start, y_start := int(f32((event.x - 1) / 2) - app.size / 2 + 1), event.y - app.size / 2

--- a/examples/term.ui/term_drawing.v
+++ b/examples/term.ui/term_drawing.v
@@ -87,19 +87,20 @@ const (
 
 struct App {
 mut:
-	tui             &tui.Context = 0
-	header_text     []string
-	mouse_pos       Point
-	msg             string
-	msg_hide_tick   int
-	primary_color   tui.Color = colors[1][6]
-	secondary_color tui.Color = colors[1][9]
-	bg_color        tui.Color = tui.Color{0, 0, 0}
-	color_index     int
-	drawing         [][]tui.Color = [][]tui.Color{len: h, init: []tui.Color{len: w}}
-	size            int = 1
-	should_redraw   bool = true
-	is_dragging     bool
+	tui                 &tui.Context = 0
+	header_text         []string
+	mouse_pos           Point
+	msg                 string
+	msg_hide_tick       int
+	primary_color       tui.Color = colors[1][6]
+	secondary_color     tui.Color = colors[1][9]
+	primary_color_idx   int = 25
+	secondary_color_idx int = 28
+	bg_color            tui.Color = tui.Color{0, 0, 0}
+	drawing             [][]tui.Color = [][]tui.Color{len: h, init: []tui.Color{len: w}}
+	size                int = 1
+	should_redraw       bool = true
+	is_dragging         bool
 }
 
 struct Point {
@@ -169,10 +170,17 @@ fn event(event &tui.Event, x voidptr) {
 				x: event.x
 				y: event.y
 			}
-			if event.direction == .down {
-				app.inc_size()
+			d := event.direction == .down
+			if event.modifiers & tui.ctrl != 0 {
+				p := event.modifiers & tui.shift == 0
+				c := if d {
+					if p { app.primary_color_idx - 1 } else { app.secondary_color_idx - 1 }
+				} else {
+					if p { app.primary_color_idx + 1 } else { app.secondary_color_idx + 1 }
+				}
+				app.select_color(p, c)
 			} else {
-				app.dec_size()
+				if d { app.inc_size() } else { app.dec_size() }
 			}
 		}
 		.key_down {
@@ -217,28 +225,22 @@ fn event(event &tui.Event, x voidptr) {
 					app.mouse_pos.x += 2
 				}
 				.t {
-					mut c := if event.modifiers & tui.shift != 0 { app.color_index - 19 } else { app.color_index +
-							19 }
-					if c < 0 {
-						c = 0
+					p := event.modifiers & tui.alt == 0
+					c := if event.modifiers & tui.shift != 0 {
+						if p { app.primary_color_idx - 19 } else { app.secondary_color_idx - 19 }
+					} else {
+						if p { app.primary_color_idx + 19 } else { app.secondary_color_idx + 19 }
 					}
-					cx := c % 19
-					cy := (c / 19) % 3
-					color := colors[cy][cx]
-					app.primary_color = color
-					app.color_index = c % (19 * 3)
+					app.select_color(p, c)
 				}
 				.r {
-					mut c := if event.modifiers & tui.shift != 0 { app.color_index - 1 } else { app.color_index +
-							1 }
-					if c < 0 {
-						c = 0
+					p := event.modifiers & tui.alt == 0
+					c := if event.modifiers & tui.shift != 0 {
+						if p { app.primary_color_idx - 1 } else { app.secondary_color_idx - 1 }
+					} else {
+						if p { app.primary_color_idx + 1 } else { app.secondary_color_idx + 1 }
 					}
-					cx := c % 19
-					cy := (c / 19) % 3
-					color := colors[cy][cx]
-					app.primary_color = color
-					app.color_index = c % (19 * 3)
+					app.select_color(p, c)
 				}
 				.plus {
 					app.inc_size()
@@ -272,6 +274,22 @@ fn (mut app App) render(paint_only bool) {
 	app.tui.flush()
 }
 
+fn (mut app App) select_color(primary bool, idx int) {
+	c := (idx + 57) % 57
+	cx := c % 19
+	cy := (c / 19) % 3
+	color := colors[cy][cx]
+	if primary {
+		app.primary_color_idx = c % (19 * 3)
+		app.primary_color = color
+	} else {
+		app.secondary_color_idx = c % (19 * 3)
+		app.secondary_color = color
+	}
+	c_str := if primary { 'primary' } else { 'secondary' }
+	app.show_msg('set $c_str color idx: $idx', 1)
+}
+
 fn (mut app App) set_pixel(x_ int, y_ int, c tui.Color) {
 	// Term coords start at 1, and adjust for the header
 	x, y := x_ - 1, y_ - 4
@@ -285,6 +303,9 @@ fn (mut app App) set_pixel(x_ int, y_ int, c tui.Color) {
 }
 
 fn (mut app App) paint(event &tui.Event) {
+	if event.y < 0 || app.tui.window_height - event.y < 3 {
+		return
+	}
 	x_start, y_start := int(f32((event.x - 1) / 2) - app.size / 2 + 1), event.y - app.size / 2
 	color := match event.button {
 		.left { app.primary_color }
@@ -374,10 +395,6 @@ fn (mut app App) draw_header() {
 	app.tui.horizontal_separator(3)
 }
 
-fn (mut app App) current_color(x int, y int) bool {
-	return app.color_index == x + (y * 19)
-}
-
 fn (mut app App) draw_footer() {
 	_, wh := app.tui.window_width, app.tui.window_height
 	app.tui.horizontal_separator(wh - 4)
@@ -386,8 +403,12 @@ fn (mut app App) draw_footer() {
 			x := j * 3 + 19
 			y := wh - 3 + i
 			app.tui.set_bg_color(color)
-			if app.current_color(j, i) {
-				app.tui.set_color(tui.Color{0, 0, 0})
+			if app.primary_color_idx == j + (i * 19) {
+				app.tui.set_color(r: 0, g: 0, b: 0)
+				app.tui.draw_text(x, y, '><')
+				app.tui.reset_color()
+			} else if app.secondary_color_idx == j + (i * 19) {
+				app.tui.set_color(r: 255, g: 255, b: 255)
 				app.tui.draw_text(x, y, '><')
 				app.tui.reset_color()
 			} else {
@@ -397,9 +418,6 @@ fn (mut app App) draw_footer() {
 	}
 	app.tui.reset_bg_color()
 	app.tui.draw_text(3, wh - 3, select_color)
-	app.tui.set_bg_color(app.primary_color)
-	app.tui.draw_text(3 + select_color.len, wh - 3, ' ')
-	app.tui.reset_bg_color()
 	app.tui.bold()
 	app.tui.draw_text(3, wh - 1, '$select_size $app.size')
 	app.tui.reset()
@@ -414,7 +432,7 @@ fn (mut app App) draw_footer() {
 
 [inline]
 fn (mut app App) inc_size() {
-	if app.size < 20 {
+	if app.size < 30 {
 		app.size++
 	}
 	app.show_msg('inc. size: $app.size', 1)
@@ -444,13 +462,7 @@ fn (mut app App) footer_click(event &tui.Event) {
 			}
 			idx := footer_y * 19 - 6 + event.x / 3
 			if idx < 0 || idx > 56 { return }
-			color := colors[idx / 19][idx % 19]
-			if event.button == .left {
-				app.primary_color = color
-			} else if event.button == .right {
-				app.secondary_color = color
-			}
-			app.show_msg('set $event.button.str().to_lower() color idx: $idx', 1)
+			app.select_color(event.button == .left, idx)
 		}
 		else {}
 	}

--- a/examples/term.ui/text_editor.v
+++ b/examples/term.ui/text_editor.v
@@ -397,7 +397,6 @@ fn (mut a App) init_file() {
 	a.ed = &Buffer{}
 	mut init_y := 0
 	mut init_x := 0
-	eprintln('> a.files: $a.files | a.current_file: $a.current_file')
 	if a.files.len > 0 && a.current_file < a.files.len && a.files[a.current_file].len > 0 {
 		if !os.is_file(a.files[a.current_file]) && a.files[a.current_file].contains(':') {
 			// support the file:line:col: format
@@ -454,8 +453,6 @@ fn event(e &tui.Event, x voidptr) {
 	if e.typ == .key_down {
 		match e.code {
 			.escape {
-				a.tui.set_cursor_position(0, 0)
-				a.tui.flush()
 				exit(0)
 			}
 			.backspace {

--- a/vlib/term/ui/input.v
+++ b/vlib/term/ui/input.v
@@ -167,8 +167,7 @@ mut:
 	termios       C.termios
 	read_buf      []byte
 	print_buf     []byte
-	// init_called  bool
-	// quit_ordered bool
+	paused        bool
 pub mut:
 	frame_count   u64
 	window_width  int
@@ -190,6 +189,7 @@ pub struct Config {
 	window_title   string
 	hide_cursor    bool
 	capture_events bool
+	use_alternate_buffer bool = true
 	// All kill signals
 	reset          []int = [1, 2, 3, 4, 6, 7, 8, 9, 11, 13, 14, 15, 19]
 }

--- a/vlib/term/ui/termios_nix.c.v
+++ b/vlib/term/ui/termios_nix.c.v
@@ -134,7 +134,7 @@ fn termios_reset() {
 	print('\x1b[?1003l\x1b[?1006l\x1b[?25h')
 	c := ctx_ptr
 	if c != 0 && c.cfg.use_alternate_buffer {
-		print('\x1b[?1049h')
+		print('\x1b[?1049l')
 	}
 	os.flush()
 }

--- a/vlib/term/ui/termios_nix.c.v
+++ b/vlib/term/ui/termios_nix.c.v
@@ -126,11 +126,17 @@ fn (mut ctx Context) termios_setup() {
 			c.event(event)
 		}
 	})
+	os.flush()
 }
 
 fn termios_reset() {
 	C.tcsetattr(C.STDIN_FILENO, C.TCSAFLUSH /* C.TCSANOW ?? */, &termios_at_startup)
-	print('\x1b[?1003l\x1b[?1006l\x1b[?1049l\x1b[?25h')
+	print('\x1b[?1003l\x1b[?1006l\x1b[?25h')
+	c := ctx_ptr
+	if c != 0 && c.cfg.use_alternate_buffer {
+		print('\x1b[?1049h')
+	}
+	os.flush()
 }
 
 ///////////////////////////////////////////


### PR DESCRIPTION
like this, whenever the app exits, the user's terminal context + scrollback info will be preserved (just like vim / nano / most other fullscreen cli apps). A nice side effect of this, is that people don't have to set the cursor's position to (0,0) when exiting, if they want to clear their app's output.

I also:
- made some changes that make the transition when pausing (i.e. ctrl. + z) and resuming apps much smoother
- made some minor improvements to the drawing example

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
