### PR TITLE
fix: fix infering int and float literal in generic fn calls

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -443,7 +443,7 @@ pub fn (mut c Checker) infer_fn_types(f table.Fn, mut call_expr ast.CallExpr) {
 			arg := call_expr.args[arg_i]
 			param_type_sym := c.table.get_type_symbol(param.typ)
 			if param.typ.has_flag(.generic) && param_type_sym.name == gt_name {
-				typ = table.mktyp(arg.typ)
+				typ = c.table.mktyp(arg.typ)
 				break
 			}
 			arg_sym := c.table.get_type_symbol(arg.typ)

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -443,11 +443,7 @@ pub fn (mut c Checker) infer_fn_types(f table.Fn, mut call_expr ast.CallExpr) {
 			arg := call_expr.args[arg_i]
 			param_type_sym := c.table.get_type_symbol(param.typ)
 			if param.typ.has_flag(.generic) && param_type_sym.name == gt_name {
-				typ = match arg.typ {
-					table.int_literal_type { table.int_type }
-					table.float_literal_type { table.f64_type }
-					else { arg.typ }
-				}
+				typ = table.mktyp(arg.typ)
 				break
 			}
 			arg_sym := c.table.get_type_symbol(arg.typ)

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -443,7 +443,11 @@ pub fn (mut c Checker) infer_fn_types(f table.Fn, mut call_expr ast.CallExpr) {
 			arg := call_expr.args[arg_i]
 			param_type_sym := c.table.get_type_symbol(param.typ)
 			if param.typ.has_flag(.generic) && param_type_sym.name == gt_name {
-				typ = arg.typ
+				typ = match arg.typ {
+					table.int_literal_type { table.int_type }
+					table.float_literal_type { table.f64_type }
+					else { arg.typ }
+				}
 				break
 			}
 			arg_sym := c.table.get_type_symbol(arg.typ)

--- a/vlib/v/tests/generic_fn_infer_modifier_test.v
+++ b/vlib/v/tests/generic_fn_infer_modifier_test.v
@@ -10,7 +10,7 @@ fn test_array() {
 	mut a := [7, 8]
 	r := f_array(a)
 	assert r == 7
-	
+
 	g_array(mut a)
 	assert a[0] == 8
 }

--- a/vlib/v/tests/generic_fn_infer_test.v
+++ b/vlib/v/tests/generic_fn_infer_test.v
@@ -19,6 +19,15 @@ fn test_explicit_calls_should_also_work() {
 	assert true
 }
 
+fn get_type_name<T>(x T) string {
+	return T.name
+}
+
+fn test_literal() {
+	assert get_type_name(1) == 'int'
+	assert get_type_name(1.0) == 'f64'
+}
+
 //
 fn choose4<T>(a T, b T, c T, d T) T {
 	// NB: a similar construct is used in prime31's via engine


### PR DESCRIPTION
Fix https://github.com/vlang/v/issues/9181
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
