### PR TITLE
doc, fmt: use `map{key: value}` syntax for map literals

### DIFF
--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -130,7 +130,7 @@ fn (vd VDoc) render_search_index(out Output) {
 }
 
 fn (mut vd VDoc) render_static_html(out Output) {
-	vd.assets = {
+	vd.assets = map{
 		'doc_css':       vd.get_resource(css_js_assets[0], out)
 		'normalize_css': vd.get_resource(css_js_assets[1], out)
 		'doc_js':        vd.get_resource(css_js_assets[2], out)

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -820,7 +820,7 @@ val := sm['bad_key']
 println(val) // ''
 ```
 ```v
-intm := map {
+intm := map{
 	1: 1234
 	2: 5678
 }
@@ -1066,7 +1066,7 @@ To do the opposite, use `!in`.
 nums := [1, 2, 3]
 println(1 in nums) // true
 println(4 !in nums) // true
-m := {
+m := map{
 	'one': 1
 	'two': 2
 }
@@ -1703,7 +1703,7 @@ fn main() {
 	// You can even have an array/map of functions:
 	fns := [sqr, cube]
 	println((10)) // "100"
-	fns_map := map {
+	fns_map := map{
 		'sqr':  sqr
 		'cube': cube
 	}

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -798,9 +798,12 @@ println(m['one']) // "1"
 println(m['bad_key']) // "0"
 println('bad_key' in m) // Use `in` to detect whether such key exists
 m.delete('two')
-// NB: map keys can have any type, `int` in this case,
-// and the whole map can be initialized using this short syntax:
-numbers := {
+```
+Maps can have keys of type string, rune, integer, float or voidptr.
+
+The whole map can be initialized using this short syntax:
+```v
+numbers := map{
 	1: 'one'
 	2: 'two'
 }
@@ -810,12 +813,14 @@ println(numbers)
 If a key is not found, a zero value is returned by default:
 
 ```v
-sm := {
+sm := map{
 	'abc': 'xyz'
 }
 val := sm['bad_key']
 println(val) // ''
-intm := {
+```
+```v
+intm := map {
 	1: 1234
 	2: 5678
 }
@@ -1132,7 +1137,7 @@ When an identifier is just a single underscore, it is ignored.
 #### Map `for`
 
 ```v
-m := {
+m := map{
 	'one': 1
 	'two': 2
 }
@@ -1145,7 +1150,7 @@ for key, value in m {
 
 Either key or value can be ignored by using a single underscore as the identifier.
 ```v
-m := {
+m := map{
 	'one': 1
 	'two': 2
 }
@@ -1698,7 +1703,7 @@ fn main() {
 	// You can even have an array/map of functions:
 	fns := [sqr, cube]
 	println((10)) // "100"
-	fns_map := {
+	fns_map := map {
 		'sqr':  sqr
 		'cube': cube
 	}

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1198,20 +1198,20 @@ fn test_struct_array_of_multi_type_in() {
 	ivan := Person{
 		name: 'ivan'
 		nums: [1, 2, 3]
-		kv: {
+		kv: map{
 			'aaa': '111'
 		}
 	}
 	people := [Person{
 		name: 'ivan'
 		nums: [1, 2, 3]
-		kv: {
+		kv: map{
 			'aaa': '111'
 		}
 	}, Person{
 		name: 'bob'
 		nums: [2]
-		kv: {
+		kv: map{
 			'bbb': '222'
 		}
 	}]
@@ -1223,20 +1223,20 @@ fn test_struct_array_of_multi_type_index() {
 	ivan := Person{
 		name: 'ivan'
 		nums: [1, 2, 3]
-		kv: {
+		kv: map{
 			'aaa': '111'
 		}
 	}
 	people := [Person{
 		name: 'ivan'
 		nums: [1, 2, 3]
-		kv: {
+		kv: map{
 			'aaa': '111'
 		}
 	}, Person{
 		name: 'bob'
 		nums: [2]
-		kv: {
+		kv: map{
 			'bbb': '222'
 		}
 	}]

--- a/vlib/builtin/map_of_floats_test.v
+++ b/vlib/builtin/map_of_floats_test.v
@@ -12,7 +12,7 @@ fn test_map_of_f32() {
 }
 
 fn test_map_of_f64() {
-	mut m64 := {
+	mut m64 := map{
 		3.14: 'pi'
 	}
 	m64[1.0] = 'one'

--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -274,25 +274,25 @@ fn test_map_assign() {
 	mut a := map[string]f64{}
 	mut b := map[string]int{}
 	mut c := map[string]u16{}
-	a = {
+	a = map{
 		'x': 12.4
 		'y': 3
 	}
-	b = {
+	b = map{
 		'u': -13
 		'v': 12
 	}
-	c = {
+	c = map{
 		's': u16(5)
 		't': 3
 	}
-	_ := Mstruct1{{
+	_ := Mstruct1{map{
 		'p': 12
 	}}
-	_ := Mstruct2{{
+	_ := Mstruct2{map{
 		'q': 1.7
 	}}
-	_ := Mstruct3{{
+	_ := Mstruct3{map{
 		'r': u16(6)
 		's': 5
 	}}
@@ -335,7 +335,7 @@ fn test_map_in_directly() {
 }
 
 fn test_plus_assign_string() {
-	mut m := {
+	mut m := map{
 		'one': ''
 	}
 	m['one'] += '1'
@@ -344,7 +344,7 @@ fn test_plus_assign_string() {
 }
 
 fn test_map_keys_to_array() {
-	m := {
+	m := map{
 		'a': 'b'
 		'c': 'd'
 	}
@@ -364,7 +364,7 @@ fn map_in_mut(mut m map[string]int) {
 }
 
 fn test_map_in_mut() {
-	mut m := {
+	mut m := map{
 		'one': 1
 	}
 	map_in_mut(mut m)
@@ -372,7 +372,7 @@ fn test_map_in_mut() {
 }
 
 fn test_map_in() {
-	m := {
+	m := map{
 		'Foo': 'bar'
 	}
 	if 'foo'.capitalize() in m {
@@ -404,7 +404,7 @@ fn mut_map_with_relation_op_in_fn(mut m map[string]int) {
 }
 
 fn test_mut_map_with_relation_op_in_fn() {
-	mut m := {
+	mut m := map{
 		'one': 1
 		'two': 2
 	}
@@ -418,7 +418,7 @@ fn test_mut_map_with_relation_op_in_fn() {
 }
 
 fn test_map_str_after_delete() {
-	mut m := {
+	mut m := map{
 		'first':  1
 		'second': 2
 		'third':  3
@@ -432,7 +432,7 @@ fn test_map_str_after_delete() {
 }
 
 fn test_modify_map_value() {
-	mut m1 := {
+	mut m1 := map{
 		'foo': 3
 		'bar': -7
 	}
@@ -443,7 +443,7 @@ fn test_modify_map_value() {
 }
 
 fn test_map_clone() {
-	mut nums := {
+	mut nums := map{
 		'foo': 1
 		'bar': 2
 	}
@@ -470,7 +470,7 @@ fn test_map_default_zero() {
 }
 
 fn test_map_or() {
-	m := {
+	m := map{
 		'first':  1
 		'second': 2
 		'third':  3
@@ -489,7 +489,7 @@ fn test_int_keys() {
 	m[5] += 24
 	m[5]++
 	assert m[5] == 25
-	m2 := {
+	m2 := map{
 		3: 9
 		4: 16
 		5: 25
@@ -521,7 +521,7 @@ fn test_voidptr_keys() {
 }
 
 fn test_rune_keys() {
-	mut m := {
+	mut m := map{
 		`!`: 2
 		`%`: 3
 	}
@@ -541,62 +541,62 @@ fn test_rune_keys() {
 }
 
 fn test_eq() {
-	a := {
+	a := map{
 		'a': 1
 		'b': 2
 	}
-	assert a == {
+	assert a == map{
 		'a': 1
 		'b': 2
 	}
-	b := {
+	b := map{
 		'a': [[1]]
 		'b': [[2]]
 	}
-	assert b == {
+	assert b == map{
 		'a': [[1]]
 		'b': [[2]]
 	}
-	c := {
-		'a': {
+	c := map{
+		'a': map{
 			'11': 1
 		}
-		'b': {
+		'b': map{
 			'22': 2
 		}
 	}
-	assert c == {
-		'a': {
+	assert c == map{
+		'a': map{
 			'11': 1
 		}
-		'b': {
+		'b': map{
 			'22': 2
 		}
 	}
-	d := {
+	d := map{
 		'a': MValue{
 			name: 'aa'
-			misc: {
+			misc: map{
 				'11': '1'
 			}
 		}
 		'b': MValue{
 			name: 'bb'
-			misc: {
+			misc: map{
 				'22': '2'
 			}
 		}
 	}
-	assert d == {
+	assert d == map{
 		'a': MValue{
 			name: 'aa'
-			misc: {
+			misc: map{
 				'11': '1'
 			}
 		}
 		'b': MValue{
 			name: 'bb'
-			misc: {
+			misc: map{
 				'22': '2'
 			}
 		}
@@ -604,24 +604,24 @@ fn test_eq() {
 }
 
 fn test_non_string_key_map_str() {
-	assert {
+	assert map{
 		23: 4
 	}.str() == '{23: 4}'
-	assert {
+	assert map{
 		`a`: 12
 		`b`: 13
 	}.str() == '{`a`: 12, `b`: 13}'
-	assert {
+	assert map{
 		23: 'foo'
 		25: 'bar'
 	}.str() == "{23: 'foo', 25: 'bar'}"
 }
 
 fn test_map_assign_empty_map_init() {
-	mut a := {
+	mut a := map{
 		'one': 1
 	}
-	a = {}
+	a = map{}
 	println(a)
 	assert a == map[string]int{}
 	assert '$a' == '{}'

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2587,6 +2587,8 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 			// `map = {}`
 			sym := c.table.get_type_symbol(left_type)
 			if sym.kind == .map && assign_stmt.right[i] is ast.StructInit {
+				c.warn('assigning a struct literal to a map is deprecated - use `map{}` instead',
+					assign_stmt.right[i].position())
 				assign_stmt.right[i] = ast.MapInit{}
 			}
 		}

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -218,7 +218,7 @@ pub fn (mut d Doc) stmt(stmt ast.Stmt, filename string) ?DocNode {
 						kind: .variable
 						parent_name: node.name
 						pos: d.convert_pos(filename, param.pos)
-						attrs: {
+						attrs: map{
 							'mut': param.is_mut.str()
 						}
 						return_type: d.type_to_str(param.typ)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2034,7 +2034,7 @@ pub fn (mut f Fmt) map_init(it ast.MapInit) {
 		f.write('{}')
 		return
 	}
-	f.writeln('{')
+	f.writeln('map{')
 	f.indent++
 	mut max_field_len := 0
 	for key in it.keys {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2029,8 +2029,13 @@ pub fn (mut f Fmt) array_init(it ast.ArrayInit) {
 
 pub fn (mut f Fmt) map_init(it ast.MapInit) {
 	if it.keys.len == 0 {
-		f.mark_types_import_as_used(it.typ)
-		f.write(f.table.type_to_str(it.typ))
+		if it.typ > table.void_type {
+			f.mark_types_import_as_used(it.typ)
+			f.write(f.table.type_to_str(it.typ))
+		} else {
+			// m = map{}
+			f.write('map')
+		}
 		f.write('{}')
 		return
 	}

--- a/vlib/v/fmt/tests/array_init_keep.vv
+++ b/vlib/v/fmt/tests/array_init_keep.vv
@@ -18,10 +18,10 @@ fn main() {
 		'eggs',
 	]
 	_ := []int{len: 10, cap: 10, init: 7}
-	_ := []map[string]string{len: 5, cap: 50, init: {
+	_ := []map[string]string{len: 5, cap: 50, init: map{
 		'a': 'a'
 	}}
-	_ := []map[string][]int{len: 7, cap: 100, init: {
+	_ := []map[string][]int{len: 7, cap: 100, init: map{
 		'a': [1, 2]
 	}}
 }

--- a/vlib/v/fmt/tests/maps_expected.vv
+++ b/vlib/v/fmt/tests/maps_expected.vv
@@ -1,5 +1,5 @@
 const (
-	reserved_types = {
+	reserved_types = map{
 		'i8':   true
 		'i16':  true
 		'int':  true
@@ -8,7 +8,7 @@ const (
 	}
 )
 
-numbers := {
+numbers := map{
 	'one':                                 1
 	'two':                                 2
 	'sevenhundredseventyseven':            777

--- a/vlib/v/fmt/tests/maps_keep.vv
+++ b/vlib/v/fmt/tests/maps_keep.vv
@@ -5,11 +5,11 @@ fn workaround() {
 
 fn main() {
 	mut ams := []map[string]string{}
-	ams << {
+	ams << map{
 		'a': 'b'
 		'c': 'd'
 	}
-	ams << {
+	ams << map{
 		'e': 'f'
 		'g': 'h'
 	}

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -445,7 +445,7 @@ fn (mut g Gen) gen_str_for_multi_return(info table.MultiReturn, styp string, str
 fn (mut g Gen) gen_str_for_struct(info table.Struct, styp string, str_fn_name string) {
 	// TODO: short it if possible
 	// generates all definitions of substructs
-	mut fnames2strfunc := {
+	mut fnames2strfunc := map{
 		'': ''
 	} // map[string]string // TODO vfmt bug
 	for field in info.fields {

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -20,7 +20,7 @@ pub const (
 )
 
 pub const (
-	external_module_dependencies_for_tool = {
+	external_module_dependencies_for_tool = map{
 		'vdoc': ['markdown']
 	}
 )

--- a/vlib/vweb/tests/vweb_test.v
+++ b/vlib/vweb/tests/vweb_test.v
@@ -208,7 +208,7 @@ fn testsuite_end() {
 	// It sends a request to the server to shutdown.
 	x := http.fetch('http://127.0.0.1:$sport/shutdown', 
 		method: .get
-		cookies: {
+		cookies: map{
 			'skey': 'superman'
 		}
 	) or {

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -19,7 +19,7 @@ pub const (
 	headers_close           = '$header_server$header_connection_close\r\n'
 	http_404                = 'HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\nContent-Length: 13\r\n${headers_close}404 Not Found'
 	http_500                = 'HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\n${headers_close}500 Internal Server Error'
-	mime_types              = {
+	mime_types              = map{
 		'.css':  'text/css; charset=utf-8'
 		'.gif':  'image/gif'
 		'.htm':  'text/html; charset=utf-8'


### PR DESCRIPTION
Follows on from #8608.

* Update docs
* checker: deprecate assigning struct literal to a map - this is important as it was intended to allow assigning an empty struct literal (i.e. an empty map) but doesn't actually check it's empty! (Use `= map{}` instead).
* fmt: use `map{key: value}` syntax for map literals

This doesn't deprecate the `{'key': value}` syntax yet as that will affect a lot of code.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
