### PR TITLE
cgen: fix for_in fixed_array of fixed_array

### DIFF
--- a/vlib/v/tests/for_in_containers_of_fixed_array_test.v
+++ b/vlib/v/tests/for_in_containers_of_fixed_array_test.v
@@ -1,4 +1,4 @@
-fn test_for_in_containers_of_fixed_array() {
+fn test_for_in_array_of_fixed_array() {
 	mut rets := []string{}
 	arr := [][2]int{len: 3}
 
@@ -11,7 +11,7 @@ fn test_for_in_containers_of_fixed_array() {
 	assert rets[2] == '[0, 0]'
 }
 
-fn test_for_mut_in_containers_of_fixed_array() {
+fn test_for_mut_in_array_of_fixed_array() {
 	mut rets := []string{}
 	mut arr := [][2]int{len: 3}
 
@@ -22,4 +22,30 @@ fn test_for_mut_in_containers_of_fixed_array() {
 	assert rets[0] == '[0, 0]'
 	assert rets[1] == '[0, 0]'
 	assert rets[2] == '[0, 0]'
+}
+
+fn test_for_in_fixed_array_of_fixed_array() {
+	mut rets := []string{}
+	arr := [[1, 2]!, [3, 4]!, [5, 6]!]!
+
+	for pair in arr {
+		println(pair)
+		rets << '$pair'
+	}
+	assert rets[0] == '[1, 2]'
+	assert rets[1] == '[3, 4]'
+	assert rets[2] == '[5, 6]'
+}
+
+fn test_for_mut_in_fixed_array_of_fixed_array() {
+	mut rets := []string{}
+	mut arr := [[1, 2]!, [3, 4]!, [5, 6]!]!
+
+	for mut pair in arr {
+		println(pair)
+		rets << '$pair'
+	}
+	assert rets[0] == '[1, 2]'
+	assert rets[1] == '[3, 4]'
+	assert rets[2] == '[5, 6]'
 }


### PR DESCRIPTION
This PR fixes for_in fixed_array of fixed_array.

- Fix for_in fixed_array of fixed_array.
- Add tests.

```vlang
fn test_for_in_fixed_array_of_fixed_array() {
	mut rets := []string{}
	arr := [[1, 2]!, [3, 4]!, [5, 6]!]!

	for pair in arr {
		println(pair)
		rets << '$pair'
	}
	assert rets[0] == '[1, 2]'
	assert rets[1] == '[3, 4]'
	assert rets[2] == '[5, 6]'
}

fn test_for_mut_in_fixed_array_of_fixed_array() {
	mut rets := []string{}
	mut arr := [[1, 2]!, [3, 4]!, [5, 6]!]!

	for mut pair in arr {
		println(pair)
		rets << '$pair'
	}
	assert rets[0] == '[1, 2]'
	assert rets[1] == '[3, 4]'
	assert rets[2] == '[5, 6]'
}
```