### PR TITLE
http: Refactor Response struct and add a render method

### DIFF
--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -411,8 +411,8 @@ fn get_installed_modules() []string {
 fn get_all_modules() []string {
 	url := get_working_server_url()
 	r := http.get(url) or { panic(err) }
-	if r.status_code != 200 {
-		println('Failed to search vpm.vlang.io. Status code: $r.status_code')
+	if r.status_code != .ok {
+		println('Failed to search vpm.vlang.io. Status code: ${int(r.status_code)}')
 		exit(1)
 	}
 	s := r.text
@@ -544,12 +544,12 @@ fn get_module_meta_info(name string) ?Mod {
 			errors << 'Error details: $err'
 			continue
 		}
-		if r.status_code == 404 || r.text.trim_space() == '404' {
+		if r.status_code == .not_found || r.text.trim_space() == '404' {
 			errors << 'Skipping module "$name", since $server_url reported that "$name" does not exist.'
 			continue
 		}
-		if r.status_code != 200 {
-			errors << 'Skipping module "$name", since $server_url responded with $r.status_code http status code. Please try again later.'
+		if r.status_code != .ok {
+			errors << 'Skipping module "$name", since $server_url responded with ${int(r.status_code)} http status code. Please try again later.'
 			continue
 		}
 		s := r.text

--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -590,7 +590,7 @@ pub fn (h Header) str() string {
 }
 
 pub fn (h Header) clone() Header {
-	return Header {
+	return Header{
 		data: h.data.clone()
 		keys: h.keys.clone()
 	}

--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -588,3 +588,10 @@ fn is_token(b byte) bool {
 pub fn (h Header) str() string {
 	return h.render(version: .v1_1)
 }
+
+pub fn (h Header) clone() Header {
+	return Header {
+		data: h.data.clone()
+		keys: h.keys.clone()
+	}
+}

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -64,7 +64,7 @@ pub fn get(url string) ?Response {
 pub fn post(url string, data string) ?Response {
 	return fetch_with_method(.post, url,
 		data: data
-		header: new_header({key: .content_type, value: http.content_type_default})
+		header: new_header(key: .content_type, value: http.content_type_default)
 	)
 }
 
@@ -72,14 +72,14 @@ pub fn post(url string, data string) ?Response {
 pub fn post_json(url string, data string) ?Response {
 	return fetch_with_method(.post, url,
 		data: data
-		header: new_header({key: .content_type, value: 'application/json'})
+		header: new_header(key: .content_type, value: 'application/json')
 	)
 }
 
 // post_form sends a POST HTTP request to the URL with X-WWW-FORM-URLENCODED data
 pub fn post_form(url string, data map[string]string) ?Response {
 	return fetch_with_method(.post, url,
-		header: new_header({key: .content_type, value: 'application/x-www-form-urlencoded'})
+		header: new_header(key: .content_type, value: 'application/x-www-form-urlencoded')
 		data: url_encode_form_data(data)
 	)
 }
@@ -88,7 +88,7 @@ pub fn post_form(url string, data map[string]string) ?Response {
 pub fn put(url string, data string) ?Response {
 	return fetch_with_method(.put, url,
 		data: data
-		header: new_header({key: .content_type, value: http.content_type_default})
+		header: new_header(key: .content_type, value: http.content_type_default)
 	)
 }
 
@@ -96,7 +96,7 @@ pub fn put(url string, data string) ?Response {
 pub fn patch(url string, data string) ?Response {
 	return fetch_with_method(.patch, url,
 		data: data
-		header: new_header({key: .content_type, value: http.content_type_default})
+		header: new_header(key: .content_type, value: http.content_type_default)
 	)
 }
 
@@ -200,7 +200,9 @@ pub fn (req &Request) do() ?Response {
 		}
 		qresp := req.method_and_url_to_response(req.method, rurl) ?
 		resp = qresp
-		if resp.status_code !in [.moved_permanently, .found, .see_other, .temporary_redirect, .permanent_redirect] {
+		if resp.status_code !in [.moved_permanently, .found, .see_other, .temporary_redirect,
+			.permanent_redirect,
+		] {
 			break
 		}
 		// follow any redirects

--- a/vlib/net/http/http_httpbin_test.v
+++ b/vlib/net/http/http_httpbin_test.v
@@ -37,7 +37,7 @@ fn test_http_fetch_bare() {
 		panic(err)
 	}
 	for response in responses {
-		assert response.status_code == 200
+		assert response.status_code == .ok
 	}
 }
 
@@ -70,7 +70,7 @@ fn test_http_fetch_with_params() {
 		// payload := json.decode(HttpbinResponseBody,response.text) or {
 		// panic(err)
 		// }
-		assert response.status_code == 200
+		assert response.status_code == .ok
 		// TODO
 		// assert payload.args['a'] == 'b'
 		// assert payload.args['c'] == 'd'
@@ -90,7 +90,7 @@ fn test_http_fetch_with_headers() ? {
 		// payload := json.decode(HttpbinResponseBody,response.text) or {
 		// panic(err)
 		// }
-		assert response.status_code == 200
+		assert response.status_code == .ok
 		// TODO
 		// assert payload.headers['Test-Header'] == 'hello world'
 	}

--- a/vlib/net/http/http_test.v
+++ b/vlib/net/http/http_test.v
@@ -18,7 +18,7 @@ fn test_http_get_from_vlang_utc_now() {
 		res := http.get(url) or {
 			panic(err)
 		}
-		assert 200 == res.status_code
+		assert .ok == res.status_code
 		assert res.text.len > 0
 		assert res.text.int() > 1566403696
 		println('Current time is: $res.text.int()')
@@ -42,7 +42,7 @@ fn test_public_servers() {
 		res := http.get(url) or {
 			panic(err)
 		}
-		assert 200 == res.status_code
+		assert .ok == res.status_code
 		assert res.text.len > 0
 	}
 }
@@ -56,7 +56,7 @@ fn test_relative_redirects() {
 	res := http.get('https://httpbin.org/relative-redirect/3?abc=xyz') or {
 		panic(err)
 	}
-	assert 200 == res.status_code
+	assert .ok == res.status_code
 	assert res.text.len > 0
 	assert res.text.contains('"abc": "xyz"')
 }

--- a/vlib/net/http/http_test.v
+++ b/vlib/net/http/http_test.v
@@ -18,7 +18,7 @@ fn test_http_get_from_vlang_utc_now() {
 		res := http.get(url) or {
 			panic(err)
 		}
-		assert .ok == res.status_code
+		assert res.status_code == .ok
 		assert res.text.len > 0
 		assert res.text.int() > 1566403696
 		println('Current time is: $res.text.int()')
@@ -42,7 +42,7 @@ fn test_public_servers() {
 		res := http.get(url) or {
 			panic(err)
 		}
-		assert .ok == res.status_code
+		assert res.status_code == .ok
 		assert res.text.len > 0
 	}
 }
@@ -56,7 +56,7 @@ fn test_relative_redirects() {
 	res := http.get('https://httpbin.org/relative-redirect/3?abc=xyz') or {
 		panic(err)
 	}
-	assert .ok == res.status_code
+	assert res.status_code == .ok
 	assert res.text.len > 0
 	assert res.text.contains('"abc": "xyz"')
 }

--- a/vlib/net/http/response.v
+++ b/vlib/net/http/response.v
@@ -8,6 +8,7 @@ pub struct Response {
 pub:
 	text         string
 	header       Header
+	// TODO: use Cookie struct
 	cookies      map[string]string
 	status_code  Status
 	http_version Version
@@ -15,6 +16,21 @@ pub:
 
 fn (mut resp Response) free() {
 	unsafe { resp.header.data.free() }
+}
+
+// Format response as an HTTP response message
+pub fn (resp Response) render() string {
+	status_code := int(resp.status_code)
+	status_msg := resp.status_code.str()
+	// add cookie to the header if not already there
+	mut header := resp.header.clone()
+	for cookie, value in resp.cookies {
+		s := '$cookie=$value'
+		if !header.values(.set_cookie).contains(s) {
+			header.add(.set_cookie, s)
+		}
+	}
+	return '$resp.http_version $status_code $status_msg\n\r${header.render(version: resp.http_version)}\n\r$resp.text'
 }
 
 // TODO: return result?

--- a/vlib/net/http/response.v
+++ b/vlib/net/http/response.v
@@ -1,0 +1,64 @@
+module http
+import net.http.chunked
+
+// Response represents the result of the request
+pub struct Response {
+pub:
+	text        string
+	header      Header
+	cookies     map[string]string
+	status_code Status
+}
+
+fn (mut resp Response) free() {
+	unsafe { resp.header.data.free() }
+}
+
+pub fn parse_response(resp string) Response {
+	mut header := new_header()
+	// TODO: Cookie data type
+	mut cookies := map[string]string{}
+	first_header := resp.all_before('\n')
+	mut status_code := 0
+	if first_header.contains('HTTP/') {
+		val := first_header.find_between(' ', ' ')
+		status_code = val.int()
+	}
+	mut text := ''
+	// Build resp header map and separate the body
+	mut nl_pos := 3
+	mut i := 1
+	for {
+		old_pos := nl_pos
+		nl_pos = resp.index_after('\n', nl_pos + 1)
+		if nl_pos == -1 {
+			break
+		}
+		h := resp[old_pos + 1..nl_pos]
+		// End of headers
+		if h.len <= 1 {
+			text = resp[nl_pos + 1..]
+			break
+		}
+		i++
+		pos := h.index(':') or { continue }
+		mut key := h[..pos]
+		val := h[pos + 2..].trim_space()
+		header.add_custom(key, val) or { eprintln('error parsing header: $err') }
+	}
+	// set cookies
+	for cookie in header.values(.set_cookie) {
+		parts := cookie.split_nth('=', 2)
+		cookies[parts[0]] = parts[1]
+	}
+	if header.get(.transfer_encoding) or { '' } == 'chunked' || header.get(.content_length) or { '' } == '' {
+		text = chunked.decode(text)
+	}
+	return Response{
+		status_code: status_from_int(status_code)
+		header: header
+		cookies: cookies
+		text: text
+	}
+}
+

--- a/vlib/net/http/response_test.v
+++ b/vlib/net/http/response_test.v
@@ -2,22 +2,22 @@ module http
 
 fn test_parse_response_line() ? {
 	if _ := parse_response_line('hello world') {
-		panic('should be error')
+		return error('should be error')
 	}
 	mut version, mut status := parse_response_line('http/1.1 200 OK') or {
-		panic('should not error')
+		return error('should not error')
 	}
 	assert version == .v1_1
 	assert status == .ok
 
 	version, status = parse_response_line('http/1.1 200 any string') or {
-		panic('should not error')
+		return error('should not error')
 	}
 	assert version == .v1_1
 	assert status == .ok
 
 	// TODO: should this not parse?
-	version, status = parse_response_line('abc 123') or { panic('should not error') }
+	version, status = parse_response_line('abc 123') or { return error('should not error') }
 	assert version == .unknown
 	assert status == .unassigned
 }

--- a/vlib/net/http/response_test.v
+++ b/vlib/net/http/response_test.v
@@ -23,3 +23,14 @@ fn test_parse_response_line() ? {
 	assert version == .unknown
 	assert status == .unassigned
 }
+
+fn test_response_render() ? {
+	resp := Response{
+		text: 'hello'
+		header: new_header(key: .content_type, value: 'text/plain')
+		cookies: {'cookie': 'jar'}
+		status_code: .ok
+		http_version: .v1_1
+	}
+	assert resp.render() == 'HTTP/1.1 200 OK\n\rContent-Type: text/plain\n\rSet-Cookie: cookie=jar\n\r\n\rhello'
+}

--- a/vlib/net/http/response_test.v
+++ b/vlib/net/http/response_test.v
@@ -17,9 +17,7 @@ fn test_parse_response_line() ? {
 	assert status == .ok
 
 	// TODO: should this not parse?
-	version, status = parse_response_line('abc 123') or {
-		panic('should not error')
-	}
+	version, status = parse_response_line('abc 123') or { panic('should not error') }
 	assert version == .unknown
 	assert status == .unassigned
 }
@@ -28,9 +26,11 @@ fn test_response_render() ? {
 	resp := Response{
 		text: 'hello'
 		header: new_header(key: .content_type, value: 'text/plain')
-		cookies: {'cookie': 'jar'}
+		cookies: map{
+			'cookie': 'jar'
+		}
 		status_code: .ok
 		http_version: .v1_1
 	}
-	assert resp.render() == 'HTTP/1.1 200 OK\n\rContent-Type: text/plain\n\rSet-Cookie: cookie=jar\n\r\n\rhello'
+	assert resp.render() == 'HTTP/1.1 200 OK\n\rContent-Type: text/plain\n\rContent-Length: 5\n\rSet-Cookie: cookie=jar\n\r\n\rhello'
 }

--- a/vlib/net/http/response_test.v
+++ b/vlib/net/http/response_test.v
@@ -1,0 +1,25 @@
+module http
+
+fn test_parse_response_line() ? {
+	if _ := parse_response_line('hello world') {
+		panic('should be error')
+	}
+	mut version, mut status := parse_response_line('http/1.1 200 OK') or {
+		panic('should not error')
+	}
+	assert version == .v1_1
+	assert status == .ok
+
+	version, status = parse_response_line('http/1.1 200 any string') or {
+		panic('should not error')
+	}
+	assert version == .v1_1
+	assert status == .ok
+
+	// TODO: should this not parse?
+	version, status = parse_response_line('abc 123') or {
+		panic('should not error')
+	}
+	assert version == .unknown
+	assert status == .unassigned
+}

--- a/vlib/vweb/tests/vweb_test.v
+++ b/vlib/vweb/tests/vweb_test.v
@@ -109,7 +109,7 @@ fn test_a_simple_tcp_client_html_page() {
 
 // net.http client based tests follow:
 fn assert_common_http_headers(x http.Response) ? {
-	assert x.status_code == 200
+	assert x.status_code == .ok
 	assert x.header.get(.server) ? == 'VWeb'
 	assert x.header.get(.content_length) ?.int() > 0
 	assert x.header.get(.connection) ? == 'close'
@@ -137,7 +137,7 @@ fn test_http_client_404() ? {
 	]
 	for url in url_404_list {
 		res := http.get(url) or { panic(err) }
-		assert res.status_code == 404
+		assert res.status_code == .not_found
 	}
 }
 
@@ -175,7 +175,7 @@ fn test_http_client_user_repo_settings_page() ? {
 	assert y.text == 'username: kent | repository: golang'
 	//
 	z := http.get('http://127.0.0.1:$sport/missing/golang/settings') or { panic(err) }
-	assert z.status_code == 404
+	assert z.status_code == .not_found
 }
 
 struct User {
@@ -238,7 +238,7 @@ fn test_http_client_shutdown_does_not_work_without_a_cookie() {
 		assert err.msg == ''
 		return
 	}
-	assert x.status_code == 404
+	assert x.status_code == .not_found
 	assert x.text == '404 Not Found'
 }
 
@@ -254,7 +254,7 @@ fn testsuite_end() {
 		assert err.msg == ''
 		return
 	}
-	assert x.status_code == 200
+	assert x.status_code == .ok
 	assert x.text == 'good bye'
 }
 


### PR DESCRIPTION
Change definition from

```v
pub struct Response {
pub:
	text        string
	header      Header
	cookies     map[string]string
	status_code int
}
```

to

```v
pub struct Response {
pub:
	text   string
	header Header
	// TODO: use Cookie struct
	cookies      map[string]string
	status_code  Status
	http_version Version
}
```

This might break existing code that checks the status_code as an int.