### PR TITLE
fmt: minor optimization in call_expr() and node_str()

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -354,7 +354,7 @@ pub fn (mut f Fmt) node_str(node ast.Node) string {
 		ast.Expr { f.expr(node) }
 		else { panic('´f.node_str()´ is not implemented for ${node}.') }
 	}
-	str := f.out.after(pos).trim_space()
+	str := f.out.after(pos)
 	f.out.go_back_to(pos)
 	f.empty_line = was_empty_line
 	f.line_len = prev_line_len
@@ -1616,9 +1616,6 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 		} else {
 			mut name := f.short_module(node.name)
 			f.mark_import_as_used(name)
-			if node.name in f.mod2alias {
-				name = f.mod2alias[node.name]
-			}
 			f.write('$name')
 		}
 	}
@@ -2116,7 +2113,7 @@ fn (mut f Fmt) match_branch(branch ast.MatchBranch, single_line bool) {
 		// normal branch
 		f.is_mbranch_expr = true
 		for j, expr in branch.exprs {
-			estr := f.node_str(expr)
+			estr := f.node_str(expr).trim_space()
 			if f.line_len + estr.len + 2 > fmt.max_len[5] {
 				f.remove_new_line({})
 				f.writeln('')


### PR DESCRIPTION
- call_expr: remove redundant mod2alias check
- node_str: do not call trim_space() by default to make it's usage more explicit and save a few calls