### PR TITLE
cgen: fix enum in map

### DIFF
--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -617,6 +617,15 @@ type ColorAlias = Color
 fn test_alias_enum() {
 	mut m := map[ColorAlias]string{}
 	m[Color.red] = 'hi'
+	assert m[Color.red] == 'hi'
+}
+
+fn test_enum_in_map() {
+	mut m := map[Color]string{}
+	m[Color.red] = 'hi'
+	assert Color.red in m
+	assert Color.green !in m
+	assert Color.blue !in m
 }
 
 fn test_voidptr_keys() {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3537,8 +3537,8 @@ fn (mut g Gen) infix_in_or_not_in(node ast.InfixExpr, left_sym ast.TypeSymbol, r
 	} else if right_sym.kind == .map {
 		g.write('_IN_MAP(')
 		if !node.left_type.is_ptr() {
-			left_type_str := g.table.type_to_str(node.left_type)
-			g.write('ADDR($left_type_str, ')
+			styp := g.typ(node.left_type)
+			g.write('ADDR($styp, ')
 			g.expr(node.left)
 			g.write(')')
 		} else {


### PR DESCRIPTION
This
```V
fn test_enum_in_map() {
	mut m := map[Color]string{}
	m[Color.red] = 'hi'
	assert Color.red in m
	assert Color.green !in m
	assert Color.blue !in m
}
```
Produced
```
==================
/tmp/v/map_test.18276831521540129350.tmp.c:21109: error: 'main' undeclared
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
```
This PR fixes it :slightly_smiling_face: 

This should fix: https://github.com/vlang/v/issues/9627
It also fixes https://github.com/vlang/v/issues/9733, when using `Level.panic` instead of `.panic`. The enum short syntax is also a problem for arrays.
