### PR TITLE
vweb: prohibit invalid parameter types in vweb app methods

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7566,7 +7566,8 @@ fn (mut c Checker) verify_vweb_params_for_method(m ast.Fn) (bool, int, int) {
 	if m.params.len > 1 {
 		for param in m.params[1..] {
 			param_sym := c.table.get_final_type_symbol(param.typ)
-			if !(param_sym.is_string() || param_sym.is_number() || param_sym.is_float() || param_sym.kind == .bool) {
+			if !(param_sym.is_string() || param_sym.is_number() || param_sym.is_float()
+				|| param_sym.kind == .bool) {
 				c.error('invalid type `$param_sym.name` for parameter `$param.name` in vweb app method `$m.name`',
 					param.pos)
 			}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7563,6 +7563,15 @@ fn (mut c Checker) verify_vweb_params_for_method(m ast.Fn) (bool, int, int) {
 		// allow non custom routed methods, with 1:1 mapping
 		return true, -1, margs
 	}
+	if m.params.len > 1 {
+		for param in m.params[1..] {
+			param_sym := c.table.get_final_type_symbol(param.typ)
+			if param_sym.kind !in [.string, .int, .bool] {
+				c.error('invalid type `$param_sym.name` for parameter `$param.name` in vweb app method `$m.name`',
+					param.pos)
+			}
+		}
+	}
 	mut route_attributes := 0
 	for a in m.attrs {
 		if a.name.starts_with('/') {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7566,7 +7566,7 @@ fn (mut c Checker) verify_vweb_params_for_method(m ast.Fn) (bool, int, int) {
 	if m.params.len > 1 {
 		for param in m.params[1..] {
 			param_sym := c.table.get_final_type_symbol(param.typ)
-			if param_sym.kind !in [.string, .int, .bool] {
+			if !(param_sym.is_string() || param_sym.is_number() || param_sym.is_float() || param_sym.kind == .bool) {
 				c.error('invalid type `$param_sym.name` for parameter `$param.name` in vweb app method `$m.name`',
 					param.pos)
 			}

--- a/vlib/v/checker/tests/invalid_vweb_param_type.out
+++ b/vlib/v/checker/tests/invalid_vweb_param_type.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/invalid_vweb_param_type.vv:8:24: error: invalid type `[]bool` for parameter `list` in vweb app method `index`
+    6 | 
+    7 | ['/:list'; get]
+    8 | fn (mut app App) index(list []bool) vweb.Result {
+      |                        ~~~~
+    9 |     return app.text('')
+   10 | }

--- a/vlib/v/checker/tests/invalid_vweb_param_type.vv
+++ b/vlib/v/checker/tests/invalid_vweb_param_type.vv
@@ -1,0 +1,12 @@
+import vweb
+
+struct App {
+	vweb.Context
+}
+
+['/:list'; get]
+fn (mut app App) index(list []bool) vweb.Result {
+	return app.text('')
+}
+
+vweb.run(&App{}, 5000)

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -10,6 +10,7 @@ import net.http
 import net.urllib
 import strings
 import time
+import v.ast
 
 pub const (
 	methods_with_form       = [http.Method.post, .put, .patch]
@@ -419,6 +420,11 @@ fn handle_conn<T>(mut conn net.TcpConn, mut app T) {
 
 	$for method in T.methods {
 		$if method.return_type is Result {
+			for arg in method.args {
+				if arg.typ != ast.string_type {
+					panic('invalid type for argument `$arg.name` in method `$method.name`, expected type `string`')
+				}
+			}
 			mut method_args := []string{}
 			// TODO: move to server start
 			http_methods, route_path := parse_attrs(method.name, method.attrs) or {

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -10,7 +10,6 @@ import net.http
 import net.urllib
 import strings
 import time
-import v.ast
 
 pub const (
 	methods_with_form       = [http.Method.post, .put, .patch]
@@ -420,11 +419,6 @@ fn handle_conn<T>(mut conn net.TcpConn, mut app T) {
 
 	$for method in T.methods {
 		$if method.return_type is Result {
-			for arg in method.args {
-				if arg.typ != ast.string_type {
-					panic('invalid type for argument `$arg.name` in method `$method.name`, expected type `string`')
-				}
-			}
 			mut method_args := []string{}
 			// TODO: move to server start
 			http_methods, route_path := parse_attrs(method.name, method.attrs) or {


### PR DESCRIPTION
this pr prohibits invalid parameter types in vweb app methods. fixes #10442.