### PR TITLE
docs: add v keyword next to the backticks

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -3512,7 +3512,7 @@ You can also define special test functions in a test file:
 
 If a test function has an error return type, any propagated errors will fail the test:
 
-```
+```v
 import strconv
 
 fn test_atoi() ? {


### PR DESCRIPTION
This PR fix minor typos of markdown code block.

Before is 

```
import strconv

fn test_atoi() ? {
	assert strconv.atoi('1') ? == 1
	assert strconv.atoi('one') ? == 1 // test will fail
}
```

Now is:

```v
import strconv

fn test_atoi() ? {
	assert strconv.atoi('1') ? == 1
	assert strconv.atoi('one') ? == 1 // test will fail
}
```