### PR TITLE
cgen: optimize array op assign

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -796,6 +796,57 @@ fn test_in_struct() {
 	assert baz.bar[0] == 3
 }
 
+[direct_array_access]
+fn test_direct_modification() {
+	mut foo := [2, 0, 5]
+	foo[1] = 3
+	foo[0] *= 7
+	foo[1]--
+	foo[2] -= 2
+	assert foo[0] == 14
+	assert foo[1] == 2
+	assert foo[2] == 3
+}
+
+fn test_shared_modification() {
+	shared foo := &[2, 0, 5]
+	lock foo {
+		unsafe {
+			foo[1] = 3
+			foo[0] *= 7
+			foo[1]--
+			foo[2] -= 2
+		}
+	}
+	rlock foo {
+		unsafe {
+			assert foo[0] == 14
+			assert foo[1] == 2
+			assert foo[2] == 3
+		}
+	}
+}
+
+[direct_array_access]
+fn test_shared_direct_modification() {
+	shared foo := &[2, 0, 5]
+	lock foo {
+		unsafe {
+			foo[1] = 3
+			foo[0] *= 7
+			foo[1]--
+			foo[2] -= 2
+		}
+	}
+	rlock foo {
+		unsafe {
+			assert foo[0] == 14
+			assert foo[1] == 2
+			assert foo[2] == 3
+		}
+	}
+}
+
 fn test_bools() {
 	println('test b')
 	mut a := [true, false]

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3686,7 +3686,6 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 						}
 					}
 					g.expr(node.left)
-					// TODO: test direct_array_access when 'shared' is implemented
 					if node.left_type.has_flag(.shared_f) {
 						if left_is_ptr {
 							g.write('->val')


### PR DESCRIPTION
This is the same optimization for arrays as was #7162 for maps, i.e. code like
```v
nums[i] *= 2
```
now compiles to
```C
(*(int*)array_get(nums, i)) *= 2;
```
instead of
```C
array_set(&nums, i, &(int[]) { *(int*)array_get(nums, i) *2 });
```
as it did before. So the address calculation (and bounds check) has to be done only once.

I've added test cases for `[direct_array_access]` and/or `shared` arrays.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
