### PR TITLE
utf8: deprecate utf8.char_len

### DIFF
--- a/vlib/encoding/utf8/east_asian/east_asian_width.v
+++ b/vlib/encoding/utf8/east_asian/east_asian_width.v
@@ -20,7 +20,7 @@ pub enum EastAsianWidthProperty {
 pub fn display_width(s string, ambiguous_width int) int {
 	mut i, mut n := 0, 0
 	for i < s.len {
-		c_len := utf8.char_len(s[i])
+		c_len := utf8_char_len(s[i])
 		n += match east_asian_width_property_at(s, i) {
 			.ambiguous { ambiguous_width }
 			.full, .wide { int(2) }

--- a/vlib/encoding/utf8/utf8_util.v
+++ b/vlib/encoding/utf8/utf8_util.v
@@ -49,7 +49,7 @@ pub fn get_uchar(s string, index int) int {
 	mut res := 0
 	mut ch_len := 0
 	if s.len > 0 {
-		ch_len = char_len(s[index])
+		ch_len = utf8_char_len(s[index])
 
 		if ch_len == 1 {
 			return u16(s[index])
@@ -170,7 +170,7 @@ fn up_low(s string, upper_flag bool) string {
 	mut str_res := unsafe {malloc(s.len + 1)}
 
 	for {
-		ch_len := char_len(s[index])
+		ch_len := utf8_char_len(s[index])
 
 		if ch_len == 1 {
 			if upper_flag==true {

--- a/vlib/encoding/utf8/utf8_util.v
+++ b/vlib/encoding/utf8/utf8_util.v
@@ -23,7 +23,7 @@ pub fn len(s string) int {
 	mut index := 0
 
 	for {
-		ch_len := char_len(s[index])
+		ch_len := utf8_char_len(s[index])
 		index += ch_len
 		count++
 		if index >= s.len {
@@ -39,6 +39,7 @@ pub fn u_len(s ustring) int {
 }
 
 // char_len calculate the length in bytes of a utf8 char
+[deprecated: 'use builtin utf8_char_len']
 pub fn char_len(b byte) int {
 	return ((0xe5000000 >> ((b >> 3) & 0x1e)) & 3) + 1
 }

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -4,7 +4,6 @@
 module scanner
 
 import os
-import encoding.utf8
 import v.token
 import v.pref
 import v.util
@@ -1057,7 +1056,7 @@ fn (mut s Scanner) text_scan() token.Token {
 }
 
 fn (mut s Scanner) invalid_character() {
-	len := utf8.char_len(s.text[s.pos])
+	len := utf8_char_len(s.text[s.pos])
 	end := util.imin(s.pos + len, s.text.len)
 	c := s.text[s.pos..end]
 	s.error('invalid character `$c`')


### PR DESCRIPTION
Currently, there are two ways to get utf8 char len, utf8.char_len and builtin utf8_char_len.

This PR deprecate `utf8.char_len`

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
