### PR TITLE
fmt: keep number separator

### DIFF
--- a/vlib/v/fmt/tests/integer_literal_keep.vv
+++ b/vlib/v/fmt/tests/integer_literal_keep.vv
@@ -10,9 +10,9 @@ fn sum_types(a []Expr) {
 }
 
 fn main() {
-	x := 0xdeadbeef
-	u := 9978654321
-	o := 0o664
+	x := 0xdead_beef
+	u := 9_978_654_321
+	o := 0o66_4
 	eprintln('  hex constant in decimal: $x')
 	eprintln('    u constant in decimal: $u')
 	eprintln('octal constant in decimal: $o')

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -39,8 +39,7 @@ pub mut:
 	line_ends                   []int // the positions of source lines ends   (i.e. \n signs)
 	nr_lines                    int // total number of lines in the source file that were scanned
 	is_vh                       bool // Keep newlines
-	is_fmt                      bool // Used only for skipping ${} in strings, since we need literal
-	// string values when generating formatted code.
+	is_fmt                      bool // Used for v fmt.
 	comments_mode               CommentsMode
 	is_inside_toplvl_statement  bool // *only* used in comments_mode: .toplevel_comments, toggled by parser
 	all_tokens                  []token.Token // *only* used in comments_mode: .toplevel_comments, contains all tokens
@@ -174,8 +173,12 @@ fn (mut s Scanner) ident_name() string {
 	return name
 }
 
-fn filter_num_sep(txt byteptr, start int, end int) string {
+fn (s Scanner) num_lit(start int, end int) string {
+	if s.is_fmt {
+		return s.text[start..end]
+	}
 	unsafe {
+		txt := s.text.str
 		mut b := malloc(end - start + 1) // add a byte for the endstring 0
 		mut i1 := 0
 		for i := start; i < end; i++ {
@@ -223,7 +226,7 @@ fn (mut s Scanner) ident_bin_number() string {
 		s.pos = first_wrong_digit_pos // adjust error position
 		s.error('this binary number has unsuitable digit `$first_wrong_digit.str()`')
 	}
-	number := filter_num_sep(s.text.str, start_pos, s.pos)
+	number := s.num_lit(start_pos, s.pos)
 	s.pos--
 	return number
 }
@@ -265,7 +268,7 @@ fn (mut s Scanner) ident_hex_number() string {
 		s.pos = first_wrong_digit_pos // adjust error position
 		s.error('this hexadecimal number has unsuitable digit `$first_wrong_digit.str()`')
 	}
-	number := filter_num_sep(s.text.str, start_pos, s.pos)
+	number := s.num_lit(start_pos, s.pos)
 	s.pos--
 	return number
 }
@@ -304,7 +307,7 @@ fn (mut s Scanner) ident_oct_number() string {
 		s.pos = first_wrong_digit_pos // adjust error position
 		s.error('this octal number has unsuitable digit `$first_wrong_digit.str()`')
 	}
-	number := filter_num_sep(s.text.str, start_pos, s.pos)
+	number := s.num_lit(start_pos, s.pos)
 	s.pos--
 	return number
 }
@@ -416,7 +419,7 @@ fn (mut s Scanner) ident_dec_number() string {
 			s.error('too many decimal points in number')
 		}
 	}
-	number := filter_num_sep(s.text.str, start_pos, s.pos)
+	number := s.num_lit(start_pos, s.pos)
 	s.pos--
 	return number
 }


### PR DESCRIPTION
In many cases, the use of number separators is for readability.

So v fmt should keep number separator. This PR implement it
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
