### PR TITLE
all: fix remaining c warnings and add -Werror to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         ## brew install sdl2 sdl2_ttf sdl2_mixer sdl2_image
         export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/openssl/lib/"
     - name: Build V
-      run:  make -j4 && ./v -cg -o v cmd/v
+      run:  make -j4 && ./v -cg -cflags -Werror -o v cmd/v
     - name: Build V using V
       run:  ./v -o v2 cmd/v && ./v2 -o v3 cmd/v
     - name: Test symlink
@@ -209,7 +209,7 @@ jobs:
          sudo apt-get install --quiet -y libglfw3 libglfw3-dev  libfreetype6-dev  libxi-dev libxcursor-dev libasound2-dev
          ## sudo apt-get install --quiet -y libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
     - name: Build V
-      run: make -j4 && ./v -cc gcc -o v cmd/v
+      run: make -j4 && ./v -cc gcc -cg -cflags -Werror -o v cmd/v
 #    - name: Test V
 #      run: ./v -silent test-compiler
 #    - name: Test v binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,7 +393,7 @@ jobs:
         echo $VFLAGS
         .\make.bat -msvc
     - name: Test new v.c
-      run: .\v.exe -cc msvc -cflags -Werror -o v cmd/v 
+      run: .\v.exe -cc msvc -o v cmd/v 
     - name: Install dependencies
       run: |
         .\v.exe setup-freetype

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,7 @@ jobs:
         gcc --version
         .\make.bat -gcc
     - name: Test new v.c
-      run: .\v.exe -o v.c cmd/v && gcc -municode -w v.c
+      run: .\v.exe -o v.c cmd/v && gcc -Werror -municode -w v.c
     - name: Install dependencies
       run: |
         .\v.exe setup-freetype

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,7 +392,7 @@ jobs:
         echo %VFLAGS%
         echo $VFLAGS
         .\make.bat -msvc
-        v -cflags /WX self
+        .\v.exe -cflags /WX self
     - name: Install dependencies
       run: |
         .\v.exe setup-freetype

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,8 +392,7 @@ jobs:
         echo %VFLAGS%
         echo $VFLAGS
         .\make.bat -msvc
-    - name: Test new v
-      run: .\v.exe -o v.exe cmd/v -cflags "/WX"
+        v -cflags /WX self
     - name: Install dependencies
       run: |
         .\v.exe setup-freetype

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,7 +393,7 @@ jobs:
         echo $VFLAGS
         .\make.bat -msvc
     - name: Test new v.c
-      run: .\v.exe -cc msvc -o v cmd/v 
+      run: .\v.exe self
     - name: Install dependencies
       run: |
         .\v.exe setup-freetype

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       run: |
         echo $VFLAGS
         make -j4
-        ./v -cg -o v cmd/v
+        ./v -cg -cflags -Werror -o v cmd/v
     - name: Test v->c
       run: |
         sudo ln -s /var/tmp/tcc/bin/tcc /usr/local/bin/tcc
@@ -384,7 +384,7 @@ jobs:
     runs-on: windows-2019
     timeout-minutes: 30
     env:
-        VFLAGS: -cc msvc
+        VFLAGS: -cc msvc -cflags -Werror
     steps:
     - uses: actions/checkout@v2
     #- uses: actions/setup-node@v1
@@ -436,7 +436,7 @@ jobs:
         move "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe.old"
         .\make.bat
     - name: Test new v.c
-      run: .\v.exe -o v.c cmd/v && .\thirdparty\tcc\tcc.exe -w -ladvapi32 -bt10 v.c
+      run: .\v.exe -o v.c cmd/v && .\thirdparty\tcc\tcc.exe -Werror -w -ladvapi32 -bt10 v.c
     - name: Install dependencies
       run: |
         .\v.exe setup-freetype

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,11 +145,7 @@ jobs:
         ## brew install sdl2 sdl2_ttf sdl2_mixer sdl2_image
         export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/openssl/lib/"
     - name: Build V
-<<<<<<< HEAD
       run:  make -j4 && ./v -cg -cflags -Werror -o v cmd/v
-=======
-      run:  make -j4 && ./v -o v cmd/v
->>>>>>> upstream/master
     - name: Build V using V
       run:  ./v -o v2 cmd/v && ./v2 -o v3 cmd/v
     - name: Test symlink

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,7 +381,7 @@ jobs:
     runs-on: windows-2019
     timeout-minutes: 30
     env:
-        VFLAGS: -cc msvc -cflags -Werror
+        VFLAGS: -cc msvc -cflags /WX
     steps:
     - uses: actions/checkout@v2
     #- uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,7 +381,7 @@ jobs:
     runs-on: windows-2019
     timeout-minutes: 30
     env:
-        VFLAGS: -cc msvc -cflags /WX
+        VFLAGS: -cc msvc
     steps:
     - uses: actions/checkout@v2
     #- uses: actions/setup-node@v1
@@ -392,6 +392,8 @@ jobs:
         echo %VFLAGS%
         echo $VFLAGS
         .\make.bat -msvc
+    - name: Test new v.c
+      run: .\v.exe -cc msvc -cflags -Werror -o v cmd/v 
     - name: Install dependencies
       run: |
         .\v.exe setup-freetype

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,8 +392,8 @@ jobs:
         echo %VFLAGS%
         echo $VFLAGS
         .\make.bat -msvc
-    - name: Test new v.c
-      run: .\v.exe self
+    - name: Test new v
+      run: .\v.exe -o v.exe cmd/v -cflags "/WX"
     - name: Install dependencies
       run: |
         .\v.exe setup-freetype

--- a/vlib/builtin/builtin_nix.c.v
+++ b/vlib/builtin/builtin_nix.c.v
@@ -49,7 +49,7 @@ fn print_backtrace_skipping_top_frames(xskipframes int) bool {
 fn print_backtrace_skipping_top_frames_mac(skipframes int) bool {
 	$if macos {
 		buffer := [100]byteptr{}
-		nr_ptrs := C.backtrace(buffer, 100)
+		nr_ptrs := C.backtrace(&voidptr(buffer), 100)
 		if nr_ptrs < 2 {
 			eprintln('C.backtrace returned less than 2 frames')
 			return false
@@ -62,7 +62,7 @@ fn print_backtrace_skipping_top_frames_mac(skipframes int) bool {
 fn print_backtrace_skipping_top_frames_freebsd(skipframes int) bool {
 	$if freebsd {
 		buffer := [100]byteptr{}
-		nr_ptrs := C.backtrace(buffer, 100)
+		nr_ptrs := C.backtrace(&voidptr(buffer), 100)
 		if nr_ptrs < 2 {
 			eprintln('C.backtrace returned less than 2 frames')
 			return false

--- a/vlib/builtin/builtin_nix.c.v
+++ b/vlib/builtin/builtin_nix.c.v
@@ -54,7 +54,7 @@ fn print_backtrace_skipping_top_frames_mac(skipframes int) bool {
 			eprintln('C.backtrace returned less than 2 frames')
 			return false
 		}
-		C.backtrace_symbols_fd(&buffer[skipframes], nr_ptrs - skipframes, 2)
+		C.backtrace_symbols_fd(&voidptr(&buffer[skipframes]), nr_ptrs - skipframes, 2)
 	}
 	return true
 }
@@ -67,7 +67,7 @@ fn print_backtrace_skipping_top_frames_freebsd(skipframes int) bool {
 			eprintln('C.backtrace returned less than 2 frames')
 			return false
 		}
-		C.backtrace_symbols_fd(&buffer[skipframes], nr_ptrs - skipframes, 2)
+		C.backtrace_symbols_fd(&voidptr(&buffer[skipframes]), nr_ptrs - skipframes, 2)
 	}
 	return true
 }

--- a/vlib/builtin/builtin_nix.c.v
+++ b/vlib/builtin/builtin_nix.c.v
@@ -48,26 +48,26 @@ fn print_backtrace_skipping_top_frames(xskipframes int) bool {
 // so there is no need to have their twins in builtin_windows.v
 fn print_backtrace_skipping_top_frames_mac(skipframes int) bool {
 	$if macos {
-		buffer := [100]byteptr{}
-		nr_ptrs := C.backtrace(&voidptr(buffer), 100)
+		buffer := [100]voidptr{}
+		nr_ptrs := C.backtrace(buffer, 100)
 		if nr_ptrs < 2 {
 			eprintln('C.backtrace returned less than 2 frames')
 			return false
 		}
-		C.backtrace_symbols_fd(&voidptr(&buffer[skipframes]), nr_ptrs - skipframes, 2)
+		C.backtrace_symbols_fd(&buffer[skipframes], nr_ptrs - skipframes, 2)
 	}
 	return true
 }
 
 fn print_backtrace_skipping_top_frames_freebsd(skipframes int) bool {
 	$if freebsd {
-		buffer := [100]byteptr{}
-		nr_ptrs := C.backtrace(&voidptr(buffer), 100)
+		buffer := [100]voidptr{}
+		nr_ptrs := C.backtrace(buffer, 100)
 		if nr_ptrs < 2 {
 			eprintln('C.backtrace returned less than 2 frames')
 			return false
 		}
-		C.backtrace_symbols_fd(&voidptr(&buffer[skipframes]), nr_ptrs - skipframes, 2)
+		C.backtrace_symbols_fd(&buffer[skipframes], nr_ptrs - skipframes, 2)
 	}
 	return true
 }

--- a/vlib/os/process_nix.c.v
+++ b/vlib/os/process_nix.c.v
@@ -45,16 +45,16 @@ fn (mut p Process) unix_spawn_process() int {
 	}
 	mut cargv := []charptr{}
 	mut cenvs := []charptr{}
-	cargv << p.filename.str
+	cargv << charptr(p.filename.str)
 	for i in 0 .. p.args.len {
-		cargv << p.args[i].str
+		cargv << charptr(p.args[i].str)
 	}
 	for i in 0 .. p.env.len {
-		cenvs << p.env[i].str
+		cenvs << charptr(p.env[i].str)
 	}
 	cargv << charptr(0)
 	cenvs << charptr(0)
-	C.execve(p.filename.str, cargv.data, cenvs.data)
+	C.execve(charptr(p.filename.str), cargv.data, cenvs.data)
 	// NB: normally execve does not return at all.
 	// If it returns, then something went wrong...
 	eprintln(posix_get_error_msg(C.errno))

--- a/vlib/time/time_darwin.c.v
+++ b/vlib/time/time_darwin.c.v
@@ -28,10 +28,10 @@ pub struct C.timeval {
 	tv_usec u64
 }
 
-fn init_time_base() InternalTimeBase {
+fn init_time_base() C.mach_timebase_info_data_t {
 	tb := C.mach_timebase_info_data_t{}
 	C.mach_timebase_info(&tb)
-	return InternalTimeBase{numer:tb.numer, denom:tb.denom}
+	return C.mach_timebase_info_data_t{numer:tb.numer, denom:tb.denom}
 }
 
 fn sys_mono_now_darwin() u64 {

--- a/vlib/time/time_darwin.c.v
+++ b/vlib/time/time_darwin.c.v
@@ -9,13 +9,13 @@ const (
 )
 
 [typedef]
-struct C.mach_timebase_info_data_t {
+struct C.mach_timebase_info_t {
 	numer u32
 	denom u32
 }
 
 fn C.mach_absolute_time() u64
-fn C.mach_timebase_info(&C.mach_timebase_info_data_t)
+fn C.mach_timebase_info(&C.mach_timebase_info_t)
 fn C.clock_gettime_nsec_np(int) u64
 
 struct InternalTimeBase {
@@ -29,7 +29,7 @@ pub struct C.timeval {
 }
 
 fn init_time_base() InternalTimeBase {
-	tb := C.mach_timebase_info_data_t{}
+	tb := C.mach_timebase_info_t{}
 	C.mach_timebase_info(&tb)
 	return InternalTimeBase{numer:tb.numer, denom:tb.denom}
 }
@@ -37,7 +37,7 @@ fn init_time_base() InternalTimeBase {
 fn sys_mono_now_darwin() u64 {
 	tm := C.mach_absolute_time()
 	if time_base.denom == 0 {
-		C.mach_timebase_info(&time_base)
+		C.mach_timebase_info(time_base)
 	}
 	return (tm - start_time) * time_base.numer / time_base.denom
 }

--- a/vlib/time/time_darwin.c.v
+++ b/vlib/time/time_darwin.c.v
@@ -9,13 +9,13 @@ const (
 )
 
 [typedef]
-struct C.mach_timebase_info_t {
+struct C.mach_timebase_info {
 	numer u32
 	denom u32
 }
 
 fn C.mach_absolute_time() u64
-fn C.mach_timebase_info(&C.mach_timebase_info_t)
+fn C.mach_timebase_info(&C.mach_timebase_info)
 fn C.clock_gettime_nsec_np(int) u64
 
 struct InternalTimeBase {
@@ -29,7 +29,7 @@ pub struct C.timeval {
 }
 
 fn init_time_base() InternalTimeBase {
-	tb := C.mach_timebase_info_t{}
+	tb := C.mach_timebase_info{}
 	C.mach_timebase_info(&tb)
 	return InternalTimeBase{numer:tb.numer, denom:tb.denom}
 }

--- a/vlib/time/time_darwin.c.v
+++ b/vlib/time/time_darwin.c.v
@@ -9,13 +9,13 @@ const (
 )
 
 [typedef]
-struct C.mach_timebase_info {
+struct C.mach_timebase_info_data_t {
 	numer u32
 	denom u32
 }
 
 fn C.mach_absolute_time() u64
-fn C.mach_timebase_info(&C.mach_timebase_info)
+fn C.mach_timebase_info(&C.mach_timebase_info_data_t)
 fn C.clock_gettime_nsec_np(int) u64
 
 struct InternalTimeBase {
@@ -29,7 +29,7 @@ pub struct C.timeval {
 }
 
 fn init_time_base() InternalTimeBase {
-	tb := C.mach_timebase_info{}
+	tb := C.mach_timebase_info_data_t{}
 	C.mach_timebase_info(&tb)
 	return InternalTimeBase{numer:tb.numer, denom:tb.denom}
 }
@@ -37,7 +37,7 @@ fn init_time_base() InternalTimeBase {
 fn sys_mono_now_darwin() u64 {
 	tm := C.mach_absolute_time()
 	if time_base.denom == 0 {
-		C.mach_timebase_info(time_base)
+		C.mach_timebase_info(&time_base)
 	}
 	return (tm - start_time) * time_base.numer / time_base.denom
 }

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -311,7 +311,7 @@ fn (mut v Builder) cc() {
 	//
 	if is_cc_clang {
 		if debug_mode {
-			debug_options = '-g3 -O0 -no-pie'
+			debug_options = '-g3 -O0'
 		}
 		optimization_options = '-O3'
 		mut have_flto := true

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1171,7 +1171,7 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 			g.writeln(' = (*$atmp)[$i];')
 		}
 	} else if it.kind == .map {
-		// `for key, val in map {`
+		// `for key, val in map {
 		g.writeln('// FOR IN map')
 		idx := g.new_tmp_var()
 		atmp := g.new_tmp_var()
@@ -1179,7 +1179,7 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		g.write('$atmp_styp $atmp = ')
 		g.expr(it.cond)
 		g.writeln(';')
-		g.writeln('for (int $idx = 0; $idx < ${atmp}.key_values.len; ++$idx) {')
+		g.writeln('for (int $idx = 0; $idx < (int)${atmp}.key_values.len; ++$idx) {')
 		g.writeln('\tif (${atmp}.key_values.keys[$idx].str == 0) {continue;}')
 		if it.key_var != '_' {
 			key_styp := g.typ(it.key_type)

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -23,14 +23,14 @@ fn (mut p Parser) hash() ast.HashStmt {
 	val := p.tok.lit
 	kind := val.all_before(' ')
 	p.next()
-	mut main := ''
+	mut main_str := ''
 	mut msg := ''
 	content := val.all_after('$kind ').all_before('//')
 	if content.contains(' #') {
-		main = content.all_before(' #').trim_space()
+		main_str = content.all_before(' #').trim_space()
 		msg = content.all_after(' #').trim_space()
 	} else {
-		main = content.trim_space()
+		main_str = content.trim_space()
 		msg = ''
 	}
 	// p.trace('a.v', 'kind: ${kind:-10s} | pos: ${pos:-45s} | hash: $val')
@@ -38,7 +38,7 @@ fn (mut p Parser) hash() ast.HashStmt {
 		mod: p.mod
 		val: val
 		kind: kind
-		main: main
+		main: main_str
 		msg: msg
 		pos: pos
 	}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1367,6 +1367,7 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 		field_name: field_name
 		pos: name_pos
 		is_mut: is_mut
+		mut_pos: mut_pos
 	}
 	mut node := ast.Expr{}
 	node = sel_expr


### PR DESCRIPTION
This PR fixes the remaining C-warnings (without -wall, etc.) with TCC, Clang, GCC, and MSVC. It also fixes operating system specific warnings. I've added "-Werror" to CI to make it fail in case of C warnings in the future. 