### PR TITLE
vdoctor: detect wsl 1 and wsl 2 separately

### DIFF
--- a/cmd/tools/vdoctor.v
+++ b/cmd/tools/vdoctor.v
@@ -50,17 +50,25 @@ fn (mut a App) collect_info() {
 	}
 	//
 	mut os_details := ''
+	wsl_check := a.cmd({
+				command: 'cat /proc/sys/kernel/osrelease'
+			})
 	if os_kind == 'linux' {
 		os_details = a.get_linux_os_name()
 		info := a.cpu_info()
 		if 'hypervisor' in info['flags'] {
-			if 'microsoft' in a.cmd({
-				command: 'cat /proc/sys/kernel/osrelease'
-			}) {
-				os_details += ' (WSL)'
+			if 'microsoft' in wsl_check  {
+				// WSL 2 is a Managed VM and Full Linux Kernel
+				// See https://docs.microsoft.com/en-us/windows/wsl/compare-versions
+				os_details += ' (WSL 2)'
 			} else {
 				os_details += ' (VM)'
 			}
+		}
+		// WSL 1 is NOT a Managed VM and Full Linux Kernel
+		// See https://docs.microsoft.com/en-us/windows/wsl/compare-versions
+		if 'Microsoft' in wsl_check {
+			os_details += ' (WSL)'
 		}
 		// From https://unix.stackexchange.com/a/14346
 		if a.cmd(command: '[ "$(awk \'\$5=="/" {print \$1}\' </proc/1/mountinfo)" != "$(awk \'\$5=="/" {print \$1}\' </proc/$$/mountinfo)" ] ; echo \$?') == '0' {

--- a/cmd/tools/vdoctor.v
+++ b/cmd/tools/vdoctor.v
@@ -54,20 +54,13 @@ fn (mut a App) collect_info() {
 		os_details = a.get_linux_os_name()
 		info := a.cpu_info()
 		if 'hypervisor' in info['flags'] {
-			// WSL 2 is a hypervisor
 			if 'microsoft' in a.cmd({
 				command: 'cat /proc/sys/kernel/osrelease'
 			}) {
-				os_details += ' (WSL 2)'
+				os_details += ' (WSL)'
 			} else {
 				os_details += ' (VM)'
 			}
-		}
-		// WSL 1 is NOT a hypervisor 
-		if 'Microsoft' in a.cmd({
-				command: 'cat /proc/sys/kernel/osrelease'
-		}) {
-				os_details += ' (WSL)'
 		}
 		// From https://unix.stackexchange.com/a/14346
 		if a.cmd(command: '[ "$(awk \'\$5=="/" {print \$1}\' </proc/1/mountinfo)" != "$(awk \'\$5=="/" {print \$1}\' </proc/$$/mountinfo)" ] ; echo \$?') == '0' {

--- a/cmd/tools/vdoctor.v
+++ b/cmd/tools/vdoctor.v
@@ -54,13 +54,20 @@ fn (mut a App) collect_info() {
 		os_details = a.get_linux_os_name()
 		info := a.cpu_info()
 		if 'hypervisor' in info['flags'] {
+			// WSL 2 is a hypervisor
 			if 'microsoft' in a.cmd({
 				command: 'cat /proc/sys/kernel/osrelease'
 			}) {
-				os_details += ' (WSL)'
+				os_details += ' (WSL 2)'
 			} else {
 				os_details += ' (VM)'
 			}
+		}
+		// WSL 1 is NOT a hypervisor 
+		if 'Microsoft' in a.cmd({
+				command: 'cat /proc/sys/kernel/osrelease'
+		}) {
+				os_details += ' (WSL)'
 		}
 		// From https://unix.stackexchange.com/a/14346
 		if a.cmd(command: '[ "$(awk \'\$5=="/" {print \$1}\' </proc/1/mountinfo)" != "$(awk \'\$5=="/" {print \$1}\' </proc/$$/mountinfo)" ] ; echo \$?') == '0' {


### PR DESCRIPTION
`v doctor`'s Output on my old machine now:

```
OS: linux, Ubuntu 20.04.1 LTS (WSL)
Processor: 2 cpus, 64bit, little endian, Pentium(R) Dual-Core  CPU      E5500  @ 2.80GHz
CC version: cc (Ubuntu 9.3.0-10ubuntu2) 9.3.0

vroot: /mnt/c/Users/admin/Documents/Github/v
vexe: /mnt/c/Users/admin/Documents/Github/v/v
vexe mtime: 2020-12-02 04:34:01
is vroot writable: true
V full version: V 0.1.30 d8b8aca

Git version: git version 2.25.1
Git vroot status: weekly.2020.48.2-54-gd8b8aca5-dirty
.git/config present: true
thirdparty/tcc status: thirdparty-linux-amd64 7543de81
```

`v doctor`'s Output on new system:
```
OS: linux, Ubuntu 20.04.1 LTS (WSL 2)
Processor: 4 cpus, 64bit, little endian, Intel(R) Core(TM) i3-5005U CPU @ 2.00GHz
CC version: cc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0

vroot: /mnt/c/Users/Swastik/Documents/GitHub/v
vexe: /mnt/c/Users/Swastik/Documents/GitHub/v/v
vexe mtime: 2020-12-02 07:24:48
is vroot writable: true
V full version: V 0.1.30 d8b8aca.3335f8d

Git version: git version 2.25.1
Git vroot status: weekly.2020.48.2-56-g3335f8d7-dirty
.git/config present: true
thirdparty/tcc status: thirdparty-linux-amd64 7543de81
```