### PR TITLE
checker: check private built-in methods are not accessible

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1472,8 +1472,7 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 		}
 	}
 	if has_method {
-		if !method.is_pub && !c.is_builtin_mod && !c.pref.is_test && left_type_sym.mod != c.mod
-			&& left_type_sym.mod != '' { // method.mod != c.mod {
+		if !method.is_pub && !c.pref.is_test && method.mod != c.mod {
 			// If a private method is called outside of the module
 			// its receiver type is defined in, show an error.
 			// println('warn $method_name lef.mod=$left_type_sym.mod c.mod=$c.mod')
@@ -1825,8 +1824,7 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 		}
 	}
 	if !f.is_pub && f.language == .v && f.name.len > 0 && f.mod.len > 0 && f.mod != c.mod {
-		c.error('function `$f.name` is private, so you can not import it in module `$c.mod`',
-			call_expr.pos)
+		c.error('function `$f.name` is private', call_expr.pos)
 	}
 	if !c.cur_fn.is_deprecated && f.is_deprecated {
 		mut deprecation_message := 'function `$f.name` has been deprecated'

--- a/vlib/v/checker/tests/import_symbol_fn_private_err.out
+++ b/vlib/v/checker/tests/import_symbol_fn_private_err.out
@@ -3,9 +3,16 @@ vlib/v/checker/tests/import_symbol_fn_private_err.vv:1:20: error: module `time` 
       |                    ~~~~~
     2 | fn main() {
     3 |   since(now())
-vlib/v/checker/tests/import_symbol_fn_private_err.vv:3:3: error: function `time.since` is private, so you can not import it in module `main`
+vlib/v/checker/tests/import_symbol_fn_private_err.vv:3:3: error: function `time.since` is private
     1 | import time { now, since }
     2 | fn main() {
     3 |   since(now())
       |   ~~~~~~~~~~~~
     4 | }
+    5 |
+vlib/v/checker/tests/import_symbol_fn_private_err.vv:7:20: error: method `map[string]int.exists_1` is private
+    5 | 
+    6 | fn method() {
+    7 |     _ = map{'h':2}.exists_1('h')
+      |                    ~~~~~~~~~~~~~
+    8 | }

--- a/vlib/v/checker/tests/import_symbol_fn_private_err.vv
+++ b/vlib/v/checker/tests/import_symbol_fn_private_err.vv
@@ -2,3 +2,7 @@ import time { now, since }
 fn main() {
   since(now())
 }
+
+fn method() {
+    _ = map{'h':2}.exists_1('h')
+}


### PR DESCRIPTION
Also fix a confusing error message about importing when *calling* a private function. Note that *importing* a private function does still error (at the top of the updated test file).
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
