### PR TITLE
vself: fix error of removing nonexists v_old

### DIFF
--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -67,7 +67,9 @@ fn backup_old_version_and_rename_newer() ?bool {
 	bak_file := os.real_path(short_bak_file)
 
 	list_folder('before:', 'removing $bak_file ...')
-	os.rm(bak_file) or { errors << 'failed removing $bak_file: $err.msg' }
+	if os.exists(bak_file) {
+		os.rm(bak_file) or { errors << 'failed removing $bak_file: $err.msg' }
+	}
 
 	list_folder('', 'moving $v_file to $bak_file ...')
 	os.mv(v_file, bak_file) or { errors << err.msg }


### PR DESCRIPTION
This PR fix error of removing nonexists v_old.

- Add `if os.exists(bak_file)` judgement.

before:
```vlang
yuyi@yuyi-PC:~/v$ v self
V self compiling ...
backup errors:
  >>  failed removing v_old: Failed to remove "v_old": No such file or directory
V built successfully!
```

now:
```vlang
yuyi@yuyi-PC:~/v$ v self
V self compiling ...
V built successfully!
```