### PR TITLE
fix warning write_str -> write_string

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -333,7 +333,7 @@ pub fn home_dir() string {
 // write_file writes `text` data to a file in `path`.
 pub fn write_file(path string, text string) ? {
 	mut f := create(path) ?
-	f.write_str(text) ?
+	f.write_string(text) ?
 	f.close()
 }
 


### PR DESCRIPTION
Recent change marked write_str deprecated.  Caused a warning here.