### PR TITLE
vweb: fix req attrib without path

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -389,14 +389,44 @@ fn handle_conn<T>(mut conn net.TcpConn, mut app T) {
 		$if method.return_type is Result {
 			attrs := method.attrs
 			route_words_a = [][]string{}
+			// Get methods
+			// Get is default
+			mut req_method_str := '$req.method'
+			if req.method == .post {
+				if 'post' in attrs {
+					route_words_a = attrs.filter(it.to_lower() != 'post').map(it[1..].split('/'))
+				}
+			} else if req.method == .put {
+				if 'put' in attrs {
+					route_words_a = attrs.filter(it.to_lower() != 'put').map(it[1..].split('/'))
+				}
+			} else if req.method == .patch {
+				if 'patch' in attrs {
+					route_words_a = attrs.filter(it.to_lower() != 'patch').map(it[1..].split('/'))
+				}
+			} else if req.method == .delete {
+				if 'delete' in attrs {
+					route_words_a = attrs.filter(it.to_lower() != 'delete').map(it[1..].split('/'))
+				}
+			} else if req.method == .head {
+				if 'head' in attrs {
+					route_words_a = attrs.filter(it.to_lower() != 'head').map(it[1..].split('/'))
+				}
+			} else if req.method == .options {
+				if 'options' in attrs {
+					route_words_a = attrs.filter(it.to_lower() != 'options').map(it[1..].split('/'))
+				}
+			} else {
+				route_words_a = attrs.filter(it.to_lower() != 'get').map(it[1..].split('/'))
+			}
 			if attrs.len == 0 {
 				// No routing for this method. If it matches, call it and finish matching
 				// since such methods have a priority.
 				// For example URL `/register` matches route `/:user`, but `fn register()`
 				// should be called first.
-				if (req.method == .get &&
+				if (req_method_str == '' &&
 					url_words[0] == method.name && url_words.len == 1) ||
-					(req.method == .post && url_words[0] + '_post' == method.name) {
+					(req_method_str == req.method.str() && url_words[0] == method.name && url_words.len == 1) {
 					$if debug {
 						println('easy match method=$method.name')
 					}
@@ -404,36 +434,6 @@ fn handle_conn<T>(mut conn net.TcpConn, mut app T) {
 					return
 				}
 			} else {
-				// Get methods
-				// Get is default
-				mut req_method_str := '$req.method'
-				if req.method == .post {
-					if 'post' in attrs {
-						route_words_a = attrs.filter(it.to_lower() != 'post').map(it[1..].split('/'))
-					}
-				} else if req.method == .put {
-					if 'put' in attrs {
-						route_words_a = attrs.filter(it.to_lower() != 'put').map(it[1..].split('/'))
-					}
-				} else if req.method == .patch {
-					if 'patch' in attrs {
-						route_words_a = attrs.filter(it.to_lower() != 'patch').map(it[1..].split('/'))
-					}
-				} else if req.method == .delete {
-					if 'delete' in attrs {
-						route_words_a = attrs.filter(it.to_lower() != 'delete').map(it[1..].split('/'))
-					}
-				} else if req.method == .head {
-					if 'head' in attrs {
-						route_words_a = attrs.filter(it.to_lower() != 'head').map(it[1..].split('/'))
-					}
-				} else if req.method == .options {
-					if 'options' in attrs {
-						route_words_a = attrs.filter(it.to_lower() != 'options').map(it[1..].split('/'))
-					}
-				} else {
-					route_words_a = attrs.filter(it.to_lower() != 'get').map(it[1..].split('/'))
-				}
 				mut req_method := []string{}
 				if route_words_a.len > 0 {
 					for route_words in route_words_a {


### PR DESCRIPTION
This PR fix the case if you just declare a function with an HTTP method.

```v
[post]
fn foo() vweb.Result {}
```

This works now with every HTTP type we support