### PR TITLE
checker: fix generics with nested external generics fn (fix #8424)

### DIFF
--- a/vlib/v/tests/generics_with_nested_external_generics_fn_test.v
+++ b/vlib/v/tests/generics_with_nested_external_generics_fn_test.v
@@ -1,0 +1,21 @@
+import rand.util
+import rand
+
+pub fn sample<T>(arr []T, k int) []T {
+	mut result := arr.clone()
+
+	rand.seed([u32(1), 2]) // set seed to produce same results in order
+	util.shuffle<T>(mut result, k)
+
+	return result[0..k]
+}
+
+fn test_generics_with_nested_external_generics_fn() {
+	mut arr := [11, 32, 24, 45, 57, 32, 37, 52, 37, 24]
+	println(arr)
+
+	ret := sample<int>(arr, 5)
+	println(ret)
+
+	assert ret == [32, 45, 57, 11, 37]
+}


### PR DESCRIPTION
This PR fix generics with nested external generics fn (fix #8424).

- Fix generics with nested external generics fn.
- Add test.

```vlang
import rand.util
import rand

pub fn sample<T>(arr []T, k int) []T {
	mut result := arr.clone()

	rand.seed([u32(1), 2]) // set seed to produce same results in order
	util.shuffle<T>(mut result, k)

	return result[0..k]
}

fn main() {
	mut arr := [11, 32, 24, 45, 57, 32, 37, 52, 37, 24]
	println(arr)

	ret := sample<int>(arr, 5)
	println(ret)

	assert ret == [32, 45, 57, 11, 37]
}

PS D:\Test\v\tt1> v run .
C:\Users\yuyi9\v\vlib\rand\util\util.v:17:13: warning: unused variable: `v`
   15 |     mut indices := []int{len: n}
   16 |     // Initialize with all indices
   17 |     for i, mut v in indices {
      |                ^
   18 |         v = i
   19 |     }
[11, 32, 24, 45, 57, 32, 37, 52, 37, 24]
[32, 45, 57, 11, 37]
```