### PR TITLE
all: implement `ch <- x or {...}` and `ch <- x ?`

### DIFF
--- a/vlib/sync/channel_push_or_1_test.v
+++ b/vlib/sync/channel_push_or_1_test.v
@@ -1,0 +1,67 @@
+const n = 1000
+const c = 100
+
+fn f(ch chan int) {
+	for _ in 0 .. n {
+		_ := <-ch
+	}
+	ch.close()
+}
+
+fn test_push_or_unbuffered() {
+	ch := chan int{}
+	go f(ch)
+	mut j := 0
+	for {
+		ch <- j or {
+			break
+		}
+		j++
+	}
+	assert j == n
+}
+
+fn test_push_or_buffered() {
+	ch := chan int{cap: c}
+	go f(ch)
+	mut j := 0
+	for {
+		ch <- j or {
+			break
+		}
+		j++
+	}
+	// we don't know how many elements are in the buffer when the channel
+	// is closed, so check j against an interval
+	assert j >= n
+	assert j <= n + c
+}
+
+fn g(ch chan int, res chan int) {
+	mut j := 0
+	for {
+		ch <- j or {
+			break
+		}
+		j++
+	}
+	println('done $j')
+	res <- j
+}
+
+fn test_many_senders() {
+	ch := chan int{}
+	res := chan int{}
+	go g(ch, res)
+	go g(ch, res)
+	go g(ch, res)
+	mut k := 0
+	for _ in 0 .. 3 * n {
+		k = <-ch
+	}
+	ch.close()
+	mut sum := <-res
+	sum += <-res
+	sum += <-res
+	assert sum == 3 * n
+}

--- a/vlib/sync/channel_push_or_2_test.v
+++ b/vlib/sync/channel_push_or_2_test.v
@@ -1,27 +1,27 @@
 const n = 1000
 
-fn f(ch chan f64) {
-	mut s := 0.0
+fn f(ch chan int) {
+	mut s := 0
 	for _ in 0 .. n {
 		s += <-ch
 	}
-	assert s == f64(n * (n + 1) / 2)
+	assert s == n * (n + 1) / 2
 	ch.close()
 }
 
-fn do_send(ch chan f64, val f64) ?f64 {
+fn do_send(ch chan int, val int) ?int {
 	ch <- val ?
-	return val + 1.0
+	return val + 1
 }
 
 fn test_push_propargate() {
-	ch := chan f64{}
+	ch := chan int{}
 	go f(ch)
-	mut s := 1.0
+	mut s := 1
 	for {
 		s = do_send(ch, s) or {
 			break
 		}
 	}
-	assert s == f64(n + 1)
+	assert s == n + 1
 }

--- a/vlib/sync/channel_push_or_2_test.v
+++ b/vlib/sync/channel_push_or_2_test.v
@@ -1,0 +1,27 @@
+const n = 1000
+
+fn f(ch chan f64) {
+	mut s := 0.0
+	for _ in 0 .. n {
+		s += <-ch
+	}
+	assert s == f64(n * (n + 1) / 2)
+	ch.close()
+}
+
+fn do_send(ch chan f64, val f64) ?f64 {
+	ch <- val ?
+	return val + 1.0
+}
+
+fn test_push_propargate() {
+	ch := chan f64{}
+	go f(ch)
+	mut s := 1.0
+	for {
+		s = do_send(ch, s) or {
+			break
+		}
+	}
+	assert s == f64(n + 1)
+}

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -337,9 +337,6 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 			}
 		}
 	}
-	// this should not happen
-	assert false
-	return .success
 }
 
 [inline]

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -262,8 +262,11 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 					ch.writesem_im.wait()
 				}
 				if C.atomic_load_u16(&ch.closed) != 0 {
-					ch.writesem_im.post()
-					return .closed
+					if have_swapped {
+						return .success
+					} else {
+						return .closed
+					}
 				}
 				if have_swapped || C.atomic_compare_exchange_strong_ptr(&ch.adr_read, &src2, voidptr(0)) {
 					ch.writesem.post()

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -337,6 +337,9 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 			}
 		}
 	}
+	// we should not get here but the V compiler want's to see a return statement
+	assert false
+	return .success
 }
 
 [inline]

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -262,7 +262,8 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 					ch.writesem_im.wait()
 				}
 				if C.atomic_load_u16(&ch.closed) != 0 {
-					if have_swapped || ch.writesem_im.try_wait() {
+					if have_swapped || C.atomic_compare_exchange_strong_ptr(&ch.adr_read, &src2, voidptr(0)) {
+						ch.writesem.post()
 						return .success
 					} else {
 						return .closed

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -262,7 +262,7 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 					ch.writesem_im.wait()
 				}
 				if C.atomic_load_u16(&ch.closed) != 0 {
-					if have_swapped {
+					if have_swapped || ch.writesem_im.try_wait() {
 						return .success
 					} else {
 						return .closed

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -532,6 +532,7 @@ pub mut:
 	left_type   table.Type
 	right_type  table.Type
 	auto_locked string
+	or_block    OrExpr
 }
 
 // ++, --

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -902,6 +902,7 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 					c.error('cannot push non-reference `$right.name` on `$left.name`',
 						right_pos)
 				}
+				c.stmts(infix_expr.or_block.stmts)
 			} else {
 				c.error('cannot push on non-channel `$left.name`', left_pos)
 			}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -565,7 +565,7 @@ static inline Option_void __Option_${styp}_pushval($styp ch, ${el_type} e) {
 		Option _tmp2 = v_error(_SLIT("channel closed"));
 		return *(Option_void*)&_tmp2;
 	}
-	Option_void _tmp = {.ok = true; .is_none = false; .v_error = (string){.str=(byteptr)""}; .ecode = 0};
+	Option_void _tmp = {.ok = true, .is_none = false, .v_error = (string){.str=(byteptr)""}, .ecode = 0};
 	return _tmp;
 }')
 	}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -560,7 +560,7 @@ fn (mut g Gen) register_chan_push_optional_call(el_type string, styp string) {
 	if styp !in g.chan_push_optionals {
 		g.chan_push_optionals << styp
 		g.channel_definitions.writeln('
-static inline Option_void __Option_${styp}_pushval($styp ch, ${el_type} e) {
+static inline Option_void __Option_${styp}_pushval($styp ch, $el_type e) {
 	if (sync__Channel_try_push_priv(ch, &e, false)) {
 		Option _tmp2 = v_error(_SLIT("channel closed"));
 		return *(Option_void*)&_tmp2;


### PR DESCRIPTION
This PR allows handling closed channels when pushing objects:
```v
// or branch
ch <- a or {
     println('channel is closed')
}
// error propagation
ch <- a ?
```
When the channel is not closed but the send operation cannot be performed immediately (because there is no space available in the buffer and no receiving command is waiting on the other side) the operation blocks waiting for a condition to continue.
The `or` branch is run when the channel was closed when the push statement is entered or when the channel is closed while the operation is blocking. So either the transfer completes or the `or` branch is run. (Not both - at least I hope so... ;-)

Test cases are added for buffered and unbuffered channels, for concurrently sending threads and for error propagation.

For the receiving side a similar approach been implemented in #6195.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
