### PR TITLE
parser: prohibit registering selectively imported (structs / enums / aliases / interfaces)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3063,7 +3063,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		return ast.FnTypeDecl{}
 	}
 	if name in p.imported_symbols {
-		p.error_with_pos('cannot register alias `$name`, this type was already imported', decl_pos.extend(p.tok.position()))
+		p.error_with_pos('cannot register alias `$name`, this type was already imported', end_pos)
 		return ast.AliasTypeDecl{}
 	}
 	mut sum_variants := []ast.TypeNode{}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2964,6 +2964,7 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 	}
 	if enum_name in p.imported_symbols {
 		p.error_with_pos('cannot register enum `$enum_name`, this type was already imported', end_pos)
+		return ast.EnumDecl{}
 	}
 	name := p.prepend_mod(enum_name)
 	p.check(.lcbr)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2963,7 +2963,8 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 		return ast.EnumDecl{}
 	}
 	if enum_name in p.imported_symbols {
-		p.error_with_pos('cannot register enum `$enum_name`, this type was already imported', end_pos)
+		p.error_with_pos('cannot register enum `$enum_name`, this type was already imported',
+			end_pos)
 		return ast.EnumDecl{}
 	}
 	name := p.prepend_mod(enum_name)
@@ -3064,7 +3065,8 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		return ast.FnTypeDecl{}
 	}
 	if name in p.imported_symbols {
-		p.error_with_pos('cannot register alias `$name`, this type was already imported', end_pos)
+		p.error_with_pos('cannot register alias `$name`, this type was already imported',
+			end_pos)
 		return ast.AliasTypeDecl{}
 	}
 	mut sum_variants := []ast.TypeNode{}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2962,6 +2962,9 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 			end_pos)
 		return ast.EnumDecl{}
 	}
+	if enum_name in p.imported_symbols {
+		p.error_with_pos('cannot register enum `$enum_name`, this type was already imported', end_pos)
+	}
 	name := p.prepend_mod(enum_name)
 	p.check(.lcbr)
 	enum_decl_comments := p.eat_comments({})
@@ -3058,6 +3061,10 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		p.error_with_pos('single letter capital names are reserved for generic template types.',
 			decl_pos)
 		return ast.FnTypeDecl{}
+	}
+	if name in p.imported_symbols {
+		p.error_with_pos('cannot register alias `$name`, this type was already imported', decl_pos.extend(p.tok.position()))
+		return ast.AliasTypeDecl{}
 	}
 	mut sum_variants := []ast.TypeNode{}
 	p.check(.assign)

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -460,7 +460,8 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 	p.check(.lcbr)
 	pre_comments := p.eat_comments({})
 	if modless_name in p.imported_symbols {
-		p.error_with_pos('cannot register interface `$interface_name`, this type was already imported', name_pos)
+		p.error_with_pos('cannot register interface `$interface_name`, this type was already imported',
+			name_pos)
 		return ast.InterfaceDecl{}
 	}
 	// Declare the type

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -73,6 +73,10 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 		p.error_with_pos('struct names must have more than one character', name_pos)
 		return ast.StructDecl{}
 	}
+	if name in p.imported_symbols {
+		p.error_with_pos('cannot register struct `$name`, this type was already imported', name_pos)
+		return ast.StructDecl{}
+	}
 	mut orig_name := name
 	if language == .c {
 		name = 'C.$name'

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -454,10 +454,15 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 	}
 	name_pos := p.tok.position()
 	p.check_for_impure_v(language, name_pos)
-	interface_name := p.prepend_mod(p.check_name()).clone()
+	modless_name := p.check_name()
+	interface_name := p.prepend_mod(modless_name).clone()
 	// println('interface decl $interface_name')
 	p.check(.lcbr)
 	pre_comments := p.eat_comments({})
+	if modless_name in p.imported_symbols {
+		p.error_with_pos('cannot register interface `$interface_name`, this type was already imported', name_pos)
+		return ast.InterfaceDecl{}
+	}
 	// Declare the type
 	reg_idx := p.table.register_type_symbol(
 		is_public: is_pub

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -74,7 +74,8 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 		return ast.StructDecl{}
 	}
 	if name in p.imported_symbols {
-		p.error_with_pos('cannot register struct `$name`, this type was already imported', name_pos)
+		p.error_with_pos('cannot register struct `$name`, this type was already imported',
+			name_pos)
 		return ast.StructDecl{}
 	}
 	mut orig_name := name

--- a/vlib/v/parser/tests/register_imported_alias.out
+++ b/vlib/v/parser/tests/register_imported_alias.out
@@ -1,0 +1,4 @@
+vlib/v/parser/tests/register_imported_alias.vv:2:6: error: cannot register alias `Duration`, this type was already imported
+    1 | import time { Duration }
+    2 | type Duration = bool
+      |      ~~~~~~~~

--- a/vlib/v/parser/tests/register_imported_alias.vv
+++ b/vlib/v/parser/tests/register_imported_alias.vv
@@ -1,0 +1,2 @@
+import time { Duration }
+type Duration = bool

--- a/vlib/v/parser/tests/register_imported_enum.out
+++ b/vlib/v/parser/tests/register_imported_enum.out
@@ -1,0 +1,4 @@
+vlib/v/parser/tests/register_imported_enum.vv:2:6: error: cannot register enum `Method`, this type was already imported
+    1 | import net.http { Method }
+    2 | enum Method { foo bar }
+      |      ~~~~~~

--- a/vlib/v/parser/tests/register_imported_enum.vv
+++ b/vlib/v/parser/tests/register_imported_enum.vv
@@ -1,0 +1,2 @@
+import net.http { Method }
+enum Method { foo bar }

--- a/vlib/v/parser/tests/register_imported_interface.out
+++ b/vlib/v/parser/tests/register_imported_interface.out
@@ -1,0 +1,4 @@
+vlib/v/parser/tests/register_imported_interface.vv:2:11: error: cannot register interface `Reader`, this type was already imported
+    1 | import io { Reader }
+    2 | interface Reader {}
+      |           ~~~~~~

--- a/vlib/v/parser/tests/register_imported_interface.vv
+++ b/vlib/v/parser/tests/register_imported_interface.vv
@@ -1,0 +1,2 @@
+import io { Reader }
+interface Reader {}

--- a/vlib/v/parser/tests/register_imported_struct.out
+++ b/vlib/v/parser/tests/register_imported_struct.out
@@ -1,0 +1,4 @@
+vlib/v/parser/tests/register_imported_struct.vv:2:8: error: cannot register struct `File`, this type was already imported
+    1 | import os { File }
+    2 | struct File {}
+      |        ~~~~

--- a/vlib/v/parser/tests/register_imported_struct.vv
+++ b/vlib/v/parser/tests/register_imported_struct.vv
@@ -1,0 +1,2 @@
+import os { File }
+struct File {}


### PR DESCRIPTION
this pr prohibits registering types that have been selectively imported. the regression tests should be self-explanatory for the change.