### PR TITLE
Small fix for #8297 - Typo in math.fractions

### DIFF
--- a/vlib/math/fractions/fraction.v
+++ b/vlib/math/fractions/fraction.v
@@ -129,7 +129,7 @@ pub fn (f1 Fraction) *(f2 Fraction) Fraction {
 // Fraction divide using operator overloading
 pub fn (f1 Fraction) /(f2 Fraction) Fraction {
 	if f2.n == 0 {
-		panic('Cannot divive by zero')
+		panic('Cannot divide by zero')
 	}
 	// If the second fraction is negative, it will
 	// mess up the sign. We need positive denominator


### PR DESCRIPTION
Quick fix via the web editor :-)
