### PR TITLE
doc: reflect current `int` → `f32` behaviour

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -434,9 +434,10 @@ These are the allowed possibilities:
    i8 → i16 → int → i64 ⬏
 ```
 An `int` value for example can be automatically promoted to `f64`
-or `i64` but not to `f32` or `u32`. (`f32` would mean precision
-loss for large values and `u32` would mean loss of the sign for
+or `i64` but not to `u32`. (`u32` would mean loss of the sign for
 negative values).
+Promotion from `int` to `f32`, however, is currently done automatically
+(but can lead to precision loss for large values).
 
 Literals like `123` or `4.56` are treated in a special way. They do
 not lead to type promotions, however they default to `int` and `f64`


### PR DESCRIPTION
Documentation should reflect current state of affairs.
Current state (with 0c055a1) is precision loss:
```
mut f := f32(3.2)
i := int(2147483583)
f =  i // loss of precision
println('${f:.2f} $i')
```

Closes #8601 Closes #6251

Related #4971 #5155 #5174 #7692 #7801 

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
