### PR TITLE
os: rename open_stdin to stdin

### DIFF
--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -131,6 +131,12 @@ pub fn create(path string) ?File {
 	}
 }
 
+[deprecated: 'use os.stdin() instead']
+[deprecated_after: '2021-05-17']
+pub fn open_stdin() File {
+    return stdin()
+}
+
 // stdin - return an os.File for stdin, so that you can use .get_line on it too.
 pub fn stdin() File {
 	return File{

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -131,8 +131,8 @@ pub fn create(path string) ?File {
 	}
 }
 
-// open_stdin - return an os.File for stdin, so that you can use .get_line on it too.
-pub fn open_stdin() File {
+// stdin - return an os.File for stdin, so that you can use .get_line on it too.
+pub fn stdin() File {
 	return File{
 		fd: 0
 		cfile: C.stdin


### PR DESCRIPTION
### What
Rename os.open_stdin to os.stdin.

### Why

Stdin is not opened and cannot be closed. The `open_` prefix implies to the
reader that a resource is being acquired that needs to be cleaned up, but that's
not the case here. In other languages like Go and Rust getting a-hold of stdin
involves accessing a package/module variable or function without open
semantics, and it is confusing to see the concept of opening stdin here.

Examples of how to access stdin in other languages.

Go:
```go
import "os"

os.Stdin
```

Rust:
```rust
use std::io;

io::stdin()
```

Close  #9988

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
