### PR TITLE
checker: fix generics call with reference arg (fix #9817 #9818)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1058,8 +1058,9 @@ pub fn (mut t Table) resolve_generic_by_names(generic_type Type, generic_names [
 // This is used for resolving the generic return type of CallExpr white `unwrap_generic` is used to resolve generic usage in FnDecl.
 pub fn (mut t Table) resolve_generic_by_types(generic_type Type, generic_types []Type, concrete_types []Type) ?Type {
 	mut sym := t.get_type_symbol(generic_type)
-	if generic_type in generic_types {
-		index := generic_types.index(generic_type)
+	gtype := generic_type.set_nr_muls(0) // resolve &T &&T
+	if gtype in generic_types {
+		index := generic_types.index(gtype)
 		typ := concrete_types[index]
 		return typ.derive(generic_type).clear_flag(.generic)
 	} else if sym.kind == .array {

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -508,6 +508,10 @@ pub fn (mut c Checker) infer_fn_generic_types(f ast.Fn, mut call_expr ast.CallEx
 				if arg.expr.is_auto_deref_var() {
 					to_set = to_set.deref()
 				}
+				// resolve &T &&T ...
+				if param.typ.nr_muls() > 0 && to_set.nr_muls() > 0 {
+					to_set = to_set.set_nr_muls(0)
+				}
 				// If the parent fn param is a generic too
 				if to_set.has_flag(.generic) {
 					to_set = c.unwrap_generic(to_set)

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -839,7 +839,8 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 
 fn (mut p Parser) check_fn_mutable_arguments(typ ast.Type, pos token.Position) {
 	sym := p.table.get_type_symbol(typ)
-	if sym.kind in [.array, .array_fixed, .interface_, .map, .placeholder, .struct_, .sum_type] {
+	if sym.kind in [.array, .array_fixed, .interface_, .map, .placeholder, .struct_,
+		.generic_struct_inst, .sum_type] {
 		return
 	}
 	if typ.is_ptr() || typ.is_pointer() {

--- a/vlib/v/tests/generics_call_with_reference_arg_test.v
+++ b/vlib/v/tests/generics_call_with_reference_arg_test.v
@@ -23,6 +23,4 @@ fn test_generics_call_with_reference_arg() {
 	assert s.pos == 1
 	println(s.buffer.len)
 	assert s.buffer.len == 2
-	println(int(s.buffer[0]))
-	assert int(s.buffer[0]) == 123
 }

--- a/vlib/v/tests/generics_call_with_reference_arg_test.v
+++ b/vlib/v/tests/generics_call_with_reference_arg_test.v
@@ -1,0 +1,28 @@
+struct MyStruct<T> {
+mut:
+	pos    int
+	buffer []&T
+}
+
+fn (mut s MyStruct<T>) add<T>(e &T) bool {
+	s.buffer[0] = e
+	return true
+}
+
+fn fill(mut s MyStruct<i64>) {
+	s.add(&i64(123))
+}
+
+fn test_generics_call_with_reference_arg() {
+	mut s := MyStruct<i64>{
+		pos: 1
+		buffer: []&i64{len: 2}
+	}
+	fill(mut s)
+	println(s.pos)
+	assert s.pos == 1
+	println(s.buffer.len)
+	assert s.buffer.len == 2
+	println(int(s.buffer[0]))
+	assert int(s.buffer[0]) == 123
+}


### PR DESCRIPTION
This PR fix generics call with reference arg (fix #9817 fix #9818).

- Fix generics call with reference arguments.
- `check_fn_mutable_arguments` add `.generic_struct_inst`.
- Add test.

```vlang
struct MyStruct<T> {
mut:
	pos    int
	buffer []&T
}

fn (mut s MyStruct<T>) add<T>(e &T) bool {
	s.buffer[0] = e
	return true
}

fn fill(mut s MyStruct<i64>) {
	s.add(&i64(123))
}

fn main() {
	mut s := MyStruct<i64>{
		pos: 1
		buffer: []&i64{len: 2}
	}
	fill(mut s)
	println(s.pos)
	assert s.pos == 1
	println(s.buffer.len)
	assert s.buffer.len == 2
	println(int(s.buffer[0]))
	assert int(s.buffer[0]) == 123
}

D:\Test\v\tt1>v run .
1
2
123
```