### PR TITLE
parser: prepare for split of `map.v`

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2086,8 +2086,8 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 		&& !p.inside_match_case && (!p.inside_if || p.inside_select)
 		&& (!p.inside_for || p.inside_select) { // && (p.tok.lit[0].is_capital() || p.builtin_mod) {
 		// map.v has struct literal: map{field: expr}
-		if p.peek_tok.kind == .lcbr && !(p.builtin_mod && p.file_base == 'map.v')
-			&& p.tok.lit == 'map' {
+		if p.peek_tok.kind == .lcbr && !(p.builtin_mod
+			&& p.file_base in ['map.v', 'map_d_gcboehm_opt.v']) && p.tok.lit == 'map' {
 			// map{key_expr: val_expr}
 			p.check(.name)
 			p.check(.lcbr)

--- a/vlib/v/parser/pratt.v
+++ b/vlib/v/parser/pratt.v
@@ -49,7 +49,7 @@ pub fn (mut p Parser) check_expr(precedence int) ?ast.Expr {
 				node = p.sql_expr()
 				p.inside_match = false
 			} else if p.tok.lit == 'map' && p.peek_tok.kind == .lcbr && !(p.builtin_mod
-				&& p.file_base == 'map.v') {
+				&& p.file_base in ['map.v', 'map_d_gcboehm_opt.v']) {
 				p.next() // `map`
 				p.next() // `{`
 				node = p.map_init()


### PR DESCRIPTION
In #10426 `noscan` functions for `map` initializations are introduced that are only used when `-gc boehm_full_opt` is applied. So it's obvious that these functions should be placed in a separate file `map_d_gcboehm_opt.v`. However the parser has to treat builtin `map.v` functions in a special way - this PR extends this to builtin `map_d_gcboehm_opt.v` functions.

This PR has to be merged and `v.c` has to be rebuilt before the split can be made. 
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
