### PR TITLE
ast, parser: add type_pos to TypeDecl nodes

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1634,7 +1634,8 @@ pub fn (node Node) position() token.Position {
 		StructField {
 			return node.pos.extend(node.type_pos)
 		}
-		MatchBranch, SelectBranch, EnumField, ConstField, StructInitField, GlobalField, CallArg, SumTypeVariant {
+		MatchBranch, SelectBranch, EnumField, ConstField, StructInitField, GlobalField, CallArg,
+		SumTypeVariant {
 			return node.pos
 		}
 		Param {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1304,6 +1304,7 @@ pub fn (mut f Fmt) fn_type_decl(node ast.FnTypeDecl) {
 	}
 
 	f.comments(node.comments, has_nl: false)
+	f.writeln('')
 }
 
 pub fn (mut f Fmt) sum_type_decl(node ast.SumTypeDecl) {

--- a/vlib/v/fmt/tests/types_expected.vv
+++ b/vlib/v/fmt/tests/types_expected.vv
@@ -3,7 +3,6 @@ type FooBar = Bar | Foo
 pub type PublicBar = Bar | Foo | FooBar
 
 type Uint = byte | u16 | u32 | u64 // This should stay on the same line
-
 type Float = f32 | f64
 
 // Alias type
@@ -14,6 +13,7 @@ pub type Abc = f32
 // Fn type decl
 
 type EmptyFn = fn ()
+
 type OneArgFn = fn (i int)
 
 type TwoDiffArgs = fn (i int, s string) bool

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -510,6 +510,7 @@ fn (mut p Parser) fn_receiver(mut params []ast.Param, mut rec ReceiverParsingInf
 		is_mut: rec.is_mut
 		is_auto_rec: is_auto_rec
 		typ: rec.typ
+		type_pos: rec.type_pos
 	}
 	p.check(.rpar)
 

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2955,12 +2955,14 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		// function type: `type mycallback = fn(string, int)`
 		fn_name := p.prepend_mod(name)
 		fn_type := p.parse_fn_type(fn_name)
+		type_pos = type_pos.extend(p.tok.position())
 		comments = p.eat_comments(same_line: true)
 		return ast.FnTypeDecl{
 			name: fn_name
 			is_pub: is_pub
 			typ: fn_type
 			pos: decl_pos
+			type_pos: type_pos
 			comments: comments
 		}
 	}
@@ -3045,6 +3047,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		name: name
 		is_pub: is_pub
 		parent_type: parent_type
+		type_pos: type_pos
 		pos: decl_pos
 		comments: comments
 	}


### PR DESCRIPTION
This PR adds type_pos field to all of the member structs under the TypeDecl sum type. The SumTypeVariant is also added into `ast.Node`. Required for https://github.com/vlang/vls/pull/95