### PR TITLE
checker: check optional interface type mismatch (fix #10608)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -304,6 +304,15 @@ pub fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 	if expected == ast.charptr_type && got == ast.char_type.to_ptr() {
 		return true
 	}
+	if expected.has_flag(.optional) {
+		sym := c.table.get_type_symbol(got)
+		if (sym.kind == .interface_ && sym.name == 'IError')
+			|| got in [ast.none_type, ast.error_type] {
+			return true
+		} else if !c.check_basic(got, expected.clear_flag(.optional)) {
+			return false
+		}
+	}
 	if !c.check_basic(got, expected) { // TODO: this should go away...
 		return false
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6162,7 +6162,6 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 						node.is_expr = true
 						node.typ = c.expected_type
 					}
-					continue
 				}
 				if c.expected_type.has_flag(.generic) {
 					if node.typ == ast.void_type {

--- a/vlib/v/checker/tests/optional_interface_mismatch.out
+++ b/vlib/v/checker/tests/optional_interface_mismatch.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/optional_interface_mismatch.vv:11:9: error: mismatched types `?MObject` and `string`
+    9 |
+   10 | fn give_string(line string) ?MObject {
+   11 |     return if true { 'string' } else { 'string' }
+      |            ~~
+   12 | }

--- a/vlib/v/checker/tests/optional_interface_mismatch.vv
+++ b/vlib/v/checker/tests/optional_interface_mismatch.vv
@@ -1,0 +1,12 @@
+fn main() {
+	le_string := give_string('string') or { return }
+	le_string.unimplemented()
+}
+
+interface MObject {
+	unimplemented() string
+}
+
+fn give_string(line string) ?MObject {
+	return if true { 'string' } else { 'string' }
+}


### PR DESCRIPTION
This PR check optional interface type mismatch (fix #10608).

- Check optional interface type mismatch.
- Add test.

```vlang
fn main() {
	le_string := give_string('string') or { return }
	le_string.unimplemented()
}

interface MObject {
	unimplemented() string
}

fn give_string(line string) ?MObject {
	return if true { 'string' } else { 'string' }
}

PS D:\Test\v\tt1> v run .
.\tt1.v:11:9: error: mismatched types `?MObject` and `string`
    9 | 
   10 | fn give_string(line string) ?MObject {
   11 |     return if true { 'string' } else { 'string' }
      |            ~~
   12 | }
```