### PR TITLE
checker: warn/error about empty const blocks

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2443,7 +2443,7 @@ pub fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 	mut field_names := []string{}
 	mut field_order := []int{}
 	if node.fields.len == 0 {
-		c.error('empty const blocks are not allowed', node.pos)
+		c.warn('empty const block', node.pos)
 	}
 	for i, field in node.fields {
 		// TODO Check const name once the syntax is decided

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2443,7 +2443,7 @@ pub fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 	mut field_names := []string{}
 	mut field_order := []int{}
 	if node.fields.len == 0 {
-		c.warn('empty const block', node.pos)
+		c.warn('const block must have at least 1 declaration', node.pos)
 	}
 	for i, field in node.fields {
 		// TODO Check const name once the syntax is decided

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2442,6 +2442,9 @@ pub fn (mut c Checker) return_stmt(mut return_stmt ast.Return) {
 pub fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 	mut field_names := []string{}
 	mut field_order := []int{}
+	if node.fields.len == 0 {
+		c.error('empty const blocks are not allowed', node.pos)
+	}
 	for i, field in node.fields {
 		// TODO Check const name once the syntax is decided
 		if field.name in c.const_names {


### PR DESCRIPTION
This PR warns about empty const blocks. Error in prod mode.

```v
stunxfs@stunxfs--pc:~/develop/v$ ./v2 run test.v
test.v:1:1: warning: const block must have at least 1 declaration
    1 | const ()
      | ~~~~~
stunxfs@stunxfs--pc:~/develop/v$ ./v2 -prod run test.v
test.v:1:1: error: const block must have at least 1 declaration
    1 | const ()
      | ~~~~~
```