### PR TITLE
 map: add functions new_map and new_map_init_1

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -227,9 +227,13 @@ pub mut:
 	len             int
 }
 
+// bootstrap
 fn new_map_1(value_bytes int) map {
+	return new_map(int(sizeof(string)), value_bytes)
+}
+
+fn new_map(key_bytes int, value_bytes int) map {
 	metasize := int(sizeof(u32) * (init_capicity + extra_metas_inc))
-	key_bytes := int(sizeof(string))
 	return map{
 		key_bytes: key_bytes
 		value_bytes: value_bytes
@@ -244,9 +248,20 @@ fn new_map_1(value_bytes int) map {
 }
 
 fn new_map_init(n int, value_bytes int, keys &string, values voidptr) map {
-	mut out := new_map_1(value_bytes)
-	for i in 0 .. n {
-		unsafe {out.set(keys[i], byteptr(values) + i * value_bytes)}
+	return new_map_init_1(n, int(sizeof(string)), value_bytes, keys, values)
+}
+
+fn new_map_init_1(n int, key_bytes int, value_bytes int, keys voidptr, values voidptr) map {
+	mut out := new_map(key_bytes, value_bytes)
+	// TODO pre-allocate n slots
+	mut pkey := byteptr(keys)
+	mut pval := byteptr(values)
+	for _ in 0 .. n {
+		unsafe {
+			out.set_1(pkey, pval)
+			pkey += key_bytes
+			pval += value_bytes
+		}
 	}
 	return out
 }


### PR DESCRIPTION
Part of #6991. Add functions that take a `key_bytes` parameter.

~~Passing T for the key type is more flexible than having a `key_bytes` parameter that is passed sizeof(KeyType). E.g. we can test `T.name == 'string'` to see whether to clone a key. (This is easier to implement than making the whole `map` struct a generic type).~~

~~I also hope later to implement taking the address of a generic function, so we can support V's `==` operator for any types that support it. E.g. `m.key_eq_fn = &key_eq<T>`.~~

Generics are not allowed ATM in builtin.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
