### PR TITLE
table: fix interface embedding with interface parameter (fix #10437)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -116,6 +116,11 @@ pub mut:
 pub fn (f Fn) new_method_with_receiver_type(new_type Type) Fn {
 	mut new_method := f
 	new_method.params = f.params.clone()
+	for i in 1 .. new_method.params.len {
+		if new_method.params[i].typ == new_method.params[0].typ {
+			new_method.params[i].typ = new_type
+		}
+	}
 	new_method.params[0].typ = new_type
 	return new_method
 }
@@ -123,6 +128,11 @@ pub fn (f Fn) new_method_with_receiver_type(new_type Type) Fn {
 pub fn (f FnDecl) new_method_with_receiver_type(new_type Type) FnDecl {
 	mut new_method := f
 	new_method.params = f.params.clone()
+	for i in 1 .. new_method.params.len {
+		if new_method.params[i].typ == new_method.params[0].typ {
+			new_method.params[i].typ = new_type
+		}
+	}
 	new_method.params[0].typ = new_type
 	return new_method
 }

--- a/vlib/v/tests/interface_embedding_with_interface_para_test.v
+++ b/vlib/v/tests/interface_embedding_with_interface_para_test.v
@@ -1,0 +1,38 @@
+interface Eq {
+	eq(other Eq) bool
+}
+
+interface Ord {
+	Eq
+	lt(other Ord) bool
+}
+
+// implement Ord for Int
+struct Int {
+	value int
+}
+
+fn (i Int) eq(other Ord) bool {
+	if other is Int {
+		return i.value == other.value
+	}
+	return false
+}
+
+fn (i Int) lt(other Ord) bool {
+	if other is Int {
+		return i.value < other.value
+	}
+	return false
+}
+
+fn compare(x Ord, y Ord) {
+	println(x.eq(y))
+	assert !x.eq(y)
+	println(x.lt(y))
+	assert x.lt(y)
+}
+
+fn test_interface_embedding_with_interface_para() {
+	compare(Int{1}, Int{2})
+}


### PR DESCRIPTION
This PR fix interface embedding with interface parameter (fix #10437).

- Fix interface embedding with interface parameter.
- Add test.

```vlang
interface Eq {
	eq(other Eq) bool
}

interface Ord {
	Eq
	lt(other Ord) bool
}

// implement Ord for Int
struct Int {
	value int
}

fn (i Int) eq(other Ord) bool {
	if other is Int {
		return i.value == other.value
	}
	return false
}

fn (i Int) lt(other Ord) bool {
	if other is Int {
		return i.value < other.value
	}
	return false
}

fn compare(x Ord, y Ord) {
	println(x.eq(y))
	assert !x.eq(y)
	println(x.lt(y))
	assert x.lt(y)
}

fn main() {
	compare(Int{1}, Int{2})
}

PS D:\Test\v\tt1> v run .
false
true
```