### PR TITLE
cgen: fix map_fixed_arrays str error (fix #8170)

### DIFF
--- a/vlib/v/gen/auto_str_methods.v
+++ b/vlib/v/gen/auto_str_methods.v
@@ -344,19 +344,16 @@ fn (mut g Gen) gen_str_for_map(info table.Map, styp string, str_fn_name string) 
 	g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _SLIT(": "));')
 	if val_sym.kind == .function {
 		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, ${elem_str_fn_name}());')
+	} else if val_sym.kind == .string {
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("\'%.*s\\000\'", 2, *($val_styp*)DenseArray_value(&m.key_values, i)));')
+	} else if val_sym.kind == .struct_ && !val_sym.has_method('str') {
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, indent_${elem_str_fn_name}(*($val_styp*)DenseArray_value(&m.key_values, i), indent_count));')
+	} else if val_sym.kind in [.f32, .f64] {
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("%g", 1, *($val_styp*)DenseArray_value(&m.key_values, i)));')
+	} else if val_sym.kind == .rune {
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("`%.*s\\000`", 2, ${elem_str_fn_name}(*($val_styp*)DenseArray_value(&m.key_values, i))));')
 	} else {
-		g.auto_str_funcs.writeln('\t\t$val_styp it = *($val_styp*)DenseArray_value(&m.key_values, i);')
-		if val_sym.kind == .string {
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("\'%.*s\\000\'", 2, it));')
-		} else if val_sym.kind == .struct_ && !val_sym.has_method('str') {
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, indent_${elem_str_fn_name}(it, indent_count));')
-		} else if val_sym.kind in [.f32, .f64] {
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("%g", 1, it));')
-		} else if val_sym.kind == .rune {
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, _STR("`%.*s\\000`", 2, ${elem_str_fn_name}(it)));')
-		} else {
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, ${elem_str_fn_name}(it));')
-		}
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write(&sb, ${elem_str_fn_name}(*($val_styp*)DenseArray_value(&m.key_values, i)));')
 	}
 	g.auto_str_funcs.writeln('\t\tif (i != m.key_values.len-1) {')
 	g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write(&sb, _SLIT(", "));')

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -4110,7 +4110,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 						g.is_array_set = true
 						g.write('map_set_1(')
 					} else {
-						g.write('*(($elem_type_str*)map_get_and_set_1(')
+						g.write('(*(($elem_type_str*)map_get_and_set_1(')
 					}
 					if !left_is_ptr || node.left_type.has_flag(.shared_f) {
 						g.write('&')
@@ -4133,7 +4133,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 					}
 					if g.assign_op != .assign && info.value_type != table.string_type {
 						zero := g.type_default(info.value_type)
-						g.write('$zero }))')
+						g.write('$zero })))')
 					}
 				} else if (g.inside_map_postfix || g.inside_map_infix) ||
 					(g.is_assign_lhs && !g.is_array_set && get_and_set_types)

--- a/vlib/v/tests/for_in_mut_val_test.v
+++ b/vlib/v/tests/for_in_mut_val_test.v
@@ -23,3 +23,29 @@ fn test_for_in_mut_val_of_fixed_array() {
 	println(arr)
 	assert arr == [2, 4, 6]!
 }
+
+fn foo3(mut m map[string][3]int){
+	for i in 0..m['hello'].len {
+		m['hello'][i] *= 2
+	}
+}
+
+fn test_fn_mut_val_of_map() {
+	mut m := {'hello': [1,2,3]!}
+	foo3(mut m)
+	println(m)
+	assert '$m' == "{'hello': [2, 4, 6]}"
+}
+
+fn foo4(mut m map[string][3]int){
+	for _, mut j in m['hello'] {
+		j *= 2
+	}
+}
+
+fn test_for_in_mut_val_of_map() {
+	mut m := {'hello':[1,2,3]!}
+	foo4(mut m)
+	println(m)
+	assert '$m' == "{'hello': [2, 4, 6]}"
+}

--- a/vlib/v/tests/map_to_string_test.v
+++ b/vlib/v/tests/map_to_string_test.v
@@ -36,4 +36,7 @@ fn test_interpolation_map_to_string() {
 	assert s.contains("y: 'abc'")
 	assert s.contains("}, '2': Test{")
 	assert s.contains("y: 'def'")
+
+	f := {'hello': [1,2,3]!}
+	assert '$f' == "{'hello': [1, 2, 3]}"
 }


### PR DESCRIPTION
This PR fix error of map_fixed_arrays str (fix #8170).

- Fix error of map_fixed_arrays str.
- Add test in map_to_string_test.v.
- Add tests in for_in_mut_val_test.v.

```v
module main

fn main() {
	m := {'hello': [1,2,3]!}
	println(m)
	assert '$m' == "{'hello': [1, 2, 3]}"
}

PS D:\Test\v\tt1> v run .
{'hello': [1, 2, 3]}
```

```vlang
fn foo(mut m map[string][3]int){
	for i in 0..m['hello'].len {
		m['hello'][i] *= 2
	}
}

fn main() {
	mut m := {'hello':[1,2,3]!}
	foo(mut m)
	println(m)
}

PS D:\Test\v\tt1> v run .
{'hello': [2, 4, 6]}
```
```vlang
fn foo(mut m map[string][3]int){
	for _, mut j in m['hello'] {
		j *= 2
	}
}

fn main() {
	mut m := {'hello':[1,2,3]!}
	foo(mut m)
	println(m)
}

PS D:\Test\v\tt1> v run .
{'hello': [2, 4, 6]}
```