### PR TITLE
Fix csv handling of last empty fields

### DIFF
--- a/vlib/encoding/csv/reader.v
+++ b/vlib/encoding/csv/reader.v
@@ -134,7 +134,7 @@ fn (mut r Reader) read_record() ?[]string {
 			need_read = false
 			keep_raw = false
 		}
-		if line[0] != `"` { // not quoted
+		if line.len == 0 || line[0] != `"` { // not quoted
 			j := line.index(r.delimiter.ascii_str()) or {
 				// last
 				fields << line[..line.len]

--- a/vlib/encoding/csv/reader.v
+++ b/vlib/encoding/csv/reader.v
@@ -160,9 +160,10 @@ fn (mut r Reader) read_record() ?[]string {
 			if next == r.delimiter {
 				fields << line[..j]
 				if j + 2 == line.len {
-					break
+					line = ''
+				} else {
+					line = line[j + 2..]
 				}
-				line = line[j + 2..]
 				continue
 			}
 		}

--- a/vlib/encoding/csv/reader_test.v
+++ b/vlib/encoding/csv/reader_test.v
@@ -116,6 +116,44 @@ fn test_last_field_empty() {
 	assert row_count == 3
 }
 
+fn test_empty_fields_no_quotes() {
+	data := '1,2,3,4\n,6,7,8\n9,,11,12\n13,14,,16\n17,18,19,\n'
+
+	mut csv_reader := csv.new_reader(data)
+	mut row_count := 0
+	for {
+		row := csv_reader.read() or { break }
+		row_count++
+		if row_count == 1 {
+			assert row[0] == '1'
+			assert row[1] == '2'
+			assert row[2] == '3'
+			assert row[3] == '4'
+		} else if row_count == 2 {
+			assert row[0] == ''
+			assert row[1] == '6'
+			assert row[2] == '7'
+			assert row[3] == '8'
+		} else if row_count == 3 {
+			assert row[0] == '9'
+			assert row[1] == ''
+			assert row[2] == '11'
+			assert row[3] == '12'
+		} else if row_count == 4 {
+			assert row[0] == '13'
+			assert row[1] == '14'
+			assert row[2] == ''
+			assert row[3] == '16'
+		} else if row_count == 5 {
+			assert row[0] == '17'
+			assert row[1] == '18'
+			assert row[2] == '19'
+			assert row[3] == ''
+		}
+	}
+	assert row_count == 5
+}
+
 fn test_empty_line() {
 	data := '"name","description","value"\n\n\n"one","first","1"\n\n"two","second",\n'
 	mut csv_reader := csv.new_reader(data)

--- a/vlib/encoding/csv/reader_test.v
+++ b/vlib/encoding/csv/reader_test.v
@@ -111,6 +111,7 @@ fn test_last_field_empty() {
 		} else if row_count == 3 {
 			assert row[0] == 'two'
 			assert row[1] == 'second'
+			assert row[2] == ''
 		}
 	}
 	assert row_count == 3


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Before:

    [hdante@dragonmount tmp]$ cat c.v 
    import encoding.csv { new_reader }
    s := '1,2,3,\n'
    mut csv := new_reader(s)
    fields := csv.read() ?
    println(fields)
    [hdante@dragonmount tmp]$ v run c.v
    V panic: string index out of range: 0 / 0
    v hash: 066374b
    /tmp/v/c.10564525193690465131.tmp.c:5398: at v_panic: Backtrace
    /tmp/v/c.10564525193690465131.tmp.c:8576: by string_at
    /tmp/v/c.10564525193690465131.tmp.c:9217: by encoding__csv__Reader_read_record
    /tmp/v/c.10564525193690465131.tmp.c:9137: by encoding__csv__Reader_read
    /tmp/v/c.10564525193690465131.tmp.c:9340: by main__main
    /tmp/v/c.10564525193690465131.tmp.c:9728: by main

After:

    [hdante@dragonmount tmp]$ v run c.v
    ['1', '2', '3', '']

Before:

    [hdante@dragonmount tmp]$ cat d.v
    import encoding.csv { new_reader }
    s := '1,2,"3",\n'
    mut csv := new_reader(s)
    fields := csv.read() ?
    println(fields)
    [hdante@dragonmount tmp]$ v run d.v
    ['1', '2', '3']

After:

    [hdante@dragonmount tmp]$ v run d.v
    ['1', '2', '3', '']
