### PR TITLE
checker: disallow indexing a voidptr

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4711,7 +4711,8 @@ pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) table.Type {
 	typ := c.expr(node.left)
 	node.left_type = typ
 	typ_sym := c.table.get_final_type_symbol(typ)
-	if typ_sym.kind !in [.array, .array_fixed, .string, .map] && !typ.is_ptr() && typ !in [table.byteptr_type, table.charptr_type] && !typ.has_flag(.variadic) {
+	if typ_sym.kind !in [.array, .array_fixed, .string, .map] && !typ.is_ptr() && typ !in [table.byteptr_type, table.charptr_type] &&
+		!typ.has_flag(.variadic) {
 		c.error('type `$typ_sym.name` does not support indexing', node.pos)
 	}
 	if typ_sym.kind == .string && !typ.is_ptr() && node.is_setter {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4711,8 +4711,7 @@ pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) table.Type {
 	typ := c.expr(node.left)
 	node.left_type = typ
 	typ_sym := c.table.get_final_type_symbol(typ)
-	if typ_sym.kind !in [.array, .array_fixed, .string, .map] && !typ.is_ptr() && !(!typ_sym.name[0].is_capital() &&
-		typ_sym.name.ends_with('ptr')) && !typ.has_flag(.variadic) { // byteptr, charptr etc
+	if typ_sym.kind !in [.array, .array_fixed, .string, .map] && !typ.is_ptr() && typ !in [table.byteptr_type, table.charptr_type] && !typ.has_flag(.variadic) {
 		c.error('type `$typ_sym.name` does not support indexing', node.pos)
 	}
 	if typ_sym.kind == .string && !typ.is_ptr() && node.is_setter {

--- a/vlib/v/checker/tests/pointer_ops.out
+++ b/vlib/v/checker/tests/pointer_ops.out
@@ -32,11 +32,18 @@ vlib/v/checker/tests/pointer_ops.vv:9:4: error: invalid operation: -- (non-numer
     9 |         p--
       |          ~~
    10 |         p -= 3
-   11 |     }
+   11 |         _ = p[3]
 vlib/v/checker/tests/pointer_ops.vv:10:3: error: operator `-=` not defined on left operand type `voidptr`
     8 |         _ = p - 1
     9 |         p--
    10 |         p -= 3
       |         ^
-   11 |     }
-   12 | }
+   11 |         _ = p[3]
+   12 |     }
+vlib/v/checker/tests/pointer_ops.vv:11:8: error: type `voidptr` does not support indexing
+    9 |         p--
+   10 |         p -= 3
+   11 |         _ = p[3]
+      |              ~~~
+   12 |     }
+   13 | }

--- a/vlib/v/checker/tests/pointer_ops.vv
+++ b/vlib/v/checker/tests/pointer_ops.vv
@@ -8,5 +8,6 @@ fn test_voidptr() {
 		_ = p - 1
 		p--
 		p -= 3
+		_ = p[3]
 	}
 }


### PR DESCRIPTION
void* indexing is not in the C standard and MSVC doesn't support it. We already disallow voidptr arithmetic.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
