### PR TITLE
cgen: add support for shared maps

### DIFF
--- a/vlib/v/tests/shared_map_test.v
+++ b/vlib/v/tests/shared_map_test.v
@@ -1,0 +1,36 @@
+import sync
+
+fn incr(shared foo map[string]int, key string, sem sync.Semaphore) {
+	for _ in 0 .. 100000 {
+		lock foo {
+			foo[key] = foo[key] + 1
+		}
+	}
+	sem.post()
+}
+
+fn test_shared_array() {
+	shared foo := &{'p': 10, 'q': 20}
+	sem := sync.new_semaphore()
+	go incr(shared foo, 'p', sem)
+	go incr(shared foo, 'q', sem)
+	go incr(shared foo, 'p', sem)
+	go incr(shared foo, 'q', sem)
+	for _ in 0 .. 50000 {
+		lock foo {
+			unsafe {
+				foo['p'] = foo['p'] - 2
+				foo['q'] = foo['q'] + 3
+			}
+		}
+	}
+	for _ in 0..4 {
+		sem.wait()
+	}
+	rlock foo {
+		fp := unsafe { foo['p'] }
+		fq := unsafe { foo['q'] }
+		assert fp == 100010
+		assert fq == 350020
+	}
+}


### PR DESCRIPTION
First part of #6992. This PR adds C code generation for shared `maps` in a similar way as #5721 did for shared arrays.

```v
fn main() {
    shared a := &{'a': 1, 'b': 2}
    go f(shared a)
    lock a {
        a['a'] = a['a'] + 2
    }
    ...
    rlock a { // read only access
        println('${a['a']}')
    }
}

fn f(shared x) {
    lock x {
        x['a'] = x['a'] +3
    }
}
```
Auto-locking is not implemented, yet, but will be added in a future PR.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
