### PR TITLE
cgen: format match_expr generated c codes

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3528,6 +3528,7 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 		g.expr(node.cond)
 		cond_var = g.out.after(pos)
 		g.out.go_back(cond_var.len)
+		cond_var = cond_var.trim_space()
 	} else {
 		cur_line := if is_expr {
 			g.empty_line = true
@@ -3587,6 +3588,9 @@ fn (mut g Gen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var str
 				if is_expr {
 					g.write('(')
 				} else {
+					if j == 0 && sumtype_index == 0 {
+						g.writeln('')
+					}
 					g.write_v_source_line_info(branch.pos)
 					g.write('if (')
 				}
@@ -3649,6 +3653,9 @@ fn (mut g Gen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var str
 			if is_expr {
 				g.write('(')
 			} else {
+				if j == 0 {
+					g.writeln('')
+				}
 				g.write_v_source_line_info(branch.pos)
 				g.write('if (')
 			}


### PR DESCRIPTION
This PR format match_expr generated c codes.

- Before (match_expr generated c codes)
```vlang
VV_LOCAL_SYMBOL multi_return_int_strconv__PrepNumber strconv__parser(string s) {
	int state = _const_strconv__fsm_a;
	int digx = 0;
	byte c = ((byte)(L' '));
	int result = _const_strconv__parser_ok;
	bool expneg = false;
	int expexp = 0;
	int i = 0;
	strconv__PrepNumber pn = (strconv__PrepNumber){.negative = 0,.exponent = 0,.mantissa = 0,};
	for (;;) {
		if (!(state != _const_strconv__fsm_stop)) break;
if (		state == _const_strconv__fsm_a) {
			if (strconv__is_space(c) == true) {
				c = string_at(s, i);
				i++;
			} else {
				state = _const_strconv__fsm_b;
			}
		}
		else if (		state == _const_strconv__fsm_b) {
			state = _const_strconv__fsm_c;
			if (c == _const_strconv__c_plus) {
				c = string_at(s, i);
				i++;
...
```
- After format (match_expr generated c codes)
```vlang
VV_LOCAL_SYMBOL multi_return_int_strconv__PrepNumber strconv__parser(string s) {
	int state = _const_strconv__fsm_a;
	int digx = 0;
	byte c = ((byte)(L' '));
	int result = _const_strconv__parser_ok;
	bool expneg = false;
	int expexp = 0;
	int i = 0;
	strconv__PrepNumber pn = (strconv__PrepNumber){.negative = 0,.exponent = 0,.mantissa = 0,};
	for (;;) {
		if (!(state != _const_strconv__fsm_stop)) break;

		if (state == _const_strconv__fsm_a) {
			if (strconv__is_space(c) == true) {
				c = string_at(s, i);
				i++;
			} else {
				state = _const_strconv__fsm_b;
			}
		}
		else if (state == _const_strconv__fsm_b) {
			state = _const_strconv__fsm_c;
			if (c == _const_strconv__c_plus) {
				c = string_at(s, i);
				i++;
			} else if (c == _const_strconv__c_minus) {
				pn.negative = true;
				c = string_at(s, i);
				i++;
...
```