### PR TITLE
parser: simplify parse_generic_struct_inst_type()

### DIFF
--- a/vlib/v/fmt/tests/generic_recursive_structs_keep.vv
+++ b/vlib/v/fmt/tests/generic_recursive_structs_keep.vv
@@ -1,0 +1,28 @@
+pub struct Node<T> {
+	value     T
+	points_to []&Node<T>
+}
+
+fn main() {
+	mid := &Node<string>{
+		value: 'Middle'
+	}
+	finish := &Node<string>{
+		value: 'Finish'
+	}
+
+	graph := &Node<string>{
+		value: 'Start'
+		points_to: [
+			&Node<string>{
+				value: 'TopLeft'
+				points_to: [
+					finish,
+					mid,
+				]
+			},
+		]
+	}
+
+	println(graph.points_to[0].value) // 'TopLeft'
+}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -523,11 +523,6 @@ pub fn (mut p Parser) parse_generic_struct_inst_type(name string) ast.Type {
 			}
 		})
 		return ast.new_type(idx)
-	} else {
-		idx := p.table.find_type_idx(name)
-		if idx != 0 {
-			return ast.new_type(idx).set_flag(.generic)
-		}
 	}
-	return p.parse_enum_or_struct_type(name, .v)
+	return p.parse_enum_or_struct_type(name, .v).set_flag(.generic)
 }


### PR DESCRIPTION
This PR make minor simplification of parse_generic_struct_inst_type() in parse_type.v.

- Simplify parse_generic_struct_inst_type() in parse_type.v.
- Fix return typ without .generic flag.
- Add test to fix format generic_recursive struct.

Format the following codes is ok.

```vlang
pub struct Node<T> {
	value     T
	points_to []&Node<T>
}
```