### PR TITLE
generic: fix return multi array generic  (fix #7727 #7753)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -427,12 +427,23 @@ pub fn (mut c Checker) infer_fn_types(f table.Fn, mut call_expr ast.CallExpr) {
 		arg_sym := c.table.get_type_symbol(arg.typ)
 		param_type_sym := c.table.get_type_symbol(param.typ)
 		if arg_sym.kind == .array && param_type_sym.kind == .array {
-			param_info := param_type_sym.info as table.Array
-			if param_info.elem_type.has_flag(.generic) {
-				arg_info := arg_sym.info as table.Array
-				typ = arg_info.elem_type
-				break
+			mut arg_elem_info := arg_sym.info as table.Array
+			mut param_elem_info := param_type_sym.info as table.Array
+			mut arg_elem_sym := c.table.get_type_symbol(arg_elem_info.elem_type)
+			mut param_elem_sym := c.table.get_type_symbol(param_elem_info.elem_type)
+			for {
+				if arg_elem_sym.kind == .array &&
+					param_elem_sym.kind == .array && param_elem_sym.name != 'T' {
+					arg_elem_info = arg_elem_sym.info as table.Array
+					arg_elem_sym = c.table.get_type_symbol(arg_elem_info.elem_type)
+					param_elem_info = param_elem_sym.info as table.Array
+					param_elem_sym = c.table.get_type_symbol(param_elem_info.elem_type)
+				} else {
+					typ = arg_elem_info.elem_type
+					break
+				}
 			}
+			break
 		}
 	}
 	if typ == table.void_type {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1767,8 +1767,19 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 			call_expr.return_type = typ
 			return typ
 		} else if return_sym.kind == .array && return_sym.name.contains('T') {
-			elem_info := return_sym.info as table.Array
-			idx := c.table.find_or_register_array(call_expr.generic_type, elem_info.nr_dims + 1)
+			mut info := return_sym.info as table.Array
+			mut sym := c.table.get_type_symbol(info.elem_type)
+			mut dims := 1
+			for {
+				if sym.kind == .array {
+					info = sym.info as table.Array
+					sym = c.table.get_type_symbol(info.elem_type)
+					dims++
+				} else {
+					break
+				}
+			}
+			idx := c.table.find_or_register_array(call_expr.generic_type, dims)
 			typ := table.new_type(idx)
 			call_expr.return_type = typ
 			return typ

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1766,23 +1766,12 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 			}
 			call_expr.return_type = typ
 			return typ
-		} else if return_sym.kind == .array {
+		} else if return_sym.kind == .array && return_sym.name.contains('T') {
 			elem_info := return_sym.info as table.Array
-			elem_sym := c.table.get_type_symbol(elem_info.elem_type)
-			if elem_sym.kind == .array {
-				info := elem_sym.info as table.Array
-				sym := c.table.get_type_symbol(info.elem_type)
-				if sym.name == 'T' {
-					idx := c.table.find_or_register_array(call_expr.generic_type, 2)
-					typ := table.new_type(idx)
-					call_expr.return_type = typ
-				}
-			} else if elem_sym.name == 'T' {
-				idx := c.table.find_or_register_array(call_expr.generic_type, 1)
-				typ := table.new_type(idx)
-				call_expr.return_type = typ
-				return typ
-			}
+			idx := c.table.find_or_register_array(call_expr.generic_type, elem_info.nr_dims + 1)
+			typ := table.new_type(idx)
+			call_expr.return_type = typ
+			return typ
 		}
 	}
 	if call_expr.generic_type.is_full() && !f.is_generic {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1769,9 +1769,19 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 		} else if return_sym.kind == .array {
 			elem_info := return_sym.info as table.Array
 			elem_sym := c.table.get_type_symbol(elem_info.elem_type)
-			if elem_sym.name == 'T' {
+			if elem_sym.kind == .array {
+				info := elem_sym.info as table.Array
+				sym := c.table.get_type_symbol(info.elem_type)
+				if sym.name == 'T' {
+					idx := c.table.find_or_register_array(call_expr.generic_type, 2)
+					typ := table.new_type(idx)
+					call_expr.return_type = typ
+				}
+			} else if elem_sym.name == 'T' {
 				idx := c.table.find_or_register_array(call_expr.generic_type, 1)
-				return table.new_type(idx)
+				typ := table.new_type(idx)
+				call_expr.return_type = typ
+				return typ
 			}
 		}
 	}

--- a/vlib/v/tests/generics_return_multi_array_test.v
+++ b/vlib/v/tests/generics_return_multi_array_test.v
@@ -6,8 +6,4 @@ fn test_generic_return_multi_array() {
 	d1 := [1, 2, 3]
 	d2 := example(d1)
 	assert d2 == [[1, 2, 3]]
-
-	d3 := [1.1, 2.2, 3.3]
-	d4 := example(d3)
-	assert d4 == [[1.1, 2.2, 3.3]]
 }

--- a/vlib/v/tests/generics_return_multi_array_test.v
+++ b/vlib/v/tests/generics_return_multi_array_test.v
@@ -1,9 +1,25 @@
-fn example<T>(data []T) [][]T {
+fn example1<T>(data []T) [][]T {
+	return [data]
+}
+
+fn example2<T>(data [][]T) [][][]T {
+	return [data]
+}
+
+fn example3<T>(data [][][]T) [][][][]T {
 	return [data]
 }
 
 fn test_generic_return_multi_array() {
 	d1 := [1, 2, 3]
-	d2 := example(d1)
+	d2 := example1(d1)
 	assert d2 == [[1, 2, 3]]
+
+	d11 := [[1, 2, 3]]
+	d22 := example2(d11)
+	assert d22 == [[[1, 2, 3]]]
+
+	d111 := [[[1, 2, 3]]]
+	d222 := example3(d111)
+	assert d222 == [[[[1, 2, 3]]]]
 }

--- a/vlib/v/tests/generics_return_multi_array_test.v
+++ b/vlib/v/tests/generics_return_multi_array_test.v
@@ -3,7 +3,11 @@ fn example<T>(data []T) [][]T {
 }
 
 fn test_generic_return_multi_array() {
-	data := [1, 2, 3]
-	d2 := example(data)
+	d1 := [1, 2, 3]
+	d2 := example(d1)
 	assert d2 == [[1, 2, 3]]
+
+	d3 := [1.1, 2.2, 3.3]
+	d4 := example(d3)
+	assert d4 == [[1.1, 2.2, 3.3]]
 }

--- a/vlib/v/tests/generics_return_multi_array_test.v
+++ b/vlib/v/tests/generics_return_multi_array_test.v
@@ -1,0 +1,9 @@
+fn example<T>(data []T) [][]T {
+	return [data]
+}
+
+fn test_generic_return_multi_array() {
+	data := [1, 2, 3]
+	d2 := example(data)
+	assert d2 == [[1, 2, 3]]
+}


### PR DESCRIPTION
This PR fixes return multi array generic  (fix #7727 #7753).

- Fixes return multi array generic.
- Add test `generics_return_multi_array_test.v`.

```v
fn example<T>(data []T) [][]T {
	return [data]
}

fn main() {
	data := [1, 2, 3]
	d2 := example(data)
	println(typeof(d2))
	assert d2 == [[1, 2, 3]]

	d3 := [1.1, 2.2, 3.3]
	d4 := example(d3)
	println(typeof(d4))
	assert d4 == [[1.1, 2.2, 3.3]]
}

PS D:\Test\v\tt1> v run .
[][]int
[][]f64
```
- Resolve any depth multi array generic
```v
fn example1<T>(data []T) [][]T {
	return [data]
}

fn example2<T>(data [][]T) [][][]T {
	return [data]
}

fn example3<T>(data [][][]T) [][][][]T {
	return [data]
}

fn test_generic_return_multi_array() {
	d1 := [1, 2, 3]
	d2 := example1(d1)
	assert d2 == [[1, 2, 3]]

	d11 := [[1, 2, 3]]
	d22 := example2(d11)
	assert d22 == [[[1, 2, 3]]]

	d111 := [[[1, 2, 3]]]
	d222 := example3(d111)
	assert d222 == [[[[1, 2, 3]]]]
}
```