### PR TITLE
http.parse_response() make public (for use by http servers)

### DIFF
--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -261,7 +261,7 @@ fn (req &Request) method_and_url_to_response(method Method, url urllib.URL) ?Res
 	return error('http.request.method_and_url_to_response: unsupported scheme: "$scheme"')
 }
 
-fn parse_response(resp string) Response {
+pub fn parse_response(resp string) Response {
 	mut header := new_header()
 	// TODO: Cookie data type
 	mut cookies := map[string]string{}


### PR DESCRIPTION
with a private http.parse_response() only http.http_do() can make use of it. server apps that setup a tcp listener need to parse just the bytes of the reponse, without involving the transport. vweb gets around this by re-implemented request parsing, which should also be changed to use this http function once its public.