### PR TITLE
ci: fix self compilation with cached modules on macOS

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -127,7 +127,7 @@ fn (mut v Builder) post_process_c_compiler_output(res os.Result) {
 fn (mut v Builder) rebuild_cached_module(vexe string, imp_path string) string {
 	// TODO: move this check somewhere else, this is really not the best place for it :/
 	// strconv is already imported inside builtin, so skip generating its object file
-	if imp_path == 'vlib/strconv' {
+	if imp_path in ['vlib/strconv', 'vlib/strings'] {
 		return ''
 	}
 	res := v.pref.cache_manager.exists('.o', imp_path) or {


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
