### PR TITLE
parser: support `x = a[k] ?` propagation for arrays and maps

### DIFF
--- a/vlib/v/parser/tests/or_default_missing.out
+++ b/vlib/v/parser/tests/or_default_missing.out
@@ -1,0 +1,14 @@
+vlib/v/parser/tests/or_default_missing.vv:4:3: error: `or` block must provide a default value of type `int`, or return/exit/continue/break/panic
+    2 |     m := [3, 4, 5]
+    3 |     el := m[4] or {
+    4 |         println('error')
+      |         ~~~~~~~~~~~~~~~~
+    5 |     }
+    6 |     println(el)
+vlib/v/parser/tests/or_default_missing.vv:16:16: error: last statement in the `or {}` block should be an expression of type `int` or exit parent scope
+   14 |     }
+   15 |     mut testvar := 0
+   16 |     el := m['pp'] or {
+      |                   ~~~~
+   17 |         testvar = 12
+   18 |     }

--- a/vlib/v/parser/tests/or_default_missing.vv
+++ b/vlib/v/parser/tests/or_default_missing.vv
@@ -1,0 +1,20 @@
+fn test_array_or() {
+	m := [3, 4, 5]
+	el := m[4] or {
+		println('error')
+	}
+	println(el)
+}
+
+fn test_map_or() {
+	m := {
+		'as': 3
+		'qw': 4
+		'kl': 5
+	}
+	mut testvar := 0
+	el := m['pp'] or {
+		testvar = 12
+	}
+	println('$el $testvar')
+}

--- a/vlib/v/tests/array_map_or_test.v
+++ b/vlib/v/tests/array_map_or_test.v
@@ -33,3 +33,43 @@ fn test_map_or() {
 	assert el == 7
 	assert good == 5
 }
+
+
+fn get_map_el(key string) ?int {
+	m := {'as': 3, 'qw': 4, 'kl': 5}
+	r := m[key] ?
+	return r
+}
+
+fn get_arr_el(i int) ?int {
+	m := [3, 4, 5]
+	r := m[i] ?
+	return r
+}
+
+fn test_propagation() {
+	mut testvar1 := 12
+	mut testvar2 := 78
+	e := get_map_el('vv') or {
+		testvar1 = -34
+		7
+	}
+	f := get_map_el('as') or {
+		testvar1 = 67
+		23
+	}
+	g := get_arr_el(3) or {
+		testvar2 = 99
+		12
+	}
+	h := get_arr_el(0) or {
+		testvar2 = 177
+		int(-67)
+	}
+	assert testvar1 == -34
+	assert testvar2 == 99
+	assert e == 7
+	assert f == 3
+	assert g == 12
+	assert h == 3
+}

--- a/vlib/v/tests/array_map_or_test.v
+++ b/vlib/v/tests/array_map_or_test.v
@@ -73,3 +73,17 @@ fn test_propagation() {
 	assert g == 12
 	assert h == 3
 }
+
+fn get_arr_el_nested(i int) ?int {
+	ind := [2, 1, 0, 5]
+	m := [3, 4, 5]
+	r := m[ind[i]] ?
+	return r
+}
+
+fn test_nested_array_propagation() {
+	g := get_arr_el_nested(3) or {
+		12
+	}
+	assert g == 12
+}


### PR DESCRIPTION
This make error propagation work for array and map read:
```v
fn get_arr_el(i int) ?int {
	m := [3, 4, 5]
	r := m[i] ?
	return r
}

fn main() {
    g := get_arr_el(3) or {
        12
    }
    println(g)
}
```
I've also added some test cases for this and for a missing default value in an `or` branch.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
