### PR TITLE
checker: fix generics with nested generics fn

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -378,17 +378,18 @@ pub:
 	attrs           []Attr
 	skip_gen        bool // this function doesn't need to be generated (for example [if foo])
 pub mut:
-	stmts           []Stmt
-	defer_stmts     []DeferStmt
-	return_type     Type
-	return_type_pos token.Position // `string` in `fn (u User) name() string` position
-	has_return      bool
-	comments        []Comment // comments *after* the header, but *before* `{`; used for InterfaceDecl
-	next_comments   []Comment // coments that are one line after the decl; used for InterfaceDecl
-	source_file     &File = 0
-	scope           &Scope
-	label_names     []string
-	pos             token.Position // function declaration position
+	stmts             []Stmt
+	defer_stmts       []DeferStmt
+	return_type       Type
+	return_type_pos   token.Position // `string` in `fn (u User) name() string` position
+	has_return        bool
+	comments          []Comment // comments *after* the header, but *before* `{`; used for InterfaceDecl
+	next_comments     []Comment // coments that are one line after the decl; used for InterfaceDecl
+	source_file       &File = 0
+	scope             &Scope
+	label_names       []string
+	pos               token.Position // function declaration position
+	cur_generic_types []Type
 }
 
 // break, continue

--- a/vlib/v/tests/generics_with_nested_generics_fn_test.v
+++ b/vlib/v/tests/generics_with_nested_generics_fn_test.v
@@ -1,6 +1,10 @@
-struct NestedGeneric {}
+struct NestedGeneric {
+	a int
+}
 
-struct Context {}
+struct Context {
+	b int
+}
 
 struct App {
 mut:

--- a/vlib/v/tests/generics_with_nested_generics_fn_test.v
+++ b/vlib/v/tests/generics_with_nested_generics_fn_test.v
@@ -1,4 +1,5 @@
 struct NestedGeneric {}
+
 struct Context {}
 
 struct App {

--- a/vlib/v/tests/generics_with_nested_generics_fn_test.v
+++ b/vlib/v/tests/generics_with_nested_generics_fn_test.v
@@ -1,0 +1,24 @@
+struct NestedGeneric {}
+struct Context {}
+
+struct App {
+mut:
+	context Context
+}
+
+fn method_test<T>(mut app T) int {
+	ng := NestedGeneric{}
+	ng.nested_test<T>(app)
+	return 22
+}
+
+fn (ng NestedGeneric) nested_test<T>(mut app T) {
+	app.context = Context{}
+}
+
+fn test_generics_with_generics_fn() {
+	mut app := App{}
+	ret := method_test(mut app)
+	println('result = $ret')
+	assert ret == 22
+}


### PR DESCRIPTION
This PR fix generics with nested generics fn.

- Fix generics with nested generics fn.
- Add test.

```vlang
struct NestedGeneric {}
struct Context {}

struct App {
mut:
	context Context
}

fn method_test<T>(mut app T) int {
	ng := NestedGeneric{}
	ng.nested_test<T>(app)
	return 22
}

fn (ng NestedGeneric) nested_test<T>(mut app T) {
	app.context = Context{}
}

fn test_generics_with_generics_fn() {
	mut app := App{}
	ret := method_test(mut app)
	println('result = $ret')
	assert ret == 22
}


D:\Test\v\tt1>v run .
result = 22
```