### PR TITLE
cgen: fix for in mut reference value (fix #10416)

### DIFF
--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -108,10 +108,10 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		}
 	} else if sym_has_str_method
 		|| sym.kind in [.array, .array_fixed, .map, .struct_, .multi_return, .sum_type, .interface_] {
-		is_ptr := typ.is_ptr()
 		is_var_mut := expr.is_auto_deref_var()
+		is_ptr := typ.is_ptr() && !(is_var_mut && typ.nr_muls() == 1)
 		str_fn_name := g.gen_str_for_type(typ)
-		if is_ptr && !is_var_mut {
+		if is_ptr {
 			g.write('str_intp(1, _MOV((StrIntpData[]){{_SLIT("&"), $si_s_code ,{.d_s=')
 		}
 		g.write('${str_fn_name}(')
@@ -131,9 +131,8 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 			g.write('->val')
 		}
 		g.write(')')
-		if is_ptr && !is_var_mut {
+		if is_ptr {
 			g.write('}}}))')
-			// g.write(')')
 		}
 	} else {
 		str_fn_name := g.gen_str_for_type(typ)

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -118,7 +118,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		if str_method_expects_ptr && !is_ptr {
 			g.write('&')
 		} else if (!str_method_expects_ptr && is_ptr && !is_shared) || is_var_mut {
-			g.write('*')
+			g.write('*'.repeat(etype.nr_muls()))
 		}
 		if expr is ast.ArrayInit {
 			if expr.is_fixed {

--- a/vlib/v/tests/for_in_mut_reference_selector_val_test.v
+++ b/vlib/v/tests/for_in_mut_reference_selector_val_test.v
@@ -24,3 +24,23 @@ fn test_for_in_mut_reference_selector_val() {
 	println(ret)
 	assert ret == ['Test1', 'Test2']
 }
+
+struct Thing {}
+
+struct Bag {
+pub mut:
+	things []&Thing
+}
+
+pub fn test_for_in_mut_array_of_reference_values() {
+	mut bag := &Bag{}
+	bag.things << &Thing{}
+
+	for mut thing in bag.things {
+		println(thing)
+		assert '$thing' == 'Thing{}'
+		mut fixed_thing := *thing
+		println(fixed_thing)
+		assert '$fixed_thing' == '&Thing{}'
+	}
+}

--- a/vlib/v/tests/for_in_mut_reference_val_test.v
+++ b/vlib/v/tests/for_in_mut_reference_val_test.v
@@ -38,7 +38,7 @@ pub fn test_for_in_mut_array_of_reference_values() {
 
 	for mut thing in bag.things {
 		println(thing)
-		assert '$thing' == 'Thing{}'
+		assert '$thing' == '&Thing{}'
 		mut fixed_thing := *thing
 		println(fixed_thing)
 		assert '$fixed_thing' == '&Thing{}'

--- a/vlib/v/tests/for_in_mut_reference_val_test.v
+++ b/vlib/v/tests/for_in_mut_reference_val_test.v
@@ -39,7 +39,7 @@ pub fn test_for_in_mut_array_of_reference_values() {
 	for mut thing in bag.things {
 		println(thing)
 		assert '$thing' == '&Thing{}'
-		mut fixed_thing := *thing
+		mut fixed_thing := unsafe { &thing }
 		println(fixed_thing)
 		assert '$fixed_thing' == '&Thing{}'
 	}


### PR DESCRIPTION
This PR fix for in mut reference value (fix #10416).

- Fix for in mut reference value.
- Add test.

```vlang
struct Thing {}

struct Bag {
pub mut:
	things []&Thing
}

pub fn main() {
	mut bag := &Bag{}
	bag.things << &Thing{}

	for mut thing in bag.things {
		println(thing)
		assert '$thing' == '&Thing{}'
		mut fixed_thing := unsafe { &thing }
		println(fixed_thing)
		assert '$fixed_thing' == '&Thing{}'
	}
}

PS D:\Test\v\tt1> v run .
&Thing{}
&Thing{}
```