### PR TITLE
checker: check the amount of parameters passed to `json.decode()`

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1732,7 +1732,8 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 	if fn_name == 'json.encode' {
 	} else if fn_name == 'json.decode' && call_expr.args.len > 0 {
 		if call_expr.args.len != 2 {
-			c.error("json.encode expects 2 arguments, a type and a string (e.g `json.decode(T, '')`)", call_expr.pos)
+			c.error("json.encode expects 2 arguments, a type and a string (e.g `json.decode(T, '')`)",
+				call_expr.pos)
 			return table.void_type
 		}
 		expr := call_expr.args[0].expr

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1731,6 +1731,10 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 	}
 	if fn_name == 'json.encode' {
 	} else if fn_name == 'json.decode' && call_expr.args.len > 0 {
+		if call_expr.args.len != 2 {
+			c.error("json.encode expects 2 arguments, a type and a string (e.g `json.decode(T, '')`)", call_expr.pos)
+			return table.void_type
+		}
 		expr := call_expr.args[0].expr
 		if expr !is ast.Type {
 			typ := expr.type_name()

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1732,7 +1732,7 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 	if fn_name == 'json.encode' {
 	} else if fn_name == 'json.decode' && call_expr.args.len > 0 {
 		if call_expr.args.len != 2 {
-			c.error("json.encode expects 2 arguments, a type and a string (e.g `json.decode(T, '')`)",
+			c.error("json.decode expects 2 arguments, a type and a string (e.g `json.decode(T, '')`)",
 				call_expr.pos)
 			return table.void_type
 		}


### PR DESCRIPTION
This PR checks the amount of parameters passed to `json.decode()`.

Fix #9251.

```
stunxfs@stunxfs--pc:~/develop/v$ cat test.v
import json
struct Ti{}
println(json.decode(Ti))
stunxfs@stunxfs--pc:~/develop/v$ ./v2 run test.v
test.v:3:14: error: json.decode expects 2 arguments, a type and a string (e.g `json.decode(T, '')`)
    1 | import json
    2 | struct Ti{}
    3 | println(json.decode(Ti))
      |              ~~~~~~~~~~
```