### PR TITLE
table: fix generics struct with anon fn fields  (fix #6895)

### DIFF
--- a/vlib/v/tests/generics_struct_anon_fn_fields_test.v
+++ b/vlib/v/tests/generics_struct_anon_fn_fields_test.v
@@ -1,0 +1,14 @@
+struct Scope<T> {
+	before fn () T
+	specs  []fn (T) T
+	after  fn (T)
+}
+
+fn test_generics_struct_anon_fn_fields() {
+	s := Scope<u32>{}
+	println(s)
+	ts := '$s'
+	assert ts.contains('before: fn () u32')
+	assert ts.contains('specs: []')
+	assert ts.contains('after: fn (u32)')
+}


### PR DESCRIPTION
This PR fix generics struct with anon fn fields  (fix #6895).

- Fix generics struct with anon fn fields.
- Add test.

```vlang
struct Scope<T> {
	before fn () T
	specs  []fn (T) T
	after  fn (T)
}

fn main() {
	s := Scope<u32>{}
	println(s)
	ts := '$s'
	assert ts.contains('before: fn () u32')
	assert ts.contains('specs: []')
	assert ts.contains('after: fn (u32)')
}

PS D:\Test\v\tt1> v run .
Scope<u32>{
    before: fn () u32
    specs: []
    after: fn (u32)
}
```