### PR TITLE
builder: allow for running symlinked .vsh files

### DIFF
--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -122,7 +122,7 @@ fn (mut v Builder) cleanup_run_executable_after_exit(exefile string) {
 		v.pref.vrun_elog('keeping executable: $exefile , because -keepc was passed')
 		return
 	}
-	if os.is_file(exefile) {
+	if os.is_executable(exefile) {
 		v.pref.vrun_elog('remove run executable: $exefile')
 		os.rm(exefile) or { panic(err) }
 	}
@@ -273,8 +273,10 @@ pub fn (v &Builder) get_user_files() []string {
 		exit(1)
 	}
 	is_real_file := does_exist && !os.is_dir(dir)
-	if is_real_file && (dir.ends_with('.v') || dir.ends_with('.vsh') || dir.ends_with('.vv')) {
-		single_v_file := dir
+	resolved_link := if is_real_file && os.is_link(dir) { os.real_path(dir) } else { dir }
+	if is_real_file && (dir.ends_with('.v') || resolved_link.ends_with('.vsh')
+		|| dir.ends_with('.vv')) {
+		single_v_file := if resolved_link.ends_with('.vsh') { resolved_link } else { dir }
 		// Just compile one file and get parent dir
 		user_files << single_v_file
 		if v.pref.is_verbose {


### PR DESCRIPTION
This fixes #9313 by resolving symlinks specifically for `.vsh` files.

I initially tried just resolving all files - but that broke a lot of tests relying on relative paths recorded in the `.out` files.

This fix doesn't take care of another issue that arose while fixing #9313 .
For some reason V errors when compiling `.vsh` files without a main even if the symlinked file is resolved to a file ending in `.vsh`.

Thus the example from #9313 needs to be [modified](https://github.com/vlang/v/issues/9313#issuecomment-803301626) for this fix to work.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
