### PR TITLE
cgen: fix error of alias string interpolation (fix #9202)

### DIFF
--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -204,7 +204,11 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 			break
 		}
 		g.write(escaped_val)
-		typ := g.unwrap_generic(node.expr_types[i])
+		mut typ := g.unwrap_generic(node.expr_types[i])
+		sym := g.table.get_type_symbol(typ)
+		if sym.kind == .alias {
+			typ = (sym.info as table.Alias).parent_type
+		}
 		// write correct format specifier to intermediate string
 		g.write('%')
 		fspec := node.fmts[i]

--- a/vlib/v/tests/string_interpolation_alias_test.v
+++ b/vlib/v/tests/string_interpolation_alias_test.v
@@ -15,3 +15,11 @@ fn test_map_alias_string() {
 	assert '$m'.contains("'one': '1'")
 	assert '$m'.contains("'two': '2'")
 }
+
+type Duration = i64
+
+fn test_i64_number_alias_string() {
+    x := i64(9_123_456_789)
+    y := Duration(x)
+    assert '$x' == '$y'
+}


### PR DESCRIPTION
This PR fixes error of alias string interpolation (fix #9202).

- Fix error of alias string interpolation.
- Add test.

```vlang
type Duration = i64

fn main() {
	x := i64(9_123_456_789)
	y := Duration(x)
	println('$x, $y')
	assert '$x' == '$y'
}

PS D:\Test\v\tt1> v run .
9123456789, 9123456789
```