### PR TITLE
szip: change documentation style

### DIFF
--- a/vlib/szip/szip.v
+++ b/vlib/szip/szip.v
@@ -37,7 +37,7 @@ fn C.zip_entry_fread(&Zip, byteptr) int
 
 fn C.zip_total_entries(&Zip) int
 
-// Ref - miniz.h
+// compression level - ref: miniz.h
 const (
 	no_compression      = 0
 	best_speed          = 1
@@ -53,18 +53,7 @@ const (
 	m_append = `a`
 )
 
-/*
-open opens zip archive with compression level using the given mode.
-
-@param zipname zip archive file name.
-@param level compression level (0-9 are the standard zlib-style levels).
-@param mode file access mode.
-        - 'r': opens a file for reading/extracting (the file must exists).
-        - 'w': creates an empty file for writing.
-        - 'a': appends to an existing archive.
-
-@return the zip archive handler or NULL on error
-*/
+// open opens zip archive with compression level using the given mode.
 pub fn open(name string, level int, mode byte) ?&Zip {
 	mut nlevel := level
 	if (nlevel & 0xF) > szip.uber_compression {
@@ -83,27 +72,15 @@ pub fn open(name string, level int, mode byte) ?&Zip {
 	return p_zip
 }
 
-/*
-close closes the zip archive, releases resources - always finalize.
-
-@param zip zip archive handler.
-*/
+// close closes the zip archive, releases resources - always finalize.
 pub fn (mut z Zip) close() {
 	C.zip_close(z)
 }
 
-/*
-open_entry opens an entry by name in the zip archive.
-
-For zip archive opened in 'w' or 'a' mode the function will append
-a new entry. In readonly mode the function tries to locate the entry
-in global dictionary.
-
-@param zip zip archive handler.
-@param entryname an entry name in local dictionary.
-
-@return the return code - 0 on success, negative number (< 0) on error.
-*/
+// open_entry opens an entry by name in the zip archive.
+// For zip archive opened in 'w' or 'a' mode the function will append
+// a new entry. In readonly mode the function tries to locate the entry
+// in global dictionary.
 pub fn (mut zentry Zip) open_entry(name string) ? {
 	res := C.zip_entry_open(zentry, name.str)
 	if res == -1 {
@@ -111,31 +88,18 @@ pub fn (mut zentry Zip) open_entry(name string) ? {
 	}
 }
 
-/*
-* close_entry closes a zip entry, flushes buffer and releases resources.
- *
- * @param zip zip archive handler.
- *
- * @return the return code - 0 on success, negative number (< 0) on error.
-*/
+// close_entry closes a zip entry, flushes buffer and releases resources.
 pub fn (mut zentry Zip) close_entry() {
 	C.zip_entry_close(zentry)
 }
 
-/*
-name returns a local name of the current zip entry.
-
-The main difference between user's entry name and local entry name
-is optional relative path.
-Following .ZIP File Format Specification - the path stored MUST not contain
-a drive or device letter, or a leading slash.
-All slashes MUST be forward slashes '/' as opposed to backwards slashes '\'
-for compatibility with Amiga and UNIX file systems etc.
-
-@param zip: zip archive handler.
-
-@return the pointer to the current zip entry name, or NULL on error.
-*/
+// name returns a local name of the current zip entry.
+// The main difference between user's entry name and local entry name
+// is optional relative path.
+// Following .ZIP File Format Specification - the path stored MUST not contain
+// a drive or device letter, or a leading slash.
+// All slashes MUST be forward slashes '/' as opposed to backwards slashes '\'
+// for compatibility with Amiga and UNIX file systems etc.
 pub fn (mut zentry Zip) name() string {
 	name := C.zip_entry_name(zentry)
 	if name == 0 {
@@ -144,13 +108,7 @@ pub fn (mut zentry Zip) name() string {
 	return unsafe { tos_clone(name) }
 }
 
-/*
-index returns an index of the current zip entry.
-
-@param zip zip archive handler.
-
-@return the index on success, negative number (< 0) on error.
-*/
+/// index returns an index of the current zip entry.
 pub fn (mut zentry Zip) index() ?int {
 	index := int(C.zip_entry_index(zentry))
 	if index == -1 {
@@ -159,14 +117,7 @@ pub fn (mut zentry Zip) index() ?int {
 	return index // must be check for INVALID_VALUE
 }
 
-/*
-isdir determines if the current zip entry is a directory entry.
-
-@param zip zip archive handler.
-
-@return the return code - 1 (true), 0 (false), negative number (< 0) on
-         error.
-*/
+// isdir determines if the current zip entry is a directory entry.
 pub fn (mut zentry Zip) isdir() ?bool {
 	isdir := C.zip_entry_isdir(zentry)
 	if isdir < 0 {
@@ -175,37 +126,17 @@ pub fn (mut zentry Zip) isdir() ?bool {
 	return isdir == 1
 }
 
-/*
-size returns an uncompressed size of the current zip entry.
-
-@param zip zip archive handler.
-
-@return the uncompressed size in bytes.
-*/
+// size returns an uncompressed size of the current zip entry.
 pub fn (mut zentry Zip) size() u64 {
 	return C.zip_entry_size(zentry)
 }
 
-/*
-crc32 returns CRC-32 checksum of the current zip entry.
-
-@param zip zip archive handler.
-
-@return the CRC-32 checksum.
-*/
+// crc32 returns CRC-32 checksum of the current zip entry.
 pub fn (mut zentry Zip) crc32() u32 {
 	return C.zip_entry_crc32(zentry)
 }
 
-/*
-write_entry compresses an input buffer for the current zip entry.
-
-@param zip zip archive handler.
-@param buf input buffer.
-@param bufsize input buffer size (in bytes).
-
-@return the return code - 0 on success, negative number (< 0) on error.
-*/
+// write_entry compresses an input buffer for the current zip entry.
 pub fn (mut zentry Zip) write_entry(data []byte) ? {
 	if (data[0] & 0xff) == -1 {
 		return error('szip: cannot write entry')
@@ -216,14 +147,7 @@ pub fn (mut zentry Zip) write_entry(data []byte) ? {
 	}
 }
 
-/*
-create_entry compresses a file for the current zip entry.
-
-@param zip zip archive handler.
-@param filename input file.
-
-@return the return code - 0 on success, negative number (< 0) on error.
-*/
+// create_entry compresses a file for the current zip entry.
 pub fn (mut zentry Zip) create_entry(name string) ? {
 	res := C.zip_entry_fwrite(zentry, name.str)
 	if res != 0 {
@@ -231,21 +155,10 @@ pub fn (mut zentry Zip) create_entry(name string) ? {
 	}
 }
 
-/*
-read_entry extracts the current zip entry into output buffer.
-
-The function allocates sufficient memory for an output buffer.
-
-@param zip zip archive handler.
-@param buf output buffer.
-@param bufsize output buffer size (in bytes).
-
-@note remember to release the memory allocated for an output buffer.
-for large entries, please take a look at zip_entry_extract function.
-
-@return the return code - the number of bytes actually read on success.
-         Otherwise a -1 on error.
-*/
+// read_entry extracts the current zip entry into output buffer.
+// The function allocates sufficient memory for an output buffer.
+// NOTE: remember to release the memory allocated for an output buffer.
+// for large entries, please take a look at zip_entry_extract function.
 pub fn (mut zentry Zip) read_entry() ?voidptr {
 	mut buf := voidptr(0)
 	mut bsize := i64(0)
@@ -256,14 +169,7 @@ pub fn (mut zentry Zip) read_entry() ?voidptr {
 	return buf
 }
 
-/*
-extract_entry extracts the current zip entry into output file.
-
-@param zip zip archive handler.
-@param filename output file.
-
-@return the return code - 0 on success, negative number (< 0) on error.
-*/
+// extract_entry extracts the current zip entry into output file.
 pub fn (mut zentry Zip) extract_entry(path string) ? {
 	if C.access(charptr(path.str), 0) == -1 {
 		return error('Cannot open file for extracting, file not exists')
@@ -274,34 +180,17 @@ pub fn (mut zentry Zip) extract_entry(path string) ? {
 	}
 }
 
-/*
-extract extracts the current zip entry using a callback function (on_extract).
-
-@param zip zip archive handler.
-@param on_extract callback function.
-@param arg opaque pointer (optional argument, which you can pass to the
-        on_extract callback)
-
-@return the return code - 0 on success, negative number (< 0) on error.
-*/
-/*
+/* extract extracts the current zip entry using a callback function (on_extract).
 fn (mut zentry Zip) extract(path string) bool {
-    if C.access(path.str, 0) == -1 {
-        return false
-        //return error('Cannot open directory for extracting, directory not exists')
-    }
-    res := C.zip_extract(zentry, path.str, 0, 0)
-    return res == 0
-}
-*/
-/*
-total returns the number of all entries (files and directories) in the zip archive.
+	if C.access(path.str, 0) == -1 {
+		return false
+		// return error('Cannot open directory for extracting, directory not exists')
+	}
+	res := C.zip_extract(zentry, path.str, 0, 0)
+	return res == 0
+}*/
 
-@param zip zip archive handler.
-
-@return the return code - the number of entries on success, negative number
-         (< 0) on error.
-*/
+// total returns the number of all entries (files and directories) in the zip archive.
 pub fn (mut zentry Zip) total() ?int {
 	tentry := int(C.zip_total_entries(zentry))
 	if tentry == -1 {

--- a/vlib/szip/szip.v
+++ b/vlib/szip/szip.v
@@ -53,7 +53,12 @@ const (
 	m_append = `a`
 )
 
-// open opens zip archive with compression level using the given mode.
+// open opens zip archive with compression level using the given mode.<br>
+// compression levels: 0-9 are the standard zlib-style levels.<br>
+// modes:<br>
+// - 'r': opens a file for reading/extracting (the file must exists).<br>
+// - 'w': creates an empty file for writing.<br>
+// - 'a': appends to an existing archive.
 pub fn open(name string, level int, mode byte) ?&Zip {
 	mut nlevel := level
 	if (nlevel & 0xF) > szip.uber_compression {

--- a/vlib/szip/szip.v
+++ b/vlib/szip/szip.v
@@ -117,8 +117,8 @@ pub fn (mut zentry Zip) index() ?int {
 	return index // must be check for INVALID_VALUE
 }
 
-// isdir determines if the current zip entry is a directory entry.
-pub fn (mut zentry Zip) isdir() ?bool {
+// is_dir determines if the current zip entry is a directory entry.
+pub fn (mut zentry Zip) is_dir() ?bool {
 	isdir := C.zip_entry_isdir(zentry)
 	if isdir < 0 {
 		return error('szip: cannot check entry type')
@@ -180,7 +180,8 @@ pub fn (mut zentry Zip) extract_entry(path string) ? {
 	}
 }
 
-/* extract extracts the current zip entry using a callback function (on_extract).
+/*
+extract extracts the current zip entry using a callback function (on_extract).
 fn (mut zentry Zip) extract(path string) bool {
 	if C.access(path.str, 0) == -1 {
 		return false
@@ -188,7 +189,8 @@ fn (mut zentry Zip) extract(path string) bool {
 	}
 	res := C.zip_extract(zentry, path.str, 0, 0)
 	return res == 0
-}*/
+}
+*/
 
 // total returns the number of all entries (files and directories) in the zip archive.
 pub fn (mut zentry Zip) total() ?int {

--- a/vlib/szip/szip_test.v
+++ b/vlib/szip/szip_test.v
@@ -1,7 +1,7 @@
 import szip
 import os
 
-fn test_compile() {
+fn test_szip() {
 	mut z := szip.open('test_compile.zip', szip.best_speed, szip.m_write) or {
 		assert false
 		return
@@ -11,3 +11,4 @@ fn test_compile() {
 		os.rm('test_compile.zip') or { }
 	}
 }
+


### PR DESCRIPTION
This PR improves the documentation style of the `szip` module, changing the `/**/` style to the `//` style.