### PR TITLE
cgen: assure floats have IEEE754 binary representation

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1196,7 +1196,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 					g.includes.writeln('// added by module `$node.mod`:')
 					g.includes.writeln(guarded_include)
 					if node.main == '<float.h>' {
-						g.includes.writeln('#if DBL_MANT_DIG != 53 || DBL_MAX_EXP != 1024 || DBL_DIG != 15 || DBL_MAX_10_EXP != 308')
+						g.includes.writeln('#if !defined(DBL_MANT_DIG) || DBL_MANT_DIG != 53 || !defined(DBL_MAX_EXP) || DBL_MAX_EXP != 1024 || !defined(DBL_DIG) || DBL_DIG != 15 || !defined(DBL_MAX_10_EXP) || DBL_MAX_10_EXP != 308')
 						g.includes.writeln('#error Your system/compiler does not suport IEEE 754 floating point')
 						g.includes.writeln('#endif')
 					}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1195,6 +1195,11 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 				} else {
 					g.includes.writeln('// added by module `$node.mod`:')
 					g.includes.writeln(guarded_include)
+					if node.main == '<float.h>' {
+						g.includes.writeln('#if DBL_MANT_DIG != 53 || DBL_MAX_EXP != 1024 || DBL_DIG != 15 || DBL_MAX_10_EXP != 308')
+						g.includes.writeln('#error Your system/compiler does not suport IEEE 754 floating point')
+						g.includes.writeln('#endif')
+					}
 				}
 			} else if node.kind == 'define' {
 				g.includes.writeln('// defined by module `$node.mod` in file `$node.source_file`:')

--- a/vlib/v/tests/go_array_wait_test.v
+++ b/vlib/v/tests/go_array_wait_test.v
@@ -9,6 +9,7 @@ fn test_array_thread_f64_wait() {
 		r << go f(f64(i) + 0.5)
 	}
 	x := r.wait()
+	// binary fractions have precise representations and can be directly compared
 	assert x == [0.25, 2.25, 6.25, 12.25, 20.25, 30.25, 42.25, 56.25, 72.25, 90.25]
 }
 


### PR DESCRIPTION
This PR is the result of a [discussion](https://github.com/vlang/v/pull/8840#discussion_r580928113) about float representations.

There is code in V library (e.g. in [strconv](https://github.com/vlang/v/blob/master/vlib/strconv/f64_str.v)) but also in test cases that assume `f64` and `f32` have internal binary IEEE754 representation.

The C standard does not exactly define the float representation, so this PR adds a check that assures IEEE754 compliance (even if it would be hard to find other systems these days).
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
