### PR TITLE
os: improve `rm` error message

### DIFF
--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -432,17 +432,14 @@ pub fn is_readable(path string) bool {
 
 // rm removes file in `path`.
 pub fn rm(path string) ? {
+	mut rc := 0
 	$if windows {
-		rc := C._wremove(path.to_wide())
-		if rc == -1 {
-			// TODO: proper error as soon as it's supported on windows
-			return error('Failed to remove "$path"')
-		}
+		rc = C._wremove(path.to_wide())
 	} $else {
-		rc := C.remove(charptr(path.str))
-		if rc == -1 {
-			return error(posix_get_error_msg(C.errno))
-		}
+		rc = C.remove(charptr(path.str))
+	}
+	if rc == -1 {
+		return error('Failed to remove "$path": ' + posix_get_error_msg(C.errno))
 	}
 	// C.unlink(path.cstr())
 }


### PR DESCRIPTION
* Show file path on non-Windows
* Fix showing reason why file couldn't be deleted on Windows

`_wremove` sets `errno`:
https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/remove-wremove?view=msvc-160#return-value

So we can call `strerror` just like on POSIX.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
