### PR TITLE
generics: fix generics_struct with generic array string (fix #9397)

### DIFF
--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -698,6 +698,7 @@ pub fn (mut t Table) find_or_register_array(elem_type Type) int {
 		name: name
 		cname: cname
 		info: Array{
+			nr_dims: 1
 			elem_type: elem_type
 		}
 	}

--- a/vlib/v/tests/generics_return_generics_struct_test.v
+++ b/vlib/v/tests/generics_return_generics_struct_test.v
@@ -29,3 +29,23 @@ fn test_generics_return_generics_struct() {
 	println(get<int>(o))
 	assert get<int>(o) == 42
 }
+
+pub struct ArrayIterator<T> {
+	data []T
+mut:
+	index int
+}
+
+pub fn iter<T>(arr []T) ArrayIterator<T> {
+	return ArrayIterator{data: arr, index: 11}
+}
+
+fn test_generics_with_generics_struct_string() {
+	data := ['foo' 'bar']
+	it := iter<string>(data)
+	println(it)
+	ret := '$it'
+	assert ret.contains('arrayIterator<string>{')
+	assert ret.contains("data: ['foo', 'bar']")
+	assert ret.contains('index: 11')
+}


### PR DESCRIPTION
This PR fix generics_struct with generic array string (fix #9397).

- Fix generics_struct with generic array string.
- Add test.

```vlang
pub struct ArrayIterator<T> {
	data []T
mut:
	index int
}

pub fn iter<T>(arr []T) ArrayIterator<T> {
	return ArrayIterator{data: arr, index: 11}
}

fn main() {
	data := ['foo' 'bar']
	it := iter<string>(data)
	println(it)
}

D:\Test\v\tt1>v run .
arrayIterator<string>{
    data: ['foo', 'bar']
    index: 11
}
```