### PR TITLE
Update mini_calculator.v

### DIFF
--- a/examples/mini_calculator.v
+++ b/examples/mini_calculator.v
@@ -23,7 +23,7 @@ fn expr_to_rev_pol(expr string) ?[]string {
 			stack << expr[pos..end_pos]
 			pos = end_pos
 		} else if end_pos == pos {
-			op := expr[pos].str()
+			op := expr[pos].ascii_str()
 			match op {
 				'(' {
 					stack << op


### PR DESCRIPTION
fix bug.


`Please enter the expression you want to calculate, e.g. 1e2+(3-2.5)*6/1.5 .
Enter 'exit' or 'EXIT' to quit.
[1] 1+2
err: invalid character `43``