### PR TITLE
net: Fix bug of socket.read_line with long line

### DIFF
--- a/vlib/net/tcp_simple_client_server_test.v
+++ b/vlib/net/tcp_simple_client_server_test.v
@@ -134,3 +134,21 @@ fn test_socket_write_fail_without_panic() {
 		}
 	}
 }
+
+fn test_socket_read_line_long_line_without_eol() {
+	server, client, socket := setup()
+	mut reader := io.new_buffered_reader({
+		reader: io.make_reader(client)
+	})
+	defer {
+		cleanup(server, client, socket)
+	}
+	message := strings.repeat_string('123', 400)
+	socket.write_str(message)
+	socket.write_str('\n')
+	line := reader.read_line() or {
+		assert false
+		return
+	}
+	assert line == message
+}


### PR DESCRIPTION
I fixed a bug that that socket.read_line don't read whole line when line is long.

As a result, fixes #6813

Test:

```
fn test_socket_read_line_long_line() {
        server, client, socket := setup()
        defer {
                cleanup(server, client, socket)
        }
        message := strings.repeat_string('123', 200)
        socket.write(message) or {
                assert false
        }
        line := client.read_line()
        assert line != message
        assert line.trim_space() == message
}

```

Before: Fail

```
-------------------------------------------------------------------- Testing... -------------------------------------------------------------------
FAIL  560.711 ms vlib/net/socket_test.v

/home/zakuro/src/github.com/zakuro9715/v/vlib/net/socket_test.v:84: failed assert in function test_socket_read_line_long_line
Source  : `line.trim_space() == message`
         left value: 123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123 <= `line.trim_space()`
        right value: 123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123123 <= `message`
write to a socket without a recipient should produce an option fail: net.write: failed with -1 | a message 2
write to a socket without a recipient should produce an option fail: net.write: failed with -1 | a message 2


---------------------------------------------------------------------------------------------------------------------------------------------------
      560.990 ms <=== total time spent running V _test.v files
                 ok, fail, skip, total =     0,     1,     0,
```

After: Pass