### PR TITLE
cgen: remove srwlock definition workaround for tcc on windows

### DIFF
--- a/vlib/sync/sync_windows.c.v
+++ b/vlib/sync/sync_windows.c.v
@@ -5,6 +5,8 @@ module sync
 
 import time
 
+#include <synchapi.h>
+
 fn C.InitializeConditionVariable(voidptr)
 fn C.WakeConditionVariable(voidptr)
 fn C.SleepConditionVariableSRW(voidptr, voidptr, u32, u32) int

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -280,14 +280,6 @@ $c_common_macros
 		#pragma comment(lib, "Dbghelp")
 
 		extern wchar_t **_wenviron;
-	#elif !defined(SRWLOCK_INIT)
-		// these seem to be missing on Windows tcc
-		typedef struct SRWLOCK { void* SRWLOCK; } SRWLOCK;
-		void InitializeSRWLock(void*);
-		void AcquireSRWLockShared(void*);
-		void AcquireSRWLockExclusive(void*);
-		void ReleaseSRWLockShared(void*);
-		void ReleaseSRWLockExclusive(void*);
 	#endif
 #else
 	#include <pthread.h>


### PR DESCRIPTION
after vlang/tccbin#17, this isn't needed any longer (and may actually cause issues because of redefinitions)

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
