### PR TITLE
ast: use `AttrKind`

### DIFF
--- a/vlib/v/ast/attr.v
+++ b/vlib/v/ast/attr.v
@@ -5,55 +5,49 @@ module ast
 
 import v.token
 
+pub enum AttrKind {
+	plain // [name]
+	string // ['name']
+	number // [123]
+	comptime_define // [if name]
+}
+
 // e.g. `[unsafe]`
 pub struct Attr {
 pub:
-	name               string // [name]
-	is_string          bool   // ['name']
-	is_comptime_define bool   // [if name]
-	arg                string // [name: arg]
-	is_string_arg      bool   // [name: 'arg']
-	is_number_arg      bool   // [name: 123]
-	pos                token.Position
+	name    string // [name]
+	has_arg bool
+	arg     string // [name: arg]
+	kind    AttrKind
+	pos     token.Position
 }
 
-// no square brackets
-pub fn (attr Attr) str() string {
+// str returns the string representation without square brackets
+pub fn (a Attr) str() string {
 	mut s := ''
-	if attr.is_comptime_define {
-		s += 'if '
-	}
-	if attr.is_string {
-		s += "'$attr.name'"
+	mut arg := if a.has_arg {
+		s += '$a.name: '
+		a.arg
 	} else {
-		s += attr.name
-		if attr.arg.len > 0 {
-			s += ': '
-			if attr.is_string_arg {
-				a := attr.arg.replace("'", "\\'")
-				s += "'$a'"
-			} else {
-				s += attr.arg
-			}
-		}
+		a.name
+	}
+	s += match a.kind {
+		.plain, .number { arg }
+		.string { "'$arg'" }
+		.comptime_define { 'if $arg' }
 	}
 	return s
 }
 
 pub fn (attrs []Attr) contains(str string) bool {
-	for a in attrs {
-		if a.name == str {
-			return true
-		}
-	}
-	return false
+	return attrs.any(it.name == str)
 }
 
-pub fn (attrs []Attr) has_comptime_define() (bool, string) {
+pub fn (attrs []Attr) find_comptime_define() ?string {
 	for a in attrs {
-		if a.is_comptime_define {
-			return true, a.name
+		if a.kind == .comptime_define {
+			return a.name
 		}
 	}
-	return false, ''
+	return none
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6460,12 +6460,9 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 		c.main_fn_decl_node = node
 	}
 	if node.return_type != ast.void_type {
-		for attr in node.attrs {
-			if attr.is_comptime_define {
-				c.error('only functions that do NOT return values can have `[if $attr.name]` tags',
-					node.pos)
-				break
-			}
+		if ct_name := node.attrs.find_comptime_define() {
+			c.error('only functions that do NOT return values can have `[if $ct_name]` tags',
+				node.pos)
 		}
 	}
 	if node.is_method {

--- a/vlib/v/gen/c/sql.v
+++ b/vlib/v/gen/c/sql.v
@@ -1075,7 +1075,7 @@ fn (mut g Gen) parse_db_from_type_string(name string) SqlType {
 fn (mut g Gen) get_sql_field_type(field ast.StructField) ast.Type {
 	mut typ := field.typ
 	for attr in field.attrs {
-		if attr.name == 'sql' && !attr.is_string_arg && attr.arg != '' {
+		if attr.kind == .plain && attr.name == 'sql' && attr.arg != '' {
 			if attr.arg.to_lower() == 'serial' {
 				typ = ast.Type(-1)
 				break
@@ -1090,7 +1090,7 @@ fn (mut g Gen) get_table_name(table_expr ast.TypeNode) string {
 	info := g.table.get_type_symbol(table_expr.typ).struct_info()
 	mut tablename := util.strip_mod_name(g.table.get_type_symbol(table_expr.typ).name)
 	for attr in info.attrs {
-		if attr.name == 'table' && attr.is_string_arg && attr.arg != '' {
+		if attr.kind == .string && attr.name == 'table' && attr.arg != '' {
 			tablename = attr.arg
 			break
 		}
@@ -1112,7 +1112,7 @@ fn (mut g Gen) get_struct_field(name string) ast.StructField {
 fn (mut g Gen) get_field_name(field ast.StructField) string {
 	mut name := field.name
 	for attr in field.attrs {
-		if attr.name == 'sql' && attr.is_string_arg && attr.arg != '' {
+		if attr.kind == .string && attr.name == 'sql' && attr.arg != '' {
 			name = attr.arg
 			break
 		}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -177,7 +177,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	is_manualfree := p.is_manualfree || p.attrs.contains('manualfree')
 	is_deprecated := p.attrs.contains('deprecated')
 	is_direct_arr := p.attrs.contains('direct_array_access')
-	is_conditional, conditional_ctdefine := p.attrs.has_comptime_define()
+	conditional_ctdefine := p.attrs.find_comptime_define() or { '' }
 	mut is_unsafe := p.attrs.contains('unsafe')
 	is_keep_alive := p.attrs.contains('keep_args_alive')
 	is_pub := p.tok.kind == .key_pub
@@ -349,7 +349,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 			is_unsafe: is_unsafe
 			is_main: is_main
 			is_test: is_test
-			is_conditional: is_conditional
+			is_conditional: conditional_ctdefine != ''
 			is_keep_alive: is_keep_alive
 			ctdefine: conditional_ctdefine
 			no_body: no_body
@@ -378,7 +378,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 			is_unsafe: is_unsafe
 			is_main: is_main
 			is_test: is_test
-			is_conditional: is_conditional
+			is_conditional: conditional_ctdefine != ''
 			is_keep_alive: is_keep_alive
 			ctdefine: conditional_ctdefine
 			no_body: no_body
@@ -421,7 +421,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		is_variadic: is_variadic
 		is_main: is_main
 		is_test: is_test
-		is_conditional: is_conditional
+		is_conditional: conditional_ctdefine != ''
 		is_keep_alive: is_keep_alive
 		receiver: ast.StructField{
 			name: rec.name

--- a/vlib/v/parser/tests/invalid_attribute_a.out
+++ b/vlib/v/parser/tests/invalid_attribute_a.out
@@ -1,0 +1,5 @@
+vlib/v/parser/tests/invalid_attribute_a.vv:1:9: error: unexpected token `]`, an argument is expected after `:`
+    1 | [foobar:]
+      |         ^
+    2 | fn my_fn_with_invalid_attr() {
+    3 | }

--- a/vlib/v/parser/tests/invalid_attribute_a.vv
+++ b/vlib/v/parser/tests/invalid_attribute_a.vv
@@ -1,0 +1,3 @@
+[foobar:]
+fn my_fn_with_invalid_attr() {
+}

--- a/vlib/v/parser/tests/invalid_attribute_b.out
+++ b/vlib/v/parser/tests/invalid_attribute_b.out
@@ -1,0 +1,5 @@
+vlib/v/parser/tests/invalid_attribute_b.vv:1:6: error: unexpected token `:`, an argument is expected after `:`
+    1 | [foo::]
+      |      ^
+    2 | fn my_fn_with_invalid_attr() {
+    3 | }

--- a/vlib/v/parser/tests/invalid_attribute_b.vv
+++ b/vlib/v/parser/tests/invalid_attribute_b.vv
@@ -1,0 +1,3 @@
+[foo::]
+fn my_fn_with_invalid_attr() {
+}

--- a/vlib/v/parser/tests/invalid_attribute_c.out
+++ b/vlib/v/parser/tests/invalid_attribute_c.out
@@ -1,0 +1,5 @@
+vlib/v/parser/tests/invalid_attribute_c.vv:1:6: error: unexpected token `[`, an argument is expected after `:`
+    1 | [bar:[]
+      |      ^
+    2 | fn my_fn_with_invalid_attr() {
+    3 | }

--- a/vlib/v/parser/tests/invalid_attribute_c.vv
+++ b/vlib/v/parser/tests/invalid_attribute_c.vv
@@ -1,0 +1,3 @@
+[bar:[]
+fn my_fn_with_invalid_attr() {
+}

--- a/vlib/v/parser/tests/invalid_attribute_d.out
+++ b/vlib/v/parser/tests/invalid_attribute_d.out
@@ -1,0 +1,5 @@
+vlib/v/parser/tests/invalid_attribute_d.vv:1:9: error: unexpected token `}`, an argument is expected after `:`
+    1 | [foobar:}
+      |         ^
+    2 | fn my_fn_with_invalid_attr() {
+    3 | }

--- a/vlib/v/parser/tests/invalid_attribute_d.vv
+++ b/vlib/v/parser/tests/invalid_attribute_d.vv
@@ -1,0 +1,3 @@
+[foobar:}
+fn my_fn_with_invalid_attr() {
+}


### PR DESCRIPTION
Use an enum `AttrKind` instead of 4 orthogonal flags in attributes.
I also:
- removed the warnings on the `unsafe_fn`, `trusted_fn` and `ref_only` attributes, since they've been deprecated for so long.
- added some parser tests for malformed attributes with arguments

~~I'm waiting for @LouisSchmieder's #9835 to be merged before marking this as ready.~~