### PR TITLE
doc: use fixed-width symbol name at start of comment

### DIFF
--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -276,7 +276,12 @@ pub fn (mut d Doc) file_ast(file_ast ast.File) map[string]DocNode {
 		if d.with_comments && (prev_comments.len > 0) {
 			// last_comment := contents[contents.len - 1].comment
 			// cmt := last_comment + '\n' + get_comment_block_right_before(prev_comments)
-			cmt := get_comment_block_right_before(prev_comments)
+			mut cmt := get_comment_block_right_before(prev_comments)
+			len := node.name.len
+			// fixed-width symbol name at start of comment
+			if cmt.starts_with(node.name) && cmt.len > len && cmt[len] == ` ` {
+				cmt = '`${cmt[..len]}`' + cmt[len..]
+			}
 			node.comment = cmt
 		}
 		prev_comments = []


### PR DESCRIPTION
Doc-comments typically look like:
```v
// foo does blah
fn foo() {
```
This pull detects if the first word matches the symbol name and puts it in fixed-width Markdown formatting, e.g. '`foo` does blah'. It doesn't attempt to cover more complex occurrences of the name as these might be ambiguous or hard to detect correctly. Instead the author should manually quote the symbol name for those.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
