### PR TITLE
arrays: use for/in instead of unsafe `[direct_array_access]`

### DIFF
--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -6,46 +6,43 @@ module arrays
 // - merge - combine two sorted arrays and maintain sorted order
 
 // min returns the minimum
-[direct_array_access]
 pub fn min<T>(a []T) T {
 	if a.len == 0 {
 		panic('.min called on an empty array')
 	}
 	mut val := a[0]
-	for i in 0 .. a.len {
-		if a[i] < val {
-			val = a[i]
+	for e in a {
+		if e < val {
+			val = e
 		}
 	}
 	return val
 }
 
 // max returns the maximum
-[direct_array_access]
 pub fn max<T>(a []T) T {
 	if a.len == 0 {
 		panic('.max called on an empty array')
 	}
 	mut val := a[0]
-	for i in 0 .. a.len {
-		if a[i] > val {
-			val = a[i]
+	for e in a {
+		if e > val {
+			val = e
 		}
 	}
 	return val
 }
 
 // idx_min returns the index of the first minimum
-[direct_array_access]
 pub fn idx_min<T>(a []T) int {
 	if a.len == 0 {
-		panic('.idxmin called on an empty array')
+		panic('.idx_min called on an empty array')
 	}
 	mut idx := 0
 	mut val := a[0]
-	for i in 0 .. a.len {
-		if a[i] < val {
-			val = a[i]
+	for i, e in a {
+		if e < val {
+			val = e
 			idx = i
 		}
 	}
@@ -53,16 +50,15 @@ pub fn idx_min<T>(a []T) int {
 }
 
 // idx_max returns the index of the first maximum
-[direct_array_access]
 pub fn idx_max<T>(a []T) int {
 	if a.len == 0 {
-		panic('.idxmax called on an empty array')
+		panic('.idx_max called on an empty array')
 	}
 	mut idx := 0
 	mut val := a[0]
-	for i in 0 .. a.len {
-		if a[i] > val {
-			val = a[i]
+	for i, e in a {
+		if e > val {
+			val = e
 			idx = i
 		}
 	}

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -1,7 +1,5 @@
 module arrays
 
-import rand
-
 fn test_min() {
 	a := [8, 2, 6, 4]
 	assert min<int>(a) == 2
@@ -53,25 +51,4 @@ fn test_merge() {
 	assert merge<int>(c, d) == []
 	assert merge<int>(a, c) == a
 	assert merge<int>(d, b) == b
-}
-
-fn test_fixed_array_assignment() {
-	mut a := [2]int{}
-	a[0] = 111
-	a[1] = 222
-	b := a
-	assert b[0] == a[0]
-	assert b[1] == a[1]
-	mut c := [2]int{}
-	c = a
-	assert c[0] == a[0]
-	assert c[1] == a[1]
-	d := [3]int{init: 333}
-	for val in d {
-		assert val == 333
-	}
-	e := [3]string{init: 'vlang'}
-	for val in e {
-		assert val == 'vlang'
-	}
 }

--- a/vlib/v/tests/fixed_array_test.v
+++ b/vlib/v/tests/fixed_array_test.v
@@ -18,6 +18,27 @@ fn test_fixed_array_can_be_assigned() {
 	assert v[1] == 3.0
 }
 
+fn test_fixed_array_assignment() {
+	mut a := [2]int{}
+	a[0] = 111
+	a[1] = 222
+	b := a
+	assert b[0] == a[0]
+	assert b[1] == a[1]
+	mut c := [2]int{}
+	c = a
+	assert c[0] == a[0]
+	assert c[1] == a[1]
+	d := [3]int{init: 333}
+	for val in d {
+		assert val == 333
+	}
+	e := [3]string{init: 'vlang'}
+	for val in e {
+		assert val == 'vlang'
+	}
+}
+
 fn test_fixed_array_can_be_used_in_declaration() {
 	x := 2.32
 	v := [1.0, x, 3.0,4.0,5.0,6.0,7.0,8.0]!
@@ -99,3 +120,4 @@ fn test_for_in_fixed_array() {
 	arr := [1,2,3]!
 	calc_size(arr)
 }
+


### PR DESCRIPTION
Also move an unrelated fixed array test to it's proper place.

for/in doesn't do bounds checks (it used to some time ago), so we don't need `[direct_array_access]` in 4 functions. for/in is expected to be comparable in efficiency of code generated (at least where the element is not `mut`).

See also: https://discord.com/channels/592103645835821068/592320321995014154/812667114916806678



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
