### PR TITLE
Honor GITFASTCLONE and TCCREPO in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,8 @@ fresh_tcc:
 ifndef ANDROID
 ifdef LINUX
 	rm -rf /var/tmp/tcc
-	git clone https://github.com/vlang/tccbin /var/tmp/tcc
-endif    
+	$(GITFASTCLONE) $(TCCREPO) /var/tmp/tcc
+endif
 	rm -rf $(TMPTCC)
 	$(GITFASTCLONE) --branch $(TCCBRANCH) $(TCCREPO) $(TMPTCC)
 endif


### PR DESCRIPTION
----

Hi there! I help maintain the vlang package in GNU Guix. Our build daemon creates a very locked-down environment, including no network access, in order to enforce high standards for secure & reproducible builds. A consequence is that we fetch all necessary resources before beginning the build and disable features of the build system which require the network.

To that end, this PR replaces a `git clone https://github.com/vlang/tccbin` with a `$(GITFASTCLONE) $(TCCREPO)` which I hope should work just as well for you. For me, it means I can set `GITFASTCLONE="mkdir -p"` and `TCCREPO=""` in order to effectively skip that step.

#