### PR TITLE
fmt: fix asm volatile & goto

### DIFF
--- a/vlib/builtin/linux_bare/linuxsys_bare.v
+++ b/vlib/builtin/linux_bare/linuxsys_bare.v
@@ -228,7 +228,7 @@ pub enum Map_flags {
 fn sys_call0(scn u64) u64 {
 	res := u64(0)
 	asm amd64 {
-		syscall 
+		syscall
 		; =a (res)
 		; a (scn)
 	}
@@ -238,7 +238,7 @@ fn sys_call0(scn u64) u64 {
 fn sys_call1(scn u64, arg1 u64) u64 {
 	res := u64(0)
 	asm amd64 {
-		syscall 
+		syscall
 		; =a (res)
 		; a (scn)
 		  D (arg1)
@@ -249,7 +249,7 @@ fn sys_call1(scn u64, arg1 u64) u64 {
 fn sys_call2(scn u64, arg1 u64, arg2 u64) u64 {
 	res := u64(0)
 	asm amd64 {
-		syscall 
+		syscall
 		; =a (res)
 		; a (scn)
 		  D (arg1)
@@ -261,7 +261,7 @@ fn sys_call2(scn u64, arg1 u64, arg2 u64) u64 {
 fn sys_call3(scn u64, arg1 u64, arg2 u64, arg3 u64) u64 {
 	res := u64(0)
 	asm amd64 {
-		syscall 
+		syscall
 		; =a (res)
 		; a (scn)
 		  D (arg1)
@@ -275,7 +275,7 @@ fn sys_call4(scn u64, arg1 u64, arg2 u64, arg3 u64, arg4 u64) u64 {
 	res := u64(0)
 	asm amd64 {
 		mov r10, arg4
-		syscall 
+		syscall
 		; =a (res)
 		; a (scn)
 		  D (arg1)
@@ -292,7 +292,7 @@ fn sys_call5(scn u64, arg1 u64, arg2 u64, arg3 u64, arg4 u64, arg5 u64) u64 {
 	asm amd64 {
 		mov r10, arg4
 		mov r8, arg5
-		syscall 
+		syscall
 		; =a (res)
 		; a (scn)
 		  D (arg1)
@@ -312,7 +312,7 @@ fn sys_call6(scn u64, arg1 u64, arg2 u64, arg3 u64, arg4 u64, arg5 u64, arg6 u64
 		mov r10, arg4
 		mov r8, arg5
 		mov r9, arg6
-		syscall 
+		syscall
 		; =a (res)
 		; a (scn)
 		  D (arg1)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -668,7 +668,13 @@ fn expr_is_single_line(expr ast.Expr) bool {
 //=== Specific Stmt methods ===//
 
 fn (mut f Fmt) asm_stmt(stmt ast.AsmStmt) {
-	f.writeln('asm $stmt.arch {')
+	f.write('asm ')
+	if stmt.is_volatile {
+		f.write('volatile ')
+	} else if stmt.is_goto {
+		f.write('goto ')
+	}
+	f.writeln('$stmt.arch {')
 	f.indent++
 	for template in stmt.templates {
 		if template.is_directive {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -684,7 +684,9 @@ fn (mut f Fmt) asm_stmt(stmt ast.AsmStmt) {
 		if template.is_label {
 			f.write(':')
 		} else {
-			f.write(' ')
+			if template.args.len > 0 {
+				f.write(' ')
+			}
 		}
 		for i, arg in template.args {
 			f.asm_arg(arg)


### PR DESCRIPTION
This PR fix the ate up of volatile and goto, aswell a added space after templates without args in asm stmt