### PR TITLE
vup: hide some output when not in verbose mode

### DIFF
--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -36,9 +36,7 @@ fn main() {
 		app.backup('cmd/tools/vup.exe')
 	}
 	app.recompile_v()
-	os.exec('"$app.vexe" cmd/tools/vup.v') or {
-		panic(err)
-	}
+	os.exec('"$app.vexe" cmd/tools/vup.v') or { panic(err) }
 	app.show_current_v_version()
 }
 
@@ -66,9 +64,12 @@ fn (app App) recompile_v() {
 		println('> recompiling v itself with `$vself` ...')
 	}
 	if self_result := os.exec(vself) {
-		println(self_result.output.trim_space())
 		if self_result.exit_code == 0 {
+			println(self_result.output.trim_space())
 			return
+		} else if app.is_verbose {
+			println('`$vself` failed, running `$make`...')
+			println(self_result.output.trim_space())
 		}
 	}
 	app.make(vself)
@@ -79,11 +80,10 @@ fn (app App) make(vself string) {
 	$if windows {
 		make = 'make.bat'
 	}
-	println('`$vself` failed, running `$make`...')
-	make_result := os.exec(make) or {
-		panic(err)
+	make_result := os.exec(make) or { panic(err) }
+	if app.is_verbose {
+		println(make_result.output)
 	}
-	println(make_result.output)
 }
 
 fn (app App) show_current_v_version() {
@@ -111,9 +111,7 @@ fn (app App) backup(file string) {
 }
 
 fn (app App) git_command(command string) {
-	git_result := os.exec('git $command') or {
-		panic(err)
-	}
+	git_result := os.exec('git $command') or { panic(err) }
 	if git_result.exit_code != 0 {
 		if git_result.output.contains('Permission denied') {
 			eprintln('No access to `$app.vroot`: Permission denied')

--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -68,7 +68,7 @@ fn (app App) recompile_v() {
 			println(self_result.output.trim_space())
 			return
 		} else if app.is_verbose {
-			println('`$vself` failed, running `$make`...')
+			println('`$vself` failed, running `make`...')
 			println(self_result.output.trim_space())
 		}
 	}


### PR DESCRIPTION
the `'v self' failed, running 'make'...` message confused many people and made them think that `v up` didn't actually work.
This PR hides that message when not running in verbose mode.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
