### PR TITLE
cgen: fix match_return with complex expr stmts (fix #8074)

### DIFF
--- a/vlib/v/tests/match_with_complex_exprs_in_branches_test.v
+++ b/vlib/v/tests/match_with_complex_exprs_in_branches_test.v
@@ -1,0 +1,31 @@
+type Arr = []int | []string
+
+fn test_match_with_array_map_in_branches() {
+	arr := Arr([0, 1])
+	ret := match arr {
+		[]int {
+			arr.map(fn(s int) string { return s.str() }).str()
+		}
+		else {
+			''
+		}
+	}
+	println(ret)
+	assert ret == "['0', '1']"
+}
+
+fn test_match_expr_of_multi_expr_stmts() {
+	a := 1
+	ret := match a {
+		1 {
+			mut m := map[string]int{}
+			m['two'] = 2
+			m['two']
+		}
+		else {
+			int(0)
+		}
+	}
+	println(ret)
+	assert ret == 2
+}


### PR DESCRIPTION
This PR fixes match_return with complex expr stmts (fix #8074).

- Fix match_return with complex expr stmts. (solution: use `if else` instead of `if xxx? a:b` with complex exprs)
- Add tests.

```vlang
type Arr = []int | []string
fn main() {
	arr := Arr([0, 1])
	println(match arr {
		[]int {
			arr.map(fn(s int) string { return s.str() }).str()
		}
		else {
			''
		}
	})
}

D:\Test\v\tt1>v run .
['0', '1']
```
```vlang
fn main() {
	a := 1
	ret := match a {
		1 {
			mut m := map[string]int{}
			m['two'] = 2
			m['two']
		}
		else {
			int(0)
		}
	}
	println(ret)
	assert ret == 2
}

D:\Test\v\tt1>v run .
2
```