### PR TITLE
ast, token, parser, scanner: add last_col position

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1506,10 +1506,9 @@ pub fn (expr Expr) position() token.Position {
 			left_pos := expr.left.position()
 			right_pos := expr.right.position()
 			return token.Position{
+				...left_pos
 				line_nr: expr.pos.line_nr
-				pos: left_pos.pos
 				len: right_pos.pos - left_pos.pos + right_pos.len
-				col: left_pos.col
 				last_line: right_pos.last_line
 			}
 		}
@@ -1660,6 +1659,7 @@ pub fn (node Node) position() token.Position {
 						pos: -1
 						last_line: -1
 						col: -1
+						last_col: -1
 					}
 				}
 			}

--- a/vlib/v/doc/utils.v
+++ b/vlib/v/doc/utils.v
@@ -23,6 +23,7 @@ pub fn ast_comment_to_doc_comment(ast_node ast.Comment) DocComment {
 			line_nr: ast_node.pos.line_nr
 			col: 0 // ast_node.pos.pos - ast_node.text.len
 			len: text.len
+			last_col: 0
 		}
 	}
 }

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -190,7 +190,7 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr, left_comments []ast.Comme
 			}
 		}
 	}
-	pos.update_last_line(p.prev_tok.line_nr)
+	pos.update_last_line(p.prev_tok)
 	return ast.AssignStmt{
 		op: op
 		left: left

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -87,7 +87,7 @@ pub fn (mut p Parser) call_expr(language ast.Language, mod string) ast.CallExpr 
 		fn_name = p.imported_symbols[fn_name]
 	}
 	comments := p.eat_comments(same_line: true)
-	pos.update_last_line(p.prev_tok.line_nr)
+	pos.update_last_line(p.prev_tok)
 	return ast.CallExpr{
 		name: fn_name
 		name_pos: first_pos

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -18,7 +18,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 	if p.tok.kind == .lcbr {
 		p.inside_for = false
 		stmts := p.parse_block_no_scope(false)
-		pos.update_last_line(p.prev_tok.line_nr)
+		pos.update_last_line(p.prev_tok)
 		for_stmt := ast.ForStmt{
 			stmts: stmts
 			pos: pos
@@ -67,7 +67,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		}
 		p.inside_for = false
 		stmts := p.parse_block_no_scope(false)
-		pos.update_last_line(p.prev_tok.line_nr)
+		pos.update_last_line(p.prev_tok)
 		for_c_stmt := ast.ForCStmt{
 			stmts: stmts
 			has_init: has_init
@@ -163,7 +163,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		}
 		p.inside_for = false
 		stmts := p.parse_block_no_scope(false)
-		pos.update_last_line(p.prev_tok.line_nr)
+		pos.update_last_line(p.prev_tok)
 		// println('nr stmts=$stmts.len')
 		for_in_stmt := ast.ForInStmt{
 			stmts: stmts
@@ -185,7 +185,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 	// extra scope for the body
 	p.open_scope()
 	stmts := p.parse_block_no_scope(false)
-	pos.update_last_line(p.prev_tok.line_nr)
+	pos.update_last_line(p.prev_tok)
 	for_stmt := ast.ForStmt{
 		cond: cond
 		stmts: stmts

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -139,7 +139,7 @@ fn (mut p Parser) if_expr(is_comptime bool) ast.IfExpr {
 			break
 		}
 	}
-	pos.update_last_line(p.prev_tok.line_nr)
+	pos.update_last_line(p.prev_tok)
 	if comments.len > 0 {
 		pos.last_line = comments.last().pos.last_line
 	}
@@ -253,16 +253,14 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 	}
 	match_last_pos := p.tok.position()
 	mut pos := token.Position{
-		line_nr: match_first_pos.line_nr
-		pos: match_first_pos.pos
+		...match_first_pos
 		len: match_last_pos.pos - match_first_pos.pos + match_last_pos.len
-		col: match_first_pos.col
 	}
 	if p.tok.kind == .rcbr {
 		p.check(.rcbr)
 	}
 	// return ast.StructInit{}
-	pos.update_last_line(p.prev_tok.line_nr)
+	pos.update_last_line(p.prev_tok)
 	return ast.MatchExpr{
 		branches: branches
 		cond: cond
@@ -398,13 +396,11 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 		p.close_scope()
 		p.inside_match_body = false
 		mut pos := token.Position{
-			line_nr: branch_first_pos.line_nr
-			pos: branch_first_pos.pos
+			...branch_first_pos
 			len: branch_last_pos.pos - branch_first_pos.pos + branch_last_pos.len
-			col: branch_first_pos.col
 		}
 		post_comments := p.eat_comments({})
-		pos.update_last_line(p.prev_tok.line_nr)
+		pos.update_last_line(p.prev_tok)
 		if post_comments.len > 0 {
 			pos.last_line = post_comments.last().pos.last_line
 		}
@@ -423,10 +419,8 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 	}
 	match_last_pos := p.tok.position()
 	pos := token.Position{
-		line_nr: match_first_pos.line_nr
-		pos: match_first_pos.pos
+		...match_first_pos
 		len: match_last_pos.pos - match_first_pos.pos + match_last_pos.len
-		col: match_first_pos.col
 	}
 	if p.tok.kind == .rcbr {
 		p.check(.rcbr)

--- a/vlib/v/parser/lock.v
+++ b/vlib/v/parser/lock.v
@@ -40,7 +40,7 @@ fn (mut p Parser) lock_expr() ast.LockExpr {
 		}
 	}
 	stmts := p.parse_block()
-	pos.update_last_line(p.prev_tok.line_nr)
+	pos.update_last_line(p.prev_tok)
 	return ast.LockExpr{
 		lockeds: lockeds
 		stmts: stmts

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -682,7 +682,7 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 			p.next()
 			mut pos := p.tok.position()
 			expr := p.expr(0)
-			pos.update_last_line(p.prev_tok.line_nr)
+			pos.update_last_line(p.prev_tok)
 			return ast.AssertStmt{
 				expr: expr
 				pos: pos
@@ -748,7 +748,7 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 				.key_if {
 					mut pos := p.tok.position()
 					expr := p.if_expr(true)
-					pos.update_last_line(p.prev_tok.line_nr)
+					pos.update_last_line(p.prev_tok)
 					return ast.ExprStmt{
 						expr: expr
 						pos: pos
@@ -760,7 +760,7 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 				.name {
 					mut pos := p.tok.position()
 					expr := p.comp_call()
-					pos.update_last_line(p.prev_tok.line_nr)
+					pos.update_last_line(p.prev_tok)
 					return ast.ExprStmt{
 						expr: expr
 						pos: pos
@@ -1692,7 +1692,7 @@ fn (mut p Parser) parse_multi_expr(is_top_level bool) ast.Stmt {
 			}
 		}
 	}
-	pos.update_last_line(p.prev_tok.line_nr)
+	pos.update_last_line(p.prev_tok)
 	if left.len == 1 {
 		return ast.ExprStmt{
 			expr: left0
@@ -3165,7 +3165,7 @@ fn (mut p Parser) unsafe_stmt() ast.Stmt {
 	}
 	if p.tok.kind == .rcbr {
 		// `unsafe {}`
-		pos.update_last_line(p.tok.line_nr)
+		pos.update_last_line(p.tok)
 		p.next()
 		return ast.Block{
 			is_unsafe: true
@@ -3184,7 +3184,7 @@ fn (mut p Parser) unsafe_stmt() ast.Stmt {
 			// `unsafe {expr}`
 			if stmt.expr.is_expr() {
 				p.next()
-				pos.update_last_line(p.prev_tok.line_nr)
+				pos.update_last_line(p.prev_tok)
 				ue := ast.UnsafeExpr{
 					expr: stmt.expr
 					pos: pos
@@ -3204,7 +3204,7 @@ fn (mut p Parser) unsafe_stmt() ast.Stmt {
 		stmts << p.stmt(false)
 	}
 	p.next()
-	pos.update_last_line(p.tok.line_nr)
+	pos.update_last_line(p.tok)
 	return ast.Block{
 		stmts: stmts
 		is_unsafe: true

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -139,7 +139,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 			p.check(.lcbr)
 			e := p.expr(0)
 			p.check(.rcbr)
-			pos.update_last_line(p.prev_tok.line_nr)
+			pos.update_last_line(p.prev_tok)
 			node = ast.UnsafeExpr{
 				expr: e
 				pos: pos
@@ -374,7 +374,7 @@ pub fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_iden
 			mut pos := tok.position()
 			p.next()
 			right := p.expr(precedence - 1)
-			pos.update_last_line(p.prev_tok.line_nr)
+			pos.update_last_line(p.prev_tok)
 			if mut node is ast.IndexExpr {
 				node.recursive_mapset_is_setter(true)
 			}
@@ -475,7 +475,7 @@ fn (mut p Parser) infix_expr(left ast.Expr) ast.Expr {
 		}
 		p.or_is_handled = false
 	}
-	pos.update_last_line(p.prev_tok.line_nr)
+	pos.update_last_line(p.prev_tok)
 	return ast.InfixExpr{
 		left: left
 		right: right
@@ -538,7 +538,7 @@ fn (mut p Parser) prefix_expr() ast.PrefixExpr {
 		}
 		p.or_is_handled = false
 	}
-	pos.update_last_line(p.prev_tok.line_nr)
+	pos.update_last_line(p.prev_tok)
 	return ast.PrefixExpr{
 		op: op
 		right: right

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -389,10 +389,9 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 				first_field_pos.len + 1
 			}
 			field_pos = token.Position{
-				line_nr: first_field_pos.line_nr
-				pos: first_field_pos.pos
+				...first_field_pos
 				len: field_len
-				col: first_field_pos.col
+				last_col: last_field_pos.last_col
 			}
 		}
 		i++

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1331,6 +1331,7 @@ pub fn (mut s Scanner) warn(msg string) {
 		line_nr: s.line_nr
 		pos: s.pos
 		col: s.current_column() - 1
+		last_col: s.current_column() - 1
 	}
 	if s.pref.output_mode == .stdout {
 		eprintln(util.formatted_error('warning:', msg, s.file_path, pos))
@@ -1349,6 +1350,7 @@ pub fn (mut s Scanner) error(msg string) {
 		line_nr: s.line_nr
 		pos: s.pos
 		col: s.current_column() - 1
+		last_col: s.current_column() - 1
 	}
 	if s.pref.output_mode == .stdout {
 		eprintln(util.formatted_error('error:', msg, s.file_path, pos))
@@ -1373,6 +1375,7 @@ fn (mut s Scanner) vet_error(msg string, fix vet.FixKind) {
 		pos: token.Position{
 			line_nr: s.line_nr
 			col: s.current_column() - 1
+			last_col: s.current_column() - 1
 		}
 		kind: .error
 		fix: fix

--- a/vlib/v/token/position.v
+++ b/vlib/v/token/position.v
@@ -11,10 +11,11 @@ pub:
 	col     int // the column in the source where the token occured
 pub mut:
 	last_line int // the line number where the ast object ends (used by vfmt)
+	last_col  int // the column where the ast object ends (used by vls)
 }
 
 pub fn (pos Position) str() string {
-	return 'Position{ line_nr: $pos.line_nr, last_line: $pos.last_line, pos: $pos.pos, col: $pos.col, len: $pos.len }'
+	return 'Position{ line_nr: $pos.line_nr, last_line: $pos.last_line, pos: $pos.pos, col: $pos.col, last_col: $pos.last_col len: $pos.len }'
 }
 
 pub fn (pos Position) extend(end Position) Position {
@@ -22,6 +23,7 @@ pub fn (pos Position) extend(end Position) Position {
 		...pos
 		len: end.pos - pos.pos + end.len
 		last_line: end.last_line
+		last_col: end.last_col
 	}
 }
 
@@ -32,11 +34,13 @@ pub fn (pos Position) extend_with_last_line(end Position, last_line int) Positio
 		last_line: last_line - 1
 		pos: pos.pos
 		col: pos.col
+		last_col: end.last_col
 	}
 }
 
-pub fn (mut pos Position) update_last_line(last_line int) {
-	pos.last_line = last_line - 1
+pub fn (mut pos Position) update_last_line(tok Token) {
+	pos.last_line = tok.line_nr - 1
+	pos.last_col = tok.col + tok.len - 1
 }
 
 [inline]
@@ -46,6 +50,7 @@ pub fn (tok &Token) position() Position {
 		line_nr: tok.line_nr - 1
 		pos: tok.pos
 		last_line: tok.line_nr - 1
+		last_col: tok.col + tok.len - 1
 		col: tok.col - 1
 	}
 }

--- a/vlib/v/util/errors.v
+++ b/vlib/v/util/errors.v
@@ -106,7 +106,7 @@ pub fn source_context(kind string, source string, pos token.Position) []string {
 	for iline := bline; iline <= aline; iline++ {
 		sline := source_lines[iline]
 		start_column := mu.max(0, mu.min(pos.col, sline.len))
-		end_column := mu.max(0, mu.min(pos.col + mu.max(0, pos.len), sline.len))
+		end_column := mu.max(0, mu.min(pos.last_col, sline.len))
 		cline := if iline == pos.line_nr {
 			sline[..start_column] + color(kind, sline[start_column..end_column]) +
 				sline[end_column..]


### PR DESCRIPTION
This PR adds a last_col position in the token's Position struct. This fixes the errors VLS is experiencing at this moment. The current approach which is computing the last column using the token's length and the token's starting column had been inaccurate in some cases. Extending the first token position with the last token's last column data solves the case.

An upcoming PR for VLS will be pushed soon.