### PR TITLE
parser,fmt: fix regression with non-void arrays in if conditions

### DIFF
--- a/vlib/v/fmt/tests/if_keep.vv
+++ b/vlib/v/fmt/tests/if_keep.vv
@@ -1,0 +1,11 @@
+fn void_type_array_cond() {
+	if fg == [] {
+		stack.ctx.reset_color()
+	}
+}
+
+fn multi_dimensional_array_cond() {
+	if t.data == [][]string{} {
+		return error('Table.data should not be empty.')
+	}
+}

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -105,7 +105,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 	mut has_cap := false
 	mut len_expr := ast.Expr{}
 	mut cap_expr := ast.Expr{}
-	if p.tok.kind == .lcbr && exprs.len == 0 && array_type != table.void_type   {
+	if p.tok.kind == .lcbr && exprs.len == 0 && array_type != table.void_type {
 		// `[]int{ len: 10, cap: 100}` syntax
 		p.next()
 		for p.tok.kind != .rcbr {

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -105,7 +105,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 	mut has_cap := false
 	mut len_expr := ast.Expr{}
 	mut cap_expr := ast.Expr{}
-	if p.tok.kind == .lcbr && exprs.len == 0 && !p.inside_if {
+	if p.tok.kind == .lcbr && exprs.len == 0 && array_type != table.void_type   {
 		// `[]int{ len: 10, cap: 100}` syntax
 		p.next()
 		for p.tok.kind != .rcbr {

--- a/vlib/v/tests/if_expression_test.v
+++ b/vlib/v/tests/if_expression_test.v
@@ -180,3 +180,14 @@ fn test_if_expr_with_array_map() {
 	println(assigned)
 	assert assigned == [2, 3]
 }
+
+fn test_if_epxr_with_array_conditions() {
+	num_arr := [1, 2, 3]
+	if num_arr == [] {
+		assert false
+	}
+	str_arr := [['foo'], ['bar']]
+	if str_arr == [][]string{} {
+		assert false
+	}
+}


### PR DESCRIPTION
Fix a parsing regression form 818be805812e7a2ccb35fdd15d11e271faee651b with non-void arrays.