### PR TITLE
Boehm-GC: fix global `const` handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,9 @@ jobs:
           thirdparty/tcc/tcc.exe -version
           ./v -cg -o v cmd/v # Make sure vtcc can build itself twice
       - name: v self compilation with -gc boehm
-        run: ./v -gc boehm -o v2 cmd/v && ./v2 -gc boehm -o v3 cmd/v && ./v3 -gc boehm -o v4 cmd/v
+        run: |
+          ./v -gc boehm -o v2 cmd/v && ./v2 -gc boehm -o v3 cmd/v && ./v3 -gc boehm -o v4 cmd/v
+          mv v4 v
       - name: v doctor
         run: |
           ./v doctor
@@ -137,8 +139,7 @@ jobs:
         run: |
           ./v -gc boehm cmd/tools/test_if_v_test_system_works.v
           ./cmd/tools/test_if_v_test_system_works
-      - name: Self tests with `-gc boehm`
-        ## The test cases are run with non-gc `v` for now
+      - name: Self tests with `-gc boehm` with V compiler using Boehm-GC itself
         run: ./v -gc boehm -silent test-self
       - name: Test leak detector
         run: |

--- a/vlib/builtin/builtin_d_gcboehm.v
+++ b/vlib/builtin/builtin_d_gcboehm.v
@@ -22,6 +22,8 @@ $if gcboehm_leak ? {
 // compiled with `-gc boehm` or `-gc boehm_leak`.
 fn C.GC_MALLOC(n size_t) voidptr
 
+fn C.GC_MALLOC_UNCOLLECTABLE(n size_t) voidptr
+
 fn C.GC_REALLOC(ptr voidptr, n size_t) voidptr
 
 fn C.GC_FREE(ptr voidptr)

--- a/vlib/builtin/builtin_notd_gcboehm.v
+++ b/vlib/builtin/builtin_notd_gcboehm.v
@@ -6,6 +6,8 @@ module builtin
 
 fn C.GC_MALLOC(n size_t) voidptr
 
+fn C.GC_MALLOC_UNCOLLECTABLE(n size_t) voidptr
+
 fn C.GC_REALLOC(ptr voidptr, n size_t) voidptr
 
 fn C.GC_FREE(ptr voidptr)

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -335,6 +335,9 @@ static inline bool _us64_lt(uint64_t a, int64_t b) { return a < INT64_MAX && (in
 #endif
 
 //================================== GLOBALS =================================*/
+#if defined(_VGCBOEHM)
+	int __v_inside_init = 1;
+#endif
 //byte g_str_buf[1024];
 byte* g_str_buf;
 int load_so(byteptr);

--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -76,6 +76,9 @@ fn (mut g Gen) gen_c_main_header() {
 		g.writeln('#endif')
 	}
 	g.writeln('\t_vinit(___argc, (voidptr)___argv);')
+	if g.pref.gc_mode in [.boehm, .boehm_leak] {
+		g.writeln('\t__v_inside_init = 0;')
+	}
 	if g.pref.is_prof {
 		g.writeln('')
 		g.writeln('\tatexit(vprint_profile_stats);')
@@ -167,6 +170,9 @@ pub fn (mut g Gen) gen_c_main_for_tests() {
 		g.writeln('#endif')
 	}
 	g.writeln('\t_vinit(___argc, (voidptr)___argv);')
+	if g.pref.gc_mode in [.boehm, .boehm_leak] {
+		g.writeln('\t__v_inside_init = 0;')
+	}
 	all_tfuncs := g.get_all_test_function_names()
 	if g.pref.is_stats {
 		g.writeln('\tmain__BenchedTests bt = main__start_testing($all_tfuncs.len, _SLIT("$g.pref.path"));')

--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -77,7 +77,9 @@ fn (mut g Gen) gen_c_main_header() {
 	}
 	g.writeln('\t_vinit(___argc, (voidptr)___argv);')
 	if g.pref.gc_mode in [.boehm, .boehm_leak] {
+		g.writeln('#if defined(_VGCBOEHM)')
 		g.writeln('\t__v_inside_init = 0;')
+		g.writeln('#endif')
 	}
 	if g.pref.is_prof {
 		g.writeln('')
@@ -171,7 +173,9 @@ pub fn (mut g Gen) gen_c_main_for_tests() {
 	}
 	g.writeln('\t_vinit(___argc, (voidptr)___argv);')
 	if g.pref.gc_mode in [.boehm, .boehm_leak] {
+		g.writeln('#if defined(_VGCBOEHM)')
 		g.writeln('\t__v_inside_init = 0;')
+		g.writeln('#endif')
 	}
 	all_tfuncs := g.get_all_test_function_names()
 	if g.pref.is_stats {


### PR DESCRIPTION
Global constants are located in a memory segment that is not scanned by Boehm-GC. For this reason, heap memory that is pointed to by global constants (e.g. `map` or `array` data) looks "unused" for the garbage collector and is freed.

This PR assures that while `_vinit()` is processed heap memory is allocated with `GC_MALLOC_UNCOLLECTABLE()`, so it is never freed.

This allows the CI testcases to be run with `-gc boehm` using a V compiler that uses the Boehm-GC itself. :smiley:
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
