### PR TITLE
cgen: fix match_in_if_expression (fix #8402)

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -3444,21 +3444,30 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 		return
 	}
 	is_expr := (node.is_expr && node.return_type != table.void_type) || g.inside_ternary > 0
+	mut cond_var := ''
 	if is_expr {
 		g.inside_ternary++
 		// g.write('/* EM ret type=${g.typ(node.return_type)}		expected_type=${g.typ(node.expected_type)}  */')
 	}
-	cur_line := if is_expr {
-		g.empty_line = true
-		g.go_before_stmt(0)
+	if node.cond is ast.Ident || node.cond is ast.SelectExpr || node.cond is ast.IndexExpr {
+		pos := g.out.len
+		g.expr(node.cond)
+		cond_var = g.out.after(pos)
+		g.out.go_back(cond_var.len)
 	} else {
-		''
+		cur_line := if is_expr {
+			g.empty_line = true
+			g.go_before_stmt(0)
+		} else {
+			''
+		}
+		cond_var = g.new_tmp_var()
+		g.write('${g.typ(node.cond_type)} $cond_var = ')
+		g.expr(node.cond)
+		g.writeln('; ')
+		g.write(cur_line)
 	}
-	cond_var := g.new_tmp_var()
-	g.write('${g.typ(node.cond_type)} $cond_var = ')
-	g.expr(node.cond)
-	g.writeln('; ')
-	g.write(cur_line)
+
 	if is_expr {
 		// brackets needed otherwise '?' will apply to everything on the left
 		g.write('(')

--- a/vlib/v/tests/match_in_if_expression_test.v
+++ b/vlib/v/tests/match_in_if_expression_test.v
@@ -1,0 +1,13 @@
+fn test_match_in_if_expression() {
+	num := 3
+	str := 'a'
+	res := if num in [1, 3] {
+		match str {
+			'a' { 'A' }
+			else { 'ODD' }
+		}
+	} else {
+		'NONE'
+	}
+	assert res == 'A'
+}


### PR DESCRIPTION
This PR fix match_in_if_expression (fix #8402).

- Fix match_in_if_expression.
- Add test.

```vlang
fn main() {
	num := 3
	str := 'a'
	res := if num in [1, 3] {
		match str {
			'a' { 'A' }
			else { 'ODD' }
		}
	} else {
		'NONE'
	}
	assert res == 'A'
	println(res)
}

PS D:\Test\v\tt1> v run .
A
```