### PR TITLE
checker: check unknown struct name (fix #8007)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -511,6 +511,9 @@ pub fn (mut c Checker) struct_init(mut struct_init ast.StructInit) table.Type {
 				struct_init.pos)
 		}
 	}
+	if type_sym.name.len == 1 && !c.cur_fn.is_generic {
+		c.error('unknown struct name `$type_sym.name`', struct_init.pos)
+	}
 	match type_sym.kind {
 		.placeholder {
 			c.error('unknown struct: $type_sym.name', struct_init.pos)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -512,7 +512,7 @@ pub fn (mut c Checker) struct_init(mut struct_init ast.StructInit) table.Type {
 		}
 	}
 	if type_sym.name.len == 1 && !c.cur_fn.is_generic {
-		c.error('unknown struct name `$type_sym.name`', struct_init.pos)
+		c.error('unknown struct `$type_sym.name`', struct_init.pos)
 	}
 	match type_sym.kind {
 		.placeholder {

--- a/vlib/v/checker/tests/unknown_struct_name.out
+++ b/vlib/v/checker/tests/unknown_struct_name.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/unknown_struct_name.vv:4:7: error: unknown struct name `F`
+    2 |
+    3 | fn main() {
+    4 |     _ := F{}
+      |          ~~~
+    5 | }

--- a/vlib/v/checker/tests/unknown_struct_name.out
+++ b/vlib/v/checker/tests/unknown_struct_name.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/unknown_struct_name.vv:4:7: error: unknown struct name `F`
+vlib/v/checker/tests/unknown_struct_name.vv:4:7: error: unknown struct `F`
     2 |
     3 | fn main() {
     4 |     _ := F{}

--- a/vlib/v/checker/tests/unknown_struct_name.vv
+++ b/vlib/v/checker/tests/unknown_struct_name.vv
@@ -1,0 +1,5 @@
+module main
+
+fn main() {
+	_ := F{}
+}


### PR DESCRIPTION
This PR check unknown struct name (fix #8007).

- Check unknown struct name.
- Add test `unknown_struct_name.vv/out`.

```v
module main

fn main() {
    _ := F{}
}

PS D:\Test\v\tt1> v run .
.\tt1.v:4:10: error: unknown struct `F`
    2 |
    3 | fn main() {
    4 |     _ := F{}
      |          ~~~
    5 | }
```