### PR TITLE
cgen: fix constants with multi-statement C initializations

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5091,7 +5091,8 @@ fn (mut g Gen) const_decl_init_later(mod string, name string, expr ast.Expr, typ
 		}
 	} else {
 		if unwrap_option {
-			g.inits[mod].writeln(g.expr_string_surround('\t$cname = *($styp*)', expr, '.data;'))
+			g.inits[mod].writeln(g.expr_string_surround('\t$cname = *($styp*)', expr,
+				'.data;'))
 		} else {
 			g.inits[mod].writeln(g.expr_string_surround('\t$cname = ', expr, ';'))
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -584,6 +584,20 @@ fn (mut g Gen) expr_string(expr ast.Expr) string {
 	return expr_str.trim_space()
 }
 
+// Surround a potentially multi-statement expression safely with `prepend` and `append`.
+// (and create a statement)
+fn (mut g Gen) expr_string_surround(prepend string, expr ast.Expr, append string) string {
+	pos := g.out.len
+	g.stmt_path_pos << pos
+	g.write(prepend)
+	g.expr(expr)
+	g.write(append)
+	expr_str := g.out.after(pos)
+	g.out.go_back(expr_str.len)
+	g.stmt_path_pos.delete_last()
+	return expr_str
+}
+
 // TODO this really shouldnt be seperate from typ
 // but I(emily) would rather have this generation
 // all unified in one place so that it doesnt break
@@ -4993,11 +5007,6 @@ fn (mut g Gen) const_decl(node ast.ConstDecl) {
 		}
 
 		name := c_name(field.name)
-		// TODO hack. Cut the generated value and paste it into definitions.
-		pos := g.out.len
-		g.expr(field.expr)
-		val := g.out.after(pos)
-		g.out.go_back(val.len)
 		/*
 		if field.typ == ast.byte_type {
 			g.const_decl_simple_define(name, val)
@@ -5014,40 +5023,43 @@ fn (mut g Gen) const_decl(node ast.ConstDecl) {
 			}
 		} else {
 		*/
+		field_expr := field.expr
 		match field.expr {
 			ast.CharLiteral, ast.FloatLiteral, ast.IntegerLiteral {
-				g.const_decl_simple_define(name, val)
+				// "Simple" expressions are not going to need multiple statements,
+				// only the ones which are inited later, so it's safe to use expr_string
+				g.const_decl_simple_define(name, g.expr_string(field_expr))
 			}
 			ast.ArrayInit {
 				if field.expr.is_fixed {
 					styp := g.typ(field.expr.typ)
 					if g.pref.build_mode != .build_module {
+						val := g.expr_string(field.expr)
 						g.definitions.writeln('$styp _const_$name = $val; // fixed array const')
 					} else {
 						g.definitions.writeln('$styp _const_$name; // fixed array const')
 					}
 				} else {
-					g.const_decl_init_later(field.mod, name, val, field.typ, false)
+					g.const_decl_init_later(field.mod, name, field.expr, field.typ, false)
 				}
 			}
 			ast.StringLiteral {
 				g.definitions.writeln('string _const_$name; // a string literal, inited later')
 				if g.pref.build_mode != .build_module {
+					val := g.expr_string(field.expr)
 					g.stringliterals.writeln('\t_const_$name = $val;')
 				}
 			}
 			ast.CallExpr {
-				if val.starts_with('Option_') {
-					g.inits[field.mod].writeln(val)
+				if field.expr.return_type.has_flag(.optional) {
 					unwrap_option := field.expr.or_block.kind != .absent
-					g.const_decl_init_later(field.mod, name, g.current_tmp_var(), field.typ,
-						unwrap_option)
+					g.const_decl_init_later(field.mod, name, field.expr, field.typ, unwrap_option)
 				} else {
-					g.const_decl_init_later(field.mod, name, val, field.typ, false)
+					g.const_decl_init_later(field.mod, name, field.expr, field.typ, false)
 				}
 			}
 			else {
-				g.const_decl_init_later(field.mod, name, val, field.typ, false)
+				g.const_decl_init_later(field.mod, name, field.expr, field.typ, false)
 			}
 		}
 	}
@@ -5062,7 +5074,7 @@ fn (mut g Gen) const_decl_simple_define(name string, val string) {
 	g.definitions.writeln(val)
 }
 
-fn (mut g Gen) const_decl_init_later(mod string, name string, val string, typ ast.Type, unwrap_option bool) {
+fn (mut g Gen) const_decl_init_later(mod string, name string, expr ast.Expr, typ ast.Type, unwrap_option bool) {
 	// Initialize more complex consts in `void _vinit/2{}`
 	// (C doesn't allow init expressions that can't be resolved at compile time).
 	mut styp := g.typ(typ)
@@ -5079,9 +5091,9 @@ fn (mut g Gen) const_decl_init_later(mod string, name string, val string, typ as
 		}
 	} else {
 		if unwrap_option {
-			g.inits[mod].writeln('\t$cname = *($styp*)${val}.data;')
+			g.inits[mod].writeln(g.expr_string_surround('\t$cname = *($styp*)', expr, '.data;'))
 		} else {
-			g.inits[mod].writeln('\t$cname = $val;')
+			g.inits[mod].writeln(g.expr_string_surround('\t$cname = ', expr, ';'))
 		}
 	}
 	if g.is_autofree {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -465,6 +465,8 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 			} else {
 				if !g.inside_const {
 					g.write('\n $cur_line *($unwrapped_styp*)${tmp_opt}.data')
+				} else {
+					g.write('\n $cur_line $tmp_opt')
 				}
 			}
 		}

--- a/vlib/v/tests/const_test.v
+++ b/vlib/v/tests/const_test.v
@@ -35,3 +35,16 @@ fn test_opt_const() {
 	assert def.name == 'foo'
 	assert bar.name == 'bar'
 }
+
+// const with expressions that compile to multiple C statements
+pub const (
+	abc = [1, 2, 3].map(it * it)
+	ghi = [1, 2, 3, 4, 5].filter(it % 2 == 0)
+	jkl = [`a`, `b`, `c`].contains(`d`)
+)
+
+fn test_multistmt_const() {
+	assert abc[2] == 9
+	assert ghi.len == 2
+	assert jkl == false
+}


### PR DESCRIPTION
Fixes #10035.
The problem was happening because `cgen.gen_array_map`'s output was copied as-is after the equals sign in a constant declaration, and therefore it was unable to write the output variable and the for loop separately. The fix introduces a function, `fn (mut Gen g) expr_string_surround`, which surrounds the expression with two strings (for example `"foo = "` and `";"`) safely, by imitating a statement, then cutting out the whole produced string, including the prepended and appended ones and the lines which were added by the expression before. `const_decl_init_later` takes an `expr ast.Expr` argument instead of `val string`, so it can generate the statements in itself.

Note that this makes const declarations behave more similar to variable declarations, so for example, `call_expr` has to write the temporary variable name after the statement when generating an optional unwrapping block.
I added a test for these initializations.in `const_test.v`.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
