### PR TITLE
parser: deprecate `{var |` struct update

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1054,6 +1054,8 @@ pub:
 	pos       token.Position
 }
 */
+
+// deprecated
 pub struct Assoc {
 pub:
 	var_name string

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1140,8 +1140,7 @@ pub fn (mut f Fmt) cast_expr(node ast.CastExpr) {
 pub fn (mut f Fmt) assoc(node ast.Assoc) {
 	f.writeln('{')
 	// f.indent++
-	f.writeln('\t$node.var_name |')
-	// TODO StructInit copy pasta
+	f.writeln('\t...$node.var_name')
 	for i, field in node.fields {
 		f.write('\t$field: ')
 		f.expr(node.exprs[i])

--- a/vlib/v/fmt/tests/struct_init_keep.vv
+++ b/vlib/v/fmt/tests/struct_init_keep.vv
@@ -7,5 +7,8 @@ fn main() {
 	u := User{
 		age: 54
 	}
-	println(u)
+	_ = User{
+		...u
+		name: 'hi'
+	}
 }

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6216,9 +6216,9 @@ $staticprefix $interface_name* I_${cctype}_to_Interface_${interface_name}_ptr($c
 					//
 					params_start_pos := g.out.len
 					mut params := method.params.clone()
-					first_param := params[0] // workaround, { params[0] | ... } doesn't work
+					// hack to mutate typ
 					params[0] = {
-						first_param |
+						...params[0]
 						typ: params[0].typ.set_nr_muls(1)
 					}
 					fargs, _ := g.fn_args(params, false) // second argument is ignored anyway

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -244,7 +244,8 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 				node = p.map_init()
 			} else {
 				// it should be a struct
-				if p.peek_tok.kind == .pipe {
+				if p.tok.kind == .name && p.peek_tok.kind == .pipe {
+					p.warn_with_pos('use e.g. `...struct_var` instead', p.peek_tok.position())
 					node = p.assoc()
 				} else if (p.tok.kind == .name && p.peek_tok.kind == .colon)
 					|| p.tok.kind in [.rcbr, .comment, .ellipsis] {


### PR DESCRIPTION
Follow up for #8613.

Also make vfmt change it to `{...var` syntax.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
