### PR TITLE
checker: support substitution of '$()' style commands in hash statements

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -123,7 +123,7 @@ For more details and troubleshooting, please visit the [vab GitHub repository](h
     * [Profiling](#profiling)
 * [Advanced Topics](#advanced-topics)
     * [Memory-unsafe code](#memory-unsafe-code)
-    * [Structs with reference fields](structs-with-reference-fields)
+    * [Structs with reference fields](#structs-with-reference-fields)
     * [sizeof and __offsetof](#sizeof-and-__offsetof)
     * [Calling C from V](#calling-c-from-v)
     * [Debugging generated C code](#debugging-generated-c-code)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3442,11 +3442,12 @@ fn (mut c Checker) exec_cmd(cmd string, pos token.Position) string {
 		}
 		cmd_to_exec := cmd_.find_between('$(', ')')
 		res := os.execute(cmd_to_exec)
-    		if res.exit_code != 0 {
-    			c.error('there was a failure when executing `$cmd_to_exec`: $res.output', pos)
-    		}
-    		res_ts := res.output.trim_space()
-    		cmd_ = cmd_.replace('$($cmd_to_exec)', res_ts)
+		if res.exit_code != 0 {
+			c.error('there was a failure when executing `$cmd_to_exec`: $res.output',
+				pos)
+		}
+		res_ts := res.output.trim_space()
+		cmd_ = cmd_.replace('$($cmd_to_exec)', res_ts)
 	}
 	return cmd_
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3432,7 +3432,7 @@ fn (mut c Checker) exec_cmd(cmd string, pos token.Position) string {
 		cmd_to_exec := cmd_.find_between('$(', ')')
 		res := os.execute(cmd_to_exec)
 		if res.exit_code != 0 {
-			c.error('cmd `$cmd_to_exec` failed: $res.output', pos)
+			c.error('there was a failure when executing `$cmd_to_exec`: $res.output', pos)
 		}
 		res_ts := res.output.trim_space()
 		cmd_ = cmd_.replace('$($cmd_to_exec)', res_ts)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3441,6 +3441,10 @@ fn (mut c Checker) exec_cmd(cmd string, pos token.Position) string {
 			return cmd_
 		}
 		cmd_to_exec := cmd_.find_between('$(', ')')
+		if cmd_to_exec.contains('$(') {
+			c.error('command substitution within another substitution is not allowed', pos)
+			return cmd_
+		}
 		res := os.execute(cmd_to_exec)
 		if res.exit_code != 0 {
 			c.error('there was a failure when executing `$cmd_to_exec`: $res.output',

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3473,7 +3473,8 @@ fn (mut c Checker) exec_cmd(cmd string, pos token.Position) string {
 		}
 		cmd_to_exec := cmd_.find_between('$(', ')')
 		if cmd_to_exec.contains('$(') {
-			c.error('command substitution within another substitution is not allowed', pos)
+			c.error('command substitution within another substitution is not allowed',
+				pos)
 			return cmd_
 		}
 		res := os.execute(cmd_to_exec)

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -894,7 +894,7 @@ fn (mut s Scanner) text_scan() token.Token {
 					return s.new_token(.comment, comment, comment.len + 2)
 				}
 				hash := s.text[start..s.pos].trim_space()
-				return s.new_token(.hash, s.exec_cmd(hash), hash.len)
+				return s.new_token(.hash, hash, hash.len)
 			}
 			`>` {
 				if nextc == `=` {
@@ -1053,20 +1053,6 @@ fn (mut s Scanner) text_scan() token.Token {
 		break
 	}
 	return s.end_of_file()
-}
-
-fn (mut s Scanner) exec_cmd(cmd string) string {
-	mut cmd_ := cmd
-	for cmd_.contains('$(') {
-		cmd_to_exec := cmd_.find_between('$(', ')')
-		res := os.execute(cmd_to_exec)
-		if res.exit_code != 0 {
-			s.error('cmd `$cmd_to_exec` failed: $res.output')
-		}
-		res_ts := res.output.trim_space()
-		cmd_ = cmd_.replace('$($cmd_to_exec)', res_ts)
-	}
-	return cmd_
 }
 
 fn (mut s Scanner) invalid_character() {

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1,5 +1,4 @@
 // Copyright (c) 2019-2021 Alexander Medvednikov. All rights reserved.
-// Copyright (c) 2019-2021 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module scanner


### PR DESCRIPTION
This PR adds the functionality to V to interpret the commands that are between `$(` and `)`.

This is very useful, and allows things like for example: `#flag $(llvm-config-11 --cflags)`