### PR TITLE
builtin: append `0` to string in `reverse()` result

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1621,13 +1621,16 @@ pub fn (s string) reverse() string {
 		return s.clone()
 	}
 	mut res := string{
-		str: unsafe { malloc(s.len) }
+		str: unsafe { malloc(s.len + 1) }
 		len: s.len
 	}
 	for i := s.len - 1; i >= 0; i-- {
 		unsafe {
 			res.str[s.len - i - 1] = s[i]
 		}
+	}
+	unsafe {
+		res.str[res.len] = 0
 	}
 	return res
 }
@@ -1681,11 +1684,11 @@ pub fn (s string) repeat(count int) string {
 			}
 		}
 	}
+	new_len := s.len * count
 	unsafe {
-		new_len := s.len * count
 		ret[new_len] = 0
-		return ret.vstring_with_len(new_len)
 	}
+	return unsafe { ret.vstring_with_len(new_len) }
 }
 
 // fields returns a string array of the string split by `\t` and ` `


### PR DESCRIPTION
While V doesn't need a terminating `0` at the end of a string, library functions always should always add one for compability with C functions.
This PR fixes `string.reverse()` to do so.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
