### PR TITLE
checker: fix generics fn inferred structure type (fix #10093)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -549,7 +549,7 @@ pub fn (mut c Checker) infer_fn_generic_types(f ast.Fn, mut call_expr ast.CallEx
 					}
 				} else if param.typ.has_flag(.variadic) {
 					to_set = c.table.mktyp(arg.typ)
-				} else if arg_sym.kind == .struct_ {
+				} else if arg_sym.kind == .struct_ && param.typ.has_flag(.generic) {
 					info := arg_sym.info as ast.Struct
 					generic_names := info.generic_types.map(c.table.get_type_symbol(it).name)
 					if gt_name in generic_names {

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -554,7 +554,7 @@ pub fn (mut c Checker) infer_fn_generic_types(f ast.Fn, mut call_expr ast.CallEx
 					generic_names := info.generic_types.map(c.table.get_type_symbol(it).name)
 					if gt_name in generic_names {
 						idx := generic_names.index(gt_name)
-						to_set = info.concrete_types[idx]
+						typ = info.concrete_types[idx]
 					}
 				}
 			}

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -549,6 +549,13 @@ pub fn (mut c Checker) infer_fn_generic_types(f ast.Fn, mut call_expr ast.CallEx
 					}
 				} else if param.typ.has_flag(.variadic) {
 					to_set = c.table.mktyp(arg.typ)
+				} else if arg_sym.kind == .struct_ {
+					info := arg_sym.info as ast.Struct
+					generic_names := info.generic_types.map(c.table.get_type_symbol(it).name)
+					if gt_name in generic_names {
+						idx := generic_names.index(gt_name)
+						to_set = info.concrete_types[idx]
+					}
 				}
 			}
 

--- a/vlib/v/tests/generic_fn_infer_struct_test.v
+++ b/vlib/v/tests/generic_fn_infer_struct_test.v
@@ -12,13 +12,8 @@ fn test_generics_fn_infer_struct() {
 	assert ret1.contains('Node<int>{')
 	assert ret1.contains('data: 0')
 
-	ret2 := foo(Node<f64>{})
+	ret2 := foo(Node<byte>{})
 	println(ret2)
-	assert ret2.contains('Node<f64>{')
+	assert ret2.contains('Node<byte>{')
 	assert ret2.contains('data: 0')
-
-	ret3 := foo(Node<byte>{})
-	println(ret3)
-	assert ret3.contains('Node<byte>{')
-	assert ret3.contains('data: 0')
 }

--- a/vlib/v/tests/generic_fn_infer_struct_test.v
+++ b/vlib/v/tests/generic_fn_infer_struct_test.v
@@ -1,0 +1,24 @@
+struct Node<T> {
+	data T
+}
+
+fn foo<T>(n Node<T>) string {
+	return '$n'
+}
+
+fn test_generics_fn_infer_struct() {
+	ret1 := foo(Node<int>{})
+	println(ret1)
+	assert ret1.contains('Node<int>{')
+	assert ret1.contains('data: 0')
+
+	ret2 := foo(Node<f64>{})
+	println(ret2)
+	assert ret2.contains('Node<f64>{')
+	assert ret2.contains('data: 0')
+
+	ret3 := foo(Node<byte>{})
+	println(ret3)
+	assert ret3.contains('Node<byte>{')
+	assert ret3.contains('data: 0')
+}


### PR DESCRIPTION
This PR fix generics fn inferred structure type (fix #10093).

- Fix generics fn inferred structure type.
- Add test.

```vlang
struct Node<T> {
	data T
}

fn foo<T>(n Node<T>) string {
	return '$n'
}

fn test_generics_fn_infer_struct() {
	ret1 := foo(Node<int>{})
	println(ret1)
	assert ret1.contains('Node<int>{')
	assert ret1.contains('data: 0')

	ret2 := foo(Node<f64>{})
	println(ret2)
	assert ret2.contains('Node<f64>{')
	assert ret2.contains('data: 0')

	ret3 := foo(Node<byte>{})
	println(ret3)
	assert ret3.contains('Node<byte>{')
	assert ret3.contains('data: 0')
}

PS D:\Test\v\tt1> v run .
Node<int>{
    data: 0
}
Node<f64>{
    data: 0
}
Node<byte>{
    data: 0
}
```