### PR TITLE
parser: display correct position on boolean expression error

### DIFF
--- a/vlib/v/checker/tests/infix_err.out
+++ b/vlib/v/checker/tests/infix_err.out
@@ -17,17 +17,17 @@ vlib/v/checker/tests/infix_err.vv:9:9: error: `+` cannot be used with `?string`
     8 | _ = f() + ''
     9 | _ = f() + f()
       |         ^
-   10 | 
+   10 |
    11 | _ = 4 + g()
 vlib/v/checker/tests/infix_err.vv:11:7: error: `+` cannot be used with `?int`
     9 | _ = f() + f()
-   10 | 
+   10 |
    11 | _ = 4 + g()
       |       ^
    12 | _ = int(0) + g() // FIXME not detected
    13 | _ = g() + int(3)
 vlib/v/checker/tests/infix_err.vv:12:12: error: unwrapped optional cannot be used in an infix expression
-   10 | 
+   10 |
    11 | _ = 4 + g()
    12 | _ = int(0) + g() // FIXME not detected
       |            ^
@@ -45,16 +45,37 @@ vlib/v/checker/tests/infix_err.vv:14:9: error: `+` cannot be used with `?int`
    13 | _ = g() + int(3)
    14 | _ = g() + 3
       |         ^
-   15 | 
+   15 |
    16 | // binary operands
 vlib/v/checker/tests/infix_err.vv:17:5: error: left operand for `&&` is not a boolean
-   15 | 
+   15 |
    16 | // binary operands
    17 | _ = 1 && 2
       |     ^
    18 | _ = true || 2
+   19 |
 vlib/v/checker/tests/infix_err.vv:18:13: error: right operand for `||` is not a boolean
    16 | // binary operands
    17 | _ = 1 && 2
    18 | _ = true || 2
       |             ^
+   19 |
+   20 | // boolean expressions
+vlib/v/checker/tests/infix_err.vv:21:22: error: use `()` to make the boolean expression clear
+   19 |
+   20 | // boolean expressions
+   21 | _ = 1 == 1 && 2 == 2 || 3 == 3
+      |                      ~~
+   22 | _ = 1 == 1
+   23 |     && 2 == 2 || 3 == 3
+vlib/v/checker/tests/infix_err.vv:23:12: error: use `()` to make the boolean expression clear
+   21 | _ = 1 == 1 && 2 == 2 || 3 == 3
+   22 | _ = 1 == 1
+   23 |     && 2 == 2 || 3 == 3
+      |               ~~
+   24 |     && 4 == 4
+vlib/v/checker/tests/infix_err.vv:24:2: error: use `()` to make the boolean expression clear
+   22 | _ = 1 == 1
+   23 |     && 2 == 2 || 3 == 3
+   24 |     && 4 == 4
+      |     ~~

--- a/vlib/v/checker/tests/infix_err.vv
+++ b/vlib/v/checker/tests/infix_err.vv
@@ -16,3 +16,9 @@ _ = g() + 3
 // binary operands
 _ = 1 && 2
 _ = true || 2
+
+// boolean expressions
+_ = 1 == 1 && 2 == 2 || 3 == 3
+_ = 1 == 1
+	&& 2 == 2 || 3 == 3
+	&& 4 == 4

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -397,12 +397,6 @@ fn (mut p Parser) infix_expr(left ast.Expr) ast.Expr {
 	}
 	precedence := p.tok.precedence()
 	mut pos := p.tok.position()
-	if left.position().line_nr < pos.line_nr {
-		pos = token.Position{
-			...pos
-			line_nr: left.position().line_nr
-		}
-	}
 	p.next()
 	mut right := ast.Expr{}
 	prev_expecting_type := p.expecting_type


### PR DESCRIPTION
Before

```
todo/bool_expr.v:2:4: error: use `()` to make the boolean expression clear
    1 | fn main() {
    2 |     flag := 1 == 2
      |       ~~
    3 |         && 1 == 2
    4 |          || 1 == 2
```

After

```
todo/bool_expr.v:4:4: error: use `()` to make the boolean expression clear
    2 |     flag := 1 == 2
    3 |         && 1 == 2
    4 |          || 1 == 2
      |          ~~
    5 |
    6 |     println(x)
```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
