### PR TITLE
cgen: fix `for _,mut j in arr` of fixed arrays (fix #8163)

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1276,15 +1276,22 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		}
 	} else if it.kind == .array_fixed {
 		atmp := g.new_tmp_var()
-		atmp_type := g.typ(it.cond_type)
+		atmp_type := g.typ(it.cond_type).trim('*')
 		if !it.cond.is_lvalue() {
-			g.write('$atmp_type *$atmp = &(($atmp_type)')
+			g.write('$atmp_type *$atmp = ')
+			if !it.cond_type.is_ptr() {
+				g.write('&')
+			}
+			g.write('(($atmp_type)')
 		} else {
-			g.write('$atmp_type *$atmp = &(')
+			g.write('$atmp_type *$atmp = ')
+			if !it.cond_type.is_ptr() {
+				g.write('&')
+			}
+			g.write('(')
 		}
 		g.expr(it.cond)
-		g.writeln(')')
-		g.writeln(';')
+		g.writeln(');')
 		i := if it.key_var in ['', '_'] { g.new_tmp_var() } else { it.key_var }
 		cond_sym := g.table.get_type_symbol(it.cond_type)
 		info := cond_sym.info as table.ArrayFixed
@@ -1298,7 +1305,11 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 				styp := g.typ(it.val_type)
 				g.write('\t$styp ${c_name(it.val_var)}')
 			}
-			g.writeln(' = (*$atmp)[$i];')
+			if it.val_is_mut {
+				g.writeln(' = &(*$atmp)[$i];')
+			} else {
+				g.writeln(' = (*$atmp)[$i];')
+			}
 		}
 	} else if it.kind == .map {
 		// `for key, val in map {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -4175,7 +4175,13 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 				g.expr(node.index)
 				g.write(')')
 			} else {
-				g.expr(node.left)
+				if sym.kind == .array_fixed && node.left_type.is_ptr() {
+					g.write('(*')
+					g.expr(node.left)
+					g.write(')')
+				} else {
+					g.expr(node.left)
+				}
 				g.write('[')
 				g.expr(node.index)
 				g.write(']')

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -241,7 +241,6 @@ fn (mut g Gen) fn_args(args []table.Param, is_variadic bool) ([]string, []string
 				g.definitions.write(')')
 			}
 		} else {
-			// TODO: combine two operations into one once ternary in expression is fixed
 			s := '$arg_type_name $caname'
 			g.write(s)
 			g.definitions.write(s)

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -242,12 +242,7 @@ fn (mut g Gen) fn_args(args []table.Param, is_variadic bool) ([]string, []string
 			}
 		} else {
 			// TODO: combine two operations into one once ternary in expression is fixed
-			mut s := if arg_type_sym.kind == .array_fixed {
-				arg_type_name.trim('*')
-			} else {
-				arg_type_name
-			}
-			s += ' ' + caname
+			s := '$arg_type_name $caname'
 			g.write(s)
 			g.definitions.write(s)
 			fargs << caname

--- a/vlib/v/tests/fixed_array_test.v
+++ b/vlib/v/tests/fixed_array_test.v
@@ -52,12 +52,12 @@ fn test_fixed_array_can_be_assigned_to_a_struct_field() {
 
 fn multiply_by_two(mut arr [3]int) {
 	for i in 0..arr.len {
-		(*arr)[i] *= 2
+		arr[i] *= 2
 	}
 }
 
 fn change_first_element(mut arr [3][3]int) {
-	(*arr)[0][0] = 0
+	arr[0][0] = 0
 }
 
 fn test_fixed_array_can_be_passed_as_mut_arg() {

--- a/vlib/v/tests/fixed_array_test.v
+++ b/vlib/v/tests/fixed_array_test.v
@@ -52,12 +52,12 @@ fn test_fixed_array_can_be_assigned_to_a_struct_field() {
 
 fn multiply_by_two(mut arr [3]int) {
 	for i in 0..arr.len {
-		arr[i] *= 2
+		(*arr)[i] *= 2
 	}
 }
 
 fn change_first_element(mut arr [3][3]int) {
-	arr[0][0] = 0
+	(*arr)[0][0] = 0
 }
 
 fn test_fixed_array_can_be_passed_as_mut_arg() {

--- a/vlib/v/tests/for_in_mut_val_test.v
+++ b/vlib/v/tests/for_in_mut_val_test.v
@@ -1,12 +1,25 @@
-fn foo(mut arr []int) {
+fn foo1(mut arr []int) {
 	for _, mut j in arr {
 		j *= 2
 	}
 }
 
-fn test_for_in_mut_val() {
+fn test_for_in_mut_val_of_array() {
 	mut arr := [1, 2, 3]
-	foo(mut arr)
+	foo1(mut arr)
 	println(arr)
 	assert arr == [2, 4, 6]
+}
+
+fn foo2(mut arr [3]int) {
+	for _, mut j in arr {
+		j *= 2
+	}
+}
+
+fn test_for_in_mut_val_of_fixed_array() {
+	mut arr := [1,2,3]!
+	foo2(mut arr)
+	println(arr)
+	assert arr == [2, 4, 6]!
 }


### PR DESCRIPTION
This PR fix `for _,mut j in arr` of fixed arrays (fix #8163).

- Fix `for _,mut j in arr` of fixed arrays.
- Add test.

```vlang
module main

fn foo(mut arr [3]int) {
	for _, mut j in arr {
		j *= 2
	}
}

fn main() {
	mut arr := [1,2,3]!
	foo(mut arr)
	println(arr)
}

PS D:\Test\v\tt1> v run .
[2, 4, 6]
```