### PR TITLE
checker: implement if smartcast multi cond (fix #10380)

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -301,8 +301,8 @@ fn (f Fmt) should_insert_newline_before_node(node ast.Node, prev_node ast.Node) 
 	prev_line_nr := prev_node.position().last_line
 	// The nodes are Stmts
 	if node is ast.Stmt && prev_node is ast.Stmt {
-		stmt := node as ast.Stmt
-		prev_stmt := prev_node as ast.Stmt
+		stmt := node
+		prev_stmt := prev_node
 		// Force a newline after a block of HashStmts
 		if prev_stmt is ast.HashStmt && stmt !is ast.HashStmt && stmt !is ast.ExprStmt {
 			return true
@@ -1662,7 +1662,7 @@ pub fn (mut f Fmt) call_args(args []ast.CallArg) {
 	}
 	for i, arg in args {
 		if i == args.len - 1 && arg.expr is ast.StructInit {
-			struct_expr := arg.expr as ast.StructInit
+			struct_expr := arg.expr
 			if struct_expr.typ == ast.void_type {
 				f.use_short_fn_args = true
 			}
@@ -2477,7 +2477,7 @@ pub fn (mut f Fmt) prefix_expr_cast_expr(node ast.Expr) {
 	mut is_pe_amp_ce := false
 	if node is ast.PrefixExpr {
 		if node.right is ast.CastExpr && node.op == .amp {
-			mut ce := node.right as ast.CastExpr
+			mut ce := node.right
 			ce.typname = f.table.get_type_symbol(ce.typ).name
 			is_pe_amp_ce = true
 			f.expr(ce)

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -325,7 +325,7 @@ fn (mut g Gen) comp_if_cond(cond ast.Expr) bool {
 						interface_sym := g.table.get_type_symbol(got_type)
 						if interface_sym.info is ast.Interface {
 							// q := g.table.get_type_symbol(interface_sym.info.types[0])
-							checked_type := g.unwrap_generic((left as ast.TypeNode).typ)
+							checked_type := g.unwrap_generic(left.typ)
 							// TODO PERF this check is run twice (also in the checker)
 							// store the result in a field
 							is_true := g.table.type_implements_interface(checked_type,

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -850,7 +850,7 @@ fn (mut g JsGen) gen_enum_decl(it ast.EnumDecl) {
 	for field in it.fields {
 		g.write('$field.name: ')
 		if field.has_expr && field.expr is ast.IntegerLiteral {
-			e := field.expr as ast.IntegerLiteral
+			e := field.expr
 			i = e.val.int()
 		}
 		g.writeln('$i,')

--- a/vlib/v/gen/js/sourcemap/mappings.v
+++ b/vlib/v/gen/js/sourcemap/mappings.v
@@ -150,8 +150,8 @@ fn compare_by_generated_positions_inflated(mapping_a Mapping, mapping_b Mapping)
 
 	if mapping_a.source_position.type_name() == mapping_b.source_position.type_name()
 		&& mapping_b.source_position is SourcePosition {
-		if
-			(mapping_a.source_position as SourcePosition).source_line != (mapping_b.source_position as SourcePosition).source_line || (mapping_a.source_position as SourcePosition).source_column != (mapping_b.source_position as SourcePosition).source_column {
+		if mapping_a.source_position.source_line != mapping_b.source_position.source_line
+			|| mapping_a.source_position.source_column != mapping_b.source_position.source_column {
 			return true
 		}
 	} else {
@@ -162,7 +162,7 @@ fn compare_by_generated_positions_inflated(mapping_a Mapping, mapping_b Mapping)
 
 	if mapping_a.names_ind.type_name() == mapping_b.names_ind.type_name()
 		&& mapping_a.names_ind is IndexNumber {
-		return (mapping_a.names_ind as IndexNumber) != (mapping_b.names_ind as IndexNumber)
+		return mapping_a.names_ind != mapping_b.names_ind
 	} else {
 		return mapping_a.names_ind.type_name() != mapping_b.names_ind.type_name()
 	}

--- a/vlib/v/parser/sql.v
+++ b/vlib/v/parser/sql.v
@@ -34,7 +34,7 @@ fn (mut p Parser) sql_expr() ast.Expr {
 		if !is_count && where_expr is ast.InfixExpr {
 			e := where_expr as ast.InfixExpr
 			if e.op == .eq && e.left is ast.Ident {
-				ident := e.left as ast.Ident
+				ident := e.left
 				if ident.name == 'id' {
 					query_one = true
 				}

--- a/vlib/v/tests/if_smartcast_multi_conds_test.v
+++ b/vlib/v/tests/if_smartcast_multi_conds_test.v
@@ -1,0 +1,47 @@
+struct Empty {}
+
+struct SourcePosition {
+	source_line   u32
+	source_column u32
+}
+
+type SourcePositionType = Empty | SourcePosition
+type NameIndexType = Empty | u32
+
+struct GenPosition {
+	gen_line   u32
+	gen_column u32
+}
+
+struct Mapping {
+	GenPosition
+	sources_ind     u32
+	names_ind       NameIndexType
+	source_position SourcePositionType
+}
+
+fn ok(mapping_a Mapping, mapping_b Mapping) bool {
+	if mapping_a.source_position is SourcePosition && mapping_b.source_position is SourcePosition {
+		return mapping_a.source_position.source_line != mapping_b.source_position.source_line
+			|| mapping_a.source_position.source_column != mapping_b.source_position.source_column
+	}
+	return false
+}
+
+fn test_if_smartcast_multi_conds() {
+	a := Mapping{
+		source_position: SourcePosition{
+			source_line: 11
+			source_column: 22
+		}
+	}
+	b := Mapping{
+		source_position: SourcePosition{
+			source_line: 22
+			source_column: 11
+		}
+	}
+	ret := ok(a, b)
+	println(ret)
+	assert ret
+}


### PR DESCRIPTION
This PR implement if smartcast multi cond (fix #10380).

It's a breaking PR, need two parts merge, but I don't know how to do it.

- Implement if smartcast multi cond.
- Modify all the related called.
- Add test.

```vlang
struct Empty {}

struct SourcePosition {
	source_line   u32
	source_column u32
}

type SourcePositionType = Empty | SourcePosition
type NameIndexType = Empty | u32

struct GenPosition {
	gen_line   u32
	gen_column u32
}

struct Mapping {
	GenPosition
	sources_ind     u32
	names_ind       NameIndexType
	source_position SourcePositionType
}

fn ok(mapping_a Mapping, mapping_b Mapping) bool {
	if mapping_a.source_position is SourcePosition && mapping_b.source_position is SourcePosition {
		return mapping_a.source_position.source_line != mapping_b.source_position.source_line
			|| mapping_a.source_position.source_column != mapping_b.source_position.source_column
	}
	return false
}

fn main() {
	a := Mapping{
		source_position: SourcePosition{
			source_line: 11
			source_column: 22
		}
	}
	b := Mapping{
		source_position: SourcePosition{
			source_line: 22
			source_column: 11
		}
	}
	ret := ok(a, b)
	println(ret)
	assert ret
}

PS D:\Test\v\tt1> v run .
true
```