### PR TITLE
cgen: fix error of fn return fixed_array (fix #9550)

### DIFF
--- a/vlib/v/tests/fn_return_fixed_array_test.v
+++ b/vlib/v/tests/fn_return_fixed_array_test.v
@@ -1,0 +1,13 @@
+fn test_fn_return_fixed_array() {
+    x := get3()
+    dump(x)
+	assert '$x' == '[1, 2, 3]'
+}
+
+fn get3() [3]int {
+    mut res := [3]int{}
+    res[0] = 1
+    res[1] = 2
+    res[2] = 3
+    return res
+}


### PR DESCRIPTION
This PR fix error of fn return fixed_array (fix #9550).

- Fix error of fn return fixed_array.
- Add test.
- minor optimization of fixed_array copy.

```vlang
fn main() {
    x := get3()
    dump(x)
}

fn get3() [3]int {
    mut res := [3]int{}
    res[0] = 1
    res[1] = 2
    res[2] = 3
    return res
}

D:\Test\v\tt1>v run .
[.\\tt1.v:3] x: [1, 2, 3]
```