### PR TITLE
ftp: fix ftp_test (fix parts of #7914)

### DIFF
--- a/vlib/io/buffered_reader.v
+++ b/vlib/io/buffered_reader.v
@@ -32,9 +32,6 @@ pub fn new_buffered_reader(o BufferedReaderConfig) &BufferedReader {
 
 // read fufills the Reader interface
 pub fn (mut r BufferedReader) read(mut buf []byte) ?int {
-	if r.end_of_stream {
-		return none
-	}
 	// read data out of the buffer if we dont have any
 	if r.needs_fill() {
 		if !r.fill_buffer() {
@@ -53,7 +50,7 @@ fn (mut r BufferedReader) fill_buffer() bool {
 	if r.end_of_stream {
 		// we know we have already reached the end of stream
 		// so return early
-		return false
+		return true
 	}
 	r.offset = 0
 	r.len = 0
@@ -117,4 +114,3 @@ pub fn (mut r BufferedReader) read_line() ?string {
 		r.offset = i
 	}
 }
- 


### PR DESCRIPTION
This PR fixes ftp error (fix parts of #7914).

- Fixes new_dtp() generated &DTP to avoid `WSAENOTSOCK` error.
- Fixes dtp.read() to read all the contents.

```v
module main

import net.ftp

// NB: this function makes network calls to external servers,
// that is why it is not a very good idea to run it in CI.
// If you want to run it manually, use `v -d network vlib/net/ftp/ftp_test.v`
fn ftp_client_test_inside() ? {
	mut ftp := ftp.new()
	defer {
		ftp.close()
	}
	connect_result := ftp.connect('ftp.redhat.com') ?
	assert connect_result
	login_result := ftp.login('ftp', 'ftp') ?
	assert login_result
	pwd := ftp.pwd() ?
	assert pwd.len > 0
	ftp.cd('/')
	dir_list1 := ftp.dir() or {
		eprintln(err)
		return
	}
	assert dir_list1.len > 0
	for ss in dir_list1 {
		println(ss)
	}
	ftp.cd('/suse/linux/enterprise/11Server/en/SAT-TOOLS/SRPMS/')
	dir_list2 := ftp.dir() or {
		assert false
		return
	}
	assert dir_list2.len > 0
	blob := ftp.get('katello-host-tools-3.3.5-8.sles11_4sat.src.rpm') or {
		assert false
		return
	}
	assert blob.len > 0
	println('blob len = $blob.len')
}

fn main() {
	ftp_client_test_inside() or { panic(err) }
}

PS D:\Test\v\tt1> v run .
.
redhat
suse
blob len = 55670
```