### PR TITLE
parser: fix multiple output modifiers in asm

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1577,7 +1577,7 @@ pub fn (expr Expr) is_expr() bool {
 
 pub fn (expr Expr) is_lit() bool {
 	return match expr {
-		BoolLiteral, StringLiteral, IntegerLiteral { true }
+		BoolLiteral, CharLiteral, StringLiteral, IntegerLiteral { true }
 		else { false }
 	}
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1558,7 +1558,9 @@ fn (mut c Checker) fail_if_immutable(expr ast.Expr) (string, token.Position) {
 			return '', pos
 		}
 		else {
-			c.error('unexpected expression `$expr.type_name()`', expr.position())
+			if !expr.is_lit() {
+				c.error('unexpected expression `$expr.type_name()`', expr.position())
+			}
 		}
 	}
 	if explicit_lock_needed {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1411,7 +1411,7 @@ fn (mut p Parser) asm_ios(output bool) []ast.AsmIO {
 		if mut expr is ast.ParExpr {
 			expr = expr.expr
 		} else {
-			p.error('asm in/output must be incolsed in brackets $expr.type_name()')
+			p.error('asm in/output must be incolsed in brackets')
 		}
 		mut alias := ''
 		if p.tok.kind == .key_as {

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -352,6 +352,9 @@ pub fn (mut p Parser) check_expr(precedence int) ?ast.Expr {
 
 pub fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_ident bool) ast.Expr {
 	mut node := left
+	if p.inside_asm && p.prev_tok.position().line_nr < p.tok.position().line_nr {
+		return node
+	}
 	// Infix
 	for precedence < p.tok.precedence() {
 		if p.tok.kind == .dot {

--- a/vlib/v/tests/assembly/asm_test.amd64.v
+++ b/vlib/v/tests/assembly/asm_test.amd64.v
@@ -169,4 +169,17 @@ fn test_flag_output() {
 		; r (zero)
 	}
 	assert out
+
+	mut maybe_four := 4
+	mut four := 4
+	asm amd64 {
+		subl four, maybe_four
+		testl four, maybe_four
+		movl maybe_four, 9
+		; +m (maybe_four)
+		  +r (four)
+		  =@ccz (out)
+	}
+	assert out
+	assert maybe_four == 9
 }

--- a/vlib/v/tests/assembly/asm_test.i386.v
+++ b/vlib/v/tests/assembly/asm_test.i386.v
@@ -151,4 +151,17 @@ fn test_flag_output() {
 		; r (zero)
 	}
 	assert out
+
+	mut maybe_four := 4
+	mut four := 4
+	asm amd64 {
+		subl four, maybe_four
+		testl four, maybe_four
+		movl maybe_four, 9
+		; +m (maybe_four)
+		  +r (four)
+		  =@ccz (out)
+	}
+	assert out
+	assert maybe_four == 9
 }


### PR DESCRIPTION
This did not work:
```v
; +m (here)
  +a (ifthis)
  =@ccz (ret)
```
because the expression parser did not stop at the `)` in `(here)`. Instead, it assumed you wanted to add `a` to `(here)`, which is not true.