### PR TITLE
orm: Fix variable binds in psql.

### DIFF
--- a/vlib/v/gen/c/sql.v
+++ b/vlib/v/gen/c/sql.v
@@ -1615,7 +1615,7 @@ fn (mut g Gen) expr_to_sql(expr ast.Expr, typ SqlType) {
 				g.inc_sql_i(typ)
 				info := expr.info as ast.IdentVar
 				ityp := info.typ
-				if typ == .sqlite3 {
+				if typ in [.sqlite3, .psql] {
 					if ityp == ast.string_type {
 						g.sql_bind('${expr.name}.str', '${expr.name}.len', g.sql_get_real_type(ityp),
 							typ)


### PR DESCRIPTION
Fixes #10504.

64391efa4d673a20e656ade9272612fb93704fee added support for mysql, which
introduced branching logic for binding variables based on the DB type.

With the new logic, psql was subsituting in the parameter number (not
the parameter value). That is, the query:

```
select from Module where id == the_id && id == the_id
```

will generate the query
```
SELECT "id", "name" FROM "Module" WHERE id = 1 and id = 2 ORDER BY id
```

I'm unable to test mysql/mssql to know what works there, but the
original logic seems to work for me in psql.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
