### PR TITLE
[WIP] cgen: check for null when calling function pointers in structs

### DIFF
--- a/vlib/v/tests/struct_fields_storing_functions_test.v
+++ b/vlib/v/tests/struct_fields_storing_functions_test.v
@@ -27,3 +27,28 @@ fn test_struct_fn_field_can_be_used_directly() {
 	eprintln(res)
 	assert res == [byte(0x88), 0x01, 0x02, 0x02, 0x99]
 }
+
+// null check test
+
+struct NullCall {
+mut:
+	nullcall fn ()
+}
+
+fn hello() {
+	println('hello world')
+}
+
+fn null_function() fn () {
+	return NullCall{}.nullcall
+}
+
+fn test_struct_fn_field_can_be_null() {
+	mut a := NullCall{hello}
+	a.nullcall()
+	a.nullcall = null_function()
+	a.nullcall() // not segfault
+	unsafe {
+		a.nullcall() // do segfault
+	}
+}


### PR DESCRIPTION
See test case, there are some tests that are not passing because the check is not done properly for some scopes.

Also I think it would be interesting to avoid having those checks for `unsafe {}` blocks.

See the test as an example

Current fail:

```
/tmp/v/v2.15775295321930989009.tmp.c: In function ‘array map_keys(map*)’:
26
/tmp/v/v2.15775295321930989009.tmp.c:14836:62: error: second operand to the conditional operator is of type ‘void’, but the third operand is neither a throw-expression nor of type ‘void’
27
14836 |     /* null check */ (m->clone_fn)? m->clone_fn(item, pkey): 0;
28
      |                                                              ^
```

I'm happy if anyone with more knowledge on the compiler internals and spare time can take my PR and finish it+merge. otherwise i will need to clarify the following things:

* How to check if the call is inside an `unsafe{}` block?
* Do we want to get a warning at runtime (or assert) instead of silently not calling the function if the pointer is null?
* Should this catch `or {}` blocks for this too?
* May -prod builds not check for this?