### PR TITLE
rand: fix wrong function signature

### DIFF
--- a/vlib/rand/pcg32/pcg32.v
+++ b/vlib/rand/pcg32/pcg32.v
@@ -91,7 +91,7 @@ pub fn (mut rng PCG32RNG) u64n(max u64) u64 {
 
 // u32_in_range returns a pseudorandom 32-bit unsigned `u32` in range `[min, max)`.
 [inline]
-pub fn (mut rng PCG32RNG) u32_in_range(min u64, max u64) u64 {
+pub fn (mut rng PCG32RNG) u32_in_range(min u32, max u32) u32 {
 	if max <= min {
 		eprintln('max must be greater than min')
 		exit(1)

--- a/vlib/rand/pcg32/pcg32_test.v
+++ b/vlib/rand/pcg32/pcg32_test.v
@@ -141,13 +141,13 @@ fn test_pcg32_u64n() {
 }
 
 fn test_pcg32_u32_in_range() {
-	max := u64(484468466)
-	min := u64(316846)
+	max := u32(484468466)
+	min := u32(316846)
 	for seed in seeds {
 		mut rng := pcg32.PCG32RNG{}
 		rng.seed(seed)
 		for _ in 0 .. range_limit {
-			value := rng.u32_in_range(u64(min), u64(max))
+			value := rng.u32_in_range(u32(min), u32(max))
 			assert value >= min
 			assert value < max
 		}

--- a/vlib/rand/pcg32/pcg32_test.v
+++ b/vlib/rand/pcg32/pcg32_test.v
@@ -1,4 +1,5 @@
 import math
+import rand
 import rand.pcg32
 import rand.seed
 
@@ -329,4 +330,8 @@ fn test_pcg32_f64_in_range() {
 			assert value < max
 		}
 	}
+}
+
+fn test_change_default_random_generator() {
+	rand.set_rng(pcg32.PCG32RNG{})
 }


### PR DESCRIPTION
Setting a PCG32RNG as the default rng fails as the function signature doesn't match the PRNG interface. This PR fixes that.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
