### PR TITLE
shared: support `lock` on SelectorExpression

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -31,6 +31,8 @@ pub type Node = CallArg | ConstField | EmptyNode | EnumField | Expr | File | Glo
 	IfBranch | MatchBranch | NodeError | Param | ScopeObject | SelectBranch | Stmt | StructField |
 	StructInitField
 
+pub type Lockable = Ident | SelectorExpr
+
 pub struct TypeNode {
 pub:
 	typ Type
@@ -740,7 +742,7 @@ pub:
 	is_rlock []bool
 	pos      token.Position
 pub mut:
-	lockeds []Ident // `x`, `y` in `lock x, y {`
+	lockeds []Lockable // `x`, `y.z` in `lock x, y.z {`
 	is_expr bool
 	typ     Type
 	scope   &Scope

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -31,8 +31,6 @@ pub type Node = CallArg | ConstField | EmptyNode | EnumField | Expr | File | Glo
 	IfBranch | MatchBranch | NodeError | Param | ScopeObject | SelectBranch | Stmt | StructField |
 	StructInitField
 
-pub type Lockable = Ident | SelectorExpr
-
 pub struct TypeNode {
 pub:
 	typ Type
@@ -742,10 +740,11 @@ pub:
 	is_rlock []bool
 	pos      token.Position
 pub mut:
-	lockeds []Lockable // `x`, `y.z` in `lock x, y.z {`
-	is_expr bool
-	typ     Type
-	scope   &Scope
+	lockeds  []Expr // `x`, `y.z` in `lock x, y.z {`
+	comments []Comment
+	is_expr  bool
+	typ      Type
+	scope    &Scope
 }
 
 pub struct MatchExpr {
@@ -1596,6 +1595,21 @@ pub fn (expr Expr) is_auto_deref_var() bool {
 		else {}
 	}
 	return false
+}
+
+// returns if an expression can be used in `lock x, y.z {`
+pub fn (e &Expr) is_lockable() bool {
+	match e {
+		Ident {
+			return true
+		}
+		SelectorExpr {
+			return e.expr.is_lockable()
+		}
+		else {
+			return false
+		}
+	}
 }
 
 // check if stmt can be an expression in C

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -401,7 +401,7 @@ pub fn (mut c Checker) fail_if_unreadable(expr ast.Expr, typ ast.Type, what stri
 			if typ.has_flag(.shared_f) {
 				if expr.name !in c.rlocked_names && expr.name !in c.locked_names {
 					action := if what == 'argument' { 'passed' } else { 'used' }
-					c.error('$expr.name is `shared` and must be `rlock`ed or `lock`ed to be $action as non-mut $what',
+					c.error('`$expr.name` is `shared` and must be `rlock`ed or `lock`ed to be $action as non-mut $what',
 						expr.pos)
 				}
 			}
@@ -413,7 +413,7 @@ pub fn (mut c Checker) fail_if_unreadable(expr ast.Expr, typ ast.Type, what stri
 				expr_name := '${expr.expr}.$expr.field_name'
 				if expr_name !in c.rlocked_names && expr_name !in c.locked_names {
 					action := if what == 'argument' { 'passed' } else { 'used' }
-					c.error('$expr_name is `shared` and must be `rlock`ed or `lock`ed to be $action as non-mut $what',
+					c.error('`$expr_name` is `shared` and must be `rlock`ed or `lock`ed to be $action as non-mut $what',
 						expr.pos)
 				}
 				return

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5694,9 +5694,13 @@ pub fn (mut c Checker) lock_expr(mut node ast.LockExpr) ast.Type {
 		e_typ := c.expr(node.lockeds[i])
 		id_name := node.lockeds[i].str()
 		if !e_typ.has_flag(.shared_f) {
-			c.error('`$id_name` must be declared `shared` to be locked', node.lockeds[i].position())
+			obj_type := if node.lockeds[i] is ast.Ident {
+				'variable'
+			} else {
+				'struct element'
+			}
+			c.error('`$id_name` must be declared as `shared` $obj_type to be locked', node.lockeds[i].position())
 		}
-		// c.error('`$id.name` is not a variable and cannot be locked', id.pos)
 		if id_name in c.locked_names {
 			c.error('`$id_name` is already locked', node.lockeds[i].position())
 		} else if id_name in c.rlocked_names {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5679,24 +5679,21 @@ pub fn (mut c Checker) lock_expr(mut node ast.LockExpr) ast.Type {
 		c.error('nested `lock`/`rlock` not allowed', node.pos)
 	}
 	for i in 0 .. node.lockeds.len {
-		c.ident(mut node.lockeds[i])
-		id := node.lockeds[i]
-		if mut id.obj is ast.Var {
-			if id.obj.typ.share() != .shared_t {
-				c.error('`$id.name` must be declared `shared` to be locked', id.pos)
-			}
-		} else {
-			c.error('`$id.name` is not a variable and cannot be locked', id.pos)
+		e_typ := c.expr(node.lockeds[i])
+		id_name := node.lockeds[i].str()
+		if !e_typ.has_flag(.shared_f) {
+			c.error('`$id_name` must be declared `shared` to be locked', node.lockeds[i].position())
 		}
-		if id.name in c.locked_names {
-			c.error('`$id.name` is already locked', id.pos)
-		} else if id.name in c.rlocked_names {
-			c.error('`$id.name` is already read-locked', id.pos)
+		// c.error('`$id.name` is not a variable and cannot be locked', id.pos)
+		if id_name in c.locked_names {
+			c.error('`$id_name` is already locked', node.lockeds[i].position())
+		} else if id_name in c.rlocked_names {
+			c.error('`$id_name` is already read-locked', node.lockeds[i].position())
 		}
 		if node.is_rlock[i] {
-			c.rlocked_names << id.name
+			c.rlocked_names << id_name
 		} else {
-			c.locked_names << id.name
+			c.locked_names << id_name
 		}
 	}
 	c.stmts(node.stmts)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1407,7 +1407,7 @@ fn (mut c Checker) fail_if_immutable(expr ast.Expr) (string, token.Position) {
 							expr.pos)
 					}
 					if field_info.typ.has_flag(.shared_f) {
-						expr_name := '${expr.expr}.${expr.field_name}'
+						expr_name := '${expr.expr}.$expr.field_name'
 						if expr_name !in c.locked_names {
 							if c.locked_names.len > 0 || c.rlocked_names.len > 0 {
 								if expr_name in c.rlocked_names {
@@ -5694,12 +5694,9 @@ pub fn (mut c Checker) lock_expr(mut node ast.LockExpr) ast.Type {
 		e_typ := c.expr(node.lockeds[i])
 		id_name := node.lockeds[i].str()
 		if !e_typ.has_flag(.shared_f) {
-			obj_type := if node.lockeds[i] is ast.Ident {
-				'variable'
-			} else {
-				'struct element'
-			}
-			c.error('`$id_name` must be declared as `shared` $obj_type to be locked', node.lockeds[i].position())
+			obj_type := if node.lockeds[i] is ast.Ident { 'variable' } else { 'struct element' }
+			c.error('`$id_name` must be declared as `shared` $obj_type to be locked',
+				node.lockeds[i].position())
 		}
 		if id_name in c.locked_names {
 			c.error('`$id_name` is already locked', node.lockeds[i].position())

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1401,11 +1401,6 @@ fn (mut c Checker) fail_if_immutable(expr ast.Expr) (string, token.Position) {
 						c.error('unknown field `${type_str}.$expr.field_name`', expr.pos)
 						return '', pos
 					}
-					if !field_info.is_mut && !c.pref.translated {
-						type_str := c.table.type_to_str(expr.expr_type)
-						c.error('field `$expr.field_name` of struct `$type_str` is immutable',
-							expr.pos)
-					}
 					if field_info.typ.has_flag(.shared_f) {
 						expr_name := '${expr.expr}.$expr.field_name'
 						if expr_name !in c.locked_names {
@@ -1422,6 +1417,11 @@ fn (mut c Checker) fail_if_immutable(expr ast.Expr) (string, token.Position) {
 							pos = expr.pos
 						}
 					} else {
+						if !field_info.is_mut && !c.pref.translated {
+							type_str := c.table.type_to_str(expr.expr_type)
+							c.error('field `$expr.field_name` of struct `$type_str` is immutable',
+								expr.pos)
+						}
 						to_lock, pos = c.fail_if_immutable(expr.expr)
 					}
 					if to_lock != '' {

--- a/vlib/v/checker/tests/lock_already_locked.out
+++ b/vlib/v/checker/tests/lock_already_locked.out
@@ -5,7 +5,7 @@ vlib/v/checker/tests/lock_already_locked.vv:11:3: error: nested `lock`/`rlock` n
       |         ~~~~~
    12 |             a.x++
    13 |         }
-vlib/v/checker/tests/lock_already_locked.vv:15:10: error: a is `shared` and must be `rlock`ed or `lock`ed to be used as non-mut argument to print
+vlib/v/checker/tests/lock_already_locked.vv:15:10: error: `a` is `shared` and must be `rlock`ed or `lock`ed to be used as non-mut argument to print
    13 |         }
    14 |     }
    15 |     println(a.x)

--- a/vlib/v/checker/tests/lock_already_rlocked.out
+++ b/vlib/v/checker/tests/lock_already_rlocked.out
@@ -5,7 +5,7 @@ vlib/v/checker/tests/lock_already_rlocked.vv:11:3: error: nested `lock`/`rlock` 
       |         ~~~~
    12 |             a.x++
    13 |         }
-vlib/v/checker/tests/lock_already_rlocked.vv:15:10: error: a is `shared` and must be `rlock`ed or `lock`ed to be used as non-mut argument to print
+vlib/v/checker/tests/lock_already_rlocked.vv:15:10: error: `a` is `shared` and must be `rlock`ed or `lock`ed to be used as non-mut argument to print
    13 |         }
    14 |     }
    15 |     println(a.x)

--- a/vlib/v/checker/tests/lock_const.out
+++ b/vlib/v/checker/tests/lock_const.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/lock_const.vv:7:8: error: `a` is not a variable and cannot be locked 
+vlib/v/checker/tests/lock_const.vv:7:8: error: `a` must be declared as `shared` variable to be locked
     5 | fn main() {
     6 |     mut c := 0
     7 |     rlock a {

--- a/vlib/v/checker/tests/lock_needed.out
+++ b/vlib/v/checker/tests/lock_needed.out
@@ -5,21 +5,21 @@ vlib/v/checker/tests/lock_needed.vv:10:2: error: `abc` is `shared` and needs exp
       |     ~~~
    11 |     println(abc.x)
    12 | }
-vlib/v/checker/tests/lock_needed.vv:11:10: error: abc is `shared` and must be `rlock`ed or `lock`ed to be used as non-mut argument to print
+vlib/v/checker/tests/lock_needed.vv:11:10: error: `abc` is `shared` and must be `rlock`ed or `lock`ed to be used as non-mut argument to print
     9 |     }
    10 |     abc.x++
    11 |     println(abc.x)
       |             ~~~
    12 | }
    13 |
-vlib/v/checker/tests/lock_needed.vv:25:12: error: you have to create a handle and `rlock` it to use a `shared` element as non-mut argument to print
+vlib/v/checker/tests/lock_needed.vv:25:12: error: `a.st` is `shared` and must be `rlock`ed or `lock`ed to be used as non-mut argument to print
    23 |         }
    24 |     }
    25 |     println(a.st.x)
       |               ~~
    26 | }
    27 |
-vlib/v/checker/tests/lock_needed.vv:30:10: error: a is `shared` and must be `rlock`ed or `lock`ed to be used as non-mut argument to print
+vlib/v/checker/tests/lock_needed.vv:30:10: error: `a` is `shared` and must be `rlock`ed or `lock`ed to be used as non-mut argument to print
    28 | fn g() {
    29 |     shared a := []f64{len: 10, init: 7.5}
    30 |     println(a[3])

--- a/vlib/v/checker/tests/lock_nonshared.out
+++ b/vlib/v/checker/tests/lock_nonshared.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/lock_nonshared.vv:10:7: error: `a` must be declared `shared` to be locked 
+vlib/v/checker/tests/lock_nonshared.vv:10:7: error: `a` must be declared as `shared` variable to be locked
     8 |         x: 5
     9 |     }
    10 |     lock a {

--- a/vlib/v/checker/tests/shared_bad_args.out
+++ b/vlib/v/checker/tests/shared_bad_args.out
@@ -1,25 +1,25 @@
-vlib/v/checker/tests/shared_bad_args.vv:43:8: error: r is `shared` and must be `rlock`ed or `lock`ed to be used as non-mut receiver
+vlib/v/checker/tests/shared_bad_args.vv:43:8: error: `r` is `shared` and must be `rlock`ed or `lock`ed to be used as non-mut receiver
    41 |     shared r := Qr{ a: 7 }
    42 |     lock s {
    43 |         u := r.s_val(s)
       |              ^
    44 |         println(u)
    45 |     }
-vlib/v/checker/tests/shared_bad_args.vv:47:16: error: s is `shared` and must be `rlock`ed or `lock`ed to be passed as non-mut argument
+vlib/v/checker/tests/shared_bad_args.vv:47:16: error: `s` is `shared` and must be `rlock`ed or `lock`ed to be passed as non-mut argument
    45 |     }
    46 |     lock r {
    47 |         v := r.s_val(s)
       |                      ^
    48 |         println(v)
    49 |     }
-vlib/v/checker/tests/shared_bad_args.vv:50:13: error: m is `shared` and must be `rlock`ed or `lock`ed to be passed as non-mut argument
+vlib/v/checker/tests/shared_bad_args.vv:50:13: error: `m` is `shared` and must be `rlock`ed or `lock`ed to be passed as non-mut argument
    48 |         println(v)
    49 |     }
    50 |     w := m_val(m)
       |                ^
    51 |     x := a_val(a)
    52 |     println('$w $x')
-vlib/v/checker/tests/shared_bad_args.vv:51:13: error: a is `shared` and must be `rlock`ed or `lock`ed to be passed as non-mut argument
+vlib/v/checker/tests/shared_bad_args.vv:51:13: error: `a` is `shared` and must be `rlock`ed or `lock`ed to be passed as non-mut argument
    49 |     }
    50 |     w := m_val(m)
    51 |     x := a_val(a)
@@ -54,28 +54,28 @@ vlib/v/checker/tests/shared_bad_args.vv:67:12: error: a is `shared` and must be 
       |               ^
    68 | }
    69 |
-vlib/v/checker/tests/shared_bad_args.vv:76:10: error: y is `shared` and must be `rlock`ed or `lock`ed to be used as non-mut argument to print
+vlib/v/checker/tests/shared_bad_args.vv:76:10: error: `y` is `shared` and must be `rlock`ed or `lock`ed to be used as non-mut argument to print
    74 | fn main() {
    75 |     shared y := St{ a: 5 }
    76 |     println(y)
       |             ^
    77 |     println('$y')
    78 |     a := Ab{ s: St{ a: 3 } }
-vlib/v/checker/tests/shared_bad_args.vv:77:12: error: y is `shared` and must be `rlock`ed or `lock`ed to be used as non-mut interpolation object
+vlib/v/checker/tests/shared_bad_args.vv:77:12: error: `y` is `shared` and must be `rlock`ed or `lock`ed to be used as non-mut interpolation object
    75 |     shared y := St{ a: 5 }
    76 |     println(y)
    77 |     println('$y')
       |               ^
    78 |     a := Ab{ s: St{ a: 3 } }
    79 |     println(a.s)
-vlib/v/checker/tests/shared_bad_args.vv:79:12: error: you have to create a handle and `rlock` it to use a `shared` element as non-mut argument to print
+vlib/v/checker/tests/shared_bad_args.vv:79:12: error: `a.s` is `shared` and must be `rlock`ed or `lock`ed to be used as non-mut argument to print
    77 |     println('$y')
    78 |     a := Ab{ s: St{ a: 3 } }
    79 |     println(a.s)
       |               ^
    80 |     println('$a.s')
    81 | }
-vlib/v/checker/tests/shared_bad_args.vv:80:14: error: you have to create a handle and `rlock` it to use a `shared` element as non-mut interpolation object
+vlib/v/checker/tests/shared_bad_args.vv:80:14: error: `a.s` is `shared` and must be `rlock`ed or `lock`ed to be used as non-mut interpolation object
    78 |     a := Ab{ s: St{ a: 3 } }
    79 |     println(a.s)
    80 |     println('$a.s')

--- a/vlib/v/checker/tests/shared_element_lock.out
+++ b/vlib/v/checker/tests/shared_element_lock.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/shared_element_lock.vv:36:5: error: you have to create a handle and `lock` it to modify `shared` field `pe` of struct `Programmer`
+vlib/v/checker/tests/shared_element_lock.vv:36:5: error: `pr.pe` is `shared` and needs explicit lock for `v.ast.SelectorExpr`
    34 |         }
    35 |     }
    36 |     pr.pe.color = 3

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3957,11 +3957,9 @@ fn (mut g Gen) lock_expr(node ast.LockExpr) {
 	if node.lockeds.len == 0 {
 		// this should not happen
 	} else if node.lockeds.len == 1 {
-		id := node.lockeds[0]
-		name := id.name
-		deref := if id.is_mut { '->' } else { '.' }
+		name := node.lockeds[0].str()
 		lock_prefix := if node.is_rlock[0] { 'r' } else { '' }
-		g.writeln('sync__RwMutex_${lock_prefix}lock(&$name${deref}mtx);')
+		g.writeln('sync__RwMutex_${lock_prefix}lock(&$name->mtx);')
 	} else {
 		mtxs = g.new_tmp_var()
 		g.writeln('uintptr_t _arr_$mtxs[$node.lockeds.len];')
@@ -3969,18 +3967,16 @@ fn (mut g Gen) lock_expr(node ast.LockExpr) {
 		mut j := 0
 		for i, id in node.lockeds {
 			if !node.is_rlock[i] {
-				name := id.name
-				deref := if id.is_mut { '->' } else { '.' }
-				g.writeln('_arr_$mtxs[$j] = (uintptr_t)&$name${deref}mtx;')
+				name := id.str()
+				g.writeln('_arr_$mtxs[$j] = (uintptr_t)&$name->mtx;')
 				g.writeln('_isrlck_$mtxs[$j] = false;')
 				j++
 			}
 		}
 		for i, id in node.lockeds {
 			if node.is_rlock[i] {
-				name := id.name
-				deref := if id.is_mut { '->' } else { '.' }
-				g.writeln('_arr_$mtxs[$j] = (uintptr_t)&$name${deref}mtx;')
+				name := id.str()
+				g.writeln('_arr_$mtxs[$j] = (uintptr_t)&$name->mtx;')
 				g.writeln('_isrlck_$mtxs[$j] = true;')
 				j++
 			}
@@ -4018,10 +4014,9 @@ fn (mut g Gen) unlock_locks() {
 	if g.cur_lock.lockeds.len == 0 {
 	} else if g.cur_lock.lockeds.len == 1 {
 		id := g.cur_lock.lockeds[0]
-		name := id.name
-		deref := if id.is_mut { '->' } else { '.' }
+		name := id.str()
 		lock_prefix := if g.cur_lock.is_rlock[0] { 'r' } else { '' }
-		g.writeln('sync__RwMutex_${lock_prefix}unlock(&$name${deref}mtx);')
+		g.writeln('sync__RwMutex_${lock_prefix}unlock(&$name->mtx);')
 	} else {
 		g.writeln('for (int $g.mtxs=${g.cur_lock.lockeds.len - 1}; $g.mtxs>=0; $g.mtxs--) {')
 		g.writeln('\tif ($g.mtxs && _arr_$g.mtxs[$g.mtxs] == _arr_$g.mtxs[$g.mtxs-1]) continue;')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4003,12 +4003,10 @@ fn (mut g Gen) lock_expr(node ast.LockExpr) {
 		g.writeln('\t\tsync__RwMutex_lock((sync__RwMutex*)_arr_$mtxs[$mtxs]);')
 		g.writeln('}')
 	}
-	println('')
 	g.mtxs = mtxs
 	defer {
 		g.mtxs = ''
 	}
-
 	g.writeln('/*lock*/ {')
 	g.stmts_with_tmp_var(node.stmts, tmp_result)
 	if node.is_expr {

--- a/vlib/v/parser/lock.v
+++ b/vlib/v/parser/lock.v
@@ -1,6 +1,66 @@
 module parser
 
+import v.token
 import v.ast
+
+// parse `x` or `x.y.z` - no index, no struct literals (`{` starts lock block)
+fn (mut p Parser) lockable() ast.Expr {
+	mut names := []string{}
+	mut positions := []token.Position{}
+	mut pos := p.tok.position()
+	for {
+		if p.tok.kind != .name {
+			p.error_with_pos('unexpected `$p.tok.lit` (field/variable name expected)', p.tok.position())
+		}
+		names << p.tok.lit
+		positions << pos
+		p.next()
+		if p.tok.kind != .dot {
+			break
+		}
+		p.next()
+		pos.extend(p.tok.position())
+	}
+	mut expr := ast.Expr(ast.Ident{
+		language: ast.Language.v
+		pos: positions[0]
+		mod: p.mod
+		name: names[0]
+		is_mut: true
+		info: ast.IdentVar{}
+		scope: p.scope
+	})
+	for i := 1; i < names.len; i++ {
+		expr = ast.SelectorExpr{
+			expr: expr
+			field_name: names[i]
+			next_token: if i < names.len - 1 { token.Kind.dot } else { p.tok.kind }
+			is_mut: true
+			pos: positions[i]
+			scope: p.scope
+		}
+	}
+	return expr
+}
+
+// like `expr_list()` but only lockables are allowed, `{` starts lock block (not struct literal)
+fn (mut p Parser) lockable_list() ([]ast.Expr, []ast.Comment) {
+	mut exprs := []ast.Expr{}
+	mut comments := []ast.Comment{}
+	for {
+		expr := p.lockable()
+		if expr is ast.Comment {
+			comments << expr
+		} else {
+			exprs << expr
+			if p.tok.kind != .comma {
+				break
+			}
+			p.next()
+		}
+	}
+	return exprs, comments
+}
 
 fn (mut p Parser) lock_expr() ast.LockExpr {
 	// TODO Handle aliasing sync
@@ -13,14 +73,14 @@ fn (mut p Parser) lock_expr() ast.LockExpr {
 	for {
 		is_rlock := p.tok.kind == .key_rlock
 		if !is_rlock && p.tok.kind != .key_lock {
-			p.error_with_pos('unexpected $p.tok, expected `lock` or `rlock`', p.tok.position())
+			p.error_with_pos('unexpected `$p.tok`, expected `lock` or `rlock`', p.tok.position())
 		}
 		p.next()
 		if p.tok.kind == .lcbr {
 			break
 		}
 		if p.tok.kind == .name {
-			exprs, comms := p.expr_list()
+			exprs, comms := p.lockable_list()
 			for e in exprs {
 				if !e.is_lockable() {
 					p.error_with_pos('`$e` cannot be locked - only `x` or `x.y` are supported', e.position())
@@ -30,9 +90,11 @@ fn (mut p Parser) lock_expr() ast.LockExpr {
 			}
 			comments << comms
 		}
+		if p.tok.kind == .lcbr {
+			break
+		}
 		if p.tok.kind == .semicolon {
 			p.next()
-			continue
 		}
 	}
 	stmts := p.parse_block_no_scope(false)

--- a/vlib/v/parser/lock.v
+++ b/vlib/v/parser/lock.v
@@ -10,7 +10,8 @@ fn (mut p Parser) lockable() ast.Expr {
 	mut pos := p.tok.position()
 	for {
 		if p.tok.kind != .name {
-			p.error_with_pos('unexpected `$p.tok.lit` (field/variable name expected)', p.tok.position())
+			p.error_with_pos('unexpected `$p.tok.lit` (field/variable name expected)',
+				p.tok.position())
 		}
 		names << p.tok.lit
 		positions << pos
@@ -83,7 +84,8 @@ fn (mut p Parser) lock_expr() ast.LockExpr {
 			exprs, comms := p.lockable_list()
 			for e in exprs {
 				if !e.is_lockable() {
-					p.error_with_pos('`$e` cannot be locked - only `x` or `x.y` are supported', e.position())
+					p.error_with_pos('`$e` cannot be locked - only `x` or `x.y` are supported',
+						e.position())
 				}
 				lockeds << e
 				is_rlocked << is_rlock

--- a/vlib/v/parser/lock.v
+++ b/vlib/v/parser/lock.v
@@ -11,26 +11,24 @@ fn (mut p Parser) lock_expr() ast.LockExpr {
 	mut comments := []ast.Comment{}
 	mut is_rlocked := []bool{}
 	for {
-		if p.tok.kind == .lcbr {
-			break
-		}
 		is_rlock := p.tok.kind == .key_rlock
 		if !is_rlock && p.tok.kind != .key_lock {
 			p.error_with_pos('unexpected $p.tok, expected `lock` or `rlock`', p.tok.position())
 		}
 		p.next()
-		exprs, comms := p.expr_list()
-		for e in exprs {
-			if !e.is_lockable() {
-				p.error_with_pos('`$e` cannot be locked - only `x` or `x.y` are supported', e.position())
-			}
-			lockeds << e
-			is_rlocked << is_rlock
-		}
-		comments << comms
-		p.next()
 		if p.tok.kind == .lcbr {
 			break
+		}
+		if p.tok.kind == .name {
+			exprs, comms := p.expr_list()
+			for e in exprs {
+				if !e.is_lockable() {
+					p.error_with_pos('`$e` cannot be locked - only `x` or `x.y` are supported', e.position())
+				}
+				lockeds << e
+				is_rlocked << is_rlock
+			}
+			comments << comms
 		}
 		if p.tok.kind == .semicolon {
 			p.next()

--- a/vlib/v/tests/lock_selector_test.v
+++ b/vlib/v/tests/lock_selector_test.v
@@ -1,4 +1,4 @@
-struct St{
+struct St {
 mut:
 	x f64
 }
@@ -23,8 +23,12 @@ fn (g Gen) set_val() bool {
 }
 
 fn (g &Gen) inc_val() {
-	shared q := St{x: 1.0}
-	shared v := St{x: 0.25}
+	shared q := St{
+		x: 1.0
+	}
+	shared v := St{
+		x: 0.25
+	}
 	lock q, g.s, v {
 		g.s.x += q.x
 		g.s.x += v.x
@@ -33,10 +37,14 @@ fn (g &Gen) inc_val() {
 
 fn test_lock_selector_expression() {
 	g := Gen{
-		s: St{x: 12.5}
+		s: St{
+			x: 12.5
+		}
 	}
 	g.set_val()
 	g.inc_val()
-	a := rlock g.s { g.s.get_f64() }
+	a := rlock g.s {
+		g.s.get_f64()
+	}
 	assert a == 7.5
 }

--- a/vlib/v/tests/lock_selector_test.v
+++ b/vlib/v/tests/lock_selector_test.v
@@ -1,0 +1,42 @@
+struct St{
+mut:
+	x f64
+}
+
+fn (s &St) get_f64() f64 {
+	return s.x
+}
+
+struct Gen {
+	s shared St
+}
+
+fn (g Gen) set_val() bool {
+	lock g.s {
+		g.s.x = 6.25
+		if g.s.x == 6.25 {
+			return true
+		}
+		g.s.x == 7.125
+	}
+	return false
+}
+
+fn (g &Gen) inc_val() {
+	shared q := St{x: 1.0}
+	shared v := St{x: 0.25}
+	lock q, g.s, v {
+		g.s.x += q.x
+		g.s.x += v.x
+	}
+}
+
+fn test_lock_selector_expression() {
+	g := Gen{
+		s: St{x: 12.5}
+	}
+	g.set_val()
+	g.inc_val()
+	a := rlock g.s { g.s.get_f64() }
+	assert a == 7.5
+}


### PR DESCRIPTION
Structs have been allowed to have `shared` elements since #8631. However, to access shared elements, a handle (a single identifier) had to be created.
This PR supports locking on a `SelectorExpr`, i.e it's now possible to lock on something like `x.y`:
```v
struct Qwe {
mut:
    n int
}

struct Abc {
   q shared Qwe
}

fn main() {
    x := Abc{
        q: Qwe{n: 3}
    }
    lock x.q {
        x.q.n += 7
    }
    y := rlock x.q { x.q.n }
    println(y) // prints 10
}
```
The expression that is locked on must be determined at compile time. For this reason locking on an `IndexExpr` (like `lock a[n] { ... }`) is not supported (and will probably never be). Too many things could happen to `n` (e.g. value changed) or `a` (e.g. being truncated). The compiler would not in general be able to check if an accessed element is locked, so a handle is still required there.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
