### PR TITLE
cgen: format if_expr generated c codes

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4117,14 +4117,12 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 		if node.typ.has_flag(.optional) {
 			g.inside_if_optional = true
 		}
-		g.write('/*experimental if expr*/')
 		styp := g.typ(node.typ)
-		// g.insert_before_stmt('$styp $tmp;')
 		cur_line = g.go_before_stmt(0)
+		g.empty_line = true
 		g.writeln('$styp $tmp; /* if prepend */')
 	} else if node.is_expr || g.inside_ternary != 0 {
 		g.inside_ternary++
-		// g.inside_if_expr = true
 		g.write('(')
 		for i, branch in node.branches {
 			if i > 0 {
@@ -4239,8 +4237,8 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 	}
 	g.writeln('}')
 	if needs_tmp_var {
-		// g.writeln('$cur_line $tmp; /*Z*/')
-		g.write('$cur_line $tmp /*Z*/')
+		g.empty_line = false
+		g.write('$cur_line $tmp')
 	}
 	if node.typ.has_flag(.optional) {
 		g.inside_if_optional = false
@@ -4454,9 +4452,6 @@ fn (mut g Gen) return_statement(node ast.Return) {
 			expr := node.exprs[0]
 			if expr is ast.Ident {
 				g.returned_var_name = expr.name
-			}
-			if tmp != '' {
-				g.writeln('; // free tmp exprs + all vars before return')
 			}
 			g.writeln(';')
 			// autofree before `return`


### PR DESCRIPTION
This PR format if_expr generated c codes.

before:
```vlang
VV_LOCAL_SYMBOL Option2_int main__foo_complex(void) {
	int a = 2;
Option2_int _t110; /* if prepend */
	if (a > 1) {
		int b = 1;
		b *= 10;
		opt_ok(&(int[]) { b }, (Option2*)(&_t110), sizeof(int));
	} else {
		int c = 0;
		c += 2;
		println(int_str(c));
		Option2 _t111 = (Option2){.state = 1, .err = (Error){.msg = _SLIT(""), .code = 0,}};
		memcpy(&_t110, &_t111, sizeof(Option2));
	}
		Option2_int _t109 = /*experimental if expr*/ _t110 /*Z*/; // free tmp exprs + all vars before return
	;
	return _t109;
}
```

now:
```vlang
VV_LOCAL_SYMBOL Option2_int main__foo_complex(void) {
	int a = 2;
	Option2_int _t110; /* if prepend */
	if (a > 1) {
		int b = 1;
		b *= 10;
		opt_ok(&(int[]) { b }, (Option2*)(&_t110), sizeof(int));
	} else {
		int c = 0;
		c += 2;
		println(int_str(c));
		Option2 _t111 = (Option2){.state = 1, .err = (Error){.msg = _SLIT(""), .code = 0,}};
		memcpy(&_t110, &_t111, sizeof(Option2));
	}
	Option2_int _t109 =  _t110;
	return _t109;
}
```