### PR TITLE
eprint[ln] behaves same as print[ln]

### DIFF
--- a/vlib/builtin/js/builtin.v
+++ b/vlib/builtin/js/builtin.v
@@ -22,13 +22,13 @@ pub fn print(s any) {
 }
 
 pub fn eprintln(s any) {
-	JS.console.error(s)
+	JS.console.error(s.toString())
 }
 
 pub fn eprint(s any) {
 	// TODO
 	// $if js.node {
-		JS.process.stderr.write(s)
+		JS.process.stderr.write(s.toString())
 	// } $else {
 	//	panic('Cannot `eprint` in a browser, use `eprintln` instead')
 	// }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1589,8 +1589,8 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 			unexpected_arguments_pos)
 		return f.return_type
 	}
-	// println can print anything
-	if fn_name in ['println', 'print'] && call_expr.args.len > 0 {
+	// println / eprintln can print anything
+	if fn_name in ['println', 'print', 'eprintln', 'eprint'] && call_expr.args.len > 0 {
 		c.expected_type = table.string_type
 		call_expr.args[0].typ = c.expr(call_expr.args[0].expr)
 		/*

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -501,8 +501,8 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 		}
 	}
 	mut name := node.name
-	is_print := name == 'println' || name == 'print'
-	print_method := if name == 'println' { 'println' } else { 'print' }
+	is_print := name in ['print', 'println', 'eprint', 'eprintln']
+	print_method := name
 	is_json_encode := name == 'json.encode'
 	is_json_decode := name == 'json.decode'
 	g.is_json_fn = is_json_encode || is_json_decode

--- a/vlib/v/tests/print_test.v
+++ b/vlib/v/tests/print_test.v
@@ -1,3 +1,4 @@
 fn test_print() {
 	println(2.0)
+	eprintln(2.0)
 }

--- a/vlib/v/tests/vargs_auto_str_method_and_println_test.v
+++ b/vlib/v/tests/vargs_auto_str_method_and_println_test.v
@@ -10,6 +10,8 @@ fn test_autoprint_string_vargs() {
 fn add_s(column string, other_columns ...string) {
 	println(column)
 	println(other_columns)
+	eprintln(column)
+	eprintln(other_columns)
 }
 
 //
@@ -23,6 +25,8 @@ fn test_autoprint_int_vargs() {
 fn add_i(column int, other_columns ...int) {
 	println(column)
 	println(other_columns)
+	eprintln(column)
+	eprintln(other_columns)
 }
 
 //
@@ -41,4 +45,6 @@ fn test_autoprint_struct_vargs() {
 fn add_point(column Point, other_columns ...Point) {
 	println(column)
 	println(other_columns)
+	eprintln(column)
+	eprintln(other_columns)
 }


### PR DESCRIPTION
Fix #7588

eprintln accepts a any type arg.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
