### PR TITLE
ast: minor cleanup in ast.FnDecl

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -379,18 +379,18 @@ pub:
 	attrs           []Attr
 	skip_gen        bool // this function doesn't need to be generated (for example [if foo])
 pub mut:
-	stmts             []Stmt
-	defer_stmts       []DeferStmt
-	return_type       Type
-	return_type_pos   token.Position // `string` in `fn (u User) name() string` position
-	has_return        bool
-	comments          []Comment // comments *after* the header, but *before* `{`; used for InterfaceDecl
-	next_comments     []Comment // coments that are one line after the decl; used for InterfaceDecl
-	source_file       &File = 0
-	scope             &Scope
-	label_names       []string
-	pos               token.Position // function declaration position
-	cur_generic_types []Type
+	stmts              []Stmt
+	defer_stmts        []DeferStmt
+	return_type        Type
+	return_type_pos    token.Position // `string` in `fn (u User) name() string` position
+	has_return         bool
+	comments           []Comment // comments *after* the header, but *before* `{`; used for InterfaceDecl
+	next_comments      []Comment // coments that are one line after the decl; used for InterfaceDecl
+	source_file        &File = 0
+	scope              &Scope
+	label_names        []string
+	pos                token.Position // function declaration position
+	cur_concrete_types []Type // current concrete types, e.g. <int, string>
 }
 
 // break, continue


### PR DESCRIPTION
This PR makes minor cleanup in ast.FnDecl.

- Change `FnDecl.cur_generic_types` to `FnDecl.cur_concrete_types`, because they are current concrete types, e.g. <int, string>.
- Modify related call.