### PR TITLE
string interpolation: Bug fix. {:g/G} behaviour with zeros and infinites fixed

### DIFF
--- a/vlib/builtin/string_int_test.v
+++ b/vlib/builtin/string_int_test.v
@@ -182,4 +182,14 @@ fn test_signed_cast() {
 		s := n.str() + 'z'
 		assert s.i16() == n
 	}
+
+	// test g format
+	{
+		mut a := 0.0
+		assert '${a:g}' == '0'
+		assert '${a:G}' == '0'
+		a = -0.0
+		assert '${a:g}' == '0'
+		assert '${a:G}' == '0'
+	}
 }

--- a/vlib/builtin/string_int_test.v
+++ b/vlib/builtin/string_int_test.v
@@ -1,3 +1,5 @@
+import strconv
+
 fn test_common_atoi() {
 	// test common cases
 	assert '70zzz'.int() == 70
@@ -185,11 +187,19 @@ fn test_signed_cast() {
 
 	// test g format
 	{
-		mut a := 0.0
-		assert '${a:g}' == '0'
-		assert '${a:G}' == '0'
-		a = -0.0
-		assert '${a:g}' == '0'
-		assert '${a:G}' == '0'
+		mut u := strconv.Float64u{
+			u: strconv.double_plus_zero
+		}
+		assert '${u.f:g}' == '0'
+		assert '${u.f:G}' == '0'
+		u.u = strconv.double_minus_zero
+		assert '${u.f:g}' == '0'
+		assert '${u.f:G}' == '0'
+		u.u = strconv.double_plus_infinity
+		assert '${u.f:g}' == '+inf'
+		assert '${u.f:G}' == '+INF'
+		u.u = strconv.double_minus_infinity
+		assert '${u.f:g}' == '-inf'
+		assert '${u.f:G}' == '-INF'
 	}
 }

--- a/vlib/builtin/string_int_test.v
+++ b/vlib/builtin/string_int_test.v
@@ -202,4 +202,20 @@ fn test_signed_cast() {
 		assert '${u.f:g}' == '-inf'
 		assert '${u.f:G}' == '-INF'
 	}
+	{
+		mut u := strconv.Float32u{
+			u: strconv.single_plus_zero
+		}
+		assert '${u.f:g}' == '0'
+		assert '${u.f:G}' == '0'
+		u.u = strconv.single_minus_zero
+		assert '${u.f:g}' == '0'
+		assert '${u.f:G}' == '0'
+		u.u = strconv.single_plus_infinity
+		assert '${u.f:g}' == '+inf'
+		assert '${u.f:G}' == '+INF'
+		u.u = strconv.single_minus_infinity
+		assert '${u.f:g}' == '-inf'
+		assert '${u.f:G}' == '-INF'
+	}
 }

--- a/vlib/builtin/string_interpolation.v
+++ b/vlib/builtin/string_interpolation.v
@@ -450,6 +450,37 @@ fn (data StrIntpData) get_fmt_format(mut sb strings.Builder) {
 					sb.write_string(f)
 					f.free()
 				} else {
+					// Manage +/-0
+					if data.d.d_f32 == strconv.single_plus_zero {
+						tmp_str := '0'
+						strconv.format_str_sb(tmp_str, bf, mut sb)
+						tmp_str.free()
+						return
+					}
+					if data.d.d_f32 == strconv.single_minus_zero {
+						tmp_str := '-0'
+						strconv.format_str_sb(tmp_str, bf, mut sb)
+						tmp_str.free()
+						return
+					}
+					// Manage +/-INF
+					if data.d.d_f32 == strconv.single_plus_infinity {
+						mut tmp_str := '+inf'
+						if upper_case {
+							tmp_str = '+INF'
+						}
+						strconv.format_str_sb(tmp_str, bf, mut sb)
+						tmp_str.free()
+					}
+					if data.d.d_f32 == strconv.single_minus_infinity {
+						mut tmp_str := '-inf'
+						if upper_case {
+							tmp_str = '-INF'
+						}
+						strconv.format_str_sb(tmp_str, bf, mut sb)
+						tmp_str.free()
+					}
+
 					if data.d.d_f32 < 0 {
 						bf.positive = false
 					}
@@ -487,6 +518,37 @@ fn (data StrIntpData) get_fmt_format(mut sb strings.Builder) {
 					sb.write_string(f)
 					f.free()
 				} else {
+					// Manage +/-0
+					if data.d.d_f64 == strconv.double_plus_zero {
+						tmp_str := '0'
+						strconv.format_str_sb(tmp_str, bf, mut sb)
+						tmp_str.free()
+						return
+					}
+					if data.d.d_f64 == strconv.double_minus_zero {
+						tmp_str := '-0'
+						strconv.format_str_sb(tmp_str, bf, mut sb)
+						tmp_str.free()
+						return
+					}
+					// Manage +/-INF
+					if data.d.d_f64 == strconv.double_plus_infinity {
+						mut tmp_str := '+inf'
+						if upper_case {
+							tmp_str = '+INF'
+						}
+						strconv.format_str_sb(tmp_str, bf, mut sb)
+						tmp_str.free()
+					}
+					if data.d.d_f64 == strconv.double_minus_infinity {
+						mut tmp_str := '-inf'
+						if upper_case {
+							tmp_str = '-INF'
+						}
+						strconv.format_str_sb(tmp_str, bf, mut sb)
+						tmp_str.free()
+					}
+
 					if data.d.d_f64 < 0 {
 						bf.positive = false
 					}


### PR DESCRIPTION
**What's inside**
- Make a coherent result when zero si feeded to the string interpolation for the `g/G` formatting
- Added tests