### PR TITLE
fmt: fix tmpl with not existing file as path

### DIFF
--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -140,8 +140,8 @@ fn (mut p Parser) comp_call() ast.ComptimeCall {
 		path = os.join_path(dir, tmpl_path)
 	}
 	if !os.exists(path) {
-		// can be in `templates/`
 		if is_html {
+			// can be in `templates/`
 			path = os.join_path(dir, 'templates', fn_path_joined)
 			path += '.html'
 		}
@@ -151,6 +151,7 @@ fn (mut p Parser) comp_call() ast.ComptimeCall {
 					scope: 0
 					is_vweb: true
 					method_name: n
+					args_var: literal_string_param
 					pos: start_pos.extend(p.prev_tok.position())
 				}
 			}


### PR DESCRIPTION
This PR fixes the formatting for tmpl calls without an existing file as argument