### PR TITLE
cmd/repl: add functionality to use custom programs on the startup

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -28,6 +28,7 @@ mut:
 const is_stdin_a_pipe = (is_atty(0) == 0)
 
 const vexe = os.getenv('VEXE')
+const startup = os.getenv('VSTARTUP')
 
 fn new_repl() Repl {
 	return Repl{
@@ -73,14 +74,23 @@ fn (r &Repl) function_call(line string) bool {
 	return false
 }
 
-fn (r &Repl) current_source_code(should_add_temp_lines bool) string {
+fn (r &Repl) current_source_code(should_add_temp_lines bool, not_add_print bool) string {
 	mut all_lines := []string{}
 	for mod in r.modules {
 		all_lines << 'import $mod\n'
 	}
+	if startup != '' {
+		l := os.read_file(startup) or { '' }
+		mut lines := l.trim_right('\n\r').split_into_lines()
+		if not_add_print {
+			lines = lines.filter(!it.starts_with('print'))
+		}
+		all_lines << lines
+	}
 	all_lines << r.includes
 	all_lines << r.functions
 	all_lines << r.lines
+
 	if should_add_temp_lines {
 		all_lines << r.temp_lines
 	}
@@ -103,6 +113,12 @@ fn run_repl(workdir string, vrepl_prefix string) {
 		println(util.full_v_version(false))
 		println('Use Ctrl-C or `exit` to exit, or `help` to see other available commands')
 	}
+
+	if startup != '' {
+		result := repl_run_vfile(startup) or { os.Result{output: 'file not found'} }
+		print_output(result)
+	}
+	
 	file := os.join_path(workdir, '.${vrepl_prefix}vrepl.v')
 	temp_file := os.join_path(workdir, '.${vrepl_prefix}vrepl_temp.v')
 	mut prompt := '>>> '
@@ -170,7 +186,7 @@ fn run_repl(workdir string, vrepl_prefix string) {
 			continue
 		}
 		if r.line == 'list' {
-			source_code := r.current_source_code(true)
+			source_code := r.current_source_code(true, false)
 			println('//////////////////////////////////////////////////////////////////////////////////////')
 			println(source_code)
 			println('//////////////////////////////////////////////////////////////////////////////////////')
@@ -183,7 +199,7 @@ fn run_repl(workdir string, vrepl_prefix string) {
 			r.line = 'println(' + r.line[1..] + ')'
 		}
 		if r.line.starts_with('print') {
-			source_code := r.current_source_code(false) + '\n$r.line\n'
+			source_code := r.current_source_code(false, true) + '\n$r.line\n'
 			os.write_file(file, source_code) or { panic(err) }
 			s := repl_run_vfile(file) or { return }
 			print_output(s)
@@ -238,10 +254,10 @@ fn run_repl(workdir string, vrepl_prefix string) {
 			if temp_line.starts_with('import ') {
 				mod := r.line.fields()[1]
 				if mod !in r.modules {
-					temp_source_code = '$temp_line\n' + r.current_source_code(false)
+					temp_source_code = '$temp_line\n' + r.current_source_code(false, false)
 				}
 			} else if temp_line.starts_with('#include ') {
-				temp_source_code = '$temp_line\n' + r.current_source_code(false)
+				temp_source_code = '$temp_line\n' + r.current_source_code(false, true)
 			} else {
 				for i, l in r.lines {
 					if (l.starts_with('for ') || l.starts_with('if ')) && l.contains('println') {
@@ -249,7 +265,7 @@ fn run_repl(workdir string, vrepl_prefix string) {
 						break
 					}
 				}
-				temp_source_code = r.current_source_code(true) + '\n$temp_line\n'
+				temp_source_code = r.current_source_code(true, true) + '\n$temp_line\n'
 			}
 			os.write_file(temp_file, temp_source_code) or { panic(err) }
 			s := repl_run_vfile(temp_file) or { return }


### PR DESCRIPTION
This PR introduces a new environment variable called `VSTARTUP` which takes `.v` file and run its content before the startup of the REPL plus it also goes inside the namespace of the current prompt This feature was inspired by Python's [`PYTHONSTARTUP`](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONSTARTUP) environment variable. 

It can be used in places where enabling/disabling of certain functionality or utility for the user's REPL experience. The `startup` file has to be same as a `.v` program, i.e. 

```v
a := 5 
a 
```
will not work the same as you do in the REPL.