### PR TITLE
fn_array: implement a direct call to an array of functions (fix #6908)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -521,13 +521,12 @@ pub mut:
 
 pub struct IndexExpr {
 pub:
-	pos        token.Position
-	left       Expr
-	index      Expr // [0], RangeExpr [start..end] or map[key]
+	pos       token.Position
+	left      Expr
+	index     Expr // [0], RangeExpr [start..end] or map[key]
 pub mut:
-	left_type  table.Type // array, map, fixed array
-	is_setter  bool
-	is_fn_call bool
+	left_type table.Type // array, map, fixed array
+	is_setter bool
 }
 
 pub struct IfExpr {

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -521,12 +521,13 @@ pub mut:
 
 pub struct IndexExpr {
 pub:
-	pos       token.Position
-	left      Expr
-	index     Expr // [0], RangeExpr [start..end] or map[key]
+	pos        token.Position
+	left       Expr
+	index      Expr // [0], RangeExpr [start..end] or map[key]
 pub mut:
-	left_type table.Type // array, map, fixed array
-	is_setter bool
+	left_type  table.Type // array, map, fixed array
+	is_setter  bool
+	is_fn_call bool
 }
 
 pub struct IfExpr {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1431,6 +1431,20 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 			f = f1
 		}
 	}
+	if !found && call_expr.left is ast.IndexExpr {
+		c.expr(call_expr.left)
+		expr := call_expr.left as ast.IndexExpr
+		sym := c.table.get_type_symbol(expr.left_type)
+		if sym.kind == .array {
+			info := sym.info as table.Array
+			elem_typ := c.table.get_type_symbol(info.elem_type)
+			if elem_typ.info is table.FnType {
+				return elem_typ.info.func.return_type
+			}
+		}
+		found = true
+		return table.string_type
+	}
 	// already prefixed (mod.fn) or C/builtin/main
 	if !found {
 		if f1 := c.table.find_fn(fn_name) {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3766,19 +3766,10 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 						g.write('(($array_ptr_type_str)')
 					} else if g.is_fn_index_call {
 						if elem_typ.info is table.FnType {
-							ret_styp := g.typ(elem_typ.info.func.return_type)
-							g.write('(($ret_styp (*) (')
-							arg_len := elem_typ.info.func.params.len
-							for i, arg in elem_typ.info.func.params {
-								arg_styp := g.typ(arg.typ)
-								g.write('$arg_styp $arg.name')
-								if i < arg_len - 1 {
-									g.write(', ')
-								}
-							}
-							g.write('))')
+							g.write('((')
+							g.write_fn_ptr_decl(&elem_typ.info, '')
+							g.write(')(*($array_ptr_type_str)/*ee elem_typ */array_get(')
 						}
-						g.write('(*($array_ptr_type_str)/*ee elem_typ */array_get(')
 					} else {
 						g.write('(*($array_ptr_type_str)/*ee elem_typ */array_get(')
 						if left_is_ptr && !node.left_type.has_flag(.shared_f) {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -116,7 +116,7 @@ mut:
 	called_fn_name                   string
 	cur_mod                          ast.Module
 	is_js_call                       bool // for handling a special type arg #1 `json.decode(User, ...)`
-	is_fn_index_call				 bool
+	is_fn_index_call                 bool
 	// nr_vars_to_free       int
 	// doing_autofree_tmp    bool
 	inside_lambda                    bool

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -254,6 +254,11 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 	if node.left is ast.AnonFn {
 		g.expr(node.left)
 	}
+	if node.left is ast.IndexExpr && node.name == '' {
+		g.is_fn_index_call = true
+		g.expr(node.left)
+		g.is_fn_index_call = false
+	}
 	if node.should_be_skipped {
 		return
 	}

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -263,6 +263,19 @@ pub fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_iden
 		} else if p.tok.kind == .lsbr {
 			node = p.index_expr(node)
 			p.is_stmt_ident = is_stmt_ident
+			if p.tok.kind == .lpar && p.tok.line_nr == p.prev_tok.line_nr && node is ast.IndexExpr {
+				p.next()
+				pos := p.tok.position()
+				args := p.call_args()
+				p.check(.rpar)
+				node = ast.CallExpr{
+					left: node
+					args: args
+					pos: pos
+					scope: p.scope
+				}
+				p.is_stmt_ident = is_stmt_ident
+			}
 		} else if p.tok.kind == .key_as {
 			// sum type as cast `x := SumType as Variant`
 			pos := p.tok.position()

--- a/vlib/v/tests/fn_array_direct_call_test.v
+++ b/vlib/v/tests/fn_array_direct_call_test.v
@@ -1,0 +1,17 @@
+struct Placeholder {
+    name string
+}
+
+struct FnStruct {
+mut:
+    array_of_fn []fn(int, &Placeholder, string)bool
+}
+
+fn test_fn_array_direct_call() {
+    mut fs := FnStruct{}
+    fs.array_of_fn << fn(x int, y &Placeholder, z string) bool {
+        return false
+    }
+
+    assert fs.array_of_fn[0](1, &Placeholder{name: 'Bob'}, 'Builder') == false
+}


### PR DESCRIPTION
This PR implements a direct call to an array of functions (fix #6908).

- Implements a direct call to an array of functions.
- Add test `fn_array_direct_call_test.v`.

```v
module main

struct Placeholder {
    name string
}

struct FnStruct {
mut:
    array_of_fn []fn(int, &Placeholder, string)bool
}

fn main() {
    mut fs := FnStruct{}
    fs.array_of_fn << fn(x int, y &Placeholder, z string) bool {
        return false
    }

	println(fs.array_of_fn[0](1, &Placeholder{name: 'Bob'}, 'Builder'))
    assert fs.array_of_fn[0](1, &Placeholder{name: 'Bob'}, 'Builder') == false
}

PS D:\Test\v\tt1> v run .
false
```