### PR TITLE
cgen: fix struct equality (fix #7637)

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3036,6 +3036,23 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 		}
 		g.expr(node.right)
 		g.write(')')
+	} else if node.op in [.eq, .ne] && left_sym.kind == .struct_ && right_sym.kind == .struct_ {
+		ptr_typ := g.gen_struct_equality_fn(left_type)
+		if node.op == .eq {
+			g.write('${ptr_typ}_struct_eq(')
+		} else if node.op == .ne {
+			g.write('!${ptr_typ}_struct_eq(')
+		}
+		if node.left_type.is_ptr() {
+			g.write('*')
+		}
+		g.expr(node.left)
+		g.write(', ')
+		if node.right_type.is_ptr() {
+			g.write('*')
+		}
+		g.expr(node.right)
+		g.write(')')
 	} else if node.op in [.key_in, .not_in] {
 		if node.op == .not_in {
 			g.write('!')

--- a/vlib/v/tests/struct_equality_test.v
+++ b/vlib/v/tests/struct_equality_test.v
@@ -1,0 +1,15 @@
+struct User {
+	name string
+	age  int
+}
+
+fn test_struct_equality() {
+	mut usr1 := User{'sanath', 28}
+	mut usr2 := User{'sanath', 28}
+	if usr1 == usr2 {
+		println('Same User')
+	} else {
+		println('Not same User')
+	}
+	assert usr1 == usr2
+}


### PR DESCRIPTION
This PR fixes struct_eq (fix #7637).

- Fixes struct_eq.
- Add test.

```v
module main

struct User {
	name string
	age  int
}

fn main() {
	mut usr1 := User{'sanath', 28}
	mut usr2 := User{'sanath', 28}
	if usr1 == usr2 {
		println('Same User')
	} else {
		println('Not same User')
	}
}

PS D:\Test\v\tt1> v run .
Same User
```