### PR TITLE
cgen: fix or_block in for declaration (fix #9721)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5906,6 +5906,9 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 			g.indent--
 		} else {
 			g.stmts(stmts)
+			if stmts.len > 0 && stmts[or_block.stmts.len - 1] is ast.ExprStmt {
+				g.writeln(';')
+			}
 		}
 	} else if or_block.kind == .propagate {
 		if g.file.mod.name == 'main' && (isnil(g.fn_decl) || g.fn_decl.is_main) {
@@ -5936,7 +5939,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 			}
 		}
 	}
-	g.write('}')
+	g.writeln('}')
 }
 
 // `a in [1,2,3]` => `a == 1 || a == 2 || a == 3`

--- a/vlib/v/tests/for_in_optional_test.v
+++ b/vlib/v/tests/for_in_optional_test.v
@@ -1,0 +1,8 @@
+import os
+
+fn test_for_in_optional() {
+	for d in os.read_lines(@FILE) or { panic('not found') } {
+		println(d)
+	}
+	assert true
+}


### PR DESCRIPTION
This PR fix or_block in for declaration (fix #9721).

- Fix or_block in for declaration.
- Add test.

```vlang
import os

fn main() {
	for d in os.read_lines(@FILE) or { panic('not found') } {
		println(d)
	}
}

PS D:\Test\v\tt1> v run .
import os

fn main() {
        for d in os.read_lines(@FILE) or { panic('not found') } {
                println(d)
        }
}
```