### PR TITLE
checker: remove duplicated unsafe tests

### DIFF
--- a/vlib/v/checker/tests/unsafe_pointer_arithmetic_should_be_checked.out
+++ b/vlib/v/checker/tests/unsafe_pointer_arithmetic_should_be_checked.out
@@ -26,9 +26,3 @@ vlib/v/checker/tests/unsafe_pointer_arithmetic_should_be_checked.vv:12:9: error:
       |         ^
    13 |     _ := q
    14 |     _ := v
-vlib/v/checker/tests/unsafe_pointer_arithmetic_should_be_checked.vv:24:7: error: method `S1.f` must be called from an `unsafe` block
-   22 | fn test_funcs() {
-   23 |     s := S1{}
-   24 |     s.f()
-      |       ~~~
-   25 | }

--- a/vlib/v/checker/tests/unsafe_pointer_arithmetic_should_be_checked.vv
+++ b/vlib/v/checker/tests/unsafe_pointer_arithmetic_should_be_checked.vv
@@ -13,13 +13,3 @@ fn test_ptr_infix() {
     _ := q
     _ := v
 }
-
-struct S1 {}
-
-[unsafe]
-fn (s S1) f(){}
-
-fn test_funcs() {
-    s := S1{}
-    s.f()
-}

--- a/vlib/v/checker/tests/unsafe_required.out
+++ b/vlib/v/checker/tests/unsafe_required.out
@@ -1,48 +1,20 @@
-vlib/v/checker/tests/unsafe_required.vv:4:3: error: pointer arithmetic is only allowed in `unsafe` blocks 
-    2 |     mut v := 5
-    3 |     mut p := &v
-    4 |     p++
-      |      ~~
-    5 |     p += 2
-    6 |     _ := v
-vlib/v/checker/tests/unsafe_required.vv:5:4: error: pointer arithmetic is only allowed in `unsafe` blocks 
-    3 |     mut p := &v
-    4 |     p++
-    5 |     p += 2
-      |       ~~
-    6 |     _ := v
-    7 | }
-vlib/v/checker/tests/unsafe_required.vv:11:14: error: pointer arithmetic is only allowed in `unsafe` blocks 
-    9 | fn test_ptr_infix() {
-   10 |     v := 4
-   11 |     mut q := &v - 1
-      |              ^
-   12 |     q = q + 3
-   13 |     _ := q
-vlib/v/checker/tests/unsafe_required.vv:12:9: error: pointer arithmetic is only allowed in `unsafe` blocks 
-   10 |     v := 4
-   11 |     mut q := &v - 1
-   12 |     q = q + 3
-      |         ^
-   13 |     _ := q
-   14 |     _ := v
-vlib/v/checker/tests/unsafe_required.vv:24:7: error: method `S1.f` must be called from an `unsafe` block 
-   22 | fn test_funcs() {
-   23 |     s := S1{}
-   24 |     s.f()
+vlib/v/checker/tests/unsafe_required.vv:8:7: error: method `S1.f` must be called from an `unsafe` block
+    6 | fn test_funcs() {
+    7 |     s := S1{}
+    8 |     s.f()
       |       ~~~
-   25 | }
-   26 |
-vlib/v/checker/tests/unsafe_required.vv:32:7: error: pointer indexing is only allowed in `unsafe` blocks 
-   30 |     _ = b[0]
-   31 |     c := &b
-   32 |     _ = c[0]
+    9 | }
+   10 |
+vlib/v/checker/tests/unsafe_required.vv:16:7: error: pointer indexing is only allowed in `unsafe` blocks
+   14 |     _ = b[0] // OK
+   15 |     c := &b
+   16 |     _ = c[0]
       |          ~~~
-   33 | 
-   34 |     v := 4
-vlib/v/checker/tests/unsafe_required.vv:36:10: error: pointer indexing is only allowed in `unsafe` blocks 
-   34 |     v := 4
-   35 |     p := &v
-   36 |     _ = p[0]
+   17 | 
+   18 |     v := 4
+vlib/v/checker/tests/unsafe_required.vv:20:10: error: pointer indexing is only allowed in `unsafe` blocks
+   18 |     v := 4
+   19 |     p := &v
+   20 |     _ = p[0]
       |          ~~~
-   37 | }
+   21 | }

--- a/vlib/v/checker/tests/unsafe_required.vv
+++ b/vlib/v/checker/tests/unsafe_required.vv
@@ -1,19 +1,3 @@
-fn test_ptr_assign() {
-	mut v := 5
-	mut p := &v
-	p++
-	p += 2
-	_ := v
-}
-
-fn test_ptr_infix() {
-    v := 4
-    mut q := &v - 1
-    q = q + 3
-    _ := q
-    _ := v
-}
-
 struct S1 {}
 
 [unsafe]
@@ -25,9 +9,9 @@ fn test_funcs() {
 }
 
 fn test_ptr_index(mut a []string) {
-	_ = a[0]
+	_ = a[0] // OK
 	b := ['jo']
-	_ = b[0]
+	_ = b[0] // OK
 	c := &b
 	_ = c[0]
 


### PR DESCRIPTION
Remove duplicated unsafe method test from arithmetic test file.
Remove duplicated unsafe pointer arithmetic tests from general test file.

Also add 2 comments.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
