### PR TITLE
checker: prevent double module name prepending on generics types regi…

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1929,7 +1929,7 @@ pub fn (mut c Checker) fn_call(mut call_expr ast.CallExpr) ast.Type {
 		}
 	}
 	if has_generic_generic {
-		if c.mod != '' {
+		if c.mod != '' && !fn_name.starts_with('${c.mod}.') {
 			// Need to prepend the module when adding a generic type to a function
 			c.table.register_fn_generic_types(c.mod + '.' + fn_name, generic_types)
 		} else {

--- a/vlib/v/tests/generics_in_generics_test.v
+++ b/vlib/v/tests/generics_in_generics_test.v
@@ -1,0 +1,12 @@
+fn gen_fn2<T>(e T) string {
+	return '$e.str()'
+}
+
+fn gen_fn<T>(e T) string {
+	return gen_fn2<T>(e)
+}
+
+fn test_generics_in_generics() {
+	assert gen_fn(u64(42)) == '42'
+	assert gen_fn('42') == '42'
+}


### PR DESCRIPTION
## Additions:
Fixed a bug where checker would prepend twice a module name to a generic when registering a new type
Test for this specific use case

## Notes:
Fixes #9774 

## Example:
Compiles successfully:
```v
fn gen_fn2<T>(e T) string {
  return '$e.str()'
}

fn gen_fn<T>(e T) string {
  return gen_fn2<T>(e)
}

fn main() {
  assert gen_fn(u64(42)) == '42'
  assert gen_fn('42') == '42'
}
```