### PR TITLE
js: fix code generation for `$if js` statements

### DIFF
--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -1270,7 +1270,11 @@ fn (mut g JsGen) gen_if_expr(node ast.IfExpr) {
 					}
 					else {
 						g.write('if (')
-						g.expr(branch.cond)
+						if '$branch.cond' == 'js' {
+							g.write('true')
+						} else {
+							g.expr(branch.cond)
+						}
 						g.writeln(') {')
 					}
 				}


### PR DESCRIPTION
With this patch it is possible to start porting vlib to js

```
$ cat a.v

fn main() {
	$if js {
		bar := fn () {
			println('hello from JS')
		}
		bar()
	} $else {
		println('Hello world C')
	}
}

$ v run a.v
Hello world C
$ v -o a.js a.v
$ node a.js
hello from JS
$
```