### PR TITLE
cgen: fix in multi_array exception (fix #7427)

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1176,8 +1176,8 @@ fn test_multi_array_insert() {
 }
 
 fn test_multi_array_in() {
-    a := [[1]]
-    println([1] in a)
+	a := [[1]]
+	println([1] in a)
 	assert [1] in a
 }
 
@@ -1187,11 +1187,9 @@ fn test_any_type_array_contains() {
 	assert true in a
 	assert a.contains(false)
 	assert false in a
-
 	b := [i64(2), 3, 4]
 	assert b.contains(i64(3))
 	assert 5 !in b
-
 	c := [[1], [2]]
 	assert c.contains([1])
 	assert [2] in c

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1174,3 +1174,26 @@ fn test_multi_array_insert() {
 	b.insert(0, [[1, 2, 3]])
 	assert b == [[1, 2, 3]]
 }
+
+fn test_multi_array_in() {
+    a := [[1]]
+    println([1] in a)
+	assert [1] in a
+}
+
+fn test_any_type_array_contains() {
+	a := [true, false]
+	assert a.contains(true)
+	assert true in a
+	assert a.contains(false)
+	assert false in a
+
+	b := [i64(2), 3, 4]
+	assert b.contains(i64(3))
+	assert 5 !in b
+
+	c := [[1], [2]]
+	assert c.contains([1])
+	assert [2] in c
+	assert [3] !in c
+}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1155,7 +1155,8 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 	// TODO: remove this for actual methods, use only for compiler magic
 	// FIXME: Argument count != 1 will break these
 	if left_type_sym.kind == .array &&
-		method_name in ['filter', 'clone', 'repeat', 'reverse', 'map', 'slice', 'sort'] {
+		method_name in
+		['filter', 'clone', 'repeat', 'reverse', 'map', 'slice', 'sort', 'contains'] {
 		mut elem_typ := table.void_type
 		is_filter_map := method_name in ['filter', 'map']
 		is_sort := method_name == 'sort'
@@ -1204,6 +1205,8 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 			// call_expr.return_type = call_expr.receiver_type
 		} else if method_name == 'sort' {
 			call_expr.return_type = table.void_type
+		} else if method_name == 'contains' {
+			call_expr.return_type = table.bool_type
 		}
 		return call_expr.return_type
 	} else if left_type_sym.kind == .map && method_name == 'clone' {

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -272,22 +272,7 @@ static void* g_live_info = NULL;
 // take the address of an rvalue
 #define ADDR(type, expr) (&((type[]){expr}[0]))
 #define _PUSH_MANY(arr, val, tmp, tmp_typ) {tmp_typ tmp = (val); array_push_many(arr, tmp.data, tmp.len);}
-#define _IN(typ, val, arr) array_##typ##_contains(arr, val)
 #define _IN_MAP(val, m) map_exists(m, val)
-
-// these macros have corresponding implementations in builtin/int.v with different signedness
-#define array_i8_contains(a, b) array_byte_contains(a, (byte)(b))
-#define array_i16_contains(a, b) array_u16_contains(a, (u16)(b))
-#define array_u32_contains(a, b) array_int_contains(a, (int)(b))
-#define array_i64_contains(a, b) array_u64_contains(a, (u64)(b))
-#define array_rune_contains(a, b) array_int_contains(a, (int)(b))
-#define array_f32_contains(a, b) array_int_contains(a, *(int*)&((f32[]){(b)}))
-#define array_f64_contains(a, b) array_u64_contains(a, *(u64*)&((f64[]){(b)}))
-#ifdef TARGET_IS_64BIT
-#define array_voidptr_contains(a, b) array_u64_contains(a, (u64)(b))
-#else
-#define array_voidptr_contains(a, b) array_int_contains(a, (int)(b))
-#endif
 
 // unsigned/signed comparisons
 static inline bool _us32_gt(uint32_t a, int32_t b) { return a > INT32_MAX || (int32_t)a > b; }

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -370,6 +370,10 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 				g.gen_array_prepend(node)
 				return
 			}
+			'contains' {
+				g.gen_array_contains(node)
+				return
+			}
 			else {}
 		}
 	}


### PR DESCRIPTION
This PR fixes in multi_array exception (fix #7427).

- Fixes in multi_array exception.
- Auto generate `xxx_contains` for any type array.
- Add tests in array_test.v.

```v
fn test_multi_array_in() {
        a := [[1]]
        println([1] in a)
	assert [1] in a
}

fn test_any_type_array_contains() {
	a := [true, false]
	assert a.contains(true)
	assert true in a
	assert a.contains(false)
	assert false in a

	b := [i64(2), 3, 4]
	assert b.contains(i64(3))
	assert 5 !in b

	c := [[1], [2]]
	assert c.contains([1])
	assert [2] in c
	assert [3] !in c
}
```