### PR TITLE
checker: check match return mismatch type (fix #6826)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3439,7 +3439,7 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) table.Type {
 						stmt.typ = ret_type
 					} else if node.is_expr && ret_type != c.expr(stmt.expr) {
 						sym := c.table.get_type_symbol(ret_type)
-						c.error('mismatched return type, it should be `$sym.name`', stmt.expr.position())
+						c.error('return type mismatch, it should be `$sym.name`', stmt.expr.position())
 					}
 				}
 				else {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3434,8 +3434,13 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) table.Type {
 			mut stmt := branch.stmts[branch.stmts.len - 1]
 			match mut stmt {
 				ast.ExprStmt {
-					ret_type = c.expr(stmt.expr)
-					stmt.typ = ret_type
+					if ret_type == table.void_type {
+						ret_type = c.expr(stmt.expr)
+						stmt.typ = ret_type
+					} else if node.is_expr && ret_type != c.expr(stmt.expr) {
+						sym := c.table.get_type_symbol(ret_type)
+						c.error('mismatched return type, it should be `$sym.name`', stmt.expr.position())
+					}
 				}
 				else {
 					// TODO: ask alex about this
@@ -4009,14 +4014,11 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) table.Type {
 	} else if node.typ == table.any_flt_type {
 		node.typ = table.f64_type
 	}
-	if expr_required {
-		if !node.has_else {
-			d := if node.is_comptime { '$' } else { '' }
-			c.error('`$if_kind` expression needs `${d}else` clause', node.pos)
-		}
-		return node.typ
+	if expr_required && !node.has_else {
+		d := if node.is_comptime { '$' } else { '' }
+		c.error('`$if_kind` expression needs `${d}else` clause', node.pos)
 	}
-	return table.bool_type
+	return node.typ
 }
 
 // comp_if_branch checks the condition of a compile-time `if` branch. It returns a `bool` that

--- a/vlib/v/checker/tests/match_return_mismatch_type_err.out
+++ b/vlib/v/checker/tests/match_return_mismatch_type_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/match_return_mismatch_type_err.vv:4:10: error: mismatched return type, it should be `string`
+vlib/v/checker/tests/match_return_mismatch_type_err.vv:4:10: error: return type mismatch, it should be `string`
     2 |     a := match 1 {
     3 |         1 { 'aa' }
     4 |         else { 22 }

--- a/vlib/v/checker/tests/match_return_mismatch_type_err.out
+++ b/vlib/v/checker/tests/match_return_mismatch_type_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/match_return_mismatch_type_err.vv:4:10: error: mismatched return type, it should be `string`
+    2 |     a := match 1 {
+    3 |         1 { 'aa' }
+    4 |         else { 22 }
+      |                ~~
+    5 |     }
+    6 |     println(a)

--- a/vlib/v/checker/tests/match_return_mismatch_type_err.vv
+++ b/vlib/v/checker/tests/match_return_mismatch_type_err.vv
@@ -1,0 +1,7 @@
+fn main() {
+	a := match 1 {
+		1 { 'aa' }
+		else { 22 }
+	}
+	println(a)
+}


### PR DESCRIPTION
This PR check match return mismatch type (fix #6826).

- Check match return mismatch type.
- Add test `checker\tests\match_return_mismatch_type_err.vv/out`.

```v
module main

fn match_error(i int) ?string {
	return match i {
		1 { 'A' }
		2 { 'B' }
		else { error('illegal argument') }
	}
}

fn main() {
	res := match_error(3) or {
		println(err)
		return
	}
	println(res)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:7:10: error: mismatched return type, it should be `string`
    5 |         1 { 'A' }
    6 |         2 { 'B' }
    7 |         else { error('illegal argument') }
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~
    8 |     }
    9 | }
```