### PR TITLE
scanner: fix escape `\u` (fix #6849)

### DIFF
--- a/vlib/v/checker/tests/string_escape_u_err_a.out
+++ b/vlib/v/checker/tests/string_escape_u_err_a.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/string_escape_u_err_a.vv:2:15: error: `\u` incomplete universal character name
+    1 | fn main() {
+    2 |     println('\u')
+      |               ^
+    3 | }

--- a/vlib/v/checker/tests/string_escape_u_err_a.out
+++ b/vlib/v/checker/tests/string_escape_u_err_a.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/string_escape_u_err_a.vv:2:15: error: `\u` incomplete universal character name
+vlib/v/checker/tests/string_escape_u_err_a.vv:2:15: error: `\u` incomplete unicode character value
     1 | fn main() {
     2 |     println('\u')
       |               ^

--- a/vlib/v/checker/tests/string_escape_u_err_a.vv
+++ b/vlib/v/checker/tests/string_escape_u_err_a.vv
@@ -1,0 +1,3 @@
+fn main() {
+    println('\u')
+}

--- a/vlib/v/checker/tests/string_escape_u_err_b.out
+++ b/vlib/v/checker/tests/string_escape_u_err_b.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/string_escape_u_err_b.vv:2:15: error: `\u` incomplete universal character name
+vlib/v/checker/tests/string_escape_u_err_b.vv:2:15: error: `\u` incomplete unicode character value
     1 | fn main() {
     2 |     println('\u345')
       |               ^

--- a/vlib/v/checker/tests/string_escape_u_err_b.out
+++ b/vlib/v/checker/tests/string_escape_u_err_b.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/string_escape_u_err_b.vv:2:15: error: `\u` incomplete universal character name
+    1 | fn main() {
+    2 |     println('\u345')
+      |               ^
+    3 | }

--- a/vlib/v/checker/tests/string_escape_u_err_b.vv
+++ b/vlib/v/checker/tests/string_escape_u_err_b.vv
@@ -1,0 +1,3 @@
+fn main() {
+    println('\u345')
+}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1050,7 +1050,7 @@ fn (mut s Scanner) ident_string() string {
 				s.text[s.pos + 2] == s.quote || s.text[s.pos + 3] == s.quote || s.text[s.pos + 4] == s.quote ||
 				!s.text[s.pos + 1].is_hex_digit() || !s.text[s.pos + 2].is_hex_digit() || !s.text[s.pos + 3].is_hex_digit() ||
 				!s.text[s.pos + 4].is_hex_digit()) {
-				s.error(r'`\u` incomplete universal character name')
+				s.error(r'`\u` incomplete unicode character value')
 			}
 		}
 		// ${var} (ignore in vfmt mode) (skip \$)

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1039,11 +1039,19 @@ fn (mut s Scanner) ident_string() string {
 				s.error(r'cannot use `\x00` (NULL character) in the string literal')
 			}
 		}
-		// Escape `\x`
-		if prevc == slash &&
-			c == `x` && s.count_symbol_before(s.pos - 2, slash) % 2 == 0 && !is_raw && !is_cstr &&
-			(s.text[s.pos + 1] == s.quote || !s.text[s.pos + 1].is_hex_digit()) {
-			s.error(r'`\x` used with no following hex digits')
+		// Escape `\x` `\u`
+		if prevc == slash && !is_raw && !is_cstr && s.count_symbol_before(s.pos - 2, slash) % 2 == 0 {
+			// Escape `\x`
+			if c == `x` && (s.text[s.pos + 1] == s.quote || !s.text[s.pos + 1].is_hex_digit()) {
+				s.error(r'`\x` used with no following hex digits')
+			}
+			// Escape `\u`
+			if c == `u` && (s.text[s.pos + 1] == s.quote ||
+				s.text[s.pos + 2] == s.quote || s.text[s.pos + 3] == s.quote || s.text[s.pos + 4] == s.quote ||
+				!s.text[s.pos + 1].is_hex_digit() || !s.text[s.pos + 2].is_hex_digit() || !s.text[s.pos + 3].is_hex_digit() ||
+				!s.text[s.pos + 4].is_hex_digit()) {
+				s.error(r'`\u` incomplete universal character name')
+			}
 		}
 		// ${var} (ignore in vfmt mode) (skip \$)
 		if prevc == `$` && c == `{` && !is_raw && s.count_symbol_before(s.pos - 2, slash) % 2 == 0 {


### PR DESCRIPTION
This PR fixes escape `\u` error. (fix #6849)

- Fixes escape `\u` error.
- Add tests `string_escape_u_err_a.vv/out` `string_escape_u_err_b.vv/out`.

```v
module main

fn main() {
	println('\u')
}
PS D:\Test\v\tt1> v run .
.\tt1.v:4:12: error: `\u` incomplete universal character name
    2 |
    3 | fn main() {
    4 |     println('\u')
      |               ^
    5 | }
```
```v
module main

fn main() {
	println('\uabc')
}
PS D:\Test\v\tt1> v run .
.\tt1.v:4:12: error: `\u` incomplete universal character name
    2 |
    3 | fn main() {
    4 |     println('\uabc')
      |               ^
    5 | }
```