### PR TITLE
generics: implement method generics (fix #7638)

### DIFF
--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -424,6 +424,11 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			}
 		}
 	}
+	if node.generic_type != table.void_type && node.generic_type != 0 {
+		// Using _T_ to differentiate between get<string> and get_string
+		// `foo<int>()` => `foo_T_int()`
+		name += '_T_' + g.typ(node.generic_type)
+	}
 	// TODO2
 	// g.generate_tmp_autofree_arg_vars(node, name)
 	//

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -50,7 +50,7 @@ pub fn (mut p Parser) call_expr(language table.Language, mod string) ast.CallExp
 		}
 	}
 	p.check(.lpar)
-	mut args := p.call_args()
+	args := p.call_args()
 	last_pos := p.tok.position()
 	p.check(.rpar)
 	// ! in mutable methods

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1435,7 +1435,7 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 		}
 	}
 	if p.tok.kind == .lpar {
-		p.check(.lpar)
+		p.next()
 		args := p.call_args()
 		if is_filter && args.len != 1 {
 			p.error('needs exactly 1 argument')

--- a/vlib/v/tests/generics_method_test.v
+++ b/vlib/v/tests/generics_method_test.v
@@ -1,0 +1,21 @@
+struct Point {
+mut:
+	x int
+	y int
+}
+
+fn (mut p Point) translate<T>(x T, y T) {
+	p.x += x
+	p.y += y
+}
+
+fn test_generic_method() {
+	mut pot := Point{}
+	pot.translate(1, 3) // report error 2
+	pot.translate(1, 3) // report error 2
+	println(pot)
+	assert pot == Point{
+		x: 2
+		y: 6
+	}
+}

--- a/vlib/v/tests/generics_method_test.v
+++ b/vlib/v/tests/generics_method_test.v
@@ -11,8 +11,8 @@ fn (mut p Point) translate<T>(x T, y T) {
 
 fn test_generic_method() {
 	mut pot := Point{}
-	pot.translate(1, 3) // report error 2
-	pot.translate(1, 3) // report error 2
+	pot.translate<int>(1, 3)
+	pot.translate(1, 3)
 	println(pot)
 	assert pot == Point{
 		x: 2


### PR DESCRIPTION
This PR implements method generics (fix #7638).

- Implements method generics.
- Add test `generics_method_test.v`.

```v
module main

struct Point {
mut:
    x int
    y int
}

fn (mut p Point) translate<T>(x T, y T) {
    p.x += x
    p.y += y
}

fn main() {
    mut pot := Point{}
    pot.translate<int>(1,3)  //report error 2
    pot.translate(1,3)  //report error 2
    println(pot)
}

PS D:\Test\v\tt1> v run .
Point{
    x: 2
    y: 6
}
```