### PR TITLE
fmt: keep empty lines in const blocks 

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2445,7 +2445,11 @@ pub fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 	for i, field in node.fields {
 		// TODO Check const name once the syntax is decided
 		if field.name in c.const_names {
-			c.error('duplicate const `$field.name`', field.pos)
+			name_pos := token.Position{
+				...field.pos
+				len: util.no_cur_mod(field.name, c.mod).len
+			}
+			c.error('duplicate const `$field.name`', name_pos)
 		}
 		c.const_names << field.name
 		field_names << field.name

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2250,6 +2250,7 @@ pub fn (mut f Fmt) const_decl(it ast.ConstDecl) {
 		}
 	}
 	f.indent++
+	mut prev_field := if it.fields.len > 0 { it.fields[0]} else{ast.ConstField{}}
 	for field in it.fields {
 		comments := field.comments
 		mut j := 0
@@ -2258,12 +2259,16 @@ pub fn (mut f Fmt) const_decl(it ast.ConstDecl) {
 			f.writeln('')
 			j++
 		}
+		if j == 0 && f.should_insert_newline_before_node(field, prev_field) {
+			f.writeln('')
+		}
 		name := field.name.after('.')
 		f.write('$name ')
 		f.write(strings.repeat(` `, max - field.name.len))
 		f.write('= ')
 		f.expr(field.expr)
 		f.writeln('')
+		prev_field = field
 	}
 	f.comments_after_last_field(it.end_comments)
 	f.indent--

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2250,7 +2250,7 @@ pub fn (mut f Fmt) const_decl(it ast.ConstDecl) {
 		}
 	}
 	f.indent++
-	mut prev_field := if it.fields.len > 0 { ast.Node(it.fields[0])} else{ast.Node{}}
+	mut prev_field := if it.fields.len > 0 { ast.Node(it.fields[0]) } else { ast.Node{} }
 	for field in it.fields {
 		if field.comments.len > 0 {
 			if f.should_insert_newline_before_node(ast.Expr(field.comments[0]), prev_field) {
@@ -2262,7 +2262,6 @@ pub fn (mut f Fmt) const_decl(it ast.ConstDecl) {
 		if f.should_insert_newline_before_node(field, prev_field) {
 			f.writeln('')
 		}
-		// println(field.pos)
 		name := field.name.after('.')
 		f.write('$name ')
 		f.write(strings.repeat(` `, max - field.name.len))

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2250,18 +2250,19 @@ pub fn (mut f Fmt) const_decl(it ast.ConstDecl) {
 		}
 	}
 	f.indent++
-	mut prev_field := if it.fields.len > 0 { it.fields[0]} else{ast.ConstField{}}
+	mut prev_field := if it.fields.len > 0 { ast.Node(it.fields[0])} else{ast.Node{}}
 	for field in it.fields {
-		comments := field.comments
-		mut j := 0
-		for j < comments.len && comments[j].pos.pos < field.pos.pos {
-			f.comment(comments[j], inline: true)
-			f.writeln('')
-			j++
+		if field.comments.len > 0 {
+			if f.should_insert_newline_before_node(ast.Expr(field.comments[0]), prev_field) {
+				f.writeln('')
+			}
+			f.comments(field.comments, inline: true)
+			prev_field = ast.Expr(field.comments.last())
 		}
-		if j == 0 && f.should_insert_newline_before_node(field, prev_field) {
+		if f.should_insert_newline_before_node(field, prev_field) {
 			f.writeln('')
 		}
+		// println(field.pos)
 		name := field.name.after('.')
 		f.write('$name ')
 		f.write(strings.repeat(` `, max - field.name.len))

--- a/vlib/v/fmt/tests/empty_lines_keep.vv
+++ b/vlib/v/fmt/tests/empty_lines_keep.vv
@@ -1,14 +1,16 @@
 // Keep empty lines in const blocks
 const (
-	a = 1
-
-	b = 2
-	c = SomeStruct{
-		val: 3
+	_ = SomeStruct{
+		val: 'Multiline field exprs should cause no problems'
 	}
-	d = 4
+	_ = 456
+
+	_ = 'Keep this empty line before'
 	// Comment before a field
-	e = 5
+	_ = 123
+
+	// The empty line above should stay too
+	_ = 789
 )
 
 fn keep_single_empty_line() {

--- a/vlib/v/fmt/tests/empty_lines_keep.vv
+++ b/vlib/v/fmt/tests/empty_lines_keep.vv
@@ -3,14 +3,22 @@ const (
 	_ = SomeStruct{
 		val: 'Multiline field exprs should cause no problems'
 	}
-	_ = 456
+	_ = 1
 
 	_ = 'Keep this empty line before'
 	// Comment before a field
-	_ = 123
+	_ = 2
 
 	// The empty line above should stay too
-	_ = 789
+	_ = 3
+
+	// This comment doesn't really belong anywhere
+
+	_ = 'A multiline string with a StringInterLiteral...
+	$foo
+	...and the ending brace on a newline had a wrong pos.last_line.
+	'
+	_ = 4
 )
 
 fn keep_single_empty_line() {

--- a/vlib/v/fmt/tests/empty_lines_keep.vv
+++ b/vlib/v/fmt/tests/empty_lines_keep.vv
@@ -1,3 +1,16 @@
+// Keep empty lines in const blocks
+const (
+	a = 1
+
+	b = 2
+	c = SomeStruct{
+		val: 3
+	}
+	d = 4
+	// Comment before a field
+	e = 5
+)
+
 fn keep_single_empty_line() {
 	println('a')
 	println('b')

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1772,7 +1772,7 @@ fn (mut p Parser) string_expr() ast.Expr {
 		fills: fills
 		fmts: fmts
 		fmt_poss: fposs
-		pos: pos
+		pos: pos.extend(p.prev_tok.position())
 	}
 	// need_fmts: prelimery - until checker finds out if really needed
 	p.inside_str_interp = false
@@ -2012,12 +2012,6 @@ fn (mut p Parser) const_decl() ast.ConstDecl {
 	const_pos := p.tok.position()
 	p.check(.key_const)
 	is_block := p.tok.kind == .lpar
-	/*
-	if p.tok.kind != .lpar {
-		p.error_with_pos('const declaration is missing parentheses `( ... )`', const_pos)
-		return ast.ConstDecl{}
-	}
-	*/
 	if is_block {
 		p.next() // (
 	}
@@ -2039,8 +2033,6 @@ fn (mut p Parser) const_decl() ast.ConstDecl {
 				pos)
 		}
 		full_name := p.prepend_mod(name)
-		// name := p.check_name()
-		// println('!!const: $name')
 		p.check(.assign)
 		if p.tok.kind == .key_fn {
 			p.error('const initializer fn literal is not a constant')

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2052,7 +2052,7 @@ fn (mut p Parser) const_decl() ast.ConstDecl {
 			mod: p.mod
 			is_pub: is_pub
 			expr: expr
-			pos: pos
+			pos: pos.extend(expr.position())
 			comments: comments
 		}
 		fields << field


### PR DESCRIPTION
Also fixed some more position parsing issues.

```v
// Keep empty lines in const blocks
const (
	_ = SomeStruct{
		val: 'Multiline field exprs should cause no problems'
	}
	_ = 1

	_ = 'Keep this empty line before'
	// Comment before a field
	_ = 2

	// The empty line above should stay too
	_ = 3

	// This comment doesn't really belong anywhere

	_ = 'A multiline string with a StringInterLiteral...
	$foo
	...and the ending brace on a newline had a wrong pos.last_line.
	'
	_ = 4
)
```