### PR TITLE
http: use Header struct for headers

### DIFF
--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -291,7 +291,7 @@ fn parse_response(resp string) Response {
 		pos := h.index(':') or { continue }
 		mut key := h[..pos]
 		val := h[pos + 2..].trim_space()
-		header.add_str(key, val) or { eprintln('error parsing header: $err') }
+		header.add_custom(key, val) or { eprintln('error parsing header: $err') }
 	}
 	// set cookies
 	for cookie in header.values(.set_cookie) {
@@ -325,7 +325,7 @@ fn (req &Request) build_request_headers(method Method, host_name string, path st
 		if key == CommonHeader.cookie.str() {
 			continue
 		}
-		val := req.header.values_str(key).join('; ')
+		val := req.header.custom_values(key).join('; ')
 		uheaders << '$key: $val\r\n'
 	}
 	uheaders << req.build_request_cookies_header()

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -191,9 +191,15 @@ fn (mut resp Response) free() {
 }
 
 // add_header adds the key and value of an HTTP request header
-// to add a custom header, use req.header.add_str
+// To add a custom header, use add_custom_header
 pub fn (mut req Request) add_header(key CommonHeader, val string) {
 	req.header.add(key, val)
+}
+
+// add_custom_header adds the key and value of an HTTP request header
+// This method may fail if the key contains characters that are not permitted
+pub fn (mut req Request) add_custom_header(key string, val string) ? {
+	return req.header.add_custom(key, val)
 }
 
 // do will send the HTTP request and returns `http.Response` as soon as the response is recevied

--- a/vlib/net/http/http_httpbin_test.v
+++ b/vlib/net/http/http_httpbin_test.v
@@ -77,12 +77,12 @@ fn test_http_fetch_with_params() {
 	}
 }
 
-fn test_http_fetch_with_headers() {
+fn test_http_fetch_with_headers() ? {
 	$if !network ? { return }
+	mut headers := new_header()
+	headers.add_str('Test-Header', 'hello world') ?
 	responses := http_fetch_mock([], {
-		headers: {
-			'Test-Header': 'hello world'
-		}
+		headers: headers
 	}) or {
 		panic(err)
 	}

--- a/vlib/net/http/http_httpbin_test.v
+++ b/vlib/net/http/http_httpbin_test.v
@@ -79,10 +79,10 @@ fn test_http_fetch_with_params() {
 
 fn test_http_fetch_with_headers() ? {
 	$if !network ? { return }
-	mut headers := new_header()
-	headers.add_str('Test-Header', 'hello world') ?
+	mut header := new_header()
+	header.add_str('Test-Header', 'hello world') ?
 	responses := http_fetch_mock([], {
-		headers: headers
+		header: header
 	}) or {
 		panic(err)
 	}

--- a/vlib/net/http/http_httpbin_test.v
+++ b/vlib/net/http/http_httpbin_test.v
@@ -80,7 +80,7 @@ fn test_http_fetch_with_params() {
 fn test_http_fetch_with_headers() ? {
 	$if !network ? { return }
 	mut header := new_header()
-	header.add_str('Test-Header', 'hello world') ?
+	header.add_custom('Test-Header', 'hello world') ?
 	responses := http_fetch_mock([], {
 		header: header
 	}) or {

--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -65,7 +65,7 @@ Everything, including HTML templates, is in one binary file. That's all you need
 ## Getting Started
 
 To start with vweb, you have to import the module `vweb`.
-After the import, define a struct to hold vweb.Context 
+After the import, define a struct to hold vweb.Context
 (and any other variables your program will need).
 The web server can be started by calling `vweb.run<App>(port)`.
 
@@ -111,7 +111,7 @@ fn (mut app App) world() vweb.Result {
 }
 ```
 
-To pass a parameter to an endpoint, you simply define it inside 
+To pass a parameter to an endpoint, you simply define it inside
 an attribute, e. g. `['/hello/:user]`.
 After it is defined in the attribute, you have to add it as a function parameter.
 
@@ -123,8 +123,9 @@ fn (mut app App) hello_user(user string) vweb.Result {
 }
 ```
 
-You have access to the raw request data such as headers 
+You have access to the raw request data such as headers
 or the request body by accessing `app` (which is `vweb.Context`).
 If you want to read the request body, you can do that by calling `app.req.data`.
-To read the request headers, you just call `app.req.headers` and access the header you want, 
-e.g. `app.req.headers['Content-Type']`
+To read the request headers, you just call `app.req.header` and access the header you want,
+e.g. `app.req.header.get(.content_type)`. See `struct Header` for all
+available methods (`v doc net.http Header`).

--- a/vlib/vweb/request.v
+++ b/vlib/vweb/request.v
@@ -11,18 +11,18 @@ fn parse_request(mut reader io.BufferedReader) ?http.Request {
 	method, target, version := parse_request_line(line) ?
 
 	// headers
-	mut headers := http.new_header()
+	mut header := http.new_header()
 	line = reader.read_line() ?
 	for line != '' {
 		key, value := parse_header(line) ?
-		headers.add_custom(key, value) ?
+		header.add_custom(key, value) ?
 		line = reader.read_line() ?
 	}
 	h.coerce(canonicalize: true)
 
 	// body
 	mut body := []byte{}
-	if length := headers.get(.content_length) {
+	if length := header.get(.content_length) {
 		n := length.int()
 		if n > 0 {
 			body = []byte{len: n}
@@ -33,7 +33,7 @@ fn parse_request(mut reader io.BufferedReader) ?http.Request {
 	return http.Request{
 		method: method
 		url: target.str()
-		headers: headers
+		header: header
 		data: body.bytestr()
 		version: version
 	}

--- a/vlib/vweb/request.v
+++ b/vlib/vweb/request.v
@@ -18,7 +18,7 @@ fn parse_request(mut reader io.BufferedReader) ?http.Request {
 		header.add_custom(key, value) ?
 		line = reader.read_line() ?
 	}
-	h.coerce(canonicalize: true)
+	header.coerce(canonicalize: true)
 
 	// body
 	mut body := []byte{}

--- a/vlib/vweb/request_test.v
+++ b/vlib/vweb/request_test.v
@@ -37,28 +37,16 @@ fn test_parse_request_two_headers() {
 	req := parse_request(mut reader('GET / HTTP/1.1\r\nTest1: a\r\nTest2:  B\r\n\r\n')) or {
 		panic('did not parse: $err')
 	}
-	assert req.headers == map{
-		'Test1': 'a'
-		'Test2': 'B'
-	}
-	assert req.lheaders == map{
-		'test1': 'a'
-		'test2': 'B'
-	}
+	assert req.headers.values_str('Test1') == ['a']
+	assert req.headers.values_str('Test2') == ['B']
 }
 
 fn test_parse_request_two_header_values() {
 	req := parse_request(mut reader('GET / HTTP/1.1\r\nTest1: a; b\r\nTest2: c\r\nTest2: d\r\n\r\n')) or {
 		panic('did not parse: $err')
 	}
-	assert req.headers == map{
-		'Test1': 'a; b'
-		'Test2': 'c; d'
-	}
-	assert req.lheaders == map{
-		'test1': 'a; b'
-		'test2': 'c; d'
-	}
+	assert req.headers.values_str('Test1') == ['a; b']
+	assert req.headers.values_str('Test2') == ['c', 'd']
 }
 
 fn test_parse_request_body() {

--- a/vlib/vweb/request_test.v
+++ b/vlib/vweb/request_test.v
@@ -37,16 +37,16 @@ fn test_parse_request_two_headers() {
 	req := parse_request(mut reader('GET / HTTP/1.1\r\nTest1: a\r\nTest2:  B\r\n\r\n')) or {
 		panic('did not parse: $err')
 	}
-	assert req.header.values_str('Test1') == ['a']
-	assert req.header.values_str('Test2') == ['B']
+	assert req.header.custom_values('Test1') == ['a']
+	assert req.header.custom_values('Test2') == ['B']
 }
 
 fn test_parse_request_two_header_values() {
 	req := parse_request(mut reader('GET / HTTP/1.1\r\nTest1: a; b\r\nTest2: c\r\nTest2: d\r\n\r\n')) or {
 		panic('did not parse: $err')
 	}
-	assert req.header.values_str('Test1') == ['a; b']
-	assert req.header.values_str('Test2') == ['c', 'd']
+	assert req.header.custom_values('Test1') == ['a; b']
+	assert req.header.custom_values('Test2') == ['c', 'd']
 }
 
 fn test_parse_request_body() {

--- a/vlib/vweb/request_test.v
+++ b/vlib/vweb/request_test.v
@@ -37,16 +37,16 @@ fn test_parse_request_two_headers() {
 	req := parse_request(mut reader('GET / HTTP/1.1\r\nTest1: a\r\nTest2:  B\r\n\r\n')) or {
 		panic('did not parse: $err')
 	}
-	assert req.headers.values_str('Test1') == ['a']
-	assert req.headers.values_str('Test2') == ['B']
+	assert req.header.values_str('Test1') == ['a']
+	assert req.header.values_str('Test2') == ['B']
 }
 
 fn test_parse_request_two_header_values() {
 	req := parse_request(mut reader('GET / HTTP/1.1\r\nTest1: a; b\r\nTest2: c\r\nTest2: d\r\n\r\n')) or {
 		panic('did not parse: $err')
 	}
-	assert req.headers.values_str('Test1') == ['a; b']
-	assert req.headers.values_str('Test2') == ['c', 'd']
+	assert req.header.values_str('Test1') == ['a; b']
+	assert req.header.values_str('Test2') == ['c', 'd']
 }
 
 fn test_parse_request_body() {

--- a/vlib/vweb/tests/vweb_test.v
+++ b/vlib/vweb/tests/vweb_test.v
@@ -108,28 +108,28 @@ fn test_a_simple_tcp_client_html_page() {
 }
 
 // net.http client based tests follow:
-fn assert_common_http_headers(x http.Response) {
+fn assert_common_http_headers(x http.Response) ? {
 	assert x.status_code == 200
-	assert x.headers['Server'] == 'VWeb'
-	assert x.headers['Content-Length'].int() > 0
-	assert x.headers['Connection'] == 'close'
+	assert x.headers.get(.server) ? == 'VWeb'
+	assert x.headers.get(.content_length) ?.int() > 0
+	assert x.headers.get(.connection) ? == 'close'
 }
 
-fn test_http_client_index() {
+fn test_http_client_index() ? {
 	x := http.get('http://127.0.0.1:$sport/') or { panic(err) }
-	assert_common_http_headers(x)
-	assert x.headers['Content-Type'] == 'text/plain'
+	assert_common_http_headers(x) ?
+	assert x.headers.get(.content_type) ? == 'text/plain'
 	assert x.text == 'Welcome to VWeb'
 }
 
-fn test_http_client_chunk_transfer() {
+fn test_http_client_chunk_transfer() ? {
 	x := http.get('http://127.0.0.1:$sport/chunk') or { panic(err) }
-	assert_common_http_headers(x)
-	assert x.headers['Transfer-Encoding'] == 'chunked'
+	assert_common_http_headers(x) ?
+	assert x.headers.get(.transfer_encoding) ? == 'chunked'
 	assert x.text == 'Lorem ipsum dolor sit amet, consetetur sadipscing'
 }
 
-fn test_http_client_404() {
+fn test_http_client_404() ? {
 	url_404_list := [
 		'http://127.0.0.1:$sport/zxcnbnm',
 		'http://127.0.0.1:$sport/JHKAJA',
@@ -141,37 +141,37 @@ fn test_http_client_404() {
 	}
 }
 
-fn test_http_client_simple() {
+fn test_http_client_simple() ? {
 	x := http.get('http://127.0.0.1:$sport/simple') or { panic(err) }
-	assert_common_http_headers(x)
-	assert x.headers['Content-Type'] == 'text/plain'
+	assert_common_http_headers(x) ?
+	assert x.headers.get(.content_type) ? == 'text/plain'
 	assert x.text == 'A simple result'
 }
 
-fn test_http_client_html_page() {
+fn test_http_client_html_page() ? {
 	x := http.get('http://127.0.0.1:$sport/html_page') or { panic(err) }
-	assert_common_http_headers(x)
-	assert x.headers['Content-Type'] == 'text/html'
+	assert_common_http_headers(x) ?
+	assert x.headers.get(.content_type) ? == 'text/html'
 	assert x.text == '<h1>ok</h1>'
 }
 
-fn test_http_client_settings_page() {
+fn test_http_client_settings_page() ? {
 	x := http.get('http://127.0.0.1:$sport/bilbo/settings') or { panic(err) }
-	assert_common_http_headers(x)
+	assert_common_http_headers(x) ?
 	assert x.text == 'username: bilbo'
 	//
 	y := http.get('http://127.0.0.1:$sport/kent/settings') or { panic(err) }
-	assert_common_http_headers(y)
+	assert_common_http_headers(y) ?
 	assert y.text == 'username: kent'
 }
 
-fn test_http_client_user_repo_settings_page() {
+fn test_http_client_user_repo_settings_page() ? {
 	x := http.get('http://127.0.0.1:$sport/bilbo/gostamp/settings') or { panic(err) }
-	assert_common_http_headers(x)
+	assert_common_http_headers(x) ?
 	assert x.text == 'username: bilbo | repository: gostamp'
 	//
 	y := http.get('http://127.0.0.1:$sport/kent/golang/settings') or { panic(err) }
-	assert_common_http_headers(y)
+	assert_common_http_headers(y) ?
 	assert y.text == 'username: kent | repository: golang'
 	//
 	z := http.get('http://127.0.0.1:$sport/missing/golang/settings') or { panic(err) }
@@ -183,7 +183,7 @@ struct User {
 	age  int
 }
 
-fn test_http_client_json_post() {
+fn test_http_client_json_post() ? {
 	ouser := User{
 		name: 'Bilbo'
 		age: 123
@@ -193,7 +193,7 @@ fn test_http_client_json_post() {
 	$if debug_net_socket_client ? {
 		eprintln('/json_echo endpoint response: $x')
 	}
-	assert x.headers['Content-Type'] == 'application/json'
+	assert x.headers.get(.content_type) ? == 'application/json'
 	assert x.text == json_for_ouser
 	nuser := json.decode(User, x.text) or { User{} }
 	assert '$ouser' == '$nuser'
@@ -202,7 +202,7 @@ fn test_http_client_json_post() {
 	$if debug_net_socket_client ? {
 		eprintln('/json endpoint response: $x')
 	}
-	assert x.headers['Content-Type'] == 'application/json'
+	assert x.headers.get(.content_type) ? == 'application/json'
 	assert x.text == json_for_ouser
 	nuser2 := json.decode(User, x.text) or { User{} }
 	assert '$ouser' == '$nuser2'

--- a/vlib/vweb/tests/vweb_test.v
+++ b/vlib/vweb/tests/vweb_test.v
@@ -110,22 +110,22 @@ fn test_a_simple_tcp_client_html_page() {
 // net.http client based tests follow:
 fn assert_common_http_headers(x http.Response) ? {
 	assert x.status_code == 200
-	assert x.headers.get(.server) ? == 'VWeb'
-	assert x.headers.get(.content_length) ?.int() > 0
-	assert x.headers.get(.connection) ? == 'close'
+	assert x.header.get(.server) ? == 'VWeb'
+	assert x.header.get(.content_length) ?.int() > 0
+	assert x.header.get(.connection) ? == 'close'
 }
 
 fn test_http_client_index() ? {
 	x := http.get('http://127.0.0.1:$sport/') or { panic(err) }
 	assert_common_http_headers(x) ?
-	assert x.headers.get(.content_type) ? == 'text/plain'
+	assert x.header.get(.content_type) ? == 'text/plain'
 	assert x.text == 'Welcome to VWeb'
 }
 
 fn test_http_client_chunk_transfer() ? {
 	x := http.get('http://127.0.0.1:$sport/chunk') or { panic(err) }
 	assert_common_http_headers(x) ?
-	assert x.headers.get(.transfer_encoding) ? == 'chunked'
+	assert x.header.get(.transfer_encoding) ? == 'chunked'
 	assert x.text == 'Lorem ipsum dolor sit amet, consetetur sadipscing'
 }
 
@@ -144,14 +144,14 @@ fn test_http_client_404() ? {
 fn test_http_client_simple() ? {
 	x := http.get('http://127.0.0.1:$sport/simple') or { panic(err) }
 	assert_common_http_headers(x) ?
-	assert x.headers.get(.content_type) ? == 'text/plain'
+	assert x.header.get(.content_type) ? == 'text/plain'
 	assert x.text == 'A simple result'
 }
 
 fn test_http_client_html_page() ? {
 	x := http.get('http://127.0.0.1:$sport/html_page') or { panic(err) }
 	assert_common_http_headers(x) ?
-	assert x.headers.get(.content_type) ? == 'text/html'
+	assert x.header.get(.content_type) ? == 'text/html'
 	assert x.text == '<h1>ok</h1>'
 }
 
@@ -193,7 +193,7 @@ fn test_http_client_json_post() ? {
 	$if debug_net_socket_client ? {
 		eprintln('/json_echo endpoint response: $x')
 	}
-	assert x.headers.get(.content_type) ? == 'application/json'
+	assert x.header.get(.content_type) ? == 'application/json'
 	assert x.text == json_for_ouser
 	nuser := json.decode(User, x.text) or { User{} }
 	assert '$ouser' == '$nuser'
@@ -202,7 +202,7 @@ fn test_http_client_json_post() ? {
 	$if debug_net_socket_client ? {
 		eprintln('/json endpoint response: $x')
 	}
-	assert x.headers.get(.content_type) ? == 'application/json'
+	assert x.header.get(.content_type) ? == 'application/json'
 	assert x.text == json_for_ouser
 	nuser2 := json.decode(User, x.text) or { User{} }
 	assert '$ouser' == '$nuser2'

--- a/vlib/vweb/tests/vweb_test_server.v
+++ b/vlib/vweb/tests/vweb_test_server.v
@@ -81,7 +81,7 @@ pub fn (mut app App) user_repo_settings(username string, repository string) vweb
 ['/json_echo'; post]
 pub fn (mut app App) json_echo() vweb.Result {
 	// eprintln('>>>>> received http request at /json_echo is: $app.req')
-	app.set_content_type(app.req.headers['Content-Type'])
+	app.set_content_type(app.req.headers.get(.content_type) or { '' })
 	return app.ok(app.req.data)
 }
 
@@ -89,7 +89,7 @@ pub fn (mut app App) json_echo() vweb.Result {
 [post]
 pub fn (mut app App) json() vweb.Result {
 	// eprintln('>>>>> received http request at /json is: $app.req')
-	app.set_content_type(app.req.headers['Content-Type'])
+	app.set_content_type(app.req.headers.get(.content_type) or { '' })
 	return app.ok(app.req.data)
 }
 

--- a/vlib/vweb/tests/vweb_test_server.v
+++ b/vlib/vweb/tests/vweb_test_server.v
@@ -81,7 +81,7 @@ pub fn (mut app App) user_repo_settings(username string, repository string) vweb
 ['/json_echo'; post]
 pub fn (mut app App) json_echo() vweb.Result {
 	// eprintln('>>>>> received http request at /json_echo is: $app.req')
-	app.set_content_type(app.req.headers.get(.content_type) or { '' })
+	app.set_content_type(app.req.header.get(.content_type) or { '' })
 	return app.ok(app.req.data)
 }
 
@@ -89,7 +89,7 @@ pub fn (mut app App) json_echo() vweb.Result {
 [post]
 pub fn (mut app App) json() vweb.Result {
 	// eprintln('>>>>> received http request at /json is: $app.req')
-	app.set_content_type(app.req.headers.get(.content_type) or { '' })
+	app.set_content_type(app.req.header.get(.content_type) or { '' })
 	return app.ok(app.req.data)
 }
 

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -281,7 +281,7 @@ pub fn (mut ctx Context) add_header(key string, val string) {
 
 // Returns the header data from the key
 pub fn (ctx &Context) get_header(key string) string {
-	return ctx.req.lheaders[key.to_lower()]
+	return ctx.req.headers.get_str(key) or { '' }
 }
 
 pub fn run<T>(port int) {
@@ -333,8 +333,8 @@ fn handle_conn<T>(mut conn net.TcpConn, mut app T) {
 		page_gen_start: page_gen_start
 	}
 	if req.method in vweb.methods_with_form {
-		if 'multipart/form-data' in req.lheaders['content-type'].split('; ') {
-			boundary := req.lheaders['content-type'].split('; ').filter(it.starts_with('boundary='))
+		if 'multipart/form-data' in req.headers.values(.content_type) {
+			boundary := req.headers.values(.content_type).filter(it.starts_with('boundary='))
 			if boundary.len != 1 {
 				send_string(mut conn, vweb.http_400) or {}
 				return
@@ -575,9 +575,9 @@ pub fn (mut ctx Context) serve_static(url string, file_path string, mime_type st
 
 // Returns the ip address from the current user
 pub fn (ctx &Context) ip() string {
-	mut ip := ctx.req.lheaders['x-forwarded-for']
+	mut ip := ctx.req.headers.get(.x_forwarded_for) or { '' }
 	if ip == '' {
-		ip = ctx.req.lheaders['x-real-ip']
+		ip = ctx.req.headers.get_str('X-Real-Ip') or { '' }
 	}
 
 	if ip.contains(',') {

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -281,7 +281,7 @@ pub fn (mut ctx Context) add_header(key string, val string) {
 
 // Returns the header data from the key
 pub fn (ctx &Context) get_header(key string) string {
-	return ctx.req.header.get_str(key) or { '' }
+	return ctx.req.header.get_custom(key) or { '' }
 }
 
 pub fn run<T>(port int) {
@@ -577,7 +577,7 @@ pub fn (mut ctx Context) serve_static(url string, file_path string, mime_type st
 pub fn (ctx &Context) ip() string {
 	mut ip := ctx.req.header.get(.x_forwarded_for) or { '' }
 	if ip == '' {
-		ip = ctx.req.header.get_str('X-Real-Ip') or { '' }
+		ip = ctx.req.header.get_custom('X-Real-Ip') or { '' }
 	}
 
 	if ip.contains(',') {

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -281,7 +281,7 @@ pub fn (mut ctx Context) add_header(key string, val string) {
 
 // Returns the header data from the key
 pub fn (ctx &Context) get_header(key string) string {
-	return ctx.req.headers.get_str(key) or { '' }
+	return ctx.req.header.get_str(key) or { '' }
 }
 
 pub fn run<T>(port int) {
@@ -333,8 +333,8 @@ fn handle_conn<T>(mut conn net.TcpConn, mut app T) {
 		page_gen_start: page_gen_start
 	}
 	if req.method in vweb.methods_with_form {
-		if 'multipart/form-data' in req.headers.values(.content_type) {
-			boundary := req.headers.values(.content_type).filter(it.starts_with('boundary='))
+		if 'multipart/form-data' in req.header.values(.content_type) {
+			boundary := req.header.values(.content_type).filter(it.starts_with('boundary='))
 			if boundary.len != 1 {
 				send_string(mut conn, vweb.http_400) or {}
 				return
@@ -575,9 +575,9 @@ pub fn (mut ctx Context) serve_static(url string, file_path string, mime_type st
 
 // Returns the ip address from the current user
 pub fn (ctx &Context) ip() string {
-	mut ip := ctx.req.headers.get(.x_forwarded_for) or { '' }
+	mut ip := ctx.req.header.get(.x_forwarded_for) or { '' }
 	if ip == '' {
-		ip = ctx.req.headers.get_str('X-Real-Ip') or { '' }
+		ip = ctx.req.header.get_str('X-Real-Ip') or { '' }
 	}
 
 	if ip.contains(',') {


### PR DESCRIPTION
This PR replaces `headers map[string]string` and `lheaders map[string]string` in http with the already implemented `Header` struct.