### PR TITLE
parser: remove unnecessary match as code

### DIFF
--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -247,10 +247,6 @@ pub fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_iden
 			node = p.index_expr(node)
 			p.is_stmt_ident = is_stmt_ident
 		} else if p.tok.kind == .key_as {
-			// sum type match `match x as alias` so return early
-			if p.inside_match {
-				return node
-			}
 			// sum type as cast `x := SumType as Variant`
 			pos := p.tok.position()
 			p.next()


### PR DESCRIPTION
`as` in `match` doesn't exist anymore