### PR TITLE
checker: make it an error to use ident outside of anon fn

### DIFF
--- a/vlib/v/checker/tests/fn_var.out
+++ b/vlib/v/checker/tests/fn_var.out
@@ -9,9 +9,10 @@ vlib/v/checker/tests/fn_var.vv:4:5: error: cannot assign to `p`: expected `&fn (
     3 | mut p := &f
     4 | p = &[f]
       |     ^
-    5 | f = fn(mut a []int) {}
-vlib/v/checker/tests/fn_var.vv:5:5: error: cannot assign to `f`: expected `fn (int) byte`, not `fn (mut []int)`
-    3 | mut p := &f
-    4 | p = &[f]
-    5 | f = fn(mut a []int) {}
-      |     ~~~~~~~~~~~~~~~~~~
+    5 | i := 0
+    6 | println(i)
+vlib/v/checker/tests/fn_var.vv:7:31: error: undefined ident: `i`
+    5 | i := 0
+    6 | println(i)
+    7 | f = fn(mut a []int) { println(i) }
+      |                               ^

--- a/vlib/v/checker/tests/fn_var.vv
+++ b/vlib/v/checker/tests/fn_var.vv
@@ -2,4 +2,6 @@ mut f := fn(i int) byte {}
 f = 4
 mut p := &f
 p = &[f]
-f = fn(mut a []int) {}
+i := 0
+println(i)
+f = fn(mut a []int) { println(i) }

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -447,6 +447,7 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 		return ast.AnonFn{}
 	}
 	p.open_scope()
+	p.scope.detached_from_parent = true
 	// TODO generics
 	args, _, is_variadic := p.fn_args()
 	for arg in args {


### PR DESCRIPTION
For now, using ident outside of anon fn is a c error not a checker error

```
fn f(n int, f1 fn (int) int) int {
        return f1(n)
}

fn main() {
        i := 0
        println(f(0, fn(n int) int { return i + n }))
}
```

```
==================
/tmp/v/closure.7790661414057867230.tmp.c:1473:10: error: use of undeclared identifier 'i'
                return i + n;
                       ^
1 error generated.
...
==================
(Use `v -cg` to print the entire error message)

builder error:
==================
C error. This should never happen.
```

This PR make it a checker error

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
