### PR TITLE
cgen: fix array of array/map init (fix #7597)

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1291,3 +1291,19 @@ fn test_array_struct_ref_index() {
 	println(coords.index(coord_1))
 	assert coords.index(coord_1) == 0
 }
+
+fn test_array_of_array_append() {
+	mut x := [][]int{len: 4}
+	println(x) // OK
+	x[2] << 123 // RTE
+	println(x)
+	assert '$x' == '[[], [], [123], []]'
+}
+
+fn test_array_of_map_insert() {
+	mut x := []map[string]int{len: 4}
+	println(x) // OK
+	x[2]['123'] = 123 // RTE
+	println(x)
+	assert '$x' == "[{}, {}, {'123': 123}, {}]"
+}

--- a/vlib/v/gen/array.v
+++ b/vlib/v/gen/array.v
@@ -80,9 +80,9 @@ fn (mut g Gen) array_init(it ast.ArrayInit) {
 			g.write('_SLIT("")')
 			g.write('})')
 		} else if it.has_len && elem_sym.kind in [.array, .map] {
-			g.write('(voidptr)&(')
+			g.write('(voidptr)&($elem_type_str[]){')
 			g.write(g.type_default(it.elem_type))
-			g.write('))')
+			g.write('}[0])')
 		} else {
 			g.write('0)')
 		}

--- a/vlib/v/gen/array.v
+++ b/vlib/v/gen/array.v
@@ -79,7 +79,7 @@ fn (mut g Gen) array_init(it ast.ArrayInit) {
 			g.write('&($elem_type_str[]){')
 			g.write('_SLIT("")')
 			g.write('})')
-		} else if elem_sym.kind in [.array, .map] {
+		} else if it.has_len && elem_sym.kind in [.array, .map] {
 			g.write('(voidptr)&')
 			g.write(g.type_default(it.elem_type))
 			g.write(')')

--- a/vlib/v/gen/array.v
+++ b/vlib/v/gen/array.v
@@ -79,6 +79,10 @@ fn (mut g Gen) array_init(it ast.ArrayInit) {
 			g.write('&($elem_type_str[]){')
 			g.write('_SLIT("")')
 			g.write('})')
+		} else if elem_sym.kind in [.array, .map] {
+			g.write('(voidptr)&')
+			g.write(g.type_default(it.elem_type))
+			g.write(')')
 		} else {
 			g.write('0)')
 		}

--- a/vlib/v/gen/array.v
+++ b/vlib/v/gen/array.v
@@ -80,9 +80,9 @@ fn (mut g Gen) array_init(it ast.ArrayInit) {
 			g.write('_SLIT("")')
 			g.write('})')
 		} else if it.has_len && elem_sym.kind in [.array, .map] {
-			g.write('(voidptr)&')
+			g.write('(voidptr)&(')
 			g.write(g.type_default(it.elem_type))
-			g.write(')')
+			g.write('))')
 		} else {
 			g.write('0)')
 		}


### PR DESCRIPTION
This PR fixes array of array/map init (fix #7597).

- Fixes array of array/map init.
- Add tests.

```v
fn main() {
	mut x := [][]int{len: 10}
	println(x) // OK
	x[3] << 123 // RTE
	println(x)
}

PS D:\Test\v\tt1> v run .
[[], [], [], [], [], [], [], [], [], []]
[[], [], [], [123], [], [], [], [], [], []]
```
```v
fn main() {
	mut x := []map[string]int{len: 10}
	println(x) // OK
	x[3]['123'] = 123 // RTE
	println(x)
}

PS D:\Test\v\tt1> v run .
[{}, {}, {}, {}, {}, {}, {}, {}, {}, {}]
[{}, {}, {}, {'123': 123}, {}, {}, {}, {}, {}, {}]
```