### PR TITLE
fmt: improve conditions for single line if

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1446,8 +1446,8 @@ pub fn (mut f Fmt) infix_expr(node ast.InfixExpr) {
 
 pub fn (mut f Fmt) if_expr(it ast.IfExpr) {
 	dollar := if it.is_comptime { '$' } else { '' }
-	single_line := it.branches.len == 2 && it.has_else && it.branches[0].stmts.len == 1 &&
-		it.branches[1].stmts.len == 1 &&
+	single_line := it.branches.len == 2 && it.has_else && branch_is_single_line(it.branches[0]) &&
+		branch_is_single_line(it.branches[1]) &&
 		(it.is_expr || f.is_assign)
 	f.single_line_if = single_line
 	for i, branch in it.branches {
@@ -1486,6 +1486,13 @@ pub fn (mut f Fmt) if_expr(it ast.IfExpr) {
 		f.writeln('')
 		f.comments(it.post_comments, has_nl: false)
 	}
+}
+
+fn branch_is_single_line(b ast.IfBranch) bool {
+	if b.stmts.len == 1 && b.comments.len == 0 && stmt_is_single_line(b.stmts[0]) {
+		return true
+	}
+	return false
 }
 
 pub fn (mut f Fmt) at_expr(node ast.AtExpr) {
@@ -1713,7 +1720,7 @@ fn expr_is_single_line(expr ast.Expr) bool {
 			return false
 		}
 		ast.StructInit {
-			if expr.fields.len > 0 || expr.pre_comments.len > 0 {
+			if !expr.is_short && (expr.fields.len > 0 || expr.pre_comments.len > 0) {
 				return false
 			}
 		}

--- a/vlib/v/fmt/tests/if_keep.vv
+++ b/vlib/v/fmt/tests/if_keep.vv
@@ -1,0 +1,17 @@
+fn main() {
+	a := if foo { 'TMP1/${b.nexpected_steps:1d}' } else { '${b.cstep:1d}/${b.nexpected_steps:1d}' }
+	b := if bar {
+		// comment
+		'some str'
+	} else {
+		'other str'
+	}
+	_ := if true {
+		Foo{}
+	} else {
+		Foo{
+			x: 5
+		}
+	}
+	_ := if false { Foo{} } else { Foo{5, 6} }
+}


### PR DESCRIPTION
-  there cannot be comments inside a branch
- the branch stmt has to be single line too
- stmt_is_single_line: treat short StructInit as single line



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
