### PR TITLE
vup: minor change to final output string

### DIFF
--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -93,7 +93,7 @@ fn (app App) show_current_v_version() {
 			latest_v_commit := vversion.split(' ').last().all_after('.')
 			if latest_v_commit_time := os.exec('git show -s --format=%ci $latest_v_commit') {
 				if latest_v_commit_time.exit_code == 0 {
-					vversion += ', commited at ' + latest_v_commit_time.output.trim_space()
+					vversion += ', last commit: ' + latest_v_commit_time.output.trim_space()
 				}
 			}
 		}

--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -93,7 +93,7 @@ fn (app App) show_current_v_version() {
 			latest_v_commit := vversion.split(' ').last().all_after('.')
 			if latest_v_commit_time := os.exec('git show -s --format=%ci $latest_v_commit') {
 				if latest_v_commit_time.exit_code == 0 {
-					vversion += ', last commit: ' + latest_v_commit_time.output.trim_space()
+					vversion += ', timestamp: ' + latest_v_commit_time.output.trim_space()
 				}
 			}
 		}


### PR DESCRIPTION
Final line of output from successful `v up` is currently like this:

`V 0.1.29 fa126b9, commited at 2020-11-25 15:47:55 +0200`

First, it should be `committed` or just `commit`, but the phrasing is also awkward to have " at `date` `time`".  It would be more correct as " on `date` at `time`" or " on `date` @ `time`".  However, that would involve more code to manipulate the output from `git`, which isn't required for this simple message.

This PR changes the output to a simpler, more correct/less awkward message:

`V 0.1.29 fa126b9, timestamp: 2020-11-25 15:47:55 +0200`
