### PR TITLE
parser: add a warning for only else branch in match

### DIFF
--- a/vlib/v/checker/tests/return_missing_match_simple.out
+++ b/vlib/v/checker/tests/return_missing_match_simple.out
@@ -1,4 +1,4 @@
- vlib/v/checker/tests/return_missing_match_simple.vv:4:3: error: `match` must have at least one non `else` branch
+vlib/v/checker/tests/return_missing_match_simple.vv:4:3: error: `match` must have at least one non `else` branch
     2 |     a := 1
     3 |     match a {
     4 |         else { println('abc') }

--- a/vlib/v/checker/tests/return_missing_match_simple.out
+++ b/vlib/v/checker/tests/return_missing_match_simple.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/return_missing_match_simple.vv:4:3: error: `match` must have at least one non `else` branch
+vlib/v/checker/tests/return_missing_match_simple.vv:4:3: warning: `match` must have at least one non `else` branch
     2 |     a := 1
     3 |     match a {
     4 |         else { println('abc') }

--- a/vlib/v/checker/tests/return_missing_match_simple.out
+++ b/vlib/v/checker/tests/return_missing_match_simple.out
@@ -1,3 +1,10 @@
+ vlib/v/checker/tests/return_missing_match_simple.vv:4:3: error: `match` must have at least one non `else` branch
+    2 |     a := 1
+    3 |     match a {
+    4 |         else { println('abc') }
+      |         ~~~~
+    5 |     }
+    6 |     println('hello')
 vlib/v/checker/tests/return_missing_match_simple.vv:1:1: error: missing return at end of function `h`
     1 | fn h() int {
       | ~~~~~~~~~~

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -247,6 +247,9 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 			post_comments: post_comments
 			scope: branch_scope
 		}
+		if is_else && branches.len == 1 {
+			p.warn_with_pos('`match` must have at least one non `else` branch', pos)
+		}
 		if p.tok.kind == .rcbr || (is_else && no_lcbr) {
 			break
 		}


### PR DESCRIPTION
A warning for:

```
warning: `match` must have at least one non `else` branch
    2 | 
    3 | match x {
    4 |     else {
      |     ~~~~
    5 |         println('hi')
    6 |     }
```