### PR TITLE
struct: properly parse comments on lines after init fields

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -207,6 +207,7 @@ pub:
 	expr          Expr
 	pos           token.Position
 	comments      []Comment
+	next_comments    []Comment
 pub mut:
 	name          string
 	typ           table.Type

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -207,7 +207,7 @@ pub:
 	expr          Expr
 	pos           token.Position
 	comments      []Comment
-	next_comments    []Comment
+	next_comments []Comment
 pub mut:
 	name          string
 	typ           table.Type

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1866,6 +1866,7 @@ pub fn (mut f Fmt) struct_init(it ast.StructInit) {
 			} else {
 				f.writeln('')
 			}
+			f.comments(field.next_comments, inline: false, has_nl: true, level: .keep)
 		}
 		f.indent--
 		if !use_short_args {

--- a/vlib/v/fmt/tests/comments_keep.vv
+++ b/vlib/v/fmt/tests/comments_keep.vv
@@ -1,5 +1,7 @@
 struct User {
 	name string // name
+	// middle comment
+	age  int
 	// last comment
 	// last comment2
 }
@@ -15,4 +17,11 @@ fn main() {
 	// else
 	// else {
 	// }
+	_ := User{
+		name: 'Henry' // comment after name
+		// on the next line
+		age: 42
+		// after age line
+		// after line2
+	}
 }

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -576,7 +576,7 @@ pub fn (mut p Parser) eat_comments() []ast.Comment {
 	return comments
 }
 
-pub fn (mut p Parser) eat_lineend_comments() []ast.Comment {
+pub fn (mut p Parser) eat_line_end_comments() []ast.Comment {
 	mut comments := []ast.Comment{}
 	for {
 		if p.tok.kind != .comment || p.tok.line_nr != p.prev_tok.line_nr {
@@ -1970,7 +1970,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		// function type: `type mycallback fn(string, int)`
 		fn_name := p.prepend_mod(name)
 		fn_type := p.parse_fn_type(fn_name)
-		comments = p.eat_lineend_comments()
+		comments = p.eat_line_end_comments()
 		return ast.FnTypeDecl{
 			name: fn_name
 			is_pub: is_pub
@@ -2017,7 +2017,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 			}
 			is_public: is_pub
 		})
-		comments = p.eat_lineend_comments()
+		comments = p.eat_line_end_comments()
 		return ast.SumTypeDecl{
 			name: name
 			is_pub: is_pub
@@ -2050,7 +2050,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		}
 		is_public: is_pub
 	})
-	comments = p.eat_lineend_comments()
+	comments = p.eat_line_end_comments()
 	return ast.AliasTypeDecl{
 		name: name
 		is_pub: is_pub

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -323,17 +323,18 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 		mut expr := ast.Expr{}
 		mut field_pos := token.Position{}
 		mut comments := []ast.Comment{}
+		mut nline_comments := []ast.Comment{}
 		if no_keys {
 			// name will be set later in checker
 			expr = p.expr(0)
 			field_pos = expr.position()
-			comments = p.eat_comments()
+			comments = p.eat_line_end_comments()
 		} else {
 			first_field_pos := p.tok.position()
 			field_name = p.check_name()
 			p.check(.colon)
 			expr = p.expr(0)
-			comments = p.eat_comments()
+			comments = p.eat_line_end_comments()
 			last_field_pos := expr.position()
 			field_pos = token.Position{
 				line_nr: first_field_pos.line_nr
@@ -345,12 +346,14 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 		if p.tok.kind == .comma {
 			p.next()
 		}
-		comments << p.eat_comments()
+		comments << p.eat_line_end_comments()
+		nline_comments << p.eat_comments()
 		fields << ast.StructInitField{
 			name: field_name
 			expr: expr
 			pos: field_pos
 			comments: comments
+			next_comments: nline_comments
 		}
 	}
 	last_pos := p.tok.position()


### PR DESCRIPTION
Fix #6760 