### PR TITLE
checker: check assigning array_init with no type (fix #10738)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3935,7 +3935,7 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) ast.Type {
 			c.expected_type = c.expected_or_type
 		}
 		mut type_sym := c.table.get_type_symbol(c.expected_type)
-		if type_sym.kind != .array {
+		if type_sym.kind != .array || type_sym.array_info().elem_type == ast.void_type {
 			c.error('array_init: no type specified (maybe: `[]Type{}` instead of `[]`)',
 				array_init.pos)
 			return ast.void_type

--- a/vlib/v/checker/tests/assign_array_init_with_no_type.out
+++ b/vlib/v/checker/tests/assign_array_init_with_no_type.out
@@ -1,0 +1,12 @@
+vlib/v/checker/tests/assign_array_init_with_no_type.vv:2:11: error: array_init: no type specified (maybe: `[]Type{}` instead of `[]`)
+    1 | fn main() {
+    2 |     mut x := []
+      |              ~~
+    3 |     println(x)
+    4 | }
+vlib/v/checker/tests/assign_array_init_with_no_type.vv:3:2: error: `println` can not print void expressions
+    1 | fn main() {
+    2 |     mut x := []
+    3 |     println(x)
+      |     ~~~~~~~~~~
+    4 | }

--- a/vlib/v/checker/tests/assign_array_init_with_no_type.vv
+++ b/vlib/v/checker/tests/assign_array_init_with_no_type.vv
@@ -1,0 +1,4 @@
+fn main() {
+	mut x := []
+	println(x)
+}


### PR DESCRIPTION
This PR check assigning array_init with no type (fix #10738).

- Check assigning array_init with no type.
- Add test.

```vlang
fn main() {
	mut x := []
	println(x)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:2:11: error: array_init: no type specified (maybe: `[]Type{}` instead of `[]`)
    1 | fn main() {
    2 |     mut x := []
      |              ~~
    3 |     println(x)
    4 | }
.\tt1.v:3:2: error: `println` can not print void expressions
    1 | fn main() {
    2 |     mut x := []
    3 |     println(x)
      |     ~~~~~~~~~~
    4 | }
```