### PR TITLE
checker: disallow op= and infix on a voidptr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
     - name: Fixed tests
       run: VJOBS=1 ./v -silent test-fixed
     - name: Build examples
-      run: ./v -silent build-examples
+      run: ./v build-examples
     - name: Build examples with -autofree
       run: |
         ./v -autofree -o tetris examples/tetris/tetris.v
@@ -231,7 +231,7 @@ jobs:
     - name: Fixed tests (-prod)
       run: ./v -o vprod -prod cmd/v && ./vprod -silent test-fixed
     - name: Build examples
-      run: ./v -silent build-examples
+      run: ./v build-examples
     - name: Build examples with -autofree
       run: |
         ./v -autofree -experimental -o tetris examples/tetris/tetris.v

--- a/cmd/tools/bench/wyhash.v
+++ b/cmd/tools/bench/wyhash.v
@@ -30,7 +30,7 @@ fn main() {
 	checksum = 0
 	for len in str_lens {
 		end_pos := start_pos + len
-		checksum ^= wyhash.wyhash_c(unsafe { bytepile.data + start_pos }, u64(len), 1)
+		checksum ^= wyhash.wyhash_c(unsafe { byteptr(bytepile.data) + start_pos }, u64(len), 1)
 		start_pos = end_pos
 	}
 	bhashing_1.measure('wyhash.wyhash_c  | checksum: ${checksum:22}')

--- a/vlib/term/ui/input_nix.c.v
+++ b/vlib/term/ui/input_nix.c.v
@@ -46,7 +46,7 @@ pub fn (mut ctx Context) run() ? {
 // TODO: remove
 fn (mut ctx Context) shift(len int) {
 	unsafe {
-		C.memmove(ctx.read_buf.data, ctx.read_buf.data + len, ctx.read_buf.cap - len)
+		C.memmove(ctx.read_buf.data, byteptr(ctx.read_buf.data) + len, ctx.read_buf.cap - len)
 		ctx.resize_arr(ctx.read_buf.len - len)
 	}
 }

--- a/vlib/term/ui/termios_nix.c.v
+++ b/vlib/term/ui/termios_nix.c.v
@@ -221,7 +221,7 @@ fn (mut ctx Context) termios_loop() {
 			sw.restart()
 			if ctx.cfg.event_fn != voidptr(0) {
 				unsafe {
-					len := C.read(C.STDIN_FILENO, ctx.read_buf.data + ctx.read_buf.len, ctx.read_buf.cap - ctx.read_buf.len)
+					len := C.read(C.STDIN_FILENO, byteptr(ctx.read_buf.data) + ctx.read_buf.len, ctx.read_buf.cap - ctx.read_buf.len)
 					ctx.resize_arr(ctx.read_buf.len + len)
 				}
 				if ctx.read_buf.len > 0 {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2232,12 +2232,10 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 						c.error('invalid right operand: $left_sym.name $assign_stmt.op $right_sym.name',
 							right.position())
 					}
-				} else if !left_sym.is_number() && left_sym.kind !in
-					[.byteptr, .charptr] {
+				} else if !left_sym.is_number() && left_sym.kind !in [.byteptr, .charptr] {
 					c.error('operator `$assign_stmt.op` not defined on left operand type `$left_sym.name`',
 						left.position())
-				} else if !right_sym.is_number() && left_sym.kind !in
-					[.byteptr, .charptr] {
+				} else if !right_sym.is_number() && left_sym.kind !in [.byteptr, .charptr] {
 					c.error('invalid right operand: $left_sym.name $assign_stmt.op $right_sym.name',
 						right.position())
 				} else if right is ast.IntegerLiteral {

--- a/vlib/v/checker/tests/pointer_ops.out
+++ b/vlib/v/checker/tests/pointer_ops.out
@@ -12,7 +12,7 @@ vlib/v/checker/tests/pointer_ops.vv:6:4: error: invalid operation: ++ (non-numer
       |          ~~
     7 |         p += 3
     8 |         _ = p - 1
-vlib/v/checker/tests/pointer_ops.vv:7:3: error: operator += not defined on left operand type `voidptr`
+vlib/v/checker/tests/pointer_ops.vv:7:3: error: operator `+=` not defined on left operand type `voidptr`
     5 |         _ = p + 1
     6 |         p++
     7 |         p += 3
@@ -33,7 +33,7 @@ vlib/v/checker/tests/pointer_ops.vv:9:4: error: invalid operation: -- (non-numer
       |          ~~
    10 |         p -= 3
    11 |     }
-vlib/v/checker/tests/pointer_ops.vv:10:3: error: operator -= not defined on left operand type `voidptr`
+vlib/v/checker/tests/pointer_ops.vv:10:3: error: operator `-=` not defined on left operand type `voidptr`
     8 |         _ = p - 1
     9 |         p--
    10 |         p -= 3

--- a/vlib/v/checker/tests/pointer_ops.out
+++ b/vlib/v/checker/tests/pointer_ops.out
@@ -1,0 +1,42 @@
+vlib/v/checker/tests/pointer_ops.vv:5:7: error: `+` cannot be used with `voidptr`
+    3 |     unsafe {
+    4 |         mut p := voidptr(0)
+    5 |         _ = p + 1
+      |             ^
+    6 |         p++
+    7 |         p += 3
+vlib/v/checker/tests/pointer_ops.vv:6:4: error: invalid operation: ++ (non-numeric type `voidptr`)
+    4 |         mut p := voidptr(0)
+    5 |         _ = p + 1
+    6 |         p++
+      |          ~~
+    7 |         p += 3
+    8 |         _ = p - 1
+vlib/v/checker/tests/pointer_ops.vv:7:3: error: operator += not defined on left operand type `voidptr`
+    5 |         _ = p + 1
+    6 |         p++
+    7 |         p += 3
+      |         ^
+    8 |         _ = p - 1
+    9 |         p--
+vlib/v/checker/tests/pointer_ops.vv:8:7: error: `-` cannot be used with `voidptr`
+    6 |         p++
+    7 |         p += 3
+    8 |         _ = p - 1
+      |             ^
+    9 |         p--
+   10 |         p -= 3
+vlib/v/checker/tests/pointer_ops.vv:9:4: error: invalid operation: -- (non-numeric type `voidptr`)
+    7 |         p += 3
+    8 |         _ = p - 1
+    9 |         p--
+      |          ~~
+   10 |         p -= 3
+   11 |     }
+vlib/v/checker/tests/pointer_ops.vv:10:3: error: operator -= not defined on left operand type `voidptr`
+    8 |         _ = p - 1
+    9 |         p--
+   10 |         p -= 3
+      |         ^
+   11 |     }
+   12 | }

--- a/vlib/v/checker/tests/pointer_ops.vv
+++ b/vlib/v/checker/tests/pointer_ops.vv
@@ -1,0 +1,12 @@
+// void* arithmetic is not allowed in MSVC, so ban it
+fn test_voidptr() {
+	unsafe {
+		mut p := voidptr(0)
+		_ = p + 1
+		p++
+		p += 3
+		_ = p - 1
+		p--
+		p -= 3
+	}
+}


### PR DESCRIPTION
MSVC does not allow `void*` arithmetic, and I suspect it's not in the C standard.

Note: postfix was already disallowed.
~~Merge `plus_assign` and `minus_assign` match branches.~~

For infix only a voidptr on the left is checked. This doesn't disallow `int + voidptr`, but I'll handle that in a separate pull because other checks don't handle a pointer on the right either.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
