### PR TITLE
cgen: fix struct_eq (fix #7637)

### DIFF
--- a/vlib/v/gen/auto_eq_methods.v
+++ b/vlib/v/gen/auto_eq_methods.v
@@ -18,28 +18,21 @@ fn (mut g Gen) gen_struct_equality_fn(left table.Type) string {
 	fn_builder.writeln('static bool ${ptr_typ}_struct_eq($ptr_typ a, $ptr_typ b) {')
 	for field in info.fields {
 		sym := g.table.get_type_symbol(field.typ)
-		match sym.kind {
-			.string {
-				fn_builder.writeln('\tif (string_ne(a.$field.name, b.$field.name)) {')
-			}
-			.struct_ {
-				eq_fn := g.gen_struct_equality_fn(field.typ)
-				fn_builder.writeln('\tif (!${eq_fn}_struct_eq(a.$field.name, b.$field.name)) {')
-			}
-			.array {
-				eq_fn := g.gen_array_equality_fn(field.typ)
-				fn_builder.writeln('\tif (!${eq_fn}_arr_eq(a.$field.name, b.$field.name)) {')
-			}
-			.map {
-				eq_fn := g.gen_map_equality_fn(field.typ)
-				fn_builder.writeln('\tif (!${eq_fn}_map_eq(a.$field.name, b.$field.name)) {')
-			}
-			.function {
-				fn_builder.writeln('\tif (*((voidptr*)(a.$field.name)) != *((voidptr*)(b.$field.name))) {')
-			}
-			else {
-				fn_builder.writeln('\tif (a.$field.name != b.$field.name) {')
-			}
+		if sym.kind == .string {
+			fn_builder.writeln('\tif (string_ne(a.$field.name, b.$field.name)) {')
+		} else if sym.kind == .struct_ && field.typ.nr_muls() == 0 {
+			eq_fn := g.gen_struct_equality_fn(field.typ)
+			fn_builder.writeln('\tif (!${eq_fn}_struct_eq(a.$field.name, b.$field.name)) {')
+		} else if sym.kind == .array && field.typ.nr_muls() == 0 {
+			eq_fn := g.gen_array_equality_fn(field.typ)
+			fn_builder.writeln('\tif (!${eq_fn}_arr_eq(a.$field.name, b.$field.name)) {')
+		} else if sym.kind == .map && field.typ.nr_muls() == 0 {
+			eq_fn := g.gen_map_equality_fn(field.typ)
+			fn_builder.writeln('\tif (!${eq_fn}_map_eq(a.$field.name, b.$field.name)) {')
+		} else if sym.kind == .function {
+			fn_builder.writeln('\tif (*((voidptr*)(a.$field.name)) != *((voidptr*)(b.$field.name))) {')
+		} else {
+			fn_builder.writeln('\tif (a.$field.name != b.$field.name) {')
 		}
 		fn_builder.writeln('\t\treturn false;')
 		fn_builder.writeln('\t}')

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3036,6 +3036,23 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 		}
 		g.expr(node.right)
 		g.write(')')
+	} else if node.op in [.eq, .ne] && left_sym.kind == .struct_ && right_sym.kind == .struct_ {
+		ptr_typ := g.gen_struct_equality_fn(left_type)
+		if node.op == .eq {
+			g.write('${ptr_typ}_struct_eq(')
+		} else if node.op == .ne {
+			g.write('!${ptr_typ}_struct_eq(')
+		}
+		if node.left_type.is_ptr() {
+			g.write('*')
+		}
+		g.expr(node.left)
+		g.write(', ')
+		if node.right_type.is_ptr() {
+			g.write('*')
+		}
+		g.expr(node.right)
+		g.write(')')
 	} else if node.op in [.key_in, .not_in] {
 		if node.op == .not_in {
 			g.write('!')

--- a/vlib/v/tests/struct_equality_test.v
+++ b/vlib/v/tests/struct_equality_test.v
@@ -1,0 +1,15 @@
+struct User {
+	name string
+	age  int
+}
+
+fn test_struct_equality() {
+	mut usr1 := User{'sanath', 28}
+	mut usr2 := User{'sanath', 28}
+	if usr1 == usr2 {
+		println('Same User')
+	} else {
+		println('Not same User')
+	}
+	assert usr1 == usr2
+}


### PR DESCRIPTION
This PR fixes struct_eq (fix #7637).

- Fixes struct_eq.
- Add test.

```v
module main

struct User {
	name string
	age  int
}

fn main() {
	mut usr1 := User{'sanath', 28}
	mut usr2 := User{'sanath', 28}
	if usr1 == usr2 {
		println('Same User')
	} else {
		println('Not same User')
	}
}

PS D:\Test\v\tt1> v run .
Same User
```