### PR TITLE
cgen: fix innermost value of map fixed array (fix #8214)

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2005,6 +2005,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					}
 				}
 			}
+			g.is_assign_lhs = false
 		} else {
 			is_inside_ternary := g.inside_ternary != 0
 			cur_line := if is_inside_ternary && is_decl {

--- a/vlib/v/tests/map_complex_fixed_array_test.v
+++ b/vlib/v/tests/map_complex_fixed_array_test.v
@@ -13,7 +13,7 @@ fn test_innermost_value_of_map_fixed_array() {
 	mut m := map[string][1][2]map[string]int
 	m['foo'] = [[{'bar': 1}, {'baz': 3}]!]!
 	println(m['foo'][0][0]['bar'])
-    println(m['foo'][0][0]['bar'] == 1)
+	println(m['foo'][0][0]['bar'] == 1)
 	assert m['foo'][0][0]['bar'] == 1
 	assert '${m['foo'][0][0]['bar']}' == '1'
 }

--- a/vlib/v/tests/map_complex_fixed_array_test.v
+++ b/vlib/v/tests/map_complex_fixed_array_test.v
@@ -8,3 +8,12 @@ fn test_complex_map_fixed_array() {
 	println(m)
 	assert '$m' == "{'foo': [[{'bar': 1}, {'baz': 3}]]}"
 }
+
+fn test_innermost_value_of_map_fixed_array() {
+	mut m := map[string][1][2]map[string]int
+	m['foo'] = [[{'bar': 1}, {'baz': 3}]!]!
+	println(m['foo'][0][0]['bar'])
+    println(m['foo'][0][0]['bar'] == 1)
+	assert m['foo'][0][0]['bar'] == 1
+	assert '${m['foo'][0][0]['bar']}' == '1'
+}


### PR DESCRIPTION
This PR fix innermost value of map fixed array (fix #8214).

- Fix innermost value of map fixed array.
- Add test.

```vlang
fn main() {
	mut m := map[string][1][2]map[string]int{}
	m['foo'] = [[{'bar': 1}, {'baz': 3}]!]!
	println(m['foo'][0][0]['bar'])
	println(m['foo'][0][0]['bar'] == 1)
}

PS D:\Test\v\tt1> v run .
1
true
```