### PR TITLE
cgen: minor cleanup in stmt()

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1042,7 +1042,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 			// if af {
 			// g.autofree_call_postgen()
 			// }
-			if g.inside_ternary == 0 && !node.is_expr && !(node.expr is ast.IfExpr) {
+			if g.inside_ternary == 0 && !node.is_expr && node.expr !is ast.IfExpr {
 				g.writeln(';')
 			}
 		}

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -1039,7 +1039,7 @@ fn (mut g JsGen) gen_struct_decl(node ast.StructDecl) {
 	}
 	// gen toString method
 	fn_names := fns.map(it.name)
-	if !('toString' in fn_names) {
+	if 'toString' !in fn_names {
 		g.writeln('toString() {')
 		g.inc_indent()
 		g.write('return `$js_name {')
@@ -1569,13 +1569,13 @@ fn (mut g JsGen) gen_type_cast_expr(it ast.CastExpr) {
 		|| (it.expr is ast.FloatLiteral && it.typ in table.float_type_idxs))
 	typ := g.typ(it.typ)
 	if !is_literal {
-		if !(typ in js.v_types) || g.ns.name == 'builtin' {
+		if typ !in js.v_types || g.ns.name == 'builtin' {
 			g.write('new ')
 		}
 		g.write('${typ}(')
 	}
 	g.expr(it.expr)
-	if typ == 'string' && !(it.expr is ast.StringLiteral) {
+	if typ == 'string' && it.expr !is ast.StringLiteral {
 		g.write('.toString()')
 	}
 	if !is_literal {


### PR DESCRIPTION
This PR makes minor cleanup in stmt().

- change `!(node.expr is ast.IfExpr)` to `node.expr !is ast.IfExpr`.