### PR TITLE
net: use custom error for invalid headers

### DIFF
--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -566,11 +566,24 @@ fn (mut h Header) add_key(key string) {
 	}
 }
 
+// Custom error struct for invalid header tokens
+struct HeaderKeyError {
+	msg string
+	code int
+	header string
+	invalid_char byte
+}
+
 // Checks if the header token is valid
 fn is_valid(header string) ? {
 	for _, c in header {
 		if int(c) >= 128 || !is_token(c) {
-			return error('Invalid header key')
+			return IError(HeaderKeyError{
+				msg: "Invalid header key: '$header'"
+				code: 1
+				header: header
+				invalid_char: c
+			})
 		}
 	}
 }

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -291,7 +291,7 @@ pub fn parse_response(resp string) Response {
 		pos := h.index(':') or { continue }
 		mut key := h[..pos]
 		val := h[pos + 2..].trim_space()
-		header.add_custom(key, val) or { eprintln('error parsing header: $err') }
+		header.add_custom(key, val) or { eprintln('$err; skipping header') }
 	}
 	// set cookies
 	for cookie in header.values(.set_cookie) {


### PR DESCRIPTION
Also make it clear that the header is being skipped in `http.parse_response`.