### PR TITLE
all: deprecate write_bytes and add write_ptr

### DIFF
--- a/examples/wkhtmltopdf.v
+++ b/examples/wkhtmltopdf.v
@@ -78,7 +78,7 @@ fn main() {
 			println('ERR: $err')
 			return
 		}
-		wrote := unsafe { file.write_bytes(data, size) }
+		wrote := unsafe { file.write_ptr(data, size) }
 		println('write_bytes: $wrote [./google.pdf]')
 		file.flush()
 		file.close()

--- a/vlib/net/http/backend_nix.c.v
+++ b/vlib/net/http/backend_nix.c.v
@@ -55,7 +55,7 @@ fn (req &Request) ssl_do(port int, method Method, host_name string, path string)
 			eprintln(unsafe { tos(bp, len) })
 			eprintln('-'.repeat(20))
 		}
-		unsafe { content.write_bytes(bp, len) }
+		unsafe { content.write_ptr(bp, len) }
 	}
 	if web != 0 {
 		C.BIO_free_all(web)

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -218,8 +218,8 @@ pub fn (mut f File) write_to(pos int, buf []byte) ?int {
 // write_bytes writes `size` bytes to the file, starting from the address in `data`.
 // NB: write_bytes is unsafe and should be used carefully, since if you pass invalid
 // pointers to it, it will cause your programs to segfault.
-[unsafe]
 [deprecated: 'use File.write_ptr()']
+[unsafe]
 pub fn (mut f File) write_bytes(data voidptr, size int) int {
 	return unsafe { f.write_ptr(data, size) }
 }
@@ -228,8 +228,8 @@ pub fn (mut f File) write_bytes(data voidptr, size int) int {
 // at byte offset `pos`, counting from the start of the file (pos 0).
 // NB: write_bytes_at is unsafe and should be used carefully, since if you pass invalid
 // pointers to it, it will cause your programs to segfault.
-[unsafe]
 [deprecated: 'use File.write_ptr_at() instead']
+[unsafe]
 pub fn (mut f File) write_bytes_at(data voidptr, size int, pos int) int {
 	return unsafe { f.write_ptr_at(data, size, pos) }
 }
@@ -253,7 +253,6 @@ pub fn (mut f File) write_ptr_at(data voidptr, size int, pos int) int {
 	C.fseek(f.cfile, 0, C.SEEK_END)
 	return res
 }
-
 
 // **************************** Read ops  ***************************
 // read_bytes reads bytes from the beginning of the file.

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -219,8 +219,9 @@ pub fn (mut f File) write_to(pos int, buf []byte) ?int {
 // NB: write_bytes is unsafe and should be used carefully, since if you pass invalid
 // pointers to it, it will cause your programs to segfault.
 [unsafe]
+[deprecated: 'use File.write_ptr()']
 pub fn (mut f File) write_bytes(data voidptr, size int) int {
-	return int(C.fwrite(data, 1, size, f.cfile))
+	return unsafe { f.write_ptr(data, size) }
 }
 
 // write_bytes_at writes `size` bytes to the file, starting from the address in `data`,
@@ -228,12 +229,31 @@ pub fn (mut f File) write_bytes(data voidptr, size int) int {
 // NB: write_bytes_at is unsafe and should be used carefully, since if you pass invalid
 // pointers to it, it will cause your programs to segfault.
 [unsafe]
+[deprecated: 'use File.write_ptr_at() instead']
 pub fn (mut f File) write_bytes_at(data voidptr, size int, pos int) int {
+	return unsafe { f.write_ptr_at(data, size, pos) }
+}
+
+// write_ptr writes `size` bytes to the file, starting from the address in `data`.
+// NB: write_ptr is unsafe and should be used carefully, since if you pass invalid
+// pointers to it, it will cause your programs to segfault.
+[unsafe]
+pub fn (mut f File) write_ptr(data voidptr, size int) int {
+	return int(C.fwrite(data, 1, size, f.cfile))
+}
+
+// write_ptr_at writes `size` bytes to the file, starting from the address in `data`,
+// at byte offset `pos`, counting from the start of the file (pos 0).
+// NB: write_ptr_at is unsafe and should be used carefully, since if you pass invalid
+// pointers to it, it will cause your programs to segfault.
+[unsafe]
+pub fn (mut f File) write_ptr_at(data voidptr, size int, pos int) int {
 	C.fseek(f.cfile, pos, C.SEEK_SET)
 	res := int(C.fwrite(data, 1, size, f.cfile))
 	C.fseek(f.cfile, 0, C.SEEK_END)
 	return res
 }
+
 
 // **************************** Read ops  ***************************
 // read_bytes reads bytes from the beginning of the file.

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -340,7 +340,7 @@ pub fn write_file(path string, text string) ? {
 // write_file_array writes the data in `buffer` to a file in `path`.
 pub fn write_file_array(path string, buffer array) ? {
 	mut f := create(path) ?
-	unsafe { f.write_bytes_at(buffer.data, (buffer.len * buffer.element_size), 0) }
+	unsafe { f.write_ptr_at(buffer.data, (buffer.len * buffer.element_size), 0) }
 	f.close()
 }
 

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -174,7 +174,7 @@ pub fn execute(cmd string) Result {
 	unsafe {
 		bufbp := &buf[0]
 		for C.fgets(charptr(bufbp), 4096, f) != 0 {
-			res.write_bytes(bufbp, vstrlen(bufbp))
+			res.write_ptr(bufbp, vstrlen(bufbp))
 		}
 	}
 	soutput := res.str()
@@ -215,11 +215,11 @@ pub fn (mut c Command) read_line() string {
 			len := vstrlen(bufbp)
 			for i in 0 .. len {
 				if bufbp[i] == `\n` {
-					res.write_bytes(bufbp, i)
+					res.write_ptr(bufbp, i)
 					return res.str()
 				}
 			}
-			res.write_bytes(bufbp, len)
+			res.write_ptr(bufbp, len)
 		}
 	}
 	c.eof = true

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -55,7 +55,7 @@ fn test_open_file_binary() {
 	}
 	mut file := os.open_file(filename, 'wb+', 0o666) or { panic(err) }
 	bytes := hello.bytes()
-	unsafe { file.write_bytes(bytes.data, bytes.len) }
+	unsafe { file.write_ptr(bytes.data, bytes.len) }
 	file.close()
 	assert hello.len == os.file_size(filename)
 	read_hello := os.read_bytes(filename) or { panic('error reading file $filename') }
@@ -144,7 +144,7 @@ fn test_write_and_read_bytes() {
 	}
 	// We use the standard write_bytes function to write the payload and
 	// compare the length of the array with the file size (have to match).
-	unsafe { file_write.write_bytes(payload.data, 5) }
+	unsafe { file_write.write_ptr(payload.data, 5) }
 	file_write.close()
 	assert payload.len == os.file_size(file_name)
 	mut file_read := os.open(os.real_path(file_name)) or {

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -288,7 +288,7 @@ pub fn execute(cmd string) Result {
 		unsafe {
 			result = C.ReadFile(child_stdout_read, &buf[0], 1000, voidptr(&bytes_read),
 				0)
-			read_data.write_bytes(&buf[0], int(bytes_read))
+			read_data.write_ptr(&buf[0], int(bytes_read))
 		}
 		if result == false || int(bytes_read) == 0 {
 			break

--- a/vlib/strings/builder.v
+++ b/vlib/strings/builder.v
@@ -26,9 +26,16 @@ pub fn new_builder(initial_size int) Builder {
 
 // write_bytes appends `bytes` to the accumulated buffer
 [unsafe]
-pub fn (mut b Builder) write_bytes(bytes byteptr, howmany int) {
-	unsafe { b.buf.push_many(bytes, howmany) }
-	b.len += howmany
+[deprecated: 'use Builder.write_ptr() instead']
+pub fn (mut b Builder) write_bytes(bytes byteptr, len int) {
+	unsafe { b.write_ptr(bytes, len) }
+}
+
+// write_ptr writes `len` bytes provided byteptr to the accumulated buffer
+[unsafe]
+pub fn (mut b Builder) write_ptr(ptr byteptr, len int) {
+	unsafe { b.buf.push_many(ptr, len) }
+	b.len += len
 }
 
 // write_b appends a single `data` byte to the accumulated buffer

--- a/vlib/strings/builder.v
+++ b/vlib/strings/builder.v
@@ -25,8 +25,8 @@ pub fn new_builder(initial_size int) Builder {
 }
 
 // write_bytes appends `bytes` to the accumulated buffer
-[unsafe]
 [deprecated: 'use Builder.write_ptr() instead']
+[unsafe]
 pub fn (mut b Builder) write_bytes(bytes byteptr, len int) {
 	unsafe { b.write_ptr(bytes, len) }
 }

--- a/vlib/v/gen/x64/elf.v
+++ b/vlib/v/gen/x64/elf.v
@@ -101,7 +101,7 @@ pub fn (mut g Gen) generate_elf_footer() {
 	// Create the binary
 	mut f := os.create(g.out_name) or { panic(err) }
 	os.chmod(g.out_name, 0o775) // make it an executable
-	unsafe { f.write_bytes(g.buf.data, g.buf.len) }
+	unsafe { f.write_ptr(g.buf.data, g.buf.len) }
 	f.close()
 	println('\nx64 elf binary has been successfully generated')
 }

--- a/vlib/v/gen/x64/macho.v
+++ b/vlib/v/gen/x64/macho.v
@@ -116,7 +116,7 @@ pub fn (mut g Gen) generate_macho_footer() {
 	// Create the binary
 	mut f := os.create(g.out_name) or { panic(err) }
 	os.chmod(g.out_name, 0o775) // make it an executable
-	unsafe { f.write_bytes(g.buf.data, g.buf.len) }
+	unsafe { f.write_ptr(g.buf.data, g.buf.len) }
 	f.close()
 	// println('\narm64 mach-o binary has been successfully generated')
 }


### PR DESCRIPTION
for now, we have two similar methods, `write_bytes` and `write_ptr`. they should have same name. And write_ptr is better imho because `write_bytes` sounds write `[]byte`
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
