### PR TITLE
fmt: correct indent for StructDecl multi line default exprs

### DIFF
--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -46,10 +46,10 @@ pub mut:
 	base_path string
 	table     &table.Table    = &table.Table{}
 	checker   checker.Checker = checker.Checker{
-	table: 0
-	cur_fn: 0
-	pref: 0
-}
+		table: 0
+		cur_fn: 0
+		pref: 0
+	}
 	fmt             fmt.Fmt
 	filename        string
 	pos             int

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -687,7 +687,7 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl) {
 	mut field_align_i := 0
 	mut comment_align_i := 0
 	mut default_expr_align_i := 0
-	mut inc_indent := false
+	mut inc_indent := false // for correct indents with multi line default exprs
 	for i, field in node.fields {
 		if i == node.mut_pos {
 			f.writeln('mut:')

--- a/vlib/v/fmt/tests/struct_keep.vv
+++ b/vlib/v/fmt/tests/struct_keep.vv
@@ -34,3 +34,13 @@ pub:
 	a int
 	b int
 }
+
+struct KeepMultiLineDefaultExprsIndent {
+	buttons []PeriodButton = [PeriodButton{
+		period: pr.Period.m1
+		text: 'M1'
+	}, PeriodButton{
+		period: pr.Period.m5
+		text: 'M5'
+	}]
+}


### PR DESCRIPTION
fix #8119 