### PR TITLE
checker: allow `a[i]` for `shared` arrays outside `unsafe`

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4940,7 +4940,7 @@ pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) table.Type {
 			if node.left.obj is ast.Var {
 				v := node.left.obj as ast.Var
 				// `mut param []T` function parameter
-				is_ok = v.is_mut && v.is_arg && !typ.deref().is_ptr()
+				is_ok = ((v.is_mut && v.is_arg) || v.share == .shared_t) && !typ.deref().is_ptr()
 			}
 		}
 		if !is_ok && !c.pref.translated {

--- a/vlib/v/tests/shared_array_test.v
+++ b/vlib/v/tests/shared_array_test.v
@@ -19,19 +19,14 @@ fn test_shared_array() {
 	go incr(shared foo, 1)
 	for _ in 0 .. 50000 {
 		lock foo {
-			unsafe {
-				foo[0] -= 2
-				foo[1] += 3
-			}
+			foo[0] -= 2
+			foo[1] += 3
 		}
 	}
 	mut finished_threads := 0
 	for {
 		rlock foo {
-			finished_threads = unsafe {
-				foo[2]
-			}
-
+			finished_threads = foo[2]
 		}
 		if finished_threads == 4 {
 			break
@@ -39,14 +34,8 @@ fn test_shared_array() {
 		time.sleep_ms(100)
 	}
 	rlock foo {
-		f0 := unsafe {
-			foo[0]
-		}
-
-		f1 := unsafe {
-			foo[1]
-		}
-
+		f0 := foo[0]
+		f1 := foo[1]
 		assert f0 == 100010
 		assert f1 == 350020
 	}

--- a/vlib/v/tests/shared_map_test.v
+++ b/vlib/v/tests/shared_map_test.v
@@ -12,9 +12,7 @@ fn incr(shared foo map[string]int, key string, sem sync.Semaphore) {
 fn test_shared_array() {
 	shared foo := &{'p': 10, 'q': 0}
 	lock foo {
-		unsafe {
-			foo['q'] = 20
-		}
+		foo['q'] = 20
 	}
 	sem := sync.new_semaphore()
 	go incr(shared foo, 'p', sem)
@@ -23,18 +21,16 @@ fn test_shared_array() {
 	go incr(shared foo, 'q', sem)
 	for _ in 0 .. 50000 {
 		lock foo {
-			unsafe {
-				foo['p'] -= 2
-				foo['q'] += 3
-			}
+			foo['p'] -= 2
+			foo['q'] += 3
 		}
 	}
 	for _ in 0..4 {
 		sem.wait()
 	}
 	rlock foo {
-		fp := unsafe { foo['p'] }
-		fq := unsafe { foo['q'] }
+		fp := foo['p']
+		fq := foo['q']
 		assert fp == 100010
 		assert fq == 350020
 	}


### PR DESCRIPTION
Due to more restrictive pointer dereferencing checks it had become necessary to put index expressions for shared arrays and maps inside `unsafe` blocks (see 276c1de). This PR relaxes those checks to allow things like
```v
shared a := &[1, 5, 7]
...
lock a {
    a[1] = 5
    b := a[0]
}
``` 
without `unsafe`, again.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
