### PR TITLE
builder: make repl work if path contains spaces

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -628,7 +628,7 @@ fn (mut v Builder) cc() {
 		}
 		//
 		os.chdir(vdir)
-		cmd := '$ccompiler @$response_file'
+		cmd := '$ccompiler "@$response_file"'
 		tried_compilation_commands << cmd
 		v.show_cc(cmd, response_file, response_file_content)
 		// Run


### PR DESCRIPTION

On windows: currently the repl cannot be compiled if the v repo has been created in a directory which contains spaces.  Fixes #8524
