### PR TITLE
cmd: improve v show

### DIFF
--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -582,22 +582,11 @@ Homepage: $module_meta_info.url
 Downloads: $module_meta_info.nr_downloads
 Installed: False
 --------
-				')
+')
 			continue
 		}
 		path := os.join_path(os.vmodules_dir(), module_name)
 		mod := vmod.from_file(os.join_path(path, 'v.mod')) or { continue }
-		// console_output := [
-		// 	'Name: $mod.name',
-		// 	'Version: $mod.version',
-		// 	'Description: $mod.description',
-		// 	'Homepage: $mod.repo_url',
-		// 	'Author: $mod.author',
-		// 	'License: $mod.license',
-		// 	'Location: $path',
-		// 	'Requires: ${mod.dependencies.join(', ')}',
-		// ].join('\n')
-		// println('${console_output}\n--------\n')
 		print('Name: $mod.name
 Version: $mod.version
 Description: $mod.description

--- a/cmd/v/help/default.txt
+++ b/cmd/v/help/default.txt
@@ -42,7 +42,7 @@ V supports the following commands:
    upgrade           Upgrade all the outdated modules.
    list              List all installed modules.
    outdated          List installed modules that need updates.
-   show              Display informations about a module on vpm
+   show              Display information about a module on vpm
 
 * Others:
    doctor            Display some useful info about your system to help reporting bugs.

--- a/cmd/v/help/default.txt
+++ b/cmd/v/help/default.txt
@@ -8,8 +8,8 @@ Examples:
    v run hello.v             Same as above but also run the produced executable immediately after compilation.
    v -cg run hello.v         Same as above, but make debugging easier (in case your program crashes).
    v -o h.c hello.v          Translate `hello.v` to `h.c`. Do not compile further.
-   
-   v watch hello.v           Re-does the same compilation, when a source code change is detected. 
+
+   v watch hello.v           Re-does the same compilation, when a source code change is detected.
                              The program is only compiled, not run.
    v watch run hello.v       Re-runs the same `hello.v` file, when a source code change is detected.
 
@@ -41,7 +41,8 @@ V supports the following commands:
    update            Update an installed module from VPM.
    upgrade           Upgrade all the outdated modules.
    list              List all installed modules.
-   outdated          Show installed modules that need updates.
+   outdated          List installed modules that need updates.
+   show              Display informations about a module on vpm
 
 * Others:
    doctor            Display some useful info about your system to help reporting bugs.

--- a/cmd/v/help/vpm.txt
+++ b/cmd/v/help/vpm.txt
@@ -3,5 +3,6 @@ Usage:
   b) v update [MODULE...]
   c) v remove [MODULE...]
   d) v search KEYWORD[...]
+  e) v show [MODULE...]
 
   You can also pass -h or --help after each vpm command from the above, to see more details about it.

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -99,7 +99,7 @@ fn main() {
 			eprintln('Translating C to V will be available in V 0.3')
 			exit(1)
 		}
-		'search', 'install', 'update', 'upgrade', 'outdated', 'list', 'remove' {
+		'install', 'list', 'outdated', 'remove', 'search', 'show', 'update', 'upgrade' {
 			util.launch_tool(prefs.is_verbose, 'vpm', os.args[1..])
 			return
 		}


### PR DESCRIPTION
- remove unecessary spaces
- add to help
- allow to be called directly from v (calling it from the vpm binary directly was
necessary, aka cmd/tools/vpm show <module>)