### PR TITLE
os: use C.GetUserNameW for os.loginname() instead + improvements os.uname()

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -217,6 +217,8 @@ fn C.ExpandEnvironmentStringsW(lpSrc &u16, lpDst &u16, nSize u32) u32
 
 fn C.GetComputerNameW(&u16, &u32) bool
 
+fn C.GetUserNameW(&u16, &u32) bool
+
 [trusted]
 fn C.SendMessageTimeout() u32
 

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -590,7 +590,3 @@ fn test_truncate() {
 fn test_hostname() {
 	assert os.hostname().len > 2
 }
-
-fn test_loginname() {
-	assert os.loginname().len > 2
-}

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -590,3 +590,7 @@ fn test_truncate() {
 fn test_hostname() {
 	assert os.hostname().len > 2
 }
+
+fn test_loginname() {
+	assert os.loginname().len > 2
+}


### PR DESCRIPTION
This PR changes os.loginname() to use Win32 API functions instead. Also there are changes on os.uname() to use hostname() and getenv()

-added flag to advapi32 DLL for TCC
-improvements to uname()
-use Win32 API for loginname()

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
