### PR TITLE
checker: fix infer_fn_type for generic methods

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -419,7 +419,11 @@ pub fn (mut c Checker) infer_fn_types(f table.Fn, mut call_expr ast.CallExpr) {
 	gt_name := 'T'
 	mut typ := table.void_type
 	for i, param in f.params {
-		arg := call_expr.args[i]
+		arg := if i != 0 && call_expr.is_method {
+			call_expr.args[i-1]
+		} else {
+			call_expr.args[i]
+		}
 		if param.typ.has_flag(.generic) {
 			typ = arg.typ
 			break

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -419,11 +419,7 @@ pub fn (mut c Checker) infer_fn_types(f table.Fn, mut call_expr ast.CallExpr) {
 	gt_name := 'T'
 	mut typ := table.void_type
 	for i, param in f.params {
-		arg := if i != 0 && call_expr.is_method {
-			call_expr.args[i-1]
-		} else {
-			call_expr.args[i]
-		}
+		arg := if i != 0 && call_expr.is_method { call_expr.args[i - 1] } else { call_expr.args[i] }
 		if param.typ.has_flag(.generic) {
 			typ = arg.typ
 			break

--- a/vlib/v/tests/generics_method_test.v
+++ b/vlib/v/tests/generics_method_test.v
@@ -19,3 +19,19 @@ fn test_generic_method() {
 		y: 6
 	}
 }
+
+struct Person {
+mut:
+	name string
+}
+
+fn (mut p Person) show<T>(name string, data T) string {
+	p.name = name
+	return 'name: $p.name, data: $data'
+}
+
+fn test_generic_method_with_fixed_arg_type() {
+	mut person := Person{}
+	res := person.show('bob', 10)
+	assert res == 'name: bob, data: 10'
+}


### PR DESCRIPTION
This fixes an array out of bounds error when the checker checks and infers the generic method in `infer_fn_type`

Log before fix:
```
V panic: array.get: index out of range (i == 1, a.len == 1)
/tmp/v/v.tmp.c:10846: at v_panic: Backtrace
/tmp/v/v.tmp.c:10365: by array_get
/tmp/v/v.tmp.c:26605: by v__checker__Checker_infer_fn_types
/tmp/v/v.tmp.c:27920: by v__checker__Checker_call_method
/tmp/v/v.tmp.c:27643: by v__checker__Checker_call_expr
/tmp/v/v.tmp.c:29606: by v__checker__Checker_expr
...
```