### PR TITLE
cgen: fix for_in map of fixed_array

### DIFF
--- a/vlib/v/tests/for_in_containers_of_fixed_array_test.v
+++ b/vlib/v/tests/for_in_containers_of_fixed_array_test.v
@@ -49,3 +49,29 @@ fn test_for_mut_in_fixed_array_of_fixed_array() {
 	assert rets[1] == '[3, 4]'
 	assert rets[2] == '[5, 6]'
 }
+
+fn test_for_in_map_of_fixed_array() {
+	mut rets := []string{}
+	m := map{'aa': [1, 2]!, 'bb': [3, 4]!, 'cc': [5, 6]!}
+
+	for k, v in m {
+		println('$k, $v')
+		rets << '$k, $v'
+	}
+	assert rets[0] == 'aa, [1, 2]'
+	assert rets[1] == 'bb, [3, 4]'
+	assert rets[2] == 'cc, [5, 6]'
+}
+
+fn test_for_mut_in_map_of_fixed_array() {
+	mut rets := []string{}
+	mut m := map{'aa': [1, 2]!, 'bb': [3, 4]!, 'cc': [5, 6]!}
+
+	for k, mut v in m {
+		println('$k, $v')
+		rets << '$k, $v'
+	}
+	assert rets[0] == 'aa, [1, 2]'
+	assert rets[1] == 'bb, [3, 4]'
+	assert rets[2] == 'cc, [5, 6]'
+}


### PR DESCRIPTION
This PR fixes for_in map of fixed_array.

- Fix for_in map of fixed_array.
- Add tests.

```vlang
fn test_for_in_map_of_fixed_array() {
	mut rets := []string{}
	m := map{'aa': [1, 2]!, 'bb': [3, 4]!, 'cc': [5, 6]!}

	for k, v in m {
		println('$k, $v')
		rets << '$k, $v'
	}
	assert rets[0] == 'aa, [1, 2]'
	assert rets[1] == 'bb, [3, 4]'
	assert rets[2] == 'cc, [5, 6]'
}

fn test_for_mut_in_map_of_fixed_array() {
	mut rets := []string{}
	mut m := map{'aa': [1, 2]!, 'bb': [3, 4]!, 'cc': [5, 6]!}

	for k, mut v in m {
		println('$k, $v')
		rets << '$k, $v'
	}
	assert rets[0] == 'aa, [1, 2]'
	assert rets[1] == 'bb, [3, 4]'
	assert rets[2] == 'cc, [5, 6]'
}
```