### PR TITLE
sokol: replace darwin flag with macos flag

### DIFF
--- a/vlib/sokol/c/declaration.c.v
+++ b/vlib/sokol/c/declaration.c.v
@@ -12,7 +12,7 @@ pub const (
 #flag freebsd -L/usr/local/lib -lX11 -lGL -lXcursor -lXi
 #flag windows -lgdi32
 // METAL
-$if darwin {
+$if macos {
 	#flag -DSOKOL_METAL
 	#flag -framework Metal -framework Cocoa -framework MetalKit -framework QuartzCore
 }


### PR DESCRIPTION
`$if darwin {` does not work like `#flag darwin`. `$if macos {` works as expected.
Without this fix, ui (and I guess sokol) for macos does not work properly.