### PR TITLE
checker: fix optional or_block {none} (fix #6625)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -24,7 +24,7 @@ pub fn (mut c Checker) check_basic(got table.Type, expected table.Type) bool {
 		return true
 	}
 	if got_idx == table.none_type_idx && expected.has_flag(.optional) {
-		return true
+		return false
 	}
 	// allow pointers to be initialized with 0. TODO: use none instead
 	if exp_is_ptr && got_idx == table.int_type_idx {

--- a/vlib/v/checker/tests/optional_or_block_none_err.out
+++ b/vlib/v/checker/tests/optional_or_block_none_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/optional_or_block_none_err.vv:18:3: error: wrong return type `none` in the `or {}` block, expected `Animal`
+   16 | fn main() {
+   17 |     mut dog := new_animal(9) or {
+   18 |         none
+      |         ~~~~
+   19 |     }
+   20 |

--- a/vlib/v/checker/tests/optional_or_block_none_err.vv
+++ b/vlib/v/checker/tests/optional_or_block_none_err.vv
@@ -1,0 +1,22 @@
+module main
+
+struct Animal {
+	mut:
+		height byte
+}
+
+fn new_animal(height byte) ?Animal {
+	if height < 10 {
+		return error('Too small to be an animal!')
+	}
+
+	return Animal{ height: height }
+}
+
+fn main() {
+	mut dog := new_animal(9) or {
+		none
+	}
+
+	println(dog)
+}


### PR DESCRIPTION
This PR fixes optional or_block {none} (fix #6625).

- Fixes optional or_block {none}.
- Add test `vlib\v\checker\tests\optional_or_block_none_err.vv/out`.

```v
module main

struct Animal {
	mut:
		height byte
}

fn new_animal(height byte) ?Animal {
	if height < 10 {
		return error('Too small to be an animal!')
	}

	return Animal{ height: height }
}

fn main() {
	mut dog := new_animal(9) or {
		none
	}

	println(dog)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:18:3: error: wrong return type `none` in the `or {}` block, expected `Animal`
   16 | fn main() {
   17 |     mut dog := new_animal(9) or {
   18 |         none
      |         ~~~~
   19 |     }
   20 |
```