### PR TITLE
cgen: fix gen_map_equality_fn()

### DIFF
--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -465,7 +465,7 @@ fn test_map_or() {
 }
 
 fn test_int_keys() {
-	mut m := map[int]int
+	mut m := map[int]int{}
 	m[3] = 9
 	m[4] = 16
 	assert m.len == 2
@@ -474,7 +474,6 @@ fn test_int_keys() {
 	m[5] += 24
 	m[5]++
 	assert m[5] == 25
-
 	mc := m.clone()
 	assert mc.len == 3
 	mut all := []int{}
@@ -483,15 +482,78 @@ fn test_int_keys() {
 		all << k
 		all << v
 	}
-	assert all == [3,9,4,16,5,25]
+	assert all == [3, 9, 4, 16, 5, 25]
 }
 
 fn test_voidptr_keys() {
-	mut m := map[voidptr]string
+	mut m := map[voidptr]string{}
 	v := 5
 	m[&v] = 'var'
 	m[&m] = 'map'
 	assert m[&v] == 'var'
 	assert m[&m] == 'map'
 	assert m.len == 2
+}
+
+fn test_eq() {
+	a := {
+		'a': 1
+		'b': 2
+	}
+	assert a == {
+		'a': 1
+		'b': 2
+	}
+	b := {
+		'a': [[1]]
+		'b': [[2]]
+	}
+	assert b == {
+		'a': [[1]]
+		'b': [[2]]
+	}
+	c := {
+		'a': {
+			'11': 1
+		}
+		'b': {
+			'22': 2
+		}
+	}
+	assert c == {
+		'a': {
+			'11': 1
+		}
+		'b': {
+			'22': 2
+		}
+	}
+	d := {
+		'a': MValue{
+			name: 'aa'
+			misc: {
+				'11': '1'
+			}
+		}
+		'b': MValue{
+			name: 'bb'
+			misc: {
+				'22': '2'
+			}
+		}
+	}
+	assert d == {
+		'a': MValue{
+			name: 'aa'
+			misc: {
+				'11': '1'
+			}
+		}
+		'b': MValue{
+			name: 'bb'
+			misc: {
+				'22': '2'
+			}
+		}
+	}
 }


### PR DESCRIPTION
This PR fixes gen_map_equality_fn().

- Fixes gen_map_equality_fn()
- Add tests in map_test.v

```v
fn test_eq() {
	a := {
		'a': 1
		'b': 2
	}
	assert a == {
		'a': 1
		'b': 2
	}
	b := {
		'a': [[1]]
		'b': [[2]]
	}
	assert b == {
		'a': [[1]]
		'b': [[2]]
	}
	c := {
		'a': {
			'11': 1
		}
		'b': {
			'22': 2
		}
	}
	assert c == {
		'a': {
			'11': 1
		}
		'b': {
			'22': 2
		}
	}
	d := {
		'a': MValue{
			name: 'aa'
			misc: {
				'11': '1'
			}
		}
		'b': MValue{
			name: 'bb'
			misc: {
				'22': '2'
			}
		}
	}
	assert d == {
		'a': MValue{
			name: 'aa'
			misc: {
				'11': '1'
			}
		}
		'b': MValue{
			name: 'bb'
			misc: {
				'22': '2'
			}
		}
	}
}
```