### PR TITLE
io: add io copy function

### DIFF
--- a/vlib/io/io.v
+++ b/vlib/io/io.v
@@ -1,0 +1,17 @@
+module io
+
+const (
+	buf_max_len = 5 * 1024
+)
+
+pub fn cp(dst Writer, src Reader) ? {
+	mut buf := read_all(reader: src) or {
+		return err
+	}
+	dst.write(buf) or {
+		return
+	}
+	unsafe {
+		buf.free()
+	}
+}

--- a/vlib/io/io_test.v
+++ b/vlib/io/io_test.v
@@ -1,0 +1,43 @@
+import io
+
+struct Buf {
+pub:
+	bytes []byte
+mut:
+	i int
+}
+
+struct Writ {
+pub mut:
+	bytes []byte
+}
+
+fn (mut b Buf) read(mut buf []byte) ?int {
+	if !(b.i < b.bytes.len) {
+		return none
+	}
+	n := copy(buf, b.bytes[b.i..])
+	b.i += n
+	return n
+}
+
+fn (mut w Writ) write(buf []byte) ?int {
+	if buf.len <= 0 {
+		return none
+	}
+	w.bytes << buf
+	return buf.len
+}
+
+fn test_copy() {
+	src := Buf{
+		bytes: 'abcdefghij'.repeat(10).bytes()
+	}
+	dst := Writ{
+		bytes: []byte{}
+	}
+	io.cp(dst, src) or {
+		assert false
+	}
+	assert dst.bytes == src.bytes
+}


### PR DESCRIPTION
This PR add's a io copy function `cp` which copies a reader src directly to a writer destination