### PR TITLE
ast, parser: add syms_pos to import ast node

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -288,6 +288,7 @@ pub:
 	pos       token.Position
 	mod_pos   token.Position
 	alias_pos token.Position
+	syms_pos  token.Position
 pub mut:
 	syms          []ImportSymbol // the list of symbols in `import {symbol1, symbol2}`
 	comments      []Comment

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2530,7 +2530,14 @@ fn (mut p Parser) import_stmt() ast.Import {
 		}
 	}
 	if p.tok.kind == .lcbr { // import module { fn1, Type2 } syntax
+		mut initial_syms_pos := p.tok.position()
 		p.import_syms(mut import_node)
+		initial_syms_pos = initial_syms_pos.extend(p.tok.position())
+		import_node = ast.Import{
+			...import_node
+			syms_pos: initial_syms_pos
+			pos: import_node.pos.extend(initial_syms_pos)
+		}
 		p.register_used_import(mod_alias) // no `unused import` msg for parent
 	}
 	pos_t := p.tok.position()


### PR DESCRIPTION
This PR includes the position of the symbols portion of the import statement required https://github.com/vlang/vls/pull/93.