### PR TITLE
parser, checker: check assert optional (fix #10202)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4064,7 +4064,7 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 fn (mut c Checker) assert_stmt(node ast.AssertStmt) {
 	cur_exp_typ := c.expected_type
 	assert_type := c.check_expr_opt_call(node.expr, c.expr(node.expr))
-	if assert_type != ast.bool_type_idx && assert_type != ast.void_type_idx {
+	if assert_type != ast.bool_type_idx {
 		atype_name := c.table.get_type_symbol(assert_type).name
 		c.error('assert can be used only with `bool` expressions, but found `$atype_name` instead',
 			node.pos)

--- a/vlib/v/checker/tests/assert_optional_err.out
+++ b/vlib/v/checker/tests/assert_optional_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/assert_optional_err.vv:4:9: error: assert can be used only with `bool` expressions, but found `void` instead
+    2 |
+    3 | fn main(){
+    4 |     assert os.truncate("testfile.txt", 6666) or { panic(err) }
+      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5 | }

--- a/vlib/v/checker/tests/assert_optional_err.vv
+++ b/vlib/v/checker/tests/assert_optional_err.vv
@@ -1,0 +1,5 @@
+import os
+
+fn main(){
+	assert os.truncate("testfile.txt", 6666) or { panic(err) }
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -685,7 +685,7 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 			pos.update_last_line(p.prev_tok.line_nr)
 			return ast.AssertStmt{
 				expr: expr
-				pos: pos
+				pos: pos.extend(p.tok.position())
 				is_used: p.inside_test_file || !p.pref.is_prod
 			}
 		}


### PR DESCRIPTION
This PR check assert optional (fix #10202).

- Check assert optional.
- Fix expr position.
- Add test.

```vlang
import os

fn main(){
   assert os.truncate("testfile.txt", 6666) or { panic(err) }
}

PS D:\Test\v\tt1> v run .
.\tt1.v:4:11: error: assert can be used only with `bool` expressions, but found `void` instead
    2 |
    3 | fn main(){
    4 |    assert os.truncate("testfile.txt", 6666) or { panic(err) }
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    5 | }
```