### PR TITLE
fmt: better newline handling in block comments

### DIFF
--- a/vlib/v/fmt/comments.v
+++ b/vlib/v/fmt/comments.v
@@ -56,13 +56,21 @@ pub fn (mut f Fmt) comment(node ast.Comment, options CommentsOptions) {
 		}
 		f.write(out_s)
 	} else {
+		expected_line_count := node.pos.last_line - node.pos.line_nr
 		lines := node.text.trim_space().split_into_lines()
 		f.writeln('/*')
+		if lines.len > expected_line_count {
+			f.remove_new_line()
+		}
 		for line in lines {
 			f.writeln(line)
 			f.empty_line = false
 		}
-		f.empty_line = true
+		if lines.len > expected_line_count {
+			f.remove_new_line()
+		} else {
+			f.empty_line = true
+		}
 		f.write('*/')
 	}
 	if options.level == .indent {

--- a/vlib/v/fmt/tests/comments_expected.vv
+++ b/vlib/v/fmt/tests/comments_expected.vv
@@ -68,3 +68,16 @@ fn main() {
 fn insert_space() {
 	// abc
 }
+
+fn linebreaks_in_block_comments() {
+	/*
+	foo
+	comment goes here!
+	bar
+	*/
+	/*
+	spam
+	spaces make no difference there
+	eggs
+	*/
+}

--- a/vlib/v/fmt/tests/comments_expected.vv
+++ b/vlib/v/fmt/tests/comments_expected.vv
@@ -64,3 +64,7 @@ fn main() {
 	// empty return
 	return
 }
+
+fn insert_space() {
+	// abc
+}

--- a/vlib/v/fmt/tests/comments_input.vv
+++ b/vlib/v/fmt/tests/comments_input.vv
@@ -56,3 +56,12 @@ fn main() {
 fn insert_space() {
 	//abc
 }
+
+fn linebreaks_in_block_comments() {
+	/*foo
+	comment goes here!
+	bar*/
+	/*  spam
+	spaces make no difference there
+	eggs */
+}

--- a/vlib/v/fmt/tests/comments_input.vv
+++ b/vlib/v/fmt/tests/comments_input.vv
@@ -52,3 +52,7 @@ fn main() {
 	}
   return // empty return
 }
+
+fn insert_space() {
+	//abc
+}

--- a/vlib/v/fmt/tests/comments_keep.vv
+++ b/vlib/v/fmt/tests/comments_keep.vv
@@ -35,16 +35,26 @@ fn main() {
 	_ := User{
 		// Just a comment
 	}
+	//////
+	// /
+	// 123
+}
+
+fn assign_comments() {
 	a := 123 // comment after assign
 	b := 'foo' // also comment after assign
 	c := true
 	// Between two assigns
 	d := false
-	//////
-	// /
-	// 123
+	// at the end
+}
+
+fn linebreaks_in_block_comments() {
 	/*
 	block
 	*/
-	println('hello world')
+	/*****
+	Want a long line of stars?
+	nw problem
+	*****/
 }

--- a/vlib/v/fmt/tests/comments_keep.vv
+++ b/vlib/v/fmt/tests/comments_keep.vv
@@ -55,6 +55,6 @@ fn linebreaks_in_block_comments() {
 	*/
 	/*****
 	Want a long line of stars?
-	nw problem
+	no problem
 	*****/
 }


### PR DESCRIPTION
Keep stuff like
```v
/*****
comment goes here
*****/
```

Improvement on #6684 