### PR TITLE
dl: make vdoc ignore submodule 'example'

### DIFF
--- a/vlib/.vdocignore
+++ b/vlib/.vdocignore
@@ -1,5 +1,6 @@
 builtin/bare
 builtin/js
+dl/example
 oldgg/
 os/bare
 os2/


### PR DESCRIPTION
This PR adds the module `dl.example` to the file `vlib/.vdocignore`.