### PR TITLE
checker: check generics fn called outside of generic fn (fix #5899)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2125,6 +2125,10 @@ pub fn (mut c Checker) fn_call(mut call_expr ast.CallExpr) ast.Type {
 			concrete_types << concrete_type
 		}
 	}
+	if c.cur_fn.cur_concrete_types.len == 0 && has_generic {
+		c.error('generic fn using generic types cannot be called outside of generic fn',
+			call_expr.pos)
+	}
 	if has_generic {
 		mut no_exists := true
 		if c.mod != '' && !fn_name.contains('.') {

--- a/vlib/v/checker/tests/generics_fn_called_outside_of_generic_fn.out
+++ b/vlib/v/checker/tests/generics_fn_called_outside_of_generic_fn.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/generics_fn_called_outside_of_generic_fn.vv:4:2: error: generic fn using generic types cannot be called outside of generic fn
+    2 |
+    3 | fn main() {
+    4 |     foo<T>()
+      |     ~~~~~~~~
+    5 | }

--- a/vlib/v/checker/tests/generics_fn_called_outside_of_generic_fn.vv
+++ b/vlib/v/checker/tests/generics_fn_called_outside_of_generic_fn.vv
@@ -1,0 +1,5 @@
+fn foo<T>() {}
+
+fn main() {
+	foo<T>()
+}


### PR DESCRIPTION
This PR check generics fn called outside of generic fn (fix #5899).

- Check generics fn called outside of generic fn.
- Add test.

```vlang
fn foo<T>() {}

fn main() {
	foo<T>()
}

PS D:\Test\v\tt1> v run .
.\tt1.v:4:2: error: generic fn using generic types cannot be called outside of generic fn
    2 |
    3 | fn main() {
    4 |     foo<T>()
      |     ~~~~~~~~
    5 | }
```