### PR TITLE
clipboard: add wayland workaround and termux support

### DIFF
--- a/vlib/clipboard/clipboard.v
+++ b/vlib/clipboard/clipboard.v
@@ -8,11 +8,17 @@ pub fn new() &Clipboard {
 	return new_clipboard()
 }
 
+const wayland_display = os.getenv('WAYLAND_DISPLAY') != ''
+
+const has_wl_clipboard = os.exists_in_system_path('wl-copy') && os.exists_in_system_path('wl-paste')
+
+const is_termux = os.exists_in_system_path('termux-clipboard-set')
+
 // copy copies `text` into the clipboard.
 pub fn (mut cb Clipboard) copy(text string) bool {
 	// WayLand workaround using wl-clipboard.
-	if os.getenv('WAYLAND_DISPLAY') != '' {
-		if os.exists_in_system_path('wl-copy') && os.exists_in_system_path('wl-paste') {
+	if clipboard.wayland_display {
+		if clipboard.has_wl_clipboard {
 			success := os.system('wl-copy $text') == 0
 			cb.is_owner = success
 			return success
@@ -21,7 +27,7 @@ pub fn (mut cb Clipboard) copy(text string) bool {
 		}
 	}
 	// Termux clipboard support
-	if os.exists_in_system_path('termux-clipboard-set') && os.exists_in_system_path('termux-clipboard-get') {
+	if clipboard.is_termux {
 		success := os.system('termux-clipboard-set $text') == 0
 		cb.is_owner = success
 		return success
@@ -33,20 +39,16 @@ pub fn (mut cb Clipboard) copy(text string) bool {
 // paste returns current entry as a `string` from the clipboard.
 pub fn (mut cb Clipboard) paste() string {
 	// WayLand workaround using wl-clipboard.
-	if os.getenv('WAYLAND_DISPLAY') != '' {
-		if os.exists_in_system_path('wl-copy') && os.exists_in_system_path('wl-paste') {
-			result := os.exec('wl-paste --no-newline') or {
-				return ''
-			}
+	if clipboard.wayland_display {
+		if clipboard.has_wl_clipboard {
+			result := os.exec('wl-paste --no-newline') or { return '' }
 			return result.output
 		}
-	} else if os.exists_in_system_path('termux-clipboard-set') && os.exists_in_system_path('termux-clipboard-get') {
-			// Termux clipboard support
-			result := os.exec('termux-clipboard-get') or {
-				return ''
-			}
-			return result.output
-	} 
+	} else if clipboard.is_termux {
+		// Termux clipboard support
+		result := os.exec('termux-clipboard-get') or { return '' }
+		return result.output
+	}
 	return cb.get_text()
 }
 
@@ -54,12 +56,12 @@ pub fn (mut cb Clipboard) paste() string {
 pub fn (mut cb Clipboard) clear_all() {
 	// wayland and termux implementation have different ways to clear clipboard
 	// check for them before
-	if os.getenv('WAYLAND_DISPLAY') != '' {
-		if os.exists_in_system_path('wl-copy') && os.exists_in_system_path('wl-paste') {
-			 os.system('wl-copy -c')
-			 cb.is_owner = false
+	if clipboard.wayland_display {
+		if clipboard.has_wl_clipboard {
+			os.system('wl-copy -c')
+			cb.is_owner = false
 		}
-	} else if os.exists_in_system_path('termux-clipboard-set') && os.exists_in_system_path('termux-clipboard-get') {
+	} else if clipboard.is_termux {
 		os.system('termux-clipboard-set  ""')
 		cb.is_owner = false
 	} else {
@@ -70,7 +72,9 @@ pub fn (mut cb Clipboard) clear_all() {
 // destroy destroys the clipboard and free it's resources.
 pub fn (mut cb Clipboard) destroy() {
 	// nothing to destroy in case of wayland and termux
-	if os.getenv('WAYLAND_DISPLAY') != '' || os.exists_in_system_path('termux-clipboard-set') { return }
+	if clipboard.wayland_display || clipboard.is_termux {
+		return
+	}
 	cb.free()
 }
 
@@ -81,10 +85,12 @@ pub fn (cb Clipboard) check_ownership() bool {
 
 // is_available returns `true` if the clipboard is available for use.
 pub fn (cb &Clipboard) is_available() bool {
-	if os.getenv('WAYLAND_DISPLAY') != '' {
-		return (os.exists_in_system_path('wl-copy') && os.exists_in_system_path('wl-paste'))
+	if clipboard.wayland_display {
+		return (clipboard.has_wl_clipboard)
 	}
-	if os.exists_in_system_path('termux-clipboard-set') { return true }
+	if clipboard.is_termux {
+		return true
+	}
 
 	return cb.check_availability()
 }

--- a/vlib/clipboard/clipboard.v
+++ b/vlib/clipboard/clipboard.v
@@ -1,5 +1,7 @@
 module clipboard
 
+import os
+
 // new returns a new `Clipboard` instance allocated on the heap.
 // The `Clipboard` resources can be released with `free()`
 pub fn new() &Clipboard {
@@ -8,21 +10,67 @@ pub fn new() &Clipboard {
 
 // copy copies `text` into the clipboard.
 pub fn (mut cb Clipboard) copy(text string) bool {
+	// WayLand workaround using wl-clipboard.
+	if os.getenv('WAYLAND_DISPLAY') != '' {
+		if os.exists_in_system_path('wl-copy') && os.exists_in_system_path('wl-paste') {
+			success := os.system('wl-copy $text') == 0
+			cb.is_owner = success
+			return success
+		} else {
+			return false
+		}
+	}
+	// Termux clipboard support
+	if os.exists_in_system_path('termux-clipboard-set') && os.exists_in_system_path('termux-clipboard-get') {
+		success := os.system('termux-clipboard-set $text') == 0
+		cb.is_owner = success
+		return success
+	}
+
 	return cb.set_text(text)
 }
 
 // paste returns current entry as a `string` from the clipboard.
 pub fn (mut cb Clipboard) paste() string {
+	// WayLand workaround using wl-clipboard.
+	if os.getenv('WAYLAND_DISPLAY') != '' {
+		if os.exists_in_system_path('wl-copy') && os.exists_in_system_path('wl-paste') {
+			result := os.exec('wl-paste --no-newline') or {
+				return ''
+			}
+			return result.output
+		}
+	} else if os.exists_in_system_path('termux-clipboard-set') && os.exists_in_system_path('termux-clipboard-get') {
+			// Termux clipboard support
+			result := os.exec('termux-clipboard-get') or {
+				return ''
+			}
+			return result.output
+	} 
 	return cb.get_text()
 }
 
 // clear_all clears the clipboard.
 pub fn (mut cb Clipboard) clear_all() {
-	cb.clear()
+	// wayland and termux implementation have different ways to clear clipboard
+	// check for them before
+	if os.getenv('WAYLAND_DISPLAY') != '' {
+		if os.exists_in_system_path('wl-copy') && os.exists_in_system_path('wl-paste') {
+			 os.system('wl-copy -c')
+			 cb.is_owner = false
+		}
+	} else if os.exists_in_system_path('termux-clipboard-set') && os.exists_in_system_path('termux-clipboard-get') {
+		os.system('termux-clipboard-set  ""')
+		cb.is_owner = false
+	} else {
+		cb.clear()
+	}
 }
 
 // destroy destroys the clipboard and free it's resources.
 pub fn (mut cb Clipboard) destroy() {
+	// nothing to destroy in case of wayland and termux
+	if os.getenv('WAYLAND_DISPLAY') != '' || os.exists_in_system_path('termux-clipboard-set') { return }
 	cb.free()
 }
 
@@ -33,5 +81,10 @@ pub fn (cb Clipboard) check_ownership() bool {
 
 // is_available returns `true` if the clipboard is available for use.
 pub fn (cb &Clipboard) is_available() bool {
+	if os.getenv('WAYLAND_DISPLAY') != '' {
+		return (os.exists_in_system_path('wl-copy') && os.exists_in_system_path('wl-paste'))
+	}
+	if os.exists_in_system_path('termux-clipboard-set') { return true }
+
 	return cb.check_availability()
 }


### PR DESCRIPTION
Wayland clipboard workaround using [wl-clipboard](https://github.com/bugaevc/wl-clipboard)
and support for Termux keyboard.