### PR TITLE
term.ui: use .stop instead of .tstp for resetting the console on exit

### DIFF
--- a/vlib/term/ui/termios_nix.c.v
+++ b/vlib/term/ui/termios_nix.c.v
@@ -127,7 +127,7 @@ fn (mut ctx Context) termios_setup() ? {
 
 	// Reset console on exit
 	C.atexit(restore_terminal_state)
-	os.signal_opt(.tstp, restore_terminal_state_signal) or {}
+	os.signal_opt(.stop, restore_terminal_state_signal) or {}
 	os.signal_opt(.cont, fn (_ os.Signal) {
 		mut c := ctx_ptr
 		if c != 0 {


### PR DESCRIPTION
This fixes an issue seen in https://github.com/jacobsalmela/vsh/issues/24 but I think this fixes unseen problem(s) elsewhere as well since `.tstp` wasn't actually in `os.Signal` in `input.v`.   I'm happy to make any changes necessary for this PR.  Thank you for your consideration.

Signed-off-by: Jacob Salmela <me@jacobsalmela.com>