### PR TITLE
os: fix os.dir() (fix #7181)

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -4,13 +4,13 @@
 module os
 
 pub const (
-	args = []string{}
+	args         = []string{}
 	max_path_len = 4096
 )
 
 // read_bytes returns all bytes read from file in `path`.
 pub fn read_bytes(path string) ?[]byte {
-	mut fp := vfopen(path, 'rb')?
+	mut fp := vfopen(path, 'rb') ?
 	cseek := C.fseek(fp, 0, C.SEEK_END)
 	if cseek != 0 {
 		return error('fseek failed')
@@ -29,12 +29,13 @@ pub fn read_bytes(path string) ?[]byte {
 	return res[0..nr_read_elements * fsize]
 }
 
-
 // read_file reads the file in `path` and returns the contents.
 pub fn read_file(path string) ?string {
 	mode := 'rb'
-	mut fp := vfopen(path, mode)?
-	defer { C.fclose(fp) }
+	mut fp := vfopen(path, mode) ?
+	defer {
+		C.fclose(fp)
+	}
 	cseek := C.fseek(fp, 0, C.SEEK_END)
 	if cseek != 0 {
 		return error('fseek failed')
@@ -57,7 +58,7 @@ pub fn read_file(path string) ?string {
 	}
 }
 
-//***************************** OS ops ************************
+// ***************************** OS ops ************************
 // file_size returns the size of the file located in `path`.
 pub fn file_size(path string) int {
 	mut s := C.stat{}
@@ -79,7 +80,7 @@ pub fn file_size(path string) int {
 pub fn mv(src string, dst string) {
 	mut rdst := dst
 	if is_dir(rdst) {
-		rdst = join_path(rdst.trim_right(path_separator),file_name(src.trim_right(path_separator)))
+		rdst = join_path(rdst.trim_right(path_separator), file_name(src.trim_right(path_separator)))
 	}
 	$if windows {
 		w_src := src.replace('/', '\\')
@@ -107,13 +108,14 @@ pub fn cp(src string, dst string) ? {
 		fp_to := C.open(charptr(dst.str), C.O_WRONLY | C.O_CREAT | C.O_TRUNC, C.S_IWUSR | C.S_IRUSR)
 		if fp_to < 0 { // Check if file opened (permissions problems ...)
 			C.close(fp_from)
-			return error_with_code('cp (permission): failed to write to $dst (fp_to: $fp_to)', int(fp_to))
+			return error_with_code('cp (permission): failed to write to $dst (fp_to: $fp_to)',
+				int(fp_to))
 		}
 		mut buf := [1024]byte{}
 		mut count := 0
 		for {
 			// FIXME: use sizeof, bug: 'os__buf' undeclared
-			//count = C.read(fp_from, buf, sizeof(buf))
+			// count = C.read(fp_from, buf, sizeof(buf))
 			count = C.read(fp_from, buf, 1024)
 			if count == 0 {
 				break
@@ -123,9 +125,7 @@ pub fn cp(src string, dst string) ? {
 			}
 		}
 		from_attr := C.stat{}
-		unsafe {
-			C.stat(charptr(src.str), &from_attr)
-		}
+		unsafe {C.stat(charptr(src.str), &from_attr)}
 		if C.chmod(charptr(dst.str), from_attr.st_mode) < 0 {
 			return error_with_code('failed to set permissions for $dst', int(-1))
 		}
@@ -143,38 +143,36 @@ pub fn cp_r(osource_path string, odest_path string, overwrite bool) ? {
 // cp_all will recursively copy `src` to `dst`,
 // optionally overwriting files or dirs in `dst`.
 pub fn cp_all(src string, dst string, overwrite bool) ? {
-	source_path := os.real_path(src)
-	dest_path := os.real_path(dst)
-	if !os.exists(source_path) {
+	source_path := real_path(src)
+	dest_path := real_path(dst)
+	if !exists(source_path) {
 		return error("Source path doesn\'t exist")
 	}
 	// single file copy
-	if !os.is_dir(source_path) {
-		adjusted_path := if os.is_dir(dest_path) {
-os.join_path(dest_path,os.file_name(source_path)) } else { dest_path }
-		if os.exists(adjusted_path) {
+	if !is_dir(source_path) {
+		adjusted_path := if is_dir(dest_path) { join_path(dest_path, file_name(source_path)) } else { dest_path }
+		if exists(adjusted_path) {
 			if overwrite {
-				os.rm(adjusted_path)
-			}
-			else {
+				rm(adjusted_path)
+			} else {
 				return error('Destination file path already exist')
 			}
 		}
-		os.cp(source_path, adjusted_path)?
+		cp(source_path, adjusted_path) ?
 		return
 	}
-	if !os.is_dir(dest_path) {
+	if !is_dir(dest_path) {
 		return error('Destination path is not a valid directory')
 	}
-	files := os.ls(source_path)?
+	files := ls(source_path) ?
 	for file in files {
-		sp := os.join_path(source_path, file)
-		dp := os.join_path(dest_path, file)
-		if os.is_dir(sp) {
-			os.mkdir(dp)?
+		sp := join_path(source_path, file)
+		dp := join_path(dest_path, file)
+		if is_dir(sp) {
+			mkdir(dp) ?
 		}
 		cp_all(sp, dp, overwrite) or {
-			os.rmdir(dp)
+			rmdir(dp)
 			return error(err)
 		}
 	}
@@ -183,8 +181,8 @@ os.join_path(dest_path,os.file_name(source_path)) } else { dest_path }
 // mv_by_cp first copies the source file, and if it is copied successfully, deletes the source file.
 // may be used when you are not sure that the source and target are on the same mount/partition.
 pub fn mv_by_cp(source string, target string) ? {
-	os.cp(source, target)?
-	os.rm(source)?
+	cp(source, target) ?
+	rm(source) ?
 }
 
 // vfopen returns an opened C file, given its path and open mode.
@@ -222,13 +220,13 @@ pub fn fileno(cfile voidptr) int {
 
 // read_lines reads the file in `path` into an array of lines.
 pub fn read_lines(path string) ?[]string {
-	buf := read_file(path)?
+	buf := read_file(path) ?
 	return buf.split_into_lines()
 }
 
 // read_ulines reads the file in `path` into an array of ustring lines.
 fn read_ulines(path string) ?[]ustring {
-	lines := read_lines(path)?
+	lines := read_lines(path) ?
 	// mut ulines := new_array(0, lines.len, sizeof(ustring))
 	mut ulines := []ustring{}
 	for myline in lines {
@@ -276,36 +274,29 @@ pub fn open_file(path string, mode string, options ...int) ?File {
 			else {}
 		}
 	}
-
 	mut permission := 0o666
 	if options.len > 0 {
 		permission = options[0]
 	}
-
 	$if windows {
 		if permission < 0o600 {
 			permission = 0x0100
-		}
-		else {
+		} else {
 			permission = 0x0100 | 0x0080
 		}
 	}
-
 	mut p := path
 	$if windows {
 		p = path.replace('/', '\\')
 	}
-
 	fd := C.open(charptr(p.str), flags, permission)
 	if fd == -1 {
 		return error(posix_get_error_msg(C.errno))
 	}
-
 	cfile := C.fdopen(fd, charptr(mode.str))
 	if isnil(cfile) {
 		return error('Failed to open or create file "$path"')
 	}
-
 	return File{
 		cfile: cfile
 		fd: fd
@@ -326,9 +317,9 @@ fn vpopen(path string) voidptr {
 	}
 }
 
-fn posix_wait4_to_exit_status(waitret int) (int,bool) {
+fn posix_wait4_to_exit_status(waitret int) (int, bool) {
 	$if windows {
-		return waitret,false
+		return waitret, false
 	} $else {
 		mut ret := 0
 		mut is_signaled := true
@@ -336,12 +327,11 @@ fn posix_wait4_to_exit_status(waitret int) (int,bool) {
 		if C.WIFEXITED(waitret) {
 			ret = C.WEXITSTATUS(waitret)
 			is_signaled = false
-		}
-		else if C.WIFSIGNALED(waitret) {
+		} else if C.WIFSIGNALED(waitret) {
 			ret = C.WTERMSIG(waitret)
 			is_signaled = true
 		}
-		return ret,is_signaled
+		return ret, is_signaled
 	}
 }
 
@@ -359,7 +349,7 @@ fn vpclose(f voidptr) int {
 	$if windows {
 		return C._pclose(f)
 	} $else {
-		ret,_ := posix_wait4_to_exit_status(C.pclose(f))
+		ret, _ := posix_wait4_to_exit_status(C.pclose(f))
 		return ret
 	}
 }
@@ -387,7 +377,7 @@ pub fn system(cmd string) int {
 	} $else {
 		$if ios {
 			unsafe {
-				arg := [ c'/bin/sh', c'-c', byteptr(cmd.str), 0 ]
+				arg := [c'/bin/sh', c'-c', byteptr(cmd.str), 0]
 				pid := 0
 				ret = C.posix_spawn(&pid, '/bin/sh', 0, 0, arg.data, 0)
 				status := 0
@@ -406,7 +396,7 @@ pub fn system(cmd string) int {
 		print_c_errno()
 	}
 	$if !windows {
-		pret,is_signaled := posix_wait4_to_exit_status(ret)
+		pret, is_signaled := posix_wait4_to_exit_status(ret)
 		if is_signaled {
 			println('Terminated by signal ${ret:2d} (' + sigint_to_signal_name(pret) + ')')
 		}
@@ -419,39 +409,17 @@ pub fn system(cmd string) int {
 pub fn sigint_to_signal_name(si int) string {
 	// POSIX signals:
 	match si {
-		1 {
-			return 'SIGHUP'
-		}
-		2 {
-			return 'SIGINT'
-		}
-		3 {
-			return 'SIGQUIT'
-		}
-		4 {
-			return 'SIGILL'
-		}
-		6 {
-			return 'SIGABRT'
-		}
-		8 {
-			return 'SIGFPE'
-		}
-		9 {
-			return 'SIGKILL'
-		}
-		11 {
-			return 'SIGSEGV'
-		}
-		13 {
-			return 'SIGPIPE'
-		}
-		14 {
-			return 'SIGALRM'
-		}
-		15 {
-			return 'SIGTERM'
-		}
+		1 { return 'SIGHUP' }
+		2 { return 'SIGINT' }
+		3 { return 'SIGQUIT' }
+		4 { return 'SIGILL' }
+		6 { return 'SIGABRT' }
+		8 { return 'SIGFPE' }
+		9 { return 'SIGKILL' }
+		11 { return 'SIGSEGV' }
+		13 { return 'SIGPIPE' }
+		14 { return 'SIGALRM' }
+		15 { return 'SIGTERM' }
 		else {}
 	}
 	$if linux {
@@ -459,37 +427,17 @@ pub fn sigint_to_signal_name(si int) string {
 		match si {
 			// TODO dependent on platform
 			// works only on x86/ARM/most others
-			10 /*, 30, 16 */ {
-				return 'SIGUSR1'
-			}
-			12 /*, 31, 17 */ {
-				return 'SIGUSR2'
-			}
-			17 /*, 20, 18 */ {
-				return 'SIGCHLD'
-			}
-			18 /*, 19, 25 */ {
-				return 'SIGCONT'
-			}
-			19 /*, 17, 23 */ {
-				return 'SIGSTOP'
-			}
-			20 /*, 18, 24 */ {
-				return 'SIGTSTP'
-			}
-			21 /*, 26 */ {
-				return 'SIGTTIN'
-			}
-			22 /*, 27 */ {
-				return 'SIGTTOU'
-			}
+			10 /* , 30, 16 */ { return 'SIGUSR1' }
+			12 /* , 31, 17 */ { return 'SIGUSR2' }
+			17 /* , 20, 18 */ { return 'SIGCHLD' }
+			18 /* , 19, 25 */ { return 'SIGCONT' }
+			19 /* , 17, 23 */ { return 'SIGSTOP' }
+			20 /* , 18, 24 */ { return 'SIGTSTP' }
+			21 /* , 26 */ { return 'SIGTTIN' }
+			22 /* , 27 */ { return 'SIGTTOU' }
 			// /////////////////////////////
-			5 {
-				return 'SIGTRAP'
-			}
-			7 {
-				return 'SIGBUS'
-			}
+			5 { return 'SIGTRAP' }
+			7 { return 'SIGBUS' }
 			else {}
 		}
 	}
@@ -515,46 +463,46 @@ pub fn exists(path string) bool {
 
 // is_executable returns `true` if `path` is executable.
 pub fn is_executable(path string) bool {
-  $if windows {
-    // NB: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/access-waccess?view=vs-2019
-    // i.e. there is no X bit there, the modes can be:
-    // 00 Existence only
-    // 02 Write-only
-    // 04 Read-only
-    // 06 Read and write
-    p := os.real_path( path )
-    return ( os.exists( p ) && p.ends_with('.exe') )
-  }
-  $if solaris {
-    statbuf := C.stat{}
-	unsafe {
-		if C.stat(charptr(path.str), &statbuf) != 0 {
-		return false
-		}
+	$if windows {
+		// NB: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/access-waccess?view=vs-2019
+		// i.e. there is no X bit there, the modes can be:
+		// 00 Existence only
+		// 02 Write-only
+		// 04 Read-only
+		// 06 Read and write
+		p := real_path(path)
+		return (exists(p) && p.ends_with('.exe'))
 	}
-    return (int(statbuf.st_mode) & ( s_ixusr | s_ixgrp | s_ixoth )) != 0
-  }
-  return C.access(charptr(path.str), x_ok) != -1
+	$if solaris {
+		statbuf := C.stat{}
+		unsafe {
+			if C.stat(charptr(path.str), &statbuf) != 0 {
+				return false
+			}
+		}
+		return (int(statbuf.st_mode) & (s_ixusr | s_ixgrp | s_ixoth)) != 0
+	}
+	return C.access(charptr(path.str), x_ok) != -1
 }
 
 // is_writable returns `true` if `path` is writable.
 pub fn is_writable(path string) bool {
-  $if windows {
-    p := path.replace('/', '\\')
-    return C._waccess(p.to_wide(), w_ok) != -1
-  } $else {
-    return C.access(charptr(path.str), w_ok) != -1
-  }
+	$if windows {
+		p := path.replace('/', '\\')
+		return C._waccess(p.to_wide(), w_ok) != -1
+	} $else {
+		return C.access(charptr(path.str), w_ok) != -1
+	}
 }
 
 // is_readable returns `true` if `path` is readable.
 pub fn is_readable(path string) bool {
-  $if windows {
-    p := path.replace('/', '\\')
-    return C._waccess(p.to_wide(), r_ok) != -1
-  } $else {
-    return C.access(charptr(path.str), r_ok) != -1
-  }
+	$if windows {
+		p := path.replace('/', '\\')
+		return C._waccess(p.to_wide(), r_ok) != -1
+	} $else {
+		return C.access(charptr(path.str), r_ok) != -1
+	}
 }
 
 [deprecated]
@@ -568,7 +516,7 @@ pub fn rm(path string) ? {
 	$if windows {
 		rc := C._wremove(path.to_wide())
 		if rc == -1 {
-			//TODO: proper error as soon as it's supported on windows
+			// TODO: proper error as soon as it's supported on windows
 			return error('Failed to remove "$path"')
 		}
 	} $else {
@@ -605,14 +553,14 @@ pub fn rmdir_recursive(path string) {
 // rmdir_all recursively removes the specified directory.
 pub fn rmdir_all(path string) ? {
 	mut ret_err := ''
-	items := os.ls(path)?
+	items := ls(path) ?
 	for item in items {
-		if os.is_dir(os.join_path(path, item)) {
-			rmdir_all(os.join_path(path, item))
+		if is_dir(join_path(path, item)) {
+			rmdir_all(join_path(path, item))
 		}
-		os.rm(os.join_path(path, item)) or { ret_err = err }
+		rm(join_path(path, item)) or { ret_err = err }
 	}
-	os.rmdir(path) or { ret_err = err }
+	rmdir(path) or { ret_err = err }
 	if ret_err.len > 0 {
 		return error(ret_err)
 	}
@@ -620,9 +568,7 @@ pub fn rmdir_all(path string) ? {
 
 // is_dir_empty will return a `bool` whether or not `path` is empty.
 pub fn is_dir_empty(path string) bool {
-	items := os.ls(path) or {
-		return true
-	}
+	items := ls(path) or { return true }
 	return items.len == 0
 }
 
@@ -636,9 +582,7 @@ fn print_c_errno() {
 // file_ext will return the part after the last occurence of `.` in `path`.
 // The `.` is included.
 pub fn file_ext(path string) string {
-	pos := path.last_index('.') or {
-		return ''
-	}
+	pos := path.last_index('.') or { return '' }
 	return path[pos..]
 }
 
@@ -651,12 +595,7 @@ pub fn dir(path string) string {
 	if path == '' {
 		return '.'
 	}
-	mut pos := path.last_index(path_separator) or {
-		return '.'
-	}
-	if path.ends_with(path_separator) {
-		pos--
-	}
+	mut pos := path.last_index(path_separator) or { return '.' }
 	return path[..pos]
 }
 
@@ -672,16 +611,12 @@ pub fn base(path string) string {
 		return path_separator
 	}
 	if path.ends_with(path_separator) {
-		path2 := path[..path.len-1]
-		pos := path2.last_index(path_separator) or {
-			return path2.clone()
-		}
-		return path2[pos+1..]
+		path2 := path[..path.len - 1]
+		pos := path2.last_index(path_separator) or { return path2.clone() }
+		return path2[pos + 1..]
 	}
-	pos := path.last_index(path_separator) or {
-		return path.clone()
-	}
-	return path[pos+1..]
+	pos := path.last_index(path_separator) or { return path.clone() }
+	return path[pos + 1..]
 }
 
 // file_name will return all characters found after the last occurence of `path_separator`.
@@ -716,7 +651,8 @@ pub fn get_raw_line() string {
 			h_input := C.GetStdHandle(std_input_handle)
 			mut bytes_read := 0
 			if is_atty(0) > 0 {
-				C.ReadConsole(h_input, buf, max_line_chars * 2, C.LPDWORD(&bytes_read), 0)
+				C.ReadConsole(h_input, buf, max_line_chars * 2, C.LPDWORD(&bytes_read),
+					0)
 				return string_from_wide2(&u16(buf), bytes_read)
 			}
 			mut offset := 0
@@ -724,7 +660,7 @@ pub fn get_raw_line() string {
 				pos := buf + offset
 				res := C.ReadFile(h_input, pos, 1, C.LPDWORD(&bytes_read), 0)
 				if !res || bytes_read == 0 {
-						break
+					break
 				}
 				if *pos == `\n` || *pos == `\r` {
 					offset++
@@ -738,13 +674,13 @@ pub fn get_raw_line() string {
 		max := size_t(0)
 		mut buf := charptr(0)
 		nr_chars := C.getline(&buf, &max, C.stdin)
-		//defer { unsafe{ free(buf) } }
+		// defer { unsafe{ free(buf) } }
 		if nr_chars == 0 || nr_chars == -1 {
 			return ''
 		}
 		return tos3(buf)
-		//res := tos_clone(buf)
-		//return res
+		// res := tos_clone(buf)
+		// return res
 	}
 }
 
@@ -761,17 +697,18 @@ pub fn get_raw_stdin() []byte {
 				pos := buf + offset
 				res := C.ReadFile(h_input, pos, block_bytes, C.LPDWORD(&bytes_read), 0)
 				offset += bytes_read
-
 				if !res {
 					break
 				}
-
-				buf = v_realloc(buf, offset + block_bytes + (block_bytes-bytes_read))
+				buf = v_realloc(buf, offset + block_bytes + (block_bytes - bytes_read))
 			}
-
 			C.CloseHandle(h_input)
-
-			return array{element_size: 1 data: voidptr(buf) len: offset cap: offset }
+			return array{
+				element_size: 1
+				data: voidptr(buf)
+				len: offset
+				cap: offset
+			}
 		}
 	} $else {
 		panic('get_raw_stdin not implemented on this platform...')
@@ -848,25 +785,25 @@ pub fn user_os() string {
 // home_dir returns path to user's home directory.
 pub fn home_dir() string {
 	$if windows {
-		return os.getenv('USERPROFILE')
+		return getenv('USERPROFILE')
 	} $else {
-		//println('home_dir() call')
-		//res:= os.getenv('HOME')
-		//println('res="$res"')
-		return os.getenv('HOME')
+		// println('home_dir() call')
+		// res:= os.getenv('HOME')
+		// println('res="$res"')
+		return getenv('HOME')
 	}
 }
 
 // write_file writes `text` data to a file in `path`.
 pub fn write_file(path string, text string) ? {
-	mut f := os.create(path)?
+	mut f := create(path) ?
 	f.write(text.bytes())
 	f.close()
 }
 
 // write_file_array writes the data in `buffer` to a file in `path`.
 pub fn write_file_array(path string, buffer array) ? {
-	mut f := os.create(path)?
+	mut f := create(path) ?
 	f.write_bytes_at(buffer.data, (buffer.len * buffer.element_size), 0)
 	f.close()
 }
@@ -885,7 +822,12 @@ pub fn read_file_array<T>(path string) []T {
 	buf := malloc(fsize)
 	C.fread(buf, fsize, 1, fp)
 	C.fclose(fp)
-	return array{element_size: tsize data: buf len: len cap: len }
+	return array{
+		element_size: tsize
+		data: buf
+		len: len
+		cap: len
+	}
 }
 
 pub fn on_segfault(f voidptr) {
@@ -893,7 +835,7 @@ pub fn on_segfault(f voidptr) {
 		return
 	}
 	$if macos {
-		C.printf("TODO")
+		C.printf('TODO')
 		/*
 		mut sa := C.sigaction{}
 		C.memset(&sa, 0, sizeof(C.sigaction_size))
@@ -915,7 +857,7 @@ pub fn executable() string {
 			eprintln('os.executable() failed at reading /proc/self/exe to get exe path')
 			return executable_fallback()
 		}
-		return unsafe { result.vstring() }
+		return unsafe {result.vstring()}
 	}
 	$if windows {
 		max := 512
@@ -924,7 +866,7 @@ pub fn executable() string {
 		len := C.GetModuleFileName(0, result, max)
 		// determine if the file is a windows symlink
 		attrs := C.GetFileAttributesW(result)
-		is_set := attrs & 0x400  // FILE_ATTRIBUTE_REPARSE_POINT
+		is_set := attrs & 0x400 // FILE_ATTRIBUTE_REPARSE_POINT
 		if is_set != 0 { // it's a windows symlink
 			// gets handle with GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0
 			file := C.CreateFile(result, 0x80000000, 1, 0, 3, 0x80, 0)
@@ -936,8 +878,7 @@ pub fn executable() string {
 					ret := string_from_wide2(final_path, final_len)
 					// remove '\\?\' from beginning (see link above)
 					return ret[4..]
-				}
-				else {
+				} else {
 					eprintln('os.executable() saw that the executable file path was too long')
 				}
 			}
@@ -953,21 +894,22 @@ pub fn executable() string {
 			eprintln('os.executable() failed at calling proc_pidpath with pid: $pid . proc_pidpath returned $ret ')
 			return executable_fallback()
 		}
-		return unsafe { result.vstring() }
+		return unsafe {result.vstring()}
 	}
 	$if freebsd {
 		mut result := vcalloc(max_path_len)
-		mib := [1/* CTL_KERN */, 14/* KERN_PROC */, 12/* KERN_PROC_PATHNAME */, -1]
+		mib := [1 /* CTL_KERN */, 14 /* KERN_PROC */, 12 /* KERN_PROC_PATHNAME */, -1]
 		size := max_path_len
-		unsafe {
-			C.sysctl(mib.data, 4, result, &size, 0, 0)
-		}
-		return unsafe { result.vstring() }
+		unsafe {C.sysctl(mib.data, 4, result, &size, 0, 0)}
+		return unsafe {result.vstring()}
 	}
 	// "Sadly there is no way to get the full path of the executed file in OpenBSD."
-	$if openbsd {}
-	$if solaris {}
-	$if haiku {}
+	$if openbsd {
+	}
+	$if solaris {
+	}
+	$if haiku {
+	}
 	$if netbsd {
 		mut result := vcalloc(max_path_len)
 		count := C.readlink('/proc/curproc/exe', charptr(result), max_path_len)
@@ -975,7 +917,7 @@ pub fn executable() string {
 			eprintln('os.executable() failed at reading /proc/curproc/exe to get exe path')
 			return executable_fallback()
 		}
-		return unsafe { result.vstring_with_len(count) }
+		return unsafe {result.vstring_with_len(count)}
 	}
 	$if dragonfly {
 		mut result := vcalloc(max_path_len)
@@ -984,7 +926,7 @@ pub fn executable() string {
 			eprintln('os.executable() failed at reading /proc/curproc/file to get exe path')
 			return executable_fallback()
 		}
-		return unsafe { result.vstring_with_len(count) }
+		return unsafe {result.vstring_with_len(count)}
 	}
 	return executable_fallback()
 }
@@ -993,57 +935,55 @@ pub fn executable() string {
 // It relies on path manipulation of os.args[0] and os.wd_at_startup, so it may not work properly in
 // all cases, but it should be better, than just using os.args[0] directly.
 fn executable_fallback() string {
-	if os.args.len == 0 {
+	if args.len == 0 {
 		// we are early in the bootstrap, os.args has not been initialized yet :-|
 		return ''
 	}
-	mut exepath := os.args[0]
+	mut exepath := args[0]
 	$if windows {
 		if !exepath.contains('.exe') {
 			exepath += '.exe'
 		}
 	}
-	if !os.is_abs_path(exepath) {
-		if exepath.contains( os.path_separator ) {
-			exepath = os.join_path(os.wd_at_startup, exepath)
-		}else{
+	if !is_abs_path(exepath) {
+		if exepath.contains(path_separator) {
+			exepath = join_path(wd_at_startup, exepath)
+		} else {
 			// no choice but to try to walk the PATH folders :-| ...
-			foundpath := os.find_abs_path_of_executable(exepath) or { '' }
+			foundpath := find_abs_path_of_executable(exepath) or { '' }
 			if foundpath.len > 0 {
 				exepath = foundpath
 			}
 		}
 	}
-	exepath = os.real_path(exepath)
+	exepath = real_path(exepath)
 	return exepath
 }
 
 // find_exe_path walks the environment PATH, just like most shell do, it returns
 // the absolute path of the executable if found
 pub fn find_abs_path_of_executable(exepath string) ?string {
-	if os.is_abs_path(exepath) {
-		return os.real_path(exepath)
+	if is_abs_path(exepath) {
+		return real_path(exepath)
 	}
 	mut res := ''
-	paths := os.getenv('PATH').split(path_delimiter)
+	paths := getenv('PATH').split(path_delimiter)
 	for p in paths {
-		found_abs_path := os.join_path( p, exepath )
-		if os.exists( found_abs_path ) && os.is_executable( found_abs_path ) {
+		found_abs_path := join_path(p, exepath)
+		if exists(found_abs_path) && is_executable(found_abs_path) {
 			res = found_abs_path
 			break
 		}
 	}
-	if res.len>0 {
-		return os.real_path(res)
+	if res.len > 0 {
+		return real_path(res)
 	}
 	return error('failed to find executable')
 }
 
 // exists_in_system_path returns `true` if `prog` exists in the system's PATH
 pub fn exists_in_system_path(prog string) bool {
-	os.find_abs_path_of_executable(prog) or {
-		return false
-	}
+	find_abs_path_of_executable(prog) or { return false }
 	return true
 }
 
@@ -1071,7 +1011,7 @@ pub fn is_dir(path string) bool {
 			return false
 		}
 		// ref: https://code.woboq.org/gcc/include/sys/stat.h.html
-		val:= int(statbuf.st_mode) & os.s_ifmt
+		val := int(statbuf.st_mode) & s_ifmt
 		return val == s_ifdir
 	}
 }
@@ -1117,7 +1057,7 @@ pub fn getwd() string {
 		if C.getcwd(charptr(buf), 512) == 0 {
 			return ''
 		}
-		return unsafe { buf.vstring() }
+		return unsafe {buf.vstring()}
 	}
 }
 
@@ -1140,7 +1080,7 @@ pub fn real_path(fpath string) string {
 			return fpath
 		}
 	}
-	res := unsafe { fullpath.vstring() }
+	res := unsafe {fullpath.vstring()}
 	return normalize_drive_letter(res)
 }
 
@@ -1151,7 +1091,8 @@ fn normalize_drive_letter(path string) string {
 	$if !windows {
 		return path
 	}
-	if path.len > 2 && path[0] >= `a` && path[0] <= `z` && path[1] == `:` && path[2] == os.path_separator[0] {
+	if path.len > 2 &&
+		path[0] >= `a` && path[0] <= `z` && path[1] == `:` && path[2] == path_separator[0] {
 		unsafe {
 			x := &path.str[0]
 			(*x) = *x - 32
@@ -1160,11 +1101,10 @@ fn normalize_drive_letter(path string) string {
 	return path
 }
 
-
 // is_abs_path returns `true` if `path` is absolute.
 pub fn is_abs_path(path string) bool {
 	$if windows {
-		return path[0] == `/` || // incase we're in MingGW bash
+		return path[0] == `/` ||  // incase we're in MingGW bash
 		(path[0].is_letter() && path[1] == `:`)
 	}
 	return path[0] == `/`
@@ -1182,23 +1122,20 @@ pub fn join_path(base string, dirs ...string) string {
 
 // walk_ext returns a recursive list of all files in `path` ending with `ext`.
 pub fn walk_ext(path string, ext string) []string {
-	if !os.is_dir(path) {
+	if !is_dir(path) {
 		return []
 	}
-	mut files := os.ls(path) or {
-		return []
-	}
+	mut files := ls(path) or { return [] }
 	mut res := []string{}
-	separator := if path.ends_with(os.path_separator) { '' } else { os.path_separator }
+	separator := if path.ends_with(path_separator) { '' } else { path_separator }
 	for file in files {
 		if file.starts_with('.') {
 			continue
 		}
 		p := path + separator + file
-		if os.is_dir(p) && !os.is_link(p) {
+		if is_dir(p) && !is_link(p) {
 			res << walk_ext(p, ext)
-		}
-		else if file.ends_with(ext) {
+		} else if file.ends_with(ext) {
 			res << p
 		}
 	}
@@ -1207,30 +1144,25 @@ pub fn walk_ext(path string, ext string) []string {
 
 // walk recursively traverses the given directory `path`.
 // When a file is encountred it will call the callback function with current file as argument.
-pub fn walk(path string, f fn(path string)) {
-	if !os.is_dir(path) {
+pub fn walk(path string, f fn (string)) {
+	if !is_dir(path) {
 		return
 	}
-	mut files := os.ls(path) or {
-		return
-	}
+	mut files := ls(path) or { return }
 	for file in files {
-		p := path + os.path_separator + file
-		if os.is_dir(p) && !os.is_link(p) {
+		p := path + path_separator + file
+		if is_dir(p) && !is_link(p) {
 			walk(p, f)
-		}
-		else if os.exists(p) {
+		} else if exists(p) {
 			f(p)
 		}
 	}
 	return
 }
 
-[unsafe] // signal will assign `handler` callback to be called when `signum` signal is recieved.
+// signal will assign `handler` callback to be called when `signum` signal is recieved.
 pub fn signal(signum int, handler voidptr) {
-	unsafe {
-		C.signal(signum, handler)
-	}
+	unsafe {C.signal(signum, handler)}
 }
 
 // fork will fork the current system process and return the pid of the fork.
@@ -1262,9 +1194,7 @@ pub fn wait() int {
 pub fn file_last_mod_unix(path string) int {
 	attr := C.stat{}
 	// # struct stat attr;
-	unsafe {
-		C.stat(charptr(path.str), &attr)
-	}
+	unsafe {C.stat(charptr(path.str), &attr)}
 	// # stat(path.str, &attr);
 	return attr.st_mtime
 	// # return attr.st_mtime ;
@@ -1288,16 +1218,14 @@ pub fn flush() {
 
 // mkdir_all will create a valid full path of all directories given in `path`.
 pub fn mkdir_all(path string) ? {
-	mut p := if path.starts_with(os.path_separator) { os.path_separator } else { '' }
-	path_parts := path.trim_left(os.path_separator).split(os.path_separator)
+	mut p := if path.starts_with(path_separator) { path_separator } else { '' }
+	path_parts := path.trim_left(path_separator).split(path_separator)
 	for subdir in path_parts {
-		p += subdir + os.path_separator
-		if os.exists(p) && os.is_dir(p) {
+		p += subdir + path_separator
+		if exists(p) && is_dir(p) {
 			continue
 		}
-		os.mkdir(p) or {
-			return error('folder: $p, error: $err')
-		}
+		mkdir(p) or { return error('folder: $p, error: $err') }
 	}
 }
 
@@ -1311,31 +1239,29 @@ pub fn cache_dir() string {
 	// non-essential data files should be stored. If $XDG_CACHE_HOME is either not set
 	// or empty, a default equal to $HOME/.cache should be used.
 	$if !windows {
-		xdg_cache_home := os.getenv('XDG_CACHE_HOME')
+		xdg_cache_home := getenv('XDG_CACHE_HOME')
 		if xdg_cache_home != '' {
 			return xdg_cache_home
 		}
 	}
-	cdir := os.join_path(os.home_dir(), '.cache')
-	if !os.is_dir(cdir) && !os.is_link(cdir) {
-		os.mkdir(cdir) or {
-			panic(err)
-		}
+	cdir := join_path(home_dir(), '.cache')
+	if !is_dir(cdir) && !is_link(cdir) {
+		mkdir(cdir) or { panic(err) }
 	}
 	return cdir
 }
 
 // temp_dir returns the path to a folder, that is suitable for storing temporary files.
 pub fn temp_dir() string {
-	mut path := os.getenv('TMPDIR')
+	mut path := getenv('TMPDIR')
 	$if windows {
 		if path == '' {
 			// TODO see Qt's implementation?
 			// https://doc.qt.io/qt-5/qdir.html#tempPath
 			// https://github.com/qt/qtbase/blob/e164d61ca8263fc4b46fdd916e1ea77c7dd2b735/src/corelib/io/qfilesystemengine_win.cpp#L1275
-			path = os.getenv('TEMP')
+			path = getenv('TEMP')
 			if path == '' {
-				path = os.getenv('TMP')
+				path = getenv('TMP')
 			}
 			if path == '' {
 				path = 'C:/tmp'
@@ -1345,7 +1271,7 @@ pub fn temp_dir() string {
 	$if android {
 		// TODO test+use '/data/local/tmp' on Android before using cache_dir()
 		if path == '' {
-			path = os.cache_dir()
+			path = cache_dir()
 		}
 	}
 	if path == '' {
@@ -1355,25 +1281,26 @@ pub fn temp_dir() string {
 }
 
 fn default_vmodules_path() string {
-	return os.join_path(os.home_dir(), '.vmodules')
+	return join_path(home_dir(), '.vmodules')
 }
+
 // vmodules_dir returns the path to a folder, where v stores its global modules.
 pub fn vmodules_dir() string {
 	paths := vmodules_paths()
 	if paths.len > 0 {
 		return paths[0]
 	}
-	return os.default_vmodules_path()
+	return default_vmodules_path()
 }
 
 // vmodules_paths returns a list of paths, where v looks up for modules.
 // You can customize it through setting the environment variable VMODULES
 pub fn vmodules_paths() []string {
-	mut path := os.getenv('VMODULES')
+	mut path := getenv('VMODULES')
 	if path == '' {
-		path = os.default_vmodules_path()
+		path = default_vmodules_path()
 	}
-	list := path.split(os.path_delimiter).map(it.trim_right(os.path_separator))
+	list := path.split(path_delimiter).map(it.trim_right(path_separator))
 	return list
 }
 
@@ -1393,17 +1320,17 @@ pub const (
 // It gives a convenient way to access program resources like images, fonts, sounds and so on,
 // *no matter* how the program was started, and what is the current working directory.
 pub fn resource_abs_path(path string) string {
-	mut base_path := os.real_path(os.dir(os.executable()))
-	vresource := os.getenv('V_RESOURCE_PATH')
+	mut base_path := real_path(dir(executable()))
+	vresource := getenv('V_RESOURCE_PATH')
 	if vresource.len != 0 {
 		base_path = vresource
 	}
-	return os.real_path(os.join_path(base_path, path))
+	return real_path(join_path(base_path, path))
 }
 
 // open tries to open a file for reading and returns back a read-only `File` object.
 pub fn open(path string) ?File {
-  /*
+	/*
 	$if linux {
 		$if !android {
 			fd := C.syscall(sys_open, path.str, 511)
@@ -1416,10 +1343,10 @@ pub fn open(path string) ?File {
 			}
 		}
 	}
-  */
-	cfile := vfopen(path, 'rb')?
+	*/
+	cfile := vfopen(path, 'rb') ?
 	fd := fileno(cfile)
-	return File {
+	return File{
 		cfile: cfile
 		fd: fd
 		is_opened: true
@@ -1428,7 +1355,7 @@ pub fn open(path string) ?File {
 
 // create creates or opens a file at a specified location and returns a write-only `File` object.
 pub fn create(path string) ?File {
-  /*
+	/*
 	// NB: android/termux/bionic is also a kind of linux,
 	// but linux syscalls there sometimes fail,
 	// while the libc version should work.
@@ -1450,10 +1377,10 @@ pub fn create(path string) ?File {
 			return file
 		}
 	}
-  */
-	cfile := vfopen(path, 'wb')?
+	*/
+	cfile := vfopen(path, 'wb') ?
 	fd := fileno(cfile)
-	return File {
+	return File{
 		cfile: cfile
 		fd: fd
 		is_opened: true

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -4,13 +4,13 @@
 module os
 
 pub const (
-	args         = []string{}
+	args = []string{}
 	max_path_len = 4096
 )
 
 // read_bytes returns all bytes read from file in `path`.
 pub fn read_bytes(path string) ?[]byte {
-	mut fp := vfopen(path, 'rb') ?
+	mut fp := vfopen(path, 'rb')?
 	cseek := C.fseek(fp, 0, C.SEEK_END)
 	if cseek != 0 {
 		return error('fseek failed')
@@ -29,13 +29,12 @@ pub fn read_bytes(path string) ?[]byte {
 	return res[0..nr_read_elements * fsize]
 }
 
+
 // read_file reads the file in `path` and returns the contents.
 pub fn read_file(path string) ?string {
 	mode := 'rb'
-	mut fp := vfopen(path, mode) ?
-	defer {
-		C.fclose(fp)
-	}
+	mut fp := vfopen(path, mode)?
+	defer { C.fclose(fp) }
 	cseek := C.fseek(fp, 0, C.SEEK_END)
 	if cseek != 0 {
 		return error('fseek failed')
@@ -58,7 +57,7 @@ pub fn read_file(path string) ?string {
 	}
 }
 
-// ***************************** OS ops ************************
+//***************************** OS ops ************************
 // file_size returns the size of the file located in `path`.
 pub fn file_size(path string) int {
 	mut s := C.stat{}
@@ -80,7 +79,7 @@ pub fn file_size(path string) int {
 pub fn mv(src string, dst string) {
 	mut rdst := dst
 	if is_dir(rdst) {
-		rdst = join_path(rdst.trim_right(path_separator), file_name(src.trim_right(path_separator)))
+		rdst = join_path(rdst.trim_right(path_separator),file_name(src.trim_right(path_separator)))
 	}
 	$if windows {
 		w_src := src.replace('/', '\\')
@@ -108,14 +107,13 @@ pub fn cp(src string, dst string) ? {
 		fp_to := C.open(charptr(dst.str), C.O_WRONLY | C.O_CREAT | C.O_TRUNC, C.S_IWUSR | C.S_IRUSR)
 		if fp_to < 0 { // Check if file opened (permissions problems ...)
 			C.close(fp_from)
-			return error_with_code('cp (permission): failed to write to $dst (fp_to: $fp_to)',
-				int(fp_to))
+			return error_with_code('cp (permission): failed to write to $dst (fp_to: $fp_to)', int(fp_to))
 		}
 		mut buf := [1024]byte{}
 		mut count := 0
 		for {
 			// FIXME: use sizeof, bug: 'os__buf' undeclared
-			// count = C.read(fp_from, buf, sizeof(buf))
+			//count = C.read(fp_from, buf, sizeof(buf))
 			count = C.read(fp_from, buf, 1024)
 			if count == 0 {
 				break
@@ -125,7 +123,9 @@ pub fn cp(src string, dst string) ? {
 			}
 		}
 		from_attr := C.stat{}
-		unsafe {C.stat(charptr(src.str), &from_attr)}
+		unsafe {
+			C.stat(charptr(src.str), &from_attr)
+		}
 		if C.chmod(charptr(dst.str), from_attr.st_mode) < 0 {
 			return error_with_code('failed to set permissions for $dst', int(-1))
 		}
@@ -143,36 +143,38 @@ pub fn cp_r(osource_path string, odest_path string, overwrite bool) ? {
 // cp_all will recursively copy `src` to `dst`,
 // optionally overwriting files or dirs in `dst`.
 pub fn cp_all(src string, dst string, overwrite bool) ? {
-	source_path := real_path(src)
-	dest_path := real_path(dst)
-	if !exists(source_path) {
+	source_path := os.real_path(src)
+	dest_path := os.real_path(dst)
+	if !os.exists(source_path) {
 		return error("Source path doesn\'t exist")
 	}
 	// single file copy
-	if !is_dir(source_path) {
-		adjusted_path := if is_dir(dest_path) { join_path(dest_path, file_name(source_path)) } else { dest_path }
-		if exists(adjusted_path) {
+	if !os.is_dir(source_path) {
+		adjusted_path := if os.is_dir(dest_path) {
+os.join_path(dest_path,os.file_name(source_path)) } else { dest_path }
+		if os.exists(adjusted_path) {
 			if overwrite {
-				rm(adjusted_path)
-			} else {
+				os.rm(adjusted_path)
+			}
+			else {
 				return error('Destination file path already exist')
 			}
 		}
-		cp(source_path, adjusted_path) ?
+		os.cp(source_path, adjusted_path)?
 		return
 	}
-	if !is_dir(dest_path) {
+	if !os.is_dir(dest_path) {
 		return error('Destination path is not a valid directory')
 	}
-	files := ls(source_path) ?
+	files := os.ls(source_path)?
 	for file in files {
-		sp := join_path(source_path, file)
-		dp := join_path(dest_path, file)
-		if is_dir(sp) {
-			mkdir(dp) ?
+		sp := os.join_path(source_path, file)
+		dp := os.join_path(dest_path, file)
+		if os.is_dir(sp) {
+			os.mkdir(dp)?
 		}
 		cp_all(sp, dp, overwrite) or {
-			rmdir(dp)
+			os.rmdir(dp)
 			return error(err)
 		}
 	}
@@ -181,8 +183,8 @@ pub fn cp_all(src string, dst string, overwrite bool) ? {
 // mv_by_cp first copies the source file, and if it is copied successfully, deletes the source file.
 // may be used when you are not sure that the source and target are on the same mount/partition.
 pub fn mv_by_cp(source string, target string) ? {
-	cp(source, target) ?
-	rm(source) ?
+	os.cp(source, target)?
+	os.rm(source)?
 }
 
 // vfopen returns an opened C file, given its path and open mode.
@@ -220,13 +222,13 @@ pub fn fileno(cfile voidptr) int {
 
 // read_lines reads the file in `path` into an array of lines.
 pub fn read_lines(path string) ?[]string {
-	buf := read_file(path) ?
+	buf := read_file(path)?
 	return buf.split_into_lines()
 }
 
 // read_ulines reads the file in `path` into an array of ustring lines.
 fn read_ulines(path string) ?[]ustring {
-	lines := read_lines(path) ?
+	lines := read_lines(path)?
 	// mut ulines := new_array(0, lines.len, sizeof(ustring))
 	mut ulines := []ustring{}
 	for myline in lines {
@@ -274,29 +276,36 @@ pub fn open_file(path string, mode string, options ...int) ?File {
 			else {}
 		}
 	}
+
 	mut permission := 0o666
 	if options.len > 0 {
 		permission = options[0]
 	}
+
 	$if windows {
 		if permission < 0o600 {
 			permission = 0x0100
-		} else {
+		}
+		else {
 			permission = 0x0100 | 0x0080
 		}
 	}
+
 	mut p := path
 	$if windows {
 		p = path.replace('/', '\\')
 	}
+
 	fd := C.open(charptr(p.str), flags, permission)
 	if fd == -1 {
 		return error(posix_get_error_msg(C.errno))
 	}
+
 	cfile := C.fdopen(fd, charptr(mode.str))
 	if isnil(cfile) {
 		return error('Failed to open or create file "$path"')
 	}
+
 	return File{
 		cfile: cfile
 		fd: fd
@@ -317,9 +326,9 @@ fn vpopen(path string) voidptr {
 	}
 }
 
-fn posix_wait4_to_exit_status(waitret int) (int, bool) {
+fn posix_wait4_to_exit_status(waitret int) (int,bool) {
 	$if windows {
-		return waitret, false
+		return waitret,false
 	} $else {
 		mut ret := 0
 		mut is_signaled := true
@@ -327,11 +336,12 @@ fn posix_wait4_to_exit_status(waitret int) (int, bool) {
 		if C.WIFEXITED(waitret) {
 			ret = C.WEXITSTATUS(waitret)
 			is_signaled = false
-		} else if C.WIFSIGNALED(waitret) {
+		}
+		else if C.WIFSIGNALED(waitret) {
 			ret = C.WTERMSIG(waitret)
 			is_signaled = true
 		}
-		return ret, is_signaled
+		return ret,is_signaled
 	}
 }
 
@@ -349,7 +359,7 @@ fn vpclose(f voidptr) int {
 	$if windows {
 		return C._pclose(f)
 	} $else {
-		ret, _ := posix_wait4_to_exit_status(C.pclose(f))
+		ret,_ := posix_wait4_to_exit_status(C.pclose(f))
 		return ret
 	}
 }
@@ -377,7 +387,7 @@ pub fn system(cmd string) int {
 	} $else {
 		$if ios {
 			unsafe {
-				arg := [c'/bin/sh', c'-c', byteptr(cmd.str), 0]
+				arg := [ c'/bin/sh', c'-c', byteptr(cmd.str), 0 ]
 				pid := 0
 				ret = C.posix_spawn(&pid, '/bin/sh', 0, 0, arg.data, 0)
 				status := 0
@@ -396,7 +406,7 @@ pub fn system(cmd string) int {
 		print_c_errno()
 	}
 	$if !windows {
-		pret, is_signaled := posix_wait4_to_exit_status(ret)
+		pret,is_signaled := posix_wait4_to_exit_status(ret)
 		if is_signaled {
 			println('Terminated by signal ${ret:2d} (' + sigint_to_signal_name(pret) + ')')
 		}
@@ -409,17 +419,39 @@ pub fn system(cmd string) int {
 pub fn sigint_to_signal_name(si int) string {
 	// POSIX signals:
 	match si {
-		1 { return 'SIGHUP' }
-		2 { return 'SIGINT' }
-		3 { return 'SIGQUIT' }
-		4 { return 'SIGILL' }
-		6 { return 'SIGABRT' }
-		8 { return 'SIGFPE' }
-		9 { return 'SIGKILL' }
-		11 { return 'SIGSEGV' }
-		13 { return 'SIGPIPE' }
-		14 { return 'SIGALRM' }
-		15 { return 'SIGTERM' }
+		1 {
+			return 'SIGHUP'
+		}
+		2 {
+			return 'SIGINT'
+		}
+		3 {
+			return 'SIGQUIT'
+		}
+		4 {
+			return 'SIGILL'
+		}
+		6 {
+			return 'SIGABRT'
+		}
+		8 {
+			return 'SIGFPE'
+		}
+		9 {
+			return 'SIGKILL'
+		}
+		11 {
+			return 'SIGSEGV'
+		}
+		13 {
+			return 'SIGPIPE'
+		}
+		14 {
+			return 'SIGALRM'
+		}
+		15 {
+			return 'SIGTERM'
+		}
 		else {}
 	}
 	$if linux {
@@ -427,17 +459,37 @@ pub fn sigint_to_signal_name(si int) string {
 		match si {
 			// TODO dependent on platform
 			// works only on x86/ARM/most others
-			10 /* , 30, 16 */ { return 'SIGUSR1' }
-			12 /* , 31, 17 */ { return 'SIGUSR2' }
-			17 /* , 20, 18 */ { return 'SIGCHLD' }
-			18 /* , 19, 25 */ { return 'SIGCONT' }
-			19 /* , 17, 23 */ { return 'SIGSTOP' }
-			20 /* , 18, 24 */ { return 'SIGTSTP' }
-			21 /* , 26 */ { return 'SIGTTIN' }
-			22 /* , 27 */ { return 'SIGTTOU' }
+			10 /*, 30, 16 */ {
+				return 'SIGUSR1'
+			}
+			12 /*, 31, 17 */ {
+				return 'SIGUSR2'
+			}
+			17 /*, 20, 18 */ {
+				return 'SIGCHLD'
+			}
+			18 /*, 19, 25 */ {
+				return 'SIGCONT'
+			}
+			19 /*, 17, 23 */ {
+				return 'SIGSTOP'
+			}
+			20 /*, 18, 24 */ {
+				return 'SIGTSTP'
+			}
+			21 /*, 26 */ {
+				return 'SIGTTIN'
+			}
+			22 /*, 27 */ {
+				return 'SIGTTOU'
+			}
 			// /////////////////////////////
-			5 { return 'SIGTRAP' }
-			7 { return 'SIGBUS' }
+			5 {
+				return 'SIGTRAP'
+			}
+			7 {
+				return 'SIGBUS'
+			}
 			else {}
 		}
 	}
@@ -463,46 +515,46 @@ pub fn exists(path string) bool {
 
 // is_executable returns `true` if `path` is executable.
 pub fn is_executable(path string) bool {
-	$if windows {
-		// NB: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/access-waccess?view=vs-2019
-		// i.e. there is no X bit there, the modes can be:
-		// 00 Existence only
-		// 02 Write-only
-		// 04 Read-only
-		// 06 Read and write
-		p := real_path(path)
-		return (exists(p) && p.ends_with('.exe'))
-	}
-	$if solaris {
-		statbuf := C.stat{}
-		unsafe {
-			if C.stat(charptr(path.str), &statbuf) != 0 {
-				return false
-			}
+  $if windows {
+    // NB: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/access-waccess?view=vs-2019
+    // i.e. there is no X bit there, the modes can be:
+    // 00 Existence only
+    // 02 Write-only
+    // 04 Read-only
+    // 06 Read and write
+    p := os.real_path( path )
+    return ( os.exists( p ) && p.ends_with('.exe') )
+  }
+  $if solaris {
+    statbuf := C.stat{}
+	unsafe {
+		if C.stat(charptr(path.str), &statbuf) != 0 {
+		return false
 		}
-		return (int(statbuf.st_mode) & (s_ixusr | s_ixgrp | s_ixoth)) != 0
 	}
-	return C.access(charptr(path.str), x_ok) != -1
+    return (int(statbuf.st_mode) & ( s_ixusr | s_ixgrp | s_ixoth )) != 0
+  }
+  return C.access(charptr(path.str), x_ok) != -1
 }
 
 // is_writable returns `true` if `path` is writable.
 pub fn is_writable(path string) bool {
-	$if windows {
-		p := path.replace('/', '\\')
-		return C._waccess(p.to_wide(), w_ok) != -1
-	} $else {
-		return C.access(charptr(path.str), w_ok) != -1
-	}
+  $if windows {
+    p := path.replace('/', '\\')
+    return C._waccess(p.to_wide(), w_ok) != -1
+  } $else {
+    return C.access(charptr(path.str), w_ok) != -1
+  }
 }
 
 // is_readable returns `true` if `path` is readable.
 pub fn is_readable(path string) bool {
-	$if windows {
-		p := path.replace('/', '\\')
-		return C._waccess(p.to_wide(), r_ok) != -1
-	} $else {
-		return C.access(charptr(path.str), r_ok) != -1
-	}
+  $if windows {
+    p := path.replace('/', '\\')
+    return C._waccess(p.to_wide(), r_ok) != -1
+  } $else {
+    return C.access(charptr(path.str), r_ok) != -1
+  }
 }
 
 [deprecated]
@@ -516,7 +568,7 @@ pub fn rm(path string) ? {
 	$if windows {
 		rc := C._wremove(path.to_wide())
 		if rc == -1 {
-			// TODO: proper error as soon as it's supported on windows
+			//TODO: proper error as soon as it's supported on windows
 			return error('Failed to remove "$path"')
 		}
 	} $else {
@@ -553,14 +605,14 @@ pub fn rmdir_recursive(path string) {
 // rmdir_all recursively removes the specified directory.
 pub fn rmdir_all(path string) ? {
 	mut ret_err := ''
-	items := ls(path) ?
+	items := os.ls(path)?
 	for item in items {
-		if is_dir(join_path(path, item)) {
-			rmdir_all(join_path(path, item))
+		if os.is_dir(os.join_path(path, item)) {
+			rmdir_all(os.join_path(path, item))
 		}
-		rm(join_path(path, item)) or { ret_err = err }
+		os.rm(os.join_path(path, item)) or { ret_err = err }
 	}
-	rmdir(path) or { ret_err = err }
+	os.rmdir(path) or { ret_err = err }
 	if ret_err.len > 0 {
 		return error(ret_err)
 	}
@@ -568,7 +620,9 @@ pub fn rmdir_all(path string) ? {
 
 // is_dir_empty will return a `bool` whether or not `path` is empty.
 pub fn is_dir_empty(path string) bool {
-	items := ls(path) or { return true }
+	items := os.ls(path) or {
+		return true
+	}
 	return items.len == 0
 }
 
@@ -582,7 +636,9 @@ fn print_c_errno() {
 // file_ext will return the part after the last occurence of `.` in `path`.
 // The `.` is included.
 pub fn file_ext(path string) string {
-	pos := path.last_index('.') or { return '' }
+	pos := path.last_index('.') or {
+		return ''
+	}
 	return path[pos..]
 }
 
@@ -595,7 +651,9 @@ pub fn dir(path string) string {
 	if path == '' {
 		return '.'
 	}
-	mut pos := path.last_index(path_separator) or { return '.' }
+	pos := path.last_index(path_separator) or {
+		return '.'
+	}
 	return path[..pos]
 }
 
@@ -611,12 +669,16 @@ pub fn base(path string) string {
 		return path_separator
 	}
 	if path.ends_with(path_separator) {
-		path2 := path[..path.len - 1]
-		pos := path2.last_index(path_separator) or { return path2.clone() }
-		return path2[pos + 1..]
+		path2 := path[..path.len-1]
+		pos := path2.last_index(path_separator) or {
+			return path2.clone()
+		}
+		return path2[pos+1..]
 	}
-	pos := path.last_index(path_separator) or { return path.clone() }
-	return path[pos + 1..]
+	pos := path.last_index(path_separator) or {
+		return path.clone()
+	}
+	return path[pos+1..]
 }
 
 // file_name will return all characters found after the last occurence of `path_separator`.
@@ -651,8 +713,7 @@ pub fn get_raw_line() string {
 			h_input := C.GetStdHandle(std_input_handle)
 			mut bytes_read := 0
 			if is_atty(0) > 0 {
-				C.ReadConsole(h_input, buf, max_line_chars * 2, C.LPDWORD(&bytes_read),
-					0)
+				C.ReadConsole(h_input, buf, max_line_chars * 2, C.LPDWORD(&bytes_read), 0)
 				return string_from_wide2(&u16(buf), bytes_read)
 			}
 			mut offset := 0
@@ -660,7 +721,7 @@ pub fn get_raw_line() string {
 				pos := buf + offset
 				res := C.ReadFile(h_input, pos, 1, C.LPDWORD(&bytes_read), 0)
 				if !res || bytes_read == 0 {
-					break
+						break
 				}
 				if *pos == `\n` || *pos == `\r` {
 					offset++
@@ -674,13 +735,13 @@ pub fn get_raw_line() string {
 		max := size_t(0)
 		mut buf := charptr(0)
 		nr_chars := C.getline(&buf, &max, C.stdin)
-		// defer { unsafe{ free(buf) } }
+		//defer { unsafe{ free(buf) } }
 		if nr_chars == 0 || nr_chars == -1 {
 			return ''
 		}
 		return tos3(buf)
-		// res := tos_clone(buf)
-		// return res
+		//res := tos_clone(buf)
+		//return res
 	}
 }
 
@@ -697,18 +758,17 @@ pub fn get_raw_stdin() []byte {
 				pos := buf + offset
 				res := C.ReadFile(h_input, pos, block_bytes, C.LPDWORD(&bytes_read), 0)
 				offset += bytes_read
+
 				if !res {
 					break
 				}
-				buf = v_realloc(buf, offset + block_bytes + (block_bytes - bytes_read))
+
+				buf = v_realloc(buf, offset + block_bytes + (block_bytes-bytes_read))
 			}
+
 			C.CloseHandle(h_input)
-			return array{
-				element_size: 1
-				data: voidptr(buf)
-				len: offset
-				cap: offset
-			}
+
+			return array{element_size: 1 data: voidptr(buf) len: offset cap: offset }
 		}
 	} $else {
 		panic('get_raw_stdin not implemented on this platform...')
@@ -785,25 +845,25 @@ pub fn user_os() string {
 // home_dir returns path to user's home directory.
 pub fn home_dir() string {
 	$if windows {
-		return getenv('USERPROFILE')
+		return os.getenv('USERPROFILE')
 	} $else {
-		// println('home_dir() call')
-		// res:= os.getenv('HOME')
-		// println('res="$res"')
-		return getenv('HOME')
+		//println('home_dir() call')
+		//res:= os.getenv('HOME')
+		//println('res="$res"')
+		return os.getenv('HOME')
 	}
 }
 
 // write_file writes `text` data to a file in `path`.
 pub fn write_file(path string, text string) ? {
-	mut f := create(path) ?
+	mut f := os.create(path)?
 	f.write(text.bytes())
 	f.close()
 }
 
 // write_file_array writes the data in `buffer` to a file in `path`.
 pub fn write_file_array(path string, buffer array) ? {
-	mut f := create(path) ?
+	mut f := os.create(path)?
 	f.write_bytes_at(buffer.data, (buffer.len * buffer.element_size), 0)
 	f.close()
 }
@@ -822,12 +882,7 @@ pub fn read_file_array<T>(path string) []T {
 	buf := malloc(fsize)
 	C.fread(buf, fsize, 1, fp)
 	C.fclose(fp)
-	return array{
-		element_size: tsize
-		data: buf
-		len: len
-		cap: len
-	}
+	return array{element_size: tsize data: buf len: len cap: len }
 }
 
 pub fn on_segfault(f voidptr) {
@@ -835,7 +890,7 @@ pub fn on_segfault(f voidptr) {
 		return
 	}
 	$if macos {
-		C.printf('TODO')
+		C.printf("TODO")
 		/*
 		mut sa := C.sigaction{}
 		C.memset(&sa, 0, sizeof(C.sigaction_size))
@@ -857,7 +912,7 @@ pub fn executable() string {
 			eprintln('os.executable() failed at reading /proc/self/exe to get exe path')
 			return executable_fallback()
 		}
-		return unsafe {result.vstring()}
+		return unsafe { result.vstring() }
 	}
 	$if windows {
 		max := 512
@@ -866,7 +921,7 @@ pub fn executable() string {
 		len := C.GetModuleFileName(0, result, max)
 		// determine if the file is a windows symlink
 		attrs := C.GetFileAttributesW(result)
-		is_set := attrs & 0x400 // FILE_ATTRIBUTE_REPARSE_POINT
+		is_set := attrs & 0x400  // FILE_ATTRIBUTE_REPARSE_POINT
 		if is_set != 0 { // it's a windows symlink
 			// gets handle with GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0
 			file := C.CreateFile(result, 0x80000000, 1, 0, 3, 0x80, 0)
@@ -878,7 +933,8 @@ pub fn executable() string {
 					ret := string_from_wide2(final_path, final_len)
 					// remove '\\?\' from beginning (see link above)
 					return ret[4..]
-				} else {
+				}
+				else {
 					eprintln('os.executable() saw that the executable file path was too long')
 				}
 			}
@@ -894,22 +950,21 @@ pub fn executable() string {
 			eprintln('os.executable() failed at calling proc_pidpath with pid: $pid . proc_pidpath returned $ret ')
 			return executable_fallback()
 		}
-		return unsafe {result.vstring()}
+		return unsafe { result.vstring() }
 	}
 	$if freebsd {
 		mut result := vcalloc(max_path_len)
-		mib := [1 /* CTL_KERN */, 14 /* KERN_PROC */, 12 /* KERN_PROC_PATHNAME */, -1]
+		mib := [1/* CTL_KERN */, 14/* KERN_PROC */, 12/* KERN_PROC_PATHNAME */, -1]
 		size := max_path_len
-		unsafe {C.sysctl(mib.data, 4, result, &size, 0, 0)}
-		return unsafe {result.vstring()}
+		unsafe {
+			C.sysctl(mib.data, 4, result, &size, 0, 0)
+		}
+		return unsafe { result.vstring() }
 	}
 	// "Sadly there is no way to get the full path of the executed file in OpenBSD."
-	$if openbsd {
-	}
-	$if solaris {
-	}
-	$if haiku {
-	}
+	$if openbsd {}
+	$if solaris {}
+	$if haiku {}
 	$if netbsd {
 		mut result := vcalloc(max_path_len)
 		count := C.readlink('/proc/curproc/exe', charptr(result), max_path_len)
@@ -917,7 +972,7 @@ pub fn executable() string {
 			eprintln('os.executable() failed at reading /proc/curproc/exe to get exe path')
 			return executable_fallback()
 		}
-		return unsafe {result.vstring_with_len(count)}
+		return unsafe { result.vstring_with_len(count) }
 	}
 	$if dragonfly {
 		mut result := vcalloc(max_path_len)
@@ -926,7 +981,7 @@ pub fn executable() string {
 			eprintln('os.executable() failed at reading /proc/curproc/file to get exe path')
 			return executable_fallback()
 		}
-		return unsafe {result.vstring_with_len(count)}
+		return unsafe { result.vstring_with_len(count) }
 	}
 	return executable_fallback()
 }
@@ -935,55 +990,57 @@ pub fn executable() string {
 // It relies on path manipulation of os.args[0] and os.wd_at_startup, so it may not work properly in
 // all cases, but it should be better, than just using os.args[0] directly.
 fn executable_fallback() string {
-	if args.len == 0 {
+	if os.args.len == 0 {
 		// we are early in the bootstrap, os.args has not been initialized yet :-|
 		return ''
 	}
-	mut exepath := args[0]
+	mut exepath := os.args[0]
 	$if windows {
 		if !exepath.contains('.exe') {
 			exepath += '.exe'
 		}
 	}
-	if !is_abs_path(exepath) {
-		if exepath.contains(path_separator) {
-			exepath = join_path(wd_at_startup, exepath)
-		} else {
+	if !os.is_abs_path(exepath) {
+		if exepath.contains( os.path_separator ) {
+			exepath = os.join_path(os.wd_at_startup, exepath)
+		}else{
 			// no choice but to try to walk the PATH folders :-| ...
-			foundpath := find_abs_path_of_executable(exepath) or { '' }
+			foundpath := os.find_abs_path_of_executable(exepath) or { '' }
 			if foundpath.len > 0 {
 				exepath = foundpath
 			}
 		}
 	}
-	exepath = real_path(exepath)
+	exepath = os.real_path(exepath)
 	return exepath
 }
 
 // find_exe_path walks the environment PATH, just like most shell do, it returns
 // the absolute path of the executable if found
 pub fn find_abs_path_of_executable(exepath string) ?string {
-	if is_abs_path(exepath) {
-		return real_path(exepath)
+	if os.is_abs_path(exepath) {
+		return os.real_path(exepath)
 	}
 	mut res := ''
-	paths := getenv('PATH').split(path_delimiter)
+	paths := os.getenv('PATH').split(path_delimiter)
 	for p in paths {
-		found_abs_path := join_path(p, exepath)
-		if exists(found_abs_path) && is_executable(found_abs_path) {
+		found_abs_path := os.join_path( p, exepath )
+		if os.exists( found_abs_path ) && os.is_executable( found_abs_path ) {
 			res = found_abs_path
 			break
 		}
 	}
-	if res.len > 0 {
-		return real_path(res)
+	if res.len>0 {
+		return os.real_path(res)
 	}
 	return error('failed to find executable')
 }
 
 // exists_in_system_path returns `true` if `prog` exists in the system's PATH
 pub fn exists_in_system_path(prog string) bool {
-	find_abs_path_of_executable(prog) or { return false }
+	os.find_abs_path_of_executable(prog) or {
+		return false
+	}
 	return true
 }
 
@@ -1011,7 +1068,7 @@ pub fn is_dir(path string) bool {
 			return false
 		}
 		// ref: https://code.woboq.org/gcc/include/sys/stat.h.html
-		val := int(statbuf.st_mode) & s_ifmt
+		val:= int(statbuf.st_mode) & os.s_ifmt
 		return val == s_ifdir
 	}
 }
@@ -1057,7 +1114,7 @@ pub fn getwd() string {
 		if C.getcwd(charptr(buf), 512) == 0 {
 			return ''
 		}
-		return unsafe {buf.vstring()}
+		return unsafe { buf.vstring() }
 	}
 }
 
@@ -1080,7 +1137,7 @@ pub fn real_path(fpath string) string {
 			return fpath
 		}
 	}
-	res := unsafe {fullpath.vstring()}
+	res := unsafe { fullpath.vstring() }
 	return normalize_drive_letter(res)
 }
 
@@ -1091,8 +1148,7 @@ fn normalize_drive_letter(path string) string {
 	$if !windows {
 		return path
 	}
-	if path.len > 2 &&
-		path[0] >= `a` && path[0] <= `z` && path[1] == `:` && path[2] == path_separator[0] {
+	if path.len > 2 && path[0] >= `a` && path[0] <= `z` && path[1] == `:` && path[2] == os.path_separator[0] {
 		unsafe {
 			x := &path.str[0]
 			(*x) = *x - 32
@@ -1101,10 +1157,11 @@ fn normalize_drive_letter(path string) string {
 	return path
 }
 
+
 // is_abs_path returns `true` if `path` is absolute.
 pub fn is_abs_path(path string) bool {
 	$if windows {
-		return path[0] == `/` ||  // incase we're in MingGW bash
+		return path[0] == `/` || // incase we're in MingGW bash
 		(path[0].is_letter() && path[1] == `:`)
 	}
 	return path[0] == `/`
@@ -1122,20 +1179,23 @@ pub fn join_path(base string, dirs ...string) string {
 
 // walk_ext returns a recursive list of all files in `path` ending with `ext`.
 pub fn walk_ext(path string, ext string) []string {
-	if !is_dir(path) {
+	if !os.is_dir(path) {
 		return []
 	}
-	mut files := ls(path) or { return [] }
+	mut files := os.ls(path) or {
+		return []
+	}
 	mut res := []string{}
-	separator := if path.ends_with(path_separator) { '' } else { path_separator }
+	separator := if path.ends_with(os.path_separator) { '' } else { os.path_separator }
 	for file in files {
 		if file.starts_with('.') {
 			continue
 		}
 		p := path + separator + file
-		if is_dir(p) && !is_link(p) {
+		if os.is_dir(p) && !os.is_link(p) {
 			res << walk_ext(p, ext)
-		} else if file.ends_with(ext) {
+		}
+		else if file.ends_with(ext) {
 			res << p
 		}
 	}
@@ -1144,25 +1204,30 @@ pub fn walk_ext(path string, ext string) []string {
 
 // walk recursively traverses the given directory `path`.
 // When a file is encountred it will call the callback function with current file as argument.
-pub fn walk(path string, f fn (string)) {
-	if !is_dir(path) {
+pub fn walk(path string, f fn(path string)) {
+	if !os.is_dir(path) {
 		return
 	}
-	mut files := ls(path) or { return }
+	mut files := os.ls(path) or {
+		return
+	}
 	for file in files {
-		p := path + path_separator + file
-		if is_dir(p) && !is_link(p) {
+		p := path + os.path_separator + file
+		if os.is_dir(p) && !os.is_link(p) {
 			walk(p, f)
-		} else if exists(p) {
+		}
+		else if os.exists(p) {
 			f(p)
 		}
 	}
 	return
 }
 
-// signal will assign `handler` callback to be called when `signum` signal is recieved.
+[unsafe] // signal will assign `handler` callback to be called when `signum` signal is recieved.
 pub fn signal(signum int, handler voidptr) {
-	unsafe {C.signal(signum, handler)}
+	unsafe {
+		C.signal(signum, handler)
+	}
 }
 
 // fork will fork the current system process and return the pid of the fork.
@@ -1194,7 +1259,9 @@ pub fn wait() int {
 pub fn file_last_mod_unix(path string) int {
 	attr := C.stat{}
 	// # struct stat attr;
-	unsafe {C.stat(charptr(path.str), &attr)}
+	unsafe {
+		C.stat(charptr(path.str), &attr)
+	}
 	// # stat(path.str, &attr);
 	return attr.st_mtime
 	// # return attr.st_mtime ;
@@ -1218,14 +1285,16 @@ pub fn flush() {
 
 // mkdir_all will create a valid full path of all directories given in `path`.
 pub fn mkdir_all(path string) ? {
-	mut p := if path.starts_with(path_separator) { path_separator } else { '' }
-	path_parts := path.trim_left(path_separator).split(path_separator)
+	mut p := if path.starts_with(os.path_separator) { os.path_separator } else { '' }
+	path_parts := path.trim_left(os.path_separator).split(os.path_separator)
 	for subdir in path_parts {
-		p += subdir + path_separator
-		if exists(p) && is_dir(p) {
+		p += subdir + os.path_separator
+		if os.exists(p) && os.is_dir(p) {
 			continue
 		}
-		mkdir(p) or { return error('folder: $p, error: $err') }
+		os.mkdir(p) or {
+			return error('folder: $p, error: $err')
+		}
 	}
 }
 
@@ -1239,29 +1308,31 @@ pub fn cache_dir() string {
 	// non-essential data files should be stored. If $XDG_CACHE_HOME is either not set
 	// or empty, a default equal to $HOME/.cache should be used.
 	$if !windows {
-		xdg_cache_home := getenv('XDG_CACHE_HOME')
+		xdg_cache_home := os.getenv('XDG_CACHE_HOME')
 		if xdg_cache_home != '' {
 			return xdg_cache_home
 		}
 	}
-	cdir := join_path(home_dir(), '.cache')
-	if !is_dir(cdir) && !is_link(cdir) {
-		mkdir(cdir) or { panic(err) }
+	cdir := os.join_path(os.home_dir(), '.cache')
+	if !os.is_dir(cdir) && !os.is_link(cdir) {
+		os.mkdir(cdir) or {
+			panic(err)
+		}
 	}
 	return cdir
 }
 
 // temp_dir returns the path to a folder, that is suitable for storing temporary files.
 pub fn temp_dir() string {
-	mut path := getenv('TMPDIR')
+	mut path := os.getenv('TMPDIR')
 	$if windows {
 		if path == '' {
 			// TODO see Qt's implementation?
 			// https://doc.qt.io/qt-5/qdir.html#tempPath
 			// https://github.com/qt/qtbase/blob/e164d61ca8263fc4b46fdd916e1ea77c7dd2b735/src/corelib/io/qfilesystemengine_win.cpp#L1275
-			path = getenv('TEMP')
+			path = os.getenv('TEMP')
 			if path == '' {
-				path = getenv('TMP')
+				path = os.getenv('TMP')
 			}
 			if path == '' {
 				path = 'C:/tmp'
@@ -1271,7 +1342,7 @@ pub fn temp_dir() string {
 	$if android {
 		// TODO test+use '/data/local/tmp' on Android before using cache_dir()
 		if path == '' {
-			path = cache_dir()
+			path = os.cache_dir()
 		}
 	}
 	if path == '' {
@@ -1281,26 +1352,25 @@ pub fn temp_dir() string {
 }
 
 fn default_vmodules_path() string {
-	return join_path(home_dir(), '.vmodules')
+	return os.join_path(os.home_dir(), '.vmodules')
 }
-
 // vmodules_dir returns the path to a folder, where v stores its global modules.
 pub fn vmodules_dir() string {
 	paths := vmodules_paths()
 	if paths.len > 0 {
 		return paths[0]
 	}
-	return default_vmodules_path()
+	return os.default_vmodules_path()
 }
 
 // vmodules_paths returns a list of paths, where v looks up for modules.
 // You can customize it through setting the environment variable VMODULES
 pub fn vmodules_paths() []string {
-	mut path := getenv('VMODULES')
+	mut path := os.getenv('VMODULES')
 	if path == '' {
-		path = default_vmodules_path()
+		path = os.default_vmodules_path()
 	}
-	list := path.split(path_delimiter).map(it.trim_right(path_separator))
+	list := path.split(os.path_delimiter).map(it.trim_right(os.path_separator))
 	return list
 }
 
@@ -1320,17 +1390,17 @@ pub const (
 // It gives a convenient way to access program resources like images, fonts, sounds and so on,
 // *no matter* how the program was started, and what is the current working directory.
 pub fn resource_abs_path(path string) string {
-	mut base_path := real_path(dir(executable()))
-	vresource := getenv('V_RESOURCE_PATH')
+	mut base_path := os.real_path(os.dir(os.executable()))
+	vresource := os.getenv('V_RESOURCE_PATH')
 	if vresource.len != 0 {
 		base_path = vresource
 	}
-	return real_path(join_path(base_path, path))
+	return os.real_path(os.join_path(base_path, path))
 }
 
 // open tries to open a file for reading and returns back a read-only `File` object.
 pub fn open(path string) ?File {
-	/*
+  /*
 	$if linux {
 		$if !android {
 			fd := C.syscall(sys_open, path.str, 511)
@@ -1343,10 +1413,10 @@ pub fn open(path string) ?File {
 			}
 		}
 	}
-	*/
-	cfile := vfopen(path, 'rb') ?
+  */
+	cfile := vfopen(path, 'rb')?
 	fd := fileno(cfile)
-	return File{
+	return File {
 		cfile: cfile
 		fd: fd
 		is_opened: true
@@ -1355,7 +1425,7 @@ pub fn open(path string) ?File {
 
 // create creates or opens a file at a specified location and returns a write-only `File` object.
 pub fn create(path string) ?File {
-	/*
+  /*
 	// NB: android/termux/bionic is also a kind of linux,
 	// but linux syscalls there sometimes fail,
 	// while the libc version should work.
@@ -1377,10 +1447,10 @@ pub fn create(path string) ?File {
 			return file
 		}
 	}
-	*/
-	cfile := vfopen(path, 'wb') ?
+  */
+	cfile := vfopen(path, 'wb')?
 	fd := fileno(cfile)
-	return File{
+	return File {
 		cfile: cfile
 		fd: fd
 		is_opened: true

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -440,8 +440,10 @@ fn test_join() {
 fn test_dir() {
 	$if windows {
 		assert os.dir('C:\\a\\b\\c') == 'C:\\a\\b'
+		assert os.dir('C:\\a\\b\\') == 'C:\\a\\b'
 	} $else {
 		assert os.dir('/var/tmp/foo') == '/var/tmp'
+		assert os.dir('/var/tmp/') == '/var/tmp'
 	}
 	assert os.dir('os') == '.'
 }


### PR DESCRIPTION
This PR fixes os.dir() (fix #7181).

- Fixes os.dir().
- Add tests in os_test.v.
```v
fn test_dir() {
	$if windows {
		assert os.dir('C:\\a\\b\\c') == 'C:\\a\\b'
		assert os.dir('C:\\a\\b\\') == 'C:\\a\\b'
	} $else {
		assert os.dir('/var/tmp/foo') == '/var/tmp'
		assert os.dir('/var/tmp/') == '/var/tmp'
	}
	assert os.dir('os') == '.'
}
```

#7181
```
C:\Users\yuyi9\v>v vlib/term/
vlib\os\os.v:1:1: error: project must include a `main` module or be a shared library (compile with )
    1 | // Copyright (c) 2019-2020 Alexander Medvednikov. All rights reserved.
      | ^
    2 | // Use of this source code is governed by an MIT license
    3 | // that can be found in the LICENSE file.
```