### PR TITLE
module: fix bug with submodule import

### DIFF
--- a/examples/submodule/main.v
+++ b/examples/submodule/main.v
@@ -2,6 +2,6 @@ import mymodules { add_xy }
 import mymodules.submodule { sub_xy }
 
 fn main() {
-    println(add_xy(2, 3)) // expected: 5
-    println(sub_xy(10, 7)) // expected: 3
+	println(add_xy(2, 3)) // expected: 5
+	println(sub_xy(10, 7)) // expected: 3
 }

--- a/examples/submodule/main.v
+++ b/examples/submodule/main.v
@@ -1,0 +1,7 @@
+import mymodules { add_xy }
+import mymodules.submodule { sub_xy }
+
+fn main() {
+    println(add_xy(2, 3)) // expected: 5
+    println(sub_xy(10, 7)) // expected: 3
+}

--- a/examples/submodule/mymodules/main_functions.v
+++ b/examples/submodule/mymodules/main_functions.v
@@ -1,0 +1,4 @@
+module mymodule
+pub fn add_xy(x int, y int) int {
+    return x + y
+}

--- a/examples/submodule/mymodules/main_functions.v
+++ b/examples/submodule/mymodules/main_functions.v
@@ -1,4 +1,5 @@
 module mymodule
+
 pub fn add_xy(x int, y int) int {
-    return x + y
+	return x + y
 }

--- a/examples/submodule/mymodules/submodule/sub_functions.v
+++ b/examples/submodule/mymodules/submodule/sub_functions.v
@@ -1,4 +1,5 @@
 module submodule
+
 pub fn sub_xy(x int, y int) int {
-    return x - y
+	return x - y
 }

--- a/examples/submodule/mymodules/submodule/sub_functions.v
+++ b/examples/submodule/mymodules/submodule/sub_functions.v
@@ -1,0 +1,4 @@
+module submodule
+pub fn sub_xy(x int, y int) int {
+    return x - y
+}

--- a/vlib/v/util/module.v
+++ b/vlib/v/util/module.v
@@ -110,7 +110,7 @@ pub fn mod_path_to_full_name(pref &pref.Preferences, mod string, path string) ?s
 			}
 		}
 	}
-	if os.is_abs_path(pref.path) && os.is_abs_path(path) && os.is_dir(path) //&& path.contains(mod) {
+	if os.is_abs_path(pref.path) && os.is_abs_path(path) && os.is_dir(path) { // && path.contains(mod )
 		rel_mod_path := path.replace(pref.path.all_before_last(os.path_separator) +
 			os.path_separator, '')
 		if rel_mod_path != path {

--- a/vlib/v/util/module.v
+++ b/vlib/v/util/module.v
@@ -110,8 +110,9 @@ pub fn mod_path_to_full_name(pref &pref.Preferences, mod string, path string) ?s
 			}
 		}
 	}
-	if os.is_abs_path(pref.path) && os.is_abs_path(path) && os.is_dir(path)/* && path.contains(mod)*/ {
-		rel_mod_path := path.replace(pref.path.all_before_last(os.path_separator) + os.path_separator, '')
+	if os.is_abs_path(pref.path) && os.is_abs_path(path) && os.is_dir(path) //&& path.contains(mod) {
+		rel_mod_path := path.replace(pref.path.all_before_last(os.path_separator) +
+			os.path_separator, '')
 		if rel_mod_path != path {
 			full_mod_name := rel_mod_path.replace(os.path_separator, '.')
 			return full_mod_name

--- a/vlib/v/util/module.v
+++ b/vlib/v/util/module.v
@@ -32,7 +32,7 @@ pub fn qualify_module(pref &pref.Preferences, mod string, file_path string) stri
 	if mod == 'main' {
 		return mod
 	}
-	clean_file_path := file_path.all_before_last('/')
+	clean_file_path := file_path.all_before_last(os.path_separator)
 	// relative module (relative to working directory)
 	// TODO: find most stable solution & test with -usecache
 	if clean_file_path.replace(os.getwd() + os.path_separator, '') == mod {
@@ -109,6 +109,13 @@ pub fn mod_path_to_full_name(pref &pref.Preferences, mod string, path string) ?s
 				}
 			}
 		}
+	}
+	// Path to project directory (pref.path)
+	if os.is_abs_path(pref.path) && os.is_abs_path(path) && path.contains(mod) {
+		rel_module_path := path.replace(pref.path.all_before_last(os.path_separator) + os.path_separator, '')
+		full_mod_name := rel_module_path.replace(os.path_separator, '.')
+		//println("~~~ $full_mod_name ~~~")
+		return full_mod_name
 	}
 	return error('module not found')
 }

--- a/vlib/v/util/module.v
+++ b/vlib/v/util/module.v
@@ -111,10 +111,11 @@ pub fn mod_path_to_full_name(pref &pref.Preferences, mod string, path string) ?s
 		}
 	}
 	// Path to project directory (pref.path)
-	if os.is_abs_path(pref.path) && os.is_abs_path(path) && path.contains(mod) {
-		rel_module_path := path.replace(pref.path.all_before_last(os.path_separator) + os.path_separator, '')
-		full_mod_name := rel_module_path.replace(os.path_separator, '.')
-		//println("~~~ $full_mod_name ~~~")
+	if os.is_abs_path(pref.path) && os.is_abs_path(path) && os.is_dir(path) && path.contains(mod) {
+		rel_mod_path := path.replace(pref.path.all_before_last(os.path_separator) +
+			os.path_separator, '')
+		full_mod_name := rel_mod_path.replace(os.path_separator, '.')
+		// println("~~~ $full_mod_name ~~~")
 		return full_mod_name
 	}
 	return error('module not found')

--- a/vlib/v/util/module.v
+++ b/vlib/v/util/module.v
@@ -110,13 +110,12 @@ pub fn mod_path_to_full_name(pref &pref.Preferences, mod string, path string) ?s
 			}
 		}
 	}
-	// Path to project directory (pref.path)
-	if os.is_abs_path(pref.path) && os.is_abs_path(path) && os.is_dir(path) && path.contains(mod) {
-		rel_mod_path := path.replace(pref.path.all_before_last(os.path_separator) +
-			os.path_separator, '')
-		full_mod_name := rel_mod_path.replace(os.path_separator, '.')
-		// println("~~~ $full_mod_name ~~~")
-		return full_mod_name
+	if os.is_abs_path(pref.path) && os.is_abs_path(path) && os.is_dir(path)/* && path.contains(mod)*/ {
+		rel_mod_path := path.replace(pref.path.all_before_last(os.path_separator) + os.path_separator, '')
+		if rel_mod_path != path {
+			full_mod_name := rel_mod_path.replace(os.path_separator, '.')
+			return full_mod_name
+		}
 	}
 	return error('module not found')
 }


### PR DESCRIPTION
fixed full module name (for `ast.Module.name` [#L2600](https://github.com/vlang/v/blob/d39a55ac11861b2b034f971edfab4708c6b6d01f/vlib/v/parser/parser.v#L2600))

fixed path separator

fix #10211