### PR TITLE
builder: show file:line when import fails

### DIFF
--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -106,7 +106,7 @@ pub fn (mut b Builder) parse_imports() {
 			import_path := b.find_module_path(mod, ast_file.path) or {
 				// v.parsers[i].error_with_token_index('cannot import module "$mod" (not found)', v.parsers[i].import_table.get_import_tok_idx(mod))
 				// break
-				verror('cannot import module "$mod" (not found)')
+				verror('cannot find module "$mod" in $ast_file.path:$imp.pos.line_nr')
 				break
 			}
 			v_files := b.v_files_from_dir(import_path)

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -96,7 +96,7 @@ pub fn (mut b Builder) parse_imports() {
 		ast_file := b.parsed_files[i]
 		for imp in ast_file.imports {
 			mod := imp.mod
-			fileline := '$ast_file.path:$imp.pos.line_nr'
+			fileline := '\n$ast_file.path:$imp.pos.line_nr'
 			if mod == 'builtin' {
 				verror('$fileline: cannot import module "builtin"')
 				break

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -96,8 +96,9 @@ pub fn (mut b Builder) parse_imports() {
 		ast_file := b.parsed_files[i]
 		for imp in ast_file.imports {
 			mod := imp.mod
+			fileline := '$ast_file.path:$imp.pos.line_nr'
 			if mod == 'builtin' {
-				verror('cannot import module "builtin"')
+				verror('$fileline: cannot import module "builtin"')
 				break
 			}
 			if mod in done_imports {
@@ -106,20 +107,20 @@ pub fn (mut b Builder) parse_imports() {
 			import_path := b.find_module_path(mod, ast_file.path) or {
 				// v.parsers[i].error_with_token_index('cannot import module "$mod" (not found)', v.parsers[i].import_table.get_import_tok_idx(mod))
 				// break
-				verror('cannot find module "$mod" in $ast_file.path:$imp.pos.line_nr')
+				verror('$fileline: cannot import module "$mod" (not found)')
 				break
 			}
 			v_files := b.v_files_from_dir(import_path)
 			if v_files.len == 0 {
 				// v.parsers[i].error_with_token_index('cannot import module "$mod" (no .v files in "$import_path")', v.parsers[i].import_table.get_import_tok_idx(mod))
-				verror('cannot import module "$mod" (no .v files in "$import_path")')
+				verror('$fileline: cannot import module "$mod" (no .v files in "$import_path")')
 			}
 			// Add all imports referenced by these libs
 			parsed_files := parser.parse_files(v_files, b.table, b.pref, b.global_scope)
 			for file in parsed_files {
 				if file.mod.name != mod {
 					// v.parsers[pidx].error_with_token_index('bad module definition: ${v.parsers[pidx].file_path} imports module "$mod" but $file is defined as module `$p_mod`', 1
-					verror('bad module definition: $ast_file.path imports module "$mod" but $file.path is defined as module `$file.mod.name`')
+					verror('$fileline: bad module definition: $ast_file.path imports module "$mod" but $file.path is defined as module `$file.mod.name`')
 				}
 			}
 			b.parsed_files << parsed_files

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -2,6 +2,7 @@ module builder
 
 import os
 import v.ast
+import v.token
 import v.table
 import v.pref
 import v.util
@@ -96,9 +97,8 @@ pub fn (mut b Builder) parse_imports() {
 		ast_file := b.parsed_files[i]
 		for imp in ast_file.imports {
 			mod := imp.mod
-			fileline := '\n$ast_file.path:$imp.pos.line_nr'
 			if mod == 'builtin' {
-				verror('$fileline: cannot import module "builtin"')
+				error_with_pos('cannot import module "builtin"', ast_file.path, imp.pos)
 				break
 			}
 			if mod in done_imports {
@@ -107,20 +107,23 @@ pub fn (mut b Builder) parse_imports() {
 			import_path := b.find_module_path(mod, ast_file.path) or {
 				// v.parsers[i].error_with_token_index('cannot import module "$mod" (not found)', v.parsers[i].import_table.get_import_tok_idx(mod))
 				// break
-				verror('$fileline: cannot import module "$mod" (not found)')
+				error_with_pos('cannot import module "$mod" (not found)', ast_file.path,
+					imp.pos)
 				break
 			}
 			v_files := b.v_files_from_dir(import_path)
 			if v_files.len == 0 {
 				// v.parsers[i].error_with_token_index('cannot import module "$mod" (no .v files in "$import_path")', v.parsers[i].import_table.get_import_tok_idx(mod))
-				verror('$fileline: cannot import module "$mod" (no .v files in "$import_path")')
+				error_with_pos('cannot import module "$mod" (no .v files in "$import_path")',
+					ast_file.path, imp.pos)
 			}
 			// Add all imports referenced by these libs
 			parsed_files := parser.parse_files(v_files, b.table, b.pref, b.global_scope)
 			for file in parsed_files {
 				if file.mod.name != mod {
 					// v.parsers[pidx].error_with_token_index('bad module definition: ${v.parsers[pidx].file_path} imports module "$mod" but $file is defined as module `$p_mod`', 1
-					verror('$fileline: bad module definition: $ast_file.path imports module "$mod" but $file.path is defined as module `$file.mod.name`')
+					error_with_pos('bad module definition: $ast_file.path imports module "$mod" but $file.path is defined as module `$file.mod.name`',
+						ast_file.path, imp.pos)
 				}
 			}
 			b.parsed_files << parsed_files
@@ -389,6 +392,12 @@ struct FunctionRedefinition {
 	fline   int
 	fheader string
 	f       ast.FnDecl
+}
+
+fn error_with_pos(s string, fpath string, pos token.Position) {
+	ferror := util.formatted_error('builder error:', s, fpath, pos)
+	eprintln(ferror)
+	exit(1)
 }
 
 fn verror(s string) {

--- a/vlib/v/checker/tests/import_not_found_err.out
+++ b/vlib/v/checker/tests/import_not_found_err.out
@@ -1,1 +1,5 @@
-builder error: cannot import module "notexist" (not found)
+vlib/v/checker/tests/import_not_found_err.vv:1:1: builder error: cannot import module "notexist" (not found)
+    1 | import notexist
+      | ~~~~~~~~~~~~~~~
+    2 | fn main() {
+    3 |     println(notexist.name)

--- a/vlib/v/tests/multiple_paths_in_vmodules/vmodules_overrides_test.v
+++ b/vlib/v/tests/multiple_paths_in_vmodules/vmodules_overrides_test.v
@@ -20,7 +20,7 @@ fn test_compiling_without_vmodules_fails() {
 	os.setenv('VMODULES', '', true)
 	res := os.exec('"$vexe" run "$mainvv"') or { panic(err) }
 	assert res.exit_code == 1
-	assert res.output.trim_space() == 'builder error: cannot import module "yyy" (not found)'
+	assert res.output.trim_space().contains('builder error: cannot import module "yyy" (not found)')
 }
 
 fn test_compiling_with_vmodules_works() {

--- a/vlib/v/tests/repl/entire_commented_module.repl
+++ b/vlib/v/tests/repl/entire_commented_module.repl
@@ -1,3 +1,7 @@
 import v.tests.modules.acommentedmodule
 ===output===
 builder error: bad module definition: .entire_commented_module.repl.vrepl_temp.v imports module "v.tests.modules.acommentedmodule" but vlib/v/tests/modules/acommentedmodule/commentedfile.v is defined as module `main`
+    1 | import v.tests.modules.acommentedmodule
+      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2 | import os
+    3 |

--- a/vlib/v/tests/repl/runner/runner.v
+++ b/vlib/v/tests/repl/runner/runner.v
@@ -63,12 +63,12 @@ pub fn run_repl_file(wd string, vexec string, file string) ?string {
 		file_expected := '${file}.expected.txt'
 		os.write_file(file_result, result) or { panic(err) }
 		os.write_file(file_expected, output) or { panic(err) }
-		diff := diff_files(file_result, file_expected)
+		diff := diff_files(file_expected, file_result)
 		return error('Difference found in REPL file: $file
-====> Got      :
-|$result|
 ====> Expected :
 |$output|
+====> Got      :
+|$result|
 ====> Diff     :
 $diff
 		')


### PR DESCRIPTION
When trying to compile this program:

```
$ cat foo.v
import findme

fn main() {
	a := findme.ordie
	println('SOYTOMNUK $a')
}
```

i get the following error:
```
$ v foo.v
builder error: cannot import module "findme" (not found)
```


after this patch: file and line information is displayed to the user:

```
$ v foo.v
builder error: cannot find module "findme" in foo.v:0
```