### PR TITLE
net: prevent 0xC0000005 errors in vschannel

### DIFF
--- a/thirdparty/vschannel/vschannel.c
+++ b/thirdparty/vschannel/vschannel.c
@@ -507,7 +507,7 @@ static SECURITY_STATUS client_handshake_loop(TlsContext *tls_ctx, BOOL fDoInitia
 	// Allocate data buffer.
 	//
 
-	IoBuffer = LocalAlloc(LMEM_FIXED, IO_BUFFER_SIZE);
+	IoBuffer = LocalAlloc(LPTR, IO_BUFFER_SIZE);
 	if(IoBuffer == NULL)
 	{
 		wprintf(L"Out of memory (1)\n");
@@ -630,8 +630,7 @@ static SECURITY_STATUS client_handshake_loop(TlsContext *tls_ctx, BOOL fDoInitia
 
 			if(InBuffers[1].BufferType == SECBUFFER_EXTRA)
 			{
-				pExtraData->pvBuffer = LocalAlloc(LMEM_FIXED, 
-												  InBuffers[1].cbBuffer);
+				pExtraData->pvBuffer = LocalAlloc(LPTR, InBuffers[1].cbBuffer);
 				if(pExtraData->pvBuffer == NULL) {
 					wprintf(L"Out of memory (2)\n");
 					return SEC_E_INTERNAL_ERROR;
@@ -741,7 +740,7 @@ static SECURITY_STATUS https_make_request(TlsContext *tls_ctx, CHAR *req, CHAR *
 	// size of this plus the header and trailer sizes should be safe enough.
 	cbIoBufferLength = Sizes.cbHeader +  Sizes.cbMaximumMessage + Sizes.cbTrailer;
 
-	pbIoBuffer = LocalAlloc(LMEM_FIXED, cbIoBufferLength);
+	pbIoBuffer = LocalAlloc(LPTR, cbIoBufferLength);
 	if(pbIoBuffer == NULL) {
 		wprintf(L"Out of memory (2)\n");
 		return SEC_E_INTERNAL_ERROR;


### PR DESCRIPTION
This fixes `Access Violation (0xC0000005)` failures in vschannel due to uninitialized memory.

According to the M$ docs:  `LPTR is a combination of LMEM_FIXED and LMEM_ZEROINIT`