### PR TITLE
cgen: fix embeds for msvc (fix #10244)

### DIFF
--- a/vlib/v/gen/c/embed.v
+++ b/vlib/v/gen/c/embed.v
@@ -61,7 +61,7 @@ fn (mut g Gen) gen_embedded_data() {
 	g.embedded_data.writeln('')
 	g.embedded_data.writeln('const v__embed_file__EmbedFileIndexEntry _v_embed_file_index[] = {')
 	for i, emfile in g.embedded_files {
-		g.embedded_data.writeln('\t{$i, { .str=(byteptr)("${emfile.rpath}"), .len=${emfile.rpath.len - 1}, .is_lit=1 }, _v_embed_blob_$i},')
+		g.embedded_data.writeln('\t{$i, { .str=(byteptr)("$emfile.rpath"), .len=${emfile.rpath.len - 1}, .is_lit=1 }, _v_embed_blob_$i},')
 	}
 	g.embedded_data.writeln('\t{-1, { .str=(byteptr)(""), .len=0, .is_lit=1 }, NULL}')
 	g.embedded_data.writeln('};')

--- a/vlib/v/gen/c/embed.v
+++ b/vlib/v/gen/c/embed.v
@@ -61,9 +61,9 @@ fn (mut g Gen) gen_embedded_data() {
 	g.embedded_data.writeln('')
 	g.embedded_data.writeln('const v__embed_file__EmbedFileIndexEntry _v_embed_file_index[] = {')
 	for i, emfile in g.embedded_files {
-		g.embedded_data.writeln('\t{$i, ${ctoslit(emfile.rpath)}, _v_embed_blob_$i},')
+		g.embedded_data.writeln('\t{$i, { "${emfile.rpath}", ${emfile.rpath.len}, 1 }, _v_embed_blob_$i},')
 	}
-	g.embedded_data.writeln('\t{-1, _SLIT(""), NULL}')
+	g.embedded_data.writeln('\t{-1, { "", 0, 1 }, NULL}')
 	g.embedded_data.writeln('};')
 	// see vlib/v/embed_file/embed_file.v, find_index_entry_by_id/2 and find_index_entry_by_path/2
 }

--- a/vlib/v/gen/c/embed.v
+++ b/vlib/v/gen/c/embed.v
@@ -61,9 +61,9 @@ fn (mut g Gen) gen_embedded_data() {
 	g.embedded_data.writeln('')
 	g.embedded_data.writeln('const v__embed_file__EmbedFileIndexEntry _v_embed_file_index[] = {')
 	for i, emfile in g.embedded_files {
-		g.embedded_data.writeln('\t{$i, { "${emfile.rpath}", ${emfile.rpath.len}, 1 }, _v_embed_blob_$i},')
+		g.embedded_data.writeln('\t{$i, { .str=(byteptr)("${emfile.rpath}"), .len=${emfile.rpath.len - 1}, .is_lit=1 }, _v_embed_blob_$i},')
 	}
-	g.embedded_data.writeln('\t{-1, { "", 0, 1 }, NULL}')
+	g.embedded_data.writeln('\t{-1, { .str=(byteptr)(""), .len=0, .is_lit=1 }, NULL}')
 	g.embedded_data.writeln('};')
 	// see vlib/v/embed_file/embed_file.v, find_index_entry_by_id/2 and find_index_entry_by_path/2
 }

--- a/vlib/v/gen/c/embed.v
+++ b/vlib/v/gen/c/embed.v
@@ -61,7 +61,7 @@ fn (mut g Gen) gen_embedded_data() {
 	g.embedded_data.writeln('')
 	g.embedded_data.writeln('const v__embed_file__EmbedFileIndexEntry _v_embed_file_index[] = {')
 	for i, emfile in g.embedded_files {
-		g.embedded_data.writeln('\t{$i, { .str=(byteptr)("$emfile.rpath"), .len=${emfile.rpath.len - 1}, .is_lit=1 }, _v_embed_blob_$i},')
+		g.embedded_data.writeln('\t{$i, { .str=(byteptr)("${cestring(emfile.rpath)}"), .len=${emfile.rpath.len - 1}, .is_lit=1 }, _v_embed_blob_$i},')
 	}
 	g.embedded_data.writeln('\t{-1, { .str=(byteptr)(""), .len=0, .is_lit=1 }, NULL}')
 	g.embedded_data.writeln('};')


### PR DESCRIPTION
Fixes an MSVC C compile time error "initializer is not a constant" (fixes #10244). I think it's caused by the use of the `_SLIT` macro so I expanded that out manually in the cgen code. Code compiles in `-prod` with gcc and msvc now.
