### PR TITLE
checker: check int literal to enum cast (fix #10125)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -35,6 +35,7 @@ pub mut:
 	cur_fn             &FnDecl = 0 // previously stored in Checker.cur_fn and Gen.cur_fn
 	cur_concrete_types []Type  // current concrete types, e.g. <int, string>
 	gostmts            int     // how many `go` statements there were in the parsed files.
+	enum_decls         map[string]EnumDecl
 	// When table.gostmts > 0, __VTHREADS__ is defined, which can be checked with `$if threads {`
 }
 
@@ -655,6 +656,11 @@ pub fn (mut t Table) register_type_symbol(typ TypeSymbol) int {
 	t.type_symbols[typ_idx].idx = typ_idx
 	t.type_idxs[typ.name] = typ_idx
 	return typ_idx
+}
+
+[inline]
+pub fn (mut t Table) register_enum_decl(enum_decl EnumDecl) {
+	t.enum_decls[enum_decl.name] = enum_decl
 }
 
 pub fn (t &Table) known_type(name string) bool {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5586,6 +5586,46 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 	if node.has_arg {
 		c.expr(node.arg)
 	}
+
+	// checks on int literal to enum cast if the value represents a value on the enum
+	if to_type_sym.kind == .enum_ {
+		if node.expr is ast.IntegerLiteral {
+			enum_decls := c.file.stmts.filter(it is ast.EnumDecl)
+			enum_typ_name := c.table.get_type_name(node.typ)
+			node_val := node.expr.val.int()
+
+			for enum_decl in enum_decls {
+				if enum_decl is ast.EnumDecl {
+					mut enum_val := 0
+					if enum_decl.name == to_type_sym.name {
+						mut in_range := false
+
+						for enum_field in enum_decl.fields {
+							// check if the field of the enum value is an integer literal
+							if enum_field.expr is ast.IntegerLiteral {
+								enum_val = enum_field.expr.val.int()
+							}
+
+							if node_val == enum_val {
+								in_range = true
+								break
+							}
+
+							enum_val += 1
+						}
+
+						if !in_range {
+							c.warn('$node_val dose not represents a value of enum $enum_typ_name',
+								node.pos)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	node.typname = c.table.get_type_symbol(node.typ).name
+
 	return node.typ
 }
 

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5591,7 +5591,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 	if to_type_sym.kind == .enum_ {
 		if node.expr is ast.IntegerLiteral {
 			enum_typ_name := c.table.get_type_name(node.typ)
-			node_val := node.expr.val.int()
+			node_val := (node.expr as ast.IntegerLiteral).val.int()
 
 			if enum_decl := c.table.enum_decls[to_type_sym.name] {
 				mut in_range := false

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5615,7 +5615,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 						}
 
 						if !in_range {
-							c.warn('$node_val dose not represents a value of enum $enum_typ_name',
+							c.warn('$node_val does not represents a value of enum $enum_typ_name',
 								node.pos)
 						}
 					}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5590,34 +5590,31 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 	// checks on int literal to enum cast if the value represents a value on the enum
 	if to_type_sym.kind == .enum_ {
 		if node.expr is ast.IntegerLiteral {
-			enum_decls := c.file.stmts.filter(it is ast.EnumDecl)
 			enum_typ_name := c.table.get_type_name(node.typ)
 			node_val := node.expr.val.int()
 
-			for enum_decl in enum_decls {
-				if enum_decl is ast.EnumDecl {
-					mut enum_val := 0
-					if enum_decl.name == to_type_sym.name {
-						mut in_range := false
+			for _, enum_decl in c.table.enum_decls {
+				mut enum_val := 0
+				if enum_decl.name == to_type_sym.name {
+					mut in_range := false
 
-						for enum_field in enum_decl.fields {
-							// check if the field of the enum value is an integer literal
-							if enum_field.expr is ast.IntegerLiteral {
-								enum_val = enum_field.expr.val.int()
-							}
-
-							if node_val == enum_val {
-								in_range = true
-								break
-							}
-
-							enum_val += 1
+					for enum_field in enum_decl.fields {
+						// check if the field of the enum value is an integer literal
+						if enum_field.expr is ast.IntegerLiteral {
+							enum_val = enum_field.expr.val.int()
 						}
 
-						if !in_range {
-							c.warn('$node_val does not represents a value of enum $enum_typ_name',
-								node.pos)
+						if node_val == enum_val {
+							in_range = true
+							break
 						}
+
+						enum_val += 1
+					}
+
+					if !in_range {
+						c.warn('$node_val does not represents a value of enum $enum_typ_name',
+							node.pos)
 					}
 				}
 			}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5593,29 +5593,27 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 			enum_typ_name := c.table.get_type_name(node.typ)
 			node_val := node.expr.val.int()
 
-			for _, enum_decl in c.table.enum_decls {
+			if enum_decl := c.table.enum_decls[to_type_sym.name] {
+				mut in_range := false
 				mut enum_val := 0
-				if enum_decl.name == to_type_sym.name {
-					mut in_range := false
 
-					for enum_field in enum_decl.fields {
-						// check if the field of the enum value is an integer literal
-						if enum_field.expr is ast.IntegerLiteral {
-							enum_val = enum_field.expr.val.int()
-						}
-
-						if node_val == enum_val {
-							in_range = true
-							break
-						}
-
-						enum_val += 1
+				for enum_field in enum_decl.fields {
+					// check if the field of the enum value is an integer literal
+					if enum_field.expr is ast.IntegerLiteral {
+						enum_val = enum_field.expr.val.int()
 					}
 
-					if !in_range {
-						c.warn('$node_val does not represents a value of enum $enum_typ_name',
-							node.pos)
+					if node_val == enum_val {
+						in_range = true
+						break
 					}
+
+					enum_val += 1
+				}
+
+				if !in_range {
+					c.warn('$node_val does not represents a value of enum $enum_typ_name',
+						node.pos)
 				}
 			}
 		}

--- a/vlib/v/checker/tests/enum_cast.out
+++ b/vlib/v/checker/tests/enum_cast.out
@@ -1,0 +1,6 @@
+examples/enums.v:6:10: warning: 12 dose not represents a value of enum Color
+    4 |     println(Color(0))
+    5 |     println(Color(10))
+    6 |     println(Color(12))
+      |             ~~~~~~~~~
+    7 | }

--- a/vlib/v/checker/tests/enum_cast.out
+++ b/vlib/v/checker/tests/enum_cast.out
@@ -1,4 +1,4 @@
-examples/enums.v:6:10: warning: 12 dose not represents a value of enum Color
+vlib/v/checker/tests/enum_cast.vv:6:13: error: 12 does not represents a value of enum Color
     4 |     println(Color(0))
     5 |     println(Color(10))
     6 |     println(Color(12))

--- a/vlib/v/checker/tests/enum_cast.vv
+++ b/vlib/v/checker/tests/enum_cast.vv
@@ -1,0 +1,7 @@
+enum Color { red green = 10 blue }
+
+fn main() {
+    println(Color(0))
+    println(Color(10))
+    println(Color(12))
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3074,7 +3074,8 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 		p.error_with_pos('cannot register enum `$name`, another type with this name exists',
 			end_pos)
 	}
-	return ast.EnumDecl{
+
+	enum_decl := ast.EnumDecl{
 		name: name
 		is_pub: is_pub
 		is_flag: is_flag
@@ -3084,6 +3085,10 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 		attrs: p.attrs
 		comments: enum_decl_comments
 	}
+
+	p.table.register_enum_decl(enum_decl)
+
+	return enum_decl
 }
 
 fn (mut p Parser) type_decl() ast.TypeDecl {


### PR DESCRIPTION
This PR adds an int literal to enum check to the `cast_expr` method of the checker (Fixes #10125)

* If the value of the given int literal does not represents a value of the given enum a warning will be shown
* This adds first the compile time check, a runtime check will be added by a separate PR 

### Example

```v
enum Color { red green = 10 blue }

fn main() {
    println(Color(0))
    println(Color(10))
    println(Color(12))
}
```
### Output


```shell
examples/enums.v:6:10: warning: 12 dose not represents a value of enum Color
    4 |     println(Color(0))
    5 |     println(Color(10))
    6 |     println(Color(12))
      |             ~~~~~~~~~
    7 | }
```