### PR TITLE
checker: fix generic fn assign generic struct (fix #10475)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3625,7 +3625,8 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			}
 		}
 		if !is_blank_ident && !left.is_auto_deref_var() && !right.is_auto_deref_var()
-			&& right_sym.kind != .placeholder && left_sym.kind != .interface_ {
+			&& right_sym.kind != .placeholder && left_sym.kind != .interface_
+			&& !right_type_unwrapped.has_flag(.generic) && !left_type_unwrapped.has_flag(.generic) {
 			// Dual sides check (compatibility check)
 			c.check_expected(right_type_unwrapped, left_type_unwrapped) or {
 				// allow for ptr += 2

--- a/vlib/v/tests/generic_fn_assign_generics_struct_test.v
+++ b/vlib/v/tests/generic_fn_assign_generics_struct_test.v
@@ -13,3 +13,26 @@ fn test_generics_assign_generics_struct() {
 	println('$x.v')
 	assert x.v == 1
 }
+
+// test generics assign generics struct_init
+struct Node<T> {
+pub mut:
+	val  T
+	next &Node<T> = 0
+}
+
+fn new<T>() &Node<T> {
+	return &Node<T>{}
+}
+
+fn (mut n Node<T>) add(val T) {
+	node := &Node<T>{val, 0}
+	n.next = node
+}
+
+fn test_generic_fn_assign_generic_struct_init() {
+	mut list := new<int>()
+	list.add(100)
+	println(list.next)
+	assert list.next.val == 100
+}


### PR DESCRIPTION
This PR fix generic fn assign generic struct (fix #10475).

- Fix generic fn assign generic struct.
- Add test.

```vlang
struct Node<T> {
pub mut:
	val  T
	next &Node<T> = 0
}

fn new<T>() &Node<T> {
	return &Node<T>{}
}

fn (mut n Node<T>) add(val T) {
	node := &Node<T>{val, 0}
	n.next = node
}

fn main() {
	mut list := new<int>()
	list.add(100)
	println(list.next)
	assert list.next.val == 100
}

PS D:\Test\v\tt1> v run .
&Node<int>{
    val: 100
    next: &nil
}
```