### PR TITLE
checker: check map copy error in fn_mut_arg (fix #8566)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2746,8 +2746,8 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 				assign_stmt.pos)
 		}
 		if left_sym.kind == .map && assign_stmt.op in [.assign, .decl_assign]
-			&& right_sym.kind == .map && !right_type.is_ptr() && !left.is_blank_ident()
-			&& right.is_lvalue() {
+			&& right_sym.kind == .map && ((right is ast.Ident && right.is_auto_deref_var())
+			|| !right_type.is_ptr()) && !left.is_blank_ident() && right.is_lvalue() {
 			// Do not allow `a = b`
 			c.error('cannot copy map: call `move` or `clone` method (or use a reference)',
 				right.position())

--- a/vlib/v/checker/tests/array_or_map_assign_err.out
+++ b/vlib/v/checker/tests/array_or_map_assign_err.out
@@ -10,10 +10,10 @@ vlib/v/checker/tests/array_or_map_assign_err.vv:5:5: error: use `array2 = array1
     4 |     mut a3 := []int{}
     5 |     a3 = a1
       |        ^
-    6 | 
+    6 |
     7 |     m1 := {'one': 1}
 vlib/v/checker/tests/array_or_map_assign_err.vv:8:8: error: cannot copy map: call `move` or `clone` method (or use a reference)
-    6 | 
+    6 |
     7 |     m1 := {'one': 1}
     8 |     m2 := m1
       |           ~~
@@ -24,5 +24,12 @@ vlib/v/checker/tests/array_or_map_assign_err.vv:10:7: error: cannot copy map: ca
     9 |     mut m3 := map[string]int{}
    10 |     m3 = m1
       |          ~~
-   11 |     
+   11 |
    12 |     _ = a2
+vlib/v/checker/tests/array_or_map_assign_err.vv:20:8: error: cannot copy map: call `move` or `clone` method (or use a reference)
+   18 |
+   19 | fn foo(mut m map[string]int) {
+   20 |     m2 := m
+      |           ^
+   21 |     m['foo'] = 100
+   22 |     println(m)

--- a/vlib/v/checker/tests/array_or_map_assign_err.vv
+++ b/vlib/v/checker/tests/array_or_map_assign_err.vv
@@ -8,7 +8,17 @@ fn main() {
 	m2 := m1
 	mut m3 := map[string]int{}
 	m3 = m1
-	
+
 	_ = a2
 	_ = m2
+
+	mut m := {'foo':1}
+	foo(mut m)
+}
+
+fn foo(mut m map[string]int) {
+	m2 := m
+	m['foo'] = 100
+	println(m)
+	println(m2)
 }


### PR DESCRIPTION
This PR checkes map copy error in fn_mut_arg (fix #8566).

- Check map copy error in fn_mut_arg.
- Add test.

```vlang
fn main() {
	mut m := {'foo':1}
	foo(mut m)
}

fn foo(mut m map[string]int) {
	m2 := m
	m['foo'] = 100
	println(m)
	println(m2)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:7:8: error: cannot copy map: call `move` or `clone` method (or use a reference)
    5 |
    6 | fn foo(mut m map[string]int) {
    7 |     m2 := m
      |           ^
    8 |     m['foo'] = 100
    9 |     println(m)
```
```vlang
fn main() {
	mut m := {'foo':1}
	foo(mut m)
}

fn foo(mut m map[string]int) {
	m2 := m.clone()
	m['foo'] = 100
	println(m)
	println(m2)
}

PS D:\Test\v\tt1> v run .
{'foo': 100}
{'foo': 1}
```