### PR TITLE
table/parser: minor optimization of anon_fn names

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -564,7 +564,7 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 		is_variadic: is_variadic
 		return_type: return_type
 	}
-	name := 'anon_${p.tok.pos}_${p.table.fn_type_signature(func)}'
+	name := 'anon_fn_${p.table.fn_type_signature(func)}_$p.tok.pos'
 	func.name = name
 	idx := p.table.find_or_register_fn_type(p.mod, func, true, false)
 	typ := table.new_type(idx)

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -98,16 +98,16 @@ pub fn (t &Table) fn_type_signature(f &Fn) string {
 	for i, arg in f.params {
 		// TODO: for now ignore mut/pts in sig for now
 		typ := arg.typ.set_nr_muls(0)
-		// if arg.is_mut {
-		// sig += 'mut_'
-		// }
-		// sig += '$arg.typ'
-		sig += '$typ'
+		arg_type_sym := t.get_type_symbol(typ)
+		sig += '$arg_type_sym.kind'
 		if i < f.params.len - 1 {
 			sig += '_'
 		}
 	}
-	sig += '_$f.return_type'
+	if f.return_type != 0 && f.return_type != void_type {
+		sym := t.get_type_symbol(f.return_type)
+		sig += '__$sym.kind'
+	}
 	return sig
 }
 


### PR DESCRIPTION
This PR makes minor optimization of anon_fn names.

```v
anon := fn (data string) string {
```
- before
```v
anon_81_18_18()
```
- now
```v
anon_fn_string__string_81()
```
