### PR TITLE
vcreate: Create .gitignore in existing git repo.

### DIFF
--- a/cmd/tools/vcreate.v
+++ b/cmd/tools/vcreate.v
@@ -109,14 +109,14 @@ fn (c &Create) create_git_repo(dir string) {
 			cerror('Unable to create git repo')
 			exit(4)
 		}
-		if !os.exists('$dir/.gitignore') {
-			mut fl := os.create('$dir/.gitignore') or {
-				// We don't really need a .gitignore, it's just a nice-to-have
-				return
-			}
-			fl.write_string(gen_gitignore(c.name)) or { panic(err) }
-			fl.close()
+	}
+	if !os.exists('$dir/.gitignore') {
+		mut fl := os.create('$dir/.gitignore') or {
+			// We don't really need a .gitignore, it's just a nice-to-have
+			return
 		}
+		fl.write_string(gen_gitignore(c.name)) or { panic(err) }
+		fl.close()
 	}
 }
 

--- a/cmd/tools/vcreate_test.v
+++ b/cmd/tools/vcreate_test.v
@@ -2,15 +2,7 @@ import os
 
 const test_path = 'vcreate_test'
 
-fn test_v_init() ? {
-	dir := os.join_path(os.temp_dir(), test_path)
-	os.rmdir_all(dir) or {}
-	os.mkdir(dir) ?
-	defer {
-		os.rmdir_all(dir) or {}
-	}
-	os.chdir(dir)
-
+fn init_and_check() ? {
 	vexe := os.getenv('VEXE')
 	os.execute_or_panic('$vexe init')
 
@@ -44,4 +36,46 @@ fn test_v_init() ? {
 		'*.dll',
 		'',
 	].join('\n')
+}
+
+fn test_v_init() ? {
+	dir := os.join_path(os.temp_dir(), test_path)
+	os.rmdir_all(dir) or {}
+	os.mkdir(dir) ?
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	os.chdir(dir)
+
+	init_and_check() ?
+}
+
+fn test_v_init_in_git_dir() ? {
+	dir := os.join_path(os.temp_dir(), test_path)
+	os.rmdir_all(dir) or {}
+	os.execute_or_panic('git init $dir')
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	os.chdir(dir)
+
+	init_and_check() ?
+}
+
+fn test_v_init_no_overwrite_gitignore() ? {
+	dir := os.join_path(os.temp_dir(), test_path)
+	os.rmdir_all(dir) or {}
+	os.mkdir(dir) ?
+	mut fl := os.create('$dir/.gitignore') ?
+	fl.write_string('blah') ?
+	fl.close()
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	os.chdir(dir)
+
+	vexe := os.getenv('VEXE')
+	os.execute_or_panic('$vexe init')
+
+	assert os.read_file('.gitignore') ? == 'blah'
 }

--- a/cmd/tools/vcreate_test.v
+++ b/cmd/tools/vcreate_test.v
@@ -65,10 +65,8 @@ fn test_v_init_in_git_dir() ? {
 fn test_v_init_no_overwrite_gitignore() ? {
 	dir := os.join_path(os.temp_dir(), test_path)
 	os.rmdir_all(dir) or {}
-	os.mkdir(dir) ?
-	mut fl := os.create('$dir/.gitignore') ?
-	fl.write_string('blah') ?
-	fl.close()
+	os.mkdir(dir) or {}
+	os.write_file('$dir/.gitignore', 'blah') ?
 	defer {
 		os.rmdir_all(dir) or {}
 	}


### PR DESCRIPTION
Previously, running `git init example && cd example && v init` would not
create a .gitignore file, as the dir was already a git repo.

We should create a .gitignore even if the repo is already init'd, as
long as a .gitignore does not already exist.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
