### PR TITLE
checker: enum name of map key can be omitted

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6109,14 +6109,16 @@ pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) ast.Type {
 			typ = typ.set_nr_muls(0)
 		}
 	} else { // [1]
-		index_type := c.expr(node.index)
 		if typ_sym.kind == .map {
 			info := typ_sym.info as ast.Map
+			c.expected_type = info.key_type
+			index_type := c.expr(node.index)
 			if !c.check_types(index_type, info.key_type) {
 				err := c.expected_msg(index_type, info.key_type)
 				c.error('invalid key: $err', node.pos)
 			}
 		} else {
+			index_type := c.expr(node.index)
 			c.check_index(typ_sym, node.index, index_type, node.pos, false)
 		}
 		value_type := c.table.value_type(typ)

--- a/vlib/v/tests/map_enum_keys_test.v
+++ b/vlib/v/tests/map_enum_keys_test.v
@@ -6,10 +6,10 @@ enum Token {
 
 fn test_map_with_enum_keys() {
 	mut m := map[Token]string{}
-	m[Token.aa] = 'abc'
+	m[.aa] = 'abc'
 	m[Token.bb] = 'def'
 	assert m[Token.aa] == 'abc'
-	assert m[Token.bb] == 'def'
+	assert m[.bb] == 'def'
 	//
 	s := '$m'
 	assert s == "{aa: 'abc', bb: 'def'}"


### PR DESCRIPTION
`m[.enum_key]` is not allowed on current master. This PR allow this

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
