### PR TITLE
checker: let `[unsafe]` on a fn, mark the whole function body as unsafe

### DIFF
--- a/vlib/gg/m4/m4_test.v
+++ b/vlib/gg/m4/m4_test.v
@@ -1,185 +1,179 @@
 import gg.m4
 
+[unsafe]
 pub fn test_m4() {
-	unsafe {
-		// Test Mat4
-		mut a := m4.Mat4{ e: [
-			f32(0),	1,	2,	3,
-				4,	5,	6,	7,
-				8,	9,	10,	11,
-				12,	13,	14,	15,
-				]!
-		}
-		mut b := m4.Mat4{}
-		mut c := m4.Mat4{}
+	// Test Mat4
+	mut a := m4.Mat4{ e: [
+		f32(0),	1,	2,	3,
+			4,	5,	6,	7,
+			8,	9,	10,	11,
+			12,	13,	14,	15,
+			]!
+	}
+	mut b := m4.Mat4{}
+	mut c := m4.Mat4{}
 
-		// equal test
-		assert a.e == [
-			f32(0),	1,	2,	3,
-				4,	5,	6,	7,
-				8,	9,	10,	11,
-				12,	13,	14,	15,
-				]!
+	// equal test
+	assert a.e == [
+		f32(0),	1,	2,	3,
+			4,	5,	6,	7,
+			8,	9,	10,	11,
+			12,	13,	14,	15,
+			]!
 
-		// copy test
-		b.copy(a)
-		assert a.e == b.e
+	// copy test
+	b.copy(a)
+	assert a.e == b.e
 
-		// test: transpose, scale
-		assert b.transpose().mul_scalar(2.0).mul_scalar(0.5).transpose().e == a.e
-		assert b.sum_all() == 120.0
+	// test: transpose, scale
+	assert b.transpose().mul_scalar(2.0).mul_scalar(0.5).transpose().e == a.e
+	assert b.sum_all() == 120.0
 
-		// test rows/columns set/get
-		for i in 0 .. 4 {
-			b = m4.zero_m4()
-			b.set_row(i, m4.Vec4{ e: [f32(1.0), 2, 3, 4]! })
-			assert b.get_f(0, i) == 1.0
-			assert b.get_f(1, i) == 2.0
-			assert b.get_f(2, i) == 3.0
-			assert b.get_f(3, i) == 4.0
-			// println(b)
-			c = m4.zero_m4()
-			c.set_col(i, m4.Vec4{ e: [f32(1.0), 2, 3, 4]! })
-			assert c.get_f(i, 0) == 1.0
-			assert c.get_f(i, 1) == 2.0
-			assert c.get_f(i, 2) == 3.0
-			assert c.get_f(i, 3) == 4.0
-			// println(c)
-		}
+	// test rows/columns set/get
+	for i in 0 .. 4 {
+		b = m4.zero_m4()
+		b.set_row(i, m4.Vec4{ e: [f32(1.0), 2, 3, 4]! })
+		assert b.get_f(0, i) == 1.0
+		assert b.get_f(1, i) == 2.0
+		assert b.get_f(2, i) == 3.0
+		assert b.get_f(3, i) == 4.0
+		// println(b)
+		c = m4.zero_m4()
+		c.set_col(i, m4.Vec4{ e: [f32(1.0), 2, 3, 4]! })
+		assert c.get_f(i, 0) == 1.0
+		assert c.get_f(i, 1) == 2.0
+		assert c.get_f(i, 2) == 3.0
+		assert c.get_f(i, 3) == 4.0
+		// println(c)
 	}
 }
 
+[unsafe]
 fn test_swap_col_row() {
-	unsafe {
-		// swap_col / swap_row
-		b := m4.Mat4{ e: [
-			f32(1),	2,	3,	4,
-				5,	6,	7,	8,
-				9,	10,	11,	12,
-				13,	14,	15,	16,
-				]!
-		}
-		b.swap_col(0, 2)
-		assert b.e == [
-			f32(3),	2,	1,	4,
-				7,	6,	5,	8,
-				11,	10,	9,	12,
-				15,	14,	13,	16,
-				]!
-		b = m4.Mat4{ e: [
-			f32(1),	2,	3,	4,
-				5,	6,	7,	8,
-				9,	10,	11,	12,
-				13,	14,	15,	16,
-				]!
-		}
-		b.swap_row(0, 2)
-		assert b.e == [
-			f32(9),	10,	11,	12,
-				5,	6,	7,	8,
-				1,	2,	3,	4,
-				13,	14,	15,	16,
-				]!
+	// swap_col / swap_row
+	b := m4.Mat4{ e: [
+		f32(1),	2,	3,	4,
+			5,	6,	7,	8,
+			9,	10,	11,	12,
+			13,	14,	15,	16,
+			]!
 	}
+	b.swap_col(0, 2)
+	assert b.e == [
+		f32(3),	2,	1,	4,
+			7,	6,	5,	8,
+			11,	10,	9,	12,
+			15,	14,	13,	16,
+			]!
+	b = m4.Mat4{ e: [
+		f32(1),	2,	3,	4,
+			5,	6,	7,	8,
+			9,	10,	11,	12,
+			13,	14,	15,	16,
+			]!
+	}
+	b.swap_row(0, 2)
+	assert b.e == [
+		f32(9),	10,	11,	12,
+			5,	6,	7,	8,
+			1,	2,	3,	4,
+			13,	14,	15,	16,
+			]!
 }
 
+[unsafe]
 fn test_sum_sub() {
-	unsafe {
-		// test sum/sub
-		b := m4.unit_m4()
-		c := m4.unit_m4()
-		assert m4.sub(m4.add(b, c), b).e == m4.unit_m4().e
-		assert (b + c - b).e == m4.unit_m4().e
-	}
+	// test sum/sub
+	b := m4.unit_m4()
+	c := m4.unit_m4()
+	assert m4.sub(m4.add(b, c), b).e == m4.unit_m4().e
+	assert (b + c - b).e == m4.unit_m4().e
 }
 
+[unsafe]
 fn test_transpose() {
-	unsafe {
-		b := m4.Mat4{ e: [
-			f32(0),	1,	2,	3,
-				4,	5,	6,	7,
-				8,	9,	10,	11,
-				12,	13,	14,	15,
-				]!
-		}
-		assert b.transpose().transpose().e == b.e
+	b := m4.Mat4{ e: [
+		f32(0),	1,	2,	3,
+			4,	5,	6,	7,
+			8,	9,	10,	11,
+			12,	13,	14,	15,
+			]!
 	}
+	assert b.transpose().transpose().e == b.e
 }
 
+[unsafe]
 fn test_multiplication() {
-	unsafe {
-		b := m4.Mat4{ e: [
-			f32(1),	0,	0,	0,
-				0,	2,	0,	0,
-				0,	0,	3,	0,
-				0,	0,	0,	4,
-				]!
-		}
-		c := m4.Mat4{ e: [
-			f32(1),	2,	3,	4,
-				5,	6,	7,	8,
-				9,	10,	11,	12,
-				13,	14,	15,	16,
-				]!
-		}
-
-		assert (c * c).e == [
-			f32(90),100,110,120,
-				202,228,254,280,
-				314,356,398,440,
-				426,484,542,600,
-				]!
-
-		assert m4.mul(c, c).e == [
-			f32(90),100,110,120,
-				202,228,254,280,
-				314,356,398,440,
-				426,484,542,600,
-		]!
-
-		assert m4.mul(b, c).e == [
-			f32(1),	2,	3,	4,
-				10,	12,	14,	16,
-				27,	30,	33,	36,
-				52,	56,	60,	64,
-				]!
-
-		assert (b * c).e == [
-			f32(1),	2,	3,	4,
-				10,	12,	14,	16,
-				27,	30,	33,	36,
-				52,	56,	60,	64,
-				]!
-
-		assert m4.det(b) == 24
+	b := m4.Mat4{ e: [
+		f32(1),	0,	0,	0,
+			0,	2,	0,	0,
+			0,	0,	3,	0,
+			0,	0,	0,	4,
+			]!
 	}
+	c := m4.Mat4{ e: [
+		f32(1),	2,	3,	4,
+			5,	6,	7,	8,
+			9,	10,	11,	12,
+			13,	14,	15,	16,
+			]!
+	}
+
+	assert (c * c).e == [
+		f32(90),100,110,120,
+			202,228,254,280,
+			314,356,398,440,
+			426,484,542,600,
+			]!
+
+	assert m4.mul(c, c).e == [
+		f32(90),100,110,120,
+			202,228,254,280,
+			314,356,398,440,
+			426,484,542,600,
+			]!
+
+	assert m4.mul(b, c).e == [
+		f32(1),	2,	3,	4,
+			10,	12,	14,	16,
+			27,	30,	33,	36,
+			52,	56,	60,	64,
+			]!
+
+	assert (b * c).e == [
+		f32(1),	2,	3,	4,
+			10,	12,	14,	16,
+			27,	30,	33,	36,
+			52,	56,	60,	64,
+			]!
+
+	assert m4.det(b) == 24
 }
 
+[unsafe]
 fn test_det() {
-	unsafe {
-		b := m4.Mat4{ e: [
-			f32(5),	6,	6,	8,
-				2,	2,	2,	8,
-				6,	6,	2,	8,
-				2,	3,	6,	7,
-				]!
-		}
-		assert m4.det(b) == -8
-
-		c := m4.Mat4{ e: [
-			f32(1),	8,	2,	3,
-				8,	2,	3,	1,
-				2,	3,	3,	2,
-				3,	1,	2,	4,
-				]!
-		}
-		// println("*** INVERSE ****")
-		// println(m4.mul(b.inverse(),b))
-		// println(m4.clean_small(m4.mul(c.inverse(),c)))
-		// println("****************")
-		assert m4.mul(b.inverse(), b).e == m4.unit_m4().e
-		assert m4.mul(c.inverse(), c).is_equal(m4.unit_m4())
+	b := m4.Mat4{ e: [
+		f32(5),	6,	6,	8,
+			2,	2,	2,	8,
+			6,	6,	2,	8,
+			2,	3,	6,	7,
+			]!
 	}
+	assert m4.det(b) == -8
+
+	c := m4.Mat4{ e: [
+		f32(1),	8,	2,	3,
+			8,	2,	3,	1,
+			2,	3,	3,	2,
+			3,	1,	2,	4,
+			]!
+	}
+	// println("*** INVERSE ****")
+	// println(m4.mul(b.inverse(),b))
+	// println(m4.clean_small(m4.mul(c.inverse(),c)))
+	// println("****************")
+	assert m4.mul(b.inverse(), b).e == m4.unit_m4().e
+	assert m4.mul(c.inverse(), c).is_equal(m4.unit_m4())
 }
 
 fn test_vec4() {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5737,7 +5737,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 	if node.name == 'main.main' {
 		c.main_fn_decl_node = node
 	}
-    
+
 	prev_unsafe := c.inside_unsafe
 	mut is_unsafe := c.inside_unsafe
 	for attr in node.attrs {


### PR DESCRIPTION
After this PR:
```v
[unsafe]
fn abc() {
    // statements
}
```
... in addition to requiring `unsafe { abc() }`, also considers all statements in the function body to be unsafe, i.e. as if you have written:
```v
[unsafe]
fn abc() {
     unsafe {
         // statements
     }
}
```
This saves 1 level of indentation, which can be more readable, when you are working on a low level library.