### PR TITLE
fmt: keep names of parameters in anonymus function 

### DIFF
--- a/cmd/tools/vtest-cleancode.v
+++ b/cmd/tools/vtest-cleancode.v
@@ -31,7 +31,6 @@ const (
 		// TODOs and unfixed vfmt bugs
 		'vlib/builtin/int.v' /* TODO byteptr: vfmt converts `pub fn (nn byteptr) str() string {` to `nn &byte` and that conflicts with `nn byte` */,
 		'vlib/builtin/string_charptr_byteptr_helpers.v' /* TODO byteptr: a temporary shim to ease the byteptr=>&byte transition */,
-		'vlib/v/tests/fn_high_test.v', /* param name removed */
 		'vlib/v/tests/interop_test.v', /* bad comment formatting */
 		'vlib/v/tests/string_interpolation_test.v' /* TODO byteptr: &byte.str() behaves differently than byteptr.str() */,
 		'vlib/v/gen/js/tests/js.v', /* local `hello` fn, gets replaced with module `hello` aliased as `hl` */

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -184,9 +184,12 @@ pub fn (t &Table) fn_type_source_signature(f &Fn) string {
 		if arg.is_mut {
 			sig += 'mut '
 		}
-		sig += arg.name
+		// NB: arg name is only added for fmt, else it would causes errors with generics
+		if t.is_fmt && arg.name.len > 0 {
+			sig += '$arg.name '
+		}
 		arg_type_sym := t.get_type_symbol(arg.typ)
-		sig += '$arg_type_sym.name'
+		sig += arg_type_sym.name
 		if i < f.params.len - 1 {
 			sig += ', '
 		}

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -184,6 +184,7 @@ pub fn (t &Table) fn_type_source_signature(f &Fn) string {
 		if arg.is_mut {
 			sig += 'mut '
 		}
+		sig += arg.name
 		arg_type_sym := t.get_type_symbol(arg.typ)
 		sig += '$arg_type_sym.name'
 		if i < f.params.len - 1 {
@@ -854,7 +855,6 @@ pub fn (mut t Table) find_or_register_fn_type(mod string, f Fn, is_anon bool, ha
 		util.no_dots(f.name.clone())
 	}
 	anon := f.name.len == 0 || is_anon
-	// existing
 	existing_idx := t.type_idxs[name]
 	if existing_idx > 0 && t.type_symbols[existing_idx].kind != .placeholder {
 		return existing_idx

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -909,7 +909,10 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 			} else {
 				if res.starts_with('fn (') {
 					// fn foo ()
-					res = t.fn_signature_using_aliases(info.func, import_aliases, type_only: true)
+					has_names := info.func.params.any(it.name.len > 0)
+					res = t.fn_signature_using_aliases(info.func, import_aliases,
+						type_only: !has_names
+					)
 				} else {
 					// FnFoo
 					res = t.shorten_user_defined_typenames(res, import_aliases)

--- a/vlib/v/fmt/tests/anon_fn_as_param_keep.vv
+++ b/vlib/v/fmt/tests/anon_fn_as_param_keep.vv
@@ -14,5 +14,7 @@ pub fn test_anon_fn_void(func fn ()) int {
 
 fn C.HasAnonFnWithNamedParams(cb fn (c C.bar, d voidptr))
 
-fn keep_param_names_in_anon_fn(f fn (a []int) []int) {
-}
+// NB: the signature of both anonymus functions should only differs in the param name
+fn anon_fn_param_has_no_name(f fn (int) string) {}
+
+fn anon_fn_with_named_param(func fn (a int) string) {}

--- a/vlib/v/fmt/tests/anon_fn_as_param_keep.vv
+++ b/vlib/v/fmt/tests/anon_fn_as_param_keep.vv
@@ -1,11 +1,18 @@
-struct Row {
-	id int
+import v.ast
+
+struct Data {
+	a fn (stmt ast.Stmt, vp voidptr) bool
 }
 
-pub fn (a []Row) reduce(iter fn (int, int) int, accum_start int) int {
+pub fn (a []Data) reduce(iter fn (int, int) int, accum_start int) int {
 	iter(accum_start)
 }
 
 pub fn test_anon_fn_void(func fn ()) int {
 	return 0
+}
+
+fn C.HasAnonFnWithNamedParams(cb fn (c C.bar, d voidptr))
+
+fn keep_param_names_in_anon_fn(f fn (a []int) []int) {
 }

--- a/vlib/v/fmt/tests/struct_fn_fields_expected.vv
+++ b/vlib/v/fmt/tests/struct_fn_fields_expected.vv
@@ -1,6 +1,0 @@
-import v.ast
-
-struct Data {
-	a fn (string, voidptr) bool
-	b fn (ast.Stmt, voidptr) bool
-}

--- a/vlib/v/fmt/tests/struct_fn_fields_input.vv
+++ b/vlib/v/fmt/tests/struct_fn_fields_input.vv
@@ -1,6 +1,0 @@
-import v.ast
-
-struct Data {
-	a fn (s string, f voidptr) bool
-	b fn (stmt ast.Stmt, f voidptr) bool
-}

--- a/vlib/v/tests/fn_high_test.v
+++ b/vlib/v/tests/fn_high_test.v
@@ -12,7 +12,7 @@ fn high_fn_no_ret(f fn (int)) {
 	f(111)
 }
 
-fn high_fn_array(f fn(a []int) []int) {
+fn high_fn_array(f fn (a []int) []int) {
 }
 
 fn high_fn_multi_return(a int, b fn (c []int, d []string) ([]int, []string)) {
@@ -61,7 +61,7 @@ fn test_high_fn_ret_anons() {
 	assert top_lvl_sqr(param) == param * param
 }
 
-fn high_fn_applier(arg int, func fn(a int)string) string {
+fn high_fn_applier(arg int, func fn (a int) string) string {
 	return func(arg)
 }
 


### PR DESCRIPTION
fix #6833 