### PR TITLE
checker: allow accessing fields common to all sumtype members

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -879,6 +879,7 @@ pub:
 	is_pub   bool
 	pos      token.Position
 	comments []Comment
+	typ      table.Type
 pub mut:
 	variants []SumTypeVariant
 }

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1357,21 +1357,7 @@ pub:
 }
 
 pub fn (stmt Stmt) position() token.Position {
-	match stmt {
-		AssertStmt, AssignStmt, Block, BranchStmt, CompFor, ConstDecl, DeferStmt, EnumDecl, ExprStmt,
-		FnDecl, ForCStmt, ForInStmt, ForStmt, GotoLabel, GotoStmt, Import, Return, StructDecl,
-		GlobalDecl, HashStmt, InterfaceDecl, Module, SqlStmt, GoStmt {
-			return stmt.pos
-		}
-		TypeDecl {
-			match stmt {
-				AliasTypeDecl, FnTypeDecl, SumTypeDecl { return stmt.pos }
-			}
-		}
-		// Please, do NOT use else{} here.
-		// This match is exhaustive *on purpose*, to help force
-		// maintaining/implementing proper .pos fields.
-	}
+	return stmt.pos
 }
 
 pub fn (node Node) position() token.Position {

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1357,7 +1357,21 @@ pub:
 }
 
 pub fn (stmt Stmt) position() token.Position {
-	return stmt.pos
+	match stmt {
+		AssertStmt, AssignStmt, Block, BranchStmt, CompFor, ConstDecl, DeferStmt, EnumDecl, ExprStmt,
+		FnDecl, ForCStmt, ForInStmt, ForStmt, GotoLabel, GotoStmt, Import, Return, StructDecl,
+		GlobalDecl, HashStmt, InterfaceDecl, Module, SqlStmt, GoStmt {
+			return stmt.pos
+		}
+		TypeDecl {
+			match stmt {
+				AliasTypeDecl, FnTypeDecl, SumTypeDecl { return stmt.pos }
+			}
+		}
+		// Please, do NOT use else{} here.
+		// This match is exhaustive *on purpose*, to help force
+		// maintaining/implementing proper .pos fields.
+	}
 }
 
 pub fn (node Node) position() token.Position {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2293,7 +2293,7 @@ pub fn (mut c Checker) selector_expr(mut selector_expr ast.SelectorExpr) table.T
 					c.error('ambiguous field `$field_name`', selector_expr.pos)
 				}
 			}
-			if sym.kind == .aggregate {
+			if sym.kind in [.aggregate, .sum_type] {
 				unknown_field_msg = err
 			}
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2321,7 +2321,7 @@ pub fn (mut c Checker) selector_expr(mut selector_expr ast.SelectorExpr) table.T
 		selector_expr.typ = field.typ
 		return field.typ
 	}
-	if sym.kind !in [.struct_, .aggregate, .interface_] {
+	if sym.kind !in [.struct_, .aggregate, .interface_, .sum_type] {
 		if sym.kind != .placeholder {
 			c.error('`$sym.name` is not a struct', selector_expr.pos)
 		}

--- a/vlib/v/checker/tests/sum_type_common_fields_alias_error.out
+++ b/vlib/v/checker/tests/sum_type_common_fields_alias_error.out
@@ -1,0 +1,20 @@
+vlib/v/checker/tests/sum_type_common_fields_alias_error.vv:35:14: error: field `name` does not exist or have the same type in all sumtype variants
+   33 |     }
+   34 |     println(m)
+   35 |     assert m[0].name == 'abc'
+      |                 ~~~~
+   36 |     assert m[1].name == 'def'
+   37 |     assert m[2].name == 'xyz'
+vlib/v/checker/tests/sum_type_common_fields_alias_error.vv:36:14: error: field `name` does not exist or have the same type in all sumtype variants
+   34 |     println(m)
+   35 |     assert m[0].name == 'abc'
+   36 |     assert m[1].name == 'def'
+      |                 ~~~~
+   37 |     assert m[2].name == 'xyz'
+   38 | }
+vlib/v/checker/tests/sum_type_common_fields_alias_error.vv:37:14: error: field `name` does not exist or have the same type in all sumtype variants
+   35 |     assert m[0].name == 'abc'
+   36 |     assert m[1].name == 'def'
+   37 |     assert m[2].name == 'xyz'
+      |                 ~~~~
+   38 | }

--- a/vlib/v/checker/tests/sum_type_common_fields_alias_error.vv
+++ b/vlib/v/checker/tests/sum_type_common_fields_alias_error.vv
@@ -1,0 +1,38 @@
+type Main = Sub1 | Sub2 | Sub3
+
+// NB: the subtypes will have a common `name` field, of the same `string`
+// type, except Sub3, which has `name` of type AliasedString.
+
+type AliasedString = string
+
+struct Sub1 {
+mut:
+	name string
+}
+
+struct Sub2 {
+mut:
+	name string
+}
+
+struct Sub3 {
+mut:
+	name AliasedString
+}
+
+fn main() {
+	mut m := []Main{}
+	m << Sub1{
+		name: 'abc'
+	}
+	m << Sub2{
+		name: 'def'
+	}
+	m << Sub3{
+		name: 'xyz'
+	}
+	println(m)
+	assert m[0].name == 'abc'
+	assert m[1].name == 'def'
+	assert m[2].name == 'xyz'
+}

--- a/vlib/v/checker/tests/sum_type_common_fields_error.out
+++ b/vlib/v/checker/tests/sum_type_common_fields_error.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/sum_type_common_fields_error.vv:53:14: error: field `val` does not exist or have the same type in all sumtype variants
+   51 |     assert m[2].name == '64bit integer'
+   52 |     assert m[3].name == 'string'
+   53 |     assert m[0].val == 123
+      |                 ~~~
+   54 | }

--- a/vlib/v/checker/tests/sum_type_common_fields_error.vv
+++ b/vlib/v/checker/tests/sum_type_common_fields_error.vv
@@ -5,43 +5,43 @@ type Main = Sub1 | Sub2 | Sub3 | Sub4
 // different subtypes => accessing `m[0].name` is fine, but *not* `m[0].val`
 struct Sub1 {
 mut:
-	val int
+	val  int
 	name string
 }
 
 struct Sub2 {
 mut:
-	val f32
+	val  f32
 	name string
 }
 
 struct Sub3 {
 mut:
-	val i64
+	val  i64
 	name string
 }
 
 struct Sub4 {
 mut:
-	val string
+	val  string
 	name string
 }
 
 fn main() {
 	mut m := []Main{}
-	m << Sub1 {
+	m << Sub1{
 		val: 123
 		name: 'integer'
 	}
-	m << Sub2 {
+	m << Sub2{
 		val: 3.14
 		name: 'float'
 	}
-	m << Sub3 {
+	m << Sub3{
 		val: 9_876_543_210
 		name: '64bit integer'
 	}
-	m << Sub4 {
+	m << Sub4{
 		val: 'abcd'
 		name: 'string'
 	}

--- a/vlib/v/checker/tests/sum_type_common_fields_error.vv
+++ b/vlib/v/checker/tests/sum_type_common_fields_error.vv
@@ -1,0 +1,54 @@
+type Main = Sub1 | Sub2 | Sub3 | Sub4
+
+// NB: all subtypes have a common name field, of the same `string` type
+// but they also have a field `val` that is of a different type in the
+// different subtypes => accessing `m[0].name` is fine, but *not* `m[0].val`
+struct Sub1 {
+mut:
+	val int
+	name string
+}
+
+struct Sub2 {
+mut:
+	val f32
+	name string
+}
+
+struct Sub3 {
+mut:
+	val i64
+	name string
+}
+
+struct Sub4 {
+mut:
+	val string
+	name string
+}
+
+fn main() {
+	mut m := []Main{}
+	m << Sub1 {
+		val: 123
+		name: 'integer'
+	}
+	m << Sub2 {
+		val: 3.14
+		name: 'float'
+	}
+	m << Sub3 {
+		val: 9_876_543_210
+		name: '64bit integer'
+	}
+	m << Sub4 {
+		val: 'abcd'
+		name: 'string'
+	}
+	println(m)
+	assert m[0].name == 'integer'
+	assert m[1].name == 'float'
+	assert m[2].name == '64bit integer'
+	assert m[3].name == 'string'
+	assert m[0].val == 123
+}

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -477,7 +477,7 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp string, str_fn_name st
 	if clean_struct_v_type_name.contains('_T_') {
 		// TODO: this is a bit hacky. styp shouldn't be even parsed with _T_
 		// use something different than g.typ for styp
-		clean_struct_v_type_name = 
+		clean_struct_v_type_name =
 			clean_struct_v_type_name.replace('_T_', '<').replace('_', ', ').replace('Array', 'array') +
 			'>'
 	}
@@ -678,7 +678,7 @@ fn (mut g Gen) gen_str_for_union_sum_type(info table.SumType, styp string, str_f
 		clean_sum_type_v_type_name = '&' + clean_sum_type_v_type_name.replace('*', '')
 	}
 	clean_sum_type_v_type_name = util.strip_main_name(clean_sum_type_v_type_name)
-	g.auto_str_funcs.writeln('\tswitch(x.typ) {')
+	g.auto_str_funcs.writeln('\tswitch(x._typ) {')
 	for typ in info.variants {
 		mut value_fmt := '%.*s\\000'
 		if typ == table.string_type {

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -477,7 +477,7 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp string, str_fn_name st
 	if clean_struct_v_type_name.contains('_T_') {
 		// TODO: this is a bit hacky. styp shouldn't be even parsed with _T_
 		// use something different than g.typ for styp
-		clean_struct_v_type_name =
+		clean_struct_v_type_name = 
 			clean_struct_v_type_name.replace('_T_', '<').replace('_', ', ').replace('Array', 'array') +
 			'>'
 	}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1619,6 +1619,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw table.Type, expected_t
 	}
 	// cast to sum type
 	exp_styp := g.typ(expected_type)
+	got_styp := g.typ(got_type)
 	if expected_type != table.void_type {
 		expected_deref_type := if expected_is_ptr { expected_type.deref() } else { expected_type }
 		got_deref_type := if got_is_ptr { got_type.deref() } else { got_type }
@@ -1647,10 +1648,13 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw table.Type, expected_t
 				}
 				g.write('${got_sym.cname}_to_sumtype_${exp_sym.cname}(')
 				if !got_is_ptr {
-					g.write('&')
+					g.write('(&(($got_styp[]){')
+					g.expr(expr)
+					g.write('}[0])))')
+				} else {
+					g.expr(expr)
+					g.write(')')
 				}
-				g.expr(expr)
-				g.write(')')
 				if expected_is_ptr {
 					g.write('})')
 				}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1656,7 +1656,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw table.Type, expected_t
 					g.write(')')
 				}
 				if expected_is_ptr {
-					g.write('})')
+					g.write('}, sizeof($exp_sym.cname))')
 				}
 			}
 			return

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1573,14 +1573,14 @@ fn (mut g Gen) write_sumtype_casting_fn(got_ table.Type, exp_ table.Type) {
 	got_cname, exp_cname := got_sym.cname, exp_sym.cname
 	sb.writeln('static inline $exp_cname ${got_cname}_to_sumtype_${exp_cname}($got_cname* x) {')
 	sb.writeln('\t$got_cname* ptr = memdup(x, sizeof($got_cname));')
-	sb.write_string('\treturn ($exp_cname){ _$got_cname: ptr, _typ: ${g.type_sidx(got)}')
+	sb.write_string('\treturn ($exp_cname){ ._$got_cname = ptr, ._typ = ${g.type_sidx(got)}')
 	for field in (exp_sym.info as table.SumType).fields {
 		field_styp := g.typ(field.typ)
 		if got_sym.kind in [.sum_type, .interface_] {
 			// the field is already a wrapped pointer; we shouldn't wrap it once again
-			sb.write_string(', $field.name: ptr->$field.name')
+			sb.write_string(', .$field.name = ptr->$field.name')
 		} else {
-			sb.write_string(', $field.name: ($field_styp*)((char*)ptr + __offsetof($got_cname, $field.name))')
+			sb.write_string(', .$field.name = ($field_styp*)((char*)ptr + __offsetof($got_cname, $field.name))')
 		}
 	}
 	sb.writeln('};\n}')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2972,7 +2972,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 		expr := g.expr_string(node.expr)
 		for v in (sym.info as table.SumType).variants {
 			vsym := g.table.get_type_symbol(v)
-			g.write('/* branch */ $expr${dot}typ == $v ? $expr${dot}_$vsym.cname->$node.field_name : ')
+			g.write('$expr${dot}typ == $v ? $expr${dot}_$vsym.cname->$node.field_name : ')
 		}
 		g.write('(v_panic(_SLIT("got invalid sumtype variant")), ${g.type_default(node.typ)}))')
 		return

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -97,15 +97,15 @@ mut:
 	defer_stmts           []ast.DeferStmt
 	defer_ifdef           string
 	defer_profile_code    string
-	str_types             []string // types that need automatic str() generation
-	threaded_fns          []string // for generating unique wrapper types and fns for `go xxx()`
-	waiter_fns            []string // functions that wait for `go xxx()` to finish
-	array_fn_definitions  []string // array equality functions that have been defined
-	map_fn_definitions    []string // map equality functions that have been defined
-	struct_fn_definitions []string // struct equality functions that have been defined
-	alias_fn_definitions  []string // alias equality functions that have been defined
-	auto_fn_definitions   []string // auto generated functions defination list
-	anon_fn_definitions   []string // anon generated functions defination list
+	str_types             []string     // types that need automatic str() generation
+	threaded_fns          []string     // for generating unique wrapper types and fns for `go xxx()`
+	waiter_fns            []string     // functions that wait for `go xxx()` to finish
+	array_fn_definitions  []string     // array equality functions that have been defined
+	map_fn_definitions    []string     // map equality functions that have been defined
+	struct_fn_definitions []string     // struct equality functions that have been defined
+	alias_fn_definitions  []string     // alias equality functions that have been defined
+	auto_fn_definitions   []string     // auto generated functions defination list
+	anon_fn_definitions   []string     // anon generated functions defination list
 	sumtype_definitions   map[int]bool // `_TypeA_to_sumtype_TypeB()` fns that have been generated
 	is_json_fn            bool     // inside json.encode()
 	json_types            []string // to avoid json gen duplicates
@@ -1562,9 +1562,10 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 
 fn (mut g Gen) write_sumtype_casting_fn(got_ table.Type, exp_ table.Type) {
 	got, exp := got_.idx(), exp_.idx()
-	if got == exp { return }
 	i := got | (exp << 16)
-	if g.sumtype_definitions[i] { return }
+	if got == exp || g.sumtype_definitions[i] {
+		return
+	}
 	g.sumtype_definitions[i] = true
 	got_sym := g.table.get_type_symbol(got)
 	exp_sym := g.table.get_type_symbol(exp)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -542,7 +542,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		g.write('tos3( /* $left_sym.name */ v_typeof_sumtype_${typ_sym.cname}( (')
 		g.expr(node.left)
 		dot := if node.left_type.is_ptr() { '->' } else { '.' }
-		g.write(')${dot}typ ))')
+		g.write(')${dot}_typ ))')
 		return
 	}
 	if left_sym.kind == .interface_ && node.name == 'type_name' {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2318,7 +2318,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		}
 		variant_types := sum_variants.map(it.typ)
 		prepend_mod_name := p.prepend_mod(name)
-		p.table.register_type_symbol(table.TypeSymbol{
+		typ := p.table.register_type_symbol(table.TypeSymbol{
 			kind: .sum_type
 			name: prepend_mod_name
 			cname: util.no_dots(prepend_mod_name)
@@ -2331,6 +2331,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		comments = p.eat_comments(same_line: true)
 		return ast.SumTypeDecl{
 			name: name
+			typ: typ
 			is_pub: is_pub
 			variants: sum_variants
 			pos: decl_pos

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -356,7 +356,9 @@ pub fn (t &Table) resolve_common_sumtype_fields(sym_ &TypeSymbol) {
 				t.resolve_common_sumtype_fields(v_sym)
 				v_sym.info.fields
 			}
-			else { []Field{} }
+			else {
+				[]Field{}
+			}
 		}
 		for field in fields {
 			if field.name !in field_map {

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -365,6 +365,7 @@ pub fn (t &Table) resolve_common_sumtype_fields(sym_ &TypeSymbol) {
 			info.fields << field_map[field]
 		}
 	}
+	info.found_fields = true
 	sym.info = info
 }
 

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -349,7 +349,13 @@ pub fn (t &Table) resolve_common_sumtype_fields(sym_ &TypeSymbol) {
 	for variant in info.variants {
 		mut v_sym := t.get_type_symbol(variant)
 		fields := match mut v_sym.info {
-			Struct, SumType { v_sym.info.fields }
+			Struct {
+				v_sym.info.fields
+			}
+			SumType {
+				t.resolve_common_sumtype_fields(v_sym)
+				v_sym.info.fields
+			}
 			else { []Field{} }
 		}
 		for field in fields {

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -277,20 +277,31 @@ pub fn (t &Table) find_field(s &TypeSymbol, name string) ?Field {
 	// println('find_field($s.name, $name) types.len=$t.types.len s.parent_idx=$s.parent_idx')
 	mut ts := s
 	for {
-		if mut ts.info is Struct {
-			if field := ts.info.find_field(name) {
+		match mut ts.info {
+			Struct {
+				if field := ts.info.find_field(name) {
+					return field
+				}
+			}
+			Aggregate {
+				if field := ts.info.find_field(name) {
+					return field
+				}
+				field := t.register_aggregate_field(mut ts, name) or { return err }
 				return field
 			}
-		} else if mut ts.info is Aggregate {
-			if field := ts.info.find_field(name) {
-				return field
+			Interface {
+				if field := ts.info.find_field(name) {
+					return field
+				}
 			}
-			field := t.register_aggregate_field(mut ts, name) or { return err }
-			return field
-		} else if mut ts.info is Interface {
-			if field := ts.info.find_field(name) {
-				return field
+			SumType {
+				t.resolve_common_sumtype_fields(s)
+				if field := ts.info.find_field(name) {
+					return field
+				}
 			}
+			else {}
 		}
 		if ts.parent_idx == 0 {
 			break
@@ -324,6 +335,39 @@ pub fn (t &Table) find_field_with_embeds(sym &TypeSymbol, field_name string) ?Fi
 		}
 		return err
 	}
+}
+
+pub fn (t &Table) resolve_common_sumtype_fields(sym_ &TypeSymbol) {
+	mut sym := sym_
+	mut info := sym.info as SumType
+	if info.found_fields {
+		return
+	}
+	mut field_map := map[string]Field{}
+	mut field_usages := map[string]int{}
+	for variant in info.variants {
+		mut v_sym := t.get_type_symbol(variant)
+		fields := match mut v_sym.info {
+			Struct, SumType { v_sym.info.fields }
+			else { []Field{} }
+		}
+		for field in fields {
+			if field.name !in field_map {
+				field_map[field.name] = field
+				field_usages[field.name]++
+			} else if field.equals(field_map[field.name]) {
+				field_usages[field.name]++
+			}
+		}
+	}
+	for field, nr_definitions in field_usages {
+		if nr_definitions == info.variants.len {
+			info.fields << field_map[field]
+		}
+	}
+	sym.info = info
+	x := info.fields.map('$it.name: ${t.get_type_name(it.typ)}')
+	println('$sym.name - $x')
 }
 
 [inline]

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -300,6 +300,7 @@ pub fn (t &Table) find_field(s &TypeSymbol, name string) ?Field {
 				if field := ts.info.find_field(name) {
 					return field
 				}
+				return error('field `$name` does not exist or have the same type in all sumtype variants')
 			}
 			else {}
 		}

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -366,8 +366,6 @@ pub fn (t &Table) resolve_common_sumtype_fields(sym_ &TypeSymbol) {
 		}
 	}
 	sym.info = info
-	x := info.fields.map('$it.name: ${t.get_type_name(it.typ)}')
-	println('$sym.name - $x')
 }
 
 [inline]

--- a/vlib/v/table/types.v
+++ b/vlib/v/table/types.v
@@ -1029,7 +1029,6 @@ pub fn (s Struct) get_field(name string) Field {
 	panic('unknown field `$name`')
 }
 
-
 pub fn (s &SumType) find_field(name string) ?Field {
 	for field in s.fields {
 		if field.name == name {

--- a/vlib/v/table/types.v
+++ b/vlib/v/table/types.v
@@ -713,7 +713,7 @@ pub mut:
 	is_global        bool
 }
 
-fn (f &Field) equals(o &Field) bool {
+pub fn (f &Field) equals(o &Field) bool {
 	// TODO: f.is_mut == o.is_mut was removed here to allow read only access
 	// to (mut/not mut), but otherwise equal fields; some other new checks are needed:
 	// - if node is declared mut, and we mutate node.stmts, all stmts fields must be mutable
@@ -755,6 +755,9 @@ pub mut:
 pub struct SumType {
 pub:
 	variants []Type
+pub mut:
+	fields       []Field
+	found_fields bool
 }
 
 // human readable type name
@@ -971,6 +974,7 @@ pub fn (t &TypeSymbol) find_field(name string) ?Field {
 		Aggregate { return t.info.find_field(name) }
 		Struct { return t.info.find_field(name) }
 		Interface { return t.info.find_field(name) }
+		SumType { return t.info.find_field(name) }
 		else { return none }
 	}
 }
@@ -1023,6 +1027,16 @@ pub fn (s Struct) get_field(name string) Field {
 		return field
 	}
 	panic('unknown field `$name`')
+}
+
+
+pub fn (s &SumType) find_field(name string) ?Field {
+	for field in s.fields {
+		if field.name == name {
+			return field
+		}
+	}
+	return none
 }
 
 pub fn (i Interface) defines_method(name string) bool {

--- a/vlib/v/tests/sum_type_common_fields_test.v
+++ b/vlib/v/tests/sum_type_common_fields_test.v
@@ -11,6 +11,13 @@ struct Sub2 {
 	val  int
 }
 
+struct Sub3 {
+	name string
+	val  int
+}
+
+type Master2 = Master | Sub3
+
 fn test_common_sumtype_field_access() {
 	mut out := []Master{}
 	out << Sub1{
@@ -33,5 +40,9 @@ fn test_common_sumtype_field_access() {
 
 	assert out[2].val == 3
 	assert out[2].name == 'three'
+
+	mut out0 := Master2(out[0]) // common fields on a doubly-wrapped sumtype
+	assert out0.val == 1
+	assert out0.name == 'one'
 }
 

--- a/vlib/v/tests/sum_type_common_fields_test.v
+++ b/vlib/v/tests/sum_type_common_fields_test.v
@@ -1,0 +1,37 @@
+type Master = Sub1 | Sub2
+
+struct Sub1 {
+mut:
+	val  int
+	name string
+}
+
+struct Sub2 {
+	name string
+	val  int
+}
+
+fn test_common_sumtype_field_access() {
+	mut out := []Master{}
+	out << Sub1{
+		val: 1
+		name: 'one'
+	}
+	out << Sub2{
+		val: 2
+		name: 'two'
+	}
+	out << Sub2{
+		val: 3
+		name: 'three'
+	}
+	assert out[0].val == 1
+	assert out[0].name == 'one'
+
+	assert out[1].val == 2
+	assert out[1].name == 'two'
+
+	assert out[2].val == 3
+	assert out[2].name == 'three'
+}
+


### PR DESCRIPTION
These common fields are only calculated once, whenever the user tries to access one of them, so this shouldn't have any difference in performance for code using sumtypes as is.

Reasoning: which of these looks nicer? :)

```v
pub fn (stmt Stmt) position() token.Position {
	return stmt.pos
}
```
```v
pub fn (stmt Stmt) position() token.Position {
	match stmt {
		AssertStmt, AssignStmt, Block, BranchStmt, CompFor, ConstDecl, DeferStmt, EnumDecl, ExprStmt,
		FnDecl, ForCStmt, ForInStmt, ForStmt, GotoLabel, GotoStmt, Import, Return, StructDecl,
		GlobalDecl, HashStmt, InterfaceDecl, Module, SqlStmt, GoStmt {
			return stmt.pos
		}
		TypeDecl {
			match stmt {
				AliasTypeDecl, FnTypeDecl, SumTypeDecl { return stmt.pos }
			}
		}
		// Please, do NOT use else{} here.
		// This match is exhaustive *on purpose*, to help force
		// maintaining/implementing proper .pos fields.
	}
}
```
