### PR TITLE
cgen: fix fn mut val of interface type (fix #10089)

### DIFF
--- a/vlib/v/gen/c/infix_expr.v
+++ b/vlib/v/gen/c/infix_expr.v
@@ -487,6 +487,9 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 			if needs_clone {
 				g.write('string_clone(')
 			}
+			if right.unaliased_sym.kind == .interface_ && node.right.is_auto_deref_var() {
+				g.write('*')
+			}
 			g.expr_with_cast(node.right, node.right_type, array_info.elem_type)
 			if needs_clone {
 				g.write(')')

--- a/vlib/v/tests/fn_mut_args_test.v
+++ b/vlib/v/tests/fn_mut_args_test.v
@@ -43,3 +43,27 @@ fn test_fn_mut_args_of_array_last() {
 	m.ar << 99
 	assert pass_array_mut(mut m.ar) == 99
 }
+
+interface ChildInterface {
+	data int
+}
+
+struct Child {
+	data int
+}
+
+struct Parent {
+mut:
+	children []ChildInterface
+}
+
+fn (mut p Parent) add(mut x ChildInterface) {
+	p.children << x
+}
+
+fn test_fn_mut_args_of_interface() {
+	mut x := Parent{}
+	x.add(mut Child{ data: 123 })
+	println(x.children[0].data)
+	assert x.children[0].data == 123
+}


### PR DESCRIPTION
This PR fix fn mut val of interface type (fix #10089).

- Fix fn mut val of interface type.
- Add test.

```vlang
interface ChildInterface {
	data int
}

struct Child {
	data int
}

struct Parent {
mut:
	children []ChildInterface
}

fn (mut p Parent) add(mut x ChildInterface) {
	p.children << x
}

fn main() {
	mut x := Parent{}
	x.add(mut Child{ data: 123 })
	println(x.children[0].data)
}

PS D:\Test\v\tt1> v run .
123
```