### PR TITLE
checker: Allow 'or { assert false }' without return

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1740,10 +1740,20 @@ pub fn (mut c Checker) check_or_expr(or_expr ast.OrExpr, ret_type table.Type, ex
 			}
 			ast.Return {}
 			else {
-				expected_type_name := c.table.type_to_str(ret_type.clear_flag(.optional))
-				c.error('last statement in the `or {}` block should be an expression of type `$expected_type_name` or exit parent scope',
-					or_expr.pos)
-				return
+				mut is_assert_false := false
+				if last_stmt is ast.AssertStmt {
+					if last_stmt.expr is ast.BoolLiteral {
+						if last_stmt.expr.val == false {
+							is_assert_false = true
+						}
+					}
+				}
+				if !is_assert_false {
+					expected_type_name := c.table.type_to_str(ret_type.clear_flag(.optional))
+					c.error('last statement in the `or {}` block should be an expression of type `$expected_type_name` or exit parent scope',
+						or_expr.pos)
+					return
+				}
 			}
 		}
 	} else {

--- a/vlib/v/checker/tests/or_err.out
+++ b/vlib/v/checker/tests/or_err.out
@@ -11,4 +11,11 @@ vlib/v/checker/tests/or_err.vv:11:2: error: wrong return type `rune` in the `or 
    11 |     `.`
       |     ~~~
    12 | }
-   13 |
+   13 | _ = f() or {
+vlib/v/checker/tests/or_err.vv:13:9: error: last statement in the `or {}` block should be an expression of type `&int` or exit parent scope
+   11 |     `.`
+   12 | }
+   13 | _ = f() or {
+      |         ~~~~
+   14 |     assert true
+   15 | }

--- a/vlib/v/checker/tests/or_err.vv
+++ b/vlib/v/checker/tests/or_err.vv
@@ -10,4 +10,15 @@ _ = f() or {
 _ = f() or {
 	`.`
 }
-
+_ = f() or {
+	assert true
+}
+_ = f() or {
+	assert false
+}
+_ = f() or {
+	panic(err)
+}
+_ = f() or {
+  return
+}


### PR DESCRIPTION
Simplify 'or assert false' pattern in test

Before

```v
fn f() ?int {
    return 0
}

fn test_f() {
    v := f() or {
        assert false
        return
    }
    assert v == 0
}
```

After

```v
fn f() ?int {
    return 0
}

fn test_f() {
    v := f() or { assert false }
    assert v == 0
}
```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
