### PR TITLE
fmt: intelligent line wrap for trailing struct syntax

### DIFF
--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -121,18 +121,22 @@ fn gg_init_sokol_window(user_data voidptr) {
 	exists := $if !android { os.is_file(g.config.font_path) } $else { true }
 	if g.config.font_path != '' && exists {
 		// t := time.ticks()
-		g.ft = new_ft(font_path: g.config.font_path, custom_bold_font_path: g.config.custom_bold_font_path, scale: sapp.dpi_scale()) or {
-			panic(err)
-		}
+		g.ft = new_ft(
+			font_path: g.config.font_path
+			custom_bold_font_path: g.config.custom_bold_font_path
+			scale: sapp.dpi_scale()
+		) or { panic(err) }
 		// println('FT took ${time.ticks()-t} ms')
 		g.font_inited = true
 	} else {
 		if !exists {
 			sfont := system_font_path()
 			eprintln('font file "$g.config.font_path" does not exist, the system font was used instead.')
-			g.ft = new_ft(font_path: sfont, custom_bold_font_path: g.config.custom_bold_font_path, scale: sapp.dpi_scale()) or {
-				panic(err)
-			}
+			g.ft = new_ft(
+				font_path: sfont
+				custom_bold_font_path: g.config.custom_bold_font_path
+				scale: sapp.dpi_scale()
+			) or { panic(err) }
 			g.font_inited = true
 		}
 	}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1858,11 +1858,15 @@ pub fn (mut f Fmt) struct_init(it ast.StructInit) {
 		}
 		f.comments(it.pre_comments, inline: true, has_nl: true, level: .indent)
 		f.indent++
+		mut short_args_multiline := false
 		mut field_start_positions := []int{}
 		for i, field in it.fields {
 			field_start_positions << f.out.len
 			f.write('$field.name: ')
 			f.prefix_expr_cast_expr(field.expr)
+			if field.expr is ast.StructInit {
+				short_args_multiline = true
+			}
 			f.comments(field.comments, inline: true, has_nl: false, level: .indent)
 			if use_short_args {
 				if i < it.fields.len - 1 {
@@ -1874,7 +1878,7 @@ pub fn (mut f Fmt) struct_init(it ast.StructInit) {
 			f.comments(field.next_comments, inline: false, has_nl: true, level: .keep)
 		}
 		if use_short_args {
-			if f.line_len > max_len[4] {
+			if f.line_len > max_len[3] || short_args_multiline {
 				mut fields := []string{}
 				for pos in field_start_positions.reverse() {
 					fields << f.out.cut_last(f.out.len - pos).trim_suffix(', ')

--- a/vlib/v/fmt/tests/fn_trailing_arg_syntax_expected.vv
+++ b/vlib/v/fmt/tests/fn_trailing_arg_syntax_expected.vv
@@ -1,0 +1,15 @@
+struct Bar {
+	x string
+	y int
+}
+
+fn main() {
+	bar_func(x: 'this line is short enough', y: 13)
+	bar_func(
+		x: 'a very long content should cause vfmt to use multiple lines instead of one.'
+		y: 123456789
+	)
+}
+
+fn bar_func(bar Bar) {
+}

--- a/vlib/v/fmt/tests/fn_trailing_arg_syntax_expected.vv
+++ b/vlib/v/fmt/tests/fn_trailing_arg_syntax_expected.vv
@@ -1,6 +1,11 @@
 struct Bar {
 	x string
 	y int
+	b Baz
+}
+
+struct Baz {
+	x int
 }
 
 fn main() {
@@ -8,6 +13,12 @@ fn main() {
 	bar_func(
 		x: 'a very long content should cause vfmt to use multiple lines instead of one.'
 		y: 123456789
+	)
+	bar_func(
+		x: 'some string'
+		b: Baz{
+			x: 0
+		}
 	)
 }
 

--- a/vlib/v/fmt/tests/fn_trailing_arg_syntax_input.vv
+++ b/vlib/v/fmt/tests/fn_trailing_arg_syntax_input.vv
@@ -1,11 +1,19 @@
 struct Bar {
 	x string
 	y int
+	b Baz
+}
+
+struct Baz {
+	x int
 }
 
 fn main() {
 	bar_func(x: 'this line is short enough', y: 13)
 	bar_func(x: 'a very long content should cause vfmt to use multiple lines instead of one.', y: 123456789)
+	bar_func(x: 'some string', b: Baz{
+		x: 0
+	})
 }
 
 fn bar_func(bar Bar) {

--- a/vlib/v/fmt/tests/fn_trailing_arg_syntax_input.vv
+++ b/vlib/v/fmt/tests/fn_trailing_arg_syntax_input.vv
@@ -1,0 +1,12 @@
+struct Bar {
+	x string
+	y int
+}
+
+fn main() {
+	bar_func(x: 'this line is short enough', y: 13)
+	bar_func(x: 'a very long content should cause vfmt to use multiple lines instead of one.', y: 123456789)
+}
+
+fn bar_func(bar Bar) {
+}

--- a/vlib/v/fmt/tests/fn_trailing_arg_syntax_keep.vv
+++ b/vlib/v/fmt/tests/fn_trailing_arg_syntax_keep.vv
@@ -16,12 +16,7 @@ fn main() {
 	foo_func(Baz{
 		x: 'Baz as Foo sumtype'
 	})
-	bar_func(
-		x: 'bar'
-		y: 2
-		z: 3
-		a: 4
-	)
+	bar_func(x: 'bar', y: 2, z: 3, a: 4)
 	func_from_other_file(val: 'something')
 }
 

--- a/vlib/v/table/types.v
+++ b/vlib/v/table/types.v
@@ -498,168 +498,38 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 	// reserve index 0 so nothing can go there
 	// save index check, 0 will mean not found
 	t.register_type_symbol(kind: .placeholder, name: 'reserved_0')
-	t.register_type_symbol(
-		kind: .void
-		name: 'void'
-		cname: 'void'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .voidptr
-		name: 'voidptr'
-		cname: 'voidptr'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .byteptr
-		name: 'byteptr'
-		cname: 'byteptr'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .charptr
-		name: 'charptr'
-		cname: 'charptr'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .i8
-		name: 'i8'
-		cname: 'i8'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .i16
-		name: 'i16'
-		cname: 'i16'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .int
-		name: 'int'
-		cname: 'int'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .i64
-		name: 'i64'
-		cname: 'i64'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .byte
-		name: 'byte'
-		cname: 'byte'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .u16
-		name: 'u16'
-		cname: 'u16'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .u32
-		name: 'u32'
-		cname: 'u32'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .u64
-		name: 'u64'
-		cname: 'u64'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .f32
-		name: 'f32'
-		cname: 'f32'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .f64
-		name: 'f64'
-		cname: 'f64'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .char
-		name: 'char'
-		cname: 'char'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .bool
-		name: 'bool'
-		cname: 'bool'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .none_
-		name: 'none'
-		cname: 'none'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .string
-		name: 'string'
-		cname: 'string'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .ustring
-		name: 'ustring'
-		cname: 'ustring'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .array
-		name: 'array'
-		cname: 'array'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .map
-		name: 'map'
-		cname: 'map'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .chan
-		name: 'chan'
-		cname: 'chan'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .size_t
-		name: 'size_t'
-		cname: 'size_t'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .rune
-		name: 'rune'
-		cname: 'rune'
-		mod: 'builtin'
-	)
-	t.register_type_symbol(
-		kind: .any
-		name: 'any'
-		cname: 'any'
-		mod: 'builtin'
-	)
+	t.register_type_symbol(kind: .void, name: 'void', cname: 'void', mod: 'builtin')
+	t.register_type_symbol(kind: .voidptr, name: 'voidptr', cname: 'voidptr', mod: 'builtin')
+	t.register_type_symbol(kind: .byteptr, name: 'byteptr', cname: 'byteptr', mod: 'builtin')
+	t.register_type_symbol(kind: .charptr, name: 'charptr', cname: 'charptr', mod: 'builtin')
+	t.register_type_symbol(kind: .i8, name: 'i8', cname: 'i8', mod: 'builtin')
+	t.register_type_symbol(kind: .i16, name: 'i16', cname: 'i16', mod: 'builtin')
+	t.register_type_symbol(kind: .int, name: 'int', cname: 'int', mod: 'builtin')
+	t.register_type_symbol(kind: .i64, name: 'i64', cname: 'i64', mod: 'builtin')
+	t.register_type_symbol(kind: .byte, name: 'byte', cname: 'byte', mod: 'builtin')
+	t.register_type_symbol(kind: .u16, name: 'u16', cname: 'u16', mod: 'builtin')
+	t.register_type_symbol(kind: .u32, name: 'u32', cname: 'u32', mod: 'builtin')
+	t.register_type_symbol(kind: .u64, name: 'u64', cname: 'u64', mod: 'builtin')
+	t.register_type_symbol(kind: .f32, name: 'f32', cname: 'f32', mod: 'builtin')
+	t.register_type_symbol(kind: .f64, name: 'f64', cname: 'f64', mod: 'builtin')
+	t.register_type_symbol(kind: .char, name: 'char', cname: 'char', mod: 'builtin')
+	t.register_type_symbol(kind: .bool, name: 'bool', cname: 'bool', mod: 'builtin')
+	t.register_type_symbol(kind: .none_, name: 'none', cname: 'none', mod: 'builtin')
+	t.register_type_symbol(kind: .string, name: 'string', cname: 'string', mod: 'builtin')
+	t.register_type_symbol(kind: .ustring, name: 'ustring', cname: 'ustring', mod: 'builtin')
+	t.register_type_symbol(kind: .array, name: 'array', cname: 'array', mod: 'builtin')
+	t.register_type_symbol(kind: .map, name: 'map', cname: 'map', mod: 'builtin')
+	t.register_type_symbol(kind: .chan, name: 'chan', cname: 'chan', mod: 'builtin')
+	t.register_type_symbol(kind: .size_t, name: 'size_t', cname: 'size_t', mod: 'builtin')
+	t.register_type_symbol(kind: .rune, name: 'rune', cname: 'rune', mod: 'builtin')
+	t.register_type_symbol(kind: .any, name: 'any', cname: 'any', mod: 'builtin')
 	t.register_type_symbol(
 		kind: .any_float
 		name: 'any_float'
 		cname: 'any_float'
 		mod: 'builtin'
 	)
-	t.register_type_symbol(
-		kind: .any_int
-		name: 'any_int'
-		cname: 'any_int'
-		mod: 'builtin'
-	)
+	t.register_type_symbol(kind: .any_int, name: 'any_int', cname: 'any_int', mod: 'builtin')
 }
 
 [inline]


### PR DESCRIPTION
Before the decision to use a single/multiple lines was based on the amount of struct fields provided.

Now it is done if the line length would exceed 87 or if the struct contains substructs.