### PR TITLE
term.ui: feature-detect the SU spec

### DIFF
--- a/vlib/term/ui/input.v
+++ b/vlib/term/ui/input.v
@@ -168,7 +168,7 @@ mut:
 	read_buf      []byte
 	print_buf     []byte
 	paused        bool
-	enable_su     bool = false
+	enable_su     bool
 pub mut:
 	frame_count   u64
 	window_width  int

--- a/vlib/term/ui/input.v
+++ b/vlib/term/ui/input.v
@@ -168,6 +168,7 @@ mut:
 	read_buf      []byte
 	print_buf     []byte
 	paused        bool
+	enable_su     bool = false
 pub mut:
 	frame_count   u64
 	window_width  int

--- a/vlib/term/ui/termios_nix.c.v
+++ b/vlib/term/ui/termios_nix.c.v
@@ -135,6 +135,9 @@ fn (mut ctx Context) termios_setup() {
 	if sx == ex && sy == ey {
 		// the terminal either ignored or handled the sequence properly, enable SU
 		ctx.enable_su = true
+	} else {
+		ctx.draw_line(sx, ex, sy, ey)
+		ctx.flush()
 	}
 
 	os.flush()

--- a/vlib/term/ui/termios_nix.c.v
+++ b/vlib/term/ui/termios_nix.c.v
@@ -126,7 +126,49 @@ fn (mut ctx Context) termios_setup() {
 			c.event(event)
 		}
 	})
+
+	// feature-test the SU spec
+	sx, sy := get_cursor_position()
+	print('\x1bP=1s\x1b\\\x1bP=2s\x1b\\')
+	ex, ey := get_cursor_position()
+
+	if sx == ex && sy == ey {
+		// the terminal either ignored or handled the sequence properly, enable SU
+		ctx.enable_su = true
+	}
+
 	os.flush()
+}
+
+fn get_cursor_position() (int, int) {
+	print('\033[6n')
+	// ESC [ YYY `;` XXX `R`
+	mut reading_x, mut reading_y := false, false
+	mut x, mut y := 0, 0
+	for i := 0; i < 15 ; i++ {
+		ch := int(C.getchar())
+		b := byte(ch)
+		i++
+		// state management:
+		if b == `R` {
+			break
+		} else if b == `[` {
+			reading_y = true
+			reading_x = false
+			continue
+		} else if b == `;` {
+			reading_y = false
+			reading_x = true
+			continue
+		}
+		// converting string vals to ints:
+		if reading_x {
+			x = x * 10 + b - byte(`0`)
+		} else if reading_y {
+			y = y * 10 + b - byte(`0`)
+		}
+	}
+	return x, y
 }
 
 fn termios_reset() {

--- a/vlib/term/ui/termios_nix.c.v
+++ b/vlib/term/ui/termios_nix.c.v
@@ -129,7 +129,7 @@ fn (mut ctx Context) termios_setup() {
 
 	// feature-test the SU spec
 	sx, sy := get_cursor_position()
-	print('\x1bP=1s\x1b\\\x1bP=2s\x1b\\')
+	print('$bsu$esu')
 	ex, ey := get_cursor_position()
 
 	if sx == ex && sy == ey {

--- a/vlib/term/ui/termios_nix.c.v
+++ b/vlib/term/ui/termios_nix.c.v
@@ -85,7 +85,8 @@ fn (mut ctx Context) termios_setup() {
 		// the terminal either ignored or handled the sequence properly, enable SU
 		ctx.enable_su = true
 	} else {
-		ctx.draw_line(sx, ex, sy, ey)
+		ctx.draw_line(sx, sy, ex, ey)
+		ctx.set_cursor_position(sx, sy)
 		ctx.flush()
 	}
 	// Prevent stdin from blocking by making its read time 0

--- a/vlib/term/ui/ui.v
+++ b/vlib/term/ui/ui.v
@@ -19,7 +19,6 @@ pub fn (c Color) hex() string {
 const (
 	bsu = '\x1bP=1s\x1b\\'
 	esu = '\x1bP=2s\x1b\\'
-	vno_bsu_esu = os.getenv('VNO_BSU_ESU').len>0
 )
 
 [inline]
@@ -34,13 +33,13 @@ pub fn (mut ctx Context) flush() {
 		// TODO
 	} $else {
 		// TODO: Diff the previous frame against this one, and only render things that changed?
-		if vno_bsu_esu {
+		if !ctx.enable_su {
 			C.write(C.STDOUT_FILENO, ctx.print_buf.data, ctx.print_buf.len)
 		} else {
 			C.write(C.STDOUT_FILENO, bsu.str, bsu.len)
 			C.write(C.STDOUT_FILENO, ctx.print_buf.data, ctx.print_buf.len)
 			C.write(C.STDOUT_FILENO, esu.str, esu.len)
-		}            
+		}
 		ctx.print_buf.clear()
 	}
 }

--- a/vlib/term/ui/ui.v
+++ b/vlib/term/ui/ui.v
@@ -1,6 +1,5 @@
 module ui
 
-import os
 import strings
 
 pub struct Color {


### PR DESCRIPTION
avoids printing trailing `=2s`'s after the mouse cursor

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
