### PR TITLE
cgen: fix high order map assignment (fix #8171)

### DIFF
--- a/vlib/v/tests/map_high_order_assign_test.v
+++ b/vlib/v/tests/map_high_order_assign_test.v
@@ -1,0 +1,6 @@
+fn test_high_order_map_assign() {
+	mut m := map[string]map[string]int
+	m['hello']['hi'] = 1
+	println(m)
+	assert '$m' == "{'hello': {'hi': 1}}"
+}


### PR DESCRIPTION
This PR fix high order map assignment (fix #8171).

- Fix high order map assignment.
- Add test.

```vlang
fn main() {
	mut m := map[string]map[string]int
	m['hello']['hi'] = 1
	println(m)
}

PS D:\Test\v\tt1> v run .
{'hello': {'hi': 1}}
```