### PR TITLE
x.websocket: Fixes wss connection failures to certain addresses

### DIFF
--- a/vlib/net/openssl/c.v
+++ b/vlib/net/openssl/c.v
@@ -91,6 +91,8 @@ fn C.SSL_library_init()
 
 fn C.SSLv23_client_method() &C.SSL_METHOD
 
+fn C.TLS_method() &C.SSL_METHOD
+
 fn C.TLSv1_2_method() voidptr
 
 fn init() {

--- a/vlib/net/openssl/c.v
+++ b/vlib/net/openssl/c.v
@@ -91,7 +91,7 @@ fn C.SSL_library_init()
 
 fn C.SSLv23_client_method() &C.SSL_METHOD
 
-fn C.TLS_method() &C.SSL_METHOD
+fn C.TLS_method() voidptr
 
 fn C.TLSv1_2_method() voidptr
 

--- a/vlib/x/openssl/openssl.v
+++ b/vlib/x/openssl/openssl.v
@@ -87,7 +87,7 @@ pub fn (mut s SSLConn) connect(mut tcp_conn net.TcpConn, hostname string) ? {
 	s.handle = tcp_conn.sock.handle
 	s.duration = tcp_conn.read_timeout()
 
-	s.sslctx = C.SSL_CTX_new(C.TLS_method())
+	s.sslctx = C.SSL_CTX_new(C.SSLv23_client_method())
 	if s.sslctx == 0 {
 		return error("Couldn't get ssl context")
 	}

--- a/vlib/x/openssl/openssl.v
+++ b/vlib/x/openssl/openssl.v
@@ -83,23 +83,42 @@ pub fn (mut s SSLConn) shutdown() ? {
 }
 
 // connect to server using open ssl
-pub fn (mut s SSLConn) connect(mut tcp_conn net.TcpConn) ? {
+pub fn (mut s SSLConn) connect(mut tcp_conn net.TcpConn, hostname string) ? {
 	s.handle = tcp_conn.sock.handle
 	s.duration = tcp_conn.read_timeout()
-	// C.SSL_load_error_strings()
-	s.sslctx = C.SSL_CTX_new(C.SSLv23_client_method())
+	ssl_method := C.TLS_method()
+	s.sslctx = C.SSL_CTX_new(ssl_method)
+
 	if s.sslctx == 0 {
 		return error("Couldn't get ssl context")
 	}
+
+	C.SSL_CTX_set_verify_depth(s.sslctx, 4)
+	flags := C.SSL_OP_NO_SSLv2 | C.SSL_OP_NO_SSLv3 | C.SSL_OP_NO_COMPRESSION
+	C.SSL_CTX_set_options(s.sslctx, flags)
+	mut res := C.SSL_CTX_load_verify_locations(s.sslctx, 'random-org-chain.pem', 0)
+	
 	s.ssl = C.SSL_new(s.sslctx)
 	if s.ssl == 0 {
 		return error("Couldn't create OpenSSL instance.")
 	}
+
+	preferred_ciphers := 'HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4'
+	res = C.SSL_set_cipher_list(s.ssl, preferred_ciphers.str)
+	if res != 1 {
+		println('http: openssl: cipher failed')
+	}
+	
+	res = C.SSL_set_tlsext_host_name(s.ssl, hostname.str)
+	if res != 1 {
+		return error('cannot set host name')
+	}
+
 	if C.SSL_set_fd(s.ssl, tcp_conn.sock.handle) != 1 {
 		return error("Couldn't assign ssl to socket.")
 	}
 	for {
-		res := C.SSL_connect(s.ssl)
+		res = C.SSL_connect(s.ssl)
 		if res != 1 {
 			err_res := openssl.ssl_error(res, s.ssl)?
 			if err_res == .ssl_error_want_read {
@@ -175,7 +194,7 @@ pub fn (mut s SSLConn) write(bytes []Byte) ? {
 				err_res := openssl.ssl_error(sent, s.ssl)?
 				if err_res == .ssl_error_want_read {
 					for {
-						ready := @select(s.handle, .read, s.duration)?
+						ready := @select(s.handle, .read, s.duration) ?
 						if ready {
 							break
 						}
@@ -216,7 +235,6 @@ fn @select(handle int, test Select, timeout time.Duration) ?bool {
 
     seconds := timeout.milliseconds() / 1000
     microseconds := timeout - (seconds * time.second)
-
     mut tt := C.timeval{
         tv_sec: u64(seconds)
         tv_usec: u64(microseconds)

--- a/vlib/x/openssl/openssl.v
+++ b/vlib/x/openssl/openssl.v
@@ -93,6 +93,11 @@ pub fn (mut s SSLConn) connect(mut tcp_conn net.TcpConn, hostname string) ? {
 		return error("Couldn't get ssl context")
 	}
 
+	// TODO: Fix option to enable/disable checks for valid
+	//		 certificates to allow both secure and self signed
+	//		 for now the checks are not done at all to comply 
+	// 		 to current autobahn tests
+
 	// C.SSL_CTX_set_verify_depth(s.sslctx, 4)
 	// flags := C.SSL_OP_NO_SSLv2 | C.SSL_OP_NO_SSLv3 | C.SSL_OP_NO_COMPRESSION
 	// C.SSL_CTX_set_options(s.sslctx, flags)

--- a/vlib/x/openssl/openssl.v
+++ b/vlib/x/openssl/openssl.v
@@ -93,23 +93,23 @@ pub fn (mut s SSLConn) connect(mut tcp_conn net.TcpConn, hostname string) ? {
 		return error("Couldn't get ssl context")
 	}
 
-	C.SSL_CTX_set_verify_depth(s.sslctx, 4)
-	flags := C.SSL_OP_NO_SSLv2 | C.SSL_OP_NO_SSLv3 | C.SSL_OP_NO_COMPRESSION
-	C.SSL_CTX_set_options(s.sslctx, flags)
-	mut res := C.SSL_CTX_load_verify_locations(s.sslctx, 'random-org-chain.pem', 0)
+	// C.SSL_CTX_set_verify_depth(s.sslctx, 4)
+	// flags := C.SSL_OP_NO_SSLv2 | C.SSL_OP_NO_SSLv3 | C.SSL_OP_NO_COMPRESSION
+	// C.SSL_CTX_set_options(s.sslctx, flags)
+	// mut res := C.SSL_CTX_load_verify_locations(s.sslctx, 'random-org-chain.pem', 0)
 	
 	s.ssl = C.SSL_new(s.sslctx)
 	if s.ssl == 0 {
 		return error("Couldn't create OpenSSL instance.")
 	}
 
-	preferred_ciphers := 'HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4'
-	res = C.SSL_set_cipher_list(s.ssl, preferred_ciphers.str)
-	if res != 1 {
-		println('http: openssl: cipher failed')
-	}
+	// preferred_ciphers := 'HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4'
+	// mut res := C.SSL_set_cipher_list(s.ssl, preferred_ciphers.str)
+	// if res != 1 {
+	// 	println('http: openssl: cipher failed')
+	// }
 	
-	res = C.SSL_set_tlsext_host_name(s.ssl, hostname.str)
+	mut res := C.SSL_set_tlsext_host_name(s.ssl, hostname.str)
 	if res != 1 {
 		return error('cannot set host name')
 	}

--- a/vlib/x/openssl/openssl.v
+++ b/vlib/x/openssl/openssl.v
@@ -86,9 +86,8 @@ pub fn (mut s SSLConn) shutdown() ? {
 pub fn (mut s SSLConn) connect(mut tcp_conn net.TcpConn, hostname string) ? {
 	s.handle = tcp_conn.sock.handle
 	s.duration = tcp_conn.read_timeout()
-	ssl_method := C.TLS_method()
-	s.sslctx = C.SSL_CTX_new(ssl_method)
 
+	s.sslctx = C.SSL_CTX_new(C.TLS_method())
 	if s.sslctx == 0 {
 		return error("Couldn't get ssl context")
 	}

--- a/vlib/x/websocket/io.v
+++ b/vlib/x/websocket/io.v
@@ -86,13 +86,14 @@ fn (mut ws Client) shutdown_socket() ? {
 
 // dial_socket connects tcp socket and initializes default configurations
 fn (mut ws Client) dial_socket() ?net.TcpConn {
-	mut t := net.dial_tcp('$ws.uri.hostname:$ws.uri.port') ?
+	tcp_address := '$ws.uri.hostname:$ws.uri.port'
+	mut t := net.dial_tcp(tcp_address) ?
 	optval := int(1)
 	t.sock.set_option_int(.keep_alive, optval) ?
-	t.set_read_timeout(10 * time.millisecond)
-	t.set_write_timeout(10 * time.millisecond)
+	t.set_read_timeout(30 * time.second)
+	t.set_write_timeout(30 * time.second)
 	if ws.is_ssl {
-		ws.ssl_conn.connect(mut t) ?
+		ws.ssl_conn.connect(mut t, ws.uri.hostname) ?
 	}
 	return t
 }


### PR DESCRIPTION
- Some hosts required `C.SSL_set_tlsext_host_name` to be set. 
>Example:  'wss://swarm-dev.hiven.io/socket?encoding=json&compression=text_json'
- Fix default timeout to 30 seconds for wss too
This a bugfix, the move to net.websocket is in different PR.