### PR TITLE
fmt: keep selective struct import when used in orm block

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1253,6 +1253,7 @@ pub fn (mut f Fmt) sql_stmt(node ast.SqlStmt) {
 
 pub fn (mut f Fmt) sql_stmt_line(node ast.SqlStmtLine) {
 	table_name := util.strip_mod_name(f.table.get_type_symbol(node.table_expr.typ).name)
+	f.mark_types_import_as_used(node.table_expr.typ)
 	f.write('\t')
 	match node.kind {
 		.insert {

--- a/vlib/v/fmt/tests/orm_keep.vv
+++ b/vlib/v/fmt/tests/orm_keep.vv
@@ -1,4 +1,5 @@
 import sqlite
+import mymodule { ModDbStruct }
 
 struct Customer {
 	id        int
@@ -55,5 +56,12 @@ fn main() {
 	sql db {
 		update Customer set name = 'Queen Elizabeth II', age = 150, nr_orders = 42, country = 'Great Britain'
 		where id == 5
+	}
+	// DB is a selective import
+	sql db {
+		delete from ModDbStruct where id == 1
+	}
+	_ := sql db {
+		select from ModDbStruct
 	}
 }


### PR DESCRIPTION
fix #10118 