### PR TITLE
parser, cgen: fix generics fn typeof name (fix #7357)

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -724,14 +724,17 @@ fn (mut g Gen) gen_str_for_union_sum_type(info ast.SumType, styp string, str_fn_
 fn (mut g Gen) fn_decl_str(info ast.FnType) string {
 	mut fn_str := 'fn ('
 	for i, arg in info.func.params {
+		if arg.is_mut {
+			fn_str += 'mut '
+		}
 		if i > 0 {
 			fn_str += ', '
 		}
-		fn_str += util.strip_main_name(g.table.get_type_name(arg.typ))
+		fn_str += util.strip_main_name(g.table.get_type_name(g.unwrap_generic(arg.typ)))
 	}
 	fn_str += ')'
 	if info.func.return_type != ast.void_type {
-		fn_str += ' ${util.strip_main_name(g.table.get_type_name(info.func.return_type))}'
+		fn_str += ' ${util.strip_main_name(g.table.get_type_name(g.unwrap_generic(info.func.return_type)))}'
 	}
 	return fn_str
 }

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3227,12 +3227,17 @@ fn (mut g Gen) expr(node ast.Expr) {
 }
 
 // T.name, typeof(expr).name
-fn (mut g Gen) type_name(type_ ast.Type) {
-	mut typ := type_
-	if typ.has_flag(.generic) {
-		typ = g.cur_concrete_types[0]
+fn (mut g Gen) type_name(typ ast.Type) {
+	sym := g.table.get_type_symbol(typ)
+	s := if sym.kind == .function {
+		if typ.is_ptr() {
+			'&' + g.fn_decl_str(sym.info as ast.FnType)
+		} else {
+			g.fn_decl_str(sym.info as ast.FnType)
+		}
+	} else {
+		g.table.type_to_str(g.unwrap_generic(typ))
 	}
-	s := g.table.type_to_str(typ)
 	g.write('_SLIT("${util.strip_main_name(s)}")')
 }
 

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3229,14 +3229,15 @@ fn (mut g Gen) expr(node ast.Expr) {
 // T.name, typeof(expr).name
 fn (mut g Gen) type_name(typ ast.Type) {
 	sym := g.table.get_type_symbol(typ)
-	s := if sym.kind == .function {
+	mut s := ''
+	if sym.kind == .function {
 		if typ.is_ptr() {
-			'&' + g.fn_decl_str(sym.info as ast.FnType)
+			s = '&' + g.fn_decl_str(sym.info as ast.FnType)
 		} else {
-			g.fn_decl_str(sym.info as ast.FnType)
+			s = g.fn_decl_str(sym.info as ast.FnType)
 		}
 	} else {
-		g.table.type_to_str(g.unwrap_generic(typ))
+		s = g.table.type_to_str(g.unwrap_generic(typ))
 	}
 	g.write('_SLIT("${util.strip_main_name(s)}")')
 }

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -703,6 +703,8 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 	types_only := p.tok.kind in [.amp, .ellipsis, .key_fn, .lsbr]
 		|| (p.peek_tok.kind == .comma && p.table.known_type(argname))
 		|| p.peek_tok.kind == .dot || p.peek_tok.kind == .rpar
+		|| (p.tok.kind == .key_mut && (p.peek_token(2).kind == .comma
+		|| p.peek_token(2).kind == .rpar))
 	// TODO copy pasta, merge 2 branches
 	if types_only {
 		mut arg_no := 1

--- a/vlib/v/tests/generic_fn_typeof_name_test.v
+++ b/vlib/v/tests/generic_fn_typeof_name_test.v
@@ -1,0 +1,15 @@
+struct Client {}
+
+fn add_handler<T>(handler fn (mut Client, T)) string {
+	return typeof(handler).name
+}
+
+fn on_message(mut client Client, event string) {
+	println(event)
+}
+
+fn test_generics_fn_typeof_name() {
+	ret := add_handler<string>(on_message)
+	println(ret)
+	assert ret == 'fn (mut Client, string)'
+}


### PR DESCRIPTION
This PR fix generics fn typeof name (fix #7357).

- Fix generics fn typeof name.
- Add test.

```vlang
struct Client {}

fn add_handler<T>(handler fn (mut Client, T)) string {
	return typeof(handler).name
}

fn on_message(mut client Client, event string) {
	println(event)
}

fn main() {
	ret := add_handler<string>(on_message)
	println(ret)
	assert ret == 'fn (mut Client, string)'
}

PS D:\Test\v\tt1> v run .
fn (mut Client, string)
```