### PR TITLE
time: parse_iso8601 supports format without microsec

### DIFF
--- a/vlib/time/parse_test.v
+++ b/vlib/time/parse_test.v
@@ -49,13 +49,25 @@ fn test_parse_rfc2822_invalid() {
 }
 
 fn test_iso8601_parse_utc() {
-	format_utc := '2020-06-05T15:38:06.015959Z'
-	t_utc := time.parse_iso8601(format_utc) or {
-		panic(err)
+	formats := [
+		'2020-06-05T15:38:06.015959Z',
+		'2020-06-05T15:38:06Z',
+	]
+	times := [
+		[2020, 6, 5, 15, 38, 6, 15959],
+		[2020, 6, 5, 15, 38, 6, 0],
+	]
+	for i, format in formats {
+		t := time.parse_iso8601(format) or { panic(err) }
+		tt := times[i]
+		assert t.year == tt[0]
+		assert t.month == tt[1]
+		assert t.day == tt[2]
+		assert t.hour == tt[3]
+		assert t.minute == tt[4]
+		assert t.second == tt[5]
+		assert t.microsecond == tt[6]
 	}
-	assert t_utc.year == 2020
-	assert t_utc.month == 6
-	assert t_utc.day == 5
 }
 
 fn test_iso8601_parse_loacl() {


### PR DESCRIPTION
See subject and code.

And small improvement in test

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
