### PR TITLE
checker: check generic fn called no arg without concrete types (fix part of #9811)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2108,6 +2108,11 @@ pub fn (mut c Checker) fn_call(mut call_expr ast.CallExpr) ast.Type {
 	for generic_type in call_expr.generic_types {
 		c.ensure_type_exists(generic_type, call_expr.generic_list_pos) or {}
 	}
+	if func.generic_names.len > 0 && call_expr.args.len == 0 && call_expr.generic_types.len == 0 {
+		c.error('no argument generic function must add concrete types, e.g. foo<int>()',
+			call_expr.pos)
+		return func.return_type
+	}
 	if func.generic_names.len > 0 && func.return_type.has_flag(.generic) {
 		c.check_return_generics_struct(func.return_type, mut call_expr, generic_types)
 	} else {

--- a/vlib/v/checker/tests/generics_fn_called_no_arg_err.out
+++ b/vlib/v/checker/tests/generics_fn_called_no_arg_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/generics_fn_called_no_arg_err.vv:13:10: error: no argument generic function must add concrete types, e.g. foo<int>()
+   11 |
+   12 | fn main() {
+   13 |     q := new_queue()
+      |          ~~~~~~~~~~~
+   14 |     println(q)
+   15 | }

--- a/vlib/v/checker/tests/generics_fn_called_no_arg_err.vv
+++ b/vlib/v/checker/tests/generics_fn_called_no_arg_err.vv
@@ -1,0 +1,15 @@
+struct Queue<T>{
+    buffer []T
+}
+
+fn new_queue<T>() Queue<T> {
+    q := Queue<T>{
+        buffer: []T{cap: 1024}
+    }
+    return q
+}
+
+fn main() {
+    q := new_queue()
+    println(q)
+}


### PR DESCRIPTION
This PR check generic fn called no arg without generic names (fix part of #9811).

- Check generic fn called no arg without generic names.
- Add test.

```vlang
struct Queue<T>{
    buffer []T
}

fn new_queue<T>() Queue<T> {
    q := Queue<T>{
        buffer: []T{cap: 1024}
    }
    return q
}

fn main() {
    q := new_queue()
    println(q)
}

D:\Test\v\tt1>v run .
.\tt1.v:13:10: error: no argument generic function must add concrete types, e.g. foo<int>()
   11 | 
   12 | fn main() {
   13 |     q := new_queue()
      |          ~~~~~~~~~~~
   14 |     println(q)
   15 | }
```