### PR TITLE
orm: add not equal token to orm

### DIFF
--- a/vlib/orm/orm_test.v
+++ b/vlib/orm/orm_test.v
@@ -30,6 +30,12 @@ fn test_orm_sqlite() {
 	db.exec("insert into User (name, age) values ('Peter', 31)")
 	db.exec("insert into User (name, age, is_customer) values ('Kate', 30, 1)")
 
+
+	c := sql db {
+		select count from User where id != 1
+	}
+	assert c == 2
+
 	nr_all_users := sql db {
 		select count from User
 	}

--- a/vlib/orm/orm_test.v
+++ b/vlib/orm/orm_test.v
@@ -30,7 +30,6 @@ fn test_orm_sqlite() {
 	db.exec("insert into User (name, age) values ('Peter', 31)")
 	db.exec("insert into User (name, age, is_customer) values ('Kate', 30, 1)")
 
-
 	c := sql db {
 		select count from User where id != 1
 	}

--- a/vlib/v/gen/c/sql.v
+++ b/vlib/v/gen/c/sql.v
@@ -372,6 +372,7 @@ fn (mut g Gen) expr_to_sql(expr ast.Expr, typ SqlType) {
 			g.sql_side = .left
 			g.expr_to_sql(expr.left, typ)
 			match expr.op {
+				.ne { g.write(' != ') }
 				.eq { g.write(' = ') }
 				.gt { g.write(' > ') }
 				.lt { g.write(' < ') }


### PR DESCRIPTION
This PR adds the not-equal (!=) token to orm. Close #9590 