### PR TITLE
vfmt: improve map value alignment (#7105)

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -872,10 +872,16 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 			}
 			f.writeln('{')
 			f.indent++
+			mut maxfieldlen := 0
+			for _, key in node.keys {
+				if key.str().len > maxfieldlen {
+					maxfieldlen = key.str().len
+				}
+			}
 			for i, key in node.keys {
 				f.expr(key)
-				// f.write(strings.repeat(` `, max - field.name.len))
 				f.write(': ')
+				f.write(strings.repeat(` `, maxfieldlen - key.str().len))
 				f.expr(node.vals[i])
 				f.writeln('')
 			}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -865,28 +865,7 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 			f.lock_expr(node)
 		}
 		ast.MapInit {
-			if node.keys.len == 0 {
-				f.write(f.table.type_to_str(node.typ))
-				f.write('{}')
-				return
-			}
-			f.writeln('{')
-			f.indent++
-			mut maxfieldlen := 0
-			for _, key in node.keys {
-				if key.str().len > maxfieldlen {
-					maxfieldlen = key.str().len
-				}
-			}
-			for i, key in node.keys {
-				f.expr(key)
-				f.write(': ')
-				f.write(strings.repeat(` `, maxfieldlen - key.str().len))
-				f.expr(node.vals[i])
-				f.writeln('')
-			}
-			f.indent--
-			f.write('}')
+			f.map_init(node)
 		}
 		ast.MatchExpr {
 			f.match_expr(node)
@@ -1809,6 +1788,31 @@ pub fn (mut f Fmt) array_init(it ast.ArrayInit) {
 			f.write('{}')
 		}
 	}
+}
+
+pub fn (mut f Fmt) map_init(it ast.MapInit) {
+	if it.keys.len == 0 {
+		f.write(f.table.type_to_str(it.typ))
+		f.write('{}')
+		return
+	}
+	f.writeln('{')
+	f.indent++
+	mut max_field_len := 0
+	for _, key in it.keys {
+		if key.str().len > max_field_len {
+			max_field_len = key.str().len
+		}
+	}
+	for i, key in it.keys {
+		f.expr(key)
+		f.write(': ')
+		f.write(strings.repeat(` `, max_field_len - key.str().len))
+		f.expr(it.vals[i])
+		f.writeln('')
+	}
+	f.indent--
+	f.write('}')
 }
 
 pub fn (mut f Fmt) struct_init(it ast.StructInit) {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1799,7 +1799,7 @@ pub fn (mut f Fmt) map_init(it ast.MapInit) {
 	f.writeln('{')
 	f.indent++
 	mut max_field_len := 0
-	for _, key in it.keys {
+	for key in it.keys {
 		if key.str().len > max_field_len {
 			max_field_len = key.str().len
 		}

--- a/vlib/v/fmt/tests/maps_expected.vv
+++ b/vlib/v/fmt/tests/maps_expected.vv
@@ -1,9 +1,16 @@
 const (
 	reserved_types = {
-		'i8': true
-		'i16': true
-		'int': true
-		'i64': true
+		'i8':   true
+		'i16':  true
+		'int':  true
+		'i64':  true
 		'i128': true
 	}
 )
+
+numbers := {
+	'one':                                 1
+	'two':                                 2
+	'sevenhundredseventyseven':            777
+	'fivethousandthreehundredtwentyseven': 5327
+}

--- a/vlib/v/fmt/tests/maps_input.vv
+++ b/vlib/v/fmt/tests/maps_input.vv
@@ -7,3 +7,10 @@ reserved_types = {
          'i128': true
 }
 )
+
+numbers := {
+  'one':  1
+  'two':     2
+  'sevenhundredseventyseven': 777
+'fivethousandthreehundredtwentyseven': 5327
+}


### PR DESCRIPTION
This PR attempts to improve vfmt to better align map values.Fix  #7105 by   

Example output taken from the updated test in `vlib/v/fmt/tests/maps_expected.vv`:

```v
const (
	reserved_types = {
		'i8':   true
		'i16':  true
		'int':  true
		'i64':  true
		'i128': true
	}
)

numbers := {
	'one':                                 1
	'two':                                 2
	'sevenhundredseventyseven':            777
	'fivethousandthreehundredtwentyseven': 5327
}
```