### PR TITLE
generics: fix generics fn return generics struct (#9409)

### DIFF
--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -502,6 +502,11 @@ pub fn (mut p Parser) parse_generic_struct_inst_type(name string) table.Type {
 			}
 		})
 		return table.new_type(idx)
+	} else {
+		idx := p.table.find_type_idx(name)
+		if idx != 0 {
+			return table.new_type(idx).set_flag(.generic)
+		}
 	}
 	return p.parse_enum_or_struct_type(name, .v)
 }

--- a/vlib/v/tests/generics_return_generics_struct_test.v
+++ b/vlib/v/tests/generics_return_generics_struct_test.v
@@ -1,0 +1,31 @@
+pub struct Optional<T> {
+mut:
+	value T
+	some bool
+}
+
+pub fn new_some<T>(value T) Optional<T> {
+	return {value: value, some: true}
+}
+
+pub fn some<T>(opt Optional<T>) bool {
+	return opt.some
+}
+
+pub fn get<T>(opt Optional<T>) T {
+	return opt.value
+}
+
+pub fn set<T>(mut opt Optional<T>, value T) {
+	opt.value = value
+	opt.some = true
+}
+
+fn test_generics_return_generics_struct() {
+	mut o := new_some<int>(23)
+	println(some<int>(o))
+	assert some<int>(o) == true
+	set<int>(mut o, 42)
+	println(get<int>(o))
+	assert get<int>(o) == 42
+}


### PR DESCRIPTION
This PR fix generics fn return generics struct (fix #9409).

- Fix generics fn return generics struct.
- Add test.

```vlang
module main

pub struct Optional<T> {
mut:
	value T
	some bool
}

pub fn new_some<T>(value T) Optional<T> {
	return {value: value, some: true}
}

pub fn some<T>(opt Optional<T>) bool {
	return opt.some
}

pub fn get<T>(opt Optional<T>) T {
	return opt.value
}

pub fn set<T>(mut opt Optional<T>, value T) {
	opt.value = value
	opt.some = true
}

fn main() {
	mut o := new_some<int>(23)
	println(some<int>(o))
	set<int>(mut o, 42)
	println(get<int>(o))
}

D:\Test\v\tt1>v run .
true
42
```