### PR TITLE
cgen: allow `shared` initialization from function returned value

### DIFF
--- a/vlib/v/gen/cgen.v
+++ b/vlib/v/gen/cgen.v
@@ -2506,6 +2506,19 @@ fn (mut g Gen) expr(node ast.Expr) {
 			// if g.fileis('1.strings') {
 			// println('\ncall_expr()()')
 			// }
+			mut shared_styp := ''
+			if g.is_shared {
+				ret_sym := g.table.get_type_symbol(node.return_type)
+				shared_typ := node.return_type.set_flag(.shared_f)
+				shared_styp = g.typ(shared_typ)
+				if ret_sym.kind == .array {
+					g.writeln('($shared_styp*)__dup_shared_array(&($shared_styp){.val = ')
+				} else if ret_sym.kind == .map {
+					g.writeln('($shared_styp*)__dup_shared_map(&($shared_styp){.val = ')
+				} else {
+					g.writeln('($shared_styp*)__dup${shared_styp}(&($shared_styp){.val = ')
+				}
+			}
 			g.call_expr(node)
 			// if g.fileis('1.strings') {
 			// println('before:' + node.autofree_pregen)
@@ -2521,6 +2534,9 @@ fn (mut g Gen) expr(node ast.Expr) {
 				}
 				g.strs_to_free0 = []
 				// println('pos=$node.pos.pos')
+			}
+			if g.is_shared {
+				g.writeln('}, sizeof($shared_styp))')
 			}
 			// if g.autofree && node.autofree_pregen != '' { // g.strs_to_free0.len != 0 {
 			/*

--- a/vlib/v/tests/shared_array_test.v
+++ b/vlib/v/tests/shared_array_test.v
@@ -46,20 +46,29 @@ fn test_shared_init_syntax() {
 	shared bar := [-12.5, 23.125, 6.0625, 12.5]
 	shared baz := &[]int{len: 5, cap: 12}
 	shared qux := []f64{len: 7}
+	shared quux := new_array()
 	lock foo {
 		foo[2] = 20
 	}
 	lock bar {
 		bar[3] = 12.5
 	}
-	lock baz, qux {
+	lock baz, qux, quux {
 		baz[3] = 12
 		qux[6] = -17.0625
+		quux[2] = 7.0625
 	}
-	rlock foo, bar, baz, qux {
+	rlock foo, bar, baz, qux, quux {
 		assert foo[2] == 20
 		assert bar[3] == 12.5
 		assert baz[3] == 12
 		assert qux[6] == -17.0625
+		assert quux[1] == 6.25
+		assert quux[2] == 7.0625
 	}
+}
+
+fn new_array() []f64 {
+	a := [12.5, 6.25, -3.125, 1.75]
+	return a
 }

--- a/vlib/v/tests/shared_map_test.v
+++ b/vlib/v/tests/shared_map_test.v
@@ -41,20 +41,29 @@ fn test_shared_init_syntax() {
 	shared bar := {'wer': 13.75, 'cvbn': -7.25, 'asd': -0.0625}
 	shared baz := &map[string]int{}
 	shared qux := map[string]f64{}
+	shared quux := new_map()
 	lock foo {
 		foo['q'] = 20
 	}
 	lock bar {
 		bar['asd'] = 12.5
 	}
-	lock baz, qux {
+	lock baz, qux, quux {
 		baz['wer'] = 12
 		qux['abc'] = -17.0625
+		quux['tzu'] = 1.125
 	}
-	rlock foo, bar, baz, qux {
+	rlock foo, bar, baz, qux, quux {
 		assert foo['q'] == 20
 		assert bar['asd'] == 12.5
 		assert baz['wer'] == 12
 		assert qux['abc'] == -17.0625
+		assert quux['tzu'] == 1.125
+		assert quux['yxc'] == 9.125
 	}
+}
+
+fn new_map() map[string]f64 {
+	m := { 'qwe': 34.25, 'yxc': 9.125, 'tzu': -7.5 }
+	return m
 }


### PR DESCRIPTION
This allows constructors returning a `struct`, `map` or `array` *value* to be used to initialize `shared` objects:
```v
fn new_struct() St { ... }
fn new_array() []f64 { ... }
fn new_map() map[string]int { ... }

shared s := new_struct()
shared a := new_array()
shared m := new_map()
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
