### PR TITLE
gen: add MapHashFn typedef before map struct is declared

### DIFF
--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -428,6 +428,8 @@ static voidptr memfreedup(voidptr ptr, voidptr src, int sz) {
 	free(ptr);
 	return memdup(src, sz);
 }
+
+typedef uint64_t (*MapHashFn)(void*);
 '
 	c_builtin_types               = '
 //================================== builtin types ================================*/

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -430,6 +430,7 @@ static voidptr memfreedup(voidptr ptr, voidptr src, int sz) {
 }
 
 typedef uint64_t (*MapHashFn)(void*);
+typedef int (*MapEqFn)(void*, void*);
 '
 	c_builtin_types               = '
 //================================== builtin types ================================*/


### PR DESCRIPTION
`map` can't have a field of type function pointer because function pointer types are `typedef`'d after the map struct is declared.

Needed to bootstrap requested changes on #7503.

Also add `MapEqFn` as it will be needed soon too.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
