### PR TITLE
repl: make readline history

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -11,6 +11,7 @@ import v.util
 
 struct Repl {
 mut:
+	readline       readline.Readline
 	indent         int // indentation level
 	in_func        bool // are we inside a new custom user function
 	line           string // the current line entered by the user
@@ -29,6 +30,7 @@ const (
 
 fn new_repl() &Repl {
 	return &Repl{
+		readline: readline.Readline{}
 		modules: ['os', 'time', 'math']
 	}
 }
@@ -131,9 +133,7 @@ fn run_repl(workdir string, vrepl_prefix string) {
 		} else {
 			prompt = '... '
 		}
-		oline := r.get_one_line(prompt) or {
-			break
-		}
+		oline := r.get_one_line(prompt) or { break }
 		line := oline.trim_space()
 		if line == '' && oline.ends_with('\n') {
 			continue
@@ -314,9 +314,7 @@ fn print_output(s os.Result) {
 		} else if line.contains('.vrepl.v:') {
 			// Ensure that .vrepl.v: is at the start, ignore the path
 			// This is needed to have stable .repl tests.
-			idx := line.index('.vrepl.v:') or {
-				return
-			}
+			idx := line.index('.vrepl.v:') or { return }
 			println(line[idx..])
 		} else {
 			println(line)
@@ -347,7 +345,6 @@ fn rerror(s string) {
 }
 
 fn (mut r Repl) get_one_line(prompt string) ?string {
-	mut readline := readline.Readline{}
 	if is_stdin_a_pipe {
 		iline := os.get_raw_line()
 		if iline.len == 0 {
@@ -355,8 +352,6 @@ fn (mut r Repl) get_one_line(prompt string) ?string {
 		}
 		return iline
 	}
-	rline := readline.read_line(prompt) or {
-		return none
-	}
+	rline := r.readline.read_line(prompt) or { return none }
 	return rline
 }


### PR DESCRIPTION
Currently, Use a new readline for each get_one_line.

But because of this, readline history doesn't work on repl.

This PR makes readline history works

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
