### PR TITLE
fmt: minor code cleanup

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1820,9 +1820,16 @@ pub fn (mut f Fmt) chan_init(mut it ast.ChanInit) {
 	f.write('}')
 }
 
+fn should_decrease_arr_penalty(e ast.Expr) bool {
+	if e is ast.ArrayInit || e is ast.StructInit || e is ast.MapInit || e is ast.CallExpr {
+		return true
+	}
+	return false
+}
+
 pub fn (mut f Fmt) array_init(it ast.ArrayInit) {
 	if it.exprs.len == 0 && it.typ != 0 && it.typ != table.void_type {
-		// `x := []string`
+		// `x := []string{}`
 		f.write(f.table.type_to_str_using_aliases(it.typ, f.mod2alias))
 		f.write('{')
 		if it.has_len {
@@ -1864,14 +1871,10 @@ pub fn (mut f Fmt) array_init(it ast.ArrayInit) {
 		line_break := f.array_init_break[f.array_init_depth - 1]
 		mut penalty := if line_break && !is_same_line_comment { 0 } else { 3 }
 		if penalty > 0 {
-			if i == 0 || it.exprs[i - 1] is ast.ArrayInit || it.exprs[i - 1] is ast.StructInit ||
-				it.exprs[i - 1] is ast.MapInit || it.exprs[i - 1] is ast.CallExpr
-			{
+			if i == 0 || should_decrease_arr_penalty(it.exprs[i - 1]) {
 				penalty--
 			}
-			if expr is ast.ArrayInit ||
-				expr is ast.StructInit || expr is ast.MapInit || expr is ast.CallExpr
-			{
+			if should_decrease_arr_penalty(expr) {
 				penalty--
 			}
 		}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -699,14 +699,14 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl) {
 		comments := field.comments
 		// Handle comments before field
 		mut comm_idx := 0
+		f.indent++
 		for comm_idx < comments.len && comments[comm_idx].pos.pos < field.pos.pos {
-			f.indent++
 			f.empty_line = true
 			f.comment(comments[comm_idx], {})
 			f.writeln('')
-			f.indent--
 			comm_idx++
 		}
+		f.indent--
 		f.write('\t$field.name ')
 		// Handle comments between field name and type
 		mut comments_len := 0

--- a/vlib/v/fmt/fmt_keep_test.v
+++ b/vlib/v/fmt/fmt_keep_test.v
@@ -59,6 +59,9 @@ fn test_fmt() {
 		if expected_ocontent != result_ocontent {
 			fmt_bench.fail()
 			eprintln(fmt_bench.step_message_fail('file $vrelpath after formatting, does not look as expected.'))
+			if ipath.ends_with(b2v_keep_path) {
+				continue
+			}
 			if diff_cmd == '' {
 				eprintln('>> sorry, but no working "diff" CLI command can be found')
 				continue


### PR DESCRIPTION
- `bin2v_keep.vv` diffs are not printed on fail as they are HUGE
- clean up penalty decrease code in `array_init`
- `struct_decl` move f.indent++/-- out of loop to reduce their calls