### PR TITLE
parser: assure explicit `map` init contains no parameters

### DIFF
--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -90,6 +90,10 @@ pub fn (mut p Parser) parse_map_type() table.Type {
 		// error is reported in parse_type
 		return 0
 	}
+	if value_type.idx() == table.void_type_idx {
+		p.error_with_pos('map value type cannot be void', p.tok.position())
+		return 0
+	}
 	idx := p.table.find_or_register_map(key_type, value_type)
 	return table.new_type(idx)
 }

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1145,7 +1145,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 			if p.tok.kind == .rcbr {
 				p.next()
 			} else {
-				p.error('`}` expected - explicit `map` initialization does not support parameters')
+				p.error('`}` expected, explicit `map` initialization does not support parameters')
 			}
 		}
 		return ast.MapInit{

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1145,7 +1145,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 			if p.tok.kind == .rcbr {
 				p.next()
 			} else {
-				p.error('`}` expected, explicit `map` initialization does not support parameters')
+				p.error('`}` expected; explicit `map` initialization does not support parameters')
 			}
 		}
 		return ast.MapInit{

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1140,9 +1140,13 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 	// `map[string]int` initialization
 	if p.tok.lit == 'map' && p.peek_tok.kind == .lsbr {
 		map_type := p.parse_map_type()
-		if p.tok.kind == .lcbr && p.peek_tok.kind == .rcbr {
+		if p.tok.kind == .lcbr {
 			p.next()
-			p.next()
+			if p.tok.kind == .rcbr {
+				p.next()
+			} else {
+				p.error('`}` expected - explicit `map` initialization does not support parameters')
+			}
 		}
 		return ast.MapInit{
 			typ: map_type

--- a/vlib/v/parser/tests/map_init.out
+++ b/vlib/v/parser/tests/map_init.out
@@ -1,6 +1,6 @@
-vlib/v/parser/tests/map_init.vv:3:19: error: `}` expected; explicit `map` initialization does not support parameters
+vlib/v/parser/tests/map_init.vv:3:22: error: `}` expected; explicit `map` initialization does not support parameters
     1 | fn main() {
-    2 |     a := map[string]{}
-    3 |     b := map[string]{cap: 10}
-      |                      ~~~
+    2 |     a := map[string]int{}
+    3 |     b := map[string]f64{cap: 10}
+      |                         ~~~
     4 | }

--- a/vlib/v/parser/tests/map_init.out
+++ b/vlib/v/parser/tests/map_init.out
@@ -1,4 +1,4 @@
-vlib/v/parser/tests/map_init.vv:3:19: error: `}` expected - explicit `map` initialization does not support parameters
+vlib/v/parser/tests/map_init.vv:3:19: error: `}` expected, explicit `map` initialization does not support parameters
     1 | fn main() {
     2 |     a := map[string]{}
     3 |     b := map[string]{cap: 10}

--- a/vlib/v/parser/tests/map_init.out
+++ b/vlib/v/parser/tests/map_init.out
@@ -1,0 +1,6 @@
+vlib/v/parser/tests/map_init.vv:3:19: error: `}` expected - explicit `map` initialization does not support parameters
+    1 | fn main() {
+    2 |     a := map[string]{}
+    3 |     b := map[string]{cap: 10}
+      |                      ~~~
+    4 | }

--- a/vlib/v/parser/tests/map_init.out
+++ b/vlib/v/parser/tests/map_init.out
@@ -1,4 +1,4 @@
-vlib/v/parser/tests/map_init.vv:3:19: error: `}` expected, explicit `map` initialization does not support parameters
+vlib/v/parser/tests/map_init.vv:3:19: error: `}` expected; explicit `map` initialization does not support parameters
     1 | fn main() {
     2 |     a := map[string]{}
     3 |     b := map[string]{cap: 10}

--- a/vlib/v/parser/tests/map_init.vv
+++ b/vlib/v/parser/tests/map_init.vv
@@ -1,4 +1,4 @@
 fn main() {
-	a := map[string]{}
-	b := map[string]{cap: 10}
+	a := map[string]int{}
+	b := map[string]f64{cap: 10}
 }

--- a/vlib/v/parser/tests/map_init.vv
+++ b/vlib/v/parser/tests/map_init.vv
@@ -1,0 +1,4 @@
+fn main() {
+	a := map[string]{}
+	b := map[string]{cap: 10}
+}

--- a/vlib/v/parser/tests/map_init_void.out
+++ b/vlib/v/parser/tests/map_init_void.out
@@ -1,0 +1,5 @@
+vlib/v/parser/tests/map_init_void.vv:2:18: error: map value type cannot be void
+    1 | fn main() {
+    2 |     m := map[string]{}
+      |                     ^
+    3 | }

--- a/vlib/v/parser/tests/map_init_void.vv
+++ b/vlib/v/parser/tests/map_init_void.vv
@@ -1,0 +1,3 @@
+fn main() {
+	m := map[string]{}
+}

--- a/vlib/v/parser/tests/map_init_void2.out
+++ b/vlib/v/parser/tests/map_init_void2.out
@@ -1,0 +1,5 @@
+vlib/v/parser/tests/map_init_void2.vv:1:19: error: expecting type declaration
+    1 | fn f(m map[string]) {
+      |                   ^
+    2 |     println('illegal function')
+    3 | }

--- a/vlib/v/parser/tests/map_init_void2.vv
+++ b/vlib/v/parser/tests/map_init_void2.vv
@@ -1,0 +1,7 @@
+fn f(m map[string]) {
+	println('illegal function')
+}
+
+fn main() {
+	println('Hello world')
+}


### PR DESCRIPTION
**Problem**
Explicit `map` initializations have a syntax that look similar to array initializations:
```v
m := map[string]f64{}
a := []f64{}
b := []int{cap: 20}
// the following used to compile, too - but with `cap` having (almost) no effect
n := map[string]int{cap: 20}
```
The above example compiles, however two similar declaration lines don't:
```v
u := map[string]int{cap: 13}
// the following line let's C compilation panic
v := map[string]int{cap: 17}
```

**Analysis**
Maps don't have a `cap` property, so it's useless to add one. The *real* problem, however is,
that this `{cap: 20}` actually causes junk C code to be produced which *happens to be* syntactically
correct! However when two such declarations are present, C compilation fails due to semantic problems with the junk code.

**Solution**
This PR enforces that no additional parameter is between `{` and `}` at explicit `map` initializations.

Furthermore the parser now makes sure that a value type is given, i.e. `x := map[string]{}` is treated as error.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
