### PR TITLE
parser: check undefined variables in assign_stmt

### DIFF
--- a/vlib/v/checker/tests/assign_expr_undefined_err_j.out
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_j.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/assign_expr_undefined_err_j.vv:2:12: error: undefined variable: `a`
+    1 | fn main() {
+    2 |     mut a := [a]
+      |               ^
+    3 |     println(a)
+    4 | }

--- a/vlib/v/checker/tests/assign_expr_undefined_err_j.vv
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_j.vv
@@ -1,0 +1,4 @@
+fn main() {
+	mut a := [a]
+	println(a)
+}

--- a/vlib/v/checker/tests/assign_expr_undefined_err_k.out
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_k.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/assign_expr_undefined_err_k.vv:2:22: error: undefined variable: `a`
+    1 | fn main() {
+    2 |     mut a := map{'one': a}
+      |                         ^
+    3 |     println(a)
+    4 | }

--- a/vlib/v/checker/tests/assign_expr_undefined_err_k.vv
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_k.vv
@@ -1,0 +1,4 @@
+fn main() {
+	mut a := map{'one': a}
+	println(a)
+}

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -23,7 +23,7 @@ fn (mut p Parser) check_undefined_variables(exprs []ast.Expr, val ast.Expr) ? {
 		ast.Ident {
 			for expr in exprs {
 				if expr is ast.Ident {
-					if expr.name == val.name {
+					if expr.name == val.name && expr.kind != .blank_ident {
 						p.error_with_pos('undefined variable: `$val.name`', val.pos)
 						return error('undefined variable: `$val.name`')
 					}
@@ -40,6 +40,9 @@ fn (mut p Parser) check_undefined_variables(exprs []ast.Expr, val ast.Expr) ? {
 			if val.has_default {
 				p.check_undefined_variables(exprs, val.default_expr) ?
 			}
+			for expr in val.exprs {
+				p.check_undefined_variables(exprs, expr) ?
+			}
 		}
 		ast.CallExpr {
 			p.check_undefined_variables(exprs, val.left) ?
@@ -50,6 +53,14 @@ fn (mut p Parser) check_undefined_variables(exprs []ast.Expr, val ast.Expr) ? {
 		ast.InfixExpr {
 			p.check_undefined_variables(exprs, val.left) ?
 			p.check_undefined_variables(exprs, val.right) ?
+		}
+		ast.MapInit {
+			for key in val.keys {
+				p.check_undefined_variables(exprs, key) ?
+			}
+			for value in val.vals {
+				p.check_undefined_variables(exprs, value) ?
+			}
 		}
 		ast.ParExpr {
 			p.check_undefined_variables(exprs, val.expr) ?


### PR DESCRIPTION
This PR Add checks for undefined variables in an assignment operation.

- Add `a := [a]` (array_init).
- Add `a := map{ 'one': a}`  (map_init).

```vlang
fn main() {
	a := [a]
	println(a)
}

.\tt1.v:2:8: error: undefined variable: `a`
    1 | fn main() {
    2 |     a := [a]
      |           ^
    3 |     println(a)
    4 | }
```
```vlang
fn main() {
	a := map{'one': a}
	println(a)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:2:18: error: undefined variable: `a`
    1 | fn main() {
    2 |     a := map{'one': a}
      |                     ^
    3 |     println(a)
    4 | }
```