### PR TITLE
checker: fix compile-time call with string identifier expression

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1132,6 +1132,7 @@ pub:
 	embed_file  EmbeddedFile
 pub mut:
 	sym table.TypeSymbol
+	result_type table.Type
 }
 
 pub struct None {

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1133,7 +1133,7 @@ pub:
 	is_embed    bool
 	embed_file  EmbeddedFile
 pub mut:
-	sym table.TypeSymbol
+	sym         table.TypeSymbol
 	result_type table.Type
 }
 

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1124,6 +1124,8 @@ pub struct ComptimeCall {
 pub:
 	has_parens  bool // if $() is used, for vfmt
 	method_name string
+	method_pos  token.Position
+	scope       &Scope
 	left        Expr
 	is_vweb     bool
 	vweb_tmpl   File

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3643,6 +3643,9 @@ fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) table.Type {
 		node.result_type = rtyp
 		return rtyp
 	}
+	if node.is_vweb || node.method_name == 'method' {
+		return table.string_type
+	}
 	// s.$my_str()
 	v := node.scope.find_var(node.method_name) or {
 		c.error('unknown identifier `$node.method_name`', node.method_pos)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3639,7 +3639,9 @@ fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) table.Type {
 		c.nr_errors += c2.nr_errors
 	}
 	if node.method_name == 'html' {
-		return c.table.find_type_idx('vweb.Result')
+		rtyp := c.table.find_type_idx('vweb.Result')
+		node.result_type = rtyp
+		return rtyp
 	}
 	mut var := c.fn_scope.objects[node.method_name]
 	if mut var is ast.Var {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3643,12 +3643,32 @@ fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) table.Type {
 		node.result_type = rtyp
 		return rtyp
 	}
-	mut var := c.fn_scope.objects[node.method_name]
-	if mut var is ast.Var {
-		var.is_used = true
-		c.fn_scope.objects[node.method_name] = var
+	// s.$my_str()
+	v := node.scope.find_var(node.method_name) or {
+		c.error('unknown identifier `$node.method_name`', node.method_pos)
+		return table.void_type
 	}
-	return table.string_type
+	if v.typ != table.string_type {
+		s := c.expected_msg(v.typ, table.string_type)
+		c.error('invalid string method call: $s', node.method_pos)
+		return table.void_type
+	}
+	// note: we should use a compile-time evaluation function rather than handle here
+	// mut variables will not work after init
+	mut method_name := ''
+	if v.expr is ast.StringLiteral {
+		method_name = v.expr.val
+	} else {
+		c.add_error_detail(v.expr.type_name())
+		c.error('todo: not a string literal', node.method_pos)
+	}
+	f := node.sym.find_method(method_name) or {
+		c.error('could not find method `$method_name`', node.method_pos)
+		return table.void_type
+	}
+	println(f.name + ' ' + c.table.type_to_str(f.return_type))
+	node.result_type = f.return_type
+	return f.return_type
 }
 
 fn (mut c Checker) at_expr(mut node ast.AtExpr) table.Type {

--- a/vlib/v/checker/tests/comptime_call_no_unused_var.out
+++ b/vlib/v/checker/tests/comptime_call_no_unused_var.out
@@ -1,1 +1,29 @@
-
+print void
+vlib/v/checker/tests/comptime_call_no_unused_var.vv:11:8: error: unknown identifier `w`
+    9 |     abc := 'print'
+   10 |     test.$abc() // OK
+   11 |     test.$w()
+      |           ^
+   12 |     v := 4
+   13 |     test.$v()
+vlib/v/checker/tests/comptime_call_no_unused_var.vv:13:8: error: invalid string method call: expected `string`, not `int`
+   11 |     test.$w()
+   12 |     v := 4
+   13 |     test.$v()
+      |           ^
+   14 |     s := 'x' + 'y'
+   15 |     test.$s()
+vlib/v/checker/tests/comptime_call_no_unused_var.vv:15:8: error: todo: not a string literal
+   13 |     test.$v()
+   14 |     s := 'x' + 'y'
+   15 |     test.$s()
+      |           ^
+   16 |     s2 := 'x'
+   17 |     test.$s2()
+details: v.ast.InfixExpr
+vlib/v/checker/tests/comptime_call_no_unused_var.vv:17:8: error: could not find method `x`
+   15 |     test.$s()
+   16 |     s2 := 'x'
+   17 |     test.$s2()
+      |           ~~
+   18 | }

--- a/vlib/v/checker/tests/comptime_call_no_unused_var.vv
+++ b/vlib/v/checker/tests/comptime_call_no_unused_var.vv
@@ -7,5 +7,12 @@ fn (test Test) print() {
 fn main() {
 	test := Test{}
 	abc := 'print'
-	test.$abc()
+	test.$abc() // OK
+	test.$w()
+	v := 4
+	test.$v()
+	s := 'x' + 'y'
+	test.$s()
+	s2 := 'x'
+	test.$s2()
 }

--- a/vlib/v/gen/comptime.v
+++ b/vlib/v/gen/comptime.v
@@ -95,7 +95,6 @@ fn (mut g Gen) comptime_call(node ast.ComptimeCall) {
 	}
 	mut j := 0
 	for method in node.sym.methods {
-		p
 		// if method.return_type != table.void_type {
 		if method.return_type != node.result_type {
 			continue
@@ -111,7 +110,9 @@ fn (mut g Gen) comptime_call(node ast.ComptimeCall) {
 		if j > 0 {
 			g.write(' else ')
 		}
-		g.write('if (string_eq($node.method_name, _SLIT("$method.name"))) ')
+		if node.is_vweb {
+			g.write('if (string_eq($node.method_name, _SLIT("$method.name"))) ')
+		}
 		g.write('${util.no_dots(node.sym.name)}_${method.name}($amp ')
 		g.expr(node.left)
 		g.writeln(');')

--- a/vlib/v/gen/comptime.v
+++ b/vlib/v/gen/comptime.v
@@ -57,9 +57,7 @@ fn (mut g Gen) comptime_call(node ast.ComptimeCall) {
 		}
 		return
 	}
-	g.writeln('// $' + 'method call. sym="$node.sym.name"')
-	mut j := 0
-	result_type := g.table.find_type_idx('vweb.Result') // TODO not just vweb
+	g.writeln('// \$method call. sym="$node.sym.name"')
 	if node.method_name == 'method' {
 		// `app.$method()`
 		m := node.sym.find_method(g.comp_for_method) or { return }
@@ -95,9 +93,11 @@ fn (mut g Gen) comptime_call(node ast.ComptimeCall) {
 		g.write(' ); // vweb action call with args')
 		return
 	}
+	mut j := 0
 	for method in node.sym.methods {
+		p
 		// if method.return_type != table.void_type {
-		if method.return_type != result_type {
+		if method.return_type != node.result_type {
 			continue
 		}
 		if method.params.len != 1 {

--- a/vlib/v/gen/comptime.v
+++ b/vlib/v/gen/comptime.v
@@ -107,10 +107,10 @@ fn (mut g Gen) comptime_call(node ast.ComptimeCall) {
 		// p.error('`$p.expr_var.name` needs to be a reference')
 		// }
 		amp := '' // if receiver.is_mut && !p.expr_var.ptr { '&' } else { '' }
-		if j > 0 {
-			g.write(' else ')
-		}
 		if node.is_vweb {
+			if j > 0 {
+				g.write(' else ')
+			}
 			g.write('if (string_eq($node.method_name, _SLIT("$method.name"))) ')
 		}
 		g.write('${util.no_dots(node.sym.name)}_${method.name}($amp ')

--- a/vlib/v/gen/embed.v
+++ b/vlib/v/gen/embed.v
@@ -27,7 +27,7 @@ fn (mut g Gen) gen_embed_file_init(node ast.ComptimeCall) {
 	g.writeln('\t\t.free_compressed = 0,')
 	g.writeln('\t\t.free_uncompressed = 0,')
 	g.writeln('\t\t.len = $file_size')
-	g.writeln('} // $' + 'embed_file("$node.embed_file.apath")')
+	g.writeln('} // \$embed_file("$node.embed_file.apath")')
 }
 
 // gen_embedded_data embeds data into the V target executable.

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -43,7 +43,9 @@ fn (mut p Parser) hash() ast.HashStmt {
 }
 
 fn (mut p Parser) comp_call() ast.ComptimeCall {
-	err_node := ast.ComptimeCall{scope: 0}
+	err_node := ast.ComptimeCall{
+		scope: 0
+	}
 	p.check(.dollar)
 	error_msg := 'only `\$tmpl()`, `\$embed_file()` and `\$vweb.html()` comptime functions are supported right now'
 	if p.peek_tok.kind == .dot {

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -43,20 +43,21 @@ fn (mut p Parser) hash() ast.HashStmt {
 }
 
 fn (mut p Parser) comp_call() ast.ComptimeCall {
+	err_node := ast.ComptimeCall{scope: 0}
 	p.check(.dollar)
 	error_msg := 'only `\$tmpl()`, `\$embed_file()` and `\$vweb.html()` comptime functions are supported right now'
 	if p.peek_tok.kind == .dot {
 		n := p.check_name() // skip `vweb.html()` TODO
 		if n != 'vweb' {
 			p.error(error_msg)
-			return ast.ComptimeCall{}
+			return err_node
 		}
 		p.check(.dot)
 	}
 	n := p.check_name() // (.name)
 	if n !in parser.supported_comptime_calls {
 		p.error(error_msg)
-		return ast.ComptimeCall{}
+		return err_node
 	}
 	is_embed_file := n == 'embed_file'
 	is_html := n == 'html'
@@ -74,7 +75,7 @@ fn (mut p Parser) comp_call() ast.ComptimeCall {
 		if epath == '' {
 			p.error_with_pos('please supply a valid relative or absolute file path to the file to embed',
 				spos)
-			return ast.ComptimeCall{}
+			return err_node
 		}
 		if !p.pref.is_fmt {
 			abs_path := os.real_path(epath)
@@ -85,12 +86,12 @@ fn (mut p Parser) comp_call() ast.ComptimeCall {
 				if !os.exists(epath) {
 					p.error_with_pos('"$epath" does not exist so it cannot be embedded',
 						spos)
-					return ast.ComptimeCall{}
+					return err_node
 				}
 				if !os.is_file(epath) {
 					p.error_with_pos('"$epath" is not a file so it cannot be embedded',
 						spos)
-					return ast.ComptimeCall{}
+					return err_node
 				}
 			} else {
 				epath = abs_path
@@ -98,6 +99,7 @@ fn (mut p Parser) comp_call() ast.ComptimeCall {
 		}
 		p.register_auto_import('v.embed_file')
 		return ast.ComptimeCall{
+			scope: 0
 			is_embed: true
 			embed_file: ast.EmbeddedFile{
 				rpath: s
@@ -126,11 +128,10 @@ fn (mut p Parser) comp_call() ast.ComptimeCall {
 		if !os.exists(path) {
 			if is_html {
 				p.error('vweb HTML template "$path" not found')
-				return ast.ComptimeCall{}
 			} else {
 				p.error('template file "$path" not found')
-				return ast.ComptimeCall{}
 			}
+			return err_node
 		}
 		// println('path is now "$path"')
 	}
@@ -185,6 +186,7 @@ fn (mut p Parser) comp_call() ast.ComptimeCall {
 		}
 	}
 	return ast.ComptimeCall{
+		scope: 0
 		is_vweb: true
 		vweb_tmpl: file
 		method_name: n
@@ -262,7 +264,9 @@ fn (mut p Parser) comptime_selector(left ast.Expr) ast.Expr {
 		has_parens = true
 	}
 	if p.peek_tok.kind == .lpar {
+		method_pos := p.tok.position()
 		method_name := p.check_name()
+		p.mark_var_as_used(method_name)
 		// `app.$action()` (`action` is a string)
 		if has_parens {
 			p.check(.rpar)
@@ -282,6 +286,8 @@ fn (mut p Parser) comptime_selector(left ast.Expr) ast.Expr {
 			has_parens: has_parens
 			left: left
 			method_name: method_name
+			method_pos: method_pos
+			scope: p.scope
 			args_var: args_var
 		}
 	}

--- a/vlib/v/tests/comptime_call_test.v
+++ b/vlib/v/tests/comptime_call_test.v
@@ -1,0 +1,23 @@
+struct Test {}
+
+fn (test Test) v() {
+	println('in v()')
+}
+fn (test Test) i() int {
+	return 4
+}
+fn (test Test) s() string {
+	return 'test'
+}
+
+fn test_call() {
+	test := Test{}
+	sv := 'v'
+	test.$sv()
+	si := 'i'
+	ri := test.$si()
+	assert ri == 4
+	ss := 's'
+	rs := test.$ss()
+	assert rs == 'test'
+}

--- a/vlib/v/tests/comptime_call_test.v
+++ b/vlib/v/tests/comptime_call_test.v
@@ -9,6 +9,9 @@ fn (test Test) i() int {
 fn (test Test) s() string {
 	return 'test'
 }
+fn (test Test) s2() string {
+	return 'Two'
+}
 
 fn test_call() {
 	test := Test{}


### PR DESCRIPTION
Note: There are 4 forms of compile-time call:
* $vweb.html()
* $embed_file()
* s.$method() - with `$for method in T.methods`
* s.$my_var() - string expression call form with `my_var := 'method_name'`.

This pull is for the last form above - improve checking and fix actually calling the method (before nothing was generated). There is an existing checker test for this form but it only really checked that the call compiled.

Note this pull's checking is not perfect (it should error when trying to read a mutable variable's initialization). I do not think we should handle that only for this specific case, and I think there is some support for compile-time evaluation of expressions, so a later pull could use that instead.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
