### PR TITLE
vdoc: fix markdown toc link rendering

### DIFF
--- a/cmd/tools/vdoc/markdown.v
+++ b/cmd/tools/vdoc/markdown.v
@@ -31,7 +31,7 @@ fn (vd VDoc) gen_markdown(d doc.Doc, with_toc bool) string {
 fn (vd VDoc) write_markdown_content(contents []doc.DocNode, mut cw strings.Builder, mut hw strings.Builder, indent int, with_toc bool) {
 	for cn in contents {
 		if with_toc && cn.name.len > 0 {
-			hw.writeln(' '.repeat(2 * indent) + '- [#$cn.name](${slug(cn.name)})')
+			hw.writeln(' '.repeat(2 * indent) + '- [${slug(cn.name)}](#$cn.name)')
 			cw.writeln('## $cn.name')
 		}
 		if cn.content.len > 0 {

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -366,8 +366,8 @@ fn (mut vd VDoc) generate_docs_from_file() {
 			vd.render_static_html(out)
 		}
 		vd.render_parallel(out)
-		println('Creating search index...')
 		if out.typ == .html {
+			println('Creating search index...')
 			vd.collect_search_index(out)
 			vd.render_search_index(out)
 			// move favicons to target directory


### PR DESCRIPTION
Fixes the output of markdown link in TOC from this:
```
[#bytes](bytes)
```
to this:
```
[bytes](#bytes)
```

Also included in this fix is the search index message which should only appear if the doc is rendered in HTML.