### PR TITLE
checker: prohibit option and `IError` in multi-return

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7458,6 +7458,18 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				}
 			}
 		}
+		return_sym := c.table.get_type_symbol(node.return_type)
+		if return_sym.info is ast.MultiReturn {
+			for multi_type in return_sym.info.types {
+				if multi_type == ast.error_type {
+					c.error('type `IError` cannot be used in multi-return, return an option instead',
+						node.return_type_pos)
+				} else if multi_type.has_flag(.optional) {
+					c.error('option cannot be used in multi-return, return an option instead',
+						node.return_type_pos)
+				}
+			}
+		}
 	}
 	if node.return_type == ast.void_type {
 		for mut a in node.attrs {

--- a/vlib/v/checker/tests/ierror_in_return_tuple.out
+++ b/vlib/v/checker/tests/ierror_in_return_tuple.out
@@ -1,0 +1,12 @@
+vlib/v/checker/tests/ierror_in_return_tuple.vv:1:29: error: type `IError` cannot be used in multi-return, return an option instead
+    1 | fn return_ierror_in_tuple() (bool, IError) {
+      |                             ~~~~~~~~~~~~~~
+    2 |     return false, error('')
+    3 | }
+vlib/v/checker/tests/ierror_in_return_tuple.vv:5:29: error: option cannot be used in multi-return, return one option instead
+    3 | }
+    4 | 
+    5 | fn return_option_in_tuple() (bool, ?bool) {
+      |                             ~~~~~~~~~~~~~
+    6 |     return false, error('')
+    7 | }

--- a/vlib/v/checker/tests/ierror_in_return_tuple.out
+++ b/vlib/v/checker/tests/ierror_in_return_tuple.out
@@ -3,7 +3,7 @@ vlib/v/checker/tests/ierror_in_return_tuple.vv:1:29: error: type `IError` cannot
       |                             ~~~~~~~~~~~~~~
     2 |     return false, error('')
     3 | }
-vlib/v/checker/tests/ierror_in_return_tuple.vv:5:29: error: option cannot be used in multi-return, return one option instead
+vlib/v/checker/tests/ierror_in_return_tuple.vv:5:29: error: option cannot be used in multi-return, return an option instead
     3 | }
     4 | 
     5 | fn return_option_in_tuple() (bool, ?bool) {

--- a/vlib/v/checker/tests/ierror_in_return_tuple.vv
+++ b/vlib/v/checker/tests/ierror_in_return_tuple.vv
@@ -1,0 +1,7 @@
+fn return_ierror_in_tuple() (bool, IError) {
+	return false, error('')
+}
+
+fn return_option_in_tuple() (bool, ?bool) {
+	return false, error('')
+}


### PR DESCRIPTION
this pr prohibits returning `?foo` or `IError` in a multi-return. closes #9720.