### PR TITLE
v.builder: remove default link flags -lm, -ldl, -lpthread

### DIFF
--- a/vlib/dl/dl_nix.c.v
+++ b/vlib/dl/dl_nix.c.v
@@ -2,6 +2,10 @@ module dl
 
 #include <dlfcn.h>
 
+$if linux {
+	#flag -ldl
+}
+
 pub const (
 	rtld_now  = C.RTLD_NOW
 	rtld_lazy = C.RTLD_LAZY

--- a/vlib/fontstash/fontstash.v
+++ b/vlib/fontstash/fontstash.v
@@ -9,6 +9,15 @@ $if gcboehm ? {
 }
 #include "fontstash.h"
 #flag -I /usr/local/Cellar/freetype/2.10.2/include/freetype2
+
+$if windows {
+	$if tinyc {
+		#flag @VEXEROOT/thirdparty/tcc/lib/openlibm.o
+	}
+} $else {
+	#flag -lm
+}
+
 //#flag -lfreetype
 pub const (
 	// TODO: fontstash.used_import is used to keep v from warning about unused imports

--- a/vlib/math/math.c.v
+++ b/vlib/math/math.c.v
@@ -4,11 +4,15 @@
 module math
 
 #include <math.h>
+
 $if windows {
 	$if tinyc {
 		#flag @VEXEROOT/thirdparty/tcc/lib/openlibm.o
 	}
+} $else {
+	#flag -lm
 }
+
 fn C.acos(x f64) f64
 
 fn C.asin(x f64) f64

--- a/vlib/sokol/c/declaration.c.v
+++ b/vlib/sokol/c/declaration.c.v
@@ -40,6 +40,8 @@ $if ios {
 #flag solaris -DSOKOL_NO_ENTRY
 // TODO end
 
+#flag linux -ldl
+
 $if gcboehm ? {
 	#define SOKOL_MALLOC GC_MALLOC
 	#define SOKOL_CALLOC(n,m) GC_MALLOC((n)*(m))

--- a/vlib/sync/threads/threads.c.v
+++ b/vlib/sync/threads/threads.c.v
@@ -1,0 +1,13 @@
+module threads
+
+// This module adds the necessary compiler flags for using threads.
+// It is automatically imported by code that does `go func()` .
+// See vlib/v/parser/pratt.v, search for ast.GoExpr .
+// The goal is that programs, that do not use threads at all will not need
+// to link to -lpthread etc.
+// NB: on some platforms like Android, linking -lpthread is not needed too.
+// See https://stackoverflow.com/a/31277163/1904615
+
+$if !windows && !android {
+	#flag -lpthread
+}

--- a/vlib/sync/threads/threads.v
+++ b/vlib/sync/threads/threads.v
@@ -1,0 +1,4 @@
+module threads
+
+// This file is just a placeholder.
+// The actual implementation is backend/platform specific, so see threads.c.v, threads.js.v etc.

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -380,19 +380,10 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	// || os.user_os() == 'linux'
 	if !v.pref.is_bare && v.pref.build_mode != .build_module
 		&& v.pref.os in [.linux, .freebsd, .openbsd, .netbsd, .dragonfly, .solaris, .haiku] {
-		ccoptions.linker_flags << '-lm'
-		ccoptions.linker_flags << '-lpthread'
-		// -ldl is a Linux only thing. BSDs have it in libc.
-		if v.pref.os == .linux {
-			ccoptions.linker_flags << '-ldl'
-		}
 		if v.pref.os in [.freebsd, .netbsd] {
 			// Free/NetBSD: backtrace needs execinfo library while linking
 			ccoptions.linker_flags << '-lexecinfo'
 		}
-	}
-	if !v.pref.is_bare && v.pref.os == .js && os.user_os() == 'linux' {
-		ccoptions.linker_flags << '-lm'
 	}
 	ccoptions.env_cflags = os.getenv('CFLAGS')
 	ccoptions.env_ldflags = os.getenv('LDFLAGS')

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -519,6 +519,7 @@ fn (mut p Parser) go_expr() ast.GoExpr {
 		}
 	}
 	pos := spos.extend(p.prev_tok.position())
+	p.register_auto_import('sync.threads')
 	return ast.GoExpr{
 		call_expr: call_expr
 		pos: pos


### PR DESCRIPTION
Instead, add module specific link flags.

This PR reduces the amount of -l flags passed for programs that do not
need math functions or threads.