### PR TITLE
tests: fix ci error of vtest-fixed (fix #7827)

### DIFF
--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -154,7 +154,6 @@ fn main() {
 	tsession.test()
 	eprintln(tsession.benchmark.total_message(title))
 	if tsession.benchmark.nfail > 0 {
-		eprintln('\nWARNING: failed $tsession.benchmark.nfail times.\n')
-		exit(1)
+		panic('\nWARNING: failed $tsession.benchmark.nfail times.\n')
 	}
 }

--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -155,6 +155,6 @@ fn main() {
 	eprintln(tsession.benchmark.total_message(title))
 	if tsession.benchmark.nfail > 0 {
 		eprintln('\nWARNING: failed $tsession.benchmark.nfail times.\n')
-		exit(-1)
+		exit(1)
 	}
 }

--- a/cmd/tools/vtest-fixed.v
+++ b/cmd/tools/vtest-fixed.v
@@ -154,6 +154,7 @@ fn main() {
 	tsession.test()
 	eprintln(tsession.benchmark.total_message(title))
 	if tsession.benchmark.nfail > 0 {
-		panic('\nWARNING: failed $tsession.benchmark.nfail times.\n')
+		eprintln('\nWARNING: failed $tsession.benchmark.nfail times.\n')
+		exit(-1)
 	}
 }

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -164,7 +164,7 @@ pub fn launch_tool(is_verbose bool, tool_name string, args []string) {
 	if is_verbose {
 		println('launch_tool running tool command: $tool_command ...')
 	}
-	os.system(tool_command)
+	exit(os.system(tool_command))
 }
 
 // NB: should_recompile_tool/2 compares unix timestamps that have 1 second resolution


### PR DESCRIPTION
This PR fixes ci error of vtest-fixed (fix #7827).

- Restore `exit(os.system(tool_command))` in util.launch_tool.
When `v test-fixed` failed, It can translate exit non zero value to ci, So ci know failed.