### PR TITLE
vdoc: ignore builtin/linux_bare

### DIFF
--- a/vlib/.vdocignore
+++ b/vlib/.vdocignore
@@ -1,5 +1,6 @@
 builtin/bare
 builtin/js
+builtin/linux_bare
 dl/example
 oldgg/
 os/bare


### PR DESCRIPTION
Fixes this error in modules toc:
![image](https://user-images.githubusercontent.com/40118727/114542417-324e9d00-9c58-11eb-9c23-59c513932b6c.png)
