### PR TITLE
cgen: fix array of alias's slice() (fix #10762)

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -58,7 +58,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 }
 
 fn (mut g Gen) range_expr(node ast.IndexExpr, range ast.RangeExpr) {
-	sym := g.table.get_type_symbol(node.left_type)
+	sym := g.table.get_final_type_symbol(node.left_type)
 	if sym.kind == .string {
 		g.write('string_substr(')
 		g.expr(node.left)

--- a/vlib/v/tests/array_of_alias_slice_test.v
+++ b/vlib/v/tests/array_of_alias_slice_test.v
@@ -1,0 +1,12 @@
+type Ints = []int
+
+fn (i Ints) slice(to int) Ints {
+	return i[0..to]
+}
+
+fn test_array_of_alias_slice() {
+	values := Ints([5, 7, 9])
+
+	println(values.slice(2))
+	assert values.slice(2) == Ints([5, 7])
+}


### PR DESCRIPTION
This PR fix array of alias's slice() (fix #10762).

- Fix array of alias's slice().
- Add test.

```vlang
type Ints = []int

fn (i Ints) slice(to int) Ints {
	return i[0..to]
}

fn main() {
	values := Ints([5, 7, 9])

	println(values.slice(2))
	assert values.slice(2) == Ints([5, 7])
}

PS D:\Test\v\tt1> v run .
[5, 7]
```