### PR TITLE
cgen: fix return if_guard expr (fix #9366)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4353,6 +4353,9 @@ fn (mut g Gen) need_tmp_var_in_if(node ast.IfExpr) bool {
 			return true
 		}
 		for branch in node.branches {
+			if branch.cond is ast.IfGuardExpr {
+				return true
+			}
 			if branch.stmts.len == 1 {
 				if branch.stmts[0] is ast.ExprStmt {
 					stmt := branch.stmts[0] as ast.ExprStmt

--- a/vlib/v/tests/if_guard_test.v
+++ b/vlib/v/tests/if_guard_test.v
@@ -59,3 +59,22 @@ fn test_chan_pop() {
 	assert res == [6.75, -3.25, -37.5]
 }
 
+struct Thing {
+	name string
+}
+
+fn test_return_if_guard() {
+	ret := option_check('zoo')
+	println(ret)
+	assert ret == 'zs'
+}
+
+fn option_check(name string) string {
+	return if thing := find_thing_by_name(name) { thing.name } else { 'safename' }
+}
+
+fn find_thing_by_name(name string) ?&Thing {
+	return &Thing{
+		name: 'zs'
+	}
+}


### PR DESCRIPTION
This PR fix return if_guard expr (fix #9366).

- Fix return if_guard expr.
- Add test.

```vlang
struct Thing {
	name string
}

fn main() {
	ret := option_check('zoo')
	println(ret)
}

fn option_check(name string) string {
	return if thing := find_thing_by_name(name) { thing.name } else { 'safename' }
}

fn find_thing_by_name(name string) ?&Thing {
	return &Thing{
		name: 'zs'
	}
}

D:\Test\v\tt1>v run .
zs
```