### PR TITLE
x64: handle -arch amd64/arm64 and -os for raw/linux/macos options

### DIFF
--- a/vlib/v/builder/x64.v
+++ b/vlib/v/builder/x64.v
@@ -7,10 +7,8 @@ import v.gen.x64
 import v.markused
 
 pub fn (mut b Builder) build_x64(v_files []string, out_file string) {
-	$if !linux {
-		println('v -x64 can only generate Linux binaries for now')
-		println('You are not on a Linux system, so you will not ' +
-			'be able to run the resulting executable')
+	$if !linux && !macos {
+		eprintln('Warning: v -x64 can only generate macOS and Linux binaries for now')
 	}
 	util.timing_start('PARSE')
 	b.parsed_files = parser.parse_files(v_files, b.table, b.pref, b.global_scope)

--- a/vlib/v/gen/x64/amd64.v
+++ b/vlib/v/gen/x64/amd64.v
@@ -1,0 +1,40 @@
+module x64
+
+pub struct Amd64 {
+	// arm64 specific stuff for code generation
+}
+
+pub fn (mut x Amd64) allocate_var(mut g Gen, name string, size int, initial_val int) {
+	// `a := 3`  =>
+	// `move DWORD [rbp-0x4],0x3`
+	match size {
+		1 {
+			// BYTE
+			g.write8(0xc6)
+			g.write8(0x45)
+		}
+		4 {
+			// DWORD
+			g.write8(0xc7)
+			g.write8(0x45)
+		}
+		8 {
+			// QWORD
+			g.write8(0x48)
+			g.write8(0xc7)
+			g.write8(0x45)
+		}
+		else {
+			verror('allocate_var: bad size $size')
+		}
+	}
+	// Generate N in `[rbp-N]`
+	n := g.stack_var_pos + size
+	g.write8(0xff - n + 1)
+	g.stack_var_pos += size
+	g.var_offset[name] = g.stack_var_pos
+	// Generate the value assigned to the variable
+	g.write32(initial_val)
+	// println('allocate_var(size=$size, initial_val=$initial_val)')
+	g.println('mov DWORD [rbp-$n.hex2()],$initial_val (Allocate var `$name`)')
+}

--- a/vlib/v/gen/x64/arm64.v
+++ b/vlib/v/gen/x64/arm64.v
@@ -1,0 +1,9 @@
+module x64
+
+pub struct Aarch64 {
+	// arm64 specific stuff for code generation
+}
+
+pub fn (mut x Aarch64) allocate_var(mut g Gen, name string, size int, initial_val int) {
+	eprintln('TODO: allocating var on arm64 ($name) = $size = $initial_val')
+}

--- a/vlib/v/gen/x64/elf.v
+++ b/vlib/v/gen/x64/elf.v
@@ -22,7 +22,8 @@ const (
 	et_rel     = 1
 	et_exec    = 2
 	et_dyn     = 3
-	e_machine  = 0x3e
+	e_machine_amd64 = 0x3e
+	e_machine_aarch64 = 183
 	shn_xindex = 0xffff
 	sht_null   = 0
 )
@@ -41,7 +42,11 @@ pub fn (mut g Gen) generate_elf_header() {
 	g.buf << 1 // elf_osabi
 	g.write64(0) // et_rel) // et_rel for .o
 	g.write16(2) // e_type
-	g.write16(x64.e_machine) //
+	if g.pref.arch == .aarch64 {
+		g.write16(x64.e_machine_aarch64)
+	} else {
+		g.write16(x64.e_machine_amd64)
+	}
 	g.write32(x64.ev_current) // e_version
 	eh_size := 0x40
 	phent_size := 0x38

--- a/vlib/v/gen/x64/elf.v
+++ b/vlib/v/gen/x64/elf.v
@@ -18,14 +18,14 @@ const (
 
 // ELF file types
 const (
-	elf_osabi  = 0
-	et_rel     = 1
-	et_exec    = 2
-	et_dyn     = 3
-	e_machine_amd64 = 0x3e
+	elf_osabi         = 0
+	et_rel            = 1
+	et_exec           = 2
+	et_dyn            = 3
+	e_machine_amd64   = 0x3e
 	e_machine_aarch64 = 183
-	shn_xindex = 0xffff
-	sht_null   = 0
+	shn_xindex        = 0xffff
+	sht_null          = 0
 )
 
 const (

--- a/vlib/v/gen/x64/gen.v
+++ b/vlib/v/gen/x64/gen.v
@@ -108,7 +108,8 @@ pub fn gen(files []ast.File, table &ast.Table, out_name string, pref &pref.Prefe
 			eprintln('Warning: ${file.warnings[0]}')
 		}
 		if file.errors.len > 0 {
-			verror('Error ${file.errors[0]}')
+			eprintln('Error ${file.errors[0]}')
+			// verror('Error ${file.errors[0]}')
 		}
 		g.stmts(file.stmts)
 	}
@@ -692,6 +693,8 @@ pub fn (mut g Gen) call_fn(node ast.CallExpr) {
 }
 
 fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
+	eprintln('for-in statement is not yet implemented')
+	/*
 	if node.is_range {
 		// `for x in 1..10 {`
 		// i := if node.val_var == '_' { g.new_tmp_var() } else { c_name(node.val_var) }
@@ -701,14 +704,13 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 		g.write32(0x3232) // ; $i < ')
 		g.expr(node.high)
 		g.write32(0x3333) // '; ++$i) {')
-		/*
 		} else if node.kind == .array {
 	} else if node.kind == .array_fixed {
 	} else if node.kind == .map {
 	} else if node.kind == .string {
 	} else if node.kind == .struct_ {
-		*/
 	}
+	*/
 }
 
 fn (mut g Gen) stmt(node ast.Stmt) {

--- a/vlib/v/gen/x64/gen.v
+++ b/vlib/v/gen/x64/gen.v
@@ -92,11 +92,19 @@ pub fn gen(files []ast.File, table &ast.Table, out_name string, pref &pref.Prefe
 	if !pref.is_verbose {
 		println('use `v -x64 -v ...` to print resulting asembly/machine code')
 	}
-	g.generate_elf_header()
+	if pref.os == .macos {
+		g.generate_macho_header()
+	} else {
+		g.generate_elf_header()
+	}
 	for file in files {
 		g.stmts(file.stmts)
 	}
-	g.generate_elf_footer()
+	if pref.os == .macos {
+		g.generate_macho_footer()
+	} else {
+		g.generate_elf_footer()
+	}
 	return g.nlines, g.buf.len
 }
 

--- a/vlib/v/gen/x64/macho.v
+++ b/vlib/v/gen/x64/macho.v
@@ -99,7 +99,7 @@ pub fn (mut g Gen) generate_macho_header() {
 	for _ in 0 .. 12 {
 		g.write32(0)
 	}
-// ADD THE CODE HERE THIS GOES INTO THE STMTS THING
+	// ADD THE CODE HERE THIS GOES INTO THE STMTS THING
 	// g.write32(0x77777777)
 	// assembly
 	g.mov_arm(.x0, 1)

--- a/vlib/v/gen/x64/macho.v
+++ b/vlib/v/gen/x64/macho.v
@@ -99,6 +99,7 @@ pub fn (mut g Gen) generate_macho_header() {
 	for _ in 0 .. 12 {
 		g.write32(0)
 	}
+// ADD THE CODE HERE THIS GOES INTO THE STMTS THING
 	// g.write32(0x77777777)
 	// assembly
 	g.mov_arm(.x0, 1)
@@ -119,9 +120,9 @@ pub fn (mut g Gen) generate_macho_header() {
 }
 
 pub fn (mut g Gen) generate_macho_footer() {
-	// Create the binary
+	// Create the binary // should be .o ?
 	mut f := os.create(g.out_name) or { panic(err) }
-	os.chmod(g.out_name, 0o775) // make it an executable
+	os.chmod(g.out_name, 0o775) // make it executable
 	unsafe { f.write_ptr(g.buf.data, g.buf.len) }
 	f.close()
 	// println('\narm64 mach-o binary has been successfully generated')

--- a/vlib/v/gen/x64/macho.v
+++ b/vlib/v/gen/x64/macho.v
@@ -37,9 +37,15 @@ struct Reloc {
 }
 
 pub fn (mut g Gen) generate_macho_header() {
-	g.write32(0xfeedfacf) // MH_MAGIC_64
-	g.write32(0x0100000c) // CPU_TYPE_ARM64
-	g.write32(0x00000000) // CPU_SUBTYPE_ARM64_ALL
+	if g.pref.arch == .aarch64 {
+		g.write32(0xfeedfacf) // MH_MAGIC_64
+		g.write32(0x0100000c) // CPU_TYPE_ARM64
+		g.write32(0x00000000) // CPU_SUBTYPE_ARM64_ALL
+	} else {
+		g.write32(0xfeedfacf) // MH_MAGIC_64
+		g.write32(0x01000007) // CPU_TYPE_X64
+		g.write32(0x00000003) // CPU_SUBTYPE_X64
+	}
 	g.write32(0x00000001) // MH_OBJECT
 	g.write32(0x00000004) // # of load commands
 	g.write32(0x118) // size of load commands
@@ -76,7 +82,7 @@ pub fn (mut g Gen) generate_macho_header() {
 	g.write32(0x18)
 
 	g.write32(0x01)
-	g.write32(0x000b0000)
+	g.write32(0x000a0000) // minOS 10.0
 	g.write32(0)
 	g.write32(0)
 	// lc_symtab
@@ -102,7 +108,7 @@ pub fn (mut g Gen) generate_macho_header() {
 	g.mov_arm(.x16, 1)
 	g.svc()
 	//
-	g.write_string('Hello WorlD!\n')
+	g.write_string('Hello World!\n')
 	g.write8(0) // padding?
 	g.write8(0)
 	g.write8(0)

--- a/vlib/v/pref/os.v
+++ b/vlib/v/pref/os.v
@@ -17,6 +17,7 @@ pub enum OS {
 	android
 	solaris
 	haiku
+	raw
 	all
 }
 
@@ -35,6 +36,7 @@ pub fn os_from_string(os_str string) ?OS {
 		'solaris' { return .solaris }
 		'android' { return .android }
 		'haiku' { return .haiku }
+		'raw' { return .raw }
 		'linux_or_macos', 'nix' { return .linux }
 		'' { return ._auto }
 		else { return error('bad OS $os_str') }
@@ -56,6 +58,7 @@ pub fn (o OS) str() string {
 		.android { return 'Android' }
 		.solaris { return 'Solaris' }
 		.haiku { return 'Haiku' }
+		.raw { return 'Raw' }
 		.all { return 'all' }
 	}
 }


### PR DESCRIPTION
* By default local host arch is used
* v -x64 -os linux -arch arm64 test.v
* v -x64 -os macos -arch amd64 test.v
* v -x64 -os raw test.v

```sh
$ cat test.sh
#!/bin/sh
v hello.v
./hello
v -x64 -os linux hello.v
file hello
v -x64 -os linux -arch arm64 hello.v
file hello
cp hello h
v -x64 -os macos hello.v
file hello
v -x64 -os macos -arch arm64 hello.v
file hello
```
output
```
$ sh test.sh
hello world
use `v -x64 -v ...` to print resulting asembly/machine code
code_start_pos = 78
hello: ELF 64-bit LSB executable, x86-64, version 1 (HP-UX), statically linked, no section header
use `v -x64 -v ...` to print resulting asembly/machine code
code_start_pos = 78
hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (HP-UX), statically linked, no section header
use `v -x64 -v ...` to print resulting asembly/machine code
hello: Mach-O 64-bit object x86_64
use `v -x64 -v ...` to print resulting asembly/machine code
hello: Mach-O 64-bit object arm64
```