### PR TITLE
ast:remove path and expr field in Module

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -130,8 +130,6 @@ pub fn (e &SelectorExpr) root_ident() Ident {
 pub struct Module {
 pub:
 	name       string
-	path       string
-	expr       Expr
 	pos        token.Position
 	is_skipped bool // module main can be skipped in single file programs
 }


### PR DESCRIPTION
I found that the path and expr field in Module struct in ast.v is never used.
I remove this two fields,  and V compiler runs  well.
Can it  be cleaned?
```
// module declaration
pub struct Module {
pub:
	name       string
	path       string  //never be used
	expr       Expr //never be used
	pos        token.Position
	is_skipped bool // module main can be skipped in single file programs
}
```