### PR TITLE
cgen: fix error of for_in map_literal

### DIFF
--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -31,6 +31,12 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 				p.inside_match = true // reuse the same var for perf instead of inside_sql TODO rename
 				node = p.sql_expr()
 				p.inside_match = false
+			} else if p.tok.lit == 'map' && p.peek_tok.kind == .lcbr && !(p.builtin_mod
+				&& p.file_base == 'map.v') {
+				p.next() // `map`
+				p.next() // `{`
+				node = p.map_init()
+				p.check(.rcbr) // `}`
 			} else {
 				if p.inside_if && p.is_generic_name() {
 					// $if T is string {}

--- a/vlib/v/tests/for_in_containers_of_fixed_array_test.v
+++ b/vlib/v/tests/for_in_containers_of_fixed_array_test.v
@@ -75,6 +75,18 @@ fn test_for_in_map_of_fixed_array() {
 	assert rets[2] == 'cc, [5, 6]'
 }
 
+fn test_for_in_map_of_fixed_array_literal() {
+	mut rets := []string{}
+
+	for k, v in map{'aa': [1, 2]!, 'bb': [3, 4]!, 'cc': [5, 6]!} {
+		println('$k, $v')
+		rets << '$k, $v'
+	}
+	assert rets[0] == 'aa, [1, 2]'
+	assert rets[1] == 'bb, [3, 4]'
+	assert rets[2] == 'cc, [5, 6]'
+}
+
 fn test_for_mut_in_map_of_fixed_array() {
 	mut rets := []string{}
 	mut m := map{'aa': [1, 2]!, 'bb': [3, 4]!, 'cc': [5, 6]!}


### PR DESCRIPTION
This PR fix error of for_in map_literal.

- Fix error of for_in map_literal.
- Add test.

```vlang
fn test_for_in_map_of_fixed_array_literal() {
	mut rets := []string{}

	for k, v in map{'aa': [1, 2]!, 'bb': [3, 4]!, 'cc': [5, 6]!} {
		println('$k, $v')
		rets << '$k, $v'
	}
	assert rets[0] == 'aa, [1, 2]'
	assert rets[1] == 'bb, [3, 4]'
	assert rets[2] == 'cc, [5, 6]'
}
```