### PR TITLE
all: promote value type function arguments to heap if necessary

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7296,6 +7296,18 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 		// Make sure all types are valid
 		for arg in node.params {
 			c.ensure_type_exists(arg.typ, arg.type_pos) or { return }
+			if !arg.typ.is_ptr() { // value parameter, i.e. on stack - check for `[heap]`
+				arg_typ_sym := c.table.get_type_symbol(arg.typ)
+				if arg_typ_sym.kind == .struct_ {
+					info := arg_typ_sym.info as ast.Struct
+					if info.is_heap { // set auto_heap to promote value parameter
+						mut v := node.scope.find_var(arg.name) or {
+							continue
+						}
+						v.is_auto_heap = true
+					}
+				}
+			}
 		}
 	}
 	if node.language == .v && node.name.after_char(`.`) == 'init' && !node.is_method

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7301,9 +7301,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				if arg_typ_sym.kind == .struct_ {
 					info := arg_typ_sym.info as ast.Struct
 					if info.is_heap { // set auto_heap to promote value parameter
-						mut v := node.scope.find_var(arg.name) or {
-							continue
-						}
+						mut v := node.scope.find_var(arg.name) or { continue }
 						v.is_auto_heap = true
 					}
 				}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6426,9 +6426,14 @@ pub fn (mut c Checker) mark_as_referenced(mut node ast.Expr) {
 					c.error('cannot reference fixed array `$node.name` outside `unsafe` blocks as it is supposed to be stored on stack',
 						node.pos)
 				} else {
-					if type_sym.kind == .struct_ {
-						info := type_sym.info as ast.Struct
-						if !info.is_heap {
+					match type_sym.kind {
+						.struct_ {
+							info := type_sym.info as ast.Struct
+							if !info.is_heap {
+								node.obj.is_auto_heap = true
+							}
+						}
+						else {
 							node.obj.is_auto_heap = true
 						}
 					}

--- a/vlib/v/checker/tests/function_missing_return_type.out
+++ b/vlib/v/checker/tests/function_missing_return_type.out
@@ -3,13 +3,6 @@ vlib/v/checker/tests/function_missing_return_type.vv:1:1: error: missing return 
       | ~~~~~~~~~~
     2 | }
     3 |
-vlib/v/checker/tests/function_missing_return_type.vv:14:11: error: `s` cannot be referenced outside `unsafe` blocks as it might be stored on stack. Consider declaring `Abc` as `[heap]`.
-   12 | fn (s Abc) abc() &int {
-   13 |     if true {
-   14 |         return &s.x
-      |                 ^
-   15 |     }
-   16 |     s.panic(@FN)
 vlib/v/checker/tests/function_missing_return_type.vv:12:1: error: missing return at end of function `abc`
    10 | }
    11 | 

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2444,7 +2444,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					ret_styp := g.typ(val.decl.return_type)
 					g.write('$ret_styp (*$ident.name) (')
 					def_pos := g.definitions.len
-					g.fn_args(val.decl.params, val.decl.is_variadic)
+					g.fn_args(val.decl.params, val.decl.is_variadic, voidptr(0))
 					g.definitions.go_back(g.definitions.len - def_pos)
 					g.write(') = ')
 				} else {
@@ -2569,7 +2569,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 				ret_styp := g.typ(func.func.return_type)
 				g.write('$ret_styp (*${g.get_ternary_name(ident.name)}) (')
 				def_pos := g.definitions.len
-				g.fn_args(func.func.params, func.func.is_variadic)
+				g.fn_args(func.func.params, func.func.is_variadic, voidptr(0))
 				g.definitions.go_back(g.definitions.len - def_pos)
 				g.write(')')
 			} else {
@@ -6147,7 +6147,7 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 						...params[0]
 						typ: params[0].typ.set_nr_muls(1)
 					}
-					fargs, _ := g.fn_args(params, false) // second argument is ignored anyway
+					fargs, _, _ := g.fn_args(params, false, voidptr(0)) // second argument is ignored anyway
 					methods_wrapper.write_string(g.out.cut_last(g.out.len - params_start_pos))
 					methods_wrapper.writeln(') {')
 					methods_wrapper.write_string('\t')

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -310,10 +310,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 					scope: 0
 				}
 			}
-			mut is_stack_obj := true
-			if param.typ.has_flag(.shared_f) {
-				is_stack_obj = false
-			}
+			is_stack_obj := !param.typ.has_flag(.shared_f) && (param.is_mut || param.typ.is_ptr())
 			p.scope.register(ast.Var{
 				name: param.name
 				typ: param.typ
@@ -628,10 +625,7 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 		if arg.name.len == 0 {
 			p.error_with_pos('use `_` to name an unused parameter', arg.pos)
 		}
-		mut is_stack_obj := true
-		if arg.typ.has_flag(.shared_f) {
-			is_stack_obj = false
-		}
+		is_stack_obj := !arg.typ.has_flag(.shared_f) && (arg.is_mut || arg.typ.is_ptr())
 		p.scope.register(ast.Var{
 			name: arg.name
 			typ: arg.typ

--- a/vlib/v/tests/break_in_lock_test.v
+++ b/vlib/v/tests/break_in_lock_test.v
@@ -6,7 +6,8 @@ mut:
 }
 
 const (
-	sleep_time = time.millisecond * 50
+	run_time   = time.millisecond * 200 // must be big enough to ensure threads have started
+	sleep_time = time.millisecond * 250 // some tolerance added
 )
 
 fn test_return_lock() {
@@ -16,12 +17,12 @@ fn test_return_lock() {
 	go fn (shared s AA, start time.Time) {
 		for {
 			reader(shared s)
-			if time.now() - start > sleep_time {
+			if time.now() - start > run_time {
 				exit(0)
 			}
 		}
 	}(shared s, start)
-	time.sleep(sleep_time * 2)
+	time.sleep(sleep_time)
 	assert false
 }
 
@@ -30,7 +31,7 @@ fn printer(shared s AA, start time.Time) {
 		lock s {
 			assert s.b in ['0', '1', '2', '3', '4', '5']
 		}
-		if time.now() - start > time.millisecond * 50 {
+		if time.now() - start > run_time {
 			exit(0)
 		}
 	}

--- a/vlib/v/tests/heap_struct_test.v
+++ b/vlib/v/tests/heap_struct_test.v
@@ -58,4 +58,27 @@ fn test_ref_struct() {
 	assert u.n == 3
 	assert v.n == 7
 	assert w.a.n == 23
+	assert d == 16.0
+}
+
+struct NotHeap {
+mut:
+	f f64
+}
+
+fn return_struct_value_as_ref(q NotHeap) &NotHeap {
+	return &q
+}
+
+fn test_value_ref_struct() {
+	mut x := NotHeap {
+		f: -17.125
+	}
+	y := return_struct_value_as_ref(x)
+	x.f = 91.0625
+	d := owerwrite_stack()
+	assert typeof(y).name == '&NotHeap'
+	assert y.f == -17.125
+	assert x.f == 91.0625
+	assert d == 16.0
 }

--- a/vlib/v/tests/heap_struct_test.v
+++ b/vlib/v/tests/heap_struct_test.v
@@ -61,6 +61,28 @@ fn test_ref_struct() {
 	assert d == 16.0
 }
 
+fn return_heap_obj_value_as_ref(qpast Qwe) &Qwe {
+	return &qpast
+}
+
+fn test_value_ref_heap_struct() {
+	mut x := Qwe{
+		f: -13.25
+		a: Abc{
+			n: -129
+		}
+	}
+	y := return_heap_obj_value_as_ref(x)
+	x.f = 22.0625
+	d := owerwrite_stack()
+	assert typeof(y).name == '&Qwe'
+	assert x.f == 22.0625
+	assert x.a.n == -129
+	assert y.f == -13.25
+	assert y.a.n == -129
+	assert d == 16.0
+}
+
 struct NotHeap {
 mut:
 	f f64
@@ -71,7 +93,7 @@ fn return_struct_value_as_ref(q NotHeap) &NotHeap {
 }
 
 fn test_value_ref_struct() {
-	mut x := NotHeap {
+	mut x := NotHeap{
 		f: -17.125
 	}
 	y := return_struct_value_as_ref(x)

--- a/vlib/v/tests/heap_struct_test.v
+++ b/vlib/v/tests/heap_struct_test.v
@@ -82,3 +82,31 @@ fn test_value_ref_struct() {
 	assert x.f == 91.0625
 	assert d == 16.0
 }
+
+fn get_int_ref() &int {
+	i := 49154
+	return &i
+}
+
+fn test_int_ref() {
+	iptr := get_int_ref()
+	assert typeof(iptr).name == '&int'
+	d := owerwrite_stack()
+	assert *iptr == 49154
+	assert d == 16.0
+}
+
+fn pass_f64_as_ref(f f64) &f64 {
+	return &f
+}
+
+fn test_value_as_ref() {
+	mut x := -31.75
+	y := pass_f64_as_ref(x)
+	assert typeof(y).name == '&f64'
+	x = 23.0625
+	d := owerwrite_stack()
+	assert x == 23.0625
+	assert *y == -31.75
+	assert d == 16.0
+}

--- a/vlib/v/tests/return_in_lock_test.v
+++ b/vlib/v/tests/return_in_lock_test.v
@@ -6,7 +6,8 @@ mut:
 }
 
 const (
-	sleep_time = time.millisecond * 50
+	run_time   = time.millisecond * 200 // must be big enough to ensure threads have started
+	sleep_time = time.millisecond * 250 // some tolerance added
 )
 
 fn test_return_lock() {
@@ -16,12 +17,12 @@ fn test_return_lock() {
 	go fn (shared s AA, start time.Time) {
 		for {
 			reader(shared s)
-			if time.now() - start > sleep_time {
+			if time.now() - start > run_time {
 				exit(0)
 			}
 		}
 	}(shared s, start)
-	time.sleep(sleep_time * 2)
+	time.sleep(sleep_time)
 	assert false
 }
 
@@ -30,7 +31,7 @@ fn printer(shared s AA, start time.Time) {
 		lock s {
 			assert s.b in ['0', '1', '2', '3', '4', '5']
 		}
-		if time.now() - start > time.millisecond * 50 {
+		if time.now() - start > run_time {
 			exit(0)
 		}
 	}


### PR DESCRIPTION
This is a further follow-up to #9873 (and #10033). It makes the following possible:

- Value arguments of functions is moved to heap if referenced:
```v
fn get_ref(s St) &St {
    return &s
}
```
- The above point always applies to structs declared as `[heap]` that are passed as value to a function
- automatic heap promotion now also works for other data types (not only structs) &ndash; so the following works:
```v
fn get_heap_ref() &int {
    n := 13
    return &n
}

fn promote_to_heap(x f64) &f64 {
    return &x
}
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
