### PR TITLE
cmd/tools/vdoc: implement color highlighting for stdout format and enable it by defauly

### DIFF
--- a/cmd/tools/vdoc/utils.v
+++ b/cmd/tools/vdoc/utils.v
@@ -141,24 +141,31 @@ fn color_highlight(code string, tb &table.Table) string {
 	builtin := ['bool', 'string', 'i8', 'i16', 'int', 'i64', 'i128', 'byte', 'u16', 'u32', 'u64',
 		'u128', 'rune', 'f32', 'f64', 'int_literal', 'float_literal', 'byteptr', 'voidptr', 'any']
 	highlight_code := fn (tok token.Token, typ HighlightTokenTyp) string {
-		lit := if typ in [.unone, .operator, .punctuation] {
-			tok.kind.str()
-		} else if typ == .string {
-			//'${term.yellow("'")}${term.magenta(tok.lit)}${term.yellow("'")}' is not working
-			// due to a vfmt bug.
-			term.yellow("'") + term.magenta(tok.lit) + term.yellow("'")
-		} else if typ == .char {
-			'${term.yellow('`')}${term.magenta(tok.lit)}${term.yellow('`')}'
-		} else if typ == .keyword {
-			term.blue(tok.lit)
-		} else if typ in [.builtin, .symbol] {
-			term.green(tok.lit)
-		} else if typ == .function {
-			term.cyan(tok.lit)
-		} else if typ == .number {
-			term.bright_blue(tok.lit)
-		} else {
-			tok.lit
+		lit := match typ {
+			.unone, .operator, .punctuation {
+				tok.kind.str()
+			}
+			.string {
+				term.yellow("'$tok.lit'")
+			}
+			.char {
+				term.yellow('`$tok.lit`')
+			}
+			.keyword {
+				term.blue(tok.lit)
+			}
+			.builtin, .symbol {
+				term.green(tok.lit)
+			}
+			.function {
+				term.cyan(tok.lit)
+			}
+			.number {
+				term.bright_blue(tok.lit)
+			}
+			else {
+				tok.lit
+			}
 		}
 		return lit
 	}
@@ -177,7 +184,7 @@ fn color_highlight(code string, tb &table.Table) string {
 						&& (next_tok.kind != .lpar || prev.kind != .key_fn) {
 						tok_typ = .builtin
 					} else if next_tok.kind in [.lcbr, .rpar, .eof]
-						&& (next_tok.kind != .rpar || prev.kind == .name) {
+						&& (next_tok.kind != .rpar || prev.kind in [.name, .amp]) {
 						tok_typ = .symbol
 					} else if next_tok.kind in [.lpar, .lt] {
 						tok_typ = .function

--- a/cmd/tools/vdoc/utils.v
+++ b/cmd/tools/vdoc/utils.v
@@ -157,8 +157,6 @@ fn color_highlight(code string, tb &table.Table) string {
 			term.cyan(tok.lit)
 		} else if typ == .number {
 			term.bright_blue(tok.lit)
-		} else if typ == .name {
-			term.white(tok.lit)
 		} else {
 			tok.lit
 		}

--- a/cmd/tools/vdoc/utils.v
+++ b/cmd/tools/vdoc/utils.v
@@ -2,6 +2,13 @@ module main
 
 import os
 import v.doc
+import term
+import v.table
+import v.scanner
+import v.token
+import strings
+import v.pref
+
 
 [inline]
 fn slug(title string) string {
@@ -129,4 +136,86 @@ fn gen_footer_text(d &doc.Doc, include_timestamp bool) string {
 	generated_time := d.time_generated
 	time_str := '$generated_time.day $generated_time.smonth() $generated_time.year $generated_time.hhmmss()'
 	return '$footer_text Generated on: $time_str'
+}
+
+fn color_highlight(code string, tb &table.Table) string {
+	builtin := ['bool', 'string', 'i8', 'i16', 'int', 'i64', 'i128', 'byte', 'u16', 'u32', 'u64',
+		'u128', 'rune', 'f32', 'f64', 'int_literal', 'float_literal', 'byteptr', 'voidptr', 'any']
+	highlight_code := fn (tok token.Token, typ HighlightTokenTyp) string {
+		lit := if typ in [.unone, .operator, .punctuation] {
+			tok.kind.str()
+		} else if typ == .string {
+			"${term.yellow("'")}${term.magenta(tok.lit)}${term.yellow("'")}"
+		} else if typ == .char {
+			"${term.yellow("`")}${term.magenta(tok.lit)}${term.yellow("`")}"
+		} else if typ in [.keyword, .operator] {
+			term.blue(tok.lit)
+		} else if typ in [.builtin, .symbol] { term.green(tok.lit) }
+		else if typ == .function { term.cyan(tok.lit) }
+		else if typ == .number { term.bright_blue(tok.lit) }
+		else if typ == .name {term.white(tok.lit) }
+		else { tok.lit }
+		return lit
+	}
+	mut s := scanner.new_scanner(code, .parse_comments, &pref.Preferences{})
+	mut tok := s.scan()
+	mut next_tok := s.scan()
+	mut buf := strings.new_builder(200)
+	mut i := 0
+	for i < code.len {
+		if i == tok.pos {
+			mut tok_typ := HighlightTokenTyp.unone
+			match tok.kind {
+				.name {
+					if (tok.lit in builtin || tb.known_type(tok.lit)) && next_tok.kind != .lpar {
+						tok_typ = .builtin
+					} else if next_tok.kind in [.lcbr, .rpar, .eof] {
+						tok_typ = .symbol
+					} else if next_tok.kind in [.lpar, .lt, .plus, .minus, .mul, .div, .mod]  {
+						tok_typ = .function
+					} else {
+						tok_typ = .name
+					}
+				}
+				.comment {
+					tok_typ = .comment
+				}
+				.chartoken {
+					tok_typ = .char
+				}
+				.string {
+					tok_typ = .string
+				}
+				.number {
+					tok_typ = .number
+				}
+				.key_true, .key_false {
+					tok_typ = .boolean
+				}
+				.lpar, .lcbr, .rpar, .rcbr, .lsbr, .rsbr, .semicolon, .colon, .comma, .dot {
+					tok_typ = .punctuation
+				}
+				else {
+					if token.is_key(tok.lit) || token.is_decl(tok.kind) {
+						tok_typ = .keyword
+					} else if tok.kind == .decl_assign || tok.kind.is_assign() || tok.is_unary()
+						|| tok.kind.is_relational() || tok.kind.is_infix() {
+						tok_typ = .operator
+					}
+				}
+			}
+			buf.write_string(highlight_code(tok, tok_typ))
+			if next_tok.kind != .eof {
+				i = tok.pos + tok.len
+				tok = next_tok
+				next_tok = s.scan()
+			} else {
+				break
+			}
+		} else {
+			buf.write_b(code[i])
+			i++
+		}
+	}
+	return buf.str()
 }

--- a/cmd/tools/vdoc/utils.v
+++ b/cmd/tools/vdoc/utils.v
@@ -9,7 +9,6 @@ import v.token
 import strings
 import v.pref
 
-
 [inline]
 fn slug(title string) string {
 	return title.replace(' ', '-')
@@ -66,6 +65,7 @@ fn set_output_type_from_str(format string) OutputType {
 		'md', 'markdown' { OutputType.markdown }
 		'json' { OutputType.json }
 		'stdout' { OutputType.stdout }
+		'color' { OutputType.color }
 		else { OutputType.plaintext }
 	}
 	return output_type
@@ -145,16 +145,24 @@ fn color_highlight(code string, tb &table.Table) string {
 		lit := if typ in [.unone, .operator, .punctuation] {
 			tok.kind.str()
 		} else if typ == .string {
-			"${term.yellow("'")}${term.magenta(tok.lit)}${term.yellow("'")}"
+			//'${term.yellow("'")}${term.magenta(tok.lit)}${term.yellow("'")}' is not working
+			// due to a vfmt bug.
+			term.yellow("'") + term.magenta(tok.lit) + term.yellow("'")
 		} else if typ == .char {
-			"${term.yellow("`")}${term.magenta(tok.lit)}${term.yellow("`")}"
+			'${term.yellow('`')}${term.magenta(tok.lit)}${term.yellow('`')}'
 		} else if typ in [.keyword, .operator] {
 			term.blue(tok.lit)
-		} else if typ in [.builtin, .symbol] { term.green(tok.lit) }
-		else if typ == .function { term.cyan(tok.lit) }
-		else if typ == .number { term.bright_blue(tok.lit) }
-		else if typ == .name {term.white(tok.lit) }
-		else { tok.lit }
+		} else if typ in [.builtin, .symbol] {
+			term.green(tok.lit)
+		} else if typ == .function {
+			term.cyan(tok.lit)
+		} else if typ == .number {
+			term.bright_blue(tok.lit)
+		} else if typ == .name {
+			term.white(tok.lit)
+		} else {
+			tok.lit
+		}
 		return lit
 	}
 	mut s := scanner.new_scanner(code, .parse_comments, &pref.Preferences{})
@@ -171,7 +179,7 @@ fn color_highlight(code string, tb &table.Table) string {
 						tok_typ = .builtin
 					} else if next_tok.kind in [.lcbr, .rpar, .eof] {
 						tok_typ = .symbol
-					} else if next_tok.kind in [.lpar, .lt, .plus, .minus, .mul, .div, .mod]  {
+					} else if next_tok.kind in [.lpar, .lt, .plus, .minus, .mul, .div, .mod] {
 						tok_typ = .function
 					} else {
 						tok_typ = .name

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -14,7 +14,7 @@ import json
 import term
 
 const (
-	allowed_formats = ['md', 'markdown', 'json', 'text', 'stdout', 'html']
+	allowed_formats = ['md', 'markdown', 'json', 'text', 'stdout', 'html', 'htm']
 	vexe            = pref.vexe_path()
 	vroot           = os.dir(vexe)
 	tabs            = ['\t\t', '\t\t\t\t\t\t', '\t\t\t\t\t\t\t']

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -14,7 +14,7 @@ import json
 import term
 
 const (
-	allowed_formats = ['md', 'markdown', 'json', 'text', 'stdout', 'html', 'htm', 'color']
+	allowed_formats = ['md', 'markdown', 'json', 'text', 'stdout', 'html']
 	vexe            = pref.vexe_path()
 	vroot           = os.dir(vexe)
 	tabs            = ['\t\t', '\t\t\t\t\t\t', '\t\t\t\t\t\t\t']
@@ -89,6 +89,9 @@ fn (vd VDoc) gen_json(d doc.Doc) string {
 fn (vd VDoc) gen_plaintext(d doc.Doc) string {
 	cfg := vd.cfg
 	mut pw := strings.new_builder(200)
+	if !term.can_show_color_on_stdout() {
+		eprintln("terminal doesn't support colors, using normal output format")
+	}
 	if cfg.is_color {
 		if term.can_show_color_on_stdout() {
 			content_arr := d.head.content.split(' ')
@@ -404,9 +407,6 @@ fn parse_arguments(args []string) Config {
 					exit(1)
 				}
 				cfg.output_type = set_output_type_from_str(format)
-				if format == 'color' {
-					cfg.is_color = true
-				}
 				i++
 			}
 			'-color' {

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -49,7 +49,7 @@ mut:
 	is_multi         bool
 	is_vlib          bool
 	is_verbose       bool
-	is_color         bool
+	is_color         bool = true
 	include_readme   bool
 	include_examples bool = true
 	inline_assets    bool

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -51,7 +51,6 @@ mut:
 	is_multi         bool
 	is_vlib          bool
 	is_verbose       bool
-	is_color         bool = true
 	include_readme   bool
 	include_examples bool = true
 	inline_assets    bool
@@ -113,7 +112,7 @@ fn (vd VDoc) write_plaintext_content(contents []doc.DocNode, mut pw strings.Buil
 	cfg := vd.cfg
 	for cn in contents {
 		if cn.content.len > 0 {
-			if use_colors || cfg.is_color {
+			if use_colors {
 				pw.writeln(color_highlight(cn.content, vd.docs[0].table))
 			} else {
 				pw.writeln(cn.content)
@@ -400,11 +399,8 @@ fn parse_arguments(args []string) Config {
 				cfg.output_type = set_output_type_from_str(format)
 				i++
 			}
-			'-color' {
-				cfg.is_color = true
-			}
-			'-no-color' {
-				cfg.is_color = false
+			'-color', '-no-color' {
+				// Detect the above flags and do nothing here as the work is done in const `use_colors`.
 			}
 			'-inline-assets' {
 				cfg.inline_assets = true

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -49,7 +49,7 @@ mut:
 	is_multi         bool
 	is_vlib          bool
 	is_verbose       bool
-	is_color 		 bool
+	is_color         bool
 	include_readme   bool
 	include_examples bool = true
 	inline_assets    bool
@@ -90,8 +90,12 @@ fn (vd VDoc) gen_plaintext(d doc.Doc) string {
 	cfg := vd.cfg
 	mut pw := strings.new_builder(200)
 	if cfg.is_color {
-		content_arr := d.head.content.split(' ')
-		pw.writeln('${term.blue(content_arr[0])} ${term.green(content_arr[1])}\n')
+		if term.can_show_color_on_stdout() {
+			content_arr := d.head.content.split(' ')
+			pw.writeln('${term.blue(content_arr[0])} ${term.green(content_arr[1])}\n')
+		} else {
+			pw.writeln('$d.head.content\n')
+		}
 	} else {
 		pw.writeln('$d.head.content\n')
 	}
@@ -112,7 +116,11 @@ fn (vd VDoc) write_plaintext_content(contents []doc.DocNode, mut pw strings.Buil
 	for cn in contents {
 		if cn.content.len > 0 {
 			if cfg.is_color {
-				pw.writeln(color_highlight(cn.content, vd.docs[0].table))
+				if term.can_show_color_on_stdout() {
+					pw.writeln(color_highlight(cn.content, vd.docs[0].table))
+				} else {
+					pw.writeln(cn.content)
+				}
 			} else {
 				pw.writeln(cn.content)
 			}
@@ -396,10 +404,13 @@ fn parse_arguments(args []string) Config {
 					exit(1)
 				}
 				cfg.output_type = set_output_type_from_str(format)
+				if format == 'color' {
+					cfg.is_color = true
+				}
 				i++
 			}
 			'-color' {
-				cfg.is_color = true 
+				cfg.is_color = true
 			}
 			'-inline-assets' {
 				cfg.inline_assets = true

--- a/cmd/v/help/doc.txt
+++ b/cmd/v/help/doc.txt
@@ -20,6 +20,7 @@ Options:
   -o              Specifies the output file/folder path where to store the generated docs.
                   Set it to "stdout" to print the output instead of saving the contents
                   to a file.
+  -color          Colorize the stdout output (Enabled by default).
   -readme         Include README.md to docs if present.
   -v              Enables verbose logging. For debugging purposes.
   -no-timestamp   Omits the timestamp in the output file.

--- a/cmd/v/help/doc.txt
+++ b/cmd/v/help/doc.txt
@@ -22,7 +22,7 @@ Options:
                   Set it to "stdout" to print the output instead of saving the contents
                   to a file.
   -color          Force stdout colorize output.
-  -no-color       Don't force stdout colorize output
+  -no-color       Force plain text output, without ANSI colors.
   -readme         Include README.md to docs if present.
   -v              Enables verbose logging. For debugging purposes.
   -no-timestamp   Omits the timestamp in the output file.

--- a/cmd/v/help/doc.txt
+++ b/cmd/v/help/doc.txt
@@ -4,6 +4,7 @@ Usage:
 Examples:
   v doc os
   v doc os File
+  v doc -no-color os
   v doc -o math.html math
   v doc -m -f html vlib/
 
@@ -20,7 +21,8 @@ Options:
   -o              Specifies the output file/folder path where to store the generated docs.
                   Set it to "stdout" to print the output instead of saving the contents
                   to a file.
-  -color          Colorize the stdout output (Enabled by default).
+  -color          Force stdout colorize output.
+  -no-color       Don't force stdout colorize output
   -readme         Include README.md to docs if present.
   -v              Enables verbose logging. For debugging purposes.
   -no-timestamp   Omits the timestamp in the output file.


### PR DESCRIPTION
This PR implementation colorized output for `v doc` command and also introduces two flags: `-color` for force colorized stdout output and `-no-color` for plain stdout output. `v doc` now will print colorized output if the terminal supports colors.

Screenshots:
- Colorized output by default
![image](https://user-images.githubusercontent.com/28479139/111139995-d2f16480-85a7-11eb-9943-197f03c2e876.png)
![image](https://user-images.githubusercontent.com/28479139/111140117-f87e6e00-85a7-11eb-8277-7a60bd03e9fd.png)

- Using `-no-color` as flag
![image](https://user-images.githubusercontent.com/28479139/111140174-0b913e00-85a8-11eb-827c-7fd04ef4e8d0.png)

- Using `-color` as flag to force colorized output
![image](https://user-images.githubusercontent.com/28479139/111140385-48f5cb80-85a8-11eb-8b1d-8e353882b12d.png)
compared to:
![image](https://user-images.githubusercontent.com/28479139/111140460-5ca13200-85a8-11eb-8246-634b1070e891.png)


**NOTE**: The colors will not be the same change as in the above screenshot if you use a custom theme for your terminal.