### PR TITLE
parser: check for module globals

### DIFF
--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -153,6 +153,12 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr, left_comments []ast.Comme
 							is_static = true
 						}
 					}
+					if lx.mod == 'main' && '.' in lx.name {
+						lx_mod := lx.name.all_before('.')
+						if lx_mod in p.table.imports && !p.pref.enable_globals {
+							return p.error_with_pos('use `v -enable-globals ...` to enable globals', lx.pos)
+						}
+					}	
 					r0 := right[0]
 					mut v := ast.Var{
 						name: lx.name

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -156,9 +156,10 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr, left_comments []ast.Comme
 					if lx.mod == 'main' && '.' in lx.name {
 						lx_mod := lx.name.all_before('.')
 						if lx_mod in p.table.imports && !p.pref.enable_globals {
-							return p.error_with_pos('use `v -enable-globals ...` to enable globals', lx.pos)
+							return p.error_with_pos('use `v -enable-globals ...` to enable globals',
+								lx.pos)
 						}
-					}	
+					}
 					r0 := right[0]
 					mut v := ast.Var{
 						name: lx.name

--- a/vlib/v/parser/tests/module_global.out
+++ b/vlib/v/parser/tests/module_global.out
@@ -1,0 +1,4 @@
+vlib/v/parser/tests/module_global.vv:2:4: error: use `v -enable-globals ...` to enable globals
+    1 | import os
+    2 | os.foo := 0
+      |    ~~~

--- a/vlib/v/parser/tests/module_global.vv
+++ b/vlib/v/parser/tests/module_global.vv
@@ -1,0 +1,2 @@
+import os
+os.foo := 0


### PR DESCRIPTION
this pr ensures that patterns like:
```v
import os
os.foo := 0
```
are checked by the parser. related to #10658.