### PR TITLE
parser: auto-import `sync` when `shared` objects are used

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1034,6 +1034,9 @@ pub fn (mut p Parser) parse_ident(language table.Language) ast.Ident {
 	// p.warn('name ')
 	is_shared := p.tok.kind == .key_shared
 	is_atomic := p.tok.kind == .key_atomic
+	if is_shared {
+		p.register_auto_import('sync')
+	}
 	mut_pos := p.tok.position()
 	is_mut := p.tok.kind == .key_mut || is_shared || is_atomic
 	if is_mut {

--- a/vlib/v/tests/shared_autolock_test.v
+++ b/vlib/v/tests/shared_autolock_test.v
@@ -1,0 +1,34 @@
+const iterations = 100000
+
+fn inc_array_elem(shared b []int, i int) {
+	for _ in 0 .. iterations {
+		b[i]++
+	}
+}
+
+fn test_autolock_array() {
+	shared a := &[1, 2, 7, 5]
+	t := go inc_array_elem(shared a, 2)
+	for _ in 0 .. iterations {
+		a[2]++
+	}
+	t.wait()
+	assert a[2] == 2 * iterations + 7
+}
+
+fn inc_map_elem(shared b map[string]int, k string) {
+	for _ in 0 .. iterations {
+		b[k]++
+	}
+}
+
+fn test_autolock_map() {
+	shared m := &{'xy': 1, 'qwe': 2, 'asd': 7, 'iop': 5}
+	t := go inc_map_elem(shared m, 'asd')
+	for _ in 0 .. iterations {
+		m['asd']++
+	}
+	t.wait()
+	assert m['asd'] == 2 * iterations + 7
+}
+


### PR DESCRIPTION
The `sync` module is automatically imported, when channel operations are used.
However, `shared` objects have a hidden `sync.RwMutex` and thus need this module, too (even though there is no `sync` token anywhere in the code).
This PR adds an auto-import of `sync` when `shared` objects are used.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
