### PR TITLE
os: Use GetComputerNameW to retrieve hostname on Windows

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -215,6 +215,8 @@ fn C.SetHandleInformation(hObject voidptr, dwMask u32, dw_flags u32) bool
 
 fn C.ExpandEnvironmentStringsW(lpSrc &u16, lpDst &u16, nSize u32) u32
 
+fn C.GetComputerNameW(&u16, &u32) bool
+
 [trusted]
 fn C.SendMessageTimeout() u32
 

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -390,8 +390,10 @@ pub fn uname() Uname {
 }
 
 pub fn hostname() string {
-	// TODO: use C.GetComputerName(&u16, u32) int instead
-	return execute('cmd /c hostname').output
+	hostname := [255]u16{}
+	size := u32(255)
+	result := C.GetComputerNameW(&hostname[0], &size)
+	return unsafe { string_from_wide(&hostname[0]) }
 }
 
 pub fn loginname() string {

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -392,7 +392,10 @@ pub fn uname() Uname {
 pub fn hostname() string {
 	hostname := [255]u16{}
 	size := u32(255)
-	result := C.GetComputerNameW(&hostname[0], &size)
+	res := C.GetComputerNameW(&hostname[0], &size)
+	if !res {
+		return error(get_error_msg(int(C.GetLastError())))
+	}
 	return unsafe { string_from_wide(&hostname[0]) }
 }
 


### PR DESCRIPTION
This PR changes the implementation of os.hostname to use the Win32 API function GetComputerNameW:

```
pub fn hostname() string {
	hostname := [255]u16{}
	size := u32(255)
	res := C.GetComputerNameW(&hostname[0], &size)
	if !res {
		return error(get_error_msg(int(C.GetLastError())))
	}
	return unsafe { string_from_wide(&hostname[0]) }
}
```

The current implementation:
```
pub fn hostname() string {
	// TODO: use C.GetComputerName(&u16, u32) int instead
	return execute('cmd /c hostname').output
}
```
The definition of GetComputerNameW is added to vlib/builtin/cfns.c.v
