### PR TITLE
cgen: generate interfaces after all other typedefs

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -791,9 +791,6 @@ pub fn (mut g Gen) write_typedef_types() {
 					}
 				}
 			}
-			.interface_ {
-				g.write_interface_typesymbol_declaration(typ)
-			}
 			.chan {
 				if typ.name != 'chan' {
 					g.type_definitions.writeln('typedef chan $typ.cname;')
@@ -823,6 +820,20 @@ static inline void __${typ.cname}_pushval($typ.cname ch, $el_stype val) {
 			else {
 				continue
 			}
+		}
+	}
+
+	// Generating interfaces after all the common types have been defined
+	// to prevent generating interface struct before definition of field types
+	for typ in g.table.type_symbols {
+		if typ.name in c.builtins {
+			continue
+		}
+		match typ.kind {
+			.interface_ {
+				g.write_interface_typesymbol_declaration(typ)
+			}
+			else {}
 		}
 	}
 }

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -826,14 +826,8 @@ static inline void __${typ.cname}_pushval($typ.cname ch, $el_stype val) {
 	// Generating interfaces after all the common types have been defined
 	// to prevent generating interface struct before definition of field types
 	for typ in g.table.type_symbols {
-		if typ.name in c.builtins {
-			continue
-		}
-		match typ.kind {
-			.interface_ {
-				g.write_interface_typesymbol_declaration(typ)
-			}
-			else {}
+		if typ.kind == .interface_ && typ.name !in c.builtins {
+			g.write_interface_typesymbol_declaration(typ)
 		}
 	}
 }

--- a/vlib/v/tests/interface_fields_typearray_test.v
+++ b/vlib/v/tests/interface_fields_typearray_test.v
@@ -1,0 +1,7 @@
+struct Test {}
+
+interface Testing {
+	tests []Test
+}
+
+fn test_field_typearray() {}


### PR DESCRIPTION
## Additions:
Generate typedefs for interfaces after all other types typedefs in order to prevent cgen of interface before typedef of fields inside it.

Old generation might create generation like this, with typedef of interface **before** the typedef for one of the fields which results in a C compiler error.:
```c
typedef struct {
	union {
		void* _object;
	};
	int _typ;
	Array_main__Test* rooms;
} main__Testing;
typedef array Array_main__Test;
```

## Notes:
Fixes #9511 

Is just doing an other loop after the main loop of generating typedef.
Thought of placing the different types for interfaces inside an array, then going over this array to generate but might add a little more memory usage vs a simple loop duplicate

## Working example:
```v
struct Test{}

interface Testing {
	rooms []Test
}
```