### PR TITLE
cgen: fix error of the map literals method call (fix #10780)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -778,7 +778,13 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			&& node.name in ['first', 'last', 'repeat'] {
 			g.write('*')
 		}
-		g.expr(node.left)
+		if node.left is ast.MapInit {
+			g.write('(map[]){')
+			g.expr(node.left)
+			g.write('}[0]')
+		} else {
+			g.expr(node.left)
+		}
 		if node.from_embed_type != 0 {
 			embed_name := typ_sym.embed_name()
 			if node.left_type.is_ptr() {

--- a/vlib/v/tests/map_literals_method_call_test.v
+++ b/vlib/v/tests/map_literals_method_call_test.v
@@ -1,0 +1,10 @@
+fn test_map_literals_method_call() {
+	a := 1 in map{
+		1: 1
+	}.keys().map(map{
+		1: 1
+	}[it])
+
+	println(a)
+	assert a
+}


### PR DESCRIPTION
This PR fix error of the map literals method call (fix #10780).

- Fix error of the map literals method call.
- Add test.

```vlang
fn main() {
	a := 1 in map{
		1: 1
	}.keys().map(map{
		1: 1
	}[it])

	println(a)
	assert a
}

PS D:\Test\v\tt1> v run .
true
```