### PR TITLE
map: use voidptr-based key equality and meta index methods

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -338,7 +338,7 @@ fn (mut m map) set(k string, value voidptr) {
 		index += 2
 		meta += probe_inc
 	}
-	kv_index := m.key_values.push(key, value)
+	kv_index := m.key_values.push(&key, value)
 	m.meta_greater(index, meta, u32(kv_index))
 	m.len++
 }


### PR DESCRIPTION
Part of #6991.

Every operation on a map key needs to take a voidptr, not a string. This pull encapsulates:
* The 'keys equal' operation on voidptr keys. 
* The 'meta index' operation on a voidptr key.

Add map::key_bytes field.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
