### PR TITLE
cgen: fix generics fn str() (fix #7403)

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -489,7 +489,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name stri
 		// TODO: this is a bit hacky. styp shouldn't be even parsed with _T_
 		// use something different than g.typ for styp
 		clean_struct_v_type_name =
-			clean_struct_v_type_name.replace('_Array', '_array').replace('_T_', '<').replace('_', ', ') +
+			clean_struct_v_type_name.replace('Array_', '[]').replace('_T_', '<').replace('_', ', ') +
 			'>'
 	}
 	clean_struct_v_type_name = util.strip_main_name(clean_struct_v_type_name)

--- a/vlib/v/tests/generics_test.v
+++ b/vlib/v/tests/generics_test.v
@@ -493,7 +493,7 @@ fn test_generic_detection() {
 	// generic
 	assert multi_generic_args<int, string>(0, 's')
 	assert multi_generic_args<Foo1, Foo2>(Foo1{}, Foo2{})
-	assert multi_generic_args<Foo<int>, Foo<int>>(Foo<int>{}, Foo<int>{})
+	assert multi_generic_args<Foo<int>, Foo<int> >(Foo<int>{}, Foo<int>{})
 	// TODO: assert multi_generic_args<Foo<int>, Foo<int>>(Foo1{}, Foo2{})
 	assert multi_generic_args<simplemodule.Data, int>(simplemodule.Data{}, 0)
 	assert multi_generic_args<int, simplemodule.Data>(0, simplemodule.Data{})

--- a/vlib/v/tests/generics_test.v
+++ b/vlib/v/tests/generics_test.v
@@ -342,7 +342,7 @@ fn test_generic_struct_print_array_as_field() {
 	foo := Foo<[]string>{
 		data: []string{}
 	}
-	assert foo.str() == 'Foo<array, string>{\n    data: []\n}'
+	assert foo.str() == 'Foo<[]string>{\n    data: []\n}'
 }
 
 /*
@@ -493,7 +493,7 @@ fn test_generic_detection() {
 	// generic
 	assert multi_generic_args<int, string>(0, 's')
 	assert multi_generic_args<Foo1, Foo2>(Foo1{}, Foo2{})
-	assert multi_generic_args<Foo<int>, Foo<int> >(Foo<int>{}, Foo<int>{})
+	assert multi_generic_args<Foo<int>, Foo<int>>(Foo<int>{}, Foo<int>{})
 	// TODO: assert multi_generic_args<Foo<int>, Foo<int>>(Foo1{}, Foo2{})
 	assert multi_generic_args<simplemodule.Data, int>(simplemodule.Data{}, 0)
 	assert multi_generic_args<int, simplemodule.Data>(0, simplemodule.Data{})


### PR DESCRIPTION
This PR fix generics fn str() (fix #7403).

- Fix generics fn str().
- Add test.

```vlang
struct Gen<T> {
	foo T
}

struct Foo {
}

fn main() {
	g := Gen<[]Foo>{}
	println(g)
}

PS D:\Test\v\tt1> v run .
Gen<[]Foo>{
    foo: []
}
```