### PR TITLE
Makefile: add install option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,3 +136,6 @@ selfcompile:
 
 selfcompile-static:
 	$(V) -cg -cflags '--static' -o v-static cmd/v
+
+install: all
+	$(V) symlink


### PR DESCRIPTION
This PR adds a simple "install" option at the end of the Makefile. This would save a step for new users installing V from this repo. Now, instead of compiling V then running `sudo ./v symlink`, one can just run `sudo make install`.
