### PR TITLE
checker: fix pass fixed array of function as argument (fix #8472)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -91,6 +91,12 @@ pub fn (mut c Checker) check_basic(got table.Type, expected table.Type) bool {
 			return true
 		}
 	}
+	// fixed array fn
+	if got_type_sym.kind == .array_fixed && exp_type_sym.kind == .array_fixed {
+		if c.table.type_to_str(got) == c.table.type_to_str(expected).trim('&') {
+			return true
+		}
+	}
 	if got_type_sym.kind == .array_fixed && exp_type_sym.kind == .byteptr {
 		info := got_type_sym.info as table.ArrayFixed
 		if info.elem_type.idx() == table.byte_type_idx {

--- a/vlib/v/tests/fn_with_fixed_array_function_args_test.v
+++ b/vlib/v/tests/fn_with_fixed_array_function_args_test.v
@@ -1,0 +1,23 @@
+fn foo(a string) int {
+	return 10 + a.len
+}
+
+fn foo2(a string) int {
+	return 20 + a.len
+}
+
+fn bar1(mut a [1]fn (string) int) int {
+        a[0] = foo2
+	return a[0]('hello')
+}
+
+fn bar2(a [1]fn (string) int) int {
+	return a[0]('hello')
+}
+
+fn test_fn_with_fixed_array_function_args() {
+	mut a1 := [foo]!
+	assert bar1(mut a1) == 25
+	a2 := [foo]!
+	assert bar2(a2) == 15
+}


### PR DESCRIPTION
This PR fix pass fixed array of function as argument (fix #8472).

- Fix pass fixed array of function as argument.
- Add test.

```vlang
fn foo(a string) int {
	return 10 + a.len
}

fn foo2(a string) int {
	return 20 + a.len
}

fn bar1(mut a [1]fn (string) int) int {
        a[0] = foo2
	return a[0]('hello')
}

fn bar2(a [1]fn (string) int) int {
	return a[0]('hello')
}

fn main() {
	mut a1 := [foo]!
	assert bar1(mut a1) == 25
	a2 := [foo]!
	assert bar2(a2) == 15
}

PS D:\Test\v\tt1> v run .

```