### PR TITLE
checker: disallow implicit conversion from fixed array to fooptr

### DIFF
--- a/vlib/math/big/big.v
+++ b/vlib/math/big/big.v
@@ -147,9 +147,13 @@ pub fn (n Number) str() string {
 // .hexstr returns a hexadecimal representation of the bignum `n`
 pub fn (n Number) hexstr() string {
 	mut buf := [8192]byte{}
-	// NB: C.bignum_to_string(), returns the HEXADECIMAL representation of the bignum n
-	C.bignum_to_string(&n, buf, 8192)
-	s := unsafe { tos_clone(buf) }
+	mut s := ''
+	unsafe {
+		bp := &buf[0]
+		// NB: C.bignum_to_string(), returns the HEXADECIMAL representation of the bignum n
+		C.bignum_to_string(&n, bp, 8192)
+		s = tos_clone(bp)
+	}
 	if s.len == 0 {
 		return '0'
 	}

--- a/vlib/net/http/backend_nix.c.v
+++ b/vlib/net/http/backend_nix.c.v
@@ -41,20 +41,21 @@ fn (req &Request) ssl_do(port int, method Method, host_name string, path string)
 	C.BIO_puts(web, req_headers.str)
 	mut content := strings.new_builder(100)
 	mut buff := [bufsize]byte{}
+	bp := &buff[0]
 	mut readcounter := 0
 	for {
 		readcounter++
-		len := unsafe { C.BIO_read(web, buff, bufsize) }
+		len := unsafe { C.BIO_read(web, bp, bufsize) }
 		if len <= 0 {
 			break
 		}
 		$if debug_http ? {
 			eprintln('ssl_do, read ${readcounter:4d} | len: $len')
 			eprintln('-'.repeat(20))
-			eprintln(unsafe { tos(buff, len) })
+			eprintln(unsafe { tos(bp, len) })
 			eprintln('-'.repeat(20))
 		}
-		unsafe { content.write_bytes(buff, len) }
+		unsafe { content.write_bytes(bp, len) }
 	}
 	if web != 0 {
 		C.BIO_free_all(web)

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -276,7 +276,7 @@ pub fn exec(cmd string) ?Result {
 		mut result := false
 		unsafe {
 			result = C.ReadFile(child_stdout_read, buf, 1000, voidptr(&bytes_read), 0)
-			read_data.write_bytes(buf, int(bytes_read))
+			read_data.write_bytes(&buf[0], int(bytes_read))
 		}
 		if result == false || int(bytes_read) == 0 {
 			break

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -46,13 +46,6 @@ pub fn (mut c Checker) check_basic(got table.Type, expected table.Type) bool {
 			return true
 		}
 	}
-	// e.g. [4096]byte vs byteptr
-	if got_sym.kind == .array_fixed {
-		info := got_sym.info as table.ArrayFixed
-		if c.table.type_to_str(info.elem_type) == c.table.type_to_str(expected).trim('ptr') {
-			return true
-		}
-	}
 	if exp_sym.kind in [.voidptr, .any] || got_sym.kind in [.voidptr, .any] {
 		return true
 	}

--- a/vlib/v/checker/tests/fixed_array_conv.out
+++ b/vlib/v/checker/tests/fixed_array_conv.out
@@ -1,0 +1,18 @@
+vlib/v/checker/tests/fixed_array_conv.vv:3:3: error: mismatched types `voidptr` and `[2]int`
+    1 | arr := [2,3]!
+    2 | mut p := voidptr(0)
+    3 | p = arr
+      |   ^
+    4 | mut ip := &int(0)
+    5 | ip = arr
+vlib/v/checker/tests/fixed_array_conv.vv:5:4: error: mismatched types `&int` and `[2]int`
+    3 | p = arr
+    4 | mut ip := &int(0)
+    5 | ip = arr
+      |    ^
+    6 | _ = &int(arr)
+vlib/v/checker/tests/fixed_array_conv.vv:6:6: error: cannot cast a fixed array (use e.g. `&arr[0]` instead)
+    4 | mut ip := &int(0)
+    5 | ip = arr
+    6 | _ = &int(arr)
+      |      ~~~~~~~~

--- a/vlib/v/checker/tests/fixed_array_conv.vv
+++ b/vlib/v/checker/tests/fixed_array_conv.vv
@@ -1,0 +1,6 @@
+arr := [2,3]!
+mut p := voidptr(0)
+p = arr
+mut ip := &int(0)
+ip = arr
+_ = &int(arr)

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -30,8 +30,9 @@ pub fn vhash() string {
 	mut buf := [50]byte{}
 	buf[0] = 0
 	unsafe {
-		C.snprintf(charptr(&buf[0]), 50, '%s', C.V_COMMIT_HASH)
-		return tos_clone(buf)
+		bp := &buf[0]
+		C.snprintf(charptr(bp), 50, '%s', C.V_COMMIT_HASH)
+		return tos_clone(bp)
 	}
 }
 
@@ -98,8 +99,9 @@ pub fn githash(should_get_from_filesystem bool) string {
 	mut buf := [50]byte{}
 	buf[0] = 0
 	unsafe {
-		C.snprintf(charptr(&buf[0]), 50, '%s', C.V_CURRENT_COMMIT_HASH)
-		return tos_clone(buf)
+		bp := &buf[0]
+		C.snprintf(charptr(bp), 50, '%s', C.V_CURRENT_COMMIT_HASH)
+		return tos_clone(bp)
 	}
 }
 


### PR DESCRIPTION
Use `&arr[0]` instead. Follows on from #8787.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
