### PR TITLE
crypto/rand: use byteptr.vbytes instead of c_array_to_bytes_tmp

### DIFF
--- a/vlib/crypto/rand/rand.v
+++ b/vlib/crypto/rand/rand.v
@@ -7,20 +7,3 @@ module rand
 const (
 	read_error = error('crypto.rand.read() error reading random bytes')
 )
-
-// NOTE: temp until we have []bytes(buff)
-fn c_array_to_bytes_tmp(len int, buffer voidptr) []byte {
-
-	mut arr := []byte{len:len, cap:1}
-	arr.data = buffer
-	/*
-
-	arr = array {
-		len: len
-		cap: 1
-		element_size: 1
-		data: buffer
-	}
-	*/
-	return arr
-}

--- a/vlib/crypto/rand/rand_darwin.c.v
+++ b/vlib/crypto/rand/rand_darwin.c.v
@@ -12,10 +12,10 @@ fn C.SecRandomCopyBytes() int
 
 // read returns an array of `bytes_needed` random bytes read from the OS.
 pub fn read(bytes_needed int) ?[]byte {
-	mut buffer := malloc(bytes_needed)
-	status := C.SecRandomCopyBytes(0, bytes_needed, buffer)
+	mut buffer := unsafe { malloc(bytes_needed).vbytes(bytes_needed) }
+	status := C.SecRandomCopyBytes(0, bytes_needed, buffer.data)
 	if status != 0 {
 		return read_error
 	}
-	return c_array_to_bytes_tmp(bytes_needed, buffer)
+	return buffer
 }

--- a/vlib/crypto/rand/rand_darwin.c.v
+++ b/vlib/crypto/rand/rand_darwin.c.v
@@ -12,7 +12,7 @@ fn C.SecRandomCopyBytes() int
 
 // read returns an array of `bytes_needed` random bytes read from the OS.
 pub fn read(bytes_needed int) ?[]byte {
-	mut buffer := unsafe { malloc(bytes_needed).vbytes(bytes_needed) }
+	mut buffer := []byte{ len: bytes_needed }
 	status := C.SecRandomCopyBytes(0, bytes_needed, buffer.data)
 	if status != 0 {
 		return read_error

--- a/vlib/crypto/rand/rand_linux.c.v
+++ b/vlib/crypto/rand/rand_linux.c.v
@@ -10,27 +10,20 @@ const (
 
 // read returns an array of `bytes_needed` random bytes read from the OS.
 pub fn read(bytes_needed int) ?[]byte {
-	mut buffer := &byte(0)
-	unsafe {
-		buffer = malloc(bytes_needed)
-	}
-	mut bstart := buffer
+	mut buffer := unsafe { malloc(bytes_needed) }
 	mut bytes_read := 0
 	mut remaining_bytes := bytes_needed
 	// getrandom syscall wont block if requesting <= 256 bytes
 	for bytes_read < bytes_needed {
 		batch_size := if remaining_bytes > read_batch_size { read_batch_size } else { remaining_bytes }
-		unsafe {
-			bstart = buffer + bytes_read
-		}
-		rbytes := getrandom(batch_size, bstart)
+		rbytes := unsafe { getrandom(batch_size, buffer + bytes_read) }
 		if rbytes == -1 {
 			unsafe { free(buffer) }
 			return read_error
 		}
 		bytes_read += rbytes
 	}
-	return c_array_to_bytes_tmp(bytes_needed, buffer)
+	return buffer.vbytes(bytes_needed)
 }
 
 fn getrandom(bytes_needed int, buffer voidptr) int {

--- a/vlib/crypto/rand/rand_linux.c.v
+++ b/vlib/crypto/rand/rand_linux.c.v
@@ -23,7 +23,7 @@ pub fn read(bytes_needed int) ?[]byte {
 		}
 		bytes_read += rbytes
 	}
-	return buffer.vbytes(bytes_needed)
+	return unsafe {buffer.vbytes(bytes_needed)}
 }
 
 fn getrandom(bytes_needed int, buffer voidptr) int {

--- a/vlib/crypto/rand/rand_solaris.c.v
+++ b/vlib/crypto/rand/rand_solaris.c.v
@@ -22,12 +22,12 @@ pub fn read(bytes_needed int) ?[]byte {
 		batch_size := if remaining_bytes > read_batch_size { read_batch_size } else { remaining_bytes }
 		rbytes := unsafe { getrandom(batch_size, buffer + bytes_read) }
 		if rbytes == -1 {
-			free(buffer)
+			unsafe { free(buffer) }
 			return read_error
 		}
 		bytes_read += rbytes
 	}
-	return buffer.vbytes(bytes_needed)
+	return unsafe {buffer.vbytes(bytes_needed)}
 }
 
 fn v_getrandom(bytes_needed int, buffer voidptr) int {

--- a/vlib/crypto/rand/rand_solaris.c.v
+++ b/vlib/crypto/rand/rand_solaris.c.v
@@ -14,27 +14,20 @@ const (
 
 // read returns an array of `bytes_needed` random bytes read from the OS.
 pub fn read(bytes_needed int) ?[]byte {
-	mut buffer := &byte(0)
-	unsafe {
-		buffer = malloc(bytes_needed)
-	}
-	mut bstart := buffer
+	mut buffer := unsafe { malloc(bytes_needed) }
 	mut bytes_read := 0
 	mut remaining_bytes := bytes_needed
 	// getrandom syscall wont block if requesting <= 256 bytes
 	for bytes_read < bytes_needed {
 		batch_size := if remaining_bytes > read_batch_size { read_batch_size } else { remaining_bytes }
-		unsafe {
-			bstart = buffer + bytes_read
-		}
-		rbytes := getrandom(batch_size, bstart)
+		rbytes := unsafe { getrandom(batch_size, buffer + bytes_read) }
 		if rbytes == -1 {
 			free(buffer)
 			return read_error
 		}
 		bytes_read += rbytes
 	}
-	return c_array_to_bytes_tmp(bytes_needed, buffer)
+	return buffer.vbytes(bytes_needed)
 }
 
 fn v_getrandom(bytes_needed int, buffer voidptr) int {

--- a/vlib/crypto/rand/rand_windows.c.v
+++ b/vlib/crypto/rand/rand_windows.c.v
@@ -15,11 +15,11 @@ const (
 
 // read returns an array of `bytes_needed` random bytes read from the OS.
 pub fn read(bytes_needed int) ?[]byte {
-	mut buffer := unsafe {malloc(bytes_needed)}
+	mut buffer := unsafe { malloc(bytes_needed).vbytes(bytes_needed) }
 	// use bcrypt_use_system_preferred_rng because we passed null as algo
-	status := C.BCryptGenRandom(0, buffer, bytes_needed, bcrypt_use_system_preferred_rng)
+	status := C.BCryptGenRandom(0, buffer.data, bytes_needed, bcrypt_use_system_preferred_rng)
 	if status != status_success {
 		return read_error
 	}
-	return c_array_to_bytes_tmp(bytes_needed, buffer)
+	return buffer
 }

--- a/vlib/crypto/rand/rand_windows.c.v
+++ b/vlib/crypto/rand/rand_windows.c.v
@@ -15,7 +15,7 @@ const (
 
 // read returns an array of `bytes_needed` random bytes read from the OS.
 pub fn read(bytes_needed int) ?[]byte {
-	mut buffer := unsafe { malloc(bytes_needed).vbytes(bytes_needed) }
+	mut buffer := []byte{ len: bytes_needed }
 	// use bcrypt_use_system_preferred_rng because we passed null as algo
 	status := C.BCryptGenRandom(0, buffer.data, bytes_needed, bcrypt_use_system_preferred_rng)
 	if status != status_success {


### PR DESCRIPTION
Also fixes an unsafe warnings for `malloc` on darwin, `free` on solaris.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
