### PR TITLE
vrepl: fix v repl on Windows

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -28,8 +28,8 @@ const (
 	is_stdin_a_pipe = (is_atty(0) == 0)
 )
 
-fn new_repl() &Repl {
-	return &Repl{
+fn new_repl() Repl {
+	return Repl{
 		readline: readline.Readline{}
 		modules: ['os', 'time', 'math']
 	}

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -164,7 +164,7 @@ pub fn launch_tool(is_verbose bool, tool_name string, args []string) {
 	if is_verbose {
 		println('launch_tool running tool command: $tool_command ...')
 	}
-	os.execvp(tool_exe, args)
+	os.system(tool_command)
 }
 
 // NB: should_recompile_tool/2 compares unix timestamps that have 1 second resolution


### PR DESCRIPTION
This PR fixes v repl on Windows.

- Change `os.execvp()` to `os.system()` in util.launch_tool.
- Change `new_repl` return type from `&Repl` to `Repl`.

- Previous (It's actually abnormally withdrawn)
```v
C:\Users\yuyi9>v
Welcome to the V REPL (for help with V itself, type `exit`, then run `v help`).

C:\Users\yuyi9>V 0.2.1 f713597
Use Ctrl-C or `exit` to exit, or `help` to see other available commands
>>> help

For more information on a specific command, type HELP command-name
ASSOC          Displays or modifies file extension associations.
ATTRIB         Displays or changes file attributes.
BREAK          Sets or clears extended CTRL+C checking.
BCDEDIT        Sets properties in boot database to control boot loading.
CACLS          Displays or modifies access control lists (ACLs) of files.
CALL           Calls one batch program from another.
CD             Displays the name of or changes the current directory.
CHCP           Displays or sets the active code page number.
```

- Now
```v
C:\Users\yuyi9\v>v
Welcome to the V REPL (for help with V itself, type `exit`, then run `v help`).
V 0.2.1 f713597
Use Ctrl-C or `exit` to exit, or `help` to see other available commands
>>> time.now()
2021-01-02 13:11:03
```