### PR TITLE
termux: symlink fix

### DIFF
--- a/cmd/tools/vsymlink.v
+++ b/cmd/tools/vsymlink.v
@@ -24,23 +24,17 @@ fn cleanup_vtmp_folder() {
 }
 
 fn setup_symlink_unix(vexe string) {
-	link_dir := '/usr/local/bin'
-	if !os.exists(link_dir) {
-		os.mkdir_all(link_dir) or { panic(err) }
+	mut link_path := '/data/data/com.termux/files/usr/bin/v'
+	if os.system("uname -o | grep -q '[A/a]ndroid'") == 1 {
+		link_dir := '/usr/local/bin'
+		if !os.exists(link_dir) {
+			os.mkdir_all(link_dir) or { panic(err) }
+		}
+		link_path = link_dir + '/v'
 	}
-	mut link_path := link_dir + '/v'
-	mut ret := os.exec('ln -sf $vexe $link_path') or { panic(err) }
+	ret := os.exec('ln -sf $vexe $link_path') or { panic(err) }
 	if ret.exit_code == 0 {
 		println('Symlink "$link_path" has been created')
-	} else if os.system("uname -o | grep -q '[A/a]ndroid'") == 0 {
-		println('Failed to create symlink "$link_path". Trying again with Termux path for Android.')
-		link_path = '/data/data/com.termux/files/usr/bin/v'
-		ret = os.exec('ln -sf $vexe $link_path') or { panic(err) }
-		if ret.exit_code == 0 {
-			println('Symlink "$link_path" has been created')
-		} else {
-			eprintln('Failed to create symlink "$link_path". Try again with sudo.')
-		}
 	} else {
 		eprintln('Failed to create symlink "$link_path". Try again with sudo.')
 	}


### PR DESCRIPTION
Termux symlink fails because there is no write access to create this folder.
os.mkdir_all('/usr/local/bin')

I also separated linux and termux handling.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
