### PR TITLE
map: fix delete 

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -637,16 +637,9 @@ fn (mut d DenseArray) delete(i int) {
 	}
 }
 
-// delete this
-pub fn (mut m map) delete(key string) {
-	unsafe {
-		m.delete_1(&key)
-	}
-}
-
 // Removes the mapping of a particular key from the map.
 [unsafe]
-pub fn (mut m map) delete_1(key voidptr) {
+pub fn (mut m map) delete(key voidptr) {
 	mut index, mut meta := m.key_to_index(key)
 	index, meta = m.meta_less(index, meta)
 	// Perform backwards shifting

--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -568,9 +568,9 @@ fn test_int_keys() {
 	}
 
 	four := 4
-	m2.delete_1(3)
-	m2.delete_1(four)
-	m2.delete_1(5)
+	m2.delete(3)
+	m2.delete(four)
+	m2.delete(5)
 	assert m2.len == 0
 	assert m2[3] == 0
 	assert m2[4] == 0
@@ -603,7 +603,7 @@ fn test_int_keys() {
 		2: 'two'
 	}
 	assert m3[1] == 'one'
-	m3.delete_1(1)
+	m3.delete(1)
 }
 
 fn test_voidptr_keys() {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1750,7 +1750,7 @@ fn (mut c Checker) map_builtin_method_call(mut call_expr ast.CallExpr, left_type
 			info := left_type_sym.info as ast.Map
 			arg_type := c.expr(call_expr.args[0].expr)
 			c.check_expected_call_arg(arg_type, info.key_type, call_expr.language) or {
-				c.error('$err.msg', call_expr.args[0].pos)
+				c.error('$err.msg in argument 1 to `Map.delete`', call_expr.args[0].pos)
 			}
 		}
 		else {}

--- a/vlib/v/checker/tests/map_delete.out
+++ b/vlib/v/checker/tests/map_delete.out
@@ -1,0 +1,20 @@
+vlib/v/checker/tests/map_delete.vv:5:11: error: cannot use `int literal` as `string`
+    3 |         '1': 1
+    4 |     }
+    5 |     m.delete(1)
+      |              ^
+    6 |     m.delete(1, 2)
+    7 |     m2 := {
+vlib/v/checker/tests/map_delete.vv:6:4: error: expected 1 argument, but got 2
+    4 |     }
+    5 |     m.delete(1)
+    6 |     m.delete(1, 2)
+      |       ~~~~~~~~~~~~
+    7 |     m2 := {
+    8 |         '1': 1
+vlib/v/checker/tests/map_delete.vv:10:2: error: `m2` is immutable, declare it with `mut` to make it mutable
+    8 |         '1': 1
+    9 |     }
+   10 |     m2.delete('1')
+      |     ~~
+   11 | }

--- a/vlib/v/checker/tests/map_delete.out
+++ b/vlib/v/checker/tests/map_delete.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/map_delete.vv:5:11: error: cannot use `int literal` as `string`
+vlib/v/checker/tests/map_delete.vv:5:11: error: cannot use `int literal` as `string` in argument 1 to `Map.delete`
     3 |         '1': 1
     4 |     }
     5 |     m.delete(1)

--- a/vlib/v/checker/tests/map_delete.vv
+++ b/vlib/v/checker/tests/map_delete.vv
@@ -1,0 +1,11 @@
+fn main() {
+	mut m := {
+		'1': 1
+	}
+	m.delete(1)
+	m.delete(1, 2)
+	m2 := {
+		'1': 1
+	}
+	m2.delete('1')
+}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -551,10 +551,10 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		}
 	}
 
-	if left_sym.kind == .map && node.name == 'delete_1' {
+	if left_sym.kind == .map && node.name == 'delete' {
 		left_info := left_sym.info as ast.Map
 		elem_type_str := g.typ(left_info.key_type)
-		g.write('map_delete_1(&')
+		g.write('map_delete(&')
 		g.expr(node.left)
 		g.write(', &($elem_type_str[]){')
 		g.expr(node.args[0].expr)


### PR DESCRIPTION
This add checks for `Map.delete` and renames `Map.delete_1`to `Map.delete` :rocket: 
```
vlib/v/checker/tests/map_delete.vv:5:11: error: cannot use `int literal` as `string` in argument 1 to `Map.delete`
    3 |         '1': 1
    4 |     }
    5 |     m.delete(1)
      |              ^
    6 |     m.delete(1, 2)
    7 |     m2 := {
vlib/v/checker/tests/map_delete.vv:6:4: error: expected 1 argument, but got 2
    4 |     }
    5 |     m.delete(1)
    6 |     m.delete(1, 2)
      |       ~~~~~~~~~~~~
    7 |     m2 := {
    8 |         '1': 1
vlib/v/checker/tests/map_delete.vv:10:2: error: `m2` is immutable, declare it with `mut` to make it mutable
    8 |         '1': 1
    9 |     }
   10 |     m2.delete('1')
      |     ~~
   11 | }
   ```