### PR TITLE
cgen: fix gen_array_sort() for overload function

### DIFF
--- a/vlib/v/gen/array.v
+++ b/vlib/v/gen/array.v
@@ -254,9 +254,9 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 			// when generating the function as long as the args are named the same.
 			g.definitions.writeln('int $compare_fn ($styp* a, $styp* b) {')
 			sym := g.table.get_type_symbol(typ)
-			if sym.has_method('<') && infix_expr.left.str().len == 1 {
+			if !is_reverse && sym.has_method('<') && infix_expr.left.str().len == 1 {
 				g.definitions.writeln('\tif (${styp}__lt(*a, *b)) { return -1; } else { return 1; }}')
-			} else if sym.has_method('>') && infix_expr.left.str().len == 1 {
+			} else if is_reverse && sym.has_method('>') && infix_expr.left.str().len == 1 {
 				g.definitions.writeln('\tif (${styp}__gt(*a, *b)) { return -1; } else { return 1; }}')
 			} else {
 				field_type := g.typ(infix_expr.left_type)

--- a/vlib/v/tests/sorting_by_different_criteria_test.v
+++ b/vlib/v/tests/sorting_by_different_criteria_test.v
@@ -11,6 +11,10 @@ fn (p Parent) < (p1 Parent) bool {
     return p.name < p1.name
 }
 
+fn (p Parent) > (p1 Parent) bool {
+    return p.name > p1.name
+}
+
 fn test_sorting_by_different_criteria_in_same_function() {
 	mut arr := [
 		Parent{Child{0.2}, 'def'},
@@ -26,4 +30,6 @@ fn test_sorting_by_different_criteria_in_same_function() {
 	assert arr[0].name == 'xyz'
 	arr.sort(a < b)
 	assert arr[0].name == 'abc'
+	arr.sort(a > b)
+	assert arr[0].name == 'xyz'
 }


### PR DESCRIPTION
This PR fixes gen_array_sort() for overload function.

- Fixes gen_array_sort() for overload function.
- Change tests.

```v
struct Child {
	f f64
}

struct Parent {
	child Child
	name  string
}

fn (p Parent) < (p1 Parent) bool {
    return p.name < p1.name
}

fn (p Parent) > (p1 Parent) bool {
    return p.name > p1.name
}

fn test_sorting_by_different_criteria_in_same_function() {
	mut arr := [
		Parent{Child{0.2}, 'def'},
		Parent{Child{0.1}, 'xyz'},
		Parent{Child{0.3}, 'abc'},
	]
	assert arr[0].name == 'def'
	arr.sort(a.name < b.name)
	// println(arr)
	assert arr[0].name == 'abc'
	// println(arr)
	arr.sort(a.child.f < b.child.f)
	assert arr[0].name == 'xyz'
	arr.sort(a < b)
	assert arr[0].name == 'abc'
	arr.sort(a > b)
	assert arr[0].name == 'xyz'
}
```