### PR TITLE
io: Add test for read_all

### DIFF
--- a/vlib/io/reader.v
+++ b/vlib/io/reader.v
@@ -15,6 +15,11 @@ pub fn make_reader(r Reader) Reader {
 	return r
 }
 
+pub const (
+	eof_code = -1
+	eof = error_with_code('EOF', eof_code)
+)
+
 const (
 	read_all_len      = 10 * 1024
 	read_all_grow_len = 1024

--- a/vlib/io/reader_test.v
+++ b/vlib/io/reader_test.v
@@ -4,12 +4,12 @@ struct Buf {
 pub:
 	bytes []byte
 mut:
-	i int
+	i     int
 }
 
 fn (mut b Buf) read(mut buf []byte) ?int {
 	if !(b.i < b.bytes.len) {
-		return error("terminated")
+		return error('terminated')
 	}
 	n := copy(buf, b.bytes[b.i..b.bytes.len])
 	b.i += n
@@ -17,12 +17,14 @@ fn (mut b Buf) read(mut buf []byte) ?int {
 }
 
 fn test_read_all() {
-	buf := Buf{bytes: "123".repeat(10).bytes()}
+	buf := Buf{
+		bytes: '123'.repeat(10).bytes()
+	}
 	res := read_all(buf) or {
 		assert false
-		"".bytes()
+		''.bytes()
 	}
-	assert res == "123".repeat(10).bytes()
+	assert res == '123'.repeat(10).bytes()
 }
 
 /*

--- a/vlib/io/reader_test.v
+++ b/vlib/io/reader_test.v
@@ -1,0 +1,38 @@
+module io
+
+struct Buf {
+pub:
+	bytes []byte
+mut:
+	i int
+}
+
+fn (mut b Buf) read(mut buf []byte) ?int {
+	if !(b.i < b.bytes.len) {
+		return error("terminated")
+	}
+	n := copy(buf, b.bytes[b.i..b.bytes.len])
+	b.i += n
+	return n
+}
+
+fn test_read_all() {
+	buf := Buf{bytes: "123".repeat(10).bytes()}
+	res := read_all(buf) or {
+		assert false
+		"".bytes()
+	}
+	assert res == "123".repeat(10).bytes()
+}
+
+/*
+TODO: This test failed by a bug of read_all
+fn test_read_all_huge() {
+	buf := Buf{bytes: "123".repeat(100000).bytes()}
+	res := read_all(buf) or {
+		assert false
+		"".bytes()
+	}
+	assert res == "123".repeat(100000).bytes()
+}
+*/

--- a/vlib/io/reader_test.v
+++ b/vlib/io/reader_test.v
@@ -9,7 +9,7 @@ mut:
 
 fn (mut b Buf) read(mut buf []byte) ?int {
 	if !(b.i < b.bytes.len) {
-		return error('terminated')
+		return eof
 	}
 	n := copy(buf, b.bytes[b.i..b.bytes.len])
 	b.i += n


### PR DESCRIPTION
Add test for io.read_all

Note: I found bug. io.read_all not works with huge data

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
