### PR TITLE
fmt: fix unexpected `comment`, expecting struct key for trailing arg syntax

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -250,8 +250,8 @@ pub struct StructInit {
 pub:
 	pos          token.Position
 	is_short     bool
-	pre_comments []Comment
 pub mut:
+	pre_comments []Comment
 	typ          table.Type
 	fields       []StructInitField
 	embeds       []StructInitEmbed

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1937,9 +1937,9 @@ pub fn (mut f Fmt) struct_init(it ast.StructInit) {
 			f.writeln('$name{')
 		}
 		init_start := f.out.len
-		f.comments(it.pre_comments, inline: true, has_nl: true, level: .indent)
 		f.indent++
 		short_args_loop: for {
+			f.comments(it.pre_comments, inline: true, has_nl: true, level: .keep)
 			for i, field in it.fields {
 				f.write('$field.name: ')
 				f.prefix_expr_cast_expr(field.expr)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1932,9 +1932,13 @@ pub fn (mut f Fmt) struct_init(it ast.StructInit) {
 	} else {
 		use_short_args := f.use_short_fn_args
 		f.use_short_fn_args = false
-		mut multiline_short_args := false
+		mut multiline_short_args := it.pre_comments.len > 0
 		if !use_short_args {
 			f.writeln('$name{')
+		} else {
+			if multiline_short_args {
+				f.writeln('')
+			}
 		}
 		init_start := f.out.len
 		f.indent++

--- a/vlib/v/fmt/tests/fn_trailing_arg_syntax_expected.vv
+++ b/vlib/v/fmt/tests/fn_trailing_arg_syntax_expected.vv
@@ -20,6 +20,15 @@ fn main() {
 			x: 0
 		}
 	)
+	ui.row(
+		// stretch: true
+		margin: {
+			top: 10
+			left: 10
+			right: 10
+			bottom: 10
+		}
+	)
 }
 
 fn bar_func(bar Bar) {

--- a/vlib/v/fmt/tests/fn_trailing_arg_syntax_input.vv
+++ b/vlib/v/fmt/tests/fn_trailing_arg_syntax_input.vv
@@ -14,6 +14,10 @@ fn main() {
 	bar_func(x: 'some string', b: Baz{
 		x: 0
 	})
+	ui.row({
+		//stretch: true
+		margin: {top:10,left:10,right:10,bottom:10}
+	})
 }
 
 fn bar_func(bar Bar) {

--- a/vlib/v/fmt/tests/fn_trailing_arg_syntax_keep.vv
+++ b/vlib/v/fmt/tests/fn_trailing_arg_syntax_keep.vv
@@ -18,8 +18,10 @@ fn main() {
 	})
 	bar_func(x: 'bar', y: 2, z: 3, a: 4)
 	func_from_other_file(val: 'something')
-	// pre comment
-	bar_func(x: 'struct has a pre comment')
+	bar_func(
+		// pre comment
+		x: 'struct has a pre comment'
+	)
 	bar_func(
 		x: 'first field'
 		// comment between fields

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -125,7 +125,11 @@ pub fn (mut p Parser) call_args() []ast.CallArg {
 		}
 		mut comments := p.eat_comments()
 		arg_start_pos := p.tok.position()
-		e := p.expr(0)
+		mut e := p.expr(0)
+		if mut e is ast.StructInit {
+			e.pre_comments << comments
+			comments = []ast.Comment{}
+		}
 		pos := arg_start_pos.extend(p.prev_tok.position())
 		comments << p.eat_comments()
 		args << ast.CallArg{

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -197,7 +197,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 				// it should be a struct
 				if p.peek_tok.kind == .pipe {
 					node = p.assoc()
-				} else if p.peek_tok.kind == .colon || p.tok.kind == .rcbr {
+				} else if p.peek_tok.kind == .colon || p.tok.kind in [.rcbr, .comment] {
 					node = p.struct_init(true) // short_syntax: true
 				} else if p.tok.kind == .name {
 					p.next()


### PR DESCRIPTION
Such code pieces gave the error. Now they work.
```v
ui.row({
    //stretch: true
    margin: {top:10,left:10,right:10,bottom:10}
})
```

Also the structs pre_comments are not put before the call anymore.