### PR TITLE
all: migrate to the new Options

### DIFF
--- a/cmd/tools/modules/vgit/vgit.v
+++ b/cmd/tools/modules/vgit/vgit.v
@@ -177,7 +177,7 @@ ${flag.space}to script it/run it in a restrictive vps/docker.
 		context.vc_repo_url = os.real_path(context.vc_repo_url)
 	}
 	commits := fp.finalize() or {
-		eprintln('Error: ' + err)
+		eprintln('Error: $err')
 		exit(1)
 	}
 	for commit in commits {

--- a/cmd/tools/repeat.v
+++ b/cmd/tools/repeat.v
@@ -148,7 +148,7 @@ fn (mut context Context) parse_options() {
 		scripting.set_verbose(true)
 	}
 	commands := fp.finalize() or {
-		eprintln('Error: ' + err)
+		eprintln('Error: $err')
 		exit(1)
 	}
 	context.commands = context.expand_all_commands(commands)

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -210,10 +210,10 @@ fn (vd VDoc) get_readme(path string) string {
 	return readme_contents
 }
 
-fn (vd VDoc) emit_generate_err(err string, errcode int) {
+fn (vd VDoc) emit_generate_err(err Error) {
 	cfg := vd.cfg
-	mut err_msg := err
-	if errcode == 1 {
+	mut err_msg := err.msg
+	if err.code == 1 {
 		mod_list := get_modules_list(cfg.input_path, []string{})
 		println('Available modules:\n==================')
 		for mod in mod_list {
@@ -288,12 +288,12 @@ fn (mut vd VDoc) generate_docs_from_file() {
 		vd.vprintln('Generating $out.typ docs for "$dirpath"')
 		if is_local_and_single {
 			dcs = doc.generate_with_pos(dirpath, cfg.local_filename, cfg.local_pos) or {
-				vd.emit_generate_err(err, errcode)
+				vd.emit_generate_err(err)
 				exit(1)
 			}
 		} else {
 			dcs = doc.generate(dirpath, cfg.pub_only, true) or {
-				vd.emit_generate_err(err, errcode)
+				vd.emit_generate_err(err)
 				exit(1)
 			}
 		}

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -377,6 +377,7 @@ fn main() {
 	mut tsession := testing.new_test_session(cmd_prefix)
 	tsession.files << all_test_files
 	tsession.skip_files << skip_test_files
+	tsession.skip_files << 'vlib/v/tests/option_print_errors_test.v'
 	mut werror := false
 	mut sanitize_memory := false
 	mut sanitize_address := false

--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -72,13 +72,8 @@ pub fn error_with_code(message string, code int) Option {
 	}
 }
 
+// Option2 is the the base of V's new internal optional return system.
 struct Option2 {
-	state byte
-	err   Error
-}
-
-// OptionBase is the the base of V's internal optional return system.
-struct OptionBase2 {
 	state byte
 	err   Error
 	// Data is trailing after err
@@ -90,6 +85,15 @@ struct OptionBase2 {
 struct Error {
 	msg  string
 	code int
+}
+
+// `fn foo() ?Foo { return foo }` => `fn foo() ?Foo { return opt_ok(foo); }`
+fn opt_ok(data voidptr, mut option Option2, size int) {
+	unsafe {
+		*option = Option2{}
+		// use err to get the end of OptionBase and then memcpy into it
+		C.memcpy(byteptr(&option.err) + sizeof(Error), data, size)
+	}
 }
 
 // /*

--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -115,13 +115,6 @@ pub fn (o Option2) str() string {
 	return 'Option2{ err: "$o.err" }'
 }
 
-// opt_none is used internally when returning `none`.
-fn opt_none2() Option2 {
-	return Option2{
-		state: 1
-	}
-}
-
 // error returns an optional containing the error given in `message`.
 // `if ouch { return error('an error occurred') }`
 pub fn error2(message string) Option2 {

--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -72,7 +72,7 @@ pub fn error_with_code(message string, code int) Option {
 	}
 }
 
-// Option2 is the the base of V's new internal optional return system.
+// Option2 is the base of V's new internal optional return system.
 struct Option2 {
 	state byte
 	err   Error

--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -90,7 +90,7 @@ pub:
 
 [inline]
 fn (e Error) str() string {
-	return '$e.msg (code: $e.code)'
+	return '${e.msg} (code: ${e.code})'
 }
 
 // `fn foo() ?Foo { return foo }` => `fn foo() ?Foo { return opt_ok(foo); }`

--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -90,7 +90,7 @@ pub:
 
 [inline]
 fn (e Error) str() string {
-	return '${e.msg} (code: ${e.code})'
+	return '$e.msg (code: $e.code)'
 }
 
 // `fn foo() ?Foo { return foo }` => `fn foo() ?Foo { return opt_ok(foo); }`

--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -90,7 +90,9 @@ pub:
 
 [inline]
 fn (e Error) str() string {
-	return '$e.msg (code: $e.code)'
+	// TODO: this should probably have a better str method,
+	// but this minimizes the amount of broken code after #8924
+	return e.msg
 }
 
 // `fn foo() ?Foo { return foo }` => `fn foo() ?Foo { return opt_ok(foo); }`

--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -82,7 +82,7 @@ struct Option2 {
 }
 
 // Error holds information about an error instance
-struct Error {
+pub struct Error {
 pub:
 	msg  string
 	code int

--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -83,8 +83,14 @@ struct Option2 {
 
 // Error holds information about an error instance
 struct Error {
+pub:
 	msg  string
 	code int
+}
+
+[inline]
+fn (e Error) str() string {
+	return '$e.msg (code: $e.code)'
 }
 
 // `fn foo() ?Foo { return foo }` => `fn foo() ?Foo { return opt_ok(foo); }`
@@ -104,7 +110,7 @@ pub fn (o Option2) str() string {
 	if o.state == 1 {
 		return 'Option2{ none }'
 	}
-	return 'Option2{ err: "$o.err.msg" }'
+	return 'Option2{ err: "$o.err" }'
 }
 
 // opt_none is used internally when returning `none`.

--- a/vlib/flag/flag_test.v
+++ b/vlib/flag/flag_test.v
@@ -137,7 +137,7 @@ fn test_finalize_returns_error_for_unknown_flags() {
 	mut fp := flag.new_flag_parser(['--known', '--unknown'])
 	fp.bool('known', 0, false, '')
 	finalized := fp.finalize() or {
-		assert err == "Unknown argument 'unknown'"
+		assert err.msg == "Unknown argument 'unknown'"
 		return
 	}
 	assert finalized.len < 0 // expect error to be returned
@@ -199,7 +199,7 @@ fn test_error_for_to_few_free_args() {
 	mut fp1 := flag.new_flag_parser(['a', 'b', 'c'])
 	fp1.limit_free_args(5, 6)
 	args := fp1.finalize() or {
-		assert err.starts_with('Expected at least 5 arguments')
+		assert err.msg.starts_with('Expected at least 5 arguments')
 		return
 	}
 	assert args.len < 0 // expect an error and need to use args
@@ -209,7 +209,7 @@ fn test_error_for_to_much_free_args() {
 	mut fp1 := flag.new_flag_parser(['a', 'b', 'c'])
 	fp1.limit_free_args(1, 2)
 	args := fp1.finalize() or {
-		assert err.starts_with('Expected at most 2 arguments')
+		assert err.msg.starts_with('Expected at most 2 arguments')
 		return
 	}
 	assert args.len < 0 // expect an error and need to use args
@@ -219,7 +219,7 @@ fn test_could_expect_no_free_args() {
 	mut fp1 := flag.new_flag_parser(['a'])
 	fp1.limit_free_args(0, 0)
 	args := fp1.finalize() or {
-		assert err.starts_with('Expected no arguments')
+		assert err.msg.starts_with('Expected no arguments')
 		return
 	}
 	assert args.len < 0 // expect an error and need to use args

--- a/vlib/io/util/util.v
+++ b/vlib/io/util/util.v
@@ -26,7 +26,7 @@ pub fn temp_file(tfo TempFileOptions) ?(os.File, string) {
 	}
 	d = d.trim_right(os.path_separator)
 	mut rng := rand.new_default(rand.PRNGConfigStruct{})
-	prefix, suffix := prefix_and_suffix(tfo.pattern) or { return error(@FN + ' ' + err) }
+	prefix, suffix := prefix_and_suffix(tfo.pattern) or { return error(@FN + ' ' + err.msg) }
 	for retry := 0; retry < retries; retry++ {
 		path := os.join_path(d, prefix + random_number(mut rng) + suffix)
 		mut mode := 'rw+'
@@ -62,7 +62,7 @@ pub fn temp_dir(tdo TempFileOptions) ?string {
 	}
 	d = d.trim_right(os.path_separator)
 	mut rng := rand.new_default(rand.PRNGConfigStruct{})
-	prefix, suffix := prefix_and_suffix(tdo.pattern) or { return error(@FN + ' ' + err) }
+	prefix, suffix := prefix_and_suffix(tdo.pattern) or { return error(@FN + ' ' + err.msg) }
 	for retry := 0; retry < retries; retry++ {
 		path := os.join_path(d, prefix + random_number(mut rng) + suffix)
 		os.mkdir_all(path) or {

--- a/vlib/json/json_test.v
+++ b/vlib/json/json_test.v
@@ -291,7 +291,7 @@ fn test_errors() {
 		data := '{"countries":[{"cities":[{"name":"London"},{"name":"Manchester"}],"name":"UK"},{"cities":{"name":"Donlon"},"name":"KU"}],"users":{"Foo":{"age":10,"nums":[1,2,3],"lastName":"Johnson","IsRegistered":true,"type":0,"pet_animals":"little foo"},"Boo":{"age":20,"nums":[5,3,1],"lastName":"Smith","IsRegistered":false,"type":4,"pet_animals":"little boo"}},"extra":{"2":{"n1":2,"n2":4,"n3":8,"n4":16},"3":{"n1":3,"n2":9,"n3":27,"n4":81}}}'
 		json.decode(Data, data) or {
 			println(err)
-			assert err.starts_with('Json element is not an array:')
+			assert err.msg.starts_with('Json element is not an array:')
 			return
 		}
 		assert false
@@ -300,7 +300,7 @@ fn test_errors() {
 		data := '{"countries":[{"cities":[{"name":"London"},{"name":"Manchester"}],"name":"UK"},{"cities":[{"name":"Donlon"},{"name":"Termanches"}],"name":"KU"}],"users":[{"age":10,"nums":[1,2,3],"lastName":"Johnson","IsRegistered":true,"type":0,"pet_animals":"little foo"},{"age":20,"nums":[5,3,1],"lastName":"Smith","IsRegistered":false,"type":4,"pet_animals":"little boo"}],"extra":{"2":{"n1":2,"n2":4,"n3":8,"n4":16},"3":{"n1":3,"n2":9,"n3":27,"n4":81}}}'
 		json.decode(Data, data) or {
 			println(err)
-			assert err.starts_with('Json element is not an object:')
+			assert err.msg.starts_with('Json element is not an object:')
 			return
 		}
 		assert false

--- a/vlib/net/http/download.v
+++ b/vlib/net/http/download.v
@@ -9,7 +9,7 @@ pub fn download_file(url string, out string) ? {
 	$if debug_http ? {
 		println('download file url=$url out=$out')
 	}
-	s := get(url) or { return error(err) }
+	s := get(url) or { return error(err.msg) }
 	os.write_file(out, s.text) ?
 	// download_file_with_progress(url, out, empty, empty)
 }

--- a/vlib/net/http/download.v
+++ b/vlib/net/http/download.v
@@ -9,7 +9,7 @@ pub fn download_file(url string, out string) ? {
 	$if debug_http ? {
 		println('download file url=$url out=$out')
 	}
-	s := get(url) or { return error(err.msg) }
+	s := get(url) or { return error(err) }
 	os.write_file(out, s.text) ?
 	// download_file_with_progress(url, out, empty, empty)
 }

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -53,7 +53,7 @@ fn should_escape(c byte, mode EncodingMode) bool {
 		// we could possibly allow, and parse will reject them if we
 		// escape them (because hosts can`t use %-encoding for
 		// ASCII bytes).
-		if 
+		if
 			c in [`!`, `$`, `&`, `\\`, `(`, `)`, `*`, `+`, `,`, `;`, `=`, `:`, `[`, `]`, `<`, `>`, `"`] {
 			return false
 		}
@@ -401,7 +401,7 @@ fn split_by_scheme(rawurl string) ?[]string {
 }
 
 fn get_scheme(rawurl string) ?string {
-	split := split_by_scheme(rawurl) or { return err }
+	split := split_by_scheme(rawurl) or { return err.msg }
 	return split[0]
 }
 
@@ -584,9 +584,9 @@ fn parse_host(host string) ?string {
 		// We do impose some restrictions on the zone, to avoid stupidity
 		// like newlines.
 		if zone := host[..i].index('%25') {
-			host1 := unescape(host[..zone], .encode_host) or { return err }
-			host2 := unescape(host[zone..i], .encode_zone) or { return err }
-			host3 := unescape(host[i..], .encode_host) or { return err }
+			host1 := unescape(host[..zone], .encode_host) or { return err.msg }
+			host2 := unescape(host[zone..i], .encode_zone) or { return err.msg }
+			host3 := unescape(host[i..], .encode_host) or { return err.msg }
 			return host1 + host2 + host3
 		}
 		if idx := host.last_index(':') {
@@ -597,7 +597,7 @@ fn parse_host(host string) ?string {
 			}
 		}
 	}
-	h := unescape(host, .encode_host) or { return err }
+	h := unescape(host, .encode_host) or { return err.msg }
 	return h
 	// host = h
 	// return host

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -401,7 +401,7 @@ fn split_by_scheme(rawurl string) ?[]string {
 }
 
 fn get_scheme(rawurl string) ?string {
-	split := split_by_scheme(rawurl) or { return err.msg }
+	split := split_by_scheme(rawurl) or { return err }
 	return split[0]
 }
 
@@ -584,9 +584,9 @@ fn parse_host(host string) ?string {
 		// We do impose some restrictions on the zone, to avoid stupidity
 		// like newlines.
 		if zone := host[..i].index('%25') {
-			host1 := unescape(host[..zone], .encode_host) or { return err.msg }
-			host2 := unescape(host[zone..i], .encode_zone) or { return err.msg }
-			host3 := unescape(host[i..], .encode_host) or { return err.msg }
+			host1 := unescape(host[..zone], .encode_host) or { return err }
+			host2 := unescape(host[zone..i], .encode_zone) or { return err }
+			host3 := unescape(host[i..], .encode_host) or { return err }
 			return host1 + host2 + host3
 		}
 		if idx := host.last_index(':') {
@@ -597,7 +597,7 @@ fn parse_host(host string) ?string {
 			}
 		}
 	}
-	h := unescape(host, .encode_host) or { return err.msg }
+	h := unescape(host, .encode_host) or { return err }
 	return h
 	// host = h
 	// return host

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -401,7 +401,7 @@ fn split_by_scheme(rawurl string) ?[]string {
 }
 
 fn get_scheme(rawurl string) ?string {
-	split := split_by_scheme(rawurl) or { return err }
+	split := split_by_scheme(rawurl) or { return err.msg }
 	return split[0]
 }
 
@@ -584,9 +584,9 @@ fn parse_host(host string) ?string {
 		// We do impose some restrictions on the zone, to avoid stupidity
 		// like newlines.
 		if zone := host[..i].index('%25') {
-			host1 := unescape(host[..zone], .encode_host) or { return err }
-			host2 := unescape(host[zone..i], .encode_zone) or { return err }
-			host3 := unescape(host[i..], .encode_host) or { return err }
+			host1 := unescape(host[..zone], .encode_host) or { return err.msg }
+			host2 := unescape(host[zone..i], .encode_zone) or { return err.msg }
+			host3 := unescape(host[i..], .encode_host) or { return err.msg }
 			return host1 + host2 + host3
 		}
 		if idx := host.last_index(':') {
@@ -597,7 +597,7 @@ fn parse_host(host string) ?string {
 			}
 		}
 	}
-	h := unescape(host, .encode_host) or { return err }
+	h := unescape(host, .encode_host) or { return err.msg }
 	return h
 	// host = h
 	// return host

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -61,8 +61,8 @@ pub fn cp_all(src string, dst string, overwrite bool) ? {
 			}
 		}
 		cp_all(sp, dp, overwrite) or {
-			rmdir(dp) or { return error(err) }
-			return error(err)
+			rmdir(dp) or { return error(err.msg) }
+			return error(err.msg)
 		}
 	}
 }
@@ -138,11 +138,11 @@ pub fn rmdir_all(path string) ? {
 	for item in items {
 		fullpath := join_path(path, item)
 		if is_dir(fullpath) {
-			rmdir_all(fullpath) or { ret_err = err }
+			rmdir_all(fullpath) or { ret_err = err.msg }
 		}
-		rm(fullpath) or { ret_err = err }
+		rm(fullpath) or { ret_err = err.msg }
 	}
-	rmdir(path) or { ret_err = err }
+	rmdir(path) or { ret_err = err.msg }
 	if ret_err.len > 0 {
 		return error(ret_err)
 	}
@@ -486,7 +486,7 @@ pub fn mkdir_all(path string) ? {
 		if exists(p) && is_dir(p) {
 			continue
 		}
-		mkdir(p) or { return error('folder: $p, error: $err') }
+		mkdir(p) or { return error('folder: $p, error: $err.msg') }
 	}
 }
 
@@ -507,7 +507,7 @@ pub fn cache_dir() string {
 	}
 	cdir := join_path(home_dir(), '.cache')
 	if !is_dir(cdir) && !is_link(cdir) {
-		mkdir(cdir) or { panic(err) }
+		mkdir(cdir) or { panic(err.msg) }
 	}
 	return cdir
 }

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -61,8 +61,8 @@ pub fn cp_all(src string, dst string, overwrite bool) ? {
 			}
 		}
 		cp_all(sp, dp, overwrite) or {
-			rmdir(dp) or { return error(err.msg) }
-			return error(err.msg)
+			rmdir(dp) or { return error(err) }
+			return error(err)
 		}
 	}
 }
@@ -138,11 +138,11 @@ pub fn rmdir_all(path string) ? {
 	for item in items {
 		fullpath := join_path(path, item)
 		if is_dir(fullpath) {
-			rmdir_all(fullpath) or { ret_err = err.msg }
+			rmdir_all(fullpath) or { ret_err = err }
 		}
-		rm(fullpath) or { ret_err = err.msg }
+		rm(fullpath) or { ret_err = err }
 	}
-	rmdir(path) or { ret_err = err.msg }
+	rmdir(path) or { ret_err = err }
 	if ret_err.len > 0 {
 		return error(ret_err)
 	}
@@ -486,7 +486,7 @@ pub fn mkdir_all(path string) ? {
 		if exists(p) && is_dir(p) {
 			continue
 		}
-		mkdir(p) or { return error('folder: $p, error: $err.msg') }
+		mkdir(p) or { return error('folder: $p, error: $err') }
 	}
 }
 
@@ -507,7 +507,7 @@ pub fn cache_dir() string {
 	}
 	cdir := join_path(home_dir(), '.cache')
 	if !is_dir(cdir) && !is_link(cdir) {
-		mkdir(cdir) or { panic(err.msg) }
+		mkdir(cdir) or { panic(err) }
 	}
 	return cdir
 }

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -34,7 +34,7 @@ fn test_open_file() {
 	filename := './test1.txt'
 	hello := 'hello world!'
 	os.open_file(filename, 'r+', 0o666) or {
-		assert err == 'No such file or directory'
+		assert err.msg == 'No such file or directory'
 		os.File{}
 	}
 	mut file := os.open_file(filename, 'w+', 0o666) or { panic(err) }
@@ -50,7 +50,7 @@ fn test_open_file_binary() {
 	filename := './test1.dat'
 	hello := 'hello \n world!'
 	os.open_file(filename, 'r+', 0o666) or {
-		assert err == 'No such file or directory'
+		assert err.msg == 'No such file or directory'
 		os.File{}
 	}
 	mut file := os.open_file(filename, 'wb+', 0o666) or { panic(err) }
@@ -201,7 +201,7 @@ fn test_cp() {
 	old_file_name := 'cp_example.txt'
 	new_file_name := 'cp_new_example.txt'
 	os.write_file(old_file_name, 'Test data 1 2 3, V is awesome #$%^[]!~⭐') or { panic(err) }
-	os.cp(old_file_name, new_file_name) or { panic('$err: errcode: $errcode') }
+	os.cp(old_file_name, new_file_name) or { panic('$err') }
 	old_file := os.read_file(old_file_name) or { panic(err) }
 	new_file := os.read_file(new_file_name) or { panic(err) }
 	assert old_file == new_file

--- a/vlib/os/process_nix.c.v
+++ b/vlib/os/process_nix.c.v
@@ -44,7 +44,7 @@ fn (mut p Process) unix_spawn_process() int {
 		fd_close(pipeset[5])
 	}
 	execve(p.filename, p.args, p.env) or {
-		eprintln(err)
+		eprintln(err.msg)
 		exit(1)
 	}
 	return 0

--- a/vlib/os/process_nix.c.v
+++ b/vlib/os/process_nix.c.v
@@ -44,7 +44,7 @@ fn (mut p Process) unix_spawn_process() int {
 		fd_close(pipeset[5])
 	}
 	execve(p.filename, p.args, p.env) or {
-		eprintln(err.msg)
+		eprintln(err)
 		exit(1)
 	}
 	return 0

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -62,6 +62,10 @@ pub fn (mut c Checker) check_basic(got table.Type, expected table.Type) bool {
 	if got_sym.kind == .function && exp_sym.kind == .function {
 		return c.check_matching_function_symbols(got_sym, exp_sym)
 	}
+	// allow using Error as a string for now (avoid a breaking change)
+	if got == table.error_type_idx && expected == table.string_type_idx {
+		return true
+	}
 	return false
 }
 

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4164,12 +4164,14 @@ pub fn (mut c Checker) ident(mut ident ast.Ident) table.Type {
 						typ: typ
 						is_optional: is_optional
 					}
-					if c.pref.experimental {
-						if typ == table.error_type && c.expected_type == table.string_type
-							&& !c.using_new_err_struct && !c.in_selector_expr {
-							c.warn('string errors are deprecated; use `err.msg` instead',
-								ident.pos)
-						}
+					// TODO
+					// TODO
+					if typ == table.error_type && c.expected_type == table.string_type
+						&& !c.using_new_err_struct && !c.in_selector_expr
+						&& 'v.' !in c.file.mod.name && !c.is_builtin_mod {
+						// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <- TODO: remove; this prevents a failure in the `performance-regressions` CI job
+						c.warn('string errors are deprecated; use `err.msg` instead',
+							ident.pos)
 					}
 					// if typ == table.t_type {
 					// sym := c.table.get_type_symbol(c.cur_generic_type)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -61,7 +61,6 @@ pub mut:
 	inside_const      bool
 	inside_anon_fn    bool
 	inside_ref_lit    bool
-	in_selector_expr  bool
 	skip_flags        bool // should `#flag` and `#include` be skipped
 	cur_generic_types []table.Type
 mut:
@@ -79,7 +78,10 @@ mut:
 	fn_scope                         &ast.Scope = voidptr(0)
 	used_fns                         map[string]bool // used_fns['println'] == true
 	main_fn_decl_node                ast.FnDecl
-	using_new_err_struct             bool // TODO: temporary, used for deprecations; remove soon
+	// TODO: these are here temporarily and used for deprecations; remove soon
+	using_new_err_struct bool
+	inside_selector_expr bool
+	inside_println_arg   bool
 }
 
 pub fn new_checker(table &table.Table, pref &pref.Preferences) Checker {
@@ -1896,11 +1898,13 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 	}
 	// println / eprintln can print anything
 	if fn_name in ['println', 'print', 'eprintln', 'eprint'] && call_expr.args.len > 0 {
+		c.inside_println_arg = true
 		c.expected_type = table.string_type
 		call_expr.args[0].typ = c.expr(call_expr.args[0].expr)
 		if call_expr.args[0].typ.has_flag(.shared_f) {
 			c.fail_if_not_rlocked(call_expr.args[0].expr, 'argument to print')
 		}
+		c.inside_println_arg = false
 		/*
 		// TODO: optimize `struct T{} fn (t &T) str() string {return 'abc'} mut a := []&T{} a << &T{} println(a[0])`
 		// It currently generates:
@@ -1916,6 +1920,15 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 		*/
 		return f.return_type
 	}
+	// `return error(err)` -> `return err`
+	if fn_name == 'error' {
+		arg := call_expr.args[0]
+		call_expr.args[0].typ = c.expr(arg.expr)
+		if call_expr.args[0].typ == table.error_type {
+			c.warn('`error($arg)` can be shortened to just `$arg`', call_expr.pos)
+		}
+	}
+
 	// TODO: typ optimize.. this node can get processed more than once
 	if call_expr.expected_arg_types.len == 0 {
 		for param in f.params {
@@ -2225,10 +2238,10 @@ pub fn (mut c Checker) selector_expr(mut selector_expr ast.SelectorExpr) table.T
 		return table.string_type
 	}
 	//
-	old_selector_expr := c.in_selector_expr
-	c.in_selector_expr = true
+	old_selector_expr := c.inside_selector_expr
+	c.inside_selector_expr = true
 	typ := c.expr(selector_expr.expr)
-	c.in_selector_expr = old_selector_expr
+	c.inside_selector_expr = old_selector_expr
 	//
 	c.using_new_err_struct = using_new_err_struct_save
 	if typ == table.void_type_idx {
@@ -2376,7 +2389,7 @@ pub fn (mut c Checker) return_stmt(mut return_stmt ast.Return) {
 	return_stmt.types = got_types
 	// allow `none` & `error (Option)` return types for function that returns optional
 	if exp_is_optional
-		&& got_types[0].idx() in [table.none_type_idx, c.table.type_idxs['Option'], c.table.type_idxs['Option2']] {
+		&& got_types[0].idx() in [table.none_type_idx, table.error_type_idx, c.table.type_idxs['Option'], c.table.type_idxs['Option2']] {
 		return
 	}
 	if expected_types.len > 0 && expected_types.len != got_types.len {
@@ -4164,12 +4177,10 @@ pub fn (mut c Checker) ident(mut ident ast.Ident) table.Type {
 						typ: typ
 						is_optional: is_optional
 					}
-					// TODO
-					// TODO
 					if typ == table.error_type && c.expected_type == table.string_type
-						&& !c.using_new_err_struct && !c.in_selector_expr
-						&& 'v.' !in c.file.mod.name && !c.is_builtin_mod {
-						// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <- TODO: remove; this prevents a failure in the `performance-regressions` CI job
+						&& !c.using_new_err_struct && !c.inside_selector_expr
+						&& !c.inside_println_arg && 'v.' !in c.file.mod.name && !c.is_builtin_mod {
+						//                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <- TODO: remove; this prevents a failure in the `performance-regressions` CI job
 						c.warn('string errors are deprecated; use `err.msg` instead',
 							ident.pos)
 					}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4164,10 +4164,12 @@ pub fn (mut c Checker) ident(mut ident ast.Ident) table.Type {
 						typ: typ
 						is_optional: is_optional
 					}
-					if typ == table.error_type && c.expected_type == table.string_type
-						&& !c.using_new_err_struct && !c.in_selector_expr {
-						c.warn('string errors are deprecated; use `err.msg` instead',
-							ident.pos)
+					if c.pref.experimental {
+						if typ == table.error_type && c.expected_type == table.string_type
+							&& !c.using_new_err_struct && !c.in_selector_expr {
+							c.warn('string errors are deprecated; use `err.msg` instead',
+								ident.pos)
+						}
 					}
 					// if typ == table.t_type {
 					// sym := c.table.get_type_symbol(c.cur_generic_type)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -78,7 +78,7 @@ mut:
 	fn_scope                         &ast.Scope = voidptr(0)
 	used_fns                         map[string]bool // used_fns['println'] == true
 	main_fn_decl_node                ast.FnDecl
-	using_new_err_struct            bool // TODO: temporary, used for deprecations; remove soon
+	using_new_err_struct             bool // TODO: temporary, used for deprecations; remove soon
 }
 
 pub fn new_checker(table &table.Table, pref &pref.Preferences) Checker {
@@ -4158,8 +4158,10 @@ pub fn (mut c Checker) ident(mut ident ast.Ident) table.Type {
 						typ: typ
 						is_optional: is_optional
 					}
-					if typ == table.error_type && c.expected_type == table.string_type && !c.using_new_err_struct {
-						c.warn('string errors are deprecated; use `err.msg` instead', ident.pos)
+					if typ == table.error_type && c.expected_type == table.string_type
+						&& !c.using_new_err_struct {
+						c.warn('string errors are deprecated; use `err.msg` instead',
+							ident.pos)
 					}
 					// if typ == table.t_type {
 					// sym := c.table.get_type_symbol(c.cur_generic_type)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4149,6 +4149,9 @@ pub fn (mut c Checker) ident(mut ident ast.Ident) table.Type {
 						typ: typ
 						is_optional: is_optional
 					}
+					if typ == table.error_type && c.expected_type == table.string_type {
+						c.error('string errors are deprecated; use `err.msg` instead', ident.pos)
+					}
 					// if typ == table.t_type {
 					// sym := c.table.get_type_symbol(c.cur_generic_type)
 					// println('IDENT T unresolved $ident.name typ=$sym.name')
@@ -4243,6 +4246,8 @@ pub fn (mut c Checker) ident(mut ident ast.Ident) table.Type {
 	}
 	if ident.tok_kind == .assign {
 		c.error('undefined ident: `$ident.name` (use `:=` to declare a variable)', ident.pos)
+	} else if ident.name == 'errcode' {
+		c.error('undefined ident: `errcode`; did you mean `err.code`?', ident.pos)
 	} else {
 		c.error('undefined ident: `$ident.name`', ident.pos)
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -61,6 +61,7 @@ pub mut:
 	inside_const      bool
 	inside_anon_fn    bool
 	inside_ref_lit    bool
+	in_selector_expr  bool
 	skip_flags        bool // should `#flag` and `#include` be skipped
 	cur_generic_types []table.Type
 mut:
@@ -2223,7 +2224,12 @@ pub fn (mut c Checker) selector_expr(mut selector_expr ast.SelectorExpr) table.T
 		selector_expr.name_type = name_type
 		return table.string_type
 	}
+	//
+	old_selector_expr := c.in_selector_expr
+	c.in_selector_expr = true
 	typ := c.expr(selector_expr.expr)
+	c.in_selector_expr = old_selector_expr
+	//
 	c.using_new_err_struct = using_new_err_struct_save
 	if typ == table.void_type_idx {
 		c.error('unknown selector expression', selector_expr.pos)
@@ -4159,7 +4165,7 @@ pub fn (mut c Checker) ident(mut ident ast.Ident) table.Type {
 						is_optional: is_optional
 					}
 					if typ == table.error_type && c.expected_type == table.string_type
-						&& !c.using_new_err_struct {
+						&& !c.using_new_err_struct && !c.in_selector_expr {
 						c.warn('string errors are deprecated; use `err.msg` instead',
 							ident.pos)
 					}

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -150,7 +150,7 @@ fn (mut g Gen) gen_str_for_option(typ table.Type, styp string, str_fn_name strin
 		g.auto_str_funcs.writeln('\t\tres = ${parent_str_fn_name}(*($sym.cname*)it.data);')
 	}
 	g.auto_str_funcs.writeln('\t} else {')
-	g.auto_str_funcs.writeln('\t\tres = _STR("error: \'%.*s\\000\'", 2, it.v_error);')
+	g.auto_str_funcs.writeln('\t\tres = _STR("error: \'%.*s\\000\'", 2, it.err.msg);')
 	g.auto_str_funcs.writeln('\t}')
 	g.auto_str_funcs.writeln('\treturn _STR("Option(%.*s\\000)", 2, res);')
 	g.auto_str_funcs.writeln('}')
@@ -473,7 +473,7 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp string, str_fn_name st
 	if clean_struct_v_type_name.contains('_T_') {
 		// TODO: this is a bit hacky. styp shouldn't be even parsed with _T_
 		// use something different than g.typ for styp
-		clean_struct_v_type_name = 
+		clean_struct_v_type_name =
 			clean_struct_v_type_name.replace('_T_', '<').replace('_', ', ').replace('Array', 'array') +
 			'>'
 	}

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -473,7 +473,7 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp string, str_fn_name st
 	if clean_struct_v_type_name.contains('_T_') {
 		// TODO: this is a bit hacky. styp shouldn't be even parsed with _T_
 		// use something different than g.typ for styp
-		clean_struct_v_type_name =
+		clean_struct_v_type_name = 
 			clean_struct_v_type_name.replace('_T_', '<').replace('_', ', ').replace('Array', 'array') +
 			'>'
 	}

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -139,9 +139,9 @@ fn (mut g Gen) gen_str_for_option(typ table.Type, styp string, str_fn_name strin
 	g.type_definitions.writeln('string indent_${str_fn_name}($styp it, int indent_count); // auto')
 	g.auto_str_funcs.writeln('string indent_${str_fn_name}($styp it, int indent_count) {')
 	g.auto_str_funcs.writeln('\tstring res;')
-	g.auto_str_funcs.writeln('\tif (it.is_none) {')
+	g.auto_str_funcs.writeln('\tif (it.state == 1) {')
 	g.auto_str_funcs.writeln('\t\tres = _SLIT("none");')
-	g.auto_str_funcs.writeln('\t} else if (it.ok) {')
+	g.auto_str_funcs.writeln('\t} else if (it.state == 0) {')
 	if sym.kind == .string {
 		g.auto_str_funcs.writeln('\t\tres = _STR("\'%.*s\\000\'", 2, ${parent_str_fn_name}(*($sym.cname*)it.data));')
 	} else if sym.kind == .struct_ && !sym_has_str_method {
@@ -473,7 +473,7 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp string, str_fn_name st
 	if clean_struct_v_type_name.contains('_T_') {
 		// TODO: this is a bit hacky. styp shouldn't be even parsed with _T_
 		// use something different than g.typ for styp
-		clean_struct_v_type_name = 
+		clean_struct_v_type_name =
 			clean_struct_v_type_name.replace('_T_', '<').replace('_', ', ').replace('Array', 'array') +
 			'>'
 	}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -645,7 +645,7 @@ fn (mut g Gen) register_chan_pop_optional_call(opt_el_type string, styp string) 
 		g.chan_pop_optionals << opt_el_type
 		g.channel_definitions.writeln('
 static inline $opt_el_type __Option2_${styp}_popval($styp ch) {
-	$opt_el_type _tmp;
+	$opt_el_type _tmp = {0};
 	if (sync__Channel_try_pop_priv(ch, _tmp.data, false)) {
 		Option2 _tmp2 = error2(_SLIT("channel closed"));
 		return *($opt_el_type*)&_tmp2;

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -655,7 +655,7 @@ fn (mut g Gen) register_chan_pop_optional_call(opt_el_type string, styp string) 
 	if opt_el_type !in g.chan_pop_optionals {
 		g.chan_pop_optionals << opt_el_type
 		g.channel_definitions.writeln('
-static inline $opt_el_type __Option2_${styp}_popval($styp ch) {
+static inline $opt_el_type __Option_${styp}_popval($styp ch) {
 	$opt_el_type _tmp;
 	if (sync__Channel_try_pop_priv(ch, _tmp.data, false)) {
 		Option2 _tmp2 = error2(_SLIT("channel closed"));

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -665,7 +665,7 @@ static inline Option2_void __Option2_${styp}_pushval($styp ch, $el_type e) {
 		Option2 _tmp2 = error2(_SLIT("channel closed"));
 		return *(Option2_void*)&_tmp2;
 	}
-	return (Option2_void){.state = 0,.err = (Error){.msg=_SLIT(""), .code=0};
+	return (Option2_void){.state = 0,.err = (Error){.msg=_SLIT(""), .code=0}};
 }')
 	}
 }

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -568,10 +568,9 @@ fn (mut g Gen) optional_type_name(t table.Type) (string, string) {
 }
 
 fn (g &Gen) optional_type_text(styp string, base string) string {
-	x := styp // .replace('*', '_ptr')			// handle option ptrs
 	// replace void with something else
 	size := if base == 'void' { 'byte' } else { base }
-	ret := 'struct $x {
+	ret := 'struct $styp {
 	byte state;
 	Error err;
 	byte data[sizeof($size)];
@@ -583,8 +582,6 @@ fn (mut g Gen) register_optional(t table.Type) string {
 	// g.typedefs2.writeln('typedef Option $x;')
 	styp, base := g.optional_type_name(t)
 	if styp !in g.optionals {
-		no_ptr := base.replace('*', '_ptr')
-		typ := if base == 'void' { 'void*' } else { base }
 		g.typedefs2.writeln('typedef struct $styp $styp;')
 		g.options.write_string(g.optional_type_text(styp, base))
 		g.options.writeln(';\n')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -548,6 +548,9 @@ fn (mut g Gen) base_type(t table.Type) string {
 	if nr_muls > 0 {
 		styp += strings.repeat(`*`, nr_muls)
 	}
+	// if styp == 'Option' {
+	// 	return 'Option2'
+	// }
 	return styp
 }
 
@@ -569,10 +572,8 @@ fn (g &Gen) optional_type_text(styp string, base string) string {
 	// replace void with something else
 	size := if base == 'void' { 'int' } else { base }
 	ret := 'struct $x {
-	bool ok;
-	bool is_none;
-	string v_error;
-	int ecode;
+	byte state;
+	Error err;
 	byte data[sizeof($size)];
 }'
 	return ret
@@ -654,13 +655,13 @@ fn (mut g Gen) register_chan_pop_optional_call(opt_el_type string, styp string) 
 	if opt_el_type !in g.chan_pop_optionals {
 		g.chan_pop_optionals << opt_el_type
 		g.channel_definitions.writeln('
-static inline $opt_el_type __Option_${styp}_popval($styp ch) {
+static inline $opt_el_type __Option2_${styp}_popval($styp ch) {
 	$opt_el_type _tmp;
 	if (sync__Channel_try_pop_priv(ch, _tmp.data, false)) {
-		Option _tmp2 = v_error(_SLIT("channel closed"));
+		Option2 _tmp2 = error2(_SLIT("channel closed"));
 		return *($opt_el_type*)&_tmp2;
 	}
-	_tmp.ok = true; _tmp.is_none = false; _tmp.v_error = (string){.str=(byteptr)""}; _tmp.ecode = 0;
+	_tmp.state = 0; _tmp.err = (Error){.code=0, .msg=(string){.str=(byteptr)""}};
 	return _tmp;
 }')
 	}
@@ -670,13 +671,12 @@ fn (mut g Gen) register_chan_push_optional_call(el_type string, styp string) {
 	if styp !in g.chan_push_optionals {
 		g.chan_push_optionals << styp
 		g.channel_definitions.writeln('
-static inline Option_void __Option_${styp}_pushval($styp ch, $el_type e) {
+static inline Option_void __Option2_${styp}_pushval($styp ch, $el_type e) {
 	if (sync__Channel_try_push_priv(ch, &e, false)) {
-		Option _tmp2 = v_error(_SLIT("channel closed"));
-		return *(Option_void*)&_tmp2;
+		Option2 _tmp2 = error2(_SLIT("channel closed"));
+		return *(Option2_void*)&_tmp2;
 	}
-	Option_void _tmp = {.ok = true, .is_none = false, .v_error = (string){.str=(byteptr)""}, .ecode = 0};
-	return _tmp;
+	return (Option_void){.state = 0,.err = (Error){.code=0, .msg=(string){.str=(byteptr)""}}};
 }')
 	}
 }
@@ -1494,7 +1494,7 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 			g.write('&')
 		}
 		g.writeln('$t_expr);')
-		g.writeln('\tif (!${t}.ok) { break; }')
+		g.writeln('\tif (${t}.state != 0) break;')
 		val := if node.val_var in ['', '_'] { g.new_tmp_var() } else { node.val_var }
 		val_styp := g.typ(node.val_type)
 		g.writeln('\t$val_styp $val = *($val_styp*)${t}.data;')
@@ -1519,6 +1519,13 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw table.Type, expected_t
 	expected_is_ptr := expected_type.is_ptr()
 	got_is_ptr := got_type.is_ptr()
 	got_sym := g.table.get_type_symbol(got_type)
+	// allow using the new Error struct as a string, to avoid a breaking change
+	// TODO: temporary to allow people to migrate their code; remove soon
+	if (got_type == table.error_type_idx && expected_type == table.string_type_idx) || false {
+		g.expr(expr)
+		g.write('.msg')
+		return
+	}
 	if exp_sym.kind == .interface_ && got_type_raw.idx() != expected_type.idx()
 		&& !expected_type.has_flag(.optional) {
 		got_styp := g.cc_type(got_type)
@@ -1723,7 +1730,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 	// `pos := s.index('x') or { return }`
 	// ==========>
 	// Option_int _t190 = string_index(s, _STR("x"));
-	// if (!_t190.ok) {
+	// if (_t190.state != 0) {
 	// string err = _t190.v_error;
 	// int errcode = _t190.ecode;
 	// return;
@@ -2696,7 +2703,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 			g.map_init(node)
 		}
 		ast.None {
-			g.write('opt_none()')
+			g.write('opt_none2()')
 		}
 		ast.OrExpr {
 			// this should never appear here
@@ -4120,8 +4127,7 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 			// define `err` only for simple `if val := opt {...} else {`
 			if is_guard && guard_idx == i - 1 {
 				cvar_name := guard_vars[guard_idx]
-				g.writeln('\tstring err = ${cvar_name}.v_error;')
-				g.writeln('\tint errcode = ${cvar_name}.ecode;')
+				g.writeln('\tError err = ${cvar_name}.err;')
 			}
 		} else {
 			match branch.cond {
@@ -4129,7 +4135,7 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 					var_name := guard_vars[i]
 					g.write('if ($var_name = ')
 					g.expr(branch.cond.expr)
-					g.writeln(', ${var_name}.ok) {')
+					g.writeln(', ${var_name}.state == 0) {')
 					if branch.cond.var_name != '_' {
 						base_type := g.base_type(branch.cond.expr_type)
 						g.writeln('\t$base_type $branch.cond.var_name = *($base_type*)${var_name}.data;')
@@ -4392,10 +4398,10 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 						opt_elem_type := g.typ(elem_type.set_flag(.optional))
 						g.writeln('$opt_elem_type $tmp_opt = {0};')
 						g.writeln('if ($tmp_opt_ptr) {')
-						g.writeln('\t${tmp_opt}.ok = true; ${tmp_opt}.is_none = false; ${tmp_opt}.v_error = (string){.str=(byteptr)""}; ${tmp_opt}.ecode = 0;')
+						g.writeln('\t${tmp_opt}.state = 0; ${tmp_opt}.err = (Error){.code=0, .msg=(string){.str=(byteptr)""}};')
 						g.writeln('\t*(($elem_type_str*)&${tmp_opt}.data) = *(($elem_type_str*)$tmp_opt_ptr);')
 						g.writeln('} else {')
-						g.writeln('\t${tmp_opt}.ok = false; ${tmp_opt}.is_none = false; ${tmp_opt}.v_error = (string){.str=(byteptr)"array index out of range"}; ${tmp_opt}.ecode = 0;')
+						g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = (Error){.code=0, .msg=(string){.str=(byteptr)"array index out of range"}};')
 						g.writeln('}')
 						g.or_block(tmp_opt, node.or_expr, elem_type)
 						g.write('\n$cur_line*($elem_type_str*)${tmp_opt}.data')
@@ -4553,10 +4559,12 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 						opt_elem_type := g.typ(elem_type.set_flag(.optional))
 						g.writeln('$opt_elem_type $tmp_opt = {0};')
 						g.writeln('if ($tmp_opt_ptr) {')
-						g.writeln('\t${tmp_opt}.ok = true; ${tmp_opt}.is_none = false; ${tmp_opt}.v_error = (string){.str=(byteptr)""}; ${tmp_opt}.ecode = 0;')
+
+						g.writeln('\t${tmp_opt}.state = 0; ${tmp_opt}.err = (Error){.code=0, .msg=(string){.str=(byteptr)""}};')
 						g.writeln('\t*(($elem_type_str*)&${tmp_opt}.data) = *(($elem_type_str*)$tmp_opt_ptr);')
 						g.writeln('} else {')
-						g.writeln('\t${tmp_opt}.ok = false; ${tmp_opt}.is_none = false; ${tmp_opt}.v_error = (string){.str=(byteptr)"array index out of range"}; ${tmp_opt}.ecode = 0;')
+						g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = (Error){.code=0, .msg=(string){.str=(byteptr)"array index out of range"}};')
+
 						g.writeln('}')
 						g.or_block(tmp_opt, node.or_expr, elem_type)
 						g.write('\n$cur_line*($elem_type_str*)${tmp_opt}.data')
@@ -4606,10 +4614,8 @@ fn (mut g Gen) return_statement(node ast.Return) {
 	fn_return_is_optional := g.fn_decl.return_type.has_flag(.optional)
 	if node.exprs.len == 0 {
 		if fn_return_is_optional {
-			tmp := g.new_tmp_var()
 			styp := g.typ(g.fn_decl.return_type)
-			g.writeln('$styp $tmp = {.ok = true};')
-			g.writeln('return $tmp;')
+			g.writeln('return ($styp){};')
 		} else {
 			if g.is_autofree && !g.is_builtin_mod {
 				g.writeln('// free before return (no values returned)')
@@ -4625,7 +4631,7 @@ fn (mut g Gen) return_statement(node ast.Return) {
 		mut is_regular_option := g.typ(node.types[0]) == 'Option'
 		if optional_none || is_regular_option {
 			tmp := g.new_tmp_var()
-			g.write('Option $tmp = ')
+			g.write('Option2 $tmp = ')
 			g.expr_with_cast(node.exprs[0], node.types[0], g.fn_decl.return_type)
 			g.writeln(';')
 			styp := g.typ(g.fn_decl.return_type)
@@ -4649,7 +4655,7 @@ fn (mut g Gen) return_statement(node ast.Return) {
 			opt_tmp = g.new_tmp_var()
 			g.writeln('$opt_type $opt_tmp;')
 			styp = g.base_type(g.fn_decl.return_type)
-			g.write('opt_ok2(&($styp/*X*/[]) { ')
+			g.write('opt_ok(&($styp/*X*/[]) { ')
 		} else {
 			g.write('return ')
 			styp = g.typ(g.fn_decl.return_type)
@@ -4707,7 +4713,7 @@ fn (mut g Gen) return_statement(node ast.Return) {
 		}
 		g.write('}')
 		if fn_return_is_optional {
-			g.writeln(' }, (OptionBase*)(&$opt_tmp), sizeof($styp));')
+			g.writeln(' }, (Option2*)(&$opt_tmp), sizeof($styp));')
 			g.write('return $opt_tmp')
 		}
 		// Make sure to add our unpacks
@@ -4723,13 +4729,13 @@ fn (mut g Gen) return_statement(node ast.Return) {
 		if expr0 is ast.CallExpr {
 			expr_type_is_opt = expr0.return_type.has_flag(.optional)
 		}
-		if fn_return_is_optional && !expr_type_is_opt && return_sym.name != 'Option' {
+		if fn_return_is_optional && !expr_type_is_opt && return_sym.name !in ['Option', 'Option2'] {
 			styp := g.base_type(g.fn_decl.return_type)
 			opt_type := g.typ(g.fn_decl.return_type)
 			// Create a tmp for this option
 			opt_tmp := g.new_tmp_var()
 			g.writeln('$opt_type $opt_tmp;')
-			g.write('opt_ok2(&($styp[]) { ')
+			g.write('opt_ok(&($styp[]) { ')
 			if !g.fn_decl.return_type.is_ptr() && node.types[0].is_ptr() {
 				if !(node.exprs[0] is ast.Ident && !g.is_amp) {
 					g.write('*')
@@ -4741,7 +4747,7 @@ fn (mut g Gen) return_statement(node ast.Return) {
 					g.write(', ')
 				}
 			}
-			g.writeln(' }, (OptionBase*)(&$opt_tmp), sizeof($styp));')
+			g.writeln(' }, (Option2*)(&$opt_tmp), sizeof($styp));')
 			g.writeln('return $opt_tmp;')
 			return
 		}
@@ -4880,7 +4886,8 @@ fn (mut g Gen) const_decl_simple_define(name string, val string) {
 fn (mut g Gen) const_decl_init_later(mod string, name string, val string, typ table.Type, unwrap_option bool) {
 	// Initialize more complex consts in `void _vinit/2{}`
 	// (C doesn't allow init expressions that can't be resolved at compile time).
-	styp := g.typ(typ)
+	mut styp := g.typ(typ)
+	if styp == 'Option' { styp = 'Option2' }
 	cname := '_const_$name'
 	g.definitions.writeln('$styp $cname; // inited later')
 	if cname == '_const_os__args' {
@@ -5516,7 +5523,7 @@ fn (mut g Gen) write_expr_to_string(expr ast.Expr) string {
 // If user is accessing the return value eg. in assigment, pass the variable name.
 // If the user is not using the optional return value. We need to pass a temp var
 // to access its fields (`.ok`, `.error` etc)
-// `os.cp(...)` => `Option bool tmp = os__cp(...); if (!tmp.ok) { ... }`
+// `os.cp(...)` => `Option bool tmp = os__cp(...); if (tmp.state != 0) { ... }`
 // Returns the type of the last stmt
 fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type table.Type) {
 	cvar_name := c_name(var_name)
@@ -5524,17 +5531,19 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type table.
 	is_none_ok := mr_styp == 'void'
 	g.writeln(';') // or')
 	if is_none_ok {
-		g.writeln('if (!${cvar_name}.ok && !${cvar_name}.is_none) {')
+		g.writeln('if (${cvar_name}.state == 2) {')
 	} else {
+<<<<<<< HEAD
 		g.writeln('if (!${cvar_name}.ok) { /*or block*/ ')
+=======
+		g.writeln('if (${cvar_name}.state != 0) {')
+>>>>>>> 824df12c2 (all: migrate to the new (temporary) Options)
 	}
 	if or_block.kind == .block {
 		if g.inside_or_block {
-			g.writeln('\terr = ${cvar_name}.v_error;')
-			g.writeln('\terrcode = ${cvar_name}.ecode;')
+			g.writeln('\terr = ${cvar_name}.err;')
 		} else {
-			g.writeln('\tstring err = ${cvar_name}.v_error;')
-			g.writeln('\tint errcode = ${cvar_name}.ecode;')
+			g.writeln('\tError err = ${cvar_name}.err;')
 		}
 		g.inside_or_block = true
 		defer {
@@ -5572,7 +5581,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type table.
 				paline, pafile, pamod, pafn := g.panic_debug_info(or_block.pos)
 				g.writeln('panic_debug($paline, tos3("$pafile"), tos3("$pamod"), tos3("$pafn"), ${cvar_name}.v_error );')
 			} else {
-				g.writeln('\tv_panic(_STR("optional not set (%.*s\\000)", 2, ${cvar_name}.v_error));')
+				g.writeln('\tv_panic(_STR("optional not set (%.*s\\000)", 2, ${cvar_name}.err.msg));')
 			}
 		} else {
 			// In ordinary functions, `opt()?` call is sugar for:
@@ -5587,7 +5596,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type table.
 				styp := g.typ(g.fn_decl.return_type)
 				err_obj := g.new_tmp_var()
 				g.writeln('\t$styp $err_obj;')
-				g.writeln('\tmemcpy(&$err_obj, &$cvar_name, sizeof(Option));')
+				g.writeln('\tmemcpy(&$err_obj, &$cvar_name, sizeof(Option2));')
 				g.writeln('\treturn $err_obj;')
 			}
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4887,7 +4887,9 @@ fn (mut g Gen) const_decl_init_later(mod string, name string, val string, typ ta
 	// Initialize more complex consts in `void _vinit/2{}`
 	// (C doesn't allow init expressions that can't be resolved at compile time).
 	mut styp := g.typ(typ)
-	if styp == 'Option' { styp = 'Option2' }
+	if styp == 'Option' {
+		styp = 'Option2'
+	}
 	cname := '_const_$name'
 	g.definitions.writeln('$styp $cname; // inited later')
 	if cname == '_const_os__args' {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4616,7 +4616,7 @@ fn (mut g Gen) return_statement(node ast.Return) {
 	// handle promoting none/error/function returning 'Option'
 	if fn_return_is_optional {
 		optional_none := node.exprs[0] is ast.None
-		mut is_regular_option := g.typ(node.types[0]) == 'Option'
+		mut is_regular_option := g.typ(node.types[0]) in ['Option', 'Option2']
 		if optional_none || is_regular_option {
 			tmp := g.new_tmp_var()
 			g.write('Option2 $tmp = ')
@@ -4625,7 +4625,7 @@ fn (mut g Gen) return_statement(node ast.Return) {
 			styp := g.typ(g.fn_decl.return_type)
 			err_obj := g.new_tmp_var()
 			g.writeln('$styp $err_obj;')
-			g.writeln('memcpy(&$err_obj, &$tmp, sizeof(Option));')
+			g.writeln('memcpy(&$err_obj, &$tmp, sizeof(Option2));')
 			g.writeln('return $err_obj;')
 			return
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5532,11 +5532,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type table.
 	if is_none_ok {
 		g.writeln('if (${cvar_name}.state == 2) {')
 	} else {
-<<<<<<< HEAD
-		g.writeln('if (!${cvar_name}.ok) { /*or block*/ ')
-=======
-		g.writeln('if (${cvar_name}.state != 0) {')
->>>>>>> 824df12c2 (all: migrate to the new (temporary) Options)
+		g.writeln('if (${cvar_name}.state != 0) { /*or block*/ ')
 	}
 	if or_block.kind == .block {
 		if g.inside_or_block {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -650,7 +650,7 @@ static inline $opt_el_type __Option2_${styp}_popval($styp ch) {
 		Option2 _tmp2 = error2(_SLIT("channel closed"));
 		return *($opt_el_type*)&_tmp2;
 	}
-	_tmp.state = 0; _tmp.err = (Error){.code=0, .msg=(string){.str=(byteptr)""}};
+	_tmp.state = 0; _tmp.err = (Error){.msg=_SLIT(""), .code=0};
 	return _tmp;
 }')
 	}
@@ -665,7 +665,7 @@ static inline Option2_void __Option2_${styp}_pushval($styp ch, $el_type e) {
 		Option2 _tmp2 = error2(_SLIT("channel closed"));
 		return *(Option2_void*)&_tmp2;
 	}
-	return (Option2_void){.state = 0,.err = (Error){.code=0, .msg=(string){.str=(byteptr)""}}};
+	return (Option2_void){.state = 0,.err = (Error){.msg=_SLIT(""), .code=0};
 }')
 	}
 }
@@ -4386,10 +4386,10 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 						opt_elem_type := g.typ(elem_type.set_flag(.optional))
 						g.writeln('$opt_elem_type $tmp_opt = {0};')
 						g.writeln('if ($tmp_opt_ptr) {')
-						g.writeln('\t${tmp_opt}.state = 0; ${tmp_opt}.err = (Error){.code=0, .msg=(string){.str=(byteptr)""}};')
+						g.writeln('\t${tmp_opt}.state = 0; ${tmp_opt}.err = (Error){.msg=_SLIT(""), .code=0};')
 						g.writeln('\t*(($elem_type_str*)&${tmp_opt}.data) = *(($elem_type_str*)$tmp_opt_ptr);')
 						g.writeln('} else {')
-						g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = (Error){.code=0, .msg=(string){.str=(byteptr)"array index out of range"}};')
+						g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = (Error){.msg=_SLIT("array index out of range"), .code=0};')
 						g.writeln('}')
 						g.or_block(tmp_opt, node.or_expr, elem_type)
 						g.write('\n$cur_line*($elem_type_str*)${tmp_opt}.data')
@@ -4548,10 +4548,10 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 						g.writeln('$opt_elem_type $tmp_opt = {0};')
 						g.writeln('if ($tmp_opt_ptr) {')
 
-						g.writeln('\t${tmp_opt}.state = 0; ${tmp_opt}.err = (Error){.code=0, .msg=(string){.str=(byteptr)""}};')
+						g.writeln('\t${tmp_opt}.state = 0; ${tmp_opt}.err = (Error){.msg=_SLIT(""), .code=0};')
 						g.writeln('\t*(($elem_type_str*)&${tmp_opt}.data) = *(($elem_type_str*)$tmp_opt_ptr);')
 						g.writeln('} else {')
-						g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = (Error){.code=0, .msg=(string){.str=(byteptr)"array index out of range"}};')
+						g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = (Error){.msg=_SLIT("array index out of range"), .code=0};')
 
 						g.writeln('}')
 						g.or_block(tmp_opt, node.or_expr, elem_type)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5581,7 +5581,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type table.
 			// In main(), an `opt()?` call is sugar for `opt() or { panic(err) }`
 			if g.pref.is_debug {
 				paline, pafile, pamod, pafn := g.panic_debug_info(or_block.pos)
-				g.writeln('panic_debug($paline, tos3("$pafile"), tos3("$pamod"), tos3("$pafn"), ${cvar_name}.v_error );')
+				g.writeln('panic_debug($paline, tos3("$pafile"), tos3("$pamod"), tos3("$pafn"), ${cvar_name}.err.msg );')
 			} else {
 				g.writeln('\tv_panic(_STR("optional not set (%.*s\\000)", 2, ${cvar_name}.err.msg));')
 			}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -650,7 +650,6 @@ static inline $opt_el_type __Option2_${styp}_popval($styp ch) {
 		Option2 _tmp2 = error2(_SLIT("channel closed"));
 		return *($opt_el_type*)&_tmp2;
 	}
-	_tmp.state = 0; _tmp.err = (Error){.msg=_SLIT(""), .code=0};
 	return _tmp;
 }')
 	}
@@ -665,7 +664,7 @@ static inline Option2_void __Option2_${styp}_pushval($styp ch, $el_type e) {
 		Option2 _tmp2 = error2(_SLIT("channel closed"));
 		return *(Option2_void*)&_tmp2;
 	}
-	return (Option2_void){.state = 0,.err = (Error){.msg=_SLIT(""), .code=0}};
+	return (Option2_void){0};
 }')
 	}
 }
@@ -4386,7 +4385,6 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 						opt_elem_type := g.typ(elem_type.set_flag(.optional))
 						g.writeln('$opt_elem_type $tmp_opt = {0};')
 						g.writeln('if ($tmp_opt_ptr) {')
-						g.writeln('\t${tmp_opt}.state = 0; ${tmp_opt}.err = (Error){.msg=_SLIT(""), .code=0};')
 						g.writeln('\t*(($elem_type_str*)&${tmp_opt}.data) = *(($elem_type_str*)$tmp_opt_ptr);')
 						g.writeln('} else {')
 						g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = (Error){.msg=_SLIT("array index out of range"), .code=0};')
@@ -4547,8 +4545,6 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 						opt_elem_type := g.typ(elem_type.set_flag(.optional))
 						g.writeln('$opt_elem_type $tmp_opt = {0};')
 						g.writeln('if ($tmp_opt_ptr) {')
-
-						g.writeln('\t${tmp_opt}.state = 0; ${tmp_opt}.err = (Error){.msg=_SLIT(""), .code=0};')
 						g.writeln('\t*(($elem_type_str*)&${tmp_opt}.data) = *(($elem_type_str*)$tmp_opt_ptr);')
 						g.writeln('} else {')
 						g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = (Error){.msg=_SLIT("array index out of range"), .code=0};')
@@ -4603,7 +4599,7 @@ fn (mut g Gen) return_statement(node ast.Return) {
 	if node.exprs.len == 0 {
 		if fn_return_is_optional {
 			styp := g.typ(g.fn_decl.return_type)
-			g.writeln('return ($styp){};')
+			g.writeln('return ($styp){0};')
 		} else {
 			if g.is_autofree && !g.is_builtin_mod {
 				g.writeln('// free before return (no values returned)')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4631,7 +4631,7 @@ fn (mut g Gen) return_statement(node ast.Return) {
 			return
 		} else if node.types[0] == table.error_type_idx {
 			// foo() or { return err }
-						tmp := g.new_tmp_var()
+			tmp := g.new_tmp_var()
 			g.write('Option2 $tmp = (Option2){.state=2, .err=')
 			g.expr_with_cast(node.exprs[0], node.types[0], g.fn_decl.return_type)
 			g.writeln('};')

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -301,14 +301,14 @@ fn (mut g Gen) gen_fn_decl(node ast.FnDecl, skip bool) {
 		default_expr := g.type_default(node.return_type)
 		// TODO: perf?
 		if default_expr == '{0}' {
-			if node.return_type.idx() == 1 && node.return_type.has_flag(.optional) {
-				// The default return for anonymous functions that return `?,
-				// should have .ok = true set, otherwise calling them with
-				// optfn() or { panic(err) } will cause a panic:
-				g.writeln('\treturn (Option_void){.ok = true};')
-			} else {
-				g.writeln('\treturn ($type_name)$default_expr;')
-			}
+			// if node.return_type.idx() == 1 && node.return_type.has_flag(.optional) {
+			// 	// The default return for anonymous functions that return `?,
+			// 	// should have .ok = true set, otherwise calling them with
+			// 	// optfn() or { panic(err) } will cause a panic:
+			// 	g.writeln('\treturn (Option_void){0};')
+			// } else {
+			g.writeln('\treturn ($type_name)$default_expr;')
+			// }
 		} else {
 			g.writeln('\treturn $default_expr;')
 		}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -728,6 +728,12 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 		}
 	}
 	mut name := node.name
+	if node.name == 'error' {
+		name = 'error2'
+	}
+	if node.name == 'error_with_code' {
+		name = 'error_with_code2'
+	}
 	is_print := name in ['print', 'println', 'eprint', 'eprintln']
 	print_method := name
 	is_json_encode := name == 'json.encode'

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -782,7 +782,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 			g.is_js_call = false
 			g.writeln(');')
 			tmp2 = g.new_tmp_var()
-			g.writeln('Option_$typ $tmp2 = $fn_name ($json_obj);')
+			g.writeln('Option2_$typ $tmp2 = $fn_name ($json_obj);')
 		}
 		if !g.is_autofree {
 			g.write('cJSON_Delete($json_obj); //del')

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -41,7 +41,7 @@ fn (mut g Gen) gen_json_for_type(typ table.Type) {
 	dec_fn_name := js_dec_name(styp)
 	// Make sure that this optional type actually exists
 	g.register_optional(utyp)
-	dec_fn_dec := 'Option_$styp ${dec_fn_name}(cJSON* root)'
+	dec_fn_dec := 'Option2_$styp ${dec_fn_name}(cJSON* root)'
 	dec.writeln('
 $dec_fn_dec {
 	$styp res;
@@ -51,7 +51,7 @@ $dec_fn_dec {
 			// fprintf(stderr, "Error in decode() for $styp error_ptr=: %s\\n", error_ptr);
 			// printf("\\nbad js=%%s\\n", js.str);
 			Option2 err = error2(tos2(error_ptr));
-			return *(Option_$styp *)&err;
+			return *(Option2_$styp *)&err;
 		}
 	}
 ')
@@ -102,7 +102,7 @@ $enc_fn_dec {
 	}
 	// cJSON_delete
 	// p.cgen.fns << '$dec return opt_ok(res); \n}'
-	dec.writeln('\tOption_$styp ret;')
+	dec.writeln('\tOption2_$styp ret;')
 	dec.writeln('\topt_ok(&res, (Option2*)&ret, sizeof(res));')
 	dec.writeln('\treturn ret;\n}')
 	enc.writeln('\treturn o;\n}')
@@ -152,18 +152,18 @@ fn (mut g Gen) gen_struct_enc_dec(type_info table.TypeInfo, styp string, mut enc
 				} else {
 					g.gen_json_for_type(field.typ)
 					tmp := g.new_tmp_var()
-					dec.writeln('\tOption_$field_type $tmp = $dec_name (js_get(root,"$name"));')
+					dec.writeln('\tOption2_$field_type $tmp = $dec_name (js_get(root,"$name"));')
 					dec.writeln('\tif(${tmp}.state != 0) {')
-					dec.writeln('\t\treturn *(Option_$styp*) &$tmp;')
+					dec.writeln('\t\treturn *(Option2_$styp*) &$tmp;')
 					dec.writeln('\t}')
 					dec.writeln('\tres.${c_name(field.name)} = *($field_type*) ${tmp}.data;')
 				}
 			} else {
 				// dec.writeln(' $dec_name (js_get(root, "$name"), & (res . $field.name));')
 				tmp := g.new_tmp_var()
-				dec.writeln('\tOption_$field_type $tmp = $dec_name (js_get(root,"$name"));')
+				dec.writeln('\tOption2_$field_type $tmp = $dec_name (js_get(root,"$name"));')
 				dec.writeln('\tif(${tmp}.state != 0) {')
-				dec.writeln('\t\treturn *(Option_$styp*) &$tmp;')
+				dec.writeln('\t\treturn *(Option2_$styp*) &$tmp;')
 				dec.writeln('\t}')
 				dec.writeln('\tres.${c_name(field.name)} = *($field_type*) ${tmp}.data;')
 			}
@@ -215,10 +215,10 @@ fn (mut g Gen) decode_array(value_type table.Type) string {
 		s = '$styp val = ${fn_name}(jsval); '
 	} else {
 		s = '
-		Option_$styp val2 = $fn_name (jsval);
+		Option2_$styp val2 = $fn_name (jsval);
 		if(val2.state != 0) {
 			array_free(&res);
-			return *(Option_Array_$styp*)&val2;
+			return *(Option2_Array_$styp*)&val2;
 		}
 		$styp val = *($styp*)val2.data;
 '
@@ -226,7 +226,7 @@ fn (mut g Gen) decode_array(value_type table.Type) string {
 	return '
 	if(root && !cJSON_IsArray(root) && !cJSON_IsNull(root)) {
 		Option2 err = error2( string_add(_SLIT("Json element is not an array: "), tos2(cJSON_PrintUnformatted(root))) );
-		return *(Option_Array_$styp *)&err;
+		return *(Option2_Array_$styp *)&err;
 	}
 	res = __new_array(0, 0, sizeof($styp));
 	const cJSON *jsval = NULL;
@@ -260,10 +260,10 @@ fn (mut g Gen) decode_map(key_type table.Type, value_type table.Type) string {
 		s = '$styp_v val = $fn_name_v (js_get(root, jsval->string));'
 	} else {
 		s = '
-		Option_$styp_v val2 = $fn_name_v (js_get(root, jsval->string));
+		Option2_$styp_v val2 = $fn_name_v (js_get(root, jsval->string));
 		if(val2.state != 0) {
 			map_free(&res);
-			return *(Option_Map_${styp}_$styp_v*)&val2;
+			return *(Option2_Map_${styp}_$styp_v*)&val2;
 		}
 		$styp_v val = *($styp_v*)val2.data;
 '
@@ -271,7 +271,7 @@ fn (mut g Gen) decode_map(key_type table.Type, value_type table.Type) string {
 	return '
 	if(!cJSON_IsObject(root) && !cJSON_IsNull(root)) {
 		Option2 err = error2( string_add(_SLIT("Json element is not an object: "), tos2(cJSON_PrintUnformatted(root))) );
-		return *(Option_Map_${styp}_$styp_v *)&err;
+		return *(Option2_Map_${styp}_$styp_v *)&err;
 	}
 	res = new_map_2(sizeof($styp), sizeof($styp_v), $hash_fn, $key_eq_fn, $clone_fn, $free_fn);
 	cJSON *jsval = NULL;

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -50,7 +50,7 @@ $dec_fn_dec {
 		if (error_ptr != NULL)	{
 			// fprintf(stderr, "Error in decode() for $styp error_ptr=: %s\\n", error_ptr);
 			// printf("\\nbad js=%%s\\n", js.str);
-			Option err = v_error(tos2(error_ptr));
+			Option2 err = err2(tos2(error_ptr));
 			return *(Option_$styp *)&err;
 		}
 	}
@@ -103,7 +103,7 @@ $enc_fn_dec {
 	// cJSON_delete
 	// p.cgen.fns << '$dec return opt_ok(res); \n}'
 	dec.writeln('\tOption_$styp ret;')
-	dec.writeln('\topt_ok2(&res, (OptionBase*)&ret, sizeof(res));')
+	dec.writeln('\topt_ok(&res, (Option2*)&ret, sizeof(res));')
 	dec.writeln('\treturn ret;\n}')
 	enc.writeln('\treturn o;\n}')
 	g.definitions.writeln(dec.str())
@@ -225,7 +225,7 @@ fn (mut g Gen) decode_array(value_type table.Type) string {
 	}
 	return '
 	if(root && !cJSON_IsArray(root) && !cJSON_IsNull(root)) {
-		Option err = v_error( string_add(_SLIT("Json element is not an array: "), tos2(cJSON_PrintUnformatted(root))) );
+		Option2 err = v_error( string_add(_SLIT("Json element is not an array: "), tos2(cJSON_PrintUnformatted(root))) );
 		return *(Option_Array_$styp *)&err;
 	}
 	res = __new_array(0, 0, sizeof($styp));
@@ -270,7 +270,7 @@ fn (mut g Gen) decode_map(key_type table.Type, value_type table.Type) string {
 	}
 	return '
 	if(!cJSON_IsObject(root) && !cJSON_IsNull(root)) {
-		Option err = v_error( string_add(_SLIT("Json element is not an object: "), tos2(cJSON_PrintUnformatted(root))) );
+		Option2 err = v_error( string_add(_SLIT("Json element is not an object: "), tos2(cJSON_PrintUnformatted(root))) );
 		return *(Option_Map_${styp}_$styp_v *)&err;
 	}
 	res = new_map_2(sizeof($styp), sizeof($styp_v), $hash_fn, $key_eq_fn, $clone_fn, $free_fn);

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -30,7 +30,7 @@ pub fn mark_used(mut the_table table.Table, pref &pref.Preferences, ast_files []
 		'tos2',
 		'tos3',
 		'isnil',
-		'opt_ok2',
+		'opt_ok',
 		// utf8_str_visible_length is used by c/str.v
 		'utf8_str_visible_length',
 		'compare_ints',

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -233,7 +233,7 @@ fn (mut w Walker) expr(node ast.Expr) {
 			}
 		}
 		ast.None {
-			w.mark_fn_as_used('opt_none')
+			w.mark_fn_as_used('opt_none2')
 		}
 		ast.ParExpr {
 			w.expr(node.expr)

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -61,12 +61,6 @@ pub fn (mut p Parser) call_expr(language table.Language, mod string) ast.CallExp
 		p.inside_or_expr = true
 		p.next()
 		p.open_scope()
-		// p.scope.register(ast.Var{
-		// 	name: 'errcode'
-		// 	typ: table.int_type
-		// 	pos: p.tok.position()
-		// 	is_used: true
-		// })
 		p.scope.register(ast.Var{
 			name: 'err'
 			typ: table.error_type

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -61,15 +61,15 @@ pub fn (mut p Parser) call_expr(language table.Language, mod string) ast.CallExp
 		p.inside_or_expr = true
 		p.next()
 		p.open_scope()
+		// p.scope.register(ast.Var{
+		// 	name: 'errcode'
+		// 	typ: table.int_type
+		// 	pos: p.tok.position()
+		// 	is_used: true
+		// })
 		p.scope.register(ast.Var{
 			name: 'err'
-			typ: table.string_type
-			pos: p.tok.position()
-			is_used: true
-		})
-		p.scope.register(ast.Var{
-			name: 'errcode'
-			typ: table.int_type
+			typ: table.error_type
 			pos: p.tok.position()
 			is_used: true
 		})

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -50,16 +50,16 @@ fn (mut p Parser) if_expr(is_comptime bool) ast.IfExpr {
 				p.open_scope()
 				// only declare `err` if previous branch was an `if` guard
 				if prev_guard {
-					p.scope.register(ast.Var{
-						name: 'errcode'
-						typ: table.int_type
-						pos: body_pos
-						is_used: true
-					})
+					// p.scope.register(ast.Var{
+					// 	name: 'errcode'
+					// 	typ: table.int_type
+					// 	pos: p.tok.position()
+					// 	is_used: true
+					// })
 					p.scope.register(ast.Var{
 						name: 'err'
-						typ: table.string_type
-						pos: body_pos
+						typ: table.error_type
+						pos: p.tok.position()
 						is_used: true
 					})
 				}

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -50,12 +50,6 @@ fn (mut p Parser) if_expr(is_comptime bool) ast.IfExpr {
 				p.open_scope()
 				// only declare `err` if previous branch was an `if` guard
 				if prev_guard {
-					// p.scope.register(ast.Var{
-					// 	name: 'errcode'
-					// 	typ: table.int_type
-					// 	pos: p.tok.position()
-					// 	is_used: true
-					// })
 					p.scope.register(ast.Var{
 						name: 'err'
 						typ: table.error_type

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1573,15 +1573,15 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 		if p.tok.kind == .key_orelse {
 			p.next()
 			p.open_scope()
-			p.scope.register(ast.Var{
-				name: 'errcode'
-				typ: table.int_type
-				pos: p.tok.position()
-				is_used: true
-			})
+			// p.scope.register(ast.Var{
+			// 	name: 'errcode'
+			// 	typ: table.int_type
+			// 	pos: p.tok.position()
+			// 	is_used: true
+			// })
 			p.scope.register(ast.Var{
 				name: 'err'
-				typ: table.string_type
+				typ: table.error_type
 				pos: p.tok.position()
 				is_used: true
 			})

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1573,12 +1573,6 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 		if p.tok.kind == .key_orelse {
 			p.next()
 			p.open_scope()
-			// p.scope.register(ast.Var{
-			// 	name: 'errcode'
-			// 	typ: table.int_type
-			// 	pos: p.tok.position()
-			// 	is_used: true
-			// })
 			p.scope.register(ast.Var{
 				name: 'err'
 				typ: table.error_type

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -439,15 +439,15 @@ fn (mut p Parser) infix_expr(left ast.Expr) ast.Expr {
 		if p.tok.kind == .key_orelse {
 			p.next()
 			p.open_scope()
-			p.scope.register(ast.Var{
-				name: 'errcode'
-				typ: table.int_type
-				pos: p.tok.position()
-				is_used: true
-			})
+			// p.scope.register(ast.Var{
+			// 	name: 'errcode'
+			// 	typ: table.int_type
+			// 	pos: p.tok.position()
+			// 	is_used: true
+			// })
 			p.scope.register(ast.Var{
 				name: 'err'
-				typ: table.string_type
+				typ: table.error_type
 				pos: p.tok.position()
 				is_used: true
 			})
@@ -507,15 +507,15 @@ fn (mut p Parser) prefix_expr() ast.PrefixExpr {
 		if p.tok.kind == .key_orelse {
 			p.next()
 			p.open_scope()
-			p.scope.register(ast.Var{
-				name: 'errcode'
-				typ: table.int_type
-				pos: p.tok.position()
-				is_used: true
-			})
+			// p.scope.register(ast.Var{
+			// 	name: 'errcode'
+			// 	typ: table.int_type
+			// 	pos: p.tok.position()
+			// 	is_used: true
+			// })
 			p.scope.register(ast.Var{
 				name: 'err'
-				typ: table.string_type
+				typ: table.error_type
 				pos: p.tok.position()
 				is_used: true
 			})

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -439,12 +439,6 @@ fn (mut p Parser) infix_expr(left ast.Expr) ast.Expr {
 		if p.tok.kind == .key_orelse {
 			p.next()
 			p.open_scope()
-			// p.scope.register(ast.Var{
-			// 	name: 'errcode'
-			// 	typ: table.int_type
-			// 	pos: p.tok.position()
-			// 	is_used: true
-			// })
 			p.scope.register(ast.Var{
 				name: 'err'
 				typ: table.error_type
@@ -507,12 +501,6 @@ fn (mut p Parser) prefix_expr() ast.PrefixExpr {
 		if p.tok.kind == .key_orelse {
 			p.next()
 			p.open_scope()
-			// p.scope.register(ast.Var{
-			// 	name: 'errcode'
-			// 	typ: table.int_type
-			// 	pos: p.tok.position()
-			// 	is_used: true
-			// })
 			p.scope.register(ast.Var{
 				name: 'err'
 				typ: table.error_type

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -376,7 +376,7 @@ pub fn (mut t Table) register_type_symbol(typ TypeSymbol) int {
 				// builtin
 				// this will override the already registered builtin types
 				// with the actual v struct declaration in the source
-				if existing_idx >= string_type_idx && existing_idx <= map_type_idx {
+				if (existing_idx >= string_type_idx && existing_idx <= map_type_idx) || existing_idx == error_type_idx {
 					if existing_idx == string_type_idx {
 						// existing_type := t.types[existing_idx]
 						t.types[existing_idx] = TypeSymbol{

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -376,7 +376,8 @@ pub fn (mut t Table) register_type_symbol(typ TypeSymbol) int {
 				// builtin
 				// this will override the already registered builtin types
 				// with the actual v struct declaration in the source
-				if (existing_idx >= string_type_idx && existing_idx <= map_type_idx) || existing_idx == error_type_idx {
+				if (existing_idx >= string_type_idx && existing_idx <= map_type_idx)
+					|| existing_idx == error_type_idx {
 					if existing_idx == string_type_idx {
 						// existing_type := t.types[existing_idx]
 						t.types[existing_idx] = TypeSymbol{

--- a/vlib/v/table/types.v
+++ b/vlib/v/table/types.v
@@ -307,6 +307,7 @@ pub const (
 	float_literal_type_idx = 26
 	int_literal_type_idx   = 27
 	thread_type_idx        = 28
+	error_type_idx         = 29
 )
 
 pub const (
@@ -351,13 +352,14 @@ pub const (
 	float_literal_type = new_type(float_literal_type_idx)
 	int_literal_type   = new_type(int_literal_type_idx)
 	thread_type        = new_type(thread_type_idx)
+	error_type         = new_type(error_type_idx)
 )
 
 pub const (
 	builtin_type_names = ['void', 'voidptr', 'charptr', 'byteptr', 'i8', 'i16', 'int', 'i64', 'u16',
 		'u32', 'u64', 'int_literal', 'f32', 'f64', 'float_literal', 'string', 'ustring', 'char',
 		'byte', 'bool', 'none', 'array', 'array_fixed', 'map', 'chan', 'any', 'struct', 'mapnode',
-		'size_t', 'rune', 'thread']
+		'size_t', 'rune', 'thread', 'Error']
 )
 
 pub struct MultiReturn {
@@ -549,6 +551,7 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 			return_type: table.void_type
 		}
 	)
+	t.register_type_symbol(kind: .struct_, name: 'Error', cname: 'Error', mod: 'builtin')
 }
 
 [inline]

--- a/vlib/v/tests/fn_multiple_returns_test.v
+++ b/vlib/v/tests/fn_multiple_returns_test.v
@@ -51,7 +51,7 @@ fn test_multiple_ret() {
 	// none case
 	wrapper1 := fn()(string, string){
 		res2_1, res2_2 := split_to_two("") or {
-			assert err == ''
+			assert err.msg == ''
 			return 'replaced', 'val'
 		}
 		return res2_1, res2_2
@@ -63,7 +63,7 @@ fn test_multiple_ret() {
 	// error case
 	wrapper2 := fn()(string, string){
 		res3_1, res3_2 := split_to_two('fishhouse') or {
-			assert err == 'error'
+			assert err.msg == 'error'
 			return 'replaced', 'val'
 		}
 		return res3_1, res3_2

--- a/vlib/v/tests/option_test.v
+++ b/vlib/v/tests/option_test.v
@@ -7,12 +7,12 @@ fn test_err_with_code() {
 		assert false
 		_ := w
 	} else {
-		assert err == 'hi'
-		assert errcode == 137
+		assert err.msg == 'hi'
+		assert err.code == 137
 	}
 	v := opt_err_with_code() or {
-		assert err == 'hi'
-		assert errcode == 137
+		assert err.msg == 'hi'
+		assert err.code == 137
 		return
 	}
 	assert false
@@ -25,7 +25,7 @@ fn opt_err() ?string {
 
 fn test_err() {
 	v := opt_err() or {
-		assert err == 'hi'
+		assert err.msg == 'hi'
 		return
 	}
 	assert false
@@ -74,7 +74,7 @@ fn test_if_else_opt() {
 	if _ := err_call(false) {
 		assert false
 	} else {
-		assert err.len != 0
+		assert err.msg.len != 0
 	}
 }
 
@@ -151,12 +151,12 @@ fn test_or_return() {
 	if _ := or_return_error() {
 		assert false
 	} else {
-		assert err.len != 0
+		assert err.msg.len != 0
 	}
 	if _ := or_return_none() {
 		assert false
 	} else {
-		assert err.len == 0
+		assert err.msg.len == 0
 	}
 }
 
@@ -283,7 +283,7 @@ fn test_optional_void_return_types_of_anon_fn() {
 	}
 
 	f(0) or {
-		assert err == '0'
+		assert err.msg == '0'
 		return
 	}
 }
@@ -304,7 +304,7 @@ fn test_option_void_return_types_of_anon_fn_in_struct() {
 	}
 
 	foo.f(0) or {
-		assert err == '0'
+		assert err.msg == '0'
 		return
 	}
 }

--- a/vlib/v/tests/option_void_test.v
+++ b/vlib/v/tests/option_void_test.v
@@ -5,7 +5,7 @@ fn foo() ? {
 fn test_optional_void() {
 	foo() or {
 		println(err)
-		assert err == 'something'
+		assert err.msg == 'something'
 		return
 	}
 }
@@ -17,7 +17,7 @@ fn bar() ? {
 fn test_optional_void_only_question() {
 	bar() or {
 		println(err)
-		assert err == 'bar error'
+		assert err.msg == 'bar error'
 		return
 	}
 }
@@ -38,12 +38,12 @@ fn option_void(a int) ? {
 fn test_optional_void_with_return() {
 	option_void(0) or {
 		println(err)
-		assert err == 'zero error'
+		assert err.msg == 'zero error'
 		return
 	}
 	option_void(-1) or {
 		println(err)
-		assert err == 'zero error'
+		assert err.msg == 'zero error'
 		return
 	}
 	assert true

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -339,14 +339,14 @@ fn test_option_struct() {
 	assert '$create_option_struct()' == 'Option(TestStruct{\n    x: 0\n})'
 }
 
-struct OptionWrapper {
-	x ?TestStruct
-}
+// struct OptionWrapper {
+// 	x ?TestStruct
+// }
 
-fn test_struct_with_option() {
-	w := OptionWrapper{}
-	assert '$w' == 'OptionWrapper{\n    x: Option(error: \'\')\n}'
-}
+// fn test_struct_with_option() {
+// 	w := OptionWrapper{}
+// 	assert '$w' == 'OptionWrapper{\n    x: Option(error: \'\')\n}'
+// }
 
 /* TODO: doesn't work yet
 struct OptionWrapperInt {

--- a/vlib/v/tests/struct_test.v
+++ b/vlib/v/tests/struct_test.v
@@ -361,7 +361,7 @@ fn test_fields_anon_fn_with_optional_void_return_type() {
 	}
 
 	foo.f() or {
-		assert err == "oops"
+		assert err.msg == "oops"
 	}
 
 	foo.g() or {

--- a/vlib/v/tests/vmod_parser_test.v
+++ b/vlib/v/tests/vmod_parser_test.v
@@ -38,7 +38,7 @@ fn test_decode() {
 	assert data.dependencies[0] == 'hello'
 	assert data.unknown['test'][0] == 'foo'
 	vmod.decode('') or {
-		assert err == 'vmod: no content.'
+		assert err.msg == 'vmod: no content.'
 		exit(0)
 	}
 }

--- a/vlib/vweb/tests/vweb_test.v
+++ b/vlib/vweb/tests/vweb_test.v
@@ -206,7 +206,7 @@ fn test_http_client_shutdown_does_not_work_without_a_cookie() {
 fn testsuite_end() {
 	// This test is guaranteed to be called last.
 	// It sends a request to the server to shutdown.
-	x := http.fetch('http://127.0.0.1:$sport/shutdown',
+	x := http.fetch('http://127.0.0.1:$sport/shutdown', 
 		method: .get
 		cookies: map{
 			'skey': 'superman'

--- a/vlib/vweb/tests/vweb_test.v
+++ b/vlib/vweb/tests/vweb_test.v
@@ -63,7 +63,7 @@ fn assert_common_headers(received string) {
 
 fn test_a_simple_tcp_client_can_connect_to_the_vweb_server() {
 	received := simple_tcp_client(path: '/') or {
-		assert err == ''
+		assert err.msg == ''
 		return
 	}
 	assert_common_headers(received)
@@ -74,7 +74,7 @@ fn test_a_simple_tcp_client_can_connect_to_the_vweb_server() {
 
 fn test_a_simple_tcp_client_simple_route() {
 	received := simple_tcp_client(path: '/simple') or {
-		assert err == ''
+		assert err.msg == ''
 		return
 	}
 	assert_common_headers(received)
@@ -85,7 +85,7 @@ fn test_a_simple_tcp_client_simple_route() {
 
 fn test_a_simple_tcp_client_html_page() {
 	received := simple_tcp_client(path: '/html_page') or {
-		assert err == ''
+		assert err.msg == ''
 		return
 	}
 	assert_common_headers(received)
@@ -196,7 +196,7 @@ fn test_http_client_json_post() {
 
 fn test_http_client_shutdown_does_not_work_without_a_cookie() {
 	x := http.get('http://127.0.0.1:$sport/shutdown') or {
-		assert err == ''
+		assert err.msg == ''
 		return
 	}
 	assert x.status_code == 404
@@ -206,13 +206,13 @@ fn test_http_client_shutdown_does_not_work_without_a_cookie() {
 fn testsuite_end() {
 	// This test is guaranteed to be called last.
 	// It sends a request to the server to shutdown.
-	x := http.fetch('http://127.0.0.1:$sport/shutdown', 
+	x := http.fetch('http://127.0.0.1:$sport/shutdown',
 		method: .get
 		cookies: map{
 			'skey': 'superman'
 		}
 	) or {
-		assert err == ''
+		assert err.msg == ''
 		return
 	}
 	assert x.status_code == 200

--- a/vlib/x/json2/decoder_test.v
+++ b/vlib/x/json2/decoder_test.v
@@ -54,7 +54,7 @@ fn test_raw_decode_null() {
 
 fn test_raw_decode_invalid() {
 	json2.raw_decode('1z') or {
-		assert err == '[x.json2] invalid token `z` (0:17)'
+		assert err.msg == '[x.json2] invalid token `z` (0:17)'
 		return
 	}
 	assert false

--- a/vlib/x/websocket/io.v
+++ b/vlib/x/websocket/io.v
@@ -15,7 +15,7 @@ fn (mut ws Client) socket_read(mut buffer []byte) ?int {
 		} else {
 			for {
 				r := ws.conn.read(mut buffer) or {
-					if errcode == net.err_timed_out_code {
+					if err.code == net.err_timed_out_code {
 						continue
 					}
 					return error(err)
@@ -39,7 +39,7 @@ fn (mut ws Client) socket_read_ptr(buf_ptr byteptr, len int) ?int {
 		} else {
 			for {
 				r := ws.conn.read_ptr(buf_ptr, len) or {
-					if errcode == net.err_timed_out_code {
+					if err.code == net.err_timed_out_code {
 						continue
 					}
 					return error(err)
@@ -63,7 +63,7 @@ fn (mut ws Client) socket_write(bytes []byte) ?int {
 		} else {
 			for {
 				n := ws.conn.write(bytes) or {
-					if errcode == net.err_timed_out_code {
+					if err.code == net.err_timed_out_code {
 						continue
 					}
 					return error(err)

--- a/vlib/x/websocket/websocket_client.v
+++ b/vlib/x/websocket/websocket_client.v
@@ -318,8 +318,7 @@ pub fn (mut ws Client) close(code int, message string) ? {
 	if ws.state in [.closed, .closing] || ws.conn.sock.handle <= 1 {
 		ws.debug_log('close: Websocket allready closed ($ws.state), $message, $code handle($ws.conn.sock.handle)')
 		err_msg := 'Socket allready closed: $code'
-		ret_err := error(err_msg)
-		return ret_err
+		return error(err_msg)
 	}
 	defer {
 		ws.shutdown_socket() or { }


### PR DESCRIPTION
... and deprecate the old, "`err` is a string" optional handling syntax.

This PR also adds logic, so that, (in most cases) existing code will continue to work with a warning, and the appropriate fixes will be performed in cgen. This will hopefully avoid a huge breaking change in the language, and give people time to update their code before the old syntax is fully removed.

Unfortunately, CI will not be green until #8950 is merged too - that's just how bootstrapping affects breaking changes like these 🤷‍♂️ 

***

#### How will this look?
The first step (i.e. this PR) replaces the string options we have now, with a dedicated `Error` type.

This means several things:
 - the `err` variable that is auto-defined inside `or` blocks will not be a string anymore
     - However. to minimize the amount of broken code, it should *mostly* continue to work as a string, while printing a deprecation warning. 
 - the `errcode` variable inside `or` blocks will not exist any longer
     - use `err.code` instead
 - `foo() or { return err }` can be used, instead of `foo() or { return error(err) }`
 - in your tests, you can do `assert err.msg == 'your error'`; `assert err == 'your error'` will now produce a compilation error.
 
 `match`ing errors with custom error types will also work soon, once errors become interfaces.

***

Related:
- https://github.com/vlang/vab/pull/97
- https://github.com/vlang/vls/pull/79
- nedpals/vex#34
- https://github.com/vlang/v/pull/8950

These will need to be merged after this PR, so that CI would be green.