### PR TITLE
parser: support short struct update syntax `{...ident,`

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1633,6 +1633,8 @@ Only more complex types such as arrays and maps may be modified.
 Use `user.register()` or `user = register(user)`
 instead of `register(mut user)`.
 
+#### Struct update syntax
+
 V makes it easy to return a modified version of an object:
 
 ```v
@@ -1644,7 +1646,7 @@ struct User {
 
 fn register(u User) User {
 	return {
-		u |
+		...u
 		is_registered: true
 	}
 }

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -245,7 +245,8 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 				// it should be a struct
 				if p.peek_tok.kind == .pipe {
 					node = p.assoc()
-				} else if p.peek_tok.kind == .colon || p.tok.kind in [.rcbr, .comment] {
+				} else if (p.tok.kind == .name && p.peek_tok.kind == .colon)
+					|| p.tok.kind in [.rcbr, .comment, .ellipsis] {
 					node = p.struct_init(true) // short_syntax: true
 				} else if p.tok.kind == .name {
 					p.next()

--- a/vlib/v/tests/struct_test.v
+++ b/vlib/v/tests/struct_test.v
@@ -164,12 +164,14 @@ fn test_assoc_with_vars() {
 	def2 := Def{
 		a: 12
 	}
-	merged := Def{
+	mut merged := Def{
 		...def2
 		a: 42
 	}
 	assert merged.a == 42
 	assert merged.b == 7
+	merged = {...def2, b: 9}
+	assert merged == Def{12, 9}
 
 	def3 := &Def{ 100, 200 }
 	merged1 := Def{...(*def3)}


### PR DESCRIPTION
Also update docs.

The old syntax was supported for struct name inference (a.k.a. short syntax):
```v
params[0] = {
	first_param |
	typ: params[0].typ.set_nr_muls(1)
}
```
`{...ident` syntax should also be supported. No need to require stating the struct name when it is already known (from return type etc).

Deprecation of old syntax needs to happen separately as cgen depends on it.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
