### PR TITLE
table: optimize empty interface

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1037,24 +1037,28 @@ pub fn (t &Table) has_deep_child_no_ref(ts &TypeSymbol, name string) bool {
 
 // complete_interface_check does a MxN check for all M interfaces vs all N types, to determine what types implement what interfaces.
 // It short circuits most checks when an interface can not possibly be implemented by a type.
-pub fn (mut table Table) complete_interface_check() {
+pub fn (mut t Table) complete_interface_check() {
 	util.timing_start(@METHOD)
 	defer {
 		util.timing_measure(@METHOD)
 	}
-	for tk, mut tsym in table.type_symbols {
+	for tk, mut tsym in t.type_symbols {
 		if tsym.kind != .struct_ {
 			continue
 		}
 		info := tsym.info as Struct
-		for _, mut idecl in table.interfaces {
+		for _, mut idecl in t.interfaces {
 			if idecl.methods.len > tsym.methods.len {
 				continue
 			}
 			if idecl.fields.len > info.fields.len {
 				continue
 			}
-			table.does_type_implement_interface(tk, idecl.typ)
+			// only generate type cast of the module in which the interface declaration resides
+			if tsym.mod != t.get_type_symbol(idecl.typ).mod {
+				continue
+			}
+			t.does_type_implement_interface(tk, idecl.typ)
 		}
 	}
 }

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1054,8 +1054,9 @@ pub fn (mut t Table) complete_interface_check() {
 			if idecl.fields.len > info.fields.len {
 				continue
 			}
-			// only generate type cast of the module in which the interface declaration resides
-			if tsym.mod != t.get_type_symbol(idecl.typ).mod {
+			// empty interface only generate type cast functions of the current module
+			if idecl.methods.len == 0 && idecl.fields.len == 0
+				&& tsym.mod != t.get_type_symbol(idecl.typ).mod {
 				continue
 			}
 			t.does_type_implement_interface(tk, idecl.typ)


### PR DESCRIPTION
This PR optimize generating type cast functions.

- Only generate type cast functions of the module in which the interface declaration resides.

```vlang
fn main(){
	stru := Stru{}
	fnc1(stru)
}
interface Inter{
}

struct Stru{
	bruh int
}

fn fnc1(inter Inter){
	println(inter)
}
```
Before, we will generate c codes:
```vlang
static main__Inter I_main__Stru_to_Interface_main__Inter(main__Stru* x);
int _main__Inter_main__Stru_index = 0;
static main__Inter I_ustring_to_Interface_main__Inter(ustring* x);
int _main__Inter_ustring_index = 1;
static main__Inter I_voidptr_to_Interface_main__Inter(voidptr* x);
int _main__Inter_voidptr_index = 2;
static main__Inter I_array_to_Interface_main__Inter(array* x);
int _main__Inter_array_index = 3;
static main__Inter I_map_to_Interface_main__Inter(map* x);
int _main__Inter_map_index = 4;
static main__Inter I_VCastTypeIndexName_to_Interface_main__Inter(VCastTypeIndexName* x);
int _main__Inter_VCastTypeIndexName_index = 5;
static main__Inter I_VAssertMetaInfo_to_Interface_main__Inter(VAssertMetaInfo* x);
int _main__Inter_VAssertMetaInfo_index = 6;
static main__Inter I_MethodArgs_to_Interface_main__Inter(MethodArgs* x);
int _main__Inter_MethodArgs_index = 7;
static main__Inter I_FunctionData_to_Interface_main__Inter(FunctionData* x);
int _main__Inter_FunctionData_index = 8;
static main__Inter I_FieldData_to_Interface_main__Inter(FieldData* x);
int _main__Inter_FieldData_index = 9;
static main__Inter I_StructAttribute_to_Interface_main__Inter(StructAttribute* x);
int _main__Inter_StructAttribute_index = 10;
static main__Inter I_SymbolInfo_to_Interface_main__Inter(SymbolInfo* x);
int _main__Inter_SymbolInfo_index = 11;
static main__Inter I_SymbolInfoContainer_to_Interface_main__Inter(SymbolInfoContainer* x);
int _main__Inter_SymbolInfoContainer_index = 12;
static main__Inter I_Line64_to_Interface_main__Inter(Line64* x);
int _main__Inter_Line64_index = 13;
static main__Inter I_ExceptionRecord_to_Interface_main__Inter(ExceptionRecord* x);
int _main__Inter_ExceptionRecord_index = 14;
static main__Inter I_ContextRecord_to_Interface_main__Inter(ContextRecord* x);
int _main__Inter_ContextRecord_index = 15;
static main__Inter I_ExceptionPointers_to_Interface_main__Inter(ExceptionPointers* x);
int _main__Inter_ExceptionPointers_index = 16;
static main__Inter I_strconv__Float64u_to_Interface_main__Inter(strconv__Float64u* x);
int _main__Inter_strconv__Float64u_index = 17;
static main__Inter I_strconv__Float32u_to_Interface_main__Inter(strconv__Float32u* x);
int _main__Inter_strconv__Float32u_index = 18;
static main__Inter I_DenseArray_to_Interface_main__Inter(DenseArray* x);
int _main__Inter_DenseArray_index = 19;
static main__Inter I_Error_to_Interface_main__Inter(Error* x);
int _main__Inter_Error_index = 20;
static main__Inter I_None___to_Interface_main__Inter(None__* x);
int _main__Inter_None___index = 21;
static main__Inter I_Option_to_Interface_main__Inter(Option* x);
int _main__Inter_Option_index = 22;
static main__Inter I_VMemoryBlock_to_Interface_main__Inter(VMemoryBlock* x);
int _main__Inter_VMemoryBlock_index = 23;
static main__Inter I_mapnode_to_Interface_main__Inter(mapnode* x);
int _main__Inter_mapnode_index = 24;
static main__Inter I_SortedMap_to_Interface_main__Inter(SortedMap* x);
int _main__Inter_SortedMap_index = 25;
static main__Inter I_RepIndex_to_Interface_main__Inter(RepIndex* x);
int _main__Inter_RepIndex_index = 26;
static main__Inter I_StrIntpMem_to_Interface_main__Inter(StrIntpMem* x);
int _main__Inter_StrIntpMem_index = 27;
static main__Inter I_StrIntpData_to_Interface_main__Inter(StrIntpData* x);
int _main__Inter_StrIntpData_index = 28;
static main__Inter I_strconv__BF_param_to_Interface_main__Inter(strconv__BF_param* x);
int _main__Inter_strconv__BF_param_index = 29;
static main__Inter I_StrIntpCgenData_to_Interface_main__Inter(StrIntpCgenData* x);
int _main__Inter_StrIntpCgenData_index = 30;
static main__Inter I_strconv__PrepNumber_to_Interface_main__Inter(strconv__PrepNumber* x);
int _main__Inter_strconv__PrepNumber_index = 31;
static main__Inter I_strconv__Dec32_to_Interface_main__Inter(strconv__Dec32* x);
int _main__Inter_strconv__Dec32_index = 32;
static main__Inter I_strconv__Uf32_to_Interface_main__Inter(strconv__Uf32* x);
int _main__Inter_strconv__Uf32_index = 33;
static main__Inter I_strconv__Dec64_to_Interface_main__Inter(strconv__Dec64* x);
int _main__Inter_strconv__Dec64_index = 34;
static main__Inter I_strconv__Uf64_to_Interface_main__Inter(strconv__Uf64* x);
int _main__Inter_strconv__Uf64_index = 35;
static main__Inter I_strconv__Uint128_to_Interface_main__Inter(strconv__Uint128* x);
int _main__Inter_strconv__Uint128_index = 36;
// ^^^ number of types for interface main__Inter: 37
```
Now:
```vlang
static main__Inter I_main__Stru_to_Interface_main__Inter(main__Stru* x);
int _main__Inter_main__Stru_index = 0;
// ^^^ number of types for interface main__Inter: 1
```