### PR TITLE
vdoc: set max-width for images

### DIFF
--- a/cmd/tools/vdoc/resources/doc.css
+++ b/cmd/tools/vdoc/resources/doc.css
@@ -342,7 +342,8 @@ body {
 	overflow: hidden;
 }
 .doc-content img {
-	width: 100%;
+	width: auto;
+	max-width: 100%;
 }
 .doc-content p {
 	line-height: 1.4;


### PR DESCRIPTION
This fixes an issue wherein an image is resized to the page container's full width: 

![image](https://user-images.githubusercontent.com/7358345/106269892-1ac26380-6268-11eb-9da2-82bd1fc325b7.png)
