### PR TITLE
map: Add voidptr key methods

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -329,6 +329,7 @@ fn (mut m map) ensure_extra_metas(probe_count u32) {
 fn (mut m map) set(key string, value voidptr) {
 	m.set_1(&key, value)
 }
+
 // Insert new element to the map. The element is inserted if its key is
 // not equivalent to the key of any other element already in the container.
 // If the key already exists, its value is changed to the value of the new element.
@@ -422,6 +423,7 @@ fn (mut m map) cached_rehash(old_cap u32) {
 fn (mut m map) get_and_set(key string, zero voidptr) voidptr {
 	return m.get_and_set_1(&key, zero)
 }
+
 // This method is used for assignment operators. If the argument-key
 // does not exist in the map, it's added to the map along with the zero/default value.
 // If the key exists, its respective value is returned.
@@ -452,6 +454,7 @@ fn (mut m map) get_and_set_1(key voidptr, zero voidptr) voidptr {
 fn (m map) get(key string, zero voidptr) voidptr {
 	return m.get_1(&key, zero)
 }
+
 // If `key` matches the key of an element in the container,
 // the method returns a reference to its mapped value.
 // If not, a zero/default value is returned.
@@ -477,6 +480,7 @@ fn (m map) get_1(key voidptr, zero voidptr) voidptr {
 fn (m map) exists(key string) bool {
 	return m.exists_1(&key)
 }
+
 // Checks whether a particular key exists in the map.
 fn (m map) exists_1(key voidptr) bool {
 	mut index, mut meta := m.key_to_index(key)
@@ -500,6 +504,7 @@ fn (m map) exists_1(key voidptr) bool {
 pub fn (mut m map) delete(key string) {
 	m.delete_1(&key)
 }
+
 // Removes the mapping of a particular key from the map.
 pub fn (mut m map) delete_1(key voidptr) {
 	mut index, mut meta := m.key_to_index(key)

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -543,9 +543,26 @@ pub fn (mut m map) delete_1(key voidptr) {
 	}
 }
 
-// Returns all keys in the map.
+// bootstrap
 pub fn (m &map) keys() []string {
 	mut keys := []string{len: m.len}
+	mut item := unsafe {byteptr(keys.data)}
+	for i := 0; i < m.key_values.len; i++ {
+		if !m.key_values.has_index(i) {
+			continue
+		}
+		unsafe {
+			pkey := m.key_values.key(i)
+			m.key_values.clone_key(item, pkey)
+			item += m.key_bytes
+		}
+	}
+	return keys
+}
+
+// Returns all keys in the map.
+pub fn (m &map) keys_1() array {
+	mut keys := __new_array(m.len, 0, m.key_bytes)
 	mut item := unsafe {byteptr(keys.data)}
 	if m.key_values.deletes == 0 {
 		for i := 0; i < m.key_values.len; i++ {

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -325,21 +325,25 @@ fn (mut m map) ensure_extra_metas(probe_count u32) {
 	}
 }
 
+// bootstrap
+fn (mut m map) set(key string, value voidptr) {
+	m.set_1(&key, value)
+}
 // Insert new element to the map. The element is inserted if its key is
 // not equivalent to the key of any other element already in the container.
 // If the key already exists, its value is changed to the value of the new element.
-fn (mut m map) set(key string, value voidptr) {
+fn (mut m map) set_1(key voidptr, value voidptr) {
 	load_factor := f32(m.len << 1) / f32(m.cap)
 	if load_factor > max_load_factor {
 		m.expand()
 	}
-	mut index, mut meta := m.key_to_index(&key)
+	mut index, mut meta := m.key_to_index(key)
 	index, meta = m.meta_less(index, meta)
 	// While we might have a match
 	for meta == unsafe {m.metas[index]} {
 		kv_index := int(unsafe {m.metas[index + 1]})
 		pkey := unsafe {m.key_values.key(kv_index)}
-		if m.keys_eq(&key, pkey) {
+		if m.keys_eq(key, pkey) {
 			unsafe {
 				pval := byteptr(pkey) + m.key_bytes
 				C.memcpy(pval, value, m.value_bytes)
@@ -349,7 +353,7 @@ fn (mut m map) set(key string, value voidptr) {
 		index += 2
 		meta += probe_inc
 	}
-	kv_index := m.key_values.push(&key, value)
+	kv_index := m.key_values.push(key, value)
 	m.meta_greater(index, meta, u32(kv_index))
 	m.len++
 }

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -449,16 +449,19 @@ fn (mut m map) get_and_set_1(key voidptr, zero voidptr) voidptr {
 	return voidptr(0)
 }
 
+fn (m map) get(key string, zero voidptr) voidptr {
+	return m.get_1(&key, zero)
+}
 // If `key` matches the key of an element in the container,
 // the method returns a reference to its mapped value.
 // If not, a zero/default value is returned.
-fn (m map) get(key string, zero voidptr) voidptr {
-	mut index, mut meta := m.key_to_index(&key)
+fn (m map) get_1(key voidptr, zero voidptr) voidptr {
+	mut index, mut meta := m.key_to_index(key)
 	for {
 		if meta == unsafe {m.metas[index]} {
 			kv_index := int(unsafe {m.metas[index + 1]})
 			pkey := unsafe {m.key_values.key(kv_index)}
-			if m.keys_eq(&key, pkey) {
+			if m.keys_eq(key, pkey) {
 				return unsafe {byteptr(pkey) + m.key_values.key_bytes}
 			}
 		}

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -419,17 +419,20 @@ fn (mut m map) cached_rehash(old_cap u32) {
 	unsafe {free(old_metas)}
 }
 
+fn (mut m map) get_and_set(key string, zero voidptr) voidptr {
+	return m.get_and_set_1(&key, zero)
+}
 // This method is used for assignment operators. If the argument-key
 // does not exist in the map, it's added to the map along with the zero/default value.
 // If the key exists, its respective value is returned.
-fn (mut m map) get_and_set(key string, zero voidptr) voidptr {
+fn (mut m map) get_and_set_1(key voidptr, zero voidptr) voidptr {
 	for {
-		mut index, mut meta := m.key_to_index(&key)
+		mut index, mut meta := m.key_to_index(key)
 		for {
 			if meta == unsafe {m.metas[index]} {
 				kv_index := int(unsafe {m.metas[index + 1]})
 				pkey := unsafe {m.key_values.key(kv_index)}
-				if m.keys_eq(&key, pkey) {
+				if m.keys_eq(key, pkey) {
 					return unsafe {byteptr(pkey) + m.key_values.key_bytes}
 				}
 			}
@@ -440,7 +443,7 @@ fn (mut m map) get_and_set(key string, zero voidptr) voidptr {
 			}
 		}
 		// Key not found, insert key with zero-value
-		m.set(key, zero)
+		m.set_1(key, zero)
 	}
 	assert false
 	return voidptr(0)

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -501,14 +501,14 @@ pub fn (mut m map) delete(key string) {
 	m.delete_1(&key)
 }
 // Removes the mapping of a particular key from the map.
-pub fn (mut m map) delete(key string) {
-	mut index, mut meta := m.key_to_index(&key)
+pub fn (mut m map) delete_1(key voidptr) {
+	mut index, mut meta := m.key_to_index(key)
 	index, meta = m.meta_less(index, meta)
 	// Perform backwards shifting
 	for meta == unsafe {m.metas[index]} {
 		kv_index := int(unsafe {m.metas[index + 1]})
 		pkey := unsafe {m.key_values.key(kv_index)}
-		if m.keys_eq(&key, pkey) {
+		if m.keys_eq(key, pkey) {
 			for (unsafe {m.metas[index + 2]} >> hashbits) > 1 {
 				unsafe {
 					m.metas[index] = m.metas[index + 2] - probe_inc

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -474,14 +474,17 @@ fn (m map) get_1(key voidptr, zero voidptr) voidptr {
 	return zero
 }
 
-// Checks whether a particular key exists in the map.
 fn (m map) exists(key string) bool {
-	mut index, mut meta := m.key_to_index(&key)
+	return m.exists_1(&key)
+}
+// Checks whether a particular key exists in the map.
+fn (m map) exists_1(key voidptr) bool {
+	mut index, mut meta := m.key_to_index(key)
 	for {
 		if meta == unsafe {m.metas[index]} {
 			kv_index := int(unsafe {m.metas[index + 1]})
 			pkey := unsafe {m.key_values.key(kv_index)}
-			if m.keys_eq(&key, pkey) {
+			if m.keys_eq(key, pkey) {
 				return true
 			}
 		}


### PR DESCRIPTION
Part of #6991.

Add methods taking a voidptr for the map key type for all existing methods with a key parameter.

Also encapsulate string key.free with function taking voidptr. (Follows on from #7327). This was the last structural change needed to make the above methods not use the `string` type directly.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
