### PR TITLE
checker: fix nested generics with different order of generics fn

### DIFF
--- a/vlib/v/tests/generics_with_nested_generics_fn_test.v
+++ b/vlib/v/tests/generics_with_nested_generics_fn_test.v
@@ -11,14 +11,14 @@ mut:
 	context Context
 }
 
+fn (ng NestedGeneric) nested_test<T>(mut app T) {
+	app.context = Context{}
+}
+
 fn method_test<T>(mut app T) int {
 	ng := NestedGeneric{}
 	ng.nested_test<T>(app)
 	return 22
-}
-
-fn (ng NestedGeneric) nested_test<T>(mut app T) {
-	app.context = Context{}
 }
 
 fn test_generics_with_generics_fn() {


### PR DESCRIPTION
This PR fix generics with different order of generics fn.

- Fix generics with different order of generics fn.
- Fix return generics map init.
- Add test.

```vlang
struct NestedGeneric {
	a int
}

struct Context {
	b int
}

struct App {
mut:
	context Context
}

fn (ng NestedGeneric) nested_test<T>(mut app T) {
	app.context = Context{}
}

fn method_test<T>(mut app T) int {
	ng := NestedGeneric{}
	ng.nested_test<T>(app)
	return 22
}

fn main() {
	mut app := App{}
	ret := method_test(mut app)
	println('result = $ret')
	assert ret == 22
}

D:\Test\v\tt1>v run .
result = 22
```
```vlang
struct NestedGeneric {
	a int
}

struct Context {
	b int
}

struct App {
mut:
	context Context
}

fn method_test<T>(mut app T) int {
	ng := NestedGeneric{}
	ng.nested_test<T>(app)
	return 22
}

fn (ng NestedGeneric) nested_test<T>(mut app T) {
	app.context = Context{}
}

fn main() {
	mut app := App{}
	ret := method_test(mut app)
	println('result = $ret')
	assert ret == 22
}

D:\Test\v\tt1>v run .
result = 22
```