### PR TITLE
cgen: fix gen of .sort method for `>` operator and improve grammar of error message

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -252,7 +252,7 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 		if !is_reverse && sym.has_method('<') && infix_expr.left.str().len == 1 {
 			g.definitions.writeln('\tif (${styp}__lt(*a, *b)) { return -1; } else { return 1; }}')
 		} else if is_reverse && sym.has_method('<') && infix_expr.left.str().len == 1 {
-			g.definitions.writeln('\tif (!${styp}__lt(*a, *b)) { return -1; } else { return 1; }}')
+			g.definitions.writeln('\tif (${styp}__lt(*b, *a)) { return -1; } else { return 1; }}')
 		} else {
 			field_type := g.typ(infix_expr.left_type)
 			mut left_expr_str := g.write_expr_to_string(infix_expr.left)

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -291,7 +291,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		}
 		p.next()
 	} else if p.tok.kind in [.ne, .gt, .ge, .le] && p.peek_tok.kind == .lpar {
-		p.error_with_pos('cannot overload `!=`, `>`, `<=` and `>=` as they are auto generated with `==` and`<`',
+		p.error_with_pos('cannot overload `!=`, `>`, `<=` and `>=` as they are auto generated from `==` and`<`',
 			p.tok.position())
 	} else {
 		pos := p.tok.position()

--- a/vlib/v/tests/operator_overloading_cmp_test.v
+++ b/vlib/v/tests/operator_overloading_cmp_test.v
@@ -13,6 +13,7 @@ fn (a Foo) == (b Foo) bool {
 fn test_operator_overloading_cmp() {
 	a := Foo{i: 38}
 	b := Foo{i: 38}
+	mut arr := [a, b]
 
 	assert (a > b) == false
 	assert (a < b) == false 
@@ -22,4 +23,9 @@ fn test_operator_overloading_cmp() {
 	//// /// //
 	assert b >= a
 	assert b <= a
+	//// /// //
+	arr.sort(a > b)
+	assert arr[0].i == 38
+	arr.sort(a < b)
+	assert arr[0].i == 38
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
