### PR TITLE
gen: fix mutable map generation

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -10,15 +10,6 @@ particularly useful for checking that errors are printed.
 
 Tip: use `v -cc tcc` when compiling tests for speed.
 
-## Run only single test file
-
-In order to test only one file, use `v test` command
-Example :
-`v test vlib/v/tests/map_mut_fn_test.v`
-
-And if you want to run a test file with println outputs just use `v` command:
-`v vlib/v/tests/map_mut_fn_test.v`
-
 
 ## `v test-compiler`
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -10,6 +10,16 @@ particularly useful for checking that errors are printed.
 
 Tip: use `v -cc tcc` when compiling tests for speed.
 
+## Run only single test file
+
+In order to test only one file, use `v test` command
+Example :
+`v test vlib/v/tests/map_mut_fn_test.v`
+
+And if you want to run a test file with println outputs just use `v` command:
+`v vlib/v/tests/map_mut_fn_test.v`
+
+
 ## `v test-compiler`
 
 This builds and tests:

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1235,16 +1235,17 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		idx := g.new_tmp_var()
 		atmp := g.new_tmp_var()
 		atmp_styp := g.typ(it.cond_type)
+		arw_or_pt := if it.cond_type.nr_muls() > 0 { '->' } else { '.' }
 		g.write('$atmp_styp $atmp = ')
 		g.expr(it.cond)
 		g.writeln(';')
-		g.writeln('for (int $idx = 0; $idx < ${atmp}.key_values.len; ++$idx) {')
+		g.writeln('for (int $idx = 0; $idx < $atmp${arw_or_pt}key_values.len; ++$idx) {')
 		// TODO: don't have this check when the map has no deleted elements
-		g.writeln('\tif (!DenseArray_has_index(&${atmp}.key_values, $idx)) {continue;}')
+		g.writeln('\tif (!DenseArray_has_index(&$atmp${arw_or_pt}key_values, $idx)) {continue;}')
 		if it.key_var != '_' {
 			key_styp := g.typ(it.key_type)
 			key := c_name(it.key_var)
-			g.writeln('\t$key_styp $key = /*key*/ *($key_styp*)DenseArray_key(&${atmp}.key_values, $idx);')
+			g.writeln('\t$key_styp $key = /*key*/ *($key_styp*)DenseArray_key(&$atmp${arw_or_pt}key_values, $idx);')
 			// TODO: analyze whether it.key_type has a .clone() method and call .clone() for all types:
 			if it.key_type == table.string_type {
 				g.writeln('\t$key = string_clone($key);')
@@ -1260,7 +1261,7 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 				val_styp := g.typ(it.val_type)
 				g.write('\t$val_styp ${c_name(it.val_var)} = (*($val_styp*)')
 			}
-			g.writeln('DenseArray_value(&${atmp}.key_values, $idx));')
+			g.writeln('DenseArray_value(&$atmp${arw_or_pt}key_values, $idx));')
 		}
 		g.stmts(it.stmts)
 		if it.key_type == table.string_type && !g.is_builtin_mod {

--- a/vlib/v/tests/map_mut_fn_test.v
+++ b/vlib/v/tests/map_mut_fn_test.v
@@ -1,0 +1,20 @@
+fn print_all(mut m map[string]string) {
+	for k, v in m {
+		println(k)
+		println(v)
+		m[k] = 'foo'
+	}
+    assert m['test'] == 'foo'
+}
+
+fn test_map_mutable_arg() {
+	mut m := map[string]string
+	m['test'] = 'test'
+
+	for k, v in m {
+		println(k)
+		println(v)
+	}
+
+	print_all(mut m)
+}

--- a/vlib/v/tests/map_mut_fn_test.v
+++ b/vlib/v/tests/map_mut_fn_test.v
@@ -4,11 +4,11 @@ fn print_all(mut m map[string]string) {
 		println(v)
 		m[k] = 'foo'
 	}
-    assert m['test'] == 'foo'
+	assert m['test'] == 'foo'
 }
 
 fn test_map_mutable_arg() {
-	mut m := map[string]string
+	mut m := map[string]string{}
 	m['test'] = 'test'
 
 	for k, v in m {


### PR DESCRIPTION
Key and value was not treated as pointer
Add some tests

Fixes a generation bug on FOR IN maps.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
