### PR TITLE
checker: improve 'operator not defined on right operand type' error

### DIFF
--- a/vlib/v/checker/tests/assign_expr_type_err_e.out
+++ b/vlib/v/checker/tests/assign_expr_type_err_e.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/assign_expr_type_err_e.vv:3:2: error: operator -= not defined on left operand type `string`
+vlib/v/checker/tests/assign_expr_type_err_e.vv:3:2: error: operator `-=` not defined on left operand type `string`
     1 | fn main() {
     2 |     mut foo := 'hello'
     3 |     foo -= `a`

--- a/vlib/v/checker/tests/assign_expr_type_err_f.out
+++ b/vlib/v/checker/tests/assign_expr_type_err_f.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/assign_expr_type_err_f.vv:3:9: error: operator -= not defined on right operand type `bool`
+vlib/v/checker/tests/assign_expr_type_err_f.vv:3:9: error: invalid right operand: int -= bool
     1 | fn main() {
     2 |     mut foo := 10
     3 |     foo -= false

--- a/vlib/v/checker/tests/assign_expr_type_err_g.out
+++ b/vlib/v/checker/tests/assign_expr_type_err_g.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/assign_expr_type_err_g.vv:3:2: error: operator += not defined on left operand type `bool`
+vlib/v/checker/tests/assign_expr_type_err_g.vv:3:2: error: operator `+=` not defined on left operand type `bool`
     1 | fn main() {
     2 |     mut foo := true
     3 |     foo += false

--- a/vlib/v/checker/tests/assign_expr_type_err_h.out
+++ b/vlib/v/checker/tests/assign_expr_type_err_h.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/assign_expr_type_err_h.vv:3:9: error: operator += not defined on right operand type `bool`
+vlib/v/checker/tests/assign_expr_type_err_h.vv:3:9: error: invalid right operand: string += bool
     1 | fn main() {
     2 |     mut foo := 'hello'
     3 |     foo += false

--- a/vlib/v/checker/tests/assign_expr_type_err_i.out
+++ b/vlib/v/checker/tests/assign_expr_type_err_i.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/assign_expr_type_err_i.vv:3:9: error: cannot assign to `foo`: expected `f64`, not `string`
+vlib/v/checker/tests/assign_expr_type_err_i.vv:3:9: error: invalid right operand: f64 += string
     1 | fn main() {
     2 |     mut foo := 1.5
     3 |     foo += 'hello' 


### PR DESCRIPTION
Change error to say 'invalid right operand'.
Show left type when right operand is invalid.
Merge `plus_assign` and `minus_assign` match branches.
Separate string logic from number logic - this means repeating the error messages but makes the logic easier to follow.
Speed up IntegerLiteral == 1 check.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
