### PR TITLE
fmt: fix removal of selective imported Enum

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1802,6 +1802,7 @@ pub fn (mut f Fmt) dump_expr(node ast.DumpExpr) {
 pub fn (mut f Fmt) enum_val(node ast.EnumVal) {
 	name := f.short_module(node.enum_name)
 	f.write(name + '.' + node.val)
+	f.mark_import_as_used(name)
 }
 
 pub fn (mut f Fmt) ident(node ast.Ident) {

--- a/vlib/v/fmt/tests/import_selective_expected.vv
+++ b/vlib/v/fmt/tests/import_selective_expected.vv
@@ -6,6 +6,7 @@ import os {
 	user_os,
 }
 import mod {
+	Enum,
 	FnArg,
 	FnRet,
 	InterfaceField,
@@ -39,6 +40,8 @@ fn f(v FnArg) FnRet {
 	if v is RightOfIs {
 	}
 	_ = v as RightOfAs
+
+	println(Enum.val)
 
 	return {}
 }

--- a/vlib/v/fmt/tests/import_selective_input.vv
+++ b/vlib/v/fmt/tests/import_selective_input.vv
@@ -22,6 +22,8 @@ import mod {
 
 	RightOfIs,
 	RightOfAs,
+
+	Enum
 }
 
 struct Struct {
@@ -42,6 +44,8 @@ interface Interface {
 fn f(v FnArg) FnRet {
 	if v is RightOfIs {}
 	_ = v as RightOfAs
+
+	println(Enum.val)
 
 	return {}
 }


### PR DESCRIPTION
On current master, v fmt removes `Enum`
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
