### PR TITLE
cgen: fix for_in_fixed_array (fix #8186)

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1307,7 +1307,7 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 				styp := g.typ(it.val_type)
 				g.write('\t$styp ${c_name(it.val_var)}')
 			}
-			addr := if it.val_is_mut {'&'} else {''}
+			addr := if it.val_is_mut { '&' } else { '' }
 			if it.cond_type.is_ptr() || it.cond is ast.ArrayInit {
 				g.writeln(' = ${addr}(*$atmp)[$i];')
 			} else {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1285,21 +1285,15 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 	} else if it.kind == .array_fixed {
 		atmp := g.new_tmp_var()
 		atmp_type := g.typ(it.cond_type).trim('*')
-		if !it.cond.is_lvalue() {
-			g.write('$atmp_type *$atmp = ')
-			if !it.cond_type.is_ptr() {
-				g.write('&')
+		if it.cond_type.is_ptr() || it.cond is ast.ArrayInit {
+			if !it.cond.is_lvalue() {
+				g.write('$atmp_type *$atmp = (($atmp_type)')
+			} else {
+				g.write('$atmp_type *$atmp = (')
 			}
-			g.write('(($atmp_type)')
-		} else {
-			g.write('$atmp_type *$atmp = ')
-			if !it.cond_type.is_ptr() {
-				g.write('&')
-			}
-			g.write('(')
+			g.expr(it.cond)
+			g.writeln(');')
 		}
-		g.expr(it.cond)
-		g.writeln(');')
 		i := if it.key_var in ['', '_'] { g.new_tmp_var() } else { it.key_var }
 		cond_sym := g.table.get_type_symbol(it.cond_type)
 		info := cond_sym.info as table.ArrayFixed
@@ -1314,9 +1308,21 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 				g.write('\t$styp ${c_name(it.val_var)}')
 			}
 			if it.val_is_mut {
-				g.writeln(' = &(*$atmp)[$i];')
+				if it.cond_type.is_ptr() || it.cond is ast.ArrayInit {
+					g.writeln(' = &(*$atmp)[$i];')
+				} else {
+					g.write(' = &')
+					g.expr(it.cond)
+					g.writeln('[$i];')
+				}
 			} else {
-				g.writeln(' = (*$atmp)[$i];')
+				if it.cond_type.is_ptr() || it.cond is ast.ArrayInit {
+					g.writeln(' = (*$atmp)[$i];')
+				} else {
+					g.write(' = ')
+					g.expr(it.cond)
+					g.writeln('[$i];')
+				}
 			}
 		}
 	} else if it.kind == .map {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1307,22 +1307,13 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 				styp := g.typ(it.val_type)
 				g.write('\t$styp ${c_name(it.val_var)}')
 			}
-			if it.val_is_mut {
-				if it.cond_type.is_ptr() || it.cond is ast.ArrayInit {
-					g.writeln(' = &(*$atmp)[$i];')
-				} else {
-					g.write(' = &')
-					g.expr(it.cond)
-					g.writeln('[$i];')
-				}
+			addr := if it.val_is_mut {'&'} else {''}
+			if it.cond_type.is_ptr() || it.cond is ast.ArrayInit {
+				g.writeln(' = ${addr}(*$atmp)[$i];')
 			} else {
-				if it.cond_type.is_ptr() || it.cond is ast.ArrayInit {
-					g.writeln(' = (*$atmp)[$i];')
-				} else {
-					g.write(' = ')
-					g.expr(it.cond)
-					g.writeln('[$i];')
-				}
+				g.write(' = $addr')
+				g.expr(it.cond)
+				g.writeln('[$i];')
 			}
 		}
 	} else if it.kind == .map {

--- a/vlib/v/tests/fixed_array_test.v
+++ b/vlib/v/tests/fixed_array_test.v
@@ -85,3 +85,17 @@ fn test_iteration_over_fixed_array_literal() {
 	}
 	assert s == 27.25
 }
+
+fn calc_size(a [3]int) {
+	mut s := 0
+	for i in a {
+		println(i)
+		s += i
+	}
+	assert s == 6
+}
+
+fn test_for_in_fixed_array() {
+	arr := [1,2,3]!
+	calc_size(arr)
+}


### PR DESCRIPTION
This PR fix for_in_fixed_array (fix #8186).

- Fix for_in_fixed_array.
- Add test.

```vlang
fn test_size(a [3]int) {
	println(a[0])
	println(a[1])
	println(a[2])
	for i := 0; i < a.len; i++ {
		println(a[i])
	}
	for i in a {
		println(i)
	}
}

fn main() {
	arr := [1, 2, 3]!
	test_size(arr)
}

PS D:\Test\v\tt1> v run .
1
2
3
1
2
3
1
2
3
```