### PR TITLE
fmt: add auto-imports after the ´module ...´ line

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -236,6 +236,9 @@ pub fn (mut f Fmt) mod(mod ast.Module) {
 	}
 	f.attrs(mod.attrs)
 	f.writeln('module $mod.short_name\n')
+	if f.import_pos == 0 {
+		f.import_pos = f.out.len
+	}
 }
 
 pub fn (mut f Fmt) mark_types_import_as_used(typ table.Type) {

--- a/vlib/v/fmt/tests/import_auto_added_expected.vv
+++ b/vlib/v/fmt/tests/import_auto_added_expected.vv
@@ -1,0 +1,7 @@
+module main
+
+import time
+
+fn main() {
+	curr_time := time.now()
+}

--- a/vlib/v/fmt/tests/import_auto_added_input.vv
+++ b/vlib/v/fmt/tests/import_auto_added_input.vv
@@ -1,0 +1,5 @@
+module main
+
+fn main() {
+	curr_time := time.now()
+}


### PR DESCRIPTION
This fixes the position of auto-imports if there are no manual imports  and the file has a `module ... ` line.

Before this PR, they were inserted directly at the file's start what could break compilation. 