### PR TITLE
checker: reject void type condition

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -213,7 +213,7 @@ fn C.RemoveDirectory() int
 fn C.GetStdHandle(u32) voidptr
 
 // fn C.SetConsoleMode()
-fn C.SetConsoleMode(voidptr, u32)
+fn C.SetConsoleMode(voidptr, u32) int
 
 // fn C.GetConsoleMode() int
 fn C.GetConsoleMode(voidptr, &u32) int

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4755,10 +4755,7 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) table.Type {
 				// check condition type is boolean
 				c.expected_type = table.bool_type
 				cond_typ := c.expr(branch.cond)
-				if cond_typ.idx() !in [table.bool_type_idx, table.void_type_idx]
-					&& !c.pref.translated {
-					// void types are skipped, because they mean the var was initialized incorrectly
-					// (via missing function etc)
+				if cond_typ.idx() != table.bool_type_idx && !c.pref.translated {
 					typ_sym := c.table.get_type_symbol(cond_typ)
 					c.error('non-bool type `$typ_sym.name` used as if condition', branch.pos)
 				}

--- a/vlib/v/checker/tests/if_non_bool_cond.out
+++ b/vlib/v/checker/tests/if_non_bool_cond.out
@@ -1,0 +1,20 @@
+vlib/v/checker/tests/if_non_bool_cond.vv:2:2: error: non-bool type `string` used as if condition
+    1 | fn main() {
+    2 |     if '10' {
+      |     ~~~~~~~
+    3 |         println('10')
+    4 |     }
+vlib/v/checker/tests/if_non_bool_cond.vv:6:2: error: non-bool type `int literal` used as if condition
+    4 |     }
+    5 | 
+    6 |     if 5 {
+      |     ~~~~
+    7 |         println(5)
+    8 |     }
+vlib/v/checker/tests/if_non_bool_cond.vv:10:2: error: non-bool type `void` used as if condition
+    8 |     }
+    9 | 
+   10 |     if println('v') {
+      |     ~~~~~~~~~~~~~~~
+   11 |         println('println')
+   12 |     }

--- a/vlib/v/checker/tests/if_non_bool_cond.vv
+++ b/vlib/v/checker/tests/if_non_bool_cond.vv
@@ -1,0 +1,13 @@
+fn main() {
+	if '10' {
+		println('10')
+	}
+
+	if 5 {
+		println(5)
+	}
+
+	if println('v') {
+		println('println')
+	}
+}


### PR DESCRIPTION
Because checker skip void type, if println('') will be c error. But it should be checker error

// void types are skipped, because they mean the var was initialized incorrectly
// (via missing function etc)

I don't know reason of skipping this check for void type. If missing function is used, no need to skip this check imho.

~~At least, ci is passed~~ WIP. I'll do it
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
