### PR TITLE
checker: obey [ref_only] tag, allow embedding in other ref struct

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -127,6 +127,7 @@ const (
 		'vlib/v/tests/module_test.v',
 		'vlib/v/tests/operator_overloading_with_string_interpolation_test.v',
 		'vlib/v/tests/orm_sub_struct_test.v',
+		'vlib/v/tests/ref_struct_test.v',
 		'vlib/v/tests/repl/repl_test.v',
 		'vlib/v/tests/semaphore_test.v',
 		'vlib/v/tests/shared_arg_test.v',

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -529,7 +529,7 @@ pub fn channel_select(mut channels []&Channel, dir []Direction, mut objrefs []vo
 	assert channels.len == dir.len
 	assert dir.len == objrefs.len
 	mut subscr := []Subscription{len: channels.len}
-	mut sem := Semaphore{}
+	mut sem := unsafe { Semaphore{} }
 	sem.init(0)
 	for i, ch in channels {
 		subscr[i].sem = &sem

--- a/vlib/sync/sync_default.c.v
+++ b/vlib/sync/sync_default.c.v
@@ -28,10 +28,12 @@ fn C.sem_timedwait(voidptr, voidptr) int
 fn C.sem_destroy(voidptr) int
 
 // [init_with=new_mutex] // TODO: implement support for this struct attribute, and disallow Mutex{} from outside the sync.new_mutex() function.
+[ref_only]
 pub struct Mutex {
 	mutex C.pthread_mutex_t
 }
 
+[ref_only]
 pub struct RwMutex {
 	mutex C.pthread_rwlock_t
 }
@@ -40,6 +42,7 @@ struct RwMutexAttr {
 	attr C.pthread_rwlockattr_t
 }
 
+[ref_only]
 struct Semaphore {
 	sem C.sem_t
 }

--- a/vlib/sync/sync_macos.c.v
+++ b/vlib/sync/sync_macos.c.v
@@ -31,10 +31,12 @@ fn C.pthread_cond_timedwait(voidptr, voidptr, voidptr) int
 fn C.pthread_cond_destroy(voidptr) int
 
 // [init_with=new_mutex] // TODO: implement support for this struct attribute, and disallow Mutex{} from outside the sync.new_mutex() function.
+[ref_only]
 pub struct Mutex {
 	mutex C.pthread_mutex_t
 }
 
+[ref_only]
 pub struct RwMutex {
 	mutex C.pthread_rwlock_t
 }
@@ -49,6 +51,7 @@ struct CondAttr {
 
 /* MacOSX has no unnamed semaphores and no `timed_wait()` at all
    so we emulate the behaviour with other devices */
+[ref_only]
 struct Semaphore {
 	mtx C.pthread_mutex_t
 	cond C.pthread_cond_t

--- a/vlib/sync/sync_windows.c.v
+++ b/vlib/sync/sync_windows.c.v
@@ -22,16 +22,19 @@ type SHANDLE = voidptr
 //[init_with=new_mutex] // TODO: implement support for this struct attribute, and disallow Mutex{} from outside the sync.new_mutex() function.
 
 // `SRWLOCK` is much more performant that `Mutex` on Windows, so use that in both cases since we don't want to share with other processes
+[ref_only]
 pub struct Mutex {
 mut:
 	mx C.SRWLOCK    // mutex handle
 }
 
+[ref_only]
 pub struct RwMutex {
 mut:
 	mx C.SRWLOCK    // mutex handle
 }
 
+[ref_only]
 struct Semaphore {
 	mtx C.SRWLOCK
 	cond C.CONDITION_VARIABLE

--- a/vlib/v/README.md
+++ b/vlib/v/README.md
@@ -34,7 +34,7 @@ a new preference is created:
 ```v
 import v.pref
 
-pref := pref.Preferences{}
+pref := &pref.Preferences{}
 ```
 
 and a new scope is created:

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -543,7 +543,7 @@ pub fn (mut c Checker) struct_init(mut struct_init ast.StructInit) table.Type {
 			c.error('struct `$type_sym.name` is declared with a `[noinit]` attribute, so ' +
 				'it cannot be initialized with `$type_sym.name{}`', struct_init.pos)
 		}
-		if info.is_ref_only && !c.inside_ref_lit && !struct_init.typ.is_ptr() {
+		if info.is_ref_only && !c.inside_ref_lit && !c.inside_unsafe && !struct_init.typ.is_ptr() {
 			c.error('`$type_sym.name` type can only be used as a reference `&$type_sym.name` or inside a `struct` reference',
 				struct_init.pos)
 		}

--- a/vlib/v/checker/tests/ref_only_struct.out
+++ b/vlib/v/checker/tests/ref_only_struct.out
@@ -1,0 +1,35 @@
+vlib/v/checker/tests/ref_only_struct.vv:18:7: error: `Abc` type can only be used as a reference `&Abc` or inside a `struct` reference
+   16 | 
+   17 | fn main() {
+   18 |     a := Abc{ n: 3 }
+      |          ~~~~~~~~~~~
+   19 |     b := St{
+   20 |         Abc{ n: 7 }
+vlib/v/checker/tests/ref_only_struct.vv:19:7: error: `St` type can only be used as a reference `&St` or inside a `struct` reference
+   17 | fn main() {
+   18 |     a := Abc{ n: 3 }
+   19 |     b := St{
+      |          ~~~
+   20 |         Abc{ n: 7 }
+   21 |     }
+vlib/v/checker/tests/ref_only_struct.vv:20:3: error: `Abc` type can only be used as a reference `&Abc` or inside a `struct` reference
+   18 |     a := Abc{ n: 3 }
+   19 |     b := St{
+   20 |         Abc{ n: 7 }
+      |         ~~~~~~~~~~~
+   21 |     }
+   22 |     x := Qwe{
+vlib/v/checker/tests/ref_only_struct.vv:22:7: error: `Qwe` type can only be used as a reference `&Qwe` or inside a `struct` reference
+   20 |         Abc{ n: 7 }
+   21 |     }
+   22 |     x := Qwe{
+      |          ~~~~
+   23 |         f: 12.25
+   24 |         a: Abc{ n: 23 }
+vlib/v/checker/tests/ref_only_struct.vv:24:6: error: `Abc` type can only be used as a reference `&Abc` or inside a `struct` reference
+   22 |     x := Qwe{
+   23 |         f: 12.25
+   24 |         a: Abc{ n: 23 }
+      |            ~~~~~~~~~~~~
+   25 |     }
+   26 |     println('$a.n $b.n $x.a.n')

--- a/vlib/v/checker/tests/ref_only_struct.vv
+++ b/vlib/v/checker/tests/ref_only_struct.vv
@@ -1,0 +1,27 @@
+[ref_only]
+struct Abc {
+mut:
+	n int
+}
+
+struct St {
+	Abc
+}
+
+struct Qwe {
+mut:
+	f f64
+	a Abc
+}
+
+fn main() {
+	a := Abc{ n: 3 }
+	b := St{
+		Abc{ n: 7 }
+	}
+	x := Qwe{
+		f: 12.25
+		a: Abc{ n: 23 }
+	}
+	println('$a.n $b.n $x.a.n')
+}

--- a/vlib/v/gen/c/cgen_test.v
+++ b/vlib/v/gen/c/cgen_test.v
@@ -19,7 +19,7 @@ fn test_c_files() {
 	for i in 1 .. (nr_tests + 1) {
 		path := '$vroot/vlib/v/gen/tests/${i}.vv'
 		ctext := os.read_file('$vroot/vlib/v/gen/tests/${i}.c') or { panic(err) }
-		mut b := builder.new_builder(pref.Preferences{})
+		mut b := builder.new_builder(&pref.Preferences{})
 		b.module_search_paths = ['$vroot/vlib/v/gen/tests/']
 		mut res := b.gen_c([path]).after('#endbuiltin')
 		if res.contains('string _STR') {

--- a/vlib/v/tests/ref_struct_test.v
+++ b/vlib/v/tests/ref_struct_test.v
@@ -1,0 +1,55 @@
+[ref_only]
+struct Abc {
+mut:
+	n int
+}
+
+struct St {
+	Abc
+}
+
+struct Qwe {
+mut:
+	f f64
+	a Abc
+}
+
+struct Rtz {
+mut:
+	f f64
+	a &Abc
+}
+
+fn test_ref() {
+	a := &Abc{ n: 3 }
+	assert a.n == 3
+}
+
+fn test_shared() {
+	shared a := Abc{ n: 4 }
+	res := rlock a { a.n }
+	assert res == 4
+}
+
+fn test_embed_in_ref_struct() {
+	a := &St{
+		Abc{ n: 5 }
+	}
+	assert a.n == 5
+}
+
+fn test_field_in_ref_struct() {
+	x := &Qwe{
+		f: 12.25
+		a: Abc{ n: 23 }
+	}
+	assert x.a.n == 23
+}
+
+fn test_ref_field() {
+	y := Rtz{
+		f: -6.25
+		a: &Abc{ n: 29 }
+	}
+	assert y.a.n == 29
+}

--- a/vlib/vweb/sse/sse.v
+++ b/vlib/vweb/sse/sse.v
@@ -35,8 +35,8 @@ pub struct SSEMessage {
 	retry int
 }
 
-pub fn new_connection(conn &net.TcpConn) SSEConnection {
-	return SSEConnection{
+pub fn new_connection(conn &net.TcpConn) &SSEConnection {
+	return &SSEConnection{
 		conn: conn
 	}
 }


### PR DESCRIPTION
With this PR the `[ref_only]` tag of structs is checked. If the flag is present two usages are allowed:
- make a reference of the struct
- include the struct as (value) field or embed into a bigger struct and make a reference of that

So, the tag essentially assures heap allocation.

Example:
```v
[ref_only]
struct Abc {
mut:
	n int
}

struct St {
	Abc
}

struct Qwe {
mut:
	f f64
	a Abc
}

a := &Abc{ n: 3 }
shared b := Abc{ n: 4 } // shared objects are always references
c := &St{
    Abc{ n: 5 }
}
d := &Qwe{
    a: Abc{ n: 23 }
}
```
Creating a value struct is still allowed inside `unsafe`.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
