### PR TITLE
encoding: change base64 signatures to use `[]byte`

### DIFF
--- a/vlib/encoding/base64/base64.v
+++ b/vlib/encoding/base64/base64.v
@@ -10,7 +10,7 @@ const (
 		13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 0, 0, 0, 0, 63, 0, 26, 27, 28, 29,
 		30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51]!
 	ending_table = [0, 2, 1]!
-	enc_table    = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'.bytes()
+	enc_table    = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
 )
 
 // decode decodes the base64 encoded `string` value passed in `data`.
@@ -19,12 +19,19 @@ const (
 pub fn decode(data string) []byte {
 	size := data.len * 3 / 4
 	if size <= 0 {
-		return []
+		return []byte{cap: 1}
 	}
 	unsafe {
 		buffer := malloc(size)
 		n := decode_in_buffer(data, buffer)
 		return array{element_size: 1, data: buffer, len: n, cap: size}
+	}
+}
+
+pub fn decode_str(data string) string {
+	result := decode(data)
+	unsafe {
+		return tos(result.data, result.len)
 	}
 }
 
@@ -43,6 +50,13 @@ pub fn encode(data []byte) string {
 	}
 }
 
+pub fn encode_str(data string) string {
+	unsafe {
+		arr := array{element_size: 1, data: data.str, len: data.len, cap: data.len}
+		return encode(arr)
+	}
+}
+
 // decode_url returns a decoded URL `string` version of
 // the a base64 url encoded `string` passed in `data`.
 pub fn decode_url(data string) []byte {
@@ -55,10 +69,24 @@ pub fn decode_url(data string) []byte {
 	return decode(data)
 }
 
+pub fn decode_url_str(data string) string {
+	result := decode_url(data)
+	unsafe {
+		return tos(result.data, result.len)
+	}
+}
+
 // encode_url returns a base64 URL encoded `string` version
 // of the value passed in `data`.
 pub fn encode_url(data []byte) string {
 	return encode(data).replace_each(['+', '-', '/', '_', '=', ''])
+}
+
+pub fn encode_url_str(data string) string {
+	unsafe {
+		arr := array{element_size: 1, data: data.str, len: data.len, cap: data.len}
+		return encode_url(arr)
+	}
 }
 
 // decode_in_buffer decodes the base64 encoded `string` reference passed in `data` into `buffer`.
@@ -133,7 +161,7 @@ pub fn encode_in_buffer(data []byte, buffer byteptr) int {
 
 	mut d := byteptr(data.data)
 	mut b := buffer
-	mut etable := byteptr(enc_table.data)
+	mut etable := byteptr(enc_table.str)
 	for i < input_length {
 		mut octet_a := 0
 		mut octet_b := 0

--- a/vlib/encoding/base64/base64_memory_test.v
+++ b/vlib/encoding/base64/base64_memory_test.v
@@ -4,7 +4,7 @@ fn test_long_encoding() {
 	repeats := 1000
 	input_size := 3000
 
-	s_original := 'a'.repeat(input_size).bytes()
+	s_original := [byte(`a`)].repeat(input_size)
 	s_encoded := base64.encode(s_original)
 	s_decoded := base64.decode(s_encoded)
 

--- a/vlib/encoding/base64/base64_memory_test.v
+++ b/vlib/encoding/base64/base64_memory_test.v
@@ -4,7 +4,7 @@ fn test_long_encoding() {
 	repeats := 1000
 	input_size := 3000
 
-	s_original := 'a'.repeat(input_size)
+	s_original := 'a'.repeat(input_size).bytes()
 	s_encoded := base64.encode(s_original)
 	s_decoded := base64.decode(s_encoded)
 

--- a/vlib/encoding/base64/base64_memory_test.v
+++ b/vlib/encoding/base64/base64_memory_test.v
@@ -4,7 +4,7 @@ fn test_long_encoding() {
 	repeats := 1000
 	input_size := 3000
 
-	s_original := [byte(`a`)].repeat(input_size)
+	s_original := []byte{len: input_size, init: `a`}
 	s_encoded := base64.encode(s_original)
 	s_decoded := base64.decode(s_encoded)
 

--- a/vlib/encoding/base64/base64_test.v
+++ b/vlib/encoding/base64/base64_test.v
@@ -56,6 +56,23 @@ fn test_decode() {
 	}
 }
 
+fn test_decode_str() {
+	assert base64.decode_str(man_pair.encoded) == man_pair.decoded
+
+	// Test for incorrect padding.
+	assert base64.decode_str('aGk') == 'hi'
+	assert base64.decode_str('aGk=') == 'hi'
+	assert base64.decode_str('aGk==') == 'hi'
+
+	for i, p in pairs {
+		got := base64.decode_str(p.encoded)
+		if got != p.decoded {
+			eprintln('pairs[${i}]: expected = ${p.decoded}, got = ${got}')
+			assert false
+		}
+	}
+}
+
 fn test_encode() {
 	assert base64.encode(man_pair.decoded.bytes()) == man_pair.encoded
 
@@ -68,8 +85,25 @@ fn test_encode() {
 	}
 }
 
+fn test_encode_str() {
+	assert base64.encode_str(man_pair.decoded) == man_pair.encoded
+
+	for i, p in pairs {
+		got := base64.encode_str(p.decoded)
+		if got != p.encoded {
+			eprintln('pairs[${i}]: expected = ${p.encoded}, got = ${got}')
+			assert false
+		}
+	}
+}
+
 fn test_encode_url() {
 	test := base64.encode_url('Hello Base64Url encoding!'.bytes())
+	assert test == 'SGVsbG8gQmFzZTY0VXJsIGVuY29kaW5nIQ'
+}
+
+fn test_encode_url_str() {
+	test := base64.encode_url_str('Hello Base64Url encoding!')
 	assert test == 'SGVsbG8gQmFzZTY0VXJsIGVuY29kaW5nIQ'
 }
 
@@ -78,10 +112,27 @@ fn test_decode_url() {
 	assert test == 'Hello Base64Url encoding!'.bytes()
 }
 
+fn test_decode_url_str() {
+	test := base64.decode_url_str("SGVsbG8gQmFzZTY0VXJsIGVuY29kaW5nIQ")
+	assert test == 'Hello Base64Url encoding!'
+}
+
 fn test_encode_null_byte() {
 	assert base64.encode([byte(`L`) 0 `L`]) == 'TABM'
 }
 
+fn test_encode_null_byte_str() {
+	// While this works, bytestr() does a memcpy
+	s := [byte(`L`) 0 `L`].bytestr()
+	assert base64.encode_str(s) == 'TABM'
+}
+
 fn test_decode_null_byte() {
 	assert base64.decode('TABM') == [byte(`L`) 0 `L`]
+}
+
+fn test_decode_null_byte_str() {
+	// While this works, bytestr() does a memcpy
+	s := [byte(`L`) 0 `L`].bytestr()
+	assert base64.decode_str('TABM') == s
 }

--- a/vlib/encoding/base64/base64_test.v
+++ b/vlib/encoding/base64/base64_test.v
@@ -40,16 +40,16 @@ const (
 )
 
 fn test_decode() {
-	assert base64.decode(man_pair.encoded) == man_pair.decoded
+	assert base64.decode(man_pair.encoded) == man_pair.decoded.bytes()
 
 	// Test for incorrect padding.
-	assert base64.decode('aGk') == 'hi'
-	assert base64.decode('aGk=') == 'hi'
-	assert base64.decode('aGk==') == 'hi'
+	assert base64.decode('aGk') == 'hi'.bytes()
+	assert base64.decode('aGk=') == 'hi'.bytes()
+	assert base64.decode('aGk==') == 'hi'.bytes()
 
 	for i, p in pairs {
 		got := base64.decode(p.encoded)
-		if got != p.decoded {
+		if got != p.decoded.bytes() {
 			eprintln('pairs[${i}]: expected = ${p.decoded}, got = ${got}')
 			assert false
 		}
@@ -57,10 +57,10 @@ fn test_decode() {
 }
 
 fn test_encode() {
-	assert base64.encode(man_pair.decoded) == man_pair.encoded
+	assert base64.encode(man_pair.decoded.bytes()) == man_pair.encoded
 
 	for i, p in pairs {
-		got := base64.encode(p.decoded)
+		got := base64.encode(p.decoded.bytes())
 		if got != p.encoded {
 			eprintln('pairs[${i}]: expected = ${p.encoded}, got = ${got}')
 			assert false
@@ -69,11 +69,19 @@ fn test_encode() {
 }
 
 fn test_encode_url() {
-	test := base64.encode_url('Hello Base64Url encoding!')
+	test := base64.encode_url('Hello Base64Url encoding!'.bytes())
 	assert test == 'SGVsbG8gQmFzZTY0VXJsIGVuY29kaW5nIQ'
 }
 
 fn test_decode_url() {
 	test := base64.decode_url("SGVsbG8gQmFzZTY0VXJsIGVuY29kaW5nIQ")
-	assert test == 'Hello Base64Url encoding!'
+	assert test == 'Hello Base64Url encoding!'.bytes()
+}
+
+fn test_encode_null_byte() {
+	assert base64.encode([byte(`L`) 0 `L`]) == 'TABM'
+}
+
+fn test_decode_null_byte() {
+	assert base64.decode('TABM') == [byte(`L`) 0 `L`]
 }

--- a/vlib/encoding/base64/base64_test.v
+++ b/vlib/encoding/base64/base64_test.v
@@ -118,21 +118,21 @@ fn test_decode_url_str() {
 }
 
 fn test_encode_null_byte() {
-	assert base64.encode([byte(`L`) 0 `L`]) == 'TABM'
+	assert base64.encode([byte(`A`) 0 `C`]) == 'QQBD'
 }
 
 fn test_encode_null_byte_str() {
 	// While this works, bytestr() does a memcpy
-	s := [byte(`L`) 0 `L`].bytestr()
-	assert base64.encode_str(s) == 'TABM'
+	s := [byte(`A`) 0 `C`].bytestr()
+	assert base64.encode_str(s) == 'QQBD'
 }
 
 fn test_decode_null_byte() {
-	assert base64.decode('TABM') == [byte(`L`) 0 `L`]
+	assert base64.decode('QQBD') == [byte(`A`) 0 `C`]
 }
 
 fn test_decode_null_byte_str() {
 	// While this works, bytestr() does a memcpy
-	s := [byte(`L`) 0 `L`].bytestr()
-	assert base64.decode_str('TABM') == s
+	s := [byte(`A`) 0 `C`].bytestr()
+	assert base64.decode_str('QQBD') == s
 }

--- a/vlib/encoding/base64/base64_test.v
+++ b/vlib/encoding/base64/base64_test.v
@@ -97,23 +97,23 @@ fn test_encode_str() {
 	}
 }
 
-fn test_encode_url() {
-	test := base64.encode_url('Hello Base64Url encoding!'.bytes())
+fn test_url_encode() {
+	test := base64.url_encode('Hello Base64Url encoding!'.bytes())
 	assert test == 'SGVsbG8gQmFzZTY0VXJsIGVuY29kaW5nIQ'
 }
 
-fn test_encode_url_str() {
-	test := base64.encode_url_str('Hello Base64Url encoding!')
+fn test_url_encode_str() {
+	test := base64.url_encode_str('Hello Base64Url encoding!')
 	assert test == 'SGVsbG8gQmFzZTY0VXJsIGVuY29kaW5nIQ'
 }
 
-fn test_decode_url() {
-	test := base64.decode_url("SGVsbG8gQmFzZTY0VXJsIGVuY29kaW5nIQ")
+fn test_url_decode() {
+	test := base64.url_decode("SGVsbG8gQmFzZTY0VXJsIGVuY29kaW5nIQ")
 	assert test == 'Hello Base64Url encoding!'.bytes()
 }
 
-fn test_decode_url_str() {
-	test := base64.decode_url_str("SGVsbG8gQmFzZTY0VXJsIGVuY29kaW5nIQ")
+fn test_url_decode_str() {
+	test := base64.url_decode_str("SGVsbG8gQmFzZTY0VXJsIGVuY29kaW5nIQ")
 	assert test == 'Hello Base64Url encoding!'
 }
 

--- a/vlib/net/smtp/smtp.v
+++ b/vlib/net/smtp/smtp.v
@@ -149,7 +149,7 @@ fn (mut c Client) send_auth() ? {
 	sb.write_b(0)
 	sb.write_string(c.password)
 	a := sb.str()
-	auth := 'AUTH PLAIN ${base64.encode(a)}\r\n'
+	auth := 'AUTH PLAIN ${base64.encode_str(a)}\r\n'
 	c.send_str(auth) ?
 	c.expect_reply(.auth_ok) ?
 }

--- a/vlib/x/websocket/handshake.v
+++ b/vlib/x/websocket/handshake.v
@@ -7,7 +7,7 @@ import strings
 // handshake manages the websocket handshake process
 fn (mut ws Client) handshake() ? {
 	nonce := get_nonce(ws.nonce_size)
-	seckey := base64.encode(nonce)
+	seckey := base64.encode_str(nonce)
 	mut sb := strings.new_builder(1024)
 	defer {
 		unsafe { sb.free() }

--- a/vlib/x/websocket/utils.v
+++ b/vlib/x/websocket/utils.v
@@ -35,7 +35,7 @@ fn create_key_challenge_response(seckey string) ?string {
 	sha1buf := seckey + guid
 	shabytes := sha1buf.bytes()
 	hash := sha1.sum(shabytes)
-	b64 := base64.encode(unsafe { tos(hash.data, hash.len) })
+	b64 := base64.encode(hash)
 	unsafe {
 		hash.free()
 		shabytes.free()


### PR DESCRIPTION
**New base64 signatures**

```v
fn decode(data string) []byte
fn decode_str(data string) string

fn encode(data []byte) string
fn encode_str(data string) string

fn decode_url(data string) []byte
fn decode_url_str(data string) string

fn encode_url(data []byte) string
fn encode_url_str(data string) string

fn decode_in_buffer(data &string, buffer byteptr) int
fn encode_in_buffer(data []byte, buffer byteptr) int
```

**Current signatures**

```v
fn decode(data string) string
fn encode(data string) string
fn decode_url(data string) string
fn encode_url(data string) string
fn decode_in_buffer(data &string, buffer byteptr) int
fn encode_in_buffer(data &string, buffer byteptr) int
```