### PR TITLE
term: fix cursor offset on term.ui windows

### DIFF
--- a/vlib/term/ui/input_windows.c.v
+++ b/vlib/term/ui/input_windows.c.v
@@ -186,8 +186,8 @@ fn (mut ctx Context) parse_events() {
 				if !C.GetConsoleScreenBufferInfo(ctx.stdout_handle, &sb_info) {
 					panic('could not get screenbuffer info')
 				}
-				x := e.dwMousePosition.X
-				y := int(e.dwMousePosition.Y) - sb_info.srWindow.Top
+				x := e.dwMousePosition.X + 1
+				y := int(e.dwMousePosition.Y) - sb_info.srWindow.Top + 1
 				mut modifiers := u32(0)
 				if e.dwControlKeyState & (0x1 | 0x2) != 0 { modifiers |= alt }
 				if e.dwControlKeyState & (0x4 | 0x8) != 0 { modifiers |= ctrl }


### PR DESCRIPTION
since unix coordinates start at (1, 1) and window's coordinates start at (0, 0) there was an offset previously of the cursor in term.ui windows. this pr adds 1 to x and y to fix the offset.