### PR TITLE
fix slice pointer array ommit high value

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3932,7 +3932,14 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 				g.write('_ARR_LEN(')
 				g.expr(node.left)
 				g.write(')')
-			} else {
+			} else if node.left_type.is_ptr() {
+				g.write('(')
+				g.write('*')
+				g.expr(node.left)
+				g.write(')')
+				g.write('.len')
+			}
+			else {
 				g.expr(node.left)
 				g.write('.len')
 			}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3938,8 +3938,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 				g.expr(node.left)
 				g.write(')')
 				g.write('.len')
-			}
-			else {
+			} else {
 				g.expr(node.left)
 				g.write('.len')
 			}

--- a/vlib/v/tests/array_slice_test.v
+++ b/vlib/v/tests/array_slice_test.v
@@ -37,3 +37,14 @@ fn test_fixed_array_slice() {
 	arr2 := fixed_array2[0..]
 	assert arr2 == [[1, 2], [2, 3], [3, 4],[4, 5]]
 }
+
+fn pointer_array_slice(mut a []int) {
+	assert a[0..] == [1,2,3]
+	assert a[..a.len] == [1,2,3]
+
+}
+
+fn test_pointer_array_slice() {
+	mut arr := [1,2,3]
+	pointer_array_slice(mut arr)
+}


### PR DESCRIPTION
```
fn pointer_array_slice(mut a []int) {
	assert a[0..] == [1,2,3]
	assert a[..a.len] == [1,2,3]

}

fn test_pointer_array_slice() {
	mut arr := [1,2,3]
	pointer_array_slice(mut arr)
}
```
make this work