### PR TITLE
gg/m4: fix unnecessary uses of [direct_array_access], add [unsafe]

### DIFF
--- a/vlib/gg/m4/graphic.v
+++ b/vlib/gg/m4/graphic.v
@@ -25,50 +25,44 @@ pub fn deg(grad f32) f32 {
 }
 
 // Calculate the perspective matrix
-[direct_array_access]
 pub fn perspective(fov f32, ar f32, n f32, f f32) Mat4 {
-	unsafe {
-		ctan := f32(1.0 / math.tan(fov * (f32(math.pi) / 360.0))) // for the FOV we use 360 instead 180
-		return Mat4{ e: [
-			ctan / ar, 	0,		0, 							0,
-				0,		ctan, 	0, 							0,
-				0,		0,		(n + f) / (n - f), 			-1.0,
-				0,		0, 		(2.0 * n * f) / (n - f), 	0,
-			]!
-		}
+	ctan := f32(1.0 / math.tan(fov * (f32(math.pi) / 360.0))) // for the FOV we use 360 instead 180
+	return Mat4{ e: [
+		ctan / ar, 	0,		0, 							0,
+			0,		ctan, 	0, 							0,
+			0,		0,		(n + f) / (n - f), 			-1.0,
+			0,		0, 		(2.0 * n * f) / (n - f), 	0,
+		]!
 	}
 }
 
 // Calculate the look-at matrix
-[direct_array_access]
 pub fn look_at(eye Vec4, center Vec4, up Vec4) Mat4 {
-	unsafe {
-		f := (center - eye).normalize3()
-		s := (f % up).normalize3()
-		u := (s % f)
+	f := (center - eye).normalize3()
+	s := (f % up).normalize3()
+	u := (s % f)
 
-		return Mat4{ e: [
-				/* [0][0] */ s.e[0],
-				/* [0][1] */ u.e[0],
-				/* [0][2] */ - f.e[0],
-				/* [0][3] */ 0,
+	return Mat4{ e: [
+			/* [0][0] */ s.e[0],
+			/* [0][1] */ u.e[0],
+			/* [0][2] */ - f.e[0],
+			/* [0][3] */ 0,
 
-				/* [1][1] */ s.e[1],
-				/* [1][1] */ u.e[1],
-				/* [1][2] */ - f.e[1],
-				/* [1][3] */ 0,
+			/* [1][1] */ s.e[1],
+			/* [1][1] */ u.e[1],
+			/* [1][2] */ - f.e[1],
+			/* [1][3] */ 0,
 
-				/* [2][0] */ s.e[2],
-				/* [2][1] */ u.e[2],
-				/* [2][2] */ - f.e[2],
-				/* [2][3] */ 0,
+			/* [2][0] */ s.e[2],
+			/* [2][1] */ u.e[2],
+			/* [2][2] */ - f.e[2],
+			/* [2][3] */ 0,
 
-				/* [3][0] */ - (s * eye),
-				/* [3][1] */ - (u * eye),
-				/* [3][2] */ f * eye,
-				/* [3][3] */ 1,
-			]!
-		}
+			/* [3][0] */ - (s * eye),
+			/* [3][1] */ - (u * eye),
+			/* [3][2] */ f * eye,
+			/* [3][3] */ 1,
+		]!
 	}
 }
 

--- a/vlib/gg/m4/matrix.v
+++ b/vlib/gg/m4/matrix.v
@@ -62,15 +62,12 @@ pub fn (a Mat4) clean() Mat4 {
 }
 
 // Sum all the elements of the matrix
-[direct_array_access]
 pub fn (x Mat4) sum_all() f32 {
-	unsafe {
-		res := f32(0)
-		for v in x.e {
-			res += v
-		}
-		return res
+	mut res := f32(0)
+	for v in unsafe { x.e } {
+		res += v
 	}
+	return res
 }
 
 // Check if two matrix are equal using module precision
@@ -118,7 +115,6 @@ pub fn (mut x Mat4) set_f(index_col int, index_row int, value f32) {
 }
 
 // Copy a matrix elements from another matrix
-[direct_array_access]
 pub fn (mut x Mat4) copy(y Mat4) {
 	unsafe {
 		x.e = [
@@ -131,7 +127,6 @@ pub fn (mut x Mat4) copy(y Mat4) {
 }
 
 // Set the trace of the matrix using a vec4
-[direct_array_access]
 pub fn (mut x Mat4) set_trace(v3 Vec4) {
 	unsafe {
 		x.e[0] = v3.e[0]
@@ -142,7 +137,6 @@ pub fn (mut x Mat4) set_trace(v3 Vec4) {
 }
 
 // Get the trace of the matrix
-[direct_array_access]
 pub fn (x Mat4) get_trace() Vec4 {
 	unsafe {
 		return Vec4{ e: [ x.e[0], x.e[5], x.e[10], x.e[15],	]! }
@@ -150,7 +144,6 @@ pub fn (x Mat4) get_trace() Vec4 {
 }
 
 // Set all the matrix elements to value
-[direct_array_access]
 pub fn (mut x Mat4) set_f32(value f32) {
 	unsafe {
 		x.e = [
@@ -169,6 +162,7 @@ pub fn (mut x Mat4) set_f32(value f32) {
 [direct_array_access]
 pub fn (mut x Mat4) set_row(row int, v3 Vec4) {
 	unsafe {
+		assert row * 4 + 3 < x.e.len
 		x.e[row * 4] = v3.e[0]
 		x.e[row * 4 + 1] = v3.e[1]
 		x.e[row * 4 + 2] = v3.e[2]
@@ -180,6 +174,7 @@ pub fn (mut x Mat4) set_row(row int, v3 Vec4) {
 [direct_array_access]
 pub fn (x Mat4) get_row(row int) Vec4 {
 	unsafe {
+		assert row >= 0 && row * 4 + 3 < x.e.len
 		return Vec4{
 			e: [
 				x.e[row * 4],
@@ -195,6 +190,7 @@ pub fn (x Mat4) get_row(row int) Vec4 {
 [direct_array_access]
 pub fn (mut x Mat4) set_col(col int, v3 Vec4) {
 	unsafe {
+		assert col >= 0 && col + 12 < x.e.len
 		x.e[col] = v3.e[0]
 		x.e[col + 4] = v3.e[1]
 		x.e[col + 8] = v3.e[2]
@@ -206,6 +202,7 @@ pub fn (mut x Mat4) set_col(col int, v3 Vec4) {
 [direct_array_access]
 pub fn (x Mat4) get_col(col int) Vec4 {
 	unsafe {
+		assert col >= 0 && col + 12 < x.e.len
 		return Vec4{
 			e: [
 				x.e[col],
@@ -221,6 +218,9 @@ pub fn (x Mat4) get_col(col int) Vec4 {
 [direct_array_access]
 pub fn (mut x Mat4) swap_col(col1 int, col2 int) {
 	unsafe {
+		assert col1 >= 0 && col1 + 12 < x.e.len
+		assert col2 >= 0 && col2 + 12 < x.e.len
+
 		v0 := x.e[col1]
 		v1 := x.e[col1 + 4]
 		v2 := x.e[col1 + 8]
@@ -242,6 +242,9 @@ pub fn (mut x Mat4) swap_col(col1 int, col2 int) {
 [direct_array_access]
 pub fn (mut x Mat4) swap_row(row1 int, row2 int) {
 	unsafe {
+		assert row1 >= 0 && row1 * 4 + 3 < x.e.len
+		assert row2 >= 0 && row2 * 4 + 3 < x.e.len
+
 		v0 := x.e[row1 * 4]
 		v1 := x.e[row1 * 4 + 1]
 		v2 := x.e[row1 * 4 + 2]
@@ -263,7 +266,6 @@ pub fn (mut x Mat4) swap_row(row1 int, row2 int) {
 // Modify data
 //-------------------------------------
 // Transpose the matrix
-[direct_array_access]
 pub fn (x Mat4) transpose() Mat4 {
 	unsafe {
 		return Mat4{ e: [
@@ -277,7 +279,6 @@ pub fn (x Mat4) transpose() Mat4 {
 }
 
 // Multiply the all the elements of the matrix by a scalar
-[direct_array_access]
 pub fn (x Mat4) mul_scalar(s f32) Mat4 {
 	unsafe {
 		return Mat4{ e: [
@@ -296,35 +297,28 @@ pub fn (x Mat4) mul_scalar(s f32) Mat4 {
 *
 *********************************************************************/
 // Return a zero matrix
-[direct_array_access]
 pub fn zero_m4() Mat4 {
-	unsafe {
-		return Mat4{ e: [
-			f32(0),	0,	0,	0,
-				0,	0,	0,	0,
-				0,	0,	0,	0,
-				0,	0,	0,	0,
-				]!
-		}
+	return Mat4{ e: [
+		f32(0),	0,	0,	0,
+			0,	0,	0,	0,
+			0,	0,	0,	0,
+			0,	0,	0,	0,
+			]!
 	}
 }
 
 // Return a unity matrix
-[direct_array_access]
 pub fn unit_m4() Mat4 {
-	unsafe {
-		return Mat4{ e: [
-				f32(1),	0,	0,	0,
-					0,	1,	0,	0,
-					0,	0,	1,	0,
-					0,	0,	0,	1,
-					]!
-		}
+	return Mat4{ e: [
+			f32(1),	0,	0,	0,
+				0,	1,	0,	0,
+				0,	0,	1,	0,
+				0,	0,	0,	1,
+				]!
 	}
 }
 
 // Return a matrix initialized with value
-[direct_array_access]
 pub fn set_m4(value f32) Mat4 {
 	return Mat4{ e: [
 			value, value, value, value,
@@ -342,7 +336,6 @@ pub fn set_m4(value f32) Mat4 {
 *********************************************************************/
 
 // Sum of matrix, operator +
-[direct_array_access]
 pub fn (a Mat4) + (b Mat4) Mat4 {
 	unsafe {
 		return Mat4{ e: [
@@ -356,7 +349,6 @@ pub fn (a Mat4) + (b Mat4) Mat4 {
 }
 
 // Subtraction of matrix, operator -
-[direct_array_access]
 pub fn (a Mat4) - (b Mat4) Mat4 {
 	unsafe {
 		return Mat4{ e: [
@@ -370,7 +362,6 @@ pub fn (a Mat4) - (b Mat4) Mat4 {
 }
 
 // Multiplication of matrix, operator *
-[direct_array_access]
 pub fn (a Mat4) * (b Mat4) Mat4 {
 	unsafe {
 		return Mat4{
@@ -421,7 +412,6 @@ pub fn mul(a Mat4, b Mat4) Mat4 {
 }
 
 // Multiply a Matrix by a vector
-[direct_array_access]
 pub fn mul_vec(a Mat4, v Vec4) Vec4 {
 	unsafe {
 		return Vec4{ e: [
@@ -435,7 +425,6 @@ pub fn mul_vec(a Mat4, v Vec4) Vec4 {
 }
 
 // Calculate the determinant of the Matrix
-[direct_array_access]
 pub fn det(x Mat4) f32 {
 	unsafe {
 		mut t := [6]f32{}
@@ -472,7 +461,6 @@ pub fn det(x Mat4) f32 {
 }
 
 // Calculate the inverse of the Matrix
-[direct_array_access]
 pub fn (x Mat4) inverse() Mat4 {
 	unsafe {
 		mut t := [6]f32{}
@@ -538,11 +526,9 @@ pub fn (x Mat4) inverse() Mat4 {
 		dest.f[3][3] = a * t[2] - b * t[4] + c * t[5]
 
 		tmp := (a * dest.f[0][0] + b * dest.f[0][1] + c * dest.f[0][2] + d * dest.f[0][3])
-
 		if tmp != 0 {
 			det = f32(1.0) / tmp
 		}
-
 		return dest.mul_scalar(det)
 	}
 }
@@ -554,13 +540,12 @@ pub fn (x Mat4) inverse() Mat4 {
 *********************************************************************/
 
 // Get a rotation matrix using w as rotation axis vector, the angle is in radians
-[direct_array_access]
 pub fn rotate(angle f32, w Vec4) Mat4 {
+	cs := f32(math.cos(angle))
+	sn := f32(math.sin(angle))
+	cv := f32(1.0) - cs
+	axis := w.normalize3()
 	unsafe {
-		cs := f32(math.cos(angle))
-		sn := f32(math.sin(angle))
-		cv := f32(1.0) - cs
-		axis := w.normalize3()
 		ax := axis.e[0]
 		ay := axis.e[1]
 		az := axis.e[2]
@@ -596,7 +581,6 @@ pub fn rotate(angle f32, w Vec4) Mat4 {
 *
 *********************************************************************/
 // Get a matrix translated by a vector w
-[direct_array_access]
 pub fn (x Mat4) translate(w Vec4) Mat4 {
 	unsafe {
 		return Mat4{ e: [
@@ -610,7 +594,6 @@ pub fn (x Mat4) translate(w Vec4) Mat4 {
 }
 
 // Get a scale matrix, the scale vector is w, only xyz are evaluated.
-[direct_array_access]
 pub fn scale(w Vec4) Mat4 {
 	unsafe {
 		return Mat4{ e: [

--- a/vlib/gg/m4/matrix.v
+++ b/vlib/gg/m4/matrix.v
@@ -160,9 +160,9 @@ pub fn (mut x Mat4) set_f32(value f32) {
 //-------------------------------------
 // Set the row as the input vec4
 [direct_array_access]
+[unsafe]
 pub fn (mut x Mat4) set_row(row int, v3 Vec4) {
 	unsafe {
-		assert row * 4 + 3 < x.e.len
 		x.e[row * 4] = v3.e[0]
 		x.e[row * 4 + 1] = v3.e[1]
 		x.e[row * 4 + 2] = v3.e[2]
@@ -172,9 +172,9 @@ pub fn (mut x Mat4) set_row(row int, v3 Vec4) {
 
 // Get a row from a matrix
 [direct_array_access]
+[unsafe]
 pub fn (x Mat4) get_row(row int) Vec4 {
 	unsafe {
-		assert row >= 0 && row * 4 + 3 < x.e.len
 		return Vec4{
 			e: [
 				x.e[row * 4],
@@ -188,9 +188,9 @@ pub fn (x Mat4) get_row(row int) Vec4 {
 
 // Set the column as the input vec4
 [direct_array_access]
+[unsafe]
 pub fn (mut x Mat4) set_col(col int, v3 Vec4) {
 	unsafe {
-		assert col >= 0 && col + 12 < x.e.len
 		x.e[col] = v3.e[0]
 		x.e[col + 4] = v3.e[1]
 		x.e[col + 8] = v3.e[2]
@@ -200,9 +200,9 @@ pub fn (mut x Mat4) set_col(col int, v3 Vec4) {
 
 // Get a column from a matrix
 [direct_array_access]
+[unsafe]
 pub fn (x Mat4) get_col(col int) Vec4 {
 	unsafe {
-		assert col >= 0 && col + 12 < x.e.len
 		return Vec4{
 			e: [
 				x.e[col],
@@ -216,11 +216,9 @@ pub fn (x Mat4) get_col(col int) Vec4 {
 
 // Swap two columns in the matrix
 [direct_array_access]
+[unsafe]
 pub fn (mut x Mat4) swap_col(col1 int, col2 int) {
 	unsafe {
-		assert col1 >= 0 && col1 + 12 < x.e.len
-		assert col2 >= 0 && col2 + 12 < x.e.len
-
 		v0 := x.e[col1]
 		v1 := x.e[col1 + 4]
 		v2 := x.e[col1 + 8]
@@ -240,11 +238,9 @@ pub fn (mut x Mat4) swap_col(col1 int, col2 int) {
 
 // Swap two rows in the matrix
 [direct_array_access]
+[unsafe]
 pub fn (mut x Mat4) swap_row(row1 int, row2 int) {
 	unsafe {
-		assert row1 >= 0 && row1 * 4 + 3 < x.e.len
-		assert row2 >= 0 && row2 * 4 + 3 < x.e.len
-
 		v0 := x.e[row1 * 4]
 		v1 := x.e[row1 * 4 + 1]
 		v2 := x.e[row1 * 4 + 2]

--- a/vlib/gg/m4/vector.v
+++ b/vlib/gg/m4/vector.v
@@ -29,33 +29,28 @@ pub fn (x Vec4) str() string {
 // Remove all the raw zeros
 [direct_array_access]
 pub fn (a Vec4) clean() Vec4 {
-	unsafe {
-		x := Vec4{}
-		for c, value in a.e {
-			if abs(value) < precision {
-				x.e[c] = 0
-			} else {
-				x.e[c] = value
-			}
+	mut x := Vec4{}
+	for c, value in a.e {
+		if abs(value) < precision {
+			x.e[c] = 0
+		} else {
+			x.e[c] = value
 		}
-		return x
 	}
+	return x
 }
 
 // Set all elements to value
-[direct_array_access]
 pub fn (mut x Vec4) copy(value f32) {
 	x.e = [ value, value, value, value,	]!
 }
 
 // Scale the vector using a scalar
-[direct_array_access]
 pub fn (x Vec4) mul_scalar(value f32) Vec4 {
 	return Vec4{ e: [ x.e[0] * value, x.e[1] * value,  x.e[2] * value, x.e[3] * value, ]! }
 }
 
 // Reciprocal of the vector
-[direct_array_access]
 pub fn (x Vec4) inv() Vec4 {
 	return Vec4{
 		e: [
@@ -68,7 +63,6 @@ pub fn (x Vec4) inv() Vec4 {
 }
 
 // Normalize the vector
-[direct_array_access]
 pub fn (x Vec4) normalize() Vec4 {
 	m := x.mod()
 	if m == 0 {
@@ -85,7 +79,6 @@ pub fn (x Vec4) normalize() Vec4 {
 }
 
 // Normalize only xyz, w set to 0
-[direct_array_access]
 pub fn (x Vec4) normalize3() Vec4 {
 	m := x.mod3()
 	if m == 0 {
@@ -102,13 +95,11 @@ pub fn (x Vec4) normalize3() Vec4 {
 }
 
 // Module of the vector xyzw
-[direct_array_access]
 pub fn (x Vec4) mod() f32 {
 	return f32(math.sqrt(x.e[0] * x.e[0] + x.e[1] * x.e[1] + x.e[2] * x.e[2] + x.e[3] * x.e[3]))
 }
 
 // Module for 3d vector xyz, w ignored
-[direct_array_access]
 pub fn (x Vec4) mod3() f32 {
 	return f32(math.sqrt(x.e[0] * x.e[0] + x.e[1] * x.e[1] + x.e[2] * x.e[2]))
 }
@@ -119,7 +110,6 @@ pub fn (x Vec4) mod3() f32 {
 *
 *********************************************************************/
 // Return a zero vector
-[direct_array_access]
 pub fn zero_v4() Vec4 {
 	return Vec4{
 		e: [
@@ -132,7 +122,6 @@ pub fn zero_v4() Vec4 {
 }
 
 // Return all one vector
-[direct_array_access]
 pub fn one_v4() Vec4 {
 	return Vec4{
 		e: [
@@ -145,7 +134,6 @@ pub fn one_v4() Vec4 {
 }
 
 // Return a blank vector
-[direct_array_access]
 pub fn blank_v4() Vec4 {
 	return Vec4{
 		e: [
@@ -158,7 +146,6 @@ pub fn blank_v4() Vec4 {
 }
 
 // Set all elements to value
-[direct_array_access]
 pub fn set_v4(value f32) Vec4 {
 	return Vec4{
 		e: [
@@ -171,7 +158,6 @@ pub fn set_v4(value f32) Vec4 {
 }
 
 // Sum of all the elements
-[direct_array_access]
 pub fn (x Vec4) sum() f32 {
 	return x.e[0] + x.e[1] + x.e[2] + x.e[3]
 }
@@ -182,7 +168,6 @@ pub fn (x Vec4) sum() f32 {
 *
 *********************************************************************/
 // Addition
-[direct_array_access]
 pub fn (a Vec4) + (b Vec4) Vec4 {
 	return Vec4{
 		e: [
@@ -195,7 +180,6 @@ pub fn (a Vec4) + (b Vec4) Vec4 {
 }
 
 // Subtraction
-[direct_array_access]
 pub fn (a Vec4) - (b Vec4) Vec4 {
 	return Vec4{
 		e: [
@@ -208,13 +192,11 @@ pub fn (a Vec4) - (b Vec4) Vec4 {
 }
 
 // Dot product
-[direct_array_access]
 pub fn (a Vec4) * (b Vec4) f32 {
 	return a.e[0] * b.e[0] + a.e[1] * b.e[1] + a.e[2] * b.e[2] + a.e[3] * b.e[3]
 }
 
 // Cross product
-[direct_array_access]
 pub fn (a Vec4) % (b Vec4) Vec4 {
 	return Vec4{
 		e: [
@@ -227,7 +209,6 @@ pub fn (a Vec4) % (b Vec4) Vec4 {
 }
 
 // Components multiplication
-[direct_array_access]
 pub fn (x Vec4) mul_vec4(y Vec4) Vec4 {
 	return Vec4{
 		e: [


### PR DESCRIPTION
Remove `[direct_array_access]` with fixed array and literal indexing (and in some cases no indexing at all).
~~Add asserts to avoid buffer overflows for runtime indexes.~~ Mark those functions `[unsafe]`.
Also remove/rescope some `unsafe` blocks.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
