### PR TITLE
checker: fix unused var warning (fix #9982)

### DIFF
--- a/thirdparty/.gitignore
+++ b/thirdparty/.gitignore
@@ -8,3 +8,4 @@ SDL2_mixer/
 SDL2_ttf/
 pg/
 tcc/
+/sqlite

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3211,17 +3211,17 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 					left.info = ident_var_info
 					if left_type != 0 {
 						match mut left.obj {
-							ast.Var { left.obj.typ = left_type }
-							ast.GlobalField { left.obj.typ = left_type }
+							ast.Var {
+								left.obj.typ = left_type
+								if !is_decl {
+									left.obj.is_used = true
+								}
+							}
+							ast.GlobalField {
+								left.obj.typ = left_type
+							}
 							else {}
 						}
-						/*
-						if left.obj is ast.Var as v {
-							v.typ = left_type
-						} else if left.obj is ast.GlobalDecl as v {
-							v.typ = left_type
-						}
-						*/
 					}
 					if is_decl {
 						full_name := '${left.mod}.$left.name'

--- a/vlib/v/checker/tests/modify_const_with_ref.out
+++ b/vlib/v/checker/tests/modify_const_with_ref.out
@@ -5,10 +5,3 @@ vlib/v/checker/tests/modify_const_with_ref.vv:11:11: error: `constant` is immuta
       |              ^
    12 |     c.value = 200
    13 | }
-vlib/v/checker/tests/modify_const_with_ref.vv:9:6: error: unused variable: `unused_var`
-    7 | 
-    8 | fn main() {
-    9 |     mut unused_var := Foo{}
-      |         ~~~~~~~~~~
-   10 |     unused_var = Foo{}
-   11 |     mut c := &constant


### PR DESCRIPTION
This PR fix unused var warning (fix #9982).

- Fix unused var warning.
- Add thirdparty/sqlite .gitignore.
- Modify test.

```vlang
fn main() {
	mut arr := [1, 2, 3]
	for mut v in arr {
		v = 2
	}
	println(arr)
}

PS D:\Test\v\tt1> v run .
[2, 2, 2]
```