### PR TITLE
ci: test-self (V compiled with -fsanitize=memory)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -633,7 +633,9 @@ jobs:
         run: make -j4 && ./v -cc clang -cg -cflags -Werror -o v cmd/v
       - name: Self tests (-fsanitize=memory)
         run: ./v -cflags -fsanitize=memory test-self
-
+      - name: Self tests (V compiled with -fsanitize=memory)
+        run:
+          ./v -cflags -fsanitize=memory -o v cmd/v && /v -cc tcc test-self -msan-compiler
   #  ubuntu-autofree-selfcompile:
   #    runs-on: ubuntu-20.04
   #    timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -635,7 +635,7 @@ jobs:
         run: ./v -cflags -fsanitize=memory test-self
       - name: Self tests (V compiled with -fsanitize=memory)
         run:
-          ./v -cflags -fsanitize=memory -o v cmd/v && /v -cc tcc test-self -msan-compiler
+          ./v -cflags -fsanitize=memory -o v cmd/v && ./v -cc tcc test-self -msan-compiler
   #  ubuntu-autofree-selfcompile:
   #    runs-on: ubuntu-20.04
   #    timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,7 +434,7 @@ jobs:
           ./v -o v2 cmd/v -cflags -fsanitize=memory
           ./v -o v3 cmd/v -cflags -fsanitize=thread
           ./v -o v4 cmd/v -cflags -fsanitize=undefined
-          ./v -o v5 cmd/v -cflags -fsanitize=address
+          ./v -o v5 cmd/v -cflags -fsanitize=address,pointer-compare,pointer-subtract
           UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./v2 -o v.c cmd/v
           UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./v3 -o v.c cmd/v
           UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./v4 -o v.c cmd/v
@@ -553,7 +553,7 @@ jobs:
       - name: Build V
         run: make -j4 && ./v -cg -cflags -Werror -o v cmd/v
       - name: Self tests (-fsanitize=address)
-        run: ASAN_OPTIONS=detect_leaks=0 ./v -cflags -fsanitize=address test-self
+        run: ASAN_OPTIONS=detect_leaks=0 ./v -cflags "-fsanitize=address,pointer-compare,pointer-subtract" test-self
       - name: Self tests (V compiled with -fsanitize=address)
         run:
           ./v -cflags -fsanitize=address -o v cmd/v &&
@@ -582,7 +582,7 @@ jobs:
           ## .\.github\workflows\windows-install-sdl.bat
       - name: Self tests (-fsanitize=address)
         run: |
-          .\v.exe -cflags "-fsanitize=address" test-self
+          .\v.exe -cflags -fsanitize=address test-self
 
   tests-sanitize-address-gcc:
     runs-on: ubuntu-20.04
@@ -608,7 +608,7 @@ jobs:
         run: ASAN_OPTIONS=detect_leaks=0 ./v -cflags -fsanitize=address test-self
       - name: Self tests (V compiled with -fsanitize=address)
         run:
-          ./v -cflags -fsanitize=address -o v cmd/v &&
+          ./v -cflags -fsanitize=address,pointer-compare,pointer-subtract -o v cmd/v &&
           ASAN_OPTIONS=detect_leaks=0 ./v -cc tcc test-self -asan-compiler
 
   tests-sanitize-memory-clang:

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -6,23 +6,22 @@ import v.pref
 
 const (
 	skip_with_fsanitize_memory    = [
-		''
-		// 'vlib/net/tcp_simple_client_server_test.v',
-		// 'vlib/net/http/cookie_test.v',
-		// 'vlib/net/http/http_test.v',
-		// 'vlib/net/http/status_test.v',
-		// 'vlib/net/http/http_httpbin_test.v',
-		// 'vlib/net/http/header_test.v',
-		// 'vlib/net/udp_test.v',
-		// 'vlib/net/tcp_test.v',
-		// 'vlib/orm/orm_test.v',
-		// 'vlib/sqlite/sqlite_test.v',
-		// 'vlib/v/tests/orm_sub_struct_test.v',
-		// 'vlib/vweb/tests/vweb_test.v',
-		// 'vlib/vweb/request_test.v',
-		// 'vlib/vweb/route_test.v',
-		// 'vlib/x/websocket/websocket_test.v',
-		// 'vlib/crypto/rand/crypto_rand_read_test.v',
+		'vlib/crypto/rand/crypto_rand_read_test.v'
+		'vlib/net/http/cookie_test.v'
+		'vlib/net/http/header_test.v'
+		'vlib/net/http/http_httpbin_test.v'
+		'vlib/net/http/http_test.v'
+		'vlib/net/http/status_test.v'
+		'vlib/net/tcp_simple_client_server_test.v'
+		'vlib/net/tcp_test.v'
+		'vlib/net/udp_test.v'
+		'vlib/orm/orm_test.v'
+		'vlib/sqlite/sqlite_test.v'
+		'vlib/v/tests/orm_sub_struct_test.v'
+		'vlib/vweb/request_test.v'
+		'vlib/vweb/route_test.v'
+		'vlib/vweb/tests/vweb_test.v'
+		'vlib/x/websocket/websocket_test.v'
 	]
 	skip_with_fsanitize_address   = [
 		'vlib/encoding/base64/base64_test.v',

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -6,22 +6,23 @@ import v.pref
 
 const (
 	skip_with_fsanitize_memory    = [
-		'vlib/net/tcp_simple_client_server_test.v',
-		'vlib/net/http/cookie_test.v',
-		'vlib/net/http/http_test.v',
-		'vlib/net/http/status_test.v',
-		'vlib/net/http/http_httpbin_test.v',
-		'vlib/net/http/header_test.v',
-		'vlib/net/udp_test.v',
-		'vlib/net/tcp_test.v',
-		'vlib/orm/orm_test.v',
-		'vlib/sqlite/sqlite_test.v',
-		'vlib/v/tests/orm_sub_struct_test.v',
-		'vlib/vweb/tests/vweb_test.v',
-		'vlib/vweb/request_test.v',
-		'vlib/vweb/route_test.v',
-		'vlib/x/websocket/websocket_test.v',
-		'vlib/crypto/rand/crypto_rand_read_test.v',
+		''
+		// 'vlib/net/tcp_simple_client_server_test.v',
+		// 'vlib/net/http/cookie_test.v',
+		// 'vlib/net/http/http_test.v',
+		// 'vlib/net/http/status_test.v',
+		// 'vlib/net/http/http_httpbin_test.v',
+		// 'vlib/net/http/header_test.v',
+		// 'vlib/net/udp_test.v',
+		// 'vlib/net/tcp_test.v',
+		// 'vlib/orm/orm_test.v',
+		// 'vlib/sqlite/sqlite_test.v',
+		// 'vlib/v/tests/orm_sub_struct_test.v',
+		// 'vlib/vweb/tests/vweb_test.v',
+		// 'vlib/vweb/request_test.v',
+		// 'vlib/vweb/route_test.v',
+		// 'vlib/x/websocket/websocket_test.v',
+		// 'vlib/crypto/rand/crypto_rand_read_test.v',
 	]
 	skip_with_fsanitize_address   = [
 		'vlib/encoding/base64/base64_test.v',
@@ -156,6 +157,9 @@ const (
 		'vlib/readline/readline_test.v',
 		'vlib/vweb/tests/vweb_test.v',
 	]
+	skip_with_msan_compiler       = [
+		''
+	]
 	skip_test_files               = []string{}
 	skip_on_musl                  = [
 		'vlib/v/tests/profile/profile_test.v',
@@ -217,9 +221,13 @@ fn main() {
 	mut sanitize_address := false
 	mut sanitize_undefined := false
 	mut asan_compiler := false
+	mut msan_compiler := false
 	for arg in args {
 		if '-asan-compiler' in arg {
 			asan_compiler = true
+		}
+		if '-msan-compiler' in arg {
+			msan_compiler = true
 		}
 		if '-Werror' in arg {
 			werror = true
@@ -248,6 +256,9 @@ fn main() {
 	}
 	if asan_compiler {
 		tsession.skip_files << skip_with_asan_compiler
+	}
+	if msan_compiler {
+		tsession.skip_files << skip_with_msan_compiler
 	}
 	// println(tsession.skip_files)
 	if os.getenv('V_CI_MUSL').len > 0 {

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -6,22 +6,22 @@ import v.pref
 
 const (
 	skip_with_fsanitize_memory    = [
-		'vlib/crypto/rand/crypto_rand_read_test.v'
-		'vlib/net/http/cookie_test.v'
-		'vlib/net/http/header_test.v'
-		'vlib/net/http/http_httpbin_test.v'
-		'vlib/net/http/http_test.v'
-		'vlib/net/http/status_test.v'
-		'vlib/net/tcp_simple_client_server_test.v'
-		'vlib/net/tcp_test.v'
-		'vlib/net/udp_test.v'
-		'vlib/orm/orm_test.v'
-		'vlib/sqlite/sqlite_test.v'
-		'vlib/v/tests/orm_sub_struct_test.v'
-		'vlib/vweb/request_test.v'
-		'vlib/vweb/route_test.v'
-		'vlib/vweb/tests/vweb_test.v'
-		'vlib/x/websocket/websocket_test.v'
+		'vlib/crypto/rand/crypto_rand_read_test.v',
+		'vlib/net/http/cookie_test.v',
+		'vlib/net/http/header_test.v',
+		'vlib/net/http/http_httpbin_test.v',
+		'vlib/net/http/http_test.v',
+		'vlib/net/http/status_test.v',
+		'vlib/net/tcp_simple_client_server_test.v',
+		'vlib/net/tcp_test.v',
+		'vlib/net/udp_test.v',
+		'vlib/orm/orm_test.v',
+		'vlib/sqlite/sqlite_test.v',
+		'vlib/v/tests/orm_sub_struct_test.v',
+		'vlib/vweb/request_test.v',
+		'vlib/vweb/route_test.v',
+		'vlib/vweb/tests/vweb_test.v',
+		'vlib/x/websocket/websocket_test.v',
 	]
 	skip_with_fsanitize_address   = [
 		'vlib/encoding/base64/base64_test.v',
@@ -157,7 +157,7 @@ const (
 		'vlib/vweb/tests/vweb_test.v',
 	]
 	skip_with_msan_compiler       = [
-		''
+		'',
 	]
 	skip_test_files               = []string{}
 	skip_on_musl                  = [

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -6,22 +6,22 @@ import v.pref
 
 const (
 	skip_with_fsanitize_memory    = [
-		'vlib/crypto/rand/crypto_rand_read_test.v',
+		'vlib/net/tcp_simple_client_server_test.v',
 		'vlib/net/http/cookie_test.v',
-		'vlib/net/http/header_test.v',
-		'vlib/net/http/http_httpbin_test.v',
 		'vlib/net/http/http_test.v',
 		'vlib/net/http/status_test.v',
-		'vlib/net/tcp_simple_client_server_test.v',
-		'vlib/net/tcp_test.v',
+		'vlib/net/http/http_httpbin_test.v',
+		'vlib/net/http/header_test.v',
 		'vlib/net/udp_test.v',
+		'vlib/net/tcp_test.v',
 		'vlib/orm/orm_test.v',
 		'vlib/sqlite/sqlite_test.v',
 		'vlib/v/tests/orm_sub_struct_test.v',
+		'vlib/vweb/tests/vweb_test.v',
 		'vlib/vweb/request_test.v',
 		'vlib/vweb/route_test.v',
-		'vlib/vweb/tests/vweb_test.v',
 		'vlib/x/websocket/websocket_test.v',
+		'vlib/crypto/rand/crypto_rand_read_test.v',
 	]
 	skip_with_fsanitize_address   = [
 		'vlib/encoding/base64/base64_test.v',
@@ -156,9 +156,7 @@ const (
 		'vlib/readline/readline_test.v',
 		'vlib/vweb/tests/vweb_test.v',
 	]
-	skip_with_msan_compiler       = [
-		'',
-	]
+	skip_with_msan_compiler       = []string{}
 	skip_test_files               = []string{}
 	skip_on_musl                  = [
 		'vlib/v/tests/profile/profile_test.v',


### PR DESCRIPTION
This PR adds a `test-self (V compiled with -fsanitize=memory)` job. I also added `-fsanitize=pointer-compare,pointer-subtract` to the `-fsanitize=address` jobs. 

I found these checks from:
https://kristerw.blogspot.com/2018/06/useful-gcc-address-sanitizer-checks-not.html

Now we finally have a very good amount of sanitize check :rocket: 

We could also look into the clang static analyzer