### PR TITLE
checker: check array literal modify error (fix #7545)

### DIFF
--- a/vlib/rand/mt19937/mt19937.v
+++ b/vlib/rand/mt19937/mt19937.v
@@ -59,7 +59,7 @@ const (
 // MT19937RNG is generator that uses the Mersenne Twister algorithm with period 2^19937.
 pub struct MT19937RNG {
 mut:
-	state    []u64 = calculate_state(seed.time_seed_array(2), mut []u64{len: mt19937.nn})
+	state    []u64 = []u64{len: mt19937.nn}
 	mti      int   = mt19937.nn
 	next_rnd u32
 	has_next bool
@@ -83,6 +83,8 @@ pub fn (mut rng MT19937RNG) seed(seed_data []u32) {
 		eprintln('mt19937 needs only two 32bit integers as seed: [lower, higher]')
 		exit(1)
 	}
+	// calculate 2 times because MT19937RNG init didn't call calculate_state.
+	rng.state = calculate_state(seed_data, mut rng.state)
 	rng.state = calculate_state(seed_data, mut rng.state)
 	rng.mti = mt19937.nn
 	rng.next_rnd = 0

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1151,6 +1151,7 @@ fn (mut c Checker) fail_if_immutable(expr ast.Expr) (string, token.Position) {
 			}
 		}
 		ast.ArrayInit {
+			c.error('array literal can not be modified', expr.pos)
 			return '', pos
 		}
 		ast.StructInit {

--- a/vlib/v/checker/tests/array_literal_modify_err.out
+++ b/vlib/v/checker/tests/array_literal_modify_err.out
@@ -1,0 +1,12 @@
+vlib/v/checker/tests/array_literal_modify_err.vv:2:14: error: array literal can not be modified
+    1 | fn main() {
+    2 |     mut nums := [1, 2, 3] << 4
+      |                 ~~~~~~~~~
+    3 |     println(nums)
+    4 | }
+vlib/v/checker/tests/array_literal_modify_err.vv:3:2: error: `println` can not print void expressions
+    1 | fn main() {
+    2 |     mut nums := [1, 2, 3] << 4
+    3 |     println(nums)
+      |     ~~~~~~~~~~~~~
+    4 | }

--- a/vlib/v/checker/tests/array_literal_modify_err.vv
+++ b/vlib/v/checker/tests/array_literal_modify_err.vv
@@ -1,0 +1,4 @@
+fn main() {
+	mut nums := [1, 2, 3] << 4
+	println(nums)
+}

--- a/vlib/v/checker/tests/mut_arg.out
+++ b/vlib/v/checker/tests/mut_arg.out
@@ -12,7 +12,7 @@ vlib/v/checker/tests/mut_arg.vv:8:3: error: `f` parameter `par` is `mut`, you ne
       |   ^
     9 |
    10 | g(mut [3,4])
-vlib/v/checker/tests/mut_arg.vv:10:7: error: `g` parameter `par` is not `mut`, `mut` is not needed`
+vlib/v/checker/tests/mut_arg.vv:10:7: error: array literal can not be modified
     8 | f(a)
     9 |
    10 | g(mut [3,4])


### PR DESCRIPTION
This PR check array literal modify error (fix #7545).

- Check array literal modify error.
- Add test.
- Fix related error of other module.

```vlang
fn main() {
	mut nums := [1, 2, 3] << 4
	println(nums)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:2:14: error: array literal can not be modified
    1 | fn main() {
    2 |     mut nums := [1, 2, 3] << 4
      |                 ~~~~~~~~~
    3 |     println(nums)
    4 | }
.\tt1.v:3:2: error: `println` can not print void expressions
    1 | fn main() {
    2 |     mut nums := [1, 2, 3] << 4
    3 |     println(nums)
      |     ~~~~~~~~~~~~~
    4 | }
```