### PR TITLE
builder: support -m32/-m64 flags for msvc

### DIFF
--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -41,7 +41,7 @@ pub fn new_builder(pref &pref.Preferences) Builder {
 	if pref.use_color == .never {
 		util.emanager.set_support_color(false)
 	}
-	msvc := find_msvc() or {
+	msvc := find_msvc(pref.m64) or {
 		if pref.ccompiler == 'msvc' {
 			verror('Cannot find MSVC on this OS')
 		}

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -51,7 +51,7 @@ fn (mut v Builder) find_win_cc() ? {
 		if v.pref.is_verbose {
 			println('$v.pref.ccompiler not found, looking for msvc...')
 		}
-		find_msvc() or {
+		find_msvc(v.pref.m64) or {
 			if v.pref.is_verbose {
 				println('msvc not found, looking for thirdparty/tcc...')
 			}

--- a/vlib/v/builder/msvc.v
+++ b/vlib/v/builder/msvc.v
@@ -8,7 +8,6 @@ import v.cflag
 #flag windows -l shell32
 #flag windows -l dbghelp
 #flag windows -l advapi32
-
 struct MsvcResult {
 	full_cl_exe_path    string
 	exe_path            string
@@ -79,7 +78,7 @@ struct WindowsKit {
 }
 
 // Try and find the root key for installed windows kits
-fn find_windows_kit_root(host_arch string) ?WindowsKit {
+fn find_windows_kit_root(target_arch string) ?WindowsKit {
 	$if windows {
 		root_key := RegKey(0)
 		path := 'SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots'
@@ -113,8 +112,8 @@ fn find_windows_kit_root(host_arch string) ?WindowsKit {
 		kit_include_highest := kit_lib_highest.replace('Lib', 'Include')
 		C.RegCloseKey(root_key)
 		return WindowsKit{
-			um_lib_path: kit_lib_highest + '\\um\\$host_arch'
-			ucrt_lib_path: kit_lib_highest + '\\ucrt\\$host_arch'
+			um_lib_path: kit_lib_highest + '\\um\\$target_arch'
+			ucrt_lib_path: kit_lib_highest + '\\ucrt\\$target_arch'
 			um_include_path: kit_include_highest + '\\um'
 			ucrt_include_path: kit_include_highest + '\\ucrt'
 			shared_include_path: kit_include_highest + '\\shared'
@@ -129,7 +128,7 @@ struct VsInstallation {
 	exe_path     string
 }
 
-fn find_vs(vswhere_dir string, host_arch string) ?VsInstallation {
+fn find_vs(vswhere_dir string, host_arch string, target_arch string) ?VsInstallation {
 	$if !windows {
 		return error('Host OS does not support finding a Visual Studio installation')
 	}
@@ -147,10 +146,10 @@ fn find_vs(vswhere_dir string, host_arch string) ?VsInstallation {
 	version2 := version // TODO remove. cgen option bug if expr
 	// println('version: $version')
 	v := if version.ends_with('\n') { version2[..version.len - 2] } else { version2 }
-	lib_path := '$res.output\\VC\\Tools\\MSVC\\$v\\lib\\$host_arch'
+	lib_path := '$res.output\\VC\\Tools\\MSVC\\$v\\lib\\$target_arch'
 	include_path := '$res.output\\VC\\Tools\\MSVC\\$v\\include'
 	if os.exists('$lib_path\\vcruntime.lib') {
-		p := '$res.output\\VC\\Tools\\MSVC\\$v\\bin\\Host$host_arch\\$host_arch'
+		p := '$res.output\\VC\\Tools\\MSVC\\$v\\bin\\Host$host_arch\\$target_arch'
 		// println('$lib_path $include_path')
 		return VsInstallation{
 			exe_path: p
@@ -162,7 +161,7 @@ fn find_vs(vswhere_dir string, host_arch string) ?VsInstallation {
 	return error('Unable to find vs exe folder')
 }
 
-fn find_msvc() ?MsvcResult {
+fn find_msvc(m64_target bool) ?MsvcResult {
 	$if windows {
 		processor_architecture := os.getenv('PROCESSOR_ARCHITECTURE')
 		vswhere_dir := if processor_architecture == 'x86' {
@@ -171,8 +170,20 @@ fn find_msvc() ?MsvcResult {
 			'%ProgramFiles(x86)%'
 		}
 		host_arch := if processor_architecture == 'x86' { 'X86' } else { 'X64' }
-		wk := find_windows_kit_root(host_arch) or { return error('Unable to find windows sdk') }
-		vs := find_vs(vswhere_dir, host_arch) or { return error('Unable to find visual studio') }
+		mut target_arch := 'X64'
+		if host_arch == 'X86' {
+			if !m64_target {
+				target_arch = 'X86'
+			}
+		} else if host_arch == 'X64' {
+			if !m64_target {
+				target_arch = 'X86'
+			}
+		}
+		wk := find_windows_kit_root(target_arch) or { return error('Unable to find windows sdk') }
+		vs := find_vs(vswhere_dir, host_arch, target_arch) or {
+			return error('Unable to find visual studio')
+		}
 		return MsvcResult{
 			full_cl_exe_path: os.real_path(vs.exe_path + os.path_separator + 'cl.exe')
 			exe_path: vs.exe_path


### PR DESCRIPTION
Support -m64/-m32 flags for msvc. Now we can crosscompile between two architectures using msvc.
