### PR TITLE
parser: fix anon_fn with array arguments (fix #9410)

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -643,7 +643,7 @@ fn (mut p Parser) fn_args() ([]table.Param, bool, bool) {
 	} else {
 		p.tok.lit
 	}
-	types_only := p.tok.kind in [.amp, .ellipsis, .key_fn]
+	types_only := p.tok.kind in [.amp, .ellipsis, .key_fn, .lsbr]
 		|| (p.peek_tok.kind == .comma && p.table.known_type(argname))
 		|| p.peek_tok.kind == .dot || p.peek_tok.kind == .rpar
 	// TODO copy pasta, merge 2 branches

--- a/vlib/v/tests/anon_fn_with_array_arguments.v
+++ b/vlib/v/tests/anon_fn_with_array_arguments.v
@@ -1,0 +1,12 @@
+fn fn_arg(f fn ([]int) int) int {
+	return f([1, 2, 3])
+}
+
+fn test_anon_fn_with_array_arguments() {
+	anon := fn (i []int) int {
+		return 0
+	}
+
+	println(fn_arg(anon))
+	assert fn_arg(anon) == 0
+}


### PR DESCRIPTION
This PR fix anon_fn with array arguments (fix #9410).

- Fix anon_fn with array arguments.
- Add test.

```vlang
fn fn_arg(f fn ([]int) int) int {
	return f([1, 2, 3])
}

fn main() {
	anon := fn (i []int) int {
		return 0
	}

	println(fn_arg(anon))
}

D:\Test\v\tt1>v run .
0
```