### PR TITLE
checker: fix treating C structs with capitalized fields as embeds

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2124,7 +2124,8 @@ pub fn (mut c Checker) selector_expr(mut selector_expr ast.SelectorExpr) table.T
 	mut unknown_field_msg := 'type `$sym.name` has no field or method `$field_name`'
 	mut has_field := false
 	mut field := table.Field{}
-	if field_name.len > 0 && field_name[0].is_capital() && sym.info is table.Struct {
+	if field_name.len > 0 && field_name[0].is_capital() && sym.info is table.Struct
+		&& sym.language == .v {
 		// x.Foo.y => access the embedded struct
 		sym_info := sym.info as table.Struct
 		for embed in sym_info.embeds {

--- a/vlib/v/tests/project_with_c_code/main.v
+++ b/vlib/v/tests/project_with_c_code/main.v
@@ -4,5 +4,5 @@ import mod1
 
 fn main() {
 	res := mod1.vadd(1, 2)
-	println(res)
+	assert res == 1003
 }

--- a/vlib/v/tests/project_with_c_code/main.v
+++ b/vlib/v/tests/project_with_c_code/main.v
@@ -4,5 +4,6 @@ import mod1
 
 fn main() {
 	res := mod1.vadd(1, 2)
+	println(res)
 	assert res == 1003
 }

--- a/vlib/v/tests/project_with_c_code/mod1/c/header.h
+++ b/vlib/v/tests/project_with_c_code/mod1/c/header.h
@@ -3,4 +3,8 @@
 
 int cadd(int a, int b);
 
+struct MyStruct {
+    int UppercaseField;
+};
+
 #endif

--- a/vlib/v/tests/project_with_c_code/mod1/wrapper.v
+++ b/vlib/v/tests/project_with_c_code/mod1/wrapper.v
@@ -5,8 +5,13 @@ module mod1
 
 #include "header.h"
 
-fn C.cadd(int,int) int
+struct C.MyStruct {
+	UppercaseField int
+}
+
+fn C.cadd(int, int) int
 
 pub fn vadd(a int, b int) int {
-	return 1000 + C.cadd(a,b)
+	x := C.MyStruct{ 100 }
+	return 900 + x.UppercaseField + C.cadd(a, b)
 }


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
