### PR TITLE
builtin: add an Option2 struct

### DIFF
--- a/examples/eventbus/eventbus.v
+++ b/examples/eventbus/eventbus.v
@@ -8,6 +8,6 @@ fn main(){
 	some_module.do_work()
 }
 
-fn on_error(sender voidptr, e &some_module.Error, x voidptr) {
+fn on_error(sender voidptr, e &some_module.MyError, x voidptr) {
 	println(e.message)
 }

--- a/examples/eventbus/modules/some_module/some_module.v
+++ b/examples/eventbus/modules/some_module/some_module.v
@@ -7,12 +7,12 @@ const (
 )
 
 pub struct Work {
-	pub:
+pub:
 	hours int
 }
 
-pub struct Error {
-	pub:
+pub struct MyError {
+pub:
 	message string
 }
 
@@ -21,7 +21,7 @@ pub fn do_work(){
 	for i in 0..20 {
 		println("working...")
 		if i == 15 {
-			error := &Error{"There was an error."}
+			error := &MyError{"There was an error."}
 			eb.publish("error", work, error)
 			eb.publish("error", work, error)
 			return

--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -3,16 +3,6 @@
 // that can be found in the LICENSE file.
 module builtin
 
-/*
-struct Option2<T> {
-	ok bool
-	is_none bool
-	error string
-	ecode int
-	data T
-}
-*/
-// OptionBase is the the base of V's internal optional return system.
 struct OptionBase {
 	ok      bool
 	is_none bool
@@ -81,3 +71,65 @@ pub fn error_with_code(message string, code int) Option {
 		ecode: code
 	}
 }
+
+struct Option2 {
+	state byte
+	err   Error
+}
+
+// OptionBase is the the base of V's internal optional return system.
+struct OptionBase2 {
+	state byte
+	err   Error
+	// Data is trailing after err
+	// and is not included in here but in the
+	// derived Option2_xxx types
+}
+
+// ErrorInfo holds information about an error instance
+struct Error {
+	msg  string
+	code int
+}
+
+// /*
+pub fn (o Option2) str() string {
+	if o.state == 0 {
+		return 'Option2{ ok }'
+	}
+	if o.state == 1 {
+		return 'Option2{ none }'
+	}
+	return 'Option2{ err: "$o.err.msg" }'
+}
+
+// opt_none is used internally when returning `none`.
+fn opt_none2() Option2 {
+	return Option2{
+		state: 1
+	}
+}
+
+// error returns an optional containing the error given in `message`.
+// `if ouch { return error('an error occurred') }`
+pub fn error2(message string) Option2 {
+	return Option2{
+		state: 2
+		err: {
+			msg: message
+		}
+	}
+}
+
+// error_with_code returns an optional containing both error `message` and error `code`.
+// `if ouch { return error_with_code('an error occurred',1) }`
+pub fn error_with_code2(message string, code int) Option2 {
+	return Option2{
+		state: 2
+		err: {
+			msg: message
+			code: code
+		}
+	}
+}
+// */

--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -86,7 +86,7 @@ struct OptionBase2 {
 	// derived Option2_xxx types
 }
 
-// ErrorInfo holds information about an error instance
+// Error holds information about an error instance
 struct Error {
 	msg  string
 	code int

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2336,7 +2336,7 @@ pub fn (mut c Checker) return_stmt(mut return_stmt ast.Return) {
 	}
 	return_stmt.types = got_types
 	// allow `none` & `error (Option)` return types for function that returns optional
-	if exp_is_optional && got_types[0].idx() in [table.none_type_idx, c.table.type_idxs['Option']] {
+	if exp_is_optional && got_types[0].idx() in [table.none_type_idx, c.table.type_idxs['Option'], c.table.type_idxs['Option2']] {
 		return
 	}
 	if expected_types.len > 0 && expected_types.len != got_types.len {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2336,7 +2336,8 @@ pub fn (mut c Checker) return_stmt(mut return_stmt ast.Return) {
 	}
 	return_stmt.types = got_types
 	// allow `none` & `error (Option)` return types for function that returns optional
-	if exp_is_optional && got_types[0].idx() in [table.none_type_idx, c.table.type_idxs['Option'], c.table.type_idxs['Option2']] {
+	if exp_is_optional
+		&& got_types[0].idx() in [table.none_type_idx, c.table.type_idxs['Option'], c.table.type_idxs['Option2']] {
 		return
 	}
 	if expected_types.len > 0 && expected_types.len != got_types.len {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5234,7 +5234,7 @@ fn (mut g Gen) write_init_function() {
 }
 
 const (
-	builtins = ['string', 'array', 'KeyValue', 'DenseArray', 'map', 'Option']
+	builtins = ['string', 'array', 'KeyValue', 'DenseArray', 'map', 'Option', 'Error', 'Option2']
 )
 
 fn (mut g Gen) write_builtin_types() {


### PR DESCRIPTION
Needed for bootstrapping, in the migration to the new error implementation with the Error interface

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
