### PR TITLE
check-md: fix missing default_command when nofmt was set

### DIFF
--- a/cmd/tools/vcheck-md.v
+++ b/cmd/tools/vcheck-md.v
@@ -170,6 +170,8 @@ fn (mut f MDFile) parse_line(lnumber int, line string) {
 			mut command := line.replace('```v', '').trim_space()
 			if command == '' {
 				command = default_command
+			} else if command == 'nofmt' {
+				command += ' $default_command'
 			}
 			f.current = VCodeExample{
 				sline: lnumber


### PR DESCRIPTION
The CI will be green after https://github.com/vlang/v/pull/8590 is merged.