### PR TITLE
checker: fix generic with fixed array parameter (fix #10116)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6449,19 +6449,32 @@ fn (mut c Checker) check_index(typ_sym &ast.TypeSymbol, index ast.Expr, index_ty
 
 pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) ast.Type {
 	mut typ := c.expr(node.left)
+	mut typ_sym := c.table.get_final_type_symbol(typ)
 	node.left_type = typ
-	typ_sym := c.table.get_final_type_symbol(typ)
-	match typ_sym.kind {
-		.map {
-			node.is_map = true
+	for {
+		match typ_sym.kind {
+			.map {
+				node.is_map = true
+				break
+			}
+			.array {
+				node.is_array = true
+				break
+			}
+			.array_fixed {
+				node.is_farray = true
+				break
+			}
+			.any {
+				typ = c.unwrap_generic(typ)
+				node.left_type = typ
+				typ_sym = c.table.get_final_type_symbol(typ)
+				continue
+			}
+			else {
+				break
+			}
 		}
-		.array {
-			node.is_array = true
-		}
-		.array_fixed {
-			node.is_farray = true
-		}
-		else {}
 	}
 	if typ_sym.kind !in [.array, .array_fixed, .string, .map] && !typ.is_ptr()
 		&& typ !in [ast.byteptr_type, ast.charptr_type] && !typ.has_flag(.variadic) {

--- a/vlib/v/tests/generics_with_fixed_array_type_test.v
+++ b/vlib/v/tests/generics_with_fixed_array_type_test.v
@@ -1,0 +1,10 @@
+fn show_element<T>(arr &T) string {
+	return unsafe { '${arr[1]}' }
+}
+
+fn test_generic_with_fixed_array_type() {
+	a := [1, 2, 3]!
+	ret := show_element(a)
+	println(ret)
+	assert ret == '2'
+}


### PR DESCRIPTION
This PR fix generic with fixed array parameter (fix #10116).

- Fix generic with fixed array parameter.
- Add test.

```vlang
fn test<T>(arr &T) {
	unsafe { println(arr[1]) }
}

fn main() {
	a := [1, 2, 3]!
	test(a)
}

PS D:\Test\v\tt1> v run .
2
```