### PR TITLE
build: Remove `v build file.v`

### DIFF
--- a/cmd/v/help/build.txt
+++ b/cmd/v/help/build.txt
@@ -1,4 +1,4 @@
-Usage: v [build flags] ['build'] <file.v|directory>
+Usage: v [build flags] <file.v|directory>
 
 This command compiles the given target, along with their dependencies, into an executable.
 

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -385,8 +385,8 @@ pub fn parse_args(args []string) (&Preferences, string) {
 			}
 			else {
 				if command == 'build' && (arg.ends_with('.v') || os.exists(command)) {
-					res.path = arg
-					continue
+					eprintln('Use `v $arg` instead.')
+					exit(1)
 				}
 				if arg[0] == `-` {
 					if arg[1..] in list_of_flags_with_param {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -384,6 +384,10 @@ pub fn parse_args(args []string) (&Preferences, string) {
 				i++
 			}
 			else {
+				if command == 'build' && (arg.ends_with('.v') || os.exists(command)) {
+					res.path = arg
+					continue
+				}
 				if arg[0] == `-` {
 					if arg[1..] in list_of_flags_with_param {
 						// skip parameter


### PR DESCRIPTION
v help build says `Usage: v [build flags] ['build'] <file.v|directory>`  but `v build file.v` doesn't work for now.

This PR fixes it.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
