### PR TITLE
Make array reference great again

### DIFF
--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -250,12 +250,6 @@ pub fn (mut p Parser) parse_type() table.Type {
 	}
 	if nr_muls > 0 {
 		typ = typ.set_nr_muls(nr_muls)
-		if is_array && nr_amps > 0 {
-			p.error('V arrays are already references behind the scenes,
-there is no need to use a reference to an array (e.g. use `[]string` instead of `&[]string`).
-If you need to modify an array in a function, use a mutable argument instead: `fn foo(mut s []string) {}`.')
-			return 0
-		}
 	}
 	return typ
 }

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -226,7 +226,6 @@ pub fn (mut p Parser) parse_type() table.Type {
 	}
 	language := p.parse_language()
 	mut typ := table.void_type
-	is_array := p.tok.kind == .lsbr
 	if p.tok.kind != .lcbr {
 		pos := p.tok.position()
 		typ = p.parse_any_type(language, nr_muls > 0, true)


### PR DESCRIPTION
Trivial fix to restore being able to store/use an array reference

Eg:
```v
struct ASTNode {
	val int
	ctx &[]ASTNode = voidptr(0)
}
mut arr := []ASTNode{}
println('len=${arr.len}')
mut ctx := &arr
ctx<<ASTNode{val:3}
println('len=${arr.len}')
for i:=0;i<arr.len;i++ {
	println('i=$i')
	println('${arr[i].val}')
}
```
