### PR TITLE
cgen: fix anon optional fn (fix #10640)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -198,7 +198,8 @@ pub fn (t &Table) fn_type_signature(f &Fn) string {
 	}
 	if f.return_type != 0 && f.return_type != void_type {
 		sym := t.get_type_symbol(f.return_type)
-		sig += '__$sym.kind'
+		opt := if f.return_type.has_flag(.optional) { 'option_' } else { '' }
+		sig += '__$opt$sym.kind'
 	}
 	return sig
 }
@@ -225,7 +226,11 @@ pub fn (t &Table) fn_type_source_signature(f &Fn) string {
 		sig += ' ?'
 	} else if f.return_type != void_type {
 		return_type_sym := t.get_type_symbol(f.return_type)
-		sig += ' $return_type_sym.name'
+		if f.return_type.has_flag(.optional) {
+			sig += ' ?$return_type_sym.name'
+		} else {
+			sig += ' $return_type_sym.name'
+		}
 	}
 	return sig
 }

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -433,9 +433,15 @@ fn (mut g Gen) fn_decl_str(info ast.FnType) string {
 		fn_str += util.strip_main_name(g.table.get_type_name(g.unwrap_generic(arg.typ)))
 	}
 	fn_str += ')'
-	if info.func.return_type != ast.void_type {
+	if info.func.return_type == ast.ovoid_type {
+		fn_str += ' ?'
+	} else if info.func.return_type != ast.void_type {
 		x := util.strip_main_name(g.table.get_type_name(g.unwrap_generic(info.func.return_type)))
-		fn_str += ' $x'
+		if info.func.return_type.has_flag(.optional) {
+			fn_str += ' ?$x'
+		} else {
+			fn_str += ' $x'
+		}
 	}
 	return fn_str
 }

--- a/vlib/v/tests/anon_fn_with_optional_test.v
+++ b/vlib/v/tests/anon_fn_with_optional_test.v
@@ -1,0 +1,30 @@
+struct Response {}
+
+pub struct Route {
+	handler     fn (mut App) Response
+	middlewares []fn (mut app App) ?Response
+}
+
+struct App {
+	routes []Route
+}
+
+pub fn check_auth(mut app App) ?Response {
+	return none
+}
+
+fn test_anon_fn_with_optional() {
+	app := App{
+		routes: [
+			Route{
+				middlewares: [
+					check_auth,
+				]
+			},
+		]
+	}
+	println(app)
+	app_str := '$app'
+	assert app_str.contains('handler: fn (mut App) Response')
+	assert app_str.contains('middlewares: [fn (mut App) ?Response]')
+}

--- a/vlib/v/tests/anon_fn_with_optional_test.v
+++ b/vlib/v/tests/anon_fn_with_optional_test.v
@@ -1,4 +1,6 @@
-struct Response {}
+struct Response {
+	ret int
+}
 
 pub struct Route {
 	handler     fn (mut App) Response


### PR DESCRIPTION
This PR fix anon optional fn (fix #10640).

- Fix anon optional fn.
- Add test.

```vlang
struct Response {}

pub struct Route {
	handler     fn (mut App) Response
	middlewares []fn (mut app App) ?Response
}

struct App {
	routes []Route
}

pub fn check_auth(mut app App) ?Response {
	return none
}

fn main() {
	app := App{
		routes: [
			Route{
				middlewares: [
					check_auth,
				]
			},
		]
	}
	println(app)
	app_str := '$app'
	assert app_str.contains('handler: fn (mut App) Response')
	assert app_str.contains('middlewares: [fn (mut App) ?Response]')
}

PS D:\Test\v\tt1> v run .
App{
    routes: [Route{
        handler: fn (mut App) Response
        middlewares: [fn (mut App) ?Response]
    }]
}
```