### PR TITLE
Fix scan_static_directory

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -536,14 +536,15 @@ fn (mut ctx Context) scan_static_directory(directory_path string, mount_path str
 	}
 	if files.len > 0 {
 		for file in files {
-			if os.is_dir(file) {
-				ctx.scan_static_directory(directory_path + '/' + file, mount_path + '/' + file)
+			full_path := directory_path + '/' + file
+			if os.is_dir(full_path) {
+				ctx.scan_static_directory(full_path, mount_path + '/' + file)
 			} else if file.contains('.') && !file.starts_with('.') && !file.ends_with('.') {
 				ext := os.file_ext(file)
 				// Rudimentary guard against adding files not in mime_types.
 				// Use serve_static directly to add non-standard mime types.
 				if ext in mime_types {
-					ctx.serve_static(mount_path + '/' + file, directory_path + '/' + file,
+					ctx.serve_static(mount_path + '/' + file, full_path,
 						mime_types[ext])
 				}
 			}


### PR DESCRIPTION
Fix #7250 Check the full file path when scanning a static directory.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
