### PR TITLE
cgen: write alias typedefs just before interfaces

### DIFF
--- a/vlib/v/tests/alias_custom_type_map_test.v
+++ b/vlib/v/tests/alias_custom_type_map_test.v
@@ -2,7 +2,7 @@ import geometry
 
 fn test_aliases_map_init() {
 	a := geometry.ShapeMap(map{
-		geometry.Shape.circle: "Shape is a circle."
+		geometry.Shape.circle: 'Shape is a circle.'
 	})
-	assert a[geometry.Shape.circle] == "Shape is a circle."
+	assert a[geometry.Shape.circle] == 'Shape is a circle.'
 }

--- a/vlib/v/tests/alias_custom_type_map_test.v
+++ b/vlib/v/tests/alias_custom_type_map_test.v
@@ -1,0 +1,8 @@
+import geometry
+
+fn test_aliases_map_init() {
+	a := geometry.ShapeMap(map{
+		geometry.Shape.circle: "Shape is a circle."
+	})
+	assert a[geometry.Shape.circle] == "Shape is a circle."
+}

--- a/vlib/v/tests/modules/geometry/geometry.v
+++ b/vlib/v/tests/modules/geometry/geometry.v
@@ -10,6 +10,8 @@ pub enum Shape {
 	triangle
 }
 
+pub type ShapeMap = map[Shape]string
+
 // used by vlib/v/tests/map_enum_keys_test.v
 pub enum Form3D {
 	sphere


### PR DESCRIPTION
fix #10146 