### PR TITLE
v.checker: make calling a deprecated fn an error, 180 days (6 months) after its deprecation date

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5220,6 +5220,18 @@ fn old_function() {
 [deprecated: 'use new_function() instead']
 fn legacy_function() {}
 
+// You can also specify a date, after which the function will be
+// considered deprecated. Before that date, calls to the function
+// will be compiler notices - you will see them, but the compilation
+// is not affected. After that date, calls will become warnings,
+// so ordinary compiling will still work, but compiling with -prod
+// will not (all warnings are treaded like errors with -prod).
+// 6 months after the deprecation date, calls will be hard
+// compiler errors.
+[deprecated: 'use new_function2() instead']
+[deprecated_after: '2021-05-27']
+fn legacy_function2() {}
+
 // This function's calls will be inlined.
 [inline]
 fn inlined_function() {

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5225,7 +5225,7 @@ fn legacy_function() {}
 // will be compiler notices - you will see them, but the compilation
 // is not affected. After that date, calls will become warnings,
 // so ordinary compiling will still work, but compiling with -prod
-// will not (all warnings are treaded like errors with -prod).
+// will not (all warnings are treated like errors with -prod).
 // 6 months after the deprecation date, calls will be hard
 // compiler errors.
 [deprecated: 'use new_function2() instead']

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3020,14 +3020,18 @@ fn (mut c Checker) deprecate_fnmethod(kind string, name string, the_fn ast.Fn, c
 			}
 		}
 	}
-	if after_time < now {
-		c.warn(semicolonize('$start_message has been deprecated since $after_time.ymmdd()',
+	error_time := after_time.add_days(180)
+	if error_time < now {
+		c.error(semicolonize('$start_message has been deprecated since $after_time.ymmdd()',
+			deprecation_message), call_expr.pos)
+	} else if after_time < now {
+		c.warn(semicolonize('$start_message has been deprecated since $after_time.ymmdd(), it will be an error after $error_time.ymmdd()',
 			deprecation_message), call_expr.pos)
 	} else if after_time == now {
 		c.warn(semicolonize('$start_message has been deprecated', deprecation_message),
 			call_expr.pos)
 	} else {
-		c.note(semicolonize('$start_message will be deprecated after $after_time.ymmdd()',
+		c.note(semicolonize('$start_message will be deprecated after $after_time.ymmdd(), and will become an error after $after_time.ymmdd()',
 			deprecation_message), call_expr.pos)
 	}
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3031,7 +3031,7 @@ fn (mut c Checker) deprecate_fnmethod(kind string, name string, the_fn ast.Fn, c
 		c.warn(semicolonize('$start_message has been deprecated', deprecation_message),
 			call_expr.pos)
 	} else {
-		c.note(semicolonize('$start_message will be deprecated after $after_time.ymmdd(), and will become an error after $after_time.ymmdd()',
+		c.note(semicolonize('$start_message will be deprecated after $after_time.ymmdd(), and will become an error after $error_time.ymmdd()',
 			deprecation_message), call_expr.pos)
 	}
 }

--- a/vlib/v/checker/tests/deprecations.out
+++ b/vlib/v/checker/tests/deprecations.out
@@ -1,11 +1,11 @@
-vlib/v/checker/tests/deprecations.vv:60:2: notice: function `future` will be deprecated after 2030-12-30, and will become an error after 2031-06-28; custom message 4
+vlib/v/checker/tests/deprecations.vv:60:2: notice: function `future` will be deprecated after 3000-12-30, and will become an error after 1912-09-02; custom message 4
    58 | 
    59 | fn main() {
    60 |     future()
       |     ~~~~~~~~
    61 |     past()
    62 |     simply_deprecated()
-vlib/v/checker/tests/deprecations.vv:67:4: notice: method `Abc.future` will be deprecated after 2030-11-01, and will become an error after 2031-04-30; custom message 1
+vlib/v/checker/tests/deprecations.vv:67:4: notice: method `Abc.future` will be deprecated after 3000-11-01, and will become an error after 1912-07-05; custom message 1
    65 |     //
    66 |     a := Abc{}
    67 |     a.future()
@@ -33,7 +33,7 @@ vlib/v/checker/tests/deprecations.vv:63:2: error: function `just_deprecated` has
       |     ~~~~~~~~~~~~~~~~~
    64 |     ancient()
    65 |     //
-vlib/v/checker/tests/deprecations.vv:64:2: error: function `ancient` has been deprecated since 2020-03-01; custom message 6
+vlib/v/checker/tests/deprecations.vv:64:2: error: function `ancient` has been deprecated since 1990-03-01; custom message 6
    62 |     simply_deprecated()
    63 |     just_deprecated()
    64 |     ancient()

--- a/vlib/v/checker/tests/deprecations.out
+++ b/vlib/v/checker/tests/deprecations.out
@@ -1,11 +1,11 @@
-vlib/v/checker/tests/deprecations.vv:60:2: notice: function `future` will be deprecated after 3000-12-30, and will become an error after 3000-12-30; custom message 4
+vlib/v/checker/tests/deprecations.vv:60:2: notice: function `future` will be deprecated after 2030-12-30, and will become an error after 2031-06-28; custom message 4
    58 | 
    59 | fn main() {
    60 |     future()
       |     ~~~~~~~~
    61 |     past()
    62 |     simply_deprecated()
-vlib/v/checker/tests/deprecations.vv:67:4: notice: method `Abc.future` will be deprecated after 3000-11-01, and will become an error after 3000-11-01; custom message 1
+vlib/v/checker/tests/deprecations.vv:67:4: notice: method `Abc.future` will be deprecated after 2030-11-01, and will become an error after 2031-04-30; custom message 1
    65 |     //
    66 |     a := Abc{}
    67 |     a.future()

--- a/vlib/v/checker/tests/deprecations.out
+++ b/vlib/v/checker/tests/deprecations.out
@@ -1,48 +1,55 @@
-vlib/v/checker/tests/deprecations.vv:54:2: notice: function `future` will be deprecated after 9999-12-30; custom message 4
-   52 | 
-   53 | fn main() {
-   54 |     future()
+vlib/v/checker/tests/deprecations.vv:60:2: notice: function `future` will be deprecated after 3000-12-30, and will become an error after 3000-12-30; custom message 4
+   58 | 
+   59 | fn main() {
+   60 |     future()
       |     ~~~~~~~~
-   55 |     past()
-   56 |     simply_deprecated()
-vlib/v/checker/tests/deprecations.vv:60:4: notice: method `Abc.future` will be deprecated after 9999-11-01; custom message 1
-   58 |     //
-   59 |     a := Abc{}
-   60 |     a.future()
+   61 |     past()
+   62 |     simply_deprecated()
+vlib/v/checker/tests/deprecations.vv:67:4: notice: method `Abc.future` will be deprecated after 3000-11-01, and will become an error after 3000-11-01; custom message 1
+   65 |     //
+   66 |     a := Abc{}
+   67 |     a.future()
       |       ~~~~~~~~
-   61 |     a.past()
-   62 |     a.simply_deprecated()
-vlib/v/checker/tests/deprecations.vv:55:2: error: function `past` has been deprecated since 2021-03-01; custom message 5
-   53 | fn main() {
-   54 |     future()
-   55 |     past()
+   68 |     a.past()
+   69 |     a.simply_deprecated()
+vlib/v/checker/tests/deprecations.vv:61:2: error: function `past` has been deprecated since 2021-03-01, it will be an error after 2021-08-28; custom message 5
+   59 | fn main() {
+   60 |     future()
+   61 |     past()
       |     ~~~~~~
-   56 |     simply_deprecated()
-   57 |     just_deprecated()
-vlib/v/checker/tests/deprecations.vv:56:2: error: function `simply_deprecated` has been deprecated; custom message 6
-   54 |     future()
-   55 |     past()
-   56 |     simply_deprecated()
+   62 |     simply_deprecated()
+   63 |     just_deprecated()
+vlib/v/checker/tests/deprecations.vv:62:2: error: function `simply_deprecated` has been deprecated; custom message 7
+   60 |     future()
+   61 |     past()
+   62 |     simply_deprecated()
       |     ~~~~~~~~~~~~~~~~~~~
-   57 |     just_deprecated()
-   58 |     //
-vlib/v/checker/tests/deprecations.vv:57:2: error: function `just_deprecated` has been deprecated
-   55 |     past()
-   56 |     simply_deprecated()
-   57 |     just_deprecated()
+   63 |     just_deprecated()
+   64 |     ancient()
+vlib/v/checker/tests/deprecations.vv:63:2: error: function `just_deprecated` has been deprecated
+   61 |     past()
+   62 |     simply_deprecated()
+   63 |     just_deprecated()
       |     ~~~~~~~~~~~~~~~~~
-   58 |     //
-   59 |     a := Abc{}
-vlib/v/checker/tests/deprecations.vv:61:4: error: method `Abc.past` has been deprecated since 2021-03-01; custom message 2
-   59 |     a := Abc{}
-   60 |     a.future()
-   61 |     a.past()
+   64 |     ancient()
+   65 |     //
+vlib/v/checker/tests/deprecations.vv:64:2: error: function `ancient` has been deprecated since 2020-03-01; custom message 6
+   62 |     simply_deprecated()
+   63 |     just_deprecated()
+   64 |     ancient()
+      |     ~~~~~~~~~
+   65 |     //
+   66 |     a := Abc{}
+vlib/v/checker/tests/deprecations.vv:68:4: error: method `Abc.past` has been deprecated since 2021-03-01, it will be an error after 2021-08-28; custom message 2
+   66 |     a := Abc{}
+   67 |     a.future()
+   68 |     a.past()
       |       ~~~~~~
-   62 |     a.simply_deprecated()
-   63 | }
-vlib/v/checker/tests/deprecations.vv:62:4: error: method `Abc.simply_deprecated` has been deprecated; custom message 3
-   60 |     a.future()
-   61 |     a.past()
-   62 |     a.simply_deprecated()
+   69 |     a.simply_deprecated()
+   70 | }
+vlib/v/checker/tests/deprecations.vv:69:4: error: method `Abc.simply_deprecated` has been deprecated; custom message 3
+   67 |     a.future()
+   68 |     a.past()
+   69 |     a.simply_deprecated()
       |       ~~~~~~~~~~~~~~~~~~~
-   63 | }
+   70 | }

--- a/vlib/v/checker/tests/deprecations.out
+++ b/vlib/v/checker/tests/deprecations.out
@@ -1,11 +1,11 @@
-vlib/v/checker/tests/deprecations.vv:60:2: notice: function `future` will be deprecated after 3000-12-30, and will become an error after 1912-09-02; custom message 4
+vlib/v/checker/tests/deprecations.vv:60:2: notice: function `future` will be deprecated after 3000-12-30, and will become an error after 3001-06-28; custom message 4
    58 | 
    59 | fn main() {
    60 |     future()
       |     ~~~~~~~~
    61 |     past()
    62 |     simply_deprecated()
-vlib/v/checker/tests/deprecations.vv:67:4: notice: method `Abc.future` will be deprecated after 3000-11-01, and will become an error after 1912-07-05; custom message 1
+vlib/v/checker/tests/deprecations.vv:67:4: notice: method `Abc.future` will be deprecated after 3000-11-01, and will become an error after 3001-04-30; custom message 1
    65 |     //
    66 |     a := Abc{}
    67 |     a.future()

--- a/vlib/v/checker/tests/deprecations.vv
+++ b/vlib/v/checker/tests/deprecations.vv
@@ -8,7 +8,7 @@ fn (a Abc) str() string {
 }
 
 [deprecated: 'custom message 1']
-[deprecated_after: '9999-11-01']
+[deprecated_after: '3000-11-01']
 fn (a Abc) future() {
 	dump(@METHOD)
 	dump(a)
@@ -29,7 +29,7 @@ fn (a Abc) simply_deprecated() {
 
 // functions using [deprecated_after]:
 [deprecated: 'custom message 4']
-[deprecated_after: '9999-12-30']
+[deprecated_after: '3000-12-30']
 fn future() {
 	dump(@FN)
 }
@@ -41,6 +41,12 @@ fn past() {
 }
 
 [deprecated: 'custom message 6']
+[deprecated_after: '2020-03-01']
+fn ancient() {
+	dump(@FN)
+}
+
+[deprecated: 'custom message 7']
 fn simply_deprecated() {
 	dump(@FN)
 }
@@ -55,6 +61,7 @@ fn main() {
 	past()
 	simply_deprecated()
 	just_deprecated()
+	ancient()
 	//
 	a := Abc{}
 	a.future()

--- a/vlib/v/checker/tests/deprecations.vv
+++ b/vlib/v/checker/tests/deprecations.vv
@@ -8,7 +8,7 @@ fn (a Abc) str() string {
 }
 
 [deprecated: 'custom message 1']
-[deprecated_after: '2030-11-01']
+[deprecated_after: '3000-11-01']
 fn (a Abc) future() {
 	dump(@METHOD)
 	dump(a)
@@ -29,7 +29,7 @@ fn (a Abc) simply_deprecated() {
 
 // functions using [deprecated_after]:
 [deprecated: 'custom message 4']
-[deprecated_after: '2030-12-30']
+[deprecated_after: '3000-12-30']
 fn future() {
 	dump(@FN)
 }
@@ -41,7 +41,7 @@ fn past() {
 }
 
 [deprecated: 'custom message 6']
-[deprecated_after: '2020-03-01']
+[deprecated_after: '1990-03-01']
 fn ancient() {
 	dump(@FN)
 }

--- a/vlib/v/checker/tests/deprecations.vv
+++ b/vlib/v/checker/tests/deprecations.vv
@@ -8,7 +8,7 @@ fn (a Abc) str() string {
 }
 
 [deprecated: 'custom message 1']
-[deprecated_after: '3000-11-01']
+[deprecated_after: '2030-11-01']
 fn (a Abc) future() {
 	dump(@METHOD)
 	dump(a)
@@ -29,7 +29,7 @@ fn (a Abc) simply_deprecated() {
 
 // functions using [deprecated_after]:
 [deprecated: 'custom message 4']
-[deprecated_after: '3000-12-30']
+[deprecated_after: '2030-12-30']
 fn future() {
 	dump(@FN)
 }


### PR DESCRIPTION
After this PR:
```v
[deprecated: 'please use `println(x)` instead']
[deprecated_after: '2020-03-01']
fn oldprintln(s string) {}
oldprintln()
```
will produce a compiler error:
```
ddd.v:4:1: error: function `oldprintln` has been deprecated since 2020-03-01; please use `println(x)` instead
    2 | [deprecated_after: '2020-03-01']
    3 | fn oldprintln(s string) {}
    4 | oldprintln()
      | ~~~~~~~~~~~~
```
because 6 months have passed after the specified date.