### PR TITLE
cgen: minor cleanup of cgen.v

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -67,12 +67,12 @@ mut:
 	is_assign_lhs         bool     // inside left part of assign expr (for array_set(), etc)
 	discard_or_result     bool     // do not safe last ExprStmt of `or` block in tmp variable to defer ongoing expr usage
 	is_void_expr_stmt     bool     // ExprStmt whos result is discarded
-	is_set                bool     // map or array set value state
+	is_arraymap_set       bool     // map or array set value state
 	is_amp                bool     // for `&Foo{}` to merge PrefixExpr `&` and StructInit `Foo{}`; also for `&byte(0)` etc
 	is_sql                bool     // Inside `sql db{}` statement, generating sql instead of C (e.g. `and` instead of `&&` etc)
 	is_shared             bool     // for initialization of hidden mutex in `[rw]shared` literals
 	is_vlines_enabled     bool     // is it safe to generate #line directives when -g is passed
-	set_pos               int      // map or array set value position
+	arraymap_set_pos      int      // map or array set value position
 	vlines_path           string   // set to the proper path for generating #line directives
 	optionals             []string // to avoid duplicates TODO perf, use map
 	chan_pop_optionals    []string // types for `x := <-ch or {...}`
@@ -1956,7 +1956,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					g.assign_op = assign_stmt.op
 					g.expr(left)
 					g.is_assign_lhs = false
-					g.is_set = false
+					g.is_arraymap_set = false
 					if left is ast.IndexExpr {
 						sym := g.table.get_type_symbol(left.left_type)
 						if sym.kind in [.map, .array] {
@@ -2004,11 +2004,11 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 			pos := g.out.len
 			g.expr(left)
 
-			if g.is_set && g.set_pos > 0 {
-				g.out.go_back_to(g.set_pos)
+			if g.is_arraymap_set && g.arraymap_set_pos > 0 {
+				g.out.go_back_to(g.arraymap_set_pos)
 				g.write(', &$v_var)')
-				g.is_set = false
-				g.set_pos = 0
+				g.is_arraymap_set = false
+				g.arraymap_set_pos = 0
 			} else {
 				g.out.go_back_to(pos)
 				is_var_mut := !is_decl && left.is_auto_deref_var()
@@ -2097,7 +2097,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 				if is_decl {
 					g.writeln(';')
 				}
-			} else if !g.is_set && !str_add && !op_overloaded {
+			} else if !g.is_arraymap_set && !str_add && !op_overloaded {
 				g.write(' $op ')
 			} else if str_add || op_overloaded {
 				g.write(', ')
@@ -2175,9 +2175,9 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 			if str_add || op_overloaded {
 				g.write(')')
 			}
-			if g.is_set {
+			if g.is_arraymap_set {
 				g.write(' })')
-				g.is_set = false
+				g.is_arraymap_set = false
 			}
 			g.is_shared = false
 		}
@@ -4623,7 +4623,7 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 	if is_amp {
 		g.out.go_back(1) // delete the `&` already generated in `prefix_expr()
 	}
-	if g.is_shared && !g.inside_opt_data && !g.is_set {
+	if g.is_shared && !g.inside_opt_data && !g.is_arraymap_set {
 		mut shared_typ := struct_init.typ.set_flag(.shared_f)
 		shared_styp = g.typ(shared_typ)
 		g.writeln('($shared_styp*)__dup${shared_styp}(&($shared_styp){.val = ($styp){')
@@ -4797,7 +4797,7 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 	}
 
 	g.write('}')
-	if g.is_shared && !g.inside_opt_data && !g.is_set {
+	if g.is_shared && !g.inside_opt_data && !g.is_arraymap_set {
 		g.write('}, sizeof($shared_styp))')
 	} else if is_amp {
 		g.write(', sizeof($styp))')

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -116,7 +116,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym table.TypeSymbol) {
 				g.write('*')
 			}
 		} else {
-			g.is_array_set = true // special handling of assign_op and closing with '})'
+			g.is_set = true // special handling of assign_op and closing with '})'
 			g.write('array_set(')
 			if !left_is_ptr || node.left_type.has_flag(.shared_f) {
 				g.write('&')
@@ -297,9 +297,9 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym table.TypeSymbol) {
 	elem_type_str := g.typ(elem_type)
 	elem_typ := g.table.get_type_symbol(elem_type)
 	get_and_set_types := elem_typ.kind in [.struct_, .map]
-	if g.is_assign_lhs && !g.is_array_set && !get_and_set_types {
+	if g.is_assign_lhs && !g.is_set && !get_and_set_types {
 		if g.assign_op == .assign || info.value_type == table.string_type {
-			g.is_array_set = true
+			g.is_set = true
 			g.write('map_set_1(')
 		} else {
 			if node.is_setter {
@@ -331,7 +331,7 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym table.TypeSymbol) {
 		if elem_typ.kind == .function {
 			g.write(', &(voidptr[]) { ')
 		} else {
-			g.array_set_pos = g.out.len
+			g.set_pos = g.out.len
 			g.write(', &($elem_type_str[]) { ')
 		}
 		if g.assign_op != .assign && info.value_type != table.string_type {
@@ -339,7 +339,7 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym table.TypeSymbol) {
 			g.write('$zero })))')
 		}
 	} else if g.inside_map_postfix || g.inside_map_infix || g.inside_map_index
-		|| (g.is_assign_lhs && !g.is_array_set && get_and_set_types) {
+		|| (g.is_assign_lhs && !g.is_set && get_and_set_types) {
 		zero := g.type_default(info.value_type)
 		if node.is_setter {
 			g.write('(*($elem_type_str*)map_get_and_set_1(')


### PR DESCRIPTION
This PR makes minor cleanup of cgen.v.

- `g.is_array_set` change to `g.is_set` because it is used by map or array.
- `g.array_set_pos` change to `g.set_pos` because it is used by map or array.