### PR TITLE
Fix SIGSEGV in struct declarations that initialize fields via functions

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2062,7 +2062,7 @@ pub fn (mut c Checker) fn_call(mut call_expr ast.CallExpr) ast.Type {
 		&& func.mod != c.mod {
 		c.error('function `$func.name` is private', call_expr.pos)
 	}
-	if !c.cur_fn.is_deprecated && func.is_deprecated {
+	if c.cur_fn != 0 && !c.cur_fn.is_deprecated && func.is_deprecated {
 		c.deprecate_fnmethod('function', func.name, func, call_expr)
 	}
 	if func.is_unsafe && !c.inside_unsafe


### PR DESCRIPTION
This PR is a draft PR because I'm not sure how to write a test for this yet.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

For code that looks like this:
```v
module testing

import json
import jsonrpc
import os
import lsp
import benchmark

struct TestResponse {
	jsonrpc string = jsonrpc.version
	id      int
	result  string                [raw]
	error   jsonrpc.ResponseError
}

struct TestNotification {
	jsonrpc string = jsonrpc.version
	method  string
	params  string [raw]
}

pub struct Testio {
mut:
	current_req_id int = 1
	has_decoded    bool
	response       TestResponse // parsed response data from raw_response
pub mut:
	bench        benchmark.Benchmark = benchmark.new_benchmark()
	raw_response string // raw JSON string of the response data
	debug        bool
}
```

When `checker.v` runs on a file containing this line:
```
	bench        benchmark.Benchmark = benchmark.new_benchmark()
```

It crashes.

To verify this fix, I manually edited this file locally to check that `C.cur_fn != 0` and it no longer crashes.


Crash log:
```crash
Process:               document_symbols_test [21489]
Path:                  /private/var/folders/*/document_symbols_test
Identifier:            document_symbols_test
Version:               ???
Code Type:             X86-64 (Native)
Parent Process:        ??? [21483]
Responsible:           Terminal [417]
User ID:               501

Date/Time:             2021-04-14 20:54:47.852 -0700
OS Version:            macOS 11.2.3 (20D91)
Report Version:        12
Bridge OS Version:     5.2 (18P4347)
Anonymous UUID:        E64A1AB1-5016-47F5-9DF4-254DF6337F0E

Sleep/Wake UUID:       7D0FA393-EDF0-4440-8CD9-D874319379A7

Time Awake Since Boot: 78000 seconds
Time Since Wake:       34000 seconds

System Integrity Protection: enabled

Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x0000000000000038
Exception Note:        EXC_CORPSE_NOTIFY

Termination Signal:    Segmentation fault: 11
Termination Reason:    Namespace SIGNAL, Code 0xb
Terminating Process:   exc handler [21489]

VM Regions Near 0x38:
--> 
    __TEXT                      10bf82000-10c10a000    [ 1568K] r-x/r-x SM=COW  /private/var/folders/*

Application Specific Information:
dyld2 mode

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   document_symbols_test         	0x000000010c0947c2 v__checker__Checker_fn_call + 6706 (checker.v:2065)
1   document_symbols_test         	0x000000010c08f8d9 v__checker__Checker_call_expr + 73 (checker.v:1313)
2   document_symbols_test         	0x000000010c07e490 v__checker__Checker_expr + 3008 (checker.v:4138)
3   document_symbols_test         	0x000000010c085efd v__checker__Checker_struct_decl + 2237 (checker.v:415)
4   document_symbols_test         	0x000000010c081df9 v__checker__Checker_stmt + 3017 (checker.v:3581)
5   document_symbols_test         	0x000000010c0811f2 v__checker__Checker_check + 562 (checker.v:113)
6   document_symbols_test         	0x000000010c08245b v__checker__Checker_check_files + 283 (checker.v:158)
7   document_symbols_test         	0x000000010c0ca552 vls__Vls_process_file + 1778 (text_synchronization.v:87)
8   document_symbols_test         	0x000000010c0c9e2d vls__Vls_did_open + 365 (text_synchronization.v:23)
9   document_symbols_test         	0x000000010c0cd55a vls__Vls_dispatch + 1178 (vls.v:156)
10  document_symbols_test         	0x000000010c0d0f52 main__test_document_symbols + 1458 (document_symbols_test.v:137)
11  document_symbols_test         	0x000000010c0d52ff main + 63 (document_symbols_test.9439264272849359160.tmp.c:1000375)
12  document_symbols_test         	0x000000010bf83454 start + 52

Thread 0 crashed with X86 Thread State (64-bit):
  rax: 0x0000000000000000  rbx: 0x0000000000000000  rcx: 0x00007ffee3c78c28  rdx: 0x0000000000000000
  rdi: 0x00007ffee3c78c78  rsi: 0x00007ffee3c78c48  rbp: 0x00007ffee3c794c0  rsp: 0x00007ffee3c77b30
   r8: 0x0000000000000002   r9: 0x0000000000000002  r10: 0x00000000f1ffffff  r11: 0x0000000000000030
  r12: 0x0000000000000000  r13: 0x0000000000000000  r14: 0x0000000000000000  r15: 0x0000000000000000
  rip: 0x000000010c0947c2  rfl: 0x0000000000010202  cr2: 0x0000000000000038
  
Logical CPU:     6
Error Code:      0x00000004 (no mapping for user data read)
Trap Number:     14

Thread 0 instruction stream:
  00 00 00 b0 00 e8 c4 6a-f0 ff 48 89 85 68 f1 ff  .......j..H..h..
  ff 48 89 95 70 f1 ff ff-48 8b 85 50 f7 ff ff 48  .H..p...H..P...H
  8b b5 68 f1 ff ff 48 8b-95 70 f1 ff ff 48 8b bd  ..h...H..p...H..
  78 e9 ff ff 48 8b 08 48-89 0c 24 48 8b 48 08 48  x...H..H..$H.H.H
  89 4c 24 08 44 8b 40 10-44 89 44 24 10 e8 bc 78  .L$.D.@.D.D$...x
  fe ff 48 8b 85 58 f7 ff-ff 48 8b 80 90 00 00 00  ..H..X...H......
 [80]78 38 00 0f 85 bc 00-00 00 0f b6 85 b9 f5 ff  .x8.............	<==
  ff 83 f8 00 0f 84 ac 00-00 00 48 8b bd 58 f7 ff  ..........H..X..
  ff 48 8d 05 d4 7b 05 00-48 89 85 58 f1 ff ff c7  .H...{..H..X....
  85 60 f1 ff ff 08 00 00-00 c7 85 64 f1 ff ff 01  .`.........d....
  00 00 00 48 8b b5 50 f7-ff ff 48 8b 85 58 f1 ff  ...H..P...H..X..
  ff 48 8b 95 60 f1 ff ff-48 8b 8d 00 f6 ff ff 4c  .H..`...H......L
  
Thread 0 last branch register state not available.


Binary Images:
       0x10bf82000 -        0x10c109fff +document_symbols_test (???) <480846E0-93C8-378F-B3E7-40E70E35402A> /private/var/folders/*/document_symbols_test
       0x1141ff000 -        0x11429afff  dyld (832.7.3) <0D4EA85F-7E30-338B-9215-314A5A5539B6> /usr/lib/dyld
    0x7fff2020a000 -     0x7fff2020bfff  libsystem_blocks.dylib (78) <E644CAA0-65B7-36E4-8041-520F3301F3DB> /usr/lib/system/libsystem_blocks.dylib
    0x7fff2020c000 -     0x7fff20241fff  libxpc.dylib (2038.80.3) <70F26262-01AA-3CEC-9FAD-2701D24096F0> /usr/lib/system/libxpc.dylib
    0x7fff20242000 -     0x7fff20259fff  libsystem_trace.dylib (1277.80.2) <87FEF600-48D9-31C9-B8FC-D5249B2AE95D> /usr/lib/system/libsystem_trace.dylib
    0x7fff2025a000 -     0x7fff202f9fff  libcorecrypto.dylib (1000.80.5) <1EB11CFB-ABD7-36DD-97C7-C112A6601416> /usr/lib/system/libcorecrypto.dylib
    0x7fff202fa000 -     0x7fff20326fff  libsystem_malloc.dylib (317.40.8) <A498D1EF-E43D-310C-84E8-9C0AADA0C475> /usr/lib/system/libsystem_malloc.dylib
    0x7fff20327000 -     0x7fff2036bfff  libdispatch.dylib (1271.40.12) <AD988EEA-1A2F-3404-9A6E-390FC2504223> /usr/lib/system/libdispatch.dylib
    0x7fff2036c000 -     0x7fff203a4fff  libobjc.A.dylib (818.2) <EB6B543F-D42C-3FB2-A2EC-43407C5F80D3> /usr/lib/libobjc.A.dylib
    0x7fff203a5000 -     0x7fff203a7fff  libsystem_featureflags.dylib (28.60.1) <9CECB43A-094E-3CA9-B730-24DEA1A6DE05> /usr/lib/system/libsystem_featureflags.dylib
    0x7fff203a8000 -     0x7fff20430fff  libsystem_c.dylib (1439.40.11) <4AF71812-4099-3E96-B271-1F259491A2B2> /usr/lib/system/libsystem_c.dylib
    0x7fff20431000 -     0x7fff20486fff  libc++.1.dylib (904.4) <B217D905-4F9C-3DE0-8844-88FAA3C2C851> /usr/lib/libc++.1.dylib
    0x7fff20487000 -     0x7fff2049ffff  libc++abi.dylib (904.4) <3C9FE530-3CD2-3A64-8A36-70816AEBDF0D> /usr/lib/libc++abi.dylib
    0x7fff204a0000 -     0x7fff204cefff  libsystem_kernel.dylib (7195.81.3) <AB413518-ECDE-3F04-A61C-278D3CF43076> /usr/lib/system/libsystem_kernel.dylib
    0x7fff204cf000 -     0x7fff204dafff  libsystem_pthread.dylib (454.80.2) <B989DF6C-ADFE-3AF9-9C91-07D2521F9E47> /usr/lib/system/libsystem_pthread.dylib
    0x7fff204db000 -     0x7fff20515fff  libdyld.dylib (832.7.3) <4641E48F-75B5-3CC7-8263-47BF79F15394> /usr/lib/system/libdyld.dylib
    0x7fff20516000 -     0x7fff2051ffff  libsystem_platform.dylib (254.80.2) <1C3E1A0A-92A8-3CDE-B622-8940B43A5DF2> /usr/lib/system/libsystem_platform.dylib
    0x7fff20520000 -     0x7fff2054bfff  libsystem_info.dylib (542.40.3) <0C96CFE8-71F5-3335-8423-581BC3DE5846> /usr/lib/system/libsystem_info.dylib
    0x7fff2293a000 -     0x7fff22943fff  libsystem_darwin.dylib (1439.40.11) <E016D8F7-C87F-36F8-B8A0-6A61B8E4BACB> /usr/lib/system/libsystem_darwin.dylib
    0x7fff22d55000 -     0x7fff22d60fff  libsystem_notify.dylib (279.40.4) <B2BF20C7-448A-3FBD-A2F5-AB7618D173F6> /usr/lib/system/libsystem_notify.dylib
    0x7fff24cb1000 -     0x7fff24cbffff  libsystem_networkextension.dylib (1295.80.3) <5213D866-7D0E-3FD9-8E1A-03C0E39CEC44> /usr/lib/system/libsystem_networkextension.dylib
    0x7fff24d1d000 -     0x7fff24d33fff  libsystem_asl.dylib (385) <5B48071E-85EB-33B0-AE9B-127AEB398AEC> /usr/lib/system/libsystem_asl.dylib
    0x7fff2641c000 -     0x7fff26423fff  libsystem_symptoms.dylib (1431.40.36) <BC85B46C-02EE-31FF-861D-F0DE01E8F6CF> /usr/lib/system/libsystem_symptoms.dylib
    0x7fff2846c000 -     0x7fff2847cfff  libsystem_containermanager.dylib (318.80.2) <6F08275F-B912-3D8E-9D74-4845158AE4F3> /usr/lib/system/libsystem_containermanager.dylib
    0x7fff29179000 -     0x7fff2917cfff  libsystem_configuration.dylib (1109.60.2) <4917D824-4DE8-32CC-9ED2-1FBF371FEB9F> /usr/lib/system/libsystem_configuration.dylib
    0x7fff2917d000 -     0x7fff29181fff  libsystem_sandbox.dylib (1441.60.4) <5F7F3DD1-4B38-310C-AA8F-19FF1B0F5276> /usr/lib/system/libsystem_sandbox.dylib
    0x7fff29e85000 -     0x7fff29e87fff  libquarantine.dylib (119.40.2) <40D35D75-524B-3DA6-8159-E7E0FA66F5BC> /usr/lib/system/libquarantine.dylib
    0x7fff2a407000 -     0x7fff2a40bfff  libsystem_coreservices.dylib (127) <529A0663-A936-309C-9318-1B04B7F70658> /usr/lib/system/libsystem_coreservices.dylib
    0x7fff2a622000 -     0x7fff2a669fff  libsystem_m.dylib (3186.40.2) <DD26CC5C-AFF6-305F-A567-14909DD57163> /usr/lib/system/libsystem_m.dylib
    0x7fff2a66b000 -     0x7fff2a670fff  libmacho.dylib (973.4) <C2584BC4-497B-3170-ADDF-21B8E10B4DFD> /usr/lib/system/libmacho.dylib
    0x7fff2a68d000 -     0x7fff2a698fff  libcommonCrypto.dylib (60178.40.2) <822A29CE-BF54-35AD-BB15-8FAECB800C7D> /usr/lib/system/libcommonCrypto.dylib
    0x7fff2a699000 -     0x7fff2a6a3fff  libunwind.dylib (200.10) <1D0A4B4A-4370-3548-8DC1-42A7B4BD45D3> /usr/lib/system/libunwind.dylib
    0x7fff2a6a4000 -     0x7fff2a6abfff  liboah.dylib (203.30) <44C477D9-013F-3A6D-A9FE-68A89214E6A5> /usr/lib/liboah.dylib
    0x7fff2a6ac000 -     0x7fff2a6b6fff  libcopyfile.dylib (173.40.2) <39DBE613-135B-3AFE-A6AF-7898A37F70C2> /usr/lib/system/libcopyfile.dylib
    0x7fff2a6b7000 -     0x7fff2a6befff  libcompiler_rt.dylib (102.2) <62EE1D14-5ED7-3CEC-81C0-9C93833641F1> /usr/lib/system/libcompiler_rt.dylib
    0x7fff2a6bf000 -     0x7fff2a6c1fff  libsystem_collections.dylib (1439.40.11) <C53D5E0C-0C4F-3B35-A24B-E0D7101A3F95> /usr/lib/system/libsystem_collections.dylib
    0x7fff2a6c2000 -     0x7fff2a6c4fff  libsystem_secinit.dylib (87.60.1) <E05E35BC-1BAB-365B-8BEE-D774189EFD3B> /usr/lib/system/libsystem_secinit.dylib
    0x7fff2a6c5000 -     0x7fff2a6c7fff  libremovefile.dylib (49.40.3) <5CC12A16-82CB-32F0-9040-72CFC88A48DF> /usr/lib/system/libremovefile.dylib
    0x7fff2a6c8000 -     0x7fff2a6c8fff  libkeymgr.dylib (31) <803F6AED-99D5-3CCF-B0FA-361BCF14C8C0> /usr/lib/system/libkeymgr.dylib
    0x7fff2a6c9000 -     0x7fff2a6d0fff  libsystem_dnssd.dylib (1310.80.1) <E0A0CAB3-6779-3C83-AC67-046CFE69F9C2> /usr/lib/system/libsystem_dnssd.dylib
    0x7fff2a6d1000 -     0x7fff2a6d6fff  libcache.dylib (83) <1A98B064-8FED-39CF-BB2E-5BDA1EF5B65A> /usr/lib/system/libcache.dylib
    0x7fff2a6d7000 -     0x7fff2a6d8fff  libSystem.B.dylib (1292.60.1) <83503CE0-32B1-36DB-A4F0-3CC6B7BCF50A> /usr/lib/libSystem.B.dylib
    0x7fff2db10000 -     0x7fff2db10fff  liblaunch.dylib (2038.80.3) <C7C51322-8491-3B78-9CFA-2B4753662BCF> /usr/lib/system/liblaunch.dylib
    0x7fff2ffc4000 -     0x7fff2ffc4fff  libsystem_product_info_filter.dylib (8.40.1) <20310EE6-2C3F-361A-9ECA-4223AFC03B65> /usr/lib/system/libsystem_product_info_filter.dylib

External Modification Summary:
  Calls made by other processes targeting this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by all processes on this machine:
    task_for_pid: 79350
    thread_create: 0
    thread_set_state: 103

VM Region Summary:
ReadOnly portion of Libraries: Total=496.1M resident=0K(0%) swapped_out_or_unallocated=496.1M(100%)
Writable regions: Total=427.4M written=0K(0%) resident=0K(0%) swapped_out=0K(0%) unallocated=427.4M(100%)
 
                                VIRTUAL   REGION 
REGION TYPE                        SIZE    COUNT (non-coalesced) 
===========                     =======  ======= 
Kernel Alloc Once                    8K        1 
MALLOC                            67.2M       24 
MALLOC guard page                   24K        5 
MALLOC_MEDIUM (reserved)         352.0M        3         reserved VM address space (unallocated)
STACK GUARD                       56.0M        1 
Stack                             8192K        1 
VM_ALLOCATE                          8K        2 
__DATA                             437K       44 
__DATA_CONST                       243K       33 
__DATA_DIRTY                        58K       21 
__LINKEDIT                       489.7M        5 
__OBJC_RO                         60.5M        1 
__OBJC_RW                         2449K        2 
__TEXT                            6560K       44 
shared memory                        8K        2 
===========                     =======  ======= 
TOTAL                              1.0G      189 
TOTAL, minus reserved VM space   690.9M      189 


```


This fixes https://github.com/vlang/vls/issues/105