### PR TITLE
gen: fix comparing signed int to u32/u64

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -20,7 +20,7 @@ const (
 	// same order as in token.Kind
 	cmp_str    = ['eq', 'ne', 'gt', 'lt', 'ge', 'le']
 	// when operands are switched
-	cmp_rev    = ['eq', 'ne', 'le', 'ge', 'lt', 'gt']
+	cmp_rev    = ['eq', 'ne', 'lt', 'gt', 'le', 'ge']
 )
 
 struct Gen {

--- a/vlib/v/tests/infix_expr_test.v
+++ b/vlib/v/tests/infix_expr_test.v
@@ -1,0 +1,51 @@
+fn test_cmp_signed_and_u32() {
+	// ==
+	assert int(1) == u32(1)
+	// !=
+	assert int(1) != u32(2)
+	// >
+	assert !(int(1) > u32(1))
+	assert int(1) > u32(0)
+	// <
+	assert !(int(1) < u32(1))
+	assert int(0) < u32(1)
+}
+
+fn test_cmp_u32_and_signed() {
+	// ==
+	assert u32(1) == int(1)
+	// !=
+	assert u32(2) != int(1)
+	// >
+	assert !(u32(1) > int(1))
+	assert u32(1) > int(0)
+	// <
+	assert !(u32(1) < int(1))
+	assert u32(0) < int(1)
+}
+
+fn test_cmp_signed_and_u64() {
+	// ==
+	assert int(1) == u64(1)
+	// !=
+	assert int(1) != u64(2)
+	// >
+	assert !(int(1) > u64(1))
+	assert int(1) > u64(0)
+	// <
+	assert !(int(1) < u64(1))
+	assert int(0) < u64(1)
+}
+
+fn test_cmp_u64_and_signed() {
+	// ==
+	assert u64(1) == int(1)
+	// !=
+	assert u64(2) != int(1)
+	// >
+	assert !(u64(1) > int(1))
+	assert u64(1) > int(0)
+	// <
+	assert !(u64(1) < int(1))
+	assert u64(0) < int(1)
+}

--- a/vlib/v/tests/infix_expr_test.v
+++ b/vlib/v/tests/infix_expr_test.v
@@ -6,9 +6,17 @@ fn test_cmp_signed_and_u32() {
 	// >
 	assert !(int(1) > u32(1))
 	assert int(1) > u32(0)
+	// >=
+	assert !(int(0) >= u32(1))
+	assert int(1) >= u32(1)
+	assert int(1) >= u32(0)
 	// <
 	assert !(int(1) < u32(1))
 	assert int(0) < u32(1)
+	// <=
+	assert int(0) <= u32(1)
+	assert int(1) <= u32(1)
+	assert !(int(1) <= u32(0))
 }
 
 fn test_cmp_u32_and_signed() {
@@ -19,9 +27,17 @@ fn test_cmp_u32_and_signed() {
 	// >
 	assert !(u32(1) > int(1))
 	assert u32(1) > int(0)
+	// >=
+	assert u32(1) >= int(0)
+	assert u32(1) >= int(1)
+	assert !(u32(0) >= int(1))
 	// <
 	assert !(u32(1) < int(1))
 	assert u32(0) < int(1)
+	// <=
+	assert u32(0) <= int(1)
+	assert u32(1) <= int(1)
+	assert !(u32(1) <= int(0))
 }
 
 fn test_cmp_signed_and_u64() {
@@ -32,9 +48,17 @@ fn test_cmp_signed_and_u64() {
 	// >
 	assert !(int(1) > u64(1))
 	assert int(1) > u64(0)
+	// >=
+	assert !(int(0) >= u64(1))
+	assert int(1) >= u64(1)
+	assert int(1) >= u64(0)
 	// <
 	assert !(int(1) < u64(1))
 	assert int(0) < u64(1)
+	// <=
+	assert int(0) <= u64(1)
+	assert int(1) <= u64(1)
+	assert !(int(1) <= u64(0))
 }
 
 fn test_cmp_u64_and_signed() {
@@ -45,7 +69,15 @@ fn test_cmp_u64_and_signed() {
 	// >
 	assert !(u64(1) > int(1))
 	assert u64(1) > int(0)
+	// >=
+	assert u64(1) >= int(0)
+	assert u64(1) >= int(1)
+	assert !(u64(0) >= int(1))
 	// <
 	assert !(u64(1) < int(1))
 	assert u64(0) < int(1)
+	// <=
+	assert u64(0) <= int(1)
+	assert u64(1) <= int(1)
+	assert !(u64(1) <= int(0))
 }


### PR DESCRIPTION
Fixes #7311
Note that the order of operands matters, comparing u32/u64 to signed integers already worked.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
