### PR TITLE
string: use operator overloading (part 1)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7093,7 +7093,11 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 			} else {
 				receiver_sym := c.table.get_type_symbol(node.receiver.typ)
 				param_sym := c.table.get_type_symbol(node.params[1].typ)
-				if param_sym.kind !in [.struct_, .alias] || receiver_sym.kind !in [.struct_, .alias] {
+				if param_sym.kind == .string && receiver_sym.kind == .string {
+					// bypass check for strings
+					// TODO there must be a better way to handle that
+				} else if param_sym.kind !in [.struct_, .alias]
+					|| receiver_sym.kind !in [.struct_, .alias] {
 					c.error('operator methods are only allowed for struct and type alias',
 						node.pos)
 				} else {


### PR DESCRIPTION
This is a refactor that removes a bit of compiler magic.
Instead of defining "eq", "ne", "lt", "add"... methods on strings, use the existing feature of operator overloading.

This is part 1 of 3 PRs, made not to break the compiler.

Part 2 & 3 can be found on branches [string-op-overload-2](https://github.com/Gladear/v/tree/string-op-overload-2) (#10183) and [string-op-overload-3](https://github.com/Gladear/v/tree/string-op-overload-3) (#10184).