### PR TITLE
vweb: separate App and Context; add Config struct

### DIFF
--- a/cmd/tools/gen_vc.v
+++ b/cmd/tools/gen_vc.v
@@ -124,7 +124,7 @@ fn main() {
 	}
 	// webhook server mode
 	if flag_options.serve {
-		mut ws := WebHookServer{}
+		mut ws := WebhookServer{}
 		ws.init_once()
 		vweb.run_app<WebhookServer>(mut ws, port: flag_options.port)
 	} else {
@@ -162,7 +162,7 @@ pub fn (mut ws WebhookServer) index() {
 }
 
 // gen webhook
-pub fn (mut ws WebhookServer) genhook() {
+pub fn (mut ws WebhookServer) genhook(mut c vweb.Context) {
 	// request data
 	// println(ws.vweb.req.data)
 	// TODO: parse request. json or urlencoded
@@ -170,10 +170,10 @@ pub fn (mut ws WebhookServer) genhook() {
 	ws.gen_vc.generate()
 	// error in generate
 	if ws.gen_vc.gen_error {
-		ws.json('{status: "failed"}')
+		c.json('{status: "failed"}')
 		return
 	}
-	ws.json('{status: "ok"}')
+	c.json('{status: "ok"}')
 }
 
 pub fn (ws &WebhookServer) reset() {

--- a/cmd/tools/gen_vc.v
+++ b/cmd/tools/gen_vc.v
@@ -89,7 +89,6 @@ mut:
 
 // webhook server
 struct WebhookServer {
-	vweb.Context
 mut:
 	gen_vc &GenVC = 0 // initialized in init_once
 }
@@ -125,7 +124,9 @@ fn main() {
 	}
 	// webhook server mode
 	if flag_options.serve {
-		vweb.run<WebhookServer>(flag_options.port)
+		mut ws := WebHookServer{}
+		ws.init_once()
+		vweb.run_app<WebhookServer>(mut ws, port: flag_options.port)
 	} else {
 		// cmd mode
 		mut gen_vc := new_gen_vc(flag_options)
@@ -154,10 +155,6 @@ pub fn (mut ws WebhookServer) init_once() {
 	ws.gen_vc = new_gen_vc(flag_options)
 	ws.gen_vc.init()
 	// ws.gen_vc = new_gen_vc(flag_options)
-}
-
-pub fn (mut ws WebhookServer) init() {
-	// ws.init_once()
 }
 
 pub fn (mut ws WebhookServer) index() {

--- a/examples/vweb/file_upload/vweb_example.v
+++ b/examples/vweb/file_upload/vweb_example.v
@@ -2,26 +2,20 @@ module main
 
 import vweb
 
-const (
-	port = 8082
-)
-
-struct App {
-	vweb.Context
-}
+struct App {}
 
 fn main() {
-	vweb.run<App>(port)
+	vweb.run<App>(port: 8082)
 }
 
-pub fn (mut app App) index() vweb.Result {
+pub fn (mut app App) index(mut c vweb.Context) vweb.Result {
 	return $vweb.html()
 }
 
 [post]
 ['/upload']
-pub fn (mut app App) upload() vweb.Result {
-	fdata := app.files['upfile']
+pub fn (mut app App) upload(mut c vweb.Context) vweb.Result {
+	fdata := c.files['upfile']
 
 	mut files := []vweb.RawHtml{}
 

--- a/examples/vweb/server_sent_events/server.v
+++ b/examples/vweb/server_sent_events/server.v
@@ -6,34 +6,32 @@ import time
 import vweb
 import vweb.sse
 
-struct App {
-	vweb.Context
-}
+struct App {}
 
 fn main() {
-	vweb.run<App>(8081)
+	mut conf := vweb.Config{
+		port: 8081
+	}
+	conf.serve_static('/favicon.ico', 'favicon.ico', 'img/x-icon')
+	conf.mount_static_folder_at(os.resource_abs_path('.'), '/')
+	vweb.run<App>(conf)
 }
 
-pub fn (mut app App) init_once() {
-	app.serve_static('/favicon.ico', 'favicon.ico', 'img/x-icon')
-	app.mount_static_folder_at(os.resource_abs_path('.'), '/')
-}
-
-pub fn (mut app App) index() vweb.Result {
+pub fn (mut app App) index(mut c vweb.Context) vweb.Result {
 	title := 'SSE Example'
 	return $vweb.html()
 }
 
-fn (mut app App) sse() vweb.Result {
-	mut session := sse.new_connection(app.conn)
+fn (mut app App) sse(mut c vweb.Context) vweb.Result {
+	mut session := sse.new_connection(c.conn)
 	// NB: you can setup session.write_timeout and session.headers here
-	session.start() or { return app.server_error(501) }
-	session.send_message(data: 'ok') or { return app.server_error(501) }
+	session.start() or { return c.server_error(501) }
+	session.send_message(data: 'ok') or { return c.server_error(501) }
 	for {
 		data := '{"time": "$time.now().str()", "random_id": "$rand.ulid()"}'
-		session.send_message(event: 'ping', data: data) or { return app.server_error(501) }
+		session.send_message(event: 'ping', data: data) or { return c.server_error(501) }
 		println('> sent event: $data')
 		time.sleep(1 * time.second)
 	}
-	return app.server_error(501)
+	return c.server_error(501)
 }

--- a/examples/vweb/vweb_assets/vweb_assets.v
+++ b/examples/vweb/vweb_assets/vweb_assets.v
@@ -4,32 +4,23 @@ import vweb
 //import vweb.assets
 import time
 
-const (
-	port = 8081
-)
-
-struct App {
-	vweb.Context
-}
+struct App {}
 
 fn main() {
-	vweb.run<App>(port)
-}
-
-pub fn (mut app App) init_once() {
+	mut conf := vweb.Config{
+		port: 8081
+	}
 	// Arbitary mime type.
-	app.serve_static('/favicon.ico', 'favicon.ico', 'img/x-icon')
+	conf.serve_static('/favicon.ico', 'favicon.ico', 'img/x-icon')
 	// Automatically make available known static mime types found in given directory.
 	// app.handle_static('assets')
 	// This would make available all known static mime types from current
 	// directory and below.
-	app.handle_static('.', false)
+	conf.handle_static('.', false)
+	vweb.run<App>(conf)
 }
 
-pub fn (mut app App) init() {
-}
-
-pub fn (mut app App) index() vweb.Result {
+pub fn (mut app App) index(mut c vweb.Context) vweb.Result {
 	// We can dynamically specify which assets are to be used in template.
 	// 	mut am := assets.new_manager()
 	// 	am.add_css('assets/index.css')
@@ -40,10 +31,10 @@ pub fn (mut app App) index() vweb.Result {
 	return $vweb.html()
 }
 
-fn (mut app App) text() vweb.Result {
-	return app.Context.text('Hello, world from vweb!')
+fn (mut app App) text(mut c vweb.Context) vweb.Result {
+	return c.text('Hello, world from vweb!')
 }
 
-fn (mut app App) time() vweb.Result {
-	return app.Context.text(time.now().format())
+fn (mut app App) time(mut c vweb.Context) vweb.Result {
+	return c.text(time.now().format())
 }

--- a/examples/vweb/vweb_example.v
+++ b/examples/vweb/vweb_example.v
@@ -1,53 +1,49 @@
 module main
 
 import vweb
-import rand
-
-const (
-	port = 8082
-)
 
 struct App {
-	vweb.Context
 mut:
 	cnt int
 }
 
 fn main() {
 	println('vweb example')
-	vweb.run<App>(port)
-}
 
-pub fn (mut app App) init_once() {
-	app.handle_static('.', false)
+	mut conf := vweb.Config{
+		port: 8082
+	}
+	conf.handle_static('.', true)
+
+	mut app := App{cnt: 100}
+	vweb.run_app(mut app, conf)
 }
 
 ['/users/:user']
-pub fn (mut app App) user_endpoint(user string) vweb.Result {
-	id := rand.intn(100)
-	return app.json('{"$user": $id}')
+pub fn (mut app App) user_endpoint(mut c vweb.Context, user string) vweb.Result {
+	return c.json('{"$user": $app.cnt}')
 }
 
-pub fn (mut app App) index() vweb.Result {
+pub fn (mut app App) index(mut c vweb.Context) vweb.Result {
 	app.cnt++
 	show := true
 	// app.text('Hello world from vweb')
 	hello := 'Hello world from vweb'
 	numbers := [1, 2, 3]
-	app.enable_chunked_transfer(40)
+	c.enable_chunked_transfer(40)
 	return $vweb.html()
 }
 
-pub fn (mut app App) show_text() vweb.Result {
-	return app.text('Hello world from vweb')
+pub fn (mut app App) show_text(mut c vweb.Context) vweb.Result {
+	return c.text('Hello world from vweb')
 }
 
-pub fn (mut app App) cookie() vweb.Result {
-	app.set_cookie(name: 'cookie', value: 'test')
-	return app.text('Headers: $app.headers')
+pub fn (mut app App) cookie(mut c vweb.Context) vweb.Result {
+	c.set_cookie(name: 'cookie', value: 'test')
+	return c.text('Headers: $c.headers')
 }
 
 [post]
-pub fn (mut app App) post() vweb.Result {
-	return app.text('Post body: $app.req.data')
+pub fn (mut app App) post(mut c vweb.Context) vweb.Result {
+	return c.text('Post body: $c.req.data')
 }

--- a/examples/vweb/vweb_example.v
+++ b/examples/vweb/vweb_example.v
@@ -1,6 +1,7 @@
 module main
 
 import vweb
+import json
 
 struct App {
 mut:
@@ -21,7 +22,7 @@ fn main() {
 
 ['/users/:user']
 pub fn (mut app App) user_endpoint(mut c vweb.Context, user string) vweb.Result {
-	return c.json('{"$user": $app.cnt}')
+	return c.json(json.encode(map{user: app.cnt}))
 }
 
 pub fn (mut app App) index(mut c vweb.Context) vweb.Result {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6521,10 +6521,10 @@ fn (mut c Checker) verify_all_vweb_routes() {
 						c.file = f.source_file // setup of file path for the warning
 						if nroute_attributes == -1 {
 							c.error('parameter `mut c vweb.Context` expected as the first argument in vweb method `${sym_app.name}.$m.name`',
-							f.pos)
+								f.pos)
 						} else {
 							c.warn('mismatched parameters count between vweb method `${sym_app.name}.$m.name` ($nargs) and route attribute $m.attrs ($nroute_attributes)',
-							f.pos)
+								f.pos)
 						}
 					}
 				}

--- a/vlib/v/checker/tests/vweb_routing_checks.out
+++ b/vlib/v/checker/tests/vweb_routing_checks.out
@@ -1,14 +1,14 @@
-vlib/v/checker/tests/vweb_routing_checks.vv:20:1: error: mismatched parameters count between vweb method `App.bar` (1) and route attribute ['/bar'] (0)
-   18 | // segfault because path taks 0 vars and fcn takes 1 arg
-   19 | ['/bar']
-   20 | pub fn (mut app App) bar(a string) vweb.Result {
-      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   21 |     return app.html('works')
-   22 | }
-vlib/v/checker/tests/vweb_routing_checks.vv:26:1: error: mismatched parameters count between vweb method `App.cow` (0) and route attribute ['/cow/:low'] (1)
-   24 | // no segfault, but it shouldnt compile
-   25 | ['/cow/:low']
-   26 | pub fn (mut app App) cow() vweb.Result {
-      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   27 |     return app.html('works')
-   28 | }
+vlib/v/checker/tests/vweb_routing_checks.vv:18:1: error: mismatched parameters count between vweb method `App.bar` (1) and route attribute ['/bar'] (0)
+   16 | // segfault because path taks 0 vars and fcn takes 1 arg
+   17 | ['/bar']
+   18 | pub fn (mut app App) bar(mut c vweb.Context, a string) vweb.Result {
+      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   19 |     return c.html('works')
+   20 | }
+vlib/v/checker/tests/vweb_routing_checks.vv:24:1: error: mismatched parameters count between vweb method `App.cow` (0) and route attribute ['/cow/:low'] (1)
+   22 | // no segfault, but it shouldnt compile
+   23 | ['/cow/:low']
+   24 | pub fn (mut app App) cow(mut c vweb.Context) vweb.Result {
+      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   25 |     return c.html('works')
+   26 | }

--- a/vlib/v/checker/tests/vweb_routing_checks.vv
+++ b/vlib/v/checker/tests/vweb_routing_checks.vv
@@ -1,30 +1,28 @@
 import vweb
 
-struct App {
-	vweb.Context
-}
+struct App {}
 
-pub fn (mut app App) no_attributes(a string) vweb.Result {
-	return app.text('ok')
+pub fn (mut app App) no_attributes(mut c vweb.Context, a string) vweb.Result {
+	return c.text('ok')
 }
 
 // works fine, as long as fcn gets 1 arg and route takes 1 var
 ['/foo/:bar']
-pub fn (mut app App) foo(a string) vweb.Result {
+pub fn (mut app App) foo(mut c vweb.Context, a string) vweb.Result {
 	eprintln('foo')
-	return app.html('works')
+	return c.html('works')
 }
 
 // segfault because path taks 0 vars and fcn takes 1 arg
 ['/bar']
-pub fn (mut app App) bar(a string) vweb.Result {
-	return app.html('works')
+pub fn (mut app App) bar(mut c vweb.Context, a string) vweb.Result {
+	return c.html('works')
 }
 
 // no segfault, but it shouldnt compile
 ['/cow/:low']
-pub fn (mut app App) cow() vweb.Result {
-	return app.html('works')
+pub fn (mut app App) cow(mut c vweb.Context) vweb.Result {
+	return c.html('works')
 }
 
 pub fn (app App) init_once() {
@@ -35,12 +33,11 @@ pub fn (app App) init() {
 	//
 }
 
-pub fn (mut app App) index() {
-	app.html('hello')
+pub fn (mut app App) index(mut c vweb.Context) {
+	c.html('hello')
 }
 
 fn main() {
-	port := 8181
 	mut app := App{}
-	vweb.run_app<App>(mut app, port)
+	vweb.run_app<App>(mut app, port: 8181)
 }

--- a/vlib/v/checker/tests/vweb_tmpl_used_var.vv
+++ b/vlib/v/checker/tests/vweb_tmpl_used_var.vv
@@ -1,15 +1,13 @@
 import vweb
 
-struct App {
-	vweb.Context
-}
+struct App {}
 
-pub fn (mut app App) index() vweb.Result {
+pub fn (mut app App) index(mut c vweb.Context) vweb.Result {
     test := 'test'
     return $vweb.html()
 }
 
 fn main() {
 	mut app := App{}
-	vweb.run_app<App>(mut app, 8181)
+	vweb.run_app<App>(mut app, port: 8181)
 }

--- a/vlib/vweb/config.v
+++ b/vlib/vweb/config.v
@@ -1,0 +1,71 @@
+module vweb
+
+import os
+
+pub struct Config {
+mut:
+	// private data for static paths
+	// this may move
+	static_files      map[string]string
+	static_mime_types map[string]string
+pub mut:
+	port int
+}
+
+
+// TODO: these Config methods may be removed
+
+// Handles a directory static
+// If `root` is set the mount path for the dir will be in '/'
+pub fn (mut c Config) handle_static(directory_path string, root bool) bool {
+	if !os.exists(directory_path) {
+		return false
+	}
+	dir_path := directory_path.trim_space().trim_right('/')
+	mut mount_path := ''
+	if dir_path != '.' && os.is_dir(dir_path) && !root {
+		// Mount point hygene, "./assets" => "/assets".
+		mount_path = '/' + dir_path.trim_left('.').trim('/')
+	}
+	c.scan_static_directory(dir_path, mount_path)
+	return true
+}
+
+// mount_static_folder_at - makes all static files in `directory_path` and inside it, available at http://server/mount_path
+// For example: suppose you have called .mount_static_folder_at('/var/share/myassets', '/assets'),
+// and you have a file /var/share/myassets/main.css .
+// => That file will be available at URL: http://server/assets/main.css .
+pub fn (mut c Config) mount_static_folder_at(directory_path string, mount_path string) bool {
+	if mount_path.len < 1 || mount_path[0] != `/` || !os.exists(directory_path) {
+		return false
+	}
+	dir_path := directory_path.trim_right('/')
+	c.scan_static_directory(dir_path, mount_path[1..])
+	return true
+}
+
+// Serves a file static
+// `url` is the access path on the site, `file_path` is the real path to the file, `mime_type` is the file type
+pub fn (mut c Config) serve_static(url string, file_path string, mime_type string) {
+	c.static_files[url] = file_path
+	c.static_mime_types[url] = mime_type
+}
+
+fn (mut c Config) scan_static_directory(directory_path string, mount_path string) {
+	files := os.ls(directory_path) or { panic(err) }
+	if files.len > 0 {
+		for file in files {
+			full_path := os.join_path(directory_path, file)
+			if os.is_dir(full_path) {
+				c.scan_static_directory(full_path, mount_path + '/' + file)
+			} else if file.contains('.') && !file.starts_with('.') && !file.ends_with('.') {
+				ext := os.file_ext(file)
+				// Rudimentary guard against adding files not in mime_types.
+				// Use serve_static directly to add non-standard mime types.
+				if ext in vweb.mime_types {
+					c.serve_static(mount_path + '/' + file, full_path, vweb.mime_types[ext])
+				}
+			}
+		}
+	}
+}

--- a/vlib/vweb/config.v
+++ b/vlib/vweb/config.v
@@ -12,7 +12,6 @@ pub mut:
 	port int
 }
 
-
 // TODO: these Config methods may be removed
 
 // Handles a directory static
@@ -62,8 +61,8 @@ fn (mut c Config) scan_static_directory(directory_path string, mount_path string
 				ext := os.file_ext(file)
 				// Rudimentary guard against adding files not in mime_types.
 				// Use serve_static directly to add non-standard mime types.
-				if ext in vweb.mime_types {
-					c.serve_static(mount_path + '/' + file, full_path, vweb.mime_types[ext])
+				if ext in mime_types {
+					c.serve_static(mount_path + '/' + file, full_path, mime_types[ext])
 				}
 			}
 		}

--- a/vlib/vweb/context.v
+++ b/vlib/vweb/context.v
@@ -16,17 +16,17 @@ pub:
 	static_files      map[string]string
 	static_mime_types map[string]string
 pub mut:
-	conn              &net.TcpConn
+	conn &net.TcpConn
 	// TODO: make form, query, and files read-only
-	form              map[string]string
-	query             map[string]string
-	files             map[string][]FileData
-	headers           string // response headers
-	done              bool
-	page_gen_start    i64
-	form_error        string
-	chunked_transfer  bool
-	max_chunk_len     int = 20
+	form             map[string]string
+	query            map[string]string
+	files            map[string][]FileData
+	headers          string // response headers
+	done             bool
+	page_gen_start   i64
+	form_error       string
+	chunked_transfer bool
+	max_chunk_len    int = 20
 }
 
 struct FileData {
@@ -55,7 +55,7 @@ pub fn (mut ctx Context) send_response_to_client(mimetype string, res string) bo
 	}
 	sb.write_string(ctx.headers)
 	sb.write_string('\r\n')
-	sb.write_string(vweb.headers_close)
+	sb.write_string(headers_close)
 	if ctx.chunked_transfer {
 		mut i := 0
 		mut len := res.len
@@ -119,7 +119,7 @@ pub fn (mut ctx Context) server_error(ecode int) Result {
 	if ctx.done {
 		return Result{}
 	}
-	send_string(mut ctx.conn, vweb.http_500) or {}
+	send_string(mut ctx.conn, http_500) or {}
 	return Result{}
 }
 
@@ -129,7 +129,7 @@ pub fn (mut ctx Context) redirect(url string) Result {
 		return Result{}
 	}
 	ctx.done = true
-	send_string(mut ctx.conn, 'HTTP/1.1 302 Found\r\nLocation: $url$ctx.headers\r\n$vweb.headers_close') or {
+	send_string(mut ctx.conn, 'HTTP/1.1 302 Found\r\nLocation: $url$ctx.headers\r\n$headers_close') or {
 		return Result{}
 	}
 	return Result{}
@@ -141,7 +141,7 @@ pub fn (mut ctx Context) not_found() Result {
 		return Result{}
 	}
 	ctx.done = true
-	send_string(mut ctx.conn, vweb.http_404) or {}
+	send_string(mut ctx.conn, http_404) or {}
 	return Result{}
 }
 
@@ -248,4 +248,3 @@ pub fn (ctx &Context) ip() string {
 pub fn (mut ctx Context) error(s string) {
 	ctx.form_error = s
 }
-

--- a/vlib/vweb/context.v
+++ b/vlib/vweb/context.v
@@ -1,0 +1,251 @@
+module vweb
+
+import net
+import net.http
+import strings
+import time
+
+[noinit]
+pub struct Context {
+mut:
+	content_type string = 'text/plain'
+	status       string = '200 OK'
+pub:
+	req http.Request
+	// TODO Response
+	static_files      map[string]string
+	static_mime_types map[string]string
+pub mut:
+	conn              &net.TcpConn
+	// TODO: make form, query, and files read-only
+	form              map[string]string
+	query             map[string]string
+	files             map[string][]FileData
+	headers           string // response headers
+	done              bool
+	page_gen_start    i64
+	form_error        string
+	chunked_transfer  bool
+	max_chunk_len     int = 20
+}
+
+struct FileData {
+pub:
+	filename     string
+	content_type string
+	data         string
+}
+
+// vweb intern function
+[manualfree]
+pub fn (mut ctx Context) send_response_to_client(mimetype string, res string) bool {
+	if ctx.done {
+		return false
+	}
+	ctx.done = true
+	mut sb := strings.new_builder(1024)
+	defer {
+		unsafe { sb.free() }
+	}
+	sb.write_string('HTTP/1.1 $ctx.status')
+	sb.write_string('\r\nContent-Type: $mimetype')
+	sb.write_string('\r\nContent-Length: $res.len')
+	if ctx.chunked_transfer {
+		sb.write_string('\r\nTransfer-Encoding: chunked')
+	}
+	sb.write_string(ctx.headers)
+	sb.write_string('\r\n')
+	sb.write_string(vweb.headers_close)
+	if ctx.chunked_transfer {
+		mut i := 0
+		mut len := res.len
+		for {
+			if len <= 0 {
+				break
+			}
+			mut chunk := ''
+			if len > ctx.max_chunk_len {
+				chunk = res[i..i + ctx.max_chunk_len]
+				i += ctx.max_chunk_len
+				len -= ctx.max_chunk_len
+			} else {
+				chunk = res[i..]
+				len = 0
+			}
+			sb.write_string(chunk.len.hex())
+			sb.write_string('\r\n$chunk\r\n')
+		}
+		sb.write_string('0\r\n\r\n') // End of chunks
+	} else {
+		sb.write_string(res)
+	}
+	s := sb.str()
+	defer {
+		unsafe { s.free() }
+	}
+	send_string(mut ctx.conn, s) or { return false }
+	return true
+}
+
+// Response HTTP_OK with s as payload with content-type `text/html`
+pub fn (mut ctx Context) html(s string) Result {
+	ctx.send_response_to_client('text/html', s)
+	return Result{}
+}
+
+// Response HTTP_OK with s as payload with content-type `text/plain`
+pub fn (mut ctx Context) text(s string) Result {
+	ctx.send_response_to_client('text/plain', s)
+	return Result{}
+}
+
+// Response HTTP_OK with s as payload with content-type `application/json`
+pub fn (mut ctx Context) json(s string) Result {
+	ctx.send_response_to_client('application/json', s)
+	return Result{}
+}
+
+// Response HTTP_OK with s as payload
+pub fn (mut ctx Context) ok(s string) Result {
+	ctx.send_response_to_client(ctx.content_type, s)
+	return Result{}
+}
+
+// Response a server error
+pub fn (mut ctx Context) server_error(ecode int) Result {
+	$if debug {
+		eprintln('> ctx.server_error ecode: $ecode')
+	}
+	if ctx.done {
+		return Result{}
+	}
+	send_string(mut ctx.conn, vweb.http_500) or {}
+	return Result{}
+}
+
+// Redirect to an url
+pub fn (mut ctx Context) redirect(url string) Result {
+	if ctx.done {
+		return Result{}
+	}
+	ctx.done = true
+	send_string(mut ctx.conn, 'HTTP/1.1 302 Found\r\nLocation: $url$ctx.headers\r\n$vweb.headers_close') or {
+		return Result{}
+	}
+	return Result{}
+}
+
+// Send an not_found response
+pub fn (mut ctx Context) not_found() Result {
+	if ctx.done {
+		return Result{}
+	}
+	ctx.done = true
+	send_string(mut ctx.conn, vweb.http_404) or {}
+	return Result{}
+}
+
+// Returns an empty result
+pub fn not_found() Result {
+	return Result{}
+}
+
+// Enables chunk transfer with max_chunk_len per chunk
+pub fn (mut ctx Context) enable_chunked_transfer(max_chunk_len int) {
+	ctx.chunked_transfer = true
+	ctx.max_chunk_len = max_chunk_len
+}
+
+// Sets a cookie
+pub fn (mut ctx Context) set_cookie(cookie Cookie) {
+	mut cookie_data := []string{}
+	mut secure := if cookie.secure { 'Secure;' } else { '' }
+	secure += if cookie.http_only { ' HttpOnly' } else { ' ' }
+	cookie_data << secure
+	if cookie.expires.unix > 0 {
+		cookie_data << 'expires=$cookie.expires.utc_string()'
+	}
+	data := cookie_data.join(' ')
+	ctx.add_header('Set-Cookie', '$cookie.name=$cookie.value; $data')
+}
+
+// Old function
+[deprecated]
+pub fn (mut ctx Context) set_cookie_old(key string, val string) {
+	// TODO support directives, escape cookie value (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)
+	// ctx.add_header('Set-Cookie', '${key}=${val};  Secure; HttpOnly')
+	ctx.add_header('Set-Cookie', '$key=$val; HttpOnly')
+}
+
+// Sets the response content type
+pub fn (mut ctx Context) set_content_type(typ string) {
+	ctx.content_type = typ
+}
+
+// Sets a cookie with a `expire_data`
+pub fn (mut ctx Context) set_cookie_with_expire_date(key string, val string, expire_date time.Time) {
+	ctx.add_header('Set-Cookie', '$key=$val;  Secure; HttpOnly; expires=$expire_date.utc_string()')
+}
+
+// Gets a cookie by a key
+pub fn (ctx &Context) get_cookie(key string) ?string { // TODO refactor
+	mut cookie_header := ctx.get_header('cookie')
+	if cookie_header == '' {
+		cookie_header = ctx.get_header('Cookie')
+	}
+	cookie_header = ' ' + cookie_header
+	// println('cookie_header="$cookie_header"')
+	// println(ctx.req.headers)
+	cookie := if cookie_header.contains(';') {
+		cookie_header.find_between(' $key=', ';')
+	} else {
+		cookie_header.find_between(' $key=', '\r')
+	}
+	if cookie != '' {
+		return cookie.trim_space()
+	}
+	return error('Cookie not found')
+}
+
+// Sets the response status
+pub fn (mut ctx Context) set_status(code int, desc string) {
+	if code < 100 || code > 599 {
+		ctx.status = '500 Internal Server Error'
+	} else {
+		ctx.status = '$code $desc'
+	}
+}
+
+// Adds an header to the response with key and val
+pub fn (mut ctx Context) add_header(key string, val string) {
+	// println('add_header($key, $val)')
+	ctx.headers = ctx.headers + '\r\n$key: $val'
+	// println(ctx.headers)
+}
+
+// Returns the header data from the key
+pub fn (ctx &Context) get_header(key string) string {
+	return ctx.req.lheaders[key.to_lower()]
+}
+
+// Returns the ip address from the current user
+pub fn (ctx &Context) ip() string {
+	mut ip := ctx.req.lheaders['x-forwarded-for']
+	if ip == '' {
+		ip = ctx.req.lheaders['x-real-ip']
+	}
+
+	if ip.contains(',') {
+		ip = ip.all_before(',')
+	}
+	if ip == '' {
+		ip = ctx.conn.peer_ip() or { '' }
+	}
+	return ip
+}
+
+// Set s to the form error
+pub fn (mut ctx Context) error(s string) {
+	ctx.form_error = s
+}
+

--- a/vlib/vweb/tests/vweb_test_server.v
+++ b/vlib/vweb/tests/vweb_test_server.v
@@ -9,7 +9,6 @@ const (
 )
 
 struct App {
-	vweb.Context
 	port    int
 	timeout int
 }
@@ -34,72 +33,66 @@ fn main() {
 		port: http_port
 		timeout: timeout
 	}
-	vweb.run_app<App>(mut app, http_port)
-}
-
-pub fn (mut app App) init() {
-}
-
-pub fn (mut app App) init_once() {
 	eprintln('>> webserver: started on http://127.0.0.1:$app.port/ , with maximum runtime of $app.timeout milliseconds.')
+	vweb.run_app<App>(mut app, port: http_port)
 }
 
-pub fn (mut app App) index() vweb.Result {
-	return app.text('Welcome to VWeb')
+pub fn (mut app App) index(mut c vweb.Context) vweb.Result {
+	return c.text('Welcome to VWeb')
 }
 
-pub fn (mut app App) simple() vweb.Result {
-	return app.text('A simple result')
+pub fn (mut app App) simple(mut c vweb.Context) vweb.Result {
+	return c.text('A simple result')
 }
 
-pub fn (mut app App) html_page() vweb.Result {
-	return app.html('<h1>ok</h1>')
+pub fn (mut app App) html_page(mut c vweb.Context) vweb.Result {
+	return c.html('<h1>ok</h1>')
 }
 
-pub fn (mut app App) chunk() vweb.Result {
-	app.enable_chunked_transfer(20)
-	return app.html('Lorem ipsum dolor sit amet, consetetur sadipscing')
+pub fn (mut app App) chunk(mut c vweb.Context) vweb.Result {
+	c.enable_chunked_transfer(20)
+	return c.html('Lorem ipsum dolor sit amet, consetetur sadipscing')
 }
 
 // the following serve custom routes
 ['/:user/settings']
-pub fn (mut app App) settings(username string) vweb.Result {
+pub fn (mut app App) settings(mut c vweb.Context, username string) vweb.Result {
 	if username !in known_users {
-		return app.not_found()
+		return c.not_found()
 	}
-	return app.html('username: $username')
+	return c.html('username: $username')
 }
 
 ['/:user/:repo/settings']
-pub fn (mut app App) user_repo_settings(username string, repository string) vweb.Result {
+pub fn (mut app App) user_repo_settings(mut c vweb.Context, username string, repository string) vweb.Result {
 	if username !in known_users {
-		return app.not_found()
+		return c.not_found()
 	}
-	return app.html('username: $username | repository: $repository')
+	return c.html('username: $username | repository: $repository')
 }
 
 ['/json_echo'; post]
-pub fn (mut app App) json_echo() vweb.Result {
-	// eprintln('>>>>> received http request at /json_echo is: $app.req')
-	app.set_content_type(app.req.headers['Content-Type'])
-	return app.ok(app.req.data)
+pub fn (mut app App) json_echo(mut c vweb.Context) vweb.Result {
+	// eprintln('>>>>> received http request at /json_echo is: $c.req')
+	c.set_content_type(c.req.headers['Content-Type'])
+	return c.ok(c.req.data)
 }
 
 // Make sure [post] works without the path
 [post]
-pub fn (mut app App) json() vweb.Result {
-	// eprintln('>>>>> received http request at /json is: $app.req')
-	app.set_content_type(app.req.headers['Content-Type'])
-	return app.ok(app.req.data)
+pub fn (mut app App) json(mut c vweb.Context) vweb.Result {
+	// eprintln('>>>>> received http request at /json is: $c.req')
+	c.set_content_type(c.req.headers['Content-Type'])
+	return c.ok(c.req.data)
 }
 
-pub fn (mut app App) shutdown() vweb.Result {
-	session_key := app.get_cookie('skey') or { return app.not_found() }
+pub fn (mut app App) shutdown(mut c vweb.Context) vweb.Result {
+	session_key := c.get_cookie('skey') or { return c.not_found() }
 	if session_key != 'superman' {
-		return app.not_found()
+		return c.not_found()
 	}
 	go app.gracefull_exit()
-	return app.ok('good bye')
+	return c.ok('good bye')
 }
 
 fn (mut app App) gracefull_exit() {

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -8,7 +8,6 @@ import io
 import net
 import net.http
 import net.urllib
-import strings
 import time
 
 pub const (
@@ -40,35 +39,6 @@ pub const (
 	default_port            = 8080
 )
 
-pub struct Context {
-mut:
-	content_type string = 'text/plain'
-	status       string = '200 OK'
-pub:
-	req http.Request
-	// TODO Response
-pub mut:
-	conn              &net.TcpConn
-	static_files      map[string]string
-	static_mime_types map[string]string
-	form              map[string]string
-	query             map[string]string
-	files             map[string][]FileData
-	headers           string // response headers
-	done              bool
-	page_gen_start    i64
-	form_error        string
-	chunked_transfer  bool
-	max_chunk_len     int = 20
-}
-
-struct FileData {
-pub:
-	filename     string
-	content_type string
-	data         string
-}
-
 struct UnexpectedExtraAttributeError {
 	msg  string
 	code int
@@ -78,12 +48,6 @@ struct MultiplePathAttributesError {
 	msg  string = 'Expected at most one path attribute'
 	code int
 }
-
-// declaring init_once in your App struct is optional
-pub fn (ctx Context) init_once() {}
-
-// declaring init in your App struct is optional
-pub fn (ctx Context) init() {}
 
 pub struct Cookie {
 	name      string
@@ -97,205 +61,14 @@ pub struct Cookie {
 pub struct Result {
 }
 
-// vweb intern function
-[manualfree]
-pub fn (mut ctx Context) send_response_to_client(mimetype string, res string) bool {
-	if ctx.done {
-		return false
-	}
-	ctx.done = true
-	mut sb := strings.new_builder(1024)
-	defer {
-		unsafe { sb.free() }
-	}
-	sb.write_string('HTTP/1.1 $ctx.status')
-	sb.write_string('\r\nContent-Type: $mimetype')
-	sb.write_string('\r\nContent-Length: $res.len')
-	if ctx.chunked_transfer {
-		sb.write_string('\r\nTransfer-Encoding: chunked')
-	}
-	sb.write_string(ctx.headers)
-	sb.write_string('\r\n')
-	sb.write_string(vweb.headers_close)
-	if ctx.chunked_transfer {
-		mut i := 0
-		mut len := res.len
-		for {
-			if len <= 0 {
-				break
-			}
-			mut chunk := ''
-			if len > ctx.max_chunk_len {
-				chunk = res[i..i + ctx.max_chunk_len]
-				i += ctx.max_chunk_len
-				len -= ctx.max_chunk_len
-			} else {
-				chunk = res[i..]
-				len = 0
-			}
-			sb.write_string(chunk.len.hex())
-			sb.write_string('\r\n$chunk\r\n')
-		}
-		sb.write_string('0\r\n\r\n') // End of chunks
-	} else {
-		sb.write_string(res)
-	}
-	s := sb.str()
-	defer {
-		unsafe { s.free() }
-	}
-	send_string(mut ctx.conn, s) or { return false }
-	return true
-}
-
-// Response HTTP_OK with s as payload with content-type `text/html`
-pub fn (mut ctx Context) html(s string) Result {
-	ctx.send_response_to_client('text/html', s)
-	return Result{}
-}
-
-// Response HTTP_OK with s as payload with content-type `text/plain`
-pub fn (mut ctx Context) text(s string) Result {
-	ctx.send_response_to_client('text/plain', s)
-	return Result{}
-}
-
-// Response HTTP_OK with s as payload with content-type `application/json`
-pub fn (mut ctx Context) json(s string) Result {
-	ctx.send_response_to_client('application/json', s)
-	return Result{}
-}
-
-// Response HTTP_OK with s as payload
-pub fn (mut ctx Context) ok(s string) Result {
-	ctx.send_response_to_client(ctx.content_type, s)
-	return Result{}
-}
-
-// Response a server error
-pub fn (mut ctx Context) server_error(ecode int) Result {
-	$if debug {
-		eprintln('> ctx.server_error ecode: $ecode')
-	}
-	if ctx.done {
-		return Result{}
-	}
-	send_string(mut ctx.conn, vweb.http_500) or {}
-	return Result{}
-}
-
-// Redirect to an url
-pub fn (mut ctx Context) redirect(url string) Result {
-	if ctx.done {
-		return Result{}
-	}
-	ctx.done = true
-	send_string(mut ctx.conn, 'HTTP/1.1 302 Found\r\nLocation: $url$ctx.headers\r\n$vweb.headers_close') or {
-		return Result{}
-	}
-	return Result{}
-}
-
-// Send an not_found response
-pub fn (mut ctx Context) not_found() Result {
-	if ctx.done {
-		return Result{}
-	}
-	ctx.done = true
-	send_string(mut ctx.conn, vweb.http_404) or {}
-	return Result{}
-}
-
-// Enables chunk transfer with max_chunk_len per chunk
-pub fn (mut ctx Context) enable_chunked_transfer(max_chunk_len int) {
-	ctx.chunked_transfer = true
-	ctx.max_chunk_len = max_chunk_len
-}
-
-// Sets a cookie
-pub fn (mut ctx Context) set_cookie(cookie Cookie) {
-	mut cookie_data := []string{}
-	mut secure := if cookie.secure { 'Secure;' } else { '' }
-	secure += if cookie.http_only { ' HttpOnly' } else { ' ' }
-	cookie_data << secure
-	if cookie.expires.unix > 0 {
-		cookie_data << 'expires=$cookie.expires.utc_string()'
-	}
-	data := cookie_data.join(' ')
-	ctx.add_header('Set-Cookie', '$cookie.name=$cookie.value; $data')
-}
-
-// Old function
-[deprecated]
-pub fn (mut ctx Context) set_cookie_old(key string, val string) {
-	// TODO support directives, escape cookie value (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)
-	// ctx.add_header('Set-Cookie', '${key}=${val};  Secure; HttpOnly')
-	ctx.add_header('Set-Cookie', '$key=$val; HttpOnly')
-}
-
-// Sets the response content type
-pub fn (mut ctx Context) set_content_type(typ string) {
-	ctx.content_type = typ
-}
-
-// Sets a cookie with a `expire_data`
-pub fn (mut ctx Context) set_cookie_with_expire_date(key string, val string, expire_date time.Time) {
-	ctx.add_header('Set-Cookie', '$key=$val;  Secure; HttpOnly; expires=$expire_date.utc_string()')
-}
-
-// Gets a cookie by a key
-pub fn (ctx &Context) get_cookie(key string) ?string { // TODO refactor
-	mut cookie_header := ctx.get_header('cookie')
-	if cookie_header == '' {
-		cookie_header = ctx.get_header('Cookie')
-	}
-	cookie_header = ' ' + cookie_header
-	// println('cookie_header="$cookie_header"')
-	// println(ctx.req.headers)
-	cookie := if cookie_header.contains(';') {
-		cookie_header.find_between(' $key=', ';')
-	} else {
-		cookie_header.find_between(' $key=', '\r')
-	}
-	if cookie != '' {
-		return cookie.trim_space()
-	}
-	return error('Cookie not found')
-}
-
-// Sets the response status
-pub fn (mut ctx Context) set_status(code int, desc string) {
-	if code < 100 || code > 599 {
-		ctx.status = '500 Internal Server Error'
-	} else {
-		ctx.status = '$code $desc'
-	}
-}
-
-// Adds an header to the response with key and val
-pub fn (mut ctx Context) add_header(key string, val string) {
-	// println('add_header($key, $val)')
-	ctx.headers = ctx.headers + '\r\n$key: $val'
-	// println(ctx.headers)
-}
-
-// Returns the header data from the key
-pub fn (ctx &Context) get_header(key string) string {
-	return ctx.req.lheaders[key.to_lower()]
-}
-
-pub fn run<T>(port int) {
+pub fn run<T>(conf &Config) {
 	mut app := T{}
-	run_app<T>(mut app, port)
+	run_app<T>(mut app, conf)
 }
 
-pub fn run_app<T>(mut app T, port int) {
-	mut l := net.listen_tcp(port) or { panic('failed to listen') }
-	println('[Vweb] Running app on http://localhost:$port')
-	app.Context = Context{
-		conn: 0
-	}
-	app.init_once()
+pub fn run_app<T>(mut app T, conf &Config) {
+	mut l := net.listen_tcp(conf.port) or { panic('failed to listen') }
+	println('[Vweb] Running app on http://localhost:$conf.port')
 	$for method in T.methods {
 		$if method.return_type is Result {
 			// check routes for validity
@@ -303,13 +76,15 @@ pub fn run_app<T>(mut app T, port int) {
 	}
 	for {
 		mut conn := l.accept() or { panic('accept() failed') }
-		// TODO: running handle_conn concurrently results in a race-condition
-		handle_conn<T>(mut conn, mut app)
+		// TODO: running handle_conn concurrently can cause a race-condition
+		//       - make `app` shared
+		//       - use kqueue / epoll
+		go handle_conn<T>(mut conn, mut app, conf)
 	}
 }
 
 [manualfree]
-fn handle_conn<T>(mut conn net.TcpConn, mut app T) {
+fn handle_conn<T>(mut conn net.TcpConn, mut app T, conf &Config) {
 	conn.set_read_timeout(30 * time.second)
 	conn.set_write_timeout(30 * time.second)
 	defer {
@@ -324,12 +99,13 @@ fn handle_conn<T>(mut conn net.TcpConn, mut app T) {
 		eprintln('error parsing request: $err')
 		return
 	}
-	app.Context = Context{
+	mut ctx := Context{
 		req: req
 		conn: conn
 		form: map[string]string{}
-		static_files: app.static_files
-		static_mime_types: app.static_mime_types
+		// TODO: clone?
+		static_files: conf.static_files
+		static_mime_types: conf.static_mime_types
 		page_gen_start: page_gen_start
 	}
 	if req.method in vweb.methods_with_form {
@@ -341,38 +117,37 @@ fn handle_conn<T>(mut conn net.TcpConn, mut app T) {
 			}
 			form, files := parse_multipart_form(req.data, boundary[0][9..])
 			for k, v in form {
-				app.form[k] = v
+				ctx.form[k] = v
 			}
 			for k, v in files {
-				app.files[k] = v
+				ctx.files[k] = v
 			}
 		} else {
 			form := parse_form(req.data)
 			for k, v in form {
-				app.form[k] = v
+				ctx.form[k] = v
 			}
 		}
 	}
 	// Serve a static file if it is one
 	// TODO: get the real path
-	url := urllib.parse(app.req.url.to_lower()) or {
+	url := urllib.parse(ctx.req.url.to_lower()) or {
 		eprintln('error parsing path: $err')
 		return
 	}
-	if serve_static<T>(mut app, url) {
+	if serve_static<T>(mut ctx, url) {
 		// successfully served a static file
 		return
 	}
 
-	app.init()
 	// Call the right action
 	$if debug {
 		println('route matching...')
 	}
 	url_words := url.path.split('/').filter(it != '')
-	// copy query args to app.query
+	// copy query args to ctx.query
 	for k, v in url.query().data {
-		app.query[k] = v.data[0]
+		ctx.query[k] = v.data[0]
 	}
 
 	$for method in T.methods {
@@ -388,27 +163,27 @@ fn handle_conn<T>(mut conn net.TcpConn, mut app T) {
 			route_words := route_path.split('/').filter(it != '')
 
 			// Skip if the HTTP request method does not match the attributes
-			if app.req.method in http_methods {
+			if ctx.req.method in http_methods {
 				// Route immediate matches first
 				// For example URL `/register` matches route `/:user`, but `fn register()`
 				// should be called first.
 				if !route_path.contains('/:') && url_words == route_words {
 					// We found a match
-					app.$method()
+					app.$method(mut ctx)
 					return
 				}
 
 				if url_words.len == 0 && route_words == ['index'] && method.name == 'index' {
-					app.$method()
+					app.$method(mut ctx)
 					return
 				}
 
 				if params := route_matches(url_words, route_words) {
 					method_args = params.clone()
-					if method_args.len != method.args.len {
+					if method_args.len + 1 != method.args.len {
 						eprintln('warning: uneven parameters count ($method.args.len) in `$method.name`, compared to the vweb route `$method.attrs` ($method_args.len)')
 					}
-					app.$method(method_args)
+					app.$method(mut ctx, method_args)
 					return
 				}
 			}
@@ -502,101 +277,20 @@ fn parse_attrs(name string, attrs []string) ?([]http.Method, string) {
 
 // check if request is for a static file and serves it
 // returns true if we served a static file, false otherwise
-fn serve_static<T>(mut app T, url urllib.URL) bool {
+fn serve_static<T>(mut ctx Context, url urllib.URL) bool {
 	// TODO: handle url parameters properly - for now, ignore them
-	static_file := app.static_files[url.path]
-	mime_type := app.static_mime_types[url.path]
+	static_file := ctx.static_files[url.path]
+	mime_type := ctx.static_mime_types[url.path]
 	if static_file == '' || mime_type == '' {
 		return false
 	}
 	data := os.read_file(static_file) or {
-		send_string(mut app.conn, vweb.http_404) or {}
+		send_string(mut ctx.conn, vweb.http_404) or {}
 		return true
 	}
-	app.send_response_to_client(mime_type, data)
+	ctx.send_response_to_client(mime_type, data)
 	unsafe { data.free() }
 	return true
-}
-
-fn (mut ctx Context) scan_static_directory(directory_path string, mount_path string) {
-	files := os.ls(directory_path) or { panic(err) }
-	if files.len > 0 {
-		for file in files {
-			full_path := os.join_path(directory_path, file)
-			if os.is_dir(full_path) {
-				ctx.scan_static_directory(full_path, mount_path + '/' + file)
-			} else if file.contains('.') && !file.starts_with('.') && !file.ends_with('.') {
-				ext := os.file_ext(file)
-				// Rudimentary guard against adding files not in mime_types.
-				// Use serve_static directly to add non-standard mime types.
-				if ext in vweb.mime_types {
-					ctx.serve_static(mount_path + '/' + file, full_path, vweb.mime_types[ext])
-				}
-			}
-		}
-	}
-}
-
-// Handles a directory static
-// If `root` is set the mount path for the dir will be in '/'
-pub fn (mut ctx Context) handle_static(directory_path string, root bool) bool {
-	if ctx.done || !os.exists(directory_path) {
-		return false
-	}
-	dir_path := directory_path.trim_space().trim_right('/')
-	mut mount_path := ''
-	if dir_path != '.' && os.is_dir(dir_path) && !root {
-		// Mount point hygene, "./assets" => "/assets".
-		mount_path = '/' + dir_path.trim_left('.').trim('/')
-	}
-	ctx.scan_static_directory(dir_path, mount_path)
-	return true
-}
-
-// mount_static_folder_at - makes all static files in `directory_path` and inside it, available at http://server/mount_path
-// For example: suppose you have called .mount_static_folder_at('/var/share/myassets', '/assets'),
-// and you have a file /var/share/myassets/main.css .
-// => That file will be available at URL: http://server/assets/main.css .
-pub fn (mut ctx Context) mount_static_folder_at(directory_path string, mount_path string) bool {
-	if ctx.done || mount_path.len < 1 || mount_path[0] != `/` || !os.exists(directory_path) {
-		return false
-	}
-	dir_path := directory_path.trim_right('/')
-	ctx.scan_static_directory(dir_path, mount_path[1..])
-	return true
-}
-
-// Serves a file static
-// `url` is the access path on the site, `file_path` is the real path to the file, `mime_type` is the file type
-pub fn (mut ctx Context) serve_static(url string, file_path string, mime_type string) {
-	ctx.static_files[url] = file_path
-	ctx.static_mime_types[url] = mime_type
-}
-
-// Returns the ip address from the current user
-pub fn (ctx &Context) ip() string {
-	mut ip := ctx.req.lheaders['x-forwarded-for']
-	if ip == '' {
-		ip = ctx.req.lheaders['x-real-ip']
-	}
-
-	if ip.contains(',') {
-		ip = ip.all_before(',')
-	}
-	if ip == '' {
-		ip = ctx.conn.peer_ip() or { '' }
-	}
-	return ip
-}
-
-// Set s to the form error
-pub fn (mut ctx Context) error(s string) {
-	ctx.form_error = s
-}
-
-// Returns an empty result
-pub fn not_found() Result {
-	return Result{}
 }
 
 fn filter(s string) string {


### PR DESCRIPTION
This PR starts implementing the design proposed in #9081 by removing `vweb.Context` from `App` and supplying it as the first argument to a handler. Each request is now being handled concurrently with `go`, however safely accessing `App` is left to the user for now.

```v
struct App {
mut:
        cnt int
}

fn main() {
        println('vweb example')

        mut conf := vweb.Config{
                port: 8082
        }
        conf.handle_static('.', true)

        mut app := App{cnt: 100}
        vweb.run_app(mut app, conf)
}

['/users/:user']
pub fn (mut app App) user_endpoint(mut c vweb.Context, user string) vweb.Result {
        return c.json(json.encode(map{user: app.cnt}))
}

pub fn (mut app App) index(mut c vweb.Context) vweb.Result {
        app.cnt++
        show := true
        // app.text('Hello world from vweb')
        hello := 'Hello world from vweb'
        numbers := [1, 2, 3]
        c.enable_chunked_transfer(40)
        return $vweb.html()
}

pub fn (mut app App) show_text(mut c vweb.Context) vweb.Result {
        return c.text('Hello world from vweb')
}
```

Note that the receiver is not `shared` yet.

This PR is a breaking change to vweb. Once `shared` is added it will be another breaking change, so I'm not sure if we should wait to add it to this PR too.
