### PR TITLE
checker/cgen: support lock expressions `x := rlock s { s.get() }` 

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4589,8 +4589,19 @@ pub fn (mut c Checker) lock_expr(mut node ast.LockExpr) table.Type {
 	c.stmts(node.stmts)
 	c.rlocked_names = []
 	c.locked_names = []
-	// void for now... maybe sometime `x := lock a { a.getval() }`
-	return table.void_type
+	// handle `x := rlock a { a.getval() }`
+	mut ret_type := table.void_type
+	if node.stmts.len > 0 {
+		last_stmt := node.stmts[node.stmts.len - 1]
+		if last_stmt is ast.ExprStmt {
+			ret_type = last_stmt.typ
+		}
+	}
+	if ret_type != table.void_type {
+		node.is_expr = true
+	}
+	node.typ = ret_type
+	return ret_type
 }
 
 pub fn (mut c Checker) unsafe_expr(mut node ast.UnsafeExpr) table.Type {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -876,7 +876,7 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) {
 			// Handle if expressions, set the value of the last expression to the temp var.
 			g.stmt_path_pos << g.out.len
 			g.skip_stmt_pos = true
-			g.writeln('$tmp_var = /* if expr set */')
+			g.write('$tmp_var = ')
 		}
 		g.stmt(stmt)
 		g.skip_stmt_pos = false
@@ -3407,6 +3407,13 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 }
 
 fn (mut g Gen) lock_expr(node ast.LockExpr) {
+	tmp_result := if node.is_expr { g.new_tmp_var() } else { '' }
+	mut cur_line := ''
+	if node.is_expr {
+		styp := g.typ(node.typ)
+		cur_line = g.go_before_stmt(0)
+		g.writeln('$styp $tmp_result;')
+	}
 	mut mtxs := ''
 	if node.lockeds.len == 0 {
 		// this should not happen
@@ -3448,7 +3455,7 @@ fn (mut g Gen) lock_expr(node ast.LockExpr) {
 		g.writeln('\t\tsync__RwMutex_lock((sync__RwMutex*)_arr_$mtxs[$mtxs]);')
 		g.writeln('}')
 	}
-	g.stmts(node.stmts)
+	g.stmts_with_tmp_var(node.stmts, tmp_result)
 	if node.lockeds.len == 0 {
 		// this should not happen
 	} else if node.lockeds.len == 1 {
@@ -3466,6 +3473,11 @@ fn (mut g Gen) lock_expr(node ast.LockExpr) {
 		g.writeln('\telse')
 		g.writeln('\t\tsync__RwMutex_unlock((sync__RwMutex*)_arr_$mtxs[$mtxs]);')
 		g.writeln('}')
+	}
+	if node.is_expr {
+		g.writeln('')
+		g.write(cur_line)
+		g.write('$tmp_result')
 	}
 }
 

--- a/vlib/v/tests/shared_lock_expr_test.v
+++ b/vlib/v/tests/shared_lock_expr_test.v
@@ -1,0 +1,14 @@
+struct St {
+mut:
+	i int
+}
+
+fn test_lock_expr() {
+	shared xx := St{ i: 173 }
+	shared y := St{ i: -57 }
+	mut m := 0
+	m = rlock y { y.i }
+	n := rlock xx { xx.i }
+	assert m == -57
+	assert n == 173
+}

--- a/vlib/v/tests/shared_lock_expr_test.v
+++ b/vlib/v/tests/shared_lock_expr_test.v
@@ -7,7 +7,7 @@ fn test_lock_expr() {
 	shared xx := St{ i: 173 }
 	shared y := St{ i: -57 }
 	mut m := 0
-	m = rlock y { y.i }
+	m = lock y { y.i }
 	n := rlock xx { xx.i }
 	assert m == -57
 	assert n == 173


### PR DESCRIPTION
This PR enables `lock` and `rlock` blocks to return expressions:
```v
x := rlock a { a.y }
z := lock b {
    b.modify()
    b.return_val()
}
```
It works analogous to `if` expressions (`x := if a { 3 } else { 4 }`) but with just one branch.

Probably `git` is not capable of merging this PR and #8538 without conflicts - so a little tweak is needed after the first of the two has been merged.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
