### PR TITLE
cgen: fix unknown labels in addressing

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1967,7 +1967,7 @@ fn (mut g Gen) gen_asm_stmt(stmt ast.AsmStmt) {
 		}
 		g.writeln('"')
 	}
-	if !stmt.is_top_level {
+	if stmt.output.len != 0 || stmt.input.len != 0 || stmt.clobbered.len != 0 || stmt.is_goto {
 		g.write(': ')
 	}
 	g.gen_asm_ios(stmt.output)
@@ -2008,7 +2008,8 @@ fn (mut g Gen) asm_arg(arg ast.AsmArg, stmt ast.AsmStmt) {
 		ast.AsmAlias {
 			name := arg.name
 			if name in stmt.local_labels || name in stmt.global_labels
-				|| name in g.file.global_labels || stmt.is_top_level {
+				|| name in g.file.global_labels || stmt.is_top_level
+				|| (name !in stmt.input.map(it.alias) && name !in stmt.output.map(it.alias)) {
 				asm_formatted_name := if name in stmt.global_labels { '%l[$name]' } else { name }
 				g.write(asm_formatted_name)
 			} else {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1382,7 +1382,7 @@ fn (mut p Parser) asm_ios(output bool) []ast.AsmIO {
 
 		mut constraint := ''
 		if p.tok.kind == .lpar {
-			constraint = if output { '+r' } else { 'r' } // default constraint
+			constraint = if output { '+r' } else { 'r' } // default constraint, though vfmt fmts to `+r` and `r`
 		} else {
 			constraint += match p.tok.kind {
 				.assign {

--- a/vlib/v/tests/assembly/asm_test.amd64.v
+++ b/vlib/v/tests/assembly/asm_test.amd64.v
@@ -167,7 +167,7 @@ fn test_rip_relative_label_byte() {
 
 $if !macos {
 	asm amd64 {
-		.global one_two_three
+		.global byte_sequence
 		byte_sequence:
 		.byte 0x27, 0x35, 0x0f, 0x48
 	}


### PR DESCRIPTION
This fixes 
```asm
lea rbx, [rip + syscall_table]
```
generating
```asm
lea %[syscall_table](%%rip), %%rbx;
```
instead of
```asm
lea syscall_table(%%rip), %%rbx;
```
and also removes the `:` at end of assembly blocks that do not have any input/output/etc.