### PR TITLE
pref: make multiple targets an error

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -400,7 +400,7 @@ pub fn parse_args(args []string) (&Preferences, string) {
 				i++
 			}
 			else {
-				if command == 'build' && (arg.ends_with('.v') || os.exists(command)) {
+				if command == 'build' && is_source_file(arg) {
 					eprintln('Use `v $arg` instead.')
 					exit(1)
 				}
@@ -417,6 +417,9 @@ pub fn parse_args(args []string) (&Preferences, string) {
 						if command == 'run' {
 							break
 						}
+					} else if is_source_file(command) && is_source_file(arg) {
+						eprintln('Too many targets. Specify just one target: <target.v|target_directory>.')
+						exit(1)
 					}
 					continue
 				}
@@ -440,7 +443,7 @@ pub fn parse_args(args []string) (&Preferences, string) {
 		eprintln('Cannot save output binary in a .v file.')
 		exit(1)
 	}
-	if command.ends_with('.v') || os.exists(command) {
+	if is_source_file(command) {
 		res.path = command
 	} else if command == 'run' {
 		res.is_run = true
@@ -513,6 +516,11 @@ fn must_exist(path string) {
 		eprintln('v expects that `$path` exists, but it does not')
 		exit(1)
 	}
+}
+
+[inline]
+fn is_source_file(path string) bool {
+	return path.ends_with('.v') || os.exists(path)
 }
 
 pub fn backend_from_string(s string) ?Backend {


### PR DESCRIPTION
Currently `v a.v b.v` compiles a.v only with no error.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
