### PR TITLE
fmt: keep comments in struct init without fields

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1829,8 +1829,14 @@ pub fn (mut f Fmt) struct_init(it ast.StructInit) {
 		name = ''
 	}
 	if it.fields.len == 0 {
-		// `Foo{}` on one line if there are no fields
-		f.write('$name{}')
+		// `Foo{}` on one line if there are no fields or comments
+		if it.pre_comments.len == 0 {
+			f.write('$name{}')
+		} else {
+			f.writeln('$name{')
+			f.comments(it.pre_comments, inline: true, has_nl: true, level: .indent)
+			f.write('}')
+		}
 	} else if it.is_short {
 		// `Foo{1,2,3}` (short syntax )
 		// if name != '' {

--- a/vlib/v/fmt/tests/comments_keep.vv
+++ b/vlib/v/fmt/tests/comments_keep.vv
@@ -15,4 +15,14 @@ fn main() {
 	// else
 	// else {
 	// }
+	u2 := User{
+		name: 'Henry' // comment after name
+		// on the next line
+		age: 42
+		// after age line
+		// after line2
+	}
+	_ := User{
+		// Just a comment
+	}
 }


### PR DESCRIPTION
Fix #7209 