### PR TITLE
checker: check labelled break/continue is inside a matching `for` loop

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2384,7 +2384,8 @@ fn is_const_integer(cfield ast.ConstField) ?ast.IntegerLiteral {
 [inline]
 fn (mut c Checker) check_loop_label(label string, pos token.Position) {
 	if label.len == 0 {
-		return // ignore
+		// ignore
+		return
 	}
 	if c.loop_label.len != 0 {
 		c.error('nesting of labelled `for` loops is not supported', pos)

--- a/vlib/v/checker/tests/labelled_break_continue.out
+++ b/vlib/v/checker/tests/labelled_break_continue.out
@@ -1,0 +1,35 @@
+vlib/v/checker/tests/labelled_break_continue.vv:7:14: error: invalid label name `L2`
+    5 |         i++
+    6 |         for {
+    7 |             if i < 7 {continue L2}
+      |                       ~~~~~~~~
+    8 |             else {break L2}
+    9 |         }
+vlib/v/checker/tests/labelled_break_continue.vv:8:10: error: invalid label name `L2`
+    6 |         for {
+    7 |             if i < 7 {continue L2}
+    8 |             else {break L2}
+      |                   ~~~~~
+    9 |         }
+   10 |     }
+vlib/v/checker/tests/labelled_break_continue.vv:15:14: error: invalid label name `L1`
+   13 |         i = e
+   14 |         for {
+   15 |             if i < 3 {continue L1}
+      |                       ~~~~~~~~
+   16 |             else {break L1}
+   17 |         }
+vlib/v/checker/tests/labelled_break_continue.vv:16:10: error: invalid label name `L1`
+   14 |         for {
+   15 |             if i < 3 {continue L1}
+   16 |             else {break L1}
+      |                   ~~~~~
+   17 |         }
+   18 |     }
+vlib/v/checker/tests/labelled_break_continue.vv:21:11: error: nesting of labelled `for` loops is not supported
+   19 |     // check nested loops (not supported ATM)
+   20 |     L3: for ;; i++ {
+   21 |         L4: for {
+      |                 ^
+   22 |             if i < 17 {continue L3}
+   23 |             else {break L3}

--- a/vlib/v/checker/tests/labelled_break_continue.vv
+++ b/vlib/v/checker/tests/labelled_break_continue.vv
@@ -1,0 +1,26 @@
+fn main() {
+	mut i := 4
+	// check branching to a later loop
+	L1: for {
+		i++
+		for {
+			if i < 7 {continue L2}
+			else {break L2}
+		}
+	}
+	// check branching to an earlier loop
+	L2: for e in [1,2,3,4] {
+		i = e
+		for {
+			if i < 3 {continue L1}
+			else {break L1}
+		}
+	}
+	// check nested loops (not supported ATM)
+	L3: for ;; i++ {
+		L4: for {
+			if i < 17 {continue L3}
+			else {break L3}
+		}
+	}
+}


### PR DESCRIPTION
(Feature added in #6887).

For now don't allow nesting of labelled `for` loops.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
