### PR TITLE
gen: fix bug where unreached defer is executed

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -333,7 +333,7 @@ pub:
 	skip_gen        bool // this function doesn't need to be generated (for example [if foo])
 pub mut:
 	stmts         []Stmt
-	defer_stmts   []&DeferStmt
+	defer_stmts   []DeferStmt
 	return_type   table.Type
 	has_return    bool
 	comments      []Comment // comments *after* the header, but *before* `{`; used for InterfaceDecl

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -333,6 +333,7 @@ pub:
 	skip_gen        bool // this function doesn't need to be generated (for example [if foo])
 pub mut:
 	stmts         []Stmt
+	defer_stmts   []&DeferStmt
 	return_type   table.Type
 	has_return    bool
 	comments      []Comment // comments *after* the header, but *before* `{`; used for InterfaceDecl
@@ -891,7 +892,8 @@ pub:
 	stmts []Stmt
 	pos   token.Position
 pub mut:
-	ifdef string
+	ifdef     string
+	idx_in_fn int = -1 // index in FnDecl.defer_stmts
 }
 
 // `(3+4)`

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3123,6 +3123,10 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 			c.inside_const = false
 		}
 		ast.DeferStmt {
+			if node.idx_in_fn < 0 {
+				node.idx_in_fn = c.cur_fn.defer_stmts.len
+				c.cur_fn.defer_stmts << &node
+			}
 			c.stmts(node.stmts)
 		}
 		ast.EnumDecl {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -989,6 +989,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 		ast.DeferStmt {
 			mut defer_stmt := node
 			defer_stmt.ifdef = g.defer_ifdef
+			g.writeln('${g.defer_flag_var(defer_stmt)} = true;')
 			g.defer_stmts << defer_stmt
 		}
 		ast.EnumDecl {
@@ -1275,6 +1276,8 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 fn (mut g Gen) write_defer_stmts() {
 	for defer_stmt in g.defer_stmts {
 		g.writeln('// Defer begin')
+		g.writeln('if (${g.defer_flag_var(defer_stmt)} == true) {')
+		g.indent++
 		if defer_stmt.ifdef.len > 0 {
 			g.writeln(defer_stmt.ifdef)
 			g.stmts(defer_stmt.stmts)
@@ -1285,6 +1288,8 @@ fn (mut g Gen) write_defer_stmts() {
 			g.stmts(defer_stmt.stmts)
 			g.indent++
 		}
+		g.indent--
+		g.writeln('}')
 		g.writeln('// Defer end')
 	}
 }

--- a/vlib/v/tests/defer_test.v
+++ b/vlib/v/tests/defer_test.v
@@ -27,8 +27,7 @@ fn set_num(i int, mut n Num) {
 	println('Hi')
 	if i < 5 {
 		return
-	}
-	else {
+	} else {
 		n.val++
 	}
 }
@@ -60,15 +59,18 @@ fn test_defer_early_exit() {
 
 fn test_defer_option() {
 	mut ok := Num{0}
-	set_num_opt(mut ok) or {}
+	set_num_opt(mut ok) or { }
 	assert ok.val == 1
 }
 
 fn test_defer_with_anon_fn() {
-	mut f := &Num{val: 110}
+	mut f := &Num{
+		val: 110
+	}
 	defer {
 		assert f.add(1) == 111
 	}
+
 	go fn () {
 		defer {
 			println('deferred 1')
@@ -82,4 +84,20 @@ fn test_defer_with_anon_fn() {
 	}
 	x()
 	return
+}
+
+fn set_num_if(mut n Num, v int, cond bool) {
+	if cond {
+		defer {
+			n.val = v
+		}
+	}
+}
+
+fn test_defer_with_if() {
+	mut n := Num{0}
+	set_num_if(mut n, 10, true)
+	assert n.val == 10
+	set_num_if(mut n, 20, false)
+	assert n.val == 10
 }


### PR DESCRIPTION
For now all defers will be executed regardless of whether the `defer {}` is reached

See test. `test_defer_with_if` will be failed on current master.

This PR fix this bug
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
