### PR TITLE
checker/ci: workaround bug causing errors with usecache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,8 +280,11 @@ jobs:
           UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./v2 -o v.c cmd/v
       - name: Build V using V
         run: ./v -o v2 cmd/v && ./v2 -o v3 cmd/v
-      - name: v self with -usecache
-        run: ./v -o v2 -usecache cmd/v
+      - name: v self compilation with -usecache
+        run: |
+          ./v -o v2 -usecache cmd/v
+          ./v2 -o v3 -usecache cmd/v
+          ./v3 -usecache examples/tetris/tetris.v
       - name: Test symlink
         run: ./v symlink
       #    - name: Set up pg database
@@ -368,10 +371,11 @@ jobs:
         run: ./v -freestanding run vlib/os/bare/bare_example_linux.v
       - name: v self compilation
         run: ./v -o v2 cmd/v && ./v2 -o v3 cmd/v && ./v3 -o v4 cmd/v
-      - name: -usecache
+      - name: v self compilation with -usecache
         run: |
           ./v -o v2 -usecache cmd/v
-          ./v -usecache examples/tetris/tetris.v
+          ./v2 -o v3 -usecache cmd/v
+          ./v3 -usecache examples/tetris/tetris.v
       - name: Verify `v test` works
         run: |
           ./v cmd/tools/test_if_v_test_system_works.v
@@ -456,8 +460,11 @@ jobs:
           ASAN_OPTIONS=detect_leaks=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./v5 -o v.c cmd/v
       - name: v self compilation
         run: ./v -o v2 cmd/v && ./v2 -o v3 cmd/v && ./v3 -o v4 cmd/v
-      - name: v self with -usecache
-        run: ./v -o v2 -usecache cmd/v
+      - name: v self compilation with -usecache
+        run: |
+          ./v -o v2 -usecache cmd/v
+          ./v2 -o v3 -usecache cmd/v
+          ./v3 -usecache examples/tetris/tetris.v
       - name: Verify `v test` works
         run: |
           ./v cmd/tools/test_if_v_test_system_works.v

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1015,7 +1015,7 @@ pub fn (mut c Checker) infix_expr(mut infix_expr ast.InfixExpr) ast.Type {
 		}
 	}
 	mut return_type := left_type
-	if !c.pref.use_cache && infix_expr.op != .key_is {
+	if infix_expr.op != .key_is {
 		match mut infix_expr.left {
 			ast.Ident, ast.SelectorExpr {
 				if infix_expr.left.is_mut {
@@ -1685,7 +1685,10 @@ fn (mut c Checker) check_map_and_filter(is_map bool, elem_typ ast.Type, call_exp
 						return
 					}
 				}
-				if !is_map && arg_expr.info.typ != ast.bool_type {
+				// NOTE: bug accessing typ field on sumtype variant (not cast properly).
+				// leaving this here as the resulting issue is notoriously hard to debug.
+				// if !is_map && arg_expr.info.typ != ast.bool_type {
+				if !is_map && arg_expr.var_info().typ != ast.bool_type {
 					c.error('type mismatch, should be bool', arg_expr.pos)
 				}
 			}
@@ -5122,7 +5125,7 @@ pub fn (mut c Checker) ident(mut ident ast.Ident) ast.Type {
 		return info.typ
 	} else if ident.kind == .unresolved {
 		// first use
-		if !c.pref.use_cache && ident.tok_kind == .assign && ident.is_mut {
+		if ident.tok_kind == .assign && ident.is_mut {
 			c.error('`mut` not allowed with `=` (use `:=` to declare a variable)', ident.pos)
 		}
 		if obj := ident.scope.find(ident.name) {


### PR DESCRIPTION
checker/ci: workaround bug causing errors with use_cache (sumtype field access) & addmore usecache tests

This fixes self compilation with usecache 
The underlying issue with accessing same name sumtype variant fields and not casting properly still exists. I have left a note in checker since the resulting errors caused by this are extremely hard to debug.