### PR TITLE
docs: Update concurrency docs and examples to use []thread{}

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2566,28 +2566,25 @@ fn main() {
 }
 ```
 
-If there is a large number of tasks that do not return a value it might be easier to manage
-them using a wait group. However, for this approach the function(s) called concurrently have
-to be designed with this wait group in mind:
+If there is a large number of tasks, it might be easier to manage them
+using an array of threads. See [examples/concurrency](/examples/concurrency)
+for more examples.
 
 ```v
-import sync
 import time
 
-fn task(id int, duration int, mut wg sync.WaitGroup) {
+fn task(id int, duration int) {
 	println('task $id begin')
 	time.wait(duration * time.millisecond)
 	println('task $id end')
-	wg.done()
 }
 
 fn main() {
-	mut wg := sync.new_waitgroup()
-	wg.add(3)
-	go task(1, 500, mut wg)
-	go task(2, 900, mut wg)
-	go task(3, 100, mut wg)
-	wg.wait()
+	mut threads := []thread{}
+	threads << go task(1, 500)
+	threads << go task(2, 900)
+	threads << go task(3, 100)
+	threads.wait()
 	println('done')
 }
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2567,8 +2567,7 @@ fn main() {
 ```
 
 If there is a large number of tasks, it might be easier to manage them
-using an array of threads. See [examples/concurrency](/examples/concurrency)
-for more examples.
+using an array of threads.
 
 ```v
 import time
@@ -2596,6 +2595,27 @@ fn main() {
 // task 1 end
 // task 2 end
 // done
+```
+
+Additionally for threads that return the same type, calling `wait()`
+on the thread array will return all computed values.
+
+```v
+fn expensive_computing(i int) int {
+	return i * i
+}
+
+fn main() {
+	mut threads := []thread int{}
+	for i in 1 .. 10 {
+		threads << go expensive_computing(i)
+	}
+	// Join all tasks
+	r := threads.wait()
+	println('All jobs finished: $r')
+}
+
+// Output: All jobs finished: [1, 4, 9, 16, 25, 36, 49, 64, 81]
 ```
 
 ### Channels

--- a/examples/concurrency/concurrency.v
+++ b/examples/concurrency/concurrency.v
@@ -1,21 +1,18 @@
-import sync
 import time
 
 // Simulate expensive computing using sleep function
-fn expensive_computing(id int, duration int, mut wg sync.WaitGroup) {
+fn expensive_computing(id int, duration int) {
 	println('Executing expensive computing task ($id)...')
 	time.wait(duration * time.millisecond)
 	println('Finish task $id on $duration ms')
-	wg.done()
 }
 
 fn main() {
-	mut wg := sync.new_waitgroup()
-	wg.add(3)
-	go expensive_computing(1, 100, mut wg)
-	go expensive_computing(2, 500, mut wg)
-	go expensive_computing(3, 1000, mut wg)
+	mut threads := []thread{}
+	threads << go expensive_computing(1, 100)
+	threads << go expensive_computing(2, 500)
+	threads << go expensive_computing(3, 1000)
 	// Join all tasks
-	wg.wait()
+	threads.wait()
 	println('All jobs finished!')
 }

--- a/examples/concurrency/concurrency_returns.v
+++ b/examples/concurrency/concurrency_returns.v
@@ -1,0 +1,13 @@
+fn expensive_computing(i int) int {
+	return i * i
+}
+
+fn main() {
+	mut threads := []thread int{}
+	for i in 1 .. 10 {
+		threads << go expensive_computing(i)
+	}
+	// Join all tasks
+	r := threads.wait()
+	println('All jobs finished: $r')
+}


### PR DESCRIPTION
This PR removes `sync.WaitGroup` from the main docs page and updates the examples to use an array of `thread` types.

It also adds another example for waiting on multiple threads that return the same type.