### PR TITLE
checker: add error for range expression assignment

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3268,6 +3268,11 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		if left is ast.CallExpr {
 			c.error('cannot call function `${left.name}()` on the left side of an assignment',
 				left.pos)
+		} else if left is ast.IndexExpr {
+			if left.index is ast.RangeExpr {
+				c.error('cannot reassign using range expression on the left side of an assignment',
+					left.pos)
+			}
 		}
 		is_blank_ident := left.is_blank_ident()
 		mut left_type := ast.void_type

--- a/vlib/v/checker/tests/slice_reassignment.out
+++ b/vlib/v/checker/tests/slice_reassignment.out
@@ -1,4 +1,4 @@
-./vlib/v/checker/tests/slice_reassignment.vv:3:5: error: cannot reassign using range expression on the left side of an assignment
+vlib/v/checker/tests/slice_reassignment.vv:3:5: error: cannot reassign using range expression on the left side of an assignment
     1 | fn main() {
     2 |     mut arr := [1, 2, 3, 4, 5]
     3 |     arr[..2] = [0, 0]

--- a/vlib/v/checker/tests/slice_reassignment.out
+++ b/vlib/v/checker/tests/slice_reassignment.out
@@ -1,0 +1,7 @@
+./vlib/v/checker/tests/slice_reassignment.vv:3:5: error: cannot reassign using range expression on the left side of an assignment
+    1 | fn main() {
+    2 |     mut arr := [1, 2, 3, 4, 5]
+    3 |     arr[..2] = [0, 0]
+      |        ~~~~~
+    4 |     println(arr)
+    5 | }

--- a/vlib/v/checker/tests/slice_reassignment.vv
+++ b/vlib/v/checker/tests/slice_reassignment.vv
@@ -1,0 +1,5 @@
+fn main() {
+	mut arr := [1, 2, 3, 4, 5]
+	arr[..2] = [0, 0]
+	println(arr)
+}


### PR DESCRIPTION
my pr checks for range expression assignment i.e. `foo[..2] = [0, 0]` and raises an error if it's found. before this pr, this code only compiles on tcc and it doesn't mutate foo at all. since this is undefined behavior, i have made it an error for the time being.