### PR TITLE
v.util: add iabs

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -568,11 +568,6 @@ pub fn (mut f Fmt) sum_type_decl(node ast.SumTypeDecl) {
 	f.comments(node.comments, has_nl: false)
 }
 
-[inline]
-fn abs(v int) int {
-	return if v >= 0 { v } else { -v }
-}
-
 pub fn (mut f Fmt) interface_decl(node ast.InterfaceDecl) {
 	if node.is_pub {
 		f.write('pub ')

--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -75,7 +75,8 @@ fn (mut list []CommentAndExprAlignInfo) add_info(attrs_len int, type_len int, li
 		list.add_new_info(attrs_len, type_len, line)
 		return
 	}
-	d_len := abs(list[i].max_attrs_len - attrs_len) + abs(list[i].max_type_len - type_len)
+	d_len := util.iabs(list[i].max_attrs_len - attrs_len) +
+		util.iabs(list[i].max_type_len - type_len)
 	if !(d_len < fmt.threshold_to_align_struct) {
 		list.add_new_info(attrs_len, type_len, line)
 		return

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -363,6 +363,11 @@ pub fn imax(a int, b int) int {
 	return if a > b { a } else { b }
 }
 
+[inline]
+pub fn iabs(v int) int {
+	return if v > 0 { v } else { -v }
+}
+
 pub fn replace_op(s string) string {
 	if s.len == 1 {
 		last_char := s[s.len - 1]


### PR DESCRIPTION
int abs fn exist only in fmt for now. But it could be used in other places. Avoid to define same function, I added iabs at v.util
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
