### PR TITLE
semver: add custom errors

### DIFF
--- a/examples/errors.v
+++ b/examples/errors.v
@@ -1,0 +1,20 @@
+import semver
+
+fn main() {
+	semver.from('asd') or { check_error(err) }
+	semver.from('') or { check_error(err) }
+}
+
+fn check_error(err IError) {
+	match err {
+		semver.InvalidVersionFormatError {
+			println('wrong format')
+		}
+		semver.EmptyInputError {
+			println('empty input')
+		}
+		else {
+			println('unknown error')
+		}
+	}
+}

--- a/vlib/semver/range.v
+++ b/vlib/semver/range.v
@@ -29,6 +29,16 @@ struct Range {
 	comparator_sets []ComparatorSet
 }
 
+struct InvalidComparatorCountError {
+	msg  string
+	code int
+}
+
+struct InvalidComparatorFormatError {
+	msg  string
+	code int
+}
+
 fn (r Range) satisfies(ver Version) bool {
 	mut final_result := false
 	for set in r.comparator_sets {
@@ -74,12 +84,16 @@ fn parse_range(input string) ?Range {
 fn parse_comparator_set(input string) ?ComparatorSet {
 	raw_comparators := input.split(semver.comparator_sep)
 	if raw_comparators.len > 2 {
-		return error('Invalid format of comparator set for input "$input"')
+		return IError(&InvalidComparatorFormatError{
+			msg: 'Invalid format of comparator set for input "$input"'
+		})
 	}
 	mut comparators := []Comparator{}
 	for raw_comp in raw_comparators {
 		c := parse_comparator(raw_comp) or {
-			return error('Invalid comparator "$raw_comp" in input "$input"')
+			return IError(&InvalidComparatorFormatError{
+				msg: 'Invalid comparator "$raw_comp" in input "$input"'
+			})
 		}
 		comparators << c
 	}

--- a/vlib/semver/semver.v
+++ b/vlib/semver/semver.v
@@ -19,15 +19,27 @@ pub enum Increment {
 	patch
 }
 
+struct EmptyInputError {
+	msg  string = 'Empty input'
+	code int
+}
+
+struct InvalidVersionFormatError {
+	msg  string
+	code int
+}
+
 // * Constructor.
 // from returns a `Version` structure parsed from `input` `string`.
 pub fn from(input string) ?Version {
 	if input.len == 0 {
-		return error('Empty input')
+		return IError(&EmptyInputError{})
 	}
 	raw_version := parse(input)
 	version := raw_version.validate() or {
-		return error('Invalid version format for input "$input"')
+		return IError(&InvalidVersionFormatError{
+			msg: 'Invalid version format for input "$input"'
+		})
 	}
 	return version
 }
@@ -88,8 +100,7 @@ v := semver.coerce('1.3-RC1-b2') or { semver.Version{} }
 assert v.satisfies('>1.0 <2.0') == true // 1.3.0
 */
 pub fn coerce(input string) ?Version {
-	ver := coerce_version(input) or { return error('Invalid version for input "$input"') }
-	return ver
+	return coerce_version(input)
 }
 
 // is_valid returns `true` if the `input` `string` can be converted to


### PR DESCRIPTION
As discussed in #9367 this PR add custom error types to semver package and tests it using a new `errors.v` example.

Semver is a small package, so we can focus on the implementation details instead of reviewing big chunks of code. 

It is also possible to repurpose this PR for all custom error additions and I can make new commits module by module when the old ones are reviewed although I would prefer individual PRs.

Two details I catched are:
1. I made errors private on purpose but I could still refer to them in the errors.v file. The good thing is, even though the `msg` field is private, it can still be read thanks to inheritance.
2. in `semver.v`, `coerce` and `coerce_version` are returning the same error messsage, so `coerce()` itself doesn't add anything extra apart from being public and not inlined, so I just made it one-liner.  
 

v test-all fails because of some mysql errors, so I can rebase this once they are fixed in master branch.