### PR TITLE
cgen: fix default zero not properly initialized (fix #7328)

### DIFF
--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -440,3 +440,16 @@ fn test_map_clone() {
 	assert nums2['foo'] == 2
 	assert nums2['bar'] == 8
 }
+
+struct MValue {
+    name string
+    misc map[string]string
+}
+
+fn test_map_default_zero() {
+    m := map[string]MValue{}
+    v := m['unknown']
+    x := v.misc['x']
+    println(x)
+	assert x == ''
+}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -5405,23 +5405,24 @@ fn (mut g Gen) type_default(typ_ table.Type) string {
 	// User struct defined in another module.
 	// if typ.contains('__') {
 	if sym.kind == .struct_ {
-		type_name := g.typ(typ)
-		mut def_val := '($type_name){'
-		info := sym.info as table.Struct
 		mut has_array_map := false
+		mut zero_str := '{'
+		info := sym.info as table.Struct
 		for field in info.fields {
 			field_sym := g.table.get_type_symbol(field.typ)
 			if field_sym.kind in [.array, .map] {
-				def_val += '.$field.name=${g.type_default(field.typ)},'
+				zero_str += '.$field.name=${g.type_default(field.typ)},'
 				has_array_map = true
 			}
 		}
 		if has_array_map {
-			def_val += '}'
+			zero_str += '}'
+			type_name := g.typ(typ)
+			zero_str = '($type_name)' + zero_str
 		} else {
-			def_val += '0}'
+			zero_str += '0}'
 		}
-		return def_val
+		return zero_str
 	}
 	// if typ.ends_with('Fn') { // TODO
 	// return '0'

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -5423,7 +5423,6 @@ fn (mut g Gen) type_default(typ_ table.Type) string {
 		}
 		return def_val
 	}
-
 	// if typ.ends_with('Fn') { // TODO
 	// return '0'
 	// }

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -5405,8 +5405,25 @@ fn (mut g Gen) type_default(typ_ table.Type) string {
 	// User struct defined in another module.
 	// if typ.contains('__') {
 	if sym.kind == .struct_ {
-		return '{0}'
+		type_name := g.typ(typ)
+		mut def_val := '($type_name){'
+		info := sym.info as table.Struct
+		mut has_array_map := false
+		for field in info.fields {
+			field_sym := g.table.get_type_symbol(field.typ)
+			if field_sym.kind in [.array, .map] {
+				def_val += '.$field.name=${g.type_default(field.typ)},'
+				has_array_map = true
+			}
+		}
+		if has_array_map {
+			def_val += '}'
+		} else {
+			def_val += '0}'
+		}
+		return def_val
 	}
+
 	// if typ.ends_with('Fn') { // TODO
 	// return '0'
 	// }


### PR DESCRIPTION
This PR fixes default zero not properly initialized (fix #7328).

- Fixes default zero not properly initialized.
- Add test in map_test.v.

```v
module main

struct MValue {
    name string
    misc map[string]string
}

fn main() {
    m := map[string]MValue{}
    v := m['unknown']
    x := v.misc['x']
    println(x)
    assert x == ''
}

PS D:\Test\v\tt1> v run .

```