### PR TITLE
checker: fix check undefined ident of struct (fix #9145 #9146)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1063,6 +1063,9 @@ fn (mut c Checker) fail_if_immutable(expr ast.Expr) (string, token.Position) {
 			to_lock, pos = c.fail_if_immutable(expr.right)
 		}
 		ast.SelectorExpr {
+			if expr.expr_type == 0 {
+				return '', pos
+			}
 			// retrieve table.Field
 			c.ensure_type_exists(expr.expr_type, expr.pos) or { return '', pos }
 			mut typ_sym := c.table.get_final_type_symbol(c.unwrap_generic(expr.expr_type))

--- a/vlib/v/checker/tests/undefined_ident_of_struct.out
+++ b/vlib/v/checker/tests/undefined_ident_of_struct.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/undefined_ident_of_struct.vv:4:2: error: undefined ident: `f`
+    2 |
+    3 | fn get()  {
+    4 |     f.a = 'test'
+      |     ^
+    5 | }
+    6 |

--- a/vlib/v/checker/tests/undefined_ident_of_struct.vv
+++ b/vlib/v/checker/tests/undefined_ident_of_struct.vv
@@ -1,0 +1,9 @@
+module main
+
+fn get()  {
+	f.a = 'test'
+}
+
+fn main() {
+	println('hello')
+}


### PR DESCRIPTION
This PR fixes check undefined ident of struct (fix #9145, fix #9146).

- Fix check undefined ident of struct.
- Add test.

```vlang
module main

fn get()  {
	f.a = 'test'	
}

fn main() {
	println('hello')
}

PS D:\Test\v\tt1> v run .
.\tt1.v:4:2: error: undefined ident: `f`
    2 |
    3 | fn get()  {
    4 |     f.a = 'test'
      |     ^
    5 | }
    6 |
```
```vlang
module main

struct Dog {
	pub mut:
		class_name string = "Dog"
		age int = 4
}

type DogT = Dog | []Dog
fn dog() DogT {

	a := Dog{}
	return a
}

fn main() {

	mut a2 := dog()
	a2.whatever.age = 8
	println(a2)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:19:5: error: `DogT` is not a struct
   17 | 
   18 |     mut a2 := dog()
   19 |     a2.whatever.age = 8
      |        ~~~~~~~~
   20 |     println(a2)
   21 | }
```