### PR TITLE
checker: fix sumtype assign error (fix #7988)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1199,6 +1199,9 @@ fn (mut c Checker) fail_if_immutable(expr ast.Expr) (string, token.Position) {
 						c.error('`$typ_sym.kind` can not be modified', expr.pos)
 					}
 				}
+				.aggregate {
+					c.fail_if_immutable(expr.expr)
+				}
 				else {
 					c.error('unexpected symbol `$typ_sym.kind`', expr.pos)
 				}

--- a/vlib/v/tests/sumtype_assign_test.v
+++ b/vlib/v/tests/sumtype_assign_test.v
@@ -1,4 +1,6 @@
 struct Foo {
+mut:
+	num int
 }
 
 struct Bar {
@@ -15,7 +17,9 @@ type FBB = Bar | Baz | Foo
 
 fn test_sumtype_assign() {
 	mut arr := []FBB{}
-	arr << Foo{}
+	arr << Foo{
+		num: 22
+	}
 	arr << Bar{
 		text: 'bar'
 	}
@@ -30,9 +34,13 @@ fn test_sumtype_assign() {
 				println(a.text)
 				results << a.text
 			}
-			else {}
+			Foo {
+				a.num = 11
+				results << 'Num is $a.num'
+			}
 		}
 	}
-	assert results[0] == 'I am bar'
-	assert results[1] == 'I am baz'
+	assert results[0] == 'Num is 11'
+	assert results[1] == 'I am bar'
+	assert results[2] == 'I am baz'
 }

--- a/vlib/v/tests/sumtype_assign_test.v
+++ b/vlib/v/tests/sumtype_assign_test.v
@@ -1,0 +1,38 @@
+struct Foo {
+}
+
+struct Bar {
+mut:
+	text string
+}
+
+struct Baz {
+mut:
+	text string
+}
+
+type FBB = Bar | Baz | Foo
+
+fn test_sumtype_assign() {
+	mut arr := []FBB{}
+	arr << Foo{}
+	arr << Bar{
+		text: 'bar'
+	}
+	arr << Baz{
+		text: 'baz'
+	}
+	mut results := []string{}
+	for a in arr {
+		match mut a {
+			Bar, Baz {
+				a.text = 'I am ' + a.text
+				println(a.text)
+				results << a.text
+			}
+			else {}
+		}
+	}
+	assert results[0] == 'I am bar'
+	assert results[1] == 'I am baz'
+}


### PR DESCRIPTION
This PR fix sumtype assign error (fix #7988).

- Fix sumtype assign error.
- Add test `sumtype_assign_test.v`.

```vlang
struct Foo {
}

struct Bar {
mut:
	text string
}

struct Baz {
mut:
	text string
}

type FBB = Bar | Baz | Foo

fn main() {
	mut arr := []FBB{}
	arr << Foo{}
	arr << Bar{
		text: 'bar'
	}
	arr << Baz{
		text: 'baz'
	}
	for a in arr {
		match mut a {
			Bar, Baz {
				a.text = 'I am ' + a.text
				println(a.text)
			}
			else {}
		}
	}
}

D:\Test\v\tt1>v run .
I am bar
I am baz
```