### PR TITLE
Json2: add custom errors to x.json2 lib

### DIFF
--- a/vlib/x/json2/decoder.v
+++ b/vlib/x/json2/decoder.v
@@ -4,7 +4,8 @@
 module json2
 
 // `Any` is a sum type that lists the possible types to be decoded and used.
-pub type Any = Null | []Any | bool | f32 | f64 | i64 | u64 | int | map[string]Any | string
+pub type Any = Null | []Any | bool | f32 | f64 | i64 | int | map[string]Any | string |
+	u64
 
 // `Null` struct is a simple representation of the `null` value in JSON.
 pub struct Null {
@@ -19,6 +20,16 @@ mut:
 	n_tok        Token
 	n_level      int
 	convert_type bool = true
+}
+
+struct InvalidTokenError {
+	msg  string
+	code int
+}
+
+struct UnknownTokenError {
+	msg  string
+	code int
 }
 
 fn (mut p Parser) next() {
@@ -73,7 +84,9 @@ fn (mut p Parser) decode() ?Any {
 	p.next_with_err() ?
 	fi := p.decode_value() ?
 	if p.tok.kind != .eof {
-		return error(p.emit_error('invalid token `$p.tok.kind`'))
+		return IError(&InvalidTokenError{
+			msg: p.emit_error('invalid token `$p.tok.kind`')
+		})
 	}
 	return fi
 }
@@ -126,7 +139,9 @@ fn (mut p Parser) decode_value() ?Any {
 			return Any(str)
 		}
 		else {
-			return error(p.emit_error('invalid token `$p.tok.kind`'))
+			return IError(&InvalidTokenError{
+				msg: p.emit_error('invalid token `$p.tok.kind`')
+			})
 		}
 	}
 	return Any{}
@@ -141,12 +156,16 @@ fn (mut p Parser) decode_array() ?Any {
 		if p.tok.kind == .comma {
 			p.next_with_err() ?
 			if p.tok.kind == .rsbr || p.tok.kind == .rcbr {
-				return error(p.emit_error('invalid token `$p.tok.lit'))
+				return IError(&InvalidTokenError{
+					msg: p.emit_error('invalid token `$p.tok.lit')
+				})
 			}
 		} else if p.tok.kind == .rsbr {
 			break
 		} else {
-			return error(p.emit_error("unknown token '$p.tok.lit' when decoding array."))
+			return IError(&UnknownTokenError{
+				msg: p.emit_error("unknown token '$p.tok.lit' when decoding array.")
+			})
 		}
 	}
 	p.next_with_err() ?
@@ -159,7 +178,9 @@ fn (mut p Parser) decode_object() ?Any {
 	for p.tok.kind != .rcbr {
 		is_key := p.tok.kind == .str_ && p.n_tok.kind == .colon
 		if !is_key {
-			return error(p.emit_error('invalid token `$p.tok.kind`, expecting `str_`'))
+			return IError(&InvalidTokenError{
+				msg: p.emit_error('invalid token `$p.tok.kind`, expecting `str_`')
+			})
 		}
 		cur_key := p.tok.lit.bytestr()
 		p.next_with_err() ?
@@ -168,7 +189,9 @@ fn (mut p Parser) decode_object() ?Any {
 		if p.tok.kind == .comma {
 			p.next_with_err() ?
 			if p.tok.kind != .str_ {
-				return error(p.emit_error("unknown token '$p.tok.lit' when decoding object."))
+				return IError(&UnknownTokenError{
+					msg: p.emit_error("unknown token '$p.tok.lit' when decoding object.")
+				})
 			}
 		}
 	}


### PR DESCRIPTION
As discussed in #9367 this PR add custom error types to json2 package.

A working example for semver was already merged in #9493.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
