### PR TITLE
 builtin: tag array methods unsafe: *_many, grow_len, pointers 

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -213,7 +213,7 @@ pub fn (mut ts TestSession) test() {
 	ts.nmessage_idx = 0
 	go ts.print_messages()
 	pool_of_test_runners.set_shared_context(ts)
-	pool_of_test_runners.work_on_pointers(remaining_files.pointers())
+	pool_of_test_runners.work_on_pointers(unsafe { remaining_files.pointers() })
 	ts.benchmark.stop()
 	ts.append_message(.sentinel, '') // send the sentinel
 	_ := <-ts.nprint_ended // wait for the stop of the printing thread

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -156,6 +156,7 @@ pub fn (mut a array) insert(i int, val voidptr) {
 }
 
 // insert_many inserts many values into the array from index `i`.
+[unsafe]
 pub fn (mut a array) insert_many(i int, val voidptr, size int) {
 	$if !no_bounds_checking ? {
 		if i < 0 || i > a.len {
@@ -178,6 +179,7 @@ pub fn (mut a array) prepend(val voidptr) {
 }
 
 // prepend_many prepends another array to this array.
+[unsafe]
 pub fn (mut a array) prepend_many(val voidptr, size int) {
 	a.insert_many(0, val, size)
 }
@@ -420,7 +422,7 @@ fn (mut a array) push(val voidptr) {
 
 // push_many implements the functionality for pushing another array.
 // `val` is array.data and user facing usage is `a << [1,2,3]`
-// TODO make private, right now it's used by strings.Builder
+[unsafe]
 pub fn (mut a3 array) push_many(val voidptr, size int) {
 	if a3.data == val && !isnil(a3.data) {
 		// handle `arr << arr`
@@ -632,6 +634,7 @@ pub fn (mut a array) grow_cap(amount int) {
 }
 
 // grow_len ensures that an array has a.len + amount of length
+[unsafe]
 pub fn (mut a array) grow_len(amount int) {
 	a.ensure_cap(a.len + amount)
 	a.len += amount
@@ -728,6 +731,7 @@ pub fn compare_f32(a &f32, b &f32) int {
 
 // pointers returns a new array, where each element
 // is the address of the corresponding element in the array.
+[unsafe]
 pub fn (a array) pointers() []voidptr {
 	mut res := []voidptr{}
 	for i in 0 .. a.len {

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -181,7 +181,7 @@ pub fn (mut a array) prepend(val voidptr) {
 // prepend_many prepends another array to this array.
 [unsafe]
 pub fn (mut a array) prepend_many(val voidptr, size int) {
-	a.insert_many(0, val, size)
+	unsafe { a.insert_many(0, val, size) }
 }
 
 // delete deletes array element at index `i`.

--- a/vlib/io/reader.v
+++ b/vlib/io/reader.v
@@ -46,7 +46,7 @@ pub fn read_all(config ReadAllConfig) ?[]byte {
 			break
 		}
 		if b.len == read {
-			b.grow_len(read_all_grow_len)
+			unsafe { b.grow_len(read_all_grow_len) }
 		}
 	}
 	return b[..read]
@@ -66,7 +66,7 @@ pub fn read_any(r Reader) ?[]byte {
 			break
 		}
 		if b.len == read {
-			b.grow_len(read_all_grow_len)
+			unsafe { b.grow_len(read_all_grow_len) }
 		}
 	}
 	return b[..read]

--- a/vlib/strings/builder.v
+++ b/vlib/strings/builder.v
@@ -27,7 +27,7 @@ pub fn new_builder(initial_size int) Builder {
 // write_bytes appends `bytes` to the accumulated buffer
 [unsafe]
 pub fn (mut b Builder) write_bytes(bytes byteptr, howmany int) {
-	b.buf.push_many(bytes, howmany)
+	unsafe { b.buf.push_many(bytes, howmany) }
 	b.len += howmany
 }
 
@@ -50,7 +50,7 @@ pub fn (mut b Builder) write_string(s string) {
 	if s == '' {
 		return
 	}
-	b.buf.push_many(s.str, s.len)
+	unsafe { b.buf.push_many(s.str, s.len) }
 	// for c in s {
 	// b.buf << c
 	// }
@@ -99,7 +99,7 @@ pub fn (mut b Builder) writeln(s string) {
 	// for c in s {
 	// b.buf << c
 	// }
-	b.buf.push_many(s.str, s.len)
+	unsafe { b.buf.push_many(s.str, s.len) }
 	// b.buf << []byte(s)  // TODO
 	b.buf << `\n`
 	b.len += s.len + 1

--- a/vlib/sync/pool/pool.v
+++ b/vlib/sync/pool/pool.v
@@ -74,7 +74,7 @@ pub fn (mut pool PoolProcessor) set_max_jobs(njobs int) {
 // work_on_items returns *after* all threads finish.
 // You can optionally call get_results after that.
 pub fn (mut pool PoolProcessor) work_on_items<T>(items []T) {
-	pool.work_on_pointers( items.pointers() )
+	pool.work_on_pointers( unsafe { items.pointers() } )
 }
 
 pub fn (mut pool PoolProcessor) work_on_pointers(items []voidptr) {

--- a/vlib/term/ui/ui.v
+++ b/vlib/term/ui/ui.v
@@ -29,7 +29,7 @@ pub fn (mut ctx Context) write(s string) {
 	if s == '' {
 		return
 	}
-	ctx.print_buf.push_many(s.str, s.len)
+	unsafe { ctx.print_buf.push_many(s.str, s.len) }
 }
 
 [inline]


### PR DESCRIPTION
`grow_len` is unsafe because it allows reading uninitialized memory.
`pointers` is unsafe because it escapes addresses of elements that could get freed.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
