### PR TITLE
core: add shell auto-completion

### DIFF
--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -205,10 +205,13 @@ complete -o nospace -F _v_completions v
 }
 
 fn auto_complete_request(args []string) []string {
-	request := args.join('\n')
+	// Using space will ensure a uniform input in cases where the shell
+	// returns the completion input as a string
+	split_by := ' '
+	request := args.join(split_by)
 	mut list := []string{}
 	// new_part := request.ends_with('\n\n')
-	mut parts := request.trim_right(' ').split('\n')
+	mut parts := request.trim_right(' ').split(split_by)
 	if parts.len <= 1 { // 'v <tab>' -> top level commands.
 		for command in auto_complete_commands {
 			list << command
@@ -294,6 +297,6 @@ fn auto_complete_request(args []string) []string {
 
 fn main() {
 	args := os.args[1..]
-	// println('"$args"')
+	//println('"$args"')
 	auto_complete(args)
 }

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -19,17 +19,42 @@
 //
 // # zsh
 // TODO
-module util
+//
+// # powershell
+// TODO
+module main
 
 import os
 
-pub const (
-	auto_complete_shells = ['bash', 'fish', 'zsh']
+const (
+	auto_complete_shells = ['bash', 'fish', 'zsh', 'powershell']
 )
 
 // Snooped from cmd/v/v.v, vlib/v/pref/pref.v
-pub const (
+const (
 	auto_complete_commands  = [
+		/* simple_cmd */
+		'fmt',
+		'up',
+		'vet',
+		'self',
+		'tracev',
+		'symlink',
+		'bin2v',
+		'test',
+		'test-fmt',
+		'test-compiler',
+		'test-fixed',
+		'test-cleancode',
+		'repl',
+		'complete',
+		'build-tools',
+		'build-examples',
+		'build-vbinaries',
+		'setup-freetype',
+		'doc',
+		'doctor',
+		/* commands */
 		'help',
 		'new',
 		'init',
@@ -118,7 +143,7 @@ pub const (
 	]
 )
 
-pub fn auto_complete(args []string) {
+fn auto_complete(args []string) {
 	if args.len <= 1 || args[0] != 'complete' {
 		if args.len == 1 {
 			eprintln('auto completion require arguments to work.')
@@ -144,10 +169,10 @@ _v_completions() {
 	local limit
 	# Send all words up to the word the cursor is currently on
 	let limit=1+$COMP_CWORD
-	src=$(v complete bash "$(printf "%s\n" "${COMP_WORDS[@]: 0:$limit}")")
+	src=$(v complete bash $(printf "%s\n" ${COMP_WORDS[@]: 0:$limit}))
 	if [[ $? == 0 ]]; then
 		eval ${src}
-		#echo "${src}"
+		#echo ${src}
 	fi
 }
 
@@ -155,6 +180,7 @@ complete -o nospace -F _v_completions v
 ' }
 				// 'fish' {} //TODO see https://github.com/kovidgoyal/kitty/blob/75a94bcd96f74be024eb0a28de87ca9e15c4c995/kitty/complete.py#L113
 				// 'zsh' {} //TODO see https://github.com/kovidgoyal/kitty/blob/75a94bcd96f74be024eb0a28de87ca9e15c4c995/kitty/complete.py#L87
+				// 'powershell' {} //TODO
 				else {}
 			}
 			println(setup)
@@ -164,7 +190,7 @@ complete -o nospace -F _v_completions v
 				exit(0)
 			}
 			mut lines := []string{}
-			list := auto_complete_request(sub_args[1])
+			list := auto_complete_request(sub_args[1..])
 			for entry in list {
 				lines << "COMPREPLY+=(\'$entry\')"
 			}
@@ -172,12 +198,14 @@ complete -o nospace -F _v_completions v
 		}
 		// 'fish' {} //TODO
 		// 'zsh' {} //TODO
+		// 'powershell' {} //TODO
 		else {}
 	}
 	exit(0)
 }
 
-fn auto_complete_request(request string) []string {
+fn auto_complete_request(args []string) []string {
+	request := args.join('\n')
 	mut list := []string{}
 	// new_part := request.ends_with('\n\n')
 	mut parts := request.trim_right(' ').split('\n')
@@ -262,4 +290,10 @@ fn auto_complete_request(request string) []string {
 		}
 	}
 	return list
+}
+
+fn main() {
+	args := os.args[1..]
+	// println('"$args"')
+	auto_complete(args)
 }

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -60,6 +60,10 @@ fn main() {
 			util.launch_tool(prefs.is_verbose, 'vcreate', os.args[1..])
 			return
 		}
+		'complete' {
+			util.auto_complete(args)
+			return
+		}
 		'translate' {
 			println('Translating C to V will be available in V 0.3')
 			return

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -15,6 +15,7 @@ const (
 		'self', 'tracev', 'symlink', 'bin2v',
 		'test', 'test-fmt', 'test-compiler', 'test-fixed', 'test-cleancode',
 		'repl',
+		'complete',
 		'build-tools', 'build-examples',
 		'build-vbinaries',
 		'setup-freetype', 'doc', 'doctor'
@@ -58,10 +59,6 @@ fn main() {
 		}
 		'new', 'init' {
 			util.launch_tool(prefs.is_verbose, 'vcreate', os.args[1..])
-			return
-		}
-		'complete' {
-			util.auto_complete(args)
 			return
 		}
 		'translate' {


### PR DESCRIPTION
As title states.

This will add a way to get shell (currently only bash is implemented) auto-completion with v.
The install method and communication with the completion system is inspired from how [kitty](https://sw.kovidgoyal.net/kitty/#completion-for-kitty) achieve this. It's especially nice as it gives *live* auto-completion possibilities and has a minimal intrusion and install method.

There's still room for improvement but currently it can complete:

* `v <tab>` -> top level commands
* `v help<tab>` -> available help topics
* `v build<tab>` -> available build flags
* `v -<tab>` -> available flags
* `v <command> <tab>` -> mimic normal dir and file completion.

The mimicking of dir and file completion is done in V to minimize the interaction with the different shell autocompletion systems,
as these all have their own way of doing things. This also allows for filtering of e.g. `*.v` files in the future.

I've made placeholders for `fish` and `zsh` as these are also implemented in `kitty` - but I haven't got access or experience with these particular shells - so I hope someone will pick them up :sweat_smile:.

To install and use V auto-completion with bash, simply add this code snippet to your `~/.bashrc`:
`source /dev/stdin <<<"$(v complete setup bash)"`
On more recent versions of bash (>3.2) this version is recommended:
`source <(v complete setup bash)`

Happy `<tab><tab>`'ing

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
