### PR TITLE
checker: warn when accessing `union` fields outside `unsafe`

### DIFF
--- a/vlib/strconv/atof.v
+++ b/vlib/strconv/atof.v
@@ -522,6 +522,7 @@ pub fn atof64(s string) f64 {
 
 	res_parsing,pn = parser(s + ' ') // TODO: need an extra char for now
 	// println(pn)
+	unsafe {
 	match res_parsing {
 		parser_ok {
 			res.u = converter(mut pn)
@@ -539,6 +540,8 @@ pub fn atof64(s string) f64 {
 			res.u = double_minus_infinity
 		}
 		else {
-		}}
+		}
+	}
 	return res.f
+	}
 }

--- a/vlib/strconv/atofq.v
+++ b/vlib/strconv/atofq.v
@@ -37,6 +37,7 @@ pub fn atof_quick(s string) f64 {
 			i++
 		}
 	}
+	unsafe {
 	// infinite
 	if s[i] == `i` && i + 2 < s.len && s[i + 1] == `n` && s[i + 2] == `f` {
 		if sign > 0.0 {
@@ -133,6 +134,7 @@ pub fn atof_quick(s string) f64 {
 	}
 	f.f = f.f * sign
 	return f.f
+	}
 }
 
 const (

--- a/vlib/strconv/f32_str.v
+++ b/vlib/strconv/f32_str.v
@@ -321,8 +321,8 @@ pub fn f32_to_decimal(mant u32, exp u32) Dec32 {
 // f32_to_str return a string in scientific notation with max n_digit after the dot
 pub fn f32_to_str(f f32, n_digit int) string {
 	mut u1 := Uf32{}
-	u1.f = f
-	u := u1.u
+	unsafe { u1.f = f }
+	u := unsafe {u1.u}
 
 	neg   := (u>>(mantbits32+expbits32)) != 0
 	mant  := u & ((u32(1)<<mantbits32) - u32(1))
@@ -348,8 +348,8 @@ pub fn f32_to_str(f f32, n_digit int) string {
 // f32_to_str return a string in scientific notation with max n_digit after the dot
 pub fn f32_to_str_pad(f f32, n_digit int) string {
 	mut u1 := Uf32{}
-	u1.f = f
-	u := u1.u
+	unsafe { u1.f = f }
+	u := unsafe {u1.u}
 
 	neg   := (u>>(mantbits32+expbits32)) != 0
 	mant  := u & ((u32(1)<<mantbits32) - u32(1))

--- a/vlib/strconv/f64_str.v
+++ b/vlib/strconv/f64_str.v
@@ -370,8 +370,8 @@ fn f64_to_decimal(mant u64, exp u64) Dec64 {
 // f64_to_str return a string in scientific notation with max n_digit after the dot
 pub fn f64_to_str(f f64, n_digit int) string {
 	mut u1 := Uf64{}
-	u1.f = f
-	u := u1.u
+	unsafe { u1.f = f }
+	u := unsafe {u1.u}
 
 	neg   := (u>>(mantbits64+expbits64)) != 0
 	mant  := u & ((u64(1)<<mantbits64) - u64(1))
@@ -395,8 +395,8 @@ pub fn f64_to_str(f f64, n_digit int) string {
 // f64_to_str return a string in scientific notation with max n_digit after the dot
 pub fn f64_to_str_pad(f f64, n_digit int) string {
 	mut u1 := Uf64{}
-	u1.f = f
-	u := u1.u
+	unsafe { u1.f = f }
+	u := unsafe {u1.u}
 
 	neg   := (u>>(mantbits64+expbits64)) != 0
 	mant  := u & ((u64(1)<<mantbits64) - u64(1))

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1050,6 +1050,9 @@ fn (mut c Checker) fail_if_immutable(expr ast.Expr) (string, token.Position) {
 						// No automatic lock for struct access
 						explicit_lock_needed = true
 					}
+					if struct_info.is_union && !c.inside_unsafe {
+						c.warn('accessing union fields requires `unsafe`', expr.pos)
+					}
 				}
 				.array, .string {
 					// This should only happen in `builtin`


### PR DESCRIPTION
Rust makes reading (and sometimes writing) union fields require `unsafe`. This pull does so for both.
https://doc.rust-lang.org/reference/items/unions.html#reading-and-writing-union-fields

Reading union fields is memory-unsafe if there is a type that is a pointer/reference field somewhere inside the union, and it can cause weird values if not used carefully - e.g. an enum field can get a value outside its members.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
