### PR TITLE
cgen: fix fixed array of function (fix #8473)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1694,6 +1694,12 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 			if elem_typ.info is table.FnType {
 				return elem_typ.info.func.return_type
 			}
+		} else if sym.kind == .array_fixed {
+			info := sym.info as table.ArrayFixed
+			elem_typ := c.table.get_type_symbol(info.elem_type)
+			if elem_typ.info is table.FnType {
+				return elem_typ.info.func.return_type
+			}
 		}
 		found = true
 		return table.string_type

--- a/vlib/v/tests/fixed_array_of_fn_test.v
+++ b/vlib/v/tests/fixed_array_of_fn_test.v
@@ -1,0 +1,9 @@
+fn foo(a string) int {
+	return 10 + a.len
+}
+
+fn test_fixed_array_fn_index() {
+	a := [foo]!
+	println(a[0]('hello'))
+	assert a[0]('hello') == 15
+}


### PR DESCRIPTION
This PR fix fixed array of function (fix #8473).

- Fix fixed array of function.
- Add test `fixed_array_of_fn_test.v`.

```vlang
fn foo(a string) int {
	return 10 + a.len
}

fn main() {
	a := [foo]!
	println(a[0]('hello'))
	assert a[0]('hello') == 15
}

PS D:\Test\v\tt1> v run .
15
```