### PR TITLE
io: make new_multi_writer use varargs

### DIFF
--- a/vlib/io/multi_writer.v
+++ b/vlib/io/multi_writer.v
@@ -6,7 +6,7 @@ module io
 // full length an error is returned and writing to other writers stops, and if
 // any writer returns an error the error is returned immediately and writing to
 // other writers stops.
-pub fn new_multi_writer(writers []Writer) Writer {
+pub fn new_multi_writer(writers ...Writer) Writer {
 	return &MultiWriter{
 		writers: writers
 	}

--- a/vlib/io/multi_writer_test.v
+++ b/vlib/io/multi_writer_test.v
@@ -3,7 +3,7 @@ module io
 fn test_multi_writer_write_successful() {
 	w0 := TestWriter{}
 	w1 := TestWriter{}
-	mw := new_multi_writer([w0, w1])
+	mw := new_multi_writer(w0, w1)
 	n := mw.write('0123456789'.bytes()) or {
 		assert false
 		return
@@ -16,7 +16,7 @@ fn test_multi_writer_write_successful() {
 fn test_multi_writer_write_incomplete() {
 	w0 := TestWriter{}
 	w1 := TestIncompleteWriter{}
-	mw := new_multi_writer([w0, w1])
+	mw := new_multi_writer(w0, w1)
 	n := mw.write('0123456789'.bytes()) or {
 		assert w0.bytes == '0123456789'.bytes()
 		assert w1.bytes == '012345678'.bytes()
@@ -29,7 +29,7 @@ fn test_multi_writer_write_error() {
 	w0 := TestWriter{}
 	w1 := TestErrorWriter{}
 	w2 := TestWriter{}
-	mw := new_multi_writer([w0, w1, w2])
+	mw := new_multi_writer(w0, w1, w2)
 	n := mw.write('0123456789'.bytes()) or {
 		assert w0.bytes == '0123456789'.bytes()
 		assert w2.bytes == []


### PR DESCRIPTION
### What
Make the `io.new_multi_writer` use variable arguments for the list of writers provided to it.

### Why
This was the design I wanted to use originally for this function when I introduced it in #10021, but there was a bug that prevented it that @spaceface777 has just recently fixed in #10052, making this possible.

### Note
This is a breaking change since the v compiler won't let you pass an array to a variable arg variable, even though it is essentially an array under the hood. Since this function was only just added and not included in any official release I think this is not an issue that it is breaking.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
