### PR TITLE
builtin: remove `unused return` C warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,11 +80,11 @@ endif
 all: latest_vc latest_tcc
 ifdef WIN32
 	$(CC) $(CFLAGS) -g -std=c99 -municode -w -o $(V) $(VC)/$(VCFILE) $(LDFLAGS)
-	$(V) -o v2.exe cmd/v
+	$(V) -o v2.exe $(VFLAGS) cmd/v
 	move /y v2.exe v.exe
 else
 	$(CC) $(CFLAGS) -g -std=gnu99 -w -o $(V) $(VC)/$(VCFILE) -lm -lpthread $(LDFLAGS)
-	$(V) -o v2.exe cmd/v
+	$(V) -o v2.exe $(VFLAGS) cmd/v
 	mv -f v2.exe v  
 endif
 	@echo "V has been successfully built"

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -120,7 +120,7 @@ pub fn eprintln(s string) {
 				C.fprintf(C.stderr, c'%.*s\n', s.len, s.str)
 			}
 		} $else {
-			mut _ := 0
+			_ := 0
 			if s.str == 0 {
 				_ = C.write(2, c'eprintln(NIL)\n', 14)
 			} else {
@@ -158,7 +158,7 @@ pub fn eprint(s string) {
 				C.fprintf(C.stderr, c'%.*s', s.len, s.str)
 			}
 		} $else {
-			mut _ := 0
+			_ := 0
 			if s.str == 0 {
 				_ = C.write(2, c'eprint(NIL)', 11)
 			} else {
@@ -172,7 +172,7 @@ pub fn eprint(s string) {
 // print prints a message to stdout. Unlike `println` stdout is not automatically flushed.
 // A call to `flush()` will flush the output buffer to stdout.
 pub fn print(s string) {
-	mut _ := 0
+	_ := 0
 	$if android {
 		C.fprintf(C.stdout, c'%.*s', s.len, s.str)
 	} $else $if ios {
@@ -194,7 +194,7 @@ fn C.asl_log(voidptr, voidptr, int, charptr)
 */
 // println prints a message with a line end, to stdout. stdout is flushed.
 pub fn println(s string) {
-	mut _ := 0
+	_ := 0
 	if s.str == 0 {
 		$if android {
 			C.fprintf(C.stdout, c'println(NIL)\n')

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -120,12 +120,12 @@ pub fn eprintln(s string) {
 				C.fprintf(C.stderr, c'%.*s\n', s.len, s.str)
 			}
 		} $else {
-			mut n := 0
+			mut _ := 0
 			if s.str == 0 {
-				n = C.write(2, c'eprintln(NIL)\n', 14)
+				_ = C.write(2, c'eprintln(NIL)\n', 14)
 			} else {
-				n = C.write(2, s.str, s.len)
-				n = C.write(2, c'\n', 1)
+				_ = C.write(2, s.str, s.len)
+				_ = C.write(2, c'\n', 1)
 			}
 		}
 		C.fflush(C.stderr)
@@ -158,11 +158,11 @@ pub fn eprint(s string) {
 				C.fprintf(C.stderr, c'%.*s', s.len, s.str)
 			}
 		} $else {
-			mut n := 0
+			mut _ := 0
 			if s.str == 0 {
-				n = C.write(2, c'eprint(NIL)', 11)
+				_ = C.write(2, c'eprint(NIL)', 11)
 			} else {
-				n = C.write(2, s.str, s.len)
+				_ = C.write(2, s.str, s.len)
 			}
 		}
 		C.fflush(C.stderr)
@@ -172,7 +172,7 @@ pub fn eprint(s string) {
 // print prints a message to stdout. Unlike `println` stdout is not automatically flushed.
 // A call to `flush()` will flush the output buffer to stdout.
 pub fn print(s string) {
-	mut n := 0
+	mut _ := 0
 	$if android {
 		C.fprintf(C.stdout, c'%.*s', s.len, s.str)
 	} $else $if ios {
@@ -181,7 +181,7 @@ pub fn print(s string) {
 	} $else $if freestanding {
 		bare_print(s.str, u64(s.len))
 	} $else {
-		n = C.write(1, s.str, s.len)
+		_ = C.write(1, s.str, s.len)
 	}
 }
 
@@ -194,7 +194,7 @@ fn C.asl_log(voidptr, voidptr, int, charptr)
 */
 // println prints a message with a line end, to stdout. stdout is flushed.
 pub fn println(s string) {
-	mut n := 0
+	mut _ := 0
 	if s.str == 0 {
 		$if android {
 			C.fprintf(C.stdout, c'println(NIL)\n')
@@ -204,7 +204,7 @@ pub fn println(s string) {
 			bare_print(s.str, u64(s.len))
 			bare_print(c'println(NIL)\n', 13)
 		} $else {
-			n = C.write(1, c'println(NIL)\n', 13)
+			_ = C.write(1, c'println(NIL)\n', 13)
 		}
 		return
 	}
@@ -216,8 +216,8 @@ pub fn println(s string) {
 		bare_print(s.str, u64(s.len))
 		bare_print(c'\n', 1)
 	} $else {
-		n = C.write(1, s.str, s.len)
-		n = C.write(1, c'\n', 1)
+		_ = C.write(1, s.str, s.len)
+		_ = C.write(1, c'\n', 1)
 	}
 }
 

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -120,11 +120,12 @@ pub fn eprintln(s string) {
 				C.fprintf(C.stderr, c'%.*s\n', s.len, s.str)
 			}
 		} $else {
+			mut n := 0
 			if s.str == 0 {
-				C.write(2, c'eprintln(NIL)\n', 14)
+				n = C.write(2, c'eprintln(NIL)\n', 14)
 			} else {
-				C.write(2, s.str, s.len)
-				C.write(2, c'\n', 1)
+				n = C.write(2, s.str, s.len)
+				n = C.write(2, c'\n', 1)
 			}
 		}
 		C.fflush(C.stderr)
@@ -157,10 +158,11 @@ pub fn eprint(s string) {
 				C.fprintf(C.stderr, c'%.*s', s.len, s.str)
 			}
 		} $else {
+			mut n := 0
 			if s.str == 0 {
-				C.write(2, c'eprint(NIL)', 11)
+				n = C.write(2, c'eprint(NIL)', 11)
 			} else {
-				C.write(2, s.str, s.len)
+				n = C.write(2, s.str, s.len)
 			}
 		}
 		C.fflush(C.stderr)
@@ -170,6 +172,7 @@ pub fn eprint(s string) {
 // print prints a message to stdout. Unlike `println` stdout is not automatically flushed.
 // A call to `flush()` will flush the output buffer to stdout.
 pub fn print(s string) {
+	mut n := 0
 	$if android {
 		C.fprintf(C.stdout, c'%.*s', s.len, s.str)
 	} $else $if ios {
@@ -178,7 +181,7 @@ pub fn print(s string) {
 	} $else $if freestanding {
 		bare_print(s.str, u64(s.len))
 	} $else {
-		C.write(1, s.str, s.len)
+		n = C.write(1, s.str, s.len)
 	}
 }
 
@@ -191,6 +194,7 @@ fn C.asl_log(voidptr, voidptr, int, charptr)
 */
 // println prints a message with a line end, to stdout. stdout is flushed.
 pub fn println(s string) {
+	mut n := 0
 	if s.str == 0 {
 		$if android {
 			C.fprintf(C.stdout, c'println(NIL)\n')
@@ -200,7 +204,7 @@ pub fn println(s string) {
 			bare_print(s.str, u64(s.len))
 			bare_print(c'println(NIL)\n', 13)
 		} $else {
-			C.write(1, c'println(NIL)\n', 13)
+			n = C.write(1, c'println(NIL)\n', 13)
 		}
 		return
 	}
@@ -212,8 +216,8 @@ pub fn println(s string) {
 		bare_print(s.str, u64(s.len))
 		bare_print(c'\n', 1)
 	} $else {
-		C.write(1, s.str, s.len)
-		C.write(1, c'\n', 1)
+		n = C.write(1, s.str, s.len)
+		n = C.write(1, c'\n', 1)
 	}
 }
 


### PR DESCRIPTION
Trivial PR to remove annoying `unused return` C warnings concerning usage of `write()`, that requires return usage.
These C warnings may be hidden when building binary directly with V, but nevertheless they show up whenever the transpiled C code is compiled through a regular C toolchain.

Also honors the VFLAGS (eg: `prod=1`) in top Makefile.
