### PR TITLE
all: minor cleanup of generics

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -9,19 +9,19 @@ import v.util
 
 pub struct Table {
 pub mut:
-	type_symbols  []TypeSymbol
-	type_idxs     map[string]int
-	fns           map[string]Fn
-	dumps         map[int]string // needed for efficiently generating all _v_dump_expr_TNAME() functions
-	imports       []string       // List of all imports
-	modules       []string       // Topologically sorted list of all modules registered by the application
-	cflags        []cflag.CFlag
-	redefined_fns []string
-	fn_gen_types  map[string][][]Type // for generic functions
-	cmod_prefix   string // needed for ast.type_to_str(Type) while vfmt; contains `os.`
-	is_fmt        bool
-	used_fns      map[string]bool // filled in by the checker, when pref.skip_unused = true;
-	used_consts   map[string]bool // filled in by the checker, when pref.skip_unused = true;
+	type_symbols     []TypeSymbol
+	type_idxs        map[string]int
+	fns              map[string]Fn
+	dumps            map[int]string // needed for efficiently generating all _v_dump_expr_TNAME() functions
+	imports          []string       // List of all imports
+	modules          []string       // Topologically sorted list of all modules registered by the application
+	cflags           []cflag.CFlag
+	redefined_fns    []string
+	fn_generic_types map[string][][]Type // for generic functions
+	cmod_prefix      string // needed for ast.type_to_str(Type) while vfmt; contains `os.`
+	is_fmt           bool
+	used_fns         map[string]bool // filled in by the checker, when pref.skip_unused = true;
+	used_consts      map[string]bool // filled in by the checker, when pref.skip_unused = true;
 }
 
 pub struct Fn {
@@ -859,13 +859,13 @@ pub fn (t &Table) mktyp(typ Type) Type {
 	}
 }
 
-pub fn (mut t Table) register_fn_gen_type(fn_name string, types []Type) {
-	mut a := t.fn_gen_types[fn_name]
+pub fn (mut t Table) register_fn_generic_types(fn_name string, types []Type) {
+	mut a := t.fn_generic_types[fn_name]
 	if types in a {
 		return
 	}
 	a << types
-	t.fn_gen_types[fn_name] = a
+	t.fn_generic_types[fn_name] = a
 }
 
 // TODO: there is a bug when casting sumtype the other way if its pointer

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -475,7 +475,7 @@ pub fn (mut c Checker) string_inter_lit(mut node ast.StringInterLiteral) ast.Typ
 	return ast.string_type
 }
 
-pub fn (mut c Checker) infer_fn_types(f ast.Fn, mut call_expr ast.CallExpr) {
+pub fn (mut c Checker) infer_fn_generic_types(f ast.Fn, mut call_expr ast.CallExpr) {
 	mut inferred_types := []ast.Type{}
 	for gi, gt_name in f.generic_names {
 		// skip known types
@@ -565,5 +565,5 @@ pub fn (mut c Checker) infer_fn_types(f ast.Fn, mut call_expr ast.CallExpr) {
 		inferred_types << typ
 		call_expr.generic_types << typ
 	}
-	c.table.register_fn_gen_type(f.name, inferred_types)
+	c.table.register_fn_generic_types(f.name, inferred_types)
 }

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -129,7 +129,7 @@ fn (mut g Gen) gen_fn_decl(node ast.FnDecl, skip bool) {
 	// }
 	if node.generic_names.len > 0 && g.cur_generic_types.len == 0 { // need the cur_generic_type check to avoid inf. recursion
 		// loop thru each generic type and generate a function
-		for gen_types in g.table.fn_gen_types[node.name] {
+		for gen_types in g.table.fn_generic_types[node.name] {
 			if g.pref.is_verbose {
 				syms := gen_types.map(g.table.get_type_symbol(it))
 				the_type := syms.map(node.name).join(', ')

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -46,7 +46,7 @@ pub fn (mut p Parser) call_expr(language ast.Language, mod string) ast.CallExpr 
 		has_generic_generic := generic_types.filter(it.has_flag(.generic)).len > 0
 		if !has_generic_generic {
 			// will be added in checker
-			p.table.register_fn_gen_type(full_generic_fn_name, generic_types)
+			p.table.register_fn_generic_types(full_generic_fn_name, generic_types)
 		}
 	}
 	p.check(.lpar)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2248,7 +2248,7 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 		has_generic_generic := generic_types.filter(it.has_flag(.generic)).len > 0
 		if !has_generic_generic {
 			// will be added in checker
-			p.table.register_fn_gen_type(field_name, generic_types)
+			p.table.register_fn_generic_types(field_name, generic_types)
 		}
 	}
 	if p.tok.kind == .lpar {


### PR DESCRIPTION
This PR makes minor cleanup of generics.

- Change `Table.fn_gen_types` to `Table.fn_generic_types`, It's a little bit clearer.
- Change `register_fn_gen_type()` to `register_fn_generic_types()`, It's a little bit clearer.
- Change `infer_fn_types()` to `infer_fn_generic_types()`, It's a little bit clearer.