### PR TITLE
all: support map[f32]string and map[f64]string (float map keys) too

### DIFF
--- a/vlib/builtin/map_of_floats_test.v
+++ b/vlib/builtin/map_of_floats_test.v
@@ -1,0 +1,27 @@
+fn test_map_of_f32() {
+	mut m32 := map[f32]string{}
+	m32[1.0] = 'one'
+	println(m32)
+	assert '$m32' == r"{1.: 'one'}"
+	for k, v in m32 {
+		assert typeof(k).name == 'f32'
+		assert typeof(v).name == 'string'
+		assert k == 1.0
+		assert v == 'one'
+	}
+}
+
+fn test_map_of_f64() {
+	mut m64 := {
+		3.14: 'pi'
+	}
+	m64[1.0] = 'one'
+	println(m64)
+	assert '$m64' == r"{3.14: 'pi', 1.: 'one'}"
+	for k, v in m64 {
+		assert typeof(k).name == 'f64'
+		assert typeof(v).name == 'string'
+		assert k in [1.0, 3.14]
+		assert v in ['pi', 'one']
+	}
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2471,7 +2471,7 @@ fn (mut g Gen) map_fn_ptrs(key_typ table.TypeSymbol) (string, string, string, st
 			key_eq_fn = '&map_eq_int_2'
 			clone_fn = '&map_clone_int_2'
 		}
-		.int, .u32, .rune {
+		.int, .u32, .rune, .f32 {
 			hash_fn = '&map_hash_int_4'
 			key_eq_fn = '&map_eq_int_4'
 			clone_fn = '&map_clone_int_4'
@@ -2484,7 +2484,7 @@ fn (mut g Gen) map_fn_ptrs(key_typ table.TypeSymbol) (string, string, string, st
 			}
 			return g.map_fn_ptrs(ts)
 		}
-		.u64, .i64 {
+		.u64, .i64, .f64 {
 			hash_fn = '&map_hash_int_8'
 			key_eq_fn = '&map_eq_int_8'
 			clone_fn = '&map_clone_int_8'

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -158,9 +158,6 @@ fn (mut p Parser) map_init() ast.MapInit {
 	mut vals := []ast.Expr{}
 	for p.tok.kind != .rcbr && p.tok.kind != .eof {
 		key := p.expr(0)
-		if key is ast.FloatLiteral {
-			p.error_with_pos('maps do not support floating point keys yet', key.pos)
-		}
 		keys << key
 		p.check(.colon)
 		val := p.expr(0)

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -80,7 +80,7 @@ pub fn (mut p Parser) parse_map_type() table.Type {
 	if !(key_type in [table.string_type_idx, table.voidptr_type_idx]
 		|| ((key_type.is_int() || key_type.is_float())&& !key_type.is_ptr())) {
 		s := p.table.type_to_str(key_type)
-		p.error_with_pos('maps only support string, integer, rune or voidptr keys for now (not `$s`)',
+		p.error_with_pos('maps only support string, integer, float, rune or voidptr keys for now (not `$s`)',
 			p.tok.position())
 		return 0
 	}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -78,7 +78,7 @@ pub fn (mut p Parser) parse_map_type() table.Type {
 		return 0
 	}
 	if !(key_type in [table.string_type_idx, table.voidptr_type_idx]
-		|| (key_type.is_int() && !key_type.is_ptr())) {
+		|| ((key_type.is_int() || key_type.is_float())&& !key_type.is_ptr())) {
 		s := p.table.type_to_str(key_type)
 		p.error_with_pos('maps only support string, integer, rune or voidptr keys for now (not `$s`)',
 			p.tok.position())


### PR DESCRIPTION
With this PR:
```v
m64 := { 3.14: 'pi' }
println(m64)
```
works.