### PR TITLE
checker: remove unecessary assert

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3569,7 +3569,6 @@ fn (mut c Checker) assert_stmt(node ast.AssertStmt) {
 
 fn (mut c Checker) block(node ast.Block) {
 	if node.is_unsafe {
-		assert !c.inside_unsafe
 		c.inside_unsafe = true
 		c.stmts(node.stmts)
 		c.inside_unsafe = false
@@ -5267,10 +5266,6 @@ pub fn (mut c Checker) lock_expr(mut node ast.LockExpr) ast.Type {
 }
 
 pub fn (mut c Checker) unsafe_expr(mut node ast.UnsafeExpr) ast.Type {
-	// assert !c.inside_unsafe
-	if c.inside_unsafe {
-		c.error('unsafe inside unsafe', node.pos)
-	}
 	c.inside_unsafe = true
 	t := c.expr(node.expr)
 	c.inside_unsafe = false


### PR DESCRIPTION
`assert` statements in the compiler should be avoided
Nested asserts are already checked in the parser



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
