### PR TITLE
cgen: fix generic method receiver typeof name error (fix #10467)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -505,7 +505,7 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 pub fn (mut g Gen) unwrap_generic(typ ast.Type) ast.Type {
 	if typ.has_flag(.generic) {
 		if t_typ := g.table.resolve_generic_to_concrete(typ, g.table.cur_fn.generic_names,
-			g.table.cur_concrete_types, false)
+			g.table.cur_concrete_types, true)
 		{
 			return t_typ
 		}

--- a/vlib/v/tests/generic_fn_typeof_name_test.v
+++ b/vlib/v/tests/generic_fn_typeof_name_test.v
@@ -41,3 +41,20 @@ fn test_no_paras_generics_fn_typeof_name() {
 	ret = print_type<bool>()
 	assert ret == 'bool'
 }
+
+// test generic method receiver typeof name
+struct Num<T> {
+	num T
+}
+
+fn (num Num<T>) test(v T) {
+	println(typeof(num).name)
+	assert typeof(num).name == 'Num<int>'
+	println(typeof(v).name)
+	assert typeof(v).name == 'int'
+}
+
+fn test_generic_method_receiver_typeof_name() {
+	num := Num<int>{3}
+	num.test(100)
+}


### PR DESCRIPTION
This PR fix generic method receiver typeof name error (fix #10467).

- Fix generic method receiver typeof name error.
- Add test.

```vlang
struct Num<T> {
	num T
}

fn (num Num<T>) test(v T) {
	println(typeof(num).name)
	assert typeof(num).name == 'Num<int>'
	println(typeof(v).name)
	assert typeof(v).name == 'int'
}

fn main() {
	num := Num<int>{3}
	num.test(100)
}

PS D:\Test\v\tt1> v run .
Num<int>
int
```