### PR TITLE
gen: fix errors of fn_str() in struct/array/map

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -5646,7 +5646,8 @@ fn (g &Gen) type_to_fmt(typ table.Type) string {
 	sym := g.table.get_type_symbol(typ)
 	if typ.is_ptr() && (typ.is_int() || typ.is_float()) {
 		return '%.*s\\000'
-	} else if sym.kind in [.struct_, .array, .array_fixed, .map, .bool, .enum_, .sum_type] {
+	} else if sym.kind in
+		[.struct_, .array, .array_fixed, .map, .bool, .enum_, .sum_type, .function] {
 		return '%.*s\\000'
 	} else if sym.kind == .string {
 		return "\'%.*s\\000\'"

--- a/vlib/v/gen/str.v
+++ b/vlib/v/gen/str.v
@@ -177,7 +177,10 @@ fn (mut g Gen) string_inter_literal_sb_optimized(call_expr ast.CallExpr) {
 		typ := node.expr_types[i]
 		g.write(g.typ(typ))
 		g.write('_str(')
-		g.expr(node.exprs[i])
+		sym := g.table.get_type_symbol(typ)
+		if sym.kind != .function {
+			g.expr(node.exprs[i])
+		}
 		g.writeln('));')
 	}
 	g.writeln('')
@@ -366,7 +369,9 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype table.Type) {
 	} else {
 		str_fn_name := g.gen_str_for_type(typ)
 		g.write('${str_fn_name}(')
-		g.expr(expr)
+		if sym.kind != .function {
+			g.expr(expr)
+		}
 		g.write(')')
 	}
 }

--- a/vlib/v/tests/string_interpolation_function_test.v
+++ b/vlib/v/tests/string_interpolation_function_test.v
@@ -10,3 +10,30 @@ fn test_function_interpolation() {
 	println(show)
 	assert '$show' == 'fn (string) string'
 }
+
+struct Info {
+	aa fn()string
+	bb int
+}
+
+fn test_function_interpolation_in_struct() {
+	a := Info{
+		aa: fn()string {return 'aaa'}
+		bb: 22
+	}
+	println(a)
+	assert '$a'.contains(': fn () string')
+}
+
+fn test_function_interpolation_in_array() {
+	f := [fn()string{return 'aaa'}, fn()string{return 'bbb'}]
+	println(f)
+	assert '$f' == '[fn () string, fn () string]'
+}
+
+fn test_function_interpolation_in_map() {
+	m := {'aaa': fn()string{return 'aaa'}, 'bbb': fn()string{return 'bbb'}}
+	println(m)
+	assert '$m'.contains(': fn () string')
+}
+


### PR DESCRIPTION
This PR fixes errors of fn_str() in struct/array/map.

- Fixes errors of fn_str() in struct/array/map.
- Add tests.

```v
struct Info {
	aa fn()string
	bb int
}

fn test_function_interpolation_in_struct() {
	a := Info{
		aa: fn()string {return 'aaa'}
		bb: 22
	}
	println(a)
	assert '$a'.contains(': fn () string')
}

fn test_function_interpolation_in_array() {
	f := [fn()string{return 'aaa'}, fn()string{return 'bbb'}]
	println(f)
	assert '$f' == '[fn () string, fn () string]'
}

fn test_function_interpolation_in_map() {
	m := {'aaa': fn()string{return 'aaa'}, 'bbb': fn()string{return 'bbb'}}
	println(m)
	assert '$m'.contains(': fn () string')
}
```

```v
module main

struct Info {
	aa fn()string
	bb int
}

fn main() {
	a := Info{
		aa: fn()string {return 'aaa'}
		bb: 22
	}
	println(a)
	assert '$a'.contains(': fn () string')
}

PS D:\Test\v\tt1> v run .
Info{
    aa: fn () string
    bb: 22
}
```