### PR TITLE
checker: check goto label exists

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -336,6 +336,7 @@ pub mut:
 	next_comments []Comment // coments that are one line after the decl; used for InterfaceDecl
 	source_file   &File = 0
 	scope         &Scope
+	label_names   []string
 }
 
 pub struct GenericParam {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3177,11 +3177,10 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 					node.call_expr.left.position())
 			}
 		}
-		ast.GotoLabel {
-		}
+		ast.GotoLabel {}
 		ast.GotoStmt {
 			if node.name !in c.cur_fn.label_names {
-				c.error('unknown label `${node.name}`', node.pos)
+				c.error('unknown label `$node.name`', node.pos)
 			}
 			// TODO: check label doesn't bypass variable declarations
 		}
@@ -5188,7 +5187,6 @@ pub fn (mut c Checker) offset_of(node ast.OffsetOf) table.Type {
 		c.error('first argument of __offsetof must be struct', node.pos)
 		return table.u32_type
 	}
-
 	if !c.table.struct_has_field(node.struct_type, node.field) {
 		c.error('struct `$sym.name` has no field called `$node.field`', node.pos)
 	}
@@ -5447,7 +5445,6 @@ fn (mut c Checker) fetch_and_verify_orm_fields(info table.Struct, pos token.Posi
 fn (mut c Checker) post_process_generic_fns() {
 	// Loop thru each generic function concrete type.
 	// Check each specific fn instantiation.
-
 	for i in 0 .. c.file.generic_fns.len {
 		if c.table.fn_gen_types.len == 0 {
 			// no concrete types, so just skip:
@@ -5598,7 +5595,6 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 	}
 	c.fn_scope = node.scope
 	c.stmts(node.stmts)
-
 	if c.fn_mut_arg_names.len > 0 {
 		c.fn_mut_arg_names.clear()
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3177,8 +3177,12 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 					node.call_expr.left.position())
 			}
 		}
-		ast.GotoLabel {}
+		ast.GotoLabel {
+		}
 		ast.GotoStmt {
+			if node.name !in c.cur_fn.label_names {
+				c.error('unknown label `${node.name}`', node.pos)
+			}
 			// TODO: check label doesn't bypass variable declarations
 		}
 		ast.HashStmt {

--- a/vlib/v/checker/tests/goto_label.out
+++ b/vlib/v/checker/tests/goto_label.out
@@ -1,14 +1,49 @@
-vlib/v/checker/tests/goto_label.vv:8:7: error: unknown label `l`
-    6 | fn g() {
-    7 |     l2:
-    8 |     goto l
-      |          ^
-    9 |     goto l2
-   10 |     goto l3
-vlib/v/checker/tests/goto_label.vv:10:7: error: unknown label `l3`
-    8 |     goto l
-    9 |     goto l2
-   10 |     goto l3
+vlib/v/checker/tests/goto_label.vv:5:7: error: unknown label `a1`
+    3 |     goto f2
+    4 |     f1:
+    5 |     goto a1
       |          ~~
-   11 | }
-   12 |
+    6 |     _ = fn(){
+    7 |         goto f1
+vlib/v/checker/tests/goto_label.vv:7:8: error: unknown label `f1`
+    5 |     goto a1
+    6 |     _ = fn(){
+    7 |         goto f1
+      |              ~~
+    8 |         goto f2
+    9 |         goto a1
+vlib/v/checker/tests/goto_label.vv:8:8: error: unknown label `f2`
+    6 |     _ = fn(){
+    7 |         goto f1
+    8 |         goto f2
+      |              ~~
+    9 |         goto a1
+   10 |         a1:
+vlib/v/checker/tests/goto_label.vv:14:7: error: unknown label `a1`
+   12 |     }
+   13 |     f2:
+   14 |     goto a1
+      |          ~~
+   15 |     goto f1 // back
+   16 |     goto f2
+vlib/v/checker/tests/goto_label.vv:22:7: error: unknown label `f1`
+   20 |     goto g1 // forward
+   21 |     g1:
+   22 |     goto f1
+      |          ~~
+   23 |     goto a1
+   24 |     goto g1 // back
+vlib/v/checker/tests/goto_label.vv:23:7: error: unknown label `a1`
+   21 |     g1:
+   22 |     goto f1
+   23 |     goto a1
+      |          ~~
+   24 |     goto g1 // back
+   25 |     goto undefined
+vlib/v/checker/tests/goto_label.vv:25:7: error: unknown label `undefined`
+   23 |     goto a1
+   24 |     goto g1 // back
+   25 |     goto undefined
+      |          ~~~~~~~~~
+   26 | }
+   27 |

--- a/vlib/v/checker/tests/goto_label.out
+++ b/vlib/v/checker/tests/goto_label.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/goto_label.vv:8:7: error: unknown label `l`
+    6 | fn g() {
+    7 |     l2:
+    8 |     goto l
+      |          ^
+    9 |     goto l2
+   10 |     goto l3
+vlib/v/checker/tests/goto_label.vv:10:7: error: unknown label `l3`
+    8 |     goto l
+    9 |     goto l2
+   10 |     goto l3
+      |          ~~
+   11 | }
+   12 |

--- a/vlib/v/checker/tests/goto_label.vv
+++ b/vlib/v/checker/tests/goto_label.vv
@@ -1,0 +1,12 @@
+fn f() {
+	goto l
+	l:
+}
+
+fn g() {
+	l2:
+	goto l
+	goto l2
+	goto l3
+}
+

--- a/vlib/v/checker/tests/goto_label.vv
+++ b/vlib/v/checker/tests/goto_label.vv
@@ -10,3 +10,6 @@ fn g() {
 	goto l3
 }
 
+l4:
+goto l4
+

--- a/vlib/v/checker/tests/goto_label.vv
+++ b/vlib/v/checker/tests/goto_label.vv
@@ -1,15 +1,32 @@
 fn f() {
-	goto l
-	l:
+	goto f1 // forward
+	goto f2
+	f1:
+	goto a1
+	_ = fn(){
+		goto f1
+		goto f2
+		goto a1
+		a1:
+		goto a1
+	}
+	f2:
+	goto a1
+	goto f1 // back
+	goto f2
 }
 
 fn g() {
-	l2:
-	goto l
-	goto l2
-	goto l3
+	goto g1 // forward
+	g1:
+	goto f1
+	goto a1
+	goto g1 // back
+	goto undefined
 }
 
-l4:
-goto l4
+// implicit main
+goto m1
+m1:
+goto m1
 

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -425,7 +425,9 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		is_builtin: p.builtin_mod || p.mod in util.builtin_module_parts
 		attrs: p.attrs
 		scope: p.scope
+		label_names: p.label_names
 	}
+	p.label_names = []
 	p.close_scope()
 	return fn_decl
 }

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -514,8 +514,13 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 		p.error_with_pos('unexpected `$p.tok.kind` after anonymous function signature, expecting `{`',
 			p.tok.position())
 	}
+	mut label_names := []string{}
 	if p.tok.kind == .lcbr {
+		tmp := p.label_names
+		p.label_names = []
 		stmts = p.parse_block_no_scope(false)
+		label_names = p.label_names
+		p.label_names = tmp
 	}
 	p.close_scope()
 	mut func := table.Fn{
@@ -542,6 +547,7 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 			pos: pos.extend(p.prev_tok.position())
 			file: p.file_name
 			scope: p.scope
+			label_names: label_names
 		}
 		typ: typ
 	}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -658,6 +658,9 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 				// `label:`
 				spos := p.tok.position()
 				name := p.check_name()
+				if name in p.label_names {
+					p.error_with_pos('duplicate label `$name`', spos)
+				}
 				p.label_names << name
 				p.next()
 				if p.tok.kind == .key_for {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -553,6 +553,7 @@ pub fn (mut p Parser) top_stmt() ast.Stmt {
 						file: p.file_name
 						return_type: table.void_type
 						scope: p.scope
+						label_names: p.label_names
 					}
 				} else if p.pref.is_fmt {
 					return p.stmt(false)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -658,6 +658,7 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 				// `label:`
 				spos := p.tok.position()
 				name := p.check_name()
+				p.label_names << name
 				p.next()
 				if p.tok.kind == .key_for {
 					mut stmt := p.stmt(is_top_level)
@@ -679,7 +680,6 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 						}
 					}
 				}
-				p.label_names << name
 				return ast.GotoLabel{
 					name: name
 					pos: spos.extend(p.tok.position())

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -69,6 +69,7 @@ mut:
 	warnings          []errors.Warning
 	vet_errors        []vet.Error
 	cur_fn_name       string
+	label_names       []string
 	in_generic_params bool // indicates if parsing between `<` and `>` of a method/function
 	name_error        bool // indicates if the token is not a name or the name is on another line
 }
@@ -677,6 +678,7 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 						}
 					}
 				}
+				p.label_names << name
 				return ast.GotoLabel{
 					name: name
 					pos: spos.extend(p.tok.position())


### PR DESCRIPTION
Since `goto` got documented recently, it's time to check that the label exists inside the current function.

 Fixes #2682.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
