### PR TITLE
parser: prohibit redefining imported const

### DIFF
--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -141,7 +141,8 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr, left_comments []ast.Comme
 					if p.scope.known_var(lx.name) {
 						return p.error_with_pos('redefinition of `$lx.name`', lx.pos)
 					} else if p.mod == 'main' && lx.name in p.imported_symbols {
-						return p.error_with_pos('redefinition of imported constant `$lx.name`', lx.pos)
+						return p.error_with_pos('redefinition of imported constant `$lx.name`',
+							lx.pos)
 					}
 					mut share := ast.ShareType(0)
 					if lx.info is ast.IdentVar {

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -140,6 +140,8 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr, left_comments []ast.Comme
 				if op == .decl_assign {
 					if p.scope.known_var(lx.name) {
 						return p.error_with_pos('redefinition of `$lx.name`', lx.pos)
+					} else if p.mod == 'main' && lx.name in p.imported_symbols {
+						return p.error_with_pos('redefinition of imported constant `$lx.name`', lx.pos)
 					}
 					mut share := ast.ShareType(0)
 					if lx.info is ast.IdentVar {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2818,7 +2818,7 @@ fn (mut p Parser) const_decl() ast.ConstDecl {
 			p.error('unexpected eof, expecting an expression')
 			return ast.ConstDecl{}
 		}
-		if p.mod == 'main' && full_name.trim_left('main.') in p.imported_symbols {
+		if name in p.imported_symbols {
 			p.error('duplicate of imported const `$full_name`')
 			return ast.ConstDecl{}
 		}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2818,6 +2818,10 @@ fn (mut p Parser) const_decl() ast.ConstDecl {
 			p.error('unexpected eof, expecting an expression')
 			return ast.ConstDecl{}
 		}
+		if p.mod == 'main' && full_name.trim_left('main.') in p.imported_symbols {
+			p.error('duplicate of imported const `$full_name`')
+			return ast.ConstDecl{}
+		}
 		expr := p.expr(0)
 		field := ast.ConstField{
 			name: full_name

--- a/vlib/v/parser/tests/redefine_imported_const_err.out
+++ b/vlib/v/parser/tests/redefine_imported_const_err.out
@@ -1,0 +1,5 @@
+vlib/v/parser/tests/redefine_imported_const_err.vv:3:16: error: duplicate of imported const `second`
+    1 | import time { second } 
+    2 | 
+    3 | const second = 10
+      |                ~~

--- a/vlib/v/parser/tests/redefine_imported_const_err.vv
+++ b/vlib/v/parser/tests/redefine_imported_const_err.vv
@@ -1,3 +1,3 @@
-import time { second } 
+import time { second }
 
 const second = 10

--- a/vlib/v/parser/tests/redefine_imported_const_err.vv
+++ b/vlib/v/parser/tests/redefine_imported_const_err.vv
@@ -1,0 +1,3 @@
+import time { second } 
+
+const second = 10


### PR DESCRIPTION
this pr prohibits defining a const or variable after importing said const.