### PR TITLE
tests: fix weird CI failure with error details

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3708,7 +3708,6 @@ fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) table.Type {
 	if v.expr is ast.StringLiteral {
 		method_name = v.expr.val
 	} else {
-		c.add_error_detail(v.expr.type_name())
 		c.error('todo: not a string literal', node.method_pos)
 	}
 	f := node.sym.find_method(method_name) or {

--- a/vlib/v/checker/tests/comptime_call_no_unused_var.out
+++ b/vlib/v/checker/tests/comptime_call_no_unused_var.out
@@ -19,7 +19,6 @@ vlib/v/checker/tests/comptime_call_no_unused_var.vv:15:8: error: todo: not a str
       |           ^
    16 |     s2 := 'x'
    17 |     test.$s2()
-Details: v.ast.InfixExpr
 vlib/v/checker/tests/comptime_call_no_unused_var.vv:17:8: error: could not find method `x`
    15 |     test.$s()
    16 |     s2 := 'x'


### PR DESCRIPTION
So the .out file gets this diff from expected in the CI:
```
-details: v.ast.InfixExpr
+Details: v.ast.InfixExpr
 vlib/v/checker/tests/comptime_call_no_unused_var.vv:17:8: error: could not find method `x`
```
But the .out file already has `Details:` - anyway it's not important so I removed the details line.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
