### PR TITLE
CHANGELOG.md: remove unimplemented "Closures".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,6 @@ files with compilation errors.
 - High order functions improvements (functions can now be returned etc).
 - Anonymous functions that can be defined inside other functions.
 - Built-in JSON module is back.
-- Closures.
 - Lots and lots of new tests added, including output tests that test error messages.
 - Multiple errors are now printed, the compiler no longer stops after the first error.
 - The new JS backend using the AST parser (almost complete).


### PR DESCRIPTION
I just spent an hour porting over some toy project to V, only
to realize that closures are not supported at all.

See also
  https://github.com/vlang/v/issues/4753
  https://github.com/vlang/v/issues/5960
  https://github.com/vlang/v/issues/7740



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
