### PR TITLE
builder: use stable MSVC version instead preview

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -247,7 +247,7 @@ if not exist "%VsWhereDir%\Microsoft Visual Studio\Installer\vswhere.exe" (
 	goto :tcc_strap
 )
 
-for /f "usebackq tokens=*" %%i in (`"%VsWhereDir%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+for /f "usebackq tokens=*" %%i in (`"%VsWhereDir%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
 	set InstallDir=%%i
 )
 

--- a/vlib/v/builder/msvc.v
+++ b/vlib/v/builder/msvc.v
@@ -137,7 +137,7 @@ fn find_vs(vswhere_dir string, host_arch string, target_arch string) ?VsInstalla
 	// VSWhere is guaranteed to be installed at this location now
 	// If its not there then end user needs to update their visual studio
 	// installation!
-	res := os.exec('"$vswhere_dir\\Microsoft Visual Studio\\Installer\\vswhere.exe" -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath') ?
+	res := os.exec('"$vswhere_dir\\Microsoft Visual Studio\\Installer\\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath') ?
 	res_output := res.output.trim_right('\r\n')
 	// println('res: "$res"')
 	version := os.read_file('$res_output\\VC\\Auxiliary\\Build\\Microsoft.VCToolsVersion.default.txt') or {


### PR DESCRIPTION
I don't want fight against bugs  in preview MSVC version, Default it to stable one
I have stable and preview, and now it always select preview version