### PR TITLE
v: anonymous structs

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1788,7 +1788,6 @@ pub fn (mut f Fmt) match_expr(it ast.MatchExpr) {
 	mut single_line := true
 	for branch in it.branches {
 		if branch.stmts.len > 1 || branch.pos.line_nr < branch.pos.last_line {
-			println(branch)
 			single_line = false
 			break
 		}

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -5083,6 +5083,8 @@ fn (mut g Gen) write_types(types []table.TypeSymbol) {
 				}
 				if name.contains('_T_') {
 					g.typedefs.writeln('typedef struct $name $name;')
+				} else if name.starts_with('_anon_struct_') {
+					g.typedefs.writeln('typedef struct $name $name;')
 				}
 				// TODO avoid buffer manip
 				start_pos := g.type_definitions.len

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -499,9 +499,9 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 	mut return_type := table.void_type
 	// lpar: multiple return types
 	if same_line {
-		if p.tok.kind.is_start_of_type() 
-		|| (p.tok.kind == .key_fn && p.tok.line_nr == p.prev_tok.line_nr)
-		|| (p.tok.kind == .key_struct && p.tok.line_nr == p.prev_tok.line_nr) {
+		if p.tok.kind.is_start_of_type()
+			|| (p.tok.kind == .key_fn && p.tok.line_nr == p.prev_tok.line_nr)
+			|| (p.tok.kind == .key_struct && p.tok.line_nr == p.prev_tok.line_nr) {
 			return_type = p.parse_type()
 		} else if p.tok.kind != .lcbr {
 			p.error_with_pos('expected return type, not $p.tok for anonymous function',

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -311,7 +311,8 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	// Return type
 	mut return_type := table.void_type
 	if p.tok.kind.is_start_of_type()
-		|| (p.tok.kind == .key_fn && p.tok.line_nr == p.prev_tok.line_nr) {
+		|| (p.tok.kind == .key_fn && p.tok.line_nr == p.prev_tok.line_nr)
+		|| (p.tok.kind == .key_struct && p.tok.line_nr == p.prev_tok.line_nr) {
 		return_type = p.parse_type()
 	}
 	mut type_sym_method_idx := 0
@@ -498,7 +499,9 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 	mut return_type := table.void_type
 	// lpar: multiple return types
 	if same_line {
-		if p.tok.kind.is_start_of_type() {
+		if p.tok.kind.is_start_of_type() 
+		|| (p.tok.kind == .key_fn && p.tok.line_nr == p.prev_tok.line_nr)
+		|| (p.tok.kind == .key_struct && p.tok.line_nr == p.prev_tok.line_nr) {
 			return_type = p.parse_type()
 		} else if p.tok.kind != .lcbr {
 			p.error_with_pos('expected return type, not $p.tok for anonymous function',
@@ -521,7 +524,7 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 		is_variadic: is_variadic
 		return_type: return_type
 	}
-	name := 'anon_${p.tok.pos}_${p.table.fn_type_signature(func)}'
+	name := 'anon_fn_${p.tok.pos}_${p.table.fn_type_signature(func)}'
 	func.name = name
 	idx := p.table.find_or_register_fn_type(p.mod, func, true, false)
 	typ := table.new_type(idx)

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -174,7 +174,7 @@ pub fn (mut p Parser) parse_struct_type() table.Type {
 			embeds << p.struct_embed(mut comments).typ
 		} else {
 			field := p.struct_field(false, mut comments)
-			fields << table.Field {
+			fields << table.Field{
 				name: field.name
 				typ: field.typ
 				default_expr: ast.ex2fe(field.default_expr)
@@ -192,7 +192,7 @@ pub fn (mut p Parser) parse_struct_type() table.Type {
 	}
 	p.check(.rcbr)
 
-	s := table.Struct {
+	s := table.Struct{
 		embeds: embeds
 		fields: fields
 		is_typedef: false

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -131,6 +131,49 @@ pub fn (t &Table) fn_type_source_signature(f &Fn) string {
 	return sig
 }
 
+pub fn (t &Table) struct_type_signature(s &Struct) string {
+	all_field_len := s.embeds.len + s.fields.len
+
+	mut sig := ''
+	for i, embed in s.embeds {
+		sig += '${embed}'
+		if i < all_field_len - 1 {
+			sig += '_'
+		}
+	}
+	for i, field in s.fields {
+		sig += '${field.name}_${field.typ}'
+		if i + s.embeds.len < all_field_len - 1 {
+			sig += '_'
+		}
+	}
+
+	return sig
+}
+
+pub fn (t &Table) struct_type_source_signature(s &Struct) string {
+	all_field_len := s.embeds.len + s.fields.len
+
+	mut sig := '{'
+	for i, embed in s.embeds {
+		embed_type_sym := t.get_type_symbol(embed)
+		sig += '${embed_type_sym.name}'
+		if i < all_field_len - 1 {
+			sig += ', '
+		}
+	}
+	for i, field in s.fields {
+		field_type_sym := t.get_type_symbol(field.typ)
+		sig += '${field.name} ${field_type_sym.name}'
+		if i + s.embeds.len < all_field_len - 1 {
+			sig += ', '
+		}
+	}
+	sig += '}'
+
+	return sig
+}
+
 pub fn (t &Table) is_same_method(f &Fn, func &Fn) string {
 	if f.return_type != func.return_type {
 		s := t.type_to_str(f.return_type)
@@ -644,6 +687,7 @@ pub fn (mut t Table) find_or_register_fn_type(mod string, f Fn, is_anon bool, ha
 	} else {
 		util.no_dots(f.name.clone())
 	}
+
 	anon := f.name.len == 0 || is_anon
 	// existing
 	existing_idx := t.type_idxs[name]
@@ -661,6 +705,27 @@ pub fn (mut t Table) find_or_register_fn_type(mod string, f Fn, is_anon bool, ha
 			func: f
 		}
 	)
+}
+
+pub fn (mut t Table) find_or_register_struct_type(s_name string, mod string, s Struct) int {
+	name := if s_name.len == 0 { 'struct${t.struct_type_source_signature(s)}' } else { s_name.clone() }
+	cname := if s_name.len == 0 {
+		'_anon_struct_${t.struct_type_signature(s)}'
+	} else {
+		util.no_dots(s_name.clone())
+	}
+
+	existing_idx := t.type_idxs[name]
+	if existing_idx > 0 && t.types[existing_idx].kind != .placeholder {
+		return existing_idx
+	}
+	return t.register_type_symbol({ 
+		kind: .struct_
+		name: name
+		cname: cname
+		mod: mod
+		info: s
+	})
 }
 
 pub fn (mut t Table) add_placeholder_type(name string, language Language) int {

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -136,13 +136,13 @@ pub fn (t &Table) struct_type_signature(s &Struct) string {
 
 	mut sig := ''
 	for i, embed in s.embeds {
-		sig += '${embed}'
+		sig += '$embed'
 		if i < all_field_len - 1 {
 			sig += '_'
 		}
 	}
 	for i, field in s.fields {
-		sig += '${field.name}_${field.typ}'
+		sig += '${field.name}_$field.typ'
 		if i + s.embeds.len < all_field_len - 1 {
 			sig += '_'
 		}
@@ -157,14 +157,14 @@ pub fn (t &Table) struct_type_source_signature(s &Struct) string {
 	mut sig := '{'
 	for i, embed in s.embeds {
 		embed_type_sym := t.get_type_symbol(embed)
-		sig += '${embed_type_sym.name}'
+		sig += '$embed_type_sym.name'
 		if i < all_field_len - 1 {
 			sig += ', '
 		}
 	}
 	for i, field in s.fields {
 		field_type_sym := t.get_type_symbol(field.typ)
-		sig += '${field.name} ${field_type_sym.name}'
+		sig += '$field.name $field_type_sym.name'
 		if i + s.embeds.len < all_field_len - 1 {
 			sig += ', '
 		}
@@ -708,7 +708,11 @@ pub fn (mut t Table) find_or_register_fn_type(mod string, f Fn, is_anon bool, ha
 }
 
 pub fn (mut t Table) find_or_register_struct_type(s_name string, mod string, s Struct) int {
-	name := if s_name.len == 0 { 'struct${t.struct_type_source_signature(s)}' } else { s_name.clone() }
+	name := if s_name.len == 0 {
+		'struct${t.struct_type_source_signature(s)}'
+	} else {
+		s_name.clone()
+	}
 	cname := if s_name.len == 0 {
 		'_anon_struct_${t.struct_type_signature(s)}'
 	} else {
@@ -719,13 +723,13 @@ pub fn (mut t Table) find_or_register_struct_type(s_name string, mod string, s S
 	if existing_idx > 0 && t.types[existing_idx].kind != .placeholder {
 		return existing_idx
 	}
-	return t.register_type_symbol({ 
+	return t.register_type_symbol(
 		kind: .struct_
 		name: name
 		cname: cname
 		mod: mod
 		info: s
-	})
+	)
 }
 
 pub fn (mut t Table) add_placeholder_type(name string, language Language) int {

--- a/vlib/v/tests/anon_struct_test.v
+++ b/vlib/v/tests/anon_struct_test.v
@@ -1,0 +1,12 @@
+fn test(config struct{name string, value int}) struct{ value string } {
+	assert config.name == 'hello'
+	assert config.value == 42
+	return {
+		value: 'world'
+	}
+}
+
+fn test_anon_struct() {
+	ret := test({ name: 'hello', value: 42 })
+	assert ret.value == 'world'
+}


### PR DESCRIPTION
**Adds anonymous structs**

Adds an initial implementation for anonymous structs (+ minor refactor to the normal struct parsing).

The implementation (using `p.parse_type()`)  comes with the drawback that currently no comments are possible inside the struct. Also it is currently only tested for the presented function parameter/return type case, other use cases should be found and tested before merge.

The current syntax of V unfortunately requires the need for the `struct` keyword in front, as it would conflict with the block of a function that returns nothing, when used as a return type. But this could definitively be mitigated for, with some syntax changes.

```v
fn test(config struct{ name string, value int }) struct{ value string } {
	assert config.name == 'hello'
	assert config.value == 42
	return {
		value: 'world'
	}
}

fn main() {
	ret := test({ name: 'hello', value: 42 })
	assert ret.value == 'world'
}
```


**TODO:**
- [] find use cases + add tests
- [] fix in array declaration `a := []struct{ name string }{}`

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```


If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
