### PR TITLE
checker: fix receiver pos for single letter type error message

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5287,7 +5287,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 		}
 		if sym.name.len == 1 {
 			// One letter types are reserved for generics.
-			c.error('unknown type `$sym.name`', node.pos)
+			c.error('unknown type `$sym.name`', node.receiver_pos)
 			return
 		}
 		// if sym.has_method(node.name) {

--- a/vlib/v/checker/tests/receiver_unknown_type_single_letter.out
+++ b/vlib/v/checker/tests/receiver_unknown_type_single_letter.out
@@ -1,3 +1,4 @@
 vlib/v/checker/tests/receiver_unknown_type_single_letter.vv:1:5: error: unknown type `A`
     1 | fn (p A) foo() {}
       |     ~~~
+    2 |


### PR DESCRIPTION
This PR fixes the discrepancy in the error message for single letter receiver types.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
