### PR TITLE
make: fix termux make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,14 +111,12 @@ fresh_vc:
 	rm -rf $(VC)
 	$(GITFASTCLONE) $(VCREPO) $(VC)
 
-ifndef ANDROID
 ifndef local
 latest_tcc: $(TMPTCC)/.git/config
 	cd $(TMPTCC) && $(GITCLEANPULL)
 else
 latest_tcc:
 	@echo "Using local tcc"
-endif
 endif
 
 fresh_tcc:


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
Building v with make is broken because this commit introduced a regresion: https://github.com/vlang/v/commit/c21df2d44cf49bbc2333e7e33bf400c542835c8b

This pull request fixes the make command on android/termux.

