### PR TITLE
vfmt: added formatting of piped input to stdout

### DIFF
--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -93,7 +93,7 @@ fn main() {
 		foptions.format_pipe()
 		exit(0)
 	}
-	if files.len == 0 {
+	if files.len == 0 || '-help' in args || '--help' in args {
 		vhelp.show_topic('fmt')
 		exit(0)
 	}
@@ -182,9 +182,10 @@ fn (foptions &FormatOptions) format_pipe() {
 	if foptions.is_verbose {
 		eprintln('vfmt2 running fmt.fmt over stdin')
 	}
+	input_text := os.get_all()
 	table := table.new_table()
 	// checker := checker.new_checker(table, prefs)
-	file_ast := parser.parse_stdin(table, .parse_comments, prefs, &ast.Scope{
+	file_ast := parser.parse_text(input_text, '', table, .parse_comments, prefs, &ast.Scope{
 		parent: 0
 	})
 	// checker.check(file_ast)

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -182,7 +182,7 @@ fn (foptions &FormatOptions) format_pipe() {
 	if foptions.is_verbose {
 		eprintln('vfmt2 running fmt.fmt over stdin')
 	}
-	input_text := os.get_all()
+	input_text := os.get_raw_lines_joined()
 	table := table.new_table()
 	// checker := checker.new_checker(table, prefs)
 	file_ast := parser.parse_text(input_text, '', table, .parse_comments, prefs, &ast.Scope{

--- a/cmd/v/help/fmt.txt
+++ b/cmd/v/help/fmt.txt
@@ -1,6 +1,8 @@
 Usage:
   v fmt [options] path_to_source.v [path_to_other_source.v]
   v fmt [options] path/to/dir [path/to/other_dir]
+  cat source.v | v fmt
+        Read source code from stdin, output formatted file to stdout.
 
 Formats the given V source files or recursively formats all files in the directory,
 then prints their formatted source to stdout.
@@ -21,8 +23,6 @@ Options:
 
   -verify Make sure the provided file is already formatted. Useful for checking code contributions
           in CI for example.
-
-  -pipe   Expect no file. Read from stdin and output formatted file to stdout.
 
 Environment Variables:
   VDIFF_TOOL      A command-line tool that will be executed with the original file path

--- a/cmd/v/help/fmt.txt
+++ b/cmd/v/help/fmt.txt
@@ -22,6 +22,8 @@ Options:
   -verify Make sure the provided file is already formatted. Useful for checking code contributions
           in CI for example.
 
+  -pipe   Expect no file. Read from stdin and output formatted file to stdout.
+
 Environment Variables:
   VDIFF_TOOL      A command-line tool that will be executed with the original file path
                   and a temporary formatted file path as arguments. e.g.

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -265,6 +265,20 @@ pub fn get_lines_joined() string {
 	return inputstr
 }
 
+// get_all reads all data from stdin and returns it as a string.
+pub fn get_all() string {
+	mut line := ''
+	mut inputstr := ''
+	for {
+		line = get_raw_line()
+		if line.len <= 0 {
+			break
+		}
+		inputstr += line
+	}
+	return inputstr
+}
+
 // user_os returns current user operating system name.
 pub fn user_os() string {
 	$if linux {

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -265,18 +265,23 @@ pub fn get_lines_joined() string {
 	return inputstr
 }
 
-// get_all reads all data from stdin and returns it as a string.
-pub fn get_all() string {
+// get_raw_lines_joined reads *all* input lines from stdin.
+// It returns them as one large string. NB: unlike os.get_lines_joined,
+// empty lines (that contain only `\r\n` or `\n`), will be present in
+// the output.
+// Reading is stopped, only on EOF of stdin.
+pub fn get_raw_lines_joined() string {
 	mut line := ''
-	mut inputstr := ''
+	mut lines := []string{}
 	for {
 		line = get_raw_line()
 		if line.len <= 0 {
 			break
 		}
-		inputstr += line
+		lines << line
 	}
-	return inputstr
+	res := lines.join('')
+	return res
 }
 
 // user_os returns current user operating system name.

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -162,6 +162,29 @@ pub fn parse_file(path string, table &table.Table, comments_mode scanner.Comment
 	return p.parse()
 }
 
+// parse_stdin reads everything from stdin and parses it as a v file.
+pub fn parse_stdin(table &table.Table, comments_mode scanner.CommentsMode, pref &pref.Preferences, global_scope &ast.Scope) ast.File {
+	// NB: when comments_mode == .toplevel_comments,
+	// the parser gives feedback to the scanner about toplevel statements, so that the scanner can skip
+	// all the tricky inner comments. This is needed because we do not have a good general solution
+	// for handling them, and should be removed when we do (the general solution is also needed for vfmt)
+	mut p := Parser{
+		scanner: scanner.new_scanner(os.get_all(), comments_mode, pref)
+		comments_mode: comments_mode
+		table: table
+		pref: pref
+		scope: &ast.Scope{
+			start_pos: 0
+			parent: global_scope
+		}
+		errors: []errors.Error{}
+		warnings: []errors.Warning{}
+		global_scope: global_scope
+	}
+
+	return p.parse()
+}
+
 pub fn parse_vet_file(path string, table_ &table.Table, pref &pref.Preferences) (ast.File, []vet.Error) {
 	global_scope := &ast.Scope{
 		parent: 0

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -162,29 +162,6 @@ pub fn parse_file(path string, table &table.Table, comments_mode scanner.Comment
 	return p.parse()
 }
 
-// parse_stdin reads everything from stdin and parses it as a v file.
-pub fn parse_stdin(table &table.Table, comments_mode scanner.CommentsMode, pref &pref.Preferences, global_scope &ast.Scope) ast.File {
-	// NB: when comments_mode == .toplevel_comments,
-	// the parser gives feedback to the scanner about toplevel statements, so that the scanner can skip
-	// all the tricky inner comments. This is needed because we do not have a good general solution
-	// for handling them, and should be removed when we do (the general solution is also needed for vfmt)
-	mut p := Parser{
-		scanner: scanner.new_scanner(os.get_all(), comments_mode, pref)
-		comments_mode: comments_mode
-		table: table
-		pref: pref
-		scope: &ast.Scope{
-			start_pos: 0
-			parent: global_scope
-		}
-		errors: []errors.Error{}
-		warnings: []errors.Warning{}
-		global_scope: global_scope
-	}
-
-	return p.parse()
-}
-
 pub fn parse_vet_file(path string, table_ &table.Table, pref &pref.Preferences) (ast.File, []vet.Error) {
 	global_scope := &ast.Scope{
 		parent: 0

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -457,15 +457,7 @@ pub fn parse_args(args []string) (&Preferences, string) {
 				output_option = '-o "$tmp_exe_file_path"'
 			}
 			tmp_v_file_path := '${tmp_file_path}.v'
-			mut lines := []string{}
-			for {
-				iline := os.get_raw_line()
-				if iline.len == 0 {
-					break
-				}
-				lines << iline
-			}
-			contents := lines.join('')
+			contents := os.get_raw_lines_joined()
 			os.write_file(tmp_v_file_path, contents) or {
 				panic('Failed to create temporary file $tmp_v_file_path')
 			}


### PR DESCRIPTION
Allows vfmt to recieve piped input form a text editor to correct buffer format before saving.

Added some functions to be able to work with the stdin data. Updated help text. Added -pipe command line argument.

Parse stdin into ast then format and print.
```
fn (foptions &FormatOptions) format_pipe()
```

Added function to get all input from stdin. Current get_lines_joined appends lines together without separators. Perhaps it is more correct to fix that.
```
+// get_all reads all data from stdin and returns it as a string.
+pub fn get_all() string {
+	mut line := ''
+	mut inputstr := ''
+	for {
+		line = get_raw_line()
+		if line.len <= 0 {
+			break
+		}
+		inputstr += line
+	}
+	return inputstr
+}
```

Added parse_stdin which creates a scanner with all input from stdin and does parsing.
```
+// parse_stdin reads everything from stdin and parses it as a v file.
+pub fn parse_stdin(table &table.Table, comments_mode scanner.CommentsMode, pref &pref.Preferences, global_scope &ast.Scope) ast.File {
+	// NB: when comments_mode == .toplevel_comments,
+	// the parser gives feedback to the scanner about toplevel statements, so that the scanner can skip
+	// all the tricky inner comments. This is needed because we do not have a good general solution
+	// for handling them, and should be removed when we do (the general solution is also needed for vfmt)
+	mut p := Parser{
+		scanner: scanner.new_scanner(os.get_all(), comments_mode, pref)
+		comments_mode: comments_mode
+		table: table
+		pref: pref
+		scope: &ast.Scope{
+			start_pos: 0
+			parent: global_scope
+		}
+		errors: []errors.Error{}
+		warnings: []errors.Warning{}
+		global_scope: global_scope
+	}
+
+	return p.parse()
+}
```


<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->