### PR TITLE
checker: check argument for `chan.try_push/pop()`

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2904,7 +2904,7 @@ println(l)
 println(c)
 mut b := Abc{}
 ch2 := chan Abc{}
-res2 := ch2.try_pop(b) // try to perform `b = <-ch2`
+res2 := ch2.try_pop(mut b) // try to perform `b = <-ch2`
 ```
 
 The `try_push/pop()` methods will return immediately with one of the results

--- a/vlib/sync/channel_polling_test.v
+++ b/vlib/sync/channel_polling_test.v
@@ -18,7 +18,7 @@ fn do_rec(ch chan int, resch chan i64, n int) {
 	mut sum := i64(0)
 	for _ in 0 .. n {
 		mut r := 0
-		for ch.try_pop(r) != .success {
+		for ch.try_pop(mut r) != .success {
 		}
 		sum += r
 	}

--- a/vlib/sync/channel_try_buf_test.v
+++ b/vlib/sync/channel_try_buf_test.v
@@ -7,7 +7,7 @@ fn test_channel_try_buffered() {
 		}
 	}
 	mut obj := int(0)
-	for ch.try_pop(obj) == .success {
+	for ch.try_pop(mut obj) == .success {
 		println(obj)
 	}
 	assert obj == 6

--- a/vlib/sync/channel_try_unbuf_test.v
+++ b/vlib/sync/channel_try_unbuf_test.v
@@ -8,6 +8,6 @@ fn test_channel_try_unbuffered() {
 		panic('push on non-ready channel not detected')
 	}
 	mut obj := -17
-	for ch.try_pop(obj) == .success {}
+	for ch.try_pop(mut obj) == .success {}
 	assert obj == -17
 }

--- a/vlib/v/checker/tests/chan_args.out
+++ b/vlib/v/checker/tests/chan_args.out
@@ -1,0 +1,28 @@
+vlib/v/checker/tests/chan_args.vv:4:19: error: cannot use `int` as `&f64` in argument 1 to `chan f64.try_push`
+    2 |     ch := chan f64{cap: 5}
+    3 |     a := 2
+    4 |     _ := ch.try_push(a)
+      |                      ^
+    5 |     _ := ch.try_push(2.5)
+    6 |     b := 2.5
+vlib/v/checker/tests/chan_args.vv:5:19: error: cannot use `float literal` as `&f64` in argument 1 to `chan f64.try_push`
+    3 |     a := 2
+    4 |     _ := ch.try_push(a)
+    5 |     _ := ch.try_push(2.5)
+      |                      ~~~
+    6 |     b := 2.5
+    7 |     _ := ch.try_pop(b)
+vlib/v/checker/tests/chan_args.vv:7:18: error: `try_pop` parameter `obj` is `mut`, you need to provide `mut` e.g. `mut arg1`
+    5 |     _ := ch.try_push(2.5)
+    6 |     b := 2.5
+    7 |     _ := ch.try_pop(b)
+      |                     ^
+    8 |     // this should work:
+    9 |     _ := ch.try_push(b)
+vlib/v/checker/tests/chan_args.vv:11:22: error: cannot use `int` as argument for `try_pop` (`f64` expected)
+    9 |     _ := ch.try_push(b)
+   10 |     mut c := 7
+   11 |     _ := ch.try_pop(mut c)
+      |                         ^
+   12 |     mut x := 12.5
+   13 |     // this should work:

--- a/vlib/v/checker/tests/chan_args.vv
+++ b/vlib/v/checker/tests/chan_args.vv
@@ -1,0 +1,15 @@
+fn main() {
+	ch := chan f64{cap: 5}
+	a := 2
+	_ := ch.try_push(a)
+	_ := ch.try_push(2.5)
+	b := 2.5
+	_ := ch.try_pop(b)
+	// this should work:
+	_ := ch.try_push(b)
+	mut c := 7
+	_ := ch.try_pop(mut c)
+	mut x := 12.5
+	// this should work:
+	_ := ch.try_pop(mut x)
+}


### PR DESCRIPTION
For special purposes there are channel methods `try_push()` and `try_pop()` that allow to try to send or receive objects without having to wait. To be usable with any channel type these methods are declared in [chan.v](https://github.com/vlang/v/blob/master/vlib/builtin/chan.v) to accept `voidptr` arguments.

This can, however, lead to memory corruption if the sizes of the argument and the channel objects do not match.

This PR introduces special checks for these builtin methods to assure the types match. So only these cases are allowed:
```v
ch := chan f64{}
a := 7.5
send_state := ch.try_push(a)
mut b := 0.0
rec_state := ch.try_pop(mut b)
```
Type and mutability mismatches result in checker errors (see error test cases included in this PR).
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
