### PR TITLE
cmd/tools/vdoc: highlight nested string quotes properly 

### DIFF
--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -92,7 +92,6 @@ enum HighlightTokenTyp {
 	none_
 	module_
 	prefix
-	str_intr
 }
 
 struct SearchModuleResult {

--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -92,6 +92,7 @@ enum HighlightTokenTyp {
 	none_
 	module_
 	prefix
+	str_intr
 }
 
 struct SearchModuleResult {

--- a/cmd/tools/vdoc/utils.v
+++ b/cmd/tools/vdoc/utils.v
@@ -183,9 +183,6 @@ fn color_highlight(code string, tb &table.Table) string {
 			.prefix {
 				lit = term.magenta(tok.lit)
 			}
-			.str_intr {
-				lit = term.red(tok.lit)
-			}
 			else {
 				lit = tok.lit
 			}
@@ -237,9 +234,6 @@ fn color_highlight(code string, tb &table.Table) string {
 				}
 				.number {
 					tok_typ = .number
-				}
-				.str_dollar, .str_inter {
-					tok_typ = .str_intr
 				}
 				.key_true, .key_false {
 					tok_typ = .boolean


### PR DESCRIPTION
This PR fixes and properly highlights string quotes according to the no. of escaped quotes and normal quotes. Below screenshot explains the PR in a nutshell:

![image](https://user-images.githubusercontent.com/28479139/111426836-41a2ff00-871b-11eb-92d5-75291b4dcbc7.png)

The whole logic is taken from `v.fmt` module.