### PR TITLE
parser: fix map_init position

### DIFF
--- a/vlib/v/checker/tests/for_in_mut_val_type.out
+++ b/vlib/v/checker/tests/for_in_mut_val_type.out
@@ -33,10 +33,10 @@ vlib/v/checker/tests/for_in_mut_val_type.vv:17:15: error: array literal is immut
       |                  ~~~~~~~~~~
    18 |         j *= 2
    19 |     }
-vlib/v/checker/tests/for_in_mut_val_type.vv:20:19: error: map literal is immutable, it cannot be changed
+vlib/v/checker/tests/for_in_mut_val_type.vv:20:18: error: map literal is immutable, it cannot be changed
    18 |         j *= 2
    19 |     }
    20 |     for _, mut j in {'aa': 1, 'bb': 2} {
-      |                      ~~~~
+      |                     ~~~~~~~~~~~~~~~~~~
    21 |         j *= 2
    22 |     }

--- a/vlib/v/checker/tests/map_init_wrong_type.out
+++ b/vlib/v/checker/tests/map_init_wrong_type.out
@@ -1,8 +1,8 @@
-vlib/v/checker/tests/map_init_wrong_type.vv:3:10: error: cannot assign to `a`: expected `map[string]f32`, not `map[string]f64`
+vlib/v/checker/tests/map_init_wrong_type.vv:3:8: error: cannot assign to `a`: expected `map[string]f32`, not `map[string]f64`
     1 | fn main() {
     2 |    mut a := map[string]f32{}
     3 |    a = { 'x': 12.3 }
-      |          ~~~
+      |        ~~~~~~~~~~~~~
     4 |    _ = {2:0 3:0 "hi":0}
     5 |    _ = {2:0 3:`@` 4:0}
 vlib/v/checker/tests/map_init_wrong_type.vv:4:17: error: invalid map key: expected `int`, not `string`

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -151,7 +151,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 }
 
 fn (mut p Parser) map_init() ast.MapInit {
-	mut pos := p.tok.position()
+	first_pos := p.prev_tok.position()
 	mut keys := []ast.Expr{}
 	mut vals := []ast.Expr{}
 	for p.tok.kind != .rcbr && p.tok.kind != .eof {
@@ -167,10 +167,9 @@ fn (mut p Parser) map_init() ast.MapInit {
 			p.next()
 		}
 	}
-	pos.update_last_line(p.tok.line_nr)
 	return ast.MapInit{
 		keys: keys
 		vals: vals
-		pos: pos
+		pos: first_pos.extend_with_last_line(p.tok.position(), p.tok.line_nr)
 	}
 }


### PR DESCRIPTION
This PR fix map_init position.

- Fix map_init position.
- Modify tests.

- Before
```vlang
module main

fn main() {
	for _, mut j in {'aa': 1, 'bb': 2} {
		j *= 2
	}
}

.\tt1.v:4:18: error: map literal is immutable, it cannot be changed
    2 | 
    3 | fn main() {
    4 |     for _, mut j in {'aa': 1, 'bb': 2} {
      |                       ~~
    5 |         j *= 2
    6 |     }
```
- Now
```vlang
module main

fn main() {
	for _, mut j in {'aa': 1, 'bb': 2} {
		j *= 2
	}
}

.\tt1.v:4:18: error: map literal is immutable, it cannot be changed
    2 | 
    3 | fn main() {
    4 |     for _, mut j in {'aa': 1, 'bb': 2} {
      |                     ~~~~~~~~~~~~~~~~~~
    5 |         j *= 2
    6 |     }
```