### PR TITLE
ast: change `expr.is_mut_ident()` to `expr.is_auto_deref_var()`

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1287,7 +1287,7 @@ pub fn (expr Expr) is_lit() bool {
 	}
 }
 
-pub fn (expr Expr) is_mut_ident() bool {
+pub fn (expr Expr) is_auto_deref_var() bool {
 	match expr {
 		Ident {
 			if expr.obj is Var {
@@ -1297,7 +1297,7 @@ pub fn (expr Expr) is_mut_ident() bool {
 			}
 		}
 		PrefixExpr {
-			if expr.op == .amp && expr.right.is_mut_ident() {
+			if expr.op == .amp && expr.right.is_auto_deref_var() {
 				return true
 			}
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -702,7 +702,8 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 	right_pos := infix_expr.right.position()
 	left_right_pos := left_pos.extend(right_pos)
 	if (left_type.is_ptr() || left.is_pointer()) && infix_expr.op in [.plus, .minus] {
-		if !c.inside_unsafe && !infix_expr.left.is_mut_ident() && !infix_expr.right.is_mut_ident() {
+		if !c.inside_unsafe && !infix_expr.left.is_auto_deref_var()
+			&& !infix_expr.right.is_auto_deref_var() {
 			c.warn('pointer arithmetic is only allowed in `unsafe` blocks', left_pos)
 		}
 		if left_type == table.voidptr_type {
@@ -1350,7 +1351,7 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 			// need to return `array_xxx` instead of `array`
 			// in ['clone', 'str'] {
 			call_expr.receiver_type = left_type.to_ptr()
-			if call_expr.left.is_mut_ident() {
+			if call_expr.left.is_auto_deref_var() {
 				call_expr.return_type = left_type.deref()
 			} else {
 				call_expr.return_type = call_expr.receiver_type.set_nr_muls(0)
@@ -1370,7 +1371,7 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 				if method_name[0] == `m` {
 					c.fail_if_immutable(call_expr.left)
 				}
-				if call_expr.left.is_mut_ident() {
+				if call_expr.left.is_auto_deref_var() {
 					ret_type = left_type.deref()
 				} else {
 					ret_type = left_type
@@ -2565,7 +2566,7 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 		right := if i < assign_stmt.right.len { assign_stmt.right[i] } else { assign_stmt.right[0] }
 		mut right_type := assign_stmt.right_types[i]
 		if is_decl {
-			if right.is_mut_ident() {
+			if right.is_auto_deref_var() {
 				left_type = c.table.mktyp(right_type.deref())
 			} else {
 				left_type = c.table.mktyp(right_type)
@@ -2699,7 +2700,7 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 				right.position())
 		}
 		left_is_ptr := left_type.is_ptr() || left_sym.is_pointer()
-		if left_is_ptr && !left.is_mut_ident() {
+		if left_is_ptr && !left.is_auto_deref_var() {
 			if !c.inside_unsafe && assign_stmt.op !in [.assign, .decl_assign] {
 				// ptr op=
 				c.warn('pointer arithmetic is only allowed in `unsafe` blocks', assign_stmt.pos)
@@ -2814,7 +2815,7 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 				}
 			}
 		}
-		if !is_blank_ident && !right.is_mut_ident() && right_sym.kind != .placeholder
+		if !is_blank_ident && !right.is_auto_deref_var() && right_sym.kind != .placeholder
 			&& left_sym.kind != .interface_ {
 			// Dual sides check (compatibility check)
 			c.check_expected(right_type_unwrapped, left_type_unwrapped) or {
@@ -2983,7 +2984,7 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) table.Type {
 			}
 			// The first element's type
 			if i == 0 {
-				if expr.is_mut_ident() {
+				if expr.is_auto_deref_var() {
 					elem_type = c.table.mktyp(typ.deref())
 				} else {
 					elem_type = c.table.mktyp(typ)
@@ -5076,7 +5077,7 @@ pub fn (mut c Checker) postfix_expr(mut node ast.PostfixExpr) table.Type {
 	typ := c.expr(node.expr)
 	typ_sym := c.table.get_type_symbol(typ)
 	is_non_void_pointer := (typ.is_ptr() || typ.is_pointer()) && typ_sym.kind != .voidptr
-	if !c.inside_unsafe && is_non_void_pointer && !node.expr.is_mut_ident() {
+	if !c.inside_unsafe && is_non_void_pointer && !node.expr.is_auto_deref_var() {
 		c.warn('pointer arithmetic is only allowed in `unsafe` blocks', node.pos)
 	}
 	if !(typ_sym.is_number() || (c.inside_unsafe && is_non_void_pointer)) {
@@ -5221,7 +5222,7 @@ pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) table.Type {
 			'(note, that variables may be mutable but string values are always immutable, like in Go and Java)',
 			node.pos)
 	}
-	if !c.inside_unsafe && ((typ.is_ptr() && !node.left.is_mut_ident()) || typ.is_pointer()) {
+	if !c.inside_unsafe && ((typ.is_ptr() && !node.left.is_auto_deref_var()) || typ.is_pointer()) {
 		mut is_ok := false
 		if mut node.left is ast.Ident {
 			if node.left.obj is ast.Var {
@@ -5401,11 +5402,11 @@ pub fn (mut c Checker) map_init(mut node ast.MapInit) table.Type {
 	}
 	// `{'age': 20}`
 	mut key0_type := c.table.mktyp(c.expr(node.keys[0]))
-	if node.keys[0].is_mut_ident() {
+	if node.keys[0].is_auto_deref_var() {
 		key0_type = key0_type.deref()
 	}
 	mut val0_type := c.table.mktyp(c.expr(node.vals[0]))
-	if node.vals[0].is_mut_ident() {
+	if node.vals[0].is_auto_deref_var() {
 		val0_type = val0_type.deref()
 	}
 	mut same_key_type := true

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -26,7 +26,7 @@ fn (mut g Gen) array_init(node ast.ArrayInit) {
 		g.write('{')
 		if node.has_val {
 			for i, expr in node.exprs {
-				if expr.is_mut_ident() {
+				if expr.is_auto_deref_var() {
 					g.write('*')
 				}
 				g.expr(expr)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1988,7 +1988,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 				g.array_set_pos = 0
 			} else {
 				g.out.go_back_to(pos)
-				is_var_mut := !is_decl && left.is_mut_ident()
+				is_var_mut := !is_decl && left.is_auto_deref_var()
 				addr := if is_var_mut { '' } else { '&' }
 				g.writeln('')
 				g.write('memcpy($addr')
@@ -2059,7 +2059,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					g.prevent_sum_type_unwrapping_once = true
 				}
 				if !is_fixed_array_copy || is_decl {
-					if !is_decl && left.is_mut_ident() {
+					if !is_decl && left.is_auto_deref_var() {
 						g.write('*')
 					}
 					g.expr(left)
@@ -2111,7 +2111,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					g.write('for (int $i_var=0; $i_var<$fixed_array.size; $i_var++) {')
 					g.expr(left)
 					g.write('[$i_var] = ')
-					if val.is_mut_ident() {
+					if val.is_auto_deref_var() {
 						g.write('*')
 					}
 					g.expr(val)
@@ -2136,7 +2136,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 							g.write('{0}')
 						}
 					} else {
-						if val.is_mut_ident() {
+						if val.is_auto_deref_var() {
 							g.write('*')
 						}
 						g.expr(val)
@@ -2721,7 +2721,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 				g.writeln('sync__RwMutex_lock(&$node.auto_locked->mtx);')
 			}
 			g.inside_map_postfix = true
-			if node.expr.is_mut_ident() {
+			if node.expr.is_auto_deref_var() {
 				g.write('(*')
 				g.expr(node.expr)
 				g.write(')')
@@ -3391,12 +3391,12 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 			if need_par {
 				g.write('(')
 			}
-			if node.left_type.is_ptr() && node.left.is_mut_ident() {
+			if node.left_type.is_ptr() && node.left.is_auto_deref_var() {
 				g.write('*')
 			}
 			g.expr(node.left)
 			g.write(' $node.op.str() ')
-			if node.right_type.is_ptr() && node.right.is_mut_ident() {
+			if node.right_type.is_ptr() && node.right.is_auto_deref_var() {
 				g.write('*')
 			}
 			g.expr(node.right)
@@ -3729,7 +3729,7 @@ fn (mut g Gen) map_init(node ast.MapInit) {
 			g.write('}), _MOV(($value_typ_str[$size]){')
 		}
 		for expr in node.vals {
-			if expr.is_mut_ident() {
+			if expr.is_auto_deref_var() {
 				g.write('*')
 			}
 			g.expr(expr)

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -264,13 +264,13 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 		if typ == table.string_type {
 			if g.inside_vweb_tmpl {
 				g.write('vweb__filter(')
-				if expr.is_mut_ident() {
+				if expr.is_auto_deref_var() {
 					g.write('*')
 				}
 				g.expr(expr)
 				g.write(')')
 			} else {
-				if expr.is_mut_ident() {
+				if expr.is_auto_deref_var() {
 					g.write('*')
 				}
 				g.expr(expr)
@@ -289,19 +289,19 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 				} else {
 					g.write('(u64)(')
 				}
-				if expr.is_mut_ident() {
+				if expr.is_auto_deref_var() {
 					g.write('*')
 				}
 				g.expr(expr)
 				g.write(')')
 			} else {
-				if expr.is_mut_ident() {
+				if expr.is_auto_deref_var() {
 					g.write('*')
 				}
 				g.expr(expr)
 			}
 		} else {
-			if expr.is_mut_ident() {
+			if expr.is_auto_deref_var() {
 				g.write('*')
 			}
 			g.expr(expr)
@@ -362,7 +362,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype table.Type) {
 	} else if sym_has_str_method
 		|| sym.kind in [.array, .array_fixed, .map, .struct_, .multi_return, .sum_type, .interface_] {
 		is_ptr := typ.is_ptr()
-		is_var_mut := expr.is_mut_ident()
+		is_var_mut := expr.is_auto_deref_var()
 		str_fn_name := g.gen_str_for_type(typ)
 		if is_ptr && !is_var_mut {
 			g.write('_STR("&%.*s\\000", 2, ')


### PR DESCRIPTION
This PR changes `expr.is_mut_ident()` to `expr.is_auto_deref_var()`.

- `expr.is_mut_ident()` is not clear, use `expr.is_auto_deref_var()` instead of it.
- Modify all the related calls.