### PR TITLE
cgen: fix bug with duplicate defer generation

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -332,6 +332,7 @@ pub:
 pub mut:
 	stmts         []Stmt
 	return_type   table.Type
+	has_return    bool
 	comments      []Comment // comments *after* the header, but *before* `{`; used for InterfaceDecl
 	next_comments []Comment // coments that are one line after the decl; used for InterfaceDecl
 	source_file   &File = 0

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5676,9 +5676,9 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 	if c.fn_mut_arg_names.len > 0 {
 		c.fn_mut_arg_names.clear()
 	}
-	returns := c.returns || has_top_return(node.stmts)
-	if node.language == .v && !node.no_body && node.return_type != table.void_type && !returns
-		&& node.name !in ['panic', 'exit'] {
+	node.has_return = c.returns || has_top_return(node.stmts)
+	if node.language == .v && !node.no_body && node.return_type != table.void_type
+		&& !node.has_return&& node.name !in ['panic', 'exit'] {
 		if c.inside_anon_fn {
 			c.error('missing return at the end of an anonymous function', node.pos)
 		} else {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -192,7 +192,7 @@ fn (mut g Gen) gen_fn_decl(node ast.FnDecl, skip bool) {
 		g.fn_mut_arg_names.clear()
 	}
 
-	if node.return_type == table.void_type {
+	if !node.has_return {
 		g.write_defer_stmts_when_needed()
 	}
 	if node.is_anon {


### PR DESCRIPTION
I found that cgen generate duplicate code from defer_test.v

This PR fix this.

```
VV_LOCAL_SYMBOL void main__test_defer_with_anon_fn() {
	main__Num* f = (main__Num*)memdup(&(main__Num){.val = 110,}, sizeof(main__Num));
	// go
	thread_arg_anon_901__1 *arg__t327 = malloc(sizeof(thread_arg_anon_901__1));
	pthread_t thread__t327;
	pthread_create(&thread__t327, NULL, (void*)anon_901__1_thread_wrapper, arg__t327);
	pthread_detach(thread__t327);
	// endgo

	void (*x) () = 	anon_969__1;
	x();
	// Defer begin
	// assert
	int _t328 = main__Num_add(/*rec*/*f, 1);
	if (_t328 == 111) {
		g_test_oks++;
		VAssertMetaInfo v_assert_meta_info__t329 = {0};
		v_assert_meta_info__t329.fpath = _SLIT("vlib/v/tests/defer_test.v");
		v_assert_meta_info__t329.line_nr = 69;
		v_assert_meta_info__t329.fn_name = _SLIT("main.test_defer_with_anon_fn");
		v_assert_meta_info__t329.src = _SLIT("f.add(1) == 111");
		v_assert_meta_info__t329.op = _SLIT("==");
		v_assert_meta_info__t329.llabel = _SLIT("f.add(1)");
		v_assert_meta_info__t329.rlabel = _SLIT("111");
		v_assert_meta_info__t329.lvalue = int_str(_t328) /* typeof: v.ast.CTempVar type: 7 */ ;
		v_assert_meta_info__t329.rvalue = int_literal_str(111) /* typeof: v.ast.IntegerLiteral type: 27 */ ;
		main__cb_assertion_ok(&v_assert_meta_info__t329);
	} else {
		g_test_fails++;
		VAssertMetaInfo v_assert_meta_info__t330 = {0};
		v_assert_meta_info__t330.fpath = _SLIT("vlib/v/tests/defer_test.v");
		v_assert_meta_info__t330.line_nr = 69;
		v_assert_meta_info__t330.fn_name = _SLIT("main.test_defer_with_anon_fn");
		v_assert_meta_info__t330.src = _SLIT("f.add(1) == 111");
		v_assert_meta_info__t330.op = _SLIT("==");
		v_assert_meta_info__t330.llabel = _SLIT("f.add(1)");
		v_assert_meta_info__t330.rlabel = _SLIT("111");
		v_assert_meta_info__t330.lvalue = int_str(_t328) /* typeof: v.ast.CTempVar type: 7 */ ;
		v_assert_meta_info__t330.rvalue = int_literal_str(111) /* typeof: v.ast.IntegerLiteral type: 27 */ ;
		main__cb_assertion_failed(&v_assert_meta_info__t330);
		longjmp(g_jump_buffer, 1);
		// TODO
		// Maybe print all vars in a test function if it fails?
	}
	// Defer end
	return;
// Defer begin
// assert
if (_t328 == 111) {
	g_test_oks++;
	VAssertMetaInfo v_assert_meta_info__t331 = {0};
	v_assert_meta_info__t331.fpath = _SLIT("vlib/v/tests/defer_test.v");
	v_assert_meta_info__t331.line_nr = 69;
	v_assert_meta_info__t331.fn_name = _SLIT("main.test_defer_with_anon_fn");
	v_assert_meta_info__t331.src = _SLIT("f.add(1) == 111");
	v_assert_meta_info__t331.op = _SLIT("==");
	v_assert_meta_info__t331.llabel = _SLIT("f.add(1)");
	v_assert_meta_info__t331.rlabel = _SLIT("111");
	v_assert_meta_info__t331.lvalue = int_str(_t328) /* typeof: v.ast.CTempVar type: 7 */ ;
	v_assert_meta_info__t331.rvalue = int_literal_str(111) /* typeof: v.ast.IntegerLiteral type: 27 */ ;
	main__cb_assertion_ok(&v_assert_meta_info__t331);
} else {
	g_test_fails++;
	VAssertMetaInfo v_assert_meta_info__t332 = {0};
	v_assert_meta_info__t332.fpath = _SLIT("vlib/v/tests/defer_test.v");
	v_assert_meta_info__t332.line_nr = 69;
	v_assert_meta_info__t332.fn_name = _SLIT("main.test_defer_with_anon_fn");
	v_assert_meta_info__t332.src = _SLIT("f.add(1) == 111");
	v_assert_meta_info__t332.op = _SLIT("==");
	v_assert_meta_info__t332.llabel = _SLIT("f.add(1)");
	v_assert_meta_info__t332.rlabel = _SLIT("111");
	v_assert_meta_info__t332.lvalue = int_str(_t328) /* typeof: v.ast.CTempVar type: 7 */ ;
	v_assert_meta_info__t332.rvalue = int_literal_str(111) /* typeof: v.ast.IntegerLiteral type: 27 */ ;
	main__cb_assertion_failed(&v_assert_meta_info__t332);
	longjmp(g_jump_buffer, 1);
	// TODO
	// Maybe print all vars in a test function if it fails?
}
// Defer end

```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
