### PR TITLE
checker: check variable used reserved words (fix #8389)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -30,6 +30,8 @@ const (
 	valid_comp_if_other     = ['js', 'debug', 'test', 'glibc', 'prealloc', 'no_bounds_checking']
 	array_builtin_methods   = ['filter', 'clone', 'repeat', 'reverse', 'map', 'slice', 'sort',
 		'contains', 'index']
+	reserved_words          = ['array', 'map', 'int', 'byte', 'string', 'rune', 'float', 'double',
+		'bool', 'byteptr', 'voidptr', 'charptr']
 )
 
 pub struct Checker {
@@ -2458,6 +2460,10 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 				} else {
 					if is_decl {
 						c.check_valid_snake_case(left.name, 'variable name', left.pos)
+						if left.name in checker.reserved_words {
+							c.error('reserved word `$left.name` cannot be used as variable name',
+								left.pos)
+						}
 					}
 					mut ident_var_info := left.info as ast.IdentVar
 					if ident_var_info.share == .shared_t {

--- a/vlib/v/checker/tests/var_used_reserved_word.out
+++ b/vlib/v/checker/tests/var_used_reserved_word.out
@@ -1,0 +1,13 @@
+vlib/v/checker/tests/var_used_reserved_word.vv:2:9: error: reserved word `array` cannot be used as variable name
+    1 | fn main() {
+    2 |     mut array := []int{}
+      |         ~~~~~
+    3 |     array << 11
+    4 |     println(array)
+vlib/v/checker/tests/var_used_reserved_word.vv:6:2: error: reserved word `string` cannot be used as variable name
+    4 |     println(array)
+    5 |
+    6 |     string := 22
+      |     ~~~~~~
+    7 |     println(string)
+    8 | }

--- a/vlib/v/checker/tests/var_used_reserved_word.vv
+++ b/vlib/v/checker/tests/var_used_reserved_word.vv
@@ -1,0 +1,8 @@
+fn main() {
+    mut array := []int{}
+	array << 11
+    println(array)
+
+	string := 22
+	println(string)
+}


### PR DESCRIPTION
This PR check variable used reserved words (fix #8389).

- Check variable used reserved words.
- Add test.

```vlang
struct Container {
pub mut:
	name string
}

fn main() {
	mut array := []&Container{}

	array << &Container{ name: 'a' }

	for elem in array {
		println(elem)
	}
}

PS D:\Test\v\tt1> v run .
.\tt1.v:7:6: error: reserved word `array` cannot be used as variable name
    5 | 
    6 | fn main() {
    7 |     mut array := []&Container{}
      |         ~~~~~
    8 |
    9 |     array << &Container{ name: 'a' }
```