### PR TITLE
cgen: fix for_in array of fixed_array (fix #9098)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1385,6 +1385,14 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 				g.write('\t')
 				g.write_fn_ptr_decl(val_sym.info as table.FnType, c_name(node.val_var))
 				g.writeln(' = ((voidptr*)$tmp${op_field}data)[$i];')
+			} else if val_sym.kind == .array_fixed {
+				right := if node.val_is_mut {
+					'(($styp)$tmp${op_field}data) + $i'
+				} else {
+					'(($styp*)$tmp${op_field}data)[$i]'
+				}
+				g.writeln('\t$styp ${c_name(node.val_var)};')
+				g.writeln('\tmemcpy(*($styp*)${c_name(node.val_var)}, (byte*)$right, sizeof($styp));')
 			} else {
 				// If val is mutable (pointer behind the scenes), we need to generate
 				// `int* val = ((int*)arr.data) + i;`

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1385,12 +1385,8 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 				g.write('\t')
 				g.write_fn_ptr_decl(val_sym.info as table.FnType, c_name(node.val_var))
 				g.writeln(' = ((voidptr*)$tmp${op_field}data)[$i];')
-			} else if val_sym.kind == .array_fixed {
-				right := if node.val_is_mut {
-					'(($styp)$tmp${op_field}data) + $i'
-				} else {
-					'(($styp*)$tmp${op_field}data)[$i]'
-				}
+			} else if val_sym.kind == .array_fixed && !node.val_is_mut {
+				right := '(($styp*)$tmp${op_field}data)[$i]'
 				g.writeln('\t$styp ${c_name(node.val_var)};')
 				g.writeln('\tmemcpy(*($styp*)${c_name(node.val_var)}, (byte*)$right, sizeof($styp));')
 			} else {

--- a/vlib/v/tests/for_in_containers_of_fixed_array_test.v
+++ b/vlib/v/tests/for_in_containers_of_fixed_array_test.v
@@ -1,0 +1,12 @@
+fn test_for_in_containers_of_fixed_array() {
+	mut rets := []string{}
+	arr := [][2]int{len: 3}
+
+	for pair in arr {
+		println(pair)
+		rets << '$pair'
+	}
+	assert rets[0] == '[0, 0]'
+	assert rets[1] == '[0, 0]'
+	assert rets[2] == '[0, 0]'
+}

--- a/vlib/v/tests/for_in_containers_of_fixed_array_test.v
+++ b/vlib/v/tests/for_in_containers_of_fixed_array_test.v
@@ -10,3 +10,16 @@ fn test_for_in_containers_of_fixed_array() {
 	assert rets[1] == '[0, 0]'
 	assert rets[2] == '[0, 0]'
 }
+
+fn test_for_mut_in_containers_of_fixed_array() {
+	mut rets := []string{}
+	mut arr := [][2]int{len: 3}
+
+	for mut pair in arr {
+		println(pair)
+		rets << '$pair'
+	}
+	assert rets[0] == '[0, 0]'
+	assert rets[1] == '[0, 0]'
+	assert rets[2] == '[0, 0]'
+}


### PR DESCRIPTION
This PR fixes for_in array of fixed_array (fix #9098).

- Fix for_in array of fixed_array.
- Fix for_mut_in array of fixed_array.
- Add test.

```vlang
fn main() {
	arr := [][2]int{len: 10}
  
	for pair in arr {
		println(pair)
	}
}

D:\Test\v\tt1>v run .
[0, 0]
[0, 0]
[0, 0]
[0, 0]
[0, 0]
[0, 0]
[0, 0]
[0, 0]
[0, 0]
[0, 0]
```
```vlang
fn main() {
	mut arr := [][2]int{len: 10}

	for mut pair in arr {
		println(pair)
	}
}

D:\Test\v\tt1>v run .
[0, 0]
[0, 0]
[0, 0]
[0, 0]
[0, 0]
[0, 0]
[0, 0]
[0, 0]
[0, 0]
[0, 0]
```