### PR TITLE
fmt: mark types import as used in struct_decl

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -674,6 +674,7 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl) {
 		}
 	}
 	for embed in node.embeds {
+		f.mark_types_import_as_used(embed.typ)
 		styp := f.table.type_to_str(embed.typ)
 		f.writeln('\t$styp')
 	}
@@ -728,6 +729,7 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl) {
 		}
 		f.write(strings.repeat(` `, field_align.max_len - field.name.len - comments_len))
 		f.write(field_types[i])
+		f.mark_types_import_as_used(field.typ)
 		attrs_len := inline_attrs_len(field.attrs)
 		has_attrs := field.attrs.len > 0
 		if has_attrs {

--- a/vlib/v/fmt/tests/import_selective_expected.vv
+++ b/vlib/v/fmt/tests/import_selective_expected.vv
@@ -1,8 +1,13 @@
 import math { max, min }
+import cli { Command }
 import math.complex { complex, Complex }
 import os {
 	user_os,
 	file_ext,
+}
+
+struct App {
+	command Command
 }
 
 fn imaginary(im f64) Complex {

--- a/vlib/v/fmt/tests/import_selective_input.vv
+++ b/vlib/v/fmt/tests/import_selective_input.vv
@@ -1,9 +1,15 @@
 import math { max,
 	min,
 }
+
+import cli { Command }
 import math.complex { complex, Complex }
 import os {
 	input, user_os, file_ext }
+
+struct App {
+	command Command
+}
 
 fn imaginary(im f64) Complex {
 	return complex(0, im)


### PR DESCRIPTION
In some cases, v fmt removes selective import because No marking as used was done in struct decl. This PR fix it.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
