### PR TITLE
x.json2: skip whitespace before scanning

### DIFF
--- a/vlib/x/json2/decoder.v
+++ b/vlib/x/json2/decoder.v
@@ -4,7 +4,8 @@
 module json2
 
 // `Any` is a sum type that lists the possible types to be decoded and used.
-pub type Any = Null | []Any | bool | f32 | f64 | i64 | u64 | int | map[string]Any | string
+pub type Any = Null | []Any | bool | f32 | f64 | i64 | int | map[string]Any | string |
+	u64
 
 // `Null` struct is a simple representation of the `null` value in JSON.
 pub struct Null {

--- a/vlib/x/json2/decoder_test.v
+++ b/vlib/x/json2/decoder_test.v
@@ -67,3 +67,14 @@ fn test_raw_decode_string_with_dollarsign() {
 	}
 	assert str.str() == r'Hello $world'
 }
+
+fn test_raw_decode_map_with_whitespaces() {
+	raw_mp := json2.raw_decode(' \n\t{"name":"Bob","age":20}\n\t') or {
+		eprintln(err.msg)
+		assert false
+		json2.Any{}
+	}
+	mp := raw_mp.as_map()
+	assert mp['name'].str() == 'Bob'
+	assert mp['age'].int() == 20
+}

--- a/vlib/x/json2/json2_test.v
+++ b/vlib/x/json2/json2_test.v
@@ -124,7 +124,7 @@ pub mut:
 	last_name     string [json: lastName]
 	is_registered bool   [json: IsRegistered]
 	typ           int    [json: 'type']
-	pets          string [raw; json: 'pet_animals']
+	pets          string [json: 'pet_animals'; raw]
 }
 
 fn (mut u User) from_json(an json2.Any) {

--- a/vlib/x/json2/scanner_test.v
+++ b/vlib/x/json2/scanner_test.v
@@ -328,3 +328,24 @@ fn test_bool_false() {
 	assert tok.lit.len == 5
 	assert tok.lit.bytestr() == 'false'
 }
+
+fn test_json_with_whitespace_start() {
+	mut sc := Scanner{
+		text: ' \n  \n\t {'.bytes()
+	}
+	tok := sc.scan()
+	eprintln(tok)
+	assert tok.kind == .lcbr
+	assert tok.lit.len == 0
+}
+
+fn test_json_with_whitespace_end() {
+	mut sc := Scanner{
+		text: '}  \n\t'.bytes()
+	}
+	tok := sc.scan()
+	assert tok.kind == .rcbr
+	tok2 := sc.scan()
+	eprintln(tok2)
+	assert tok2.kind == .eof
+}


### PR DESCRIPTION
Executes `move` method on the start of the `scan` method. Fixes #9490.