### PR TITLE
vfmt: only print non-empty diffs

### DIFF
--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -210,7 +210,10 @@ fn (foptions &FormatOptions) post_process_file(file string, formatted_file_path 
 		if foptions.is_verbose {
 			eprintln('Using diff command: $diff_cmd')
 		}
-		println(util.color_compare_files(diff_cmd, file, formatted_file_path))
+		diff := util.color_compare_files(diff_cmd, file, formatted_file_path)
+		if diff.len > 0 {
+			println(diff)
+		}
 		return
 	}
 	if foptions.is_verify {


### PR DESCRIPTION
Prevents terminal being cluttered with void.