### PR TITLE
gg: support getting system font on Android

### DIFF
--- a/vlib/gg/text_rendering.v
+++ b/vlib/gg/text_rendering.v
@@ -267,7 +267,7 @@ pub fn system_font_path() string {
 	}
 	$if android {
 		xml_files := ['/system/etc/system_fonts.xml', '/system/etc/fonts.xml', '/etc/system_fonts.xml',
-			'/etc/fonts.xml', '/data/fonts/fonts.xml']
+			'/etc/fonts.xml', '/data/fonts/fonts.xml', '/etc/fallback_fonts.xml']
 		font_locations := ['/system/fonts', '/data/fonts']
 		for xml_file in xml_files {
 			if os.is_file(xml_file) && os.is_readable(xml_file) {

--- a/vlib/gg/text_rendering.v
+++ b/vlib/gg/text_rendering.v
@@ -82,17 +82,24 @@ fn new_ft(c FTConfig) ?&FT {
 			// Load default font
 		}
 	}
-	$if !android {
-		if c.font_path == '' || !os.exists(c.font_path) {
+
+	if c.font_path == '' || !os.exists(c.font_path) {
+		$if !android {
 			println('failed to load font "$c.font_path"')
 			return none
 		}
 	}
+
 	mut bytes := []byte{}
 	$if android {
-		bytes = os.read_apk_asset(c.font_path) or {
-			println('failed to load font "$c.font_path"')
-			return none
+		// First try any filesystem paths
+		bytes = os.read_bytes(c.font_path) or { []byte{} }
+		if bytes.len == 0 {
+			// ... then try the APK asset path
+			bytes = os.read_apk_asset(c.font_path) or {
+				println('failed to load font "$c.font_path"')
+				return none
+			}
 		}
 	} $else {
 		bytes = os.read_bytes(c.font_path) or {
@@ -255,6 +262,31 @@ pub fn system_font_path() string {
 		for font in fonts {
 			if os.is_file(font) {
 				return font
+			}
+		}
+	}
+	$if android {
+		xml_files := ['/system/etc/system_fonts.xml', '/system/etc/fonts.xml', '/etc/system_fonts.xml',
+			'/etc/fonts.xml', '/data/fonts/fonts.xml']
+		font_locations := ['/system/fonts', '/data/fonts']
+		for xml_file in xml_files {
+			if os.is_file(xml_file) && os.is_readable(xml_file) {
+				xml := os.read_file(xml_file) or { continue }
+				lines := xml.split('\n')
+				mut candidate_font := ''
+				for line in lines {
+					if line.contains('<font') {
+						candidate_font = line.all_after('>').all_before('<').trim(' \n\t\r')
+						if candidate_font.contains('.ttf') {
+							for location in font_locations {
+								candidate_path := os.join_path(location, candidate_font)
+								if os.is_file(candidate_path) && os.is_readable(candidate_path) {
+									return candidate_path
+								}
+							}
+						}
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR will let `gg.system_font_path()` try extremely hard to find a default system font on Android.

There is apparently no standard way to get a default system font on Android so I've resorted to an implementation
based on a compilation of various internet sources:

https://android.stackexchange.com/a/138345
https://android.googlesource.com/platform/frameworks/base/+/master/data/fonts/fonts.xml
https://stackoverflow.com/a/39877797/1904615

(A nice side effect of the PR is that all `gg` and `ui` examples (where default font is used) should now run without modifications on Android devices)
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
