### PR TITLE
docs: remove `import os` in the hot code reloading example

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -4638,7 +4638,6 @@ Translating it to V gives you several advantages:
 module main
 
 import time
-import os
 
 [live]
 fn print_message() {


### PR DESCRIPTION
remove `import os`.
module 'os' is imported but never used.