### PR TITLE
all: allow functions to return `shared` object

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2543,7 +2543,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 				node.return_type.clear_flag(.optional)
 			}
 			mut shared_styp := ''
-			if g.is_shared {
+			if g.is_shared && !ret_type.has_flag(.shared_f) {
 				ret_sym := g.table.get_type_symbol(ret_type)
 				shared_typ := ret_type.set_flag(.shared_f)
 				shared_styp = g.typ(shared_typ)
@@ -2571,7 +2571,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 				g.strs_to_free0 = []
 				// println('pos=$node.pos.pos')
 			}
-			if g.is_shared {
+			if g.is_shared && !ret_type.has_flag(.shared_f) {
 				g.writeln('}, sizeof($shared_styp))')
 			}
 			// if g.autofree && node.autofree_pregen != '' { // g.strs_to_free0.len != 0 {

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -207,6 +207,9 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 				p.warn_with_pos('use `(mut f Foo)` instead of `(f mut Foo)`', lpar_pos.extend(p.peek_tok2.position()))
 			}
 		}
+		if p.tok.kind == .key_shared {
+			p.error_with_pos('use `(shared f Foo)` instead of `(f shared Foo)`', lpar_pos.extend(p.peek_tok2.position()))
+		}
 		receiver_pos = rec_start_pos.extend(p.tok.position())
 		is_amp := p.tok.kind == .amp
 		if p.tok.kind == .name && p.tok.lit == 'JS' {
@@ -684,6 +687,9 @@ fn (mut p Parser) fn_args() ([]table.Param, bool, bool) {
 					p.warn_with_pos('use `mut f Foo` instead of `f mut Foo`', p.tok.position())
 				}
 				is_mut = true
+			}
+			if p.tok.kind == .key_shared {
+				p.error_with_pos('use `shared f Foo` instead of `f shared Foo`', p.tok.position())
 			}
 			if p.tok.kind == .ellipsis {
 				p.next()

--- a/vlib/v/tests/fn_shared_return_test.v
+++ b/vlib/v/tests/fn_shared_return_test.v
@@ -36,15 +36,19 @@ fn test_shared_opt_propagate() {
 }
 
 fn test_shared_opt_good() {
-	shared my_default := St{ x: 37.5 }
-	shared yy := g(true) or { my_default }
+	shared yy := g(true) or {
+		shared my_default := St{ x: 37.5 }
+	    my_default
+	}
 	val := rlock yy { yy.x }
 	assert val == 12.75
 }
 
 fn test_shared_opt_bad() {
-	shared my_default := St{ x: 37.5 }
-	shared yy := g(false) or { my_default }
+	shared yy := g(false) or {
+		shared my_default := St{ x: 37.5 }
+	    my_default
+	}
 	val := rlock yy { yy.x }
 	assert val == 37.5
 }

--- a/vlib/v/tests/fn_shared_return_test.v
+++ b/vlib/v/tests/fn_shared_return_test.v
@@ -1,0 +1,50 @@
+struct St {
+mut:
+	x f64
+}
+
+fn f() shared St {
+	shared x := St{ x: 3.25 }
+	return x
+}
+
+fn g(good bool) ?shared St {
+	if !good {
+		return error('no shared St created')
+	}
+	shared x := St{ x: 12.75 }
+	return x
+}
+
+fn test_shared_fn_return() {
+	shared x := f()
+	val := rlock x { x.x }
+	assert val == 3.25
+}
+
+fn shared_opt_propagate(good bool) ?f64 {
+	shared x := g(good) ?
+	ret := rlock x { x.x }
+	return ret
+}
+
+fn test_shared_opt_propagate() {
+	x := shared_opt_propagate(true) or { 1.25 }
+	y := shared_opt_propagate(false) or { 2.125 }
+	assert x == 12.75
+	assert y == 2.125
+}
+
+fn test_shared_opt_good() {
+	shared my_default := St{ x: 37.5 }
+	shared yy := g(true) or { my_default }
+	val := rlock yy { yy.x }
+	assert val == 12.75
+}
+
+fn test_shared_opt_bad() {
+	shared my_default := St{ x: 37.5 }
+	shared yy := g(false) or { my_default }
+	val := rlock yy { yy.x }
+	assert val == 37.5
+}

--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -427,7 +427,7 @@ pub fn (tok Kind) is_relational() bool {
 }
 
 pub fn (k Kind) is_start_of_type() bool {
-	return k in [.name, .lpar, .amp, .lsbr, .question]
+	return k in [.name, .lpar, .amp, .lsbr, .question, .key_shared]
 }
 
 pub fn (kind Kind) is_prefix() bool {


### PR DESCRIPTION
This PR allows functions to return a `shared` object:
```v
struct Server { ... }

fn simple_shared() shared Server {
    shared s := Server{ .... }
    return s
}

fn new_server() ?shared Server {
    if something_is_bad() {
        return error('something bad happened')
    }
    shared s := Server{ ... }
    return s
}

shared s := simple_server()
shared s2 := new_server() ?
shared s3 := new_server() or {
    shared default_s := Server{ ... }
    default_s
}
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
