### PR TITLE
checker: avoid SelectorExpr filter on Ident unless it's a generic type name

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2050,7 +2050,8 @@ pub fn (mut c Checker) selector_expr(mut selector_expr ast.SelectorExpr) table.T
 	match mut selector_expr.expr {
 		ast.Ident {
 			name := selector_expr.expr.name
-			valid_generic := c.cur_fn.generic_params.filter(it.name == name).len != 0
+			valid_generic := util.is_generic_type_name(name) &&
+				c.cur_fn.generic_params.filter(it.name == name).len != 0
 			if valid_generic {
 				name_type = table.Type(c.table.find_type_idx(name)).set_flag(.generic)
 			}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2050,8 +2050,8 @@ pub fn (mut c Checker) selector_expr(mut selector_expr ast.SelectorExpr) table.T
 	match mut selector_expr.expr {
 		ast.Ident {
 			name := selector_expr.expr.name
-			valid_generic := util.is_generic_type_name(name) &&
-				c.cur_fn.generic_params.filter(it.name == name).len != 0
+			valid_generic := util.is_generic_type_name(name)
+				&& c.cur_fn.generic_params.filter(it.name == name).len != 0
 			if valid_generic {
 				name_type = table.Type(c.table.find_type_idx(name)).set_flag(.generic)
 			}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -449,7 +449,7 @@ fn (mut p Parser) parse_generic_params() []ast.GenericParam {
 		if name.len > 1 {
 			p.error('generic parameter name needs to be exactly one char')
 		}
-		if is_generic_name_reserved(p.tok.lit) {
+		if !util.is_generic_type_name(p.tok.lit) {
 			p.error('`$p.tok.lit` is a reserved name and cannot be used for generics')
 		}
 		if name in param_names {
@@ -467,23 +467,9 @@ fn (mut p Parser) parse_generic_params() []ast.GenericParam {
 	return param_names.map(ast.GenericParam{it})
 }
 
-// is_valid_generic_character returns true if the character is reserved for someting else.
-fn is_generic_name_reserved(name string) bool {
-	// C is used for cinterop
-	if name == 'C' {
-		return true
-	}
-	return false
-}
-
-// is_generic_name returns true if the current token is a generic name.
-fn is_generic_name(name string) bool {
-	return name.len == 1 && name.is_capital() && !is_generic_name_reserved(name)
-}
-
 // is_generic_name returns true if the current token is a generic name.
 fn (p Parser) is_generic_name() bool {
-	return p.tok.kind == .name && is_generic_name(p.tok.lit)
+	return p.tok.kind == .name && util.is_generic_type_name(p.tok.lit)
 }
 
 fn (mut p Parser) anon_fn() ast.AnonFn {

--- a/vlib/v/util/scanning.v
+++ b/vlib/v/util/scanning.v
@@ -38,8 +38,8 @@ pub fn good_type_name(s string) bool {
 	return true
 }
 
-[inline]
 // is_generic_type_name returns true if the current token is a generic type name.
+[inline]
 pub fn is_generic_type_name(name string) bool {
 	return name.len == 1 && name.is_capital() && name != 'C'
 }

--- a/vlib/v/util/scanning.v
+++ b/vlib/v/util/scanning.v
@@ -38,6 +38,12 @@ pub fn good_type_name(s string) bool {
 	return true
 }
 
+[inline]
+// is_generic_type_name returns true if the current token is a generic type name.
+pub fn is_generic_type_name(name string) bool {
+	return name.len == 1 && name.is_capital() && name != 'C'
+}
+
 pub fn cescaped_path(s string) string {
 	return s.replace('\\', '\\\\')
 }


### PR DESCRIPTION
This should be a bit quicker inside a generic function.

Move is_generic_name to util.is_generic_type_name.
Avoid & remove is_generic_name_reserved().



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
