### PR TITLE
cgen: fix for runtime `rlock`/`lock` handling

### DIFF
--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -37,7 +37,7 @@ static inline void __sort_ptr(uintptr_t a[], bool b[], int l)
 		uintptr_t ins = a[i];
 		bool insb = b[i];
 		int j = i;
-		while(j>0 && (a[j-1] > ins || b[j-1] && !insb)) {
+		while(j>0 && a[j-1] > ins) {
 			a[j] = a[j-1];
 			b[j] = b[j-1];
 			j--;


### PR DESCRIPTION
This is a small fix as followup to #8534 concerning a small bug in the runtime routine (which might cause a rare dead lock).
This PR also slightly improves run time performance by doing a pre-sort at compile time and taking advantage of a stable sort algorithm being used.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
