### PR TITLE
gen: use voidptr key methods: map_get_1, map_set_1, map_get_and_set_1

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -458,7 +458,7 @@ fn (m map) get(key string, zero voidptr) voidptr {
 // If `key` matches the key of an element in the container,
 // the method returns a reference to its mapped value.
 // If not, a zero/default value is returned.
-fn (m map) get_1(key voidptr, zero voidptr) voidptr {
+fn (m &map) get_1(key voidptr, zero voidptr) voidptr {
 	mut index, mut meta := m.key_to_index(key)
 	for {
 		if meta == unsafe {m.metas[index]} {
@@ -482,7 +482,7 @@ fn (m map) exists(key string) bool {
 }
 
 // Checks whether a particular key exists in the map.
-fn (m map) exists_1(key voidptr) bool {
+fn (m &map) exists_1(key voidptr) bool {
 	mut index, mut meta := m.key_to_index(key)
 	for {
 		if meta == unsafe {m.metas[index]} {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1719,9 +1719,12 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 							g.write('$styp _var_$left.pos.pos = *($styp*)map_get_1(')
 						}
 						if !left.left_type.is_ptr() {
-							g.write('&')
+							g.write('ADDR(map, ')
+							g.expr(left.left)
+							g.write(')')
+						} else {
+							g.expr(left.left)
 						}
-						g.expr(left.left)
 						g.write(', &(string[]){')
 						g.expr(left.index)
 						g.write('}')
@@ -3896,9 +3899,12 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 						g.write('(*($elem_type_str*)map_get_1(')
 					}
 					if !left_is_ptr || node.left_type.has_flag(.shared_f) {
-						g.write('&')
+						g.write('ADDR(map, ')
+						g.expr(node.left)
+					} else {
+						g.write('(')
+						g.expr(node.left)
 					}
-					g.expr(node.left)
 					if node.left_type.has_flag(.shared_f) {
 						if left_is_ptr {
 							g.write('->val')
@@ -3906,7 +3912,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 							g.write('.val')
 						}
 					}
-					g.write(', &(string[]){')
+					g.write('), &(string[]){')
 					g.expr(node.index)
 					g.write('}')
 					if g.is_fn_index_call {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -4549,14 +4549,14 @@ fn (mut g Gen) gen_map_equality_fn(left table.Type) string {
 				g.definitions.write(', ')
 			}
 		}
-		g.definitions.writeln(') = (*(voidptr*)map_get(a, k, &(voidptr[]){ 0 }));')
+		g.definitions.writeln(') = (*(voidptr*)map_get_1(&a, &k, &(voidptr[]){ 0 }));')
 	} else {
-		g.definitions.writeln('\t\t$value_typ v = (*($value_typ*)map_get(a, k, &($value_typ[]){ 0 }));')
+		g.definitions.writeln('\t\t$value_typ v = (*($value_typ*)map_get_1(&a, &k, &($value_typ[]){ 0 }));')
 	}
 	match value_sym.kind {
-		.string { g.definitions.writeln('\t\tif (!map_exists(b, k) || string_ne((*($value_typ*)map_get(b, k, &($value_typ[]){_SLIT("")})), v)) {') }
-		.function { g.definitions.writeln('\t\tif (!map_exists(b, k) || (*(voidptr*)map_get(b, k, &(voidptr[]){ 0 })) != v) {') }
-		else { g.definitions.writeln('\t\tif (!map_exists(b, k) || (*($value_typ*)map_get(b, k, &($value_typ[]){ 0 })) != v) {') }
+		.string { g.definitions.writeln('\t\tif (!map_exists(b, k) || string_ne((*(string*)map_get_1(&b, &k, &(string[]){_SLIT("")})), v)) {') }
+		.function { g.definitions.writeln('\t\tif (!map_exists(b, k) || (*(voidptr*)map_get_1(&b, &k, &(voidptr[]){ 0 })) != v) {') }
+		else { g.definitions.writeln('\t\tif (!map_exists(b, k) || (*($value_typ*)map_get_1(&b, &k, &($value_typ[]){ 0 })) != v) {') }
 	}
 	g.definitions.writeln('\t\t\treturn false;')
 	g.definitions.writeln('\t\t}')

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3895,7 +3895,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 					} else {
 						g.write('(*($elem_type_str*)map_get_1(')
 					}
-					if !node.left_type.is_ptr() && !node.left_type.has_flag(.shared_f) {
+					if !left_is_ptr || node.left_type.has_flag(.shared_f) {
 						g.write('&')
 					}
 					g.expr(node.left)

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -269,6 +269,8 @@ static void* g_live_info = NULL;
 //#define tos4(s, slen) ((string){.str=(s), .len=(slen)})
 // `"" s` is used to enforce a string literal argument
 #define _SLIT(s) ((string){.str=(byteptr)("" s), .len=(sizeof(s)-1), .is_lit=1})
+// take the address of an rvalue
+#define ADDR(type, expr) (&((type[]){expr}[0]))
 #define _PUSH_MANY(arr, val, tmp, tmp_typ) {tmp_typ tmp = (val); array_push_many(arr, tmp.data, tmp.len);}
 #define _IN(typ, val, arr) array_##typ##_contains(arr, val)
 #define _IN_MAP(val, m) map_exists(m, val)

--- a/vlib/v/gen/json.v
+++ b/vlib/v/gen/json.v
@@ -263,7 +263,8 @@ fn (mut g Gen) decode_map(key_type table.Type, value_type table.Type) string {
 	cJSON_ArrayForEach(jsval, root)
 	{
 		$s
-		map_set(&res, tos2( (byteptr) jsval->string ) , &val );
+		string key = tos2( (byteptr) jsval->string );
+		map_set_1(&res, &key, &val);
 	}
 '
 }
@@ -286,7 +287,7 @@ fn (mut g Gen) encode_map(key_type table.Type, value_type table.Type) string {
 	array_$styp $keys_tmp = map_keys(&val);
 	for (int i = 0; i < ${keys_tmp}.len; ++i) {
 		$key
-		cJSON_AddItemToObject(o, (char*) key.str, $fn_name_v ( *($styp_v*) map_get(val, key, &($styp_v[]) { $zero } ) ) );
+		cJSON_AddItemToObject(o, (char*) key.str, $fn_name_v ( *($styp_v*) map_get_1(&val, &key, &($styp_v[]) { $zero } ) ) );
 	}
 	array_free(&$keys_tmp);
 '

--- a/vlib/v/tests/maps_equal_test.v
+++ b/vlib/v/tests/maps_equal_test.v
@@ -1,0 +1,9 @@
+fn test_string_int() {
+	mut m := {'hi':4}
+	m2:= {'hi':5}
+	assert m != m2
+	m['hi']++
+	assert m == m2
+	m.delete('hi')
+	assert m != m2
+}


### PR DESCRIPTION
Part of #6991. 

Use 3 of the voidptr key map methods added in #7377 in cgen and gen/json.v.
Add a test for map equality.

Use a pointer receiver for map methods `get_1` and `exists_1` for efficiency. 

~~This change **breaks** a case in a test where indexing a map rvalue (e.g. result of a function producing a map) did work, but in several other cases this **did not** work anyway. I tried to keep support for that case but it seems too awkward to do in this pull.~~
*Update*: I've fixed that case.

Also add a cgen macro ADDR to take the address of an rvalue. This helps keep code readable and makes it easy to support rvalue references without having to remember the C99 trick.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
