### PR TITLE
checker: fix generic fn inferring multi paras type (fix #10623)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -550,7 +550,7 @@ pub fn (mut c Checker) infer_fn_generic_types(f ast.Fn, mut call_expr ast.CallEx
 				if to_set.has_flag(.generic) {
 					to_set = c.unwrap_generic(to_set)
 				}
-			} else {
+			} else if param.typ.has_flag(.generic) {
 				arg_sym := c.table.get_type_symbol(arg.typ)
 				if arg_sym.kind == .array && param_type_sym.kind == .array {
 					mut arg_elem_info := arg_sym.info as ast.Array
@@ -588,7 +588,7 @@ pub fn (mut c Checker) infer_fn_generic_types(f ast.Fn, mut call_expr ast.CallEx
 					}
 				} else if param.typ.has_flag(.variadic) {
 					to_set = c.table.mktyp(arg.typ)
-				} else if arg_sym.kind == .struct_ && param.typ.has_flag(.generic) {
+				} else if arg_sym.kind == .struct_ {
 					info := arg_sym.info as ast.Struct
 					generic_names := info.generic_types.map(c.table.get_type_symbol(it).name)
 					if gt_name in generic_names && info.generic_types.len == info.concrete_types.len {

--- a/vlib/v/tests/generic_fn_infer_multi_paras_test.v
+++ b/vlib/v/tests/generic_fn_infer_multi_paras_test.v
@@ -2,17 +2,13 @@ pub struct Page {
 pub mut:
 	lang    string
 	page    string
-	var_one string
-	var_two string
 }
 
 fn get_keys_and_values<T>(mut keys []string, mut values []string, mut data T) ([]string, []string, T) {
-	$for field in T.fields {
-		$if field.typ is string {
-			keys << field.name
-			values << data.$(field.name)
-		}
-	}
+	keys << 'lang'
+	values << 'vlang'
+	keys << 'page'
+	values << 'one'
 	return keys, values, data
 }
 
@@ -21,17 +17,15 @@ fn awesome<T>(mut data T) {
 	mut values := []string{}
 	get_keys_and_values(mut keys, mut values, mut data)
 	println(keys)
-	assert keys == ['lang', 'page', 'var_one', 'var_two']
+	assert keys == ['lang', 'page']
 	println(values)
-	assert values == ['vlang', 'one', 'variable one', 'variable two']
+	assert values == ['vlang', 'one']
 }
 
 fn test_generic_fn_infer_multi_paras() {
 	mut page := Page{
 		lang: 'vlang'
 		page: 'one'
-		var_one: 'variable one'
-		var_two: 'variable two'
 	}
 	awesome(mut page)
 }

--- a/vlib/v/tests/generic_fn_infer_multi_paras_test.v
+++ b/vlib/v/tests/generic_fn_infer_multi_paras_test.v
@@ -11,8 +11,6 @@ fn get_keys_and_values<T>(mut keys []string, mut values []string, mut data T) ([
 		$if field.typ is string {
 			keys << field.name
 			values << data.$(field.name)
-		} $else {
-			keys, values, _ = get_keys_and_values(mut keys, mut values, mut data)
 		}
 	}
 	return keys, values, data
@@ -25,11 +23,13 @@ fn awesome<T>(mut data T) {
 	println(keys)
 	assert keys == ['lang', 'page', 'var_one', 'var_two']
 	println(values)
-	assert values == ['', '', 'variable one', 'variable two']
+	assert values == ['vlang', 'one', 'variable one', 'variable two']
 }
 
 fn test_generic_fn_infer_multi_paras() {
 	mut page := Page{
+		lang: 'vlang'
+		page: 'one'
 		var_one: 'variable one'
 		var_two: 'variable two'
 	}

--- a/vlib/v/tests/generic_fn_infer_multi_paras_test.v
+++ b/vlib/v/tests/generic_fn_infer_multi_paras_test.v
@@ -1,0 +1,37 @@
+pub struct Page {
+pub mut:
+	lang    string
+	page    string
+	var_one string
+	var_two string
+}
+
+fn get_keys_and_values<T>(mut keys []string, mut values []string, mut data T) ([]string, []string, T) {
+	$for field in T.fields {
+		$if field.typ is string {
+			keys << field.name
+			values << data.$(field.name)
+		} $else {
+			keys, values, _ = get_keys_and_values(mut keys, mut values, mut data)
+		}
+	}
+	return keys, values, data
+}
+
+fn awesome<T>(mut data T) {
+	mut keys := []string{}
+	mut values := []string{}
+	get_keys_and_values(mut keys, mut values, mut data)
+	println(keys)
+	assert keys == ['lang', 'page', 'var_one', 'var_two']
+	println(values)
+	assert values == ['', '', 'variable one', 'variable two']
+}
+
+fn test_generic_fn_infer_multi_paras() {
+	mut page := Page{
+		var_one: 'variable one'
+		var_two: 'variable two'
+	}
+	awesome(mut page)
+}

--- a/vlib/v/tests/generic_fn_infer_multi_paras_test.v
+++ b/vlib/v/tests/generic_fn_infer_multi_paras_test.v
@@ -2,14 +2,17 @@ pub struct Page {
 pub mut:
 	lang    string
 	page    string
+	var_one string
+	var_two string
 }
 
-fn get_keys_and_values<T>(mut keys []string, mut values []string, mut data T) ([]string, []string, T) {
-	keys << 'lang'
-	values << 'vlang'
-	keys << 'page'
-	values << 'one'
-	return keys, values, data
+fn get_keys_and_values<T>(mut keys []string, mut values []string, mut data T) {
+	$for field in T.fields {
+		$if field.typ is string {
+			keys << field.name
+			values << data.$(field.name)
+		}
+	}
 }
 
 fn awesome<T>(mut data T) {
@@ -17,15 +20,17 @@ fn awesome<T>(mut data T) {
 	mut values := []string{}
 	get_keys_and_values(mut keys, mut values, mut data)
 	println(keys)
-	assert keys == ['lang', 'page']
+	assert keys == ['lang', 'page', 'var_one', 'var_two']
 	println(values)
-	assert values == ['vlang', 'one']
+	assert values == ['vlang', 'one', 'variable one', 'variable two']
 }
 
 fn test_generic_fn_infer_multi_paras() {
 	mut page := Page{
 		lang: 'vlang'
 		page: 'one'
+		var_one: 'variable one'
+		var_two: 'variable two'
 	}
 	awesome(mut page)
 }


### PR DESCRIPTION
This PR fix generic fn inferring multi paras type (fix #10623).

- Fix generic fn inferring multi paras type.
- Add test.

```vlang
pub struct Page {
pub mut:
	lang    string
	page    string
	var_one string
	var_two string
}

fn get_keys_and_values<T>(mut keys []string, mut values []string, mut data T) {
	$for field in T.fields {
		$if field.typ is string {
			keys << field.name
			values << data.$(field.name)
		} $else {
			get_keys_and_values(mut keys, mut values, mut data)
		}
	}
}

fn awesome<T>(mut data T) {
	mut keys := []string{}
	mut values := []string{}
	get_keys_and_values(mut keys, mut values, mut data)
	println(keys)
	assert keys == ['lang', 'page', 'var_one', 'var_two']
	println(values)
	assert values == ['', '', 'variable one', 'variable two']
}

fn main() {
	mut page := Page{
		var_one: 'variable one'
		var_two: 'variable two'
	}
	awesome(mut page)
}

PS D:\Test\v\tt1> v run .
['lang', 'page', 'var_one', 'var_two']
['', '', 'variable one', 'variable two']
```