### PR TITLE
checker: make optional array element an error

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3103,7 +3103,7 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) table.Type {
 		// println('ex $c.expected_type')
 		// }
 		for i, expr in array_init.exprs {
-			typ := c.expr(expr)
+			typ := c.check_expr_opt_call(expr, c.expr(expr))
 			array_init.expr_types << typ
 			// The first element's type
 			if expecting_interface_array {

--- a/vlib/v/checker/tests/optional_fn_err.out
+++ b/vlib/v/checker/tests/optional_fn_err.out
@@ -1,0 +1,20 @@
+vlib/v/checker/tests/optional_fn_err.vv:11:2: error: foo() returns an option, so it should have either an `or {}` block, or `?` at the end
+    9 | fn main() {
+   10 |     // Calling foo() without ? or an or block, should be an error.
+   11 |     foo()
+      |     ~~~~~
+   12 | 
+   13 |     _ := bar()
+vlib/v/checker/tests/optional_fn_err.vv:13:7: error: bar() returns an option, so it should have either an `or {}` block, or `?` at the end
+   11 |     foo()
+   12 | 
+   13 |     _ := bar()
+      |          ~~~~~
+   14 |     _ := [bar()]
+   15 | }
+vlib/v/checker/tests/optional_fn_err.vv:14:8: error: bar() returns an option, so it should have either an `or {}` block, or `?` at the end
+   12 | 
+   13 |     _ := bar()
+   14 |     _ := [bar()]
+      |           ~~~~~
+   15 | }

--- a/vlib/v/checker/tests/optional_fn_err.vv
+++ b/vlib/v/checker/tests/optional_fn_err.vv
@@ -2,7 +2,14 @@ fn foo() ? {
 	println('foo is called')
 }
 
+fn bar() ?int {
+	return none
+}
+
 fn main() {
 	// Calling foo() without ? or an or block, should be an error.
 	foo()
+
+	_ := bar()
+	_ := [bar()]
 }

--- a/vlib/v/checker/tests/optional_void_called_as_normal.out
+++ b/vlib/v/checker/tests/optional_void_called_as_normal.out
@@ -1,6 +1,0 @@
-vlib/v/checker/tests/optional_void_called_as_normal.vv:7:2: error: foo() returns an option, so it should have either an `or {}` block, or `?` at the end
-    5 | fn main() {
-    6 |     // Calling foo() without ? or an or block, should be an error.
-    7 |     foo()
-      |     ~~~~~
-    8 | }


### PR DESCRIPTION
For now, optional array element can be compiled. And it run like this.
```
╭─ zakuro   ~/src/github.com/zakuro9715/v   master
╰─ > cat main.v
type Data = string | int

fn foo() ?Data {
        return none
}

fn bar() ?Data {
        return 's'
}

fn put(arr []Data) {
        println(arr)
}

fn main() {
        put([foo(), bar()])
}
╭─ zakuro   ~/src/github.com/zakuro9715/v   master
╰─ > v run main.v
[unknown sum type value, unknown sum type value]
╭─ zakuro   ~/src/github.com/zakuro9715/v   master
╰─ >

```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
