### PR TITLE
cli: improve multiple value management

### DIFF
--- a/examples/cli.v
+++ b/examples/cli.v
@@ -28,7 +28,7 @@ fn main() {
 	greet_cmd.add_flag(Flag{
 		flag: .int
 		name: 'times'
-		value: ['3']
+		default_value: ['3']
 		description: 'Number of times the message gets printed.'
 	})
 	greet_cmd.add_flag(Flag{

--- a/examples/cli.v
+++ b/examples/cli.v
@@ -32,10 +32,9 @@ fn main() {
 		description: 'Number of times the message gets printed.'
 	})
 	greet_cmd.add_flag(Flag{
-		flag: .string
-		name: 'fun'
-		multiple: true
-		description: 'Just a dumby flags to show multiple.'
+	 	flag: .string_array
+	 	name: 'fun'
+	 	description: 'Just a dumby flags to show multiple.'
 	})
 	cmd.add_command(greet_cmd)
 	cmd.setup()

--- a/vlib/cli/flag.v
+++ b/vlib/cli/flag.v
@@ -5,6 +5,10 @@ pub enum FlagType {
 	int
 	float
 	string
+	// If flag can set multiple time, use array type
+	int_array
+	float_array
+	string_array
 }
 
 // Flag holds information for a command line flag.
@@ -12,17 +16,18 @@ pub enum FlagType {
 // These are typically denoted in the shell by a short form `-f` and/or a long form `--flag`
 pub struct Flag {
 pub mut:
-	flag        FlagType
-	name        string
-	abbrev      string
+	flag FlagType
+	// Name of flag
+	name string
+	// Like short option
+	abbrev string
+	// Desciption of flag
 	description string
 	global      bool
-	required    bool
-	value       []string = []
-	// If allow multiple value.
-	// If bool, multiple has no impact, bool can only set once.
-	// If not multiple, and multiple value set at command args, raise an error.
-	multiple bool
+	// If flag is requierd
+	required bool
+	// Value of flag
+	value []string = []
 mut:
 	// Set true if flag found.
 	found bool
@@ -68,8 +73,8 @@ pub fn (flag Flag) get_int() ?int {
 // get_ints returns the array of `int` value argument of the flag specified in `name`.
 // get_ints returns an error if the `FlagType` is not integer.
 pub fn (flag Flag) get_ints() ?[]int {
-	if flag.flag != .int {
-		return error('$flag.name: Invalid flag type `$flag.flag`, expected `int`')
+	if flag.flag != .int_array {
+		return error('$flag.name: Invalid flag type `$flag.flag`, expected `int_array`')
 	}
 
 	if flag.value.len == 0 {
@@ -116,8 +121,8 @@ pub fn (flag Flag) get_float() ?f64 {
 // get_floats returns the `f64` value argument of the flag.
 // get_floats returns an error if the `FlagType` is not floating point.
 pub fn (flag Flag) get_floats() ?[]f64 {
-	if flag.flag != .float {
-		return error('$flag.name: Invalid flag type `$flag.flag`, expected `float`')
+	if flag.flag != .float_array {
+		return error('$flag.name: Invalid flag type `$flag.flag`, expected `float_array`')
 	}
 
 	if flag.value.len == 0 {
@@ -164,8 +169,8 @@ pub fn (flag Flag) get_string() ?string {
 // get_strings returns the array of `string` value argument of the flag.
 // get_strings returns an error if the `FlagType` is not string.
 pub fn (flag Flag) get_strings() ?[]string {
-	if flag.flag != .string {
-		return error('$flag.name: Invalid flag type `$flag.flag`, expected `string`')
+	if flag.flag != .string_array {
+		return error('$flag.name: Invalid flag type `$flag.flag`, expected `string_array`')
 	}
 
 	if flag.value.len == 0 {
@@ -193,9 +198,6 @@ pub fn (flags []Flag) get_strings(name string) ?[]string {
 // an array of arguments with all consumed elements removed.
 fn (mut flag Flag) parse(args []string, with_abbrev bool) ?[]string {
 	if flag.matches(args, with_abbrev) {
-		// TODO
-		// Si pas multiple generer une erreur
-		// Permettre de récupérer plusieurs valeur
 		if flag.init == false {
 			flag.init = true
 			// Clear defaut value if set
@@ -206,7 +208,8 @@ fn (mut flag Flag) parse(args []string, with_abbrev bool) ?[]string {
 			new_args := flag.parse_bool(args) ?
 			return new_args
 		} else {
-			if flag.value.len > 0 && !flag.multiple {
+			if flag.value.len > 0 && flag.flag != .int_array && flag.flag != .float_array
+				&& flag.flag != .string_array {
 				return error('The argument `$flag.name` accept only one value!')
 			}
 

--- a/vlib/cli/flag_test.v
+++ b/vlib/cli/flag_test.v
@@ -127,7 +127,6 @@ fn test_if_float_flag_parses() {
 	}
 
 	flag.parse(['-flag=3.14159'], false) or { panic(err) }
-	assert flag.value[0].f64() == 3.14159
 	value = flag.get_float() or { panic(err) }
 	assert value == 3.14159
 
@@ -192,4 +191,26 @@ fn test_if_multiple_value_on_single_value() {
 	} else {
 		assert true
 	}
+}
+
+fn test_default_value() {
+	mut flag := cli.Flag{
+		flag: .float
+		name: 'flag'
+		default_value: ['1.234']
+	}
+
+	flag.parse(['-flag', '3.14158'], false) or { panic(err) }
+	mut value := flag.get_float() or { panic(err) }
+	assert value == 3.14158
+
+	flag = cli.Flag{
+		flag: .float
+		name: 'flag'
+		default_value: ['1.234']
+	}
+
+	flag.parse([''], false) or { panic(err) }
+	value = flag.get_float() or { panic(err) }
+	assert value == 1.234
 }

--- a/vlib/cli/flag_test.v
+++ b/vlib/cli/flag_test.v
@@ -18,9 +18,8 @@ fn test_if_string_flag_parses() {
 	assert value == 'value2'
 
 	flag = cli.Flag{
-		flag: .string
+		flag: .string_array
 		name: 'flag'
-		multiple: true
 	}
 	flag.parse(['-flag=value1'], false) or { panic(err) }
 	flag.parse(['-flag=value2'], false) or { panic(err) }
@@ -29,9 +28,8 @@ fn test_if_string_flag_parses() {
 
 	flags := [
 		cli.Flag{
-			flag: .string
+			flag: .string_array
 			name: 'flag'
-			multiple: true
 			value: ['a', 'b', 'c']
 		},
 		cli.Flag{
@@ -88,9 +86,8 @@ fn test_if_int_flag_parses() {
 	assert value == 45
 
 	flag = cli.Flag{
-		flag: .int
+		flag: .int_array
 		name: 'flag'
-		multiple: true
 	}
 
 	flag.parse(['-flag=42'], false) or { panic(err) }
@@ -100,9 +97,8 @@ fn test_if_int_flag_parses() {
 
 	flags := [
 		cli.Flag{
-			flag: .int
+			flag: .int_array
 			name: 'flag'
-			multiple: true
 			value: ['1', '2', '3']
 		},
 		cli.Flag{
@@ -136,9 +132,8 @@ fn test_if_float_flag_parses() {
 	assert value == 3.14159
 
 	flag = cli.Flag{
-		flag: .float
+		flag: .float_array
 		name: 'flag'
-		multiple: true
 	}
 
 	flag.parse(['-flag=3.1'], false) or { panic(err) }
@@ -148,9 +143,8 @@ fn test_if_float_flag_parses() {
 
 	flags := [
 		cli.Flag{
-			flag: .float
+			flag: .float_array
 			name: 'flag'
-			multiple: true
 			value: ['1.1', '2.2', '3.3']
 		},
 		cli.Flag{


### PR DESCRIPTION
Hi all,

in my PR #8256 (it was merged), @timbasel had have great idea, use `.xxx_array` instead of `multiple` field.

This PR fix this in first commit.

The second commit improve by adding `default_value` public field and change `value` public field to private, to avoid error in code when use this field (now application cannot change this value at runtime) and to be more clear (`default_value`is little bi more clear I found).

Ask me if you prefer another PR for second commit.

Kind regards,
