### PR TITLE
fmt: keep comments after assign on same line

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -697,6 +697,7 @@ pub:
 	op            token.Kind
 	pos           token.Position
 	comments      []Comment
+	end_comments  []Comment
 pub mut:
 	left          []Expr
 	left_types    []table.Type

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -259,7 +259,6 @@ pub fn (mut f Fmt) stmt(node ast.Stmt) {
 	}
 	match node {
 		ast.AssignStmt {
-			f.comments(node.comments, {})
 			for i, left in node.left {
 				if left is ast.Ident {
 					var_info := left.var_info()
@@ -282,6 +281,7 @@ pub fn (mut f Fmt) stmt(node ast.Stmt) {
 					f.write(', ')
 				}
 			}
+			f.comments(node.comments, {has_nl: false, inline: true, level: .keep})
 			if !f.single_line_if {
 				f.writeln('')
 			}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -259,6 +259,7 @@ pub fn (mut f Fmt) stmt(node ast.Stmt) {
 	}
 	match node {
 		ast.AssignStmt {
+			f.comments(node.end_comments, {})
 			for i, left in node.left {
 				if left is ast.Ident {
 					var_info := left.var_info()
@@ -281,7 +282,7 @@ pub fn (mut f Fmt) stmt(node ast.Stmt) {
 					f.write(', ')
 				}
 			}
-			f.comments(node.comments, has_nl: false, inline: true, level: .keep)
+			f.comments(node.end_comments, has_nl: false, inline: true, level: .keep)
 			if !f.single_line_if {
 				f.writeln('')
 			}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -281,7 +281,7 @@ pub fn (mut f Fmt) stmt(node ast.Stmt) {
 					f.write(', ')
 				}
 			}
-			f.comments(node.comments, {has_nl: false, inline: true, level: .keep})
+			f.comments(node.comments, has_nl: false, inline: true, level: .keep)
 			if !f.single_line_if {
 				f.writeln('')
 			}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -259,7 +259,7 @@ pub fn (mut f Fmt) stmt(node ast.Stmt) {
 	}
 	match node {
 		ast.AssignStmt {
-			f.comments(node.end_comments, {})
+			f.comments(node.comments, {})
 			for i, left in node.left {
 				if left is ast.Ident {
 					var_info := left.var_info()

--- a/vlib/v/fmt/tests/comments_expected.vv
+++ b/vlib/v/fmt/tests/comments_expected.vv
@@ -16,6 +16,8 @@ fn main() {
 	// just to make it worse
 	b, c := a, 2
 	d := c // and an extra one
+	e := c
+	// more comments = more good
 	// before arg comment
 	// after arg comment
 	println('this is a test')

--- a/vlib/v/fmt/tests/comments_input.vv
+++ b/vlib/v/fmt/tests/comments_input.vv
@@ -10,6 +10,8 @@ fn main() {
 	a := /* this is a comment */ 1
 	b, c := /* and another comment */ a, /* just to make it worse */ 2
 	d := c // and an extra one
+	e := c
+	// more comments = more good
 	println(/* before arg comment */ 'this is a test' /* after arg comment */)
 	if /* before if expr */ true /* after if expr */  {
 		println('if')

--- a/vlib/v/fmt/tests/comments_keep.vv
+++ b/vlib/v/fmt/tests/comments_keep.vv
@@ -27,4 +27,9 @@ fn main() {
 	_ := User{
 		// Just a comment
 	}
+	a := 123 // comment after assign
+	b := 'foo' // also comment after assign
+	c := true
+	// between two assigns
+	d := false
 }

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -91,10 +91,10 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr, left_comments []ast.Comme
 	pos := p.tok.position()
 	p.next()
 	right, right_comments := p.expr_list()
-	mut comments := []ast.Comment{}
+	mut comments := []ast.Comment{cap: left_comments.len + right_comments.len}
 	comments << left_comments
 	comments << right_comments
-	comments << p.eat_line_end_comments()
+	end_comments := p.eat_line_end_comments()
 	mut has_cross_var := false
 	if op == .decl_assign {
 		// a, b := a + 1, b
@@ -188,6 +188,7 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr, left_comments []ast.Comme
 		left: left
 		right: right
 		comments: comments
+		end_comments: end_comments
 		pos: pos
 		has_cross_var: has_cross_var
 		is_simple: p.inside_for && p.tok.kind == .lcbr

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -91,9 +91,10 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr, left_comments []ast.Comme
 	pos := p.tok.position()
 	p.next()
 	right, right_comments := p.expr_list()
-	mut comments := []ast.Comment{cap: left_comments.len + right_comments.len}
+	mut comments := []ast.Comment{}
 	comments << left_comments
 	comments << right_comments
+	comments << p.eat_line_end_comments()
 	mut has_cross_var := false
 	if op == .decl_assign {
 		// a, b := a + 1, b


### PR DESCRIPTION
Fix #7219 