### PR TITLE
run: Ignore flags after file.v when v run and only pass to script

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -394,6 +394,9 @@ pub fn parse_args(args []string) (&Preferences, string) {
 					if command == '' {
 						command = arg
 						command_pos = i
+						if command == 'run' {
+							break
+						}
 					}
 					continue
 				}


### PR DESCRIPTION
```v
import os
println(os.args)
```

## Before: 
```
$ v run main.v -v
# Long V's verbose log ...
# ...
# ...
['/home/zakuro/src/github.com/zakuro9715/v/main', '-v']
```

This is inconvenient and confusing when develop cli tools.

## After
```
$ v run main.v -v
['/home/zakuro/src/github.com/zakuro9715/v/main', '-v']
```

All build flags can still be used by placing the flag before 'run'

```
$ v -v run main.v
# Long V's verbose log ...
# ...
# ...
['/home/zakuro/src/github.com/zakuro9715/v/main', '-v']
```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
