### PR TITLE
builtin: allow libgc to be used on windows as well

### DIFF
--- a/vlib/builtin/builtin_d_gcboehm.v
+++ b/vlib/builtin/builtin_d_gcboehm.v
@@ -2,6 +2,11 @@ module builtin
 
 #define GC_THREADS 1
 
+$if windows {
+	#flag -I@VROOT/thirdparty/libgc/include
+	#flag -L@VROOT/thirdparty/libgc
+}
+
 #include <gc.h>
 
 #flag -lgc


### PR DESCRIPTION
requires https://github.com/spaceface777/libgc-bin to be cloned into `thirdparty/libgc/`

the binary is x64-specific for now; we can compile it to other architectures as well, if that is also needed.

![](https://media.discordapp.net/attachments/592320321995014154/822910381944733746/unknown.png)


<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
