### PR TITLE
checker: merge array_filter_fn_err tests

### DIFF
--- a/vlib/v/checker/tests/array_filter_anon_fn_err_a.out
+++ b/vlib/v/checker/tests/array_filter_anon_fn_err_a.out
@@ -1,6 +1,0 @@
-vlib/v/checker/tests/array_filter_anon_fn_err_a.vv:2:24: error: function needs exactly 1 argument
-    1 | fn main() {
-    2 |     a := [1,2,3,4].filter(fn(a int, b int) bool { return a > 0 })
-      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    3 |     println(a)
-    4 | }

--- a/vlib/v/checker/tests/array_filter_anon_fn_err_a.vv
+++ b/vlib/v/checker/tests/array_filter_anon_fn_err_a.vv
@@ -1,4 +1,0 @@
-fn main() {
-	a := [1,2,3,4].filter(fn(a int, b int) bool { return a > 0 })
-	println(a)
-}

--- a/vlib/v/checker/tests/array_filter_anon_fn_err_b.out
+++ b/vlib/v/checker/tests/array_filter_anon_fn_err_b.out
@@ -1,6 +1,0 @@
-vlib/v/checker/tests/array_filter_anon_fn_err_b.vv:2:24: error: type mismatch, should use `fn(a int) bool {...}`
-    1 | fn main() {
-    2 |     a := [1,2,3,4].filter(fn(a string) bool { return a.len > 0 })
-      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    3 |     println(a)
-    4 | }

--- a/vlib/v/checker/tests/array_filter_anon_fn_err_b.vv
+++ b/vlib/v/checker/tests/array_filter_anon_fn_err_b.vv
@@ -1,4 +1,0 @@
-fn main() {
-	a := [1,2,3,4].filter(fn(a string) bool { return a.len > 0 })
-	println(a)
-}

--- a/vlib/v/checker/tests/array_filter_fn_err.out
+++ b/vlib/v/checker/tests/array_filter_fn_err.out
@@ -1,0 +1,27 @@
+vlib/v/checker/tests/array_filter_fn_err.vv:2:25: error: function needs exactly 1 argument
+    1 | fn main() {
+    2 |     a1 := [1,2,3,4].filter(fn(a int, b int) bool { return a > 0 })
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3 |     println(a1)
+    4 |
+vlib/v/checker/tests/array_filter_fn_err.vv:5:25: error: type mismatch, should use `fn(a int) bool {...}`
+    3 |     println(a1)
+    4 |
+    5 |     a2 := [1,2,3,4].filter(fn(a string) bool { return a.len > 0 })
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    6 |     println(a2)
+    7 |
+vlib/v/checker/tests/array_filter_fn_err.vv:8:18: error: function needs exactly 1 argument
+    6 |     println(a2)
+    7 |
+    8 |     a3 := [1,2,3,4].filter(fil1)
+      |                     ~~~~~~~~~~~~
+    9 |     println(a3)
+   10 |
+vlib/v/checker/tests/array_filter_fn_err.vv:11:25: error: type mismatch, should use `fn(a int) bool {...}`
+    9 |     println(a3)
+   10 |
+   11 |     a4 := [1,2,3,4].filter(fil2)
+      |                            ~~~~
+   12 |     println(a4)
+   13 | }

--- a/vlib/v/checker/tests/array_filter_fn_err.vv
+++ b/vlib/v/checker/tests/array_filter_fn_err.vv
@@ -1,0 +1,21 @@
+fn main() {
+	a1 := [1,2,3,4].filter(fn(a int, b int) bool { return a > 0 })
+	println(a1)
+
+	a2 := [1,2,3,4].filter(fn(a string) bool { return a.len > 0 })
+	println(a2)
+
+	a3 := [1,2,3,4].filter(fil1)
+	println(a3)
+
+	a4 := [1,2,3,4].filter(fil2)
+	println(a4)
+}
+
+fn fil1(a int, b int) bool {
+	return a > 0
+}
+
+fn fil2(a string) bool {
+	return a.len > 0
+}

--- a/vlib/v/checker/tests/array_filter_fn_err_a.out
+++ b/vlib/v/checker/tests/array_filter_fn_err_a.out
@@ -1,7 +1,0 @@
-vlib/v/checker/tests/array_filter_fn_err_a.vv:5:17: error: function needs exactly 1 argument
-    3 | }
-    4 | fn main() {
-    5 |     a := [1,2,3,4].filter(fil)
-      |                    ~~~~~~~~~~~
-    6 |     println(a)
-    7 | }

--- a/vlib/v/checker/tests/array_filter_fn_err_a.vv
+++ b/vlib/v/checker/tests/array_filter_fn_err_a.vv
@@ -1,7 +1,0 @@
-fn fil(a int, b int) bool {
-	return a > 0
-}
-fn main() {
-	a := [1,2,3,4].filter(fil)
-	println(a)
-}

--- a/vlib/v/checker/tests/array_filter_fn_err_b.out
+++ b/vlib/v/checker/tests/array_filter_fn_err_b.out
@@ -1,7 +1,0 @@
-vlib/v/checker/tests/array_filter_fn_err_b.vv:5:24: error: type mismatch, should use `fn(a int) bool {...}`
-    3 | }
-    4 | fn main() {
-    5 |     a := [1,2,3,4].filter(fil)
-      |                           ~~~
-    6 |     println(a)
-    7 | }

--- a/vlib/v/checker/tests/array_filter_fn_err_b.vv
+++ b/vlib/v/checker/tests/array_filter_fn_err_b.vv
@@ -1,7 +1,0 @@
-fn fil(a string) bool {
-	return a.len > 0
-}
-fn main() {
-	a := [1,2,3,4].filter(fil)
-	println(a)
-}


### PR DESCRIPTION
This PR merges array_filter_fn_err tests in checker.

```vlang
fn main() {
	a1 := [1,2,3,4].filter(fn(a int, b int) bool { return a > 0 })
	println(a1)

	a2 := [1,2,3,4].filter(fn(a string) bool { return a.len > 0 })
	println(a2)

	a3 := [1,2,3,4].filter(fil1)
	println(a3)

	a4 := [1,2,3,4].filter(fil2)
	println(a4)
}

fn fil1(a int, b int) bool {
	return a > 0
}

fn fil2(a string) bool {
	return a.len > 0
}

vlib/v/checker/tests/array_filter_fn_err.vv:2:25: error: function needs exactly 1 argument
    1 | fn main() {
    2 |     a1 := [1,2,3,4].filter(fn(a int, b int) bool { return a > 0 })
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    3 |     println(a1)
    4 |
vlib/v/checker/tests/array_filter_fn_err.vv:5:25: error: type mismatch, should use `fn(a int) bool {...}`
    3 |     println(a1)
    4 |
    5 |     a2 := [1,2,3,4].filter(fn(a string) bool { return a.len > 0 })
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    6 |     println(a2)
    7 |
vlib/v/checker/tests/array_filter_fn_err.vv:8:18: error: function needs exactly 1 argument
    6 |     println(a2)
    7 |
    8 |     a3 := [1,2,3,4].filter(fil1)
      |                     ~~~~~~~~~~~~
    9 |     println(a3)
   10 |
vlib/v/checker/tests/array_filter_fn_err.vv:11:25: error: type mismatch, should use `fn(a int) bool {...}`
    9 |     println(a3)
   10 |
   11 |     a4 := [1,2,3,4].filter(fil2)
      |                            ~~~~
   12 |     println(a4)
   13 | }
```