### PR TITLE
builtin: use fprintf to print to stderr on Android

### DIFF
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -82,7 +82,7 @@ pub fn eprintln(s string) {
 	// eprintln is used in panics, so it should not fail at all
 	$if android {
 		if s.str == 0 {
-			C.fprintf(C.stderr, c'%s', c'eprintln(NIL)\n')
+			C.fprintf(C.stderr, c'eprintln(NIL)\n')
 		} else {
 			C.fprintf(C.stderr, c'%.*s\n', s.len, s.str)
 		}
@@ -103,13 +103,13 @@ pub fn eprint(s string) {
 	C.fflush(C.stderr)
 	$if android {
 		if s.str == 0 {
-			C.fprintf(C.stderr, c'%s', c'eprintln(NIL)\n')
+			C.fprintf(C.stderr, c'eprint(NIL)')
 		} else {
 			C.fprintf(C.stderr, c'%.*s', s.len, s.str)
 		}
 	} $else {
 		if s.str == 0 {
-			C.write(2, c'eprint(NIL)\n', 12)
+			C.write(2, c'eprint(NIL)', 11)
 		} else {
 			C.write(2, s.str, s.len)
 		}
@@ -121,7 +121,7 @@ pub fn eprint(s string) {
 // A call to `flush()` will flush the output buffer to stdout.
 pub fn print(s string) {
 	$if android {
-		C.fprintf(C.stdout, c'%s', s.str)
+		C.fprintf(C.stdout, c'%.*s', s.len, s.str)
 	} $else {
 		C.write(1, s.str, s.len)
 	}

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -80,11 +80,19 @@ pub fn eprintln(s string) {
 	C.fflush(C.stdout)
 	C.fflush(C.stderr)
 	// eprintln is used in panics, so it should not fail at all
-	if s.str == 0 {
-		C.write(2, c'eprintln(NIL)\n', 14)
-	} else {
-		C.write(2, s.str, s.len)
-		C.write(2, c'\n', 1)
+	$if android {
+		if s.str == 0 {
+			C.fprintf(C.stderr, c'%s', c'eprintln(NIL)\n')
+		} else {
+			C.fprintf(C.stderr, c'%.*s\n', s.len, s.str)
+		}
+	} $else {
+		if s.str == 0 {
+			C.write(2, c'eprintln(NIL)\n', 14)
+		} else {
+			C.write(2, s.str, s.len)
+			C.write(2, c'\n', 1)
+		}
 	}
 	C.fflush(C.stderr)
 }
@@ -93,10 +101,18 @@ pub fn eprintln(s string) {
 pub fn eprint(s string) {
 	C.fflush(C.stdout)
 	C.fflush(C.stderr)
-	if s.str == 0 {
-		C.write(2, c'eprint(NIL)\n', 12)
-	} else {
-		C.write(2, s.str, s.len)
+	$if android {
+		if s.str == 0 {
+			C.fprintf(C.stderr, c'%s', c'eprintln(NIL)\n')
+		} else {
+			C.fprintf(C.stderr, c'%.*s', s.len, s.str)
+		}
+	} $else {
+		if s.str == 0 {
+			C.write(2, c'eprint(NIL)\n', 12)
+		} else {
+			C.write(2, s.str, s.len)
+		}
 	}
 	C.fflush(C.stderr)
 }
@@ -104,7 +120,11 @@ pub fn eprint(s string) {
 // print prints a message to stdout. Unlike `println` stdout is not automatically flushed.
 // A call to `flush()` will flush the output buffer to stdout.
 pub fn print(s string) {
-	C.write(1, s.str, s.len)
+	$if android {
+		C.fprintf(C.stdout, c'%s', s.str)
+	} $else {
+		C.write(1, s.str, s.len)
+	}
 }
 
 /*


### PR DESCRIPTION
Refer to [Discord chat](https://discord.com/channels/592103645835821068/592106336838352923/817323968377651220).

Using `fprintf` on Android is currently necessary to catch debug output printed to `stderr` - since the stacktrace dumping is hard to get working and the way [we do printing on Android](https://github.com/vlang/v/blob/f4c03e8ed82d29646f4de311e100efde2c049083/thirdparty/sokol/sokol_v.h#L18) currently - this help a great deal when debugging panics.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
