### PR TITLE
cgen: fix match in map or expr (fix #9866)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4020,7 +4020,8 @@ fn (mut g Gen) need_tmp_var_in_match(node ast.MatchExpr) bool {
 				if branch.stmts[0] is ast.ExprStmt {
 					stmt := branch.stmts[0] as ast.ExprStmt
 					if stmt.expr is ast.CallExpr || stmt.expr is ast.IfExpr
-						|| stmt.expr is ast.MatchExpr {
+						|| stmt.expr is ast.MatchExpr || (stmt.expr is ast.IndexExpr
+						&& (stmt.expr as ast.IndexExpr).or_expr.kind != .absent) {
 						return true
 					}
 				}

--- a/vlib/v/tests/match_in_map_or_expr_test .v
+++ b/vlib/v/tests/match_in_map_or_expr_test .v
@@ -1,0 +1,15 @@
+fn test_match_in_map_or_expr() {
+	a := 5
+	some_map := map{
+		3: '3'
+		4: '4'
+	}
+	something := match a {
+		7 { '7' }
+		6 { '6' }
+		5 { '5' }
+		else { some_map[a] or { a.str() } } // here is the error
+	}
+	println(something)
+	assert something == '5'
+}


### PR DESCRIPTION
This PR fix match in map or expr (fix #9866).

- Fix match in map or expr.
- Add test.

```vlang
fn main() {
	a := 5
	some_map := map{
		3: '3'
		4: '4'
	}
	something := match a {
		7 { '7' }
		6 { '6' }
		5 { '5' }
		else { some_map[a] or { a.str() } } // here is the error
	}
	println(something)
	assert something == '5'
}

PS D:\Test\v\tt1> v run .
5
```