### PR TITLE
cgen: fix child struct's default values not assigned (fix #8146)

### DIFF
--- a/vlib/v/tests/struct_child_field_default_test.v
+++ b/vlib/v/tests/struct_child_field_default_test.v
@@ -1,0 +1,22 @@
+struct Position {
+	line_nr int = 1
+}
+
+struct Statement {
+	pos Position
+}
+
+struct Expression {
+	pos Position
+}
+
+fn test_child_struct_field_default() {
+	stmt := Statement{
+		pos: Position{}
+	}
+	expr := Expression{}
+	println(stmt)
+	println(expr)
+	assert stmt.pos.line_nr == 1
+	assert expr.pos.line_nr == 1
+}


### PR DESCRIPTION
This PR fix child struct's default values not assigned (fix #8146).

- Fix child struct's default values not assigned.
- Add test.

```v
struct Position {
	line_nr int = 1
}

struct Statement {
	pos Position
}

struct Expression {
	pos Position
}

fn test_child_struct_field_default() {
	stmt := Statement{
		pos: Position{}
	}
	expr := Expression{}
	println(stmt)
	println(expr)
	assert stmt.pos.line_nr == 1
	assert expr.pos.line_nr == 1
}

PS D:\Test\v\tt1> v run .
Statement{
    pos: Position{
        line_nr: 1
    }
}
Expression{
    pos: Position{
        line_nr: 1
    }
}
```