### PR TITLE
parser,scanner: replace p.peek_tok2 and p.peek_tok3 with p.peek_token(2) and p.peek_token(3)

### DIFF
--- a/vlib/v/builder/c.v
+++ b/vlib/v/builder/c.v
@@ -11,7 +11,9 @@ pub fn (mut b Builder) gen_c(v_files []string) string {
 	util.timing_start('PARSE')
 	b.parsed_files = parser.parse_files(v_files, b.table, b.pref, b.global_scope)
 	b.parse_imports()
-	util.timing_measure('PARSE')
+	util.get_timers().show('SCAN')
+	util.get_timers().show('PARSE')
+	util.get_timers().show_if_exists('PARSE stmt')
 	if b.pref.only_check_syntax {
 		return ''
 	}

--- a/vlib/v/builder/js.v
+++ b/vlib/v/builder/js.v
@@ -11,7 +11,9 @@ pub fn (mut b Builder) gen_js(v_files []string) string {
 	util.timing_start('PARSE')
 	b.parsed_files = parser.parse_files(v_files, b.table, b.pref, b.global_scope)
 	b.parse_imports()
-	util.timing_measure('PARSE')
+	util.get_timers().show('SCAN')
+	util.get_timers().show('PARSE')
+	util.get_timers().show_if_exists('PARSE stmt')
 	//
 	util.timing_start('CHECK')
 	b.checker.check_files(b.parsed_files)

--- a/vlib/v/builder/x64.v
+++ b/vlib/v/builder/x64.v
@@ -15,7 +15,9 @@ pub fn (mut b Builder) build_x64(v_files []string, out_file string) {
 	util.timing_start('PARSE')
 	b.parsed_files = parser.parse_files(v_files, b.table, b.pref, b.global_scope)
 	b.parse_imports()
-	util.timing_measure('PARSE')
+	util.get_timers().show('SCAN')
+	util.get_timers().show('PARSE')
+	util.get_timers().show_if_exists('PARSE stmt')
 	//
 	util.timing_start('CHECK')
 	b.checker.check_files(b.parsed_files)

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -423,11 +423,13 @@ fn (mut p Parser) fn_receiver(mut params []table.Param, mut rec ReceiverParsingI
 	if !rec.is_mut {
 		rec.is_mut = p.tok.kind == .key_mut
 		if rec.is_mut {
-			p.warn_with_pos('use `(mut f Foo)` instead of `(f mut Foo)`', lpar_pos.extend(p.peek_token(2).position()))
+			ptoken2 := p.peek_token(2) // needed to prevent codegen bug, where .position() expects &Token
+			p.warn_with_pos('use `(mut f Foo)` instead of `(f mut Foo)`', lpar_pos.extend(ptoken2.position()))
 		}
 	}
 	if p.tok.kind == .key_shared {
-		p.error_with_pos('use `(shared f Foo)` instead of `(f shared Foo)`', lpar_pos.extend(p.peek_token(2).position()))
+		ptoken2 := p.peek_token(2) // needed to prevent codegen bug, where .position() expects &Token
+		p.error_with_pos('use `(shared f Foo)` instead of `(f shared Foo)`', lpar_pos.extend(ptoken2.position()))
 	}
 	rec.pos = rec_start_pos.extend(p.tok.position())
 	is_amp := p.tok.kind == .amp

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -423,11 +423,11 @@ fn (mut p Parser) fn_receiver(mut params []table.Param, mut rec ReceiverParsingI
 	if !rec.is_mut {
 		rec.is_mut = p.tok.kind == .key_mut
 		if rec.is_mut {
-			p.warn_with_pos('use `(mut f Foo)` instead of `(f mut Foo)`', lpar_pos.extend(p.peek_tok2.position()))
+			p.warn_with_pos('use `(mut f Foo)` instead of `(f mut Foo)`', lpar_pos.extend(p.peek_token(2).position()))
 		}
 	}
 	if p.tok.kind == .key_shared {
-		p.error_with_pos('use `(shared f Foo)` instead of `(f shared Foo)`', lpar_pos.extend(p.peek_tok2.position()))
+		p.error_with_pos('use `(shared f Foo)` instead of `(f shared Foo)`', lpar_pos.extend(p.peek_token(2).position()))
 	}
 	rec.pos = rec_start_pos.extend(p.tok.position())
 	is_amp := p.tok.kind == .amp

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -30,8 +30,8 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		p.close_scope()
 		return for_stmt
 	} else if p.peek_tok.kind in [.decl_assign, .assign, .semicolon]
-		|| p.tok.kind == .semicolon || (p.peek_tok.kind == .comma && p.peek_tok2.kind != .key_mut
-			&& p.peek_token(3).kind != .key_in) {
+		|| p.tok.kind == .semicolon || (p.peek_tok.kind == .comma
+		&& p.peek_token(2).kind != .key_mut && p.peek_token(3).kind != .key_in) {
 		// `for i := 0; i < 10; i++ {` or `for a,b := 0,1; a < 10; a++ {`
 		if p.tok.kind == .key_mut {
 			p.error('`mut` is not needed in `for ;;` loops: use `for i := 0; i < n; i ++ {`')
@@ -43,7 +43,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		mut has_init := false
 		mut has_cond := false
 		mut has_inc := false
-		mut is_multi := p.peek_tok.kind == .comma && p.peek_tok2.kind != .key_mut
+		mut is_multi := p.peek_tok.kind == .comma && p.peek_token(2).kind != .key_mut
 			&& p.peek_token(3).kind != .key_in
 		if p.peek_tok.kind in [.assign, .decl_assign] || is_multi {
 			init = p.assign_stmt()
@@ -87,7 +87,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		p.close_scope()
 		return for_c_stmt
 	} else if p.peek_tok.kind in [.key_in, .comma]
-		|| (p.tok.kind == .key_mut && p.peek_tok2.kind in [.key_in, .comma]) {
+		|| (p.tok.kind == .key_mut && p.peek_token(2).kind in [.key_in, .comma]) {
 		// `for i in vals`, `for i in start .. end`, `for mut user in users`, `for i, mut user in users`
 		mut val_is_mut := p.tok.kind == .key_mut
 		mut_pos := p.tok.position()

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -31,7 +31,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		return for_stmt
 	} else if p.peek_tok.kind in [.decl_assign, .assign, .semicolon]
 		|| p.tok.kind == .semicolon || (p.peek_tok.kind == .comma && p.peek_tok2.kind != .key_mut
-		&& p.peek_tok3.kind != .key_in) {
+			&& p.peek_token(3).kind != .key_in) {
 		// `for i := 0; i < 10; i++ {` or `for a,b := 0,1; a < 10; a++ {`
 		if p.tok.kind == .key_mut {
 			p.error('`mut` is not needed in `for ;;` loops: use `for i := 0; i < n; i ++ {`')
@@ -44,7 +44,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		mut has_cond := false
 		mut has_inc := false
 		mut is_multi := p.peek_tok.kind == .comma && p.peek_tok2.kind != .key_mut
-			&& p.peek_tok3.kind != .key_in
+			&& p.peek_token(3).kind != .key_in
 		if p.peek_tok.kind in [.assign, .decl_assign] || is_multi {
 			init = p.assign_stmt()
 			has_init = true

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -182,8 +182,8 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 			p.next()
 		} else if (p.tok.kind == .name && !(p.tok.lit == 'C' && p.peek_tok.kind == .dot)
 			&& (p.tok.lit in table.builtin_type_names || p.tok.lit[0].is_capital()
-			|| (p.peek_tok.kind == .dot && p.peek_tok2.lit.len > 0
-			&& p.peek_tok2.lit[0].is_capital()))) || p.tok.kind == .lsbr {
+			|| (p.peek_tok.kind == .dot && p.peek_token(2).lit.len > 0
+			&& p.peek_token(2).lit[0].is_capital()))) || p.tok.kind == .lsbr {
 			mut types := []table.Type{}
 			for {
 				// Sum type match

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -55,7 +55,7 @@ pub fn (mut p Parser) parse_array_type() table.Type {
 	}
 	mut nr_dims := 1
 	// detect attr
-	not_attr := p.peek_tok.kind != .name && p.peek_tok2.kind !in [.semicolon, .rsbr]
+	not_attr := p.peek_tok.kind != .name && p.peek_token(2).kind !in [.semicolon, .rsbr]
 	for p.tok.kind == .lsbr && not_attr {
 		p.next()
 		p.check(.rsbr)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -346,13 +346,11 @@ pub fn (mut p Parser) read_first_token() {
 	// need to call next() 4 times to get peek token 1,2,3 and current token
 	p.next()
 	p.next()
-	p.next()
-	p.next()
 }
 
 [inline]
 pub fn (p &Parser) peek_token(n int) token.Token {
-	return p.scanner.peek_token(n)
+	return p.scanner.peek_token(n-2)
 }
 
 pub fn (mut p Parser) open_scope() {
@@ -416,9 +414,9 @@ fn (mut p Parser) next_with_comment() {
 fn (mut p Parser) next() {
 	p.prev_tok = p.tok
 	p.tok = p.peek_tok
-	p.peek_tok = p.peek_tok2
-	p.peek_tok2 = p.peek_tok3
-	p.peek_tok3 = p.scanner.scan()
+	p.peek_tok = p.scanner.scan()
+	p.peek_tok2 = p.peek_token(2)
+	p.peek_tok3 = p.peek_token(3)
 	/*
 	if p.tok.kind==.comment {
 		p.comments << ast.Comment{text:p.tok.lit, line_nr:p.tok.line_nr}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -350,6 +350,11 @@ pub fn (mut p Parser) read_first_token() {
 	p.next()
 }
 
+[inline]
+pub fn (p &Parser) peek_token(n int) token.Token {
+	return p.scanner.peek_token(n)
+}
+
 pub fn (mut p Parser) open_scope() {
 	p.scope = &ast.Scope{
 		parent: p.scope

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -85,6 +85,10 @@ pub fn parse_stmt(text string, table &table.Table, scope &ast.Scope) ast.Stmt {
 		}
 	}
 	p.init_parse_fns()
+	util.timing_start('PARSE stmt')
+	defer {
+		util.timing_measure_cumulative('PARSE stmt')
+	}
 	p.read_first_token()
 	return p.stmt(false)
 }
@@ -118,6 +122,13 @@ pub fn parse_text(text string, path string, table &table.Table, comments_mode sc
 	}
 	p.set_path(path)
 	return p.parse()
+}
+
+[unsafe]
+pub fn (mut p Parser) free() {
+	unsafe {
+		p.scanner.free()
+	}
 }
 
 pub fn (mut p Parser) set_path(path string) {
@@ -166,7 +177,7 @@ pub fn parse_vet_file(path string, table_ &table.Table, pref &pref.Preferences) 
 		parent: 0
 	}
 	mut p := Parser{
-		scanner: scanner.new_vet_scanner_file(path, .parse_comments, pref)
+		scanner: scanner.new_scanner_file(path, .parse_comments, pref)
 		comments_mode: .parse_comments
 		table: table_
 		pref: pref
@@ -194,6 +205,10 @@ pub fn parse_vet_file(path string, table_ &table.Table, pref &pref.Preferences) 
 }
 
 pub fn (mut p Parser) parse() ast.File {
+	util.timing_start('PARSE')
+	defer {
+		util.timing_measure_cumulative('PARSE')
+	}
 	// comments_mode: comments_mode
 	p.init_parse_fns()
 	p.read_first_token()
@@ -323,9 +338,6 @@ pub fn parse_files(paths []string, table &table.Table, pref &pref.Preferences, g
 }
 
 pub fn (mut p Parser) init_parse_fns() {
-	if p.comments_mode == .toplevel_comments {
-		p.scanner.scan_all_tokens_in_buffer()
-	}
 	// p.prefix_parse_fns = make(100, 100, sizeof(PrefixParseFn))
 	// p.prefix_parse_fns[token.Kind.name] = parse_name
 }

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -369,7 +369,7 @@ pub fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_iden
 		} else if p.tok.kind.is_infix() {
 			if p.tok.kind.is_prefix() && p.tok.line_nr != p.prev_tok.line_nr {
 				// return early for deref assign `*x = 2` goes to prefix expr
-				if p.tok.kind == .mul && p.peek_tok2.kind == .assign {
+				if p.tok.kind == .mul && p.peek_token(2).kind == .assign {
 					return node
 				}
 				// added 10/2020: LATER this will be parsed as PrefixExpr instead

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -149,7 +149,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			if p.expecting_type {
 				// parse json.decode type (`json.decode([]User, s)`)
 				node = p.name_expr()
-			} else if p.is_amp && p.peek_tok.kind == .rsbr && p.peek_tok3.kind != .lcbr {
+			} else if p.is_amp && p.peek_tok.kind == .rsbr && p.peek_token(3).kind != .lcbr {
 				pos := p.tok.position()
 				typ := p.parse_type().to_ptr()
 				p.check(.lpar)

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -140,11 +140,9 @@ pub fn new_scanner(text string, comments_mode CommentsMode, pref &pref.Preferenc
 }
 
 fn (mut s Scanner) init_scanner() {
-	if s.comments_mode != .parse_comments {
-		util.get_timers().measure_pause('PARSE')
-		s.scan_all_tokens_in_buffer(s.comments_mode)
-		util.get_timers().measure_resume('PARSE')
-	}
+	util.get_timers().measure_pause('PARSE')
+	s.scan_all_tokens_in_buffer(s.comments_mode)
+	util.get_timers().measure_resume('PARSE')
 }
 
 [unsafe]
@@ -544,7 +542,7 @@ pub fn (mut s Scanner) scan_all_tokens_in_buffer(mode CommentsMode) {
 pub fn (mut s Scanner) scan_remaining_text() {
 	for {
 		t := s.text_scan()
-		if t.kind == .comment && s.comments_mode == .skip_comments {
+		if s.comments_mode == .skip_comments && t.kind == .comment {
 			continue
 		}
 		s.all_tokens << t
@@ -555,9 +553,6 @@ pub fn (mut s Scanner) scan_remaining_text() {
 }
 
 pub fn (mut s Scanner) scan() token.Token {
-	if s.comments_mode == .parse_comments {
-		return s.text_scan()
-	}
 	return s.buffer_scan()
 }
 

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1346,7 +1346,7 @@ pub fn (mut s Scanner) codegen(newtext string) {
 	// feeding code generated V code to vfmt or vdoc will
 	// cause them to output/document ephemeral stuff.
 	if s.comments_mode == .skip_comments {
-		s.all_tokens.pop() // remove .eof from end of .all_tokens
+		s.all_tokens.delete_last() // remove .eof from end of .all_tokens
 		s.text += newtext
 		old_tidx := s.tidx
 		s.tidx = s.all_tokens.len

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -112,11 +112,9 @@ pub fn new_scanner_file(file_path string, comments_mode CommentsMode, pref &pref
 		is_print_rel_paths_on_error: true
 		is_fmt: pref.is_fmt
 		comments_mode: comments_mode
-		file_path: 'internal_memory'
-		file_base: 'internal_memory'
+		file_path: file_path
+		file_base: os.base(file_path)
 	}
-	s.file_path = file_path
-	s.file_base = os.base(file_path)
 	s.init_scanner()
 	return s
 }

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -67,8 +67,7 @@ no reason to complain about them.
 When the parser determines, that it is outside of a top level statement,
 it tells the scanner to backtrack s.tidx to the current p.tok index,
 then it changes .is_inside_toplvl_statement to false , and refills its
-lookahead buffer (i.e. p.peek_tok, p.peek_tok2, p.peek_tok3) from the
-scanner.
+lookahead buffer (i.e. p.peek_tok), from the scanner.
 
 In effect, from the parser's point of view, the next tokens, that it will
 receive with p.next(), will be the same, as if comments are not ignored
@@ -579,7 +578,7 @@ pub fn (s &Scanner) peek_token(n int) token.Token {
 	if idx >= s.all_tokens.len {
 		return s.new_eof_token()
 	}
-	t := s.all_tokens[ idx ]
+	t := s.all_tokens[idx]
 	return t
 }
 

--- a/vlib/v/util/timers.v
+++ b/vlib/v/util/timers.v
@@ -33,13 +33,18 @@ pub fn timing_measure(label string) {
 	get_timers().show(label)
 }
 
+pub fn timing_measure_cumulative(label string) {
+	get_timers().measure_cumulative(label)
+}
+
 pub fn timing_set_should_print(should_print bool) {
 	mut t := util.timers
 	t.should_print = should_print
 }
 
 pub fn (mut t Timers) start(name string) {
-	sw := time.new_stopwatch({})
+	mut sw := t.swatches[name] or { time.new_stopwatch({}) }
+	sw.start()
 	t.swatches[name] = sw
 }
 
@@ -54,6 +59,35 @@ pub fn (mut t Timers) measure(name string) i64 {
 	return ms
 }
 
+pub fn (mut t Timers) measure_cumulative(name string) i64 {
+	ms := t.measure(name)
+	if name !in t.swatches {
+		return ms
+	}
+	mut sw := t.swatches[name]
+	sw.pause()
+	t.swatches[name] = sw
+	return ms
+}
+
+pub fn (mut t Timers) measure_pause(name string) {
+	if name !in t.swatches {
+		return
+	}
+	mut sw := t.swatches[name]
+	sw.pause()
+	t.swatches[name] = sw
+}
+
+pub fn (mut t Timers) measure_resume(name string) {
+	if name !in t.swatches {
+		return
+	}
+	mut sw := t.swatches[name]
+	sw.start()
+	t.swatches[name] = sw
+}
+
 pub fn (mut t Timers) message(name string) string {
 	ms := f64(t.measure(name)) / 1000.0
 	value := bold('${ms:-8.3f}')
@@ -66,6 +100,13 @@ pub fn (mut t Timers) show(label string) {
 	if t.should_print {
 		println(formatted_message)
 	}
+}
+
+pub fn (mut t Timers) show_if_exists(label string) {
+	if label !in t.swatches {
+		return
+	}
+	t.show(label)
 }
 
 pub fn (mut t Timers) dump_all() {

--- a/vlib/x/json2/decoder.v
+++ b/vlib/x/json2/decoder.v
@@ -81,7 +81,7 @@ fn new_parser(srce string, convert_type bool) Parser {
 		}
 	}
 	return Parser{
-		scanner: scanner.new_scanner(src, .parse_comments, &pref.Preferences{})
+		scanner: scanner.new_scanner(src, .parse_comments, &pref.Preferences{output_mode: .silent})
 		convert_type: convert_type
 	}
 }


### PR DESCRIPTION
This PR makes it possible to have unlimited look ahead.
This allows for easier disambiguation of generic calls like 
`x.simple<simplemodule.Data>(params)`
vs `x.simple < simplemodule.Data` .

This PR also makes V between ~1.5% to 2.4% faster without -prod,
and -0.4% (-cc gcc-10 -prod) and +1.5% faster (-cc clang-10 -prod) with -prod.

Also, now -show-timings has a separate 'SCAN' timing line, independent from 'PARSE', which will hopefully make it easier to optimize the scanner's performance in the future.