### PR TITLE
fmt: Add test for struct embed

### DIFF
--- a/vlib/v/fmt/tests/struct_keep.vv
+++ b/vlib/v/fmt/tests/struct_keep.vv
@@ -27,3 +27,10 @@ type Expr = IfExpr | IntegerLiteral
 fn exprs(e []Expr) {
 	println(e.len)
 }
+
+struct KeepStructEmbed {
+	User
+pub:
+	a int
+	b int
+}


### PR DESCRIPTION
Fix #7814
It is fixed in fc6d45b2d78b7c55a197be80d84f802386dec40c . But no test exists. So I add test.

I checked that this test fail before fc6d45b2d78b7c55a197be80d84f802386dec40c.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
