### PR TITLE
docs: mention custom sorting

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -889,6 +889,39 @@ mut users := [User{21, 'Bob'}, User{20, 'Zarkon'}, User{25, 'Alice'}]
 users.sort(a.age < b.age) // sort by User.age int field
 users.sort(a.name > b.name) // reverse sort by User.name string field
 ```
+V also supports custom sorting, through the `sort_with_compare` function which expects a comparing function which will define the sort order.
+Useful for sorting on multiple fields or with specific sorting rules.
+The code below sorts the array ascending on `name` and descending `age`.
+```v
+struct User {
+	age  int
+	name string
+}
+
+mut users := [User{21, 'Bob'}, User{65, 'Bob'}, User{25, 'Alice'}]
+
+custom_sort_fn := fn (a &User, b &User) int {
+	// return -1 when a comes before b
+	// return 0, when both are in same order
+	// return 1 when b comes before a
+	if a.name == b.name {
+		if a.age < b.age {
+			return 1
+		}
+		if a.age > b.age {
+			return -1
+		}
+		return 0
+	}
+	if a.name < b.name {
+		return -1
+	} else if a.name > b.name {
+		return 1
+	}
+	return 0
+}
+users.sort_with_compare(custom_sort_fn)
+```
 
 #### Array Slices
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -889,9 +889,9 @@ mut users := [User{21, 'Bob'}, User{20, 'Zarkon'}, User{25, 'Alice'}]
 users.sort(a.age < b.age) // sort by User.age int field
 users.sort(a.name > b.name) // reverse sort by User.name string field
 ```
-V also supports custom sorting, through the `sort_with_compare` function which 
-expects a comparing function which will define the sort order.
-Useful for sorting on multiple fields or with specific sorting rules.
+V also supports custom sorting, through the `sort_with_compare` array method.
+Which expects a comparing function which will define the sort order.
+Useful for sorting on multiple fields at the same time by custom sorting rules.
 The code below sorts the array ascending on `name` and descending `age`.
 ```v
 struct User {

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -889,7 +889,8 @@ mut users := [User{21, 'Bob'}, User{20, 'Zarkon'}, User{25, 'Alice'}]
 users.sort(a.age < b.age) // sort by User.age int field
 users.sort(a.name > b.name) // reverse sort by User.name string field
 ```
-V also supports custom sorting, through the `sort_with_compare` function which expects a comparing function which will define the sort order.
+V also supports custom sorting, through the `sort_with_compare` function which 
+expects a comparing function which will define the sort order.
 Useful for sorting on multiple fields or with specific sorting rules.
 The code below sorts the array ascending on `name` and descending `age`.
 ```v


### PR DESCRIPTION
V also supports sorting of arrays based on a custom function, to sort on multiple fields or perform custom sorting logic.
This PR adds this to the docs.md, since I missed the existence of this feature by looking at the docs.

Not sure if it should include the added example code which makes the documentation more noisy. 
Or just leave it at mentioning the possibility of `sort_with_compare`?
