### PR TITLE
os: remove unnecessary check (#9722)

### DIFF
--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -134,8 +134,9 @@ pub fn read_file(path string) ?string {
 }
 
 // ***************************** OS ops ************************
-
+//
 // truncate changes the size of the file located in `path` to `len`.
+// Note that changing symbolic links on Windows only works as admin.
 pub fn truncate(path string, len u64) ? {
 	fp := C.open(&char(path.str), o_wronly | o_trunc)
 	defer {
@@ -155,7 +156,9 @@ pub fn truncate(path string, len u64) ? {
 	}
 }
 
-// file_size returns the size of the file located in `path`. In case of error -1 is returned.
+// file_size returns the size of the file located in `path`.
+// In case of an error 0 is returned. 
+// Note that use of this on symbolic links on Windows returns allways 0.
 pub fn file_size(path string) u64 {
 	mut s := C.stat{}
 	unsafe {
@@ -182,7 +185,7 @@ pub fn file_size(path string) u64 {
 			}
 		}
 	}
-	return -1
+	return 0
 }
 
 // mv moves files or folders from `src` to `dst`.
@@ -868,12 +871,8 @@ pub fn chown(path string, owner int, group int) ? {
 	$if windows {
 		return error('os.chown() not implemented for Windows')
 	} $else {
-		if owner < 0 || group < 0 {
-			return error('os.chown() uid and gid cannot be negative: Not changing owner!')
-		} else {
-			if C.chown(&char(path.str), owner, group) != 0 {
-				return error_with_code(posix_get_error_msg(C.errno), C.errno)
-			}
+		if C.chown(&char(path.str), owner, group) != 0 {
+			return error_with_code(posix_get_error_msg(C.errno), C.errno)
 		}
 	}
 }

--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -157,7 +157,7 @@ pub fn truncate(path string, len u64) ? {
 }
 
 // file_size returns the size of the file located in `path`.
-// In case of an error 0 is returned. 
+// In case of an error 0 is returned.
 // Note that use of this on symbolic links on Windows returns allways 0.
 pub fn file_size(path string) u64 {
 	mut s := C.stat{}

--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -157,8 +157,8 @@ pub fn truncate(path string, len u64) ? {
 }
 
 // file_size returns the size of the file located in `path`.
-// In case of an error 0 is returned.
-// Note that use of this on symbolic links on Windows returns allways 0.
+// If an error occurs it returns 0.
+// Note that use of this on symbolic links on Windows returns always 0.
 pub fn file_size(path string) u64 {
 	mut s := C.stat{}
 	unsafe {


### PR DESCRIPTION
This PR resolves two remarks and issues from my last two PRs.
- this removes the unnecessary check, see (#9722)
- return of os.file_size() can't be negative because return statement is u64 (see #9752) (my fault...)
- more informative comment for os.file_size() & os.truncate()



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
