### PR TITLE
vfmt: print worker execution errors with -debug

### DIFF
--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -119,6 +119,9 @@ fn main() {
 		}
 		worker_result := os.execute(worker_cmd)
 		if worker_result.exit_code != 0 {
+			if foptions.is_debug {
+				eprintln(worker_result.output)
+			}
 			errors++
 			continue
 		}
@@ -126,7 +129,7 @@ fn main() {
 		if worker_result.exit_code != 0 {
 			eprintln(worker_result.output)
 			if worker_result.exit_code == 1 {
-				eprintln('vfmt error while formatting file: $file .')
+				eprintln('Internal vfmt error while formatting file: ${file}.')
 			}
 			errors++
 			continue


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
