### PR TITLE
time: fix date parsing tests in winter for regions using DST

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
       run: TZ=Etc/GMT-3 ./v test vlib/time/
     - name: Test time functions in a timezone UTC+12
       run: TZ=Etc/GMT-12 ./v test vlib/time/
+    - name: Test time functions in a timezone using daylight saving (Europe/Paris)
+      run: TZ=Europe/Paris ./v test vlib/time/
     - name: Test building v tools
       run: ./v -silent build-tools
     - name: v doctor

--- a/vlib/time/parse.v
+++ b/vlib/time/parse.v
@@ -111,5 +111,5 @@ pub fn parse_iso8601(s string) ?Time {
 		t = unix2(int(unix_time), t.microsecond)
 	}
 	// Convert the time to local time
-	return to_local_time(t)
+	return t.to_local_time()
 }

--- a/vlib/time/parse_test.v
+++ b/vlib/time/parse_test.v
@@ -1,5 +1,4 @@
 import time
-import math
 
 fn test_parse() {
 	s := '2018-01-27 12:48:34'
@@ -52,13 +51,17 @@ fn test_parse_rfc2822_invalid() {
 fn test_parse_iso8601() {
 	// Because there is a small difference between time.now() - time.utc and actual offset,
 	// round to the nearest hour.
-	offset := time.Duration(i64(math.round((time.now() - time.utc()).hours())) * time.hour)
+	offset_summer := time.Duration(time.new_time(year: 2020, month: 6, day: 5, hour: 15).to_local_time() -
+		time.new_time(year: 2020, month: 6, day: 5, hour: 15))
+	offset_winter := time.Duration(time.new_time(year: 2020, month: 11, day: 5, hour: 15).to_local_time() -
+		time.new_time(year: 2020, month: 11, day: 5, hour: 15))
 	formats := [
 		'2020-06-05T15:38:06Z',
 		'2020-06-05T15:38:06.015959Z',
 		'2020-06-05T15:38:06.015959+00:00',
 		'2020-06-05T15:38:06.015959+02:00',
 		'2020-06-05T15:38:06.015959-02:00',
+		'2020-11-05T15:38:06.015959Z'
 	]
 	times := [
 		[2020, 6, 5, 15, 38, 6, 0],
@@ -66,8 +69,10 @@ fn test_parse_iso8601() {
 		[2020, 6, 5, 15, 38, 6, 15959],
 		[2020, 6, 5, 13, 38, 6, 15959],
 		[2020, 6, 5, 17, 38, 6, 15959],
+		[2020, 11, 5, 15, 38, 6, 15959],
 	]
 	for i, format in formats {
+		println(i)
 		t := time.parse_iso8601(format) or {
 			assert false
 			continue
@@ -81,7 +86,7 @@ fn test_parse_iso8601() {
 			minute: data[4]
 			second: data[5]
 			microsecond: data[6]
-		).add(offset)
+		).add(if i <= 4 { offset_summer } else { offset_winter })
 		assert t.year == t2.year
 		assert t.month == t2.month
 		assert t.day == t2.day

--- a/vlib/time/parse_test.v
+++ b/vlib/time/parse_test.v
@@ -49,8 +49,9 @@ fn test_parse_rfc2822_invalid() {
 }
 
 fn test_parse_iso8601() {
-	// Because there is a small difference between time.now() - time.utc and actual offset,
-	// round to the nearest hour.
+	// Because the offset between local time and UTC is not constant in regions
+	// that use daylight saving times we need to calculate separete offsets for
+	// summer and winter
 	offset_summer := time.Duration(time.new_time(year: 2020, month: 6, day: 5, hour: 15).to_local_time() -
 		time.new_time(year: 2020, month: 6, day: 5, hour: 15))
 	offset_winter := time.Duration(time.new_time(year: 2020, month: 11, day: 5, hour: 15).to_local_time() -
@@ -72,7 +73,6 @@ fn test_parse_iso8601() {
 		[2020, 11, 5, 15, 38, 6, 15959],
 	]
 	for i, format in formats {
-		println(i)
 		t := time.parse_iso8601(format) or {
 			assert false
 			continue

--- a/vlib/time/time_nix.c.v
+++ b/vlib/time/time_nix.c.v
@@ -24,7 +24,7 @@ fn make_unix_time(t C.tm) int {
 	return int(C.timegm(&t))
 }
 
-fn to_local_time(t Time) Time {
+pub fn (t Time) to_local_time() Time {
 	loc_tm := C.tm{}
 	C.localtime_r(time_t(&t.unix), &loc_tm)
 	return convert_ctime(loc_tm, t.microsecond)

--- a/vlib/time/time_windows.c.v
+++ b/vlib/time/time_windows.c.v
@@ -93,7 +93,7 @@ fn local_as_unix_time() int {
 	return make_unix_time(tm)
 }
 
-fn to_local_time(t Time) Time {
+pub fn (t Time) to_local_time() Time {
 	st_utc := SystemTime{
 		year: u16(t.year)
 		month: u16(t.month)


### PR DESCRIPTION
**Problem:**
Test cases in `time/parse_test.v` fail for regions that use daylight saving times when run in winter. (See [this comment](https://github.com/vlang/v/commit/5fec0d785a2a89debc1dca3e4bd8161f72ad18f5#r45049974).)
**Cause:**
The test case has used the difference between local "now" and UTC "now" (i.e. the time when the test cases are run) to calculate an offset. The dates used in the parsing tests are in summer so this fails when there is a different offset during DST.
**Solution:**
Calculate the offset for the date that is used in the parsing test case. For this I've promoted the function `to_local_time()` to `pub` and made it a method (otherwise "`time`" would have to be typed too often...).
I've added a parsing test case for winter and added a run for Paris in the workflow.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
