### PR TITLE
generics: fix generic_struct_insts_to_concrete (fix #9540)

### DIFF
--- a/vlib/v/table/table.v
+++ b/vlib/v/table/table.v
@@ -1091,27 +1091,22 @@ pub fn (mut t Table) generic_struct_insts_to_concrete() {
 			}
 			mut parent_info := parent.info as Struct
 			mut fields := parent_info.fields.clone()
-			for i, _ in fields {
-				mut field := fields[i]
-				if field.typ.has_flag(.generic) {
-					if parent_info.generic_types.len != info.generic_types.len {
-						// TODO: proper error
-						panic('generic template mismatch')
+			if parent_info.generic_types.len == info.generic_types.len {
+				for i, _ in fields {
+					mut field := fields[i]
+					if t_typ := t.resolve_generic_by_types(field.typ, parent_info.generic_types,
+						info.generic_types)
+					{
+						field.typ = t_typ
 					}
-					for j, gp in parent_info.generic_types {
-						if gp == field.typ {
-							field.typ = info.generic_types[j].derive(field.typ).clear_flag(.generic)
-							break
-						}
-					}
+					fields[i] = field
 				}
-				fields[i] = field
+				parent_info.generic_types = []
+				parent_info.fields = fields
+				typ.is_public = true
+				typ.kind = .struct_
+				typ.info = parent_info
 			}
-			parent_info.generic_types = []
-			parent_info.fields = fields
-			typ.is_public = true
-			typ.kind = .struct_
-			typ.info = parent_info
 		}
 	}
 }

--- a/vlib/v/tests/generics_return_generics_struct_test.v
+++ b/vlib/v/tests/generics_return_generics_struct_test.v
@@ -49,3 +49,15 @@ fn test_generics_with_generics_struct_string() {
 	assert ret.contains("data: ['foo', 'bar']")
 	assert ret.contains('index: 11')
 }
+
+fn test_generics_struct_insts_to_concrete() {
+	ai := ArrayIterator<int>{
+		data: [11, 22],
+		index: 22
+	}
+	println(ai)
+	ret := '$ai'
+	assert ret.contains('ArrayIterator<int>{')
+	assert ret.contains('data: [11, 22]')
+	assert ret.contains('index: 22')
+}


### PR DESCRIPTION
This PR fix generic_struct_insts_to_concrete.  (fix #9540)

- Fix generic_struct_insts_to_concrete(). (it only process single generic type previously, not include []T/map[string]T...)
- Add test.

```vlang
pub struct ArrayIterator<T> {
	data []T
mut:
	index int
}

fn main() {
	ai := ArrayIterator<int>{
		data: [11, 22],
		index: 22
	}
	println(ai)
	ret := '$ai'
	assert ret.contains('ArrayIterator<int>{')
	assert ret.contains('data: [11, 22]')
	assert ret.contains('index: 22')
}

D:\Test\v\tt1>v run .
ArrayIterator<int>{
    data: [11, 22]
    index: 22
}
```
```vlang
struct Queue<T> {
	queue []T
}

fn main() {
	q := Queue<int>{}
	println("queue elements $q.queue.len")
}

D:\Test\v\tt1>v run .
queue elements 0
```