### PR TITLE
mssql: support orm create and drop table

### DIFF
--- a/vlib/mssql/config.v
+++ b/vlib/mssql/config.v
@@ -6,8 +6,15 @@ pub:
 	server string
 	uid    string
 	pwd    string
+	// if dbname empty, conn str will not contain Database info,
+	// and it is up to the server to choose which db to connect to.
+	dbname string 
 }
 
 pub fn (cfg Config) get_conn_str() string {
-	return 'Driver=$cfg.driver;Server=$cfg.server;UID=$cfg.uid;PWD=$cfg.pwd'
+	mut str := 'Driver=$cfg.driver;Server=$cfg.server;UID=$cfg.uid;PWD=$cfg.pwd'
+	if cfg.dbname != ""{
+		str += ';Database=${cfg.dbname}'
+	}
+	return str
 }

--- a/vlib/mssql/config.v
+++ b/vlib/mssql/config.v
@@ -8,13 +8,13 @@ pub:
 	pwd    string
 	// if dbname empty, conn str will not contain Database info,
 	// and it is up to the server to choose which db to connect to.
-	dbname string 
+	dbname string
 }
 
 pub fn (cfg Config) get_conn_str() string {
 	mut str := 'Driver=$cfg.driver;Server=$cfg.server;UID=$cfg.uid;PWD=$cfg.pwd'
-	if cfg.dbname != ""{
-		str += ';Database=${cfg.dbname}'
+	if cfg.dbname != '' {
+		str += ';Database=$cfg.dbname'
 	}
 	return str
 }

--- a/vlib/mssql/mssql.v
+++ b/vlib/mssql/mssql.v
@@ -113,8 +113,11 @@ fn extract_error(fnName string, handle C.SQLHANDLE, tp C.SQLSMALLINT) string {
 
 		// add driver error string
 		if ret == C.SQLRETURN(C.SQL_SUCCESS) || ret == C.SQLRETURN(C.SQL_SUCCESS_WITH_INFO) {
-			unsafe {
-				err_str += ':odbc=$(&sql_state[0]).vstring():$i:${int(native_error)}:$(&message_text[0]).vstring()\n'
+			unsafe{
+				state_str := (&sql_state[0]).vstring()
+				native_error_code := int(native_error)
+				txt_str := (&message_text[0]).vstring()
+				err_str += '\n\todbc=${state_str}:${i}:${native_error_code}:${txt_str}'
 			}
 		}
 	}

--- a/vlib/mssql/mssql.v
+++ b/vlib/mssql/mssql.v
@@ -113,11 +113,11 @@ fn extract_error(fnName string, handle C.SQLHANDLE, tp C.SQLSMALLINT) string {
 
 		// add driver error string
 		if ret == C.SQLRETURN(C.SQL_SUCCESS) || ret == C.SQLRETURN(C.SQL_SUCCESS_WITH_INFO) {
-			unsafe{
+			unsafe {
 				state_str := (&sql_state[0]).vstring()
 				native_error_code := int(native_error)
 				txt_str := (&message_text[0]).vstring()
-				err_str += '\n\todbc=${state_str}:${i}:${native_error_code}:${txt_str}'
+				err_str += '\n\todbc=$state_str:$i:$native_error_code:$txt_str'
 			}
 		}
 	}

--- a/vlib/v/gen/c/sql.v
+++ b/vlib/v/gen/c/sql.v
@@ -69,7 +69,7 @@ fn (mut g Gen) sql_create_table(node ast.SqlStmtLine, expr ast.Expr) {
 		.psql {
 			g.psql_create_table(node, typ, expr)
 		}
-		.mssql{
+		.mssql {
 			g.mssql_create_table(node, typ, expr)
 		}
 		else {
@@ -90,7 +90,7 @@ fn (mut g Gen) sql_drop_table(node ast.SqlStmtLine, expr ast.Expr) {
 		.psql {
 			g.psql_drop_table(node, typ, expr)
 		}
-		.mssql{
+		.mssql {
 			g.mssql_drop_table(node, typ, expr)
 		}
 		else {
@@ -144,7 +144,7 @@ fn (mut g Gen) sql_type_from_v(typ SqlType, v_typ ast.Type) string {
 		.psql {
 			return g.psql_get_table_type(v_typ)
 		}
-		.mssql{
+		.mssql {
 			return g.mssql_get_table_type(v_typ)
 		}
 		else {
@@ -1158,7 +1158,8 @@ fn (mut g Gen) mssql_create_table(node ast.SqlStmtLine, typ SqlType, db_expr ast
 fn (mut g Gen) mssql_drop_table(node ast.SqlStmtLine, typ SqlType, db_expr ast.Expr) {
 	table_name := g.get_table_name(node.table_expr)
 	g.writeln('// mssql table drop')
-	drop_string := 'DROP TABLE \\"$table_name\\";'
+	lit := '\\"'
+	drop_string := 'DROP TABLE $lit$table_name$lit;'
 	tmp := g.new_tmp_var()
 	g.write('Option_mssql__Result $tmp = mssql__Connection_query(&')
 	g.expr(db_expr)
@@ -1410,7 +1411,7 @@ fn (mut g Gen) table_gen(node ast.SqlStmtLine, typ SqlType, expr ast.Expr) strin
 	}
 
 	mut create_string := 'CREATE TABLE IF NOT EXISTS $lit$table_name$lit ('
-	if typ == .mssql{ 
+	if typ == .mssql {
 		// mssql detecting create if not exist is awkward
 		create_string = 'IF NOT EXISTS (SELECT * FROM sysobjects WHERE name=\'$table_name\' and xtype=\'U\') CREATE TABLE $lit$table_name$lit ('
 	}


### PR DESCRIPTION
ORM create and drop table are working for mssql
The below code works.
```
        db.connect("conn str") ?

	sql db {
    	         create table Person
	}

	sql db {
		drop table Person
	}
```

`Select` will be supported in upcoming PRs.

Tag issue: https://github.com/vlang/v/issues/8690