### PR TITLE
parser: fix parsing of `go` call expression

### DIFF
--- a/vlib/v/tests/go_wait_3_test.v
+++ b/vlib/v/tests/go_wait_3_test.v
@@ -1,0 +1,22 @@
+struct Test {
+	sub SubTest
+}
+
+struct SubTest {
+	test string
+}
+
+fn test_method_go_wait() {
+	a := Test{
+		sub: SubTest{
+			test: 'hi'
+		}
+	}
+	thread := go a.sub.get()
+	r := thread.wait()
+	assert r == 'hi'
+}
+
+fn (t SubTest) get() string {
+	return t.test
+}


### PR DESCRIPTION
This fixes #8134.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
