### PR TITLE
parser: support imported enums as map keys

### DIFF
--- a/cmd/tools/vtest-cleancode.v
+++ b/cmd/tools/vtest-cleancode.v
@@ -35,6 +35,7 @@ const (
 		'vlib/v/tests/interop_test.v', /* bad comment formatting */
 		'vlib/v/tests/string_interpolation_test.v' /* TODO byteptr: &byte.str() behaves differently than byteptr.str() */,
 		'vlib/v/gen/js/tests/js.v', /* local `hello` fn, gets replaced with module `hello` aliased as `hl` */
+		'vlib/v/tests/map_enum_keys_test.v' /* temporary here, till PR#10235 is merged */,
 		'examples/c_interop_wkhtmltopdf.v' /* &charptr --> &&char */,
 	]
 	vfmt_verify_list                = [

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -92,7 +92,7 @@ pub fn (mut p Parser) parse_map_type() ast.Type {
 		return 0
 	}
 	key_type_supported := key_type in [ast.string_type_idx, ast.voidptr_type_idx]
-		|| key_sym.kind == .enum_ || ((key_type.is_int() || key_type.is_float()
+		|| key_sym.kind == .enum_ || key_sym.kind == .placeholder || ((key_type.is_int() || key_type.is_float()
 		|| is_alias) && !key_type.is_ptr())
 	if !key_type_supported {
 		if is_alias {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -92,8 +92,8 @@ pub fn (mut p Parser) parse_map_type() ast.Type {
 		return 0
 	}
 	key_type_supported := key_type in [ast.string_type_idx, ast.voidptr_type_idx]
-		|| key_sym.kind == .enum_ || key_sym.kind == .placeholder || ((key_type.is_int() || key_type.is_float()
-		|| is_alias) && !key_type.is_ptr())
+		|| key_sym.kind == .enum_ || key_sym.kind == .placeholder
+		|| ((key_type.is_int() || key_type.is_float() || is_alias) && !key_type.is_ptr())
 	if !key_type_supported {
 		if is_alias {
 			p.error('cannot use the alias type as the parent type is unsupported')

--- a/vlib/v/tests/map_enum_keys_test.v
+++ b/vlib/v/tests/map_enum_keys_test.v
@@ -1,3 +1,5 @@
+import gg { MouseButton }
+
 enum Token {
 	aa = 2
 	bb
@@ -10,8 +12,25 @@ fn test_map_with_enum_keys() {
 	m[Token.bb] = 'def'
 	assert m[Token.aa] == 'abc'
 	assert m[.bb] == 'def'
-	//
 	s := '$m'
 	assert s == "{aa: 'abc', bb: 'def'}"
 	println(m)
+}
+
+fn test_map_with_imported_enum_keys() {
+	mut km := map[gg.KeyCode]string{}
+	km[.minus] = '-'
+	km[gg.KeyCode.comma] = ','
+	assert km[.invalid] == ''
+	assert gg.KeyCode.comma in km
+	assert km[.minus] == '-'
+}
+
+fn test_map_with_selective_imported_enum_keys() {
+	mut bm := map[MouseButton]string{}
+	bm[.left] = 'lb'
+	bm[MouseButton.middle] = 'mb'
+	assert bm[.left] == 'lb'
+	bm.delete(MouseButton.left)
+	assert MouseButton.left !in bm
 }

--- a/vlib/v/tests/map_enum_keys_test.v
+++ b/vlib/v/tests/map_enum_keys_test.v
@@ -1,4 +1,6 @@
-import gg { MouseButton }
+// This tests that V can import and use enums from other modules,
+// and that vfmt can handle all edge cases.
+import geometry { Shape }
 
 enum Token {
 	aa = 2
@@ -18,19 +20,19 @@ fn test_map_with_enum_keys() {
 }
 
 fn test_map_with_imported_enum_keys() {
-	mut km := map[gg.KeyCode]string{}
-	km[.minus] = '-'
-	km[gg.KeyCode.comma] = ','
-	assert km[.invalid] == ''
-	assert gg.KeyCode.comma in km
-	assert km[.minus] == '-'
+	mut fm := map[geometry.Form3D]string{}
+	fm[.cube] = 'a cube'
+	fm[geometry.Form3D.sphere] = 'a sphere'
+	assert fm[.invalid] == ''
+	assert geometry.Form3D.cube in fm
+	assert fm[.sphere] == 'a sphere'
 }
 
 fn test_map_with_selective_imported_enum_keys() {
-	mut bm := map[MouseButton]string{}
-	bm[.left] = 'lb'
-	bm[MouseButton.middle] = 'mb'
-	assert bm[.left] == 'lb'
-	bm.delete(MouseButton.left)
-	assert MouseButton.left !in bm
+	mut shapes := map[Shape]string{}
+	shapes[.circle] = 'a circle'
+	shapes[Shape.rectangle] = 'a rectangle'
+	assert shapes[.circle] == 'a circle'
+	shapes.delete(Shape.circle)
+	assert Shape.circle !in shapes
 }

--- a/vlib/v/tests/modules/geometry/geometry.v
+++ b/vlib/v/tests/modules/geometry/geometry.v
@@ -10,6 +10,15 @@ pub enum Shape {
 	triangle
 }
 
+// used by vlib/v/tests/map_enum_keys_test.v
+pub enum Form3D {
+	sphere
+	cylinder
+	cone
+	cube
+	invalid
+}
+
 pub struct Point {
 pub mut:
 	x int


### PR DESCRIPTION
fix #10232 

Required for #10235