### PR TITLE
cgen: fix generic struct to string

### DIFF
--- a/vlib/v/gen/c/auto_str_struct.v
+++ b/vlib/v/gen/c/auto_str_struct.v
@@ -94,12 +94,12 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name stri
 
 		for i, field in info.fields {
 			mut ptr_amp := if field.typ.is_ptr() { '&' } else { '' }
-			base_fmt := g.type_to_fmt1(field.typ)
+			base_fmt := g.type_to_fmt1(g.unwrap_generic(field.typ))
 
 			// manage prefix and quote symbol for the filed
 			mut quote_str := ''
 			mut prefix := ''
-			sym := g.table.get_type_symbol(field.typ)
+			sym := g.table.get_type_symbol(g.unwrap_generic(field.typ))
 			if sym.kind == .string {
 				quote_str = "'"
 			} else if field.typ in ast.charptr_types {

--- a/vlib/v/tests/generics_struct_to_string_test.v
+++ b/vlib/v/tests/generics_struct_to_string_test.v
@@ -1,0 +1,33 @@
+struct Info<T> {
+	data T
+}
+
+fn get_info<T>(res Info<T>) string {
+	return '$res'
+}
+
+fn test_generic_struct_to_string() {
+	mut ret := get_info(Info<bool>{true})
+	println(ret)
+	assert ret.contains('data: true')
+
+	ret = get_info(Info<int>{123})
+	println(ret)
+	assert ret.contains('data: 123')
+
+	ret = get_info(Info<f32>{f32(2.2)})
+	println(ret)
+	assert ret.contains('data: 2.2')
+
+	ret = get_info(Info<f64>{2.2})
+	println(ret)
+	assert ret.contains('data: 2.2')
+
+	ret = get_info(Info<string>{'aaa'})
+	println(ret)
+	assert ret.contains("data: 'aaa'")
+
+	ret = get_info(Info<u64>{u64(234)})
+	println(ret)
+	assert ret.contains('data: 234')
+}


### PR DESCRIPTION
This PR fix generic struct to string.

- Fix generic struct to string.
- Add test.

```vlang
struct Info<T> {
	data T
}

fn get_info<T>(res Info<T>) string {
	return '$res'
}

fn main() {
	mut ret := get_info(Info<bool>{true})
	println(ret)
	assert ret.contains('data: true')

	ret = get_info(Info<int>{123})
	println(ret)
	assert ret.contains('data: 123')

	ret = get_info(Info<f32>{f32(2.2)})
	println(ret)
	assert ret.contains('data: 2.2')

	ret = get_info(Info<f64>{2.2})
	println(ret)
	assert ret.contains('data: 2.2')

	ret = get_info(Info<string>{'aaa'})
	println(ret)
	assert ret.contains("data: 'aaa'")

	ret = get_info(Info<u64>{u64(234)})
	println(ret)
	assert ret.contains('data: 234')
}

PS D:\Test\v\tt1> v run .
Info<bool>{
    data: true
}
Info<int>{
    data: 123
}
Info<f32>{
    data: 2.2
}
Info<f64>{
    data: 2.2
}
Info<string>{
    data: 'aaa'
}
Info<u64>{
    data: 234
}
```