### PR TITLE
array: fix array_clone (fix #8220)

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -346,16 +346,24 @@ pub fn (a &array) clone() array {
 	// Recursively clone-generated elements if array element is array type
 	size_of_array := int(sizeof(array))
 	if a.element_size == size_of_array {
+		mut is_elem_array := true
 		for i in 0 .. a.len {
 			ar := array{}
 			unsafe { C.memcpy(&ar, a.get_unsafe(i), size_of_array) }
+			if ar.len > ar.cap || ar.cap <= 0 || ar.element_size <= 0 {
+				is_elem_array = false
+				break
+			}
 			ar_clone := ar.clone()
 			unsafe { arr.set_unsafe(i, &ar_clone) }
 		}
-	} else {
-		if !isnil(a.data) {
-			unsafe { C.memcpy(byteptr(arr.data), a.data, a.cap * a.element_size) }
+		if is_elem_array {
+			return arr
 		}
+	}
+
+	if !isnil(a.data) {
+		unsafe { C.memcpy(byteptr(arr.data), a.data, a.cap * a.element_size) }
 	}
 	return arr
 }

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1345,7 +1345,7 @@ fn test_multi_fixed_array_with_default_init() {
 }
 
 struct Abc {
-	mut:
+mut:
 	x i64
 	y i64
 	z i64
@@ -1353,9 +1353,8 @@ struct Abc {
 
 fn test_clone_of_same_elem_size_array() {
 	mut arr := []Abc{}
-	arr << Abc{1,2,3}
-	arr << Abc{2,3,4}
-
+	arr << Abc{1, 2, 3}
+	arr << Abc{2, 3, 4}
 	arr2 := arr.clone()
 	println(arr2)
 	assert arr2 == [Abc{1, 2, 3}, Abc{2, 3, 4}]

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1343,3 +1343,20 @@ fn test_multi_fixed_array_with_default_init() {
 	println(a)
 	assert a == [[10, 10, 10]!, [10, 10, 10]!, [10, 10, 10]!]!
 }
+
+struct Abc {
+	mut:
+	x i64
+	y i64
+	z i64
+}
+
+fn test_clone_of_same_elem_size_array() {
+	mut arr := []Abc{}
+	arr << Abc{1,2,3}
+	arr << Abc{2,3,4}
+
+	arr2 := arr.clone()
+	println(arr2)
+	assert arr2 == [Abc{1, 2, 3}, Abc{2, 3, 4}]
+}


### PR DESCRIPTION
This PR fix array_clone (fix #8220).

- Fix array_clone.
- Add test.

```vlang
struct Abc {
	mut:
	x i64
	y i64
	z i64
}
fn main() {
	mut arr := []Abc{}
	arr << Abc{1,2,3}
	arr << Abc{2,3,4}
	arr << Abc{3,4,5}
	arr << Abc{4,5,6}
	arr << Abc{5,6,7}

	mut arr2 := arr.clone()
	println(arr)
	println(arr2)
}

PS D:\Test\v\tt1> v run .
[Abc{
    x: 1
    y: 2
    z: 3
}, Abc{
    x: 2
    y: 3
    z: 4
}, Abc{
    x: 3
    y: 4
    z: 5
}, Abc{
    x: 4
    y: 5
    z: 6
}, Abc{
    x: 5
    y: 6
    z: 7
}]
[Abc{
    x: 1
    y: 2
    z: 3
}, Abc{
    x: 2
    y: 3
    z: 4
}, Abc{
    x: 3
    y: 4
    z: 5
}, Abc{
    x: 4
    y: 5
    z: 6
}, Abc{
    x: 5
    y: 6
    z: 7
}]
```