### PR TITLE
tools/vcomplete: add fish auto completion support

### DIFF
--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -231,7 +231,7 @@ complete -o nospace -F _v_completions v
 					setup = '
 function __v_completions
     # Send all words up to the one before the cursor
-    \$vexe complete fish (commandline -cop)
+    $vexe complete fish (commandline -cop)
 end
 complete -f -c v -a "(__v_completions)"
 '}

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -27,7 +27,7 @@
 // # Completion for v
 // v complete setup zsh | source /dev/stdin
 // ```
-// # It's important is to make sure the call to v to load the zsh completions happens after the call to compinit
+// Please note that you should let v load the zsh completions after the call to compinit
 //
 // # powershell //TODO
 //

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -9,15 +9,18 @@
 // auto-completion features.
 //
 // # bash
-// To install auto-completion for V in bash, simply add this code to your ~/.bashrc:
+// To install auto-completion for V in bash, simply add this code to your `~/.bashrc`:
 // `source /dev/stdin <<<"$(v complete setup bash)"`
 // On more recent versions of bash (>3.2) this should suffice:
 // `source <(v complete setup bash)`
 //
-// # fish // TODO
+// # fish
+// For versions of fish <3.0.0, add the following to your `~/.config/fish/config.fish`
+// `v complete setup fish | source`
+// Later versions of fish source completions by default.
 //
 // # zsh
-// To install auto-completion for V in zsh - please add the following to your ~/.zshrc:
+// To install auto-completion for V in zsh - please add the following to your `~/.zshrc`:
 // ```
 // autoload -Uz compinit
 // compinit
@@ -224,7 +227,14 @@ _v_completions() {
 
 complete -o nospace -F _v_completions v
 ' }
-				// 'fish' {} //TODO see https://github.com/kovidgoyal/kitty/blob/75a94bcd96f74be024eb0a28de87ca9e15c4c995/kitty/complete.py#L113
+				'fish' {
+					setup = '
+function __v_completions
+    # Send all words up to the one before the cursor
+    \$vexe complete fish (commandline -cop)
+end
+complete -f -c v -a "(__v_completions)"
+'}
 				'zsh' { setup = '
 #compdef v
 _v() {
@@ -254,7 +264,17 @@ compdef _v v
 			}
 			println(lines.join('\n'))
 		}
-		// 'fish' {} //TODO
+		'fish' {
+			if sub_args.len <= 1 {
+				exit(0)
+			}
+			mut lines := []string{}
+			list := auto_complete_request(sub_args[1..])
+			for entry in list {
+				lines << "\'$entry\'"
+			}
+			println(lines.join('\n'))
+		}
 		'zsh' {
 			if sub_args.len <= 1 {
 				exit(0)

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -227,14 +227,13 @@ _v_completions() {
 
 complete -o nospace -F _v_completions v
 ' }
-				'fish' {
-					setup = '
+				'fish' { setup = '
 function __v_completions
     # Send all words up to the one before the cursor
     $vexe complete fish (commandline -cop)
 end
 complete -f -c v -a "(__v_completions)"
-'}
+' }
 				'zsh' { setup = '
 #compdef v
 _v() {
@@ -271,7 +270,7 @@ compdef _v v
 			mut lines := []string{}
 			list := auto_complete_request(sub_args[1..])
 			for entry in list {
-				lines << "$entry"
+				lines << '$entry'
 			}
 			println(lines.join('\n'))
 		}

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -229,8 +229,8 @@ complete -o nospace -F _v_completions v
 ' }
 				'fish' { setup = '
 function __v_completions
-    # Send all words up to the one before the cursor
-    $vexe complete fish (commandline -cop)
+	# Send all words up to the one before the cursor
+	$vexe complete fish (commandline -cop)
 end
 complete -f -c v -a "(__v_completions)"
 ' }

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -271,7 +271,7 @@ compdef _v v
 			mut lines := []string{}
 			list := auto_complete_request(sub_args[1..])
 			for entry in list {
-				lines << "\'$entry\'"
+				lines << "$entry"
 			}
 			println(lines.join('\n'))
 		}


### PR DESCRIPTION
As title states - support for `fish` auto-completion.

I don't use `fish` personally so I've done this "in the blind" via a small Docker container (like I did with zsh).

Users of `fish` will most likely have to chip in.

To get it to work add these lines to your `~/.config/fish/config.fish`:
```
v complete setup fish | source
```

Some [sources describe](https://sw.kovidgoyal.net/kitty/#fish) that fish versions >3.0.0 will source completions automatically - however I haven't been able to confirm this in the version of fish I used in the Docker dev environment.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
