### PR TITLE
checker: check for mut val in immutable obj

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3094,17 +3094,18 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 								if node.cond.obj is ast.Var {
 									obj := node.cond.obj as ast.Var
 									if !obj.is_mut {
-										c.error('`$obj.name` is immutable, cannot mutated',
+										c.error('`$obj.name` is immutable, it cannot be changed',
 											node.cond.pos)
 									}
 								}
 							}
 							ast.ArrayInit {
-								c.error('array literal is immutable, cannot mutated',
+								c.error('array literal is immutable, it cannot be changed',
 									node.cond.pos)
 							}
 							ast.MapInit {
-								c.error('map literal is immutable, cannot mutated', node.cond.pos)
+								c.error('map literal is immutable, it cannot be changed',
+									node.cond.pos)
 							}
 							else {}
 						}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3089,6 +3089,25 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 					}
 					if node.val_is_mut {
 						value_type = value_type.to_ptr()
+						match node.cond {
+							ast.Ident {
+								if node.cond.obj is ast.Var {
+									obj := node.cond.obj as ast.Var
+									if !obj.is_mut {
+										c.error('`$obj.name` is immutable, cannot mutated',
+											node.cond.pos)
+									}
+								}
+							}
+							ast.ArrayInit {
+								c.error('array literal is immutable, cannot mutated',
+									node.cond.pos)
+							}
+							ast.MapInit {
+								c.error('map literal is immutable, cannot mutated', node.cond.pos)
+							}
+							else {}
+						}
 					}
 					node.cond_type = typ
 					node.kind = sym.kind

--- a/vlib/v/checker/tests/for_in_mut_val_type.out
+++ b/vlib/v/checker/tests/for_in_mut_val_type.out
@@ -1,39 +1,39 @@
-vlib/v/checker/tests/for_in_mut_val_type.vv:3:15: error: `a1` is immutable, cannot mutated
+vlib/v/checker/tests/for_in_mut_val_type.vv:3:15: error: `a1` is immutable, it cannot be changed
     1 | fn main() {
     2 |     a1 := [1, 2, 3]
     3 |     for mut j in a1 {
       |                  ~~
     4 |         j *= 2
     5 |     }
-vlib/v/checker/tests/for_in_mut_val_type.vv:7:15: error: `a2` is immutable, cannot mutated
+vlib/v/checker/tests/for_in_mut_val_type.vv:7:15: error: `a2` is immutable, it cannot be changed
     5 |     }
     6 |     a2 := [1, 2, 3]!
     7 |     for mut j in a2 {
       |                  ~~
     8 |         j *= 2
     9 |     }
-vlib/v/checker/tests/for_in_mut_val_type.vv:11:18: error: `m` is immutable, cannot mutated
+vlib/v/checker/tests/for_in_mut_val_type.vv:11:18: error: `m` is immutable, it cannot be changed
     9 |     }
    10 |     m := {'aa': 1, 'bb': 2}
    11 |     for _, mut j in m {
       |                     ^
    12 |         j *= 2
    13 |     }
-vlib/v/checker/tests/for_in_mut_val_type.vv:14:15: error: array literal is immutable, cannot mutated
+vlib/v/checker/tests/for_in_mut_val_type.vv:14:15: error: array literal is immutable, it cannot be changed
    12 |         j *= 2
    13 |     }
    14 |     for mut j in [1, 2, 3] {
       |                  ~~~~~~~~~
    15 |         j *= 2
    16 |     }
-vlib/v/checker/tests/for_in_mut_val_type.vv:17:15: error: array literal is immutable, cannot mutated
+vlib/v/checker/tests/for_in_mut_val_type.vv:17:15: error: array literal is immutable, it cannot be changed
    15 |         j *= 2
    16 |     }
    17 |     for mut j in [1, 2, 3]! {
       |                  ~~~~~~~~~~
    18 |         j *= 2
    19 |     }
-vlib/v/checker/tests/for_in_mut_val_type.vv:20:19: error: map literal is immutable, cannot mutated
+vlib/v/checker/tests/for_in_mut_val_type.vv:20:19: error: map literal is immutable, it cannot be changed
    18 |         j *= 2
    19 |     }
    20 |     for _, mut j in {'aa': 1, 'bb': 2} {

--- a/vlib/v/checker/tests/for_in_mut_val_type.out
+++ b/vlib/v/checker/tests/for_in_mut_val_type.out
@@ -1,0 +1,42 @@
+vlib/v/checker/tests/for_in_mut_val_type.vv:3:15: error: `a1` is immutable, cannot mutated
+    1 | fn main() {
+    2 |     a1 := [1, 2, 3]
+    3 |     for mut j in a1 {
+      |                  ~~
+    4 |         j *= 2
+    5 |     }
+vlib/v/checker/tests/for_in_mut_val_type.vv:7:15: error: `a2` is immutable, cannot mutated
+    5 |     }
+    6 |     a2 := [1, 2, 3]!
+    7 |     for mut j in a2 {
+      |                  ~~
+    8 |         j *= 2
+    9 |     }
+vlib/v/checker/tests/for_in_mut_val_type.vv:11:18: error: `m` is immutable, cannot mutated
+    9 |     }
+   10 |     m := {'aa': 1, 'bb': 2}
+   11 |     for _, mut j in m {
+      |                     ^
+   12 |         j *= 2
+   13 |     }
+vlib/v/checker/tests/for_in_mut_val_type.vv:14:15: error: array literal is immutable, cannot mutated
+   12 |         j *= 2
+   13 |     }
+   14 |     for mut j in [1, 2, 3] {
+      |                  ~~~~~~~~~
+   15 |         j *= 2
+   16 |     }
+vlib/v/checker/tests/for_in_mut_val_type.vv:17:15: error: array literal is immutable, cannot mutated
+   15 |         j *= 2
+   16 |     }
+   17 |     for mut j in [1, 2, 3]! {
+      |                  ~~~~~~~~~~
+   18 |         j *= 2
+   19 |     }
+vlib/v/checker/tests/for_in_mut_val_type.vv:20:19: error: map literal is immutable, cannot mutated
+   18 |         j *= 2
+   19 |     }
+   20 |     for _, mut j in {'aa': 1, 'bb': 2} {
+      |                      ~~~~
+   21 |         j *= 2
+   22 |     }

--- a/vlib/v/checker/tests/for_in_mut_val_type.vv
+++ b/vlib/v/checker/tests/for_in_mut_val_type.vv
@@ -1,0 +1,23 @@
+fn main() {
+	a1 := [1, 2, 3]
+	for mut j in a1 {
+		j *= 2
+	}
+	a2 := [1, 2, 3]!
+	for mut j in a2 {
+		j *= 2
+	}
+	m := {'aa': 1, 'bb': 2}
+	for _, mut j in m {
+		j *= 2
+	}
+	for mut j in [1, 2, 3] {
+		j *= 2
+	}
+	for mut j in [1, 2, 3]! {
+		j *= 2
+	}
+	for _, mut j in {'aa': 1, 'bb': 2} {
+		j *= 2
+	}
+}


### PR DESCRIPTION
This PR check for mut val in immutable obj.

- Check for mut val in immutable obj.
- Add tests.

```vlang
fn main() {
	a1 := [1, 2, 3]
	for mut j in a1 {
		j *= 2
	}
	a2 := [1, 2, 3]!
	for mut j in a2 {
		j *= 2
	}
	m := {'aa': 1, 'bb': 2}
	for _, mut j in m {
		j *= 2
	}
	for mut j in [1, 2, 3] {
		j *= 2
	}
	for mut j in [1, 2, 3]! {
		j *= 2
	}
	for _, mut j in {'aa': 1, 'bb': 2} {
		j *= 2
	}
}

vlib/v/checker/tests/for_in_mut_val_type.vv:3:15: error: `a1` is immutable, it cannot be changed
    1 | fn main() {
    2 |     a1 := [1, 2, 3]
    3 |     for mut j in a1 {
      |                  ~~
    4 |         j *= 2
    5 |     }
vlib/v/checker/tests/for_in_mut_val_type.vv:7:15: error: `a2` is immutable, it cannot be changed
    5 |     }
    6 |     a2 := [1, 2, 3]!
    7 |     for mut j in a2 {
      |                  ~~
    8 |         j *= 2
    9 |     }
vlib/v/checker/tests/for_in_mut_val_type.vv:11:18: error: `m` is immutable, it cannot be changed
    9 |     }
   10 |     m := {'aa': 1, 'bb': 2}
   11 |     for _, mut j in m {
      |                     ^
   12 |         j *= 2
   13 |     }
vlib/v/checker/tests/for_in_mut_val_type.vv:14:15: error: array literal is immutable, it cannot be changed
   12 |         j *= 2
   13 |     }
   14 |     for mut j in [1, 2, 3] {
      |                  ~~~~~~~~~
   15 |         j *= 2
   16 |     }
vlib/v/checker/tests/for_in_mut_val_type.vv:17:15: error: array literal is immutable, it cannot be changed
   15 |         j *= 2
   16 |     }
   17 |     for mut j in [1, 2, 3]! {
      |                  ~~~~~~~~~~
   18 |         j *= 2
   19 |     }
vlib/v/checker/tests/for_in_mut_val_type.vv:20:19: error: map literal is immutable, it cannot be changed
   18 |         j *= 2
   19 |     }
   20 |     for _, mut j in {'aa': 1, 'bb': 2} {
      |                      ~~~~
   21 |         j *= 2
   22 |     }
```