### PR TITLE
ci: remove double vab build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1015,5 +1015,3 @@ jobs:
         run: git clone --depth 1 https://github.com/vlang/vab
       - name: Build vab
         run: cd vab; ../v ./vab.v ; cd ..
-      - name: Build vab with
-        run: cd vab; ../v ./vab.v ; cd ..


### PR DESCRIPTION
I catched this by accident, seems to be leftovers from the `-prod` flag removal in https://github.com/vlang/v/commit/d7049ae2dadf410c7b79b69056fb972d5e4ac09d