### PR TITLE
gen: minor cleanup in gen_expr_to_string()

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -4637,7 +4637,6 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype table.Type) ?bool {
 		g.write(')')
 	} else if typ == table.string_type {
 		g.expr(expr)
-		return true
 	} else if sym.kind == .enum_ {
 		is_var := match expr {
 			ast.SelectorExpr, ast.Ident { true }


### PR DESCRIPTION
This PR minor cleanup in gen_expr_to_string().

