### PR TITLE
os: add `(read|write)_raw[_at]` to File

### DIFF
--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -389,11 +389,15 @@ pub fn (mut f File) read_raw_at<T>(pos int) ?T {
 		return none
 	}
 	C.errno = 0
-	C.fseek(f.cfile, pos, C.SEEK_SET)
+	if C.fseek(f.cfile, pos, C.SEEK_SET) != 0 {
+		return error(posix_get_error_msg(C.errno))
+	}
 	mut t := T{}
 	nbytes := int(C.fread(&t, 1, tsize, f.cfile))
-	C.fseek(f.cfile, 0, C.SEEK_END)
 	if C.errno != 0 {
+		return error(posix_get_error_msg(C.errno))
+	}
+	if C.fseek(f.cfile, 0, C.SEEK_END) != 0 {
 		return error(posix_get_error_msg(C.errno))
 	}
 	if nbytes != tsize {
@@ -453,7 +457,6 @@ pub fn (mut f File) write_raw<T>(t &T) ? {
 	if tsize == 0 {
 		return error('struct size is 0')
 	}
-	C.errno = 0
 	nbytes := int(C.fwrite(t, 1, tsize, f.cfile))
 	if C.errno != 0 {
 		return error(posix_get_error_msg(C.errno))
@@ -472,11 +475,14 @@ pub fn (mut f File) write_raw_at<T>(t &T, pos int) ? {
 	if tsize == 0 {
 		return error('struct size is 0')
 	}
-	C.errno = 0
-	C.fseek(f.cfile, pos, C.SEEK_SET)
+	if C.fseek(f.cfile, pos, C.SEEK_SET) != 0 {
+		return error(posix_get_error_msg(C.errno))
+	}
 	nbytes := int(C.fwrite(t, 1, tsize, f.cfile))
-	C.fseek(f.cfile, 0, C.SEEK_END)
 	if C.errno != 0 {
+		return error(posix_get_error_msg(C.errno))
+	}
+	if C.fseek(f.cfile, 0, C.SEEK_END) != 0 {
 		return error(posix_get_error_msg(C.errno))
 	}
 	if nbytes != tsize {

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -457,6 +457,7 @@ pub fn (mut f File) write_raw<T>(t &T) ? {
 	if tsize == 0 {
 		return error('struct size is 0')
 	}
+	C.errno = 0
 	nbytes := int(C.fwrite(t, 1, tsize, f.cfile))
 	if C.errno != 0 {
 		return error(posix_get_error_msg(C.errno))

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -60,7 +60,7 @@ fn testsuite_end() ? {
 }
 
 fn test_write_struct() ? {
-	os.rm(tfile) or {}
+	os.rm(tfile) or {} // FIXME This is a workaround for macos, because the file isn't truncated when open with 'w'
 	size_of_point := int(sizeof(Point))
 	mut f := os.open_file(tfile, 'w') ?
 	f.write_struct(another_point) ?
@@ -114,7 +114,7 @@ fn test_read_struct_at() ? {
 }
 
 fn test_write_raw() ? {
-	os.rm(tfile) or {}
+	os.rm(tfile) or {} // FIXME This is a workaround for macos, because the file isn't truncated when open with 'w'
 	size_of_point := int(sizeof(Point))
 	mut f := os.open_file(tfile, 'w') ?
 	f.write_raw(another_point) ?

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -18,15 +18,32 @@ struct Extended_Point {
 	i f64
 }
 
-const unit_point = Point{1.0, 1.0, 1.0}
+enum Color {
+	red
+	green
+	blue
+}
 
-const tfolder = os.join_path(os.temp_dir(), 'os_file_test')
+[flag]
+enum Permissions {
+	read
+	write
+	execute
+}
 
-const tfile = os.join_path(tfolder, 'test_file')
+const (
+	unit_point         = Point{1.0, 1.0, 1.0}
+	another_point      = Point{0.25, 2.25, 6.25}
+	extended_point     = Extended_Point{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0}
+	another_byte       = byte(123)
+	another_color      = Color.red
+	another_permission = Permissions.read | .write
+)
 
-const another_point = Point{0.25, 2.25, 6.25}
-
-const extended_point = Extended_Point{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0}
+const (
+	tfolder = os.join_path(os.temp_dir(), 'os_file_test')
+	tfile   = os.join_path(tfolder, 'test_file')
+)
 
 fn testsuite_begin() {
 	os.rmdir_all(tfolder) or {}
@@ -56,6 +73,19 @@ fn test_write_struct() {
 	}
 }
 
+fn test_write_struct_at() {
+	mut f := os.open_file(tfile, 'w') or { panic(err) }
+	f.write_struct(extended_point) or { panic(err) }
+	f.write_struct_at(another_point, 3) or { panic(err) }
+	f.close()
+	f = os.open_file(tfile, 'r') or { panic(err) }
+	mut p := Point{}
+	f.read_struct_at(mut p, 3) or { panic(err) }
+	f.close()
+
+	assert p == another_point
+}
+
 fn test_read_struct() {
 	mut f := os.open_file(tfile, 'w') or { panic(err) }
 	f.write_struct(another_point) or { panic(err) }
@@ -82,10 +112,25 @@ fn test_read_struct_at() {
 	assert p == another_point
 }
 
-fn test_write_struct_at() {
+/*
+fn test_write_any() {
+	size_of_point := int(sizeof(Point))
 	mut f := os.open_file(tfile, 'w') or { panic(err) }
-	f.write_struct(extended_point) or { panic(err) }
-	f.write_struct_at(another_point, 3) or { panic(err) }
+	f.write_any(another_point) or { panic(err) }
+	f.close()
+	x := os.read_file(tfile) or { panic(err) }
+	y := unsafe { byteptr(memdup(&another_point, size_of_point)).vstring_with_len(size_of_point) }
+	assert x == y
+	$if debug {
+		eprintln(x.bytes())
+		eprintln(y.bytes())
+	}
+}
+
+fn test_write_any_at() {
+	mut f := os.open_file(tfile, 'w') or { panic(err) }
+	f.write_any(extended_point) or { panic(err) }
+	f.write_any_at(another_point, 3) or { panic(err) }
 	f.close()
 	f = os.open_file(tfile, 'r') or { panic(err) }
 	mut p := Point{}
@@ -93,4 +138,51 @@ fn test_write_struct_at() {
 	f.close()
 
 	assert p == another_point
+}
+*/
+
+fn test_read_any() {
+	mut f := os.open_file(tfile, 'w') or { panic(err) }
+	f.write_struct(another_point) or { panic(err) }
+	f.write_struct(another_byte) or { panic(err) }
+	f.write_struct(another_color) or { panic(err) }
+	f.write_struct(another_permission) or { panic(err) }
+	f.close()
+	f = os.open_file(tfile, 'r') or { panic(err) }
+	p := f.read_any<Point>() or { panic(err) }
+	b := f.read_any<byte>() or { panic(err) }
+	c := f.read_any<Color>() or { panic(err) }
+	x := f.read_any<Permissions>() or { panic(err) }
+	f.close()
+
+	assert p == another_point
+	assert b == another_byte
+	assert c == another_color
+	assert x == another_permission
+}
+
+fn test_read_any_at() {
+	mut f := os.open_file(tfile, 'w') or { panic(err) }
+	f.write([byte(1), 2, 3]) or { panic(err) }
+	f.write_struct(another_point) or { panic(err) }
+	f.write_struct(another_byte) or { panic(err) }
+	f.write_struct(another_color) or { panic(err) }
+	f.write_struct(another_permission) or { panic(err) }
+	f.close()
+	f = os.open_file(tfile, 'r') or { panic(err) }
+	mut at := 3
+	p := f.read_any_at<Point>(at) or { panic(err) }
+	at += int(sizeof(Point))
+	b := f.read_any_at<byte>(at) or { panic(err) }
+	at += int(sizeof(byte))
+	c := f.read_any_at<Color>(at) or { panic(err) }
+	at += int(sizeof(Color))
+	x := f.read_any_at<Permissions>(at) or { panic(err) }
+	at += int(sizeof(Permissions))
+	f.close()
+
+	assert p == another_point
+	assert b == another_byte
+	assert c == another_color
+	assert x == another_permission
 }

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -45,26 +45,26 @@ const (
 	tfile   = os.join_path(tfolder, 'test_file')
 )
 
-fn testsuite_begin() {
+fn testsuite_begin() ? {
 	os.rmdir_all(tfolder) or {}
 	assert !os.is_dir(tfolder)
-	os.mkdir_all(tfolder) or { panic(err) }
+	os.mkdir_all(tfolder) ?
 	os.chdir(tfolder)
 	assert os.is_dir(tfolder)
 }
 
-fn testsuite_end() {
+fn testsuite_end() ? {
 	os.chdir(os.wd_at_startup)
-	os.rmdir_all(tfolder) or { panic(err) }
+	os.rmdir_all(tfolder) ?
 	assert !os.is_dir(tfolder)
 }
 
-fn test_write_struct() {
+fn test_write_struct() ? {
 	size_of_point := int(sizeof(Point))
-	mut f := os.open_file(tfile, 'w') or { panic(err) }
-	f.write_struct(another_point) or { panic(err) }
+	mut f := os.open_file(tfile, 'w') ?
+	f.write_struct(another_point) ?
 	f.close()
-	x := os.read_file(tfile) or { panic(err) }
+	x := os.read_file(tfile) ?
 	y := unsafe { byteptr(memdup(&another_point, size_of_point)).vstring_with_len(size_of_point) }
 	assert x == y
 	$if debug {
@@ -73,52 +73,51 @@ fn test_write_struct() {
 	}
 }
 
-fn test_write_struct_at() {
-	mut f := os.open_file(tfile, 'w') or { panic(err) }
-	f.write_struct(extended_point) or { panic(err) }
-	f.write_struct_at(another_point, 3) or { panic(err) }
+fn test_write_struct_at() ? {
+	mut f := os.open_file(tfile, 'w') ?
+	f.write_struct(extended_point) ?
+	f.write_struct_at(another_point, 3) ?
 	f.close()
-	f = os.open_file(tfile, 'r') or { panic(err) }
+	f = os.open_file(tfile, 'r') ?
 	mut p := Point{}
-	f.read_struct_at(mut p, 3) or { panic(err) }
+	f.read_struct_at(mut p, 3) ?
 	f.close()
 
 	assert p == another_point
 }
 
-fn test_read_struct() {
-	mut f := os.open_file(tfile, 'w') or { panic(err) }
-	f.write_struct(another_point) or { panic(err) }
+fn test_read_struct() ? {
+	mut f := os.open_file(tfile, 'w') ?
+	f.write_struct(another_point) ?
 	f.close()
 
-	f = os.open_file(tfile, 'r') or { panic(err) }
+	f = os.open_file(tfile, 'r') ?
 	mut p := Point{}
-	f.read_struct(mut p) or { panic(err) }
+	f.read_struct(mut p) ?
 	f.close()
 
 	assert p == another_point
 }
 
-fn test_read_struct_at() {
-	mut f := os.open_file(tfile, 'w') or { panic(err) }
-	f.write([byte(1), 2, 3]) or { panic(err) }
-	f.write_struct(another_point) or { panic(err) }
+fn test_read_struct_at() ? {
+	mut f := os.open_file(tfile, 'w') ?
+	f.write([byte(1), 2, 3]) ?
+	f.write_struct(another_point) ?
 	f.close()
-	f = os.open_file(tfile, 'r') or { panic(err) }
+	f = os.open_file(tfile, 'r') ?
 	mut p := Point{}
-	f.read_struct_at(mut p, 3) or { panic(err) }
+	f.read_struct_at(mut p, 3) ?
 	f.close()
 
 	assert p == another_point
 }
 
-/*
-fn test_write_any() {
+fn test_write_raw() ? {
 	size_of_point := int(sizeof(Point))
-	mut f := os.open_file(tfile, 'w') or { panic(err) }
-	f.write_any(another_point) or { panic(err) }
+	mut f := os.open_file(tfile, 'w') ?
+	f.write_raw(another_point) ?
 	f.close()
-	x := os.read_file(tfile) or { panic(err) }
+	x := os.read_file(tfile) ?
 	y := unsafe { byteptr(memdup(&another_point, size_of_point)).vstring_with_len(size_of_point) }
 	assert x == y
 	$if debug {
@@ -127,32 +126,40 @@ fn test_write_any() {
 	}
 }
 
-fn test_write_any_at() {
-	mut f := os.open_file(tfile, 'w') or { panic(err) }
-	f.write_any(extended_point) or { panic(err) }
-	f.write_any_at(another_point, 3) or { panic(err) }
+fn test_write_raw_at() ? {
+	mut f := os.open_file(tfile, 'w') ?
+	f.write_raw(extended_point) ?
+	f.write_raw_at(another_point, 3) ?
 	f.close()
-	f = os.open_file(tfile, 'r') or { panic(err) }
+	f = os.open_file(tfile, 'r') ?
 	mut p := Point{}
-	f.read_struct_at(mut p, 3) or { panic(err) }
+	f.read_struct_at(mut p, 3) ?
 	f.close()
 
 	assert p == another_point
 }
-*/
 
-fn test_read_any() {
-	mut f := os.open_file(tfile, 'w') or { panic(err) }
-	f.write_struct(another_point) or { panic(err) }
-	f.write_struct(another_byte) or { panic(err) }
-	f.write_struct(another_color) or { panic(err) }
-	f.write_struct(another_permission) or { panic(err) }
+fn test_write_raw_at_negative_pos() ? {
+	mut f := os.open_file(tfile, 'w') ?
+	if _ := f.write_raw_at(another_point, -1) {
+		assert false
+	}
+	f.write_raw_at(another_point, -234) or { assert err.msg == 'Invalid argument' }
 	f.close()
-	f = os.open_file(tfile, 'r') or { panic(err) }
-	p := f.read_any<Point>() or { panic(err) }
-	b := f.read_any<byte>() or { panic(err) }
-	c := f.read_any<Color>() or { panic(err) }
-	x := f.read_any<Permissions>() or { panic(err) }
+}
+
+fn test_read_raw() ? {
+	mut f := os.open_file(tfile, 'w') ?
+	f.write_raw(another_point) ?
+	f.write_raw(another_byte) ?
+	f.write_raw(another_color) ?
+	f.write_raw(another_permission) ?
+	f.close()
+	f = os.open_file(tfile, 'r') ?
+	p := f.read_raw<Point>() ?
+	b := f.read_raw<byte>() ?
+	c := f.read_raw<Color>() ?
+	x := f.read_raw<Permissions>() ?
 	f.close()
 
 	assert p == another_point
@@ -161,23 +168,23 @@ fn test_read_any() {
 	assert x == another_permission
 }
 
-fn test_read_any_at() {
-	mut f := os.open_file(tfile, 'w') or { panic(err) }
-	f.write([byte(1), 2, 3]) or { panic(err) }
-	f.write_struct(another_point) or { panic(err) }
-	f.write_struct(another_byte) or { panic(err) }
-	f.write_struct(another_color) or { panic(err) }
-	f.write_struct(another_permission) or { panic(err) }
+fn test_read_raw_at() ? {
+	mut f := os.open_file(tfile, 'w') ?
+	f.write([byte(1), 2, 3]) ?
+	f.write_raw(another_point) ?
+	f.write_raw(another_byte) ?
+	f.write_raw(another_color) ?
+	f.write_raw(another_permission) ?
 	f.close()
-	f = os.open_file(tfile, 'r') or { panic(err) }
+	f = os.open_file(tfile, 'r') ?
 	mut at := 3
-	p := f.read_any_at<Point>(at) or { panic(err) }
+	p := f.read_raw_at<Point>(at) ?
 	at += int(sizeof(Point))
-	b := f.read_any_at<byte>(at) or { panic(err) }
+	b := f.read_raw_at<byte>(at) ?
 	at += int(sizeof(byte))
-	c := f.read_any_at<Color>(at) or { panic(err) }
+	c := f.read_raw_at<Color>(at) ?
 	at += int(sizeof(Color))
-	x := f.read_any_at<Permissions>(at) or { panic(err) }
+	x := f.read_raw_at<Permissions>(at) ?
 	at += int(sizeof(Permissions))
 	f.close()
 
@@ -185,4 +192,13 @@ fn test_read_any_at() {
 	assert b == another_byte
 	assert c == another_color
 	assert x == another_permission
+}
+
+fn test_read_raw_at_negative_pos() ? {
+	mut f := os.open_file(tfile, 'r') ?
+	if _ := f.read_raw_at<Point>(-1) {
+		assert false
+	}
+	f.read_raw_at<Point>(-234) or { assert err.msg == 'Invalid argument' }
+	f.close()
 }

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -60,6 +60,7 @@ fn testsuite_end() ? {
 }
 
 fn test_write_struct() ? {
+	os.rm(tfile) or {}
 	size_of_point := int(sizeof(Point))
 	mut f := os.open_file(tfile, 'w') ?
 	f.write_struct(another_point) ?
@@ -113,6 +114,7 @@ fn test_read_struct_at() ? {
 }
 
 fn test_write_raw() ? {
+	os.rm(tfile) or {}
 	size_of_point := int(sizeof(Point))
 	mut f := os.open_file(tfile, 'w') ?
 	f.write_raw(another_point) ?

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -138,11 +138,11 @@ pub fn rmdir_all(path string) ? {
 	for item in items {
 		fullpath := join_path(path, item)
 		if is_dir(fullpath) {
-			rmdir_all(fullpath) or { ret_err = err }
+			rmdir_all(fullpath) or { ret_err = err.msg }
 		}
-		rm(fullpath) or { ret_err = err }
+		rm(fullpath) or { ret_err = err.msg }
 	}
-	rmdir(path) or { ret_err = err }
+	rmdir(path) or { ret_err = err.msg }
 	if ret_err.len > 0 {
 		return error(ret_err)
 	}

--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -382,7 +382,7 @@ pub fn rmdir(path string) ? {
 		rc := C.RemoveDirectory(path.to_wide())
 		if rc == 0 {
 			// https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-removedirectorya - 0 is failure
-			return error('Failed to remove "$path"')
+			return error('Failed to remove "$path": ' + posix_get_error_msg(C.errno))
 		}
 	} $else {
 		rc := C.rmdir(charptr(path.str))


### PR DESCRIPTION
As asked in https://github.com/vlang/v/pull/9114

Name suggestions are open, I honestly don't like `read_any` but couldn't find anything better 😕 

Please note that, as it is just a "memory dump", writing strings or arrays won't work correctly.