### PR TITLE
checker: check generic type indexing error (fix #10116)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6487,32 +6487,23 @@ fn (mut c Checker) check_index(typ_sym &ast.TypeSymbol, index ast.Expr, index_ty
 
 pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) ast.Type {
 	mut typ := c.expr(node.left)
-	mut typ_sym := c.table.get_final_type_symbol(typ)
+	typ_sym := c.table.get_final_type_symbol(typ)
 	node.left_type = typ
-	for {
-		match typ_sym.kind {
-			.map {
-				node.is_map = true
-				break
-			}
-			.array {
-				node.is_array = true
-				break
-			}
-			.array_fixed {
-				node.is_farray = true
-				break
-			}
-			.any {
-				typ = c.unwrap_generic(typ)
-				node.left_type = typ
-				typ_sym = c.table.get_final_type_symbol(typ)
-				continue
-			}
-			else {
-				break
-			}
+	match typ_sym.kind {
+		.map {
+			node.is_map = true
 		}
+		.array {
+			node.is_array = true
+		}
+		.array_fixed {
+			node.is_farray = true
+		}
+		.any {
+			c.error('generic type `$typ_sym.name` does not support indexing, please use compound type, e.g. `[]$typ_sym.name`',
+				node.pos)
+		}
+		else {}
 	}
 	if typ_sym.kind !in [.array, .array_fixed, .string, .map] && !typ.is_ptr()
 		&& typ !in [ast.byteptr_type, ast.charptr_type] && !typ.has_flag(.variadic) {

--- a/vlib/v/checker/tests/generics_type_para_index_err.out
+++ b/vlib/v/checker/tests/generics_type_para_index_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/generics_type_para_index_err.vv:2:24: error: generic type `T` does not support indexing, please use compound type, e.g. `[]T`
+    1 | fn show_element<T>(arr &T) string {
+    2 |     return unsafe { '${arr[1]}' }
+      |                           ~~~
+    3 | }
+    4 |

--- a/vlib/v/checker/tests/generics_type_para_index_err.vv
+++ b/vlib/v/checker/tests/generics_type_para_index_err.vv
@@ -2,9 +2,8 @@ fn show_element<T>(arr &T) string {
 	return unsafe { '${arr[1]}' }
 }
 
-fn test_generic_with_fixed_array_type() {
+fn main() {
 	a := [1, 2, 3]!
 	ret := show_element(a)
 	println(ret)
-	assert ret == '2'
 }


### PR DESCRIPTION
This PR check generic type indexing error (fix #10116).

- Check generic type indexing error.
- Add test.
- #10233 cannot fix multi type cases, the following cannot work, and it cannot be solved under the current generic framework.
```vlang
fn test<T>(arr T) {
	a := arr[1]
	println(a)
}

fn main() {
	a := [1, 2, 3]!
	test(a)

	b := ['a', 'b', 'c']!
	test(b)
}
```
- We should avoid this usage, and use compound generic type, e.g. []T...

```vlang
fn show_element<T>(arr &T) string {
	return unsafe { '${arr[1]}' }
}

fn main() {
	a := [1, 2, 3]!
	ret := show_element(a)
	println(ret)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:2:24: error: generic type `T` does not support indexing, please use compound type, e.g. `[]T`
    1 | fn show_element<T>(arr &T) string {
    2 |     return unsafe { '${arr[1]}' }
      |                           ~~~
    3 | }
    4 |
```
 