### PR TITLE
table: minor optimization of types.v

### DIFF
--- a/vlib/v/table/types.v
+++ b/vlib/v/table/types.v
@@ -431,7 +431,11 @@ pub enum Kind {
 }
 
 pub fn (t &TypeSymbol) str() string {
-	return t.name.replace('array_', '[]')
+	if t.kind in [.array, .array_fixed] {
+		return t.name.replace('array_', '[]')
+	} else {
+		return t.name
+	}
 }
 
 [inline]


### PR DESCRIPTION
This PR makes minor optimization of types.v.
```v
pub fn (t &TypeSymbol) str() string {
	return t.name.replace('array_', '[]')
}
```
to:
```v
pub fn (t &TypeSymbol) str() string {
	if t.kind in [.array, .array_fixed] {
		return t.name.replace('array_', '[]')
	} else {
		return t.name
	}
}
```
This avoids unnecessary character replacement operations.
