### PR TITLE
time: Fix timezone problems of parse_iso8601 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,14 @@ jobs:
       run: ./v -o v2 cmd/v && ./v2 -o v3 cmd/v && ./v3 -o v4 cmd/v
     - name: Fixed tests
       run: ./v -silent test-fixed
+    - name: Test time functions in a timezone UTC-12
+      run: TZ=Etc/GMT+12 ./v test vlib/time/
+    - name: Test time functions in a timezone UTC-3
+      run: TZ=Etc/GMT+3 ./v test vlib/time/
+    - name: Test time functions in a timezone UTC+3
+      run: TZ=Etc/GMT-3 ./v test vlib/time/
+    - name: Test time functions in a timezone UTC+12
+      run: TZ=Etc/GMT-12 ./v test vlib/time/
     - name: Test building v tools
       run: ./v -silent build-tools
     - name: v doctor

--- a/vlib/time/parse.v
+++ b/vlib/time/parse.v
@@ -91,11 +91,8 @@ pub fn parse_iso8601(s string) ?Time {
 		second: second
 		microsecond: mic_second
 	})
-	if is_utc {
-		return t
-	}
 	if is_local_time {
-		return to_local_time(t)
+		return t // Time already local time
 	}
 	mut unix_time := t.unix
 	mut unix_offset := int(0)

--- a/vlib/time/parse_test.v
+++ b/vlib/time/parse_test.v
@@ -101,4 +101,8 @@ fn test_parse_iso8601_local() {
 	assert t.year == 2020
 	assert t.month == 6
 	assert t.day == 5
+	assert t.hour == 15
+	assert t.minute == 38
+	assert t.second == 6
+	assert t.microsecond == 15959
 }

--- a/vlib/time/parse_test.v
+++ b/vlib/time/parse_test.v
@@ -93,12 +93,12 @@ fn test_parse_iso8601() {
 }
 
 fn test_parse_iso8601_local() {
-	format_utc := '2020-06-05T15:38:06.015959'
-	t_utc := time.parse_iso8601(format_utc) or {
+	format := '2020-06-05T15:38:06.015959'
+	t := time.parse_iso8601(format) or {
 		assert false
 		return
 	}
-	assert t_utc.year == 2020
-	assert t_utc.month == 6
-	assert t_utc.day == 5
+	assert t.year == 2020
+	assert t.month == 6
+	assert t.day == 5
 }

--- a/vlib/time/parse_test.v
+++ b/vlib/time/parse_test.v
@@ -53,7 +53,6 @@ fn test_parse_iso8601() {
 	// Because there is a small difference between time.now() - time.utc and actual offset,
 	// round to the nearest hour.
 	offset := time.Duration(i64(math.round((time.now() - time.utc()).hours())) * time.hour)
-	println(offset.hours())
 	formats := [
 		'2020-06-05T15:38:06Z',
 		'2020-06-05T15:38:06.015959Z',
@@ -69,7 +68,10 @@ fn test_parse_iso8601() {
 		[2020, 6, 5, 17, 38, 6, 15959],
 	]
 	for i, format in formats {
-		t := time.parse_iso8601(format) or { panic(err) }
+		t := time.parse_iso8601(format) or {
+			assert false
+			continue
+		}
 		data := times[i]
 		t2 := time.new_time(
 			year: data[0]
@@ -92,7 +94,10 @@ fn test_parse_iso8601() {
 
 fn test_parse_iso8601_local() {
 	format_utc := '2020-06-05T15:38:06.015959'
-	t_utc := time.parse_iso8601(format_utc) or { panic(err) }
+	t_utc := time.parse_iso8601(format_utc) or {
+		assert false
+		return
+	}
 	assert t_utc.year == 2020
 	assert t_utc.month == 6
 	assert t_utc.day == 5


### PR DESCRIPTION
See also #7210

Implementation

CI on multi timezone
- Update tests for multi timezone
- parse_iso8601 returns time as local time. So parse_iso8601 with 'Z' format returns utc time that is converted by to_local_time
- iso8601 with no timezone represents local time. So parse_iso8601 returns without to_local_time
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
