### PR TITLE
feat(v new): add options dry run & yes

### DIFF
--- a/cmd/tools/vcreate.v
+++ b/cmd/tools/vcreate.v
@@ -9,6 +9,19 @@ module main
 // functionality is essentially the same.
 import os
 
+const (
+	options = Options{
+		yes: ['-y', '--yes']
+		dry_run: ['-d', '--dry-run']
+	}
+)
+
+struct Options {
+mut:
+	yes     []string
+	dry_run []string
+}
+
 struct Create {
 mut:
 	name        string

--- a/cmd/tools/vcreate.v
+++ b/cmd/tools/vcreate.v
@@ -8,8 +8,10 @@ module main
 // makes the program structure in a _sub_ directory. Besides that, the
 // functionality is essentially the same.
 import os
+import v.pref
 
 const (
+	vexe    = pref.vexe_path()
 	options = Options{
 		yes: ['-y', '--yes']
 		dry_run: ['-d', '--dry-run']
@@ -157,10 +159,21 @@ fn init_project() {
 }
 
 fn main() {
+	help_options := ['-h', '--help', 'help']
 	if os.args[1] == 'new' {
-		create(os.args[2..])
+		if os.args[2] in help_options {
+			os.system('$vexe help new')
+			exit(0)
+		} else {
+			create(os.args[2..])
+		}
 	} else if os.args[1] == 'init' {
-		init_project()
+		if os.args[2] in help_options {
+			os.system('$vexe help init')
+			exit(0)
+		} else {
+			init_project()
+		}
 	} else {
 		cerror('Unknown command: ${os.args[1]}')
 		exit(1)

--- a/cmd/tools/vcreate.v
+++ b/cmd/tools/vcreate.v
@@ -13,8 +13,8 @@ import v.pref
 const (
 	vexe    = pref.vexe_path()
 	options = Options{
-		yes: ['-y', '--yes']
-		dry_run: ['-d', '--dry-run']
+		yes: ['-y', '-yes']
+		dry_run: ['-d', '-dry-run']
 	}
 )
 
@@ -159,7 +159,7 @@ fn init_project() {
 }
 
 fn main() {
-	help_options := ['-h', '--help', 'help']
+	help_options := ['-help', '--help', 'help']
 	if os.args[1] == 'new' {
 		if os.args[2] in help_options {
 			os.system('$vexe help new')

--- a/cmd/v/help/init.txt
+++ b/cmd/v/help/init.txt
@@ -1,0 +1,4 @@
+Usage:
+  v init
+
+Setup the file structure for an already existing V project.

--- a/cmd/v/help/new.txt
+++ b/cmd/v/help/new.txt
@@ -3,8 +3,9 @@ Usage:
 
 Examples:
   v new
-  v new -d
+  v new -y
   v new MyProject
+  v new MyProject "This is my great project."
 
 Setup the file structure for a V project (in a sub folder).
 

--- a/cmd/v/help/new.txt
+++ b/cmd/v/help/new.txt
@@ -1,5 +1,13 @@
 Usage:
-  v new [name] [description]
-  v init
+  v new [flags] [name] [description]
 
-Setup file structure for a V project.
+Examples:
+  v new
+  v new -d
+  v new MyProject
+
+Setup the file structure for a V project (in a sub folder).
+
+Options:
+  -d, --dry-run   Just output the files which should be created.
+  -y, --yes       Skip the questionnaire altogether and use default values.

--- a/cmd/v/help/new.txt
+++ b/cmd/v/help/new.txt
@@ -9,5 +9,5 @@ Examples:
 Setup the file structure for a V project (in a sub folder).
 
 Options:
-  -d, --dry-run   Just output the files which should be created.
-  -y, --yes       Skip the questionnaire altogether and use default values.
+  -d, -dry-run   Just output the files which should be created.
+  -y, -yes       Skip the questionnaire altogether and use default values.


### PR DESCRIPTION
#9117

Waiting for #9178 to use array intersection to check if options are part of os.args

## dry-run
A dry run (`-d`, `-dry-run`) doesn't create files, it just outputs the files which should be created.

## yes
The option `-yes` (or in short `-y`) is used to says yes to default options, similar to `npm init -y`. The directory is then used as the project name, description will stay empty and license and version are using the default value.