### PR TITLE
docs: fix missing shebang from chmoddable script

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -3890,6 +3890,7 @@ module global (so that you can use `mkdir()` instead of `os.mkdir()`, for exampl
 
 An example `deploy.vsh`:
 ```v wip
+#!/usr/bin/env -S v run
 // The shebang above associates the file to V on Unix-like systems,
 // so it can be run just by specifying the path to the file
 // once it's made executable using `chmod +x`.


### PR DESCRIPTION
Very minor change; the shebang was missing from the script, even though the comment was referring to it.

