### PR TITLE
checker,gen: remove automatic string to C string conversion

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -411,9 +411,6 @@ pub const (
 	error_type         = new_type(error_type_idx)
 	charptr_types      = [charptr_type, new_type(char_type_idx).set_nr_muls(1)]
 	byteptr_types      = [byteptr_type, new_type(byte_type_idx).set_nr_muls(1)]
-	cptr_or_bptr_types = [charptr_type, byteptr_type, new_type(char_type_idx).set_nr_muls(1),
-		new_type(byte_type_idx).set_nr_muls(1),
-	]
 )
 
 pub const (

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -34,12 +34,6 @@ pub fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type,
 			&& got.idx() in [ast.int_type_idx, ast.int_literal_type_idx]) {
 			return
 		}
-		// allow `C.printf('foo')` instead of `C.printf(c'foo')`
-		if got.idx() == ast.string_type_idx
-			&& (expected in [ast.byteptr_type_idx, ast.charptr_type_idx]
-			|| (expected.idx() == ast.char_type_idx && expected.is_ptr())) {
-			return
-		}
 		exp_sym := c.table.get_type_symbol(expected)
 		// unknown C types are set to int, allow int to be used for types like `&C.FILE`
 		// eg. `C.fflush(C.stderr)` - error: cannot use `int` as `&C.FILE` in argument 1 to `C.fflush`
@@ -47,7 +41,6 @@ pub fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type,
 			&& got == ast.int_type_idx {
 			return
 		}
-		// return
 	}
 	if c.check_types(got, expected) {
 		return

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -76,7 +76,6 @@ pub mut:
 	inside_anon_fn bool
 	inside_ref_lit bool
 	inside_fn_arg  bool // `a`, `b` in `a.f(b)`
-	inside_c_call  bool // true inside C.printf( param ) calls, but NOT in nested calls, unless they are also C.
 	inside_ct_attr bool // true inside [if expr]
 	skip_flags     bool // should `#flag` and `#include` be skipped
 mut:
@@ -1737,11 +1736,6 @@ fn (mut c Checker) check_map_and_filter(is_map bool, elem_typ ast.Type, call_exp
 }
 
 pub fn (mut c Checker) method_call(mut call_expr ast.CallExpr) ast.Type {
-	was_inside_c_call := c.inside_c_call
-	c.inside_c_call = call_expr.language == .c
-	defer {
-		c.inside_c_call = was_inside_c_call
-	}
 	left_type := c.expr(call_expr.left)
 	c.expected_type = left_type
 	mut is_generic := left_type.has_flag(.generic)
@@ -2227,11 +2221,6 @@ fn (mut c Checker) array_builtin_method_call(mut call_expr ast.CallExpr, left_ty
 }
 
 pub fn (mut c Checker) fn_call(mut call_expr ast.CallExpr) ast.Type {
-	was_inside_c_call := c.inside_c_call
-	c.inside_c_call = call_expr.language == .c
-	defer {
-		c.inside_c_call = was_inside_c_call
-	}
 	fn_name := call_expr.name
 	if fn_name == 'main' {
 		c.error('the `main` function cannot be called in the program', call_expr.pos)
@@ -2564,10 +2553,6 @@ pub fn (mut c Checker) fn_call(mut call_expr ast.CallExpr) ast.Type {
 			&& param.typ !in [ast.byteptr_type, ast.charptr_type, ast.voidptr_type] {
 			// sym := c.table.get_type_symbol(typ)
 			c.warn('automatic referencing/dereferencing is deprecated and will be removed soon (got: $typ.nr_muls() references, expected: $param.typ.nr_muls() references)',
-				call_arg.pos)
-		}
-		if func.language == .c && typ == ast.string_type && param.typ in ast.cptr_or_bptr_types {
-			c.warn("automatic string to C-string conversion is deprecated and will be removed on 2021-06-19, use `c'<string_value>'` and set the C function parameter type to `&u8`",
 				call_arg.pos)
 		}
 	}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -69,7 +69,6 @@ mut:
 	last_fn_c_name         string
 	tmp_count              int      // counter for unique tmp vars (_tmp1, tmp2 etc)
 	tmp_count2             int      // a separate tmp var counter for autofree fn calls
-	is_c_call              bool     // e.g. `C.printf("v")`
 	is_assign_lhs          bool     // inside left part of assign expr (for array_set(), etc)
 	discard_or_result      bool     // do not safe last ExprStmt of `or` block in tmp variable to defer ongoing expr usage
 	is_void_expr_stmt      bool     // ExprStmt whos result is discarded

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -883,7 +883,6 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 	if node.language == .c {
 		// Skip "C."
 		name = util.no_dots(name[2..])
-		g.is_c_call = true
 	} else {
 		name = c_name(name)
 	}
@@ -979,7 +978,6 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 			}
 		}
 	}
-	g.is_c_call = false
 	g.is_json_fn = false
 }
 

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -6,15 +6,8 @@ import v.ast
 import v.util
 
 fn (mut g Gen) string_literal(node ast.StringLiteral) {
-	if node.is_raw {
-		escaped_val := util.smart_quote(node.val, true)
-		g.write('_SLIT("$escaped_val")')
-		return
-	}
-	escaped_val := util.smart_quote(node.val, false)
-	if g.is_c_call || node.language == .c {
-		// In C calls we have to generate C strings
-		// `C.printf("hi")` => `printf("hi");`
+	escaped_val := util.smart_quote(node.val, node.is_raw)
+	if node.language == .c {
 		g.write('"$escaped_val"')
 	} else {
 		g.write('_SLIT("$escaped_val")')


### PR DESCRIPTION
Follow up of #10140
Fixes #10127

~~Requires https://github.com/vlang/ui/pull/355~~ ✅

Don't merge before 2020-06-19, the date of removal indicated in the deprecation warning.