### PR TITLE
builtin: document remaining pub structs in builtin.v

### DIFF
--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -4,8 +4,8 @@
 module builtin
 
 __global (
-	g_m2_buf byteptr 
-	g_m2_ptr byteptr 
+	g_m2_buf byteptr
+	g_m2_ptr byteptr
 )
 
 // isnil returns true if an object is nil (only for C objects).
@@ -38,7 +38,7 @@ __global (
 	total_m              = i64(0)
 	nr_mallocs           = int(0)
 	// will be filled in cgen
-	as_cast_type_indexes   []VCastTypeIndexName 
+	as_cast_type_indexes   []VCastTypeIndexName
 )
 
 fn __as_cast(obj voidptr, obj_type int, expected_type int) voidptr {
@@ -85,11 +85,13 @@ fn __print_assert_failure(i &VAssertMetaInfo) {
 	}
 }
 
+// MethodArgs holds type information for function and/or method arguments.
 pub struct MethodArgs {
 pub:
 	typ int
 }
 
+// FunctionData holds information about a parsed function.
 pub struct FunctionData {
 pub:
 	name        string
@@ -99,6 +101,7 @@ pub:
 	typ         int
 }
 
+// FieldData holds information about a field. Fields reside on structs.
 pub struct FieldData {
 pub:
 	name   string


### PR DESCRIPTION
Ticks off `vlib/builtin/builtin.v` in #7047 when merged.
Also vfmt'ed the file.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
