### PR TITLE
parser: fix alias key

### DIFF
--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -606,6 +606,19 @@ fn test_int_keys() {
 	m3.delete(1)
 }
 
+enum Color {
+	red
+	green
+	blue
+}
+
+type ColorAlias = Color
+
+fn test_alias_enum() {
+	mut m := map[ColorAlias]string{}
+	m[Color.red] = 'hi'
+}
+
 fn test_voidptr_keys() {
 	mut m := map[voidptr]string{}
 	v := 5

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -83,14 +83,14 @@ pub fn (mut p Parser) parse_map_type() ast.Type {
 		// error is reported in parse_type
 		return 0
 	}
-	if is_alias && !(key_type in [ast.string_type_idx, ast.voidptr_type_idx]
-		|| ((key_type.is_int() || key_type.is_float()) && !key_type.is_ptr())) {
-		p.error('cannot use the alias type as the parent type is unsupported')
-		return 0
-	}
-	if !(key_type in [ast.string_type_idx, ast.voidptr_type_idx]
+	key_type_supported := key_type in [ast.string_type_idx, ast.voidptr_type_idx]
 		|| key_sym.kind == .enum_ || ((key_type.is_int() || key_type.is_float()
-		|| is_alias) && !key_type.is_ptr())) {
+		|| is_alias) && !key_type.is_ptr())
+	if !key_type_supported {
+		if is_alias {
+			p.error('cannot use the alias type as the parent type is unsupported')
+			return 0
+		}
 		s := p.table.type_to_str(key_type)
 		p.error_with_pos('maps only support string, integer, float, rune, enum or voidptr keys for now (not `$s`)',
 			p.tok.position())


### PR DESCRIPTION
This code:
```V
enum Color {
	red
	green
	blue
}

type ColorAlias = Color

fn main() {
    mut hooks := map[ColorAlias]string{}
    hooks[Color.red] = "hi"
}
```
Produced
```V
vlib/builtin/map_test.v:618:25: error: cannot use the alias type as the parent type is unsupported
  616 | 
  617 | fn test_alias_enum() {
  618 |     mut m := map[ColorAlias]string{}
      |                            ^
  619 |     m[Color.red] = 'hi'
  620 | }
```

This PR fixes it :slightly_smiling_face: 