### PR TITLE
arrays: remove_at for array

### DIFF
--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -4,6 +4,7 @@ module arrays
 // - min / max - return the value of the minumum / maximum
 // - idx_min / idx_max - return the index of the first minumum / maximum
 // - merge - combine two sorted arrays and maintain sorted order
+// - remove_at return the array without the value at a fixed position
 
 // min returns the minimum
 pub fn min<T>(a []T) T {
@@ -123,6 +124,17 @@ pub fn group<T>(lists ...[]T) [][]T {
 	}
 
 	return [][]T{}
+}
+
+// remove element at a fixed position
+pub fn remove_at<T>(a []T, pos int) []T {
+	mut res := []T{}
+	for i, e in a {
+		if i != pos {
+			res << e
+		}
+	}
+	return res
 }
 
 [deprecated]

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -85,3 +85,10 @@ fn test_group() {
 	assert z2 == [[8, 2], [9, 1]]
 	assert group<int>(x, []int{}) == [][]int{}
 }
+
+fn test_remove_at() {
+	x := [1, 2, 3]
+
+	y := remove_at<int>(x, 1)
+	assert y == [1, 3]
+}


### PR DESCRIPTION
It seems that  there is no direct way to remove an element of array at a fixed position whereas there is it is insert function. I understand that removing an element is difficult since some type does not have equality comparison. 

Removing by index is an alternative even if it is less general. 

I add  `remove_at<T>()` function that works also for ui.Widget and a test function. 
