### PR TITLE
dl: add `get_libname` function

### DIFF
--- a/vlib/dl/dl.v
+++ b/vlib/dl/dl.v
@@ -7,13 +7,19 @@ pub const (
 
 // get_shared_library_extension returns the platform dependent shared library extension
 // i.e. .dll on windows, .so on most unixes, .dylib on macos.
+[inline]
 pub fn get_shared_library_extension() string {
-	mut res := '.so'
-	$if macos {
+	mut res := $if macos {
 		res = '.dylib'
-	}
-	$if windows {
+	} $else $if windows {
 		res = '.dll'
 	}
 	return res
+}
+
+// get_libname returns a library name with the operating system specific extension for
+// shared libraries.
+[inline]
+pub fn get_libname(libname string) string {
+	return '$libname$dl.dl_ext'
 }

--- a/vlib/dl/dl.v
+++ b/vlib/dl/dl.v
@@ -9,9 +9,11 @@ pub const (
 // i.e. .dll on windows, .so on most unixes, .dylib on macos.
 [inline]
 pub fn get_shared_library_extension() string {
-	mut res := $if macos {
+	mut res := '.so'
+	$if macos {
 		res = '.dylib'
-	} $else $if windows {
+	}
+	$if windows {
 		res = '.dll'
 	}
 	return res

--- a/vlib/dl/dl_nix.c.v
+++ b/vlib/dl/dl_nix.c.v
@@ -1,6 +1,7 @@
 module dl
 
 #include <dlfcn.h>
+
 pub const (
 	rtld_now  = C.RTLD_NOW
 	rtld_lazy = C.RTLD_LAZY

--- a/vlib/dl/example/use.v
+++ b/vlib/dl/example/use.v
@@ -6,7 +6,7 @@ import dl
 type FNAdder = fn (int, int) int
 
 fn main() {
-	library_file_path := os.join_path(os.getwd(), 'library$dl.dl_ext')
+	library_file_path := os.join_path(os.getwd(), dl.get_libname('library'))
 	handle := dl.open(library_file_path, dl.rtld_lazy)
 	eprintln('handle: ${ptr_str(handle)}')
 	mut f := &FNAdder(0)

--- a/vlib/dl/example/use_test.v
+++ b/vlib/dl/example/use_test.v
@@ -7,7 +7,7 @@ const (
 	vexe              = os.real_path(os.getenv('VEXE'))
 	cfolder           = os.dir(@FILE)
 	so_ext            = dl.dl_ext
-	library_file_name = os.join_path(cfolder, 'library$so_ext')
+	library_file_name = os.join_path(cfolder, dl.get_libname('library'))
 )
 
 fn test_vexe() {


### PR DESCRIPTION
This PR adds a new function to the `dl` module: `get_libname(string) string`. This function returns a string containing the name of the library that was passed as the first parameter and the extension that the user's operating system uses for the shared libraries as a suffix.

```v
import dl

println(dl.get_libname('lua5.3'))
// on windows: lua5.3.dll
// on macos:   lua5.3.dylib
// on linux:   lua5.3.so
```