### PR TITLE
ftp: fix error of dir() (fix #8500)

### DIFF
--- a/vlib/net/ftp/ftp.v
+++ b/vlib/net/ftp/ftp.v
@@ -67,7 +67,9 @@ mut:
 }
 
 pub fn new() FTP {
-	mut f := FTP{ conn: 0 }
+	mut f := FTP{
+		conn: 0
+	}
 	f.buffer_size = 1024
 	return f
 }
@@ -178,7 +180,7 @@ fn new_dtp(msg string) ?&DTP {
 	mut dtp := &DTP{
 		ip: ip
 		port: port
-        conn: 0
+		conn: 0
 	}
 	conn := net.dial_tcp('$ip:$port') or { return error('Cannot connect to the data channel') }
 	dtp.conn = conn
@@ -220,7 +222,7 @@ pub fn (mut zftp FTP) dir() ?[]string {
 	for lfile in sdir.split('\n') {
 		if lfile.len > 1 {
 			spl := lfile.split(' ')
-			dir << spl[spl.len - 1]
+			dir << spl[spl.len - 1].trim_space()
 		}
 	}
 	return dir

--- a/vlib/net/ftp/ftp_test.v
+++ b/vlib/net/ftp/ftp_test.v
@@ -7,13 +7,13 @@ fn test_ftp_cleint() {
 	// NB: this function makes network calls to external servers,
 	// that is why it is not a very good idea to run it in CI.
 	// If you want to run it manually, use:
-    // `v -d network vlib/net/ftp/ftp_test.v`
+	// `v -d network vlib/net/ftp/ftp_test.v`
 	ftp_client_test_inside() or { panic(err) }
 }
 
 fn ftp_client_test_inside() ? {
 	mut zftp := ftp.new()
-    // eprintln(zftp)
+	// eprintln(zftp)
 	defer {
 		zftp.close() or { panic(err) }
 	}
@@ -41,6 +41,7 @@ fn ftp_client_test_inside() ? {
 		return
 	}
 	assert dir_list2.len > 0
+	assert dir_list2.contains('katello-host-tools-3.3.5-8.sles11_4sat.src.rpm')
 	blob := zftp.get('katello-host-tools-3.3.5-8.sles11_4sat.src.rpm') or {
 		assert false
 		return


### PR DESCRIPTION
This PR fix error of dir() (fix #8500).

- Fix error of dir() in ftp module.
- Add test in `ftp_test.v`.

```vlang
import net.ftp

fn main() {
	mut c := ftp.new()
	defer {
		c.close() or { panic(err) }
	}
	connect := c.connect('speedtest.tele2.net')?
	assert connect
	println(connect)
	login := c.login('anonymous', '')?
	println(login)
	pwd := c.pwd()?
	println(pwd)
	assert pwd.len > 0
	dirs := c.dir()?
	println(dirs)
	println(dirs.len)
}

PS D:\Test\v\tt1> v run .
true
true
/
['1000GB.zip', '100GB.zip', '100KB.zip', '100MB.zip', '10GB.zip', '10MB.zip', '1GB.zip', '1KB.zip', '1MB.zip', '200MB.zip', '20MB.zip', '2MB.zip', '3MB.zip', '500MB.zip', '50MB.zip', '512KB.zip', '5MB.zip', 'upload']
18
```