### PR TITLE
cgen: fix iteration over `shared` map

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1538,7 +1538,11 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 			g.expr(node.cond)
 			g.writeln(';')
 		}
-		arw_or_pt := if node.cond_type.is_ptr() { '->' } else { '.' }
+		arw_or_pt := if node.cond_type.is_ptr() {
+			if node.cond_type.has_flag(.shared_f) { '->val.' } else { '->' }
+		} else {
+			'.'
+		}
 		idx := g.new_tmp_var()
 		map_len := g.new_tmp_var()
 		g.empty_line = true

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1538,10 +1538,9 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 			g.expr(node.cond)
 			g.writeln(';')
 		}
-		arw_or_pt := if node.cond_type.is_ptr() {
-			if node.cond_type.has_flag(.shared_f) { '->val.' } else { '->' }
-		} else {
-			'.'
+		mut arw_or_pt := if node.cond_type.is_ptr() { '->' } else { '.' }
+		if node.cond_type.has_flag(.shared_f) {
+			arw_or_pt = '->val.'
 		}
 		idx := g.new_tmp_var()
 		map_len := g.new_tmp_var()

--- a/vlib/v/tests/shared_map_test.v
+++ b/vlib/v/tests/shared_map_test.v
@@ -84,7 +84,11 @@ fn new_map() map[string]f64 {
 }
 
 fn test_shared_map_iteration() {
-	shared m := map{'qwe': 12.75, 'rtz': -0.125, 'k': 17}
+	shared m := map{
+		'qwe': 12.75
+		'rtz': -0.125
+		'k':   17
+	}
 	mut n0 := 0
 	mut n1 := 0
 	mut n2 := 0

--- a/vlib/v/tests/shared_map_test.v
+++ b/vlib/v/tests/shared_map_test.v
@@ -83,6 +83,42 @@ fn new_map() map[string]f64 {
 	return m
 }
 
+fn test_shared_array_iteration() {
+	shared a := [12.75, -0.125, 17]
+	mut n0 := 0
+	mut n1 := 0
+	mut n2 := 0
+	lock a {
+		for i, val in a {
+			match i {
+				1 {
+					assert val == -0.125
+					n1++
+					// check for order, too:
+					assert n0 == 1
+				}
+				0 {
+					assert val == 12.75
+					n0++
+				}
+				2 {
+					assert val == 17.0
+					n2++
+					assert n1 == 1
+				}
+				else {
+					// this should not happen
+					assert false
+				}
+			}
+		}
+	}
+	// make sure we have iterated over each of the 3 keys exactly once
+	assert n0 == 1
+	assert n1 == 1
+	assert n2 == 1
+}
+
 fn test_shared_map_iteration() {
 	shared m := map{
 		'qwe': 12.75

--- a/vlib/v/tests/shared_map_test.v
+++ b/vlib/v/tests/shared_map_test.v
@@ -82,3 +82,36 @@ fn new_map() map[string]f64 {
 	}
 	return m
 }
+
+fn test_shared_map_iteration() {
+	shared m := map{'qwe': 12.75, 'rtz': -0.125, 'k': 17}
+	mut n0 := 0
+	mut n1 := 0
+	mut n2 := 0
+	lock m {
+		for k, val in m {
+			match k {
+				'rtz' {
+					assert val == -0.125
+					n0++
+				}
+				'qwe' {
+					assert val == 12.75
+					n1++
+				}
+				'k' {
+					assert val == 17.0
+					n2++
+				}
+				else {
+					// this should not happen
+					assert false
+				}
+			}
+		}
+	}
+	// make sure we have iterated over each of the 3 keys exactly once
+	assert n0 == 1
+	assert n1 == 1
+	assert n2 == 1
+}

--- a/vlib/v/tests/shared_map_test.v
+++ b/vlib/v/tests/shared_map_test.v
@@ -88,7 +88,7 @@ fn test_shared_array_iteration() {
 	mut n0 := 0
 	mut n1 := 0
 	mut n2 := 0
-	lock a {
+	rlock a {
 		for i, val in a {
 			match i {
 				1 {

--- a/vlib/v/tests/shared_map_test.v
+++ b/vlib/v/tests/shared_map_test.v
@@ -88,7 +88,7 @@ fn test_shared_map_iteration() {
 	mut n0 := 0
 	mut n1 := 0
 	mut n2 := 0
-	lock m {
+	rlock m {
 		for k, val in m {
 			match k {
 				'rtz' {


### PR DESCRIPTION
This fixes iteration over a ((r)locked) map:
```v
shared m := map{'qwe': 12.75, 'rtz': -0.125, 'k': 17}
rlock m {
    for k, val in m {
        println('$k: $val')
    }
}
```

Iterating over `shared` arrays did already work, but I've added a test case for this, too (in addition to a map iteration test case).
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
