### PR TITLE
parser: hot fix to handle `x = <-ch[i] or { }`

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -38,6 +38,7 @@ mut:
 	inside_for        bool
 	inside_fn         bool
 	inside_str_interp bool
+	or_is_handled     bool // ignore `or` in this expression
 	builtin_mod       bool // are we in the `builtin` module?
 	mod               string // current module name
 	attrs             []table.Attr // attributes before next decl stmt
@@ -1327,7 +1328,7 @@ fn (mut p Parser) index_expr(left ast.Expr) ast.IndexExpr {
 	pos := start_pos.extend(p.tok.position())
 	p.check(.rsbr)
 	// a[i] or { ... }
-	if p.tok.kind == .key_orelse {
+	if p.tok.kind == .key_orelse && !p.or_is_handled {
 		was_inside_or_expr := p.inside_or_expr
 		mut or_pos := p.tok.position()
 		p.next()

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -371,6 +371,7 @@ fn (mut p Parser) prefix_expr() ast.PrefixExpr {
 		p.is_amp = true
 	}
 	if op == .arrow {
+		p.or_is_handled = true
 		p.register_auto_import('sync')
 	}
 	// if op == .mul && !p.inside_unsafe {
@@ -411,6 +412,7 @@ fn (mut p Parser) prefix_expr() ast.PrefixExpr {
 			p.next()
 			or_kind = .propagate
 		}
+		p.or_is_handled = false
 	}
 	return ast.PrefixExpr{
 		op: op


### PR DESCRIPTION
This is a (temporary?) hot fix to make the automatic checks work again. It handles `x = <-ch[i] or { }` in a way that the `or` branch is triggered when `ch[i]` is closed.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
