### PR TITLE
cgen: auto eq method for sumtype

### DIFF
--- a/vlib/v/checker/tests/eq_ne_op_wrong_type_err.out
+++ b/vlib/v/checker/tests/eq_ne_op_wrong_type_err.out
@@ -1,84 +1,139 @@
-vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:10:10: error: infix expr: cannot use `int literal` (right expression) as `Aaa`
-    8 | 
-    9 | fn main() {
-   10 |     println(Aaa{} == 10)
-      |             ~~~~~~~~~~~
-   11 |     println(10 == Aaa{})
-   12 |     println(Aaa{} != 10)
-vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:11:10: error: infix expr: cannot use `Aaa` (right expression) as `int literal`
-    9 | fn main() {
-   10 |     println(Aaa{} == 10)
-   11 |     println(10 == Aaa{})
-      |             ~~~~~~~~~~~
-   12 |     println(Aaa{} != 10)
-   13 |     println(10 != Aaa{})
 vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:12:10: error: infix expr: cannot use `int literal` (right expression) as `Aaa`
-   10 |     println(Aaa{} == 10)
-   11 |     println(10 == Aaa{})
-   12 |     println(Aaa{} != 10)
+   10 | 
+   11 | fn main() {
+   12 |     println(Aaa{} == 10)
       |             ~~~~~~~~~~~
-   13 |     println(10 != Aaa{})
-   14 |
+   13 |     println(10 == Aaa{})
+   14 |     println(Aaa{} != 10)
 vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:13:10: error: infix expr: cannot use `Aaa` (right expression) as `int literal`
-   11 |     println(10 == Aaa{})
-   12 |     println(Aaa{} != 10)
-   13 |     println(10 != Aaa{})
+   11 | fn main() {
+   12 |     println(Aaa{} == 10)
+   13 |     println(10 == Aaa{})
       |             ~~~~~~~~~~~
-   14 | 
-   15 |     println(Aaa{0} == AAaa{0})
-vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:15:10: error: possible type mismatch of compared values of `==` operation
-   13 |     println(10 != Aaa{})
-   14 | 
-   15 |     println(Aaa{0} == AAaa{0})
+   14 |     println(Aaa{} != 10)
+   15 |     println(10 != Aaa{})
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:14:10: error: infix expr: cannot use `int literal` (right expression) as `Aaa`
+   12 |     println(Aaa{} == 10)
+   13 |     println(10 == Aaa{})
+   14 |     println(Aaa{} != 10)
+      |             ~~~~~~~~~~~
+   15 |     println(10 != Aaa{})
+   16 |
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:15:10: error: infix expr: cannot use `Aaa` (right expression) as `int literal`
+   13 |     println(10 == Aaa{})
+   14 |     println(Aaa{} != 10)
+   15 |     println(10 != Aaa{})
+      |             ~~~~~~~~~~~
+   16 | 
+   17 |     println(Aaa{0} == AAaa{0})
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:17:10: error: possible type mismatch of compared values of `==` operation
+   15 |     println(10 != Aaa{})
+   16 | 
+   17 |     println(Aaa{0} == AAaa{0})
       |             ~~~~~~~~~~~~~~~~~
-   16 |     println(AAaa{0} == Aaa{0})
-   17 |     println(AAaa{1} != Aaa{1})
-vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:16:10: error: possible type mismatch of compared values of `==` operation
-   14 | 
-   15 |     println(Aaa{0} == AAaa{0})
-   16 |     println(AAaa{0} == Aaa{0})
+   18 |     println(AAaa{0} == Aaa{0})
+   19 |     println(AAaa{1} != Aaa{1})
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:18:10: error: possible type mismatch of compared values of `==` operation
+   16 | 
+   17 |     println(Aaa{0} == AAaa{0})
+   18 |     println(AAaa{0} == Aaa{0})
       |             ~~~~~~~~~~~~~~~~~
-   17 |     println(AAaa{1} != Aaa{1})
-   18 |     println(Aaa{1} != AAaa{1})
-vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:17:10: error: possible type mismatch of compared values of `!=` operation
-   15 |     println(Aaa{0} == AAaa{0})
-   16 |     println(AAaa{0} == Aaa{0})
-   17 |     println(AAaa{1} != Aaa{1})
+   19 |     println(AAaa{1} != Aaa{1})
+   20 |     println(Aaa{1} != AAaa{1})
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:19:10: error: possible type mismatch of compared values of `!=` operation
+   17 |     println(Aaa{0} == AAaa{0})
+   18 |     println(AAaa{0} == Aaa{0})
+   19 |     println(AAaa{1} != Aaa{1})
       |             ~~~~~~~~~~~~~~~~~
-   18 |     println(Aaa{1} != AAaa{1})
-   19 |
-vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:18:10: error: possible type mismatch of compared values of `!=` operation
-   16 |     println(AAaa{0} == Aaa{0})
-   17 |     println(AAaa{1} != Aaa{1})
-   18 |     println(Aaa{1} != AAaa{1})
+   20 |     println(Aaa{1} != AAaa{1})
+   21 |
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:20:10: error: possible type mismatch of compared values of `!=` operation
+   18 |     println(AAaa{0} == Aaa{0})
+   19 |     println(AAaa{1} != Aaa{1})
+   20 |     println(Aaa{1} != AAaa{1})
       |             ~~~~~~~~~~~~~~~~~
-   19 | 
-   20 |     arr := Arr([0])
-vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:21:10: error: possible type mismatch of compared values of `==` operation
-   19 | 
-   20 |     arr := Arr([0])
-   21 |     println(arr == [0])
+   21 | 
+   22 |     arr := Arr([0])
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:23:10: error: possible type mismatch of compared values of `==` operation
+   21 | 
+   22 |     arr := Arr([0])
+   23 |     println(arr == [0])
       |             ~~~~~~~~~~
-   22 |     println([1] == arr)
-   23 |     println(arr != [0])
-vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:22:10: error: possible type mismatch of compared values of `==` operation
-   20 |     arr := Arr([0])
-   21 |     println(arr == [0])
-   22 |     println([1] == arr)
+   24 |     println([1] == arr)
+   25 |     println(arr != [0])
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:24:10: error: possible type mismatch of compared values of `==` operation
+   22 |     arr := Arr([0])
+   23 |     println(arr == [0])
+   24 |     println([1] == arr)
       |             ~~~~~~~~~~
-   23 |     println(arr != [0])
-   24 |     println([1] != arr)
-vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:23:10: error: possible type mismatch of compared values of `!=` operation
-   21 |     println(arr == [0])
-   22 |     println([1] == arr)
-   23 |     println(arr != [0])
+   25 |     println(arr != [0])
+   26 |     println([1] != arr)
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:25:10: error: possible type mismatch of compared values of `!=` operation
+   23 |     println(arr == [0])
+   24 |     println([1] == arr)
+   25 |     println(arr != [0])
       |             ~~~~~~~~~~
-   24 |     println([1] != arr)
-   25 | }
-vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:24:10: error: possible type mismatch of compared values of `!=` operation
-   22 |     println([1] == arr)
-   23 |     println(arr != [0])
-   24 |     println([1] != arr)
+   26 |     println([1] != arr)
+   27 |
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:26:10: error: possible type mismatch of compared values of `!=` operation
+   24 |     println([1] == arr)
+   25 |     println(arr != [0])
+   26 |     println([1] != arr)
       |             ~~~~~~~~~~
-   25 | }
-
+   27 | 
+   28 |     arr_aaa := ArrAaa(arr)
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:29:10: error: possible type mismatch of compared values of `==` operation
+   27 | 
+   28 |     arr_aaa := ArrAaa(arr)
+   29 |     println(arr_aaa == arr)
+      |             ~~~~~~~~~~~~~~
+   30 |     println(arr == arr_aaa)
+   31 |     println(arr_aaa != arr)
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:30:10: error: possible type mismatch of compared values of `==` operation
+   28 |     arr_aaa := ArrAaa(arr)
+   29 |     println(arr_aaa == arr)
+   30 |     println(arr == arr_aaa)
+      |             ~~~~~~~~~~~~~~
+   31 |     println(arr_aaa != arr)
+   32 |     println(arr != arr_aaa)
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:31:10: error: possible type mismatch of compared values of `!=` operation
+   29 |     println(arr_aaa == arr)
+   30 |     println(arr == arr_aaa)
+   31 |     println(arr_aaa != arr)
+      |             ~~~~~~~~~~~~~~
+   32 |     println(arr != arr_aaa)
+   33 |
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:32:10: error: possible type mismatch of compared values of `!=` operation
+   30 |     println(arr == arr_aaa)
+   31 |     println(arr_aaa != arr)
+   32 |     println(arr != arr_aaa)
+      |             ~~~~~~~~~~~~~~
+   33 | 
+   34 |     println(arr_aaa == [0])
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:34:10: error: infix expr: cannot use `[]int` (right expression) as `ArrAaa`
+   32 |     println(arr != arr_aaa)
+   33 | 
+   34 |     println(arr_aaa == [0])
+      |             ~~~~~~~~~~~~~~
+   35 |     println([1] == arr_aaa)
+   36 |     println(arr_aaa != [0])
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:35:10: error: infix expr: cannot use `ArrAaa` (right expression) as `[]int`
+   33 | 
+   34 |     println(arr_aaa == [0])
+   35 |     println([1] == arr_aaa)
+      |             ~~~~~~~~~~~~~~
+   36 |     println(arr_aaa != [0])
+   37 |     println([1] != arr_aaa)
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:36:10: error: infix expr: cannot use `[]int` (right expression) as `ArrAaa`
+   34 |     println(arr_aaa == [0])
+   35 |     println([1] == arr_aaa)
+   36 |     println(arr_aaa != [0])
+      |             ~~~~~~~~~~~~~~
+   37 |     println([1] != arr_aaa)
+   38 | }
+vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv:37:10: error: infix expr: cannot use `ArrAaa` (right expression) as `[]int`
+   35 |     println([1] == arr_aaa)
+   36 |     println(arr_aaa != [0])
+   37 |     println([1] != arr_aaa)
+      |             ~~~~~~~~~~~~~~
+   38 | }

--- a/vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv
+++ b/vlib/v/checker/tests/eq_ne_op_wrong_type_err.vv
@@ -6,6 +6,8 @@ type AAaa = Aaa
 
 type Arr = []int
 
+type ArrAaa = Aaa | Arr
+
 fn main() {
 	println(Aaa{} == 10)
 	println(10 == Aaa{})
@@ -22,4 +24,15 @@ fn main() {
 	println([1] == arr)
 	println(arr != [0])
 	println([1] != arr)
+
+	arr_aaa := ArrAaa(arr)
+	println(arr_aaa == arr)
+	println(arr == arr_aaa)
+	println(arr_aaa != arr)
+	println(arr != arr_aaa)
+
+	println(arr_aaa == [0])
+	println([1] == arr_aaa)
+	println(arr_aaa != [0])
+	println([1] != arr_aaa)
 }

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -32,95 +32,96 @@ struct Gen {
 	pref         &pref.Preferences
 	module_built string
 mut:
-	table                 &table.Table
-	out                   strings.Builder
-	cheaders              strings.Builder
-	includes              strings.Builder // all C #includes required by V modules
-	typedefs              strings.Builder
-	typedefs2             strings.Builder
-	type_definitions      strings.Builder // typedefs, defines etc (everything that goes to the top of the file)
-	definitions           strings.Builder // typedefs, defines etc (everything that goes to the top of the file)
-	inits                 map[string]strings.Builder // contents of `void _vinit/2{}`
-	cleanups              map[string]strings.Builder // contents of `void _vcleanup(){}`
-	gowrappers            strings.Builder // all go callsite wrappers
-	stringliterals        strings.Builder // all string literals (they depend on tos3() beeing defined
-	auto_str_funcs        strings.Builder // function bodies of all auto generated _str funcs
-	comptime_defines      strings.Builder // custom defines, given by -d/-define flags on the CLI
-	pcs_declarations      strings.Builder // -prof profile counter declarations for each function
-	hotcode_definitions   strings.Builder // -live declarations & functions
-	embedded_data         strings.Builder // data to embed in the executable/binary
-	shared_types          strings.Builder // shared/lock types
-	shared_functions      strings.Builder // shared constructors
-	channel_definitions   strings.Builder // channel related code
-	options_typedefs      strings.Builder // Option typedefs
-	options               strings.Builder // `Option_xxxx` types
-	json_forward_decls    strings.Builder // json type forward decls
-	enum_typedefs         strings.Builder // enum types
-	sql_buf               strings.Builder // for writing exprs to args via `sqlite3_bind_int()` etc
-	file                  ast.File
-	fn_decl               &ast.FnDecl // pointer to the FnDecl we are currently inside otherwise 0
-	last_fn_c_name        string
-	tmp_count             int      // counter for unique tmp vars (_tmp1, tmp2 etc)
-	tmp_count2            int      // a separate tmp var counter for autofree fn calls
-	is_c_call             bool     // e.g. `C.printf("v")`
-	is_assign_lhs         bool     // inside left part of assign expr (for array_set(), etc)
-	discard_or_result     bool     // do not safe last ExprStmt of `or` block in tmp variable to defer ongoing expr usage
-	is_void_expr_stmt     bool     // ExprStmt whos result is discarded
-	is_arraymap_set       bool     // map or array set value state
-	is_amp                bool     // for `&Foo{}` to merge PrefixExpr `&` and StructInit `Foo{}`; also for `&byte(0)` etc
-	is_sql                bool     // Inside `sql db{}` statement, generating sql instead of C (e.g. `and` instead of `&&` etc)
-	is_shared             bool     // for initialization of hidden mutex in `[rw]shared` literals
-	is_vlines_enabled     bool     // is it safe to generate #line directives when -g is passed
-	arraymap_set_pos      int      // map or array set value position
-	vlines_path           string   // set to the proper path for generating #line directives
-	optionals             []string // to avoid duplicates TODO perf, use map
-	chan_pop_optionals    []string // types for `x := <-ch or {...}`
-	chan_push_optionals   []string // types for `ch <- x or {...}`
-	shareds               []int    // types with hidden mutex for which decl has been emitted
-	inside_ternary        int      // ?: comma separated statements on a single line
-	inside_map_postfix    bool     // inside map++/-- postfix expr
-	inside_map_infix      bool     // inside map<</+=/-= infix expr
-	inside_map_index      bool
-	inside_opt_data       bool
-	inside_if_optional    bool
-	ternary_names         map[string]string
-	ternary_level_names   map[string][]string
-	stmt_path_pos         []int // positions of each statement start, for inserting C statements before the current statement
-	skip_stmt_pos         bool  // for handling if expressions + autofree (since both prepend C statements)
-	right_is_opt          bool
-	is_autofree           bool // false, inside the bodies of fns marked with [manualfree], otherwise === g.pref.autofree
-	indent                int
-	empty_line            bool
-	is_test               bool
-	assign_op             token.Kind // *=, =, etc (for array_set)
-	defer_stmts           []ast.DeferStmt
-	defer_ifdef           string
-	defer_profile_code    string
-	str_types             []string     // types that need automatic str() generation
-	threaded_fns          []string     // for generating unique wrapper types and fns for `go xxx()`
-	waiter_fns            []string     // functions that wait for `go xxx()` to finish
-	array_fn_definitions  []string     // array equality functions that have been defined
-	map_fn_definitions    []string     // map equality functions that have been defined
-	struct_fn_definitions []string     // struct equality functions that have been defined
-	alias_fn_definitions  []string     // alias equality functions that have been defined
-	auto_fn_definitions   []string     // auto generated functions defination list
-	anon_fn_definitions   []string     // anon generated functions defination list
-	sumtype_definitions   map[int]bool // `_TypeA_to_sumtype_TypeB()` fns that have been generated
-	is_json_fn            bool     // inside json.encode()
-	json_types            []string // to avoid json gen duplicates
-	pcs                   []ProfileCounterMeta // -prof profile counter fn_names => fn counter name
-	is_builtin_mod        bool
-	hotcode_fn_names      []string
-	embedded_files        []ast.EmbeddedFile
-	cur_fn                ast.FnDecl
-	cur_generic_types     []table.Type // `int`, `string`, etc in `foo<T>()`
-	sql_i                 int
-	sql_stmt_name         string
-	sql_side              SqlExprSide // left or right, to distinguish idents in `name == name`
-	inside_vweb_tmpl      bool
-	inside_return         bool
-	inside_or_block       bool
-	strs_to_free0         []string // strings.Builder
+	table                  &table.Table
+	out                    strings.Builder
+	cheaders               strings.Builder
+	includes               strings.Builder // all C #includes required by V modules
+	typedefs               strings.Builder
+	typedefs2              strings.Builder
+	type_definitions       strings.Builder // typedefs, defines etc (everything that goes to the top of the file)
+	definitions            strings.Builder // typedefs, defines etc (everything that goes to the top of the file)
+	inits                  map[string]strings.Builder // contents of `void _vinit/2{}`
+	cleanups               map[string]strings.Builder // contents of `void _vcleanup(){}`
+	gowrappers             strings.Builder // all go callsite wrappers
+	stringliterals         strings.Builder // all string literals (they depend on tos3() beeing defined
+	auto_str_funcs         strings.Builder // function bodies of all auto generated _str funcs
+	comptime_defines       strings.Builder // custom defines, given by -d/-define flags on the CLI
+	pcs_declarations       strings.Builder // -prof profile counter declarations for each function
+	hotcode_definitions    strings.Builder // -live declarations & functions
+	embedded_data          strings.Builder // data to embed in the executable/binary
+	shared_types           strings.Builder // shared/lock types
+	shared_functions       strings.Builder // shared constructors
+	channel_definitions    strings.Builder // channel related code
+	options_typedefs       strings.Builder // Option typedefs
+	options                strings.Builder // `Option_xxxx` types
+	json_forward_decls     strings.Builder // json type forward decls
+	enum_typedefs          strings.Builder // enum types
+	sql_buf                strings.Builder // for writing exprs to args via `sqlite3_bind_int()` etc
+	file                   ast.File
+	fn_decl                &ast.FnDecl // pointer to the FnDecl we are currently inside otherwise 0
+	last_fn_c_name         string
+	tmp_count              int      // counter for unique tmp vars (_tmp1, tmp2 etc)
+	tmp_count2             int      // a separate tmp var counter for autofree fn calls
+	is_c_call              bool     // e.g. `C.printf("v")`
+	is_assign_lhs          bool     // inside left part of assign expr (for array_set(), etc)
+	discard_or_result      bool     // do not safe last ExprStmt of `or` block in tmp variable to defer ongoing expr usage
+	is_void_expr_stmt      bool     // ExprStmt whos result is discarded
+	is_arraymap_set        bool     // map or array set value state
+	is_amp                 bool     // for `&Foo{}` to merge PrefixExpr `&` and StructInit `Foo{}`; also for `&byte(0)` etc
+	is_sql                 bool     // Inside `sql db{}` statement, generating sql instead of C (e.g. `and` instead of `&&` etc)
+	is_shared              bool     // for initialization of hidden mutex in `[rw]shared` literals
+	is_vlines_enabled      bool     // is it safe to generate #line directives when -g is passed
+	arraymap_set_pos       int      // map or array set value position
+	vlines_path            string   // set to the proper path for generating #line directives
+	optionals              []string // to avoid duplicates TODO perf, use map
+	chan_pop_optionals     []string // types for `x := <-ch or {...}`
+	chan_push_optionals    []string // types for `ch <- x or {...}`
+	shareds                []int    // types with hidden mutex for which decl has been emitted
+	inside_ternary         int      // ?: comma separated statements on a single line
+	inside_map_postfix     bool     // inside map++/-- postfix expr
+	inside_map_infix       bool     // inside map<</+=/-= infix expr
+	inside_map_index       bool
+	inside_opt_data        bool
+	inside_if_optional     bool
+	ternary_names          map[string]string
+	ternary_level_names    map[string][]string
+	stmt_path_pos          []int // positions of each statement start, for inserting C statements before the current statement
+	skip_stmt_pos          bool  // for handling if expressions + autofree (since both prepend C statements)
+	right_is_opt           bool
+	is_autofree            bool // false, inside the bodies of fns marked with [manualfree], otherwise === g.pref.autofree
+	indent                 int
+	empty_line             bool
+	is_test                bool
+	assign_op              token.Kind // *=, =, etc (for array_set)
+	defer_stmts            []ast.DeferStmt
+	defer_ifdef            string
+	defer_profile_code     string
+	str_types              []string     // types that need automatic str() generation
+	threaded_fns           []string     // for generating unique wrapper types and fns for `go xxx()`
+	waiter_fns             []string     // functions that wait for `go xxx()` to finish
+	array_fn_definitions   []string     // array equality functions that have been defined
+	map_fn_definitions     []string     // map equality functions that have been defined
+	struct_fn_definitions  []string     // struct equality functions that have been defined
+	sumtype_fn_definitions []string     // sumtype equality functions that have been defined
+	alias_fn_definitions   []string     // alias equality functions that have been defined
+	auto_fn_definitions    []string     // auto generated functions defination list
+	anon_fn_definitions    []string     // anon generated functions defination list
+	sumtype_definitions    map[int]bool // `_TypeA_to_sumtype_TypeB()` fns that have been generated
+	is_json_fn             bool     // inside json.encode()
+	json_types             []string // to avoid json gen duplicates
+	pcs                    []ProfileCounterMeta // -prof profile counter fn_names => fn counter name
+	is_builtin_mod         bool
+	hotcode_fn_names       []string
+	embedded_files         []ast.EmbeddedFile
+	cur_fn                 ast.FnDecl
+	cur_generic_types      []table.Type // `int`, `string`, etc in `foo<T>()`
+	sql_i                  int
+	sql_stmt_name          string
+	sql_side               SqlExprSide // left or right, to distinguish idents in `name == name`
+	inside_vweb_tmpl       bool
+	inside_return          bool
+	inside_or_block        bool
+	strs_to_free0          []string // strings.Builder
 	// strs_to_free          []string // strings.Builder
 	inside_call           bool
 	has_main              bool
@@ -3507,6 +3508,23 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 			} else if node.op == .ne {
 				g.write('!${ptr_typ}_struct_eq(')
 			}
+		}
+		if node.left_type.is_ptr() {
+			g.write('*')
+		}
+		g.expr(node.left)
+		g.write(', ')
+		if node.right_type.is_ptr() {
+			g.write('*')
+		}
+		g.expr(node.right)
+		g.write(')')
+	} else if op_is_eq_or_ne && left_sym.kind == .sum_type && right_sym.kind == .sum_type {
+		ptr_typ := g.gen_sumtype_equality_fn(left_type)
+		if node.op == .eq {
+			g.write('${ptr_typ}_sumtype_eq(')
+		} else if node.op == .ne {
+			g.write('!${ptr_typ}_sumtype_eq(')
 		}
 		if node.left_type.is_ptr() {
 			g.write('*')

--- a/vlib/v/table/types.v
+++ b/vlib/v/table/types.v
@@ -525,6 +525,14 @@ pub fn (t &TypeSymbol) struct_info() Struct {
 	}
 }
 
+[inline]
+pub fn (t &TypeSymbol) sumtype_info() SumType {
+	match mut t.info {
+		SumType { return t.info }
+		else { panic('TypeSymbol.sumtype_info(): no sumtype info for type: $t.name') }
+	}
+}
+
 /*
 pub fn (t TypeSymbol) str() string {
 	return t.name

--- a/vlib/v/tests/sumtype_equality_test.v
+++ b/vlib/v/tests/sumtype_equality_test.v
@@ -1,0 +1,29 @@
+type Str = string | ustring
+
+struct Foo {
+	v int
+}
+
+struct Bar {
+	v int
+}
+
+type FooBar = Foo | Bar
+
+fn test_sumtype_equality() {
+	s1 := Str('s')
+	s2 := Str('s2')
+	u1 := Str('s1'.ustring())
+	u2 := Str('s2'.ustring())
+	assert s1 == s1
+	assert u1 == u1
+	assert s1 != s2
+	assert u1 != u2
+	assert u1 != s1
+
+	// Same value, defferent type
+	foo := FooBar(Foo{v: 0})
+	bar := FooBar(Bar{v: 0})
+	assert foo.v == bar.v
+	assert foo != bar
+}


### PR DESCRIPTION
both of alias and sum type declaration are very similar syntax.

And alias has auto eq methods, but sum type don't have it. This is not intuitive behavior imho.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
