### PR TITLE
parser: fix handling of `-` inside array literals

### DIFF
--- a/vlib/v/fmt/tests/array_init_expected.vv
+++ b/vlib/v/fmt/tests/array_init_expected.vv
@@ -14,3 +14,22 @@ fn wrapping_tests() {
 		'velit. Sed at mauris et quam ornare tristique.',
 	]
 }
+
+fn array_init_without_commas() {
+	a := [3, -4, 5, -2]
+	b := [5 - 2, 7, 2 * 3, -4, -7 * 8, 2 * -4]
+	c := [4, 6 - 7, 8, 3 * 4]
+	d := [&a, &b, &c]
+	e := u16(434)
+	f := u16(23)
+	g := u16(4324)
+	h := [e & f, g, g & g]
+	k := 323
+	l := [k, -k, 5]
+	x := &e
+	y := &f
+	z := &g
+	q := [f, *y, f * g, e]
+	ch := chan u16{}
+	w := [f, 12 <- ch]
+}

--- a/vlib/v/fmt/tests/array_init_input.vv
+++ b/vlib/v/fmt/tests/array_init_input.vv
@@ -10,3 +10,22 @@ fn main() {
 fn wrapping_tests() {
 	my_arr := ['Lorem ipsum dolor sit amet, consectetur adipiscing', 'elit. Donec varius purus leo, vel maximus diam', 'finibus sed. Etiam eu urna ante. Nunc quis vehicula', 'velit. Sed at mauris et quam ornare tristique.']
 }
+
+fn array_init_without_commas() {
+	a := [3 -4 5 -2]
+	b := [5-2,7,2*3,-4,-7*8,2*-4]
+	c := [4 6 - 7 8 3 * 4]
+	d := [&a &b &c]
+	e := u16(434)
+	f := u16(23)
+	g := u16(4324)
+	h := [e&f g g & g]
+	k := 323
+	l := [k -k 5]
+	x := &e
+	y := &f
+	z := &g
+	q := [f *y f * g e]
+	ch := chan u16{}
+	w := [f 12 <-ch]
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1538,7 +1538,11 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 			g.expr(node.cond)
 			g.writeln(';')
 		}
-		arw_or_pt := if node.cond_type.is_ptr() { '->' } else { '.' }
+		arw_or_pt := if node.cond_type.is_ptr() {
+			if node.cond_type.has_flag(.shared_f) { '->val.' } else { '->' }
+		} else {
+			'.'
+		}
 		idx := g.new_tmp_var()
 		map_len := g.new_tmp_var()
 		g.empty_line = true

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1538,10 +1538,9 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 			g.expr(node.cond)
 			g.writeln(';')
 		}
-		arw_or_pt := if node.cond_type.is_ptr() {
-			if node.cond_type.has_flag(.shared_f) { '->val.' } else { '->' }
-		} else {
-			'.'
+		mut arw_or_pt := if node.cond_type.is_ptr() { '->' } else { '.' }
+		if node.cond_type.has_flag(.shared_f) {
+			arw_or_pt = '->val.'
 		}
 		idx := g.new_tmp_var()
 		map_len := g.new_tmp_var()

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -43,6 +43,8 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 		last_pos = p.tok.position()
 	} else {
 		// [1,2,3] or [const]byte
+		old_inside_array_lit := p.inside_array_lit
+		p.inside_array_lit = true
 		pre_cmnts = p.eat_comments({})
 		for i := 0; p.tok.kind !in [.rsbr, .eof]; i++ {
 			exprs << p.expr(0)
@@ -52,6 +54,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 			}
 			ecmnts.last() << p.eat_comments({})
 		}
+		p.inside_array_lit = old_inside_array_lit
 		line_nr := p.tok.line_nr
 		$if tinyc {
 			// NB: do not remove the next line without testing

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -40,6 +40,7 @@ mut:
 	inside_fn           bool // true even with implicit main
 	inside_unsafe_fn    bool
 	inside_str_interp   bool
+	inside_array_lit    bool
 	or_is_handled       bool       // ignore `or` in this expression
 	builtin_mod         bool       // are we in the `builtin` module?
 	mod                 string     // current module name

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -19,6 +19,11 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 	if !p.pref.is_fmt {
 		p.eat_comments({})
 	}
+	inside_array_lit := p.inside_array_lit
+	p.inside_array_lit = false
+	defer {
+		p.inside_array_lit = inside_array_lit
+	}
 	// Prefix
 	match p.tok.kind {
 		.key_mut, .key_shared, .key_atomic, .key_static {
@@ -320,6 +325,11 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 				// eof should be handled where it happens
 				return p.error_with_pos('invalid expression: unexpected $p.tok', p.tok.position())
 			}
+		}
+	}
+	if inside_array_lit {
+		if p.tok.kind == .minus && p.tok.pos + 1 == p.peek_tok.pos {
+			return node
 		}
 	}
 	return p.expr_with_left(node, precedence, is_stmt_ident)

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -328,7 +328,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 		}
 	}
 	if inside_array_lit {
-		if p.tok.kind == .minus && p.tok.pos + 1 == p.peek_tok.pos
+		if p.tok.kind in [.minus, .mul, .amp, .arrow] && p.tok.pos + 1 == p.peek_tok.pos
 			&& p.prev_tok.pos + p.prev_tok.len + 1 != p.peek_tok.pos {
 			return node
 		}

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -328,7 +328,8 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 		}
 	}
 	if inside_array_lit {
-		if p.tok.kind == .minus && p.tok.pos + 1 == p.peek_tok.pos {
+		if p.tok.kind == .minus && p.tok.pos + 1 == p.peek_tok.pos
+			&& p.prev_tok.pos + p.prev_tok.len + 1 != p.peek_tok.pos {
 			return node
 		}
 	}

--- a/vlib/v/tests/shared_map_test.v
+++ b/vlib/v/tests/shared_map_test.v
@@ -84,7 +84,7 @@ fn new_map() map[string]f64 {
 }
 
 fn test_shared_array_iteration() {
-	shared a := [12.75 -0.125 18.5 - (1.0 + .5)]
+	shared a := [12.75, -0.125, 18.5 - (1.0 + .5)]
 	mut n0 := 0
 	mut n1 := 0
 	mut n2 := 0

--- a/vlib/v/tests/shared_map_test.v
+++ b/vlib/v/tests/shared_map_test.v
@@ -84,7 +84,11 @@ fn new_map() map[string]f64 {
 }
 
 fn test_shared_map_iteration() {
-	shared m := map{'qwe': 12.75, 'rtz': -0.125, 'k': 17}
+	shared m := map{
+		'qwe': 12.75
+		'rtz': -0.125
+		'k':   17
+	}
 	mut n0 := 0
 	mut n1 := 0
 	mut n2 := 0

--- a/vlib/v/tests/shared_map_test.v
+++ b/vlib/v/tests/shared_map_test.v
@@ -83,6 +83,42 @@ fn new_map() map[string]f64 {
 	return m
 }
 
+fn test_shared_array_iteration() {
+	shared a := [12.75, -0.125, 17]
+	mut n0 := 0
+	mut n1 := 0
+	mut n2 := 0
+	lock a {
+		for i, val in a {
+			match i {
+				1 {
+					assert val == -0.125
+					n1++
+					// check for order, too:
+					assert n0 == 1
+				}
+				0 {
+					assert val == 12.75
+					n0++
+				}
+				2 {
+					assert val == 17.0
+					n2++
+					assert n1 == 1
+				}
+				else {
+					// this should not happen
+					assert false
+				}
+			}
+		}
+	}
+	// make sure we have iterated over each of the 3 keys exactly once
+	assert n0 == 1
+	assert n1 == 1
+	assert n2 == 1
+}
+
 fn test_shared_map_iteration() {
 	shared m := map{
 		'qwe': 12.75

--- a/vlib/v/tests/shared_map_test.v
+++ b/vlib/v/tests/shared_map_test.v
@@ -82,3 +82,36 @@ fn new_map() map[string]f64 {
 	}
 	return m
 }
+
+fn test_shared_map_iteration() {
+	shared m := map{'qwe': 12.75, 'rtz': -0.125, 'k': 17}
+	mut n0 := 0
+	mut n1 := 0
+	mut n2 := 0
+	lock m {
+		for k, val in m {
+			match k {
+				'rtz' {
+					assert val == -0.125
+					n0++
+				}
+				'qwe' {
+					assert val == 12.75
+					n1++
+				}
+				'k' {
+					assert val == 17.0
+					n2++
+				}
+				else {
+					// this should not happen
+					assert false
+				}
+			}
+		}
+	}
+	// make sure we have iterated over each of the 3 keys exactly once
+	assert n0 == 1
+	assert n1 == 1
+	assert n2 == 1
+}

--- a/vlib/v/tests/shared_map_test.v
+++ b/vlib/v/tests/shared_map_test.v
@@ -88,7 +88,7 @@ fn test_shared_array_iteration() {
 	mut n0 := 0
 	mut n1 := 0
 	mut n2 := 0
-	lock a {
+	rlock a {
 		for i, val in a {
 			match i {
 				1 {

--- a/vlib/v/tests/shared_map_test.v
+++ b/vlib/v/tests/shared_map_test.v
@@ -88,7 +88,7 @@ fn test_shared_map_iteration() {
 	mut n0 := 0
 	mut n1 := 0
 	mut n2 := 0
-	lock m {
+	rlock m {
 		for k, val in m {
 			match k {
 				'rtz' {

--- a/vlib/v/tests/shared_map_test.v
+++ b/vlib/v/tests/shared_map_test.v
@@ -84,7 +84,7 @@ fn new_map() map[string]f64 {
 }
 
 fn test_shared_array_iteration() {
-	shared a := [12.75, -0.125, 17]
+	shared a := [12.75 -0.125 18.5 - (1.0 + .5)]
 	mut n0 := 0
 	mut n1 := 0
 	mut n2 := 0


### PR DESCRIPTION
V has been accepting array initializations without commata a while now:
```v
a := [1 2 7 2]
```
However this syntax used to produce unexpected results in case of negative numbers, i.e.
```v
a := [3 -4 5]
```
has been read as `a := [(3 - 4), 5]`.

This PR fixes this by taking into account if there is a space after the minus sign (and before - so `[3-2,4,5]` is still an array with 3 elements). This is consistent with what [Julia](https://julialang.org/), [Matlab](https://www.mathworks.com/products/matlab.html), [Octave](https://www.gnu.org/software/octave/) and [GNU Emacs Calc](https://www.gnu.org/software/emacs/manual/html_node/calc/index.html) do.

Other ambigous operators (`&`, `*`, `<-`) are treated the same for consistency.

Unfortunately it's not possible to add a functional test case for this since `vfmt` inserts commata - and unformatted test cases are not accepted any more. So a `vfmt` test case is added, instead (edited).
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
