### PR TITLE
cgen: fix error of match in fn_call (fix #8895)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3544,14 +3544,15 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 		cond_var = g.new_tmp_var()
 		g.write('${g.typ(node.cond_type)} $cond_var = ')
 		g.expr(node.cond)
-		g.writeln('; ')
+		g.writeln(';')
+		g.stmt_path_pos << g.out.len
 		g.write(line)
 	}
 	if need_tmp_var {
 		g.empty_line = true
 		cur_line = g.go_before_stmt(0)
 		tmp_var = g.new_tmp_var()
-		g.writeln('\t${g.typ(node.return_type)} $tmp_var;')
+		g.writeln('${g.typ(node.return_type)} $tmp_var;')
 	}
 
 	if is_expr && !need_tmp_var {

--- a/vlib/v/tests/match_in_fn_call_test.v
+++ b/vlib/v/tests/match_in_fn_call_test.v
@@ -1,0 +1,42 @@
+struct Data {
+	array []int
+}
+
+fn (d Data) len() int {
+	return d.array.len
+}
+
+fn make_result() []Data {
+	return []
+}
+
+fn f_doesnotcompile(d Data) []Data {
+	return match d.len() {
+		1 { make_result() }
+		else { make_result() }
+	}
+}
+
+fn f_compiles1(d Data) []Data {
+	return match d.array.len {
+		1 { make_result() }
+		else { make_result() }
+	}
+}
+
+fn f_compiles2(d Data) []Data {
+	length := d.array.len
+	return match length {
+		1 { make_result() }
+		else { make_result() }
+	}
+}
+
+fn test_match_in_fn_call() {
+	println(f_doesnotcompile({}))
+	assert f_doesnotcompile({}) == []Data{}
+	println(f_compiles1({}))
+	assert f_compiles1({}) == []Data{}
+	println(f_compiles2({}))
+	assert f_compiles2({}) == []Data{}
+}


### PR DESCRIPTION
This PR fixes error of match in fn_call (fix #8895).

- Fix error of match in fn_call.
- Add test.

```vlang
struct Data {
	array []int
}

fn (d Data) len() int {
	return d.array.len
}

fn make_result() []Data {
	return []
}

fn f_doesnotcompile(d Data) []Data {
	return match d.len() {
		1 { make_result() }
		else { make_result() }
	}
}

fn f_compiles1(d Data) []Data {
	return match d.array.len {
		1 { make_result() }
		else { make_result() }
	}
}

fn f_compiles2(d Data) []Data {
	length := d.array.len
	return match length {
		1 { make_result() }
		else { make_result() }
	}
}

fn main() {
	println(f_doesnotcompile({}))
	println(f_compiles1({}))
	println(f_compiles2({}))
}

D:\Test\v\tt1>v run .
[]
[]
[]
```