### PR TITLE
fmt: dont prepend mod to selectivly imported types from nested module

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -80,9 +80,11 @@ pub fn fmt(file ast.File, table &table.Table, pref &pref.Preferences, is_debug b
 
 pub fn (mut f Fmt) process_file_imports(file &ast.File) {
 	for imp in file.imports {
-		f.mod2alias[imp.mod.all_after_last('.')] = imp.alias
+		mod := imp.mod.all_after_last('.')
+		f.mod2alias[mod] = imp.alias
 		for sym in imp.syms {
 			f.mod2alias['${imp.mod}.$sym.name'] = sym.name
+			f.mod2alias['${mod}.$sym.name'] = sym.name
 			f.mod2alias[sym.name] = sym.name
 			f.import_syms_used[sym.name] = false
 		}

--- a/vlib/v/fmt/tests/import_selective_expected.vv
+++ b/vlib/v/fmt/tests/import_selective_expected.vv
@@ -1,7 +1,12 @@
 import math { max, min }
+import math.complex { complex, Complex }
 import os {
 	user_os,
 	file_ext,
+}
+
+fn imaginary(im f64) Complex {
+	return complex(0, im)
 }
 
 fn main() {
@@ -9,4 +14,5 @@ fn main() {
 	println(min(0.1, 0.2))
 	println(user_os())
 	println(file_ext('main.v'))
+	println(imaginary(1))
 }

--- a/vlib/v/fmt/tests/import_selective_input.vv
+++ b/vlib/v/fmt/tests/import_selective_input.vv
@@ -1,12 +1,18 @@
 import math { max,
 	min,
 }
+import math.complex { complex, Complex }
 import os {
 	input, user_os, file_ext }
+
+fn imaginary(im f64) Complex {
+	return complex(0, im)
+}
 
 fn main() {
 	println(max(0.1, 0.2))
 	println(min(0.1, 0.2))
 	println(user_os())
 	println(file_ext('main.v'))
+	println(imaginary(1))
 }


### PR DESCRIPTION
About this code

```v
import math.complex { Complex }

fn foo() Complex {
}
```

current v fmt prints below

```v
import math.complex { Complex }

fn foo() complex.Complex {
}
```

This PR make vfmt don't prepend mod name (for this example, v fmt do nothing)
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
