### PR TITLE
str_intp: bug fix

### DIFF
--- a/vlib/builtin/string_interpolation.v
+++ b/vlib/builtin/string_interpolation.v
@@ -649,12 +649,12 @@ pub fn str_intp_rune(in_str string) string {
 
 [inline]
 pub fn str_intp_g32(in_str string) string {
-	return 'str_intp(1, _MOV((StrIntpData[]){{_SLIT(""), $si_g32_code, {.d_f32 = $in_str }}}))'
+	return 'str_intp(1, _MOV((StrIntpData[]){{_SLIT0, $si_g32_code, {.d_f32 = $in_str }}}))'
 }
 
 [inline]
 pub fn str_intp_g64(in_str string) string {
-	return 'str_intp(1, _MOV((StrIntpData[]){{_SLIT(""), $si_g64_code, {.d_f64 = $in_str }}}))'
+	return 'str_intp(1, _MOV((StrIntpData[]){{_SLIT0, $si_g64_code, {.d_f64 = $in_str }}}))'
 }
 
 // replace %% with the in_str

--- a/vlib/v/gen/c/sql.v
+++ b/vlib/v/gen/c/sql.v
@@ -700,7 +700,7 @@ fn (mut g Gen) mysql_create_table(node ast.SqlStmtLine, typ SqlType, db_expr ast
 	g.expr(db_expr)
 	g.writeln(', _SLIT("$create_string"));')
 
-	tmp_str := 'str_intp(1, _MOV((StrIntpData[]){_SLIT("Something went wrong: "), $si_s_code ,{.d_s=IError_str(err)}}))'
+	tmp_str := 'str_intp(1, _MOV((StrIntpData[]){{_SLIT("Something went wrong: "), $si_s_code ,{.d_s=IError_str(err)}}}))'
 	g.writeln('if (${tmp}.state != 0) { IError err = ${tmp}.err; eprintln($tmp_str); }')
 }
 
@@ -713,7 +713,7 @@ fn (mut g Gen) mysql_drop_table(node ast.SqlStmtLine, typ SqlType, db_expr ast.E
 	g.expr(db_expr)
 	g.writeln(', _SLIT("$drop_string"));')
 
-	tmp_str := 'str_intp(1, _MOV((StrIntpData[]){_SLIT("Something went wrong: "), $si_s_code ,{.d_s=IError_str(err)}}))'
+	tmp_str := 'str_intp(1, _MOV((StrIntpData[]){{_SLIT("Something went wrong: "), $si_s_code ,{.d_s=IError_str(err)}}}))'
 	g.writeln('if (${tmp}.state != 0) { IError err = ${tmp}.err; eprintln($tmp_str); }')
 }
 
@@ -862,7 +862,7 @@ fn (mut g Gen) psql_stmt(node ast.SqlStmtLine, typ SqlType, db_expr ast.Expr) {
 				res := g.new_tmp_var()
 				g.writeln('Option_pg__Row $res = pg__DB_exec_one($db_name, _SLIT("SELECT LASTVAL();"));')
 
-				tmp_str := 'str_intp(1, _MOV((StrIntpData[]){_SLIT0, $si_s_code ,{.d_s=IError_str(err)}}))'
+				tmp_str := 'str_intp(1, _MOV((StrIntpData[]){{_SLIT0, $si_s_code ,{.d_s=IError_str(err)}}}))'
 				g.writeln('if (${res}.state != 0) { IError err = ${res}.err; eprintln($tmp_str); }')
 
 				g.sql_buf = strings.new_builder(100)
@@ -905,7 +905,7 @@ fn (mut g Gen) psql_stmt(node ast.SqlStmtLine, typ SqlType, db_expr ast.Expr) {
 		res := g.new_tmp_var()
 		g.writeln('Option_pg__Row $res = pg__DB_exec_one($db_name, _SLIT("SELECT LASTVAL();"));')
 
-		tmp_str := 'str_intp(1, _MOV((StrIntpData[]){_SLIT0, $si_s_code ,{.d_s=IError_str(err)}}))'
+		tmp_str := 'str_intp(1, _MOV((StrIntpData[]){{_SLIT0, $si_s_code ,{.d_s=IError_str(err)}}}))'
 		g.writeln('if (${res}.state != 0) { IError err = ${res}.err; eprintln($tmp_str); }')
 
 		id_name := g.new_tmp_var()
@@ -939,7 +939,7 @@ fn (mut g Gen) psql_select_expr(node ast.SqlExpr, sub bool, line string, typ Sql
 	res := g.new_tmp_var()
 	g.writeln('Option_Array_pg__Row $res = pg__DB_exec($db_name, $g.sql_stmt_name);')
 
-	tmp_str := 'str_intp(1, _MOV((StrIntpData[]){_SLIT("Something went wrong: "), $si_s_code ,{.d_s=IError_str(err)}}))'
+	tmp_str := 'str_intp(1, _MOV((StrIntpData[]){{_SLIT("Something went wrong: "), $si_s_code ,{.d_s=IError_str(err)}}}))'
 	g.writeln('if (${res}.state != 0) { IError err = ${res}.err; eprintln($tmp_str); }')
 
 	rows := g.new_tmp_var()
@@ -1057,7 +1057,7 @@ fn (mut g Gen) psql_create_table(node ast.SqlStmtLine, typ SqlType, db_expr ast.
 	g.expr(db_expr)
 	g.writeln(', _SLIT("$create_string"));')
 
-	tmp_str := 'str_intp(1, _MOV((StrIntpData[]){_SLIT("Something went wrong: "), $si_s_code ,{.d_s=IError_str(err)}}))'
+	tmp_str := 'str_intp(1, _MOV((StrIntpData[]){{_SLIT("Something went wrong: "), $si_s_code ,{.d_s=IError_str(err)}}}))'
 	g.writeln('if (${tmp}.state != 0) { IError err = ${tmp}.err; eprintln($tmp_str); }')
 }
 
@@ -1071,7 +1071,7 @@ fn (mut g Gen) psql_drop_table(node ast.SqlStmtLine, typ SqlType, db_expr ast.Ex
 	g.expr(db_expr)
 	g.writeln(', _SLIT("$drop_string"));')
 
-	tmp_str := 'str_intp(1, _MOV((StrIntpData[]){_SLIT("Something went wrong: "), $si_s_code ,{.d_s=IError_str(err)}}))'
+	tmp_str := 'str_intp(1, _MOV((StrIntpData[]){{_SLIT("Something went wrong: "), $si_s_code ,{.d_s=IError_str(err)}}}))'
 	g.writeln('if (${tmp}.state != 0) { IError err = ${tmp}.err; eprintln($tmp_str); }')
 }
 

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -123,7 +123,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		is_var_mut := expr.is_auto_deref_var()
 		str_fn_name := g.gen_str_for_type(typ)
 		if is_ptr && !is_var_mut {
-			g.write('str_intp(1, _MOV((StrIntpData[]){_SLIT("&"), $si_s_code ,{.d_s=')
+			g.write('str_intp(1, _MOV((StrIntpData[]){{_SLIT("&"), $si_s_code ,{.d_s=')
 		}
 		g.write('${str_fn_name}(')
 		if str_method_expects_ptr && !is_ptr {
@@ -143,7 +143,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		}
 		g.write(')')
 		if is_ptr && !is_var_mut {
-			g.write('}}))')
+			g.write('}}}))')
 			// g.write(')')
 		}
 	} else {


### PR DESCRIPTION
**What's inside**
- fix a bug about a missing `{` level on same `str_intp` calls in `str.v` and `sql.v` of `gen/c`
- replaced the `_MOV((StrIntpData[]){{_SLIT("")` with `_MOV((StrIntpData[]){{_SLIT0` in the `str_intp` calls