### PR TITLE
fmt: restructure comment line break logic inside arrays

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -134,7 +134,7 @@ pub fn (mut f Fmt) wrap_long_line(penalty_idx int, add_indent bool) bool {
 	if f.buffering {
 		return false
 	}
-	if f.line_len <= fmt.max_len[penalty_idx] {
+	if penalty_idx > 0 && f.line_len <= fmt.max_len[penalty_idx] {
 		return false
 	}
 	if f.out.buf[f.out.buf.len - 1] == ` ` {
@@ -1965,29 +1965,34 @@ pub fn (mut f Fmt) array_init(node ast.ArrayInit) {
 	mut inc_indent := false
 	mut last_line_nr := node.pos.line_nr // to have the same newlines between array elements
 	f.array_init_depth++
-	for i, c in node.pre_cmnts {
-		if c.pos.line_nr > last_line_nr {
-			f.writeln('')
-		} else if i > 0 {
-			f.write(' ')
-		}
-		f.comment(c, level: .indent, iembed: true)
-		last_line_nr = c.pos.last_line
-	}
 	if node.pre_cmnts.len > 0 {
-		same_line := node.pre_cmnts[0].pos.line_nr == node.pos.line_nr
-		if same_line && node.exprs.len > 0 {
-			f.write(' ')
-		} else if !same_line && node.exprs.len == 0 {
+		if node.pre_cmnts[0].pos.line_nr > last_line_nr {
 			f.writeln('')
 		}
+	}
+	for i, c in node.pre_cmnts {
+		f.comment(c, level: .indent, iembed: true)
+		if i < node.pre_cmnts.len - 1 {
+			if c.pos.last_line < node.pre_cmnts[i + 1].pos.line_nr {
+				f.writeln('')
+			} else {
+				f.write(' ')
+			}
+		} else {
+			if c.pos.last_line < node.pos.last_line && node.exprs.len == 0 {
+				f.writeln('')
+			} else if node.exprs.len > 0 {
+				f.write(' ')
+			}
+		}
+		last_line_nr = c.pos.last_line
 	}
 	mut set_comma := false
 	for i, expr in node.exprs {
 		pos := expr.position()
 		if i == 0 {
 			if f.array_init_depth > f.array_init_break.len {
-				f.array_init_break << (last_line_nr < pos.line_nr)
+				f.array_init_break << pos.line_nr > last_line_nr
 			}
 		}
 		line_break := f.array_init_break[f.array_init_depth - 1]

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1984,10 +1984,10 @@ pub fn (mut f Fmt) array_init(node ast.ArrayInit) {
 	}
 	mut set_comma := false
 	for i, expr in node.exprs {
-		line_nr := expr.position().line_nr
+		pos := expr.position()
 		if i == 0 {
 			if f.array_init_depth > f.array_init_break.len {
-				f.array_init_break << (last_line_nr < line_nr)
+				f.array_init_break << (last_line_nr < pos.line_nr)
 			}
 		}
 		line_break := f.array_init_break[f.array_init_depth - 1]
@@ -2034,7 +2034,7 @@ pub fn (mut f Fmt) array_init(node ast.ArrayInit) {
 		} else if !set_comma {
 			f.write(',')
 		}
-		last_line_nr = line_nr
+		last_line_nr = pos.last_line
 		set_comma = false
 	}
 	f.array_init_depth--

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1990,10 +1990,8 @@ pub fn (mut f Fmt) array_init(node ast.ArrayInit) {
 				f.array_init_break << (last_line_nr < line_nr)
 			}
 		}
-		is_same_line_comment := i > 0
-			&& (expr is ast.Comment && line_nr == node.exprs[i - 1].position().line_nr)
 		line_break := f.array_init_break[f.array_init_depth - 1]
-		mut penalty := if line_break && !is_same_line_comment { 0 } else { 4 }
+		mut penalty := if line_break { 0 } else { 4 }
 		if penalty > 0 {
 			if i == 0 || should_decrease_arr_penalty(node.exprs[i - 1]) {
 				penalty--
@@ -2028,14 +2026,12 @@ pub fn (mut f Fmt) array_init(node ast.ArrayInit) {
 		}
 		if i == node.exprs.len - 1 {
 			if is_new_line {
-				if !set_comma && expr !is ast.Comment {
+				if !set_comma{
 					f.write(',')
 				}
 				f.writeln('')
-			} else if is_same_line_comment {
-				f.writeln('')
 			}
-		} else if !set_comma && expr !is ast.Comment {
+		} else if !set_comma {
 			f.write(',')
 		}
 		last_line_nr = line_nr

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2031,7 +2031,7 @@ pub fn (mut f Fmt) array_init(node ast.ArrayInit) {
 		}
 		if i == node.exprs.len - 1 {
 			if is_new_line {
-				if !set_comma{
+				if !set_comma {
 					f.write(',')
 				}
 				f.writeln('')


### PR DESCRIPTION
More progress towards #8437 and I removed some obsolete lines. 
The actual switch to line comments should be possible in the next PR.