### PR TITLE
checker: simplify generic structs

### DIFF
--- a/vlib/builtin/js/builtin.v
+++ b/vlib/builtin/js/builtin.v
@@ -55,10 +55,9 @@ pub fn panic(s string) {
 	exit(1)
 }
 
-struct Option<T> {
+struct Option {
 	state byte
 	err   Error
-	data  T
 }
 
 pub struct Error {

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -561,7 +561,7 @@ pub fn (mut c Checker) infer_fn_generic_types(f ast.Fn, mut call_expr ast.CallEx
 				} else if arg_sym.kind == .struct_ && param.typ.has_flag(.generic) {
 					info := arg_sym.info as ast.Struct
 					generic_names := info.generic_types.map(c.table.get_type_symbol(it).name)
-					if gt_name in generic_names {
+					if gt_name in generic_names && info.generic_types.len == info.concrete_types.len {
 						idx := generic_names.index(gt_name)
 						typ = info.concrete_types[idx]
 					}


### PR DESCRIPTION
This PR simplify generic structs.

- Remove `check_return_generics_struct()`.
- Change `unwrap_generics_struct_init()` to `unwrap_generic_struct()`.
- Modify related called.
- Fix js `Option<T>` error.