### PR TITLE
builtin: int.v workaround vfmt bug

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -34,7 +34,10 @@ pub fn (nn int) str1() string {
 	return tos(buf + max - len, len)
 }
 */
-// ----- value to string functions -----
+/*
+*
+ ----- value to string functions -----
+*/
 /*
 // old function for reference
 pub fn ptr_str(ptr voidptr) string {


### PR DESCRIPTION
Fix to workaround this in the docs:
![image](https://user-images.githubusercontent.com/768942/103670820-62f8a980-4f7a-11eb-85f8-3c07007b2f8a.png)

When running `v fmt -w int.v` it would result in vfmt converting a 3 line block comment to a single line - resulting in vdoc picking it up (`vdoc` is doing it correctly IMO - but not `vfmt` in this case?)
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
