### PR TITLE
cgen: fix fixed array of function str() (fix #10744)

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -563,12 +563,12 @@ fn (mut g Gen) gen_str_for_array_fixed(info ast.ArrayFixed, styp string, str_fn_
 	g.auto_str_funcs.writeln('static string indent_${str_fn_name}($styp a, int indent_count) {')
 	g.auto_str_funcs.writeln('\tstrings__Builder sb = strings__new_builder($info.size * 10);')
 	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, _SLIT("["));')
+	g.auto_str_funcs.writeln('\tfor (int i = 0; i < $info.size; ++i) {')
 	if sym.kind == .function {
 		g.auto_str_funcs.writeln('\t\tstring x = ${elem_str_fn_name}();')
 		g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, x);')
 	} else {
 		deref, deref_label := deref_kind(str_method_expects_ptr, is_elem_ptr, typ)
-		g.auto_str_funcs.writeln('\tfor (int i = 0; i < $info.size; ++i) {')
 		if should_use_indent_func(sym.kind) && !sym_has_str_method {
 			if is_elem_ptr {
 				g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, _SLIT("$deref_label"));')
@@ -594,11 +594,11 @@ fn (mut g Gen) gen_str_for_array_fixed(info ast.ArrayFixed, styp string, str_fn_
 		} else {
 			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}( $deref a[i]));')
 		}
-		g.auto_str_funcs.writeln('\t\tif (i < ${info.size - 1}) {')
-		g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write_string(&sb, _SLIT(", "));')
-		g.auto_str_funcs.writeln('\t\t}')
-		g.auto_str_funcs.writeln('\t}')
 	}
+	g.auto_str_funcs.writeln('\t\tif (i < ${info.size - 1}) {')
+	g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write_string(&sb, _SLIT(", "));')
+	g.auto_str_funcs.writeln('\t\t}')
+	g.auto_str_funcs.writeln('\t}')
 	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, _SLIT("]"));')
 	g.auto_str_funcs.writeln('\tstring res = strings__Builder_str(&sb);')
 	g.auto_str_funcs.writeln('\tstrings__Builder_free(&sb);')

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -565,6 +565,7 @@ fn (mut g Gen) gen_str_for_array_fixed(info ast.ArrayFixed, styp string, str_fn_
 	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, _SLIT("["));')
 	if sym.kind == .function {
 		g.auto_str_funcs.writeln('\t\tstring x = ${elem_str_fn_name}();')
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, x);')
 	} else {
 		deref, deref_label := deref_kind(str_method_expects_ptr, is_elem_ptr, typ)
 		g.auto_str_funcs.writeln('\tfor (int i = 0; i < $info.size; ++i) {')
@@ -593,11 +594,11 @@ fn (mut g Gen) gen_str_for_array_fixed(info ast.ArrayFixed, styp string, str_fn_
 		} else {
 			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}( $deref a[i]));')
 		}
+		g.auto_str_funcs.writeln('\t\tif (i < ${info.size - 1}) {')
+		g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write_string(&sb, _SLIT(", "));')
+		g.auto_str_funcs.writeln('\t\t}')
+		g.auto_str_funcs.writeln('\t}')
 	}
-	g.auto_str_funcs.writeln('\t\tif (i < ${info.size - 1}) {')
-	g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write_string(&sb, _SLIT(", "));')
-	g.auto_str_funcs.writeln('\t\t}')
-	g.auto_str_funcs.writeln('\t}')
 	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, _SLIT("]"));')
 	g.auto_str_funcs.writeln('\tstring res = strings__Builder_str(&sb);')
 	g.auto_str_funcs.writeln('\tstrings__Builder_free(&sb);')

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -440,7 +440,7 @@ fn test_multi_return() {
 }
 
 fn test_fixed_array_of_function() {
-	a := [println]!
+	a := [println, println]!
 	println(a)
-	assert '$a' == '[fn (string)]'
+	assert '$a' == '[fn (string), fn (string)]'
 }

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -438,3 +438,9 @@ fn test_multi_return() {
     value: 'two'
 })"
 }
+
+fn test_fixed_array_of_function() {
+	a := [println]!
+	println(a)
+	assert '$a' == '[fn (string)]'
+}


### PR DESCRIPTION
This PR fix fixed array of function str() (fix #10744).

- Fix fixed array of function str().
- Add test.

```vlang
fn main() {
	a := [println]!
	println(a)
	assert '$a' == '[fn (string)]'
}

PS D:\Test\v\tt1> v run .
[fn (string)]
```