### PR TITLE
fmt: fix formating cascade generic types call_expr

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1651,6 +1651,10 @@ fn (mut f Fmt) write_generic_if_require(node ast.CallExpr) {
 				f.write(', ')
 			}
 		}
+		// avoid `<Foo<int>>` => `<Foo<int> >`
+		if f.out.last_n(1) == '>' {
+			f.write(' ')
+		}
 		f.write('>')
 	}
 }

--- a/vlib/v/fmt/tests/generics_cascade_types_keep.vv
+++ b/vlib/v/fmt/tests/generics_cascade_types_keep.vv
@@ -1,4 +1,3 @@
-
 struct Foo<T> {
 pub:
 	data T

--- a/vlib/v/fmt/tests/generics_cascade_types_keep.vv
+++ b/vlib/v/fmt/tests/generics_cascade_types_keep.vv
@@ -1,0 +1,28 @@
+
+struct Foo<T> {
+pub:
+	data T
+}
+
+struct Foo1 {}
+
+struct Foo2 {}
+
+fn multi_generic_args<T, V>(t T, v V) bool {
+	return true
+}
+
+fn main() {
+	v1, v2 := -1, 1
+
+	// not generic
+	a1, a2 := v1 < v2, v2 > v1
+	assert a1 && a2
+	b1, b2 := v1 < simplemodule.zero, v2 > v1
+	assert b1 && b2
+
+	// generic
+	assert multi_generic_args<int, string>(0, 's')
+	assert multi_generic_args<Foo1, Foo2>(Foo1{}, Foo2{})
+	assert multi_generic_args<Foo<int>, Foo<int> >(Foo<int>{}, Foo<int>{})
+}


### PR DESCRIPTION
This PR fix formating cascade generic types call_expr.

- Fix formating cascade generic types call_expr.
- Add fmt test.
- `tests/generics_test.v` format correctly.

```vlang
struct Foo<T> {
pub:
	data T
}

struct Foo1 {}

struct Foo2 {}

fn multi_generic_args<T, V>(t T, v V) bool {
	return true
}

fn main() {
	v1, v2 := -1, 1

	// not generic
	a1, a2 := v1 < v2, v2 > v1
	assert a1 && a2
	b1, b2 := v1 < simplemodule.zero, v2 > v1
	assert b1 && b2

	// generic
	assert multi_generic_args<int, string>(0, 's')
	assert multi_generic_args<Foo1, Foo2>(Foo1{}, Foo2{})
	assert multi_generic_args<Foo<int>, Foo<int> >(Foo<int>{}, Foo<int>{})
}
```