### PR TITLE
cgen: fix if_expr with array methods cond (fix #10731)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4517,7 +4517,10 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 		if needs_tmp_var {
 			g.stmts_with_tmp_var(branch.stmts, tmp)
 		} else {
+			// restore if_expr stmt header pos
+			stmt_pos := g.nth_stmt_pos(0)
 			g.stmts(branch.stmts)
+			g.stmt_path_pos << stmt_pos
 		}
 	}
 	g.writeln('}')

--- a/vlib/v/tests/if_expression_test.v
+++ b/vlib/v/tests/if_expression_test.v
@@ -199,3 +199,17 @@ fn min<T>(a T, b T) T {
 fn test_if_expr_with_fn_generic() {
 	assert min(42, 13) == 13
 }
+
+fn test_if_expr_with_complex_array_methods() {
+	mut ret := []string{}
+	entries := ['a', 'b', 'c']
+
+	if false {
+		ret = entries.map(it.capitalize())
+	} else if entries.any(it == 'a') {
+		ret = entries.map(it)
+	}
+
+	println(ret)
+	assert ret == ['a', 'b', 'c']
+}


### PR DESCRIPTION
This PR fix if_expr with array methods cond (fix #10731).

- Fix if_expr with array methods cond.
- Add test.

```vlang
fn main() {
	mut ret := []string{}
	entries := ['a', 'b', 'c']

	if false {
		ret = entries.map(it.capitalize())
	} else if entries.any(it == 'a') {
		ret = entries.map(it)
	}

	println(ret)
	assert ret == ['a', 'b', 'c']
}

PS D:\Test\v\tt1> v run .
['a', 'b', 'c']
```