### PR TITLE
vfmt: fix early exit when verifying multiple files; update help

### DIFF
--- a/cmd/v/help/fmt.txt
+++ b/cmd/v/help/fmt.txt
@@ -1,7 +1,9 @@
 Usage:
   v fmt [options] path_to_source.v [path_to_other_source.v]
+  v fmt [options] path/to/dir [path/to/other_dir]
 
-Formats the given V source files, then prints their formatted source to stdout.
+Formats the given V source files or recursively format all files in the directory,
+then prints their formatted source to stdout.
 
 Options:
   -c      Check if a file is already formatted. If not, print the filepath and exit with code 2.

--- a/cmd/v/help/fmt.txt
+++ b/cmd/v/help/fmt.txt
@@ -2,7 +2,7 @@ Usage:
   v fmt [options] path_to_source.v [path_to_other_source.v]
   v fmt [options] path/to/dir [path/to/other_dir]
 
-Formats the given V source files or recursively format all files in the directory,
+Formats the given V source files or recursively formats all files in the directory,
 then prints their formatted source to stdout.
 
 Options:


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
