### PR TITLE
fmt: smarter wrap of orm update lines

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -465,6 +465,7 @@ pub fn (mut f Fmt) stmt(node ast.Stmt) {
 						} else {
 							f.write(' ')
 						}
+						f.wrap_long_line(2, true)
 					}
 					f.write('where ')
 					f.expr(node.where_expr)
@@ -1110,8 +1111,8 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 	}
 }
 
-pub fn (mut f Fmt) wrap_long_line(penalty int, add_indent bool) bool {
-	if f.line_len <= max_len[penalty] {
+pub fn (mut f Fmt) wrap_long_line(penalty_idx int, add_indent bool) bool {
+	if f.line_len <= max_len[penalty_idx] {
 		return false
 	}
 	if f.out.buf[f.out.buf.len - 1] == ` ` {

--- a/vlib/v/fmt/tests/orm_keep.vv
+++ b/vlib/v/fmt/tests/orm_keep.vv
@@ -46,4 +46,8 @@ fn main() {
 	sql db {
 		delete from Customer where nr_orders == 10 && name == 'Bob'
 	}
+	sql db {
+		update Customer set name = 'Queen Elizabeth II', age = 150, nr_orders = 42, country = 'Great Britain'
+		where id == 5
+	}
 }


### PR DESCRIPTION
Orm update lines can easily become really long, but were only wrapped after `where id ==`.
Now they can be wrapped after any `set col = val`