### PR TITLE
checker: check that `mut` args are lvalues

### DIFF
--- a/vlib/net/http/request_test.v
+++ b/vlib/net/http/request_test.v
@@ -28,19 +28,22 @@ fn reader(s string) &io.BufferedReader {
 }
 
 fn test_parse_request_not_http() {
-	parse_request(mut reader('hello')) or { return }
+	mut reader__ := reader('hello')
+	parse_request(mut reader__) or { return }
 	panic('should not have parsed')
 }
 
 fn test_parse_request_no_headers() {
-	req := parse_request(mut reader('GET / HTTP/1.1\r\n\r\n')) or { panic('did not parse: $err') }
+	mut reader_ := reader('GET / HTTP/1.1\r\n\r\n')
+	req := parse_request(mut reader_) or { panic('did not parse: $err') }
 	assert req.method == .get
 	assert req.url == '/'
 	assert req.version == .v1_1
 }
 
 fn test_parse_request_two_headers() {
-	req := parse_request(mut reader('GET / HTTP/1.1\r\nTest1: a\r\nTest2:  B\r\n\r\n')) or {
+	mut reader_ := reader('GET / HTTP/1.1\r\nTest1: a\r\nTest2:  B\r\n\r\n')
+	req := parse_request(mut reader_) or {
 		panic('did not parse: $err')
 	}
 	assert req.header.custom_values('Test1') == ['a']
@@ -48,7 +51,8 @@ fn test_parse_request_two_headers() {
 }
 
 fn test_parse_request_two_header_values() {
-	req := parse_request(mut reader('GET / HTTP/1.1\r\nTest1: a; b\r\nTest2: c\r\nTest2: d\r\n\r\n')) or {
+	mut reader_ := reader('GET / HTTP/1.1\r\nTest1: a; b\r\nTest2: c\r\nTest2: d\r\n\r\n')
+	req := parse_request(mut reader_) or {
 		panic('did not parse: $err')
 	}
 	assert req.header.custom_values('Test1') == ['a; b']
@@ -56,7 +60,8 @@ fn test_parse_request_two_header_values() {
 }
 
 fn test_parse_request_body() {
-	req := parse_request(mut reader('GET / HTTP/1.1\r\nTest1: a\r\nTest2: b\r\nContent-Length: 4\r\n\r\nbodyabc')) or {
+	mut reader_ := reader('GET / HTTP/1.1\r\nTest1: a\r\nTest2: b\r\nContent-Length: 4\r\n\r\nbodyabc')
+	req := parse_request(mut reader_) or {
 		panic('did not parse: $err')
 	}
 	assert req.data == 'body'
@@ -132,7 +137,8 @@ ${contents[1]}
 fn test_parse_large_body() ? {
 	body := 'A'.repeat(101) // greater than max_bytes
 	req := 'GET / HTTP/1.1\r\nContent-Length: $body.len\r\n\r\n$body'
-	result := parse_request(mut reader(req)) ?
+	mut reader_ := reader(req)
+	result := parse_request(mut reader_) ?
 	assert result.data.len == body.len
 	assert result.data == body
 }

--- a/vlib/net/http/request_test.v
+++ b/vlib/net/http/request_test.v
@@ -43,27 +43,21 @@ fn test_parse_request_no_headers() {
 
 fn test_parse_request_two_headers() {
 	mut reader_ := reader('GET / HTTP/1.1\r\nTest1: a\r\nTest2:  B\r\n\r\n')
-	req := parse_request(mut reader_) or {
-		panic('did not parse: $err')
-	}
+	req := parse_request(mut reader_) or { panic('did not parse: $err') }
 	assert req.header.custom_values('Test1') == ['a']
 	assert req.header.custom_values('Test2') == ['B']
 }
 
 fn test_parse_request_two_header_values() {
 	mut reader_ := reader('GET / HTTP/1.1\r\nTest1: a; b\r\nTest2: c\r\nTest2: d\r\n\r\n')
-	req := parse_request(mut reader_) or {
-		panic('did not parse: $err')
-	}
+	req := parse_request(mut reader_) or { panic('did not parse: $err') }
 	assert req.header.custom_values('Test1') == ['a; b']
 	assert req.header.custom_values('Test2') == ['c', 'd']
 }
 
 fn test_parse_request_body() {
 	mut reader_ := reader('GET / HTTP/1.1\r\nTest1: a\r\nTest2: b\r\nContent-Length: 4\r\n\r\nbodyabc')
-	req := parse_request(mut reader_) or {
-		panic('did not parse: $err')
-	}
+	req := parse_request(mut reader_) or { panic('did not parse: $err') }
 	assert req.data == 'body'
 }
 

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2619,6 +2619,9 @@ pub fn (mut c Checker) fn_call(mut call_expr ast.CallExpr) ast.Type {
 		}
 		if call_arg.is_mut && func.language == .v {
 			to_lock, pos := c.fail_if_immutable(call_arg.expr)
+			if !call_arg.expr.is_lvalue() {
+				c.error('cannot pass expression as `mut`', call_arg.expr.position())
+			}
 			if !param.is_mut {
 				tok := call_arg.share.str()
 				c.error('`$call_expr.name` parameter `$param.name` is not `$tok`, `$tok` is not needed`',

--- a/vlib/v/checker/tests/pass_mut_lit.out
+++ b/vlib/v/checker/tests/pass_mut_lit.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/pass_mut_lit.vv:10:12: error: cannot pass expression as `mut`
+    8 | }
+    9 | 
+   10 | modify(mut Box{}, 10)
+      |            ~~~~~

--- a/vlib/v/checker/tests/pass_mut_lit.vv
+++ b/vlib/v/checker/tests/pass_mut_lit.vv
@@ -1,0 +1,10 @@
+struct Box {
+mut:
+	value int
+}
+
+fn modify(mut box Box, value int) {
+	box.value = value
+}
+
+modify(mut Box{}, 10)

--- a/vlib/v/tests/struct_test.v
+++ b/vlib/v/tests/struct_test.v
@@ -280,8 +280,10 @@ fn test_struct_literal_args() {
 
 	bar_config({}, 10)
 	bar_config({ def: 4 }, 4)
-	
-	mut c_ := Config { def: 10 }
+
+	mut c_ := Config{
+		def: 10
+	}
 	c := mut_bar_config(mut c_, 10)
 	assert c.n == 10
 	assert c.def == 10

--- a/vlib/v/tests/struct_test.v
+++ b/vlib/v/tests/struct_test.v
@@ -280,8 +280,9 @@ fn test_struct_literal_args() {
 
 	bar_config({}, 10)
 	bar_config({ def: 4 }, 4)
-
-	c := mut_bar_config(mut { def: 10 }, 10)
+	
+	mut c_ := Config { def: 10 }
+	c := mut_bar_config(mut c_, 10)
 	assert c.n == 10
 	assert c.def == 10
 

--- a/vlib/vweb/request_test.v
+++ b/vlib/vweb/request_test.v
@@ -43,27 +43,21 @@ fn test_parse_request_no_headers() {
 
 fn test_parse_request_two_headers() {
 	mut reader_ := reader('GET / HTTP/1.1\r\nTest1: a\r\nTest2:  B\r\n\r\n')
-	req := parse_request(mut reader_) or {
-		panic('did not parse: $err')
-	}
+	req := parse_request(mut reader_) or { panic('did not parse: $err') }
 	assert req.header.custom_values('Test1') == ['a']
 	assert req.header.custom_values('Test2') == ['B']
 }
 
 fn test_parse_request_two_header_values() {
 	mut reader_ := reader('GET / HTTP/1.1\r\nTest1: a; b\r\nTest2: c\r\nTest2: d\r\n\r\n')
-	req := parse_request(mut reader_) or {
-		panic('did not parse: $err')
-	}
+	req := parse_request(mut reader_) or { panic('did not parse: $err') }
 	assert req.header.custom_values('Test1') == ['a; b']
 	assert req.header.custom_values('Test2') == ['c', 'd']
 }
 
 fn test_parse_request_body() {
 	mut reader_ := reader('GET / HTTP/1.1\r\nTest1: a\r\nTest2: b\r\nContent-Length: 4\r\n\r\nbodyabc')
-	req := parse_request(mut reader_) or {
-		panic('did not parse: $err')
-	}
+	req := parse_request(mut reader_) or { panic('did not parse: $err') }
 	assert req.data == 'body'
 }
 

--- a/vlib/vweb/request_test.v
+++ b/vlib/vweb/request_test.v
@@ -28,19 +28,22 @@ fn reader(s string) &io.BufferedReader {
 }
 
 fn test_parse_request_not_http() {
-	parse_request(mut reader('hello')) or { return }
+	mut reader_ := reader('hello')
+	parse_request(mut reader_) or { return }
 	panic('should not have parsed')
 }
 
 fn test_parse_request_no_headers() {
-	req := parse_request(mut reader('GET / HTTP/1.1\r\n\r\n')) or { panic('did not parse: $err') }
+	mut reader_ := reader('GET / HTTP/1.1\r\n\r\n')
+	req := parse_request(mut reader_) or { panic('did not parse: $err') }
 	assert req.method == .get
 	assert req.url == '/'
 	assert req.version == .v1_1
 }
 
 fn test_parse_request_two_headers() {
-	req := parse_request(mut reader('GET / HTTP/1.1\r\nTest1: a\r\nTest2:  B\r\n\r\n')) or {
+	mut reader_ := reader('GET / HTTP/1.1\r\nTest1: a\r\nTest2:  B\r\n\r\n')
+	req := parse_request(mut reader_) or {
 		panic('did not parse: $err')
 	}
 	assert req.header.custom_values('Test1') == ['a']
@@ -48,7 +51,8 @@ fn test_parse_request_two_headers() {
 }
 
 fn test_parse_request_two_header_values() {
-	req := parse_request(mut reader('GET / HTTP/1.1\r\nTest1: a; b\r\nTest2: c\r\nTest2: d\r\n\r\n')) or {
+	mut reader_ := reader('GET / HTTP/1.1\r\nTest1: a; b\r\nTest2: c\r\nTest2: d\r\n\r\n')
+	req := parse_request(mut reader_) or {
 		panic('did not parse: $err')
 	}
 	assert req.header.custom_values('Test1') == ['a; b']
@@ -56,7 +60,8 @@ fn test_parse_request_two_header_values() {
 }
 
 fn test_parse_request_body() {
-	req := parse_request(mut reader('GET / HTTP/1.1\r\nTest1: a\r\nTest2: b\r\nContent-Length: 4\r\n\r\nbodyabc')) or {
+	mut reader_ := reader('GET / HTTP/1.1\r\nTest1: a\r\nTest2: b\r\nContent-Length: 4\r\n\r\nbodyabc')
+	req := parse_request(mut reader_) or {
 		panic('did not parse: $err')
 	}
 	assert req.data == 'body'
@@ -132,7 +137,8 @@ ${contents[1]}
 fn test_parse_large_body() ? {
 	body := 'ABCEF\r\n'.repeat(1024 * 1024) // greater than max_bytes
 	req := 'GET / HTTP/1.1\r\nContent-Length: $body.len\r\n\r\n$body'
-	result := parse_request(mut reader(req)) ?
+	mut reader_ := reader(req)
+	result := parse_request(mut reader_) ?
 	assert result.data.len == body.len
 	assert result.data == body
 }


### PR DESCRIPTION
this pr ensures that literals and other non-lvalues cannot be passed as mut arguments. closes #10774.