### PR TITLE
checker: add checks for optional selector_expr

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2122,6 +2122,11 @@ pub fn (mut c Checker) selector_expr(mut selector_expr ast.SelectorExpr) table.T
 		c.error('cannot access fields of an optional, hint: handle the error with `or {...}` or propagate it with `?`',
 			selector_expr.pos)
 	}
+	if selector_expr.expr_type.has_flag(.optional) && selector_expr.expr is ast.Ident
+		&& (selector_expr.expr as ast.Ident).kind != .constant {
+		c.error('cannot access fields of an optional, hint: handle the error with `or {...}` or propagate it with `?`',
+			selector_expr.pos)
+	}
 	field_name := selector_expr.field_name
 	utyp := c.unwrap_generic(typ)
 	sym := c.table.get_type_symbol(utyp)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2119,7 +2119,7 @@ pub fn (mut c Checker) selector_expr(mut selector_expr ast.SelectorExpr) table.T
 	selector_expr.expr_type = typ
 	if selector_expr.expr_type.has_flag(.optional) && !((selector_expr.expr is ast.Ident
 		&& (selector_expr.expr as ast.Ident).kind == .constant)) {
-		c.error('cannot access fields of an optional, hint: handle the error with `or {...}` or propagate it with `?`',
+		c.error('cannot access fields of an optional, handle the error with `or {...}` or propagate it with `?`',
 			selector_expr.pos)
 	}
 	field_name := selector_expr.field_name

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2117,6 +2117,10 @@ pub fn (mut c Checker) selector_expr(mut selector_expr ast.SelectorExpr) table.T
 		return table.void_type
 	}
 	selector_expr.expr_type = typ
+	if selector_expr.expr_type.has_flag(.optional) {
+		c.error('cannot access fields of an optional, hint: handle the error with `or {...}` or propagate it with `?`',
+			selector_expr.pos)
+	}
 	field_name := selector_expr.field_name
 	utyp := c.unwrap_generic(typ)
 	sym := c.table.get_type_symbol(utyp)
@@ -4885,7 +4889,7 @@ fn (mut c Checker) check_index(typ_sym &table.TypeSymbol, index ast.Expr, index_
 			c.error('$type_str', pos)
 		}
 		if index is ast.IntegerLiteral {
-			if index.val.starts_with('-')  {
+			if index.val.starts_with('-') {
 				c.error('invalid index `$index.val` (index must be non-negative)', index.pos)
 			}
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2117,7 +2117,8 @@ pub fn (mut c Checker) selector_expr(mut selector_expr ast.SelectorExpr) table.T
 		return table.void_type
 	}
 	selector_expr.expr_type = typ
-	if selector_expr.expr_type.has_flag(.optional) {
+	if selector_expr.expr_type.has_flag(.optional) && selector_expr.expr is ast.Ident
+		&& (selector_expr.expr as ast.Ident).kind != .constant {
 		c.error('cannot access fields of an optional, hint: handle the error with `or {...}` or propagate it with `?`',
 			selector_expr.pos)
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2117,8 +2117,8 @@ pub fn (mut c Checker) selector_expr(mut selector_expr ast.SelectorExpr) table.T
 		return table.void_type
 	}
 	selector_expr.expr_type = typ
-	if selector_expr.expr_type.has_flag(.optional) && selector_expr.expr is ast.Ident
-		&& (selector_expr.expr as ast.Ident).kind != .constant {
+	if selector_expr.expr_type.has_flag(.optional) && !((selector_expr.expr is ast.Ident
+		&& (selector_expr.expr as ast.Ident).kind == .constant)) {
 		c.error('cannot access fields of an optional, hint: handle the error with `or {...}` or propagate it with `?`',
 			selector_expr.pos)
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2122,11 +2122,6 @@ pub fn (mut c Checker) selector_expr(mut selector_expr ast.SelectorExpr) table.T
 		c.error('cannot access fields of an optional, hint: handle the error with `or {...}` or propagate it with `?`',
 			selector_expr.pos)
 	}
-	if selector_expr.expr_type.has_flag(.optional) && selector_expr.expr is ast.Ident
-		&& (selector_expr.expr as ast.Ident).kind != .constant {
-		c.error('cannot access fields of an optional, hint: handle the error with `or {...}` or propagate it with `?`',
-			selector_expr.pos)
-	}
 	field_name := selector_expr.field_name
 	utyp := c.unwrap_generic(typ)
 	sym := c.table.get_type_symbol(utyp)

--- a/vlib/v/checker/tests/selector_expr_optional_err.out
+++ b/vlib/v/checker/tests/selector_expr_optional_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/selector_expr_optional_err.vv:4:46: error: cannot access fields of an optional, hint: handle the error with `or {...}` or propagate it with `?`
+    2 | 
+    3 | fn main() {
+    4 |     println(http.get('https://httpbin.org/').status_code)
+      |                                              ~~~~~~~~~~~
+    5 | }

--- a/vlib/v/checker/tests/selector_expr_optional_err.out
+++ b/vlib/v/checker/tests/selector_expr_optional_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/selector_expr_optional_err.vv:4:46: error: cannot access fields of an optional, hint: handle the error with `or {...}` or propagate it with `?`
+vlib/v/checker/tests/selector_expr_optional_err.vv:4:46: error: cannot access fields of an optional, handle the error with `or {...}` or propagate it with `?`
     2 | 
     3 | fn main() {
     4 |     println(http.get('https://httpbin.org/').status_code)

--- a/vlib/v/checker/tests/selector_expr_optional_err.vv
+++ b/vlib/v/checker/tests/selector_expr_optional_err.vv
@@ -1,0 +1,5 @@
+import net.http
+
+fn main() {
+    println(http.get('https://httpbin.org/').status_code)
+}


### PR DESCRIPTION
Add an error for:

```
vlib/v/checker/tests/selector_expr_optional_err.vv:4:46: error: cannot access fields of an optional, hint: handle the error with `or {...}` or propagate it with `?`
    2 | 
    3 | fn main() {
    4 |     println(http.get('https://httpbin.org/').status_code)
      |                                              ~~~~~~~~~~~
    5 | }
 ```