### PR TITLE
vweb: Re-enable concurrency and remove count from example

### DIFF
--- a/examples/vweb/vweb_example.v
+++ b/examples/vweb/vweb_example.v
@@ -9,8 +9,6 @@ const (
 
 struct App {
 	vweb.Context
-mut:
-	cnt int
 }
 
 fn main() {
@@ -29,9 +27,7 @@ pub fn (mut app App) user_endpoint(user string) vweb.Result {
 }
 
 pub fn (mut app App) index() vweb.Result {
-	app.cnt++
 	show := true
-	// app.text('Hello world from vweb')
 	hello := 'Hello world from vweb'
 	numbers := [1, 2, 3]
 	app.enable_chunked_transfer(40)

--- a/examples/vweb/vweb_example.v
+++ b/examples/vweb/vweb_example.v
@@ -9,6 +9,13 @@ const (
 
 struct App {
 	vweb.Context
+mut:
+	state shared State
+}
+
+struct State {
+mut:
+	cnt int
 }
 
 fn main() {
@@ -27,6 +34,9 @@ pub fn (mut app App) user_endpoint(user string) vweb.Result {
 }
 
 pub fn (mut app App) index() vweb.Result {
+	lock app.state {
+		app.state.cnt++
+	}
 	show := true
 	hello := 'Hello world from vweb'
 	numbers := [1, 2, 3]

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -334,7 +334,7 @@ pub fn run<T>(global_app &T, port int) {
 		// conn: 0
 		//}
 		mut conn := l.accept() or { panic('accept() failed') }
-		handle_conn<T>(mut conn, mut request_app)
+		go handle_conn<T>(mut conn, mut request_app)
 	}
 }
 


### PR DESCRIPTION
Now that `handle_conn` is not operating on shared data, I think it's safe to execute it in a thread.

I also removed `count` from the vweb example because it's misleading - any variable (besides db) will get reset to its default value now that a new `App` is created per request.