### PR TITLE
fmt: allow selective imports

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -266,11 +266,7 @@ pub fn (mut f Fmt) imports(imports []ast.Import) {
 		}
 		already_imported[import_text] = true
 		if imp.syms.len > 0 {
-			import_text += ' { '
-			for sym in imp.syms {
-				import_text += sym.name + ' '
-			}
-			import_text += '}'
+			import_text += ' { ' + imp.syms.map(it.name).join(', ') + ' }'
 		} 
 		f.out_imports.writeln(import_text)
 		f.import_comments(imp.comments, inline: true)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -260,11 +260,18 @@ pub fn (mut f Fmt) imports(imports []ast.Import) {
 		if imp.mod in f.auto_imports && imp.mod !in f.used_imports {
 			continue
 		}
-		import_text := 'import ${f.imp_stmt_str(imp)}'
+		mut import_text := 'import ${f.imp_stmt_str(imp)}'
 		if already_imported[import_text] {
 			continue
 		}
 		already_imported[import_text] = true
+		if imp.syms.len > 0 {
+			import_text += ' { '
+			for sym in imp.syms {
+				import_text += sym.name + ' '
+			}
+			import_text += '}'
+		} 
 		f.out_imports.writeln(import_text)
 		f.import_comments(imp.comments, inline: true)
 		f.import_comments(imp.next_comments, {})

--- a/vlib/v/fmt/tests/selective_import_expected.vv
+++ b/vlib/v/fmt/tests/selective_import_expected.vv
@@ -1,0 +1,1 @@
+import os { input, execute }

--- a/vlib/v/fmt/tests/selective_import_input.vv
+++ b/vlib/v/fmt/tests/selective_import_input.vv
@@ -1,0 +1,4 @@
+import os {
+	input,
+	execute
+}


### PR DESCRIPTION
this pr allows selective imports to remain after v fmt. before this pr they are removed by v fmt.