### PR TITLE
builtin,v.cgen: implement chunked allocation of 16MB blocks with -prealloc, instead of a finite 150MB one

### DIFF
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -217,6 +217,7 @@ pub fn println(s string) {
 	}
 }
 
+__global total_m = i64(0)
 // malloc dynamically allocates a `n` bytes block of memory on the heap.
 // malloc returns a `byteptr` pointing to the memory address of the allocated space.
 // unlike the `calloc` family of functions - malloc will not zero the memory block.

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -40,12 +40,8 @@ struct VCastTypeIndexName {
 	tname  string
 }
 
-__global (
-	total_m              = i64(0)
-	nr_mallocs           = int(0)
-	// will be filled in cgen
-	as_cast_type_indexes []VCastTypeIndexName
-)
+// will be filled in cgen
+__global as_cast_type_indexes []VCastTypeIndexName
 
 fn __as_cast(obj voidptr, obj_type int, expected_type int) voidptr {
 	if obj_type != expected_type {

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -3,11 +3,6 @@
 // that can be found in the LICENSE file.
 module builtin
 
-__global (
-	g_m2_buf &byte
-	g_m2_ptr &byte
-)
-
 // isnil returns true if an object is nil (only for C objects).
 [inline]
 pub fn isnil(v voidptr) bool {

--- a/vlib/builtin/prealloc.c.v
+++ b/vlib/builtin/prealloc.c.v
@@ -51,7 +51,9 @@ fn vmemory_block_malloc(n int) &byte {
 fn prealloc_vinit() {
 	unsafe {
 		g_memory_block = vmemory_block_new(voidptr(0), prealloc_block_size)
-		C.atexit(prealloc_vcleanup)
+		$if !freestanding {
+			C.atexit(prealloc_vcleanup)
+		}
 	}
 }
 

--- a/vlib/builtin/prealloc.c.v
+++ b/vlib/builtin/prealloc.c.v
@@ -1,0 +1,36 @@
+module builtin
+
+__global (
+	g_m2_buf &byte
+	g_m2_ptr &byte
+)
+
+[unsafe]
+fn prealloc_malloc(n int) &byte {
+	unsafe {
+		mut res := &byte(0)
+		res = g_m2_ptr
+		g_m2_ptr += n
+		nr_mallocs++
+		return res
+	}
+}
+
+[unsafe]
+fn prealloc_realloc(old_data &byte, old_size int, new_size int) &byte {
+	unsafe {
+		new_ptr := prealloc_malloc(new_size)
+		min_size := if old_size < new_size { old_size } else { new_size }
+		C.memcpy(new_ptr, old_data, min_size)
+		return new_ptr
+	}
+}	
+
+[unsafe]
+pub fn prealloc_calloc(n int) &byte {
+	unsafe {
+		new_ptr := prealloc_malloc(n)
+		C.memset(new_ptr, 0, n)
+		return new_ptr
+	}
+}

--- a/vlib/builtin/prealloc.c.v
+++ b/vlib/builtin/prealloc.c.v
@@ -1,54 +1,99 @@
 module builtin
 
-__global g_m2_buf &byte
-__global g_m2_ptr &byte
-__global nr_mallocs = int(0)
+const prealloc_block_size = 16777216
+
+__global g_memory_block &VMemoryBlock
+[heap]
+struct VMemoryBlock {
+mut:
+	id        int
+	cap       int
+	start     &byte = 0
+	previous  &VMemoryBlock = 0
+	remaining int
+	current   &byte = 0
+	mallocs   int
+}
+
+[unsafe]
+fn vmemory_block_new(prev &VMemoryBlock, at_least int) &VMemoryBlock {
+	mut v := unsafe { &VMemoryBlock(C.calloc(1, sizeof(VMemoryBlock))) }
+	if prev != 0 {
+		v.id = prev.id + 1
+	}
+	v.previous = prev
+	block_size := if at_least < prealloc_block_size { prealloc_block_size } else { at_least }
+	v.start = unsafe { C.malloc(block_size) }
+	v.cap = block_size
+	v.remaining = block_size
+	v.current = v.start
+	return v
+}
+
+[unsafe]
+fn vmemory_block_malloc(n int) &byte {
+	unsafe {
+		if g_memory_block.remaining < n {
+			g_memory_block = vmemory_block_new(g_memory_block, n)
+		}
+		mut res := &byte(0)
+		res = g_memory_block.current
+		g_memory_block.remaining -= n
+		g_memory_block.mallocs++
+		g_memory_block.current += n
+		return res
+	}
+}
+
+/////////////////////////////////////////////////
 
 [unsafe]
 fn prealloc_vinit() {
 	unsafe {
-		g_m2_buf = C.malloc(250 * 1000 * 1000)
-		g_m2_ptr = g_m2_buf
+		g_memory_block = vmemory_block_new(voidptr(0), prealloc_block_size)
 		C.atexit(prealloc_vcleanup)
 	}
 }
 
 [unsafe]
 fn prealloc_vcleanup() {
-	unsafe {
-		$if prealloc_stats ? {
-			eprintln('> g_m2_buf: ${voidptr(g_m2_buf)} | g_m2_ptr: ${voidptr(g_m2_ptr)} | nr_mallocs: $nr_mallocs | diff: ${u64(g_m2_ptr) - u64(g_m2_buf)} bytes')
+	$if prealloc_stats ? {
+		// NB: we do 2 loops here, because string interpolation
+		// in the first loop may still use g_memory_block
+		// The second loop however should *not* allocate at all.
+		mut nr_mallocs := i64(0)
+		mut mb := g_memory_block
+		for mb != 0 {
+			nr_mallocs += mb.mallocs
+			eprintln('> freeing mb.id: ${mb.id:3} | cap: ${mb.cap:7} | rem: ${mb.remaining:7} | start: ${voidptr(mb.start)} | current: ${voidptr(mb.current)} | diff: ${u64(mb.current) - u64(mb.start):7} bytes | mallocs: $mb.mallocs')
+			mb = mb.previous
 		}
-		C.free(g_m2_buf)
+		eprintln('> nr_mallocs: $nr_mallocs')
+	}
+	unsafe {
+		for g_memory_block != 0 {
+			C.free(g_memory_block.start)
+			g_memory_block = g_memory_block.previous
+		}
 	}
 }
 
 [unsafe]
 fn prealloc_malloc(n int) &byte {
-	unsafe {
-		mut res := &byte(0)
-		res = g_m2_ptr
-		g_m2_ptr += n
-		nr_mallocs++
-		return res
-	}
+	return unsafe { vmemory_block_malloc(n) }
 }
 
 [unsafe]
 fn prealloc_realloc(old_data &byte, old_size int, new_size int) &byte {
-	unsafe {
-		new_ptr := prealloc_malloc(new_size)
-		min_size := if old_size < new_size { old_size } else { new_size }
-		C.memcpy(new_ptr, old_data, min_size)
-		return new_ptr
-	}
+	new_ptr := unsafe { vmemory_block_malloc(new_size) }
+	min_size := if old_size < new_size { old_size } else { new_size }
+	unsafe { C.memcpy(new_ptr, old_data, min_size) }
+	return new_ptr
 }
 
 [unsafe]
 pub fn prealloc_calloc(n int) &byte {
-	unsafe {
-		new_ptr := prealloc_malloc(n)
-		C.memset(new_ptr, 0, n)
-		return new_ptr
-	}
+	new_ptr := unsafe { vmemory_block_malloc(n) }
+	unsafe { C.memset(new_ptr, 0, n) }
+	return new_ptr
 }

--- a/vlib/builtin/prealloc.c.v
+++ b/vlib/builtin/prealloc.c.v
@@ -12,7 +12,8 @@ module builtin
 // mode program), for a ~8-10% speed increase.
 // NB: `-prealloc` is NOT safe to be used for multithreaded programs!
 
-const prealloc_block_size = 16*1024*1024 // size of the preallocated chunk
+// size of the preallocated chunk
+const prealloc_block_size = 16 * 1024 * 1024
 
 __global g_memory_block &VMemoryBlock
 [heap]

--- a/vlib/builtin/prealloc.c.v
+++ b/vlib/builtin/prealloc.c.v
@@ -94,7 +94,7 @@ fn prealloc_realloc(old_data &byte, old_size int, new_size int) &byte {
 }
 
 [unsafe]
-pub fn prealloc_calloc(n int) &byte {
+fn prealloc_calloc(n int) &byte {
 	new_ptr := unsafe { vmemory_block_malloc(n) }
 	unsafe { C.memset(new_ptr, 0, n) }
 	return new_ptr

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5535,8 +5535,7 @@ fn (mut g Gen) write_init_function() {
 		// g.writeln('g_str_buf = malloc( ${mb_size} * 1024 * 1000 );')
 	}
 	if g.pref.prealloc {
-		g.writeln('g_m2_buf = malloc(300 * 1000 * 1000);')
-		g.writeln('g_m2_ptr = g_m2_buf;')
+		g.writeln('prealloc_vinit();')
 	}
 	// NB: the as_cast table should be *before* the other constant initialize calls,
 	// because it may be needed during const initialization of builtin and during
@@ -5575,9 +5574,6 @@ fn (mut g Gen) write_init_function() {
 		}
 		// g.writeln('\tfree(g_str_buf);')
 		g.writeln('\tarray_free(&as_cast_type_indexes);')
-	}
-	if g.pref.prealloc {
-		g.writeln('free(g_m2_buf);')
 	}
 	g.writeln('}')
 	if g.pref.printfn_list.len > 0 && '_vcleanup' in g.pref.printfn_list {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5535,7 +5535,7 @@ fn (mut g Gen) write_init_function() {
 		// g.writeln('g_str_buf = malloc( ${mb_size} * 1024 * 1000 );')
 	}
 	if g.pref.prealloc {
-		g.writeln('g_m2_buf = malloc(150 * 1000 * 1000);')
+		g.writeln('g_m2_buf = malloc(300 * 1000 * 1000);')
 		g.writeln('g_m2_ptr = g_m2_buf;')
 	}
 	// NB: the as_cast table should be *before* the other constant initialize calls,
@@ -5575,6 +5575,9 @@ fn (mut g Gen) write_init_function() {
 		}
 		// g.writeln('\tfree(g_str_buf);')
 		g.writeln('\tarray_free(&as_cast_type_indexes);')
+	}
+	if g.pref.prealloc {
+		g.writeln('free(g_m2_buf);')
 	}
 	g.writeln('}')
 	if g.pref.printfn_list.len > 0 && '_vcleanup' in g.pref.printfn_list {

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -66,11 +66,7 @@ void _STR_PRINT_ARG(const char *fmt, char** refbufp, int *nbytes, int *memsize, 
 		}
 		// increase buffer (somewhat exponentially)
 		*memsize += guess + 3 * (*memsize) / 2;
-#ifdef _VGCBOEHM
-		*refbufp = (char*)GC_REALLOC((void*)*refbufp, *memsize);
-#else
-		*refbufp = (char*)realloc((void*)*refbufp, *memsize);
-#endif
+		*refbufp = (char*)v_realloc((void*)*refbufp, *memsize);
 	}
 	va_end(args);
 }
@@ -79,11 +75,7 @@ string _STR(const char *fmt, int nfmts, ...) {
 	va_list argptr;
 	int memsize = 128;
 	int nbytes = 0;
-#ifdef _VGCBOEHM
-	char* buf = (char*)GC_MALLOC(memsize);
-#else
-	char* buf = (char*)malloc(memsize);
-#endif
+	char* buf = (char*)v_malloc(memsize);
 	va_start(argptr, nfmts);
 	for (int i=0; i<nfmts; ++i) {
 		int k = strlen(fmt);

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -18,6 +18,8 @@ pub fn mark_used(mut table ast.Table, pref &pref.Preferences, ast_files []ast.Fi
 		'__new_array',
 		'__new_array_with_default',
 		'__new_array_with_array_default',
+		'v_realloc' /* needed for _STR */,
+		'v_malloc' /* needed for _STR */,
 		'new_array_from_c_array',
 		'v_fixed_index',
 		'memdup',

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -162,6 +162,10 @@ pub fn mark_used(mut table ast.Table, pref &pref.Preferences, ast_files []ast.Fi
 			all_fn_root_names << k
 			continue
 		}
+		if pref.prealloc && k.starts_with('prealloc_') {
+			all_fn_root_names << k
+			continue
+		}
 	}
 
 	// handle assertions and testing framework callbacks:


### PR DESCRIPTION
With `-prealloc`, previously V allocated one large 150MB block at the start of its execution and used it for most (but not all) memory operations like malloc/calloc/realloc . The single block precluded using -prealloc with larger programs, because it could not grow dynamically even if the user had enough memory.

This PR, instead makes V call libc's malloc in chunks, each at least 16MB in size, as needed. Once a chunk is available, all malloc() calls within V code, that can fit inside the chunk, will use it instead, each bumping a pointer, till the chunk is filled.

Once a chunk is filled, a new chunk will be allocated by calling libc's malloc, and the process will continue.

Each new chunk has a pointer to the old one, and at the end of the program, the entire linked list of chunks is freed.

The effect is that just like before, calls to malloc/free are amortized at the expense of higher memory usage, but this time V can be used to compile larger programs in -prealloc mode too.

Here is how the list of chunks looks like after V compiling itself with `-prealloc -d prealloc_stats`:
![image](https://user-images.githubusercontent.com/26967/118716719-d3b7a880-b82d-11eb-8800-d38b79cfb4d5.png)

Here is how the memory usage grows with that mode (the 16MB steps are clearly visible):
![image](https://user-images.githubusercontent.com/26967/118718120-918f6680-b82f-11eb-9a04-eea4a6bfe968.png)


Here is also a flame graph of the allocations:
![image](https://user-images.githubusercontent.com/26967/118718480-f6e35780-b82f-11eb-8ca7-1a1692f4314a.png)

From the flame graph above, it can be seen that now, all allocations in V code pass through the prealloc_ functions, and thus use chunks (before, vcalloc allocated directly, even with -prealloc, which was probably a bug), and the only remaining users of libc's malloc etc are other libc functions like `opendir` and `fseek`, over which we do not have direct control.
