### PR TITLE
cgen: fix generics multi_array in (fix #7451)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -453,9 +453,10 @@ fn (mut g Gen) gen_array_prepend(node ast.CallExpr) {
 }
 
 fn (mut g Gen) gen_array_contains_method(left_type ast.Type) string {
-	mut left_sym := g.table.get_type_symbol(left_type)
-	left_final_sym := g.table.get_final_type_symbol(left_type)
-	mut left_type_str := g.typ(left_type).replace('*', '')
+	unwrap_left_type := g.unwrap_generic(left_type)
+	mut left_sym := g.table.get_type_symbol(unwrap_left_type)
+	left_final_sym := g.table.get_final_type_symbol(unwrap_left_type)
+	mut left_type_str := g.typ(unwrap_left_type).replace('*', '')
 	fn_name := '${left_type_str}_contains'
 	if !left_sym.has_method('contains') {
 		left_info := left_final_sym.info as ast.Array
@@ -494,7 +495,7 @@ fn (mut g Gen) gen_array_contains_method(left_type ast.Type) string {
 		left_sym.register_method(&ast.Fn{
 			name: 'contains'
 			params: [ast.Param{
-				typ: left_type
+				typ: unwrap_left_type
 			}, ast.Param{
 				typ: left_info.elem_type
 			}]
@@ -517,8 +518,9 @@ fn (mut g Gen) gen_array_contains(node ast.CallExpr) {
 }
 
 fn (mut g Gen) gen_array_index_method(left_type ast.Type) string {
-	mut left_sym := g.table.get_type_symbol(left_type)
-	mut left_type_str := g.typ(left_type).trim('*')
+	unwrap_left_type := g.unwrap_generic(left_type)
+	mut left_sym := g.table.get_type_symbol(unwrap_left_type)
+	mut left_type_str := g.typ(unwrap_left_type).trim('*')
 	fn_name := '${left_type_str}_index'
 	if !left_sym.has_method('index') {
 		info := left_sym.info as ast.Array
@@ -557,7 +559,7 @@ fn (mut g Gen) gen_array_index_method(left_type ast.Type) string {
 		left_sym.register_method(&ast.Fn{
 			name: 'index'
 			params: [ast.Param{
-				typ: left_type
+				typ: unwrap_left_type
 			}, ast.Param{
 				typ: info.elem_type
 			}]

--- a/vlib/v/tests/generics_multi_array_in_test.v
+++ b/vlib/v/tests/generics_multi_array_in_test.v
@@ -1,0 +1,14 @@
+fn include<T>(a T, b []T) bool {
+	return a in b
+}
+
+fn test_generics_multi_array_in() {
+	println(include(1, [1]))
+	assert include(1, [1])
+
+	println(include([1], [[1]]))
+	assert include([1], [[1]])
+
+	println(include([[1]], [[[1]]]))
+	assert include([[1]], [[[1]]])
+}


### PR DESCRIPTION
This PR fix generics multi_array in (fix #7451).

- Fix generics multi_array in.
- Add test.

```vlang
fn include<T>(a T, b []T) bool {
	return a in b
}

fn main() {
	println(include(1, [1]))
	assert include(1, [1])

	println(include([1], [[1]]))
	assert include([1], [[1]])

	println(include([[1]], [[[1]]]))
	assert include([[1]], [[[1]]])
}

D:\Test\v\tt1>v run .
true
true
true
```