### PR TITLE
all: make __global behave consistent with const

### DIFF
--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -4,8 +4,8 @@
 module builtin
 
 __global (
-	g_m2_buf &byte 
-	g_m2_ptr &byte 
+	g_m2_buf &byte
+	g_m2_ptr &byte
 )
 
 // isnil returns true if an object is nil (only for C objects).
@@ -48,7 +48,7 @@ __global (
 	total_m              = i64(0)
 	nr_mallocs           = int(0)
 	// will be filled in cgen
-	as_cast_type_indexes   []VCastTypeIndexName 
+	as_cast_type_indexes []VCastTypeIndexName
 )
 
 fn __as_cast(obj voidptr, obj_type int, expected_type int) voidptr {

--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -66,7 +66,9 @@ const (
 )
 
 // g_original_codepage - used to restore the original windows console code page when exiting
-__global ( g_original_codepage = u32(0))
+__global (
+	g_original_codepage = u32(0)
+)
 
 // utf8 to stdout needs C.SetConsoleOutputCP(C.CP_UTF8)
 fn C.GetConsoleOutputCP() u32

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1285,7 +1285,9 @@ pub fn (s string) ustring() ustring {
 // A hack that allows to create ustring without allocations.
 // It's called from functions like draw_text() where we know that the string is going to be freed
 // right away. Uses global buffer for storing runes []int array.
-__global ( g_ustring_runes []int )
+__global (
+	g_ustring_runes []int
+)
 
 pub fn (s string) ustring_tmp() ustring {
 	if g_ustring_runes.len == 0 {

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -526,8 +526,8 @@ pub mut:
 
 pub struct GlobalDecl {
 pub:
-	pos token.Position
-	is_block     bool // __global() block
+	pos      token.Position
+	is_block bool // __global() block
 pub mut:
 	fields       []GlobalField
 	end_comments []Comment

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -525,6 +525,7 @@ pub mut:
 }
 
 pub struct GlobalDecl {
+	is_block     bool // __global() block
 pub:
 	pos token.Position
 pub mut:

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -525,9 +525,9 @@ pub mut:
 }
 
 pub struct GlobalDecl {
-	is_block     bool // __global() block
 pub:
 	pos token.Position
+	is_block     bool // __global() block
 pub mut:
 	fields       []GlobalField
 	end_comments []Comment

--- a/vlib/v/checker/tests/globals/assign_no_type.out
+++ b/vlib/v/checker/tests/globals/assign_no_type.out
@@ -1,3 +1,3 @@
-vlib/v/checker/tests/globals/assign_no_type.vv:1:21: error: global assign must have a type and value, use `__global ( name = type(value) )` or `__global ( name type )`
+vlib/v/checker/tests/globals/assign_no_type.vv:1:21: error: global assign must have a type and value, use `name = type(value)` or `name type`
     1 | __global ( test = 0 )
       |                     ^

--- a/vlib/v/checker/tests/globals/assign_no_value.out
+++ b/vlib/v/checker/tests/globals/assign_no_value.out
@@ -1,3 +1,3 @@
-vlib/v/checker/tests/globals/assign_no_value.vv:1:23: error: global assign must have a type and value, use `__global ( name = type(value) )` or `__global ( name type )`
+vlib/v/checker/tests/globals/assign_no_value.vv:1:23: error: global assign must have a type and value, use `name = type(value)` or `name type`
     1 | __global ( test = int )
       |                       ^

--- a/vlib/v/checker/tests/globals/unexpected_eof.out
+++ b/vlib/v/checker/tests/globals/unexpected_eof.out
@@ -1,0 +1,3 @@
+vlib/v/checker/tests/globals/unexpected_eof.vv:3:1: error: unexpected eof, expecting ´)´
+    1 | __global (
+    2 |     x string

--- a/vlib/v/checker/tests/globals/unexpected_eof.vv
+++ b/vlib/v/checker/tests/globals/unexpected_eof.vv
@@ -1,0 +1,2 @@
+__global (
+	x string

--- a/vlib/v/fmt/tests/global_keep.vv
+++ b/vlib/v/fmt/tests/global_keep.vv
@@ -1,0 +1,10 @@
+__global x = bool(true)
+__global y f32
+__global ()
+__global (
+	spam string
+	foo  = int(5)
+)
+__global (
+	a int
+)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2818,7 +2818,6 @@ fn (mut p Parser) global_decl() ast.GlobalDecl {
 		return ast.GlobalDecl{}
 	}
 	start_pos := p.tok.position()
-	end_pos := p.tok.position()
 	p.check(.key_global)
 	is_block := p.tok.kind == .lpar
 	if is_block {
@@ -2875,7 +2874,7 @@ fn (mut p Parser) global_decl() ast.GlobalDecl {
 		p.check(.rpar)
 	}
 	return ast.GlobalDecl{
-		pos: start_pos.extend(end_pos)
+		pos: start_pos.extend(p.prev_tok.position())
 		fields: fields
 		end_comments: comments
 		is_block: is_block

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2820,15 +2820,18 @@ fn (mut p Parser) global_decl() ast.GlobalDecl {
 	start_pos := p.tok.position()
 	end_pos := p.tok.position()
 	p.check(.key_global)
-	if p.tok.kind != .lpar {
-		p.error('globals must be grouped, e.g. `__global ( a = int(1) )`')
-		return ast.GlobalDecl{}
+	is_block := p.tok.kind == .lpar
+	if is_block {
+		p.next() // (
 	}
-	p.next() // (
 	mut fields := []ast.GlobalField{}
 	mut comments := []ast.Comment{}
 	for {
 		comments = p.eat_comments({})
+		if is_block && p.tok.kind == .eof {
+			p.error('unexpected eof, expecting ´)´')
+			return ast.GlobalDecl{}
+		}
 		if p.tok.kind == .rpar {
 			break
 		}
@@ -2840,13 +2843,13 @@ fn (mut p Parser) global_decl() ast.GlobalDecl {
 		}
 		typ := p.parse_type()
 		if p.tok.kind == .assign {
-			p.error('global assign must have the type around the value, use `__global ( name = type(value) )`')
+			p.error('global assign must have the type around the value, use `name = type(value)`')
 			return ast.GlobalDecl{}
 		}
 		mut expr := ast.empty_expr()
 		if has_expr {
 			if p.tok.kind != .lpar {
-				p.error('global assign must have a type and value, use `__global ( name = type(value) )` or `__global ( name type )`')
+				p.error('global assign must have a type and value, use `name = type(value)` or `name type`')
 				return ast.GlobalDecl{}
 			}
 			p.next() // (
@@ -2864,12 +2867,18 @@ fn (mut p Parser) global_decl() ast.GlobalDecl {
 		fields << field
 		p.global_scope.register(field)
 		comments = []
+		if !is_block {
+			break
+		}
 	}
-	p.check(.rpar)
+	if is_block {
+		p.check(.rpar)
+	}
 	return ast.GlobalDecl{
 		pos: start_pos.extend(end_pos)
 		fields: fields
 		end_comments: comments
+		is_block: is_block
 	}
 }
 


### PR DESCRIPTION
```v
// single line
__global x = bool(true)
__global y f32

// blocks
__global ()
__global (
	spam string
        foo  = int(5)
)
__global (
	a int
)
```