### PR TITLE
gen: fix function with multiple blank params

### DIFF
--- a/vlib/v/gen/fn.v
+++ b/vlib/v/gen/fn.v
@@ -239,7 +239,7 @@ fn (mut g Gen) fn_args(args []table.Param, is_variadic bool) ([]string, []string
 	mut fargs := []string{}
 	mut fargtypes := []string{}
 	for i, arg in args {
-		caname := c_name(arg.name)
+		caname := if arg.name == '_' { g.new_tmp_var() } else { c_name(arg.name) }
 		typ := g.unwrap_generic(arg.typ)
 		arg_type_sym := g.table.get_type_symbol(typ)
 		mut arg_type_name := g.typ(typ) // util.no_dots(arg_type_sym.name)

--- a/vlib/v/tests/blank_ident_test.v
+++ b/vlib/v/tests/blank_ident_test.v
@@ -10,6 +10,20 @@ fn test_fn_with_blank_param() {
 	fn_with_blank_param(321)
 }
 
+fn fn_with_multiple_blank_param(_ int, _ f32) {
+	_ = 'not an int nor a float'
+}
+
+struct Abc {}
+
+fn (_ Abc) fn_with_multiple_blank_param(_ int, _ f32) {}
+
+fn test_fn_with_multiple_blank_param() {
+	fn_with_multiple_blank_param(1, 1.1)
+	a := Abc{}
+	a.fn_with_multiple_blank_param(1, 1.1)
+}
+
 fn test_for_in_range() {
 	for _ in 1 .. 10 {
 		assert true


### PR DESCRIPTION
Replaces parameters named `_` with a temporary variable name, never reused
Add tests

Fixes #8467
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
