### PR TITLE
parser: return node on incomplete module selector

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1147,6 +1147,10 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 				if p.peek_tok.kind == .dot &&
 					p.peek_tok2.kind != .eof && p.peek_tok2.lit.len > 0 && p.peek_tok2.lit[0].is_capital() {
 					is_mod_cast = true
+				} else if p.peek_tok.kind == .dot && p.peek_tok2.kind != .eof && p.peek_tok2.lit.len == 0 {
+					// incomplete module selector must be handled by dot_expr instead
+					node = p.parse_ident(language)
+					return node
 				}
 			}
 			// prepend the full import

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1153,7 +1153,8 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 				if p.peek_tok.kind == .dot &&
 					p.peek_tok2.kind != .eof && p.peek_tok2.lit.len > 0 && p.peek_tok2.lit[0].is_capital() {
 					is_mod_cast = true
-				} else if p.peek_tok.kind == .dot && p.peek_tok2.kind != .eof && p.peek_tok2.lit.len == 0 {
+				} else if p.peek_tok.kind == .dot &&
+					p.peek_tok2.kind != .eof && p.peek_tok2.lit.len == 0 {
 					// incomplete module selector must be handled by dot_expr instead
 					node = p.parse_ident(language)
 					return node

--- a/vlib/v/parser/tests/uncomplete_module_call_err.out
+++ b/vlib/v/parser/tests/uncomplete_module_call_err.out
@@ -1,4 +1,4 @@
-vlib/v/parser/tests/uncomplete_module_call_err.vv:7:1: error: unexpected token ``
+vlib/v/parser/tests/uncomplete_module_call_err.vv:7:1: error: unexpected `}`, expecting `name`
     5 | fn main() {
     6 |     os.
     7 | }


### PR DESCRIPTION
Continuation of #7530 . `name_expr` will return an Ident when the module selector is incomplete and delegates it to `dot_expr` method in order to be transformed into a proper `SelectorExpr` AST node.