### PR TITLE
gen: correct indirection difference between reciever and object

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -647,12 +647,14 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		if !node.left_type.has_flag(.shared_f) {
 			g.write('/*rec*/*')
 		}
-	} else if !is_range_slice && node.from_embed_type == 0 {
+	} else if !is_range_slice && node.from_embed_type == 0  && node.name != 'str' {
 		diff := node.left_type.nr_muls() - node.receiver_type.nr_muls()
 		if diff < 0 {
 			// TODO
 			// g.write('&')
 		} else if diff > 0 {
+			println('${node.name}: l: ${g.typ(node.left_type)}\tr: ${g.typ(node.receiver_type)}')
+			println('${node}')
 			g.write('/*diff=$diff*/')
 			g.write([]byte{len: diff, init: `*`}.bytestr())
 		}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -647,6 +647,15 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		if !node.left_type.has_flag(.shared_f) {
 			g.write('/*rec*/*')
 		}
+	} else if !is_range_slice {
+		diff := node.left_type.nr_muls() - node.receiver_type.nr_muls()
+		if diff < 0 {
+			// TODO
+			// g.write('&')
+		} else if diff > 0 {
+			g.write('/*diff=$diff*/')
+			g.write([]byte{len:diff, init:`*`}.bytestr())
+		}
 	}
 	if g.is_autofree && node.free_receiver && !g.inside_lambda && !g.is_builtin_mod {
 		// The receiver expression needs to be freed, use the temp var.

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -647,7 +647,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		if !node.left_type.has_flag(.shared_f) {
 			g.write('/*rec*/*')
 		}
-	} else if !is_range_slice {
+	} else if !is_range_slice && node.from_embed_type == 0 {
 		diff := node.left_type.nr_muls() - node.receiver_type.nr_muls()
 		if diff < 0 {
 			// TODO
@@ -657,6 +657,11 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			g.write([]byte{len: diff, init: `*`}.bytestr())
 		}
 	}
+
+	// if node.left_type.idx() != node.receiver_type.idx() {
+	// 	println('${g.typ(node.left_type)} ${g.typ(node.receiver_type)}')
+	// }
+
 	if g.is_autofree && node.free_receiver && !g.inside_lambda && !g.is_builtin_mod {
 		// The receiver expression needs to be freed, use the temp var.
 		fn_name := node.name.replace('.', '_')

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -654,7 +654,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			// g.write('&')
 		} else if diff > 0 {
 			g.write('/*diff=$diff*/')
-			g.write([]byte{len:diff, init:`*`}.bytestr())
+			g.write([]byte{len: diff, init: `*`}.bytestr())
 		}
 	}
 	if g.is_autofree && node.free_receiver && !g.inside_lambda && !g.is_builtin_mod {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -647,14 +647,12 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		if !node.left_type.has_flag(.shared_f) {
 			g.write('/*rec*/*')
 		}
-	} else if !is_range_slice && node.from_embed_type == 0  && node.name != 'str' {
+	} else if !is_range_slice && node.from_embed_type == 0 && node.name != 'str' {
 		diff := node.left_type.nr_muls() - node.receiver_type.nr_muls()
 		if diff < 0 {
 			// TODO
 			// g.write('&')
 		} else if diff > 0 {
-			println('${node.name}: l: ${g.typ(node.left_type)}\tr: ${g.typ(node.receiver_type)}')
-			println('${node}')
 			g.write('/*diff=$diff*/')
 			g.write([]byte{len: diff, init: `*`}.bytestr())
 		}


### PR DESCRIPTION
(accidently pushed this to origin oop :grimacing:)

This fixes a bunch of cases in my safe-transit project where the recievers would be the wrong indirection for the reciever function
(e.g. https://github.com/emily33901/safe-transit/blob/master/apps/ping.v#L28). I believe this only arised from getting a `mut` from a map of `ref T` (e.g. `m := map[int]&net.TcpConn ; mut x := m[10]`)