### PR TITLE
map: fix zeros_to_end

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -175,8 +175,8 @@ fn (mut d DenseArray) zeros_to_end() {
 		if d.has_index(i) {
 			// swap (TODO: optimize)
 			unsafe {
-				// Swap keys
 				if count != i {
+					// Swap keys
 					C.memcpy(tmp_key, d.key(count), d.key_bytes)
 					C.memcpy(d.key(count), d.key(i), d.key_bytes)
 					C.memcpy(d.key(i), tmp_key, d.key_bytes)

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -172,17 +172,19 @@ fn (mut d DenseArray) zeros_to_end() {
 	mut tmp_key := unsafe { malloc(d.key_bytes) }
 	mut count := 0
 	for i in 0 .. d.len {
-		if d.has_index(i) && count != i {
+		if d.has_index(i) {
 			// swap (TODO: optimize)
 			unsafe {
 				// Swap keys
-				C.memcpy(tmp_key, d.key(count), d.key_bytes)
-				C.memcpy(d.key(count), d.key(i), d.key_bytes)
-				C.memcpy(d.key(i), tmp_key, d.key_bytes)
-				// Swap values
-				C.memcpy(tmp_value, d.value(count), d.value_bytes)
-				C.memcpy(d.value(count), d.value(i), d.value_bytes)
-				C.memcpy(d.value(i), tmp_value, d.value_bytes)
+				if count != i {
+					C.memcpy(tmp_key, d.key(count), d.key_bytes)
+					C.memcpy(d.key(count), d.key(i), d.key_bytes)
+					C.memcpy(d.key(i), tmp_key, d.key_bytes)
+					// Swap values
+					C.memcpy(tmp_value, d.value(count), d.value_bytes)
+					C.memcpy(d.value(count), d.value(i), d.value_bytes)
+					C.memcpy(d.value(i), tmp_value, d.value_bytes)
+				}
 			}
 			count++
 		}

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -172,7 +172,7 @@ fn (mut d DenseArray) zeros_to_end() {
 	mut tmp_key := unsafe { malloc(d.key_bytes) }
 	mut count := 0
 	for i in 0 .. d.len {
-		if d.has_index(i) {
+		if d.has_index(i) && count != i {
 			// swap (TODO: optimize)
 			unsafe {
 				// Swap keys


### PR DESCRIPTION
Should fix this bug:
```
==1426== Source and destination overlap in memcpy(0x8fe6150, 0x8fe6150, 16)
==1426==    at 0x484F1D4: __GI_memcpy (in /usr/lib/aarch64-linux-gnu/valgrind/vgpreload_memcheck-arm64-linux.so)
==1426==    by 0x406B4F: map_delete
==1426==
==1426== Source and destination overlap in memcpy(0x8fe5b80, 0x8fe5b80, 24)
==1426==    at 0x484F1D4: __GI_memcpy (in /usr/lib/aarch64-linux-gnu/valgrind/vgpreload_memcheck-arm64-linux.so)
==1426==    by 0x406B8F: map_delete
```