### PR TITLE
cgen: support explicit array handling even in [direct_array_access] functions

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -4105,7 +4105,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 							g.write('.val')
 						}
 					}
-					if is_direct_array_access {
+					if is_direct_array_access && !gen_or {
 						if left_is_ptr && !node.left_type.has_flag(.shared_f) {
 							g.write('->')
 						} else {

--- a/vlib/v/tests/array_map_or_test.v
+++ b/vlib/v/tests/array_map_or_test.v
@@ -14,6 +14,23 @@ fn test_array_or() {
 	assert good == 4
 }
 
+[direct_array_access]
+fn test_array_or_direct() {
+	m := [3, 4, 5]
+	mut testvar := 17
+	el := m[4] or {
+		testvar = -43
+		999
+	}
+	good := m[1] or {
+		testvar = 11
+		0
+	}
+	assert testvar == -43
+	assert el == 999
+	assert good == 4
+}
+
 fn test_map_or() {
 	m := {
 		'as': 3
@@ -47,6 +64,13 @@ fn get_arr_el(i int) ?int {
 	return r
 }
 
+[direct_array_access]
+fn get_arr_el_direct(i int) ?int {
+	m := [3, 4, 5]
+	r := m[i] ?
+	return r
+}
+
 fn test_propagation() {
 	mut testvar1 := 12
 	mut testvar2 := 78
@@ -66,12 +90,20 @@ fn test_propagation() {
 		testvar2 = 177
 		int(-67)
 	}
+	m := get_arr_el_direct(3) or {
+		17
+	}
+	n := get_arr_el_direct(0) or {
+		int(-73)
+	}
 	assert testvar1 == -34
 	assert testvar2 == 99
 	assert e == 7
 	assert f == 3
 	assert g == 12
 	assert h == 3
+	assert m == 17
+	assert n == 3
 }
 
 fn get_arr_el_nested(i int) ?int {


### PR DESCRIPTION
This allows
```v
x := a[i] or { ... }
y := b[j] ?
```
to be used even in functions that were declared with `[direct_array_access]`.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
