### PR TITLE
checker: fix multiple_assign with last call_expr (fix #9330)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2626,21 +2626,25 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 	right_first := assign_stmt.right[0]
 	mut right_len := assign_stmt.right.len
 	mut right_type0 := table.void_type
-	for right in assign_stmt.right {
+	for i, right in assign_stmt.right {
 		if right is ast.CallExpr || right is ast.IfExpr || right is ast.LockExpr
 			|| right is ast.MatchExpr {
 			right_type0 = c.expr(right)
-			assign_stmt.right_types = [
-				c.check_expr_opt_call(right, right_type0),
-			]
+			if i == 0 {
+				assign_stmt.right_types = [
+					c.check_expr_opt_call(right, right_type0),
+				]
+			}
 			right_type_sym0 := c.table.get_type_symbol(right_type0)
 			if right_type_sym0.kind == .multi_return {
 				if assign_stmt.right.len > 1 {
 					c.error('cannot use multi-value $right_type_sym0.name in signle-value context',
 						right.position())
 				}
-				assign_stmt.right_types = right_type_sym0.mr_info().types
-				right_len = assign_stmt.right_types.len
+				if i == 0 {
+					assign_stmt.right_types = right_type_sym0.mr_info().types
+					right_len = assign_stmt.right_types.len
+				}
 			} else if right_type0 == table.void_type {
 				right_len = 0
 			}

--- a/vlib/v/tests/multiple_assign_test.v
+++ b/vlib/v/tests/multiple_assign_test.v
@@ -64,3 +64,10 @@ fn test_multiple_assign_complex_expr() {
 	assert b == -66
 	assert c == 11
 }
+
+fn test_multiple_assign_last_call_expr() {
+	arr := "string.1".split('.')
+	_, num := arr[0], arr[1].int()
+	println("$num + $num = ${num * 2}")
+	assert num == 1
+}


### PR DESCRIPTION
This PR fix multiple_assign with last call_expr (fix #9330).

- Fix multiple_assign with last call_expr.
- Add test.

```vlang
module main

fn main() {
	arr := "string.1".split('.')
	_, num := arr[0], arr[1].int()
	println("$num + $num = ${num * 2}")
}

D:\Test\v\tt1>v run .
1 + 1 = 2
```