### PR TITLE
all: implement `fn (a foo) method()` auto change to `fn (a &foo) method()`

### DIFF
--- a/vlib/os/process.v
+++ b/vlib/os/process.v
@@ -28,7 +28,7 @@ pub mut:
 	env_is_custom bool     // true, when the environment was customized with .set_environment
 	env           []string // the environment with which the process was started  (list of 'var=val')
 	use_stdio_ctl bool     // when true, then you can use p.stdin_write(), p.stdout_slurp() and p.stderr_slurp()
-	stdio_fd      [3]int   // the file descriptors	
+	stdio_fd      [3]int   // the file descriptors
 }
 
 // new_process - create a new process descriptor
@@ -45,62 +45,62 @@ pub fn new_process(filename string) &Process {
 // set_args - set the arguments for the new process
 pub fn (mut p Process) set_args(pargs []string) &Process {
 	if p.status != .not_started {
-		return p
+		return &p
 	}
 	p.args = pargs
-	return p
+	return &p
 }
 
 // set_environment - set a custom environment variable mapping for the new process
 pub fn (mut p Process) set_environment(envs map[string]string) &Process {
 	if p.status != .not_started {
-		return p
+		return &p
 	}
 	p.env_is_custom = true
 	p.env = []string{}
 	for k, v in envs {
 		p.env << '$k=$v'
 	}
-	return p
+	return &p
 }
 
 // run - starts the new process
 pub fn (mut p Process) run() &Process {
 	if p.status != .not_started {
-		return p
+		return &p
 	}
 	p._spawn()
-	return p
+	return &p
 }
 
 // signal_kill - kills the process, after that it is no longer running
 pub fn (mut p Process) signal_kill() &Process {
 	if p.status !in [.running, .stopped] {
-		return p
+		return &p
 	}
 	p._signal_kill()
 	p.status = .aborted
-	return p
+	return &p
 }
 
 // signal_stop - stops the process, you can resume it with p.signal_continue()
 pub fn (mut p Process) signal_stop() &Process {
 	if p.status != .running {
-		return p
+		return &p
 	}
 	p._signal_stop()
 	p.status = .stopped
-	return p
+	return &p
 }
 
 // signal_continue - tell a stopped process to continue/resume its work
 pub fn (mut p Process) signal_continue() &Process {
 	if p.status != .stopped {
-		return p
+		return &p
 	}
 	p._signal_continue()
 	p.status = .running
-	return p
+	return &p
 }
 
 // wait - wait for a process to finish.
@@ -114,10 +114,10 @@ pub fn (mut p Process) wait() &Process {
 		p._spawn()
 	}
 	if p.status !in [.running, .stopped] {
-		return p
+		return &p
 	}
 	p._wait()
-	return p
+	return &p
 }
 
 //
@@ -154,7 +154,7 @@ pub fn (mut p Process) is_alive() bool {
 //
 pub fn (mut p Process) set_redirect_stdio() &Process {
 	p.use_stdio_ctl = true
-	return p
+	return &p
 }
 
 pub fn (mut p Process) stdin_write(s string) {

--- a/vlib/os/process.v
+++ b/vlib/os/process.v
@@ -45,62 +45,62 @@ pub fn new_process(filename string) &Process {
 // set_args - set the arguments for the new process
 pub fn (mut p Process) set_args(pargs []string) &Process {
 	if p.status != .not_started {
-		return &p
+		return p
 	}
 	p.args = pargs
-	return &p
+	return p
 }
 
 // set_environment - set a custom environment variable mapping for the new process
 pub fn (mut p Process) set_environment(envs map[string]string) &Process {
 	if p.status != .not_started {
-		return &p
+		return p
 	}
 	p.env_is_custom = true
 	p.env = []string{}
 	for k, v in envs {
 		p.env << '$k=$v'
 	}
-	return &p
+	return p
 }
 
 // run - starts the new process
 pub fn (mut p Process) run() &Process {
 	if p.status != .not_started {
-		return &p
+		return p
 	}
 	p._spawn()
-	return &p
+	return p
 }
 
 // signal_kill - kills the process, after that it is no longer running
 pub fn (mut p Process) signal_kill() &Process {
 	if p.status !in [.running, .stopped] {
-		return &p
+		return p
 	}
 	p._signal_kill()
 	p.status = .aborted
-	return &p
+	return p
 }
 
 // signal_stop - stops the process, you can resume it with p.signal_continue()
 pub fn (mut p Process) signal_stop() &Process {
 	if p.status != .running {
-		return &p
+		return p
 	}
 	p._signal_stop()
 	p.status = .stopped
-	return &p
+	return p
 }
 
 // signal_continue - tell a stopped process to continue/resume its work
 pub fn (mut p Process) signal_continue() &Process {
 	if p.status != .stopped {
-		return &p
+		return p
 	}
 	p._signal_continue()
 	p.status = .running
-	return &p
+	return p
 }
 
 // wait - wait for a process to finish.
@@ -114,10 +114,10 @@ pub fn (mut p Process) wait() &Process {
 		p._spawn()
 	}
 	if p.status !in [.running, .stopped] {
-		return &p
+		return p
 	}
 	p._wait()
-	return &p
+	return p
 }
 
 //
@@ -154,7 +154,7 @@ pub fn (mut p Process) is_alive() bool {
 //
 pub fn (mut p Process) set_redirect_stdio() &Process {
 	p.use_stdio_ctl = true
-	return &p
+	return p
 }
 
 pub fn (mut p Process) stdin_write(s string) {

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -320,7 +320,6 @@ pub:
 	is_main         bool // true for `fn main()`
 	is_test         bool // true for `fn test_abcde`
 	is_conditional  bool // true for `[if abc] fn abc(){}`
-	receiver        Field
 	receiver_pos    token.Position // `(u User)` in `fn (u User) name()` position
 	is_method       bool
 	method_type_pos token.Position // `User` in ` fn (u User)` position
@@ -338,6 +337,7 @@ pub:
 	attrs           []table.Attr
 	skip_gen        bool // this function doesn't need to be generated (for example [if foo])
 pub mut:
+	receiver      Field
 	stmts         []Stmt
 	defer_stmts   []DeferStmt
 	return_type   table.Type

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -320,6 +320,7 @@ pub:
 	is_main         bool // true for `fn main()`
 	is_test         bool // true for `fn test_abcde`
 	is_conditional  bool // true for `[if abc] fn abc(){}`
+	receiver        Field
 	receiver_pos    token.Position // `(u User)` in `fn (u User) name()` position
 	is_method       bool
 	method_type_pos token.Position // `User` in ` fn (u User)` position
@@ -337,7 +338,6 @@ pub:
 	attrs           []table.Attr
 	skip_gen        bool // this function doesn't need to be generated (for example [if foo])
 pub mut:
-	receiver      Field
 	stmts         []Stmt
 	defer_stmts   []DeferStmt
 	return_type   table.Type

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -33,6 +33,9 @@ pub fn (node &FnDecl) stringify(t &table.Table, cur_mod string, m2a map[string]s
 			styp = styp[1..] // remove &
 		}
 		styp = util.no_cur_mod(styp, cur_mod)
+		if node.params[0].is_auto_rec {
+			styp = styp.trim('&')
+		}
 		receiver = '($m$node.receiver.name $styp) '
 		/*
 		sym := t.get_type_symbol(node.receiver.typ)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4498,7 +4498,17 @@ fn (mut g Gen) return_statement(node ast.Return) {
 		} else {
 			g.write('return ')
 		}
-		g.expr_with_cast(node.exprs[0], node.types[0], g.fn_decl.return_type)
+		if expr0.is_auto_deref_var() {
+			if g.fn_decl.return_type.is_ptr() {
+				expr_str := g.expr_string(expr0)
+				g.write(expr_str.trim('&'))
+			} else {
+				g.write('*')
+				g.expr(expr0)
+			}
+		} else {
+			g.expr_with_cast(node.exprs[0], node.types[0], g.fn_decl.return_type)
+		}
 		if free {
 			expr := node.exprs[0]
 			if expr is ast.Ident {
@@ -5750,7 +5760,7 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 	}
 }
 
-fn (g Gen) as_cast_name_table() string {
+fn (g &Gen) as_cast_name_table() string {
 	if g.as_cast_type_names.len == 0 {
 		return 'new_array_from_c_array(1, 1, sizeof(VCastTypeIndexName), _MOV((VCastTypeIndexName[1]){(VCastTypeIndexName){.tindex = 0,.tname = _SLIT("unknown")}}));'
 	}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4500,8 +4500,9 @@ fn (mut g Gen) return_statement(node ast.Return) {
 		}
 		if expr0.is_auto_deref_var() {
 			if g.fn_decl.return_type.is_ptr() {
-				expr_str := g.expr_string(expr0)
-				g.write(expr_str.trim('&'))
+				g.write('&(*')
+				g.expr(expr0)
+				g.write(')')
 			} else {
 				g.write('*')
 				g.expr(expr0)
@@ -5760,7 +5761,7 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 	}
 }
 
-fn (g &Gen) as_cast_name_table() string {
+fn (g Gen) as_cast_name_table() string {
 	if g.as_cast_type_names.len == 0 {
 		return 'new_array_from_c_array(1, 1, sizeof(VCastTypeIndexName), _MOV((VCastTypeIndexName[1]){(VCastTypeIndexName){.tindex = 0,.tname = _SLIT("unknown")}}));'
 	}

--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -57,12 +57,13 @@ fn (f &Fn) method_equals(o &Fn) bool {
 
 pub struct Param {
 pub:
-	pos       token.Position
-	name      string
-	is_mut    bool
-	typ       Type
-	type_pos  token.Position
-	is_hidden bool // interface first arg
+	pos         token.Position
+	name        string
+	is_mut      bool
+	is_auto_rec bool
+	typ         Type
+	type_pos    token.Position
+	is_hidden   bool // interface first arg
 }
 
 fn (p &Param) equals(o &Param) bool {


### PR DESCRIPTION
This PR implement `fn (a foo) method()` auto change to `fn (a &foo) method()`.

- If receiver type is big struct (fields count > 8), we can auto change `fn (a foo) method()` to `fn (a &foo) method()`.

```vlang
struct Info {
	a1 int
	a2 int
	a3 int
	a4 int
	b1 string
	b2 string
	b3 string
	b4 string
	c1 f32
	c2 f32
	c3 f32
	c4 f32
}

fn (inf Info) show_info() {
	println(inf.a1)
	println(inf.a2)
	println(inf.a3)
	println(inf.a4)
	println(inf.b1)
	println(inf.b2)
	println(inf.b3)
	println(inf.b4)
	println(inf.c1)
	println(inf.c2)
	println(inf.c3)
	println(inf.c4)
}

fn main() {
	info := Info {
		a1: 1
		a2: 2
		a3: 3
		a4: 4
		b1: 'aaa'
		b2: 'bbb'
		b3: 'ccc'
		b4: 'ddd'
		c1: 1.1
		c2: 2.2
		c3: 3.3
		c4: 4.4
	}
	info.show_info()
}
```
gen codes:
```vlang
VV_LOCAL_SYMBOL void main__Info_show_info(main__Info* inf) {
	println(int_str(inf->a1));
	println(int_str(inf->a2));
	println(int_str(inf->a3));
	println(int_str(inf->a4));
	println(inf->b1);
	println(inf->b2);
	println(inf->b3);
	println(inf->b4);
	println(f32_str(inf->c1));
	println(f32_str(inf->c2));
	println(f32_str(inf->c3));
	println(f32_str(inf->c4));
}

VV_LOCAL_SYMBOL void main__main(void) {
	main__Info info = (main__Info){
		.a1 = 1,
		.a2 = 2,
		.a3 = 3,
		.a4 = 4,
		.b1 = _SLIT("aaa"),
		.b2 = _SLIT("bbb"),
		.b3 = _SLIT("ccc"),
		.b4 = _SLIT("ddd"),
		.c1 = 1.1,
		.c2 = 2.2,
		.c3 = 3.3,
		.c4 = 4.4,
	};
	main__Info_show_info(&info);
}
```