### PR TITLE
v: -usecache fixes and self compilation & some type cname optimisation

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3558,24 +3558,28 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, type_sym table.TypeSymbol
 				mut expr_type := table.Type(0)
 				if expr_types.len > 1 {
 					mut agg_name := strings.new_builder(20)
+					mut agg_cname := strings.new_builder(20)
 					agg_name.write('(')
 					for i, expr in expr_types {
 						if i > 0 {
 							agg_name.write(' | ')
+							agg_cname.write('___')
 						}
 						type_str := c.table.type_to_str(expr.typ)
-						agg_name.write(if c.is_builtin_mod {
+						name := if c.is_builtin_mod {
 							type_str
 						} else {
 							'${c.mod}.$type_str'
-						})
+						}
+						agg_name.write(name)
+						agg_cname.write(util.no_dots(name))
 					}
 					agg_name.write(')')
 					name := agg_name.str()
 					expr_type = c.table.register_type_symbol(table.TypeSymbol{
 						name: name
 						source_name: name
-						cname: util.no_dots(name)
+						cname: agg_cname.str()
 						kind: .aggregate
 						mod: c.mod
 						info: table.Aggregate{

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3575,6 +3575,7 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, type_sym table.TypeSymbol
 					expr_type = c.table.register_type_symbol(table.TypeSymbol{
 						name: name
 						source_name: name
+						cname: util.no_dots(name)
 						kind: .aggregate
 						mod: c.mod
 						info: table.Aggregate{

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3566,11 +3566,7 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, type_sym table.TypeSymbol
 							agg_cname.write('___')
 						}
 						type_str := c.table.type_to_str(expr.typ)
-						name := if c.is_builtin_mod {
-							type_str
-						} else {
-							'${c.mod}.$type_str'
-						}
+						name := if c.is_builtin_mod { type_str } else { '${c.mod}.$type_str' }
 						agg_name.write(name)
 						agg_cname.write(util.no_dots(name))
 					}

--- a/vlib/v/gen/auto_str_methods.v
+++ b/vlib/v/gen/auto_str_methods.v
@@ -518,11 +518,10 @@ fn (mut g Gen) gen_str_for_union_sum_type(info table.SumType, styp string, str_f
 		mut func_name := if typ_str in gen_fn_names { gen_fn_names[typ_str] } else { g.gen_str_for_type_with_styp(typ,
 				typ_str) }
 		sym := g.table.get_type_symbol(typ)
-		sname := sym.name.replace('.', '_')
 		if sym.kind == .struct_ {
 			func_name = 'indent_$func_name'
 		}
-		g.auto_str_funcs.write('\t\tcase $typ: return _STR("${clean_sum_type_v_type_name}($value_fmt)", 2, ${func_name}(*($typ_str*)x._$sname')
+		g.auto_str_funcs.write('\t\tcase $typ: return _STR("${clean_sum_type_v_type_name}($value_fmt)", 2, ${func_name}(*($typ_str*)x._$sym.cname')
 		if sym.kind == .struct_ {
 			g.auto_str_funcs.write(', indent_count')
 		}

--- a/vlib/v/gen/auto_str_methods.v
+++ b/vlib/v/gen/auto_str_methods.v
@@ -518,10 +518,11 @@ fn (mut g Gen) gen_str_for_union_sum_type(info table.SumType, styp string, str_f
 		mut func_name := if typ_str in gen_fn_names { gen_fn_names[typ_str] } else { g.gen_str_for_type_with_styp(typ,
 				typ_str) }
 		sym := g.table.get_type_symbol(typ)
+		sname := sym.name.replace('.', '_')
 		if sym.kind == .struct_ {
 			func_name = 'indent_$func_name'
 		}
-		g.auto_str_funcs.write('\t\tcase $typ: return _STR("${clean_sum_type_v_type_name}($value_fmt)", 2, ${func_name}(*($typ_str*)x._$typ.idx()')
+		g.auto_str_funcs.write('\t\tcase $typ: return _STR("${clean_sum_type_v_type_name}($value_fmt)", 2, ${func_name}(*($typ_str*)x._$sname')
 		if sym.kind == .struct_ {
 			g.auto_str_funcs.write(', indent_count')
 		}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -201,18 +201,15 @@ pub fn cgen(files []ast.File, table &table.Table, pref &pref.Preferences) string
 	if autofree_used {
 		g.autofree = true // so that void _vcleanup is generated
 	}
+	// to make sure type idx's are the same in cached mods
 	if g.pref.build_mode == .build_module {
 		for idx, typ in g.table.types {
-			if idx == 0 || typ.info is table.Aggregate {
-				continue
-			}
+			if idx == 0 { continue }
 			g.definitions.writeln('int _v_type_idx_${typ.cname}();')
 		}
 	} else if g.pref.use_cache {
 		for idx, typ in g.table.types {
-			if idx == 0 || typ.info is table.Aggregate {
-				continue
-			}
+			if idx == 0 { continue }
 			g.definitions.writeln('int _v_type_idx_${typ.cname}() { return $idx; };')
 		}
 	}
@@ -5521,6 +5518,7 @@ fn styp_to_str_fn_name(styp string) string {
 
 [inline]
 fn (mut g Gen) gen_str_for_type(typ table.Type) string {
+	// note: why was this here, removed for --usecache fix
 	// if g.pref.build_mode == .build_module {
 	// return ''
 	// }

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -205,13 +205,13 @@ pub fn cgen(files []ast.File, table &table.Table, pref &pref.Preferences) string
 		for idx, typ in g.table.types {
 			if idx == 0 || typ.info is table.Aggregate { continue }
 			sname := typ.name.replace('.', '_')
-			g.definitions.writeln('int VTypeIdx_${sname}();')
+			g.definitions.writeln('int _v_type_idx_${sname}();')
 		}
 	} else if g.pref.use_cache {
 		for idx, typ in g.table.types {
 			if idx == 0 || typ.info is table.Aggregate { continue }
 			sname := typ.name.replace('.', '_')
-			g.definitions.writeln('int VTypeIdx_${sname}() { return $idx; };')
+			g.definitions.writeln('int _v_type_idx_${sname}() { return $idx; };')
 		}
 	}
 	g.write_variadic_types()
@@ -547,9 +547,12 @@ fn (g &Gen) cc_type(t table.Type) string {
 
 [inline]
 fn (g &Gen) type_sidx(t table.Type) string {
-	sym := g.table.get_type_symbol(g.unwrap_generic(t))
-	sname := sym.name.replace('.', '_')
-	return if g.pref.build_mode == .build_module { 'VTypeIdx_${sname}()' } else { '$t.idx()' }
+	if g.pref.build_mode == .build_module {
+		sym := g.table.get_type_symbol(t)
+		sname := sym.name.replace('.', '_')
+		return '_v_type_idx_${sname}()'
+	}
+	return '$t.idx()'
 }
 
 //

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -204,12 +204,16 @@ pub fn cgen(files []ast.File, table &table.Table, pref &pref.Preferences) string
 	// to make sure type idx's are the same in cached mods
 	if g.pref.build_mode == .build_module {
 		for idx, typ in g.table.types {
-			if idx == 0 { continue }
+			if idx == 0 {
+				continue
+			}
 			g.definitions.writeln('int _v_type_idx_${typ.cname}();')
 		}
 	} else if g.pref.use_cache {
 		for idx, typ in g.table.types {
-			if idx == 0 { continue }
+			if idx == 0 {
+				continue
+			}
 			g.definitions.writeln('int _v_type_idx_${typ.cname}() { return $idx; };')
 		}
 	}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -203,12 +203,16 @@ pub fn cgen(files []ast.File, table &table.Table, pref &pref.Preferences) string
 	}
 	if g.pref.build_mode == .build_module {
 		for idx, typ in g.table.types {
-			if idx == 0 || typ.info is table.Aggregate { continue }
+			if idx == 0 || typ.info is table.Aggregate {
+				continue
+			}
 			g.definitions.writeln('int _v_type_idx_${typ.cname}();')
 		}
 	} else if g.pref.use_cache {
 		for idx, typ in g.table.types {
-			if idx == 0 || typ.info is table.Aggregate { continue }
+			if idx == 0 || typ.info is table.Aggregate {
+				continue
+			}
 			g.definitions.writeln('int _v_type_idx_${typ.cname}() { return $idx; };')
 		}
 	}
@@ -279,10 +283,10 @@ pub fn cgen(files []ast.File, table &table.Table, pref &pref.Preferences) string
 		b.write(g.stringliterals.str())
 	}
 	if g.auto_str_funcs.len > 0 {
-		//if g.pref.build_mode != .build_module {
-			b.writeln('\n// V auto str functions:')
-			b.write(g.auto_str_funcs.str())
-		//}
+		// if g.pref.build_mode != .build_module {
+		b.writeln('\n// V auto str functions:')
+		b.write(g.auto_str_funcs.str())
+		// }
 	}
 	b.writeln('\n// V out')
 	b.write(g.out.str())
@@ -2526,7 +2530,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 								if mut cast_sym.info is table.Aggregate {
 									agg_sym := g.table.get_type_symbol(cast_sym.info.types[g.aggregate_type_idx])
 									sum_type_deref_field += '_$agg_sym.cname'
-									//sum_type_deref_field += '_${cast_sym.info.types[g.aggregate_type_idx]}'
+									// sum_type_deref_field += '_${cast_sym.info.types[g.aggregate_type_idx]}'
 								} else {
 									sum_type_deref_field += '_$cast_sym.cname'
 								}
@@ -2570,7 +2574,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 			// type_idx := node.typ.idx()
 			sym := g.table.get_type_symbol(node.typ)
 			sidx := g.type_sidx(node.typ)
-			//g.write('$type_idx /* $sym.name */')
+			// g.write('$type_idx /* $sym.name */')
 			g.write('$sidx /* $sym.name */')
 		}
 		ast.TypeOf {
@@ -5480,7 +5484,7 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 		g.expr(node.expr)
 		g.write(')')
 		g.write(dot)
-		//g.write('typ, /*expected:*/$node.typ)')
+		// g.write('typ, /*expected:*/$node.typ)')
 		sidx := g.type_sidx(node.typ)
 		g.write('typ, /*expected:*/$sidx)')
 	}
@@ -5517,9 +5521,9 @@ fn styp_to_str_fn_name(styp string) string {
 
 [inline]
 fn (mut g Gen) gen_str_for_type(typ table.Type) string {
-	//if g.pref.build_mode == .build_module {
-	//	return ''
-	//}
+	// if g.pref.build_mode == .build_module {
+	// return ''
+	// }
 	styp := g.typ(typ)
 	return g.gen_str_for_type_with_styp(typ, styp)
 }

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -4,6 +4,7 @@
 module parser
 
 import v.table
+import v.util
 
 pub fn (mut p Parser) parse_array_type() table.Type {
 	p.check(.lsbr)
@@ -333,6 +334,7 @@ pub fn (mut p Parser) parse_generic_template_type(name string) table.Type {
 	idx = p.table.register_type_symbol(table.TypeSymbol{
 		name: name
 		source_name: name
+		cname: util.no_dots(name)
 		mod: p.mod
 		kind: .any
 		is_public: true
@@ -378,6 +380,7 @@ pub fn (mut p Parser) parse_generic_struct_inst_type(name string) table.Type {
 			kind: .generic_struct_inst
 			name: bs_name
 			source_name: bs_name
+			cname: util.no_dots(bs_name)
 			mod: p.mod
 			info: table.GenericStructInst{
 				parent_idx: parent_idx

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1635,6 +1635,7 @@ fn (mut p Parser) import_syms(mut parent ast.Import) {
 				kind: .alias
 				name: prepend_mod_name
 				source_name: prepend_mod_name
+				cname: util.no_dots(prepend_mod_name)
 				mod: p.mod
 				parent_idx: idx
 				info: table.Alias{
@@ -1889,6 +1890,7 @@ $pubfn (mut e  $enum_name) toggle(flag $enum_name)   { unsafe{ *e = int(*e) ^  (
 		kind: .enum_
 		name: name
 		source_name: name
+		cname: util.no_dots(name)
 		mod: p.mod
 		info: table.Enum{
 			vals: vals
@@ -1971,6 +1973,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 			kind: .sum_type
 			name: prepend_mod_name
 			source_name: prepend_mod_name
+			cname: util.no_dots(prepend_mod_name)
 			mod: p.mod
 			info: table.SumType{
 				variants: variant_types
@@ -2002,6 +2005,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		kind: .alias
 		name: prepend_mod_name
 		source_name: prepend_mod_name
+		cname: util.no_dots(prepend_mod_name)
 		mod: p.mod
 		parent_idx: pid
 		info: table.Alias{

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -252,6 +252,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 		name: name
 		language: language
 		source_name: name
+		cname: util.no_dots(name)
 		mod: p.mod
 		info: table.Struct{
 			fields: fields
@@ -380,6 +381,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		kind: .interface_
 		name: interface_name
 		source_name: interface_name
+		cname: util.no_dots(interface_name)
 		mod: p.mod
 		info: table.Interface{
 			types: []

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -6,6 +6,7 @@ module table
 import os
 import v.cflag
 import v.token
+import v.util
 
 pub struct Table {
 pub mut:
@@ -506,6 +507,7 @@ pub fn (mut t Table) find_or_register_chan(elem_type Type, is_mut bool) int {
 		kind: .chan
 		name: name
 		source_name: source_name
+		cname: util.no_dots(name)
 		info: Chan{
 			elem_type: elem_type
 			is_mut: is_mut
@@ -528,6 +530,7 @@ pub fn (mut t Table) find_or_register_map(key_type Type, value_type Type) int {
 		kind: .map
 		name: name
 		source_name: source_name
+		cname: util.no_dots(name)
 		info: Map{
 			key_type: key_type
 			value_type: value_type
@@ -550,6 +553,7 @@ pub fn (mut t Table) find_or_register_array(elem_type Type, nr_dims int, mod str
 		kind: .array
 		name: name
 		source_name: source_name
+		cname: util.no_dots(name)
 		info: Array{
 			elem_type: elem_type
 			nr_dims: nr_dims
@@ -572,6 +576,7 @@ pub fn (mut t Table) find_or_register_array_fixed(elem_type Type, size int, nr_d
 		kind: .array_fixed
 		name: name
 		source_name: source_name
+		cname: util.no_dots(name)
 		info: ArrayFixed{
 			elem_type: elem_type
 			size: size
@@ -603,6 +608,7 @@ pub fn (mut t Table) find_or_register_multi_return(mr_typs []Type) int {
 		kind: .multi_return
 		name: name
 		source_name: source_name
+		cname: util.no_dots(name)
 		info: MultiReturn{
 			types: mr_typs
 		}
@@ -618,6 +624,7 @@ pub fn (mut t Table) find_or_register_fn_type(mod string, f Fn, is_anon bool, ha
 		kind: .function
 		name: name
 		source_name: source_name
+		cname: util.no_dots(name)
 		mod: mod
 		info: FnType{
 			is_anon: anon
@@ -635,6 +642,7 @@ pub fn (mut t Table) add_placeholder_type(name string, language Language) int {
 	ph_type := TypeSymbol{
 		kind: .placeholder
 		name: name
+		cname: util.no_dots(name)
 		language: language
 		source_name: name
 		mod: modname

--- a/vlib/v/table/types.v
+++ b/vlib/v/table/types.v
@@ -39,6 +39,7 @@ pub mut:
 	kind        Kind
 	name        string // the internal name of the type or underlying type, i.e. `array_fixed_int_5`. See also .source_name below.
 	source_name string // the original source name of the type, i.e. `[5]int`.
+	cname       string // the name with no dots for use in the generated C code
 	methods     []Fn
 	mod         string
 	is_public   bool
@@ -505,95 +506,111 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 		kind: .void
 		name: 'void'
 		source_name: 'void'
+		cname: 'void'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .voidptr
 		name: 'voidptr'
 		source_name: 'voidptr'
+		cname: 'voidptr'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .byteptr
 		name: 'byteptr'
 		source_name: 'byteptr'
+		cname: 'byteptr'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .charptr
 		name: 'charptr'
 		source_name: 'charptr'
+		cname: 'charptr'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .i8
 		name: 'i8'
 		source_name: 'i8'
+		cname: 'i8'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .i16
 		name: 'i16'
 		source_name: 'i16'
+		cname: 'i16'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .int
 		name: 'int'
 		source_name: 'int'
+		cname: 'int'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .i64
 		name: 'i64'
 		source_name: 'i64'
+		cname: 'i64'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .byte
 		name: 'byte'
 		source_name: 'byte'
+		cname: 'byte'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .u16
 		name: 'u16'
 		source_name: 'u16'
+		cname: 'u16'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .u32
 		name: 'u32'
 		source_name: 'u32'
+		cname: 'u32'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .u64
 		name: 'u64'
 		source_name: 'u64'
+		cname: 'u64'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .f32
 		name: 'f32'
 		source_name: 'f32'
+		cname: 'f32'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .f64
 		name: 'f64'
 		source_name: 'f64'
+		cname: 'f64'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .char
 		name: 'char'
 		source_name: 'char'
+		cname: 'char'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .bool
 		name: 'bool'
+		cname: 'bool'
 		source_name: 'bool'
 		mod: 'builtin'
 	})
@@ -601,66 +618,77 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 		kind: .none_
 		name: 'none'
 		source_name: 'none'
+		cname: 'none'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .string
 		name: 'string'
 		source_name: 'string'
+		cname: 'string'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .ustring
 		name: 'ustring'
 		source_name: 'ustring'
+		cname: 'ustring'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .array
 		name: 'array'
 		source_name: 'array'
+		cname: 'array'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .map
 		name: 'map'
 		source_name: 'map'
+		cname: 'map'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .chan
 		name: 'chan'
 		source_name: 'chan'
+		cname: 'chan'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .size_t
 		name: 'size_t'
 		source_name: 'size_t'
+		cname: 'size_t'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .rune
 		name: 'rune'
 		source_name: 'rune'
+		cname: 'rune'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .any
 		name: 'any'
 		source_name: 'any'
+		cname: 'any'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .any_float
 		name: 'any_float'
 		source_name: 'any_float'
+		cname: 'any_float'
 		mod: 'builtin'
 	})
 	t.register_type_symbol({
 		kind: .any_int
 		name: 'any_int'
 		source_name: 'any_int'
+		cname: 'any_int'
 		mod: 'builtin'
 	})
 	// TODO: remove. for v1 map compatibility
@@ -670,6 +698,7 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 		kind: .alias
 		name: 'map_string'
 		source_name: 'map_string'
+		cname: 'map_string'
 		mod: 'builtin'
 		parent_idx: map_string_string_idx
 	})
@@ -677,6 +706,7 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 		kind: .alias
 		name: 'map_int'
 		source_name: 'map_int'
+		cname: 'map_int'
 		mod: 'builtin'
 		parent_idx: map_string_int_idx
 	})


### PR DESCRIPTION
This PR fixes the -usecache flag and allows v to be self compiled with it: `v -usecache -o v2 cmd/v`

It also adds type_sym.cname to save multiple calls of `util.no_dots`/`type_name.replace('.', '__')`