### PR TITLE
os: fix warnings in os.v

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -61,8 +61,8 @@ pub fn cp_all(src string, dst string, overwrite bool) ? {
 			}
 		}
 		cp_all(sp, dp, overwrite) or {
-			rmdir(dp) or { return error(err) }
-			return error(err)
+			rmdir(dp) or { return err }
+			return err
 		}
 	}
 }


### PR DESCRIPTION
this pr changes two instances of `return error(err)` to `return err` in `vlib/os/os.v`. they raise warnings currently, after the pr they do not.
