### PR TITLE
parser: fix position offset by 1

### DIFF
--- a/vlib/v/checker/tests/match_sumtype_multiple_types.out
+++ b/vlib/v/checker/tests/match_sumtype_multiple_types.out
@@ -1,3 +1,4 @@
+found:
 vlib/v/checker/tests/match_sumtype_multiple_types.vv:26:13: error: type `Charlie` has no field or method `char`
    24 |     match l {
    25 |         Alfa, Charlie {
@@ -9,6 +10,6 @@ vlib/v/checker/tests/match_sumtype_multiple_types.vv:27:13: error: unknown metho
    25 |         Alfa, Charlie {
    26 |             assert l.char == `a`
    27 |             assert l.letter() == 'a'
-      |                      ~~~~~~~~~
+      |                      ~~~~~~~~
    28 |         }
    29 |         Bravo {

--- a/vlib/v/checker/tests/match_sumtype_multiple_types.out
+++ b/vlib/v/checker/tests/match_sumtype_multiple_types.out
@@ -1,4 +1,3 @@
-found:
 vlib/v/checker/tests/match_sumtype_multiple_types.vv:26:13: error: type `Charlie` has no field or method `char`
    24 |     match l {
    25 |         Alfa, Charlie {

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -50,11 +50,7 @@ pub fn (mut p Parser) call_expr(language table.Language, mod string) ast.CallExp
 	if p.tok.kind == .not {
 		p.next()
 	}
-	pos := token.Position{
-		line_nr: first_pos.line_nr
-		pos: first_pos.pos
-		len: last_pos.pos - first_pos.pos + last_pos.len
-	}
+	pos := first_pos.extend(last_pos)
 	mut or_stmts := []ast.Stmt{}
 	mut or_pos := p.tok.position()
 	if p.tok.kind == .key_orelse {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1351,12 +1351,8 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 			or_kind = .propagate
 		}
 		//
-		end_pos := p.tok.position()
-		pos := token.Position{
-			line_nr: name_pos.line_nr
-			pos: name_pos.pos
-			len: end_pos.pos - name_pos.pos
-		}
+		end_pos := p.prev_tok.position()
+		pos := name_pos.extend(end_pos)
 		mcall_expr := ast.CallExpr{
 			left: left
 			name: field_name


### PR DESCRIPTION
i saw that the position was wrang by 1 character. in vscode with the vls we have multiline errors. in the cli it wasn't displayed.