### PR TITLE
vweb: Add chromium filter for double http requests

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -223,13 +223,12 @@ pub fn run_app<T>(mut app T, port int) {
 	// app.reset()
 	mut last_ip := ''
 	for {
-		is_chromium := app.Context.is_chromium
-		app.Context.is_chromium = false
 		mut conn := l.accept() or { panic('accept() failed') }
 		now_ip := conn.peer_ip() or { '' }
-		if !is_chromium || now_ip != last_ip {
+		if !app.Context.is_chromium || now_ip != last_ip {
 			handle_conn<T>(mut conn, mut app)
 		}
+		app.Context.is_chromium = false
 		last_ip = now_ip
 		// app.vweb.page_gen_time = time.ticks() - t
 		// eprintln('handle conn() took ${time.ticks()-t}ms')

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -343,7 +343,7 @@ fn handle_conn<T>(mut conn net.TcpConn, mut app T) {
 	// mut app := T{
 	app.Context = Context{
 		req: req
-		is_chromium: true
+		is_chromium: is_chromium
 		conn: conn
 		form: map[string]string{}
 		static_files: app.static_files


### PR DESCRIPTION
This PR adds a chromium filter for doubled http requests on loading the site. The problem is known and this PR handle is that the handle_conn don't get called twice and that there is no `failed first_line` error.