### PR TITLE
vdoc: search fix titles

### DIFF
--- a/cmd/tools/vdoc/resources/doc.js
+++ b/cmd/tools/vdoc/resources/doc.js
@@ -125,8 +125,8 @@ function setupSearch() {
             var searchIndexLength = searchIndex.length;
             var results = [];
             for (var i = 0; i < searchIndexLength; i++) {
-                var title = searchIndex[i].toLowerCase();
-                if (title.indexOf(searchValue) === -1) {
+                var title = searchIndex[i];
+                if (title.toLowerCase().indexOf(searchValue) === -1) {
                     continue
                 }
                 // [badge, description, link]

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -743,7 +743,11 @@ fn (mut cfg DocConfig) create_search_results(mod string, dn doc.DocNode) {
 	dn_description := trim_doc_node_description(dn.comment)
 	cfg.search_index << dn.name
 	cfg.search_data << SearchResult{
-		prefix: if dn.parent_name != '' { '$dn.kind ($dn.parent_name)' } else { '$dn.kind ' }
+		prefix: if dn.parent_name != '' {
+			'$dn.kind ($dn.parent_name)'
+		} else {
+			'$dn.kind '
+		}
 		description: dn_description
 		badge: mod
 		link: cfg.get_file_name(mod) + '#' + get_node_id(dn)

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -743,7 +743,7 @@ fn (mut cfg DocConfig) create_search_results(mod string, dn doc.DocNode) {
 	dn_description := trim_doc_node_description(dn.comment)
 	cfg.search_index << dn.name
 	cfg.search_data << SearchResult{
-		prefix: '$dn.kind ($dn.parent_name)'
+		prefix: if dn.parent_name != '' { '$dn.kind ($dn.parent_name)' } else { '$dn.kind ' }
 		description: dn_description
 		badge: mod
 		link: cfg.get_file_name(mod) + '#' + get_node_id(dn)


### PR DESCRIPTION
This fixes some title bugs.
Before:
![image](https://user-images.githubusercontent.com/30751516/103283536-1db40500-49d9-11eb-9e6f-9379d16175de.png)
after:
![image](https://user-images.githubusercontent.com/30751516/103283545-23a9e600-49d9-11eb-8d8d-968c4e4209f6.png)
