### PR TITLE
all: support generic `chan`

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1523,6 +1523,13 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 					idx := c.table.find_or_register_array(call_expr.generic_type)
 					return table.new_type(idx)
 				}
+			} else if return_sym.kind == .chan {
+				elem_info := return_sym.info as table.Chan
+				elem_sym := c.table.get_type_symbol(elem_info.elem_type)
+				if elem_sym.name == 'T' {
+					idx := c.table.find_or_register_chan(elem_info.elem_type, elem_info.elem_type.nr_muls() > 0)
+					return table.new_type(idx)
+				}
 			}
 		}
 		if call_expr.generic_type.is_full() && !method.is_generic {
@@ -1859,6 +1866,11 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 				}
 			}
 			idx := c.table.find_or_register_array_with_dims(call_expr.generic_type, dims)
+			typ := table.new_type(idx)
+			call_expr.return_type = typ
+			return typ
+		} else if return_sym.kind == .chan && return_sym.name.contains('T') {
+			idx := c.table.find_or_register_chan(call_expr.generic_type, call_expr.generic_type.nr_muls() > 0)
 			typ := table.new_type(idx)
 			call_expr.return_type = typ
 			return typ

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1527,7 +1527,8 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 				elem_info := return_sym.info as table.Chan
 				elem_sym := c.table.get_type_symbol(elem_info.elem_type)
 				if elem_sym.name == 'T' {
-					idx := c.table.find_or_register_chan(elem_info.elem_type, elem_info.elem_type.nr_muls() > 0)
+					idx := c.table.find_or_register_chan(elem_info.elem_type, elem_info.elem_type.nr_muls() >
+						0)
 					return table.new_type(idx)
 				}
 			}
@@ -1870,7 +1871,8 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 			call_expr.return_type = typ
 			return typ
 		} else if return_sym.kind == .chan && return_sym.name.contains('T') {
-			idx := c.table.find_or_register_chan(call_expr.generic_type, call_expr.generic_type.nr_muls() > 0)
+			idx := c.table.find_or_register_chan(call_expr.generic_type, call_expr.generic_type.nr_muls() >
+				0)
 			typ := table.new_type(idx)
 			call_expr.return_type = typ
 			return typ

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -715,7 +715,7 @@ pub fn (mut g Gen) write_fn_typesymbol_declaration(sym table.TypeSymbol) {
 	func := info.func
 	is_fn_sig := func.name == ''
 	not_anon := !info.is_anon
-	if !info.has_decl && (not_anon || is_fn_sig) {
+	if !info.has_decl && (not_anon || is_fn_sig) && !func.return_type.has_flag(.generic) {
 		fn_name := sym.cname
 		g.type_definitions.write('typedef ${g.typ(func.return_type)} (*$fn_name)(')
 		for i, param in func.params {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -681,17 +681,20 @@ typedef struct {
 				if typ.name != 'chan' {
 					g.type_definitions.writeln('typedef chan $typ.cname;')
 					chan_inf := typ.chan_info()
-					el_stype := g.typ(chan_inf.elem_type)
-					g.channel_definitions.writeln('
+					chan_elem_type := chan_inf.elem_type
+					if !chan_elem_type.has_flag(.generic) {
+						el_stype := g.typ(chan_elem_type)
+						g.channel_definitions.writeln('
 static inline $el_stype __${typ.cname}_popval($typ.cname ch) {
 	$el_stype val;
 	sync__Channel_try_pop_priv(ch, &val, false);
 	return val;
 }')
-					g.channel_definitions.writeln('
+						g.channel_definitions.writeln('
 static inline void __${typ.cname}_pushval($typ.cname ch, $el_stype val) {
 	sync__Channel_try_push_priv(ch, &val, false);
 }')
+					}
 				}
 			}
 			.map {

--- a/vlib/v/tests/generic_chan_test.v
+++ b/vlib/v/tests/generic_chan_test.v
@@ -1,0 +1,22 @@
+fn mk_chan<T>(f fn () T) chan T {
+	gench := chan T{cap: 1}
+	// // This does not work, yet
+	// go fn(ch2 chan T, f2 fn() T) {
+	//     res := f2()
+	//     ch2 <- res
+	// }(gench, f)
+	return gench
+}
+
+fn g(x f64, y f64) f64 {
+	return x * x + y * y
+}
+
+fn test_generic_chan_return() {
+	ch := mk_chan<f64>(fn () f64 {
+		return g(3, 4)
+	})
+	ch <- 13.4
+	res := <-ch
+	assert res == 13.4
+}


### PR DESCRIPTION
This partly fixes #8173

- generic channels (`chan T`) work
- passing a function to a generic function expecting a function literal that contains the generic type works (when the types match) - as in this example
```v
fn genf<T>(fn() T) {...}
...
genf<f64>(fn() f64 {...})
```

The first example in #8173, however, does not work, yet (but at least the V compiler doesn't crash anymore). There is still a problem when creating a function object inside a generic function when this function object contains the generic type. But that's a case that deserves it's on PR to fix...
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
