### PR TITLE
clipboard.to_wide: fix return type

### DIFF
--- a/cmd/tools/vcreate.v
+++ b/cmd/tools/vcreate.v
@@ -10,7 +10,7 @@ import (
 
 struct Create {
 mut:
-	name string
+	name        string
 	description string
 }
 
@@ -19,36 +19,54 @@ fn cerror(e string){
 }
 
 fn (c Create)write_vmod() {
-	mut vmod := os.create('${c.name}/v.mod') or { cerror(err) exit(1) }
-	mut vmod_content := []string
-	vmod_content << '#V Project#\n'
-	vmod_content << 'Module {'
-	vmod_content << '	name: \'${c.name}\','
-	vmod_content << '	description: \'${c.description}\','
-	vmod_content << '	dependencies: []'
-	vmod_content << '}'
+	mut vmod := os.create('${c.name}/v.mod') or {
+		cerror(err)
+		exit(1)
+	}
+	vmod_content := [
+		'#V Project#\n',
+		'Module {',
+		'	name: \'${c.name}\',',
+		'	description: \'${c.description}\',',
+		'	dependencies: []',
+		'}'
+	]
 	vmod.write(vmod_content.join('\n'))
 }
 
 fn (c Create)write_main() {
-	mut main := os.create('${c.name}/${c.name}.v') or {	cerror(err) exit(2)	}
-	mut main_content := []string
-	main_content << 'module main\n'
-	main_content << 'fn main() {'
-	main_content << '	println(\'Hello World !\')'
-	main_content << '}'
+	mut main := os.create('${c.name}/${c.name}.v') or {
+		cerror(err)
+		exit(2)
+	}
+	main_content := [
+		'module main\n',
+		'fn main() {',
+		'	println(\'Hello World !\')',
+		'}'
+	]
 	main.write(main_content.join('\n'))
 }
 
 fn main() {
 	mut c := Create{}
-	print('Choose your project name: ')
+
+	print('Input your project name: ')
 	c.name = os.get_line()
-	print('Choose your project description: ')
+	
+	if (os.is_dir(c.name)) {
+		cerror('${c.name} folder already exists')
+		exit(3)
+	}
+
+	print('Input your project description: ')
 	c.description = os.get_line()
+
 	println('Initialising ...')
-	if (os.is_dir(c.name)) { cerror('folder already exists') exit(3) }
-	os.mkdir(c.name) or { panic(err) }
+
+	os.mkdir(c.name) or {
+		panic(err)
+	}
 	c.write_vmod()
 	c.write_main()
 	println('Complete !')


### PR DESCRIPTION
error: fn clipboard.to_wide expects you to return a reference type &C.HGLOBAL, but you are returning C.HGLOBAL instead

Ran into this issue during running the UI examples.

Changed the return type to a reference.