### PR TITLE
Boehm-GC: add `-gc boehm_leak` for leak detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,21 @@ jobs:
       - name: Self tests with `-gc boehm`
         ## The test cases are run with non-gc `v` for now
         run: ./v -gc boehm -silent test-self
+      - name: Test leak detector
+        run: |
+          ./v -gc boehm_leak -o testcase_leak vlib/v/tests/testcase_leak.v
+          ./testcase_leak 2>leaks.txt
+          grep "Found 1 leaked object" leaks.txt && grep ", sz=1000," leaks.txt
+      - name: Test leak detector not being active for `-gc boehm`
+        run: |
+          ./v -gc boehm -o testcase_leak vlib/v/tests/testcase_leak.v
+          ./testcase_leak 2>leaks.txt
+          [ "$(stat -c %s leaks.txt)" = "0" ]
+      - name: Test leak detector not being active for normal compile
+        run: |
+          ./v -o testcase_leak vlib/v/tests/testcase_leak.v
+          ./testcase_leak 2>leaks.txt
+          [ "$(stat -c %s leaks.txt)" = "0" ]
 
   misc-tooling:
     runs-on: ubuntu-20.04

--- a/cmd/v/help/build-c.txt
+++ b/cmd/v/help/build-c.txt
@@ -86,7 +86,7 @@ see also `v help build`.
       collection pauses from time to time *do not matter much*.
 
       The option `-gc boehm_leak` is intended for leak detection in
-      manual memory management. The function `gcboehm_check_leaks()`
+      manual memory management. The function `gc_check_leaks()`
       can be called to get detection results. This function is a no-op
       when `-gc boehm_leak` is not supplied.
 

--- a/cmd/v/help/build-c.txt
+++ b/cmd/v/help/build-c.txt
@@ -72,17 +72,23 @@ see also `v help build`.
       
    -gc <mode>
       Use and link an optional garbage collector. 
-      Only `-gc boehm` is supported currently. You need to install a
-      `libgc-dev` package first, or install it manually from source: 
+      Only `-gc boehm` and `-gc boehm_leak` are supported currently.
+      You need to install a `libgc-dev` package first, or install it manually
+      from source: 
           https://github.com/ivmai/bdwgc
           
-      Note, this option is complementary to -autofree. The Boehm garbage
+      Note, `-gc boehm` is complementary to -autofree. The Boehm garbage
       collector is conservative, and it may make your program significantly
       slower if it does many small allocations in a loop. This option
       is intended *mainly* for reducing the memory usage of programs, that
       process large amounts of text in *batch mode* on low/limited memory 
       environments like small VPSes, and for which a few ms of garbage
       collection pauses from time to time *do not matter much*.
+
+      The option `-gc boehm_leak` is intended for leak detection in
+      manual memory management. The function `gcboehm_check_leaks()`
+      can be called to get detection results. This function is a no-op
+      when `-gc boehm_leak` is not supplied.
 
 # Miscellaneous:
    -printfn <fn_name>

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -315,9 +315,14 @@ pub fn free(ptr voidptr) {
 		return
 	}
 	$if gcboehm ? {
-		// It is better to leave it to Boehm's gc to free things.
+		// It is generally better to leave it to Boehm's gc to free things.
 		// Calling C.GC_FREE(ptr) was tried initially, but does not work
 		// well with programs that do manual management themselves.
+		//
+		// The exception is doing leak detection for manual memory management:
+		$if gcboehm_leak ? {
+			C.GC_FREE(ptr)
+		}
 		return
 	}
 	C.free(ptr)

--- a/vlib/builtin/builtin_d_gcboehm.v
+++ b/vlib/builtin/builtin_d_gcboehm.v
@@ -24,6 +24,12 @@ fn C.GC_set_find_leak(int)
 
 fn C.GC_gcollect()
 
+fn C.GC_disable()
+
+fn C.GC_is_disabled() int
+
+fn C.GC_enable()
+
 fn gcboehm_check_leaks() {
 	$if gcboehm_leak ? {
 		C.GC_gcollect()

--- a/vlib/builtin/builtin_d_gcboehm.v
+++ b/vlib/builtin/builtin_d_gcboehm.v
@@ -39,7 +39,7 @@ fn C.GC_enable()
 fn C.GC_is_disabled() int
 
 // for leak detection it is advisable to do explicit garbage collections
-pub fn gcboehm_check_leaks() {
+pub fn gc_check_leaks() {
 	$if gcboehm_leak ? {
 		C.GC_gcollect()
 	}

--- a/vlib/builtin/builtin_d_gcboehm.v
+++ b/vlib/builtin/builtin_d_gcboehm.v
@@ -39,7 +39,7 @@ fn C.GC_enable()
 fn C.GC_is_disabled() int
 
 // for leak detection it is advisable to do explicit garbage collections
-fn gcboehm_check_leaks() {
+pub fn gcboehm_check_leaks() {
 	$if gcboehm_leak ? {
 		C.GC_gcollect()
 	}

--- a/vlib/builtin/builtin_d_gcboehm.v
+++ b/vlib/builtin/builtin_d_gcboehm.v
@@ -22,5 +22,10 @@ fn C.GC_FREE(ptr voidptr)
 
 fn C.GC_set_find_leak(int)
 
-// fn C.CHECK_LEAKS()
 fn C.GC_gcollect()
+
+fn gcboehm_check_leaks() {
+	$if gcboehm_leak ? {
+		C.GC_gcollect()
+	}
+}

--- a/vlib/builtin/builtin_d_gcboehm.v
+++ b/vlib/builtin/builtin_d_gcboehm.v
@@ -9,7 +9,9 @@ $if windows {
 $if macos {
 	#pkgconfig bdw-gc
 }
-
+$if gcboehm_leak ? {
+	#define GC_DEBUG
+}
 #include <gc.h>
 
 #flag -lgc

--- a/vlib/builtin/builtin_d_gcboehm.v
+++ b/vlib/builtin/builtin_d_gcboehm.v
@@ -9,9 +9,7 @@ $if windows {
 $if macos {
 	#pkgconfig bdw-gc
 }
-$if gcboehm_leak ? {
-	#define GC_DEBUG
-}
+
 #include <gc.h>
 
 #flag -lgc

--- a/vlib/builtin/builtin_d_gcboehm.v
+++ b/vlib/builtin/builtin_d_gcboehm.v
@@ -14,22 +14,29 @@ $if macos {
 
 #flag -lgc
 
+// replacements for `malloc()/calloc()`, `realloc()` and `free()`
+// for use with Boehm-GC
+// Do not use them manually. They are automatically chosen when
+// compiled with `-gc boehm` or `-gc boehm_leak`.
 fn C.GC_MALLOC(n size_t) voidptr
 
 fn C.GC_REALLOC(ptr voidptr, n size_t) voidptr
 
 fn C.GC_FREE(ptr voidptr)
 
-fn C.GC_set_find_leak(int)
-
+// explicitely perform garbage collection now! Garbage collections
+// are done automatically when needed, so this function is hardly needed 
 fn C.GC_gcollect()
 
+// functions to temporarily suspend/resume garbage collection
 fn C.GC_disable()
-
-fn C.GC_is_disabled() int
 
 fn C.GC_enable()
 
+// returns non-zero if GC is disabled
+fn C.GC_is_disabled() int
+
+// for leak detection it is advisable to do explicit garbage collections
 fn gcboehm_check_leaks() {
 	$if gcboehm_leak ? {
 		C.GC_gcollect()

--- a/vlib/builtin/builtin_notd_gcboehm.v
+++ b/vlib/builtin/builtin_notd_gcboehm.v
@@ -1,5 +1,15 @@
 module builtin
 
+// Just define the C functions, so that V does not error because of the missing definitions.
+
+// NB: they will NOT be used, since calls to them are wrapped with `$if gcboehm ? { }`
+
+fn C.GC_MALLOC(n size_t) voidptr
+
+fn C.GC_REALLOC(ptr voidptr, n size_t) voidptr
+
+fn C.GC_FREE(ptr voidptr)
+
 // provide an empty function when manual memory management is used
 // to simplify leak detection
 //

--- a/vlib/builtin/builtin_notd_gcboehm.v
+++ b/vlib/builtin/builtin_notd_gcboehm.v
@@ -12,4 +12,10 @@ fn C.GC_FREE(ptr voidptr)
 
 fn C.GC_gcollect()
 
+fn C.GC_disable()
+
+fn C.GC_is_disabled() int
+
+fn C.GC_enable()
+
 fn gcboehm_check_leaks() {}

--- a/vlib/builtin/builtin_notd_gcboehm.v
+++ b/vlib/builtin/builtin_notd_gcboehm.v
@@ -10,5 +10,6 @@ fn C.GC_REALLOC(ptr voidptr, n size_t) voidptr
 
 fn C.GC_FREE(ptr voidptr)
 
-// fn C.CHECK_LEAKS()
 fn C.GC_gcollect()
+
+fn gcboehm_check_leaks() {}

--- a/vlib/builtin/builtin_notd_gcboehm.v
+++ b/vlib/builtin/builtin_notd_gcboehm.v
@@ -13,4 +13,4 @@ fn C.GC_FREE(ptr voidptr)
 // provide an empty function when manual memory management is used
 // to simplify leak detection
 //
-pub fn gcboehm_check_leaks() {}
+pub fn gc_check_leaks() {}

--- a/vlib/builtin/builtin_notd_gcboehm.v
+++ b/vlib/builtin/builtin_notd_gcboehm.v
@@ -13,4 +13,4 @@ fn C.GC_FREE(ptr voidptr)
 // provide an empty function when manual memory management is used
 // to simplify leak detection
 //
-fn gcboehm_check_leaks() {}
+pub fn gcboehm_check_leaks() {}

--- a/vlib/builtin/builtin_notd_gcboehm.v
+++ b/vlib/builtin/builtin_notd_gcboehm.v
@@ -1,21 +1,6 @@
 module builtin
 
-// Just define the C functions, so that V does not error because of the missing definitions.
-
-// NB: they will NOT be used, since calls to them are wrapped with `$if gcboehm ? { }`
-
-fn C.GC_MALLOC(n size_t) voidptr
-
-fn C.GC_REALLOC(ptr voidptr, n size_t) voidptr
-
-fn C.GC_FREE(ptr voidptr)
-
-fn C.GC_gcollect()
-
-fn C.GC_disable()
-
-fn C.GC_is_disabled() int
-
-fn C.GC_enable()
-
+// provide an empty function when manual memory management is used
+// to simplify leak detection
+//
 fn gcboehm_check_leaks() {}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -423,7 +423,7 @@ pub fn (mut g Gen) init() {
 		}
 		g.comptime_defines.writeln('')
 	}
-	if g.pref.gc_mode == .boehm {
+	if g.pref.gc_mode in [.boehm, .boehm_leak] {
 		g.comptime_defines.writeln('#define _VGCBOEHM (1)')
 	}
 	if g.pref.is_debug || 'debug' in g.pref.compile_defines {

--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -67,8 +67,11 @@ fn (mut g Gen) gen_c_main_function_header() {
 
 fn (mut g Gen) gen_c_main_header() {
 	g.gen_c_main_function_header()
-	if g.pref.gc_mode == .boehm {
+	if g.pref.gc_mode in [.boehm, .boehm_leak] {
 		g.writeln('#if defined(_VGCBOEHM)')
+		if g.pref.gc_mode == .boehm_leak {
+			g.writeln('\tGC_set_find_leak(1);')
+		}
 		g.writeln('\tGC_INIT();')
 		g.writeln('#endif')
 	}
@@ -155,8 +158,11 @@ pub fn (mut g Gen) gen_c_main_for_tests() {
 	main_fn_start_pos := g.out.len
 	g.writeln('')
 	g.gen_c_main_function_header()
-	if g.pref.gc_mode == .boehm {
+	if g.pref.gc_mode in [.boehm, .boehm_leak] {
 		g.writeln('#if defined(_VGCBOEHM)')
+		if g.pref.gc_mode == .boehm_leak {
+			g.writeln('\tGC_set_find_leak(1);')
+		}
 		g.writeln('\tGC_INIT();')
 		g.writeln('#endif')
 	}

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -20,6 +20,7 @@ pub enum BuildMode {
 pub enum GarbageCollectionMode {
 	no_gc
 	boehm
+	boehm_leak
 }
 
 pub enum OutputMode {
@@ -229,6 +230,11 @@ pub fn parse_args(known_external_commands []string, args []string) (&Preferences
 					'boehm' {
 						res.gc_mode = .boehm
 						parse_define(mut res, 'gcboehm')
+					}
+					'boehm_leak' {
+						res.gc_mode = .boehm
+						parse_define(mut res, 'gcboehm')
+						parse_define(mut res, 'gcboehm_leak')
 					}
 					else {
 						eprintln('unknown garbage collection mode, only `-gc boehm` is supported')

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -159,7 +159,7 @@ pub mut:
 	build_options       []string // list of options, that should be passed down to `build-module`, if needed for -usecache
 	cache_manager       vcache.CacheManager
 	is_help             bool // -h, -help or --help was passed
-	gc_mode             GarbageCollectionMode = .no_gc // .no_gc, .boehm
+	gc_mode             GarbageCollectionMode = .no_gc // .no_gc, .boehm, .boehm_leak
 	// checker settings:
 	checker_match_exhaustive_cutoff_limit int = 10
 }

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -232,12 +232,12 @@ pub fn parse_args(known_external_commands []string, args []string) (&Preferences
 						parse_define(mut res, 'gcboehm')
 					}
 					'boehm_leak' {
-						res.gc_mode = .boehm
+						res.gc_mode = .boehm_leak
 						parse_define(mut res, 'gcboehm')
 						parse_define(mut res, 'gcboehm_leak')
 					}
 					else {
-						eprintln('unknown garbage collection mode, only `-gc boehm` is supported')
+						eprintln('unknown garbage collection mode, only `-gc boehm` and `-gc boehm_leak` are supported')
 						exit(1)
 					}
 				}

--- a/vlib/v/tests/testcase_leak.v
+++ b/vlib/v/tests/testcase_leak.v
@@ -1,0 +1,12 @@
+// This program is supposed to test the leak detector which
+// is integrated with `-gc boehm_leak` at compile time.
+//
+// If compiled with `-gc boehm` or without `-gc` nothing
+// will be reported.
+
+fn main() {
+	mut y := unsafe { malloc(1000) }
+	// unsafe { free(y) } // leak if commented out
+	y = voidptr(0)
+	gcboehm_check_leaks()
+}

--- a/vlib/v/tests/testcase_leak.v
+++ b/vlib/v/tests/testcase_leak.v
@@ -8,5 +8,5 @@ fn main() {
 	mut y := unsafe { malloc(1000) }
 	// unsafe { free(y) } // leak if commented out
 	y = voidptr(0)
-	gcboehm_check_leaks()
+	gc_check_leaks()
 }


### PR DESCRIPTION
Boehm-GC can be used for leak detection to debug memory management, even when automatic garbage collection is not intended. This PR adds:

- a command line option `-gc boehm_leak` to compile for leak detection
- a built-in function `gc_check_leaks()` that can be called to check for leaked memoy

Example:
```v
fn main() {
    mut y := unsafe { malloc(1000) }
    // unsafe { free(y) } // leak if commented out
    y = voidptr(0)
    gc_check_leaks()
}
```
When compiled with `v -gc boehm_leak file.v` and run it produces the following output on `stderr`:
```
Found 1 leaked objects:
0x187faa0 (/tmp/v/file.17546374167919862936.tmp.c:5666, sz=1000, NORMAL)
```
When compiled without GC option or with `-gc boehm` the function `gc_check_leaks()` is just a no-op.

Edit: renamed `gcboehm_check_leaks()` -> `gc_check_leaks()` as suggested below by @medvednikov.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
