### PR TITLE
os: correctly handle errors on fread

### DIFF
--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -21,6 +21,10 @@ fn C.open(&char, int, ...int) int
 
 fn C.fdopen(fd int, mode &char) &C.FILE
 
+fn C.ferror(stream &C.FILE) int
+
+fn C.feof(stream &C.FILE) int
+
 fn C.CopyFile(&u16, &u16, bool) int
 
 // fn C.lstat(charptr, voidptr) u64
@@ -100,8 +104,10 @@ pub fn read_file(path string) ?string {
 	C.rewind(fp)
 	unsafe {
 		mut str := malloc(fsize + 1)
-		nelements := int(C.fread(str, fsize, 1, fp))
-		if nelements == 0 && fsize > 0 {
+		C.fread(str, fsize, 1, fp)
+		is_eof := int(C.feof(fp))
+		is_error := int(C.ferror(fp))
+		if is_eof == 0 && is_error != 0 {
 			free(str)
 			return error('fread failed')
 		}


### PR DESCRIPTION
## Additions:
Correctly handle errors after a `fread` by using return values of `feof` and `ferror` to determine if `fread` have failed.

According to man:
```
fread()  does  not  distinguish between end-of-file and error, and
callers must use feof(3) and ferror(3) to determine which occurred.
```

## Notes:
Fixes #8860