### PR TITLE
tmpl: fix outout when inline style  has attribute

### DIFF
--- a/vlib/v/parser/tmpl.v
+++ b/vlib/v/parser/tmpl.v
@@ -19,6 +19,42 @@ enum State {
 	// span // span.{
 }
 
+// check HTML open tag `<name attr="x" >`
+fn is_html_open_tag(name string, s string) bool {
+	mut len := s.len
+	if len < name.len {
+		return false
+	}
+	mut sub := s[0..1]
+	if sub != '<' { // not start with '<'
+		return false
+	}
+	sub = s[len - 1..len]
+	if sub != '>' { // not end with '<'
+		return false
+	}
+	sub = s[len - 2..len - 1]
+	if sub == '/' { // self-closing
+		return false
+	}
+	sub = s[1..len - 1]
+	if sub.contains_any('<>') { // `<name <bad> >`
+		return false
+	}
+	if sub == name { // `<name>`
+		return true
+	} else {
+		len = name.len
+		if sub.len <= len { // `<nam>` or `<meme>`
+			return false
+		}
+		if sub[..len + 1] != '$name ' { // not `<name ...>`
+			return false
+		}
+		return true
+	}
+}
+
 // compile_file compiles the content of a file by the given path as a template
 pub fn (mut p Parser) compile_template_file(template_file string, fn_name string) string {
 	mut lines := os.read_lines(template_file) or {
@@ -50,11 +86,11 @@ mut sb := strings.new_builder($lstartlength)\n
 			eprintln('>>> tfile: $template_file, spos: ${start_of_line_pos:6}, epos:${end_of_line_pos:6}, fi: ${tline_number:5}, i: ${i:5}, line: $oline')
 		}
 		line := oline.trim_space()
-		if line == '<style>' {
+		if is_html_open_tag('style', line) {
 			state = .css
 		} else if line == '</style>' {
 			state = .html
-		} else if line == '<script>' {
+		} else if is_html_open_tag('script', line) {
 			state = .js
 		} else if line == '</script>' {
 			state = .html

--- a/vlib/v/parser/v_parser_test.v
+++ b/vlib/v/parser/v_parser_test.v
@@ -218,3 +218,49 @@ for s in text_expr {
 	println('===================')
 }
 */
+
+fn test_fn_is_html_open_tag() {
+	mut s := '<style>'
+	mut b := is_html_open_tag('style', s)
+	assert b == true
+
+	s = '<style    media="print"    custom-attr    >'
+	b = is_html_open_tag('style', s)
+	assert b == true
+
+	s = '<style/>'
+	b = is_html_open_tag('style', s)
+	assert b == false
+
+	s = 'styl'
+	b = is_html_open_tag('style', s)
+	assert b == false
+
+	s = 'style'
+	b = is_html_open_tag('style', s)
+	assert b == false
+
+	s = '<style'
+	b = is_html_open_tag('style', s)
+	assert b == false
+
+	s = '<<style>'
+	b = is_html_open_tag('style', s)
+	assert b == false
+
+	s = '<style>>'
+	b = is_html_open_tag('style', s)
+	assert b == false
+
+	s = '<stylex>'
+	b = is_html_open_tag('style', s)
+	assert b == false
+
+	s = '<html>'
+	b = is_html_open_tag('style', s)
+	assert b == false
+
+	s = '<sript>'
+	b = is_html_open_tag('style', s)
+	assert b == false
+}

--- a/vlib/v/tests/inout/file.html
+++ b/vlib/v/tests/inout/file.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<style>
+h1 {
+color: green;
+}
+</style>
+<style media="print">
+h1 {
+color: red;
+}
+</style>
+<script type="application/ld+json">
+<!-- JSON-LD -->
+</script>
+<script>
+document.getElementById("demo").innerHTML = "Hello JavaScript!";
+</script>
+</head>
+
+<body>
+<header>
+<h1>@{title}</h1>
+</header>
+</body>
+
+</html>

--- a/vlib/v/tests/inout/tmpl_parse_html.out
+++ b/vlib/v/tests/inout/tmpl_parse_html.out
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<style>
+h1 {
+color: green;
+}
+</style>
+<style media="print">
+h1 {
+color: red;
+}
+</style>
+<script type="application/ld+json">
+<!-- JSON-LD -->
+</script>
+<script>
+document.getElementById("demo").innerHTML = "Hello JavaScript!";
+</script>
+</head>
+
+<body>
+<header>
+<h1>TEST</h1>
+</header>
+</body>
+
+</html>

--- a/vlib/v/tests/inout/tmpl_parse_html.vv
+++ b/vlib/v/tests/inout/tmpl_parse_html.vv
@@ -1,0 +1,8 @@
+fn abc() string {
+	title := 'TEST'
+	return $tmpl('file.html')
+}
+
+fn main() {
+	print(abc())
+}


### PR DESCRIPTION
FIx issue #9594 .

Add `is_html_open_tag` function for checking inline style & script.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
