### PR TITLE
vodc: more syntax highlighting and fixes

### DIFF
--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -89,6 +89,9 @@ enum HighlightTokenTyp {
 	punctuation
 	string
 	symbol
+	none_
+	module_
+	prefix
 }
 
 struct SearchModuleResult {

--- a/cmd/tools/vdoc/utils.v
+++ b/cmd/tools/vdoc/utils.v
@@ -160,7 +160,7 @@ fn color_highlight(code string, tb &table.Table) string {
 			.function {
 				term.cyan(tok.lit)
 			}
-			.number {
+			.number, .module_ {
 				term.bright_blue(tok.lit)
 			}
 			.boolean {
@@ -168,9 +168,6 @@ fn color_highlight(code string, tb &table.Table) string {
 			}
 			.none_ {
 				term.red(tok.lit)
-			}
-			.module_ {
-				term.yellow(tok.lit)
 			}
 			.prefix {
 				term.magenta(tok.lit)
@@ -246,23 +243,20 @@ fn color_highlight(code string, tb &table.Table) string {
 				}
 			}
 			buf.write_string(highlight_code(tok, tok_typ))
-			if prev_prev.kind != .eof {
-				prev_prev = prev
-			} else {
+			if prev_prev.kind == .eof {
 				break
 			}
-			if prev.kind != .eof {
-				prev = tok
-			} else {
+			prev_prev = prev
+			if prev.kind == .eof {
 				break
 			}
-			if next_tok.kind != .eof {
-				i = tok.pos + tok.len
-				tok = next_tok
-				next_tok = s.scan()
-			} else {
+			prev = tok
+			if next_tok.kind == .eof {
 				break
 			}
+			i = tok.pos + tok.len
+			tok = next_tok
+			next_tok = s.scan()
 		} else {
 			buf.write_b(code[i])
 			i++

--- a/cmd/tools/vdoc/utils.v
+++ b/cmd/tools/vdoc/utils.v
@@ -197,7 +197,7 @@ fn color_highlight(code string, tb &table.Table) string {
 						&& (next_tok.kind != .lpar || prev.kind !in [.key_fn, .rpar]) {
 						tok_typ = .builtin
 					} else if 
-						next_tok.kind in [.lcbr, .rpar, .eof, .comma, .pipe, .name, .rcbr, .assign, .key_pub, .key_mut, .pipe]
+						next_tok.kind in [.lcbr, .rpar, .eof, .comma, .pipe, .name, .rcbr, .assign, .key_pub, .key_mut, .pipe, .comma]
 						&& prev.kind in [.name, .amp, .rsbr, .key_type, .assign, .dot, .question, .rpar, .key_struct, .key_enum, .pipe]
 						&& (tok.lit[0].ascii_str().is_upper() || prev_prev.lit in ['C', 'JS']) {
 						tok_typ = .symbol

--- a/cmd/tools/vdoc/utils.v
+++ b/cmd/tools/vdoc/utils.v
@@ -198,7 +198,7 @@ fn color_highlight(code string, tb &table.Table) string {
 						tok_typ = .builtin
 					} else if 
 						next_tok.kind in [.lcbr, .rpar, .eof, .comma, .pipe, .name, .rcbr, .assign, .key_pub, .key_mut, .pipe, .comma]
-						&& prev.kind in [.name, .amp, .rsbr, .key_type, .assign, .dot, .question, .rpar, .key_struct, .key_enum, .pipe]
+						&& prev.kind in [.name, .amp, .rsbr, .key_type, .assign, .dot, .question, .rpar, .key_struct, .key_enum, .pipe, .key_interface]
 						&& (tok.lit[0].ascii_str().is_upper() || prev_prev.lit in ['C', 'JS']) {
 						tok_typ = .symbol
 					} else if next_tok.kind in [.lpar, .lt] {


### PR DESCRIPTION
This PR introduces new syntax highlighting colors for `v doc` command for the following:

- Module highlighting with `bright_blue`:
![image](https://user-images.githubusercontent.com/28479139/111290166-e108b900-866b-11eb-93ec-6fc885ba45f5.png)


- Language and String Prefix highlighting with `magenta`:
![image](https://user-images.githubusercontent.com/28479139/111279086-52db0580-8660-11eb-969e-9c337854ae8b.png)
![image](https://user-images.githubusercontent.com/28479139/111279150-67b79900-8660-11eb-940d-80f5c36886e7.png)

- Boolean values highlighted with `bright_magenta`:
![image](https://user-images.githubusercontent.com/28479139/111279298-903f9300-8660-11eb-8bfd-1bd7aaa6c6a9.png)

 This PR also fixes:

- Highlighting of all Symbols in a `struct`
![image](https://user-images.githubusercontent.com/28479139/111279541-cda42080-8660-11eb-97ae-6670995fe754.png)

- Highlighting of all Symbols in a `sum type`
![image](https://user-images.githubusercontent.com/28479139/111279676-f0ced000-8660-11eb-9bfb-9ef8ddf38449.png)
