### PR TITLE
parser: disallow `map{}` without keys

### DIFF
--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -175,7 +175,7 @@ fn (mut p Parser) map_init() ast.MapInit {
 		comments << p.eat_comments({})
 	}
 	if keys.len == 0 {
-		p.error_with_pos("empty maps cannot be declared, use `map[K]V{}` instead", first_pos.extend(p.tok.position()))
+		p.error_with_pos('empty maps cannot be declared, use `map[K]V{}` instead', first_pos.extend(p.tok.position()))
 	}
 	return ast.MapInit{
 		keys: keys

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -174,6 +174,9 @@ fn (mut p Parser) map_init() ast.MapInit {
 		}
 		comments << p.eat_comments({})
 	}
+	if keys.len == 0 {
+		p.error_with_pos("empty maps cannot be declared, use `map[K]V{}` instead", first_pos.extend(p.tok.position()))
+	}
 	return ast.MapInit{
 		keys: keys
 		vals: vals


### PR DESCRIPTION
This PR does not allow to declare variables with a `map{}` without keys. This to avoid a panic that the compiler throws.

```v
module main

fn main() {
	map := map{}
	println(map)
}
```

Before:

```
stunxfs@stunxfs--pc:~/develop/v$ v run test.v 
V panic: array.get: index out of range (i == 0, a.len == 0)
/tmp/v/v2.2086140718195749027.tmp.c:11347: at v_panic: Backtrace
/tmp/v/v2.2086140718195749027.tmp.c:10848: by array_get
/tmp/v/v2.2086140718195749027.tmp.c:37193: by v__checker__Checker_map_init
/tmp/v/v2.2086140718195749027.tmp.c:35165: by v__checker__Checker_expr
/tmp/v/v2.2086140718195749027.tmp.c:33852: by v__checker__Checker_assign_stmt
/tmp/v/v2.2086140718195749027.tmp.c:34314: by v__checker__Checker_stmt
/tmp/v/v2.2086140718195749027.tmp.c:34766: by v__checker__Checker_stmts
/tmp/v/v2.2086140718195749027.tmp.c:37668: by v__checker__Checker_fn_decl
/tmp/v/v2.2086140718195749027.tmp.c:34351: by v__checker__Checker_stmt
/tmp/v/v2.2086140718195749027.tmp.c:31247: by v__checker__Checker_check
/tmp/v/v2.2086140718195749027.tmp.c:31299: by v__checker__Checker_check_files
/tmp/v/v2.2086140718195749027.tmp.c:59229: by v__builder__Builder_gen_c
/tmp/v/v2.2086140718195749027.tmp.c:59246: by v__builder__Builder_build_c
/tmp/v/v2.2086140718195749027.tmp.c:59286: by v__builder__Builder_compile_c
/tmp/v/v2.2086140718195749027.tmp.c:60316: by v__builder__compile
/tmp/v/v2.2086140718195749027.tmp.c:61108: by main__main
/tmp/v/v2.2086140718195749027.tmp.c:61470: by main
```

After:

```
test.v:4:12: error: empty maps cannot be declared, use `map[K]V{}` instead
    2 | 
    3 | fn main() {
    4 |     map := map{}
      |               ~~
    5 |     println(map)
    6 | }
```
