### PR TITLE
Remove websocket from test-cleancode list

### DIFF
--- a/cmd/tools/vtest-cleancode.v
+++ b/cmd/tools/vtest-cleancode.v
@@ -69,8 +69,6 @@ const (
 		'vlib/strings/',
 		'vlib/time/',
 		'vlib/vweb/',
-		'vlib/x/websocket/websocket_server.v',
-		'vlib/x/websocket/websocket_client.v',
 	]
 )
 


### PR DESCRIPTION
CI on master is broken.

I tried `v fmt -w vlib/x/websocket`, but result is not good. So I just remove from cleancode list

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
