### PR TITLE
all: implement error interfaces

### DIFF
--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -207,7 +207,7 @@ fn (vd VDoc) get_readme(path string) string {
 	return readme_contents
 }
 
-fn (vd VDoc) emit_generate_err(err Error) {
+fn (vd VDoc) emit_generate_err(err IError) {
 	cfg := vd.cfg
 	mut err_msg := err.msg
 	if err.code == 1 {

--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -18,8 +18,10 @@ pub:
 
 struct Option3 {
 	state byte
-	err   IError = __none
+	err   IError = none__
 }
+
+const none__ = IError(&None__{})
 
 struct None__ {
 	msg  string
@@ -27,8 +29,6 @@ struct None__ {
 }
 
 fn (_ None__) str() string { return 'none' }
-
-const __none = IError(&None__{})
 
 fn opt_ok3(data voidptr, mut option Option3, size int) {
 	unsafe {
@@ -67,13 +67,6 @@ struct Option2 {
 	// derived Option2_xxx types
 }
 
-// [inline]
-// fn (e Error) str() string {
-// 	// TODO: this should probably have a better str method,
-// 	// but this minimizes the amount of broken code after #8924
-// 	return e.msg
-// }
-
 // `fn foo() ?Foo { return foo }` => `fn foo() ?Foo { return opt_ok(foo); }`
 fn opt_ok(data voidptr, mut option Option2, size int) {
 	unsafe {
@@ -82,8 +75,6 @@ fn opt_ok(data voidptr, mut option Option2, size int) {
 		C.memcpy(byteptr(&option.err) + sizeof(Error), data, size)
 	}
 }
-
-pub fn yeet() Option3 { return Option3{} }
 
 // error returns an optional containing the error given in `message`.
 // `if ouch { return error('an error occurred') }`

--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -16,15 +16,19 @@ pub:
 	code int
 }
 
-pub struct Option3 {
+struct Option3 {
 	state byte
-	err   IError
+	err   IError = __none
 }
 
-[inline]
-fn (e IError) str() string {
-	return e.msg
+struct None__ {
+	msg  string
+	code int
 }
+
+fn (_ None__) str() string { return 'none' }
+
+const __none = IError(&None__{})
 
 fn opt_ok3(data voidptr, mut option Option3, size int) {
 	unsafe {
@@ -32,16 +36,6 @@ fn opt_ok3(data voidptr, mut option Option3, size int) {
 		// use err to get the end of Option3 and then memcpy into it
 		C.memcpy(byteptr(&option.err) + sizeof(IError), data, size)
 	}
-}
-
-pub fn (o Option3) str() string {
-	if o.state == 0 {
-		return 'Option{ ok }'
-	}
-	if o.state == 1 {
-		return 'Option{ none }'
-	}
-	return 'Option{ err: "$o.err" }'
 }
 
 [inline]
@@ -73,12 +67,12 @@ struct Option2 {
 	// derived Option2_xxx types
 }
 
-[inline]
-fn (e Error) str() string {
-	// TODO: this should probably have a better str method,
-	// but this minimizes the amount of broken code after #8924
-	return e.msg
-}
+// [inline]
+// fn (e Error) str() string {
+// 	// TODO: this should probably have a better str method,
+// 	// but this minimizes the amount of broken code after #8924
+// 	return e.msg
+// }
 
 // `fn foo() ?Foo { return foo }` => `fn foo() ?Foo { return opt_ok(foo); }`
 fn opt_ok(data voidptr, mut option Option2, size int) {
@@ -89,15 +83,7 @@ fn opt_ok(data voidptr, mut option Option2, size int) {
 	}
 }
 
-pub fn (o Option2) str() string {
-	if o.state == 0 {
-		return 'Option{ ok }'
-	}
-	if o.state == 1 {
-		return 'Option{ none }'
-	}
-	return 'Option{ error: "$o.err" }'
-}
+pub fn yeet() Option3 { return Option3{} }
 
 // error returns an optional containing the error given in `message`.
 // `if ouch { return error('an error occurred') }`

--- a/vlib/sync/channel_opt_propagate_test.v
+++ b/vlib/sync/channel_opt_propagate_test.v
@@ -14,7 +14,7 @@ fn do_rec_calc_send(chs []chan i64, mut sem sync.Semaphore) {
 	mut msg := ''
 	for {
 		mut s := get_val_from_chan(chs[0]) or {
-			msg = err.str()
+			msg = err.msg
 			break
 		}
 		s++

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -413,7 +413,7 @@ pub fn (mut c Checker) struct_decl(mut decl ast.StructDecl) {
 				c.check_expected(field_expr_type, field.typ) or {
 					if !(sym.kind == .interface_
 						&& c.type_implements(field_expr_type, field.typ, field.pos)) {
-						c.error('incompatible initializer for field `$field.name`: $err',
+						c.error('incompatible initializer for field `$field.name`: $err.msg',
 							field.default_expr.position())
 					}
 				}
@@ -582,7 +582,7 @@ pub fn (mut c Checker) struct_init(mut struct_init ast.StructInit) table.Type {
 					expr_type_sym := c.table.get_type_symbol(expr_type)
 					if expr_type != table.void_type && expr_type_sym.kind != .placeholder {
 						c.check_expected(expr_type, embed_type) or {
-							c.error('cannot assign to field `$info_field.name`: $err',
+							c.error('cannot assign to field `$info_field.name`: $err.msg',
 								field.pos)
 						}
 					}
@@ -598,7 +598,7 @@ pub fn (mut c Checker) struct_init(mut struct_init ast.StructInit) table.Type {
 						c.type_implements(expr_type, info_field.typ, field.pos)
 					} else if expr_type != table.void_type && expr_type_sym.kind != .placeholder {
 						c.check_expected(expr_type, info_field.typ) or {
-							c.error('cannot assign to field `$info_field.name`: $err',
+							c.error('cannot assign to field `$info_field.name`: $err.msg',
 								field.pos)
 						}
 					}
@@ -752,21 +752,21 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 					elem_type := right.array_info().elem_type
 					// if left_default.kind != right_sym.kind {
 					c.check_expected(left_type, elem_type) or {
-						c.error('left operand to `$infix_expr.op` does not match the array element type: $err',
+						c.error('left operand to `$infix_expr.op` does not match the array element type: $err.msg',
 							left_right_pos)
 					}
 				}
 				.map {
 					map_info := right.map_info()
 					c.check_expected(left_type, map_info.key_type) or {
-						c.error('left operand to `$infix_expr.op` does not match the map key type: $err',
+						c.error('left operand to `$infix_expr.op` does not match the map key type: $err.msg',
 							left_right_pos)
 					}
 					infix_expr.left_type = map_info.key_type
 				}
 				.string {
 					c.check_expected(left_type, right_type) or {
-						c.error('left operand to `$infix_expr.op` does not match: $err',
+						c.error('left operand to `$infix_expr.op` does not match: $err.msg',
 							left_right_pos)
 					}
 				}
@@ -913,16 +913,25 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 			return c.check_shift(left_type, right_type, left_pos, right_pos)
 		}
 		.key_is, .not_is {
-			type_expr := infix_expr.right as ast.Type
-			typ_sym := c.table.get_type_symbol(type_expr.typ)
+			right_expr := infix_expr.right
+			mut typ := match right_expr {
+				ast.Type { right_expr.typ }
+				ast.None { table.none_type_idx }
+				else {
+					c.error('invalid type `$right_expr`', right_expr.position())
+					table.Type(0)
+				}
+			}
+			typ_sym := c.table.get_type_symbol(typ)
+			op := infix_expr.op.str()
 			if typ_sym.kind == .placeholder {
-				c.error('$infix_expr.op.str(): type `$typ_sym.name` does not exist', type_expr.pos)
+				c.error('$op: type `$typ_sym.name` does not exist', right_expr.position())
 			}
 			if left.kind !in [.interface_, .sum_type] {
-				c.error('`$infix_expr.op.str()` can only be used with interfaces and sum types',
+				c.error('`$op` can only be used with interfaces and sum types',
 					infix_expr.pos)
 			} else if mut left.info is table.SumType {
-				if type_expr.typ !in left.info.variants {
+				if typ !in left.info.variants {
 					c.error('`$left.name` has no variant `$right.name`', infix_expr.pos)
 				}
 			}
@@ -1401,7 +1410,7 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 		}
 		if left_type_sym.kind == .aggregate {
 			// the error message contains the problematic type
-			unknown_method_msg = err
+			unknown_method_msg = err.msg
 		}
 	}
 	if has_method {
@@ -1483,7 +1492,7 @@ pub fn (mut c Checker) call_method(mut call_expr ast.CallExpr) table.Type {
 				// continue
 				// }
 				if got_arg_typ != table.void_type {
-					c.error('$err in argument ${i + 1} to `${left_type_sym.name}.$method_name`',
+					c.error('$err.msg in argument ${i + 1} to `${left_type_sym.name}.$method_name`',
 						arg.pos)
 				}
 			}
@@ -2004,7 +2013,7 @@ pub fn (mut c Checker) call_fn(mut call_expr ast.CallExpr) table.Type {
 			if f.generic_names.len > 0 {
 				continue
 			}
-			c.error('$err in argument ${i + 1} to `$fn_name`', call_arg.pos)
+			c.error('$err.msg in argument ${i + 1} to `$fn_name`', call_arg.pos)
 		}
 	}
 	if f.generic_names.len != call_expr.generic_types.len {
@@ -2033,9 +2042,24 @@ fn (mut c Checker) type_implements(typ table.Type, inter_typ table.Type, pos tok
 	utyp := c.unwrap_generic(typ)
 	typ_sym := c.table.get_type_symbol(utyp)
 	mut inter_sym := c.table.get_type_symbol(inter_typ)
+	// do not check the same type more than once
+	if mut inter_sym.info is table.Interface {
+		for t in inter_sym.info.types {
+			if t.idx() == utyp.idx() {
+				return true
+			}
+		}
+	}
 	styp := c.table.type_to_str(utyp)
-	same_base_type := utyp.idx() == inter_typ.idx()
-	if typ_sym.kind == .interface_ && inter_sym.kind == .interface_ && !same_base_type {
+	if utyp.idx() == inter_typ.idx() {
+		// same type -> already casted to the interface
+		return true
+	}
+	if inter_typ.idx() == table.error_type_idx && utyp.idx() == table.none_type_idx {
+		// `none` "implements" the Error interface
+		return true
+	}
+	if typ_sym.kind == .interface_ && inter_sym.kind == .interface_ {
 		c.error('cannot implement interface `$inter_sym.name` with a different interface `$styp`',
 			pos)
 	}
@@ -2304,7 +2328,7 @@ pub fn (mut c Checker) selector_expr(mut selector_expr ast.SelectorExpr) table.T
 				}
 			}
 			if sym.kind in [.aggregate, .sum_type] {
-				unknown_field_msg = err
+				unknown_field_msg = err.msg
 			}
 		}
 		if !c.inside_unsafe {
@@ -2874,7 +2898,7 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 			&& left_sym.kind != .interface_ {
 			// Dual sides check (compatibility check)
 			c.check_expected(right_type_unwrapped, left_type_unwrapped) or {
-				c.error('cannot assign to `$left`: $err', right.position())
+				c.error('cannot assign to `$left`: $err.msg', right.position())
 			}
 		}
 		if left_sym.kind == .interface_ {
@@ -3054,7 +3078,7 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) table.Type {
 				continue
 			}
 			c.check_expected(typ, elem_type) or {
-				c.error('invalid array element: $err', expr.position())
+				c.error('invalid array element: $err.msg', expr.position())
 			}
 		}
 		if array_init.is_fixed {
@@ -4411,7 +4435,7 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) table.Type {
 			// probably any mismatch will be caught by not producing a value instead
 			for st in branch.stmts[0..branch.stmts.len - 1] {
 				// must not contain C statements
-				st.check_c_expr() or { c.error('`match` expression branch has $err', st.pos) }
+				st.check_c_expr() or { c.error('`match` expression branch has $err.msg', st.pos) }
 			}
 		}
 		// If the last statement is an expression, return its type
@@ -5030,7 +5054,7 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) table.Type {
 			}
 			for st in branch.stmts {
 				// must not contain C statements
-				st.check_c_expr() or { c.error('`if` expression branch has $err', st.pos) }
+				st.check_c_expr() or { c.error('`if` expression branch has $err.msg', st.pos) }
 			}
 		}
 		// Also check for returns inside a comp.if's statements, even if its contents aren't parsed

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -915,8 +915,12 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 		.key_is, .not_is {
 			right_expr := infix_expr.right
 			mut typ := match right_expr {
-				ast.Type { right_expr.typ }
-				ast.None { table.none_type_idx }
+				ast.Type {
+					right_expr.typ
+				}
+				ast.None {
+					table.none_type_idx
+				}
 				else {
 					c.error('invalid type `$right_expr`', right_expr.position())
 					table.Type(0)
@@ -928,8 +932,7 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) table.Type {
 				c.error('$op: type `$typ_sym.name` does not exist', right_expr.position())
 			}
 			if left.kind !in [.interface_, .sum_type] {
-				c.error('`$op` can only be used with interfaces and sum types',
-					infix_expr.pos)
+				c.error('`$op` can only be used with interfaces and sum types', infix_expr.pos)
 			} else if mut left.info is table.SumType {
 				if typ !in left.info.variants {
 					c.error('`$left.name` has no variant `$right.name`', infix_expr.pos)

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -142,9 +142,7 @@ fn (mut g Gen) gen_str_for_option(typ table.Type, styp string, str_fn_name strin
 	g.type_definitions.writeln('string indent_${str_fn_name}($styp it, int indent_count); // auto')
 	g.auto_str_funcs.writeln('string indent_${str_fn_name}($styp it, int indent_count) {')
 	g.auto_str_funcs.writeln('\tstring res;')
-	g.auto_str_funcs.writeln('\tif (it.state == 1) {')
-	g.auto_str_funcs.writeln('\t\tres = _SLIT("none");')
-	g.auto_str_funcs.writeln('\t} else if (it.state == 0) {')
+	g.auto_str_funcs.writeln('\tif (it.state == 0) {')
 	if sym.kind == .string {
 		g.auto_str_funcs.writeln('\t\tres = _STR("\'%.*s\\000\'", 2, ${parent_str_fn_name}(*($sym.cname*)it.data));')
 	} else if should_use_indent_func(sym.kind) && !sym_has_str_method {
@@ -153,7 +151,7 @@ fn (mut g Gen) gen_str_for_option(typ table.Type, styp string, str_fn_name strin
 		g.auto_str_funcs.writeln('\t\tres = ${parent_str_fn_name}(*($sym.cname*)it.data);')
 	}
 	g.auto_str_funcs.writeln('\t} else {')
-	g.auto_str_funcs.writeln('\t\tres = _STR("error: \'%.*s\\000\'", 2, it.err.msg);')
+	g.auto_str_funcs.writeln('\t\tres = _STR("error: %.*s\\000", 2, indent_IError_str(it.err, indent_count));')
 	g.auto_str_funcs.writeln('\t}')
 	g.auto_str_funcs.writeln('\treturn _STR("Option(%.*s\\000)", 2, res);')
 	g.auto_str_funcs.writeln('}')
@@ -476,7 +474,7 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp string, str_fn_name st
 	if clean_struct_v_type_name.contains('_T_') {
 		// TODO: this is a bit hacky. styp shouldn't be even parsed with _T_
 		// use something different than g.typ for styp
-		clean_struct_v_type_name = 
+		clean_struct_v_type_name =
 			clean_struct_v_type_name.replace('_T_', '<').replace('_', ', ').replace('Array', 'array') +
 			'>'
 	}

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -474,7 +474,7 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp string, str_fn_name st
 	if clean_struct_v_type_name.contains('_T_') {
 		// TODO: this is a bit hacky. styp shouldn't be even parsed with _T_
 		// use something different than g.typ for styp
-		clean_struct_v_type_name =
+		clean_struct_v_type_name = 
 			clean_struct_v_type_name.replace('_T_', '<').replace('_', ', ').replace('Array', 'array') +
 			'>'
 	}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2793,7 +2793,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 			g.map_init(node)
 		}
 		ast.None {
-			g.write('_const___none')
+			g.write('_const_none__')
 		}
 		ast.OrExpr {
 			// this should never appear here

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5301,7 +5301,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type table.
 			// In main(), an `opt()?` call is sugar for `opt() or { panic(err) }`
 			if g.pref.is_debug {
 				paline, pafile, pamod, pafn := g.panic_debug_info(or_block.pos)
-				g.writeln('panic_debug($paline, tos3("$pafile"), tos3("$pamod"), tos3("$pafn"), ${cvar_name}.err.msg );')
+				g.writeln('panic_debug($paline, tos3("$pafile"), tos3("$pamod"), tos3("$pafn"), *${cvar_name}.err.msg );')
 			} else {
 				g.writeln('\tv_panic(_STR("optional not set (%.*s\\000)", 2, ${cvar_name}.err.msg));')
 			}

--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -141,7 +141,7 @@ pub fn (mut g Gen) gen_failing_error_propagation_for_test_fn(or_block ast.OrExpr
 	// `or { cb_propagate_test_error(@LINE, @FILE, @MOD, @FN, err.msg) }`
 	// and the test is considered failed
 	paline, pafile, pamod, pafn := g.panic_debug_info(or_block.pos)
-	g.writeln('\tmain__cb_propagate_test_error($paline, tos3("$pafile"), tos3("$pamod"), tos3("$pafn"), ${cvar_name}.err.msg );')
+	g.writeln('\tmain__cb_propagate_test_error($paline, tos3("$pafile"), tos3("$pamod"), tos3("$pafn"), *(${cvar_name}.err.msg) );')
 	g.writeln('\tg_test_fails++;')
 	g.writeln('\tlongjmp(g_jump_buffer, 1);')
 }

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -720,10 +720,10 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 	}
 	mut name := node.name
 	if node.name == 'error' {
-		name = 'error2'
+		name = 'error3'
 	}
 	if node.name == 'error_with_code' {
-		name = 'error_with_code2'
+		name = 'error_with_code3'
 	}
 	is_print := name in ['print', 'println', 'eprint', 'eprintln', 'panic']
 	print_method := name
@@ -773,7 +773,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 			g.is_js_call = false
 			g.writeln(');')
 			tmp2 = g.new_tmp_var()
-			g.writeln('Option2_$typ $tmp2 = $fn_name ($json_obj);')
+			g.writeln('Option3_$typ $tmp2 = $fn_name ($json_obj);')
 		}
 		if !g.is_autofree {
 			g.write('cJSON_Delete($json_obj); //del')

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -247,7 +247,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym table.TypeSymbol) {
 			g.writeln('if ($tmp_opt_ptr) {')
 			g.writeln('\t*(($elem_type_str*)&${tmp_opt}.data) = *(($elem_type_str*)$tmp_opt_ptr);')
 			g.writeln('} else {')
-			g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = (Error){.msg=_SLIT("array index out of range"), .code=0};')
+			g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = error3(_SLIT("array index out of range"));')
 			g.writeln('}')
 			if !node.is_option {
 				g.or_block(tmp_opt, node.or_expr, elem_type)
@@ -414,8 +414,7 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym table.TypeSymbol) {
 			g.writeln('if ($tmp_opt_ptr) {')
 			g.writeln('\t*(($elem_type_str*)&${tmp_opt}.data) = *(($elem_type_str*)$tmp_opt_ptr);')
 			g.writeln('} else {')
-			g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = (Error){.msg=_SLIT("array index out of range"), .code=0};')
-
+			g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = error3(_SLIT("array index out of range"));')
 			g.writeln('}')
 			if !node.is_option {
 				g.or_block(tmp_opt, node.or_expr, elem_type)

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -41,7 +41,7 @@ fn (mut g Gen) gen_json_for_type(typ table.Type) {
 	dec_fn_name := js_dec_name(styp)
 	// Make sure that this optional type actually exists
 	g.register_optional(utyp)
-	dec_fn_dec := 'Option2_$styp ${dec_fn_name}(cJSON* root)'
+	dec_fn_dec := 'Option3_$styp ${dec_fn_name}(cJSON* root)'
 	dec.writeln('
 $dec_fn_dec {
 	$styp res;
@@ -50,8 +50,7 @@ $dec_fn_dec {
 		if (error_ptr != NULL)	{
 			// fprintf(stderr, "Error in decode() for $styp error_ptr=: %s\\n", error_ptr);
 			// printf("\\nbad js=%%s\\n", js.str);
-			Option2 err = error2(tos2(error_ptr));
-			return *(Option2_$styp *)&err;
+			return (Option3_$styp){.state = 2,.err = error3(tos2(error_ptr))};
 		}
 	}
 ')
@@ -102,8 +101,8 @@ $enc_fn_dec {
 	}
 	// cJSON_delete
 	// p.cgen.fns << '$dec return opt_ok(res); \n}'
-	dec.writeln('\tOption2_$styp ret;')
-	dec.writeln('\topt_ok(&res, (Option2*)&ret, sizeof(res));')
+	dec.writeln('\tOption3_$styp ret;')
+	dec.writeln('\topt_ok3(&res, (Option3*)&ret, sizeof(res));')
 	dec.writeln('\treturn ret;\n}')
 	enc.writeln('\treturn o;\n}')
 	g.definitions.writeln(dec.str())
@@ -152,18 +151,18 @@ fn (mut g Gen) gen_struct_enc_dec(type_info table.TypeInfo, styp string, mut enc
 				} else {
 					g.gen_json_for_type(field.typ)
 					tmp := g.new_tmp_var()
-					dec.writeln('\tOption2_$field_type $tmp = $dec_name (js_get(root,"$name"));')
+					dec.writeln('\tOption3_$field_type $tmp = $dec_name (js_get(root,"$name"));')
 					dec.writeln('\tif(${tmp}.state != 0) {')
-					dec.writeln('\t\treturn *(Option2_$styp*) &$tmp;')
+					dec.writeln('\t\treturn *(Option3_$styp*) &$tmp;')
 					dec.writeln('\t}')
 					dec.writeln('\tres.${c_name(field.name)} = *($field_type*) ${tmp}.data;')
 				}
 			} else {
 				// dec.writeln(' $dec_name (js_get(root, "$name"), & (res . $field.name));')
 				tmp := g.new_tmp_var()
-				dec.writeln('\tOption2_$field_type $tmp = $dec_name (js_get(root,"$name"));')
+				dec.writeln('\tOption3_$field_type $tmp = $dec_name (js_get(root,"$name"));')
 				dec.writeln('\tif(${tmp}.state != 0) {')
-				dec.writeln('\t\treturn *(Option2_$styp*) &$tmp;')
+				dec.writeln('\t\treturn *(Option3_$styp*) &$tmp;')
 				dec.writeln('\t}')
 				dec.writeln('\tres.${c_name(field.name)} = *($field_type*) ${tmp}.data;')
 			}
@@ -215,18 +214,17 @@ fn (mut g Gen) decode_array(value_type table.Type) string {
 		s = '$styp val = ${fn_name}(jsval); '
 	} else {
 		s = '
-		Option2_$styp val2 = $fn_name (jsval);
+		Option3_$styp val2 = $fn_name (jsval);
 		if(val2.state != 0) {
 			array_free(&res);
-			return *(Option2_Array_$styp*)&val2;
+			return *(Option3_Array_$styp*)&val2;
 		}
 		$styp val = *($styp*)val2.data;
 '
 	}
 	return '
 	if(root && !cJSON_IsArray(root) && !cJSON_IsNull(root)) {
-		Option2 err = error2( string_add(_SLIT("Json element is not an array: "), tos2(cJSON_PrintUnformatted(root))) );
-		return *(Option2_Array_$styp *)&err;
+		return (Option3_Array_$styp){.state = 2, .err = error3(string_add(_SLIT("Json element is not an array: "), tos2(cJSON_PrintUnformatted(root))))};
 	}
 	res = __new_array(0, 0, sizeof($styp));
 	const cJSON *jsval = NULL;
@@ -260,18 +258,17 @@ fn (mut g Gen) decode_map(key_type table.Type, value_type table.Type) string {
 		s = '$styp_v val = $fn_name_v (js_get(root, jsval->string));'
 	} else {
 		s = '
-		Option2_$styp_v val2 = $fn_name_v (js_get(root, jsval->string));
+		Option3_$styp_v val2 = $fn_name_v (js_get(root, jsval->string));
 		if(val2.state != 0) {
 			map_free(&res);
-			return *(Option2_Map_${styp}_$styp_v*)&val2;
+			return *(Option3_Map_${styp}_$styp_v*)&val2;
 		}
 		$styp_v val = *($styp_v*)val2.data;
 '
 	}
 	return '
 	if(!cJSON_IsObject(root) && !cJSON_IsNull(root)) {
-		Option2 err = error2( string_add(_SLIT("Json element is not an object: "), tos2(cJSON_PrintUnformatted(root))) );
-		return *(Option2_Map_${styp}_$styp_v *)&err;
+		return (Option3_Map_${styp}_$styp_v){ .state = 2, .err = error3( string_add(_SLIT("Json element is not an object: "), tos2(cJSON_PrintUnformatted(root))) )};
 	}
 	res = new_map_2(sizeof($styp), sizeof($styp_v), $hash_fn, $key_eq_fn, $clone_fn, $free_fn);
 	cJSON *jsval = NULL;

--- a/vlib/v/gen/js/tests/js.v
+++ b/vlib/v/gen/js/tests/js.v
@@ -88,7 +88,7 @@ fn main() {
 		println(message)
 	})
 	hl.raw_js_log()
-	propagation() or { println(err.msg) }
+	propagation() or { println(err) }
 }
 
 fn anon_consumer(greeting string, anon fn (message string)) {

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -30,7 +30,8 @@ pub fn mark_used(mut the_table table.Table, pref &pref.Preferences, ast_files []
 		'tos2',
 		'tos3',
 		'isnil',
-		'opt_ok',
+		'opt_ok3',
+		'error3'
 		// utf8_str_visible_length is used by c/str.v
 		'utf8_str_visible_length',
 		'compare_ints',

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -32,7 +32,7 @@ pub fn mark_used(mut the_table table.Table, pref &pref.Preferences, ast_files []
 		'isnil',
 		'opt_ok3',
 		'error3'
-		// utf8_str_visible_length is used by c/str.v
+		// utf8_str_visible_length is used by c/str.v,,
 		'utf8_str_visible_length',
 		'compare_ints',
 		'compare_u64s',

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -31,8 +31,8 @@ pub fn mark_used(mut the_table table.Table, pref &pref.Preferences, ast_files []
 		'tos3',
 		'isnil',
 		'opt_ok3',
-		'error3'
-		// utf8_str_visible_length is used by c/str.v,,
+		'error3',
+		// utf8_str_visible_length is used by c/str.v
 		'utf8_str_visible_length',
 		'compare_ints',
 		'compare_u64s',

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -235,9 +235,7 @@ fn (mut w Walker) expr(node ast.Expr) {
 				w.stmts(b.stmts)
 			}
 		}
-		ast.None {
-			w.mark_fn_as_used('opt_none2')
-		}
+		ast.None {}
 		ast.ParExpr {
 			w.expr(node.expr)
 		}

--- a/vlib/v/table/types.v
+++ b/vlib/v/table/types.v
@@ -551,7 +551,7 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 			return_type: table.void_type
 		}
 	)
-	t.register_type_symbol(kind: .struct_, name: 'Error', cname: 'Error', mod: 'builtin')
+	t.register_type_symbol(kind: .interface_, name: 'IError', cname: 'IError', mod: 'builtin')
 }
 
 [inline]

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -296,7 +296,12 @@ fn create_option_err() ?string {
 }
 
 fn test_option_err() {
-	assert '$create_option_err()' == 'Option(error: \'this is an error\')'
+	assert '$create_option_err()' == "
+Option(error: IError(Error{
+    msg: 'this is an error'
+    code: 0
+}))
+".trim_space()
 }
 
 fn create_option_none() ?string {
@@ -304,7 +309,7 @@ fn create_option_none() ?string {
 }
 
 fn test_option_none() {
-	assert '$create_option_none()' == 'Option(none)'
+	assert '$create_option_none()' == 'Option(error: IError(none))'
 }
 
 fn create_option_string() ?string {


### PR DESCRIPTION
This (finally) works:
```v
struct CustomError {
    msg string = 'hello'
    code int = 86
}

fn custom_error() ? {
    return IError(&CustomError{})
}

custom_error() or {
    println('err.msg = $err.msg')

    match err {
        none { println('got `none`') }
        Error { println('got `Error`') }
        CustomError { println('got `CustomError`') }
        else { panic('unhandled error: $err') }
    }
}
```