### PR TITLE
cgen: fix fn return array of interface (fix #9729)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -77,7 +77,7 @@ mut:
 	is_sql                 bool     // Inside `sql db{}` statement, generating sql instead of C (e.g. `and` instead of `&&` etc)
 	is_shared              bool     // for initialization of hidden mutex in `[rw]shared` literals
 	is_vlines_enabled      bool     // is it safe to generate #line directives when -g is passed
-	is_cast_in_heap        bool     // fn return struct_init to interface type (cannot use stack, should use heap)
+	inside_cast_in_heap    int      // inside cast to interface type in heap (resolve recursive calls)
 	arraymap_set_pos       int      // map or array set value position
 	vlines_path            string   // set to the proper path for generating #line directives
 	optionals              []string // to avoid duplicates TODO perf, use map
@@ -1827,11 +1827,21 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 	}
 	if exp_sym.kind == .interface_ && got_type_raw.idx() != expected_type.idx()
 		&& !expected_type.has_flag(.optional) {
-		got_styp := g.cc_type(got_type, true)
-		exp_styp := g.cc_type(expected_type, true)
-		fname := 'I_${got_styp}_to_Interface_$exp_styp'
-		g.call_cfn_for_casting_expr(fname, expr, expected_is_ptr, exp_styp, got_is_ptr,
-			got_styp)
+		if expr is ast.StructInit && !got_type.is_ptr() {
+			g.inside_cast_in_heap++
+			got_styp := g.cc_type(got_type.to_ptr(), true)
+			exp_styp := g.cc_type(expected_type, true)
+			fname := 'I_${got_styp}_to_Interface_$exp_styp'
+			g.call_cfn_for_casting_expr(fname, expr, expected_is_ptr, exp_styp, true,
+				got_styp)
+			g.inside_cast_in_heap--
+		} else {
+			got_styp := g.cc_type(got_type, true)
+			exp_styp := g.cc_type(expected_type, true)
+			fname := 'I_${got_styp}_to_Interface_$exp_styp'
+			g.call_cfn_for_casting_expr(fname, expr, expected_is_ptr, exp_styp, got_is_ptr,
+				got_styp)
+		}
 		return
 	}
 	// cast to sum type
@@ -4727,14 +4737,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 				g.expr(expr0)
 			}
 		} else {
-			rs := g.table.get_type_symbol(g.fn_decl.return_type)
-			if node.exprs[0] is ast.StructInit && rs.kind == .interface_ && !node.types[0].is_ptr() {
-				g.is_cast_in_heap = true
-				g.expr_with_cast(node.exprs[0], node.types[0].to_ptr(), g.fn_decl.return_type)
-				g.is_cast_in_heap = false
-			} else {
-				g.expr_with_cast(node.exprs[0], node.types[0], g.fn_decl.return_type)
-			}
+			g.expr_with_cast(node.exprs[0], node.types[0], g.fn_decl.return_type)
 		}
 		if use_tmp_var {
 			g.writeln(';')
@@ -4922,7 +4925,7 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 		mut shared_typ := struct_init.typ.set_flag(.shared_f)
 		shared_styp = g.typ(shared_typ)
 		g.writeln('($shared_styp*)__dup${shared_styp}(&($shared_styp){.mtx = {0}, .val =($styp){')
-	} else if is_amp || g.is_cast_in_heap {
+	} else if is_amp || g.inside_cast_in_heap > 0 {
 		g.write('($styp*)memdup(&($styp){')
 	} else if struct_init.typ.is_ptr() {
 		basetyp := g.typ(struct_init.typ.set_nr_muls(0))
@@ -5112,7 +5115,7 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 	g.write('}')
 	if g.is_shared && !g.inside_opt_data && !g.is_arraymap_set {
 		g.write('}, sizeof($shared_styp))')
-	} else if is_amp || g.is_cast_in_heap {
+	} else if is_amp || g.inside_cast_in_heap > 0 {
 		g.write(', sizeof($styp))')
 	}
 }

--- a/vlib/v/tests/interface_fn_return_array_of_interface_test.v
+++ b/vlib/v/tests/interface_fn_return_array_of_interface_test.v
@@ -1,0 +1,26 @@
+import os
+
+interface Node {
+	name string
+}
+
+struct NodeEmpty {
+	name string = 'abc'
+}
+
+fn pusher(lines []string) []Node {
+	mut nodes := []Node{}
+
+	for line in lines {
+		nodes << NodeEmpty{}
+	}
+
+	return nodes
+}
+
+fn test_fn_return_array_of_interface() {
+	lines := os.read_lines(@FILE) or { panic(err) }
+	pushed := pusher(lines)
+	println(pushed)
+	assert pushed.len > 0
+}


### PR DESCRIPTION
This PR fix fn return array of interface (fix #9729, fix #9764).

- Fix fn return array of interface.
- Add test.

```vlang
import os

interface Node {
	name string
}

struct NodeEmpty {
	name string = 'abc'
}

fn pusher(lines []string) []Node {
	mut nodes := []Node{}

	for _ in lines {
		nodes << NodeEmpty{}
	}

	return nodes
}

fn main() {
	lines := os.read_lines(@FILE) or { panic(err) }
	pushed := pusher(lines)
	println(pushed)
	assert pushed.len > 0
}

PS D:\Test\v\tt1> v run .
[Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
}), Node(NodeEmpty{
    name: 'abc'
})]
```

```vlang
struct IntTree {
	value int
	children []IntTree
}

interface ITree {
	children() []ITree
}

fn (t IntTree) children() []ITree {
	return map_children<IntTree>(t.children)
}

fn map_children<T>(children []T) []ITree {
	mut result := []ITree{}
	for c in children {
		result << unsafe { ITree(c) }
	}
	return result
}

fn encode_as_count_array (n ITree) []int {
	mut result := []int{}
	inner_encode(n, mut result)
	return result
}

fn inner_encode(n ITree, mut result []int) {
	result << n.children().len
	println(result)
	for child in n.children() {
		// println(child)
		inner_encode(child, mut result)
	}
}

fn main() {
	n := IntTree {
		value: 25
		children: [
			IntTree {
				value: 10
			},
			IntTree {
				value: 40
			}
		]
	}
	println(n)

	l := encode_as_count_array(ITree(n))
	println(l)
}

PS D:\Test\v\tt1> v run .
IntTree{
    value: 25
    children: [IntTree{
        value: 10
        children: []
    }, IntTree{
        value: 40
        children: []
    }]
}
[2]
[2, 0]
[2, 0, 0]
[2, 0, 0]
```