### PR TITLE
gen: fix generating `$if expr || expr`

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -286,7 +286,7 @@ fn (mut g Gen) comp_if_cond(cond ast.Expr) bool {
 					l := g.comp_if_cond(cond.left)
 					g.write(' $cond.op ')
 					r := g.comp_if_cond(cond.right)
-					return l && r
+					return if cond.op == .and {l && r} else {l || r}
 				}
 				.key_is, .not_is {
 					left := cond.left

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -286,7 +286,7 @@ fn (mut g Gen) comp_if_cond(cond ast.Expr) bool {
 					l := g.comp_if_cond(cond.left)
 					g.write(' $cond.op ')
 					r := g.comp_if_cond(cond.right)
-					return if cond.op == .and {l && r} else {l || r}
+					return if cond.op == .and { l && r } else { l || r }
 				}
 				.key_is, .not_is {
 					left := cond.left

--- a/vlib/v/tests/comptime_if_is_test.v
+++ b/vlib/v/tests/comptime_if_is_test.v
@@ -13,3 +13,17 @@ fn test_generic_is() {
 	assert f<int>() == 1
 	assert f<bool>() == -1
 }
+
+fn g<T>(t T) int {
+	$if T is byte || T is i8 {
+		return 1
+	}
+	return 2
+}
+
+fn test_is_or() {
+	assert g(byte(1)) == 1
+	assert g(i8(1)) == 1
+	assert g(1) == 2
+}
+


### PR DESCRIPTION
Fixes https://github.com/vlang/v/issues/9182.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
