### PR TITLE
vfmt: keep `mut:` in interface declarations

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -231,6 +231,7 @@ pub:
 	field_names  []string
 	is_pub       bool
 	methods      []FnDecl
+	mut_pos      int // mut:
 	fields       []StructField
 	pos          token.Position
 	pre_comments []Comment

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -808,7 +808,10 @@ pub fn (mut f Fmt) interface_decl(node ast.InterfaceDecl) {
 		f.writeln('')
 	}
 	f.comments_after_last_field(node.pre_comments)
-	for field in node.fields {
+	for i, field in node.fields {
+		if i == node.mut_pos {
+			f.writeln('mut:')
+		}
 		// TODO: alignment, comments, etc.
 		mut ft := f.no_cur_mod(f.table.type_to_str(field.typ))
 		if !ft.contains('C.') && !ft.contains('JS.') && !ft.contains('fn (') {

--- a/vlib/v/fmt/tests/interface_with_mut_fields_keep.vv
+++ b/vlib/v/fmt/tests/interface_with_mut_fields_keep.vv
@@ -1,0 +1,6 @@
+interface Toto {
+	a int
+mut:
+	b int
+	f()
+}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -461,6 +461,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 	mut fields := []ast.StructField{cap: 20}
 	mut methods := []ast.FnDecl{cap: 20}
 	mut is_mut := false
+	mut mut_pos := -1
 	for p.tok.kind != .rcbr && p.tok.kind != .eof {
 		if p.tok.kind == .key_mut {
 			if is_mut {
@@ -470,6 +471,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			p.next()
 			p.check(.colon)
 			is_mut = true
+			mut_pos = fields.len
 		}
 		if p.peek_tok.kind == .lpar {
 			method_start_pos := p.tok.position()
@@ -566,5 +568,6 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		is_pub: is_pub
 		pos: pos
 		pre_comments: pre_comments
+		mut_pos: mut_pos
 	}
 }


### PR DESCRIPTION
Fixes vfmt eating `mut:` from:
```v
interface Toto {
   a int
mut:
   b int
   f()
}
```

Closes: #9050 .