### PR TITLE
ast, parser: add additional info for CallExpr, StructInit nodes

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -91,6 +91,7 @@ pub fn (mut p Parser) call_expr(language table.Language, mod string) ast.CallExp
 	pos.update_last_line(p.prev_tok.line_nr)
 	return ast.CallExpr{
 		name: fn_name
+		name_pos: first_pos
 		args: args
 		mod: p.mod
 		pos: pos

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -359,6 +359,7 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 		mut field_name := ''
 		mut expr := ast.Expr{}
 		mut field_pos := token.Position{}
+		mut first_field_pos := token.Position{}
 		mut comments := []ast.Comment{}
 		mut nline_comments := []ast.Comment{}
 		is_update_expr := fields.len == 0 && p.tok.kind == .ellipsis
@@ -366,6 +367,7 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 			// name will be set later in checker
 			expr = p.expr(0)
 			field_pos = expr.position()
+			first_field_pos = field_pos
 			comments = p.eat_comments(same_line: true)
 		} else if is_update_expr {
 			// struct updating syntax; f2 := Foo{ ...f, name: 'f2' }
@@ -374,7 +376,7 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 			update_expr_comments << p.eat_comments(same_line: true)
 			has_update_expr = true
 		} else {
-			first_field_pos := p.tok.position()
+			first_field_pos = p.tok.position()
 			field_name = p.check_name()
 			p.check(.colon)
 			expr = p.expr(0)
@@ -403,6 +405,7 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 				name: field_name
 				expr: expr
 				pos: field_pos
+				name_pos: first_field_pos
 				comments: comments
 				next_comments: nline_comments
 			}
@@ -419,6 +422,7 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 		update_expr: update_expr
 		update_expr_comments: update_expr_comments
 		has_update_expr: has_update_expr
+		name_pos: first_pos
 		pos: first_pos.extend(p.prev_tok.position())
 		is_short: no_keys
 		pre_comments: pre_comments


### PR DESCRIPTION
This PR is one of the many changes (possibly) for https://github.com/vlang/vls/pull/83. This adds the args list to the `CallExpr` children, make `CallArg` node part of `ast.Node`, and add name_pos to `CallExpr` and `StructInit` nodes