### PR TITLE
orm: add unique fields & add drop table stmt

### DIFF
--- a/examples/database/orm.v
+++ b/examples/database/orm.v
@@ -11,14 +11,13 @@ struct Module {
 struct User {
 	id             int    [primary; sql: serial]
 	age            int
-	name           string [nonull]
-	is_customer    bool
+	name           string [unique]
+	is_customer    bool   [unique]
 	skipped_string string [skip]
 }
 
 fn main() {
 	db := sqlite.connect(':memory:') or { panic(err) }
-	db.exec('drop table if exists User')
 	sql db {
 		create table Module
 	}
@@ -38,6 +37,10 @@ fn main() {
 
 	modul := sql db {
 		select from Module where id == 1
+	}
+
+	sql db {
+		drop table Module
 	}
 
 	eprintln(modul)

--- a/examples/database/orm.v
+++ b/examples/database/orm.v
@@ -10,9 +10,9 @@ struct Module {
 
 struct User {
 	id             int    [primary; sql: serial]
-	age            int
+	age            int    [unique: 'user']
 	name           string [unique]
-	is_customer    bool   [unique]
+	is_customer    bool   [unique: 'user']
 	skipped_string string [skip]
 }
 

--- a/vlib/orm/README.md
+++ b/vlib/orm/README.md
@@ -4,7 +4,8 @@
 
 ### Fields
 
-- `[primary]` set the field as the primary key
+- `[primary]` sets the field as the primary key
+- `[unique]` sets the field unique
 - `[nonull]` field will be `NOT NULL` in table creation
 - `[skip]` field will be skipped
 - `[sql: type]` sets the type which is used in sql (special type `serial`)
@@ -23,6 +24,14 @@ struct Foo {
 ```v ignore
 sql db {
     create table Foo
+}
+```
+
+### Drop
+
+```v ignore
+sql db {
+    drop table Foo
 }
 ```
 

--- a/vlib/orm/README.md
+++ b/vlib/orm/README.md
@@ -6,6 +6,7 @@
 
 - `[primary]` sets the field as the primary key
 - `[unique]` sets the field unique
+- `[unique: 'foo']` adds the field to a unique group
 - `[nonull]` field will be `NOT NULL` in table creation
 - `[skip]` field will be skipped
 - `[sql: type]` sets the type which is used in sql (special type `serial`)

--- a/vlib/orm/README.md
+++ b/vlib/orm/README.md
@@ -5,7 +5,7 @@
 ### Fields
 
 - `[primary]` sets the field as the primary key
-- `[unique]` sets the field unique
+- `[unique]` sets the field as unique
 - `[unique: 'foo']` adds the field to a unique group
 - `[nonull]` field will be `NOT NULL` in table creation
 - `[skip]` field will be skipped

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1415,6 +1415,7 @@ pub enum SqlStmtKind {
 	update
 	delete
 	create
+	drop
 }
 
 pub struct SqlStmt {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1235,6 +1235,9 @@ pub fn (mut f Fmt) sql_stmt(node ast.SqlStmt) {
 		.create {
 			f.writeln('create table $table_name')
 		}
+		.drop {
+			f.writeln('drop table $table_name')
+		}
 	}
 	f.writeln('}')
 }

--- a/vlib/v/gen/c/sql.v
+++ b/vlib/v/gen/c/sql.v
@@ -327,7 +327,6 @@ fn (mut g Gen) sqlite3_drop_table(node ast.SqlStmt, typ SqlType) {
 	g.writeln(', _SLIT("$create_string"));')
 }
 
-
 fn (mut g Gen) sqlite3_bind(val string, len string, typ ast.Type) {
 	match g.sqlite3_type_from_v(typ) {
 		'INTEGER' {
@@ -893,7 +892,7 @@ fn (mut g Gen) table_gen(node ast.SqlStmt, typ SqlType) string {
 		for f in unique {
 			tmp << '`$f`'
 		}
-		fields << 'UNIQUE(${tmp.join(", ")})'
+		fields << 'UNIQUE(${tmp.join(', ')})'
 	}
 	if typ == .mysql {
 		fields << 'PRIMARY KEY(`$primary`)'

--- a/vlib/v/gen/c/sql.v
+++ b/vlib/v/gen/c/sql.v
@@ -609,7 +609,7 @@ fn (mut g Gen) mysql_create_table(node ast.SqlStmt, typ SqlType) {
 	g.write('Option_mysql__Result $tmp = mysql__Connection_query(&')
 	g.expr(node.db_expr)
 	g.writeln(', _SLIT("$create_string"));')
-	g.writeln('if (${tmp}.state != 0) { IError err = ${tmp}.err; _STR("Something went wrong\\000%.*s", 2, IError_str(err)); }')
+	g.writeln('if (${tmp}.state != 0) { IError err = ${tmp}.err; eprintln(_STR("Something went wrong\\000%.*s", 2, IError_str(err))); }')
 }
 
 fn (mut g Gen) mysql_drop_table(node ast.SqlStmt, typ SqlType) {
@@ -620,7 +620,7 @@ fn (mut g Gen) mysql_drop_table(node ast.SqlStmt, typ SqlType) {
 	g.write('Option_mysql__Result $tmp = mysql__Connection_query(&')
 	g.expr(node.db_expr)
 	g.writeln(', _SLIT("$create_string"));')
-	g.writeln('if (${tmp}.state != 0) { IError err = ${tmp}.err; _STR("Something went wrong\\000%.*s", 2, IError_str(err)); }')
+	g.writeln('if (${tmp}.state != 0) { IError err = ${tmp}.err; eprintln(_STR("Something went wrong\\000%.*s", 2, IError_str(err))); }')
 }
 
 fn (mut g Gen) mysql_bind(val string, _ ast.Type) {

--- a/vlib/v/parser/sql.v
+++ b/vlib/v/parser/sql.v
@@ -146,6 +146,25 @@ fn (mut p Parser) sql_stmt() ast.SqlStmt {
 				pos: typ_pos
 			}
 		}
+	} else if n == 'drop' {
+		kind = .drop
+		table := p.check_name()
+		if table != 'table' {
+			p.error('expected `table` got `$table`')
+			return ast.SqlStmt{}
+		}
+		typ := p.parse_type()
+		typ_pos := p.tok.position()
+		p.check(.rcbr)
+		return ast.SqlStmt{
+			db_expr: db_expr
+			kind: kind
+			pos: pos.extend(p.prev_tok.position())
+			table_expr: ast.TypeNode{
+				typ: typ
+				pos: typ_pos
+			}
+		}
 	}
 	mut inserted_var_name := ''
 	mut table_type := ast.Type(0)


### PR DESCRIPTION
This PR adds the possibility to set a field unique with the `[unique]` attribute. I also added the drop table statement to delete tables with orm. Both works for sqlite3 & mysql atm