### PR TITLE
semver: add input information in error and panic output

### DIFF
--- a/vlib/semver/range.v
+++ b/vlib/semver/range.v
@@ -78,7 +78,9 @@ fn parse_comparator_set(input string) ?ComparatorSet {
 	}
 	mut comparators := []Comparator{}
 	for raw_comp in raw_comparators {
-		c := parse_comparator(raw_comp) or { return error('Invalid comparator "$raw_comp" in input "$input"') }
+		c := parse_comparator(raw_comp) or {
+			return error('Invalid comparator "$raw_comp" in input "$input"')
+		}
 		comparators << c
 	}
 	return ComparatorSet{comparators}

--- a/vlib/semver/range.v
+++ b/vlib/semver/range.v
@@ -74,11 +74,11 @@ fn parse_range(input string) ?Range {
 fn parse_comparator_set(input string) ?ComparatorSet {
 	raw_comparators := input.split(comparator_sep)
 	if raw_comparators.len > 2 {
-		return error('Invalid format of comparator set')
+		return error('Invalid format of comparator set for input "$input"')
 	}
 	mut comparators := []Comparator{}
 	for raw_comp in raw_comparators {
-		c := parse_comparator(raw_comp) or { return error('Invalid comparator: $raw_comp') }
+		c := parse_comparator(raw_comp) or { return error('Invalid comparator "$raw_comp" in input "$input"') }
 		comparators << c
 	}
 	return ComparatorSet{comparators}

--- a/vlib/semver/semver.v
+++ b/vlib/semver/semver.v
@@ -26,7 +26,9 @@ pub fn from(input string) ?Version {
 		return error('Empty input')
 	}
 	raw_version := parse(input)
-	version := raw_version.validate() or { return error('Invalid version format for input "$input"') }
+	version := raw_version.validate() or {
+		return error('Invalid version format for input "$input"')
+	}
 	return version
 }
 

--- a/vlib/semver/semver.v
+++ b/vlib/semver/semver.v
@@ -26,7 +26,7 @@ pub fn from(input string) ?Version {
 		return error('Empty input')
 	}
 	raw_version := parse(input)
-	version := raw_version.validate() or { return error('Invalid version format') }
+	version := raw_version.validate() or { return error('Invalid version format for input "$input"') }
 	return version
 }
 
@@ -69,7 +69,7 @@ pub fn (v1 Version) le(v2 Version) bool {
 
 // * Utilites.
 pub fn coerce(input string) ?Version {
-	ver := coerce_version(input) or { return error('Invalid version: $input') }
+	ver := coerce_version(input) or { return error('Invalid version for input "$input"') }
 	return ver
 }
 

--- a/vlib/semver/util.v
+++ b/vlib/semver/util.v
@@ -10,7 +10,7 @@ fn is_version_valid(input string) bool {
 [inline]
 fn coerce_version(input string) ?Version {
 	raw_ver := parse(input)
-	ver := raw_ver.coerce() or { return error('Invalid version: $input') }
+	ver := raw_ver.coerce() or { return error('Invalid version for input "$input"') }
 	return ver
 }
 


### PR DESCRIPTION
I have a panic message from a user in an [issue](https://github.com/vlang/vab/issues/6) in `vlang/vab` that has no value (as in no value to a developer trying to fix an issue) - this PR should fix that throughout the `semver` module. :smile: 

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
