### PR TITLE
string: support integer parsing errors

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -447,22 +447,22 @@ pub fn (s string) bool() bool {
 
 // int returns the value of the string as an integer `'1'.int() == 1`.
 pub fn (s string) int() int {
-	return int(strconv.common_parse_int(s, 0, 32, false, false))
+	return int(strconv.common_parse_int(s, 0, 32) or { 0 })
 }
 
 // i64 returns the value of the string as i64 `'1'.i64() == i64(1)`.
 pub fn (s string) i64() i64 {
-	return strconv.common_parse_int(s, 0, 64, false, false)
+	return strconv.common_parse_int(s, 0, 64) or { i64(0) }
 }
 
 // i8 returns the value of the string as i8 `'1'.i8() == i8(1)`.
 pub fn (s string) i8() i8 {
-	return i8(strconv.common_parse_int(s, 0, 8, false, false))
+	return i8(strconv.common_parse_int(s, 0, 8) or { 0 })
 }
 
 // i16 returns the value of the string as i16 `'1'.i16() == i16(1)`.
 pub fn (s string) i16() i16 {
-	return i16(strconv.common_parse_int(s, 0, 16, false, false))
+	return i16(strconv.common_parse_int(s, 0, 16) or { 0 })
 }
 
 // f32 returns the value of the string as f32 `'1.0'.f32() == f32(1)`.
@@ -479,17 +479,17 @@ pub fn (s string) f64() f64 {
 
 // u16 returns the value of the string as u16 `'1'.u16() == u16(1)`.
 pub fn (s string) u16() u16 {
-	return u16(strconv.common_parse_uint(s, 0, 16, false, false))
+	return u16(strconv.common_parse_uint(s, 0, 16, true) or { 0 })
 }
 
 // u32 returns the value of the string as u32 `'1'.u32() == u32(1)`.
 pub fn (s string) u32() u32 {
-	return u32(strconv.common_parse_uint(s, 0, 32, false, false))
+	return u32(strconv.common_parse_uint(s, 0, 32, true) or { 0 })
 }
 
 // u64 returns the value of the string as u64 `'1'.u64() == u64(1)`.
 pub fn (s string) u64() u64 {
-	return strconv.common_parse_uint(s, 0, 64, false, false)
+	return strconv.common_parse_uint(s, 0, 64, true) or { 0 }
 }
 
 // eq implements the `s == a` (equal) operator.

--- a/vlib/strconv/atoi_test.v
+++ b/vlib/strconv/atoi_test.v
@@ -30,48 +30,51 @@ fn test_atoi() {
 	}
 }
 
-fn test_parse_int() {
-	// Different bases
-	assert strconv.parse_int('16', 16, 0) == 0x16
-	assert strconv.parse_int('16', 8, 0) == 0o16
-	assert strconv.parse_int('11', 2, 0) == 3
-	// Different bit sizes
-	assert strconv.parse_int('127', 10, 8) == 127
-	assert strconv.parse_int('128', 10, 8) == 127
-	assert strconv.parse_int('32767', 10, 16) == 32767
-	assert strconv.parse_int('32768', 10, 16) == 32767
-	assert strconv.parse_int('2147483647', 10, 32) == 2147483647
-	assert strconv.parse_int('2147483648', 10, 32) == 2147483647
-	assert strconv.parse_int('9223372036854775807', 10, 64) == 9223372036854775807
-	assert strconv.parse_int('9223372036854775808', 10, 64) == 9223372036854775807
-	// Invalid bit sizes
-	assert strconv.parse_int('123', 10, 65) == 0
-	assert strconv.parse_int('123', 10, -1) == 0
+fn parse_int_or_zero(s string, base int, bits int) i64 {
+	return strconv.parse_int(s, base, bits) or { 0 }
 }
 
-fn test_common_parse_uint2() {
-	mut result, mut error := strconv.common_parse_uint2('1', 10, 8)
-	assert result == 1
-	assert error == 0
-	result, error = strconv.common_parse_uint2('123', 10, 8)
-	assert result == 123
-	assert error == 0
-	result, error = strconv.common_parse_uint2('123', 10, 65)
-	assert result == 0
-	assert error == -2
-	result, error = strconv.common_parse_uint2('123', 10, -1)
-	assert result == 0
-	assert error == -2
-	result, error = strconv.common_parse_uint2('', 10, 8)
-	assert result == 0
-	assert error == 1
-	result, error = strconv.common_parse_uint2('1a', 10, 8)
-	assert result == 1
-	assert error == 2
-	result, error = strconv.common_parse_uint2('12a', 10, 8)
-	assert result == 12
-	assert error == 3
-	result, error = strconv.common_parse_uint2('123a', 10, 8)
-	assert result == 123
-	assert error == 4
+fn test_parse_int() {
+	// Different bases
+	assert parse_int_or_zero('16', 16, 0) == 0x16
+	assert parse_int_or_zero('16', 8, 0) == 0o16
+	assert parse_int_or_zero('11', 2, 0) == 3
+	// Different bit sizes
+	assert parse_int_or_zero('127', 10, 8) == 127
+	assert parse_int_or_zero('128', 10, 8) == 0
+	assert parse_int_or_zero('32767', 10, 16) == 32767
+	assert parse_int_or_zero('32768', 10, 16) == 0
+	assert parse_int_or_zero('2147483647', 10, 32) == 2147483647
+	assert parse_int_or_zero('2147483648', 10, 32) == 0
+	assert parse_int_or_zero('9223372036854775807', 10, 64) == 9223372036854775807
+	assert parse_int_or_zero('9223372036854775808', 10, 64) == 0
+	// Invalid bit sizes
+	assert parse_int_or_zero('123', 10, 65) == 0
+	assert parse_int_or_zero('123', 10, -1) == 0
+}
+
+fn test_common_parse_uint() ? {
+	r1 := strconv.common_parse_uint('1', 10, 8, false) ?
+	assert r1 == 1
+	r2 := strconv.common_parse_uint('123', 10, 8, false) ?
+	assert r2 == 123
+	if result := strconv.common_parse_uint('123', 10, 65, false) {
+		assert false
+	}
+	if result := strconv.common_parse_uint('123', 10, -1, false) {
+		assert false
+	}
+	if result := strconv.common_parse_uint('', 10, 8, false) {
+		assert false
+	}
+	if result := strconv.common_parse_uint('1a', 10, 8, false) {
+		println(result)
+		assert false
+	}
+	if result := strconv.common_parse_uint('12a', 10, 8, false) {
+		assert false
+	}
+	if result := strconv.common_parse_uint('123a', 10, 8, false) {
+		assert false
+	}
 }

--- a/vlib/strconv/number_to_base_test.v
+++ b/vlib/strconv/number_to_base_test.v
@@ -26,7 +26,7 @@ fn test_format_int() {
 	}
 }
 
-fn test_format_uint() {
+fn test_format_uint() ? {
 	assert strconv.format_uint(0, 2) == '0'
 	assert strconv.format_int(255, 2) == '11111111'
 	assert strconv.format_int(255, 8) == '377'
@@ -35,6 +35,7 @@ fn test_format_uint() {
 	assert strconv.format_uint(18446744073709551615, 2) ==
 		'1111111111111111111111111111111111111111111111111111111111111111'
 	assert strconv.format_uint(18446744073709551615, 16) == 'ffffffffffffffff'
-	assert strconv.parse_int('baobab', 36, 64) == 683058467
+	i := strconv.parse_int('baobab', 36, 64) ?
+	assert i == 683058467
 	assert strconv.format_uint(683058467, 36) == 'baobab'
 }

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1221,7 +1221,7 @@ fn decode_u_escapes(s string, start int, escapes_pos []int) string {
 	for i, pos in escapes_pos {
 		idx := pos - start
 		end_idx := idx + 6 // "\uXXXX".len == 6
-		ss << utf32_to_str(u32(strconv.parse_uint(s[idx + 2..end_idx], 16, 32)))
+		ss << utf32_to_str(u32(strconv.parse_uint_or_zero(s[idx + 2..end_idx], 16, 32)))
 		if i + 1 < escapes_pos.len {
 			ss << s[end_idx..escapes_pos[i + 1] - start]
 		} else {

--- a/vlib/x/json2/scanner.v
+++ b/vlib/x/json2/scanner.v
@@ -159,7 +159,7 @@ fn (mut s Scanner) text_scan() Token {
 					if codepoint.len != 4 {
 						return s.error('unicode escape must have 4 hex digits')
 					}
-					val := u32(strconv.parse_uint(codepoint.bytestr(), 16, 32))
+					val := u32(strconv.parse_uint_or_zero(codepoint.bytestr(), 16, 32))
 					converted := utf32_to_str(val)
 					converted_bytes := converted.bytes()
 					chrs << converted_bytes


### PR DESCRIPTION
```v
// this change makes it possible to determine if a string holds an integer or not:
strconv.parse_int('hello', 10, 0) or { ...executes this... }
```