### PR TITLE
builtin: use NSLog on iOS for print

### DIFF
--- a/thirdparty/ios/ios.m
+++ b/thirdparty/ios/ios.m
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+void WrappedNSLog(const char *message,...) {
+    va_list args;
+    va_start(args, message);
+    NSLog(@"%@",[[NSString alloc] initWithFormat:[NSString stringWithUTF8String:message] arguments:args]);
+    va_end(args);
+}

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -89,6 +89,12 @@ pub fn eprintln(s string) {
 		} else {
 			C.fprintf(C.stderr, c'%.*s\n', s.len, s.str)
 		}
+	} $else $if ios {
+		if s.str == 0 {
+			C.WrappedNSLog(c'eprintln(NIL)\n')
+		} else {
+			C.WrappedNSLog(s.str)
+		}
 	} $else {
 		if s.str == 0 {
 			C.write(2, c'eprintln(NIL)\n', 14)
@@ -110,6 +116,13 @@ pub fn eprint(s string) {
 		} else {
 			C.fprintf(C.stderr, c'%.*s', s.len, s.str)
 		}
+	} $else $if ios {
+		// TODO: Implement a buffer as NSLog doesn't have a "print"
+		if s.str == 0 {
+			C.WrappedNSLog(c'eprint(NIL)')
+		} else {
+			C.WrappedNSLog(s.str)
+		}
 	} $else {
 		if s.str == 0 {
 			C.write(2, c'eprint(NIL)', 11)
@@ -125,7 +138,10 @@ pub fn eprint(s string) {
 pub fn print(s string) {
 	$if android {
 		C.fprintf(C.stdout, c'%.*s', s.len, s.str)
-	} $else {
+	} $else $if ios {
+		// TODO: Implement a buffer as NSLog doesn't have a "print"
+		C.WrappedNSLog(s.str)
+	}  $else {
 		C.write(1, s.str, s.len)
 	}
 }
@@ -142,6 +158,8 @@ pub fn println(s string) {
 	if s.str == 0 {
 		$if android {
 			C.fprintf(C.stdout, c'println(NIL)\n')
+		} $else $if ios {
+			C.WrappedNSLog(c'println(NIL)')
 		} $else {
 			C.write(1, c'println(NIL)\n', 13)
 		}
@@ -149,6 +167,8 @@ pub fn println(s string) {
 	}
 	$if android {
 		C.fprintf(C.stdout, c'%.*s\n', s.len, s.str)
+	} $else $if ios {
+		C.WrappedNSLog(s.str)
 	} $else {
 		C.write(1, s.str, s.len)
 		C.write(1, c'\n', 1)

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -141,7 +141,7 @@ pub fn print(s string) {
 	} $else $if ios {
 		// TODO: Implement a buffer as NSLog doesn't have a "print"
 		C.WrappedNSLog(s.str)
-	}  $else {
+	} $else {
 		C.write(1, s.str, s.len)
 	}
 }

--- a/vlib/builtin/builtin_ios.c.v
+++ b/vlib/builtin/builtin_ios.c.v
@@ -1,0 +1,8 @@
+module builtin
+
+// TODO: Remove this later, added to make sure v self works
+$if ios {
+	#include "@VROOT/thirdparty/ios/ios.m"
+}
+
+fn C.WrappedNSLog(str &byte)

--- a/vlib/builtin/builtin_ios.c.v
+++ b/vlib/builtin/builtin_ios.c.v
@@ -4,5 +4,3 @@ module builtin
 $if ios {
 	#include "@VROOT/thirdparty/ios/ios.m"
 }
-
-fn C.WrappedNSLog(str &byte)

--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -451,3 +451,6 @@ fn C.dup2(oldfd int, newfd int) int
 
 // used by gl, stbi, freetype
 fn C.glTexImage2D()
+
+// used by ios for println
+fn C.WrappedNSLog(str &byte)

--- a/vlib/v/pref/should_compile.v
+++ b/vlib/v/pref/should_compile.v
@@ -141,6 +141,9 @@ pub fn (prefs &Preferences) should_compile_c(file string) bool {
 	if (file.ends_with('_macos.c.v') || file.ends_with('_macos.v')) && prefs.os != .macos {
 		return false
 	}
+	if (file.ends_with('_ios.c.v') || file.ends_with('_ios.v')) && prefs.os != .ios  {
+		return false
+	}
 	if file.ends_with('_nix.c.v') && prefs.os == .windows {
 		return false
 	}

--- a/vlib/v/pref/should_compile.v
+++ b/vlib/v/pref/should_compile.v
@@ -141,7 +141,7 @@ pub fn (prefs &Preferences) should_compile_c(file string) bool {
 	if (file.ends_with('_macos.c.v') || file.ends_with('_macos.v')) && prefs.os != .macos {
 		return false
 	}
-	if (file.ends_with('_ios.c.v') || file.ends_with('_ios.v')) && prefs.os != .ios  {
+	if (file.ends_with('_ios.c.v') || file.ends_with('_ios.v')) && prefs.os != .ios {
 		return false
 	}
 	if file.ends_with('_nix.c.v') && prefs.os == .windows {


### PR DESCRIPTION
There's no easy way to view stdout on iOS, especially not on a physical device. NSLog on the other hand even logs over the network, so you can view the output in Console.app on macOS. It doesn't have a line buffer however, so that needs to be added later for print() to work properly. Right now each print() call is placed on a new line.