### PR TITLE
cgen: fix #6927

### DIFF
--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -60,9 +60,10 @@ fn (mut g Gen) gen_fn_decl(it ast.FnDecl, skip bool) {
 	}
 	mut type_name := g.typ(it.return_type)
 	if g.cur_generic_type != 0 {
-		// foo<T>() => foo_int(), foo_string() etc
+		// foo<T>() => foo_T_int(), foo_T_string() etc
 		gen_name := g.typ(g.cur_generic_type)
-		name += '_' + gen_name
+		// Using _T_ to differentiate betweem get<string> nad get_string
+		name += '_T_' + gen_name
 	}
 	// if g.pref.show_cc && it.is_builtin {
 	// println(name)
@@ -534,8 +535,9 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 		name = c_name(name)
 	}
 	if node.generic_type != table.void_type && node.generic_type != 0 {
-		// `foo<int>()` => `foo_int()`
-		name += '_' + g.typ(node.generic_type)
+		// Using _T_ to differentiate betweem get<string> nad get_string
+		// `foo<int>()` => `foo_T_int()`
+		name += '_T_' + g.typ(node.generic_type)
 	}
 	// TODO2
 	// cgen shouldn't modify ast nodes, this should be moved

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -62,7 +62,7 @@ fn (mut g Gen) gen_fn_decl(it ast.FnDecl, skip bool) {
 	if g.cur_generic_type != 0 {
 		// foo<T>() => foo_T_int(), foo_T_string() etc
 		gen_name := g.typ(g.cur_generic_type)
-		// Using _T_ to differentiate betweem get<string> nad get_string
+		// Using _T_ to differentiate between get<string> and get_string
 		name += '_T_' + gen_name
 	}
 	// if g.pref.show_cc && it.is_builtin {
@@ -535,7 +535,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 		name = c_name(name)
 	}
 	if node.generic_type != table.void_type && node.generic_type != 0 {
-		// Using _T_ to differentiate betweem get<string> nad get_string
+		// Using _T_ to differentiate between get<string> and get_string
 		// `foo<int>()` => `foo_T_int()`
 		name += '_T_' + g.typ(node.generic_type)
 	}

--- a/vlib/v/tests/generic_functions_with_normal_function_test.v
+++ b/vlib/v/tests/generic_functions_with_normal_function_test.v
@@ -1,0 +1,12 @@
+fn get<T>(typ T) T {
+   return typ
+}
+
+fn get_string(typ string) string {
+   return 'boom'
+}
+
+fn test_generic_with_same_type() {
+	assert get_string('') == 'boom'
+	assert get<string>('hello') == 'hello'
+}


### PR DESCRIPTION
This PR fixes https://github.com/vlang/v/issues/6927 by using adding `_T_` prefix in the function name so it is easy to identify them plus fix the above issue. I have talked and discussed @joe-conigliaro about it and he approves!

How it looks in cgen now:
```c
VV_LOCAL_SYMBOL string main__get_T_string(string typ) {
    return typ;
}
```

Before:
```c
VV_LOCAL_SYMBOL string main__get_string(string typ) {
    return typ;
}
```