### PR TITLE
sync: fix `chan.close()` while sending thread is waiting

### DIFF
--- a/vlib/sync/channel_close_test.v
+++ b/vlib/sync/channel_close_test.v
@@ -74,25 +74,35 @@ fn test_channel_close_unbuffered() {
 
 fn test_channel_send_close_buffered() {
 	ch := chan int{cap: 1}
-	go fn (ch chan int) {
+	t := go fn (ch chan int) {
 		ch <- 31
-		ch <- 17 or {}
+		mut x := 45
+		ch <- 17 or {
+			x = -133
+		}
+		assert x == -133
 	}(ch)
 	time.sleep(100 * time.millisecond)
 	ch.close()
 	mut r := <-ch
 	r = <-ch or { 23 }
 	assert r == 23
+	t.wait()
 }
 
 fn test_channel_send_close_unbuffered() {
 	time.sleep(1 * time.second)
 	ch := chan int{}
-	go fn (ch chan int) {
-		ch <- 177 or {}
+	t := go fn (ch chan int) {
+		mut x := 31
+		ch <- 177 or {
+			x = -71
+		}
+		assert x == -71
 	}(ch)
 	time.sleep(100 * time.millisecond)
 	ch.close()
 	r := <-ch or { 238 }
 	assert r == 238
+	t.wait()
 }

--- a/vlib/sync/channel_close_test.v
+++ b/vlib/sync/channel_close_test.v
@@ -1,4 +1,4 @@
-import sync
+import time
 
 fn do_rec(ch chan int, resch chan i64) {
 	mut sum := i64(0)
@@ -70,4 +70,29 @@ fn test_channel_close_unbuffered() {
 	mut sum := i64(0)
 	sum += <-resch
 	assert sum == i64(8000) * (8000 - 1) / 2
+}
+
+fn test_channel_send_close_buffered() {
+	ch := chan int{cap: 1}
+	go fn (ch chan int) {
+		ch <- 31
+		ch <- 17 or {}
+	}(ch)
+	time.sleep(100 * time.millisecond)
+	ch.close()
+	mut r := <-ch
+	r = <-ch or { 23 }
+	assert r == 23
+}
+
+fn test_channel_send_close_unbuffered() {
+	time.sleep(1 * time.second)
+	ch := chan int{}
+	go fn (ch chan int) {
+		ch <- 177 or {}
+	}(ch)
+	time.sleep(100 * time.millisecond)
+	ch.close()
+	r := <-ch or { 238 }
+	assert r == 238
 }

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -165,6 +165,9 @@ pub fn (mut ch Channel) close() {
 	}
 	C.atomic_store_u16(&ch.write_sub_mtx, u16(0))
 	ch.writesem.post()
+	if ch.cap == 0 {
+		C.atomic_store_ptr(&ch.read_adr, voidptr(0))
+	}
 	ch.writesem_im.post()
 }
 


### PR DESCRIPTION
When a channel is closed, waiting send statements `ch <- x or { ... }` should be interrupted and the `or` branch should be executed. Any later attempt to receive from this channel `x := <-ch or { ... }` should fail executing the `or` branch, too.

This did not work correctly for unbuffered channels. This PR fixes the issue by doing an additional cleanup step. Test cases for both the buffered and the unbuffered case are added.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
