### PR TITLE
string: rewrite split_nth and fix some bugs

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -301,6 +301,7 @@ fn run_repl(workdir string, vrepl_prefix string) {
 }
 
 fn print_output(s os.Result) {
+	if s.output == '' { return }	
 	lines := s.output.trim_right('\n\r').split('\n')
 	for line in lines {
 		if line.contains('.vrepl_temp.v:') {

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -301,8 +301,7 @@ fn run_repl(workdir string, vrepl_prefix string) {
 }
 
 fn print_output(s os.Result) {
-	if s.output == '' { return }	
-	lines := s.output.trim_right('\n\r').split('\n')
+	lines := s.output.trim_right('\n\r').split_into_lines()
 	for line in lines {
 		if line.contains('.vrepl_temp.v:') {
 			// Hide the temporary file name

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -493,13 +493,12 @@ pub fn (s string) split_nth(delim string, nth int) []string {
 		return res
 	}
 	mut start := 0
-	nth_1 := nth - 1
 	// Take the left part for each delimiter occurence
 	for i <= s.len {
 		is_delim := i + delim.len <= s.len && s.substr(i, i + delim.len) == delim
 		if is_delim {
 			val := s.substr(start, i)
-			was_last := nth > 0 && res.len == nth_1
+			was_last := nth > 0 && res.len == nth - 1
 			if was_last {
 				break
 			}

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -484,7 +484,7 @@ pub fn (s string) split_nth(delim string, nth int) []string {
 		i = 1
 		for ch in s {
 			if nth > 0 && i >= nth {
-				res << s.substr(i, s.len)
+				res << s.right(i)
 				break
 			}
 			res << ch.str()
@@ -494,37 +494,29 @@ pub fn (s string) split_nth(delim string, nth int) []string {
 	}
 	mut start := 0
 	nth_1 := nth - 1
+	// Take the left part for each delimiter occurence
 	for i <= s.len {
-		mut is_delim := unsafe {s.str[i] == delim.str[0]}
-		mut j := 0
-		for is_delim && j < delim.len {
-			is_delim = is_delim && unsafe {s.str[i + j] == delim.str[j]}
-			j++
-		}
-		last := i == s.len - 1
-		if is_delim || last {
-			if !is_delim && last {
-				i++
-			}
-			mut val := s.substr(start, i)
-			if val.starts_with(delim) {
-				val = val.right(delim.len)
-			}
+		is_delim := i + delim.len <= s.len && s.substr(i, i + delim.len) == delim
+		if is_delim {
+			val := s.substr(start, i)
 			was_last := nth > 0 && res.len == nth_1
 			if was_last {
-				res << s.right(start)
 				break
 			}
 			res << val
 			start = i + delim.len
+			i = start
+		} else {
+			i++
 		}
-		i++
 	}
-	if s.ends_with(delim) && (nth < 1 || res.len < nth) {
-		res << ''
+	// Then the remaining right part of the string
+	if nth < 1 || res.len < nth {
+		res << s.right(start)
 	}
 	return res
 }
+
 
 pub fn (s string) split_into_lines() []string {
 	mut res := []string{}

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -138,8 +138,8 @@ fn test_split_nth() {
 	assert (d.split_nth(',', -1).len == 2)
 	assert (d.split_nth(',', 3).len == 2)
 	e := ",,,0,,,,,a,,b,"
-	// assert (e.split(',,').len == 5)
-	// assert (e.split_nth(',,', 3).len == 2)
+	assert (e.split(',,').len == 5)
+	assert (e.split_nth(',,', 3).len == 3)
 	assert (e.split_nth(',', -1).len == 12)
 	assert (e.split_nth(',', 3).len == 3)
 }
@@ -213,6 +213,12 @@ fn test_split() {
 	assert a[4] == 'o'
 	assert a[5] == 'm'
 	assert a[6] == 'e'
+	// /////////
+	s = 'wavy turquoise bags'
+	vals = s.split(' bags')
+	assert vals.len == 2
+	assert vals[0] == 'wavy turquoise'
+	assert vals[1] == ''
 }
 
 fn test_trim_space() {


### PR DESCRIPTION
`split` behaviour was kind of inconstant, so I rewrite it. Hope my code is OK.
At least, all the tests passes + the new ones :) 

* Simplify the whole code
* add some tests
* uncomment asserts
* remove unsafe sections
* use s.right everywhere



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
