### PR TITLE
checker: update check for arr=arr1

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -352,6 +352,7 @@ fn test_mut_arg() {
 
 fn test_clone() {
 	nums := [1, 2, 3, 4, 100]
+	_ := nums
 	nums2 := nums.clone()
 	assert nums2.len == 5
 	assert nums.str() == '[1, 2, 3, 4, 100]'

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -352,7 +352,7 @@ fn test_mut_arg() {
 
 fn test_clone() {
 	nums := [1, 2, 3, 4, 100]
-	_ := nums
+	_ = nums
 	nums2 := nums.clone()
 	assert nums2.len == 5
 	assert nums.str() == '[1, 2, 3, 4, 100]'

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2293,7 +2293,7 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 			continue
 		}
 		if left_sym.kind == .array && !c.inside_unsafe && assign_stmt.op in [.assign, .decl_assign] &&
-			right_sym.kind == .array && left is ast.Ident && right is ast.Ident {
+			right_sym.kind == .array && (left is ast.Ident && !left.is_blank_ident()) && right is ast.Ident {
 			// Do not allow `a = b`, only `a = b.clone()`
 			c.error('use `array2 = array1.clone()` instead of `array2 = array1` (or use `unsafe`)',
 				assign_stmt.pos)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2293,7 +2293,8 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 			continue
 		}
 		if left_sym.kind == .array && !c.inside_unsafe && assign_stmt.op in [.assign, .decl_assign] &&
-			right_sym.kind == .array && (left is ast.Ident && !left.is_blank_ident()) && right is ast.Ident {
+			right_sym.kind == .array &&
+			(left is ast.Ident && !left.is_blank_ident()) && right is ast.Ident {
 			// Do not allow `a = b`, only `a = b.clone()`
 			c.error('use `array2 = array1.clone()` instead of `array2 = array1` (or use `unsafe`)',
 				assign_stmt.pos)


### PR DESCRIPTION
I saw that `_ = arr` was giving a warning during today's livestream so I decided to fix it.