### PR TITLE
readline: move get_prompt_offset back to _linux.c.v

### DIFF
--- a/vlib/readline/readline.v
+++ b/vlib/readline/readline.v
@@ -41,17 +41,3 @@ mut:
 	search_index      int
 	is_tty            bool
 }
-
-// get_prompt_offset computes the length of the `prompt` `string` argument.
-fn get_prompt_offset(prompt string) int {
-	mut len := 0
-	for i := 0; i < prompt.len; i++ {
-		if prompt[i] == `\e` {
-			for ; i < prompt.len && prompt[i] != `m`; i++ {
-			}
-		} else {
-			len = len + 1
-		}
-	}
-	return prompt.len - len
-}

--- a/vlib/readline/readline_linux.c.v
+++ b/vlib/readline/readline_linux.c.v
@@ -333,6 +333,20 @@ fn calculate_screen_position(x_in int, y_in int, screen_columns int, char_count 
 	return out
 }
 
+// get_prompt_offset computes the length of the `prompt` `string` argument.
+fn get_prompt_offset(prompt string) int {
+	mut len := 0
+	for i := 0; i < prompt.len; i++ {
+		if prompt[i] == `\e` {
+			for ; i < prompt.len && prompt[i] != `m`; i++ {
+			}
+		} else {
+			len = len + 1
+		}
+	}
+	return prompt.len - len
+}
+
 // refresh_line redraws the current line, including the prompt.
 fn (mut r Readline) refresh_line() {
 	mut end_of_input := [0, 0]


### PR DESCRIPTION
Fix ahead-of-time slip-up from #7683 

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
