### PR TITLE
checker: prohibit illegal types in string interpolation literals

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -437,6 +437,12 @@ pub fn (mut c Checker) string_inter_lit(mut node ast.StringInterLiteral) ast.Typ
 	c.inside_println_arg = true
 	for i, expr in node.exprs {
 		ftyp := c.expr(expr)
+		if ftyp == ast.void_type {
+			c.error('expression does not return a value', expr.position())
+		} else if ftyp == ast.char_type && ftyp.nr_muls() == 0 {
+			c.error('expression returning type `char` cannot be used in string interpolation directly, print its address or cast it to an integer instead',
+				expr.position())
+		}
 		c.fail_if_unreadable(expr, ftyp, 'interpolation object')
 		node.expr_types << ftyp
 		typ := c.table.unalias_num_type(ftyp)

--- a/vlib/v/checker/tests/bad_types_in_string_inter_lit.out
+++ b/vlib/v/checker/tests/bad_types_in_string_inter_lit.out
@@ -1,0 +1,8 @@
+vlib/v/checker/tests/bad_types_in_string_inter_lit.vv:1:12: error: expression does not return a value
+    1 | println('${exit(0)}')
+      |            ~~~~~~~
+    2 | println('${char(48)}')
+vlib/v/checker/tests/bad_types_in_string_inter_lit.vv:2:12: error: expression returning type `char` cannot be used in string interpolation directly, print its address or cast it to an integer instead
+    1 | println('${exit(0)}')
+    2 | println('${char(48)}')
+      |            ~~~~~~~~

--- a/vlib/v/checker/tests/bad_types_in_string_inter_lit.vv
+++ b/vlib/v/checker/tests/bad_types_in_string_inter_lit.vv
@@ -1,0 +1,2 @@
+println('${exit(0)}')
+println('${char(48)}')

--- a/vlib/v/checker/tests/unknown_method_suggest_name.out
+++ b/vlib/v/checker/tests/unknown_method_suggest_name.out
@@ -14,3 +14,9 @@ Did you mean `translate`?
       |            ~~~~~~~~~~~~
    28 |     println('p: $p')
    29 |     println('v: $v')
+vlib/v/checker/tests/unknown_method_suggest_name.vv:30:15: error: expression does not return a value
+   28 |     println('p: $p')
+   29 |     println('v: $v')
+   30 |     println('z: $z')
+      |                  ^
+   31 | }

--- a/vlib/v/checker/tests/unknown_struct_field_suggest_name.out
+++ b/vlib/v/checker/tests/unknown_struct_field_suggest_name.out
@@ -6,3 +6,10 @@ Did you mean `xxxx`?
       |                ~~~~
    12 |         println('x: $x')
    13 |     }
+vlib/v/checker/tests/unknown_struct_field_suggest_name.vv:12:19: error: expression does not return a value
+   10 |     println('p: $p')
+   11 |     for x in p.xxxa {
+   12 |         println('x: $x')
+      |                      ^
+   13 |     }
+   14 | }


### PR DESCRIPTION
this pr prohibits using expression types not meant to be used with `.str()` from being used in string interpolation literals. fixes #10704.