### PR TITLE
checker: fix generic type ignores implemented interface

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2030,10 +2030,11 @@ fn (mut c Checker) type_implements(typ table.Type, inter_typ table.Type, pos tok
 	$if debug_interface_type_implements ? {
 		eprintln('> type_implements typ: $typ.debug() | inter_typ: $inter_typ.debug()')
 	}
-	typ_sym := c.table.get_type_symbol(typ)
+	utyp := c.unwrap_generic(typ)
+	typ_sym := c.table.get_type_symbol(utyp)
 	mut inter_sym := c.table.get_type_symbol(inter_typ)
-	styp := c.table.type_to_str(typ)
-	same_base_type := typ.idx() == inter_typ.idx()
+	styp := c.table.type_to_str(utyp)
+	same_base_type := utyp.idx() == inter_typ.idx()
 	if typ_sym.kind == .interface_ && inter_sym.kind == .interface_ && !same_base_type {
 		c.error('cannot implement interface `$inter_sym.name` with a different interface `$styp`',
 			pos)
@@ -2077,8 +2078,8 @@ fn (mut c Checker) type_implements(typ table.Type, inter_typ table.Type, pos tok
 			c.error("`$styp` doesn't implement field `$ifield.name` of interface `$inter_sym.name`",
 				pos)
 		}
-		if typ !in inter_sym.info.types && typ_sym.kind != .interface_ {
-			inter_sym.info.types << typ
+		if utyp !in inter_sym.info.types && typ_sym.kind != .interface_ {
+			inter_sym.info.types << utyp
 		}
 	}
 	return true

--- a/vlib/v/tests/interface_edge_cases/i9_test.v
+++ b/vlib/v/tests/interface_edge_cases/i9_test.v
@@ -1,0 +1,35 @@
+// The series of i?_test.v files, do test different edge cases for
+// interface table generation. The differences may seem very minor
+// (placement of the interface declaration, whether or not there are
+// helper methods, etc), but PLEASE do NOT be tempted to merge them in
+// a single _test.v file. Debugging interface code generation issues
+// is *much easier* when the _test.v files are very short and focused.
+struct Point {
+	x i8
+	y i8
+}
+
+fn (p Point) draw() string {
+	return 'Point($p.x,$p.y)'
+}
+
+fn to_string(d Drawer) {
+	println(d.draw())
+}
+
+interface Drawer {
+	draw() string
+}
+
+fn to_string_generic<T>(t T) {
+	to_string(t)
+}
+
+fn test_to_string_generic_can_be_called() {
+	p := Point{
+		x: 2
+		y: 3
+	}
+	to_string_generic(p)
+	assert true
+}


### PR DESCRIPTION
Fixed by calling unwrap_generic on the generic type before checking if it implements an interface

Fixes #9123 

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
