### PR TITLE
vdoc: remove sorting by kind

### DIFF
--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -406,7 +406,6 @@ pub fn (mut d Doc) file_asts(file_asts []ast.File) ? {
 			if d.contents[name].kind != .none_ || node.kind == .none_ {
 				d.contents[name].children << node.children
 				d.contents[name].children.sort_by_name()
-				d.contents[name].children.sort_by_kind()
 			}
 		}
 	}

--- a/vlib/v/doc/node.v
+++ b/vlib/v/doc/node.v
@@ -42,6 +42,5 @@ fn compare_nodes_by_name(a &DocNode, b &DocNode) int {
 pub fn (cnts map[string]DocNode) arr() []DocNode {
 	mut contents := cnts.keys().map(cnts[it])
 	contents.sort_by_name()
-	contents.sort_by_kind()
 	return contents
 }


### PR DESCRIPTION
Fixes #7539. This PR now only sorts by name only