### PR TITLE
parser: fix multi fixed arrays init (fix #7983)

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1305,3 +1305,8 @@ fn test_array_of_map_insert() {
 	println(x)
 	assert '$x' == "[{}, {}, {'123': 123}, {}]"
 }
+
+fn test_multi_fixed_array_init() {
+	a := [3][3]int{}
+	assert '$a' == '[[0, 0, 0], [0, 0, 0], [0, 0, 0]]'
+}

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -54,7 +54,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 		}
 		last_pos = p.tok.position()
 		p.check(.rsbr)
-		if exprs.len == 1 && p.tok.kind in [.name, .amp] && p.tok.line_nr == line_nr {
+		if exprs.len == 1 && p.tok.kind in [.name, .amp, .lsbr] && p.tok.line_nr == line_nr {
 			// [100]byte
 			elem_type = p.parse_type()
 			is_fixed = true


### PR DESCRIPTION
This PR fixes multi fixed arrays init (fix #7983).

- Fixes multi fixed arrays init.
- Add test in array_test.v.

```v
module main

fn main() {
    a := [3][3]int{}
    println(a)
}

PS D:\Test\v\tt1> v run .
[[0, 0, 0], [0, 0, 0], [0, 0, 0]]
```