### PR TITLE
builtin, checker, cgen: implement `x = a[k] or { ... }` for maps and arrays

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -229,6 +229,16 @@ fn (a array) get(i int) voidptr {
 	}
 }
 
+// Private function. Used to implement x = a[i] or { ... }
+fn (a array) get_with_check(i int) voidptr {
+	if i < 0 || i >= a.len {
+		return 0
+	}
+	unsafe {
+		return byteptr(a.data) + i * a.element_size
+	}
+}
+
 // first returns the first element of the array.
 pub fn (a array) first() voidptr {
 	$if !no_bounds_checking ? {

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -552,6 +552,29 @@ fn (m &map) get_1(key voidptr, zero voidptr) voidptr {
 	return zero
 }
 
+// If `key` matches the key of an element in the container,
+// the method returns a reference to its mapped value.
+// If not, a zero pointer is returned.
+// This is used in `x := m['key'] or { ... }`
+fn (m &map) get_1_check(key voidptr) voidptr {
+	mut index, mut meta := m.key_to_index(key)
+	for {
+		if meta == unsafe { m.metas[index] } {
+			kv_index := int(unsafe { m.metas[index + 1] })
+			pkey := unsafe { m.key_values.key(kv_index) }
+			if m.key_eq_fn(key, pkey) {
+				return unsafe { byteptr(pkey) + m.key_values.key_bytes }
+			}
+		}
+		index += 2
+		meta += probe_inc
+		if meta > unsafe { m.metas[index] } {
+			break
+		}
+	}
+	return 0
+}
+
 // Checks whether a particular key exists in the map.
 fn (m &map) exists_1(key voidptr) bool {
 	mut index, mut meta := m.key_to_index(key)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4830,7 +4830,6 @@ pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) table.Type {
 			c.warn('pointer indexing is only allowed in `unsafe` blocks', node.pos)
 		}
 	}
-	
 	if mut node.index is ast.RangeExpr { // [1..2]
 		if node.index.has_low {
 			index_type := c.expr(node.index.low)

--- a/vlib/v/tests/array_map_or_test.v
+++ b/vlib/v/tests/array_map_or_test.v
@@ -4,8 +4,12 @@ fn test_array_or() {
 	el := m[4] or {
 		testvar = -43
 	}
+	good := m[1] or {
+		testvar = 11
+	}
 	assert testvar == -43
 	assert el == 0
+	assert good == 4
 }
 
 fn test_map_or() {
@@ -14,6 +18,10 @@ fn test_map_or() {
 	el := m['pp'] or {
 		testvar = 7931
 	}
+	good := m['kl'] or {
+		testvar = -45
+	}
 	assert testvar == 7931
 	assert el == 0
+	assert good == 5
 }

--- a/vlib/v/tests/array_map_or_test.v
+++ b/vlib/v/tests/array_map_or_test.v
@@ -1,0 +1,19 @@
+fn test_array_or() {
+	m := [3, 4, 5]
+	mut testvar := 17
+	el := m[4] or {
+		testvar = -43
+	}
+	assert testvar == -43
+	assert el == 0
+}
+
+fn test_map_or() {
+	m := {'as': 3, 'qw': 4, 'kl': 5}
+	mut testvar := -21
+	el := m['pp'] or {
+		testvar = 7931
+	}
+	assert testvar == 7931
+	assert el == 0
+}


### PR DESCRIPTION
This PR enables error handling for array and map read access:
```v
x := a[i] or {
    ...
}

y := m['key'] or {
    ...
}
```
This fixes #8183.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
