### PR TITLE
checker: allow void,char,byteptr to be mut args

### DIFF
--- a/vlib/v/checker/tests/function_arg_mutable_err.out
+++ b/vlib/v/checker/tests/function_arg_mutable_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/function_arg_mutable_err.vv:1:18: error: mutable arguments are only allowed for arrays, maps, and structs
+vlib/v/checker/tests/function_arg_mutable_err.vv:1:18: error: mutable arguments are only allowed for arrays, maps, structs and pointers
 return values instead: `fn foo(mut n int) {` => `fn foo(n int) int {`
     1 | fn mod_ptr(mut a int) {
       |                  ~~~

--- a/vlib/v/checker/tests/mut_int.out
+++ b/vlib/v/checker/tests/mut_int.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/mut_int.vv:1:14: error: mutable arguments are only allowed for arrays, maps, and structs
+vlib/v/checker/tests/mut_int.vv:1:14: error: mutable arguments are only allowed for arrays, maps, structs and pointers
 return values instead: `fn foo(mut n int) {` => `fn foo(n int) int {`
     1 | fn foo(mut x int) {
       |              ~~~

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -596,8 +596,8 @@ fn (mut p Parser) fn_args() ([]table.Param, bool, bool) {
 
 fn (mut p Parser) check_fn_mutable_arguments(typ table.Type, pos token.Position) {
 	sym := p.table.get_type_symbol(typ)
-	if sym.kind !in [.array, .struct_, .map, .placeholder, .sum_type] && !typ.is_ptr() {
-		p.error_with_pos('mutable arguments are only allowed for arrays, maps, and structs\n' +
+	if sym.kind !in [.array, .struct_, .map, .placeholder, .sum_type] && !typ.is_ptr() && !typ.is_pointer() {
+		p.error_with_pos('mutable arguments are only allowed for arrays, maps, structs and pointers\n' +
 			'return values instead: `fn foo(mut n $sym.name) {` => `fn foo(n $sym.name) $sym.name {`',
 			pos)
 	}

--- a/vlib/v/tests/type_voidptr_test.v
+++ b/vlib/v/tests/type_voidptr_test.v
@@ -1,0 +1,21 @@
+[direct_array_access]
+[unsafe]
+fn memcpy(mut dest voidptr, src voidptr, len u32) voidptr {
+	mut d := byteptr(dest)
+	s := byteptr(src)
+	mut l := len
+	for l > 0 {
+		l--
+		unsafe {
+			d[l] = s[l]
+		}
+	}
+	return dest
+}
+
+fn test_mut_voidptr_arg() {
+	mut a := [1, 2]!!
+	b := [3, 4]!!
+	memcpy(mut a, b, sizeof(int))
+	assert a == [3, 2]!!
+}


### PR DESCRIPTION
`voidptr`, `charptr` and `byteptr` can now be `mut` args
Add a test case for voidptr
Also modify the error message to include pointers

This change will be required to implement the memory functions in V correctly, and make sense since pointer can already be mutable.


<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
