### PR TITLE
checker: fix generic struct with anon fn type (fix #10152)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2055,7 +2055,7 @@ pub fn (mut c Checker) method_call(mut call_expr ast.CallExpr) ast.Type {
 	// call struct field fn type
 	// TODO: can we use SelectorExpr for all? this dosent really belong here
 	if field := c.table.find_field(left_type_sym, method_name) {
-		field_type_sym := c.table.get_type_symbol(field.typ)
+		field_type_sym := c.table.get_type_symbol(c.unwrap_generic(field.typ))
 		if field_type_sym.kind == .function {
 			// call_expr.is_method = false
 			call_expr.is_field = true

--- a/vlib/v/tests/generics_struct_anon_fn_type_test.v
+++ b/vlib/v/tests/generics_struct_anon_fn_type_test.v
@@ -2,22 +2,52 @@ fn neg(a int) int {
 	return -a
 }
 
-struct FnHolder<T> {
+struct FnHolder1<T> {
 	func T
 }
 
-fn (self FnHolder<T>) call<T>(a int) int {
+fn (self FnHolder1<T>) call(a int) int {
 	return self.func(a)
 }
 
-fn holder_call<T>(func T, a int) int {
-	_ = FnHolder<T>{func}
-	return 0
+struct FnHolder2<T> {
+	func fn (int) int
+}
+
+fn (self FnHolder2<T>) call(a int) int {
+	return self.func(a)
+}
+
+fn holder_call_1<T>(func T, a int) int {
+	h := FnHolder1{func}
+	return h.call(a)
+}
+
+fn holder_call_2<T>(func T, a int) int {
+	h := FnHolder2{func}
+	return h.call(a)
+}
+
+fn holder_call_11<T>(func T, a int) int {
+	f := func
+	h := FnHolder1{f}
+	return h.call(a)
+}
+
+fn holder_call_21<T>(func T, a int) int {
+	f := func
+	h := FnHolder2{f}
+	return h.call(a)
 }
 
 fn test_generic_struct_with_anon_fn_parameter() {
-	mut ret := 0
+	mut ret := holder_call_1(neg, 1)
+	assert ret == -1
+	ret = holder_call_11(neg, 2)
+	assert ret == -2
 
-	ret = holder_call(neg, 1)
-	assert ret == 0
+	ret = holder_call_2(neg, 3)
+	assert ret == -3
+	ret = holder_call_21(neg, 4)
+	assert ret == -4
 }


### PR DESCRIPTION
This PR fix generic struct with anon fn type (fix #10152).

- Fix generic struct with anon fn type.
- Modify test.

```vlang
fn neg(a int) int {
	return -a
}

struct FnHolder1<T> {
	func T
}

fn (self FnHolder1<T>) call(a int) int {
	return self.func(a)
}

struct FnHolder2<T> {
	func fn (int) int
}

fn (self FnHolder2<T>) call(a int) int {
	return self.func(a)
}

fn holder_call_1<T>(func T, a int) int {
	h := FnHolder1{func}
	return h.call(a)
}

fn holder_call_2<T>(func T, a int) int {
	h := FnHolder2{func}
	return h.call(a)
}

fn holder_call_11<T>(func T, a int) int {
	f := func
	h := FnHolder1{f}
	return h.call(a)
}

fn holder_call_21<T>(func T, a int) int {
	f := func
	h := FnHolder2{f}
	return h.call(a)
}

fn main() {
	mut ret := holder_call_1(neg, 1)
	assert ret == -1
	ret = holder_call_11(neg, 2)
	assert ret == -2

	ret = holder_call_2(neg, 3)
	assert ret == -3
	ret = holder_call_21(neg, 4)
	assert ret == -4
}

PS D:\Test\v\tt1> v run .
```