### PR TITLE
v: replace `--enable-globals` with `-enable-globals`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,7 +196,7 @@ files with compilation errors.
 - `os.cp()` for copying files and directores.
 - Additional compile-time flags: `$if clang, msvc, mingw, x32, x64, big_endian, little_endian {`.
 - All C functions now have to be declared, all missing C functions have been defined.
-- Global variables (only with the `--enable-globals` flag)
+- Global variables (only with the `-enable-globals` flag)
     for low level applications like kernels and drivers.
 - Nothing can be cast to bool (previously code like `if bool(1) {` worked).
 - `<<` and `>>` now work with all integer types.

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1713,7 +1713,7 @@ immutable by default, even when [references](#references) are passed.
 
 V is not a purely functional language however.
 
-There is a compiler flag to enable global variables (`--enable-globals`), but this is
+There is a compiler flag to enable global variables (`-enable-globals`), but this is
 intended for low-level applications like kernels and drivers.
 
 ### Mutable arguments

--- a/vlib/v/checker/tests/globals_error.out
+++ b/vlib/v/checker/tests/globals_error.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/globals_error.vv:2:1: error: use `v --enable-globals ...` to enable globals
+vlib/v/checker/tests/globals_error.vv:2:1: error: use `v -enable-globals ...` to enable globals
     1 |
     2 | __global ( rfcnt int )
       | ~~~~~~~~

--- a/vlib/v/compiler_errors_test.v
+++ b/vlib/v/compiler_errors_test.v
@@ -75,9 +75,9 @@ fn test_all() {
 	tasks.add('', parser_dir, '-prod', '.out', parser_tests, false)
 	tasks.add('', checker_dir, '-prod', '.out', checker_tests, false)
 	tasks.add('', scanner_dir, '-prod', '.out', scanner_tests, false)
-	tasks.add('', checker_dir, '--enable-globals run', '.run.out', ['globals_error.vv'],
+	tasks.add('', checker_dir, '-enable-globals run', '.run.out', ['globals_error.vv'],
 		false)
-	tasks.add('', global_dir, '--enable-globals', '.out', global_tests, false)
+	tasks.add('', global_dir, '-enable-globals', '.out', global_tests, false)
 	tasks.add('', module_dir, '-prod run', '.out', module_tests, true)
 	tasks.add('', run_dir, 'run', '.run.out', run_tests, false)
 	tasks.run()

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2806,7 +2806,7 @@ fn (mut p Parser) global_decl() ast.GlobalDecl {
 	if !p.pref.translated && !p.pref.is_livemain && !p.builtin_mod && !p.pref.building_v
 		&& p.mod != 'ui' && p.mod != 'gg2' && p.mod != 'uiold' && !p.pref.enable_globals
 		&& !p.pref.is_fmt && p.mod !in parser.global_enabled_mods {
-		p.error('use `v --enable-globals ...` to enable globals')
+		p.error('use `v -enable-globals ...` to enable globals')
 		return ast.GlobalDecl{}
 	}
 	start_pos := p.tok.position()

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -336,7 +336,11 @@ pub fn parse_args(known_external_commands []string, args []string) (&Preferences
 			'-shared' {
 				res.is_shared = true
 			}
-			'--enable-globals', '-enable-globals' {
+			'--enable-globals' {
+				eprintln('`--enable-globals` flag is deprecated, please use `-enable-globals` instead')
+				res.enable_globals = true
+			}
+			'-enable-globals' {
 				res.enable_globals = true
 			}
 			'-autofree' {


### PR DESCRIPTION
For consistency across options, deprecate `--enable-globals` in favor of `-enable-globals`, and replace it's appearance in various places