### PR TITLE
parser: disable template variables in `<style>`

### DIFF
--- a/vlib/v/parser/tmpl.v
+++ b/vlib/v/parser/tmpl.v
@@ -218,6 +218,10 @@ mut sb := strings.new_builder($lstartlength)\n
 			// replace `$` to `\$` at first to escape JavaScript template literal syntax
 			source.writeln(line.replace(r'$', r'\$').replace(r'$$', r'@').replace(r'.$',
 				r'.@').replace(r"'", r"\'"))
+		} else if state == .css {
+			// disable template variable declaration in inline stylesheet
+			// because of  some CSS rules prefixed with `@`.
+			source.writeln(line.replace(r'.$', r'.@').replace(r"'", r"\'"))
 		} else {
 			// HTML, may include `@var`
 			// escaped by cgen, unless it's a `vweb.RawHtml` string

--- a/vlib/v/tests/inout/file.html
+++ b/vlib/v/tests/inout/file.html
@@ -6,6 +6,11 @@
 h1 {
 color: green;
 }
+
+@keyframes mymove {
+  from {top: 0px;}
+  to {top: 200px;}
+}
 </style>
 <style media="print">
 h1 {

--- a/vlib/v/tests/inout/tmpl_parse_html.out
+++ b/vlib/v/tests/inout/tmpl_parse_html.out
@@ -6,6 +6,11 @@
 h1 {
 color: green;
 }
+
+@keyframes mymove {
+from {top: 0px;}
+to {top: 200px;}
+}
 </style>
 <style media="print">
 h1 {


### PR DESCRIPTION
As mentioned in issue #9596, [CSS At-rules] (like `@keyframes`) conflict with template variables declaration.

If these rules are accurately filtered according to the CSS specification, the implementation would be complicated.

Disabling template variable declarations in inline stylesheets is a better solution.

[CSS At-rules]: https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule