### PR TITLE
sqlite: add function to retrieve last_insert_rowid

### DIFF
--- a/vlib/sqlite/sqlite.v
+++ b/vlib/sqlite/sqlite.v
@@ -47,6 +47,8 @@ fn C.sqlite3_open(&char, &&C.sqlite3) int
 
 fn C.sqlite3_close(&C.sqlite3) int
 
+fn C.sqlite3_last_insert_rowid(&C.sqlite3) i64
+
 //
 fn C.sqlite3_prepare_v2(&C.sqlite3, &char, int, &&C.sqlite3_stmt, &&char) int
 
@@ -122,6 +124,12 @@ fn get_int_from_stmt(stmt &C.sqlite3_stmt) int {
 	res := C.sqlite3_column_int(stmt, 0)
 	C.sqlite3_finalize(stmt)
 	return res
+}
+
+// Returns last insert rowid
+// https://www.sqlite.org/c3ref/last_insert_rowid.html
+pub fn (db DB) last_insert_rowid() i64 {
+	return C.sqlite3_last_insert_rowid(db.conn)
 }
 
 // Returns a single cell with value int.

--- a/vlib/sqlite/sqlite_test.v
+++ b/vlib/sqlite/sqlite_test.v
@@ -9,8 +9,11 @@ fn test_sqlite() {
 	db.exec('drop table if exists users')
 	db.exec("create table users (id integer primary key, name text default '');")
 	db.exec("insert into users (name) values ('Sam')")
+	assert db.last_insert_rowid() == 1
 	db.exec("insert into users (name) values ('Peter')")
+	assert db.last_insert_rowid() == 2
 	db.exec("insert into users (name) values ('Kate')")
+	assert db.last_insert_rowid() == 3
 	nr_users := db.q_int('select count(*) from users')
 	assert nr_users == 3
 	name := db.q_string('select name from users where id = 1')


### PR DESCRIPTION
I wanted to get `id (AUTO INCREMENT in sqlite)` right after successful insert, but there was no such method.
So, what I had to do is like follows, which requires extra "select" statement.
https://github.com/vlang/gitly/blob/350f03eb1f093c61a427c04defb39f41bbaeaf95/user.v#L87-L103
