### PR TITLE
OpenBSD: support Boehm-GC, X11 and Sqlite

### DIFF
--- a/vlib/builtin/builtin_d_gcboehm.v
+++ b/vlib/builtin/builtin_d_gcboehm.v
@@ -8,18 +8,26 @@ $if static_boehm ? {
 		#flag   $first_existing("/opt/homebrew/lib/libgc.a", "/usr/local/lib/libgc.a")
 	} $else $if linux {
 		#flag -l:libgc.a
+	} $else $if openbsd {
+		#flag -I/usr/local/include
+		#flag /usr/local/lib/libgc.a
+		#flag -lpthread
 	} $else {
 		#flag -lgc
 	}
 } $else {
 	$if macos {
 		#pkgconfig bdw-gc
-	}
-	$if windows {
+	} $else $if windows {
 		#flag -I@VEXEROOT/thirdparty/libgc/include
 		#flag -L@VEXEROOT/thirdparty/libgc
+	} $else $if openbsd {
+		#flag -I/usr/local/include
+		#flag -L/usr/local/lib
+		#flag -lgc
+	} $else {
+		#flag -lgc
 	}
-	#flag -lgc
 }
 
 $if gcboehm_leak ? {

--- a/vlib/builtin/builtin_d_gcboehm.v
+++ b/vlib/builtin/builtin_d_gcboehm.v
@@ -18,13 +18,13 @@ $if static_boehm ? {
 } $else {
 	$if macos {
 		#pkgconfig bdw-gc
-	} $else $if windows {
-		#flag -I@VEXEROOT/thirdparty/libgc/include
-		#flag -L@VEXEROOT/thirdparty/libgc
-	} $else $if openbsd {
+	} $else $if openbsd || freebsd {
 		#flag -I/usr/local/include
 		#flag -L/usr/local/lib
-		#flag -lgc
+	}
+	$if windows {
+		#flag -I@VEXEROOT/thirdparty/libgc/include
+		#flag -L@VEXEROOT/thirdparty/libgc
 	} $else {
 		#flag -lgc
 	}

--- a/vlib/builtin/builtin_nix.c.v
+++ b/vlib/builtin/builtin_nix.c.v
@@ -85,7 +85,7 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 	$if no_backtrace ? {
 		return false
 	} $else {
-		$if !freestanding {
+		$if linux && !freestanding {
 			$if tinyc {
 				C.tcc_backtrace(c'Backtrace')
 				return false

--- a/vlib/clipboard/x11/clipboard.c.v
+++ b/vlib/clipboard/x11/clipboard.c.v
@@ -6,9 +6,15 @@ import time
 import sync
 import math
 
+$if freebsd {
+	#flag -I/usr/local/include
+	#flag -L/usr/local/lib
+} $else $if openbsd {
+	#flag -I/usr/X11R6/include
+	#flag -L/usr/X11R6/lib
+}
 #flag -lX11
-#flag freebsd -I/usr/local/include
-#flag freebsd -L/usr/local/lib -lX11
+
 #include <X11/Xlib.h> # Please install a package with the X11 development headers, for example: `apt-get install libx11-dev`
 // X11
 [typedef]

--- a/vlib/sqlite/sqlite.v
+++ b/vlib/sqlite/sqlite.v
@@ -1,17 +1,19 @@
 module sqlite
 
-#flag darwin  -lsqlite3
-#flag linux   -lsqlite3
-#flag solaris -lsqlite3
-#flag freebsd -I/usr/local/include
-#flag freebsd -Wl -L/usr/local/lib -lsqlite3
-#flag windows -I@VEXEROOT/thirdparty/sqlite
-#flag windows -L@VEXEROOT/thirdparty/sqlite
-#flag windows @VEXEROOT/thirdparty/sqlite/sqlite3.o
-// #flag linux -I @VEXEROOT/thirdparty/sqlite
-// #flag @VEXEROOT/thirdparty/sqlite/sqlite.c
+$if freebsd || openbsd {
+	#flag -I/usr/local/include
+	#flag -L/usr/local/lib
+}
+$if windows {
+	#flag windows -I@VEXEROOT/thirdparty/sqlite
+	#flag windows -L@VEXEROOT/thirdparty/sqlite
+	#flag windows @VEXEROOT/thirdparty/sqlite/sqlite3.o
+} $else {
+	#flag -lsqlite3
+}
+
 #include "sqlite3.h"
-//
+
 struct C.sqlite3 {
 }
 


### PR DESCRIPTION
This fixes a build problem with `-gc boehm` on OpenBSD that was cause by a call to `backtrace_symbols()`. The call was actually never done but the function was referenced thus causing the linker to fail.
This PR hides the call for non-Linux systems. (An alternative would have been to add `-lexecinfo` to the C flags but that would have added an unused shared library.)
I've also adjusted the include and library paths for X11 and sqlite3, so `vlib/clipboard/clipboard_test.v` and `vlib/sqlite/sqlite_test.v` now pass on OpenBSD.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
