### PR TITLE
cgen: fix blank identifier in IfGard (`if _ := <-ch { ... }`, etc)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4570,20 +4570,20 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 						g.expr(branch.cond.expr)
 						g.writeln(', ${var_name}.state == 0) {')
 					}
-					if branch.cond.var_name != '_' {
+					if short_opt || branch.cond.var_name != '_' {
 						base_type := g.base_type(branch.cond.expr_type)
 						if short_opt {
-							g.write('\t$base_type $branch.cond.var_name = ')
+							cond_var_name := if branch.cond.var_name == '_' {
+								'_dummy_${g.tmp_count + 1}'
+							} else {
+								branch.cond.var_name
+							}
+							g.write('\t$base_type $cond_var_name = ')
 							g.expr(branch.cond.expr)
 							g.writeln(';')
 						} else {
 							g.writeln('\t$base_type $branch.cond.var_name = *($base_type*)${var_name}.data;')
 						}
-					} else if short_opt {
-						base_type := g.base_type(branch.cond.expr_type)
-						g.write('\t$base_type _dummy_${g.tmp_count + 1} = ')
-						g.expr(branch.cond.expr)
-						g.writeln(';')
 					}
 				}
 				else {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4579,6 +4579,11 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 						} else {
 							g.writeln('\t$base_type $branch.cond.var_name = *($base_type*)${var_name}.data;')
 						}
+					} else if short_opt {
+						base_type := g.base_type(branch.cond.expr_type)
+						g.write('\t$base_type _dummy_${g.tmp_count + 1} = ')
+						g.expr(branch.cond.expr)
+						g.writeln(';')
 					}
 				}
 				else {

--- a/vlib/v/tests/if_guard_test.v
+++ b/vlib/v/tests/if_guard_test.v
@@ -17,6 +17,14 @@ fn test_fn_return() {
 	assert res == [31.0, 7.5]
 }
 
+fn test_fn_return_empty() {
+	if _ := f(-3) {
+		assert false
+	} else {
+		assert true
+	}
+}
+
 fn test_map_get() {
 	mut m := map{
 		'xy': 5
@@ -33,6 +41,18 @@ fn test_map_get() {
 	assert res == [-17, 7]
 }
 
+fn test_map_get_empty() {
+	mut m := map{
+		'xy': 5
+		'zu': 7
+	}
+	if _ := m['jk'] {
+		assert false
+	} else {
+		assert true
+	}
+}
+
 fn test_array_get() {
 	mut a := [12.5, 6.5, -17.25]
 	mut res := []f64{cap: 2}
@@ -44,6 +64,15 @@ fn test_array_get() {
 		}
 	}
 	assert res == [6.5, -23.0]
+}
+
+fn test_array_get_empty() {
+	mut a := [12.5, 6.5, -17.25]
+	if _ := a[7] {
+		assert false
+	} else {
+		assert true
+	}
 }
 
 fn test_chan_pop() {
@@ -60,6 +89,20 @@ fn test_chan_pop() {
 		}
 	}
 	assert res == [6.75, -3.25, -37.5]
+}
+
+fn test_chan_pop_empty() {
+	ch := chan f64{cap: 10}
+	ch <- 6.75
+	ch <- -3.25
+	ch.close()
+	for i in 0 .. 3 {
+		if _ := <-ch {
+			assert i < 2
+		} else {
+			assert i == 2
+		}
+	}
 }
 
 struct Thing {


### PR DESCRIPTION
This PR fixes the usage of a blank identifier in if-guards involving channels-pop and index expressions:
```v
if _ := <-ch {
    // ...
}

if _ := m[index_or_key] { // array or map
    // ...
}
```
These cases have caused C compiler errors. The function call case (`if _ := f() { ... }`) did work already, nevertheless I've added a test case for this, too.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
