### PR TITLE
checker: check index_expr or_expr types mismatch (fix #10190)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6521,6 +6521,7 @@ pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) ast.Type {
 		}
 	}
 	c.stmts(node.or_expr.stmts)
+	c.check_expr_opt_call(node, typ)
 	return typ
 }
 

--- a/vlib/v/checker/tests/or_expr_types_mismatch.out
+++ b/vlib/v/checker/tests/or_expr_types_mismatch.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/or_expr_types_mismatch.vv:3:19: error: wrong return type `none` in the `or {}` block, expected `string`
+    1 | fn get_map() ?string {
+    2 |     m := map{1: 'a', 2: 'b'}
+    3 |     return m[1] or { none }
+      |                      ~~~~
+    4 | }
+    5 |
+vlib/v/checker/tests/or_expr_types_mismatch.vv:8:19: error: wrong return type `none` in the `or {}` block, expected `int`
+    6 | fn get_array() ?int {
+    7 |     a := [1, 2, 3]
+    8 |     return a[4] or { none }
+      |                      ~~~~
+    9 | }
+   10 |

--- a/vlib/v/checker/tests/or_expr_types_mismatch.vv
+++ b/vlib/v/checker/tests/or_expr_types_mismatch.vv
@@ -1,0 +1,17 @@
+fn get_map() ?string {
+	m := map{1: 'a', 2: 'b'}
+	return m[1] or { none }
+}
+
+fn get_array() ?int {
+	a := [1, 2, 3]
+	return a[4] or { none }
+}
+
+fn main() {
+	map_result := get_map() or { return }
+	println(map_result)
+
+	array_result := get_array() or { return }
+	println(array_result)
+}


### PR DESCRIPTION
This PR check index_expr or_expr types mismatch (fix #10190).

- Check index_expr or_expr types mismatch.
- Add test.

```vlang
import vweb

struct App {
	vweb.Context
}

fn (mut app App) index() vweb.Result {
	name := get_data(app, 'name') or { 'John' }

	return app.html('<h1>Hello, $name</h1>')
}

fn get_data<T>(app T, key string) ?string {
	return app.query[key] or { none }
}

fn main() {
	vweb.run(&App{}, 8000)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:14:29: error: wrong return type `none` in the `or {}` block, expected `string`
   12 |
   13 | fn get_data<T>(app T, key string) ?string {
   14 |     return app.query[key] or { none }
      |                                ~~~~
   15 | }
   16 |
```

```vlang
fn get_map() ?string {
	m := map{1: 'a', 2: 'b'}
	return m[1] or { none }
}

fn get_array() ?int {
	a := [1, 2, 3]
	return a[4] or { none }
}

fn main() {
	map_result := get_map() or { return }
	println(map_result)

	array_result := get_array() or { return }
	println(array_result)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:3:19: error: wrong return type `none` in the `or {}` block, expected `string`
    1 | fn get_map() ?string {
    2 |     m := map{1: 'a', 2: 'b'}
    3 |     return m[1] or { none }
      |                      ~~~~
    4 | }
    5 |
.\tt1.v:8:19: error: wrong return type `none` in the `or {}` block, expected `int`
    6 | fn get_array() ?int {
    7 |     a := [1, 2, 3]
    8 |     return a[4] or { none }
      |                      ~~~~
    9 | }
   10 |
```