### PR TITLE
x.json2: proper string encoding + minor fixes

### DIFF
--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -87,8 +87,7 @@ pub fn (f Any) str() string {
 }
 
 // char_len_list is a modified version of builtin.utf8_str_len
-// that returns an array of char length to be used for escaping
-// the characters
+// that returns an array of character lengths. (e.g "t✔" => [1,2])
 fn char_len_list(s string) []int {
 	mut l := 1
 	mut ls := []int{}
@@ -108,7 +107,7 @@ fn char_len_list(s string) []int {
 
 const escaped_chars = [r'\b', r'\f', r'\n', r'\r', r'\t']
 
-// json_string returns the valid JSON version of the string.
+// json_string returns the JSON spec-compliant version of the string.
 [manualfree]
 fn json_string(s string) string {
 	// not the best implementation but will revisit it soon

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -51,8 +51,8 @@ pub fn (flds []Any) str() string {
 	return res
 }
 
-// str returns the string representation of the `Any` type. If you want to
-// use the escaped string version of the `Any` type. Use the `json_str` method instead.
+// str returns the string representation of the `Any` type. Use the `json_str` method
+// if you want to use the escaped str() version of the `Any` type.
 pub fn (f Any) str() string {
 	if f is string {
 		return f

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -51,8 +51,18 @@ pub fn (flds []Any) str() string {
 	return res
 }
 
-// str returns the string representation of the `Any` type.
+// str returns the string representation of the `Any` type. If you want to
+// use the escaped string version of the `Any` type. Use the `json_str` method instead.
 pub fn (f Any) str() string {
+	if f is string {
+		return f
+	} else {
+		return f.json_str()
+	}
+}
+
+// json_str returns the JSON string representation of the `Any` type.
+pub fn (f Any) json_str() string {
 	match f {
 		string {
 			return json_string(f)

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -6,7 +6,7 @@ module json2
 import strings
 
 fn write_value(v Any, i int, len int, mut wr strings.Builder) {
-	str := v.str()
+	str := v.json_str()
 	if v is string {
 		wr.write_string('"$str"')
 	} else {

--- a/vlib/x/json2/encoder_test.v
+++ b/vlib/x/json2/encoder_test.v
@@ -1,7 +1,7 @@
 import x.json2
 
 fn test_json_string_characters() {
-	text := json2.Any('\n\r\b\f\t\\\"\/')
+	text := json2.raw_decode(r'"\n\r\b\f\t\\\"\/"') or { '' }
 	assert text.json_str() == '\\n\\r\\b\\f\\t\\\\\\"\\/'
 }
 

--- a/vlib/x/json2/encoder_test.v
+++ b/vlib/x/json2/encoder_test.v
@@ -1,0 +1,21 @@
+import x.json2
+
+fn test_json_string_characters() {
+	text := json2.Any('\n\r\b\f\t\\\"\/')
+	assert text.str() == '\\n\\r\\b\\f\\t\\\\\\"\\/'
+}
+
+fn test_json_string() {
+	text := json2.Any('te✔st')
+	assert text.str() == r'te\u2714st'
+}
+
+fn test_json_string_emoji() {
+	text := json2.Any('🐈')
+	assert text.str() == r' '
+}
+
+fn test_json_string_non_ascii() {
+	text := json2.Any('ひらがな')
+	assert text.str() == r'\u3072\u3089\u304c\u306a'
+}

--- a/vlib/x/json2/encoder_test.v
+++ b/vlib/x/json2/encoder_test.v
@@ -2,20 +2,20 @@ import x.json2
 
 fn test_json_string_characters() {
 	text := json2.Any('\n\r\b\f\t\\\"\/')
-	assert text.str() == '\\n\\r\\b\\f\\t\\\\\\"\\/'
+	assert text.json_str() == '\\n\\r\\b\\f\\t\\\\\\"\\/'
 }
 
 fn test_json_string() {
 	text := json2.Any('te✔st')
-	assert text.str() == r'te\u2714st'
+	assert text.json_str() == r'te\u2714st'
 }
 
 fn test_json_string_emoji() {
 	text := json2.Any('🐈')
-	assert text.str() == r' '
+	assert text.json_str() == r' '
 }
 
 fn test_json_string_non_ascii() {
 	text := json2.Any('ひらがな')
-	assert text.str() == r'\u3072\u3089\u304c\u306a'
+	assert text.json_str() == r'\u3072\u3089\u304c\u306a'
 }

--- a/vlib/x/json2/scanner.v
+++ b/vlib/x/json2/scanner.v
@@ -41,12 +41,12 @@ const (
 	// list of characters commonly used in JSON.
 	char_list                 = [`{`, `}`, `[`, `]`, `,`, `:`]
 	// list of newlines to check when moving to a new position.
-	newlines                  = [`\r`, `\n`, byte(9), `\t`]
+	newlines                  = [`\r`, `\n`, `\t`]
 	// list of escapable that needs to be escaped inside a JSON string.
 	// double quotes and forward slashes are excluded intentionally since
 	// they have their own separate checks for it in order to pass the
 	// JSON test suite (https://github.com/nst/JSONTestSuite/).
-	important_escapable_chars = [byte(9), 10, 0, `\b`, `\f`, `\n`, `\r`, `\t`]
+	important_escapable_chars = [`\b`, `\f`, `\n`, `\r`, `\t`]
 	// list of valid unicode escapes aside from \u{4-hex digits}
 	valid_unicode_escapes     = [`b`, `f`, `n`, `r`, `t`, `\\`, `"`, `/`]
 	// used for transforming escapes into valid unicode (eg. n => \n)
@@ -129,7 +129,7 @@ fn (mut s Scanner) text_scan() Token {
 		} else if (s.pos - 1 >= 0 && s.text[s.pos - 1] != `\\`)
 			&& ch in json2.important_escapable_chars {
 			return s.error('character must be escaped with a backslash')
-		} else if s.pos == s.text.len - 1 && ch == `\\` {
+		} else if (s.pos == s.text.len - 1 && ch == `\\`) || ch == byte(0) {
 			return s.error('invalid backslash escape')
 		} else if s.pos + 1 < s.text.len && ch == `\\` {
 			peek := s.text[s.pos + 1]

--- a/vlib/x/json2/scanner.v
+++ b/vlib/x/json2/scanner.v
@@ -154,8 +154,15 @@ fn (mut s Scanner) text_scan() Token {
 					if codepoint.len != 4 {
 						return s.error('unicode escape must have 4 hex digits')
 					}
-					chrs << byte(strconv.parse_uint(codepoint.bytestr(), 16, 32))
-					unsafe { codepoint.free() }
+					val := u32(strconv.parse_uint(codepoint.bytestr(), 16, 32))
+					converted := utf32_to_str(val)
+					converted_bytes := converted.bytes()
+					chrs << converted_bytes
+					unsafe {
+						converted.free()
+						converted_bytes.free()
+						codepoint.free()
+					}
 					continue
 				} else {
 					return s.error('incomplete unicode escape')

--- a/vlib/x/json2/scanner_test.v
+++ b/vlib/x/json2/scanner_test.v
@@ -20,6 +20,16 @@ fn test_str_valid_unicode_escape() {
 	assert tok.lit.bytestr() == 'H'
 }
 
+fn test_str_valid_unicode_escape_2() {
+	mut sc := Scanner{
+		text: r'"\u2714"'.bytes()
+	}
+	tok := sc.scan()
+	assert tok.kind == .str_
+	assert tok.lit.len == 3
+	assert tok.lit.bytestr() == '✔'
+}
+
 fn test_str_invalid_escape() {
 	mut sc := Scanner{
 		text: r'"\z"'.bytes()


### PR DESCRIPTION
This PR fixes the JSON encoding for strings with escape characters (newline, carriage return, etc.) and UTF-8/16 symbols. Just a basic implementation for now and edge cases such as emojis are replaced with a space. This also renames the old `str()` method into `json_str()` and creates a new `str()` method for un-escaped string version of the string.

Another fix included in this PR are:
1. The proper conversion of escaped unicode sequences outside the ASCII range.
2. Making the null character an error in scanning process.

See the highlighted changes in `encoder_test.v` and `scanner_test.v` for the outputs.