### PR TITLE
fmt: don't break indexing in string interpolation.

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -180,7 +180,7 @@ pub fn (lit &StringInterLiteral) get_fspec_braces(i int) (string, bool) {
 					} else if sub_expr.left is CallExpr {
 						sub_expr = sub_expr.left
 						continue
-					} else if sub_expr.left is CastExpr {
+					} else if sub_expr.left is CastExpr || sub_expr.left is IndexExpr {
 						needs_braces = true
 					}
 					break

--- a/vlib/v/fmt/tests/string_interpolation_keep.vv
+++ b/vlib/v/fmt/tests/string_interpolation_keep.vv
@@ -7,9 +7,11 @@ fn main() {
 	b := 'xyz'
 	e := 'a: $a b: $b i: $i'
 	d := 'a: ${a:5s} b: ${b:-5s} i: ${i:20d}'
+	f := 'a byte string'.bytes()
 	println('a: $a $b xxx')
 	eprintln('e: $e')
 	_ = ' ${foo.method(bar).str()} '
 	println('(${some_struct.@type}, $some_struct.y)')
 	_ := 'CastExpr ${int(d.e).str()}'
+	println('${f[0..4].bytestr()}')
 }


### PR DESCRIPTION
This prevents `v fmt` from removing braces around an expression
consisting of both an index expression and a call expression, which
would change the meaning of the expression.

Fixes #10192.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
