### PR TITLE
checker: forbid leaving function from inside `defer` block

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -82,8 +82,7 @@ pub fn (mut p Parser) call_expr(language ast.Language, mod string) ast.CallExpr 
 		// `foo()?`
 		p.next()
 		if p.inside_defer {
-			p.error_with_pos('error propagation not allowed inside `defer` blocks',
-				p.prev_tok.position())
+			p.error_with_pos('error propagation not allowed inside `defer` blocks', p.prev_tok.position())
 		}
 		or_kind = .propagate
 	}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -82,7 +82,8 @@ pub fn (mut p Parser) call_expr(language ast.Language, mod string) ast.CallExpr 
 		// `foo()?`
 		p.next()
 		if p.inside_defer {
-			p.error_with_pos('error propagation not allowed inside `defer` blocks', p.prev_tok.position())
+			p.error_with_pos('error propagation not allowed inside `defer` blocks',
+				p.prev_tok.position())
 		}
 		or_kind = .propagate
 	}
@@ -598,6 +599,8 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 			p.tok.position())
 		return ast.AnonFn{}
 	}
+	old_inside_defer := p.inside_defer
+	p.inside_defer = false
 	p.open_scope()
 	if p.pref.backend != .js {
 		p.scope.detached_from_parent = true
@@ -663,6 +666,7 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 	func.name = name
 	idx := p.table.find_or_register_fn_type(p.mod, func, true, false)
 	typ := ast.new_type(idx)
+	p.inside_defer = old_inside_defer
 	// name := p.table.get_type_name(typ)
 	return ast.AnonFn{
 		decl: ast.FnDecl{

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -81,6 +81,9 @@ pub fn (mut p Parser) call_expr(language ast.Language, mod string) ast.CallExpr 
 	if p.tok.kind == .question {
 		// `foo()?`
 		p.next()
+		if p.inside_defer {
+			p.error_with_pos('error propagation not allowed inside `defer` blocks', p.prev_tok.position())
+		}
 		or_kind = .propagate
 	}
 	if fn_name in p.imported_symbols {

--- a/vlib/v/parser/tests/defer_propagate.out
+++ b/vlib/v/parser/tests/defer_propagate.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/defer_propagate.vv:9:15: error: error propagation not allowed inside `defer` blocks
+    7 |     mut a := 0
+    8 |     defer {
+    9 |         a = test1() ?
+      |                     ^
+   10 |     }
+   11 |     return a

--- a/vlib/v/parser/tests/defer_propagate.vv
+++ b/vlib/v/parser/tests/defer_propagate.vv
@@ -1,0 +1,16 @@
+fn test1() ?int {
+	a := 3
+	return a
+}
+
+fn test2() ?int {
+	mut a := 0
+	defer {
+		a = test1() ?
+	}
+	return a
+
+fn main() {
+	x := test2() or { -1 }
+	println(x)
+}

--- a/vlib/v/parser/tests/defer_return.out
+++ b/vlib/v/parser/tests/defer_return.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/defer_return.vv:3:3: error: `return` not allowed inside `defer` block
+    1 | fn main() {
+    2 |     defer {
+    3 |         return
+      |         ~~~~~~
+    4 |     }
+    5 | }

--- a/vlib/v/parser/tests/defer_return.vv
+++ b/vlib/v/parser/tests/defer_return.vv
@@ -1,0 +1,5 @@
+fn main() {
+	defer {
+		return
+	}
+}

--- a/vlib/v/parser/tests/defer_return2.out
+++ b/vlib/v/parser/tests/defer_return2.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/defer_return2.vv:3:3: error: `return` not allowed inside `defer` block
+    1 | fn test1() int {
+    2 |     defer {
+    3 |         return 12
+      |         ~~~~~~
+    4 |     }
+    5 |     a := 3

--- a/vlib/v/parser/tests/defer_return2.vv
+++ b/vlib/v/parser/tests/defer_return2.vv
@@ -1,0 +1,12 @@
+fn test1() int {
+	defer {
+		return 12
+	}
+	a := 3
+	return a
+}
+
+fn main() {
+	x := test1()
+	println(x)
+}

--- a/vlib/v/parser/tests/nested_defer.out
+++ b/vlib/v/parser/tests/nested_defer.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/nested_defer.vv:5:3: error: `defer` blocks cannot be nested
+    3 |     defer {
+    4 |         a = 12
+    5 |         defer {
+      |         ~~~~~
+    6 |             a = 13
+    7 |         }

--- a/vlib/v/parser/tests/nested_defer.vv
+++ b/vlib/v/parser/tests/nested_defer.vv
@@ -1,0 +1,14 @@
+fn test1() int {
+	mut a := 0
+	defer {
+		a = 12
+		defer {
+			a = 13
+		}
+	}
+	return a
+
+fn main() {
+	x := test1()
+	println(x)
+}

--- a/vlib/v/tests/nest_defer_fn_test.v
+++ b/vlib/v/tests/nest_defer_fn_test.v
@@ -1,0 +1,30 @@
+struct Fst {
+mut:
+	f fn() int
+}
+
+fn setfn(mut f Fst) {
+	mut i := 0
+	f.f = fn() int {
+		return 5
+	}
+	defer {
+		if i > 0 {
+			f.f = fn() int {
+				a := 0
+				defer {
+					assert a == 0
+				}
+				return 7
+			}
+		}
+	}
+	i = 1
+}
+
+fn test_nested_defer() {
+	mut g := Fst{}
+	setfn(mut g)
+	x := g.f()
+	assert x == 7
+}

--- a/vlib/v/tests/nest_defer_fn_test.v
+++ b/vlib/v/tests/nest_defer_fn_test.v
@@ -1,16 +1,16 @@
 struct Fst {
 mut:
-	f fn() int
+	f fn () int
 }
 
 fn setfn(mut f Fst) {
 	mut i := 0
-	f.f = fn() int {
+	f.f = fn () int {
 		return 5
 	}
 	defer {
 		if i > 0 {
-			f.f = fn() int {
+			f.f = fn () int {
 				a := 0
 				defer {
 					assert a == 0


### PR DESCRIPTION
A `defer` block is supposed to be executed *after* the return statement has been evaluated but *before* the function returns. For this reason it does not make sense to return from inside a `defer` block. (What about other `defer` blocks, what about the return value that has already been evaluated, ...). The same applies to error propagation, too. So this PR forbids the following:
```v
fn f() int {
    defer {
        return 7 // <- forbidden - `3` already evaluated as return value
    }
    return 3
}

fn g() ?int {
    defer {
        h() ? <- forbidden - `4` already evaluated
    }
    return 4
}
```
Furthermore this PR forbids nested `defer` blocks - with the exception that an anonymous function that is declared inside a `defer` block may have `defer` blocks itself:

```v
fn f() {
    defer {
        defer { // <- forbidden
            // ...
        }
    }
}

fn g() {
    // ...
    defer {
        f = fn () {
            defer { // <- allowed
                // ...
            }
        }
    }
}
```
This PR fixes #10265.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
