### PR TITLE
sync: enable Android support

### DIFF
--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -3,6 +3,8 @@ module sync
 import time
 import rand
 
+// See include directory rules in sync_default.c.v
+#include <atomic.h>
 // The following functions are actually generic in C
 fn C.atomic_load_ptr(voidptr) voidptr
 fn C.atomic_store_ptr(voidptr, voidptr)

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -3,29 +3,7 @@ module sync
 import time
 import rand
 
-#flag windows -I @VROOT/thirdparty/stdatomic/win
-#flag linux -I @VROOT/thirdparty/stdatomic/nix
-#flag darwin -I @VROOT/thirdparty/stdatomic/nix
-#flag freebsd -I @VROOT/thirdparty/stdatomic/nix
-#flag solaris -I @VROOT/thirdparty/stdatomic/nix
-
-$if linux {
-	$if tinyc {
-		// most Linux distributions have /usr/lib/libatomic.so, but Ubuntu uses gcc version specific dir
-		#flag -L/usr/lib/gcc/x86_64-linux-gnu/6
-		#flag -L/usr/lib/gcc/x86_64-linux-gnu/7
-		#flag -L/usr/lib/gcc/x86_64-linux-gnu/8
-		#flag -L/usr/lib/gcc/x86_64-linux-gnu/9
-		#flag -L/usr/lib/gcc/x86_64-linux-gnu/10
-		#flag -L/usr/lib/gcc/x86_64-linux-gnu/11
-		#flag -L/usr/lib/gcc/x86_64-linux-gnu/12
-		#flag -latomic
-	}
-}
-
-#include <atomic.h>
-
-// the following functions are actually generic in C
+// The following functions are actually generic in C
 fn C.atomic_load_ptr(voidptr) voidptr
 fn C.atomic_store_ptr(voidptr, voidptr)
 fn C.atomic_compare_exchange_weak_ptr(voidptr, voidptr, voidptr) bool

--- a/vlib/sync/channels.v
+++ b/vlib/sync/channels.v
@@ -3,7 +3,27 @@ module sync
 import time
 import rand
 
-// See include directory rules in sync_default.c.v
+
+$if windows {
+	#flag -I @VROOT/thirdparty/stdatomic/win
+} $else {
+	#flag -I @VROOT/thirdparty/stdatomic/nix
+}
+
+$if linux {
+	$if tinyc {
+		// most Linux distributions have /usr/lib/libatomic.so, but Ubuntu uses gcc version specific dir
+		#flag -L/usr/lib/gcc/x86_64-linux-gnu/6
+		#flag -L/usr/lib/gcc/x86_64-linux-gnu/7
+		#flag -L/usr/lib/gcc/x86_64-linux-gnu/8
+		#flag -L/usr/lib/gcc/x86_64-linux-gnu/9
+		#flag -L/usr/lib/gcc/x86_64-linux-gnu/10
+		#flag -L/usr/lib/gcc/x86_64-linux-gnu/11
+		#flag -L/usr/lib/gcc/x86_64-linux-gnu/12
+		#flag -latomic
+	}
+}
+
 #include <atomic.h>
 // The following functions are actually generic in C
 fn C.atomic_load_ptr(voidptr) voidptr

--- a/vlib/sync/sync_default.c.v
+++ b/vlib/sync/sync_default.c.v
@@ -5,7 +5,33 @@ module sync
 
 import time
 
-#flag -lpthread
+$if windows {
+	#flag -I @VROOT/thirdparty/stdatomic/win
+} $else {
+	#flag -I @VROOT/thirdparty/stdatomic/nix
+}
+
+// There's no additional linking (-lpthread) needed for Android.
+// See https://stackoverflow.com/a/31277163/1904615
+$if !android {
+	#flag -lpthread
+}
+
+$if linux {
+	$if tinyc {
+		// most Linux distributions have /usr/lib/libatomic.so, but Ubuntu uses gcc version specific dir
+		#flag -L/usr/lib/gcc/x86_64-linux-gnu/6
+		#flag -L/usr/lib/gcc/x86_64-linux-gnu/7
+		#flag -L/usr/lib/gcc/x86_64-linux-gnu/8
+		#flag -L/usr/lib/gcc/x86_64-linux-gnu/9
+		#flag -L/usr/lib/gcc/x86_64-linux-gnu/10
+		#flag -L/usr/lib/gcc/x86_64-linux-gnu/11
+		#flag -L/usr/lib/gcc/x86_64-linux-gnu/12
+		#flag -latomic
+	}
+}
+
+#include <atomic.h>
 #include <semaphore.h>
 
 [trusted]

--- a/vlib/sync/sync_default.c.v
+++ b/vlib/sync/sync_default.c.v
@@ -5,30 +5,10 @@ module sync
 
 import time
 
-$if windows {
-	#flag -I @VROOT/thirdparty/stdatomic/win
-} $else {
-	#flag -I @VROOT/thirdparty/stdatomic/nix
-}
-
 // There's no additional linking (-lpthread) needed for Android.
 // See https://stackoverflow.com/a/31277163/1904615
 $if !android {
 	#flag -lpthread
-}
-
-$if linux {
-	$if tinyc {
-		// most Linux distributions have /usr/lib/libatomic.so, but Ubuntu uses gcc version specific dir
-		#flag -L/usr/lib/gcc/x86_64-linux-gnu/6
-		#flag -L/usr/lib/gcc/x86_64-linux-gnu/7
-		#flag -L/usr/lib/gcc/x86_64-linux-gnu/8
-		#flag -L/usr/lib/gcc/x86_64-linux-gnu/9
-		#flag -L/usr/lib/gcc/x86_64-linux-gnu/10
-		#flag -L/usr/lib/gcc/x86_64-linux-gnu/11
-		#flag -L/usr/lib/gcc/x86_64-linux-gnu/12
-		#flag -latomic
-	}
 }
 
 #include <semaphore.h>

--- a/vlib/sync/sync_default.c.v
+++ b/vlib/sync/sync_default.c.v
@@ -31,7 +31,6 @@ $if linux {
 	}
 }
 
-#include <atomic.h>
 #include <semaphore.h>
 
 [trusted]


### PR DESCRIPTION
This PR enables the `sync` module to be used on the Android platform.

~~To make the Android cases clear I've moved some C flags from `vlib/sync/channels.v` to `vlib/sync/sync_default.c.v`~~
