### PR TITLE
cgen: fix initialization errors with fixed array aliases (fix #10776)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2512,9 +2512,12 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 			}
 			else {}
 		}
-		right_sym := g.table.get_type_symbol(g.unwrap_generic(val_type))
-		is_fixed_array_var := right_sym.kind == .array_fixed && (val is ast.Ident
-			|| val is ast.IndexExpr || val is ast.CallExpr
+		unwrapped_val_type := g.unwrap_generic(val_type)
+		right_sym := g.table.get_type_symbol(unwrapped_val_type)
+		unaliased_right_sym := g.table.get_final_type_symbol(unwrapped_val_type)
+		is_fixed_array_var := unaliased_right_sym.kind == .array_fixed && val !is ast.ArrayInit
+			&& (val is ast.Ident || val is ast.IndexExpr || val is ast.CallExpr
+			|| (val is ast.CastExpr && (val as ast.CastExpr).expr !is ast.ArrayInit)
 			|| val is ast.SelectorExpr)
 		g.is_assign_lhs = true
 		g.assign_op = assign_stmt.op
@@ -4319,6 +4322,8 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 		g.write('*(($styp *)(&')
 		g.expr(node.expr)
 		g.write('))')
+	} else if sym.kind == .alias && g.table.get_final_type_symbol(node.typ).kind == .array_fixed {
+		g.expr(node.expr)
 	} else {
 		styp := g.typ(node.typ)
 		mut cast_label := ''

--- a/vlib/v/tests/alias_fixed_array_init_test.v
+++ b/vlib/v/tests/alias_fixed_array_init_test.v
@@ -1,0 +1,12 @@
+type Tres = [3]int
+
+fn test_alias_fixed_array_init() {
+	fixed_three := [1, 2, 3]!
+	x := Tres(fixed_three)
+	println(x)
+	assert '$x' == 'Tres([1, 2, 3])'
+
+	y := Tres([2, 3, 4]!)
+	println(y)
+	assert '$y' == 'Tres([2, 3, 4])'
+}


### PR DESCRIPTION
This PR fix initialization errors with fixed array aliases (fix #10776).

- Fix initialization errors with fixed array aliases.
- Add test.

```vlang
type Tres = [3]int

fn main() {
	fixed_three := [1, 2, 3]!
	x := Tres(fixed_three)
	println(x)
	assert '$x' == 'Tres([1, 2, 3])'

	y := Tres([2, 3, 4]!)
	println(y)
	assert '$y' == 'Tres([2, 3, 4])'
}

PS D:\Test\v\tt1> v run .
[1, 2, 3]
[2, 3, 4]
```