### PR TITLE
scanner: allow '$f(expr)'

### DIFF
--- a/vlib/v/tests/string_interpolation_test.v
+++ b/vlib/v/tests/string_interpolation_test.v
@@ -207,6 +207,6 @@ fn f(i int) int {
 }
 
 fn test_call() {
-	assert '${f(4)}' == '4'
-	assert '$f(4)' == '4'
+	assert '${f(f(4))}' == '4'
+	assert '$f(f(4))' == '4'
 }

--- a/vlib/v/tests/string_interpolation_test.v
+++ b/vlib/v/tests/string_interpolation_test.v
@@ -182,8 +182,12 @@ struct Bb {
 	b Aa
 }
 
-fn (x Bb) f() Aa {
+fn (x Bb) f1() Aa {
 	return x.b
+}
+
+fn (x Bb) f2(i int) Aa {
+	return Aa{ a: x.b.a + i }
 }
 
 fn test_method_interpolation() {
@@ -192,8 +196,10 @@ fn test_method_interpolation() {
 			a: 2
 		}
 	}
-	assert '>${y.f().a}<' == '>2<'
-	assert '>$y.f().a<' == '>2<'
+	assert '>${y.f1().a}<' == '>2<'
+	assert '>$y.f1().a<' == '>2<'
+	assert '>${y.f2(1).a}<' == '>3<'
+	assert '>$y.f2(1).a<' == '>3<'
 }
 
 fn f(i int) int {
@@ -201,6 +207,6 @@ fn f(i int) int {
 }
 
 fn test_call() {
-	s := '${f(4)}'
-	assert s == '4'
+	assert '${f(4)}' == '4'
+	assert '$f(4)' == '4'
 }


### PR DESCRIPTION
For now, `$f()` is allowed and `$f(expr)` is not allowed.

Of course, `${f(expr)}` is recommended. But this is strange behavior.

imho, this should be allowed with a warning.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
