### PR TITLE
cgen: create enclosing block on C side for V `lock` blocks

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3448,7 +3448,9 @@ fn (mut g Gen) lock_expr(node ast.LockExpr) {
 		g.writeln('\t\tsync__RwMutex_lock((sync__RwMutex*)_arr_$mtxs[$mtxs]);')
 		g.writeln('}')
 	}
+	g.writeln('/*lock*/ {')
 	g.stmts(node.stmts)
+	g.writeln('}')
 	if node.lockeds.len == 0 {
 		// this should not happen
 	} else if node.lockeds.len == 1 {
@@ -3465,7 +3467,7 @@ fn (mut g Gen) lock_expr(node ast.LockExpr) {
 		g.writeln('\t\tsync__RwMutex_runlock((sync__RwMutex*)_arr_$mtxs[$mtxs]);')
 		g.writeln('\telse')
 		g.writeln('\t\tsync__RwMutex_unlock((sync__RwMutex*)_arr_$mtxs[$mtxs]);')
-		g.writeln('}')
+		g.write('}')
 	}
 }
 

--- a/vlib/v/tests/shared_arg_test.v
+++ b/vlib/v/tests/shared_arg_test.v
@@ -48,12 +48,12 @@ fn test_shared_as_value() {
 		assert v == 35
 	}
 	rlock m {
-		w := m_val(m)
-		assert w == -3.125
+		u := m_val(m)
+		assert u == -3.125
 	}
 	lock a {
-		x := a_val(a)
-		assert x == 4
+		u := a_val(a)
+		assert u == 4
 	}
 }
 


### PR DESCRIPTION
Variables created inside a `lock` block should be local to this block:
```v
lock x {
    a := [1, 2, 3]
}
lock y {
    a := map[string]f64{}
}
```
So the `a` identifiers in the above example should be completely independent. Therefore, this PR makes `cgen` create an enclosing `{ ... }` block to make the variables local on the C side, too.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
