### PR TITLE
fmt: fix bug that vfmt removes emmbeded struct in single-line struct

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -643,7 +643,7 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl) {
 		f.write(gtypes)
 		f.write('>')
 	}
-	if node.fields.len == 0 && node.pos.line_nr == node.pos.last_line {
+	if node.fields.len == 0 && node.embeds.len == 0 && node.pos.line_nr == node.pos.last_line {
 		f.writeln(' {}\n')
 		return
 	}

--- a/vlib/v/fmt/tests/struct_embed_keep.vv
+++ b/vlib/v/fmt/tests/struct_embed_keep.vv
@@ -10,3 +10,8 @@ struct Bar {
 	y int
 	z string
 }
+
+struct Baz {
+	Foo
+	Test
+}

--- a/vlib/v/fmt/tests/structs_expected.vv
+++ b/vlib/v/fmt/tests/structs_expected.vv
@@ -19,6 +19,10 @@ pub mut:
 	pub_mut_field string
 }
 
+struct Bar {
+	Foo
+}
+
 fn new_user() User {
 	return User{
 		name: 'Serious Sam'

--- a/vlib/v/fmt/tests/structs_input.vv
+++ b/vlib/v/fmt/tests/structs_input.vv
@@ -19,6 +19,8 @@ struct Foo {
 	pub_mut_field string
 }
 
+struct Bar { Foo }
+
 fn new_user()
 User
 {


### PR DESCRIPTION
fix #8761
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
