### PR TITLE
checker: fix inferring generics method receiver types (fix #10164)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -503,7 +503,8 @@ pub fn (mut c Checker) infer_fn_generic_types(f ast.Fn, mut call_expr ast.CallEx
 				if sym.kind == .struct_ {
 					info := sym.info as ast.Struct
 					receiver_generic_names := info.generic_types.map(c.table.get_type_symbol(it).name)
-					if gt_name in receiver_generic_names {
+					if gt_name in receiver_generic_names
+						&& info.generic_types.len == info.concrete_types.len {
 						idx := receiver_generic_names.index(gt_name)
 						typ = info.concrete_types[idx]
 					}

--- a/vlib/v/tests/generics_struct_anon_fn_type_test.v
+++ b/vlib/v/tests/generics_struct_anon_fn_type_test.v
@@ -40,14 +40,30 @@ fn holder_call_21<T>(func T, a int) int {
 	return h.call(a)
 }
 
+fn holder_call_12<T>(func T, a int) int {
+	return FnHolder1{func}.call(a)
+}
+
+fn holder_call_22<T>(func T, a int) int {
+	return FnHolder2{func}.call(a)
+}
+
 fn test_generic_struct_with_anon_fn_parameter() {
 	mut ret := holder_call_1(neg, 1)
 	assert ret == -1
 	ret = holder_call_11(neg, 2)
 	assert ret == -2
+	ret = holder_call_12(neg, 3)
+	assert ret == -3
+	ret = FnHolder1<fn (int) int>{neg}.call(4)
+	assert ret == -4
 
 	ret = holder_call_2(neg, 3)
 	assert ret == -3
 	ret = holder_call_21(neg, 4)
 	assert ret == -4
+	ret = holder_call_22(neg, 5)
+	assert ret == -5
+	ret = FnHolder2<fn (int) int>{neg}.call(6)
+	assert ret == -6
 }


### PR DESCRIPTION
This PR fix inferring generics method receiver types (fix #10164).

- Fix inferring generics method receiver types.
- Modify vlib\v\tests\generics_struct_anon_fn_type_test.v.

```vlang
fn neg(a int) int {
	return -a
}

struct FnHolder1<T> {
	func T
}

fn (self FnHolder1<T>) call(a int) int {
	return self.func(a)
}

struct FnHolder2<T> {
	func fn (int) int
}

fn (self FnHolder2<T>) call(a int) int {
	return self.func(a)
}

fn holder_call_1<T>(func T, a int) int {
	h := FnHolder1{func}
	return h.call(a)
}

fn holder_call_2<T>(func T, a int) int {
	h := FnHolder2{func}
	return h.call(a)
}

fn holder_call_11<T>(func T, a int) int {
	f := func
	h := FnHolder1{f}
	return h.call(a)
}

fn holder_call_21<T>(func T, a int) int {
	f := func
	h := FnHolder2{f}
	return h.call(a)
}

fn holder_call_12<T>(func T, a int) int {
	return FnHolder1{func}.call(a)
}

fn holder_call_22<T>(func T, a int) int {
	return FnHolder2{func}.call(a)
}

fn main() {
	mut ret := holder_call_1(neg, 1)
	assert ret == -1
	ret = holder_call_11(neg, 2)
	assert ret == -2
	ret = holder_call_12(neg, 3)
	assert ret == -3
	ret = FnHolder1<fn (int) int>{neg}.call(4)
	assert ret == -4

	ret = holder_call_2(neg, 3)
	assert ret == -3
	ret = holder_call_21(neg, 4)
	assert ret == -4
	ret = holder_call_22(neg, 5)
	assert ret == -5
	ret = FnHolder2<fn (int) int>{neg}.call(6)
	assert ret == -6
}

PS D:\Test\v\tt1> v run .
```