### PR TITLE
scanner: fix interpolation with more embedded string args (fix #7257)

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1002,7 +1002,7 @@ fn (mut s Scanner) ident_string() string {
 	is_raw := is_quote && s.pos > 0 && s.text[s.pos - 1] == `r`
 	is_cstr := is_quote && s.pos > 0 && s.text[s.pos - 1] == `c`
 	if is_quote {
-		if s.is_inside_string {
+		if s.is_inside_string || s.is_enclosed_inter || s.is_inter_start {
 			s.inter_quote = q
 		} else {
 			s.quote = q

--- a/vlib/v/tests/string_interpolation_string_args_test.v
+++ b/vlib/v/tests/string_interpolation_string_args_test.v
@@ -2,6 +2,10 @@ fn show_info(a string) string {
 	return a
 }
 
+fn show_more_info(a string, b string) string {
+	return a + b
+}
+
 fn test_interpolation_string_args() {
 	assert '${show_info("abc")}' == 'abc'
 	assert '${show_info('abc')}' == 'abc'
@@ -11,4 +15,17 @@ fn test_interpolation_string_args() {
 
 	assert '${"aaa"}' == 'aaa'
 	assert '${'aaa'}' == 'aaa'
+
+	assert '${"aaa" + "bbb"}' == 'aaabbb'
+	assert '${'aaa' + 'bbb'}' == 'aaabbb'
+	assert '${"aaa" + 'bbb'}' == 'aaabbb'
+	assert '${'aaa' + "bbb"}' == 'aaabbb'
+
+	assert '${show_more_info("aaa", "bbb")}' == 'aaabbb'
+	assert '${show_more_info('aaa', 'bbb')}' == 'aaabbb'
+	assert '${show_more_info("aaa", 'bbb')}' == 'aaabbb'
+	assert '${show_more_info('aaa', "bbb")}' == 'aaabbb'
+
+	assert '1_${show_more_info("aaa", "111")} 2_${show_more_info("bbb", "222")}' == '1_aaa111 2_bbb222'
+	assert '1_${show_more_info('aaa', '111')} 2_${show_more_info('bbb', '222')}' == '1_aaa111 2_bbb222'
 }


### PR DESCRIPTION
This PR fixes interpolation with more embedded string args (fix #7257).

- Fixes interpolation with more embedded string args.
- Add tests.

```v
fn show_info(a string) string {
	return a
}

fn show_more_info(a string, b string) string {
	return a + b
}

fn test_interpolation_string_args() {
	assert '${show_info("abc")}' == 'abc'
	assert '${show_info('abc')}' == 'abc'

	assert '1_${show_info("aaa")} 2_${show_info("bbb")}' == '1_aaa 2_bbb'
	assert '1_${show_info('aaa')} 2_${show_info('bbb')}' == '1_aaa 2_bbb'

	assert '${"aaa"}' == 'aaa'
	assert '${'aaa'}' == 'aaa'

	assert '${"aaa" + "bbb"}' == 'aaabbb'
	assert '${'aaa' + 'bbb'}' == 'aaabbb'
	assert '${"aaa" + 'bbb'}' == 'aaabbb'
	assert '${'aaa' + "bbb"}' == 'aaabbb'

	assert '${show_more_info("aaa", "bbb")}' == 'aaabbb'
	assert '${show_more_info('aaa', 'bbb')}' == 'aaabbb'
	assert '${show_more_info("aaa", 'bbb')}' == 'aaabbb'
	assert '${show_more_info('aaa', "bbb")}' == 'aaabbb'

	assert '1_${show_more_info("aaa", "111")} 2_${show_more_info("bbb", "222")}' == '1_aaa111 2_bbb222'
	assert '1_${show_more_info('aaa', '111')} 2_${show_more_info('bbb', '222')}' == '1_aaa111 2_bbb222'
}
```