### PR TITLE
checker: check generic method call args mismatch

### DIFF
--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -306,15 +306,15 @@ fn test_read_raw_at() ? {
 	f.write_raw(another_permission) ?
 	f.close()
 	f = os.open_file(tfile, 'r') ?
-	mut at := 3
+	mut at := u64(3)
 	p := f.read_raw_at<Point>(at) ?
-	at += int(sizeof(Point))
+	at += sizeof(Point)
 	b := f.read_raw_at<byte>(at) ?
-	at += int(sizeof(byte))
+	at += sizeof(byte)
 	c := f.read_raw_at<Color>(at) ?
-	at += int(sizeof(Color))
+	at += sizeof(Color)
 	x := f.read_raw_at<Permissions>(at) ?
-	at += int(sizeof(Permissions))
+	at += sizeof(Permissions)
 	f.close()
 
 	assert p == another_point

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2038,7 +2038,7 @@ pub fn (mut c Checker) method_call(mut call_expr ast.CallExpr) ast.Type {
 				}
 				continue
 			}
-			if method.generic_names.len > 0 {
+			if exp_arg_typ.has_flag(.generic) {
 				continue
 			}
 			c.check_expected_call_arg(got_arg_typ, c.unwrap_generic(exp_arg_typ), call_expr.language) or {

--- a/vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.out
+++ b/vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.out
@@ -3,5 +3,12 @@ vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.vv:3:13: error: cann
     2 |     x := 'ab'.runes()[..1]
     3 |     foo_str(1, x)
       |                ^
-    4 | }
-    5 |
+    4 |
+    5 |     foo := Foo<int>{}
+vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.vv:6:11: error: cannot use `[]rune` as `string` in argument 1 to `Foo<int>.info`
+    4 |
+    5 |     foo := Foo<int>{}
+    6 |     foo.info(x)
+      |              ^
+    7 | }
+    8 |

--- a/vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.vv
+++ b/vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.vv
@@ -1,7 +1,17 @@
 fn main() {
 	x := 'ab'.runes()[..1]
 	foo_str(1, x)
+
+	foo := Foo<int>{}
+	foo.info(x)
 }
 
 fn foo_str<T>(b T, a string) {
+}
+
+struct Foo<T> {
+	t T
+}
+
+fn (f Foo<T>) info(a string) {
 }


### PR DESCRIPTION
This PR check generic method call args mismatch.

- Check generic method call args mismatch.
- Add test.

```vlang
fn main() {
	x := 'ab'.runes()[..1]
	foo_str(1, x)

	foo := Foo<int>{}
	foo.info(x)
}

fn foo_str<T>(b T, a string) {
}

struct Foo<T> {
	t T
}

fn (f Foo<T>) info(a string) {
}

PS D:\Test\v\tt1> v run .
.\tt1.v:3:13: error: cannot use `[]rune` as `string` in argument 2 to `foo_str`
    1 | fn main() {
    2 |     x := 'ab'.runes()[..1]
    3 |     foo_str(1, x)
      |                ^
    4 |
    5 |     foo := Foo<int>{}
.\tt1.v:6:11: error: cannot use `[]rune` as `string` in argument 1 to `Foo<int>.info`
    4 |
    5 |     foo := Foo<int>{}
    6 |     foo.info(x)
      |              ^
    7 | }
    8 |
```