### PR TITLE
checker: check array type mismatch of array append (fix #10391)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -331,6 +331,13 @@ pub fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 	return true
 }
 
+fn (mut c Checker) check_array_value_types(got ast.Type, expected ast.Type) bool {
+	if expected.is_number() && got.is_number() && expected != c.table.mktyp(got) {
+		return false
+	}
+	return c.check_types(got, expected)
+}
+
 pub fn (mut c Checker) check_expected(got ast.Type, expected ast.Type) ? {
 	if c.check_types(got, expected) {
 		return

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1242,7 +1242,7 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					return ast.void_type
 				}
 				if right_final.kind == .array
-					&& c.check_types(left_value_type, c.table.value_type(right_type)) {
+					&& c.check_array_value_types(left_value_type, c.table.value_type(right_type)) {
 					// []T << []T
 					return ast.void_type
 				}

--- a/vlib/v/checker/tests/array_append_array_type_mismatch_err.out
+++ b/vlib/v/checker/tests/array_append_array_type_mismatch_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/array_append_array_type_mismatch_err.vv:3:8: error: cannot append `[]int` to `[]byte`
+    1 | fn main() {
+    2 |     mut bc := []byte{}
+    3 |     bc << [0xCA, 0xFE, 0xBA, 0xBE]
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~
+    4 |     println(bc)
+    5 | }

--- a/vlib/v/checker/tests/array_append_array_type_mismatch_err.vv
+++ b/vlib/v/checker/tests/array_append_array_type_mismatch_err.vv
@@ -1,0 +1,5 @@
+fn main() {
+	mut bc := []byte{}
+	bc << [0xCA, 0xFE, 0xBA, 0xBE]
+	println(bc)
+}


### PR DESCRIPTION
This PR check array type mismatch of array append (fix #10391).

- Check array type mismatch of array append.
- Add test.

```vlang
fn main() {
	mut bc := []byte{}
	bc << [0xCA, 0xFE, 0xBA, 0xBE]
	println(bc)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:3:8: error: cannot append `[]int` to `[]byte`
    1 | fn main() {
    2 |     mut bc := []byte{}
    3 |     bc << [0xCA, 0xFE, 0xBA, 0xBE]
      |           ~~~~~~~~~~~~~~~~~~~~~~~~
    4 |     println(bc)
    5 | }
```