### PR TITLE
array: remove redundant []string.str method

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -3,8 +3,6 @@
 // that can be found in the LICENSE file.
 module builtin
 
-import strings
-
 // array is a struct used for denoting array types in V
 pub struct array {
 pub:
@@ -465,24 +463,6 @@ pub fn (a &array) free() {
 	// return
 	// }
 	C.free(a.data)
-}
-
-// str returns a string representation of the array of strings
-// => '["a", "b", "c"]'.
-pub fn (a []string) str() string {
-	mut sb := strings.new_builder(a.len * 3)
-	sb.write('[')
-	for i in 0 .. a.len {
-		val := a[i]
-		sb.write("\'")
-		sb.write(val)
-		sb.write("\'")
-		if i < a.len - 1 {
-			sb.write(', ')
-		}
-	}
-	sb.write(']')
-	return sb.str()
 }
 
 // hex returns a string with the hexadecimal representation

--- a/vlib/v/gen/auto_str_methods.v
+++ b/vlib/v/gen/auto_str_methods.v
@@ -172,6 +172,8 @@ fn (mut g Gen) gen_str_for_array(info table.Array, styp string, str_fn_name stri
 			}
 		} else if sym.kind in [.f32, .f64] {
 			g.auto_str_funcs.writeln('\t\tstring x = _STR("%g", 1, it);')
+		} else if sym.kind == .string {
+			g.auto_str_funcs.writeln('\t\tstring x = _STR("\'%.*s\\000\'", 2, it);')
 		} else {
 			// There is a custom .str() method, so use it.
 			// NB: we need to take account of whether the user has defined


### PR DESCRIPTION
This PR just remove redundant []string.str method.

- Remove []string.str method.
- Remove `import strings`.