### PR TITLE
ast, parser: cleanup of generic struct

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -228,10 +228,10 @@ pub mut:
 
 pub struct StructDecl {
 pub:
-	pos       token.Position
-	name      string
-	gen_types []Type
-	is_pub    bool
+	pos           token.Position
+	name          string
+	generic_types []Type
+	is_pub        bool
 	// _pos fields for vfmt
 	mut_pos      int // mut:
 	pub_pos      int // pub:

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1066,17 +1066,17 @@ pub fn (mut t Table) generic_struct_insts_to_concrete() {
 			}
 			mut parent_info := parent.info as Struct
 			mut fields := parent_info.fields.clone()
-			if parent_info.generic_types.len == info.generic_types.len {
+			if parent_info.generic_types.len == info.concrete_types.len {
 				generic_names := parent_info.generic_types.map(t.get_type_symbol(it).name)
 				for i in 0 .. fields.len {
 					if t_typ := t.resolve_generic_to_concrete(fields[i].typ, generic_names,
-						info.generic_types)
+						info.concrete_types)
 					{
 						fields[i].typ = t_typ
 					}
 				}
 				parent_info.generic_types = []
-				parent_info.concrete_types = info.generic_types.clone()
+				parent_info.concrete_types = info.concrete_types.clone()
 				parent_info.fields = fields
 				parent_info.parent_type = new_type(info.parent_idx).set_flag(.generic)
 				typ.is_public = true

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -730,8 +730,8 @@ pub mut:
 // instantiation of a generic struct
 pub struct GenericStructInst {
 pub mut:
-	parent_idx    int // idx of the base generic struct
-	generic_types []Type
+	parent_idx     int    // idx of the base generic struct
+	concrete_types []Type // concrete types, e.g. <int, string>
 }
 
 pub struct Interface {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6426,11 +6426,11 @@ fn (mut c Checker) post_process_generic_fns() {
 			}
 			mut node := c.file.generic_fns[i]
 			c.mod = node.mod
-			for gen_types in c.table.fn_generic_types[node.name] {
-				node.cur_generic_types = gen_types
+			for generic_types in c.table.fn_generic_types[node.name] {
+				node.cur_generic_types = generic_types
 				c.fn_decl(mut node)
 				if node.name in ['vweb.run_app', 'vweb.run'] {
-					c.vweb_gen_types << gen_types
+					c.vweb_gen_types << generic_types
 				}
 			}
 			node.cur_generic_types = []

--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -102,9 +102,9 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl) {
 	f.write_language_prefix(node.language)
 	name := node.name.after('.')
 	f.write(name)
-	if node.gen_types.len > 0 {
+	if node.generic_types.len > 0 {
 		f.write('<')
-		gtypes := node.gen_types.map(f.table.type_to_str(it)).join(', ')
+		gtypes := node.generic_types.map(f.table.type_to_str(it)).join(', ')
 		f.write(gtypes)
 		f.write('>')
 	}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -129,13 +129,13 @@ fn (mut g Gen) gen_fn_decl(node ast.FnDecl, skip bool) {
 	// }
 	if node.generic_names.len > 0 && g.cur_generic_types.len == 0 { // need the cur_generic_type check to avoid inf. recursion
 		// loop thru each generic type and generate a function
-		for gen_types in g.table.fn_generic_types[node.name] {
+		for generic_types in g.table.fn_generic_types[node.name] {
 			if g.pref.is_verbose {
-				syms := gen_types.map(g.table.get_type_symbol(it))
+				syms := generic_types.map(g.table.get_type_symbol(it))
 				the_type := syms.map(node.name).join(', ')
 				println('gen fn `$node.name` for type `$the_type`')
 			}
-			g.cur_generic_types = gen_types
+			g.cur_generic_types = generic_types
 			g.gen_fn_decl(node, skip)
 		}
 		g.cur_generic_types = []

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -481,7 +481,7 @@ pub fn (mut p Parser) parse_generic_struct_inst_type(name string) ast.Type {
 	p.in_generic_params = true
 	bs_name += '<'
 	bs_cname += '_T_'
-	mut generic_types := []ast.Type{}
+	mut concrete_types := []ast.Type{}
 	mut is_instance := false
 	for p.tok.kind != .eof {
 		gt := p.parse_type()
@@ -491,7 +491,7 @@ pub fn (mut p Parser) parse_generic_struct_inst_type(name string) ast.Type {
 		gts := p.table.get_type_symbol(gt)
 		bs_name += gts.name
 		bs_cname += gts.cname
-		generic_types << gt
+		concrete_types << gt
 		if p.tok.kind != .comma {
 			break
 		}
@@ -502,7 +502,7 @@ pub fn (mut p Parser) parse_generic_struct_inst_type(name string) ast.Type {
 	p.check(.gt)
 	p.in_generic_params = false
 	bs_name += '>'
-	if is_instance && generic_types.len > 0 {
+	if is_instance && concrete_types.len > 0 {
 		mut gt_idx := p.table.find_type_idx(bs_name)
 		if gt_idx > 0 {
 			return ast.new_type(gt_idx)
@@ -519,7 +519,7 @@ pub fn (mut p Parser) parse_generic_struct_inst_type(name string) ast.Type {
 			mod: p.mod
 			info: ast.GenericStructInst{
 				parent_idx: parent_idx
-				generic_types: generic_types
+				concrete_types: concrete_types
 			}
 		})
 		return ast.new_type(idx)

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -332,7 +332,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 		is_union: is_union
 		attrs: attrs
 		end_comments: end_comments
-		gen_types: generic_types
+		generic_types: generic_types
 		embeds: embeds
 	}
 }


### PR DESCRIPTION
This PR make cleanup of generic struct.

- `generic_types` change to `concrete_types` in struct GenericStructInst, and add comments.
- Modify related call.