### PR TITLE
checker: allow ++, -- on byteptr, charptr

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2668,7 +2668,7 @@ Examples of potentially memory-unsafe operations are:
 
 To mark potentially memory-unsafe operations, enclose them in an `unsafe` block:
 
-```v
+```v wip
 // allocate 2 uninitialized bytes & return a reference to them
 mut p := unsafe { malloc(2) }
 p[0] = `h` // Error: pointer indexing is only allowed in `unsafe` blocks

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2668,7 +2668,7 @@ Examples of potentially memory-unsafe operations are:
 
 To mark potentially memory-unsafe operations, enclose them in an `unsafe` block:
 
-```v failcompile
+```v
 // allocate 2 uninitialized bytes & return a reference to them
 mut p := unsafe { malloc(2) }
 p[0] = `h` // Error: pointer indexing is only allowed in `unsafe` blocks

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4137,14 +4137,13 @@ fn (c &Checker) has_return(stmts []ast.Stmt) ?bool {
 pub fn (mut c Checker) postfix_expr(mut node ast.PostfixExpr) table.Type {
 	typ := c.expr(node.expr)
 	typ_sym := c.table.get_type_symbol(typ)
-	// if !typ.is_number() {
-	if !typ_sym.is_number() {
+	if !typ_sym.is_number() && typ_sym.kind !in [.byteptr, .charptr] {
 		c.error('invalid operation: $node.op.str() (non-numeric type `$typ_sym.name`)',
 			node.pos)
 	} else {
 		node.auto_locked, _ = c.fail_if_immutable(node.expr)
 	}
-	if (typ.is_ptr() || typ_sym.is_pointer()) && !c.inside_unsafe {
+	if !c.inside_unsafe && (typ.is_ptr() || typ_sym.is_pointer()) {
 		c.warn('pointer arithmetic is only allowed in `unsafe` blocks', node.pos)
 	}
 	return typ

--- a/vlib/v/tests/ptr_arithmetic_test.v
+++ b/vlib/v/tests/ptr_arithmetic_test.v
@@ -28,4 +28,7 @@ fn test_ptr_arithmetic_over_byteptr() {
 	assert q == byteptr(9)
 	s := unsafe { q - 1 }
 	assert s == byteptr(8)
+
+	unsafe {q++ q++ q--}
+	assert q == byteptr(10)
 }


### PR DESCRIPTION
op= and infix work for these C pointer types, so postfix should work too.

Also make unsafe check slightly faster.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
