### PR TITLE
checker: fix generics that return reference generics struct (fix #6218)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1449,7 +1449,7 @@ fn (mut c Checker) check_return_generics_struct(return_type ast.Type, mut call_e
 			idx := c.table.type_idxs[nrt]
 			if idx != 0 {
 				c.ensure_type_exists(idx, call_expr.pos) or {}
-				call_expr.return_type = ast.new_type(idx).derive(return_type)
+				call_expr.return_type = ast.new_type(idx).derive(return_type).clear_flag(.generic)
 			} else {
 				mut fields := rts.info.fields.clone()
 				if rts.info.generic_types.len == concrete_types.len {
@@ -1473,7 +1473,7 @@ fn (mut c Checker) check_return_generics_struct(return_type ast.Type, mut call_e
 						mod: c.mod
 						info: info
 					})
-					call_expr.return_type = ast.new_type(stru_idx)
+					call_expr.return_type = ast.new_type(stru_idx).derive(return_type).clear_flag(.generic)
 				}
 			}
 		}

--- a/vlib/v/tests/generics_return_reference_generics_struct_test.v
+++ b/vlib/v/tests/generics_return_reference_generics_struct_test.v
@@ -1,0 +1,15 @@
+struct Foo<T> {
+	data []T
+}
+
+fn new_foo<T>(len int) &Foo<T> {
+	return &Foo{
+		data: []T{len: len}
+	}
+}
+
+fn main() {
+	f := new_foo<int>(4)
+	println(f)
+	assert f.data == [0, 0, 0, 0]
+}

--- a/vlib/v/tests/generics_return_reference_generics_struct_test.v
+++ b/vlib/v/tests/generics_return_reference_generics_struct_test.v
@@ -8,7 +8,7 @@ fn new_foo<T>(len int) &Foo<T> {
 	}
 }
 
-fn main() {
+fn test_generics_return_reference_generics_struct() {
 	f := new_foo<int>(4)
 	println(f)
 	assert f.data == [0, 0, 0, 0]


### PR DESCRIPTION
This PR fix generics that return reference generics struct (fix #6218).

- Fix generics that return reference generics struct.
- Add test.

```vlang
struct Foo<T> {
	data []T
}

fn new_foo<T>(len int) &Foo<T> {
	return &Foo{
		data: []T{len: len}
	}
}

fn main() {
	f := new_foo<int>(4)
	println(f)
	assert f.data == [0, 0, 0, 0]
}

D:\Test\v\tt1>v run .
&Foo<int>{
    data: [0, 0, 0, 0]
}
```