### PR TITLE
vweb: refactor form parsing and add tests

### DIFF
--- a/vlib/vweb/request.v
+++ b/vlib/vweb/request.v
@@ -114,28 +114,16 @@ fn parse_multipart_form(body string, boundary string) (map[string]string, map[st
 			}
 			mut ct := lines[1].split_nth(':', 2)[1]
 			ct = ct.trim_left(' \t')
-			mut sb := strings.new_builder(field.len)
-			for i in 3 .. lines.len - 1 {
-				sb.writeln(lines[i])
-			}
+			data := lines_to_string(field.len, lines, 3, lines.len - 1)
 			files[name] << FileData{
 				filename: filename
 				content_type: ct
-				data: sb.str()
-			}
-			unsafe {
-				sb.free()
+				data: data
 			}
 			continue
 		}
-		mut sb := strings.new_builder(field.len)
-		for i in 2 .. lines.len - 1 {
-			sb.writeln(lines[i])
-		}
-		form[name] = sb.str()
-		unsafe {
-			sb.free()
-		}
+		data := lines_to_string(field.len, lines, 2, lines.len - 1)
+		form[name] = data
 	}
 	return form, files
 }
@@ -158,4 +146,15 @@ fn parse_disposition(line string) map[string]string {
 		}
 	}
 	return data
+}
+
+[manualfree]
+fn lines_to_string(len int, lines []string, start int, end int) string {
+	mut sb := strings.new_builder(len)
+	for i in start .. end {
+		sb.writeln(lines[i])
+	}
+	res := sb.str()
+	unsafe { sb.free() }
+	return res
 }

--- a/vlib/vweb/request.v
+++ b/vlib/vweb/request.v
@@ -1,10 +1,11 @@
 module vweb
 
 import io
+import strings
 import net.http
 import net.urllib
 
-pub fn parse_request(mut reader io.BufferedReader) ?http.Request {
+fn parse_request(mut reader io.BufferedReader) ?http.Request {
 	// request line
 	mut line := reader.read_line() ?
 	method, target, version := parse_request_line(line) ?
@@ -68,21 +69,92 @@ fn parse_header(s string) ?(string, string) {
 		return error('missing colon in header')
 	}
 	words := s.split_nth(':', 2)
-	if !is_token(words[0]) {
-		return error('invalid character in header name')
-	}
 	// TODO: parse quoted text according to the RFC
 	return words[0], words[1].trim_left(' \t')
 }
 
-// TODO: use map for faster lookup (untested)
-const token_chars = r"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-.^_`|~".bytes()
+// Parse URL encoded key=value&key=value forms
+fn parse_form(body string) map[string]string {
+	words := body.split('&')
+	mut form := map[string]string{}
+	for word in words {
+		kv := word.split_nth('=', 2)
+		if kv.len != 2 {
+			continue
+		}
+		key := urllib.query_unescape(kv[0]) or { continue }
+		val := urllib.query_unescape(kv[1]) or { continue }
+		form[key] = val
+	}
+	return form
+	// }
+	// todo: parse form-data and application/json
+	// ...
+}
 
-fn is_token(s string) bool {
-	for c in s {
-		if c !in vweb.token_chars {
-			return false
+fn parse_multipart_form(body string, boundary string) (map[string]string, map[string][]FileData) {
+	sections := body.split(boundary)
+	fields := sections[1..sections.len - 1]
+	mut form := map[string]string{}
+	mut files := map[string][]FileData{}
+
+	for field in fields {
+		// TODO: do not split into lines; do same parsing for HTTP body
+		lines := field.split_into_lines()[1..]
+		disposition := parse_disposition(lines[0])
+		// Grab everything between the double quotes
+		name := disposition['name'] or { continue }
+		// Parse files
+		// TODO: filename*
+		if 'filename' in disposition {
+			filename := disposition['filename']
+			// Parse Content-Type header
+			if lines.len == 1 || !lines[1].to_lower().starts_with('content-type:') {
+				continue
+			}
+			ct := lines[1].split_nth(': ', 2)[1].trim_left(' \t')
+			mut sb := strings.new_builder(field.len)
+			for i in 3 .. lines.len - 1 {
+				sb.writeln(lines[i])
+			}
+			files[name] << FileData{
+				filename: filename
+				content_type: ct
+				data: sb.str()
+			}
+			unsafe {
+				sb.free()
+			}
+			continue
+		}
+		mut sb := strings.new_builder(field.len)
+		for i in 2 .. lines.len - 1 {
+			sb.writeln(lines[i])
+		}
+		form[name] = sb.str()
+		unsafe {
+			sb.free()
 		}
 	}
-	return true
+	return form, files
+}
+
+// Parse the Content-Disposition header of a multipart form
+// Returns a map of the key="value" pairs
+// Example: parse_disposition('Content-Disposition: form-data; name="a"; filename="b"') == {'name': 'a', 'filename': 'b'}
+fn parse_disposition(line string) map[string]string {
+	mut data := map[string]string{}
+	for word in line.split(';') {
+		kv := word.split_nth('=', 2)
+		if kv.len != 2 {
+			continue
+		}
+		key, value := kv[0].to_lower().trim_left(' \t'), kv[1]
+		if value.starts_with('"') && value.ends_with('"') {
+			data[key] = value[1..value.len - 1]
+		} else {
+			data[key] = value
+		}
+	}
+	return data
 }

--- a/vlib/vweb/request.v
+++ b/vlib/vweb/request.v
@@ -112,7 +112,8 @@ fn parse_multipart_form(body string, boundary string) (map[string]string, map[st
 			if lines.len == 1 || !lines[1].to_lower().starts_with('content-type:') {
 				continue
 			}
-			ct := lines[1].split_nth(': ', 2)[1].trim_left(' \t')
+			mut ct := lines[1].split_nth(':', 2)[1]
+			ct = ct.trim_left(' \t')
 			mut sb := strings.new_builder(field.len)
 			for i in 3 .. lines.len - 1 {
 				sb.writeln(lines[i])


### PR DESCRIPTION
This PR refactors the form parsing logic and adds tests for them. These functions have moved into `vweb/request.v` and are no longer methods of `Context`.