### PR TITLE
fmt: do not insert a space before struct declaration generics

### DIFF
--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -104,7 +104,7 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl) {
 	name := node.name.after('.')
 	f.write(name)
 	if node.gen_types.len > 0 {
-		f.write(' <')
+		f.write('<')
 		gtypes := node.gen_types.map(f.table.type_to_str(it)).join(', ')
 		f.write(gtypes)
 		f.write('>')

--- a/vlib/v/fmt/tests/generic_structs_keep.vv
+++ b/vlib/v/fmt/tests/generic_structs_keep.vv
@@ -1,4 +1,4 @@
-struct Foo <T> {
+struct Foo<T> {
 pub:
 	data T
 }
@@ -9,7 +9,7 @@ fn (f Foo<int>) value() string {
 
 type DB = string
 
-struct Repo <T, U> {
+struct Repo<T, U> {
 	db DB
 pub mut:
 	model      T


### PR DESCRIPTION
Be consistent with function declarations and struct inits.