### PR TITLE
 parser: Fix bug when using some types like map in generic method

### DIFF
--- a/vlib/v/tests/generics_method_test.v
+++ b/vlib/v/tests/generics_method_test.v
@@ -35,3 +35,19 @@ fn test_generic_method_with_fixed_arg_type() {
 	res := person.show('bob', 10)
 	assert res == 'name: bob, data: 10'
 }
+
+struct Foo {}
+
+fn (v Foo) new<T>() T {
+	return T{}
+}
+
+fn test_generic_method_with_map_type() {
+	foo := Foo{}
+	assert foo.new<map[string]string>() == map[string]string{}
+}
+
+fn test_generic_method_with_array_type() {
+	foo := Foo{}
+	assert foo.new<[]string>() == []string{}
+}


### PR DESCRIPTION
Fix #7860 

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
