### PR TITLE
cgen: fix match array or map cond (fix #10240)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4231,6 +4231,27 @@ fn (mut g Gen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var str
 						g.expr(expr)
 						g.write(')')
 					}
+				} else if type_sym.kind == .array {
+					ptr_typ := g.gen_array_equality_fn(node.cond_type)
+					g.write('${ptr_typ}_arr_eq(')
+					g.write(cond_var)
+					g.write(', ')
+					g.expr(expr)
+					g.write(')')
+				} else if type_sym.kind == .array_fixed {
+					ptr_typ := g.gen_fixed_array_equality_fn(node.cond_type)
+					g.write('${ptr_typ}_arr_eq(')
+					g.write(cond_var)
+					g.write(', ')
+					g.expr(expr)
+					g.write(')')
+				} else if type_sym.kind == .map {
+					ptr_typ := g.gen_map_equality_fn(node.cond_type)
+					g.write('${ptr_typ}_map_eq(')
+					g.write(cond_var)
+					g.write(', ')
+					g.expr(expr)
+					g.write(')')
 				} else if expr is ast.RangeExpr {
 					// if type is unsigned and low is 0, check is unneeded
 					mut skip_low := false

--- a/vlib/v/tests/match_array_or_map_cond_test.v
+++ b/vlib/v/tests/match_array_or_map_cond_test.v
@@ -1,0 +1,37 @@
+fn test_match_array_or_map_cond() {
+	// array
+	y1 := []byte{}
+	x1 := []byte{}
+	ret1 := match x1 {
+		y1 { true }
+		else { false }
+	}
+	println('ret1 is $ret1')
+	assert ret1
+
+	// fixed array
+	y2 := [1, 2, 3]!
+	x2 := [1, 2, 3]!
+	ret2 := match x2 {
+		y2 { true }
+		else { false }
+	}
+	println('ret2 is $ret2')
+	assert ret2
+
+	// map
+	y3 := map{
+		1: 11
+		2: 22
+	}
+	x3 := map{
+		1: 11
+		2: 22
+	}
+	ret3 := match x3 {
+		y3 { true }
+		else { false }
+	}
+	println('ret3 is $ret3')
+	assert ret3
+}


### PR DESCRIPTION
This PR fix match array or map cond (fix #10240).

- Fix match array or map cond.
- Add test.

```vlang
fn main() {
	// array
	y1 := []byte{}
	x1 := []byte{}
	ret1 := match x1 {
		y1 { true }
		else { false }
	}
	println('ret1 is $ret1')
	assert ret1

	// fixed array
	y2 := [1, 2, 3]!
	x2 := [1, 2, 3]!
	ret2 := match x2 {
		y2 { true }
		else { false }
	}
	println('ret2 is $ret2')
	assert ret2

	// map
	y3 := map{
		1: 11
		2: 22
	}
	x3 := map{
		1: 11
		2: 22
	}
	ret3 := match x3 {
		y3 { true }
		else { false }
	}
	println('ret3 is $ret3')
	assert ret3
}

PS D:\Test\v\tt1> v run .
ret1 is true
ret2 is true
ret3 is true
```