### PR TITLE
cgen: fix in array of ref struct (fix #7623)

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1272,3 +1272,16 @@ fn test__array_struct_contains() {
 	assert exists == true
 	assert not_exists == false
 }
+
+fn test__array_struct_ref_contains() {
+	mut coords := []&Coord{}
+	coord_1 := &Coord{
+		x: 1
+		y: 2
+		z: -1
+	}
+	coords << coord_1
+	exists := coord_1 in coords
+	println(exists)
+	assert exists == true
+}

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1258,7 +1258,7 @@ struct Coord {
 	z int
 }
 
-fn test__array_struct_contains() {
+fn test_array_struct_contains() {
 	mut coords := []Coord{}
 	coord_1 := Coord{
 		x: 1
@@ -1273,7 +1273,7 @@ fn test__array_struct_contains() {
 	assert not_exists == false
 }
 
-fn test__array_struct_ref_contains() {
+fn test_array_struct_ref_contains() {
 	mut coords := []&Coord{}
 	coord_1 := &Coord{
 		x: 1

--- a/vlib/v/gen/array.v
+++ b/vlib/v/gen/array.v
@@ -406,28 +406,21 @@ fn (mut g Gen) gen_array_contains_method(left_type table.Type) string {
 		mut fn_builder := strings.new_builder(512)
 		fn_builder.writeln('static bool ${fn_name}($left_type_str a, $elem_type_str v) {')
 		fn_builder.writeln('\tfor (int i = 0; i < a.len; ++i) {')
-		match elem_sym.kind {
-			.string {
-				fn_builder.writeln('\t\tif (string_eq((*(string*)array_get(a, i)), v)) {')
-			}
-			.array {
-				ptr_typ := g.gen_array_equality_fn(left_info.elem_type)
-				fn_builder.writeln('\t\tif (${ptr_typ}_arr_eq(*($elem_type_str*)array_get(a, i), v)) {')
-			}
-			.function {
-				fn_builder.writeln('\t\tif ((*(voidptr*)array_get(a, i)) == v) {')
-			}
-			.map {
-				ptr_typ := g.gen_map_equality_fn(left_info.elem_type)
-				fn_builder.writeln('\t\tif (${ptr_typ}_map_eq(*($elem_type_str*)array_get(a, i), v)) {')
-			}
-			.struct_ {
-				ptr_typ := g.gen_struct_equality_fn(left_info.elem_type)
-				fn_builder.writeln('\t\tif (${ptr_typ}_struct_eq(*($elem_type_str*)array_get(a, i), v)) {')
-			}
-			else {
-				fn_builder.writeln('\t\tif ((*($elem_type_str*)array_get(a, i)) == v) {')
-			}
+		if elem_sym.kind == .string {
+			fn_builder.writeln('\t\tif (string_eq((*(string*)array_get(a, i)), v)) {')
+		} else if elem_sym.kind == .array && left_info.elem_type.nr_muls() == 0 {
+			ptr_typ := g.gen_array_equality_fn(left_info.elem_type)
+			fn_builder.writeln('\t\tif (${ptr_typ}_arr_eq(*($elem_type_str*)array_get(a, i), v)) {')
+		} else if elem_sym.kind == .function {
+			fn_builder.writeln('\t\tif ((*(voidptr*)array_get(a, i)) == v) {')
+		} else if elem_sym.kind == .map && left_info.elem_type.nr_muls() == 0 {
+			ptr_typ := g.gen_map_equality_fn(left_info.elem_type)
+			fn_builder.writeln('\t\tif (${ptr_typ}_map_eq(*($elem_type_str*)array_get(a, i), v)) {')
+		} else if elem_sym.kind == .struct_ && left_info.elem_type.nr_muls() == 0 {
+			ptr_typ := g.gen_struct_equality_fn(left_info.elem_type)
+			fn_builder.writeln('\t\tif (${ptr_typ}_struct_eq(*($elem_type_str*)array_get(a, i), v)) {')
+		} else {
+			fn_builder.writeln('\t\tif ((*($elem_type_str*)array_get(a, i)) == v) {')
 		}
 		fn_builder.writeln('\t\t\treturn true;')
 		fn_builder.writeln('\t\t}')


### PR DESCRIPTION
This PR fixes in array of ref struct (fix #7623).

- Fixes in array of ref struct.
- Add test.

```v
module main

struct Coord {
	x int
	y int
	z int
}

fn main() {
	mut coords := []&Coord{}
	coord_1 := &Coord{
		x: 1
		y: 2
		z: -1
	}
	coords << coord_1
	exists := coord_1 in coords
	println(exists)
}

PS D:\Test\v\tt1> v run .
true
```