### PR TITLE
checker: fix multi_array prepend/insert type mismatch check (fix #7484)

### DIFF
--- a/vlib/v/checker/tests/array_insert_type_mismatch.out
+++ b/vlib/v/checker/tests/array_insert_type_mismatch.out
@@ -1,0 +1,56 @@
+vlib/v/checker/tests/array_insert_type_mismatch.vv:3:14: error: cannot insert `any_float` to `[]int`
+    1 | fn main() {
+    2 |     mut a := [1, 2]
+    3 |     a.insert(1, 2.3)
+      |                 ~~~
+    4 |     a.insert(1, 'abc')
+    5 |     a.insert(1, [1.1, 2.2])
+vlib/v/checker/tests/array_insert_type_mismatch.vv:4:14: error: cannot insert `string` to `[]int`
+    2 |     mut a := [1, 2]
+    3 |     a.insert(1, 2.3)
+    4 |     a.insert(1, 'abc')
+      |                 ~~~~~
+    5 |     a.insert(1, [1.1, 2.2])
+    6 |     a.insert(1, ['aa', 'bb', 'cc'])
+vlib/v/checker/tests/array_insert_type_mismatch.vv:5:14: error: cannot insert `[]f64` to `[]int`
+    3 |     a.insert(1, 2.3)
+    4 |     a.insert(1, 'abc')
+    5 |     a.insert(1, [1.1, 2.2])
+      |                 ~~~~~~~~~~
+    6 |     a.insert(1, ['aa', 'bb', 'cc'])
+    7 |     a.insert(1, [[1]])
+vlib/v/checker/tests/array_insert_type_mismatch.vv:6:14: error: cannot insert `[]string` to `[]int`
+    4 |     a.insert(1, 'abc')
+    5 |     a.insert(1, [1.1, 2.2])
+    6 |     a.insert(1, ['aa', 'bb', 'cc'])
+      |                 ~~~~~~~~~~~~~~~~~~
+    7 |     a.insert(1, [[1]])
+    8 |     a.insert(1, [[['aa']]])
+vlib/v/checker/tests/array_insert_type_mismatch.vv:7:14: error: cannot insert `[][]int` to `[]int`
+    5 |     a.insert(1, [1.1, 2.2])
+    6 |     a.insert(1, ['aa', 'bb', 'cc'])
+    7 |     a.insert(1, [[1]])
+      |                 ~~~~~
+    8 |     a.insert(1, [[['aa']]])
+    9 |     println(a)
+vlib/v/checker/tests/array_insert_type_mismatch.vv:8:14: error: cannot insert `[][][]string` to `[]int`
+    6 |     a.insert(1, ['aa', 'bb', 'cc'])
+    7 |     a.insert(1, [[1]])
+    8 |     a.insert(1, [[['aa']]])
+      |                 ~~~~~~~~~~
+    9 |     println(a)
+   10 |
+vlib/v/checker/tests/array_insert_type_mismatch.vv:12:14: error: cannot insert `[][][]int` to `[][]int`
+   10 |
+   11 |     mut b := [[1, 2, 3]]
+   12 |     b.insert(0, [[[2]]])
+      |                 ~~~~~~~
+   13 |     b.insert(0, [[[['aa']]]])
+   14 |     println(b)
+vlib/v/checker/tests/array_insert_type_mismatch.vv:13:14: error: cannot insert `[][][][]string` to `[][]int`
+   11 |     mut b := [[1, 2, 3]]
+   12 |     b.insert(0, [[[2]]])
+   13 |     b.insert(0, [[[['aa']]]])
+      |                 ~~~~~~~~~~~~
+   14 |     println(b)
+   15 | }

--- a/vlib/v/checker/tests/array_insert_type_mismatch.vv
+++ b/vlib/v/checker/tests/array_insert_type_mismatch.vv
@@ -1,0 +1,15 @@
+fn main() {
+	mut a := [1, 2]
+	a.insert(1, 2.3)
+	a.insert(1, 'abc')
+	a.insert(1, [1.1, 2.2])
+	a.insert(1, ['aa', 'bb', 'cc'])
+	a.insert(1, [[1]])
+	a.insert(1, [[['aa']]])
+	println(a)
+
+	mut b := [[1, 2, 3]]
+	b.insert(0, [[[2]]])
+	b.insert(0, [[[['aa']]]])
+	println(b)
+}

--- a/vlib/v/checker/tests/array_insert_type_mismatch_a.out
+++ b/vlib/v/checker/tests/array_insert_type_mismatch_a.out
@@ -1,7 +1,0 @@
-vlib/v/checker/tests/array_insert_type_mismatch_a.vv:3:14: error: type mismatch, should use `int`
-    1 | fn main() {
-    2 |     mut a := [1, 2]
-    3 |     a.insert(1, 2.3)
-      |                 ~~~
-    4 |     println(a)
-    5 | }

--- a/vlib/v/checker/tests/array_insert_type_mismatch_a.vv
+++ b/vlib/v/checker/tests/array_insert_type_mismatch_a.vv
@@ -1,5 +1,0 @@
-fn main() {
-	mut a := [1, 2]
-	a.insert(1, 2.3)
-	println(a)
-}

--- a/vlib/v/checker/tests/array_insert_type_mismatch_b.out
+++ b/vlib/v/checker/tests/array_insert_type_mismatch_b.out
@@ -1,7 +1,0 @@
-vlib/v/checker/tests/array_insert_type_mismatch_b.vv:3:14: error: type mismatch, should use `int`
-    1 | fn main() {
-    2 |     mut a := [1, 2]
-    3 |     a.insert(1, 'abc')
-      |                 ~~~~~
-    4 |     println(a)
-    5 | }

--- a/vlib/v/checker/tests/array_insert_type_mismatch_b.vv
+++ b/vlib/v/checker/tests/array_insert_type_mismatch_b.vv
@@ -1,5 +1,0 @@
-fn main() {
-	mut a := [1, 2]
-	a.insert(1, 'abc')
-	println(a)
-}

--- a/vlib/v/checker/tests/array_insert_type_mismatch_c.out
+++ b/vlib/v/checker/tests/array_insert_type_mismatch_c.out
@@ -1,7 +1,0 @@
-vlib/v/checker/tests/array_insert_type_mismatch_c.vv:3:14: error: type mismatch, should use `f64[]`
-    1 | fn main() {
-    2 |     mut a := [1.1, 2.2]
-    3 |     a.insert(1, [2, 3])
-      |                 ~~~~~~
-    4 |     println(a)
-    5 | }

--- a/vlib/v/checker/tests/array_insert_type_mismatch_c.vv
+++ b/vlib/v/checker/tests/array_insert_type_mismatch_c.vv
@@ -1,5 +1,0 @@
-fn main() {
-	mut a := [1.1, 2.2]
-	a.insert(1, [2, 3])
-	println(a)
-}

--- a/vlib/v/checker/tests/array_insert_type_mismatch_d.out
+++ b/vlib/v/checker/tests/array_insert_type_mismatch_d.out
@@ -1,7 +1,0 @@
-vlib/v/checker/tests/array_insert_type_mismatch_d.vv:3:14: error: type mismatch, should use `int[]`
-    1 | fn main() {
-    2 |     mut a := [1, 2]
-    3 |     a.insert(1, ['aa', 'bb', 'cc'])
-      |                 ~~~~~~~~~~~~~~~~~~
-    4 |     println(a)
-    5 | }

--- a/vlib/v/checker/tests/array_insert_type_mismatch_d.vv
+++ b/vlib/v/checker/tests/array_insert_type_mismatch_d.vv
@@ -1,5 +1,0 @@
-fn main() {
-	mut a := [1, 2]
-	a.insert(1, ['aa', 'bb', 'cc'])
-	println(a)
-}

--- a/vlib/v/checker/tests/array_prepend_type_mismatch.out
+++ b/vlib/v/checker/tests/array_prepend_type_mismatch.out
@@ -1,0 +1,56 @@
+vlib/v/checker/tests/array_prepend_type_mismatch.vv:3:12: error: cannot prepend `any_float` to `[]int`
+    1 | fn main() {
+    2 |     mut a := [1, 2]
+    3 |     a.prepend(2.3)
+      |               ~~~
+    4 |     a.prepend('abc')
+    5 |     a.prepend([2.2, 3.3])
+vlib/v/checker/tests/array_prepend_type_mismatch.vv:4:12: error: cannot prepend `string` to `[]int`
+    2 |     mut a := [1, 2]
+    3 |     a.prepend(2.3)
+    4 |     a.prepend('abc')
+      |               ~~~~~
+    5 |     a.prepend([2.2, 3.3])
+    6 |     a.prepend(['aa', 'bb', 'cc'])
+vlib/v/checker/tests/array_prepend_type_mismatch.vv:5:12: error: cannot prepend `[]f64` to `[]int`
+    3 |     a.prepend(2.3)
+    4 |     a.prepend('abc')
+    5 |     a.prepend([2.2, 3.3])
+      |               ~~~~~~~~~~
+    6 |     a.prepend(['aa', 'bb', 'cc'])
+    7 |     a.prepend([[1]])
+vlib/v/checker/tests/array_prepend_type_mismatch.vv:6:12: error: cannot prepend `[]string` to `[]int`
+    4 |     a.prepend('abc')
+    5 |     a.prepend([2.2, 3.3])
+    6 |     a.prepend(['aa', 'bb', 'cc'])
+      |               ~~~~~~~~~~~~~~~~~~
+    7 |     a.prepend([[1]])
+    8 |     a.prepend([[['aa']]])
+vlib/v/checker/tests/array_prepend_type_mismatch.vv:7:12: error: cannot prepend `[][]int` to `[]int`
+    5 |     a.prepend([2.2, 3.3])
+    6 |     a.prepend(['aa', 'bb', 'cc'])
+    7 |     a.prepend([[1]])
+      |               ~~~~~
+    8 |     a.prepend([[['aa']]])
+    9 |     println(a)
+vlib/v/checker/tests/array_prepend_type_mismatch.vv:8:12: error: cannot prepend `[][][]string` to `[]int`
+    6 |     a.prepend(['aa', 'bb', 'cc'])
+    7 |     a.prepend([[1]])
+    8 |     a.prepend([[['aa']]])
+      |               ~~~~~~~~~~
+    9 |     println(a)
+   10 |
+vlib/v/checker/tests/array_prepend_type_mismatch.vv:12:12: error: cannot prepend `[][][]int` to `[][]int`
+   10 |
+   11 |     mut b := [[1, 2, 3]]
+   12 |     b.prepend([[[2]]])
+      |               ~~~~~~~
+   13 |     b.prepend([[[['aa']]]])
+   14 |     println(b)
+vlib/v/checker/tests/array_prepend_type_mismatch.vv:13:12: error: cannot prepend `[][][][]string` to `[][]int`
+   11 |     mut b := [[1, 2, 3]]
+   12 |     b.prepend([[[2]]])
+   13 |     b.prepend([[[['aa']]]])
+      |               ~~~~~~~~~~~~
+   14 |     println(b)
+   15 | }

--- a/vlib/v/checker/tests/array_prepend_type_mismatch.vv
+++ b/vlib/v/checker/tests/array_prepend_type_mismatch.vv
@@ -1,0 +1,15 @@
+fn main() {
+	mut a := [1, 2]
+	a.prepend(2.3)
+	a.prepend('abc')
+	a.prepend([2.2, 3.3])
+	a.prepend(['aa', 'bb', 'cc'])
+	a.prepend([[1]])
+	a.prepend([[['aa']]])
+	println(a)
+
+	mut b := [[1, 2, 3]]
+	b.prepend([[[2]]])
+	b.prepend([[[['aa']]]])
+	println(b)
+}

--- a/vlib/v/checker/tests/array_prepend_type_mismatch_a.out
+++ b/vlib/v/checker/tests/array_prepend_type_mismatch_a.out
@@ -1,7 +1,0 @@
-vlib/v/checker/tests/array_prepend_type_mismatch_a.vv:3:12: error: type mismatch, should use `int`
-    1 | fn main() {
-    2 |     mut a := [1, 2]
-    3 |     a.prepend(2.3)
-      |               ~~~
-    4 |     println(a)
-    5 | }

--- a/vlib/v/checker/tests/array_prepend_type_mismatch_a.vv
+++ b/vlib/v/checker/tests/array_prepend_type_mismatch_a.vv
@@ -1,5 +1,0 @@
-fn main() {
-	mut a := [1, 2]
-	a.prepend(2.3)
-	println(a)
-}

--- a/vlib/v/checker/tests/array_prepend_type_mismatch_b.out
+++ b/vlib/v/checker/tests/array_prepend_type_mismatch_b.out
@@ -1,7 +1,0 @@
-vlib/v/checker/tests/array_prepend_type_mismatch_b.vv:3:12: error: type mismatch, should use `int`
-    1 | fn main() {
-    2 |     mut a := [1, 2]
-    3 |     a.prepend('abc')
-      |               ~~~~~
-    4 |     println(a)
-    5 | }

--- a/vlib/v/checker/tests/array_prepend_type_mismatch_b.vv
+++ b/vlib/v/checker/tests/array_prepend_type_mismatch_b.vv
@@ -1,5 +1,0 @@
-fn main() {
-	mut a := [1, 2]
-	a.prepend('abc')
-	println(a)
-}

--- a/vlib/v/checker/tests/array_prepend_type_mismatch_c.out
+++ b/vlib/v/checker/tests/array_prepend_type_mismatch_c.out
@@ -1,7 +1,0 @@
-vlib/v/checker/tests/array_prepend_type_mismatch_c.vv:3:12: error: type mismatch, should use `f64[]`
-    1 | fn main() {
-    2 |     mut a := [1.1, 2.2]
-    3 |     a.prepend([2, 3])
-      |               ~~~~~~
-    4 |     println(a)
-    5 | }

--- a/vlib/v/checker/tests/array_prepend_type_mismatch_c.vv
+++ b/vlib/v/checker/tests/array_prepend_type_mismatch_c.vv
@@ -1,5 +1,0 @@
-fn main() {
-	mut a := [1.1, 2.2]
-	a.prepend([2, 3])
-	println(a)
-}

--- a/vlib/v/checker/tests/array_prepend_type_mismatch_d.out
+++ b/vlib/v/checker/tests/array_prepend_type_mismatch_d.out
@@ -1,7 +1,0 @@
-vlib/v/checker/tests/array_prepend_type_mismatch_d.vv:3:12: error: type mismatch, should use `int[]`
-    1 | fn main() {
-    2 |     mut a := [1, 2]
-    3 |     a.prepend(['aa', 'bb', 'cc'])
-      |               ~~~~~~~~~~~~~~~~~~
-    4 |     println(a)
-    5 | }

--- a/vlib/v/checker/tests/array_prepend_type_mismatch_d.vv
+++ b/vlib/v/checker/tests/array_prepend_type_mismatch_d.vv
@@ -1,5 +1,0 @@
-fn main() {
-	mut a := [1, 2]
-	a.prepend(['aa', 'bb', 'cc'])
-	println(a)
-}


### PR DESCRIPTION
This PR fixes multi_array prepend/insert type mismatch check (fix #7484).

- Fixes multi_array prepend/insert type mismatch check.
- Add check tests.
- Merge multiple tests into one.

```v
module main

fn main() {
	mut a := [[1, 2, 3]]
	a.prepend([[[1]]])
	println(a)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:5:12: error: cannot prepend `[][][]int` to `[][]int`
    3 | fn main() {
    4 |     mut a := [[1, 2, 3]]
    5 |     a.prepend([[[1]]])
      |               ~~~~~~~
    6 |     println(a)
    7 | }
```