### PR TITLE
js: initial support for optional return unwrapping

### DIFF
--- a/vlib/builtin/js/builtin.v
+++ b/vlib/builtin/js/builtin.v
@@ -37,7 +37,52 @@ pub fn exit(c int) {
 	JS.process.exit(c)
 }
 
+pub fn unwrap(opt any) any {
+	o := &Option(opt)
+	if o.not_ok {
+		panic(o.error)
+		return o.error
+	}
+	return opt
+}
+
 pub fn panic(s string) {
 	eprintln('V panic: $s')
 	exit(1)
+}
+
+
+struct Option {
+	not_ok  bool
+	is_none bool
+	error   string
+	ecode   int
+	data    any
+}
+
+pub fn (o Option) str() string {
+   if !o.not_ok {
+	  return 'Option{ ok }'
+   }
+   if o.is_none {
+	  return 'Option{ none }'
+   }
+   return 'Option{ error: "${o.error}" }'
+}
+
+pub fn error(s string) Option {
+	return Option{
+		not_ok: true
+		is_none: false
+		error: s
+	}
+}
+
+pub fn error_with_code(s string, code int) Option {
+	return Option{
+		not_ok: true
+		is_none: false
+		error: s
+		ecode: code
+	}
 }

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -1175,6 +1175,10 @@ fn (mut g JsGen) gen_call_expr(it ast.CallExpr) {
 	} else {
 		name = g.js_name(it.name)
 	}
+	call_return_is_optional := it.return_type.has_flag(.optional)
+	if call_return_is_optional {
+		g.write('builtin.unwrap(')
+	}
 	g.expr(it.left)
 	if it.is_method { // foo.bar.baz()
 		sym := g.table.get_type_symbol(it.receiver_type)
@@ -1224,7 +1228,11 @@ fn (mut g JsGen) gen_call_expr(it ast.CallExpr) {
 			g.write(', ')
 		}
 	}
-	g.write(')')
+	if call_return_is_optional {
+		g.write('))')
+	} else {
+		g.write(')')
+	}
 }
 
 fn (mut g JsGen) gen_ident(node ast.Ident) {


### PR DESCRIPTION
Using this sample:

```go
$ cat test.v
struct Test {
        name string
}

fn res() ?string {
        // return 'hello' 
        return error('this fails')
}

fn main() {
        foo := &Test{'pepito'}
        println('hello world $foo.name')
        if foo.name == 'pepito' {
                // res()?
                a := res() or { panic(err) }
                println(a)
        }
}
$
```

the current code generated is like this:

```
println(res());
```

even using the commneted line (res()?) it never handles the `return error()`. with this patch the error is handled as a panic.

there are probably better ways to unwrap the error type and maybe we should use `Error` natively and throw/catch to handle the errors on different constructions? Also, may be good to add some tests but i dont know how/where to add it.