### PR TITLE
cgen: fix array_sort and format array_filter/map generated codes

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -141,7 +141,8 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 	if inp_sym.kind != .array {
 		verror('map() requires an array')
 	}
-	g.write('\t${g.typ(node.left_type)} ${tmp}_orig = ')
+	g.empty_line = true
+	g.write('${g.typ(node.left_type)} ${tmp}_orig = ')
 	g.expr(node.left)
 	g.writeln(';')
 	g.writeln('int ${tmp}_len = ${tmp}_orig.len;')
@@ -296,13 +297,14 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 	//
 	deref := if node.left_type.is_ptr() || node.left_type.is_pointer() { '->' } else { '.' }
 	// eprintln('> qsort: pointer $node.left_type | deref: `$deref`')
+	g.empty_line = true
 	g.write('qsort(')
 	g.expr(node.left)
 	g.write('${deref}data, ')
 	g.expr(node.left)
 	g.write('${deref}len, ')
 	g.expr(node.left)
-	g.writeln('${deref}element_size, (int (*)(const void *, const void *))&$compare_fn);')
+	g.write('${deref}element_size, (int (*)(const void *, const void *))&$compare_fn)')
 }
 
 // `nums.filter(it % 2 == 0)`
@@ -317,7 +319,8 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 	info := sym.info as table.Array
 	styp := g.typ(node.return_type)
 	elem_type_str := g.typ(info.elem_type)
-	g.write('\t${g.typ(node.left_type)} ${tmp}_orig = ')
+	g.empty_line = true
+	g.write('${g.typ(node.left_type)} ${tmp}_orig = ')
 	g.expr(node.left)
 	g.writeln(';')
 	g.writeln('int ${tmp}_len = ${tmp}_orig.len;')


### PR DESCRIPTION
This PR fix array_sort and format array_filter/map generated codes.

- array.sort() generated redundant ';'.
- array.filter/map generated codes's indent is wrong.

before:
```vlang
void v__util__Suggestion_sort(v__util__Suggestion* s) {
qsort(s->known.data, s->known.len, s->known.element_size, (int (*)(const void *, const void *))&compare__t928_v__util__Possibility);
	;
}

string v__util__Suggestion_say(v__util__Suggestion s, string msg) {
	string res = msg;
	bool found = false;
	if (s.known.len > 0) {
		v__util__Possibility top_posibility = (*(v__util__Possibility*)array_last(s.known));
		if (top_posibility.similarity > 0.5) {
			string val = top_posibility.value;
			if (!string_starts_with(val, _SLIT("[]"))) {
				res = /*f*/string_add(res, _STR(".\nDid you mean `%.*s\000`?", 2, val));
				found = true;
			}
		}
	}
	if (!found) {
		if (s.known.len > 0) {
	Array_v__util__Possibility _t929_orig = s.known;
			int _t929_len = _t929_orig.len;
			Array_string _t929 = __new_array(0, _t929_len, sizeof(string));

			for (int _t930 = 0; _t930 < _t929_len; ++_t930) {
				v__util__Possibility it = ((v__util__Possibility*) _t929_orig.data)[_t930];
				string ti = _STR("`%.*s\000`", 2, it.svalue);
				array_push(&_t929, &ti);
			}
			
			Array_string values = _t929;
			qsort(values.data, values.len, values.element_size, (int (*)(const void *, const void *))&compare_strings);
			;
			if (values.len == 1) {
				res = /*f*/string_add(res, _STR(".\n1 possibility: %.*s\000.", 2, (*(string*)/*ee elem_typ */array_get(values, 0))));
			} else if (values.len < 25) {
				res = /*f*/string_add(res, string_add(string_add(_STR(".\n%"PRId32"\000 possibilities: ", 2, values.len), Array_string_join(values, _SLIT(", "))), _SLIT(".")));
			}
		}
	}
	return res;
}
```
now:
```vlang
void v__util__Suggestion_sort(v__util__Suggestion* s) {
	qsort(s->known.data, s->known.len, s->known.element_size, (int (*)(const void *, const void *))&compare__t928_v__util__Possibility);
}

string v__util__Suggestion_say(v__util__Suggestion s, string msg) {
	string res = msg;
	bool found = false;
	if (s.known.len > 0) {
		v__util__Possibility top_posibility = (*(v__util__Possibility*)array_last(s.known));
		if (top_posibility.similarity > 0.5) {
			string val = top_posibility.value;
			if (!string_starts_with(val, _SLIT("[]"))) {
				res = /*f*/string_add(res, _STR(".\nDid you mean `%.*s\000`?", 2, val));
				found = true;
			}
		}
	}
	if (!found) {
		if (s.known.len > 0) {
			Array_v__util__Possibility _t929_orig = s.known;
			int _t929_len = _t929_orig.len;
			Array_string _t929 = __new_array(0, _t929_len, sizeof(string));

			for (int _t930 = 0; _t930 < _t929_len; ++_t930) {
				v__util__Possibility it = ((v__util__Possibility*) _t929_orig.data)[_t930];
				string ti = _STR("`%.*s\000`", 2, it.svalue);
				array_push(&_t929, &ti);
			}
			
			Array_string values = _t929;
			qsort(values.data, values.len, values.element_size, (int (*)(const void *, const void *))&compare_strings);
			if (values.len == 1) {
				res = /*f*/string_add(res, _STR(".\n1 possibility: %.*s\000.", 2, (*(string*)/*ee elem_typ */array_get(values, 0))));
			} else if (values.len < 25) {
				res = /*f*/string_add(res, string_add(string_add(_STR(".\n%"PRId32"\000 possibilities: ", 2, values.len), Array_string_join(values, _SLIT(", "))), _SLIT(".")));
			}
		}
	}
	return res;
}
```