### PR TITLE
fix: uppercase libraries that prevented linux->windows cross compilation

### DIFF
--- a/cmd/tools/vsymlink.v
+++ b/cmd/tools/vsymlink.v
@@ -4,8 +4,8 @@ import v.util
 
 $if windows {
 	$if tinyc {
-		#flag -lAdvapi32
-		#flag -lUser32
+		#flag -ladvapi32
+		#flag -luser32
 	}
 }
 fn main() {

--- a/vlib/clipboard/clipboard_windows.c.v
+++ b/vlib/clipboard/clipboard_windows.c.v
@@ -3,7 +3,7 @@ module clipboard
 import time
 
 #include <windows.h>
-#flag -lUser32
+#flag -luser32
 
 struct WndClassEx {
 	cb_size         u32


### PR DESCRIPTION
`OS: Ubuntu 20.04.2 LTS x86_64`

`V: 0.2.2 4614876`

Cross compilation to `Windows` code with `import ui` resulted in error message.

> ./v code_with_ui.v -os windows
Cross compiling for Windows...
/usr/bin/x86_64-w64-mingw32-ld: cannot find -lUser32
collect2: error: ld returned 1 exit status
Cross compilation for Windows failed. Make sure you have mingw-w64 installed.
Try `sudo apt install -y mingw-w64` on Debian based distros, or `sudo pacman -S mingw-w64-gcc` on Arch, etc...
```

After the fix compiler produces `exe` binary.