### PR TITLE
cgen: fix generics with embed generics (fix #8694)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3355,10 +3355,18 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) ast.Type {
 		}
 		if array_init.is_fixed {
 			idx := c.table.find_or_register_array_fixed(elem_type, array_init.exprs.len)
-			array_init.typ = ast.new_type(idx)
+			if elem_type.has_flag(.generic) {
+				array_init.typ = ast.new_type(idx).set_flag(.generic)
+			} else {
+				array_init.typ = ast.new_type(idx)
+			}
 		} else {
 			idx := c.table.find_or_register_array(elem_type)
-			array_init.typ = ast.new_type(idx)
+			if elem_type.has_flag(.generic) {
+				array_init.typ = ast.new_type(idx).set_flag(.generic)
+			} else {
+				array_init.typ = ast.new_type(idx)
+			}
 		}
 		array_init.elem_type = elem_type
 	} else if array_init.is_fixed && array_init.exprs.len == 1
@@ -3393,8 +3401,11 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) ast.Type {
 			c.error('fixed size cannot be zero or negative', init_expr.position())
 		}
 		idx := c.table.find_or_register_array_fixed(array_init.elem_type, fixed_size)
-		array_type := ast.new_type(idx)
-		array_init.typ = array_type
+		if array_init.elem_type.has_flag(.generic) {
+			array_init.typ = ast.new_type(idx).set_flag(.generic)
+		} else {
+			array_init.typ = ast.new_type(idx)
+		}
 		if array_init.has_default {
 			c.expr(array_init.default_expr)
 		}
@@ -6049,10 +6060,13 @@ pub fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 				c.check_dup_keys(node, i)
 			}
 		}
-		map_type := ast.new_type(c.table.find_or_register_map(key0_type, val0_type))
+		mut map_type := ast.new_type(c.table.find_or_register_map(key0_type, val0_type))
 		node.typ = map_type
 		node.key_type = key0_type
 		node.value_type = val0_type
+		if node.key_type.has_flag(.generic) || node.value_type.has_flag(.generic) {
+			map_type = map_type.set_flag(.generic)
+		}
 		return map_type
 	}
 	return node.typ

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3617,7 +3617,7 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 		// arr << val
 		tmp := g.new_tmp_var()
 		info := left_final_sym.info as ast.Array
-		if right_final_sym.kind == .array && info.elem_type != node.right_type {
+		if right_final_sym.kind == .array && info.elem_type != g.unwrap_generic(node.right_type) {
 			// push an array => PUSH_MANY, but not if pushing an array to 2d array (`[][]int << []int`)
 			g.write('_PUSH_MANY(')
 			mut expected_push_many_atype := left_type

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -605,7 +605,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	}
 	// TODO performance, detect `array` method differently
 	if left_sym.kind == .array
-		&& node.name in ['repeat', 'sort_with_compare', 'free', 'push_many', 'trim', 'first', 'last', 'pop', 'clone', 'reverse', 'slice'] {
+		&& node.name in ['repeat', 'sort_with_compare', 'free', 'push_many', 'trim', 'first', 'last', 'pop', 'clone', 'reverse', 'slice', 'pointers'] {
 		// && rec_sym.name == 'array' {
 		// && rec_sym.name == 'array' && receiver_name.starts_with('array') {
 		// `array_byte_clone` => `array_clone`

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -33,7 +33,11 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 			// this is set here because it's a known type, others could be the
 			// result of expr so we do those in checker
 			idx := p.table.find_or_register_array(elem_type)
-			array_type = ast.new_type(idx)
+			if elem_type.has_flag(.generic) {
+				array_type = ast.new_type(idx).set_flag(.generic)
+			} else {
+				array_type = ast.new_type(idx)
+			}
 			has_type = true
 		}
 		last_pos = p.tok.position()

--- a/vlib/v/tests/generics_with_embed_generics_test.v
+++ b/vlib/v/tests/generics_with_embed_generics_test.v
@@ -10,7 +10,7 @@ fn group_new<T>(val ...T) Group<T> {
 	for i in val {
 		arr << i
 	}
-	mut g := Group<T>{
+	mut g := Group{
 		len: val.len
 		val: arr
 	}

--- a/vlib/v/tests/generics_with_embed_generics_test.v
+++ b/vlib/v/tests/generics_with_embed_generics_test.v
@@ -1,0 +1,36 @@
+struct Group<T> {
+	len int
+	val []T
+mut:
+	index int
+}
+
+fn group_new<T>(val ...T) Group<T> {
+	mut arr := []T{cap: val.len}
+	for i in val {
+		arr << i
+	}
+	mut g := Group<T>{
+		len: val.len
+		val: arr
+	}
+
+	return g
+}
+
+fn (mut it Group<T>) next<T>() ?T {
+	if it.index >= it.len {
+		return none
+	}
+	v := it.val[it.index]
+	it.index++
+	return v
+}
+
+fn test_generics_with_embed_generics() {
+	gx := group_new<int>(1, 2, 3)
+	for x in gx.val {
+		println(x)
+	}
+	assert gx.val == [1, 2, 3]
+}


### PR DESCRIPTION
This PR fix generics with embed generics (fix #8694).

- Fix generics with embed generics.
- Add test.

```vlang
struct Group<T> {
	len int
	val []T
mut:
	index int
}

fn group_new<T>(val ...T) Group<T> {
	mut arr := []T{cap: val.len}
	for i in val {
		arr << i
	}
	mut g := Group<T>{
		len: val.len
		val: arr
	}

	return g
}

fn (mut it Group<T>) next<T>() ?T {
	if it.index >= it.len {
		return none
	}
	v := it.val[it.index]
	it.index++
	return v
}

fn main() {
	gx := group_new<int>(1, 2, 3)
	for x in gx.val {
		println(x)
	}
	assert gx.val == [1, 2, 3]
}

D:\Test\v\tt1>v run .
1
2
3
```