### PR TITLE
vtest-cleancode: remove generics_return_generics_struct_test.v from verify_known_failing_exceptions

### DIFF
--- a/cmd/tools/vtest-cleancode.v
+++ b/cmd/tools/vtest-cleancode.v
@@ -32,7 +32,6 @@ const (
 		'vlib/builtin/int.v' /* TODO byteptr: vfmt converts `pub fn (nn byteptr) str() string {` to `nn &byte` and that conflicts with `nn byte` */,
 		'vlib/builtin/string_charptr_byteptr_helpers.v' /* TODO byteptr: a temporary shim to ease the byteptr=>&byte transition */,
 		'vlib/v/tests/fn_high_test.v', /* param name removed */
-		'vlib/v/tests/generics_return_generics_struct_test.v', /* generic fn param removed */
 		'vlib/v/tests/interop_test.v', /* bad comment formatting */
 		'vlib/v/tests/string_interpolation_test.v' /* TODO byteptr: &byte.str() behaves differently than byteptr.str() */,
 		'vlib/v/gen/js/tests/js.v', /* local `hello` fn, gets replaced with module `hello` aliased as `hl` */


### PR DESCRIPTION
This PR remove generics_return_generics_struct_test.v from verify_known_failing_exceptions of vtest-cleancode.v.

- vfmt generics_return_generics_struct_test.v is ok now.