### PR TITLE
parser: add information about the ending line for a few elements

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -382,7 +382,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		rec_mut: rec_mut
 		language: language
 		no_body: no_body
-		pos: start_pos.extend(end_pos)
+		pos: start_pos.extend(end_pos, end_pos.line_nr)
 		body_pos: body_start_pos
 		file: p.file_name
 		is_builtin: p.builtin_mod || p.mod in util.builtin_module_parts

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -382,7 +382,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		rec_mut: rec_mut
 		language: language
 		no_body: no_body
-		pos: start_pos.extend_with_last_line(end_pos, end_pos.line_nr)
+		pos: start_pos.extend_with_last_line(end_pos, p.prev_tok.line_nr)
 		body_pos: body_start_pos
 		file: p.file_name
 		is_builtin: p.builtin_mod || p.mod in util.builtin_module_parts

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -382,7 +382,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		rec_mut: rec_mut
 		language: language
 		no_body: no_body
-		pos: start_pos.extend(end_pos, end_pos.line_nr)
+		pos: start_pos.extend_with_last_line(end_pos, end_pos.line_nr)
 		body_pos: body_start_pos
 		file: p.file_name
 		is_builtin: p.builtin_mod || p.mod in util.builtin_module_parts

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -8,7 +8,7 @@ import v.table
 
 fn (mut p Parser) for_stmt() ast.Stmt {
 	p.check(.key_for)
-	pos := p.tok.position()
+	mut pos := p.tok.position()
 	p.open_scope()
 	p.inside_for = true
 	if p.tok.kind == .key_match {
@@ -20,6 +20,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 	if p.tok.kind == .lcbr {
 		p.inside_for = false
 		stmts := p.parse_block_no_scope(false)
+		pos.last_line = p.prev_tok.line_nr
 		for_stmt := ast.ForStmt{
 			stmts: stmts
 			pos: pos
@@ -63,6 +64,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		}
 		p.inside_for = false
 		stmts := p.parse_block_no_scope(false)
+		pos.last_line = p.prev_tok.line_nr
 		for_c_stmt := ast.ForCStmt{
 			stmts: stmts
 			has_init: has_init
@@ -151,6 +153,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		}
 		p.inside_for = false
 		stmts := p.parse_block_no_scope(false)
+		pos.last_line = p.prev_tok.line_nr
 		// println('nr stmts=$stmts.len')
 		for_in_stmt := ast.ForInStmt{
 			stmts: stmts

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -20,7 +20,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 	if p.tok.kind == .lcbr {
 		p.inside_for = false
 		stmts := p.parse_block_no_scope(false)
-		pos.last_line = p.prev_tok.line_nr
+		pos.last_line = p.prev_tok.line_nr - 1
 		for_stmt := ast.ForStmt{
 			stmts: stmts
 			pos: pos
@@ -64,7 +64,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		}
 		p.inside_for = false
 		stmts := p.parse_block_no_scope(false)
-		pos.last_line = p.prev_tok.line_nr
+		pos.last_line = p.prev_tok.line_nr - 1
 		for_c_stmt := ast.ForCStmt{
 			stmts: stmts
 			has_init: has_init
@@ -153,7 +153,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		}
 		p.inside_for = false
 		stmts := p.parse_block_no_scope(false)
-		pos.last_line = p.prev_tok.line_nr
+		pos.last_line = p.prev_tok.line_nr - 1
 		// println('nr stmts=$stmts.len')
 		for_in_stmt := ast.ForInStmt{
 			stmts: stmts
@@ -173,6 +173,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 	cond := p.expr(0)
 	p.inside_for = false
 	stmts := p.parse_block_no_scope(false)
+	pos.last_line = p.prev_tok.line_nr - 1
 	for_stmt := ast.ForStmt{
 		cond: cond
 		stmts: stmts

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -712,7 +712,7 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 			stmts := p.parse_block()
 			return ast.DeferStmt{
 				stmts: stmts
-				pos: spos.extend(p.tok.position(), p.tok.line_nr)
+				pos: spos.extend_with_last_line(p.tok.position(), p.tok.line_nr)
 			}
 		}
 		.key_go {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2007,7 +2007,7 @@ $pubfn (mut e  $enum_name) toggle(flag $enum_name)   { unsafe{ *e = int(*e) ^  (
 		is_flag: is_flag
 		is_multi_allowed: is_multi_allowed
 		fields: fields
-		pos: start_pos.extend_with_last_line(end_pos, end_pos.line_nr)
+		pos: start_pos.extend_with_last_line(end_pos, p.prev_tok.line_nr)
 		attrs: p.attrs
 		comments: enum_decl_comments
 	}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -600,8 +600,9 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 	p.is_stmt_ident = p.tok.kind == .name
 	match p.tok.kind {
 		.lcbr {
-			pos := p.tok.position()
+			mut pos := p.tok.position()
 			stmts := p.parse_block()
+			pos.last_line = p.prev_tok.line_nr
 			return ast.Block{
 				stmts: stmts
 				pos: pos
@@ -2232,7 +2233,7 @@ pub fn (mut p Parser) mark_var_as_used(varname string) bool {
 }
 
 fn (mut p Parser) unsafe_stmt() ast.Stmt {
-	pos := p.tok.position()
+	mut pos := p.tok.position()
 	p.next()
 	if p.tok.kind != .lcbr {
 		p.error_with_pos('please use `unsafe {`', p.tok.position())
@@ -2245,6 +2246,7 @@ fn (mut p Parser) unsafe_stmt() ast.Stmt {
 	}
 	if p.tok.kind == .rcbr {
 		// `unsafe {}`
+		pos.last_line = p.tok.line_nr
 		p.next()
 		return ast.Block{
 			is_unsafe: true
@@ -2281,6 +2283,7 @@ fn (mut p Parser) unsafe_stmt() ast.Stmt {
 	for p.tok.kind != .rcbr {
 		stmts << p.stmt(false)
 	}
+	pos.last_line = p.tok.line_nr
 	p.next()
 	return ast.Block{
 		stmts: stmts

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -712,7 +712,7 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 			stmts := p.parse_block()
 			return ast.DeferStmt{
 				stmts: stmts
-				pos: spos.extend_with_last_line(p.tok.position(), p.tok.line_nr)
+				pos: spos.extend_with_last_line(p.tok.position(), p.prev_tok.line_nr)
 			}
 		}
 		.key_go {
@@ -2246,7 +2246,7 @@ fn (mut p Parser) unsafe_stmt() ast.Stmt {
 	}
 	if p.tok.kind == .rcbr {
 		// `unsafe {}`
-		pos.last_line = p.tok.line_nr
+		pos.last_line = p.tok.line_nr - 1
 		p.next()
 		return ast.Block{
 			is_unsafe: true

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -712,7 +712,7 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 			stmts := p.parse_block()
 			return ast.DeferStmt{
 				stmts: stmts
-				pos: spos.extend(p.tok.position())
+				pos: spos.extend(p.tok.position(), p.tok.line_nr)
 			}
 		}
 		.key_go {
@@ -2007,7 +2007,7 @@ $pubfn (mut e  $enum_name) toggle(flag $enum_name)   { unsafe{ *e = int(*e) ^  (
 		is_flag: is_flag
 		is_multi_allowed: is_multi_allowed
 		fields: fields
-		pos: start_pos.extend(end_pos)
+		pos: start_pos.extend_with_last_line(end_pos, end_pos.line_nr)
 		attrs: p.attrs
 		comments: enum_decl_comments
 	}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -85,6 +85,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 	mut is_field_mut := false
 	mut is_field_pub := false
 	mut is_field_global := false
+	mut end_line := -1
 	mut end_comments := []ast.Comment{}
 	if !no_body {
 		p.check(.lcbr)
@@ -252,6 +253,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 			p.attrs = []
 		}
 		p.top_level_statement_end()
+		end_line = p.tok.line_nr
 		p.check(.rcbr)
 	}
 	if language == .c {
@@ -290,7 +292,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 		name: name
 		is_pub: is_pub
 		fields: ast_fields
-		pos: start_pos.extend(name_pos)
+		pos: start_pos.extend2(name_pos, end_line)
 		mut_pos: mut_pos
 		pub_pos: pub_pos
 		pub_mut_pos: pub_mut_pos

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -85,7 +85,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 	mut is_field_mut := false
 	mut is_field_pub := false
 	mut is_field_global := false
-	mut end_line := -1
+	mut last_line := -1
 	mut end_comments := []ast.Comment{}
 	if !no_body {
 		p.check(.lcbr)
@@ -253,7 +253,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 			p.attrs = []
 		}
 		p.top_level_statement_end()
-		end_line = p.tok.line_nr
+		last_line = p.tok.line_nr
 		p.check(.rcbr)
 	}
 	if language == .c {
@@ -292,7 +292,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 		name: name
 		is_pub: is_pub
 		fields: ast_fields
-		pos: start_pos.extend2(name_pos, end_line)
+		pos: start_pos.extend_with_last_line(name_pos, last_line)
 		mut_pos: mut_pos
 		pub_pos: pub_pos
 		pub_mut_pos: pub_mut_pos

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -458,12 +458,13 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		)
 	}
 	p.top_level_statement_end()
+	last_line := p.tok.line_nr
 	p.check(.rcbr)
 	return ast.InterfaceDecl{
 		name: interface_name
 		methods: methods
 		is_pub: is_pub
-		pos: start_pos
+		pos: start_pos.extend_with_last_line(token.Position{}, last_line)
 		pre_comments: pre_comments
 	}
 }

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -379,7 +379,7 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 
 fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 	p.top_level_statement_start()
-	start_pos := p.tok.position()
+	mut start_pos := p.tok.position()
 	is_pub := p.tok.kind == .key_pub
 	if is_pub {
 		p.next()
@@ -458,13 +458,13 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		)
 	}
 	p.top_level_statement_end()
-	last_line := p.tok.line_nr
 	p.check(.rcbr)
+	start_pos.last_line = p.prev_tok.line_nr
 	return ast.InterfaceDecl{
 		name: interface_name
 		methods: methods
 		is_pub: is_pub
-		pos: start_pos.extend_with_last_line(token.Position{}, last_line)
+		pos: start_pos
 		pre_comments: pre_comments
 	}
 }

--- a/vlib/v/token/position.v
+++ b/vlib/v/token/position.v
@@ -9,7 +9,7 @@ pub:
 	line_nr int // the line number in the source where the token occured
 	pos     int // the position of the token in scanner text
 pub mut:
-	last_line int // the line number where the ast object ends
+	last_line int // the line number where the ast object ends (used by vfmt)
 }
 
 pub fn (pos Position) str() string {

--- a/vlib/v/token/position.v
+++ b/vlib/v/token/position.v
@@ -7,17 +7,27 @@ pub struct Position {
 pub:
 	len     int // length of the literal in the source
 	line_nr int // the line number in the source where the token occured
+	last_line int // the line number where the ast object ends
 	pos     int // the position of the token in scanner text
 }
 
 pub fn (pos Position) str() string {
-	return 'Position{ line_nr: $pos.line_nr, pos: $pos.pos, len: $pos.len }'
+	return 'Position{ line_nr: $pos.line_nr, last_line: $pos.last_line, pos: $pos.pos, len: $pos.len }'
 }
 
 pub fn (pos Position) extend(end Position) Position {
 	return {
 		pos |
 		len: end.pos - pos.pos + end.len
+	}
+}
+
+pub fn (pos Position) extend2(end Position, last_line int) Position {
+	return {
+		len: end.pos - pos.pos + end.len
+		line_nr: pos.line_nr
+		last_line: last_line
+		pos: pos.pos
 	}
 }
 

--- a/vlib/v/token/position.v
+++ b/vlib/v/token/position.v
@@ -22,11 +22,11 @@ pub fn (pos Position) extend(end Position) Position {
 	}
 }
 
-pub fn (pos Position) extend2(end Position, last_line int) Position {
+pub fn (pos Position) extend_with_last_line(end Position, last_line int) Position {
 	return {
 		len: end.pos - pos.pos + end.len
 		line_nr: pos.line_nr
-		last_line: last_line
+		last_line: last_line - 1
 		pos: pos.pos
 	}
 }

--- a/vlib/v/token/position.v
+++ b/vlib/v/token/position.v
@@ -7,8 +7,9 @@ pub struct Position {
 pub:
 	len     int // length of the literal in the source
 	line_nr int // the line number in the source where the token occured
-	last_line int // the line number where the ast object ends
 	pos     int // the position of the token in scanner text
+pub mut:
+	last_line int // the line number where the ast object ends
 }
 
 pub fn (pos Position) str() string {


### PR DESCRIPTION
token.Position has a new field `last_line`.
It is currently only set for the AST nodes StructDecl, EnumDecl, InterfaceDecl, FnDecl, all for loops, DeferStmt and Block.

This allows a implementation of https://github.com/vlang/v/pull/7329 that respects the current code style and I can later make
https://github.com/vlang/v/issues/6684 work for multiline comments.