### PR TITLE
cgen: fix assembly in generic fns

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7367,4 +7367,3 @@ fn (mut c Checker) ensure_type_exists(typ ast.Type, pos token.Position) ? {
 		else {}
 	}
 }
-

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4957,7 +4957,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		}
 	} else if to_type_sym.kind == .interface_ {
 		c.type_implements(node.expr_type, node.typ, node.pos)
-	} else if node.typ == ast.bool_type {
+	} else if node.typ == ast.bool_type && !c.inside_unsafe {
 		c.error('cannot cast to bool - use e.g. `some_int != 0` instead', node.pos)
 	} else if node.expr_type == ast.none_type && !node.typ.has_flag(.optional) {
 		type_name := c.table.type_to_str(node.typ)
@@ -7367,3 +7367,4 @@ fn (mut c Checker) ensure_type_exists(typ ast.Type, pos token.Position) ? {
 		else {}
 	}
 }
+

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6661,4 +6661,3 @@ fn (mut g Gen) check_noscan(elem_typ ast.Type) string {
 	}
 	return ''
 }
-

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1937,7 +1937,8 @@ fn (mut g Gen) gen_asm_stmt(stmt ast.AsmStmt) {
 	}
 	g.writeln(' (')
 	g.indent++
-	for mut template in stmt.templates {
+	for template_tmp in stmt.templates {
+		mut template := template_tmp
 		g.write('"')
 		if template.is_directive {
 			g.write('.')
@@ -6660,3 +6661,4 @@ fn (mut g Gen) check_noscan(elem_typ ast.Type) string {
 	}
 	return ''
 }
+

--- a/vlib/v/tests/assembly/asm_test.amd64.v
+++ b/vlib/v/tests/assembly/asm_test.amd64.v
@@ -1,4 +1,4 @@
-import util
+import v.tests.assembly.util
 
 fn test_inline_asm() {
 	a, mut b := i64(10), i64(0)
@@ -205,4 +205,3 @@ fn generic_asm<T>(var &T) T {
 	}
 	return ret
 }
-

--- a/vlib/v/tests/assembly/asm_test.amd64.v
+++ b/vlib/v/tests/assembly/asm_test.amd64.v
@@ -1,4 +1,4 @@
-import v.tests.assembly.util
+import util
 
 fn test_inline_asm() {
 	a, mut b := i64(10), i64(0)
@@ -183,3 +183,26 @@ fn test_flag_output() {
 	assert out
 	assert maybe_four == 9
 }
+
+fn test_asm_generic() {
+	u := u64(49)
+	b := unsafe { bool(123) }
+	assert generic_asm(u) == 14
+	assert u == 63
+	assert u64(generic_asm(b)) == 14
+	assert u64(b) == 137
+}
+
+fn generic_asm<T>(var &T) T {
+	mut ret := T(14)
+	unsafe {
+		asm volatile amd64 {
+			add var, ret
+			; +m (var[0]) as var
+			  +r (ret)
+			; ; memory
+		}
+	}
+	return ret
+}
+

--- a/vlib/v/tests/assembly/asm_test.i386.v
+++ b/vlib/v/tests/assembly/asm_test.i386.v
@@ -1,4 +1,4 @@
-import util
+import v.tests.assembly.util
 
 fn test_inline_asm() {
 	a, mut b := 10, 0
@@ -186,4 +186,3 @@ fn generic_asm<T>(var &T) T {
 	}
 	return ret
 }
-

--- a/vlib/v/tests/assembly/asm_test.i386.v
+++ b/vlib/v/tests/assembly/asm_test.i386.v
@@ -1,5 +1,4 @@
-import v.tests.assembly.util
-// rename this file to asm_test.amd64.v (and make more for other architectures) once pure v code is enforced
+import util
 
 fn test_inline_asm() {
 	a, mut b := 10, 0
@@ -165,3 +164,26 @@ fn test_flag_output() {
 	assert out
 	assert maybe_four == 9
 }
+
+fn test_asm_generic() {
+	u := u64(49)
+	b := unsafe { bool(123) }
+	assert generic_asm(u) == 14
+	assert u == 63
+	assert u64(generic_asm(b)) == 14
+	assert u64(b) == 137
+}
+
+fn generic_asm<T>(var &T) T {
+	mut ret := T(14)
+	unsafe {
+		asm volatile amd64 {
+			add var, ret
+			; +m (var[0]) as var
+			  +r (ret)
+			; ; memory
+		}
+	}
+	return ret
+}
+


### PR DESCRIPTION
This PR fixes the order of assembly arguments being reversed for every instantiation in cgen