### PR TITLE
builtin.string: optimize split_into_lines

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -648,32 +648,29 @@ pub fn (s string) split_nth(delim string, nth int) []string {
 }
 
 // split_into_lines splits the string by newline characters.
-// Both `\n` and `\r\n` newline endings is supported.
+// newlines are stripped.
+// Both `\n` and `\r\n` newline endings are supported.
+[direct_array_access]
 pub fn (s string) split_into_lines() []string {
 	mut res := []string{}
 	if s.len == 0 {
 		return res
 	}
 	mut start := 0
+	mut end := 0
 	for i := 0; i < s.len; i++ {
-		is_lf := unsafe { s.str[i] } == 10
-		is_crlf := i != s.len - 1 && unsafe { s.str[i] == 13 && s.str[i + 1] == 10 }
-		is_eol := is_lf || is_crlf
-		is_last := if is_crlf { i == s.len - 2 } else { i == s.len - 1 }
-		if is_eol || is_last {
-			if is_last && !is_eol {
-				i++
-			}
-			line := s.substr(start, i)
-			res << line
-			if is_crlf {
-				i++
-			}
+		if s[i] == 10 {
+			end = if i > 0 && s[i - 1] == 13 { i - 1 } else { i }
+			res << if start == end { '' } else { s[start..end] }
 			start = i + 1
 		}
 	}
+	if start < s.len {
+		res << s[start..]
+	}
 	return res
 }
+
 
 // used internally for [2..4]
 fn (s string) substr2(start int, _end int, end_max bool) string {


### PR DESCRIPTION
Minor optimization that will be more noticeable on larger files.

Test bench: split_into_lines.v
```v
import benchmark

lines := '
one
two
three
four
five
six
seven
eight
nine
ten'

mut bench := benchmark.start()
for _ in 0..100000 {
        lines.split_into_lines()
}
bench.measure('split loop')
```
Several runs:
```
jalon@Ripper:~/testing$ v run split_into_lines.v
 SPENT   144.427 ms in split loop
jalon@Ripper:~/testing$ ~/git/vv/v run split_into_lines.v
 SPENT   118.418 ms in split loop
jalon@Ripper:~/testing$ v run split_into_lines.v
 SPENT   142.780 ms in split loop
jalon@Ripper:~/testing$ ~/git/vv/v run split_into_lines.v
 SPENT   119.177 ms in split loop
jalon@Ripper:~/testing$ v run split_into_lines.v
 SPENT   145.559 ms in split loop
jalon@Ripper:~/testing$ ~/git/vv/v run split_into_lines.v
 SPENT   118.264 ms in split loop
jalon@Ripper:~/testing$
```

BONUS:  `unsafe` no longer required.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
