### PR TITLE
cgen: fix rune array sort (fix #9557)

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -807,6 +807,21 @@ fn test_sort() {
 	// assert users.map(it.name).join(' ') == 'Alice Bob Peter'
 }
 
+fn test_rune_sort() {
+	mut bs := [`f`, `e`, `d`, `b`, `c`, `a`]
+	bs.sort()
+	println(bs)
+	assert '$bs' == '[`a`, `b`, `c`, `d`, `e`, `f`]'
+
+	bs.sort(a > b)
+	println(bs)
+	assert '$bs' == '[`f`, `e`, `d`, `c`, `b`, `a`]'
+
+	bs.sort(a < b)
+	println(bs)
+	assert '$bs' == '[`a`, `b`, `c`, `d`, `e`, `f`]'
+}
+
 fn test_sort_by_different_order_of_a_b() {
 	mut x := [1, 2, 3]
 	x.sort(a < b)


### PR DESCRIPTION
This PR fix rune array sort (fix #9557).

- Fix rune array sort.
- Add test.

```vlang
fn main() {
	mut bs := [`f`, `e`, `d`, `b`, `c`, `a`]
	bs.sort()
	println(bs)
	bs.sort(a > b)
	println(bs)
	bs.sort(a < b)
	println(bs)
}

D:\Test\v\tt1>v run .
[`a`, `b`, `c`, `d`, `e`, `f`]
[`f`, `e`, `d`, `c`, `b`, `a`]
[`a`, `b`, `c`, `d`, `e`, `f`]
```