### PR TITLE
checker: check reference return to be really reference

### DIFF
--- a/vlib/live/common.v
+++ b/vlib/live/common.v
@@ -52,7 +52,7 @@ pub mut:
 // so that the user can set callbacks, read meta information, etc.
 pub fn info() &LiveReloadInfo {
 	if C.g_live_info != 0 {
-		return C.g_live_info
+		return &LiveReloadInfo(C.g_live_info)
 	}
 	// When the current program is not compiled with -live, simply
 	// return a new empty struct LiveReloadInfo in order to prevent

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2031,6 +2031,12 @@ pub fn (mut c Checker) return_stmt(mut return_stmt ast.Return) {
 			c.error('fn `$c.cur_fn.name` expects you to return a non reference type `${c.table.type_to_str(exp_type)}`, but you are returning `${c.table.type_to_str(got_typ)}` instead',
 				pos)
 		}
+		if (exp_type.is_ptr() || exp_type.is_pointer()) &&
+			(!got_typ.is_ptr() && !got_typ.is_pointer()) && got_typ != table.any_int_type {
+			pos := return_stmt.exprs[i].position()
+			c.error('fn `$c.cur_fn.name` expects you to return a reference type `${c.table.type_to_str(exp_type)}`, but you are returning `${c.table.type_to_str(got_typ)}` instead',
+				pos)
+		}
 	}
 	if exp_is_optional && return_stmt.exprs.len > 0 {
 		expr0 := return_stmt.exprs[0]

--- a/vlib/v/checker/tests/reference_return.out
+++ b/vlib/v/checker/tests/reference_return.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/reference_return.vv:6:9: error: fn `f` expects you to return a reference type `&Aa`, but you are returning `Aa` instead
+    4 | 
+    5 | fn f() &Aa {
+    6 |     return Aa{
+      |            ~~~
+    7 |         a: 1
+    8 |     }

--- a/vlib/v/checker/tests/reference_return.vv
+++ b/vlib/v/checker/tests/reference_return.vv
@@ -1,0 +1,14 @@
+struct Aa {
+	a int
+}
+
+fn f() &Aa {
+	return Aa{
+		a: 1
+	}
+}
+
+fn main() {
+	x := f()
+	println(x.a)
+}

--- a/vlib/v/tests/ref_return_test.v
+++ b/vlib/v/tests/ref_return_test.v
@@ -1,0 +1,14 @@
+struct Aa {
+	a int
+}
+
+fn f() &Aa {
+	return &Aa{
+		a: 5
+	}
+}
+
+fn test_ref_return() {
+	x := f()
+	assert x.a == 5
+}


### PR DESCRIPTION
This PR introduces a check that a function declared as returning a reference really returns a reference, as in:
```v
fn f() &Xy {
    ...
    return &Xy{ ... }
}
```
This closes #7422.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
