### PR TITLE
cli: add missing documentation to all pub functionality

### DIFF
--- a/vlib/cli/flag.v
+++ b/vlib/cli/flag.v
@@ -7,6 +7,9 @@ pub enum FlagType {
 	string
 }
 
+// Flag holds information for a command line flag.
+// (flags are also commonly referred to as "options" or "switches")
+// These are typically denoted in the shell by a short form `-f` and/or a long form `--flag`
 pub struct Flag {
 pub mut:
 	flag        FlagType
@@ -20,10 +23,13 @@ mut:
 	found bool
 }
 
+// get_all_found returns an array of all `Flag`s found in the command parameters
 pub fn (flags []Flag) get_all_found() []Flag {
 	return flags.filter(it.found)
 }
 
+// get_bool returns `true` if the flag is set.
+// get_bool returns an error if the `FlagType` is not boolean.
 pub fn (flag Flag) get_bool() ?bool {
 	if flag.flag != .bool {
 		return error('$flag.name: Invalid flag type `$flag.flag`, expected `bool`')
@@ -31,11 +37,15 @@ pub fn (flag Flag) get_bool() ?bool {
 	return flag.value == 'true'
 }
 
+// get_bool returns `true` if the flag specified in `name` is set.
+// get_bool returns an error if the `FlagType` is not boolean.
 pub fn (flags []Flag) get_bool(name string) ?bool {
 	flag := flags.get(name) ?
 	return flag.get_bool()
 }
 
+// get_int returns the `int` value argument of the flag.
+// get_int returns an error if the `FlagType` is not integer.
 pub fn (flag Flag) get_int() ?int {
 	if flag.flag != .int {
 		return error('$flag.name: Invalid flag type `$flag.flag`, expected `int`')
@@ -43,11 +53,15 @@ pub fn (flag Flag) get_int() ?int {
 	return flag.value.int()
 }
 
+// get_int returns the `int` value argument of the flag specified in `name`.
+// get_int returns an error if the `FlagType` is not integer.
 pub fn (flags []Flag) get_int(name string) ?int {
 	flag := flags.get(name) ?
 	return flag.get_int()
 }
 
+// get_float returns the `f64` value argument of the flag.
+// get_float returns an error if the `FlagType` is not floating point.
 pub fn (flag Flag) get_float() ?f64 {
 	if flag.flag != .float {
 		return error('$flag.name: Invalid flag type `$flag.flag`, expected `float`')
@@ -55,11 +69,15 @@ pub fn (flag Flag) get_float() ?f64 {
 	return flag.value.f64()
 }
 
+// get_float returns the `f64` value argument of the flag specified in `name`.
+// get_float returns an error if the `FlagType` is not floating point.
 pub fn (flags []Flag) get_float(name string) ?f64 {
 	flag := flags.get(name) ?
 	return flag.get_float()
 }
 
+// get_string returns the `string` value argument of the flag.
+// get_string returns an error if the `FlagType` is not string.
 pub fn (flag Flag) get_string() ?string {
 	if flag.flag != .string {
 		return error('$flag.name: Invalid flag type `$flag.flag`, expected `string`')
@@ -67,12 +85,15 @@ pub fn (flag Flag) get_string() ?string {
 	return flag.value
 }
 
+// get_string returns the `string` value argument of the flag specified in `name`.
+// get_string returns an error if the `FlagType` is not string.
 pub fn (flags []Flag) get_string(name string) ?string {
 	flag := flags.get(name) ?
 	return flag.get_string()
 }
 
-// parse flag value from arguments and return arguments with all consumed element removed
+// parse parses flag values from arguments and return
+// an array of arguments with all consumed elements removed.
 fn (mut flag Flag) parse(args []string, with_abbrev bool) ?[]string {
 	if flag.matches(args, with_abbrev) {
 		if flag.flag == .bool {
@@ -87,7 +108,7 @@ fn (mut flag Flag) parse(args []string, with_abbrev bool) ?[]string {
 	}
 }
 
-// check if first arg matches flag
+// matches returns `true` if first arg in `args` matches this flag.
 fn (mut flag Flag) matches(args []string, with_abbrev bool) bool {
 	if with_abbrev {
 		return (flag.name != '' && args[0] == '--$flag.name') ||
@@ -125,6 +146,8 @@ fn (mut flag Flag) parse_bool(args []string) ?[]string {
 	return args[1..]
 }
 
+// get returns the `Flag` matching `name` or an error
+// if it can't be found.
 fn (flags []Flag) get(name string) ?Flag {
 	for flag in flags {
 		if flag.name == name {


### PR DESCRIPTION
When merged, this should tick off the following boxes in #7047 :

- [x] `vlib/cli/command.v`
- [x] `vlib/cli/flag.v`
- [x] `vlib/cli/help.v`
- [x] `vlib/cli/version.v`

I haven't documented the non-`pub` functions as many of these are somewhat self-explanatory (to me at least).

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
