### PR TITLE
vdoc: don't escape < and > in README, fixes #7951

### DIFF
--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -14,7 +14,7 @@ const (
 	css_js_assets = ['doc.css', 'normalize.css', 'doc.js', 'dark-mode.js']
 	res_path      = os.resource_abs_path('resources')
 	favicons_path = os.join_path(res_path, 'favicons')
-	link_svg = '<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>'
+	link_svg      = '<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>'
 	html_content  = '<!DOCTYPE html>
 <html lang="en">
 	<head>
@@ -422,18 +422,16 @@ fn html_highlight(code string, tb &table.Table) string {
 
 fn doc_node_html(dn doc.DocNode, link string, head bool, include_examples bool, tb &table.Table) string {
 	mut dnw := strings.new_builder(200)
-
 	head_tag := if head { 'h1' } else { 'h2' }
 	comments := dn.merge_comments_without_examples()
 	// Allow README.md to go through unescaped except for script tags
 	escaped_html := if head && is_module_readme(dn) {
 		// Strip markdown [TOC] directives, since we generate our own.
-		stripped := comments.replace('[TOC]','')
+		stripped := comments.replace('[TOC]', '')
 		markdown_escape_script_tags(stripped)
 	} else {
 		html_tag_escape(comments)
 	}
-
 	md_content := markdown.to_html(escaped_html)
 	hlighted_code := html_highlight(dn.content, tb)
 	node_class := if dn.kind == .const_group { ' const' } else { '' }

--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -14,6 +14,7 @@ const (
 	css_js_assets = ['doc.css', 'normalize.css', 'doc.js', 'dark-mode.js']
 	res_path      = os.resource_abs_path('resources')
 	favicons_path = os.join_path(res_path, 'favicons')
+	link_svg = '<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>'
 	html_content  = '<!DOCTYPE html>
 <html lang="en">
 	<head>
@@ -421,10 +422,19 @@ fn html_highlight(code string, tb &table.Table) string {
 
 fn doc_node_html(dn doc.DocNode, link string, head bool, include_examples bool, tb &table.Table) string {
 	mut dnw := strings.new_builder(200)
-	link_svg := '<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>'
+
 	head_tag := if head { 'h1' } else { 'h2' }
 	comments := dn.merge_comments_without_examples()
-	md_content := markdown.to_html(html_tag_escape(comments))
+	// Allow README.md to go through unescaped except for script tags
+	escaped_html := if head && is_module_readme(dn) {
+		// Strip markdown [TOC] directives, since we generate our own.
+		stripped := comments.replace('[TOC]','')
+		markdown_escape_script_tags(stripped)
+	} else {
+		html_tag_escape(comments)
+	}
+
+	md_content := markdown.to_html(escaped_html)
 	hlighted_code := html_highlight(dn.content, tb)
 	node_class := if dn.kind == .const_group { ' const' } else { '' }
 	sym_name := get_sym_name(dn)

--- a/cmd/tools/vdoc/markdown.v
+++ b/cmd/tools/vdoc/markdown.v
@@ -3,6 +3,10 @@ module main
 import strings
 import v.doc
 
+fn markdown_escape_script_tags(str string) string {
+	return str.replace_each(['<script>','`','</script>','`'])
+}
+
 fn (vd VDoc) gen_markdown(d doc.Doc, with_toc bool) string {
 	mut hw := strings.new_builder(200)
 	mut cw := strings.new_builder(200)

--- a/cmd/tools/vdoc/markdown.v
+++ b/cmd/tools/vdoc/markdown.v
@@ -4,7 +4,7 @@ import strings
 import v.doc
 
 fn markdown_escape_script_tags(str string) string {
-	return str.replace_each(['<script>','`','</script>','`'])
+	return str.replace_each(['<script>', '`', '</script>', '`'])
 }
 
 fn (vd VDoc) gen_markdown(d doc.Doc, with_toc bool) string {


### PR DESCRIPTION
...also protect against XSS via README.md in HTML output.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
