### PR TITLE
Fix short struct init with `mut`

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1122,6 +1122,9 @@ fn (mut c Checker) fail_if_immutable(expr ast.Expr) (string, token.Position) {
 		ast.ArrayInit {
 			return '', pos
 		}
+		ast.StructInit {
+			return '', pos
+		}
 		else {
 			c.error('unexpected expression `$expr.type_name()`', expr.position())
 		}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -4711,7 +4711,7 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 			g.write('($styp*)memdup(&($styp){')
 		}
 	} else if struct_init.typ.is_ptr() {
-		basetyp := styp.all_before_last('*')
+		basetyp := g.typ(struct_init.typ.set_nr_muls(0))
 		if is_multiline {
 			g.writeln('&($basetyp){')
 		} else {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -4710,6 +4710,13 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 		} else {
 			g.write('($styp*)memdup(&($styp){')
 		}
+	} else if struct_init.typ.is_ptr() {
+		basetyp := styp.all_before_last('*')
+		if is_multiline {
+			g.writeln('&($basetyp){')
+		} else {
+			g.write('&($basetyp){')
+		}
 	} else {
 		if g.is_shared {
 			g.writeln('{.val = {')

--- a/vlib/v/tests/struct_test.v
+++ b/vlib/v/tests/struct_test.v
@@ -231,6 +231,7 @@ fn test_fixed_field() {
 }
 */
 struct Config {
+mut:
 	n   int
 	def int = 10
 }
@@ -240,6 +241,11 @@ fn foo_config(def int, c Config) {
 }
 fn bar_config(c Config, def int) {
 	assert c.def == def
+}
+fn mut_bar_config(mut c Config, def int) &Config {
+	c.n = c.def
+	assert c.n == def
+	return c
 }
 
 fn foo_user(u User) {}
@@ -255,6 +261,10 @@ fn test_struct_literal_args() {
 
 	bar_config({}, 10)
 	bar_config({def:4}, 4)
+
+	c := mut_bar_config(mut {def: 10}, 10)
+	assert c.n == 10
+	assert c.def == 10
 
 	foo_user({
 		name: 'Peter'


### PR DESCRIPTION
Fixes #8382 and a complementary c error, because you can't initialize a pointer directly
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
