### PR TITLE
checker: fix generics with generic structs init (fix #10059)

### DIFF
--- a/vlib/v/checker/tests/check_generic_int_init.out
+++ b/vlib/v/checker/tests/check_generic_int_init.out
@@ -1,6 +1,0 @@
-vlib/v/checker/tests/check_generic_int_init.vv:2:9: error: type `int` is private
-    1 | fn test<T>() T {
-    2 |     return T{}
-      |            ~~~
-    3 | }
-    4 |

--- a/vlib/v/checker/tests/check_generic_int_init.vv
+++ b/vlib/v/checker/tests/check_generic_int_init.vv
@@ -1,7 +1,0 @@
-fn test<T>() T {
-	return T{}
-}
-
-fn main() {
-	_ := test<int>()
-}

--- a/vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.out
+++ b/vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.out
@@ -12,3 +12,10 @@ vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.vv:32:1: error: g
       | ~~~~~~~~~~~~~~
    33 |     println("hi")
    34 | }
+vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.vv:21:14: error: cannot use `Generic<Concrete>` as `Generic<T>` in argument 1 to `g_worker`
+   19 |     }
+   20 |
+   21 |     go g_worker(g)
+      |                 ^
+   22 |
+   23 |     return g

--- a/vlib/v/checker/tests/generics_fn_return_generic_struct_err.out
+++ b/vlib/v/checker/tests/generics_fn_return_generic_struct_err.out
@@ -5,3 +5,9 @@ vlib/v/checker/tests/generics_fn_return_generic_struct_err.vv:13:32: error: retu
       |                                ~~~~~~~~~~~~~~~~~~~~
    14 |     d := GenericChannelStruct{
    15 |         ch: chan T{}
+vlib/v/checker/tests/generics_fn_return_generic_struct_err.vv:17:9: error: cannot use `GenericChannelStruct<Simple>` as type `GenericChannelStruct` in return argument
+   15 |         ch: chan T{}
+   16 |     }
+   17 |     return d
+      |            ^
+   18 | }

--- a/vlib/v/tests/generics_with_generics_struct_init_test.v
+++ b/vlib/v/tests/generics_with_generics_struct_init_test.v
@@ -1,0 +1,32 @@
+struct List<T> {
+mut:
+	count u32
+	first &ListNode<T>
+	last  &ListNode<T>
+}
+
+struct ListNode<T> {
+mut:
+	val  T
+	next &ListNode<T> = 0
+}
+
+fn create<T>(arr []T) &List<T> {
+	assert arr.len > 0
+	mut n := &ListNode{
+		val: arr[0]
+		next: 0
+	}
+	mut l := &List{
+		first: n
+		last: n
+		count: 1
+	}
+	return l
+}
+
+fn test_generics_with_generic_structs_init() {
+	n := create([1, 2, 3])
+	println(n)
+	assert n.count == 1
+}


### PR DESCRIPTION
This PR fix generics with generic structs init (fix #10059).

- Fix generics with generic structs init.
- Add test.

```vlang
struct List<T> {
mut:
	count u32
	first &ListNode<T>
	last  &ListNode<T>
}

struct ListNode<T> {
mut:
	val  T
	next &ListNode<T> = 0
}

fn create<T>(arr []T) &List<T> {
	assert arr.len > 0
	mut n := &ListNode{
		val: arr[0]
		next: 0
	}
	mut l := &List{
		first: n
		last: n
		count: 1
	}
	return l
}

fn test_generics_with_generic_structs_init() {
	n := create([1, 2, 3])
	println(n)
	assert n.count == 1
}

PS D:\Test\v\tt1> v run .
&List<int>{
    count: 1
    first: &ListNode<int>{
        val: 1
        next: &nil
    }
    last: &ListNode<int>{
        val: 1
        next: &nil
    }
}
```