### PR TITLE
table/cgen: fix bug preventing `t := []thread{}` to compile

### DIFF
--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -487,6 +487,9 @@ pub fn (t &Table) chan_cname(elem_type Type, is_mut bool) string {
 
 [inline]
 pub fn (t &Table) thread_name(return_type Type) string {
+	if return_type == void_type {
+		return 'thread'
+	}
 	return_type_sym := t.get_type_symbol(return_type)
 	ptr := if return_type.is_ptr() { '&' } else { '' }
 	return 'thread $ptr$return_type_sym.name'
@@ -494,6 +497,9 @@ pub fn (t &Table) thread_name(return_type Type) string {
 
 [inline]
 pub fn (t &Table) thread_cname(return_type Type) string {
+	if return_type == void_type {
+		return '__v_thread'
+	}
 	return_type_sym := t.get_type_symbol(return_type)
 	suffix := if return_type.is_ptr() { '_ptr' } else { '' }
 	return '__v_thread_$return_type_sym.cname$suffix'

--- a/vlib/v/table/types.v
+++ b/vlib/v/table/types.v
@@ -540,7 +540,15 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 		cname: 'int_literal'
 		mod: 'builtin'
 	)
-	t.register_type_symbol(kind: .thread, name: 'thread', cname: '__v_thread', mod: 'builtin')
+	t.register_type_symbol(
+		kind: .thread
+		name: 'thread'
+		cname: '__v_thread'
+		mod: 'builtin'
+		info: Thread{
+			return_type: table.void_type
+		}
+	)
 }
 
 [inline]

--- a/vlib/v/tests/go_array_wait_test.v
+++ b/vlib/v/tests/go_array_wait_test.v
@@ -36,3 +36,16 @@ fn test_array_thread_void_wait() {
 	}
 }
 
+fn test_void_thread_decl() {
+	shared a := [2 3 9]
+	mut t1 := thread(0)
+	mut tarr := []thread{len: 2}
+	t1 = go g(shared a, 0)
+	tarr[0] = go g(shared a, 1)
+	tarr[1] = go g(shared a, 2)
+	t1.wait()
+	tarr.wait()
+	rlock a {
+		assert a == [6, 12, 90]
+	}
+}


### PR DESCRIPTION
There has been an inconsistency in naming of `void` thread types on the `C` side, in particular if the are called `__v_thread_void` or just `__v_thread`. This has prevented some code from compile.

This PR fixes the issue by consistently using `__v_thread`.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
