### PR TITLE
encoding.utf8: Fix panicking from len and ulen and optimize raw_index

### DIFF
--- a/vlib/encoding/utf8/utf8_util.v
+++ b/vlib/encoding/utf8/utf8_util.v
@@ -88,12 +88,15 @@ pub fn get_uchar(s string, index int) int {
 
 
 // raw_index - get the raw chracter from the string by the given index value.
-// example: '我是V Lang'.raw_index(1) => '是'
-
+// example: utf8.raw_index('我是V Lang', 1) => '是'
 pub fn raw_index(s string, index int) string {
 	mut r := []rune{}
 
 	for i := 0; i < s.len; i++ {
+		if r.len - 1 == index {
+			break
+		}
+
         b := s[i]
         ch_len := ((0xe5000000>>((b>>3) & 0x1e)) & 3)
         

--- a/vlib/encoding/utf8/utf8_util.v
+++ b/vlib/encoding/utf8/utf8_util.v
@@ -111,25 +111,6 @@ pub fn raw_index(s string, index int) string {
 }
 
 /*
-pub fn raw_index(s string, index int) string {
-	mut r := []rune{}
-
-	for i := 0; i < s.len; i++ {
-		b := s[i]
-		ch_len := ((0xe5000000 >> ((b >> 3) & 0x1e)) & 3)
-
-		r << if ch_len > 0 {
-			i += ch_len
-			rune(get_uchar(s, i - ch_len))
-		} else {
-			rune(b)
-		}
-	}
-
-	return r[index].str()
-}
-
-/*
 Conversion functions
 */
 

--- a/vlib/encoding/utf8/utf8_util.v
+++ b/vlib/encoding/utf8/utf8_util.v
@@ -87,6 +87,27 @@ pub fn get_uchar(s string, index int) int {
 }
 
 
+// raw_index - get the raw chracter from the string by the given index value.
+// example: '我是V Lang'.raw_index(1) => '是'
+
+pub fn raw_index(s string, index int) string {
+	mut r := []rune{}
+
+	for i := 0; i < s.len; i++ {
+        b := s[i]
+        ch_len := ((0xe5000000>>((b>>3) & 0x1e)) & 3)
+        
+		r << if ch_len > 0 {
+            i += ch_len
+            rune(get_uchar(s,i-ch_len))
+        } else {
+            rune(b)
+        }
+    }
+
+	return r[index].str()
+}
+
 /*
 
 Conversion functions

--- a/vlib/encoding/utf8/utf8_util.v
+++ b/vlib/encoding/utf8/utf8_util.v
@@ -96,16 +96,16 @@ pub fn raw_index(s string, index int) string {
 			break
 		}
 
-        b := s[i]
-        ch_len := ((0xe5000000>>((b>>3) & 0x1e)) & 3)
-        
+		b := s[i]
+		ch_len := ((0xe5000000 >> ((b >> 3) & 0x1e)) & 3)
+
 		r << if ch_len > 0 {
-            i += ch_len
-            rune(get_uchar(s,i-ch_len))
-        } else {
-            rune(b)
-        }
-    }
+			i += ch_len
+			rune(get_uchar(s, i - ch_len))
+		} else {
+			rune(b)
+		}
+	}
 
 	return r[index].str()
 }

--- a/vlib/encoding/utf8/utf8_util.v
+++ b/vlib/encoding/utf8/utf8_util.v
@@ -19,6 +19,10 @@ Utility functions
 
 // len return the length as number of unicode chars from a string
 pub fn len(s string) int {
+	if s.len == 0 {
+		return 0
+	}
+
 	mut count := 0
 	mut index := 0
 

--- a/vlib/encoding/utf8/utf8_util_test.v
+++ b/vlib/encoding/utf8/utf8_util_test.v
@@ -21,14 +21,14 @@ fn test_utf8_util() {
 	assert lower1 == (src_lower.ustring())
 
 	// test len function
-	assert utf8.len("")==0
-	assert utf8.len("pippo")==5
-	assert utf8.len(src)==15 //29
-	assert src.len==24 //49
+	assert utf8.len('') == 0
+	assert utf8.len('pippo') == 5
+	assert utf8.len(src) == 15 // 29
+	assert src.len == 24 // 49
 	// test u_len function
-	assert utf8.u_len("".ustring())==0
-	assert utf8.u_len(src1)==15 //29
-	assert utf8.u_len("pippo".ustring())==5
+	assert utf8.u_len(''.ustring()) == 0
+	assert utf8.u_len(src1) == 15 // 29
+	assert utf8.u_len('pippo'.ustring()) == 5
 
 	// western punctuation
 	a := '.abc?abcòàè.'

--- a/vlib/encoding/utf8/utf8_util_test.v
+++ b/vlib/encoding/utf8/utf8_util_test.v
@@ -68,20 +68,3 @@ fn test_raw_indexing() {
 	assert utf8.raw_index(a, 7) == 'g'
 	assert utf8.raw_index(a, 8) == '!'
 }
-
-fn test_raw_indexing() {
-	a := "我是V Lang!"
-
-	// test non ascii characters
-	assert utf8.raw_index(a, 0) == '我'
-	assert utf8.raw_index(a, 1) == '是'
-	
-	// test ascii characters
-	assert utf8.raw_index(a, 2) == 'V'
-	assert utf8.raw_index(a, 3) == ' '
-	assert utf8.raw_index(a, 4) == 'L'
-	assert utf8.raw_index(a, 5) == 'a'
-	assert utf8.raw_index(a, 6) == 'n'
-	assert utf8.raw_index(a, 7) == 'g'
-	assert utf8.raw_index(a, 8) == '!'
-}

--- a/vlib/encoding/utf8/utf8_util_test.v
+++ b/vlib/encoding/utf8/utf8_util_test.v
@@ -50,3 +50,20 @@ fn test_utf8_util() {
   	// test utility functions
   	assert utf8.get_uchar(b,0)==0x002E
 }
+
+fn test_raw_indexing() {
+	a := "我是V Lang!"
+
+	// test non ascii characters
+	assert utf8.raw_index(a, 0) == '我'
+	assert utf8.raw_index(a, 1) == '是'
+	
+	// test ascii characters
+	assert utf8.raw_index(a, 2) == 'V'
+	assert utf8.raw_index(a, 3) == ' '
+	assert utf8.raw_index(a, 4) == 'L'
+	assert utf8.raw_index(a, 5) == 'a'
+	assert utf8.raw_index(a, 6) == 'n'
+	assert utf8.raw_index(a, 7) == 'g'
+	assert utf8.raw_index(a, 8) == '!'
+}

--- a/vlib/encoding/utf8/utf8_util_test.v
+++ b/vlib/encoding/utf8/utf8_util_test.v
@@ -22,10 +22,12 @@ fn test_utf8_util() {
 	assert lower1==( src_lower.ustring() )
 
 	// test len function
+	assert utf8.len("")==0
 	assert utf8.len("pippo")==5
 	assert utf8.len(src)==15 //29
 	assert src.len==24 //49
 	// test u_len function
+	assert utf8.u_len("".ustring())==0
 	assert utf8.u_len(src1)==15 //29
 	assert utf8.u_len("pippo".ustring())==5
 


### PR DESCRIPTION
len & ulen:
Fix panicking when passing an empty (0 len) string / ustring.

raw_index:
Prevent unnecessary rune transforming when the given index is reached.
ie:
```v
s := '我是V Lang!'
utf8.raw_index(s, 2) // 'V'
// raw_index stops when the rune array's len is 3, so ' Lang!' won't get a transformation into rune
```