### PR TITLE
checker: check generic method receiver with no type parameter (fix #10373)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7252,6 +7252,15 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 			c.error('missing return at end of function `$node.name`', node.pos)
 		}
 	}
+	if node.is_method {
+		sym := c.table.get_type_symbol(node.receiver.typ)
+		if sym.kind == .struct_ {
+			info := sym.info as ast.Struct
+			if info.is_generic && c.table.cur_fn.generic_names.len == 0 {
+				c.error('receiver must specify the generic type names, e.g. Foo<T>', node.method_type_pos)
+			}
+		}
+	}
 	c.returns = false
 	node.source_file = c.file
 }

--- a/vlib/v/checker/tests/generics_method_receiver_type_err.out
+++ b/vlib/v/checker/tests/generics_method_receiver_type_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/generics_method_receiver_type_err.vv:6:11: error: receiver must specify the generic type names, e.g. Foo<T>
+    4 | }
+    5 |
+    6 | pub fn (x Node) str() string {
+      |           ~~~~
+    7 |     return 'Value is : ${u16(x.val)}\nName is : $x.name'
+    8 | }

--- a/vlib/v/checker/tests/generics_method_receiver_type_err.vv
+++ b/vlib/v/checker/tests/generics_method_receiver_type_err.vv
@@ -1,0 +1,16 @@
+struct Node<T> {
+	val  T
+	name string
+}
+
+pub fn (x Node) str() string {
+	return 'Value is : ${u16(x.val)}\nName is : $x.name'
+}
+
+fn main() {
+	xx := Node<u16>{
+		val: u16(11)
+		name: 'man'
+	}
+	println(xx.str())
+}


### PR DESCRIPTION
This PR check generic method receiver with no type parameter (fix #10373).

- Check generic method receiver with no type parameter.
- Add test.

```vlang
struct Node<T> {
	val  T
	name string
}

pub fn (x Node) str() string {
	return 'Value is : ${u16(x.val)}\nName is : $x.name'
}

fn main() {
	xx := Node<u16>{
		val: u16(11)
		name: 'man'
	}
	println(xx.str())
}

PS D:\Test\v\tt1> v run .
.\tt1.v:6:11: error: receiver must specify the generic type names, e.g. Foo<T>
    4 | }
    5 | 
    6 | pub fn (x Node) str() string {
      |           ~~~~
    7 |     return 'Value is : ${u16(x.val)}\nName is : $x.name'
    8 | }
```