### PR TITLE
parser: minor optimization of `expr()` in pratt.v

### DIFF
--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -22,7 +22,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 	// Prefix
 	match p.tok.kind {
 		.key_mut, .key_shared, .key_atomic, .key_static {
-			node = p.name_expr()
+			node = p.parse_ident(table.Language.v)
 			p.is_stmt_ident = is_stmt_ident
 		}
 		.name {


### PR DESCRIPTION
This PR makes minor optimization of `expr()` in pratt.v.

- In `.key_mut, .key_shared, .key_atomic, .key_static {` , avoid unnecessary series of judgments.
- Increase processing speed.