### PR TITLE
time: fix typo in thursday

### DIFF
--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -34,7 +34,7 @@ const (
 		31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30,
 		31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30 + 31,
 	]
-	long_days          = ['Monday', 'Tuesday', 'Wednesday', 'Thusday', 'Friday', 'Saturday', 'Sunday']
+	long_days          = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
 )
 
 pub struct Time {


### PR DESCRIPTION
Replace: `Thusday` -> `Thursday`