### PR TITLE
tests: fix 3 tests with memory errors

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -24,11 +24,8 @@ const (
 		'vlib/crypto/rand/crypto_rand_read_test.v',
 	]
 	skip_with_fsanitize_address   = [
-		'vlib/encoding/base64/base64_test.v',
 		'vlib/json/json_test.v',
 		'vlib/regex/regex_test.v',
-		'vlib/v/tests/ptr_arithmetic_test.v',
-		'vlib/v/tests/unsafe_test.v',
 		'vlib/x/websocket/websocket_test.v',
 	]
 	skip_with_fsanitize_undefined = []string{}

--- a/vlib/encoding/base64/base64.v
+++ b/vlib/encoding/base64/base64.v
@@ -18,7 +18,7 @@ const (
 // Example: assert base64.decode('ViBpbiBiYXNlIDY0') == 'V in base 64'
 pub fn decode(data string) []byte {
 	size := data.len * 3 / 4
-	if size <= 0 {
+	if size <= 0 || data.len % 4 != 0 {
 		return []
 	}
 	unsafe {
@@ -31,7 +31,7 @@ pub fn decode(data string) []byte {
 // decode_str is the string variant of decode
 pub fn decode_str(data string) string {
 	size := data.len * 3 / 4
-	if size <= 0 {
+	if size <= 0 || data.len % 4 != 0 {
 		return ''
 	}
 	unsafe {

--- a/vlib/encoding/base64/base64_test.v
+++ b/vlib/encoding/base64/base64_test.v
@@ -43,9 +43,9 @@ fn test_decode() {
 	assert base64.decode(man_pair.encoded) == man_pair.decoded.bytes()
 
 	// Test for incorrect padding.
-	assert base64.decode('aGk') == 'hi'.bytes()
+	assert base64.decode('aGk') == ''.bytes()
 	assert base64.decode('aGk=') == 'hi'.bytes()
-	assert base64.decode('aGk==') == 'hi'.bytes()
+	assert base64.decode('aGk==') == ''.bytes()
 
 	for i, p in pairs {
 		got := base64.decode(p.encoded)
@@ -60,9 +60,9 @@ fn test_decode_str() {
 	assert base64.decode_str(man_pair.encoded) == man_pair.decoded
 
 	// Test for incorrect padding.
-	assert base64.decode_str('aGk') == 'hi'
+	assert base64.decode_str('aGk') == ''
 	assert base64.decode_str('aGk=') == 'hi'
-	assert base64.decode_str('aGk==') == 'hi'
+	assert base64.decode_str('aGk==') == ''
 
 	for i, p in pairs {
 		got := base64.decode_str(p.encoded)

--- a/vlib/v/tests/ptr_arithmetic_test.v
+++ b/vlib/v/tests/ptr_arithmetic_test.v
@@ -9,12 +9,12 @@ fn test_ptr_arithmetic() {
 		p++
 		p += 2
 		p = p - 1
-		assert p == &v + 2
+		assert ptr_str(p) == ptr_str(&v + 2)
 		p = p + 1
-		assert p == &v + 3
+		assert ptr_str(p) == ptr_str(&v + 3)
 		r := p++
-		assert r == &v + 3
-		assert p == &v + 4
+		assert ptr_str(r) == ptr_str(&v + 3)
+		assert ptr_str(p) == ptr_str(&v + 4)
 	}
 }
 

--- a/vlib/v/tests/unsafe_test.v
+++ b/vlib/v/tests/unsafe_test.v
@@ -36,7 +36,7 @@ fn test_ptr_infix() {
 	v := 4
 	mut q := unsafe {&v - 1}
 	q = unsafe {q + 3}
-	assert q == unsafe {&v + 2}
+	assert ptr_str(q) == ptr_str(unsafe {&v + 2})
 }
 
 struct S1 {


### PR DESCRIPTION
This PR fixes three tests that did not pass with `-fsanitize=address`:

```
-		'vlib/encoding/base64/base64_test.v',
-		'vlib/v/tests/ptr_arithmetic_test.v',
-		'vlib/v/tests/unsafe_test.v',
```