### PR TITLE
parser, fmt: prevent error with comment after expr inside match

### DIFF
--- a/vlib/v/fmt/tests/comments_keep.vv
+++ b/vlib/v/fmt/tests/comments_keep.vv
@@ -37,6 +37,12 @@ fn main() {
 	//////
 	// /
 	// 123
+	match 0 {
+		0 {
+			0 // comment after an expression inside match
+		}
+		else {}
+	}
 }
 
 fn assign_comments() {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1694,7 +1694,7 @@ fn (mut p Parser) parse_multi_expr(is_top_level bool) ast.Stmt {
 	// TODO remove translated
 	if p.tok.kind in [.assign, .decl_assign] || p.tok.kind.is_assign() {
 		return p.partial_assign_stmt(left, left_comments)
-	} else if !p.pref.translated
+	} else if !p.pref.translated && !p.pref.is_fmt
 		&& tok.kind !in [.key_if, .key_match, .key_lock, .key_rlock, .key_select] {
 		for node in left {
 			if node !is ast.CallExpr && (is_top_level || p.tok.kind != .rcbr)


### PR DESCRIPTION
fix #9444 