### PR TITLE
cgen: fix anon_fn in containers (fix #8965)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1955,9 +1955,9 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					g.is_assign_lhs = true
 					g.assign_op = assign_stmt.op
 					g.expr(left)
+					g.is_assign_lhs = false
 					if left is ast.IndexExpr {
 						sym := g.table.get_type_symbol(left.left_type)
-						g.is_assign_lhs = false
 						if sym.kind in [.map, .array] {
 							g.expr(val)
 							g.writeln('});')
@@ -1966,7 +1966,6 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					}
 					g.write(' = ')
 				}
-				g.is_assign_lhs = false
 				g.expr(val)
 				g.writeln(';')
 				if blank_assign {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1952,9 +1952,21 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					g.definitions.go_back(g.definitions.len - def_pos)
 					g.write(') = ')
 				} else {
+					g.is_assign_lhs = true
+					g.assign_op = assign_stmt.op
 					g.expr(left)
+					if left is ast.IndexExpr {
+						sym := g.table.get_type_symbol(left.left_type)
+						g.is_assign_lhs = false
+						if sym.kind in [.map, .array] {
+							g.expr(val)
+							g.writeln('});')
+							continue
+						}
+					}
 					g.write(' = ')
 				}
+				g.is_assign_lhs = false
 				g.expr(val)
 				g.writeln(';')
 				if blank_assign {

--- a/vlib/v/tests/anon_fn_in_containers_test.v
+++ b/vlib/v/tests/anon_fn_in_containers_test.v
@@ -1,0 +1,23 @@
+import sync
+
+fn test_go_anon_fn() {
+	mut wg := sync.new_waitgroup()
+	wg.add(1)    
+	go fn (mut wg sync.WaitGroup) {
+		wg.done()
+	}(mut wg)
+	wg.wait()
+}
+
+struct AnonFnWrapper {
+mut:
+	fn_ fn () bool
+}
+
+fn test_anon_assign_struct() {
+	mut w := AnonFnWrapper{}
+	w.fn_ = fn () bool {
+		return true
+	}
+	assert w.fn_()
+}

--- a/vlib/v/tests/anon_fn_in_containers_test.v
+++ b/vlib/v/tests/anon_fn_in_containers_test.v
@@ -1,23 +1,13 @@
-import sync
-
-fn test_go_anon_fn() {
-	mut wg := sync.new_waitgroup()
-	wg.add(1)    
-	go fn (mut wg sync.WaitGroup) {
-		wg.done()
-	}(mut wg)
-	wg.wait()
-}
-
-struct AnonFnWrapper {
-mut:
-	fn_ fn () bool
-}
-
-fn test_anon_assign_struct() {
-	mut w := AnonFnWrapper{}
-	w.fn_ = fn () bool {
-		return true
+fn test_anon_fn_in_map() {
+	mut woop := map{
+		'what': fn() string {
+			return 'whoopity whoop'
+		}
 	}
-	assert w.fn_()
+	assert woop['what']() == 'whoopity whoop'
+
+	woop['shat'] = fn() string {
+		return 'shoopity shoop'
+	}
+	assert woop['shat']() == 'shoopity shoop'
 }


### PR DESCRIPTION
This PR fixes anon_fn in containers (fix #8965).

- Fix anon_fn in containers.
- Add tests.

```vlang
fn main()
{
	mut woop := map{
		'what': fn(){
			println("whoopity whoop")
		}
	}
	// Works!
	woop['what']()

	woop['shat'] = fn() {
		println("shoopity shoop")
	}
	// Doesn't work
	woop['shat']()
}

D:\Test\v\tt1>v run .
whoopity whoop
shoopity shoop
```