### PR TITLE
checker: fix missing check generic fn call args (fix #10649)

### DIFF
--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -178,7 +178,7 @@ fn (vd VDoc) work_processor(mut work sync.Channel, mut wg sync.WaitGroup) {
 
 fn (vd VDoc) render_parallel(out Output) {
 	vjobs := runtime.nr_jobs()
-	mut work := sync.new_channel<ParallelDoc>(vd.docs.len)
+	mut work := sync.new_channel<ParallelDoc>(u32(vd.docs.len))
 	mut wg := sync.new_waitgroup()
 	for i in 0 .. vd.docs.len {
 		p_doc := ParallelDoc{vd.docs[i], out}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2609,7 +2609,7 @@ pub fn (mut c Checker) fn_call(mut call_expr ast.CallExpr) ast.Type {
 			if typ_sym.kind == .void && param_typ_sym.kind == .string {
 				continue
 			}
-			if func.generic_names.len > 0 {
+			if param.typ.has_flag(.generic) {
 				continue
 			}
 			if c.pref.translated {

--- a/vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.out
+++ b/vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.out
@@ -12,13 +12,6 @@ vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.vv:27:7: error: <
       |          ~~
    28 |     handle(t)
    29 |     // println("${t.msg}")
-vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.vv:28:9: error: cannot use `void` as `T` in argument 1 to `handle`
-   26 | fn g_worker(g Generic<T>) {
-   27 |     t := <-g.ch
-   28 |     handle(t)
-      |            ^
-   29 |     // println("${t.msg}")
-   30 | }
 vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.vv:32:1: error: generic function declaration must specify generic type names, e.g. foo<T>
    30 | }
    31 |

--- a/vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.out
+++ b/vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.vv:3:13: error: cannot use `[]rune` as `string` in argument 2 to `foo_str`
+    1 | fn main() {
+    2 |     x := 'ab'.runes()[..1]
+    3 |     foo_str(1, x)
+      |                ^
+    4 | }
+    5 |

--- a/vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.vv
+++ b/vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.vv
@@ -1,0 +1,7 @@
+fn main() {
+	x := 'ab'.runes()[..1]
+	foo_str(1, x)
+}
+
+fn foo_str<T>(b T, a string) {
+}

--- a/vlib/v/compiler_errors_test.v
+++ b/vlib/v/compiler_errors_test.v
@@ -174,8 +174,8 @@ fn (mut tasks Tasks) run() {
 	vjobs := if tasks.parallel_jobs > 0 { tasks.parallel_jobs } else { runtime.nr_jobs() }
 	mut bench := benchmark.new_benchmark()
 	bench.set_total_expected_steps(tasks.all.len)
-	mut work := sync.new_channel<TaskDescription>(tasks.all.len)
-	mut results := sync.new_channel<TaskDescription>(tasks.all.len)
+	mut work := sync.new_channel<TaskDescription>(u32(tasks.all.len))
+	mut results := sync.new_channel<TaskDescription>(u32(tasks.all.len))
 	mut m_skip_files := skip_files.clone()
 	if os.getenv('V_CI_UBUNTU_MUSL').len > 0 {
 		m_skip_files << skip_on_ubuntu_musl


### PR DESCRIPTION
This PR fix missing check generic fn call args (fix #10649).

- Check generic fn call multi args.
- Add test.

```vlang
fn main() {
	x := 'ab'.runes()[..1]
	foo_str(1, x)
}

fn foo_str<T>(b T, a string) {
}

PS D:\Test\v\tt1> v run .
.\tt1.v:3:13: error: cannot use `[]rune` as `string` in argument 2 to `foo_str`
    1 | fn main() {
    2 |     x := 'ab'.runes()[..1]
    3 |     foo_str(1, x)
      |                ^
    4 | }
    5 |
```