### PR TITLE
checker: improve error message for invalid property

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2335,7 +2335,7 @@ pub fn (mut c Checker) selector_expr(mut selector_expr ast.SelectorExpr) table.T
 	}
 	if sym.kind !in [.struct_, .aggregate, .interface_, .sum_type] {
 		if sym.kind != .placeholder {
-			c.error('`$sym.name` is not a struct', selector_expr.pos)
+			c.error('`$sym.name` has no property `$selector_expr.field_name`', selector_expr.pos)
 		}
 	} else {
 		if sym.info is table.Struct {

--- a/vlib/v/checker/tests/invalid_property.out
+++ b/vlib/v/checker/tests/invalid_property.out
@@ -1,0 +1,18 @@
+vlib/v/checker/tests/invalid_property.vv:2:7: error: `string` has no property `length`
+    1 | s :=''
+    2 | _ = s.length
+      |       ~~~~~~
+    3 | _ = [1,2].foo
+    4 |
+vlib/v/checker/tests/invalid_property.vv:3:11: error: `[]int` has no property `foo`
+    1 | s :=''
+    2 | _ = s.length
+    3 | _ = [1,2].foo
+      |           ~~~
+    4 | 
+    5 | mut fa := [3,4]!
+vlib/v/checker/tests/invalid_property.vv:6:8: error: `[2]int` has no property `bar`
+    4 | 
+    5 | mut fa := [3,4]!
+    6 | _ = fa.bar
+      |        ~~~

--- a/vlib/v/checker/tests/invalid_property.vv
+++ b/vlib/v/checker/tests/invalid_property.vv
@@ -1,0 +1,6 @@
+s :=''
+_ = s.length
+_ = [1,2].foo
+
+mut fa := [3,4]!
+_ = fa.bar


### PR DESCRIPTION
Instead of *`Type` is not a struct*, use *`Type` has no property `foo`*. This is more user friendly.
Non-structs can have properties, e.g. `string` has `len`.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
