### PR TITLE
vweb: no lowercase url to process it

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -359,7 +359,7 @@ fn handle_conn<T>(mut conn net.TcpConn, mut app T) {
 	}
 	// Serve a static file if it is one
 	// TODO: get the real path
-	url := urllib.parse(app.req.url.to_lower()) or {
+	url := urllib.parse(app.req.url) or {
 		eprintln('error parsing path: $err')
 		return
 	}


### PR DESCRIPTION
This allows to differentiate between upper and lower case of endpoints, parameters and static files