### PR TITLE
parser: fix parsing interface methods with varargs

### DIFF
--- a/vlib/v/fmt/tests/interface_variadic_keep.vv
+++ b/vlib/v/fmt/tests/interface_variadic_keep.vv
@@ -1,0 +1,4 @@
+interface Element {
+	unnamed_method(...f64)
+	named_method(params ...f64)
+}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -504,9 +504,9 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		methods << method
 		// println('register method $name')
 		ts.register_method(
-			name: name,
-			params: args,
-			return_type: method.return_type,
+			name: name
+			params: args
+			return_type: method.return_type
 			is_variadic: is_variadic
 			is_pub: true
 		)

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -476,7 +476,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			return ast.InterfaceDecl{}
 		}
 		// field_names << name
-		args2, _, _ := p.fn_args() // TODO merge table.Param and ast.Arg to avoid this
+		args2, _, is_variadic := p.fn_args() // TODO merge table.Param and ast.Arg to avoid this
 		mut args := [table.Param{
 			name: 'x'
 			typ: typ
@@ -489,6 +489,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			params: args
 			file: p.file_name
 			return_type: table.void_type
+			is_variadic: is_variadic
 			is_pub: true
 			pos: method_start_pos.extend(p.prev_tok.position())
 			scope: p.scope

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -503,7 +503,13 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		method.next_comments = mnext_comments
 		methods << method
 		// println('register method $name')
-		ts.register_method(name: name, params: args, return_type: method.return_type, is_pub: true)
+		ts.register_method(
+			name: name,
+			params: args,
+			return_type: method.return_type,
+			is_variadic: is_variadic
+			is_pub: true
+		)
 	}
 	p.top_level_statement_end()
 	p.check(.rcbr)

--- a/vlib/v/tests/interface_variadic_test.v
+++ b/vlib/v/tests/interface_variadic_test.v
@@ -1,0 +1,25 @@
+interface Element {
+	method(params ...f64) string
+}
+
+struct Foo {}
+
+fn (f &Foo) method(params ...f64) string {
+	return params.str()
+}
+
+fn test_variadic_array_decompose() {
+	mut a := []Element{}
+	a << Foo{}
+
+	input := [0.0, 1.0]
+	assert a[0].method(...input) == '[0, 1]'
+	assert a[0].method(...[0.0, 1.0]) == '[0, 1]'
+}
+
+fn test_variadic_multiple_args() {
+	mut a := []Element{}
+	a << Foo{}
+
+	assert a[0].method(0.0, 1.0) == '[0, 1]'
+}


### PR DESCRIPTION
Fix parsing of interface methods with variadic number of arguments.
Add tests for both formatting and compiling (the `...` used to be removed when running vfmt).
Fixes #8225
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
