### PR TITLE
v: support for `$if threads {}`, depending on whether `go ` was used in a program or its modules

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -29,6 +29,8 @@ pub mut:
 	panic_userdata   voidptr        = voidptr(0) // can be used to pass arbitrary data to panic_handler;
 	panic_npanics    int
 	cur_fn           &FnDecl = 0 // previously stored in Checker.cur_fn and Gen.cur_fn
+	gostmts          int     // how many `go` statements there were in the parsed files.
+	// When table.gostmts > 0, __VTHREADS__ is defined, which can be checked with `$if threads {`
 }
 
 [unsafe]

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -28,7 +28,7 @@ const (
 		'big_endian',
 	]
 	valid_comp_if_other         = ['js', 'debug', 'prod', 'test', 'glibc', 'prealloc',
-		'no_bounds_checking', 'freestanding']
+		'no_bounds_checking', 'freestanding', 'threads']
 	array_builtin_methods       = ['filter', 'clone', 'repeat', 'reverse', 'map', 'slice', 'sort',
 		'contains', 'index', 'wait', 'any', 'all', 'first', 'last', 'pop']
 	vroot_is_deprecated_message = '@VROOT is deprecated, use @VMODROOT or @VEXEROOT instead'
@@ -6157,6 +6157,7 @@ fn (mut c Checker) comp_if_branch(cond ast.Expr, pos token.Position) bool {
 					'prod' { return !c.pref.is_prod }
 					'test' { return !c.pref.is_test }
 					'glibc' { return false } // TODO
+					'threads' { return c.table.gostmts == 0 }
 					'prealloc' { return !c.pref.prealloc }
 					'no_bounds_checking' { return cond.name !in c.pref.compile_defines_all }
 					'freestanding' { return !c.pref.is_bare || c.pref.output_cross_c }

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -441,6 +441,9 @@ pub fn (mut g Gen) init() {
 		}
 		g.comptime_defines.writeln('')
 	}
+	if g.table.gostmts > 0 {
+		g.comptime_defines.writeln('#define __VTHREADS__ (1)')
+	}
 	if g.pref.gc_mode in [.boehm_full, .boehm_incr, .boehm_full_opt, .boehm_incr_opt, .boehm,
 		.boehm_leak,
 	] {

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -606,6 +606,9 @@ fn (mut g Gen) comp_if_to_ifdef(name string, is_comptime_optional bool) ?string 
 			return '__cplusplus'
 		}
 		// other:
+		'threads' {
+			return '__VTHREADS__'
+		}
 		'gcboehm' {
 			return '_VGCBOEHM'
 		}

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -520,6 +520,7 @@ fn (mut p Parser) go_expr() ast.GoExpr {
 	}
 	pos := spos.extend(p.prev_tok.position())
 	p.register_auto_import('sync.threads')
+	p.table.gostmts++
 	return ast.GoExpr{
 		call_expr: call_expr
 		pos: pos

--- a/vlib/v/tests/comptime_if_threads_no_test.v
+++ b/vlib/v/tests/comptime_if_threads_no_test.v
@@ -1,0 +1,11 @@
+fn abc() {
+	// go fn() {}()
+}
+
+fn test_if_threads() {
+	$if threads {
+		assert false
+	} $else {
+		assert true
+	}
+}

--- a/vlib/v/tests/comptime_if_threads_yes_test.v
+++ b/vlib/v/tests/comptime_if_threads_yes_test.v
@@ -1,0 +1,11 @@
+fn abc() {
+	go fn () {}()
+}
+
+fn test_if_threads() {
+	$if threads {
+		assert true
+	} $else {
+		assert false
+	}
+}


### PR DESCRIPTION
This PR allows the following program:
```v
fn function_that_uses_threads() {  go fn () {}() }

fn main() {
        $if threads {
                println('program uses threads')
        } $else {
                println('program is single threaded')
        }
}
```
i.e. there is a comptime way to write code that can have different behavior if the compiled program is a single threaded one (as far as V is concerned).

The goal is relaxing the need for locking in vlib modules for single threaded programs.