### PR TITLE
os: Fix bug in os walk function

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -463,8 +463,12 @@ pub fn walk(path string, f fn (string)) {
 		return
 	}
 	mut files := ls(path) or { return }
+	mut local_path_separator := path_separator
+	if path.ends_with(path_separator) {
+		local_path_separator = ""
+	}
 	for file in files {
-		p := path + path_separator + file
+		p := path + local_path_separator + file
 		if is_dir(p) && !is_link(p) {
 			walk(p, f)
 		} else if exists(p) {

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -465,7 +465,7 @@ pub fn walk(path string, f fn (string)) {
 	mut files := ls(path) or { return }
 	mut local_path_separator := path_separator
 	if path.ends_with(path_separator) {
-		local_path_separator = ""
+		local_path_separator = ''
 	}
 	for file in files {
 		p := path + local_path_separator + file


### PR DESCRIPTION
Fix the bug that inserts an extra path separator in the walk function if the input path has a separator at the end. Add an additional check for the separator at the end and a local version of the path separator to remove if duplicated.
