### PR TITLE
fmt: hide ´[]Type{} instead of []Type´ and ´(f mut Foo)´ warnings

### DIFF
--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -94,7 +94,9 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 		}
 	}
 	if exprs.len == 0 && p.tok.kind != .lcbr && has_type {
-		p.warn_with_pos('use `x := []Type{}` instead of `x := []Type`', first_pos.extend(last_pos))
+		if !p.pref.is_fmt {
+			p.warn_with_pos('use `x := []Type{}` instead of `x := []Type`', first_pos.extend(last_pos))
+		}
 	}
 	mut has_len := false
 	mut has_cap := false

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -665,7 +665,9 @@ fn (mut p Parser) fn_args() ([]table.Param, bool, bool) {
 			}
 			if p.tok.kind == .key_mut {
 				// TODO remove old syntax
-				p.warn_with_pos('use `mut f Foo` instead of `f mut Foo`', p.tok.position())
+				if !p.pref.is_fmt {
+					p.warn_with_pos('use `mut f Foo` instead of `f mut Foo`', p.tok.position())
+				}
 				is_mut = true
 			}
 			if p.tok.kind == .ellipsis {


### PR DESCRIPTION
Just as it is already done with the function parameter type warning, these two warnings are now hidden too.

Because they are fixed automatically, the user should not be tricked into thinking, that there is still something wrong just to look at fine code when investigating.