### PR TITLE
15:27 UTC: fix vweb

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -318,6 +318,9 @@ pub fn run<T>(global_app &T, port int) {
 	for {
 		// Create a new app object for each connection, copy global data like db connections
 		mut request_app := &T{}
+		unsafe {
+			request_app = global_app
+		}
 		$if T is DbInterface {
 			request_app.db = global_app.db
 		} $else {


### PR DESCRIPTION
Copy entrire global_app instance so requests can access any other app{} members.

If the struct that encloses the web app (i.e.: has vweb.Context embedded) has any other members such as objects initialized at startup and those object need to be shared among requests, with this fix now is possible.

I use it for a process pub/sub manager that needs to be held by the app, but modified by any request.


