### PR TITLE
Fix typo in tutorial about how to install V

### DIFF
--- a/tutorials/building-a-simple-web-blog-with-vweb.md
+++ b/tutorials/building-a-simple-web-blog-with-vweb.md
@@ -23,7 +23,7 @@ The code is available <a href='https://github.com/vlang/v/tree/master/tutorials/
 ### Installing V
 
 ```
-wget https://github.com/vlang/v/releases/latest/download/linux.zip
+wget https://github.com/vlang/v/releases/latest/download/v_linux.zip
 unzip v_linux.zip
 cd v
 sudo ./v symlink


### PR DESCRIPTION
I think the right URL is https://github.com/vlang/v/releases/latest/download/v_linux.zip with "v_".
Regards.
