### PR TITLE
checker: fix optionals in match condition (#9938)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5135,6 +5135,7 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 	// since it is used in c.match_exprs() it saves checking twice
 	node.cond_type = c.table.mktyp(cond_type)
 	c.ensure_type_exists(node.cond_type, node.pos) or { return ast.void_type }
+	c.check_expr_opt_call(node.cond, cond_type)
 	cond_type_sym := c.table.get_type_symbol(cond_type)
 	if cond_type_sym.kind !in [.interface_, .sum_type] {
 		node.is_sum_type = false

--- a/vlib/v/checker/tests/optional_fn_err.out
+++ b/vlib/v/checker/tests/optional_fn_err.out
@@ -151,10 +151,18 @@ vlib/v/checker/tests/optional_fn_err.vv:69:18: error: bar() returns an option, s
    69 |     println(arr.any(bar(true)))
       |                     ~~~~~~~~~
    70 |     println(arr.all(bar(true)))
-   71 | }
+   71 |
 vlib/v/checker/tests/optional_fn_err.vv:70:18: error: bar() returns an option, so it should have either an `or {}` block, or `?` at the end
    68 |     println(arr.filter(bar(true)))
    69 |     println(arr.any(bar(true)))
    70 |     println(arr.all(bar(true)))
       |                     ~~~~~~~~~
-   71 | }
+   71 | 
+   72 |     match bar(0) {
+vlib/v/checker/tests/optional_fn_err.vv:72:8: error: bar() returns an option, so it should have either an `or {}` block, or `?` at the end
+   70 |     println(arr.all(bar(true)))
+   71 | 
+   72 |     match bar(0) {
+      |           ~~~~~~
+   73 |         0 { }
+   74 |         else { }

--- a/vlib/v/checker/tests/optional_fn_err.vv
+++ b/vlib/v/checker/tests/optional_fn_err.vv
@@ -68,4 +68,9 @@ fn main() {
 	println(arr.filter(bar(true)))
 	println(arr.any(bar(true)))
 	println(arr.all(bar(true)))
+
+	match bar(0) {
+		0 { }
+		else { }
+	}
 }


### PR DESCRIPTION
This fixes #9938, where an optional in the match statement's condition causes a C error. This happened because `check_expr_opt_call` was not called in `match_expr`.

Now an unchecked optional in `match` properly shows the ``function() returns an option, so it should have either an `or {}` block, or `?` at the end`` error.

A test was also added in vlib/v/checker/tests/optional_fn_err.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
