### PR TITLE
checker,cgen: fix generics with generic_fn type parameter (fix #9851)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2255,7 +2255,7 @@ pub fn (mut c Checker) fn_call(mut call_expr ast.CallExpr) ast.Type {
 	if !found {
 		if v := call_expr.scope.find_var(fn_name) {
 			if v.typ != 0 {
-				vts := c.table.get_type_symbol(v.typ)
+				vts := c.table.get_type_symbol(c.unwrap_generic(v.typ))
 				if vts.kind == .function {
 					info := vts.info as ast.FnType
 					func = info.func

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -371,18 +371,11 @@ fn (mut g Gen) fn_args(args []ast.Param, is_variadic bool) ([]string, []string) 
 		if arg_type_sym.kind == .function {
 			info := arg_type_sym.info as ast.FnType
 			func := info.func
-			if !info.is_anon {
-				g.write(arg_type_name + ' ' + caname)
-				g.definitions.write_string(arg_type_name + ' ' + caname)
-				fargs << caname
-				fargtypes << arg_type_name
-			} else {
-				g.write('${g.typ(func.return_type)} (*$caname)(')
-				g.definitions.write_string('${g.typ(func.return_type)} (*$caname)(')
-				g.fn_args(func.params, func.is_variadic)
-				g.write(')')
-				g.definitions.write_string(')')
-			}
+			g.write('${g.typ(func.return_type)} (*$caname)(')
+			g.definitions.write_string('${g.typ(func.return_type)} (*$caname)(')
+			g.fn_args(func.params, func.is_variadic)
+			g.write(')')
+			g.definitions.write_string(')')
 		} else {
 			s := '$arg_type_name $caname'
 			g.write(s)

--- a/vlib/v/tests/generics_with_generics_fn_type_parameter_test.v
+++ b/vlib/v/tests/generics_with_generics_fn_type_parameter_test.v
@@ -1,0 +1,34 @@
+fn neg(a int) int {
+	return -a
+}
+
+fn indirect_call(func fn (int) int, a int) int {
+	println(typeof(func).name)
+	return func(a)
+}
+
+fn generic_call<T>(func T, a int) int {
+	println(T.name)
+	return func(a)
+}
+
+fn generic_indirect_call<T>(func T, a int) int {
+	println(T.name)
+	return indirect_call(func, a)
+}
+
+fn test_generics_with_generics_fn_type_parameter() {
+	mut ret := 0
+
+	ret = indirect_call(neg, 2)
+	println(ret)
+	assert ret == -2
+
+	ret = generic_call(neg, 3)
+	println(ret)
+	assert ret == -3
+
+	ret = generic_indirect_call(neg, 4)
+	println(ret)
+	assert ret == -4
+}


### PR DESCRIPTION
This PR fix generics with generic_fn type parameter (fix #9851).

- Fix generics with generic_fn type parameter.
- Add test.

```vlang
fn neg(a int) int {
	return -a
}

fn indirect_call(func fn (int) int, a int) int {
	println(typeof(func).name)
	return func(a)
}

fn generic_call<T>(func T, a int) int {
	println(T.name)
	return func(a)
}

fn generic_indirect_call<T>(func T, a int) int {
	println(T.name)
	return indirect_call(func, a)
}

fn main() {
	mut ret := 0

	ret = indirect_call(neg, 2)
	println(ret)
	assert ret == -2

	ret = generic_call(neg, 3)
	println(ret)
	assert ret == -3

	ret = generic_indirect_call(neg, 4)
	println(ret)
	assert ret == -4
}

PS D:\Test\v\tt1> v run .
fn (int) int
-2
fn (int) int
-3
fn (int) int
fn (int) int
-4
```