### PR TITLE
builtin: document rest of map.v

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -78,7 +78,7 @@ const (
 	probe_inc           = u32(0x01000000)
 )
 
-// This function is intended to be fast when
+// fast_string_eq is intended to be fast when
 // the strings are very likely to be equal
 // TODO: add branch prediction hints
 [inline]
@@ -91,7 +91,7 @@ fn fast_string_eq(a string, b string) bool {
 	}
 }
 
-// Dynamic array with very low growth factor
+// DenseArray represents a dynamic array with very low growth factor
 struct DenseArray {
 	key_bytes   int
 	value_bytes int
@@ -198,6 +198,7 @@ type MapCloneFn = fn (voidptr, voidptr)
 
 type MapFreeFn = fn (voidptr)
 
+// map is the internal representation of a V `map` type.
 pub struct map {
 	// Number of bytes of a key
 	key_bytes int
@@ -717,6 +718,7 @@ fn (d &DenseArray) clone() DenseArray {
 	return res
 }
 
+// clone returns a clone of the `map`.
 [unsafe]
 pub fn (m &map) clone() map {
 	metasize := int(sizeof(u32) * (m.even_index + 2 + m.extra_metas))
@@ -750,6 +752,7 @@ pub fn (m &map) clone() map {
 	return res
 }
 
+// free releases all memory resources occupied by the `map`.
 [unsafe]
 pub fn (m &map) free() {
 	unsafe { free(m.metas) }


### PR DESCRIPTION
This should tick off `vlib/builtin/map.v` in #7047 when merged.

I've skipped the following pub functions, because of the associated comments that note they're up for deletion:
[pub fn (mut m map) delete()](https://github.com/vlang/v/blob/d30f94507c3cfde71b5996306444389463e64636/vlib/builtin/map.v#L609-L612)
[pub fn (mut m map) delete_1()](https://github.com/vlang/v/blob/d30f94507c3cfde71b5996306444389463e64636/vlib/builtin/map.v#L615)
[pub fn (m &map) keys()](https://github.com/vlang/v/blob/d30f94507c3cfde71b5996306444389463e64636/vlib/builtin/map.v#L655)

The comments aren't `TODO` entries so it's not fully clear to me what their future is - but I believe the original contributor have had their reasons :) (maybe @ka-weihe knows?)

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
