### PR TITLE
vfmt: improve the documentation for the -c flag

### DIFF
--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -16,7 +16,6 @@ import vhelp
 
 struct FormatOptions {
 	is_l       bool
-	is_c       bool // NB: This refers to the '-c' fmt flag, NOT the C backend
 	is_w       bool
 	is_diff    bool
 	is_verbose bool
@@ -50,8 +49,10 @@ fn main() {
 	toolexe := os.executable()
 	util.set_vroot_folder(os.dir(os.dir(os.dir(toolexe))))
 	args := util.join_env_vflags_and_os_args()
+	if '-c' in args {
+		eprintln('`-c` is deprectaed. Please use `-verify` instead.')
+	}
 	foptions := FormatOptions{
-		is_c: '-c' in args
 		is_l: '-l' in args
 		is_w: '-w' in args
 		is_diff: '-diff' in args
@@ -225,13 +226,6 @@ fn (foptions &FormatOptions) post_process_file(file string, formatted_file_path 
 		return
 	}
 	is_formatted_different := fc != formatted_fc
-	if foptions.is_c {
-		if is_formatted_different {
-			eprintln('File is not formatted: $file')
-			exit(2)
-		}
-		return
-	}
 	if foptions.is_l {
 		if is_formatted_different {
 			eprintln('File needs formatting: $file')

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -16,6 +16,7 @@ import vhelp
 
 struct FormatOptions {
 	is_l       bool
+	is_c       bool // NB: This refers to the '-c' fmt flag, NOT the C backend
 	is_w       bool
 	is_diff    bool
 	is_verbose bool
@@ -49,10 +50,8 @@ fn main() {
 	toolexe := os.executable()
 	util.set_vroot_folder(os.dir(os.dir(os.dir(toolexe))))
 	args := util.join_env_vflags_and_os_args()
-	if '-c' in args {
-		eprintln('`-c` is deprectaed. Please use `-verify` instead.')
-	}
 	foptions := FormatOptions{
+		is_c: '-c' in args
 		is_l: '-l' in args
 		is_w: '-w' in args
 		is_diff: '-diff' in args
@@ -226,6 +225,13 @@ fn (foptions &FormatOptions) post_process_file(file string, formatted_file_path 
 		return
 	}
 	is_formatted_different := fc != formatted_fc
+	if foptions.is_c {
+		if is_formatted_different {
+			eprintln('File is not formatted: $file')
+			exit(2)
+		}
+		return
+	}
 	if foptions.is_l {
 		if is_formatted_different {
 			eprintln('File needs formatting: $file')

--- a/cmd/v/help/fmt.txt
+++ b/cmd/v/help/fmt.txt
@@ -4,6 +4,9 @@ Usage:
 Formats the given V source files, then prints their formatted source to stdout.
 
 Options:
+  -c      Check if a file is already formatted. If not, print the filepath and exit with code 2.
+          Compared to -verify it is quicker but has a small trade-off in precision.
+
   -diff   Display the differences between the formatted source(s) and the original source(s).
           This will attempt to find a working `diff` command automatically unless you
           specify one with the VDIFF_TOOL environment variable.

--- a/cmd/v/help/fmt.txt
+++ b/cmd/v/help/fmt.txt
@@ -4,9 +4,6 @@ Usage:
 Formats the given V source files, then prints their formatted source to stdout.
 
 Options:
-  -c      Check if file is already formatted.
-          If it is not, print filepath, and exit with code 2.
-
   -diff   Display the differences between the formatted source(s) and the original source(s).
           This will attempt to find a working `diff` command automatically unless you
           specify one with the VDIFF_TOOL environment variable.


### PR DESCRIPTION
`fmt -c <file>` and `fmt -verify <file>` have the same purpose.
Therefore this PR deprecates the `-c` flag, that I never saw used anywhere, in favor of `-verify`.