### PR TITLE
os: fix os.dir() (fix #7181)

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -651,11 +651,8 @@ pub fn dir(path string) string {
 	if path == '' {
 		return '.'
 	}
-	mut pos := path.last_index(path_separator) or {
+	pos := path.last_index(path_separator) or {
 		return '.'
-	}
-	if path.ends_with(path_separator) {
-		pos--
 	}
 	return path[..pos]
 }

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -440,8 +440,10 @@ fn test_join() {
 fn test_dir() {
 	$if windows {
 		assert os.dir('C:\\a\\b\\c') == 'C:\\a\\b'
+		assert os.dir('C:\\a\\b\\') == 'C:\\a\\b'
 	} $else {
 		assert os.dir('/var/tmp/foo') == '/var/tmp'
+		assert os.dir('/var/tmp/') == '/var/tmp'
 	}
 	assert os.dir('os') == '.'
 }


### PR DESCRIPTION
This PR fixes os.dir() (fix #7181).

- Fixes os.dir().
- Add tests in os_test.v.
```v
fn test_dir() {
	$if windows {
		assert os.dir('C:\\a\\b\\c') == 'C:\\a\\b'
		assert os.dir('C:\\a\\b\\') == 'C:\\a\\b'
	} $else {
		assert os.dir('/var/tmp/foo') == '/var/tmp'
		assert os.dir('/var/tmp/') == '/var/tmp'
	}
	assert os.dir('os') == '.'
}
```

#7181
```
C:\Users\yuyi9\v>v vlib/term/
vlib\os\os.v:1:1: error: project must include a `main` module or be a shared library (compile with )
    1 | // Copyright (c) 2019-2020 Alexander Medvednikov. All rights reserved.
      | ^
    2 | // Use of this source code is governed by an MIT license
    3 | // that can be found in the LICENSE file.
```