### PR TITLE
checker: prohibit selective const imports

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -120,7 +120,8 @@ pub fn (mut c Checker) check(ast_file &ast.File) {
 		for sym in ast_import.syms {
 			full_name := ast_import.mod + '.' + sym.name
 			if full_name in c.const_names {
-				c.error('cannot selectively import constant `$sym.name` from `$ast_import.mod`, import `$ast_import.mod` and use `$full_name` instead', sym.pos)
+				c.error('cannot selectively import constant `$sym.name` from `$ast_import.mod`, import `$ast_import.mod` and use `$full_name` instead',
+					sym.pos)
 			}
 		}
 		for j in 0 .. i {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -117,6 +117,12 @@ pub fn new_checker(table &ast.Table, pref &pref.Preferences) &Checker {
 pub fn (mut c Checker) check(ast_file &ast.File) {
 	c.change_current_file(ast_file)
 	for i, ast_import in ast_file.imports {
+		for sym in ast_import.syms {
+			full_name := ast_import.mod + '.' + sym.name
+			if full_name in c.const_names {
+				c.error('cannot selectively import constant `$sym.name` from `$ast_import.mod`, import `$ast_import.mod` and use `$full_name` instead', sym.pos)
+			}
+		}
 		for j in 0 .. i {
 			if ast_import.mod == ast_file.imports[j].mod {
 				c.error('`$ast_import.mod` was already imported on line ${

--- a/vlib/v/checker/tests/selective_const_import.out
+++ b/vlib/v/checker/tests/selective_const_import.out
@@ -1,0 +1,3 @@
+vlib/v/checker/tests/selective_const_import.vv:1:15: error: cannot selectively import constant `second` from `time`, import `time` and use `time.second` instead
+    1 | import time { second }
+      |               ~~~~~~

--- a/vlib/v/checker/tests/selective_const_import.vv
+++ b/vlib/v/checker/tests/selective_const_import.vv
@@ -1,0 +1,1 @@
+import time { second }

--- a/vlib/v/tests/imported_symbols_test.v
+++ b/vlib/v/tests/imported_symbols_test.v
@@ -1,6 +1,6 @@
 module main
 
-import geometry { Line, Point, PointCond, Shape, module_name, point_str }
+import geometry { Line, Point, PointCond, Shape, point_str }
 
 fn point_is(p Point, cond PointCond) bool {
 	return cond(p)
@@ -37,10 +37,6 @@ fn test_imported_symbols_functions() {
 	assert p0.str() == '20 40'
 	// function
 	assert point_str(p0) == '20 40'
-}
-
-fn test_imported_symbols_constants() {
-	assert module_name == 'geometry'
 }
 
 fn vertex_count(s Shape) int {


### PR DESCRIPTION
this pr prohibits selective const imports like `import time { second }`.