### PR TITLE
v complete: add zsh auto completion support

### DIFF
--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -14,14 +14,20 @@
 // On more recent versions of bash (>3.2) this should suffice:
 // `source <(v complete setup bash)`
 //
-// # fish
-// TODO
+// # fish // TODO
 //
 // # zsh
-// TODO
+// To install auto-completion for V in zsh - please add the following to your ~/.zshrc:
+// ```
+// autoload -Uz compinit
+// compinit
+// # Completion for v
+// v complete setup zsh | source /dev/stdin
+// ```
+// # It's important is to make sure the call to v to load the zsh completions happens after the call to compinit
 //
-// # powershell
-// TODO
+// # powershell //TODO
+//
 module main
 
 import os
@@ -219,7 +225,7 @@ _v_completions() {
 complete -o nospace -F _v_completions v
 ' }
 				// 'fish' {} //TODO see https://github.com/kovidgoyal/kitty/blob/75a94bcd96f74be024eb0a28de87ca9e15c4c995/kitty/complete.py#L113
-				'zsh' { //TODO see https://github.com/kovidgoyal/kitty/blob/75a94bcd96f74be024eb0a28de87ca9e15c4c995/kitty/complete.py#L87
+				'zsh' {
 					setup = '
 #compdef v
 _v() {
@@ -250,7 +256,7 @@ compdef _v v
 			println(lines.join('\n'))
 		}
 		// 'fish' {} //TODO
-		'zsh' { //TODO
+		'zsh' {
 			if sub_args.len <= 1 {
 				exit(0)
 			}

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -225,8 +225,7 @@ _v_completions() {
 complete -o nospace -F _v_completions v
 ' }
 				// 'fish' {} //TODO see https://github.com/kovidgoyal/kitty/blob/75a94bcd96f74be024eb0a28de87ca9e15c4c995/kitty/complete.py#L113
-				'zsh' {
-					setup = '
+				'zsh' { setup = '
 #compdef v
 _v() {
     local src
@@ -238,7 +237,7 @@ _v() {
     fi
 }
 compdef _v v
-'}
+' }
 				// 'powershell' {} //TODO
 				else {}
 			}
@@ -263,7 +262,7 @@ compdef _v v
 			mut lines := []string{}
 			list := auto_complete_request(sub_args[1..])
 			for entry in list {
-				lines << "compadd -U -S \"\" -- \'$entry\';"
+				lines << 'compadd -U -S \"\" -- \'$entry\';'
 			}
 			println(lines.join('\n'))
 		}

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -219,7 +219,20 @@ _v_completions() {
 complete -o nospace -F _v_completions v
 ' }
 				// 'fish' {} //TODO see https://github.com/kovidgoyal/kitty/blob/75a94bcd96f74be024eb0a28de87ca9e15c4c995/kitty/complete.py#L113
-				// 'zsh' {} //TODO see https://github.com/kovidgoyal/kitty/blob/75a94bcd96f74be024eb0a28de87ca9e15c4c995/kitty/complete.py#L87
+				'zsh' { //TODO see https://github.com/kovidgoyal/kitty/blob/75a94bcd96f74be024eb0a28de87ca9e15c4c995/kitty/complete.py#L87
+					setup = '
+#compdef v
+_v() {
+    local src
+    # Send all words up to the word the cursor is currently on
+    src=\$($vexe complete zsh \$(printf "%s\\n" \${(@)words[1,\$CURRENT]}))
+    if [[ \$? == 0 ]]; then
+        eval \${src}
+        #echo \${src}
+    fi
+}
+compdef _v v
+'}
 				// 'powershell' {} //TODO
 				else {}
 			}
@@ -237,7 +250,17 @@ complete -o nospace -F _v_completions v
 			println(lines.join('\n'))
 		}
 		// 'fish' {} //TODO
-		// 'zsh' {} //TODO
+		'zsh' { //TODO
+			if sub_args.len <= 1 {
+				exit(0)
+			}
+			mut lines := []string{}
+			list := auto_complete_request(sub_args[1..])
+			for entry in list {
+				lines << "compadd -U -S \"\" -- \'$entry\';"
+			}
+			println(lines.join('\n'))
+		}
 		// 'powershell' {} //TODO
 		else {}
 	}

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -228,13 +228,13 @@ complete -o nospace -F _v_completions v
 				'zsh' { setup = '
 #compdef v
 _v() {
-    local src
-    # Send all words up to the word the cursor is currently on
-    src=\$($vexe complete zsh \$(printf "%s\\n" \${(@)words[1,\$CURRENT]}))
-    if [[ \$? == 0 ]]; then
-        eval \${src}
-        #echo \${src}
-    fi
+	local src
+	# Send all words up to the word the cursor is currently on
+	src=\$($vexe complete zsh \$(printf "%s\\n" \${(@)words[1,\$CURRENT]}))
+	if [[ \$? == 0 ]]; then
+		eval \${src}
+		#echo \${src}
+	fi
 }
 compdef _v v
 ' }


### PR DESCRIPTION
As title states - ~~preliminary~~ support for `zsh` auto-completion.

I don't use zsh personally so I've done this "in the blind" via a small Docker container.

Users of `zsh` will most likely have to chip in.

To get it to work add these lines to your `~/.zshrc`:
```
autoload -Uz compinit
compinit
# Completion for v
v complete setup zsh | source /dev/stdin
```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
