### PR TITLE
cgen: fix generation of array names in generic structs

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -530,7 +530,7 @@ fn (g &Gen) cc_type2(t table.Type) string {
 			mut sgtyps := '_T'
 			for gt in sym.info.generic_types {
 				gts := g.table.get_type_symbol(if gt.has_flag(.generic) { g.unwrap_generic(gt) } else { gt })
-				sgtyps += '_$gts.name'
+				sgtyps += '_$gts.cname'
 			}
 			styp += sgtyps
 		}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -387,7 +387,7 @@ pub fn (mut p Parser) parse_generic_struct_inst_type(name string) table.Type {
 		}
 		gts := p.table.get_type_symbol(gt)
 		bs_name += gts.name
-		bs_cname += gts.name
+		bs_cname += gts.cname
 		generic_types << gt
 		if p.tok.kind != .comma {
 			break

--- a/vlib/v/tests/generics_test.v
+++ b/vlib/v/tests/generics_test.v
@@ -288,6 +288,14 @@ fn test_struct_from_other_module() {
 	assert g.msg.name == ''
 }
 
+fn test_generic_struct_print_array_as_field() {
+    foo := Foo<[]string>{
+        data: []string{}
+    }
+	assert foo.str() == 'Foo<array, string>{\n    data: []\n}'
+
+}
+
 /*
 struct Abc{ x int y int z int }
 


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fixes https://github.com/vlang/v/issues/7321
