### PR TITLE
parser: fix generic fn with upper name type (#9460)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1710,7 +1710,7 @@ pub fn (mut p Parser) parse_ident(language table.Language) ast.Ident {
 }
 
 fn (p &Parser) is_typename(t token.Token) bool {
-	return t.kind == .name && (t.lit.is_capital() || p.table.known_type(t.lit))
+	return t.kind == .name && (t.lit[0].is_capital() || p.table.known_type(t.lit))
 }
 
 // heuristics to detect `func<T>()` from `var < expr`

--- a/vlib/v/tests/generic_fn_upper_name_type_test.v
+++ b/vlib/v/tests/generic_fn_upper_name_type_test.v
@@ -1,6 +1,10 @@
-struct XX {}
+struct XX {
+	x int
+}
 
-struct YY {}
+struct YY {
+	y int
+}
 
 fn show_result<T, U>(x T, y U) bool {
 	return true

--- a/vlib/v/tests/generic_fn_upper_name_type_test.v
+++ b/vlib/v/tests/generic_fn_upper_name_type_test.v
@@ -1,0 +1,14 @@
+struct XX {}
+
+struct YY {}
+
+fn show_result<T, U>(x T, y U) bool {
+	return true
+}
+
+fn test_generic_fn_upper_name_type() {
+	assert show_result<int, bool>(1,  false)
+	assert show_result<string, XX>( "s",  XX{})
+	assert show_result< XX, string>(XX{}, "s")
+	assert show_result< XX, YY>(XX{}, YY{})
+}


### PR DESCRIPTION
This PR fix generic fn with upper name type (fix #9460).

- Fix generic fn with upper name type.
- Add test.

```vlang
struct XX {}

struct YY {}

fn show_result<T, U>(x T, y U) bool {
	return true
}

fn main() {
	assert show_result<int, bool>(1,  false)
	assert show_result<string, XX>( "s",  XX{})
	assert show_result< XX, string>(XX{}, "s")
	assert show_result< XX, YY>(XX{}, YY{})
}
```