### PR TITLE
cgen: fix for_mut_val_in_map_fixed_array (fix part of #8296)

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1978,7 +1978,14 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 			right := val as ast.ArrayInit
 			if right.has_val {
 				for j, expr in right.exprs {
-					g.expr(left)
+					if !is_decl && left is ast.Ident
+						&& g.for_in_mul_val_name == (left as ast.Ident).name {
+						g.write('(*')
+						g.expr(left)
+						g.write(')')
+					} else {
+						g.expr(left)
+					}
 					if g.is_array_set {
 						g.out.go_back(2)
 					} else {
@@ -1995,7 +2002,14 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 			} else {
 				fixed_array := right_sym.info as table.ArrayFixed
 				for j in 0 .. fixed_array.size {
-					g.expr(left)
+					if !is_decl && left is ast.Ident
+						&& g.for_in_mul_val_name == (left as ast.Ident).name {
+						g.write('(*')
+						g.expr(left)
+						g.write(')')
+					} else {
+						g.expr(left)
+					}
 					if g.is_array_set {
 						g.out.go_back(2)
 					} else {

--- a/vlib/v/tests/for_in_mut_val_test.v
+++ b/vlib/v/tests/for_in_mut_val_test.v
@@ -58,3 +58,12 @@ fn test_for_in_mut_val_of_map_direct() {
 	println(m)
 	assert '$m' == "{'foo': 3, 'bar': 3}"
 }
+
+fn test_for_in_mut_val_of_map_fixed_array() {
+	mut m := {'foo': [{'a': 1}]!, 'bar': [{'b': 2}]!}
+	for _, mut j in m {
+		j = [{'c': 3}]!
+	}
+	println(m)
+	assert '$m' == "{'foo': [{'c': 3}], 'bar': [{'c': 3}]}"
+}


### PR DESCRIPTION
This PR fix for_mut_val_in_map_fixed_array (fix part of #8296).

- Fix for_mut_val_in_map_fixed_array.
- Add test.

```vlang
module main

fn main() {
	mut m := {'foo': [{'a': 1}]!, 'bar': [{'b': 2}]!}
	for _, mut j in m {
		j = [{'c': 3}]!
	}
	println(m)
}

PS D:\Test\v\tt1> v run .
{'foo': [{'c': 3}], 'bar': [{'c': 3}]}
```