### PR TITLE
cgen: fix assign map value of fixed array (fix #10515)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2473,7 +2473,9 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 			else {}
 		}
 		right_sym := g.table.get_type_symbol(g.unwrap_generic(val_type))
-		is_fixed_array_var := right_sym.kind == .array_fixed && val is ast.Ident
+		is_fixed_array_var := right_sym.kind == .array_fixed && (val is ast.Ident
+			|| val is ast.IndexExpr || val is ast.CallExpr
+			|| val is ast.SelectorExpr)
 		g.is_assign_lhs = true
 		g.assign_op = assign_stmt.op
 		if val_type.has_flag(.optional) {
@@ -2490,7 +2492,8 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 				g.expr(val)
 				g.writeln(';}')
 			}
-		} else if assign_stmt.op == .assign && (is_fixed_array_init || is_fixed_array_var) {
+		} else if assign_stmt.op == .assign
+			&& (is_fixed_array_init || (right_sym.kind == .array_fixed && val is ast.Ident)) {
 			mut v_var := ''
 			arr_typ := styp.trim('*')
 			if is_fixed_array_init {

--- a/vlib/v/tests/assign_map_value_of_fixed_array_test.v
+++ b/vlib/v/tests/assign_map_value_of_fixed_array_test.v
@@ -1,0 +1,18 @@
+fn test_assign_map_value_of_fixed_array() {
+	mut m := map[string][2]f64{}
+
+	m['A'] = [1.1, 2.2]!
+	m['B'] = [0.1, 0.2]!
+
+	mut arr := m['A']
+	println(arr)
+	assert '$arr' == '[1.1, 2.2]'
+
+	arr = m['B']
+	println(arr)
+	assert '$arr' == '[0.1, 0.2]'
+
+	arr = m['C']
+	println(arr)
+	assert '$arr' == '[0, 0]'
+}


### PR DESCRIPTION
This PR fix assign map value of fixed array (fix #10515).

- Fix assign map value of fixed array.
- Add test.

```vlang
fn main() {
	mut m := map[string][2]f64{}

	m['A'] = [1.1, 2.2]!
	m['B'] = [0.1, 0.2]!

	mut arr := m['A']
	println(arr)
	assert '$arr' == '[1.1, 2.2]'

	arr = m['B']
	println(arr)
	assert '$arr' == '[0.1, 0.2]'

	arr = m['C']
	println(arr)
	assert '$arr' == '[0, 0]'
}

PS D:\Test\v\tt1> v run .
[1.1, 2.2]
[0.1, 0.2]
[0, 0]
```