### PR TITLE
checker: ban any types outside buitlin

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -293,17 +293,17 @@ pub:
 	is_variadic     bool
 	is_anon         bool
 	receiver        Field
-	receiver_pos    token.Position
+	receiver_pos    token.Position // receiver's position
 	is_method       bool
-	method_type_pos token.Position
+	method_type_pos token.Position // `User` in `(u User)` position
 	method_idx      int
 	rec_mut         bool // is receiver mutable
 	rec_share       table.ShareType
 	language        table.Language
 	no_body         bool // just a definition `fn C.malloc()`
 	is_builtin      bool // this function is defined in builtin/strconv
-	pos             token.Position
-	body_pos        token.Position
+	pos             token.Position // function declaration position
+	body_pos        token.Position // function body's position
 	file            string
 	is_generic      bool
 	is_direct_arr   bool // direct array access

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -293,9 +293,9 @@ pub:
 	is_variadic     bool
 	is_anon         bool
 	receiver        Field
-	receiver_pos    token.Position // receiver's position
+	receiver_pos    token.Position // `(u User)` in `fn (u User) name()` position
 	is_method       bool
-	method_type_pos token.Position // `User` in `(u User)` position
+	method_type_pos token.Position // `User` in ` fn (u User)` position
 	method_idx      int
 	rec_mut         bool // is receiver mutable
 	rec_share       table.ShareType
@@ -303,7 +303,7 @@ pub:
 	no_body         bool // just a definition `fn C.malloc()`
 	is_builtin      bool // this function is defined in builtin/strconv
 	pos             token.Position // function declaration position
-	body_pos        token.Position // function body's position
+	body_pos        token.Position // function bodys position
 	file            string
 	is_generic      bool
 	is_direct_arr   bool // direct array access

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -53,8 +53,8 @@ pub mut:
 	scope_returns                    bool
 	mod                              string // current module name
 	is_builtin_mod                   bool // are we in `builtin`?
-	inside_unsafe                    bool // are we inside `unsafe{}`?
-	inside_const                     bool /// are we in `const` block?
+	inside_unsafe                    bool
+	inside_const                     bool
 	skip_flags                       bool // should `#flag` and `#include` be skipped
 	cur_generic_type                 table.Type
 mut:

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -387,7 +387,8 @@ pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
 					c.error('field name `$field.name` duplicate', field.pos)
 				}
 			}
-			if sym.kind in [.placeholder, .any_int, .any_float] && decl.language != .c && !sym.name.starts_with('C.') {
+			if sym.kind in [.placeholder, .any_int, .any_float] &&
+				decl.language != .c && !sym.name.starts_with('C.') {
 				c.error(util.new_suggestion(sym.name, c.table.known_type_names()).say('unknown type `$sym.name`'),
 					field.type_pos)
 			}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4848,12 +4848,12 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				c.error('unknown type `$sym.name`', node.method_type_pos)
 			}
 			if sym.kind in [table.Kind.any_int, .any_float] && !c.is_builtin_mod {
-				c.error('cannot use type `$sym.name`', node.method_type_pos)
+				c.error('cannot use type `$sym.name` as parameter type', node.pos)
 			}
 		}
 	}
 	if node.return_type in [table.any_flt_type, table.any_int_type] {
-		c.error('cannot `any_int` and `any_float` as return type', node.pos)
+		c.error('cannot use `any_int` and `any_float` as return type', node.pos)
 	}
 	if node.language == .v && node.is_method && node.name == 'str' {
 		if node.return_type != table.string_type {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -387,10 +387,16 @@ pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
 					c.error('field name `$field.name` duplicate', field.pos)
 				}
 			}
-			if sym.kind in [.placeholder, .any_int, .any_float] &&
+			if sym.kind == .placeholder &&
 				decl.language != .c && !sym.name.starts_with('C.') {
 				c.error(util.new_suggestion(sym.name, c.table.known_type_names()).say('unknown type `$sym.name`'),
 					field.type_pos)
+			}
+			// Separate error condition for `any_int` and `any_float` because `util.suggestion` may give different
+			// suggestionns due to f32 comparision issue. 
+			if sym.kind in [.any_int, .any_float] {
+				msg := if sym.kind == .any_int {'unknown type `$sym.name`.\nDid you mean `int`?'} else {'unknown type `$sym.name`.\nDid you mean `f64`?'}
+				c.error(msg, field.type_pos)
 			}
 			if sym.kind == .array {
 				array_info := sym.array_info()

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4840,13 +4840,15 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 		// Make sure all types are valid
 		for arg in node.params {
 			sym := c.table.get_type_symbol(arg.typ)
-			if sym.kind == .placeholder || (sym.kind in [table.Kind.any_int, .any_float] && !c.is_builtin_mod)  {
+			if sym.kind == .placeholder ||
+				(sym.kind in [table.Kind.any_int, .any_float] && !c.is_builtin_mod) {
 				c.error('unknown type `$sym.name`', node.pos)
 			}
 		}
 	}
 	return_sym := c.table.get_type_symbol(node.return_type)
-	if node.language == .v && return_sym.kind in [.placeholder, .any_int, .any_float] && return_sym.language == .v {
+	if node.language == .v &&
+		return_sym.kind in [.placeholder, .any_int, .any_float] && return_sym.language == .v {
 		c.error('unknown return type `$return_sym.name`', node.pos)
 	}
 	if node.language == .v && node.is_method && node.name == 'str' {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -387,12 +387,9 @@ pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
 					c.error('field name `$field.name` duplicate', field.pos)
 				}
 			}
-			if sym.kind == .placeholder && decl.language != .c && !sym.name.starts_with('C.') {
+			if sym.kind in [.placeholder, .any_int, .any_float] && decl.language != .c && !sym.name.starts_with('C.') {
 				c.error(util.new_suggestion(sym.name, c.table.known_type_names()).say('unknown type `$sym.name`'),
 					field.type_pos)
-			}
-			if sym.kind in [.any_int, .any_float] {
-				c.error('unknown type `$sym.name`', field.type_pos)
 			}
 			if sym.kind == .array {
 				array_info := sym.array_info()
@@ -4849,7 +4846,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 	return_sym := c.table.get_type_symbol(node.return_type)
 	if node.language == .v &&
 		return_sym.kind in [.placeholder, .any_int, .any_float] && return_sym.language == .v {
-		c.error('unknown return type `$return_sym.name`', node.pos)
+		c.error('unknown type `$return_sym.name`', node.pos)
 	}
 	if node.language == .v && node.is_method && node.name == 'str' {
 		if node.return_type != table.string_type {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -318,7 +318,7 @@ pub fn (mut c Checker) type_decl(node ast.TypeDecl) {
 					node.pos)
 			} else if typ_sym.kind == .chan {
 				c.error('aliases of `chan` types are not allowed.', node.pos)
-			} else if typ_sym.kind in [table.Kind.any_int, .any_float] && !c.is_builtin_mod {
+			} else if typ_sym.kind in [table.Kind.any_int, .any_float] {
 				c.error('cannot type alias `$typ_sym.name`', node.pos)
 			}
 		}
@@ -402,6 +402,9 @@ pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
 					c.error(util.new_suggestion(elem_sym.name, c.table.known_type_names()).say('unknown type `$elem_sym.name`'),
 						field.type_pos)
 				}
+			}
+			if sym.kind in [table.Kind.any_int, .any_float] {
+				c.error('cannot use `$sym.name` type as struct field type', field.type_pos)
 			}
 			if sym.kind == .struct_ {
 				info := sym.info as table.Struct
@@ -4844,7 +4847,13 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 			if sym.kind == .placeholder {
 				c.error('unknown type `$sym.name`', node.method_type_pos)
 			}
+			if sym.kind in [table.Kind.any_int, .any_float] && !c.is_builtin_mod {
+				c.error('cannot use type `$sym.name`', node.method_type_pos)
+			}
 		}
+	}
+	if node.return_type in [table.any_flt_type, table.any_int_type] {
+		c.error('cannot `any_int` and `any_float` as return type', node.pos)
 	}
 	if node.language == .v && node.is_method && node.name == 'str' {
 		if node.return_type != table.string_type {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -387,15 +387,18 @@ pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
 					c.error('field name `$field.name` duplicate', field.pos)
 				}
 			}
-			if sym.kind == .placeholder &&
-				decl.language != .c && !sym.name.starts_with('C.') {
+			if sym.kind == .placeholder && decl.language != .c && !sym.name.starts_with('C.') {
 				c.error(util.new_suggestion(sym.name, c.table.known_type_names()).say('unknown type `$sym.name`'),
 					field.type_pos)
 			}
 			// Separate error condition for `any_int` and `any_float` because `util.suggestion` may give different
 			// suggestionns due to f32 comparision issue. 
 			if sym.kind in [.any_int, .any_float] {
-				msg := if sym.kind == .any_int {'unknown type `$sym.name`.\nDid you mean `int`?'} else {'unknown type `$sym.name`.\nDid you mean `f64`?'}
+				msg := if sym.kind == .any_int {
+					'unknown type `$sym.name`.\nDid you mean `int`?'
+				} else {
+					'unknown type `$sym.name`.\nDid you mean `f64`?'
+				}
 				c.error(msg, field.type_pos)
 			}
 			if sym.kind == .array {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -392,7 +392,7 @@ pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
 					field.type_pos)
 			}
 			// Separate error condition for `any_int` and `any_float` because `util.suggestion` may give different
-			// suggestionns due to f32 comparision issue. 
+			// suggestions due to f32 comparision issue. 
 			if sym.kind in [.any_int, .any_float] {
 				msg := if sym.kind == .any_int {
 					'unknown type `$sym.name`.\nDid you mean `int`?'

--- a/vlib/v/checker/tests/any_int_float_ban_err.out
+++ b/vlib/v/checker/tests/any_int_float_ban_err.out
@@ -1,36 +1,36 @@
-vlib/v/checker/tests/any_int_float_ban_err.vv:1:12: error: cannot use `any_int` in sum type
+vlib/v/checker/tests/any_int_float_ban_err.vv:1:12: error: type `any_int` doesn't exist
     1 | type Foo = any_int | any_float
       |            ~~~~~~~
     2 | type Fo2 = any_int
     3 |
-vlib/v/checker/tests/any_int_float_ban_err.vv:2:1: error: cannot type alias `any_int`
+vlib/v/checker/tests/any_int_float_ban_err.vv:2:1: error: type `any_int` doesn't exist
     1 | type Foo = any_int | any_float
     2 | type Fo2 = any_int
       | ~~~~~~~~
     3 | 
     4 | struct Int {
-vlib/v/checker/tests/any_int_float_ban_err.vv:5:7: error: cannot use `any_int` type as struct field type
+vlib/v/checker/tests/any_int_float_ban_err.vv:5:7: error: unknown type `any_int`
     3 | 
     4 | struct Int {
     5 |     i any_int
       |       ~~~~~~~
     6 |     f any_float
     7 | }
-vlib/v/checker/tests/any_int_float_ban_err.vv:6:7: error: cannot use `any_float` type as struct field type
+vlib/v/checker/tests/any_int_float_ban_err.vv:6:7: error: unknown type `any_float`
     4 | struct Int {
     5 |     i any_int
     6 |     f any_float
       |       ~~~~~~~~~
     7 | }
     8 |
-vlib/v/checker/tests/any_int_float_ban_err.vv:9:1: error: cannot use type `any_int` as parameter type
+vlib/v/checker/tests/any_int_float_ban_err.vv:9:1: error: unknown type `any_int`
     7 | }
     8 | 
     9 | fn foo(i any_int) any_int {
       | ~~~~~~~~~~~~~~~~~~~~~~~~~
    10 |     return i
    11 | }
-vlib/v/checker/tests/any_int_float_ban_err.vv:13:1: error: cannot use `any_int` and `any_float` as return type
+vlib/v/checker/tests/any_int_float_ban_err.vv:13:1: error: unknown return type `any_int`
    11 | }
    12 | 
    13 | fn foo2() any_int {

--- a/vlib/v/checker/tests/any_int_float_ban_err.out
+++ b/vlib/v/checker/tests/any_int_float_ban_err.out
@@ -10,7 +10,7 @@ vlib/v/checker/tests/any_int_float_ban_err.vv:2:1: error: type `any_int` doesn't
     3 | 
     4 | struct Int {
 vlib/v/checker/tests/any_int_float_ban_err.vv:5:7: error: unknown type `any_int`.
-Did you mean `any`?
+Did you mean `int`?
     3 | 
     4 | struct Int {
     5 |     i any_int
@@ -18,7 +18,7 @@ Did you mean `any`?
     6 |     f any_float
     7 | }
 vlib/v/checker/tests/any_int_float_ban_err.vv:6:7: error: unknown type `any_float`.
-Did you mean `any`?
+Did you mean `f64`?
     4 | struct Int {
     5 |     i any_int
     6 |     f any_float

--- a/vlib/v/checker/tests/any_int_float_ban_err.out
+++ b/vlib/v/checker/tests/any_int_float_ban_err.out
@@ -9,14 +9,16 @@ vlib/v/checker/tests/any_int_float_ban_err.vv:2:1: error: type `any_int` doesn't
       | ~~~~~~~~
     3 | 
     4 | struct Int {
-vlib/v/checker/tests/any_int_float_ban_err.vv:5:7: error: unknown type `any_int`
+vlib/v/checker/tests/any_int_float_ban_err.vv:5:7: error: unknown type `any_int`.
+Did you mean `any`?
     3 | 
     4 | struct Int {
     5 |     i any_int
       |       ~~~~~~~
     6 |     f any_float
     7 | }
-vlib/v/checker/tests/any_int_float_ban_err.vv:6:7: error: unknown type `any_float`
+vlib/v/checker/tests/any_int_float_ban_err.vv:6:7: error: unknown type `any_float`.
+Did you mean `any`?
     4 | struct Int {
     5 |     i any_int
     6 |     f any_float
@@ -30,7 +32,7 @@ vlib/v/checker/tests/any_int_float_ban_err.vv:9:1: error: unknown type `any_int`
       | ~~~~~~~~~~~~~~~~~~~~~~~~~
    10 |     return i
    11 | }
-vlib/v/checker/tests/any_int_float_ban_err.vv:13:1: error: unknown return type `any_int`
+vlib/v/checker/tests/any_int_float_ban_err.vv:13:1: error: unknown type `any_int`
    11 | }
    12 | 
    13 | fn foo2() any_int {

--- a/vlib/v/checker/tests/any_int_float_ban_err.out
+++ b/vlib/v/checker/tests/any_int_float_ban_err.out
@@ -1,0 +1,39 @@
+vlib/v/checker/tests/any_int_float_ban_err.vv:1:12: error: cannot use `any_int` in sum type
+    1 | type Foo = any_int | any_float
+      |            ~~~~~~~
+    2 | type Fo2 = any_int
+    3 |
+vlib/v/checker/tests/any_int_float_ban_err.vv:2:1: error: cannot type alias `any_int`
+    1 | type Foo = any_int | any_float
+    2 | type Fo2 = any_int
+      | ~~~~~~~~
+    3 | 
+    4 | struct Int {
+vlib/v/checker/tests/any_int_float_ban_err.vv:5:7: error: cannot use `any_int` type as struct field type
+    3 | 
+    4 | struct Int {
+    5 |     i any_int
+      |       ~~~~~~~
+    6 |     f any_float
+    7 | }
+vlib/v/checker/tests/any_int_float_ban_err.vv:6:7: error: cannot use `any_float` type as struct field type
+    4 | struct Int {
+    5 |     i any_int
+    6 |     f any_float
+      |       ~~~~~~~~~
+    7 | }
+    8 |
+vlib/v/checker/tests/any_int_float_ban_err.vv:9:1: error: cannot use type `any_int` as parameter type
+    7 | }
+    8 | 
+    9 | fn foo(i any_int) any_int {
+      | ~~~~~~~~~~~~~~~~~~~~~~~~~
+   10 |     return i
+   11 | }
+vlib/v/checker/tests/any_int_float_ban_err.vv:13:1: error: cannot use `any_int` and `any_float` as return type
+   11 | }
+   12 | 
+   13 | fn foo2() any_int {
+      | ~~~~~~~~~~~~~~~~~
+   14 |     return 1
+   15 | }

--- a/vlib/v/checker/tests/any_int_float_ban_err.vv
+++ b/vlib/v/checker/tests/any_int_float_ban_err.vv
@@ -1,0 +1,15 @@
+type Foo = any_int | any_float
+type Fo2 = any_int
+
+struct Int {
+    i any_int
+    f any_float
+}
+
+fn foo(i any_int) any_int {
+    return i
+}
+
+fn foo2() any_int {
+    return 1
+} 

--- a/vlib/v/checker/tests/sum_type_exists.out
+++ b/vlib/v/checker/tests/sum_type_exists.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/sum_type_exists.vv:1:1: error: type `Nope` doesn't exist
+vlib/v/checker/tests/sum_type_exists.vv:1:22: error: type `Nope` doesn't exist
     1 | type Miscellaneous = Nope | Inexistant | int
-      | ~~~~~~~~~~~~~~~~~~
-    2 |
+      |                      ~~~~
+    2 | 
     3 | fn main() {

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -730,7 +730,7 @@ pub fn (table &Table) sumtype_has_variant(parent Type, variant Type) bool {
 pub fn (table &Table) known_type_names() []string {
 	mut res := []string{}
 	for _, idx in table.type_idxs {
-		if idx == 0 {
+		if idx in [0, any_int_type_idx, any_flt_type_idx] {
 			continue
 		}
 		res << table.type_to_str(idx)

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -730,6 +730,7 @@ pub fn (table &Table) sumtype_has_variant(parent Type, variant Type) bool {
 pub fn (table &Table) known_type_names() []string {
 	mut res := []string{}
 	for _, idx in table.type_idxs {
+		// Skip `any_int_type_idx` and `any_flt_type_idx` because they shouldn't be visible to the User.
 		if idx in [0, any_int_type_idx, any_flt_type_idx] {
 			continue
 		}

--- a/vlib/x/json2/decoder.v
+++ b/vlib/x/json2/decoder.v
@@ -11,7 +11,7 @@ import v.util
 import v.pref
 
 // `Any` is a sum type that lists the possible types to be decoded and used.
-pub type Any = string | int | i64 | f32 | f64 | any_int | any_float | bool | Null | []Any | map[string]Any
+pub type Any = string | int | i64 | f32 | f64 | bool | Null | []Any | map[string]Any
 
 // `Null` struct is a simple representation of the `null` value in JSON.
 pub struct Null {

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -79,12 +79,6 @@ pub fn (f Any) str() string {
 				str_f64
 			}
 		}
-		any_int {
-			return f.str()
-		}
-		any_float {
-			return f.str()
-		}
 		bool {
 			return f.str()
 		}


### PR DESCRIPTION
This PR bans the usage of `any_int` and `any_float` everywhere except `builtin`.