### PR TITLE
cgen: format if_guard_expr generated c codes

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2861,7 +2861,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 					}
 					if is_gen_or_and_assign_rhs {
 						elem_styp := g.typ(elem_type)
-						g.write('\n$cur_line*($elem_styp*)${tmp_opt}.data')
+						g.write(';\n$cur_line*($elem_styp*)${tmp_opt}.data')
 					}
 				}
 			} else {
@@ -3705,7 +3705,7 @@ fn (mut g Gen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var str
 					g.write('(')
 				} else {
 					if j == 0 && sumtype_index == 0 {
-						g.writeln('')
+						g.empty_line = true
 					}
 					g.write_v_source_line_info(branch.pos)
 					g.write('if (')
@@ -4202,8 +4202,6 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 				is_guard = true
 				guard_idx = i
 				guard_vars = []string{len: node.branches.len}
-				g.writeln(';')
-				g.writeln('{ /* if guard */ ')
 			}
 			if cond.expr !is ast.IndexExpr && cond.expr !is ast.PrefixExpr {
 				var_name := g.new_tmp_var()
@@ -4282,9 +4280,6 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 		} else {
 			g.stmts(branch.stmts)
 		}
-	}
-	if is_guard {
-		g.write('}')
 	}
 	g.writeln('}')
 	if needs_tmp_var {


### PR DESCRIPTION
This PR format if_guard_expr generated c codes.

before:
```vlang
Option2_v__table__Field v__table__Table_find_field(v__table__Table* t, v__table__TypeSymbol* s, string name) {
	v__table__TypeSymbol* ts = s;
	for (;;) {

		if (ts->info._typ == 169 /* v.table.Struct */) {
			;
			{ /* if guard */ 
			Option2_v__table__Field _t1308;
			if (_t1308 = v__table__Struct_find_field((*ts->info._v__table__Struct), name), _t1308.state == 0) {
				v__table__Field field = *(v__table__Field*)_t1308.data;
				Option2_v__table__Field _t1309;
				opt_ok(&(v__table__Field[]) { field }, (Option2*)(&_t1309), sizeof(v__table__Field));
				return _t1309;
			}}
		}
		else if (ts->info._typ == 388 /* v.table.Aggregate */) {
			;
			{ /* if guard */ 
			Option2_v__table__Field _t1310;
			if (_t1310 = v__table__Aggregate_find_field(&(*ts->info._v__table__Aggregate), name), _t1310.state == 0) {
				v__table__Field field = *(v__table__Field*)_t1310.data;
				Option2_v__table__Field _t1311;
				opt_ok(&(v__table__Field[]) { field }, (Option2*)(&_t1311), sizeof(v__table__Field));
				return _t1311;
			}}
			Option2_v__table__Field _t1312 = v__table__Table_register_aggregate_field(t, ts, name);
			if (_t1312.state != 0) { /*or block*/ 
				Error err = _t1312.err;
				Option2 _t1313 = (Option2){.state=2, .err=err};
				Option2_v__table__Field _t1314;
				memcpy(&_t1314, &_t1313, sizeof(Option2));
				return _t1314;
			}
 			v__table__Field field =  *(v__table__Field*)_t1312.data;
			Option2_v__table__Field _t1315;
			opt_ok(&(v__table__Field[]) { field }, (Option2*)(&_t1315), sizeof(v__table__Field));
			return _t1315;
		}
...
```
now:
```vlang
Option2_v__table__Field v__table__Table_find_field(v__table__Table* t, v__table__TypeSymbol* s, string name) {
	v__table__TypeSymbol* ts = s;
	for (;;) {
		if (ts->info._typ == 169 /* v.table.Struct */) {
			Option2_v__table__Field _t1309;
			if (_t1309 = v__table__Struct_find_field((*ts->info._v__table__Struct), name), _t1309.state == 0) {
				v__table__Field field = *(v__table__Field*)_t1309.data;
				Option2_v__table__Field _t1310;
				opt_ok(&(v__table__Field[]) { field }, (Option2*)(&_t1310), sizeof(v__table__Field));
				return _t1310;
			}
		}
		else if (ts->info._typ == 388 /* v.table.Aggregate */) {
			Option2_v__table__Field _t1311;
			if (_t1311 = v__table__Aggregate_find_field(&(*ts->info._v__table__Aggregate), name), _t1311.state == 0) {
				v__table__Field field = *(v__table__Field*)_t1311.data;
				Option2_v__table__Field _t1312;
				opt_ok(&(v__table__Field[]) { field }, (Option2*)(&_t1312), sizeof(v__table__Field));
				return _t1312;
			}
			Option2_v__table__Field _t1313 = v__table__Table_register_aggregate_field(t, ts, name);
			if (_t1313.state != 0) { /*or block*/ 
				Error err = _t1313.err;
				Option2 _t1314 = (Option2){.state=2, .err=err};
				Option2_v__table__Field _t1315;
				memcpy(&_t1315, &_t1314, sizeof(Option2));
				return _t1315;
			}
 			v__table__Field field =  *(v__table__Field*)_t1313.data;
			Option2_v__table__Field _t1316;
			opt_ok(&(v__table__Field[]) { field }, (Option2*)(&_t1316), sizeof(v__table__Field));
			return _t1316;
		}
...
```