### PR TITLE
docs/sync: update to current usage syntax

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2360,7 +2360,7 @@ println(l)
 println(c)
 mut b := Abc{}
 ch2 := chan Abc{}
-res2 := ch2.try_pop(mut b) // try to perform `b = <-ch2
+res2 := ch2.try_pop(mut b) // try to perform `b = <-ch2`
 ```
 
 The `try_push/pop()` methods will return immediately with one of the results

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2261,8 +2261,8 @@ Objects can be pushed to channels using the arrow operator. The same operator ca
 pop objects from the other end:
 
 ```v
-mut ch := chan int{}
-mut ch2 := chan f64{}
+ch := chan int{}
+ch2 := chan f64{}
 n := 5
 x := 7.3
 ch <- n
@@ -2280,8 +2280,8 @@ associated channel has been closed and the buffer is empty. This situation can b
 handled using an or branch (see [Handling Optionals](#handling-optionals)).
 
 ```v wip
-mut ch := chan int{}
-mut ch2 := chan f64{}
+ch := chan int{}
+ch2 := chan f64{}
 // ...
 ch.close()
 // ...
@@ -2301,10 +2301,10 @@ of statements - similar to the [match](#match) command:
 ```v wip
 import time
 fn main () {
-  mut c := chan f64{}
-  mut ch := chan f64{}
-  mut ch2 := chan f64{}
-  mut ch3 := chan f64{}
+  c := chan f64{}
+  ch := chan f64{}
+  ch2 := chan f64{}
+  ch3 := chan f64{}
   mut b := 0.0
   // ...
   select {
@@ -2351,16 +2351,16 @@ struct Abc {
 }
 
 a := 2.13
-mut ch := chan f64{}
+ch := chan f64{}
 res := ch.try_push(a) // try to perform `ch <- a`
 println(res)
 l := ch.len // number of elements in queue
 c := ch.cap // maximum queue length
 println(l)
 println(c)
-// mut b := Abc{}
-// mut ch2 := chan f64{}
-// res2 := ch2.try_pop(mut b) // try to perform `b = <-ch2
+mut b := Abc{}
+ch2 := chan Abc{}
+res2 := ch2.try_pop(mut b) // try to perform `b = <-ch2
 ```
 
 The `try_push/pop()` methods will return immediately with one of the results
@@ -2370,33 +2370,31 @@ Usage of these methods and properties in production is not recommended -
 algorithms based on them are often subject to race conditions. Use `select` instead.
 
 Data can be exchanged between a coroutine and the calling thread via a shared variable.
-Such variables should be created as references and passed to the coroutine as `mut`.
-The underlying `struct` should also contain a `mutex` to lock concurrent access:
+Such variables should be created as `shared` and passed to the coroutine as such, too.
+The underlying `struct` contains a hidden *mutex* that allows locking concurrent access
+using `rlock` for read-only and `lock` for read/write access.
 
 ```v
-import sync
-
 struct St {
 mut:
-	x   int // share data
-	mtx &sync.Mutex
+    x   int // data to shared
 }
 
-fn (mut b St) g() {
-	b.mtx.m_lock()
-	// read/modify/write b.x
-	b.mtx.unlock()
+fn (shared b St) g() {
+    lock b {
+        // read/modify/write b.x
+    }
 }
 
-fn caller() {
-	mut a := &St{ // create as reference so it's on the heap
-		x: 10
-		mtx: sync.new_mutex()
-	}
-	go a.g()
-	a.mtx.m_lock()
-	// read/modify/write a.x
-	a.mtx.unlock()
+fn main() {
+    shared a := &St{ // create as reference so it's on the heap
+        x: 10
+    }
+    go a.g()
+	// ...
+    rlock a {
+        // read a.x
+    }
 }
 ```
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2377,24 +2377,24 @@ using `rlock` for read-only and `lock` for read/write access.
 ```v
 struct St {
 mut:
-    x   int // data to shared
+	x int // data to shared
 }
 
 fn (shared b St) g() {
-    lock b {
-        // read/modify/write b.x
-    }
+	lock b {
+		// read/modify/write b.x
+	}
 }
 
 fn main() {
-    shared a := &St{ // create as reference so it's on the heap
-        x: 10
-    }
-    go a.g()
+	shared a := &St{ // create as reference so it's on the heap
+		x: 10
+	}
+	go a.g()
 	// ...
-    rlock a {
-        // read a.x
-    }
+	rlock a {
+		// read a.x
+	}
 }
 ```
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2360,7 +2360,7 @@ println(l)
 println(c)
 mut b := Abc{}
 ch2 := chan Abc{}
-res2 := ch2.try_pop(mut b) // try to perform `b = <-ch2`
+res2 := ch2.try_pop(b) // try to perform `b = <-ch2`
 ```
 
 The `try_push/pop()` methods will return immediately with one of the results


### PR DESCRIPTION
This PR updates the docs for builtin `sync`:
- don't declare channels as `mut` (unless you want to assign a different channel to the variable, later)
- use builtin `shared` variables instead of manually built `struct`s with mutex

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
