### PR TITLE
builder: auto cleanup xxx.def generated by tcc on windows

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -591,6 +591,12 @@ fn (mut v Builder) cc() {
 			v.pref.cleanup_files << v.out_name_c
 			v.pref.cleanup_files << response_file
 		}
+		$if windows {
+			if ccompiler.contains('tcc') {
+				def_name := v.pref.out_name[0..v.pref.out_name.len - 4]
+				v.pref.cleanup_files << '${def_name}.def'
+			}
+		}
 		//
 		todo()
 		os.chdir(vdir)

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -592,7 +592,7 @@ fn (mut v Builder) cc() {
 			v.pref.cleanup_files << response_file
 		}
 		$if windows {
-			if ccompiler.contains('tcc') {
+			if v.ccoptions.is_cc_tcc {
 				def_name := v.pref.out_name[0..v.pref.out_name.len - 4]
 				v.pref.cleanup_files << '${def_name}.def'
 			}


### PR DESCRIPTION
This PR implements auto cleanup `xxx.def` generated by tcc on windows.
![image](https://user-images.githubusercontent.com/6949593/103647546-74e84580-4f96-11eb-801d-302b671e9baa.png)
- Too many useless files are left after tcc compilation.
