### PR TITLE
checker: check generic struct declaration (fix #9974)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -523,8 +523,12 @@ pub fn (mut c Checker) struct_decl(mut decl ast.StructDecl) {
 		c.check_valid_pascal_case(decl.name, 'struct name', decl.pos)
 	}
 	mut struct_sym := c.table.find_type(decl.name) or { ast.TypeSymbol{} }
+	mut has_generic_types := false
 	if mut struct_sym.info is ast.Struct {
 		for embed in decl.embeds {
+			if embed.typ.has_flag(.generic) {
+				has_generic_types = true
+			}
 			embed_sym := c.table.get_type_symbol(embed.typ)
 			if embed_sym.kind != .struct_ {
 				c.error('`$embed_sym.name` is not a struct', embed.pos)
@@ -542,6 +546,9 @@ pub fn (mut c Checker) struct_decl(mut decl ast.StructDecl) {
 		}
 		for i, field in decl.fields {
 			c.ensure_type_exists(field.typ, field.type_pos) or { return }
+			if field.typ.has_flag(.generic) {
+				has_generic_types = true
+			}
 			if decl.language == .v {
 				c.check_valid_snake_case(field.name, 'field name', field.pos)
 			}
@@ -592,6 +599,10 @@ pub fn (mut c Checker) struct_decl(mut decl ast.StructDecl) {
 					}
 				}
 			}
+		}
+		if decl.generic_types.len == 0 && has_generic_types {
+			c.error('generic struct declaration must specify the generic type names, e.g. Foo<T>',
+				decl.pos)
 		}
 	}
 }

--- a/vlib/v/checker/tests/generics_struct_declaration_err.out
+++ b/vlib/v/checker/tests/generics_struct_declaration_err.out
@@ -5,10 +5,3 @@ vlib/v/checker/tests/generics_struct_declaration_err.vv:5:1: error: generic stru
       | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     6 |     GenericChannelStruct<T>
     7 |     msg string
-vlib/v/checker/tests/generics_struct_declaration_err.vv:15:2: error: unused variable: `d`
-   13 |
-   14 | fn main() {
-   15 |     d := new_channel_struct<Simple>()
-      |     ^
-   16 | }
-   17 |

--- a/vlib/v/checker/tests/generics_struct_declaration_err.out
+++ b/vlib/v/checker/tests/generics_struct_declaration_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/generics_struct_declaration_err.vv:5:1: error: generic struct declaration must specify the generic type names, e.g. Foo<T>
+    3 | }
+    4 |
+    5 | struct MyGenericChannelStruct {
+      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    6 |     GenericChannelStruct<T>
+    7 |     msg string
+vlib/v/checker/tests/generics_struct_declaration_err.vv:15:2: error: unused variable: `d`
+   13 |
+   14 | fn main() {
+   15 |     d := new_channel_struct<Simple>()
+      |     ^
+   16 | }
+   17 |

--- a/vlib/v/checker/tests/generics_struct_declaration_err.vv
+++ b/vlib/v/checker/tests/generics_struct_declaration_err.vv
@@ -12,7 +12,7 @@ struct Simple {
 }
 
 fn main() {
-	d := new_channel_struct<Simple>()
+	new_channel_struct<Simple>()
 }
 
 pub fn new_channel_struct<T>() GenericChannelStruct<T> {

--- a/vlib/v/checker/tests/generics_struct_declaration_err.vv
+++ b/vlib/v/checker/tests/generics_struct_declaration_err.vv
@@ -1,0 +1,24 @@
+struct GenericChannelStruct<T> {
+	ch chan T
+}
+
+struct MyGenericChannelStruct {
+	GenericChannelStruct<T>
+	msg string
+}
+
+struct Simple {
+	msg string
+}
+
+fn main() {
+	d := new_channel_struct<Simple>()
+}
+
+pub fn new_channel_struct<T>() GenericChannelStruct<T> {
+	d := GenericChannelStruct{
+		ch: chan T{}
+	}
+
+	return d
+}


### PR DESCRIPTION
This PR check generic struct declaration (fix #9974).

- Check generic struct declaration without generic type names.
- Add test.

```vlang
struct GenericChannelStruct<T> {
	ch chan T
}

struct MyGenericChannelStruct {
	GenericChannelStruct<T>
	msg string
}

struct Simple {
	msg string
}

fn main() {
	new_channel_struct<Simple>()
}

pub fn new_channel_struct<T>() GenericChannelStruct<T> {
	d := GenericChannelStruct{
		ch: chan T{}
	}

	return d
}

PS D:\Test\v\tt1> v run .
.\tt1.v:5:1: error: generic struct declaration must specify the generic type names, e.g. Foo<T>
    3 | }
    4 | 
    5 | struct MyGenericChannelStruct {
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    6 |     GenericChannelStruct<T>
    7 |     msg string
```