### PR TITLE
fmt: remove parenthesis around single ident

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -270,7 +270,7 @@ pub fn (mut a array) pop() voidptr {
 		}
 	}
 	new_len := a.len - 1
-	last_elem := unsafe { &byte(a.data) + (new_len) * a.element_size }
+	last_elem := unsafe { &byte(a.data) + new_len * a.element_size }
 	a.len = new_len
 	// NB: a.cap is not changed here *on purpose*, so that
 	// further << ops on that array will be more efficient.

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -43,7 +43,7 @@ fn test_between() {
 fn test_compare() {
 	a := 'Music'
 	b := 'src'
-	assert b >= (a)
+	assert b >= a
 }
 
 fn test_lt() {
@@ -53,12 +53,12 @@ fn test_lt() {
 	d := 'b'
 	e := 'aa'
 	f := 'ab'
-	assert a < (b)
+	assert a < b
 	assert !(b < c)
-	assert c < (d)
+	assert c < d
 	assert !(d < e)
-	assert c < (e)
-	assert e < (f)
+	assert c < e
+	assert e < f
 }
 
 fn test_ge() {
@@ -67,11 +67,11 @@ fn test_ge() {
 	c := 'ab'
 	d := 'abc'
 	e := 'aaa'
-	assert b >= (a)
-	assert c >= (b)
-	assert d >= (c)
+	assert b >= a
+	assert c >= b
+	assert d >= c
 	assert !(c >= d)
-	assert e >= (a)
+	assert e >= a
 }
 
 fn test_compare_strings() {

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -188,7 +188,7 @@ const (
 const (
 	sublang_neutral = 0x00
 	sublang_default = 0x01
-	lang_neutral    = (sublang_neutral)
+	lang_neutral    = sublang_neutral
 )
 
 // Ref - https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--12000-15999-

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2157,11 +2157,16 @@ pub fn (mut f Fmt) or_expr(node ast.OrExpr) {
 }
 
 pub fn (mut f Fmt) par_expr(node ast.ParExpr) {
-	f.write('(')
-	f.par_level++
+	requires_paren := node.expr !is ast.Ident
+	if requires_paren {
+		f.par_level++
+		f.write('(')
+	}
 	f.expr(node.expr)
-	f.par_level--
-	f.write(')')
+	if requires_paren {
+		f.par_level--
+		f.write(')')
+	}
 }
 
 pub fn (mut f Fmt) postfix_expr(node ast.PostfixExpr) {

--- a/vlib/v/fmt/tests/par_expr_expected.vv
+++ b/vlib/v/fmt/tests/par_expr_expected.vv
@@ -1,0 +1,3 @@
+fn main() {
+	_ := (cond1 && cond2) || single_ident
+}

--- a/vlib/v/fmt/tests/par_expr_input.vv
+++ b/vlib/v/fmt/tests/par_expr_input.vv
@@ -1,0 +1,3 @@
+fn main() {
+	_ := (cond1 && cond2) || (single_ident)
+}


### PR DESCRIPTION
`x := (foo)` --> `x := foo`