### PR TITLE
vfmt: fix extra whitspace in fn type decl with type-only args

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -529,11 +529,11 @@ pub fn (mut f Fmt) type_decl(node ast.TypeDecl) {
 				should_add_type := true || is_last_arg || fn_info.params[i + 1].typ != arg.typ ||
 					(fn_info.is_variadic && i == fn_info.params.len - 2)
 				if should_add_type {
-					ns := if arg.name == '' { '' } else {' '}
+					ns := if arg.name == '' { '' } else { ' ' }
 					if fn_info.is_variadic && is_last_arg {
 						f.write(ns + '...' + s)
 					} else {
-						f.write(ns +  s)
+						f.write(ns + s)
 					}
 				}
 				if !is_last_arg {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -527,10 +527,11 @@ pub fn (mut f Fmt) type_decl(node ast.TypeDecl) {
 				should_add_type := true || is_last_arg || fn_info.params[i + 1].typ != arg.typ ||
 					(fn_info.is_variadic && i == fn_info.params.len - 2)
 				if should_add_type {
+					ns := if arg.name == '' { '' } else {' '}
 					if fn_info.is_variadic && is_last_arg {
-						f.write(' ...' + s)
+						f.write(ns + '...' + s)
 					} else {
-						f.write(' ' + s)
+						f.write(ns +  s)
 					}
 				}
 				if !is_last_arg {

--- a/vlib/v/fmt/tests/types_expected.vv
+++ b/vlib/v/fmt/tests/types_expected.vv
@@ -24,3 +24,5 @@ type TwoSameArgs = fn (i int, j int) string
 type VarArgs = fn (s ...string) int
 
 type NOVarArgs = fn (i int, s ...string) f64
+
+type NoNameArgs = fn (int, string, ...string)

--- a/vlib/v/fmt/tests/types_input.vv
+++ b/vlib/v/fmt/tests/types_input.vv
@@ -33,3 +33,5 @@ type VarArgs = fn
 (s ...string) int
 
 type NOVarArgs = fn(i int, s ...string) f64
+
+type NoNameArgs = fn( int,  string , ...string)


### PR DESCRIPTION
Fix #6759

Required for https://github.com/vlang/ui/pull/248.