### PR TITLE
vdoc: prefix for head section id

### DIFF
--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -403,7 +403,7 @@ fn doc_node_html(dd doc.DocNode, link string, head bool, tb &table.Table) string
 	hlighted_code := html_highlight(dd.content, tb)
 	node_class := if dd.kind == .const_group { ' const' } else { '' }
 	sym_name := get_sym_name(dd)
-	node_id := get_node_id(dd)
+	node_id := if head { 'head_' + get_node_id(dd) } else { get_node_id(dd) }
 	hash_link := if !head { ' <a href="#$node_id">#</a>' } else { '' }
 	dnw.writeln('${tabs[1]}<section id="$node_id" class="doc-node$node_class">')
 	if dd.name.len > 0 {


### PR DESCRIPTION
If a module has a function with the same name as the module. The toc link to this function instead links to the module heading.
Now the head section id is prefixed with `head_` to heavily reduce the clashes.
Fix #7812 