### PR TITLE
cgen: fix array_sort by different order of a/b (fix #9101)

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -807,6 +807,18 @@ fn test_sort() {
 	// assert users.map(it.name).join(' ') == 'Alice Bob Peter'
 }
 
+fn test_sort_by_different_order_of_a_b() {
+	mut x := [1, 2, 3]
+	x.sort(a < b)
+	println(x)
+	assert x == [1, 2, 3]
+
+	mut y := [1, 2, 3]
+	y.sort(b < a)
+	println(y)
+	assert y == [3, 2, 1]
+}
+
 fn test_f32_sort() {
 	mut f := [f32(50.0), 15, 1, 79, 38, 0, 27]
 	f.sort_with_compare(compare_f32)

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -106,10 +106,10 @@ fn test_sort_reverse() {
 	len := vals.len
 	vals.sort(b>a)
 	assert len == vals.len
-	assert vals[3] == 'a'
-	assert vals[2] == 'an'
-	assert vals[1] == 'any'
-	assert vals[0] == 'arr'
+	assert vals[0] == 'a'
+	assert vals[1] == 'an'
+	assert vals[2] == 'any'
+	assert vals[3] == 'arr'
 }
 
 fn test_split_nth() {

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -219,8 +219,10 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 		is_default = true
 	} else {
 		infix_expr := node.args[0].expr as ast.InfixExpr
-		is_default = '$infix_expr.left' in ['a', 'b'] && '$infix_expr.right' in ['a', 'b']
-		is_reverse = infix_expr.op == .gt
+		left_name := '$infix_expr.left'
+		is_default = left_name in ['a', 'b'] && '$infix_expr.right' in ['a', 'b']
+		is_reverse = (left_name.starts_with('a') && infix_expr.op == .gt)
+			|| (left_name.starts_with('b') && infix_expr.op == .lt)
 	}
 	if is_default {
 		// users.sort() or users.sort(a > b)


### PR DESCRIPTION
This PR fixes array_sort by different order of a/b (fix #9101).

- Fix array_sort by different order of a/b.
- Add test.

```vlang
fn main() {
	mut x := [1 2 3]
	x.sort(a < b)
	println(x)

	mut y := [1 2 3]
	y.sort(b < a)
	println(y)
}

D:\Test\v\tt1>v run .
[1, 2, 3]
[3, 2, 1]
```