### PR TITLE
fmt: fixed to enable shared return types

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -26,7 +26,8 @@ pub fn (node &FnDecl) stringify(t &table.Table, cur_mod string, m2a map[string]s
 	}
 	mut receiver := ''
 	if node.is_method {
-		mut styp := util.no_cur_mod(t.type_to_code(node.receiver.typ), cur_mod)
+		mut styp := util.no_cur_mod(t.type_to_code(node.receiver.typ.clear_flag(.shared_f)),
+			cur_mod)
 		m := if node.rec_mut { node.receiver.typ.share().str() + ' ' } else { '' }
 		if node.rec_mut {
 			styp = styp[1..] // remove &
@@ -88,7 +89,7 @@ pub fn (node &FnDecl) stringify(t &table.Table, cur_mod string, m2a map[string]s
 			f.write(arg.typ.share().str() + ' ')
 		}
 		f.write(arg.name)
-		mut s := t.type_to_str(arg.typ)
+		mut s := t.type_to_str(arg.typ.clear_flag(.shared_f))
 		if arg.is_mut {
 			// f.write(' mut')
 			if s.starts_with('&') {

--- a/vlib/v/checker/tests/shared_type_mismatch.out
+++ b/vlib/v/checker/tests/shared_type_mismatch.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/shared_type_mismatch.vv:13:3: error: wrong return type `St` in the `or {}` block, expected `shared St`
+   11 | fn test_shared_opt_bad() {
+   12 |     shared yy := f() or {
+   13 |         St{ x: 37.5 }
+      |         ~~~~~~~~~~~~~
+   14 |     }
+   15 |     rlock yy {

--- a/vlib/v/checker/tests/shared_type_mismatch.vv
+++ b/vlib/v/checker/tests/shared_type_mismatch.vv
@@ -1,0 +1,18 @@
+struct St {
+mut:
+	x f64
+}
+
+fn f() ?shared St {
+	shared x := St{ x: 12.75 }
+	return x
+}
+
+fn test_shared_opt_bad() {
+	shared yy := f() or {
+		St{ x: 37.5 }
+	}
+	rlock yy {
+	    println(yy.x)
+	}
+}

--- a/vlib/v/fmt/tests/shared_expected.vv
+++ b/vlib/v/fmt/tests/shared_expected.vv
@@ -17,6 +17,34 @@ fn (shared x St) f(shared z St) {
 	}
 }
 
+fn g() shared St {
+	shared x := St{
+		a: 12
+	}
+	return x
+}
+
+fn h() ?shared St {
+	return error('no value')
+}
+
+fn k() {
+	shared x := g()
+	shared y := h() or {
+		shared f := St{}
+		f
+	}
+	shared z := h() ?
+	shared p := v
+	v := rlock z {
+		z.a
+	}
+	lock y, z; rlock x, p {
+		z.a = x.a + y.a
+	}
+	println(v)
+}
+
 const (
 	reads_per_thread = 30
 	read_threads     = 10

--- a/vlib/v/fmt/tests/shared_input.vv
+++ b/vlib/v/fmt/tests/shared_input.vv
@@ -18,6 +18,30 @@ fn (shared x St) f(shared z St) {
 	}
 }
 
+fn g() shared St {
+shared  x := St{a: 12 }
+		return   x
+}
+
+fn h() ?shared St {
+    return error('no value')
+}
+
+fn k() {
+  shared  x := g()
+  shared y := h() or {
+      shared f := St{}
+	  f
+	 }
+	 shared z := h() ?
+	 shared p := v
+	 v := rlock  z {  z.a }
+	 rlock x; lock y, z; rlock p {
+	  z.a = x.a + y.a
+	  }
+	 println(v)
+}
+
 const (
 	reads_per_thread = 30
 	read_threads     = 10

--- a/vlib/v/table/types.v
+++ b/vlib/v/table/types.v
@@ -846,7 +846,11 @@ pub fn (mytable &Table) type_to_str_using_aliases(t Type, import_aliases map[str
 			res = mytable.shorten_user_defined_typenames(res, import_aliases)
 		}
 	}
-	nr_muls := t.nr_muls()
+	mut nr_muls := t.nr_muls()
+	if t.has_flag(.shared_f) {
+		nr_muls--
+		res = 'shared ' + res
+	}
 	if nr_muls > 0 {
 		res = strings.repeat(`&`, nr_muls) + res
 	}


### PR DESCRIPTION
This enables `vfmt` to format the syntax introduced in #8606. This is basically done by adjusing `table.type_to_str_using_aliases()`. As a side effect the shown type in error messages is corrected, too.

`fmt` test case for several recently added `shared` syntax elements and for error messages are added.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
