### PR TITLE
darwin: fix the errors and warnings when compile

### DIFF
--- a/vlib/darwin/darwin.v
+++ b/vlib/darwin/darwin.v
@@ -6,46 +6,46 @@ module darwin
 #flag -framework Cocoa
 #flag -framework Carbon
 
-struct C.NSString { }
+struct C.NSString {}
 
 #include "@VROOT/vlib/darwin/darwin.m"
 
 fn C.nsstring2(s string) voidptr
 
 // macOS and iOS helpers
-//pub fn nsstring(s string) *C.NSString {
+// pub fn nsstring(s string) *C.NSString {
 pub fn nsstring(s string) voidptr {
 	return C.nsstring2(s)
 	// println('ns $s len=$s.len')
 	//# return [ [ NSString alloc ] initWithBytesNoCopy:s.str  length:s.len
 	//# encoding:NSUTF8StringEncoding freeWhenDone: false];
-	//return 0
+	// return 0
 
-	//ns := C.alloc_NSString()
-	//return ns.initWithBytesNoCopy(s.str, length: s.len,
-		//encoding: NSUTF8StringEncoding,		freeWhenDone: false)
+	// ns := C.alloc_NSString()
+	// return ns.initWithBytesNoCopy(s.str, length: s.len,
+	// encoding: NSUTF8StringEncoding,		freeWhenDone: false)
 }
 
 // returns absolute path to folder where your resources should / will reside
 // for .app packages: .../my.app/Contents/Resources
 // for cli: .../parent_folder/Resources
 
-fn C.CFBundleCopyResourcesDirectoryURL() byteptr
+fn C.CFBundleCopyResourcesDirectoryURL(bundle voidptr) byteptr
 fn C.CFBundleGetMainBundle() voidptr
-fn C.CFURLGetFileSystemRepresentation() int
-fn C.CFRelease()
+fn C.CFURLGetFileSystemRepresentation(url byteptr, resolve_against_base bool, buffer byteptr, buffer_size int) int
+fn C.CFRelease(url byteptr)
 
 pub fn resource_path() string {
-
 	main_bundle := C.CFBundleGetMainBundle()
 	resource_dir_url := C.CFBundleCopyResourcesDirectoryURL(main_bundle)
 	if isnil(resource_dir_url) {
 		panic('CFBundleCopyResourcesDirectoryURL failed')
 	}
 	buffer_size := 4096
-	mut buffer := malloc(buffer_size)
-	buffer[0] = 0
-	conv_result := C.CFURLGetFileSystemRepresentation(resource_dir_url, true, buffer, buffer_size)
+	mut buffer := unsafe{ malloc(buffer_size) }
+	unsafe{ buffer[0] = 0 }
+	conv_result := C.CFURLGetFileSystemRepresentation(resource_dir_url, true, buffer,
+		buffer_size)
 	if conv_result == 0 {
 		panic('CFURLGetFileSystemRepresentation failed')
 	}


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
This PR fixes the errors and warnings when compiling the `darwin` module.
<img width="945" alt="taggon_Taegonui-iMac____Projects_vaker" src="https://user-images.githubusercontent.com/212034/110336443-37706900-8068-11eb-852b-3897a84dfed4.png">

* System:  MacOS Big Sur (v11.1)
* V version: `0.2.2 1b47e29`