### PR TITLE
fmt: keep user choice for newlines in match branches

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -658,6 +658,7 @@ pub:
 	cond     Expr
 	branches []MatchBranch
 	pos      token.Position
+	comments []Comment // comments before the first branch
 pub mut:
 	is_expr       bool // returns a value
 	return_type   table.Type
@@ -672,9 +673,8 @@ pub:
 	ecmnts        [][]Comment // inline comments for each left side expr
 	stmts         []Stmt      // right side
 	pos           token.Position
-	comments      []Comment // comment above `xxx {`
 	is_else       bool
-	post_comments []Comment
+	post_comments []Comment // comments below ´... }´
 pub mut:
 	scope &Scope
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4790,13 +4790,21 @@ pub fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) table.Type {
 	// TODO: testing ref/deref strategy
 	if node.op == .amp && !right_type.is_ptr() {
 		match node.right {
-			ast.IntegerLiteral { c.error('cannot take the address of an int literal',
-					node.pos) }
-			ast.BoolLiteral { c.error('cannot take the address of a bool literal', node.pos) }
-			ast.StringLiteral, ast.StringInterLiteral { c.error('cannot take the address of a string literal',
-					node.pos) }
-			ast.FloatLiteral { c.error('cannot take the address of a float literal', node.pos) }
-			ast.CharLiteral { c.error('cannot take the address of a char literal', node.pos) }
+			ast.IntegerLiteral {
+				c.error('cannot take the address of an int literal', node.pos)
+			}
+			ast.BoolLiteral {
+				c.error('cannot take the address of a bool literal', node.pos)
+			}
+			ast.StringLiteral, ast.StringInterLiteral {
+				c.error('cannot take the address of a string literal', node.pos)
+			}
+			ast.FloatLiteral {
+				c.error('cannot take the address of a float literal', node.pos)
+			}
+			ast.CharLiteral {
+				c.error('cannot take the address of a char literal', node.pos)
+			}
 			else {}
 		}
 		if mut node.right is ast.IndexExpr {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1744,7 +1744,7 @@ pub fn (mut f Fmt) match_expr(it ast.MatchExpr) {
 	f.indent++
 	mut single_line := true
 	for branch in it.branches {
-		if branch.stmts.len > 1 {
+		if branch.stmts.len > 1 || branch.pos.line_nr < branch.pos.last_line {
 			single_line = false
 			break
 		}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1742,9 +1742,11 @@ pub fn (mut f Fmt) match_expr(it ast.MatchExpr) {
 	}
 	f.writeln(' {')
 	f.indent++
+	f.comments(it.comments, {})
 	mut single_line := true
 	for branch in it.branches {
 		if branch.stmts.len > 1 || branch.pos.line_nr < branch.pos.last_line {
+			println(branch)
 			single_line = false
 			break
 		}
@@ -1757,10 +1759,6 @@ pub fn (mut f Fmt) match_expr(it ast.MatchExpr) {
 		}
 	}
 	for branch in it.branches {
-		for cmnt in branch.comments {
-			f.comment(cmnt, inline: true)
-			f.writeln('')
-		}
 		if !branch.is_else {
 			// normal branch
 			f.is_mbranch_expr = true

--- a/vlib/v/fmt/tests/match_expected.vv
+++ b/vlib/v/fmt/tests/match_expected.vv
@@ -1,12 +1,3 @@
-fn match_expr() {
-	a := 10
-	match a {
-		10 { println('10') }
-		20 { println('20') }
-		else {}
-	}
-}
-
 fn match_expr_assignment() {
 	a := 20
 	_ := match a {

--- a/vlib/v/fmt/tests/match_input.vv
+++ b/vlib/v/fmt/tests/match_input.vv
@@ -1,16 +1,3 @@
-fn match_expr() {
-	a := 10
-	match a {
-		10 {
-			println('10')
-		}
-		20 {
-			println('20')
-		}
-		else {}
-	}
-}
-
 fn match_expr_assignment() {
     a := 20
 	_ := match a {

--- a/vlib/v/fmt/tests/match_keep.vv
+++ b/vlib/v/fmt/tests/match_keep.vv
@@ -1,5 +1,4 @@
-fn main() {
-	// Nested match
+fn nested_match() {
 	match 100 {
 		0...1 {
 			println('0 to 1')
@@ -11,7 +10,9 @@ fn main() {
 			}
 		}
 	}
-	// StructInit
+}
+
+fn branches_are_struct_inits() {
 	match 'a' {
 		'b' { SpamStruct{} }
 	}
@@ -25,11 +26,13 @@ fn main() {
 	match 'a' {
 		'b' {
 			SpamStruct{
-				// only a comment
+				// comment inside init
 			}
 		}
 	}
-	// CallExpr with or block
+}
+
+fn branches_are_call_exprs_with_or_blocks() {
 	match 'a' {
 		'b' { foo() or { panic(err) } }
 	}
@@ -48,5 +51,23 @@ fn main() {
 				panic(err)
 			}
 		}
+	}
+}
+
+fn keep_branch_linebreaks() {
+	a := 10
+	match a {
+		10 {
+			println('10')
+		}
+		20 {
+			println('20')
+		}
+		else {}
+	}
+	match a {
+		10 { println('10') }
+		20 { println('20') }
+		else {}
 	}
 }

--- a/vlib/v/fmt/tests/match_keep.vv
+++ b/vlib/v/fmt/tests/match_keep.vv
@@ -57,6 +57,7 @@ fn branches_are_call_exprs_with_or_blocks() {
 fn keep_branch_linebreaks() {
 	a := 10
 	match a {
+		// first comment
 		10 {
 			println('10')
 		}
@@ -66,7 +67,9 @@ fn keep_branch_linebreaks() {
 		else {}
 	}
 	match a {
+		// first comment
 		10 { println('10') }
+		// post_comment of the first branch
 		20 { println('20') }
 		else {}
 	}

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -236,12 +236,8 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 		branch_scope := p.scope
 		p.close_scope()
 		p.inside_match_body = false
-		mut pos := branch_first_pos.extend(branch_last_pos)
+		pos := branch_first_pos.extend_with_last_line(branch_last_pos, p.prev_tok.line_nr)
 		post_comments := p.eat_comments()
-		pos.update_last_line(p.prev_tok.line_nr)
-		if post_comments.len > 0 {
-			pos.last_line = post_comments.last().pos.last_line
-		}
 		branches << ast.MatchBranch{
 			exprs: exprs
 			ecmnts: ecmnts

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -167,10 +167,10 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 	if !no_lcbr {
 		p.check(.lcbr)
 	}
+	comments := p.eat_comments() // comments before the first branch
 	mut branches := []ast.MatchBranch{}
 	for p.tok.kind != .eof {
 		branch_first_pos := p.tok.position()
-		comments := p.eat_comments() // comments before {}
 		mut exprs := []ast.Expr{}
 		mut ecmnts := [][]ast.Comment{}
 		p.open_scope()
@@ -243,7 +243,6 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 			ecmnts: ecmnts
 			stmts: stmts
 			pos: pos
-			comments: comments
 			is_else: is_else
 			post_comments: post_comments
 			scope: branch_scope
@@ -271,6 +270,7 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 		cond: cond
 		is_sum_type: is_sum_type
 		pos: pos
+		comments: comments
 	}
 }
 


### PR DESCRIPTION
fix #8063 