### PR TITLE
GC-boehm: extend optimized mode to strings

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -248,7 +248,11 @@ pub fn (a string) clone() string {
 		return ''
 	}
 	mut b := string{
-		str: unsafe { malloc(a.len + 1) }
+		str: $if gcboehm_opt ? {
+			unsafe { C.GC_MALLOC_ATOMIC(a.len + 1) }
+		} $else {
+			unsafe { malloc(a.len + 1) }
+		}
 		len: a.len
 	}
 	unsafe {
@@ -303,7 +307,11 @@ pub fn (s string) replace(rep string, with string) string {
 	}
 	// Now we know the number of replacements we need to do and we can calc the len of the new string
 	new_len := s.len + idxs.len * (with.len - rep.len)
-	mut b := unsafe { malloc(new_len + 1) } // add space for the null byte at the end
+	mut b := $if gcboehm_opt ? {
+		unsafe { C.GC_MALLOC_ATOMIC(new_len + 1) }
+	} $else {
+		unsafe { malloc(new_len + 1) } // add space for the null byte at the end
+	}
 	// Fill the new string
 	mut b_i := 0
 	mut s_idx := 0
@@ -406,7 +414,11 @@ pub fn (s string) replace_each(vals []string) string {
 		return s.clone()
 	}
 	idxs.sort2()
-	mut b := unsafe { malloc(new_len + 1) } // add space for 0 terminator
+	mut b := $if gcboehm_opt ? {
+		unsafe { C.GC_MALLOC_ATOMIC(new_len + 1) }
+	} $else {
+		unsafe { malloc(new_len + 1) } // add space for 0 terminator
+	}
 	// Fill the new string
 	mut idx_pos := 0
 	mut cur_idx := idxs[idx_pos]
@@ -532,7 +544,11 @@ fn (s string) < (a string) bool {
 fn (s string) + (a string) string {
 	new_len := a.len + s.len
 	mut res := string{
-		str: unsafe { malloc(new_len + 1) }
+		str: $if gcboehm_opt ? {
+			unsafe { C.GC_MALLOC_ATOMIC(new_len + 1) }
+		} $else {
+			unsafe { malloc(new_len + 1) }
+		}
 		len: new_len
 	}
 	for j in 0 .. s.len {
@@ -676,7 +692,11 @@ pub fn (s string) substr(start int, end int) string {
 		return s.clone()
 	}
 	mut res := string{
-		str: unsafe { malloc(len + 1) }
+		str: $if gcboehm_opt ? {
+			unsafe { C.GC_MALLOC_ATOMIC(len + 1) }
+		} $else {
+			unsafe { malloc(len + 1) }
+		}
 		len: len
 	}
 	for i in 0 .. len {
@@ -948,7 +968,11 @@ pub fn (s string) ends_with(p string) bool {
 // TODO only works with ASCII
 pub fn (s string) to_lower() string {
 	unsafe {
-		mut b := malloc(s.len + 1)
+		mut b := $if gcboehm_opt ? {
+			C.GC_MALLOC_ATOMIC(s.len + 1)
+		} $else {
+			malloc(s.len + 1)
+		}
 		for i in 0 .. s.len {
 			if s.str[i] >= `A` && s.str[i] <= `Z` {
 				b[i] = s.str[i] + 32
@@ -977,7 +1001,11 @@ pub fn (s string) is_lower() bool {
 // Example: assert 'Hello V'.to_upper() == 'HELLO V'
 pub fn (s string) to_upper() string {
 	unsafe {
-		mut b := malloc(s.len + 1)
+		mut b := $if gcboehm_opt ? {
+			C.GC_MALLOC_ATOMIC(s.len + 1)
+		} $else {
+			malloc(s.len + 1)
+		}
 		for i in 0 .. s.len {
 			if s.str[i] >= `a` && s.str[i] <= `z` {
 				b[i] = s.str[i] - 32
@@ -1262,7 +1290,7 @@ pub fn (s string) ustring() ustring {
 	mut res := ustring{
 		s: s // runes will have at least s.len elements, save reallocations
 		// TODO use VLA for small strings?
-		runes: __new_array(0, s.len, int(sizeof(int)))
+		runes: __new_array_noscan(0, s.len, int(sizeof(int)))
 	}
 	for i := 0; i < s.len; i++ {
 		char_len := utf8_char_len(unsafe { s.str[i] })
@@ -1586,7 +1614,11 @@ pub fn (a []string) join(sep string) string {
 	len -= sep.len
 	// Allocate enough memory
 	mut res := string{
-		str: unsafe { malloc(len + 1) }
+		str: $if gcboehm_opt ? {
+			unsafe { C.GC_MALLOC_ATOMIC(len + 1) }
+		} $else {
+			unsafe { malloc(len + 1) }
+		}
 		len: len
 	}
 	mut idx := 0
@@ -1621,7 +1653,11 @@ pub fn (s string) reverse() string {
 		return s.clone()
 	}
 	mut res := string{
-		str: unsafe { malloc(s.len + 1) }
+		str: $if gcboehm_opt ? {
+			unsafe { C.GC_MALLOC_ATOMIC(s.len + 1) }
+		} $else {
+			unsafe { malloc(s.len + 1) }
+		}
 		len: s.len
 	}
 	for i := s.len - 1; i >= 0; i-- {
@@ -1676,7 +1712,11 @@ pub fn (s string) repeat(count int) string {
 	} else if count == 1 {
 		return s.clone()
 	}
-	mut ret := unsafe { malloc(s.len * count + 1) }
+	mut ret := $if gcboehm_opt ? {
+		unsafe { C.GC_MALLOC_ATOMIC(s.len * count + 1) }
+	} $else {
+		unsafe { malloc(s.len * count + 1) }
+	}
 	for i in 0 .. count {
 		for j in 0 .. s.len {
 			unsafe {
@@ -1753,7 +1793,11 @@ pub fn (s string) strip_margin_custom(del byte) string {
 	}
 	// don't know how much space the resulting string will be, but the max it
 	// can be is this big
-	mut ret := unsafe { malloc(s.len + 1) }
+	mut ret := $if gcboehm_opt ? {
+		unsafe { C.GC_MALLOC_ATOMIC(s.len + 1) }
+	} $else {
+		unsafe { malloc(s.len + 1) }
+	}
 	mut count := 0
 	for i := 0; i < s.len; i++ {
 		if s[i] in [10, 13] {

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1262,7 +1262,11 @@ pub fn (s string) ustring() ustring {
 	mut res := ustring{
 		s: s // runes will have at least s.len elements, save reallocations
 		// TODO use VLA for small strings?
-		runes: __new_array(0, s.len, int(sizeof(int)))
+	}
+	$if gcboehm_opt ? {
+		res.runes = __new_array_noscan(0, s.len, int(sizeof(int)))
+	} $else {
+		res.runes = __new_array(0, s.len, int(sizeof(int)))
 	}
 	for i := 0; i < s.len; i++ {
 		char_len := utf8_char_len(unsafe { s.str[i] })
@@ -1282,7 +1286,11 @@ __global (
 
 pub fn (s string) ustring_tmp() ustring {
 	if g_ustring_runes.len == 0 {
-		g_ustring_runes = __new_array(0, 128, int(sizeof(int)))
+		$if gcboehm_opt ? {
+			g_ustring_runes = __new_array_noscan(0, 128, int(sizeof(int)))
+		} $else {
+			g_ustring_runes = __new_array(0, 128, int(sizeof(int)))
+		}
 	}
 	mut res := ustring{
 		s: s
@@ -1311,7 +1319,11 @@ fn (u ustring) < (a ustring) bool {
 fn (u ustring) + (a ustring) ustring {
 	mut res := ustring{
 		s: u.s + a.s
-		runes: __new_array(0, u.s.len + a.s.len, int(sizeof(int)))
+	}
+	$if gcboehm_opt ? {
+		res.runes = __new_array_noscan(0, u.s.len + a.s.len, int(sizeof(int)))
+	} $else {
+		res.runes = __new_array(0, u.s.len + a.s.len, int(sizeof(int)))
 	}
 	mut j := 0
 	for i := 0; i < u.s.len; i++ {


### PR DESCRIPTION
This is a further follow-up to #9716 and #10406. It prevents string data (the letters - not the `string` control structure) from being scanned for possible addresses by GC-Boehm.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
