### PR TITLE
rand.util: add sample_r and sample_nr

### DIFF
--- a/vlib/rand/util/util.v
+++ b/vlib/rand/util/util.v
@@ -15,8 +15,8 @@ pub fn sample_nr<T>(array []T, k int) []T {
 	mut results := []T{len: k}
 	mut indices := []int{len: n}
 	// Initialize with all indices
-	for i := 0; i < n; i++ {
-		indices[i] = i
+	for i, mut v in indices {
+		v = i
 	}
 	arrays.shuffle<int>(mut indices, k)
 	for i in 0 .. k {

--- a/vlib/rand/util/util.v
+++ b/vlib/rand/util/util.v
@@ -4,47 +4,7 @@
 module util
 
 import rand
-
-[direct_array_access]
-fn element_location(element int, array []int) int {
-	if array.len == 0 {
-		return 0
-	}
-	if array.len == 1 {
-		return if element == array[0] {
-			0
-		} else {
-			1
-		}
-	}
-	mut lo := 0
-	mut hi := array.len - 1
-	for lo <= hi {
-		mut mid := lo + ((hi - lo) >> 1)
-		current_element := array[mid]
-		if element == current_element {
-			return mid
-		} else if element < current_element {
-			hi = mid - 1
-		} else {
-			lo = mid + 1
-		}
-	}
-	return lo
-}
-
-[direct_array_access]
-fn insert_element(element int, location int, mut array []int) {
-	needs_shift := location < array.len
-	array << element
-	if needs_shift {
-		count := array.len - location
-		unsafe {
-			C.memcpy(&array[location + 1], &array[location], count * 4)
-		}
-		array[location] = element
-	}
-}
+import arrays
 
 // sample_nr returns a sample of the array without replacement. This means the indices cannot repeat and it restricts the sample size to be less than or equal to the size of the given array. Note that if the array has repeating elements, then the sample may have repeats as well.
 pub fn sample_nr<T>(array []T, k int) []T {
@@ -53,14 +13,12 @@ pub fn sample_nr<T>(array []T, k int) []T {
 		panic('Cannot sample $k elements without replacement from a $n-element array.')
 	}
 	mut results := []T{len: k}
-	mut indices := []int{cap: k}
-	for indices.len < k {
-		index := rand.intn(n)
-		location := element_location(index, indices)
-		if location >= indices.len || indices[location] != index {
-			insert_element(index, location, mut indices)
-		}
+	mut indices := []int{len: n}
+	// Initialize with all indices
+	for i := 0; i < n; i++ {
+		indices[i] = i
 	}
+	arrays.shuffle<int>(mut indices, k)
 	for i in 0 .. k {
 		results[i] = array[indices[i]]
 	}

--- a/vlib/rand/util/util.v
+++ b/vlib/rand/util/util.v
@@ -3,4 +3,76 @@
 // that can be found in the LICENSE file.
 module util
 
+import rand
 
+[direct_array_access]
+fn element_location(element int, array []int) int {
+	if array.len == 0 {
+		return 0
+	}
+	if array.len == 1 {
+		return if element == array[0] {
+			0
+		} else {
+			1
+		}
+	}
+	mut lo := 0
+	mut hi := array.len - 1
+	for lo <= hi {
+		mut mid := lo + ((hi - lo) >> 1)
+		current_element := array[mid]
+		if element == current_element {
+			return mid
+		} else if element < current_element {
+			hi = mid - 1
+		} else {
+			lo = mid + 1
+		}
+	}
+	return lo
+}
+
+[direct_array_access]
+fn insert_element(element int, location int, mut array []int) {
+	needs_shift := location < array.len
+	array << element
+	if needs_shift {
+		count := array.len - location
+		unsafe {
+			C.memcpy(&array[location + 1], &array[location], count * 4)
+		}
+		array[location] = element
+	}
+}
+
+// sample_nr returns a sample of the array without replacement. This means the indices cannot repeat and it restricts the sample size to be less than or equal to the size of the given array. Note that if the array has repeating elements, then the sample may have repeats as well.
+pub fn sample_nr<T>(array []T, k int) []T {
+	n := array.len
+	if k > n {
+		panic('Cannot sample $k elements without replacement from a $n-element array.')
+	}
+	mut results := []T{len: k}
+	mut indices := []int{cap: k}
+	for indices.len < k {
+		index := rand.intn(n)
+		location := element_location(index, indices)
+		if location >= indices.len || indices[location] != index {
+			insert_element(index, location, mut indices)
+		}
+	}
+	for i in 0 .. k {
+		results[i] = array[indices[i]]
+	}
+	return results
+}
+
+// sample_r returns a sample of the array with replacement. This means the elements can repeat and the size of the sample may exceed the size of the array
+pub fn sample_r<T>(array []T, k int) []T {
+	n := array.len
+	mut results := []T{len: k}
+	for i in 0 .. k {
+		results[i] = array[rand.intn(n)]
+	}
+	return results
+}

--- a/vlib/rand/util/util_test.v
+++ b/vlib/rand/util/util_test.v
@@ -1,0 +1,29 @@
+import rand.util
+
+fn test_sample_nr() {
+	length := 5
+	a := ['one', 'two', 'three', 'four', 'five', 'six', 'seven']
+	b := util.sample_nr(a, length)
+	assert b.len == length
+	for element in b {
+		assert element in a
+		// make sure every element occurs once
+		mut count := 0
+		for e in b {
+			if e == element {
+				count++
+			}
+		}
+		assert count == 1
+	}
+}
+
+fn test_sample_r() {
+	k := 20
+	a := ['heads', 'tails']
+	b := util.sample_r(a, k)
+	assert b.len == k
+	for element in b {
+		assert element in a
+	}
+}

--- a/vlib/rand/util/util_test.v
+++ b/vlib/rand/util/util_test.v
@@ -1,20 +1,22 @@
 import rand.util
 
 fn test_sample_nr() {
-	length := 5
+	lengths := [1, 3, 4, 5, 6, 7]
 	a := ['one', 'two', 'three', 'four', 'five', 'six', 'seven']
-	b := util.sample_nr(a, length)
-	assert b.len == length
-	for element in b {
-		assert element in a
-		// make sure every element occurs once
-		mut count := 0
-		for e in b {
-			if e == element {
-				count++
+	for length in lengths {
+		b := util.sample_nr(a, length)
+		assert b.len == length
+		for element in b {
+			assert element in a
+			// make sure every element occurs once
+			mut count := 0
+			for e in b {
+				if e == element {
+					count++
+				}
 			}
+			assert count == 1
 		}
-		assert count == 1
 	}
 }
 


### PR DESCRIPTION
Adds two sampling functions to `rand.util`:

1. `sample_r` - Sample the elements of a given array with replacement.
2. `sample_nr` - Sample the elements of a given array without replacement.

Also included unit tests.