### PR TITLE
builder: fix wrong file extension

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -288,6 +288,8 @@ fn (mut v Builder) cc() {
 		args << '-fPIC' // -Wl,-z,defs'
 		$if macos {
 			v.pref.out_name += '.dylib'
+		} $else $if windows {
+			v.pref.out_name += '.dll'
 		} $else {
 			v.pref.out_name += '.so'
 		}


### PR DESCRIPTION
On Windows, tcc and gcc create shared libraries with the .so extension,
because of the missing Windows OS check. This PR fixes the problem.

Fixes: #6940