### PR TITLE
cgen: fix generic_struct str()

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -475,7 +475,7 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp string, str_fn_name st
 		// TODO: this is a bit hacky. styp shouldn't be even parsed with _T_
 		// use something different than g.typ for styp
 		clean_struct_v_type_name = 
-			clean_struct_v_type_name.replace('_T_', '<').replace('Array_', 'array_').replace('_Array', '_array').replace('_', ', ') +
+			clean_struct_v_type_name.replace('_Array', '_array').replace('_T_', '<').replace('_', ', ') +
 			'>'
 	}
 	clean_struct_v_type_name = util.strip_main_name(clean_struct_v_type_name)

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -475,7 +475,7 @@ fn (mut g Gen) gen_str_for_struct(info table.Struct, styp string, str_fn_name st
 		// TODO: this is a bit hacky. styp shouldn't be even parsed with _T_
 		// use something different than g.typ for styp
 		clean_struct_v_type_name = 
-			clean_struct_v_type_name.replace('_T_', '<').replace('_', ', ').replace('Array', 'array') +
+			clean_struct_v_type_name.replace('_T_', '<').replace('Array_', 'array_').replace('_Array', '_array').replace('_', ', ') +
 			'>'
 	}
 	clean_struct_v_type_name = util.strip_main_name(clean_struct_v_type_name)

--- a/vlib/v/tests/generics_return_generics_struct_test.v
+++ b/vlib/v/tests/generics_return_generics_struct_test.v
@@ -45,7 +45,7 @@ fn test_generics_with_generics_struct_string() {
 	it := iter<string>(data)
 	println(it)
 	ret := '$it'
-	assert ret.contains('arrayIterator<string>{')
+	assert ret.contains('ArrayIterator<string>{')
 	assert ret.contains("data: ['foo', 'bar']")
 	assert ret.contains('index: 11')
 }


### PR DESCRIPTION
This PR fix generic_struct str().

- Fix `gen_str_for_struct()`.
- Modify test.

```vlang
pub struct ArrayIterator<T> {
	data []T
mut:
	index int
}

pub fn iter<T>(arr []T) ArrayIterator<T> {
	return ArrayIterator{data: arr, index: 11}
}

fn main() {
	data := ['foo' 'bar']
	it := iter<string>(data)
	println(it)
}

D:\Test\v\tt1>v run .
ArrayIterator<string>{
    data: ['foo', 'bar']
    index: 11
}
```