### PR TITLE
cli: don't sort flags / commands by default

### DIFF
--- a/vlib/cli/command.v
+++ b/vlib/cli/command.v
@@ -21,8 +21,8 @@ pub mut:
 	disable_help    bool
 	disable_version bool
 	disable_flags   bool
-	sort_flags      bool     = true
-	sort_commands   bool     = true
+	sort_flags      bool
+	sort_commands   bool
 	parent          &Command = 0
 	commands        []Command
 	flags           []Flag


### PR DESCRIPTION
But cli should keep original order by default because sorts mixes up commands and default commands. 

For example, help of command that have two subcommands, `foo`, `some`  will be like:

```
# 1. enable sorting
Commands:
  foo
  help
  some
  version

# 2. disable sorting
Commands:
  foo
  some
  help
  version
```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
