### PR TITLE
cgen: fix c error when using `dump(ptr)`

### DIFF
--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -1,6 +1,7 @@
 module c
 
 import v.ast
+import v.table
 
 fn (mut g Gen) dump_expr(node ast.DumpExpr) {
 	sexpr := ctoslit(node.expr.str())
@@ -10,28 +11,41 @@ fn (mut g Gen) dump_expr(node ast.DumpExpr) {
 		g.expr(node.expr)
 		return
 	}
-	g.write(' _v_dump_expr_${node.cname}(${ctoslit(fpath)}, $line, $sexpr, ')
+	dump_fn_name := '_v_dump_expr_$node.cname' + (if node.expr_type.is_ptr() { '_ptr' } else { '' })
+	g.write(' ${dump_fn_name}(${ctoslit(fpath)}, $line, $sexpr, ')
 	g.expr(node.expr)
 	g.write(' )')
 }
 
 fn (mut g Gen) dump_expr_definitions() {
 	if g.pref.build_mode == .build_module {
-		for _, cname in g.table.dumps {
-			g.definitions.writeln('$cname _v_dump_expr_${cname}(string fpath, int line, string sexpr, $cname x);')
+		for dump_type, cname in g.table.dumps {
+			is_ptr := table.Type(dump_type).is_ptr()
+			ptr_suffix := if is_ptr { '*' } else { '' }
+			dump_fn_name := '_v_dump_expr_$cname' + (if is_ptr { '_ptr' } else { '' })
+			g.definitions.writeln('$cname$ptr_suffix ${dump_fn_name}(string fpath, int line, string sexpr, $cname$ptr_suffix x) {')
 		}
 	} else {
 		for dump_type, cname in g.table.dumps {
 			to_string_fn_name := g.gen_str_for_type(dump_type)
-			g.definitions.writeln('$cname _v_dump_expr_${cname}(string fpath, int line, string sexpr, $cname x) {')
+			is_ptr := table.Type(dump_type).is_ptr()
+			ptr_astarisk := if is_ptr { '*' } else { '' }
+			dump_fn_name := '_v_dump_expr_$cname' + (if is_ptr { '_ptr' } else { '' })
+			g.definitions.writeln('$cname$ptr_astarisk ${dump_fn_name}(string fpath, int line, string sexpr, $cname$ptr_astarisk x) {')
 			g.definitions.writeln('\teprint(${ctoslit('[')});')
 			g.definitions.writeln('\teprint(fpath);')
 			g.definitions.writeln('\teprint(${ctoslit(':')});')
 			g.definitions.writeln('\teprint(int_str(line));')
 			g.definitions.writeln('\teprint(${ctoslit('] ')});')
+
 			g.definitions.writeln('\teprint(sexpr);')
 			g.definitions.writeln('\teprint(${ctoslit(': ')});')
-			g.definitions.writeln('\teprintln(${to_string_fn_name}(x));')
+
+			if is_ptr {
+				g.definitions.writeln('\teprint(${ctoslit('&')});')
+			}
+			g.definitions.writeln('\teprintln(${to_string_fn_name}(${ptr_astarisk}x));')
+
 			g.definitions.writeln('\treturn x;')
 			g.definitions.writeln('}')
 		}

--- a/vlib/v/tests/inout/dump_expression.out
+++ b/vlib/v/tests/inout/dump_expression.out
@@ -1,6 +1,16 @@
 [vlib/v/tests/inout/dump_expression.vv:2] 1: 1
 [vlib/v/tests/inout/dump_expression.vv:7] 'a': a
-[vlib/v/tests/inout/dump_expression.vv:20] point: Point{
+[vlib/v/tests/inout/dump_expression.vv:23] p: Point{
+    x: 1
+    y: 2
+    z: 3
+}
+[vlib/v/tests/inout/dump_expression.vv:24] p_mut: Point{
+    x: 1
+    y: 2
+    z: 3
+}
+[vlib/v/tests/inout/dump_expression.vv:25] p_ptr: &Point{
     x: 1
     y: 2
     z: 3

--- a/vlib/v/tests/inout/dump_expression.vv
+++ b/vlib/v/tests/inout/dump_expression.vv
@@ -16,10 +16,19 @@ mut:
 }
 
 fn dump_of_struct() {
-	point := Point{1, 2, 3}
-	mut x := dump(point)
-	x.x += 100
-	assert x == Point{101, 2, 3}
+	p := Point{1, 2, 3}
+	mut p_mut := Point{1, 2, 3}
+	p_ptr := &Point{1, 2, 3}
+
+	mut x1 := dump(p)
+	mut x2 := dump(p_mut)
+	mut x3 := dump(p_ptr)
+	x1.x += 100
+	x2.x += 100
+	x3.x += 100
+	assert x1 == Point{101, 2, 3}
+	assert x2 == Point{101, 2, 3}
+	assert x3 == Point{101, 2, 3}
 }
 
 fn main() {


### PR DESCRIPTION
Currently `dump(ptr)` will crash
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
