### PR TITLE
cgen: fix accessing fields in propagated optional subexpressions

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -462,7 +462,7 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 				g.write('\n $cur_line $tmp_opt /*U*/')
 			} else {
 				if !g.inside_const {
-					g.write('\n $cur_line *($unwrapped_styp*)${tmp_opt}.data')
+					g.write('\n $cur_line (*($unwrapped_styp*)${tmp_opt}.data)')
 				} else {
 					g.write('\n $cur_line $tmp_opt')
 				}

--- a/vlib/v/tests/option_2_test.v
+++ b/vlib/v/tests/option_2_test.v
@@ -62,5 +62,5 @@ fn foo() ?string {
 }
 
 fn test_opt_subexp_field() ? {
-	assert foo()?.len == 2
+	assert foo() ?.len == 2
 }

--- a/vlib/v/tests/option_2_test.v
+++ b/vlib/v/tests/option_2_test.v
@@ -56,3 +56,11 @@ fn test_nested_opt() {
 	a := f(f(f(-3) or { -7 }) or { 4 }) or { 17 }
 	assert a == 4
 }
+
+fn foo() ?string {
+	return 'hi'
+}
+
+fn test_opt_subexp_field() ? {
+	assert foo()?.len == 2
+}


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
