### PR TITLE
vfmt: fix fn/method that return generic struct

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -930,6 +930,21 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 			}
 			res += ')'
 		}
+		.struct_ {
+			if typ.has_flag(.generic) {
+				info := sym.info as Struct
+				res += '<'
+				for i, gtyp in info.generic_types {
+					res += t.get_type_symbol(gtyp).name
+					if i != info.generic_types.len - 1 {
+						res += ', '
+					}
+				}
+				res += '>'
+			} else {
+				res = t.shorten_user_defined_typenames(res, import_aliases)
+			}
+		}
 		.void {
 			if typ.has_flag(.optional) {
 				return '?'

--- a/vlib/v/fmt/tests/fn_return_generic_struct_keep.vv
+++ b/vlib/v/fmt/tests/fn_return_generic_struct_keep.vv
@@ -1,0 +1,39 @@
+pub struct Optional<T> {
+mut:
+	value T
+	some  bool
+}
+
+pub struct Foo {
+	foo int
+}
+
+pub fn (f Foo) new_some<T>(value T) Optional<T> {
+	return {
+		value: value
+		some: true
+	}
+}
+
+pub fn (f Foo) some<T>(opt Optional<T>) bool {
+	return opt.some
+}
+
+pub fn (f Foo) get<T>(opt Optional<T>) T {
+	return opt.value
+}
+
+pub fn (f Foo) set<T>(mut opt Optional<T>, value T) {
+	opt.value = value
+	opt.some = true
+}
+
+fn main() {
+	foo := Foo{}
+	mut o := foo.new_some<int>(23)
+	println(foo.some<int>(o))
+	assert foo.some<int>(o) == true
+	foo.set<int>(mut o, 42)
+	println(foo.get<int>(o))
+	assert foo.get<int>(o) == 42
+}


### PR DESCRIPTION
This PR fix format error of fn/method that return generic struct.

- Fix format error of fn/method that return generic struct.
- Add test `vlib\v\fmt\tests\fn_return_generic_struct_keep.vv`.