### PR TITLE
fixed_array: change `[1,2,3]!!` to `[1,2,3]!`

### DIFF
--- a/vlib/v/checker/tests/cannot_assign_array.out
+++ b/vlib/v/checker/tests/cannot_assign_array.out
@@ -1,6 +1,6 @@
 vlib/v/checker/tests/cannot_assign_array.vv:9:11: error: cannot assign to `ctx.vb`: expected `string`, not `[8]f64`
     7 |     mut ctx := Context{}
     8 |     x := 2.32
-    9 |     ctx.vb = [1.1, x, 3.3, 4.4, 5.0, 6.0, 7.0, 8.9]!!
-      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    9 |     ctx.vb = [1.1, x, 3.3, 4.4, 5.0, 6.0, 7.0, 8.9]!
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    10 | }

--- a/vlib/v/checker/tests/cannot_assign_array.vv
+++ b/vlib/v/checker/tests/cannot_assign_array.vv
@@ -6,5 +6,5 @@ struct Context {
 fn main() {
 	mut ctx := Context{}
 	x := 2.32
-	ctx.vb = [1.1, x, 3.3, 4.4, 5.0, 6.0, 7.0, 8.9]!!
+	ctx.vb = [1.1, x, 3.3, 4.4, 5.0, 6.0, 7.0, 8.9]!
 }

--- a/vlib/v/checker/tests/fn_args.out
+++ b/vlib/v/checker/tests/fn_args.out
@@ -3,17 +3,17 @@ vlib/v/checker/tests/fn_args.vv:6:5: error: cannot use `&int` as `byte` in argum
     5 | v := 4
     6 | ptr(&v)
       |     ~~
-    7 | arr([5]!!)
+    7 | arr([5]!)
     8 | fun(fn(i &int){})
 vlib/v/checker/tests/fn_args.vv:7:5: error: cannot use `[1]int` as `[]int` in argument 1 to `arr`
     5 | v := 4
     6 | ptr(&v)
-    7 | arr([5]!!)
-      |     ~~~~~
+    7 | arr([5]!)
+      |     ~~~~
     8 | fun(fn(i &int){})
 vlib/v/checker/tests/fn_args.vv:8:5: error: cannot use `fn (&int)` as `fn (int)` in argument 1 to `fun`
     6 | ptr(&v)
-    7 | arr([5]!!)
+    7 | arr([5]!)
     8 | fun(fn(i &int){})
       |     ~~~~~~~~~~~~
 details: ``'s expected fn argument: `` is NOT a pointer, but the passed fn argument: `i` is a pointer

--- a/vlib/v/checker/tests/fn_args.vv
+++ b/vlib/v/checker/tests/fn_args.vv
@@ -4,5 +4,5 @@ fn fun(a fn(int)) {}
 
 v := 4
 ptr(&v)
-arr([5]!!)
+arr([5]!)
 fun(fn(i &int){})

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -78,15 +78,16 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 					last_pos)
 			}
 		} else {
-			if p.tok.kind == .not {
+			if p.tok.kind == .not && p.tok.line_nr == p.prev_tok.line_nr {
 				last_pos = p.tok.position()
-				p.next()
-			}
-			if p.tok.kind == .not {
-				last_pos = p.tok.position()
-				p.next()
 				is_fixed = true
 				has_val = true
+				p.next()
+			}
+			if p.tok.kind == .not && p.tok.line_nr == p.prev_tok.line_nr {
+				last_pos = p.tok.position()
+				p.warn_with_pos('use e.g. `[1, 2, 3]!` instead of `[1, 2, 3]!!`', last_pos)
+				p.next()
 			}
 		}
 	}


### PR DESCRIPTION
This PR change fixed arrays `[1,2,3]!!` to `[1,2,3]!`.

```v
fn main() {
	a := [1, 2, 3, 4]!
	println(typeof(a).name)
	println(a)

	b := [4, 3, 2, 1]!!
	println(typeof(b).name)
	println(b)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:8:20: warning: use e.g. `[1, 2, 3]!` instead of `[1, 2, 3]!!`
    6 |     println(a)
    7 | 
    8 |     b := [4, 3, 2, 1]!!
      |                       ^
    9 |     println(typeof(b).name)
   10 |     println(b)
[4]int
[1, 2, 3, 4]
[4]int
[4, 3, 2, 1]
```