### PR TITLE
rand: update byte()

### DIFF
--- a/vlib/rand/rand.v
+++ b/vlib/rand/rand.v
@@ -73,7 +73,7 @@ pub fn intn(max int) int {
 
 // byte returns a uniformly distributed pseudorandom 8-bit unsigned positive `byte`.
 pub fn byte() byte {
-	return byte(default_rng.intn(256))
+	return byte(default_rng.u32() & 0xff)
 }
 
 // int_in_range returns a uniformly distributed pseudorandom  32-bit signed int in range `[min, max)`.


### PR DESCRIPTION
Currently, the byte function calls the `intn()` function which is fine for general limits but potentially slower for powers of 2. In this instance, the limit is 256, and a faster way to obtain the desired byte is to call `u32()` and simply mask out the lowest 8 bits. It can potentially avoid extra iterations.

This PR is related to https://github.com/vlang/v/issues/8212