### PR TITLE
sokol: remove `.lib` extensions in `#pragma` directives

### DIFF
--- a/thirdparty/sokol/sokol_audio.h
+++ b/thirdparty/sokol/sokol_audio.h
@@ -487,12 +487,12 @@ inline void saudio_setup(const saudio_desc& desc) { return saudio_setup(&desc); 
     #include <synchapi.h>
     #if (defined(WINAPI_FAMILY_PARTITION) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP))
         #define SOKOL_WIN32_NO_MMDEVICE
-        #pragma comment (lib, "WindowsApp.lib")
+        #pragma comment (lib, "WindowsApp")
     #else
-        #pragma comment (lib, "kernel32.lib")
-        #pragma comment (lib, "ole32.lib")
+        #pragma comment (lib, "kernel32")
+        #pragma comment (lib, "ole32")
         #if defined(SOKOL_WIN32_NO_MMDEVICE)
-            #pragma comment (lib, "mmdevapi.lib")
+            #pragma comment (lib, "mmdevapi")
         #endif
     #endif
 #endif

--- a/thirdparty/sokol/sokol_gfx.h
+++ b/thirdparty/sokol/sokol_gfx.h
@@ -2538,12 +2538,12 @@ inline void sg_init_pass(sg_pass pass_id, const sg_pass_desc& desc) { return sg_
     #include <d3dcompiler.h>
     #ifdef _MSC_VER
     #if (defined(WINAPI_FAMILY_PARTITION) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP))
-    #pragma comment (lib, "WindowsApp.lib")
+    #pragma comment (lib, "WindowsApp")
     #else
-    #pragma comment (lib, "user32.lib")
-    #pragma comment (lib, "dxgi.lib")
-    #pragma comment (lib, "d3d11.lib")
-    #pragma comment (lib, "dxguid.lib")
+    #pragma comment (lib, "user32")
+    #pragma comment (lib, "dxgi")
+    #pragma comment (lib, "d3d11")
+    #pragma comment (lib, "dxguid")
     #endif
     #endif
 #elif defined(SOKOL_METAL)

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -277,7 +277,7 @@ $c_common_macros
 		#define __IRQHANDLER __declspec(naked)
 
 		#include <dbghelp.h>
-		#pragma comment(lib, "Dbghelp.lib")
+		#pragma comment(lib, "Dbghelp")
 
 		extern wchar_t **_wenviron;
 	#elif !defined(SRWLOCK_INIT)


### PR DESCRIPTION
fixes tcc on windows- we've needed to do this several times in the past, and this diff should probably be upstreamed to sokol soon to prevent things from breaking every time we update the headers.

Related: floooh/sokol#474

Closes vlang/tccbin#18

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
