### PR TITLE
checker/cgen: enable `IfGuardExpr` for `a[k]` and `<-ch`

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -108,6 +108,7 @@ const (
 		'vlib/v/tests/go_call_generic_fn_test.v',
 		'vlib/v/tests/generics_test.v',
 		'vlib/v/tests/go_wait_2_test.v',
+		'vlib/v/tests/if_guard_test.v',
 		'vlib/v/tests/in_expression_test.v',
 		'vlib/v/tests/interface_edge_cases/assign_to_interface_field_test.v',
 		'vlib/v/tests/interface_fields_test.v',

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1036,9 +1036,9 @@ pub mut:
 pub struct IfGuardExpr {
 pub:
 	var_name string
-	expr     Expr
 	pos      token.Position
 pub mut:
+	expr      Expr
 	expr_type table.Type
 }
 

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -619,6 +619,7 @@ pub mut:
 	is_map    bool
 	is_array  bool
 	is_farray bool
+	is_option bool // IfGuard
 }
 
 pub struct IfExpr {

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -600,11 +600,12 @@ pub mut:
 pub struct PrefixExpr {
 pub:
 	op    token.Kind
-	right Expr
 	pos   token.Position
 pub mut:
 	right_type table.Type
+	right      Expr
 	or_block   OrExpr
+	is_option  bool // IfGuard
 }
 
 pub struct IndexExpr {

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -599,8 +599,8 @@ pub mut:
 // See: token.Kind.is_prefix
 pub struct PrefixExpr {
 pub:
-	op    token.Kind
-	pos   token.Position
+	op  token.Kind
+	pos token.Position
 pub mut:
 	right_type table.Type
 	right      Expr

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3747,7 +3747,18 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 		ast.IfGuardExpr {
 			node.expr_type = c.expr(node.expr)
 			if !node.expr_type.has_flag(.optional) {
-				c.error('expression should return an option', node.expr.position())
+				mut no_opt := true
+				match mut node.expr {
+					ast.IndexExpr {
+						no_opt = false
+						node.expr_type = node.expr_type.set_flag(.optional)
+						node.expr.is_option = true
+					}
+					else {}
+				}
+				if no_opt {
+					c.error('expression should return an option', node.expr.position())
+				}
 			}
 			return table.bool_type
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3754,6 +3754,13 @@ pub fn (mut c Checker) expr(node ast.Expr) table.Type {
 						node.expr_type = node.expr_type.set_flag(.optional)
 						node.expr.is_option = true
 					}
+					ast.PrefixExpr {
+						if node.expr.op == .arrow {
+							no_opt = false
+							node.expr_type = node.expr_type.set_flag(.optional)
+							node.expr.is_option = true
+						}
+					}
 					else {}
 				}
 				if no_opt {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4181,6 +4181,7 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 					if var_name == '' {
 						short_opt = true // we don't need a further tmp, so use the one we'll get later
 						var_name = g.new_tmp_var()
+						guard_vars[i] = var_name // for `else`
 						g.tmp_count--
 						g.writeln('if (${var_name}.state == 0) {')
 					} else {

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -287,7 +287,7 @@ fn (mut g Gen) index_of_fixed_array(node ast.IndexExpr, sym table.TypeSymbol) {
 }
 
 fn (mut g Gen) index_of_map(node ast.IndexExpr, sym table.TypeSymbol) {
-	gen_or := node.or_expr.kind != .absent
+	gen_or := node.or_expr.kind != .absent || node.is_option
 	left_is_ptr := node.left_type.is_ptr()
 	info := sym.info as table.Map
 	key_type_str := g.typ(info.key_type)
@@ -414,7 +414,9 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym table.TypeSymbol) {
 			g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = (Error){.msg=_SLIT("array index out of range"), .code=0};')
 
 			g.writeln('}')
-			g.or_block(tmp_opt, node.or_expr, elem_type)
+			if !node.is_option {
+				g.or_block(tmp_opt, node.or_expr, elem_type)
+			}
 			g.write('\n$cur_line*($elem_type_str*)${tmp_opt}.data')
 		}
 	}

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -92,7 +92,7 @@ fn (mut g Gen) range_expr(node ast.IndexExpr, range ast.RangeExpr) {
 }
 
 fn (mut g Gen) index_of_array(node ast.IndexExpr, sym table.TypeSymbol) {
-	gen_or := node.or_expr.kind != .absent
+	gen_or := node.or_expr.kind != .absent || node.is_option
 	left_is_ptr := node.left_type.is_ptr()
 	info := sym.info as table.Array
 	elem_type_str := g.typ(info.elem_type)
@@ -248,7 +248,9 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym table.TypeSymbol) {
 			g.writeln('} else {')
 			g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = (Error){.msg=_SLIT("array index out of range"), .code=0};')
 			g.writeln('}')
-			g.or_block(tmp_opt, node.or_expr, elem_type)
+			if !node.is_option {
+				g.or_block(tmp_opt, node.or_expr, elem_type)
+			}
 			g.write('\n$cur_line*($elem_type_str*)${tmp_opt}.data')
 		}
 	}

--- a/vlib/v/tests/if_guard_test.v
+++ b/vlib/v/tests/if_guard_test.v
@@ -1,0 +1,61 @@
+fn f(n int) ?f64 {
+	if n < 0 {
+		return error('negative')
+	}
+	return 1.5 * f64(n)
+}
+
+fn test_fn_return() {
+	mut res := []f64{cap:2}
+	for m in [-3, 5] {
+		if x := f(m) {
+			res << x
+		} else {
+			res << 31.0
+		}
+	}
+	assert res == [31.0, 7.5]
+}
+
+fn test_map_get() {
+	mut m := {'xy': 5, 'zu': 7}
+	mut res := []int{cap:2}
+	for k in ['jk', 'zu'] {
+		if x := m[k] {
+			res << x
+		} else {
+			res << -17
+		}
+	}
+	assert res == [-17, 7]
+}
+
+fn test_array_get() {
+	mut a := [12.5, 6.5, -17.25]
+	mut res := []f64{cap:2}
+	for i in [1, 4] {
+		if x := a[i] {
+			res << x
+		} else {
+			res << -23.0
+		}
+	}
+	assert res == [6.5, -23.0]
+}
+
+fn test_chan_pop() {
+	mut res := []f64{cap:3}
+	ch := chan f64{cap: 10}
+	ch <- 6.75
+	ch <- -3.25
+	ch.close()
+	for _ in 0 .. 3 {
+		if x:= <-ch {
+			res << x
+		} else {
+			res << -37.5
+		}
+	}
+	assert res == [6.75, -3.25, -37.5]
+}
+


### PR DESCRIPTION
This PR enables using index expressions and channel pop expressions to be used in it-guard expressions:
```v
if x := a[i] { ... } else { /* array index out of range */ ... }
if x := m[key] { ... } else { /* key not present in map */ ... }
if x:= <-ch { ... } else { /* channel was closed and queue is empty */ ... }
```
This syntax has already been available for call expressions that return optionals:
```v
if x:= f() { ... } else { /* no valid function result */ ... }
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
