### PR TITLE
map: encapsulate key clone operation on voidptr

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -526,14 +526,14 @@ pub fn (mut m map) delete(key string) {
 // Returns all keys in the map.
 pub fn (m &map) keys() []string {
 	mut keys := []string{len: m.len}
-	mut j := 0
+	mut item := unsafe {byteptr(keys.data)}
 	if m.key_values.deletes == 0 {
 		for i := 0; i < m.key_values.len; i++ {
 			unsafe {
 				pkey := m.key_values.key(i)
-				m.key_values.clone_key(&keys[j], pkey)
+				m.key_values.clone_key(item, pkey)
+				item += m.key_bytes
 			}
-			j++
 		}
 		return keys
 	}
@@ -543,9 +543,9 @@ pub fn (m &map) keys() []string {
 		}
 		unsafe {
 			pkey := m.key_values.key(i)
-			m.key_values.clone_key(&keys[j], pkey)
+			m.key_values.clone_key(item, pkey)
+			item += m.key_bytes
 		}
-		j++
 	}
 	return keys
 }

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -140,7 +140,7 @@ fn (d &DenseArray) has_index(i int) bool {
 }
 
 [inline]
-fn (mut d DenseArray) clone_key(dest voidptr, pkey voidptr) {
+fn (d &DenseArray) clone_key(dest voidptr, pkey voidptr) {
 	unsafe {
 		s := (*&string(pkey)).clone()
 		C.memcpy(dest, &s, d.key_bytes)
@@ -529,8 +529,10 @@ pub fn (m &map) keys() []string {
 	mut j := 0
 	if m.key_values.deletes == 0 {
 		for i := 0; i < m.key_values.len; i++ {
-			pkey := unsafe {&string(m.key_values.key(i))}
-			keys[j] = pkey.clone()
+			unsafe {
+				pkey := m.key_values.key(i)
+				m.key_values.clone_key(&keys[j], pkey)
+			}
 			j++
 		}
 		return keys
@@ -539,8 +541,10 @@ pub fn (m &map) keys() []string {
 		if !m.key_values.has_index(i) {
 			continue
 		}
-		pkey := unsafe {&string(m.key_values.key(i))}
-		keys[j] = pkey.clone()
+		unsafe {
+			pkey := m.key_values.key(i)
+			m.key_values.clone_key(&keys[j], pkey)
+		}
 		j++
 	}
 	return keys

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -324,18 +324,18 @@ fn (mut m map) ensure_extra_metas(probe_count u32) {
 // Insert new element to the map. The element is inserted if its key is
 // not equivalent to the key of any other element already in the container.
 // If the key already exists, its value is changed to the value of the new element.
-fn (mut m map) set(k string, value voidptr) {
+fn (mut m map) set(key string, value voidptr) {
 	load_factor := f32(m.len << 1) / f32(m.cap)
 	if load_factor > max_load_factor {
 		m.expand()
 	}
-	mut index, mut meta := m.key_to_index(&k)
+	mut index, mut meta := m.key_to_index(&key)
 	index, meta = m.meta_less(index, meta)
 	// While we might have a match
 	for meta == unsafe {m.metas[index]} {
 		kv_index := int(unsafe {m.metas[index + 1]})
 		pkey := unsafe {m.key_values.key(kv_index)}
-		if m.keys_eq(&k, pkey) {
+		if m.keys_eq(&key, pkey) {
 			unsafe {
 				pval := byteptr(pkey) + m.key_bytes
 				C.memcpy(pval, value, m.value_bytes)
@@ -345,7 +345,7 @@ fn (mut m map) set(k string, value voidptr) {
 		index += 2
 		meta += probe_inc
 	}
-	kv_index := m.key_values.push(&k, value)
+	kv_index := m.key_values.push(&key, value)
 	m.meta_greater(index, meta, u32(kv_index))
 	m.len++
 }

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -547,7 +547,7 @@ pub fn (m &map) keys() []string {
 }
 
 [unsafe]
-pub fn (d DenseArray) clone() DenseArray {
+pub fn (d &DenseArray) clone() DenseArray {
 	res := DenseArray{
 		key_bytes: d.key_bytes
 		value_bytes: d.value_bytes


### PR DESCRIPTION
Follows on from #7320.

Add DenseArray.clone_key method taking voidptrs.
Make DenseArray.push do the clone (instead of map.set) to avoid extra memcpy call.
Don't clone key passed to map.set if it already exists in the map.

*Update*: Make map.keys also use clone_key.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
