### PR TITLE
cgen: fix `mut` variable in `for` loop reads as address (fix #8548)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2123,7 +2123,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					g.prevent_sum_type_unwrapping_once = true
 				}
 				if !is_fixed_array_copy || is_decl {
-					if !is_decl && var_type != table.string_type_idx && g.is_mut_ident(left) {
+					if !is_decl && g.is_mut_ident(left) {
 						g.write('*')
 					}
 					g.expr(left)
@@ -2175,7 +2175,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					g.write('for (int $i_var=0; $i_var<$fixed_array.size; $i_var++) {')
 					g.expr(left)
 					g.write('[$i_var] = ')
-					if var_type != table.string_type_idx && g.is_mut_ident(val) {
+					if g.is_mut_ident(val) {
 						g.write('*')
 					}
 					g.expr(val)
@@ -2200,7 +2200,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 							g.write('{0}')
 						}
 					} else {
-						if var_type != table.string_type_idx && g.is_mut_ident(val) {
+						if g.is_mut_ident(val) {
 							g.write('*')
 						}
 						g.expr(val)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2175,7 +2175,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					g.write('for (int $i_var=0; $i_var<$fixed_array.size; $i_var++) {')
 					g.expr(left)
 					g.write('[$i_var] = ')
-					if g.is_mut_ident(val) {
+					if var_type != table.string_type_idx && g.is_mut_ident(val) {
 						g.write('*')
 					}
 					g.expr(val)
@@ -2200,7 +2200,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 							g.write('{0}')
 						}
 					} else {
-						if g.is_mut_ident(val) {
+						if var_type != table.string_type_idx && g.is_mut_ident(val) {
 							g.write('*')
 						}
 						g.expr(val)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -171,7 +171,7 @@ fn (mut g Gen) gen_fn_decl(node ast.FnDecl, skip bool) {
 		g.write(fn_header)
 	}
 	for i, param in node.params {
-		if node.is_method && i == 0 {
+		if i == 0 && node.is_method {
 			continue
 		}
 		if param.is_mut {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -170,7 +170,10 @@ fn (mut g Gen) gen_fn_decl(node ast.FnDecl, skip bool) {
 		g.definitions.write(fn_header)
 		g.write(fn_header)
 	}
-	for param in node.params {
+	for i, param in node.params {
+		if node.is_method && i == 0 {
+			continue
+		}
 		if param.is_mut {
 			g.fn_mut_arg_names << param.name
 		}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -82,7 +82,7 @@ fn (mut g Gen) gen_fn_decl(node ast.FnDecl, skip bool) {
 	if is_livefn && !is_livemode {
 		eprintln('INFO: compile with `v -live $g.pref.path `, if you want to use the [live] function $node.name .')
 	}
-	//
+
 	mut name := node.name
 	if name in ['+', '-', '*', '/', '%', '<', '=='] {
 		name = util.replace_op(name)

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -267,6 +267,9 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 				g.expr(expr)
 				g.write(')')
 			} else {
+				if g.is_mut_ident(expr) {
+					g.write('*')
+				}
 				g.expr(expr)
 			}
 		} else if node.fmts[i] == `s` || typ.has_flag(.variadic) {
@@ -283,12 +286,21 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 				} else {
 					g.write('(u64)(')
 				}
+				if g.is_mut_ident(expr) {
+					g.write('*')
+				}
 				g.expr(expr)
 				g.write(')')
 			} else {
+				if g.is_mut_ident(expr) {
+					g.write('*')
+				}
 				g.expr(expr)
 			}
 		} else {
+			if g.is_mut_ident(expr) {
+				g.write('*')
+			}
 			g.expr(expr)
 		}
 		if node.fmts[i] == `s` && node.fwidths[i] != 0 {

--- a/vlib/v/tests/mut_test.v
+++ b/vlib/v/tests/mut_test.v
@@ -47,3 +47,18 @@ fn test_mut_2() {
 	assert b.a[0].v[3] == 8
 	assert b.a[0].v[4] == 5
 }
+
+fn test_mut_3() {
+    mut indices := []int{len: 3}
+	mut results := []string{}
+
+    for i, mut v in indices {
+        v = i
+        a := v
+        println('$i $v $a')
+		results << '$i $v $a'
+    }
+	assert results[0] == '0 0 0'
+	assert results[1] == '1 1 1'
+	assert results[2] == '2 2 2'
+}


### PR DESCRIPTION
This PR fix `mut` variable in `for` loop reads as address (fix #8548).

- Fix `mut` variable in `for` loop reads as address.
- Add test.

```vlang
fn main() {
    mut indices := []int{len: 3}

    for i, mut v in indices {
        v = i
        a := v
        println('$i $v $a')
    }
}

PS D:\Test\v\tt1> v run .
0 0 0
1 1 1
2 2 2
```