### PR TITLE
checker: fix generics return recursive generic struct (fix #10028)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1618,7 +1618,7 @@ fn (mut c Checker) check_return_generics_struct(return_type ast.Type, mut call_e
 				mut fields := rts.info.fields.clone()
 				if rts.info.generic_types.len == concrete_types.len {
 					generic_names := rts.info.generic_types.map(c.table.get_type_symbol(it).name)
-					for i, _ in fields {
+					for i in 0 .. fields.len {
 						if t_typ := c.table.resolve_generic_to_concrete(fields[i].typ,
 							generic_names, concrete_types, true)
 						{

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1620,7 +1620,7 @@ fn (mut c Checker) check_return_generics_struct(return_type ast.Type, mut call_e
 					generic_names := rts.info.generic_types.map(c.table.get_type_symbol(it).name)
 					for i, _ in fields {
 						if t_typ := c.table.resolve_generic_to_concrete(fields[i].typ,
-							generic_names, concrete_types, false)
+							generic_names, concrete_types, true)
 						{
 							fields[i].typ = t_typ
 						}

--- a/vlib/v/tests/generics_return_recursive_generics_struct_test.v
+++ b/vlib/v/tests/generics_return_recursive_generics_struct_test.v
@@ -1,0 +1,18 @@
+struct Node<T> {
+mut:
+	val  T
+	next &Node<T>
+}
+
+fn make_node<T>(val []T) Node<T> {
+	return Node{
+		val: val[0]
+		next: 0
+	}
+}
+
+fn test_generics_return_recursive_generics_struct() {
+	n := make_node([1, 2, 3])
+	println(n.val)
+	assert n.val == 1
+}


### PR DESCRIPTION
This PR fix generics return recursive generic struct (fix #10028).

- Fix generics return recursive generic struct.
- Add test.

```vlang
struct Node<T> {
mut:
	val  T
	next &Node<T>
}

fn make_node<T>(val []T) Node<T> {
	return Node{
		val: val[0]
		next: 0
	}
}

fn main() {
	n := make_node([1, 2, 3])
	println(n.val)
	assert n.val == 1
}

PS D:\Test\v\tt1> v run .
1
```