### PR TITLE
cgen: fix error of anon_fn_call (fix #8104)

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -93,6 +93,7 @@ mut:
 	map_fn_definitions    []string // map equality functions that have been defined
 	struct_fn_definitions []string // struct equality functions that have been defined
 	auto_fn_definitions   []string // auto generated functions defination list
+	anon_fn_definitions   []string // anon generated functions defination list
 	is_json_fn            bool     // inside json.encode()
 	json_types            []string // to avoid json gen duplicates
 	pcs                   []ProfileCounterMeta // -prof profile counter fn_names => fn counter name
@@ -338,6 +339,11 @@ pub fn cgen(files []ast.File, table &table.Table, pref &pref.Preferences) string
 	}
 	if g.auto_fn_definitions.len > 0 {
 		for fn_def in g.auto_fn_definitions {
+			b.writeln(fn_def)
+		}
+	}
+	if g.anon_fn_definitions.len > 0 {
+		for fn_def in g.anon_fn_definitions {
 			b.writeln(fn_def)
 		}
 	}
@@ -2361,12 +2367,10 @@ fn (mut g Gen) autofree_var_call(free_fn_name string, v ast.Var) {
 
 fn (mut g Gen) gen_anon_fn_decl(it ast.AnonFn) {
 	pos := g.out.len
-	def_pos := g.definitions.len
 	g.stmt(it.decl)
 	fn_body := g.out.after(pos)
 	g.out.go_back(fn_body.len)
-	g.definitions.go_back(g.definitions.len - def_pos)
-	g.definitions.write(fn_body)
+	g.anon_fn_definitions << fn_body
 }
 
 fn (mut g Gen) map_fn_ptrs(key_typ table.TypeSymbol) (string, string, string, string) {

--- a/vlib/v/tests/anon_fn_call_test.v
+++ b/vlib/v/tests/anon_fn_call_test.v
@@ -1,0 +1,10 @@
+fn test_anon_fn_call() {
+	anon_fn := fn() string {
+		return test()
+	}
+	assert anon_fn() == 'Test'
+}
+
+fn test() string {
+	return "Test"
+}


### PR DESCRIPTION
This PR fix error of anon_fn_call (fix #8104).

- Fix error of anon_fn_call.
- Add test `anon_fn_call_test.v`.

```v
module main

fn main() {
	anon_fn := fn() {
		println(test())
	}
	anon_fn()
}

fn test() string {
	return "Test"
}

PS D:\Test\v\tt1> v run .
Test
```