### PR TITLE
 checker: warn for unused parameters

### DIFF
--- a/cmd/tools/gen_vc.v
+++ b/cmd/tools/gen_vc.v
@@ -155,11 +155,11 @@ pub fn (mut ws WebhookServer) init_once() {
 	// ws.gen_vc = new_gen_vc(flag_options)
 }
 
-pub fn (mut ws WebhookServer) init() {
+pub fn (mut _ WebhookServer) init() {
 	// ws.init_once()
 }
 
-pub fn (mut ws WebhookServer) index() {
+pub fn (mut _ WebhookServer) index() {
 	eprintln('WebhookServer.index() called')
 }
 
@@ -178,7 +178,7 @@ pub fn (mut ws WebhookServer) genhook() {
 	ws.json('{status: "ok"}')
 }
 
-pub fn (ws &WebhookServer) reset() {
+pub fn (_ &WebhookServer) reset() {
 }
 
 // parse flags to FlagOptions struct

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -215,7 +215,7 @@ pub fn (mut ts TestSession) test() {
 	}
 }
 
-fn worker_trunner(mut p sync.PoolProcessor, idx int, thread_id int) voidptr {
+fn worker_trunner(mut p sync.PoolProcessor, idx int, _ int) voidptr {
 	mut ts := &TestSession(p.get_shared_context())
 	tmpd := ts.vtmp_dir
 	show_stats := '-stats' in ts.vargs.split(' ')

--- a/cmd/tools/vbin2v.v
+++ b/cmd/tools/vbin2v.v
@@ -42,11 +42,11 @@ fn (context Context) header() string {
 	return header_s
 }
 
-fn (context Context) footer() string {
+fn (_ Context) footer() string {
 	return ')\n'
 }
 
-fn (context Context) file2v(bname string, fbytes []byte, bn_max int) string {
+fn (_ Context) file2v(bname string, fbytes []byte, bn_max int) string {
 	mut sb := strings.new_builder(1000)
 	bn_diff_len := bn_max - bname.len
 	sb.write('\t${bname}_len' + ' '.repeat(bn_diff_len - 4) + ' = $fbytes.len\n')
@@ -81,7 +81,7 @@ fn (context Context) bname_and_bytes(file string) ?(string, []byte) {
 	return byte_name, fbytes
 }
 
-fn (context Context) max_bname_len(bnames []string) int {
+fn (_ Context) max_bname_len(bnames []string) int {
 	mut max := 0
 	for n in bnames {
 		if n.len > max {

--- a/cmd/tools/vtest-parser.v
+++ b/cmd/tools/vtest-parser.v
@@ -154,7 +154,7 @@ fn yellow(msg string) string {
 	return term.yellow(msg)
 }
 
-fn (mut context Context) info(msg string) {
+fn (mut _ Context) info(msg string) {
 	println(msg)
 }
 
@@ -166,7 +166,7 @@ fn (mut context Context) log(msg string) {
 	}
 }
 
-fn (mut context Context) error(msg string) {
+fn (mut _ Context) error(msg string) {
 	label := red('error')
 	eprintln('$label: $msg')
 }

--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -77,10 +77,10 @@ fn (app App) recompile_v() {
 			app.vprintln(self_result.output.trim_space())
 		}
 	}
-	app.make(vself)
+	app.make()
 }
 
-fn (app App) make(vself string) {
+fn (app App) make() {
 	mut make := 'make'
 	$if windows {
 		make = 'make.bat'
@@ -105,7 +105,7 @@ fn (app App) show_current_v_version() {
 	}
 }
 
-fn (app App) backup(file string) {
+fn (_ App) backup(file string) {
 	backup_file := '${file}_old.exe'
 	if os.exists(backup_file) {
 		os.rm(backup_file) or { eprintln('failed removing $backup_file: $err') }
@@ -127,7 +127,7 @@ fn (app App) git_command(command string) {
 	app.vprintln(git_result.output)
 }
 
-fn (app App) get_git() {
+fn (_ App) get_git() {
 	$if windows {
 		println('Downloading git 32 bit for Windows, please wait.')
 		// We'll use 32 bit because maybe someone out there is using 32-bit windows

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -131,7 +131,7 @@ fn main() {
 	if command in ['run', 'build', 'build-module'] || command.ends_with('.v') || os.exists(command) {
 		// println('command')
 		// println(prefs.path)
-		builder.compile(command, prefs)
+		builder.compile(prefs)
 		return
 	}
 	eprintln('v $command: unknown command\nRun "v help" for usage.')

--- a/examples/cli.v
+++ b/examples/cli.v
@@ -32,10 +32,10 @@ fn main() {
 		description: 'Number of times the message gets printed.'
 	})
 	greet_cmd.add_flag(Flag{
-	 	flag: .string
-	 	name: 'fun'
-	 	multipe: true
-	 	description: 'Just a dumby flags to show multiple.'
+		flag: .string
+		name: 'fun'
+		multipe: true
+		description: 'Just a dumby flags to show multiple.'
 	})
 	cmd.add_command(greet_cmd)
 	cmd.setup()
@@ -76,10 +76,10 @@ fn greet_func(cmd Command) {
 	}
 }
 
-fn greet_pre_func(cmd Command) {
+fn greet_pre_func(_ Command) {
 	println('This is a function running before the main function.\n')
 }
 
-fn greet_post_func(cmd Command) {
+fn greet_post_func(_ Command) {
 	println('\nThis is a function running after the main function.')
 }

--- a/examples/compiletime/compile-time-for.v
+++ b/examples/compiletime/compile-time-for.v
@@ -1,8 +1,8 @@
 struct App {}
 
-fn (mut app App) method_one() {}
-fn (mut app App) method_two() int {	return 0 }
-fn (mut app App) method_three(s string) string { return s }
+fn (mut _ App) method_one() {}
+fn (mut _ App) method_two() int { return 0 }
+fn (mut _ App) method_three(s string) string { return s }
 
 fn main() {
 	$for method in App.methods {

--- a/examples/eventbus/eventbus.v
+++ b/examples/eventbus/eventbus.v
@@ -8,6 +8,6 @@ fn main(){
 	some_module.do_work()
 }
 
-fn on_error(sender voidptr, e &some_module.Error, x voidptr) {
+fn on_error(_ voidptr, e &some_module.Error, _ voidptr) {
 	println(e.message)
 }

--- a/examples/gg/rectangles.v
+++ b/examples/gg/rectangles.v
@@ -34,7 +34,7 @@ fn main() {
 	app.gg.run()
 }
 
-fn init_images(mut app App) {
+fn init_images(mut _ App) {
 	// app.image = gg.create_image('logo.png')
 }
 

--- a/examples/lander.v
+++ b/examples/lander.v
@@ -8,7 +8,7 @@ struct Moon {
 
 struct Mars {
 }
-fn (m Mars) dust_storm() bool {
+fn dust_storm() bool {
 	return rand.int() >= 0
 }
 
@@ -19,10 +19,10 @@ type World = Moon | Mars | Venus
 
 struct Lander {
 }
-fn (l Lander) deorbit() {
+fn (_ Lander) deorbit() {
 	println('leaving orbit')
 }
-fn (l Lander) open_parachutes(n int) {
+fn (_ Lander) open_parachutes(n int) {
 	println('opening $n parachutes')
 }
 
@@ -33,7 +33,7 @@ fn wait() {
 
 fn (l Lander) land(w World) {
 	if w is Mars {
-		for w.dust_storm() {
+		for dust_storm() {
 			wait()
 		}
 	}

--- a/examples/news_fetcher.v
+++ b/examples/news_fetcher.v
@@ -10,7 +10,7 @@ struct Story {
 	url   string
 }
 
-fn worker_fetch(p &sync.PoolProcessor, cursor int, worker_id int) voidptr {
+fn worker_fetch(p &sync.PoolProcessor, cursor int, _ int) voidptr {
 	id := p.get_int_item(cursor)
 	resp := http.get('https://hacker-news.firebaseio.com/v0/item/${id}.json') or {
 		println('failed to fetch data from /v0/item/${id}.json')

--- a/examples/path_tracing.v
+++ b/examples/path_tracing.v
@@ -484,7 +484,7 @@ fn radiance(r Ray, depthi int, scene_id int) Vec {
 }
 
 //*********************** beam scan routine *********************************
-fn ray_trace(w int, h int, samps int, file_name string, scene_id int) Image {
+fn ray_trace(w int, h int, samps int, scene_id int) Image {
 	image := new_image(w, h)
 
 	// inverse costants
@@ -563,7 +563,7 @@ fn main() {
 
 	t1 := time.ticks()
 
-	image := ray_trace(width, height, samples, file_name, scene_id)
+	image := ray_trace(width, height, samples, scene_id)
 	t2 := time.ticks()
 
 	eprintln('\nRendering finished. Took: ${(t2 - t1):5}ms')

--- a/examples/snek/snek.v
+++ b/examples/snek/snek.v
@@ -73,7 +73,7 @@ fn (mut app App) move_food() {
 }
 
 // events
-fn on_keydown(key sapp.KeyCode, mod sapp.Modifier, mut app App) {
+fn on_keydown(key sapp.KeyCode, _ sapp.Modifier, mut app App) {
 	match key {
 		.w, .up {
 			if app.dir != .down {

--- a/examples/sokol/cube.v
+++ b/examples/sokol/cube.v
@@ -31,7 +31,7 @@ mut:
 	texture       C.sg_image
 	init_flag     bool
 	frame_count   int
-	
+
 	mouse_x       int = -1
 	mouse_y       int = -1
 }
@@ -60,7 +60,7 @@ fn create_texture(w int, h int, buf byteptr) C.sg_image{
 		ptr: buf
 		size: sz
 	}
-	
+
 	sg_img := C.sg_make_image(&img_desc)
 	return sg_img
 }
@@ -136,7 +136,7 @@ fn cube() {
 fn draw_cubes(app App) {
 	rot := [f32(1.0)*(app.frame_count % 360), 0.5*f32(app.frame_count%360)]
 	//rot := [f32(app.mouse_x), f32(app.mouse_y)]
-	
+
 	sgl.defaults()
 	sgl.load_pipeline(app.pip_3d)
 
@@ -240,7 +240,7 @@ fn cube_field(app App){
 	rot := [f32(app.mouse_x), f32(app.mouse_y)]
 	xyz_sz := f32(2.0)
 	field_size := 20
-		
+
 	sgl.defaults()
 	sgl.load_pipeline(app.pip_3d)
 
@@ -249,13 +249,13 @@ fn cube_field(app App){
 
 	sgl.matrix_mode_projection()
 	sgl.perspective(sgl.rad(45.0), 1.0, 0.1, 200.0)
-		
+
 	sgl.matrix_mode_modelview()
-		
+
 	sgl.translate(field_size, 0.0, -120.0)
 	sgl.rotate(sgl.rad(rot[0]), 0.0, 1.0, 0.0)
 	sgl.rotate(sgl.rad(rot[1]), 1.0, 0.0, 0.0)
-		
+
 	// draw field_size*field_size cubes
 	for y in 0..field_size {
 		for x in 0..field_size {
@@ -265,7 +265,7 @@ fn cube_field(app App){
 			cube_t(f32(f32(x)/field_size), f32(f32(y)/field_size),1)
 			sgl.pop_matrix()
 		}
-	}		
+	}
 	sgl.disable_texture()
 }
 
@@ -278,28 +278,28 @@ fn frame(mut app App) {
 	//x1 := dw/2
 	y0 := 0
 	y1 := dh/2
-		
+
 	app.gg.begin()
 	//sgl.defaults()
 
 	// 2d triangle
 	sgl.viewport(x0, y0, ww, hh, true)
 	draw_triangle()
-	
+
 	// colored cubes with viewport
 	sgl.viewport(x0, y1, ww, hh, true)
 	draw_cubes(app)
-	
+
 	// textured cubed with viewport
 	sgl.viewport(0, 0, dw, dh, true)
 	draw_texture_cubes(app)
-	
+
 	// textured field of cubes with viewport
 	sgl.viewport(0, 0, dw, dh, true)
 	cube_field(app)
 
 	app.frame_count++
-	
+
 	app.gg.end()
 }
 
@@ -310,7 +310,7 @@ fn frame(mut app App) {
 ******************************************************************************/
 fn my_init(mut app App) {
 	app.init_flag = true
-	
+
 	// set max vertices,
 	// for a large number of the same type of object it is better use the instances!!
 	desc := sapp.create_desc()
@@ -319,7 +319,7 @@ fn my_init(mut app App) {
 		max_vertices: 50 * 65536
 	}
 	sgl.setup(&sgl_desc)
-	
+
 	// 3d pipeline
 	mut pipdesc := C.sg_pipeline_desc{}
 	unsafe {C.memset(&pipdesc, 0, sizeof(pipdesc))}
@@ -334,7 +334,7 @@ fn my_init(mut app App) {
 		cull_mode: .back
 	}
 	app.pip_3d = sgl.make_pipeline(&pipdesc)
-	
+
 	// create chessboard texture 256*256 RGBA
 	w := 256
 	h := 256
@@ -359,7 +359,7 @@ fn my_init(mut app App) {
 				tmp_txt[i+2] =  byte(0)
 				tmp_txt[i+3] =  byte(0xFF)
 			} else {
-				col := if ((x+y) & 1) == 1 {0xFF} else {0}		
+				col := if ((x+y) & 1) == 1 {0xFF} else {0}
 				tmp_txt[i  ] =  byte(col)   // red
 				tmp_txt[i+1] =  byte(col)   // green
 				tmp_txt[i+2] =  byte(col)   // blue
@@ -372,7 +372,7 @@ fn my_init(mut app App) {
 	free(tmp_txt)
 }
 
-fn cleanup(mut app App) {
+fn cleanup(mut _ App) {
 	gfx.shutdown()
 }
 

--- a/examples/sokol/drawing.v
+++ b/examples/sokol/drawing.v
@@ -26,7 +26,7 @@ fn main() {
 	sapp.run(&desc)
 }
 
-fn init(user_data voidptr) {
+fn init(_ voidptr) {
 	desc := sapp.create_desc() // C.sg_desc{
 	gfx.setup(&desc)
 	sgl_desc := C.sgl_desc_t{}

--- a/examples/vweb/vweb_assets/vweb_assets.v
+++ b/examples/vweb/vweb_assets/vweb_assets.v
@@ -26,9 +26,6 @@ pub fn (mut app App) init_once() {
 	app.handle_static('.')
 }
 
-pub fn (mut app App) init() {
-}
-
 pub fn (mut app App) index() vweb.Result {
 	// We can dynamically specify which assets are to be used in template.
 	// 	mut am := assets.new_manager()

--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -171,14 +171,14 @@ fn print_backtrace_skipping_top_frames_msvc(skipframes int) bool {
 	}
 }
 
-fn print_backtrace_skipping_top_frames_mingw(skipframes int) bool {
+fn print_backtrace_skipping_top_frames_mingw(_ int) bool {
 	eprintln('print_backtrace_skipping_top_frames_mingw is not implemented')
 	return false
 }
 
 fn C.tcc_backtrace(fmt charptr, other ...charptr) int
 
-fn print_backtrace_skipping_top_frames_tcc(skipframes int) bool {
+fn print_backtrace_skipping_top_frames_tcc(_ int) bool {
 	$if tinyc {
 		$if no_backtrace ? {
 			eprintln('backtraces are disabled')

--- a/vlib/builtin/chan.v
+++ b/vlib/builtin/chan.v
@@ -9,12 +9,12 @@ enum ChanState {
 // The following methods are only stubs. The real implementation
 // is in `vlib/sync/channels.v`
 
-pub fn (ch chan) close() {}
+pub fn (_ chan) close() {}
 
-pub fn (ch chan) try_pop(obj voidptr) ChanState {
+pub fn (_ chan) try_pop(_ voidptr) ChanState {
 	return .success
 }
 
-pub fn (ch chan) try_push(obj voidptr) ChanState {
+pub fn (_ chan) try_push(_ voidptr) ChanState {
 	return .success
 }

--- a/vlib/builtin/sorted_map.v
+++ b/vlib/builtin/sorted_map.v
@@ -38,6 +38,7 @@ mut:
 }
 
 fn new_sorted_map(n int, value_bytes int) SortedMap { // TODO: Remove `n`
+	_ = n // TODO Remove, just here to silence `unused` warning
 	return SortedMap {
 		value_bytes: value_bytes
 		root: new_node()
@@ -423,6 +424,7 @@ pub fn (m &SortedMap) keys() []string {
 }
 
 fn (mut n mapnode) free() {
+	_ = n // TODO Remove, just here to silence `unused` warning
 	println('TODO')
 }
 
@@ -434,6 +436,7 @@ pub fn (mut m SortedMap) free() {
 }
 
 pub fn (m SortedMap) print() {
+	_ = m // TODO Remove, just here to silence `unused` warning
 	println('TODO')
 }
 

--- a/vlib/crypto/md5/md5.v
+++ b/vlib/crypto/md5/md5.v
@@ -138,12 +138,12 @@ fn block(mut dig Digest, p []byte) {
 }
 
 // size returns the size of the checksum in bytes.
-pub fn (d &Digest) size() int {
+pub fn (_ &Digest) size() int {
 	return size
 }
 
 // block_size returns the block size of the checksum in bytes.
-pub fn (d &Digest) block_size() int {
+pub fn (_ &Digest) block_size() int {
 	return block_size
 }
 

--- a/vlib/crypto/sha1/sha1.v
+++ b/vlib/crypto/sha1/sha1.v
@@ -140,12 +140,12 @@ fn block(mut dig Digest, p []byte) {
 }
 
 // size returns the size of the checksum in bytes.
-pub fn (d &Digest) size() int {
+pub fn (_ &Digest) size() int {
 	return size
 }
 
 // block_size returns the block size of the checksum in bytes.
-pub fn (d &Digest) block_size() int {
+pub fn (_ &Digest) block_size() int {
 	return block_size
 }
 

--- a/vlib/io/readerwriter.v
+++ b/vlib/io/readerwriter.v
@@ -35,11 +35,11 @@ pub fn make_readerwriter(r Reader, w Writer) ReaderWriterImpl {
 struct Zzz_CoerceInterfaceTableGeneration {
 }
 
-fn (_ Zzz_CoerceInterfaceTableGeneration) write(buf []byte) ?int {
+fn (_ Zzz_CoerceInterfaceTableGeneration) write(_ []byte) ?int {
 	return none
 }
 
-fn (_ Zzz_CoerceInterfaceTableGeneration) read(mut buf []byte) ?int {
+fn (_ Zzz_CoerceInterfaceTableGeneration) read(mut _ []byte) ?int {
 	return none
 }
 

--- a/vlib/json/json_primitives.v
+++ b/vlib/json/json_primitives.v
@@ -13,12 +13,12 @@ struct C.cJSON {
 	valuestring byteptr
 }
 
-pub fn decode(typ voidptr, s string) ?voidptr {
+pub fn decode(_ voidptr, _ string) ?voidptr {
 	// compiler implementation
 	return 0
 }
 
-pub fn encode(x voidptr) string {
+pub fn encode(_ voidptr) string {
 	// compiler implementation
 	return ''
 }

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -110,7 +110,7 @@ fn (mut l Log) log_file(s string, level Level) {
 }
 
 // log_cli writes log line `s` with `level` to stdout.
-fn (l &Log) log_cli(s string, level Level) {
+fn log_cli(s string, level Level) {
 	f := tag_to_cli(level)
 	t := time.now()
 	println('[$f $t.format_ss()] $s')
@@ -122,7 +122,7 @@ fn (mut l Log) send_output(s &string, level Level) {
 	if l.output_to_file {
 		l.log_file(s, level)
 	} else {
-		l.log_cli(s, level)
+		log_cli(s, level)
 	}
 }
 

--- a/vlib/net/http/download_nix.c.v
+++ b/vlib/net/http/download_nix.c.v
@@ -14,6 +14,11 @@ mut:
 }
 */
 fn download_cb(ptr voidptr, size size_t, nmemb size_t, userp voidptr) {
+	// TODO Remove, just here to silence `unused` warning
+	_ = ptr
+	_ = size
+	_ = nmemb
+	_ = userp
 	/*
 	mut data := &DownloadStruct(userp)
 	written := C.fwrite(ptr, size, nmemb, data.stream)
@@ -25,6 +30,11 @@ fn download_cb(ptr voidptr, size size_t, nmemb size_t, userp voidptr) {
 }
 
 pub fn download_file_with_progress(url string, out string, cb DownloadFn, cb_finished fn()) {
+	// TODO Remove, just here to silence `unused` warning
+	_ = url
+	_ = out
+	_ = cb
+	_ = cb_finished
 	/*
 	curl := C.curl_easy_init()
 	if isnil(curl) {

--- a/vlib/net/http/download_windows.c.v
+++ b/vlib/net/http/download_windows.c.v
@@ -9,6 +9,11 @@ module http
 #include <urlmon.h>
 
 fn download_file_with_progress(url string, out string, cb voidptr, cb_finished voidptr) {
+	// TODO
+	_ = url
+	_ = out
+	_ = cb
+	_ = cb_finished
 }
 
 /*

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -67,7 +67,7 @@ pub fn get(url string) ?Response {
 }
 
 pub fn post(url string, data string) ?Response {
-	return fetch_with_method(.post, url, 
+	return fetch_with_method(.post, url,
 		data: data
 		headers: {
 			'Content-Type': http.content_type_default
@@ -76,7 +76,7 @@ pub fn post(url string, data string) ?Response {
 }
 
 pub fn post_json(url string, data string) ?Response {
-	return fetch_with_method(.post, url, 
+	return fetch_with_method(.post, url,
 		data: data
 		headers: {
 			'Content-Type': 'application/json'
@@ -85,7 +85,7 @@ pub fn post_json(url string, data string) ?Response {
 }
 
 pub fn post_form(url string, data map[string]string) ?Response {
-	return fetch_with_method(.post, url, 
+	return fetch_with_method(.post, url,
 		headers: {
 			'Content-Type': 'application/x-www-form-urlencoded'
 		}
@@ -94,7 +94,7 @@ pub fn post_form(url string, data map[string]string) ?Response {
 }
 
 pub fn put(url string, data string) ?Response {
-	return fetch_with_method(.put, url, 
+	return fetch_with_method(.put, url,
 		data: data
 		headers: {
 			'Content-Type': http.content_type_default
@@ -103,7 +103,7 @@ pub fn put(url string, data string) ?Response {
 }
 
 pub fn patch(url string, data string) ?Response {
-	return fetch_with_method(.patch, url, 
+	return fetch_with_method(.patch, url,
 		data: data
 		headers: {
 			'Content-Type': http.content_type_default
@@ -358,19 +358,19 @@ fn (req &Request) build_request_cookies_header() string {
 	return 'Cookie: ' + cookie.join('; ') + '\r\n'
 }
 
-pub fn unescape_url(s string) string {
+pub fn unescape_url(_ string) string {
 	panic('http.unescape_url() was replaced with urllib.query_unescape()')
 }
 
-pub fn escape_url(s string) string {
+pub fn escape_url(_ string) string {
 	panic('http.escape_url() was replaced with urllib.query_escape()')
 }
 
-pub fn unescape(s string) string {
+pub fn unescape(_ string) string {
 	panic('http.unescape() was replaced with http.unescape_url()')
 }
 
-pub fn escape(s string) string {
+pub fn escape(_ string) string {
 	panic('http.escape() was replaced with http.escape_url()')
 }
 

--- a/vlib/net/udp.v
+++ b/vlib/net/udp.v
@@ -150,7 +150,7 @@ pub fn (mut c UdpConn) wait_for_write() ? {
 	return wait_for_write(c.sock.handle, c.write_deadline, c.write_timeout)
 }
 
-pub fn (c &UdpConn) str() string {
+pub fn (_ &UdpConn) str() string {
 	// TODO
 	return 'UdpConn'
 }

--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -565,7 +565,7 @@ pub fn read_file_array<T>(path string) []T {
 	}
 }
 
-pub fn on_segfault(f voidptr) {
+pub fn on_segfault(_ voidptr) {
 	$if windows {
 		return
 	}

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -395,6 +395,6 @@ pub fn getpid() int {
 	return C._getpid()
 }
 
-pub fn posix_set_permission_bit(path_s string, mode u32, enable bool) {
+pub fn posix_set_permission_bit(_ string, _ u32, _ bool) {
 	// windows has no concept of a permission mask, so do nothing
 }

--- a/vlib/os/process_nix.c.v
+++ b/vlib/os/process_nix.c.v
@@ -101,22 +101,22 @@ fn (mut p Process) unix_is_alive() bool {
 }
 
 // these are here to make v_win.c/v.c generation work in all cases:
-fn (mut p Process) win_spawn_process() int {
+fn (mut _ Process) win_spawn_process() int {
 	return 0
 }
 
-fn (mut p Process) win_stop_process() {
+fn (mut _ Process) win_stop_process() {
 }
 
-fn (mut p Process) win_resume_process() {
+fn (mut _ Process) win_resume_process() {
 }
 
-fn (mut p Process) win_kill_process() {
+fn (mut _ Process) win_kill_process() {
 }
 
-fn (mut p Process) win_wait() {
+fn (mut _ Process) win_wait() {
 }
 
-fn (mut p Process) win_is_alive() bool {
+fn (mut _ Process) win_is_alive() bool {
 	return false
 }

--- a/vlib/os/process_windows.c.v
+++ b/vlib/os/process_windows.c.v
@@ -1,19 +1,19 @@
 module os
 
-fn (mut p Process) win_spawn_process() int {
+fn (mut _ Process) win_spawn_process() int {
 	eprintln('TODO implement waiting for a process on windows')
 	return 12345
 }
 
-fn (mut p Process) win_stop_process() {
+fn (mut _ Process) win_stop_process() {
 	eprintln('TODO implement stopping a process on windows')
 }
 
-fn (mut p Process) win_resume_process() {
+fn (mut _ Process) win_resume_process() {
 	eprintln('TODO implement resuming a process on windows')
 }
 
-fn (mut p Process) win_kill_process() {
+fn (mut _ Process) win_kill_process() {
 	eprintln('TODO implement killing a process on windows')
 }
 
@@ -23,29 +23,29 @@ fn (mut p Process) win_wait() {
 	p.code = 0
 }
 
-fn (mut p Process) win_is_alive() bool {
+fn (mut _ Process) win_is_alive() bool {
 	eprintln('TODO implement checking whether the process is still alive on windows')
 	return false
 }
 
 //
 // these are here to make v_win.c/v.c generation work in all cases:
-fn (mut p Process) unix_spawn_process() int {
+fn (mut _ Process) unix_spawn_process() int {
 	return 0
 }
 
-fn (mut p Process) unix_stop_process() {
+fn (mut _ Process) unix_stop_process() {
 }
 
-fn (mut p Process) unix_resume_process() {
+fn (mut _ Process) unix_resume_process() {
 }
 
-fn (mut p Process) unix_kill_process() {
+fn (mut _ Process) unix_kill_process() {
 }
 
-fn (mut p Process) unix_wait() {
+fn (mut _ Process) unix_wait() {
 }
 
-fn (mut p Process) unix_is_alive() bool {
+fn (mut _ Process) unix_is_alive() bool {
 	return false
 }

--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -225,7 +225,7 @@ fn rw_callback(loop &C.picoev_loop, fd int, events int, cb_arg voidptr) {
 	}
 }
 
-fn accept_callback(loop &C.picoev_loop, fd int, events int, cb_arg voidptr) {
+fn accept_callback(loop &C.picoev_loop, fd int, _ int, cb_arg voidptr) {
 	newfd := C.accept(fd, 0, 0)
 	if newfd != -1 {
 		setup_sock(newfd)

--- a/vlib/readline/readline_linux.c.v
+++ b/vlib/readline/readline_linux.c.v
@@ -93,7 +93,7 @@ pub fn (mut r Readline) disable_raw_mode() {
 }
 
 // read_char reads a single character.
-pub fn (r Readline) read_char() int {
+pub fn (_ Readline) read_char() int {
 	return utf8_getchar()
 }
 
@@ -452,7 +452,7 @@ fn (mut r Readline) move_cursor_end() {
 }
 
 // is_break_character returns true if the character is considered as a word-breaking character.
-fn (r Readline) is_break_character(c string) bool {
+fn (_ &Readline) is_break_character(c string) bool {
 	break_characters := ' \t\v\f\a\b\r\n`~!@#$%^&*()-=+[{]}\\|;:\'",<.>/?'
 	return break_characters.contains(c)
 }

--- a/vlib/regex/regex.v
+++ b/vlib/regex/regex.v
@@ -185,7 +185,7 @@ fn is_upper(in_char byte) bool {
 	return tmp <= 25
 }
 
-pub fn (re RE) get_parse_error_string(err int) string {
+pub fn (_ RE) get_parse_error_string(err int) string {
 	match err {
 		compile_ok             { return "compile_ok" }
 		no_match_found         { return "no_match_found" }
@@ -685,7 +685,7 @@ enum Quant_parse_state {
 }
 
 // parse_quantifier return (min, max, str_len, greedy_flag) of a {min,max}? quantifier starting after the { char
-fn (re RE) parse_quantifier(in_txt string, in_i int) (int, int, int, bool) {
+fn parse_quantifier(in_txt string, in_i int) (int, int, int, bool) {
 	mut status := Quant_parse_state.start
 	mut i := in_i
 
@@ -1072,7 +1072,7 @@ fn (mut re RE) impl_compile(in_txt string) (int,int) {
 				}
 
 				`{` {
-					min, max, tmp, greedy := re.parse_quantifier(in_txt, i+1)
+					min, max, tmp, greedy := parse_quantifier(in_txt, i+1)
 					// it is a quantifier
 					if min >= 0 {
 						//println("{$min,$max}\n str:[${in_txt[i..i+tmp]}] greedy:$greedy")

--- a/vlib/sokol/gfx/gfx_structs.v
+++ b/vlib/sokol/gfx/gfx_structs.v
@@ -163,13 +163,13 @@ pub fn (mut desc C.sg_shader_desc) set_frag_uniform_block_size(block_index int, 
 	return desc
 }
 
-pub fn (mut desc C.sg_shader_desc) set_vert_uniform(block_index int, uniform_index int, name string, @type UniformType, array_count int) &C.sg_shader_desc {
+pub fn (mut desc C.sg_shader_desc) set_vert_uniform(block_index int, uniform_index int, name string, @type UniformType, _ int) &C.sg_shader_desc {
 	desc.vs.uniform_blocks[block_index].uniforms[uniform_index].name = name.str
 	desc.vs.uniform_blocks[block_index].uniforms[uniform_index].@type = @type
 	return desc
 }
 
-pub fn (mut desc C.sg_shader_desc) set_frag_uniform(block_index int, uniform_index int, name string, @type UniformType, array_count int) &C.sg_shader_desc {
+pub fn (mut desc C.sg_shader_desc) set_frag_uniform(block_index int, uniform_index int, name string, @type UniformType, _ int) &C.sg_shader_desc {
 	desc.fs.uniform_blocks[block_index].uniforms[uniform_index].name = name.str
 	desc.fs.uniform_blocks[block_index].uniforms[uniform_index].@type = @type
 	return desc

--- a/vlib/sqlite/sqlite.v
+++ b/vlib/sqlite/sqlite.v
@@ -176,7 +176,7 @@ TODO
 pub fn (db DB) exec_param(query string, param string) []Row {
 }
 */
-pub fn (db DB) insert<T>(x T) {
+pub fn (_ DB) insert<T>(_ T) {
 }
 
 pub fn (db DB) create_table(table_name string, columns []string) {

--- a/vlib/sync/sync_windows.c.v
+++ b/vlib/sync/sync_windows.c.v
@@ -84,7 +84,7 @@ pub fn (mut m RwMutex) unlock() {
 	C.ReleaseSRWLockExclusive(&m.mx)
 }
 
-pub fn (mut m Mutex) destroy() {
+pub fn (mut _ Mutex) destroy() {
 	// nothing to do
 }
 
@@ -182,6 +182,6 @@ unlock:
 	return res != 0
 }
 
-pub fn (s Semaphore) destroy() bool {
+pub fn (_ Semaphore) destroy() bool {
 	return true
 }

--- a/vlib/term/ui/ui.v
+++ b/vlib/term/ui/ui.v
@@ -103,7 +103,7 @@ pub fn (mut ctx Context) clear() {
 
 [inline]
 // set_window_title sets the string `s` as the window title.
-pub fn (mut ctx Context) set_window_title(s string) {
+pub fn (mut _ Context) set_window_title(s string) {
 	print('\x1b]0;$s\x07')
 }
 

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -197,6 +197,7 @@ pub fn (t Time) add_days(days int) Time {
 
 // since returns a number of seconds elapsed since a given time.
 fn since(t Time) int {
+	_ = t // TODO Remove, just here to silence `unused` warning
 	// TODO Use time.Duration instead of seconds
 	return 0
 }

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -74,7 +74,7 @@ fn (mut v Builder) find_win_cc() ? {
 	v.pref.ccompiler_type = pref.cc_from_string(v.pref.ccompiler)
 }
 
-fn (mut v Builder) show_c_compiler_output(res os.Result) {
+fn show_c_compiler_output(res os.Result) {
 	println('======== C Compiler output ========')
 	println(res.output)
 	println('=================================')
@@ -642,7 +642,7 @@ fn (mut v Builder) cc() {
 		}
 		v.timing_measure(ccompiler_label)
 		if v.pref.show_c_output {
-			v.show_c_compiler_output(res)
+			show_c_compiler_output(res)
 		}
 		os.chdir(original_pwd)
 		vcache.dlog('| Builder.' + @FN, '>       v.pref.use_cache: $v.pref.use_cache | v.pref.retry_compilation: $v.pref.retry_compilation')

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -19,7 +19,7 @@ fn (mut b Builder) get_vtmp_filename(base_file_name string, postfix string) stri
 		'$uniq$postfix'))
 }
 
-pub fn compile(command string, pref &pref.Preferences) {
+pub fn compile(pref &pref.Preferences) {
 	odir := os.dir(pref.out_name)
 	// When pref.out_name is just the name of an executable, i.e. `./v -o executable main.v`
 	// without a folder component, just use the current folder instead:

--- a/vlib/v/builder/msvc.v
+++ b/vlib/v/builder/msvc.v
@@ -309,7 +309,7 @@ pub fn (mut v Builder) cc_msvc() {
 	}
 	v.timing_measure('C msvc')
 	if v.pref.show_c_output {
-		v.show_c_compiler_output(res)
+		show_c_compiler_output(res)
 	} else {
 		v.post_process_c_compiler_output(res)
 	}

--- a/vlib/v/cflag/cflags.v
+++ b/vlib/v/cflag/cflags.v
@@ -38,10 +38,12 @@ pub fn (cf &CFlag) format() string {
 
 // TODO: implement msvc specific c_options_before_target and c_options_after_target ...
 pub fn (cflags []CFlag) c_options_before_target_msvc() []string {
+	_ = cflags // TODO Remove, just here to silence `unused` warning
 	return []
 }
 
 pub fn (cflags []CFlag) c_options_after_target_msvc() []string {
+	_ = cflags // TODO Remove, just here to silence `unused` warning
 	return []
 }
 

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -120,7 +120,7 @@ pub fn (mut c Checker) check_basic(got table.Type, expected table.Type) bool {
 		return true
 	}
 	// sum type
-	if c.table.sumtype_has_variant(expected, c.table.mktyp(got)) {
+	if c.table.sumtype_has_variant(expected, table.mktyp(got)) {
 		return true
 	}
 	// fn type
@@ -182,7 +182,7 @@ fn (mut c Checker) check_shift(left_type table.Type, right_type table.Type, left
 	return left_type
 }
 
-pub fn (c &Checker) promote(left_type table.Type, right_type table.Type) table.Type {
+pub fn promote(left_type table.Type, right_type table.Type) table.Type {
 	if left_type.is_ptr() || left_type.is_pointer() {
 		if right_type.is_int() {
 			return left_type
@@ -200,7 +200,7 @@ pub fn (c &Checker) promote(left_type table.Type, right_type table.Type) table.T
 		return left_type // strings, self defined operators
 	}
 	if right_type.is_number() && left_type.is_number() {
-		return c.promote_num(left_type, right_type)
+		return promote_num(left_type, right_type)
 	} else if left_type.has_flag(.optional) != right_type.has_flag(.optional) {
 		// incompatible
 		return table.void_type
@@ -209,7 +209,7 @@ pub fn (c &Checker) promote(left_type table.Type, right_type table.Type) table.T
 	}
 }
 
-fn (c &Checker) promote_num(left_type table.Type, right_type table.Type) table.Type {
+fn promote_num(left_type table.Type, right_type table.Type) table.Type {
 	// sort the operands to save time
 	mut type_hi := left_type
 	mut type_lo := right_type
@@ -296,7 +296,7 @@ pub fn (mut c Checker) check_types(got table.Type, expected table.Type) bool {
 		} else if expected == table.rune_type && got == table.byte_type {
 			return true
 		}
-		if c.promote_num(expected, got) != expected {
+		if promote_num(expected, got) != expected {
 			// println('could not promote ${c.table.get_type_symbol(got).name} to ${c.table.get_type_symbol(expected).name}')
 			return false
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -113,7 +113,8 @@ pub fn (mut c Checker) check_scope_vars(sc &ast.Scope) {
 			ast.Var {
 				if !c.pref.is_repl {
 					if !obj.is_used && obj.name[0] != `_` {
-						c.warn('unused variable: `$obj.name`', obj.pos)
+						obj_type := if obj.is_arg { 'parameter' } else { 'variable' }
+						c.warn('unused $obj_type: `$obj.name`', obj.pos)
 					}
 				}
 				if obj.is_mut && !obj.is_changed && !c.is_builtin_mod && obj.name != 'it' {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -691,7 +691,7 @@ pub fn (mut c Checker) struct_init(mut struct_init ast.StructInit) table.Type {
 			from_info := from_sym.info as table.Struct
 			to_info := to_sym.info as table.Struct
 			// TODO this check is too strict
-			if !c.check_struct_signature(from_info, to_info) {
+			if !check_struct_signature(from_info, to_info) {
 				c.error('struct `$from_sym.name` is not compatible with struct `$to_sym.name`',
 					struct_init.update_expr.position())
 			}

--- a/vlib/v/checker/tests/array_filter_fn_err_a.vv
+++ b/vlib/v/checker/tests/array_filter_fn_err_a.vv
@@ -1,5 +1,5 @@
 fn fil(a int, b int) bool {
-	return a > 0
+	return a > 0 && b > 0
 }
 fn main() {
 	a := [1,2,3,4].filter(fil)

--- a/vlib/v/checker/tests/array_map_fn_err_c.out
+++ b/vlib/v/checker/tests/array_map_fn_err_c.out
@@ -1,7 +1,7 @@
-vlib/v/checker/tests/array_map_fn_err_c.vv:3:21: error: type mismatch, should use `fn(a int) T {...}`
-    1 | fn do_nothing(a string) {}
-    2 | fn main() {
-    3 |     a := [1,2,3,4].map(do_nothing)
+vlib/v/checker/tests/array_map_fn_err_c.vv:6:21: error: type mismatch, should use `fn(a int) T {...}`
+    4 |
+    5 | fn main() {
+    6 |     a := [1,2,3,4].map(do_nothing)
       |                        ~~~~~~~~~~
-    4 |     println(a)
-    5 | }
+    7 |     println(a)
+    8 | }

--- a/vlib/v/checker/tests/array_map_fn_err_c.vv
+++ b/vlib/v/checker/tests/array_map_fn_err_c.vv
@@ -1,4 +1,7 @@
-fn do_nothing(a string) {}
+fn do_nothing(a string) {
+	_ = a
+}
+
 fn main() {
 	a := [1,2,3,4].map(do_nothing)
 	println(a)

--- a/vlib/v/checker/tests/assign_fn_call_on_left_side_err.vv
+++ b/vlib/v/checker/tests/assign_fn_call_on_left_side_err.vv
@@ -1,5 +1,5 @@
 fn foo(s string) int {
-	return 1
+	return s.len
 }
 
 fn main() {

--- a/vlib/v/checker/tests/comptime_call_method.vv
+++ b/vlib/v/checker/tests/comptime_call_method.vv
@@ -1,6 +1,6 @@
 struct S1 {}
 
-fn (t S1) m(s string) int {
+fn (_ S1) m(_ string) int {
 	return 7
 }
 

--- a/vlib/v/checker/tests/comptime_call_no_unused_var.vv
+++ b/vlib/v/checker/tests/comptime_call_no_unused_var.vv
@@ -1,7 +1,7 @@
 struct Test {}
 
 fn (test Test) print() {
-	println('test')
+	println(test)
 }
 
 fn main() {

--- a/vlib/v/checker/tests/fn_args.vv
+++ b/vlib/v/checker/tests/fn_args.vv
@@ -1,6 +1,6 @@
-fn ptr(a byte) {}
-fn arr(a []int) {}
-fn fun(a fn(int)) {}
+fn ptr(_ byte) {}
+fn arr(_ []int) {}
+fn fun(_ fn(int)) {}
 
 v := 4
 ptr(&v)

--- a/vlib/v/checker/tests/function_count_of_args_mismatch_err.vv
+++ b/vlib/v/checker/tests/function_count_of_args_mismatch_err.vv
@@ -1,7 +1,7 @@
-fn test(b bool) {
+fn test(_ bool) {
 }
 
-fn test2<T>(b bool, v T) {
+fn test2<T>(_ bool, _ T) {
 }
 
 fn main() {

--- a/vlib/v/checker/tests/is_type_invalid.vv
+++ b/vlib/v/checker/tests/is_type_invalid.vv
@@ -6,7 +6,7 @@ interface Animal {
 
 struct Dog {}
 
-fn (d Dog) speak() {}
+fn (_ Dog) speak() {}
 
 struct Cat {}
 

--- a/vlib/v/checker/tests/match_invalid_type.vv
+++ b/vlib/v/checker/tests/match_invalid_type.vv
@@ -14,7 +14,7 @@ interface Animal {
 
 struct Dog {}
 
-fn (d Dog) speak() {}
+fn (_ Dog) speak() {}
 
 struct Cat {}
 

--- a/vlib/v/checker/tests/method_wrong_arg_type.vv
+++ b/vlib/v/checker/tests/method_wrong_arg_type.vv
@@ -1,7 +1,7 @@
 enum MyEnum { x y z }
 pub fn (e MyEnum) str() string { return int(e).str() }
 struct Sss { }
-fn (s Sss) info(msg string) { println(msg) }
+fn (_ Sss) info(msg string) { println(msg) }
 fn main() {
 	e := MyEnum.x
 	s := Sss{}

--- a/vlib/v/checker/tests/mut_arg.out
+++ b/vlib/v/checker/tests/mut_arg.out
@@ -1,24 +1,24 @@
-vlib/v/checker/tests/mut_arg.vv:6:3: error: `f` parameter `par` is `mut`, you need to provide `mut` e.g. `mut arg1`
+vlib/v/checker/tests/mut_arg.vv:6:3: error: `f` parameter `_` is `mut`, you need to provide `mut` e.g. `mut arg1`
     4 | }
     5 |
     6 | f([3,4])
       |   ~~~~~
     7 | mut a := [1,2]
     8 | f(a)
-vlib/v/checker/tests/mut_arg.vv:8:3: error: `f` parameter `par` is `mut`, you need to provide `mut` e.g. `mut arg1`
+vlib/v/checker/tests/mut_arg.vv:8:3: error: `f` parameter `_` is `mut`, you need to provide `mut` e.g. `mut arg1`
     6 | f([3,4])
     7 | mut a := [1,2]
     8 | f(a)
       |   ^
     9 |
    10 | g(mut [3,4])
-vlib/v/checker/tests/mut_arg.vv:10:7: error: `g` parameter `par` is not `mut`, `mut` is not needed`
+vlib/v/checker/tests/mut_arg.vv:10:7: error: `g` parameter `_` is not `mut`, `mut` is not needed`
     8 | f(a)
     9 |
    10 | g(mut [3,4])
       |       ~~~~~
    11 | g(mut a)
-vlib/v/checker/tests/mut_arg.vv:11:7: error: `g` parameter `par` is not `mut`, `mut` is not needed`
+vlib/v/checker/tests/mut_arg.vv:11:7: error: `g` parameter `_` is not `mut`, `mut` is not needed`
     9 |
    10 | g(mut [3,4])
    11 | g(mut a)

--- a/vlib/v/checker/tests/mut_arg.vv
+++ b/vlib/v/checker/tests/mut_arg.vv
@@ -1,6 +1,6 @@
-fn f(mut par []int) {
+fn f(mut _ []int) {
 }
-fn g(par []int) {
+fn g(_ []int) {
 }
 
 f([3,4])

--- a/vlib/v/checker/tests/no_interface_instantiation_b.vv
+++ b/vlib/v/checker/tests/no_interface_instantiation_b.vv
@@ -1,6 +1,6 @@
 interface Speaker {}
 
-fn my_fn(s Speaker) {}
+fn my_fn(_ Speaker) {}
 
 fn main() {
     my_fn({})

--- a/vlib/v/checker/tests/no_interface_instantiation_c.vv
+++ b/vlib/v/checker/tests/no_interface_instantiation_c.vv
@@ -2,7 +2,7 @@ interface Speaker {
     speak()
 }
 
-fn my_fn(s Speaker) {}
+fn my_fn(_ Speaker) {}
 
 fn main() {
     my_fn(

--- a/vlib/v/checker/tests/no_interface_str.vv
+++ b/vlib/v/checker/tests/no_interface_str.vv
@@ -5,7 +5,7 @@ interface Animal {
 struct Cow {
 }
 
-fn (c Cow)speak() {
+fn (_ Cow)speak() {
 	println('moo')
 }
 

--- a/vlib/v/checker/tests/no_method_on_interface_propagation.vv
+++ b/vlib/v/checker/tests/no_method_on_interface_propagation.vv
@@ -6,7 +6,7 @@ interface Animal {
 	breed string
 }
 
-fn (a Animal) foo() {}
+fn (_ Animal) foo() {}
 
 fn new_animal(breed string) Animal {
 	return &Cat{breed}

--- a/vlib/v/checker/tests/optional_propagate_nested.vv
+++ b/vlib/v/checker/tests/optional_propagate_nested.vv
@@ -16,7 +16,7 @@ mut:
 	z f64
 }
 
-fn (mut s St) raise() ?f64 {
+fn (mut _ St) raise() ?f64 {
 	return error('some error')
 }
 

--- a/vlib/v/checker/tests/unimplemented_interface_a.vv
+++ b/vlib/v/checker/tests/unimplemented_interface_a.vv
@@ -4,7 +4,7 @@ interface Animal {
 
 struct Cat {}
 
-fn foo(a Animal) {}
+fn foo(_ Animal) {}
 
 fn main() {
 	foo(Cat{})

--- a/vlib/v/checker/tests/unimplemented_interface_b.vv
+++ b/vlib/v/checker/tests/unimplemented_interface_b.vv
@@ -4,9 +4,9 @@ interface Animal {
 
 struct Cat {}
 
-fn (c Cat) name() {}
+fn (_ Cat) name() {}
 
-fn foo(a Animal) {}
+fn foo(_ Animal) {}
 
 fn main() {
 	c := Cat{}

--- a/vlib/v/checker/tests/unimplemented_interface_c.vv
+++ b/vlib/v/checker/tests/unimplemented_interface_c.vv
@@ -4,9 +4,9 @@ interface Animal {
 
 struct Cat {}
 
-fn (c Cat) name(s string) {}
+fn (_ Cat) name(_ string) {}
 
-fn foo(a Animal) {}
+fn foo(_ Animal) {}
 
 fn main() {
 	foo(Cat{})

--- a/vlib/v/checker/tests/unimplemented_interface_d.vv
+++ b/vlib/v/checker/tests/unimplemented_interface_d.vv
@@ -4,9 +4,9 @@ interface Animal {
 
 struct Cat {}
 
-fn (c Cat) speak() {}
+fn (_ Cat) speak() {}
 
-fn foo(a Animal) {}
+fn foo(_ Animal) {}
 
 fn main() {
 	foo(Cat{})

--- a/vlib/v/checker/tests/unimplemented_interface_e.vv
+++ b/vlib/v/checker/tests/unimplemented_interface_e.vv
@@ -4,9 +4,9 @@ interface Animal {
 
 struct Cat {}
 
-fn (c Cat) speak(s &string) {}
+fn (_ Cat) speak(_ &string) {}
 
-fn foo(a Animal) {}
+fn foo(_ Animal) {}
 
 fn main() {
 	foo(Cat{})

--- a/vlib/v/checker/tests/unimplemented_interface_f.vv
+++ b/vlib/v/checker/tests/unimplemented_interface_f.vv
@@ -4,7 +4,7 @@ interface Animal {
 
 struct Cat {}
 
-fn (c Cat) speak() {}
+fn (_ Cat) speak() {}
 
 fn main() {
 	mut animals := []Animal{}

--- a/vlib/v/checker/tests/unknown_generic_type.vv
+++ b/vlib/v/checker/tests/unknown_generic_type.vv
@@ -1,4 +1,4 @@
-fn decode<T>(raw_data string) ?T {
+fn decode<T>(_ string) ?T {
 	return none
 }
 

--- a/vlib/v/checker/tests/unknown_method_suggest_name.vv
+++ b/vlib/v/checker/tests/unknown_method_suggest_name.vv
@@ -17,7 +17,7 @@ fn (p Point) translate(v Vector) Point {
 	return Point{p.x + v.x, p.y + v.y, p.z + v.z}
 }
 
-fn (p Point) identity() Point {
+fn (_ Point) identity() Point {
 	return Point{1, 1, 1}
 }
 

--- a/vlib/v/checker/tests/unsafe_required.vv
+++ b/vlib/v/checker/tests/unsafe_required.vv
@@ -1,7 +1,7 @@
 struct S1 {}
 
 [unsafe]
-fn (s S1) f(){}
+fn (_ S1) f(){}
 
 fn test_funcs() {
     s := S1{}

--- a/vlib/v/checker/tests/void_function_assign_to_string.vv
+++ b/vlib/v/checker/tests/void_function_assign_to_string.vv
@@ -1,4 +1,4 @@
-fn x(x int,y int) {
+fn x(_ int, _ int) {
 
 }
 fn main(){

--- a/vlib/v/checker/tests/vweb_routing_checks.out
+++ b/vlib/v/checker/tests/vweb_routing_checks.out
@@ -1,7 +1,7 @@
 vlib/v/checker/tests/vweb_routing_checks.vv:20:1: error: mismatched parameters count between vweb method `App.bar` (1) and route attribute ['/bar'] (0)
    18 | // segfault because path taks 0 vars and fcn takes 1 arg
    19 | ['/bar']
-   20 | pub fn (mut app App) bar(a string) vweb.Result {
+   20 | pub fn (mut app App) bar(_ string) vweb.Result {
       | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    21 |     return app.html('works')
    22 | }

--- a/vlib/v/checker/tests/vweb_routing_checks.vv
+++ b/vlib/v/checker/tests/vweb_routing_checks.vv
@@ -4,20 +4,20 @@ struct App {
 	vweb.Context
 }
 
-pub fn (mut app App) no_attributes(a string) vweb.Result {
+pub fn (mut app App) no_attributes(_ string) vweb.Result {
 	return app.text('ok')
 }
 
 // works fine, as long as fcn gets 1 arg and route takes 1 var
 ['/foo/:bar']
-pub fn (mut app App) foo(a string) vweb.Result {
+pub fn (mut app App) foo(_ string) vweb.Result {
 	eprintln('foo')
 	return app.html('works')
 }
 
 // segfault because path taks 0 vars and fcn takes 1 arg
 ['/bar']
-pub fn (mut app App) bar(a string) vweb.Result {
+pub fn (mut app App) bar(_ string) vweb.Result {
 	return app.html('works')
 }
 
@@ -27,11 +27,11 @@ pub fn (mut app App) cow() vweb.Result {
 	return app.html('works')
 }
 
-pub fn (app App) init_once() {
+pub fn (_ App) init_once() {
 	//
 }
 
-pub fn (app App) init() {
+pub fn (_ App) init() {
 	//
 }
 

--- a/vlib/v/doc/utils.v
+++ b/vlib/v/doc/utils.v
@@ -120,7 +120,7 @@ pub fn (mut d Doc) stmt_signature(stmt ast.Stmt) string {
 }
 
 // stmt_name returns the name of a given `ast.Stmt` node.
-pub fn (d Doc) stmt_name(stmt ast.Stmt) string {
+pub fn (_ Doc) stmt_name(stmt ast.Stmt) string {
 	match stmt {
 		ast.FnDecl, ast.StructDecl, ast.EnumDecl, ast.InterfaceDecl {
 			return stmt.name
@@ -141,7 +141,7 @@ pub fn (d Doc) stmt_name(stmt ast.Stmt) string {
 
 // stmt_pub returns a boolean if a given `ast.Stmt` node
 // is exposed to the public.
-pub fn (d Doc) stmt_pub(stmt ast.Stmt) bool {
+pub fn (_ Doc) stmt_pub(stmt ast.Stmt) bool {
 	match stmt {
 		ast.FnDecl, ast.StructDecl, ast.EnumDecl, ast.InterfaceDecl, ast.ConstDecl {
 			return stmt.is_pub

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -160,7 +160,7 @@ pub fn (mut f Fmt) set_current_module_name(cmodname string) {
 	f.table.cmod_prefix = cmodname + '.'
 }
 
-fn (f Fmt) get_modname_prefix(mname string) (string, string) {
+fn get_modname_prefix(mname string) (string, string) {
 	// ./tests/proto_module_importing_vproto_keep.vv to know, why here is checked for ']' and '&'
 	if !mname.contains(']') && !mname.contains('&') {
 		return mname, ''
@@ -171,7 +171,7 @@ fn (f Fmt) get_modname_prefix(mname string) (string, string) {
 	return modname, mname.trim_suffix(modname)
 }
 
-fn (mut f Fmt) is_external_name(name string) bool {
+fn is_external_name(name string) bool {
 	if name.len > 2 && name[0] == `C` && name[1] == `.` {
 		return true
 	}
@@ -206,7 +206,7 @@ pub fn (mut f Fmt) short_module(name string) string {
 	if vals.len < 2 {
 		return name
 	}
-	mname, tprefix := f.get_modname_prefix(vals[vals.len - 2])
+	mname, tprefix := get_modname_prefix(vals[vals.len - 2])
 	symname := vals[vals.len - 1]
 	aname := f.mod2alias[mname]
 	if aname == '' {
@@ -264,7 +264,7 @@ pub fn (mut f Fmt) imports(imports []ast.Import) {
 		if imp.mod in f.auto_imports && imp.mod !in f.used_imports {
 			continue
 		}
-		import_text := 'import ${f.imp_stmt_str(imp)}'
+		import_text := 'import ${imp_stmt_str(imp)}'
 		if already_imported[import_text] {
 			continue
 		}
@@ -278,7 +278,7 @@ pub fn (mut f Fmt) imports(imports []ast.Import) {
 	}
 }
 
-pub fn (f Fmt) imp_stmt_str(imp ast.Import) string {
+pub fn imp_stmt_str(imp ast.Import) string {
 	is_diff := imp.alias != imp.mod && !imp.mod.ends_with('.' + imp.alias)
 	mut imp_alias_suffix := if is_diff { ' as $imp.alias' } else { '' }
 	if imp.syms.len > 0 {
@@ -1321,7 +1321,7 @@ pub fn (mut f Fmt) size_of(node ast.SizeOf) {
 	if node.is_type {
 		sym := f.table.get_type_symbol(node.typ)
 		if sym.name != '' {
-			if f.is_external_name(sym.name) {
+			if is_external_name(sym.name) {
 				f.write(sym.name)
 			} else {
 				f.write(f.short_module(sym.name))

--- a/vlib/v/gen/auto_str_methods.v
+++ b/vlib/v/gen/auto_str_methods.v
@@ -449,7 +449,7 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp string, str_fn_name st
 	if clean_struct_v_type_name.contains('_T_') {
 		// TODO: this is a bit hacky. styp shouldn't be even parsed with _T_
 		// use something different than g.typ for styp
-		clean_struct_v_type_name = 
+		clean_struct_v_type_name =
 			clean_struct_v_type_name.replace('_T_', '<').replace('_', ', ') + '>'
 	}
 	clean_struct_v_type_name = util.strip_main_name(clean_struct_v_type_name)
@@ -561,7 +561,7 @@ fn (mut g Gen) gen_str_for_enum(info table.Enum, styp string, str_fn_name string
 	g.auto_str_funcs.writeln('}')
 }
 
-fn (mut g Gen) gen_str_for_interface(info table.Interface, styp string, str_fn_name string) {
+fn (mut g Gen) gen_str_for_interface(_ table.Interface, styp string, str_fn_name string) {
 	// TODO
 	g.type_definitions.writeln('static string ${str_fn_name}($styp it); // auto')
 	g.auto_str_funcs.writeln('static string ${str_fn_name}($styp it) { /* gen_str_for_interface */')
@@ -633,7 +633,7 @@ fn (mut g Gen) fn_decl_str(info table.FnType) string {
 	return fn_str
 }
 
-fn (mut g Gen) gen_str_for_fn_type(info table.FnType, styp string, str_fn_name string) {
+fn (mut g Gen) gen_str_for_fn_type(info table.FnType, _ string, str_fn_name string) {
 	g.type_definitions.writeln('static string ${str_fn_name}(); // auto')
 	g.auto_str_funcs.writeln('static string ${str_fn_name}() { return _SLIT("${g.fn_decl_str(info)}");}')
 }

--- a/vlib/v/gen/auto_str_methods.v
+++ b/vlib/v/gen/auto_str_methods.v
@@ -449,7 +449,7 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp string, str_fn_name st
 	if clean_struct_v_type_name.contains('_T_') {
 		// TODO: this is a bit hacky. styp shouldn't be even parsed with _T_
 		// use something different than g.typ for styp
-		clean_struct_v_type_name =
+		clean_struct_v_type_name = 
 			clean_struct_v_type_name.replace('_T_', '<').replace('_', ', ') + '>'
 	}
 	clean_struct_v_type_name = util.strip_main_name(clean_struct_v_type_name)

--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -524,7 +524,7 @@ fn (mut g Gen) optional_type_name(t table.Type) (string, string) {
 	return styp, base
 }
 
-fn (g &Gen) optional_type_text(styp string, base string) string {
+fn optional_type_text(styp string, base string) string {
 	x := styp // .replace('*', '_ptr')			// handle option ptrs
 	// replace void with something else
 	size := if base == 'void' { 'int' } else { base }
@@ -553,7 +553,7 @@ fn (mut g Gen) register_optional(t table.Type) string {
 		} Option2_$no_ptr;')
 		// println(styp)
 		g.typedefs2.writeln('typedef struct $styp $styp;')
-		g.options.write(g.optional_type_text(styp, base))
+		g.options.write(optional_type_text(styp, base))
 		g.options.writeln(';\n')
 		g.optionals << styp.clone()
 	}
@@ -1451,7 +1451,7 @@ fn (mut g Gen) for_in(it ast.ForInStmt) {
 
 // use instead of expr() when you need to cast to a different type
 fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw table.Type, expected_type table.Type) {
-	got_type := g.table.mktyp(got_type_raw)
+	got_type := table.mktyp(got_type_raw)
 	exp_sym := g.table.get_type_symbol(expected_type)
 	if exp_sym.kind == .interface_ && got_type_raw.idx() != expected_type.idx()
 		&& !expected_type.has_flag(.optional) {
@@ -1943,7 +1943,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					ret_styp := g.typ(val.decl.return_type)
 					g.write('$ret_styp (*$ident.name) (')
 					def_pos := g.definitions.len
-					g.fn_args(val.decl.params, val.decl.is_variadic)
+					g.fn_args(val.decl.params)
 					g.definitions.go_back(g.definitions.len - def_pos)
 					g.write(') = ')
 				} else {
@@ -2049,7 +2049,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 				ret_styp := g.typ(func.func.return_type)
 				g.write('$ret_styp (*${g.get_ternary_name(ident.name)}) (')
 				def_pos := g.definitions.len
-				g.fn_args(func.func.params, func.func.is_variadic)
+				g.fn_args(func.func.params)
 				g.definitions.go_back(g.definitions.len - def_pos)
 				g.write(')')
 			} else {
@@ -3648,7 +3648,7 @@ fn (mut g Gen) select_expr(node ast.SelectExpr) {
 						objs << ast.Expr{}
 						tmp_obj := g.new_tmp_var()
 						tmp_objs << tmp_obj
-						el_stype := g.typ(g.table.mktyp(expr.right_type))
+						el_stype := g.typ(table.mktyp(expr.right_type))
 						g.writeln('$el_stype $tmp_obj;')
 					}
 					is_push << true
@@ -5091,7 +5091,7 @@ fn (mut g Gen) write_types(types []table.TypeSymbol) {
 							styp, base := g.optional_type_name(field.typ)
 							g.optionals << styp
 							g.typedefs2.writeln('typedef struct $styp $styp;')
-							g.type_definitions.writeln('${g.optional_type_text(styp, base)};')
+							g.type_definitions.writeln('${optional_type_text(styp, base)};')
 							g.type_definitions.write(last_text)
 						}
 						type_name := g.typ(field.typ)
@@ -6041,7 +6041,7 @@ $staticprefix $interface_name* I_${cctype}_to_Interface_${interface_name}_ptr($c
 						first_param |
 						typ: params[0].typ.set_nr_muls(1)
 					}
-					fargs, _ := g.fn_args(params, false) // second argument is ignored anyway
+					fargs, _ := g.fn_args(params)
 					methods_wrapper.write(g.out.cut_last(g.out.len - params_start_pos))
 					methods_wrapper.writeln(') {')
 					methods_wrapper.write('\t')

--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -132,7 +132,7 @@ fn (mut g Gen) gen_fn_decl(node ast.FnDecl, skip bool) {
 		}
 	}
 	arg_start_pos := g.out.len
-	fargs, fargtypes := g.fn_args(node.params, node.is_variadic)
+	fargs, fargtypes := g.fn_args(node.params)
 	arg_str := g.out.after(arg_start_pos)
 	if node.no_body || ((g.pref.use_cache && g.pref.build_mode != .build_module) && node.is_builtin
 		&& !g.is_test)|| skip {
@@ -235,7 +235,7 @@ fn (mut g Gen) write_defer_stmts_when_needed() {
 }
 
 // fn decl args
-fn (mut g Gen) fn_args(args []table.Param, is_variadic bool) ([]string, []string) {
+fn (mut g Gen) fn_args(args []table.Param) ([]string, []string) {
 	mut fargs := []string{}
 	mut fargtypes := []string{}
 	for i, arg in args {
@@ -254,7 +254,7 @@ fn (mut g Gen) fn_args(args []table.Param, is_variadic bool) ([]string, []string
 			} else {
 				g.write('${g.typ(func.return_type)} (*$caname)(')
 				g.definitions.write('${g.typ(func.return_type)} (*$caname)(')
-				g.fn_args(func.params, func.is_variadic)
+				g.fn_args(func.params)
 				g.write(')')
 				g.definitions.write(')')
 			}

--- a/vlib/v/gen/js/builtin_types.v
+++ b/vlib/v/gen/js/builtin_types.v
@@ -1,7 +1,7 @@
 module js
 import v.table
 
-fn (mut g JsGen) to_js_typ_def_val(s string) string {
+fn to_js_typ_def_val(s string) string {
 	mut dval := ''
 	match s {
 		'JS.Number' { dval = '0' }
@@ -16,25 +16,25 @@ fn (mut g JsGen) to_js_typ_def_val(s string) string {
 fn (mut g JsGen) to_js_typ_val(t table.Type) string {
 	sym := g.table.get_type_symbol(t)
 	mut styp := ''
-	mut prefix := if g.file.mod.name == 'builtin' { 'new ' } else { '' } 
+	mut prefix := if g.file.mod.name == 'builtin' { 'new ' } else { '' }
 	match sym.kind {
 		.i8, .i16, .int, .i64, .byte, .u16, .u32, .u64, .f32, .f64, .int_literal, .float_literal, .size_t {
-			styp = '${prefix}${g.sym_to_js_typ(sym)}(0)'
+			styp = '${prefix}${sym_to_js_typ(sym)}(0)'
 		}
 		.bool {
-			styp = '${prefix}${g.sym_to_js_typ(sym)}(false)'
+			styp = '${prefix}${sym_to_js_typ(sym)}(false)'
 		}
 		.string {
-			styp = '${prefix}${g.sym_to_js_typ(sym)}("")'
+			styp = '${prefix}${sym_to_js_typ(sym)}("")'
 		}
 		.map {
 			styp = 'new Map()'
 		}
 		.array {
-			styp = '${prefix}${g.sym_to_js_typ(sym)}()'
+			styp = '${prefix}${sym_to_js_typ(sym)}()'
 		}
 		.struct_ {
-			styp = 'new ${g.js_name(sym.name)}(${g.to_js_typ_def_val(sym.name)})'
+			styp = 'new ${g.js_name(sym.name)}(${to_js_typ_def_val(sym.name)})'
 		}
 		else {
 			// TODO
@@ -44,7 +44,7 @@ fn (mut g JsGen) to_js_typ_val(t table.Type) string {
 	return styp
 }
 
-fn (mut g JsGen) sym_to_js_typ(sym table.TypeSymbol) string {
+fn sym_to_js_typ(sym table.TypeSymbol) string {
 	mut styp := ''
 	match sym.kind {
 		.i8 { styp = 'i8' }
@@ -88,28 +88,28 @@ pub fn (mut g JsGen) typ(t table.Type) string {
 			styp = 'any'
 		}
 		.byteptr, .charptr {
-			styp = '${g.sym_to_js_typ(sym)}'
+			styp = '${sym_to_js_typ(sym)}'
 		}
 		.i8, .i16, .int, .i64, .byte, .u16, .u32, .u64, .f32, .f64, .int_literal, .float_literal, .size_t {
-			styp = '${g.sym_to_js_typ(sym)}'
+			styp = '${sym_to_js_typ(sym)}'
 		}
 		.bool {
-			styp = '${g.sym_to_js_typ(sym)}'
+			styp = '${sym_to_js_typ(sym)}'
 		}
 		.none_ {
 			styp = 'undefined'
 		}
 		.string, .ustring, .char {
-			styp = '${g.sym_to_js_typ(sym)}'
+			styp = '${sym_to_js_typ(sym)}'
 		}
 		// 'array_array_int' => 'number[][]'
 		.array {
 			info := sym.info as table.Array
-			styp = '${g.sym_to_js_typ(sym)}(${g.typ(info.elem_type)})'
+			styp = '${sym_to_js_typ(sym)}(${g.typ(info.elem_type)})'
 		}
 		.array_fixed {
 			info := sym.info as table.ArrayFixed
-			styp = '${g.sym_to_js_typ(sym)}(${g.typ(info.elem_type)})'
+			styp = '${sym_to_js_typ(sym)}(${g.typ(info.elem_type)})'
 		}
 		.chan {
 			styp = 'chan'

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -1214,6 +1214,8 @@ fn (mut g JsGen) gen_ident(node ast.Ident) {
 
 fn (mut g JsGen) gen_lock_expr(node ast.LockExpr) {
 	// TODO: implement this
+	_ = g // TODO Remove, just here to silence `unused` warning
+	_ = node
 }
 
 fn (mut g JsGen) gen_if_expr(node ast.IfExpr) {
@@ -1376,7 +1378,7 @@ fn (mut g JsGen) gen_infix_expr(it ast.InfixExpr) {
 			&& int(it.right_type) in table.integer_type_idxs
 		is_arithmetic := it.op in [token.Kind.plus, .minus, .mul, .div, .mod]
 		if is_arithmetic {
-			g.write('${g.typ(g.greater_typ(it.left_type, it.right_type))}(')
+			g.write('${g.typ(greater_typ(it.left_type, it.right_type))}(')
 		}
 		if it.op == .div && both_are_int {
 			g.write('((')
@@ -1401,7 +1403,7 @@ fn (mut g JsGen) gen_infix_expr(it ast.InfixExpr) {
 	}
 }
 
-fn (mut g JsGen) greater_typ(left table.Type, right table.Type) table.Type {
+fn greater_typ(left table.Type, right table.Type) table.Type {
 	l := int(left)
 	r := int(right)
 	lr := [l, r]

--- a/vlib/v/gen/x64/gen.v
+++ b/vlib/v/gen/x64/gen.v
@@ -573,6 +573,7 @@ fn (mut g Gen) mov(reg Register, val int) {
 }
 
 fn (mut g Gen) mov_reg(a Register, b Register) {
+	_ = b // TODO Remove, just here to silence `unused` warning
 	match a {
 		.rbp {
 			g.write8(0x48)

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -520,7 +520,7 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 		is_variadic: is_variadic
 		return_type: return_type
 	}
-	name := 'anon_${p.tok.pos}_${p.table.fn_type_signature(func)}'
+	name := 'anon_${p.tok.pos}_${table.fn_type_signature(func)}'
 	func.name = name
 	idx := p.table.find_or_register_fn_type(p.mod, func, true, false)
 	typ := table.new_type(idx)

--- a/vlib/v/parser/tests/postfix_err.out
+++ b/vlib/v/parser/tests/postfix_err.out
@@ -1,21 +1,21 @@
-vlib/v/parser/tests/postfix_err.vv:5:10: warning: `++` operator can only be used as a statement
-    3 | fn test_postfix() {
-    4 |     mut x := 1
-    5 |     _ = (x++)
+vlib/v/parser/tests/postfix_err.vv:7:10: warning: `++` operator can only be used as a statement
+    5 | fn test_postfix() {
+    6 |     mut x := 1
+    7 |     _ = (x++)
       |             ^
-    6 |     x--, x-- // OK
-    7 |     f(x++)
-vlib/v/parser/tests/postfix_err.vv:7:7: warning: `++` operator can only be used as a statement
-    5 |     _ = (x++)
-    6 |     x--, x-- // OK
-    7 |     f(x++)
+    8 |     x--, x-- // OK
+    9 |     f(x++)
+vlib/v/parser/tests/postfix_err.vv:9:7: warning: `++` operator can only be used as a statement
+    7 |     _ = (x++)
+    8 |     x--, x-- // OK
+    9 |     f(x++)
       |          ^
-    8 |     a := [x]
-    9 |     _ = a[x--]
-vlib/v/parser/tests/postfix_err.vv:9:11: warning: `--` operator can only be used as a statement
-    7 |     f(x++)
-    8 |     a := [x]
-    9 |     _ = a[x--]
+   10 |     a := [x]
+   11 |     _ = a[x--]
+vlib/v/parser/tests/postfix_err.vv:11:11: warning: `--` operator can only be used as a statement
+    9 |     f(x++)
+   10 |     a := [x]
+   11 |     _ = a[x--]
       |              ^
-   10 | }
-   11 |
+   12 | }
+   13 |

--- a/vlib/v/parser/tests/postfix_err.vv
+++ b/vlib/v/parser/tests/postfix_err.vv
@@ -1,4 +1,6 @@
-fn f(i int) {}
+fn f(i int) {
+	_ = i
+}
 
 fn test_postfix() {
 	mut x := 1

--- a/vlib/v/pref/should_compile.v
+++ b/vlib/v/pref/should_compile.v
@@ -17,7 +17,7 @@ pub fn (prefs &Preferences) should_compile_filtered_files(dir string, files_ []s
 		if prefs.backend == .c && !prefs.should_compile_c(file) {
 			continue
 		}
-		if prefs.backend == .js && !prefs.should_compile_js(file) {
+		if prefs.backend == .js && !should_compile_js(file) {
 			continue
 		}
 		if file.contains('_d_') {
@@ -142,7 +142,7 @@ pub fn (prefs &Preferences) should_compile_c(file string) bool {
 	return true
 }
 
-pub fn (prefs &Preferences) should_compile_js(file string) bool {
+pub fn should_compile_js(file string) bool {
 	if !file.ends_with('.js.v') && file.split('.').len > 2 {
 		// Probably something like `a.c.v`.
 		return false

--- a/vlib/v/preludes/tests_assertions.v
+++ b/vlib/v/preludes/tests_assertions.v
@@ -64,7 +64,7 @@ fn cb_assertion_failed(i &VAssertMetaInfo) {
 	eprintln('')
 }
 
-fn cb_assertion_ok(i &VAssertMetaInfo) {
+fn cb_assertion_ok(_ &VAssertMetaInfo) {
 	// prints for every assertion instead of per test function
 	// TODO: needs to be changed
 	/*

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -90,7 +90,7 @@ pub fn new_table() &Table {
 }
 
 // used to compare fn's & for naming anon fn's
-pub fn (t &Table) fn_type_signature(f &Fn) string {
+pub fn fn_type_signature(f &Fn) string {
 	mut sig := ''
 	for i, arg in f.params {
 		// TODO: for now ignore mut/pts in sig for now
@@ -640,7 +640,7 @@ pub fn (mut t Table) find_or_register_multi_return(mr_typs []Type) int {
 pub fn (mut t Table) find_or_register_fn_type(mod string, f Fn, is_anon bool, has_decl bool) int {
 	name := if f.name.len == 0 { 'fn ${t.fn_type_source_signature(f)}' } else { f.name.clone() }
 	cname := if f.name.len == 0 {
-		'anon_fn_${t.fn_type_signature(f)}'
+		'anon_fn_${fn_type_signature(f)}'
 	} else {
 		util.no_dots(f.name.clone())
 	}
@@ -721,7 +721,7 @@ pub fn (t &Table) value_type(typ Type) Type {
 }
 
 [inline]
-pub fn (t &Table) mktyp(typ Type) Type {
+pub fn mktyp(typ Type) Type {
 	match typ {
 		float_literal_type { return f64_type }
 		int_literal_type { return int_type }

--- a/vlib/v/vmod/vmod.v
+++ b/vlib/v/vmod/vmod.v
@@ -106,7 +106,7 @@ fn (mut mcache ModFileCacher) traverse(mfolder string) ([]string, ModFileAndFold
 			}
 			return folders_so_far, res
 		}
-		if mcache.check_for_stop(cfolder, files) {
+		if check_for_stop(files) {
 			break
 		}
 		cfolder = os.dir(cfolder)
@@ -138,7 +138,7 @@ const (
 	mod_file_stop_paths = ['.git', '.hg', '.svn', '.v.mod.stop']
 )
 
-fn (mcache &ModFileCacher) check_for_stop(cfolder string, files []string) bool {
+fn check_for_stop(files []string) bool {
 	for i in vmod.mod_file_stop_paths {
 		if i in files {
 			return true

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -69,13 +69,13 @@ pub:
 }
 
 // declaring init_once in your App struct is optional
-pub fn (ctx Context) init_once() {}
+pub fn (_ Context) init_once() {}
 
 // declaring init in your App struct is optional
-pub fn (ctx Context) init() {}
+pub fn (_ Context) init() {}
 
 // declaring uninit in your App struct is optional
-pub fn (ctx Context) uninit() {}
+pub fn (_ Context) uninit() {}
 
 pub struct Cookie {
 	name      string
@@ -304,7 +304,7 @@ fn handle_conn<T>(mut conn net.TcpConn, mut app T) {
 	page_gen_start := time.ticks()
 	first_line := reader.read_line() or {
 		$if debug {
-			eprintln('Failed first_line') // show this only in debug mode, because it always would be shown after a chromium user visits the site 
+			eprintln('Failed first_line') // show this only in debug mode, because it always would be shown after a chromium user visits the site
 		}
 		return
 	}

--- a/vlib/x/ttf/render_bmp.v
+++ b/vlib/x/ttf/render_bmp.v
@@ -10,8 +10,8 @@ module ttf
 *
 * Note:
 *
-* TODO: 
-* - manage text directions R to L 
+* TODO:
+* - manage text directions R to L
 **********************************************************************/
 import encoding.utf8
 import math
@@ -131,7 +131,7 @@ pub fn (mut bmp BitMap) exec_filler() {
 	}
 }
 
-pub fn (mut bmp BitMap) fline(in_x0 int, in_y0 int, in_x1 int, in_y1 int, c u32) {
+pub fn (mut bmp BitMap) fline(in_x0 int, in_y0 int, in_x1 int, in_y1 int, _ u32) {
 	mut x0 := f32(in_x0)
 	mut x1 := f32(in_x1)
 	mut y0 := f32(in_y0)
@@ -798,7 +798,7 @@ pub fn (mut bmp BitMap) draw_glyph(index u16) (int, int) {
 					//        (prev.y + point.y) / 2 + y);
 
 					// bmp.line(x0, y0, start_point.x, start_point.y, u32(0x00FF0000)
-					// u32(0xFF000000))              
+					// u32(0xFF000000))
 					bmp.quadratic(x0, y0, start_point.x, start_point.y, (point.x +
 						start_point.x) / 2, (point.y + start_point.y) / 2, color)
 				}

--- a/vlib/x/ttf/text_block.v
+++ b/vlib/x/ttf/text_block.v
@@ -10,7 +10,7 @@ module ttf
 *
 * Note:
 *
-* TODO: 
+* TODO:
 **********************************************************************/
 pub struct Text_block {
 	x         int  // x postion of the left high corner
@@ -20,7 +20,7 @@ pub struct Text_block {
 	cut_lines bool = true // force to cut the line if the length is over the text block width
 }
 
-fn (mut dev BitMap) get_justify_space_cw(txt string, w int, block_w int, space_cw int) f32 {
+fn (mut _ BitMap) get_justify_space_cw(txt string, w int, block_w int, space_cw int) f32 {
 	num_spaces := txt.count(' ')
 	if num_spaces < 1 {
 		return 0

--- a/vlib/x/websocket/websocket_server.v
+++ b/vlib/x/websocket/websocket_server.v
@@ -35,6 +35,7 @@ pub mut:
 
 // new_server instance a new websocket server on provided port and route
 pub fn new_server(port int, route string) &Server {
+	_ = route // TODO Route should probably be used or removed ?
 	return &Server{
 		ls: 0
 		port: port
@@ -64,7 +65,7 @@ pub fn (mut s Server) listen() ? {
 }
 
 // Close closes server (not implemented yet)
-fn (mut s Server) close() {
+fn (mut _ Server) close() {
 	// TODO: implement close when moving to net from x.net
 }
 


### PR DESCRIPTION
Add a warning when a parameter is unused.

```
$ v run fn.v
fn.v:1:18: warning: unused parameter: `a`
    1 | fn unused_params(a int) {}
      |                  ^
```

~~Due to https://github.com/vlang/v/issues/8467, some parameters cannot simply be named `_` to remove the warning, so I used `_ = param` for those cases. They will have to be removed once the issue is fixed. (little help: I marked each occurrence with "// TODO Remove, functions can't have two args with name \`_\`")~~

The PR will require some changes on externals modules (markdown, vls, vab) for the CI to pass, I'll link the PR here once they are done.
- markdown : https://github.com/vlang/markdown/pull/3 (merged)
- vls : https://github.com/vlang/vls/pull/67 (merged)
- vab : https://github.com/vlang/vab/pull/55 (merged)
- v (not external but required anyway) : #8480 (merged)
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
