### PR TITLE
android: enable custom (e)println output via android log system

### DIFF
--- a/examples/2048/2048.v
+++ b/examples/2048/2048.v
@@ -936,13 +936,6 @@ fn (mut app App) showfps() {
 	}
 }
 
-// TODO: Move this somewhere else (vlib?) once Android support is merged
-$if android {
-	#include <android/log.h>
-	#define LOG_TAG "v_logcat_test"
-	#define printf(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
-	#define fprintf(a, ...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
-}
 fn main() {
 	mut app := &App{}
 	app.new_game()

--- a/thirdparty/sokol/sokol_v.h
+++ b/thirdparty/sokol/sokol_v.h
@@ -1,0 +1,20 @@
+#if defined(__ANDROID__)
+	// Adapted from https://stackoverflow.com/a/196018/1904615
+	#define V_ANDROID_LOG_STR_VALUE(arg) #arg
+	#define V_ANDROID_LOG_NAME(tag_name) V_ANDROID_LOG_STR_VALUE(tag_name)
+
+	#ifndef V_ANDROID_LOG_TAG
+		#if defined(APPNAME)
+			#define V_ANDROID_LOG_TAG APPNAME
+		#else
+			#define V_ANDROID_LOG_TAG "V_ANDROID"
+		#endif
+	#endif
+
+	#define V_ANDROID_LOG_TAG_NAME V_ANDROID_LOG_NAME(V_ANDROID_LOG_TAG)
+
+	#include <android/log.h>
+	#define printf(...) __android_log_print(ANDROID_LOG_INFO, V_ANDROID_LOG_TAG_NAME, __VA_ARGS__)
+	#define fprintf(a, ...) __android_log_print(ANDROID_LOG_ERROR, V_ANDROID_LOG_TAG_NAME, __VA_ARGS__)
+#endif
+

--- a/vlib/sokol/c/declaration.c.v
+++ b/vlib/sokol/c/declaration.c.v
@@ -41,6 +41,8 @@ pub const (
 #flag solaris -DSOKOL_NO_ENTRY
 // TODO end
 
+#include "sokol_v.h"
+
 #include "sokol_app.h"
 
 #define SOKOL_IMPL


### PR DESCRIPTION
This PR will enable `eprintln` and `println` to redirect output via Android's logging system.

Having a way to capture log output will help greatly in `vab`'s CI to detect if an app has started flawlessly, among other useful things (also helps troubleshoot sokol debug info).

To set a custom tag one can use a define `-DV_ANDROID_LOG_TAG="MyVApp"`.
If no custom tag is defined - the `APPNAME` define will be used (this is normally set when building Android apps)
If no `APPNAME` is defined it will fallback to `V_ANDROID`.

I'm building support for capturing log output in `vab` - which will ofc benefit and support this setup.

Credits to @spaceface777 - who initially came up with a [log solution in 2048](https://github.com/vlang/v/blob/5de287a6e7ebf2e12f4f66371fb9b471fe99aa3a/examples/2048/2048.v#L939-L945).
While this is a good solution in V - we currently don't support the `#ifndef`'s needed to set the custom and default values.

Capturing, otherwise confusing, log output via logcat then more simply becomes:
`adb logcat -d SOKOL_APP:D V_ANDROID:D <log tag>:D '*:S'`
This will be built into `vab` at some point.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
