### PR TITLE
cgen: fix map value op-assign modification

### DIFF
--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -353,3 +353,11 @@ fn test_map_str_after_delete() {
 	assert osm == "{'first': 1, 'second': 2, 'third': 3}"
 	assert nsm == "{'first': 1, 'third': 3}"
 }
+
+fn test_modify_map_value() {
+	mut m1 := {'foo': 3, 'bar': -7}
+	m1['foo'] += 5
+	m1['bar'] *= -2
+	assert m1['foo'] == 8
+	assert m1['bar'] == 14
+}

--- a/vlib/v/tests/shared_map_test.v
+++ b/vlib/v/tests/shared_map_test.v
@@ -10,7 +10,12 @@ fn incr(shared foo map[string]int, key string, sem sync.Semaphore) {
 }
 
 fn test_shared_array() {
-	shared foo := &{'p': 10, 'q': 20}
+	shared foo := &{'p': 10, 'q': 0}
+	lock foo {
+		unsafe {
+			foo['q'] = 20
+		}
+	}
 	sem := sync.new_semaphore()
 	go incr(shared foo, 'p', sem)
 	go incr(shared foo, 'q', sem)
@@ -19,8 +24,8 @@ fn test_shared_array() {
 	for _ in 0 .. 50000 {
 		lock foo {
 			unsafe {
-				foo['p'] = foo['p'] - 2
-				foo['q'] = foo['q'] + 3
+				foo['p'] -= 2
+				foo['q'] += 3
 			}
 		}
 	}


### PR DESCRIPTION
While testing `shared map`s I've discovered that expressions like
```v
m['foo'] += 3
m['bar'] *= -2
```
give wrong results. As it turned out that this was already broken for "normal" `mut` maps.

This PR fixes the behaviour. I've added tests for both cases (`shared` and `mut`).
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
