### PR TITLE
tools: uname -o doesnt exist in macOS, checking for a file is fine

### DIFF
--- a/cmd/tools/vsymlink.v
+++ b/cmd/tools/vsymlink.v
@@ -24,7 +24,7 @@ fn cleanup_vtmp_folder() {
 
 fn setup_symlink_unix(vexe string) {
 	mut link_path := '/data/data/com.termux/files/usr/bin/v'
-	if !os.exists('/data/data/com.termux/files/usr/bin/bash') {
+	if !os.is_dir('/data/data/com.termux/files') {
 		link_dir := '/usr/local/bin'
 		if !os.exists(link_dir) {
 			os.mkdir_all(link_dir) or { panic(err) }

--- a/cmd/tools/vsymlink.v
+++ b/cmd/tools/vsymlink.v
@@ -24,7 +24,7 @@ fn cleanup_vtmp_folder() {
 
 fn setup_symlink_unix(vexe string) {
 	mut link_path := '/data/data/com.termux/files/usr/bin/v'
-	if os.system("uname -o | grep -q '[A/a]ndroid'") == 1 {
+	if !os.exists('/data/data/com.termux/files/usr/bin/bash') {
 		link_dir := '/usr/local/bin'
 		if !os.exists(link_dir) {
 			os.mkdir_all(link_dir) or { panic(err) }


### PR DESCRIPTION
```
$ make install
Please use `sudo v symlink` instead.

$ sudo ./v symlink
uname: illegal option -- o
usage: uname [-amnprsv]
Symlink "/usr/local/bin/v" has been created

$ uname -o
uname: illegal option -- o
usage: uname [-amnprsv]

$
```