### PR TITLE
builtin: document last of array.v

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -135,7 +135,7 @@ pub fn (a array) repeat(count int) array {
 	return arr
 }
 
-// sort sorts array in-place using given `compare` function as comparator.
+// sort_with_compare sorts array in-place using given `compare` function as comparator.
 pub fn (mut a array) sort_with_compare(compare voidptr) {
 	C.qsort(mut a.data, a.len, a.element_size, compare)
 }
@@ -418,7 +418,8 @@ fn (mut a array) push(val voidptr) {
 	a.len++
 }
 
-// `val` is array.data
+// push_many implements the functionality for pushing another array.
+// `val` is array.data and user facing usage is `a << [1,2,3]`
 // TODO make private, right now it's used by strings.Builder
 pub fn (mut a3 array) push_many(val voidptr, size int) {
 	if a3.data == val && !isnil(a3.data) {


### PR DESCRIPTION
Should tick `vlib/builtin/array.v` in #7047 when merged.

The rest reported by `v vet array.v` is functions in a block comment - and `push_many()` will seemingly be made private at some point.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
