### PR TITLE
ast.table: fix anonymous functions for non-tcc c compilers

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -180,7 +180,9 @@ pub fn (t &Table) fn_type_signature(f &Fn) string {
 		// TODO: for now ignore mut/pts in sig for now
 		typ := arg.typ.set_nr_muls(0)
 		arg_type_sym := t.get_type_symbol(typ)
-		sig += '$arg_type_sym.kind'
+		sig += arg_type_sym.str().to_lower().replace_each(['.', '__', '&', '', '[]', 'arr_', 'chan ',
+			'chan_',
+		])
 		if i < f.params.len - 1 {
 			sig += '_'
 		}

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -181,8 +181,7 @@ pub fn (t &Table) fn_type_signature(f &Fn) string {
 		typ := arg.typ.set_nr_muls(0)
 		arg_type_sym := t.get_type_symbol(typ)
 		sig += arg_type_sym.str().to_lower().replace_each(['.', '__', '&', '', '[]', 'arr_', 'chan ',
-			'chan_',
-		])
+			'chan_', 'map[', 'map_of_', ']', '_to_'])
 		if i < f.params.len - 1 {
 			sig += '_'
 		}


### PR DESCRIPTION
https://github.com/Terisback/discord.v did not work on C compilers other than tcc (it might be a tcc bug that it worked). This is because while two anonymous functions accepting i64 and int were different, two anonymous functions accepting two different structs were considered the same. This fixes the problem by making generated function names based on their actual type, instead of their `ast.Kind`.