### PR TITLE
parser: fix generic fn typeof name (fix #10361)

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -578,6 +578,15 @@ fn (mut p Parser) parse_generic_names() []string {
 		}
 		p.check(.name)
 		param_names << name
+		if p.table.find_type_idx(name) == 0 {
+			p.table.register_type_symbol(ast.TypeSymbol{
+				name: name
+				cname: util.no_dots(name)
+				mod: p.mod
+				kind: .any
+				is_public: true
+			})
+		}
 		first_done = true
 		count++
 	}

--- a/vlib/v/tests/generic_fn_typeof_name_test.v
+++ b/vlib/v/tests/generic_fn_typeof_name_test.v
@@ -13,3 +13,31 @@ fn test_generics_fn_typeof_name() {
 	println(ret)
 	assert ret == 'fn (mut Client, string)'
 }
+
+// test no paras generics fn typeof name
+struct Test1 {}
+
+struct Test2 {}
+
+fn print_type<T>() string {
+	name := T.name
+	println(name)
+	return name
+}
+
+fn test_no_paras_generics_fn_typeof_name() {
+	mut ret := print_type<Test1>()
+	assert ret == 'Test1'
+
+	ret = print_type<Test2>()
+	assert ret == 'Test2'
+
+	ret = print_type<int>()
+	assert ret == 'int'
+
+	ret = print_type<f32>()
+	assert ret == 'f32'
+
+	ret = print_type<bool>()
+	assert ret == 'bool'
+}


### PR DESCRIPTION
This PR fix generic fn typeof name (fix #10361).

- Fix generic fn typeof name.
- Add test.

```vlang
struct Test1 {}

struct Test2 {}

fn main() {
	mut ret := print_type<Test1>()
	assert ret == 'Test1'

	ret = print_type<Test2>()
	assert ret == 'Test2'

	ret = print_type<int>()
	assert ret == 'int'

	ret = print_type<f32>()
	assert ret == 'f32'

	ret = print_type<bool>()
	assert ret == 'bool'
}

fn print_type<T>() string {
	name := T.name
	println(name)
	return name
}

PS D:\Test\v\tt1> v run .
Test1
Test2
int
f32
bool
```