### PR TITLE
Changed the V Logo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 <p>
-    <img width="80" src="https://raw.githubusercontent.com/donnisnoni95/v-logo/master/dist/v-logo.svg?sanitize=true">
+    <img width="80" src="https://raw.githubusercontent.com/vlang/v-logo/master/dist/v-logo.svg?sanitize=true">
 </p>
 <h1>The V Programming Language</h1>
 


### PR DESCRIPTION
Changed the URL of the V logo to point to the Official V Logo repository of Vlang organization.

_The previous link is a redirection, but that seems unnecessary as Vlang does have an official repository for the logo._