### PR TITLE
cgen: support `shared` initialization from call returning optional

### DIFF
--- a/vlib/v/tests/shared_fn_return_test.v
+++ b/vlib/v/tests/shared_fn_return_test.v
@@ -1,0 +1,48 @@
+struct St {
+mut:
+	x f64
+}
+
+fn f() St {
+	x := St{ x: 3.25 }
+	return x
+}
+
+fn g(good bool) ?St {
+	if !good {
+		return error('no St created')
+	}
+	x := St{ x: 12.75 }
+	return x
+}
+
+fn test_shared_fn_return() {
+	shared x := f()
+	val := rlock x { x.x }
+	assert val == 3.25
+}
+
+fn shared_opt_propagate(good bool) ?f64 {
+	shared x := g(good) ?
+	ret := rlock x { x.x }
+	return ret
+}
+
+fn test_shared_opt_propagate() {
+	x := shared_opt_propagate(true) or { 1.25 }
+	y := shared_opt_propagate(false) or { 2.125 }
+	assert x == 12.75
+	assert y == 2.125
+}
+
+fn test_shared_opt_good() {
+	shared yy := g(true) or { St{ x: 37.5 } }
+	val := rlock yy { yy.x }
+	assert val == 12.75
+}
+
+fn test_shared_opt_bad() {
+	shared yy := g(false) or { St{ x: 37.5 } }
+	val := rlock yy { yy.x }
+	assert val == 37.5
+}


### PR DESCRIPTION
This allows the following initialization of `shared` objects from functions that return an optional value:
```v
fn f() ?St { ... }

shared x := f() or { St{...} }
shared y := f() ?
...
lock x, y {
    ...
}
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
