### PR TITLE
checker: fix for_in mut var unused warning (fix #9982)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3211,17 +3211,17 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 					left.info = ident_var_info
 					if left_type != 0 {
 						match mut left.obj {
-							ast.Var { left.obj.typ = left_type }
-							ast.GlobalField { left.obj.typ = left_type }
+							ast.Var {
+								left.obj.typ = left_type
+								if left.obj.is_auto_deref {
+									left.obj.is_used = true
+								}
+							}
+							ast.GlobalField {
+								left.obj.typ = left_type
+							}
 							else {}
 						}
-						/*
-						if left.obj is ast.Var as v {
-							v.typ = left_type
-						} else if left.obj is ast.GlobalDecl as v {
-							v.typ = left_type
-						}
-						*/
 					}
 					if is_decl {
 						full_name := '${left.mod}.$left.name'

--- a/vlib/v/checker/tests/no_warning_for_in_mut_var_unused.vv
+++ b/vlib/v/checker/tests/no_warning_for_in_mut_var_unused.vv
@@ -1,0 +1,7 @@
+fn main() {
+	mut arr := [1, 2, 3]
+	for mut v in arr {
+		v = 2
+	}
+	println(arr)
+}


### PR DESCRIPTION
This PR fix for_in mut var unused warning (fix #9982).

- Fix for_in mut var unused warning.
- Add test.

```vlang
fn main() {
	mut arr := [1, 2, 3]
	for mut v in arr {
		v = 2
	}
	println(arr)
}

PS D:\Test\v\tt1> v run .
[2, 2, 2]
```