### PR TITLE
cgen: fix generics struct_init (fix #8932 #9184)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5002,7 +5002,7 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 		g.go_back_out(3)
 		return
 	}
-	sym := g.table.get_final_type_symbol(struct_init.typ)
+	sym := g.table.get_final_type_symbol(g.unwrap_generic(struct_init.typ))
 	is_amp := g.is_amp
 	is_multiline := struct_init.fields.len > 5
 	g.is_amp = false // reset the flag immediately so that other struct inits in this expr are handled correctly

--- a/vlib/v/tests/generics_struct_init_test.v
+++ b/vlib/v/tests/generics_struct_init_test.v
@@ -1,0 +1,15 @@
+struct Blah {
+mut:
+	arr []string
+}
+
+fn test<T>() T {
+	return T{}
+}
+
+fn test_generics_struct_init() {
+	mut b := test<Blah>()
+	b.arr << 'item'
+	println(b.arr)
+	assert b.arr == ['item']
+}


### PR DESCRIPTION
This PR fix generics struct_init (fix #8932 fix #9184).

- Fix generics struct_init.
- Add test.

```vlang
struct Blah {
mut:
	arr []string
}

fn test<T>() T {
	return T{}
}

fn main() {
	mut b := test<Blah>()
	b.arr << 'item'
	println(b)
}

D:\Test\v\tt1>v run .
Blah{
    arr: ['item']
}
```
```vlang
import vweb

struct App {
	vweb.Context
mut:
	cache Cache = {}
}

struct KVStrings {
	key string
	value string
}

struct Cache {
mut:
	kvs []KVStrings = []
}

fn main() {
	vweb.run<App>(8080)
}

['/post/:k/:v']
fn (mut app App) post_kv(k string, v string) vweb.Result {
	println('post_kv: $k -> $v')
	println('${app.cache.kvs}')
//	app.cache.kvs = []

	app.cache.kvs << KVStrings{
		key: 'a'
		value: 'b'
	}
	vv := app.cache.kvs.len
	println('$vv')

	return app.text(v)
}

D:\Test\v\tt1>v run .
[Vweb] Running app on http://localhost:8080

```