### PR TITLE
generics: make minor simplification of generics

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -373,7 +373,7 @@ pub:
 	is_builtin      bool // this function is defined in builtin/strconv
 	body_pos        token.Position // function bodys position
 	file            string
-	generic_params  []GenericParam
+	generic_names   []string
 	is_direct_arr   bool // direct array access
 	attrs           []Attr
 	skip_gen        bool // this function doesn't need to be generated (for example [if foo])
@@ -389,11 +389,6 @@ pub mut:
 	scope           &Scope
 	label_names     []string
 	pos             token.Position // function declaration position
-}
-
-pub struct GenericParam {
-pub:
-	name string
 }
 
 // break, continue

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -62,11 +62,11 @@ pub fn (node &FnDecl) stringify(t &Table, cur_mod string, m2a map[string]string)
 	if name in ['+', '-', '*', '/', '%', '<', '>', '==', '!=', '>=', '<='] {
 		f.write_string(' ')
 	}
-	if node.generic_params.len > 0 {
+	if node.generic_names.len > 0 {
 		f.write_string('<')
-		for i, param in node.generic_params {
-			is_last := i == node.generic_params.len - 1
-			f.write_string(param.name)
+		for i, gname in node.generic_names {
+			is_last := i == node.generic_names.len - 1
+			f.write_string(gname)
 			if !is_last {
 				f.write_string(', ')
 			}

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -360,7 +360,7 @@ pub fn (mut c Checker) symmetric_check(left ast.Type, right ast.Type) bool {
 	return c.check_basic(left, right)
 }
 
-pub fn (c &Checker) get_default_fmt(ftyp ast.Type, typ ast.Type) byte {
+pub fn (mut c Checker) get_default_fmt(ftyp ast.Type, typ ast.Type) byte {
 	if ftyp.has_flag(.optional) {
 		return `s`
 	} else if typ.is_float() {
@@ -521,7 +521,7 @@ pub fn (mut c Checker) infer_fn_types(f ast.Fn, mut call_expr ast.CallExpr) {
 					mut param_elem_sym := c.table.get_type_symbol(param_elem_info.elem_type)
 					for {
 						if arg_elem_sym.kind == .array && param_elem_sym.kind == .array
-							&& c.cur_fn.generic_params.filter(it.name == param_elem_sym.name).len == 0 {
+							&& param_elem_sym.name !in c.cur_fn.generic_names {
 							arg_elem_info = arg_elem_sym.info as ast.Array
 							arg_elem_sym = c.table.get_type_symbol(arg_elem_info.elem_type)
 							param_elem_info = param_elem_sym.info as ast.Array

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -687,7 +687,7 @@ static inline Option_void __Option_${styp}_pushval($styp ch, $el_type e) {
 }
 
 // cc_type whether to prefix 'struct' or not (C__Foo -> struct Foo)
-fn (g &Gen) cc_type(typ ast.Type, is_prefix_struct bool) string {
+fn (mut g Gen) cc_type(typ ast.Type, is_prefix_struct bool) string {
 	sym := g.table.get_type_symbol(g.unwrap_generic(typ))
 	mut styp := sym.cname
 	// TODO: this needs to be removed; cgen shouldn't resolve generic types (job of checker)

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -274,7 +274,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		}
 	}
 	// <T>
-	generic_params := p.parse_generic_params()
+	generic_names := p.parse_generic_names()
 	// Args
 	args2, are_args_type_only, is_variadic := p.fn_args()
 	params << args2
@@ -338,7 +338,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 			params: params
 			return_type: return_type
 			is_variadic: is_variadic
-			generic_names: generic_params.map(it.name)
+			generic_names: generic_names
 			is_pub: is_pub
 			is_deprecated: is_deprecated
 			is_unsafe: is_unsafe
@@ -367,7 +367,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 			params: params
 			return_type: return_type
 			is_variadic: is_variadic
-			generic_names: generic_params.map(it.name)
+			generic_names: generic_names
 			is_pub: is_pub
 			is_deprecated: is_deprecated
 			is_unsafe: is_unsafe
@@ -422,7 +422,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 			name: rec.name
 			typ: rec.typ
 		}
-		generic_params: generic_params
+		generic_names: generic_names
 		receiver_pos: rec.pos
 		is_method: is_method
 		method_type_pos: rec.type_pos
@@ -517,10 +517,10 @@ fn (mut p Parser) fn_receiver(mut params []ast.Param, mut rec ReceiverParsingInf
 	return
 }
 
-fn (mut p Parser) parse_generic_params() []ast.GenericParam {
+fn (mut p Parser) parse_generic_names() []string {
 	mut param_names := []string{}
 	if p.tok.kind != .lt {
-		return []ast.GenericParam{}
+		return param_names
 	}
 	p.check(.lt)
 	mut first_done := false
@@ -551,7 +551,7 @@ fn (mut p Parser) parse_generic_params() []ast.GenericParam {
 		count++
 	}
 	p.check(.gt)
-	return param_names.map(ast.GenericParam{it})
+	return param_names
 }
 
 // is_generic_name returns true if the current token is a generic name.


### PR DESCRIPTION
This PR make minor simplification of generics.

- Change `generic_params` to `generic_names` in ast.FnDecl.
- `unwrap_generic()` in checker.v/cgen.v add handling complex generic (e.g. []T...)
- Modify related called.