### PR TITLE
cmd/tools/vdoc: support `v doc -os os module`and show docs according to the plaform

### DIFF
--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -57,6 +57,7 @@ mut:
 	output_type      OutputType = .unset
 	input_path       string
 	symbol_name      string
+	os               string
 }
 
 //
@@ -292,7 +293,7 @@ fn (mut vd VDoc) generate_docs_from_file() {
 	}
 	for dirpath in dirs {
 		vd.vprintln('Generating $out.typ docs for "$dirpath"')
-		mut dcs := doc.generate(dirpath, cfg.pub_only, true, cfg.symbol_name) or {
+		mut dcs := doc.generate(dirpath, cfg.pub_only, true, cfg.os, cfg.symbol_name) or {
 			vd.emit_generate_err(err)
 			exit(1)
 		}
@@ -417,6 +418,11 @@ fn parse_arguments(args []string) Config {
 			'-o' {
 				opath := cmdline.option(current_args, '-o', '')
 				cfg.output_path = if opath == 'stdout' { opath } else { os.real_path(opath) }
+				i++
+			}
+			'-os' {
+				os := cmdline.option(current_args, '-os', '')
+				cfg.os = os
 				i++
 			}
 			'-no-timestamp' {

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -600,3 +600,12 @@ pub fn (mut f File) write_raw_at<T>(t &T, pos int) ? {
 		return error_with_code('incomplete struct write', nbytes)
 	}
 }
+
+pub fn (mut f File) close() {
+	if !f.is_opened {
+		return
+	}
+	f.is_opened = false
+	C.fflush(f.cfile)
+	C.fclose(f.cfile)
+}

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -600,12 +600,3 @@ pub fn (mut f File) write_raw_at<T>(t &T, pos int) ? {
 		return error_with_code('incomplete struct write', nbytes)
 	}
 }
-
-pub fn (mut f File) close() {
-	if !f.is_opened {
-		return
-	}
-	f.is_opened = false
-	C.fflush(f.cfile)
-	C.fclose(f.cfile)
-}

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -69,11 +69,11 @@ pub fn platform_from_string(platform_str string) ?Platform {
 
 pub fn platform_from_filename(filename string) Platform {
 	suffix := filename.all_after_last('_').all_before('.c.v')
-	mut plf := platform_from_string(suffix) or { Platform.cross }
-	if plf == .auto {
-		plf = .cross
+	mut platform := platform_from_string(suffix) or { Platform.cross }
+	if platform == .auto {
+		platform = .cross
 	}
-	return plf
+	return platform
 }
 
 pub fn (sk SymbolKind) str() string {

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -27,6 +27,53 @@ pub enum SymbolKind {
 	struct_
 	struct_field
 }
+pub enum Platform {
+	auto
+	ios
+	macos
+	linux
+	windows
+	freebsd
+	openbsd
+	netbsd
+	dragonfly
+	js // for interoperability in prefs.OS
+	android
+	solaris
+	haiku
+	cross
+}
+
+// copy of pref.os_from_string
+pub fn platform_from_string(platform_str string) ?Platform {
+	match platform_str {
+		'all', 'cross' { return .cross }
+		'linux' { return .linux }
+		'windows' { return .windows }
+		'ios' { return .ios }
+		'macos' { return .macos }
+		'freebsd' { return .freebsd }
+		'openbsd' { return .openbsd }
+		'netbsd' { return .netbsd }
+		'dragonfly' { return .dragonfly }
+		'js' { return .js }
+		'solaris' { return .solaris }
+		'android' { return .android }
+		'haiku' { return .haiku }
+		'linux_or_macos', 'nix' { return .linux }
+		'' { return .auto }
+		else { return error('vdoc: invalid platform `$platform_str`') }
+	}
+}
+
+pub fn platform_from_filename(filename string) Platform {
+	suffix := filename.all_after_last('_').all_before('.c.v')
+	mut plf := platform_from_string(suffix) or { Platform.cross }
+	if plf == .auto {
+		plf = .cross
+	}
+	return plf
+}
 
 pub fn (sk SymbolKind) str() string {
 	return match sk {
@@ -66,7 +113,8 @@ pub mut:
 	orig_mod_name       string
 	extract_vars        bool
 	filter_symbol_names []string
-	os                  string
+	common_symbols      []string
+	platform            Platform
 }
 
 pub struct DocNode {
@@ -84,6 +132,7 @@ pub mut:
 	attrs       map[string]string [json: attributes]
 	from_scope  bool
 	is_pub      bool              [json: public]
+	platform    Platform
 }
 
 // new_vdoc_preferences creates a new instance of pref.Preferences tailored for v.doc.
@@ -121,12 +170,21 @@ pub fn new(input_path string) Doc {
 // An option error is thrown if the symbol is not exposed to the public
 // (when `pub_only` is enabled) or the content's of the AST node is empty.
 pub fn (mut d Doc) stmt(stmt ast.Stmt, filename string) ?DocNode {
+	mut name := d.stmt_name(stmt)
+	if name in d.common_symbols {
+		return error('already documented')
+	}
+	//println('mod: $d.orig_mod_name')
+	if name.starts_with(d.orig_mod_name + '.') {
+		name = name.all_after(d.orig_mod_name + '.')
+	}
 	mut node := DocNode{
-		name: d.stmt_name(stmt)
+		name: name
 		content: d.stmt_signature(stmt)
 		pos: stmt.pos
 		file_path: os.join_path(d.base_path, filename)
 		is_pub: d.stmt_pub(stmt)
+		platform: platform_from_filename(filename)
 	}
 	if (!node.is_pub && d.pub_only) || stmt is ast.GlobalDecl {
 		return error('symbol $node.name not public')
@@ -228,6 +286,9 @@ pub fn (mut d Doc) stmt(stmt ast.Stmt, filename string) ?DocNode {
 	included := node.name in d.filter_symbol_names || node.parent_name in d.filter_symbol_names
 	if d.filter_symbol_names.len != 0 && !included {
 		return error('not included in the list of symbol names')
+	}
+	if d.prefs.os == .all {
+		d.common_symbols << node.name
 	}
 	return node
 }
@@ -432,14 +493,19 @@ pub fn (mut d Doc) file_asts(file_asts []ast.File) ? {
 
 // generate documents a certain file directory and returns an
 // instance of `Doc` if it is successful. Otherwise, it will  throw an error.
-pub fn generate(input_path string, pub_only bool, with_comments bool, os_ string, filter_symbol_names ...string) ?Doc {
+pub fn generate(input_path string, pub_only bool, with_comments bool, platform Platform, filter_symbol_names ...string) ?Doc {
+	if platform == .js {
+		return error('vdoc: Platform `${platform}` is not supported.')
+	}
 	mut doc := new(input_path)
 	doc.pub_only = pub_only
 	doc.with_comments = with_comments
 	doc.filter_symbol_names = filter_symbol_names.filter(it.len != 0)
-	if os_ != '' {
-		doc.prefs.os = pref.os_from_string(os_) or { pref.get_host_os() }
-	}
+	doc.prefs.os = if platform == .auto {
+		pref.get_host_os()
+	} else {
+		pref.OS(int(platform))
+ 	}
 	doc.generate() ?
 	return doc
 }

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -27,6 +27,7 @@ pub enum SymbolKind {
 	struct_
 	struct_field
 }
+
 pub enum Platform {
 	auto
 	ios
@@ -174,7 +175,6 @@ pub fn (mut d Doc) stmt(stmt ast.Stmt, filename string) ?DocNode {
 	if name in d.common_symbols {
 		return error('already documented')
 	}
-	//println('mod: $d.orig_mod_name')
 	if name.starts_with(d.orig_mod_name + '.') {
 		name = name.all_after(d.orig_mod_name + '.')
 	}
@@ -495,17 +495,13 @@ pub fn (mut d Doc) file_asts(file_asts []ast.File) ? {
 // instance of `Doc` if it is successful. Otherwise, it will  throw an error.
 pub fn generate(input_path string, pub_only bool, with_comments bool, platform Platform, filter_symbol_names ...string) ?Doc {
 	if platform == .js {
-		return error('vdoc: Platform `${platform}` is not supported.')
+		return error('vdoc: Platform `$platform` is not supported.')
 	}
 	mut doc := new(input_path)
 	doc.pub_only = pub_only
 	doc.with_comments = with_comments
 	doc.filter_symbol_names = filter_symbol_names.filter(it.len != 0)
-	doc.prefs.os = if platform == .auto {
-		pref.get_host_os()
-	} else {
-		pref.OS(int(platform))
- 	}
+	doc.prefs.os = if platform == .auto { pref.get_host_os() } else { pref.OS(int(platform)) }
 	doc.generate() ?
 	return doc
 }

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -42,7 +42,7 @@ pub enum Platform {
 	android
 	solaris
 	haiku
-	cross
+	cross // TODO: add functionality for v doc -os cross whenever possible
 }
 
 // copy of pref.os_from_string

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -432,15 +432,13 @@ pub fn (mut d Doc) file_asts(file_asts []ast.File) ? {
 
 // generate documents a certain file directory and returns an
 // instance of `Doc` if it is successful. Otherwise, it will  throw an error.
-pub fn generate(input_path string, pub_only bool, with_comments bool, os string, filter_symbol_names ...string) ?Doc {
+pub fn generate(input_path string, pub_only bool, with_comments bool, os_ string, filter_symbol_names ...string) ?Doc {
 	mut doc := new(input_path)
 	doc.pub_only = pub_only
 	doc.with_comments = with_comments
 	doc.filter_symbol_names = filter_symbol_names.filter(it.len != 0)
-	if os == '' {
-		doc.prefs.os = pref.get_host_os()
-	} else {
-		doc.prefs.os = pref.os_from_string(os) or { pref.get_host_os() }
+	if os_ != '' {
+		doc.prefs.os = pref.os_from_string(os_) or { pref.get_host_os() }
 	}
 	doc.generate() ?
 	return doc

--- a/vlib/v/doc/module.v
+++ b/vlib/v/doc/module.v
@@ -87,5 +87,5 @@ pub fn lookup_module(mod string) ?string {
 // generate_from_mod generates a documentation from a specific module.
 pub fn generate_from_mod(module_name string, pub_only bool, with_comments bool) ?Doc {
 	mod_path := lookup_module(module_name) ?
-	return generate(mod_path, pub_only, with_comments, '')
+	return generate(mod_path, pub_only, with_comments, .auto)
 }

--- a/vlib/v/doc/module.v
+++ b/vlib/v/doc/module.v
@@ -87,5 +87,5 @@ pub fn lookup_module(mod string) ?string {
 // generate_from_mod generates a documentation from a specific module.
 pub fn generate_from_mod(module_name string, pub_only bool, with_comments bool) ?Doc {
 	mod_path := lookup_module(module_name) ?
-	return generate(mod_path, pub_only, with_comments)
+	return generate(mod_path, pub_only, with_comments, '')
 }

--- a/vlib/v/pref/os.v
+++ b/vlib/v/pref/os.v
@@ -34,7 +34,7 @@ pub fn os_from_string(os_str string) ?OS {
 		'solaris' { return .solaris }
 		'android' { return .android }
 		'haiku' { return .haiku }
-		'linux_or_macos' { return .linux }
+		'linux_or_macos', 'nix' { return .linux }
 		'' { return ._auto }
 		else { return error('bad OS $os_str') }
 	}

--- a/vlib/v/pref/os.v
+++ b/vlib/v/pref/os.v
@@ -17,6 +17,7 @@ pub enum OS {
 	android
 	solaris
 	haiku
+	all
 }
 
 // Helper function to convert string names to OS enum
@@ -55,6 +56,7 @@ pub fn (o OS) str() string {
 		.android { return 'Android' }
 		.solaris { return 'Solaris' }
 		.haiku { return 'Haiku' }
+		.all { return 'all' }
 	}
 }
 

--- a/vlib/v/pref/should_compile.v
+++ b/vlib/v/pref/should_compile.v
@@ -120,6 +120,9 @@ pub fn (prefs &Preferences) should_compile_c(file string) bool {
 		// Probably something like `a.js.v`.
 		return false
 	}
+	if prefs.os == .all {
+		return true
+	}
 	if (file.ends_with('_windows.c.v') || file.ends_with('_windows.v')) && prefs.os != .windows {
 		return false
 	}


### PR DESCRIPTION
This PR adds support for viewing docs according to the platform and functionality to view docs for other OS via `v doc -os os module`. Previously it used to show docs for `_default.c.v` files so this PR also fixed that.

Screenshots:
![image](https://user-images.githubusercontent.com/28479139/112604817-98f05000-8e3c-11eb-9f1e-e35bd0bc07d6.png)

![image](https://user-images.githubusercontent.com/28479139/112604976-cc32df00-8e3c-11eb-8b8f-39f6488b9f47.png)

![image](https://user-images.githubusercontent.com/28479139/112605017-d8b73780-8e3c-11eb-95b2-074a6203f0e9.png)

![image](https://user-images.githubusercontent.com/28479139/112605107-f1275200-8e3c-11eb-98c4-dc334decb5db.png)

**NOTE**: `v doc -os cross module` is not yet supported due to a parser issue which cannot be tackled right now :/