### PR TITLE
gen/c: fix gen_str_for_struct with custom ref str (fix #7179)

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -469,7 +469,7 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp string, str_fn_name st
 	if clean_struct_v_type_name.contains('_T_') {
 		// TODO: this is a bit hacky. styp shouldn't be even parsed with _T_
 		// use something different than g.typ for styp
-		clean_struct_v_type_name = 
+		clean_struct_v_type_name =
 			clean_struct_v_type_name.replace('_T_', '<').replace('_', ', ').replace('Array', 'array') +
 			'>'
 	}
@@ -530,12 +530,12 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp string, str_fn_name st
 }
 
 fn struct_auto_str_func(sym table.TypeSymbol, field_type table.Type, fn_name string, field_name string) string {
-	has_custom_str := sym.has_method('str')
+	has_custom_str, expects_ptr, _ := sym.str_method_info()
 	if sym.kind in [.enum_, .interface_] {
 		return '${fn_name}(it.${c_name(field_name)})'
 	} else if sym.kind == .struct_ {
 		mut obj := 'it.${c_name(field_name)}'
-		if field_type.is_ptr() {
+		if field_type.is_ptr() && !expects_ptr {
 			obj = '*$obj'
 		}
 		if has_custom_str {
@@ -553,7 +553,7 @@ fn struct_auto_str_func(sym table.TypeSymbol, field_type table.Type, fn_name str
 		mut method_str := 'it.${c_name(field_name)}'
 		if sym.kind == .bool {
 			method_str += ' ? _SLIT("true") : _SLIT("false")'
-		} else if (field_type.is_int() || field_type.is_float()) && field_type.is_ptr() {
+		} else if (field_type.is_int() || field_type.is_float()) && field_type.is_ptr() && !expects_ptr {
 			// ptr int can be "nil", so this needs to be castet to a string
 			fmt := if sym.kind in [.f32, .f64] {
 				'%g\\000'

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -469,7 +469,7 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp string, str_fn_name st
 	if clean_struct_v_type_name.contains('_T_') {
 		// TODO: this is a bit hacky. styp shouldn't be even parsed with _T_
 		// use something different than g.typ for styp
-		clean_struct_v_type_name =
+		clean_struct_v_type_name = 
 			clean_struct_v_type_name.replace('_T_', '<').replace('_', ', ').replace('Array', 'array') +
 			'>'
 	}
@@ -553,7 +553,8 @@ fn struct_auto_str_func(sym table.TypeSymbol, field_type table.Type, fn_name str
 		mut method_str := 'it.${c_name(field_name)}'
 		if sym.kind == .bool {
 			method_str += ' ? _SLIT("true") : _SLIT("false")'
-		} else if (field_type.is_int() || field_type.is_float()) && field_type.is_ptr() && !expects_ptr {
+		} else if (field_type.is_int() || field_type.is_float()) && field_type.is_ptr()
+			&& !expects_ptr {
 			// ptr int can be "nil", so this needs to be castet to a string
 			fmt := if sym.kind in [.f32, .f64] {
 				'%g\\000'

--- a/vlib/v/tests/string_interpolation_custom_str_test.v
+++ b/vlib/v/tests/string_interpolation_custom_str_test.v
@@ -1,0 +1,20 @@
+struct Foo {
+	bar int
+}
+
+fn (f &Foo) str() string {
+	return '${f.bar}'
+}
+
+struct Bar  {
+	foo &Foo
+}
+
+fn test_interpolation_with_custom_ref_str() {
+	foo := Foo{}
+	bar := Bar { &foo }
+	println(bar)
+	assert '$bar'.contains('Bar{')
+	assert '$bar'.contains('foo: &0')
+	assert '$bar'.contains('}')
+}


### PR DESCRIPTION
This PR fix gen_str_for_struct with custom ref str (fix #7179).

- Fix gen_str_for_struct with custom ref str.
- Add test `string_interpolation_custom_str_test.v`.

```vlang
struct Foo {
	bar int
}

fn (f &Foo) str() string {
	return '${f.bar}'
}

struct Bar  {
	foo &Foo
}

fn main() {
	foo := Foo{}
	bar := Bar { &foo }
	println(bar)
}

D:\Test\v\tt1>v run .
Bar{
    foo: &0
}
```