### PR TITLE
os: add stdout() and stderr()

### DIFF
--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -140,6 +140,24 @@ pub fn open_stdin() File {
 	}
 }
 
+// stdout - return an os.File for stdout
+pub fn stdout() File {
+	return File{
+		fd: 1
+		cfile: C.stdout
+		is_opened: true
+	}
+}
+
+// stderr - return an os.File for stderr
+pub fn stderr() File {
+	return File{
+		fd: 2
+		cfile: C.stderr
+		is_opened: true
+	}
+}
+
 // **************************** Write ops  ***************************
 // write implements the Writer interface.
 // It returns how many bytes were actually written.


### PR DESCRIPTION
### What
Add `os.stdout()` and `os.stderr()` functions that return `File`s for stdout and stderr.

### Why
The stdlib exposes direct access to stdin via a `File`, through the `os.open_stdin()` function. It would be very helpful if there were similar functions for stdout and stderr. This  is specifically handy for IO CLIs that operate on and are composable with other unix tools via stdin and stdout. It is extremely easy to write these types of CLIs applications in Go, and this would help make it equally as easy in v.

Close  #9981

### Implementation  Notes
This change adds the functions without the `open_` prefix that  was used with stdin. There is discussion in #9989 about why. If that other PR is not accepted  I can make a change to this  PR to add  the `open_` prefix to these functions,  although I think that will communicate the wrong semantics.

This change includes no tests because I  don't seeh ow to write a meaningful  test  for these functions. I also note that there are no tests for the existing `os.open_stdin()`.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
