### PR TITLE
cgen: Make character constants wide

### DIFF
--- a/vlib/builtin/utf8_test.v
+++ b/vlib/builtin/utf8_test.v
@@ -4,3 +4,11 @@ fn test_utf8_char_len() {
 	s := 'п'
 	assert utf8_char_len(s[0]) == 2
 }
+
+fn test_utf8_wide_char() {
+	r := `🌎`
+	val := r.str().str
+	unsafe {
+		assert '${val[0]:x}${val[1]:x}${val[2]:x}${val[3]:x}' == 'f09f8c8e'
+	}
+}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2452,7 +2452,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 			if node.val == r'\`' {
 				g.write("'`'")
 			} else {
-				g.write("'$node.val'")
+				g.write("L'$node.val'")
 			}
 		}
 		ast.AtExpr {


### PR DESCRIPTION
Since literal characters are stored in a uint32, this takes up the same
storage space, while properly handling Unicode characters.

This fixes #7758.