### PR TITLE
fmt: fix removal of attrs with comments afterwards

### DIFF
--- a/vlib/v/fmt/tests/attrs_expected.vv
+++ b/vlib/v/fmt/tests/attrs_expected.vv
@@ -2,3 +2,8 @@
 [tom: 'jerry']
 [direct_array_access; inline; unsafe]
 fn heavily_tagged() {}
+
+// console attribute for easier diagnostics on windows
+// also it's not safe to use
+[console; unsafe]
+fn dangerous_console() {}

--- a/vlib/v/fmt/tests/attrs_input.vv
+++ b/vlib/v/fmt/tests/attrs_input.vv
@@ -4,3 +4,7 @@
 [unsafe]
 [tom: 'jerry']
 fn heavily_tagged() {}
+
+[console] // console attribute for easier diagnostics on windows
+[unsafe] // also it's not safe to use
+fn dangerous_console() {}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -240,9 +240,12 @@ pub fn (mut p Parser) parse() ast.File {
 			break
 		}
 		// println('stmt at ' + p.tok.str())
-		stmts << p.top_stmt()
+		stmt := p.top_stmt()
 		// clear the attributes after each statement
-		p.attrs = []
+		if !(stmt is ast.ExprStmt && (stmt as ast.ExprStmt).expr is ast.Comment) {
+			p.attrs = []
+		}
+		stmts << stmt
 	}
 	// println('nr stmts = $stmts.len')
 	// println(stmts[0])


### PR DESCRIPTION
The handling isn't optimal in my eyes but if the comments should stay directly behind the attribute, quite big change would be required.