### PR TITLE
scanner: remove debug_tokens

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -28,7 +28,6 @@ pub mut:
 	is_inter_start    bool // for hacky string interpolation TODO simplify
 	is_inter_end      bool
 	is_enclosed_inter bool
-	is_debug          bool
 	line_comment      string
 	// prev_tok                 TokenKind
 	is_started                  bool
@@ -1173,29 +1172,6 @@ fn (s &Scanner) expect(want string, start_pos int) bool {
 		}
 	}
 	return true
-}
-
-fn (mut s Scanner) debug_tokens() {
-	s.pos = 0
-	s.is_started = false
-	s.is_debug = true
-	fname := s.file_path.all_after_last(os.path_separator)
-	println('\n===DEBUG TOKENS $fname===')
-	for {
-		tok := s.scan()
-		tok_kind := tok.kind
-		lit := tok.lit
-		print(tok_kind.str())
-		if lit != '' {
-			println(' `$lit`')
-		} else {
-			println('')
-		}
-		if tok_kind == .eof {
-			println('============ END OF DEBUG TOKENS ==================')
-			break
-		}
-	}
 }
 
 [inline]


### PR DESCRIPTION
debug_tokens is private and unused.

`$debugscanner` in `scan_all_tokens_in_buffer` can be used to debug tokens.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
