### PR TITLE
cgen: fix anon_fn in containers

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1956,6 +1956,9 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					g.assign_op = assign_stmt.op
 					g.expr(left)
 					g.is_assign_lhs = false
+					if g.is_array_set {
+						g.is_array_set = false
+					}
 					if left is ast.IndexExpr {
 						sym := g.table.get_type_symbol(left.left_type)
 						if sym.kind in [.map, .array] {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1956,9 +1956,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					g.assign_op = assign_stmt.op
 					g.expr(left)
 					g.is_assign_lhs = false
-					if g.is_array_set {
-						g.is_array_set = false
-					}
+					g.is_array_set = false
 					if left is ast.IndexExpr {
 						sym := g.table.get_type_symbol(left.left_type)
 						if sym.kind in [.map, .array] {

--- a/vlib/v/tests/anon_fn_in_containers_test.v
+++ b/vlib/v/tests/anon_fn_in_containers_test.v
@@ -11,3 +11,27 @@ fn test_anon_fn_in_map() {
 	}
 	assert woop['shat']() == 'shoopity shoop'
 }
+
+fn test_anon_fn_in_array() {
+	mut woop := [fn() string {
+		return 'whoopity whoop'
+	}]
+	assert woop[0]() == 'whoopity whoop'
+
+	woop[0] = fn() string {
+		return 'shoopity shoop'
+	}
+	assert woop[0]() == 'shoopity shoop'
+}
+
+fn test_anon_fn_in_fixed_array() {
+	mut woop := [fn() string {
+		return 'whoopity whoop'
+	}]!
+	assert woop[0]() == 'whoopity whoop'
+
+	woop[0] = fn() string {
+		return 'shoopity shoop'
+	}
+	assert woop[0]() == 'shoopity shoop'
+}


### PR DESCRIPTION
This PR fixes anon_fn in containers.

Mixing `map` and `array/fixed_array` will be error.

- Fix error of anon_fn in containers mix.
- Add tests.

```vlang
fn test_anon_fn_in_map() {
	mut woop := map{
		'what': fn() string {
			return 'whoopity whoop'
		}
	}
	assert woop['what']() == 'whoopity whoop'

	woop['shat'] = fn() string {
		return 'shoopity shoop'
	}
	assert woop['shat']() == 'shoopity shoop'
}

fn test_anon_fn_in_array() {
	mut woop := [fn() string {
		return 'whoopity whoop'
	}]
	assert woop[0]() == 'whoopity whoop'

	woop[0] = fn() string {
		return 'shoopity shoop'
	}
	assert woop[0]() == 'shoopity shoop'
}

fn test_anon_fn_in_fixed_array() {
	mut woop := [fn() string {
		return 'whoopity whoop'
	}]!
	assert woop[0]() == 'whoopity whoop'

	woop[0] = fn() string {
		return 'shoopity shoop'
	}
	assert woop[0]() == 'shoopity shoop'
}
```