### PR TITLE
net: fix chunked check, remove length workaround

### DIFF
--- a/vlib/net/http/chunked/dechunk.v
+++ b/vlib/net/http/chunked/dechunk.v
@@ -68,9 +68,5 @@ pub fn decode(text string) string {
 		cscanner.skip_crlf()
 	}
 	cscanner.skip_crlf()
-	if sb.len > 0 {
-		return sb.str()
-	} else {
-		return text
-	}
+	return sb.str()
 }

--- a/vlib/net/http/response.v
+++ b/vlib/net/http/response.v
@@ -66,9 +66,7 @@ pub fn parse_response(resp string) Response {
 		parts := cookie.split_nth('=', 2)
 		cookies[parts[0]] = parts[1]
 	}
-	if header.get(.transfer_encoding) or { '' } == 'chunked' || header.get(.content_length) or {
-		''
-	} == '' {
+	if header.get(.transfer_encoding) or { '' } == 'chunked' {
 		text = chunked.decode(text)
 	}
 	return Response{


### PR DESCRIPTION
A response it only valid as chunked if the `Transfer-Encoding` header is set to `chunked`, so only call the `chunked.decode()` function if this is true.

Remove previous workaround of checking the length of decoded data.

This is a cleaner, faster fix for 0-length downloads, which will also use less memory (because of fewer string copies).