### PR TITLE
Makefile: Fix `make prod=1` building dev profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,10 +80,10 @@ endif
 all: latest_vc latest_tcc
 ifdef WIN32
 	$(CC) $(CFLAGS) -g -std=c99 -municode -w -o $(V) $(VC)/$(VCFILE) $(LDFLAGS)
-	$(V) self
+	$(V) $(VFLAGS) self
 else
 	$(CC) $(CFLAGS) -g -std=gnu99 -w -o $(V) $(VC)/$(VCFILE) -lm -lpthread $(LDFLAGS)
-	$(V) self
+	$(V) $(VFLAGS) self
 endif
 	@echo "V has been successfully built"
 	@$(V) -version
@@ -132,10 +132,10 @@ asan:
 	$(MAKE) all CFLAGS='-fsanitize=address,undefined'
 
 selfcompile:
-	$(V) -cg -o v cmd/v
+	$(V) $(VFLAGS) -cg -o v cmd/v
 
 selfcompile-static:
-	$(V) -cg -cflags '--static' -o v-static cmd/v
+	$(V) $(VFLAGS) -cg -cflags '--static' -o v-static cmd/v
 
 install: all
 	$(V) symlink


### PR DESCRIPTION
In ed9ca0b7bd1a13185eb4b1feb11b87b296b111bc, the VFLAGS variable was introduced in the Makefile to be used for prod builds. However, VFLAGS isn't actually used in the Makefile, so `make prod=1` no longer creates a production build.

This commit utilizes VFLAGS so `make prod=1` works properly again.