### PR TITLE
gen: fix multiple blank param with interface

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -6050,22 +6050,22 @@ $staticprefix $interface_name* I_${cctype}_to_Interface_${interface_name}_ptr($c
 					// inline void Cat_speak_method_wrapper(Cat c) { return Cat_speak(*c); }
 					methods_wrapper.write('static inline ${g.typ(method.return_type)}')
 					methods_wrapper.write(' ${method_call}_method_wrapper(')
-					methods_wrapper.write('$cctype* ${method.params[0].name}')
-					// TODO g.fn_args
-					for j in 1 .. method.params.len {
-						arg := method.params[j]
-						methods_wrapper.write(', ${g.typ(arg.typ)} $arg.name')
+					//
+					params_start_pos := g.out.len
+					mut params := method.params.clone()
+					first_param := params[0] // workaround, { params[0] | ... } doesn't work
+					params[0] = {
+						first_param |
+						typ: params[0].typ.set_nr_muls(1)
 					}
+					fargs, _ := g.fn_args(params, false) // second argument is ignored anyway
+					methods_wrapper.write(g.out.cut_last(g.out.len - params_start_pos))
 					methods_wrapper.writeln(') {')
 					methods_wrapper.write('\t')
 					if method.return_type != table.void_type {
 						methods_wrapper.write('return ')
 					}
-					methods_wrapper.write('${method_call}(*${method.params[0].name}')
-					for j in 1 .. method.params.len {
-						methods_wrapper.write(', ${method.params[j].name}')
-					}
-					methods_wrapper.writeln(');')
+					methods_wrapper.writeln('${method_call}(*${fargs.join(', ')});')
 					methods_wrapper.writeln('}')
 					// .speak = Cat_speak_method_wrapper
 					method_call += '_method_wrapper'

--- a/vlib/v/tests/blank_ident_test.v
+++ b/vlib/v/tests/blank_ident_test.v
@@ -14,6 +14,10 @@ fn fn_with_multiple_blank_param(_ int, _ f32) {
 	_ = 'not an int nor a float'
 }
 
+interface Foo {
+	fn_with_multiple_blank_param(int, f32)
+}
+
 struct Abc {}
 
 fn (_ Abc) fn_with_multiple_blank_param(_ int, _ f32) {}
@@ -22,6 +26,14 @@ fn test_fn_with_multiple_blank_param() {
 	fn_with_multiple_blank_param(1, 1.1)
 	a := Abc{}
 	a.fn_with_multiple_blank_param(1, 1.1)
+}
+
+fn call_fn_with_multiple_blank_param(foo Foo) {
+	foo.fn_with_multiple_blank_param(1, 1.1)
+}
+
+fn test_interface_fn_with_multiple_blank_param() {
+	call_fn_with_multiple_blank_param(Abc{})
 }
 
 fn test_for_in_range() {


### PR DESCRIPTION
Following #8475
Required for #8471

There is currently a C error when using multiple blank parameters on a function that is used as an interface's method.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
