### PR TITLE
Console CMD: Return Cursor to Top-Left Corner in V Console on 'Clear'

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -97,7 +97,7 @@ fn repl_help() {
 
 fn run_repl(workdir string, vrepl_prefix string) {
 	if !is_stdin_a_pipe {
-		println(util.full_v_version(false))
+		println(util.full_v_version(true))
 		println('Use Ctrl-C or `exit` to exit, or `help` to see other available commands')
 	}
 	file := os.join_path(workdir, '.${vrepl_prefix}vrepl.v')
@@ -146,7 +146,7 @@ fn run_repl(workdir string, vrepl_prefix string) {
 			continue
 		}
 		if r.line == 'clear' {
-			term.erase_display('2')
+			term.erase_clear()
 			continue
 		}
 		if r.line == 'help' {

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -97,7 +97,7 @@ fn repl_help() {
 
 fn run_repl(workdir string, vrepl_prefix string) {
 	if !is_stdin_a_pipe {
-		println(util.full_v_version(true))
+		println(util.full_v_version(false))
 		println('Use Ctrl-C or `exit` to exit, or `help` to see other available commands')
 	}
 	file := os.join_path(workdir, '.${vrepl_prefix}vrepl.v')

--- a/vlib/term/control.v
+++ b/vlib/term/control.v
@@ -46,6 +46,7 @@ pub fn cursor_back(n int) {
 // type: 1 -> current cursor position to beginning of the screen
 // type: 2 -> clears entire screen
 // type: 3 -> clears entire screen and also delete scrollback buffer
+
 pub fn erase_display(t string) {
 	print('\x1b[' + t + 'J')
 }
@@ -58,8 +59,9 @@ pub fn erase_tobeg() {
 	erase_display('1')
 }
 
+// clears entire screen and returns cursor to top left-corner
 pub fn erase_clear() {
-	erase_display('2')
+	print("\033[H\033[J")
 }
 
 pub fn erase_del_clear() {


### PR DESCRIPTION
The current clear command in the V console clears the screen but leaves the '>>>' hanging at the same location. However, a minor fix to this command as seen in this request will return the '>>>' to the top left corner of the screen.

Thank you in advance for your consideration in this matter.

Kind regards