### PR TITLE
pkgconfig: fix pkgconfig.v for homebrew

### DIFF
--- a/vlib/v/pkgconfig/pkgconfig.v
+++ b/vlib/v/pkgconfig/pkgconfig.v
@@ -136,13 +136,19 @@ fn (mut pc PkgConfig) parse(file string) bool {
 }
 
 fn (mut pc PkgConfig) resolve(pkgname string) ?string {
-	if pc.paths.len == 0 {
-		pc.paths << '.'
-	}
-	for path in pc.paths {
-		file := '$path/${pkgname}.pc'
-		if os.exists(file) {
-			return file
+	if pkgname.ends_with('.pc') {
+		if os.exists(pkgname) {
+			return pkgname
+		}
+	} else {
+		if pc.paths.len == 0 {
+			pc.paths << '.'
+		}
+		for path in pc.paths {
+			file := '$path/${pkgname}.pc'
+			if os.exists(file) {
+				return file
+			}
 		}
 	}
 	return error('Cannot find "$pkgname" pkgconfig file')


### PR DESCRIPTION
This fix allows pkgconfig.v to resolve properly the following line in the file `/usr/local/lib/pkgconfig/gobject-2.0.pc` provided by the homebrew.
```
Requires.private: /usr/local/opt/libffi/lib/pkgconfig/libffi.pc >=  3.0.0
```
This was required for me to make the project `vgtk/vgtk3` working properly on my macOS. 
