### PR TITLE
cgen: fix generics with generics fn type parameter (fix #10073)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2373,7 +2373,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 			}
 			else {}
 		}
-		right_sym := g.table.get_type_symbol(val_type)
+		right_sym := g.table.get_type_symbol(g.unwrap_generic(val_type))
 		is_fixed_array_copy := right_sym.kind == .array_fixed && val is ast.Ident
 		g.is_assign_lhs = true
 		g.assign_op = assign_stmt.op

--- a/vlib/v/tests/generics_with_generics_fn_type_parameter_test.v
+++ b/vlib/v/tests/generics_with_generics_fn_type_parameter_test.v
@@ -4,17 +4,38 @@ fn neg(a int) int {
 
 fn indirect_call(func fn (int) int, a int) int {
 	println(typeof(func).name)
+	assert typeof(func).name == typeof(neg).name
 	return func(a)
 }
 
 fn generic_call<T>(func T, a int) int {
 	println(T.name)
+	assert T.name == typeof(neg).name
 	return func(a)
 }
 
 fn generic_indirect_call<T>(func T, a int) int {
 	println(T.name)
+	assert T.name == typeof(neg).name
 	return indirect_call(func, a)
+}
+
+fn indirect_call_v2(func fn (int) int, a int) int {
+	f := func
+	assert typeof(f).name == typeof(neg).name
+	return f(a)
+}
+
+fn generic_call_v2<T>(func T, a int) int {
+	f := func
+	assert typeof(f).name == typeof(neg).name
+	return f(a)
+}
+
+fn generic_indirect_call_v2<T>(func T, a int) int {
+	f := func
+	assert typeof(f).name == typeof(neg).name
+	return indirect_call_v2(f, a)
 }
 
 fn test_generics_with_generics_fn_type_parameter() {
@@ -31,4 +52,16 @@ fn test_generics_with_generics_fn_type_parameter() {
 	ret = generic_indirect_call(neg, 4)
 	println(ret)
 	assert ret == -4
+
+	ret = indirect_call_v2(neg, 5)
+	println(ret)
+	assert ret == -5
+
+	ret = generic_call_v2(neg, 6)
+	println(ret)
+	assert ret == -6
+
+	ret = generic_indirect_call_v2(neg, 7)
+	println(ret)
+	assert ret == -7
 }


### PR DESCRIPTION
This PR fix generics with generics fn type parameter (fix #10073).

- Fix generics with generics fn type parameter.
- Modify test.

```vlang
fn neg(a int) int {
	return -a
}

fn indirect_call(func fn (int) int, a int) int {
	println(typeof(func).name)
	assert typeof(func).name == typeof(neg).name
	return func(a)
}

fn generic_call<T>(func T, a int) int {
	println(T.name)
	assert T.name == typeof(neg).name
	return func(a)
}

fn generic_indirect_call<T>(func T, a int) int {
	println(T.name)
	assert T.name == typeof(neg).name
	return indirect_call(func, a)
}

fn indirect_call_v2(func fn (int) int, a int) int {
	f := func
	assert typeof(f).name == typeof(neg).name
	return f(a)
}

fn generic_call_v2<T>(func T, a int) int {
	f := func
	assert typeof(f).name == typeof(neg).name
	return f(a)
}

fn generic_indirect_call_v2<T>(func T, a int) int {
	f := func
	assert typeof(f).name == typeof(neg).name
	return indirect_call_v2(f, a)
}

fn main() {
	mut ret := 0

	ret = indirect_call(neg, 2)
	println(ret)
	assert ret == -2

	ret = generic_call(neg, 3)
	println(ret)
	assert ret == -3

	ret = generic_indirect_call(neg, 4)
	println(ret)
	assert ret == -4

	ret = indirect_call_v2(neg, 5)
	println(ret)
	assert ret == -5

	ret = generic_call_v2(neg, 6)
	println(ret)
	assert ret == -6

	ret = generic_indirect_call_v2(neg, 7)
	println(ret)
	assert ret == -7
}

PS D:\Test\v\tt1> v run .
fn (int) int
-2
fn (int) int
-3
fn (int) int
fn (int) int
-4
-5
-6
-7
```