### PR TITLE
sync: make `chan.close()` more robust for multiple calls

### DIFF
--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -138,7 +138,10 @@ fn new_channel_st(n u32, st u32) &Channel {
 }
 
 pub fn (mut ch Channel) close() {
-	C.atomic_store_u16(&ch.closed, 1)
+	open_val := u16(0)
+	if !C.atomic_compare_exchange_strong_u16(&ch.closed, &open_val, 1) {
+		return
+	}
 	mut nulladr := voidptr(0)
 	for !C.atomic_compare_exchange_weak_ptr(&ch.adr_written, &nulladr, voidptr(-1)) {
 		nulladr = voidptr(0)


### PR DESCRIPTION
When a channel is closed more than once, the behaviour has not been really well defined.
This PR makes things more robust by atomically checking/setting the `closed` flag and doing the cleanup only if the flag was not already set.
I.e. all but the first `chan.close()` are silently ignored (no matter in what thread they may appear).
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
