### PR TITLE
tests: add test for s.$method() with T.methods

### DIFF
--- a/vlib/v/tests/comptime_call_test.v
+++ b/vlib/v/tests/comptime_call_test.v
@@ -1,7 +1,7 @@
 struct Test {}
 
 fn (test Test) v() {
-	println('in v()')
+	println('Test.v()')
 }
 fn (test Test) i() int {
 	return 4
@@ -13,7 +13,7 @@ fn (test Test) s2() string {
 	return 'Two'
 }
 
-fn test_call() {
+fn test_string_identifier() {
 	test := Test{}
 	sv := 'v'
 	test.$sv()
@@ -23,4 +23,30 @@ fn test_call() {
 	ss := 's'
 	rs := test.$ss()
 	assert rs == 'test'
+}
+
+fn test_for_methods() {
+	test := Test{}
+	mut r := ''
+	$for method in Test.methods {
+		// currently the checker thinks all $method calls return string
+		$if method.return_type is string {
+			//~ $if method.name == 's' {println('yes')}
+			v := test.$method()
+			r += v.str()
+		}
+		$else $if method.return_type is int {
+			// TODO
+			//v := test.$method()
+			v := '?'
+			r += v.str()
+			assert method.name == 'i'
+		}
+		$else {
+			// no return type
+			test.$method()
+			assert method.name == 'v'
+		}
+	}
+	assert r == '?testTwo'
 }


### PR DESCRIPTION
There was no simple test for this. It did get tested (with a `[]string` argument) in `vlib/vweb/vweb.v:510`, here there's no argument.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
