### PR TITLE
cgen: fix match with multi sumtype exprs (fix #10371)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4127,7 +4127,6 @@ fn (mut g Gen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var str
 					if is_expr && tmp_var.len == 0 {
 						g.write(' : ')
 					} else {
-						g.writeln('')
 						g.write_v_source_line_info(branch.pos)
 						g.write('else ')
 					}
@@ -4168,7 +4167,8 @@ fn (mut g Gen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var str
 			g.stmts_with_tmp_var(branch.stmts, tmp_var)
 			g.expected_cast_type = 0
 			if g.inside_ternary == 0 {
-				g.write('}')
+				g.writeln('}')
+				g.stmt_path_pos << g.out.len
 			}
 			sumtype_index++
 			if branch.exprs.len == 0 || sumtype_index == branch.exprs.len {

--- a/vlib/v/tests/match_with_multi_sumtype_exprs_test.v
+++ b/vlib/v/tests/match_with_multi_sumtype_exprs_test.v
@@ -1,0 +1,37 @@
+struct Empty {}
+
+type SumType = Empty | int
+
+fn isok(a SumType, b SumType) bool {
+	return !(match a {
+		int {
+			match b {
+				int { a == b }
+				Empty { false }
+			}
+		}
+		Empty {
+			false
+		}
+	} || match a {
+		int {
+			match b {
+				int { a + 10 == b - 10 }
+				Empty { false }
+			}
+		}
+		Empty {
+			false
+		}
+	})
+}
+
+fn test_match_with_multi_sumtype_exprs() {
+	a := SumType(1)
+	b := SumType(Empty{})
+
+	res := isok(a, b)
+
+	dump(res)
+	assert res
+}


### PR DESCRIPTION
This PR fix match with multi sumtype exprs (fix #10371).

- Fix match with multi sumtype exprs.
- Add test.

```vlang
struct Empty {}

type SumType = Empty | int

fn isok(a SumType, b SumType) bool {
	return !(match a {
		int {
			match b {
				int { a == b }
				Empty { false }
			}
		}
		Empty {
			false
		}
	} || match a {
		int {
			match b {
				int { a + 10 == b - 10 }
				Empty { false }
			}
		}
		Empty {
			false
		}
	})
}

fn main() {
	a := SumType(1)
	b := SumType(Empty{})

	res := isok(a, b)

	dump(res)
	assert res
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:35] res: true
```