### PR TITLE
builtin: fix termux prints

### DIFF
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -142,7 +142,8 @@ pub fn eprint(s string) {
 pub fn print(s string) {
 	$if android {
 		C.fprintf(C.stdout, c'%.*s', s.len, s.str) // logcat
-	} // no else if for android termux support
+	}
+	// no else if for android termux support
 	$if ios {
 		// TODO: Implement a buffer as NSLog doesn't have a "print"
 		C.WrappedNSLog(s.str)
@@ -163,9 +164,10 @@ pub fn println(s string) {
 	$if android {
 		C.fprintf(C.stdout, c'%.*s\n', s.len, s.str) // logcat
 		return
-	} // no else if for android termux support
+	}
+	// no else if for android termux support
 	$if ios {
-		C.WrappedNSLog(s.str)
+		C.WrappedNSLog(s.str)
 		return
 	} $else $if freestanding {
 		bare_print(s.str, u64(s.len))

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -141,10 +141,9 @@ pub fn eprint(s string) {
 [manualfree]
 pub fn print(s string) {
 	$if android {
-		// android print for logcat
-		C.fprintf(C.stdout, c'%.*s', s.len, s.str)
-		_write_buf_to_fd(1, s.str, s.len)
-	} $else $if ios {
+		C.fprintf(C.stdout, c'%.*s', s.len, s.str) // logcat
+	} // no else if for android termux support
+	$if ios {
 		// TODO: Implement a buffer as NSLog doesn't have a "print"
 		C.WrappedNSLog(s.str)
 	} $else $if freestanding {
@@ -161,13 +160,12 @@ pub fn println(s string) {
 		println('println(NIL)')
 		return
 	}
-	$if ios {
-		C.WrappedNSLog(s.str)
+	$if android {
+		C.fprintf(C.stdout, c'%.*s\n', s.len, s.str) // logcat
 		return
-	} $else $if android {
-		// android print for logcat
-		C.fprintf(C.stdout, c'%.*s\n', s.len, s.str)
-		_writeln_to_fd(1, s)
+	} // no else if for android termux support
+	$if ios {
+		C.WrappedNSLog(s.str)
 		return
 	} $else $if freestanding {
 		bare_print(s.str, u64(s.len))


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
Fix for missing v output on termux/android.

This commit introduced the regression 
https://github.com/vlang/v/commit/dd254a665267cc0fd06ebc51d44f78d91c7e2da9
