### PR TITLE
cgen: fix error of generic array typedef (fix #10678)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -769,7 +769,11 @@ pub fn (mut g Gen) write_typedef_types() {
 		}
 		match typ.kind {
 			.array {
-				g.type_definitions.writeln('typedef array $typ.cname;')
+				info := typ.info as ast.Array
+				elem_sym := g.table.get_type_symbol(info.elem_type)
+				if elem_sym.kind != .placeholder {
+					g.type_definitions.writeln('typedef array $typ.cname;')
+				}
 			}
 			.array_fixed {
 				info := typ.info as ast.ArrayFixed

--- a/vlib/v/tests/generics_array_typedef_test.v
+++ b/vlib/v/tests/generics_array_typedef_test.v
@@ -1,0 +1,31 @@
+struct Node<T> {
+mut:
+	data T
+	next &Node<T> = 0
+}
+
+struct SinglyLinkedList<T> {
+mut:
+	first_node &Node<T> = 0
+}
+
+fn init_singlylinkedlist<T>(nodes []Node<T>) SinglyLinkedList<T> {
+	mut current_node := &nodes[0]
+
+	for i in 0 .. nodes.len - 1 {
+		current_node = &nodes[i]
+		current_node.next = &nodes[i + 1]
+	}
+
+	return SinglyLinkedList<T>{&nodes[0]}
+}
+
+fn test_generic_array_typedef() {
+	sll := init_singlylinkedlist<int>([Node<int>{ data: 1 }, Node<int>{
+		data: 2
+	}, Node<int>{
+		data: 798
+	}])
+	println(sll.first_node.next)
+	assert sll.first_node.next.data == 2
+}


### PR DESCRIPTION
This PR fix error of generic array typedef (fix #10678).

- Fix error of generic array typedef.
- Add test.

```vlang
struct Node<T> {
mut:
	data T
	next &Node<T> = 0
}

struct SinglyLinkedList<T> {
mut:
	first_node &Node<T> = 0
}

fn init_singlylinkedlist<T>(nodes []Node<T>) SinglyLinkedList<T> {
	mut current_node := &nodes[0]

	for i in 0 .. nodes.len - 1 {
		current_node = &nodes[i]
		current_node.next = &nodes[i + 1]
	}

	return SinglyLinkedList<T>{&nodes[0]}
}

fn main() {
	sll := init_singlylinkedlist<int>([Node<int>{ data: 1 }, Node<int>{
		data: 2
	}, Node<int>{
		data: 798
	}])
	println(sll.first_node.next)
	assert sll.first_node.next.data == 2
}

PS D:\Test\v\tt1> v run .
&Node<int>{
    data: 2
    next: &<circular>
}
```