### PR TITLE
make: fix make.bat

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -351,9 +351,6 @@ if !invalid_cc! EQU 1 (
     echo.
 )
 
-del v_old.exe>>"!log_file!" 2>NUL
-del "!log_file!" 2>NUL
-
 :version
 echo.
 echo | set /p="V version: "


### PR DESCRIPTION
This PR fixes make.bat on Windows.

- `v_old.exe` cannot delete before make exit.

- Previous
```v
C:\Users\yuyi9\v>make
Updating TCC
 > Syncing TCC from https://github.com/vlang/tccbin

Updating vc...
 > Sync with remote https://github.com/vlang/vc

Building V...
 > Clang not found
 > Attempting to build v_win.c with GCC
 > Compiling with .\v.exe self
 > V built successfully
 > To add V to your PATH, run `.\v.exe symlink`.
The process cannot access the file because it is being used by another process.
C:\Users\yuyi9\AppData\Local\Temp\v_make.log

V version: V 0.2.1 3e655d6
```

- Now
```v
C:\Users\yuyi9\v>make
Updating TCC
 > Syncing TCC from https://github.com/vlang/tccbin

Updating vc...
 > Sync with remote https://github.com/vlang/vc

Building V...
 > Clang not found
 > Attempting to build v_win.c with GCC
 > Compiling with .\v.exe self
 > V built successfully
 > To add V to your PATH, run `.\v.exe symlink`.

V version: V 0.2.1 3e655d6
```