### PR TITLE
test: add more embed string interpolation tests

### DIFF
--- a/vlib/v/tests/string_interpolation_string_args_test.v
+++ b/vlib/v/tests/string_interpolation_string_args_test.v
@@ -4,6 +4,11 @@ fn show_info(a string) string {
 
 fn test_interpolation_string_args() {
 	assert '${show_info("abc")}' == 'abc'
-	assert '${show_info("bac")}' == 'bac'
+	assert '${show_info('abc')}' == 'abc'
+
+	assert '1_${show_info("aaa")} 2_${show_info("bbb")}' == '1_aaa 2_bbb'
+	assert '1_${show_info('aaa')} 2_${show_info('bbb')}' == '1_aaa 2_bbb'
+
 	assert '${"aaa"}' == 'aaa'
+	assert '${'aaa'}' == 'aaa'
 }


### PR DESCRIPTION
This PR add more embed string interpolation tests.

```v
fn show_info(a string) string {
	return a
}

fn test_interpolation_string_args() {
	assert '${show_info("abc")}' == 'abc'
	assert '${show_info('abc')}' == 'abc'

	assert '1_${show_info("aaa")} 2_${show_info("bbb")}' == '1_aaa 2_bbb'
	assert '1_${show_info('aaa')} 2_${show_info('bbb')}' == '1_aaa 2_bbb'

	assert '${"aaa"}' == 'aaa'
	assert '${'aaa'}' == 'aaa'
}
```