### PR TITLE
all: implement array .any and .all

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1319,6 +1319,24 @@ fn (mut c Checker) check_map_and_filter(is_map bool, elem_typ table.Type, call_e
 						arg_expr.pos)
 				}
 			} else if arg_expr.kind == .variable {
+				if arg_expr.obj is ast.Var {
+					expr := arg_expr.obj.expr
+					if expr is ast.AnonFn {
+						// copied from above
+						if expr.decl.params.len > 1 {
+							c.error('function needs exactly 1 argument', expr.decl.pos)
+						} else if is_map && (expr.decl.return_type == table.void_type
+							|| expr.decl.params[0].typ != elem_typ) {
+							c.error('type mismatch, should use `fn(a $elem_sym.name) T {...}`',
+								expr.decl.pos)
+						} else if !is_map && (expr.decl.return_type != table.bool_type
+							|| expr.decl.params[0].typ != elem_typ) {
+							c.error('type mismatch, should use `fn(a $elem_sym.name) bool {...}`',
+								expr.decl.pos)
+						}
+						return
+					}
+				}
 				if !is_map && arg_expr.info.typ != table.bool_type {
 					c.error('type mismatch, should be bool', arg_expr.pos)
 				}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -535,6 +535,14 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 				g.gen_array_wait(node)
 				return
 			}
+			'any' {
+				g.gen_array_any(node)
+				return
+			}
+			'all' {
+				g.gen_array_all(node)
+				return
+			}
 			else {}
 		}
 	}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2111,7 +2111,7 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 	} else {
 		p.name_error = true
 	}
-	is_filter := field_name in ['filter', 'map']
+	is_filter := field_name in ['filter', 'map', 'any', 'all']
 	if is_filter || field_name == 'sort' {
 		p.open_scope()
 	}

--- a/vlib/v/tests/array_methods_test.v
+++ b/vlib/v/tests/array_methods_test.v
@@ -17,4 +17,14 @@ fn test_array_eval_count() {
 
 	mut a2 := Counter{}
 	assert a2.new_arr('filter() failed').filter(it < 3) == [1, 2]
+
+	mut a3 := Counter{}
+	assert a3.new_arr('any() failed').any(it == 2) == true
+	a3 = Counter{}
+	assert a3.new_arr('any() failed').any(it < 0) == false
+
+	mut a4 := Counter{}
+	assert a4.new_arr('all() failed').all(it > 0) == true
+	a4 = Counter{}
+	assert a4.new_arr('all() failed').all(it == 2) == false
 }


### PR DESCRIPTION
This PR implements the `any` and `all` "compiler magic" methods on arrays.

```v
[1 2 3].any(it == 2) == true
[1 2 3].any(it == 0) == false

[1 2 3].all(it > 0) == true
[1 2 3].all(it <= 2) == false
```

This PR also prevents using a non-bool identifier for `filter` `any` and `all`:
```v
>>> [1 2 3].filter(it)
error: type mismatch, should be bool
    5 | import math
    6 |
    7 | println([1 2 3].filter(it))
      |                        ~~
```