### PR TITLE
net: fix download_file

### DIFF
--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -74,7 +74,7 @@ pub fn (req &Request) do() ?Response {
 fn (req &Request) method_and_url_to_response(method Method, url urllib.URL) ?Response {
 	host_name := url.hostname()
 	scheme := url.scheme
-	p := url.path.trim_left('/')
+	p := url.escaped_path().trim_left('/')
 	path := if url.query().len > 0 { '/$p?$url.query().encode()' } else { '/$p' }
 	mut nport := url.port().int()
 	if nport == 0 {

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -649,7 +649,7 @@ pub fn (mut u URL) set_path(p string) ?bool {
 // their results.
 // In general, code should call escaped_path instead of
 // reading u.raw_path directly.
-fn (u &URL) escaped_path() string {
+pub fn (u &URL) escaped_path() string {
 	if u.raw_path != '' && valid_encoded_path(u.raw_path) {
 		unescape(u.raw_path, .encode_path) or { return '' }
 		return u.raw_path


### PR DESCRIPTION
Outgoing URLs at this low level must _always_ be URL encoded, otherwise it breaks the HTTP protocol.

Fixes #10402