### PR TITLE
fmt: keep selective type imports used for casting

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1720,6 +1720,7 @@ pub fn (mut f Fmt) call_args(args []ast.CallArg) {
 
 pub fn (mut f Fmt) cast_expr(node ast.CastExpr) {
 	f.write(f.table.type_to_str_using_aliases(node.typ, f.mod2alias) + '(')
+	f.mark_types_import_as_used(node.typ)
 	f.expr(node.expr)
 	if node.has_arg {
 		f.write(', ')

--- a/vlib/v/fmt/tests/cast_expected.vv
+++ b/vlib/v/fmt/tests/cast_expected.vv
@@ -1,5 +1,5 @@
 import v.ast { InfixExpr }
-import v.table
+import v.table { Type }
 
 fn test_as() {
 	_ := sum_expr() as InfixExpr

--- a/vlib/v/fmt/tests/import_selective_keep.vv
+++ b/vlib/v/fmt/tests/import_selective_keep.vv
@@ -1,10 +1,12 @@
 import math.complex { Complex }
 import gg { MouseButton }
+import time { Duration }
 
 fn keep_imported_enum_map_key() {
 	bm := map[MouseButton]string{}
 }
 
 fn main() {
+	_ := Duration(10) // keep cast type
 	assert *(&f64(&byte(&num) + __offsetof(Complex, re))) == 1.0
 }


### PR DESCRIPTION
fix #10583 