### PR TITLE
os: fix os.real_path on Windows

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -275,6 +275,8 @@ fn C._wgetcwd() int
 
 fn C._fullpath() int
 
+fn C.GetFullPathNameA(charptr, u32, charptr, charptr) u32
+
 fn C.GetCommandLine() voidptr
 
 fn C.LocalFree()

--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -275,7 +275,7 @@ fn C._wgetcwd() int
 
 fn C._fullpath() int
 
-fn C.GetFullPathNameA(charptr, u32, charptr, charptr) u32
+fn C.GetFullPathName(voidptr, u32, voidptr, voidptr) u32
 
 fn C.GetCommandLine() voidptr
 

--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -744,13 +744,13 @@ pub fn getwd() string {
 // NB: this particular rabbit hole is *deep* ...
 [manualfree]
 pub fn real_path(fpath string) string {
-	mut fullpath := voidptr(0)
+	mut fullpath := byteptr(0)
 	defer {
 		unsafe { free(fullpath) }
 	}
 
 	$if windows {
-		fullpath = unsafe { &u16(malloc(max_path_len * 2)) }
+		fullpath = unsafe { &u16(vcalloc(max_path_len * 2)) }
 		// TODO: check errors if path len is not enough
 		ret := C.GetFullPathName(fpath.to_wide(), max_path_len, fullpath, 0)
 		if ret == 0 {

--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -748,14 +748,16 @@ pub fn real_path(fpath string) string {
 	defer {
 		unsafe { free(fullpath) }
 	}
-	mut ret := charptr(0)
+
 	$if windows {
-		ret = charptr(C._fullpath(charptr(fullpath), charptr(fpath.str), max_path_len))
+		// TODO: check errors if path len is not enough
+		ret := C.GetFullPathNameA(charptr(fpath.str), max_path_len, charptr(fullpath),
+			0)
 		if ret == 0 {
 			return fpath
 		}
 	} $else {
-		ret = charptr(C.realpath(charptr(fpath.str), charptr(fullpath)))
+		ret := charptr(C.realpath(charptr(fpath.str), charptr(fullpath)))
 		if ret == 0 {
 			return fpath
 		}

--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -750,10 +750,9 @@ pub fn real_path(fpath string) string {
 	}
 
 	$if windows {
-		fullpath = unsafe { &u16(malloc(max_path_len*2)) }
+		fullpath = unsafe { &u16(malloc(max_path_len * 2)) }
 		// TODO: check errors if path len is not enough
-		ret := C.GetFullPathName(fpath.to_wide(), max_path_len, fullpath,
-			0)
+		ret := C.GetFullPathName(fpath.to_wide(), max_path_len, fullpath, 0)
 		if ret == 0 {
 			return fpath
 		}

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -271,6 +271,10 @@ fn test_cp_all() {
 	os.cp_all('ex', './', true) or { panic(err) }
 }
 
+fn test_realpath() {
+	assert(os.real_path('') == '')
+}
+
 fn test_tmpdir() {
 	t := os.temp_dir()
 	assert t.len > 0

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -272,7 +272,7 @@ fn test_cp_all() {
 }
 
 fn test_realpath() {
-	assert(os.real_path('') == '')
+	assert os.real_path('') == ''
 }
 
 fn test_tmpdir() {


### PR DESCRIPTION
Replaced _fullpath with GetFullPathName, because _fullpath return getcwd if we try to resolve nullptr or empty string.

Long explanation:

`v fmt` didn't add empty line after lines with HashStmt like `#flag`

this condition never didn't executed
https://github.com/vlang/v/blob/4878077c62536b7837ba5cad496e23ea2fbee9b0/vlib/v/fmt/fmt.v#L334-L336

windows trace before patch
```
.\v fmt -w .\vlib\v\builder\msvc.v
fn real_path(E:\Projects\_opensource\vlang\v\v.exe)
fn real_path()
rpath = E:\Projects\_opensource\vlang\v
rpath_name = v
p.building_v = true
fn real_path(E:\Projects\_opensource\vlang\v\v.exe)
fn real_path(E:\Projects\_opensource\vlang\v\cmd\tools\vfmt)
fn real_path(E:\Projects\_opensource\vlang\v\v.exe)
fn real_path(.\vlib\v\builder\msvc.v)
Already formatted file: E:\Projects\_opensource\vlang\v\vlib\v\builder\msvc.v
fn real_path(E:\Projects\_opensource\vlang\v\v.exe)
fn real_path()
rpath = E:\Projects\_opensource\vlang\v
rpath_name = v
p.building_v = true
```
linux trace before patch:
```
fn real_path(/home/crackedmind/vlang/v)
fn real_path()
rpath = 
rpath_name = 
p.building_v = false
fn real_path(/home/crackedmind/vlang/v)
fn real_path(/home/crackedmind/vlang/cmd/tools/vfmt)
fn real_path(/home/crackedmind/vlang/v)
fn real_path(vlib/v/builder/msvc.v)
Already formatted file: /home/crackedmind/vlang/vlib/v/builder/msvc.v
fn real_path(/home/crackedmind/vlang/v)
fn real_path()
rpath = 
rpath_name = 
p.building_v = false
```