### PR TITLE
vcomplete: add powershell support

### DIFF
--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -29,7 +29,11 @@
 // ```
 // Please note that you should let v load the zsh completions after the call to compinit
 //
-// # powershell //TODO
+// # powershell
+// To install auto-complete for V in PowerShell, simply add this code to your `$PROFILE`
+// `v complete setup powershell >> $PROFILE`
+// and reload prifile
+// `& $PROFILE`
 //
 module main
 
@@ -249,7 +253,7 @@ _v() {
 compdef _v v
 ' }
 				'powershell' { setup = '
-Register-ArgumentCompleter -Native -CommandName ./v -ScriptBlock {
+Register-ArgumentCompleter -Native -CommandName v -ScriptBlock {
 	param(\$commandName, \$wordToComplete, \$cursorPosition)
 		$vexe complete powershell "\$wordToComplete" | ForEach-Object {
 			[System.Management.Automation.CompletionResult]::new(\$_, \$_, \'ParameterValue\', \$_)

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -34,6 +34,8 @@
 // `v complete setup powershell >> $PROFILE`
 // and reload prifile
 // `& $PROFILE`
+// If `$PROFILE` didn't exist yet, create it before
+// `New-Item -Type File -Force $PROFILE`
 //
 module main
 

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -32,7 +32,7 @@
 // # powershell
 // To install auto-complete for V in PowerShell, simply do this
 // `v complete setup powershell >> $PROFILE`
-// and reload prifile
+// and reload profile
 // `& $PROFILE`
 // If `$PROFILE` didn't exist yet, create it before
 // `New-Item -Type File -Force $PROFILE`

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -30,7 +30,7 @@
 // Please note that you should let v load the zsh completions after the call to compinit
 //
 // # powershell
-// To install auto-complete for V in PowerShell, simply add this code to your `$PROFILE`
+// To install auto-complete for V in PowerShell, simply do this
 // `v complete setup powershell >> $PROFILE`
 // and reload prifile
 // `& $PROFILE`

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -248,7 +248,14 @@ _v() {
 }
 compdef _v v
 ' }
-				// 'powershell' {} //TODO
+				'powershell' { setup = '
+Register-ArgumentCompleter -Native -CommandName ./v -ScriptBlock {
+	param(\$commandName, \$wordToComplete, \$cursorPosition)
+		$vexe complete powershell "\$wordToComplete" | ForEach-Object {
+			[System.Management.Automation.CompletionResult]::new(\$_, \$_, \'ParameterValue\', \$_)
+		}
+}
+' }
 				else {}
 			}
 			println(setup)
@@ -264,7 +271,7 @@ compdef _v v
 			}
 			println(lines.join('\n'))
 		}
-		'fish' {
+		'fish', 'powershell' {
 			if sub_args.len <= 1 {
 				exit(0)
 			}
@@ -286,7 +293,6 @@ compdef _v v
 			}
 			println(lines.join('\n'))
 		}
-		// 'powershell' {} //TODO
 		else {}
 	}
 	exit(0)


### PR DESCRIPTION
Works perfectly with PowerShell > 7.0
With Windows PowerShell (PowerShell 5) doesn't work arguments completion
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
