### PR TITLE
builtin.string: optimize split_into_lines

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -648,28 +648,24 @@ pub fn (s string) split_nth(delim string, nth int) []string {
 }
 
 // split_into_lines splits the string by newline characters.
-// Both `\n` and `\r\n` newline endings is supported.
+// newlines are stripped.
+// Both `\n` and `\r\n` newline endings are supported.
+[direct_array_access]
 pub fn (s string) split_into_lines() []string {
 	mut res := []string{}
 	if s.len == 0 {
 		return res
 	}
 	mut start := 0
-	for i := 0; i < s.len; i++ {
-		is_lf := unsafe { s.str[i] } == 10
-		is_crlf := i != s.len - 1 && unsafe { s.str[i] == 13 && s.str[i + 1] == 10 }
-		is_eol := is_lf || is_crlf
-		is_last := if is_crlf { i == s.len - 2 } else { i == s.len - 1 }
-		if is_eol || is_last {
-			if is_last && !is_eol {
+	mut end := 0
+	for i := 0; i <= s.len; i++ {
+		unsafe {
+			if s.str[i] == 10 || i == s.len {
+				end = if i > 0 && s[i-1] == 13 { i - 1 } else { i }
+				res << s[start..end]
 				i++
+				start = i
 			}
-			line := s.substr(start, i)
-			res << line
-			if is_crlf {
-				i++
-			}
-			start = i + 1
 		}
 	}
 	return res

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -661,7 +661,7 @@ pub fn (s string) split_into_lines() []string {
 	for i := 0; i <= s.len; i++ {
 		unsafe {
 			if s.str[i] == 10 || i == s.len {
-				end = if i > 0 && s[i-1] == 13 { i - 1 } else { i }
+				end = if i > 0 && s[i - 1] == 13 { i - 1 } else { i }
 				res << s[start..end]
 				i++
 				start = i


### PR DESCRIPTION
Minor optimization, will mostly be noticed on large files.
```v
import benchmark

lines := '
one
two
three
four
five
six
seven
eight
nine
ten'

mut bench := benchmark.start()
for _ in 0..100000 {
        lines.split_into_lines()
}
bench.measure('split')
```
Several runs:
```
jalon@Ripper:~/testing$ v run split_into_lines.v
 SPENT   150.032 ms in split loop
jalon@Ripper:~/testing$ ../git/vv/v run split_into_lines.v
 SPENT   122.297 ms in split loop
jalon@Ripper:~/testing$ v run split_into_lines.v
 SPENT   151.656 ms in split loop
jalon@Ripper:~/testing$ ../git/vv/v run split_into_lines.v
 SPENT   122.940 ms in split loop
jalon@Ripper:~/testing$ v run split_into_lines.v
 SPENT   151.748 ms in split loop
jalon@Ripper:~/testing$ ../git/vv/v run split_into_lines.v
 SPENT   122.910 ms in split loop
jalon@Ripper:~/testing$
```



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
