### PR TITLE
checker: fix generic struct with anon fn parameter (fix #10145)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -618,7 +618,7 @@ fn (mut c Checker) unwrap_generics_struct_init(struct_type ast.Type) ast.Type {
 			for i in 0 .. ts.info.generic_types.len {
 				gts := c.table.get_type_symbol(c.unwrap_generic(ts.info.generic_types[i]))
 				nrt += gts.name
-				c_nrt += gts.name
+				c_nrt += gts.cname
 				if i != ts.info.generic_types.len - 1 {
 					nrt += ','
 					c_nrt += '_'
@@ -1685,14 +1685,14 @@ fn (mut c Checker) check_return_generics_struct(return_type ast.Type, mut call_e
 	if rts.info is ast.Struct {
 		if rts.info.is_generic {
 			mut nrt := '$rts.name<'
-			mut c_nrt := '${rts.name}_T_'
+			mut c_nrt := '${rts.cname}_T_'
 			for i in 0 .. rts.info.generic_types.len {
 				if ct := c.table.resolve_generic_to_concrete(rts.info.generic_types[i],
 					generic_names, concrete_types, false)
 				{
 					gts := c.table.get_type_symbol(ct)
 					nrt += gts.name
-					c_nrt += gts.name
+					c_nrt += gts.cname
 					if i != rts.info.generic_types.len - 1 {
 						nrt += ','
 						c_nrt += '_'

--- a/vlib/v/tests/generics_struct_anon_fn_type_test.v
+++ b/vlib/v/tests/generics_struct_anon_fn_type_test.v
@@ -1,0 +1,23 @@
+fn neg(a int) int {
+	return -a
+}
+
+struct FnHolder<T> {
+	func T
+}
+
+fn (self FnHolder<T>) call<T>(a int) int {
+	return self.func(a)
+}
+
+fn holder_call<T>(func T, a int) int {
+	_ = FnHolder<T>{func}
+	return 0
+}
+
+fn test_generic_struct_with_anon_fn_parameter() {
+	mut ret := 0
+
+	ret = holder_call(neg, 1)
+	assert ret == 0
+}


### PR DESCRIPTION
This PR fix generic struct with anon fn parameter (fix #10145).

- Fix generic struct with anon fn parameter.
- Add test.

```vlang
fn neg(a int) int {
	return -a
}

struct FnHolder<T> {
	func T
}

fn (self FnHolder<T>) call(a int) int {
	return self.func(a)
}

fn holder_call<T>(func T, a int) int {
	_ = FnHolder{func}
	return 0
}

fn main() {
	mut ret := 0

	ret = holder_call(neg, 1)
	println(ret)
	assert ret == 0
}

PS D:\Test\v\tt1> v run .
0
```