### PR TITLE
tetris: fix high dpi scaling

### DIFF
--- a/examples/tetris/tetris.v
+++ b/examples/tetris/tetris.v
@@ -144,8 +144,8 @@ fn (mut game Game) showfps() {
 
 fn frame(mut game Game) {
 	ws := gg.window_size()
-	bs := remap(block_size, 0, win_height, 0, ws.height)
-	m := (f32(ws.width) - bs * field_width) * 0.5
+	bs := remap(block_size, 0, win_height, 0, ws.height) / game.gg.scale
+	m := ((f32(ws.width) - bs * field_width) / game.gg.scale) * 0.5  / game.gg.scale
 	game.block_size = int(bs)
 	game.margin = int(m)
 	game.frame_sw.restart()


### PR DESCRIPTION
This tries to fix problems introduced in c818ad9 - with tetros scaling too much on high dpi monitors.
This should close #8738 

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
