### PR TITLE
docs: add [console] attribute

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -3879,8 +3879,8 @@ On Unix-like platforms, the file can be run directly after making it executable 
 
 V has several attributes that modify the behavior of functions and structs.
 
-An attribute is specified inside `[]` right before a function/struct declaration
-and applies only to the following declaration.
+An attribute is a compiler instruction specified inside `[]` right before a
+function/struct/enum declaration and applies only to the following declaration.
 
 ```v
 // Calling this function will result in a deprecation warning
@@ -3917,6 +3917,14 @@ struct C.Foo {
 // Used in Win32 API code when you need to pass callback function
 [windows_stdcall]
 fn C.DefWindowProc(hwnd int, msg int, lparam int, wparam int)
+
+// Windows only:
+// If a default graphics library is imported (ex. gg, ui), then the graphical window takes
+// priority and no console window is created, effectively disabling println() statements.
+// Use to explicity create console window. Valid before main() only.
+[console]
+fn main() {
+}
 ```
 
 ## Goto


### PR DESCRIPTION
Document the [console] attribute in docs.md.

It is currently undocumented, leading to confusion on Windows when using both imported default graphics libraries and the console. ([console] omitted, there is no output when using println() ).

#8794,  #8800
