### PR TITLE
make.bat: update convention to be consistent and add target support

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -210,7 +210,7 @@ where /q tcc
 if %ERRORLEVEL% NEQ 0 (
 	if !compiler! == "fresh-tcc" (
         echo  ^> Clean TCC directory
-        call :buildcmd "rmdir /s /q "%tcc_dir%" "  "
+        call :buildcmd "rmdir /s /q "%tcc_dir%"" "  "
         set /a valid_cc=1
     ) else if !compiler! == "tcc" set /a valid_cc=1
     if not exist %tcc_dir% (

--- a/make.bat
+++ b/make.bat
@@ -118,7 +118,7 @@ if !compiler! == "gcc" goto :gcc_strap
 if !compiler! == "msvc" goto :msvc_strap
 if !compiler! == "tcc" goto :tcc_strap
 if !compiler! == "fresh-tcc" goto :tcc_strap
-if [!compiler!] == [""] goto :gcc_strap
+if [!compiler!] == [""] goto :clang_strap
 
 :clang_strap
 where /q clang
@@ -177,7 +177,7 @@ if "%PROCESSOR_ARCHITECTURE%" == "x86" (
 
 if not exist "%VsWhereDir%\Microsoft Visual Studio\Installer\vswhere.exe" (
 	echo  ^> MSVC not found
-	if not !compiler! == "" goto :error
+	if not [!compiler!] == [""] goto :error
 	goto :tcc_strap
 )
 


### PR DESCRIPTION
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
This commit adds preliminary target support into the existing parsing routine using `shift`(e.g `make <target>), as well as fix some inconsistencies of style, conventions and minor typos. It also adds a `help` target to display detailed usage help for each subcommand(target).

Additions:
- Add subcommands to parsing block
- Add subcommand usage help
- Add `eof` label for jump, future proofing for when the `version` label may not be the last step

Modifications:
- Fixed certain capitialization and case issues on comments
- Revised convention to use `==` for explicit string comparison, and command extensions(e.g `EQU`, `NEQ`, etc0 for numerical comparison. Variables that contain path are modified to be wrapped instead of encapsulated in quotes, this allows concatenation of paths to be easier without expansions. Trim spaces after all inline commands as they could lead to undesired side effects(`set` in particular consumes all character up to a line terminator if the value type is not a number). Wrap `[]` around potential unset or empty variables in if comparisons to detect whitespaces and special escapes.
- Fixed redundant redirections of stdout through calling `buildcmd` label
- Factored the VC github repository link as a variable, for future proofing and ease of access

Deletion:
- Removed deprecated `-h/--help` option for parsing block and usage help