### PR TITLE
io: mark the mutability requirements of the Writer interface explicitly; swap the io.cp/2 parameter order to be like os.cp/2

### DIFF
--- a/vlib/io/io.v
+++ b/vlib/io/io.v
@@ -4,7 +4,7 @@ const (
 	buf_max_len = 1024
 )
 
-pub fn cp(dst Writer, src Reader) ? {
+pub fn cp(src Reader, mut dst Writer) ? {
 	mut buf := []byte{len: io.buf_max_len}
 	for {
 		len := src.read(mut buf) or { break }

--- a/vlib/io/io_cp_test.v
+++ b/vlib/io/io_cp_test.v
@@ -2,7 +2,8 @@ import io
 import os
 
 fn test_cp() ? {
-	mut f := os.open(@FILE) or { panic(err) }
+	my_source := @FILE
+	mut f := os.open(my_source) or { panic(err) }
 	defer {
 		f.close()
 	}

--- a/vlib/io/io_cp_test.v
+++ b/vlib/io/io_cp_test.v
@@ -1,0 +1,13 @@
+import io
+import os
+
+fn test_cp() ? {
+	mut f := os.open(@FILE) or { panic(err) }
+	defer {
+		f.close()
+	}
+	mut r := io.new_buffered_reader(reader: io.make_reader(f))
+	mut stdout := os.stdout()
+	io.cp(r, mut stdout) ?
+	assert true
+}

--- a/vlib/io/io_cp_test.v
+++ b/vlib/io/io_cp_test.v
@@ -2,8 +2,7 @@ import io
 import os
 
 fn test_cp() ? {
-	my_source := @FILE
-	mut f := os.open(my_source) or { panic(err) }
+	mut f := os.open(@FILE) or { panic(err) }
 	defer {
 		f.close()
 	}

--- a/vlib/io/io_cp_test.v
+++ b/vlib/io/io_cp_test.v
@@ -6,7 +6,7 @@ fn test_cp() ? {
 	defer {
 		f.close()
 	}
-	mut r := io.new_buffered_reader(reader: io.make_reader(f))
+	mut r := io.new_buffered_reader(reader: f)
 	mut stdout := os.stdout()
 	io.cp(r, mut stdout) ?
 	assert true

--- a/vlib/io/io_test.v
+++ b/vlib/io/io_test.v
@@ -33,9 +33,9 @@ fn test_copy() {
 	src := Buf{
 		bytes: 'abcdefghij'.repeat(10).bytes()
 	}
-	dst := Writ{
+	mut dst := Writ{
 		bytes: []byte{}
 	}
-	io.cp(dst, src) or { assert false }
+	io.cp(src, mut dst) or { assert false }
 	assert dst.bytes == src.bytes
 }

--- a/vlib/io/multi_writer.v
+++ b/vlib/io/multi_writer.v
@@ -14,7 +14,7 @@ pub fn new_multi_writer(writers ...Writer) Writer {
 
 // MultiWriter writes to all its writers.
 pub struct MultiWriter {
-pub:
+pub mut:
 	writers []Writer
 }
 
@@ -22,8 +22,8 @@ pub:
 // written. If any writer fails to write the full length an error is returned
 // and writing to other writers stops. If any writer returns an error the error
 // is returned immediately and writing to other writers stops.
-pub fn (m MultiWriter) write(buf []byte) ?int {
-	for w in m.writers {
+pub fn (mut m MultiWriter) write(buf []byte) ?int {
+	for mut w in m.writers {
 		n := w.write(buf) ?
 		if n != buf.len {
 			return error('io: incomplete write to writer of MultiWriter')

--- a/vlib/io/multi_writer_test.v
+++ b/vlib/io/multi_writer_test.v
@@ -3,7 +3,7 @@ module io
 fn test_multi_writer_write_successful() {
 	w0 := TestWriter{}
 	w1 := TestWriter{}
-	mw := new_multi_writer(w0, w1)
+	mut mw := new_multi_writer(w0, w1)
 	n := mw.write('0123456789'.bytes()) or {
 		assert false
 		return
@@ -16,7 +16,7 @@ fn test_multi_writer_write_successful() {
 fn test_multi_writer_write_incomplete() {
 	w0 := TestWriter{}
 	w1 := TestIncompleteWriter{}
-	mw := new_multi_writer(w0, w1)
+	mut mw := new_multi_writer(w0, w1)
 	n := mw.write('0123456789'.bytes()) or {
 		assert w0.bytes == '0123456789'.bytes()
 		assert w1.bytes == '012345678'.bytes()
@@ -29,7 +29,7 @@ fn test_multi_writer_write_error() {
 	w0 := TestWriter{}
 	w1 := TestErrorWriter{}
 	w2 := TestWriter{}
-	mw := new_multi_writer(w0, w1, w2)
+	mut mw := new_multi_writer(w0, w1, w2)
 	n := mw.write('0123456789'.bytes()) or {
 		assert w0.bytes == '0123456789'.bytes()
 		assert w2.bytes == []

--- a/vlib/io/readerwriter.v
+++ b/vlib/io/readerwriter.v
@@ -12,6 +12,7 @@ pub interface ReaderWriter {
 // a seperate reader and writer (see fn make_readerwriter)
 struct ReaderWriterImpl {
 	r Reader
+mut:
 	w Writer
 }
 

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -19,7 +19,7 @@ const (
 		'float', 'for', 'free', 'goto', 'if', 'inline', 'int', 'link', 'long', 'malloc', 'namespace',
 		'new', 'panic', 'register', 'restrict', 'return', 'short', 'signed', 'sizeof', 'static',
 		'struct', 'switch', 'typedef', 'typename', 'union', 'unix', 'unsigned', 'void', 'volatile',
-		'while', 'template']
+		'while', 'template', 'stdout', 'stdin', 'stderr']
 	c_reserved_map = string_array_to_map(c_reserved)
 	// same order as in token.Kind
 	cmp_str        = ['eq', 'ne', 'gt', 'lt', 'ge', 'le']


### PR DESCRIPTION
This PR makes the following uncompilable:
```v
import io
import os
fn main() {
    stdin := os.stdin()
    stdout := os.stdout()
    io.cp(stdout, stdin) ?
}
```

Instead, this program now compiles:
```v
import io
import os
fn main() {
    stdin := os.stdin()
    mut stdout := os.stdout()
    io.cp(stdin, mut stdout) ?
}
```