### PR TITLE
cgen: fix some compiler error of empty struct init

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5120,7 +5120,9 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 	mut nr_fields := 1
 	if sym.kind == .struct_ {
 		info := sym.info as ast.Struct
-		nr_fields = info.fields.len
+		$if !msvc {
+			nr_fields = info.fields.len
+		}
 		if info.is_union && struct_init.fields.len > 1 {
 			verror('union must not have more than 1 initializer')
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5117,9 +5117,10 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 	}
 	// The rest of the fields are zeroed.
 	// `inited_fields` is a list of fields that have been init'ed, they are skipped
-	// mut nr_fields := 0
+	mut nr_fields := 1
 	if sym.kind == .struct_ {
 		info := sym.info as ast.Struct
+		nr_fields = info.fields.len
 		if info.is_union && struct_init.fields.len > 1 {
 			verror('union must not have more than 1 initializer')
 		}
@@ -5214,7 +5215,7 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 		g.indent--
 	}
 
-	if !initialized {
+	if !initialized && nr_fields > 0 {
 		g.write('0')
 	}
 


### PR DESCRIPTION
This PR fix some compiler error of empty struct init.

- Empty struct init generated c codes `(Foo){0}` will be error in some compiler.
```vlang
/tmp/v/test_session_590515162822/generics_with_nested_generics_fn_test.14081481805459519835.tmp.c:13537:49: error: excess elements in struct initializer [-Werror]
13537 |  main__NestedGeneric ng = (main__NestedGeneric){0};
      |                                                 ^
```
- It should generate `(Foo){}` instead of `(Foo){0}` when it's empty struct.