### PR TITLE
gen: make _SLIT macro determine `len` at compile-time

### DIFF
--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -267,7 +267,8 @@ static void* g_live_info = NULL;
 
 //============================== HELPER C MACROS =============================*/
 //#define tos4(s, slen) ((string){.str=(s), .len=(slen)})
-#define _SLIT(s) ((string){.str=(byteptr)(s), .len=(strlen(s)), .is_lit=1})
+// V string literal. ""s is used to enforce a literal argument
+#define _SLIT(s) ((string){.str=(byteptr)(""s), .len=(sizeof(s)-1), .is_lit=1})
 #define _PUSH_MANY(arr, val, tmp, tmp_typ) {tmp_typ tmp = (val); array_push_many(arr, tmp.data, tmp.len);}
 #define _IN(typ, val, arr) array_##typ##_contains(arr, val)
 #define _IN_MAP(val, m) map_exists(m, val)

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -267,8 +267,8 @@ static void* g_live_info = NULL;
 
 //============================== HELPER C MACROS =============================*/
 //#define tos4(s, slen) ((string){.str=(s), .len=(slen)})
-// V string literal. ""s is used to enforce a literal argument
-#define _SLIT(s) ((string){.str=(byteptr)(""s), .len=(sizeof(s)-1), .is_lit=1})
+// `"" s` is used to enforce a string literal argument
+#define _SLIT(s) ((string){.str=(byteptr)("" s), .len=(sizeof(s)-1), .is_lit=1})
 #define _PUSH_MANY(arr, val, tmp, tmp_typ) {tmp_typ tmp = (val); array_push_many(arr, tmp.data, tmp.len);}
 #define _IN(typ, val, arr) array_##typ##_contains(arr, val)
 #define _IN_MAP(val, m) map_exists(m, val)


### PR DESCRIPTION
Also ensure `s` argument is a string literal using pre-processor concatenation with "". This prevents side-effects from double evaluation if passing an expression.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
