### PR TITLE
Regex: bugfix out of bound with gcc "-fsanitize=address"

### DIFF
--- a/vlib/regex/regex.v
+++ b/vlib/regex/regex.v
@@ -1690,7 +1690,7 @@ pub fn (mut re RE) match_base(in_txt &byte, in_txt_len int ) (int,int) {
 		}
 
 		// we're out of text, manage it
-		if state.i > in_txt_len || m_state == .new_line {
+		if state.i >= in_txt_len || m_state == .new_line {
 			//println("Finished text!!")
 			src_end = true
 


### PR DESCRIPTION
**What's inside**
- Fix for an out of bound error using `./v -gc boehm -cc gcc -cflags "-fsanitize=address" test vlib/regex/`
- solved with a simple `>=` instead of a `>` :D
- Now using: `./v -gc boehm -cc gcc -cflags "-fsanitize=address" test vlib/regex/` all green and no memory leaks detectd
Ubuntu 18.04
gcc v 10.1.0

Tnx to Kasper W for having highlighted this bug :)