### PR TITLE
checker: simplify checking array append type mismatch

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -331,13 +331,6 @@ pub fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 	return true
 }
 
-fn (mut c Checker) check_array_value_types(got ast.Type, expected ast.Type) bool {
-	if expected.is_number() && got.is_number() && expected != c.table.mktyp(got) {
-		return false
-	}
-	return c.check_types(got, expected)
-}
-
 pub fn (mut c Checker) check_expected(got ast.Type, expected ast.Type) ? {
 	if c.check_types(got, expected) {
 		return

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1236,14 +1236,9 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					}
 					return ast.void_type
 				}
-				// the expressions have different types (array_x and x)
-				if c.check_types(right_type, left_value_type) { // , right_type) {
-					// []T << T
-					return ast.void_type
-				}
-				if right_final.kind == .array
-					&& c.check_array_value_types(left_value_type, c.table.value_type(right_type)) {
-					// []T << []T
+				// []T << T or []T << []T
+				if c.check_types(right_type, left_value_type)
+					|| c.check_types(right_type, left_type) {
 					return ast.void_type
 				}
 				c.error('cannot append `$right_sym.name` to `$left_sym.name`', right_pos)


### PR DESCRIPTION
This PR simplify checking array append type mismatch.

- Remove check_array_value_types().
- Simplify checking array append type mismatch.