### PR TITLE
net: use mut and refs as receivers consistently

### DIFF
--- a/vlib/net/ftp/ftp.v
+++ b/vlib/net/ftp/ftp.v
@@ -55,7 +55,7 @@ fn (mut dtp DTP) read() ?[]byte {
 	return data
 }
 
-fn (dtp DTP) close() {
+fn (mut dtp DTP) close() {
 	dtp.conn.close()
 }
 

--- a/vlib/net/net_nix.c.v
+++ b/vlib/net/net_nix.c.v
@@ -9,7 +9,7 @@ module net
 #include <netdb.h>
 #include <errno.h>
 #include <fcntl.h>
-
+#flag solaris -lsocket
 fn error_code() int {
 	return C.errno
 }
@@ -24,5 +24,3 @@ pub const (
 const (
 	error_ewouldblock = C.EWOULDBLOCK
 )
-
-#flag solaris -lsocket

--- a/vlib/net/smtp/smtp.v
+++ b/vlib/net/smtp/smtp.v
@@ -12,14 +12,14 @@ import time
 import io
 
 const (
-	recv_size  = 128
+	recv_size = 128
 )
 
 enum ReplyCode {
-	ready      = 220
-	close      = 221
-	auth_ok    = 235
-	action_ok  = 250
+	ready = 220
+	close = 221
+	auth_ok = 235
+	action_ok = 250
 	mail_start = 354
 }
 
@@ -39,7 +39,7 @@ pub:
 	password string
 	from     string
 pub mut:
-    is_open  bool
+	is_open bool
 }
 
 pub struct Mail {
@@ -54,15 +54,19 @@ pub struct Mail {
 }
 
 // new_client returns a new SMTP client and connects to it
-pub fn new_client(config Client) ?Client {
-	mut c := config
-	c.reconnect()?
+pub fn new_client(config Client) ?&Client {
+	mut c := &Client{
+		...config
+	}
+	c.reconnect() ?
 	return c
 }
 
 // reconnect reconnects to the SMTP server if the connection was closed
 pub fn (mut c Client) reconnect() ? {
-	if c.is_open { return error('Already connected to server') }
+	if c.is_open {
+		return error('Already connected to server')
+	}
 
 	conn := net.dial_tcp('$c.server:$c.port') or { return error('Connecting to server failed') }
 	c.conn = conn
@@ -76,29 +80,34 @@ pub fn (mut c Client) reconnect() ? {
 }
 
 // send sends an email
-pub fn (c Client) send(config Mail) ? {
-	if !c.is_open { return error('Disconnected from server') }
+pub fn (mut c Client) send(config Mail) ? {
+	if !c.is_open {
+		return error('Disconnected from server')
+	}
 	from := if config.from != '' { config.from } else { c.from }
 	c.send_mailfrom(from) or { return error('Sending mailfrom failed') }
 	c.send_mailto(config.to) or { return error('Sending mailto failed') }
 	c.send_data() or { return error('Sending mail data failed') }
-	c.send_body({ config | from: from }) or { return error('Sending mail body failed') }
+	c.send_body({
+		config |
+		from: from
+	}) or { return error('Sending mail body failed') }
 }
 
 // quit closes the connection to the server
 pub fn (mut c Client) quit() ? {
 	c.send_str('QUIT\r\n')
 	c.expect_reply(.close)
-	c.conn.close()?
+	c.conn.close() ?
 	c.is_open = false
 }
 
 // expect_reply checks if the SMTP server replied with the expected reply code
-fn (c Client) expect_reply(expected ReplyCode) ? {
-	bytes := io.read_all(reader: c.conn)?
+fn (mut c Client) expect_reply(expected ReplyCode) ? {
+	bytes := io.read_all(reader: c.conn) ?
 
 	str := bytes.bytestr().trim_space()
-	$if smtp_debug? {
+	$if smtp_debug ? {
 		eprintln('\n\n[RECV]')
 		eprint(str)
 	}
@@ -108,30 +117,32 @@ fn (c Client) expect_reply(expected ReplyCode) ? {
 		if ReplyCode(status) != expected {
 			return error('Received unexpected status code $status, expecting $expected')
 		}
-	} else { return error('Recieved unexpected SMTP data: $str') }
+	} else {
+		return error('Recieved unexpected SMTP data: $str')
+	}
 }
 
 [inline]
-fn (c Client) send_str(s string) ? {
-	$if smtp_debug? {
+fn (mut c Client) send_str(s string) ? {
+	$if smtp_debug ? {
 		eprintln('\n\n[SEND START]')
 		eprint(s.trim_space())
 		eprintln('\n[SEND END]')
 	}
-	c.conn.write(s.bytes())?
+	c.conn.write(s.bytes()) ?
 }
 
 [inline]
-fn (c Client) send_ehlo() ? {
-	c.send_str('EHLO $c.server\r\n')?
-	c.expect_reply(.action_ok)?
+fn (mut c Client) send_ehlo() ? {
+	c.send_str('EHLO $c.server\r\n') ?
+	c.expect_reply(.action_ok) ?
 }
 
 [inline]
-fn (c Client) send_auth() ? {
+fn (mut c Client) send_auth() ? {
 	if c.username.len == 0 {
 		return
-	}    
+	}
 	mut sb := strings.new_builder(100)
 	sb.write_b(0)
 	sb.write(c.username)
@@ -139,26 +150,26 @@ fn (c Client) send_auth() ? {
 	sb.write(c.password)
 	a := sb.str()
 	auth := 'AUTH PLAIN ${base64.encode(a)}\r\n'
-	c.send_str(auth)?
-	c.expect_reply(.auth_ok)?
+	c.send_str(auth) ?
+	c.expect_reply(.auth_ok) ?
 }
 
-fn (c Client) send_mailfrom(from string) ? {
-	c.send_str('MAIL FROM: <$from>\r\n')?
-	c.expect_reply(.action_ok)?
+fn (mut c Client) send_mailfrom(from string) ? {
+	c.send_str('MAIL FROM: <$from>\r\n') ?
+	c.expect_reply(.action_ok) ?
 }
 
-fn (c Client) send_mailto(to string) ? {
-	c.send_str('RCPT TO: <$to>\r\n')?
-	c.expect_reply(.action_ok)?
+fn (mut c Client) send_mailto(to string) ? {
+	c.send_str('RCPT TO: <$to>\r\n') ?
+	c.expect_reply(.action_ok) ?
 }
 
-fn (c Client) send_data() ? {
-	c.send_str('DATA\r\n')?
+fn (mut c Client) send_data() ? {
+	c.send_str('DATA\r\n') ?
 	c.expect_reply(.mail_start)
 }
 
-fn (c Client) send_body(cfg Mail) ? {
+fn (mut c Client) send_body(cfg Mail) ? {
 	is_html := cfg.body_type == .html
 	date := cfg.date.utc_string().trim_right(' UTC') // TODO
 	mut sb := strings.new_builder(200)
@@ -174,6 +185,6 @@ fn (c Client) send_body(cfg Mail) ? {
 	sb.write('\r\n\r\n')
 	sb.write(cfg.body)
 	sb.write('\r\n.\r\n')
-	c.send_str(sb.str())?
-	c.expect_reply(.action_ok)?
+	c.send_str(sb.str()) ?
+	c.expect_reply(.action_ok) ?
 }

--- a/vlib/net/smtp/smtp_test.v
+++ b/vlib/net/smtp/smtp_test.v
@@ -3,7 +3,7 @@ import smtp
 import time
 
 // Used to test that a function call returns an error
-fn fn_errors(c smtp.Client, m smtp.Mail) bool {
+fn fn_errors(mut c smtp.Client, m smtp.Mail) bool {
 	c.send(m) or { return true }
 	return false
 }
@@ -14,7 +14,9 @@ fn fn_errors(c smtp.Client, m smtp.Mail) bool {
 * Created by: nedimf (07/2020)
 */
 fn test_smtp() {
-	$if !network ? { return }
+	$if !network ? {
+		return
+	}
 
 	client_cfg := smtp.Client{
 		server: 'smtp.mailtrap.io'
@@ -32,20 +34,57 @@ fn test_smtp() {
 		body: 'Plain text'
 	}
 
-	mut client := smtp.new_client(client_cfg) or { assert false return }
+	mut client := smtp.new_client(client_cfg) or {
+		assert false
+		return
+	}
 	assert true
-	client.send(send_cfg) or { assert false return }
+	client.send(send_cfg) or {
+		assert false
+		return
+	}
 	assert true
 	// client.send({ send_cfg | body_type: .html, body: '<html><h1>HTML V email!</h1></html>' }) or { assert false return }
-	client.send({ send_cfg | from: 'alexander@vlang.io' }) or { assert false return }
-	client.send({ send_cfg | cc: 'alexander@vlang.io,joe@vlang.io', bcc: 'spytheman@vlang.io' }) or { assert false return }
-	client.send({ send_cfg | date: time.now().add_days(1000) }) or { assert false return }
+	client.send({
+		send_cfg |
+		from: 'alexander@vlang.io'
+	}) or {
+		assert false
+		return
+	}
+	client.send({
+		send_cfg |
+		cc: 'alexander@vlang.io,joe@vlang.io'
+		bcc: 'spytheman@vlang.io'
+	}) or {
+		assert false
+		return
+	}
+	client.send({
+		send_cfg |
+		date: time.now().add_days(1000)
+	}) or {
+		assert false
+		return
+	}
 	assert true
-	client.quit() or { assert false return }
+	client.quit() or {
+		assert false
+		return
+	}
 	assert true
 	// This call should return an error, since the connection is closed
-	if !fn_errors(client, send_cfg) { assert false return }
-	client.reconnect() or { assert false return }
-	client.send(send_cfg) or { assert false return }
+	if !fn_errors(mut client, send_cfg) {
+		assert false
+		return
+	}
+	client.reconnect() or {
+		assert false
+		return
+	}
+	client.send(send_cfg) or {
+		assert false
+		return
+	}
 	assert true
 }

--- a/vlib/net/tcp_read_line.v
+++ b/vlib/net/tcp_read_line.v
@@ -10,7 +10,7 @@ const (
 // It will *always* return a line, ending with CRLF, or just '', on EOF.
 // NB: if you want more control over the buffer, please use a buffered IO
 // reader instead: `io.new_buffered_reader({reader: io.make_reader(con)})`
-pub fn (con TcpConn) read_line() string {
+pub fn (mut con TcpConn) read_line() string {
 	mut buf := [max_read]byte{} // where C.recv will store the network data
 	mut res := '' // The final result, including the ending \n.
 	for {

--- a/vlib/net/tcp_simple_client_server_test.v
+++ b/vlib/net/tcp_simple_client_server_test.v
@@ -6,36 +6,28 @@ const (
 	server_port = 22334
 )
 
-fn setup() (net.TcpListener, net.TcpConn, net.TcpConn) {
-	server := net.listen_tcp(server_port) or {
-		panic(err)
-	}
-	mut client := net.dial_tcp('127.0.0.1:$server_port') or {
-		panic(err)
-	}
-	mut socket := server.accept() or {
-		panic(err)
-	}
+fn setup() (&net.TcpListener, &net.TcpConn, &net.TcpConn) {
+	mut server := net.listen_tcp(server_port) or { panic(err) }
+	mut client := net.dial_tcp('127.0.0.1:$server_port') or { panic(err) }
+	mut socket := server.accept() or { panic(err) }
 	$if debug_peer_ip ? {
-		ip := con.peer_ip() or {
-			'$err'
-		}
+		ip := con.peer_ip() or { '$err' }
 		eprintln('connection peer_ip: $ip')
 	}
 	assert true
 	return server, client, socket
 }
 
-fn cleanup(server &net.TcpListener, client &net.TcpConn, socket &net.TcpConn) {
+fn cleanup(mut server net.TcpListener, mut client net.TcpConn, mut socket net.TcpConn) {
 	server.close() or { }
 	client.close() or { }
 	socket.close() or { }
 }
 
 fn test_socket() {
-	server, client, socket := setup()
+	mut server, mut client, mut socket := setup()
 	defer {
-		cleanup(server, client, socket)
+		cleanup(mut server, mut client, mut socket)
 	}
 	message := 'Hello World'
 	socket.write_str(message) or {
@@ -65,14 +57,12 @@ fn test_socket() {
 }
 
 fn test_socket_write_and_read() {
-	server, client, socket := setup()
+	mut server, mut client, mut socket := setup()
 	defer {
-		cleanup(server, client, socket)
+		cleanup(mut server, mut client, mut socket)
 	}
 	message1 := 'a message 1'
-	socket.write_str(message1) or {
-		assert false
-	}
+	socket.write_str(message1) or { assert false }
 	mut rbuf := []byte{len: message1.len}
 	client.read(mut rbuf)
 	line := rbuf.bytestr()
@@ -80,18 +70,16 @@ fn test_socket_write_and_read() {
 }
 
 fn test_socket_read_line() {
-	server, client, socket := setup()
-	mut reader := io.new_buffered_reader({
+	mut server, mut client, mut socket := setup()
+	mut reader := io.new_buffered_reader(
 		reader: io.make_reader(client)
-	})
+	)
 	defer {
-		cleanup(server, client, socket)
+		cleanup(mut server, mut client, mut socket)
 	}
 	message1, message2 := 'message1', 'message2'
 	message := '$message1\n$message2\n'
-	socket.write_str(message) or {
-		assert false
-	}
+	socket.write_str(message) or { assert false }
 	assert true
 	//
 	line1 := reader.read_line() or {
@@ -109,9 +97,9 @@ fn test_socket_read_line() {
 }
 
 fn test_socket_write_fail_without_panic() {
-	server, client, socket := setup()
+	mut server, mut client, mut socket := setup()
 	defer {
-		cleanup(server, client, socket)
+		cleanup(mut server, mut client, mut socket)
 	}
 	message2 := 'a message 2'
 	// ensure that socket.write (i.e. done on the server side)
@@ -131,12 +119,12 @@ fn test_socket_write_fail_without_panic() {
 }
 
 fn test_socket_read_line_long_line_without_eol() {
-	server, client, socket := setup()
-	mut reader := io.new_buffered_reader({
+	mut server, mut client, mut socket := setup()
+	mut reader := io.new_buffered_reader(
 		reader: io.make_reader(client)
-	})
+	)
 	defer {
-		cleanup(server, client, socket)
+		cleanup(mut server, mut client, mut socket)
 	}
 	message := strings.repeat_string('123', 400)
 	socket.write_str(message)

--- a/vlib/net/tcp_test.v
+++ b/vlib/net/tcp_test.v
@@ -4,8 +4,7 @@ const (
 	test_port = 45123
 )
 
-fn handle_conn(_c net.TcpConn) {
-	mut c := _c
+fn handle_conn(mut c net.TcpConn) {
 	for {
 		mut buf := []byte{len: 100, init: 0}
 		read := c.read(mut buf) or {
@@ -19,25 +18,23 @@ fn handle_conn(_c net.TcpConn) {
 	}
 }
 
-fn echo_server(l net.TcpListener) ? {
+fn echo_server(mut l net.TcpListener) ? {
 	for {
-		new_conn := l.accept() or {
-			continue
-		}
-		go handle_conn(new_conn)
+		mut new_conn := l.accept() or { continue }
+		go handle_conn(mut new_conn)
 	}
 	return none
 }
 
 fn echo() ? {
-	mut c := net.dial_tcp('127.0.0.1:$test_port')?
+	mut c := net.dial_tcp('127.0.0.1:$test_port') ?
 	defer {
 		c.close() or { }
 	}
 	data := 'Hello from vlib/net!'
-	c.write_str(data)?
+	c.write_str(data) ?
 	mut buf := []byte{len: 4096}
-	read := c.read(mut buf)?
+	read := c.read(mut buf) ?
 	assert read == data.len
 	for i := 0; i < read; i++ {
 		assert buf[i] == data[i]
@@ -47,16 +44,8 @@ fn echo() ? {
 }
 
 fn test_tcp() {
-	l := net.listen_tcp(test_port) or {
-		panic(err)
-	}
-	go echo_server(l)
-	echo() or {
-		panic(err)
-	}
+	mut l := net.listen_tcp(test_port) or { panic(err) }
+	go echo_server(mut l)
+	echo() or { panic(err) }
 	l.close() or { }
-}
-
-fn main() {
-	test_tcp()
 }

--- a/vlib/net/udp.v
+++ b/vlib/net/udp.v
@@ -8,7 +8,8 @@ const (
 )
 
 pub struct UdpConn {
-	sock           UdpSocket
+pub mut:
+	sock UdpSocket
 mut:
 	write_deadline time.Time
 	read_deadline  time.Time
@@ -16,7 +17,7 @@ mut:
 	write_timeout  time.Duration
 }
 
-pub fn dial_udp(laddr string, raddr string) ?UdpConn {
+pub fn dial_udp(laddr string, raddr string) ?&UdpConn {
 	// Dont have to do this when its fixed
 	// this just allows us to store this `none` optional in a struct
 	resolve_wrapper := fn (raddr string) ?Addr {
@@ -30,27 +31,27 @@ pub fn dial_udp(laddr string, raddr string) ?UdpConn {
 		l: local
 		r: resolve_wrapper(raddr)
 	}
-	return UdpConn{
+	return &UdpConn{
 		sock: sock
 		read_timeout: udp_default_read_timeout
 		write_timeout: udp_default_write_timeout
 	}
 }
 
-pub fn (c UdpConn) write_ptr(b byteptr, len int) ? {
+pub fn (mut c UdpConn) write_ptr(b byteptr, len int) ? {
 	remote := c.sock.remote() or { return err_no_udp_remote }
 	return c.write_to_ptr(remote, b, len)
 }
 
-pub fn (c UdpConn) write(buf []byte) ? {
+pub fn (mut c UdpConn) write(buf []byte) ? {
 	return c.write_ptr(buf.data, buf.len)
 }
 
-pub fn (c UdpConn) write_str(s string) ? {
+pub fn (mut c UdpConn) write_str(s string) ? {
 	return c.write_ptr(s.str, s.len)
 }
 
-pub fn (c UdpConn) write_to_ptr(addr Addr, b byteptr, len int) ? {
+pub fn (mut c UdpConn) write_to_ptr(addr Addr, b byteptr, len int) ? {
 	res := C.sendto(c.sock.handle, b, len, 0, &addr.addr, addr.len)
 	if res >= 0 {
 		return none
@@ -66,17 +67,17 @@ pub fn (c UdpConn) write_to_ptr(addr Addr, b byteptr, len int) ? {
 }
 
 // write_to blocks and writes the buf to the remote addr specified
-pub fn (c UdpConn) write_to(addr Addr, buf []byte) ? {
+pub fn (mut c UdpConn) write_to(addr Addr, buf []byte) ? {
 	return c.write_to_ptr(addr, buf.data, buf.len)
 }
 
 // write_to_string blocks and writes the buf to the remote addr specified
-pub fn (c UdpConn) write_to_string(addr Addr, s string) ? {
+pub fn (mut c UdpConn) write_to_string(addr Addr, s string) ? {
 	return c.write_to_ptr(addr, s.str, s.len)
 }
 
 // read reads from the socket into buf up to buf.len returning the number of bytes read
-pub fn (c UdpConn) read(mut buf []byte) ?(int, Addr) {
+pub fn (mut c UdpConn) read(mut buf []byte) ?(int, Addr) {
 	mut addr_from := C.sockaddr{}
 	len := sizeof(C.sockaddr)
 	mut res := wrap_read_result(C.recvfrom(c.sock.handle, buf.data, buf.len, 0, &addr_from,
@@ -100,7 +101,7 @@ pub fn (c UdpConn) read(mut buf []byte) ?(int, Addr) {
 	return none
 }
 
-pub fn (c UdpConn) read_deadline() ?time.Time {
+pub fn (c &UdpConn) read_deadline() ?time.Time {
 	if c.read_deadline.unix == 0 {
 		return c.read_deadline
 	}
@@ -111,7 +112,7 @@ pub fn (mut c UdpConn) set_read_deadline(deadline time.Time) {
 	c.read_deadline = deadline
 }
 
-pub fn (c UdpConn) write_deadline() ?time.Time {
+pub fn (c &UdpConn) write_deadline() ?time.Time {
 	if c.write_deadline.unix == 0 {
 		return c.write_deadline
 	}
@@ -122,7 +123,7 @@ pub fn (mut c UdpConn) set_write_deadline(deadline time.Time) {
 	c.write_deadline = deadline
 }
 
-pub fn (c UdpConn) read_timeout() time.Duration {
+pub fn (c &UdpConn) read_timeout() time.Duration {
 	return c.read_timeout
 }
 
@@ -130,7 +131,7 @@ pub fn (mut c UdpConn) set_read_timeout(t time.Duration) {
 	c.read_timeout = t
 }
 
-pub fn (c UdpConn) write_timeout() time.Duration {
+pub fn (c &UdpConn) write_timeout() time.Duration {
 	return c.write_timeout
 }
 
@@ -139,27 +140,27 @@ pub fn (mut c UdpConn) set_write_timeout(t time.Duration) {
 }
 
 [inline]
-pub fn (c UdpConn) wait_for_read() ? {
+pub fn (mut c UdpConn) wait_for_read() ? {
 	return wait_for_read(c.sock.handle, c.read_deadline, c.read_timeout)
 }
 
 [inline]
-pub fn (c UdpConn) wait_for_write() ? {
+pub fn (mut c UdpConn) wait_for_write() ? {
 	return wait_for_write(c.sock.handle, c.write_deadline, c.write_timeout)
 }
 
-pub fn (c UdpConn) str() string {
+pub fn (c &UdpConn) str() string {
 	// TODO
 	return 'UdpConn'
 }
 
-pub fn (c UdpConn) close() ? {
+pub fn (mut c UdpConn) close() ? {
 	return c.sock.close()
 }
 
-pub fn listen_udp(port int) ?UdpConn {
+pub fn listen_udp(port int) ?&UdpConn {
 	s := new_udp_socket(port) ?
-	return UdpConn{
+	return &UdpConn{
 		sock: s
 		read_timeout: udp_default_read_timeout
 		write_timeout: udp_default_write_timeout
@@ -172,9 +173,9 @@ struct UdpSocket {
 	r      ?Addr
 }
 
-fn new_udp_socket(local_port int) ?UdpSocket {
+fn new_udp_socket(local_port int) ?&UdpSocket {
 	sockfd := socket_error(C.socket(SocketFamily.inet, SocketType.udp, 0)) ?
-	s := UdpSocket{
+	mut s := &UdpSocket{
 		handle: sockfd
 	}
 	s.set_option_bool(.reuse_addr, true) ?
@@ -197,11 +198,11 @@ fn new_udp_socket(local_port int) ?UdpSocket {
 	return s
 }
 
-pub fn (s UdpSocket) remote() ?Addr {
+pub fn (s &UdpSocket) remote() ?Addr {
 	return s.r
 }
 
-pub fn (s UdpSocket) set_option_bool(opt SocketOption, value bool) ? {
+pub fn (mut s UdpSocket) set_option_bool(opt SocketOption, value bool) ? {
 	// TODO reenable when this `in` operation works again
 	// if opt !in opts_can_set {
 	// 	return err_option_not_settable
@@ -213,10 +214,10 @@ pub fn (s UdpSocket) set_option_bool(opt SocketOption, value bool) ? {
 	return none
 }
 
-fn (s UdpSocket) close() ? {
+fn (mut s UdpSocket) close() ? {
 	return shutdown(s.handle)
 }
 
-fn (s UdpSocket) @select(test Select, timeout time.Duration) ?bool {
+fn (mut s UdpSocket) @select(test Select, timeout time.Duration) ?bool {
 	return @select(s.handle, test, timeout)
 }

--- a/vlib/net/udp_test.v
+++ b/vlib/net/udp_test.v
@@ -1,12 +1,9 @@
 import net
 
-fn echo_server(_c net.UdpConn) {
-	mut c := _c
+fn echo_server(mut c net.UdpConn) {
 	for {
-		mut buf := []byte{ len: 100, init: 0 }
-		read, addr := c.read(mut buf) or {
-			continue
-		}
+		mut buf := []byte{len: 100, init: 0}
+		read, addr := c.read(mut buf) or { continue }
 
 		c.write_to(addr, buf[..read]) or {
 			println('Server: connection dropped')
@@ -16,14 +13,16 @@ fn echo_server(_c net.UdpConn) {
 }
 
 fn echo() ? {
-	mut c := net.dial_udp('127.0.0.1:40003', '127.0.0.1:40001')?
-	defer { c.close() or { } }
+	mut c := net.dial_udp('127.0.0.1:40003', '127.0.0.1:40001') ?
+	defer {
+		c.close() or { }
+	}
 	data := 'Hello from vlib/net!'
 
-	c.write_str(data)?
+	c.write_str(data) ?
 
-	mut buf := []byte{ len: 100, init: 0 }
-	read, addr := c.read(mut buf)?
+	mut buf := []byte{len: 100, init: 0}
+	read, addr := c.read(mut buf) ?
 
 	assert read == data.len
 	println('Got address $addr')
@@ -35,21 +34,21 @@ fn echo() ? {
 		assert buf[i] == data[i]
 	}
 
-	println('Got "${buf.bytestr()}"')
+	println('Got "$buf.bytestr()"')
 
-	c.close()?
+	c.close() ?
 
 	return none
 }
 
 fn test_udp() {
-	l := net.listen_udp(40001) or {
+	mut l := net.listen_udp(40001) or {
 		println(err)
 		assert false
 		panic('')
 	}
 
-	go echo_server(l)
+	go echo_server(mut l)
 	echo() or {
 		println(err)
 		assert false

--- a/vlib/vweb/tests/vweb_test.v
+++ b/vlib/vweb/tests/vweb_test.v
@@ -228,7 +228,7 @@ struct SimpleTcpClientConfig {
 }
 
 fn simple_tcp_client(config SimpleTcpClientConfig) ?string {
-	mut client := net.TcpConn{}
+	mut client := &net.TcpConn(0)
 	mut tries := 0
 	for tries < config.retries {
 		tries++

--- a/vlib/x/websocket/io.v
+++ b/vlib/x/websocket/io.v
@@ -86,7 +86,7 @@ fn (mut ws Client) shutdown_socket() ? {
 }
 
 // dial_socket connects tcp socket and initializes default configurations
-fn (mut ws Client) dial_socket() ?net.TcpConn {
+fn (mut ws Client) dial_socket() ?&net.TcpConn {
 	tcp_address := '$ws.uri.hostname:$ws.uri.port'
 	mut t := net.dial_tcp(tcp_address) ?
 	optval := int(1)

--- a/vlib/x/websocket/websocket_client.v
+++ b/vlib/x/websocket/websocket_client.v
@@ -30,7 +30,7 @@ pub:
 	uri    Uri    // uri of current connection
 	id     string // unique id of client
 pub mut:
-	conn              net.TcpConn // underlying TCP socket connection
+	conn              &net.TcpConn // underlying TCP socket connection
 	nonce_size        int = 16 // size of nounce used for masking
 	panic_on_callback bool     // set to true of callbacks can panic
 	state             State    // current state of connection
@@ -75,6 +75,7 @@ pub enum OPCode {
 pub fn new_client(address string) ?&Client {
 	uri := parse_uri(address) ?
 	return &Client{
+		conn: 0
 		is_server: false
 		ssl_conn: openssl.new_ssl_conn()
 		is_ssl: address.starts_with('wss')

--- a/vlib/x/websocket/websocket_server.v
+++ b/vlib/x/websocket/websocket_server.v
@@ -9,8 +9,8 @@ import rand
 // Server represents a websocket server connection
 pub struct Server {
 mut:
-	logger                  &log.Log              // logger used to log
-	ls                      net.TcpListener       // listener used to get incoming connection to socket
+	logger                  &log.Log // logger used to log
+	ls                      &net.TcpListener      // listener used to get incoming connection to socket
 	accept_client_callbacks []AcceptClientFn      // accept client callback functions
 	message_callbacks       []MessageEventHandler // new message callback functions
 	close_callbacks         []CloseEventHandler   // close message callback functions
@@ -36,6 +36,7 @@ pub mut:
 // new_server instance a new websocket server on provided port and route
 pub fn new_server(port int, route string) &Server {
 	return &Server{
+		ls: 0
 		port: port
 		logger: &log.Log{
 			level: .info


### PR DESCRIPTION
NB: this is a breaking change, but I think it will be worth it, in terms of making writing multithreaded network servers less error prone.

TCP network servers frequently have accept loops, looking like this:
```v
for {
        mut con := l.accept() or { panic('accept() failed') }
        handle_connection(mut con) 
        ...
}
```
Note, that with the current API, `con` will be allocated on the stack, which is ok for a single threaded server.

However, consider what happens, if you decide to make your server, handle each new client connection in a new thread:
```v
for {
        mut con := l.accept() or { panic('accept() failed') }
        go handle_connection(mut con) 
        ...
}
```
... which now no longer compiles, because `go` expects `con` now to be a reference, but instead it is a local variable.

At this point, the 'easiest' is to just do: `go handle_connection(mut &con)`, which will work, but will also introduce a bug, because the next accepted connection, will overwrite the local variable `con`, whose address we have already passed to the thread, serving the first connection...

Preventing the problem for future users:
*change the constructor functions and methods in `net` like .accept() , dial_tcp() etc, to return a reference, to a heap allocated object, instead of a local result allocated on the stack*

This prevents the error prone situation from before. 
Now, each connection will have an independent reference, thus no overwriting is possible/easy.

