### PR TITLE
parser: fix InterfaceDecl's position

### DIFF
--- a/vlib/v/checker/tests/incorrect_name_interface.out
+++ b/vlib/v/checker/tests/incorrect_name_interface.out
@@ -1,3 +1,3 @@
 vlib/v/checker/tests/incorrect_name_interface.vv:1:1: error: interface name `_MyInterface` must begin with capital letter
     1 | interface _MyInterface {}
-      | ~~~~~~~~~
+      | ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -571,7 +571,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 	ts.info = info
 	p.top_level_statement_end()
 	p.check(.rcbr)
-	pos.update_last_line(p.prev_tok.line_nr)
+	pos = pos.extend_with_last_line(p.prev_tok.position(), p.prev_tok.line_nr)
 	return ast.InterfaceDecl{
 		name: interface_name
 		fields: fields


### PR DESCRIPTION
This PR fixes InterfaceDecl's position by using extend_with_last_line to include the position of the last token instead of just the line number.