### PR TITLE
cgen: fix `for` iteration over fixed array literal

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1278,11 +1278,12 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		atmp := g.new_tmp_var()
 		atmp_type := g.typ(it.cond_type)
 		if !it.cond.is_lvalue() {
-			g.error('for in: unhandled condition `$it.cond`', it.pos)
+			g.write('$atmp_type *$atmp = &(($atmp_type)')
+		} else {
+			g.write('$atmp_type *$atmp = &(')
 		}
-		// TODO rvalue cond
-		g.write('$atmp_type *$atmp = &')
 		g.expr(it.cond)
+		g.writeln(')')
 		g.writeln(';')
 		i := if it.key_var in ['', '_'] { g.new_tmp_var() } else { it.key_var }
 		cond_sym := g.table.get_type_symbol(it.cond_type)

--- a/vlib/v/tests/fixed_array_test.v
+++ b/vlib/v/tests/fixed_array_test.v
@@ -68,3 +68,20 @@ fn test_fixed_array_can_be_passed_as_mut_arg() {
 	change_first_element(mut arr2)
 	assert arr2 == [[0,2,3]!, [4,5,6]!, [7,8,9]!]!
 }
+
+fn test_iteration_over_fixed_array() {
+	mut s := u16(0)
+	arr := [u16(3), 2, 17, 23]!
+	for v in arr {
+		s += v
+	}
+	assert s == 45
+}
+
+fn test_iteration_over_fixed_array_literal() {
+	mut s := 0.0
+	for v in [0.5, -2.25, 3.75, 12.0, 13.25]! {
+		s += v
+	}
+	assert s == 27.25
+}


### PR DESCRIPTION
This PR allows the following to work:
```v
mut s := 0.0
for v in [0.5, -2.25, 3.75, 12.0, 13.25]! {
    s += v
}
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please:
  A) run the tests with `v test-compiler` .
  B) make sure, that V can still compile itself:
```shell
./v -o v cmd/v
./v -o v cmd/v
```
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
