### PR TITLE
cgen: fix in map_literal (fix #8868)

### DIFF
--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -131,7 +131,7 @@ fn test_map_init() {
 	one := 'one'
 	three := 'three'
 	m := map{
-		one: 1
+		one:   1
 		'two': 2
 		three: 1 + 2
 	}
@@ -326,7 +326,7 @@ fn test_assign_directly() {
 }
 
 fn test_map_in_directly() {
-	for k, v in {
+	for k, v in map{
 		'aa': 1
 	} {
 		assert k == 'aa'
@@ -628,5 +628,7 @@ fn test_map_assign_empty_map_init() {
 }
 
 fn test_in_map_literal() {
-	assert 1 in map{1: 'one'}
+	assert 1 in map{
+		1: 'one'
+	}
 }

--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -626,3 +626,7 @@ fn test_map_assign_empty_map_init() {
 	assert a == map[string]int{}
 	assert '$a' == '{}'
 }
+
+fn test_in_map_literal() {
+	assert 1 in map{1: 'one'}
+}

--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -326,7 +326,7 @@ fn test_assign_directly() {
 }
 
 fn test_map_in_directly() {
-	for k, v in map{
+	for k, v in {
 		'aa': 1
 	} {
 		assert k == 'aa'

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -750,6 +750,15 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 						c.error('left operand to `$infix_expr.op` does not match the map key type: $err',
 							left_right_pos)
 					}
+					match infix_expr.left_type {
+						table.int_literal_type {
+							infix_expr.left_type = table.int_type
+						}
+						table.float_literal_type {
+							infix_expr.left_type = table.f64_type
+						}
+						else {}
+					}
 				}
 				.string {
 					c.check_expected(left_type, right_type) or {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -745,20 +745,12 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 					}
 				}
 				.map {
-					elem_type := right.map_info().key_type
-					c.check_expected(left_type, elem_type) or {
+					map_info := right.map_info()
+					c.check_expected(left_type, map_info.key_type) or {
 						c.error('left operand to `$infix_expr.op` does not match the map key type: $err',
 							left_right_pos)
 					}
-					match infix_expr.left_type {
-						table.int_literal_type {
-							infix_expr.left_type = table.int_type
-						}
-						table.float_literal_type {
-							infix_expr.left_type = table.f64_type
-						}
-						else {}
-					}
+					infix_expr.left_type = map_info.key_type
 				}
 				.string {
 					c.check_expected(left_type, right_type) or {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3225,7 +3225,7 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 		} else if right_sym.kind == .map {
 			g.write('_IN_MAP(')
 			if !node.left_type.is_ptr() {
-				left_type_str := g.typ(node.left_type)
+				left_type_str := g.table.type_to_str(node.left_type)
 				g.write('ADDR($left_type_str, ')
 				g.expr(node.left)
 				g.write(')')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3225,7 +3225,7 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 		} else if right_sym.kind == .map {
 			g.write('_IN_MAP(')
 			if !node.left_type.is_ptr() {
-				left_type_str := g.table.type_to_str(node.left_type)
+				left_type_str := g.typ(node.left_type)
 				g.write('ADDR($left_type_str, ')
 				g.expr(node.left)
 				g.write(')')


### PR DESCRIPTION
This PR fixes in map_literal (fix #8868).

- Fix in map_literal.
- Add test.

```vlang
fn main() {
	a := 1 in map{1: 'one'}
	println(a)
}

D:\Test\v\tt1>v run .
true
```