### PR TITLE
v build-module: show error and exit when no module specified

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -634,6 +634,10 @@ pub fn parse_args(known_external_commands []string, args []string) (&Preferences
 	}
 	if command == 'build-module' {
 		res.build_mode = .build_module
+		if command_pos + 1 >= args.len {
+			eprintln('v build-module: no module specified')
+			exit(1)
+		}
 		res.path = args[command_pos + 1]
 	}
 	// keep only the unique res.build_options:


### PR DESCRIPTION
`v build-module` with no module causes panic on current master. This PR fix it
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
