### PR TITLE
feat: net.http.request / set custom read and write timeouts

### DIFF
--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -7,6 +7,7 @@ import io
 import net
 import net.urllib
 import strings
+import time
 
 // Request holds information about an HTTP request (either received by
 // a server or to be sent by a client)
@@ -22,8 +23,8 @@ pub mut:
 	verbose       bool
 	user_ptr      voidptr
 	// NOT implemented for ssl connections
-	read_timeout  i64 = net.tcp_default_read_timeout
-	write_timeout i64 = net.tcp_default_write_timeout
+	read_timeout  i64 = 30 * time.second
+	write_timeout i64 = 30 * time.second
 }
 
 fn (mut req Request) free() {

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -13,16 +13,17 @@ import time
 // a server or to be sent by a client)
 pub struct Request {
 pub mut:
-	version       Version = .v1_1
-	method        Method
-	header        Header
-	cookies       map[string]string
-	data          string
-	url           string
-	user_agent    string = 'v.http'
-	verbose       bool
-	user_ptr      voidptr
+	version    Version = .v1_1
+	method     Method
+	header     Header
+	cookies    map[string]string
+	data       string
+	url        string
+	user_agent string = 'v.http'
+	verbose    bool
+	user_ptr   voidptr
 	// NOT implemented for ssl connections
+	// time = -1 for no timeout
 	read_timeout  i64 = 30 * time.second
 	write_timeout i64 = 30 * time.second
 }

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -12,15 +12,18 @@ import strings
 // a server or to be sent by a client)
 pub struct Request {
 pub mut:
-	version    Version = .v1_1
-	method     Method
-	header     Header
-	cookies    map[string]string
-	data       string
-	url        string
-	user_agent string = 'v.http'
-	verbose    bool
-	user_ptr   voidptr
+	version       Version = .v1_1
+	method        Method
+	header        Header
+	cookies       map[string]string
+	data          string
+	url           string
+	user_agent    string = 'v.http'
+	verbose       bool
+	user_ptr      voidptr
+	// NOT implemented for ssl connections
+	read_timeout  i64 = net.tcp_default_read_timeout
+	write_timeout i64 = net.tcp_default_write_timeout
 }
 
 fn (mut req Request) free() {
@@ -138,6 +141,8 @@ fn (req &Request) http_do(host string, method Method, path string) ?Response {
 	host_name, _ := net.split_address(host) ?
 	s := req.build_request_headers(method, host_name, path)
 	mut client := net.dial_tcp(host) ?
+	client.set_read_timeout(req.read_timeout)
+	client.set_write_timeout(req.write_timeout)
 	// TODO this really needs to be exposed somehow
 	client.write(s.bytes()) ?
 	$if trace_http_request ? {


### PR DESCRIPTION
Allow to change timeouts (read/write 30 sec) for `pub fn (req &Request) do()`

* add `read_timeout` and `write_timeout` to `pub struct Request {}`
* use the same defaults - couldn't use the existing `net.tcp_default_read_timeout` as they are private to `net.http`
* set timeouts before the http request with `http_do`

This is PR does only add this to HTTP - for HTTPS connection someone who does know the openssl api should implement it there too.

I have not added this changes to http.fetch as I think that everyone who needs this would be better of to start at the lower level.

**example:**
```v
req_incocation_next := http.Request{
  method: http.Method.get
  url: 'http://my.server.test'
  read_timeout: -1 // unlimited wait
  write_timeout: 60  * time.second 
}
req_incocation_next.do() or { panic(err) }
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
