### PR TITLE
scanner: decode \uXXXX in scanner

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1198,8 +1198,6 @@ fn (mut s Scanner) ident_string() string {
 }
 
 fn decode_u_escapes(s string, start int, escapes_pos []int) string {
-	return s
-	/*
 	if escapes_pos.len == 0 {
 		return s
 	}
@@ -1216,7 +1214,6 @@ fn decode_u_escapes(s string, start int, escapes_pos []int) string {
 		}
 	}
 	return ss.join('')
-	*/
 }
 
 fn trim_slash_line_break(s string) string {

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -5,6 +5,7 @@ module scanner
 
 import math.mathutil as mu
 import os
+import strconv
 import v.token
 import v.pref
 import v.util
@@ -1101,7 +1102,7 @@ fn (mut s Scanner) ident_string() string {
 		start++
 	}
 	s.is_inside_string = false
-	mut u_to_x_pos := []int{} // pos list to replace \u0020 -> \x20
+	mut u_escapes_pos := []int{} // pos list of \uXXXX
 	slash := `\\`
 	for {
 		s.pos++
@@ -1153,11 +1154,8 @@ fn (mut s Scanner) ident_string() string {
 					|| !s.text[s.pos + 1].is_hex_digit() || !s.text[s.pos + 2].is_hex_digit()
 					|| !s.text[s.pos + 3].is_hex_digit() || !s.text[s.pos + 4].is_hex_digit() {
 					s.error(r'`\u` incomplete unicode character value')
-				} else if s.text[s.pos + 1] == `0` && s.text[s.pos + 2] == `0`
-					&& (`0` <= s.text[s.pos + 3] && s.text[s.pos + 3] < `8`) {
-					// ascii
-					u_to_x_pos << s.pos - 1
 				}
+				u_escapes_pos << s.pos - 1
 			}
 		}
 		// ${var} (ignore in vfmt mode) (skip \$)
@@ -1184,14 +1182,8 @@ fn (mut s Scanner) ident_string() string {
 	}
 	if start <= s.pos {
 		mut string_so_far := s.text[start..end]
-		if u_to_x_pos.len > 0 {
-			mut ss := []string{cap: u_to_x_pos.len + 1}
-			ss << string_so_far[..u_to_x_pos[0] - start]
-			for i in 0 .. u_to_x_pos.len - 1 {
-				ss << r'\x' + string_so_far[u_to_x_pos[i] - start + 4..u_to_x_pos[i + 1] - start]
-			}
-			ss << r'\x' + string_so_far[u_to_x_pos.last() + 4 - start..]
-			string_so_far = ss.join('')
+		if !s.is_fmt && u_escapes_pos.len > 0 {
+			string_so_far = decode_u_escapes(string_so_far, start, u_escapes_pos)
 		}
 		if n_cr_chars > 0 {
 			string_so_far = string_so_far.replace('\r', '')
@@ -1203,6 +1195,25 @@ fn (mut s Scanner) ident_string() string {
 		}
 	}
 	return lit
+}
+
+fn decode_u_escapes(s string, start int, escapes_pos []int) string {
+	if escapes_pos.len == 0 {
+		return s
+	}
+	mut ss := []string{cap: escapes_pos.len * 2 + 1}
+	ss << s[..escapes_pos.first() - start]
+	for i, pos in escapes_pos {
+		idx := pos - start
+		end_idx := idx + 6 // "\uXXXX".len == 6
+		ss << utf32_to_str(u32(strconv.parse_uint(s[idx+2..end_idx], 16, 32)))
+		if i + 1 < escapes_pos.len {
+			ss << s[end_idx..escapes_pos[i + 1] - start]
+		} else {
+			ss << s[end_idx..]
+		}
+	}
+	return ss.join('')
 }
 
 fn trim_slash_line_break(s string) string {

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1198,6 +1198,8 @@ fn (mut s Scanner) ident_string() string {
 }
 
 fn decode_u_escapes(s string, start int, escapes_pos []int) string {
+	return s
+	/*
 	if escapes_pos.len == 0 {
 		return s
 	}
@@ -1214,6 +1216,7 @@ fn decode_u_escapes(s string, start int, escapes_pos []int) string {
 		}
 	}
 	return ss.join('')
+	*/
 }
 
 fn trim_slash_line_break(s string) string {

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1206,7 +1206,7 @@ fn decode_u_escapes(s string, start int, escapes_pos []int) string {
 	for i, pos in escapes_pos {
 		idx := pos - start
 		end_idx := idx + 6 // "\uXXXX".len == 6
-		ss << utf32_to_str(u32(strconv.parse_uint(s[idx+2..end_idx], 16, 32)))
+		ss << utf32_to_str(u32(strconv.parse_uint(s[idx + 2..end_idx], 16, 32)))
 		if i + 1 < escapes_pos.len {
 			ss << s[end_idx..escapes_pos[i + 1] - start]
 		} else {

--- a/vlib/v/tests/strings_unicode_test.v
+++ b/vlib/v/tests/strings_unicode_test.v
@@ -5,6 +5,6 @@ fn test_raw_string() {
 fn test_escape() {
 	assert '\x20' == ' '
 	assert '\u0020' == ' '
-	// assert '\u00c4' == 'Ä'
+	assert '\u00c4' == 'Ä'
 	assert '\r\n'.bytes() == [byte(0x0d), 0x0a]
 }


### PR DESCRIPTION
In some cases, C compiler treat `\uXXXX` as not utf8.

This PR avoid this problem by decode unicode escape by scanner
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
