### PR TITLE
builtin: fix termux println

### DIFF
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -204,9 +204,7 @@ pub fn println(s string) {
 		}
 		return
 	}
-	$if android {
-		C.fprintf(C.stdout, c'%.*s\n', s.len, s.str)
-	} $else $if ios {
+	$if ios {
 		C.WrappedNSLog(s.str)
 	} $else $if freestanding {
 		bare_print(s.str, u64(s.len))

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -204,6 +204,9 @@ pub fn println(s string) {
 		}
 		return
 	}
+	$if android {
+		C.fprintf(C.stdout, c'%.*s\n', s.len, s.str)
+	}
 	$if ios {
 		C.WrappedNSLog(s.str)
 	} $else $if freestanding {


### PR DESCRIPTION
Fix for missing v output on termux/android.
https://github.com/vlang/v/issues/9662

This commit introduced the regression
https://github.com/vlang/v/commit/824790a2bdd35337488d20e2dbf9cfa31434d53d

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
