### PR TITLE
checker: fix interpolation recursive str (fix #1905)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -390,6 +390,10 @@ pub fn (mut c Checker) string_inter_lit(mut node ast.StringInterLiteral) table.T
 			}
 			node.need_fmts[i] = fmt != c.get_default_fmt(ftyp, typ)
 		}
+		// check recursive str
+		if c.cur_fn.is_method && c.cur_fn.name == 'str' && c.cur_fn.receiver.name == expr.str() {
+			c.error('`str()` method is called recursively', expr.position())
+		}
 	}
 	return table.string_type
 }

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -392,7 +392,7 @@ pub fn (mut c Checker) string_inter_lit(mut node ast.StringInterLiteral) table.T
 		}
 		// check recursive str
 		if c.cur_fn.is_method && c.cur_fn.name == 'str' && c.cur_fn.receiver.name == expr.str() {
-			c.error('`str()` method is called recursively', expr.position())
+			c.error('cannot call `str()` method recursively', expr.position())
 		}
 	}
 	return table.string_type

--- a/vlib/v/checker/tests/interpolation_recursive_str_err.out
+++ b/vlib/v/checker/tests/interpolation_recursive_str_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/interpolation_recursive_str_err.vv:8:8: error: `str()` method is called recursively
+    6 |
+    7 | fn (t Test) str() string {
+    8 |     _ = '$t'
+      |           ^
+    9 |     return 'test'
+   10 | }

--- a/vlib/v/checker/tests/interpolation_recursive_str_err.out
+++ b/vlib/v/checker/tests/interpolation_recursive_str_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/interpolation_recursive_str_err.vv:8:8: error: `str()` method is called recursively
+vlib/v/checker/tests/interpolation_recursive_str_err.vv:8:8: error: cannot call `str()` method recursively
     6 |
     7 | fn (t Test) str() string {
     8 |     _ = '$t'

--- a/vlib/v/checker/tests/interpolation_recursive_str_err.vv
+++ b/vlib/v/checker/tests/interpolation_recursive_str_err.vv
@@ -1,0 +1,15 @@
+module main
+
+struct Test {
+	a int
+}
+
+fn (t Test) str() string {
+	_ = '$t'
+	return 'test'
+}
+
+fn main() {
+	a := Test{}
+	println(a)
+}


### PR DESCRIPTION
This PR fixes interpolation recursive str (fix #1905).

- Fixes interpolation recursive str.
- Add test `vlib\v\checker\tests\interpolation_recursive_str_err.vv/out`.

```v
module main

struct Test {
	a int
}

fn (t Test) str() string {
	_ = '$t'
	return 'test'
}

fn main() {
	a := Test{}
	println(a)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:8:8: error: `str()` method is called recursively
    6 | 
    7 | fn (t Test) str() string {
    8 |     _ = '$t'
      |           ^
    9 |     return 'test'
   10 | }
```