### PR TITLE
builtin: disable unhandled exception handler when no_backtrace flag is used

### DIFF
--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -98,7 +98,9 @@ fn builtin_init() {
 			C.setbuf(C.stderr, 0)
 		}
 	}
-	add_unhandled_exception_handler()
+	$if !no_backtrace ? {
+		add_unhandled_exception_handler()
+	}
 }
 
 fn print_backtrace_skipping_top_frames(skipframes int) bool {


### PR DESCRIPTION
Windows only.

