### PR TITLE
clipboard: fix `to_wide()` in clipboard_windows.c.v

### DIFF
--- a/vlib/clipboard/clipboard_windows.c.v
+++ b/vlib/clipboard/clipboard_windows.c.v
@@ -125,7 +125,7 @@ fn (mut cb Clipboard) free() {
 }
 
 // the string.to_wide doesn't work with SetClipboardData, don't know why
-fn to_wide(text string) &C.HGLOBAL {
+fn to_wide(text string) C.HGLOBAL {
 	len_required := C.MultiByteToWideChar(C.CP_UTF8, C.MB_ERR_INVALID_CHARS, text.str,
 		text.len + 1, C.NULL, 0)
 	buf := C.GlobalAlloc(C.GMEM_MOVEABLE, i64(sizeof(u16)) * len_required)


### PR DESCRIPTION
This PR fixes `to_wide()` in clipboard_windows.c.v.
```v
FAIL [ 11/324]   106.244 ms vlib\clipboard\clipboard_test.v
vlib\clipboard\clipboard_windows.c.v:141:9: error: fn `clipboard.to_wide` expects you to return a rd
  139 |         C.GlobalUnlock(buf)
  140 |     }
  141 |     return buf
      |            ~~~
  142 | }
  143 |
```

If just `return &buf` causes a memory access exception. 
```v
FAIL [ 28/324]  2936.023 ms vlib\clipboard\clipboard_test.v
Unhandled Exception 0xC0000374
C:/Users/yuyi9/AppData/Local/Temp/v/test_session_32206700/clipboard_test.exe.14351091409503463746.te
C:/Users/yuyi9/AppData/Local/Temp/v/test_session_32206700/clipboard_test.exe.14351091409503463746.ts
C:/Users/yuyi9/AppData/Local/Temp/v/test_session_32206700/clipboard_test.exe.14351091409503463746.tr
7ffbf1cea98a : by ???
```
C.HGLOBAL is handle we can use, so change return type to `C.HGLOBAL` instead of `&C.HGLOBAL`.