### PR TITLE
checker: fix fn_array types check (fix #7372)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -74,10 +74,12 @@ pub fn (mut c Checker) check_basic(got table.Type, expected table.Type) bool {
 		(exp_type_sym.is_int() && got_type_sym.kind == .enum_) {
 		return true
 	}
-	// TODO
-	// if got_type_sym.kind == .array && exp_type_sym.kind == .array {
-	// return true
-	// }
+	// array fn
+	if got_type_sym.kind == .array && exp_type_sym.kind == .array {
+		if c.table.type_to_str(got) == c.table.type_to_str(expected) {
+			return true
+		}
+	}
 	if got_type_sym.kind == .array_fixed && exp_type_sym.kind == .byteptr {
 		info := got_type_sym.info as table.ArrayFixed
 		if info.elem_type.idx() == table.byte_type_idx {

--- a/vlib/v/tests/struct_test.v
+++ b/vlib/v/tests/struct_test.v
@@ -252,10 +252,10 @@ fn test_struct_literal_args() {
 	foo_config(10, {})
 	foo_config(10, n: 40)
 	foo_config(40, n: 30, def: 40)
-	
+
 	bar_config({}, 10)
 	bar_config({def:4}, 4)
-	
+
 	foo_user({
 		name: 'Peter'
 	})
@@ -349,3 +349,20 @@ fn test_fields_anon_fn_with_optional_void_return_type() {
 	}
 }
 
+struct Commands {
+    show []fn() string
+}
+
+fn a() string {
+    return 'HELLOW'
+}
+
+fn b() string {
+    return 'WOLLEH'
+}
+
+fn test_fields_array_of_fn() {
+    commands := Commands{show: [a, b]}
+    println(commands.show)
+	assert '$commands.show' == '[fn () string, fn () string]'
+}


### PR DESCRIPTION
This PR fixes fn_array types check (fix #7372).

- Fixes fn_array types check.
- Add test in `struct_test.v`.

```v
module main

struct Commands {
    show []fn() string
}

fn a() string {
    return 'HELLOW'
}

fn b() string {
    return 'WOLLEH'
}

fn main() {
    commands := Commands{show: [a, b]}
    println(commands.show)
}

PS D:\Test\v\tt1> v run .
[fn () string, fn () string]
```