### PR TITLE
cgen: fix interface only declare with optional method (fix #10441)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1332,6 +1332,12 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 		ast.Import {}
 		ast.InterfaceDecl {
 			// definitions are sorted and added in write_types
+			for method in node.methods {
+				if method.return_type.has_flag(.optional) {
+					// Register an optional if it's not registered yet
+					g.register_optional(method.return_type)
+				}
+			}
 		}
 		ast.Module {
 			// g.is_builtin_mod = node.name == 'builtin'

--- a/vlib/v/tests/interface_only_decl_with_optional_test.v
+++ b/vlib/v/tests/interface_only_decl_with_optional_test.v
@@ -1,0 +1,8 @@
+interface Message {
+	serialize() ?[]byte
+}
+
+fn test_interface_only_decl_with_optional() {
+	println('test interface')
+	assert true
+}


### PR DESCRIPTION
This PR fix interface only declare with optional method (fix #10441).

- Fix interface only declare with optional method.
- Add test.

```vlang
import crypto.sha1

// Topics are 64bit integers
struct Topic {
	hash u64
}

pub fn topic_from_name(topicName string) Topic {
	hashed := sha1.sum(topicName.bytes())
	mut num := u64(0)
	for i in 0 .. 8 {
		num |= hashed[i]<<(i<<3)
	}

	return Topic{
		hash: num
	}
}

// messages are simply anything which can be serialized
interface Message {
	t Topic
	serialize() ?[]byte
}

fn main() {
	println(topic_from_name("telem.loop.t1.j1.voltage"))
}

PS D:\Test\v\tt1> v run .
Topic{
    hash: 18446744073606623099
}
```