### PR TITLE
vet: add suggestions for function documentation

### DIFF
--- a/cmd/tools/check-md.v
+++ b/cmd/tools/check-md.v
@@ -30,12 +30,12 @@ c) `v run cmd/tools/check-md.v -hide-warnings file.md` - same, but will not prin
 
 NB: There are several special keywords, which you can put after the code fences for v.
 These are:
-   compile      - default, you do not need to specify it. cmd/tools/check-md.v compile the example.
-   ignore       - ignore the example, useful for examples that just use the syntax highlighting
-   failcompile  - known failing compilation. Useful for examples demonstrating compiler errors.
-   oksyntax     - it should parse, it may not compile. Useful for partial examples.
-   badsyntax    - known bad syntax, it should not even parse
-   wip          - like ignore; a planned feature; easy to search.
+	compile      - default, you do not need to specify it. cmd/tools/check-md.v compile the example.
+	ignore       - ignore the example, useful for examples that just use the syntax highlighting
+	failcompile  - known failing compilation. Useful for examples demonstrating compiler errors.
+	oksyntax     - it should parse, it may not compile. Useful for partial examples.
+	badsyntax    - known bad syntax, it should not even parse
+	wip          - like ignore; a planned feature; easy to search.
 ')
 		exit(0)
 	}

--- a/cmd/tools/vvet/tests/array_init_one_val.out
+++ b/cmd/tools/vvet/tests/array_init_one_val.out
@@ -1,2 +1,2 @@
-cmd/tools/vvet/tests/array_init_one_val.vv:2: Use `var == value` instead of `var in [value]`
+cmd/tools/vvet/tests/array_init_one_val.vv:2: error: Use `var == value` instead of `var in [value]`
 NB: You can run `v fmt -w file.v` to fix these automatically

--- a/cmd/tools/vvet/tests/indent_with_space.out
+++ b/cmd/tools/vvet/tests/indent_with_space.out
@@ -1,2 +1,2 @@
-cmd/tools/vvet/tests/indent_with_space.vv:2: Looks like you are using spaces for indentation.
+cmd/tools/vvet/tests/indent_with_space.vv:2: error: Looks like you are using spaces for indentation.
 NB: You can run `v fmt -w file.v` to fix these automatically

--- a/cmd/tools/vvet/tests/module_file_test.out
+++ b/cmd/tools/vvet/tests/module_file_test.out
@@ -1,5 +1,4 @@
-vlib/v/vet/tests/module_file_test.vv:7: Function documentation seems to be missing for "pub fn foo() string".
-vlib/v/vet/tests/module_file_test.vv:13: A function name is missing from the documentation of "pub fn bar() string".
-vlib/v/vet/tests/module_file_test.vv:35: Function documentation seems to be missing for "pub fn (f Foo) foo() string".
-vlib/v/vet/tests/module_file_test.vv:46: A function name is missing from the documentation of "pub fn (f Foo) fooo() string".
-NB: You can run `v fmt -w file.v` to fix these automatically
+cmd/tools/vvet/tests/module_file_test.vv:7: warning: Function documentation seems to be missing for "pub fn foo() string".
+cmd/tools/vvet/tests/module_file_test.vv:13: warning: A function name is missing from the documentation of "pub fn bar() string".
+cmd/tools/vvet/tests/module_file_test.vv:35: warning: Function documentation seems to be missing for "pub fn (f Foo) foo() string".
+cmd/tools/vvet/tests/module_file_test.vv:46: warning: A function name is missing from the documentation of "pub fn (f Foo) fooo() string".

--- a/cmd/tools/vvet/tests/module_file_test.out
+++ b/cmd/tools/vvet/tests/module_file_test.out
@@ -1,0 +1,5 @@
+vlib/v/vet/tests/module_file_test.vv:7: Function documentation seems to be missing for "pub fn foo() string".
+vlib/v/vet/tests/module_file_test.vv:13: A function name is missing from the documentation of "pub fn bar() string".
+vlib/v/vet/tests/module_file_test.vv:35: Function documentation seems to be missing for "pub fn (f Foo) foo() string".
+vlib/v/vet/tests/module_file_test.vv:46: A function name is missing from the documentation of "pub fn (f Foo) fooo() string".
+NB: You can run `v fmt -w file.v` to fix these automatically

--- a/cmd/tools/vvet/tests/module_file_test.vv
+++ b/cmd/tools/vvet/tests/module_file_test.vv
@@ -1,0 +1,49 @@
+module foo
+
+struct Foo {
+	foo int
+}
+
+pub fn foo() string {
+	// Missing doc
+	return 'foo'
+}
+
+// foo does bar
+pub fn bar() string {
+	// not using convention style: '// <fn name>'
+	return 'bar'
+}
+
+// fooo does x
+pub fn fooo() string {
+	// Documented
+	return 'fooo'
+}
+
+// booo does x
+fn booo() string {
+	// Documented, but not pub
+	return 'booo'
+}
+
+fn boo() string {
+	// Missing doc
+	return 'boo'
+}
+
+pub fn (f Foo) foo() string {
+	// Missing doc
+	return f.fo()
+}
+
+fn (f Foo) fo() string {
+	// Missing doc, but not pub
+	return 'foo'
+}
+
+// wrong doc
+pub fn (f Foo) fooo() string {
+	// not using convention
+	return f.fo()
+}

--- a/cmd/tools/vvet/tests/parens_space_a.out
+++ b/cmd/tools/vvet/tests/parens_space_a.out
@@ -1,2 +1,2 @@
-cmd/tools/vvet/tests/parens_space_a.vv:1: Looks like you are adding a space after `(`
+cmd/tools/vvet/tests/parens_space_a.vv:1: error: Looks like you are adding a space after `(`
 NB: You can run `v fmt -w file.v` to fix these automatically

--- a/cmd/tools/vvet/tests/parens_space_b.out
+++ b/cmd/tools/vvet/tests/parens_space_b.out
@@ -1,2 +1,2 @@
-cmd/tools/vvet/tests/parens_space_b.vv:1: Looks like you are adding a space before `)`
+cmd/tools/vvet/tests/parens_space_b.vv:1: error: Looks like you are adding a space before `)`
 NB: You can run `v fmt -w file.v` to fix these automatically

--- a/cmd/tools/vvet/vet_test.v
+++ b/cmd/tools/vvet/vet_test.v
@@ -33,7 +33,8 @@ fn check_path(vexe string, dir string, tests []string) int {
 	for path in paths {
 		program := path
 		print(path + ' ')
-		res := os.exec('$vexe vet $program') or { panic(err) }
+		// -force is needed so that `v vet` would not skip the regression files
+		res := os.exec('$vexe vet -force $program') or { panic(err) }
 		mut expected := os.read_file(program.replace('.vv', '') + '.out') or { panic(err) }
 		expected = clean_line_endings(expected)
 		found := clean_line_endings(res.output)

--- a/cmd/tools/vvet/vet_test.v
+++ b/cmd/tools/vvet/vet_test.v
@@ -1,6 +1,14 @@
 import os
 import term
 import v.util.vtest
+import v.util
+
+const diff_cmd = find_diff_cmd()
+
+fn find_diff_cmd() string {
+	res := util.find_working_diff_command() or { '' }
+	return res
+}
 
 fn test_vet() {
 	vexe := os.getenv('VEXE')
@@ -37,6 +45,9 @@ fn check_path(vexe string, dir string, tests []string) int {
 			println('============')
 			println('found:')
 			println(found)
+			println('============\n')
+			println('diff:')
+			println(util.color_compare_strings(diff_cmd, found, expected))
 			println('============\n')
 			nb_fail++
 		} else {

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -4,7 +4,6 @@ module main
 
 import os
 import os.cmdline
-
 import v.vet
 import v.pref
 import v.parser

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -28,6 +28,11 @@ fn (vet &Vet) vprintln(s string) {
 	println(s)
 }
 
+fn should_skip(path string) bool {
+	return path.ends_with('_test.v') ||
+		(path.contains('/tests/') && !path.contains('cmd/tools/vvet/tests/'))
+}
+
 fn main() {
 	args := os.args.clone()
 	mut paths := cmdline.only_non_options(cmdline.options_after(args, ['vet']))
@@ -48,7 +53,7 @@ fn main() {
 			eprintln('File/folder $path does not exist')
 			continue
 		}
-		if path.ends_with('_test.v') || path.contains('/tests/') {
+		if should_skip(path) {
 			eprintln('skipping $path')
 			continue
 		}
@@ -62,7 +67,7 @@ fn main() {
 			files << vfiles
 			files << vvfiles
 			for file in files {
-				if file.ends_with('_test.v') || file.contains('/tests/') { // TODO copy pasta
+				if should_skip(file) {
 					continue
 				}
 				vet.vet_file(file)

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -143,7 +143,7 @@ fn (mut vt Vet) vet_file(path string, is_regression_test bool) {
 	mut prefs := pref.new_preferences()
 	prefs.is_vet = true
 	table := table.new_table()
-	vet_options.vprintln("vetting file '$path'...")
+	vt.vprintln("vetting file '$path'...")
 	_, errors := parser.parse_vet_file(path, table, prefs)
 	// Transfer errors from scanner and parser
 	vt.errors << errors

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -48,8 +48,7 @@ fn main() {
 			eprintln('File/folder $path does not exist')
 			continue
 		}
-		if path.ends_with('_test.v') ||
-			(path.contains('/tests/') && !path.contains('cmd/tools/vvet/tests/')) {
+		if path.ends_with('_test.v') || path.contains('/tests/') {
 			eprintln('skipping $path')
 			continue
 		}
@@ -90,7 +89,7 @@ fn main() {
 
 fn (mut v Vet) error(msg string, line int, fix vet.FixKind) {
 	pos := token.Position{
-		line_nr: line
+		line_nr: line + 1
 	}
 	v.errors << vet.Error{
 		message: msg
@@ -103,7 +102,7 @@ fn (mut v Vet) error(msg string, line int, fix vet.FixKind) {
 
 fn (mut v Vet) warn(msg string, line int, fix vet.FixKind) {
 	pos := token.Position{
-		line_nr: line
+		line_nr: line + 1
 	}
 	v.errors << vet.Error{
 		message: msg

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -4,6 +4,7 @@ module main
 
 import os
 import os.cmdline
+
 import v.vet
 import v.pref
 import v.parser

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -28,26 +28,28 @@ fn (vet &Vet) vprintln(s string) {
 	println(s)
 }
 
-const is_force = '-force' in os.args
+const vet_options = cmdline.options_after(os.args, ['vet'])
 
-const is_verbose = '-verbose' in os.args || '-v' in os.args
+const is_force = '-force' in vet_options
 
-const show_warnings = '-hide-warnings' !in os.args
+const is_verbose = '-verbose' in vet_options || '-v' in vet_options
+
+const show_warnings = '-hide-warnings' !in vet_options
 
 fn main() {
-	mut paths := cmdline.only_non_options(cmdline.options_after(os.args, ['vet']))
-	vtmp := os.getenv('VTMP')
-	if vtmp != '' {
-		// `v test-cleancode` passes also `-o tmpfolder` as well as all options in VFLAGS
-		paths = paths.filter(!it.starts_with(vtmp))
-	}
-	//
 	opt := Options{
 		is_verbose: is_verbose
 	}
 	mut vet := Vet{
 		opt: opt
 	}
+	mut paths := cmdline.only_non_options(vet_options)
+	vtmp := os.getenv('VTMP')
+	if vtmp != '' {
+		// `v test-cleancode` passes also `-o tmpfolder` as well as all options in VFLAGS
+		paths = paths.filter(!it.starts_with(vtmp))
+	}
+	//
 	for path in paths {
 		if !os.exists(path) {
 			eprintln('File/folder $path does not exist')

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -2,22 +2,29 @@
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module main
 
+import os
+import os.cmdline
+
 import v.vet
 import v.pref
 import v.parser
 import v.util
 import v.table
-import os
-import os.cmdline
+import v.token
 
-struct VetOptions {
-	is_verbose bool
+struct Vet {
+	opt    Options
 mut:
-	errors     []vet.Error
+	errors []vet.Error
+	file   string
 }
 
-fn (vet_options &VetOptions) vprintln(s string) {
-	if !vet_options.is_verbose {
+struct Options {
+	is_verbose bool
+}
+
+fn (vet &Vet) vprintln(s string) {
+	if !vet.opt.is_verbose {
 		return
 	}
 	println(s)
@@ -26,8 +33,11 @@ fn (vet_options &VetOptions) vprintln(s string) {
 fn main() {
 	args := util.join_env_vflags_and_os_args()
 	paths := cmdline.only_non_options(cmdline.options_after(args, ['vet']))
-	mut vet_options := VetOptions{
+	opt := Options{
 		is_verbose: '-verbose' in args || '-v' in args
+	}
+	mut vet := Vet{
+		opt: opt
 	}
 	for path in paths {
 		if !os.exists(path) {
@@ -40,9 +50,9 @@ fn main() {
 			continue
 		}
 		if path.ends_with('.v') || path.ends_with('.vv') {
-			vet_options.vet_file(path)
+			vet.vet_file(path)
 		} else if os.is_dir(path) {
-			vet_options.vprintln("vetting folder '$path'...")
+			vet.vprintln("vetting folder '$path'...")
 			vfiles := os.walk_ext(path, '.v')
 			vvfiles := os.walk_ext(path, '.vv')
 			mut files := []string{}
@@ -52,17 +62,17 @@ fn main() {
 				if file.ends_with('_test.v') || file.contains('/tests/') { // TODO copy pasta
 					continue
 				}
-				vet_options.vet_file(file)
+				vet.vet_file(file)
 			}
 		}
 	}
-	if vet_options.errors.len > 0 {
-		for err in vet_options.errors.filter(it.kind == .error) {
+	if vet.errors.len > 0 {
+		for err in vet.errors.filter(it.kind == .error && it.fix == .vfmt) {
 			eprintln('$err.file_path:$err.pos.line_nr: $err.message')
 		}
 		eprintln('NB: You can run `v fmt -w file.v` to fix these automatically')
 		/*
-		for err in vet_options.errors.filter(it.kind == .warning) {
+		for err in vet.errors.filter(it.kind == .warning) {
 			eprintln('$err.file_path:$err.pos.line_nr: err.message')
 		}
 		*/
@@ -70,12 +80,122 @@ fn main() {
 	}
 }
 
-fn (mut vet_options VetOptions) vet_file(path string) {
+fn (mut vet Vet) error(msg string, line int, fix FixKind) {
+	pos := token.Position{
+		line_nr: line
+	}
+	vet.errors << vet.Error{
+		message: msg
+		file_path: vet.file
+		pos: pos
+		kind: .error
+		fix: fix
+	}
+}
+
+// vet_file vets the file read from `path`.
+fn (mut vet Vet) vet_file(path string) {
+	vet.file = path
 	mut prefs := pref.new_preferences()
 	prefs.is_vet = true
 	table := table.new_table()
 	vet_options.vprintln("vetting file '$path'...")
 	_, errors := parser.parse_vet_file(path, table, prefs)
 	// Transfer errors from scanner and parser
-	vet_options.errors << errors
+	vet.errors << errors
+	// Scan each line in file for things to improve
+	source_lines := os.read_lines(vet.file) or { []string{} }
+	for lnumber, line in source_lines {
+		vet_line(line, lnumber)
+	}
+}
+
+// vet_line vets the contents of `line` from `vet.file`.
+fn (mut vet Vet) vet_line(line string, lnumber int) {
+	// Vet public functions
+	if line.starts_with('pub fn') ||
+		(line.starts_with('fn ') && !(line.starts_with('fn C.') || line.starts_with('fn main'))) {
+		// Scan function declarations for missing documentation
+		is_pub_fn := line.starts_with('pub fn')
+		if lnumber > 0 && source_lines.len > 0 {
+			collect_tags := fn(line string) []string {
+				mut cleaned := line.all_before('/')
+				cleaned = cleaned.replace_each(['[', '', ']', '', ' ', ''])
+				return cleaned.split(',')
+			}
+			ident_fn_name := fn(line string) string {
+				mut fn_idx := line.index(' fn ') or { return '' }
+				mut skip := false
+				mut p_count := 0
+				mut fn_name := ''
+				for i := fn_idx + 4; i < line.len; i++ {
+					char := line[i]
+					if !skip && char == `(` {
+						p_count++
+						skip = true
+						continue
+					} else if skip && char == `)` {
+						skip = false
+						continue
+					} else if char == ` ` {
+						continue
+					} else if char.is_letter() {
+						//fn_name += char.str()
+						fn_name = line[i..].all_before('(')
+						break
+					}
+					if p_count > 1 {
+						break
+					}
+				}
+				return fn_name
+			}
+			mut line_above := source_lines[lnumber - 1]
+			mut tags := []string{}
+			if !line_above.starts_with('//') {
+				mut grab := true
+				for j := lnumber - 1; j >= 0; j-- {
+					prev_line := source_lines[j]
+					if prev_line.contains('}') { // We've looked back to the above scope, stop here
+						break
+					} else if prev_line.starts_with('[') {
+						tags << collect_tags(prev_line)
+						continue
+					} else if prev_line.starts_with('//') { // Single-line comment
+						grab = false
+						break
+					}
+				}
+				if grab {
+					clean_line := line.all_before_last('{').trim(' ')
+					if is_pub_fn {
+						vet.error('Function documentation seems to be missing for "$clean_line".', lnumber, .doc)
+					}
+				}
+			} else {
+				fn_name := ident_fn_name(line)
+				mut grab := true
+				for j := lnumber - 1; j >= 0; j-- {
+					prev_line := source_lines[j]
+					if prev_line.contains('}') { // We've looked back to the above scope, stop here
+						break
+					} else if prev_line.starts_with('// $fn_name ') {
+						grab = false
+						break
+					} else if prev_line.starts_with('[') {
+						tags << collect_tags(prev_line)
+						continue
+					} else if prev_line.starts_with('//') { // Single-line comment
+						continue
+					}
+				}
+				if grab {
+					clean_line := line.all_before_last('{').trim(' ')
+					if is_pub_fn {
+						p.vet_error('A function name is missing from the documentation of "$clean_line".', lnumber, .doc)
+					}
+				}
+			}
+		}
+	}
 }

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -179,105 +179,12 @@ pub fn parse_vet_file(path string, table_ &table.Table, pref &pref.Preferences) 
 		global_scope: global_scope
 	}
 	p.set_path(path)
-<<<<<<< HEAD
 	if p.scanner.text.contains('\n  ') {
 		source_lines := os.read_lines(path) or { []string{} }
 		for lnumber, line in source_lines {
 			if line.starts_with('  ') {
 				p.vet_error('Looks like you are using spaces for indentation.', lnumber,
 					.vfmt)
-=======
-	// Scan each line in file for things to improve
-	source_lines := os.read_lines(path) or { []string{} }
-	for lnumber, line in source_lines {
-		if line.starts_with('  ') {
-			p.vet_error('Looks like you are using spaces for indentation.', lnumber)
-		} else if line.starts_with('pub fn') ||
-			(line.starts_with('fn ') && !(line.starts_with('fn C.') || line.starts_with('fn main'))) {
-			// Scan function declarations for missing documentation
-			is_pub_fn := line.starts_with('pub fn')
-			if lnumber > 0 && source_lines.len > 0 {
-				collect_tags := fn (line string) []string {
-					mut cleaned := line.all_before('/')
-					cleaned = cleaned.replace_each(['[', '', ']', '', ' ', ''])
-					return cleaned.split(',')
-				}
-				ident_fn_name := fn (line string) string {
-					mut fn_idx := line.index(' fn ') or { return '' }
-					mut skip := false
-					mut p_count := 0
-					mut fn_name := ''
-					for i := fn_idx + 4; i < line.len; i++ {
-						char := line[i]
-						if !skip && char == `(` {
-							p_count++
-							skip = true
-							continue
-						} else if skip && char == `)` {
-							skip = false
-							continue
-						} else if char == ` ` {
-							continue
-						} else if char.is_letter() {
-							// fn_name += char.str()
-							fn_name = line[i..].all_before('(')
-							break
-						}
-						if p_count > 1 {
-							break
-						}
-					}
-					return fn_name
-				}
-				mut line_above := source_lines[lnumber - 1]
-				mut tags := []string{}
-				if !line_above.starts_with('//') {
-					mut grab := true
-					for j := lnumber - 1; j >= 0; j-- {
-						prev_line := source_lines[j]
-						if prev_line.contains('}') { // We've looked back to the above scope, stop here
-							break
-						} else if prev_line.starts_with('[') {
-							tags << collect_tags(prev_line)
-							continue
-						} else if prev_line.starts_with('//') { // Single-line comment
-							grab = false
-							break
-						}
-					}
-					if grab {
-						clean_line := line.all_before_last('{').trim(' ')
-						if is_pub_fn {
-							p.vet_error('Function documentation seems to be missing for "$clean_line".',
-								lnumber)
-						}
-					}
-				} else {
-					fn_name := ident_fn_name(line)
-					mut grab := true
-					for j := lnumber - 1; j >= 0; j-- {
-						prev_line := source_lines[j]
-						if prev_line.contains('}') { // We've looked back to the above scope, stop here
-							break
-						} else if prev_line.starts_with('// $fn_name ') {
-							grab = false
-							break
-						} else if prev_line.starts_with('[') {
-							tags << collect_tags(prev_line)
-							continue
-						} else if prev_line.starts_with('//') { // Single-line comment
-							continue
-						}
-					}
-					if grab {
-						clean_line := line.all_before_last('{').trim(' ')
-						if is_pub_fn {
-							p.vet_error('A function name is missing from the documentation of "$clean_line".',
-								lnumber)
-						}
-					}
-				}
->>>>>>> run vfmt over parser.v
 			}
 		}
 	}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -179,12 +179,105 @@ pub fn parse_vet_file(path string, table_ &table.Table, pref &pref.Preferences) 
 		global_scope: global_scope
 	}
 	p.set_path(path)
+<<<<<<< HEAD
 	if p.scanner.text.contains('\n  ') {
 		source_lines := os.read_lines(path) or { []string{} }
 		for lnumber, line in source_lines {
 			if line.starts_with('  ') {
 				p.vet_error('Looks like you are using spaces for indentation.', lnumber,
 					.vfmt)
+=======
+	// Scan each line in file for things to improve
+	source_lines := os.read_lines(path) or { []string{} }
+	for lnumber, line in source_lines {
+		if line.starts_with('  ') {
+			p.vet_error('Looks like you are using spaces for indentation.', lnumber)
+		} else if line.starts_with('pub fn') ||
+			(line.starts_with('fn ') && !(line.starts_with('fn C.') || line.starts_with('fn main'))) {
+			// Scan function declarations for missing documentation
+			is_pub_fn := line.starts_with('pub fn')
+			if lnumber > 0 && source_lines.len > 0 {
+				collect_tags := fn (line string) []string {
+					mut cleaned := line.all_before('/')
+					cleaned = cleaned.replace_each(['[', '', ']', '', ' ', ''])
+					return cleaned.split(',')
+				}
+				ident_fn_name := fn (line string) string {
+					mut fn_idx := line.index(' fn ') or { return '' }
+					mut skip := false
+					mut p_count := 0
+					mut fn_name := ''
+					for i := fn_idx + 4; i < line.len; i++ {
+						char := line[i]
+						if !skip && char == `(` {
+							p_count++
+							skip = true
+							continue
+						} else if skip && char == `)` {
+							skip = false
+							continue
+						} else if char == ` ` {
+							continue
+						} else if char.is_letter() {
+							// fn_name += char.str()
+							fn_name = line[i..].all_before('(')
+							break
+						}
+						if p_count > 1 {
+							break
+						}
+					}
+					return fn_name
+				}
+				mut line_above := source_lines[lnumber - 1]
+				mut tags := []string{}
+				if !line_above.starts_with('//') {
+					mut grab := true
+					for j := lnumber - 1; j >= 0; j-- {
+						prev_line := source_lines[j]
+						if prev_line.contains('}') { // We've looked back to the above scope, stop here
+							break
+						} else if prev_line.starts_with('[') {
+							tags << collect_tags(prev_line)
+							continue
+						} else if prev_line.starts_with('//') { // Single-line comment
+							grab = false
+							break
+						}
+					}
+					if grab {
+						clean_line := line.all_before_last('{').trim(' ')
+						if is_pub_fn {
+							p.vet_error('Function documentation seems to be missing for "$clean_line".',
+								lnumber)
+						}
+					}
+				} else {
+					fn_name := ident_fn_name(line)
+					mut grab := true
+					for j := lnumber - 1; j >= 0; j-- {
+						prev_line := source_lines[j]
+						if prev_line.contains('}') { // We've looked back to the above scope, stop here
+							break
+						} else if prev_line.starts_with('// $fn_name ') {
+							grab = false
+							break
+						} else if prev_line.starts_with('[') {
+							tags << collect_tags(prev_line)
+							continue
+						} else if prev_line.starts_with('//') { // Single-line comment
+							continue
+						}
+					}
+					if grab {
+						clean_line := line.all_before_last('{').trim(' ')
+						if is_pub_fn {
+							p.vet_error('A function name is missing from the documentation of "$clean_line".',
+								lnumber)
+						}
+					}
+				}
+>>>>>>> run vfmt over parser.v
 			}
 		}
 	}

--- a/vlib/v/vet/vet.v
+++ b/vlib/v/vet/vet.v
@@ -11,6 +11,7 @@ pub enum ErrorKind {
 
 pub enum FixKind {
 	unknown
+	doc
 	vfmt
 }
 


### PR DESCRIPTION
As title states

This will allow `vet` to suggest documenting undocumented `pub fn` functions - for encouraging developers to document their code. The logic is adapted from the `missdoc` tool I wrote for #7047 

I'm a little uncertain of the state of `vet` currently - as it seems to be *very early* WIP and spread across multiple files which is confusing to me?

vvet will now collect errors/warnings from scanner and parser runs plus have it's own run where it's possible to validate code per line in the file or by walking the ast.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
