### PR TITLE
fmt: move else branch of match expr into last of match

### DIFF
--- a/vlib/v/fmt/tests/match_input.vv
+++ b/vlib/v/fmt/tests/match_input.vv
@@ -2,8 +2,8 @@ fn match_expr_assignment() {
     a := 20
 	_ := match a {
 		10 { 10	}
-		5 {	5 }
 		else { 2 }
+		5 {	5 }
 	}
 }
 


### PR DESCRIPTION
Move else branch like this

```
match x {
  else { }
  0 { }
  1 { } 
}
```

```
match x {
  0 { }
  1 { }
  else { }
}
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
