### PR TITLE
cgen: format match_expr() generated c codes

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4086,7 +4086,7 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 	}
 	if need_tmp_var {
 		g.empty_line = true
-		cur_line = g.go_before_stmt(0).trim_space()
+		cur_line = g.go_before_stmt(0).trim_left(' \t')
 		tmp_var = g.new_tmp_var()
 		g.writeln('${g.typ(node.return_type)} $tmp_var;')
 	}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1026,7 +1026,9 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) {
 				g.skip_stmt_pos = true
 				g.write('$tmp_var = ')
 				g.stmt(stmt)
-				g.writeln(';')
+				if !g.out.last_n(2).contains(';') {
+					g.writeln(';')
+				}
 			}
 		} else {
 			g.stmt(stmt)
@@ -4084,7 +4086,7 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 	}
 	if need_tmp_var {
 		g.empty_line = true
-		cur_line = g.go_before_stmt(0)
+		cur_line = g.go_before_stmt(0).trim_space()
 		tmp_var = g.new_tmp_var()
 		g.writeln('${g.typ(node.return_type)} $tmp_var;')
 	}


### PR DESCRIPTION
This PR format match_expr() generated c codes.

- Remove extra semicolons.
- Format indents.

before:
```vlang
// TypeDecl
VV_LOCAL_SYMBOL bool main__isok(main__SumType a, main__SumType b) {
	bool _t740;
	if (a._typ == 7 /* int */) {
		_t740 = ((b._typ == 7 /* int */) ? ((*a._int) == (*b._int)) : (false));
		;
	}
	else if (a._typ == 94 /* main.Empty */) {
		_t740 = false;
		;
	}
	bool _t741;
	if (a._typ == 7 /* int */) {
		_t741 = ((b._typ == 7 /* int */) ? ((*a._int) + 10 == (*b._int) - 10) : (false));
		;
	}
	else if (a._typ == 94 /* main.Empty */) {
		_t741 = false;
		;
	}
			bool _t739 = !(_t740 || _t741);
	return _t739;
}
```

now:
```vlang
// TypeDecl
VV_LOCAL_SYMBOL bool main__isok(main__SumType a, main__SumType b) {
	bool _t740;
	if (a._typ == 7 /* int */) {
		_t740 = ((b._typ == 7 /* int */) ? ((*a._int) == (*b._int)) : (false));
	}
	else if (a._typ == 94 /* main.Empty */) {
		_t740 = false;
	}
	bool _t741;
	if (a._typ == 7 /* int */) {
		_t741 = ((b._typ == 7 /* int */) ? ((*a._int) + 10 == (*b._int) - 10) : (false));
	}
	else if (a._typ == 94 /* main.Empty */) {
		_t741 = false;
	}
	bool _t739 = !(_t740 || _t741);
	return _t739;
}
```