### PR TITLE
checker: prohibit casting `void`

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -343,7 +343,7 @@ fn C.closesocket(int) int
 
 fn C.vschannel_init(&C.TlsContext)
 
-fn C.request(&C.TlsContext, int, &u16, &byte, &&byte)
+fn C.request(&C.TlsContext, int, &u16, &byte, &&byte) int
 
 fn C.vschannel_cleanup(&C.TlsContext)
 

--- a/vlib/net/http/backend_windows.c.v
+++ b/vlib/net/http/backend_windows.c.v
@@ -18,7 +18,7 @@ fn (req &Request) ssl_do(port int, method Method, host_name string, path string)
 	$if trace_http_request ? {
 		eprintln('> $sdata')
 	}
-	length := int(C.request(&ctx, port, addr.to_wide(), sdata.str, &buff))
+	length := C.request(&ctx, port, addr.to_wide(), sdata.str, &buff)
 	C.vschannel_cleanup(&ctx)
 	response_text := unsafe { buff.vstring_with_len(length) }
 	$if trace_http_response ? {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5115,7 +5115,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 	n_e_t_idx := node.expr_type.idx()
 	expr_is_ptr := node.expr_type.is_ptr() || n_e_t_idx in ast.pointer_type_idxs
 	if node.expr_type == ast.void_type {
-		c.error('type `void` cannot be casted', node.pos)
+		c.error('expression does not return a value so it cannot be casted', node.expr.position())
 	}
 	if expr_is_ptr && to_type_sym.kind == .string && !node.in_prexpr {
 		if node.has_arg {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5114,6 +5114,9 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 	}
 	n_e_t_idx := node.expr_type.idx()
 	expr_is_ptr := node.expr_type.is_ptr() || n_e_t_idx in ast.pointer_type_idxs
+	if node.expr_type == ast.void_type {
+		c.error('type `void` cannot be casted', node.pos)
+	}
 	if expr_is_ptr && to_type_sym.kind == .string && !node.in_prexpr {
 		if node.has_arg {
 			c.warn('to convert a C string buffer pointer to a V string, use x.vstring_with_len(len) instead of string(x,len)',

--- a/vlib/v/checker/tests/cast_void.out
+++ b/vlib/v/checker/tests/cast_void.out
@@ -1,0 +1,4 @@
+vlib/v/checker/tests/cast_void.vv:1:8: error: type `void` cannot be casted
+    1 | num := int(print(''))
+      |        ~~~~~~~~~~~~~~
+    2 | println(num)

--- a/vlib/v/checker/tests/cast_void.out
+++ b/vlib/v/checker/tests/cast_void.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/cast_void.vv:1:8: error: type `void` cannot be casted
+vlib/v/checker/tests/cast_void.vv:1:12: error: expression does not return a value so it cannot be casted
     1 | num := int(print(''))
-      |        ~~~~~~~~~~~~~~
+      |            ~~~~~~~~~
     2 | println(num)

--- a/vlib/v/checker/tests/cast_void.vv
+++ b/vlib/v/checker/tests/cast_void.vv
@@ -1,0 +1,2 @@
+num := int(print(''))
+println(num)


### PR DESCRIPTION
this pr prohibits casting `void`. closes #9488.