### PR TITLE
docs: fix errors in docs

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -897,7 +897,7 @@ It works like this:
 ```v oksyntax
 mut x := MySumType(MyStruct{123})
 if mut x is MyStruct {
-	// x is casted to MyStruct even it's mutable
+	// x is casted to MyStruct even if it's mutable
 	// without the mut keyword that wouldn't work
 	println(x)
 }


### PR DESCRIPTION
Hello V community,

I've made two changes:
1. Removed arrow pointing from `int` to `f32` because as the documentation says that conversion cannot be made (unless I have misunderstood it):
> An `int` value for example can be automatically promoted to `f64`
An `int` value for example can be automatically promoted to `f64`
or `i64` but not to `f32` or `u32`.
2. Fixed a grammatical error by adding an "if".

Cheers!