### PR TITLE
csv: fix error of read() (fix #9185)

### DIFF
--- a/vlib/encoding/csv/reader.v
+++ b/vlib/encoding/csv/reader.v
@@ -17,7 +17,7 @@ struct Reader {
 	// not used yet
 	// has_header        bool
 	// headings          []string
-	data              string
+	data string
 pub mut:
 	delimiter         byte
 	comment           byte
@@ -59,7 +59,7 @@ pub fn (mut r Reader) read() ?[]string {
 fn (mut r Reader) read_line() ?string {
 	// last record
 	if r.row_pos == r.data.len {
-		return err_eof
+		return csv.err_eof
 	}
 	le := if r.is_mac_pre_osx_le { '\r' } else { '\n' }
 	mut i := r.data.index_after(le, r.row_pos)
@@ -71,7 +71,7 @@ fn (mut r Reader) read_line() ?string {
 				r.is_mac_pre_osx_le = true
 			} else {
 				// no valid line endings found
-				return err_invalid_le
+				return csv.err_invalid_le
 			}
 		} else {
 			// No line ending on file
@@ -89,10 +89,10 @@ fn (mut r Reader) read_line() ?string {
 
 fn (mut r Reader) read_record() ?[]string {
 	if r.delimiter == r.comment {
-		return err_comment_is_delim
+		return csv.err_comment_is_delim
 	}
 	if !valid_delim(r.delimiter) {
-		return err_invalid_delim
+		return csv.err_invalid_delim
 	}
 	mut need_read := true
 	mut keep_raw := false
@@ -146,13 +146,15 @@ fn (mut r Reader) read_record() ?[]string {
 			next := line[j + 1]
 			if next == r.delimiter {
 				fields << line[..j]
-				line = line[j..]
+				if j + 2 == line.len {
+					break
+				}
+				line = line[j + 2..]
 				continue
 			}
-			line = line[1..]
 		}
 		if i <= -1 && fields.len == 0 {
-			return err_invalid_delim
+			return csv.err_invalid_delim
 		}
 	}
 	return fields

--- a/vlib/encoding/csv/reader_test.v
+++ b/vlib/encoding/csv/reader_test.v
@@ -173,3 +173,32 @@ fn test_field_multiple_line() {
 		}
 	}
 }
+
+fn test_field_quotes_for_parts() {
+	data := 'a1,"b1",c1\n"a2",b2,c2\na3,b3,"c3"\na4,b4,c4\n'
+	mut csv_reader := csv.new_reader(data)
+	mut row_count := 0
+	for {
+		row := csv_reader.read() or {
+			break
+		}
+		row_count++
+		if row_count == 1 {
+			assert row[0] == 'a1'
+			assert row[1] == 'b1'
+			assert row[2] == 'c1'
+		} else if row_count == 2 {
+			assert row[0] == 'a2'
+			assert row[1] == 'b2'
+			assert row[2] == 'c2'
+		} else if row_count == 3 {
+			assert row[0] == 'a3'
+			assert row[1] == 'b3'
+			assert row[2] == 'c3'
+		} else if row_count == 4 {
+			assert row[0] == 'a4'
+			assert row[1] == 'b4'
+			assert row[2] == 'c4'
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes error of read() (fix #9185).

- Fix error of read().
- Add test.

```vlang
import encoding.csv
import os

fn main() {
    data := os.read_file('test.csv') ?
    println(data)
    mut parser := csv.new_reader(data)
     for {
            line := parser.read() or { break }
            println(line)
     }
}

PS D:\Test\v\tt1> v run .
some,rows,names,junk
A,B,C,D
E,F,"G",H
I,J,K,L

['some', 'rows', 'names', 'junk']
['A', 'B', 'C', 'D']
['E', 'F', 'G', 'H']
['I', 'J', 'K', 'L']
```