### PR TITLE
parser: parse `JS.` interfaces properly

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -264,6 +264,7 @@ pub struct InterfaceDecl {
 pub:
 	name         string
 	name_pos     token.Position
+	language     Language
 	field_names  []string
 	is_pub       bool
 	methods      []FnDecl

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -352,14 +352,18 @@ pub fn (mut c Checker) sum_type_decl(node ast.SumTypeDecl) {
 pub fn (mut c Checker) interface_decl(decl ast.InterfaceDecl) {
 	c.check_valid_pascal_case(decl.name, 'interface name', decl.pos)
 	for method in decl.methods {
-		c.check_valid_snake_case(method.name, 'method name', method.pos)
+		if decl.language == .v {
+			c.check_valid_snake_case(method.name, 'method name', method.pos)
+		}
 		c.ensure_type_exists(method.return_type, method.return_type_pos) or { return }
 		for param in method.params {
 			c.ensure_type_exists(param.typ, param.pos) or { return }
 		}
 	}
 	for i, field in decl.fields {
-		c.check_valid_snake_case(field.name, 'field name', field.pos)
+		if decl.language == .v {
+			c.check_valid_snake_case(field.name, 'field name', field.pos)
+		}
 		c.ensure_type_exists(field.typ, field.pos) or { return }
 		for j in 0 .. i {
 			if field.name == decl.fields[j].name {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1149,8 +1149,10 @@ pub fn (mut f Fmt) interface_decl(node ast.InterfaceDecl) {
 	if node.is_pub {
 		f.write('pub ')
 	}
+	f.write('interface ')
+	f.write_language_prefix(node.language)
 	name := node.name.after('.')
-	f.write('interface $name {')
+	f.write('$name {')
 	if node.fields.len > 0 || node.methods.len > 0 || node.pos.line_nr < node.pos.last_line {
 		f.writeln('')
 	}


### PR DESCRIPTION
this (for example) now works:

```v
interface JS.HTMLElement {
    innerText string
    addEventListener()
    removeEventListener()
}
```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
