### PR TITLE
vdoc: improve error message for non-existing symbol in module

### DIFF
--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -330,7 +330,8 @@ fn (mut vd VDoc) generate_docs_from_file() {
 		}
 		outputs := vd.render(out)
 		if outputs.len == 0 {
-			println('No documentation for $dirs')
+			eprintln('vdoc: No documentation found for ${dirs[0]}')
+			exit(1)
 		} else {
 			first := outputs.keys()[0]
 			println(outputs[first])

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -231,10 +231,6 @@ pub fn (mut d Doc) stmt(stmt ast.Stmt, filename string) ?DocNode {
 			return error('invalid stmt type to document')
 		}
 	}
-	included := node.name in d.filter_symbol_names || node.parent_name in d.filter_symbol_names
-	if d.filter_symbol_names.len != 0 && !included {
-		return error('not included in the list of symbol names')
-	}
 	return node
 }
 
@@ -425,6 +421,13 @@ pub fn (mut d Doc) file_asts(file_asts []ast.File) ? {
 				d.contents[name].children << node.children
 				d.contents[name].children.sort_by_name()
 				d.contents[name].children.sort_by_kind()
+			}
+		}
+	}
+	if d.filter_symbol_names.len != 0 && d.contents.len != 0 {
+		for filter_name in d.filter_symbol_names {
+			if filter_name !in d.contents {
+				return error('vdoc: `$filter_name` symbol in module `$d.orig_mod_name` not found')
 			}
 		}
 	}


### PR DESCRIPTION
This improves the error message when a user checks the documentation of a specific symbol of a module. (with additional fix tipped by @Delta456 )