### PR TITLE
generics: fix generics in big_struct method (fix #9373)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -443,6 +443,9 @@ pub fn (mut c Checker) infer_fn_types(f table.Fn, mut call_expr ast.CallExpr) {
 			param_type_sym := c.table.get_type_symbol(param.typ)
 			if param.typ.has_flag(.generic) && param_type_sym.name == gt_name {
 				typ = c.table.mktyp(arg.typ)
+				if arg.expr.is_auto_deref_var() {
+					typ = typ.deref()
+				}
 				break
 			}
 			arg_sym := c.table.get_type_symbol(arg.typ)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1019,7 +1019,7 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 				}
 			} else {
 				if node.generic_types.len > 0 && arg.expr.is_auto_deref_var() && !arg.is_mut
-					&& !arg.typ.is_ptr() {
+					&& !expected_types[i].is_ptr() {
 					g.write('*')
 				}
 				g.ref_or_deref_arg(arg, expected_types[i], node.language)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1019,7 +1019,7 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 				}
 			} else {
 				if node.generic_types.len > 0 && arg.expr.is_auto_deref_var() && !arg.is_mut
-					&& (!node.is_method || (node.is_method && i != 0)) {
+					&& !arg.typ.is_ptr() {
 					g.write('*')
 				}
 				g.ref_or_deref_arg(arg, expected_types[i], node.language)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1018,7 +1018,8 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 					g.write('/*af arg*/' + name)
 				}
 			} else {
-				if node.generic_types.len > 0 && arg.expr.is_auto_deref_var() && !arg.is_mut {
+				if node.generic_types.len > 0 && arg.expr.is_auto_deref_var() && !arg.is_mut
+					&& (!node.is_method || (node.is_method && i != 0)) {
 					g.write('*')
 				}
 				g.ref_or_deref_arg(arg, expected_types[i], node.language)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1018,6 +1018,9 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 					g.write('/*af arg*/' + name)
 				}
 			} else {
+				if node.generic_types.len > 0 && arg.expr.is_auto_deref_var() && !arg.is_mut {
+					g.write('*')
+				}
 				g.ref_or_deref_arg(arg, expected_types[i], node.language)
 			}
 		} else {

--- a/vlib/v/tests/generics_in_big_struct_method_test.v
+++ b/vlib/v/tests/generics_in_big_struct_method_test.v
@@ -1,0 +1,27 @@
+struct Product {
+pub mut:
+	id    int    = 2
+	sku   string = 'ABCD'
+	ean13 string = 'EFGH'
+
+	collections    string
+	ptype          string
+	featured_image string
+	featured_media string
+	handle         string
+	variant        int
+}
+
+pub fn (p Product) save() string {
+	return do_something(p)
+}
+
+fn do_something<T>(p T) string {
+	return 'whatever'
+}
+
+fn test_generics_in_big_struct_method() {
+	mut p := Product{}
+	println(p.save())
+	assert p.save() == 'whatever'
+}


### PR DESCRIPTION
This PR fix generics in big_struct method (fix #9373).

- Fix generics in big_struct method.
- Add test.

```vlang
module main

struct Product {
pub mut:
	id    int    = 2
	sku   string = 'ABCD'
	ean13 string = 'EFGH'

	collections    string
	ptype          string
	featured_image string
	featured_media string
	handle         string
	variant        int
}

pub fn (p Product) save() string {
	return do_something(p)
}

fn do_something<T>(p T) string {
	return 'whatever'
}

fn main() {
	mut p := Product{}
	println('------RESULT------')
	println(p.save())
}

D:\Test\v\tt1>v run .
------RESULT------
whatever
```