### PR TITLE
os: add test for os.file_name

### DIFF
--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -415,6 +415,19 @@ fn test_base() {
 	assert os.base('filename') == 'filename'
 }
 
+fn test_file_name() {
+	$if windows {
+		assert os.file_name('v\\vlib\\os\\os.v') == 'os.v'
+		assert os.file_name('v\\vlib\\os\\') == ''
+		assert os.file_name('v\\vlib\\os') == 'os'
+	} $else {
+		assert os.file_name('v/vlib/os/os.v') == 'os.v'
+		assert os.file_name('v/vlib/os/') == ''
+		assert os.file_name('v/vlib/os') == 'os'
+	}
+	assert os.file_name('filename') == 'filename'
+}
+
 fn test_uname() {
 	u := os.uname()
 	assert u.sysname.len > 0


### PR DESCRIPTION
Currently, there is no test for `os.file_name`.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
