### PR TITLE
git: add 'sqlite/' to thirdparty/.gitignore

### DIFF
--- a/thirdparty/.gitignore
+++ b/thirdparty/.gitignore
@@ -8,3 +8,4 @@ SDL2_mixer/
 SDL2_ttf/
 pg/
 tcc/
+sqlite/


### PR DESCRIPTION
This PR add 'sqlite/' to thirdparty/.gitignore in order to use thirdparty/sqlite local installed.