### PR TITLE
GC-Boehm: fix for Windows

### DIFF
--- a/vlib/builtin/builtin_d_gcboehm.v
+++ b/vlib/builtin/builtin_d_gcboehm.v
@@ -25,9 +25,8 @@ $if static_boehm ? {
 	$if windows {
 		#flag -I@VEXEROOT/thirdparty/libgc/include
 		#flag -L@VEXEROOT/thirdparty/libgc
-	} $else {
-		#flag -lgc
 	}
+	#flag -lgc
 }
 
 $if gcboehm_leak ? {


### PR DESCRIPTION
This is a small fix for a bug that had crept in with the OpenBSD support in #10300.

GC-Boehm on Windows still needs binaries that have been prepared by @spaceface777 (see #9393). Maybe we should transfer these binaries to a vlang repository and treat them similar to `vlang/tccbin`...
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
