### PR TITLE
String fix

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1677,26 +1677,26 @@ pub fn (s string) strip_margin_custom(del byte) string {
 pub fn (s string) split_by_whitespace() []string {
 	mut res := []string{}
 	mut word_start := 0
-	mut word_end := 0
+	mut word_len := 0
 	mut is_in_word := false
 	mut is_space := false
 	for i, c in s {
 		is_space = c in [` `, `\t`, `\n`]
 		if !is_in_word && !is_space {
 			word_start = i
+			word_len++
 			is_in_word = true
 			continue
 		}
 		if is_space && is_in_word {
-			word_end = i
-			res << s[word_start..word_end]
+			res << s[word_start..word_start+word_len]
 			is_in_word = false
-			word_end = 0
+			word_len = 0
 			word_start = 0
 			continue
 		}
 	}
-	if is_in_word && word_start > 0 {
+	if is_in_word && word_len > 0 {
 		// collect the remainder word at the end
 		res << s[word_start..s.len]
 	}

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1682,9 +1682,11 @@ pub fn (s string) split_by_whitespace() []string {
 	mut is_space := false
 	for i, c in s {
 		is_space = c in [` `, `\t`, `\n`]
+		if !is_space {
+			word_len++
+		}
 		if !is_in_word && !is_space {
 			word_start = i
-			word_len++
 			is_in_word = true
 			continue
 		}

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -905,6 +905,7 @@ fn test_split_by_whitespace() {
 	assert 'a bcde'.split_by_whitespace() == ['a', 'bcde']
 	assert '  sss \t  ssss '.split_by_whitespace() == ['sss', 'ssss']
 	assert '\n xyz \t abc   def'.split_by_whitespace() == ['xyz', 'abc', 'def']
+	assert 'hello'.split_by_whitespace() == ['hello']
 	assert ''.split_by_whitespace() == []
 }
 


### PR DESCRIPTION
split_by_whitespace was not working if a string only contained non-whitespace.

Before:
```v
assert('hello'.split_by_space()) == ['hello']
```
failed with
```
   > assert 'hello'.split_by_whitespace() == ['hello']
     Left value: []
    Right value: ['hello']
```
After:

assert succeeds.