### PR TITLE
fmt: do not move single line block comments to previous line

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -690,7 +690,7 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl) {
 				continue
 			}
 			if comment.pos.pos > field.pos.pos {
-				comments_len += '/* $comment.text */ '.len
+				comments_len += '/* ${comment.text.trim_left('\x01')} */ '.len
 			}
 		}
 		if comments_len + field.name.len > max {
@@ -730,7 +730,7 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl) {
 		// Handle comments between field name and type
 		mut comments_len := 0
 		for comm_idx < comments.len && comments[comm_idx].pos.pos < end_pos {
-			comment_text := '/* ${comments[comm_idx].text} */ ' // TODO handle in a function
+			comment_text := '/* ${comments[comm_idx].text.trim_left('\x01')} */ ' // TODO handle in a function
 			comments_len += comment_text.len
 			f.write(comment_text)
 			comm_idx++
@@ -1381,7 +1381,7 @@ pub fn (mut f Fmt) comment(node ast.Comment, options CommentsOptions) {
 	}
 	if !node.text.contains('\n') {
 		is_separate_line := !options.inline || node.text.starts_with('\x01')
-		mut s := if node.text.starts_with('\x01') { node.text[1..] } else { node.text }
+		mut s := node.text.trim_left('\x01')
 		mut out_s := '//'
 		if s != '' {
 			match s[0] {

--- a/vlib/v/fmt/tests/comments_expected.vv
+++ b/vlib/v/fmt/tests/comments_expected.vv
@@ -9,6 +9,18 @@ fn mr_fun() (int, int) {
 	return 1, 2
 }
 
+fn single_line_blocks() {
+	// 1
+	println('')
+	// 2
+	println('')
+	// 3
+	// 4
+	println('')
+	// 5
+	// 6
+}
+
 fn main() {
 	/*
 	block1

--- a/vlib/v/fmt/tests/comments_input.vv
+++ b/vlib/v/fmt/tests/comments_input.vv
@@ -6,6 +6,18 @@ fn mr_fun() (int, int) {
 	return /* one comment */ 1, /* another comment */ 2
 }
 
+fn single_line_blocks() {
+	/* 1 */
+	println('')
+	/* 2 */
+	println('')
+	/* 3 */
+	/* 4 */
+	println('')
+	// 5
+	/* 6 */
+}
+
 fn main() {
 	/* block1
 	*/

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -959,7 +959,10 @@ fn (mut s Scanner) text_scan() token.Token {
 					}
 					s.pos++
 					if s.should_parse_comment() {
-						comment := s.text[start..(s.pos - 1)].trim(' ')
+						mut comment := s.text[start..(s.pos - 1)].trim(' ')
+						if !comment.contains('\n') {
+							comment = '\x01' + comment
+						}
 						return s.new_token(.comment, comment, comment.len + 4)
 					}
 					// Skip if not in fmt mode


### PR DESCRIPTION
Fix #8027 