### PR TITLE
vweb: Fix none error for empty TCP connections

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -321,7 +321,10 @@ fn handle_conn<T>(mut conn net.TcpConn, mut app T) {
 	}
 	page_gen_start := time.ticks()
 	req := parse_request(mut reader) or {
-		eprintln('error parsing request: $err')
+		// Prevents errors from being thrown when BufferedReader is empty
+		if '$err' != 'none' {
+			eprintln('error parsing request: $err')
+		}
 		return
 	}
 	app.Context = Context{


### PR DESCRIPTION
**This PR addresses the problem in #9740**
Reading an empty TCP request would throw a "none" error that I found the only easy way to fix was to just ignore "none" errors in the vweb.v file compared to the request.v, file where it actually occurs.