### PR TITLE
array: remove redundant index method in array.v

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -586,62 +586,6 @@ pub fn (mut a []int) sort() {
 	a.sort_with_compare(compare_ints)
 }
 
-// index returns the first index at which a given element can be found in the array
-// or -1 if the value is not found.
-pub fn (a []string) index(v string) int {
-	for i in 0 .. a.len {
-		if a[i] == v {
-			return i
-		}
-	}
-	return -1
-}
-
-// index returns the first index at which a given element can be found in the array
-// or -1 if the value is not found.
-pub fn (a []int) index(v int) int {
-	for i in 0 .. a.len {
-		if a[i] == v {
-			return i
-		}
-	}
-	return -1
-}
-
-// index returns the first index at which a given element can be found in the array
-// or -1 if the value is not found.
-pub fn (a []byte) index(v byte) int {
-	for i in 0 .. a.len {
-		if a[i] == v {
-			return i
-		}
-	}
-	return -1
-}
-
-// index returns the first index at which a given element can be found in the array
-// or -1 if the value is not found.
-pub fn (a []rune) index(v rune) int {
-	for i in 0 .. a.len {
-		if a[i] == v {
-			return i
-		}
-	}
-	return -1
-}
-
-// index returns the first index at which a given element can be found in the array
-// or -1 if the value is not found.
-// TODO is `char` type yet in the language?
-pub fn (a []char) index(v char) int {
-	for i in 0 .. a.len {
-		if a[i] == v {
-			return i
-		}
-	}
-	return -1
-}
-
 // reduce executes a given reducer function on each element of the array,
 // resulting in a single output value.
 pub fn (a []int) reduce(iter fn (int, int) int, accum_start int) int {

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -586,6 +586,17 @@ pub fn (mut a []int) sort() {
 	a.sort_with_compare(compare_ints)
 }
 
+// index returns the first index at which a given element can be found in the array
+// or -1 if the value is not found.
+pub fn (a []string) index(v string) int {
+	for i in 0 .. a.len {
+		if a[i] == v {
+			return i
+		}
+	}
+	return -1
+}
+
 // reduce executes a given reducer function on each element of the array,
 // resulting in a single output value.
 pub fn (a []int) reduce(iter fn (int, int) int, accum_start int) int {


### PR DESCRIPTION
This PR just remove redundant index method in array.v.