### PR TITLE
vweb: add domain and path to cookies

### DIFF
--- a/vlib/vweb/tests/vweb_cookie_test.v
+++ b/vlib/vweb/tests/vweb_cookie_test.v
@@ -24,7 +24,7 @@ fn (mut app App) index() vweb.Result {
 	return app.html('<h1>Hello world</h1>')
 }
 
-fn main() {
+fn test_cookie() {
 	go vweb.run(&App{}, port)
 	resp := http.get('http://127.0.0.1:$port/') or { panic('server not running') }
 	darkmode := resp.cookies['darkmode'] or { panic('cookie not set') }

--- a/vlib/vweb/tests/vweb_cookie_test.v
+++ b/vlib/vweb/tests/vweb_cookie_test.v
@@ -1,0 +1,52 @@
+import vweb
+import net.http
+
+const (
+	port = 8000
+)
+
+struct App {
+	vweb.Context
+}
+
+fn (mut app App) index() vweb.Result {
+	app.set_cookie(vweb.Cookie{
+		name: 'darkmode'
+		value: '0'
+		path: '/' // <------ new
+		domain: '127.0.0.1' // <------ new
+	})
+
+	if cookie := app.get_cookie('darkmode') {
+		println(cookie)
+	}
+
+	return app.html('<h1>Hello world</h1>')
+}
+
+fn main() {
+	go vweb.run(&App{}, port)
+	resp := http.get('http://127.0.0.1:$port/') or { panic('server not running') }
+	darkmode := resp.cookies['darkmode'] or { panic('cookie not set') }
+	value := darkmode[0].ascii_str().int()
+	mut path := ''
+	mut domain := ''
+	path_index := darkmode.index('path=') or { panic("path doesn't exist") } + 5
+	domain_index := darkmode.index('domain=') or { panic("domain doesn't exist") } + 7
+	for ch in darkmode[path_index..] {
+		if ch == `;` {
+			break
+		}
+		path += ch.ascii_str()
+	}
+	for ch in darkmode[domain_index..] {
+		if ch == `;` {
+			break
+		}
+		domain += ch.ascii_str()
+	}
+	assert value == 0
+	assert path == '/'
+	assert domain == '127.0.0.1'
+	println(resp.cookies)
+}

--- a/vlib/vweb/tests/vweb_cookie_test.v
+++ b/vlib/vweb/tests/vweb_cookie_test.v
@@ -2,7 +2,7 @@ import vweb
 import net.http
 
 const (
-	port = 8000
+	port = 12380
 )
 
 struct App {
@@ -26,7 +26,7 @@ fn (mut app App) index() vweb.Result {
 
 fn test_cookie() {
 	go vweb.run(&App{}, port)
-	resp := http.get('http://127.0.0.1:$port/') or { panic('server not running') }
+	resp := http.get('http://127.0.0.1:$port/') or { panic(err) }
 	darkmode := resp.cookies['darkmode'] or { panic('cookie not set') }
 	value := darkmode[0].ascii_str().int()
 	mut path := ''

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -218,6 +218,12 @@ pub fn (mut ctx Context) enable_chunked_transfer(max_chunk_len int) {
 // Sets a cookie
 pub fn (mut ctx Context) set_cookie(cookie Cookie) {
 	mut cookie_data := []string{}
+	if path := cookie.path {
+		cookie_data << 'path=$path;'
+	}
+	if domain := cookie.domain {
+		cookie_data << 'domain=$domain;'
+	}
 	mut secure := if cookie.secure { 'Secure;' } else { '' }
 	secure += if cookie.http_only { ' HttpOnly' } else { ' ' }
 	cookie_data << secure

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -90,6 +90,8 @@ pub struct Cookie {
 	name      string
 	value     string
 	expires   time.Time
+	path      ?string
+	domain    ?string
 	secure    bool
 	http_only bool
 }

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -90,8 +90,8 @@ pub struct Cookie {
 	name      string
 	value     string
 	expires   time.Time
-	path      ?string
-	domain    ?string
+	path      string
+	domain    string
 	secure    bool
 	http_only bool
 }
@@ -218,12 +218,8 @@ pub fn (mut ctx Context) enable_chunked_transfer(max_chunk_len int) {
 // Sets a cookie
 pub fn (mut ctx Context) set_cookie(cookie Cookie) {
 	mut cookie_data := []string{}
-	if path := cookie.path {
-		cookie_data << 'path=$path;'
-	}
-	if domain := cookie.domain {
-		cookie_data << 'domain=$domain;'
-	}
+	cookie_data << 'path=$cookie.path;'
+	cookie_data << 'domain=$cookie.domain;'
 	mut secure := if cookie.secure { 'Secure;' } else { '' }
 	secure += if cookie.http_only { ' HttpOnly' } else { ' ' }
 	cookie_data << secure


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR tries to fix #10434 and adds support for path and domain to the cookies in vweb.