### PR TITLE
checker: fix error of match in map_init (fix #8579)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5416,6 +5416,7 @@ pub fn (mut c Checker) map_init(mut node ast.MapInit) table.Type {
 		}
 		val := node.vals[i]
 		key_type := c.expr(key)
+		c.expected_type = val0_type
 		val_type := c.expr(val)
 		if !c.check_types(key_type, key0_type) {
 			msg := c.expected_msg(key_type, key0_type)

--- a/vlib/v/tests/match_in_map_init_test.v
+++ b/vlib/v/tests/match_in_map_init_test.v
@@ -1,0 +1,24 @@
+fn test_match_in_map_init() {
+	ret := foo()
+	println(ret)
+	assert ret == {'token': 'a', 'sleep': '30', 'every': '1'}
+}
+
+fn foo() map[string]string {
+	mut cfg := map[string][]string{}
+	cfg['token'] = ['a', 'b']
+	cfg['sleep'] = ['30', '60']
+	cfg['every'] = ['1', '5']
+
+	return {
+		'token': cfg['token'][0]
+		'sleep': match cfg['sleep'][0].len {
+			0 { '60' }
+			else { cfg['sleep'][0] }
+		}
+		'every': match cfg['every'][0].len {
+			0 { '5' }
+			else { cfg['every'][0] }
+		}
+	}
+}

--- a/vlib/v/tests/match_in_map_init_test.v
+++ b/vlib/v/tests/match_in_map_init_test.v
@@ -1,7 +1,7 @@
 fn test_match_in_map_init() {
 	ret := foo()
 	println(ret)
-	assert ret == {'token': 'a', 'sleep': '30', 'every': '1'}
+	assert ret == map{'token': 'a', 'sleep': '30', 'every': '1'}
 }
 
 fn foo() map[string]string {
@@ -10,7 +10,7 @@ fn foo() map[string]string {
 	cfg['sleep'] = ['30', '60']
 	cfg['every'] = ['1', '5']
 
-	return {
+	return map{
 		'token': cfg['token'][0]
 		'sleep': match cfg['sleep'][0].len {
 			0 { '60' }


### PR DESCRIPTION
This PR fixes error of match in map_init (fix #8579).

- Fix error of match in map_init.
- Add test.

```vlang
fn main() {
	a := x()
	println(a)
}

fn x() map[string]string {
	mut cfg := map[string][]string{}
	cfg['token'] = ['a', 'b']
	cfg['sleep'] = ['30', '60']
	cfg['every'] = ['1', '5']

	return {
		'token': cfg['token'][0]
		'sleep': match cfg['sleep'][0].len {
			0 { '60' }
			else { cfg['sleep'][0] }
		}
		'every': match cfg['every'][0].len {
			0 { '5' }
			else { cfg['every'][0] }
		}
	}
}

D:\Test\v\tt1>v run .
{'token': 'a', 'sleep': '30', 'every': '1'}
```