### PR TITLE
gen: fix infinite loop when struct's ref field is pointing to self (#8632)

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -510,7 +510,14 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp string, str_fn_name st
 						g.auto_str_funcs.write('*')
 					}
 				}
-				g.auto_str_funcs.write(func)
+
+				// handle circular ref type of struct to the struct itself
+				if styp == field_styp {
+					g.auto_str_funcs.write('_SLIT("<circular>")')
+				} else {
+					g.auto_str_funcs.write(func)
+				}
+
 				if i < info.fields.len - 1 {
 					g.auto_str_funcs.write(',\n\t\t')
 				}

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -447,7 +447,7 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp string, str_fn_name st
 	// generates all definitions of substructs
 	mut fnames2strfunc := map{
 		'': ''
-	} // map[string]string // TODO vfmt bug
+	}
 	for field in info.fields {
 		sym := g.table.get_type_symbol(field.typ)
 		if !sym.has_method('str') {
@@ -510,7 +510,6 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp string, str_fn_name st
 						g.auto_str_funcs.write('*')
 					}
 				}
-
 				// handle circular ref type of struct to the struct itself
 				if styp == field_styp {
 					g.auto_str_funcs.write('_SLIT("<circular>")')

--- a/vlib/v/tests/string_interpolation_struct_test.v
+++ b/vlib/v/tests/string_interpolation_struct_test.v
@@ -50,3 +50,22 @@ fn test_struct_map_field_string_interpolation() {
 	assert s.contains("dict: {'a': 1, 'b': 2}")
 	assert s.ends_with('}')
 }
+
+struct Circular {
+mut:
+     next &Circular
+}
+
+fn test_stack_circular_elem_auto_str() {
+    mut elem := Circular{0}
+    elem.next = &elem
+    s := "$elem".replace("\n", "|")
+    assert s == "Circular{|    next: &<circular>|}"
+}
+
+fn test_heap_circular_elem_auto_str() {
+    mut elem := &Circular{0}
+    elem.next = elem
+    s := "$elem".replace("\n", "|")
+    assert s == "&Circular{|    next: &<circular>|}"
+}

--- a/vlib/v/tests/string_interpolation_struct_test.v
+++ b/vlib/v/tests/string_interpolation_struct_test.v
@@ -53,19 +53,19 @@ fn test_struct_map_field_string_interpolation() {
 
 struct Circular {
 mut:
-     next &Circular
+	next &Circular
 }
 
 fn test_stack_circular_elem_auto_str() {
-    mut elem := Circular{0}
-    elem.next = &elem
-    s := "$elem".replace("\n", "|")
-    assert s == "Circular{|    next: &<circular>|}"
+	mut elem := Circular{0}
+	elem.next = &elem
+	s := '$elem'.replace('\n', '|')
+	assert s == 'Circular{|    next: &<circular>|}'
 }
 
 fn test_heap_circular_elem_auto_str() {
-    mut elem := &Circular{0}
-    elem.next = elem
-    s := "$elem".replace("\n", "|")
-    assert s == "&Circular{|    next: &<circular>|}"
+	mut elem := &Circular{0}
+	elem.next = elem
+	s := '$elem'.replace('\n', '|')
+	assert s == '&Circular{|    next: &<circular>|}'
 }


### PR DESCRIPTION
Fixing a string representation of `struct` reference field referencing the parent `struct` itself (circular/self-reference) because it causes an infinite loop by default.

Closes #8632

> If you are fixing a bug, please add a test that covers it.

I'm not sure where exactly to add the test as `auto_str_methods.v` doesn't have a test file. Should I create it from scratch or is it tested somewhere else already?

> Before submitting a PR, please run `v test-all` .

Running in Docker container, the headers won't be present, obviously.

<details><summary>Here's the output</summary>

```
root@78d8a3f085ad:/opt/src# v test-all
> Running: "/opt/vlang/v examples/hello_world.v" took: 223 ms.

> Running: "/opt/vlang/v -o vtmp cmd/v" took: 1571 ms.

--------------------------------------------------------------------- Run `v vet` over most .v files --------------------------------------------------------------------
 OK    [4/4]   588.814 ms vlib/v                                                                                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Summary for running `v vet` over most .v files: 4 passed, 4 total. Runtime: 589 ms.

----------------------------------------------------------------- Run `v fmt -verify` over most .v files ----------------------------------------------------------------
 OK    [54/54]   260.555 ms vlib/x/websocket/                                                                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Summary for running `v fmt -verify` over most .v files: 54 passed, 54 total. Runtime: 1430 ms.

> Running: "/opt/vlang/v  -progress test-cleancode" took: 5967 ms.

---------------------------------------------------------------------- Run "v fmt" over all .v files --------------------------------------------------------------------
 SKIP  [135/988]     0.001 ms examples/wkhtmltopdf.v                                                                                                                     
 SKIP  [146/988]     0.002 ms vlib/builtin/array_eq_test.v                                                                                                               
 SKIP  [150/988]     0.001 ms vlib/builtin/bare/linuxsys_bare.v                                                                                                          
 SKIP  [168/988]     0.001 ms vlib/builtin/js/builtin.v                                                                                                                  
 SKIP  [169/988]     0.001 ms vlib/builtin/js/jsfns.js.v                                                                                                                 
 SKIP  [170/988]     0.001 ms vlib/builtin/js/jsfns_browser.js.v                                                                                                         
 SKIP  [171/988]     0.001 ms vlib/builtin/js/jsfns_node.js.v                                                                                                            
 SKIP  [204/988]     0.003 ms vlib/crypto/aes/const.v                                                                                                                    
 SKIP  [395/988]     0.002 ms vlib/picoev/picoev.v                                                                                                                       
 SKIP  [620/988]     0.001 ms vlib/v/gen/js/tests/life.v                                                                                                                 
 SKIP  [969/988]     0.001 ms vlib/x/ttf/ttf_test.v                                                                                                                      
 OK    [988/988]    12.215 ms vlib/x/websocket/websocket_test.v                                                                                                          
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Summary for running vfmt over V files: 977 passed, 11 skipped, 988 total. Runtime: 3495 ms.

> Running: "/opt/vlang/v  -progress test-fmt" took: 4020 ms.

---------------------------------------------------------------------------- testing all tests --------------------------------------------------------------------------
 FAIL  [ 20/381]  1207.304 ms vlib/clipboard/clipboard_test.v                                                                                                            
builder error: Header file <X11/Xlib.h>, needed for module `clipboard.x11` was not found. Please install a package with the X11 development headers, for example: `apt-get install libx11-dev`.

 FAIL  [ 57/381]  1176.421 ms vlib/net/http/cookie_test.v                                                                                                                
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

 FAIL  [ 58/381]  1196.583 ms vlib/net/http/http_httpbin_test.v                                                                                                          
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

 FAIL  [ 59/381]  1098.743 ms vlib/net/http/http_test.v                                                                                                                  
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

 FAIL  [ 62/381]  1147.705 ms vlib/net/http/status_test.v                                                                                                                
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

 FAIL  [ 69/381]   984.763 ms vlib/orm/orm_test.v                                                                                                                        
builder error: Header file "sqlite3.h", needed for module `sqlite` was not found. Please install the corresponding development headers.

 FAIL  [ 87/381]   899.579 ms vlib/sqlite/sqlite_test.v                                                                                                                  
builder error: Header file "sqlite3.h", needed for module `sqlite` was not found. Please install the corresponding development headers.

 FAIL  [297/381]  3289.253 ms vlib/v/tests/profile/profile_test.v                                                                                                        
/opt/vlang/vlib/v/tests/profile/profile_test.v:18: ✗ fn test_v_profile_works
   > assert res.exit_code == 0
     Left value: 1
    Right value: 0

 FAIL  [311/381] 76251.889 ms vlib/v/compiler_errors_test.v                                                                                                              
 OK    [  1/461]    78.182 ms vlib/v/parser/tests/anon_fn_return_type.vv
 OK    [  2/461]   117.155 ms vlib/v/parser/tests/c_struct_no_embed.vv
 OK    [  3/461]   148.768 ms vlib/v/parser/tests/array_pos_err.vv
 OK    [  4/461]   142.907 ms vlib/v/parser/tests/dec_use_as_value.vv
 OK    [  5/461]   129.441 ms vlib/v/parser/tests/duplicate_field_embed_err.vv
 OK    [  6/461]   130.452 ms vlib/v/parser/tests/duplicate_type_b.vv
 OK    [  7/461]   145.268 ms vlib/v/parser/tests/duplicate_type_a.vv
 OK    [  8/461]   106.743 ms vlib/v/parser/tests/duplicated_generic_err.vv
 OK    [  9/461]   124.016 ms vlib/v/parser/tests/expecting_assign_type_alias.vv
 OK    [ 10/461]    85.287 ms vlib/v/parser/tests/expr_evaluated_but_not_used_a.vv
 OK    [ 11/461]   445.622 ms vlib/v/parser/tests/expected_type_enum_err.vv
 OK    [ 12/461]   161.968 ms vlib/v/parser/tests/expr_evaluated_but_not_used_b.vv
 OK    [ 13/461]   115.435 ms vlib/v/parser/tests/expr_evaluated_but_not_used_d.vv
 OK    [ 14/461]   191.124 ms vlib/v/parser/tests/expr_evaluated_but_not_used_c.vv
 OK    [ 15/461]   151.086 ms vlib/v/parser/tests/expr_evaluated_but_not_used_if.vv
 OK    [ 16/461]   170.270 ms vlib/v/parser/tests/expr_evaluated_but_not_used_or.vv
 OK    [ 17/461]   147.380 ms vlib/v/parser/tests/fn_attributes_duplicate_multiple.vv
 OK    [ 18/461]   157.280 ms vlib/v/parser/tests/fn_attributes_duplicate_single.vv
 OK    [ 19/461]    90.784 ms vlib/v/parser/tests/fn_type_only_args_in_interfaces.vv
 OK    [ 20/461]   168.090 ms vlib/v/parser/tests/fn_attributes_empty_err.vv
 OK    [ 21/461]   151.873 ms vlib/v/parser/tests/fn_type_only_args_no_body.vv
 OK    [ 22/461]   235.023 ms vlib/v/parser/tests/fn_type_only_args_unknown_name.vv
 OK    [ 23/461]   140.505 ms vlib/v/parser/tests/fn_use_builtin_err.vv
 OK    [ 24/461]   160.206 ms vlib/v/parser/tests/for.vv
 OK    [ 25/461]   176.400 ms vlib/v/parser/tests/for_in_mut_index_of_array.vv
 OK    [ 26/461]   117.521 ms vlib/v/parser/tests/for_in_mut_key_of_map.vv
 OK    [ 27/461]   141.536 ms vlib/v/parser/tests/generic_lowercase_err.vv
 OK    [ 28/461]   155.939 ms vlib/v/parser/tests/inc_use_as_value.vv
 OK    [ 29/461]   227.306 ms vlib/v/parser/tests/interface_duplicate_method.vv
 OK    [ 30/461]   305.827 ms vlib/v/parser/tests/invalid_fn_decl_script_err.vv
 OK    [ 31/461]   182.815 ms vlib/v/parser/tests/invalid_recursive_struct1_err.vv
 OK    [ 32/461]   165.372 ms vlib/v/parser/tests/invalid_recursive_struct2_err.vv
 OK    [ 33/461]   138.905 ms vlib/v/parser/tests/long_generic_err.vv
 OK    [ 34/461]   159.385 ms vlib/v/parser/tests/map_init.vv
 OK    [ 35/461]   166.566 ms vlib/v/parser/tests/map_init_void.vv
 OK    [ 36/461]   166.163 ms vlib/v/parser/tests/map_init_void2.vv
 OK    [ 37/461]   171.695 ms vlib/v/parser/tests/match_range_dotdot_err.vv
 OK    [ 38/461]   165.184 ms vlib/v/parser/tests/method_decl_on_non_local_array.vv
 OK    [ 39/461]   153.617 ms vlib/v/parser/tests/method_decl_on_non_local_map.vv
 OK    [ 40/461]   168.164 ms vlib/v/parser/tests/method_decl_on_non_local_type.vv
 OK    [ 41/461]   167.532 ms vlib/v/parser/tests/multi_argumented_assign_err.vv
 OK    [ 42/461]   170.843 ms vlib/v/parser/tests/nested_unsafe_expr.vv
 OK    [ 43/461]   156.639 ms vlib/v/parser/tests/nested_unsafe_stmt.vv
 OK    [ 44/461]   106.084 ms vlib/v/parser/tests/operator_normal_fn.vv
 OK    [ 45/461]   246.268 ms vlib/v/parser/tests/or_default_missing.vv
 OK    [ 46/461]   447.898 ms vlib/v/parser/tests/prefix_first.vv
 OK    [ 47/461]   199.206 ms vlib/v/parser/tests/select_bad_key_1.vv
 OK    [ 48/461]   221.042 ms vlib/v/parser/tests/select_bad_key_2.vv
 OK    [ 49/461]    94.912 ms vlib/v/parser/tests/select_bad_key_3.vv
 OK    [ 50/461]   248.134 ms vlib/v/parser/tests/select_bad_key_4.vv
 OK    [ 51/461]   140.347 ms vlib/v/parser/tests/select_else_1.vv
 OK    [ 52/461]   132.205 ms vlib/v/parser/tests/select_else_2.vv
 OK    [ 53/461]   162.875 ms vlib/v/parser/tests/string_invalid_prefix_err.vv
 OK    [ 54/461]   243.630 ms vlib/v/parser/tests/struct_embed_duplicate.vv
 OK    [ 55/461]   152.074 ms vlib/v/parser/tests/struct_embed_unknown_module.vv
 OK    [ 56/461]   111.198 ms vlib/v/parser/tests/struct_embed_wrong_pos_long_err.vv
 OK    [ 57/461]   110.523 ms vlib/v/parser/tests/struct_embed_wrong_pos_short_err.vv
 OK    [ 58/461]   405.099 ms vlib/v/parser/tests/struct_module_section.vv
 OK    [ 59/461]   120.144 ms vlib/v/parser/tests/struct_update_err.vv
 OK    [ 60/461]   137.186 ms vlib/v/parser/tests/too_many_generics_err.vv
 OK    [ 61/461]   167.743 ms vlib/v/parser/tests/type_alias_existing_type_err.vv
 OK    [ 62/461]   165.873 ms vlib/v/parser/tests/type_alias_same_type_err.vv
 OK    [ 63/461]   143.419 ms vlib/v/parser/tests/uncomplete_module_call_err.vv
 OK    [ 64/461]   220.372 ms vlib/v/parser/tests/unexpected_keyword.vv
 OK    [ 65/461]   300.078 ms vlib/v/parser/tests/unnecessary_mut.vv
 OK    [ 66/461]   203.471 ms vlib/v/parser/tests/unnecessary_mut_2.vv
 OK    [ 67/461]  8318.759 ms vlib/v/parser/tests/array_init.vv
 OK    [ 68/461]   631.800 ms vlib/v/checker/tests/a_test_file_with_0_test_fns_test.vv
 OK    [ 69/461]   366.034 ms vlib/v/checker/tests/add_op_wrong_type_err.vv
 OK    [ 70/461]   287.381 ms vlib/v/checker/tests/alias_type_exists.vv
 OK    [ 71/461]   375.428 ms vlib/v/checker/tests/ambiguous_field_method_err.vv
 OK    [ 72/461]   433.024 ms vlib/v/checker/tests/ambiguous_function_call.vv
 OK    [ 73/461]  9124.000 ms vlib/v/parser/tests/const_index.vv
 OK    [ 74/461]   285.863 ms vlib/v/checker/tests/array_cmp_err.vv
 OK    [ 75/461]   468.159 ms vlib/v/checker/tests/any_int_float_ban_err.vv
 OK    [ 76/461]   378.147 ms vlib/v/checker/tests/array_builtin_redefinition.vv
 OK    [ 77/461]   142.430 ms vlib/v/checker/tests/array_declare_element_a.vv
 OK    [ 78/461]   122.215 ms vlib/v/checker/tests/array_declare_element_c.vv
 OK    [ 79/461]   181.641 ms vlib/v/checker/tests/array_declare_element_b.vv
 OK    [ 80/461]   389.293 ms vlib/v/checker/tests/array_element_type.vv
 OK    [ 81/461]   326.280 ms vlib/v/checker/tests/array_init_sum_type_without_init_value_and_len_err.vv
 OK    [ 82/461]   389.473 ms vlib/v/checker/tests/array_filter_fn_err.vv
 OK    [ 83/461]   273.687 ms vlib/v/checker/tests/array_insert_type_mismatch.vv
 OK    [ 84/461]   368.342 ms vlib/v/checker/tests/array_map_arg_mismatch.vv
 OK    [ 85/461]   375.233 ms vlib/v/checker/tests/array_map_fn_err.vv
 OK    [ 86/461]   276.256 ms vlib/v/checker/tests/array_prepend_type_mismatch.vv
 OK    [ 87/461]   401.734 ms vlib/v/checker/tests/arrow_op_wrong_left_type_err_b.vv
 OK    [ 88/461]   448.671 ms vlib/v/checker/tests/arrow_op_wrong_left_type_err_a.vv
 OK    [ 89/461]   501.815 ms vlib/v/checker/tests/arrow_op_wrong_right_type_err_a.vv
 OK    [ 90/461]   362.348 ms vlib/v/checker/tests/arrow_op_wrong_right_type_err_b.vv
 OK    [ 91/461]   344.674 ms vlib/v/checker/tests/assign_expr_type_err_a.vv
 OK    [ 92/461]   488.991 ms vlib/v/checker/tests/assign_expr_type_err_b.vv
 OK    [ 93/461]   481.596 ms vlib/v/checker/tests/assign_expr_type_err_d.vv
 OK    [ 94/461]   503.897 ms vlib/v/checker/tests/assign_expr_type_err_c.vv
 OK    [ 95/461]   419.942 ms vlib/v/checker/tests/assign_expr_type_err_e.vv
 OK    [ 96/461]   307.351 ms vlib/v/checker/tests/assign_expr_type_err_f.vv
 OK    [ 97/461]   321.426 ms vlib/v/checker/tests/assign_expr_type_err_g.vv
 OK    [ 98/461]   233.786 ms vlib/v/checker/tests/assign_expr_undefined_err_a.vv
 OK    [ 99/461]  8733.213 ms vlib/v/parser/tests/postfix_err.vv
 OK    [100/461]   101.804 ms vlib/v/checker/tests/assign_expr_undefined_err_c.vv
 OK    [101/461]   169.904 ms vlib/v/checker/tests/assign_expr_undefined_err_b.vv
 OK    [102/461]   460.926 ms vlib/v/checker/tests/assign_expr_type_err_i.vv
 OK    [103/461]   501.609 ms vlib/v/checker/tests/assign_expr_type_err_h.vv
 OK    [104/461]   161.179 ms vlib/v/checker/tests/assign_expr_undefined_err_d.vv
 OK    [105/461]   141.572 ms vlib/v/checker/tests/assign_expr_undefined_err_e.vv
 OK    [106/461]   135.365 ms vlib/v/checker/tests/assign_expr_undefined_err_f.vv
 OK    [107/461]   162.336 ms vlib/v/checker/tests/assign_expr_undefined_err_g.vv
 OK    [108/461]   276.107 ms vlib/v/checker/tests/assign_expr_unresolved_variables_err_chain.vv
 OK    [109/461]   324.391 ms vlib/v/checker/tests/assign_fn_call_on_left_side_err.vv
 OK    [110/461]   305.830 ms vlib/v/checker/tests/assign_multi_mismatch.vv
 OK    [111/461]   368.536 ms vlib/v/checker/tests/assign_multi_immutable_err.vv
 OK    [112/461]   159.628 ms vlib/v/checker/tests/assign_mut.vv
 OK    [113/461]   168.822 ms vlib/v/checker/tests/bin_lit_without_digit_err.vv
 OK    [114/461]   176.728 ms vlib/v/checker/tests/bin_lit_wrong_digit_err.vv
 OK    [115/461]   388.923 ms vlib/v/checker/tests/assign_sumtype2_err.vv
 OK    [116/461]   389.806 ms vlib/v/checker/tests/assign_sumtype_err.vv
 OK    [117/461]   355.925 ms vlib/v/checker/tests/bit_op_wrong_right_type_err.vv
 OK    [118/461]   396.273 ms vlib/v/checker/tests/bit_op_wrong_left_type_err.vv
 OK    [119/461]   378.771 ms vlib/v/checker/tests/blank_ident_invalid_use.vv
 OK    [120/461]   359.162 ms vlib/v/checker/tests/blank_modify.vv
 OK    [121/461]   276.273 ms vlib/v/checker/tests/bool_string_cast_err.vv
 OK    [122/461]   266.302 ms vlib/v/checker/tests/cannot_assign_array.vv
 OK    [123/461]   408.235 ms vlib/v/checker/tests/c_fn_surplus_args.vv
 OK    [124/461]   357.617 ms vlib/v/checker/tests/cannot_cast_to_alias.vv
 OK    [125/461]   358.949 ms vlib/v/checker/tests/cannot_cast_to_struct.vv
 OK    [126/461]   352.810 ms vlib/v/checker/tests/cast_err.vv
 OK    [127/461]   364.587 ms vlib/v/checker/tests/cast_string_err.vv
 OK    [128/461]   372.026 ms vlib/v/checker/tests/cast_string_with_byte_err.vv
 OK    [129/461]   427.897 ms vlib/v/checker/tests/check_generic_int_init.vv
 OK    [130/461]   599.338 ms vlib/v/checker/tests/chan_mut.vv
 OK    [131/461]   499.641 ms vlib/v/checker/tests/chan_ref.vv
 OK    [132/461]   312.009 ms vlib/v/checker/tests/comptime_call_no_unused_var.vv
 OK    [133/461]   659.661 ms vlib/v/checker/tests/comparing_typesymbol_to_a_type_should_not_compile.vv
 OK    [134/461]   327.146 ms vlib/v/checker/tests/comptime_field_selector_not_in_for_err.vv
 OK    [135/461]   406.257 ms vlib/v/checker/tests/comptime_call_method.vv
 OK    [136/461]   138.189 ms vlib/v/checker/tests/const_define_in_function_err.vv
 OK    [137/461]   306.168 ms vlib/v/checker/tests/comptime_field_selector_not_name_err.vv
 OK    [138/461]   368.667 ms vlib/v/checker/tests/const_field_add_err.vv
 OK    [139/461]   355.858 ms vlib/v/checker/tests/const_field_dec_err.vv
 OK    [140/461]   272.663 ms vlib/v/checker/tests/const_field_inc_err.vv
 OK    [141/461]   411.945 ms vlib/v/checker/tests/const_field_name_duplicate_err.vv
 OK    [142/461]   340.841 ms vlib/v/checker/tests/const_field_sub_err.vv
 SKIP  [143/461]     0.000 ms vlib/v/checker/tests/custom_comptime_define_if_flag.vv
 OK    [144/461]   414.962 ms vlib/v/checker/tests/ctdefine.vv
 OK    [145/461]   152.381 ms vlib/v/checker/tests/dec_lit_wrong_digit_err.vv
 OK    [146/461]   252.287 ms vlib/v/checker/tests/custom_comptime_define_error.vv
 OK    [147/461]   326.988 ms vlib/v/checker/tests/decompose_type_err.vv
 OK    [148/461]   355.490 ms vlib/v/checker/tests/div_mod_by_cast_zero_int_err.vv
 OK    [149/461]   417.931 ms vlib/v/checker/tests/div_op_wrong_type_err.vv
 OK    [150/461]   267.790 ms vlib/v/checker/tests/division_by_zero_float_err.vv
 OK    [151/461]   424.403 ms vlib/v/checker/tests/division_by_cast_zero_float_err.vv
 OK    [152/461]   387.630 ms vlib/v/checker/tests/division_by_zero_int_err.vv
 OK    [153/461]   344.451 ms vlib/v/checker/tests/enum_as_int_err.vv
 OK    [154/461]   341.068 ms vlib/v/checker/tests/enum_empty.vv
 OK    [155/461]   428.115 ms vlib/v/checker/tests/enum_err.vv
 OK    [156/461]   473.816 ms vlib/v/checker/tests/enum_field_name_duplicate_err.vv
 OK    [157/461]   431.653 ms vlib/v/checker/tests/enum_field_overflow.vv
 OK    [158/461]   443.922 ms vlib/v/checker/tests/enum_field_value_duplicate_err.vv
 OK    [159/461]   105.589 ms vlib/v/checker/tests/enum_single_letter.vv
 OK    [160/461]   426.044 ms vlib/v/checker/tests/enum_op_err.vv
 OK    [161/461]   476.644 ms vlib/v/checker/tests/enum_field_value_overflow.vv
 OK    [162/461]   203.182 ms vlib/v/checker/tests/error_with_comment_with_crlf_ending.vv
 OK    [163/461]   159.572 ms vlib/v/checker/tests/error_with_comment_with_lf_ending.vv
 OK    [164/461]   537.458 ms vlib/v/checker/tests/error_with_several_comments_with_crlf_ending.vv
 OK    [165/461]   423.945 ms vlib/v/checker/tests/filter_on_non_arr_err.vv
 OK    [166/461]   432.685 ms vlib/v/checker/tests/expression_should_return_an_option.vv
 OK    [167/461]   176.968 ms vlib/v/checker/tests/float_lit_exp_without_digit_err.vv
 OK    [168/461]   238.635 ms vlib/v/checker/tests/float_lit_exp_not_integer_err.vv
 OK    [169/461]   148.134 ms vlib/v/checker/tests/float_lit_too_many_points_err.vv
 OK    [170/461]   527.286 ms vlib/v/checker/tests/fixed_array_size_err.vv
 OK    [171/461]   423.283 ms vlib/v/checker/tests/float_modulo_err.vv
 OK    [172/461]   477.350 ms vlib/v/checker/tests/fn_args.vv
 OK    [173/461]   451.708 ms vlib/v/checker/tests/fn_call_no_body.vv
 OK    [174/461]   594.653 ms vlib/v/checker/tests/fn_type_exists.vv
 OK    [175/461]   522.619 ms vlib/v/checker/tests/fn_var.vv
 OK    [176/461]   755.940 ms vlib/v/checker/tests/for_in_index_optional.vv
 OK    [177/461]   544.077 ms vlib/v/checker/tests/for_in_index_type.vv
 OK    [178/461]   689.274 ms vlib/v/checker/tests/for_in_map_one_variable_err.vv
 OK    [179/461]   520.753 ms vlib/v/checker/tests/for_in_mut_val_type.vv
 OK    [180/461]   204.202 ms vlib/v/checker/tests/for_match_err.vv
 OK    [181/461]   717.460 ms vlib/v/checker/tests/for_in_range_not_match_type.vv
 OK    [182/461]   210.035 ms vlib/v/checker/tests/function_arg_mutable_err.vv
 OK    [183/461]   667.023 ms vlib/v/checker/tests/for_in_range_string_type.vv
 OK    [184/461]   244.131 ms vlib/v/checker/tests/function_arg_redefinition.vv
 OK    [185/461]   174.215 ms vlib/v/checker/tests/function_variadic_arg_non_final.vv
 OK    [186/461]   552.888 ms vlib/v/checker/tests/function_missing_return_type.vv
 OK    [187/461]   605.466 ms vlib/v/checker/tests/function_count_of_args_mismatch_err.vv
 OK    [188/461]   549.209 ms vlib/v/checker/tests/function_wrong_arg_type.vv
 OK    [189/461]   177.021 ms vlib/v/checker/tests/globals_error.vv
 OK    [190/461]   530.023 ms vlib/v/checker/tests/function_wrong_return_type.vv
 OK    [191/461]   148.978 ms vlib/v/checker/tests/go_expr.vv
 OK    [192/461]   564.294 ms vlib/v/checker/tests/generics_non_generic_fn_called_like_a_generic_one.vv
 OK    [193/461]   489.816 ms vlib/v/checker/tests/go_mut_arg.vv
 OK    [194/461]   457.304 ms vlib/v/checker/tests/go_mut_receiver.vv
 OK    [195/461]   516.952 ms vlib/v/checker/tests/goto_label.vv
 OK    [196/461]   225.213 ms vlib/v/checker/tests/hex_lit_without_digit_err.vv
 OK    [197/461]   241.466 ms vlib/v/checker/tests/hex_lit_wrong_digit_err.vv
 OK    [198/461]   522.709 ms vlib/v/checker/tests/if_expr_last_stmt.vv
 OK    [199/461]   499.990 ms vlib/v/checker/tests/if_expr_mismatch.vv
 OK    [200/461]   639.678 ms vlib/v/checker/tests/if_expr_no_else.vv
 OK    [201/461]   195.146 ms vlib/v/checker/tests/if_match_expr_err.vv
 OK    [202/461]   627.749 ms vlib/v/checker/tests/if_match_expr.vv
 OK    [203/461]   398.438 ms vlib/v/checker/tests/if_match_result.vv
 OK    [204/461]   527.381 ms vlib/v/checker/tests/immutable_arg.vv
 OK    [205/461]   553.925 ms vlib/v/checker/tests/immutable_array_field_assign.vv
 OK    [206/461]   596.600 ms vlib/v/checker/tests/immutable_array_field_shift.vv
 OK    [207/461]   586.136 ms vlib/v/checker/tests/immutable_array_struct_assign.vv
 OK    [208/461]   545.912 ms vlib/v/checker/tests/immutable_array_var.vv
 OK    [209/461]   710.903 ms vlib/v/checker/tests/immutable_array_struct_shift.vv
 OK    [210/461]   500.763 ms vlib/v/checker/tests/immutable_field.vv
 OK    [211/461]   353.967 ms vlib/v/checker/tests/immutable_interface_field.vv
 OK    [212/461]   488.881 ms vlib/v/checker/tests/immutable_field_postfix.vv
 OK    [213/461]   510.392 ms vlib/v/checker/tests/immutable_map_postfix.vv
 OK    [214/461]   325.116 ms vlib/v/checker/tests/immutable_rec.vv
 OK    [215/461]   352.162 ms vlib/v/checker/tests/immutable_var.vv
 OK    [216/461]   568.232 ms vlib/v/checker/tests/immutable_struct_postfix.vv
 OK    [217/461]   196.416 ms vlib/v/checker/tests/import_middle_err.vv
 OK    [218/461]   549.527 ms vlib/v/checker/tests/immutable_var_postfix.vv
 OK    [219/461]   194.994 ms vlib/v/checker/tests/import_mod_as_mod_err.vv
 OK    [220/461]   555.410 ms vlib/v/checker/tests/import_duplicate_err.vv
 OK    [221/461]   245.330 ms vlib/v/checker/tests/import_mod_sub_as_sub_err.vv
 OK    [222/461]    97.719 ms vlib/v/checker/tests/import_multiple_modules_err.vv
 OK    [223/461]   205.108 ms vlib/v/checker/tests/import_not_same_line_err.vv
 OK    [224/461]   283.463 ms vlib/v/checker/tests/import_not_found_err.vv
 OK    [225/461]   169.051 ms vlib/v/checker/tests/import_symbol_empty.vv
 OK    [226/461]   427.300 ms vlib/v/checker/tests/import_symbol_fn_err.vv
 OK    [227/461] 11925.442 ms vlib/v/checker/tests/const_field_name_snake_case.vv
 OK    [228/461]   772.291 ms vlib/v/checker/tests/import_symbol_const_private_err.vv
 OK    [229/461]   111.971 ms vlib/v/checker/tests/import_symbol_invalid.vv
 OK    [230/461]   468.225 ms vlib/v/checker/tests/import_symbol_fn_private_err.vv
 OK    [231/461]   180.345 ms vlib/v/checker/tests/import_symbol_unclosed.vv
 OK    [232/461]   289.167 ms vlib/v/checker/tests/import_symbol_type_err.vv
 OK    [233/461]   172.474 ms vlib/v/checker/tests/import_syntax_err.vv
 OK    [234/461]   387.550 ms vlib/v/checker/tests/import_symbol_type_private_err.vv
 OK    [235/461]   286.563 ms vlib/v/checker/tests/in_mismatch_type.vv
 OK    [236/461]   422.921 ms vlib/v/checker/tests/incorrect_for_in_name_variable.vv
 OK    [237/461]   379.816 ms vlib/v/checker/tests/incorrect_name_alias_type.vv
 OK    [238/461]   405.430 ms vlib/v/checker/tests/incorrect_name_enum.vv
 OK    [239/461]   430.256 ms vlib/v/checker/tests/incorrect_name_enum_field.vv
 OK    [240/461]   395.904 ms vlib/v/checker/tests/incorrect_name_fn_type.vv
 OK    [241/461]   398.488 ms vlib/v/checker/tests/incorrect_name_function.vv
 OK    [242/461]   274.244 ms vlib/v/checker/tests/incorrect_name_interface.vv
 OK    [243/461]   461.989 ms vlib/v/checker/tests/incorrect_name_interface_method.vv
 OK    [244/461]   112.769 ms vlib/v/checker/tests/incorrect_name_struct.vv
 OK    [245/461]   452.142 ms vlib/v/checker/tests/incorrect_name_module.vv
 OK    [246/461]   307.759 ms vlib/v/checker/tests/incorrect_name_sum_type.vv
 OK    [247/461]   390.203 ms vlib/v/checker/tests/incorrect_name_struct_field.vv
 OK    [248/461]   343.737 ms vlib/v/checker/tests/incorrect_name_variable.vv
 OK    [249/461]   366.213 ms vlib/v/checker/tests/index_expr.vv
 OK    [250/461]   390.207 ms vlib/v/checker/tests/infix_err.vv
 OK    [251/461]   338.599 ms vlib/v/checker/tests/int_modulo_by_zero_err.vv
 OK    [252/461]   283.935 ms vlib/v/checker/tests/interface_implementing_interface.vv
 OK    [253/461]   290.985 ms vlib/v/checker/tests/interpolation_recursive_str_err.vv
 OK    [254/461]   259.340 ms vlib/v/checker/tests/invert_other_types_bits_error.vv
 OK    [255/461]   350.726 ms vlib/v/checker/tests/is_type_invalid.vv
 OK    [256/461]   428.674 ms vlib/v/checker/tests/is_type_not_exist.vv
 OK    [257/461]   446.108 ms vlib/v/checker/tests/labelled_break_continue.vv
 OK    [258/461]   414.265 ms vlib/v/checker/tests/left_shift_err.vv
 OK    [259/461]   711.332 ms vlib/v/checker/tests/lock_already_locked.vv
 OK    [260/461]   611.041 ms vlib/v/checker/tests/lock_already_rlocked.vv
 OK    [261/461]   490.021 ms vlib/v/checker/tests/lock_const.vv
 OK    [262/461]   560.010 ms vlib/v/checker/tests/lock_needed.vv
 OK    [263/461]   409.731 ms vlib/v/checker/tests/main_and_script_err.vv
 OK    [264/461]   723.657 ms vlib/v/checker/tests/lock_nonshared.vv
 OK    [265/461]   580.046 ms vlib/v/checker/tests/main_args_err.vv
 OK    [266/461]   649.422 ms vlib/v/checker/tests/main_called_err.vv
 OK    [267/461]   693.358 ms vlib/v/checker/tests/main_no_body_err.vv
 OK    [268/461]   630.971 ms vlib/v/checker/tests/main_return_err.vv
 OK    [269/461]   441.968 ms vlib/v/checker/tests/map_init_key_duplicate_err.vv
 OK    [270/461]   462.489 ms vlib/v/checker/tests/map_init_wrong_type.vv
 OK    [271/461]   555.625 ms vlib/v/checker/tests/map_ops.vv
 OK    [272/461]   514.998 ms vlib/v/checker/tests/map_unknown_value.vv
 OK    [273/461]   531.406 ms vlib/v/checker/tests/match_duplicate_branch.vv
 OK    [274/461]   719.139 ms vlib/v/checker/tests/match_else_last_expr.vv
 OK    [275/461]   490.004 ms vlib/v/checker/tests/match_expr_and_expected_type_error.vv
 OK    [276/461]   365.943 ms vlib/v/checker/tests/match_expr_else.vv
 OK    [277/461]   417.412 ms vlib/v/checker/tests/match_invalid_type.vv
 OK    [278/461]   356.861 ms vlib/v/checker/tests/match_return_mismatch_type_err.vv
 OK    [279/461]   282.777 ms vlib/v/checker/tests/match_sumtype_multiple_types.vv
 OK    [280/461]   385.706 ms vlib/v/checker/tests/match_undefined_cond.vv
 OK    [281/461] 10183.271 ms vlib/v/checker/tests/import_unused_warning.vv
 OK    [282/461]   415.345 ms vlib/v/checker/tests/method_array_slice.vv
 OK    [283/461]   315.054 ms vlib/v/checker/tests/method_op_alias_err.vv
 OK    [284/461]   348.835 ms vlib/v/checker/tests/method_generic_infer_err.vv
 OK    [285/461]   414.356 ms vlib/v/checker/tests/method_op_err.vv
 OK    [286/461] 10527.869 ms vlib/v/checker/tests/incorrect_name_const.vv
 SKIP  [287/461]     0.000 ms vlib/v/checker/tests/missing_c_lib_header_1.vv
 SKIP  [288/461]     0.000 ms vlib/v/checker/tests/missing_c_lib_header_with_explanation_2.vv
 OK    [289/461]   366.519 ms vlib/v/checker/tests/method_wrong_arg_type.vv
 OK    [290/461]   528.747 ms vlib/v/checker/tests/minus_op_wrong_type_err.vv
 OK    [291/461]   223.358 ms vlib/v/checker/tests/module_multiple_names_err.vv
 OK    [292/461]   364.681 ms vlib/v/checker/tests/mismatched_ptr_op_ptr.vv
 OK    [293/461]   169.795 ms vlib/v/checker/tests/module_not_at_same_line_err.vv
 OK    [294/461]   159.261 ms vlib/v/checker/tests/module_syntax_err.vv
 OK    [295/461]   420.247 ms vlib/v/checker/tests/mod_op_wrong_type_err.vv
 OK    [296/461]   157.436 ms vlib/v/checker/tests/multi_names_err.vv
 OK    [297/461]   339.093 ms vlib/v/checker/tests/multi_const_field_name_duplicate_err.vv
 OK    [298/461]   397.281 ms vlib/v/checker/tests/mul_op_wrong_type_err.vv
 OK    [299/461]   333.572 ms vlib/v/checker/tests/mut_arg.vv
 OK    [300/461]   163.623 ms vlib/v/checker/tests/mut_int.vv
 OK    [301/461]   359.666 ms vlib/v/checker/tests/mut_array_get_element_address_err.vv
 OK    [302/461]   163.813 ms vlib/v/checker/tests/mut_receiver.vv
 OK    [303/461]   334.396 ms vlib/v/checker/tests/mut_map_get_value_address_err.vv
 OK    [304/461]   397.459 ms vlib/v/checker/tests/nested_aliases.vv
 OK    [305/461]   385.507 ms vlib/v/checker/tests/no_interface_instantiation_b.vv
 OK    [306/461]   440.318 ms vlib/v/checker/tests/no_interface_instantiation_a.vv
 OK    [307/461]   439.791 ms vlib/v/checker/tests/no_interface_str.vv
 OK    [308/461]   459.562 ms vlib/v/checker/tests/no_interface_instantiation_c.vv
 OK    [309/461]   426.970 ms vlib/v/checker/tests/no_main_mod.vv
 OK    [310/461]   247.517 ms vlib/v/checker/tests/no_method_on_interface_propagation.vv
 OK    [311/461]   314.793 ms vlib/v/checker/tests/no_main_println_err.vv
 OK    [312/461]   138.588 ms vlib/v/checker/tests/oct_lit_without_digit_err.vv
 OK    [313/461]   456.187 ms vlib/v/checker/tests/non_matching_functional_args.vv
 OK    [314/461]   134.911 ms vlib/v/checker/tests/oct_lit_wrong_digit_err.vv
 OK    [315/461]   382.715 ms vlib/v/checker/tests/none_type_cast_err.vv
 OK    [316/461]   372.013 ms vlib/v/checker/tests/optional_index_err.vv
 OK    [317/461]   424.647 ms vlib/v/checker/tests/optional_method_err.vv
 OK    [318/461]   462.377 ms vlib/v/checker/tests/optional_or_block_mismatch.vv
 OK    [319/461]   285.897 ms vlib/v/checker/tests/optional_or_block_none_err.vv
 OK    [320/461]   396.106 ms vlib/v/checker/tests/optional_or_block_returns_value_of_incompatible_type.vv
 OK    [321/461]   469.575 ms vlib/v/checker/tests/optional_propagate_nested.vv
 OK    [322/461]   441.772 ms vlib/v/checker/tests/optional_type_call_err.vv
 OK    [323/461]   399.543 ms vlib/v/checker/tests/optional_void_called_as_normal.vv
 OK    [324/461]   424.023 ms vlib/v/checker/tests/orm_empty_struct.vv
 OK    [325/461]   442.232 ms vlib/v/checker/tests/or_err.vv
 OK    [326/461]   314.417 ms vlib/v/checker/tests/overflow_int_err.vv
 OK    [327/461]   385.521 ms vlib/v/checker/tests/overload_return_type.vv
 OK    [328/461]   426.058 ms vlib/v/checker/tests/plus_or_minus_assign_one_err.vv
 OK    [329/461]   345.264 ms vlib/v/checker/tests/pointer_ops.vv
 OK    [330/461]   377.274 ms vlib/v/checker/tests/prefix_err.vv
 OK    [331/461]   380.142 ms vlib/v/checker/tests/ptr_assign.vv
 OK    [332/461]   454.411 ms vlib/v/checker/tests/prefix_expr_decl_assign_err.vv
 OK    [333/461]   362.027 ms vlib/v/checker/tests/receiver_unknown_type_single_letter.vv
 OK    [334/461]   341.098 ms vlib/v/checker/tests/reference_return.vv
 OK    [335/461]   470.914 ms vlib/v/checker/tests/reference_field_must_be_initialized.vv
 OK    [336/461]   385.403 ms vlib/v/checker/tests/return_duplicate_with_none_err_a.vv
 OK    [337/461]   442.485 ms vlib/v/checker/tests/return_duplicate_with_none_err_b.vv
 OK    [338/461]   488.233 ms vlib/v/checker/tests/return_missing_comp_if.vv
 OK    [339/461]   419.913 ms vlib/v/checker/tests/return_missing_comp_if_nested.vv
 OK    [340/461]   390.824 ms vlib/v/checker/tests/return_missing_if_else_simple.vv
 OK    [341/461]   501.571 ms vlib/v/checker/tests/return_missing_if_match.vv
 OK    [342/461]   398.059 ms vlib/v/checker/tests/return_missing_match_if.vv
 OK    [343/461]   449.804 ms vlib/v/checker/tests/return_missing_match_simple.vv
 OK    [344/461]   287.337 ms vlib/v/checker/tests/return_missing_simple.vv
 OK    [345/461]   420.459 ms vlib/v/checker/tests/return_missing_nested.vv
 OK    [346/461]   387.712 ms vlib/v/checker/tests/return_optional_err.vv
 OK    [347/461]   410.798 ms vlib/v/checker/tests/return_ref_as_no_ref_bug.vv
 OK    [348/461]   415.271 ms vlib/v/checker/tests/return_type.vv
 OK    [349/461]  9023.376 ms vlib/v/checker/tests/mut_args_warning.vv
 OK    [350/461]  9705.905 ms vlib/v/checker/tests/return_working_comp_if_nested.vv
 OK    [351/461]  9872.334 ms vlib/v/checker/tests/return_working_comp_if.vv
 OK    [352/461] 10344.170 ms vlib/v/checker/tests/return_working_if_match.vv
 OK    [353/461] 10157.425 ms vlib/v/checker/tests/return_working_match_if.vv
 OK    [354/461]  8767.982 ms vlib/v/checker/tests/return_working_nested.vv
 OK    [355/461]   340.919 ms vlib/v/checker/tests/rshift_op_wrong_left_type_err.vv
 OK    [356/461]  9294.567 ms vlib/v/checker/tests/return_working_simple.vv
 OK    [357/461]    94.834 ms vlib/v/checker/tests/selector_expr_assign.vv
 OK    [358/461]  8744.167 ms vlib/v/checker/tests/return_working_two_if.vv
 OK    [359/461]   409.019 ms vlib/v/checker/tests/rshift_op_wrong_right_type_err.vv
 OK    [360/461]   307.317 ms vlib/v/checker/tests/shift_op_wrong_left_type_err.vv
 OK    [361/461]   565.271 ms vlib/v/checker/tests/shared_bad_args.vv
 OK    [362/461]   650.479 ms vlib/v/checker/tests/selector_expr_optional_err.vv
 OK    [363/461]   398.200 ms vlib/v/checker/tests/shift_op_wrong_right_type_err.vv
 OK    [364/461]   117.386 ms vlib/v/checker/tests/static_vars_in_translated_mode.vv
 OK    [365/461]   440.240 ms vlib/v/checker/tests/sort_method_called_on_immutable_receiver.vv
 OK    [366/461]   458.282 ms vlib/v/checker/tests/short_struct_wrong_number.vv
 OK    [367/461]   331.727 ms vlib/v/checker/tests/str_method_0_arguments.vv
 OK    [368/461]   176.375 ms vlib/v/checker/tests/string_char_null_err.vv
 OK    [369/461]   168.190 ms vlib/v/checker/tests/string_escape_u_err_a.vv
 OK    [370/461]   141.406 ms vlib/v/checker/tests/string_escape_u_err_b.vv
 OK    [371/461]   442.109 ms vlib/v/checker/tests/str_method_return_string.vv
 OK    [372/461]   142.811 ms vlib/v/checker/tests/string_escape_x_err_a.vv
 OK    [373/461]   166.715 ms vlib/v/checker/tests/string_escape_x_err_b.vv
 OK    [374/461]   123.511 ms vlib/v/checker/tests/string_interpolation_invalid_fmt.vv
 OK    [375/461]   365.093 ms vlib/v/checker/tests/string_index_non_int_err.vv
 OK    [376/461]   416.987 ms vlib/v/checker/tests/string_index_assign_error.vv
 OK    [377/461]   452.275 ms vlib/v/checker/tests/string_interpolation_wrong_fmt.vv
 OK    [378/461]  8596.497 ms vlib/v/checker/tests/return_working_unsafe.vv
 OK    [379/461]   379.570 ms vlib/v/checker/tests/struct_assigned_to_pointer_to_struct.vv
 OK    [380/461]   405.588 ms vlib/v/checker/tests/struct_cast_to_struct_generic_err.vv
 OK    [381/461]   347.139 ms vlib/v/checker/tests/struct_cast_to_struct_mut_err_a.vv
 OK    [382/461]   352.160 ms vlib/v/checker/tests/struct_cast_to_struct_mut_err_b.vv
 OK    [383/461]   380.336 ms vlib/v/checker/tests/struct_cast_to_struct_pub_err_a.vv
 OK    [384/461]   333.830 ms vlib/v/checker/tests/struct_cast_to_struct_pub_err_b.vv
 OK    [385/461]   378.888 ms vlib/v/checker/tests/struct_embed_invalid_type.vv
 OK    [386/461]   315.863 ms vlib/v/checker/tests/struct_pub_field.vv
 OK    [387/461]   451.334 ms vlib/v/checker/tests/struct_field_name_duplicate_err.vv
 OK    [388/461]   450.280 ms vlib/v/checker/tests/struct_init_update_type_err.vv
 OK    [389/461]   398.204 ms vlib/v/checker/tests/struct_required_field.vv
 OK    [390/461]   341.650 ms vlib/v/checker/tests/struct_unknown_field.vv
 OK    [391/461]   428.242 ms vlib/v/checker/tests/struct_type_cast_err.vv
 OK    [392/461]   354.648 ms vlib/v/checker/tests/struct_unneeded_default.vv
 OK    [393/461]   466.721 ms vlib/v/checker/tests/sum.vv
 OK    [394/461]   276.338 ms vlib/v/checker/tests/sum_type_infix_err.vv
 OK    [395/461]   501.220 ms vlib/v/checker/tests/sum_type_assign_non_variant_err.vv
 OK    [396/461]   486.284 ms vlib/v/checker/tests/sum_type_exists.vv
 OK    [397/461]   420.978 ms vlib/v/checker/tests/sum_type_multiple_type_define.vv
 OK    [398/461]   296.579 ms vlib/v/checker/tests/sum_type_ref_variant_err.vv
 OK    [399/461]   475.413 ms vlib/v/checker/tests/sum_type_mutable_cast_err.vv
 OK    [400/461]   121.969 ms vlib/v/checker/tests/trailing_comma_struct_attr.vv
 OK    [401/461]   390.950 ms vlib/v/checker/tests/test_functions_should_not_return_test.vv
 OK    [402/461]   242.582 ms vlib/v/checker/tests/typedef_attr_v_struct_err.vv
 OK    [403/461]   291.364 ms vlib/v/checker/tests/unexpected_or.vv
 OK    [404/461]   125.111 ms vlib/v/checker/tests/unfinished_string.vv
 OK    [405/461]   463.014 ms vlib/v/checker/tests/type_cast_optional_err.vv
 OK    [406/461]   373.544 ms vlib/v/checker/tests/unexpected_or_propagate.vv
 OK    [407/461]   244.164 ms vlib/v/checker/tests/unimplemented_interface_c.vv
 OK    [408/461]   352.853 ms vlib/v/checker/tests/unimplemented_interface_b.vv
 OK    [409/461]   375.349 ms vlib/v/checker/tests/unimplemented_interface_a.vv
 OK    [410/461]   372.197 ms vlib/v/checker/tests/unimplemented_interface_d.vv
 OK    [411/461]   288.094 ms vlib/v/checker/tests/unimplemented_interface_e.vv
 OK    [412/461]   367.908 ms vlib/v/checker/tests/unimplemented_interface_h.vv
 OK    [413/461]   393.941 ms vlib/v/checker/tests/unimplemented_interface_f.vv
 OK    [414/461]   376.161 ms vlib/v/checker/tests/unimplemented_interface_i.vv
 OK    [415/461]   369.273 ms vlib/v/checker/tests/unimplemented_interface_j.vv
 OK    [416/461]   250.670 ms vlib/v/checker/tests/union_unsafe_fields.vv
 OK    [417/461]   299.111 ms vlib/v/checker/tests/unknown_array_element_type_b.vv
 OK    [418/461]   252.337 ms vlib/v/checker/tests/unknown_comptime_expr.vv
 OK    [419/461]   427.614 ms vlib/v/checker/tests/unknown_as_type.vv
 OK    [420/461]   303.897 ms vlib/v/checker/tests/unknown_field.vv
 OK    [421/461]   304.628 ms vlib/v/checker/tests/unknown_generic_type.vv
 OK    [422/461]   241.244 ms vlib/v/checker/tests/unknown_method.vv
 OK    [423/461]   345.489 ms vlib/v/checker/tests/unknown_struct_field_suggest_name.vv
 OK    [424/461]   375.746 ms vlib/v/checker/tests/unknown_method_suggest_name.vv
 OK    [425/461]   380.979 ms vlib/v/checker/tests/unknown_struct_name.vv
 OK    [426/461]   415.479 ms vlib/v/checker/tests/unknown_var_assign.vv
 OK    [427/461]   433.998 ms vlib/v/checker/tests/unreachable_code.vv
 OK    [428/461]   504.502 ms vlib/v/checker/tests/unnecessary_parenthesis.vv
 OK    [429/461]   529.689 ms vlib/v/checker/tests/unsafe_c_calls_should_be_checked.vv
 OK    [430/461]   426.546 ms vlib/v/checker/tests/unsafe_required.vv
 OK    [431/461]   638.931 ms vlib/v/checker/tests/unsafe_pointer_arithmetic_should_be_checked.vv
 OK    [432/461]   423.277 ms vlib/v/checker/tests/unwrapped_optional_infix.vv
 OK    [433/461]   171.413 ms vlib/v/checker/tests/var_eval_not_used.vv
 OK    [434/461]   169.488 ms vlib/v/checker/tests/var_eval_not_used_scope.vv
 OK    [435/461]   427.701 ms vlib/v/checker/tests/var_duplicate_const.vv
 OK    [436/461]   669.597 ms vlib/v/checker/tests/use_deprecated_function_warning.vv
 OK    [437/461]   263.332 ms vlib/v/checker/tests/void_optional_err.vv
 OK    [438/461]   503.766 ms vlib/v/checker/tests/var_used_before_declaration.vv
 OK    [439/461]   536.954 ms vlib/v/checker/tests/void_fn_as_value.vv
 OK    [440/461]   577.660 ms vlib/v/checker/tests/void_function_assign_to_string.vv
 OK    [441/461]   523.037 ms vlib/v/checker/tests/warnings_for_string_c2v_calls.vv
 OK    [442/461]   178.989 ms vlib/v/scanner/tests/bin_consecutively_separator_err.vv
 OK    [443/461]   475.699 ms vlib/v/checker/tests/wrong_propagate_ret_type.vv
 OK    [444/461]   866.260 ms vlib/v/checker/tests/vweb_routing_checks.vv
 OK    [445/461]   199.564 ms vlib/v/scanner/tests/bin_separator_in_front_err.vv
 OK    [446/461]   193.818 ms vlib/v/scanner/tests/hex_consecutively_separator_err.vv
 OK    [447/461]   218.792 ms vlib/v/scanner/tests/hex_separator_in_front_err.vv
 OK    [448/461]   219.848 ms vlib/v/scanner/tests/oct_consecutively_separator_err.vv
 OK    [449/461]   518.189 ms vlib/v/scanner/tests/dec_consecutively_separator_err.vv
 SKIP  [450/461]     0.000 ms vlib/v/checker/tests/custom_comptime_define_if_flag.vv
 SKIP  [451/461]     0.000 ms vlib/v/checker/tests/custom_comptime_define_if_flag.vv
 OK    [452/461]   160.235 ms vlib/v/scanner/tests/oct_separator_in_front_err.vv
 OK    [453/461]   147.262 ms vlib/v/checker/tests/globals/assign_no_type.vv
 OK    [454/461]   249.799 ms vlib/v/checker/tests/globals/assign_no_value.vv
 OK    [455/461]   869.740 ms vlib/v/checker/tests/globals_error.vv
 OK    [456/461]   588.752 ms vlib/v/checker/tests/globals/incorrect_name_global.vv
 OK    [457/461]   199.652 ms vlib/v/checker/tests/globals/no_type.vv
 OK    [458/461]  1227.308 ms vlib/v/checker/tests/custom_comptime_define_error.vv
 FAIL  [459/461]  2843.253 ms vlib/v/checker/tests/vweb_tmpl_used_var.vv
============
failed cmd: /opt/vlang/v -prod vlib/v/checker/tests/vweb_tmpl_used_var.vv
expected_out_path: vlib/v/checker/tests/vweb_tmpl_used_var.out
============
expected:

============
found:
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.
============

diff: 
--- /root/.cache/450961081706608.expected.txt	2021-02-08 21:41:20.012504066 +0000
+++ /root/.cache/450961081706608.found.txt	2021-02-08 21:41:20.012504066 +0000
@@ -0,0 +1 @@
+builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.
\ No newline at end of file
============

 OK    [460/461]   596.701 ms vlib/v/checker/tests/modules/overload_return_type
 OK    [461/461]   814.026 ms vlib/v/checker/tests/run/unused_variable_warning.vv
--------------------------------------------------------------------------------
Summary for all tests: 1 failed, 455 passed, 5 skipped, 461 total. Runtime: 75565 ms.

 FAIL  [376/381]  1229.713 ms vlib/vweb/tests/vweb_test.v                                                                                                                
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

 SKIP  [377/381]     0.001 ms vlib/x/ttf/ttf_test.v                                                                                                                      
 FAIL  [379/381]  2806.134 ms vlib/v/tests/valgrind/valgrind_test.v                                                                                                      
----------------------- memory leak checking with valgrind ---------------------
 FAIL  [1/6]   460.662 ms valgrind could not be executed
 SKIP  [2/6]   414.921 ms vlib/v/tests/valgrind/option_simple.v
 SKIP  [3/6]   350.173 ms vlib/v/tests/valgrind/fn_returning_string_param.v
 SKIP  [4/6]   554.362 ms vlib/v/tests/valgrind/fn_with_return_should_free_local_vars.v
 SKIP  [5/6]   279.829 ms vlib/v/tests/valgrind/struct_field.v
 SKIP  [6/6]     0.000 ms vlib/v/tests/valgrind/option_reassigned.v
--------------------------------------------------------------------------------
Summary for memory leak checking with valgrind: 1 failed, 5 skipped, 6 total. Runtime: 2060 ms.

 FAIL  [381/381]   982.205 ms vlib/x/websocket/websocket_test.v                                                                                                          
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.


-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Summary for testing all tests: 12 failed, 368 passed, 1 skipped, 381 total. Runtime: 109244 ms.


WARNING: failed 12 times.

> Running: "/opt/vlang/v  -progress test-self" took: 109637 ms.

------------------------------------------------------------------------- Building cmd/tools ... ------------------------------------------------------------------------
v compiler args: "-progress -W "
 FAIL  [ 8/36]  1165.973 ms cmd/tools/gen_vc.v                                                                                                                           
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

 FAIL  [21/36]  1175.719 ms cmd/tools/vpm.v                                                                                                                              
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

 OK    [36/36]   800.014 ms cmd/tools/vvet                                                                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Summary for building cmd/tools: 2 failed, 34 passed, 36 total. Runtime: 6841 ms.

> Running: "/opt/vlang/v  -progress -W build-tools" took: 8564 ms.

-------------------------------------------------------------------------- Building examples ... ------------------------------------------------------------------------
v compiler args: "-progress -W "
 FAIL  [ 5/78]   899.015 ms examples/2048/2048.v                                                                                                                         
/opt/vlang/thirdparty/stb_image/stbi.o not found, building it in /root/.vmodules/cache/9f/9fd3364128055d0dfe8ea5c99b7afa30.o ...

==================
In file included from /tmp/v/test_session_450981150748986/2048.17661888709844334297.tmp.c:766:
/opt/vlang/thirdparty/sokol/sokol_app.h:1345:14: fatal error: X11/Xlib.h: No such file or directory
     #include <X11/Xlib.h>
              ^~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [ 6/78]   206.658 ms examples/database/mysql.v                                                                                                                    
vlib/mysql/_cdefs_nix.c.v:3:3: error: Cannot find "mysqlclient" pkgconfig file
    1 | module mysql
    2 | 
    3 | #pkgconfig mysqlclient
      |   ~~~~~~~~~~~~~~~~~~~~
    4 | #include <mysql.h> # Please install the mysqlclient development headers

 FAIL  [ 9/78]   611.953 ms examples/database/sqlite.v                                                                                                                   
builder error: Header file "sqlite3.h", needed for module `sqlite` was not found. Please install the corresponding development headers.

 FAIL  [10/78]  1107.863 ms examples/concurrency/concurrency_http.v                                                                                                      
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

 FAIL  [13/78]  1068.723 ms examples/fetch.v                                                                                                                             
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

 FAIL  [14/78]   849.346 ms examples/fireworks/fireworks.v                                                                                                               
==================
In file included from /tmp/v/test_session_450981150748986/fireworks.5271503579569507649.tmp.c:758:
/opt/vlang/thirdparty/sokol/sokol_app.h:1345:14: fatal error: X11/Xlib.h: No such file or directory
     #include <X11/Xlib.h>
              ^~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [16/78]   826.453 ms examples/flappylearning/game.v                                                                                                               
==================
In file included from /tmp/v/test_session_450981150748986/game.8334713550263076550.tmp.c:763:
/opt/vlang/thirdparty/sokol/sokol_app.h:1345:14: fatal error: X11/Xlib.h: No such file or directory
     #include <X11/Xlib.h>
              ^~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [17/78]   738.590 ms examples/gg/polygons.v                                                                                                                       
==================
In file included from /tmp/v/test_session_450981150748986/polygons.11304653090780300010.tmp.c:716:
/opt/vlang/thirdparty/sokol/sokol_app.h:1345:14: fatal error: X11/Xlib.h: No such file or directory
     #include <X11/Xlib.h>
              ^~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [18/78]   793.155 ms examples/gg/raven_text_rendering.v                                                                                                           
==================
In file included from /tmp/v/test_session_450981150748986/raven_text_rendering.6325765571267871262.tmp.c:716:
/opt/vlang/thirdparty/sokol/sokol_app.h:1345:14: fatal error: X11/Xlib.h: No such file or directory
     #include <X11/Xlib.h>
              ^~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [20/78]   818.361 ms examples/gg/rectangles.v                                                                                                                     
==================
In file included from /tmp/v/test_session_450981150748986/rectangles.6665882881748230988.tmp.c:716:
/opt/vlang/thirdparty/sokol/sokol_app.h:1345:14: fatal error: X11/Xlib.h: No such file or directory
     #include <X11/Xlib.h>
              ^~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [21/78]   822.686 ms examples/gg/stars.v                                                                                                                          
==================
In file included from /tmp/v/test_session_450981150748986/stars.14866588224441414028.tmp.c:756:
/opt/vlang/thirdparty/sokol/sokol_app.h:1345:14: fatal error: X11/Xlib.h: No such file or directory
     #include <X11/Xlib.h>
              ^~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [25/78]   680.308 ms examples/hot_reload/bounce.v                                                                                                                 
INFO: compile with `v -live /opt/vlang/examples/hot_reload/bounce.v `, if you want to use the [live] function main.frame .
INFO: compile with `v -live /opt/vlang/examples/hot_reload/bounce.v `, if you want to use the [live] function update_model .
==================
In file included from /tmp/v/test_session_450981150748986/bounce.11638028889492726794.tmp.c:752:
/opt/vlang/thirdparty/sokol/sokol_app.h:1345:14: fatal error: X11/Xlib.h: No such file or directory
     #include <X11/Xlib.h>
              ^~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [34/78]  1078.181 ms examples/links_scraper.v                                                                                                                     
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

 FAIL  [38/78]  1195.919 ms examples/net_t.v                                                                                                                             
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

 FAIL  [40/78]  1198.209 ms examples/news_fetcher.v                                                                                                                      
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

 FAIL  [45/78]   407.581 ms examples/sokol/drawing.v                                                                                                                     
==================
In file included from /tmp/v/test_session_450981150748986/drawing.9416108043402459011.tmp.c:567:
/opt/vlang/thirdparty/sokol/sokol_app.h:1345:14: fatal error: X11/Xlib.h: No such file or directory
     #include <X11/Xlib.h>
              ^~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [46/78]   758.201 ms examples/sokol/cube.v                                                                                                                        
==================
In file included from /tmp/v/test_session_450981150748986/cube.17058727740103863506.tmp.c:716:
/opt/vlang/thirdparty/sokol/sokol_app.h:1345:14: fatal error: X11/Xlib.h: No such file or directory
     #include <X11/Xlib.h>
              ^~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [47/78]   878.153 ms examples/snek/snek.v                                                                                                                         
==================
In file included from /tmp/v/test_session_450981150748986/snek.12085358089103478201.tmp.c:757:
/opt/vlang/thirdparty/sokol/sokol_app.h:1345:14: fatal error: X11/Xlib.h: No such file or directory
     #include <X11/Xlib.h>
              ^~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [48/78]   582.554 ms examples/sokol/fonts.v                                                                                                                       
==================
In file included from /tmp/v/test_session_450981150748986/fonts.17647188175238297798.tmp.c:658:
/opt/vlang/thirdparty/sokol/sokol_app.h:1345:14: fatal error: X11/Xlib.h: No such file or directory
     #include <X11/Xlib.h>
              ^~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [49/78]   566.970 ms examples/sokol/freetype_raven.v                                                                                                              
==================
In file included from /tmp/v/test_session_450981150748986/freetype_raven.10372949556905050432.tmp.c:694:
/opt/vlang/thirdparty/sokol/sokol_app.h:1345:14: fatal error: X11/Xlib.h: No such file or directory
     #include <X11/Xlib.h>
              ^~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [50/78]   544.190 ms examples/sokol/particles/particles.v                                                                                                         
==================
In file included from /tmp/v/test_session_450981150748986/particles.10646040807219471776.tmp.c:610:
/opt/vlang/thirdparty/sokol/sokol_app.h:1345:14: fatal error: X11/Xlib.h: No such file or directory
     #include <X11/Xlib.h>
              ^~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [51/78]   466.424 ms examples/sokol/sounds/simple_sin_tones.v                                                                                                     
==================
In file included from /tmp/v/test_session_450981150748986/simple_sin_tones.7415798468528729495.tmp.c:600:
/opt/vlang/thirdparty/sokol/sokol_audio.h:506:14: fatal error: alsa/asoundlib.h: No such file or directory
     #include <alsa/asoundlib.h>
              ^~~~~~~~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [52/78]   613.023 ms examples/sokol/sounds/melody.v                                                                                                               
==================
In file included from /tmp/v/test_session_450981150748986/melody.15616068187507154610.tmp.c:586:
/opt/vlang/thirdparty/sokol/sokol_audio.h:506:14: fatal error: alsa/asoundlib.h: No such file or directory
     #include <alsa/asoundlib.h>
              ^~~~~~~~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [53/78]   493.313 ms examples/sokol/sounds/wav_player.v                                                                                                           
==================
In file included from /tmp/v/test_session_450981150748986/wav_player.7516778441062877571.tmp.c:682:
/opt/vlang/thirdparty/sokol/sokol_audio.h:506:14: fatal error: alsa/asoundlib.h: No such file or directory
     #include <alsa/asoundlib.h>
              ^~~~~~~~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [64/78]   810.555 ms examples/tetris/tetris.v                                                                                                                     
==================
In file included from /tmp/v/test_session_450981150748986/tetris.4180986986579147600.tmp.c:755:
/opt/vlang/thirdparty/sokol/sokol_app.h:1345:14: fatal error: X11/Xlib.h: No such file or directory
     #include <X11/Xlib.h>
              ^~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [67/78]   880.965 ms examples/ttf_font/example_ttf.v                                                                                                              
==================
In file included from /tmp/v/test_session_450981150748986/example_ttf.16574868385488257562.tmp.c:730:
/opt/vlang/thirdparty/sokol/sokol_app.h:1345:14: fatal error: X11/Xlib.h: No such file or directory
     #include <X11/Xlib.h>
              ^~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [69/78]  1128.550 ms examples/vweb/server_sent_events/server.v                                                                                                    
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

 FAIL  [70/78]  1228.196 ms examples/vweb/file_upload/vweb_example.v                                                                                                     
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

 FAIL  [71/78]  1092.843 ms examples/vweb/vweb_assets/vweb_assets.v                                                                                                      
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

 FAIL  [72/78]  1254.386 ms examples/vweb/vweb_example.v                                                                                                                 
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

 SKIP  [73/78]     0.001 ms examples/wkhtmltopdf.v                                                                                                                       
 FAIL  [75/78]  1256.605 ms examples/websocket/client-server/client.v                                                                                                    
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

 FAIL  [76/78]  1275.796 ms examples/websocket/ping.v                                                                                                                    
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

 FAIL  [78/78]  1443.943 ms examples/websocket/client-server/server.v                                                                                                    
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.


-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Summary for building examples: 33 failed, 44 passed, 1 skipped, 78 total. Runtime: 12269 ms.

> Running: "/opt/vlang/v  -progress -W build-examples" took: 12670 ms.

******************************************************* Check ```v ``` code examples and formatting of .MD files... *****************************************************
./vlib/mysql/README.md:7:1: error: example failed to compile
import mysql

// Create connection
mut connection := mysql.Connection{
	username: 'root'
	dbname: 'mysql'
}
// Connect to server
connection.connect() ?
// Change the default database
connection.select_db('db_users') ?
// Do a query
get_users_query_result := connection.query('SELECT * FROM users') ?
// Get the result as maps
for user in get_users_query_result.maps() {
	// Access the name of user
	println(user['name'])
}
// Free the query result
get_users_query_result.free()
// Close the connection if needed
connection.close()


Warnings: 71 | Errors: 1 | OKs: 195
> Running: "/opt/vlang/v run cmd/tools/check-md.v -hide-warnings -all" took: 39952 ms.

cannot compile `/opt/vlang/cmd/tools/vpm.v`: 
builder error: Header file <openssl/rand.h>, needed for module `net.openssl` was not found. Please install OpenSSL development headers.

> Running: "/opt/vlang/v install nedpals.args" took: 712 ms.

==================
In file included from /tmp/v/tetris.9899974632206477485.tmp.c:755:
/opt/vlang/thirdparty/sokol/sokol_app.h:1345:14: fatal error: X11/Xlib.h: No such file or directory
     #include <X11/Xlib.h>
              ^~~~~~~~~~~~
compilation terminated.
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.

If you were not working with C interop, please raise an issue on GitHub:

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

> Running: "/opt/vlang/v -usecache examples/tetris/tetris.v" took: 2789 ms.


--------------------------------------------------------------- Summary of `v test-all`: -------------------------------------------------------------
Total runtime: 186111 ms
>          OK: V can compile hello world. 
>          OK: V can compile itself. 
>          OK: All important .v files are invariant when processed with `v fmt` 
>          OK: All .v files can be processed with `v fmt`. NB: the result may not always be compilable, it just means that `v fmt` does not crash. 
>      Failed: /opt/vlang/v  -progress test-self 
>      Failed: /opt/vlang/v  -progress -W build-tools 
>      Failed: /opt/vlang/v  -progress -W build-examples 
>      Failed: /opt/vlang/v run cmd/tools/check-md.v -hide-warnings -all 
>      Failed: /opt/vlang/v install nedpals.args 
>      Failed: /opt/vlang/v -usecache examples/tetris/tetris.v 
```
</details>