### PR TITLE
cgen: minor simplification of struct zero init

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4793,7 +4793,7 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 	}
 
 	if !initialized {
-		g.write('\n#ifndef __cplusplus\n0\n#endif\n')
+		g.write('0')
 	}
 
 	g.write('}')


### PR DESCRIPTION
This PR makes minor simplification of struct zero init.

- Use `{0}` instead of `{\n#ifndef __cplusplus\n0\n#endif\n}`.