### PR TITLE
strconv: fix memory corruption

### DIFF
--- a/vlib/strconv/format_mem.v
+++ b/vlib/strconv/format_mem.v
@@ -445,7 +445,7 @@ pub fn remove_tail_zeros(s string) string {
 		mut i_s := 0
 		
 		// skip spaces
-		for i_s < s.len && s[i_s] !in [`-`,`+`] && s[i_s] >= `9` && s[i_s] <= `0`{
+		for i_s < s.len && s[i_s] !in [`-`,`+`] && (s[i_s] > `9` || s[i_s] < `0`) {
 			buf[i_d] = s[i_s]
 			i_s++
 			i_d++
@@ -482,16 +482,19 @@ pub fn remove_tail_zeros(s string) string {
 			i_s = i_s1
 		}
 
-		if s[i_s] != `.` {
+		if i_s < s.len && s[i_s] != `.` {
 			// check exponent
-			for i_s < s.len {
+			for {
 				buf[i_d] = s[i_s]
 				i_s++
 				i_d++
+				if i_s >= s.len {
+					break
+				}
 			}
 		}
 
 		buf[i_d] = 0
-		return tos(buf, i_d+1)
+		return tos(buf, i_d)
 	}
 }


### PR DESCRIPTION
This PR fixes some issues in `strconv`:
- fix logic to detect non-numbers in `remove_tail_zeros()`
- fix array bound violation in that function (it used `[direct_array_access]`, so that has not been detected by test cases)
- don't count trailing `0` to length of returned string
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
