### PR TITLE
net.html: use `or {}` in .writeln() method calls

### DIFF
--- a/vlib/net/html/data_structures.v
+++ b/vlib/net/html/data_structures.v
@@ -12,7 +12,7 @@ mut:
 
 [inline]
 fn is_null(data int) bool {
-	return data == null_element
+	return data == html.null_element
 }
 
 [inline]
@@ -21,15 +21,11 @@ fn (stack Stack) is_empty() bool {
 }
 
 fn (stack Stack) peek() int {
-	return if !stack.is_empty() {
-		stack.elements[stack.size - 1]
-	} else {
-		null_element
-	}
+	return if !stack.is_empty() { stack.elements[stack.size - 1] } else { html.null_element }
 }
 
 fn (mut stack Stack) pop() int {
-	mut to_return := null_element
+	mut to_return := html.null_element
 	if !stack.is_empty() {
 		to_return = stack.elements[stack.size - 1]
 		stack.size--

--- a/vlib/net/html/dom.v
+++ b/vlib/net/html/dom.v
@@ -25,7 +25,7 @@ mut:
 fn (mut dom DocumentObjectModel) print_debug(data string) {
 	$if debug {
 		if data.len > 0 {
-			dom.debug_file.writeln(data)
+			dom.debug_file.writeln(data) or { panic(err) }
 		}
 	}
 }
@@ -114,9 +114,10 @@ fn (mut dom DocumentObjectModel) construct(tag_list []&Tag) {
 		if is_close_tag(tag) {
 			temp_int = stack.peek()
 			temp_string = tag.name[1..]
-			for !is_null(temp_int) && temp_string != tag_list[temp_int].name && !tag_list[temp_int].closed {
-				dom.print_debug(temp_string + ' >> ' + tag_list[temp_int].name + ' ' + (temp_string ==
-					tag_list[temp_int].name).str())
+			for !is_null(temp_int) && temp_string != tag_list[temp_int].name
+				&& !tag_list[temp_int].closed {
+				dom.print_debug(temp_string + ' >> ' + tag_list[temp_int].name + ' ' +
+					(temp_string == tag_list[temp_int].name).str())
 				stack.pop()
 				temp_int = stack.peek()
 			}
@@ -142,7 +143,8 @@ fn (mut dom DocumentObjectModel) construct(tag_list []&Tag) {
 				dom.print_debug("Added ${tag.name} as child of '" + tag_list[temp_int].name +
 					"' which now has ${dom.btree.get_children().len} childrens")
 				*/
-				dom.print_debug("Added $tag.name as child of '" + temp_tag.name + "' which now has $temp_tag.children.len childrens")
+				dom.print_debug("Added $tag.name as child of '" + temp_tag.name +
+					"' which now has $temp_tag.children.len childrens")
 			} else { // dom.new_root(tag)
 				stack.push(root_index)
 			}
@@ -168,20 +170,12 @@ pub fn (mut dom DocumentObjectModel) get_tag_by_attribute_value(name string, val
 
 // get_tag retrieves all the tags in the document that has the given tag name.
 pub fn (dom DocumentObjectModel) get_tag(name string) []&Tag {
-	return if name in dom.tag_type {
-		dom.tag_type[name]
-	} else {
-		[]&Tag{}
-	}
+	return if name in dom.tag_type { dom.tag_type[name] } else { []&Tag{} }
 }
 
 // get_tag_by_attribute retrieves all the tags in the document that has the given attribute name.
 pub fn (dom DocumentObjectModel) get_tag_by_attribute(name string) []&Tag {
-	return if name in dom.all_attributes {
-		dom.all_attributes[name]
-	} else {
-		[]&Tag{}
-	}
+	return if name in dom.all_attributes { dom.all_attributes[name] } else { []&Tag{} }
 }
 
 // get_root returns the root of the document.

--- a/vlib/net/html/parser.v
+++ b/vlib/net/html/parser.v
@@ -14,7 +14,7 @@ mut:
 	opened_code_type string
 	line_count       int
 	lexeme_builder   strings.Builder = strings.Builder{}
-	code_tags        map[string]bool = {
+	code_tags        map[string]bool = map{
 	'script': true
 	'style':  true
 }
@@ -25,12 +25,12 @@ pub struct Parser {
 mut:
 	dom                DocumentObjectModel
 	lexical_attributes LexicalAttributes = LexicalAttributes{
-	current_tag: &Tag{}
-}
-	filename           string = 'direct-parse'
-	initialized        bool
-	tags               []&Tag
-	debug_file         os.File
+		current_tag: &Tag{}
+	}
+	filename    string = 'direct-parse'
+	initialized bool
+	tags        []&Tag
+	debug_file  os.File
 }
 
 // This function is used to add a tag for the parser ignore it's content.
@@ -53,7 +53,7 @@ fn (parser Parser) builder_str() string {
 fn (mut parser Parser) print_debug(data string) {
 	$if debug {
 		if data.len > 0 {
-			parser.debug_file.writeln(data)
+			parser.debug_file.writeln(data) or { panic(err) }
 		}
 	}
 }
@@ -99,8 +99,8 @@ fn (mut parser Parser) generate_tag() {
 	if parser.lexical_attributes.open_tag {
 		return
 	}
-	if parser.lexical_attributes.current_tag.name.len > 0 ||
-		parser.lexical_attributes.current_tag.content.len > 0 {
+	if parser.lexical_attributes.current_tag.name.len > 0
+		|| parser.lexical_attributes.current_tag.content.len > 0 {
 		parser.tags << parser.lexical_attributes.current_tag
 	}
 	parser.lexical_attributes.current_tag = &Tag{}
@@ -119,8 +119,8 @@ pub fn (mut parser Parser) split_parse(data string) {
 		}
 		if parser.lexical_attributes.open_code { // here will verify all needed to know if open_code finishes and string in code
 			parser.lexical_attributes.lexeme_builder.write_b(chr)
-			if parser.lexical_attributes.open_string > 0 &&
-				parser.lexical_attributes.open_string == string_code {
+			if parser.lexical_attributes.open_string > 0
+				&& parser.lexical_attributes.open_string == string_code {
 				parser.lexical_attributes.open_string = 0
 			} else if is_quote {
 				parser.lexical_attributes.open_string = string_code
@@ -167,8 +167,8 @@ pub fn (mut parser Parser) split_parse(data string) {
 				parser.lexical_attributes.lexeme_builder.write_b(chr)
 			} else if chr == `>` { // close tag >
 				complete_lexeme := parser.builder_str().to_lower()
-				parser.lexical_attributes.current_tag.closed = (complete_lexeme.len > 0 &&
-					complete_lexeme[complete_lexeme.len - 1] == `/`) // if equals to /
+				parser.lexical_attributes.current_tag.closed = (complete_lexeme.len > 0
+					&& complete_lexeme[complete_lexeme.len - 1] == `/`) // if equals to /
 				if complete_lexeme.len > 0 && complete_lexeme[0] == `/` {
 					parser.dom.close_tags[complete_lexeme] = true
 				}
@@ -210,8 +210,9 @@ pub fn (mut parser Parser) split_parse(data string) {
 		} else if chr == `<` { // open tag '<'
 			temp_string := parser.builder_str()
 			if parser.lexical_attributes.lexeme_builder.len >= 1 {
-				if parser.lexical_attributes.current_tag.name.len > 1 &&
-					parser.lexical_attributes.current_tag.name[0] == 47 && !blank_string(temp_string) {
+				if parser.lexical_attributes.current_tag.name.len > 1
+					&& parser.lexical_attributes.current_tag.name[0] == 47
+					&& !blank_string(temp_string) {
 					parser.tags << &Tag{
 						name: 'text'
 						content: temp_string

--- a/vlib/net/html/parser_test.v
+++ b/vlib/net/html/parser_test.v
@@ -34,7 +34,7 @@ fn test_giant_string() {
 
 fn test_script_tag() {
 	mut parser := Parser{}
-	script_content := "\nvar googletag = googletag || {};\ngoogletag.cmd = googletag.cmd || [];if(3 > 5) {console.log(\'Birl\');}\n"
+	script_content := "\nvar googletag = googletag || {};\ngoogletag.cmd = googletag.cmd || [];if(3 > 5) {console.log('Birl');}\n"
 	temp_html := '<html><body><script>$script_content</script></body></html>'
 	parser.parse_html(temp_html)
 	assert parser.tags[2].content.len == script_content.replace('\n', '').len

--- a/vlib/net/html/tag.v
+++ b/vlib/net/html/tag.v
@@ -54,11 +54,7 @@ pub fn (tag &Tag) str() string {
 			html_str.write_string('="$value"')
 		}
 	}
-	html_str.write_string(if tag.closed && tag.close_type == .in_name {
-		'/>'
-	} else {
-		'>'
-	})
+	html_str.write_string(if tag.closed && tag.close_type == .in_name { '/>' } else { '>' })
 	html_str.write_string(tag.content)
 	if tag.children.len > 0 {
 		for child in tag.children {


### PR DESCRIPTION
This PR use or blocks in `.writeln()` method calls, and also apply a vfmt to the `net.html` module.

Fix #8942.