### PR TITLE
all: cleanup of generics

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -378,18 +378,18 @@ pub:
 	attrs           []Attr
 	skip_gen        bool // this function doesn't need to be generated (for example [if foo])
 pub mut:
-	stmts             []Stmt
-	defer_stmts       []DeferStmt
-	return_type       Type
-	return_type_pos   token.Position // `string` in `fn (u User) name() string` position
-	has_return        bool
-	comments          []Comment // comments *after* the header, but *before* `{`; used for InterfaceDecl
-	next_comments     []Comment // coments that are one line after the decl; used for InterfaceDecl
-	source_file       &File = 0
-	scope             &Scope
-	label_names       []string
-	pos               token.Position // function declaration position
-	cur_generic_types []Type
+	stmts              []Stmt
+	defer_stmts        []DeferStmt
+	return_type        Type
+	return_type_pos    token.Position // `string` in `fn (u User) name() string` position
+	has_return         bool
+	comments           []Comment // comments *after* the header, but *before* `{`; used for InterfaceDecl
+	next_comments      []Comment // coments that are one line after the decl; used for InterfaceDecl
+	source_file        &File = 0
+	scope              &Scope
+	label_names        []string
+	pos                token.Position // function declaration position
+	cur_concrete_types []Type // current concrete types, e.g. <int, string>
 }
 
 // break, continue
@@ -420,8 +420,8 @@ pub mut:
 	receiver_type      Type // User
 	return_type        Type
 	should_be_skipped  bool
-	generic_types      []Type
-	generic_list_pos   token.Position
+	concrete_types     []Type
+	concrete_list_pos  token.Position
 	free_receiver      bool // true if the receiver expression needs to be freed
 	scope              &Scope
 	from_embed_type    Type // holds the type of the embed that the method is called from

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -9,22 +9,22 @@ import v.util
 
 pub struct Table {
 pub mut:
-	type_symbols     []TypeSymbol
-	type_idxs        map[string]int
-	fns              map[string]Fn
-	dumps            map[int]string // needed for efficiently generating all _v_dump_expr_TNAME() functions
-	imports          []string       // List of all imports
-	modules          []string       // Topologically sorted list of all modules registered by the application
-	cflags           []cflag.CFlag
-	redefined_fns    []string
-	fn_generic_types map[string][][]Type // for generic functions
-	cmod_prefix      string // needed for ast.type_to_str(Type) while vfmt; contains `os.`
-	is_fmt           bool
-	used_fns         map[string]bool // filled in by the checker, when pref.skip_unused = true;
-	used_consts      map[string]bool // filled in by the checker, when pref.skip_unused = true;
-	panic_handler    FnPanicHandler = default_table_panic_handler
-	panic_userdata   voidptr        = voidptr(0) // can be used to pass arbitrary data to panic_handler;
-	panic_npanics    int
+	type_symbols      []TypeSymbol
+	type_idxs         map[string]int
+	fns               map[string]Fn
+	dumps             map[int]string // needed for efficiently generating all _v_dump_expr_TNAME() functions
+	imports           []string       // List of all imports
+	modules           []string       // Topologically sorted list of all modules registered by the application
+	cflags            []cflag.CFlag
+	redefined_fns     []string
+	fn_concrete_types map[string][][]Type // for generic functions <int, string>
+	cmod_prefix       string // needed for ast.type_to_str(Type) while vfmt; contains `os.`
+	is_fmt            bool
+	used_fns          map[string]bool // filled in by the checker, when pref.skip_unused = true;
+	used_consts       map[string]bool // filled in by the checker, when pref.skip_unused = true;
+	panic_handler     FnPanicHandler = default_table_panic_handler
+	panic_userdata    voidptr        = voidptr(0) // can be used to pass arbitrary data to panic_handler;
+	panic_npanics     int
 }
 
 [unsafe]
@@ -38,7 +38,7 @@ pub fn (t &Table) free() {
 		t.modules.free()
 		t.cflags.free()
 		t.redefined_fns.free()
-		t.fn_generic_types.free()
+		t.fn_concrete_types.free()
 		t.cmod_prefix.free()
 		t.used_fns.free()
 		t.used_consts.free()
@@ -903,13 +903,13 @@ pub fn (t &Table) mktyp(typ Type) Type {
 	}
 }
 
-pub fn (mut t Table) register_fn_generic_types(fn_name string, types []Type) {
-	mut a := t.fn_generic_types[fn_name]
+pub fn (mut t Table) register_fn_concrete_types(fn_name string, types []Type) {
+	mut a := t.fn_concrete_types[fn_name]
 	if types in a {
 		return
 	}
 	a << types
-	t.fn_generic_types[fn_name] = a
+	t.fn_concrete_types[fn_name] = a
 }
 
 // TODO: there is a bug when casting sumtype the other way if its pointer

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -479,8 +479,8 @@ pub fn (mut c Checker) infer_fn_generic_types(f ast.Fn, mut call_expr ast.CallEx
 	mut inferred_types := []ast.Type{}
 	for gi, gt_name in f.generic_names {
 		// skip known types
-		if gi < call_expr.generic_types.len {
-			inferred_types << call_expr.generic_types[gi]
+		if gi < call_expr.concrete_types.len {
+			inferred_types << call_expr.concrete_types[gi]
 			continue
 		}
 		mut typ := ast.void_type
@@ -563,7 +563,7 @@ pub fn (mut c Checker) infer_fn_generic_types(f ast.Fn, mut call_expr ast.CallEx
 			println('inferred `$f.name<$s>`')
 		}
 		inferred_types << typ
-		call_expr.generic_types << typ
+		call_expr.concrete_types << typ
 	}
-	c.table.register_fn_generic_types(f.name, inferred_types)
+	c.table.register_fn_concrete_types(f.name, inferred_types)
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2104,7 +2104,7 @@ pub fn (mut c Checker) fn_call(mut call_expr ast.CallExpr) ast.Type {
 	for concrete_type in call_expr.concrete_types {
 		c.ensure_type_exists(concrete_type, call_expr.concrete_list_pos) or {}
 	}
-	if func.generic_names.len > 0 && call_expr.args.len == 0 && call_expr.generic_types.len == 0 {
+	if func.generic_names.len > 0 && call_expr.args.len == 0 && call_expr.concrete_types.len == 0 {
 		c.error('no argument generic function must add concrete types, e.g. foo<int>()',
 			call_expr.pos)
 		return func.return_type

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6445,7 +6445,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 		// It will be processed later in c.post_process_generic_fns,
 		// after all other normal functions are processed.
 		// This is done so that all generic function calls can
-		// have a chance to populate c.table.fn_generic_types with
+		// have a chance to populate c.table.fn_concrete_types with
 		// the correct concrete types.
 		c.file.generic_fns << node
 		return

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1599,11 +1599,11 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 }
 
 fn (mut f Fmt) write_generic_if_require(node ast.CallExpr) {
-	if node.generic_types.len > 0 {
+	if node.concrete_types.len > 0 {
 		f.write('<')
-		for i, generic_type in node.generic_types {
-			is_last := i == node.generic_types.len - 1
-			f.write(f.table.type_to_str(generic_type))
+		for i, concrete_type in node.concrete_types {
+			is_last := i == node.concrete_types.len - 1
+			f.write(f.table.type_to_str(concrete_type))
 			if !is_last {
 				f.write(', ')
 			}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -113,7 +113,7 @@ mut:
 	hotcode_fn_names       []string
 	embedded_files         []ast.EmbeddedFile
 	cur_fn                 ast.FnDecl
-	cur_generic_types      []ast.Type // `int`, `string`, etc in `foo<T>()`
+	cur_concrete_types     []ast.Type // `int`, `string`, etc in `foo<T>()`
 	sql_i                  int
 	sql_stmt_name          string
 	sql_bind_name          string
@@ -3206,7 +3206,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 fn (mut g Gen) type_name(type_ ast.Type) {
 	mut typ := type_
 	if typ.has_flag(.generic) {
-		typ = g.cur_generic_types[0]
+		typ = g.cur_concrete_types[0]
 	}
 	s := g.table.type_to_str(typ)
 	g.write('_SLIT("${util.strip_main_name(s)}")')
@@ -5949,14 +5949,14 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 	mut expr := node.call_expr
 	mut name := expr.name // util.no_dots(expr.name)
 	// TODO: fn call is duplicated. merge with fn_call().
-	for i, generic_type in expr.generic_types {
-		if generic_type != ast.void_type && generic_type != 0 {
+	for i, concrete_type in expr.concrete_types {
+		if concrete_type != ast.void_type && concrete_type != 0 {
 			// Using _T_ to differentiate between get<string> and get_string
 			// `foo<int>()` => `foo_T_int()`
 			if i == 0 {
 				name += '_T'
 			}
-			name += '_' + g.typ(generic_type)
+			name += '_' + g.typ(concrete_type)
 		}
 	}
 	if expr.is_method {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -127,18 +127,18 @@ fn (mut g Gen) gen_fn_decl(node ast.FnDecl, skip bool) {
 	// if g.fileis('vweb.v') {
 	// println('\ngen_fn_decl() $node.name $node.is_generic $g.cur_generic_type')
 	// }
-	if node.generic_names.len > 0 && g.cur_generic_types.len == 0 { // need the cur_generic_type check to avoid inf. recursion
+	if node.generic_names.len > 0 && g.cur_concrete_types.len == 0 { // need the cur_generic_type check to avoid inf. recursion
 		// loop thru each generic type and generate a function
-		for gen_types in g.table.fn_generic_types[node.name] {
+		for concrete_types in g.table.fn_concrete_types[node.name] {
 			if g.pref.is_verbose {
-				syms := gen_types.map(g.table.get_type_symbol(it))
+				syms := concrete_types.map(g.table.get_type_symbol(it))
 				the_type := syms.map(node.name).join(', ')
 				println('gen fn `$node.name` for type `$the_type`')
 			}
-			g.cur_generic_types = gen_types
+			g.cur_concrete_types = concrete_types
 			g.gen_fn_decl(node, skip)
 		}
-		g.cur_generic_types = []
+		g.cur_concrete_types = []
 		return
 	}
 	cur_fn_save := g.cur_fn
@@ -173,12 +173,12 @@ fn (mut g Gen) gen_fn_decl(node ast.FnDecl, skip bool) {
 		name = c_name(name)
 	}
 	mut type_name := g.typ(node.return_type)
-	if g.cur_generic_types.len > 0 {
+	if g.cur_concrete_types.len > 0 {
 		// foo<T>() => foo_T_int(), foo_T_string() etc
 		// Using _T_ to differentiate between get<string> and get_string
 		name += '_T'
-		for generic_type in g.cur_generic_types {
-			gen_name := g.typ(generic_type)
+		for concrete_type in g.cur_concrete_types {
+			gen_name := g.typ(concrete_type)
 			name += '_' + gen_name
 		}
 	}
@@ -477,7 +477,7 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 
 pub fn (mut g Gen) unwrap_generic(typ ast.Type) ast.Type {
 	if typ.has_flag(.generic) {
-		if t_typ := g.table.resolve_generic_by_names(typ, g.cur_fn.generic_names, g.cur_generic_types) {
+		if t_typ := g.table.resolve_generic_by_names(typ, g.cur_fn.generic_names, g.cur_concrete_types) {
 			return t_typ
 		}
 	}
@@ -654,14 +654,14 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			}
 		}
 	}
-	for i, generic_type in node.generic_types {
-		if generic_type != ast.void_type && generic_type != 0 {
+	for i, concrete_type in node.concrete_types {
+		if concrete_type != ast.void_type && concrete_type != 0 {
 			// Using _T_ to differentiate between get<string> and get_string
 			// `foo<int>()` => `foo_T_int()`
 			if i == 0 {
 				name += '_T'
 			}
-			name += '_' + g.typ(generic_type)
+			name += '_' + g.typ(concrete_type)
 		}
 	}
 	// TODO2
@@ -832,13 +832,13 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 			panic('cgen: obf name "$key" not found, this should never happen')
 		}
 	}
-	for i, generic_type in node.generic_types {
+	for i, concrete_type in node.concrete_types {
 		// Using _T_ to differentiate between get<string> and get_string
 		// `foo<int>()` => `foo_T_int()`
 		if i == 0 {
 			name += '_T'
 		}
-		name += '_' + g.typ(generic_type)
+		name += '_' + g.typ(concrete_type)
 	}
 	// TODO2
 	// cgen shouldn't modify ast nodes, this should be moved
@@ -1072,7 +1072,7 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 					g.write('/*af arg*/' + name)
 				}
 			} else {
-				if node.generic_types.len > 0 && arg.expr.is_auto_deref_var() && !arg.is_mut
+				if node.concrete_types.len > 0 && arg.expr.is_auto_deref_var() && !arg.is_mut
 					&& !expected_types[i].is_ptr() {
 					g.write('*')
 				}
@@ -1104,7 +1104,7 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 				varg_type_name := g.table.type_to_str(varg_type)
 				for i, fn_gen_name in fn_def.generic_names {
 					if fn_gen_name == varg_type_name {
-						arr_info.elem_type = node.generic_types[i]
+						arr_info.elem_type = node.concrete_types[i]
 						break
 					}
 				}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -33,20 +33,20 @@ pub fn (mut p Parser) call_expr(language ast.Language, mod string) ast.CallExpr 
 	}
 	p.expr_mod = ''
 	//
-	mut generic_types := []ast.Type{}
-	mut generic_list_pos := p.tok.position()
+	mut concrete_types := []ast.Type{}
+	mut concrete_list_pos := p.tok.position()
 	if p.tok.kind == .lt {
 		// `foo<int>(10)`
 		p.expr_mod = ''
-		generic_types = p.parse_generic_type_list()
-		generic_list_pos = generic_list_pos.extend(p.prev_tok.position())
+		concrete_types = p.parse_concrete_type_list()
+		concrete_list_pos = concrete_list_pos.extend(p.prev_tok.position())
 		// In case of `foo<T>()`
 		// T is unwrapped and registered in the checker.
 		full_generic_fn_name := if fn_name.contains('.') { fn_name } else { p.prepend_mod(fn_name) }
-		has_generic_generic := generic_types.filter(it.has_flag(.generic)).len > 0
-		if !has_generic_generic {
+		has_generic := concrete_types.filter(it.has_flag(.generic)).len > 0
+		if !has_generic {
 			// will be added in checker
-			p.table.register_fn_generic_types(full_generic_fn_name, generic_types)
+			p.table.register_fn_concrete_types(full_generic_fn_name, concrete_types)
 		}
 	}
 	p.check(.lpar)
@@ -95,8 +95,8 @@ pub fn (mut p Parser) call_expr(language ast.Language, mod string) ast.CallExpr 
 		mod: p.mod
 		pos: pos
 		language: language
-		generic_types: generic_types
-		generic_list_pos: generic_list_pos
+		concrete_types: concrete_types
+		concrete_list_pos: concrete_list_pos
 		or_block: ast.OrExpr{
 			stmts: or_stmts
 			kind: or_kind

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2238,18 +2238,18 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 	}
 	// Method call
 	// TODO move to fn.v call_expr()
-	mut generic_types := []ast.Type{}
-	mut generic_list_pos := p.tok.position()
+	mut concrete_types := []ast.Type{}
+	mut concrete_list_pos := p.tok.position()
 	if is_generic_call {
 		// `g.foo<int>(10)`
-		generic_types = p.parse_generic_type_list()
-		generic_list_pos = generic_list_pos.extend(p.prev_tok.position())
+		concrete_types = p.parse_concrete_type_list()
+		concrete_list_pos = concrete_list_pos.extend(p.prev_tok.position())
 		// In case of `foo<T>()`
 		// T is unwrapped and registered in the checker.
-		has_generic_generic := generic_types.filter(it.has_flag(.generic)).len > 0
-		if !has_generic_generic {
+		has_generic := concrete_types.filter(it.has_flag(.generic)).len > 0
+		if !has_generic {
 			// will be added in checker
-			p.table.register_fn_generic_types(field_name, generic_types)
+			p.table.register_fn_concrete_types(field_name, concrete_types)
 		}
 	}
 	if p.tok.kind == .lpar {
@@ -2289,8 +2289,8 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 			name_pos: name_pos
 			pos: pos
 			is_method: true
-			generic_types: generic_types
-			generic_list_pos: generic_list_pos
+			concrete_types: concrete_types
+			concrete_list_pos: concrete_list_pos
 			or_block: ast.OrExpr{
 				stmts: or_stmts
 				kind: or_kind
@@ -2331,7 +2331,7 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 	return sel_expr
 }
 
-fn (mut p Parser) parse_generic_type_list() []ast.Type {
+fn (mut p Parser) parse_concrete_type_list() []ast.Type {
 	mut types := []ast.Type{}
 	if p.tok.kind != .lt {
 		return types


### PR DESCRIPTION
This PR make cleanup of generics.

- Use `concrete_types` instead of `generic_types` when they are concrete types, e.g. <int, string>.
- Modify all the related call.

This is clearer and easier to understand.

Since the structure of FnDecl has been modified, relevant parts of `fmt` and `vls` also need to be modified. `fmt` has been modified here, but `vls` has not been modified, so ci-v-apps-compile reported an error.