### PR TITLE
builtin: make 5 C functions trusted, tweak signatures

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -7,6 +7,7 @@ fn C.memcmp(byteptr, byteptr, int) int
 
 fn C.memmove(byteptr, byteptr, int) voidptr
 
+[trusted]
 fn C.calloc(int, int) byteptr
 
 fn C.malloc(int) byteptr
@@ -15,6 +16,7 @@ fn C.realloc(a byteptr, b int) byteptr
 
 fn C.free(ptr voidptr)
 
+[trusted]
 fn C.exit(code int)
 
 fn C.qsort(base voidptr, items size_t, item_size size_t, cb qsort_callback_func)
@@ -25,7 +27,8 @@ fn C.strlen(s charptr) int
 
 fn C.sscanf(byteptr, byteptr, ...byteptr) int
 
-fn C.isdigit(s byteptr) bool
+[trusted]
+fn C.isdigit(c int) bool
 
 // stdio.h
 fn C.popen(c charptr, t charptr) voidptr
@@ -70,7 +73,7 @@ fn C.pclose() int
 // process execution, os.process:
 fn C.getpid() int
 
-fn C.system() int
+fn C.system(cmd charptr) int
 
 fn C.posix_spawn(child_pid &int, path charptr, file_actions voidptr, attrp voidptr, argv &charptr, envp &charptr) int
 
@@ -78,6 +81,7 @@ fn C.posix_spawnp(child_pid &int, exefile charptr, file_actions voidptr, attrp v
 
 fn C.execve(cmd_path charptr, args voidptr, envs voidptr) int
 
+[trusted]
 fn C.fork() int
 
 fn C.wait(status &int) int
@@ -112,7 +116,7 @@ fn C.memset() int
 
 fn C.sigemptyset() int
 
-fn C.getcwd() int
+fn C.getcwd(buf charptr, size size_t) charptr
 
 fn C.signal(signal int, handlercb voidptr) voidptr
 

--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -131,7 +131,13 @@ fn C.closedir() int
 
 fn C.mkdir() int
 
-fn C.srand() int
+// C.rand returns a pseudorandom integer from 0 (inclusive) to C.RAND_MAX (exclusive)
+[trusted]
+fn C.rand() int
+
+// C.srand seeds the internal PRNG with the given value.
+[trusted]
+fn C.srand(seed uint)
 
 fn C.atof() int
 

--- a/vlib/rand/sys/system_rng.c.v
+++ b/vlib/rand/sys/system_rng.c.v
@@ -9,10 +9,11 @@ import rand.constants
 
 // Implementation note:
 // ====================
-// C.rand() is okay to use within its defined range of C.RAND_MAX.
+// C.rand returns a pseudorandom integer from 0 (inclusive) to C.RAND_MAX (exclusive)
+// C.rand() is okay to use within its defined range.
 // (See: https://web.archive.org/web/20180801210127/http://eternallyconfuzzled.com/arts/jsw_art_rand.aspx)
 // The problem is, this value varies with the libc implementation. On windows,
-// for example, RAND_MAX is usually a measly 32767, whereas on (newer) linux it's generaly
+// for example, RAND_MAX is usually a measly 32767, whereas on (newer) linux it's generally
 // 2147483647. The repetition period also varies wildly. In order to provide more entropy
 // without altering the underlying algorithm too much, this implementation simply
 // requests for more random bits until the necessary width for the integers is achieved.
@@ -29,11 +30,6 @@ fn calculate_iterations_for(bits int) int {
 	return base + extra
 }
 
-// C.rand returns a pseudorandom integer from 0 (inclusive) to C.RAND_MAX (exclusive)
-fn C.rand() int
-
-// C.srand seeds the internal PRNG with the given int seed.
-// fn C.srand(seed int)
 // SysRNG is the PRNG provided by default in the libc implementiation that V uses.
 pub struct SysRNG {
 mut:
@@ -47,7 +43,7 @@ pub fn (mut r SysRNG) seed(seed_data []u32) {
 		exit(1)
 	}
 	r.seed = seed_data[0]
-	unsafe { C.srand(int(r.seed)) }
+	C.srand(r.seed)
 }
 
 // r.default_rand() exposes the default behavior of the system's RNG


### PR DESCRIPTION
~~Depends on #8727.~~
C.calloc is memory-safe (assuming the system traps dereferencing a null return value).

Also add C.rand because we already have C.srand.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
