### PR TITLE
parser: check not used expression for all exprs in multi-expr

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1020,13 +1020,16 @@ fn (mut p Parser) parse_multi_expr(is_top_level bool) ast.Stmt {
 	if p.tok.kind in [.assign, .decl_assign] || p.tok.kind.is_assign() {
 		return p.partial_assign_stmt(left, left_comments)
 	} else if !p.pref.translated
-		&& tok.kind !in [.key_if, .key_match, .key_lock, .key_rlock, .key_select]
-		&& left0 !is ast.CallExpr && (is_top_level || p.tok.kind != .rcbr)
-		&& left0 !is ast.PostfixExpr && !(left0 is ast.InfixExpr
-		&& (left0 as ast.InfixExpr).op in [.left_shift, .arrow]) && left0 !is ast.ComptimeCall
-		&& left0 !is ast.SelectorExpr {
-		p.error_with_pos('expression evaluated but not used', left0.position())
-		return ast.Stmt{}
+		&& tok.kind !in [.key_if, .key_match, .key_lock, .key_rlock, .key_select] {
+		for node in left {
+			if node !is ast.CallExpr && (is_top_level || p.tok.kind != .rcbr)
+				&& node !is ast.PostfixExpr && !(node is ast.InfixExpr
+				&& (node as ast.InfixExpr).op in [.left_shift, .arrow]) && node !is ast.ComptimeCall
+				&& node !is ast.SelectorExpr {
+				p.error_with_pos('expression evaluated but not used', node.position())
+				return ast.Stmt{}
+			}
+		}
 	}
 	pos.update_last_line(p.prev_tok.line_nr)
 	if left.len == 1 {

--- a/vlib/v/parser/tests/expr_evaluated_but_not_used_d.out
+++ b/vlib/v/parser/tests/expr_evaluated_but_not_used_d.out
@@ -1,7 +1,6 @@
-vlib/v/parser/tests/expr_evaluated_but_not_used_d.vv:4:5: error: expression evaluated but not used
+vlib/v/parser/tests/expr_evaluated_but_not_used_d.vv:4:19: error: expression evaluated but not used
     2 |     a := 1
     3 |     b := 2
-    4 |     a+b
-      |     ~~~
-    5 |     println(a*b)
-    6 | }
+    4 |     println(a*b), a+b
+      |                   ~~~
+    5 | }

--- a/vlib/v/parser/tests/expr_evaluated_but_not_used_d.vv
+++ b/vlib/v/parser/tests/expr_evaluated_but_not_used_d.vv
@@ -1,6 +1,5 @@
 fn main() {
     a := 1
     b := 2
-    a+b
-    println(a*b)
+    println(a*b), a+b
 }

--- a/vlib/v/parser/tests/expr_evaluated_but_not_used_e.out
+++ b/vlib/v/parser/tests/expr_evaluated_but_not_used_e.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/expr_evaluated_but_not_used_e.vv:3:14: error: expression evaluated but not used
+    1 | fn main() {
+    2 |     mut array := [1, 2, 3]
+    3 |     array << 4, 5
+      |                 ^
+    4 |     println(array)
+    5 | }

--- a/vlib/v/parser/tests/expr_evaluated_but_not_used_e.vv
+++ b/vlib/v/parser/tests/expr_evaluated_but_not_used_e.vv
@@ -1,0 +1,5 @@
+fn main() {
+	mut array := [1, 2, 3]
+	array << 4, 5
+	println(array)
+}


### PR DESCRIPTION
fix #8693 
Currently check only first expr of multi expr. This occurs c error like #8693 


<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
