### PR TITLE
checker: deprecate using V string in C function call

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -3506,7 +3506,7 @@ fn my_callback(arg voidptr, howmany int, cvalues &&char, cnames &&char) int {
 fn main() {
 	db := &C.sqlite3(0) // this means `sqlite3* db = 0`
 	// passing a string literal to a C function call results in a C string, not a V string
-	C.sqlite3_open('users.db', &db)
+	C.sqlite3_open(c'users.db', &db)
 	// C.sqlite3_open(db_path.str, &db)
 	query := 'select count(*) from users'
 	stmt := &C.sqlite3_stmt(0)

--- a/examples/c_interop_wkhtmltopdf.v
+++ b/examples/c_interop_wkhtmltopdf.v
@@ -62,7 +62,7 @@ fn main() {
 	converter := C.wkhtmltopdf_create_converter(global_settings)
 	println('wkhtmltopdf_create_converter: ${voidptr(converter)}')
 	// convert
-	mut result := C.wkhtmltopdf_set_object_setting(object_settings, 'page', 'http://www.google.com.br')
+	mut result := C.wkhtmltopdf_set_object_setting(object_settings, c'page', c'http://www.google.com.br')
 	println('wkhtmltopdf_set_object_setting: $result [page = http://www.google.com.br]')
 	C.wkhtmltopdf_add_object(converter, object_settings, 0)
 	println('wkhtmltopdf_add_object')

--- a/examples/sokol/fonts.v
+++ b/examples/sokol/fonts.v
@@ -48,7 +48,7 @@ fn init(mut state AppState) {
 	// or use DroidSerif-Regular.ttf
 	if bytes := os.read_bytes(os.resource_abs_path('../assets/fonts/RobotoMono-Regular.ttf')) {
 		println('loaded font: $bytes.len')
-		state.font_normal = C.fonsAddFontMem(state.fons, 'sans', bytes.data, bytes.len,
+		state.font_normal = C.fonsAddFontMem(state.fons, c'sans', bytes.data, bytes.len,
 			false)
 	}
 }

--- a/examples/sokol/freetype_raven.v
+++ b/examples/sokol/freetype_raven.v
@@ -101,7 +101,7 @@ fn init(user_data voidptr) {
 	// or use DroidSerif-Regular.ttf
 	if bytes := os.read_bytes(os.resource_abs_path('../assets/fonts/RobotoMono-Regular.ttf')) {
 		println('loaded font: $bytes.len')
-		state.font_normal = C.fonsAddFontMem(state.fons, 'sans', bytes.data, bytes.len,
+		state.font_normal = C.fonsAddFontMem(state.fons, c'sans', bytes.data, bytes.len,
 			false)
 	}
 }

--- a/vlib/gg/text_rendering.v
+++ b/vlib/gg/text_rendering.v
@@ -68,13 +68,13 @@ fn new_ft(c FTConfig) ?&FT {
 
 			return &FT{
 				fons: fons
-				font_normal: C.fonsAddFontMem(fons, 'sans', bytes_normal.data, bytes_normal.len,
+				font_normal: C.fonsAddFontMem(fons, c'sans', bytes_normal.data, bytes_normal.len,
 					false)
-				font_bold: C.fonsAddFontMem(fons, 'sans', bytes_bold.data, bytes_bold.len,
+				font_bold: C.fonsAddFontMem(fons, c'sans', bytes_bold.data, bytes_bold.len,
 					false)
-				font_mono: C.fonsAddFontMem(fons, 'sans', bytes_mono.data, bytes_mono.len,
+				font_mono: C.fonsAddFontMem(fons, c'sans', bytes_mono.data, bytes_mono.len,
 					false)
-				font_italic: C.fonsAddFontMem(fons, 'sans', bytes_italic.data, bytes_italic.len,
+				font_italic: C.fonsAddFontMem(fons, c'sans', bytes_italic.data, bytes_italic.len,
 					false)
 				scale: c.scale
 			}
@@ -129,10 +129,10 @@ fn new_ft(c FTConfig) ?&FT {
 	fons := sfons.create(512, 512, 1)
 	return &FT{
 		fons: fons
-		font_normal: C.fonsAddFontMem(fons, 'sans', bytes.data, bytes.len, false)
-		font_bold: C.fonsAddFontMem(fons, 'sans', bytes_bold.data, bytes_bold.len, false)
-		font_mono: C.fonsAddFontMem(fons, 'sans', bytes_mono.data, bytes_mono.len, false)
-		font_italic: C.fonsAddFontMem(fons, 'sans', bytes_italic.data, bytes_italic.len,
+		font_normal: C.fonsAddFontMem(fons, c'sans', bytes.data, bytes.len, false)
+		font_bold: C.fonsAddFontMem(fons, c'sans', bytes_bold.data, bytes_bold.len, false)
+		font_mono: C.fonsAddFontMem(fons, c'sans', bytes_mono.data, bytes_mono.len, false)
+		font_italic: C.fonsAddFontMem(fons, c'sans', bytes_italic.data, bytes_italic.len,
 			false)
 		scale: c.scale
 	}

--- a/vlib/glm/glm.v
+++ b/vlib/glm/glm.v
@@ -116,7 +116,7 @@ fn (a Vec3) print() {
 	x := a.x
 	y := a.y
 	z := a.z
-	C.printf('vec3{%f,%f,%f}\n', x, y, z)
+	C.printf(c'vec3{%f,%f,%f}\n', x, y, z)
 	// println('vec3{$x,$y,$z}')
 }
 

--- a/vlib/net/http/backend_nix.c.v
+++ b/vlib/net/http/backend_nix.c.v
@@ -16,7 +16,7 @@ fn (req &Request) ssl_do(port int, method Method, host_name string, path string)
 	C.SSL_CTX_set_verify_depth(ctx, 4)
 	flags := C.SSL_OP_NO_SSLv2 | C.SSL_OP_NO_SSLv3 | C.SSL_OP_NO_COMPRESSION
 	C.SSL_CTX_set_options(ctx, flags)
-	mut res := C.SSL_CTX_load_verify_locations(ctx, 'random-org-chain.pem', 0)
+	mut res := C.SSL_CTX_load_verify_locations(ctx, c'random-org-chain.pem', 0)
 	web := C.BIO_new_ssl_connect(ctx)
 	addr := host_name + ':' + port.str()
 	res = C.BIO_set_conn_hostname(web, addr.str)

--- a/vlib/net/openssl/c.v
+++ b/vlib/net/openssl/c.v
@@ -5,7 +5,7 @@ module openssl
 // openssl from libssl-dev. If there is no local openssl,
 // the next flag is harmless, since it will still use the
 // (older) system openssl.
-#flag linux -I/usr/local/include/openssl -L/usr/local/lib 
+#flag linux -I/usr/local/include/openssl -L/usr/local/lib
 #flag windows -l libssl -l libcrypto
 #flag -lssl -lcrypto
 #flag linux -ldl -lpthread

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -829,8 +829,8 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 	}
 	if node.language == .c {
 		// Skip "C."
-		g.is_c_call = true
 		name = util.no_dots(name[2..])
+		g.is_c_call = true
 	} else {
 		name = c_name(name)
 	}

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -5,7 +5,6 @@ module c
 import v.ast
 import v.util
 
-[inline]
 fn (mut g Gen) write_str_fn_definitions() {
 	g.writeln(c_str_fn_defs)
 }

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -5,6 +5,7 @@ module c
 import v.ast
 import v.util
 
+[inline]
 fn (mut g Gen) write_str_fn_definitions() {
 	g.writeln(c_str_fn_defs)
 }
@@ -21,12 +22,6 @@ fn (mut g Gen) string_literal(node ast.StringLiteral) {
 		// `C.printf("hi")` => `printf("hi");`
 		g.write('"$escaped_val"')
 	} else {
-		// TODO calculate the literal's length in V, it's a bit tricky with all the
-		// escape characters.
-		// Clang and GCC optimize `strlen("lorem ipsum")` to `11`
-		// g.write('tos4("$escaped_val", strlen("$escaped_val"))')
-		// g.write('tos4("$escaped_val", $it.val.len)')
-		// g.write('_SLIT("$escaped_val")')
 		g.write('_SLIT("$escaped_val")')
 	}
 }

--- a/vlib/v/tests/cstrings_test.v
+++ b/vlib/v/tests/cstrings_test.v
@@ -1,10 +1,8 @@
 fn test_cstring() {
 	w := &char(c'world')
 	hlen := unsafe { C.strlen(c'hello') }
-	hlen2 := unsafe { C.strlen('hello') }
 	wlen := unsafe { C.strlen(w) }
 	assert hlen == 5
-	assert hlen2 == 5
 	assert wlen == 5
 }
 

--- a/vlib/v/util/quote.v
+++ b/vlib/v/util/quote.v
@@ -12,7 +12,7 @@ pub fn smart_quote(str string, raw bool) string {
 	if len == 0 {
 		return str
 	}
-	mut result := strings.new_builder(0)
+	mut result := strings.new_builder(len)
 	mut pos := -1
 	mut last := ''
 	// TODO: This should be a single char?


### PR DESCRIPTION
Currently, the following codes are equivalent:
```v
fn C.my_fn(string)

C.my_fn('my_string')
```
```v
fn C.my_fn(&u8)

C.my_fn(c'my_string')
```
I'm deprecating the first one in favor of the second.
This adds a temporary limitation, string literal can't be used at all in C function call. However, they used to break C compilation (see #10127). Once the feature and deprecation are removed, this limitation won't stay.