### PR TITLE
vweb: Errors in accept wont panic plus improved retry logic

### DIFF
--- a/vlib/net/common.v
+++ b/vlib/net/common.v
@@ -78,7 +78,7 @@ fn select_with_retry(handle int, test Select, timeout time.Duration) ?bool {
 				// signal! lets retry max 10 times
 				// suspend thread with sleep to let the gc get
 				// cycles in the case the Bohem gc is interupting
-				time.sleep(1*time.millisecond)
+				time.sleep(1 * time.millisecond)
 				retries -= 1
 				continue
 			}

--- a/vlib/net/common.v
+++ b/vlib/net/common.v
@@ -76,7 +76,8 @@ fn select_with_retry(handle int, test Select, timeout time.Duration) ?bool {
 		ready := @select(handle, test, timeout) or {
 			if err.code == 4 {
 				// signal! lets retry max 10 times
-				// suspend thread to let the gc do it's thing
+				// suspend thread with sleep to let the gc get
+				// cycles in the case the Bohem gc is interupting
 				time.sleep(1*time.millisecond)
 				retries -= 1
 				continue

--- a/vlib/net/common.v
+++ b/vlib/net/common.v
@@ -71,11 +71,13 @@ fn @select(handle int, test Select, timeout time.Duration) ?bool {
 // collection
 [inline]
 fn select_with_retry(handle int, test Select, timeout time.Duration) ?bool {
-	mut retries := 3
+	mut retries := 10
 	for retries > 0 {
 		ready := @select(handle, test, timeout) or {
 			if err.code == 4 {
-				// signal! lets retry max 3 times
+				// signal! lets retry max 10 times
+				// suspend thread to let the gc do it's thing
+				time.sleep(1*time.millisecond)
 				retries -= 1
 				continue
 			}

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -333,7 +333,11 @@ pub fn run<T>(global_app &T, port int) {
 		// request_app.Context = Context{
 		// conn: 0
 		//}
-		mut conn := l.accept() or { panic('accept() failed') }
+		mut conn := l.accept() or {
+			// failures should not panic
+			eprintln('accept() failed with error: $err.msg')
+			continue
+		}
 		go handle_conn<T>(mut conn, mut request_app)
 	}
 }


### PR DESCRIPTION
vweb accept was currently panicing if the accept method returned error.
new behaviour: It correctly logs the error and continue serve requests. 

I also added a few more retries on the retry logic in net select module plus a small wait to let the GC get CPU cylcles and lessen the probablility that it is signalling again. 

These two should contribute to make the vweb keep running even if interupted by signal and lessen the chance that interuption is happening.
