### PR TITLE
gen: fix `for ... in array`

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1292,7 +1292,8 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		g.expr(it.cond)
 		g.writeln(';')
 		i := if it.key_var in ['', '_'] { g.new_tmp_var() } else { it.key_var }
-		op_field := if it.cond_type.is_ptr() { '->' } else { '.' } + if it.cond_type.share() == .shared_t { 'val.' } else { '' }
+		op_field := if it.cond_type.is_ptr() { '->' } else { '.' } +
+			if it.cond_type.share() == .shared_t { 'val.' } else { '' }
 		g.writeln('for (int $i = 0; $i < $tmp${op_field}len; ++$i) {')
 		if it.val_var != '_' {
 			if val_sym.kind == .function {

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1286,14 +1286,13 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		g.writeln('// FOR IN array')
 		styp := g.typ(it.val_type)
 		val_sym := g.table.get_type_symbol(it.val_type)
-		cond_type_is_ptr := it.cond_type.is_ptr()
 		tmp := g.new_tmp_var()
-		tmp_type := if cond_type_is_ptr { 'array *' } else { 'array' }
-		g.write('$tmp_type $tmp = ')
+		g.write(g.typ(it.cond_type))
+		g.write(' $tmp = ')
 		g.expr(it.cond)
 		g.writeln(';')
 		i := if it.key_var in ['', '_'] { g.new_tmp_var() } else { it.key_var }
-		op_field := if cond_type_is_ptr { '->' } else { '.' }
+		op_field := if it.cond_type.is_ptr() { '->' } else { '.' }
 		g.writeln('for (int $i = 0; $i < $tmp${op_field}len; ++$i) {')
 		if it.val_var != '_' {
 			if val_sym.kind == .function {
@@ -1353,9 +1352,9 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		g.writeln('// FOR IN map')
 		idx := g.new_tmp_var()
 		atmp := g.new_tmp_var()
-		atmp_styp := g.typ(it.cond_type)
-		arw_or_pt := if it.cond_type.nr_muls() > 0 { '->' } else { '.' }
-		g.write('$atmp_styp $atmp = ')
+		arw_or_pt := if it.cond_type.is_ptr() { '->' } else { '.' }
+		g.write(g.typ(it.cond_type))
+		g.write(' $atmp = ')
 		g.expr(it.cond)
 		g.writeln(';')
 		g.writeln('for (int $idx = 0; $idx < $atmp${arw_or_pt}key_values.len; ++$idx) {')

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -1292,7 +1292,7 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 		g.expr(it.cond)
 		g.writeln(';')
 		i := if it.key_var in ['', '_'] { g.new_tmp_var() } else { it.key_var }
-		op_field := if it.cond_type.is_ptr() { '->' } else { '.' }
+		op_field := if it.cond_type.is_ptr() { '->' } else { '.' } + if it.cond_type.share() == .shared_t { 'val.' } else { '' }
 		g.writeln('for (int $i = 0; $i < $tmp${op_field}len; ++$i) {')
 		if it.val_var != '_' {
 			if val_sym.kind == .function {

--- a/vlib/v/tests/array_test.v
+++ b/vlib/v/tests/array_test.v
@@ -9,3 +9,12 @@ fn test_for_in_array_named_array() {
 		assert *elem == 2
 	}
 }
+
+fn test_for_in_shared_array_named_array() {
+	shared array := &[1]
+	rlock array {
+		for elem in array {
+			assert elem == 1
+		}
+	}
+}

--- a/vlib/v/tests/array_test.v
+++ b/vlib/v/tests/array_test.v
@@ -1,0 +1,11 @@
+fn test_for_in_array_named_array() {
+	mut array := [1]
+	for elem in array {
+		assert elem == 1
+	}
+	for mut elem in array {
+		assert *elem == 1
+		elem = 2
+		assert *elem == 2
+	}
+}


### PR DESCRIPTION
Fixes #8389

As explained [in this comment](https://github.com/vlang/v/pull/8401#issuecomment-770021635), the generated C code began with `array _t<x> = array;` which confused the compiler. So instead, it now uses the actual type of the array (e.g. `array_int`). Some special handling is required for shared arrays, because there used to be a pointer cast from two incompatible types (`__shared__array_int` to `array`, which worked because the `val` attribute of `__shared__array_int`, so the array, was the first attribute).

Also adds tests.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
