### PR TITLE
orm: Don't panic for psql query with no results.

### DIFF
--- a/vlib/v/gen/c/sql.v
+++ b/vlib/v/gen/c/sql.v
@@ -994,6 +994,7 @@ fn (mut g Gen) psql_select_expr(node ast.SqlExpr, sub bool, line string, typ Sql
 			g.writeln('};')
 		}
 		fields := g.new_tmp_var()
+		g.writeln('if (${rows}.len > 0) {')
 		g.writeln('Array_string $fields = (*(pg__Row*) array_get($rows, $tmp_i)).vals;')
 		fld := g.new_tmp_var()
 		g.writeln('string $fld;')
@@ -1050,6 +1051,7 @@ fn (mut g Gen) psql_select_expr(node ast.SqlExpr, sub bool, line string, typ Sql
 			g.writeln('\t array_push((array*)&${tmp}_array, _MOV(($elem_type_str[]) { $tmp }));\n')
 			g.writeln('}')
 		}
+		g.writeln('}')
 		g.writeln('string_free(&$g.sql_stmt_name);')
 		if node.is_array {
 			g.writeln('$cur_line ${tmp}_array; ')


### PR DESCRIPTION

This fixes part of the issue in #10507, where psql will panic for an
empty result while sqlite will return a default struct.

Given the following code:

```
module main

import pg
import sqlite

struct Player {
	id   int    [primary; sql: serial]
	name string
}

fn main() {
	mut db := pg.connect(host: 'localhost', user: 'postgres', dbname: 'postgres', password: 'abc') ?
	// mut db := sqlite.connect(':memory:') ?
	sql db {
		create table Player
	}
	res := sql db {
		select from Player where id == 99
	}
	println(res)
}
```

psql will panic (assuming id 99 does not exist), while sqlite will
return an empty `Player`.

This avoids the panic by checking if the result is empty first.
Ideally both would return an Optional.

[example.zip](https://github.com/vlang/v/files/6679494/example.zip) contains before/after c code.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
