### PR TITLE
parser: cleanup check_cross_variables()

### DIFF
--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -70,12 +70,12 @@ fn (mut p Parser) check_undefined_variables(exprs []ast.Expr, val ast.Expr) ? {
 }
 
 fn (mut p Parser) check_cross_variables(exprs []ast.Expr, val ast.Expr) bool {
-	val_ := val
-	match val_ {
+	val_str := val.str()
+	match val {
 		ast.Ident {
 			for expr in exprs {
 				if expr is ast.Ident {
-					if expr.name == val_.name {
+					if expr.name == val.name {
 						return true
 					}
 				}
@@ -83,24 +83,24 @@ fn (mut p Parser) check_cross_variables(exprs []ast.Expr, val ast.Expr) bool {
 		}
 		ast.IndexExpr {
 			for expr in exprs {
-				if expr.str() == val.str() {
+				if expr.str() == val_str {
 					return true
 				}
 			}
 		}
 		ast.InfixExpr {
-			return p.check_cross_variables(exprs, val_.left)
-				|| p.check_cross_variables(exprs, val_.right)
+			return p.check_cross_variables(exprs, val.left)
+				|| p.check_cross_variables(exprs, val.right)
 		}
 		ast.PrefixExpr {
-			return p.check_cross_variables(exprs, val_.right)
+			return p.check_cross_variables(exprs, val.right)
 		}
 		ast.PostfixExpr {
-			return p.check_cross_variables(exprs, val_.expr)
+			return p.check_cross_variables(exprs, val.expr)
 		}
 		ast.SelectorExpr {
 			for expr in exprs {
-				if expr.str() == val.str() {
+				if expr.str() == val_str {
 					return true
 				}
 			}


### PR DESCRIPTION
This PR makes minor cleanups of `check_cross_variables()` in parser.