### PR TITLE
 checker: improve errors for interface method compatibility 

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1849,7 +1849,7 @@ fn (mut c Checker) type_implements(typ table.Type, inter_typ table.Type, pos tok
 	styp := c.table.type_to_str(typ)
 	for imethod in inter_sym.methods {
 		if method := typ_sym.find_method(imethod.name) {
-			msg := c.table.is_same_method_as(imethod, method)
+			msg := c.table.is_same_method(imethod, method)
 			if msg.len > 0 {
 				c.error('`$styp` incorrectly implements method `$imethod.name` of interface `$inter_sym.name`: $msg',
 					pos)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1849,10 +1849,12 @@ fn (mut c Checker) type_implements(typ table.Type, inter_typ table.Type, pos tok
 	styp := c.table.type_to_str(typ)
 	for imethod in inter_sym.methods {
 		if method := typ_sym.find_method(imethod.name) {
-			if !imethod.is_same_method_as(method) {
+			msg := c.table.is_same_method_as(imethod, method)
+			if msg.len > 0 {
 				sig := c.table.fn_signature(imethod, skip_receiver: true)
-				c.error('`$styp` incorrectly implements method `$imethod.name` of interface `$inter_sym.name`, expected `$sig`',
+				c.error('`$styp` incorrectly implements method `$imethod.name` of interface `$inter_sym.name`: $msg',
 					pos)
+				c.add_error_detail('expected `$sig`')
 				return false
 			}
 			continue

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1851,10 +1851,8 @@ fn (mut c Checker) type_implements(typ table.Type, inter_typ table.Type, pos tok
 		if method := typ_sym.find_method(imethod.name) {
 			msg := c.table.is_same_method_as(imethod, method)
 			if msg.len > 0 {
-				sig := c.table.fn_signature(imethod, skip_receiver: true)
 				c.error('`$styp` incorrectly implements method `$imethod.name` of interface `$inter_sym.name`: $msg',
 					pos)
-				c.add_error_detail('expected `$sig`')
 				return false
 			}
 			continue

--- a/vlib/v/checker/tests/unimplemented_interface_b.out
+++ b/vlib/v/checker/tests/unimplemented_interface_b.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/unimplemented_interface_b.vv:13:6: error: `Cat` incorrectly implements method `name` of interface `Animal`, expected `name() string`
+vlib/v/checker/tests/unimplemented_interface_b.vv:13:6: error: `Cat` incorrectly implements method `name` of interface `Animal`: expected return type `string`
    11 | fn main() {
    12 |     c := Cat{}
    13 |     foo(c)

--- a/vlib/v/checker/tests/unimplemented_interface_c.out
+++ b/vlib/v/checker/tests/unimplemented_interface_c.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/unimplemented_interface_c.vv:12:6: error: `Cat` incorrectly implements method `name` of interface `Animal`, expected `name()`
-   10 |
+vlib/v/checker/tests/unimplemented_interface_c.vv:12:6: error: `Cat` incorrectly implements method `name` of interface `Animal`: expected 1 parameter(s), not 2
+   10 | 
    11 | fn main() {
    12 |     foo(Cat{})
       |         ~~~~~

--- a/vlib/v/checker/tests/unimplemented_interface_d.out
+++ b/vlib/v/checker/tests/unimplemented_interface_d.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/unimplemented_interface_d.vv:12:6: error: `Cat` incorrectly implements method `speak` of interface `Animal`, expected `speak(s string)`
-   10 |
+vlib/v/checker/tests/unimplemented_interface_d.vv:12:6: error: `Cat` incorrectly implements method `speak` of interface `Animal`: expected 2 parameter(s), not 1
+   10 | 
    11 | fn main() {
    12 |     foo(Cat{})
       |         ~~~~~

--- a/vlib/v/checker/tests/unimplemented_interface_e.out
+++ b/vlib/v/checker/tests/unimplemented_interface_e.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/unimplemented_interface_e.vv:12:6: error: `Cat` incorrectly implements method `speak` of interface `Animal`, expected `speak(s string)`
-   10 |
+vlib/v/checker/tests/unimplemented_interface_e.vv:12:6: error: `Cat` incorrectly implements method `speak` of interface `Animal`: expected `string`, not `&string` for parameter 1
+   10 | 
    11 | fn main() {
    12 |     foo(Cat{})
       |         ~~~~~

--- a/vlib/v/checker/tests/unimplemented_interface_f.out
+++ b/vlib/v/checker/tests/unimplemented_interface_f.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/unimplemented_interface_f.vv:11:13: error: `Cat` incorrectly implements method `speak` of interface `Animal`, expected `speak(s string)`
+vlib/v/checker/tests/unimplemented_interface_f.vv:11:13: error: `Cat` incorrectly implements method `speak` of interface `Animal`: expected 2 parameter(s), not 1
     9 | fn main() {
    10 |     mut animals := []Animal{}
    11 |     animals << Cat{}

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -129,7 +129,7 @@ pub fn (t &Table) fn_type_source_signature(f &Fn) string {
 	return sig
 }
 
-pub fn (t &Table) is_same_method_as(f &Fn, func &Fn) string {
+pub fn (t &Table) is_same_method(f &Fn, func &Fn) string {
 	if f.return_type != func.return_type {
 		s := t.type_to_str(f.return_type)
 		return 'expected return type `$s`'

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -129,19 +129,21 @@ pub fn (t &Table) fn_type_source_signature(f &Fn) string {
 	return sig
 }
 
-pub fn (f &Fn) is_same_method_as(func &Fn) bool {
+pub fn (t &Table) is_same_method_as(f &Fn, func &Fn) string {
 	if f.return_type != func.return_type {
-		return false
+		s := t.type_to_str(f.return_type)
+		return 'expected return type `$s`'
 	}
 	if f.params.len != func.params.len {
-		return false
+		return 'expected ${f.params.len} parameters'
 	}
 	for i in 1 .. f.params.len {
 		if f.params[i].typ != func.params[i].typ {
-			return false
+			s := t.type_to_str(f.params[i].typ)
+			return 'type of parameter $i is not `$s`'
 		}
 	}
-	return true
+	return ''
 }
 
 pub fn (t &Table) find_fn(name string) ?Fn {

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -135,12 +135,13 @@ pub fn (t &Table) is_same_method_as(f &Fn, func &Fn) string {
 		return 'expected return type `$s`'
 	}
 	if f.params.len != func.params.len {
-		return 'expected ${f.params.len} parameters'
+		return 'expected $f.params.len parameter(s), not $func.params.len'
 	}
 	for i in 1 .. f.params.len {
 		if f.params[i].typ != func.params[i].typ {
-			s := t.type_to_str(f.params[i].typ)
-			return 'type of parameter $i is not `$s`'
+			exps := t.type_to_str(f.params[i].typ)
+			gots := t.type_to_str(func.params[i].typ)
+			return 'expected `$exps`, not `$gots` for parameter $i'
 		}
 	}
 	return ''


### PR DESCRIPTION
Split out from #8092.

Be more specific about why a struct method doesn't match an interface method.
Make Table.is_same_method return error message.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
