### PR TITLE
cgen: fix for_in_mut_val of map (fix #8219)

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1362,11 +1362,21 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 				g.write(' = (*(voidptr*)')
 			} else {
 				val_styp := g.typ(it.val_type)
-				g.write('\t$val_styp ${c_name(it.val_var)} = (*($val_styp*)')
+				if it.val_type.is_ptr() {
+					g.write('\t$val_styp ${c_name(it.val_var)} = &(*($val_styp)')
+				} else {
+					g.write('\t$val_styp ${c_name(it.val_var)} = (*($val_styp*)')
+				}
 			}
 			g.writeln('DenseArray_value(&$atmp${arw_or_pt}key_values, $idx));')
 		}
+		if it.val_is_mut {
+			g.for_in_mul_val_name = it.val_var
+		}
 		g.stmts(it.stmts)
+		if it.val_is_mut {
+			g.for_in_mul_val_name = ''
+		}
 		if it.key_type == table.string_type && !g.is_builtin_mod {
 			// g.writeln('string_free(&$key);')
 		}

--- a/vlib/v/tests/for_in_mut_val_test.v
+++ b/vlib/v/tests/for_in_mut_val_test.v
@@ -49,3 +49,12 @@ fn test_for_in_mut_val_of_map() {
 	println(m)
 	assert '$m' == "{'hello': [2, 4, 6]}"
 }
+
+fn test_for_in_mut_val_of_map_direct() {
+	mut m := {'foo': 1, 'bar': 2}
+	for _, mut j in m {
+		j = 3
+	}
+	println(m)
+	assert '$m' == "{'foo': 3, 'bar': 3}"
+}


### PR DESCRIPTION
This PR fix for_in_mut_val of map (fix #8219).

- Fix for_in_mut_val of map.
- Add test.

```vlang
fn main() {
	mut m := {'foo': 1, 'bar': 2}
	for _, mut j in m {
		j = 3
	}
	println(m)
}

PS D:\Test\v\tt1> v run .
{'foo': 3, 'bar': 3}
```

```vlang
fn main() {
	mut m := {'foo': {'a': 1}, 'bar': {'b': 2}}
	for _, mut j in m {
		j = {'c': 10}
	}
	println(m)
}

PS D:\Test\v\tt1> v run .
{'foo': {'c': 10}, 'bar': {'c': 10}}
```