### PR TITLE
Fixed 'length' typo in two spots.

### DIFF
--- a/vlib/encoding/utf8/utf8_util.v
+++ b/vlib/encoding/utf8/utf8_util.v
@@ -17,7 +17,7 @@ Utility functions
 
 */
 
-// len return the leght as number of unicode chars from a string
+// len return the length as number of unicode chars from a string
 pub fn len(s string) int {
 	mut count := 0
 	mut index := 0
@@ -33,7 +33,7 @@ pub fn len(s string) int {
 	return count
 }
 
-// u_len return the leght as number of unicode chars from a ustring
+// u_len return the length as number of unicode chars from a ustring
 pub fn u_len(s ustring) int {
 	return len(s.s)
 }


### PR DESCRIPTION
Length was misspelled in the docstrings in two locations. 