### PR TITLE
http: add header_from_map and join functions

### DIFF
--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -353,6 +353,28 @@ pub fn new_header(kvs ...HeaderConfig) Header {
 	return h
 }
 
+// header_from_map creates a Header from key value pairs
+pub fn header_from_map(kvs map[CommonHeader]string) Header {
+	mut h := Header{
+		data: map[string][]string{}
+	}
+	for k, v in kvs {
+		h.add(k, v)
+	}
+	return h
+}
+
+// custom_header_from_map creates a Header from string key value pairs
+pub fn custom_header_from_map(kvs map[string]string) ?Header {
+	mut h := Header{
+		data: map[string][]string{}
+	}
+	for k, v in kvs {
+		h.add_custom(k.str(), v) ?
+	}
+	return h
+}
+
 // Append a value to the header key.
 pub fn (mut h Header) add(key CommonHeader, value string) {
 	k := key.str()
@@ -554,6 +576,23 @@ pub fn (h Header) render(flags HeaderRenderConfig) string {
 	res := sb.str()
 	unsafe { sb.free() }
 	return res
+}
+
+// join combines two Header structs into a new Header struct
+pub fn (h Header) join(other Header) Header {
+	mut combined := Header{
+		data: h.data.clone()
+		keys: h.keys.clone()
+	}
+	for k in other.keys() {
+		for v in other.custom_values(k, exact: true) {
+			combined.add_custom(k, v) or {
+				// panic because this should never fail
+				panic('unexpected error: $err')
+			}
+		}
+	}
+	return combined
 }
 
 // Canonicalize an HTTP header key

--- a/vlib/net/http/header_test.v
+++ b/vlib/net/http/header_test.v
@@ -274,3 +274,25 @@ fn test_str() ? {
 	assert h.str() == 'Accept: text/html,image/jpeg\r\nX-custom: Hello\r\n'
 		|| h.str() == 'X-custom: Hello\r\nAccept:text/html,image/jpeg\r\n'
 }
+
+fn test_header_from_map() ? {
+	h := header_from_map(map{
+		CommonHeader.accept:  'nothing'
+		CommonHeader.expires: 'yesterday'
+	})
+	assert h.contains(.accept)
+	assert h.contains(.expires)
+	assert h.get(.accept) or { '' } == 'nothing'
+	assert h.get(.expires) or { '' } == 'yesterday'
+}
+
+fn test_custom_header_from_map() ? {
+	h := custom_header_from_map(map{
+		'Server': 'VWeb'
+		'foo':    'bar'
+	}) ?
+	assert h.contains_custom('server')
+	assert h.contains_custom('foo')
+	assert h.get_custom('server') or { '' } == 'VWeb'
+	assert h.get_custom('foo') or { '' } == 'bar'
+}

--- a/vlib/net/http/header_test.v
+++ b/vlib/net/http/header_test.v
@@ -296,3 +296,30 @@ fn test_custom_header_from_map() ? {
 	assert h.get_custom('server') or { '' } == 'VWeb'
 	assert h.get_custom('foo') or { '' } == 'bar'
 }
+
+fn test_header_join() ? {
+	h1 := header_from_map(map{
+		CommonHeader.accept:  'nothing'
+		CommonHeader.expires: 'yesterday'
+	})
+	h2 := custom_header_from_map(map{
+		'Server': 'VWeb'
+		'foo':    'bar'
+	}) ?
+	h3 := h1.join(h2)
+	// h1 is unchanged
+	assert h1.contains(.accept)
+	assert h1.contains(.expires)
+	assert !h1.contains_custom('Server')
+	assert !h1.contains_custom('foo')
+	// h2 is unchanged
+	assert !h2.contains(.accept)
+	assert !h2.contains(.expires)
+	assert h2.contains_custom('Server')
+	assert h2.contains_custom('foo')
+	// h3 has all four headers
+	assert h3.contains(.accept)
+	assert h3.contains(.expires)
+	assert h3.contains_custom('Server')
+	assert h3.contains_custom('foo')
+}

--- a/vlib/net/http/header_test.v
+++ b/vlib/net/http/header_test.v
@@ -276,7 +276,7 @@ fn test_str() ? {
 }
 
 fn test_header_from_map() ? {
-	h := header_from_map(map{
+	h := new_header_from_map(map{
 		CommonHeader.accept:  'nothing'
 		CommonHeader.expires: 'yesterday'
 	})
@@ -287,7 +287,7 @@ fn test_header_from_map() ? {
 }
 
 fn test_custom_header_from_map() ? {
-	h := custom_header_from_map(map{
+	h := new_custom_header_from_map(map{
 		'Server': 'VWeb'
 		'foo':    'bar'
 	}) ?
@@ -298,11 +298,11 @@ fn test_custom_header_from_map() ? {
 }
 
 fn test_header_join() ? {
-	h1 := header_from_map(map{
+	h1 := new_header_from_map(map{
 		CommonHeader.accept:  'nothing'
 		CommonHeader.expires: 'yesterday'
 	})
-	h2 := custom_header_from_map(map{
+	h2 := new_custom_header_from_map(map{
 		'Server': 'VWeb'
 		'foo':    'bar'
 	}) ?

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -13,7 +13,7 @@ import time
 
 pub const (
 	methods_with_form = [http.Method.post, .put, .patch]
-	headers_close     = http.custom_header_from_map(map{
+	headers_close     = http.new_custom_header_from_map(map{
 		'Server':          'VWeb'
 		http.CommonHeader.connection.str(): 'close'
 	}) or { panic('should never fail') }
@@ -22,7 +22,7 @@ pub const (
 		version: .v1_1
 		status_code: 400
 		text: '400 Bad Request'
-		header: http.header_from_map(map{
+		header: http.new_header_from_map(map{
 			http.CommonHeader.content_type:   'text/plain'
 			http.CommonHeader.content_length: '15'
 		}).join(headers_close)
@@ -31,7 +31,7 @@ pub const (
 		version: .v1_1
 		status_code: 404
 		text: '404 Not Found'
-		header: http.header_from_map(map{
+		header: http.new_header_from_map(map{
 			http.CommonHeader.content_type:   'text/plain'
 			http.CommonHeader.content_length: '13'
 		}).join(headers_close)
@@ -40,7 +40,7 @@ pub const (
 		version: .v1_1
 		status_code: 500
 		text: '500 Internal Server Error'
-		header: http.header_from_map(map{
+		header: http.new_header_from_map(map{
 			http.CommonHeader.content_type:   'text/plain'
 			http.CommonHeader.content_length: '25'
 		}).join(headers_close)

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -13,56 +13,37 @@ import time
 
 pub const (
 	methods_with_form = [http.Method.post, .put, .patch]
+	headers_close     = http.custom_header_from_map(map{
+		'Server':          'VWeb'
+		http.CommonHeader.connection.str(): 'close'
+	}) or { panic('should never fail') }
+
 	http_400          = http.Response{
 		version: .v1_1
 		status_code: 400
 		text: '400 Bad Request'
-		header: fn () http.Header {
-			mut h := http.new_header()
-			h.add(.content_type, 'text/plain')
-			h.add(.content_length, '15')
-			close := headers_close()
-			for k in close.keys() {
-				for v in close.custom_values(k) {
-					h.add_custom(k, v) or {}
-				}
-			}
-			return h
-		}()
+		header: http.header_from_map(map{
+			http.CommonHeader.content_type:   'text/plain'
+			http.CommonHeader.content_length: '15'
+		}).join(headers_close)
 	}
 	http_404 = http.Response{
 		version: .v1_1
 		status_code: 404
 		text: '404 Not Found'
-		header: fn () http.Header {
-			mut h := http.new_header()
-			h.add(.content_type, 'text/plain')
-			h.add(.content_length, '13')
-			close := headers_close()
-			for k in close.keys() {
-				for v in close.custom_values(k) {
-					h.add_custom(k, v) or {}
-				}
-			}
-			return h
-		}()
+		header: http.header_from_map(map{
+			http.CommonHeader.content_type:   'text/plain'
+			http.CommonHeader.content_length: '13'
+		}).join(headers_close)
 	}
 	http_500 = http.Response{
 		version: .v1_1
 		status_code: 500
 		text: '500 Internal Server Error'
-		header: fn () http.Header {
-			mut h := http.new_header()
-			h.add(.content_type, 'text/plain')
-			h.add(.content_length, '25')
-			close := headers_close()
-			for k in close.keys() {
-				for v in close.custom_values(k) {
-					h.add_custom(k, v) or {}
-				}
-			}
-			return h
-		}()
+		header: http.header_from_map(map{
+			http.CommonHeader.content_type:   'text/plain'
+			http.CommonHeader.content_length: '25'
+		}).join(headers_close)
 	}
 	mime_types = map{
 		'.css':  'text/css; charset=utf-8'
@@ -161,7 +142,7 @@ pub fn (mut ctx Context) send_response_to_client(mimetype string, res string) bo
 	}
 	sb.write_string(ctx.headers)
 	sb.write_string('\r\n')
-	sb.write_string(headers_close().str())
+	sb.write_string(vweb.headers_close.str())
 	sb.write_string('\r\n')
 	if ctx.chunked_transfer {
 		mut i := 0
@@ -236,7 +217,7 @@ pub fn (mut ctx Context) redirect(url string) Result {
 		return Result{}
 	}
 	ctx.done = true
-	send_string(mut ctx.conn, 'HTTP/1.1 302 Found\r\nLocation: $url$ctx.headers\r\n$headers_close().str()\r\n') or {
+	send_string(mut ctx.conn, 'HTTP/1.1 302 Found\r\nLocation: $url$ctx.headers\r\n$vweb.headers_close\r\n') or {
 		return Result{}
 	}
 	return Result{}
@@ -706,10 +687,4 @@ pub type RawHtml = string
 
 fn send_string(mut conn net.TcpConn, s string) ? {
 	conn.write(s.bytes()) ?
-}
-
-fn headers_close() http.Header {
-	mut h := http.new_header(key: .connection, value: 'close')
-	h.add_custom('Server', 'VWeb') or {}
-	return h
 }


### PR DESCRIPTION
An alternative solution to chaining that doesn't use anonymous functions to create `const` Header structs.

New functions / methods:

```v
pub fn header_from_map(kvs map[CommonHeader]string) Header

pub fn custom_header_from_map(kvs map[string]string) ?Header

pub fn (h Header) join(other Header) Header
```