### PR TITLE
parser, cgen: fix generic functions with pointer args

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1180,7 +1180,7 @@ pub fn (mut t Table) resolve_generic_to_concrete(generic_type Type, generic_name
 			return none
 		}
 		typ := concrete_types[index]
-		return typ.derive(generic_type).clear_flag(.generic)
+		return typ.derive_add_muls(generic_type).clear_flag(.generic)
 	}
 	match mut sym.info {
 		Array {
@@ -1195,7 +1195,7 @@ pub fn (mut t Table) resolve_generic_to_concrete(generic_type Type, generic_name
 			}
 			if typ := t.resolve_generic_to_concrete(elem_type, generic_names, concrete_types) {
 				idx := t.find_or_register_array_with_dims(typ, dims)
-				return new_type(idx).derive(generic_type).clear_flag(.generic)
+				return new_type(idx).derive_add_muls(generic_type).clear_flag(.generic)
 			}
 		}
 		ArrayFixed {
@@ -1203,7 +1203,7 @@ pub fn (mut t Table) resolve_generic_to_concrete(generic_type Type, generic_name
 				concrete_types)
 			{
 				idx := t.find_or_register_array_fixed(typ, sym.info.size, None{})
-				return new_type(idx).derive(generic_type).clear_flag(.generic)
+				return new_type(idx).derive_add_muls(generic_type).clear_flag(.generic)
 			}
 		}
 		Chan {
@@ -1211,7 +1211,7 @@ pub fn (mut t Table) resolve_generic_to_concrete(generic_type Type, generic_name
 				concrete_types)
 			{
 				idx := t.find_or_register_chan(typ, typ.nr_muls() > 0)
-				return new_type(idx).derive(generic_type).clear_flag(.generic)
+				return new_type(idx).derive_add_muls(generic_type).clear_flag(.generic)
 			}
 		}
 		FnType {
@@ -1234,7 +1234,7 @@ pub fn (mut t Table) resolve_generic_to_concrete(generic_type Type, generic_name
 				}
 			}
 			idx := t.find_or_register_fn_type('', func, true, false)
-			return new_type(idx).derive(generic_type).clear_flag(.generic)
+			return new_type(idx).derive_add_muls(generic_type).clear_flag(.generic)
 		}
 		MultiReturn {
 			mut types := []Type{}
@@ -1249,7 +1249,7 @@ pub fn (mut t Table) resolve_generic_to_concrete(generic_type Type, generic_name
 			}
 			if type_changed {
 				idx := t.find_or_register_multi_return(types)
-				return new_type(idx).derive(generic_type).clear_flag(.generic)
+				return new_type(idx).derive_add_muls(generic_type).clear_flag(.generic)
 			}
 		}
 		Map {
@@ -1270,7 +1270,7 @@ pub fn (mut t Table) resolve_generic_to_concrete(generic_type Type, generic_name
 			}
 			if type_changed {
 				idx := t.find_or_register_map(unwrapped_key_type, unwrapped_value_type)
-				return new_type(idx).derive(generic_type).clear_flag(.generic)
+				return new_type(idx).derive_add_muls(generic_type).clear_flag(.generic)
 			}
 		}
 		Struct {
@@ -1292,7 +1292,7 @@ pub fn (mut t Table) resolve_generic_to_concrete(generic_type Type, generic_name
 				if idx == 0 {
 					idx = t.add_placeholder_type(nrt, .v)
 				}
-				return new_type(idx).derive(generic_type).clear_flag(.generic)
+				return new_type(idx).derive_add_muls(generic_type).clear_flag(.generic)
 			}
 		}
 		else {}

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -252,6 +252,12 @@ pub fn (t Type) derive(t_from Type) Type {
 	return (0xffff0000 & t_from) | u16(t)
 }
 
+// copy flags from `t_from` to `t` and return `t`
+[inline]
+pub fn (t Type) derive_add_muls(t_from Type) Type {
+	return Type((0xff000000 & t_from) | u16(t)).set_nr_muls(t.nr_muls() + t_from.nr_muls())
+}
+
 // return new type with TypeSymbol idx set to `idx`
 [inline]
 pub fn new_type(idx int) Type {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1677,9 +1677,8 @@ fn (mut f Fmt) write_generic_if_require(node ast.CallExpr) {
 	if node.concrete_types.len > 0 {
 		f.write('<')
 		for i, concrete_type in node.concrete_types {
-			is_last := i == node.concrete_types.len - 1
-			f.write(f.table.type_to_str(concrete_type))
-			if !is_last {
+			f.write(f.table.type_to_str_using_aliases(concrete_type, f.mod2alias))
+			if i != node.concrete_types.len - 1 {
 				f.write(', ')
 			}
 		}
@@ -1824,7 +1823,7 @@ pub fn (mut f Fmt) ident(node ast.Ident) {
 		// Force usage of full path to const in the same module:
 		// `println(minute)` => `println(time.minute)`
 		// This makes it clear that a module const is being used
-		// (since V's conts are no longer ALL_CAP).
+		// (since V's consts are no longer ALL_CAP).
 		// ^^^ except for `main`, where consts are allowed to not have a `main.` prefix.
 		if !node.name.contains('.') && !f.inside_const {
 			mod := f.cur_mod

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -582,6 +582,23 @@ fn (mut g Gen) base_type(t ast.Type) string {
 	return styp
 }
 
+fn (mut g Gen) generic_fn_name(types []ast.Type, before string, is_decl bool) string {
+	if types.len == 0 {
+		return before
+	}
+	// Using _T_ to differentiate between get<string> and get_string
+	// `foo<int>()` => `foo_T_int()`
+	mut name := before + '_T'
+	for typ in types {
+		nr_muls := typ.nr_muls()
+		if is_decl && nr_muls > 0 {
+			name = strings.repeat(`*`, nr_muls) + name
+		}
+		name += '_' + strings.repeat_string('__ptr__', nr_muls) + g.typ(typ.set_nr_muls(0))
+	}
+	return name
+}
+
 fn (mut g Gen) expr_string(expr ast.Expr) string {
 	pos := g.out.len
 	g.expr(expr)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1852,7 +1852,8 @@ fn (p &Parser) is_typename(t token.Token) bool {
 //	   otherwise it is not generic because it may be multi-value (e.g. `return f < foo, 0`).
 // 5. `f<mod.Foo>` is same as case 3
 // 6. `f<mod.Foo,` is same as case 4
-// 7. otherwise, it's not generic
+// 7. if there is a &, ignore the & and see if it is a type
+// 10. otherwise, it's not generic
 // see also test_generic_detection in vlib/v/tests/generics_test.v
 fn (p &Parser) is_generic_call() bool {
 	lit0_is_capital := if p.tok.kind != .eof && p.tok.lit.len > 0 {
@@ -1863,11 +1864,21 @@ fn (p &Parser) is_generic_call() bool {
 	if lit0_is_capital || p.peek_tok.kind != .lt {
 		return false
 	}
-	tok2 := p.peek_token(2)
-	tok3 := p.peek_token(3)
-	tok4 := p.peek_token(4)
-	tok5 := p.peek_token(5)
-	kind2, kind3, kind4, kind5 := tok2.kind, tok3.kind, tok4.kind, tok5.kind
+	mut tok2 := p.peek_token(2)
+	mut tok3 := p.peek_token(3)
+	mut tok4 := p.peek_token(4)
+	mut tok5 := p.peek_token(5)
+	mut kind2, mut kind3, mut kind4, mut kind5 := tok2.kind, tok3.kind, tok4.kind, tok5.kind
+	if kind2 == .amp { // if there is a & in front, shift everything left
+		tok2 = tok3
+		kind2 = kind3
+		tok3 = tok4
+		kind3 = kind4
+		tok4 = tok5
+		kind4 = kind5
+		tok5 = p.peek_token(6)
+		kind5 = tok5.kind
+	}
 
 	if kind2 == .lsbr {
 		// case 1

--- a/vlib/v/tests/generics_test.v
+++ b/vlib/v/tests/generics_test.v
@@ -15,7 +15,8 @@ fn test_identity() {
 		'a': 'b'
 	})['a'] == 'b'
 
-	assert simple<simplemodule.Data>(simplemodule.Data{ value: 0 }).value == 0
+	assert simple<simplemodule.Data>(simplemodule.Data{ value: 8 }).value == 8
+	assert simple<&simplemodule.Data>(&simplemodule.Data{ value: 123 }).value == 123
 }
 
 fn plus<T>(xxx T, b T) T {


### PR DESCRIPTION
Fixes pointers in generics:
```v
abc<&int>(123)
```
Before, this would be seen as abc smaller than (`<`) pointer to the variable int greater than (`>`) 123 in parentheses.

This helps with #10685.