### PR TITLE
parser: Fix parsing error when using imported types in short fn signature

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -493,7 +493,8 @@ fn (mut p Parser) fn_args() ([]table.Param, bool, bool) {
 		p.tok.lit
 	}
 	types_only := p.tok.kind in [.amp, .ellipsis, .key_fn] ||
-		(p.peek_tok.kind == .comma && p.table.known_type(argname)) || p.peek_tok.kind == .rpar
+		(p.peek_tok.kind == .comma && p.table.known_type(argname)) || p.peek_tok.kind == .dot ||
+		p.peek_tok.kind == .rpar
 	// TODO copy pasta, merge 2 branches
 	if types_only {
 		// p.warn('types only')

--- a/vlib/v/tests/fn_test.v
+++ b/vlib/v/tests/fn_test.v
@@ -1,3 +1,4 @@
+import time
 // 1 line comment // 1 line comment
 /*
 multi line comment (1)
@@ -39,6 +40,8 @@ type F4 = fn (voidptr) int
 type F5 = fn (int, int) int
 
 type F6 = fn (int, int)
+
+type F7 = fn (time.Time, int)
 
 fn C.atoi(byteptr) int
 


### PR DESCRIPTION
fix #7773

Before:

```v
vlib/v/tests/fn_test.v:44:19: error: expecting type declaration
   42 | type F6 = fn (int, int)
   43 |
   44 | type F7 = fn (time.Time, int)
      |                   ^
   45 |
   46 | fn C.atoi(byteptr) int

```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
