### PR TITLE
checker: disallow array append in an expression

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -579,8 +579,9 @@ pub fn (i &Ident) var_info() IdentVar {
 // See: token.Kind.is_infix
 pub struct InfixExpr {
 pub:
-	op  token.Kind
-	pos token.Position
+	op      token.Kind
+	pos     token.Position
+	is_stmt bool
 pub mut:
 	left        Expr
 	right       Expr

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -155,7 +155,7 @@ fn (mut c Checker) check_shift(left_type table.Type, right_type table.Type, left
 			// allow `bool << 2` in translated C code
 			return table.int_type
 		}
-		c.error('invalid operation: shift of type `$sym.name`', left_pos)
+		c.error('invalid operation: shift on type `$sym.name`', left_pos)
 		return table.void_type
 	} else if !right_type.is_int() {
 		c.error('cannot shift non-integer type `${c.table.get_type_symbol(right_type).name}` into type `${c.table.get_type_symbol(left_type).name}`',

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -875,6 +875,9 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 		}
 		.left_shift {
 			if left_final.kind == .array {
+				if !infix_expr.is_stmt {
+					c.error('array append cannot be used in an expression', infix_expr.pos)
+				}
 				// `array << elm`
 				infix_expr.auto_locked, _ = c.fail_if_immutable(infix_expr.left)
 				left_value_type := c.table.value_type(left_type)

--- a/vlib/v/checker/tests/append_err.out
+++ b/vlib/v/checker/tests/append_err.out
@@ -1,0 +1,20 @@
+vlib/v/checker/tests/append_err.vv:3:7: error: cannot append `string` to `[]int`
+    1 | fn main() {
+    2 |     mut l := []int{}
+    3 |     l << 'test'
+      |          ~~~~~~
+    4 |     
+    5 |     _ = l << 3
+vlib/v/checker/tests/append_err.vv:5:8: error: array append cannot be used in an expression
+    3 |     l << 'test'
+    4 |     
+    5 |     _ = l << 3
+      |           ~~
+    6 |     _ = (l << 3).len
+    7 | }
+vlib/v/checker/tests/append_err.vv:6:9: error: array append cannot be used in an expression
+    4 |     
+    5 |     _ = l << 3
+    6 |     _ = (l << 3).len
+      |            ~~
+    7 | }

--- a/vlib/v/checker/tests/append_err.vv
+++ b/vlib/v/checker/tests/append_err.vv
@@ -1,4 +1,7 @@
 fn main() {
 	mut l := []int{}
 	l << 'test'
+	
+	_ = l << 3
+	_ = (l << 3).len
 }

--- a/vlib/v/checker/tests/array_literal_modify_err.out
+++ b/vlib/v/checker/tests/array_literal_modify_err.out
@@ -1,7 +1,7 @@
-vlib/v/checker/tests/array_literal_modify_err.vv:2:14: error: array literal can not be modified
+vlib/v/checker/tests/array_literal_modify_err.vv:2:24: error: array append cannot be used in an expression
     1 | fn main() {
     2 |     mut nums := [1, 2, 3] << 4
-      |                 ~~~~~~~~~
+      |                           ~~
     3 |     println(nums)
     4 | }
 vlib/v/checker/tests/array_literal_modify_err.vv:3:2: error: `println` can not print void expressions

--- a/vlib/v/checker/tests/left_shift_err.out
+++ b/vlib/v/checker/tests/left_shift_err.out
@@ -1,6 +1,0 @@
-vlib/v/checker/tests/left_shift_err.vv:3:7: error: cannot append `string` to `[]int`
-    1 | fn main() {
-    2 |     mut l := []int{}
-    3 |     l << 'test'
-      |          ~~~~~~
-    4 | }

--- a/vlib/v/checker/tests/rshift_op_wrong_left_type_err.out
+++ b/vlib/v/checker/tests/rshift_op_wrong_left_type_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/rshift_op_wrong_left_type_err.vv:2:10: error: invalid operation: shift of type `float literal`
+vlib/v/checker/tests/rshift_op_wrong_left_type_err.vv:2:10: error: invalid operation: shift on type `float literal`
     1 | fn main() {
     2 |     println(0.5 >> 1)
       |             ~~~

--- a/vlib/v/checker/tests/shift_op_wrong_left_type_err.out
+++ b/vlib/v/checker/tests/shift_op_wrong_left_type_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/shift_op_wrong_left_type_err.vv:2:10: error: invalid operation: shift of type `float literal`
+vlib/v/checker/tests/shift_op_wrong_left_type_err.vv:2:10: error: invalid operation: shift on type `float literal`
     1 | fn main() {
     2 |     println(0.5 << 1)
       |             ~~~

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -377,6 +377,7 @@ pub fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_iden
 				right: right
 				op: tok.kind
 				pos: pos
+				is_stmt: true
 			}
 		} else if p.tok.kind.is_infix() {
 			if p.tok.kind.is_prefix() && p.tok.line_nr != p.prev_tok.line_nr {
@@ -473,6 +474,7 @@ fn (mut p Parser) infix_expr(left ast.Expr) ast.Expr {
 		right: right
 		op: op
 		pos: pos
+		is_stmt: p.is_stmt_ident
 		or_block: ast.OrExpr{
 			stmts: or_stmts
 			kind: or_kind


### PR DESCRIPTION
Fixes https://github.com/vlang/v/issues/9241.

Rename `left_shift_err.vv` test file (because it tests append, not shift) and extend it.
Also tweak error message for invalid shift on left type.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
