### PR TITLE
string: optimize `*_with` & add test case

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -850,17 +850,9 @@ pub fn (s string) starts_with(prefix string) bool {
 	return s.len >= prefix.len && s[0..prefix.len].str() == prefix
 }
 
-// ends_with returns `true` if the string ends with `p`.
-pub fn (s string) ends_with(p string) bool {
-	if p.len > s.len {
-		return false
-	}
-	for i in 0 .. p.len {
-		if p[i] != s[s.len - p.len + i] {
-			return false
-		}
-	}
-	return true
+// ends_with returns `true` if the string ends with `suffix`.
+pub fn (s string) ends_with(suffix string) bool {
+	return s.len >= suffix.len && s[s.len-suffix.len..].str() == suffix
 }
 
 // to_lower returns the string in all lowercase characters.

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -845,17 +845,9 @@ pub fn (s string) contains_any_substr(substrs []string) bool {
 	return false
 }
 
-// starts_with returns `true` if the string starts with `p`.
-pub fn (s string) starts_with(p string) bool {
-	if p.len > s.len {
-		return false
-	}
-	for i in 0 .. p.len {
-		if unsafe {s.str[i] != p.str[i]} {
-			return false
-		}
-	}
-	return true
+// starts_with returns `true` if the string starts with `prefix`.
+pub fn (s string) starts_with(prefix string) bool {
+	return s.len >= prefix.len && s[0..prefix.len].str() == prefix
 }
 
 // ends_with returns `true` if the string ends with `p`.

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -31,6 +31,11 @@ fn test_ends_with() {
 	assert s.ends_with('Language') == true
 	assert s.ends_with('Programming Language') == true
 	assert s.ends_with('V') == false
+
+	ms := '😅Test😁Test😴'
+	assert ms.ends_with('😴') == true
+	assert ms.ends_with('😁Test😴') == true
+	assert ms.ends_with('😅Test😁') == false
 }
 
 fn test_between() {
@@ -716,6 +721,11 @@ fn test_starts_with() {
 	assert s.starts_with('V') == true
 	assert s.starts_with('V Programming') == true
 	assert s.starts_with('Language') == false
+
+	ms := '😅Test😁Test😴'
+	assert ms.starts_with('😅') == true
+	assert ms.starts_with('😅Test😁') == true
+	assert ms.starts_with('😁Test😴') == false
 }
 
 fn test_trim_prefix() {


### PR DESCRIPTION
- Change for-loop to non-use with `*_with` string function
- Add multi-byte strings to test cases