### PR TITLE
fmt: fix formatting array decomposition

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1140,6 +1140,7 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 		}
 		ast.ArrayDecompose {
 			f.expr(node.expr)
+			f.write('...')
 		}
 	}
 }

--- a/vlib/v/fmt/tests/array_decomposition_keep.vv
+++ b/vlib/v/fmt/tests/array_decomposition_keep.vv
@@ -1,0 +1,8 @@
+fn varargs(a ...int) {
+	println(a)
+}
+
+fn main() {
+	a := [1, 2, 3]
+	varargs(a...)
+}


### PR DESCRIPTION
Fixes #7832
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
