### PR TITLE
cgen: fix return_statement generated redundant `;`

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4501,7 +4501,6 @@ fn (mut g Gen) return_statement(node ast.Return) {
 			if expr is ast.Ident {
 				g.returned_var_name = expr.name
 			}
-			g.writeln(';')
 			// autofree before `return`
 			// set free_parent_scopes to true, since all variables defined in parent
 			// scopes need to be freed before the return
@@ -4509,6 +4508,7 @@ fn (mut g Gen) return_statement(node ast.Return) {
 				g.autofree_scope_vars(node.pos.pos - 1, node.pos.line_nr, true)
 			}
 			if tmp != '' {
+				g.writeln(';')
 				g.write('return $tmp')
 			}
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4329,6 +4329,7 @@ fn (mut g Gen) return_statement(node ast.Return) {
 	sym := g.table.get_type_symbol(g.fn_decl.return_type)
 	fn_return_is_multi := sym.kind == .multi_return
 	fn_return_is_optional := g.fn_decl.return_type.has_flag(.optional)
+	mut has_semicolon := false
 	if node.exprs.len == 0 {
 		if fn_return_is_optional {
 			styp := g.typ(g.fn_decl.return_type)
@@ -4501,25 +4502,26 @@ fn (mut g Gen) return_statement(node ast.Return) {
 			if expr is ast.Ident {
 				g.returned_var_name = expr.name
 			}
-			tmp_is_not_empty := tmp != ''
-			if tmp_is_not_empty {
-				g.writeln(';')
-			}
+			g.writeln(';')
+			has_semicolon = true
 			// autofree before `return`
 			// set free_parent_scopes to true, since all variables defined in parent
 			// scopes need to be freed before the return
 			if g.pref.autofree {
 				g.autofree_scope_vars(node.pos.pos - 1, node.pos.line_nr, true)
 			}
-			if tmp_is_not_empty {
+			if tmp != '' {
 				g.write('return $tmp')
+				has_semicolon = false
 			}
 		}
 	} else { // if node.exprs.len == 0 {
 		println('this should never happen')
 		g.write('/*F*/return')
 	}
-	g.writeln(';')
+	if !has_semicolon {
+		g.writeln(';')
+	}
 }
 
 fn (mut g Gen) const_decl(node ast.ConstDecl) {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4501,14 +4501,17 @@ fn (mut g Gen) return_statement(node ast.Return) {
 			if expr is ast.Ident {
 				g.returned_var_name = expr.name
 			}
+			tmp_is_not_empty := tmp != ''
+			if tmp_is_not_empty {
+				g.writeln(';')
+			}
 			// autofree before `return`
 			// set free_parent_scopes to true, since all variables defined in parent
 			// scopes need to be freed before the return
 			if g.pref.autofree {
 				g.autofree_scope_vars(node.pos.pos - 1, node.pos.line_nr, true)
 			}
-			if tmp != '' {
-				g.writeln(';')
+			if tmp_is_not_empty {
 				g.write('return $tmp')
 			}
 		}


### PR DESCRIPTION
This PR fix return_statement generated redundant `;` in cgen.v.

- There are many such cases in v.c/v_win.c.

before:
```vlang
VV_LOCAL_SYMBOL string v__builder__Builder_rebuild_cached_module(v__builder__Builder* v, string vexe, string imp_path) {
	Option_string _t3127 = v__vcache__CacheManager_exists(&v->pref->cache_manager, _SLIT(".o"), imp_path);
	if (_t3127.state != 0) { /*or block*/ 
		IError err = _t3127.err;
		if (v->pref->is_verbose) {
			println(_STR("Cached %.*s\000 .o file not found... Building .o file for %.*s", 2, imp_path, imp_path));
		}
		string pwd = os__getwd();
		string vroot = os__dir(vexe);
		os__chdir(vroot);
		string boptions = Array_string_join(v->pref->build_options, _SLIT(" "));
		string rebuild_cmd = _STR("%.*s\000 %.*s\000 build-module %.*s", 3, vexe, boptions, imp_path);
		v__vcache__dlog(string_add(_SLIT("| Builder."), _SLIT("rebuild_cached_module")), _STR("vexe: %.*s\000 | imp_path: %.*s\000 | rebuild_cmd: %.*s", 3, vexe, imp_path, rebuild_cmd));
		os__system(rebuild_cmd);
		Option_string _t3128 = v__vcache__CacheManager_exists(&v->pref->cache_manager, _SLIT(".o"), imp_path);
		if (_t3128.state != 0) { /*or block*/ 
			err = _t3128.err;
			v_panic(_STR("could not rebuild cache module for %.*s\000, error: %.*s", 2, imp_path, IError_str(err)));
		}
 		string rebuilded_o =  *(string*)_t3128.data;
		os__chdir(pwd);
		return rebuilded_o;
		;
	}
 	string res =  *(string*)_t3127.data;
	return res;
	;
}
```

now:
```vlang
VV_LOCAL_SYMBOL string v__builder__Builder_rebuild_cached_module(v__builder__Builder* v, string vexe, string imp_path) {
	Option_string _t3127 = v__vcache__CacheManager_exists(&v->pref->cache_manager, _SLIT(".o"), imp_path);
	if (_t3127.state != 0) { /*or block*/ 
		IError err = _t3127.err;
		if (v->pref->is_verbose) {
			println(_STR("Cached %.*s\000 .o file not found... Building .o file for %.*s", 2, imp_path, imp_path));
		}
		string pwd = os__getwd();
		string vroot = os__dir(vexe);
		os__chdir(vroot);
		string boptions = Array_string_join(v->pref->build_options, _SLIT(" "));
		string rebuild_cmd = _STR("%.*s\000 %.*s\000 build-module %.*s", 3, vexe, boptions, imp_path);
		v__vcache__dlog(string_add(_SLIT("| Builder."), _SLIT("rebuild_cached_module")), _STR("vexe: %.*s\000 | imp_path: %.*s\000 | rebuild_cmd: %.*s", 3, vexe, imp_path, rebuild_cmd));
		os__system(rebuild_cmd);
		Option_string _t3128 = v__vcache__CacheManager_exists(&v->pref->cache_manager, _SLIT(".o"), imp_path);
		if (_t3128.state != 0) { /*or block*/ 
			err = _t3128.err;
			v_panic(_STR("could not rebuild cache module for %.*s\000, error: %.*s", 2, imp_path, IError_str(err)));
		}
 		string rebuilded_o =  *(string*)_t3128.data;
		os__chdir(pwd);
		return rebuilded_o;
	}
 	string res =  *(string*)_t3127.data;
	return res;
}
```