### PR TITLE
clipboard: add android variant

### DIFF
--- a/vlib/clipboard/clipboard_android.c.v
+++ b/vlib/clipboard/clipboard_android.c.v
@@ -1,0 +1,15 @@
+module clipboard
+
+import clipboard.dummy
+
+pub type Clipboard = dummy.Clipboard
+
+fn new_clipboard() &Clipboard {
+	return dummy.new_clipboard()
+}
+
+// new_primary returns a new X11 `PRIMARY` type `Clipboard` instance allocated on the heap.
+// Please note: new_primary only works on X11 based systems.
+pub fn new_primary() &Clipboard {
+	return dummy.new_primary()
+}


### PR DESCRIPTION
This will enable compiling V sources using both `clipboard` and `ui` on Android.

For some weird reason this also fixes compiling V UI based sources which before gave `error: VERROR_MESSAGE Header file <atomic.h>, needed for module `sync` was not found. Please install the corresponding development headers.`

Currently V UI seems broken on Android though. Running the `calculator.v` example on an Android results in an seemingly infinite loop trying to open a window:
```
02-05 14:05:59.484 22357 22357 I SOKOL_APP: NativeActivity onCreate()
02-05 14:05:59.485 22357 22357 I v_test_app: window() state =0x7cc015ee50 
02-05 14:05:59.495 22357 22357 I v_test_app: print_backtrace_skipping_top_frames is not implemented. skipframes: 3
02-05 14:05:59.949 22440 22440 I SOKOL_APP: NativeActivity onCreate()
02-05 14:05:59.950 22440 22440 I v_test_app: window() state =0x7cc015ee50 
02-05 14:05:59.967 22440 22440 I v_test_app: print_backtrace_skipping_top_frames is not implemented. skipframes: 3
... ∞
```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
