### PR TITLE
fmt: fix removal of selective imported type that is used as right of `is`

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2429,6 +2429,7 @@ pub fn (mut f Fmt) string_inter_literal(node ast.StringInterLiteral) {
 }
 
 pub fn (mut f Fmt) type_expr(node ast.TypeNode) {
+	f.mark_types_import_as_used(node.typ)
 	f.write(f.table.type_to_str_using_aliases(node.typ, f.mod2alias))
 }
 

--- a/vlib/v/fmt/tests/import_selective_expected.vv
+++ b/vlib/v/fmt/tests/import_selective_expected.vv
@@ -11,6 +11,7 @@ import mod {
 	InterfaceField,
 	InterfaceMethodArg,
 	InterfaceMethodRet,
+	RightOfIs,
 	StructEmbed,
 	StructField,
 	StructMethodArg,
@@ -34,6 +35,9 @@ interface Interface {
 }
 
 fn f(v FnArg) FnRet {
+	if v is RightOfIs {
+	}
+
 	return {}
 }
 

--- a/vlib/v/fmt/tests/import_selective_input.vv
+++ b/vlib/v/fmt/tests/import_selective_input.vv
@@ -19,6 +19,8 @@ import mod {
 
 	FnArg,
 	FnRet,
+
+	RightOfIs,
 }
 
 struct Struct {
@@ -37,6 +39,8 @@ interface Interface {
 }
 
 fn f(v FnArg) FnRet {
+	if v is RightOfIs {}
+
 	return {}
 }
 


### PR DESCRIPTION
On current master, `RightOfIs` will be removed. This PR fix it



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
