### PR TITLE
fmt: keep single empty lines

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1210,6 +1210,7 @@ pub fn (expr Expr) position() token.Position {
 				line_nr: expr.pos.line_nr
 				pos: left_pos.pos
 				len: right_pos.pos - left_pos.pos + right_pos.len
+				last_line: right_pos.last_line
 			}
 		}
 		CTempVar {

--- a/vlib/v/checker/tests/prefix_expr_decl_assign_err.out
+++ b/vlib/v/checker/tests/prefix_expr_decl_assign_err.out
@@ -4,9 +4,9 @@ vlib/v/checker/tests/prefix_expr_decl_assign_err.vv:2:5: error: non-name on the 
       |     ^
     3 |     (*d) := 14
     4 | }
-vlib/v/checker/tests/prefix_expr_decl_assign_err.vv:3:10: error: non-name `(*d)` on left side of `:=`
+vlib/v/checker/tests/prefix_expr_decl_assign_err.vv:3:5: error: non-name `(*d)` on left side of `:=`
     1 | fn main() {
     2 |     &a := 12
     3 |     (*d) := 14
-      |          ~~
+      |     ~~~~
     4 | }

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -339,20 +339,16 @@ pub fn (f Fmt) imp_stmt_str(imp ast.Import) string {
 
 pub fn (mut f Fmt) stmts(stmts []ast.Stmt) {
 	f.indent++
-
 	mut prev_line_nr := 0
 	if stmts.len >= 1 {
 		prev_pos := stmts[0].position()
 		prev_line_nr = util.imax(prev_pos.line_nr, prev_pos.last_line)
 	}
-
 	for stmt in stmts {
 		if stmt.position().line_nr - prev_line_nr > 1 {
 			f.out.writeln('')
 		}
-
 		f.stmt(stmt)
-
 		prev_pos := stmt.position()
 		prev_line_nr = util.imax(prev_pos.line_nr, prev_pos.last_line)
 	}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -339,8 +339,28 @@ pub fn (f Fmt) imp_stmt_str(imp ast.Import) string {
 
 pub fn (mut f Fmt) stmts(stmts []ast.Stmt) {
 	f.indent++
+
+	mut prev_line_nr := 0
+	if stmts.len >= 1 {
+		prev_pos := stmts[0].position()
+		prev_line_nr = util.imax(prev_pos.line_nr, prev_pos.last_line)
+	}
+
 	for stmt in stmts {
+		if f.is_debug {
+			println('${stmt} -> prev_line_nr: ${prev_line_nr}; current_line_nr: ${stmt.position().line_nr}')
+		}
+		if stmt.position().line_nr - prev_line_nr > 1 {
+			if f.is_debug {
+				println("--> EMPTY LINE <---")
+			}
+			f.out.writeln('')
+		}
+
 		f.stmt(stmt)
+
+		prev_pos := stmt.position()
+		prev_line_nr = util.imax(prev_pos.line_nr, prev_pos.last_line)
 	}
 	f.indent--
 }

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -348,13 +348,7 @@ pub fn (mut f Fmt) stmts(stmts []ast.Stmt) {
 
 	for stmt in stmts {
 		if stmt.position().line_nr - prev_line_nr > 1 {
-			if f.is_debug {
-				println('--> EMPTY LINE <---')
-			}
 			f.out.writeln('')
-		}
-		if f.is_debug {
-			println('$stmt -> prev_line_nr: $prev_line_nr; current_line_nr: $stmt.position().line_nr')
 		}
 
 		f.stmt(stmt)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -347,14 +347,14 @@ pub fn (mut f Fmt) stmts(stmts []ast.Stmt) {
 	}
 
 	for stmt in stmts {
-		if f.is_debug {
-			println('${stmt} -> prev_line_nr: ${prev_line_nr}; current_line_nr: ${stmt.position().line_nr}')
-		}
 		if stmt.position().line_nr - prev_line_nr > 1 {
 			if f.is_debug {
-				println("--> EMPTY LINE <---")
+				println('--> EMPTY LINE <---')
 			}
 			f.out.writeln('')
+		}
+		if f.is_debug {
+			println('$stmt -> prev_line_nr: $prev_line_nr; current_line_nr: $stmt.position().line_nr')
 		}
 
 		f.stmt(stmt)

--- a/vlib/v/fmt/tests/empty_lines_expected.vv
+++ b/vlib/v/fmt/tests/empty_lines_expected.vv
@@ -1,0 +1,52 @@
+fn keep_single_empty_line() {
+	println('a')
+	println('b')
+
+	println('c')
+
+	d := 0
+
+	e := 0
+}
+
+fn squash_multiple_empty_lines() {
+	println('a')
+
+	println('b')
+
+	c := 0
+
+	d := 0
+}
+
+fn remove_leading_and_trailing_empty_lines() {
+	println('a')
+
+	println('b')
+
+	if test {
+		c := 0
+	} else {
+		d := 0
+	}
+}
+
+fn no_empty_line_after_multi_line_statements() {
+	// line1
+	/*
+	block1
+	*/
+	/*
+	block2
+	*/
+	if test {
+		println('a')
+	}
+	println('b')
+	for test {
+		println('c')
+	}
+	c := fn (s string) {
+		println('s')
+	}
+}

--- a/vlib/v/fmt/tests/empty_lines_expected.vv
+++ b/vlib/v/fmt/tests/empty_lines_expected.vv
@@ -6,7 +6,11 @@ fn keep_single_empty_line() {
 
 	d := 0
 
-	e := 0
+	if true {
+		println('e')
+	}
+
+	f := 0
 }
 
 fn squash_multiple_empty_lines() {

--- a/vlib/v/fmt/tests/empty_lines_expected.vv
+++ b/vlib/v/fmt/tests/empty_lines_expected.vv
@@ -1,18 +1,3 @@
-fn keep_single_empty_line() {
-	println('a')
-	println('b')
-
-	println('c')
-
-	d := 0
-
-	if true {
-		println('e')
-	}
-
-	f := 0
-}
-
 fn squash_multiple_empty_lines() {
 	println('a')
 
@@ -32,25 +17,5 @@ fn remove_leading_and_trailing_empty_lines() {
 		c := 0
 	} else {
 		d := 0
-	}
-}
-
-fn no_empty_line_after_multi_line_statements() {
-	// line1
-	/*
-	block1
-	*/
-	/*
-	block2
-	*/
-	if test {
-		println('a')
-	}
-	println('b')
-	for test {
-		println('c')
-	}
-	c := fn (s string) {
-		println('s')
 	}
 }

--- a/vlib/v/fmt/tests/empty_lines_input.vv
+++ b/vlib/v/fmt/tests/empty_lines_input.vv
@@ -6,7 +6,11 @@ fn keep_single_empty_line() {
 
 	d := 0
 
-	e := 0
+	if true {
+		println('e')
+	}
+
+	f := 0
 }
 
 fn squash_multiple_empty_lines() {

--- a/vlib/v/fmt/tests/empty_lines_input.vv
+++ b/vlib/v/fmt/tests/empty_lines_input.vv
@@ -1,18 +1,3 @@
-fn keep_single_empty_line() {
-	println('a')
-	println('b')
-
-	println('c')
-
-	d := 0
-
-	if true {
-		println('e')
-	}
-
-	f := 0
-}
-
 fn squash_multiple_empty_lines() {
 	println('a')
 
@@ -42,23 +27,4 @@ fn remove_leading_and_trailing_empty_lines() {
 
 	}
 
-}
-
-fn no_empty_line_after_multi_line_statements() {
-	// line1
-	/* block1 
-	*/
-	/*
-	block2
-	*/
-	if test {
-		println('a')
-	}
-	println('b')
-	for test {
-		println('c')
-	}
-	c := fn(s string) {
-		println('s')
-	}
 }

--- a/vlib/v/fmt/tests/empty_lines_input.vv
+++ b/vlib/v/fmt/tests/empty_lines_input.vv
@@ -1,0 +1,60 @@
+fn keep_single_empty_line() {
+	println('a')
+	println('b')
+
+	println('c')
+
+	d := 0
+
+	e := 0
+}
+
+fn squash_multiple_empty_lines() {
+	println('a')
+
+
+	println('b')
+
+
+	c := 0
+
+
+	d := 0
+}
+
+fn remove_leading_and_trailing_empty_lines() {
+
+	println('a')
+
+	println('b')
+
+	if test {
+
+		c := 0
+
+	} else {
+
+		d := 0
+
+	}
+
+}
+
+fn no_empty_line_after_multi_line_statements() {
+	// line1
+	/* block1 
+	*/
+	/*
+	block2
+	*/
+	if test {
+		println('a')
+	}
+	println('b')
+	for test {
+		println('c')
+	}
+	c := fn(s string) {
+		println('s')
+	}
+}

--- a/vlib/v/fmt/tests/empty_lines_keep.vv
+++ b/vlib/v/fmt/tests/empty_lines_keep.vv
@@ -1,0 +1,34 @@
+fn keep_single_empty_line() {
+	println('a')
+	println('b')
+
+	println('c')
+
+	d := 0
+
+	if true {
+		println('e')
+	}
+
+	f := 0
+}
+
+fn prevent_empty_line_after_multi_line_statements() {
+	// line1
+	/*
+	block1
+	*/
+	/*
+	block2
+	*/
+	if test {
+		println('a')
+	}
+	println('b')
+	for test {
+		println('c')
+	}
+	c := fn (s string) {
+		println('s')
+	}
+}

--- a/vlib/v/fmt/tests/expressions_expected.vv
+++ b/vlib/v/fmt/tests/expressions_expected.vv
@@ -35,6 +35,7 @@ fn string_inter_lit(mut c checker.Checker, mut node ast.StringInterLiteral) tabl
 		}
 		node.need_fmts[i] = fmt != c.get_default_fmt(ftyp, typ)
 	}
+
 	return table.string_type
 }
 

--- a/vlib/v/fmt/tests/go_stmt_expected.vv
+++ b/vlib/v/fmt/tests/go_stmt_expected.vv
@@ -9,5 +9,6 @@ fn my_thread_with_params(s string) {
 fn my_fn_calling_threads() {
 	go my_thread()
 	go my_thread_with_params('yay')
+
 	go my_thread_with_params('nono')
 }

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -88,7 +88,7 @@ fn (mut p Parser) check_cross_variables(exprs []ast.Expr, val ast.Expr) bool {
 fn (mut p Parser) partial_assign_stmt(left []ast.Expr, left_comments []ast.Comment) ast.Stmt {
 	p.is_stmt_ident = false
 	op := p.tok.kind
-	pos := p.tok.position()
+	mut pos := p.tok.position()
 	p.next()
 	mut comments := []ast.Comment{cap: 2 * left_comments.len + 1}
 	comments << left_comments
@@ -195,6 +195,7 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr, left_comments []ast.Comme
 			}
 		}
 	}
+	pos.last_line = p.prev_tok.line_nr - 1
 	return ast.AssignStmt{
 		op: op
 		left: left

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -195,7 +195,7 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr, left_comments []ast.Comme
 			}
 		}
 	}
-	pos.last_line = p.prev_tok.line_nr - 1
+	pos.update_last_line(p.prev_tok.line_nr)
 	return ast.AssignStmt{
 		op: op
 		left: left

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -167,7 +167,7 @@ fn (mut p Parser) map_init() ast.MapInit {
 			p.next()
 		}
 	}
-	pos.last_line = p.prev_tok.line_nr
+	pos.update_last_line(p.tok.line_nr)
 	return ast.MapInit{
 		keys: keys
 		vals: vals

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -130,7 +130,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 		}
 		p.check(.rcbr)
 	}
-	pos := first_pos.extend(last_pos)
+	pos := first_pos.extend_with_last_line(last_pos, p.prev_tok.line_nr)
 	return ast.ArrayInit{
 		is_fixed: is_fixed
 		has_val: has_val
@@ -151,7 +151,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 }
 
 fn (mut p Parser) map_init() ast.MapInit {
-	pos := p.tok.position()
+	mut pos := p.tok.position()
 	mut keys := []ast.Expr{}
 	mut vals := []ast.Expr{}
 	for p.tok.kind != .rcbr && p.tok.kind != .eof {
@@ -167,6 +167,7 @@ fn (mut p Parser) map_init() ast.MapInit {
 			p.next()
 		}
 	}
+	pos.last_line = p.prev_tok.line_nr
 	return ast.MapInit{
 		keys: keys
 		vals: vals

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -57,7 +57,7 @@ pub fn (mut p Parser) call_expr(language table.Language, mod string) ast.CallExp
 	if p.tok.kind == .not {
 		p.next()
 	}
-	pos := first_pos.extend(last_pos)
+	mut pos := first_pos.extend(last_pos)
 	mut or_stmts := []ast.Stmt{} // TODO remove unnecessary allocations by just using .absent
 	mut or_pos := p.tok.position()
 	if p.tok.kind == .key_orelse {
@@ -93,6 +93,7 @@ pub fn (mut p Parser) call_expr(language table.Language, mod string) ast.CallExp
 		fn_name = p.imported_symbols[fn_name]
 	}
 	comments := p.eat_line_end_comments()
+	pos.update_last_line(p.prev_tok.line_nr)
 	return ast.CallExpr{
 		name: fn_name
 		args: args
@@ -487,7 +488,7 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 	idx := p.table.find_or_register_fn_type(p.mod, func, true, false)
 	typ := table.new_type(idx)
 	// name := p.table.get_type_name(typ)
-	pos.last_line = p.prev_tok.line_nr
+	pos.update_last_line(p.prev_tok.line_nr)
 	return ast.AnonFn{
 		decl: ast.FnDecl{
 			name: name

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -435,7 +435,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 }
 
 fn (mut p Parser) anon_fn() ast.AnonFn {
-	pos := p.tok.position()
+	mut pos := p.tok.position()
 	p.check(.key_fn)
 	if p.pref.is_script && p.tok.kind == .name {
 		p.error_with_pos('function declarations in script mode should be before all script statements',
@@ -487,6 +487,7 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 	idx := p.table.find_or_register_fn_type(p.mod, func, true, false)
 	typ := table.new_type(idx)
 	// name := p.table.get_type_name(typ)
+	pos.last_line = p.prev_tok.line_nr
 	return ast.AnonFn{
 		decl: ast.FnDecl{
 			name: name

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -20,7 +20,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 	if p.tok.kind == .lcbr {
 		p.inside_for = false
 		stmts := p.parse_block_no_scope(false)
-		pos.last_line = p.prev_tok.line_nr - 1
+		pos.update_last_line(p.prev_tok.line_nr)
 		for_stmt := ast.ForStmt{
 			stmts: stmts
 			pos: pos
@@ -64,7 +64,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		}
 		p.inside_for = false
 		stmts := p.parse_block_no_scope(false)
-		pos.last_line = p.prev_tok.line_nr - 1
+		pos.update_last_line(p.prev_tok.line_nr)
 		for_c_stmt := ast.ForCStmt{
 			stmts: stmts
 			has_init: has_init
@@ -159,7 +159,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		}
 		p.inside_for = false
 		stmts := p.parse_block_no_scope(false)
-		pos.last_line = p.prev_tok.line_nr - 1
+		pos.update_last_line(p.prev_tok.line_nr)
 		// println('nr stmts=$stmts.len')
 		for_in_stmt := ast.ForInStmt{
 			stmts: stmts
@@ -181,7 +181,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 	// extra scope for the body
 	p.open_scope()
 	stmts := p.parse_block_no_scope(false)
-	pos.last_line = p.prev_tok.line_nr - 1
+	pos.update_last_line(p.prev_tok.line_nr)
 	for_stmt := ast.ForStmt{
 		cond: cond
 		stmts: stmts

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -144,6 +144,9 @@ fn (mut p Parser) if_expr(is_comptime bool) ast.IfExpr {
 		}
 	}
 	pos.update_last_line(p.prev_tok.line_nr)
+	if comments.len > 0 {
+		pos.last_line = comments.last().pos.last_line
+	}
 	return ast.IfExpr{
 		is_comptime: is_comptime
 		branches: branches
@@ -236,8 +239,12 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 		branch_scope := p.scope
 		p.close_scope()
 		p.inside_match_body = false
-		pos := branch_first_pos.extend(branch_last_pos)
+		mut pos := branch_first_pos.extend(branch_last_pos)
 		post_comments := p.eat_comments()
+		pos.update_last_line(p.prev_tok.line_nr)
+		if post_comments.len > 0 {
+			pos.last_line = post_comments.last().pos.last_line
+		}
 		branches << ast.MatchBranch{
 			exprs: exprs
 			ecmnts: ecmnts
@@ -399,12 +406,16 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 		stmts := p.parse_block_no_scope(false)
 		p.close_scope()
 		p.inside_match_body = false
-		pos := token.Position{
+		mut pos := token.Position{
 			line_nr: branch_first_pos.line_nr
 			pos: branch_first_pos.pos
 			len: branch_last_pos.pos - branch_first_pos.pos + branch_last_pos.len
 		}
 		post_comments := p.eat_comments()
+		pos.update_last_line(p.prev_tok.line_nr)
+		if post_comments.len > 0 {
+			pos.last_line = post_comments.last().pos.last_line
+		}
 		branches << ast.SelectBranch{
 			stmt: stmt
 			stmts: stmts

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -15,7 +15,7 @@ fn (mut p Parser) if_expr(is_comptime bool) ast.IfExpr {
 		p.inside_ct_if_expr = was_inside_ct_if_expr
 	}
 	p.inside_if_expr = true
-	pos := if is_comptime {
+	mut pos := if is_comptime {
 		p.inside_ct_if_expr = true
 		p.next() // `$`
 		p.prev_tok.position().extend(p.tok.position())
@@ -143,6 +143,7 @@ fn (mut p Parser) if_expr(is_comptime bool) ast.IfExpr {
 			break
 		}
 	}
+	pos.last_line = p.prev_tok.line_nr
 	return ast.IfExpr{
 		is_comptime: is_comptime
 		branches: branches
@@ -255,7 +256,7 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 		}
 	}
 	match_last_pos := p.tok.position()
-	pos := token.Position{
+	mut pos := token.Position{
 		line_nr: match_first_pos.line_nr
 		pos: match_first_pos.pos
 		len: match_last_pos.pos - match_first_pos.pos + match_last_pos.len
@@ -264,6 +265,7 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 		p.check(.rcbr)
 	}
 	// return ast.StructInit{}
+	pos.last_line = p.prev_tok.line_nr
 	return ast.MatchExpr{
 		branches: branches
 		cond: cond
@@ -427,7 +429,7 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 	}
 	return ast.SelectExpr{
 		branches: branches
-		pos: pos
+		pos: pos.extend_with_last_line(p.prev_tok.position(), p.prev_tok.line_nr)
 		has_exception: has_else || has_timeout
 	}
 }

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -143,7 +143,7 @@ fn (mut p Parser) if_expr(is_comptime bool) ast.IfExpr {
 			break
 		}
 	}
-	pos.last_line = p.prev_tok.line_nr
+	pos.update_last_line(p.prev_tok.line_nr)
 	return ast.IfExpr{
 		is_comptime: is_comptime
 		branches: branches
@@ -265,7 +265,7 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 		p.check(.rcbr)
 	}
 	// return ast.StructInit{}
-	pos.last_line = p.prev_tok.line_nr
+	pos.update_last_line(p.prev_tok.line_nr)
 	return ast.MatchExpr{
 		branches: branches
 		cond: cond

--- a/vlib/v/parser/lock.v
+++ b/vlib/v/parser/lock.v
@@ -6,7 +6,7 @@ import v.table
 fn (mut p Parser) lock_expr() ast.LockExpr {
 	// TODO Handle aliasing sync
 	p.register_auto_import('sync')
-	pos := p.tok.position()
+	mut pos := p.tok.position()
 	is_rlock := p.tok.kind == .key_rlock
 	p.next()
 	mut lockeds := []ast.Ident{}
@@ -27,6 +27,7 @@ fn (mut p Parser) lock_expr() ast.LockExpr {
 		p.check(.comma)
 	}
 	stmts := p.parse_block()
+	pos.last_line = p.prev_tok.line_nr
 	return ast.LockExpr{
 		lockeds: lockeds
 		stmts: stmts

--- a/vlib/v/parser/lock.v
+++ b/vlib/v/parser/lock.v
@@ -27,7 +27,7 @@ fn (mut p Parser) lock_expr() ast.LockExpr {
 		p.check(.comma)
 	}
 	stmts := p.parse_block()
-	pos.last_line = p.prev_tok.line_nr
+	pos.update_last_line(p.prev_tok.line_nr)
 	return ast.LockExpr{
 		lockeds: lockeds
 		stmts: stmts

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -569,8 +569,9 @@ pub fn (mut p Parser) check_comment() ast.Comment {
 }
 
 pub fn (mut p Parser) comment() ast.Comment {
-	pos := p.tok.position()
+	mut pos := p.tok.position()
 	text := p.tok.lit
+	pos.last_line = pos.line_nr + text.count('\n')
 	p.next()
 	// p.next_with_comment()
 	return ast.Comment{
@@ -692,16 +693,20 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 		.dollar {
 			match p.peek_tok.kind {
 				.key_if {
+					pos := p.tok.position()
 					return ast.ExprStmt{
 						expr: p.if_expr(true)
+						pos: pos.extend(p.prev_tok.position())
 					}
 				}
 				.key_for {
 					return p.comp_for()
 				}
 				.name {
+					pos := p.tok.position()
 					return ast.ExprStmt{
 						expr: p.comp_call()
+						pos: pos.extend(p.prev_tok.position())
 					}
 				}
 				else {
@@ -2456,6 +2461,7 @@ fn (mut p Parser) unsafe_stmt() ast.Stmt {
 		stmts << p.stmt(false)
 	}
 	p.next()
+	pos.last_line = p.tok.line_nr - 1
 	return ast.Block{
 		stmts: stmts
 		is_unsafe: true

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -95,12 +95,13 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			node = p.parse_number_literal()
 		}
 		.lpar {
+			mut pos := p.tok.position()
 			p.check(.lpar)
 			node = p.expr(0)
 			p.check(.rpar)
 			node = ast.ParExpr{
 				expr: node
-				pos: p.tok.position()
+				pos: pos.extend(p.prev_tok.position())
 			}
 		}
 		.key_if {
@@ -118,7 +119,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			p.check(.lcbr)
 			e := p.expr(0)
 			p.check(.rcbr)
-			pos.last_line = p.prev_tok.line_nr - 1
+			pos.update_last_line(p.prev_tok.line_nr)
 			node = ast.UnsafeExpr{
 				expr: e
 				pos: pos
@@ -315,9 +316,10 @@ pub fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_iden
 		} else if p.tok.kind == .left_shift && p.is_stmt_ident {
 			// arr << elem
 			tok := p.tok
-			pos := tok.position()
+			mut pos := tok.position()
 			p.next()
 			right := p.expr(precedence - 1)
+			pos.update_last_line(p.prev_tok.line_nr)
 			node = ast.InfixExpr{
 				left: node
 				right: right
@@ -370,7 +372,13 @@ fn (mut p Parser) infix_expr(left ast.Expr) ast.Expr {
 	// mut typ := p.
 	// println('infix op=$op.str()')
 	precedence := p.tok.precedence()
-	pos := p.tok.position()
+	mut pos := p.tok.position()
+	if left.position().line_nr < pos.line_nr {
+		pos = {
+			pos |
+			line_nr: left.position().line_nr
+		}
+	}
 	p.next()
 	mut right := ast.Expr{}
 	prev_expecting_type := p.expecting_type
@@ -415,6 +423,7 @@ fn (mut p Parser) infix_expr(left ast.Expr) ast.Expr {
 		}
 		p.or_is_handled = false
 	}
+	pos.update_last_line(p.prev_tok.line_nr)
 	return ast.InfixExpr{
 		left: left
 		right: right
@@ -429,7 +438,7 @@ fn (mut p Parser) infix_expr(left ast.Expr) ast.Expr {
 }
 
 fn (mut p Parser) prefix_expr() ast.PrefixExpr {
-	pos := p.tok.position()
+	mut pos := p.tok.position()
 	op := p.tok.kind
 	if op == .amp {
 		p.is_amp = true
@@ -482,6 +491,7 @@ fn (mut p Parser) prefix_expr() ast.PrefixExpr {
 		}
 		p.or_is_handled = false
 	}
+	pos.update_last_line(p.prev_tok.line_nr)
 	return ast.PrefixExpr{
 		op: op
 		right: right

--- a/vlib/v/parser/sql.v
+++ b/vlib/v/parser/sql.v
@@ -107,7 +107,7 @@ fn (mut p Parser) sql_expr() ast.Expr {
 // insert user into User
 // update User set nr_oders=nr_orders+1 where id == user_id
 fn (mut p Parser) sql_stmt() ast.SqlStmt {
-	pos := p.tok.position()
+	mut pos := p.tok.position()
 	p.inside_match = true
 	defer {
 		p.inside_match = false
@@ -194,6 +194,7 @@ fn (mut p Parser) sql_stmt() ast.SqlStmt {
 		where_expr = p.expr(0)
 	}
 	p.check(.rcbr)
+	pos.last_line = p.prev_tok.line_nr
 	return ast.SqlStmt{
 		db_expr: db_expr
 		table_name: table_name

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -429,7 +429,7 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 
 fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 	p.top_level_statement_start()
-	mut start_pos := p.tok.position()
+	mut pos := p.tok.position()
 	is_pub := p.tok.kind == .key_pub
 	if is_pub {
 		p.next()
@@ -506,12 +506,12 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 	}
 	p.top_level_statement_end()
 	p.check(.rcbr)
-	start_pos.last_line = p.prev_tok.line_nr - 1
+	pos.update_last_line(p.prev_tok.line_nr)
 	return ast.InterfaceDecl{
 		name: interface_name
 		methods: methods
 		is_pub: is_pub
-		pos: start_pos
+		pos: pos
 		pre_comments: pre_comments
 	}
 }

--- a/vlib/v/parser/tests/or_default_missing.out
+++ b/vlib/v/parser/tests/or_default_missing.out
@@ -1,0 +1,14 @@
+vlib/v/parser/tests/or_default_missing.vv:4:3: error: `or` block must provide a default value of type `int`, or return/exit/continue/break/panic
+    2 |     m := [3, 4, 5]
+    3 |     el := m[4] or {
+    4 |         println('error')
+      |         ~~~~~~~~~~~~~~~~
+    5 |     }
+    6 |     println(el)
+vlib/v/parser/tests/or_default_missing.vv:16:16: error: last statement in the `or {}` block should be an expression of type `int` or exit parent scope
+   14 |     }
+   15 |     mut testvar := 0
+   16 |     el := m['pp'] or {
+      |                   ~~~~
+   17 |         testvar = 12
+   18 |     }

--- a/vlib/v/parser/tests/or_default_missing.vv
+++ b/vlib/v/parser/tests/or_default_missing.vv
@@ -1,0 +1,20 @@
+fn test_array_or() {
+	m := [3, 4, 5]
+	el := m[4] or {
+		println('error')
+	}
+	println(el)
+}
+
+fn test_map_or() {
+	m := {
+		'as': 3
+		'qw': 4
+		'kl': 5
+	}
+	mut testvar := 0
+	el := m['pp'] or {
+		testvar = 12
+	}
+	println('$el $testvar')
+}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -162,6 +162,20 @@ fn (mut s Scanner) new_token(tok_kind token.Kind, lit string, len int) token.Tok
 }
 
 [inline]
+fn (mut s Scanner) new_mulitline_token(tok_kind token.Kind, lit string, len int, start_line int) token.Token {
+	cidx := s.tidx
+	s.tidx++
+	return token.Token{
+		kind: tok_kind
+		lit: lit
+		line_nr: start_line + 1,
+		pos: s.pos - len + 1
+		len: len
+		tidx: cidx
+	}
+}
+
+[inline]
 fn (mut s Scanner) ident_name() string {
 	start := s.pos
 	s.pos++
@@ -938,6 +952,7 @@ fn (mut s Scanner) text_scan() token.Token {
 				// Multiline comments
 				if nextc == `*` {
 					start := s.pos + 2
+					start_line := s.line_nr
 					mut nest_count := 1
 					// Skip comment
 					for nest_count > 0 && s.pos < s.text.len - 1 {
@@ -964,7 +979,7 @@ fn (mut s Scanner) text_scan() token.Token {
 						if !comment.contains('\n') {
 							comment = '\x01' + comment
 						}
-						return s.new_token(.comment, comment, comment.len + 4)
+						return s.new_mulitline_token(.comment, comment, comment.len + 4, start_line)
 					}
 					// Skip if not in fmt mode
 					continue

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -168,7 +168,7 @@ fn (mut s Scanner) new_mulitline_token(tok_kind token.Kind, lit string, len int,
 	return token.Token{
 		kind: tok_kind
 		lit: lit
-		line_nr: start_line + 1,
+		line_nr: start_line + 1
 		pos: s.pos - len + 1
 		len: len
 		tidx: cidx
@@ -979,7 +979,8 @@ fn (mut s Scanner) text_scan() token.Token {
 						if !comment.contains('\n') {
 							comment = '\x01' + comment
 						}
-						return s.new_mulitline_token(.comment, comment, comment.len + 4, start_line)
+						return s.new_mulitline_token(.comment, comment, comment.len + 4,
+							start_line)
 					}
 					// Skip if not in fmt mode
 					continue

--- a/vlib/v/tests/array_map_or_test.v
+++ b/vlib/v/tests/array_map_or_test.v
@@ -33,3 +33,57 @@ fn test_map_or() {
 	assert el == 7
 	assert good == 5
 }
+
+
+fn get_map_el(key string) ?int {
+	m := {'as': 3, 'qw': 4, 'kl': 5}
+	r := m[key] ?
+	return r
+}
+
+fn get_arr_el(i int) ?int {
+	m := [3, 4, 5]
+	r := m[i] ?
+	return r
+}
+
+fn test_propagation() {
+	mut testvar1 := 12
+	mut testvar2 := 78
+	e := get_map_el('vv') or {
+		testvar1 = -34
+		7
+	}
+	f := get_map_el('as') or {
+		testvar1 = 67
+		23
+	}
+	g := get_arr_el(3) or {
+		testvar2 = 99
+		12
+	}
+	h := get_arr_el(0) or {
+		testvar2 = 177
+		int(-67)
+	}
+	assert testvar1 == -34
+	assert testvar2 == 99
+	assert e == 7
+	assert f == 3
+	assert g == 12
+	assert h == 3
+}
+
+fn get_arr_el_nested(i int) ?int {
+	ind := [2, 1, 0, 5]
+	m := [3, 4, 5]
+	r := m[ind[i]] ?
+	return r
+}
+
+fn test_nested_array_propagation() {
+	g := get_arr_el_nested(3) or {
+		12
+	}
+	assert g == 12
+}

--- a/vlib/v/tests/map_high_order_assign_test.v
+++ b/vlib/v/tests/map_high_order_assign_test.v
@@ -1,0 +1,6 @@
+fn test_high_order_map_assign() {
+	mut m := map[string]map[string]int
+	m['hello']['hi'] = 1
+	println(m)
+	assert '$m' == "{'hello': {'hi': 1}}"
+}

--- a/vlib/v/token/position.v
+++ b/vlib/v/token/position.v
@@ -20,6 +20,7 @@ pub fn (pos Position) extend(end Position) Position {
 	return {
 		pos |
 		len: end.pos - pos.pos + end.len
+		last_line: end.line_nr
 	}
 }
 
@@ -38,5 +39,6 @@ pub fn (tok &Token) position() Position {
 		len: tok.len
 		line_nr: tok.line_nr - 1
 		pos: tok.pos
+		last_line: tok.line_nr - 1
 	}
 }

--- a/vlib/v/token/position.v
+++ b/vlib/v/token/position.v
@@ -20,7 +20,7 @@ pub fn (pos Position) extend(end Position) Position {
 	return {
 		pos |
 		len: end.pos - pos.pos + end.len
-		last_line: end.line_nr
+		last_line: end.last_line
 	}
 }
 
@@ -31,6 +31,10 @@ pub fn (pos Position) extend_with_last_line(end Position, last_line int) Positio
 		last_line: last_line - 1
 		pos: pos.pos
 	}
+}
+
+pub fn (mut pos Position) update_last_line(last_line int) {
+	pos.last_line = last_line - 1
 }
 
 [inline]


### PR DESCRIPTION
Fixes #3917
Lets `v fmt` keep single empty lines between statements. Multiple empty lines get squashed to a single one.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
