### PR TITLE
checker: implement smartcast if multi conds (part 2)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2900,8 +2900,7 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 	if field_name.len > 0 && field_name[0].is_capital() && sym.info is ast.Struct
 		&& sym.language == .v {
 		// x.Foo.y => access the embedded struct
-		sym_info := sym.info as ast.Struct
-		for embed in sym_info.embeds {
+		for embed in sym.info.embeds {
 			embed_sym := c.table.get_type_symbol(embed)
 			if embed_sym.embed_name() == field_name {
 				node.typ = embed
@@ -4241,7 +4240,6 @@ fn (mut c Checker) for_stmt(mut node ast.ForStmt) {
 		if infix.op == .key_is {
 			if (infix.left is ast.Ident || infix.left is ast.SelectorExpr)
 				&& infix.right is ast.TypeNode {
-				right_expr := infix.right as ast.TypeNode
 				is_variable := if mut infix.left is ast.Ident {
 					infix.left.kind == .variable
 				} else {
@@ -4251,7 +4249,8 @@ fn (mut c Checker) for_stmt(mut node ast.ForStmt) {
 				left_sym := c.table.get_type_symbol(left_type)
 				if is_variable {
 					if left_sym.kind in [.sum_type, .interface_] {
-						c.smartcast(infix.left, infix.left_type, right_expr.typ, mut node.scope)
+						c.smartcast(infix.left, infix.left_type, infix.right.typ, mut
+							node.scope)
 					}
 				}
 			}
@@ -5972,7 +5971,7 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 					} else if branch.cond.right is ast.TypeNode && left is ast.TypeNode
 						&& sym.kind == .interface_ {
 						// is interface
-						checked_type := c.unwrap_generic((left as ast.TypeNode).typ)
+						checked_type := c.unwrap_generic(left.typ)
 						should_skip = !c.table.type_implements_interface(checked_type,
 							got_type)
 					} else if left is ast.TypeNode {
@@ -6016,50 +6015,7 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 			c.skip_flags = cur_skip_flags
 		} else {
 			// smartcast sumtypes and interfaces when using `is`
-			pos := branch.cond.position()
-			if branch.cond is ast.InfixExpr {
-				if branch.cond.op == .key_is {
-					right_expr := branch.cond.right
-					right_type := match right_expr {
-						ast.TypeNode {
-							right_expr.typ
-						}
-						ast.None {
-							ast.none_type_idx
-						}
-						else {
-							c.error('invalid type `$right_expr`', right_expr.position())
-							ast.Type(0)
-						}
-					}
-					if right_type != ast.Type(0) {
-						left_sym := c.table.get_type_symbol(branch.cond.left_type)
-						expr_type := c.expr(branch.cond.left)
-						if left_sym.kind == .interface_ {
-							c.type_implements(right_type, expr_type, pos)
-						} else if !c.check_types(right_type, expr_type) {
-							expect_str := c.table.type_to_str(right_type)
-							expr_str := c.table.type_to_str(expr_type)
-							c.error('cannot use type `$expect_str` as type `$expr_str`',
-								pos)
-						}
-						if (branch.cond.left is ast.Ident || branch.cond.left is ast.SelectorExpr)
-							&& branch.cond.right is ast.TypeNode {
-							is_variable := if mut branch.cond.left is ast.Ident {
-								branch.cond.left.kind == .variable
-							} else {
-								true
-							}
-							if is_variable {
-								if left_sym.kind in [.interface_, .sum_type] {
-									c.smartcast(branch.cond.left, branch.cond.left_type,
-										right_type, mut branch.scope)
-								}
-							}
-						}
-					}
-				}
-			}
+			c.smartcast_if_conds(branch.cond, mut branch.scope)
 			c.stmts(branch.stmts)
 		}
 		if expr_required {
@@ -6204,8 +6160,7 @@ fn (mut c Checker) comp_if_branch(cond ast.Expr, pos token.Position) bool {
 				.key_is, .not_is {
 					if cond.left is ast.TypeNode && cond.right is ast.TypeNode {
 						// `$if Foo is Interface {`
-						type_node := cond.right as ast.TypeNode
-						sym := c.table.get_type_symbol(type_node.typ)
+						sym := c.table.get_type_symbol(cond.right.typ)
 						if sym.kind != .interface_ {
 							c.expr(cond.left)
 							// c.error('`$sym.name` is not an interface', cond.right.position())

--- a/vlib/v/checker/tests/is_type_invalid.out
+++ b/vlib/v/checker/tests/is_type_invalid.out
@@ -5,10 +5,10 @@ vlib/v/checker/tests/is_type_invalid.vv:14:12: error: `IoS` has no variant `byte
       |               ~~
    15 |         println('not cool')
    16 |     }
-vlib/v/checker/tests/is_type_invalid.vv:18:5: error: `Cat` doesn't implement method `speak` of interface `Animal`
+vlib/v/checker/tests/is_type_invalid.vv:18:7: error: `Cat` doesn't implement method `speak` of interface `Animal`
    16 |     }
    17 |     a := Animal(Dog{})
    18 |     if a is Cat {
-      |        ~~~~~~~~
+      |          ~~
    19 |         println('not cool either')
    20 |     }

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -301,8 +301,8 @@ fn (f Fmt) should_insert_newline_before_node(node ast.Node, prev_node ast.Node) 
 	prev_line_nr := prev_node.position().last_line
 	// The nodes are Stmts
 	if node is ast.Stmt && prev_node is ast.Stmt {
-		stmt := node as ast.Stmt
-		prev_stmt := prev_node as ast.Stmt
+		stmt := node
+		prev_stmt := prev_node
 		// Force a newline after a block of HashStmts
 		if prev_stmt is ast.HashStmt && stmt !is ast.HashStmt && stmt !is ast.ExprStmt {
 			return true
@@ -1662,8 +1662,7 @@ pub fn (mut f Fmt) call_args(args []ast.CallArg) {
 	}
 	for i, arg in args {
 		if i == args.len - 1 && arg.expr is ast.StructInit {
-			struct_expr := arg.expr as ast.StructInit
-			if struct_expr.typ == ast.void_type {
+			if arg.expr.typ == ast.void_type {
 				f.use_short_fn_args = true
 			}
 		}
@@ -2477,7 +2476,7 @@ pub fn (mut f Fmt) prefix_expr_cast_expr(node ast.Expr) {
 	mut is_pe_amp_ce := false
 	if node is ast.PrefixExpr {
 		if node.right is ast.CastExpr && node.op == .amp {
-			mut ce := node.right as ast.CastExpr
+			mut ce := node.right
 			ce.typname = f.table.get_type_symbol(ce.typ).name
 			is_pe_amp_ce = true
 			f.expr(ce)

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -325,7 +325,7 @@ fn (mut g Gen) comp_if_cond(cond ast.Expr) bool {
 						interface_sym := g.table.get_type_symbol(got_type)
 						if interface_sym.info is ast.Interface {
 							// q := g.table.get_type_symbol(interface_sym.info.types[0])
-							checked_type := g.unwrap_generic((left as ast.TypeNode).typ)
+							checked_type := g.unwrap_generic(left.typ)
 							// TODO PERF this check is run twice (also in the checker)
 							// store the result in a field
 							is_true := g.table.type_implements_interface(checked_type,

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -850,8 +850,7 @@ fn (mut g JsGen) gen_enum_decl(it ast.EnumDecl) {
 	for field in it.fields {
 		g.write('$field.name: ')
 		if field.has_expr && field.expr is ast.IntegerLiteral {
-			e := field.expr as ast.IntegerLiteral
-			i = e.val.int()
+			i = field.expr.val.int()
 		}
 		g.writeln('$i,')
 		i++

--- a/vlib/v/gen/js/sourcemap/mappings.v
+++ b/vlib/v/gen/js/sourcemap/mappings.v
@@ -150,8 +150,8 @@ fn compare_by_generated_positions_inflated(mapping_a Mapping, mapping_b Mapping)
 
 	if mapping_a.source_position.type_name() == mapping_b.source_position.type_name()
 		&& mapping_b.source_position is SourcePosition {
-		if
-			(mapping_a.source_position as SourcePosition).source_line != (mapping_b.source_position as SourcePosition).source_line || (mapping_a.source_position as SourcePosition).source_column != (mapping_b.source_position as SourcePosition).source_column {
+		if mapping_a.source_position.source_line != mapping_b.source_position.source_line
+			|| mapping_a.source_position.source_column != mapping_b.source_position.source_column {
 			return true
 		}
 	} else {
@@ -161,8 +161,8 @@ fn compare_by_generated_positions_inflated(mapping_a Mapping, mapping_b Mapping)
 	}
 
 	if mapping_a.names_ind.type_name() == mapping_b.names_ind.type_name()
-		&& mapping_a.names_ind is IndexNumber {
-		return (mapping_a.names_ind as IndexNumber) != (mapping_b.names_ind as IndexNumber)
+		&& mapping_a.names_ind is IndexNumber && mapping_b.names_ind is IndexNumber {
+		return mapping_a.names_ind != mapping_b.names_ind
 	} else {
 		return mapping_a.names_ind.type_name() != mapping_b.names_ind.type_name()
 	}

--- a/vlib/v/parser/sql.v
+++ b/vlib/v/parser/sql.v
@@ -34,8 +34,7 @@ fn (mut p Parser) sql_expr() ast.Expr {
 		if !is_count && where_expr is ast.InfixExpr {
 			e := where_expr as ast.InfixExpr
 			if e.op == .eq && e.left is ast.Ident {
-				ident := e.left as ast.Ident
-				if ident.name == 'id' {
+				if e.left.name == 'id' {
 					query_one = true
 				}
 			}

--- a/vlib/v/tests/if_smartcast_multi_conds_test.v
+++ b/vlib/v/tests/if_smartcast_multi_conds_test.v
@@ -1,0 +1,47 @@
+struct Empty {}
+
+struct SourcePosition {
+	source_line   u32
+	source_column u32
+}
+
+type SourcePositionType = Empty | SourcePosition
+type NameIndexType = Empty | u32
+
+struct GenPosition {
+	gen_line   u32
+	gen_column u32
+}
+
+struct Mapping {
+	GenPosition
+	sources_ind     u32
+	names_ind       NameIndexType
+	source_position SourcePositionType
+}
+
+fn ok(mapping_a Mapping, mapping_b Mapping) bool {
+	if mapping_a.source_position is SourcePosition && mapping_b.source_position is SourcePosition {
+		return mapping_a.source_position.source_line != mapping_b.source_position.source_line
+			|| mapping_a.source_position.source_column != mapping_b.source_position.source_column
+	}
+	return false
+}
+
+fn test_if_smartcast_multi_conds() {
+	a := Mapping{
+		source_position: SourcePosition{
+			source_line: 11
+			source_column: 22
+		}
+	}
+	b := Mapping{
+		source_position: SourcePosition{
+			source_line: 22
+			source_column: 11
+		}
+	}
+	ret := ok(a, b)
+	println(ret)
+	assert ret
+}


### PR DESCRIPTION
This PR implement if smartcast multi cond (fix #10380) part 2.

Sorry, This two-step submission is still failed. It can only be modified all at once and cannot rebuild from v.c, so I don't know how to resolve it. @medvednikov  I wonder if there is a good way?

- Implement if smartcast multi cond.
- Modify all the related called.
- Add test.

```vlang
struct Empty {}

struct SourcePosition {
	source_line   u32
	source_column u32
}

type SourcePositionType = Empty | SourcePosition
type NameIndexType = Empty | u32

struct GenPosition {
	gen_line   u32
	gen_column u32
}

struct Mapping {
	GenPosition
	sources_ind     u32
	names_ind       NameIndexType
	source_position SourcePositionType
}

fn ok(mapping_a Mapping, mapping_b Mapping) bool {
	if mapping_a.source_position is SourcePosition && mapping_b.source_position is SourcePosition {
		return mapping_a.source_position.source_line != mapping_b.source_position.source_line
			|| mapping_a.source_position.source_column != mapping_b.source_position.source_column
	}
	return false
}

fn main() {
	a := Mapping{
		source_position: SourcePosition{
			source_line: 11
			source_column: 22
		}
	}
	b := Mapping{
		source_position: SourcePosition{
			source_line: 22
			source_column: 11
		}
	}
	ret := ok(a, b)
	println(ret)
	assert ret
}

PS D:\Test\v\tt1> v run .
true
```