### PR TITLE
fmt: keep `arr << if x {} else {}` on a single line

### DIFF
--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -201,11 +201,7 @@ fn (mut vd VDoc) create_search_results(mod string, dn doc.DocNode, out Output) {
 	dn_description := trim_doc_node_description(comments)
 	vd.search_index << dn.name
 	vd.search_data << SearchResult{
-		prefix: if dn.parent_name != '' {
-			'$dn.kind ($dn.parent_name)'
-		} else {
-			'$dn.kind '
-		}
+		prefix: if dn.parent_name != '' { '$dn.kind ($dn.parent_name)' } else { '$dn.kind ' }
 		description: dn_description
 		badge: mod
 		link: vd.get_file_name(mod, out) + '#' + get_node_id(dn)

--- a/vlib/v/fmt/tests/assign_keep.vv
+++ b/vlib/v/fmt/tests/assign_keep.vv
@@ -1,3 +1,0 @@
-a, b := if true { 'a', 'b' } else { 'b', 'a' }
-println(a)
-println(b)

--- a/vlib/v/fmt/tests/if_keep.vv
+++ b/vlib/v/fmt/tests/if_keep.vv
@@ -17,5 +17,4 @@ fn main() {
 			x: 5
 		}
 	}
-	_ := if false { Foo{} } else { Foo{5, 6} }
 }

--- a/vlib/v/fmt/tests/if_single_line_keep.vv
+++ b/vlib/v/fmt/tests/if_single_line_keep.vv
@@ -1,0 +1,4 @@
+a, b := if true { 'a', 'b' } else { 'b', 'a' }
+_ := if false { Foo{} } else { Foo{5, 6} }
+arr := [0, 1]
+arr << if true { 2 } else { 3 }

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -273,16 +273,8 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 				typ: typ
 				default_expr: ast.ex2fe(default_expr)
 				has_default_expr: has_default_expr
-				is_pub: if is_embed {
-					true
-				} else {
-					is_field_pub
-				}
-				is_mut: if is_embed {
-					true
-				} else {
-					is_field_mut
-				}
+				is_pub: if is_embed { true } else { is_field_pub }
+				is_mut: if is_embed { true } else { is_field_mut }
 				is_global: is_field_global
 				attrs: p.attrs
 			}


### PR DESCRIPTION
```v
arr << if true { 2 } else { 3 }
```
instead of
```v
arr << if true { 
    2 
} else { 
    3 
}
```