### PR TITLE
docs: mention present tense convention, explain long comments

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2482,7 +2482,7 @@ For more examples, see <a href='https://github.com/vlang/v/blob/master/vlib/orm/
 ## Writing Documentation
 
 The way it works is very similar to Go. It's very simple: there's no need to
-write documentation separately for your code,you
+write documentation separately for your code,
 vdoc will generate it from docstrings in the source code.
 
 Documentation for each function/type/const must be placed right before the declaration:

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2502,8 +2502,8 @@ span to the documented function using single line comments:
 ```v
 // copy_all recursively copies all elements of the array by their value,
 // if `dupes` is false all duplicate values are eliminated in the process.
-pub fn copy_all(dupes bool) []int {
-
+fn copy_all(dupes bool) {
+	// ...
 }
 ```
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2482,7 +2482,7 @@ For more examples, see <a href='https://github.com/vlang/v/blob/master/vlib/orm/
 ## Writing Documentation
 
 The way it works is very similar to Go. It's very simple: there's no need to
-write documentation separately for your code,
+write documentation separately for your code,you
 vdoc will generate it from docstrings in the source code.
 
 Documentation for each function/type/const must be placed right before the declaration:
@@ -2495,6 +2495,19 @@ fn clearall() {
 ```
 
 The comment must start with the name of the definition.
+
+Sometimes one line isn't enough to explain what a function does, in that case comments should
+span to the documented function using single line comments:
+
+```v
+// copy_all recursively copies all elements of the array by their value,
+// if `dupes` is false all duplicate values are eliminated in the process.
+pub fn copy_all(dupes bool) []int {
+
+}
+```
+
+By convention it is preferred that comments are written in *present tense*.
 
 An overview of the module must be placed in the first comment right after the module's name.
 


### PR DESCRIPTION
This will add help the in documentation on how to deal with long lines of function comments.
It will also explicitly mention the convention about using *present tense* in comments - to avoid [confusion](https://github.com/vlang/v/pull/6979#discussion_r531654667)

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
