### PR TITLE
fmt: do not wrap real multiline comments into single line in arrays 

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -85,16 +85,6 @@ pub fn (mut f Fmt) process_file_imports(file &ast.File) {
 	}
 }
 
-/*
-fn (mut f Fmt) find_comment(line_nr int) {
-	for comment in f.file.comments {
-		if comment.line_nr == line_nr {
-			f.writeln('// FFF $comment.line_nr $comment.text')
-			return
-		}
-	}
-}
-*/
 pub fn (mut f Fmt) write(s string) {
 	if !f.buffering {
 		if f.indent > 0 && f.empty_line {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1224,8 +1224,14 @@ struct CommentsOptions {
 
 pub fn (mut f Fmt) comment(node ast.Comment, options CommentsOptions) {
 	if options.iembed {
-		x := node.text.replace('\n', ' ').trim_left('\x01')
-		f.write('/* $x */')
+		x := node.text.trim_left('\x01')
+		if x.contains('\n') {
+			f.writeln('/*')
+			f.writeln(x)
+			f.write('*/')
+		} else {
+			f.write('/* $x */')
+		}
 		return
 	}
 	if !node.text.contains('\n') {

--- a/vlib/v/fmt/tests/array_init_keep.vv
+++ b/vlib/v/fmt/tests/array_init_keep.vv
@@ -6,4 +6,13 @@ fn main() {
 		2,
 		/* test 2 */
 	]
+	arr2 := [
+		'foo',
+		/*
+		'bar',
+		'baz',
+		'spam',
+		*/
+		'eggs',
+	]
 }


### PR DESCRIPTION
Consider this code
```v
arr := [
  'foo',
  /*
  'bar',
  'spam',
  */
  'eggs',
]
```
Before this PR it got formatted to 
```v
arr := [
  'foo',
  /* 'bar',  'spam', */
  'eggs',
]
```
Now it will stay as is.