### PR TITLE
move constants to new module

### DIFF
--- a/vlib/rand/constants/constants.v
+++ b/vlib/rand/constants/constants.v
@@ -1,0 +1,12 @@
+module constants
+
+// Commonly used constants across RNGs - some taken from "Numerical Recipes".
+pub const (
+	lower_mask     = u64(0x00000000FFFFFFFF)
+	max_u32        = 0xFFFFFFFF
+	max_u64        = 0xFFFFFFFFFFFFFFFF
+	max_u32_as_f32 = f32(max_u32) + 1
+	max_u64_as_f64 = f64(max_u64) + 1
+	u31_mask       = u32(0x7FFFFFFF)
+	u63_mask       = u64(0x7FFFFFFFFFFFFFFF)
+)

--- a/vlib/rand/musl/musl_rng.v
+++ b/vlib/rand/musl/musl_rng.v
@@ -5,7 +5,7 @@ module musl
 
 import math.bits
 import rand.seed
-import rand.util
+import rand.constants
 
 // MuslRNG ported from https://git.musl-libc.org/cgit/musl/tree/src/prng/rand_r.c
 pub struct MuslRNG {
@@ -191,13 +191,13 @@ pub fn (mut rng MuslRNG) i64_in_range(min i64, max i64) i64 {
 // f32 returns a pseudorandom `f32` value in range `[0, 1)`.
 [inline]
 pub fn (mut rng MuslRNG) f32() f32 {
-	return f32(rng.u32()) / util.max_u32_as_f32
+	return f32(rng.u32()) / constants.max_u32_as_f32
 }
 
 // f64 returns a pseudorandom `f64` value in range `[0, 1)`.
 [inline]
 pub fn (mut rng MuslRNG) f64() f64 {
-	return f64(rng.u64()) / util.max_u64_as_f64
+	return f64(rng.u64()) / constants.max_u64_as_f64
 }
 
 // f32n returns a pseudorandom `f32` value in range `[0, max)`.

--- a/vlib/rand/pcg32/pcg32.v
+++ b/vlib/rand/pcg32/pcg32.v
@@ -4,7 +4,7 @@
 module pcg32
 
 import rand.seed
-import rand.util
+import rand.constants
 
 // PCG32RNG ported from http://www.pcg-random.org/download.html,
 // https://github.com/imneme/pcg-c-basic/blob/master/pcg_basic.c, and
@@ -176,13 +176,13 @@ pub fn (mut rng PCG32RNG) i64_in_range(min i64, max i64) i64 {
 // f32 returns a pseudorandom `f32` value in range `[0, 1)`.
 [inline]
 pub fn (mut rng PCG32RNG) f32() f32 {
-	return f32(rng.u32()) / util.max_u32_as_f32
+	return f32(rng.u32()) / constants.max_u32_as_f32
 }
 
 // f64 returns a pseudorandom `f64` value in range `[0, 1)`.
 [inline]
 pub fn (mut rng PCG32RNG) f64() f64 {
-	return f64(rng.u64()) / util.max_u64_as_f64
+	return f64(rng.u64()) / constants.max_u64_as_f64
 }
 
 // f32n returns a pseudorandom `f32` value in range `[0, max)`.

--- a/vlib/rand/splitmix64/splitmix64.v
+++ b/vlib/rand/splitmix64/splitmix64.v
@@ -4,7 +4,7 @@
 module splitmix64
 
 import rand.seed
-import rand.util
+import rand.constants
 
 // SplitMix64RNG ported from http://xoshiro.di.unimi.it/splitmix64.c
 pub struct SplitMix64RNG {
@@ -33,7 +33,7 @@ pub fn (mut rng SplitMix64RNG) u32() u32 {
 		return rng.extra
 	}
 	full_value := rng.u64()
-	lower := u32(full_value & util.lower_mask)
+	lower := u32(full_value & constants.lower_mask)
 	upper := u32(full_value >> 32)
 	rng.extra = upper
 	rng.has_extra = true
@@ -122,13 +122,13 @@ pub fn (mut rng SplitMix64RNG) i64() i64 {
 // int31 returns a positive pseudorandom 31-bit `int`.
 [inline]
 pub fn (mut rng SplitMix64RNG) int31() int {
-	return int(rng.u32() & util.u31_mask) // Set the 32nd bit to 0.
+	return int(rng.u32() & constants.u31_mask) // Set the 32nd bit to 0.
 }
 
 // int63 returns a positive pseudorandom 63-bit `i64`.
 [inline]
 pub fn (mut rng SplitMix64RNG) int63() i64 {
-	return i64(rng.u64() & util.u63_mask) // Set the 64th bit to 0.
+	return i64(rng.u64() & constants.u63_mask) // Set the 64th bit to 0.
 }
 
 // intn returns a pseudorandom `int` in range `[0, max)`.
@@ -175,13 +175,13 @@ pub fn (mut rng SplitMix64RNG) i64_in_range(min i64, max i64) i64 {
 // f32 returns a pseudorandom `f32` value in range `[0, 1)`.
 [inline]
 pub fn (mut rng SplitMix64RNG) f32() f32 {
-	return f32(rng.u32()) / util.max_u32_as_f32
+	return f32(rng.u32()) / constants.max_u32_as_f32
 }
 
 // f64 returns a pseudorandom `f64` value in range `[0, 1)`.
 [inline]
 pub fn (mut rng SplitMix64RNG) f64() f64 {
-	return f64(rng.u64()) / util.max_u64_as_f64
+	return f64(rng.u64()) / constants.max_u64_as_f64
 }
 
 // f32n returns a pseudorandom `f32` value in range `[0, max)`.

--- a/vlib/rand/sys/system_rng.c.v
+++ b/vlib/rand/sys/system_rng.c.v
@@ -5,7 +5,7 @@ module sys
 
 import math.bits
 import rand.seed
-import rand.util
+import rand.constants
 
 // Implementation note:
 // ====================
@@ -176,13 +176,13 @@ pub fn (r SysRNG) i64() i64 {
 // r.int31() returns a pseudorandom 31-bit int which is non-negative
 [inline]
 pub fn (r SysRNG) int31() int {
-	return int(r.u32() & util.u31_mask) // Set the 32nd bit to 0.
+	return int(r.u32() & constants.u31_mask) // Set the 32nd bit to 0.
 }
 
 // r.int63() returns a pseudorandom 63-bit int which is non-negative
 [inline]
 pub fn (r SysRNG) int63() i64 {
-	return i64(r.u64() & util.u63_mask) // Set the 64th bit to 0.
+	return i64(r.u64() & constants.u63_mask) // Set the 64th bit to 0.
 }
 
 // r.intn(max) returns a pseudorandom int that lies in [0, max)
@@ -229,13 +229,13 @@ pub fn (r SysRNG) i64_in_range(min i64, max i64) i64 {
 // r.f32() returns a pseudorandom f32 value between 0.0 (inclusive) and 1.0 (exclusive) i.e [0, 1)
 [inline]
 pub fn (r SysRNG) f32() f32 {
-	return f32(r.u32()) / util.max_u32_as_f32
+	return f32(r.u32()) / constants.max_u32_as_f32
 }
 
 // r.f64() returns a pseudorandom f64 value between 0.0 (inclusive) and 1.0 (exclusive) i.e [0, 1)
 [inline]
 pub fn (r SysRNG) f64() f64 {
-	return f64(r.u64()) / util.max_u64_as_f64
+	return f64(r.u64()) / constants.max_u64_as_f64
 }
 
 // r.f32n() returns a pseudorandom f32 value in [0, max)

--- a/vlib/rand/util/util.v
+++ b/vlib/rand/util/util.v
@@ -3,13 +3,4 @@
 // that can be found in the LICENSE file.
 module util
 
-// Commonly used constants across RNGs - some taken from "Numerical Recipes".
-pub const (
-	lower_mask     = u64(0x00000000FFFFFFFF)
-	max_u32        = 0xFFFFFFFF
-	max_u64        = 0xFFFFFFFFFFFFFFFF
-	max_u32_as_f32 = f32(max_u32) + 1
-	max_u64_as_f64 = f64(max_u64) + 1
-	u31_mask       = u32(0x7FFFFFFF)
-	u63_mask       = u64(0x7FFFFFFFFFFFFFFF)
-)
+

--- a/vlib/rand/wyrand/wyrand.v
+++ b/vlib/rand/wyrand/wyrand.v
@@ -5,7 +5,7 @@ module wyrand
 
 import math.bits
 import rand.seed
-import rand.util
+import rand.constants
 import hash
 
 // Redefinition of some constants that we will need for pseudorandom number generation.
@@ -40,7 +40,7 @@ pub fn (mut rng WyRandRNG) u32() u32 {
 		return rng.extra
 	}
 	full_value := rng.u64()
-	lower := u32(full_value & util.lower_mask)
+	lower := u32(full_value & constants.lower_mask)
 	upper := u32(full_value >> 32)
 	rng.extra = upper
 	rng.has_extra = true
@@ -149,13 +149,13 @@ pub fn (mut rng WyRandRNG) i64() i64 {
 // int31 returns a positive pseudorandom 31-bit `int`.
 [inline]
 pub fn (mut rng WyRandRNG) int31() int {
-	return int(rng.u32() & util.u31_mask) // Set the 32nd bit to 0.
+	return int(rng.u32() & constants.u31_mask) // Set the 32nd bit to 0.
 }
 
 // int63 returns a positive pseudorandom 63-bit `i64`.
 [inline]
 pub fn (mut rng WyRandRNG) int63() i64 {
-	return i64(rng.u64() & util.u63_mask) // Set the 64th bit to 0.
+	return i64(rng.u64() & constants.u63_mask) // Set the 64th bit to 0.
 }
 
 // intn returns a pseudorandom `int` in range `[0, max)`.
@@ -202,13 +202,13 @@ pub fn (mut rng WyRandRNG) i64_in_range(min i64, max i64) i64 {
 // f32 returns a pseudorandom `f32` value in range `[0, 1)`.
 [inline]
 pub fn (mut rng WyRandRNG) f32() f32 {
-	return f32(rng.u32()) / util.max_u32_as_f32
+	return f32(rng.u32()) / constants.max_u32_as_f32
 }
 
 // f64 returns a pseudorandom `f64` value in range `[0, 1)`.
 [inline]
 pub fn (mut rng WyRandRNG) f64() f64 {
-	return f64(rng.u64()) / util.max_u64_as_f64
+	return f64(rng.u64()) / constants.max_u64_as_f64
 }
 
 // f32n returns a pseudorandom `f32` value in range `[0, max)`.


### PR DESCRIPTION
This PR is a preparation for adding new functions to the `util` submodule. Currently, adding new functions in `util.v` creates a circular dependency, causing compilation to fail. Moving the constants out of this module prevents that from happening and the utility functions can import `rand` without any problems.