### PR TITLE
checker: check fixed array size (fix #8217)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2820,7 +2820,7 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) table.Type {
 		array_init.elem_type = elem_type
 	} else if array_init.is_fixed && array_init.exprs.len == 1 && array_init.elem_type != table.void_type {
 		// [50]byte
-		mut fixed_size := 1
+		mut fixed_size := 0
 		init_expr := array_init.exprs[0]
 		c.expr(init_expr)
 		match init_expr {
@@ -2840,6 +2840,9 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) table.Type {
 			else {
 				c.error('expecting `int` for fixed size', array_init.pos)
 			}
+		}
+		if fixed_size <= 0 {
+			c.error('fixed size cannot be zero or negative', init_expr.position())
 		}
 		idx := c.table.find_or_register_array_fixed(array_init.elem_type, fixed_size)
 		array_type := table.new_type(idx)

--- a/vlib/v/checker/tests/fixed_array_size_err.out
+++ b/vlib/v/checker/tests/fixed_array_size_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/fixed_array_size_err.vv:4:8: error: fixed size cannot be zero or negative
+    2 |
+    3 | fn main() {
+    4 |     a := [size]int{}
+      |           ~~~~
+    5 |     b := [0]byte{}
+    6 |     println(a)
+vlib/v/checker/tests/fixed_array_size_err.vv:5:8: error: fixed size cannot be zero or negative
+    3 | fn main() {
+    4 |     a := [size]int{}
+    5 |     b := [0]byte{}
+      |           ^
+    6 |     println(a)
+    7 |     println(b)

--- a/vlib/v/checker/tests/fixed_array_size_err.vv
+++ b/vlib/v/checker/tests/fixed_array_size_err.vv
@@ -1,0 +1,8 @@
+const size = -1
+
+fn main() {
+	a := [size]int{}
+	b := [0]byte{}
+	println(a)
+	println(b)
+}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -40,6 +40,9 @@ pub fn (mut p Parser) parse_array_type() table.Type {
 			// error is handled by parse_type
 			return 0
 		}
+		if fixed_size <= 0 {
+			p.error_with_pos('fixed size cannot be zero or negative', size_expr.position())
+		}
 		// sym := p.table.get_type_symbol(elem_type)
 		idx := p.table.find_or_register_array_fixed(elem_type, fixed_size)
 		return table.new_type(idx)


### PR DESCRIPTION
This PR check fixed array size (fix #8217).

- Check fixed array size.
- Add test.

```vlang
const size = -1

fn main() {
	a := [size]int{}
	b := [0]byte{}
	println(a)
	println(b)
}

vlib/v/checker/tests/fixed_array_size_err.vv:4:8: error: fixed size cannot be zero or negative
    2 |
    3 | fn main() {
    4 |     a := [size]int{}
      |           ~~~~
    5 |     b := [0]byte{}
    6 |     println(a)
vlib/v/checker/tests/fixed_array_size_err.vv:5:8: error: fixed size cannot be zero or negative
    3 | fn main() {
    4 |     a := [size]int{}
    5 |     b := [0]byte{}
      |           ^
    6 |     println(a)
    7 |     println(b)
```