### PR TITLE
cgen: format generated struct definition c codes

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5577,7 +5577,7 @@ fn (mut g Gen) write_types(types []ast.TypeSymbol) {
 						g.type_definitions.writeln('\t$type_name $field_name;')
 					}
 				} else {
-					g.type_definitions.writeln('EMPTY_STRUCT_DECLARATION;')
+					g.type_definitions.writeln('\tEMPTY_STRUCT_DECLARATION;')
 				}
 				// g.type_definitions.writeln('} $name;\n')
 				//
@@ -5586,7 +5586,7 @@ fn (mut g Gen) write_types(types []ast.TypeSymbol) {
 				} else {
 					''
 				}
-				g.type_definitions.writeln('} $attrs;\n')
+				g.type_definitions.writeln('}$attrs;\n')
 			}
 			ast.Alias {
 				// ast.Alias { TODO


### PR DESCRIPTION
This PR format generated struct definition c codes.

Before:
```vlang
typedef HANDLE __v_thread;
struct ContextRecord {
EMPTY_STRUCT_DECLARATION;
} ;

struct ExceptionPointers {
	ExceptionRecord* exception_record;
	ContextRecord* context_record;
} ;

struct ustring {
	string s;
	Array_int runes;
	int len;
} ;

struct VCastTypeIndexName {
	int tindex;
	string tname;
} ;

struct VAssertMetaInfo {
	string fpath;
	int line_nr;
	string fn_name;
	string src;
	string op;
	string llabel;
	string rlabel;
	string lvalue;
	string rvalue;
} ;

struct MethodArgs {
	int typ;
	string name;
} ;
```
Now:
```vlang
typedef HANDLE __v_thread;
struct ContextRecord {
	EMPTY_STRUCT_DECLARATION;
};

struct ExceptionPointers {
	ExceptionRecord* exception_record;
	ContextRecord* context_record;
};

struct ustring {
	string s;
	Array_int runes;
	int len;
};

struct VCastTypeIndexName {
	int tindex;
	string tname;
};

struct VAssertMetaInfo {
	string fpath;
	int line_nr;
	string fn_name;
	string src;
	string op;
	string llabel;
	string rlabel;
	string lvalue;
	string rvalue;
};

struct MethodArgs {
	int typ;
	string name;
};
```