### PR TITLE
cgen: fix interface with nested fields (fix #10077)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -866,8 +866,9 @@ pub fn (mut g Gen) write_alias_typesymbol_declaration(sym ast.TypeSymbol) {
 
 pub fn (mut g Gen) write_interface_typesymbol_declaration(sym ast.TypeSymbol) {
 	info := sym.info as ast.Interface
-	g.type_definitions.writeln('typedef struct ${c_name(sym.name)} ${c_name(sym.name)};')
-	g.type_definitions.writeln('struct ${c_name(sym.name)} {')
+	struct_name := c_name(sym.name)
+	g.type_definitions.writeln('typedef struct $struct_name $struct_name;')
+	g.type_definitions.writeln('struct $struct_name {')
 	g.type_definitions.writeln('\tunion {')
 	g.type_definitions.writeln('\t\tvoid* _object;')
 	for variant in info.types {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -866,7 +866,8 @@ pub fn (mut g Gen) write_alias_typesymbol_declaration(sym ast.TypeSymbol) {
 
 pub fn (mut g Gen) write_interface_typesymbol_declaration(sym ast.TypeSymbol) {
 	info := sym.info as ast.Interface
-	g.type_definitions.writeln('typedef struct {')
+	g.type_definitions.writeln('typedef struct ${c_name(sym.name)} ${c_name(sym.name)};')
+	g.type_definitions.writeln('struct ${c_name(sym.name)} {')
 	g.type_definitions.writeln('\tunion {')
 	g.type_definitions.writeln('\t\tvoid* _object;')
 	for variant in info.types {
@@ -880,7 +881,7 @@ pub fn (mut g Gen) write_interface_typesymbol_declaration(sym ast.TypeSymbol) {
 		cname := c_name(field.name)
 		g.type_definitions.writeln('\t$styp* $cname;')
 	}
-	g.type_definitions.writeln('} ${c_name(sym.name)};')
+	g.type_definitions.writeln('};')
 }
 
 pub fn (mut g Gen) write_fn_typesymbol_declaration(sym ast.TypeSymbol) {

--- a/vlib/v/tests/interface_nested_field_test.v
+++ b/vlib/v/tests/interface_nested_field_test.v
@@ -1,0 +1,39 @@
+struct Base {
+}
+
+interface Foo {
+	parent Foo
+	thing(mut b Base, value i64) string
+}
+
+struct Bar {
+	parent Foo
+}
+
+fn (f Bar) thing(mut b Base, value i64) string {
+	return 'bar'
+}
+
+struct SubBar {
+	parent Foo = Bar{}
+}
+
+fn (f SubBar) thing(mut b Base, value i64) string {
+	return 'subbar'
+}
+
+fn test_interface_nested_field() {
+	mut foo_group := []Foo{}
+	foo_group << Bar{}
+	foo_group << SubBar{}
+
+	mut b := Base{}
+	mut ret := []string{}
+	for foo in foo_group {
+		println(foo.thing(mut b, 22))
+		ret << foo.thing(mut b, 22)
+	}
+	assert ret.len == 2
+	assert ret[0] == 'bar'
+	assert ret[1] == 'subbar'
+}


### PR DESCRIPTION
This PR fix the interface with nested fields (fix #10077).

- Fix the interface with nested fields.
- Add test.

```vlang
struct Base {
}

interface Foo {
	parent Foo
	thing(mut b Base, value i64) string
}

struct Bar {
	parent Foo
}

fn (f Bar) thing(mut b Base, value i64) string {
	return 'bar'
}

struct SubBar {
	parent Foo = Bar{}
}

fn (f SubBar) thing(mut b Base, value i64) string {
	return 'subbar'
}

fn main() {
	mut foo_group := []Foo{}
	foo_group << Bar{}
	foo_group << SubBar{}

	mut b := Base{}
	mut ret := []string{}
	for foo in foo_group {
		println(foo.thing(mut b, 22))
		ret << foo.thing(mut b, 22)
	}
	assert ret.len == 2
	assert ret[0] == 'bar'
	assert ret[1] == 'subbar'
}

PS D:\Test\v\tt1> v run .
bar
subbar
```