### PR TITLE
fmt: use trailing arg syntax only last arg

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1584,14 +1584,6 @@ pub fn (mut f Fmt) at_expr(node ast.AtExpr) {
 }
 
 pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
-	old_short_arg_state := f.use_short_fn_args
-	f.use_short_fn_args = false
-	if node.args.len > 0 && node.args.last().expr is ast.StructInit {
-		struct_expr := node.args.last().expr as ast.StructInit
-		if struct_expr.typ == ast.void_type {
-			f.use_short_fn_args = true
-		}
-	}
 	for arg in node.args {
 		f.comments(arg.comments, {})
 	}
@@ -1639,7 +1631,6 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 	f.write(')')
 	f.or_expr(node.or_block)
 	f.comments(node.comments, has_nl: false)
-	f.use_short_fn_args = old_short_arg_state
 }
 
 fn (mut f Fmt) write_generic_if_require(node ast.CallExpr) {
@@ -1662,10 +1653,19 @@ fn (mut f Fmt) write_generic_if_require(node ast.CallExpr) {
 
 pub fn (mut f Fmt) call_args(args []ast.CallArg) {
 	f.single_line_fields = true
+	old_short_arg_state := f.use_short_fn_args
+	f.use_short_fn_args = false
 	defer {
 		f.single_line_fields = false
+		f.use_short_fn_args = old_short_arg_state
 	}
 	for i, arg in args {
+		if i == args.len - 1 && arg.expr is ast.StructInit {
+			struct_expr := arg.expr as ast.StructInit
+			if struct_expr.typ == ast.void_type {
+				f.use_short_fn_args = true
+			}
+		}
 		if arg.is_mut {
 			f.write(arg.share.str() + ' ')
 		}

--- a/vlib/v/fmt/tests/fn_trailing_arg_syntax_expected.vv
+++ b/vlib/v/fmt/tests/fn_trailing_arg_syntax_expected.vv
@@ -22,6 +22,10 @@ fn main() {
 			y: 0
 		}
 	)
+	bar2_func({}, {})
+	bar2_func({ x: 's' },
+		x: 's'
+	)
 	baz_func('foo', 'bar',
 		x: 0
 		y: 0
@@ -38,6 +42,9 @@ fn main() {
 }
 
 fn bar_func(bar Bar) {
+}
+
+fn bar2_func(bar1 Bar, bar2 Bar) {
 }
 
 fn baz_func(a string, b string, baz Baz) {}

--- a/vlib/v/fmt/tests/fn_trailing_arg_syntax_input.vv
+++ b/vlib/v/fmt/tests/fn_trailing_arg_syntax_input.vv
@@ -16,6 +16,8 @@ fn main() {
 		x: 0
 		y: 0
 	})
+	bar2_func({}, {})
+	bar2_func({x: 's'}, {x: 's'})
 	baz_func('foo', 'bar', x: 0
 		y: 0
 	)
@@ -26,6 +28,9 @@ fn main() {
 }
 
 fn bar_func(bar Bar) {
+}
+
+fn bar2_func(bar1 Bar, bar2 Bar) {
 }
 
 fn baz_func(a string, b string, baz Baz) {}


### PR DESCRIPTION
on current master, v fmt breakes code like this. This PR fix it.

```
╭─ zakuro   ~/src/github.com/zakuro9715/v   master
╰─ > cat main.v
struct St {
        a int
}

fn f(s St, s2 St) {
}

f({a: 0}, {a: 0})
╭─ zakuro   ~/src/github.com/zakuro9715/v   master
╰─ > v fmt main.v
struct St {
        a int
}

fn f(s St, s2 St) {
}

f(a: 0, {
        a: 0
})
╭─ zakuro   ~/src/github.com/zakuro9715/v   master
╰─ > v fmt main.v | v
01F65VWK62Z4E449KFNQSK256H.v:8:9: error: unexpected token `{`, expecting name
    6 | }
    7 |
    8 | f(a: 0, {
      |         ^
    9 |     a: 0
   10 | })
```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
