### PR TITLE
ui: fix error of clipboard_windows.c.v

### DIFF
--- a/vlib/clipboard/clipboard_windows.c.v
+++ b/vlib/clipboard/clipboard_windows.c.v
@@ -151,7 +151,7 @@ fn (mut cb Clipboard) set_text(text string) bool {
 	} else {
 		// EmptyClipboard must be called to properly update clipboard ownership
 		C.EmptyClipboard()
-		if C.SetClipboardData(C.CF_UNICODETEXT, buf) == C.HANDLE(C.NULL) {
+		if C.SetClipboardData(C.CF_UNICODETEXT, &buf) == C.HANDLE(C.NULL) {
 			println('SetClipboardData: Failed.')
 			C.CloseClipboard()
 			C.GlobalFree(buf)


### PR DESCRIPTION
This PR fixes error of clipboard_windows.c.v, so vui can work on windows.

```v
C:\Users\yuyi9\.vmodules\ui\examples>v run users.v
C:\Users\yuyi9\.vmodules\ui\examples>v run timer.v
C:\Users\yuyi9\.vmodules\ui\examples>v run rectangles.v
```
![image](https://user-images.githubusercontent.com/6949593/103540590-eb247380-4ed4-11eb-9844-1c2148193402.png)
