### PR TITLE
checker: improve error message when using fields as methods

### DIFF
--- a/vlib/v/checker/tests/filter_on_non_arr_err.out
+++ b/vlib/v/checker/tests/filter_on_non_arr_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/filter_on_non_arr_err.vv:2:14: error: unknown method: `string.filter`
+vlib/v/checker/tests/filter_on_non_arr_err.vv:2:14: error: unknown method or field: `string.filter`
     1 | fn main() {
     2 |     _ := 'test'.filter(it == `t`)
       |                 ~~~~~~~~~~~~~~~~~

--- a/vlib/v/checker/tests/no_method_on_interface_propagation.out
+++ b/vlib/v/checker/tests/no_method_on_interface_propagation.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/no_method_on_interface_propagation.vv:18:5: error: unknown method: `Cat.foo`
+vlib/v/checker/tests/no_method_on_interface_propagation.vv:18:5: error: unknown method or field: `Cat.foo`
    16 |     a := new_animal('persian')
    17 |     if a is Cat {
    18 |         a.foo()

--- a/vlib/v/checker/tests/unknown_field.out
+++ b/vlib/v/checker/tests/unknown_field.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/unknown_field.vv:7:12: error: type `Test` has no field or method `sdd`
+vlib/v/checker/tests/unknown_field.vv:7:12: error: type `Test` has no field named `sdd`
     5 | fn main() {
     6 |     t := Test{}
     7 |     println(t.sdd)

--- a/vlib/v/checker/tests/unknown_method.out
+++ b/vlib/v/checker/tests/unknown_method.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/unknown_method.vv:7:12: error: unknown method: `Test.sdd`
+vlib/v/checker/tests/unknown_method.vv:7:12: error: unknown method or field: `Test.sdd`
     5 | fn main() {
     6 |     t := Test{}
     7 |     println(t.sdd())

--- a/vlib/v/checker/tests/unknown_method_suggest_name.out
+++ b/vlib/v/checker/tests/unknown_method_suggest_name.out
@@ -6,7 +6,7 @@ Did you mean `crc32.Crc32`?
       |               ~~~~~
    14 | }
    15 |
-vlib/v/checker/tests/unknown_method_suggest_name.vv:27:9: error: unknown method: `Point.tranzlate`.
+vlib/v/checker/tests/unknown_method_suggest_name.vv:27:9: error: unknown method or field: `Point.tranzlate`.
 Did you mean `translate`?
    25 |     p := Point{1, 2, 3}
    26 |     v := Vector{x: 5, y: 5, z: 10}

--- a/vlib/v/checker/tests/unknown_struct_field_suggest_name.out
+++ b/vlib/v/checker/tests/unknown_struct_field_suggest_name.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/unknown_struct_field_suggest_name.vv:11:16: error: type `Points` has no field or method `xxxa`.
+vlib/v/checker/tests/unknown_struct_field_suggest_name.vv:11:16: error: type `Points` has no field named `xxxa`.
 Did you mean `xxxx`?
     9 |     p := Points{[1], [2], [3]}
    10 |     println('p: $p')


### PR DESCRIPTION
Current behaviour:

```v
struct Test {
	//foo int
}
fn (t Test)foo() int {
	return 1
}
fn main() {
	mut t := Test{}
	t.foo = 123
	exit(t.foo())
}

$ v v.v
v.v:12:4: error: type `Test` has no field or method `foo`
   10 | fn main() {
   11 |     mut t := Test{}
   12 |     t.foo = 123
      |       ~~~
   13 |     exit(t.foo())
   14 | }
```

After this PR:

instead of:
```
v.v:12:4: error: type `Test` has no field or method `foo`
```

report:
```
v.v:12:4: error: type `Test` has no field `foo` did you mean to access the field with the same name instead?
```

Also tested when there's a method and no field and when none of both exists and the behaviour looks correct to me
