### PR TITLE
json: support raw json fields with raw attribute...

### DIFF
--- a/vlib/json/json_primitives.v
+++ b/vlib/json/json_primitives.v
@@ -22,6 +22,8 @@ fn C.cJSON_CreateBool(bool) &C.cJSON
 
 fn C.cJSON_CreateString(&char) &C.cJSON
 
+fn C.cJSON_CreateRaw(&char) &C.cJSON
+
 fn C.cJSON_Parse(&char) &C.cJSON
 
 fn C.cJSON_PrintUnformatted(&C.cJSON) &char
@@ -179,6 +181,10 @@ fn encode_bool(val bool) &C.cJSON {
 
 fn encode_string(val string) &C.cJSON {
 	return C.cJSON_CreateString(&char(val.str))
+}
+
+fn encode_raw(val string) &C.cJSON {
+	return C.cJSON_CreateRaw(&char(val.str))
 }
 
 // ///////////////////////

--- a/vlib/json/json_primitives.v
+++ b/vlib/json/json_primitives.v
@@ -184,7 +184,11 @@ fn encode_string(val string) &C.cJSON {
 }
 
 fn encode_raw(val string) &C.cJSON {
-	return C.cJSON_CreateRaw(&char(val.str))
+	mut ret_val := val
+	if ret_val.len == 0 {
+		ret_val = "null"
+	}
+	return C.cJSON_CreateRaw(&char(ret_val.str))
 }
 
 // ///////////////////////

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -183,6 +183,9 @@ fn (mut g Gen) gen_struct_enc_dec(type_info ast.TypeInfo, styp string, mut enc s
 				// it has to be encoded as a unix timestamp number
 				enc.writeln('\tcJSON_AddItemToObject(o, "$name", json__encode_u64(val.${c_name(field.name)}.v_unix));')
 			} else {
+				if field.attrs.contains('raw') {
+					enc_name = js_enc_name('raw')
+				}
 				enc.writeln('\tcJSON_AddItemToObject(o, "$name", ${enc_name}(val.${c_name(field.name)}));\n')
 			}
 		}


### PR DESCRIPTION
support encoding json with raw json string using `[raw]` attribute, it uses cJSON_CreateRaw, and should only be used when encoding as the cJSON_Raw type is not used by cJSON for parsing, see https://github.com/DaveGamble/cJSON\#data-structure.


Example:

```v
struct Sub {
	type_ int [json: "type"]
}

struct Person {
	name string
	data string [raw]
}

fn main() {
	p := Person{
		name: "ahmed"
		data: json.encode(Sub{type_: 1})
	}

	println(json.encode(p))
}
```

This should output:

```json
{"name":"ahmed","data":{"type":1}}
```

I don't know if we defined a new type like json.Raw and use it instead `[raw]` attribute for string fields.
