### PR TITLE
fmt: change `[1,2,3]!!` to `[1,2,3]!`

### DIFF
--- a/cmd/tools/vbin2v.v
+++ b/cmd/tools/vbin2v.v
@@ -68,7 +68,7 @@ fn (context Context) file2v(bname string, fbytes []byte, bn_max int) string {
 			sb.write('$b, ')
 		}
 	}
-	sb.write(']!!\n')
+	sb.write(']!\n')
 	return sb.str()
 }
 

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2049,7 +2049,7 @@ pub fn (mut f Fmt) array_init(it ast.ArrayInit) {
 	// `[100]byte`
 	if it.is_fixed {
 		if it.has_val {
-			f.write('!!')
+			f.write('!')
 			return
 		}
 		f.write(f.table.type_to_str(it.elem_type))

--- a/vlib/v/fmt/tests/fixed_size_array_type_keep.vv
+++ b/vlib/v/fmt/tests/fixed_size_array_type_keep.vv
@@ -1,5 +1,5 @@
 fn foo() [1]f32 {
-	return [f32(0.0)]!!
+	return [f32(0.0)]!
 }
 
 fn main() {

--- a/vlib/v/fmt/tests/typeof_keep.vv
+++ b/vlib/v/fmt/tests/typeof_keep.vv
@@ -1,3 +1,3 @@
 fn test_typeof() {
-	println(typeof(x))
+	println(typeof(x).name)
 }


### PR DESCRIPTION
This PR change `[1,2,3]!!` to `[1,2,3]!` in fmt.

- Change `[1,2,3]!!` to `[1,2,3]!` in fmt.
- Change tools/bin2v.
- Change fmt tests.