### PR TITLE
checker: don't panic on non-array decomposition

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -398,7 +398,7 @@ pub fn (mut c Checker) struct_decl(decl ast.StructDecl) {
 					field.type_pos)
 			}
 			// Separate error condition for `any_int` and `any_float` because `util.suggestion` may give different
-			// suggestions due to f32 comparision issue. 
+			// suggestions due to f32 comparision issue.
 			if sym.kind in [.any_int, .any_float] {
 				msg := if sym.kind == .any_int {
 					'unknown type `$sym.name`.\nDid you mean `int`?'
@@ -3049,7 +3049,8 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 			typ := c.expr(node.expr)
 			type_sym := c.table.get_type_symbol(typ)
 			if type_sym.kind != .array {
-				c.error('expected array', node.pos)
+				c.error('decomposition can only be used on arrays', node.expr.position())
+				return table.void_type
 			}
 			array_info := type_sym.info as table.Array
 			elem_type := array_info.elem_type.set_flag(.variadic)

--- a/vlib/v/checker/tests/decompose_type_err.out
+++ b/vlib/v/checker/tests/decompose_type_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/decompose_type_err.vv:4:10: error: decomposition can only be used on arrays
+    2 |
+    3 | fn main() {
+    4 |     varargs(123...)
+      |             ~~~
+    5 | }

--- a/vlib/v/checker/tests/decompose_type_err.vv
+++ b/vlib/v/checker/tests/decompose_type_err.vv
@@ -1,0 +1,5 @@
+fn varargs(a ...int) { println(a) }
+
+fn main() {
+	varargs(123...)
+}


### PR DESCRIPTION
Fixes panic when compiling `func(123...)`
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
