### PR TITLE
fmt: add a space around single-line `unsafe` expressions

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -39,7 +39,7 @@ fn __new_array_with_default(mylen int, cap int, elm_size int, val voidptr) array
 	}
 	if val != 0 {
 		for i in 0 .. arr.len {
-			unsafe {arr.set_unsafe(i, val)}
+			unsafe { arr.set_unsafe(i, val) }
 		}
 	}
 	return arr
@@ -55,7 +55,7 @@ fn __new_array_with_array_default(mylen int, cap int, elm_size int, val array) a
 	}
 	for i in 0 .. arr.len {
 		val_clone := val.clone()
-		unsafe {arr.set_unsafe(i, &val_clone)}
+		unsafe { arr.set_unsafe(i, &val_clone) }
 	}
 	return arr
 }
@@ -70,7 +70,7 @@ fn new_array_from_c_array(len int, cap int, elm_size int, c_array voidptr) array
 		cap: cap_
 	}
 	// TODO Write all memory functions (like memcpy) in V
-	unsafe {C.memcpy(arr.data, c_array, len * elm_size)}
+	unsafe { C.memcpy(arr.data, c_array, len * elm_size) }
 	return arr
 }
 
@@ -125,11 +125,11 @@ pub fn (a array) repeat(count int) array {
 	for i in 0 .. count {
 		if a.len > 0 && a.element_size == size_of_array {
 			ary := array{}
-			unsafe {C.memcpy(&ary, a.data, size_of_array)}
+			unsafe { C.memcpy(&ary, a.data, size_of_array) }
 			ary_clone := ary.clone()
-			unsafe {C.memcpy(arr.get_unsafe(i * a.len), &ary_clone, a.len * a.element_size)}
+			unsafe { C.memcpy(arr.get_unsafe(i * a.len), &ary_clone, a.len * a.element_size) }
 		} else {
-			unsafe {C.memcpy(arr.get_unsafe(i * a.len), byteptr(a.data), a.len * a.element_size)}
+			unsafe { C.memcpy(arr.get_unsafe(i * a.len), byteptr(a.data), a.len * a.element_size) }
 		}
 	}
 	return arr
@@ -191,7 +191,7 @@ pub fn (mut a array) delete(i int) {
 	}
 	// NB: if a is [12,34], a.len = 2, a.delete(0)
 	// should move (2-0-1) elements = 1 element (the 34) forward
-	unsafe {C.memmove(a.get_unsafe(i), a.get_unsafe(i + 1), (a.len - i - 1) * a.element_size)}
+	unsafe { C.memmove(a.get_unsafe(i), a.get_unsafe(i + 1), (a.len - i - 1) * a.element_size) }
 	a.len--
 }
 
@@ -260,7 +260,7 @@ pub fn (mut a array) pop() voidptr {
 		}
 	}
 	new_len := a.len - 1
-	last_elem := unsafe {byteptr(a.data) + (new_len) * a.element_size}
+	last_elem := unsafe { byteptr(a.data) + (new_len) * a.element_size }
 	a.len = new_len
 	// NB: a.cap is not changed here *on purpose*, so that
 	// further << ops on that array will be more efficient.
@@ -338,13 +338,13 @@ pub fn (a &array) clone() array {
 	if a.element_size == size_of_array {
 		for i in 0 .. a.len {
 			ar := array{}
-			unsafe {C.memcpy(&ar, a.get_unsafe(i), size_of_array)}
+			unsafe { C.memcpy(&ar, a.get_unsafe(i), size_of_array) }
 			ar_clone := ar.clone()
-			unsafe {arr.set_unsafe(i, &ar_clone)}
+			unsafe { arr.set_unsafe(i, &ar_clone) }
 		}
 	} else {
 		if !isnil(a.data) {
-			unsafe {C.memcpy(byteptr(arr.data), a.data, a.cap * a.element_size)}
+			unsafe { C.memcpy(byteptr(arr.data), a.data, a.cap * a.element_size) }
 		}
 	}
 	return arr
@@ -381,7 +381,7 @@ fn (a &array) slice_clone(start int, _end int) array {
 [inline]
 [unsafe]
 fn (mut a array) set_unsafe(i int, val voidptr) {
-	unsafe {C.memcpy(byteptr(a.data) + a.element_size * i, val, a.element_size)}
+	unsafe { C.memcpy(byteptr(a.data) + a.element_size * i, val, a.element_size) }
 }
 
 // Private function. Used to implement assigment to the array element.
@@ -391,12 +391,12 @@ fn (mut a array) set(i int, val voidptr) {
 			panic('array.set: index out of range (i == $i, a.len == $a.len)')
 		}
 	}
-	unsafe {C.memcpy(byteptr(a.data) + a.element_size * i, val, a.element_size)}
+	unsafe { C.memcpy(byteptr(a.data) + a.element_size * i, val, a.element_size) }
 }
 
 fn (mut a array) push(val voidptr) {
 	a.ensure_cap(a.len + 1)
-	unsafe {C.memmove(byteptr(a.data) + a.element_size * a.len, val, a.element_size)}
+	unsafe { C.memmove(byteptr(a.data) + a.element_size * a.len, val, a.element_size) }
 	a.len++
 }
 
@@ -414,7 +414,7 @@ pub fn (mut a3 array) push_many(val voidptr, size int) {
 	} else {
 		a3.ensure_cap(a3.len + size)
 		if !isnil(a3.data) && !isnil(val) {
-			unsafe {C.memcpy(a3.get_unsafe(a3.len), val, a3.element_size * size)}
+			unsafe { C.memcpy(a3.get_unsafe(a3.len), val, a3.element_size * size) }
 		}
 	}
 	a3.len += size
@@ -449,7 +449,7 @@ pub fn (a array) reverse() array {
 		cap: a.cap
 	}
 	for i in 0 .. a.len {
-		unsafe {arr.set_unsafe(i, a.get_unsafe(a.len - 1 - i))}
+		unsafe { arr.set_unsafe(i, a.get_unsafe(a.len - 1 - i)) }
 	}
 	return arr
 }
@@ -514,7 +514,7 @@ pub fn copy(dst []byte, src []byte) int {
 	if dst.len > 0 && src.len > 0 {
 		mut min := 0
 		min = if dst.len < src.len { dst.len } else { src.len }
-		unsafe {C.memcpy(byteptr(dst.data), src[..min].data, dst.element_size * min)}
+		unsafe { C.memcpy(byteptr(dst.data), src[..min].data, dst.element_size * min) }
 		return min
 	}
 	return 0
@@ -757,7 +757,7 @@ pub fn compare_f32(a &f32, b &f32) int {
 pub fn (a array) pointers() []voidptr {
 	mut res := []voidptr{}
 	for i in 0 .. a.len {
-		unsafe {res << a.get_unsafe(i)}
+		unsafe { res << a.get_unsafe(i) }
 	}
 	return res
 }
@@ -777,5 +777,5 @@ pub fn (data voidptr) vbytes(len int) []byte {
 // byteptr.vbytes() - makes a V []byte structure from a C style memory buffer. NB: the data is reused, NOT copied!
 [unsafe]
 pub fn (data byteptr) vbytes(len int) []byte {
-	return unsafe {voidptr(data).vbytes(len)}
+	return unsafe { voidptr(data).vbytes(len) }
 }

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -125,18 +125,18 @@ fn new_dense_array(key_bytes int, value_bytes int) DenseArray {
 
 [inline]
 fn (d &DenseArray) key(i int) voidptr {
-	return unsafe {d.data + i * d.slot_bytes}
+	return unsafe { d.data + i * d.slot_bytes }
 }
 
 // for cgen
 [inline]
 fn (d &DenseArray) value(i int) voidptr {
-	return unsafe {d.data + i * d.slot_bytes + d.key_bytes}
+	return unsafe { d.data + i * d.slot_bytes + d.key_bytes }
 }
 
 [inline]
 fn (d &DenseArray) has_index(i int) bool {
-	return d.deletes == 0 || unsafe {d.all_deleted[i]} == 0
+	return d.deletes == 0 || unsafe { d.all_deleted[i] } == 0
 }
 
 [inline]
@@ -289,7 +289,7 @@ fn (m &map) free_key(pkey voidptr) {
 fn (m &map) meta_less(_index u32, _metas u32) (u32, u32) {
 	mut index := _index
 	mut meta := _metas
-	for meta < unsafe {m.metas[index]} {
+	for meta < unsafe { m.metas[index] } {
 		index += 2
 		meta += probe_inc
 	}
@@ -301,8 +301,8 @@ fn (mut m map) meta_greater(_index u32, _metas u32, kvi u32) {
 	mut meta := _metas
 	mut index := _index
 	mut kv_index := kvi
-	for unsafe {m.metas[index]} != 0 {
-		if meta > unsafe {m.metas[index]} {
+	for unsafe { m.metas[index] } != 0 {
+		if meta > unsafe { m.metas[index] } {
 			unsafe {
 				tmp_meta := m.metas[index]
 				m.metas[index] = meta
@@ -356,9 +356,9 @@ fn (mut m map) set_1(key voidptr, value voidptr) {
 	mut index, mut meta := m.key_to_index(key)
 	index, meta = m.meta_less(index, meta)
 	// While we might have a match
-	for meta == unsafe {m.metas[index]} {
-		kv_index := int(unsafe {m.metas[index + 1]})
-		pkey := unsafe {m.key_values.key(kv_index)}
+	for meta == unsafe { m.metas[index] } {
+		kv_index := int(unsafe { m.metas[index + 1] })
+		pkey := unsafe { m.key_values.key(kv_index) }
 		if m.keys_eq(key, pkey) {
 			unsafe {
 				pval := byteptr(pkey) + m.key_bytes
@@ -405,7 +405,7 @@ fn (mut m map) rehash() {
 		if !m.key_values.has_index(i) {
 			continue
 		}
-		pkey := unsafe {m.key_values.key(i)}
+		pkey := unsafe { m.key_values.key(i) }
 		mut index, mut meta := m.key_to_index(pkey)
 		index, meta = m.meta_less(index, meta)
 		m.meta_greater(index, meta, u32(i))
@@ -420,19 +420,19 @@ fn (mut m map) cached_rehash(old_cap u32) {
 	m.metas = &u32(vcalloc(metasize))
 	old_extra_metas := m.extra_metas
 	for i := u32(0); i <= old_cap + old_extra_metas; i += 2 {
-		if unsafe {old_metas[i]} == 0 {
+		if unsafe { old_metas[i] } == 0 {
 			continue
 		}
-		old_meta := unsafe {old_metas[i]}
+		old_meta := unsafe { old_metas[i] }
 		old_probe_count := ((old_meta >> hashbits) - 1) << 1
 		old_index := (i - old_probe_count) & (m.even_index >> 1)
 		mut index := (old_index | (old_meta << m.shift)) & m.even_index
 		mut meta := (old_meta & hash_mask) | probe_inc
 		index, meta = m.meta_less(index, meta)
-		kv_index := unsafe {old_metas[i + 1]}
+		kv_index := unsafe { old_metas[i + 1] }
 		m.meta_greater(index, meta, kv_index)
 	}
-	unsafe {free(old_metas)}
+	unsafe { free(old_metas) }
 }
 
 fn (mut m map) get_and_set(key string, zero voidptr) voidptr {
@@ -446,16 +446,16 @@ fn (mut m map) get_and_set_1(key voidptr, zero voidptr) voidptr {
 	for {
 		mut index, mut meta := m.key_to_index(key)
 		for {
-			if meta == unsafe {m.metas[index]} {
-				kv_index := int(unsafe {m.metas[index + 1]})
-				pkey := unsafe {m.key_values.key(kv_index)}
+			if meta == unsafe { m.metas[index] } {
+				kv_index := int(unsafe { m.metas[index + 1] })
+				pkey := unsafe { m.key_values.key(kv_index) }
 				if m.keys_eq(key, pkey) {
-					return unsafe {byteptr(pkey) + m.key_values.key_bytes}
+					return unsafe { byteptr(pkey) + m.key_values.key_bytes }
 				}
 			}
 			index += 2
 			meta += probe_inc
-			if meta > unsafe {m.metas[index]} {
+			if meta > unsafe { m.metas[index] } {
 				break
 			}
 		}
@@ -476,16 +476,16 @@ fn (m map) get(key string, zero voidptr) voidptr {
 fn (m &map) get_1(key voidptr, zero voidptr) voidptr {
 	mut index, mut meta := m.key_to_index(key)
 	for {
-		if meta == unsafe {m.metas[index]} {
-			kv_index := int(unsafe {m.metas[index + 1]})
-			pkey := unsafe {m.key_values.key(kv_index)}
+		if meta == unsafe { m.metas[index] } {
+			kv_index := int(unsafe { m.metas[index + 1] })
+			pkey := unsafe { m.key_values.key(kv_index) }
 			if m.keys_eq(key, pkey) {
-				return unsafe {byteptr(pkey) + m.key_values.key_bytes}
+				return unsafe { byteptr(pkey) + m.key_values.key_bytes }
 			}
 		}
 		index += 2
 		meta += probe_inc
-		if meta > unsafe {m.metas[index]} {
+		if meta > unsafe { m.metas[index] } {
 			break
 		}
 	}
@@ -500,16 +500,16 @@ fn (m map) exists(key string) bool {
 fn (m &map) exists_1(key voidptr) bool {
 	mut index, mut meta := m.key_to_index(key)
 	for {
-		if meta == unsafe {m.metas[index]} {
-			kv_index := int(unsafe {m.metas[index + 1]})
-			pkey := unsafe {m.key_values.key(kv_index)}
+		if meta == unsafe { m.metas[index] } {
+			kv_index := int(unsafe { m.metas[index + 1] })
+			pkey := unsafe { m.key_values.key(kv_index) }
 			if m.keys_eq(key, pkey) {
 				return true
 			}
 		}
 		index += 2
 		meta += probe_inc
-		if meta > unsafe {m.metas[index]} {
+		if meta > unsafe { m.metas[index] } {
 			break
 		}
 	}
@@ -536,11 +536,11 @@ pub fn (mut m map) delete_1(key voidptr) {
 	mut index, mut meta := m.key_to_index(key)
 	index, meta = m.meta_less(index, meta)
 	// Perform backwards shifting
-	for meta == unsafe {m.metas[index]} {
-		kv_index := int(unsafe {m.metas[index + 1]})
-		pkey := unsafe {m.key_values.key(kv_index)}
+	for meta == unsafe { m.metas[index] } {
+		kv_index := int(unsafe { m.metas[index + 1] })
+		pkey := unsafe { m.key_values.key(kv_index) }
 		if m.keys_eq(key, pkey) {
-			for (unsafe {m.metas[index + 2]} >> hashbits) > 1 {
+			for (unsafe { m.metas[index + 2] } >> hashbits) > 1 {
 				unsafe {
 					m.metas[index] = m.metas[index + 2] - probe_inc
 					m.metas[index + 1] = m.metas[index + 3]
@@ -573,7 +573,7 @@ pub fn (mut m map) delete_1(key voidptr) {
 // bootstrap
 pub fn (m &map) keys() []string {
 	mut keys := []string{len: m.len}
-	mut item := unsafe {byteptr(keys.data)}
+	mut item := unsafe { byteptr(keys.data) }
 	for i := 0; i < m.key_values.len; i++ {
 		if !m.key_values.has_index(i) {
 			continue
@@ -590,7 +590,7 @@ pub fn (m &map) keys() []string {
 // Returns all keys in the map.
 pub fn (m &map) keys_1() array {
 	mut keys := __new_array(m.len, 0, m.key_bytes)
-	mut item := unsafe {byteptr(keys.data)}
+	mut item := unsafe { byteptr(keys.data) }
 	if m.key_values.deletes == 0 {
 		for i := 0; i < m.key_values.len; i++ {
 			unsafe {
@@ -645,18 +645,18 @@ pub fn (m &map) clone() map {
 		even_index: m.even_index
 		cached_hashbits: m.cached_hashbits
 		shift: m.shift
-		key_values: unsafe {m.key_values.clone()}
+		key_values: unsafe { m.key_values.clone() }
 		metas: &u32(malloc(metasize))
 		extra_metas: m.extra_metas
 		len: m.len
 	}
-	unsafe {C.memcpy(res.metas, m.metas, metasize)}
+	unsafe { C.memcpy(res.metas, m.metas, metasize) }
 	return res
 }
 
 [unsafe]
 pub fn (m &map) free() {
-	unsafe {free(m.metas)}
+	unsafe { free(m.metas) }
 	if m.key_values.deletes == 0 {
 		for i := 0; i < m.key_values.len; i++ {
 			unsafe {
@@ -674,7 +674,7 @@ pub fn (m &map) free() {
 				m.free_key(pkey)
 			}
 		}
-		unsafe {free(m.key_values.all_deleted)}
+		unsafe { free(m.key_values.all_deleted) }
 	}
-	unsafe {free(m.key_values.data)}
+	unsafe { free(m.key_values.data) }
 }

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -142,7 +142,7 @@ fn gg_init_sokol_window(user_data voidptr) {
 	}
 	//
 	mut pipdesc := C.sg_pipeline_desc{}
-	unsafe {C.memset(&pipdesc, 0, sizeof(pipdesc))}
+	unsafe { C.memset(&pipdesc, 0, sizeof(pipdesc)) }
 	pipdesc.blend.enabled = true
 	pipdesc.blend.src_factor_rgb = C.SG_BLENDFACTOR_SRC_ALPHA
 	pipdesc.blend.dst_factor_rgb = C.SG_BLENDFACTOR_ONE_MINUS_SRC_ALPHA

--- a/vlib/os/environment.c.v
+++ b/vlib/os/environment.c.v
@@ -82,8 +82,8 @@ pub fn environ() map[string]string {
 		C.FreeEnvironmentStringsW(estrings)
 	} $else {
 		e := &charptr(C.environ)
-		for i := 0; !isnil(unsafe {e[i]}); i++ {
-			eline := unsafe {cstring_to_vstring(byteptr(e[i]))}
+		for i := 0; !isnil(unsafe { e[i] }); i++ {
+			eline := unsafe { cstring_to_vstring(byteptr(e[i])) }
 			eq_index := eline.index_byte(`=`)
 			if eq_index > 0 {
 				res[eline[0..eq_index]] = eline[eq_index + 1..]

--- a/vlib/os/fd.c.v
+++ b/vlib/os/fd.c.v
@@ -14,7 +14,7 @@ pub fn fd_write(fd int, s string) {
 			return
 		}
 		remaining = remaining - written
-		sp = unsafe {sp + written}
+		sp = unsafe { sp + written }
 	}
 }
 

--- a/vlib/os/inode.c.v
+++ b/vlib/os/inode.c.v
@@ -32,7 +32,7 @@ pub:
 // it supports windows for regular files but it doesn't matter if you use owner, group or others when checking permissions on windows
 pub fn inode(path string) FileMode {
 	mut attr := C.stat{}
-	unsafe {C.stat(charptr(path.str), &attr)}
+	unsafe { C.stat(charptr(path.str), &attr) }
 	mut typ := FileType.regular
 	if attr.st_mode & u32(C.S_IFMT) == u32(C.S_IFDIR) {
 		typ = .directory

--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -160,7 +160,7 @@ pub fn cp(src string, dst string) ? {
 			}
 		}
 		from_attr := C.stat{}
-		unsafe {C.stat(charptr(src.str), &from_attr)}
+		unsafe { C.stat(charptr(src.str), &from_attr) }
 		if C.chmod(charptr(dst.str), from_attr.st_mode) < 0 {
 			return error_with_code('failed to set permissions for $dst', int(-1))
 		}
@@ -580,7 +580,7 @@ pub fn executable() string {
 			eprintln('os.executable() failed at reading /proc/self/exe to get exe path')
 			return executable_fallback()
 		}
-		return unsafe {result.vstring()}
+		return unsafe { result.vstring() }
 	}
 	$if windows {
 		max := 512
@@ -617,14 +617,14 @@ pub fn executable() string {
 			eprintln('os.executable() failed at calling proc_pidpath with pid: $pid . proc_pidpath returned $ret ')
 			return executable_fallback()
 		}
-		return unsafe {result.vstring()}
+		return unsafe { result.vstring() }
 	}
 	$if freebsd {
 		mut result := vcalloc(max_path_len)
 		mib := [1 /* CTL_KERN */, 14 /* KERN_PROC */, 12 /* KERN_PROC_PATHNAME */, -1]
 		size := max_path_len
-		unsafe {C.sysctl(mib.data, 4, result, &size, 0, 0)}
-		return unsafe {result.vstring()}
+		unsafe { C.sysctl(mib.data, 4, result, &size, 0, 0) }
+		return unsafe { result.vstring() }
 	}
 	// "Sadly there is no way to get the full path of the executed file in OpenBSD."
 	$if openbsd {
@@ -640,7 +640,7 @@ pub fn executable() string {
 			eprintln('os.executable() failed at reading /proc/curproc/exe to get exe path')
 			return executable_fallback()
 		}
-		return unsafe {result.vstring_with_len(count)}
+		return unsafe { result.vstring_with_len(count) }
 	}
 	$if dragonfly {
 		mut result := vcalloc(max_path_len)
@@ -649,7 +649,7 @@ pub fn executable() string {
 			eprintln('os.executable() failed at reading /proc/curproc/file to get exe path')
 			return executable_fallback()
 		}
-		return unsafe {result.vstring_with_len(count)}
+		return unsafe { result.vstring_with_len(count) }
 	}
 	return executable_fallback()
 }
@@ -668,7 +668,7 @@ pub fn is_dir(path string) bool {
 		return false
 	} $else {
 		statbuf := C.stat{}
-		if unsafe {C.stat(charptr(path.str), &statbuf)} != 0 {
+		if unsafe { C.stat(charptr(path.str), &statbuf) } != 0 {
 			return false
 		}
 		// ref: https://code.woboq.org/gcc/include/sys/stat.h.html
@@ -713,7 +713,7 @@ pub fn getwd() string {
 		if C.getcwd(charptr(buf), 512) == 0 {
 			return ''
 		}
-		return unsafe {buf.vstring()}
+		return unsafe { buf.vstring() }
 	}
 }
 
@@ -736,7 +736,7 @@ pub fn real_path(fpath string) string {
 			return fpath
 		}
 	}
-	res := unsafe {fullpath.vstring()}
+	res := unsafe { fullpath.vstring() }
 	return normalize_drive_letter(res)
 }
 
@@ -759,7 +759,7 @@ fn normalize_drive_letter(path string) string {
 
 // signal will assign `handler` callback to be called when `signum` signal is recieved.
 pub fn signal(signum int, handler voidptr) {
-	unsafe {C.signal(signum, handler)}
+	unsafe { C.signal(signum, handler) }
 }
 
 // fork will fork the current system process and return the pid of the fork.
@@ -791,7 +791,7 @@ pub fn wait() int {
 pub fn file_last_mod_unix(path string) int {
 	attr := C.stat{}
 	// # struct stat attr;
-	unsafe {C.stat(charptr(path.str), &attr)}
+	unsafe { C.stat(charptr(path.str), &attr) }
 	// # stat(path.str, &attr);
 	return attr.st_mtime
 	// # return attr.st_mtime ;

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -52,7 +52,7 @@ fn init_os_args(argc int, argv &&byte) []string {
 	// mut args := []string{len:argc}
 	for i in 0 .. argc {
 		// args [i] = argv[i].vstring()
-		unsafe {args << byteptr(argv[i]).vstring()}
+		unsafe { args << byteptr(argv[i]).vstring() }
 	}
 	return args
 }
@@ -122,7 +122,7 @@ pub fn mkdir(path string) ?bool {
 		}
 	}
 	*/
-	r := unsafe {C.mkdir(charptr(apath.str), 511)}
+	r := unsafe { C.mkdir(charptr(apath.str), 511) }
 	if r == -1 {
 		return error(posix_get_error_msg(C.errno))
 	}

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -78,7 +78,7 @@ mut:
 fn init_os_args_wide(argc int, argv &byteptr) []string {
 	mut args := []string{}
 	for i in 0 .. argc {
-		args << string_from_wide(unsafe {&u16(argv[i])})
+		args << string_from_wide(unsafe { &u16(argv[i]) })
 	}
 	return args
 }

--- a/vlib/strings/builder.js.v
+++ b/vlib/strings/builder.js.v
@@ -37,7 +37,7 @@ pub fn (mut b Builder) writeln(s string) {
 }
 
 pub fn (b Builder) str() string {
-	return unsafe {byteptr(b.buf.data).vstring_with_len(b.len)}
+	return unsafe { byteptr(b.buf.data).vstring_with_len(b.len) }
 }
 
 pub fn (mut b Builder) cut(n int) {

--- a/vlib/strings/builder.v
+++ b/vlib/strings/builder.v
@@ -137,7 +137,7 @@ pub fn (mut b Builder) str() string {
 
 // manually free the contents of the buffer
 pub fn (mut b Builder) free() {
-	unsafe {free(b.buf.data)}
+	unsafe { free(b.buf.data) }
 	// b.buf = []byte{cap: b.initial_size}
 	b.len = 0
 	b.str_calls = 0

--- a/vlib/strings/strings.c.v
+++ b/vlib/strings/strings.c.v
@@ -5,12 +5,12 @@ pub fn repeat(c byte, n int) string {
 	if n <= 0 {
 		return ''
 	}
-	mut bytes := unsafe {malloc(n + 1)}
+	mut bytes := unsafe { malloc(n + 1) }
 	unsafe {
 		C.memset(bytes, c, n)
 		bytes[n] = `0`
 	}
-	return unsafe {bytes.vstring_with_len(n)}
+	return unsafe { bytes.vstring_with_len(n) }
 }
 
 // strings.repeat_string - gives you `n` repetitions of the substring `s`
@@ -22,7 +22,7 @@ pub fn repeat_string(s string, n int) string {
 	}
 	slen := s.len
 	blen := slen * n
-	mut bytes := unsafe {malloc(blen + 1)}
+	mut bytes := unsafe { malloc(blen + 1) }
 	for bi in 0 .. n {
 		bislen := bi * slen
 		for si in 0 .. slen {
@@ -34,5 +34,5 @@ pub fn repeat_string(s string, n int) string {
 	unsafe {
 		bytes[blen] = `0`
 	}
-	return unsafe {bytes.vstring_with_len(blen)}
+	return unsafe { bytes.vstring_with_len(blen) }
 }

--- a/vlib/time/parse.v
+++ b/vlib/time/parse.v
@@ -39,8 +39,8 @@ pub fn parse_rfc2822(s string) ?Time {
 	unsafe {
 		tmstr = malloc(s.len * 2)
 	}
-	count := unsafe {C.snprintf(charptr(tmstr), (s.len * 2), '%s-%02d-%s %s', fields[3].str,
-		mm, fields[1].str, fields[4].str)}
+	count := unsafe { C.snprintf(charptr(tmstr), (s.len * 2), '%s-%02d-%s %s', fields[3].str,
+		mm, fields[1].str, fields[4].str) }
 	return parse(tos(tmstr, count))
 }
 
@@ -51,7 +51,7 @@ const (
 
 fn parse_iso8601_date(s string) ?(int, int, int) {
 	year, month, day, dummy := 0, 0, 0, byte(0)
-	count := unsafe {C.sscanf(charptr(s.str), '%4d-%2d-%2d%c', &year, &month, &day, &dummy)}
+	count := unsafe { C.sscanf(charptr(s.str), '%4d-%2d-%2d%c', &year, &month, &day, &dummy) }
 	if count != 3 {
 		return err_invalid_8601
 	}
@@ -66,12 +66,12 @@ fn parse_iso8601_time(s string) ?(int, int, int, int, i64, bool) {
 	plus_min_z := `a`
 	offset_hour := 0
 	offset_minute := 0
-	mut count := unsafe {C.sscanf(charptr(s.str), '%2d:%2d:%2d.%6d%c%2d:%2d', &hour, &minute,
-		&second, &microsecond, charptr(&plus_min_z), &offset_hour, &offset_minute)}
+	mut count := unsafe { C.sscanf(charptr(s.str), '%2d:%2d:%2d.%6d%c%2d:%2d', &hour,
+		&minute, &second, &microsecond, charptr(&plus_min_z), &offset_hour, &offset_minute) }
 	// Missread microsecond ([Sec Hour Minute].len == 3 < 4)
 	if count < 4 {
-		count = unsafe {C.sscanf(charptr(s.str), '%2d:%2d:%2d%c%2d:%2d', &hour, &minute,
-			&second, charptr(&plus_min_z), &offset_hour, &offset_minute)}
+		count = unsafe { C.sscanf(charptr(s.str), '%2d:%2d:%2d%c%2d:%2d', &hour, &minute,
+			&second, charptr(&plus_min_z), &offset_hour, &offset_minute) }
 		count++ // Increment count because skipped microsecond
 	}
 	if count < 4 {

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1188,12 +1188,12 @@ pub fn (stmt Stmt) position() token.Position {
 // field table.Field.default_expr, which should be ast.Expr
 pub fn fe2ex(x table.FExpr) Expr {
 	res := Expr{}
-	unsafe {C.memcpy(&res, &x, sizeof(Expr))}
+	unsafe { C.memcpy(&res, &x, sizeof(Expr)) }
 	return res
 }
 
 pub fn ex2fe(x Expr) table.FExpr {
 	res := table.FExpr{}
-	unsafe {C.memcpy(&res, &x, sizeof(table.FExpr))}
+	unsafe { C.memcpy(&res, &x, sizeof(table.FExpr)) }
 	return res
 }

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -61,7 +61,7 @@ pub fn compile(command string, pref &pref.Preferences) {
 	}
 	b.exit_on_invalid_syntax()
 	// running does not require the parsers anymore
-	unsafe {b.myfree()}
+	unsafe { b.myfree() }
 	if pref.is_test || pref.is_run {
 		b.run_compiled_executable_and_exit()
 	}
@@ -72,7 +72,7 @@ pub fn compile(command string, pref &pref.Preferences) {
 fn (mut b Builder) myfree() {
 	// for file in b.parsed_files {
 	// }
-	unsafe {b.parsed_files.free()}
+	unsafe { b.parsed_files.free() }
 }
 
 fn (b &Builder) exit_on_invalid_syntax() {

--- a/vlib/v/builder/generics.v
+++ b/vlib/v/builder/generics.v
@@ -8,7 +8,7 @@ import v.table
 // generic struct instantiations to concrete types
 pub fn (b &Builder) generic_struct_insts_to_concrete() {
 	for idx, _ in b.table.types {
-		mut typ := unsafe {&b.table.types[idx]}
+		mut typ := unsafe { &b.table.types[idx] }
 		if typ.kind == .generic_struct_inst {
 			info := typ.info as table.GenericStructInst
 			parent := b.table.types[info.parent_idx]

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -135,7 +135,7 @@ pub fn (mut c Checker) check_files(ast_files []ast.File) {
 	mut has_main_fn := false
 	mut files_from_main_module := []&ast.File{}
 	for i in 0 .. ast_files.len {
-		file := unsafe {&ast_files[i]}
+		file := unsafe { &ast_files[i] }
 		c.timers.start('checker_check $file.path')
 		c.check(file)
 		if file.mod.name == 'main' {
@@ -167,7 +167,7 @@ pub fn (mut c Checker) check_files(ast_files []ast.File) {
 	// checked, to eunsure all generic calls are processed as this information
 	// is needed when the generic type is auto inferred from the call argument
 	for i in 0 .. ast_files.len {
-		file := unsafe {&ast_files[i]}
+		file := unsafe { &ast_files[i] }
 		if file.generic_fns.len > 0 {
 			c.file = file
 			c.mod = file.mod.name

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1113,9 +1113,9 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 			f.write(')')
 		}
 		ast.UnsafeExpr {
-			f.write('unsafe {')
+			f.write('unsafe { ')
 			f.expr(node.expr)
-			f.write('}')
+			f.write(' }')
 		}
 	}
 }

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -608,7 +608,7 @@ typedef struct {
 	for typ in g.table.types {
 		match typ.kind {
 			.alias {
-				parent := unsafe {&g.table.types[typ.parent_idx]}
+				parent := unsafe { &g.table.types[typ.parent_idx] }
 				is_c_parent := parent.name.len > 2 && parent.name[0] == `C` && parent.name[1] == `.`
 				parent_styp := if is_c_parent { 'struct ' + parent.cname[3..] } else { parent.cname }
 				g.type_definitions.writeln('typedef $parent_styp $typ.cname;')

--- a/vlib/v/gen/x64/gen.v
+++ b/vlib/v/gen/x64/gen.v
@@ -626,7 +626,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 				if word.len != 2 {
 					verror('opcodes format: xx xx xx xx')
 				}
-				b := unsafe {C.strtol(charptr(word.str), 0, 16)}
+				b := unsafe { C.strtol(charptr(word.str), 0, 16) }
 				// b := word.byte()
 				// println('"$word" $b')
 				g.write8(b)

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -220,7 +220,7 @@ pub fn (t &Table) type_find_method(s &TypeSymbol, name string) ?Fn {
 		if ts.parent_idx == 0 {
 			break
 		}
-		ts = unsafe {&t.types[ts.parent_idx]}
+		ts = unsafe { &t.types[ts.parent_idx] }
 	}
 	return none
 }
@@ -277,7 +277,7 @@ pub fn (t &Table) struct_find_field(s &TypeSymbol, name string) ?Field {
 		if ts.parent_idx == 0 {
 			break
 		}
-		ts = unsafe {&t.types[ts.parent_idx]}
+		ts = unsafe { &t.types[ts.parent_idx] }
 	}
 	return none
 }
@@ -301,7 +301,7 @@ pub fn (t &Table) get_type_symbol(typ Type) &TypeSymbol {
 	// println('get_type_symbol $typ')
 	idx := typ.idx()
 	if idx > 0 {
-		return unsafe {&t.types[idx]}
+		return unsafe { &t.types[idx] }
 	}
 	// this should never happen
 	panic('get_type_symbol: invalid type (typ=$typ idx=$idx). Compiler bug. This should never happen. Please create a GitHub issue.
@@ -318,7 +318,7 @@ pub fn (t &Table) get_final_type_symbol(typ Type) &TypeSymbol {
 			alias_info := current_type.info as Alias
 			return t.get_final_type_symbol(alias_info.parent_type)
 		}
-		return unsafe {&t.types[idx]}
+		return unsafe { &t.types[idx] }
 	}
 	// this should never happen
 	panic('get_final_type_symbol: invalid type (typ=$typ idx=$idx). Compiler bug. This should never happen. Please create a GitHub issue.')

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -28,7 +28,7 @@ pub const (
 pub fn vhash() string {
 	mut buf := [50]byte{}
 	buf[0] = 0
-	unsafe {C.snprintf(charptr(buf), 50, '%s', C.V_COMMIT_HASH)}
+	unsafe { C.snprintf(charptr(buf), 50, '%s', C.V_COMMIT_HASH) }
 	return tos_clone(buf)
 }
 
@@ -94,7 +94,7 @@ pub fn githash(should_get_from_filesystem bool) string {
 	}
 	mut buf := [50]byte{}
 	buf[0] = 0
-	unsafe {C.snprintf(charptr(buf), 50, '%s', C.V_CURRENT_COMMIT_HASH)}
+	unsafe { C.snprintf(charptr(buf), 50, '%s', C.V_CURRENT_COMMIT_HASH) }
 	return tos_clone(buf)
 }
 


### PR DESCRIPTION
makes it look consistent with the spaces around `or { expr }` / `if cond { expr } else { expr }` / etc. 

Plus, it just looks nicer overall imho
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
