### PR TITLE
cgen: fix generic fn return mut para

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2280,6 +2280,9 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 						g.write('*')
 					}
 				}
+				if lx.is_auto_deref_var() {
+					g.write('*')
+				}
 				g.expr(lx)
 				noscan := if is_auto_heap { g.check_noscan(return_type) } else { '' }
 				if is_opt {
@@ -4622,6 +4625,9 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 				continue
 			}
 			g.write('.arg$arg_idx=')
+			if expr.is_auto_deref_var() {
+				g.write('*')
+			}
 			g.expr(expr)
 			arg_idx++
 			if i < node.exprs.len - 1 {

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -138,6 +138,9 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 	} else {
 		str_fn_name := g.gen_str_for_type(typ)
 		g.write('${str_fn_name}(')
+		if expr.is_auto_deref_var() {
+			g.write('*')
+		}
 		if sym.kind != .function {
 			g.expr_with_cast(expr, typ, typ)
 		}

--- a/vlib/v/tests/generic_fn_infer_multi_paras_test.v
+++ b/vlib/v/tests/generic_fn_infer_multi_paras_test.v
@@ -1,28 +1,38 @@
-pub struct Page {
+pub struct Two_data {
 pub mut:
-	lang    string
-	page    string
-	var_one string
-	var_two string
+	title   string
+	content string
 }
 
-fn get_keys_and_values<T>(mut keys []string, mut values []string, mut data T) {
+pub struct Page {
+pub mut:
+	lang      string
+	page      string
+	var_one   string
+	var_two   string
+	var_three Two_data
+}
+
+fn get_keys_and_values<T>(mut keys []string, mut values []string, mut data T) ([]string, []string, T) {
 	$for field in T.fields {
 		$if field.typ is string {
 			keys << field.name
 			values << data.$(field.name)
 		}
 	}
+	return keys, values, data
 }
 
 fn awesome<T>(mut data T) {
 	mut keys := []string{}
 	mut values := []string{}
-	get_keys_and_values(mut keys, mut values, mut data)
+	keys, values, data = get_keys_and_values(mut keys, mut values, mut data)
 	println(keys)
 	assert keys == ['lang', 'page', 'var_one', 'var_two']
 	println(values)
 	assert values == ['vlang', 'one', 'variable one', 'variable two']
+	println(data)
+	assert '$data'.contains("title: 'what a title'")
 }
 
 fn test_generic_fn_infer_multi_paras() {
@@ -31,6 +41,10 @@ fn test_generic_fn_infer_multi_paras() {
 		page: 'one'
 		var_one: 'variable one'
 		var_two: 'variable two'
+		var_three: {
+			title: 'what a title'
+			content: 'what a content'
+		}
 	}
 	awesome(mut page)
 }


### PR DESCRIPTION
This PR fix generic fn return mut para.

- Fix generic fn return mut para.
- Change `generic_fn_infer_multi_paras_test.v` to return_multi.

```vlang
pub struct Two_data {
pub mut:
	title   string
	content string
}

pub struct Page {
pub mut:
	lang      string
	page      string
	var_one   string
	var_two   string
	var_three Two_data
}

fn get_keys_and_values<T>(mut keys []string, mut values []string, mut data T) ([]string, []string, T) {
	$for field in T.fields {
		$if field.typ is string {
			keys << field.name
			values << data.$(field.name)
		}
	}
	return keys, values, data
}

fn awesome<T>(mut data T) {
	mut keys := []string{}
	mut values := []string{}
	keys, values, data = get_keys_and_values(mut keys, mut values, mut data)
	println(keys)
	println(values)
	println(data)
}

fn main() {
	mut page := Page{
		var_one: 'variable one'
		var_two: 'variable two'
		var_three: {
			title: 'what a title'
			content: 'what a content'
		}
	}
	awesome(mut page)
}

PS D:\Test\v\tt1> v run .
['lang', 'page', 'var_one', 'var_two']
['', '', 'variable one', 'variable two']
Page{
    lang: ''
    page: ''
    var_one: 'variable one'
    var_two: 'variable two'
    var_three: Two_data{
        title: 'what a title'
        content: 'what a content'
    }
}
```