### PR TITLE
szip: add support for unpacking zip archives and simple zip files

### DIFF
--- a/thirdparty/zip/zip.c
+++ b/thirdparty/zip/zip.c
@@ -1007,6 +1007,10 @@ int zip_extract(const char *zipname, const char *dir,
   return status;
 }
 
+int zip_extract_without_callback(const char *zipname, const char *dir) {
+  return zip_extract(zipname, dir, NULL, NULL);
+} // for simple V bind ¯\_(ツ)_/¯
+
 int zip_extract_stream(const char *stream, size_t size, const char *dir,
                        int (*on_extract)(const char *filename, void *arg),
                        void *arg) {

--- a/thirdparty/zip/zip.h
+++ b/thirdparty/zip/zip.h
@@ -312,6 +312,8 @@ extern int zip_create(const char *zipname, const char *filenames[], size_t len);
 extern int zip_extract(const char *zipname, const char *dir,
                        int (*on_extract_entry)(const char *filename, void *arg),
                        void *arg);
+// temporary working unzip solution
+extern int zip_extract_without_callback(const char *zipname, const char *dir);
 
 /**
  * Extracts a zip archive stream into directory.

--- a/vlib/szip/szip.v
+++ b/vlib/szip/szip.v
@@ -39,6 +39,8 @@ fn C.zip_entry_fread(&Zip, byteptr) int
 
 fn C.zip_total_entries(&Zip) int
 
+fn C.zip_extract_without_callback(charptr, charptr) int
+
 // CompressionLevel lists compression levels, see in "thirdparty/zip/miniz.h"
 pub enum CompressionLevel {
 	no_compression = 0
@@ -201,15 +203,68 @@ pub fn (mut zentry Zip) extract_entry(path string) ? {
 	}
 }
 
-/*
-extract extracts the current zip entry using a callback function (on_extract).
-fn (mut zentry Zip) extract(path string) bool {
-	if C.access(path.str, 0) == -1 {
-		return false
-		// return error('szip: cannot open directory for extracting, directory not exists')
+
+// extract zip file to directory
+pub fn extract_zip_to_dir(file string, dir string) ?bool {
+	if C.access(dir.str, 0) == -1 {
+		return error('szip: cannot open directory for extracting, directory not exists')
 	}
-	res := C.zip_extract(zentry, path.str, 0, 0)
+	res := C.zip_extract_without_callback(charptr(file.str), charptr(dir.str))
 	return res == 0
+}
+
+// zip files (full path) to zip file
+pub fn zip_files(path_to_file []string, path_to_export_zip string) ? {
+
+	// open or create new zip
+	mut zip := szip.open(path_to_export_zip, .no_compression, .write) or { panic(err) }
+
+	// add all files from the directory to the archive
+	for file in path_to_file {
+
+		// add file to zip
+		zip.open_entry(os.base(file)) or { panic(err) }
+		file_as_byte := os.read_bytes(file) or { panic(err) }
+        zip.write_entry(file_as_byte) or { panic(err) }
+
+        zip.close_entry()
+	}
+
+	// close zip
+	defer {
+		zip.close()
+	}
+}
+
+/*
+
+TODO add 
+// zip all files in directory to zip file
+pub fn zip_folder(path_to_dir string, path_to_export_zip string) {
+
+	// get list files from directory
+	files := os.ls(path_to_dir) or { panic(err) }
+
+	// open or create new zip
+	mut zip := szip.open(path_to_export_zip, .no_compression, .write) or { panic(err) }
+
+	// add all files from the directory to the archive
+	for file in files {
+		eprintln('Zipping $file to ${path_to_export_zip}...')
+		println(path_to_dir + file)
+
+		// add file to zip
+		zip.open_entry(file) or { panic(err) }
+		file_as_byte := os.read_bytes(path_to_dir + '/'+ file) or { panic(err) }
+        zip.write_entry(file_as_byte) or { panic(err) }
+
+        zip.close_entry()
+	}
+
+	// close zip
+	zip.close()
+
+	eprintln('Successfully')
 }
 */
 

--- a/vlib/szip/szip_test.v
+++ b/vlib/szip/szip_test.v
@@ -2,12 +2,36 @@ import szip
 import os
 
 fn test_szip() {
-	mut z := szip.open('test_compile.zip', .best_speed, .write) or {
-		assert false
-		return
+
+// create temp files for zip/unzip test
+	test_path := 'zip files'
+	test_out_zip := 'v_test_zip.zip'
+	
+	os.mkdir(test_path) or { panic(err) }
+	os.write_file(test_path + os.path_separator + 'file_1.txt', 'file one') or { panic(err) }
+	os.write_file(test_path + os.path_separator + 'file_2.txt', 'file file two') or { panic(err) }
+
+	// get list files from directory
+	mut files := os.ls(test_path) or { panic(err) }
+	for mut file in files {
+		file = os.getwd() + os.path_separator + test_path + os.path_separator + *file
 	}
-	defer {
-		z.close()
-		os.rm('test_compile.zip') or { }
-	}
+
+// zip files
+	szip.zip_files(files, test_out_zip) or { panic(err) }
+	assert os.exists(test_out_zip)
+
+// remove files before next test
+	os.rm(test_path + os.path_separator + 'file_1.txt') or { panic(err) }
+	os.rm(test_path + os.path_separator + 'file_2.txt') or { panic(err) }
+
+// extract test
+	szip.extract_zip_to_dir(test_out_zip, test_path) or { panic(err) }
+	assert os.exists(test_path + os.path_separator + 'file_1.txt')
+	assert os.exists(test_path + os.path_separator + 'file_2.txt')
+
+// clear temp files
+	// remove temp files and dir
+	os.rmdir_all (test_path) or { panic(err) }
+	os.rm(test_out_zip) or { }
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

## szip module update: 
* [Added support for unpacking zip archives](https://github.com/koplenov/v/blob/4ccde99f601c1252937b82b17ed03bc976e5f9a1/vlib/szip/szip.v#L207-L214)
* [Simple zip files](https://github.com/koplenov/v/blob/4ccde99f601c1252937b82b17ed03bc976e5f9a1/vlib/szip/szip.v#L216-L237)

## New funcs
 ###  fn zip_files
> fn zip_files(path_to_file []string, path_to_export_zip string)

zip files (full path) to zip file

```V
Sample usage:

test_path := 'zip files'
test_out_zip := 'v_test_zip.zip'

// get list files from directory
mut files := os.ls(test_path) or { panic(err) }
for mut file in files {
	file = os.getwd() + os.path_separator + test_path + os.path_separator + *file
}

szip.zip_files(files, test_out_zip) or { panic(err) }
```

 ### fn extract_zip_to_dir
> fn extract_zip_to_dir(file string, dir string) ?bool

extract zip file to directory
 ```V
// Sample usage:

path_export_zip := 'path/to/zip.zip'
path_to_dir := 'path/to/unzip/directory'

szip.extract_zip_to_dir(path_export_zip, path_to_dir) or { panic(err) }
```