### PR TITLE
ast, checker: make SelectorExpr.root_ident return ?Ident

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -149,14 +149,18 @@ pub mut:
 }
 
 // root_ident returns the origin ident where the selector started.
-pub fn (e &SelectorExpr) root_ident() Ident {
+pub fn (e &SelectorExpr) root_ident() ?Ident {
 	mut root := e.expr
 	for root is SelectorExpr {
 		// TODO: remove this line
 		selector_expr := root as SelectorExpr
 		root = selector_expr.expr
 	}
-	return root as Ident
+	if root is Ident {
+		return root as Ident
+	}
+
+	return none
 }
 
 // module declaration

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5114,9 +5114,10 @@ fn (c Checker) smartcast(expr ast.Expr, cur_type ast.Type, to_type_ ast.Type, mu
 			mut orig_type := 0
 			if field := c.table.find_field(expr_sym, expr.field_name) {
 				if field.is_mut {
-					root_ident := expr.root_ident()
-					if v := scope.find_var(root_ident.name) {
-						is_mut = v.is_mut
+					if root_ident := expr.root_ident() {
+						if v := scope.find_var(root_ident.name) {
+							is_mut = v.is_mut
+						}
 					}
 				}
 				if orig_type == 0 {


### PR DESCRIPTION
This PR makes `SelectorExpr.root_ident` method return `?Ident` in order to prevent the as cast assertion error. Fixes https://github.com/vlang/vls/issues/100.

v-apps-compile CI failed because of VLS, but I will immediately add a fix as soon as it is merged.