### PR TITLE
builtin: make v_realloc take an int parameter instead of u32

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -96,7 +96,7 @@ fn (mut a array) ensure_cap(required int) {
 	if a.cap == 0 {
 		a.data = vcalloc(cap * a.element_size)
 	} else {
-		a.data = v_realloc(a.data, u32(cap * a.element_size))
+		a.data = v_realloc(a.data, cap * a.element_size)
 	}
 	a.cap = cap
 }

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -171,10 +171,10 @@ TODO
 //fn malloc_size(b byteptr) int
 
 [unsafe]
-pub fn v_realloc(b byteptr, n u32) byteptr {
+pub fn v_realloc(b byteptr, n int) byteptr {
 	$if prealloc {
 		unsafe {
-			new_ptr := malloc(int(n))
+			new_ptr := malloc(n)
 			size := 0 //malloc_size(b)
 			C.memcpy(new_ptr, b, size)
 			return new_ptr

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -124,9 +124,9 @@ fn (mut d DenseArray) push(key string, value voidptr) u32 {
 	if d.cap == d.len {
 		d.cap += d.cap >> 3
 		unsafe {
-			x := v_realloc(byteptr(d.keys), sizeof(string) * d.cap)
+			x := v_realloc(byteptr(d.keys), int(sizeof(string) * d.cap))
 			d.keys = &string(x)
-			d.values = v_realloc(byteptr(d.values), u32(d.value_bytes) * d.cap)
+			d.values = v_realloc(byteptr(d.values), d.value_bytes * int(d.cap))
 		}
 	}
 	push_index := d.len
@@ -175,9 +175,9 @@ fn (mut d DenseArray) zeros_to_end() {
 	d.len = count
 	d.cap = if count < 8 { u32(8) } else { count }
 	unsafe {
-		x := v_realloc(byteptr(d.keys), sizeof(string) * d.cap)
+		x := v_realloc(byteptr(d.keys), int(sizeof(string) * d.cap))
 		d.keys = &string(x)
-		d.values = v_realloc(byteptr(d.values), u32(d.value_bytes) * d.cap)
+		d.values = v_realloc(byteptr(d.values), d.value_bytes * int(d.cap))
 	}
 }
 
@@ -283,9 +283,9 @@ fn (mut m map) ensure_extra_metas(probe_count u32) {
 		m.extra_metas += extra_metas_inc
 		mem_size := (m.cap + 2 + m.extra_metas)
 		unsafe {
-			x := v_realloc(byteptr(m.metas), sizeof(u32) * mem_size)
+			x := v_realloc(byteptr(m.metas), int(sizeof(u32) * mem_size))
 			m.metas = &u32(x)
-			C.memset(m.metas + mem_size - extra_metas_inc, 0, sizeof(u32) * extra_metas_inc)
+			C.memset(m.metas + mem_size - extra_metas_inc, 0, int(sizeof(u32) * extra_metas_inc))
 		}
 		// Should almost never happen
 		if probe_count == 252 {
@@ -346,7 +346,7 @@ fn (mut m map) expand() {
 fn (mut m map) rehash() {
 	meta_bytes := sizeof(u32) * (m.cap + 2 + m.extra_metas)
 	unsafe {
-		x := v_realloc(byteptr(m.metas), meta_bytes)
+		x := v_realloc(byteptr(m.metas), int(meta_bytes))
 		m.metas = &u32(x)
 		C.memset(m.metas, 0, meta_bytes)
 	}
@@ -407,8 +407,8 @@ fn (mut m map) get_and_set(key string, zero voidptr) voidptr {
 		// Key not found, insert key with zero-value
 		m.set(key, zero)
 	}
-	assert false    
-	return voidptr(0)    
+	assert false
+	return voidptr(0)
 }
 
 // If `key` matches the key of an element in the container,

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -766,7 +766,7 @@ pub fn get_raw_stdin() []byte {
 					break
 				}
 
-				buf = v_realloc(buf, u32(offset + block_bytes + (block_bytes-bytes_read)))
+				buf = v_realloc(buf, offset + block_bytes + (block_bytes-bytes_read))
 			}
 
 			C.CloseHandle(h_input)


### PR DESCRIPTION
This PR fixes <https://github.com/vlang/v/issues/7065>
- remove the need for  `V_realloc` to perform an intermediate int cast
- change calls to `v_realloc` to pass an int parameter