### PR TITLE
gg: fix width and height in draw_rounded_rect primitive

### DIFF
--- a/examples/2048/2048.v
+++ b/examples/2048/2048.v
@@ -623,7 +623,7 @@ fn (app &App) draw_tiles() {
 	toffset := app.ui.tile_size + app.ui.padding_size
 	tiles_size := mu.min(app.ui.window_width, app.ui.window_height) - app.ui.border_size * 2
 	// Draw the padding around the tiles
-	app.gg.draw_rounded_rect(xstart, ystart, tiles_size / 2, tiles_size / 2, tiles_size / 24,
+	app.gg.draw_rounded_rect(xstart, ystart, tiles_size, tiles_size, tiles_size / 24,
 		app.theme.padding_color)
 	// Draw the actual tiles
 	for y in 0 .. 4 {
@@ -640,7 +640,7 @@ fn (app &App) draw_tiles() {
 			th := tw // square tiles, w == h
 			xoffset := xstart + app.ui.padding_size + x * toffset + (app.ui.tile_size - tw) / 2
 			yoffset := ystart + app.ui.padding_size + y * toffset + (app.ui.tile_size - th) / 2
-			app.gg.draw_rounded_rect(xoffset, yoffset, tw / 2, th / 2, tw / 8, tile_color)
+			app.gg.draw_rounded_rect(xoffset, yoffset, tw, th, tw / 8, tile_color)
 			if tidx != 0 { // 0 == blank spot
 				xpos := xoffset + tw / 2
 				ypos := yoffset + th / 2

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -611,7 +611,7 @@ pub fn (ctx &Context) draw_rounded_rect(x f32, y f32, w f32, h f32, radius f32, 
 		sgl.v2f(lx, ly)
 	}
 	// right top
-	mut rx := nx + 2 * width - r
+	mut rx := nx + width - r
 	mut ry := ny + r
 	for i in rt .. int(segments) {
 		theta = 2 * f32(math.pi) * f32(i) / segments
@@ -622,7 +622,7 @@ pub fn (ctx &Context) draw_rounded_rect(x f32, y f32, w f32, h f32, radius f32, 
 	}
 	// right bottom
 	mut rbx := rx
-	mut rby := ny + 2 * height - r
+	mut rby := ny + height - r
 	for i in rb .. lb {
 		theta = 2 * f32(math.pi) * f32(i) / segments
 		xx = r * math.cosf(theta)
@@ -632,7 +632,7 @@ pub fn (ctx &Context) draw_rounded_rect(x f32, y f32, w f32, h f32, radius f32, 
 	}
 	// left bottom
 	mut lbx := lx
-	mut lby := ny + 2 * height - r
+	mut lby := ny + height - r
 	for i in lb .. lt {
 		theta = 2 * f32(math.pi) * f32(i) / segments
 		xx = r * math.cosf(theta)
@@ -678,7 +678,7 @@ pub fn (ctx &Context) draw_empty_rounded_rect(x f32, y f32, w f32, h f32, radius
 		sgl.v2f(xx + lx, yy + ly)
 	}
 	// right top
-	mut rx := nx + 2 * width - r
+	mut rx := nx + width - r
 	mut ry := ny + r
 	for i in rt .. int(segments) {
 		theta = 2 * f32(math.pi) * f32(i) / segments
@@ -688,7 +688,7 @@ pub fn (ctx &Context) draw_empty_rounded_rect(x f32, y f32, w f32, h f32, radius
 	}
 	// right bottom
 	mut rbx := rx
-	mut rby := ny + 2 * height - r
+	mut rby := ny + height - r
 	for i in rb .. lb {
 		theta = 2 * f32(math.pi) * f32(i) / segments
 		xx = r * math.cosf(theta)
@@ -697,7 +697,7 @@ pub fn (ctx &Context) draw_empty_rounded_rect(x f32, y f32, w f32, h f32, radius
 	}
 	// left bottom
 	mut lbx := lx
-	mut lby := ny + 2 * height - r
+	mut lby := ny + height - r
 	for i in lb .. lt {
 		theta = 2 * f32(math.pi) * f32(i) / segments
 		xx = r * math.cosf(theta)


### PR DESCRIPTION
`draw_rounded_rect`and `draw_rounded_empty_rect` are twice the height and the width because of 2 factor in the source code. This PR simply removes its factor.
