### PR TITLE
time: Implement parse_iso8601 with regex

### DIFF
--- a/vlib/time/parse.v
+++ b/vlib/time/parse.v
@@ -3,6 +3,8 @@
 // that can be found in the LICENSE file.
 module time
 
+import regex
+
 // parse returns time from a date string in "YYYY-MM-DD HH:MM:SS" format.
 pub fn parse(s string) ?Time {
 	pos := s.index(' ') or {
@@ -48,36 +50,78 @@ pub fn parse_rfc2822(s string) ?Time {
 	return parse(tos(tmstr, count))
 }
 
-// parse_iso8601 parses rfc8601 time format yyyy-MM-ddTHH:mm:ss.dddddd+dd:dd as local time
+fn re_get_str_group(re regex.RE, input string, name string) ?string {
+	i, j := re.get_group(name)
+	if i >= 0 && j > i {
+		return input[i..j]
+	}
+	return none
+}
+
+fn re_get_int_group(re regex.RE, input string, name string) ?int {
+	s := re_get_str_group(re, input, name) or {
+		return none
+	}
+	return s.int()
+}
+
+fn new_iso8601_query() string {
+	date_query := r'(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})'
+	time_query := r'(?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2})\.(?P<microsecond>\d{6})'
+	offset_query := r'(?P<plusminus>\+|-)(?P<offsethour>\d{2}):(?P<offsetmin>\d{2})'
+	z_query := r'(?P<z>Z)'
+	return '^${date_query}T${time_query}($z_query|$offset_query)?'
+}
+
+const (
+	err_invalid_8601 = error('Invalid 8601 format')
+	iso8601_query    = new_iso8601_query()
+)
+
+// parse_iso8601 parses rfc8601 time format yyyy-MM-ddTHH:mm:ss.dddddd+dd:dd
 // the fraction part is difference in milli seconds and the last part is offset
 // from UTC time and can be both +/- HH:mm
-// remarks: not all iso8601 is supported only the 'yyyy-MM-ddTHH:mm:ss.dddddd+dd:dd'
+// remarks: not all iso8601 is supported
 // also checks and support for leapseconds should be added in future PR
 pub fn parse_iso8601(s string) ?Time {
-	year := 0
-	month := 0
-	day := 0
-	hour := 0
-	minute := 0
-	second := 0
-	mic_second := 0
-	time_char := `a`
-	plus_min_z := `a`
-	offset_hour := 0
-	offset_min := 0
-	count := unsafe {C.sscanf(charptr(s.str), '%4d-%2d-%2d%c%2d:%2d:%2d.%6d%c%2d:%2d',
-		&year, &month, &day, charptr(&time_char), &hour, &minute, &second, &mic_second, charptr(&plus_min_z), &offset_hour,
-		&offset_min)}
-	is_local_time := plus_min_z == `a` && count == 8
-	is_utc := plus_min_z == `Z` && count == 9
-	if count != 11 && !is_local_time && !is_utc {
-		return error('Invalid 8601 format')
+	mut re := regex.new()
+	re.group_max = 10
+	re.compile_opt(iso8601_query) or {
+		println(err)
 	}
-	if time_char != `T` && time_char != ` ` {
-		return error('Invalid 8601 format, expected space or `T` as time separator')
+	re.match_string(s)
+	year := re_get_int_group(re, s, 'year') or {
+		return err_invalid_8601
 	}
-	if plus_min_z != `+` && plus_min_z != `-` && plus_min_z != `Z` && !is_local_time {
-		return error('Invalid 8601 format, expected `Z` or `+` or `-` as time separator')
+	month := re_get_int_group(re, s, 'month') or {
+		return err_invalid_8601
+	}
+	day := re_get_int_group(re, s, 'day') or {
+		return err_invalid_8601
+	}
+	hour := re_get_int_group(re, s, 'hour') or {
+		return err_invalid_8601
+	}
+	minute := re_get_int_group(re, s, 'minute') or {
+		return err_invalid_8601
+	}
+	second := re_get_int_group(re, s, 'second') or {
+		return err_invalid_8601
+	}
+	microsecond := re_get_int_group(re, s, 'microsecond') or {
+		return err_invalid_8601
+	}
+	z_i, z_j := re.get_group('z')
+	is_utc := z_i >= 0 && z_j > z_i
+	plus_minus := re_get_str_group(re, s, 'plusminus') or {
+		''
+	}
+	is_local_time := !is_utc && plus_minus.len == 0
+	offset_hour := re_get_int_group(re, s, 'offsethour') or {
+		0
+	}
+	offset_min := re_get_int_group(re, s, 'offsetmin') or {
+		0
 	}
 	mut t := new_time(Time{
 		year: year
@@ -86,12 +130,11 @@ pub fn parse_iso8601(s string) ?Time {
 		hour: hour
 		minute: minute
 		second: second
-		microsecond: mic_second
+		microsecond: microsecond
 	})
 	if is_local_time {
 		return to_local_time(t)
 	}
-
 	mut unix_time := t.unix
 	mut unix_offset := int(0)
 	if offset_hour > 0 {
@@ -101,13 +144,12 @@ pub fn parse_iso8601(s string) ?Time {
 		unix_offset += 60 * offset_min
 	}
 	if unix_offset != 0 {
-		if plus_min_z == `+` {
+		if plus_minus == '+' {
 			unix_time -= u64(unix_offset)
 		} else {
 			unix_time += u64(unix_offset)
 		}
 		t = unix2(int(unix_time), t.microsecond)
 	}
-	// Convert the time to local time
-	return to_local_time(t)
+	return t
 }


### PR DESCRIPTION
Re implement parse_iso8601 with regex to support full iso8601 in future.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
