### PR TITLE
time: Change typeof duration constants from i64 to Duration

### DIFF
--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -380,11 +380,11 @@ pub type Duration = i64
 
 pub const (
 	nanosecond  = Duration(1)
-	microsecond = Duration(1000) * nanosecond
-	millisecond = Duration(1000) * microsecond
-	second      = Duration(1000) * millisecond
-	minute      = Duration(60) * second
-	hour        = Duration(60) * minute
+	microsecond = Duration(1000 * nanosecond)
+	millisecond = Duration(1000 * microsecond)
+	second      = Duration(1000 * millisecond)
+	minute      = Duration(60 * second)
+	hour        = Duration(60 * minute)
 	infinite    = Duration(-1)
 )
 

--- a/vlib/time/time_nix.c.v
+++ b/vlib/time/time_nix.c.v
@@ -108,8 +108,8 @@ pub fn (d Duration) timespec() C.timespec {
 	d_nsec := d % second
 	ts.tv_sec += d_sec
 	ts.tv_nsec += d_nsec
-	if ts.tv_nsec > second {
-		ts.tv_nsec -= second
+	if ts.tv_nsec > i64(second) {
+		ts.tv_nsec -= i64(second)
 		ts.tv_sec++
 	}
 	return ts


### PR DESCRIPTION
typeof duration constants expect nanosecond and infinity are i64 for now. This PR changes them into time.Duration
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
