### PR TITLE
checker: fix match expr returning optional (fix #10274)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5358,7 +5358,7 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 					}
 					expr_type := c.expr(stmt.expr)
 					if ret_type == ast.void_type {
-						if node.is_expr
+						if node.is_expr && !node.expected_type.has_flag(.optional)
 							&& c.table.get_type_symbol(node.expected_type).kind == .sum_type {
 							ret_type = node.expected_type
 						} else {

--- a/vlib/v/tests/match_expr_returning_optional_test.v
+++ b/vlib/v/tests/match_expr_returning_optional_test.v
@@ -1,0 +1,36 @@
+type Any = int | string
+
+fn ok(s string) Any {
+	return match s {
+		'foo' {
+			Any(1)
+		}
+		else {
+			Any('asdf')
+		}
+	}
+}
+
+fn fails(s string) ?Any {
+	return match s {
+		'foo' {
+			Any(1)
+		}
+		else {
+			Any('asdf')
+		}
+	}
+}
+
+fn test_match_expr_returning_optional() {
+	ret1 := ok('foo')
+	println(ret1)
+	assert ret1 == Any(1)
+
+	ret2 := fails('foo') or {
+		assert false
+		return
+	}
+	println(ret2)
+	assert ret2 == Any(1)
+}


### PR DESCRIPTION
This PR fix match expr returning optional (fix #10274).

- Fix match expr returning optional.
- Add test.

```vlang
type Any = int | string

fn ok(s string) Any {
	return match s {
		'foo' {
			Any(1)
		}
		else {
			Any('asdf')
		}
	}
}

fn fails(s string) ?Any {
	return match s {
		'foo' {
			Any(1)
		}
		else {
			Any('asdf')
		}
	}
}

fn main() {
	ret1 := ok('foo')
	println(ret1)
	assert ret1 == Any(1)

	ret2 := fails('foo') ?
	println(ret2)
	assert ret2 == Any(1)
}

PS D:\Test\v\tt1> v run .
Any(1)
Any(1)
```