### PR TITLE
builtin,os: fix unused return C warnings for real

### DIFF
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -120,12 +120,12 @@ pub fn eprintln(s string) {
 				C.fprintf(C.stderr, c'%.*s\n', s.len, s.str)
 			}
 		} $else {
-			_ := 0
+			mut n := 0
 			if s.str == 0 {
-				_ = C.write(2, c'eprintln(NIL)\n', 14)
+				n = C.write(2, c'eprintln(NIL)\n', 14)
 			} else {
-				_ = C.write(2, s.str, s.len)
-				_ = C.write(2, c'\n', 1)
+				n = C.write(2, s.str, s.len)
+				n = C.write(2, c'\n', 1)
 			}
 		}
 		C.fflush(C.stderr)
@@ -158,11 +158,11 @@ pub fn eprint(s string) {
 				C.fprintf(C.stderr, c'%.*s', s.len, s.str)
 			}
 		} $else {
-			_ := 0
+			mut n := 0
 			if s.str == 0 {
-				_ = C.write(2, c'eprint(NIL)', 11)
+				n = C.write(2, c'eprint(NIL)', 11)
 			} else {
-				_ = C.write(2, s.str, s.len)
+				n = C.write(2, s.str, s.len)
 			}
 		}
 		C.fflush(C.stderr)
@@ -172,7 +172,7 @@ pub fn eprint(s string) {
 // print prints a message to stdout. Unlike `println` stdout is not automatically flushed.
 // A call to `flush()` will flush the output buffer to stdout.
 pub fn print(s string) {
-	_ := 0
+	mut n := 0
 	$if android {
 		C.fprintf(C.stdout, c'%.*s', s.len, s.str)
 	} $else $if ios {
@@ -181,7 +181,7 @@ pub fn print(s string) {
 	} $else $if freestanding {
 		bare_print(s.str, u64(s.len))
 	} $else {
-		_ = C.write(1, s.str, s.len)
+		n = C.write(1, s.str, s.len)
 	}
 }
 
@@ -194,7 +194,7 @@ fn C.asl_log(voidptr, voidptr, int, charptr)
 */
 // println prints a message with a line end, to stdout. stdout is flushed.
 pub fn println(s string) {
-	_ := 0
+	mut n := 0
 	if s.str == 0 {
 		$if android {
 			C.fprintf(C.stdout, c'println(NIL)\n')
@@ -204,7 +204,7 @@ pub fn println(s string) {
 			bare_print(s.str, u64(s.len))
 			bare_print(c'println(NIL)\n', 13)
 		} $else {
-			_ = C.write(1, c'println(NIL)\n', 13)
+			n = C.write(1, c'println(NIL)\n', 13)
 		}
 		return
 	}
@@ -216,8 +216,8 @@ pub fn println(s string) {
 		bare_print(s.str, u64(s.len))
 		bare_print(c'\n', 1)
 	} $else {
-		_ = C.write(1, s.str, s.len)
-		_ = C.write(1, c'\n', 1)
+		n = C.write(1, s.str, s.len)
+		n = C.write(1, c'\n', 1)
 	}
 }
 

--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -740,10 +740,11 @@ pub fn is_link(path string) bool {
 
 // chdir changes the current working directory to the new directory in `path`.
 pub fn chdir(path string) {
+	mut n := 0
 	$if windows {
 		C._wchdir(path.to_wide())
 	} $else {
-		C.chdir(&char(path.str))
+		n = C.chdir(&char(path.str))
 	}
 }
 

--- a/vlib/os/process_nix.c.v
+++ b/vlib/os/process_nix.c.v
@@ -3,11 +3,12 @@ module os
 fn C.setpgid(pid int, pgid int) int
 
 fn (mut p Process) unix_spawn_process() int {
+	mut n := 0
 	mut pipeset := [6]int{}
 	if p.use_stdio_ctl {
-		C.pipe(&pipeset[0]) // pipe read end 0 <- 1 pipe write end
-		C.pipe(&pipeset[2]) // pipe read end 2 <- 3 pipe write end
-		C.pipe(&pipeset[4]) // pipe read end 4 <- 5 pipe write end
+		n = C.pipe(&pipeset[0]) // pipe read end 0 <- 1 pipe write end
+		n = C.pipe(&pipeset[2]) // pipe read end 2 <- 3 pipe write end
+		n = C.pipe(&pipeset[4]) // pipe read end 4 <- 5 pipe write end
 	}
 	pid := fork()
 	if pid != 0 {


### PR DESCRIPTION
This trivial PR fixes some annoying `unused result` C warnings related to `write` and other C functions

They were already adressed in a previously merged PR, but in a wrong way, due to a last minute change during review, asking to replace the *apparently* useless and dummy `n` *unused* V variable, by the `_` V variable, which in turn does *no-op* through the generated C code, thus destroying the sole purpose of this very PR.

So, indeed, the "unused" `n` V variables, are required to fix the `unused result` C warnings. Yes.
Believe me. That's important :-)