### PR TITLE
cgen: fix array/fixed_array_rune_str

### DIFF
--- a/vlib/v/gen/auto_str_methods.v
+++ b/vlib/v/gen/auto_str_methods.v
@@ -332,9 +332,7 @@ fn (mut g Gen) gen_str_for_map(info table.Map, styp string, str_fn_name string) 
 	if key_sym.kind == .string {
 		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("\'%.*s\\000\'", 2, key));')
 	} else if key_sym.kind == .rune {
-		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, tos3("`"));')
-		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, ${key_str_fn_name}(key));')
-		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, tos3("`"));')
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("`%.*s\\000`", 2, ${key_str_fn_name}(key)));')
 	} else {
 		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, ${key_str_fn_name}(key));')
 	}

--- a/vlib/v/gen/auto_str_methods.v
+++ b/vlib/v/gen/auto_str_methods.v
@@ -214,6 +214,8 @@ fn (mut g Gen) gen_str_for_array(info table.Array, styp string, str_fn_name stri
 			}
 		} else if sym.kind in [.f32, .f64] {
 			g.auto_str_funcs.writeln('\t\tstring x = _STR("%g", 1, it);')
+		} else if sym.kind == .rune {
+			g.auto_str_funcs.writeln('\t\tstring x = _STR("`%.*s\\000`", 2, ${elem_str_fn_name}(it));')
 		} else {
 			// There is a custom .str() method, so use it.
 			// NB: we need to take account of whether the user has defined
@@ -280,6 +282,8 @@ fn (mut g Gen) gen_str_for_array_fixed(info table.ArrayFixed, styp string, str_f
 			g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("%g", 1, a[i]));')
 		} else if sym.kind == .string {
 			g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("\'%.*s\\000\'", 2, a[i]));')
+		} else if sym.kind == .rune {
+			g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("`%.*s\\000`", 2, ${elem_str_fn_name}(a[i])));')
 		} else {
 			if (str_method_expects_ptr && is_elem_ptr) || (!str_method_expects_ptr && !is_elem_ptr) {
 				g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, ${elem_str_fn_name}(a[i]));')

--- a/vlib/v/gen/auto_str_methods.v
+++ b/vlib/v/gen/auto_str_methods.v
@@ -348,9 +348,7 @@ fn (mut g Gen) gen_str_for_map(info table.Map, styp string, str_fn_name string) 
 		} else if val_sym.kind in [.f32, .f64] {
 			g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("%g", 1, it));')
 		} else if val_sym.kind == .rune {
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, tos3("`"));')
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, ${elem_str_fn_name}(it));')
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, tos3("`"));')
+			g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("`%.*s\\000`", 2, ${elem_str_fn_name}(it)));')
 		} else {
 			g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, ${elem_str_fn_name}(it));')
 		}

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -42,10 +42,10 @@ fn test_array_of_ints() {
 	assert '$c2' == '[11, 22, 33]'
 }
 
-fn test_array_of_bytes() {
+fn test_array_of_runes() {
 	aa := [`a`, `b`, `c`]
-	assert aa.str() == '[a, b, c]'
-	assert '$aa' == '[a, b, c]'
+	assert aa.str() == '[`a`, `b`, `c`]'
+	assert '$aa' == '[`a`, `b`, `c`]'
 }
 
 fn test_array_of_strings() {
@@ -128,10 +128,10 @@ fn test_fixed_array_of_ints() {
 	assert '$c2' == '[11, 22, 33]'
 }
 
-fn test_fixed_array_of_bytes() {
+fn test_fixed_array_of_runes() {
 	aa := [`a`, `b`, `c`]!!
-	assert aa.str() == '[a, b, c]'
-	assert '$aa' == '[a, b, c]'
+	assert aa.str() == '[`a`, `b`, `c`]'
+	assert '$aa' == '[`a`, `b`, `c`]'
 }
 
 fn test_fixed_array_of_strings() {

--- a/vlib/v/tests/string_interpolation_array_test.v
+++ b/vlib/v/tests/string_interpolation_array_test.v
@@ -67,9 +67,9 @@ fn test_array_of_ints_interpolation() {
 	assert '$c2' == '[11, 22, 33]'
 }
 
-fn test_array_of_bytes_interpolation() {
+fn test_array_of_runes_interpolation() {
 	aa := [`a`, `b`, `c`]
-	assert '$aa' == '[a, b, c]'
+	assert '$aa' == '[`a`, `b`, `c`]'
 }
 
 fn test_array_of_strings_interpolation() {


### PR DESCRIPTION
This PR fixes array/fixed_array_rune_str.

- Fix array/fixed_array_rune_str.
- Modify related tests.

```v
fn main() {
	a := [`a`, `b`]
	println(a)
	b := [`a`, `b`]!!
	println(b)
}

PS D:\Test\v\tt1> v run .
[`a`, `b`]
[`a`, `b`]
```