### PR TITLE
fmt: add a sapce after operator in overload function

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -3074,11 +3074,11 @@ fn (a Vec) str() string {
 	return '{$a.x, $a.y}'
 }
 
-fn (a Vec) +(b Vec) Vec {
+fn (a Vec) + (b Vec) Vec {
 	return Vec{a.x + b.x, a.y + b.y}
 }
 
-fn (a Vec) -(b Vec) Vec {
+fn (a Vec) - (b Vec) Vec {
 	return Vec{a.x - b.x, a.y - b.y}
 }
 

--- a/vlib/time/operator.v
+++ b/vlib/time/operator.v
@@ -47,7 +47,7 @@ pub fn (t1 Time) ge(t2 Time) bool {
 
 // Time subtract using eperator overloading
 [inline]
-pub fn (lhs Time) -(rhs Time) Duration {
+pub fn (lhs Time) - (rhs Time) Duration {
 	lhs_micro := lhs.unix * 1000 * 1000 + u64(lhs.microsecond)
 	rhs_micro := rhs.unix * 1000 * 1000 + u64(rhs.microsecond)
 	return (i64(lhs_micro) - i64(rhs_micro)) * microsecond

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -50,6 +50,9 @@ pub fn (node &FnDecl) stringify(t &table.Table, cur_mod string) string {
 		name = 'JS.$name'
 	}
 	f.write('fn $receiver$name')
+	if name in '+-*/%' {
+		f.write(' ')
+	}
 	if node.is_generic {
 		f.write('<T>')
 	}

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -50,7 +50,7 @@ pub fn (node &FnDecl) stringify(t &table.Table, cur_mod string) string {
 		name = 'JS.$name'
 	}
 	f.write('fn $receiver$name')
-	if /* name.len == 1 &&  */name in ['+', '-', '*', '/', '%'] {
+	if name in ['+', '-', '*', '/', '%'] {
 		f.write(' ')
 	}
 	if node.is_generic {

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -50,7 +50,7 @@ pub fn (node &FnDecl) stringify(t &table.Table, cur_mod string) string {
 		name = 'JS.$name'
 	}
 	f.write('fn $receiver$name')
-	if name in '+-*/%' {
+	if /* name.len == 1 &&  */name in ['+', '-', '*', '/', '%'] {
 		f.write(' ')
 	}
 	if node.is_generic {

--- a/vlib/v/checker/tests/modules/overload_return_type/point.v
+++ b/vlib/v/checker/tests/modules/overload_return_type/point.v
@@ -6,6 +6,6 @@ mut:
 	y int
 }
 
-pub fn (a Point) +(b Point) int {
+pub fn (a Point) + (b Point) int {
 	return a.x + b.x
 }

--- a/vlib/v/fmt/tests/operator_overload_keep.v
+++ b/vlib/v/fmt/tests/operator_overload_keep.v
@@ -1,0 +1,11 @@
+struct Foo {
+	x int
+}
+
+fn (a Foo) + (b Foo) Foo {
+	return Foo{a.x + b.x}
+}
+
+fn (a Foo) % (b Foo) Foo {
+	return Foo{a.x % b.x}
+}


### PR DESCRIPTION
`(a Foo) +(b Foo)` --> `(a Foo) + (b Foo)`