### PR TITLE
vet: simplify fn name identifying, add warning for incomplete documentation

### DIFF
--- a/cmd/tools/vvet/tests/module_file_test.out
+++ b/cmd/tools/vvet/tests/module_file_test.out
@@ -2,3 +2,4 @@ cmd/tools/vvet/tests/module_file_test.vv:7: warning: Function documentation seem
 cmd/tools/vvet/tests/module_file_test.vv:13: warning: A function name is missing from the documentation of "pub fn bar() string".
 cmd/tools/vvet/tests/module_file_test.vv:35: warning: Function documentation seems to be missing for "pub fn (f Foo) foo() string".
 cmd/tools/vvet/tests/module_file_test.vv:46: warning: A function name is missing from the documentation of "pub fn (f Foo) fooo() string".
+cmd/tools/vvet/tests/module_file_test.vv:52: warning: The documentation for "pub fn (f Foo) boo() string" seems incomplete.

--- a/cmd/tools/vvet/tests/module_file_test.vv
+++ b/cmd/tools/vvet/tests/module_file_test.vv
@@ -47,3 +47,9 @@ pub fn (f Foo) fooo() string {
 	// not using convention
 	return f.fo()
 }
+
+// boo
+pub fn (f Foo) boo() string {
+	// Incomplete doc
+	return f.fo()
+}


### PR DESCRIPTION
This PR will greatly simplify the function that identifies the function names from a string.
There's also added a warning for documentation that seems incomplete.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
