### PR TITLE
cgen: fix interface fn return with struct_init (fix #9144)

### DIFF
--- a/vlib/v/tests/interface_fn_return_with_struct_init.v
+++ b/vlib/v/tests/interface_fn_return_with_struct_init.v
@@ -1,0 +1,34 @@
+struct Animal {
+	class_name string = 'Animal'
+pub mut:
+	interf Adoptable
+}
+
+interface Adoptable {
+	class_name string
+	age int
+	test int
+}
+
+struct Cat {
+pub mut:
+	class_name string = 'Cat'
+	age        int    = 2
+	test       int    = 2
+}
+
+fn new_adoptable() Adoptable {
+	return Cat{}
+}
+
+fn test_interface_fn_return_with_struct_init() {
+	mut a := Animal{
+		interf: new_adoptable()
+	}
+	println(a.interf.class_name)
+	assert a.interf.class_name == 'Cat'
+	println(a.interf.age)
+	assert a.interf.age == 2
+	println(a.interf.test)
+	assert a.interf.test == 2
+}


### PR DESCRIPTION
This PR fix interface fn return with struct_init (fix #9144).

- Fix interface fn return with struct_init.
- Add test.

```vlang
struct Animal {
	class_name string = 'Animal'
pub mut:
	interf Adoptable
}

interface Adoptable {
	class_name string
	age int
	test int
}

struct Cat {
pub mut:
	class_name string = 'Cat'
	age        int    = 2
	test       int    = 2
}

fn new_adoptable() Adoptable {
	return Cat{}
}

fn main() {
	mut a := Animal{
		interf: new_adoptable()
	}
        println(a.interf)
	println(a.interf.class_name)
	assert a.interf.class_name == 'Cat'
	println(a.interf.age)
	assert a.interf.age == 2
	println(a.interf.test)
	assert a.interf.test == 2
}

PS D:\Test\v\tt1> v run .
Adoptable(Cat{
    class_name: 'Cat'
    age: 2
    test: 2
})
Cat
2
2
```