### PR TITLE
table: minor optimization in new_table()

### DIFF
--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -90,7 +90,7 @@ mut:
 
 pub fn new_table() &Table {
 	mut t := &Table{
-		types: []TypeSymbol{cap: 64000}
+		types: []TypeSymbol{cap: 640}
 	}
 	t.register_builtin_type_symbols()
 	t.is_fmt = true


### PR DESCRIPTION
This PR makes minor optimization in new_table().

- `sizeof(table.TypeSymbol) = 112` and `64000 * 112 = 7168000`, it will malloc about 7M memory.
- v self:  `g.table.types.len = 522` and hello_world app: `g.table.types.len = 257`.
- I think `cap: 64000` is bigger, and `cap: 640` is better.