### PR TITLE
checker: support nested propagation cases `f(g() ?)`

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1211,13 +1211,12 @@ pub fn (mut c Checker) call_expr(mut call_expr ast.CallExpr) table.Type {
 	c.expected_or_type = call_expr.return_type.clear_flag(.optional)
 	c.stmts(call_expr.or_block.stmts)
 	c.expected_or_type = table.void_type
-	if call_expr.or_block.kind == .propagate {
-		if !c.cur_fn.return_type.has_flag(.optional) && !c.inside_const {
-			cur_names := c.cur_fn.name.split('.')
-			if cur_names[cur_names.len-1] != 'main' {
-				c.error('to propagate the optional call, `${c.cur_fn.name}` must return an optional',
-					call_expr.or_block.pos)
-			}
+	if call_expr.or_block.kind == .propagate && !c.cur_fn.return_type.has_flag(.optional)
+		&& !c.inside_const {
+		cur_names := c.cur_fn.name.split('.')
+		if cur_names[cur_names.len - 1] != 'main' {
+			c.error('to propagate the optional call, `$c.cur_fn.name` must return an optional',
+				call_expr.or_block.pos)
 		}
 	}
 	return typ
@@ -3716,7 +3715,7 @@ fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) table.Type {
 		c.error('could not find method `$method_name`', node.method_pos)
 		return table.void_type
 	}
-	println(f.name + ' ' + c.table.type_to_str(f.return_type))
+	// println(f.name + ' ' + c.table.type_to_str(f.return_type))
 	node.result_type = f.return_type
 	return f.return_type
 }

--- a/vlib/v/checker/tests/comptime_call_no_unused_var.out
+++ b/vlib/v/checker/tests/comptime_call_no_unused_var.out
@@ -1,4 +1,3 @@
-print void
 vlib/v/checker/tests/comptime_call_no_unused_var.vv:11:8: error: unknown identifier `w`
     9 |     abc := 'print'
    10 |     test.$abc() // OK
@@ -20,7 +19,7 @@ vlib/v/checker/tests/comptime_call_no_unused_var.vv:15:8: error: todo: not a str
       |           ^
    16 |     s2 := 'x'
    17 |     test.$s2()
-details: v.ast.InfixExpr
+Details: v.ast.InfixExpr
 vlib/v/checker/tests/comptime_call_no_unused_var.vv:17:8: error: could not find method `x`
    15 |     test.$s()
    16 |     s2 := 'x'

--- a/vlib/v/checker/tests/optional_propagate_nested.out
+++ b/vlib/v/checker/tests/optional_propagate_nested.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/optional_propagate_nested.vv:10:19: error: to propagate the optional call, `xx_prop` must return an optional
+    8 | 
+    9 | fn xx_prop() string {
+   10 |     s := ret(raise() ?)
+      |                      ^
+   11 |     return s
+   12 | }
+vlib/v/checker/tests/optional_propagate_nested.vv:28:22: error: to propagate the optional call, `aa_propagate` must return an optional
+   26 | 
+   27 | fn (mut s St) aa_propagate() {
+   28 |     f := retf(s.raise() ?)
+      |                         ^
+   29 |     s.z = 7.5
+   30 |     println(f)

--- a/vlib/v/checker/tests/optional_propagate_nested.vv
+++ b/vlib/v/checker/tests/optional_propagate_nested.vv
@@ -1,0 +1,31 @@
+fn ret(s string) string {
+	return s
+}
+
+fn raise() ?string {
+	return none
+}
+
+fn xx_prop() string {
+	s := ret(raise() ?)
+	return s
+}
+
+struct St {
+mut:
+	z f64
+}
+
+fn (mut s St) raise() ?f64 {
+	return error('some error')
+}
+
+fn retf(f f64) f64 {
+	return f
+}
+
+fn (mut s St) aa_propagate() {
+	f := retf(s.raise() ?)
+	s.z = 7.5
+	println(f)
+}

--- a/vlib/v/tests/nested_option_call_test.v
+++ b/vlib/v/tests/nested_option_call_test.v
@@ -15,6 +15,16 @@ fn test_nested_or() {
 	xx()
 }
 
+fn xx_prop() ?string {
+	s := ret(raise() ?)
+	return s
+}
+
+fn test_nested_propagation() {
+	a := xx_prop() or { 'propagated' }
+	assert a == 'propagated'
+}
+
 struct St {
 mut:
 	z f64
@@ -40,4 +50,20 @@ fn test_nested_or_method_call() {
 	}
 	x.aa()
 	assert x.z == 2.25
+}
+
+fn (mut s St) aa_propagate() ? {
+	f := retf(s.raise() ?)
+	s.z = 7.5
+	println(f)
+}
+
+fn test_nested_propagation_method() {
+	mut x := St{
+		z: 2.25
+	}
+	x.aa_propagate() or {
+		x.z = 13.0625
+	}
+	assert x.z == 13.0625
 }


### PR DESCRIPTION
This PR allows error propagation from a nested function call:
```v
fn f() ? {
    g(h() ?)
    ...
}

fn (mut a St) b() ?f64 {
    r(a.x() ?)
    ...
}
```
This partly worked already with #8430. However, in this PR here a test is added that makes sure the enclosing function (`f()` and `b()`) do return an option. Exceptions are `main()` and constant declarations.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
