### PR TITLE
token: remove // from comment token kind string

### DIFF
--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -237,7 +237,7 @@ fn build_token_str() []string {
 	s[Kind.question] = '?'
 	s[Kind.left_shift] = '<<'
 	s[Kind.right_shift] = '>>'
-	s[Kind.comment] = '// comment'
+	s[Kind.comment] = 'comment'
 	s[Kind.nl] = 'NLL'
 	s[Kind.dollar] = '$'
 	s[Kind.at] = '@'


### PR DESCRIPTION
I removed `//` from comment kind string as this could be misleading with multi line comments.