### PR TITLE
tools: fix shortcut creation & registry access in `v symlink` on windows

### DIFF
--- a/cmd/tools/vsymlink.v
+++ b/cmd/tools/vsymlink.v
@@ -48,8 +48,9 @@ fn setup_symlink_windows(vexe string) {
 		vdir := os.real_path(os.dir(vexe))
 		vsymlinkdir := os.join_path(vdir, '.bin')
 		mut vsymlink := os.join_path(vsymlinkdir, 'v.exe')
+		// Remove old symlink first (v could have been moved, symlink rerun)
 		if !os.exists(vsymlinkdir) {
-			os.mkdir(vsymlinkdir) or { panic(err) } // will panic if fails
+			os.mkdir(vsymlinkdir) or { panic(err) }
 		} else {
 			if os.exists(vsymlink) {
 				os.rm(vsymlink) or { panic(err) }
@@ -109,7 +110,7 @@ fn setup_symlink_windows(vexe string) {
 				C.RegCloseKey(reg_sys_env_handle)
 				warn_and_exit(err)
 			}
-			println('done.')
+			println('Done.')
 		}
 		println('Notifying running processes to update their Environment...')
 		send_setting_change_msg('Environment') or {
@@ -118,9 +119,9 @@ fn setup_symlink_windows(vexe string) {
 			warn_and_exit('You might need to run this again to have the `v` command in your %PATH%')
 		}
 		C.RegCloseKey(reg_sys_env_handle)
-		println('')
-		println('Note: restart your shell/IDE to load the new %PATH%.')
-		println('After restarting your shell/IDE, give `v version` a try in another dir!')
+		println('Done.')
+		println('Note: Restart your shell/IDE to load the new %PATH%.')
+		println('After restarting your shell/IDE, give `v version` a try in another directory!')
 	}
 }
 
@@ -150,7 +151,7 @@ fn get_reg_value(reg_env_key voidptr, key string) ?string {
 		reg_value_size := 4095 // this is the max length (not for the registry, but for the system %PATH%)
 		mut reg_value := unsafe { &u16(malloc(reg_value_size)) }
 		if C.RegQueryValueEx(reg_env_key, key.to_wide(), 0, 0, reg_value, &reg_value_size) != 0 {
-			return error('Unable to get registry value for "$key", try rerunning as an Administrator')
+			return error('Unable to get registry value for "$key".')
 		}
 		return unsafe { string_from_wide(reg_value) }
 	}
@@ -160,8 +161,8 @@ fn get_reg_value(reg_env_key voidptr, key string) ?string {
 // sets the value for the given $key to the given  $value
 fn set_reg_value(reg_key voidptr, key string, value string) ?bool {
 	$if windows {
-		if C.RegSetValueEx(reg_key, key.to_wide(), 0, 1, value.to_wide(), 4095) != 0 {
-			return error('Unable to set registry value for "$key", are you running as an Administrator?')
+		if C.RegSetValueEx(reg_key, key.to_wide(), 0, C.REG_EXPAND_SZ, value.to_wide(), value.len*2) != 0 {
+			return error('Unable to set registry value for "$key". %PATH% may be too long.')
 		}
 		return true
 	}

--- a/cmd/tools/vsymlink.v
+++ b/cmd/tools/vsymlink.v
@@ -1,7 +1,6 @@
 import os
 import v.pref
 import v.util
-import time
 
 $if windows {
 	$if tinyc {
@@ -52,9 +51,15 @@ fn setup_symlink_windows(vexe string) {
 		if !os.exists(vsymlinkdir) {
 			os.mkdir(vsymlinkdir) or { panic(err) } // will panic if fails
 		} else {
-			os.rmdir_all(vsymlinkdir) or { panic(err) }
-			time.usleep(1000) // 1 ms
-			os.mkdir(vsymlinkdir) or { panic(err) }
+			if os.exists(vsymlink) {
+				os.rm(vsymlink) or { panic(err) }
+			} else {
+				vsymlink = os.join_path(vsymlinkdir, 'v.bat')
+				if os.exists(vsymlink) {
+					os.rm(vsymlink) or { panic(err) }
+				}
+				vsymlink = os.join_path(vsymlinkdir, 'v.exe')
+			}
 		}
 		// First, try to create a native symlink at .\.bin\v.exe
 		os.symlink(vsymlink, vexe) or {

--- a/cmd/tools/vsymlink.v
+++ b/cmd/tools/vsymlink.v
@@ -106,18 +106,16 @@ fn setup_symlink_windows(vexe string) {
 			println('System %PATH% was not configured.')
 			println('Adding symlink directory to system %PATH%...')
 			set_reg_value(reg_sys_env_handle, 'Path', new_sys_env_path) or {
-				warn_and_exit(err)
 				C.RegCloseKey(reg_sys_env_handle)
-				return
+				warn_and_exit(err)
 			}
 			println('done.')
 		}
 		println('Notifying running processes to update their Environment...')
 		send_setting_change_msg('Environment') or {
 			eprintln(err)
-			warn_and_exit('You might need to run this again to have the `v` command in your %PATH%')
 			C.RegCloseKey(reg_sys_env_handle)
-			return
+			warn_and_exit('You might need to run this again to have the `v` command in your %PATH%')
 		}
 		C.RegCloseKey(reg_sys_env_handle)
 		println('')

--- a/cmd/tools/vsymlink.v
+++ b/cmd/tools/vsymlink.v
@@ -1,6 +1,7 @@
 import os
 import v.pref
 import v.util
+import time
 
 $if windows {
 	$if tinyc {
@@ -51,7 +52,8 @@ fn setup_symlink_windows(vexe string) {
 		if !os.exists(vsymlinkdir) {
 			os.mkdir(vsymlinkdir) or { panic(err) } // will panic if fails
 		} else {
-			os.rmdir(vsymlinkdir) or { panic(err) }
+			os.rmdir_all(vsymlinkdir) or { panic(err) }
+			time.usleep(1000) // 1 ms
 			os.mkdir(vsymlinkdir) or { panic(err) }
 		}
 		// First, try to create a native symlink at .\.bin\v.exe

--- a/cmd/tools/vsymlink.v
+++ b/cmd/tools/vsymlink.v
@@ -8,7 +8,6 @@ $if windows {
 		#flag -lUser32
 	}
 }
-
 fn main() {
 	C.atexit(cleanup_vtmp_folder)
 	vexe := os.real_path(pref.vexe_path())
@@ -161,7 +160,8 @@ fn get_reg_value(reg_env_key voidptr, key string) ?string {
 // sets the value for the given $key to the given  $value
 fn set_reg_value(reg_key voidptr, key string, value string) ?bool {
 	$if windows {
-		if C.RegSetValueEx(reg_key, key.to_wide(), 0, C.REG_EXPAND_SZ, value.to_wide(), value.len*2) != 0 {
+		if C.RegSetValueEx(reg_key, key.to_wide(), 0, C.REG_EXPAND_SZ, value.to_wide(),
+			value.len * 2) != 0 {
 			return error('Unable to set registry value for "$key". %PATH% may be too long.')
 		}
 		return true


### PR DESCRIPTION
* Checks for possible existing symlinks before deleting and recreating them (rather than the directory, see note below).
* Passes # bytes when setting reg value, rather than max path length, which causes path update to fail.
* Explicitly specifies reg value type, rather than the type's int, when setting reg value.
* Do not need admin rights to edit HKEY_CURRENT_USER. Changes error messages to reflect more likely system issues.
* Reorders statements to remove dead code and properly close the reg key handle. (Needed only while `defer` does not work in `if` blocks).

Comments on [previous commit](https://github.com/vlang/v/commit/63ed3c0d41097969e86ce975b537da461a6dc9b4).
Issue #8725.


Note: Calling os.mkdir() immediately after os.rmdir_all() fails to create new directory on some Windows systems.