### PR TITLE
Optional decl cast (none part)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1401,7 +1401,6 @@ pub mut:
 pub struct None {
 pub:
 	pos token.Position
-	foo int // todo
 }
 
 pub enum SqlStmtKind {

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -362,6 +362,9 @@ pub fn (x Expr) str() string {
 		UnsafeExpr {
 			return 'unsafe { $x.expr }'
 		}
+		None {
+			return 'none'
+		}
 		else {}
 	}
 	return '[unhandled expr type $x.type_name()]'

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4341,7 +4341,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 				ast.f64_type
 			})
 		}
-		if !c.table.sumtype_has_variant(node.typ, node.expr_type) && !node.typ.has_flag(.optional) && node.expr_type != ast.none_type {
+		if !c.table.sumtype_has_variant(node.typ, node.expr_type) && !node.typ.has_flag(.optional) {
 			c.error('cannot cast `$from_type_sym.name` to `$to_type_sym.name`', node.pos)
 		}
 	} else if mut to_type_sym.info is ast.Alias {
@@ -4390,7 +4390,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		c.type_implements(node.expr_type, node.typ, node.pos)
 	} else if node.typ == ast.bool_type {
 		c.error('cannot cast to bool - use e.g. `some_int != 0` instead', node.pos)
-	} else if node.expr_type == ast.none_type {
+	} else if node.expr_type == ast.none_type && !node.typ.has_flag(.optional) && node.expr_type != ast.none_type {
 		type_name := c.table.type_to_str(node.typ)
 		c.error('cannot cast `none` to `$type_name`', node.pos)
 	} else if from_type_sym.kind == .struct_ && !node.expr_type.is_ptr() {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4341,7 +4341,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 				ast.f64_type
 			})
 		}
-		if !c.table.sumtype_has_variant(node.typ, node.expr_type) && !node.typ.has_flag(.optional) && node.expr_type == ast.none_type {
+		if !c.table.sumtype_has_variant(node.typ, node.expr_type) && !node.typ.has_flag(.optional) && node.expr_type != ast.none_type {
 			c.error('cannot cast `$from_type_sym.name` to `$to_type_sym.name`', node.pos)
 		}
 	} else if mut to_type_sym.info is ast.Alias {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4390,7 +4390,8 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		c.type_implements(node.expr_type, node.typ, node.pos)
 	} else if node.typ == ast.bool_type {
 		c.error('cannot cast to bool - use e.g. `some_int != 0` instead', node.pos)
-	} else if node.expr_type == ast.none_type && !node.typ.has_flag(.optional) && node.expr_type != ast.none_type {
+	} else if node.expr_type == ast.none_type && !node.typ.has_flag(.optional)
+		&& node.expr_type != ast.none_type {
 		type_name := c.table.type_to_str(node.typ)
 		c.error('cannot cast `none` to `$type_name`', node.pos)
 	} else if from_type_sym.kind == .struct_ && !node.expr_type.is_ptr() {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4341,7 +4341,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 				ast.f64_type
 			})
 		}
-		if !c.table.sumtype_has_variant(node.typ, node.expr_type) {
+		if !c.table.sumtype_has_variant(node.typ, node.expr_type) && !node.typ.has_flag(.optional) && node.expr_type == ast.none_type {
 			c.error('cannot cast `$from_type_sym.name` to `$to_type_sym.name`', node.pos)
 		}
 	} else if mut to_type_sym.info is ast.Alias {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4390,8 +4390,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		c.type_implements(node.expr_type, node.typ, node.pos)
 	} else if node.typ == ast.bool_type {
 		c.error('cannot cast to bool - use e.g. `some_int != 0` instead', node.pos)
-	} else if node.expr_type == ast.none_type && !node.typ.has_flag(.optional)
-		&& node.expr_type != ast.none_type {
+	} else if node.expr_type == ast.none_type && !node.typ.has_flag(.optional) {
 		type_name := c.table.type_to_str(node.typ)
 		c.error('cannot cast `none` to `$type_name`', node.pos)
 	} else if from_type_sym.kind == .struct_ && !node.expr_type.is_ptr() {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4397,7 +4397,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 			|| (sym.info as ast.Alias).parent_type !in [node.expr_type, ast.string_type] {
 			cast_label = '($styp)'
 		}
-		if node.typ.has_flag(.optional) {
+		if node.typ.has_flag(.optional) && node.expr is ast.None {
 			g.gen_optional_error(node.typ, node.expr)
 		} else {
 			g.write('(${cast_label}(')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1761,6 +1761,10 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 			g.write('*')
 		}
 	}
+	if expected_type.has_flag(.optional) && expr is ast.None {
+		g.gen_optional_error(expected_type, expr)
+		return
+	}
 	// no cast
 	g.expr(expr)
 }
@@ -2902,61 +2906,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 			*/
 		}
 		ast.CastExpr {
-			// g.write('/*cast*/')
-			if g.is_amp {
-				// &Foo(0) => ((Foo*)0)
-				g.out.go_back(1)
-			}
-			g.is_amp = false
-			sym := g.table.get_type_symbol(node.typ)
-			if sym.kind == .string && !node.typ.is_ptr() {
-				// `string(x)` needs `tos()`, but not `&string(x)
-				// `tos(str, len)`, `tos2(str)`
-				if node.has_arg {
-					g.write('tos((byteptr)')
-				} else {
-					g.write('tos2((byteptr)')
-				}
-				g.expr(node.expr)
-				expr_sym := g.table.get_type_symbol(node.expr_type)
-				if expr_sym.kind == .array {
-					// if we are casting an array, we need to add `.data`
-					g.write('.data')
-				}
-				if node.has_arg {
-					// len argument
-					g.write(', ')
-					g.expr(node.arg)
-				}
-				g.write(')')
-			} else if sym.kind in [.sum_type, .interface_] {
-				g.expr_with_cast(node.expr, node.expr_type, node.typ)
-			} else if sym.kind == .struct_ && !node.typ.is_ptr()
-				&& !(sym.info as ast.Struct).is_typedef {
-				// deprecated, replaced by Struct{...exr}
-				styp := g.typ(node.typ)
-				g.write('*(($styp *)(&')
-				g.expr(node.expr)
-				g.write('))')
-			} else {
-				styp := g.typ(node.typ)
-				mut cast_label := ''
-				// `ast.string_type` is done for MSVC's bug
-				if sym.kind != .alias
-					|| (sym.info as ast.Alias).parent_type !in [node.expr_type, ast.string_type] {
-					cast_label = '($styp)'
-				}
-				g.write('(${cast_label}(')
-				g.expr(node.expr)
-				if node.expr is ast.IntegerLiteral {
-					if node.typ in [ast.u64_type, ast.u32_type, ast.u16_type] {
-						if !node.expr.val.starts_with('-') {
-							g.write('U')
-						}
-					}
-				}
-				g.write('))')
-			}
+			g.cast_expr(node)
 		}
 		ast.ChanInit {
 			elem_typ_str := g.typ(node.elem_type)
@@ -4403,6 +4353,63 @@ fn (mut g Gen) ident(node ast.Ident) {
 	g.write(g.get_ternary_name(name))
 }
 
+fn (mut g Gen) cast_expr(node ast.CastExpr) {
+	if g.is_amp {
+		// &Foo(0) => ((Foo*)0)
+		g.out.go_back(1)
+	}
+	g.is_amp = false
+	sym := g.table.get_type_symbol(node.typ)
+	if sym.kind == .string && !node.typ.is_ptr() {
+		// `string(x)` needs `tos()`, but not `&string(x)
+		// `tos(str, len)`, `tos2(str)`
+		if node.has_arg {
+			g.write('tos((byteptr)')
+		} else {
+			g.write('tos2((byteptr)')
+		}
+		g.expr(node.expr)
+		expr_sym := g.table.get_type_symbol(node.expr_type)
+		if expr_sym.kind == .array {
+			// if we are casting an array, we need to add `.data`
+			g.write('.data')
+		}
+		if node.has_arg {
+			// len argument
+			g.write(', ')
+			g.expr(node.arg)
+		}
+		g.write(')')
+	} else if sym.kind in [.sum_type, .interface_] {
+		g.expr_with_cast(node.expr, node.expr_type, node.typ)
+	} else if sym.kind == .struct_ && !node.typ.is_ptr()
+		&& !(sym.info as ast.Struct).is_typedef {
+		// deprecated, replaced by Struct{...exr}
+		styp := g.typ(node.typ)
+		g.write('*(($styp *)(&')
+		g.expr(node.expr)
+		g.write('))')
+	} else {
+		styp := g.typ(node.typ)
+		mut cast_label := ''
+		// `ast.string_type` is done for MSVC's bug
+		if sym.kind != .alias
+			|| (sym.info as ast.Alias).parent_type !in [node.expr_type, ast.string_type] {
+			cast_label = '($styp)'
+		}
+		g.write('(${cast_label}(')
+		g.expr(node.expr)
+		if node.expr is ast.IntegerLiteral {
+			if node.typ in [ast.u64_type, ast.u32_type, ast.u16_type] {
+				if !node.expr.val.starts_with('-') {
+					g.write('U')
+				}
+			}
+		}
+		g.write('))')
+	}
+}
+
 fn (mut g Gen) concat_expr(node ast.ConcatExpr) {
 	styp := g.typ(node.return_type)
 	sym := g.table.get_type_symbol(node.return_type)
@@ -4598,6 +4605,13 @@ fn (g &Gen) expr_is_multi_return_call(expr ast.Expr) bool {
 	}
 }
 
+fn (mut g Gen) gen_optional_error(target_type ast.Type, expr ast.Expr) {
+	styp := g.typ(target_type)
+	g.write('($styp){ .state=2, .err=')
+	g.expr(expr)
+	g.write(' }')
+}
+
 fn (mut g Gen) return_statement(node ast.Return) {
 	g.write_v_source_line_info(node.pos)
 	if node.exprs.len > 0 {
@@ -4635,18 +4649,10 @@ fn (mut g Gen) return_statement(node ast.Return) {
 		optional_none := node.exprs[0] is ast.None
 		ftyp := g.typ(node.types[0])
 		mut is_regular_option := ftyp in ['Option2', 'Option']
-		if optional_none || is_regular_option {
-			styp := g.typ(g.fn_decl.return_type)
-			g.write('return ($styp){ .state=2, .err=')
-			g.expr_with_cast(node.exprs[0], node.types[0], g.fn_decl.return_type)
-			g.writeln(' };')
-			return
-		} else if node.types[0] == ast.error_type_idx {
-			// foo() or { return err }
-			styp := g.typ(g.fn_decl.return_type)
-			g.write('return ($styp){.state=2, .err=')
-			g.expr_with_cast(node.exprs[0], node.types[0], g.fn_decl.return_type)
-			g.writeln(' };')
+		if optional_none || is_regular_option || node.types[0] == ast.error_type_idx {
+			g.write('return ')
+			g.gen_optional_error(g.fn_decl.return_type, node.exprs[0])
+			g.writeln(';')
 			return
 		}
 	}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4397,16 +4397,20 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 			|| (sym.info as ast.Alias).parent_type !in [node.expr_type, ast.string_type] {
 			cast_label = '($styp)'
 		}
-		g.write('(${cast_label}(')
-		g.expr(node.expr)
-		if node.expr is ast.IntegerLiteral {
-			if node.typ in [ast.u64_type, ast.u32_type, ast.u16_type] {
-				if !node.expr.val.starts_with('-') {
-					g.write('U')
+		if node.typ.has_flag(.optional) {
+			g.gen_optional_error(node.typ, node.expr)
+		} else {
+			g.write('(${cast_label}(')
+			g.expr(node.expr)
+			if node.expr is ast.IntegerLiteral {
+				if node.typ in [ast.u64_type, ast.u32_type, ast.u16_type] {
+					if !node.expr.val.starts_with('-') {
+						g.write('U')
+					}
 				}
 			}
+			g.write('))')
 		}
-		g.write('))')
 	}
 }
 

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4382,8 +4382,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 		g.write(')')
 	} else if sym.kind in [.sum_type, .interface_] {
 		g.expr_with_cast(node.expr, node.expr_type, node.typ)
-	} else if sym.kind == .struct_ && !node.typ.is_ptr()
-		&& !(sym.info as ast.Struct).is_typedef {
+	} else if sym.kind == .struct_ && !node.typ.is_ptr() && !(sym.info as ast.Struct).is_typedef {
 		// deprecated, replaced by Struct{...exr}
 		styp := g.typ(node.typ)
 		g.write('*(($styp *)(&')

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1933,14 +1933,15 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 	} else {
 		false
 	}
+	is_optional := p.tok.kind == .question
 	// p.warn('name expr  $p.tok.lit $p.peek_tok.str()')
 	same_line := p.tok.line_nr == p.peek_tok.line_nr
 	// `(` must be on same line as name token otherwise it's a ParExpr
 	if !same_line && p.peek_tok.kind == .lpar {
 		node = p.parse_ident(language)
-	} else if p.peek_tok.kind == .lpar || p.is_generic_call() {
+	} else if p.peek_tok.kind == .lpar || (is_optional && p.peek_token(2).kind == .lpar) || p.is_generic_call() {
 		// foo(), foo<int>() or type() cast
-		mut name := p.tok.lit
+		mut name := if is_optional { p.peek_tok.lit } else { p.tok.lit }
 		if mod.len > 0 {
 			name = '${mod}.$name'
 		}
@@ -1987,6 +1988,9 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 		} else {
 			// fn call
 			// println('calling $p.tok.lit')
+			if is_optional {
+				p.error_with_pos('unexpected $p.prev_tok', p.prev_tok.position())
+			}
 			node = p.call_expr(language, mod)
 		}
 	} else if (p.peek_tok.kind == .lcbr || (p.peek_tok.kind == .lt && lit0_is_capital))

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1939,7 +1939,8 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 	// `(` must be on same line as name token otherwise it's a ParExpr
 	if !same_line && p.peek_tok.kind == .lpar {
 		node = p.parse_ident(language)
-	} else if p.peek_tok.kind == .lpar || (is_optional && p.peek_token(2).kind == .lpar) || p.is_generic_call() {
+	} else if p.peek_tok.kind == .lpar
+		|| (is_optional && p.peek_token(2).kind == .lpar) || p.is_generic_call() {
 		// foo(), foo<int>() or type() cast
 		mut name := if is_optional { p.peek_tok.lit } else { p.tok.lit }
 		if mod.len > 0 {

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -25,7 +25,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			node = p.parse_ident(ast.Language.v)
 			p.is_stmt_ident = is_stmt_ident
 		}
-		.name {
+		.name, .question {
 			if p.tok.lit == 'sql' && p.peek_tok.kind == .name {
 				p.inside_match = true // reuse the same var for perf instead of inside_sql TODO rename
 				node = p.sql_expr()

--- a/vlib/v/tests/optional_assign_test.v
+++ b/vlib/v/tests/optional_assign_test.v
@@ -6,6 +6,12 @@ fn test_optional_none_assign() {
 	// assert !x.has_value
 }
 
+fn test_optional_none_assign_nonsumtype() {
+	x := ?int(none)
+	// assert x.err == none
+	// assert !x.has_value
+}
+
 // TODO: make this working next
 /*
 fn test_optional_value_assign() {

--- a/vlib/v/tests/optional_assign_test.v
+++ b/vlib/v/tests/optional_assign_test.v
@@ -1,0 +1,19 @@
+type Foo = int | string
+
+fn test_optional_none_assign() {
+	x := ?Foo(none)
+	// assert x.err == none
+	// assert !x.has_value
+}
+
+// TODO: make this working next
+/*
+fn test_optional_value_assign() {
+	x := ?Foo('test')
+}
+
+fn test_optional_none_reassign() {
+	mut x := ?Foo('test')
+	x = none
+}
+*/


### PR DESCRIPTION
```
type Foo = int | string

fn main() {
	x := ?Foo(none)
}
```

This compiles for now. But Optional doesn't have methods or attributes that are accessable..

Don't know how we can make
```
x.has_value
```
working 