### PR TITLE
gen: fix variadic interpolation (fix #6634)

### DIFF
--- a/vlib/v/gen/str.v
+++ b/vlib/v/gen/str.v
@@ -221,6 +221,8 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 			} else {
 				g.write('*.*s')
 			}
+		} else if typ.has_flag(.variadic) {
+			g.write('.*s')
 		} else if typ.is_float() {
 			g.write('$fmt${fspec:c}')
 		} else if typ.is_pointer() {
@@ -266,6 +268,8 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 			} else {
 				g.expr(expr)
 			}
+		} else if typ.has_flag(.variadic) {
+			g.gen_expr_to_string(expr, typ)
 		} else if typ == table.bool_type {
 			g.expr(expr)
 			g.write(' ? _SLIT("true") : _SLIT("false")')

--- a/vlib/v/tests/string_interpolation_variadic_test.v
+++ b/vlib/v/tests/string_interpolation_variadic_test.v
@@ -9,7 +9,7 @@ struct Man {
 }
 
 fn my_variadic_function(x ...Man) string {
-	return '$x'	// this interpolation should generate .str() methods for Man
+	return '$x' // this interpolation should generate .str() methods for Man
 }
 
 fn test_vargs_string_interpolation() {
@@ -28,4 +28,17 @@ fn test_vargs_string_interpolation() {
 	assert results.contains('}]')
 	//
 	println(results)
+}
+
+fn variadic_int(x ...int) string {
+	return '$x'
+}
+
+fn variadic_bool(x ...bool) string {
+	return '$x'
+}
+
+fn test_variadic_interpolation() {
+	assert variadic_int(3, 2, 1) == '[3, 2, 1]'
+	assert variadic_bool(true, false, true) == '[true, false, true]'
 }


### PR DESCRIPTION
This PR fixes variadic interpolation (fix #6634).

- Fixes variadic interpolation.
- Add test `test_variadic_interpolation()`.

```v
module main

fn sum(a ...int) {
	println(typeof(a))
	println(a) // Outputs [2, 1]
	println('$a') // Outputs 6552944
}

fn main() {
	sum(2, 1)
}

PS D:\Test\v\tt1> v run .
int
[2, 1]
[2, 1]
```