### PR TITLE
net: fix 0 length file if Content-Header is missing or corrupt

### DIFF
--- a/vlib/net/http/chunked/dechunk.v
+++ b/vlib/net/http/chunked/dechunk.v
@@ -68,5 +68,9 @@ pub fn decode(text string) string {
 		cscanner.skip_crlf()
 	}
 	cscanner.skip_crlf()
-	return sb.str()
+	if sb.len > 0 {
+		return sb.str()
+	} else {
+		return text
+	}
 }


### PR DESCRIPTION
If the Content-Length header is missing or corrupted (example from recently reported problems... was sent as `Cteonnt-Length` - the `te` and `on` are swapped - from one website on some files), the file was assumed to be `chunked` text.  However, if it isn't actually `chunked`, an empty string was being returned.

This just changes the logic such that if the data cannot be decoded as chunked text, it returns the original.