### PR TITLE
crypto: make Digest.sum() and Digest.write() private in md5 and sha1

### DIFF
--- a/vlib/crypto/md5/md5.v
+++ b/vlib/crypto/md5/md5.v
@@ -51,7 +51,7 @@ pub fn new() &Digest {
 	return d
 }
 
-pub fn (mut d Digest) write(p_ []byte) int {
+fn (mut d Digest) write(p_ []byte) int {
 	unsafe {
 		mut p := p_
 		nn := p.len
@@ -85,7 +85,7 @@ pub fn (mut d Digest) write(p_ []byte) int {
 	}
 }
 
-pub fn (d &Digest) sum(b_in []byte) []byte {
+fn (d &Digest) sum(b_in []byte) []byte {
 	// Make a copy of d so that caller can keep writing and summing.
 	mut d0 := *d
 	hash := d0.checksum()

--- a/vlib/crypto/sha1/sha1.v
+++ b/vlib/crypto/sha1/sha1.v
@@ -55,7 +55,7 @@ pub fn new() &Digest {
 }
 
 [manualfree]
-pub fn (mut d Digest) write(p_ []byte) int {
+fn (mut d Digest) write(p_ []byte) int {
 	nn := p_.len
 	unsafe {
 		mut p := p_
@@ -89,7 +89,7 @@ pub fn (mut d Digest) write(p_ []byte) int {
 	return nn
 }
 
-pub fn (d &Digest) sum(b_in []byte) []byte {
+fn (d &Digest) sum(b_in []byte) []byte {
 	// Make a copy of d so that caller can keep writing and summing.
 	mut d0 := *d
 	hash := d0.checksum()


### PR DESCRIPTION
Make `Digest` methods `sum()` and `write()` private.
These looked like typos or copy-paste accidents as they touch internal state of the struct.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
