### PR TITLE
parser: support `module:` for immutable private struct fields

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -194,9 +194,11 @@ pub:
 	name         string
 	gen_types    []table.Type
 	is_pub       bool
+	// _pos fields for vfmt
 	mut_pos      int // mut:
 	pub_pos      int // pub:
 	pub_mut_pos  int // pub mut:
+	module_pos   int // module:
 	language     table.Language
 	is_union     bool
 	attrs        []table.Attr

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -190,10 +190,10 @@ pub mut:
 
 pub struct StructDecl {
 pub:
-	pos          token.Position
-	name         string
-	gen_types    []table.Type
-	is_pub       bool
+	pos       token.Position
+	name      string
+	gen_types []table.Type
+	is_pub    bool
 	// _pos fields for vfmt
 	mut_pos      int // mut:
 	pub_pos      int // pub:

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -748,6 +748,8 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl) {
 			f.writeln('pub:')
 		} else if i == node.pub_mut_pos {
 			f.writeln('pub mut:')
+		} else if i == node.module_pos {
+			f.writeln('module:')
 		}
 		end_pos := field.pos.pos + field.pos.len
 		comments := field.comments

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -93,6 +93,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 	mut pub_pos := -1
 	mut pub_mut_pos := -1
 	mut global_pos := -1
+	mut module_pos := -1
 	mut is_field_mut := false
 	mut is_field_pub := false
 	mut is_field_global := false
@@ -157,6 +158,17 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 				is_field_pub = true
 				is_field_mut = true
 				is_field_global = true
+			} else if p.tok.kind == .key_module {
+				if module_pos != -1 {
+					p.error('redefinition of `module` section')
+					return {}
+				}
+				p.next()
+				p.check(.colon)
+				module_pos = fields.len
+				is_field_pub = false
+				is_field_mut = false
+				is_field_global = false
 			}
 			for p.tok.kind == .comment {
 				comments << p.comment()
@@ -320,6 +332,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 		mut_pos: mut_pos - embeds.len
 		pub_pos: pub_pos - embeds.len
 		pub_mut_pos: pub_mut_pos - embeds.len
+		module_pos: module_pos - embeds.len
 		language: language
 		is_union: is_union
 		attrs: attrs

--- a/vlib/v/parser/tests/struct_module_section.out
+++ b/vlib/v/parser/tests/struct_module_section.out
@@ -1,0 +1,12 @@
+vlib/v/parser/tests/struct_module_section.vv:16:3: error: field `i` of struct `S1` is immutable
+   14 | 
+   15 | mut s := S1{}
+   16 | s.i++
+      |   ^
+   17 | mut s2 := S2{}
+   18 | s2.j++
+vlib/v/parser/tests/struct_module_section.vv:18:4: error: field `j` of struct `S2` is immutable
+   16 | s.i++
+   17 | mut s2 := S2{}
+   18 | s2.j++
+      |    ^

--- a/vlib/v/parser/tests/struct_module_section.vv
+++ b/vlib/v/parser/tests/struct_module_section.vv
@@ -1,0 +1,18 @@
+struct S1 {
+pub mut:
+	v byte
+module:
+	i int
+}
+
+struct S2 {
+module:
+	j int
+mut:
+	v byte
+}
+
+mut s := S1{}
+s.i++
+mut s2 := S2{}
+s2.j++


### PR DESCRIPTION
Fixes #6582.
Otherwise immutable private fields have to come first despite being least interesting.

*Update*: this feature is necessary (but not sufficient) for:
1. optimizing alignment of types whose size is not a multiple of the bus size.
2. optimizing cache performance of commonly used fields in struct larger than the processor's cache size.

I decided to use the `module` keyword for this as non-public fields are accessible in the module only.
Alex agrees that this should be possible, but there was no agreed syntax: https://github.com/vlang/v/issues/6582#issuecomment-735765489



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
