### PR TITLE
checker: fix type error when call `f<T>(fn (v T))` with multiple different T

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1211,6 +1211,7 @@ pub fn (mut t Table) resolve_generic_to_concrete(generic_type Type, generic_name
 				func.return_type = typ
 			}
 		}
+		func.params = func.params.clone()
 		for mut param in func.params {
 			if param.typ.has_flag(.generic) {
 				if typ := t.resolve_generic_to_concrete(param.typ, generic_names, concrete_types,

--- a/vlib/v/tests/generics_with_anon_generics_fn_test.v
+++ b/vlib/v/tests/generics_with_anon_generics_fn_test.v
@@ -24,6 +24,14 @@ pub fn consume(data int) int {
 	return data
 }
 
+pub fn consume_str(data string) string {
+	return data
+}
+
+fn call<T>(f fn (T) T, v T) T {
+	return f(v)
+}
+
 fn test_generics_with_anon_generics_fn() {
 	mut s := MyStruct<int>{
 		arr: [1, 2, 3, 4, 5]
@@ -31,4 +39,9 @@ fn test_generics_with_anon_generics_fn() {
 	y := s.iterate<int>(consume)
 	println(y)
 	assert y == 15
+
+	assert call<int>(consume, 1) == 1
+	assert call<string>(consume_str, '1') == '1'
+	assert call(consume, 1) == 1
+	assert call(consume_str, '1') == '1'
 }


### PR DESCRIPTION
Added test is failed on current master. This PR fix it.

```
 FAIL    55.163 ms vlib/v/tests/generics_with_anon_generics_fn_test.v
vlib/v/tests/generics_with_anon_generics_fn_test.v:44:22: error: cannot use `fn (string) string` as `fn (int) string` in argument 1 to `call`
   42 |
   43 |     assert call<int>(consume, 1) == 1
   44 |     assert call<string>(consume_str, '1') == '1'
      |                         ~~~~~~~~~~~
   45 |     assert call(consume, 1) == 1
   46 |     assert call(consume_str, '1') == '1'
vlib/v/tests/generics_with_anon_generics_fn_test.v:46:14: error: cannot use `fn (string) string` as `fn (int) string` in argument 1 to `call`
   44 |     assert call<string>(consume_str, '1') == '1'
   45 |     assert call(consume, 1) == 1
   46 |     assert call(consume_str, '1') == '1'
      |                 ~~~~~~~~~~~
   47 | }
```


<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
