### PR TITLE
time: parse_iso8601 supports date only format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,10 @@ jobs:
       run: ./v -o v2 cmd/v && ./v2 -o v3 cmd/v && ./v3 -o v4 cmd/v
     - name: Fixed tests
       run: ./v -silent test-fixed
+    - name: Test time functions in a timezone A, different than UTC
+      run: TZ=UTC+3 ./v test vlib/time/
+    - name: Test time functions in a timezone B, different than UTC
+      run: TZ=UTC+12 ./v test vlib/time/
     - name: Test building v tools
       run: ./v -silent build-tools
     - name: v doctor

--- a/vlib/time/parse.v
+++ b/vlib/time/parse.v
@@ -44,44 +44,72 @@ pub fn parse_rfc2822(s string) ?Time {
 	return parse(tos(tmstr, count))
 }
 
+const (
+	err_invalid_8601 = error('Invalid 8601 Format')
+)
+
+fn parse_iso8601_date(s string) ?(int, int, int) {
+	year, month, day := 0, 0, 0
+	count := unsafe {C.sscanf(charptr(s.str), '%4d-%2d-%2d', &year, &month, &day)}
+	if count != 3 {
+		return err_invalid_8601
+	}
+	return year, month, day
+}
+
+fn parse_iso8601_time(s string) ?(int, int, int, int, i64, bool) {
+	hour := 0
+	minute := 0
+	second := 0
+	microsecond := 0
+	plus_min_z := `a`
+	offset_hour := 0
+	offset_minute := 0
+	mut count := unsafe {C.sscanf(charptr(s.str), '%2d:%2d:%2d.%6d%c%2d:%2d', &hour, &minute,
+		&second, &microsecond, charptr(&plus_min_z), &offset_hour, &offset_minute)}
+	// Missread microsecond ([Sec Hour Minute].len == 3 < 4)
+	if count < 4 {
+		count = unsafe {C.sscanf(charptr(s.str), '%2d:%2d:%2d%c%2d:%2d', &hour, &minute,
+			&second, charptr(&plus_min_z), &offset_hour, &offset_minute)}
+		count++ // Increment count because skipped microsecond
+	}
+	if count < 4 {
+		return err_invalid_8601
+	}
+	is_local_time := plus_min_z == `a` && count == 4
+	is_utc := plus_min_z == `Z` && count == 5
+	if !(count == 7 || is_local_time || is_utc) {
+		return err_invalid_8601
+	}
+	if plus_min_z != `+` && plus_min_z != `-` && !is_utc && !is_local_time {
+		return error('Invalid 8601 format, expected `Z` or `+` or `-` as time separator')
+	}
+	mut unix_offset := 0
+	if offset_hour > 0 {
+		unix_offset += 3600 * offset_hour
+	}
+	if offset_minute > 0 {
+		unix_offset += 60 * offset_minute
+	}
+	if plus_min_z == `+` {
+		unix_offset *= -1
+	}
+	return hour, minute, second, microsecond, unix_offset, is_utc
+}
+
 // parse_iso8601 parses rfc8601 time format yyyy-MM-ddTHH:mm:ss.dddddd+dd:dd as local time
 // the fraction part is difference in milli seconds and the last part is offset
 // from UTC time and can be both +/- HH:mm
 // remarks: not all iso8601 is supported
 // also checks and support for leapseconds should be added in future PR
 pub fn parse_iso8601(s string) ?Time {
-	year := 0
-	month := 0
-	day := 0
-	hour := 0
-	minute := 0
-	second := 0
-	mic_second := 0
-	time_char := `a`
-	plus_min_z := `a`
-	offset_hour := 0
-	offset_min := 0
-	mut count := unsafe {C.sscanf(charptr(s.str), '%4d-%2d-%2d%c%2d:%2d:%2d.%6d%c%2d:%2d',
-		&year, &month, &day, charptr(&time_char), &hour, &minute, &second, &mic_second, charptr(&plus_min_z),
-		&offset_hour, &offset_min)}
-	// Missread microsec ([Year Month Day T Sec Hour Minute].len == 7 < 8)
-	if count < 8 {
-		count = unsafe {C.sscanf(charptr(s.str), '%4d-%2d-%2d%c%2d:%2d:%2d%c%2d:%2d',
-			&year, &month, &day, charptr(&time_char), &hour, &minute, &second, charptr(&plus_min_z),
-			&offset_hour, &offset_min)}
-		count++ // Increment count because skipped microsec
+	t_i := s.index('T') or { -1 }
+	parts := if t_i != -1 { [s[..t_i], s[t_i + 1..]] } else { s.split(' ') }
+	if parts.len != 2 {
+		return err_invalid_8601
 	}
-	is_local_time := plus_min_z == `a` && count == 8
-	is_utc := plus_min_z == `Z` && count == 9
-	if count != 11 && !is_local_time && !is_utc {
-		return error('Invalid 8601 format')
-	}
-	if time_char != `T` && time_char != ` ` {
-		return error('Invalid 8601 format, expected space or `T` as time separator')
-	}
-	if plus_min_z != `+` && plus_min_z != `-` && plus_min_z != `Z` && !is_local_time {
-		return error('Invalid 8601 format, expected `Z` or `+` or `-` as time separator')
-	}
+	year, month, day := parse_iso8601_date(parts[0]) ?
+	hour, minute, second, microsecond, unix_offset, is_utc := parse_iso8601_time(parts[1]) ?
 	mut t := new_time(Time{
 		year: year
 		month: month
@@ -89,30 +117,18 @@ pub fn parse_iso8601(s string) ?Time {
 		hour: hour
 		minute: minute
 		second: second
-		microsecond: mic_second
+		microsecond: microsecond
 	})
 	if is_utc {
 		return t
 	}
-	if is_local_time {
-		return to_local_time(t)
-	}
 	mut unix_time := t.unix
-	mut unix_offset := int(0)
-	if offset_hour > 0 {
-		unix_offset += 3600 * offset_hour
+	if unix_offset < 0 {
+		unix_time -= u64(-unix_offset)
+	} else if unix_offset > 0 {
+		unix_time += u64(unix_offset)
 	}
-	if offset_min > 0 {
-		unix_offset += 60 * offset_min
-	}
-	if unix_offset != 0 {
-		if plus_min_z == `+` {
-			unix_time -= u64(unix_offset)
-		} else {
-			unix_time += u64(unix_offset)
-		}
-		t = unix2(int(unix_time), t.microsecond)
-	}
+	t = unix2(int(unix_time), t.microsecond)
 	// Convert the time to local time
 	return to_local_time(t)
 }

--- a/vlib/time/parse.v
+++ b/vlib/time/parse.v
@@ -97,7 +97,7 @@ fn parse_iso8601_time(s string) ?(int, int, int, int, i64, bool) {
 	return hour, minute, second, microsecond, unix_offset, is_utc
 }
 
-// parse_iso8601 parses rfc8601 time format yyyy-MM-ddTHH:mm:ss.dddddd+dd:dd as local time
+// parse_iso8601 parses iso8601 time format yyyy-MM-ddTHH:mm:ss.dddddd+dd:dd as local time
 // the fraction part is difference in milli seconds and the last part is offset
 // from UTC time and can be both +/- HH:mm
 // remarks: not all iso8601 is supported

--- a/vlib/time/parse.v
+++ b/vlib/time/parse.v
@@ -105,11 +105,14 @@ fn parse_iso8601_time(s string) ?(int, int, int, int, i64, bool) {
 pub fn parse_iso8601(s string) ?Time {
 	t_i := s.index('T') or { -1 }
 	parts := if t_i != -1 { [s[..t_i], s[t_i + 1..]] } else { s.split(' ') }
-	if parts.len != 2 {
+	if !(parts.len == 1 || parts.len == 2) {
 		return err_invalid_8601
 	}
 	year, month, day := parse_iso8601_date(parts[0]) ?
-	hour, minute, second, microsecond, unix_offset, is_utc := parse_iso8601_time(parts[1]) ?
+	mut hour, mut minute, mut second, mut microsecond, mut unix_offset, mut is_utc := 0, 0, 0, 0, i64(0), false
+	if parts.len == 2 {
+		hour, minute, second, microsecond, unix_offset, is_utc = parse_iso8601_time(parts[1]) ?
+	}
 	mut t := new_time(Time{
 		year: year
 		month: month

--- a/vlib/time/parse_test.v
+++ b/vlib/time/parse_test.v
@@ -48,14 +48,18 @@ fn test_parse_rfc2822_invalid() {
 	assert false
 }
 
-fn test_iso8601_parse_utc() {
+fn test_parse_iso8601() {
 	formats := [
-		'2020-06-05T15:38:06.015959Z',
+		'2020-06-05',
 		'2020-06-05T15:38:06Z',
+		'2020-06-05T15:38:06.015959Z',
+		'2020-06-05T15:38:06.015959'
 	]
 	times := [
-		[2020, 6, 5, 15, 38, 6, 15959],
+		[2020, 6, 5, 0, 0, 0, 0],
 		[2020, 6, 5, 15, 38, 6, 0],
+		[2020, 6, 5, 15, 38, 6, 15959],
+		[2020, 6, 5, 15, 38, 6, 15959],
 	]
 	for i, format in formats {
 		t := time.parse_iso8601(format) or { panic(err) }
@@ -68,16 +72,6 @@ fn test_iso8601_parse_utc() {
 		assert t.second == tt[5]
 		assert t.microsecond == tt[6]
 	}
-}
-
-fn test_iso8601_parse_local() {
-	format_utc := '2020-06-05T15:38:06.015959'
-	t_utc := time.parse_iso8601(format_utc) or {
-		panic(err)
-	}
-	assert t_utc.year == 2020
-	assert t_utc.month == 6
-	assert t_utc.day == 5
 }
 
 fn test_iso8601_parse_utc_diff() {


### PR DESCRIPTION
I don't know whether date only format is standard compliant. But famous languages supports it.

Python: https://wandbox.org/permlink/wRZAzQWVK5hod5Sx
Ruby: https://wandbox.org/permlink/GmC6cTYKiiTn1UuA

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
