### PR TITLE
util: add [inline] for some short frequently called fns

### DIFF
--- a/vlib/v/util/scanning.v
+++ b/vlib/v/util/scanning.v
@@ -39,6 +39,7 @@ pub fn is_generic_type_name(name string) bool {
 	return name.len == 1 && name.is_capital() && name != 'C'
 }
 
+[inline]
 pub fn cescaped_path(s string) string {
 	return s.replace('\\', '\\\\')
 }

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -478,14 +478,17 @@ pub fn ensure_modules_for_all_tools_are_installed(is_verbose bool) {
 	}
 }
 
+[inline]
 pub fn strip_mod_name(name string) string {
 	return name.all_after_last('.')
 }
 
+[inline]
 pub fn strip_main_name(name string) string {
 	return name.replace('main.', '')
 }
 
+[inline]
 pub fn no_dots(s string) string {
 	return s.replace('.', '__')
 }


### PR DESCRIPTION
This PR add [inline] for some short frequently called fns in util.

```vlang
[inline]
pub fn strip_mod_name(name string) string {
	return name.all_after_last('.')
}

[inline]
pub fn strip_main_name(name string) string {
	return name.replace('main.', '')
}

[inline]
pub fn no_dots(s string) string {
	return s.replace('.', '__')
}

[inline]
pub fn cescaped_path(s string) string {
	return s.replace('\\', '\\\\')
}
```