### PR TITLE
cgen: fix multi fixed arrays with default init (fix #8038)

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1339,7 +1339,7 @@ fn test_array_of_multi_map() {
 }
 
 fn test_multi_fixed_array_with_default_init() {
-	a := [3][3]int{init:[3]int{init: 10}}
+	a := [3][3]int{init: [3]int{init: 10}}
 	println(a)
 	assert a == [[10, 10, 10]!!, [10, 10, 10]!!, [10, 10, 10]!!]!!
 }

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1337,3 +1337,9 @@ fn test_array_of_multi_map() {
 	assert nums.odds == [3, 5, 7]
 	assert nums.evens == [2, 6, 10]
 }
+
+fn test_multi_fixed_array_with_default_init() {
+	a := [3][3]int{init:[3]int{init: 10}}
+	println(a)
+	assert a == [[10, 10, 10]!!, [10, 10, 10]!!, [10, 10, 10]!!]!!
+}

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1341,5 +1341,5 @@ fn test_array_of_multi_map() {
 fn test_multi_fixed_array_with_default_init() {
 	a := [3][3]int{init: [3]int{init: 10}}
 	println(a)
-	assert a == [[10, 10, 10]!!, [10, 10, 10]!!, [10, 10, 10]!!]!!
+	assert a == [[10, 10, 10]!, [10, 10, 10]!, [10, 10, 10]!]!
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2741,6 +2741,9 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) table.Type {
 			1)
 		array_type := table.new_type(idx)
 		array_init.typ = array_type
+		if array_init.has_default {
+			c.expr(array_init.default_expr)
+		}
 	}
 	return array_init.typ
 }

--- a/vlib/v/gen/array.v
+++ b/vlib/v/gen/array.v
@@ -35,6 +35,13 @@ fn (mut g Gen) array_init(it ast.ArrayInit) {
 					g.write(', ')
 				}
 			}
+		} else if it.has_default {
+			g.expr(it.default_expr)
+			info := type_sym.info as table.ArrayFixed
+			for _ in 1 .. info.size {
+				g.write(', ')
+				g.expr(it.default_expr)
+			}
 		} else {
 			g.write('0')
 		}


### PR DESCRIPTION
This PR fixes multi fixed arrays with default init (fix #8038).

- Fixes multi fixed arrays with default init.
- Add test in array_test.v.

```v
module main

fn main() {
	a := [3][3]int{init:[3]int{init: 10}}
	println(a)
	assert a == [[10, 10, 10]!, [10, 10, 10]!, [10, 10, 10]!]!
}

PS D:\Test\v\tt1> v run .
[[10, 10, 10], [10, 10, 10], [10, 10, 10]]
```