### PR TITLE
checker: fix error of for_in alias (fix #10765)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4358,7 +4358,7 @@ fn (mut c Checker) for_in_stmt(mut node ast.ForInStmt) {
 		}
 		node.scope.update_var_type(node.val_var, node.val_type)
 	} else {
-		sym := c.table.get_type_symbol(typ)
+		sym := c.table.get_final_type_symbol(typ)
 		if sym.kind == .struct_ {
 			// iterators
 			next_fn := sym.find_method('next') or {

--- a/vlib/v/tests/for_in_alias_test.v
+++ b/vlib/v/tests/for_in_alias_test.v
@@ -1,0 +1,26 @@
+enum Nucleotide {
+	a
+	c
+	g
+	t
+}
+
+type Codon = []Nucleotide
+type Gene = []Codon
+
+fn test_for_in_alias() {
+	mut gene := Gene([
+		Codon([Nucleotide.a, Nucleotide.c, Nucleotide.g]),
+		Codon([Nucleotide.g, Nucleotide.a, Nucleotide.t]),
+	])
+
+	mut ret := []string{}
+	for cdn in gene {
+		println(cdn)
+		ret << '$cdn'
+	}
+
+	assert ret.len == 2
+	assert ret[0] == 'Codon([a, c, g])'
+	assert ret[1] == 'Codon([g, a, t])'
+}


### PR DESCRIPTION
This PR fix error of for_in alias (fix #10765).

- Fix error of for_in alias.
- Add test.

```vlang
enum Nucleotide {
	a
	c
	g
	t
}

type Codon = []Nucleotide
type Gene = []Codon

fn main() {
	mut gene := Gene([
		Codon([Nucleotide.a, Nucleotide.c, Nucleotide.g]),
		Codon([Nucleotide.g, Nucleotide.a, Nucleotide.t]),
	])

	mut ret := []string{}
	for cdn in gene {
		println(cdn)
		ret << '$cdn'
	}

	assert ret.len == 2
	assert ret[0] == 'Codon([a, c, g])'
	assert ret[1] == 'Codon([g, a, t])'
}

PS D:\Test\v\tt1> v run .
[a, c, g]
[g, a, t]
```