### PR TITLE
cgen: fix for_in_mut_val (fix #8087)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -64,7 +64,7 @@ mut:
 	inside_sql                       bool // to handle sql table fields pseudo variables
 	cur_orm_ts                       table.TypeSymbol
 	error_details                    []string
-	for_in_mut_val_typ               table.Type
+	for_in_mut_val_name              string
 	vmod_file_content                string       // needed for @VMOD_FILE, contents of the file, *NOT its path**
 	vweb_gen_types                   []table.Type // vweb route checks
 	prevent_sum_type_unwrapping_once bool   // needed for assign new values to sum type, stopping unwrapping then
@@ -2464,7 +2464,7 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 				assign_stmt.pos)
 		}
 		left_is_ptr := left_type.is_ptr() || left_sym.is_pointer()
-		if left_is_ptr && c.for_in_mut_val_typ != left_type {
+		if left_is_ptr && c.for_in_mut_val_name != left.str() {
 			if !c.inside_unsafe && assign_stmt.op !in [.assign, .decl_assign] {
 				// ptr op=
 				c.warn('pointer arithmetic is only allowed in `unsafe` blocks', assign_stmt.pos)
@@ -2963,11 +2963,11 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 			}
 			c.check_loop_label(node.label, node.pos)
 			if node.val_is_mut {
-				c.for_in_mut_val_typ = node.val_type
+				c.for_in_mut_val_name = node.val_var
 			}
 			c.stmts(node.stmts)
 			if node.val_is_mut {
-				c.for_in_mut_val_typ = 0
+				c.for_in_mut_val_name = ''
 			}
 			c.loop_label = prev_loop_label
 			c.in_for_count--

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2462,7 +2462,7 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 			c.error('use `array2 = array1.clone()` instead of `array2 = array1` (or use `unsafe`)',
 				assign_stmt.pos)
 		}
-		left_is_ptr := left_type.is_ptr() || left_sym.is_pointer()
+		left_is_ptr := (left_type.is_ptr() || left_sym.is_pointer()) && c.in_for_count == 0
 		if left_is_ptr {
 			if !c.inside_unsafe && assign_stmt.op !in [.assign, .decl_assign] {
 				// ptr op=

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -64,6 +64,7 @@ mut:
 	inside_sql                       bool // to handle sql table fields pseudo variables
 	cur_orm_ts                       table.TypeSymbol
 	error_details                    []string
+	for_in_mut_val_typ               table.Type
 	vmod_file_content                string       // needed for @VMOD_FILE, contents of the file, *NOT its path**
 	vweb_gen_types                   []table.Type // vweb route checks
 	prevent_sum_type_unwrapping_once bool   // needed for assign new values to sum type, stopping unwrapping then
@@ -2462,8 +2463,8 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 			c.error('use `array2 = array1.clone()` instead of `array2 = array1` (or use `unsafe`)',
 				assign_stmt.pos)
 		}
-		left_is_ptr := (left_type.is_ptr() || left_sym.is_pointer()) && c.in_for_count == 0
-		if left_is_ptr {
+		left_is_ptr := left_type.is_ptr() || left_sym.is_pointer()
+		if left_is_ptr && c.for_in_mut_val_typ != left_type {
 			if !c.inside_unsafe && assign_stmt.op !in [.assign, .decl_assign] {
 				// ptr op=
 				c.warn('pointer arithmetic is only allowed in `unsafe` blocks', assign_stmt.pos)
@@ -2961,7 +2962,13 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 				}
 			}
 			c.check_loop_label(node.label, node.pos)
+			if node.val_is_mut {
+				c.for_in_mut_val_typ = node.val_type
+			}
 			c.stmts(node.stmts)
+			if node.val_is_mut {
+				c.for_in_mut_val_typ = 0
+			}
 			c.loop_label = prev_loop_label
 			c.in_for_count--
 		}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -110,7 +110,7 @@ mut:
 	strs_to_free0    []string // strings.Builder
 	// strs_to_free          []string // strings.Builder
 	inside_call           bool
-	for_in_mul_val_typ    table.Type
+	for_in_mul_val_name   string
 	has_main              bool
 	inside_const          bool
 	comp_for_method       string      // $for method in T.methods {}
@@ -1371,11 +1371,11 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		g.error('for in: unhandled symbol `$it.cond` of type `$s`', it.pos)
 	}
 	if it.val_is_mut {
-		g.for_in_mul_val_typ = it.val_type
+		g.for_in_mul_val_name = it.val_var
 	}
 	g.stmts(it.stmts)
 	if it.val_is_mut {
-		g.for_in_mul_val_typ = 0
+		g.for_in_mul_val_name = ''
 	}
 	if it.label.len > 0 {
 		g.writeln('\t${it.label}__continue: {}')
@@ -1998,7 +1998,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					g.prevent_sum_type_unwrapping_once = true
 				}
 				if !is_fixed_array_copy || is_decl {
-					if !is_decl && left is ast.Ident && g.for_in_mul_val_typ == var_type {
+					if !is_decl && left is ast.Ident && g.for_in_mul_val_name == (left as ast.Ident).name {
 						g.write('*')
 					}
 					g.expr(left)

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -110,6 +110,7 @@ mut:
 	strs_to_free0    []string // strings.Builder
 	// strs_to_free          []string // strings.Builder
 	inside_call           bool
+	for_in_mul_val        string
 	has_main              bool
 	inside_const          bool
 	comp_for_method       string      // $for method in T.methods {}
@@ -1369,7 +1370,13 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		s := g.table.type_to_str(it.cond_type)
 		g.error('for in: unhandled symbol `$it.cond` of type `$s`', it.pos)
 	}
+	if it.val_is_mut {
+		g.for_in_mul_val = g.typ(it.val_type)
+	}
 	g.stmts(it.stmts)
+	if it.val_is_mut {
+		g.for_in_mul_val = ''
+	}
 	if it.label.len > 0 {
 		g.writeln('\t${it.label}__continue: {}')
 	}
@@ -1991,6 +1998,9 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					g.prevent_sum_type_unwrapping_once = true
 				}
 				if !is_fixed_array_copy || is_decl {
+					if !is_decl && left is ast.Ident && g.for_in_mul_val == g.typ(var_type) {
+						g.write('*')
+					}
 					g.expr(left)
 				}
 			}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -110,7 +110,7 @@ mut:
 	strs_to_free0    []string // strings.Builder
 	// strs_to_free          []string // strings.Builder
 	inside_call           bool
-	for_in_mul_val        string
+	for_in_mul_val_typ    table.Type
 	has_main              bool
 	inside_const          bool
 	comp_for_method       string      // $for method in T.methods {}
@@ -1371,11 +1371,11 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		g.error('for in: unhandled symbol `$it.cond` of type `$s`', it.pos)
 	}
 	if it.val_is_mut {
-		g.for_in_mul_val = g.typ(it.val_type)
+		g.for_in_mul_val_typ = it.val_type
 	}
 	g.stmts(it.stmts)
 	if it.val_is_mut {
-		g.for_in_mul_val = ''
+		g.for_in_mul_val_typ = 0
 	}
 	if it.label.len > 0 {
 		g.writeln('\t${it.label}__continue: {}')
@@ -1998,7 +1998,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					g.prevent_sum_type_unwrapping_once = true
 				}
 				if !is_fixed_array_copy || is_decl {
-					if !is_decl && left is ast.Ident && g.for_in_mul_val == g.typ(var_type) {
+					if !is_decl && left is ast.Ident && g.for_in_mul_val_typ == var_type {
 						g.write('*')
 					}
 					g.expr(left)

--- a/vlib/v/tests/for_in_mut_val_test.v
+++ b/vlib/v/tests/for_in_mut_val_test.v
@@ -1,0 +1,12 @@
+fn foo(mut arr []int) {
+	for _, mut j in arr {
+		j *= 2
+	}
+}
+
+fn test_for_in_mut_val() {
+	mut arr := [1, 2, 3]
+	foo(mut arr)
+	println(arr)
+	assert arr == [2, 4, 6]
+}


### PR DESCRIPTION
This PR fix for_in_mut_val (fix #8087).

- Fix for_in_mut_val.
- Add test `for_in_mut_val_test.v`.

```v
module main

fn foo(mut arr []int) {
	for _, mut j in arr {
		j *= 2
	}
}

fn main() {
	mut arr := [1,2,3]
	foo(mut arr)
	println(arr)
}

PS D:\Test\v\tt1> v run .
[2, 4, 6]
```