### PR TITLE
vweb: fix parsing form data

### DIFF
--- a/vlib/vweb/request.v
+++ b/vlib/vweb/request.v
@@ -105,15 +105,10 @@ fn parse_multipart_form(body string, boundary string) (map[string]string, map[st
 		// TODO: filename*
 		if 'filename' in disposition {
 			filename := disposition['filename']
-			// Parse Content-Type header
-			if lines.len == 1 || !lines[1].to_lower().starts_with('content-type:') {
-				continue
-			}
-			mut ct := lines[1].split_nth(':', 2)[1]
-			ct = ct.trim_left(' \t')
+			_, content_type := parse_header(if lines.len > 1 { lines[1] } else { '' }) or { '', '' }
 			files[name] << FileData{
 				filename: filename
-				content_type: ct
+				content_type: content_type
 				data: data
 			}
 			continue

--- a/vlib/vweb/request.v
+++ b/vlib/vweb/request.v
@@ -1,7 +1,6 @@
 module vweb
 
 import io
-import strings
 import net.http
 import net.urllib
 
@@ -136,16 +135,4 @@ fn parse_disposition(line string) map[string]string {
 		}
 	}
 	return data
-}
-
-[manualfree]
-fn lines_to_string(len int, lines []string, start int, end int) string {
-	mut sb := strings.new_builder(len)
-	for i in start .. end {
-		sb.writeln(lines[i])
-	}
-	sb.cut_last(1) // last newline
-	res := sb.str()
-	unsafe { sb.free() }
-	return res
 }

--- a/vlib/vweb/request.v
+++ b/vlib/vweb/request.v
@@ -103,7 +103,9 @@ fn parse_multipart_form(body string, boundary string) (map[string]string, map[st
 		// TODO: filename*
 		if 'filename' in disposition {
 			filename := disposition['filename']
-			_, content_type := parse_header(if headers.len > 1 { headers[1] } else { '' }) or { '', '' }
+			_, content_type := parse_header(if headers.len > 1 { headers[1] } else { '' }) or {
+				'', ''
+			}
 			files[name] << FileData{
 				filename: filename
 				content_type: content_type

--- a/vlib/vweb/request.v
+++ b/vlib/vweb/request.v
@@ -91,11 +91,10 @@ fn parse_multipart_form(body string, boundary string) (map[string]string, map[st
 	mut files := map[string][]FileData{}
 
 	for field in fields {
-		// TODO: do not split into lines; do same parsing for HTTP body
 		crnl := field.contains('\r\n\r\n')
 		mut section_start := field.index('\r\n\r\n') or { field.index('\n\n') or { 0 } }
-		lines := field[0..section_start].split_into_lines()[1..]
-		disposition := parse_disposition(if lines.len > 0 { lines[0] } else { '' })
+		headers := field[0..section_start].split_into_lines()[1..]
+		disposition := parse_disposition(if headers.len > 0 { headers[0] } else { '' })
 		name := disposition['name'] or { continue }
 		section_start += if section_start > 0 && crnl { 4 } else { 2 }
 		section_end := field.last_index('\n') or { field.len }
@@ -104,7 +103,7 @@ fn parse_multipart_form(body string, boundary string) (map[string]string, map[st
 		// TODO: filename*
 		if 'filename' in disposition {
 			filename := disposition['filename']
-			_, content_type := parse_header(if lines.len > 1 { lines[1] } else { '' }) or { '', '' }
+			_, content_type := parse_header(if headers.len > 1 { headers[1] } else { '' }) or { '', '' }
 			files[name] << FileData{
 				filename: filename
 				content_type: content_type

--- a/vlib/vweb/request_test.v
+++ b/vlib/vweb/request_test.v
@@ -129,6 +129,37 @@ ${contents[1]}
 	}
 }
 
+fn test_parse_multipart_form_data() {
+	boundary := '6844a625b1f0b300'
+	names := ['foo', 'text']
+	file := 'bar.v'
+	ct := 'application/octet-stream'
+	contents := ['ABCdef123 \t\v\r\r\n\r\n'.repeat(6400), 'deadbeef']
+	data := "--------------------------$boundary\r
+Content-Disposition: form-data; name=\"${names[0]}\"; filename=\"$file\"\r
+Content-Type: $ct\r
+\r
+${contents[0]}\r
+--------------------------$boundary\r
+Content-Disposition: form-data; name=\"${names[1]}\"\r
+\r
+${contents[1]}\r
+--------------------------$boundary--\r
+"
+	form, files := parse_multipart_form(data, boundary)
+	assert files == map{
+		names[0]: [FileData{
+			filename: file
+			content_type: ct
+			data: contents[0]
+		}]
+	}
+
+	assert form == map{
+		names[1]: contents[1]
+	}
+}
+
 fn test_parse_large_body() ? {
 	body := 'A'.repeat(101) // greater than max_bytes
 	req := 'GET / HTTP/1.1\r\nContent-Length: $body.len\r\n\r\n$body'


### PR DESCRIPTION
Fixes #9934.
Fix parsing form data and files, and unifies it.
Remove lines_to_string()
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
