### PR TITLE
cgen: fix for in mut reference selector val (fix #10524)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -279,14 +279,10 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 				g.definitions.writeln('\tif (${styp}__lt(*b, *a)) { return -1; } else { return 1; }}')
 			} else {
 				field_type := g.typ(infix_expr.left_type)
-				mut left_expr_str := g.write_expr_to_string(infix_expr.left)
-				mut right_expr_str := g.write_expr_to_string(infix_expr.right)
-				if typ.is_ptr() {
-					left_expr_str = left_expr_str.replace_once('a', '(*a)')
-					right_expr_str = right_expr_str.replace_once('b', '(*b)')
-				}
-				g.definitions.writeln('$field_type a_ = $left_expr_str;')
-				g.definitions.writeln('$field_type b_ = $right_expr_str;')
+				left_expr_str := g.write_expr_to_string(infix_expr.left)
+				right_expr_str := g.write_expr_to_string(infix_expr.right)
+				g.definitions.writeln('\t$field_type a_ = $left_expr_str;')
+				g.definitions.writeln('\t$field_type b_ = $right_expr_str;')
 				mut op1, mut op2 := '', ''
 				if infix_expr.left_type == ast.string_type {
 					if is_reverse {
@@ -306,8 +302,8 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 						op2 = '${deref_str}a_ > ${deref_str}b_'
 					}
 				}
-				g.definitions.writeln('if ($op1) return -1;')
-				g.definitions.writeln('if ($op2) return 1; else return 0; }\n')
+				g.definitions.writeln('\tif ($op1) return -1;')
+				g.definitions.writeln('\tif ($op2) return 1; \n\telse return 0; \n}\n')
 			}
 		}
 	}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3492,7 +3492,14 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 			}
 		}
 	}
-	g.expr(node.expr)
+	n_ptr := node.expr_type.nr_muls() - 1
+	if n_ptr > 0 {
+		g.write('(' + '*'.repeat(n_ptr))
+		g.expr(node.expr)
+		g.write(')')
+	} else {
+		g.expr(node.expr)
+	}
 	if is_optional {
 		g.write('.data)')
 	}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3494,7 +3494,8 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	}
 	n_ptr := node.expr_type.nr_muls() - 1
 	if n_ptr > 0 {
-		g.write('(' + '*'.repeat(n_ptr))
+		g.write('(')
+		g.write('*'.repeat(n_ptr))
 		g.expr(node.expr)
 		g.write(')')
 	} else {

--- a/vlib/v/tests/for_in_mut_reference_selector_val_test.v
+++ b/vlib/v/tests/for_in_mut_reference_selector_val_test.v
@@ -1,0 +1,26 @@
+pub struct AA {
+	id string
+}
+
+pub struct BB {
+pub mut:
+	arr []&AA
+}
+
+fn test_for_in_mut_reference_selector_val() {
+	bb := BB{
+		arr: [&AA{
+			id: 'Test1'
+		}, &AA{
+			id: 'Test2'
+		}]
+	}
+
+	mut ret := []string{}
+	for mut aa in bb.arr {
+		println(aa.id)
+		ret << aa.id
+	}
+	println(ret)
+	assert ret == ['Test1', 'Test2']
+}


### PR DESCRIPTION
This PR fix for in mut reference selector val (fix #10524).

- Fix for in mut reference selector val.
- Add test.

```vlang
pub struct AA {
	id string
}

pub struct BB {
pub mut:
	arr []&AA
}

fn main() {
	bb := BB{
		arr: [&AA{
			id: 'Test1'
		}, &AA{
			id: 'Test2'
		}]
	}

	mut ret := []string{}
	for mut aa in bb.arr {
		println(aa.id)
		ret << aa.id
	}
	println(ret)
	assert ret == ['Test1', 'Test2']
}

PS D:\Test\v\tt1> v run .
Test1
Test2
['Test1', 'Test2']
```