### PR TITLE
cgen: fix if_expr of multi-stmts optional

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -946,6 +946,9 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) {
 			}
 		} else {
 			g.stmt(stmt)
+			if g.inside_if_optional && stmt is ast.ExprStmt {
+				g.writeln(';')
+			}
 		}
 		g.skip_stmt_pos = false
 		if g.inside_ternary > 0 && i < stmts.len - 1 {

--- a/vlib/v/tests/if_expr_of_optional_test.v
+++ b/vlib/v/tests/if_expr_of_optional_test.v
@@ -23,3 +23,23 @@ fn test_if_expr_of_optional() {
 	println(a3)
 	assert a3 == 2
 }
+
+fn foo_complex() ?int {
+	a := 2
+	return if a > 1 {
+		mut b := 1
+		b *= 10
+		b
+	} else {
+		mut c := 0
+		c += 2
+		println(c)
+		none
+	}
+}
+
+fn test_if_expr_of_optional_complex() {
+	a := foo_complex() or { panic('error') }
+	println(a)
+	assert a == 10
+}


### PR DESCRIPTION
This PR fixes if_expr of multi-stmts optional.

- Fix if_expr of multi-stmts optional.
- Add test.

```vlang
fn foo_complex() ?int {
	a := 2
	return if a > 1 {
		mut b := 1
		b *= 10
		b
	} else {
		c := 0
		println(c)
		none
	}
}

fn main() {
	a := foo_complex() or { panic('error') }
	println(a)
	assert a == 10
}

D:\Test\v\tt1>v run .
10
```