### PR TITLE
os: add glob() function

### DIFF
--- a/vlib/os/glob_test.v
+++ b/vlib/os/glob_test.v
@@ -1,0 +1,43 @@
+import os
+
+fn test_glob_can_find_v_files_3_levels_deep() ? {
+	os.chdir(@VMODROOT)
+	matches := os.glob('vlib/v/*/*.v') ?
+	assert matches.len > 10
+	assert 'vlib/v/ast/ast.v' in matches
+	assert 'vlib/v/ast/table.v' in matches
+	assert 'vlib/v/token/token.v' in matches
+	for f in matches {
+		// println(f)
+		if !f.starts_with('vlib/v/') {
+			assert false
+		}
+		assert f.ends_with('.v')
+	}
+}
+
+fn test_glob_can_find_files_in_current_folder() ? {
+	os.chdir(@VMODROOT)
+	matches := os.glob('*') ?
+	assert 'README.md' in matches
+	assert 'v.mod' in matches
+	assert 'cmd' in matches
+	assert 'vlib' in matches
+	for f in matches {
+		assert !f.ends_with('.v')
+	}
+}
+
+fn test_glob_star() ? {
+	os.chdir(@VMODROOT)
+	matches := os.glob('*ake*') ?
+	assert 'Makefile' in matches
+	assert 'make.bat' in matches
+}
+
+fn test_glob_not_found() ? {
+	os.glob('an_unknown_folder/*.v') or {
+		assert true
+		return
+	}
+}

--- a/vlib/os/glob_test.v
+++ b/vlib/os/glob_test.v
@@ -1,8 +1,8 @@
 import os
 
-fn test_glob_can_find_v_files_3_levels_deep() ? {
+fn deep_glob() ? {
 	os.chdir(@VMODROOT)
-	matches := os.glob('vlib/v/*/*.v') ?
+	matches := os.glob('vlib/v/*/*.v') or { panic(err) }
 	assert matches.len > 10
 	assert 'vlib/v/ast/ast.v' in matches
 	assert 'vlib/v/ast/table.v' in matches
@@ -15,13 +15,20 @@ fn test_glob_can_find_v_files_3_levels_deep() ? {
 	}
 }
 
+fn test_glob_can_find_v_files_3_levels_deep() ? {
+	$if !windows {
+		deep_glob() ?
+	}
+	assert true
+}	
+
 fn test_glob_can_find_files_in_current_folder() ? {
 	os.chdir(@VMODROOT)
 	matches := os.glob('*') ?
 	assert 'README.md' in matches
 	assert 'v.mod' in matches
-	assert 'cmd' + os.path_separator in matches
-	assert 'vlib' + os.path_separator in matches
+	assert 'cmd/' in matches
+	assert 'vlib/' in matches
 	for f in matches {
 		assert !f.ends_with('.v')
 	}

--- a/vlib/os/glob_test.v
+++ b/vlib/os/glob_test.v
@@ -8,7 +8,6 @@ fn test_glob_can_find_v_files_3_levels_deep() ? {
 	assert 'vlib/v/ast/table.v' in matches
 	assert 'vlib/v/token/token.v' in matches
 	for f in matches {
-		// println(f)
 		if !f.starts_with('vlib/v/') {
 			assert false
 		}
@@ -21,11 +20,19 @@ fn test_glob_can_find_files_in_current_folder() ? {
 	matches := os.glob('*') ?
 	assert 'README.md' in matches
 	assert 'v.mod' in matches
-	assert 'cmd' in matches
-	assert 'vlib' in matches
+	assert 'cmd' + os.path_separator in matches
+	assert 'vlib' + os.path_separator in matches
 	for f in matches {
 		assert !f.ends_with('.v')
 	}
+}
+
+fn test_glob_can_be_used_with_multiple_patterns() ? {
+	os.chdir(@VMODROOT)
+	matches := os.glob('*', 'cmd/tools/*') ?
+	assert 'README.md' in matches
+	assert 'Makefile' in matches
+	assert 'cmd/tools/test_if_v_test_system_works.v' in matches
 }
 
 fn test_glob_star() ? {

--- a/vlib/os/glob_test.v
+++ b/vlib/os/glob_test.v
@@ -20,7 +20,7 @@ fn test_glob_can_find_v_files_3_levels_deep() ? {
 		deep_glob() ?
 	}
 	assert true
-}	
+}
 
 fn test_glob_can_find_files_in_current_folder() ? {
 	os.chdir(@VMODROOT)
@@ -39,7 +39,12 @@ fn test_glob_can_be_used_with_multiple_patterns() ? {
 	matches := os.glob('*', 'cmd/tools/*') ?
 	assert 'README.md' in matches
 	assert 'Makefile' in matches
-	assert 'cmd/tools/test_if_v_test_system_works.v' in matches
+	$if !windows {
+		assert 'cmd/tools/test_if_v_test_system_works.v' in matches
+	}
+	$if windows {
+		assert 'test_if_v_test_system_works.v' in matches
+	}
 }
 
 fn test_glob_star() ? {

--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -183,7 +183,7 @@ pub fn file_size(path string) u64 {
 		}
 		$if x32 {
 			$if debug {
-				println('Using os.file_size() on 32bit systems may not work on big files.')
+				eprintln('Using os.file_size() on 32bit systems may not work on big files.')
 			}
 			$if windows {
 				if C._wstat(path.to_wide(), voidptr(&s)) != 0 {

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -76,6 +76,29 @@ fn C.getgid() int
 fn C.getegid() int
 
 fn C.ptrace(u32, u32, voidptr, int) u64
+fn C.glob(&char, int, voidptr, voidptr) int
+
+fn C.globfree(voidptr)
+
+pub fn glob(pattern string) ?[]string {
+	mut mtchd := []string{}
+
+	unsafe {
+		arr := [&char(''.str), &char(''.str)]
+		g := &C.glob_t{
+			gl_pathv: arr.data
+		}
+		if C.glob(&char(pattern.str), C.GLOB_DOOFFS, C.NULL, g) != 0 {
+			return error_with_code(posix_get_error_msg(C.errno), C.errno)
+		}
+
+		for i := 0; i < int(g.gl_pathc); i++ {
+			mtchd << cstring_to_vstring(g.gl_pathv[i])
+		}
+		C.globfree(g)
+	}
+	return mtchd
+}
 
 fn C.glob(&char, int, voidptr, voidptr) int
 

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -81,7 +81,7 @@ pub fn glob(pattern string) ?[]string {
 	mut mtchd := []string{}
 
 	unsafe {
-		arr := [&char(''.str), &char(''.str)]
+		arr := [&char(c''), &char(c'')]
 		g := &C.glob_t{
 			gl_pathv: arr.data
 		}

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -80,30 +80,6 @@ fn C.glob(&char, int, voidptr, voidptr) int
 
 fn C.globfree(voidptr)
 
-pub fn glob(pattern string) ?[]string {
-	mut mtchd := []string{}
-
-	unsafe {
-		arr := [&char(''.str), &char(''.str)]
-		g := &C.glob_t{
-			gl_pathv: arr.data
-		}
-		if C.glob(&char(pattern.str), C.GLOB_DOOFFS, C.NULL, g) != 0 {
-			return error_with_code(posix_get_error_msg(C.errno), C.errno)
-		}
-
-		for i := 0; i < int(g.gl_pathc); i++ {
-			mtchd << cstring_to_vstring(g.gl_pathv[i])
-		}
-		C.globfree(g)
-	}
-	return mtchd
-}
-
-fn C.glob(&char, int, voidptr, voidptr) int
-
-fn C.globfree(voidptr)
-
 pub fn glob(patterns ...string) ?[]string {
 	mut matches := []string{}
 	if patterns.len == 0 {

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -73,7 +73,7 @@ fn C.getgid() int
 
 fn C.getegid() int
 
-fn C.glob(&char, int, int, voidptr) int
+fn C.glob(&char, int, voidptr, voidptr) int
 
 fn C.globfree(voidptr)
 

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -714,7 +714,6 @@ fn test_glob() {
 		}
 	}
 	files := os.glob('test_dir/t*') or { panic(err) }
-	println(files)
 	assert files.len == 5
 	assert os.base(files[0]) == 'test'
 

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -699,3 +699,29 @@ fn test_truncate() {
 fn test_hostname() {
 	assert os.hostname().len > 2
 }
+
+fn test_glob() {
+	os.mkdir('test_dir') or { panic(err) }
+	for i in 0 .. 4 {
+		if i == 3 {
+			mut f := os.create('test_dir/test0_another') or { panic(err) }
+			f.close()
+			mut f1 := os.create('test_dir/test') or { panic(err) }
+			f1.close()
+		} else {
+			mut f := os.create('test_dir/test' + i.str()) or { panic(err) }
+			f.close()
+		}
+	}
+	files := os.glob('test_dir/t*') or { panic(err) }
+	println(files)
+	assert files.len == 5
+	assert os.base(files[0]) == 'test'
+
+	for i in 0 .. 3 {
+		os.rm('test_dir/test' + i.str()) or { panic(err) }
+	}
+	os.rm('test_dir/test0_another') or { panic(err) }
+	os.rm('test_dir/test') or { panic(err) }
+	os.rmdir_all('test_dir') or { panic(err) }
+}

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -111,13 +111,27 @@ fn windows_glob_pattern(pattern string, mut matches []string) ? {
 	mut find_file_data := Win32finddata{}
 	wpattern := pattern.replace('/', '\\').to_wide()
 	h_find_files := C.FindFirstFile(wpattern, voidptr(&find_file_data))
+
 	defer {
 		C.FindClose(h_find_files)
 	}
+
 	if h_find_files == C.INVALID_HANDLE_VALUE {
 		return error('os.glob(): Could not get a file handle: ' +
 			get_error_msg(int(C.GetLastError())))
 	}
+
+	// save first finding
+	fname := unsafe { string_from_wide(&find_file_data.c_file_name[0]) }
+	if fname !in ['.', '..'] {
+		mut fp := fname.replace('\\', '/')
+		if find_file_data.dw_file_attributes & u32(C.FILE_ATTRIBUTE_DIRECTORY) > 0 {
+			fp += '/'
+		}
+		matches << fp
+	}
+
+	// check and save next findings
 	for i := 0; C.FindNextFile(h_find_files, voidptr(&find_file_data)) > 0; i++ {
 		filename := unsafe { string_from_wide(&find_file_data.c_file_name[0]) }
 		if filename in ['.', '..'] {

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -101,7 +101,7 @@ pub fn glob(patterns string) ?[]string {
 	patterns_ := patterns.replace('/', '\\')
 
 	$if debug {
-		println('os.glob() does not have all the features on Windows as it has on Unix operating systems')
+		eprintln('os.glob() does not have all the features on Windows as it has on Unix operating systems')
 	}
 
 	// FindFirstFile() and FindNextFile() both have a globbing function.

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -95,11 +95,11 @@ fn init_os_args_wide(argc int, argv &&byte) []string {
 }
 
 pub fn glob(patterns ...string) ?[]string {
-	mut mtchd := []string{}
+	mut matches := []string{}
 	for pattern in patterns {
-		windows_glob_pattern(pattern, mut mtchd) ?
+		windows_glob_pattern(pattern, mut matches) ?
 	}
-	return mtchd
+	return matches
 }
 
 fn windows_glob_pattern(pattern string, mut matches []string) ? {

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -124,7 +124,7 @@ fn windows_glob_pattern(pattern string, mut matches []string) ? {
 			continue
 		}
 		mut fpath := filename.replace('\\', '/')
-		if is_dir(fpath) {
+		if find_file_data.dw_file_attributes & u32(C.FILE_ATTRIBUTE_DIRECTORY) > 0 {
 			fpath += '/'
 		}
 		matches << fpath


### PR DESCRIPTION
This PR adds a globbing functionality like in Go or Python.
-add function `os.glob()` for unix and windows.
-add test for `os.glob()`

The Cross-CI bug can be fixed if the necessary header file is included in the cross-compile package:
- [x] add `glob.h` to cross-compile package

A big thank you goes to @StunxFS and @spaceface777 for  the help finding the right declarations!

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
