### PR TITLE
vbug: use readline to read expected result

### DIFF
--- a/cmd/tools/vbug.v
+++ b/cmd/tools/vbug.v
@@ -156,7 +156,6 @@ fn main() {
 
 	expected_result := readline.read_line('What did you expect to see? ') or {
 		// Ctrl-C was pressed
-		pressed
 		eprintln('\nCanceled')
 		exit(1)
 	}

--- a/cmd/tools/vbug.v
+++ b/cmd/tools/vbug.v
@@ -1,6 +1,7 @@
 import dl
 import net.urllib
 import os
+import readline
 
 // get output from `v doctor`
 fn get_vdoctor_output(is_verbose bool) string {
@@ -153,7 +154,10 @@ fn main() {
 		confirm_or_exit('An error occured retrieving the information, do you want to continue?')
 	}
 
-	expected_result := os.input_opt('What did you expect to see? ') or { '' }
+	expected_result := readline.read_line('What did you expect to see? ') or {
+		eprintln('canceled')
+		exit(1)
+	}
 	// open prefilled issue creation page, or print link as a fallback
 
 	if !is_yes && vdoctor_output.contains('behind V master') {

--- a/cmd/tools/vbug.v
+++ b/cmd/tools/vbug.v
@@ -155,6 +155,8 @@ fn main() {
 	}
 
 	expected_result := readline.read_line('What did you expect to see? ') or {
+		// Ctrl-C was pressed
+		pressed
 		eprintln('\nCanceled')
 		exit(1)
 	}

--- a/cmd/tools/vbug.v
+++ b/cmd/tools/vbug.v
@@ -155,7 +155,7 @@ fn main() {
 	}
 
 	expected_result := readline.read_line('What did you expect to see? ') or {
-		eprintln('canceled')
+		eprintln('\nCanceled')
 		exit(1)
 	}
 	// open prefilled issue creation page, or print link as a fallback


### PR DESCRIPTION
v bug can handle arrow keys but they are printed as is. This is inconvenient. This PR fix this problem by use readline
```
v bug main.v
What did you expect to see? a^[[D^[[D^[[C^[[C
```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
