### PR TITLE
cgen: fix VUNREACHABLE inside ternary

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -532,7 +532,11 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 			g.writeln(';')
 			g.write('VUNREACHABLE()')
 		} else {
-			g.write(', ({VUNREACHABLE();})')
+			$if msvc {
+				// MSVC has no support for the statement expressions used below
+			} $else {
+				g.write(', ({VUNREACHABLE();})')
+			}
 		}
 	}
 }

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -528,7 +528,11 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 		}
 	}
 	if node.is_noreturn {
-		g.writeln(';')
+		if g.inside_ternary == 0 {
+			g.writeln(';')
+		} else {
+			g.write(', ')
+		}
 		g.write('VUNREACHABLE()')
 	}
 }

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -530,10 +530,10 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 	if node.is_noreturn {
 		if g.inside_ternary == 0 {
 			g.writeln(';')
+			g.write('VUNREACHABLE()')
 		} else {
-			g.write(', ')
+			g.write(', ({VUNREACHABLE();})')
 		}
-		g.write('VUNREACHABLE()')
 	}
 }
 

--- a/vlib/v/tests/unreachable_code_path.v
+++ b/vlib/v/tests/unreachable_code_path.v
@@ -1,0 +1,11 @@
+fn main() {
+	x := if false {
+		'foo'
+	} else if true {
+		'bar'
+	} else {
+		panic('err')
+		'empty'
+	}
+	assert x == 'bar'
+}

--- a/vlib/v/tests/unreachable_code_paths_test.v
+++ b/vlib/v/tests/unreachable_code_paths_test.v
@@ -1,4 +1,4 @@
-fn main() {
+fn test_inside_ternary() {
 	x := if false {
 		'foo'
 	} else if true {


### PR DESCRIPTION
fix #10671 

NB: msvc lacks support for [C statement exprs](https://gcc.gnu.org/onlinedocs/gcc/Statement-Exprs.html) so `VUNREACHABLE` won't be added in this special case when msvc is used