### PR TITLE
fmt: heavily refactor and improve/fix logic for structs that use short args syntax

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1931,41 +1931,38 @@ pub fn (mut f Fmt) struct_init(it ast.StructInit) {
 	} else {
 		use_short_args := f.use_short_fn_args
 		f.use_short_fn_args = false
+		mut multiline_short_args := false
 		if !use_short_args {
 			f.writeln('$name{')
 		}
+		init_start := f.out.len
 		f.comments(it.pre_comments, inline: true, has_nl: true, level: .indent)
 		f.indent++
-		mut short_args_multiline := false
-		mut field_start_positions := []int{}
-		for i, field in it.fields {
-			field_start_positions << f.out.len
-			f.write('$field.name: ')
-			f.prefix_expr_cast_expr(field.expr)
-			if field.expr is ast.StructInit {
-				short_args_multiline = true
-			}
-			f.comments(field.comments, inline: true, has_nl: false, level: .indent)
-			if use_short_args {
-				if i < it.fields.len - 1 {
-					f.write(', ')
+		short_args_loop: for {
+			for i, field in it.fields {
+				f.write('$field.name: ')
+				f.prefix_expr_cast_expr(field.expr)
+				f.comments(field.comments, inline: true, has_nl: false, level: .indent)
+				if use_short_args && !multiline_short_args {
+					if i < it.fields.len - 1 {
+						f.write(', ')
+					}
+				} else {
+					f.writeln('')
 				}
-			} else {
-				f.writeln('')
-			}
-			f.comments(field.next_comments, inline: false, has_nl: true, level: .keep)
-		}
-		if use_short_args {
-			if f.line_len > max_len[3] || short_args_multiline {
-				mut fields := []string{}
-				for pos in field_start_positions.reverse() {
-					fields << f.out.cut_last(f.out.len - pos).trim_suffix(', ')
-				}
-				f.writeln('')
-				for field in fields.reverse() {
-					f.writeln(field)
+				f.comments(field.next_comments, inline: false, has_nl: true, level: .keep)
+				if use_short_args && !multiline_short_args &&
+					(field.comments.len > 0 ||
+					field.next_comments.len > 0 || !expr_is_single_line(field.expr) || f.line_len > max_len.last()) {
+					multiline_short_args = true
+					f.out.go_back_to(init_start)
+					f.line_len = init_start
+					f.remove_new_line()
+					f.writeln('')
+					continue short_args_loop
 				}
 			}
+			break
 		}
 		f.indent--
 		if !use_short_args {

--- a/vlib/v/fmt/tests/fn_trailing_arg_syntax_keep.vv
+++ b/vlib/v/fmt/tests/fn_trailing_arg_syntax_keep.vv
@@ -18,6 +18,21 @@ fn main() {
 	})
 	bar_func(x: 'bar', y: 2, z: 3, a: 4)
 	func_from_other_file(val: 'something')
+	// pre comment
+	bar_func(x: 'struct has a pre comment')
+	bar_func(
+		x: 'first field'
+		// comment between fields
+		y: 100
+	)
+	bar_func(
+		x: 'Look! A comment to my right.' // comment after field
+	)
+	func_from_other_file(
+		xyz: AnotherStruct{
+			f: 'here'
+		}
+	)
 }
 
 fn bar_func(bar Bar) {

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -459,12 +459,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		method.comments = mcomments
 		methods << method
 		// println('register method $name')
-		ts.register_method(
-			name: name
-			params: args
-			return_type: method.return_type
-			is_pub: true
-		)
+		ts.register_method(name: name, params: args, return_type: method.return_type, is_pub: true)
 	}
 	p.top_level_statement_end()
 	p.check(.rcbr)

--- a/vlib/v/table/types.v
+++ b/vlib/v/table/types.v
@@ -519,12 +519,7 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 	t.register_type_symbol(kind: .chan, name: 'chan', cname: 'chan', mod: 'builtin')
 	t.register_type_symbol(kind: .size_t, name: 'size_t', cname: 'size_t', mod: 'builtin')
 	t.register_type_symbol(kind: .any, name: 'any', cname: 'any', mod: 'builtin')
-	t.register_type_symbol(
-		kind: .any_float
-		name: 'any_float'
-		cname: 'any_float'
-		mod: 'builtin'
-	)
+	t.register_type_symbol(kind: .any_float, name: 'any_float', cname: 'any_float', mod: 'builtin')
 	t.register_type_symbol(kind: .any_int, name: 'any_int', cname: 'any_int', mod: 'builtin')
 }
 


### PR DESCRIPTION
Until now comments were problematic. And the check for fields that have multi line exprs was very limited.

In general I refactored the code to be somewhat similar to the logic I used for single line ifs.