### PR TITLE
parser: improve error message for missing db expr in ORM

### DIFF
--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -8,6 +8,12 @@ import v.vet
 import v.token
 
 pub fn (mut p Parser) expr(precedence int) ast.Expr {
+	return p.check_expr(precedence) or {
+		p.error_with_pos('invalid expression: unexpected $p.tok', p.tok.position())
+	}
+}
+
+pub fn (mut p Parser) check_expr(precedence int) ?ast.Expr {
 	$if trace_parser ? {
 		tok_pos := p.tok.position()
 		eprintln('parsing file: ${p.file_name:-30} | tok.kind: ${p.tok.kind:-10} | tok.lit: ${p.tok.lit:-10} | tok_pos: ${tok_pos.str():-45} | expr($precedence)')
@@ -323,7 +329,8 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 		else {
 			if p.tok.kind != .eof && !(p.tok.kind == .rsbr && p.inside_asm) {
 				// eof should be handled where it happens
-				return p.error_with_pos('invalid expression: unexpected $p.tok', p.tok.position())
+				return none
+				// return p.error_with_pos('invalid expression: unexpected $p.tok', p.tok.position())
 			}
 		}
 	}

--- a/vlib/v/parser/sql.v
+++ b/vlib/v/parser/sql.v
@@ -9,7 +9,10 @@ fn (mut p Parser) sql_expr() ast.Expr {
 	// `sql db {`
 	pos := p.tok.position()
 	p.check_name()
-	db_expr := p.expr(0)
+	db_expr := p.check_expr(0) or {
+		p.error_with_pos('invalid expression: unexpected $p.tok, expecting database',
+			p.tok.position())
+	}
 	p.check(.lcbr)
 	p.check(.key_select)
 	n := p.check_name()
@@ -116,7 +119,10 @@ fn (mut p Parser) sql_stmt() ast.SqlStmt {
 	}
 	// `sql db {`
 	p.check_name()
-	db_expr := p.expr(0)
+	db_expr := p.check_expr(0) or {
+		p.error_with_pos('invalid expression: unexpected $p.tok, expecting database',
+			p.tok.position())
+	}
 	// println(typeof(db_expr))
 	p.check(.lcbr)
 	// kind := ast.SqlExprKind.select_

--- a/vlib/v/parser/tests/sql_no_db_expr_a.out
+++ b/vlib/v/parser/tests/sql_no_db_expr_a.out
@@ -1,0 +1,6 @@
+vlib/v/parser/tests/sql_no_db_expr_a.vv:3:6: error: invalid expression: unexpected token `:=`, expecting database
+    1 | fn x() {
+    2 |     // SqlStmt
+    3 |     sql :=
+      |         ~~
+    4 | }

--- a/vlib/v/parser/tests/sql_no_db_expr_a.vv
+++ b/vlib/v/parser/tests/sql_no_db_expr_a.vv
@@ -1,0 +1,4 @@
+fn x() {
+	// SqlStmt
+	sql :=
+}

--- a/vlib/v/parser/tests/sql_no_db_expr_b.out
+++ b/vlib/v/parser/tests/sql_no_db_expr_b.out
@@ -1,0 +1,6 @@
+vlib/v/parser/tests/sql_no_db_expr_b.vv:3:11: error: invalid expression: unexpected token `:=`
+    1 | fn x() {
+    2 |     // SqlExpr
+    3 |     x := sql :=
+      |              ~~
+    4 | }

--- a/vlib/v/parser/tests/sql_no_db_expr_b.vv
+++ b/vlib/v/parser/tests/sql_no_db_expr_b.vv
@@ -1,0 +1,4 @@
+fn x() {
+	// SqlExpr
+	x := sql :=
+}


### PR DESCRIPTION
> If someone has a better name for `p.check_expr() or {...}` please comment.

close #6258 