### PR TITLE
v: make `echo println(2+2)|v` same as `echo println(2+2)|v run -`

### DIFF
--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -44,10 +44,8 @@ fn main() {
 			if is_atty(0) != 0 {
 				println('Welcome to the V REPL (for help with V itself, type `exit`, then run `v help`).')
 			} else {
-				mut args_and_flags := []string{}
-				args_and_flags << util.join_env_vflags_and_os_args()[1..]
-				args_and_flags << 'run'
-				args_and_flags << '-'
+				mut args_and_flags := util.join_env_vflags_and_os_args()[1..].clone()
+				args_and_flags << ['run', '-']
 				pref.parse_args(args_and_flags)
 			}
 		}

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -40,8 +40,14 @@ fn main() {
 	// args = 123
 	if args.len == 0 || args[0] in ['-', 'repl'] {
 		// Running `./v` without args launches repl
-		if args.len == 0 && is_atty(0) != 0 {
-			println('Welcome to the V REPL (for help with V itself, type `exit`, then run `v help`).')
+		if args.len == 0 {
+			if is_atty(0) != 0 {
+				println('Welcome to the V REPL (for help with V itself, type `exit`, then run `v help`).')
+			} else {
+				mut args_and_flags := util.join_env_vflags_and_os_args()[1..]
+				args_and_flags << ['run', '-']
+				pref.parse_args(args_and_flags)
+			}
 		}
 		util.launch_tool(false, 'vrepl', os.args[1..])
 		return

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -44,8 +44,10 @@ fn main() {
 			if is_atty(0) != 0 {
 				println('Welcome to the V REPL (for help with V itself, type `exit`, then run `v help`).')
 			} else {
-				mut args_and_flags := util.join_env_vflags_and_os_args()[1..]
-				args_and_flags << ['run', '-']
+				mut args_and_flags := []string{}
+				args_and_flags << util.join_env_vflags_and_os_args()[1..]
+				args_and_flags << 'run'
+				args_and_flags << '-'
 				pref.parse_args(args_and_flags)
 			}
 		}


### PR DESCRIPTION
This PR changes the behavior of piping to v's stdin.
Before, it used to use the repl in non interactive mode, compiling a v program for each input line and running it.
Now, it uses the same behavior as the new `v run -`, i.e. slurping all of the stdin into a single v program, then running it just once.
