### PR TITLE
gen: fix return type for MapEqFn and add MapCloneFn, MapFreeFn

### DIFF
--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -458,10 +458,10 @@ typedef struct sync__Channel* chan;
 	#endif
 #endif
 
-typedef u64 (*_MapHashFn)(voidptr);
-typedef bool (*_MapEqFn)(voidptr, voidptr);
-typedef void (*_MapCloneFn)(voidptr, voidptr);
-typedef void (*_MapFreeFn)(voidptr);
+typedef u64 (*MapHashFn)(voidptr);
+typedef bool (*MapEqFn)(voidptr, voidptr);
+typedef void (*MapCloneFn)(voidptr, voidptr);
+typedef void (*MapFreeFn)(voidptr);
 '
 	bare_c_headers                = '
 $c_common_macros

--- a/vlib/v/gen/cheaders.v
+++ b/vlib/v/gen/cheaders.v
@@ -428,9 +428,6 @@ static voidptr memfreedup(voidptr ptr, voidptr src, int sz) {
 	free(ptr);
 	return memdup(src, sz);
 }
-
-typedef uint64_t (*MapHashFn)(void*);
-typedef int (*MapEqFn)(void*, void*);
 '
 	c_builtin_types               = '
 //================================== builtin types ================================*/
@@ -460,6 +457,11 @@ typedef struct sync__Channel* chan;
 		#define false 0
 	#endif
 #endif
+
+typedef u64 (*_MapHashFn)(voidptr);
+typedef bool (*_MapEqFn)(voidptr, voidptr);
+typedef void (*_MapCloneFn)(voidptr, voidptr);
+typedef void (*_MapFreeFn)(voidptr);
 '
 	bare_c_headers                = '
 $c_common_macros


### PR DESCRIPTION
Needed for #7503.

Fix bool return type for `MapEqFn` and use V type names rather than C99.
Also move map typedefs to `c_builtin_types` section rather than `c_headers`.
~~Also add underscores to typedef names~~.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
