### PR TITLE
cgen: make use of mut_rec in method consistent

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4498,9 +4498,8 @@ fn (mut g Gen) return_statement(node ast.Return) {
 		}
 		if expr0.is_auto_deref_var() {
 			if g.fn_decl.return_type.is_ptr() {
-				g.write('&(*')
-				g.expr(expr0)
-				g.write(')')
+				var_str := g.expr_string(expr0)
+				g.write(var_str.trim('&'))
 			} else {
 				g.write('*')
 				g.expr(expr0)

--- a/vlib/v/tests/mut_receiver_returned_as_reference_test.v
+++ b/vlib/v/tests/mut_receiver_returned_as_reference_test.v
@@ -10,13 +10,14 @@ fn (mut p Player) set_name(name string) &Player {
 	return p // because of automatic (de)reference of return values
 }
 
+// NB: `p` is declared as a `mut` parameter, 
+// which now only affects its mutability.
 fn (mut p Player) set_position(x int, y int) &Player {
 	p.x = x
 	p.y = y
-	// NB: `p` is declared as a `mut` parameter,
-	// returning &p here just ignores `&` for now.
-	// TODO: this should be a checker error.
-	// `&p` should be of type `&&Player`
+	// TODO: from the point of view of the V programmer,
+	// `p` has still type &Player.
+	// assert typeof(p).name == 'Player'
 	return &p
 }
 

--- a/vlib/v/tests/mut_receiver_returned_as_reference_test.v
+++ b/vlib/v/tests/mut_receiver_returned_as_reference_test.v
@@ -1,0 +1,35 @@
+struct Player {
+mut:
+	name string
+	x    int
+	y    int
+}
+
+fn (mut p Player) set_name(name string) &Player {
+	p.name = name
+	return p // because of automatic (de)reference of return values
+}
+
+fn (mut p Player) set_position(x int, y int) &Player {
+	p.x = x
+	p.y = y
+	// NB: `p` is declared as a `mut` parameter,
+	// returning &p here just ignores `&` for now.
+	// TODO: this should be a checker error.
+	// `&p` should be of type `&&Player`
+	return &p
+}
+
+fn test_mut_receiver() {
+	mut p := &Player{}
+	f := p.set_name('frodo')
+	assert u64(p) == u64(f)
+	z := p.set_position(111, 222)
+	assert u64(p) == u64(z)
+	//
+	assert p.name == 'frodo'
+	assert p.x == 111
+	assert p.y == 222
+	assert u64(p.set_name('bilbo')) == u64(p)
+	assert p.name == 'bilbo'
+}


### PR DESCRIPTION
This PR make use of mut_rec in method consistent.

- Change os_process.
- Change return_statement.

```vlang
// signal_stop - stops the process, you can resume it with p.signal_continue()
pub fn (mut p Process) signal_stop() &Process {
	if p.status != .running {
		return &p
	}
	p._signal_stop()
	p.status = .stopped
	return &p
}
```