### PR TITLE
tests: add auto as cast already smartcast sumtype test

### DIFF
--- a/vlib/v/tests/as_cast_already_smartcast_sumtype_test.v
+++ b/vlib/v/tests/as_cast_already_smartcast_sumtype_test.v
@@ -1,0 +1,30 @@
+struct S1 {
+	s1 string = 'abc'
+}
+
+struct Empty {
+}
+
+type Sum = S1 | Empty
+
+fn test_as_cast_already_smartcast_sumtype() {
+	a := Sum(S1{})
+	if a is S1 {
+		println('if expr: $a.s1')
+		assert a.s1 == 'abc'
+		v1 := a as S1
+		println('if expr (as cast): $v1.s1')
+		assert v1.s1 == 'abc'
+	}
+
+	match a {
+		S1 {
+			println('match expr: $a.s1')
+			assert a.s1 == 'abc'
+			v1 := a as S1
+			println('match expr (as cast): $v1.s1')
+			assert v1.s1 == 'abc'
+		}
+		else {}
+	}
+}

--- a/vlib/v/tests/as_cast_already_smartcast_sumtype_test.v
+++ b/vlib/v/tests/as_cast_already_smartcast_sumtype_test.v
@@ -5,7 +5,7 @@ struct S1 {
 struct Empty {
 }
 
-type Sum = S1 | Empty
+type Sum = Empty | S1
 
 fn test_as_cast_already_smartcast_sumtype() {
 	a := Sum(S1{})


### PR DESCRIPTION
This PR add auto as cast already smartcast sumtype test.

```vlang
struct S1 {
	s1 string = 'abc'
}

struct Empty {
}

type Sum = S1 | Empty

fn main() {
	a := Sum(S1{})
	if a is S1 {
		println('if expr: $a.s1')
		assert a.s1 == 'abc'
		v1 := a as S1
		println('if expr (as cast): $v1.s1')
		assert v1.s1 == 'abc'
	}

	match a {
		S1 {
			println('match expr: $a.s1')
			assert a.s1 == 'abc'
			v1 := a as S1
			println('match expr (as cast): $v1.s1')
			assert v1.s1 == 'abc'
		}
		else {}
	}
}

PS D:\Test\v\tt1> v run .
if expr: abc
if expr (as cast): abc
match expr: abc
match expr (as cast): abc
```