### PR TITLE
x.websocket: bring back shift operators

### DIFF
--- a/vlib/x/websocket/message.v
+++ b/vlib/x/websocket/message.v
@@ -1,7 +1,6 @@
 module websocket
 
 import encoding.utf8
-import math
 
 const (
 	header_len_offset           = 2 // offset for lengthpart of websocket header
@@ -254,7 +253,7 @@ pub fn (mut ws Client) parse_frame_header() ?Frame {
 		if frame.payload_len == 126 && bytes_read == u64(extended_payload16_end_byte) {
 			frame.header_len += 2
 			frame.payload_len = 0
-			frame.payload_len |= (buffer[2] * int(math.pow(2, 8)))
+			frame.payload_len |= buffer[2] << 8
 			frame.payload_len |= buffer[3]
 			frame.frame_size = frame.header_len + frame.payload_len
 			if !frame.has_mask {
@@ -263,15 +262,17 @@ pub fn (mut ws Client) parse_frame_header() ?Frame {
 		}
 		if frame.payload_len == 127 && bytes_read == u64(extended_payload64_end_byte) {
 			frame.header_len += 8
-			frame.payload_len = 0
-			frame.payload_len |= (buffer[2] * int(math.pow(2, 56)))
-			frame.payload_len |= (buffer[3] * int(math.pow(2, 48)))
-			frame.payload_len |= (buffer[4] * int(math.pow(2, 40)))
-			frame.payload_len |= (buffer[5] * int(math.pow(2, 32)))
-			frame.payload_len |= (buffer[6] * int(math.pow(2, 24)))
-			frame.payload_len |= (buffer[7] * int(math.pow(2, 16)))
-			frame.payload_len |= (buffer[8] * int(math.pow(2, 8)))
-			frame.payload_len |= buffer[9]
+			// these shift operators needs 64 bit on clang with -prod flag
+			mut payload_len := u64(0)
+			payload_len |= buffer[2] << 56
+			payload_len |= buffer[3] << 48
+			payload_len |= buffer[4] << 40
+			payload_len |= buffer[5] << 32
+			payload_len |= buffer[6] << 24
+			payload_len |= buffer[7] << 16
+			payload_len |= buffer[8] << 8
+			payload_len |= buffer[9]
+			frame.payload_len = int(payload_len)
 			if !frame.has_mask {
 				break
 			}


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
Now found the root cause of failure on clang `-prod` bug using shift operators. Using them on `u64`will work. This PR brings back using more efficient shift operators.