### PR TITLE
v.v: fix exit codes and add stderr

### DIFF
--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -84,8 +84,8 @@ fn main() {
 		exit(1)
 	}
 	if command == 'test-vet' {
-		println('Please use `v test-cleancode` instead.')
-		return
+		eprintln('Please use `v test-cleancode` instead.')
+		exit(1)
 	}
 	// Start calling the correct functions/external tools
 	// Note for future contributors: Please add new subcommands in the `match` block below.

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -104,7 +104,7 @@ fn main() {
 		}
 		'translate' {
 			eprintln('Translating C to V will be available in V 0.3')
-			return
+			exit(1)
 		}
 		'search', 'install', 'update', 'upgrade', 'outdated', 'list', 'remove' {
 			util.launch_tool(prefs.is_verbose, 'vpm', os.args[1..])

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -103,7 +103,7 @@ fn main() {
 			return
 		}
 		'translate' {
-			println('Translating C to V will be available in V 0.3')
+			eprintln('Translating C to V will be available in V 0.3')
 			return
 		}
 		'search', 'install', 'update', 'upgrade', 'outdated', 'list', 'remove' {
@@ -114,7 +114,7 @@ fn main() {
 			util.launch_tool(prefs.is_verbose, 'vdoc', ['doc', 'vlib'])
 		}
 		'get' {
-			println('V Error: Use `v install` to install modules from vpm.vlang.io')
+			eprintln('V Error: Use `v install` to install modules from vpm.vlang.io')
 			exit(1)
 		}
 		'version' {


### PR DESCRIPTION
This adds exit code 1 to errors and write the message in stderr instead of stdout.

So that the process fail, cause it does not work and not continues. printing message as error, cause it's a error and not a normal output.

Should I remove the translate commit (https://github.com/vlang/v/commit/55bef7e0c365e80f50713aed5b2eda9287cd799a)  cause it is WIP and could break your local git env?

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
