### PR TITLE
vlib: replace all `goto` statements with labelled break

### DIFF
--- a/vlib/encoding/utf8/utf8.v
+++ b/vlib/encoding/utf8/utf8.v
@@ -32,7 +32,6 @@ fn (mut s Utf8State) seq(r0 bool, r1 bool, is_tail bool) bool {
 			s.subindex++
 			return true
 		}
-		goto next
 	} else {
 		s.failed = true
 		if is_tail {
@@ -42,7 +41,6 @@ fn (mut s Utf8State) seq(r0 bool, r1 bool, is_tail bool) bool {
 		}
 		return true
 	}
-	next:
 	s.index++
 	s.subindex = 0
 	return false

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -563,6 +563,7 @@ pub fn channel_select(mut channels []&Channel, dir []Direction, mut objrefs []vo
 	}
 	stopwatch := if timeout <= 0 { time.StopWatch{} } else { time.new_stopwatch({}) }
 	mut event_idx := -1 // negative index means `timed out`
+outer:
 	for {
 		rnd := rand.u32_in_range(0, u32(channels.len))
 		mut num_closed := 0
@@ -575,7 +576,7 @@ pub fn channel_select(mut channels []&Channel, dir []Direction, mut objrefs []vo
 				stat := channels[i].try_push_priv(objrefs[i], true)
 				if stat == .success {
 					event_idx = i
-					goto restore
+					break outer
 				} else if stat == .closed {
 					num_closed++
 				}
@@ -583,7 +584,7 @@ pub fn channel_select(mut channels []&Channel, dir []Direction, mut objrefs []vo
 				stat := channels[i].try_pop_priv(objrefs[i], true)
 				if stat == .success {
 					event_idx = i
-					goto restore
+					break outer
 				} else if stat == .closed {
 					num_closed++
 				}
@@ -591,21 +592,20 @@ pub fn channel_select(mut channels []&Channel, dir []Direction, mut objrefs []vo
 		}
 		if num_closed == channels.len {
 			event_idx = -2
-			goto restore
+			break outer
 		}
 		if timeout == 0 {
-			goto restore
+			break outer
 		}
 		if timeout > 0 {
 			remaining := timeout - stopwatch.elapsed()
 			if !sem.timed_wait(remaining) {
-				goto restore
+				break outer
 			}
 		} else {
 			sem.wait()
 		}
 	}
-restore:
 	// reset subscribers
 	for i, ch in channels {
 		if dir[i] == .push {


### PR DESCRIPTION
The encoding/utf8 one was redundant.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
