### PR TITLE
cgen: fix empty struct init using macro

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5122,9 +5122,10 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 	}
 	// The rest of the fields are zeroed.
 	// `inited_fields` is a list of fields that have been init'ed, they are skipped
-	// mut nr_fields := 0
+	mut nr_fields := 1
 	if sym.kind == .struct_ {
 		info := sym.info as ast.Struct
+		nr_fields = info.fields.len
 		if info.is_union && struct_init.fields.len > 1 {
 			verror('union must not have more than 1 initializer')
 		}
@@ -5220,7 +5221,11 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 	}
 
 	if !initialized {
-		g.write('0')
+		if nr_fields > 0 {
+			g.write('0')
+		} else {
+			g.write('EMPTY_STRUCT_INITIALIZATION')
+		}
 	}
 
 	g.write('}')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5838,7 +5838,11 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 			type_name := g.typ(typ)
 			init_str = '($type_name)' + init_str
 		} else {
-			init_str += '0}'
+			if info.fields.len > 0 {
+				init_str += '0}'
+			} else {
+				init_str += 'EMPTY_STRUCT_INITIALIZATION}'
+			}
 		}
 		if typ.has_flag(.shared_f) {
 			styp := '__shared__${g.table.get_type_symbol(typ).cname}'

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5197,7 +5197,6 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 			if field.typ in info.embeds {
 				continue
 			}
-			mut has_init_str := true
 			if struct_init.has_update_expr {
 				g.expr(struct_init.update_expr)
 				if struct_init.update_expr_type.is_ptr() {
@@ -5207,14 +5206,14 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 				}
 				g.write(field.name)
 			} else {
-				has_init_str = g.zero_struct_field(field)
-			}
-			if has_init_str {
-				if is_multiline {
-					g.writeln(',')
-				} else {
-					g.write(',')
+				if !g.zero_struct_field(field) {
+					continue
 				}
+			}
+			if is_multiline {
+				g.writeln(',')
+			} else {
+				g.write(',')
 			}
 			initialized = true
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5207,6 +5207,7 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 				g.write(field.name)
 			} else {
 				if !g.zero_struct_field(field) {
+					nr_fields--
 					continue
 				}
 			}

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -179,7 +179,7 @@ string _STR_TMP(const char *fmt, ...) {
 	c_common_macros                 = '
 #define EMPTY_VARG_INITIALIZATION 0
 #define EMPTY_STRUCT_DECLARATION
-#define EMPTY_STRUCT_INITIALIZATION 0
+#define EMPTY_STRUCT_INITIALIZATION
 // Due to a tcc bug, the length of an array needs to be specified, but GCC crashes if it is...
 #define EMPTY_ARRAY_OF_ELEMS(x,n) (x[])
 #define TCCSKIP(x) x
@@ -209,13 +209,13 @@ string _STR_TMP(const char *fmt, ...) {
 #endif
 #ifdef _MSC_VER
 	#undef __V_GCC__
+	#undef EMPTY_STRUCT_INITIALIZATION
+	#define EMPTY_STRUCT_INITIALIZATION 0
 #endif
 
 #ifdef __TINYC__
 	#undef EMPTY_STRUCT_DECLARATION
-	#undef EMPTY_STRUCT_INITIALIZATION
 	#define EMPTY_STRUCT_DECLARATION char _dummy
-	#define EMPTY_STRUCT_INITIALIZATION 0
 	#undef EMPTY_ARRAY_OF_ELEMS
 	#define EMPTY_ARRAY_OF_ELEMS(x,n) (x[n])
 	#undef __NOINLINE

--- a/vlib/v/tests/generics_with_nested_generics_fn_test.v
+++ b/vlib/v/tests/generics_with_nested_generics_fn_test.v
@@ -1,9 +1,7 @@
 struct NestedGeneric {
-	a int
 }
 
 struct Context {
-	b int
 }
 
 struct App {


### PR DESCRIPTION
This PR fix empty struct init using macro.

- Fix empty struct init using macro.
- Modify test using empty struct.