### PR TITLE
os: fix file read

### DIFF
--- a/vlib/os/fd.c.v
+++ b/vlib/os/fd.c.v
@@ -49,7 +49,7 @@ pub fn fd_read(fd int, maxbytes int) (string, int) {
 		return '', 0
 	}
 	unsafe {
-		mut buf := malloc(maxbytes)
+		mut buf := malloc(maxbytes + 1)
 		nbytes := C.read(fd, buf, maxbytes)
 		if nbytes < 0 {
 			free(buf)


### PR DESCRIPTION
This PR contains some bug fixes for reading from files.

- When reading a string from a file descriptor, a terminating `0` has already been added. This PR ensures there is enough space for this byte in the allocated memory block
- When data is read from a file the size of the file has already been checked in advance to know the amount of data to expect. This size has been used for the return value.
  However the file might be truncated concurrently while it is read resulting in a smaller amount of data. This PR makes sure only the data that has been successfully read is reported on `return`.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
