### PR TITLE
map: optimize free() and keys()

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1234,6 +1234,7 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		g.expr(it.cond)
 		g.writeln(';')
 		g.writeln('for (int $idx = 0; $idx < ${atmp}.key_values.len; ++$idx) {')
+		// TODO: don't have this check when the map has no deleted elements
 		g.writeln('\tif (!DenseArray_has_index(&${atmp}.key_values, $idx)) {continue;}')
 		if it.key_var != '_' {
 			key_styp := g.typ(it.key_type)


### PR DESCRIPTION
This PR is just a simple optimization for `map.keys()` and  `map.free()` when the map has had no deletes. This should make them a lot faster. I'm planning to do the same optimization for `for-in` in another PR. I also formatted the file. 