### PR TITLE
compiler: Add `[console]` attribute for main function to force console subsystem

### DIFF
--- a/vlib/sokol/c/declaration.c.v
+++ b/vlib/sokol/c/declaration.c.v
@@ -36,6 +36,7 @@ pub const (
 #flag linux   -DSOKOL_NO_ENTRY
 #flag darwin  -DSOKOL_NO_ENTRY
 #flag windows -DSOKOL_NO_ENTRY
+#flag windows -DSOKOL_WIN32_FORCE_MAIN
 #flag freebsd -DSOKOL_NO_ENTRY
 #flag solaris -DSOKOL_NO_ENTRY
 // TODO end

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -242,7 +242,8 @@ fn (mut c Checker) check_file_in_main(file ast.File) bool {
 				} else {
 					for attr in stmt.attrs {
 						if attr.name == 'console' {
-							c.error('only `main` can have the `[console]` attribute', stmt.pos)
+							c.error('only `main` can have the `[console]` attribute',
+								stmt.pos)
 						}
 					}
 					if stmt.is_pub && !stmt.is_method {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -240,6 +240,11 @@ fn (mut c Checker) check_file_in_main(file ast.File) bool {
 						c.error('function `main` cannot return values', stmt.pos)
 					}
 				} else {
+					for attr in stmt.attrs {
+						if attr.name == 'console' {
+							c.error('only `main` can have the `[console]` attribute', stmt.pos)
+						}
+					}
 					if stmt.is_pub && !stmt.is_method {
 						c.warn('function `$stmt.name` $no_pub_in_main_warning', stmt.pos)
 					}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -131,6 +131,7 @@ mut:
 	returned_var_name                string // to detect that a var doesn't need to be freed since it's being returned
 	branch_parent_pos                int // used in BranchStmt (continue/break) for autofree stop position
 	timers                           &util.Timers = util.new_timers(false)
+	force_main_console               bool // true when [console] used on fn main()
 }
 
 const (

--- a/vlib/v/gen/cmain.v
+++ b/vlib/v/gen/cmain.v
@@ -43,6 +43,10 @@ fn (mut g Gen) gen_vlines_reset() {
 fn (mut g Gen) gen_c_main_function_header() {
 	if g.pref.os == .windows {
 		if g.is_gui_app() {
+			$if msvc {
+				// This is kinda bad but I dont see a way that is better
+				g.writeln('#pragma comment(linker, "/SUBSYSTEM:WINDOWS")')
+			}
 			// GUI application
 			g.writeln('int WINAPI wWinMain(HINSTANCE instance, HINSTANCE prev_instance, LPWSTR cmd_line, int show_cmd){')
 		} else {

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -885,6 +885,9 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type table.Type) {
 
 fn (mut g Gen) is_gui_app() bool {
 	$if windows {
+		if g.force_main_console {
+			return false
+		}
 		for cf in g.table.cflags {
 			if cf.value == 'gdi32' {
 				return true
@@ -960,6 +963,9 @@ fn (mut g Gen) write_fn_attrs(attrs []table.Attr) string {
 				// windows attributes (msvc/mingw)
 				// prefixed by windows to indicate they're for advanced users only and not really supported by V.
 				msvc_attrs += '__stdcall '
+			}
+			'console' {
+				g.force_main_console = true
 			}
 			else {
 				// nothing but keep V happy


### PR DESCRIPTION
This changes the behaviour for msvc windows to allow for a `[console]` attribute to override the gdi32 heuristic for seeing if we are a gui app.

This is useful when you want to do println and similar and want it to be in the console where it was called from rather than a new one with  `C.AllocConsole()`

usage:
```v
#flag -L gdi32

[console]
fn main() {
    println('Even if you link with gdi and msvc you should still be able to see this message in a console somewhere!')
}
```