### PR TITLE
ftp: minor optimization in dir()

### DIFF
--- a/vlib/net/ftp/ftp.v
+++ b/vlib/net/ftp/ftp.v
@@ -221,8 +221,7 @@ pub fn (mut zftp FTP) dir() ?[]string {
 	sdir := list_dir.bytestr()
 	for lfile in sdir.split('\n') {
 		if lfile.len > 1 {
-			spl := lfile.split(' ')
-			dir << spl[spl.len - 1].trim_space()
+			dir << lfile.after(' ').trim_space()
 		}
 	}
 	return dir


### PR DESCRIPTION
This PR makes minor optimization in dir().

Avoid using split, improve performance.

```vlang
			spl := lfile.split(' ')
			dir << spl[spl.len - 1].trim_space()
```
to
```vlang
			dir << lfile.after(' ').trim_space()
```