### PR TITLE
cgen: add list of modules with C includes to not cache, bundle with m…

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -7,6 +7,7 @@ import os
 import time
 import v.cflag
 import v.pref
+import v.util
 import term
 
 const (
@@ -373,6 +374,9 @@ fn (mut v Builder) cc() {
 				for imp_stmt in ast_file.imports {
 					imp := imp_stmt.mod
 					if imp in built_modules {
+						continue
+					}
+					if util.should_bundle_module(imp) {
 						continue
 					}
 					// not working

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -922,13 +922,16 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 			// g.tmp_count = 0 TODO
 			mut skip := false
 			pos := g.out.buf.len
+			should_bundle_module := util.should_bundle_module(node.mod)
 			if g.pref.build_mode == .build_module {
 				// if node.name.contains('parse_text') {
 				// println('!!! $node.name mod=$node.mod, built=$g.module_built')
 				// }
 				// TODO true for not just "builtin"
 				mod := if g.is_builtin_mod { 'builtin' } else { node.name.all_before_last('.') }
-				if mod != g.module_built && node.mod != g.module_built.after('/') {
+				if (mod != g.module_built &&
+					node.mod != g.module_built.after('/')) ||
+					should_bundle_module {
 					// Skip functions that don't have to be generated for this module.
 					// println('skip bm $node.name mod=$node.mod module_built=$g.module_built')
 					skip = true
@@ -943,7 +946,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 			if g.pref.use_cache {
 				// We are using prebuilt modules, we do not need to generate
 				// their functions in main.c.
-				if node.mod != 'main' && node.mod != 'help' {
+				if node.mod != 'main' && node.mod != 'help' && !should_bundle_module {
 					skip = true
 				}
 			}

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -15,6 +15,7 @@ pub const (
 // math.bits is needed by strconv.ftoa
 pub const (
 	builtin_module_parts = ['math.bits', 'strconv', 'strconv.ftoa', 'hash', 'strings', 'builtin']
+	bundle_modules       = ['sokol', 'gx', 'gg', 'fontstash']
 )
 
 pub const (
@@ -407,4 +408,8 @@ pub fn recompile_file(vexe string, file string) {
 		eprintln('could not recompile $file')
 		exit(2)
 	}
+}
+
+pub fn should_bundle_module(mod string) bool {
+	return mod in bundle_modules || (mod.contains('.') && mod.all_before('.') in bundle_modules)
 }


### PR DESCRIPTION
A simple way to specify which modules should be bundled with the main program rather than being built as cached modules.
This is useful for modules which include C headers.