### PR TITLE
checker: check duplicate of a const name (fix #8385)

### DIFF
--- a/vlib/time/format.v
+++ b/vlib/time/format.v
@@ -93,7 +93,7 @@ pub fn (t Time) get_fmt_time_str(fmt_time FormatTime) string {
 		return ''
 	}
 	tp := if t.hour > 11 { 'p.m.' } else { 'a.m.' }
-	hour := if t.hour > 12 {
+	hour_ := if t.hour > 12 {
 		t.hour - 12
 	} else if t.hour == 0 {
 		12
@@ -101,9 +101,9 @@ pub fn (t Time) get_fmt_time_str(fmt_time FormatTime) string {
 		t.hour
 	}
 	return match fmt_time {
-		.hhmm12 { '$hour:${t.minute:02d} $tp' }
+		.hhmm12 { '$hour_:${t.minute:02d} $tp' }
 		.hhmm24 { '${t.hour:02d}:${t.minute:02d}' }
-		.hhmmss12 { '$hour:${t.minute:02d}:${t.second:02d} $tp' }
+		.hhmmss12 { '$hour_:${t.minute:02d}:${t.second:02d} $tp' }
 		.hhmmss24 { '${t.hour:02d}:${t.minute:02d}:${t.second:02d}' }
 		.hhmmss24_milli { '${t.hour:02d}:${t.minute:02d}:${t.second:02d}.${(t.microsecond / 1000):03d}' }
 		.hhmmss24_micro { '${t.hour:02d}:${t.minute:02d}:${t.second:02d}.${t.microsecond:06d}' }

--- a/vlib/time/parse.v
+++ b/vlib/time/parse.v
@@ -13,16 +13,16 @@ pub fn parse(s string) ?Time {
 	}
 	shms := s[pos..]
 	hms := shms.split(':')
-	hour := hms[0][1..]
-	minute := hms[1]
-	second := hms[2]
+	hour_ := hms[0][1..]
+	minute_ := hms[1]
+	second_ := hms[2]
 	res := new_time(Time{
 		year: ymd[0].int()
 		month: ymd[1].int()
 		day: ymd[2].int()
-		hour: hour.int()
-		minute: minute.int()
-		second: second.int()
+		hour: hour_.int()
+		minute: minute_.int()
+		second: second_.int()
 	})
 	return res
 }
@@ -61,21 +61,21 @@ fn parse_iso8601_date(s string) ?(int, int, int) {
 }
 
 fn parse_iso8601_time(s string) ?(int, int, int, int, i64, bool) {
-	hour := 0
-	minute := 0
-	second := 0
-	microsecond := 0
+	hour_ := 0
+	minute_ := 0
+	second_ := 0
+	microsecond_ := 0
 	plus_min_z := `a`
 	offset_hour := 0
 	offset_minute := 0
 	mut count := unsafe {
-		C.sscanf(charptr(s.str), '%2d:%2d:%2d.%6d%c%2d:%2d', &hour, &minute, &second,
-			&microsecond, charptr(&plus_min_z), &offset_hour, &offset_minute)
+		C.sscanf(charptr(s.str), '%2d:%2d:%2d.%6d%c%2d:%2d', &hour_, &minute_, &second_,
+			&microsecond_, charptr(&plus_min_z), &offset_hour, &offset_minute)
 	}
 	// Missread microsecond ([Sec Hour Minute].len == 3 < 4)
 	if count < 4 {
 		count = unsafe {
-			C.sscanf(charptr(s.str), '%2d:%2d:%2d%c%2d:%2d', &hour, &minute, &second,
+			C.sscanf(charptr(s.str), '%2d:%2d:%2d%c%2d:%2d', &hour_, &minute_, &second_,
 				charptr(&plus_min_z), &offset_hour, &offset_minute)
 		}
 		count++ // Increment count because skipped microsecond
@@ -101,7 +101,7 @@ fn parse_iso8601_time(s string) ?(int, int, int, int, i64, bool) {
 	if plus_min_z == `+` {
 		unix_offset *= -1
 	}
-	return hour, minute, second, microsecond, unix_offset, is_local_time
+	return hour_, minute_, second_, microsecond_, unix_offset, is_local_time
 }
 
 // parse_iso8601 parses rfc8601 time format yyyy-MM-ddTHH:mm:ss.dddddd+dd:dd as local time
@@ -116,18 +116,18 @@ pub fn parse_iso8601(s string) ?Time {
 		return time.err_invalid_8601
 	}
 	year, month, day := parse_iso8601_date(parts[0]) ?
-	mut hour, mut minute, mut second, mut microsecond, mut unix_offset, mut is_local_time := 0, 0, 0, 0, i64(0), true
+	mut hour_, mut minute_, mut second_, mut microsecond_, mut unix_offset, mut is_local_time := 0, 0, 0, 0, i64(0), true
 	if parts.len == 2 {
-		hour, minute, second, microsecond, unix_offset, is_local_time = parse_iso8601_time(parts[1]) ?
+		hour_, minute_, second_, microsecond_, unix_offset, is_local_time = parse_iso8601_time(parts[1]) ?
 	}
 	mut t := new_time(Time{
 		year: year
 		month: month
 		day: day
-		hour: hour
-		minute: minute
-		second: second
-		microsecond: microsecond
+		hour: hour_
+		minute: minute_
+		second: second_
+		microsecond: microsecond_
 	})
 	if is_local_time {
 		return t // Time already local time

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2478,11 +2478,11 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 						}
 						*/
 					}
-					if false && is_decl {
+					if is_decl {
 						full_name := '${left.mod}.$left.name'
 						if obj := c.file.global_scope.find(full_name) {
 							if obj is ast.ConstField {
-								c.warn('duplicate of a const name `$full_name', left.pos)
+								c.warn('duplicate of a const name `$full_name`', left.pos)
 							}
 						}
 					}

--- a/vlib/v/checker/tests/var_duplicate_const.out
+++ b/vlib/v/checker/tests/var_duplicate_const.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/var_duplicate_const.vv:4:5: error: duplicate of a const name `size`
+    2 |
+    3 | fn main() {
+    4 |     size := 11
+      |     ~~~~
+    5 |     println(main.size)
+    6 | }

--- a/vlib/v/checker/tests/var_duplicate_const.vv
+++ b/vlib/v/checker/tests/var_duplicate_const.vv
@@ -1,0 +1,6 @@
+const size = 22
+
+fn main() {
+    size := 11
+    println(main.size)
+}

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -567,7 +567,7 @@ pub fn (mut t Table) find_or_register_array(elem_type Type) int {
 		return existing_idx
 	}
 	// register
-	array_type := TypeSymbol{
+	array_type_ := TypeSymbol{
 		parent_idx: array_type_idx
 		kind: .array
 		name: name
@@ -576,7 +576,7 @@ pub fn (mut t Table) find_or_register_array(elem_type Type) int {
 			elem_type: elem_type
 		}
 	}
-	return t.register_type_symbol(array_type)
+	return t.register_type_symbol(array_type_)
 }
 
 pub fn (mut t Table) find_or_register_array_with_dims(elem_type Type, nr_dims int) int {


### PR DESCRIPTION
This PR restore checking duplicate of a const name (fix #8385).

- Check duplicate of a const name.
- Add test.
- Correct related errors.

```vlang
const size = 22

fn main() {
    size := 11
    println(main.size)
}

vlib/v/checker/tests/var_duplicate_const.vv:4:5: error: duplicate of a const name `size`
    2 |
    3 | fn main() {
    4 |     size := 11
      |     ~~~~
    5 |     println(main.size)
    6 | }
```