### PR TITLE
util: fix launch_tool on Windows

### DIFF
--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -164,7 +164,7 @@ pub fn launch_tool(is_verbose bool, tool_name string, args []string) {
 	if is_verbose {
 		println('launch_tool running tool command: $tool_command ...')
 	}
-	os.execvp(tool_exe, args)
+	os.system(tool_command)
 }
 
 // NB: should_recompile_tool/2 compares unix timestamps that have 1 second resolution


### PR DESCRIPTION
This PR fixes launch_tool on Windows.

- Use `os.execvp()` will never return on Windows.
```v
C:\Users\yuyi9\v>v self

C:\Users\yuyi9\v>V self compiling ...
```
- So use `os.system()` instead of it.