### PR TITLE
fmt: keep new line at both ends of block comment

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1369,7 +1369,7 @@ pub fn (mut f Fmt) comment(node ast.Comment, options CommentsOptions) {
 		x := node.text.trim_left('\x01')
 		if x.contains('\n') {
 			f.writeln('/*')
-			f.writeln(x)
+			f.writeln(x.trim_space())
 			f.write('*/')
 		} else {
 			f.write('/* ${x.trim(' ')} */')
@@ -1394,7 +1394,7 @@ pub fn (mut f Fmt) comment(node ast.Comment, options CommentsOptions) {
 		f.write(out_s)
 		return
 	}
-	lines := node.text.split_into_lines()
+	lines := node.text.trim_space().split_into_lines()
 	f.writeln('/*')
 	for line in lines {
 		f.writeln(line)

--- a/vlib/v/fmt/tests/comments_expected.vv
+++ b/vlib/v/fmt/tests/comments_expected.vv
@@ -10,6 +10,15 @@ fn mr_fun() (int, int) {
 }
 
 fn main() {
+	/*
+	block1
+	*/
+	/*
+	block2
+	*/
+	/*
+	block3
+	*/
 	// this is a comment
 	a := 1
 	// and another comment

--- a/vlib/v/fmt/tests/comments_input.vv
+++ b/vlib/v/fmt/tests/comments_input.vv
@@ -7,6 +7,15 @@ fn mr_fun() (int, int) {
 }
 
 fn main() {
+	/* block1
+	*/
+	/*
+	block2 */
+	/*
+
+	block3
+
+	*/
 	a := /* this is a comment */ 1
 	b, c := /* and another comment */ a, /* just to make it worse */ 2
 	d := c // and an extra one

--- a/vlib/v/fmt/tests/comments_keep.vv
+++ b/vlib/v/fmt/tests/comments_keep.vv
@@ -43,5 +43,8 @@ fn main() {
 	//////
 	// /
 	// 123
+	/*
+	block
+	*/
 	println('hello world')
 }

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -959,7 +959,7 @@ fn (mut s Scanner) text_scan() token.Token {
 					}
 					s.pos++
 					if s.should_parse_comment() {
-						comment := s.text[start..(s.pos - 1)].trim_space()
+						comment := s.text[start..(s.pos - 1)].trim(' ')
 						return s.new_token(.comment, comment, comment.len + 4)
 					}
 					// Skip if not in fmt mode


### PR DESCRIPTION
Single-line-content block comments with a line break at the beginning or end should not be rewritten as inline comments.

See also #7899

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
