### PR TITLE
scanner: fix silent mode string parse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -595,3 +595,15 @@ jobs:
         with:
             name: client wss
             path: ${{github.workspace}}/reports_wss/clients/index.html
+
+  parser-silent-hello-world:
+    name: Parser silent mode - examples/hello_world.v
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build local v
+      run: make -j4
+    - name: Run test-parser
+      run: |
+        ./v test-parser examples/hello_world.v

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1008,6 +1008,7 @@ fn (mut s Scanner) ident_string() string {
 		s.pos++
 		if s.pos >= s.text.len {
 			s.error('unfinished string literal')
+			break
 		}
 		c := s.text[s.pos]
 		prevc := s.text[s.pos - 1]


### PR DESCRIPTION
This fixes a crash when passing -silent if strings are not finished like: `println('test`. It also adds a CI job for testing that.