### PR TITLE
cgen: fix for_in fixed_array of fixed_array literal

### DIFF
--- a/vlib/v/tests/for_in_containers_of_fixed_array_test.v
+++ b/vlib/v/tests/for_in_containers_of_fixed_array_test.v
@@ -50,6 +50,18 @@ fn test_for_mut_in_fixed_array_of_fixed_array() {
 	assert rets[2] == '[5, 6]'
 }
 
+fn test_for_in_fixed_array_of_fixed_array_literal() {
+	mut rets := []string{}
+
+	for pair in [[1, 2]!, [3, 4]!, [5, 6]!]! {
+		println(pair)
+		rets << '$pair'
+	}
+	assert rets[0] == '[1, 2]'
+	assert rets[1] == '[3, 4]'
+	assert rets[2] == '[5, 6]'
+}
+
 fn test_for_in_map_of_fixed_array() {
 	mut rets := []string{}
 	m := map{'aa': [1, 2]!, 'bb': [3, 4]!, 'cc': [5, 6]!}


### PR DESCRIPTION
This PR fixes for_in fixed_array of fixed_array literal.

- Fix error of for_in fixed_array of fixed_array literal.
- Add test.

```vlang
fn test_for_in_fixed_array_of_fixed_array_literal() {
	mut rets := []string{}

	for pair in [[1, 2]!, [3, 4]!, [5, 6]!]! {
		println(pair)
		rets << '$pair'
	}
	assert rets[0] == '[1, 2]'
	assert rets[1] == '[3, 4]'
	assert rets[2] == '[5, 6]'
}
```