### PR TITLE
fmt,parser: prevent unknown module error

### DIFF
--- a/vlib/v/fmt/tests/module_struct_keep.vv
+++ b/vlib/v/fmt/tests/module_struct_keep.vv
@@ -3,6 +3,7 @@ module module_fmt
 pub struct MyStruct {
 mut:
 	value int
+	foo   mod.Foo
 }
 
 pub fn (m MyStruct) foo() bool {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -342,7 +342,7 @@ pub fn (mut p Parser) parse_any_type(language ast.Language, is_ptr bool, check_d
 			p.next()
 			p.check(.dot)
 		}
-		if !p.known_import(mod) {
+		if !p.known_import(mod) && !p.pref.is_fmt {
 			mut msg := 'unknown module `$mod`'
 			if mod.len > mod_last_part.len && p.known_import(mod_last_part) {
 				msg += '; did you mean `$mod_last_part`?'
@@ -352,9 +352,10 @@ pub fn (mut p Parser) parse_any_type(language ast.Language, is_ptr bool, check_d
 		}
 		if mod in p.imports {
 			p.register_used_import(mod)
+			mod = p.imports[mod]
 		}
 		// prefix with full module
-		name = '${p.imports[mod]}.$p.tok.lit'
+		name = '${mod}.$p.tok.lit'
 		if p.tok.lit.len > 0 && !p.tok.lit[0].is_capital() {
 			p.error('imported types must start with a capital letter')
 			return 0


### PR DESCRIPTION
use of `unknownmod.Type` will cause `v fmt` to fail on current master. This PR fix this problem.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
