### PR TITLE
net.html: changed license in readme

### DIFF
--- a/vlib/net/html/README.md
+++ b/vlib/net/html/README.md
@@ -115,4 +115,4 @@ A: Like XPath yes. Exactly equal to it, no.
   - [x] finish dom test
 
 ## License
-[MIT](../../LICENSE)
+[MIT](../../../LICENSE)

--- a/vlib/net/html/README.md
+++ b/vlib/net/html/README.md
@@ -115,4 +115,4 @@ A: Like XPath yes. Exactly equal to it, no.
   - [x] finish dom test
 
 ## License
-[GPL3](LICENSE)
+[MIT](../../LICENSE)


### PR DESCRIPTION

As requested in issue #7106 , changed license to the same used in V, using relative path to link to it