### PR TITLE
x.websocket: Fix weird shift operator bug in clang -prod flag

### DIFF
--- a/vlib/x/websocket/message.v
+++ b/vlib/x/websocket/message.v
@@ -255,7 +255,7 @@ pub fn (mut ws Client) parse_frame_header() ?Frame {
 			frame.header_len += 2
 			frame.payload_len = 0
 			frame.payload_len |= (buffer[2] * int(math.pow(2, 8)))
-			frame.payload_len |= buffer[3] 
+			frame.payload_len |= buffer[3]
 			frame.frame_size = frame.header_len + frame.payload_len
 			if !frame.has_mask {
 				break
@@ -264,13 +264,13 @@ pub fn (mut ws Client) parse_frame_header() ?Frame {
 		if frame.payload_len == 127 && bytes_read == u64(extended_payload64_end_byte) {
 			frame.header_len += 8
 			frame.payload_len = 0
-			frame.payload_len |= (buffer[2] * int(math.pow(2,56)))
-			frame.payload_len |= (buffer[3] * int(math.pow(2,48)))
-			frame.payload_len |= (buffer[4] * int(math.pow(2,40)))
-			frame.payload_len |= (buffer[5] * int(math.pow(2,32)))
-			frame.payload_len |= (buffer[6] * int(math.pow(2,24)))
-			frame.payload_len |= (buffer[7] * int(math.pow(2,16)))
-			frame.payload_len |= (buffer[8] * int(math.pow(2,8)))
+			frame.payload_len |= (buffer[2] * int(math.pow(2, 56)))
+			frame.payload_len |= (buffer[3] * int(math.pow(2, 48)))
+			frame.payload_len |= (buffer[4] * int(math.pow(2, 40)))
+			frame.payload_len |= (buffer[5] * int(math.pow(2, 32)))
+			frame.payload_len |= (buffer[6] * int(math.pow(2, 24)))
+			frame.payload_len |= (buffer[7] * int(math.pow(2, 16)))
+			frame.payload_len |= (buffer[8] * int(math.pow(2, 8)))
 			frame.payload_len |= buffer[9]
 			if !frame.has_mask {
 				break

--- a/vlib/x/websocket/message.v
+++ b/vlib/x/websocket/message.v
@@ -1,6 +1,7 @@
 module websocket
 
 import encoding.utf8
+import math
 
 const (
 	header_len_offset           = 2 // offset for lengthpart of websocket header
@@ -253,8 +254,8 @@ pub fn (mut ws Client) parse_frame_header() ?Frame {
 		if frame.payload_len == 126 && bytes_read == u64(extended_payload16_end_byte) {
 			frame.header_len += 2
 			frame.payload_len = 0
-			frame.payload_len |= buffer[2] << 8
-			frame.payload_len |= buffer[3] << 0
+			frame.payload_len |= (buffer[2] * int(math.pow(2, 8)))
+			frame.payload_len |= buffer[3] 
 			frame.frame_size = frame.header_len + frame.payload_len
 			if !frame.has_mask {
 				break
@@ -263,14 +264,14 @@ pub fn (mut ws Client) parse_frame_header() ?Frame {
 		if frame.payload_len == 127 && bytes_read == u64(extended_payload64_end_byte) {
 			frame.header_len += 8
 			frame.payload_len = 0
-			frame.payload_len |= buffer[2] << 56
-			frame.payload_len |= buffer[3] << 48
-			frame.payload_len |= buffer[4] << 40
-			frame.payload_len |= buffer[5] << 32
-			frame.payload_len |= buffer[6] << 24
-			frame.payload_len |= buffer[7] << 16
-			frame.payload_len |= buffer[8] << 8
-			frame.payload_len |= buffer[9] << 0
+			frame.payload_len |= (buffer[2] * int(math.pow(2,56)))
+			frame.payload_len |= (buffer[3] * int(math.pow(2,48)))
+			frame.payload_len |= (buffer[4] * int(math.pow(2,40)))
+			frame.payload_len |= (buffer[5] * int(math.pow(2,32)))
+			frame.payload_len |= (buffer[6] * int(math.pow(2,24)))
+			frame.payload_len |= (buffer[7] * int(math.pow(2,16)))
+			frame.payload_len |= (buffer[8] * int(math.pow(2,8)))
+			frame.payload_len |= buffer[9]
 			if !frame.has_mask {
 				break
 			}


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
Fixes the problem using clang and `-prod` flag. It optimizes the shift operators with error. gcc works as expected with -prod.

Following code works 
```V
			frame.payload_len = 0
			frame.payload_len |= (buffer[2] * int(math.pow(2,56)))
			frame.payload_len |= (buffer[3] * int(math.pow(2,48)))
			frame.payload_len |= (buffer[4] * int(math.pow(2,40)))
			frame.payload_len |= (buffer[5] * int(math.pow(2,32)))
			frame.payload_len |= (buffer[6] * int(math.pow(2,24)))
			frame.payload_len |= (buffer[7] * int(math.pow(2,16)))
			frame.payload_len |= (buffer[8] * int(math.pow(2,8)))
			frame.payload_len |= buffer[9]
```
but following code does not work the same on clang and -prod
```V
			frame.payload_len = 0
			frame.payload_len |= buffer[2] << 56
			frame.payload_len |= buffer[3] << 48
			frame.payload_len |= buffer[4] << 40
			frame.payload_len |= buffer[5] << 32
			frame.payload_len |= buffer[6] << 24
			frame.payload_len |= buffer[7] << 16
			frame.payload_len |= buffer[8] << 8
			frame.payload_len |= buffer[9]
```
both examples work as expected without the -prod flag in gcc/clang
