### PR TITLE
cgen: merge cc_type and cc_type2

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -541,7 +541,7 @@ fn (mut g Gen) typ(t table.Type) string {
 
 fn (mut g Gen) base_type(t table.Type) string {
 	share := t.share()
-	mut styp := if share == .atomic_t { t.atomic_typename() } else { g.cc_type(t) }
+	mut styp := if share == .atomic_t { t.atomic_typename() } else { g.cc_type(t, true) }
 	if t.has_flag(.shared_f) {
 		styp = g.find_or_register_shared(t, styp)
 	}
@@ -674,10 +674,9 @@ static inline Option2_void __Option2_${styp}_pushval($styp ch, $el_type e) {
 	}
 }
 
-// TODO: merge cc_type and cc_type2
-// cc_type but without the `struct` prefix
-fn (g &Gen) cc_type2(t table.Type) string {
-	sym := g.table.get_type_symbol(g.unwrap_generic(t))
+// cc_type whether to prefix 'struct' or not (C__Foo -> struct Foo)
+fn (g &Gen) cc_type(typ table.Type, is_prefix_struct bool) string {
+	sym := g.table.get_type_symbol(g.unwrap_generic(typ))
 	mut styp := sym.cname
 	// TODO: this needs to be removed; cgen shouldn't resolve generic types (job of checker)
 	if mut sym.info is table.Struct {
@@ -702,15 +701,7 @@ fn (g &Gen) cc_type2(t table.Type) string {
 		}
 		return cname
 	}
-	return styp
-}
-
-// cc_type returns the Cleaned Concrete Type name, *without ptr*,
-// i.e. it's always just Cat, not Cat_ptr:
-fn (g &Gen) cc_type(t table.Type) string {
-	sym := g.table.get_type_symbol(g.unwrap_generic(t))
-	mut styp := g.cc_type2(t)
-	if styp.starts_with('C__') {
+	if is_prefix_struct && styp.starts_with('C__') {
 		styp = styp[3..]
 		if sym.kind == .struct_ {
 			info := sym.info as table.Struct
@@ -1524,8 +1515,8 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw table.Type, expected_t
 	}
 	if exp_sym.kind == .interface_ && got_type_raw.idx() != expected_type.idx()
 		&& !expected_type.has_flag(.optional) {
-		got_styp := g.cc_type(got_type)
-		exp_styp := g.cc_type(expected_type)
+		got_styp := g.cc_type(got_type, true)
+		exp_styp := g.cc_type(expected_type, true)
 		g.write('I_${got_styp}_to_Interface_$exp_styp')
 		if expected_type.is_ptr() {
 			g.write('_ptr')
@@ -6136,7 +6127,7 @@ fn (mut g Gen) interface_table() string {
 		for st in inter_info.types {
 			// cctype is the Cleaned Concrete Type name, *without ptr*,
 			// i.e. cctype is always just Cat, not Cat_ptr:
-			cctype := g.cc_type(st)
+			cctype := g.cc_type(st, true)
 			$if debug_interface_table ? {
 				eprintln(
 					'>> interface name: $ityp.name | concrete type: $st.debug() | st symname: ' +

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -158,7 +158,7 @@ fn (mut g Gen) gen_fn_decl(node ast.FnDecl, skip bool) {
 		name = util.replace_op(name)
 	}
 	if node.is_method {
-		name = g.cc_type2(node.receiver.typ) + '_' + name
+		name = g.cc_type(node.receiver.typ, false) + '_' + name
 		// name = g.table.get_type_symbol(node.receiver.typ).name + '_' + name
 	}
 	if node.language == .c {
@@ -477,11 +477,9 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	if node.receiver_type == 0 {
 		g.checker_bug('CallExpr.receiver_type is 0 in method_call', node.pos)
 	}
-	// mut receiver_type_name := g.cc_type(node.receiver_type)
-	// mut receiver_type_name := g.typ(node.receiver_type)
 	typ_sym := g.table.get_type_symbol(g.unwrap_generic(node.receiver_type))
-	// mut receiver_type_name := util.no_dots(typ_sym.name)
-	mut receiver_type_name := util.no_dots(g.cc_type2(g.unwrap_generic(node.receiver_type)))
+	mut receiver_type_name := util.no_dots(g.cc_type(g.unwrap_generic(node.receiver_type),
+		false))
 	if typ_sym.kind == .interface_ && (typ_sym.info as table.Interface).defines_method(node.name) {
 		// Speaker_name_table[s._interface_idx].speak(s._object)
 		$if debug_interface_method_call ? {
@@ -591,7 +589,6 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	if g.pref.obfuscate && g.cur_mod.name == 'main' && name.starts_with('main__')
 		&& node.name != 'str' {
 		sym := g.table.get_type_symbol(node.receiver_type)
-		// key = g.cc_type2(node.receiver.typ) + '.' + node.name
 		key := sym.name + '.' + node.name
 		g.write('/* obf method call: $key */')
 		name = g.obf_table[key] or {


### PR DESCRIPTION
This PR makes minor cleanup in cgen.

- Merge cc_type and cc_type2.
```vlang
// cc_type whether to prefix 'struct' or not (C__Foo -> struct Foo)
fn (g &Gen) cc_type(typ table.Type, is_prefix_struct bool) string {
```
- Remove cc_type2().
- Modify related calls.