### PR TITLE
cgen: return .alias as string instead of %d

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -45,8 +45,7 @@ fn (g &Gen) type_to_fmt(typ table.Type) string {
 	if typ.is_ptr() && (typ.is_int() || typ.is_float()) {
 		return '%.*s\\000'
 	} else if sym.kind in [.struct_, .array, .array_fixed, .map, .bool, .enum_, .interface_, .sum_type,
-		.function,
-	] {
+		.function, .alias] {
 		return '%.*s\\000'
 	} else if sym.kind == .string {
 		return "'%.*s\\000'"

--- a/vlib/v/tests/alias_in_a_struct_field_autostr_test.v
+++ b/vlib/v/tests/alias_in_a_struct_field_autostr_test.v
@@ -1,0 +1,12 @@
+type Duration = i64
+
+struct Abc {
+	d Duration
+}
+
+fn test_string_interpolation_of_alias() {
+	x := Abc{
+		d: i64(9_123_456_789)
+	}
+	assert '$x' == 'Abc{\n    d:     Duration(9123456789)\n}'
+}


### PR DESCRIPTION
This is a fix for https://github.com/vlang/v/issues/9183


If the type that needs to be formatted is an alias, the `type_to_fmt` should  return the string format instead of falling to the default case of `%d`.


