### PR TITLE
allow `lock` expression to return multiple objects

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2551,7 +2551,8 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 	mut right_len := assign_stmt.right.len
 	mut right_type0 := table.void_type
 	for right in assign_stmt.right {
-		if right is ast.CallExpr || right is ast.IfExpr || right is ast.LockExpr || right is ast.MatchExpr {
+		if right is ast.CallExpr || right is ast.IfExpr || right is ast.LockExpr
+			|| right is ast.MatchExpr {
 			right_type0 = c.expr(right)
 			assign_stmt.right_types = [
 				c.check_expr_opt_call(right, right_type0),

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2551,7 +2551,7 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 	mut right_len := assign_stmt.right.len
 	mut right_type0 := table.void_type
 	for right in assign_stmt.right {
-		if right is ast.CallExpr || right is ast.IfExpr || right is ast.MatchExpr {
+		if right is ast.CallExpr || right is ast.IfExpr || right is ast.LockExpr || right is ast.MatchExpr {
 			right_type0 = c.expr(right)
 			assign_stmt.right_types = [
 				c.check_expr_opt_call(right, right_type0),

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1742,6 +1742,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 	right_expr := assign_stmt.right[0]
 	match right_expr {
 		ast.CallExpr { return_type = right_expr.return_type }
+		ast.LockExpr { return_type = right_expr.typ }
 		ast.MatchExpr { return_type = right_expr.return_type }
 		ast.IfExpr { return_type = right_expr.typ }
 		else {}

--- a/vlib/v/tests/shared_lock_expr_test.v
+++ b/vlib/v/tests/shared_lock_expr_test.v
@@ -12,3 +12,32 @@ fn test_lock_expr() {
 	assert m == -57
 	assert n == 173
 }
+
+struct Abc {
+mut:
+	a f64
+}
+
+fn test_multi_objects() {
+	shared x := Abc{ a: 12.5 }
+	shared y := Abc{ a: -7.5 }
+	shared z := Abc{ a: 13.125 }
+	a, b, c := rlock z, x, y { y.a, z.a, x.a }
+	assert a == -7.5
+	assert b == 13.125
+	assert c == 12.5
+}
+
+fn (mut st Abc) getvals(mut a Abc, mut b Abc) (f64, f64, f64) {
+	return a.a, st.a, b.a
+}
+
+fn test_mult_ret_method() {
+	shared x := Abc{ a: 12.5 }
+	shared y := Abc{ a: -7.5 }
+	shared z := Abc{ a: 13.125 }
+	a, b, c := lock z, x, y { z.getvals(mut x, mut y) }
+	assert a == 12.5
+	assert b == 13.125
+	assert c == -7.5
+}


### PR DESCRIPTION
This allows:
```v
a, b, c := rlock { ... }
```
Analogous to the same syntax in `if` branches. The last statement inside `{ ... }` can be either a list (`x, y, z`) or a function call returning the required number of elements.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
