### PR TITLE
parser: minor cleanup of `parse_block_no_scope()`

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -364,15 +364,15 @@ pub fn (mut p Parser) parse_block_no_scope(is_top_level bool) []ast.Stmt {
 	p.check(.lcbr)
 	mut stmts := []ast.Stmt{}
 	if p.tok.kind != .rcbr {
-		mut c := 0
+		mut count := 0
 		for p.tok.kind !in [.eof, .rcbr] {
 			stmts << p.stmt(is_top_level)
-			c++
-			if c % 100000 == 0 {
-				eprintln('parsed $c statements so far from fn $p.cur_fn_name ...')
+			count++
+			if count % 100000 == 0 {
+				eprintln('parsed $count statements so far from fn $p.cur_fn_name ...')
 			}
-			if c > 1000000 {
-				p.error_with_pos('parsed over $c statements from fn $p.cur_fn_name, the parser is probably stuck',
+			if count > 1000000 {
+				p.error_with_pos('parsed over $count statements from fn $p.cur_fn_name, the parser is probably stuck',
 					p.tok.position())
 				return []
 			}


### PR DESCRIPTION
This PR makes minor cleanup of `parse_block_no_scope()`.

- Using variable `count` instead of `c`.