### PR TITLE
make.bat: fix --local mode

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -136,10 +136,10 @@ if %ERRORLEVEL% NEQ 0 echo Invalid subcommand: !subcmd!
 exit /b %ERRORLEVEL%
 
 :build
-call :download_tcc
-if %ERRORLEVEL% NEQ 0 goto :error
-del "!log_file!">NUL 2>&1
 if !flag_local! NEQ 1 (
+    call :download_tcc
+    if %ERRORLEVEL% NEQ 0 goto :error
+    del "!log_file!">NUL 2>&1
     pushd "%vc_dir%" 2>NUL && (
         echo Updating vc...
         echo  ^> Sync with remote !vc_url!


### PR DESCRIPTION
This PR fixes --local mode in make.bat.

- issue
It still needs to download TCC when using `--local` mode.

- solution
```
if !flag_local! NEQ 1 (
    call :download_tcc
    if %ERRORLEVEL% NEQ 0 goto :error
    del "!log_file!">NUL 2>&1
```

- result
```v
C:\Users\yuyi9\v>make --local
Building V...
 > Clang not found
 > Attempting to build v_win.c with GCC
 > Compiling with .\v.exe self
 > V built successfully
 > To add V to your PATH, run `.\v.exe symlink`.

V version: V 0.1.30 e274bcb
```