### PR TITLE
v: run code from stdin `echo println(2+2) | v run -`, with no repl limits

### DIFF
--- a/cmd/v/help/run.txt
+++ b/cmd/v/help/run.txt
@@ -1,7 +1,10 @@
-Usage: v [build flags] run <file.v|directory> [arguments...]
+Usage: v [build flags] run <file.v|directory|-> [arguments...]
 
 This command is equivalent to running `v build` and running the compiled executable.
 The executable is passed the arguments as provided in [arguments...].
+
+If the target is '-', it means that the V source code to build comes from stdin.
+If '-o' option not specified, and the target is '-', a temporary base name will be used.
 
 The exit status of run will be:
 * `1` if the compilation failed.

--- a/cmd/v/help/run.txt
+++ b/cmd/v/help/run.txt
@@ -4,7 +4,7 @@ This command is equivalent to running `v build` and running the compiled executa
 The executable is passed the arguments as provided in [arguments...].
 
 If the target is '-', it means that the V source code to build comes from stdin.
-If '-o' option not specified, and the target is '-', a temporary base name will be used.
+If the '-o' option is not specified, and the target is '-', a temporary base name for the executable will be used.
 
 The exit status of run will be:
 * `1` if the compilation failed.

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -414,10 +414,10 @@ pub fn parse_args(args []string) (&Preferences, string) {
 			mut tmp_exe_file_path := res.out_name
 			mut output_option := ''
 			if tmp_exe_file_path == '' {
-				tmp_exe_file_path = os.real_path('${tmp_file_path}.exe')
+				tmp_exe_file_path = '${tmp_file_path}.exe'
 				output_option = '-o "$tmp_exe_file_path"'
 			}
-			tmp_v_file_path := os.real_path('${tmp_file_path}.v')
+			tmp_v_file_path := '${tmp_file_path}.v'
 			mut lines := []string{}
 			for {
 				iline := os.get_raw_line()

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -432,7 +432,7 @@ pub fn parse_args(args []string) (&Preferences, string) {
 			}
 			run_options := cmdline.options_before(args, ['run']).join(' ')
 			command_options := cmdline.options_after(args, ['run'])[1..].join(' ')
-			vexe := pref.vexe_path()
+			vexe := vexe_path()
 			tmp_cmd := '"$vexe" $output_option $run_options run "$tmp_v_file_path" $command_options'
 			//
 			res.vrun_elog('tmp_cmd: $tmp_cmd')
@@ -474,7 +474,6 @@ fn (pref &Preferences) vrun_elog(s string) {
 		eprintln('> v run -, $s')
 	}
 }
-
 
 fn must_exist(path string) {
 	if !os.exists(path) {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -410,7 +410,7 @@ pub fn parse_args(args []string) (&Preferences, string) {
 		res.path = args[command_pos + 1]
 		res.run_args = args[command_pos + 2..]
 		if res.path == '-' {
-			tmp_file_path := '$rand.ulid()'
+			tmp_file_path := rand.ulid()
 			mut tmp_exe_file_path := res.out_name
 			mut output_option := ''
 			if tmp_exe_file_path == '' {
@@ -418,9 +418,6 @@ pub fn parse_args(args []string) (&Preferences, string) {
 				output_option = '-o $tmp_exe_file_path'
 			}
 			tmp_v_file_path := '${tmp_file_path}.v'
-			mut fo := os.create(tmp_v_file_path) or {
-				panic('Failed to create temp file')
-			}
 			mut lines := []string{}
 			for {
 				iline := os.get_raw_line()
@@ -430,8 +427,9 @@ pub fn parse_args(args []string) (&Preferences, string) {
 				lines << iline
 			}
 			contents := lines.join('')
-			fo.write_str(contents)
-			fo.close()
+			os.write_file(tmp_v_file_path, contents) or {
+				panic('Failed to create temporary file $tmp_v_file_path')
+			}
 			run_options := cmdline.options_before(args, ['run']).join(' ')
 			command_options := cmdline.options_after(args, ['run'])[1..].join(' ')
 			result := os.system('$os.executable() $output_option $run_options run $tmp_v_file_path $command_options')

--- a/vlib/v/tests/run_v_code_from_stdin_test.v
+++ b/vlib/v/tests/run_v_code_from_stdin_test.v
@@ -1,0 +1,23 @@
+import os
+
+const (
+	vexe = os.getenv('VEXE')
+)
+
+fn test_vexe_is_set() {
+	assert vexe != ''
+}
+
+fn test_pipe_to_v_run() ? {
+	cat_cmd := if os.user_os() == 'windows' { 'type' } else { 'cat' }
+	tmp_v_file := os.join_path(os.temp_dir(), 'generated_piped_program.v')
+	os.write_file(tmp_v_file, 'println(1 + 3)\nprintln("hello")\n') ?
+	assert os.is_file(tmp_v_file)
+	cmd := '"$cat_cmd" "$tmp_v_file" | "$vexe" run -'
+	res := os.exec(cmd) ?
+	// eprintln('>> cmd: $cmd | res: $res')
+	assert res.exit_code == 0
+	assert res.output.trim_space().split('\n') == ['4', 'hello']
+	os.rm(tmp_v_file)
+	assert !os.exists(tmp_v_file)
+}


### PR DESCRIPTION
pref: support running code from stdin

Support running V code provided through stdin, rather than via a file, not using REPL.
If output target not specified, a temporary file will be created and removed.

Thanks to Spytheman for most parts of the implementation ideas.
