### PR TITLE
checker: initial support for evaluating expressions at compile time

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1122,6 +1122,13 @@ pub fn (expr Expr) is_expr() bool {
 	return true
 }
 
+pub fn (expr Expr) is_lit() bool {
+	return match expr {
+		BoolLiteral, StringLiteral, IntegerLiteral { true }
+		else { false }
+	}
+}
+
 // check if stmt can be an expression in C
 pub fn (stmt Stmt) check_c_expr() ? {
 	match stmt {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4086,7 +4086,7 @@ fn (mut c Checker) comp_if_branch(cond ast.Expr, pos token.Position) bool {
 					if cond.left is ast.SelectorExpr && cond.right is ast.Type {
 						// $if method.@type is string
 					} else {
-						c.error('invalid `\$if` condition: ${cond.left}', cond.pos)
+						c.error('invalid `\$if` condition: $cond.left', cond.pos)
 					}
 				}
 				.eq, .ne {
@@ -4103,12 +4103,17 @@ fn (mut c Checker) comp_if_branch(cond ast.Expr, pos token.Position) bool {
 						if !c.check_types(right_type, left_type) {
 							left_name := c.table.type_to_str(left_type)
 							right_name := c.table.type_to_str(right_type)
-							c.error('mismatched types `$left_name` and `$right_name`', cond.pos)
+							c.error('mismatched types `$left_name` and `$right_name`',
+								cond.pos)
 						}
 						// :)
 						// until `v.eval` is stable, I can't think of a better way to do this
 						different := expr.str() != cond.right.str()
-						return if cond.op == .eq { different } else { !different }
+						return if cond.op == .eq {
+							different
+						} else {
+							!different
+						}
 					} else {
 						c.error('invalid `\$if` condition: ${typeof(cond.left)}', cond.pos)
 					}
@@ -4166,15 +4171,10 @@ fn (mut c Checker) comp_if_branch(cond ast.Expr, pos token.Position) bool {
 
 fn (mut c Checker) find_definition(ident ast.Ident) ?ast.Expr {
 	match ident.kind {
-		.unresolved, .blank_ident {
-			return none
-		} .variable, .constant {
-			return c.find_obj_definition(ident.obj)
-		} .global {
-			return error('$ident.name is a global variable')
-		} .function {
-			return error('$ident.name is a function')
-		}
+		.unresolved, .blank_ident { return none }
+		.variable, .constant { return c.find_obj_definition(ident.obj) }
+		.global { return error('$ident.name is a global variable') }
+		.function { return error('$ident.name is a function') }
 	}
 }
 

--- a/vlib/v/checker/tests/custom_comptime_define_error.out
+++ b/vlib/v/checker/tests/custom_comptime_define_error.out
@@ -1,7 +1,7 @@
-vlib/v/checker/tests/custom_comptime_define_error.vv:6:9: error: unknown $if value
+vlib/v/checker/tests/custom_comptime_define_error.vv:6:13: error: undefined ident: `mysymbol`
     4 |             println('optional compitme define works')
     5 |         }
     6 |         $if mysymbol {
-      |         ~~~~~~~~~~~~
+      |             ~~~~~~~~
     7 |             // this will produce a checker error when `-d mysymbol` is not given on the CLI
     8 |             println('non optional comptime define works')

--- a/vlib/v/checker/tests/unknown_comptime_expr.out
+++ b/vlib/v/checker/tests/unknown_comptime_expr.out
@@ -1,0 +1,13 @@
+vlib/v/checker/tests/unknown_comptime_expr.vv:5:6: error: `foo` is mut and may have changed since its definition
+    3 | fn main() {
+    4 |     mut foo := 0
+    5 |     $if foo == 0 {}
+      |         ~~~
+    6 | 
+    7 |     bar := unknown_at_ct()
+vlib/v/checker/tests/unknown_comptime_expr.vv:8:6: error: definition of `bar` is unknown at compile time
+    6 | 
+    7 |     bar := unknown_at_ct()
+    8 |     $if bar == 0 {}
+      |         ~~~
+    9 | }

--- a/vlib/v/checker/tests/unknown_comptime_expr.vv
+++ b/vlib/v/checker/tests/unknown_comptime_expr.vv
@@ -1,0 +1,9 @@
+fn unknown_at_ct() int { return 0 }
+
+fn main() {
+	mut foo := 0
+	$if foo == 0 {}
+
+	bar := unknown_at_ct()
+	$if bar == 0 {}
+}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -5163,7 +5163,7 @@ fn op_to_fn_name(name string) string {
 	}
 }
 
-fn (mut g Gen) comp_if_to_ifdef(name string, is_comptime_optional bool) string {
+fn (mut g Gen) comp_if_to_ifdef(name string, is_comptime_optional bool) ?string {
 	match name {
 		// platforms/os-es:
 		'windows' {
@@ -5285,11 +5285,10 @@ fn (mut g Gen) comp_if_to_ifdef(name string, is_comptime_optional bool) string {
 				(g.pref.compile_defines_all.len > 0 && name in g.pref.compile_defines_all) {
 				return 'CUSTOM_DEFINE_$name'
 			}
-			verror('bad os ifdef name "$name"') // should never happen, caught in the checker
+			return error('bad os ifdef name "$name"') // should never happen, caught in the checker
 		}
 	}
-	// verror('bad os ifdef name "$name"')
-	return ''
+	return none
 }
 
 [inline]

--- a/vlib/v/tests/comptime_if_expr_test.v
+++ b/vlib/v/tests/comptime_if_expr_test.v
@@ -1,0 +1,30 @@
+const (
+	version              = 123
+	disable_opt_features = true
+)
+
+// NB: the `unknown_fn()` calls are here on purpose, to make sure that anything
+// that doesn't match a compile-time condition is not even parsed.
+fn test_ct_expressions() {
+	foo := version
+	bar := foo
+	$if bar == 123 {
+		assert true
+	} $else {
+		unknown_fn()
+	}
+
+	$if bar != 123 {
+		unknown_fn()
+	} $else $if bar != 124 {
+		assert true
+	} $else {
+		unknown_fn()
+	}
+
+	$if !disable_opt_features {
+		unknown_fn()
+	} $else {
+		assert true
+	}
+}


### PR DESCRIPTION
Closes #7165.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
