### PR TITLE
crypto: document rest of rand submodule

### DIFF
--- a/vlib/crypto/rand/utils.v
+++ b/vlib/crypto/rand/utils.v
@@ -7,6 +7,7 @@ module rand
 import math.bits
 import encoding.binary
 
+// int_u64 returns a random unsigned 64-bit integer `u64` read from a real OS source of entropy.
 pub fn int_u64(max u64) ?u64 {
 	bitlen := bits.len_64(max)
 	if bitlen == 0 {
@@ -19,8 +20,8 @@ pub fn int_u64(max u64) ?u64 {
 	}
 	mut n := u64(0)
 	for {
-		mut bytes := read(k)?
-		bytes[0] &= byte(int(u64(1)<<b) - 1)
+		mut bytes := read(k) ?
+		bytes[0] &= byte(int(u64(1) << b) - 1)
 		x := bytes_to_u64(bytes)
 		n = x[0]
 		// NOTE: maybe until we have bigint could do it another way?
@@ -35,20 +36,20 @@ pub fn int_u64(max u64) ?u64 {
 }
 
 fn bytes_to_u64(b []byte) []u64 {
-	ws := 64/8
-	mut z := []u64{len:((b.len + ws - 1) / ws)}
+	ws := 64 / 8
+	mut z := []u64{len: ((b.len + ws - 1) / ws)}
 	mut i := b.len
 	for k := 0; i >= ws; k++ {
-		z[k] = binary.big_endian_u64(b[i-ws..i])
+		z[k] = binary.big_endian_u64(b[i - ws..i])
 		i -= ws
 	}
 	if i > 0 {
 		mut d := u64(0)
 		for s := u64(0); i > 0; s += u64(8) {
-			d |= u64(b[i-1]) << s
+			d |= u64(b[i - 1]) << s
 			i--
 		}
-		z[z.len-1] = d
+		z[z.len - 1] = d
 	}
 	return z
 }


### PR DESCRIPTION
Should tick off `vlib/crypto/rand/utils.v` in #7047 when merged.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
