### PR TITLE
szip: use enums instead of constants

### DIFF
--- a/vlib/szip/szip.v
+++ b/vlib/szip/szip.v
@@ -50,6 +50,9 @@ pub enum CompressionLevel {
 }
 
 // OpenMode lists the opening modes
+// .write: opens a file for reading/extracting (the file must exists).<br>
+// .read_only: creates an empty file for writing.<br>
+// .append: appends to an existing archive.
 pub enum OpenMode {
 	write
 	read_only
@@ -71,6 +74,9 @@ fn (om OpenMode) to_byte() byte {
 }
 
 // open opens zip archive with compression level using the given mode.
+// name: the name of the zip file to open
+// level: can be any value of the CompressionLevel enum
+// mode: can be any value of the OpenMode enum
 pub fn open(name string, level CompressionLevel, mode OpenMode) ?&Zip {
 	mut nlevel := int(level)
 	// 10 = uber_compression

--- a/vlib/szip/szip.v
+++ b/vlib/szip/szip.v
@@ -39,7 +39,7 @@ fn C.zip_entry_fread(&Zip, byteptr) int
 
 fn C.zip_total_entries(&Zip) int
 
-// CompressionLevel lists compression levels - ref: miniz.h
+// CompressionLevel lists compression levels, see in "thirdparty/miniz.h"
 pub enum CompressionLevel {
 	no_compression = 0
 	best_speed = 1
@@ -120,7 +120,7 @@ pub fn (mut zentry Zip) name() string {
 	if name == 0 {
 		return ''
 	}
-	return unsafe { tos_clone(name) }
+	return unsafe { name.vstring() }
 }
 
 /// index returns an index of the current zip entry.

--- a/vlib/szip/szip.v
+++ b/vlib/szip/szip.v
@@ -59,6 +59,7 @@ pub enum OpenMode {
 	append
 }
 
+[inline]
 fn (om OpenMode) to_byte() byte {
 	return match om {
 		.write {

--- a/vlib/szip/szip.v
+++ b/vlib/szip/szip.v
@@ -53,12 +53,12 @@ const (
 	m_append = `a`
 )
 
-// open opens zip archive with compression level using the given mode.<br>
-// compression levels: 0-9 are the standard zlib-style levels.<br>
-// modes:<br>
-// - 'r': opens a file for reading/extracting (the file must exists).<br>
-// - 'w': creates an empty file for writing.<br>
-// - 'a': appends to an existing archive.
+// open opens zip archive with compression level using the given mode.
+// compression levels: 0-9 are the standard zlib-style levels.
+// modes:
+// 'r' (opens a file for reading/extracting, note: the file must exists)
+// 'w' (creates an empty file for writing)
+// 'a' (appends to an existing archive)
 pub fn open(name string, level int, mode byte) ?&Zip {
 	mut nlevel := level
 	if (nlevel & 0xF) > szip.uber_compression {

--- a/vlib/szip/szip.v
+++ b/vlib/szip/szip.v
@@ -39,7 +39,7 @@ fn C.zip_entry_fread(&Zip, byteptr) int
 
 fn C.zip_total_entries(&Zip) int
 
-// CompressionLevel lists compression levels, see in "thirdparty/miniz.h"
+// CompressionLevel lists compression levels, see in "thirdparty/zip/miniz.h"
 pub enum CompressionLevel {
 	no_compression = 0
 	best_speed = 1

--- a/vlib/szip/szip.v
+++ b/vlib/szip/szip.v
@@ -50,8 +50,8 @@ pub enum CompressionLevel {
 }
 
 // OpenMode lists the opening modes
-// .write: opens a file for reading/extracting (the file must exists).<br>
-// .read_only: creates an empty file for writing.<br>
+// .write: opens a file for reading/extracting (the file must exists).
+// .read_only: creates an empty file for writing.
 // .append: appends to an existing archive.
 pub enum OpenMode {
 	write

--- a/vlib/szip/szip.v
+++ b/vlib/szip/szip.v
@@ -73,7 +73,7 @@ fn (om OpenMode) to_byte() byte {
 // open opens zip archive with compression level using the given mode.
 pub fn open(name string, level CompressionLevel, mode OpenMode) ?&Zip {
 	mut nlevel := int(level)
-	// uber_compression
+	// 10 = uber_compression
 	if (nlevel & 0xF) > 10 {
 		nlevel = 6 // szip.default_level
 	}

--- a/vlib/szip/szip.v
+++ b/vlib/szip/szip.v
@@ -95,6 +95,7 @@ pub fn open(name string, level CompressionLevel, mode OpenMode) ?&Zip {
 }
 
 // close closes the zip archive, releases resources - always finalize.
+[inline]
 pub fn (mut z Zip) close() {
 	C.zip_close(z)
 }
@@ -111,6 +112,7 @@ pub fn (mut zentry Zip) open_entry(name string) ? {
 }
 
 // close_entry closes a zip entry, flushes buffer and releases resources.
+[inline]
 pub fn (mut zentry Zip) close_entry() {
 	C.zip_entry_close(zentry)
 }
@@ -149,11 +151,13 @@ pub fn (mut zentry Zip) is_dir() ?bool {
 }
 
 // size returns an uncompressed size of the current zip entry.
+[inline]
 pub fn (mut zentry Zip) size() u64 {
 	return C.zip_entry_size(zentry)
 }
 
 // crc32 returns CRC-32 checksum of the current zip entry.
+[inline]
 pub fn (mut zentry Zip) crc32() u32 {
 	return C.zip_entry_crc32(zentry)
 }

--- a/vlib/szip/szip.v
+++ b/vlib/szip/szip.v
@@ -79,15 +79,10 @@ fn (om OpenMode) to_byte() byte {
 // level: can be any value of the CompressionLevel enum
 // mode: can be any value of the OpenMode enum
 pub fn open(name string, level CompressionLevel, mode OpenMode) ?&Zip {
-	mut nlevel := int(level)
-	// 10 = uber_compression
-	if (nlevel & 0xF) > 10 {
-		nlevel = 6 // szip.default_level
-	}
 	if name.len == 0 {
 		return error('szip: name of file empty')
 	}
-	p_zip := &Zip(C.zip_open(name.str, nlevel, mode.to_byte()))
+	p_zip := &Zip(C.zip_open(name.str, int(level), mode.to_byte()))
 	if isnil(p_zip) {
 		return error('szip: cannot open/create/append new zip archive')
 	}

--- a/vlib/szip/szip_test.v
+++ b/vlib/szip/szip_test.v
@@ -2,7 +2,7 @@ import szip
 import os
 
 fn test_szip() {
-	mut z := szip.open('test_compile.zip', szip.best_speed, szip.m_write) or {
+	mut z := szip.open('test_compile.zip', .best_speed, .write) or {
 		assert false
 		return
 	}
@@ -11,4 +11,3 @@ fn test_szip() {
 		os.rm('test_compile.zip') or { }
 	}
 }
-


### PR DESCRIPTION
This PR makes improvements to the `szip` module, using enums instead of constants.