### PR TITLE
fn: fixed array passed as mutable argument [READY]

### DIFF
--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -240,7 +240,8 @@ fn (mut g Gen) fn_args(args []table.Param, is_variadic bool) ([]string, []string
 				g.definitions.write(')')
 			}
 		} else {
-			s := arg_type_name + ' ' + caname
+			s := if arg_type_sym.kind ==
+				.array_fixed { arg_type_name.trim('*') } else { arg_type_name } + ' ' + caname
 			g.write(s)
 			g.definitions.write(s)
 			fargs << caname

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -240,8 +240,12 @@ fn (mut g Gen) fn_args(args []table.Param, is_variadic bool) ([]string, []string
 				g.definitions.write(')')
 			}
 		} else {
-			//TODO: combine two lines into one once ternary in expression is fixed
-			mut s := if arg_type_sym.kind == .array_fixed { arg_type_name.trim('*') } else { arg_type_name } 
+			// TODO: combine two operations into one once ternary in expression is fixed
+			mut s := if arg_type_sym.kind == .array_fixed {
+				arg_type_name.trim('*')
+			} else {
+				arg_type_name
+			}
 			s += ' ' + caname
 			g.write(s)
 			g.definitions.write(s)

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -240,8 +240,9 @@ fn (mut g Gen) fn_args(args []table.Param, is_variadic bool) ([]string, []string
 				g.definitions.write(')')
 			}
 		} else {
-			s := if arg_type_sym.kind ==
-				.array_fixed { arg_type_name.trim('*') } else { arg_type_name } + ' ' + caname
+			//TODO: combine two lines into one once ternary in expression is fixed
+			mut s := if arg_type_sym.kind == .array_fixed { arg_type_name.trim('*') } else { arg_type_name } 
+			s += ' ' + caname
 			g.write(s)
 			g.definitions.write(s)
 			fargs << caname

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -686,7 +686,8 @@ fn (mut p Parser) fn_args() ([]table.Param, bool, bool) {
 
 fn (mut p Parser) check_fn_mutable_arguments(typ table.Type, pos token.Position) {
 	sym := p.table.get_type_symbol(typ)
-	if sym.kind !in [.array, .array_fixed, .struct_, .map, .placeholder, .sum_type] && !typ.is_ptr() && !typ.is_pointer() {
+	if sym.kind !in [.array, .array_fixed, .struct_, .map, .placeholder, .sum_type] &&
+		!typ.is_ptr() && !typ.is_pointer() {
 		p.error_with_pos('mutable arguments are only allowed for arrays, maps, structs and pointers\n' +
 			'return values instead: `fn foo(mut n $sym.name) {` => `fn foo(n $sym.name) $sym.name {`',
 			pos)

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -686,7 +686,7 @@ fn (mut p Parser) fn_args() ([]table.Param, bool, bool) {
 
 fn (mut p Parser) check_fn_mutable_arguments(typ table.Type, pos token.Position) {
 	sym := p.table.get_type_symbol(typ)
-	if sym.kind !in [.array, .struct_, .map, .placeholder, .sum_type] && !typ.is_ptr() && !typ.is_pointer() {
+	if sym.kind !in [.array, .array_fixed, .struct_, .map, .placeholder, .sum_type] && !typ.is_ptr() && !typ.is_pointer() {
 		p.error_with_pos('mutable arguments are only allowed for arrays, maps, structs and pointers\n' +
 			'return values instead: `fn foo(mut n $sym.name) {` => `fn foo(n $sym.name) $sym.name {`',
 			pos)

--- a/vlib/v/tests/fixed_array_test.v
+++ b/vlib/v/tests/fixed_array_test.v
@@ -56,8 +56,15 @@ fn multiply_by_two(mut arr [3]int) {
 	}
 }
 
+fn change_first_element(mut arr [3][3]int) {
+	a[0][0] = 0
+}
+
 fn test_fixed_array_can_be_passed_as_mut_arg() {
 	mut arr := [1,2,3]!
 	multiply_by_two(mut arr)
 	assert arr == [2,4,6]!
+	mut arr2 := [[1,2,3]!, [4,5,6]!, [7,8,9]!]!
+	change_first_element(mut arr2)
+	assert arr2 == [[0,2,3]!, [4,5,6]!, [7,8,9]!]!
 }

--- a/vlib/v/tests/fixed_array_test.v
+++ b/vlib/v/tests/fixed_array_test.v
@@ -57,7 +57,7 @@ fn multiply_by_two(mut arr [3]int) {
 }
 
 fn change_first_element(mut arr [3][3]int) {
-	a[0][0] = 0
+	arr[0][0] = 0
 }
 
 fn test_fixed_array_can_be_passed_as_mut_arg() {

--- a/vlib/v/tests/fixed_array_test.v
+++ b/vlib/v/tests/fixed_array_test.v
@@ -2,7 +2,7 @@ fn test_fixed_array_can_be_assigned() {
 	x := 2.32
 	mut v := [8]f64{}
 	assert v[1] == 0
-	v = [1.0, x, 3.0,4.0,5.0,6.0,7.0,8.0]!!
+	v = [1.0, x, 3.0,4.0,5.0,6.0,7.0,8.0]!
 	assert v[1] == x
 	v[1] = 2.0
 	for i, e in v {
@@ -20,7 +20,7 @@ fn test_fixed_array_can_be_assigned() {
 
 fn test_fixed_array_can_be_used_in_declaration() {
 	x := 2.32
-	v := [1.0, x, 3.0,4.0,5.0,6.0,7.0,8.0]!!
+	v := [1.0, x, 3.0,4.0,5.0,6.0,7.0,8.0]!
 	assert v.len == 8
 	assert v[1] == x
 }
@@ -35,7 +35,7 @@ fn test_fixed_array_can_be_assigned_to_a_struct_field() {
 	mut ctx := Context{}
 	assert ctx.vb.len == 8
 	x := 2.32
-	ctx.vb = [1.1, x, 3.3, 4.4, 5.0, 6.0, 7.0, 8.9]!!
+	ctx.vb = [1.1, x, 3.3, 4.4, 5.0, 6.0, 7.0, 8.9]!
 	assert ctx.vb[1] == x
 	assert ctx.vb[7] == 8.9
 	for i, e in ctx.vb {
@@ -48,4 +48,16 @@ fn test_fixed_array_can_be_assigned_to_a_struct_field() {
 	println( ctx.vb[2] )
 	println( ctx.vb[3] )
 	*/
+}
+
+fn multiply_by_two(mut arr [3]int) {
+	for i in 0..arr.len {
+		arr[i] *= 2
+	}
+}
+
+fn test_fixed_array_can_be_passed_as_mut_arg() {
+	mut arr := [1,2,3]!
+	multiply_by_two(mut arr)
+	assert arr == [2,4,6]!
 }


### PR DESCRIPTION
This PR fixes #8083.
```V
fn multiply_by_two(mut arr [3]int) {
	for i in 0..arr.len {
		arr[i] *= 2
	}
}

fn test_fixed_array_can_be_passed_as_mut_arg() {
	mut arr := [1,2,3]!
	multiply_by_two(mut arr)
	assert arr == [2,4,6]!
}
```