### PR TITLE
parser: fix `rewind_scanner_to_current_token_in_new_mode`

### DIFF
--- a/cmd/tools/vdoc/tests/testdata/project1/main.out
+++ b/cmd/tools/vdoc/tests/testdata/project1/main.out
@@ -1,3 +1,1 @@
-cmd/tools/vdoc/tests/testdata/project1/main.v:0:1: error: unexpected unknown, expecting `const`
-    1 | const (
-    2 |     source_root = 'temp'
+vdoc: No documentation found for /v/vmaster/cmd/tools/vdoc/tests/testdata/project1/main.v

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3261,7 +3261,8 @@ fn (mut p Parser) rewind_scanner_to_current_token_in_new_mode() {
 	no_token := token.Token{}
 	p.prev_tok = no_token
 	p.tok = no_token
-	p.peek_tok = no_token
+	p.peek_tok = no_token // requires 2 calls p.next() or check p.tok.kind != token.Kind.unknown
+	p.next()
 	for {
 		p.next()
 		// eprintln('rewinding to ${p.tok.tidx:5} | goal: ${tidx:5}')


### PR DESCRIPTION
fix #10385

Added forgotten repeated call `p.next()`