### PR TITLE
gen: ensure C compiler size_t matches V's usize

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -331,6 +331,13 @@ pub fn (mut g Gen) init() {
 		g.cheaders.writeln('#include <spawn.h>')
 	}
 	g.write_builtin_types()
+	g.definitions.writeln('#define STATIC_ASSERT(COND, UNDERSCORE_MSG) \\')
+	g.definitions.writeln('\ttypedef char static_assertion_##UNDERSCORE_MSG[(COND) ? 1 : -1]')
+	if g.pref.m64 {
+		g.definitions.writeln('STATIC_ASSERT(sizeof(size_t) == 8, size_t_must_be_8);')
+	} else {
+		g.definitions.writeln('STATIC_ASSERT(sizeof(size_t) == 4, size_t_must_be_4);')
+	}
 	g.write_typedef_types()
 	g.write_typeof_functions()
 	if g.pref.build_mode != .build_module {


### PR DESCRIPTION
Use a C static assert hack to ensure `sizeof(size_t)` in C is consistent with V's `m64` pref. 

Follows on from #7011, needed for #6213.

If the `STATIC_ASSERT` fails, you'll see something like this:
```
C:\Users\ntrel\AppData\Local\Temp\v\v2.8731864504705008227.tmp.c:4050:15: error: size of array 'static_assertion_size_t_must_be_8' is negative
  typedef char static_assertion_##UNDERSCORE_MSG[(COND) ? 1 : -1]
               ^~~~~~~~~~~~~~~~~
C:\Users\ntrel\AppData\Local\Temp\v\v2.8731864504705008227.tmp.c:4051:1: note: in expansion of macro 'STATIC_ASSERT'
 STATIC_ASSERT(sizeof(size_t) == 8, size_t_must_be_8);
 ^~~~~~~~~~~~~
```


<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
