### PR TITLE
checker: fix multi types generic struct init (fix #10185)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3238,7 +3238,7 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 		}
 		return
 	}
-	//
+
 	is_decl := assign_stmt.op == .decl_assign
 	for i, left in assign_stmt.left {
 		if left is ast.CallExpr {
@@ -3280,6 +3280,13 @@ pub fn (mut c Checker) assign_stmt(mut assign_stmt ast.AssignStmt) {
 		right := if i < assign_stmt.right.len { assign_stmt.right[i] } else { assign_stmt.right[0] }
 		mut right_type := assign_stmt.right_types[i]
 		if is_decl {
+			// check generic struct init and return unwrap generic struct type
+			if right is ast.StructInit {
+				if right.typ.has_flag(.generic) {
+					c.expr(right)
+					right_type = right.typ
+				}
+			}
 			if right.is_auto_deref_var() {
 				left_type = c.table.mktyp(right_type.deref())
 			} else {

--- a/vlib/v/tests/generics_multi_types_struct_init_test.v
+++ b/vlib/v/tests/generics_multi_types_struct_init_test.v
@@ -1,0 +1,41 @@
+struct Response<T> {
+	result T
+}
+
+pub fn send<T>(res T) string {
+	msg := Response<T>{
+		result: res
+	}
+	return '$msg'
+}
+
+struct Foo {}
+
+struct Bar {}
+
+fn test_generics_multi_types_struct_init() {
+	mut ret := send(Foo{})
+	println(ret)
+	assert ret.contains('Response<Foo>{')
+	assert ret.contains('result: Foo{}')
+
+	ret = send(Bar{})
+	println(ret)
+	assert ret.contains('Response<Bar>{')
+	assert ret.contains('result: Bar{}')
+
+	ret = send(123)
+	println(ret)
+	assert ret.contains('Response<int>{')
+	assert ret.contains('result: 123')
+
+	ret = send('abc')
+	println(ret)
+	assert ret.contains('Response<string>{')
+	assert ret.contains("result: 'abc'")
+
+	ret = send(2.22)
+	println(ret)
+	assert ret.contains('Response<f64>{')
+	assert ret.contains('result: 2.22')
+}


### PR DESCRIPTION
This PR fix multi types generic struct init (fix #10185).

- Fix multi types generic struct init.
- Add test.

```vlang
struct Response<T> {
	result T
}

pub fn send<T>(res T) string {
	msg := Response<T>{
		result: res
	}
	return '$msg'
}

struct Foo {}

struct Bar {}

fn main() {
	mut ret := send(Foo{})
	println(ret)
	assert ret.contains('Response<Foo>{')
	assert ret.contains('result: Foo{}')

	ret = send(Bar{})
	println(ret)
	assert ret.contains('Response<Bar>{')
	assert ret.contains('result: Bar{}')

	ret = send(123)
	println(ret)
	assert ret.contains('Response<int>{')
	assert ret.contains('result: 123')

	ret = send('abc')
	println(ret)
	assert ret.contains('Response<string>{')
	assert ret.contains("result: 'abc'")

	ret = send(2.22)
	println(ret)
	assert ret.contains('Response<f64>{')
	assert ret.contains('result: 2.22')
}

PS D:\Test\v\tt1> v run .
Response<Foo>{
    result: Foo{}
}
Response<Bar>{
    result: Bar{}
}
Response<int>{
    result: 123
}
Response<string>{
    result: 'abc'
}
Response<f64>{
    result: 2.22
}
```