### PR TITLE
compile: infer source file if a binary by the same name exists in same dir

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -409,6 +409,11 @@ pub fn parse_args(args []string) (&Preferences, string) {
 		res.path = args[command_pos + 1]
 		res.run_args = args[command_pos + 2..]
 		must_exist(res.path)
+		if !res.path.ends_with('.v') && os.is_executable(res.path) && os.is_file(res.path) &&
+			os.is_file(res.path + '.v') {
+			eprintln('It looks like you wanted to run `v $res.path`, so we went ahead and did that since "$res.path" is an executable.')
+			res.path += '.v'
+		}
 	}
 	if command == 'build-module' {
 		res.build_mode = .build_module


### PR DESCRIPTION
This PR allows for compiling source files inferred from an executable by the same name as long as they reside in the same dir.

You can then do:
`v examples/hanoi.v`
... and in any subsequent calls:
`v examples/hanoi`

or: 
`v run examples/hanoi.v`
... and in any subsequent calls:
`v run examples/hanoi`

This is especially useful when using shell auto completion - but also very useful to save some keystrokes

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
