### PR TITLE
fmt: do not insert a newline before returned $vweb.html()

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1140,6 +1140,7 @@ pub:
 	has_parens bool // if $() is used, for vfmt
 	left       Expr
 	field_expr Expr
+	pos        token.Position
 pub mut:
 	left_type table.Type
 	typ       table.Type
@@ -1147,6 +1148,7 @@ pub mut:
 
 pub struct ComptimeCall {
 pub:
+	pos         token.Position
 	has_parens  bool // if $() is used, for vfmt
 	method_name string
 	method_pos  token.Position
@@ -1233,7 +1235,7 @@ pub fn (expr Expr) position() token.Position {
 			return expr.decl.pos
 		}
 		ArrayDecompose, ArrayInit, AsCast, Assoc, AtExpr, BoolLiteral, CallExpr, CastExpr, ChanInit,
-		CharLiteral, ConcatExpr, Comment, EnumVal, FloatLiteral, GoExpr, Ident, IfExpr, IndexExpr,
+		CharLiteral, ConcatExpr, Comment, ComptimeCall, ComptimeSelector, EnumVal, FloatLiteral, GoExpr, Ident, IfExpr, IndexExpr,
 		IntegerLiteral, Likely, LockExpr, MapInit, MatchExpr, None, OffsetOf, OrExpr, ParExpr,
 		PostfixExpr, PrefixExpr, RangeExpr, SelectExpr, SelectorExpr, SizeOf, SqlExpr, StringInterLiteral,
 		StringLiteral, StructInit, Type, TypeOf, UnsafeExpr {
@@ -1241,9 +1243,6 @@ pub fn (expr Expr) position() token.Position {
 		}
 		IfGuardExpr {
 			return expr.expr.position()
-		}
-		ComptimeCall, ComptimeSelector {
-			return expr.left.position()
 		}
 		InfixExpr {
 			left_pos := expr.left.position()

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1235,10 +1235,11 @@ pub fn (expr Expr) position() token.Position {
 			return expr.decl.pos
 		}
 		ArrayDecompose, ArrayInit, AsCast, Assoc, AtExpr, BoolLiteral, CallExpr, CastExpr, ChanInit,
-		CharLiteral, ConcatExpr, Comment, ComptimeCall, ComptimeSelector, EnumVal, FloatLiteral, GoExpr, Ident, IfExpr, IndexExpr,
-		IntegerLiteral, Likely, LockExpr, MapInit, MatchExpr, None, OffsetOf, OrExpr, ParExpr,
-		PostfixExpr, PrefixExpr, RangeExpr, SelectExpr, SelectorExpr, SizeOf, SqlExpr, StringInterLiteral,
-		StringLiteral, StructInit, Type, TypeOf, UnsafeExpr {
+		CharLiteral, ConcatExpr, Comment, ComptimeCall, ComptimeSelector, EnumVal, FloatLiteral,
+		GoExpr, Ident, IfExpr, IndexExpr, IntegerLiteral, Likely, LockExpr, MapInit, MatchExpr,
+		None, OffsetOf, OrExpr, ParExpr, PostfixExpr, PrefixExpr, RangeExpr, SelectExpr, SelectorExpr,
+		SizeOf, SqlExpr, StringInterLiteral, StringLiteral, StructInit, Type, TypeOf, UnsafeExpr
+		 {
 			return expr.pos
 		}
 		IfGuardExpr {

--- a/vlib/v/fmt/tests/comptime_keep.vv
+++ b/vlib/v/fmt/tests/comptime_keep.vv
@@ -1,3 +1,5 @@
+import vweb
+
 struct App {
 	a string
 	b string
@@ -57,8 +59,7 @@ fn comptime_for_fields() {
 	}
 }
 
-struct Result {
-}
+struct Result {}
 
 fn (mut a App) my_method(p string) Result {
 	println('>>>> ${@FN} | p: $p')
@@ -79,6 +80,10 @@ fn handle_conn<T>(mut app T) {
 fn comptime_call_dollar_method() {
 	mut app := App{}
 	handle_conn<App>(mut app)
+}
+
+fn (mut app App) create() vweb.Result {
+	return $vweb.html()
 }
 
 fn main() {

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -47,6 +47,7 @@ fn (mut p Parser) comp_call() ast.ComptimeCall {
 		scope: 0
 	}
 	p.check(.dollar)
+	start_pos := p.prev_tok.position()
 	error_msg := 'only `\$tmpl()`, `\$env()`, `\$embed_file()` and `\$vweb.html()` comptime functions are supported right now'
 	if p.peek_tok.kind == .dot {
 		n := p.check_name() // skip `vweb.html()` TODO
@@ -211,6 +212,7 @@ fn (mut p Parser) comp_call() ast.ComptimeCall {
 		vweb_tmpl: file
 		method_name: n
 		args_var: literal_string_param
+		pos: start_pos.extend(p.prev_tok.position())
 	}
 }
 
@@ -288,6 +290,7 @@ fn (mut p Parser) at() ast.AtExpr {
 
 fn (mut p Parser) comptime_selector(left ast.Expr) ast.Expr {
 	p.check(.dollar)
+	start_pos := p.prev_tok.position()
 	if p.peek_tok.kind == .lpar {
 		method_pos := p.tok.position()
 		method_name := p.check_name()
@@ -311,6 +314,7 @@ fn (mut p Parser) comptime_selector(left ast.Expr) ast.Expr {
 			method_pos: method_pos
 			scope: p.scope
 			args_var: args_var
+			pos: start_pos.extend(p.prev_tok.position())
 		}
 	}
 	mut has_parens := false
@@ -328,5 +332,6 @@ fn (mut p Parser) comptime_selector(left ast.Expr) ast.Expr {
 		has_parens: has_parens
 		left: left
 		field_expr: expr
+		pos: start_pos.extend(p.prev_tok.position())
 	}
 }

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -147,6 +147,14 @@ fn (mut p Parser) comp_call() ast.ComptimeCall {
 			path += '.html'
 		}
 		if !os.exists(path) {
+			if p.pref.is_fmt {
+				return ast.ComptimeCall{
+					scope: 0
+					is_vweb: true
+					method_name: n
+					pos: start_pos.extend(p.prev_tok.position())
+				}
+			}
 			if is_html {
 				p.error('vweb HTML template "$path" not found')
 			} else {


### PR DESCRIPTION
The cause was wrong position information. Therefore I added a proper pos field to ComptimeCall and ComptimeSelector.