### PR TITLE
Encoding: add custom errors to encoding lib

### DIFF
--- a/vlib/encoding/csv/writer.v
+++ b/vlib/encoding/csv/writer.v
@@ -7,7 +7,7 @@ import strings
 
 struct Writer {
 mut:
-	sb        strings.Builder
+	sb strings.Builder
 pub mut:
 	use_crlf  bool
 	delimiter byte
@@ -23,7 +23,7 @@ pub fn new_writer() &Writer {
 // write writes a single record
 pub fn (mut w Writer) write(record []string) ?bool {
 	if !valid_delim(w.delimiter) {
-		return err_invalid_delim
+		return IError(&ErrInvalidDelimiter{})
 	}
 	le := if w.use_crlf { '\r\n' } else { '\n' }
 	for n, field_ in record {


### PR DESCRIPTION
As discussed in #9367 this PR add custom error types to encoding package and tests it using a new errors.v example.

A working example for semver was already merged in #9493.