### PR TITLE
backtrace: Fix tcc backtrace windows compilation error

### DIFF
--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -191,6 +191,8 @@ fn print_backtrace_skipping_top_frames_tcc(skipframes int) bool {
 		eprintln('print_backtrace_skipping_top_frames_tcc must be called only when the compiler is tcc')
 		return false
 	}
+	// Not reachable, but it looks like it's not detectable by V
+	return false
 }
 
 // TODO copypaste from os

--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -182,9 +182,10 @@ fn print_backtrace_skipping_top_frames_tcc(skipframes int) bool {
 	$if tinyc {
 		$if no_backtrace ? {
 			eprintln('backtraces are disabled')
+			return false
 		} $else {
 			C.tcc_backtrace('Backtrace')
-			return false
+			return true
 		}
 	} $else {
 		eprintln('print_backtrace_skipping_top_frames_tcc must be called only when the compiler is tcc')


### PR DESCRIPTION
Fixes self compilation error from:
```v
V self compiling ...
cannot compile to `C:\msys64\home\User\Workspace\v`:
vlib\builtin\builtin_windows.c.v:181:1: error: missing return at end of function `print_backtrace_skipping_top_frames_tcc`
  179 | fn C.tcc_backtrace(fmt charptr, other ...charptr) int
  180 |
  181 | fn print_backtrace_skipping_top_frames_tcc(skipframes int) bool {
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  182 |     $if tinyc {
  183 |         $if no_backtrace ? {
```