### PR TITLE
checker: only allow passing integer *literal* to non-integer pointer method parameter

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -32,7 +32,7 @@ pub fn (mut c Checker) check_basic(got table.Type, expected table.Type) bool {
 		return true
 	}
 	// allow pointers to be initialized with 0. TODO: use none instead
-	if expected.is_ptr() && got_.idx() == table.int_literal_type {
+	if expected.is_ptr() && got_ == table.int_literal_type {
 		return true
 	}
 	// TODO: use sym so it can be absorbed into below [.voidptr, .any] logic

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -32,7 +32,7 @@ pub fn (mut c Checker) check_basic(got table.Type, expected table.Type) bool {
 		return true
 	}
 	// allow pointers to be initialized with 0. TODO: use none instead
-	if expected.is_ptr() && got_.idx() == table.int_type_idx {
+	if expected.is_ptr() && got_.idx() == table.int_literal_type {
 		return true
 	}
 	// TODO: use sym so it can be absorbed into below [.voidptr, .any] logic

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5383,7 +5383,7 @@ pub fn (mut c Checker) offset_of(node ast.OffsetOf) table.Type {
 		c.error('first argument of __offsetof must be struct', node.pos)
 		return table.u32_type
 	}
-	if !c.table.struct_has_field(node.struct_type, node.field) {
+	if !c.table.struct_has_field(sym, node.field) {
 		c.error('struct `$sym.name` has no field called `$node.field`', node.pos)
 	}
 	return table.u32_type

--- a/vlib/v/checker/tests/fn_args.out
+++ b/vlib/v/checker/tests/fn_args.out
@@ -1,19 +1,28 @@
-vlib/v/checker/tests/fn_args.vv:6:5: error: cannot use `&int` as `byte` in argument 1 to `ptr`
-    4 |
-    5 | v := 4
-    6 | ptr(&v)
-      |     ~~
-    7 | arr([5]!)
-    8 | fun(fn(i &int){})
-vlib/v/checker/tests/fn_args.vv:7:5: error: cannot use `[1]int` as `[]int` in argument 1 to `arr`
-    5 | v := 4
-    6 | ptr(&v)
-    7 | arr([5]!)
-      |     ~~~~
-    8 | fun(fn(i &int){})
-vlib/v/checker/tests/fn_args.vv:8:5: error: cannot use `fn (&int)` as `fn (int)` in argument 1 to `fun`
-    6 | ptr(&v)
-    7 | arr([5]!)
-    8 | fun(fn(i &int){})
-      |     ~~~~~~~~~~~~
+vlib/v/checker/tests/fn_args.vv:7:5: error: cannot use `&int` as `byte` in argument 1 to `u8`
+    5 | fn basic() {
+    6 |     v := 4
+    7 |     u8(&v)
+      |        ~~
+    8 |     arr([5]!)
+    9 |     fun(fn(i &int){})
+vlib/v/checker/tests/fn_args.vv:8:6: error: cannot use `[1]int` as `[]int` in argument 1 to `arr`
+    6 |     v := 4
+    7 |     u8(&v)
+    8 |     arr([5]!)
+      |         ~~~~
+    9 |     fun(fn(i &int){})
+   10 | }
+vlib/v/checker/tests/fn_args.vv:9:6: error: cannot use `fn (&int)` as `fn (int)` in argument 1 to `fun`
+    7 |     u8(&v)
+    8 |     arr([5]!)
+    9 |     fun(fn(i &int){})
+      |         ~~~~~~~~~~~~
+   10 | }
+   11 |
 Details: ``'s expected fn argument: `` is NOT a pointer, but the passed fn argument: `i` is a pointer
+vlib/v/checker/tests/fn_args.vv:18:4: error: cannot use `int` as `&S1` in argument 1 to `f`
+   16 | fn ptr() {
+   17 |     v := 4
+   18 |     f(v)
+      |       ^
+   19 | }

--- a/vlib/v/checker/tests/fn_args.vv
+++ b/vlib/v/checker/tests/fn_args.vv
@@ -1,8 +1,19 @@
-fn ptr(a byte) {}
+fn u8(a byte) {}
 fn arr(a []int) {}
 fn fun(a fn(int)) {}
 
-v := 4
-ptr(&v)
-arr([5]!)
-fun(fn(i &int){})
+fn basic() {
+	v := 4
+	u8(&v)
+	arr([5]!)
+	fun(fn(i &int){})
+}
+
+struct S1 {
+}
+fn f(p &S1) {}
+
+fn ptr() {
+	v := 4
+	f(v)
+}

--- a/vlib/v/checker/tests/method_wrong_arg_type.out
+++ b/vlib/v/checker/tests/method_wrong_arg_type.out
@@ -1,6 +1,13 @@
-vlib/v/checker/tests/method_wrong_arg_type.vv:8:4: error: cannot use `MyEnum` as `string` in argument 1 to `Sss.info`
-    6 |     e := MyEnum.x
-    7 |     s := Sss{}
-    8 |     s.info(e)
+vlib/v/checker/tests/method_wrong_arg_type.vv:10:4: error: cannot use `MyEnum` as `string` in argument 1 to `Sss.info`
+    8 |     e := MyEnum.x
+    9 |     s := Sss{}
+   10 |     s.info(e)
       |       ~~~~~~~
-    9 | }
+   11 | }
+   12 |
+vlib/v/checker/tests/method_wrong_arg_type.vv:18:4: error: cannot use `int` as `&Sss` in argument 1 to `Sss.ptr`
+   16 |     s := Sss{}
+   17 |     v := 4
+   18 |     s.ptr(v)
+      |       ~~~~~~
+   19 | }

--- a/vlib/v/checker/tests/method_wrong_arg_type.vv
+++ b/vlib/v/checker/tests/method_wrong_arg_type.vv
@@ -1,9 +1,19 @@
 enum MyEnum { x y z }
 pub fn (e MyEnum) str() string { return int(e).str() }
+
 struct Sss { }
 fn (s Sss) info(msg string) { println(msg) }
-fn main() {
+
+fn enum_str() {
 	e := MyEnum.x
 	s := Sss{}
 	s.info(e)
+}
+
+fn (s Sss) ptr(p &Sss) {}
+
+fn ptr_arg() {
+	s := Sss{}
+	v := 4
+	s.ptr(v)
 }


### PR DESCRIPTION
Also fix bug detected by fix - checking __offsetof field name.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
