### PR TITLE
parser: implement support for -Wimpure-v

### DIFF
--- a/cmd/v/help/build.txt
+++ b/cmd/v/help/build.txt
@@ -126,8 +126,15 @@ The build flags are shared by the build and run commands:
       Treat all warnings as errors, even in development builds.
    
    -Wfatal-errors
-      Unconditionally exit with exit(1) after the first error. Useful for scripts/tooling that calls V.
+      Unconditionally exit with exit(1) after the first error. 
+      Useful for scripts/tooling that calls V.
 
+   -Wimpure-v
+      Warn about using C. or JS. symbols in plain .v files. 
+      These should be moved in .c.v and .js.v .
+      NB: in the future, this will be turned on by default,
+      and will become an error, after vlib is cleaned up.
+      
 For C-specific build flags, use `v help build-c`.
 
 See also:

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -21,7 +21,7 @@ pub fn (mut p Parser) call_expr(language table.Language, mod string) ast.CallExp
 		p.check_name()
 	}
 	if language != .v {
-		p.check_for_unpure_v(language, first_pos)
+		p.check_for_impure_v(language, first_pos)
 	}
 	mut or_kind := ast.OrKind.absent
 	if fn_name == 'json.decode' {
@@ -158,7 +158,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	if language != .v {
 		p.next()
 		p.check(.dot)
-		p.check_for_unpure_v(language, p.tok.position())
+		p.check_for_impure_v(language, p.tok.position())
 	}
 	// Receiver?
 	mut rec_name := ''

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -20,6 +20,9 @@ pub fn (mut p Parser) call_expr(language table.Language, mod string) ast.CallExp
 	} else {
 		p.check_name()
 	}
+	if language != .v {
+		p.check_for_unpure_v(language, first_pos)
+	}
 	mut or_kind := ast.OrKind.absent
 	if fn_name == 'json.decode' {
 		p.expecting_type = true // Makes name_expr() parse the type `User` in `json.decode(User, txt)`
@@ -155,6 +158,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	if language != .v {
 		p.next()
 		p.check(.dot)
+		p.check_for_unpure_v(language, p.tok.position())
 	}
 	// Receiver?
 	mut rec_name := ''

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -15,11 +15,12 @@ import runtime
 import time
 
 pub struct Parser {
+	pref              &pref.Preferences
+mut:
 	file_base         string // "hello.v"
 	file_name         string // "/home/user/hello.v"
 	file_name_dir     string // "/home/user"
-	pref              &pref.Preferences
-mut:
+	file_backend_mode table.Language // .c for .c.v|.c.vv|.c.vsh files; .js for .js.v files, .v otherwise.
 	scanner           &scanner.Scanner
 	comments_mode     scanner.CommentsMode = .skip_comments
 	// see comment in parse_file
@@ -101,9 +102,6 @@ pub fn parse_text(text string, path string, table &table.Table, comments_mode sc
 	mut p := Parser{
 		scanner: s
 		comments_mode: comments_mode
-		file_name: path
-		file_base: os.base(path)
-		file_name_dir: os.dir(path)
 		table: table
 		pref: pref
 		scope: &ast.Scope{
@@ -114,7 +112,21 @@ pub fn parse_text(text string, path string, table &table.Table, comments_mode sc
 		warnings: []errors.Warning{}
 		global_scope: global_scope
 	}
+	p.set_path(path)
 	return p.parse()
+}
+
+pub fn (mut p Parser) set_path(path string) {
+	p.file_name = path
+	p.file_base = os.base(path)
+	p.file_name_dir = os.dir(path)
+	p.file_backend_mode = .v
+	if path.ends_with('.c.v') || path.ends_with('.c.vv') || path.ends_with('.c.vsh') {
+		p.file_backend_mode = .c
+	}
+	if path.ends_with('.js.v') || path.ends_with('.js.vv') || path.ends_with('.js.vsh') {
+		p.file_backend_mode = .js
+	}
 }
 
 pub fn parse_file(path string, table &table.Table, comments_mode scanner.CommentsMode, pref &pref.Preferences, global_scope &ast.Scope) ast.File {
@@ -130,9 +142,6 @@ pub fn parse_file(path string, table &table.Table, comments_mode scanner.Comment
 		scanner: scanner.new_scanner_file(path, comments_mode, pref)
 		comments_mode: comments_mode
 		table: table
-		file_name: path
-		file_base: os.base(path)
-		file_name_dir: os.dir(path)
 		pref: pref
 		scope: &ast.Scope{
 			start_pos: 0
@@ -142,6 +151,7 @@ pub fn parse_file(path string, table &table.Table, comments_mode scanner.Comment
 		warnings: []errors.Warning{}
 		global_scope: global_scope
 	}
+	p.set_path(path)
 	return p.parse()
 }
 
@@ -153,9 +163,6 @@ pub fn parse_vet_file(path string, table_ &table.Table, pref &pref.Preferences) 
 		scanner: scanner.new_vet_scanner_file(path, .parse_comments, pref)
 		comments_mode: .parse_comments
 		table: table_
-		file_name: path
-		file_base: os.base(path)
-		file_name_dir: os.dir(path)
 		pref: pref
 		scope: &ast.Scope{
 			start_pos: 0
@@ -165,6 +172,7 @@ pub fn parse_vet_file(path string, table_ &table.Table, pref &pref.Preferences) 
 		warnings: []errors.Warning{}
 		global_scope: global_scope
 	}
+	p.set_path(path)
 	if p.scanner.text.contains('\n  ') {
 		source_lines := os.read_lines(path) or { []string{} }
 		for lnumber, line in source_lines {
@@ -845,6 +853,28 @@ fn (mut p Parser) parse_attr() table.Attr {
 	}
 }
 
+
+pub fn (mut p Parser) check_for_unpure_v(language table.Language, pos token.Position) {
+	if language == .v {
+		// pure V code is always allowed everywhere
+		return
+	}
+	if !p.pref.warn_unpure_v {
+		// the stricter mode is not ON yet => allow everything for now
+		return
+	}
+	if p.file_backend_mode != language {
+		upcase_language := language.str().to_upper()
+		if p.file_backend_mode == .v {
+			p.warn_with_pos('$upcase_language code will not be allowed in pure .v files, please move it to a .${language}.v file instead', pos)
+			return
+		} else {
+			p.warn_with_pos('$upcase_language code is not allowed in .${p.file_backend_mode}.v files, please move it to a .${language}.v file', pos)
+			return
+		}
+	}
+}
+
 pub fn (mut p Parser) error(s string) {
 	p.error_with_pos(s, p.tok.position())
 }
@@ -1016,12 +1046,13 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 			pos: type_pos
 		}
 	}
-	language := if p.tok.lit == 'C' {
-		table.Language.c
+	mut language := table.Language.v
+	if p.tok.lit == 'C' {
+		language = table.Language.c
+		p.check_for_unpure_v(language, p.tok.position())
 	} else if p.tok.lit == 'JS' {
-		table.Language.js
-	} else {
-		table.Language.v
+		language = table.Language.js
+		p.check_for_unpure_v(language, p.tok.position())
 	}
 	mut mod := ''
 	// p.warn('resetting')
@@ -2030,12 +2061,13 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 	parent_type := first_type
 	parent_name := p.table.get_type_symbol(parent_type).name
 	pid := parent_type.idx()
-	language := if parent_name.len > 2 && parent_name.starts_with('C.') {
-		table.Language.c
+	mut language := table.Language.v
+	if parent_name.len > 2 && parent_name.starts_with('C.') {
+		language = table.Language.c
+		p.check_for_unpure_v(language, decl_pos)
 	} else if parent_name.len > 2 && parent_name.starts_with('JS.') {
-		table.Language.js
-	} else {
-		table.Language.v
+		language = table.Language.js
+		p.check_for_unpure_v(language, decl_pos)
 	}
 	prepend_mod_name := p.prepend_mod(name)
 	p.table.register_type_symbol(table.TypeSymbol{

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -853,7 +853,6 @@ fn (mut p Parser) parse_attr() table.Attr {
 	}
 }
 
-
 pub fn (mut p Parser) check_for_unpure_v(language table.Language, pos token.Position) {
 	if language == .v {
 		// pure V code is always allowed everywhere
@@ -866,10 +865,12 @@ pub fn (mut p Parser) check_for_unpure_v(language table.Language, pos token.Posi
 	if p.file_backend_mode != language {
 		upcase_language := language.str().to_upper()
 		if p.file_backend_mode == .v {
-			p.warn_with_pos('$upcase_language code will not be allowed in pure .v files, please move it to a .${language}.v file instead', pos)
+			p.warn_with_pos('$upcase_language code will not be allowed in pure .v files, please move it to a .${language}.v file instead',
+				pos)
 			return
 		} else {
-			p.warn_with_pos('$upcase_language code is not allowed in .${p.file_backend_mode}.v files, please move it to a .${language}.v file', pos)
+			p.warn_with_pos('$upcase_language code is not allowed in .${p.file_backend_mode}.v files, please move it to a .${language}.v file',
+				pos)
 			return
 		}
 	}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -853,12 +853,12 @@ fn (mut p Parser) parse_attr() table.Attr {
 	}
 }
 
-pub fn (mut p Parser) check_for_unpure_v(language table.Language, pos token.Position) {
+pub fn (mut p Parser) check_for_impure_v(language table.Language, pos token.Position) {
 	if language == .v {
 		// pure V code is always allowed everywhere
 		return
 	}
-	if !p.pref.warn_unpure_v {
+	if !p.pref.warn_impure_v {
 		// the stricter mode is not ON yet => allow everything for now
 		return
 	}
@@ -1050,10 +1050,10 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 	mut language := table.Language.v
 	if p.tok.lit == 'C' {
 		language = table.Language.c
-		p.check_for_unpure_v(language, p.tok.position())
+		p.check_for_impure_v(language, p.tok.position())
 	} else if p.tok.lit == 'JS' {
 		language = table.Language.js
-		p.check_for_unpure_v(language, p.tok.position())
+		p.check_for_impure_v(language, p.tok.position())
 	}
 	mut mod := ''
 	// p.warn('resetting')
@@ -2065,10 +2065,10 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 	mut language := table.Language.v
 	if parent_name.len > 2 && parent_name.starts_with('C.') {
 		language = table.Language.c
-		p.check_for_unpure_v(language, decl_pos)
+		p.check_for_impure_v(language, decl_pos)
 	} else if parent_name.len > 2 && parent_name.starts_with('JS.') {
 		language = table.Language.js
-		p.check_for_unpure_v(language, decl_pos)
+		p.check_for_impure_v(language, decl_pos)
 	}
 	prepend_mod_name := p.prepend_mod(name)
 	p.table.register_type_symbol(table.TypeSymbol{

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -36,6 +36,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 		p.next() // .
 	}
 	name_pos := p.tok.position()
+	p.check_for_unpure_v(language, name_pos)
 	mut name := p.check_name()
 	// defer {
 	// if name.contains('App') {

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -36,7 +36,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 		p.next() // .
 	}
 	name_pos := p.tok.position()
-	p.check_for_unpure_v(language, name_pos)
+	p.check_for_impure_v(language, name_pos)
 	mut name := p.check_name()
 	// defer {
 	// if name.contains('App') {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -121,7 +121,8 @@ pub mut:
 	printfn_list        []string // a list of generated function names, whose source should be shown, for debugging
 	print_v_files       bool // when true, just print the list of all parsed .v files then stop.
 	skip_running        bool // when true, do no try to run the produced file (set by b.cc(), when -o x.c or -o x.js)
-	skip_warnings       bool // like C's "-w"
+	skip_warnings       bool // like C's "-w", forces warnings to be ignored.
+	warn_unpure_v       bool // -Wunpure-v, force a warning for JS.fn()/C.fn(), outside of .js.v/.c.v files. TODO: turn to an error by default
 	warns_are_errors    bool // -W, like C's "-Werror", treat *every* warning is an error
 	fatal_errors        bool // unconditionally exit after the first error with exit(1)
 	reuse_tmpc          bool // do not use random names for .tmp.c and .tmp.c.rsp files, and do not remove them
@@ -172,6 +173,9 @@ pub fn parse_args(args []string) (&Preferences, string) {
 			}
 			'-progress' {
 				// processed by testing tools in cmd/tools/modules/testing/common.v
+			}
+			'-Wunpure-v' {
+				res.warn_unpure_v = true
 			}
 			'-Wfatal-errors' {
 				res.fatal_errors = true

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -122,7 +122,7 @@ pub mut:
 	print_v_files       bool // when true, just print the list of all parsed .v files then stop.
 	skip_running        bool // when true, do no try to run the produced file (set by b.cc(), when -o x.c or -o x.js)
 	skip_warnings       bool // like C's "-w", forces warnings to be ignored.
-	warn_unpure_v       bool // -Wunpure-v, force a warning for JS.fn()/C.fn(), outside of .js.v/.c.v files. TODO: turn to an error by default
+	warn_impure_v       bool // -Wimpure-v, force a warning for JS.fn()/C.fn(), outside of .js.v/.c.v files. TODO: turn to an error by default
 	warns_are_errors    bool // -W, like C's "-Werror", treat *every* warning is an error
 	fatal_errors        bool // unconditionally exit after the first error with exit(1)
 	reuse_tmpc          bool // do not use random names for .tmp.c and .tmp.c.rsp files, and do not remove them
@@ -174,8 +174,8 @@ pub fn parse_args(args []string) (&Preferences, string) {
 			'-progress' {
 				// processed by testing tools in cmd/tools/modules/testing/common.v
 			}
-			'-Wunpure-v' {
-				res.warn_unpure_v = true
+			'-Wimpure-v' {
+				res.warn_impure_v = true
 			}
 			'-Wfatal-errors' {
 				res.fatal_errors = true


### PR DESCRIPTION
Implement -Wunpure-v flag. With it:
```
vlib/v/ast/ast.v:1165:12: warning: C code will not be allowed in pure .v files, please move it to a .c.v file instead
 1163 | pub fn ex2fe(x Expr) table.FExpr {
 1164 |     res := table.FExpr{}
 1165 |     unsafe {C.memcpy(&res, &x, sizeof(table.FExpr))}
      |               ~~~~~~
 1166 |     return res
 1167 | }
vlib/v/gen/x64/gen.v:629:18: warning: C code will not be allowed in pure .v files, please move it to a .c.v file instead
  627 |                     verror('opcodes format: xx xx xx xx')
  628 |                 }
  629 |                 b := unsafe {C.strtol(charptr(word.str), 0, 16)}
      |                              ^
  630 |                 // b := word.byte()
  631 |                 // println('"$word" $b')
vlib/v/gen/x64/gen.v:629:20: warning: C code will not be allowed in pure .v files, please move it to a .c.v file instead
  627 |                     verror('opcodes format: xx xx xx xx')
  628 |                 }
  629 |                 b := unsafe {C.strtol(charptr(word.str), 0, 16)}
      |                                ~~~~~~
  630 |                 // b := word.byte()
  631 |                 // println('"$word" $b')
vlib/v/gen/x64/gen.v:647:6: warning: C code will not be allowed in pure .v files, please move it to a .c.v file instead
  645 | }
  646 | 
  647 | fn C.strtol() int
      |      ~~~~~~
  648 | 
  649 | fn (mut g Gen) expr(node ast.Expr) {
vlib/runtime/runtime.v:10:6: warning: C code will not be allowed in pure .v files, please move it to a .c.v file instead
    8 | 
    9 | //$if linux {
   10 | fn C.sysconf(name int) i64
      |      ~~~~~~~
   11 | //}
   12 |
vlib/runtime/runtime.v:14:6: warning: C code will not be allowed in pure .v files, please move it to a .c.v file instead
   12 | 
   13 | //$if windows {
   14 | fn C.GetCurrentProcessorNumber() u32
      |      ~~~~~~~~~~~~~~~~~~~~~~~~~
   15 | //}
   16 |
0[11:58:57]delian@nemesis: /v/pv $
```