### PR TITLE
tmpl: escape JavaScript template literal syntax

### DIFF
--- a/vlib/v/parser/tmpl.v
+++ b/vlib/v/parser/tmpl.v
@@ -216,13 +216,13 @@ mut sb := strings.new_builder($lstartlength)\n
 			}
 		} else if state == .js {
 			// replace `$` to `\$` at first to escape JavaScript template literal syntax
-			source.writeln(line.replace('$', '\\$').replace('$$', '@').replace('.$', '.@').replace("'",
-				"\\'"))
+			source.writeln(line.replace(r'$', r'\$').replace(r'$$', r'@').replace(r'.$',
+				r'.@').replace(r"'", r"\'"))
 		} else {
 			// HTML, may include `@var`
 			// escaped by cgen, unless it's a `vweb.RawHtml` string
-			source.writeln(line.replace('@', '$').replace('$$', '@').replace('.$', '.@').replace("'",
-				"\\'"))
+			source.writeln(line.replace(r'@', r'$').replace(r'$$', r'@').replace(r'.$',
+				r'.@').replace(r"'", r"\'"))
 		}
 	}
 	source.writeln(parser.tmpl_str_end)

--- a/vlib/v/parser/tmpl.v
+++ b/vlib/v/parser/tmpl.v
@@ -214,6 +214,10 @@ mut sb := strings.new_builder($lstartlength)\n
 			} else {
 				source.writeln('</div>')
 			}
+		} else if state == .js {
+			// replace `$` to `\$` at first to escape JavaScript template literal syntax
+			source.writeln(line.replace('$', '\\$').replace('$$', '@').replace('.$', '.@').replace("'",
+				"\\'"))
 		} else {
 			// HTML, may include `@var`
 			// escaped by cgen, unless it's a `vweb.RawHtml` string

--- a/vlib/v/tests/inout/file.html
+++ b/vlib/v/tests/inout/file.html
@@ -17,6 +17,9 @@ color: red;
 </script>
 <script>
 document.getElementById("demo").innerHTML = "Hello JavaScript!";
+
+const classes = `header ${ isLargeScreen() ? '' :
+`icon-${item.isCollapsed ? 'expander' : 'collapser'}` }`;
 </script>
 </head>
 

--- a/vlib/v/tests/inout/tmpl_parse_html.out
+++ b/vlib/v/tests/inout/tmpl_parse_html.out
@@ -17,6 +17,9 @@ color: red;
 </script>
 <script>
 document.getElementById("demo").innerHTML = "Hello JavaScript!";
+
+const classes = `header ${ isLargeScreen() ? '' :
+`icon-${item.isCollapsed ? 'expander' : 'collapser'}` }`;
 </script>
 </head>
 


### PR DESCRIPTION
when HTML template contains JavaScript template literal syntax:
```html
<script>
    let a = 100;
    let b = `${a}px`
</script>
```
it occurs  `undefined ident error: a`.

This PR fixes the error by replacing `$` to `\$` in `<script>` scope.

The tests are passed, but I got error when running `v -o vtmp_werror -cflags -Werror cmd/v`.


