### PR TITLE
v: building on NetBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,11 @@ TCCOS := freebsd
 LDFLAGS += -lexecinfo
 endif
 
+ifeq ($(_SYS),NetBSD)
+TCCOS := netbsd
+LDFLAGS += -lexecinfo
+endif
+
 ifdef ANDROID_ROOT
 ANDROID := 1
 undefine LINUX
@@ -94,10 +99,11 @@ clean:
 	rm -rf $(TMPTCC)
 	rm -rf $(VC)
 
-latest_vc: $(VC)/.git/config
 ifndef local
+latest_vc: $(VC)/.git/config
 	cd $(VC) && $(GITCLEANPULL)
 else
+latest_vc:
 	@echo "Using local vc"
 endif
 
@@ -105,11 +111,12 @@ fresh_vc:
 	rm -rf $(VC)
 	$(GITFASTCLONE) $(VCREPO) $(VC)
 
-latest_tcc: $(TMPTCC)/.git/config
 ifndef ANDROID
 ifndef local
+latest_tcc: $(TMPTCC)/.git/config
 	cd $(TMPTCC) && $(GITCLEANPULL)
 else
+latest_tcc:
 	@echo "Using local tcc"
 endif
 endif

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -386,8 +386,8 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 		if v.pref.os == .linux {
 			ccoptions.linker_flags << '-ldl'
 		}
-		if v.pref.os == .freebsd {
-			// FreeBSD: backtrace needs execinfo library while linking
+		if v.pref.os in [.freebsd, .netbsd] {
+			// Free/NetBSD: backtrace needs execinfo library while linking
 			ccoptions.linker_flags << '-lexecinfo'
 		}
 	}


### PR DESCRIPTION
I like your claim of easy bootstrapping and I'm putting it to the test :-)
    
I'm preparing a pkgsrc package for V. Since pkgsrc doesn't allow network
access during the build, I'm pre-downloading vc and tcc repositories
before starting the build. Then I build with `gmake local=1`.
    
This didn't prevent re-cloning of those repos. This patch improves that.
    
It also adds `LDFLAGS += -lexecinfo` for NetBSD.



NetBSD: backtrace needs execinfo library while linking, like FreeBSD.
    
Running `v test-all` reveals that some more tweaks are needed for extra
linking options (probably more -pthread or -lpthread, and
options for X headers and libraries, which could be in /usr/X11R7 or
/usr/pkg).
I haven't found those out yet.

[typescript.txt](https://github.com/vlang/v/files/6409574/typescript.txt)
