### PR TITLE
cgen: fix the alias of fixed_array (fix #9537)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5445,18 +5445,17 @@ fn (mut g Gen) write_types(types []table.TypeSymbol) {
 				g.type_definitions.writeln('')
 			}
 			table.ArrayFixed {
-				// .array_fixed {
-				styp := typ.cname
-				// array_fixed_char_300 => char x[300]
-				mut fixed := styp[12..]
-				len := styp.after('_')
-				fixed = fixed[..fixed.len - len.len - 1]
-				if fixed.starts_with('C__') {
-					fixed = fixed[3..]
-				}
-				elem_type := typ.info.elem_type
-				elem_sym := g.table.get_type_symbol(elem_type)
+				elem_sym := g.table.get_type_symbol(typ.info.elem_type)
 				if !elem_sym.is_builtin() {
+					// .array_fixed {
+					styp := typ.cname
+					// array_fixed_char_300 => char x[300]
+					mut fixed := styp[12..]
+					len := styp.after('_')
+					fixed = fixed[..fixed.len - len.len - 1]
+					if fixed.starts_with('C__') {
+						fixed = fixed[3..]
+					}
 					if elem_sym.info is table.FnType {
 						pos := g.out.len
 						g.write_fn_ptr_decl(&elem_sym.info, '')

--- a/vlib/v/tests/alias_fixed_array_test.v
+++ b/vlib/v/tests/alias_fixed_array_test.v
@@ -1,6 +1,6 @@
 type Block = [8]byte
 
-fn test_alias_fixed_array(){
+fn test_alias_fixed_array() {
 	a := [8]byte{init: 22}
 	ret := get(Block(a))
 	println(ret)

--- a/vlib/v/tests/alias_fixed_array_test.v
+++ b/vlib/v/tests/alias_fixed_array_test.v
@@ -1,0 +1,12 @@
+type Block = [8]byte
+
+fn test_alias_fixed_array(){
+	a := [8]byte{init: 22}
+	ret := get(Block(a))
+	println(ret)
+	assert ret == 'Block([22, 22, 22, 22, 22, 22, 22, 22])'
+}
+
+fn get(b Block) string {
+	return '$b'
+}


### PR DESCRIPTION
This PR fix the alias of fixed_array (fix #9537)

- Fix the alias of fixed_array.
- Add test.

```vlang
type Block = [8]byte

fn main(){
	a := [8]byte{init: 22}
	ret := get(Block(a))
	println(ret)
}

fn get(b Block) string {
	return '$b'
}

D:\Test\v\tt1>v run .
Block([22, 22, 22, 22, 22, 22, 22, 22])
```