### PR TITLE
Fix #10343

### DIFF
--- a/vlib/rand/util/util.v
+++ b/vlib/rand/util/util.v
@@ -14,8 +14,9 @@ pub fn sample_nr<T>(array []T, k int) []T {
 	mut results := []T{len: k}
 	mut indices := []int{len: n}
 	// Initialize with all indices
-	for i, mut v in indices {
-		v = i
+	// temporary workaround for issue #10343
+	for i in 0 .. indices.len {
+		indices[i] = i
 	}
 	shuffle(mut indices, k)
 	for i in 0 .. k {


### PR DESCRIPTION
The following code will result in an unused variable warning (and error if using `-prod`):
```
for i, mut x in my_array {
    x = i
}
```
V doesn't see mut x as being used.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
