### PR TITLE
checker: prohibit fixed array to fixed array assignment where elem_typ is a pointer

### DIFF
--- a/vlib/gg/image.v
+++ b/vlib/gg/image.v
@@ -222,7 +222,8 @@ pub fn (mut ctx Context) new_streaming_image(w int, h int, channels int) int {
 // update_pixel_data is a helper for working with image streams (i.e. images,
 // that are updated dynamically by the CPU on each frame)
 pub fn (mut ctx Context) update_pixel_data(cached_image_idx int, buf &byte) {
-	ctx.get_cached_image_by_idx(cached_image_idx).update_pixel_data(buf)
+	mut image := ctx.get_cached_image_by_idx(cached_image_idx)
+	image.update_pixel_data(buf)
 }
 
 pub fn (mut img Image) update_pixel_data(buf &byte) {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3664,6 +3664,17 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			c.error('use `array2 $node.op.str() array1.clone()` instead of `array2 $node.op.str() array1` (or use `unsafe`)',
 				node.pos)
 		}
+		if left_sym.kind == .array_fixed && !c.inside_unsafe && node.op in [.assign, .decl_assign]
+			&& right_sym.kind == .array_fixed && (left is ast.Ident && !left.is_blank_ident())
+			&& right is ast.Ident {
+			if right_sym.info is ast.ArrayFixed {
+				eprintln(right_sym.info.elem_type)
+				if right_sym.info.elem_type.is_ptr() {
+					c.error('assignment from one fixed array to another with a pointer element type is prohibited outside of `unsafe`',
+						node.pos)
+				}
+			}
+		}
 		if left_sym.kind == .map && node.op in [.assign, .decl_assign] && right_sym.kind == .map
 			&& ((right is ast.Ident && right.is_auto_deref_var())
 			|| !right_type.is_ptr()) && !left.is_blank_ident() && right.is_lvalue() {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3668,7 +3668,6 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			&& right_sym.kind == .array_fixed && (left is ast.Ident && !left.is_blank_ident())
 			&& right is ast.Ident {
 			if right_sym.info is ast.ArrayFixed {
-				eprintln(right_sym.info.elem_type)
 				if right_sym.info.elem_type.is_ptr() {
 					c.error('assignment from one fixed array to another with a pointer element type is prohibited outside of `unsafe`',
 						node.pos)

--- a/vlib/v/checker/tests/unsafe_fixed_array_assign.out
+++ b/vlib/v/checker/tests/unsafe_fixed_array_assign.out
@@ -1,0 +1,8 @@
+65620
+vlib/v/checker/tests/unsafe_fixed_array_assign.vv:8:7: error: assignment from one fixed array to another with a pointer element type is prohibited outside of `unsafe`
+    6 | mut box := Box { num: 10 }
+    7 | a := [&box]!
+    8 | mut b := a
+      |       ~~
+    9 | b[0].num = 0
+   10 | println(a)

--- a/vlib/v/checker/tests/unsafe_fixed_array_assign.out
+++ b/vlib/v/checker/tests/unsafe_fixed_array_assign.out
@@ -1,4 +1,3 @@
-65620
 vlib/v/checker/tests/unsafe_fixed_array_assign.vv:8:7: error: assignment from one fixed array to another with a pointer element type is prohibited outside of `unsafe`
     6 | mut box := Box { num: 10 }
     7 | a := [&box]!

--- a/vlib/v/checker/tests/unsafe_fixed_array_assign.vv
+++ b/vlib/v/checker/tests/unsafe_fixed_array_assign.vv
@@ -1,0 +1,10 @@
+struct Box {
+mut:
+	num int
+}
+
+mut box := Box { num: 10 }
+a := [&box]!
+mut b := a
+b[0].num = 0
+println(a)


### PR DESCRIPTION
this pr prohibits assigning from one fixed array to another where the element type is a pointer. closes #8603.