### PR TITLE
crypto/sha256: make digest sum public

### DIFF
--- a/vlib/crypto/sha256/sha256.v
+++ b/vlib/crypto/sha256/sha256.v
@@ -124,7 +124,7 @@ fn (mut d Digest) write(p_ []byte) ?int {
 	}
 }
 
-fn (d &Digest) sum(b_in []byte) []byte {
+pub fn (d &Digest) sum(b_in []byte) []byte {
 	// Make a copy of d so that caller can keep writing and summing.
 	mut d0 := *d
 	hash := d0.checksum()

--- a/vlib/crypto/sha256/sha256_test.v
+++ b/vlib/crypto/sha256/sha256_test.v
@@ -8,3 +8,12 @@ fn test_crypto_sha256() {
 	assert sha256.sum('This is a sha256 checksum.'.bytes()).hex() ==
 		'dc7163299659529eae29683eb1ffec50d6c8fc7275ecb10c145fde0e125b8727'
 }
+
+fn test_crypto_sha256_writer() {
+	mut digest := sha256.new()
+	digest.write('This is a'.bytes()) or { assert false }
+	digest.write(' sha256 checksum.'.bytes()) or { assert false }
+	sum := digest.sum([])
+	assert sum.hex() ==
+		'dc7163299659529eae29683eb1ffec50d6c8fc7275ecb10c145fde0e125b8727'
+}


### PR DESCRIPTION
### What
Make the SHA256 Digest types `sum` method public.

### Why
It is not possible to stream data into the SHA256 Digest type and get the final result because the `sum` function is not public. The SHA1 Digest type has its sum public, so I think this was just missed. For the most part people are probably hashing small amounts of data and using the helper functions that don't require using the Digest type directly. But for anyone who is hashing large amounts of data they will probably want to stream it in chunks.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
