### PR TITLE
cgen: fix error when using anon generics fn that have generics struct arg

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -192,7 +192,7 @@ pub fn (t &Table) fn_type_signature(f &Fn) string {
 		typ := arg.typ.set_nr_muls(0)
 		arg_type_sym := t.get_type_symbol(typ)
 		sig += arg_type_sym.str().to_lower().replace_each(['.', '__', '&', '', '[]', 'arr_', 'chan ',
-			'chan_', 'map[', 'map_of_', ']', '_to_'])
+			'chan_', 'map[', 'map_of_', ']', '_to_', '<', '_T_', ',', '_', '>', ''])
 		if i < f.params.len - 1 {
 			sig += '_'
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7464,7 +7464,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				node.pos)
 		}
 	}
-	if node.language == .v && !c.is_builtin_mod {
+	if node.language == .v && !c.is_builtin_mod && !node.is_anon {
 		c.check_valid_snake_case(node.name, 'function name', node.pos)
 	}
 	if node.name == 'main.main' {

--- a/vlib/v/tests/generics_with_anon_generics_fn_test.v
+++ b/vlib/v/tests/generics_with_anon_generics_fn_test.v
@@ -32,6 +32,11 @@ fn call<T>(f fn (T) T, v T) T {
 	return f(v)
 }
 
+struct Pair<T, U> {
+	a T
+	b U
+}
+
 fn test_generics_with_anon_generics_fn() {
 	mut s := MyStruct<int>{
 		arr: [1, 2, 3, 4, 5]
@@ -44,4 +49,9 @@ fn test_generics_with_anon_generics_fn() {
 	assert call<string>(consume_str, '1') == '1'
 	assert call(consume, 1) == 1
 	assert call(consume_str, '1') == '1'
+
+	pair := Pair<int,string>{1, 's'}
+	assert call(fn (v Pair<int, string>) Pair<int, string> {
+		return v
+	}, pair) == pair
 }


### PR DESCRIPTION
On current master, added tests will be fail like this.
```
 FAIL   203.441 ms vlib/v/tests/generics_with_anon_generics_fn_test.v
==================
                                ^
/tmp/v/test_session_238469896300200/generics_with_anon_generics_fn_test.10985890569059397659.tmp.c:2480:76: error: expected ';' after top level declarator
VV_LOCAL_SYMBOL main__Pair_T_int_string anon_fn_f83dac51187db949_main__pair<int,string>__generic_struct_inst_862(main__Pair_T_int_string v);
                                                                           ^
                                                                           ;
/tmp/v/test_session_238469896300200/generics_with_anon_generics_fn_test.10985890569059397659.tmp.c:2581:76: error: expected ';' after top level declarator
VV_LOCAL_SYMBOL main__Pair_T_int_string anon_fn_f83dac51187db949_main__pair<int,string>__generic_struct_inst_862(main__Pair_T_int_string v) {
                                                                           ^
                                                                           ;
/tmp/v/test_session_238469896300200/generics_with_anon_generics_fn_test.10985890569059397659.tmp.c:8234:202: warning: implicit declaration of function 'v_typeof_interface_IError' is invalid in C99 [-Wimplicit-function-declaration]
        return ((err._typ == _IError_None___index) ? (_SLIT("none")) : (err._typ == _IError_Error_index) ? ((err._Error)->msg) : ( str_intp(3, _MOV((StrIntpData[]){{_SLIT0, 0xfe10, {.d_s = tos3( /* IError */ v_typeof_interface_IError( (err)._typ ))}}, {_SLIT(": "), 0xfe10, {.d_s = (*(err.msg))}}, {_SLIT0, 0, { .d_c = 0 }}}))));
```

This PR fix this problem.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
