### PR TITLE
os: implement os.truncate() + improve error handling

### DIFF
--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -840,7 +840,7 @@ pub fn chown(path string, owner int, group int) ? {
 		return error('os.chown() not implemented for Windows')
 	} $else {
 		if owner < 0 || group < 0 {
-			return error('os.chown() uid or gid equal not valid: Not changing owner!')
+			return error('os.chown() uid and gid cannot be negative: Not changing owner!')
 		} else {
 			if C.chown(&char(path.str), owner, group) != 0 {
 				return error_with_code(posix_get_error_msg(C.errno), C.errno)

--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -135,7 +135,7 @@ pub fn read_file(path string) ?string {
 
 // ***************************** OS ops ************************
 
-// truncate changes the size of file in `path` to `len`.
+// truncate changes the size of the file located in `path` to `len`.
 pub fn truncate(path string, len u64) ? {
 	fp := C.open(&char(real_path(path).str), o_wronly | o_trunc)
 	defer {
@@ -864,7 +864,7 @@ pub fn chmod(path string, mode int) {
 	}
 }
 
-// chown changes owner and group attributes of `path` to `owner` and `group`.
+// chown changes the owner and group attributes of `path` to `owner` and `group`.
 pub fn chown(path string, owner int, group int) ? {
 	$if windows {
 		return error('os.chown() not implemented for Windows')

--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -31,6 +31,8 @@ fn C.CopyFile(&u16, &u16, bool) int
 
 fn C._wstat64(&char, voidptr) u64
 
+fn C.chown(&char, int, int) int
+
 // fn C.proc_pidpath(int, byteptr, int) int
 struct C.stat {
 	st_size  u64
@@ -827,7 +829,24 @@ pub fn flush() {
 // chmod change file access attributes of `path` to `mode`.
 // Octals like `0o600` can be used.
 pub fn chmod(path string, mode int) {
-	C.chmod(&char(path.str), mode)
+	if C.chmod(&char(path.str), mode) != 0 {
+		panic(posix_get_error_msg(C.errno))
+	}
+}
+
+// chown change owner and group attributes of path to `owner` and `group`.
+pub fn chown(path string, owner int, group int) ? {
+	$if windows {
+		return error('os.chown() not implemented for Windows')
+	} $else {
+		if owner < 0 || group < 0 {
+			return error('os.chown() uid or gid equal not valid: Not changing owner!')
+		} else {
+			if C.chown(&char(path.str), owner, group) != 0 {
+				return error_with_code(posix_get_error_msg(C.errno), C.errno)
+			}
+		}
+	}
 }
 
 // open_append opens `path` file for appending.

--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -33,6 +33,10 @@ fn C._wstat64(&char, voidptr) u64
 
 fn C.chown(&char, int, int) int
 
+fn C.ftruncate(voidptr, u64) int
+
+fn C._chsize_s(voidptr, u64) int
+
 // fn C.proc_pidpath(int, byteptr, int) int
 struct C.stat {
 	st_size  u64
@@ -130,7 +134,28 @@ pub fn read_file(path string) ?string {
 }
 
 // ***************************** OS ops ************************
-// file_size returns the size of the file located in `path`.
+
+// truncate changes the size of file in `path` to `len`.
+pub fn truncate(path string, len u64) ? {
+	fp := C.open(&char(real_path(path).str), o_wronly | o_trunc)
+	defer {
+		C.close(fp)
+	}
+	if fp < 0 {
+		return error('open file failed')
+	}
+	$if windows {
+		if C._chsize_s(fp, len) != 0 {
+			return error('truncate file failed: ' + posix_get_error_msg(C.errno))
+		}
+	} $else {
+		if C.ftruncate(fp, len) != 0 {
+			return error('truncate file failed: ' + posix_get_error_msg(C.errno))
+		}
+	}
+}
+
+// file_size returns the size of the file located in `path`. In case of error -1 is returned.
 pub fn file_size(path string) u64 {
 	mut s := C.stat{}
 	unsafe {
@@ -157,7 +182,7 @@ pub fn file_size(path string) u64 {
 			}
 		}
 	}
-	return 0
+	return -1
 }
 
 // mv moves files or folders from `src` to `dst`.
@@ -191,26 +216,29 @@ pub fn cp(src string, dst string) ? {
 			return error_with_code('failed to copy $src to $dst', int(result))
 		}
 	} $else {
-		fp_from := C.open(&char(src.str), C.O_RDONLY)
+		fp_from := C.open(&char(real_path(src).str), C.O_RDONLY)
 		if fp_from < 0 { // Check if file opened
 			return error_with_code('cp: failed to open $src', int(fp_from))
 		}
-		fp_to := C.open(&char(dst.str), C.O_WRONLY | C.O_CREAT | C.O_TRUNC, C.S_IWUSR | C.S_IRUSR)
+		fp_to := C.open(&char(real_path(dst).str), C.O_WRONLY | C.O_CREAT | C.O_TRUNC,
+			C.S_IWUSR | C.S_IRUSR)
 		if fp_to < 0 { // Check if file opened (permissions problems ...)
 			C.close(fp_from)
 			return error_with_code('cp (permission): failed to write to $dst (fp_to: $fp_to)',
 				int(fp_to))
 		}
+		// TODO use defer{} to close files in case of error or return.
+		// Currently there is a C-Error when building.
 		mut buf := [1024]byte{}
 		mut count := 0
 		for {
-			// FIXME: use sizeof, bug: 'os__buf' undeclared
-			// count = C.read(fp_from, buf, sizeof(buf))
-			count = C.read(fp_from, &buf[0], 1024)
+			count = C.read(fp_from, &buf[0], sizeof(buf))
 			if count == 0 {
 				break
 			}
 			if C.write(fp_to, &buf[0], count) < 0 {
+				C.close(fp_to)
+				C.close(fp_from)
 				return error_with_code('cp: failed to write to $dst', int(-1))
 			}
 		}
@@ -219,6 +247,8 @@ pub fn cp(src string, dst string) ? {
 			C.stat(&char(src.str), &from_attr)
 		}
 		if C.chmod(&char(dst.str), from_attr.st_mode) < 0 {
+			C.close(fp_to)
+			C.close(fp_from)
 			return error_with_code('failed to set permissions for $dst', int(-1))
 		}
 		C.close(fp_to)
@@ -235,9 +265,9 @@ pub fn vfopen(path string, mode string) ?&C.FILE {
 	}
 	mut fp := voidptr(0)
 	$if windows {
-		fp = C._wfopen(path.to_wide(), mode.to_wide())
+		fp = C._wfopen(real_path(path).to_wide(), mode.to_wide())
 	} $else {
-		fp = C.fopen(&char(path.str), &char(mode.str))
+		fp = C.fopen(&char(real_path(path).str), &char(mode.str))
 	}
 	if isnil(fp) {
 		return error('failed to open file "$path"')
@@ -830,11 +860,11 @@ pub fn flush() {
 // Octals like `0o600` can be used.
 pub fn chmod(path string, mode int) {
 	if C.chmod(&char(path.str), mode) != 0 {
-		panic(posix_get_error_msg(C.errno))
+		panic('chmod failed: ' + posix_get_error_msg(C.errno))
 	}
 }
 
-// chown change owner and group attributes of path to `owner` and `group`.
+// chown changes owner and group attributes of `path` to `owner` and `group`.
 pub fn chown(path string, owner int, group int) ? {
 	$if windows {
 		return error('os.chown() not implemented for Windows')
@@ -843,7 +873,7 @@ pub fn chown(path string, owner int, group int) ? {
 			return error('os.chown() uid and gid cannot be negative: Not changing owner!')
 		} else {
 			if C.chown(&char(path.str), owner, group) != 0 {
-				return error_with_code(posix_get_error_msg(C.errno), C.errno)
+				return error('chown failed: ' + posix_get_error_msg(C.errno))
 			}
 		}
 	}

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -69,6 +69,10 @@ pub fn uname() Uname {
 	return u
 }
 
+pub fn hostname() string {
+	return uname().nodename
+}
+
 fn init_os_args(argc int, argv &&byte) []string {
 	mut args_ := []string{}
 	// mut args := []string(make(0, argc, sizeof(string)))

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -51,6 +51,8 @@ fn C.uname(name voidptr) int
 
 fn C.symlink(&char, &char) int
 
+fn C.gethostname(&char, int) int
+
 pub fn uname() Uname {
 	mut u := Uname{}
 	utsize := sizeof(C.utsname)
@@ -70,7 +72,15 @@ pub fn uname() Uname {
 }
 
 pub fn hostname() string {
-	return uname().nodename
+	mut hstnme := ''
+	size := 256
+	mut buf := unsafe { &char(malloc(size)) }
+	if C.gethostname(buf, size) == 0 {
+		hstnme = unsafe { cstring_to_vstring(buf) }
+		unsafe { free(buf) }
+		return hstnme
+	}
+	return ''
 }
 
 fn init_os_args(argc int, argv &&byte) []string {

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -573,3 +573,16 @@ fn test_exists_in_system_path() {
 	}
 	assert os.exists_in_system_path('ls')
 }
+
+fn test_truncate() {
+	filename := './test_trunc.txt'
+	hello := 'hello world!'
+	mut f := os.create(filename) or { panic(err) }
+	f.write_string(hello) or { panic(err) }
+	f.close()
+	assert hello.len == os.file_size(filename)
+	newlen := u64(40000)
+	os.truncate(filename, newlen) or { panic(err) }
+	assert newlen == os.file_size(filename)
+	os.rm(filename) or { panic(err) }
+}

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -376,8 +376,8 @@ pub fn debugger_present() bool {
 }
 
 pub fn uname() Uname {
+	// TODO: use Win32 Api functions instead
 	sys_and_ver := execute('cmd /c ver').output.split('[')
-
 	nodename := execute('cmd /c hostname').output
 	machine := execute('cmd /c echo %PROCESSOR_ARCHITECTURE%').output
 	return Uname{
@@ -390,6 +390,7 @@ pub fn uname() Uname {
 }
 
 pub fn hostname() string {
+	// TODO: use C.GetComputerName(&u16, u32) int instead
 	return execute('cmd /c hostname').output
 }
 

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -376,15 +376,21 @@ pub fn debugger_present() bool {
 }
 
 pub fn uname() Uname {
-	// TODO: implement `os.uname()` for windows
-	unknown := 'unknown'
+	sys_and_ver := execute('cmd /c ver').output.split('[')
+
+	nodename := execute('cmd /c hostname').output
+	machine := execute('cmd /c echo %PROCESSOR_ARCHITECTURE%').output
 	return Uname{
-		sysname: unknown
-		nodename: unknown
-		release: unknown
-		version: unknown
-		machine: unknown
+		sysname: sys_and_ver[0].trim_space()
+		nodename: nodename
+		release: sys_and_ver[1].replace(']', '')
+		version: sys_and_ver[0] + '[' + sys_and_ver[1]
+		machine: machine
 	}
+}
+
+pub fn hostname() string {
+	return execute('cmd /c hostname').output
 }
 
 // `is_writable_folder` - `folder` exists and is writable to the process


### PR DESCRIPTION
This PR implements os.truncate() for resizing a file and improves some error messages in os_c.v.
Tested on Ubuntu 20, Parrot OS, Windows 10.

What I have done:
- implement os.truncate() (function to resize a file)
  - add test for os.truncate()
- add or improve some error messages
- in case of open files use os.real_path() to get full path.
- vfmt

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
