### PR TITLE
builtin: fix termux prints

### DIFF
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -119,13 +119,12 @@ pub fn eprintln(s string) {
 			} else {
 				C.fprintf(C.stderr, c'%.*s\n', s.len, s.str)
 			}
-		} $else {
-			if s.str == 0 {
-				_ = C.write(2, c'eprintln(NIL)\n', 14)
-			} else {
-				_ = C.write(2, s.str, s.len)
-				_ = C.write(2, c'\n', 1)
-			}
+		}
+		if s.str == 0 {
+			_ = C.write(2, c'eprintln(NIL)\n', 14)
+		} else {
+			_ = C.write(2, s.str, s.len)
+			_ = C.write(2, c'\n', 1)
 		}
 		C.fflush(C.stderr)
 	}
@@ -156,12 +155,11 @@ pub fn eprint(s string) {
 			} else {
 				C.fprintf(C.stderr, c'%.*s', s.len, s.str)
 			}
-		} $else {
-			if s.str == 0 {
-				_ = C.write(2, c'eprint(NIL)', 11)
-			} else {
-				_ = C.write(2, s.str, s.len)
-			}
+		}
+		if s.str == 0 {
+			_ = C.write(2, c'eprint(NIL)', 11)
+		} else {
+			_ = C.write(2, s.str, s.len)
 		}
 		C.fflush(C.stderr)
 	}
@@ -172,7 +170,8 @@ pub fn eprint(s string) {
 pub fn print(s string) {
 	$if android {
 		C.fprintf(C.stdout, c'%.*s', s.len, s.str)
-	} $else $if ios {
+	}
+	$if ios {
 		// TODO: Implement a buffer as NSLog doesn't have a "print"
 		C.WrappedNSLog(s.str)
 	} $else $if freestanding {


### PR DESCRIPTION
Fix for missing v output on termux/android.
#9662 .

This is a follow up to #9829 .
This should fix normal print(), eprint() and eprintln().