### PR TITLE
time: Subtract operator overloading

### DIFF
--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -348,6 +348,13 @@ pub fn (t Time) str() string {
 	return t.format_ss()
 }
 
+// Time subtract using eperator overloading
+pub fn (lhs Time) -(rhs Time) Duration {
+	lhs_micro := lhs.unix * 1000 * 1000 + u64(lhs.microsecond)
+	rhs_micro := rhs.unix * 1000 * 1000 + u64(rhs.microsecond)
+	return (i64(lhs_micro) - i64(rhs_micro)) * microsecond
+}
+
 fn convert_ctime(t C.tm, microsecond int) Time {
 	return Time{
 		year: t.tm_year + 1900

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -164,6 +164,20 @@ fn test_str() {
 	assert '1980-07-11 21:23:42' == time_to_test.str()
 }
 
+fn test_subtract() {
+	d_seconds := 3
+	d_microseconds := 13
+	duration := d_seconds * time.second + d_microseconds * time.microsecond
+	t1 := time_to_test
+	t2 := time.unix2(int(t1.unix) + d_seconds, t1.microsecond + d_microseconds)
+	d1 := t2 - t1
+	d2 := t1 - t2
+	assert d1 > 0
+	assert d1 == duration
+	assert d2 < 0
+	assert d2 == -duration
+}
+
 // not optimal test but will find obvious bugs
 fn test_now() {
 	now := time.now()


### PR DESCRIPTION
Add subtract operator overrloading for Time

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
