### PR TITLE
cgen: fix match struct type cond

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4254,6 +4254,13 @@ fn (mut g Gen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var str
 					g.write(', ')
 					g.expr(expr)
 					g.write(')')
+				} else if type_sym.kind == .struct_ {
+					ptr_typ := g.gen_struct_equality_fn(node.cond_type)
+					g.write('${ptr_typ}_struct_eq(')
+					g.write(cond_var)
+					g.write(', ')
+					g.expr(expr)
+					g.write(')')
 				} else if expr is ast.RangeExpr {
 					// if type is unsigned and low is 0, check is unneeded
 					mut skip_low := false

--- a/vlib/v/tests/match_compound_type_cond_test.v
+++ b/vlib/v/tests/match_compound_type_cond_test.v
@@ -1,3 +1,5 @@
+struct Foo {}
+
 fn test_match_array_or_map_cond() {
 	// array
 	y1 := []byte{}
@@ -34,4 +36,14 @@ fn test_match_array_or_map_cond() {
 	}
 	println('ret3 is $ret3')
 	assert ret3
+	
+	// struct
+	y4 := Foo{}
+	x4 := Foo{}
+	ret4 := match x4 {
+		y4 { true }
+		else { false }
+	}
+	println('ret4 is $ret4')
+	assert ret4
 }

--- a/vlib/v/tests/match_compound_type_cond_test.v
+++ b/vlib/v/tests/match_compound_type_cond_test.v
@@ -36,7 +36,7 @@ fn test_match_array_or_map_cond() {
 	}
 	println('ret3 is $ret3')
 	assert ret3
-	
+
 	// struct
 	y4 := Foo{}
 	x4 := Foo{}


### PR DESCRIPTION
This PR fix match struct type cond.

- Fix match struct type cond.
- Add test.

```vlang
struct Foo {}

fn main() {
	// struct
	y4 := Foo{}
	x4 := Foo{}
	ret4 := match x4 {
		y4 { true }
		else { false }
	}
	println('ret4 is $ret4')
	assert ret4
}

PS D:\Test\v\tt1> v run .
ret4 is true
```