### PR TITLE
parser: check assign_stmt of undefined variable (fix #8280)

### DIFF
--- a/vlib/v/checker/tests/assign_expr_undefined_err_g.out
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_g.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/assign_expr_undefined_err_g.vv:2:14: error: undefined variable: `file`
+    1 | fn main() {
+    2 |     mut file := file.open_file('bees.pdf', 'rw', 0o666)
+      |                 ~~~~
+    3 | }

--- a/vlib/v/checker/tests/assign_expr_undefined_err_g.vv
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_g.vv
@@ -1,0 +1,3 @@
+fn main() {
+	mut file := file.open_file('bees.pdf', 'rw', 0o666)
+}

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -23,6 +23,9 @@ fn (mut p Parser) check_undefined_variables(exprs []ast.Expr, val ast.Expr) ? {
 				}
 			}
 		}
+		ast.CallExpr {
+			p.check_undefined_variables(exprs, val.left) ?
+		}
 		ast.InfixExpr {
 			p.check_undefined_variables(exprs, val.left) ?
 			p.check_undefined_variables(exprs, val.right) ?


### PR DESCRIPTION
This PR checks assign_stmt of undefined variable (fix #8280).

- Checks assign_stmt of undefined variable.
- Add test.

```vlang
module main

fn main() {
	mut file := file.open_file('bees.pdf', 'rw', 0o666)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:4:14: error: undefined variable: `file`
    2 | 
    3 | fn main() {
    4 |     mut file := file.open_file('bees.pdf', 'rw', 0o666)
      |                 ~~~~
    5 | }
```