### PR TITLE
cgen: fix c error by use of fn type that have alias type argument

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -822,9 +822,6 @@ static inline void __${typ.cname}_pushval($typ.cname ch, $el_stype val) {
 			.map {
 				g.type_definitions.writeln('typedef map $typ.cname;')
 			}
-			.function {
-				g.write_fn_typesymbol_declaration(typ)
-			}
 			else {
 				continue
 			}
@@ -833,6 +830,11 @@ static inline void __${typ.cname}_pushval($typ.cname ch, $el_stype val) {
 	for typ in g.table.type_symbols {
 		if typ.kind == .alias && typ.name !in c.builtins {
 			g.write_alias_typesymbol_declaration(typ)
+		}
+	}
+	for typ in g.table.type_symbols {
+		if typ.kind == .function && typ.name !in c.builtins {
+			g.write_fn_typesymbol_declaration(typ)
 		}
 	}
 	// Generating interfaces after all the common types have been defined

--- a/vlib/v/tests/fn_test.v
+++ b/vlib/v/tests/fn_test.v
@@ -30,6 +30,7 @@ fn foobar()
 
 fn slopediv(num u32, den u32) int
 
+
 type F1 = fn ()
 
 type F2 = fn (voidptr)
@@ -43,6 +44,9 @@ type F5 = fn (int, int) int
 type F6 = fn (int, int)
 
 type F7 = fn (time.Time, int)
+
+type MyTime = time.Time
+type F8 = fn (MyTime)
 
 fn C.atoi(&byte) int
 fn C.freec(ptr voidptr)

--- a/vlib/v/tests/fn_test.v
+++ b/vlib/v/tests/fn_test.v
@@ -30,7 +30,6 @@ fn foobar()
 
 fn slopediv(num u32, den u32) int
 
-
 type F1 = fn ()
 
 type F2 = fn (voidptr)


### PR DESCRIPTION
On current master, test added by this PR will fail like this.

```
==================
/tmp/v/fn_test.7110901478057742328.tmp.c:1022:26: error: a parameter list without types is only allowed in a function definition
typedef void (*main__F8)(main__MyTime);
                         ^
1 error generated.
...
==================
(Use `v -cg` to print the entire error message)

builder error:
==================
C error. This should never happen.
```

This PR fix this problem

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
