### PR TITLE
fmt: do not generate `import` statements for auto imports

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2228,8 +2228,6 @@ a property of the individual channel object. Channels can be passed to coroutine
 variables:
 
 ```v
-import sync
-
 fn f(ch chan int) {
 	// ...
 }
@@ -2331,8 +2329,6 @@ if select {
 
 For special purposes there are some builtin properties and methods:
 ```v nofmt
-import sync
-
 struct Abc{x int}
 
 a := 2.13

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1,5 +1,3 @@
-import sync
-
 fn test_pointer() {
 	mut arr := []&int{}
 	a := 1

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -459,6 +459,7 @@ pub mut:
 	scope            &Scope
 	stmts            []Stmt   // all the statements in the source file
 	imports          []Import // all the imports
+	auto_imports     []string // imports that were implicitely added
 	imported_symbols map[string]string // used for `import {symbol}`, it maps symbol => module.symbol
 	errors           []errors.Error    // all the checker errors in the file
 	warnings         []errors.Warning  // all the checker warings in the file

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -39,7 +39,6 @@ pub mut:
 	did_imports       bool
 	is_assign         bool
 	auto_imports      []string // automatically inserted imports that the user does not need to specify
-	auto_imports_keep []string // auto imports that should be imported explicitely as they are used explicitely
 	import_pos        int      // position of the imports in the resulting string for later autoimports insertion
 	used_imports      []string // to remove unused imports
 	is_debug          bool
@@ -216,7 +215,7 @@ pub fn (mut f Fmt) imports(imports []ast.Import) {
 			// TODO bring back once only unused imports are removed
 			// continue
 		}
-		if imp.mod in f.auto_imports && imp.mod !in f.auto_imports_keep {
+		if imp.mod in f.auto_imports && imp.mod !in f.used_imports {
 			continue
 		}
 		f.out_imports.write('import ')
@@ -1682,7 +1681,7 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 			// `time.now()` without `time imported` is processed as a method call with `time` being
 			// a `node.left` expression. Import `time` automatically.
 			// TODO fetch all available modules
-			if node.left.name in ['time', 'os', 'strings', 'math', 'json', 'base64', 'sync'] {
+			if node.left.name in ['time', 'os', 'strings', 'math', 'json', 'base64'] {
 				f.file.imports << ast.Import{
 					mod: node.left.name
 					alias: node.left.name
@@ -1690,9 +1689,6 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 				// for imp in f.file.imports {
 				// println(imp.mod)
 				// }
-				if node.left.name in f.auto_imports && node.left.name !in f.auto_imports_keep {
-					f.auto_imports_keep << node.left.name
-				}
 			}
 		}
 		f.expr(node.left)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -39,6 +39,7 @@ pub mut:
 	did_imports       bool
 	is_assign         bool
 	auto_imports      []string // automatically inserted imports that the user does not need to specify
+	auto_imports_keep []string // auto imports that should be imported explicitely as they are used explicitely
 	import_pos        int      // position of the imports in the resulting string for later autoimports insertion
 	used_imports      []string // to remove unused imports
 	is_debug          bool
@@ -215,7 +216,7 @@ pub fn (mut f Fmt) imports(imports []ast.Import) {
 			// TODO bring back once only unused imports are removed
 			// continue
 		}
-		if imp.mod in f.auto_imports {
+		if imp.mod in f.auto_imports && imp.mod !in f.auto_imports_keep {
 			continue
 		}
 		f.out_imports.write('import ')
@@ -1681,17 +1682,17 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 			// `time.now()` without `time imported` is processed as a method call with `time` being
 			// a `node.left` expression. Import `time` automatically.
 			// TODO fetch all available modules
-			if node.left.name in ['time', 'os', 'strings', 'math', 'json', 'base64'] {
-				if node.left.name !in f.auto_imports {
-					f.auto_imports << node.left.name
-					f.file.imports << ast.Import{
-						mod: node.left.name
-						alias: node.left.name
-					}
+			if node.left.name in ['time', 'os', 'strings', 'math', 'json', 'base64', 'sync'] {
+				f.file.imports << ast.Import{
+					mod: node.left.name
+					alias: node.left.name
 				}
 				// for imp in f.file.imports {
 				// println(imp.mod)
 				// }
+				if node.left.name in f.auto_imports && node.left.name !in f.auto_imports_keep {
+					f.auto_imports_keep << node.left.name
+				}
 			}
 		}
 		f.expr(node.left)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -38,7 +38,7 @@ pub mut:
 	file              ast.File
 	did_imports       bool
 	is_assign         bool
-	auto_imports      []string // automatically inserted imports that the user forgot to specify
+	auto_imports      []string // automatically inserted imports that the user does not need to specify
 	import_pos        int      // position of the imports in the resulting string for later autoimports insertion
 	used_imports      []string // to remove unused imports
 	is_debug          bool
@@ -83,6 +83,7 @@ pub fn (mut f Fmt) process_file_imports(file &ast.File) {
 			f.mod2alias[sym.name] = sym.name
 		}
 	}
+	f.auto_imports = file.auto_imports
 }
 
 pub fn (mut f Fmt) write(s string) {
@@ -200,8 +201,8 @@ pub fn (mut f Fmt) imports(imports []ast.Import) {
 	if f.did_imports || imports.len == 0 {
 		return
 	}
-	// f.import_pos = f.out.len
 	f.did_imports = true
+	mut num_imports := 0
 	/*
 	if imports.len == 1 {
 		imp_stmt_str := f.imp_stmt_str(imports[0])
@@ -214,12 +215,16 @@ pub fn (mut f Fmt) imports(imports []ast.Import) {
 			// TODO bring back once only unused imports are removed
 			// continue
 		}
-		// f.out_imports.write('\t')
-		// f.out_imports.writeln(f.imp_stmt_str(imp))
+		if imp.mod in f.auto_imports {
+			continue
+		}
 		f.out_imports.write('import ')
 		f.out_imports.writeln(f.imp_stmt_str(imp))
+		num_imports++
 	}
-	f.out_imports.writeln('')
+	if num_imports > 0 {
+		f.out_imports.writeln('')
+	}
 	// f.out_imports.writeln(')\n')
 	// }
 }

--- a/vlib/v/fmt/tests/chan_init_keep.vv
+++ b/vlib/v/fmt/tests/chan_init_keep.vv
@@ -1,5 +1,3 @@
-import sync
-
 struct FSMEvent {
 	x int
 }

--- a/vlib/v/fmt/tests/shared_expected.vv
+++ b/vlib/v/fmt/tests/shared_expected.vv
@@ -1,4 +1,3 @@
-import sync
 import time
 
 struct St {

--- a/vlib/v/parser/module.v
+++ b/vlib/v/parser/module.v
@@ -42,6 +42,9 @@ fn (mut p Parser) register_auto_import(alias string) {
 		}
 		p.ast_imports << node
 	}
+	if alias !in p.auto_imports {
+		p.auto_imports << alias
+	}
 	p.register_used_import(alias)
 }
 

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -52,6 +52,7 @@ mut:
 	imports           map[string]string // alias => mod_name
 	ast_imports       []ast.Import      // mod_names
 	used_imports      []string // alias
+	auto_imports      []string // imports, the user does not need to specify
 	imported_symbols  map[string]string
 	is_amp            bool // for generating the right code for `&Foo{}`
 	returns           bool
@@ -231,6 +232,7 @@ pub fn (mut p Parser) parse() ast.File {
 		mod: module_decl
 		imports: p.ast_imports
 		imported_symbols: p.imported_symbols
+		auto_imports: p.auto_imports
 		stmts: stmts
 		scope: p.scope
 		global_scope: p.global_scope

--- a/vlib/x/websocket/io.v
+++ b/vlib/x/websocket/io.v
@@ -2,7 +2,6 @@ module websocket
 
 import net
 import time
-import sync
 
 // socket_read reads from socket into the provided buffer
 fn (mut ws Client) socket_read(mut buffer []byte) ?int {

--- a/vlib/x/websocket/websocket_client.v
+++ b/vlib/x/websocket/websocket_client.v
@@ -7,7 +7,6 @@ import x.openssl
 import net.urllib
 import time
 import log
-import sync
 import rand
 
 const (

--- a/vlib/x/websocket/websocket_server.v
+++ b/vlib/x/websocket/websocket_server.v
@@ -3,7 +3,6 @@ module websocket
 import net
 import x.openssl
 import log
-import sync
 import time
 import rand
 


### PR DESCRIPTION
Whenever channels are used, module `sync` is imported behind the scenes. For this reasons `vfmt` used to create an `import sync` statement even though this identifier is never visible in the code.

This PR changes the behaviour so the `import sync` is only generated by `vfmt` when there is actually a visible usage for this symbol (e.g. `sem := sync.new_semaphore()`.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
