### PR TITLE
sokol, gg: add CKJ support.(Linux only)

### DIFF
--- a/thirdparty/sokol/sokol_app.h
+++ b/thirdparty/sokol/sokol_app.h
@@ -767,7 +767,9 @@ typedef enum sapp_event_type {
     SAPP_EVENTTYPE_QUIT_REQUESTED,
     SAPP_EVENTTYPE_CLIPBOARD_PASTED,
     _SAPP_EVENTTYPE_NUM,
-    _SAPP_EVENTTYPE_FORCE_U32 = 0x7FFFFFFF
+    _SAPP_EVENTTYPE_FORCE_U32 = 0x7FFFFFFF,
+
+    SAPP_EVENTTYPE_CKJ_INPUT
 } sapp_event_type;
 
 /* key codes are the same names and values as GLFW */
@@ -936,6 +938,21 @@ typedef struct sapp_event {
     int window_height;
     int framebuffer_width;
     int framebuffer_height;
+
+    char* ckj_pending;
+    //char* japanese_converting;
+    char* ckj_confirm;
+
+    int ckj_length; // pending only
+    int ckj_first;  // pending only
+    int ckj_caret;  // pending only
+ 
+    // FIXME: ckj MODE enum
+    int ckj_input_mode;
+    // 0 : no japanese
+    // 1 : pending
+    // 2 : confirm
+
 } sapp_event;
 
 typedef struct sapp_desc {
@@ -1344,6 +1361,7 @@ inline int sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #define GL_GLEXT_PROTOTYPES
     #include <X11/Xlib.h>
     #include <X11/Xutil.h>
+    #include <X11/Xos.h>
     #include <X11/XKBlib.h>
     #include <X11/keysym.h>
     #include <X11/Xresource.h>
@@ -9089,42 +9107,42 @@ _SOKOL_PRIVATE sapp_keycode _sapp_x11_translate_key(int scancode) {
         case XK_KP_Equal:       return SAPP_KEYCODE_KP_EQUAL;
         case XK_KP_Enter:       return SAPP_KEYCODE_KP_ENTER;
 
-        case XK_a:              return SAPP_KEYCODE_A;
-        case XK_b:              return SAPP_KEYCODE_B;
-        case XK_c:              return SAPP_KEYCODE_C;
-        case XK_d:              return SAPP_KEYCODE_D;
-        case XK_e:              return SAPP_KEYCODE_E;
-        case XK_f:              return SAPP_KEYCODE_F;
-        case XK_g:              return SAPP_KEYCODE_G;
-        case XK_h:              return SAPP_KEYCODE_H;
-        case XK_i:              return SAPP_KEYCODE_I;
-        case XK_j:              return SAPP_KEYCODE_J;
-        case XK_k:              return SAPP_KEYCODE_K;
-        case XK_l:              return SAPP_KEYCODE_L;
-        case XK_m:              return SAPP_KEYCODE_M;
-        case XK_n:              return SAPP_KEYCODE_N;
-        case XK_o:              return SAPP_KEYCODE_O;
-        case XK_p:              return SAPP_KEYCODE_P;
-        case XK_q:              return SAPP_KEYCODE_Q;
-        case XK_r:              return SAPP_KEYCODE_R;
-        case XK_s:              return SAPP_KEYCODE_S;
-        case XK_t:              return SAPP_KEYCODE_T;
-        case XK_u:              return SAPP_KEYCODE_U;
-        case XK_v:              return SAPP_KEYCODE_V;
-        case XK_w:              return SAPP_KEYCODE_W;
-        case XK_x:              return SAPP_KEYCODE_X;
-        case XK_y:              return SAPP_KEYCODE_Y;
-        case XK_z:              return SAPP_KEYCODE_Z;
-        case XK_1:              return SAPP_KEYCODE_1;
-        case XK_2:              return SAPP_KEYCODE_2;
-        case XK_3:              return SAPP_KEYCODE_3;
-        case XK_4:              return SAPP_KEYCODE_4;
-        case XK_5:              return SAPP_KEYCODE_5;
-        case XK_6:              return SAPP_KEYCODE_6;
-        case XK_7:              return SAPP_KEYCODE_7;
-        case XK_8:              return SAPP_KEYCODE_8;
-        case XK_9:              return SAPP_KEYCODE_9;
-        case XK_0:              return SAPP_KEYCODE_0;
+        //case XK_a:              return SAPP_KEYCODE_A;
+        //case XK_b:              return SAPP_KEYCODE_B;
+        //case XK_c:              return SAPP_KEYCODE_C;
+        //case XK_d:              return SAPP_KEYCODE_D;
+        //case XK_e:              return SAPP_KEYCODE_E;
+        //case XK_f:              return SAPP_KEYCODE_F;
+        //case XK_g:              return SAPP_KEYCODE_G;
+        //case XK_h:              return SAPP_KEYCODE_H;
+        //case XK_i:              return SAPP_KEYCODE_I;
+        //case XK_j:              return SAPP_KEYCODE_J;
+        //case XK_k:              return SAPP_KEYCODE_K;
+        //case XK_l:              return SAPP_KEYCODE_L;
+        //case XK_m:              return SAPP_KEYCODE_M;
+        //case XK_n:              return SAPP_KEYCODE_N;
+        //case XK_o:              return SAPP_KEYCODE_O;
+        //case XK_p:              return SAPP_KEYCODE_P;
+        //case XK_q:              return SAPP_KEYCODE_Q;
+        //case XK_r:              return SAPP_KEYCODE_R;
+        //case XK_s:              return SAPP_KEYCODE_S;
+        //case XK_t:              return SAPP_KEYCODE_T;
+        //case XK_u:              return SAPP_KEYCODE_U;
+        //case XK_v:              return SAPP_KEYCODE_V;
+        //case XK_w:              return SAPP_KEYCODE_W;
+        //case XK_x:              return SAPP_KEYCODE_X;
+        //case XK_y:              return SAPP_KEYCODE_Y;
+        //case XK_z:              return SAPP_KEYCODE_Z;
+        //case XK_1:              return SAPP_KEYCODE_1;
+        //case XK_2:              return SAPP_KEYCODE_2;
+        //case XK_3:              return SAPP_KEYCODE_3;
+        //case XK_4:              return SAPP_KEYCODE_4;
+        //case XK_5:              return SAPP_KEYCODE_5;
+        //case XK_6:              return SAPP_KEYCODE_6;
+        //case XK_7:              return SAPP_KEYCODE_7;
+        //case XK_8:              return SAPP_KEYCODE_8;
+        //case XK_9:              return SAPP_KEYCODE_9;
+        //case XK_0:              return SAPP_KEYCODE_0;
         case XK_space:          return SAPP_KEYCODE_SPACE;
         case XK_minus:          return SAPP_KEYCODE_MINUS;
         case XK_equal:          return SAPP_KEYCODE_EQUAL;
@@ -9332,9 +9350,49 @@ _SOKOL_PRIVATE void _sapp_x11_process_event(XEvent* event) {
     }
 }
 
+
+// MARK: CKJ IME callback
+static void preedit_draw_callback(
+    XIM xim,
+    XPointer client_data,
+    XIMPreeditDrawCallbackStruct *call_data)
+{
+
+    XIMText *xim_text = call_data->text;
+    if (xim_text != NULL)
+    {
+        //printf("Draw callback string: %s, length: %d, first: %d, caret: %d\n", xim_text->string.multi_byte, call_data->chg_length, call_data->chg_first, call_data->caret);
+        _sapp_init_event(SAPP_EVENTTYPE_CKJ_INPUT);
+        _sapp.event.ckj_pending = xim_text->string.multi_byte;
+        _sapp.event.ckj_length  = call_data->chg_length;
+        _sapp.event.ckj_first   = call_data->chg_first;
+        _sapp.event.ckj_caret   = call_data->caret;
+        _sapp.event.ckj_input_mode = 1;
+        _sapp_call_event(&_sapp.event);
+    }
+    else
+    {
+        //printf("Draw callback string: (DELETED), length: %d, first: %d, caret: %d\n", call_data->chg_length, call_data->chg_first, call_data->caret);
+    }
+}
+
+// FIXME: mozc can't move cursor pos.
+void send_spot(XIC ic, XPoint nspot)
+{
+    XVaNestedList preedit_attr;
+    preedit_attr = XVaCreateNestedList(0, XNSpotLocation, &nspot, NULL);
+    XSetICValues(ic, XNPreeditAttributes, preedit_attr, NULL);
+    XFree(preedit_attr);
+}
+
+// end ------
+
 _SOKOL_PRIVATE void _sapp_linux_run(const sapp_desc* desc) {
     _sapp_init_state(desc);
     _sapp.x11.window_state = NormalState;
+
+    setlocale(LC_CTYPE, "");
+    XSetLocaleModifiers("");
 
     XInitThreads();
     XrmInitialize();
@@ -9363,13 +9421,94 @@ _SOKOL_PRIVATE void _sapp_linux_run(const sapp_desc* desc) {
     _sapp_x11_query_window_size();
     _sapp_glx_swapinterval(_sapp.swap_interval);
     XFlush(_sapp.x11.display);
+
+    // TODO: CKJ
+    
+    XIMCallback draw_callback;
+    draw_callback.client_data = NULL;
+    draw_callback.callback = (XIMProc)preedit_draw_callback;
+
+    XVaNestedList preedit_attributes = XVaCreateNestedList(
+        0,
+        XNPreeditDrawCallback, &draw_callback,
+        NULL);
+
+    XIM xim = XOpenIM(_sapp.x11.display, NULL, NULL, NULL);
+    XIC ic = XCreateIC(xim,
+                       XNInputStyle, XIMPreeditCallbacks | XIMStatusNothing,
+                       XNClientWindow, _sapp.x11.window,
+                       XNFocusWindow, _sapp.x11.window,
+                       XNPreeditAttributes, preedit_attributes,
+                       NULL);
+    XSetICFocus(ic);
+    //XSelectInput(_sapp.x11.display, _sapp.x11.window, KeyPressMask);
+    XPoint spot;
+    spot.x = 0;
+    spot.y = 0;
+    // mozc not working
+    send_spot(ic, spot);
+
+    static char *buff;
+    size_t buff_size = 16;
+    buff = (char *)malloc(buff_size);
+
     while (!_sapp.quit_ordered) {
         _sapp_glx_make_current();
         int count = XPending(_sapp.x11.display);
         while (count--) {
             XEvent event;
+            KeySym ksym;
+            Status status;
             XNextEvent(_sapp.x11.display, &event);
-            _sapp_x11_process_event(&event);
+            if (XFilterEvent(&event, None)) {
+                //continue;
+            }else{
+                // TODO'
+                if (event.type == KeyPress) {
+                    //printf("event.type keypress-------------\n");
+
+                    int keycode = event.xkey.keycode;
+                    if (keycode){
+                        const sapp_keycode key = _sapp_x11_translate_key(keycode);
+                        const uint32_t mods = _sapp_x11_mod(event.xkey.state);
+                        if (mods != 0){
+                            //printf(" mods is %p \n", mods);
+                            _sapp_x11_process_event(&event);
+                            continue;
+                        }
+                    }
+                    spot.x += 20;
+                    spot.y += 20;
+                    send_spot(ic, spot);
+
+                    size_t c = Xutf8LookupString(ic, &event.xkey,
+                                                 buff, buff_size - 1,
+                                                 &ksym, &status);
+                    if (status == XBufferOverflow) {
+                        //printf("reallocate to the size of: %lu\n", c + 1);
+                        buff = realloc(buff, c + 1);
+                        c = XmbLookupString(ic, &event.xkey,
+                                            buff, c,
+                                            &ksym, &status);
+                    }
+                    if (c) {
+                        spot.x += 20;
+                        spot.y += 20;
+                        send_spot(ic, spot);
+                        buff[c] = 0;
+                        // confirm
+                        //printf("delievered string: %s\n", buff);
+                        _sapp_init_event(SAPP_EVENTTYPE_CKJ_INPUT);
+                        _sapp.event.ckj_confirm = buff;
+                        _sapp.event.ckj_input_mode = 2;
+                        _sapp_call_event(&_sapp.event);
+                    }
+                }else{
+                    _sapp_x11_process_event(&event);
+                }
+            }
+            // end -----
+            //_sapp_x11_process_event(&event);
         }
         _sapp_frame();
         _sapp_glx_swap_buffers();

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -23,10 +23,9 @@ pub type FNMove = fn (x f32, y f32, z voidptr)
 
 pub type FNChar = fn (c u32, x voidptr)
 
-pub type FNCKJInputPending = fn(text string, length int, first int, caret int, x voidptr)
+pub type FNCKJInputPending = fn (text string, length int, first int, caret int, x voidptr)
 
-pub type FNCKJInputConfirm = fn(text string, x voidptr)
-
+pub type FNCKJInputConfirm = fn (text string, x voidptr)
 
 pub struct Event {
 pub:
@@ -81,11 +80,9 @@ pub:
 	fail_fn           FNFail    = voidptr(0)
 	event_fn          FNEvent   = voidptr(0)
 	keydown_fn        FNKeyDown = voidptr(0)
-
-    // ckj input
-    ckj_input_pending FNCKJInputPending = voidptr(0)
-    ckj_input_confirm FNCKJInputConfirm = voidptr(0)
-
+	// ckj input
+	ckj_input_pending FNCKJInputPending = voidptr(0)
+	ckj_input_confirm FNCKJInputConfirm = voidptr(0)
 	// special case of event_fn
 	char_fn FNChar = voidptr(0)
 	// special case of event_fn
@@ -293,27 +290,26 @@ fn gg_event_fn(ce &C.sapp_event, user_data voidptr) {
 				cfn(e.mouse_x / g.scale, e.mouse_y / g.scale, g.config.user_data)
 			}
 		}
-        else {
-            // FIXME
-            match ce.ckj_input_mode {
-                1 {
-                    jpp := string(ce.ckj_pending)
-                    if g.config.ckj_input_pending != voidptr(0) {
-                        jpfn := g.config.ckj_input_pending
-                        jpfn(jpp, ce.ckj_length, ce.ckj_first, ce.ckj_caret, g.config.user_data)
-                    }
-                }
-                2 {
-                    jpc := string(ce.ckj_confirm)
-                    if g.config.ckj_input_confirm != voidptr(0) {
-                        jpfn := g.config.ckj_input_confirm
-                        jpfn(jpc, g.config.user_data)
-                    }
-                }
-                else{}
-            }
-        }
-
+		else {
+			// FIXME
+			match ce.ckj_input_mode {
+				1 {
+					jpp := string(ce.ckj_pending)
+					if g.config.ckj_input_pending != voidptr(0) {
+						jpfn := g.config.ckj_input_pending
+						jpfn(jpp, ce.ckj_length, ce.ckj_first, ce.ckj_caret, g.config.user_data)
+					}
+				}
+				2 {
+					jpc := string(ce.ckj_confirm)
+					if g.config.ckj_input_confirm != voidptr(0) {
+						jpfn := g.config.ckj_input_confirm
+						jpfn(jpc, g.config.user_data)
+					}
+				}
+				else {}
+			}
+		}
 	}
 }
 

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -23,6 +23,11 @@ pub type FNMove = fn (x f32, y f32, z voidptr)
 
 pub type FNChar = fn (c u32, x voidptr)
 
+pub type FNCKJInputPending = fn(text string, length int, first int, caret int, x voidptr)
+
+pub type FNCKJInputConfirm = fn(text string, x voidptr)
+
+
 pub struct Event {
 pub:
 	frame_count u64
@@ -76,6 +81,11 @@ pub:
 	fail_fn           FNFail    = voidptr(0)
 	event_fn          FNEvent   = voidptr(0)
 	keydown_fn        FNKeyDown = voidptr(0)
+
+    // ckj input
+    ckj_input_pending FNCKJInputPending = voidptr(0)
+    ckj_input_confirm FNCKJInputConfirm = voidptr(0)
+
 	// special case of event_fn
 	char_fn FNChar = voidptr(0)
 	// special case of event_fn
@@ -283,7 +293,27 @@ fn gg_event_fn(ce &C.sapp_event, user_data voidptr) {
 				cfn(e.mouse_x / g.scale, e.mouse_y / g.scale, g.config.user_data)
 			}
 		}
-		else {}
+        else {
+            // FIXME
+            match ce.ckj_input_mode {
+                1 {
+                    jpp := string(ce.ckj_pending)
+                    if g.config.ckj_input_pending != voidptr(0) {
+                        jpfn := g.config.ckj_input_pending
+                        jpfn(jpp, ce.ckj_length, ce.ckj_first, ce.ckj_caret, g.config.user_data)
+                    }
+                }
+                2 {
+                    jpc := string(ce.ckj_confirm)
+                    if g.config.ckj_input_confirm != voidptr(0) {
+                        jpfn := g.config.ckj_input_confirm
+                        jpfn(jpc, g.config.user_data)
+                    }
+                }
+                else{}
+            }
+        }
+
 	}
 }
 

--- a/vlib/sokol/sapp/sapp_structs.v
+++ b/vlib/sokol/sapp/sapp_structs.v
@@ -78,6 +78,14 @@ pub:
 	window_height      int
 	framebuffer_width  int
 	framebuffer_height int
+
+    ckj_pending charptr
+    ckj_confirm charptr
+    ckj_input_mode int
+
+    ckj_length int
+    ckj_first  int
+    ckj_caret  int
 }
 
 pub fn (e &C.sapp_event) str() string {


### PR DESCRIPTION
Added support for CKJ (Chinese, Korean, Japanese) input to sokol and gg. (Linux Only)

**This is a destructive change.**


Incoming Key_down(a〜z,A〜Z) events will be notified to `ckj_input_confirm`.



<br><br>
Example

```v
	app.gg = gg.new_context(
        ...
        ckj_input_pending: jip
        ckj_input_confirm: jic
	)

...
fn jip(text string, length int, first int, caret int, mut app App){
    println("pending_text: $text")
}

fn jic(text string, mut app App){
    println("confirm text: $text")
}
```


<img width="601" alt="スクリーンショット 2021-03-05 14 53 13" src="https://user-images.githubusercontent.com/50548952/110073333-901ed800-7dc2-11eb-9806-976e8278a708.png">
