### PR TITLE
vdoc: remove 's' between paragraphs

### DIFF
--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -405,7 +405,7 @@ fn doc_node_html(dd doc.DocNode, link string, head bool, tb &table.Table) string
 	sym_name := get_sym_name(dd)
 	node_id := get_node_id(dd)
 	hash_link := if !head { ' <a href="#$node_id">#</a>' } else { '' }
-	dnw.writeln('${tabs[1]}s<section id="$node_id" class="doc-node$node_class">')
+	dnw.writeln('${tabs[1]}<section id="$node_id" class="doc-node$node_class">')
 	if dd.name.len > 0 {
 		if dd.kind == .const_group {
 			dnw.write('${tabs[2]}<div class="title"><$head_tag>$sym_name$hash_link</$head_tag>')


### PR DESCRIPTION
![Screenshot_20210102_154551](https://user-images.githubusercontent.com/40118727/103459766-a7354100-4d11-11eb-9153-43e6831e06d5.png)
The `s` above are no more.