### PR TITLE
cli: fix test where a callback wasn't being used

### DIFF
--- a/vlib/cli/command_test.v
+++ b/vlib/cli/command_test.v
@@ -24,13 +24,13 @@ fn test_if_subcommands_parse_args() {
 	}
 	subcmd := cli.Command{
 		name: 'subcommand'
-		execute: empty_func
+		execute: if_subcommands_parse_args_func
 	}
 	cmd.add_command(subcmd)
 	cmd.parse(['command', 'subcommand', 'arg0', 'arg1'])
 }
 
-fn if_subcommands_parse_args_func(cmd cli.Command) {
+fn if_subcommands_parse_args_func(cmd cli.Command) ? {
 	assert cmd.name == 'subcommand' && compare_arrays(cmd.args, ['arg0', 'arg1'])
 }
 


### PR DESCRIPTION
I noticed that a callback function wasn't being used where it should have been (and that it had a slightly incorrect signature)