### PR TITLE
time: Fix timezone problems of parse_iso8601

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,14 @@ jobs:
       run: ./v -o v2 cmd/v && ./v2 -o v3 cmd/v && ./v3 -o v4 cmd/v
     - name: Fixed tests
       run: ./v -silent test-fixed
+    - name: Test time functions in a timezone UTC-12
+      run: TZ=Etc/GMT+12 ./v test vlib/time/
+    - name: Test time functions in a timezone UTC-3
+      run: TZ=Etc/GMT+3 ./v test vlib/time/
+    - name: Test time functions in a timezone UTC+3
+      run: TZ=Etc/GMT-3 ./v test vlib/time/
+    - name: Test time functions in a timezone UTC+12
+      run: TZ=Etc/GMT-12 ./v test vlib/time/
     - name: Test building v tools
       run: ./v -silent build-tools
     - name: v doctor

--- a/vlib/time/parse.v
+++ b/vlib/time/parse.v
@@ -91,11 +91,8 @@ pub fn parse_iso8601(s string) ?Time {
 		second: second
 		microsecond: mic_second
 	})
-	if is_utc {
-		return t
-	}
 	if is_local_time {
-		return to_local_time(t)
+		return t // Time already local time
 	}
 	mut unix_time := t.unix
 	mut unix_offset := int(0)

--- a/vlib/time/parse_test.v
+++ b/vlib/time/parse_test.v
@@ -69,7 +69,7 @@ fn test_parse_iso8601() {
 		[2020, 6, 5, 17, 38, 6, 15959],
 	]
 	for i, format in formats {
-		t := time.parse_iso8601(format) or { panic(err) }
+		t := time.parse_iso8601(format) or { assert false }
 		data := times[i]
 		t2 := time.new_time(
 			year: data[0]
@@ -92,7 +92,7 @@ fn test_parse_iso8601() {
 
 fn test_parse_iso8601_local() {
 	format_utc := '2020-06-05T15:38:06.015959'
-	t_utc := time.parse_iso8601(format_utc) or { panic(err) }
+	t_utc := time.parse_iso8601(format_utc) or { assert false }
 	assert t_utc.year == 2020
 	assert t_utc.month == 6
 	assert t_utc.day == 5

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -171,15 +171,22 @@ pub fn (t Time) unix_time_milli() u64 {
 	return t.unix * 1000 + u64(t.microsecond / 1000)
 }
 
+// add returns a new time that duration is added
+pub fn (t Time) add(d Duration) Time {
+	microseconds := t.microsecond + d.microseconds()
+	unix := i64(t.unix) + microseconds / (1000 * 1000)
+	micro := microseconds % (1000 * 1000)
+	return unix2(int(unix), int(micro))
+}
+
 // add_seconds returns a new time struct with an added number of seconds.
 pub fn (t Time) add_seconds(seconds int) Time {
-	// TODO Add(d time.Duration)
-	return unix(int(t.unix + u64(seconds)))
+	return t.add(seconds * second)
 }
 
 // add_days returns a new time struct with an added number of days.
 pub fn (t Time) add_days(days int) Time {
-	return unix(int(t.unix + u64(i64(days) * 3600 * 24)))
+	return t.add(days * 24 * hour)
 }
 
 // since returns a number of seconds elapsed since a given time.

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -173,8 +173,8 @@ pub fn (t Time) unix_time_milli() u64 {
 
 // add returns a new time that duration is added
 pub fn (t Time) add(d Duration) Time {
-	microseconds := t.microsecond + d.microseconds()
-	unix := i64(t.unix) + microseconds / (1000 * 1000)
+	microseconds := i64(t.unix) * 1000 * 1000 + t.microsecond + d.microseconds()
+	unix := microseconds / (1000 * 1000)
 	micro := microseconds % (1000 * 1000)
 	return unix2(int(unix), int(micro))
 }

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -162,6 +162,10 @@ fn test_add() {
 	assert t2.second == t1.second + d_seconds
 	assert t2.microsecond == t1.microsecond + d_microseconds
 	assert t2.unix == t1.unix + u64(d_seconds)
+	t3 := time_to_test.add(-duration)
+	assert t3.second == t1.second - d_seconds
+	assert t3.microsecond == t1.microsecond - d_microseconds
+	assert t3.unix == t1.unix - u64(d_seconds)
 }
 
 fn test_add_days() {

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -153,6 +153,17 @@ fn test_weekday_str() {
 	}
 }
 
+fn test_add() {
+	d_seconds := 3
+	d_microseconds := 13
+	duration := time.Duration(d_seconds * time.second + d_microseconds * time.microsecond)
+	t1 := time_to_test
+	t2 := time_to_test.add(duration)
+	assert t2.second == t1.second + d_seconds
+	assert t2.microsecond == t1.microsecond + d_microseconds
+	assert t2.unix == t1.unix + u64(d_seconds)
+}
+
 fn test_add_days() {
 	num_of_days := 3
 	t := time_to_test.add_days(num_of_days)


### PR DESCRIPTION
See also #7210 
Depends #7262.

Implementation

- CI on multi timezone
- Update tests for multi timezone
- parse_iso8601 returns time as local time. So parse_iso8601 with 'Z' format returns utc time that is converted by to_local_time
- iso8601 with no timezone represents local time. So parse_iso8601 returns without to_local_time

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
