### PR TITLE
missdoc: change default behaviour to exclude deprecated functions

### DIFF
--- a/cmd/tools/missdoc.v
+++ b/cmd/tools/missdoc.v
@@ -1,4 +1,6 @@
 // Copyright (c) 2020 Lars Pontoppidan. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
 import os
 import flag
 


### PR DESCRIPTION
This PR will change default behaviour to exclude deprecated functions.
So `v run cmd/tools/missdoc.v vlib/os` will **exclude** deprecated functions such as `file_exists` as an example.
This makes more sense IMO in regards to the ongoing efforts in #7047 
The changed behaviour is now put behind a flag option (`-d/--deprecated`) - which will **include** deprecated functions instead, if it's needed.
I've also added a flag option `-h/--help` to print tool help and `-t/--tags` which will output function tags (e.g. `['unsafe']` or `['unsafe','inline']`) if any is found (nested and multiple tags is supported).
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
