### PR TITLE
parser: fix required function members in struct

### DIFF
--- a/vlib/v/checker/tests/struct_required_fn_field.out
+++ b/vlib/v/checker/tests/struct_required_fn_field.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/struct_required_fn_field.vv:12:6: error: field `Abc.f3` must be initialized
+   10 |         f3: fn () {}
+   11 |     }
+   12 |     _ = Abc{
+      |         ~~~~
+   13 |         f1: 123
+   14 |         f2: 789

--- a/vlib/v/checker/tests/struct_required_fn_field.vv
+++ b/vlib/v/checker/tests/struct_required_fn_field.vv
@@ -1,7 +1,7 @@
 struct Abc {
 	f1 int [required]
 	f2 int
-	f3 fn () [required]
+	f3 fn () [attr1; required; attr2]
 }
 
 fn main() {

--- a/vlib/v/checker/tests/struct_required_fn_field.vv
+++ b/vlib/v/checker/tests/struct_required_fn_field.vv
@@ -1,0 +1,16 @@
+struct Abc {
+	f1 int [required]
+	f2 int
+	f3 fn () [required]
+}
+
+fn main() {
+	_ = Abc{
+		f1: 123
+		f3: fn () {}
+	}
+	_ = Abc{
+		f1: 123
+		f2: 789
+	}
+}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -212,7 +212,6 @@ pub fn (mut p Parser) parse_fn_type(name string) ast.Type {
 	}
 	mut return_type := ast.void_type
 	mut return_type_pos := token.Position{}
-
 	if p.tok.line_nr == line_nr && p.tok.kind.is_start_of_type() && !p.is_attributes() {
 		return_type_pos = p.tok.position()
 		return_type = p.parse_type()

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -212,7 +212,10 @@ pub fn (mut p Parser) parse_fn_type(name string) ast.Type {
 	}
 	mut return_type := ast.void_type
 	mut return_type_pos := token.Position{}
-	if p.tok.line_nr == line_nr && p.tok.kind.is_start_of_type() {
+
+	// don't confuse required attribute: struct{ f fn () [required] }
+	if p.tok.line_nr == line_nr && p.tok.kind.is_start_of_type()
+		&& (p.tok.kind != .lsbr || p.peek_tok.lit != 'required') {
 		return_type_pos = p.tok.position()
 		return_type = p.parse_type()
 		if return_type.has_flag(.generic) {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -213,9 +213,7 @@ pub fn (mut p Parser) parse_fn_type(name string) ast.Type {
 	mut return_type := ast.void_type
 	mut return_type_pos := token.Position{}
 
-	// don't confuse required attribute: struct{ f fn () [required] }
-	if p.tok.line_nr == line_nr && p.tok.kind.is_start_of_type()
-		&& (p.tok.kind != .lsbr || p.peek_tok.lit != 'required') {
+	if p.tok.line_nr == line_nr && p.tok.kind.is_start_of_type() && !p.is_attributes() {
 		return_type_pos = p.tok.position()
 		return_type = p.parse_type()
 		if return_type.has_flag(.generic) {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1460,6 +1460,28 @@ fn (mut p Parser) expr_list() ([]ast.Expr, []ast.Comment) {
 	return exprs, comments
 }
 
+fn (mut p Parser) is_attributes() bool {
+	if p.tok.kind != .lsbr {
+		return false
+	}
+	mut i := 0
+	for {
+		tok := p.peek_token(i)
+		if tok.kind == .eof || tok.line_nr != p.tok.line_nr {
+			return false
+		}
+		if tok.kind == .rsbr {
+			break
+		}
+		i++
+	}
+	peek_rsbr_tok := p.peek_token(i + 1)
+	if peek_rsbr_tok.line_nr == p.tok.line_nr && peek_rsbr_tok.kind != .rcbr {
+		return false
+	}
+	return true
+}
+
 // when is_top_stmt is true attrs are added to p.attrs
 fn (mut p Parser) attributes() {
 	p.check(.lsbr)

--- a/vlib/v/tests/struct_fields_storing_required_functions_test.v
+++ b/vlib/v/tests/struct_fields_storing_required_functions_test.v
@@ -1,0 +1,14 @@
+struct Struct {
+	f fn () [required]
+}
+
+fn func() {
+}
+
+fn test_struct_fields_storing_required_functions() {
+	s := Struct{
+		f: func
+	}
+
+	assert s.f == func
+}

--- a/vlib/v/tests/struct_fields_storing_required_functions_test.v
+++ b/vlib/v/tests/struct_fields_storing_required_functions_test.v
@@ -1,5 +1,6 @@
 struct Struct {
-	f fn () [required]
+	f1 fn () [required]
+	f2 fn () [attr1; required]
 }
 
 fn func() {
@@ -7,8 +8,10 @@ fn func() {
 
 fn test_struct_fields_storing_required_functions() {
 	s := Struct{
-		f: func
+		f1: func
+		f2: func
 	}
 
-	assert s.f == func
+	assert s.f1 == func
+	assert s.f2 == func
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

fixes #10290

I first implemented a simpler way in https://github.com/vlang/v/pull/10299/commits/20b1fdd2538fec57b0fa5b2dca15fb8a1830b33c but realized that it's not covering all edge cases like 

```v
struct Struct {
 	f fn () [custom_attr; required]
}
```
or
```v
const required = 12

struct Struct {
	f fn () [required]int
}
```

Also filed #10320 for the above example.

I've also considered to use something like `(p.tok.kind != .lsbr || p.peek_tok.kind == .rsbr)` in https://github.com/vlang/v/pull/10299#discussion_r643130504 but for and example like:

```v
struct Struct {
 	f fn () [12]int
 }

 fn main() {
 	s := Struct{
 	}
	
	println(s)
 }
```
I'm getting
```
m.v:2:12: error: unexpected number `12`, expecting name
    1 | struct Struct {
    2 |      f fn () [12]int
      |               ~~
    3 |  }
    4 |
```
Which is very confusing and not user friendly so, I moved forward with implementing is_attributes.