### PR TITLE
string: simplify replace_each()

### DIFF
--- a/cmd/tools/fast/fast.v
+++ b/cmd/tools/fast/fast.v
@@ -63,7 +63,7 @@ fn main() {
 	date := time.unix(commit_date.int())
 	mut out := os.create('table.html') ?
 	// Place the new row on top
-	html_message := message.replace_each(['<', '&lt;', '>', '&gt;'])
+	html_message := message.replace_each('<', '&lt;', '>', '&gt;')
 	table =
 		'<tr>
 		<td>$date.format()</td>

--- a/cmd/tools/missdoc.v
+++ b/cmd/tools/missdoc.v
@@ -107,7 +107,7 @@ fn report_undocumented_functions_in_file(opt Options, file string) {
 
 fn collect_tags(line string) []string {
 	mut cleaned := line.all_before('/')
-	cleaned = cleaned.replace_each(['[', '', ']', '', ' ', ''])
+	cleaned = cleaned.replace_each('[', '', ']', '', ' ', '')
 	return cleaned.split(',')
 }
 

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -72,16 +72,8 @@ pub fn (mut ts TestSession) print_messages() {
 		if rmessage.kind != .info {
 			ts.nmessage_idx++
 		}
-		msg := rmessage.message.replace_each([
-			'TMP1',
-			'${ts.nmessage_idx:1d}',
-			'TMP2',
-			'${ts.nmessage_idx:2d}',
-			'TMP3',
-			'${ts.nmessage_idx:3d}',
-			'TMP4',
-			'${ts.nmessage_idx:4d}',
-		])
+		msg := rmessage.message.replace_each('TMP1', '${ts.nmessage_idx:1d}', 'TMP2',
+			'${ts.nmessage_idx:2d}', 'TMP3', '${ts.nmessage_idx:3d}', 'TMP4', '${ts.nmessage_idx:4d}')
 		is_ok := rmessage.kind == .ok
 		//
 		time_passed := print_msg_time.elapsed().seconds()

--- a/cmd/tools/performance_compare.v
+++ b/cmd/tools/performance_compare.v
@@ -152,20 +152,12 @@ fn (c Context) compare_v_performance(label string, commands []string) string {
 		println(cmd)
 	}
 	for cmd in commands {
-		hyperfine_commands_arguments << ' \'cd ${c.b:-34s} ; ./$cmd \' '.replace_each([
-			'@COMPILER@',
-			source_location_b,
-			'@DEBUG@',
-			debug_option_b,
-		])
+		hyperfine_commands_arguments << ' \'cd ${c.b:-34s} ; ./$cmd \' '.replace_each('@COMPILER@',
+			source_location_b, '@DEBUG@', debug_option_b)
 	}
 	for cmd in commands {
-		hyperfine_commands_arguments << ' \'cd ${c.a:-34s} ; ./$cmd \' '.replace_each([
-			'@COMPILER@',
-			source_location_a,
-			'@DEBUG@',
-			debug_option_a,
-		])
+		hyperfine_commands_arguments << ' \'cd ${c.a:-34s} ; ./$cmd \' '.replace_each('@COMPILER@',
+			source_location_a, '@DEBUG@', debug_option_a)
 	}
 	// /////////////////////////////////////////////////////////////////////////////
 	cmd_stats_file := os.real_path([c.vgo.workdir, 'v_performance_stats_${label}.json'].join(os.path_separator))

--- a/cmd/tools/vbin2v.v
+++ b/cmd/tools/vbin2v.v
@@ -75,7 +75,7 @@ fn (context Context) file2v(bname string, fbytes []byte, bn_max int) string {
 
 fn (context Context) bname_and_bytes(file string) ?(string, []byte) {
 	fname := os.file_name(file)
-	fname_escaped := fname.replace_each(['.', '_', '-', '_'])
+	fname_escaped := fname.replace_each('.', '_', '-', '_')
 	byte_name := '$context.prefix$fname_escaped'.to_lower()
 	fbytes := os.read_bytes(file) or { return error('Error: $err.msg') }
 	return byte_name, fbytes

--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -481,7 +481,7 @@ fn doc_node_html(dn doc.DocNode, link string, head bool, include_examples bool, 
 }
 
 fn html_tag_escape(str string) string {
-	return str.replace_each(['<', '&lt;', '>', '&gt;'])
+	return str.replace_each('<', '&lt;', '>', '&gt;')
 }
 
 /*

--- a/cmd/tools/vdoc/markdown.v
+++ b/cmd/tools/vdoc/markdown.v
@@ -4,7 +4,7 @@ import strings
 import v.doc
 
 fn markdown_escape_script_tags(str string) string {
-	return str.replace_each(['<script>', '`', '</script>', '`'])
+	return str.replace_each('<script>', '`', '</script>', '`')
 }
 
 fn (vd VDoc) gen_markdown(d doc.Doc, with_toc bool) string {

--- a/cmd/tools/vdoc/utils.v
+++ b/cmd/tools/vdoc/utils.v
@@ -15,7 +15,7 @@ fn slug(title string) string {
 }
 
 fn escape(str string) string {
-	return str.replace_each(['"', '\\"', '\r\n', '\\n', '\n', '\\n', '\t', '\\t'])
+	return str.replace_each('"', '\\"', '\r\n', '\\n', '\n', '\\n', '\t', '\\t')
 }
 
 fn get_sym_name(dn doc.DocNode) string {
@@ -44,7 +44,7 @@ fn is_module_readme(dn doc.DocNode) bool {
 }
 
 fn trim_doc_node_description(description string) string {
-	mut dn_description := description.replace_each(['\r\n', '\n', '"', '\\"'])
+	mut dn_description := description.replace_each('\r\n', '\n', '"', '\\"')
 	// 80 is enough to fill one line
 	if dn_description.len > 80 {
 		dn_description = dn_description[..80]
@@ -152,10 +152,10 @@ fn color_highlight(code string, tb &ast.Table) string {
 					'"',
 				])
 				if use_double_quote {
-					s := unescaped_val.replace_each(['\x01', '\\\\', '"', '\\"'])
+					s := unescaped_val.replace_each('\x01', '\\\\', '"', '\\"')
 					lit = term.yellow('"$s"')
 				} else {
-					s := unescaped_val.replace_each(['\x01', '\\\\', "'", "\\'"])
+					s := unescaped_val.replace_each('\x01', '\\\\', "'", "\\'")
 					lit = term.yellow("'$s'")
 				}
 			}

--- a/cmd/tools/vdoc/utils.v
+++ b/cmd/tools/vdoc/utils.v
@@ -148,9 +148,8 @@ fn color_highlight(code string, tb &ast.Table) string {
 			}
 			.string {
 				use_double_quote := tok.lit.contains("'") && !tok.lit.contains('"')
-				unescaped_val := tok.lit.replace('\\\\', '\x01').replace_each(["\\'", "'", '\\"',
-					'"',
-				])
+				unescaped_val := tok.lit.replace('\\\\', '\x01').replace_each("\\'", "'",
+					'\\"', '"')
 				if use_double_quote {
 					s := unescaped_val.replace_each('\x01', '\\\\', '"', '\\"')
 					lit = term.yellow('"$s"')

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -118,7 +118,7 @@ fn (mut vt Vet) vet_line(lines []string, line string, lnumber int) {
 		if lnumber > 0 {
 			collect_tags := fn (line string) []string {
 				mut cleaned := line.all_before('/')
-				cleaned = cleaned.replace_each(['[', '', ']', '', ' ', ''])
+				cleaned = cleaned.replace_each('[', '', ']', '', ' ', '')
 				return cleaned.split(',')
 			}
 			ident_fn_name := fn (line string) string {

--- a/examples/term.ui/text_editor.v
+++ b/examples/term.ui/text_editor.v
@@ -123,7 +123,7 @@ pub mut:
 }
 
 fn (b Buffer) flat() string {
-	return b.raw().replace_each(['\n', r'\n', '\t', r'\t'])
+	return b.raw().replace_each('\n', r'\n', '\t', r'\t')
 }
 
 fn (b Buffer) raw() string {

--- a/examples/vweb/file_upload/vweb_example.v
+++ b/examples/vweb/file_upload/vweb_example.v
@@ -25,7 +25,7 @@ pub fn (mut app App) upload() vweb.Result {
 	mut files := []vweb.RawHtml{}
 
 	for d in fdata {
-		files << d.data.replace_each(['\n', '<br>', '\n\r', '<br>', '\t', '	', ' ', '&nbsp;'])
+		files << d.data.replace_each('\n', '<br>', '\n\r', '<br>', '\t', '	', ' ', '&nbsp;')
 	}
 
 	return $vweb.html()

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -358,9 +358,9 @@ fn (mut a []RepIndex) sort2() {
 }
 
 // replace_each replaces all occurences of the string pairs given in `vals`.
-// Example: assert 'ABCD'.replace_each(['B','C/','C','D','D','C']) == 'AC/DC'
+// Example: assert 'ABCD'.replace_each('B','C/','C','D','D','C') == 'AC/DC'
 [direct_array_access]
-pub fn (s string) replace_each(vals []string) string {
+pub fn (s string) replace_each(vals ...string) string {
 	if s.len == 0 || vals.len == 0 {
 		return s.clone()
 	}

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -298,39 +298,18 @@ fn test_replace() {
 
 fn test_replace_each() {
 	s := 'hello man man :)'
-	q := s.replace_each([
-		'man',
-		'dude',
-		'hello',
-		'hey',
-	])
+	q := s.replace_each('man', 'dude', 'hello', 'hey')
 	assert q == 'hey dude dude :)'
 	bb := '[b]bold[/b] [code]code[/code]'
-	assert bb.replace_each([
-		'[b]',
-		'<b>',
-		'[/b]',
-		'</b>',
-		'[code]',
-		'<code>',
-		'[/code]',
-		'</code>',
-	]) == '<b>bold</b> <code>code</code>'
+	assert bb.replace_each('[b]', '<b>', '[/b]', '</b>', '[code]', '<code>', '[/code]',
+		'</code>') == '<b>bold</b> <code>code</code>'
 	bb2 := '[b]cool[/b]'
-	assert bb2.replace_each([
-		'[b]',
-		'<b>',
-		'[/b]',
-		'</b>',
-	]) == '<b>cool</b>'
+	assert bb2.replace_each('[b]', '<b>', '[/b]', '</b>') == '<b>cool</b>'
 	t := 'aaaaaaaa'
-	y := t.replace_each([
-		'aa',
-		'b',
-	])
+	y := t.replace_each('aa', 'b')
 	assert y == 'bbbb'
 	s2 := 'hello_world hello'
-	assert s2.replace_each(['hello_world', 'aaa', 'hello', 'bbb']) == 'aaa bbb'
+	assert s2.replace_each('hello_world', 'aaa', 'hello', 'bbb') == 'aaa bbb'
 }
 
 fn test_itoa() {

--- a/vlib/encoding/base64/base64.v
+++ b/vlib/encoding/base64/base64.v
@@ -69,7 +69,7 @@ fn alloc_and_encode(src &byte, len int) string {
 // url_decode returns a decoded URL `string` version of
 // the a base64 url encoded `string` passed in `data`.
 pub fn url_decode(data string) []byte {
-	mut result := data.replace_each(['-', '+', '_', '/'])
+	mut result := data.replace_each('-', '+', '_', '/')
 	match result.len % 4 {
 		// Pad with trailing '='s
 		2 { result += '==' } // 2 pad chars
@@ -81,7 +81,7 @@ pub fn url_decode(data string) []byte {
 
 // url_decode_str is the string variant of url_decode
 pub fn url_decode_str(data string) string {
-	mut result := data.replace_each(['-', '+', '_', '/'])
+	mut result := data.replace_each('-', '+', '_', '/')
 	match result.len % 4 {
 		// Pad with trailing '='s
 		2 { result += '==' } // 2 pad chars
@@ -94,12 +94,12 @@ pub fn url_decode_str(data string) string {
 // url_encode returns a base64 URL encoded `string` version
 // of the value passed in `data`.
 pub fn url_encode(data []byte) string {
-	return encode(data).replace_each(['+', '-', '/', '_', '=', ''])
+	return encode(data).replace_each('+', '-', '/', '_', '=', '')
 }
 
 // url_encode_str is the string variant of url_encode
 pub fn url_encode_str(data string) string {
-	return encode_str(data).replace_each(['+', '-', '/', '_', '=', ''])
+	return encode_str(data).replace_each('+', '-', '/', '_', '=', '')
 }
 
 // decode_in_buffer decodes the base64 encoded `string` reference passed in `data` into `buffer`.

--- a/vlib/net/http/cookie.v
+++ b/vlib/net/http/cookie.v
@@ -10,20 +10,21 @@ pub struct Cookie {
 pub mut:
 	name        string
 	value       string
-	path        string // optional
-	domain      string // optional
+	path        string    // optional
+	domain      string    // optional
 	expires     time.Time // optional
-	raw_expires string // for reading cookies only. optional.
+	raw_expires string    // for reading cookies only. optional.
 	// max_age=0 means no 'Max-Age' attribute specified.
 	// max_age<0 means delete cookie now, equivalently 'Max-Age: 0'
 	// max_age>0 means Max-Age attribute present and given in seconds
-	max_age     int
-	secure      bool
-	http_only   bool
-	same_site   SameSite
-	raw         string
-	unparsed    []string // Raw text of unparsed attribute-value pairs
+	max_age   int
+	secure    bool
+	http_only bool
+	same_site SameSite
+	raw       string
+	unparsed  []string // Raw text of unparsed attribute-value pairs
 }
+
 // SameSite allows a server to define a cookie attribute making it impossible for
 // the browser to send this cookie along with cross-site requests. The main
 // goal is to mitigate the risk of cross-origin information leakage, and provide
@@ -61,12 +62,10 @@ pub fn read_set_cookies(h map[string][]string) []&Cookie {
 		if !is_cookie_name_valid(name) {
 			continue
 		}
-		value := parse_cookie_value(raw_value, true) or {
-			continue
-		}
-		mut c  := &Cookie{
-			name: name,
-			value: value,
+		value := parse_cookie_value(raw_value, true) or { continue }
+		mut c := &Cookie{
+			name: name
+			value: value
 			raw: line
 		}
 		for i, _ in parts {
@@ -182,10 +181,11 @@ pub fn read_cookies(h map[string][]string, filter string) []&Cookie {
 			if filter != '' && filter != name {
 				continue
 			}
-			val = parse_cookie_value(val, true) or {
-				continue
+			val = parse_cookie_value(val, true) or { continue }
+			cookies << &Cookie{
+				name: name
+				value: val
 			}
-			cookies << &Cookie{name: name, value: val}
 		}
 	}
 	return cookies
@@ -203,7 +203,8 @@ pub fn (c &Cookie) str() string {
 	// extra_cookie_length derived from typical length of cookie attributes
 	// see RFC 6265 Sec 4.1.
 	extra_cookie_length := 110
-	mut b := strings.new_builder(c.name.len + c.value.len + c.domain.len + c.path.len + extra_cookie_length)
+	mut b := strings.new_builder(c.name.len + c.value.len + c.domain.len + c.path.len +
+		extra_cookie_length)
 	b.write_string(c.name)
 	b.write_string('=')
 	b.write_string(sanitize_cookie_value(c.value))
@@ -229,7 +230,7 @@ pub fn (c &Cookie) str() string {
 	}
 	if c.expires.year > 1600 {
 		e := c.expires
-		time_str := '${e.weekday_str()}, ${e.day.str()} ${e.smonth()} ${e.year} ${e.hhmmss()} GMT'
+		time_str := '$e.weekday_str(), $e.day.str() $e.smonth() $e.year $e.hhmmss() GMT'
 		b.write_string('; expires=')
 		b.write_string(time_str)
 	}
@@ -264,9 +265,9 @@ pub fn (c &Cookie) str() string {
 	return b.str()
 }
 
-fn sanitize(valid fn(byte) bool, v string) string {
+fn sanitize(valid fn (byte) bool, v string) string {
 	mut ok := true
-	for i in 0..v.len {
+	for i in 0 .. v.len {
 		if valid(v[i]) {
 			continue
 		}
@@ -281,7 +282,7 @@ fn sanitize(valid fn(byte) bool, v string) string {
 }
 
 fn sanitize_cookie_name(name string) string {
-	return name.replace_each(['\n', '-', '\r', '-'])
+	return name.replace_each('\n', '-', '\r', '-')
 }
 
 // https://tools.ietf.org/html/rfc6265#section-4.1.1
@@ -370,7 +371,7 @@ pub fn is_cookie_domain_name(_s string) bool {
 			}
 			part_len = 0
 		} else {
-			 return false
+			return false
 		}
 		last = c
 	}
@@ -386,7 +387,7 @@ fn parse_cookie_value(_raw string, allow_double_quote bool) ?string {
 	if allow_double_quote && raw.len > 1 && raw[0] == `"` && raw[raw.len - 1] == `"` {
 		raw = raw.substr(1, raw.len - 1)
 	}
-	for i in 0..raw.len {
+	for i in 0 .. raw.len {
 		if !valid_cookie_value_byte(raw[i]) {
 			return error('http.cookie: invalid cookie value')
 		}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2373,13 +2373,13 @@ pub fn (mut f Fmt) string_literal(node ast.StringLiteral) {
 			f.write("'$node.val'")
 		}
 	} else {
-		unescaped_val := node.val.replace('$fmt.bs$fmt.bs', '\x01').replace_each(["$fmt.bs'", "'",
-			'$fmt.bs"', '"'])
+		unescaped_val := node.val.replace('$fmt.bs$fmt.bs', '\x01').replace_each("$fmt.bs'",
+			"'", '$fmt.bs"', '"')
 		if use_double_quote {
-			s := unescaped_val.replace_each(['\x01', '$fmt.bs$fmt.bs', '"', '$fmt.bs"'])
+			s := unescaped_val.replace_each('\x01', '$fmt.bs$fmt.bs', '"', '$fmt.bs"')
 			f.write('"$s"')
 		} else {
-			s := unescaped_val.replace_each(['\x01', '$fmt.bs$fmt.bs', "'", "$fmt.bs'"])
+			s := unescaped_val.replace_each('\x01', '$fmt.bs$fmt.bs', "'", "$fmt.bs'")
 			f.write("'$s'")
 		}
 	}

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -491,7 +491,7 @@ fn (mut g Gen) gen_str_for_fn_type(info ast.FnType, styp string, str_fn_name str
 
 [inline]
 fn styp_to_str_fn_name(styp string) string {
-	return styp.replace_each(['*', '', '.', '__', ' ', '__']) + '_str'
+	return styp.replace_each('*', '', '.', '__', ' ', '__') + '_str'
 }
 
 fn deref_kind(str_method_expects_ptr bool, is_elem_ptr bool, typ ast.Type) (string, string) {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1715,7 +1715,7 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 		t_var := g.new_tmp_var()
 		receiver_typ := next_fn.params[0].typ
 		receiver_styp := g.typ(receiver_typ)
-		fn_name := receiver_styp.replace_each(['*', '', '.', '__']) + '_next'
+		fn_name := receiver_styp.replace_each('*', '', '.', '__') + '_next'
 		g.write('\t${g.typ(ret_typ)} $t_var = ${fn_name}(')
 		if !node.cond_type.is_ptr() && receiver_typ.is_ptr() {
 			g.write('&')

--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -188,7 +188,7 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 	// fn (mut g Gen) str_int2(node ast.StringInterLiteral) {
 	mut data := []StrIntpCgenData{}
 	for i, val in node.vals {
-		// mut escaped_val := val.replace_each(['%', '%%'])
+		// mut escaped_val := val.replace_each('%', '%%')
 		// escaped_val = util.smart_quote(escaped_val, false)
 		escaped_val := util.smart_quote(val, false)
 

--- a/vlib/v/pref/should_compile.v
+++ b/vlib/v/pref/should_compile.v
@@ -89,32 +89,9 @@ pub fn (prefs &Preferences) should_compile_filtered_files(dir string, files_ []s
 }
 
 fn fname_without_platform_postfix(file string) string {
-	res := file.replace_each([
-		'default.c.v',
-		'_',
-		'nix.c.v',
-		'_',
-		'windows.c.v',
-		'_',
-		'linux.c.v',
-		'_',
-		'darwin.c.v',
-		'_',
-		'macos.c.v',
-		'_',
-		'android.c.v',
-		'_',
-		'freebsd.c.v',
-		'_',
-		'netbsd.c.v',
-		'_',
-		'dragonfly.c.v',
-		'_',
-		'solaris.c.v',
-		'_',
-		'native.v',
-		'_',
-	])
+	res := file.replace_each('default.c.v', '_', 'nix.c.v', '_', 'windows.c.v', '_', 'linux.c.v',
+		'_', 'darwin.c.v', '_', 'macos.c.v', '_', 'android.c.v', '_', 'freebsd.c.v', '_',
+		'netbsd.c.v', '_', 'dragonfly.c.v', '_', 'solaris.c.v', '_', 'native.v', '_')
 	return res
 }
 

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -632,14 +632,7 @@ pub fn not_found() Result {
 }
 
 fn filter(s string) string {
-	return s.replace_each([
-		'<',
-		'&lt;',
-		'"',
-		'&quot;',
-		'&',
-		'&amp;',
-	])
+	return s.replace_each('<', '&lt;', '"', '&quot;', '&', '&amp;')
 }
 
 // A type which don't get filtered inside templates


### PR DESCRIPTION
This PR simplify replace_each().

- `pub fn (s string) replace_each(vals []string) string {` change to `pub fn (s string) replace_each(vals ...string) string {`.
- Function call is clearer.
- Modify all the related call.