### PR TITLE
checker: fix indexing a type alias instance

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4601,7 +4601,7 @@ fn (mut c Checker) check_index_type(typ_sym &table.TypeSymbol, index_type table.
 pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) table.Type {
 	typ := c.expr(node.left)
 	node.left_type = typ
-	typ_sym := c.table.get_type_symbol(typ)
+	typ_sym := c.table.get_final_type_symbol(typ)
 	if typ_sym.kind !in [.array, .array_fixed, .string, .map] && !typ.is_ptr() && !(!typ_sym.name[0].is_capital() &&
 		typ_sym.name.ends_with('ptr')) && !typ.has_flag(.variadic) { // byteptr, charptr etc
 		c.error('type `$typ_sym.name` does not support indexing', node.pos)

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3840,7 +3840,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 			g.write(')')
 		}
 		else {
-			sym := g.table.get_type_symbol(node.left_type)
+			sym := g.table.get_final_type_symbol(node.left_type)
 			left_is_ptr := node.left_type.is_ptr()
 			if sym.kind == .array {
 				info := sym.info as table.Array

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -638,7 +638,7 @@ pub fn (mut t Table) add_placeholder_type(name string, language Language) int {
 
 [inline]
 pub fn (t &Table) value_type(typ Type) Type {
-	typ_sym := t.get_type_symbol(typ)
+	typ_sym := t.get_final_type_symbol(typ)
 	if typ.has_flag(.variadic) {
 		// ...string => string
 		// return typ.clear_flag(.variadic)

--- a/vlib/v/tests/array_type_alias_test.v
+++ b/vlib/v/tests/array_type_alias_test.v
@@ -1,0 +1,6 @@
+type Test = []int
+
+fn test_index() {
+    t := Test([2,4])
+    assert t[1] == 4
+}

--- a/vlib/v/tests/map_type_alias_test.v
+++ b/vlib/v/tests/map_type_alias_test.v
@@ -1,11 +1,6 @@
 type Test = map[string]string
 
-fn (t Test) get(key string) string {
-    return t[key]
-}
-
-fn main() {
+fn test_index() {
     t := Test({'c': 'abc'})
-    r := t.get('c')
-    println(r)
+    assert t['c'] == 'abc'
 }

--- a/vlib/v/tests/map_type_alias_test.v
+++ b/vlib/v/tests/map_type_alias_test.v
@@ -1,0 +1,11 @@
+type Test = map[string]string
+
+fn (t Test) get(key string) string {
+    return t[key]
+}
+
+fn main() {
+    t := Test({'c': 'abc'})
+    r := t.get('c')
+    println(r)
+}


### PR DESCRIPTION
Fixes #5551.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
