### PR TITLE
bitfield: add methods `insert` and `extract`

### DIFF
--- a/vlib/bitfield/bitfield.v
+++ b/vlib/bitfield/bitfield.v
@@ -140,11 +140,12 @@ pub fn (mut instance BitField) clear_bit(bitnr int) {
 // extract returns the value converted from a slice of bit numbers
 // from 'start' by the length of 'len'.
 pub fn (instance BitField) extract(start int, len int) u64 {
+	// panic?
 	if start < 0 {
-		return 0 // or panic?
+		return 0
 	}
 	mut output := u64(0)
-	for i in 0..len {
+	for i in 0 .. len {
 		output |= u64(instance.get_bit(start + i)) << i
 	}
 	return output
@@ -153,11 +154,12 @@ pub fn (instance BitField) extract(start int, len int) u64 {
 // insert sets bit numbers from 'start' to 'len' length with
 // the value converted from the number 'value'.
 pub fn (mut instance BitField) insert<T>(start int, len int, _value T) {
+	// panic?
 	if start < 0 {
-		return // or panic?
+		return
 	}
 	mut value := _value
-	for pos in start..start+len {
+	for pos in start .. start + len {
 		if value & 1 == 1 {
 			instance.set_bit(pos)
 		} else {

--- a/vlib/bitfield/bitfield.v
+++ b/vlib/bitfield/bitfield.v
@@ -139,7 +139,43 @@ pub fn (mut instance BitField) clear_bit(bitnr int) {
 
 // extract returns the value converted from a slice of bit numbers
 // from 'start' by the length of 'len'.
+// 0101 (1, 2) => 0b10
 pub fn (instance BitField) extract(start int, len int) u64 {
+	// panic?
+	if start < 0 {
+		return 0
+	}
+	mut output := u64(0)
+	for i in 0 .. len {
+		output |= u64(instance.get_bit(start + len - i - 1)) << i
+	}
+	return output
+}
+
+// insert sets bit numbers from 'start' to 'len' length with
+// the value converted from the number 'value'.
+// 0000 (1, 2, 0b10) => 0100
+pub fn (mut instance BitField) insert<T>(start int, len int, _value T) {
+	// panic?
+	if start < 0 {
+		return
+	}
+	mut value := _value
+	for i in 0 .. len {
+		pos := start + len - i - 1
+		if value & 1 == 1 {
+			instance.set_bit(pos)
+		} else {
+			instance.clear_bit(pos)
+		}
+		value >>= 1
+	}
+}
+
+// extract returns the value converted from a slice of bit numbers
+// from 'start' by the length of 'len'.
+// 0101 (1, 2) => 0b01
+pub fn (instance BitField) extract_lowest_bits_first(start int, len int) u64 {
 	// panic?
 	if start < 0 {
 		return 0
@@ -153,7 +189,8 @@ pub fn (instance BitField) extract(start int, len int) u64 {
 
 // insert sets bit numbers from 'start' to 'len' length with
 // the value converted from the number 'value'.
-pub fn (mut instance BitField) insert<T>(start int, len int, _value T) {
+// 0000 (1, 2, 0b10) => 0010
+pub fn (mut instance BitField) insert_lowest_bits_first<T>(start int, len int, _value T) {
 	// panic?
 	if start < 0 {
 		return

--- a/vlib/bitfield/bitfield.v
+++ b/vlib/bitfield/bitfield.v
@@ -137,6 +137,36 @@ pub fn (mut instance BitField) clear_bit(bitnr int) {
 	instance.field[bitslot(bitnr)] &= ~bitmask(bitnr)
 }
 
+// extract returns the value converted from a slice of bit numbers
+// from 'start' by the length of 'len'.
+pub fn (instance BitField) extract(start int, len int) u64 {
+	if start < 0 {
+		return 0 // or panic?
+	}
+	mut output := u64(0)
+	for i in 0..len {
+		output |= u64(instance.get_bit(start + i)) << i
+	}
+	return output
+}
+
+// insert sets bit numbers from 'start' to 'len' length with
+// the value converted from the number 'value'.
+pub fn (mut instance BitField) insert<T>(start int, len int, _value T) {
+	if start < 0 {
+		return // or panic?
+	}
+	mut value := _value
+	for pos in start..start+len {
+		if value & 1 == 1 {
+			instance.set_bit(pos)
+		} else {
+			instance.clear_bit(pos)
+		}
+		value >>= 1
+	}
+}
+
 // set_all sets all bits in the array to 1.
 pub fn (mut instance BitField) set_all() {
 	for i in 0 .. zbitnslots(instance.size) {

--- a/vlib/bitfield/bitfield_test.v
+++ b/vlib/bitfield/bitfield_test.v
@@ -20,9 +20,14 @@ fn test_bf_insert_extract() {
 	mut instance := bitfield.new(11)
 	instance.set_all()
 	instance.insert(2, 9, 3)
-	assert instance.extract(2, 1) == 1
-	assert instance.extract(2, 8) == 3
-	assert instance.extract(10, 1) == 0
+	assert instance.extract(2, 1) == 0
+	assert instance.extract(2, 8) == 1
+	assert instance.extract(10, 1) == 1
+	instance.set_all()
+	instance.insert_lowest_bits_first(2, 9, 3)
+	assert instance.extract_lowest_bits_first(2, 1) == 1
+	assert instance.extract_lowest_bits_first(2, 8) == 3
+	assert instance.extract_lowest_bits_first(10, 1) == 0
 }
 
 fn test_bf_and_not_or_xor() {

--- a/vlib/bitfield/bitfield_test.v
+++ b/vlib/bitfield/bitfield_test.v
@@ -16,6 +16,15 @@ fn test_bf_set_clear_toggle_get() {
 	assert instance.get_bit(47) == 1
 }
 
+fn test_bf_insert_extract() {
+	mut instance := bitfield.new(11)
+	instance.set_all()
+	instance.insert(2, 9, 3)
+	assert instance.extract(2, 1) == 1
+	assert instance.extract(2, 8) == 3
+	assert instance.extract(10, 1) == 0
+}
+
 fn test_bf_and_not_or_xor() {
 	len := 80
 	mut input1 := bitfield.new(len)


### PR DESCRIPTION
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Add methods `insert` and `extract` to bitfield module.
```v
mut instance := bitfield.new(8)
instance.clear_all()
instance.insert(1, 4, 11) // instance is now 0 1 1 0 1 0 0 0
println(instance.extract(1, 2)) // prints 3
println(instance.extract(3, 2)) // prints 2
```
It can be used as bit packing as well.