### PR TITLE
parser: remove ++/-- exception for vlib modules

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -529,11 +529,13 @@ pub fn (b []byte) hex() string {
 	for i in b {
 		n0 := i >> 4
 		unsafe {
-			hex[dst_i++] = if n0 < 10 { n0 + `0` } else { n0 + byte(87) }
+			hex[dst_i] = if n0 < 10 { n0 + `0` } else { n0 + byte(87) }
+			dst_i++
 		}
 		n1 := i & 0xF
 		unsafe {
-			hex[dst_i++] = if n1 < 10 { n1 + `0` } else { n1 + byte(87) }
+			hex[dst_i] = if n1 < 10 { n1 + `0` } else { n1 + byte(87) }
+			dst_i++
 		}
 	}
 	unsafe {

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -79,15 +79,19 @@ fn (nn int) str_l(max int) string {
 	}
 	mut index := max
 	unsafe {
-		buf[index--] = 0
+		buf[index] = 0
+		index--
 	}
 	for n > 0 {
 		n1 := int(n / 100)
 		d = ((int(n) - (n1 * 100)) << 1)
 		n = n1
 		unsafe {
-			buf[index--] = digit_pairs.str[d++]
-			buf[index--] = digit_pairs.str[d]
+			buf[index] = digit_pairs.str[d]
+			index--
+			d++
+			buf[index] = digit_pairs.str[d]
+			index--
 		}
 	}
 	index++
@@ -145,15 +149,19 @@ pub fn (nn u32) str() string {
 	mut buf := unsafe { malloc(max + 1) }
 	mut index := max
 	unsafe {
-		buf[index--] = 0
+		buf[index] = 0
+		index--
 	}
 	for n > 0 {
 		n1 := n / u32(100)
 		d = ((n - (n1 * u32(100))) << u32(1))
 		n = n1
 		unsafe {
-			buf[index--] = digit_pairs[d++]
-			buf[index--] = digit_pairs[d]
+			buf[index] = digit_pairs[d]
+			index--
+			d++
+			buf[index] = digit_pairs[d]
+			index--
 		}
 	}
 	index++
@@ -191,15 +199,19 @@ pub fn (nn i64) str() string {
 	}
 	mut index := max
 	unsafe {
-		buf[index--] = 0
+		buf[index] = 0
+		index--
 	}
 	for n > 0 {
 		n1 := n / i64(100)
 		d = ((n - (n1 * i64(100))) << i64(1))
 		n = n1
 		unsafe {
-			buf[index--] = digit_pairs[d++]
-			buf[index--] = digit_pairs[d]
+			buf[index] = digit_pairs[d]
+			index--
+			d++
+			buf[index] = digit_pairs[d]
+			index--
 		}
 	}
 	index++
@@ -233,15 +245,19 @@ pub fn (nn u64) str() string {
 	mut buf := vcalloc(max + 1)
 	mut index := max
 	unsafe {
-		buf[index--] = 0
+		buf[index] = 0
+		index--
 	}
 	for n > 0 {
 		n1 := n / 100
 		d = ((n - (n1 * 100)) << 1)
 		n = n1
 		unsafe {
-			buf[index--] = digit_pairs[d++]
-			buf[index--] = digit_pairs[d]
+			buf[index] = digit_pairs[d]
+			index--
+			d++
+			buf[index] = digit_pairs[d]
+			index--
 		}
 	}
 	index++

--- a/vlib/regex/regex.v
+++ b/vlib/regex/regex.v
@@ -483,8 +483,10 @@ fn (re RE) get_char_class(pc int) string {
 
 		if re.cc[cc_i].cc_type == cc_bsls {
 			unsafe {
-				buf_ptr[i++] = `\\`
-				buf_ptr[i++] = byte(re.cc[cc_i].ch0)
+				buf_ptr[i] = `\\`
+				i++
+				buf_ptr[i] = byte(re.cc[cc_i].ch0)
+				i++
 			}
 		}
 		else if re.cc[cc_i].ch0 == re.cc[cc_i].ch1 {
@@ -493,7 +495,8 @@ fn (re RE) get_char_class(pc int) string {
 				x := byte((re.cc[cc_i].ch0 >> (tmp*8)) & 0xFF)
 				if x != 0 {
 					unsafe {
-						buf_ptr[i++] = x
+						buf_ptr[i] = x
+						i++
 					}
 				}
 				tmp--
@@ -505,20 +508,23 @@ fn (re RE) get_char_class(pc int) string {
 				x := byte((re.cc[cc_i].ch0 >> (tmp*8)) & 0xFF)
 				if x != 0 {
 					unsafe {
-						buf_ptr[i++] = x
+						buf_ptr[i] = x
+						i++
 					}
 				}
 				tmp--
 			}
 			unsafe {
-				buf_ptr[i++] = `-`
+				buf_ptr[i] = `-`
+				i++
 			}
 			tmp = 3
 			for tmp >= 0 {
 				x := byte((re.cc[cc_i].ch1 >> (tmp*8)) & 0xFF)
 				if x != 0 {
 					unsafe {
-						buf_ptr[i++] = x
+						buf_ptr[i] = x
+						i++
 					}
 				}
 				tmp--

--- a/vlib/strconv/atof.v
+++ b/vlib/strconv/atof.v
@@ -205,10 +205,12 @@ fn parser(s string) (int,PrepNumber) {
 			// skip the inital zeros
 			fsm_c {
 				if c == c_zero {
-					c = s[i++]
+					c = s[i]
+					i++
 				}
 				else if c == c_dpoint {
-					c = s[i++]
+					c = s[i]
+					i++
 					state = fsm_d
 				}
 				else {
@@ -218,7 +220,8 @@ fn parser(s string) (int,PrepNumber) {
 			// reading leading zeros in the fractional part of mantissa
 			fsm_d {
 				if c == c_zero {
-					c = s[i++]
+					c = s[i]
+					i++
 					if pn.exponent > -2147483647 {
 						pn.exponent--
 					}
@@ -238,10 +241,12 @@ fn parser(s string) (int,PrepNumber) {
 					else if pn.exponent < 2147483647 {
 						pn.exponent++
 					}
-					c = s[i++]
+					c = s[i]
+					i++
 				}
 				else if c == c_dpoint {
-					c = s[i++]
+					c = s[i]
+					i++
 					state = fsm_f
 				}
 				else {
@@ -257,10 +262,12 @@ fn parser(s string) (int,PrepNumber) {
 						pn.exponent--
 						digx++
 					}
-					c = s[i++]
+					c = s[i]
+					i++
 				}
 				else if is_exp(c) {
-					c = s[i++]
+					c = s[i]
+					i++
 					state = fsm_g
 				}
 				else {
@@ -270,18 +277,21 @@ fn parser(s string) (int,PrepNumber) {
 			// reading sign of exponent
 			fsm_g {
 				if c == c_plus {
-					c = s[i++]
+					c = s[i]
+					i++
 				}
 				else if c == c_minus {
 					expneg = true
-					c = s[i++]
+					c = s[i]
+					i++
 				}
 				state = fsm_h
 			}
 			// skipping leading zeros of exponent
 			fsm_h {
 				if c == c_zero {
-					c = s[i++]
+					c = s[i]
+					i++
 				}
 				else {
 					state = fsm_i
@@ -294,7 +304,8 @@ fn parser(s string) (int,PrepNumber) {
 						expexp *= 10
 						expexp += int(c - c_zero)
 					}
-					c = s[i++]
+					c = s[i]
+					i++
 				}
 				else {
 					state = fsm_stop

--- a/vlib/strconv/f32_str.v
+++ b/vlib/strconv/f32_str.v
@@ -114,7 +114,8 @@ pub fn (d Dec32) get_string_32(neg bool, i_n_digit int, i_pad_digit int) string 
 	}
 
 	for fw_zeros > 0 {
-		buf[i++] = `0`
+		buf[i] = `0`
+		i++
 		fw_zeros--
 	}
 

--- a/vlib/strconv/f64_str.v
+++ b/vlib/strconv/f64_str.v
@@ -130,7 +130,8 @@ fn (d Dec64) get_string_64(neg bool, i_n_digit int, i_pad_digit int) string {
 	}
 
 	for fw_zeros > 0 {
-		buf[i++] = `0`
+		buf[i] = `0`
+		i++
 		fw_zeros--
 	}
 

--- a/vlib/strconv/format.v
+++ b/vlib/strconv/format.v
@@ -97,7 +97,8 @@ pub fn f64_to_str_lnd(f f64, dec_digit int) string {
 			i++
 		}
 		else if c >= `0` && c <= `9` {
-			b[i1++] = c
+			b[i1] = c
+			i1++
 			i++
 		} else if c == `.` {
 			if sgn > 0 {
@@ -136,51 +137,59 @@ pub fn f64_to_str_lnd(f f64, dec_digit int) string {
 
 	if sgn == 1 {
 		if m_sgn_flag {
-			res[r_i++] = `+`
+			res[r_i] = `+`
+			r_i++
 		}
 	} else {
-		res[r_i++] = `-`
+		res[r_i] = `-`
+		r_i++
 	}
 
 	i = 0
 	if exp_sgn >= 0 {
 		for b[i] != 0 {
-			res[r_i++] = b[i]
+			res[r_i] = b[i]
+			r_i++
 			i++
 			if i >= d_pos && exp >= 0 {
 				if exp == 0 {
 					dot_res_sp = r_i
-					res[r_i++] = `.`
+					res[r_i] = `.`
+					r_i++
 				}
 				exp--
 			}
 		}
 		for exp >= 0 {
-			res[r_i++] = `0`
+			res[r_i] = `0`
+			r_i++
 			exp--
 		}
 		//println("exp: $exp $r_i $dot_res_sp")
 	} else {
 		mut dot_p := true
 		for exp > 0 {
-			res[r_i++] = `0`
+			res[r_i] = `0`
+			r_i++
 			exp--
 			if dot_p  {
 				dot_res_sp = r_i
-				res[r_i++] = `.`
+				res[r_i] = `.`
+				r_i++
 				dot_p = false
 			}
 		}
 		for b[i] != 0 {
-			res[r_i++] = b[i]
+			res[r_i] = b[i]
+			r_i++
 			i++
 		}
 	}
-	
+
 	// no more digits needed, stop here
-	if dec_digit <= 0 {	
+	if dec_digit <= 0 {
 		return unsafe { tos(res.data, dot_res_sp) }
-	} 
+	}
 
 	//println("r_i-d_pos: ${r_i - d_pos}")
 	if dot_res_sp >= 0 {
@@ -193,9 +202,11 @@ pub fn f64_to_str_lnd(f f64, dec_digit int) string {
 	} else {
 		if dec_digit > 0 {
 			mut c := 0
-			res[r_i++] = `.`
+			res[r_i] = `.`
+			r_i++
 			for c < dec_digit {
-				res[r_i++] = `0`
+				res[r_i] = `0`
+				r_i++
 				c++
 			}
 			res[r_i] = 0

--- a/vlib/strconv/utilities.v
+++ b/vlib/strconv/utilities.v
@@ -260,7 +260,8 @@ pub fn f64_to_str_l(f f64) string {
 			i++
 		}
 		else if c >= `0` && c <= `9` {
-			b[i1++] = c
+			b[i1] = c
+			i1++
 			i++
 		} else if c == `.` {
 			if sgn > 0 {
@@ -298,40 +299,48 @@ pub fn f64_to_str_l(f f64) string {
 
 	if sgn == 1 {
 		if m_sgn_flag {
-			res[r_i++] = `+`
+			res[r_i] = `+`
+			r_i++
 		}
 	} else {
-		res[r_i++] = `-`
+		res[r_i] = `-`
+		r_i++
 	}
 
 	i = 0
 	if exp_sgn >= 0 {
 		for b[i] != 0 {
-			res[r_i++] = b[i]
+			res[r_i] = b[i]
+			r_i++
 			i++
 			if i >= d_pos && exp >= 0 {
 				if exp == 0 {
-					res[r_i++] = `.`
+					res[r_i] = `.`
+					r_i++
 				}
 				exp--
 			}
 		}
 		for exp >= 0 {
-			res[r_i++] = `0`
+			res[r_i] = `0`
+			r_i++
 			exp--
 		}
 	} else {
 		mut dot_p := true
 		for exp > 0 {
-			res[r_i++] = `0`
+			res[r_i] = `0`
+			r_i++
 			exp--
 			if dot_p  {
-				res[r_i++] = `.`
+				res[r_i] = `.`
+				r_i++
 				dot_p = false
 			}
 		}
 		for b[i] != 0 {
-			res[r_i++] = b[i]
+			res[r_i] = b[i]
+			r_i++
 			i++
 		}
 	}

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -772,7 +772,8 @@ fn (mut g JsGen) gen_enum_decl(it ast.EnumDecl) {
 			e := field.expr as ast.IntegerLiteral
 			i = e.val.int()
 		}
-		g.writeln('${i++},')
+		g.writeln('$i,')
+		i++
 	}
 	g.dec_indent()
 	g.writeln('};')

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -419,7 +419,7 @@ pub fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_iden
 		} else if p.tok.kind in [.inc, .dec] || (p.tok.kind == .question && p.inside_ct_if_expr) {
 			// Postfix
 			// detect `f(x++)`, `a[x++]`
-			if p.peek_tok.kind in [.rpar, .rsbr] && p.mod !in ['builtin', 'regex', 'strconv'] { // temp
+			if p.peek_tok.kind in [.rpar, .rsbr] {
 				p.warn_with_pos('`$p.tok.kind` operator can only be used as a statement',
 					p.peek_tok.position())
 			}


### PR DESCRIPTION
Don't allow using `++` and `--` as an expression in 'builtin', 'regex' and 'strconv'
Fixes usages in these modules