### PR TITLE
cmd: add map_fuzz.v

### DIFF
--- a/cmd/tools/fuzz/fuzz.sh
+++ b/cmd/tools/fuzz/fuzz.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+cores=$(nproc --all)
+
+echo Number of cores: $cores
+echo Compiling...
+./v -cc clang -o cmd/tools/fuzz/map_fuzz cmd/tools/fuzz/map_fuzz.v -prod -cflags "-fsanitize=memory"
+
+echo Fuzzing:
+while true
+do
+  for ((i=1;i<=cores;++i))
+  do
+    ./fuzz &
+  done
+  wait
+done

--- a/cmd/tools/fuzz/fuzz.sh
+++ b/cmd/tools/fuzz/fuzz.sh
@@ -11,6 +11,7 @@ while true
 do
   for ((i=1;i<=cores;++i))
   do
+    sleep 0.001
     ./cmd/tools/fuzz/map_fuzz &
   done
   wait

--- a/cmd/tools/fuzz/fuzz.sh
+++ b/cmd/tools/fuzz/fuzz.sh
@@ -11,7 +11,7 @@ while true
 do
   for ((i=1;i<=cores;++i))
   do
-    ./fuzz &
+    ./cmd/tools/fuzz/map_fuzz &
   done
   wait
 done

--- a/cmd/tools/fuzz/map_fuzz.v
+++ b/cmd/tools/fuzz/map_fuzz.v
@@ -1,9 +1,9 @@
 import rand
 import time
 
-fn generate_strings(str_len int, arr_len int, ) []string {
+fn generate_strings(str_len int, arr_len int) []string {
 	mut arr := []string{len: arr_len}
-	for i in 0..arr_len {
+	for i in 0 .. arr_len {
 		arr[i] = rand.string(str_len)
 	}
 	return arr
@@ -16,14 +16,14 @@ fn fuzz1() {
 	arr := generate_strings(len, amount)
 	arr2 := generate_strings(len, amount2)
 	mut m := map[string]int{}
-	for i in 0..amount {
+	for i in 0 .. amount {
 		m[arr[i]] = i
 		assert i == m[arr[i]]
 	}
-	for i in 0..amount {
+	for i in 0 .. amount {
 		assert i == m[arr[i]]
 	}
-	for i in 0..amount2 {
+	for i in 0 .. amount2 {
 		assert 0 == m[arr2[i]]
 	}
 	unsafe {
@@ -78,10 +78,10 @@ fn fuzz4() {
 	len := 25 - rand.intn(10)
 	arr := generate_strings(len, amount)
 	mut m := map[string]int{}
-	for i in 0..amount {
+	for i in 0 .. amount {
 		m[arr[i]] = i
 	}
-	for i in 0..amount {
+	for i in 0 .. amount {
 		m.delete(arr[i])
 		assert m[arr[i]] == 0
 	}
@@ -96,11 +96,11 @@ fn fuzz5() {
 	amount := rand.intn(500000) + 1
 	arr := generate_strings(20, amount)
 	mut m := map[string]int{}
-	for i in 0..amount {
+	for i in 0 .. amount {
 		m[arr[i]] = i
 		assert (arr[i] in m) == true
 	}
-	for i in 0..amount {
+	for i in 0 .. amount {
 		m.delete(arr[i])
 		assert (arr[i] !in m) == true
 		assert m.len == amount - i - 1

--- a/cmd/tools/fuzz/map_fuzz.v
+++ b/cmd/tools/fuzz/map_fuzz.v
@@ -131,7 +131,7 @@ fn fuzz6() {
 	}
 }
 
-fn test_fuzz() {
+fn main() {
 	seed := u32(time.ticks())
 	println('seed: $seed.hex()')
 	rand.seed([seed, seed])

--- a/vlib/builtin/map_fuzz_test.v
+++ b/vlib/builtin/map_fuzz_test.v
@@ -1,0 +1,144 @@
+import rand
+import time
+
+fn generate_strings(str_len int, arr_len int, ) []string {
+	mut arr := []string{len: arr_len}
+	for i in 0..arr_len {
+		arr[i] = rand.string(str_len)
+	}
+	return arr
+}
+
+fn fuzz1() {
+	amount := 200000 - rand.intn(100000)
+	amount2 := 200000 - rand.intn(100000)
+	len := 25 - rand.intn(10)
+	arr := generate_strings(len, amount)
+	arr2 := generate_strings(len, amount2)
+	mut m := map[string]int{}
+	for i in 0..amount {
+		m[arr[i]] = i
+		assert i == m[arr[i]]
+	}
+	for i in 0..amount {
+		assert i == m[arr[i]]
+	}
+	for i in 0..amount2 {
+		assert 0 == m[arr2[i]]
+	}
+	unsafe {
+		m.free()
+		arr.free()
+	}
+}
+
+fn fuzz2() {
+	mut m := map[string]int{}
+	amount := rand.intn(500000) + 1
+	len := 25 - rand.intn(10)
+	arr := generate_strings(len, amount)
+	for i, x in arr {
+		m[x] = i
+	}
+	mut i := 0
+	for key, val in m {
+		assert key == arr[i]
+		assert val == i
+		i++
+	}
+	unsafe {
+		m.free()
+		arr.free()
+	}
+}
+
+fn fuzz3() {
+	mut m := map[string]int{}
+	amount := rand.intn(500000) + 1
+	len := 25 - rand.intn(10)
+	arr := generate_strings(len, amount)
+	for i, x in arr {
+		if (i % 10000) == 0 {
+			keys := m.keys()
+			assert keys.len == i
+			assert keys == arr[0..i]
+		}
+		m[x] = i
+	}
+	assert m.keys() == arr
+	assert m.keys().len == amount
+	unsafe {
+		m.free()
+		arr.free()
+	}
+}
+
+fn fuzz4() {
+	amount := rand.intn(500000)
+	len := 25 - rand.intn(10)
+	arr := generate_strings(len, amount)
+	mut m := map[string]int{}
+	for i in 0..amount {
+		m[arr[i]] = i
+	}
+	for i in 0..amount {
+		m.delete(arr[i])
+		assert m[arr[i]] == 0
+	}
+	assert m.len == 0
+	unsafe {
+		m.free()
+		arr.free()
+	}
+}
+
+fn fuzz5() {
+	amount := rand.intn(500000) + 1
+	arr := generate_strings(20, amount)
+	mut m := map[string]int{}
+	for i in 0..amount {
+		m[arr[i]] = i
+		assert (arr[i] in m) == true
+	}
+	for i in 0..amount {
+		m.delete(arr[i])
+		assert (arr[i] !in m) == true
+		assert m.len == amount - i - 1
+	}
+	assert m.len == 0
+	unsafe {
+		m.free()
+		arr.free()
+	}
+}
+
+fn fuzz6() {
+	mut m := map[string]int{}
+	amount := rand.intn(500000) + 1
+	len := 25 - rand.intn(10)
+	arr := generate_strings(len, amount)
+	for i, x in arr {
+		m[x]++
+		m[x] += i
+		assert m[x] == i + 1
+	}
+	for i, x in arr {
+		assert m[x] == i + 1
+	}
+	unsafe {
+		m.free()
+		arr.free()
+	}
+}
+
+fn test_fuzz() {
+	seed := u32(time.ticks())
+	println('seed: $seed.hex()')
+	rand.seed([seed, seed])
+	fuzz1()
+	fuzz2()
+	fuzz3()
+	fuzz4()
+	fuzz5()
+	fuzz6()
+}


### PR DESCRIPTION
In #7284 I mentioned it would be good to have fuzzing of the map, so I added it. I was not completely sure where to place the files, so I placed them in `cmd/tools/fuzz`. These tests should be run for multiple hours in multiple threads. You run these tests by:

```
sh cmd/tools/fuzz/fuzz.sh
```
It will compile the program with `fsanitize=memory` and `prod` and it will run the test on all your cores (be ready, may crash your computer):
```
Number of cores: 4
Compiling...
Fuzzing:
seed: 5988f4b1
seed: 5988f4b2
seed: 5988f4b3
seed: 5988f4bb
```
I have not added these tests to CI, but they could be.
