### PR TITLE
net: return error unless response code was 200

### DIFF
--- a/vlib/net/http/download.v
+++ b/vlib/net/http/download.v
@@ -10,6 +10,9 @@ pub fn download_file(url string, out string) ? {
 		println('download file url=$url out=$out')
 	}
 	s := get(url) or { return err }
+	if s.status_code != 200 {
+		return error('received http code $s.status_code')
+	}
 	os.write_file(out, s.text) ?
 	// download_file_with_progress(url, out, empty, empty)
 }


### PR DESCRIPTION
Better to tell the user if they don't get the file they asked for, than to silently download a 404 error page or whatever.