### PR TITLE
os: fix file read end-of-file detection

### DIFF
--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -407,7 +407,7 @@ pub fn (f &File) read(mut buf []byte) ?int {
 		// than there was an error. This is because fread and ferror do not set
 		// errno.
 		if C.ferror(f.cfile) != 0 {
-			return error("read failed: $f.cfile")
+			return error("file read error")
 		}
 	}
 	return nbytes

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -392,9 +392,8 @@ pub fn (f &File) read(mut buf []byte) ?int {
 		return 0
 	}
 	nbytes := int(C.fread(buf.data, 1, buf.len, f.cfile))
-	// If no bytes were read, check for errors or eof.
+	// If no bytes were read, check for errors and end-of-file.
 	if nbytes <= 0 {
-		// If no bytes read, check for errors and end-of-file.
 		// If fread encountered end-of-file return the none error. Note that fread
 		// may read data and encounter the end-of-file, but we shouldn't return none
 		// in that case which is why we only check for end-of-file if no data was

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -340,7 +340,7 @@ fn fread(ptr voidptr, item_size int, items int, stream &C.FILE) ?int {
 		// than there was an error. This is because fread and ferror do not set
 		// errno.
 		if C.ferror(stream) != 0 {
-			return error("file read error")
+			return error('file read error')
 		}
 	}
 	return nbytes

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -392,29 +392,26 @@ pub fn (f &File) read(mut buf []byte) ?int {
 		return 0
 	}
 	nbytes := int(C.fread(buf.data, 1, buf.len, f.cfile))
-	// If bytes were read, inform the caller.
-	if nbytes > 0 {
-		return nbytes
+	// If no bytes were read, check for errors or eof.
+	if nbytes <= 0 {
+		// If no bytes read, check for errors and end-of-file.
+		// If fread encountered end-of-file return the none error. Note that fread
+		// may read data and encounter the end-of-file, but we shouldn't return none
+		// in that case which is why we only check for end-of-file if no data was
+		// read. The caller will get none on their next call because there will be
+		// no data available and the end-of-file will be encountered again.
+		if C.feof(f.cfile) != 0 {
+			return none
+		}
+		// If fread encountered an error, return it. Note that fread and ferror do
+		// not tell us what the error was, so we can't return anything more specific
+		// than there was an error. This is because fread and ferror do not set
+		// errno.
+		if C.ferror(f.cfile) != 0 {
+			return error("read failed: $f.cfile")
+		}
 	}
-	// If no bytes read, check for errors and end-of-file.
-	// If fread encountered end-of-file return the none error. Note that fread
-	// may read data and encounter the end-of-file, but we shouldn't return none
-	// in that case which is why we only check for end-of-file if no data was
-	// read. The caller will get none on their next call because there will be
-	// no data available and the end-of-file will be encountered again.
-	if C.feof(f.cfile) != 0 {
-		return none
-	}
-	// If fread encountered an error, return it. Note that fread and ferror do
-	// not tell us what the error was, so we can't return anything more specific
-	// than there was an error. This is because fread and ferror do not set
-	// errno.
-	if C.ferror(f.cfile) != 0 {
-		return error("read failed: $f.cfile")
-	}
-
-	// No data read, and no errors or end-of-file detected.
-	return 0
+	return nbytes
 }
 
 // read_at reads `buf.len` bytes starting at file byte offset `pos`, in `buf`.

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -321,6 +321,31 @@ pub fn (mut f File) write_ptr_at(data voidptr, size int, pos u64) int {
 }
 
 // **************************** Read ops  ***************************
+
+// fread wraps C.fread and handles error and end-of-file detection.
+fn fread(ptr voidptr, item_size int, items int, stream &C.FILE) ?int {
+	nbytes := int(C.fread(ptr, item_size, items, stream))
+	// If no bytes were read, check for errors and end-of-file.
+	if nbytes <= 0 {
+		// If fread encountered end-of-file return the none error. Note that fread
+		// may read data and encounter the end-of-file, but we shouldn't return none
+		// in that case which is why we only check for end-of-file if no data was
+		// read. The caller will get none on their next call because there will be
+		// no data available and the end-of-file will be encountered again.
+		if C.feof(stream) != 0 {
+			return none
+		}
+		// If fread encountered an error, return it. Note that fread and ferror do
+		// not tell us what the error was, so we can't return anything more specific
+		// than there was an error. This is because fread and ferror do not set
+		// errno.
+		if C.ferror(stream) != 0 {
+			return error("file read error")
+		}
+	}
+	return nbytes
+}
+
 // read_bytes reads bytes from the beginning of the file.
 // Utility method, same as .read_bytes_at(size, 0).
 pub fn (f &File) read_bytes(size int) []byte {
@@ -391,25 +416,7 @@ pub fn (f &File) read(mut buf []byte) ?int {
 	if buf.len == 0 {
 		return 0
 	}
-	nbytes := int(C.fread(buf.data, 1, buf.len, f.cfile))
-	// If no bytes were read, check for errors and end-of-file.
-	if nbytes <= 0 {
-		// If fread encountered end-of-file return the none error. Note that fread
-		// may read data and encounter the end-of-file, but we shouldn't return none
-		// in that case which is why we only check for end-of-file if no data was
-		// read. The caller will get none on their next call because there will be
-		// no data available and the end-of-file will be encountered again.
-		if C.feof(f.cfile) != 0 {
-			return none
-		}
-		// If fread encountered an error, return it. Note that fread and ferror do
-		// not tell us what the error was, so we can't return anything more specific
-		// than there was an error. This is because fread and ferror do not set
-		// errno.
-		if C.ferror(f.cfile) != 0 {
-			return error("file read error")
-		}
-	}
+	nbytes := fread(buf.data, 1, buf.len, f.cfile) ?
 	return nbytes
 }
 

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -65,12 +65,12 @@ fn testsuite_end() ? {
 // containing data.
 fn test_read_eof_last_read_partial_buffer_fill() ? {
 	mut f := os.open_file(tfile, 'w') ?
-	bw := []byte{len:199, init:5}
+	bw := []byte{len: 199, init: 5}
 	f.write(bw) ?
 	f.close()
 
 	f = os.open_file(tfile, 'r') ?
-	mut br := []byte{len:100}
+	mut br := []byte{len: 100}
 	// Read first 100 bytes of 199 byte file, should fill buffer with no error.
 	n0 := f.read(mut br) ?
 	assert n0 == 100
@@ -97,12 +97,12 @@ fn test_read_eof_last_read_partial_buffer_fill() ? {
 // fread that returns no data.
 fn test_read_eof_last_read_full_buffer_fill() ? {
 	mut f := os.open_file(tfile, 'w') ?
-	bw := []byte{len:200, init:5}
+	bw := []byte{len: 200, init: 5}
 	f.write(bw) ?
 	f.close()
 
 	f = os.open_file(tfile, 'r') ?
-	mut br := []byte{len:100}
+	mut br := []byte{len: 100}
 	// Read first 100 bytes of 200 byte file, should fill buffer with no error.
 	n0 := f.read(mut br) ?
 	assert n0 == 100

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -160,8 +160,13 @@ fn test_write_and_read_bytes() {
 	// check that trying to read data from EOF doesn't error and returns 0
 	mut a := []byte{len: 5}
 	nread := file_read.read_bytes_into(5, mut a) or {
-		eprintln(err)
-		int(-1)
+		n := if err is none {
+			int(0)
+		} else {
+			eprintln(err)
+			int(-1)
+		}
+		n
 	}
 	assert nread == 0
 	file_read.close()


### PR DESCRIPTION
### What
Detect the end of file and error correctly when reading files, and return corresponding none or error errors.

### Why
The file read functions do not currently detect file read errors or the end-of-file.

The file read functions attempt to use errno, but the fread function does not set errno, so errno will always indicate no error even if an error has occurred. To detect an error the ferror function must be used. Additionally, when using fread and ferror there is no way to detect what error occurred, just that an error occurred, so the code to convert the error code into a posix error is not useful here and not replaceable unless this code was rewritten to use the non-buffered read function instead of fread.

The file read functions also do not detect the end-of-file at all and when encountering the end-of-file will return zero bytes read. Other functions in the stdlib, like `io.cp()`, expect a none error to be returned in this case. To detect the end-of-file the feof function must be used.

Close #10036.
