### PR TITLE
Make Docs CI only run when markdown files changed

### DIFF
--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -2,15 +2,21 @@ name: Docs CI
 
 ### Run on *EVERY* commit. The documentation *SHOULD* stay valid, and
 ### the developers should receive early warning if they break it.
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - "**.md"
+  pull_request:
+    paths:
+      - "**.md"
 
 jobs:
   check-markdown:
     runs-on: ubuntu-18.04
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v2
-    - name: Build V
-      run: make
-    - name: Check markdown line length & code examples
-      run: ./v run cmd/tools/check-md.v -all
+      - uses: actions/checkout@v2
+      - name: Build V
+        run: make
+      - name: Check markdown line length & code examples
+        run: ./v run cmd/tools/check-md.v -all


### PR DESCRIPTION
With this patch, the `Docs CI` workflow will only run if files with the `md` extension are added, changed, or deleted.

Ref => https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#patterns-to-match-file-paths