### PR TITLE
os: implement file method to read into buffer, break on newline

### DIFF
--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -17,7 +17,6 @@ fn C.fseeko(voidptr, u64, int) int
 
 fn C._fseeki64(voidptr, u64, int) int
 
-[inline]
 fn C.getc(voidptr) int
 
 // open_file can be used to open or create a file with custom flags and permissions and returns a `File` object.

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -17,15 +17,7 @@ fn C.fseeko(voidptr, u64, int) int
 
 fn C._fseeki64(voidptr, u64, int) int
 
-fn C.ftrylockfile(voidptr) int
-
-fn C.funlockfile(voidptr)
-
-fn C.getc_unlocked(voidptr) int
-
-fn C.feof_unlocked(voidptr) int
-
-fn C.ferror_unlocked(voidptr) int
+fn C.getc(voidptr) int
 
 // open_file can be used to open or create a file with custom flags and permissions and returns a `File` object.
 pub fn open_file(path string, mode string, options ...int) ?File {
@@ -379,27 +371,19 @@ pub fn (f &File) read_bytes_into_newline(mut buf []byte) ?int {
 	if buf.len == 0 {
 		panic(@FN + ': `buf.len` == 0')
 	}
-
-	if C.ftrylockfile(f.cfile) != 0 {
-		return error('Could not read file')
-	}
-	defer {
-		C.funlockfile(f.cfile)
-	}
-
 	newline := 10
 	mut c := 0
 	mut buf_ptr := 0
 	mut nbytes := 0
 
 	for (buf_ptr < buf.len) {
-		c = C.getc_unlocked(f.cfile)
+		c = C.getc(f.cfile)
 		match c {
 			C.EOF {
-				if C.feof_unlocked(f.cfile) != 0 {
+				if C.feof(f.cfile) != 0 {
 					return nbytes
 				}
-				if C.ferror_unlocked(f.cfile) != 0 {
+				if C.ferror(f.cfile) != 0 {
 					return error('file read error')
 				}
 			}

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -376,7 +376,7 @@ pub fn (f &File) read_bytes_into_newline(mut buf []byte) int {
 	mut buf_ptr := 0
 	mut nbytes := 0
 
-	for _likely_(buf_ptr < buf.len) {
+	for (buf_ptr < buf.len) {
 		c = C.getc(f.cfile)
 		match c {
 			C.EOF {

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -371,7 +371,7 @@ pub fn (f &File) read_bytes_into_newline(mut buf []byte) int {
 	if buf.len == 0 {
 		panic(@FN + ': `buf.len` == 0')
 	}
-	newline := '\n'[0]
+	newline := 10
 	mut c := 0
 	mut buf_ptr := 0
 	mut nbytes := 0

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -17,7 +17,15 @@ fn C.fseeko(voidptr, u64, int) int
 
 fn C._fseeki64(voidptr, u64, int) int
 
-fn C.getc(voidptr) int
+fn C.ftrylockfile(voidptr) int
+
+fn C.funlockfile(voidptr)
+
+fn C.getc_unlocked(voidptr) int
+
+fn C.feof_unlocked(voidptr) int
+
+fn C.ferror_unlocked(voidptr) int
 
 // open_file can be used to open or create a file with custom flags and permissions and returns a `File` object.
 pub fn open_file(path string, mode string, options ...int) ?File {
@@ -367,20 +375,33 @@ pub fn (f &File) read_bytes_at(size int, pos u64) []byte {
 // read_bytes_into_newline reads from the beginning of the file into the provided buffer.
 // Each consecutive call on the same file continues reading where it previously ended.
 // A read call is either stopped, if the buffer is full, a newline was read or EOF.
-pub fn (f &File) read_bytes_into_newline(mut buf []byte) int {
+pub fn (f &File) read_bytes_into_newline(mut buf []byte) ?int {
 	if buf.len == 0 {
 		panic(@FN + ': `buf.len` == 0')
 	}
+
+	if C.ftrylockfile(f.cfile) != 0 {
+		return error('Could not read file')
+	}
+	defer {
+		C.funlockfile(f.cfile)
+	}
+
 	newline := 10
 	mut c := 0
 	mut buf_ptr := 0
 	mut nbytes := 0
 
 	for (buf_ptr < buf.len) {
-		c = C.getc(f.cfile)
+		c = C.getc_unlocked(f.cfile)
 		match c {
 			C.EOF {
-				return nbytes
+				if C.feof_unlocked(f.cfile) != 0 {
+					return nbytes
+				}
+				if C.ferror_unlocked(f.cfile) != 0 {
+					return error('file read error')
+				}
 			}
 			newline {
 				buf[buf_ptr] = byte(c)

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -90,6 +90,7 @@ fn test_read_bytes_into_newline_text() ? {
 // This test simulates the scenario when a byte stream is read and a newline byte
 // appears in that stream and an EOF occurs before the buffer is full.
 fn test_read_bytes_into_newline_binary() ? {
+	os.rm(tfile) or {} // FIXME This is a workaround for macos, because the file isn't truncated when open with 'w'
 	mut bw := []byte{len: 15}
 	bw[9] = 0xff
 	bw[12] = 10 // newline
@@ -114,9 +115,6 @@ fn test_read_bytes_into_newline_binary() ? {
 	assert buf[..n1] == n1_bytes
 
 	n2 := f.read_bytes_into_newline(mut buf) ?
-	// At this point the buffer should look like this: Why does MacOS fail?
-	// [`\0`, `\0`, `\n`, `\0`, `\0`, `\0`, `\0`, `\0`, `\0`, 0xff]
-	println(buf)
 	assert n2 == 2
 	assert buf[..n2] == n2_bytes
 	f.close()

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -114,6 +114,9 @@ fn test_read_bytes_into_newline_binary() ? {
 	assert buf[..n1] == n1_bytes
 
 	n2 := f.read_bytes_into_newline(mut buf) ?
+	// At this point the buffer should look like this: Why does MacOS fail?
+	// [`\0`, `\0`, `\n`, `\0`, `\0`, `\0`, `\0`, `\0`, `\0`, 0xff]
+	println(buf)
 	assert n2 == 2
 	assert buf[..n2] == n2_bytes
 	f.close()

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -71,16 +71,16 @@ fn test_read_bytes_into_newline_text() ? {
 	f = os.open_file(tfile, 'r') ?
 	mut buf := []byte{len: 8}
 
-	n0 := f.read_bytes_into_newline(mut buf)
+	n0 := f.read_bytes_into_newline(mut buf) ?
 	assert n0 == 8
 
-	n1 := f.read_bytes_into_newline(mut buf)
+	n1 := f.read_bytes_into_newline(mut buf) ?
 	assert n1 == 5
 
-	n2 := f.read_bytes_into_newline(mut buf)
+	n2 := f.read_bytes_into_newline(mut buf) ?
 	assert n2 == 8
 
-	n3 := f.read_bytes_into_newline(mut buf)
+	n3 := f.read_bytes_into_newline(mut buf) ?
 	assert n3 == 6
 
 	f.close()
@@ -105,15 +105,15 @@ fn test_read_bytes_into_newline_binary() ? {
 	f = os.open_file(tfile, 'r') ?
 	mut buf := []byte{len: 10}
 
-	n0 := f.read_bytes_into_newline(mut buf)
+	n0 := f.read_bytes_into_newline(mut buf) ?
 	assert n0 == 10
 	assert buf[..n0] == n0_bytes
 
-	n1 := f.read_bytes_into_newline(mut buf)
+	n1 := f.read_bytes_into_newline(mut buf) ?
 	assert n1 == 3
 	assert buf[..n1] == n1_bytes
 
-	n2 := f.read_bytes_into_newline(mut buf)
+	n2 := f.read_bytes_into_newline(mut buf) ?
 	assert n2 == 2
 	assert buf[..n2] == n2_bytes
 	f.close()

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -92,7 +92,7 @@ fn test_read_bytes_into_newline_text() ? {
 fn test_read_bytes_into_newline_binary() ? {
 	mut bw := []byte{len: 15}
 	bw[9] = 0xff
-	bw[12] = '\n'[0]
+	bw[12] = 10 // newline
 
 	n0_bytes := bw[0..10]
 	n1_bytes := bw[10..13]

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -59,6 +59,66 @@ fn testsuite_end() ? {
 	assert !os.is_dir(tfolder)
 }
 
+// test_read_bytes_into_newline_text tests reading text from a file with newlines.
+// This test simulates reading a larger text file step by step into a buffer and
+// returning on each newline, even before the buffer is full, and reaching EOF before
+// the buffer is completely filled.
+fn test_read_bytes_into_newline_text() ? {
+	mut f := os.open_file(tfile, 'w') ?
+	f.write_string('Hello World!\nGood\r morning.') ?
+	f.close()
+
+	f = os.open_file(tfile, 'r') ?
+	mut buf := []byte{len: 8}
+
+	n0 := f.read_bytes_into_newline(mut buf)
+	assert n0 == 8
+
+	n1 := f.read_bytes_into_newline(mut buf)
+	assert n1 == 5
+
+	n2 := f.read_bytes_into_newline(mut buf)
+	assert n2 == 8
+
+	n3 := f.read_bytes_into_newline(mut buf)
+	assert n3 == 6
+
+	f.close()
+}
+
+// test_read_bytes_into_newline_binary tests reading a binary file with NUL bytes.
+// This test simulates the scenario when a byte stream is read and a newline byte
+// appears in that stream and an EOF occurs before the buffer is full.
+fn test_read_bytes_into_newline_binary() ? {
+	mut bw := []byte{len: 15}
+	bw[9] = 0xff
+	bw[12] = '\n'[0]
+
+	n0_bytes := bw[0..10]
+	n1_bytes := bw[10..13]
+	n2_bytes := bw[13..]
+
+	mut f := os.open_file(tfile, 'w') ?
+	f.write(bw) ?
+	f.close()
+
+	f = os.open_file(tfile, 'r') ?
+	mut buf := []byte{len: 10}
+
+	n0 := f.read_bytes_into_newline(mut buf)
+	assert n0 == 10
+	assert buf[..n0] == n0_bytes
+
+	n1 := f.read_bytes_into_newline(mut buf)
+	assert n1 == 3
+	assert buf[..n1] == n1_bytes
+
+	n2 := f.read_bytes_into_newline(mut buf)
+	assert n2 == 2
+	assert buf[..n2] == n2_bytes
+	f.close()
+}
+
 // test_read_eof_last_read_partial_buffer_fill tests that when reading a file
 // the end-of-file is detected and results in a none error being returned. This
 // test simulates file reading where the end-of-file is reached inside an fread


### PR DESCRIPTION
The file method 'read_bytes_into_newline' takes the concept of 'read_bytes_into', but stops when it encounters a '\n' newline.
I wrote this, as there is no method yet to read from stdin with constant memory usage.

get_line() and similar functions can cause a crash, running out of memory, if a piped in stream is really long and without a newline.
And the method 'read_bytes_into' blocks until the buffer is full, resulting in seeing nothing until the buffer is full, if the piped in data is slow.

read_bytes_into_newline takes the best from both worlds and combines it into a method for reading into a buffer until it's full or a newline is read, thus solving both described problems. The return value states the bytes read in that read-call.
In the following next call to the method, reading is continued where it stopped in the last call.

I included tests to show and test both cases of reading text and pure binary data.

The core reading is done via the standard C getc() function.

Edit: changed the description to actually match the changes that have finally been made.