### PR TITLE
os: fix some C compiler warnings for windows

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -246,7 +246,7 @@ fn C.RegSetValueExW(hKey voidptr, lpValueName &u16, Reserved u32, dwType u32, lp
 
 fn C.RegCloseKey(hKey voidptr)
 
-fn C.RemoveDirectory(lpPathName &char) int
+fn C.RemoveDirectory(lpPathName &u16) int
 
 // fn C.GetStdHandle() voidptr
 fn C.GetStdHandle(u32) voidptr

--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -29,7 +29,7 @@ fn C.CopyFile(&u16, &u16, bool) int
 
 // fn C.lstat(charptr, voidptr) u64
 
-fn C._wstat64(&char, voidptr) u64
+fn C._wstat64(&u16, voidptr) u64
 
 fn C.chown(&char, int, int) int
 
@@ -168,7 +168,7 @@ pub fn file_size(path string) u64 {
 		$if x64 {
 			$if windows {
 				mut swin := C.__stat64{}
-				if C._wstat64(&char(path.to_wide()), voidptr(&swin)) != 0 {
+				if C._wstat64(path.to_wide(), voidptr(&swin)) != 0 {
 					eprintln_unknown_file_size()
 					return 0
 				}
@@ -471,7 +471,7 @@ pub fn rm(path string) ? {
 // rmdir removes a specified directory.
 pub fn rmdir(path string) ? {
 	$if windows {
-		rc := C.RemoveDirectory(&char(path.to_wide()))
+		rc := C.RemoveDirectory(path.to_wide())
 		if rc == 0 {
 			// https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-removedirectorya - 0 is failure
 			return error('Failed to remove "$path": ' + posix_get_error_msg(C.errno))
@@ -777,7 +777,7 @@ pub fn getwd() string {
 // NB: this particular rabbit hole is *deep* ...
 [manualfree]
 pub fn real_path(fpath string) string {
-	mut fullpath := &byte(0)
+	mut fullpath := &u16(0)
 	mut res := ''
 	$if windows {
 		// GetFullPathName doesn't work with symbolic links,

--- a/vlib/os/os_c.v
+++ b/vlib/os/os_c.v
@@ -777,12 +777,11 @@ pub fn getwd() string {
 // NB: this particular rabbit hole is *deep* ...
 [manualfree]
 pub fn real_path(fpath string) string {
-	mut fullpath := &u16(0)
 	mut res := ''
 	$if windows {
 		// GetFullPathName doesn't work with symbolic links,
 		// so if it is not a file, get full path
-		fullpath = unsafe { &u16(vcalloc_noscan(max_path_len * 2)) }
+		mut fullpath := unsafe { &u16(vcalloc_noscan(max_path_len * 2)) }
 		// TODO: check errors if path len is not enough
 		ret := C.GetFullPathName(fpath.to_wide(), max_path_len, fullpath, 0)
 		if ret == 0 {
@@ -791,7 +790,7 @@ pub fn real_path(fpath string) string {
 		}
 		res = unsafe { string_from_wide(fullpath) }
 	} $else {
-		fullpath = vcalloc_noscan(max_path_len)
+		mut fullpath := vcalloc_noscan(max_path_len)
 		ret := &char(C.realpath(&char(fpath.str), &char(fullpath)))
 		if ret == 0 {
 			unsafe { free(fullpath) }


### PR DESCRIPTION
This PR fixes some Windows C-compiler warnings in the OS module.
The fixed functions are:
- `os.real_path()` Windows needs a `(short unsigned int *)` aka. `&u16` 
- same for `os.file_size()` and `os.rmdir()` 
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
