### PR TITLE
parser: fix error of `-foo.bar()`

### DIFF
--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -507,11 +507,7 @@ fn (mut p Parser) prefix_expr() ast.PrefixExpr {
 	// p.warn('unsafe')
 	// }
 	p.next()
-	mut right := if op == .minus {
-		p.expr(int(token.Precedence.call))
-	} else {
-		p.expr(int(token.Precedence.prefix))
-	}
+	mut right := p.expr(int(token.Precedence.prefix))
 	p.is_amp = false
 	if mut right is ast.CastExpr {
 		right.in_prexpr = true

--- a/vlib/v/tests/prefix_expr_test.v
+++ b/vlib/v/tests/prefix_expr_test.v
@@ -1,0 +1,25 @@
+fn value(n int) int {
+	return n
+}
+
+struct Foo {
+	n int
+}
+
+fn (foo Foo) value() int {
+	return foo.n
+}
+
+fn test_negative() {
+	one := 1
+	negative_one := -1
+	assert -one == negative_one
+	assert one == -negative_one
+
+	assert -value(1) == -1
+
+	// issue #9643
+	foo := Foo{1}
+	assert -foo.value() == -1
+	assert -(foo.value()) == -1
+}

--- a/vlib/v/tests/prefix_expr_test.v
+++ b/vlib/v/tests/prefix_expr_test.v
@@ -22,4 +22,8 @@ fn test_negative() {
 	foo := Foo{1}
 	assert -foo.value() == -1
 	assert -(foo.value()) == -1
+
+	arr := [1, 2, 3]
+	assert -arr[0] == -1
+	assert -arr[1] == -2
 }


### PR DESCRIPTION
fix #9643 

New test fail on current master

```
 FAIL   255.022 ms vlib/v/tests/prefix_expr_test.v
==================
/tmp/v/test_session_45397102546857/prefix_expr_test.6414832436039155658.tmp.c:13298:30: error: invalid argument type 'main__Foo' (aka 'struct main__Foo') to unary expression
        int _t308 = main__Foo_value(-foo);
                                    ^~~~
1 error generated.
...
==================
(Use `v -cg` to print the entire error message)


```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
