### PR TITLE
checker: change non-const size of fixed array error message

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2993,8 +2993,7 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) table.Type {
 						fixed_size = cint
 					}
 				} else {
-					c.error('non existent integer const $init_expr.name while initializing the size of a static array',
-						array_init.pos)
+					c.error('non-constant array bound `$init_expr.name`', init_expr.pos)
 				}
 			}
 			else {

--- a/vlib/v/checker/tests/fixed_array_non_const_size_err.out
+++ b/vlib/v/checker/tests/fixed_array_non_const_size_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/fixed_array_non_const_size_err.vv:4:12: error: non-constant array bound `size`
+    2 |     size := 2
+    3 |
+    4 |     array := [size]int{}
+      |               ~~~~
+    5 |
+    6 |     println(array)

--- a/vlib/v/checker/tests/fixed_array_non_const_size_err.vv
+++ b/vlib/v/checker/tests/fixed_array_non_const_size_err.vv
@@ -1,0 +1,7 @@
+fn main() {
+	size := 2
+
+	array := [size]int{}
+
+	println(array)
+}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -22,12 +22,11 @@ pub fn (mut p Parser) parse_array_type() table.Type {
 					if const_field.expr is ast.IntegerLiteral {
 						fixed_size = const_field.expr.val.int()
 					} else {
-						p.error_with_pos('non existent integer const $size_expr.name while initializing the size of a static array',
+						p.error_with_pos('non-constant array bound `$size_expr.name`',
 							size_expr.pos)
 					}
 				} else {
-					p.error_with_pos('non existent integer const $size_expr.name while initializing the size of a static array',
-						size_expr.pos)
+					p.error_with_pos('non-constant array bound `$size_expr.name`', size_expr.pos)
 				}
 			}
 			else {


### PR DESCRIPTION
This PR changes non-const size of fixed array error message just like Go. (fix #8557)

- Change non-const size of fixed array error message.
- Add test.

```vlang
fn main() {
	size := 2

	array := [size]int{}

	println(array)
}

D:\Test\v\tt1>v run .
.\tt1.v:4:12: error: non-constant array bound `size`
    2 |     size := 2
    3 | 
    4 |     array := [size]int{}
      |               ~~~~
    5 | 
    6 |     println(array)
```