### PR TITLE
Recompile tools when timestamp is strictly less than source

### DIFF
--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -205,9 +205,7 @@ pub fn should_recompile_tool(vexe string, tool_source string) bool {
 		// recompile even if other heuristics say that we should. Users in such environments,
 		// have to explicitly do: `v cmd/tools/vfmt.v`, and/or install v from source, and not
 		// use the system packaged one, if they desire to develop v itself.
-		ancient_threshold := 1024
-		is_mtime_ancient := mtime_vexe < ancient_threshold && mtime_tool_exe < ancient_threshold
-		if is_mtime_ancient {
+		if mtime_vexe < 1024 && mtime_tool_exe < 1024 {
 			should_compile = false
 		}
 	}

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -195,7 +195,7 @@ pub fn should_recompile_tool(vexe string, tool_source string) bool {
 				should_compile = false
 			}
 		}
-		if mtime_tool_exe < mtime_tool_source {
+		if mtime_tool_exe <= mtime_tool_source {
 			// the user changed the source code of the tool, or git updated it:
 			should_compile = true
 		}

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -179,7 +179,7 @@ pub fn should_recompile_tool(vexe string, tool_source string) bool {
 	if !os.exists(tool_exe) {
 		should_compile = true
 	} else {
-		if os.file_last_mod_unix(tool_exe) <= os.file_last_mod_unix(vexe) {
+		if os.file_last_mod_unix(tool_exe) < os.file_last_mod_unix(vexe) {
 			// v was recompiled, maybe after v up ...
 			// rebuild the tool too just in case
 			should_compile = true
@@ -192,7 +192,7 @@ pub fn should_recompile_tool(vexe string, tool_source string) bool {
 				should_compile = false
 			}
 		}
-		if os.file_last_mod_unix(tool_exe) <= os.file_last_mod_unix(tool_source) {
+		if os.file_last_mod_unix(tool_exe) < os.file_last_mod_unix(tool_source) {
 			// the user changed the source code of the tool, or git updated it:
 			should_compile = true
 		}

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -201,12 +201,12 @@ pub fn should_recompile_tool(vexe string, tool_source string) bool {
 		}
 		// GNU Guix and possibly other environments, have bit for bit reproducibility in mind,
 		// including filesystem attributes like modification times, so they set the modification
-		// times of executables to 0. In this case, we should not recompile even if other
+		// times of executables to 1. In this case, we should not recompile even if other
 		// heuristics say that we should. Users in such environments, have to explicitly do:
 		// `v cmd/tools/vfmt.v`, and/or install v from source, and not use the system packaged
 		// one.
-		is_mtime_0 := mtime_vexe == 0 && mtime_tool_exe == 0
-		if is_mtime_0 {
+		is_mtime_ancient := mtime_vexe == 1 && mtime_tool_exe == 1
+		if is_mtime_ancient {
 			should_compile = false
 		}
 	}

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -201,11 +201,12 @@ pub fn should_recompile_tool(vexe string, tool_source string) bool {
 		}
 		// GNU Guix and possibly other environments, have bit for bit reproducibility in mind,
 		// including filesystem attributes like modification times, so they set the modification
-		// times of executables to 1. In this case, we should not recompile even if other
-		// heuristics say that we should. Users in such environments, have to explicitly do:
-		// `v cmd/tools/vfmt.v`, and/or install v from source, and not use the system packaged
-		// one.
-		is_mtime_ancient := mtime_vexe == 1 && mtime_tool_exe == 1
+		// times of executables to a small number like 0, 1 etc. In this case, we should not
+		// recompile even if other heuristics say that we should. Users in such environments,
+		// have to explicitly do: `v cmd/tools/vfmt.v`, and/or install v from source, and not
+		// use the system packaged one, if they desire to develop v itself.
+		ancient_threshold := 1024
+		is_mtime_ancient := mtime_vexe < ancient_threshold && mtime_tool_exe < ancient_threshold
 		if is_mtime_ancient {
 			should_compile = false
 		}


### PR DESCRIPTION
This PR changes vlib/util to never rebuild a v tool when its timestamp and that of its source are both exactly `1`. This avoids rebuilding tools when the source and binary have the exact same ancient timestamp, which is an important use case for me.

### Context

In order to create package outputs that are bit-for-bit reproducible regardless of when they are built, GNU Guix sets the timestamps for all files in a package to 1 second since the beginning of the UNIX Epoch. I've discovered that this is baked pretty deeply into the design of the Guix build daemon and currently cannot be overridden.

So as a result, after installing v as a Guix package it always thinks it has to rebuild each tool, which will fail because package directories are read-only at runtime.

### Testing

I've tested this with v 0.2. It resolves my issue with packages trying to re-build in Guix.