### PR TITLE
builtin: prepare for error interfaces

### DIFF
--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -3,74 +3,10 @@
 // that can be found in the LICENSE file.
 module builtin
 
-struct OptionBase {
-	ok      bool
-	is_none bool
-	error   string
-	ecode   int
-	// Data is trailing after ecode
-	// and is not included in here but in the
-	// derived Option_xxx types
-}
-
-// `fn foo() ?Foo { return foo }` => `fn foo() ?Foo { return opt_ok(foo); }`
-fn opt_ok2(data voidptr, mut option OptionBase, size int) {
-	unsafe {
-		*option = OptionBase{
-			ok: true
-		}
-		// use ecode to get the end of OptionBase and then memcpy into it
-		C.memcpy(byteptr(&option.ecode) + sizeof(int), data, size)
-	}
-}
-
-// Option is the old option type used for bootstrapping
-struct Option {
-	ok      bool
-	is_none bool
-	error   string
-	ecode   int
-}
-
-// str returns the string representation of the Option.
-pub fn (o Option) str() string {
-	if o.ok && !o.is_none {
-		return 'Option{ ok }'
-	}
-	if o.is_none {
-		return 'Option{ none }'
-	}
-	return 'Option{ error: "$o.error" }'
-}
-
-// opt_none is used internally when returning `none`.
-fn opt_none() Option {
-	return Option{
-		ok: false
-		is_none: true
-	}
-}
-
-// error returns an optional containing the error given in `message`.
-// `if ouch { return error('an error occurred') }`
-pub fn error(message string) Option {
-	return Option{
-		ok: false
-		is_none: false
-		error: message
-	}
-}
-
-// error_with_code returns an optional containing both error `message` and error `code`.
-// `if ouch { return error_with_code('an error occurred',1) }`
-pub fn error_with_code(message string, code int) Option {
-	return Option{
-		ok: false
-		is_none: false
-		error: message
-		ecode: code
-	}
-}
+// these are just here temporarily to avoid breaking the compiler;
+// they will be removed soon
+pub fn error(a string) Option2 { return {} }
+pub fn error_with_code(a string, b int) Option2 { return {} }
 
 // Option2 is the base of V's new internal optional return system.
 struct Option2 {
@@ -104,15 +40,14 @@ fn opt_ok(data voidptr, mut option Option2, size int) {
 	}
 }
 
-// /*
 pub fn (o Option2) str() string {
 	if o.state == 0 {
-		return 'Option2{ ok }'
+		return 'Option{ ok }'
 	}
 	if o.state == 1 {
-		return 'Option2{ none }'
+		return 'Option{ none }'
 	}
-	return 'Option2{ err: "$o.err" }'
+	return 'Option{ err: "$o.err" }'
 }
 
 // error returns an optional containing the error given in `message`.
@@ -137,4 +72,57 @@ pub fn error_with_code2(message string, code int) Option2 {
 		}
 	}
 }
-// */
+
+////////////////////////////////////////
+
+pub struct Option3 {
+	state byte
+	err   Error3
+}
+
+pub interface Error3 {
+	msg  string
+	code int
+}
+
+pub struct DefaultError {
+	msg  string
+	code int
+}
+
+[inline]
+fn (e Error3) str() string {
+	return e.msg
+}
+
+fn opt_ok3(data voidptr, mut option Option3, size int) {
+	unsafe {
+		*option = Option3{}
+		// use err to get the end of Option3 and then memcpy into it
+		C.memcpy(byteptr(&option.err) + sizeof(Error3), data, size)
+	}
+}
+
+pub fn (o Option3) str() string {
+	if o.state == 0 {
+		return 'Option{ ok }'
+	}
+	if o.state == 1 {
+		return 'Option{ none }'
+	}
+	return 'Option{ err: "$o.err" }'
+}
+
+[inline]
+pub fn error3(message string) Error3 {
+	return &DefaultError{
+		msg: message
+	}
+}
+
+pub fn error_with_code3(message string, code int) Error3 {
+	return &DefaultError {
+		msg: message
+		code: code
+	}
+}

--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -3,8 +3,64 @@
 // that can be found in the LICENSE file.
 module builtin
 
-// these are just here temporarily to avoid breaking the compiler;
-// they will be removed soon
+// IError holds information about an error instance
+pub interface IError {
+	msg  string
+	code int
+}
+
+// Error is the default implementation of IError, that is returned by e.g. `error()`
+pub struct Error {
+pub:
+	msg  string
+	code int
+}
+
+pub struct Option3 {
+	state byte
+	err   IError
+}
+
+[inline]
+fn (e IError) str() string {
+	return e.msg
+}
+
+fn opt_ok3(data voidptr, mut option Option3, size int) {
+	unsafe {
+		*option = Option3{}
+		// use err to get the end of Option3 and then memcpy into it
+		C.memcpy(byteptr(&option.err) + sizeof(IError), data, size)
+	}
+}
+
+pub fn (o Option3) str() string {
+	if o.state == 0 {
+		return 'Option{ ok }'
+	}
+	if o.state == 1 {
+		return 'Option{ none }'
+	}
+	return 'Option{ err: "$o.err" }'
+}
+
+[inline]
+pub fn error3(message string) IError {
+	return &Error{
+		msg: message
+	}
+}
+
+pub fn error_with_code3(message string, code int) IError {
+	return &Error {
+		msg: message
+		code: code
+	}
+}
+
+////////////////////////////////////////
+
+// these are just here temporarily to avoid breaking the compiler; they will be removed soon
 pub fn error(a string) Option2 { return {} }
 pub fn error_with_code(a string, b int) Option2 { return {} }
 
@@ -15,13 +71,6 @@ struct Option2 {
 	// Data is trailing after err
 	// and is not included in here but in the
 	// derived Option2_xxx types
-}
-
-// Error holds information about an error instance
-pub struct Error {
-pub:
-	msg  string
-	code int
 }
 
 [inline]
@@ -70,59 +119,5 @@ pub fn error_with_code2(message string, code int) Option2 {
 			msg: message
 			code: code
 		}
-	}
-}
-
-////////////////////////////////////////
-
-pub struct Option3 {
-	state byte
-	err   Error3
-}
-
-pub interface Error3 {
-	msg  string
-	code int
-}
-
-pub struct DefaultError {
-	msg  string
-	code int
-}
-
-[inline]
-fn (e Error3) str() string {
-	return e.msg
-}
-
-fn opt_ok3(data voidptr, mut option Option3, size int) {
-	unsafe {
-		*option = Option3{}
-		// use err to get the end of Option3 and then memcpy into it
-		C.memcpy(byteptr(&option.err) + sizeof(Error3), data, size)
-	}
-}
-
-pub fn (o Option3) str() string {
-	if o.state == 0 {
-		return 'Option{ ok }'
-	}
-	if o.state == 1 {
-		return 'Option{ none }'
-	}
-	return 'Option{ err: "$o.err" }'
-}
-
-[inline]
-pub fn error3(message string) Error3 {
-	return &DefaultError{
-		msg: message
-	}
-}
-
-pub fn error_with_code3(message string, code int) Error3 {
-	return &DefaultError {
-		msg: message
-		code: code
 	}
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2389,7 +2389,7 @@ pub fn (mut c Checker) return_stmt(mut return_stmt ast.Return) {
 	return_stmt.types = got_types
 	// allow `none` & `error (Option)` return types for function that returns optional
 	if exp_is_optional
-		&& got_types[0].idx() in [table.none_type_idx, table.error_type_idx, c.table.type_idxs['Option'], c.table.type_idxs['Option2']] {
+		&& got_types[0].idx() in [table.none_type_idx, table.error_type_idx, c.table.type_idxs['Option2'], c.table.type_idxs['Option3']] {
 		return
 	}
 	if expected_types.len > 0 && expected_types.len != got_types.len {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2389,7 +2389,7 @@ pub fn (mut c Checker) return_stmt(mut return_stmt ast.Return) {
 	return_stmt.types = got_types
 	// allow `none` & `error (Option)` return types for function that returns optional
 	if exp_is_optional
-		&& got_types[0].idx() in [table.none_type_idx, table.error_type_idx, c.table.type_idxs['Option2'], c.table.type_idxs['Option3']] {
+		&& got_types[0].idx() in [table.none_type_idx, table.error_type_idx, c.table.type_idxs['Option'], c.table.type_idxs['Option2'], c.table.type_idxs['Option3']] {
 		return
 	}
 	if expected_types.len > 0 && expected_types.len != got_types.len {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -721,7 +721,9 @@ fn (g &Gen) type_sidx(t table.Type) string {
 //
 pub fn (mut g Gen) write_typedef_types() {
 	for typ in g.table.types {
-		if typ.name in builtins { continue }
+		if typ.name in c.builtins {
+			continue
+		}
 		match typ.kind {
 			.alias {
 				parent := unsafe { &g.table.types[typ.parent_idx] }

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4930,7 +4930,7 @@ fn (mut g Gen) write_init_function() {
 }
 
 const (
-	builtins = ['string', 'array', 'DenseArray', 'map', 'Error', 'Option2', 'Error3', 'Option3']
+	builtins = ['string', 'array', 'DenseArray', 'map', 'Error', 'IError', 'Option2', 'Option3']
 )
 
 fn (mut g Gen) write_builtin_types() {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -549,9 +549,6 @@ fn (mut g Gen) base_type(t table.Type) string {
 	if nr_muls > 0 {
 		styp += strings.repeat(`*`, nr_muls)
 	}
-	// if styp == 'Option' {
-	// 	return 'Option2'
-	// }
 	return styp
 }
 
@@ -580,7 +577,6 @@ fn (g &Gen) optional_type_text(styp string, base string) string {
 }
 
 fn (mut g Gen) register_optional(t table.Type) string {
-	// g.typedefs2.writeln('typedef Option $x;')
 	styp, base := g.optional_type_name(t)
 	if styp !in g.optionals {
 		g.typedefs2.writeln('typedef struct $styp $styp;')
@@ -725,6 +721,7 @@ fn (g &Gen) type_sidx(t table.Type) string {
 //
 pub fn (mut g Gen) write_typedef_types() {
 	for typ in g.table.types {
+		if typ.name in builtins { continue }
 		match typ.kind {
 			.alias {
 				parent := unsafe { &g.table.types[typ.parent_idx] }
@@ -744,16 +741,7 @@ pub fn (mut g Gen) write_typedef_types() {
 				g.type_definitions.writeln('typedef array $typ.cname;')
 			}
 			.interface_ {
-				info := typ.info as table.Interface
-				g.type_definitions.writeln('typedef struct {')
-				g.type_definitions.writeln('\tvoid* _object;')
-				g.type_definitions.writeln('\tint _interface_idx;')
-				for field in info.fields {
-					styp := g.typ(field.typ)
-					cname := c_name(field.name)
-					g.type_definitions.writeln('\t$styp* $cname;')
-				}
-				g.type_definitions.writeln('} ${c_name(typ.name)};')
+				g.write_interface_typesymbol_declaration(typ)
 			}
 			.chan {
 				if typ.name != 'chan' {
@@ -786,6 +774,19 @@ static inline void __${typ.cname}_pushval($typ.cname ch, $el_stype val) {
 			}
 		}
 	}
+}
+
+pub fn (mut g Gen) write_interface_typesymbol_declaration(sym table.TypeSymbol) {
+	info := sym.info as table.Interface
+	g.type_definitions.writeln('typedef struct {')
+	g.type_definitions.writeln('\tvoid* _object;')
+	g.type_definitions.writeln('\tint _interface_idx;')
+	for field in info.fields {
+		styp := g.typ(field.typ)
+		cname := c_name(field.name)
+		g.type_definitions.writeln('\t$styp* $cname;')
+	}
+	g.type_definitions.writeln('} ${c_name(sym.name)};\n')
 }
 
 pub fn (mut g Gen) write_fn_typesymbol_declaration(sym table.TypeSymbol) {
@@ -909,7 +910,7 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) {
 				g.skip_stmt_pos = true
 				if stmt is ast.ExprStmt {
 					sym := g.table.get_type_symbol(stmt.typ)
-					if sym.name in ['Option', 'Option2'] || stmt.expr is ast.None {
+					if sym.name in ['Option2', 'Option3'] || stmt.expr is ast.None {
 						tmp := g.new_tmp_var()
 						g.write('Option2 $tmp = ')
 						g.expr(stmt.expr)
@@ -4267,7 +4268,7 @@ fn (mut g Gen) return_statement(node ast.Return) {
 	if fn_return_is_optional {
 		optional_none := node.exprs[0] is ast.None
 		ftyp := g.typ(node.types[0])
-		mut is_regular_option := ftyp in ['Option', 'Option2']
+		mut is_regular_option := ftyp in ['Option2', 'Option3']
 		if optional_none || is_regular_option {
 			tmp := g.new_tmp_var()
 			g.write('Option2 $tmp = ')
@@ -4384,7 +4385,7 @@ fn (mut g Gen) return_statement(node ast.Return) {
 				node.types[0].has_flag(.optional)
 			}
 		}
-		if fn_return_is_optional && !expr_type_is_opt && return_sym.name !in ['Option', 'Option2'] {
+		if fn_return_is_optional && !expr_type_is_opt && return_sym.name !in ['Option2', 'Option3'] {
 			styp := g.base_type(g.fn_decl.return_type)
 			opt_type := g.typ(g.fn_decl.return_type)
 			// Create a tmp for this option
@@ -4542,9 +4543,6 @@ fn (mut g Gen) const_decl_init_later(mod string, name string, val string, typ ta
 	// Initialize more complex consts in `void _vinit/2{}`
 	// (C doesn't allow init expressions that can't be resolved at compile time).
 	mut styp := g.typ(typ)
-	if styp == 'Option' {
-		styp = 'Option2'
-	}
 	cname := '_const_$name'
 	g.definitions.writeln('$styp $cname; // inited later')
 	if cname == '_const_os__args' {
@@ -4930,7 +4928,7 @@ fn (mut g Gen) write_init_function() {
 }
 
 const (
-	builtins = ['string', 'array', 'KeyValue', 'DenseArray', 'map', 'Option', 'Error', 'Option2']
+	builtins = ['string', 'array', 'DenseArray', 'map', 'Error', 'Option2', 'Error3', 'Option3']
 )
 
 fn (mut g Gen) write_builtin_types() {
@@ -4938,7 +4936,12 @@ fn (mut g Gen) write_builtin_types() {
 	// builtin types need to be on top
 	// everything except builtin will get sorted
 	for builtin_name in c.builtins {
-		builtin_types << g.table.types[g.table.type_idxs[builtin_name]]
+		sym := g.table.types[g.table.type_idxs[builtin_name]]
+		if sym.kind == .interface_ {
+			g.write_interface_typesymbol_declaration(sym)
+		} else {
+			builtin_types << sym
+		}
 	}
 	g.write_types(builtin_types)
 }


### PR DESCRIPTION
As discussed, the `err` variable inside `or`blocks will be made an interface, to allow people to return custom errors.

## Summary

#### The interface itself

```v
pub interface IError {
    msg  string
    code int
}
```
As long as your custom error type implements those two fields, you should be able to return it as an error.
It looks very similar to the existing Error struct - that is done on purpose, since the current Error struct will continue to exist, as the default error implementation returned by the builtin function `error(msg)`.

#### Returning custom errors

```v
struct MyCustomError {
    msg          string
    code         int
    custom_field bool
}
fn foo() ? {
    return IError(MyCustomError{ msg: 'hello', code: -1, custom_field: true })
}
```

Note that, with the current proposal, custom errors must be casted to `IError` first, to make it explicit that an error is being returned, etc.


#### Handling errors

```v
foo() or {
    println(err.msg) // replicates existing behavior - accesses the `msg` field on the IError interface
    
    match err {
        Error { ... } // default error implementation
        MyCustomError { println(err.custom_field) } // `err` is smartcasted into the proper interface type, so you can access any extra information on the custom type
        else { panic('unhandled error `$err`') } // an `else` branch *must always* be included, in case the function adds a new error branch, or propagates a new error, or whatever the case may be
    }
}
```

**These changes should be completely transparent** - any existing code should continue to work as-is; only those using the new feature will notice a difference.
