### PR TITLE
vsymlink.v: update registry calls on windows

### DIFF
--- a/cmd/tools/vsymlink.v
+++ b/cmd/tools/vsymlink.v
@@ -19,7 +19,7 @@ fn main() {
 }
 
 fn cleanup_vtmp_folder() {
-	os.rmdir_all(util.get_vtmp_folder()) or { }
+	os.rmdir_all(util.get_vtmp_folder()) or {}
 }
 
 fn setup_symlink_unix(vexe string) {

--- a/cmd/tools/vsymlink.v
+++ b/cmd/tools/vsymlink.v
@@ -149,7 +149,7 @@ fn get_reg_value(reg_env_key voidptr, key string) ?string {
 		// query the value (shortcut the sizing step)
 		reg_value_size := 4095 // this is the max length (not for the registry, but for the system %PATH%)
 		mut reg_value := unsafe { &u16(malloc(reg_value_size)) }
-		if C.RegQueryValueEx(reg_env_key, key.to_wide(), 0, 0, reg_value, &reg_value_size) != 0 {
+		if C.RegQueryValueExW(reg_env_key, key.to_wide(), 0, 0, reg_value, &reg_value_size) != 0 {
 			return error('Unable to get registry value for "$key".')
 		}
 		return unsafe { string_from_wide(reg_value) }
@@ -160,7 +160,7 @@ fn get_reg_value(reg_env_key voidptr, key string) ?string {
 // sets the value for the given $key to the given  $value
 fn set_reg_value(reg_key voidptr, key string, value string) ?bool {
 	$if windows {
-		if C.RegSetValueEx(reg_key, key.to_wide(), 0, C.REG_EXPAND_SZ, value.to_wide(),
+		if C.RegSetValueExW(reg_key, key.to_wide(), 0, C.REG_EXPAND_SZ, value.to_wide(),
 			value.len * 2) != 0 {
 			return error('Unable to set registry value for "$key". %PATH% may be too long.')
 		}
@@ -173,7 +173,7 @@ fn set_reg_value(reg_key voidptr, key string, value string) ?bool {
 // letting them know that the system environment has changed and should be reloaded
 fn send_setting_change_msg(message_data string) ?bool {
 	$if windows {
-		if C.SendMessageTimeout(os.hwnd_broadcast, os.wm_settingchange, 0, message_data.to_wide(),
+		if C.SendMessageTimeoutW(os.hwnd_broadcast, os.wm_settingchange, 0, message_data.to_wide(),
 			os.smto_abortifhung, 5000, 0) == 0 {
 			return error('Could not broadcast WM_SETTINGCHANGE')
 		}


### PR DESCRIPTION
Symlinking was failing on windows due to incorrect function calls in vsymlink.v:

RegQueryValueEx => RegQueryValueExW
RegSetValueEx => RegSetValueExW
SendMessageTimeout => SendMessageTimeoutW

======================================================
**ERROR Before fix:**
c:\v>c:\v\v.exe symlink
failed    cmd: "C:\v\v.exe"  -g "C:\v\cmd\tools\vsymlink.v"
failed   code: 1
V panic: C:\v\cmd\tools\vsymlink.v:163:22: error: expected 0 arguments, but got 6
  161 | fn set_reg_value(reg_key voidptr, key string, value string) ?bool {
  162 |     $if windows {
  163 |         if C.RegSetValueEx(reg_key, key.to_wide(), 0, C.REG_EXPAND_SZ, value.to_wide(),
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  164 |             value.len * 2) != 0 {
  165 |             return error('Unable to set registry value for "$key". %PATH% may be too long.')
C:\v\cmd\tools\vsymlink.v:176:27: error: expected 0 arguments, but got 7
  174 | fn send_setting_change_msg(message_data string) ?bool {
  175 |     $if windows {
  176 |         if C.SendMessageTimeout(os.hwnd_broadcast, os.wm_settingchange, 0, message_data.to_wide(),
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  177 |             os.smto_abortifhung, 5000, 0) == 0 {
  178 |             return error('Could not broadcast WM_SETTINGCHANGE')

**After FIX:**
c:\v>c:\v\v.exe symlink
Symlink C:\v\.bin\v.exe to C:\v\v.exe created.
Checking system %PATH%...
System %PATH% was not configured.
Adding symlink directory to system %PATH%...
Done.
Notifying running processes to update their Environment...
Done.
Note: Restart your shell/IDE to load the new %PATH%.
After restarting your shell/IDE, give `v version` a try in another directory!