### PR TITLE
checker: make `[] == ArrayAlias([])` an error

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -770,9 +770,9 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 	match infix_expr.op {
 		// .eq, .ne, .gt, .lt, .ge, .le, .and, .logical_or, .dot, .key_as, .right_shift {}
 		.eq, .ne {
-			is_alias_eq_struct := left.kind == .alias && right.kind == .struct_
-			is_struct_eq_alias := left.kind == .struct_ && right.kind == .alias
-			if is_alias_eq_struct || is_struct_eq_alias {
+			is_mismatch := (left.kind == .alias && right.kind in [.struct_, .array])
+				|| (right.kind == .alias && left.kind in [.struct_, .array])
+			if is_mismatch {
 				c.error('possible type mismatch of compared values of `$infix_expr.op` operation',
 					infix_expr.pos)
 			}

--- a/vlib/v/checker/tests/eq_ne_op_wrong_type_err.out
+++ b/vlib/v/checker/tests/eq_ne_op_wrong_type_err.out
@@ -1,0 +1,83 @@
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:10:16: error: infix expr: cannot use `int literal` (right expression) as `Aaa`
+    8 | 
+    9 | fn main() {
+   10 |     println(Aaa{} == 10)
+      |                   ~~
+   11 |     println(10 == Aaa{})
+   12 |     println(Aaa{} != 10)
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:11:13: error: infix expr: cannot use `Aaa` (right expression) as `int literal`
+    9 | fn main() {
+   10 |     println(Aaa{} == 10)
+   11 |     println(10 == Aaa{})
+      |                ~~
+   12 |     println(Aaa{} != 10)
+   13 |     println(10 != Aaa{})
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:12:16: error: infix expr: cannot use `int literal` (right expression) as `Aaa`
+   10 |     println(Aaa{} == 10)
+   11 |     println(10 == Aaa{})
+   12 |     println(Aaa{} != 10)
+      |                   ~~
+   13 |     println(10 != Aaa{})
+   14 |
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:13:13: error: infix expr: cannot use `Aaa` (right expression) as `int literal`
+   11 |     println(10 == Aaa{})
+   12 |     println(Aaa{} != 10)
+   13 |     println(10 != Aaa{})
+      |                ~~
+   14 | 
+   15 |     println(Aaa{0} == AAaa{0})
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:15:17: error: possible type mismatch of compared values of `==` operation
+   13 |     println(10 != Aaa{})
+   14 | 
+   15 |     println(Aaa{0} == AAaa{0})
+      |                    ~~
+   16 |     println(AAaa{0} == Aaa{0})
+   17 |     println(AAaa{1} != Aaa{1})
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:16:18: error: possible type mismatch of compared values of `==` operation
+   14 | 
+   15 |     println(Aaa{0} == AAaa{0})
+   16 |     println(AAaa{0} == Aaa{0})
+      |                     ~~
+   17 |     println(AAaa{1} != Aaa{1})
+   18 |     println(Aaa{1} != AAaa{1})
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:17:18: error: possible type mismatch of compared values of `!=` operation
+   15 |     println(Aaa{0} == AAaa{0})
+   16 |     println(AAaa{0} == Aaa{0})
+   17 |     println(AAaa{1} != Aaa{1})
+      |                     ~~
+   18 |     println(Aaa{1} != AAaa{1})
+   19 |
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:18:17: error: possible type mismatch of compared values of `!=` operation
+   16 |     println(AAaa{0} == Aaa{0})
+   17 |     println(AAaa{1} != Aaa{1})
+   18 |     println(Aaa{1} != AAaa{1})
+      |                    ~~
+   19 | 
+   20 |     arr := Arr([0])
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:21:14: error: possible type mismatch of compared values of `==` operation
+   19 | 
+   20 |     arr := Arr([0])
+   21 |     println(arr == [0])
+      |                 ~~
+   22 |     println([1] == arr)
+   23 |     println(arr != [0])
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:22:14: error: possible type mismatch of compared values of `==` operation
+   20 |     arr := Arr([0])
+   21 |     println(arr == [0])
+   22 |     println([1] == arr)
+      |                 ~~
+   23 |     println(arr != [0])
+   24 |     println([1] != arr)
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:23:14: error: possible type mismatch of compared values of `!=` operation
+   21 |     println(arr == [0])
+   22 |     println([1] == arr)
+   23 |     println(arr != [0])
+      |                 ~~
+   24 |     println([1] != arr)
+   25 | }
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:24:14: error: possible type mismatch of compared values of `!=` operation
+   22 |     println([1] == arr)
+   23 |     println(arr != [0])
+   24 |     println([1] != arr)
+      |                 ~~
+   25 | }

--- a/vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv
+++ b/vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv
@@ -1,0 +1,25 @@
+struct Aaa {
+	i int
+}
+
+type AAaa = Aaa
+
+type Arr = []int
+
+fn main() {
+	println(Aaa{} == 10)
+	println(10 == Aaa{})
+	println(Aaa{} != 10)
+	println(10 != Aaa{})
+
+	println(Aaa{0} == AAaa{0})
+	println(AAaa{0} == Aaa{0})
+	println(AAaa{1} != Aaa{1})
+	println(Aaa{1} != AAaa{1})
+
+	arr := Arr([0])
+	println(arr == [0])
+	println([1] == arr)
+	println(arr != [0])
+	println([1] != arr)
+}


### PR DESCRIPTION

```
module main

type ArrayOfStrings = []string

fn main() {
        mut arr1 := ArrayOfStrings(["S", "t"])
        mut arr2 := ["S", "t"]
        assert arr1 == arr2
}
```

Now

```
/tmp/v/array.8759432707900729972.tmp.c:8441:13: error: invalid operands to binary expression ('main__ArrayOfStrings' (aka 'struct array') and 'array_string' (aka 'struct array'))
        if (!(arr1 == arr2)) {
              ~~~~ ^  ~~~~
1 error generated.
...
==================
(Use `v -cg` to print the entire error message)

builder error:
==================
C error. This should never happen.



```

After

```
todo/array.v:8:14: error: possible type mismatch of compared values of `==` operation
    6 |     mut arr1 := ArrayOfStrings(["S", "t"])
    7 |     mut arr2 := ["S", "t"]
    8 |     assert arr1 == arr2
      |                 ~~
    9 | }
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
