### PR TITLE
checker: fix duplicate variable name (fix #265)

### DIFF
--- a/cmd/tools/test_if_v_test_system_works.v
+++ b/cmd/tools/test_if_v_test_system_works.v
@@ -18,21 +18,21 @@ fn get_vexe_path() string {
 	}
 	me := os.executable()
 	eprintln('me: $me')
-	mut vexe := os.join_path(os.dir(os.dir(os.dir(me))), 'v')
+	mut vexe_ := os.join_path(os.dir(os.dir(os.dir(me))), 'v')
 	if os.user_os() == 'windows' {
-		vexe += '.exe'
+		vexe_ += '.exe'
 	}
-	return vexe
+	return vexe_
 }
 
 fn new_tdir() string {
-	tdir := os.join_path(os.temp_dir(), rand.ulid())
-	if os.exists(tdir) {
-		os.rmdir(tdir)
+	tdir_ := os.join_path(os.temp_dir(), rand.ulid())
+	if os.exists(tdir_) {
+		os.rmdir(tdir_)
 	}
-	os.mkdir(tdir)
+	os.mkdir(tdir_)
 	C.atexit(cleanup_tdir)
-	return tdir
+	return tdir_
 }
 
 fn cleanup_tdir() {

--- a/examples/2048/2048.v
+++ b/examples/2048/2048.v
@@ -950,12 +950,12 @@ fn main() {
 	$if android {
 		font_path = 'fonts/RobotoMono-Regular.ttf'
 	}
-	mut window_title := 'V 2048'
+	mut window_title_ := 'V 2048'
 	// TODO: Make emcc a real platform ifdef
 	$if emscripten ? {
 		// in emscripten, sokol uses `window_title` as the selector to the canvas it'll render to,
 		// and since `document.querySelector('V 2048')` isn't valid JS, we use `canvas` instead
-		window_title = 'canvas'
+		window_title_ = 'canvas'
 	}
 	app.perf = &Perf{}
 	app.gg = gg.new_context({
@@ -964,7 +964,7 @@ fn main() {
 		height: default_window_height
 		sample_count: 8 // higher quality curves
 		create_window: true
-		window_title: window_title
+		window_title: window_title_
 		frame_fn: frame
 		event_fn: on_event
 		init_fn: init

--- a/examples/term.ui/term_drawing.v
+++ b/examples/term.ui/term_drawing.v
@@ -323,14 +323,14 @@ fn (mut app App) paint(event &tui.Event) {
 }
 
 fn (mut app App) draw_content() {
-	w, mut h := app.tui.window_width / 2, app.tui.window_height - 8
+	w_, mut h := app.tui.window_width / 2, app.tui.window_height - 8
 	if h > app.drawing.len {
 		h = app.drawing.len
 	}
 	for row_idx, row in app.drawing[..h] {
 		app.tui.set_cursor_position(0, row_idx + 4)
 		mut last := tui.Color{0, 0, 0}
-		for cell in row[..w] {
+		for cell in row[..w_] {
 			if cell.r == 0 && cell.g == 0 && cell.b == 0 {
 				if !(cell.r == last.r && cell.g == last.g && cell.b == last.b) {
 					app.tui.reset()

--- a/examples/term.ui/term_drawing.v
+++ b/examples/term.ui/term_drawing.v
@@ -323,11 +323,11 @@ fn (mut app App) paint(event &tui.Event) {
 }
 
 fn (mut app App) draw_content() {
-	w_, mut h := app.tui.window_width / 2, app.tui.window_height - 8
-	if h > app.drawing.len {
-		h = app.drawing.len
+	w_, mut h_ := app.tui.window_width / 2, app.tui.window_height - 8
+	if h_ > app.drawing.len {
+		h_ = app.drawing.len
 	}
-	for row_idx, row in app.drawing[..h] {
+	for row_idx, row in app.drawing[..h_] {
 		app.tui.set_cursor_position(0, row_idx + 4)
 		mut last := tui.Color{0, 0, 0}
 		for cell in row[..w_] {

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -67,14 +67,14 @@ pub fn uname() Uname {
 }
 
 fn init_os_args(argc int, argv &&byte) []string {
-	mut args := []string{}
+	mut args_ := []string{}
 	// mut args := []string(make(0, argc, sizeof(string)))
 	// mut args := []string{len:argc}
 	for i in 0 .. argc {
 		// args [i] = argv[i].vstring()
-		unsafe { args << byteptr(argv[i]).vstring() }
+		unsafe { args_ << byteptr(argv[i]).vstring() }
 	}
-	return args
+	return args_
 }
 
 pub fn ls(path string) ?[]string {

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -76,11 +76,11 @@ mut:
 }
 
 fn init_os_args_wide(argc int, argv &byteptr) []string {
-	mut args := []string{}
+	mut args_ := []string{}
 	for i in 0 .. argc {
-		args << string_from_wide(unsafe { &u16(argv[i]) })
+		args_ << string_from_wide(unsafe { &u16(argv[i]) })
 	}
-	return args
+	return args_
 }
 
 pub fn ls(path string) ?[]string {

--- a/vlib/term/ui/color.v
+++ b/vlib/term/ui/color.v
@@ -11,37 +11,37 @@ const (
 
 [direct_array_access]
 fn init_color_table() []int {
-	mut color_table := []int{len: 256}
+	mut color_table_ := []int{len: 256}
 	// ansi colors
-	color_table[0] = 0x000000
-	color_table[1] = 0x800000
-	color_table[2] = 0x008000
-	color_table[3] = 0x808000
-	color_table[4] = 0x000080
-	color_table[5] = 0x800080
-	color_table[6] = 0x008080
-	color_table[7] = 0xc0c0c0
-	color_table[8] = 0x808080
-	color_table[9] = 0xff0000
-	color_table[10] = 0x00ff00
-	color_table[11] = 0xffff00
-	color_table[12] = 0x0000ff
-	color_table[13] = 0xff00ff
-	color_table[14] = 0x00ffff
-	color_table[15] = 0xffffff
+	color_table_[0] = 0x000000
+	color_table_[1] = 0x800000
+	color_table_[2] = 0x008000
+	color_table_[3] = 0x808000
+	color_table_[4] = 0x000080
+	color_table_[5] = 0x800080
+	color_table_[6] = 0x008080
+	color_table_[7] = 0xc0c0c0
+	color_table_[8] = 0x808080
+	color_table_[9] = 0xff0000
+	color_table_[10] = 0x00ff00
+	color_table_[11] = 0xffff00
+	color_table_[12] = 0x0000ff
+	color_table_[13] = 0xff00ff
+	color_table_[14] = 0x00ffff
+	color_table_[15] = 0xffffff
 	// color palette
 	for i in 0 .. 216 {
 		r := value_range[(i / 36) % 6]
 		g := value_range[(i / 6) % 6]
 		b := value_range[i % 6]
-		color_table[i + 16] = ((r << 16) & 0xffffff) + ((g << 8) & 0xffff) + (b & 0xff)
+		color_table_[i + 16] = ((r << 16) & 0xffffff) + ((g << 8) & 0xffff) + (b & 0xff)
 	}
 	// grayscale
 	for i in 0 .. 24 {
 		r := 8 + (i * 10)
-		color_table[i + 232] = ((r << 16) & 0xffffff) + ((r << 8) & 0xffff) + (r & 0xff)
+		color_table_[i + 232] = ((r << 16) & 0xffffff) + ((r << 8) & 0xffff) + (r & 0xff)
 	}
-	return color_table
+	return color_table_
 }
 
 fn clamp(x int, y int, z int) int {

--- a/vlib/time/unix.v
+++ b/vlib/time/unix.v
@@ -116,9 +116,9 @@ fn calculate_time_from_offset(second_offset_ int) (int, int, int) {
 	if second_offset < 0 {
 		second_offset += seconds_per_day
 	}
-	hour := second_offset / seconds_per_hour
+	hour_ := second_offset / seconds_per_hour
 	second_offset %= seconds_per_hour
 	min := second_offset / seconds_per_minute
 	second_offset %= seconds_per_minute
-	return hour, min, second_offset
+	return hour_, min, second_offset
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2402,7 +2402,7 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 					if is_decl {
 						full_name := '${left.mod}.$left.name'
 						if full_name in c.const_names {
-							c.error('duplicate variable name `$left.name`', left.pos)
+							c.error('duplicate of a const name `$left.name`', left.pos)
 						}
 					}
 				}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2399,7 +2399,7 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 						}
 						*/
 					}
-					if is_decl && left.mod != 'builtin' {
+					if is_decl {
 						full_name := '${left.mod}.$left.name'
 						if full_name in c.const_names {
 							c.error('duplicate variable name `$left.name`', left.pos)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2399,6 +2399,12 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 						}
 						*/
 					}
+					if is_decl && left.mod != 'builtin' {
+						full_name := '${left.mod}.$left.name'
+						if full_name in c.const_names {
+							c.error('duplicate variable name `$left.name`', left.pos)
+						}
+					}
 				}
 			}
 			ast.PrefixExpr {

--- a/vlib/v/checker/tests/var_duplicate_const.out
+++ b/vlib/v/checker/tests/var_duplicate_const.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/var_duplicate_const.vv:8:2: error: duplicate variable name `age`
+    6 |
+    7 | fn main() {
+    8 |     age := 30
+      |     ~~~
+    9 |     println(age)
+   10 | }

--- a/vlib/v/checker/tests/var_duplicate_const.out
+++ b/vlib/v/checker/tests/var_duplicate_const.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/var_duplicate_const.vv:8:2: error: duplicate variable name `age`
+vlib/v/checker/tests/var_duplicate_const.vv:8:2: error: duplicate of a const name `age`
     6 |
     7 | fn main() {
     8 |     age := 30

--- a/vlib/v/checker/tests/var_duplicate_const.vv
+++ b/vlib/v/checker/tests/var_duplicate_const.vv
@@ -1,0 +1,10 @@
+module main
+
+const (
+	age = 40
+)
+
+fn main() {
+	age := 30
+	println(age)
+}


### PR DESCRIPTION
This PR fixes duplicate variable name (fix #265).

- Fixes duplicate variable name.
- Add test `var_duplicate_const.vv/out`.
- Fixes related error of previous.

```v
module main

const (
	age = 40
)

fn main() {
	age := 30
	println(age)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:8:2: error: duplicate of a const name `age`
    6 |
    7 | fn main() {
    8 |     age := 30
      |     ~~~
    9 |     println(age)
   10 | }
```