### PR TITLE
parser: prohibit redeclaration of imported functions

### DIFF
--- a/test.v
+++ b/test.v
@@ -1,0 +1,3 @@
+import os { input }
+fn input() {}
+input()

--- a/test.v
+++ b/test.v
@@ -1,3 +1,0 @@
-import os { input }
-fn input() {}
-input()

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -274,6 +274,13 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 				scope: 0
 			}
 		}
+		// cannot redefine imported function
+		if name in p.imported_symbols {
+			p.error_with_pos('cannot redefine imported function `$name`', name_pos)
+			return ast.FnDecl{
+				scope: 0
+			}
+		}
 	} else if p.tok.kind in [.plus, .minus, .mul, .div, .mod, .lt, .eq] && p.peek_tok.kind == .lpar {
 		name = p.tok.kind.str() // op_to_fn_name()
 		if rec.typ == ast.void_type {

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -267,18 +267,18 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 				}
 			}
 		}
-		// cannot redefine buildin function
-		if !is_method && !p.builtin_mod && name in builtin_functions {
-			p.error_with_pos('cannot redefine builtin function `$name`', name_pos)
-			return ast.FnDecl{
-				scope: 0
+		if !p.pref.is_fmt {
+			if !is_method && !p.builtin_mod && name in builtin_functions {
+				p.error_with_pos('cannot redefine builtin function `$name`', name_pos)
+				return ast.FnDecl{
+					scope: 0
+				}
 			}
-		}
-		// cannot redefine imported function
-		if name in p.imported_symbols {
-			p.error_with_pos('cannot redefine imported function `$name`', name_pos)
-			return ast.FnDecl{
-				scope: 0
+			if name in p.imported_symbols {
+				p.error_with_pos('cannot redefine imported function `$name`', name_pos)
+				return ast.FnDecl{
+					scope: 0
+				}
 			}
 		}
 	} else if p.tok.kind in [.plus, .minus, .mul, .div, .mod, .lt, .eq] && p.peek_tok.kind == .lpar {

--- a/vlib/v/parser/tests/redeclaration_of_imported_fn.out
+++ b/vlib/v/parser/tests/redeclaration_of_imported_fn.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/redeclaration_of_imported_fn.vv:3:4: error: cannot redefine imported function `input`
+    1 | import os { input }
+    2 | 
+    3 | fn input() {}
+      |    ~~~~~
+    4 | 
+    5 | input()

--- a/vlib/v/parser/tests/redeclaration_of_imported_fn.vv
+++ b/vlib/v/parser/tests/redeclaration_of_imported_fn.vv
@@ -1,0 +1,5 @@
+import os { input }
+
+fn input() {}
+
+input()


### PR DESCRIPTION
this pr prohibits redeclaring imported functions. prior to this pr 
```v
import os { input }
fn input() {}
input()
```
errors on line 3, but now it raises a parser on line 2 as it should.