### PR TITLE
checker, cgen: allow using literals as `int` and `f64` for sum types

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -123,7 +123,7 @@ pub fn (mut c Checker) check_basic(got table.Type, expected table.Type) bool {
 		return true
 	}
 	// sum type
-	if c.table.sumtype_has_variant(expected, got) {
+	if c.table.sumtype_has_variant(expected, c.table.mktyp(got)) {
 		return true
 	}
 	// fn type

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2092,7 +2092,7 @@ pub fn (mut c Checker) return_stmt(mut return_stmt ast.Return) {
 				pos)
 		}
 		if !c.check_types(got_typ, exp_type) {
-			got_typ_sym := c.table.get_type_symbol(c.table.mktyp(got_typ))
+			got_typ_sym := c.table.get_type_symbol(got_typ)
 			mut exp_typ_sym := c.table.get_type_symbol(exp_type)
 			pos := return_stmt.exprs[i].position()
 			if exp_typ_sym.kind == .interface_ {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2092,7 +2092,7 @@ pub fn (mut c Checker) return_stmt(mut return_stmt ast.Return) {
 				pos)
 		}
 		if !c.check_types(got_typ, exp_type) {
-			got_typ_sym := c.table.get_type_symbol(got_typ)
+			got_typ_sym := c.table.get_type_symbol(c.table.mktyp(got_typ))
 			mut exp_typ_sym := c.table.get_type_symbol(exp_type)
 			pos := return_stmt.exprs[i].position()
 			if exp_typ_sym.kind == .interface_ {

--- a/vlib/v/checker/tests/is_type_not_exist.out
+++ b/vlib/v/checker/tests/is_type_not_exist.out
@@ -1,10 +1,3 @@
-vlib/v/checker/tests/is_type_not_exist.vv:4:25: error: cannot use `int literal` as `Integer` in argument 1 to `fn_with_sum_type_param`
-    2 | 
-    3 | fn main() {
-    4 |     fn_with_sum_type_param(1)
-      |                            ^
-    5 | }
-    6 |
 vlib/v/checker/tests/is_type_not_exist.vv:8:10: error: is: type `SomethingThatDontExist` does not exist
     6 | 
     7 | fn fn_with_sum_type_param(i Integer) {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1320,7 +1320,8 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 }
 
 // use instead of expr() when you need to cast to union sum type (can add other casts also)
-fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type table.Type, expected_type table.Type) {
+fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw table.Type, expected_type table.Type) {
+	got_type := g.table.mktyp(got_type_raw)
 	// cast to sum type
 	if expected_type != table.void_type {
 		expected_is_ptr := expected_type.is_ptr()

--- a/vlib/v/tests/sumtype_literal_test.v
+++ b/vlib/v/tests/sumtype_literal_test.v
@@ -1,0 +1,84 @@
+type Foo = f32 | f64 | i16 | int | u64
+
+fn test_assign_cast() {
+	a := Foo(3)
+	b := Foo(3.0)
+	c := Foo(-7.25)
+	d := Foo(i16(-4))
+	e := Foo(f32(-0.0625))
+	assert a is int
+	assert b is f64
+	assert b !is int
+	assert c is f64
+	assert d is i16
+	assert e is f32
+}
+
+fn test_assign_mut() {
+	mut a := Foo(0)
+	mut b := Foo(i16(3))
+	mut c := Foo(f32(1))
+	a = 12.3
+	b = -123456
+	c = 33.
+	assert a is f64
+	assert b is int
+	assert c is f64
+}
+
+fn test_call_arg() {
+	assert get_type_idx(0.25) == 1
+	assert get_type_idx(-7) == 3
+	assert get_type_idx(u64(0)) == 4
+	assert get_type_idx(f32(-0.125e-7)) == 0
+}
+
+fn get_type_idx(x Foo) int {
+	match x {
+		f32 {
+			return 0
+		}
+		f64 {
+			return 1
+		}
+		i16 {
+			return 2
+		}
+		int {
+			return 3
+		}
+		u64 {
+			return 4
+		}
+	}
+}
+
+fn test_sumtype_return() {
+	a := gen_foo(0)
+	b := gen_foo(1)
+	c := gen_foo(2)
+	d := gen_foo(3)
+	e := gen_foo(4)
+	assert a is f32
+	assert b is f64
+	assert c is f64
+	assert c !is int
+	assert d is i16
+	assert e is int
+}
+
+fn gen_foo(n int) Foo {
+	if n == 0 {
+		return f32(0.5)
+	}
+	if n == 1 {
+		return -17.3e23
+	}
+	if n == 2 {
+		return 32.
+	}
+	if n == 3 {
+		return i16(13)
+	}
+	return 1
+}


### PR DESCRIPTION
This allows using number literals like `123` or `3.14` to initialize sum types as `int` or `f64`:
```v
type Num = i16 | int | f32 | f64
x := Num(12)            // Num.int
y := Num(13.4)          // Num.f64
mut z := Num(f32(12.3)) // Num.f32
z = 7                   // Num.int
z = 1.4e17              // Num.f64
```
This corresponds to simple initialization (`a := 1`) where `int` and `f64` are also used as default types.

Using literals for function arguments and function returns is supported, too:
```v
fn f(x Num) Num {
    if x is int {
        return -45.3 // Num.f64
    }
    return 1 // Num.int
}

fn main() {
    a := f(1)
    b := f(1.)
    assert a is f64
    assert b is int
}
```
Test cases are added. This fixes #6575 and similar issues.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
