### PR TITLE
make.bat: fix error of `make --local`

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -16,6 +16,7 @@ set target=build
 REM TCC variables
 set "tcc_url=https://github.com/vlang/tccbin"
 set "tcc_dir=%~dp0thirdparty\tcc"
+set "tcc_exe=%~dp0thirdparty\tcc\tcc.exe"
 if "%PROCESSOR_ARCHITECTURE%" == "x86" ( set "tcc_branch=thirdparty-windows-i386" ) else ( set "tcc_branch=thirdparty-windows-amd64" )
 if "%~1" == "-tcc32" set "tcc_branch=thirdparty-windows-i386"
 


### PR DESCRIPTION
This PR fixes error of `make --local` on windows.

error:
```vlang
C:\Users\yuyi9\v>make --local
Building V...
 > Attempting to build v_win.c with TCC


Exiting from error
```

This is because `tcc_exe` is uninitialized.

```vlang
C:\Users\yuyi9\v>make --local
Building V...
 > Attempting to build v_win.c with TCC
 > Compiling with .\v.exe self
 > V built successfully
 > To add V to your PATH, run `.\v.exe symlink`.

WARNING:  No C compiler was detected in your PATH. `tcc` was used temporarily
          to build V, but it may have some bugs and may not work in all cases.
          A more advanced C compiler like GCC or MSVC is recommended.
          https://github.com/vlang/v/wiki/Installing-a-C-compiler-on-Windows


V version: V 0.2.2 fbc02cb
```