### PR TITLE
vlib: implement `memcpy`, `memcmp`, `memmove` and `strlen` in V

### DIFF
--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -289,6 +289,7 @@ pub:
 	lvalue  string // the stringified *actual value* of the left side of a failed assertion
 	rvalue  string // the stringified *actual value* of the right side of a failed assertion
 }
+
 fn __print_assert_failure(i &VAssertMetaInfo) {
 	eprintln('${i.fpath}:${i.line_nr+1}: FAIL: fn ${i.fn_name}: assert ${i.src}')
 	if i.op.len > 0 && i.op != 'call' {

--- a/vlib/x/builtin/memory.v
+++ b/vlib/x/builtin/memory.v
@@ -1,0 +1,21 @@
+// Copyright (c) 2019-2020 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module builtin
+
+// TODO Replace `u32` by `usize` once available
+
+[direct_array_access]
+[unsafe]
+pub fn memcpy(mut dest voidptr, src voidptr, len u32) voidptr {
+	mut d := byteptr(dest)
+	s := byteptr(src)
+	mut l := len
+	for l > 0 {
+		l--
+		unsafe {
+			d[l] = s[l]
+		}
+	}
+	return dest
+}

--- a/vlib/x/builtin/memory.v
+++ b/vlib/x/builtin/memory.v
@@ -10,11 +10,32 @@ module builtin
 pub fn memcpy(mut dest voidptr, src voidptr, len u32) voidptr {
 	mut d := byteptr(dest)
 	s := byteptr(src)
-	mut l := len
-	for l > 0 {
-		l--
+	for l := u32(0); l < len; l++ {
 		unsafe {
 			d[l] = s[l]
+		}
+	}
+	return dest
+}
+
+[direct_array_access]
+[unsafe]
+pub fn memmove(mut dest voidptr, src voidptr, len u32) voidptr {
+	mut d := byteptr(dest)
+	s := byteptr(src)
+	if d < s {
+		for l := u32(0); l < len; l++ {
+			unsafe {
+				d[l] = s[l]
+			}
+		}
+	} else {
+		mut l := len
+		for l > 0 {
+			l--
+			unsafe {
+				d[l] = s[l]
+			}
 		}
 	}
 	return dest

--- a/vlib/x/builtin/memory.v
+++ b/vlib/x/builtin/memory.v
@@ -19,3 +19,19 @@ pub fn memcpy(mut dest voidptr, src voidptr, len u32) voidptr {
 	}
 	return dest
 }
+
+[direct_array_access]
+pub fn memcmp(str1 voidptr, str2 voidptr, len u32) int {
+	s1 := byteptr(str1)
+	s2 := byteptr(str2)
+	mut l := len
+	for l > 0 {
+		l--
+		unsafe {
+			if s1[l] != s2[l] {
+				return if s1[l] < s2[l] { -1 } else { 1 }
+			}
+		}
+	}
+	return 0
+}

--- a/vlib/x/builtin/memory_test.v
+++ b/vlib/x/builtin/memory_test.v
@@ -1,0 +1,44 @@
+import x.builtin
+
+struct Color {
+	r byte
+	g byte
+	b byte
+}
+
+fn (c &Color) eq(o &Color) bool {
+	return c.r == o.r && c.g == o.g && c.b == o.b
+}
+
+fn test_memcpy() {
+	mut arr_1a := [1, 2]!!
+	arr_1b := [3, 4]!!
+	unsafe {
+		builtin.memcpy(mut arr_1a, arr_1b, sizeof(int))
+	}
+	assert arr_1a == [3, 2]!!
+	mut arr_2a := [1, 2]!!
+	arr_2b := [3, 4]!!
+	unsafe {
+		builtin.memcpy(mut arr_2a, arr_2b, sizeof(arr_2a))
+	}
+	assert arr_2a == arr_2b
+	mut c_1a := Color{0, 0, 0}
+	c_1b := Color{255, 255, 255}
+	unsafe {
+		builtin.memcpy(mut c_1a, c_1b, sizeof(byte) * 2)
+	}
+	assert c_1a.eq(Color{255, 255, 0})
+	mut c_2a := Color{0, 0, 0}
+	c_2b := Color{255, 255, 255}
+	unsafe {
+		builtin.memcpy(mut c_2a, c_2b, sizeof(Color))
+	}
+	assert c_2a.eq(c_2b)
+	mut c_3a := Color{0, 0, 0}
+	c_3b := Color{255, 255, 255}
+	unsafe {
+		builtin.memcpy(mut c_3a, c_3b, sizeof(c_2a))
+	}
+	assert c_3a.eq(c_3b)
+}

--- a/vlib/x/builtin/memory_test.v
+++ b/vlib/x/builtin/memory_test.v
@@ -41,6 +41,41 @@ fn test_memcpy() {
 		builtin.memcpy(mut c_3a, c_3b, sizeof(c_2a))
 	}
 	assert c_3a.eq(c_3b)
+	// TODO Tests for edge cases compared to memmove
+}
+
+fn test_memmove() {
+	mut arr_1a := [1, 2]!!
+	arr_1b := [3, 4]!!
+	unsafe {
+		builtin.memmove(mut arr_1a, arr_1b, sizeof(int))
+	}
+	assert arr_1a == [3, 2]!!
+	arr_2b := [3, 4]!!
+	mut arr_2a := [1, 2]!!
+	unsafe {
+		builtin.memmove(mut arr_2a, arr_2b, sizeof(arr_2a))
+	}
+	assert arr_2a == arr_2b
+	mut c_1a := Color{0, 0, 0}
+	c_1b := Color{255, 255, 255}
+	unsafe {
+		builtin.memmove(mut c_1a, c_1b, sizeof(byte) * 2)
+	}
+	assert c_1a.eq(Color{255, 255, 0})
+	c_2b := Color{255, 255, 255}
+	mut c_2a := Color{0, 0, 0}
+	unsafe {
+		builtin.memmove(mut c_2a, c_2b, sizeof(Color))
+	}
+	assert c_2a.eq(c_2b)
+	mut c_3a := Color{0, 0, 0}
+	c_3b := Color{255, 255, 255}
+	unsafe {
+		builtin.memmove(mut c_3a, c_3b, sizeof(c_2a))
+	}
+	assert c_3a.eq(c_3b)
+	// TODO Tests for edge cases compared to memcpy
 }
 
 fn test_memcmp() {

--- a/vlib/x/builtin/memory_test.v
+++ b/vlib/x/builtin/memory_test.v
@@ -42,3 +42,11 @@ fn test_memcpy() {
 	}
 	assert c_3a.eq(c_3b)
 }
+
+fn test_memcmp() {
+	i_a := 1
+	i_b := 1
+	assert builtin.memcmp(i_a, i_b, sizeof(int)) == 0
+	i_c := 2
+	assert builtin.memcmp(i_a, i_c, sizeof(int)) == -1
+}

--- a/vlib/x/builtin/string.v
+++ b/vlib/x/builtin/string.v
@@ -1,0 +1,18 @@
+// Copyright (c) 2019-2020 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module builtin
+
+// TODO Replace `u32` by `usize` once available
+
+// TODO Make it a method of byteptr ? It would easier to apply it to voidptr and charptr
+[unsafe]
+pub fn strlen(str byteptr) u32 {
+	l := u32(0)
+	unsafe {
+		for str[l] != `\0` {
+			l++
+		}
+	}
+	return l
+}

--- a/vlib/x/builtin/string_test.v
+++ b/vlib/x/builtin/string_test.v
@@ -1,0 +1,23 @@
+import x.builtin
+
+fn test_strlen() {
+	bytes1 := [byte(`a`), `b`, `c`, 0x00]!!
+	unsafe {
+		assert builtin.strlen(bytes1) == 3
+	}
+	mut bytes2 := [10]byte{}
+	bytes2[0] = `a`
+	bytes2[1] = `b`
+	bytes2[2] = 0x00
+	unsafe {
+		assert builtin.strlen(bytes2) == 2
+	}
+	c_str := c'test'
+	unsafe {
+		assert builtin.strlen(c_str) == 4
+	}
+	raw_byteptr := byteptr(c'anothertest')
+	unsafe {
+		assert builtin.strlen(raw_byteptr) == 11
+	}
+}


### PR DESCRIPTION
Implement `memcpy`, `memmove`, `memcmp` and `strlen` in V.
They will be able to replace their C equivalent once `usize` becomes available, so for now, I put them in an `x.builtin` module.

Some things are to be discussed in my opinion :
- Should they have the same name as in C ? It doesn't really look like V convention
- Should they be in the `builtin` module ?
- Should `strlen` be a method of `byteptr` (it would be easier to make versions for `charptr` and maybe `voidptr`)


<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
