### PR TITLE
cgen: fix anon_fn redefinition (fix #8920)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -300,8 +300,9 @@ pub:
 // anonymous function
 pub struct AnonFn {
 pub mut:
-	decl FnDecl
-	typ  table.Type // the type of anonymous fn. Both .typ and .decl.name are auto generated
+	decl    FnDecl
+	typ     table.Type // the type of anonymous fn. Both .typ and .decl.name are auto generated
+	has_gen bool       // has been generated
 }
 
 // function or method declaration
@@ -360,9 +361,8 @@ pub:
 // function or method call expr
 pub struct CallExpr {
 pub:
-	pos  token.Position
-	left Expr // `user` in `user.register()`
-	mod  string
+	pos token.Position
+	mod string
 pub mut:
 	name               string // left.name()
 	is_method          bool
@@ -371,6 +371,7 @@ pub mut:
 	expected_arg_types []table.Type
 	language           table.Language
 	or_block           OrExpr
+	left               Expr       // `user` in `user.register()`
 	left_type          table.Type // type of `user`
 	receiver_type      table.Type // User
 	return_type        table.Type

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -150,11 +150,11 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 	g.writeln('for (int $i = 0; $i < ${tmp}_len; ++$i) {')
 	g.writeln('\t$inp_elem_type it = (($inp_elem_type*) ${tmp}_orig.data)[$i];')
 	mut is_embed_map_filter := false
-	expr := node.args[0].expr
-	match expr {
+	mut expr := node.args[0].expr
+	match mut expr {
 		ast.AnonFn {
 			g.write('\t$ret_elem_type ti = ')
-			g.gen_anon_fn_decl(expr)
+			g.gen_anon_fn_decl(mut expr)
 			g.write('${expr.decl.name}(it)')
 		}
 		ast.Ident {
@@ -324,11 +324,11 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 	g.writeln('for (int $i = 0; $i < ${tmp}_len; ++$i) {')
 	g.writeln('\t$elem_type_str it = (($elem_type_str*) ${tmp}_orig.data)[$i];')
 	mut is_embed_map_filter := false
-	expr := node.args[0].expr
-	match expr {
+	mut expr := node.args[0].expr
+	match mut expr {
 		ast.AnonFn {
 			g.write('\tif (')
-			g.gen_anon_fn_decl(expr)
+			g.gen_anon_fn_decl(mut expr)
 			g.write('${expr.decl.name}(it)')
 		}
 		ast.Ident {

--- a/vlib/v/tests/anon_fn_redefinition_test.v
+++ b/vlib/v/tests/anon_fn_redefinition_test.v
@@ -1,0 +1,24 @@
+const default_logger = Example{}
+
+struct Example {
+	structs []Another = [Another{}]
+}
+
+pub struct Another {
+	function fn (string) = fn (value string) {
+		println('$value')
+	}
+}
+
+pub fn (e Example) useless() string {
+	return 'ok'
+}
+
+fn test_anon_fn_redefinition() {
+	e1 := Example{}
+	assert e1.useless() == 'ok'
+	e2 := Example{}
+	assert e2.useless() == 'ok'
+	e3 := Example{}
+	assert e3.useless() == 'ok'
+}


### PR DESCRIPTION
This PR fixes anon_fn redefinition (fix #8920).

- Fix anon_fn redefinition.
- Add test `anon_fn_redefinition_test.v`.

```vlang
struct Example {
	structs []Another = [Another{}]
}

pub struct Another {
	function fn (string) = fn (value string) {
		println('$value')
	}
}

pub fn (e Example) useless() string {
	return 'ok'
}

fn main() {
	e1 := Example{}
	println(e1.useless())
	assert e1.useless() == 'ok'
	e2 := Example{}
	println(e2.useless())
	assert e2.useless() == 'ok'
	e3 := Example{}
	println(e3.useless())
	assert e3.useless() == 'ok'
}

const default_logger = Example{}

D:\Test\v\tt1>v run .
ok
ok
ok
```