### PR TITLE
parser: check assign undefined variable (fix #10741)

### DIFF
--- a/vlib/v/checker/tests/assign_expr_undefined_err_i.out
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_i.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/assign_expr_undefined_err_i.vv:2:23: error: undefined variable: `a`
+    1 | fn main() {
+    2 |     mut a := []int{init: a}
+      |                          ^
+    3 |     println(a)
+    4 | }

--- a/vlib/v/checker/tests/assign_expr_undefined_err_i.vv
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_i.vv
@@ -1,0 +1,4 @@
+fn main() {
+	mut a := []int{init: a}
+	println(a)
+}

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -30,6 +30,17 @@ fn (mut p Parser) check_undefined_variables(exprs []ast.Expr, val ast.Expr) ? {
 				}
 			}
 		}
+		ast.ArrayInit {
+			if val.has_cap {
+				p.check_undefined_variables(exprs, val.cap_expr) ?
+			}
+			if val.has_len {
+				p.check_undefined_variables(exprs, val.len_expr) ?
+			}
+			if val.has_default {
+				p.check_undefined_variables(exprs, val.default_expr) ?
+			}
+		}
 		ast.CallExpr {
 			p.check_undefined_variables(exprs, val.left) ?
 			for arg in val.args {


### PR DESCRIPTION
This PR check assign undefined variable (fix #10741).

- Check assign undefined variable.
- Add test.

```vlang
fn main() {
	mut a := []int{init: a}
	println(a)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:2:23: error: undefined variable: `a`
    1 | fn main() {
    2 |     mut a := []int{init: a}
      |                          ^
    3 |     println(a)
    4 | }
```