### PR TITLE
cli: fix typo

### DIFF
--- a/examples/cli.v
+++ b/examples/cli.v
@@ -34,7 +34,7 @@ fn main() {
 	greet_cmd.add_flag(Flag{
 	 	flag: .string
 	 	name: 'fun'
-	 	multipe: true
+	 	multiple: true
 	 	description: 'Just a dumby flags to show multiple.'
 	})
 	cmd.add_command(greet_cmd)

--- a/vlib/cli/flag.v
+++ b/vlib/cli/flag.v
@@ -22,7 +22,7 @@ pub mut:
 	// If allow multiple value.
 	// If bool, multiple has no impact, bool can only set once.
 	// If not multiple, and multiple value set at command args, raise an error.
-	multipe bool
+	multiple bool
 mut:
 	// Set true if flag found.
 	found bool
@@ -206,7 +206,7 @@ fn (mut flag Flag) parse(args []string, with_abbrev bool) ?[]string {
 			new_args := flag.parse_bool(args) ?
 			return new_args
 		} else {
-			if flag.value.len > 0 && !flag.multipe {
+			if flag.value.len > 0 && !flag.multiple {
 				return error('The argument `$flag.name` accept only one value!')
 			}
 

--- a/vlib/cli/flag_test.v
+++ b/vlib/cli/flag_test.v
@@ -20,7 +20,7 @@ fn test_if_string_flag_parses() {
 	flag = cli.Flag{
 		flag: .string
 		name: 'flag'
-		multipe: true
+		multiple: true
 	}
 	flag.parse(['-flag=value1'], false) or { panic(err) }
 	flag.parse(['-flag=value2'], false) or { panic(err) }
@@ -31,7 +31,7 @@ fn test_if_string_flag_parses() {
 		cli.Flag{
 			flag: .string
 			name: 'flag'
-			multipe: true
+			multiple: true
 			value: ['a', 'b', 'c']
 		},
 		cli.Flag{
@@ -90,7 +90,7 @@ fn test_if_int_flag_parses() {
 	flag = cli.Flag{
 		flag: .int
 		name: 'flag'
-		multipe: true
+		multiple: true
 	}
 
 	flag.parse(['-flag=42'], false) or { panic(err) }
@@ -102,7 +102,7 @@ fn test_if_int_flag_parses() {
 		cli.Flag{
 			flag: .int
 			name: 'flag'
-			multipe: true
+			multiple: true
 			value: ['1', '2', '3']
 		},
 		cli.Flag{
@@ -138,7 +138,7 @@ fn test_if_float_flag_parses() {
 	flag = cli.Flag{
 		flag: .float
 		name: 'flag'
-		multipe: true
+		multiple: true
 	}
 
 	flag.parse(['-flag=3.1'], false) or { panic(err) }
@@ -150,7 +150,7 @@ fn test_if_float_flag_parses() {
 		cli.Flag{
 			flag: .float
 			name: 'flag'
-			multipe: true
+			multiple: true
 			value: ['1.1', '2.2', '3.3']
 		},
 		cli.Flag{


### PR DESCRIPTION
I think there's a misspelled word: `multipe` should be `multiple`, right?