### PR TITLE
docs: added Windows installation recommendation

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -38,6 +38,8 @@ NB: You can also pass one of `-gcc`, `-msvc`, `-clang` to `make.bat` instead,
 if you do prefer to use a different C compiler, but -tcc is small, fast, and
 easy to install (V will download a prebuilt binary automatically).
 
+It is recommended to add this folder to the PATH  of your environment variables. Otherwise you always have to call the full path to the `v.exe`.
+
 ### Android
 Running V graphical apps on Android is also possible via [vab](https://github.com/vlang/vab).
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -38,7 +38,7 @@ NB: You can also pass one of `-gcc`, `-msvc`, `-clang` to `make.bat` instead,
 if you do prefer to use a different C compiler, but -tcc is small, fast, and
 easy to install (V will download a prebuilt binary automatically).
 
-It is recommended to add this folder to the PATH  of your environment variables. Otherwise you always have to call the full path to the `v.exe`.
+It is recommended to add this folder to the PATH of your environment variables. Otherwise you always have to call the full path to the `v.exe`.
 
 ### Android
 Running V graphical apps on Android is also possible via [vab](https://github.com/vlang/vab).

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -38,7 +38,8 @@ NB: You can also pass one of `-gcc`, `-msvc`, `-clang` to `make.bat` instead,
 if you do prefer to use a different C compiler, but -tcc is small, fast, and
 easy to install (V will download a prebuilt binary automatically).
 
-It is recommended to add this folder to the PATH of your environment variables. Otherwise you always have to call the full path to the `v.exe`.
+It is recommended to add this folder to the PATH of your environment variables. 
+Otherwise you always have to call the full path to the `v.exe`.
 
 ### Android
 Running V graphical apps on Android is also possible via [vab](https://github.com/vlang/vab).

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -38,8 +38,8 @@ NB: You can also pass one of `-gcc`, `-msvc`, `-clang` to `make.bat` instead,
 if you do prefer to use a different C compiler, but -tcc is small, fast, and
 easy to install (V will download a prebuilt binary automatically).
 
-It is recommended to add this folder to the PATH of your environment variables. 
-Otherwise you always have to call the full path to the `v.exe`.
+It is recommended to add this folder to the PATH of your environment variables.
+This can be done with the command `v.exe symlink`.
 
 ### Android
 Running V graphical apps on Android is also possible via [vab](https://github.com/vlang/vab).


### PR DESCRIPTION
Added a simple Windows installation recommendation to enable a more easily start with the V language on a windows system.
This is the page you see if you click on the Documentation tab on the vlang.io website. For me this installation guide was not 100% clear since it says you just have to run the bat file and then you can call `v` from the CLI.