### PR TITLE
gen: more efficient `for in` with a map

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1180,7 +1180,6 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		val_sym := g.table.get_type_symbol(it.val_type)
 		idx := g.new_tmp_var()
 		key := if it.key_var in ['', '_'] { g.new_tmp_var() } else { it.key_var }
-		zero := g.type_default(it.val_type)
 		atmp := g.new_tmp_var()
 		atmp_styp := g.typ(it.cond_type)
 		g.write('$atmp_styp $atmp = ')
@@ -1195,12 +1194,13 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 			g.writeln('\t$key_styp $key = /*kkkk*/ $atmp\.key_values.keys[$idx];')
 		}
 		if it.val_var != '_' {
+			valstr := '(void*)($atmp\.key_values.values + $idx * (u32)($atmp\.value_bytes))'
 			if val_sym.kind == .function {
 				g.write('\t')
 				g.write_fn_ptr_decl(val_sym.info as table.FnType, c_name(it.val_var))
-				g.writeln(' = (*(voidptr*)map_get($atmp, $key, &(voidptr[]){ $zero }));')
+				g.writeln(' = (*(voidptr*)$valstr);')
 			} else {
-				g.writeln('\t$val_styp ${c_name(it.val_var)} = (*($val_styp*)map_get($atmp, $key, &($val_styp[]){ $zero }));')
+				g.writeln('\t$val_styp ${c_name(it.val_var)} = (*($val_styp*)$valstr);')
 			}
 		}
 		g.stmts(it.stmts)

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1178,7 +1178,6 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		key_styp := g.typ(it.key_type)
 		val_styp := g.typ(it.val_type)
 		val_sym := g.table.get_type_symbol(it.val_type)
-		keys_tmp := 'keys_' + g.new_tmp_var()
 		idx := g.new_tmp_var()
 		key := if it.key_var in ['', '_'] { g.new_tmp_var() } else { it.key_var }
 		zero := g.type_default(it.val_type)
@@ -1187,13 +1186,13 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		g.write('$atmp_styp $atmp = ')
 		g.expr(it.cond)
 		g.writeln(';')
-		g.writeln('array_$key_styp $keys_tmp = map_keys(&$atmp);')
-		g.writeln('for (int $idx = 0; $idx < ${keys_tmp}.len; ++$idx) {')
+		g.writeln('for (int $idx = 0; $idx < $atmp\.key_values.len; ++$idx) {')
+		g.writeln('\tif ($atmp\.key_values.keys[$idx].str == 0) {continue;}')
 		// TODO: analyze whether it.key_type has a .clone() method and call .clone() for all types:
 		if it.key_type == table.string_type {
-			g.writeln('\t$key_styp $key = /*kkkk*/ string_clone( (($key_styp*)${keys_tmp}.data)[$idx] );')
+			g.writeln('\t$key_styp $key = /*kkkk*/ string_clone($atmp\.key_values.keys[$idx]);')
 		} else {
-			g.writeln('\t$key_styp $key = /*kkkk*/ (($key_styp*)${keys_tmp}.data)[$idx];')
+			g.writeln('\t$key_styp $key = /*kkkk*/ $atmp\.key_values.keys[$idx];')
 		}
 		if it.val_var != '_' {
 			if val_sym.kind == .function {
@@ -1215,9 +1214,6 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		if it.label.len > 0 {
 			g.writeln('\t$it.label\__break: {}')
 		}
-		g.writeln('/*for in map cleanup*/')
-		g.writeln('for (int $idx = 0; $idx < ${keys_tmp}.len; ++$idx) { string_free(&(($key_styp*)${keys_tmp}.data)[$idx]); }')
-		g.writeln('array_free(&$keys_tmp);')
 		return
 	} else if it.cond_type.has_flag(.variadic) {
 		g.writeln('// FOR IN cond_type/variadic')

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1179,7 +1179,6 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		val_styp := g.typ(it.val_type)
 		val_sym := g.table.get_type_symbol(it.val_type)
 		idx := g.new_tmp_var()
-		key := if it.key_var in ['', '_'] { g.new_tmp_var() } else { it.key_var }
 		atmp := g.new_tmp_var()
 		atmp_styp := g.typ(it.cond_type)
 		g.write('$atmp_styp $atmp = ')
@@ -1187,11 +1186,14 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		g.writeln(';')
 		g.writeln('for (int $idx = 0; $idx < $atmp\.key_values.len; ++$idx) {')
 		g.writeln('\tif ($atmp\.key_values.keys[$idx].str == 0) {continue;}')
-		// TODO: analyze whether it.key_type has a .clone() method and call .clone() for all types:
-		if it.key_type == table.string_type {
-			g.writeln('\t$key_styp $key = /*kkkk*/ string_clone($atmp\.key_values.keys[$idx]);')
-		} else {
-			g.writeln('\t$key_styp $key = /*kkkk*/ $atmp\.key_values.keys[$idx];')
+		if it.key_var != '_' {
+			key := c_name(it.key_var)
+			// TODO: analyze whether it.key_type has a .clone() method and call .clone() for all types:
+			if it.key_type == table.string_type {
+				g.writeln('\t$key_styp $key = /*kkkk*/ string_clone($atmp\.key_values.keys[$idx]);')
+			} else {
+				g.writeln('\t$key_styp $key = /*kkkk*/ $atmp\.key_values.keys[$idx];')
+			}
 		}
 		if it.val_var != '_' {
 			valstr := '(void*)($atmp\.key_values.values + $idx * (u32)($atmp\.value_bytes))'

--- a/vlib/v/tests/blank_ident_test.v
+++ b/vlib/v/tests/blank_ident_test.v
@@ -103,9 +103,11 @@ fn test_for_in_map_val() {
 }
 
 fn test_for_in_map_both() {
+	mut i := 0
 	for _, _ in m {
-		assert true
+		i++
 	}
+	assert i == 1
 }
 
 fn test_nested_for_in_map_key() {
@@ -127,11 +129,13 @@ fn test_nested_for_in_map_val() {
 }
 
 fn test_nested_for_in_map_both() {
+	mut i := 0
 	for _, _ in m {
 		for _, _ in m {
-			assert true
+			i++
 		}
 	}
+	assert i == 1
 }
 
 fn fn_for_in_variadic_args_simple(arr ...string) {

--- a/vlib/v/tests/for_loops_test.v
+++ b/vlib/v/tests/for_loops_test.v
@@ -49,10 +49,17 @@ fn test_for_string_in_map() {
 		'c': 'd'
 	}
 	mut acc := ''
-	for k, char in m {
-		acc += '$k: $char, '
+	for k, v in m {
+		acc += '$k: $v, '
 	}
 	assert acc == 'a: b, c: d, '
+
+	m2 := {'a': 3, 'b': 4}
+	acc = ''
+	for k, v in m2 {
+		acc += '$k: $v, '
+	}
+	assert acc == 'a: 3, b: 4, '
 }
 
 fn test_mut_for() {

--- a/vlib/v/tests/for_loops_test.v
+++ b/vlib/v/tests/for_loops_test.v
@@ -43,7 +43,7 @@ fn test_for_char_in_string() {
 	assert sum == 394 // ascii codes of `a` + `b` + `c` + `d`
 }
 
-fn test_for_char_in_map() {
+fn test_for_string_in_map() {
 	m := {
 		'a': 'b'
 		'c': 'd'

--- a/vlib/v/tests/for_loops_test.v
+++ b/vlib/v/tests/for_loops_test.v
@@ -54,12 +54,13 @@ fn test_for_string_in_map() {
 	}
 	assert acc == 'a: b, c: d, '
 
-	m2 := {'a': 3, 'b': 4}
+	mut m2 := {'a': 3, 'b': 4, 'c': 5}
+	m2.delete('b')
 	acc = ''
 	for k, v in m2 {
 		acc += '$k: $v, '
 	}
-	assert acc == 'a: 3, b: 4, '
+	assert acc == 'a: 3, c: 5, '
 }
 
 fn test_mut_for() {


### PR DESCRIPTION
gen: don't allocate keys array with `for in` on a map
gen: avoid looking up map value from key
gen: don't declare key variable if not needed

The existing code calls `map::keys`, but we can do that iteration ourselves. Valid indexes for keys are the same indexes needed for values, so no need to call `map::get`.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
