### PR TITLE
doc: improve selective import docs

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1061,7 +1061,8 @@ fn main() {
 	println('Hello, $name!')
 }
 ```
-Note: This will import the module as well. Also, this is not allowed for constants - they must always be prefixed.
+Note: This will import the module as well. Also, this is not allowed for
+constants - they must always be prefixed.
 
 You can import several specific symbols at once:
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1061,7 +1061,7 @@ fn main() {
 	println('Hello, $name!')
 }
 ```
-Note: This is not allowed for constants - they must always be prefixed.
+Note: This will import the module as well. Also, this is not allowed for constants - they must always be prefixed.
 
 You can import several specific symbols at once:
 


### PR DESCRIPTION
this pr clarifies in the docs that `import foo { bar }` imports foo as well. 