### PR TITLE
x:websocket: Make websocket compile with autofree

### DIFF
--- a/vlib/crypto/sha1/sha1.v
+++ b/vlib/crypto/sha1/sha1.v
@@ -54,6 +54,7 @@ pub fn new() &Digest {
 	return d
 }
 
+[manualfree]
 pub fn (mut d Digest) write(p_ []byte) int {
 	nn := p_.len
 	unsafe {

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -451,6 +451,7 @@ fn parse_request_uri(rawurl string) ?URL {
 // via_request is true, the URL is assumed to have arrived via an HTTP request,
 // in which case only absolute URLs or path-absolute relative URLs are allowed.
 // If via_request is false, all forms of relative URLs are allowed.
+[manualfree]
 fn parse_url(rawurl string, via_request bool) ?URL {
 	if string_contains_ctl_byte(rawurl) {
 		return error(error_msg('parse_url: invalid control character in URL', rawurl))

--- a/vlib/x/websocket/handshake.v
+++ b/vlib/x/websocket/handshake.v
@@ -1,3 +1,4 @@
+[manualfree]
 module websocket
 
 import encoding.base64


### PR DESCRIPTION

This PR makes x.websockets build with `-autofree`. This was due to some incompatibilities with autofree in urllib and should probably be fixed in autofree later. This PR does not prevent leaking using `-autofree`. For now resources are manually freed and some incompabilities are marked with the new `[manualfree]`. 