### PR TITLE
checker: fix array_insert_or_prepend_short_struct_init (fix #8387)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1239,6 +1239,7 @@ fn (mut c Checker) check_map_and_filter(is_map bool, elem_typ table.Type, call_e
 
 pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 	left_type := c.expr(call_expr.left)
+	c.expected_type = left_type
 	is_generic := left_type.has_flag(.generic)
 	call_expr.left_type = left_type
 	// Set default values for .return_type & .receiver_type too,

--- a/vlib/v/tests/array_append_short_struct_test.v
+++ b/vlib/v/tests/array_append_short_struct_test.v
@@ -8,5 +8,18 @@ fn test_array_append_short_struct() {
 		contents: 3
 	}
 	println(pages)
-	assert pages == [Page{ contents: 3}]
+	assert pages == [Page{contents: 3}]
+}
+
+struct Container {
+pub mut:
+	name string
+}
+
+fn test_array_insert_or_prepend_short_struct() {
+	mut a := []Container{}
+	a.prepend({name: 'a'})
+	a.insert(0, {name: 'b'})
+	println(a)
+	assert a == [Container{name: 'b'}, Container{name: 'a'}]
 }


### PR DESCRIPTION
This PR fix array_insert_or_prepend_short_struct_init (fix #8387).

- Fix array_insert_or_prepend_short_struct_init.
- Add test.

```vlang
struct Container {
pub mut:
	name string
}

fn main() {
	mut test := []Container{}
	test.prepend({ name: 'a' })
	test.insert(0, { name: 'b' })
	println(test)
}

PS D:\Test\v\tt1> v run .
[Container{
    name: 'b'
}, Container{
    name: 'a'
}]
```