### PR TITLE
cgen: fix string interpolation where the expression generates multiple C statements

### DIFF
--- a/vlib/v/tests/string_interpolation_multistmt_test.v
+++ b/vlib/v/tests/string_interpolation_multistmt_test.v
@@ -1,0 +1,16 @@
+// This file checks that string interpolations where expressions that generate
+// multiple C statements work correctly
+import json
+
+fn test_array_map_interpolation() {
+	numbers := [1, 2, 3]
+	assert '${numbers.map(it * it)}' == '[1, 4, 9]'
+}
+
+fn test_json_encode_interpolation() {
+	object := map{
+		'example': 'string'
+		'other':   'data'
+	}
+	assert '${json.encode(object)}' == '{"example":"string","other":"data"}'
+}


### PR DESCRIPTION
This PR fixes #10558, where a method call such as `map` or `json.encode` causes a C error. Similarly to my earlier PR, the issue here was that cgen "copy-pastes" the generated expression.

This makes `Gen.str_val` directly write the expression instead of returning a string. The first loop in `string_inter_literal` also writes the code without adding items into a temporary array.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
