### PR TITLE
gen: fix fn mut args of array (fix #10492)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -760,6 +760,10 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		arg_name := '_arg_expr_${fn_name}_0_$node.pos.pos'
 		g.write('/*af receiver arg*/' + arg_name)
 	} else {
+		if left_sym.kind == .array && node.left.is_auto_deref_var()
+			&& node.name in ['first', 'last', 'repeat'] {
+			g.write('*')
+		}
 		g.expr(node.left)
 		if node.from_embed_type != 0 {
 			embed_name := typ_sym.embed_name()

--- a/vlib/v/tests/fn_mut_args_test.v
+++ b/vlib/v/tests/fn_mut_args_test.v
@@ -25,3 +25,21 @@ fn test_fn_mut_args_of_map() {
 		'one': 1
 	}
 }
+
+struct MyData {
+pub mut:
+	ar []int
+}
+
+fn pass_array_mut(mut ar []int) int {
+	if ar.len > 0 && ar.last() == 99 {
+		return 99
+	}
+	return 0
+}
+
+fn test_fn_mut_args_of_array_last() {
+	mut m := MyData{}
+	m.ar << 99
+	assert pass_array_mut(mut m.ar) == 99
+}


### PR DESCRIPTION
This PR fix fn mut args of array (fix #10492).

- Fix fn mut args of array.
- Add test.

```vlang
struct MyData1 {
pub mut:
	ar []int
}

fn pass_array_mut(mut ar []int) int {
	if ar.len > 0 && ar.last() == 99 {
		return 99
	}
	return 0
}

fn main() {
	mut m := MyData1{}
	m.ar << 99
	assert pass_array_mut(mut m.ar) == 99
}

PS D:\Test\v\tt1> v run .
```