### PR TITLE
checker: fix or_block return type mismatch (fix #6742)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1698,7 +1698,8 @@ pub fn (mut c Checker) check_or_expr(or_expr ast.OrExpr, ret_type table.Type, ex
 		match last_stmt {
 			ast.ExprStmt {
 				last_stmt_typ := c.expr(last_stmt.expr)
-				type_fits := c.check_types(last_stmt_typ, ret_type)
+				type_fits := c.check_types(last_stmt_typ, ret_type) && last_stmt_typ.nr_muls() ==
+					ret_type.nr_muls()
 				is_panic_or_exit := is_expr_panic_or_exit(last_stmt.expr)
 				if type_fits || is_panic_or_exit {
 					return

--- a/vlib/v/checker/tests/optional_or_block_mismatch.out
+++ b/vlib/v/checker/tests/optional_or_block_mismatch.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/optional_or_block_mismatch.vv:10:18: error: wrong return type `Bar` in the `or {}` block, expected `&Bar`
+    8 |
+    9 | fn main() {
+   10 |     x := foo() or { Bar{} }
+      |                     ~~~
+   11 |     println(x)
+   12 | }

--- a/vlib/v/checker/tests/optional_or_block_mismatch.vv
+++ b/vlib/v/checker/tests/optional_or_block_mismatch.vv
@@ -1,0 +1,12 @@
+module main
+
+struct Bar {}
+
+fn foo() ?&Bar {
+	return none
+}
+
+fn main() {
+	x := foo() or { Bar{} }
+	println(x)
+}


### PR DESCRIPTION
This PR fixes or_block return type mismatch (fix #6742).

- Fixes or_block return type mismatch check error.
- Add test `vlib\v\checker\tests\optional_or_block_mismatch.vv/out`.

```v
module main

struct Bar {}

fn foo() ?&Bar {
	return none
}

fn main() {
	x := foo() or { Bar{} }
	println(x)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:10:18: error: wrong return type `Bar` in the `or {}` block, expected `&Bar`
    8 |
    9 | fn main() {
   10 |     x := foo() or { Bar{} }
      |                     ~~~
   11 |     println(x)
   12 | }
```