### PR TITLE
make.bat: parsing block revision

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -236,7 +236,7 @@ if %ERRORLEVEL% NEQ 0 (
     popd
     set "tcc_exe=%tcc_dir%\tcc.exe"
 ) else (
-	for /f "delims=" %%i in ('where tcc') do set "tcc_exe=%%i"
+	for /f "usebackq delims=" %%i in (`where tcc`) do set "tcc_exe=%%i"
 )
 
 echo  ^> Updating prebuilt TCC...

--- a/make.bat
+++ b/make.bat
@@ -2,23 +2,24 @@
 setlocal EnableDelayedExpansion EnableExtensions
 
 REM Option flags
-set /a valid_cc=0
-set /a use_local=0
-set /a verbose_log=0
+set /a invalid_cc=0
 set /a shift_counter=0
+set /a flag_local=0
+set /a flag_verbose=0
 
 REM Option variables
-set log_file="%TEMP%\v_make.log"
-set compiler=""
-set target=""
+set "log_file=%TEMP%\v_make.log"
+set compiler=
+set subcmd=
+set target=build
 
-REM tcc variables
+REM TCC variables
 set "tcc_url=https://github.com/vlang/tccbin_win.git"
 set "tcc_dir=%~dp0thirdparty\tcc"
 set "vc_url=https://github.com/vlang/vc.git"
 set "vc_dir=%~dp0vc"
 
-REM Let a particular environment specify their own tcc repo
+REM Let a particular environment specify their own TCC repo
 if /I not ["%TCC_GIT%"] == [""] set "tcc_url=%TCC_GIT%"
 
 pushd %~dp0
@@ -29,41 +30,36 @@ if ["%~1"] == [""] goto :init
 
 REM Target options
 if !shift_counter! LSS 1 (
-    if "%~1" == "build" set target="build"& shift& set /a shift_counter+=1& goto :verifyopt
-    if "%~1" == "clean" set target="clean"& shift& set /a shift_counter+=1& goto :verifyopt
-    if "%~1" == "clean-all" set target="clean-all"& shift& set /a shift_counter+=1& goto :verifyopt
     if "%~1" == "help" (
-        if "%~2" == "build" call :help_build& exit /b %ERRORLEVEL%
-        if "%~2" == "clean" call :help_clean& exit /b %ERRORLEVEL%
-        if "%~2" == "clean-all" call :help_cleanall& exit /b %ERRORLEVEL%
-        if "%~2" == "help" call :help_help& exit /b %ERRORLEVEL%
-        if ["%~2"] == [""] call :usage& exit /b %ERRORLEVEL%
-        shift
+        if not ["%~2"] == [""] set "subcmd=%~2"& shift& set /a shift_counter+=1
+    )
+    for %%z in (build clean cleanall help) do (
+        if "%~1" == "%%z" set target=%1& shift& set /a shift_counter+=1& goto :verifyopt
     )
 )
 
 REM Compiler option
-if "%~1" == "-gcc" set compiler="gcc"& set /a shift_counter+=1& shift& goto :verifyopt
-if "%~1" == "-msvc" set compiler="msvc"& set /a shift_counter+=1& shift& goto :verifyopt
-if "%~1" == "-tcc" set compiler="tcc"& set /a shift_counter+=1& shift& goto :verifyopt
-if "%~1" == "-fresh-tcc" set compiler="fresh-tcc"& set /a shift_counter+=1& shift& goto :verifyopt
-if "%~1" == "-clang" set compiler="clang"& set /a shift_counter+=1& shift& goto :verifyopt
+for %%g in (-gcc -msvc -tcc -fresh-tcc -clang) do (
+    if "%~1" == "%%g" set compiler=%~1& set compiler=!compiler:~1!& shift& set /a shift_counter+=1& goto :verifyopt
+)
 
 REM Standard options
-if "%~1" == "--local" (
-    if !use_local! EQU 0 set /a use_local=1
-    set /a shift_counter+=1
-    shift
-    goto :verifyopt
-)
-if "%~1" == "-v" (
-    if !verbose_log! EQU 0 set /a verbose_log=1
-    set /a shift_counter+=1
-    shift
-    goto :verifyopt
-)
 if "%~1" == "--verbose" (
-    if !verbose_log! EQU 0 set /a verbose_log=1
+    if !flag_verbose! NEQ 0 (
+        echo The flag %~1 has already been specified. 1>&2
+        exit /b 2
+    )
+    set /a flag_verbose=1
+    set /a shift_counter+=1
+    shift
+    goto :verifyopt
+)
+if "%~1" == "--local" (
+    if !flag_local! NEQ 0 (
+        echo The flag %~1 has already been specified. 1>&2
+        exit /b 2
+    )
+    set /a flag_local=1
     set /a shift_counter+=1
     shift
     goto :verifyopt
@@ -78,25 +74,50 @@ if "%~1" == "--logfile" (
         exit /b 2
     )
     popd
-    set log_file="%~sf2"
+    set "log_file=%~sf2"
     set /a shift_counter+=2
     shift
     shift
     goto :verifyopt
 )
+
 echo Undefined option: %~1
 exit /b 2
 
 :init
-if !target! == "build" goto :build
-if !target! == "clean" echo Cleanup build artifacts& goto :clean
-if !target! == "clean-all" echo Cleanup all& goto :cleanall
-if [!target!] == [""] goto :build
+goto :!target!
+
+:cleanall
+call :clean
+echo.
+echo Cleanup vc
+echo  ^> Purge TCC binaries
+call :buildcmd "rmdir /s /q "%tcc_dir%"" "  "
+echo  ^> Purge vc repository
+call :buildcmd "rmdir /s /q "%vc_dir%"" "  "
+exit /b 0
+
+:clean
+echo Cleanup build artifacts
+echo  ^> Purge debug symbols
+call :buildcmd "del *.pdb *.lib *.bak *.out *.ilk *.exp *.obj *.o *.a *.so" "  "
+echo  ^> Delete old V executable
+call :buildcmd "del v_old.exe v*.exe" "  "
+exit /b 0
+
+:help
+if [!subcmd!] == [] (
+    call :usage 2>NUL
+) else (
+    call :help_!subcmd! 2>NUL
+)
+if %ERRORLEVEL% NEQ 0 echo Invalid subcommand: !subcmd!
+exit /b %ERRORLEVEL%
 
 :build
-del !log_file!>NUL 2>&1
-if !use_local! NEQ 1 (
-    pushd "%vc_dir%" 2>NUL&& (
+del "!log_file!">NUL 2>&1
+if !flag_local! NEQ 1 (
+    pushd "%vc_dir%" 2>NUL && (
         echo Updating vc...
         echo  ^> Sync with remote !vc_url!
         call :buildcmd "cd "%vc_dir%"" "  "
@@ -108,27 +129,19 @@ if !use_local! NEQ 1 (
         call :buildcmd "git clone --depth 1 --quiet "%vc_url%"" "  "
     )
     popd
+    echo.
 )
 
-echo.
 echo Building V...
-
-if !compiler! == "clang" goto :clang_strap
-if !compiler! == "gcc" goto :gcc_strap
-if !compiler! == "msvc" goto :msvc_strap
-if !compiler! == "tcc" goto :tcc_strap
-if !compiler! == "fresh-tcc" goto :tcc_strap
-if [!compiler!] == [""] goto :clang_strap
+if not [!compiler!] == [] goto :!compiler!_strap
 
 :clang_strap
 where /q clang
 if %ERRORLEVEL% NEQ 0 (
 	echo  ^> Clang not found
-	if not [!compiler!] == [""] goto :error
+	if not [!compiler!] == [] goto :error
 	goto :gcc_strap
 )
-
-set /a valid_cc=1
 
 echo  ^> Attempting to build v.c with Clang
 call :buildcmd "clang -std=c99 -municode -w -o v.exe .\vc\v_win.c" "  "
@@ -147,11 +160,9 @@ goto :success
 where /q gcc
 if %ERRORLEVEL% NEQ 0 (
 	echo  ^> GCC not found
-	if not [!compiler!] == [""] goto :error
+	if not [!compiler!] == [] goto :error
 	goto :msvc_strap
 )
-
-set /a valid_cc=1
 
 echo  ^> Attempting to build v.c with GCC
 call :buildcmd "gcc -std=c99 -municode -w -o v.exe .\vc\v_win.c" "  "
@@ -177,11 +188,9 @@ if "%PROCESSOR_ARCHITECTURE%" == "x86" (
 
 if not exist "%VsWhereDir%\Microsoft Visual Studio\Installer\vswhere.exe" (
 	echo  ^> MSVC not found
-	if not [!compiler!] == [""] goto :error
+	if not [!compiler!] == [] goto :error
 	goto :tcc_strap
 )
-
-set /a valid_cc=1
 
 for /f "usebackq tokens=*" %%i in (`"%VsWhereDir%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
 	set InstallDir=%%i
@@ -201,18 +210,20 @@ if %ERRORLEVEL% NEQ 0 goto :compile_error
 
 echo  ^> Compiling with .\v.exe self
 call :buildcmd "v.exe -cc msvc self" "  "
-del %ObjFile%>>!log_file! 2>>&1
+del %ObjFile%>>"!log_file!" 2>>&1
 if %ERRORLEVEL% NEQ 0 goto :compile_error
 goto :success
+
+:fresh-tcc_strap
+echo  ^> Clean TCC directory
+call :buildcmd "rmdir /s /q "%tcc_dir%"" "  "
+call :tcc_strap
+exit /b %ERRORLEVEL%
 
 :tcc_strap
 where /q tcc
 if %ERRORLEVEL% NEQ 0 (
-	if !compiler! == "fresh-tcc" (
-        echo  ^> Clean TCC directory
-        call :buildcmd "rmdir /s /q "%tcc_dir%"" "  "
-        set /a valid_cc=1
-    ) else if !compiler! == "tcc" set /a valid_cc=1
+    if [!compiler!] == [] set /a invalid_cc=1
     if not exist %tcc_dir% (
         echo  ^> TCC not found
         echo  ^> Downloading TCC from %tcc_url%
@@ -226,7 +237,6 @@ if %ERRORLEVEL% NEQ 0 (
     set "tcc_exe=%tcc_dir%\tcc.exe"
 ) else (
 	for /f "delims=" %%i in ('where tcc') do set "tcc_exe=%%i"
-    set /a valid_cc=1
 )
 
 echo  ^> Updating prebuilt TCC...
@@ -243,24 +253,9 @@ call :buildcmd "v.exe -cc "!tcc_exe!" self" "  "
 if %ERRORLEVEL% NEQ 0 goto :compile_error
 goto :success
 
-:cleanall
-call :clean
-echo  ^> Purge TCC binaries
-call :buildcmd "rmdir /s /q "%tcc_dir%"" "  "
-echo  ^> Purge vc repository
-call :buildcmd "rmdir /s /q "%vc_dir%"" "  "
-exit /b 0
-
-:clean
-echo  ^> Purge debug symbols
-call :buildcmd "del *.pdb *.lib *.bak *.out *.ilk *.exp *.obj *.o *.a *.so" "  "
-echo  ^> Delete old V executable
-call :buildcmd "del v_old.exe v*.exe" "  "
-exit /b 0
-
 :compile_error
 echo.
-type !log_file!>NUL 2>&1
+type "!log_file!">NUL 2>&1
 goto :error
 
 :error
@@ -271,7 +266,7 @@ exit /b 1
 :success
 echo  ^> V built successfully!
 echo  ^> To add V to your PATH, run `.\v.exe symlink`.
-if !valid_cc! EQU 0 (
+if !invalid_cc! EQU 1 (
     echo.
     echo WARNING:  No C compiler was detected in your PATH. `tcc` was used temporarily
     echo           to build V, but it may have some bugs and may not work in all cases.
@@ -280,8 +275,8 @@ if !valid_cc! EQU 0 (
     echo.
 )
 
-del v_old.exe>>!log_file! 2>NUL
-del !log_file! 2>NUL
+del v_old.exe>>"!log_file!" 2>NUL
+del "!log_file!" 2>NUL
 
 :version
 echo.
@@ -290,15 +285,14 @@ echo | set /p="V version: "
 goto :eof
 
 :buildcmd
-if !verbose_log! EQU 1 (
-    echo [Debug] %~1>>!log_file!
+if !flag_verbose! EQU 1 (
+    echo [Debug] %~1>>"!log_file!"
     echo %~2 %~1
 )
-%~1>>!log_file! 2>>&1
+%~1>>"!log_file!" 2>>&1
 exit /b %ERRORLEVEL%
 
 :usage
-echo.
 echo Usage:
 echo     make.bat [target] [compiler] [options]
 echo.
@@ -319,7 +313,7 @@ echo     make.bat help clean
 echo.
 echo Use "make help <target>" for more information about a target, for instance: "make help clean"
 echo.
-echo Note: Any undefined options will cause an error
+echo Note: Any undefined/unsupported options will be ignored
 exit /b 0
 
 :help_help
@@ -336,7 +330,7 @@ echo     make.bat clean
 echo.
 echo Options:
 echo    --logfile PATH                    Use the specified PATH as the log
-echo    -v ^| --verbose                    Output compilation commands to stdout
+echo    --verbose                         Output compilation commands to stdout
 exit /b 0
 
 :help_cleanall
@@ -345,7 +339,7 @@ echo     make.bat clean-all
 echo.
 echo Options:
 echo    --logfile PATH                    Use the specified PATH as the log
-echo    -v ^| --verbose                    Output compilation commands to stdout
+echo    --verbose                         Output compilation commands to stdout
 exit /b 0
 
 :help_build
@@ -360,7 +354,7 @@ echo    --local                           Use the local vc repository without
 echo                                      syncing with remote
 echo    --logfile PATH                    Use the specified PATH as the log
 echo                                      file
-echo    -v ^| --verbose                    Output compilation commands to stdout
+echo    --verbose                         Output compilation commands to stdout
 exit /b 0
 
 :eof


### PR DESCRIPTION
This is a followup on <https://github.com/vlang/v/pull/6975>, the commit replaces chained if statement with a running for loop and removes redundant checking by renaming `jump` labels to match input values, allowing for direct `goto` jumps without intermediate parsing.