### PR TITLE
checker: check unknown generic type (fix #7947)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1651,6 +1651,12 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 		// builtin C.m*, C.s* only - temp
 		c.warn('function `$f.name` must be called from an `unsafe` block', call_expr.pos)
 	}
+	if f.is_generic {
+		sym := c.table.get_type_symbol(call_expr.generic_type)
+		if sym.kind == .placeholder {
+			c.error('unknown type `$sym.name`', call_expr.generic_list_pos)
+		}
+	}
 	if f.is_generic && f.return_type.has_flag(.generic) {
 		rts := c.table.get_type_symbol(f.return_type)
 		if rts.kind == .struct_ {

--- a/vlib/v/checker/tests/unknown_generic_type.out
+++ b/vlib/v/checker/tests/unknown_generic_type.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/unknown_generic_type.vv:5:13: error: unknown type `Foo`
+    3 |
+    4 | fn main() {
+    5 |     x := decode<Foo>('{"name": "test"}')?
+      |                ~~~~~
+    6 |     println(x)
+    7 | }

--- a/vlib/v/checker/tests/unknown_generic_type.vv
+++ b/vlib/v/checker/tests/unknown_generic_type.vv
@@ -1,0 +1,7 @@
+fn decode<T>(raw_data string) ?T {
+}
+
+fn main() {
+	x := decode<Foo>('{"name": "test"}')?
+	println(x)
+}


### PR DESCRIPTION
This PR check unknown generic type (fix #7947).

- Check unknown generic type.
- Add test `unknown_generic_type.vv/out`.

```v
module main

fn decode<T>(raw_data string) ?T {
}

fn main() {
	x := decode<Foo>('{"name": "test"}')?
	println(x)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:7:13: error: unknown type `Foo`
    5 |
    6 | fn main() {
    7 |     x := decode<Foo>('{"name": "test"}')?
      |                ~~~~~
    8 |     println(x)
    9 | }
```