### PR TITLE
checker: disallow casting non-reference types to interfaces

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1985,8 +1985,8 @@ interface Speaker {
 	speak() string
 }
 
-dog := Dog{'Leonberger'}
-cat := Cat{'Siamese'}
+dog := &Dog{'Leonberger'}
+cat := &Cat{'Siamese'}
 
 mut arr := []Speaker{}
 arr << dog
@@ -2040,7 +2040,7 @@ fn (a Adoptable) speak() string {
 }
 
 fn new_adoptable() Adoptable {
-	return Cat{}
+	return &Cat{}
 }
 
 fn main() {

--- a/vlib/io/os_file_reader_test.v
+++ b/vlib/io/os_file_reader_test.v
@@ -7,7 +7,7 @@ fn read_file(file string, cap int) []string {
 	defer {
 		f.close()
 	}
-	mut r := io.new_buffered_reader(reader: io.make_reader(f), cap: cap)
+	mut r := io.new_buffered_reader(reader: &f, cap: cap)
 	for {
 		l := r.read_line() or { break }
 		lines << l

--- a/vlib/io/reader_test.v
+++ b/vlib/io/reader_test.v
@@ -20,7 +20,7 @@ fn test_read_all() {
 	buf := Buf{
 		bytes: '123'.repeat(10).bytes()
 	}
-	res := read_all(reader: buf) or {
+	res := read_all(reader: &buf) or {
 		assert false
 		''.bytes()
 	}
@@ -31,7 +31,7 @@ fn test_read_all_huge() {
 	buf := Buf{
 		bytes: '123'.repeat(100000).bytes()
 	}
-	res := read_all(reader: buf) or {
+	res := read_all(reader: &buf) or {
 		assert false
 		''.bytes()
 	}
@@ -63,7 +63,7 @@ fn test_stringreader() {
 		text: text
 	}
 	mut r := new_buffered_reader({
-		reader: make_reader(s)
+		reader: make_reader(&s)
 	})
 	for i := 0; true; i++ {
 		if _ := r.read_line() {
@@ -90,7 +90,7 @@ fn test_stringreader2() {
 		text: text
 	}
 	mut r := new_buffered_reader({
-		reader: make_reader(s)
+		reader: make_reader(&s)
 	})
 	for i := 0; true; i++ {
 		if _ := r.read_line() {
@@ -117,7 +117,7 @@ fn test_leftover() {
 		text: text
 	}
 	mut r := new_buffered_reader({
-		reader: make_reader(s)
+		reader: make_reader(&s)
 	})
 	_ := r.read_line() or {
 		assert false

--- a/vlib/net/smtp/smtp.v
+++ b/vlib/net/smtp/smtp.v
@@ -71,7 +71,7 @@ pub fn (mut c Client) reconnect() ? {
 	conn := net.dial_tcp('$c.server:$c.port') or { return error('Connecting to server failed') }
 	c.conn = conn
 
-	c.reader = io.new_buffered_reader(reader: io.make_reader(c.conn))
+	c.reader = io.new_buffered_reader(reader: io.make_reader(&c.conn))
 
 	c.expect_reply(.ready) or { return error('Received invalid response from server') }
 	c.send_ehlo() or { return error('Sending EHLO packet failed') }
@@ -104,7 +104,7 @@ pub fn (mut c Client) quit() ? {
 
 // expect_reply checks if the SMTP server replied with the expected reply code
 fn (mut c Client) expect_reply(expected ReplyCode) ? {
-	bytes := io.read_all(reader: c.conn) ?
+	bytes := io.read_all(reader: &c.conn) ?
 
 	str := bytes.bytestr().trim_space()
 	$if smtp_debug ? {

--- a/vlib/v/ast/walker/walker.v
+++ b/vlib/v/ast/walker/walker.v
@@ -24,7 +24,7 @@ pub fn (i &Inspector) visit(node ast.Node) ? {
 
 // inspect traverses and checks the AST node on a depth-first order and based on the data given
 pub fn inspect(node ast.Node, data voidptr, inspector_callback InspectorFn) {
-	walk(Inspector{inspector_callback, data}, node)
+	walk(&Inspector{inspector_callback, data}, node)
 }
 
 // walk traverses the AST using the given visitor

--- a/vlib/v/ast/walker/walker_test.v
+++ b/vlib/v/ast/walker/walker_test.v
@@ -39,7 +39,7 @@ struct Foo {
 	mut nbo := NodeByOffset{
 		pos: 13
 	}
-	walker.walk(nbo, file)
+	walker.walk(&nbo, file)
 	assert nbo.node is ast.Stmt
 	stmt := nbo.node as ast.Stmt
 	assert stmt is ast.StructDecl

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4773,27 +4773,6 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) table.Type {
 		if !node.is_comptime && branch.cond is ast.InfixExpr {
 			infix := branch.cond as ast.InfixExpr
 			if infix.op == .key_is {
-				// // handle `foo is &MyInterface`
-				// // TODO: is this a parser issue? Should the & be parsed as part of the type,
-				// // rather than as a separate `ast.PrefixExpr` node?
-				// right_expr := match infix.right {
-				// 	ast.Type {
-				// 		infix.right
-				// 	}
-				// 	ast.PrefixExpr {
-				// 		expr := infix.right.expr
-				// 		if expr !is ast.Type {
-				// 			c.error('expecting type, not `$expr`', expr.position())
-				// 			return
-				// 		}
-				// 		expr as ast.Type
-				// 	}
-				// 	else {
-				// 		c.error('expecting type, not `$infix.right`', infix.right.position())
-				// 		ast.Type{}
-				// 	}
-				// }
-
 				right_expr := infix.right as ast.Type
 				left_sym := c.table.get_type_symbol(infix.left_type)
 				expr_type := c.expr(infix.left)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2062,7 +2062,8 @@ fn (mut c Checker) type_implements(typ table.Type, inter_typ table.Type, pos tok
 	}
 	if mut inter_sym.info is table.Interface {
 		if !typ.is_ptr() && !same_base_type {
-			c.error('cannot cast non-reference type `$styp` to interface `$inter_sym.name`', pos)
+			c.error('cannot cast non-reference type `$styp` to interface `$inter_sym.name`',
+				pos)
 		}
 		for ifield in inter_sym.info.fields {
 			if field := typ_sym.find_field(ifield.name) {

--- a/vlib/v/checker/tests/immutable_interface_field.vv
+++ b/vlib/v/checker/tests/immutable_interface_field.vv
@@ -11,6 +11,6 @@ fn mutate_interface(mut b Bbb) {
 }
 
 fn main() {
-	mut a := Aaa{1}
+	mut a := &Aaa{1}
 	mutate_interface(mut a)
 }

--- a/vlib/v/checker/tests/interface_implementing_interface.out
+++ b/vlib/v/checker/tests/interface_implementing_interface.out
@@ -1,5 +1,5 @@
 vlib/v/checker/tests/interface_implementing_interface.vv:15:10: error: cannot implement interface `Thing` with a different interface `Animal`
-   13 | dog := Dog{}
+   13 | dog := &Dog{}
    14 | animal := Animal(dog)
    15 | thing := Thing(animal)
       |          ~~~~~~~~~~~~~

--- a/vlib/v/checker/tests/interface_implementing_interface.vv
+++ b/vlib/v/checker/tests/interface_implementing_interface.vv
@@ -10,7 +10,7 @@ struct Dog {
     kind string = 'labrador'
 }
 
-dog := Dog{}
+dog := &Dog{}
 animal := Animal(dog)
 thing := Thing(animal)
 println(thing)

--- a/vlib/v/checker/tests/is_type_invalid.out
+++ b/vlib/v/checker/tests/is_type_invalid.out
@@ -7,7 +7,7 @@ vlib/v/checker/tests/is_type_invalid.vv:14:12: error: `IoS` has no variant `byte
    16 |     }
 vlib/v/checker/tests/is_type_invalid.vv:18:2: error: `Cat` doesn't implement method `speak` of interface `Animal`
    16 |     }
-   17 |     a := Animal(Dog{})
+   17 |     a := Animal(&Dog{})
    18 |     if a is Cat {
       |     ~~~~~~~~~~~
    19 |         println('not cool either')

--- a/vlib/v/checker/tests/is_type_invalid.vv
+++ b/vlib/v/checker/tests/is_type_invalid.vv
@@ -14,7 +14,7 @@ fn main() {
 	if IoS(1) is byte {
 		println('not cool')
 	}
-	a := Animal(Dog{})
+	a := Animal(&Dog{})
 	if a is Cat {
 		println('not cool either')
 	}

--- a/vlib/v/checker/tests/match_invalid_type.out
+++ b/vlib/v/checker/tests/match_invalid_type.out
@@ -13,7 +13,7 @@ vlib/v/checker/tests/match_invalid_type.vv:4:2: error: match must be exhaustive 
     5 |         byte {
     6 |             println('not cool')
 vlib/v/checker/tests/match_invalid_type.vv:24:3: error: `Cat` doesn't implement method `speak` of interface `Animal`
-   22 |     a := Animal(Dog{})
+   22 |     a := Animal(&Dog{})
    23 |     match a {
    24 |         Cat {
       |         ~~~

--- a/vlib/v/checker/tests/match_invalid_type.vv
+++ b/vlib/v/checker/tests/match_invalid_type.vv
@@ -19,7 +19,7 @@ fn (d Dog) speak() {}
 struct Cat {}
 
 fn iface() {
-	a := Animal(Dog{})
+	a := Animal(&Dog{})
 	match a {
 		Cat {
 			println('not cool either')

--- a/vlib/v/checker/tests/no_interface_str.vv
+++ b/vlib/v/checker/tests/no_interface_str.vv
@@ -10,7 +10,7 @@ fn (c Cow)speak() {
 }
 
 fn get_animal() Animal {
-	return Cow{}
+	return &Cow{}
 }
 
 fn moin() {

--- a/vlib/v/checker/tests/struct_type_cast_err.out
+++ b/vlib/v/checker/tests/struct_type_cast_err.out
@@ -53,11 +53,11 @@ vlib/v/checker/tests/struct_type_cast_err.vv:12:10: error: cannot cast struct to
    12 |     _ := i64(foo)
       |          ~~~~~~~~
    13 |     _ := int(foo)
-   14 |     _ = &I1(foo)
+   14 | }
 vlib/v/checker/tests/struct_type_cast_err.vv:13:10: error: cannot cast struct to `int`
    11 |     _ := i8(foo)
    12 |     _ := i64(foo)
    13 |     _ := int(foo)
       |          ~~~~~~~~
-   14 |     _ = &I1(foo)
-   15 | }
+   14 | }
+   15 |

--- a/vlib/v/checker/tests/struct_type_cast_err.vv
+++ b/vlib/v/checker/tests/struct_type_cast_err.vv
@@ -11,7 +11,6 @@ fn main() {
     _ := i8(foo)
     _ := i64(foo)
     _ := int(foo)
-    _ = &I1(foo)
 }
 
 interface I1{}

--- a/vlib/v/checker/tests/unimplemented_interface_h.out
+++ b/vlib/v/checker/tests/unimplemented_interface_h.out
@@ -1,6 +1,6 @@
 vlib/v/checker/tests/unimplemented_interface_h.vv:9:13: error: `Cat` doesn't implement field `name` of interface `Animal`
     7 | fn main() {
     8 |     mut animals := []Animal{}
-    9 |     animals << Cat{}
-      |                ~~~~~
+    9 |     animals << &Cat{}
+      |                ^
    10 | }

--- a/vlib/v/checker/tests/unimplemented_interface_h.vv
+++ b/vlib/v/checker/tests/unimplemented_interface_h.vv
@@ -6,5 +6,5 @@ struct Cat {}
 
 fn main() {
 	mut animals := []Animal{}
-	animals << Cat{}
+	animals << &Cat{}
 }

--- a/vlib/v/checker/tests/unimplemented_interface_i.out
+++ b/vlib/v/checker/tests/unimplemented_interface_i.out
@@ -1,6 +1,6 @@
 vlib/v/checker/tests/unimplemented_interface_i.vv:11:13: error: `Cat` incorrectly implements field `name` of interface `Animal`, expected `string`, got `int`
     9 | fn main() {
    10 |     mut animals := []Animal{}
-   11 |     animals << Cat{}
-      |                ~~~~~
+   11 |     animals << &Cat{}
+      |                ^
    12 | }

--- a/vlib/v/checker/tests/unimplemented_interface_i.vv
+++ b/vlib/v/checker/tests/unimplemented_interface_i.vv
@@ -8,5 +8,5 @@ struct Cat {
 
 fn main() {
 	mut animals := []Animal{}
-	animals << Cat{}
+	animals << &Cat{}
 }

--- a/vlib/v/checker/tests/unimplemented_interface_j.out
+++ b/vlib/v/checker/tests/unimplemented_interface_j.out
@@ -1,6 +1,6 @@
 vlib/v/checker/tests/unimplemented_interface_j.vv:12:13: error: `Cat` incorrectly implements interface `Animal`, field `name` must be mutable
    10 | fn main() {
    11 |     mut animals := []Animal{}
-   12 |     animals << Cat{}
-      |                ~~~~~
+   12 |     animals << &Cat{}
+      |                ^
    13 | }

--- a/vlib/v/checker/tests/unimplemented_interface_j.vv
+++ b/vlib/v/checker/tests/unimplemented_interface_j.vv
@@ -9,5 +9,5 @@ struct Cat {
 
 fn main() {
 	mut animals := []Animal{}
-	animals << Cat{}
+	animals << &Cat{}
 }

--- a/vlib/v/gen/js/tests/interface.v
+++ b/vlib/v/gen/js/tests/interface.v
@@ -42,6 +42,6 @@ fn use(a Animal) {
 }
 
 fn main() {
-	use(Dog{'Doggo', 5})
-	use(Cat{'Nyancat', 6})
+	use(&Dog{'Doggo', 5})
+	use(&Cat{'Nyancat', 6})
 }

--- a/vlib/v/tests/blank_ident_test.v
+++ b/vlib/v/tests/blank_ident_test.v
@@ -33,7 +33,7 @@ fn call_fn_with_multiple_blank_param(foo Foo) {
 }
 
 fn test_interface_fn_with_multiple_blank_param() {
-	call_fn_with_multiple_blank_param(Abc{})
+	call_fn_with_multiple_blank_param(&Abc{})
 }
 
 fn test_for_in_range() {

--- a/vlib/v/tests/cast_to_interface_test.v
+++ b/vlib/v/tests/cast_to_interface_test.v
@@ -6,7 +6,7 @@ interface Adoptable {
 }
 
 fn test_casting_to_interface() {
-	cat := Cat{}
+	cat := &Cat{}
 	a := Adoptable(cat)
 	if a is Cat {
 		assert typeof(a).name == '&Cat'

--- a/vlib/v/tests/interface_edge_cases/array_of_interfaces_test.v
+++ b/vlib/v/tests/interface_edge_cases/array_of_interfaces_test.v
@@ -12,7 +12,7 @@ fn get_name(s Speaker) {
 
 //
 fn test_an_array_of_interfaces_works() {
-	dog := Dog{}
+	dog := &Dog{}
 	// get_name(dog) // uncommenting this line fixes the example
 	get_names([dog, dog])
 }

--- a/vlib/v/tests/interface_edge_cases/array_of_interfaces_with_utility_fn_test.v
+++ b/vlib/v/tests/interface_edge_cases/array_of_interfaces_with_utility_fn_test.v
@@ -12,7 +12,7 @@ fn get_name(s Speaker) {
 
 //
 fn test_an_array_of_interfaces_works() {
-	dog := Dog{}
+	dog := &Dog{}
 	get_name(dog) // NB: this line does nothing, but forces interface _name_table generation
 	get_names([dog, dog])
 }

--- a/vlib/v/tests/interface_edge_cases/assign_to_interface_field_test.v
+++ b/vlib/v/tests/interface_edge_cases/assign_to_interface_field_test.v
@@ -21,8 +21,8 @@ mut:
 
 fn test_a_struct_implementing_an_interface_can_be_assigned_without_explicit_casts() {
 	mut anyplanet := AnyPlanet{}
-	anyplanet.planet = Moon{}
+	anyplanet.planet = &Moon{}
 	assert anyplanet.planet.name() == 'moon'
-	anyplanet.planet = Mars{}
+	anyplanet.planet = &Mars{}
 	assert anyplanet.planet.name() == 'mars'
 }

--- a/vlib/v/tests/interface_edge_cases/i1_test.v
+++ b/vlib/v/tests/interface_edge_cases/i1_test.v
@@ -26,6 +26,6 @@ fn test_to_string_can_be_called() {
 		x: 2
 		y: 3
 	}
-	to_string(p)
+	to_string(&p)
 	assert true
 }

--- a/vlib/v/tests/interface_edge_cases/i2_test.v
+++ b/vlib/v/tests/interface_edge_cases/i2_test.v
@@ -29,6 +29,6 @@ fn test_to_string_can_be_called() {
 		x: 2
 		y: 3
 	}
-	res := to_string(p)
+	res := to_string(&p)
 	assert res == 'Point(2,3)'
 }

--- a/vlib/v/tests/interface_edge_cases/i3_test.v
+++ b/vlib/v/tests/interface_edge_cases/i3_test.v
@@ -27,7 +27,7 @@ fn test_calling_to_string() {
 		x: 2
 		y: 3
 	}
-	res := to_string(p)
+	res := to_string(&p)
 	println(res)
 	assert res == 'Point(2,3)'
 }

--- a/vlib/v/tests/interface_edge_cases/i7_test.v
+++ b/vlib/v/tests/interface_edge_cases/i7_test.v
@@ -20,7 +20,7 @@ fn (p Point) draw() string {
 // Note: this helper function forced the compiler to generate an
 // interface dispatch table. Now, it should not be needed anymore,
 // but it is better to test it too, to prevent future interface regressions.
-fn (x Point) tointerface() Drawable {
+fn (x &Point) tointerface() Drawable {
 	return x
 }
 
@@ -29,7 +29,7 @@ fn to_string(d Drawable) string {
 }
 
 fn test_p_draw_can_be_called() {
-	p := Point{
+	p := &Point{
 		x: 2
 		y: 3
 	}

--- a/vlib/v/tests/interface_fields_test.v
+++ b/vlib/v/tests/interface_fields_test.v
@@ -41,10 +41,10 @@ fn mutate_interface(mut a Animal) {
 }
 
 fn test_interface_fields() {
-	mut c := Cat{
+	mut c := &Cat{
 		breed: 'Persian'
 	}
-	mut d := Dog{
+	mut d := &Dog{
 		breed: 'Labrador'
 	}
 	use_interface(c)

--- a/vlib/v/tests/interface_struct_test.v
+++ b/vlib/v/tests/interface_struct_test.v
@@ -35,7 +35,7 @@ mut:
 
 fn test_interface_struct() {
 	bz1 := Baz{
-		sp: Boss{
+		sp: &Boss{
 			name: 'Richard'
 		}
 	}
@@ -43,7 +43,7 @@ fn test_interface_struct() {
 	print('Test Boss inside Baz struct: ')
 	bz1.sp.speak('Hello world!')
 	bz2 := Baz{
-		sp: Cat{
+		sp: &Cat{
 			name: 'Grungy'
 			breed: 'Persian Cat'
 		}
@@ -55,12 +55,12 @@ fn test_interface_struct() {
 
 fn test_interface_mut_struct() {
 	mut mbaz := Baz{
-		sp: Boss{
+		sp: &Boss{
 			name: 'Derek'
 		}
 	}
 	assert mbaz.sp.say_hello() == "Hello, My name is Derek and I\'m the bawz"
-	mbaz.sp = Cat{
+	mbaz.sp = &Cat{
 		name: 'Dog'
 		breed: 'Not a dog'
 	}
@@ -70,13 +70,13 @@ fn test_interface_mut_struct() {
 fn test_interface_struct_from_array() {
 	bazs := [
 		Baz{
-			sp: Cat{
+			sp: &Cat{
 				name: 'Kitty'
 				breed: 'Catty Koo'
 			}
 		},
 		Baz{
-			sp: Boss{
+			sp: &Boss{
 				name: 'Bob'
 			}
 		},

--- a/vlib/v/tests/interface_test.v
+++ b/vlib/v/tests/interface_test.v
@@ -89,20 +89,20 @@ fn perform_speak_on_ptr(a &Animal) {
 }
 
 fn test_perform_speak() {
-	dog := Dog{
+	dog := &Dog{
 		breed: 'Labrador Retriever'
 	}
 	perform_speak(dog)
 	perform_speak_on_ptr(dog)
-	cat := Cat{
+	cat := &Cat{
 		breed: 'Persian'
 	}
 	perform_speak(cat)
-	perform_speak(Cat{
+	perform_speak(&Cat{
 		breed: 'Persian'
 	})
 	perform_speak_on_ptr(cat)
-	perform_speak_on_ptr(Cat{
+	perform_speak_on_ptr(&Cat{
 		breed: 'Persian'
 	})
 	handle_animals([dog, cat])
@@ -118,7 +118,7 @@ fn change_animal_breed(mut a Animal, new string) {
 }
 
 fn test_interface_ptr_modification() {
-	mut cat := Cat{
+	mut cat := &Cat{
 		breed: 'Persian'
 	}
 	// TODO Should fail and require `mut cat`
@@ -133,23 +133,23 @@ fn perform_name_detailed(a Animal) {
 }
 
 fn test_perform_name_detailed() {
-	dog := Dog{
+	dog := &Dog{
 		breed: 'Labrador Retriever'
 	}
 	println('Test on Dog: $dog ...') // using default conversion to string
 	perform_name_detailed(dog)
-	cat := Cat{}
+	cat := &Cat{}
 	println('Test on empty Cat: $cat ...')
 	perform_speak(cat)
 	println('Test on a Persian Cat: ...')
-	perform_speak(Cat{
+	perform_speak(&Cat{
 		breed: 'Persian'
 	})
 	cat_persian2 := Cat{
 		breed: 'Persian'
 	}
 	println('Test on another Persian Cat: "$cat_persian2" ...')
-	perform_speak(cat_persian2)
+	perform_speak(&cat_persian2)
 	cat_persian2_str := cat_persian2.str()
 	println("Persian Cat 2: '$cat_persian2_str' ...")
 	assert cat_persian2_str == 'Custom string conversion for Cat: Persian'
@@ -181,7 +181,7 @@ fn handle_reg(r Register) {
 }
 
 fn test_register() {
-	f := RegTest{}
+	f := &RegTest{}
 	f.register()
 	handle_reg(f)
 }
@@ -227,7 +227,7 @@ fn return_speaker2(mut sp Speaker2) Speaker2 {
 }
 
 fn test_interface_returning_interface() {
-	mut b := Boss{'bob'}
+	mut b := &Boss{'bob'}
 	assert b.name == 'bob'
 	s2 := return_speaker2(mut b)
 	if s2 is Boss {
@@ -250,11 +250,11 @@ interface Animal {
 fn test_interface_array() {
 	println('Test on array of animals ...')
 	mut animals := []Animal{}
-	animals = [Cat{}, Dog{
+	animals = [&Cat{}, &Dog{
 		breed: 'Labrador Retriever'
 	}]
 	assert true
-	animals << Cat{}
+	animals << &Cat{}
 	assert true
 	// TODO .str() from the real types should be called
 	// println('Animals array contains: ${animals.str()}') // explicit call to 'str' function
@@ -264,17 +264,17 @@ fn test_interface_array() {
 
 fn test_interface_ptr_array() {
 	mut animals := []&Animal{}
-	animals = [Cat{}, Dog{
+	animals = [&Cat{}, &Dog{
 		breed: 'Labrador Retriever'
 	}]
 	assert true
-	animals << Cat{}
+	animals << &Cat{}
 	assert true
 	assert animals.len == 3
 }
 
 fn test_is() {
-	dog := Dog{}
+	dog := &Dog{}
 	assert foo2(dog) == 1
 }
 
@@ -287,7 +287,7 @@ fn foo2(a Animal) int {
 }
 
 fn new_animal() Animal {
-	dog := Dog{}
+	dog := &Dog{}
 	return dog
 }
 

--- a/vlib/v/tests/interface_variadic_test.v
+++ b/vlib/v/tests/interface_variadic_test.v
@@ -10,7 +10,7 @@ fn (f &Foo) method(params ...f64) string {
 
 fn test_variadic_array_decompose() {
 	mut a := []Element{}
-	a << Foo{}
+	a << &Foo{}
 
 	input := [0.0, 1.0]
 	assert a[0].method(...input) == '[0, 1]'
@@ -19,7 +19,7 @@ fn test_variadic_array_decompose() {
 
 fn test_variadic_multiple_args() {
 	mut a := []Element{}
-	a << Foo{}
+	a << &Foo{}
 
 	assert a[0].method(0.0, 1.0) == '[0, 1]'
 }

--- a/vlib/v/tests/struct_field_default_value_interface_cast_test.v
+++ b/vlib/v/tests/struct_field_default_value_interface_cast_test.v
@@ -7,7 +7,7 @@ interface FooBar {
 }
 
 struct Abc {
-    foobar FooBar = Foo { x: 123 }
+    foobar FooBar = &Foo { x: 123 }
 }
 
 fn test_struct_field_default_value_interface_cast() {


### PR DESCRIPTION
The old behavior was memory-unsafe; if the original variable was allocated on the stack and went out of scope, the interface would still hold a pointer to stack memory which would then be invalid. 

Note that you can still do `MyInterface(&stack_var)` - afaik, currently the compiler cannot distinguish between things allocated on the heap, and pointers to stack variables.

~~Currently depends on vlang/vls#73.~~

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
