### PR TITLE
thirdparty: make `fontstash` and `sokol` C-libraries work with Boehm-GC

### DIFF
--- a/thirdparty/fontstash/fontstash.h
+++ b/thirdparty/fontstash/fontstash.h
@@ -34,6 +34,12 @@ extern "C" {
 
 #define FONS_INVALID -1
 
+#if !defined(FONTSTASH_MALLOC)
+#define FONTSTASH_MALLOC malloc
+#define FONTSTASH_REALLOC realloc
+#define FONTSTASH_FREE free
+#endif
+
 enum FONSflags {
 	FONS_ZERO_TOPLEFT = 1,
 	FONS_ZERO_BOTTOMLEFT = 2,
@@ -540,8 +546,8 @@ static unsigned int fons__decutf8(unsigned int* state, unsigned int* codep, unsi
 static void fons__deleteAtlas(FONSatlas* atlas)
 {
 	if (atlas == NULL) return;
-	if (atlas->nodes != NULL) free(atlas->nodes);
-	free(atlas);
+	if (atlas->nodes != NULL) FONTSTASH_FREE(atlas->nodes);
+	FONTSTASH_FREE(atlas);
 }
 
 static FONSatlas* fons__allocAtlas(int w, int h, int nnodes)
@@ -549,7 +555,7 @@ static FONSatlas* fons__allocAtlas(int w, int h, int nnodes)
 	FONSatlas* atlas = NULL;
 
 	// Allocate memory for the font stash.
-	atlas = (FONSatlas*)malloc(sizeof(FONSatlas));
+	atlas = (FONSatlas*)FONTSTASH_MALLOC(sizeof(FONSatlas));
 	if (atlas == NULL) goto error;
 	memset(atlas, 0, sizeof(FONSatlas));
 
@@ -557,7 +563,7 @@ static FONSatlas* fons__allocAtlas(int w, int h, int nnodes)
 	atlas->height = h;
 
 	// Allocate space for skyline nodes
-	atlas->nodes = (FONSatlasNode*)malloc(sizeof(FONSatlasNode) * nnodes);
+	atlas->nodes = (FONSatlasNode*)FONTSTASH_MALLOC(sizeof(FONSatlasNode) * nnodes);
 	if (atlas->nodes == NULL) goto error;
 	memset(atlas->nodes, 0, sizeof(FONSatlasNode) * nnodes);
 	atlas->nnodes = 0;
@@ -582,7 +588,7 @@ static int fons__atlasInsertNode(FONSatlas* atlas, int idx, int x, int y, int w)
 	// Insert node
 	if (atlas->nnodes+1 > atlas->cnodes) {
 		atlas->cnodes = atlas->cnodes == 0 ? 8 : atlas->cnodes * 2;
-		atlas->nodes = (FONSatlasNode*)realloc(atlas->nodes, sizeof(FONSatlasNode) * atlas->cnodes);
+		atlas->nodes = (FONSatlasNode*)FONTSTASH_REALLOC(atlas->nodes, sizeof(FONSatlasNode) * atlas->cnodes);
 		if (atlas->nodes == NULL)
 			return 0;
 	}
@@ -743,14 +749,14 @@ FONScontext* fonsCreateInternal(FONSparams* params)
 	FONScontext* stash = NULL;
 
 	// Allocate memory for the font stash.
-	stash = (FONScontext*)malloc(sizeof(FONScontext));
+	stash = (FONScontext*)FONTSTASH_MALLOC(sizeof(FONScontext));
 	if (stash == NULL) goto error;
 	memset(stash, 0, sizeof(FONScontext));
 
 	stash->params = *params;
 
 	// Allocate scratch buffer.
-	stash->scratch = (unsigned char*)malloc(FONS_SCRATCH_BUF_SIZE);
+	stash->scratch = (unsigned char*)FONTSTASH_MALLOC(FONS_SCRATCH_BUF_SIZE);
 	if (stash->scratch == NULL) goto error;
 
 	// Initialize implementation library
@@ -765,7 +771,7 @@ FONScontext* fonsCreateInternal(FONSparams* params)
 	if (stash->atlas == NULL) goto error;
 
 	// Allocate space for fonts.
-	stash->fonts = (FONSfont**)malloc(sizeof(FONSfont*) * FONS_INIT_FONTS);
+	stash->fonts = (FONSfont**)FONTSTASH_MALLOC(sizeof(FONSfont*) * FONS_INIT_FONTS);
 	if (stash->fonts == NULL) goto error;
 	memset(stash->fonts, 0, sizeof(FONSfont*) * FONS_INIT_FONTS);
 	stash->cfonts = FONS_INIT_FONTS;
@@ -774,7 +780,7 @@ FONScontext* fonsCreateInternal(FONSparams* params)
 	// Create texture for the cache.
 	stash->itw = 1.0f/stash->params.width;
 	stash->ith = 1.0f/stash->params.height;
-	stash->texData = (unsigned char*)malloc(stash->params.width * stash->params.height);
+	stash->texData = (unsigned char*)FONTSTASH_MALLOC(stash->params.width * stash->params.height);
 	if (stash->texData == NULL) goto error;
 	memset(stash->texData, 0, stash->params.width * stash->params.height);
 
@@ -877,9 +883,9 @@ void fonsClearState(FONScontext* stash)
 static void fons__freeFont(FONSfont* font)
 {
 	if (font == NULL) return;
-	if (font->glyphs) free(font->glyphs);
-	if (font->freeData && font->data) free(font->data);
-	free(font);
+	if (font->glyphs) FONTSTASH_FREE(font->glyphs);
+	if (font->freeData && font->data) FONTSTASH_FREE(font->data);
+	FONTSTASH_FREE(font);
 }
 
 static int fons__allocFont(FONScontext* stash)
@@ -887,15 +893,15 @@ static int fons__allocFont(FONScontext* stash)
 	FONSfont* font = NULL;
 	if (stash->nfonts+1 > stash->cfonts) {
 		stash->cfonts = stash->cfonts == 0 ? 8 : stash->cfonts * 2;
-		stash->fonts = (FONSfont**)realloc(stash->fonts, sizeof(FONSfont*) * stash->cfonts);
+		stash->fonts = (FONSfont**)FONTSTASH_REALLOC(stash->fonts, sizeof(FONSfont*) * stash->cfonts);
 		if (stash->fonts == NULL)
 			return -1;
 	}
-	font = (FONSfont*)malloc(sizeof(FONSfont));
+	font = (FONSfont*)FONTSTASH_MALLOC(sizeof(FONSfont));
 	if (font == NULL) goto error;
 	memset(font, 0, sizeof(FONSfont));
 
-	font->glyphs = (FONSglyph*)malloc(sizeof(FONSglyph) * FONS_INIT_GLYPHS);
+	font->glyphs = (FONSglyph*)FONTSTASH_MALLOC(sizeof(FONSglyph) * FONS_INIT_GLYPHS);
 	if (font->glyphs == NULL) goto error;
 	font->cglyphs = FONS_INIT_GLYPHS;
 	font->nglyphs = 0;
@@ -967,7 +973,7 @@ static FONSglyph* fons__allocGlyph(FONSfont* font)
 {
 	if (font->nglyphs+1 > font->cglyphs) {
 		font->cglyphs = font->cglyphs == 0 ? 8 : font->cglyphs * 2;
-		font->glyphs = (FONSglyph*)realloc(font->glyphs, sizeof(FONSglyph) * font->cglyphs);
+		font->glyphs = (FONSglyph*)FONTSTASH_REALLOC(font->glyphs, sizeof(FONSglyph) * font->cglyphs);
 		if (font->glyphs == NULL) return NULL;
 	}
 	font->nglyphs++;
@@ -1610,10 +1616,10 @@ FONS_DEF void fonsDeleteInternal(FONScontext* stash)
 		fons__freeFont(stash->fonts[i]);
 
 	if (stash->atlas) fons__deleteAtlas(stash->atlas);
-	if (stash->fonts) free(stash->fonts);
-	if (stash->texData) free(stash->texData);
-	if (stash->scratch) free(stash->scratch);
-	free(stash);
+	if (stash->fonts) FONTSTASH_FREE(stash->fonts);
+	if (stash->texData) FONTSTASH_FREE(stash->texData);
+	if (stash->scratch) FONTSTASH_FREE(stash->scratch);
+	FONTSTASH_FREE(stash);
 }
 
 FONS_DEF void fonsSetErrorCallback(FONScontext* stash, void (*callback)(void* uptr, int error, int val), void* uptr)
@@ -1651,7 +1657,7 @@ FONS_DEF int fonsExpandAtlas(FONScontext* stash, int width, int height)
 			return 0;
 	}
 	// Copy old texture data over.
-	data = (unsigned char*)malloc(width * height);
+	data = (unsigned char*)FONTSTASH_MALLOC(width * height);
 	if (data == NULL)
 		return 0;
 	for (i = 0; i < stash->params.height; i++) {
@@ -1664,7 +1670,7 @@ FONS_DEF int fonsExpandAtlas(FONScontext* stash, int width, int height)
 	if (height > stash->params.height)
 		memset(&data[stash->params.height * width], 0, (height - stash->params.height) * width);
 
-	free(stash->texData);
+	FONTSTASH_FREE(stash->texData);
 	stash->texData = data;
 
 	// Increase atlas size
@@ -1704,7 +1710,7 @@ FONS_DEF int fonsResetAtlas(FONScontext* stash, int width, int height)
 	fons__atlasReset(stash->atlas, width, height);
 
 	// Clear texture data.
-	stash->texData = (unsigned char*)realloc(stash->texData, width * height);
+	stash->texData = (unsigned char*)FONTSTASH_REALLOC(stash->texData, width * height);
 	if (stash->texData == NULL) return 0;
 	memset(stash->texData, 0, width * height);
 

--- a/thirdparty/fontstash/stb_truetype.h
+++ b/thirdparty/fontstash/stb_truetype.h
@@ -464,8 +464,8 @@ int main(int arg, char **argv)
    // #define your own functions "STBTT_malloc" / "STBTT_free" to avoid malloc.h
    #ifndef STBTT_malloc
    #include <stdlib.h>
-   #define STBTT_malloc(x,u)  ((void)(u),malloc(x))
-   #define STBTT_free(x,u)    ((void)(u),free(x))
+   #define STBTT_malloc(x,u)  ((void)(u),FONTSTASH_MALLOC(x))
+   #define STBTT_free(x,u)    ((void)(u),FONTSTASH_FREE(x))
    #endif
 
    #ifndef STBTT_assert

--- a/vlib/fontstash/fontstash.v
+++ b/vlib/fontstash/fontstash.v
@@ -2,6 +2,11 @@ module fontstash
 
 #flag -I @VROOT/thirdparty/fontstash
 #define FONTSTASH_IMPLEMENTATION
+$if gcboehm ? {
+	#define FONTSTASH_MALLOC GC_MALLOC
+	#define FONTSTASH_REALLOC GC_REALLOC
+	#define FONTSTASH_FREE GC_FREE
+}
 #include "fontstash.h"
 #flag -I /usr/local/Cellar/freetype/2.10.2/include/freetype2
 //#flag -lfreetype

--- a/vlib/sokol/c/declaration.c.v
+++ b/vlib/sokol/c/declaration.c.v
@@ -33,6 +33,14 @@ pub const (
 #flag freebsd -DSOKOL_NO_ENTRY
 #flag solaris -DSOKOL_NO_ENTRY
 // TODO end
+
+$if gcboehm ? {
+	#define SOKOL_MALLOC GC_MALLOC
+	#define SOKOL_CALLOC(n,m) GC_MALLOC((n)*(m))
+	#define SOKOL_REALLOC GC_REALLOC
+	#define SOKOL_FREE GC_FREE
+}
+
 #include "sokol_v.h"
 #include "sokol_app.h"
 #define SOKOL_IMPL


### PR DESCRIPTION
This makes the thirdparty `C` libraries `fontstash` and `sokol` work for V programs compiled with `-gc boehm`.

The principle problem when using C libraries together with a garbage collector is, that pointers to collectable (V) memory blocks may end up in memory areas allocated with simple (C) `malloc()` which are not scanned by the collector. This may lead to the collectable memory being freed while still in use by the C library.

This problem is not V specific, it is something that programs/languages using garbage collection have in common. In principle there are two ways to deal with it:

1. When passing a pointer to an external `C` routine, make sure that there is still another pointer to this area in the V program, thus keeping the memory block "alive". This is not as easy as it might look at the first glace, especially when compiler optimization is involved. Maybe we should provide a special function like `assure_memory_block_is_still_alive_up_to_here(voidptr)` that can be called after the `C` call to make this approach easier.
2. Make the C library in question use `GC_MALLOC()`, ... too, when the V program is compiled with `-gc boehm`.

This PR uses the second approach for `fontstash` and `sokol`. With this `ved` seems to work.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
