### PR TITLE
v.checker: add error for `-not_a_number`

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -328,12 +328,6 @@ pub fn (typ Type) is_number() bool {
 	return typ.clear_flags() in ast.number_type_idxs
 }
 
-pub fn (typ Type) is_number_or_literal() bool {
-	res := int(typ) in ast.number_type_idxs
-	eprintln('> is_number_or_literal typ: $typ.debug() | res: $res')
-	return res
-}
-
 [inline]
 pub fn (typ Type) is_string() bool {
 	return typ.idx() in ast.string_type_idxs

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5867,14 +5867,19 @@ pub fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 	if node.op == .not && right_type != ast.bool_type_idx && !c.pref.translated {
 		c.error('! operator can only be used with bool types', node.pos)
 	}
+	// FIXME
+	// there are currently other issues to investigate if right_type
+	// is unwraped directly as initialization, so do it here
+	right_sym := c.table.get_final_type_symbol(c.unwrap_generic(right_type))
+	if node.op == .minus && !right_sym.is_number() {
+		c.error('- operator can only be used with number types', node.pos)
+	}
 	if node.op == .arrow {
-		right := c.table.get_type_symbol(right_type)
-		if right.kind == .chan {
+		if right_sym.kind == .chan {
 			c.stmts(node.or_block.stmts)
-			return right.chan_info().elem_type
-		} else {
-			c.error('<- operator can only be used with `chan` types', node.pos)
+			return right_sym.chan_info().elem_type
 		}
+		c.error('<- operator can only be used with `chan` types', node.pos)
 	}
 	return right_type
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5872,7 +5872,7 @@ pub fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 	// is unwraped directly as initialization, so do it here
 	right_sym := c.table.get_final_type_symbol(c.unwrap_generic(right_type))
 	if node.op == .minus && !right_sym.is_number() {
-		c.error('- operator can only be used with number types', node.pos)
+		c.error('- operator can only be used with numeric types', node.pos)
 	}
 	if node.op == .arrow {
 		if right_sym.kind == .chan {

--- a/vlib/v/checker/tests/minus_op_wrong_type_err.out
+++ b/vlib/v/checker/tests/minus_op_wrong_type_err.out
@@ -1,42 +1,62 @@
-vlib/v/checker/tests/minus_op_wrong_type_err.vv:3:13: error: mismatched types `Aaa` and `int literal`
-    1 | struct Aaa{}
-    2 | fn main() {
-    3 |     println(Aaa{} - 10)
+vlib/v/checker/tests/minus_op_wrong_type_err.vv:10:10: error: mismatched types `Aaa` and `int literal`
+    8 |
+    9 | fn main() {
+   10 |     println(Aaa{} - 10)
       |             ~~~~~~~~~~
-    4 |     println(10 - Aaa{})
-    5 |     println([1,2,3] - 10)
-vlib/v/checker/tests/minus_op_wrong_type_err.vv:4:13: error: mismatched types `int literal` and `Aaa`
-    2 | fn main() {
-    3 |     println(Aaa{} - 10)
-    4 |     println(10 - Aaa{})
+   11 |     println(10 - Aaa{})
+   12 |     println([1, 2, 3] - 10)
+vlib/v/checker/tests/minus_op_wrong_type_err.vv:11:10: error: mismatched types `int literal` and `Aaa`
+    9 | fn main() {
+   10 |     println(Aaa{} - 10)
+   11 |     println(10 - Aaa{})
       |             ~~~~~~~~~~
-    5 |     println([1,2,3] - 10)
-    6 |     println(10 - [1,2,3])
-vlib/v/checker/tests/minus_op_wrong_type_err.vv:5:13: error: mismatched types `[]int` and `int literal`
-    3 |     println(Aaa{} - 10)
-    4 |     println(10 - Aaa{})
-    5 |     println([1,2,3] - 10)
-      |             ~~~~~~~~~~~~
-    6 |     println(10 - [1,2,3])
-    7 |     a := map[string]int
-vlib/v/checker/tests/minus_op_wrong_type_err.vv:6:13: error: mismatched types `int literal` and `[]int`
-    4 |     println(10 - Aaa{})
-    5 |     println([1,2,3] - 10)
-    6 |     println(10 - [1,2,3])
-      |             ~~~~~~~~~~~~
-    7 |     a := map[string]int
-    8 |     println(a - 10)
-vlib/v/checker/tests/minus_op_wrong_type_err.vv:8:13: error: mismatched types `map[string]int` and `int literal`
-    6 |     println(10 - [1,2,3])
-    7 |     a := map[string]int
-    8 |     println(a - 10)
+   12 |     println([1, 2, 3] - 10)
+   13 |     println(10 - [1, 2, 3])
+vlib/v/checker/tests/minus_op_wrong_type_err.vv:12:10: error: mismatched types `[]int` and `int literal`
+   10 |     println(Aaa{} - 10)
+   11 |     println(10 - Aaa{})
+   12 |     println([1, 2, 3] - 10)
+      |             ~~~~~~~~~~~~~~
+   13 |     println(10 - [1, 2, 3])
+   14 |     a := map[string]int{}
+vlib/v/checker/tests/minus_op_wrong_type_err.vv:13:10: error: mismatched types `int literal` and `[]int`
+   11 |     println(10 - Aaa{})
+   12 |     println([1, 2, 3] - 10)
+   13 |     println(10 - [1, 2, 3])
+      |             ~~~~~~~~~~~~~~
+   14 |     a := map[string]int{}
+   15 |     println(a - 10)
+vlib/v/checker/tests/minus_op_wrong_type_err.vv:15:10: error: mismatched types `map[string]int` and `int literal`
+   13 |     println(10 - [1, 2, 3])
+   14 |     a := map[string]int{}
+   15 |     println(a - 10)
       |             ~~~~~~
-    9 |     println(10 - a)
-   10 | }
-vlib/v/checker/tests/minus_op_wrong_type_err.vv:9:13: error: mismatched types `int literal` and `map[string]int`
-    7 |     a := map[string]int
-    8 |     println(a - 10)
-    9 |     println(10 - a)
+   16 |     println(10 - a)
+   17 |     println(-Aaa{})
+vlib/v/checker/tests/minus_op_wrong_type_err.vv:16:10: error: mismatched types `int literal` and `map[string]int`
+   14 |     a := map[string]int{}
+   15 |     println(a - 10)
+   16 |     println(10 - a)
       |             ~~~~~~
-   10 | }
-
+   17 |     println(-Aaa{})
+   18 |     println(-a)
+vlib/v/checker/tests/minus_op_wrong_type_err.vv:17:10: error: - operator can only be used with number types
+   15 |     println(a - 10)
+   16 |     println(10 - a)
+   17 |     println(-Aaa{})
+      |             ^
+   18 |     println(-a)
+   19 |     println(-Color.red)
+vlib/v/checker/tests/minus_op_wrong_type_err.vv:18:10: error: - operator can only be used with number types
+   16 |     println(10 - a)
+   17 |     println(-Aaa{})
+   18 |     println(-a)
+      |             ^
+   19 |     println(-Color.red)
+   20 | }
+vlib/v/checker/tests/minus_op_wrong_type_err.vv:19:10: error: - operator can only be used with number types
+   17 |     println(-Aaa{})
+   18 |     println(-a)
+   19 |     println(-Color.red)
+      |             ^
+   20 | }

--- a/vlib/v/checker/tests/minus_op_wrong_type_err.out
+++ b/vlib/v/checker/tests/minus_op_wrong_type_err.out
@@ -40,21 +40,21 @@ vlib/v/checker/tests/minus_op_wrong_type_err.vv:16:10: error: mismatched types `
       |             ~~~~~~
    17 |     println(-Aaa{})
    18 |     println(-a)
-vlib/v/checker/tests/minus_op_wrong_type_err.vv:17:10: error: - operator can only be used with number types
+vlib/v/checker/tests/minus_op_wrong_type_err.vv:17:10: error: - operator can only be used with numeric types
    15 |     println(a - 10)
    16 |     println(10 - a)
    17 |     println(-Aaa{})
       |             ^
    18 |     println(-a)
    19 |     println(-Color.red)
-vlib/v/checker/tests/minus_op_wrong_type_err.vv:18:10: error: - operator can only be used with number types
+vlib/v/checker/tests/minus_op_wrong_type_err.vv:18:10: error: - operator can only be used with numeric types
    16 |     println(10 - a)
    17 |     println(-Aaa{})
    18 |     println(-a)
       |             ^
    19 |     println(-Color.red)
    20 | }
-vlib/v/checker/tests/minus_op_wrong_type_err.vv:19:10: error: - operator can only be used with number types
+vlib/v/checker/tests/minus_op_wrong_type_err.vv:19:10: error: - operator can only be used with numeric types
    17 |     println(-Aaa{})
    18 |     println(-a)
    19 |     println(-Color.red)

--- a/vlib/v/checker/tests/minus_op_wrong_type_err.vv
+++ b/vlib/v/checker/tests/minus_op_wrong_type_err.vv
@@ -1,10 +1,20 @@
-struct Aaa{}
+struct Aaa {}
+
+enum Color {
+	red
+	green
+	blue
+}
+
 fn main() {
-    println(Aaa{} - 10)
-    println(10 - Aaa{})
-    println([1,2,3] - 10)
-    println(10 - [1,2,3])
-	a := map[string]int
-    println(a - 10)
-    println(10 - a)
+	println(Aaa{} - 10)
+	println(10 - Aaa{})
+	println([1, 2, 3] - 10)
+	println(10 - [1, 2, 3])
+	a := map[string]int{}
+	println(a - 10)
+	println(10 - a)
+	println(-Aaa{})
+	println(-a)
+	println(-Color.red)
 }


### PR DESCRIPTION
Fixes #9849

Even if the test file changes seem big, I actually only formatted the test file, and added this three tests
```
vlib/v/checker/tests/minus_op_wrong_type_err.vv:17:10: error: - operator can only be used with number types
   15 |     println(a - 10)
   16 |     println(10 - a)
   17 |     println(-Aaa{})
      |             ^
   18 |     println(-a)
   19 |     println(-Color.red)
vlib/v/checker/tests/minus_op_wrong_type_err.vv:18:10: error: - operator can only be used with number types
   16 |     println(10 - a)
   17 |     println(-Aaa{})
   18 |     println(-a)
      |             ^
   19 |     println(-Color.red)
   20 | }
vlib/v/checker/tests/minus_op_wrong_type_err.vv:19:10: error: - operator can only be used with number types
   17 |     println(-Aaa{})
   18 |     println(-a)
   19 |     println(-Color.red)
      |             ^
   20 | }
```