### PR TITLE
vlib: add trailing `0` to string returned by library functions

### DIFF
--- a/vlib/encoding/base64/base64.v
+++ b/vlib/encoding/base64/base64.v
@@ -35,7 +35,8 @@ pub fn decode_str(data string) string {
 		return ''
 	}
 	unsafe {
-		buffer := malloc(size)
+		buffer := malloc(size + 1)
+		buffer[size] = 0
 		return tos(buffer, decode_in_buffer(data, buffer))
 	}
 }
@@ -61,7 +62,8 @@ fn alloc_and_encode(src &byte, len int) string {
 		return ''
 	}
 	unsafe {
-		buffer := malloc(size)
+		buffer := malloc(size + 1)
+		buffer[size] = 0
 		return tos(buffer, encode_from_buffer(buffer, src, len))
 	}
 }

--- a/vlib/rand/rand.v
+++ b/vlib/rand/rand.v
@@ -197,11 +197,14 @@ pub fn string_from_set(charset string, len int) string {
 	if len == 0 {
 		return ''
 	}
-	mut buf := unsafe { malloc(len) }
+	mut buf := unsafe { malloc(len + 1) }
 	for i in 0 .. len {
 		unsafe {
 			buf[i] = charset[intn(charset.len)]
 		}
+	}
+	unsafe {
+		buf[len] = 0
 	}
 	return unsafe { buf.vstring_with_len(len) }
 }


### PR DESCRIPTION
Similar to #10248 this PR adds a trailing `0` to the returned result of
- `encoding.base64.decode_str()`
- `rand.string_from_set()`

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
