### PR TITLE
cgen: implement generic `array.index`

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -586,62 +586,6 @@ pub fn (mut a []int) sort() {
 	a.sort_with_compare(compare_ints)
 }
 
-// index returns the first index at which a given element can be found in the array
-// or -1 if the value is not found.
-pub fn (a []string) index(v string) int {
-	for i in 0 .. a.len {
-		if a[i] == v {
-			return i
-		}
-	}
-	return -1
-}
-
-// index returns the first index at which a given element can be found in the array
-// or -1 if the value is not found.
-pub fn (a []int) index(v int) int {
-	for i in 0 .. a.len {
-		if a[i] == v {
-			return i
-		}
-	}
-	return -1
-}
-
-// index returns the first index at which a given element can be found in the array
-// or -1 if the value is not found.
-pub fn (a []byte) index(v byte) int {
-	for i in 0 .. a.len {
-		if a[i] == v {
-			return i
-		}
-	}
-	return -1
-}
-
-// index returns the first index at which a given element can be found in the array
-// or -1 if the value is not found.
-pub fn (a []rune) index(v rune) int {
-	for i in 0 .. a.len {
-		if a[i] == v {
-			return i
-		}
-	}
-	return -1
-}
-
-// index returns the first index at which a given element can be found in the array
-// or -1 if the value is not found.
-// TODO is `char` type yet in the language?
-pub fn (a []char) index(v char) int {
-	for i in 0 .. a.len {
-		if a[i] == v {
-			return i
-		}
-	}
-	return -1
-}
-
 // reduce executes a given reducer function on each element of the array,
 // resulting in a single output value.
 pub fn (a []int) reduce(iter fn (int, int) int, accum_start int) int {

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -586,6 +586,62 @@ pub fn (mut a []int) sort() {
 	a.sort_with_compare(compare_ints)
 }
 
+// index returns the first index at which a given element can be found in the array
+// or -1 if the value is not found.
+pub fn (a []string) index(v string) int {
+	for i in 0 .. a.len {
+		if a[i] == v {
+			return i
+		}
+	}
+	return -1
+}
+
+// index returns the first index at which a given element can be found in the array
+// or -1 if the value is not found.
+pub fn (a []int) index(v int) int {
+	for i in 0 .. a.len {
+		if a[i] == v {
+			return i
+		}
+	}
+	return -1
+}
+
+// index returns the first index at which a given element can be found in the array
+// or -1 if the value is not found.
+pub fn (a []byte) index(v byte) int {
+	for i in 0 .. a.len {
+		if a[i] == v {
+			return i
+		}
+	}
+	return -1
+}
+
+// index returns the first index at which a given element can be found in the array
+// or -1 if the value is not found.
+pub fn (a []rune) index(v rune) int {
+	for i in 0 .. a.len {
+		if a[i] == v {
+			return i
+		}
+	}
+	return -1
+}
+
+// index returns the first index at which a given element can be found in the array
+// or -1 if the value is not found.
+// TODO is `char` type yet in the language?
+pub fn (a []char) index(v char) int {
+	for i in 0 .. a.len {
+		if a[i] == v {
+			return i
+		}
+	}
+	return -1
+}
+
 // reduce executes a given reducer function on each element of the array,
 // resulting in a single output value.
 pub fn (a []int) reduce(iter fn (int, int) int, accum_start int) int {

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1226,3 +1226,28 @@ fn test_struct_array_of_multi_type_in() {
 	println(ivan in people)
 	assert ivan in people
 }
+
+fn test_struct_array_of_multi_type_index() {
+	ivan := Person{
+		name: 'ivan'
+		nums: [1, 2, 3]
+		kv: {
+			'aaa': '111'
+		}
+	}
+	people := [Person{
+		name: 'ivan'
+		nums: [1, 2, 3]
+		kv: {
+			'aaa': '111'
+		}
+	}, Person{
+		name: 'bob'
+		nums: [2]
+		kv: {
+			'bbb': '222'
+		}
+	}]
+	println(people.index(ivan))
+	assert people.index(ivan) == 0
+}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1161,7 +1161,7 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 	// FIXME: Argument count != 1 will break these
 	if left_type_sym.kind == .array &&
 		method_name in
-		['filter', 'clone', 'repeat', 'reverse', 'map', 'slice', 'sort', 'contains'] {
+		['filter', 'clone', 'repeat', 'reverse', 'map', 'slice', 'sort', 'contains', 'index'] {
 		mut elem_typ := table.void_type
 		is_filter_map := method_name in ['filter', 'map']
 		is_sort := method_name == 'sort'
@@ -1212,6 +1212,8 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 			call_expr.return_type = table.void_type
 		} else if method_name == 'contains' {
 			call_expr.return_type = table.bool_type
+		} else if method_name == 'index' {
+			call_expr.return_type = table.int_type
 		}
 		return call_expr.return_type
 	} else if left_type_sym.kind == .map && method_name == 'clone' {

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -374,6 +374,10 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 				g.gen_array_contains(node)
 				return
 			}
+			'index' {
+				g.gen_array_index(node)
+				return
+			}
 			else {}
 		}
 	}


### PR DESCRIPTION
This PR implement generic `array.index`.

- Implement generic `array.index`.
- Remove redundant `index` in array.v.
- Add test `test_struct_array_of_multi_type_index`.

```v
module main

struct Person {
	name string
	nums []int
	kv   map[string]string
}

fn main() {
	ivan := Person{
		name: 'ivan'
		nums: [1, 2, 3]
		kv: {
			'aaa': '111'
		}
	}
	people := [Person{
		name: 'ivan'
		nums: [1, 2, 3]
		kv: {
			'aaa': '111'
		}
	}, Person{
		name: 'bob'
		nums: [2]
		kv: {
			'bbb': '222'
		}
	}]
	println(people.index(ivan))
	assert people.index(ivan) == 0
}

PS D:\Test\v\tt1> v run .
0
```