### PR TITLE
ci: sanitize compiler for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,7 +377,7 @@ jobs:
         echo "Running it..."
         ls
 
-  ubuntu-clang-sanitize-undefined:
+  tests-sanitize-undefined:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -400,7 +400,7 @@ jobs:
     - name: Fixed tests (-fsanitize=undefined)
       run: ./v -cc clang -cflags "-fsanitize=undefined" -o v2 cmd/v && ./v2 -cflags -fsanitize=undefined test-fixed
     
-  ubuntu-clang-sanitize-address:
+  tests-sanitize-address:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -423,7 +423,7 @@ jobs:
     - name: Fixed tests (-fsanitize=address)
       run: ASAN_OPTIONS=detect_leaks=0 ./v -cflags -fsanitize=address test-fixed
 
-  ubuntu-clang-sanitize-memory:
+  tests-sanitize-memory:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,7 @@ jobs:
     - name: Build V
       run: make -j4 && ./v -cc clang -cg -cflags -Werror -o v cmd/v
     - name: Fixed tests (-fsanitize=undefined)
-      run: ./v -cflags -fsanitize=undefined test-fixed
+      run: ./v -cc clang -cflags "-fsanitize=undefined" self && ./v -cflags -fsanitize=undefined test-fixed
     
   ubuntu-clang-sanitize-address:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,7 @@ jobs:
     - name: Build V
       run: make -j4 && ./v -cc clang -cg -cflags -Werror -o v cmd/v
     - name: Fixed tests (-fsanitize=undefined)
-      run: ./v -cc clang -cflags "-fsanitize=undefined" self && ./v -cflags -fsanitize=undefined test-fixed
+      run: ./v -cc clang -cflags "-fsanitize=undefined" -o v2 cmd/v && ./v2 -cflags -fsanitize=undefined test-fixed
     
   ubuntu-clang-sanitize-address:
     runs-on: ubuntu-latest

--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -5,7 +5,7 @@ import testing
 import v.pref
 
 const (
-	skip_with_fsanitize_memory  = [
+	skip_with_fsanitize_memory    = [
 		'vlib/x/websocket/websocket_test.v',
 		'vlib/encoding/csv/reader_test.v',
 		'vlib/net/tcp_test.v',
@@ -18,9 +18,9 @@ const (
 		'vlib/sqlite/sqlite_test.v',
 		'vlib/vweb/tests/vweb_test.v',
 		'vlib/x/websocket/websocket_test.v',
-		'vlib/v/tests/unsafe_test.v'
+		'vlib/v/tests/unsafe_test.v',
 	]
-	skip_with_fsanitize_address  = [
+	skip_with_fsanitize_address   = [
 		'vlib/encoding/base64/base64_test.v',
 		'vlib/encoding/csv/reader_test.v',
 		'vlib/flag/flag_test.v',
@@ -49,19 +49,19 @@ const (
 		'vlib/v/tests/vmod_parser_test.v',
 		'vlib/v/vcache/vcache_test.v',
 		'vlib/x/json2/decoder_test.v',
-		'vlib/x/websocket/websocket_test.v'
+		'vlib/x/websocket/websocket_test.v',
 	]
-	skip_with_fsanitize_undefined  = [
-		'vlib/encoding/csv/reader_test.v'
+	skip_with_fsanitize_undefined = [
+		'vlib/encoding/csv/reader_test.v',
 	]
-	skip_test_files     = [
+	skip_test_files               = [
 		'vlib/net/http/http_httpbin_test.v',
 	]
-	skip_on_musl        = [
+	skip_on_musl                  = [
 		'vlib/v/tests/profile/profile_test.v',
 	]
-	skip_on_ubuntu_musl = [
-		// 'vlib/v/gen/js/jsgen_test.v',
+	skip_on_ubuntu_musl           = [
+		/* 'vlib/v/gen/js/jsgen_test.v', */
 		'vlib/net/http/cookie_test.v',
 		'vlib/net/http/http_test.v',
 		'vlib/net/http/status_test.v',
@@ -72,19 +72,19 @@ const (
 		'vlib/vweb/tests/vweb_test.v',
 		'vlib/x/websocket/websocket_test.v',
 	]
-	skip_on_linux       = []string{}
-	skip_on_non_linux   = [
+	skip_on_linux                 = []string{}
+	skip_on_non_linux             = [
 		'vlib/net/websocket/ws_test.v',
 	]
-	skip_on_windows     = [
+	skip_on_windows               = [
 		'vlib/orm/orm_test.v',
 		'vlib/net/websocket/ws_test.v',
 		'vlib/x/websocket/websocket_test.v',
 		'vlib/vweb/tests/vweb_test.v',
 	]
-	skip_on_non_windows = []string{}
-	skip_on_macos       = []string{}
-	skip_on_non_macos   = []string{}
+	skip_on_non_windows           = []string{}
+	skip_on_macos                 = []string{}
+	skip_on_non_macos             = []string{}
 )
 
 // NB: musl misses openssl, thus the http tests can not be done there
@@ -113,7 +113,7 @@ fn main() {
 			sanitize_address = true
 		}
 		if '-fsanitize=undefined' in arg {
-			sanitize_address = true
+			sanitize_undefined = true
 		}
 	}
 	if sanitize_memory {
@@ -125,6 +125,7 @@ fn main() {
 	if sanitize_undefined {
 		tsession.skip_files << skip_with_fsanitize_undefined
 	}
+	println(tsession.skip_files)
 	//
 	if os.getenv('V_CI_MUSL').len > 0 {
 		tsession.skip_files << skip_on_musl

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2082,7 +2082,7 @@ pub fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 
 pub fn (mut c Checker) enum_decl(decl ast.EnumDecl) {
 	c.check_valid_pascal_case(decl.name, 'enum name', decl.pos)
-	mut seen := []int{}
+	mut seen := []i64{}
 	for i, field in decl.fields {
 		if !c.pref.experimental && util.contains_capital(field.name) {
 			// TODO C2V uses hundreds of enums with capitals, remove -experimental check once it's handled
@@ -2100,10 +2100,10 @@ pub fn (mut c Checker) enum_decl(decl ast.EnumDecl) {
 					val := field.expr.val.i64()
 					if val < int_min || val > int_max {
 						c.error('enum value `$val` overflows int', field.expr.pos)
-					} else if !decl.is_multi_allowed && int(val) in seen {
+					} else if !decl.is_multi_allowed && i64(val) in seen {
 						c.error('enum value `$val` already exists', field.expr.pos)
 					}
-					seen << int(val)
+					seen << i64(val)
 				}
 				ast.PrefixExpr {}
 				else {


### PR DESCRIPTION
This PR simply changes:
`./v -cflags -fsanitize=undefined test-fixed`
to
`./v -cc clang -cflags "-fsanitize=undefined" -o v2 cmd/v && ./v2 -cflags -fsanitize=undefined test-fixed`

The other changes are primarily formatting and renaming.