### PR TITLE
cgen: fix generics with variadic generic args (fix #10697)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1173,12 +1173,10 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 		mut arr_info := arr_sym.info as ast.Array
 		if varg_type.has_flag(.generic) {
 			if fn_def := g.table.find_fn(node.name) {
-				varg_type_name := g.table.type_to_str(varg_type)
-				for i, fn_gen_name in fn_def.generic_names {
-					if fn_gen_name == varg_type_name {
-						arr_info.elem_type = node.concrete_types[i]
-						break
-					}
+				if utyp := g.table.resolve_generic_to_concrete(arr_info.elem_type, fn_def.generic_names,
+					node.concrete_types)
+				{
+					arr_info.elem_type = utyp
 				}
 			} else {
 				g.error('unable to find function $node.name', node.pos)

--- a/vlib/v/tests/generics_with_variadic_generic_args_test.v
+++ b/vlib/v/tests/generics_with_variadic_generic_args_test.v
@@ -1,0 +1,31 @@
+struct Node<T> {
+mut:
+	data T
+	next &Node<T> = 0
+}
+
+struct SinglyLinkedList<T> {
+mut:
+	first_node &Node<T> = 0
+}
+
+fn init_singlylinkedlist<T>(nodes ...Node<T>) SinglyLinkedList<T> {
+	mut current_node := &nodes[0]
+
+	for i in 0 .. nodes.len - 1 {
+		current_node = &nodes[i]
+		current_node.next = &nodes[i + 1]
+	}
+
+	return SinglyLinkedList{&nodes[0]}
+}
+
+fn test_generic_with_variadic_generic_args() {
+	sll := init_singlylinkedlist<int>(Node<int>{ data: 1 }, Node<int>{
+		data: 2
+	}, Node<int>{
+		data: 798
+	})
+	println(sll.first_node.next)
+	assert sll.first_node.next.data == 2
+}


### PR DESCRIPTION
This PR fix generics with variadic generic args (fix #10697).

- Fix generics with variadic generic args.
- Add test.

```vlang
struct Node<T> {
mut:
	data T
	next &Node<T> = 0
}

struct SinglyLinkedList<T> {
mut:
	first_node &Node<T> = 0
}

fn init_singlylinkedlist<T>(nodes ...Node<T>) SinglyLinkedList<T> {
	mut current_node := &nodes[0]

	for i in 0 .. nodes.len - 1 {
		current_node = &nodes[i]
		current_node.next = &nodes[i + 1]
	}

	return SinglyLinkedList{&nodes[0]}
}

fn main() {
	sll := init_singlylinkedlist<int>(Node<int>{ data: 1 }, Node<int>{
		data: 2
	}, Node<int>{
		data: 798
	})
	println(sll.first_node.next)
	assert sll.first_node.next.data == 2
}

PS D:\Test\v\tt1> v run .
&Node<int>{
    data: 2
    next: &<circular>
}
```