### PR TITLE
cgen: cleanup write_expr_to_string()

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -278,8 +278,8 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 				g.definitions.writeln('\tif (${styp}__lt(*b, *a)) { return -1; } else { return 1; }}')
 			} else {
 				field_type := g.typ(infix_expr.left_type)
-				left_expr_str := g.write_expr_to_string(infix_expr.left)
-				right_expr_str := g.write_expr_to_string(infix_expr.right)
+				left_expr_str := g.expr_string(infix_expr.left)
+				right_expr_str := g.expr_string(infix_expr.right)
 				g.definitions.writeln('\t$field_type a_ = $left_expr_str;')
 				g.definitions.writeln('\t$field_type b_ = $right_expr_str;')
 				mut op1, mut op2 := '', ''

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5597,12 +5597,6 @@ fn (mut g Gen) insert_before_stmt(s string) {
 	g.write(cur_line)
 }
 
-fn (mut g Gen) write_expr_to_string(expr ast.Expr) string {
-	pos := g.out.len
-	g.expr(expr)
-	return g.out.cut_last(g.out.len - pos)
-}
-
 // fn (mut g Gen) start_tmp() {
 // }
 // If user is accessing the return value eg. in assigment, pass the variable name.

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1060,7 +1060,7 @@ fn (mut g Gen) autofree_call_pregen(node ast.CallExpr) {
 			s = 'string $t = '
 		}
 		// g.expr(arg.expr)
-		s += g.write_expr_to_string(arg.expr)
+		s += g.expr_string(arg.expr)
 		// g.writeln(';// new af pre')
 		s += ';// new af2 pre'
 		g.strs_to_free0 << s


### PR DESCRIPTION
This PR cleanup write_expr_to_string().

- Remove `write_expr_to_string()` because it is redundant.
- Use `expr_string()` instead of it.
- Modify all the related calls.