### PR TITLE
checker: fix match error to none (fix #10063)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5332,6 +5332,8 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 	cond_type_sym := c.table.get_type_symbol(cond_type)
 	if cond_type_sym.kind !in [.interface_, .sum_type] {
 		node.is_sum_type = false
+	} else {
+		node.is_sum_type = true
 	}
 	c.match_exprs(mut node, cond_type_sym)
 	c.expected_type = cond_type

--- a/vlib/v/tests/match_error_to_none_test.v
+++ b/vlib/v/tests/match_error_to_none_test.v
@@ -1,0 +1,25 @@
+fn do_a_thing(i int) ?int {
+	if i < 0 {
+		return error("can't be negative")
+	}
+	if i == 0 {
+		return none
+	}
+	return i
+}
+
+fn test_match_error_to_none() {
+	i := 0
+	if r := do_a_thing(i) {
+		println(r)
+	} else {
+		match err {
+			none {
+				assert true
+			}
+			else {
+				assert false
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR fix match error to none (fix #10063).

- Fix match error to none.
- Add test.

```vlang
fn do_a_thing(i int) ?int {
	if i < 0 {
		return error("can't be negative")
	}
	if i == 0 {
		return none
	}
	return i
}

fn main() {
	i := 0
	if r := do_a_thing(i) {
		println(r)
	} else {
		match err {
			none {
				assert true
			}
			else {
				assert false
			}
		}
	}
}

PS D:\Test\v\tt1> v run .
```