### PR TITLE
doc: fix README embedding

### DIFF
--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -267,12 +267,7 @@ pub fn (mut d Doc) file_ast(file_ast ast.File) map[string]DocNode {
 				if module_comment == '' {
 					continue
 				}
-				/*
-				if d.head.comment != '' {
-					d.head.comment += '\n'
-				}
-				*/
-				d.head.comments << preceeding_comments //+= module_comment
+				d.head.comments << preceeding_comments
 			}
 			continue
 		}
@@ -280,13 +275,7 @@ pub fn (mut d Doc) file_ast(file_ast ast.File) map[string]DocNode {
 			// the accumulated comments were interspersed before/between the imports;
 			// just add them all to the module comments:
 			if d.with_head {
-				// import_comments := merge_comments(preceeding_comments)
-				/*
-				if d.head.comment != '' {
-					d.head.comment += '\n'
-				}
-				*/
-				d.head.comments << preceeding_comments //+= import_comments
+				d.head.comments << preceeding_comments
 			}
 			preceeding_comments = []
 			imports_section = false
@@ -310,17 +299,7 @@ pub fn (mut d Doc) file_ast(file_ast ast.File) map[string]DocNode {
 			}
 		}
 		if d.with_comments && (preceeding_comments.len > 0) {
-			// last_comment := contents[contents.len - 1].comment
-			// cmt := last_comment + '\n' + merge_doc_comments(preceeding_comments)
-			/*
-			mut cmt := merge_doc_comments(preceeding_comments)
-			len := node.name.len
-			// fixed-width symbol name at start of comment
-			if cmt.starts_with(node.name) && cmt.len > len && cmt[len] == ` ` {
-				cmt = '`${cmt[..len]}`' + cmt[len..]
-			}
-			*/
-			node.comments << preceeding_comments //= cmt
+			node.comments << preceeding_comments
 		}
 		preceeding_comments = []
 		if node.parent_name.len > 0 {

--- a/vlib/v/doc/utils.v
+++ b/vlib/v/doc/utils.v
@@ -56,7 +56,7 @@ pub fn merge_doc_comments(comments []DocComment) string {
 			// break
 		}
 		mut cmt_content := cmt.text.trim_left('\x01')
-		if cmt_content.len == cmt.text.len || cmt.is_multi {
+		if cmt.is_multi {
 			// ignore /* */ style comments for now
 			continue
 			// if cmt_content.len == 0 {


### PR DESCRIPTION
This fixes README embedding in HTML and plain text output after adding support for inline examples in docs.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
