### PR TITLE
parser: fix showing error position for pratt.v

### DIFF
--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -194,7 +194,8 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 					s := if p.tok.lit != '' { '`$p.tok.lit`' } else { p.tok.kind.str() }
 					p.error_with_pos('unexpected $s, expecting `:`', p.tok.position())
 				} else {
-					p.error_with_pos('unexpected `$p.tok.lit`, expecting struct key', p.tok.position())
+					p.error_with_pos('unexpected `$p.tok.lit`, expecting struct key',
+						p.tok.position())
 				}
 			}
 			p.check(.rcbr)
@@ -230,7 +231,8 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			}
 		}
 		else {
-			p.error_with_pos('invalid expression: unexpected $p.tok.kind.str() token', p.tok.position())
+			p.error_with_pos('invalid expression: unexpected $p.tok.kind.str() token',
+				p.tok.position())
 		}
 	}
 	return p.expr_with_left(node, precedence, is_stmt_ident)

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -52,7 +52,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			match p.peek_tok.kind {
 				.name { return p.vweb() }
 				.key_if { return p.if_expr(true) }
-				else { p.error('unexpected $') }
+				else { p.error_with_pos('unexpected `$`', p.peek_tok.position()) }
 			}
 		}
 		.chartoken {
@@ -191,10 +191,10 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 					node = p.struct_init(true) // short_syntax: true
 				} else if p.tok.kind == .name {
 					p.next()
-					lit := if p.tok.lit != '' { p.tok.lit } else { p.tok.kind.str() }
-					p.error('unexpected `$lit`, expecting `:`')
+					s := if p.tok.lit != '' { '`$p.tok.lit`' } else { p.tok.kind.str() }
+					p.error_with_pos('unexpected $s, expecting `:`', p.tok.position())
 				} else {
-					p.error('unexpected `$p.tok.lit`, expecting struct key')
+					p.error_with_pos('unexpected `$p.tok.lit`, expecting struct key', p.tok.position())
 				}
 			}
 			p.check(.rcbr)
@@ -230,7 +230,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			}
 		}
 		else {
-			p.error('expr(): bad token `$p.tok.kind.str()`')
+			p.error_with_pos('invalid expression: unexpected $p.tok.kind.str() token', p.tok.position())
 		}
 	}
 	return p.expr_with_left(node, precedence, is_stmt_ident)


### PR DESCRIPTION
Also fix wrong backticks for two errors (token kind is not actual code).

Note: There are a lot of uses of `p.error()` or `p.warn()` that don't show a position. Perhaps we could make a github list of easy tasks for new contributors and include fixing showing parser error positions.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
