### PR TITLE
json2: trim spaces from json string before parsing

### DIFF
--- a/vlib/x/json2/decoder_test.v
+++ b/vlib/x/json2/decoder_test.v
@@ -67,3 +67,15 @@ fn test_raw_decode_string_with_dollarsign() {
 	}
 	assert str.str() == r'Hello $world'
 }
+
+fn test_multiline_raw_decode_map() {
+	raw_mp := json2.raw_decode('
+	{"name":"Bob","age":20}
+	') or {
+		assert false
+		json2.Any{}
+	}
+	mp := raw_mp.as_map()
+	assert mp['name'].str() == 'Bob'
+	assert mp['age'].int() == 20
+}

--- a/vlib/x/json2/json2.v
+++ b/vlib/x/json2/json2.v
@@ -14,7 +14,7 @@ pub interface Serializable {
 
 // Decodes a JSON string into an `Any` type. Returns an option.
 pub fn raw_decode(src string) ?Any {
-	mut p := new_parser(src, true)
+	mut p := new_parser(src.trim_space(), true)
 	return p.decode()
 }
 


### PR DESCRIPTION
There is an error discovered in #9490 where json2 cannot parse strings if the first character whitespace/newline. This PR will fix that by applying `trim_space` to the string before `raw_decode`.

Fixes #9490
