### PR TITLE
termui: add show_cursor() and hide_cursor()

### DIFF
--- a/vlib/term/ui/input_windows.c.v
+++ b/vlib/term/ui/input_windows.c.v
@@ -68,7 +68,7 @@ pub fn init(cfg Config) &Context {
 	}
 
 	if ctx.cfg.hide_cursor {
-		print('\x1b[?25l')
+		ctx.hide_cursor()
 	}
 
 	if ctx.cfg.window_title != '' {

--- a/vlib/term/ui/input_windows.c.v
+++ b/vlib/term/ui/input_windows.c.v
@@ -69,6 +69,7 @@ pub fn init(cfg Config) &Context {
 
 	if ctx.cfg.hide_cursor {
 		ctx.hide_cursor()
+		ctx.flush()
 	}
 
 	if ctx.cfg.window_title != '' {

--- a/vlib/term/ui/termios_nix.c.v
+++ b/vlib/term/ui/termios_nix.c.v
@@ -78,9 +78,7 @@ fn (mut ctx Context) termios_setup() ? {
 
 	if ctx.cfg.hide_cursor {
 		ctx.hide_cursor()
-		ctx.flush() Member
-
-these should have a ctx.flush() call after them - otherwise they w
+		ctx.flush()
 	}
 
 	if ctx.cfg.window_title != '' {

--- a/vlib/term/ui/termios_nix.c.v
+++ b/vlib/term/ui/termios_nix.c.v
@@ -77,7 +77,7 @@ fn (mut ctx Context) termios_setup() ? {
 	}
 
 	if ctx.cfg.hide_cursor {
-		print('\x1b[?25l')
+		ctx.hide_cursor()
 	}
 
 	if ctx.cfg.window_title != '' {

--- a/vlib/term/ui/termios_nix.c.v
+++ b/vlib/term/ui/termios_nix.c.v
@@ -78,6 +78,9 @@ fn (mut ctx Context) termios_setup() ? {
 
 	if ctx.cfg.hide_cursor {
 		ctx.hide_cursor()
+		ctx.flush() Member
+
+these should have a ctx.flush() call after them - otherwise they w
 	}
 
 	if ctx.cfg.window_title != '' {

--- a/vlib/term/ui/ui.v
+++ b/vlib/term/ui/ui.v
@@ -59,6 +59,18 @@ pub fn (mut ctx Context) set_cursor_position(x int, y int) {
 }
 
 [inline]
+// show_cursor will make the cursor appear if it is not already visible
+pub fn (mut ctx Context) show_cursor() {
+	ctx.write('\x1b[?25h')
+}
+
+// hide_cursor will make the cursor invisible
+[inline]
+pub fn hide_cursor() {
+	ctx.write('\x1b[?25l')
+}
+
+[inline]
 // set_color sets the current foreground color used by any succeeding `draw_*` calls.
 pub fn (mut ctx Context) set_color(c Color) {
 	if ctx.enable_rgb {

--- a/vlib/term/ui/ui.v
+++ b/vlib/term/ui/ui.v
@@ -66,7 +66,7 @@ pub fn (mut ctx Context) show_cursor() {
 
 // hide_cursor will make the cursor invisible
 [inline]
-pub fn hide_cursor() {
+pub fn (mut ctx Context) hide_cursor() {
 	ctx.write('\x1b[?25l')
 }
 


### PR DESCRIPTION
Added Context.show_cursor() and hide_cursor(), and implemented them in the inits. Basically copied from https://github.com/vlang/v/blob/38495da07e604fdaafca92b1dfbb812a1f3bdbae/vlib/term/control.v#L91-L94