### PR TITLE
checker: check div/mod by cast zero (fix #1672)

### DIFF
--- a/vlib/v/checker/tests/div_mod_by_cast_zero_int_err.out
+++ b/vlib/v/checker/tests/div_mod_by_cast_zero_int_err.out
@@ -1,0 +1,40 @@
+vlib/v/checker/tests/div_mod_by_cast_zero_int_err.vv:2:21: error: division by zero
+    1 | fn main() {
+    2 |     println(u64(1)/u64(0))
+      |                        ^
+    3 |     println(u64(1)%u64(0))
+    4 |
+vlib/v/checker/tests/div_mod_by_cast_zero_int_err.vv:3:21: error: modulo by zero
+    1 | fn main() {
+    2 |     println(u64(1)/u64(0))
+    3 |     println(u64(1)%u64(0))
+      |                        ^
+    4 |
+    5 |     println(u32(1)/u32(0x0))
+vlib/v/checker/tests/div_mod_by_cast_zero_int_err.vv:5:21: error: division by zero
+    3 |     println(u64(1)%u64(0))
+    4 |
+    5 |     println(u32(1)/u32(0x0))
+      |                        ~~~
+    6 |     println(u32(1)%u32(0x0))
+    7 |
+vlib/v/checker/tests/div_mod_by_cast_zero_int_err.vv:6:21: error: modulo by zero
+    4 |
+    5 |     println(u32(1)/u32(0x0))
+    6 |     println(u32(1)%u32(0x0))
+      |                        ~~~
+    7 |
+    8 |     println(u16(1)/u16(0b0))
+vlib/v/checker/tests/div_mod_by_cast_zero_int_err.vv:8:21: error: division by zero
+    6 |     println(u32(1)%u32(0x0))
+    7 |
+    8 |     println(u16(1)/u16(0b0))
+      |                        ~~~
+    9 |     println(u16(1)%u16(0b0))
+   10 | }
+vlib/v/checker/tests/div_mod_by_cast_zero_int_err.vv:9:21: error: modulo by zero
+    7 |
+    8 |     println(u16(1)/u16(0b0))
+    9 |     println(u16(1)%u16(0b0))
+      |                        ~~~
+   10 | }

--- a/vlib/v/checker/tests/div_mod_by_cast_zero_int_err.vv
+++ b/vlib/v/checker/tests/div_mod_by_cast_zero_int_err.vv
@@ -1,0 +1,10 @@
+fn main() {
+	println(u64(1)/u64(0))
+	println(u64(1)%u64(0))
+
+	println(u32(1)/u32(0x0))
+	println(u32(1)%u32(0x0))
+
+	println(u16(1)/u16(0b0))
+	println(u16(1)%u16(0b0))
+}

--- a/vlib/v/checker/tests/division_by_cast_zero_float_err.out
+++ b/vlib/v/checker/tests/division_by_cast_zero_float_err.out
@@ -1,0 +1,12 @@
+vlib/v/checker/tests/division_by_cast_zero_float_err.vv:2:23: error: division by zero
+    1 | fn main() {
+    2 |     println(f32(1.0)/f32(0.0))
+      |                          ~~~
+    3 |     println(f64(1.0)/f64(0.0))
+    4 | }
+vlib/v/checker/tests/division_by_cast_zero_float_err.vv:3:23: error: division by zero
+    1 | fn main() {
+    2 |     println(f32(1.0)/f32(0.0))
+    3 |     println(f64(1.0)/f64(0.0))
+      |                          ~~~
+    4 | }

--- a/vlib/v/checker/tests/division_by_cast_zero_float_err.vv
+++ b/vlib/v/checker/tests/division_by_cast_zero_float_err.vv
@@ -1,0 +1,4 @@
+fn main() {
+	println(f32(1.0)/f32(0.0))
+	println(f64(1.0)/f64(0.0))
+}


### PR DESCRIPTION
This PR check div/mod by cast zero (fix #1672).

- Check div/mod by cast zero.
- Add tests `div_mod_by_cast_zero_int_err.vv/out` and `division_by_cast_zero_float_err.vv/out`.

```v
module main

fn main() {
    println(u64(4) % u64(0))
}

PS D:\Test\v\tt1> v run .
.\tt1.v:4:26: error: modulo by zero
    2 | 
    3 | fn main() {
    4 |     println(u64(4) % u64(0))
      |                          ^
    5 | }
```