### PR TITLE
checker: Support integer and voidptr key types for maps

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -283,9 +283,7 @@ fn (m &map) key_to_index(pkey voidptr) (u32, u32) {
 [inline]
 fn (m &map) clone_key(dest voidptr, pkey voidptr) {
 	if !m.has_string_keys {
-		unsafe {
-			C.memcpy(dest, pkey, m.key_bytes)
-		}
+		unsafe {C.memcpy(dest, pkey, m.key_bytes)}
 		return
 	}
 	unsafe {

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -226,19 +226,19 @@ fn map_hash_string(pkey voidptr) u64 {
 }
 
 fn map_hash_int_1(pkey voidptr) u64 {
-	return hash.wyhash_c(pkey, 1, 0)
+	return hash.wyhash64_c(*&byte(pkey), 0)
 }
 
 fn map_hash_int_2(pkey voidptr) u64 {
-	return hash.wyhash_c(pkey, 2, 0)
+	return hash.wyhash64_c(*&u16(pkey), 0)
 }
 
 fn map_hash_int_4(pkey voidptr) u64 {
-	return hash.wyhash_c(pkey, 4, 0)
+	return hash.wyhash64_c(*&u32(pkey), 0)
 }
 
 fn map_hash_int_8(pkey voidptr) u64 {
-	return hash.wyhash_c(pkey, 8, 0)
+	return hash.wyhash64_c(*&u64(pkey), 0)
 }
 
 // bootstrap

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -670,6 +670,7 @@ pub fn (m &map) clone() map {
 		metas: &u32(malloc(metasize))
 		extra_metas: m.extra_metas
 		len: m.len
+		has_string_keys: m.has_string_keys
 	}
 	unsafe { C.memcpy(res.metas, m.metas, metasize) }
 	if !m.has_string_keys {

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -635,6 +635,7 @@ pub fn (m &map) keys_1() array {
 	return keys
 }
 
+// warning: only copies keys, does not clone
 [unsafe]
 pub fn (d &DenseArray) clone() DenseArray {
 	res := DenseArray{
@@ -653,7 +654,6 @@ pub fn (d &DenseArray) clone() DenseArray {
 		}
 		res.data = memdup(d.data, d.cap * d.slot_bytes)
 	}
-	// FIXME clone each key
 	return res
 }
 
@@ -672,6 +672,16 @@ pub fn (m &map) clone() map {
 		len: m.len
 	}
 	unsafe { C.memcpy(res.metas, m.metas, metasize) }
+	if !m.has_string_keys {
+		return res
+	}
+	// clone keys
+	for i in 0 .. m.key_values.len {
+		if !m.key_values.has_index(i) {
+			continue
+		}
+		m.clone_key(res.key_values.key(i), m.key_values.key(i))
+	}
 	return res
 }
 

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -190,7 +190,7 @@ fn (mut d DenseArray) zeros_to_end() {
 	}
 }
 
-type MapHashFn = fn(voidptr)u64
+type MapHashFn = fn (voidptr) u64
 
 pub struct map {
 	// Number of bytes of a key
@@ -252,11 +252,11 @@ fn new_map(key_bytes int, value_bytes int) map {
 	has_string_keys := key_bytes > sizeof(voidptr)
 	mut hash_fn := voidptr(0)
 	match key_bytes {
-		1 {hash_fn = &map_hash_int_1}
-		2 {hash_fn = &map_hash_int_2}
-		4 {hash_fn = &map_hash_int_4}
-		8 {hash_fn = &map_hash_int_8}
-		else {hash_fn = &map_hash_string}
+		1 { hash_fn = &map_hash_int_1 }
+		2 { hash_fn = &map_hash_int_2 }
+		4 { hash_fn = &map_hash_int_4 }
+		8 { hash_fn = &map_hash_int_8 }
+		else { hash_fn = &map_hash_string }
 	}
 	return map{
 		key_bytes: key_bytes
@@ -298,7 +298,7 @@ fn (m &map) keys_eq(a voidptr, b voidptr) bool {
 		return fast_string_eq(*&string(a), *&string(b))
 	}
 	// FIXME only works with integer/pointer types
-	return unsafe {C.memcmp(a, b, m.key_bytes)} == 0
+	return unsafe { C.memcmp(a, b, m.key_bytes) } == 0
 }
 
 [inline]
@@ -312,7 +312,7 @@ fn (m &map) key_to_index(pkey voidptr) (u32, u32) {
 [inline]
 fn (m &map) clone_key(dest voidptr, pkey voidptr) {
 	if !m.has_string_keys {
-		unsafe {C.memcpy(dest, pkey, m.key_bytes)}
+		unsafe { C.memcpy(dest, pkey, m.key_bytes) }
 		return
 	}
 	unsafe {

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -348,6 +348,12 @@ fn new_map(key_bytes int, value_bytes int) map {
 			clone_fn = &map_clone_string
 		}
 	}
+	mut free_fn := MapFreeFn(0)
+	if has_string_keys {
+		free_fn = &map_free_string
+	} else {
+		free_fn = &map_free_nop
+	}
 	return map{
 		key_bytes: key_bytes
 		value_bytes: value_bytes
@@ -362,11 +368,7 @@ fn new_map(key_bytes int, value_bytes int) map {
 		hash_fn: hash_fn
 		key_eq_fn: key_eq_fn
 		clone_fn: clone_fn
-		free_fn: if has_string_keys {
-			&map_free_string
-		} else {
-			&map_free_nop
-		}
+		free_fn: free_fn
 	}
 }
 

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -263,12 +263,10 @@ fn map_eq_int_2(a voidptr, b voidptr) bool {
 }
 
 fn map_eq_int_4(a voidptr, b voidptr) bool {
-	println('int4')
 	return *&u32(a) == *&u32(b)
 }
 
 fn map_eq_int_8(a voidptr, b voidptr) bool {
-	println('int8')
 	return *&u64(a) == *&u64(b)
 }
 

--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -463,3 +463,25 @@ fn test_map_or() {
 	_ = m
 	// num := m['first'] or { return }
 }
+
+fn test_int_keys() {
+	mut m := map[int]int
+	m[3] = 9
+	m[4] = 16
+	assert m.len == 2
+	assert m[3] == 9
+	assert m[4] == 16
+	m[5] += 24
+	m[5]++
+	assert m[5] == 25
+
+	mc := m.clone()
+	assert mc.len == 3
+	mut all := []int{}
+	for k, v in mc {
+		assert m[k] == v
+		all << k
+		all << v
+	}
+	assert all == [3,9,4,16,5,25]
+}

--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -485,3 +485,13 @@ fn test_int_keys() {
 	}
 	assert all == [3,9,4,16,5,25]
 }
+
+fn test_voidptr_keys() {
+	mut m := map[voidptr]string
+	v := 5
+	m[&v] = 'var'
+	m[&m] = 'map'
+	assert m[&v] == 'var'
+	assert m[&m] == 'map'
+	assert m.len == 2
+}

--- a/vlib/hash/wyhash.c.v
+++ b/vlib/hash/wyhash.c.v
@@ -3,9 +3,14 @@ module hash
 //#flag -I @VROOT/thirdparty/wyhash
 //#include "wyhash.h"
 fn C.wyhash(byteptr, u64, u64) u64
+fn C.wyhash64(u64, u64) u64
 
 [inline]
 pub fn wyhash_c(key byteptr, len u64, seed u64) u64 {
 	return C.wyhash(key, len, seed)
 }
 
+[inline]
+pub fn wyhash64_c(a u64, b u64) u64 {
+	return C.wyhash64(a, b)
+}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4433,9 +4433,14 @@ pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) table.Type {
 		return typ.set_nr_muls(0)
 	} else { // [1]
 		index_type := c.expr(node.index)
-		c.check_index_type(typ_sym, index_type, node.pos)
-		if typ_sym.kind == .map && index_type.idx() != table.string_type_idx {
-			c.error('non-string map index (map type `$typ_sym.name`)', node.pos)
+		if typ_sym.kind == .map {
+			info := typ_sym.info as table.Map
+			if !c.check_types(index_type, info.key_type) {
+				err := c.expected_msg(index_type, info.key_type)
+				c.error('invalid key: $err', node.pos)
+			}
+		} else {
+			c.check_index_type(typ_sym, index_type, node.pos)
 		}
 		value_type := c.table.value_type(typ)
 		if value_type != table.void_type {

--- a/vlib/v/checker/tests/map_ops.out
+++ b/vlib/v/checker/tests/map_ops.out
@@ -1,0 +1,26 @@
+vlib/v/checker/tests/map_ops.vv:2:18: warning: non-string keys are work in progress
+    1 | fn test_map() {
+    2 |     mut m := map[int]string
+      |                     ^
+    3 |     _ = m[`!`]
+    4 |     m['hi'] = 8
+vlib/v/checker/tests/map_ops.vv:3:7: error: invalid key: expected `int`, not `rune`
+    1 | fn test_map() {
+    2 |     mut m := map[int]string
+    3 |     _ = m[`!`]
+      |          ~~~~~
+    4 |     m['hi'] = 8
+    5 |     m[&m] += 4
+vlib/v/checker/tests/map_ops.vv:4:3: error: invalid key: expected `int`, not `string`
+    2 |     mut m := map[int]string
+    3 |     _ = m[`!`]
+    4 |     m['hi'] = 8
+      |      ~~~~~~
+    5 |     m[&m] += 4
+    6 | }
+vlib/v/checker/tests/map_ops.vv:5:3: error: invalid key: expected `int`, not `&map[int]string`
+    3 |     _ = m[`!`]
+    4 |     m['hi'] = 8
+    5 |     m[&m] += 4
+      |      ~~~~
+    6 | }

--- a/vlib/v/checker/tests/map_ops.vv
+++ b/vlib/v/checker/tests/map_ops.vv
@@ -1,0 +1,6 @@
+fn test_map() {
+	mut m := map[int]string
+	_ = m[`!`]
+	m['hi'] = 8
+	m[&m] += 4
+}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1726,6 +1726,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 						g.writeln(');')
 					} else if sym.kind == .map {
 						info := sym.info as table.Map
+						skeytyp := g.typ(info.key_type)
 						styp := g.typ(info.value_type)
 						zero := g.type_default(info.value_type)
 						val_typ := g.table.get_type_symbol(info.value_type)
@@ -1744,7 +1745,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 						} else {
 							g.expr(left.left)
 						}
-						g.write(', &(string[]){')
+						g.write(', &($skeytyp[]){')
 						g.expr(left.index)
 						g.write('}')
 						if val_typ.kind == .function {
@@ -3884,6 +3885,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 				}
 			} else if sym.kind == .map {
 				info := sym.info as table.Map
+				key_type_str := g.typ(info.key_type)
 				elem_type_str := g.typ(info.value_type)
 				elem_typ := g.table.get_type_symbol(info.value_type)
 				get_and_set_types := elem_typ.kind in [.struct_, .map]
@@ -3905,7 +3907,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 							g.write('.val')
 						}
 					}
-					g.write(', &(string[]){')
+					g.write(', &($key_type_str[]){')
 					g.expr(node.index)
 					g.write('}')
 					if elem_typ.kind == .function {
@@ -3925,7 +3927,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 						g.write('&')
 					}
 					g.expr(node.left)
-					g.write(', &(string[]){')
+					g.write(', &($key_type_str[]){')
 					g.expr(node.index)
 					g.write('}, &($elem_type_str[]){ $zero }))')
 				} else {
@@ -3955,7 +3957,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 							g.write('.val')
 						}
 					}
-					g.write('), &(string[]){')
+					g.write('), &($key_type_str[]){')
 					g.expr(node.index)
 					g.write('}')
 					if g.is_fn_index_call {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -52,8 +52,8 @@ pub fn (mut p Parser) parse_map_type() table.Type {
 		// error is reported in parse_type
 		return 0
 	}
-	if !(key_type == table.string_type_idx || (key_type.is_int() && !key_type.is_ptr()) ||
-		key_type.is_pointer()) {
+	if !(key_type in [table.string_type_idx, table.voidptr_type_idx] ||
+		(key_type.is_int() && !key_type.is_ptr())) {
 		s := p.table.type_to_str(key_type)
 		p.error_with_pos('maps do not support `$s` keys for now', p.tok.position())
 		return 0

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -52,10 +52,10 @@ pub fn (mut p Parser) parse_map_type() table.Type {
 		// error is reported in parse_type
 		return 0
 	}
-	// key_type_sym := p.get_type_symbol(key_type)
-	// if key_type_sym.kind != .string {
-	if key_type.idx() != table.string_type_idx {
-		p.error('maps can only have string keys for now')
+	if !(key_type == table.string_type_idx || (key_type.is_int() && !key_type.is_ptr()) ||
+		key_type.is_pointer()) {
+		s := p.table.type_to_str(key_type)
+		p.error('maps cannot have `$s` keys yet')
 		return 0
 	}
 	p.check(.rsbr)

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -55,7 +55,8 @@ pub fn (mut p Parser) parse_map_type() table.Type {
 	if !(key_type in [table.string_type_idx, table.voidptr_type_idx] ||
 		(key_type.is_int() && !key_type.is_ptr())) {
 		s := p.table.type_to_str(key_type)
-		p.error_with_pos('maps do not support `$s` keys for now', p.tok.position())
+		p.error_with_pos('maps only support string, integer, rune or voidptr keys for now (not `$s`)',
+			p.tok.position())
 		return 0
 	}
 	if key_type != table.string_type_idx {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -55,8 +55,11 @@ pub fn (mut p Parser) parse_map_type() table.Type {
 	if !(key_type == table.string_type_idx || (key_type.is_int() && !key_type.is_ptr()) ||
 		key_type.is_pointer()) {
 		s := p.table.type_to_str(key_type)
-		p.error('maps cannot have `$s` keys yet')
+		p.error_with_pos('maps do not support `$s` keys for now', p.tok.position())
 		return 0
+	}
+	if key_type != table.string_type_idx {
+		p.warn_with_pos('non-string keys are work in progress', p.tok.position())
 	}
 	p.check(.rsbr)
 	value_type := p.parse_type()

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -121,7 +121,10 @@ pub fn (mut p Parser) parse_fn_type(name string) table.Type {
 		is_variadic: is_variadic
 		return_type: return_type
 	}
-	idx := p.table.find_or_register_fn_type(p.mod, func, false, false)
+	// MapFooFn typedefs are manually added in cheaders.v 
+	// because typedefs get generated after the map struct is generated
+	has_decl := p.builtin_mod && name.starts_with('Map') && name.ends_with('Fn')
+	idx := p.table.find_or_register_fn_type(p.mod, func, false, has_decl)
 	return table.new_type(idx)
 }
 

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2053,7 +2053,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 	mut type_pos := p.tok.position()
 	mut comments := []ast.Comment{}
 	if p.tok.kind == .key_fn {
-		// function type: `type mycallback fn(string, int)`
+		// function type: `type mycallback = fn(string, int)`
 		fn_name := p.prepend_mod(name)
 		fn_type := p.parse_fn_type(fn_name)
 		comments = p.eat_line_end_comments()


### PR DESCRIPTION
Part of #6991.

Allow maps with integer, rune and voidptr keys & implement basic indexing operations for them (see `map_test.v` additions). I have implemented non-string map literals too but I'll submit that separately for easier review. `for` and map.clone() also work (and are in the int keys test) but I have a list of other things which need fixing so for now I have added a warning saying non-string keys are WIP.

Add map.has_string_keys field - for now this is `true` when the key size is bigger than a pointer. When false, keys are assumed to be bitwise comparable (the parser enforces these assumptions).
~~Change DenseArray.clone_key to a `map` method to access map.has_string_keys (in future it will probably need to access a function pointer field of `map`).~~
Change DenseArray.push to only make space, not clone key (cloning needs knowledge of the key type).
Fix map.clone to clone keys too.

*Update*: use function pointers for hash, equal, clone and free key operations.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
