### PR TITLE
checker/cgen: fix `v := rlock m { m[key] or { default_val } }` 

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -77,9 +77,9 @@ pub:
 	expr     Expr
 	pos      token.Position
 	comments []Comment
-	is_expr  bool
 pub mut:
-	typ Type
+	is_expr bool
+	typ     Type
 }
 
 pub struct IntegerLiteral {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3502,7 +3502,23 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 		ast.ExprStmt {
 			node.typ = c.expr(node.expr)
 			c.expected_type = ast.void_type
-			c.check_expr_opt_call(node.expr, ast.void_type)
+			mut or_typ := ast.void_type
+			match node.expr {
+				ast.IndexExpr {
+					if node.expr.or_expr.kind != .absent {
+						node.is_expr = true
+						or_typ = node.typ
+					}
+				}
+				ast.PrefixExpr {
+					if node.expr.or_block.kind != .absent {
+						node.is_expr = true
+						or_typ = node.typ
+					}
+				}
+				else {}
+			}
+			c.check_expr_opt_call(node.expr, or_typ)
 			// TODO This should work, even if it's prolly useless .-.
 			// node.typ = c.check_expr_opt_call(node.expr, ast.void_type)
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3827,6 +3827,9 @@ fn (mut g Gen) lock_expr(node ast.LockExpr) {
 	}
 	g.writeln('/*lock*/ {')
 	g.stmts_with_tmp_var(node.stmts, tmp_result)
+	if node.is_expr {
+		g.writeln(';')
+	}
 	g.writeln('}')
 	if node.lockeds.len == 0 {
 		// this should not happen

--- a/vlib/v/tests/shared_lock_expr_test.v
+++ b/vlib/v/tests/shared_lock_expr_test.v
@@ -91,3 +91,25 @@ fn test_shared_lock_array_index_expr() {
 		}
 	}
 }
+
+struct DummySt {
+	a int
+}
+
+fn test_shared_lock_chan_rec_expr() {
+	ch := chan int{cap: 10}
+	shared st := DummySt{}
+	ch <- 7
+	ch <- -13
+	ch.close()
+	for i in 0 .. 3 {
+		v := rlock st { <-ch or { -17 } }
+		if i == 0 {
+			assert v == 7
+		} else if i == 1 {
+			assert v == -13
+		} else {
+			assert v == -17
+		}
+	}
+}

--- a/vlib/v/tests/shared_lock_expr_test.v
+++ b/vlib/v/tests/shared_lock_expr_test.v
@@ -65,3 +65,29 @@ fn test_mult_ret_method() {
 	assert b == 13.125
 	assert c == -7.5
 }
+
+fn test_shared_lock_map_index_expr() {
+	shared m := map{'qwe': 'asd'}
+	for key in ['fdf', 'qwe'] {
+		v := rlock m { m[key] or { 'key not found' } }
+		if key == 'qwe' {
+			assert v == 'asd'
+		} else {
+			assert v == 'key not found'
+		}
+	}
+}
+
+fn test_shared_lock_array_index_expr() {
+	shared a := [-12.5 6.25]
+	for i in -2 .. 4 {
+		v := rlock a { a[i] or { 23.75 } }
+		if i == 0 {
+			assert v == -12.5
+		} else if i == 1 {
+			assert v == 6.25
+		} else {
+			assert v == 23.75
+		}
+	}
+}

--- a/vlib/v/tests/shared_lock_expr_test.v
+++ b/vlib/v/tests/shared_lock_expr_test.v
@@ -67,9 +67,13 @@ fn test_mult_ret_method() {
 }
 
 fn test_shared_lock_map_index_expr() {
-	shared m := map{'qwe': 'asd'}
+	shared m := map{
+		'qwe': 'asd'
+	}
 	for key in ['fdf', 'qwe'] {
-		v := rlock m { m[key] or { 'key not found' } }
+		v := rlock m {
+			m[key] or { 'key not found' }
+		}
 		if key == 'qwe' {
 			assert v == 'asd'
 		} else {
@@ -79,9 +83,11 @@ fn test_shared_lock_map_index_expr() {
 }
 
 fn test_shared_lock_array_index_expr() {
-	shared a := [-12.5 6.25]
+	shared a := [-12.5, 6.25]
 	for i in -2 .. 4 {
-		v := rlock a { a[i] or { 23.75 } }
+		v := rlock a {
+			a[i] or { 23.75 }
+		}
 		if i == 0 {
 			assert v == -12.5
 		} else if i == 1 {
@@ -103,7 +109,9 @@ fn test_shared_lock_chan_rec_expr() {
 	ch <- -13
 	ch.close()
 	for i in 0 .. 3 {
-		v := rlock st { <-ch or { -17 } }
+		v := rlock st {
+			<-ch or { -17 }
+		}
 		if i == 0 {
 			assert v == 7
 		} else if i == 1 {


### PR DESCRIPTION
Using an `IndexExpr` with `or` branch inside a `LockExpr`, used to cause errors in `checker` (and wrong code produced by `cgen`).
This PR fixes these issues.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
