### PR TITLE
checker: disallow use of non-public methods of builtin types

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1472,8 +1472,8 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 		}
 	}
 	if has_method {
-		if !method.is_pub && !c.is_builtin_mod && !c.pref.is_test && left_type_sym.mod != c.mod
-			&& left_type_sym.mod != '' { // method.mod != c.mod {
+		//if !method.is_pub && !c.is_builtin_mod && !c.pref.is_test && left_type_sym.mod != c.mod
+		if !method.is_pub && !c.is_builtin_mod && !c.pref.is_test && method.mod != c.mod { // method.mod != c.mod {
 			// If a private method is called outside of the module
 			// its receiver type is defined in, show an error.
 			// println('warn $method_name lef.mod=$left_type_sym.mod c.mod=$c.mod')
@@ -1824,7 +1824,7 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 				call_expr.pos)
 		}
 	}
-	if !f.is_pub && f.language == .v && f.name.len > 0 && f.mod.len > 0 && f.mod != c.mod {
+	if !f.is_pub && f.language == .v && (f.name.len > 0 && f.mod.len > 0) && f.mod != c.mod {
 		c.error('function `$f.name` is private, so you can not import it in module `$c.mod`',
 			call_expr.pos)
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1823,7 +1823,7 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 				call_expr.pos)
 		}
 	}
-	if !f.is_pub && f.language == .v && (f.name.len > 0 && f.mod.len > 0) && f.mod != c.mod {
+	if !f.is_pub && f.language == .v && f.name.len > 0 && f.mod.len > 0 && f.mod != c.mod {
 		c.error('function `$f.name` is private, so you can not import it in module `$c.mod`',
 			call_expr.pos)
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1472,8 +1472,7 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 		}
 	}
 	if has_method {
-		//if !method.is_pub && !c.is_builtin_mod && !c.pref.is_test && left_type_sym.mod != c.mod
-		if !method.is_pub && !c.is_builtin_mod && !c.pref.is_test && method.mod != c.mod { // method.mod != c.mod {
+		if !method.is_pub && !c.is_builtin_mod && !c.pref.is_test && method.mod != c.mod {
 			// If a private method is called outside of the module
 			// its receiver type is defined in, show an error.
 			// println('warn $method_name lef.mod=$left_type_sym.mod c.mod=$c.mod')

--- a/vlib/v/checker/tests/use_non-public_methods_outside_the_builtin_module.out
+++ b/vlib/v/checker/tests/use_non-public_methods_outside_the_builtin_module.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/use_non-public_methods_outside_the_builtin_module.vv:5:13: error: method `map[string]string.exists_1` is private
+    3 | fn main() {
+    4 |     mp := map{'key': 'value'}
+    5 |     println(mp.exists_1('key'))
+      |                ~~~~~~~~~~~~~~~
+    6 | }

--- a/vlib/v/checker/tests/use_non-public_methods_outside_the_builtin_module.vv
+++ b/vlib/v/checker/tests/use_non-public_methods_outside_the_builtin_module.vv
@@ -1,0 +1,6 @@
+module main
+
+fn main() {
+	mp := map{'key': 'value'}
+	println(mp.exists_1('key'))
+}


### PR DESCRIPTION
This PR does not allow the use of non-public methods of types that are declared in the builtin module.

The cause of this failure is strange, it turns out that this comparison was originally used:
```v
if !method.is_pub && !c.is_builtin_mod && !c.pref.is_test && left_type_sym.mod != c.mod
```

To fix this, I have changed `left_type_sym.mod` to `method.mod`:

```v
if !method.is_pub && !c.is_builtin_mod && !c.pref.is_test && method.mod != c.mod
```

And now we get this :D:

```
mod_fnpriv/mod_fnpriv.v:9:13: error: method `map[string]string.exists_1` is private
    7 |     //mod.say("Reality!")
    8 |     ma := map{'': ''}
    9 |     println(ma.exists_1('key'))
      |                ~~~~~~~~~~~~~~~
   10 | }
```