### PR TITLE
cgen: cleanup header for MSVC

### DIFF
--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -259,7 +259,6 @@ $c_common_macros
 
 	#include <io.h> // _waccess
 	#include <direct.h> // _wgetcwd
-	//#include <WinSock2.h>
 
 	#ifdef _MSC_VER
 		// On MSVC these are the same (as long as /volatile:ms is passed)
@@ -278,8 +277,6 @@ $c_common_macros
 
 		#include <dbghelp.h>
 		#pragma comment(lib, "Dbghelp")
-
-		extern wchar_t **_wenviron;
 	#endif
 #else
 	#include <pthread.h>


### PR DESCRIPTION
Remove `extern wchar_t **_wenviron;` because of `warning C4273: '__p__wenviron': inconsistent dll linkage` and it already exists in stdlib.h, which includes before
Remove commented include
