### PR TITLE
os: fix cp_all mkdir panic

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -62,7 +62,9 @@ pub fn cp_all(src string, dst string, overwrite bool) ? {
 		sp := join_path(source_path, file)
 		dp := join_path(dest_path, file)
 		if is_dir(sp) {
-			mkdir(dp) ?
+			if !exists(dp) {
+				mkdir(dp) ?
+			}
 		}
 		cp_all(sp, dp, overwrite) or {
 			rmdir(dp) or { return error(err) }

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -250,7 +250,7 @@ fn test_mv() {
 	assert os.exists(expected) && !is_dir(expected) == true
 }
 
-fn test_cp_r() {
+fn test_cp_all() {
 	// fileX -> dir/fileX
 	// NB: clean up of the files happens inside the cleanup_leftovers function
 	os.write_file('ex1.txt', 'wow!') or { panic(err) }
@@ -267,6 +267,8 @@ fn test_cp_r() {
 	assert old2 == new2
 	// recurring on dir -> local dir
 	os.cp_all('ex', './', true) or { panic(err) }
+	// regression test for executive runs with overwrite := true
+	os.cp_all('ex', './', true) or { panic(err) }
 }
 
 fn test_tmpdir() {
@@ -274,7 +276,7 @@ fn test_tmpdir() {
 	assert t.len > 0
 	assert os.is_dir(t)
 	tfile := t + os.path_separator + 'tmpfile.txt'
-	os.rm(tfile) or { } // just in case 
+	os.rm(tfile) or { } // just in case
 	tfile_content := 'this is a temporary file'
 	os.write_file(tfile, tfile_content) or { panic(err) }
 	tfile_content_read := os.read_file(tfile) or { panic(err) }


### PR DESCRIPTION
Fix a case where `os.cp_all` panics when making dirs that already exist.

```v
import os

fn main() {
	os.mkdir_all('/tmp/v/dst') or { panic(err) }
	os.mkdir_all('/tmp/v/src/test') or { panic(err) }
	os.cp_all('/tmp/v/src', '/tmp/v/dst', true) or { panic(err) }
}
```

Before this PR, running the above code twice in a row would result in the error:

```
V panic: File exists
/dev/shm/v/t.17261584416731309917.tmp.c:5610: at v_panic: Backtrace
/dev/shm/v/t.17261584416731309917.tmp.c:11576: by main__main
/dev/shm/v/t.17261584416731309917.tmp.c:11664: by main
```

This is not correct behaviour as I see it. If `overwrite` is sat to true the function should be able to run multiple times in a row and give the  same result :slightly_smiling_face: 

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
