### PR TITLE
doc: Add Module Publish section

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -100,7 +100,7 @@ For more details and troubleshooting, please visit the [vab GitHub repository](h
 * [Builtin functions](#builtin-functions)
 * [Printing custom types](#printing-custom-types)
 * [Modules](#modules)
-    * [Package management](#package-management)
+    * [Manage Packages](#manage-packages)
 	* [Publish package](#publish-package)
 * [Types 2](#types-2)
     * [Interfaces](#interfaces)
@@ -2244,7 +2244,7 @@ fn init() {
 The `init` function cannot be public - it will be called automatically. This feature is
 particularly useful for initializing a C library.
 
-### Package management
+### Manage Packages
 
 Briefly:
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -100,7 +100,8 @@ For more details and troubleshooting, please visit the [vab GitHub repository](h
 * [Builtin functions](#builtin-functions)
 * [Printing custom types](#printing-custom-types)
 * [Modules](#modules)
-    * [Module/package management](#modulepackage-management)
+    * [Package management](#package-management)
+	* [Publish package](#publish-package)
 * [Types 2](#types-2)
     * [Interfaces](#interfaces)
     * [Enums](#enums)
@@ -2243,7 +2244,7 @@ fn init() {
 The `init` function cannot be public - it will be called automatically. This feature is
 particularly useful for initializing a C library.
 
-### Module/package management
+### Package management
 
 Briefly:
 
@@ -2323,7 +2324,66 @@ v outdated
 Modules are up to date.
 ```
 
-You can also add your module to VPM by following the instructions on the website https://vpm.vlang.io/new
+### Publish package
+
+1. Put a `v.mod` file inside the toplevel folder of your module (if you
+	created your module with the command `v new mymodule` you already have a v.mod file). 
+
+	```sh
+	v new mymodule
+	Input your project description: My nice module.
+	Input your project version: (0.0.0) 0.0.1
+	Input your project license: (MIT) 
+	Initialising ...
+	Complete!
+	```
+
+	Example `v.mod`:
+	```v ignore
+	Module {
+		name: 'mymodule'
+		description: 'My nice module.'
+		version: '0.0.1'
+		license: 'MIT'
+		dependencies: []
+	}
+	```
+
+	Minimal file structure:
+	```
+	v.mod
+	mymodule.v
+	```
+
+	Check that your module name is used in `mymodule.v`:
+	```v
+	module mymodule
+
+	fn hello_world() {
+		println('Hello World!')
+	}
+	```
+
+2. Create a git repository in the folder with the `v.mod` file:
+	```sh
+	git init
+	git add .
+	git commit -m "INIT"
+	````
+
+3. Create a public repository on github.com.
+4. Connect your local repository to the remote repository and push the changes.
+5. Add your module to the public V module registry VPM:
+	https://vpm.vlang.io/new
+
+	You will have to login with your Github account to register the module.
+	**Warning:** _Currently it is not possibility to edit your entry after submiting.
+	Check your module name and github url twice as this cannot be changed by you later._
+6. The final module name is a combination of your github account and 
+	the module name you provided e.g. `mygithubname.mymodule`.
+
+**Optional:** tag your V module with `vlang` and `vlang-module` on github.com 
+to allow a better search experiance.
 
 ## Types 2
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2327,7 +2327,7 @@ Modules are up to date.
 ### Publish package
 
 1. Put a `v.mod` file inside the toplevel folder of your module (if you
-	created your module with the command `v new mymodule` you already have a v.mod file). 
+	created your module with the command `v new mymodule` or `v init` you already have a v.mod file). 
 
 	```sh
 	v new mymodule
@@ -2364,7 +2364,8 @@ Modules are up to date.
 	}
 	```
 
-2. Create a git repository in the folder with the `v.mod` file:
+2. Create a git repository in the folder with the `v.mod` file 
+	(this is not required if you used `v new` or `v init`):
 	```sh
 	git init
 	git add .

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2359,7 +2359,7 @@ Modules are up to date.
 	```v
 	module mymodule
 
-	fn hello_world() {
+	pub fn hello_world() {
 		println('Hello World!')
 	}
 	```


### PR DESCRIPTION
* change title "Module/package management" => "Manage Packages"
* add section "Publish module"

open questions:
1. when I use v new mymodule the result is a v.mod with name: 'mymodule' but in the created mymodule.v there is module main - shouldn´t there be module mymodule?
2. it looks like the VPM new is broken - after login with github I always get back to the screen with the link login via github
3. if I remember correctly I had to enter a module name and a github url - which name is used? the module name from the submit process or the name from the `v.mod` file?
4. Is there a form to change a submitted entry?