### PR TITLE
string: use operator overloading (part 2)

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -516,6 +516,10 @@ fn (s string) eq(a string) bool {
 	}
 }
 
+fn (s string) == (a string) bool {
+	return s.eq(a)
+}
+
 // ne implements the `s != a` (not equal) operator.
 fn (s string) ne(a string) bool {
 	return !s.eq(a)
@@ -536,6 +540,10 @@ fn (s string) lt(a string) bool {
 	return false
 }
 
+fn (s string) < (a string) bool {
+	return s.lt(a)
+}
+
 // le implements the `s <= a` (less than or equal to) operator.
 fn (s string) le(a string) bool {
 	return s.lt(a) || s.eq(a)
@@ -551,9 +559,8 @@ fn (s string) ge(a string) bool {
 	return !s.lt(a)
 }
 
-// TODO `fn (s string) + (a string)` ? To be consistent with operator overloading syntax.
 // add concatenates string with the string given in `s`.
-pub fn (s string) add(a string) string {
+fn (s string) add(a string) string {
 	new_len := a.len + s.len
 	mut res := string{
 		str: unsafe { malloc(new_len + 1) }
@@ -573,6 +580,10 @@ pub fn (s string) add(a string) string {
 		res.str[new_len] = 0 // V strings are not null terminated, but just in case
 	}
 	return res
+}
+
+fn (s string) + (a string) string {
+	return s.add(a)
 }
 
 // split splits the string to an array by `delim`.

--- a/vlib/math/complex/complex_test.v
+++ b/vlib/math/complex/complex_test.v
@@ -169,11 +169,11 @@ fn test_complex_mulinv() {
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
 	println(c2.str())
 	println(result.str())
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(-0.12, -0.16)
 	result = c1.mulinv()
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-0.2, 0.4)
 	result = c1.mulinv()
@@ -201,17 +201,17 @@ fn test_complex_pow() {
 	mut c2 := cmplx.complex(-24.0, 70.0)
 	mut result := c1.pow(2)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(117, 44)
 	result = c1.pow(3)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-7, -24)
 	result = c1.pow(4)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_root() {
@@ -220,17 +220,17 @@ fn test_complex_root() {
 	mut c2 := cmplx.complex(2.607904, 1.342074)
 	mut result := c1.root(2)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(1.264953, 1.150614)
 	result = c1.root(3)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(1.068059, -0.595482)
 	result = c1.root(4)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_exp() {
@@ -239,17 +239,17 @@ fn test_complex_exp() {
 	mut c2 := cmplx.complex(111.889015, 97.505457)
 	mut result := c1.exp()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(-0.032543, -0.037679)
 	result = c1.exp()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-0.153092, -0.334512)
 	result = c1.exp()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_ln() {
@@ -258,17 +258,17 @@ fn test_complex_ln() {
 	mut c2 := cmplx.complex(2.152033, 0.950547)
 	mut result := c1.ln()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(1.609438, 2.214297)
 	result = c1.ln()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(0.804719, -2.034444)
 	result = c1.ln()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_arg() {
@@ -297,19 +297,19 @@ fn test_complex_log() {
 	mut c2 := cmplx.complex(0.232873, -1.413175)
 	mut result := c1.log(b1)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	b1 = cmplx.complex(3, -1)
 	c2 = cmplx.complex(0.152198, -0.409312)
 	result = c1.log(b1)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	b1 = cmplx.complex(0, 9)
 	c2 = cmplx.complex(-0.298243, 1.197981)
 	result = c1.log(b1)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_cpow() {
@@ -319,19 +319,19 @@ fn test_complex_cpow() {
 	mut c2 := cmplx.complex(11.022341, -0.861785)
 	mut result := c1.cpow(r1)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	r1 = cmplx.complex(-4, -2)
 	c2 = cmplx.complex(0.118303, 0.063148)
 	result = c1.cpow(r1)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	r1 = cmplx.complex(8, -9)
 	c2 = cmplx.complex(-0.000000, 0.000007)
 	result = c1.cpow(r1)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_sin() {
@@ -340,17 +340,17 @@ fn test_complex_sin() {
 	mut c2 := cmplx.complex(-525.794515, 155.536550)
 	mut result := c1.sin()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(-3.853738, -27.016813)
 	result = c1.sin()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-3.165779, -1.959601)
 	result = c1.sin()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_cos() {
@@ -359,17 +359,17 @@ fn test_complex_cos() {
 	mut c2 := cmplx.complex(155.536809, 525.793641)
 	mut result := c1.cos()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(-27.034946, 3.851153)
 	result = c1.cos()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(2.032723, -3.051898)
 	result = c1.cos()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_tan() {
@@ -378,17 +378,17 @@ fn test_complex_tan() {
 	mut c2 := cmplx.complex(-0.000001, 1.000001)
 	mut result := c1.tan()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(0.000187, 0.999356)
 	result = c1.tan()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-0.033813, -1.014794)
 	result = c1.tan()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_cot() {
@@ -397,17 +397,17 @@ fn test_complex_cot() {
 	mut c2 := cmplx.complex(-0.000001, -0.999999)
 	mut result := c1.cot()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(0.000188, -1.000644)
 	result = c1.cot()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-0.032798, 0.984329)
 	result = c1.cot()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_sec() {
@@ -416,17 +416,17 @@ fn test_complex_sec() {
 	mut c2 := cmplx.complex(0.000517, -0.001749)
 	mut result := c1.sec()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(-0.036253, -0.005164)
 	result = c1.sec()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(0.151176, 0.226974)
 	result = c1.sec()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_csc() {
@@ -435,17 +435,17 @@ fn test_complex_csc() {
 	mut c2 := cmplx.complex(-0.001749, -0.000517)
 	mut result := c1.csc()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(-0.005174, 0.036276)
 	result = c1.csc()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-0.228375, 0.141363)
 	result = c1.csc()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_asin() {
@@ -454,17 +454,17 @@ fn test_complex_asin() {
 	mut c2 := cmplx.complex(0.617064, 2.846289)
 	mut result := c1.asin()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(-0.633984, 2.305509)
 	result = c1.asin()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-0.427079, -1.528571)
 	result = c1.asin()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_acos() {
@@ -473,17 +473,17 @@ fn test_complex_acos() {
 	mut c2 := cmplx.complex(0.953732, -2.846289)
 	mut result := c1.acos()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(2.204780, -2.305509)
 	result = c1.acos()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(1.997875, 1.528571)
 	result = c1.acos()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_atan() {
@@ -492,17 +492,17 @@ fn test_complex_atan() {
 	mut c2 := cmplx.complex(1.502727, 0.094441)
 	mut result := c1.atan()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(-1.448307, 0.158997)
 	result = c1.atan()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-1.338973, -0.402359)
 	result = c1.atan()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_acot() {
@@ -511,17 +511,17 @@ fn test_complex_acot() {
 	mut c2 := cmplx.complex(0.068069, -0.094441)
 	mut result := c1.acot()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(-0.122489, -0.158997)
 	result = c1.acot()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-0.231824, 0.402359)
 	result = c1.acot()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_asec() {
@@ -530,17 +530,17 @@ fn test_complex_asec() {
 	mut c2 := cmplx.complex(1.503480, 0.094668)
 	mut result := c1.asec()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(1.689547, 0.160446)
 	result = c1.asec()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(1.757114, -0.396568)
 	result = c1.asec()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_acsc() {
@@ -549,17 +549,17 @@ fn test_complex_acsc() {
 	mut c2 := cmplx.complex(0.067317, -0.094668)
 	mut result := c1.acsc()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(-0.118751, -0.160446)
 	result = c1.acsc()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-0.186318, 0.396568)
 	result = c1.acsc()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_sinh() {
@@ -568,17 +568,17 @@ fn test_complex_sinh() {
 	mut c2 := cmplx.complex(55.941968, 48.754942)
 	mut result := c1.sinh()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(6.548120, -7.619232)
 	result = c1.sinh()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(0.489056, -1.403119)
 	result = c1.sinh()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_cosh() {
@@ -587,17 +587,17 @@ fn test_complex_cosh() {
 	mut c2 := cmplx.complex(55.947047, 48.750515)
 	mut result := c1.cosh()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(-6.580663, 7.581553)
 	result = c1.cosh()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-0.642148, 1.068607)
 	result = c1.cosh()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_tanh() {
@@ -606,17 +606,17 @@ fn test_complex_tanh() {
 	mut c2 := cmplx.complex(0.999988, 0.000090)
 	mut result := c1.tanh()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(-1.000710, 0.004908)
 	result = c1.tanh()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-1.166736, 0.243458)
 	result = c1.tanh()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_coth() {
@@ -625,17 +625,17 @@ fn test_complex_coth() {
 	mut c2 := cmplx.complex(1.000012, -0.000090)
 	mut result := c1.coth()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(-0.999267, -0.004901)
 	result = c1.coth()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-0.821330, -0.171384)
 	result = c1.coth()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_sech() {
@@ -644,17 +644,17 @@ fn test_complex_sech() {
 	mut c2 := cmplx.complex(0.010160, -0.008853)
 	mut result := c1.sech()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(-0.065294, -0.075225)
 	result = c1.sech()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-0.413149, -0.687527)
 	result = c1.sech()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_csch() {
@@ -663,17 +663,17 @@ fn test_complex_csch() {
 	mut c2 := cmplx.complex(0.010159, -0.008854)
 	mut result := c1.csch()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(0.064877, 0.075490)
 	result = c1.csch()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(0.221501, 0.635494)
 	result = c1.csch()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_asinh() {
@@ -682,17 +682,17 @@ fn test_complex_asinh() {
 	mut c2 := cmplx.complex(2.844098, 0.947341)
 	mut result := c1.asinh()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(-2.299914, 0.917617)
 	result = c1.asinh()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-1.469352, -1.063440)
 	result = c1.asinh()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_acosh() {
@@ -701,17 +701,17 @@ fn test_complex_acosh() {
 	mut c2 := cmplx.complex(2.846289, 0.953732)
 	mut result := c1.acosh()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(2.305509, 2.204780)
 	result = c1.acosh()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(1.528571, -1.997875)
 	result = c1.acosh()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_atanh() {
@@ -720,17 +720,17 @@ fn test_complex_atanh() {
 	mut c2 := cmplx.complex(0.067066, 1.476056)
 	mut result := c1.atanh()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(-0.117501, 1.409921)
 	result = c1.atanh()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-0.173287, -1.178097)
 	result = c1.atanh()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_acoth() {
@@ -739,17 +739,17 @@ fn test_complex_acoth() {
 	mut c2 := cmplx.complex(0.067066, -0.094740)
 	mut result := c1.acoth()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(-0.117501, -0.160875)
 	result = c1.acoth()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-0.173287, 0.392699)
 	result = c1.acoth()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 // fn test_complex_asech() {
@@ -758,17 +758,17 @@ fn test_complex_acoth() {
 // 	mut c2 := cmplx.complex(0.094668,-1.503480)
 // 	mut result := c1.asech()
 // 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-// 	assert result.str().eq(c2.str())
+// 	assert result.str() == c2.str()
 // 	c1 = cmplx.complex(-3,4)
 // 	c2 = cmplx.complex(0.160446,-1.689547)
 // 	result = c1.asech()
 // 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-// 	assert result.str().eq(c2.str())
+// 	assert result.str() c2.str()
 // 	c1 = cmplx.complex(-1,-2)
 // 	c2 = cmplx.complex(0.396568,1.757114)
 // 	result = c1.asech()
 // 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-// 	assert result.str().eq(c2.str())
+// 	assert result.str() == c2.str()
 // }
 
 fn test_complex_acsch() {
@@ -777,17 +777,17 @@ fn test_complex_acsch() {
 	mut c2 := cmplx.complex(0.067819, -0.094518)
 	mut result := c1.acsch()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-3, 4)
 	c2 = cmplx.complex(-0.121246, -0.159507)
 	result = c1.acsch()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 	c1 = cmplx.complex(-1, -2)
 	c2 = cmplx.complex(-0.215612, 0.401586)
 	result = c1.acsch()
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert result.str().eq(c2.str())
+	assert result.str() == c2.str()
 }
 
 fn test_complex_re_im() {

--- a/vlib/math/stats/stats_test.v
+++ b/vlib/math/stats/stats_test.v
@@ -44,8 +44,8 @@ fn test_geometric_mean() {
 	data = [f64(-3.0), f64(67.31), f64(4.4), f64(1.89)]
 	o = stats.geometric_mean(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string
-	assert o.str().eq('nan') || o.str().eq('-nan') || o.str().eq('-1.#IND00') || o == f64(0)
-		|| o.str().eq('-nan(ind)') // Because in math it yields a complex number
+	assert o.str() == 'nan' || o.str() == '-nan' || o.str() == '-1.#IND00' || o == f64(0)
+		|| o.str() == '-nan(ind)' // Because in math it yields a complex number
 	data = [f64(12.0), f64(7.88), f64(76.122), f64(54.83)]
 	o = stats.geometric_mean(data)
 	// Some issue with precision comparison in f64 using == operator hence serializing to string

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -290,11 +290,11 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 				mut op1, mut op2 := '', ''
 				if infix_expr.left_type == ast.string_type {
 					if is_reverse {
-						op1 = 'string_gt(a_, b_)'
-						op2 = 'string_lt(a_, b_)'
+						op1 = 'string__lt(b_, a_)'
+						op2 = 'string__lt(a_, b_)'
 					} else {
-						op1 = 'string_lt(a_, b_)'
-						op2 = 'string_gt(a_, b_)'
+						op1 = 'string__lt(a_, b_)'
+						op2 = 'string__lt(b_, a_)'
 					}
 				} else {
 					deref_str := if infix_expr.left_type.is_ptr() { '*' } else { '' }

--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -23,7 +23,7 @@ fn (mut g Gen) gen_sumtype_equality_fn(left ast.Type) string {
 		fn_builder.writeln('\tif (a._typ == $typ) {')
 		name := '_$sym.cname'
 		if sym.kind == .string {
-			fn_builder.writeln('\t\tif (string_ne(*a.$name, *b.$name)) {')
+			fn_builder.writeln('\t\tif (!string__eq(*a.$name, *b.$name)) {')
 		} else if sym.kind == .sum_type && !typ.is_ptr() {
 			eq_fn := g.gen_sumtype_equality_fn(typ)
 			fn_builder.writeln('\t\tif (!${eq_fn}_sumtype_eq(*a.$name, *b.$name)) {')
@@ -73,7 +73,7 @@ fn (mut g Gen) gen_struct_equality_fn(left ast.Type) string {
 	}
 	fn_builder.writeln('static bool ${ptr_typ}_struct_eq($ptr_typ a, $ptr_typ b) {')
 
-	// orverloaded
+	// overloaded
 	if left_sym.has_method('==') {
 		fn_builder.writeln('\treturn ${ptr_typ}__eq(a, b);')
 		fn_builder.writeln('}')
@@ -83,7 +83,7 @@ fn (mut g Gen) gen_struct_equality_fn(left ast.Type) string {
 	for field in info.fields {
 		sym := g.table.get_type_symbol(field.typ)
 		if sym.kind == .string {
-			fn_builder.writeln('\tif (string_ne(a.$field.name, b.$field.name)) {')
+			fn_builder.writeln('\tif (!string__eq(a.$field.name, b.$field.name)) {')
 		} else if sym.kind == .sum_type && !field.typ.is_ptr() {
 			eq_fn := g.gen_sumtype_equality_fn(field.typ)
 			fn_builder.writeln('\tif (!${eq_fn}_sumtype_eq(a.$field.name, b.$field.name)) {')
@@ -128,7 +128,7 @@ fn (mut g Gen) gen_alias_equality_fn(left ast.Type) string {
 	fn_builder.writeln('static bool ${ptr_typ}_alias_eq($ptr_typ a, $ptr_typ b) {')
 	sym := g.table.get_type_symbol(info.parent_type)
 	if sym.kind == .string {
-		fn_builder.writeln('\tif (string_ne(a, b)) {')
+		fn_builder.writeln('\tif (!string__eq(a, b)) {')
 	} else if sym.kind == .sum_type && !left.is_ptr() {
 		eq_fn := g.gen_sumtype_equality_fn(info.parent_type)
 		fn_builder.writeln('\tif (!${eq_fn}_sumtype_eq(a, b)) {')
@@ -176,7 +176,7 @@ fn (mut g Gen) gen_array_equality_fn(left ast.Type) string {
 	fn_builder.writeln('\tfor (int i = 0; i < a.len; ++i) {')
 	// compare every pair of elements of the two arrays
 	if elem_sym.kind == .string {
-		fn_builder.writeln('\t\tif (string_ne(*(($ptr_elem_typ*)((byte*)a.data+(i*a.element_size))), *(($ptr_elem_typ*)((byte*)b.data+(i*b.element_size))))) {')
+		fn_builder.writeln('\t\tif (!string__eq(*(($ptr_elem_typ*)((byte*)a.data+(i*a.element_size))), *(($ptr_elem_typ*)((byte*)b.data+(i*b.element_size))))) {')
 	} else if elem_sym.kind == .sum_type && !elem_typ.is_ptr() {
 		eq_fn := g.gen_sumtype_equality_fn(elem_typ)
 		fn_builder.writeln('\t\tif (!${eq_fn}_sumtype_eq((($ptr_elem_typ*)a.data)[i], (($ptr_elem_typ*)b.data)[i])) {')
@@ -226,7 +226,7 @@ fn (mut g Gen) gen_fixed_array_equality_fn(left ast.Type) string {
 	fn_builder.writeln('\tfor (int i = 0; i < $size; ++i) {')
 	// compare every pair of elements of the two fixed arrays
 	if elem_sym.kind == .string {
-		fn_builder.writeln('\t\tif (string_ne(a[i], b[i])) {')
+		fn_builder.writeln('\t\tif (!string__eq(a[i], b[i])) {')
 	} else if elem_sym.kind == .sum_type && !elem_typ.is_ptr() {
 		eq_fn := g.gen_sumtype_equality_fn(elem_typ)
 		fn_builder.writeln('\t\tif (!${eq_fn}_sumtype_eq(a[i], b[i])) {')

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -106,11 +106,11 @@ fn (mut g Gen) gen_str_default(sym ast.TypeSymbol, styp string, str_fn_name stri
 	g.type_definitions.writeln('string ${str_fn_name}($styp it); // auto')
 	g.auto_str_funcs.writeln('string ${str_fn_name}($styp it) {')
 	if convertor == 'bool' {
-		g.auto_str_funcs.writeln('\tstring tmp1 = string_add(_SLIT("${styp}("), ($convertor)it ? _SLIT("true") : _SLIT("false"));')
+		g.auto_str_funcs.writeln('\tstring tmp1 = string__plus(_SLIT("${styp}("), ($convertor)it ? _SLIT("true") : _SLIT("false"));')
 	} else {
-		g.auto_str_funcs.writeln('\tstring tmp1 = string_add(_SLIT("${styp}("), tos3(${typename_}_str(($convertor)it).str));')
+		g.auto_str_funcs.writeln('\tstring tmp1 = string__plus(_SLIT("${styp}("), tos3(${typename_}_str(($convertor)it).str));')
 	}
-	g.auto_str_funcs.writeln('\tstring tmp2 = string_add(tmp1, _SLIT(")"));')
+	g.auto_str_funcs.writeln('\tstring tmp2 = string__plus(tmp1, _SLIT(")"));')
 	g.auto_str_funcs.writeln('\tstring_free(&tmp1);')
 	g.auto_str_funcs.writeln('\treturn tmp2;')
 	g.auto_str_funcs.writeln('}')
@@ -234,13 +234,13 @@ fn (mut g Gen) gen_str_for_alias(info ast.Alias, styp string, str_fn_name string
 	g.auto_str_funcs.writeln('static string indent_${str_fn_name}($styp it, int indent_count) {')
 	g.auto_str_funcs.writeln('\tstring indents = _SLIT("");')
 	g.auto_str_funcs.writeln('\tfor (int i = 0; i < indent_count; ++i) {')
-	g.auto_str_funcs.writeln('\t\tindents = string_add(indents, _SLIT("    "));')
+	g.auto_str_funcs.writeln('\t\tindents = string__plus(indents, _SLIT("    "));')
 	g.auto_str_funcs.writeln('\t}')
 
 	g.auto_str_funcs.writeln('\treturn str_intp(3, _MOV((StrIntpData[]){
 		{_SLIT0, $c.si_s_code, {.d_s = indents }},
 		{_SLIT("${clean_type_v_type_name}("), $c.si_s_code, {.d_s = ${parent_str_fn_name}(it) }},
-		{_SLIT(")"), 0, {.d_c = 0 }} 
+		{_SLIT(")"), 0, {.d_c = 0 }}
 	}));\n')
 
 	// g.auto_str_funcs.writeln('\treturn _STR("%.*s\\000${clean_type_v_type_name}(%.*s\\000)", 3, indents, ${parent_str_fn_name}(it));')
@@ -317,9 +317,9 @@ fn (mut g Gen) gen_str_for_enum(info ast.Enum, styp string, str_fn_name string) 
 		g.auto_str_funcs.writeln('\tstring ret = _SLIT("$clean_name{");')
 		g.auto_str_funcs.writeln('\tint first = 1;')
 		for i, val in info.vals {
-			g.auto_str_funcs.writeln('\tif (it & (1 << $i)) {if (!first) {ret = string_add(ret, _SLIT(" | "));} ret = string_add(ret, _SLIT(".$val")); first = 0;}')
+			g.auto_str_funcs.writeln('\tif (it & (1 << $i)) {if (!first) {ret = string__plus(ret, _SLIT(" | "));} ret = string__plus(ret, _SLIT(".$val")); first = 0;}')
 		}
-		g.auto_str_funcs.writeln('\tret = string_add(ret, _SLIT("}"));')
+		g.auto_str_funcs.writeln('\tret = string__plus(ret, _SLIT("}"));')
 		g.auto_str_funcs.writeln('\treturn ret;')
 	} else {
 		g.auto_str_funcs.writeln('\tswitch(it) {')

--- a/vlib/v/gen/c/auto_str_struct.v
+++ b/vlib/v/gen/c/auto_str_struct.v
@@ -84,7 +84,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name stri
 	// generate ident / indent length = 4 spaces
 	g.auto_str_funcs.writeln('\tstring indents = _SLIT("");')
 	g.auto_str_funcs.writeln('\tfor (int i = 0; i < indent_count; ++i) {')
-	g.auto_str_funcs.writeln('\t\tindents = string_add(indents, _SLIT("    "));')
+	g.auto_str_funcs.writeln('\t\tindents = string__plus(indents, _SLIT("    "));')
 	g.auto_str_funcs.writeln('\t}')
 	if info.fields.len == 0 {
 		g.auto_str_funcs.write_string('\treturn _SLIT("$clean_struct_v_type_name{}");')
@@ -290,7 +290,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name stri
 	// generate ident / indent length = 4 spaces
 	g.auto_str_funcs.writeln('\tstring indents = _SLIT("");')
 	g.auto_str_funcs.writeln('\tfor (int i = 0; i < indent_count; ++i) {')
-	g.auto_str_funcs.writeln('\t\tindents = string_add(indents, _SLIT("    "));')
+	g.auto_str_funcs.writeln('\t\tindents = string__plus(indents, _SLIT("    "));')
 	g.auto_str_funcs.writeln('\t}')
 	if info.fields.len == 0 {
 		g.auto_str_funcs.write_string('\treturn _SLIT("$clean_struct_v_type_name{}");')

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -156,7 +156,7 @@ fn (mut g Gen) comptime_call(node ast.ComptimeCall) {
 			if j > 0 {
 				g.write(' else ')
 			}
-			g.write('if (string_eq($node.method_name, _SLIT("$method.name"))) ')
+			g.write('if (string__eq($node.method_name, _SLIT("$method.name"))) ')
 		}
 		g.write('${util.no_dots(node.sym.name)}_${method.name}($amp ')
 		g.expr(node.left)

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -225,7 +225,7 @@ fn (mut g Gen) decode_array(value_type ast.Type) string {
 	noscan := g.check_noscan(value_type)
 	return '
 	if(root && !cJSON_IsArray(root) && !cJSON_IsNull(root)) {
-		return (Option_Array_$styp){.state = 2, .err = v_error(string_add(_SLIT("Json element is not an array: "), tos2((byteptr)cJSON_PrintUnformatted(root)))), .data = {0}};
+		return (Option_Array_$styp){.state = 2, .err = v_error(string__plus(_SLIT("Json element is not an array: "), tos2((byteptr)cJSON_PrintUnformatted(root)))), .data = {0}};
 	}
 	res = __new_array${noscan}(0, 0, sizeof($styp));
 	const cJSON *jsval = NULL;
@@ -269,7 +269,7 @@ fn (mut g Gen) decode_map(key_type ast.Type, value_type ast.Type) string {
 	}
 	return '
 	if(!cJSON_IsObject(root) && !cJSON_IsNull(root)) {
-		return (Option_Map_${styp}_$styp_v){ .state = 2, .err = v_error( string_add(_SLIT("Json element is not an object: "), tos2((byteptr)cJSON_PrintUnformatted(root)))), .data = {0}};
+		return (Option_Map_${styp}_$styp_v){ .state = 2, .err = v_error(string__plus(_SLIT("Json element is not an object: "), tos2((byteptr)cJSON_PrintUnformatted(root)))), .data = {0}};
 	}
 	res = new_map(sizeof($styp), sizeof($styp_v), $hash_fn, $key_eq_fn, $clone_fn, $free_fn);
 	cJSON *jsval = NULL;

--- a/vlib/v/gen/c/sql.v
+++ b/vlib/v/gen/c/sql.v
@@ -737,7 +737,7 @@ fn (mut g Gen) mysql_bind(val string, typ ast.Type) {
 			g.sql_buf.write_string(')')
 		}
 	} else {
-		g.sql_buf.write_string('string_add(_SLIT("\'"), string_add(((string) $val), _SLIT("\'")))')
+		g.sql_buf.write_string('string__plus(_SLIT("\'"), string__plus(((string) $val), _SLIT("\'")))')
 	}
 	g.sql_buf.writeln(');')
 }
@@ -1031,7 +1031,7 @@ fn (mut g Gen) psql_select_expr(node ast.SqlExpr, sub bool, line string, typ Sql
 			} else if field.typ == ast.i8_type {
 				g.writeln('${tmp}.$field.name = (i8) string_${name}($fld);')
 			} else if field.typ == ast.bool_type {
-				g.writeln('${tmp}.$field.name = string_eq($fld, _SLIT("0")) ? false : true;')
+				g.writeln('${tmp}.$field.name = string__eq($fld, _SLIT("0")) ? false : true;')
 			} else {
 				g.writeln('${tmp}.$field.name = string_${name}($fld);')
 			}
@@ -1126,7 +1126,7 @@ fn (mut g Gen) psql_bind(val string, typ ast.Type) {
 			g.sql_buf.write_string(')')
 		}
 	} else {
-		g.sql_buf.write_string('string_add(_SLIT("\'"), string_add(((string) $val), _SLIT("\'")))')
+		g.sql_buf.write_string('string__plus(_SLIT("\'"), string__plus(((string) $val), _SLIT("\'")))')
 	}
 	g.sql_buf.writeln(');')
 }

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -373,25 +373,16 @@ pub fn skip_bom(file_content string) string {
 }
 
 pub fn replace_op(s string) string {
-	if s.len == 1 {
-		last_char := s[s.len - 1]
-		suffix := match last_char {
-			`+` { '_plus' }
-			`-` { '_minus' }
-			`*` { '_mult' }
-			`/` { '_div' }
-			`%` { '_mod' }
-			`<` { '_lt' }
-			`>` { '_gt' }
-			else { '' }
-		}
-		return s[..s.len - 1] + suffix
-	} else {
-		suffix := match s {
-			'==' { '_eq' }
-			else { '' }
-		}
-		return s[..s.len - 2] + suffix
+	return match s {
+		'+' { '_plus' }
+		'-' { '_minus' }
+		'*' { '_mult' }
+		'/' { '_div' }
+		'%' { '_mod' }
+		'<' { '_lt' }
+		'>' { '_gt' }
+		'==' { '_eq' }
+		else { '' }
 	}
 }
 


### PR DESCRIPTION
This is a refactor that removes a bit of compiler magic.
Instead of defining "eq", "ne", "lt", "add"... methods on strings, use the existing feature of operator overloading.

This is part 2 of 3 PRs, made not to break the compiler.

Part 1 & 3 can be found on branches [string-op-overload-1](https://github.com/Gladear/v/tree/string-op-overload-1) (#10182) and [string-op-overload-3](https://github.com/Gladear/v/tree/string-op-overload-3) (#10184).

Tests won't pass until #10182 is merged.