### PR TITLE
gg: fix draw_line when scaling

### DIFF
--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -565,20 +565,6 @@ pub fn (ctx &Context) draw_line(x f32, y f32, x2 f32, y2 f32, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
 	}
-	$if !android {
-		if ctx.scale > 1 {
-			// Make the line more clear on hi dpi screens: draw a rectangle
-			mut width := (x2 - x)
-			mut height := (y2 - y)
-			if width == 0 {
-				width = 1
-			} else if height == 0 {
-				height = 1
-			}
-			ctx.draw_rect(x, y, width, height, c)
-			return
-		}
-	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 	sgl.begin_line_strip()
 	sgl.v2f(x * ctx.scale, y * ctx.scale)


### PR DESCRIPTION
When `ctx.scale` is greater than 1, rather than drawing a line `draw_line` actually draws a rectangle between the two points. I'm guessing this was done to increase the thickness, but it draws a rectangle between the points instead of a line.

Most UI programs did not show any change after this.

RGB Color Sync (rectangle):
![rgb_color_sync_incorrect](https://user-images.githubusercontent.com/4183007/121764082-2162c080-cb0f-11eb-99de-7bada43d8e57.png)

RGB Color Sync (line):
![rgb_color_sync_correct](https://user-images.githubusercontent.com/4183007/121764090-29226500-cb0f-11eb-8ed3-3b0eeddb684c.png)

