### PR TITLE
parser: `mut:` interface methods, mut interface fn parameter

### DIFF
--- a/vlib/v/checker/tests/function_arg_mutable_err.out
+++ b/vlib/v/checker/tests/function_arg_mutable_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/function_arg_mutable_err.vv:1:18: error: mutable arguments are only allowed for arrays, maps, structs and pointers
+vlib/v/checker/tests/function_arg_mutable_err.vv:1:18: error: mutable arguments are only allowed for arrays, maps, aggregates and pointers
 return values instead: `fn foo(mut n int) {` => `fn foo(n int) int {`
     1 | fn mod_ptr(mut a int) {
       |                  ~~~

--- a/vlib/v/checker/tests/function_arg_mutable_err.out
+++ b/vlib/v/checker/tests/function_arg_mutable_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/function_arg_mutable_err.vv:1:18: error: mutable arguments are only allowed for arrays, maps, aggregates and pointers
+vlib/v/checker/tests/function_arg_mutable_err.vv:1:18: error: mutable arguments are only allowed for arrays, interfaces, maps, pointers and structs
 return values instead: `fn foo(mut n int) {` => `fn foo(n int) int {`
     1 | fn mod_ptr(mut a int) {
       |                  ~~~

--- a/vlib/v/checker/tests/mut_int.out
+++ b/vlib/v/checker/tests/mut_int.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/mut_int.vv:1:14: error: mutable arguments are only allowed for arrays, maps, structs and pointers
+vlib/v/checker/tests/mut_int.vv:1:14: error: mutable arguments are only allowed for arrays, maps, aggregates and pointers
 return values instead: `fn foo(mut n int) {` => `fn foo(n int) int {`
     1 | fn foo(mut x int) {
       |              ~~~

--- a/vlib/v/checker/tests/mut_int.out
+++ b/vlib/v/checker/tests/mut_int.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/mut_int.vv:1:14: error: mutable arguments are only allowed for arrays, maps, aggregates and pointers
+vlib/v/checker/tests/mut_int.vv:1:14: error: mutable arguments are only allowed for arrays, interfaces, maps, pointers and structs
 return values instead: `fn foo(mut n int) {` => `fn foo(n int) int {`
     1 | fn foo(mut x int) {
       |              ~~~

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -704,7 +704,7 @@ fn (mut p Parser) check_fn_mutable_arguments(typ table.Type, pos token.Position)
 		[.array, .array_fixed, .interface_, .map, .placeholder, .struct_, .sum_type] && !typ.is_ptr() &&
 		!typ.is_pointer()
 	{
-		p.error_with_pos('mutable arguments are only allowed for arrays, maps, aggregates and pointers\n' +
+		p.error_with_pos('mutable arguments are only allowed for arrays, interfaces, maps, pointers and structs\n' +
 			'return values instead: `fn foo(mut n $sym.name) {` => `fn foo(n $sym.name) $sym.name {`',
 			pos)
 	}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -700,10 +700,11 @@ fn (mut p Parser) fn_args() ([]table.Param, bool, bool) {
 
 fn (mut p Parser) check_fn_mutable_arguments(typ table.Type, pos token.Position) {
 	sym := p.table.get_type_symbol(typ)
-	if sym.kind !in [.array, .array_fixed, .struct_, .map, .placeholder, .sum_type] &&
-		!typ.is_ptr() && !typ.is_pointer()
+	if sym.kind !in
+		[.array, .array_fixed, .interface_, .map, .placeholder, .struct_, .sum_type] && !typ.is_ptr() &&
+		!typ.is_pointer()
 	{
-		p.error_with_pos('mutable arguments are only allowed for arrays, maps, structs and pointers\n' +
+		p.error_with_pos('mutable arguments are only allowed for arrays, maps, aggregates and pointers\n' +
 			'return values instead: `fn foo(mut n $sym.name) {` => `fn foo(n $sym.name) $sym.name {`',
 			pos)
 	}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -701,8 +701,8 @@ fn (mut p Parser) fn_args() ([]table.Param, bool, bool) {
 fn (mut p Parser) check_fn_mutable_arguments(typ table.Type, pos token.Position) {
 	sym := p.table.get_type_symbol(typ)
 	if sym.kind !in
-		[.array, .array_fixed, .interface_, .map, .placeholder, .struct_, .sum_type] && !typ.is_ptr() &&
-		!typ.is_pointer()
+		[.array, .array_fixed, .interface_, .map, .placeholder, .struct_, .sum_type] &&
+		!typ.is_ptr() && !typ.is_pointer()
 	{
 		p.error_with_pos('mutable arguments are only allowed for arrays, interfaces, maps, pointers and structs\n' +
 			'return values instead: `fn foo(mut n $sym.name) {` => `fn foo(n $sym.name) $sym.name {`',

--- a/vlib/v/tests/interface_test.v
+++ b/vlib/v/tests/interface_test.v
@@ -7,7 +7,7 @@ mut:
 	breed string
 }
 
-fn (mut c Cat) name() string {
+fn (c &Cat) name() string {
 	if c.breed != '' {
 		assert c.breed == 'Persian'
 	}
@@ -113,7 +113,7 @@ fn test_perform_speak() {
 	*/
 }
 
-fn change_animal_breed(a &Animal, new string) {
+fn change_animal_breed(mut a Animal, new string) {
 	a.set_breed(new)
 }
 
@@ -122,7 +122,7 @@ fn test_interface_ptr_modification() {
 		breed: 'Persian'
 	}
 	// TODO Should fail and require `mut cat`
-	change_animal_breed(cat, 'Siamese')
+	change_animal_breed(mut cat, 'Siamese')
 	assert cat.breed == 'Siamese'
 }
 
@@ -190,6 +190,7 @@ interface Speaker2 {
 	name() string
 	speak()
 	return_speaker() Speaker2
+mut:
 	return_speaker2() ?Speaker2
 }
 
@@ -218,10 +219,10 @@ fn (mut b Boss) return_speaker2() ?Speaker2 {
 	return b
 }
 
-fn return_speaker2(sp Speaker2) Speaker2 {
+fn return_speaker2(mut sp Speaker2) Speaker2 {
 	s := sp.return_speaker()
 	s2 := sp.return_speaker2() or {
-		return sp
+		return *sp
 	}
 	s.speak()
 	s2.speak()
@@ -231,7 +232,7 @@ fn return_speaker2(sp Speaker2) Speaker2 {
 fn test_interface_returning_interface() {
 	mut b := Boss{'bob'}
 	assert b.name == 'bob'
-	s2 := return_speaker2(b)
+	s2 := return_speaker2(mut b)
 	if s2 is Boss {
 		assert s2.name == 'boss'
 	}
@@ -246,6 +247,7 @@ interface Animal {
 	name() string
 	name_detailed(pet_name string) string
 	speak(s string)
+mut:
 	set_breed(s string)
 }
 

--- a/vlib/v/tests/interface_test.v
+++ b/vlib/v/tests/interface_test.v
@@ -190,7 +190,6 @@ interface Speaker2 {
 	name() string
 	speak()
 	return_speaker() Speaker2
-mut:
 	return_speaker2() ?Speaker2
 }
 
@@ -221,9 +220,7 @@ fn (mut b Boss) return_speaker2() ?Speaker2 {
 
 fn return_speaker2(mut sp Speaker2) Speaker2 {
 	s := sp.return_speaker()
-	s2 := sp.return_speaker2() or {
-		return *sp
-	}
+	s2 := sp.return_speaker2() or { return *sp }
 	s.speak()
 	s2.speak()
 	return s2
@@ -247,7 +244,6 @@ interface Animal {
 	name() string
 	name_detailed(pet_name string) string
 	speak(s string)
-mut:
 	set_breed(s string)
 }
 


### PR DESCRIPTION
Now depends on #8097, draft until merged.
~~Fixes~~ #1081.
~~Fixes~~ #7338.

Parse mut interface method, mut interface parameter.
~~Also check method parameter mutability matches.~~ - this caused too many errors, these will need fixing in batches.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
