### PR TITLE
checker: fix generics return generic struct (fix #9659)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1446,6 +1446,8 @@ fn (mut c Checker) check_return_generics_struct(return_type ast.Type, mut call_e
 					}
 					mut info := rts.info
 					info.generic_types = []
+					info.concrete_types = generic_types.clone()
+					info.parent_type = return_type
 					info.fields = fields
 					stru_idx := c.table.register_type_symbol(ast.TypeSymbol{
 						kind: .struct_

--- a/vlib/v/tests/generics_return_generics_struct_test.v
+++ b/vlib/v/tests/generics_return_generics_struct_test.v
@@ -2,11 +2,14 @@
 pub struct Optional<T> {
 mut:
 	value T
-	some bool
+	some  bool
 }
 
 pub fn new_some<T>(value T) Optional<T> {
-	return {value: value, some: true}
+	return {
+		value: value
+		some: true
+	}
 }
 
 pub fn some<T>(opt Optional<T>) bool {
@@ -36,19 +39,22 @@ pub struct Foo {
 	foo int
 }
 
-pub fn (f Foo)new_some<T>(value T) Optional<T> {
-	return {value: value, some: true}
+pub fn (f Foo) new_some<T>(value T) Optional<T> {
+	return {
+		value: value
+		some: true
+	}
 }
 
-pub fn (f Foo)some<T>(opt Optional<T>) bool {
+pub fn (f Foo) some<T>(opt Optional<T>) bool {
 	return opt.some
 }
 
-pub fn (f Foo)get<T>(opt Optional<T>) T {
+pub fn (f Foo) get<T>(opt Optional<T>) T {
 	return opt.value
 }
 
-pub fn (f Foo)set<T>(mut opt Optional<T>, value T) {
+pub fn (f Foo) set<T>(mut opt Optional<T>, value T) {
 	opt.value = value
 	opt.some = true
 }
@@ -71,11 +77,14 @@ mut:
 }
 
 pub fn iter<T>(arr []T) ArrayIterator<T> {
-	return ArrayIterator{data: arr, index: 11}
+	return ArrayIterator{
+		data: arr
+		index: 11
+	}
 }
 
 fn test_generics_with_generics_struct_string() {
-	data := ['foo' 'bar']
+	data := ['foo', 'bar']
 	it := iter<string>(data)
 	println(it)
 	ret := '$it'
@@ -86,7 +95,7 @@ fn test_generics_with_generics_struct_string() {
 
 fn test_generics_struct_insts_to_concrete() {
 	ai := ArrayIterator<int>{
-		data: [11, 22],
+		data: [11, 22]
 		index: 22
 	}
 	println(ai)
@@ -94,4 +103,24 @@ fn test_generics_struct_insts_to_concrete() {
 	assert ret.contains('ArrayIterator<int>{')
 	assert ret.contains('data: [11, 22]')
 	assert ret.contains('index: 22')
+}
+
+struct Iterator<T> {
+	data []T
+}
+
+pub fn (mut i Iterator<T>) next<T>() ?T {
+	return i.data[0]
+}
+
+pub fn iter_data<T>(data []T) Iterator<T> {
+	return Iterator{
+		data: data
+	}
+}
+
+fn test_generics_return_generic_struct_from_fn() {
+	mut it := iter_data<int>([1, 2, 3])
+	println(it.next())
+	assert '$it.next()' == 'Option(1)'
 }


### PR DESCRIPTION
This PR fix generics return generic struct (fix #9659).

- Fix generics return generic struct.
- Add test.

```vlang
struct Iterator<T> {
	data []T
}

pub fn (mut i Iterator<T>) next<T>() ?T {
	return i.data[0]
}

pub fn iter<T>(data []T) Iterator<T> {
	return Iterator<T>{ data: data }
}

fn main() {
	//mut it := Iterator<int>{data: [1 2 3]}
	mut it := iter<int>([1 2 3])
	println(it.next())
	assert '$it.next()' == 'Option(1)'
}

D:\Test\v\tt1>v run .
Option(1)
```