### PR TITLE
os: create os.hostname() and os.chown() + os.uname() for windows 

### DIFF
--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -840,7 +840,7 @@ pub fn chown(path string, owner int, group int) ? {
 		return error('os.chown() not implemented for Windows')
 	} $else {
 		if owner < 0 || group < 0 {
-			return error('os.chown() uid or gid equal not valid: Not changing owner!')
+			return error('os.chown() uid and gid cannot be negative: Not changing owner!')
 		} else {
 			if C.chown(&char(path.str), owner, group) != 0 {
 				return error_with_code(posix_get_error_msg(C.errno), C.errno)

--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -31,6 +31,8 @@ fn C.CopyFile(&u16, &u16, bool) int
 
 fn C._wstat64(&char, voidptr) u64
 
+fn C.chown(&char, int, int) int
+
 // fn C.proc_pidpath(int, byteptr, int) int
 struct C.stat {
 	st_size  u64
@@ -827,7 +829,24 @@ pub fn flush() {
 // chmod change file access attributes of `path` to `mode`.
 // Octals like `0o600` can be used.
 pub fn chmod(path string, mode int) {
-	C.chmod(&char(path.str), mode)
+	if C.chmod(&char(path.str), mode) != 0 {
+		panic(posix_get_error_msg(C.errno))
+	}
+}
+
+// chown change owner and group attributes of path to `owner` and `group`.
+pub fn chown(path string, owner int, group int) ? {
+	$if windows {
+		return error('os.chown() not implemented for Windows')
+	} $else {
+		if owner < 0 || group < 0 {
+			return error('os.chown() uid or gid equal not valid: Not changing owner!')
+		} else {
+			if C.chown(&char(path.str), owner, group) != 0 {
+				return error_with_code(posix_get_error_msg(C.errno), C.errno)
+			}
+		}
+	}
 }
 
 // open_append opens `path` file for appending.

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -69,6 +69,10 @@ pub fn uname() Uname {
 	return u
 }
 
+pub fn hostname() string {
+	return uname().nodename
+}
+
 fn init_os_args(argc int, argv &&byte) []string {
 	mut args_ := []string{}
 	// mut args := []string(make(0, argc, sizeof(string)))

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -51,6 +51,8 @@ fn C.uname(name voidptr) int
 
 fn C.symlink(&char, &char) int
 
+fn C.gethostname(&char, int) int
+
 pub fn uname() Uname {
 	mut u := Uname{}
 	utsize := sizeof(C.utsname)
@@ -70,7 +72,15 @@ pub fn uname() Uname {
 }
 
 pub fn hostname() string {
-	return uname().nodename
+	mut hstnme := ''
+	size := 256
+	mut buf := unsafe { &char(malloc(size)) }
+	if C.gethostname(buf, size) == 0 {
+		hstnme = unsafe { cstring_to_vstring(buf) }
+		unsafe { free(buf) }
+		return hstnme
+	}
+	return ''
 }
 
 fn init_os_args(argc int, argv &&byte) []string {

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -376,8 +376,8 @@ pub fn debugger_present() bool {
 }
 
 pub fn uname() Uname {
+	// TODO: use Win32 Api functions instead
 	sys_and_ver := execute('cmd /c ver').output.split('[')
-
 	nodename := execute('cmd /c hostname').output
 	machine := execute('cmd /c echo %PROCESSOR_ARCHITECTURE%').output
 	return Uname{
@@ -390,6 +390,7 @@ pub fn uname() Uname {
 }
 
 pub fn hostname() string {
+	// TODO: use C.GetComputerName(&u16, u32) int instead
 	return execute('cmd /c hostname').output
 }
 

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -376,15 +376,21 @@ pub fn debugger_present() bool {
 }
 
 pub fn uname() Uname {
-	// TODO: implement `os.uname()` for windows
-	unknown := 'unknown'
+	sys_and_ver := execute('cmd /c ver').output.split('[')
+
+	nodename := execute('cmd /c hostname').output
+	machine := execute('cmd /c echo %PROCESSOR_ARCHITECTURE%').output
 	return Uname{
-		sysname: unknown
-		nodename: unknown
-		release: unknown
-		version: unknown
-		machine: unknown
+		sysname: sys_and_ver[0].trim_space()
+		nodename: nodename
+		release: sys_and_ver[1].replace(']', '')
+		version: sys_and_ver[0] + '[' + sys_and_ver[1]
+		machine: machine
 	}
+}
+
+pub fn hostname() string {
+	return execute('cmd /c hostname').output
 }
 
 // `is_writable_folder` - `folder` exists and is writable to the process


### PR DESCRIPTION
Until now, the os.uname() function was only available for Linux. Temporarily I have now integrated it for Windows. For the future the execute() commands should be replaced by the Win32 API functions. What do you think about this?

I have already tried an implementation with the Win32 API (as the following hostname example shows), but without success.
```v
fn C.GetComputerName(&u16, u32) int

// some code

pub fn hostname(){
  mut buf := &u16(malloc(256))
  mut nsize := 256
  C.GetComputerName(buf, nsize) /* or */  C.GetComputerName(voidptr(&buf), nsize)
  return string_from_wide2(buf)// or something like this
}
```
Both ended in segfault...

What I have done:
- create hostname() which returns the computers hostname
  - on Linux with C.gethostname(), on Windows with execute()
- create uname() for windows
- vfmt

[EDIT]
- add os.chown() (error with Windows)
- add error check for os.chmod()



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
