### PR TITLE
http: Make Header methods chainable

### DIFF
--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -354,44 +354,49 @@ pub fn new_header(kvs ...HeaderConfig) Header {
 }
 
 // Append a value to the header key.
-pub fn (mut h Header) add(key CommonHeader, value string) {
+pub fn (mut h Header) add(key CommonHeader, value string) &Header {
 	k := key.str()
 	h.data[k] << value
 	h.add_key(k)
+	return unsafe { h }
 }
 
 // Append a value to a custom header key. This function will return an error
 // if the key contains invalid header characters.
-pub fn (mut h Header) add_custom(key string, value string) ? {
+pub fn (mut h Header) add_custom(key string, value string) ?&Header {
 	is_valid(key) ?
 	h.data[key] << value
 	h.add_key(key)
+	return unsafe { h }
 }
 
 // Sets the key-value pair. This function will clear any other values
 // that exist for the CommonHeader.
-pub fn (mut h Header) set(key CommonHeader, value string) {
+pub fn (mut h Header) set(key CommonHeader, value string) &Header {
 	k := key.str()
 	h.data[k] = [value]
 	h.add_key(k)
+	return unsafe { h }
 }
 
 // Sets the key-value pair for a custom header key. This function will
 // clear any other values that exist for the header. This function will
 // return an error if the key contains invalid header characters.
-pub fn (mut h Header) set_custom(key string, value string) ? {
+pub fn (mut h Header) set_custom(key string, value string) ?&Header {
 	is_valid(key) ?
 	h.data[key] = [value]
 	h.add_key(key)
+	return unsafe { h }
 }
 
 // Delete all values for a key.
-pub fn (mut h Header) delete(key CommonHeader) {
+pub fn (mut h Header) delete(key CommonHeader) &Header {
 	h.delete_custom(key.str())
+	return unsafe { h }
 }
 
 // Delete all values for a custom header key.
-pub fn (mut h Header) delete_custom(key string) {
+pub fn (mut h Header) delete_custom(key string) &Header {
 	h.data.delete(key)
 
 	// remove key from keys metadata
@@ -399,6 +404,7 @@ pub fn (mut h Header) delete_custom(key string) {
 	if kl in h.keys {
 		h.keys[kl] = h.keys[kl].filter(it != key)
 	}
+	return unsafe { h }
 }
 
 pub struct HeaderCoerceConfig {
@@ -406,7 +412,7 @@ pub struct HeaderCoerceConfig {
 }
 
 // Coerce data by joining keys that match case-insensitively into one entry
-pub fn (mut h Header) coerce(flags ...HeaderCoerceConfig) {
+pub fn (mut h Header) coerce(flags ...HeaderCoerceConfig) &Header {
 	canon := flags.any(it.canonicalize)
 
 	for kl, data_keys in h.keys {
@@ -426,6 +432,7 @@ pub fn (mut h Header) coerce(flags ...HeaderCoerceConfig) {
 		}
 		h.keys[kl] = [master_key]
 	}
+	return unsafe { h }
 }
 
 // Returns whether the header key exists in the map.

--- a/vlib/net/http/header_test.v
+++ b/vlib/net/http/header_test.v
@@ -274,3 +274,16 @@ fn test_str() ? {
 	assert h.str() == 'Accept: text/html,image/jpeg\r\nX-custom: Hello\r\n'
 		|| h.str() == 'X-custom: Hello\r\nAccept:text/html,image/jpeg\r\n'
 }
+
+fn test_chain() ? {
+	h := new_header().add(.accept, 'nothing').add(.expires, 'yesterday')
+	assert h.contains(.accept)
+	assert h.contains(.expires)
+	assert h.get(.accept) or { '' } == 'nothing'
+	assert h.get(.expires) or { '' } == 'yesterday'
+
+	mut h1 := new_header()
+	h2 := h1.add(.accept, 'text/html').add_custom('accept', 'foo')?.add(.host, 'host')
+
+	assert h1 == h2
+}

--- a/vlib/net/http/header_test.v
+++ b/vlib/net/http/header_test.v
@@ -283,7 +283,7 @@ fn test_chain() ? {
 	assert h.get(.expires) or { '' } == 'yesterday'
 
 	mut h1 := new_header()
-	h2 := h1.add(.accept, 'text/html').add_custom('accept', 'foo')?.add(.host, 'host')
+	h2 := h1.add(.accept, 'text/html').add_custom('accept', 'foo') ?.add(.host, 'host')
 
 	assert h1 == h2
 }

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -41,7 +41,7 @@ pub fn (mut req Request) add_header(key CommonHeader, val string) {
 // add_custom_header adds the key and value of an HTTP request header
 // This method may fail if the key contains characters that are not permitted
 pub fn (mut req Request) add_custom_header(key string, val string) ? {
-	return req.header.add_custom(key, val)
+	req.header.add_custom(key, val)?
 }
 
 // do will send the HTTP request and returns `http.Response` as soon as the response is recevied

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -41,7 +41,7 @@ pub fn (mut req Request) add_header(key CommonHeader, val string) {
 // add_custom_header adds the key and value of an HTTP request header
 // This method may fail if the key contains characters that are not permitted
 pub fn (mut req Request) add_custom_header(key string, val string) ? {
-	req.header.add_custom(key, val)?
+	req.header.add_custom(key, val) ?
 }
 
 // do will send the HTTP request and returns `http.Response` as soon as the response is recevied


### PR DESCRIPTION
Example usage:

```v
import net.http

h := http.new_header()
    .add(.content_type, 'text/html')
    .add_custom('foo', 'bar')?
    .add(.date, 'today')
```

Previous usage is unaffected.