### PR TITLE
v.util: fix bug of mod_path_to_full_name

### DIFF
--- a/vlib/v/util/module.v
+++ b/vlib/v/util/module.v
@@ -90,18 +90,17 @@ pub fn mod_path_to_full_name(mod string, path string) ?string {
 					if ls := os.ls(parent) {
 						// currently CI clones some modules into the v repo to test, the condition
 						// after `'v.mod' in ls` can be removed once a proper solution is added
-						if try_path_parts.len <= i {
-							continue
-						}
-						if 'v.mod' in ls && try_path_parts[i] != 'v' && 'vlib' !in ls {
+						if 'v.mod' in ls &&
+							(try_path_parts.len > i && try_path_parts[i] != 'v' && 'vlib' !in ls)
+						{
 							last_v_mod = j
-							continue
 						}
+						continue
 					}
 					break
 				}
 				if last_v_mod > -1 {
-					mod_full_name := try_path_parts[last_v_mod - 1..].join('.')
+					mod_full_name := try_path_parts[last_v_mod..].join('.')
 					return mod_full_name
 				}
 			}


### PR DESCRIPTION
```
$ tree .
.
├── i1
│   └── i2
│       └── i2.v
├── main.v
└── v.mod
$ cat main.v
import i1.i2
```

```
$ v .
./main.v:1:8: warning: module 'i2 (i1.i2)' is imported but never used
    1 | import i1.i2
      |        ~~~~~
builder error: bad module definition: ./main.v imports module "i1.i2" but /home/zakuro/src/github.com/zakuro9715/vvv/i1/i2/i2.v is defined as module `i2`
```

This PR fix this.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
