### PR TITLE
cgen: check unknown sizeof type (fix #8806)

### DIFF
--- a/vlib/v/checker/tests/unknown_sizeof_type_err_a.out
+++ b/vlib/v/checker/tests/unknown_sizeof_type_err_a.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/unknown_sizeof_type_err_a.vv:14:34: cgen error: unknown type `T`
+   12 |     println("size of Abc: ${sizeof(Abc)}")
+   13 |     println("size of Xyz: ${sizeof(Xyz)}")
+   14 |     println("size of Test: ${sizeof(T)}")
+      |                                     ^
+   15 | }

--- a/vlib/v/checker/tests/unknown_sizeof_type_err_a.vv
+++ b/vlib/v/checker/tests/unknown_sizeof_type_err_a.vv
@@ -1,0 +1,15 @@
+struct Abc {
+	i int
+}
+
+struct Xyz {
+	f f64
+}
+
+type Test = Abc | Xyz
+
+fn main() {
+	println("size of Abc: ${sizeof(Abc)}")
+	println("size of Xyz: ${sizeof(Xyz)}")
+	println("size of Test: ${sizeof(T)}")
+}

--- a/vlib/v/checker/tests/unknown_sizeof_type_err_b.out
+++ b/vlib/v/checker/tests/unknown_sizeof_type_err_b.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/unknown_sizeof_type_err_b.vv:14:34: cgen error: unknown type `Zabc`
+   12 |     println("size of Abc: ${sizeof(Abc)}")
+   13 |     println("size of Xyz: ${sizeof(Xyz)}")
+   14 |     println("size of Test: ${sizeof(Zabc)}")
+      |                                     ~~~~
+   15 | }

--- a/vlib/v/checker/tests/unknown_sizeof_type_err_b.vv
+++ b/vlib/v/checker/tests/unknown_sizeof_type_err_b.vv
@@ -1,0 +1,15 @@
+struct Abc {
+	i int
+}
+
+struct Xyz {
+	f f64
+}
+
+type Test = Abc | Xyz
+
+fn main() {
+	println("size of Abc: ${sizeof(Abc)}")
+	println("size of Xyz: ${sizeof(Xyz)}")
+	println("size of Test: ${sizeof(Zabc)}")
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2786,6 +2786,10 @@ fn (mut g Gen) expr(node ast.Expr) {
 		}
 		ast.SizeOf {
 			node_typ := g.unwrap_generic(node.typ)
+			sym := g.table.get_type_symbol(node_typ)
+			if sym.language == .v && sym.kind in [.placeholder, .any] {
+				g.error('unknown type `$sym.name`', node.pos)
+			}
 			styp := g.typ(node_typ)
 			g.write('/*SizeOf*/ sizeof(${util.no_dots(styp)})')
 		}

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -163,9 +163,9 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			}
 		}
 		.key_sizeof {
-			pos := p.tok.position()
 			p.next() // sizeof
 			p.check(.lpar)
+			pos := p.tok.position()
 			is_known_var := p.mark_var_as_used(p.tok.lit)
 			// assume mod. prefix leads to a type
 			if is_known_var || !(p.known_import(p.tok.lit) || p.tok.kind.is_start_of_type()) {


### PR DESCRIPTION
This PR check unknown sizeof type (fix #8806).

- Check unknown sizeof type.
- Check in cgen because of generic type.
- Add tests.

```vlang
struct Abc {
	i int
}

struct Xyz {
	f f64
}

type Test = Abc | Xyz

fn main() {
	println("size of Abc: ${sizeof(Abc)}")
	println("size of Xyz: ${sizeof(Xyz)}")
	println("size of Test: ${sizeof(T)}")
}

vlib/v/checker/tests/unknown_sizeof_type_err_a.vv:14:34: cgen error: unknown type `T`
   12 |     println("size of Abc: ${sizeof(Abc)}")
   13 |     println("size of Xyz: ${sizeof(Xyz)}")
   14 |     println("size of Test: ${sizeof(T)}")
      |                                     ^
   15 | }
```
```vlang
struct Abc {
	i int
}

struct Xyz {
	f f64
}

type Test = Abc | Xyz

fn main() {
	println("size of Abc: ${sizeof(Abc)}")
	println("size of Xyz: ${sizeof(Xyz)}")
	println("size of Test: ${sizeof(Zabc)}")
}

vlib/v/checker/tests/unknown_sizeof_type_err_b.vv:14:34: cgen error: unknown type `Zabc`
   12 |     println("size of Abc: ${sizeof(Abc)}")
   13 |     println("size of Xyz: ${sizeof(Xyz)}")
   14 |     println("size of Test: ${sizeof(Zabc)}")
      |                                     ~~~~
   15 | }
```