### PR TITLE
cgen: auto initialize `chan` that are struct elements

### DIFF
--- a/vlib/sync/struct_chan_init_test.v
+++ b/vlib/sync/struct_chan_init_test.v
@@ -1,0 +1,14 @@
+struct Abc {
+	ch chan int
+}
+
+fn f(st Abc) {
+	st.ch <- 47
+}
+
+fn test_chan_init() {
+	st := Abc{}
+	go f(st)
+	i := <-st.ch
+	assert i == 47
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5718,6 +5718,10 @@ fn (mut g Gen) type_default(typ_ table.Type) string {
 		'rune' { return '0' }
 		else {}
 	}
+	if sym.kind == .chan {
+		elemtypstr := g.typ(sym.chan_info().elem_type)
+		return 'sync__new_channel_st(0, sizeof($elemtypstr))'
+	}
 	return match sym.kind {
 		.interface_, .sum_type, .array_fixed, .multi_return { '{0}' }
 		.alias { g.type_default((sym.info as table.Alias).parent_type) }


### PR DESCRIPTION
This PR makes channel struct elements that are not explicitly initialized be initialized by a valid channel with buffer length 0:
```v
struct Abc {
    ch chan int
}

x := Abc{ ch: chan int{cap: 0} } // explicit initialization
y := Abc{} // y.ch will be automatically initialized
```
This fixes #8498.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
