### PR TITLE
checker: check fn_variadic with array_decompose (fix #8891)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1907,6 +1907,11 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 		} else {
 			f.params[i]
 		}
+		if f.is_variadic && call_arg.expr is ast.ArrayDecompose {
+			if i > f.params.len - 1 {
+				c.error('too many arguments in call to `$f.name`', call_expr.pos)
+			}
+		}
 		c.expected_type = arg.typ
 		typ := c.expr(call_arg.expr)
 		call_expr.args[i].typ = typ

--- a/vlib/v/checker/tests/function_variadic_arg_array_decompose.out
+++ b/vlib/v/checker/tests/function_variadic_arg_array_decompose.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/function_variadic_arg_array_decompose.vv:11:10: error: too many arguments in call to `sum`
+    9 | fn main() {
+   10 |     b := [5, 6, 7]
+   11 |     println(sum(1, 2, ...b))
+      |             ~~~~~~~~~~~~~~~
+   12 | }

--- a/vlib/v/checker/tests/function_variadic_arg_array_decompose.vv
+++ b/vlib/v/checker/tests/function_variadic_arg_array_decompose.vv
@@ -1,0 +1,12 @@
+fn sum(a ...int) int {
+	mut total := 0
+	for x in a {
+		total += x
+	}
+	return total
+}
+
+fn main() {
+	b := [5, 6, 7]
+	println(sum(1, 2, ...b))
+}


### PR DESCRIPTION
This PR checks fn_variadic with array_decompose (fix #8891).

- Check fn_variadic with array_decompose.
- Add test.

```vlang
fn sum(a ...int) int {
	mut total := 0
	for x in a {
		total += x
	}
	return total
}

fn main() {
	b := [5, 6, 7]
	println(sum(1, 2, ...b))
}

D:\Test\v\tt1>v run .
.\tt1.v:11:10: error: too many arguments in call to `sum`
    9 | fn main() {
   10 |     b := [5, 6, 7]
   11 |     println(sum(1, 2, ...b))
      |             ~~~~~~~~~~~~~~~
   12 | }
```