### PR TITLE
GitHub Action: fix 'weekly' naming

### DIFF
--- a/.github/workflows/binary_artifact.yml
+++ b/.github/workflows/binary_artifact.yml
@@ -3,7 +3,7 @@ name: Build binary artifacts
 on:
   push:
      tags:
-       - weekly.**
+       - latest.**
        - 0.**
 
 jobs:


### PR DESCRIPTION
'weekly' is the wrong term, since a new release happens at every push.  Even 'daily' is not enough ;)
