### PR TITLE
gen1m.v: update generated code

### DIFF
--- a/cmd/tools/gen1m.v
+++ b/cmd/tools/gen1m.v
@@ -1,6 +1,4 @@
 fn main() {
-	println('fn print(a int) {}')
-	// println('fn println(a string) {}')
 	for i in 0 .. 100000 {
 		println('
 fn foo${i}() {


### PR DESCRIPTION
The generated code, `1mil.v`, does not compile :
```
../../1mil.v:1:4: error: cannot redefine builtin function `print`
    1 | fn print(a int) {}
````

This PR fixes it. fast.vlang.io might need to regenerate the faulty `1mil.v` when merged