### PR TITLE
checker: prevent uninitialized references in array inits

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3711,6 +3711,9 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) ast.Type {
 		}
 		if array_init.has_len {
 			c.ensure_sumtype_array_has_default_value(array_init)
+			if array_init.elem_type.is_ptr() {
+				c.error('array type cannot be uninitialized reference type', array_init.pos)
+			}
 		}
 		c.ensure_type_exists(array_init.elem_type, array_init.elem_type_pos) or {}
 		return array_init.typ

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3689,6 +3689,13 @@ pub fn (mut c Checker) ensure_sumtype_array_has_default_value(array_init ast.Arr
 	}
 }
 
+pub fn (mut c Checker) ensure_reference_array_has_default_value(array_init ast.ArrayInit) {
+	if array_init.elem_type.is_ptr() && !array_init.has_default {
+		c.error('an array of references with `len:` > 0, should always be initialized with `init:`',
+			array_init.pos)
+	}
+}
+
 pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) ast.Type {
 	// println('checker: array init $array_init.pos.line_nr $c.file.path')
 	mut elem_type := ast.void_type
@@ -3711,15 +3718,14 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) ast.Type {
 		}
 		if array_init.has_len {
 			c.ensure_sumtype_array_has_default_value(array_init)
-			if array_init.elem_type.is_ptr() {
-				c.error('array type cannot be uninitialized reference type', array_init.pos)
-			}
+			c.ensure_reference_array_has_default_value(array_init)
 		}
 		c.ensure_type_exists(array_init.elem_type, array_init.elem_type_pos) or {}
 		return array_init.typ
 	}
 	if array_init.is_fixed {
 		c.ensure_sumtype_array_has_default_value(array_init)
+		c.ensure_reference_array_has_default_value(array_init)
 		c.ensure_type_exists(array_init.elem_type, array_init.elem_type_pos) or {}
 	}
 	// a = []

--- a/vlib/v/checker/tests/array_init_with_uninitialized_struct_references_err.out
+++ b/vlib/v/checker/tests/array_init_with_uninitialized_struct_references_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/array_init_with_uninitialized_struct_references_err.vv:6:10: error: array type cannot be uninitialized reference type
+vlib/v/checker/tests/array_init_with_uninitialized_struct_references_err.vv:6:10: error: an array of references with `len:` > 0, should always be initialized with `init:`
     4 | 
     5 | fn main() {
     6 |     println([]&Person{len: 4})

--- a/vlib/v/checker/tests/array_init_with_uninitialized_struct_references_err.out
+++ b/vlib/v/checker/tests/array_init_with_uninitialized_struct_references_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/array_init_with_uninitialized_struct_references_err.vv:6:10: error: array type cannot be uninitialized reference type
+    4 | 
+    5 | fn main() {
+    6 |     println([]&Person{len: 4})
+      |             ~~~~~~~~~~
+    7 | }

--- a/vlib/v/checker/tests/array_init_with_uninitialized_struct_references_err.vv
+++ b/vlib/v/checker/tests/array_init_with_uninitialized_struct_references_err.vv
@@ -1,0 +1,7 @@
+struct Person {
+	name string
+}
+
+fn main() {
+	println([]&Person{len: 4})
+}

--- a/vlib/v/checker/tests/fixed_array_init_with_uninitialized_struct_references_err.out
+++ b/vlib/v/checker/tests/fixed_array_init_with_uninitialized_struct_references_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/fixed_array_init_with_uninitialized_struct_references_err.vv:6:10: error: an array of references with `len:` > 0, should always be initialized with `init:`
+    4 |
+    5 | fn main() {
+    6 |     println([4]&Person{})
+      |             ~~~~~~~~~~~~
+    7 | }

--- a/vlib/v/checker/tests/fixed_array_init_with_uninitialized_struct_references_err.vv
+++ b/vlib/v/checker/tests/fixed_array_init_with_uninitialized_struct_references_err.vv
@@ -1,0 +1,7 @@
+struct Person {
+	name string
+}
+
+fn main() {
+	println([4]&Person{})
+}


### PR DESCRIPTION
This commit adds a check to prevent the following code from
compiling (previously it resulted in a runtime error):

```v
struct Person {
	name string
}

fn main() {
	println([]&Person{len: 4})
}
```

Fixes #9961

---

Since this is my first contribution, I had a few questions that I wasn't sure about:

1. Is it expected that a handful of tests fail (on `master`) on my local machine? I don't know if it's because I'm using macOS but using the compiler from `make` with `test-all` gives me a few warnings and test failures.
2. I tried the above code with a fixed-size array, and the output was: `[&0, &0, &0, &0]`. Is that expected or should I prevent that case too?