### PR TITLE
all: fix fn_or_for_in mut value (part 1)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -434,6 +434,7 @@ pub:
 	is_mut          bool
 	is_autofree_tmp bool
 	is_arg          bool // fn args should not be autofreed
+	is_auto_deref   bool
 pub mut:
 	typ            table.Type
 	orig_type      table.Type   // original sumtype type; 0 if it's not a sumtype

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1532,3 +1532,14 @@ pub struct Table {
 	// pub mut:
 	// main_fn_decl_node FnDecl
 }
+
+pub fn (expr Expr) is_mut_ident() bool {
+	if expr is Ident {
+		if expr.obj is Var {
+			if expr.obj.is_auto_deref {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2543,17 +2543,6 @@ pub fn (mut c Checker) enum_decl(decl ast.EnumDecl) {
 	}
 }
 
-pub fn (mut c Checker) is_mut_ident(expr ast.Expr) bool {
-	if mut expr is ast.Ident {
-		if mut expr.obj is ast.Var {
-			if expr.obj.is_auto_deref {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 	c.expected_type = table.none_type // TODO a hack to make `x := if ... work`
 	defer {
@@ -2749,7 +2738,7 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 				assign_stmt.pos)
 		}
 		left_is_ptr := left_type.is_ptr() || left_sym.is_pointer()
-		if left_is_ptr && !c.is_mut_ident(left) {
+		if left_is_ptr && !left.is_mut_ident() {
 			if !c.inside_unsafe && assign_stmt.op !in [.assign, .decl_assign] {
 				// ptr op=
 				c.warn('pointer arithmetic is only allowed in `unsafe` blocks', assign_stmt.pos)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1717,17 +1717,6 @@ fn (mut g Gen) write_fn_ptr_decl(func &table.FnType, ptr_name string) {
 	g.write(')')
 }
 
-pub fn (mut g Gen) is_mut_ident(expr ast.Expr) bool {
-	if mut expr is ast.Ident {
-		if mut expr.obj is ast.Var {
-			if expr.obj.is_auto_deref {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 // TODO this function is scary. Simplify/split up.
 fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 	if assign_stmt.is_static {
@@ -2043,7 +2032,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 				g.array_set_pos = 0
 			} else {
 				g.out.go_back_to(pos)
-				is_var_mut := !is_decl && g.is_mut_ident(left)
+				is_var_mut := !is_decl && left.is_mut_ident()
 				addr := if is_var_mut { '' } else { '&' }
 				g.writeln('')
 				g.write('memcpy($addr')
@@ -2114,7 +2103,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					g.prevent_sum_type_unwrapping_once = true
 				}
 				if !is_fixed_array_copy || is_decl {
-					if !is_decl && g.is_mut_ident(left) {
+					if !is_decl && left.is_mut_ident() {
 						g.write('*')
 					}
 					g.expr(left)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -170,11 +170,6 @@ fn (mut g Gen) gen_fn_decl(node ast.FnDecl, skip bool) {
 		g.definitions.write(fn_header)
 		g.write(fn_header)
 	}
-	for param in node.params {
-		if param.is_mut {
-			g.fn_mut_arg_names << param.name
-		}
-	}
 	arg_start_pos := g.out.len
 	fargs, fargtypes := g.fn_args(node.params, node.is_variadic)
 	arg_str := g.out.after(arg_start_pos)
@@ -223,9 +218,6 @@ fn (mut g Gen) gen_fn_decl(node ast.FnDecl, skip bool) {
 	g.defer_stmts = []
 	g.stmts(node.stmts)
 	// clear g.fn_mut_arg_names
-	if g.fn_mut_arg_names.len > 0 {
-		g.fn_mut_arg_names.clear()
-	}
 
 	if !node.has_return {
 		g.write_defer_stmts_when_needed()

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -343,7 +343,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype table.Type) {
 	} else if sym_has_str_method
 		|| sym.kind in [.array, .array_fixed, .map, .struct_, .multi_return, .sum_type, .interface_] {
 		is_ptr := typ.is_ptr()
-		is_var_mut := g.is_mut_ident(expr)
+		is_var_mut := expr.is_mut_ident()
 		str_fn_name := g.gen_str_for_type(typ)
 		if is_ptr && !is_var_mut {
 			g.write('_STR("&%.*s\\000", 2, ')

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -343,8 +343,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype table.Type) {
 	} else if sym_has_str_method
 		|| sym.kind in [.array, .array_fixed, .map, .struct_, .multi_return, .sum_type, .interface_] {
 		is_ptr := typ.is_ptr()
-		is_var_mut := expr is ast.Ident && ((expr as ast.Ident).name == g.for_in_mut_val_name
-			|| (expr as ast.Ident).name in g.fn_mut_arg_names)
+		is_var_mut := g.is_mut_ident(expr)
 		str_fn_name := g.gen_str_for_type(typ)
 		if is_ptr && !is_var_mut {
 			g.write('_STR("&%.*s\\000", 2, ')

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -317,6 +317,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 				name: param.name
 				typ: param.typ
 				is_mut: param.is_mut
+				is_auto_deref: param.is_mut
 				pos: param.pos
 				is_used: true
 				is_arg: true

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -157,6 +157,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 				name: val_var_name
 				pos: val_var_pos
 				is_mut: val_is_mut
+				is_auto_deref: val_is_mut
 				is_tmp: true
 			})
 		}


### PR DESCRIPTION
This PR makes optimization in fn_or_for_in mut value.  (part 1)

- Add `is_auto_deref` in ast.Var.
```vlang
pub struct Var {
pub:
	name            string
	expr            Expr
...
	is_auto_deref   bool
...
```
- Remove `for_in_mut_val_name` and `fn_mut_arg_names` from `struct Checker` and `struct Gen`.
- Remove the original time-consuming processing.
- Merge duplicate `is_mut_ident` into ast.v.
- And I'll implement complete processing (fix #8548) in part 2.