### PR TITLE
checker: fix array append short struct init (fix #8279)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -493,7 +493,12 @@ pub fn (mut c Checker) struct_init(mut struct_init ast.StructInit) table.Type {
 			c.error('unexpected short struct syntax', struct_init.pos)
 			return table.void_type
 		}
-		struct_init.typ = c.expected_type
+		sym := c.table.get_type_symbol(c.expected_type)
+		if sym.kind == .array {
+			struct_init.typ = c.table.value_type(c.expected_type)
+		} else {
+			struct_init.typ = c.expected_type
+		}
 	}
 	if struct_init.typ == 0 {
 		c.error('unknown type', struct_init.pos)

--- a/vlib/v/tests/array_append_short_struct_test.v
+++ b/vlib/v/tests/array_append_short_struct_test.v
@@ -1,0 +1,12 @@
+struct Page {
+    contents int
+}
+
+fn test_array_append_short_struct() {
+	mut pages := []Page{}
+	pages << {
+		contents: 3
+	}
+	println(pages)
+	assert pages == [Page{ contents: 3}]
+}


### PR DESCRIPTION
This PR fix array append short struct init (fix #8279).

- Fix array append short struct init.
- Add test.

```vlang
module main

struct Page {
    contents int
}

fn main () {
    mut pages := []Page{}
    pages << {
        contents: 3
    }
    println(pages)
}

PS D:\Test\v\tt1> v run .
[Page{
    contents: 3
}]
```