### PR TITLE
gg: added window_size_real_pixels that is used for 3D without dpi scaling

### DIFF
--- a/examples/sokol/01_cubes/cube.v
+++ b/examples/sokol/01_cubes/cube.v
@@ -268,7 +268,7 @@ fn cube_field(app App) {
 }
 
 fn frame(mut app App) {
-	ws := gg.window_size()
+	ws := gg.window_size_real_pixels()
 	ratio := f32(ws.width) / ws.height
 	dw := ws.width
 	dh := ws.height

--- a/examples/sokol/02_cubes_glsl/cube_glsl.v
+++ b/examples/sokol/02_cubes_glsl/cube_glsl.v
@@ -359,7 +359,7 @@ fn draw_cube_glsl(app App) {
 
 	rot := [f32(app.mouse_y), f32(app.mouse_x)]
 
-	ws := gg.window_size()
+	ws := gg.window_size_real_pixels()
 	// ratio := f32(ws.width)/ws.height
 	dw := f32(ws.width / 2)
 	dh := f32(ws.height / 2)
@@ -428,7 +428,7 @@ fn draw_texture_cubes(app App) {
 }
 
 fn frame(mut app App) {
-	ws := gg.window_size()
+	ws := gg.window_size_real_pixels()
 	ratio := f32(ws.width) / ws.height
 	dw := ws.width
 	dh := ws.height

--- a/examples/sokol/03_march_tracing_glsl/rt_glsl.v
+++ b/examples/sokol/03_march_tracing_glsl/rt_glsl.v
@@ -255,7 +255,7 @@ fn draw_cube_glsl(app App) {
 		return
 	}
 
-	ws := gg.window_size()
+	ws := gg.window_size_real_pixels()
 	ratio := f32(ws.width) / ws.height
 	dw := f32(ws.width / 2)
 	dh := f32(ws.height / 2)
@@ -297,7 +297,7 @@ fn draw_cube_glsl(app App) {
 }
 
 fn frame(mut app App) {
-	ws := gg.window_size()
+	ws := gg.window_size_real_pixels()
 
 	// clear
 	mut color_action := C.sg_color_attachment_action{

--- a/examples/sokol/04_multi_shader_glsl/rt_glsl.v
+++ b/examples/sokol/04_multi_shader_glsl/rt_glsl.v
@@ -372,7 +372,7 @@ fn draw_cube_glsl_m(app App) {
 		return
 	}
 
-	ws := gg.window_size()
+	ws := gg.window_size_real_pixels()
 	ratio := f32(ws.width) / ws.height
 	dw := f32(ws.width / 2)
 	dh := f32(ws.height / 2)
@@ -415,7 +415,7 @@ fn draw_cube_glsl_p(app App) {
 		return
 	}
 
-	ws := gg.window_size()
+	ws := gg.window_size_real_pixels()
 	ratio := f32(ws.width) / ws.height
 	dw := f32(ws.width / 2)
 	dh := f32(ws.height / 2)
@@ -458,7 +458,7 @@ fn draw_start_glsl(app App) {
 		return
 	}
 
-	ws := gg.window_size()
+	ws := gg.window_size_real_pixels()
 	// ratio := f32(ws.width) / ws.height
 	// dw := f32(ws.width  / 2)
 	// dh := f32(ws.height / 2)
@@ -472,7 +472,7 @@ fn draw_end_glsl(app App) {
 }
 
 fn frame(mut app App) {
-	ws := gg.window_size()
+	ws := gg.window_size_real_pixels()
 
 	// clear
 	mut color_action := C.sg_color_attachment_action{

--- a/examples/sokol/05_instancing_glsl/rt_glsl.v
+++ b/examples/sokol/05_instancing_glsl/rt_glsl.v
@@ -292,7 +292,7 @@ fn draw_cube_glsl_i(mut app App){
 		return
 	}
 
-	ws := gg.window_size()
+	ws := gg.window_size_real_pixels()
 	//ratio := f32(ws.width) / ws.height
 	dw := f32(ws.width  / 2)
 	dh := f32(ws.height / 2)
@@ -356,7 +356,7 @@ fn draw_start_glsl(app App){
 		return
 	}
 
-	ws := gg.window_size()
+	ws := gg.window_size_real_pixels()
 	//ratio := f32(ws.width) / ws.height
 	//dw := f32(ws.width  / 2)
 	//dh := f32(ws.height / 2)
@@ -370,7 +370,7 @@ fn draw_end_glsl(app App){
 }
 
 fn frame(mut app App) {
-	ws := gg.window_size()
+	ws := gg.window_size_real_pixels()
 
 	// clear
 	mut color_action := C.sg_color_attachment_action{

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -760,6 +760,11 @@ pub fn window_size() Size {
 	return Size{int(sapp.width() / s), int(sapp.height() / s)}
 }
 
+// window_size_real_pixels returns the `Size` of the active window without scale
+pub fn window_size_real_pixels() Size {
+	return Size{sapp.width(), sapp.height()}
+}
+
 pub fn dpi_scale() f32 {
 	mut s := sapp.dpi_scale()
 	$if android {


### PR DESCRIPTION
**What's inside**
Because the DPI scale introduction in gg a lot of sokol's examples are showing a wrong viewport.
The 3D examples need the real pixel size of the window, thus the add of the function `window_size_real_pixels`.