### PR TITLE
vdoc, v.doc: remove DocPos and use token.Position

### DIFF
--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -222,13 +222,13 @@ fn (vd VDoc) write_content(cn &doc.DocNode, d &doc.Doc, mut hw strings.Builder) 
 	} else {
 		os.file_name(cn.file_path)
 	}
-	src_link := get_src_link(vd.manifest.repo_url, file_path_name, cn.pos.line)
+	src_link := get_src_link(vd.manifest.repo_url, file_path_name, cn.pos.line_nr + 1)
 	if cn.content.len != 0 || (cn.name == 'Constants') {
 		hw.write_string(doc_node_html(cn, src_link, false, cfg.include_examples, d.table))
 	}
 	for child in cn.children {
 		child_file_path_name := child.file_path.replace('$base_dir/', '')
-		child_src_link := get_src_link(vd.manifest.repo_url, child_file_path_name, child.pos.line)
+		child_src_link := get_src_link(vd.manifest.repo_url, child_file_path_name, child.pos.line_nr + 1)
 		hw.write_string(doc_node_html(child, child_src_link, false, cfg.include_examples,
 			d.table))
 	}

--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -228,7 +228,8 @@ fn (vd VDoc) write_content(cn &doc.DocNode, d &doc.Doc, mut hw strings.Builder) 
 	}
 	for child in cn.children {
 		child_file_path_name := child.file_path.replace('$base_dir/', '')
-		child_src_link := get_src_link(vd.manifest.repo_url, child_file_path_name, child.pos.line_nr + 1)
+		child_src_link := get_src_link(vd.manifest.repo_url, child_file_path_name, 
+			child.pos.line_nr + 1)
 		hw.write_string(doc_node_html(child, child_src_link, false, cfg.include_examples,
 			d.table))
 	}

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -124,7 +124,7 @@ fn (vd VDoc) write_plaintext_content(contents []doc.DocNode, mut pw strings.Buil
 				pw.writeln(comments.trim_space().split_into_lines().map('    ' + it).join('\n'))
 			}
 			if cfg.show_loc {
-				pw.writeln('Location: $cn.file_path:$cn.pos.line\n')
+				pw.writeln('Location: $cn.file_path:${cn.pos.line_nr + 1}\n')
 			}
 		}
 		vd.write_plaintext_content(cn.children, mut pw)

--- a/vlib/v/doc/comment.v
+++ b/vlib/v/doc/comment.v
@@ -1,5 +1,7 @@
 module doc
 
+import v.token
+
 const (
 	example_pattern = '\x01 Example: '
 )
@@ -8,7 +10,7 @@ pub struct DocComment {
 pub mut:
 	text     string // Raw text content of the comment, excluding the comment token chars ('//, /*, */')
 	is_multi bool   // Is a block / multi-line comment
-	pos      DocPos = DocPos{-1, -1, 0}
+	pos      token.Position
 }
 
 // is_example returns true if the contents of this comment is a doc example.

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -9,7 +9,7 @@ import v.parser
 import v.pref
 import v.scanner
 import v.table
-import v.util
+import v.token
 
 // SymbolKind categorizes the symbols it documents.
 // The names are intentionally not in order as a guide when sorting the nodes.
@@ -50,31 +50,22 @@ pub mut:
 		cur_fn: 0
 		pref: 0
 	}
-	fmt             fmt.Fmt
-	filename        string
-	pos             int
-	pub_only        bool = true
-	with_comments   bool = true
-	with_pos        bool
-	with_head       bool = true
-	is_vlib         bool
-	time_generated  time.Time
-	head            DocNode
-	contents        map[string]DocNode
-	scoped_contents map[string]DocNode
-	// for storing the contents of the file.
-	sources             map[string]string
+	fmt                 fmt.Fmt
+	filename            string
+	pos                 int
+	pub_only            bool = true
+	with_comments       bool = true
+	with_pos            bool
+	with_head           bool = true
+	is_vlib             bool
+	time_generated      time.Time
+	head                DocNode
+	contents            map[string]DocNode
+	scoped_contents     map[string]DocNode
 	parent_mod_name     string
 	orig_mod_name       string
 	extract_vars        bool
 	filter_symbol_names []string
-}
-
-pub struct DocPos {
-pub:
-	line int
-	col  int
-	len  int
 }
 
 pub struct DocNode {
@@ -82,7 +73,7 @@ pub mut:
 	name        string
 	content     string
 	comments    []DocComment
-	pos         DocPos = DocPos{-1, -1, 0}
+	pos         token.Position
 	file_path   string
 	kind        SymbolKind
 	deprecated  bool
@@ -111,7 +102,6 @@ pub fn new(input_path string) Doc {
 		table: table.new_table()
 		head: DocNode{}
 		contents: map[string]DocNode{}
-		sources: map[string]string{}
 		time_generated: time.now()
 	}
 	d.fmt = fmt.Fmt{
@@ -131,7 +121,7 @@ pub fn (mut d Doc) stmt(stmt ast.Stmt, filename string) ?DocNode {
 	mut node := DocNode{
 		name: d.stmt_name(stmt)
 		content: d.stmt_signature(stmt)
-		pos: d.convert_pos(filename, stmt.pos)
+		pos: stmt.pos
 		file_path: os.join_path(d.base_path, filename)
 		is_pub: d.stmt_pub(stmt)
 	}
@@ -158,7 +148,7 @@ pub fn (mut d Doc) stmt(stmt ast.Stmt, filename string) ?DocNode {
 					node.children << DocNode{
 						name: field.name.all_after(d.orig_mod_name + '.')
 						kind: .constant
-						pos: d.convert_pos(filename, field.pos)
+						pos: field.pos
 						return_type: ret_type
 					}
 				}
@@ -173,7 +163,7 @@ pub fn (mut d Doc) stmt(stmt ast.Stmt, filename string) ?DocNode {
 						name: field.name
 						kind: .enum_field
 						parent_name: node.name
-						pos: d.convert_pos(filename, field.pos)
+						pos: field.pos
 						return_type: ret_type
 					}
 				}
@@ -195,7 +185,7 @@ pub fn (mut d Doc) stmt(stmt ast.Stmt, filename string) ?DocNode {
 						name: field.name
 						kind: .struct_field
 						parent_name: node.name
-						pos: d.convert_pos(filename, field.pos)
+						pos: field.pos
 						return_type: ret_type
 					}
 				}
@@ -219,7 +209,7 @@ pub fn (mut d Doc) stmt(stmt ast.Stmt, filename string) ?DocNode {
 						name: param.name
 						kind: .variable
 						parent_name: node.name
-						pos: d.convert_pos(filename, param.pos)
+						pos: param.pos
 						attrs: map{
 							'mut': param.is_mut.str()
 						}
@@ -334,7 +324,7 @@ pub fn (mut d Doc) file_ast_with_pos(file_ast ast.File, pos int) map[string]DocN
 		vr_data := val as ast.Var
 		l_node := DocNode{
 			name: name
-			pos: d.convert_pos(os.base(file_ast.path), vr_data.pos)
+			pos: vr_data.pos
 			file_path: file_ast.path
 			from_scope: true
 			kind: .variable
@@ -373,8 +363,6 @@ pub fn (mut d Doc) generate() ? {
 		if i == 0 {
 			d.parent_mod_name = get_parent_mod(d.base_path) or { '' }
 		}
-		filename := os.base(file_path)
-		d.sources[filename] = util.read_file(file_path) or { '' }
 		file_asts << parser.parse_file(file_path, d.table, comments_mode, d.prefs, global_scope)
 	}
 	return d.file_asts(file_asts)

--- a/vlib/v/doc/utils.v
+++ b/vlib/v/doc/utils.v
@@ -1,12 +1,9 @@
 module doc
 
-import math.mathutil as mu
 import strings
 import v.ast
-import v.util
 import v.token
 import v.table
-import os
 
 // merge_comments merges all the comment contents into a single text.
 pub fn merge_comments(comments []ast.Comment) string {
@@ -23,8 +20,8 @@ pub fn ast_comment_to_doc_comment(ast_node ast.Comment) DocComment {
 	return DocComment{
 		text: text
 		is_multi: ast_node.is_multi
-		pos: DocPos{
-			line: ast_node.pos.line_nr - 1
+		pos: token.Position{
+			line_nr: ast_node.pos.line_nr
 			col: 0 // ast_node.pos.pos - ast_node.text.len
 			len: text.len
 		}
@@ -51,7 +48,7 @@ pub fn merge_doc_comments(comments []DocComment) string {
 	mut last_comment_line_nr := 0
 	for i := comments.len - 1; i >= 0; i-- {
 		cmt := comments[i]
-		if last_comment_line_nr != 0 && cmt.pos.line < last_comment_line_nr - 1 {
+		if last_comment_line_nr != 0 && cmt.pos.line_nr + 1 < last_comment_line_nr - 1 {
 			// skip comments that are not part of a continuous block,
 			// located right above the top level statement.
 			// break
@@ -83,24 +80,9 @@ pub fn merge_doc_comments(comments []DocComment) string {
 		// eprintln('cmt: $cmt')
 		cseparator := if cmt_content.starts_with('```') { '\n' } else { ' ' }
 		comment = cmt_content + cseparator + comment
-		last_comment_line_nr = cmt.pos.line
+		last_comment_line_nr = cmt.pos.line_nr + 1
 	}
 	return comment
-}
-
-// convert_pos converts the `token.Position` data into a `DocPos`.
-fn (mut d Doc) convert_pos(filename string, pos token.Position) DocPos {
-	if filename !in d.sources {
-		d.sources[filename] = util.read_file(os.join_path(d.base_path, filename)) or { '' }
-	}
-	source := d.sources[filename]
-	mut p := mu.max(0, mu.min(source.len - 1, pos.pos))
-	column := mu.max(0, pos.pos - p - 1)
-	return DocPos{
-		line: pos.line_nr + 1
-		col: mu.max(1, column + 1)
-		len: pos.len
-	}
 }
 
 // stmt_signature returns the signature of a given `ast.Stmt` node.


### PR DESCRIPTION
Follow-up PR to #9407. Removes the need of a separate `DocPos` in favor of `v.token`'s `Position` struct. This also removes the need to store source codes for position conversion.