### PR TITLE
vdoc: escape `<` and `>` before creating md

### DIFF
--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -399,7 +399,7 @@ fn doc_node_html(dd doc.DocNode, link string, head bool, tb &table.Table) string
 	mut dnw := strings.new_builder(200)
 	link_svg := '<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>'
 	head_tag := if head { 'h1' } else { 'h2' }
-	md_content := markdown.to_html(dd.comment)
+	md_content := markdown.to_html(html_tag_escape(dd.comment))
 	hlighted_code := html_highlight(dd.content, tb)
 	node_class := if dd.kind == .const_group { ' const' } else { '' }
 	sym_name := get_sym_name(dd)
@@ -432,6 +432,11 @@ fn doc_node_html(dd doc.DocNode, link string, head bool, tb &table.Table) string
 	}
 	return dnw_str
 }
+
+fn html_tag_escape(str string) string {
+  return str.replace_each(["<", "&lt;", ">", "&gt;"])
+}
+
 
 fn get_sym_name(dn doc.DocNode) string {
 	sym_name := if dn.parent_name.len > 0 && dn.parent_name != 'void' {

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -434,9 +434,8 @@ fn doc_node_html(dd doc.DocNode, link string, head bool, tb &table.Table) string
 }
 
 fn html_tag_escape(str string) string {
-  return str.replace_each(["<", "&lt;", ">", "&gt;"])
+	return str.replace_each(['<', '&lt;', '>', '&gt;'])
 }
-
 
 fn get_sym_name(dn doc.DocNode) string {
 	sym_name := if dn.parent_name.len > 0 && dn.parent_name != 'void' {


### PR DESCRIPTION
Currently, https://modules.vlang.io/vweb.assets.html has a html rendering error caused by the "<script>" in the markdowned text.
In order to avoid this error, this PR replaces "<" with "\&lt;" and ">" with "\&gt;" before they are markdowned.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
