### PR TITLE
vweb: fix parsing form data

### DIFF
--- a/vlib/vweb/request_test.v
+++ b/vlib/vweb/request_test.v
@@ -130,7 +130,7 @@ ${contents[1]}
 }
 
 fn test_parse_large_body() ? {
-	body := 'A'.repeat(101) // greater than max_bytes
+	body := 'ABCEF\r\n'.repeat(1024 * 1024) // greater than max_bytes
 	req := 'GET / HTTP/1.1\r\nContent-Length: $body.len\r\n\r\n$body'
 	result := parse_request(mut reader(req)) ?
 	assert result.data.len == body.len


### PR DESCRIPTION
Fix #9934 by using split() instead of split_into_lines() to preserve \r.
Also increase large body test.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
