### PR TITLE
ci: add test-fixed with -fsanitize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,8 @@ jobs:
         ./v -silent test-fixed
     - name: Fixed tests (-prod)
       run: ./v -o vprod -prod cmd/v && ./vprod -silent test-fixed
+    - name: Fixed tests (-fsanitize)
+      run: ./v -cflags -fsanitize=memory
     - name: Build examples
       run: ./v build-examples
     - name: Build examples with -autofree

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,8 @@ jobs:
          ## sudo apt-get install --quiet -y libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
     - name: Build V
       run: make -j4 && ./v -cc clang -cg -cflags -Werror -o v cmd/v
+    - name: Fixed tests (-fsanitize=memory)
+      run: ./v -cflags -fsanitize=memory test-fixed
     - name: Valgrind
       run: valgrind --error-exitcode=1 ./v -o v.c cmd/v
     - name: Run sanitizers
@@ -344,8 +346,6 @@ jobs:
         ./v -silent test-fixed
     - name: Fixed tests (-prod)
       run: ./v -o vprod -prod cmd/v && ./vprod -silent test-fixed
-    - name: Fixed tests (-fsanitize)
-      run: ./v -cflags -fsanitize=memory
     - name: Build examples
       run: ./v build-examples
     - name: Build examples with -autofree

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,8 +325,6 @@ jobs:
          ## sudo apt-get install --quiet -y libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
     - name: Build V
       run: make -j4 && ./v -cc clang -cg -cflags -Werror -o v cmd/v
-    - name: Fixed tests (-fsanitize=memory)
-      run: ./v -cflags -fsanitize=memory test-fixed
     - name: Valgrind
       run: valgrind --error-exitcode=1 ./v -o v.c cmd/v
     - name: Run sanitizers
@@ -346,6 +344,8 @@ jobs:
         ./v -silent test-fixed
     - name: Fixed tests (-prod)
       run: ./v -o vprod -prod cmd/v && ./vprod -silent test-fixed
+    - name: Fixed tests (-fsanitize=memory)
+      run: ./v -cflags -fsanitize=memory test-fixed
     - name: Build examples
       run: ./v build-examples
     - name: Build examples with -autofree

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,8 +344,6 @@ jobs:
         ./v -silent test-fixed
     - name: Fixed tests (-prod)
       run: ./v -o vprod -prod cmd/v && ./vprod -silent test-fixed
-    - name: Fixed tests (-fsanitize=memory)
-      run: ./v -cflags -fsanitize=memory test-fixed
     - name: Build examples
       run: ./v build-examples
     - name: Build examples with -autofree
@@ -378,6 +376,75 @@ jobs:
         ../../vprod -backend x64 -o 1m 1m.v
         echo "Running it..."
         ls
+
+  ubuntu-clang-sanitize-undefined:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      VFLAGS: -cc clang
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Install dependencies
+      run: |
+         sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list;
+         sudo apt-get update;
+         sudo apt-get install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
+         sudo apt-get install --quiet -y libglfw3 libglfw3-dev  libfreetype6-dev  libxi-dev libxcursor-dev libasound2-dev
+         sudo apt-get install clang
+         ## sudo apt-get install --quiet -y libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
+    - name: Build V
+      run: make -j4 && ./v -cc clang -cg -cflags -Werror -o v cmd/v
+    - name: Fixed tests (-fsanitize=undefined)
+      run: ./v -cflags -fsanitize=undefined test-fixed
+    
+  ubuntu-clang-sanitize-address:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      VFLAGS: -cc clang
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Install dependencies
+      run: |
+         sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list;
+         sudo apt-get update;
+         sudo apt-get install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
+         sudo apt-get install --quiet -y libglfw3 libglfw3-dev  libfreetype6-dev  libxi-dev libxcursor-dev libasound2-dev
+         sudo apt-get install clang
+         ## sudo apt-get install --quiet -y libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
+    - name: Build V
+      run: make -j4 && ./v -cc clang -cg -cflags -Werror -o v cmd/v
+    - name: Fixed tests (-fsanitize=address)
+      run: ./v -cflags -fsanitize=address test-fixed
+
+  ubuntu-clang-sanitize-memory:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      VFLAGS: -cc clang
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Install dependencies
+      run: |
+         sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list;
+         sudo apt-get update;
+         sudo apt-get install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
+         sudo apt-get install --quiet -y libglfw3 libglfw3-dev  libfreetype6-dev  libxi-dev libxcursor-dev libasound2-dev
+         sudo apt-get install clang
+         ## sudo apt-get install --quiet -y libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
+    - name: Build V
+      run: make -j4 && ./v -cc clang -cg -cflags -Werror -o v cmd/v
+    - name: Fixed tests (-fsanitize=memory)
+      run: ./v -cflags -fsanitize=memory test-fixed
 
 #  ubuntu-autofree-selfcompile:
 #    runs-on: ubuntu-18.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,7 +421,7 @@ jobs:
     - name: Build V
       run: make -j4 && ./v -cc clang -cg -cflags -Werror -o v cmd/v
     - name: Fixed tests (-fsanitize=address)
-      run: ./v -cflags -fsanitize=address test-fixed
+      run: ASAN_OPTIONS=detect_leaks=0 ./v -cflags -fsanitize=address test-fixed
 
   ubuntu-clang-sanitize-memory:
     runs-on: ubuntu-latest

--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -17,7 +17,8 @@ const (
 		'vlib/orm/orm_test.v',
 		'vlib/sqlite/sqlite_test.v',
 		'vlib/vweb/tests/vweb_test.v',
-		'vlib/x/websocket/websocket_test.v'
+		'vlib/x/websocket/websocket_test.v',
+		'vlib/v/tests/unsafe_test.v'
 	]
 	skip_with_fsanitize_address  = [
 		'vlib/encoding/base64/base64_test.v',

--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -5,8 +5,8 @@ import testing
 import v.pref
 
 const (
-	skip_with_sanitize  = [
-		'vlib/x/websocket/websocket_test.v'
+	skip_with_fsanitize_memory  = [
+		'vlib/x/websocket/websocket_test.v',
 		'vlib/encoding/csv/reader_test.v',
 		'vlib/net/tcp_test.v',
 		'vlib/net/tcp_simple_client_server_test.v',
@@ -17,8 +17,41 @@ const (
 		'vlib/orm/orm_test.v',
 		'vlib/sqlite/sqlite_test.v',
 		'vlib/vweb/tests/vweb_test.v',
-		'vlib/x/websocket/websocket_test.v',
-		'vlib/v/tests/unsafe_test.v'
+		'vlib/x/websocket/websocket_test.v'
+	]
+	skip_with_fsanitize_address  = [
+		'vlib/encoding/base64/base64_test.v',
+		'vlib/encoding/csv/reader_test.v',
+		'vlib/flag/flag_test.v',
+		'vlib/io/util/util_test.v',
+		'vlib/io/reader_test.v',
+		'vlib/json/json_test.v',
+		'vlib/net/http/cookie_test.v',
+		'vlib/os/inode_test.v',
+		'vlib/os/os_test.v',
+		'vlib/regex/regex_test.v',
+		'vlib/semver/semver_test.v',
+		'vlib/sync/channel_opt_propagate_test.v',
+		'vlib/time/parse_test.v',
+		'vlib/v/fmt/fmt_keep_test.v',
+		'vlib/v/fmt/fmt_test.v',
+		'vlib/v/tests/array_init_test.v',
+		'vlib/v/doc/doc_test.v',
+		'vlib/v/tests/const_test.v',
+		'vlib/v/tests/fn_multiple_returns_test.v',
+		'vlib/v/tests/inout/compiler_test.v',
+		'vlib/v/tests/option_default_values_test.v',
+		'vlib/v/tests/option_test.v',
+		'vlib/v/tests/ptr_arithmetic_test.v',
+		'vlib/v/tests/str_gen_test.v',
+		'vlib/v/tests/unsafe_test.v',
+		'vlib/v/tests/vmod_parser_test.v',
+		'vlib/v/vcache/vcache_test.v',
+		'vlib/x/json2/decoder_test.v',
+		'vlib/x/websocket/websocket_test.v'
+	]
+	skip_with_fsanitize_undefined  = [
+		'vlib/encoding/csv/reader_test.v'
 	]
 	skip_test_files     = [
 		'vlib/net/http/http_httpbin_test.v',
@@ -68,14 +101,28 @@ fn main() {
 	mut tsession := testing.new_test_session(cmd_prefix)
 	tsession.files << all_test_files
 	tsession.skip_files << skip_test_files
-	mut sanitize := false
+	mut sanitize_memory := false
+	mut sanitize_address := false
+	mut sanitize_undefined := false
 	for arg in args {
-		if '-fsanitize' in arg {
-			sanitize = true
+		if '-fsanitize=memory' in arg {
+			sanitize_memory = true
+		}
+		if '-fsanitize=address' in arg {
+			sanitize_address = true
+		}
+		if '-fsanitize=undefined' in arg {
+			sanitize_address = true
 		}
 	}
-	if sanitize {
-		tsession.skip_files << skip_with_sanitize
+	if sanitize_memory {
+		tsession.skip_files << skip_with_fsanitize_memory
+	}
+	if sanitize_address {
+		tsession.skip_files << skip_with_fsanitize_address
+	}
+	if sanitize_undefined {
+		tsession.skip_files << skip_with_fsanitize_undefined
 	}
 	//
 	if os.getenv('V_CI_MUSL').len > 0 {

--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -7,17 +7,17 @@ import v.pref
 const (
 	skip_with_sanitize  = [
 		'vlib/x/websocket/websocket_test.v'
-		// 'vlib/encoding/csv/reader_test.v',
-		// 'vlib/net/tcp_test.v',
-		// 'vlib/net/tcp_simple_client_server_test.v',
-		// 'vlib/net/udp_test.v',
-		// 'vlib/net/http/cookie_test.v',
-		// 'vlib/net/http/http_test.v',
-		// 'vlib/net/http/status_test.v',
-		// 'vlib/orm/orm_test.v',
-		// 'vlib/sqlite/sqlite_test.v',
-		// 'vlib/vweb/tests/vweb_test.v',
-		// 'vlib/x/websocket/websocket_test.v'
+		'vlib/encoding/csv/reader_test.v',
+		'vlib/net/tcp_test.v',
+		'vlib/net/tcp_simple_client_server_test.v',
+		'vlib/net/udp_test.v',
+		'vlib/net/http/cookie_test.v',
+		'vlib/net/http/http_test.v',
+		'vlib/net/http/status_test.v',
+		'vlib/orm/orm_test.v',
+		'vlib/sqlite/sqlite_test.v',
+		'vlib/vweb/tests/vweb_test.v',
+		'vlib/x/websocket/websocket_test.v'
 	]
 	skip_test_files     = [
 		'vlib/net/http/http_httpbin_test.v',

--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -17,7 +17,8 @@ const (
 		'vlib/orm/orm_test.v',
 		'vlib/sqlite/sqlite_test.v',
 		'vlib/vweb/tests/vweb_test.v',
-		'vlib/x/websocket/websocket_test.v'
+		'vlib/x/websocket/websocket_test.v',
+		'vlib/v/tests/unsafe_test.v'
 	]
 	skip_test_files     = [
 		'vlib/net/http/http_httpbin_test.v',

--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -6,7 +6,7 @@ import v.pref
 
 const (
 	skip_with_sanitize  = [
-		// 'vlib/x/websocket/websocket_test.v',
+		'vlib/x/websocket/websocket_test.v'
 		// 'vlib/encoding/csv/reader_test.v',
 		// 'vlib/net/tcp_test.v',
 		// 'vlib/net/tcp_simple_client_server_test.v',

--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -5,6 +5,20 @@ import testing
 import v.pref
 
 const (
+	skip_with_sanitize  = [
+		// 'vlib/x/websocket/websocket_test.v',
+		// 'vlib/encoding/csv/reader_test.v',
+		// 'vlib/net/tcp_test.v',
+		// 'vlib/net/tcp_simple_client_server_test.v',
+		// 'vlib/net/udp_test.v',
+		// 'vlib/net/http/cookie_test.v',
+		// 'vlib/net/http/http_test.v',
+		// 'vlib/net/http/status_test.v',
+		// 'vlib/orm/orm_test.v',
+		// 'vlib/sqlite/sqlite_test.v',
+		// 'vlib/vweb/tests/vweb_test.v',
+		// 'vlib/x/websocket/websocket_test.v'
+	]
 	skip_test_files     = [
 		'vlib/net/http/http_httpbin_test.v',
 	]
@@ -53,6 +67,15 @@ fn main() {
 	mut tsession := testing.new_test_session(cmd_prefix)
 	tsession.files << all_test_files
 	tsession.skip_files << skip_test_files
+	mut sanitize := false
+	for arg in args {
+		if '-fsanitize' in arg {
+			sanitize = true
+		}
+	}
+	if sanitize {
+		tsession.skip_files << skip_with_sanitize
+	}
 	//
 	if os.getenv('V_CI_MUSL').len > 0 {
 		tsession.skip_files << skip_on_musl


### PR DESCRIPTION
This PR adds jobs for test-fixed with `-fsanitize=memory`, `-fsanitize=address` and `-fsanitize=undefined`. We currently have to skips a lot of tests. This is an area of improvement. They are in three separate jobs because they take long.

We could also do this for the examples and where the compiler is compiled with these flags.
