### PR TITLE
parser: fix error of $tmpl in anon_fn (fix #8847)

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -551,6 +551,14 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 			p.tok.position())
 	}
 	mut label_names := []string{}
+	mut func := table.Fn{
+		params: args
+		is_variadic: is_variadic
+		return_type: return_type
+	}
+	name := 'anon_fn_${p.table.fn_type_signature(func)}_$p.tok.pos'
+	keep_fn_name := p.cur_fn_name
+	p.cur_fn_name = name
 	if p.tok.kind == .lcbr {
 		tmp := p.label_names
 		p.label_names = []
@@ -558,13 +566,8 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 		label_names = p.label_names
 		p.label_names = tmp
 	}
+	p.cur_fn_name = keep_fn_name
 	p.close_scope()
-	mut func := table.Fn{
-		params: args
-		is_variadic: is_variadic
-		return_type: return_type
-	}
-	name := 'anon_fn_${p.table.fn_type_signature(func)}_$p.tok.pos'
 	func.name = name
 	idx := p.table.find_or_register_fn_type(p.mod, func, true, false)
 	typ := table.new_type(idx)

--- a/vlib/v/tests/tmpl_test.v
+++ b/vlib/v/tests/tmpl_test.v
@@ -19,3 +19,23 @@ numbers: [1, 2, 3]
 
 3'
 }
+
+fn test_tmpl_in_anon_fn() {
+	anon := fn (name string, age int, numbers []int) string {
+		return $tmpl('tmpl/1.txt')
+	}
+
+	println(anon('Peter', 25, [1, 2, 3]))
+	assert anon('Peter', 25, [1, 2, 3]).trim_space() == 'name: Peter
+
+age: 25
+
+numbers: [1, 2, 3]
+
+
+1
+
+2
+
+3'
+}


### PR DESCRIPTION
This PR fixes error of $tmpl in anon_fn (fix #8847).

- Fixes error of $tmpl in anon_fn.
- Add test in `tmpl_test.v`.

```vlang
fn test_tmpl_in_anon_fn() {
	anon := fn (name string, age int, numbers []int) string {
		return $tmpl('tmpl/1.txt')
	}

	println(anon('Peter', 25, [1, 2, 3]))
	assert anon('Peter', 25, [1, 2, 3]).trim_space() == 'name: Peter

age: 25

numbers: [1, 2, 3]


1

2

3'
}
```