### PR TITLE
checker: show signature for interface method on error

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1851,6 +1851,8 @@ fn (mut c Checker) type_implements(typ table.Type, inter_typ table.Type, pos tok
 		if method := typ_sym.find_method(imethod.name) {
 			msg := c.table.is_same_method(imethod, method)
 			if msg.len > 0 {
+				sig := c.table.fn_signature(imethod, skip_receiver: true)
+				c.add_error_detail('$inter_sym.name has `$sig`')
 				c.error('`$styp` incorrectly implements method `$imethod.name` of interface `$inter_sym.name`: $msg',
 					pos)
 				return false
@@ -4907,6 +4909,7 @@ pub fn (mut c Checker) map_init(mut node ast.MapInit) table.Type {
 	return map_type
 }
 
+// call this *before* calling error or warn
 pub fn (mut c Checker) add_error_detail(s string) {
 	c.error_details << s
 }

--- a/vlib/v/checker/tests/unimplemented_interface_b.out
+++ b/vlib/v/checker/tests/unimplemented_interface_b.out
@@ -4,3 +4,4 @@ vlib/v/checker/tests/unimplemented_interface_b.vv:13:6: error: `Cat` incorrectly
    13 |     foo(c)
       |         ^
    14 | }
+details: main.Animal has `name() string`

--- a/vlib/v/checker/tests/unimplemented_interface_c.out
+++ b/vlib/v/checker/tests/unimplemented_interface_c.out
@@ -4,3 +4,4 @@ vlib/v/checker/tests/unimplemented_interface_c.vv:12:6: error: `Cat` incorrectly
    12 |     foo(Cat{})
       |         ~~~~~
    13 | }
+details: main.Animal has `name()`

--- a/vlib/v/checker/tests/unimplemented_interface_d.out
+++ b/vlib/v/checker/tests/unimplemented_interface_d.out
@@ -4,3 +4,4 @@ vlib/v/checker/tests/unimplemented_interface_d.vv:12:6: error: `Cat` incorrectly
    12 |     foo(Cat{})
       |         ~~~~~
    13 | }
+details: main.Animal has `speak(s string)`

--- a/vlib/v/checker/tests/unimplemented_interface_e.out
+++ b/vlib/v/checker/tests/unimplemented_interface_e.out
@@ -4,3 +4,4 @@ vlib/v/checker/tests/unimplemented_interface_e.vv:12:6: error: `Cat` incorrectly
    12 |     foo(Cat{})
       |         ~~~~~
    13 | }
+details: main.Animal has `speak(s string)`

--- a/vlib/v/checker/tests/unimplemented_interface_f.out
+++ b/vlib/v/checker/tests/unimplemented_interface_f.out
@@ -4,3 +4,4 @@ vlib/v/checker/tests/unimplemented_interface_f.vv:11:13: error: `Cat` incorrectl
    11 |     animals << Cat{}
       |                ~~~~~
    12 | }
+details: main.Animal has `speak(s string)`


### PR DESCRIPTION
Follow up to #8097. Before that the signature was included in the error message, but it would be too long now. Show it on the next line instead.

This helps the programmer rather than just saying the first parameter type mismatch or the number of parameters. 

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
