### PR TITLE
vlib: Fixed const declaration error

### DIFF
--- a/vlib/strconv/number_to_base.v
+++ b/vlib/strconv/number_to_base.v
@@ -1,6 +1,8 @@
 module strconv
 
-const base_digits = '0123456789abcdefghijklmnopqrstuvwxyz'
+const (
+	base_digits = '0123456789abcdefghijklmnopqrstuvwxyz'
+)
 
 // format_int returns the string representation of the number n in base `radix`
 // for digit values > 10, this function uses the small latin leters a-z.


### PR DESCRIPTION
Constants should be defined in Paranthesis. Just fixed that. It was giving me an error when I was trying to upgrade and run doctor.
The error was:
C:\src\v\vlib\strconv\number_to_base.v:3:1: error: const declaration is missing parentheses `( ... )`
    1 | module strconv
    2 |
    3 | const base_digits = '0123456789abcdefghijklmnopqrstuvwxyz'
      | ~~~~~
    4 |
    5 | // format_int returns the string representation of the number n in base `radix`

This is a potential fix of Issue #8377