### PR TITLE
parser: fix weird minus after comment parse error in arrays

### DIFF
--- a/vlib/v/fmt/tests/comments_embedded_keep.vv
+++ b/vlib/v/fmt/tests/comments_embedded_keep.vv
@@ -14,4 +14,10 @@ fn only_comments_array() {
 fn array_pre_comments() {
 	_ := [/* 2, */ 3]
 	_ := [/* 4, */ /* 5, */ 6]
+	_ := [/* cmt */ -4]
+}
+
+fn negative_num_after_comment_expr() {
+	// This caused a bug where the ´-´ was parsed as InfixExpr and not as part of an IntegerLiteral
+	_ := [1, /* cmt */ -4]
 }

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -45,6 +45,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 		}
 		.comment {
 			node = p.comment()
+			return node
 		}
 		.dot {
 			// .enum_val


### PR DESCRIPTION
> This sh** took me one hour to debug why fmt inserts a wrong space...
> Just for a missing return 😭