### PR TITLE
utf8: fix utf8_test

### DIFF
--- a/vlib/builtin/utf8_test.v
+++ b/vlib/builtin/utf8_test.v
@@ -6,9 +6,9 @@ fn test_utf8_char_len() {
 }
 
 fn test_utf8_wide_char() {
-	r := `🌎`
+	r := `✔`
 	val := r.str().str
 	unsafe {
-		assert '${val[0]:x}${val[1]:x}${val[2]:x}${val[3]:x}' == 'f09f8c8e'
+		assert '${val[0]:x}${val[1]:x}${val[2]:x}${val[3]:x}' == 'e29c940'
 	}
 }


### PR DESCRIPTION
This PR fixes utf8_test.

- Issue on win10
```v
FAIL [ 10/324]   829.567 ms vlib\builtin\utf8_test.v
1

C:\\Users\\yuyi9\\v\\vlib\\builtin\\utf8_test.v:12: failed assert in function test_utf8_wide_char
Source  : `'${val[0]:x}${val[1]:x}${val[2]:x}${val[3]:x}' == 'f09f8c8e'`
         left value: edbc8e0
        right value: f09f8c8e
```
- Cause
🌎 code number is 127758.  
wchar_t  n = L'🌎' can only receive 2 bytes number on Windows, So assert failed.

- Solution
Now use smaller code like `✔`, it's code number is 22909, It can work on all the platform.