### PR TITLE
docs(v doc): added available output formats

### DIFF
--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -485,7 +485,7 @@ fn parse_arguments(args []string) Config {
 }
 
 fn main() {
-	if os.args.len < 2 || '-h' in os.args || '--help' in os.args || os.args[1..] == ['doc', 'help'] {
+	if os.args.len < 2 || '-help' in os.args || '--help' in os.args || os.args[1..] == ['doc', 'help'] {
 		os.system('$vexe help doc')
 		exit(0)
 	}

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -485,7 +485,7 @@ fn parse_arguments(args []string) Config {
 }
 
 fn main() {
-	if os.args.len < 2 || '-help' in os.args || '--help' in os.args
+	if os.args.len < 2 || '-h' in os.args || '-help' in os.args || '--help' in os.args
 		|| os.args[1..] == ['doc', 'help'] {
 		os.system('$vexe help doc')
 		exit(0)

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -485,7 +485,8 @@ fn parse_arguments(args []string) Config {
 }
 
 fn main() {
-	if os.args.len < 2 || '-help' in os.args || '--help' in os.args || os.args[1..] == ['doc', 'help'] {
+	if os.args.len < 2 || '-help' in os.args || '--help' in os.args
+		|| os.args[1..] == ['doc', 'help'] {
 		os.system('$vexe help doc')
 		exit(0)
 	}

--- a/cmd/v/help/doc.txt
+++ b/cmd/v/help/doc.txt
@@ -13,8 +13,9 @@ or Markdown format.
 
 Options:
   -all            Includes private and public functions/methods/structs/consts/enums.
-  -f              Specifies the output format to be used.
-  -h, -help       Prints this help text.
+  -f              Specifies the output format to be used. Available formats are:
+                  md/markdown, json, text, stdout and html/htm
+  -h, --help      Prints this help text.
   -m              Generate docs for modules listed in that folder.
   -o              Specifies the output file/folder path where to store the generated docs.
                   Set it to "stdout" to print the output instead of saving the contents

--- a/cmd/v/help/doc.txt
+++ b/cmd/v/help/doc.txt
@@ -15,7 +15,7 @@ Options:
   -all            Includes private and public functions/methods/structs/consts/enums.
   -f              Specifies the output format to be used. Available formats are:
                   md/markdown, json, text, stdout and html/htm
-  -h, --help      Prints this help text.
+  -help           Prints this help text.
   -m              Generate docs for modules listed in that folder.
   -o              Specifies the output file/folder path where to store the generated docs.
                   Set it to "stdout" to print the output instead of saving the contents

--- a/cmd/v/help/doc.txt
+++ b/cmd/v/help/doc.txt
@@ -15,7 +15,7 @@ Options:
   -all            Includes private and public functions/methods/structs/consts/enums.
   -f              Specifies the output format to be used. Available formats are:
                   md/markdown, json, text, stdout and html/htm
-  -help           Prints this help text.
+  -h, -help       Prints this help text.
   -m              Generate docs for modules listed in that folder.
   -o              Specifies the output file/folder path where to store the generated docs.
                   Set it to "stdout" to print the output instead of saving the contents

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -71,15 +71,6 @@ fn main() {
 	}
 	args_and_flags := util.join_env_vflags_and_os_args()[1..]
 	prefs, command := pref.parse_args(external_tools, args_and_flags)
-	if prefs.is_help {
-		invoke_help_and_exit(args)
-	}
-	if prefs.is_verbose {
-		// println('args= ')
-		// println(args) // QTODO
-		// println('prefs= ')
-		// println(prefs) // QTODO
-	}
 	if prefs.use_cache && os.user_os() == 'windows' {
 		eprintln('-usecache is currently disabled on windows')
 		exit(1)
@@ -137,6 +128,9 @@ fn main() {
 		// println(prefs.path)
 		builder.compile(command, prefs)
 		return
+	}
+	if prefs.is_help {
+		invoke_help_and_exit(args)
 	}
 	eprintln('v $command: unknown command\nRun "v help" for usage.')
 	exit(1)


### PR DESCRIPTION
Added available output formats as defined in the source code. I also noticed, that the help flag is `--help` and not `-help`.