### PR TITLE
x.json2: fix nest level check

### DIFF
--- a/vlib/x/json2/decoder.v
+++ b/vlib/x/json2/decoder.v
@@ -149,6 +149,11 @@ fn (mut p Parser) decode_value() ?Any {
 
 fn (mut p Parser) decode_array() ?Any {
 	mut items := []Any{}
+	defer {
+		if p.n_level != 0 {
+			p.n_level--
+		}
+	}
 	p.next_with_err() ?
 	for p.tok.kind != .rsbr {
 		item := p.decode_value() ?
@@ -174,6 +179,11 @@ fn (mut p Parser) decode_array() ?Any {
 
 fn (mut p Parser) decode_object() ?Any {
 	mut fields := map[string]Any{}
+	defer {
+		if p.n_level != 0 {
+			p.n_level--
+		}
+	}
 	p.next_with_err() ?
 	for p.tok.kind != .rcbr {
 		is_key := p.tok.kind == .str_ && p.n_tok.kind == .colon

--- a/vlib/x/json2/decoder.v
+++ b/vlib/x/json2/decoder.v
@@ -95,10 +95,6 @@ fn (mut p Parser) decode_value() ?Any {
 	if p.n_level == 500 {
 		return error(p.emit_error('reached maximum nesting level of 500'))
 	}
-	if (p.tok.kind == .lsbr && p.n_tok.kind == .lcbr)
-		|| (p.p_tok.kind == p.tok.kind && p.tok.kind == .lsbr) {
-		p.n_level++
-	}
 	match p.tok.kind {
 		.lsbr {
 			return p.decode_array()
@@ -149,12 +145,8 @@ fn (mut p Parser) decode_value() ?Any {
 
 fn (mut p Parser) decode_array() ?Any {
 	mut items := []Any{}
-	defer {
-		if p.n_level != 0 {
-			p.n_level--
-		}
-	}
 	p.next_with_err() ?
+	p.n_level++
 	for p.tok.kind != .rsbr {
 		item := p.decode_value() ?
 		items << item
@@ -174,17 +166,14 @@ fn (mut p Parser) decode_array() ?Any {
 		}
 	}
 	p.next_with_err() ?
+	p.n_level--
 	return Any(items)
 }
 
 fn (mut p Parser) decode_object() ?Any {
 	mut fields := map[string]Any{}
-	defer {
-		if p.n_level != 0 {
-			p.n_level--
-		}
-	}
 	p.next_with_err() ?
+	p.n_level++
 	for p.tok.kind != .rcbr {
 		is_key := p.tok.kind == .str_ && p.n_tok.kind == .colon
 		if !is_key {
@@ -206,5 +195,6 @@ fn (mut p Parser) decode_object() ?Any {
 		}
 	}
 	p.next_with_err() ?
+	p.n_level--
 	return Any(fields)
 }

--- a/vlib/x/json2/decoder.v
+++ b/vlib/x/json2/decoder.v
@@ -92,7 +92,7 @@ fn (mut p Parser) decode() ?Any {
 }
 
 fn (mut p Parser) decode_value() ?Any {
-	if p.n_level == 500 {
+	if p.n_level + 1 == 500 {
 		return error(p.emit_error('reached maximum nesting level of 500'))
 	}
 	match p.tok.kind {

--- a/vlib/x/json2/decoder_test.v
+++ b/vlib/x/json2/decoder_test.v
@@ -1,25 +1,27 @@
-import x.json2
+module json2
+
+import os
 
 fn test_raw_decode_string() {
-	str := json2.raw_decode('"Hello!"') or {
+	str := raw_decode('"Hello!"') or {
 		assert false
-		json2.Any(json2.null)
+		Any(null)
 	}
 	assert str.str() == 'Hello!'
 }
 
 fn test_raw_decode_number() {
-	num := json2.raw_decode('123') or {
+	num := raw_decode('123') or {
 		assert false
-		json2.Any(json2.null)
+		Any(null)
 	}
 	assert num.int() == 123
 }
 
 fn test_raw_decode_array() {
-	raw_arr := json2.raw_decode('["Foo", 1]') or {
+	raw_arr := raw_decode('["Foo", 1]') or {
 		assert false
-		json2.Any(json2.null)
+		Any(null)
 	}
 	arr := raw_arr.arr()
 	assert arr[0].str() == 'Foo'
@@ -27,17 +29,17 @@ fn test_raw_decode_array() {
 }
 
 fn test_raw_decode_bool() {
-	bol := json2.raw_decode('false') or {
+	bol := raw_decode('false') or {
 		assert false
-		json2.Any(json2.null)
+		Any(null)
 	}
 	assert bol.bool() == false
 }
 
 fn test_raw_decode_map() {
-	raw_mp := json2.raw_decode('{"name":"Bob","age":20}') or {
+	raw_mp := raw_decode('{"name":"Bob","age":20}') or {
 		assert false
-		json2.Any(json2.null)
+		Any(null)
 	}
 	mp := raw_mp.as_map()
 	assert mp['name'].str() == 'Bob'
@@ -45,15 +47,15 @@ fn test_raw_decode_map() {
 }
 
 fn test_raw_decode_null() {
-	nul := json2.raw_decode('null') or {
+	nul := raw_decode('null') or {
 		assert false
-		json2.Any(json2.null)
+		Any(null)
 	}
-	assert nul is json2.Null
+	assert nul is Null
 }
 
 fn test_raw_decode_invalid() {
-	json2.raw_decode('1z') or {
+	raw_decode('1z') or {
 		assert err.msg == '[x.json2] invalid token `z` (0:17)'
 		return
 	}
@@ -61,20 +63,26 @@ fn test_raw_decode_invalid() {
 }
 
 fn test_raw_decode_string_with_dollarsign() {
-	str := json2.raw_decode(r'"Hello $world"') or {
+	str := raw_decode(r'"Hello $world"') or {
 		assert false
-		json2.Any(json2.null)
+		Any(null)
 	}
 	assert str.str() == r'Hello $world'
 }
 
 fn test_raw_decode_map_with_whitespaces() {
-	raw_mp := json2.raw_decode(' \n\t{"name":"Bob","age":20}\n\t') or {
+	raw_mp := raw_decode(' \n\t{"name":"Bob","age":20}\n\t') or {
 		eprintln(err.msg)
 		assert false
-		json2.Any(json2.null)
+		Any(null)
 	}
 	mp := raw_mp.as_map()
 	assert mp['name'].str() == 'Bob'
 	assert mp['age'].int() == 20
+}
+
+fn test_nested_array_map() ? {
+	mut parser := new_parser('[[],[[]],[[[[]]]]]', false)
+	decoded := parser.decode() ?
+	assert parser.n_level == 0
 }

--- a/vlib/x/json2/decoder_test.v
+++ b/vlib/x/json2/decoder_test.v
@@ -1,40 +1,40 @@
 module json2
 
-fn test_raw_decode_string() {
+fn test_raw_decode_string() ? {
 	str := raw_decode('"Hello!"') ?
 	assert str.str() == 'Hello!'
 }
 
-fn test_raw_decode_number() {
+fn test_raw_decode_number() ? {
 	num := raw_decode('123') ?
 	assert num.int() == 123
 }
 
-fn test_raw_decode_array() {
+fn test_raw_decode_array() ? {
 	raw_arr := raw_decode('["Foo", 1]') ?
 	arr := raw_arr.arr()
 	assert arr[0].str() == 'Foo'
 	assert arr[1].int() == 1
 }
 
-fn test_raw_decode_bool() {
+fn test_raw_decode_bool() ? {
 	bol := raw_decode('false') ?
 	assert bol.bool() == false
 }
 
-fn test_raw_decode_map() {
+fn test_raw_decode_map() ? {
 	raw_mp := raw_decode('{"name":"Bob","age":20}') ?
 	mp := raw_mp.as_map()
 	assert mp['name'].str() == 'Bob'
 	assert mp['age'].int() == 20
 }
 
-fn test_raw_decode_null() {
+fn test_raw_decode_null() ? {
 	nul := raw_decode('null') ?
 	assert nul is Null
 }
 
-fn test_raw_decode_invalid() {
+fn test_raw_decode_invalid() ? {
 	raw_decode('1z') or {
 		assert err.msg == '[x.json2] invalid token `z` (0:17)'
 		return
@@ -42,12 +42,12 @@ fn test_raw_decode_invalid() {
 	assert false
 }
 
-fn test_raw_decode_string_with_dollarsign() {
+fn test_raw_decode_string_with_dollarsign() ? {
 	str := raw_decode(r'"Hello $world"') ?
 	assert str.str() == r'Hello $world'
 }
 
-fn test_raw_decode_map_with_whitespaces() {
+fn test_raw_decode_map_with_whitespaces() ? {
 	raw_mp := raw_decode(' \n\t{"name":"Bob","age":20}\n\t') ?
 	mp := raw_mp.as_map()
 	assert mp['name'].str() == 'Bob'

--- a/vlib/x/json2/decoder_test.v
+++ b/vlib/x/json2/decoder_test.v
@@ -1,56 +1,36 @@
 module json2
 
-import os
-
 fn test_raw_decode_string() {
-	str := raw_decode('"Hello!"') or {
-		assert false
-		Any(null)
-	}
+	str := raw_decode('"Hello!"') ?
 	assert str.str() == 'Hello!'
 }
 
 fn test_raw_decode_number() {
-	num := raw_decode('123') or {
-		assert false
-		Any(null)
-	}
+	num := raw_decode('123') ?
 	assert num.int() == 123
 }
 
 fn test_raw_decode_array() {
-	raw_arr := raw_decode('["Foo", 1]') or {
-		assert false
-		Any(null)
-	}
+	raw_arr := raw_decode('["Foo", 1]') ?
 	arr := raw_arr.arr()
 	assert arr[0].str() == 'Foo'
 	assert arr[1].int() == 1
 }
 
 fn test_raw_decode_bool() {
-	bol := raw_decode('false') or {
-		assert false
-		Any(null)
-	}
+	bol := raw_decode('false') ?
 	assert bol.bool() == false
 }
 
 fn test_raw_decode_map() {
-	raw_mp := raw_decode('{"name":"Bob","age":20}') or {
-		assert false
-		Any(null)
-	}
+	raw_mp := raw_decode('{"name":"Bob","age":20}') ?
 	mp := raw_mp.as_map()
 	assert mp['name'].str() == 'Bob'
 	assert mp['age'].int() == 20
 }
 
 fn test_raw_decode_null() {
-	nul := raw_decode('null') or {
-		assert false
-		Any(null)
-	}
+	nul := raw_decode('null') ?
 	assert nul is Null
 }
 
@@ -63,26 +43,19 @@ fn test_raw_decode_invalid() {
 }
 
 fn test_raw_decode_string_with_dollarsign() {
-	str := raw_decode(r'"Hello $world"') or {
-		assert false
-		Any(null)
-	}
+	str := raw_decode(r'"Hello $world"') ?
 	assert str.str() == r'Hello $world'
 }
 
 fn test_raw_decode_map_with_whitespaces() {
-	raw_mp := raw_decode(' \n\t{"name":"Bob","age":20}\n\t') or {
-		eprintln(err.msg)
-		assert false
-		Any(null)
-	}
+	raw_mp := raw_decode(' \n\t{"name":"Bob","age":20}\n\t') ?
 	mp := raw_mp.as_map()
 	assert mp['name'].str() == 'Bob'
 	assert mp['age'].int() == 20
 }
 
-fn test_nested_array_map() ? {
-	mut parser := new_parser('[[],[[]],[[[[]]]]]', false)
+fn test_nested_array_object() ? {
+	mut parser := new_parser(r'[[[[[],[],[]]]],{"Test":{}},[[]]]', false)
 	decoded := parser.decode() ?
 	assert parser.n_level == 0
 }


### PR DESCRIPTION
This PR fixes the code for checking the nest level. Before the patch, the parser/decoder will only check for subsequent tokens such as `[[]]` or `[{}]` and increase the nest level count if satisfied but does not decrease after parsing the array/object. This causes false positive errors similar to [this](https://github.com/takkyuuplayer/v-anki/pull/1/files#diff-c499ec09094052cf95fa05b66488dd7c104d7acd184467f7ede6181802344f80R70). 

Now the nested level increases whenever the parser encounters the opening array token (left square bracket) or opening object token (left curly brackets) regardless of the token on the left. Aside from that, the code for putting the maximum limit is modified since the rule is changed.