### PR TITLE
tests: fix str_gen_test.v

### DIFF
--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -72,10 +72,10 @@ fn test_map_of_floats() {
 	assert '$aa' == "{'a': 1.1, 'b': 2.2, 'c': 3.3}"
 }
 
-fn test_map_of_bytes() {
+fn test_map_of_runes() {
 	aa := {'a': `a`, 'b': `b`, 'c': `c`}
-	assert aa.str() == "{'a': a, 'b': b, 'c': c}"
-	assert '$aa' == "{'a': a, 'b': b, 'c': c}"
+	assert aa.str() == "{'a': `a`, 'b': `b`, 'c': `c`}"
+	assert '$aa' == "{'a': `a`, 'b': `b`, 'c': `c`}"
 }
 
 fn test_map_of_bools() {


### PR DESCRIPTION
This PR fixes str_gen_test.v in tests.

```v
OK   [278/324]  1182.841 ms vlib\v\tests\sorting_by_different_criteria_test.v
FAIL [279/324]  1303.934 ms vlib\v\tests\str_gen_test.v
C:\\Users\\yuyi9\\v\\vlib\\v\\tests\\str_gen_test.v:77: failed assert in function test_map_of_bytes
Source  : `aa.str() == '{'a': a, 'b': b, 'c': c}'`
         left value: {'a': `a`, 'b': `b`, 'c': `c`}
        right value: {'a': a, 'b': b, 'c': c}
```

- Change `test_map_of_bytes` to `test_map_of_runes`.