### PR TITLE
examples: rename "Chield" to "Child" in examples/database/orm.v 

### DIFF
--- a/examples/database/orm.v
+++ b/examples/database/orm.v
@@ -21,10 +21,10 @@ struct User {
 struct Parent {
 	id       int      [primary; sql: serial]
 	name     string
-	children []Chield [fkey: 'parent_id']
+	children []Child [fkey: 'parent_id']
 }
 
-struct Chield {
+struct Child {
 	id        int    [primary; sql: serial]
 	parent_id int
 	name      string
@@ -49,10 +49,10 @@ fn sqlite3_array() {
 	par := Parent{
 		name: 'test'
 		children: [
-			Chield{
+			Child{
 				name: 'abc'
 			},
-			Chield{
+			Child{
 				name: 'def'
 			},
 		]
@@ -67,7 +67,7 @@ fn sqlite3_array() {
 	}
 
 	sql db {
-		drop table Chield
+		drop table Child
 		drop table Parent
 	}
 
@@ -91,10 +91,10 @@ fn mysql_array() {
 	par := Parent{
 		name: 'test'
 		children: [
-			Chield{
+			Child{
 				name: 'abc'
 			},
-			Chield{
+			Child{
 				name: 'def'
 			},
 		]
@@ -111,7 +111,7 @@ fn mysql_array() {
 	eprintln(parent)
 
 	sql db {
-		drop table Chield
+		drop table Child
 		drop table Parent
 	}
 
@@ -130,10 +130,10 @@ fn psql_array() {
 	par := Parent{
 		name: 'test'
 		children: [
-			Chield{
+			Child{
 				name: 'abc'
 			},
-			Chield{
+			Child{
 				name: 'def'
 			},
 		]
@@ -150,7 +150,7 @@ fn psql_array() {
 	eprintln(parent)
 
 	sql db {
-		drop table Chield
+		drop table Child
 		drop table Parent
 	}
 

--- a/examples/database/orm.v
+++ b/examples/database/orm.v
@@ -19,7 +19,7 @@ struct User {
 }
 
 struct Parent {
-	id       int      [primary; sql: serial]
+	id       int     [primary; sql: serial]
 	name     string
 	children []Child [fkey: 'parent_id']
 }


### PR DESCRIPTION
this pr fixes a typo of "Child" as "Chield" in examples/database/orm.v, closes #10382