### PR TITLE
cgen: fix map['xxx']() error

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3762,14 +3762,14 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 					if needs_clone {
 						g.write('/*2*/string_clone(')
 					}
-					if is_direct_array_access {
-						g.write('(($array_ptr_type_str)')
-					} else if g.is_fn_index_call {
+					if g.is_fn_index_call {
 						if elem_typ.info is table.FnType {
 							g.write('((')
 							g.write_fn_ptr_decl(&elem_typ.info, '')
 							g.write(')(*($array_ptr_type_str)/*ee elem_typ */array_get(')
 						}
+					} else if is_direct_array_access {
+						g.write('(($array_ptr_type_str)')
 					} else {
 						g.write('(*($array_ptr_type_str)/*ee elem_typ */array_get(')
 						if left_is_ptr && !node.left_type.has_flag(.shared_f) {
@@ -3854,7 +3854,13 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 					g.write(', &($elem_type_str[]){ $zero }))')
 				} else {
 					zero := g.type_default(info.value_type)
-					if elem_typ.kind == .function {
+					if g.is_fn_index_call {
+						if elem_typ.info is table.FnType {
+							g.write('((')
+							g.write_fn_ptr_decl(&elem_typ.info, '')
+							g.write(')(*(voidptr*)map_get(')
+						}
+					} else if elem_typ.kind == .function {
 						g.write('(*(voidptr*)map_get(')
 					} else {
 						g.write('(*($elem_type_str*)map_get(')
@@ -3872,7 +3878,9 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 					}
 					g.write(', ')
 					g.expr(node.index)
-					if elem_typ.kind == .function {
+					if g.is_fn_index_call {
+						g.write(', &(voidptr[]){ $zero })))')
+					} else if elem_typ.kind == .function {
 						g.write(', &(voidptr[]){ $zero }))')
 					} else {
 						g.write(', &($elem_type_str[]){ $zero }))')

--- a/vlib/v/tests/fn_index_direct_call_test.v
+++ b/vlib/v/tests/fn_index_direct_call_test.v
@@ -13,5 +13,17 @@ fn test_fn_array_direct_call() {
         return false
     }
 
+    println(fs.array_of_fn[0](1, &Placeholder{name: 'Bob'}, 'Builder'))
     assert fs.array_of_fn[0](1, &Placeholder{name: 'Bob'}, 'Builder') == false
+}
+
+fn test_fn_map_direct_call() {
+	a := {
+		'aaa': fn()string {return 'aaa'},
+		'bbb': fn()string {return 'bbb'},
+	}
+	println(a['aaa']())
+    println(a['bbb']())
+    assert a['aaa']() == 'aaa'
+    assert a['bbb']() == 'bbb'
 }


### PR DESCRIPTION
This PR fixes map['xxx']() error.

- Fixes map['xxx']() error.
- Add test `test_fn_map_direct_call()`.

```v
fn test_fn_map_direct_call() {
	a := {
		'aaa': fn()string {return 'aaa'},
		'bbb': fn()string {return 'bbb'},
	}
	println(a['aaa']())
        println(a['bbb']())
        assert a['aaa']() == 'aaa'
        assert a['bbb']() == 'bbb'
}
```