### PR TITLE
Regex: added less restrictive use of '-' in CC

### DIFF
--- a/vlib/regex/README.md
+++ b/vlib/regex/README.md
@@ -69,8 +69,8 @@ and all the digits `\d`.
 
 It is possible to mix all the properties of the char class together.
 
-**Note:** In order to match the `-` (minus) char, it must be located at the first position
- in the cc, for example `[-_\d\a]` will match `-` minus, `_`underscore, `\d` numeric chars,
+**Note:** In order to match the `-` (minus) char, it must be preceded by a backslash
+ in the cc, for example `[\-_\d\a]` will match `-` minus, `_`underscore, `\d` numeric chars,
  `\a` lower case chars.
 
 ### Meta-chars

--- a/vlib/regex/regex.v
+++ b/vlib/regex/regex.v
@@ -390,7 +390,7 @@ const(
 	]
 
 	// these chars are escape if preceded by a \
-	bsls_escape_list = [`\\`, `|`, `.`, `:`, `*`, `+`, `-`, `{`, `}`, `[`, `]`, `(`, `)`, `?`]
+	bsls_escape_list = [`\\`, `|`, `.`, `:`, `*`, `+`, `-`, `{`, `}`, `[`, `]`, `(`, `)`, `?`, `^`, `!`]
 )
 
 enum BSLS_parse_state {
@@ -598,7 +598,7 @@ fn (mut re RE) parse_char_class(in_txt string, in_i int) (int, int, rune) {
 		}
 
 		if status == .in_bsls {
-			//println("CC bsls validation.")
+			println("CC bsls validation.")
 			for c,x in bsls_validator_array {
 				if x.ch == ch {
 					//println("CC bsls found [${ch:c}]")
@@ -613,8 +613,15 @@ fn (mut re RE) parse_char_class(in_txt string, in_i int) (int, int, rune) {
 				}
 			}
 			if status == .in_bsls {
+				// manage as a simple char
 				//println("CC bsls not found [${ch:c}]")
+				re.cc[tmp_index].cc_type = cc_char
+				re.cc[tmp_index].ch0     = char_tmp
+				re.cc[tmp_index].ch1     = char_tmp
+				i += char_len
+				tmp_index++
 				status = .in_char
+				continue
 			}else {
 				continue
 			}

--- a/vlib/regex/regex.v
+++ b/vlib/regex/regex.v
@@ -598,7 +598,7 @@ fn (mut re RE) parse_char_class(in_txt string, in_i int) (int, int, rune) {
 		}
 
 		if status == .in_bsls {
-			println("CC bsls validation.")
+			//println("CC bsls validation.")
 			for c,x in bsls_validator_array {
 				if x.ch == ch {
 					//println("CC bsls found [${ch:c}]")

--- a/vlib/regex/regex_test.v
+++ b/vlib/regex/regex_test.v
@@ -15,6 +15,14 @@ struct TestItem {
 
 const(
 match_test_suite = [
+	// minus in CC
+	TestItem{"d.def",r"abc.\.[\w\-]{,100}",-1,0},
+	TestItem{"abc12345.asd",r"abc.\.[\w\-]{,100}",-1,0},
+	TestItem{"abca.exe",r"abc.\.[\w\-]{,100}",0,8},
+	TestItem{"abc2.exe-test_12",r"abc.\.[\w\-]{,100}",0,13},
+	TestItem{"abcdefGHK",r"[a-f]+\A+",0,9},
+	TestItem{"ab-cd-efGHK",r"[a-f\-g]+\A+",0,11},
+
 	// base OR
 	TestItem{"a",r"a|b",0,1},
 	TestItem{"a",r"b|a",0,1},


### PR DESCRIPTION
**What's inside**
- Relaxed the rule for `-` escaping in Char Classes
- Added tests
- Updated README.md