### PR TITLE
checker: check generics fn that return generic struct (fix #9972)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6794,6 +6794,15 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 			c.error('only functions that do NOT return values can have `[if $ct_name]` tags',
 				node.pos)
 		}
+		if node.generic_names.len > 0 {
+			gs := c.table.get_type_symbol(node.return_type)
+			if gs.info is ast.Struct {
+				if gs.info.is_generic && !node.return_type.has_flag(.generic) {
+					c.error('return generic struct in fn declaration must specify the generic type names, e.g. Foo<T>',
+						node.return_type_pos)
+				}
+			}
+		}
 	}
 	if node.is_method {
 		mut sym := c.table.get_type_symbol(node.receiver.typ)

--- a/vlib/v/checker/tests/generics_fn_return_generic_struct_err.out
+++ b/vlib/v/checker/tests/generics_fn_return_generic_struct_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/generics_fn_return_generic_struct_err.vv:13:32: error: return generic struct in fn declaration must specify the generic type names, e.g. Foo<T>
+   11 | }
+   12 |
+   13 | pub fn new_channel_struct<T>() GenericChannelStruct {
+      |                                ~~~~~~~~~~~~~~~~~~~~
+   14 |     d := GenericChannelStruct{
+   15 |         ch: chan T{}

--- a/vlib/v/checker/tests/generics_fn_return_generic_struct_err.vv
+++ b/vlib/v/checker/tests/generics_fn_return_generic_struct_err.vv
@@ -1,0 +1,18 @@
+struct GenericChannelStruct<T> {
+	ch chan T
+}
+
+struct Simple {
+	msg string
+}
+
+fn main() {
+	new_channel_struct<Simple>()
+}
+
+pub fn new_channel_struct<T>() GenericChannelStruct {
+	d := GenericChannelStruct{
+		ch: chan T{}
+	}
+	return d
+}


### PR DESCRIPTION
This PR check generics fn that return generic struct (fix #9972).

- Check generics fn that return generic struct.
- Add test.

```vlang
struct GenericChannelStruct<T> {
	ch chan T
}

struct Simple {
	msg string
}

fn main() {
	new_channel_struct<Simple>()
}

pub fn new_channel_struct<T>() GenericChannelStruct {
	d := GenericChannelStruct{
		ch: chan T{}
	}
	return d
}

.\tt1.v:13:32: error: return generic struct in fn declaration must specify the generic type names, e.g. Foo<T>
   11 | }
   12 |
   13 | pub fn new_channel_struct<T>() GenericChannelStruct {
      |                                ~~~~~~~~~~~~~~~~~~~~
   14 |     d := GenericChannelStruct{
   15 |         ch: chan T{}
```