### PR TITLE
szip: fix szip_test

### DIFF
--- a/vlib/szip/szip_test.v
+++ b/vlib/szip/szip_test.v
@@ -2,8 +2,12 @@ import szip
 import os
 
 fn test_compile() {
-	szip.open('test_compile.zip', szip.best_speed, szip.m_write) or {
+	mut z := szip.open('test_compile.zip', szip.best_speed, szip.m_write) or {
 		assert false
+		return
 	}
-	os.rm('test_compile.zip') or { }
+	defer {
+		z.close()
+		os.rm('test_compile.zip') or { }
+	}
 }


### PR DESCRIPTION
This PR fixes szip_test.

- Problem
The `test_compile.zip` will remain after  `szip_test` test.

- Reson
After szip.open(), the zip file cannot be deleted without closing.

- Method
```
fn test_compile() {
	mut z := szip.open('test_compile.zip', szip.best_speed, szip.m_write) or {
		assert false
		return
	}
	defer {
		z.close()
		os.rm('test_compile.zip') or { }
	}
}
```
