### PR TITLE
docs: remove obsolete information about generic types

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2525,7 +2525,6 @@ posts_repo := new_repo<Post>(db) // returns Repo<Post>
 user := users_repo.find_by_id(1)? // find_by_id<User>
 post := posts_repo.find_by_id(1)? // find_by_id<Post>
 ```
-At the moment only one type parameter named `T` is supported.
 
 Currently generic function definitions must declare their type parameters, but in
 future V will infer generic type parameters from single-letter type names in


### PR DESCRIPTION

> At the moment only one type parameter named `T` is supported.

fake! now V supports several generic types