### PR TITLE
vweb: revert free of app on every request

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -349,9 +349,6 @@ fn handle_conn<T>(mut conn net.TcpConn, mut app T) {
 	conn.set_write_timeout(30 * time.second)
 	defer {
 		conn.close() or {}
-		unsafe {
-			free(app)
-		}
 	}
 	mut reader := io.new_buffered_reader(reader: conn)
 	defer {


### PR DESCRIPTION
It's not useful to free the app object if you have an DB or other static values and connections over the app object and in every request you need to reinitialize all.