### PR TITLE
checker: improve errors for `return` count mismatch

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2356,13 +2356,12 @@ pub fn (mut c Checker) return_stmt(mut return_stmt ast.Return) {
 	expected_type := c.unwrap_generic(c.expected_type)
 	expected_type_sym := c.table.get_type_symbol(expected_type)
 	if return_stmt.exprs.len > 0 && c.cur_fn.return_type == table.void_type {
-		c.error('unexpected argument, current function does not return anything',
-			return_stmt.exprs[0].position())
+		c.error('unexpected argument, current function does not return anything', return_stmt.exprs[0].position())
 		return
 	} else if return_stmt.exprs.len == 0 && !(c.expected_type == table.void_type
 		|| expected_type_sym.kind == .void) {
 		stype := c.table.type_to_str(expected_type)
-		arg := if expected_type_sym.kind == .multi_return {'arguments'} else {'argument'}
+		arg := if expected_type_sym.kind == .multi_return { 'arguments' } else { 'argument' }
 		c.error('expected `$stype` $arg', return_stmt.pos)
 		return
 	}
@@ -2396,7 +2395,7 @@ pub fn (mut c Checker) return_stmt(mut return_stmt ast.Return) {
 		return
 	}
 	if expected_types.len > 0 && expected_types.len != got_types.len {
-		arg := if expected_types.len == 1 {'argument'} else {'arguments'}
+		arg := if expected_types.len == 1 { 'argument' } else { 'arguments' }
 		c.error('expected $expected_types.len $arg, but got $got_types.len', return_stmt.pos)
 		return
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1298,7 +1298,7 @@ pub fn (mut c Checker) call_expr(mut call_expr ast.CallExpr) table.Type {
 
 fn (mut c Checker) check_map_and_filter(is_map bool, elem_typ table.Type, call_expr ast.CallExpr) {
 	if call_expr.args.len != 1 {
-		c.error('expected 1 arguments, but got $call_expr.args.len', call_expr.pos)
+		c.error('expected 1 argument, but got $call_expr.args.len', call_expr.pos)
 		// Finish early so that it doesn't fail later
 		return
 	}
@@ -2356,12 +2356,14 @@ pub fn (mut c Checker) return_stmt(mut return_stmt ast.Return) {
 	expected_type := c.unwrap_generic(c.expected_type)
 	expected_type_sym := c.table.get_type_symbol(expected_type)
 	if return_stmt.exprs.len > 0 && c.cur_fn.return_type == table.void_type {
-		c.error('too many arguments to return, current function does not return anything',
-			return_stmt.pos)
+		c.error('unexpected argument, current function does not return anything',
+			return_stmt.exprs[0].position())
 		return
 	} else if return_stmt.exprs.len == 0 && !(c.expected_type == table.void_type
 		|| expected_type_sym.kind == .void) {
-		c.error('too few arguments to return', return_stmt.pos)
+		stype := c.table.type_to_str(expected_type)
+		arg := if expected_type_sym.kind == .multi_return {'arguments'} else {'argument'}
+		c.error('expected `$stype` $arg', return_stmt.pos)
 		return
 	}
 	if return_stmt.exprs.len == 0 {
@@ -2394,7 +2396,8 @@ pub fn (mut c Checker) return_stmt(mut return_stmt ast.Return) {
 		return
 	}
 	if expected_types.len > 0 && expected_types.len != got_types.len {
-		c.error('wrong number of return arguments', return_stmt.pos)
+		arg := if expected_types.len == 1 {'argument'} else {'arguments'}
+		c.error('expected $expected_types.len $arg, but got $got_types.len', return_stmt.pos)
 		return
 	}
 	for i, exp_type in expected_types {

--- a/vlib/v/checker/tests/array_map_arg_mismatch.out
+++ b/vlib/v/checker/tests/array_map_arg_mismatch.out
@@ -1,11 +1,11 @@
-vlib/v/checker/tests/array_map_arg_mismatch.vv:3:4: error: expected 1 arguments, but got 0
+vlib/v/checker/tests/array_map_arg_mismatch.vv:3:4: error: expected 1 argument, but got 0
     1 | fn main() {
     2 |     a := [1, 2, 3]
     3 |     a.map()
       |       ~~~~~
     4 |     a.map(it * 2, 3)
     5 | }
-vlib/v/checker/tests/array_map_arg_mismatch.vv:4:4: error: expected 1 arguments, but got 2
+vlib/v/checker/tests/array_map_arg_mismatch.vv:4:4: error: expected 1 argument, but got 2
     2 |     a := [1, 2, 3]
     3 |     a.map()
     4 |     a.map(it * 2, 3)

--- a/vlib/v/checker/tests/return_count_mismatch.out
+++ b/vlib/v/checker/tests/return_count_mismatch.out
@@ -1,0 +1,34 @@
+vlib/v/checker/tests/return_count_mismatch.vv:2:9: error: unexpected argument, current function does not return anything
+    1 | fn v() {
+    2 |     return 3
+      |            ^
+    3 | }
+    4 |
+vlib/v/checker/tests/return_count_mismatch.vv:7:2: error: expected `int` argument
+    5 | fn f() int
+    6 | {
+    7 |     return
+      |     ~~~~~~
+    8 | }
+    9 |
+vlib/v/checker/tests/return_count_mismatch.vv:12:2: error: expected `(int, string)` arguments
+   10 | fn g() (int, string)
+   11 | {
+   12 |     return
+      |     ~~~~~~
+   13 | }
+   14 |
+vlib/v/checker/tests/return_count_mismatch.vv:17:2: error: expected 1 argument, but got 2
+   15 | fn ff() int
+   16 | {
+   17 |     return 2, ''
+      |     ~~~~~~~~~~~~
+   18 | }
+   19 |
+vlib/v/checker/tests/return_count_mismatch.vv:22:2: error: expected 2 arguments, but got 1
+   20 | fn gg() (int, string)
+   21 | {
+   22 |     return 3
+      |     ~~~~~~~~
+   23 | }
+   24 |

--- a/vlib/v/checker/tests/return_count_mismatch.vv
+++ b/vlib/v/checker/tests/return_count_mismatch.vv
@@ -1,0 +1,24 @@
+fn v() {
+	return 3
+}
+
+fn f() int
+{
+	return
+}
+
+fn g() (int, string)
+{
+	return
+}
+
+fn ff() int
+{
+	return 2, ''
+}
+
+fn gg() (int, string)
+{
+	return 3
+}
+


### PR DESCRIPTION
* Show expected argument type(s) when `return` has no arguments
* Show number of arguments supplied vs expected
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
