### PR TITLE
cgen: modify escaped keywords to prevent collision with backend

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -813,7 +813,13 @@ fn (mut s Scanner) text_scan() token.Token {
 					}
 					s.error(at_error_msg)
 				}
-				return s.new_token(.name, name, name.len)
+				if name in ['continue', 'return', 'assert', 'atomic', 'const', 'continue', 'else',
+					'enum', 'false', 'for', 'goto', 'if', 'lock', 'shared', 'static', 'struct',
+					'true', 'union'] {
+					return s.new_token(.name, 'v_' + name, name.len + 2)
+				} else {
+					return s.new_token(.name, name, name.len)
+				}
 			}
 			/*
 			case `\r`:

--- a/vlib/v/scanner/scanner_test.v
+++ b/vlib/v/scanner/scanner_test.v
@@ -141,3 +141,8 @@ fn test_escape_string() {
 	assert '\x61' == 'a'
 	assert '\x62' == 'b'
 }
+
+fn test_escape_keywords() {
+	@continue := "Needs a prefix because it's a shared keyword w/ C"
+	assert @continue == "Needs a prefix because it's a shared keyword w/ C"
+}


### PR DESCRIPTION
Adds 'v_' prefix to escaped keywords (like @continue or @for), so that they don't generate invalid C code.

```v
@continue := 'bug'
....
```
 was becoming
```c
string continue = _SLIT("bug");
...
```

which failed to compile due to `continue` being a C keyword. A simple fix was prepending 'v_' to the token's name. If something else is desired, I can surely do that.