### PR TITLE
cgen: fix errors of multi_array prepend/insert (fix #7375)

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1181,3 +1181,23 @@ fn test_voidptr_vbytes() {
 		println(bytes)
 	}
 }
+
+fn test_multi_array_prepend() {
+	mut a := [][]int{}
+	a.prepend([1, 2, 3])
+	assert a == [[1, 2, 3]]
+
+	mut b := [][]int{}
+	b.prepend([[1, 2, 3]])
+	assert b == [[1, 2, 3]]
+}
+
+fn test_multi_array_insert() {
+	mut a := [][]int{}
+	a.insert(0, [1, 2, 3])
+	assert a == [[1, 2, 3]]
+
+	mut b := [][]int{}
+	b.insert(0, [[1, 2, 3]])
+	assert b == [[1, 2, 3]]
+}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -5032,7 +5032,7 @@ fn (mut g Gen) gen_array_insert(node ast.CallExpr) {
 	left_info := left_sym.info as table.Array
 	elem_type_str := g.typ(left_info.elem_type)
 	arg2_sym := g.table.get_type_symbol(node.args[1].typ)
-	is_arg2_array := arg2_sym.kind == .array
+	is_arg2_array := arg2_sym.kind == .array && node.args[1].typ == node.left_type
 	if is_arg2_array {
 		g.write('array_insert_many(&')
 	} else {
@@ -5066,7 +5066,7 @@ fn (mut g Gen) gen_array_prepend(node ast.CallExpr) {
 	left_info := left_sym.info as table.Array
 	elem_type_str := g.typ(left_info.elem_type)
 	arg_sym := g.table.get_type_symbol(node.args[0].typ)
-	is_arg_array := arg_sym.kind == .array
+	is_arg_array := arg_sym.kind == .array && node.args[0].typ == node.left_type
 	if is_arg_array {
 		g.write('array_prepend_many(&')
 	} else {


### PR DESCRIPTION
This PR fixes errors of multi_array prepend/insert (fix #7375).

- Fixes errors of multi_array prepend/insert.
- Add tests in `array_test.v`.

```v
fn test_multi_array_prepend() {
	mut a := [][]int{}
	a.prepend([1, 2, 3])
	assert a == [[1, 2, 3]]

	mut b := [][]int{}
	b.prepend([[1, 2, 3]])
	assert b == [[1, 2, 3]]
}

fn test_multi_array_insert() {
	mut a := [][]int{}
	a.insert(0, [1, 2, 3])
	assert a == [[1, 2, 3]]

	mut b := [][]int{}
	b.insert(0, [[1, 2, 3]])
	assert b == [[1, 2, 3]]
}
```