### PR TITLE
vdoc: fix padding above heading with README toc link

### DIFF
--- a/cmd/tools/vdoc/resources/doc.css
+++ b/cmd/tools/vdoc/resources/doc.css
@@ -593,7 +593,7 @@ pre {
 	.doc-content {
 		font-size: 0.95rem;
 		flex: 1;
-		padding: 1rem 2rem;
+		padding: 0rem 2rem 1rem 2rem;
 	}
 	.doc-toc {
 		position: relative;


### PR DESCRIPTION
Before
![Peek 2021-02-19 23-43](https://user-images.githubusercontent.com/40118727/108569545-52bf4280-730c-11eb-8b87-cbf76cf11af6.gif)

After
![Peek 2021-02-19 23-44](https://user-images.githubusercontent.com/40118727/108569613-71253e00-730c-11eb-94cd-467609a69bdf.gif)
