### PR TITLE
Prettier REPL Prompt

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -115,7 +115,7 @@ fn repl_help() {
 fn run_repl(workdir string, vrepl_prefix string) {
 	if !is_stdin_a_pipe {
 		println(util.full_v_version(false))
-		println('Use Ctrl-C or ${repl_pretty_print('exit')} to exit, or ${repl_pretty_print('help')} to see other available commands')
+		println('Use Ctrl-C or ${util.pretty_print('exit')} to exit, or ${util.pretty_print('help')} to see other available commands')
 	}
 
 	if vstartup != '' {
@@ -387,8 +387,4 @@ fn repl_run_vfile(file string) ?os.Result {
 		return error(s.output)
 	}
 	return s
-}
-
-fn repl_pretty_print(command string) string {
-	return term.bright_white(term.bg_cyan(' $command '))
 }

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -115,7 +115,7 @@ fn repl_help() {
 fn run_repl(workdir string, vrepl_prefix string) {
 	if !is_stdin_a_pipe {
 		println(util.full_v_version(false))
-		println('Use Ctrl-C or `exit` to exit, or `help` to see other available commands')
+		println('Use Ctrl-C or ${repl_pretty_print('exit')} to exit, or ${repl_pretty_print('help')} to see other available commands')
 	}
 
 	if vstartup != '' {
@@ -387,4 +387,8 @@ fn repl_run_vfile(file string) ?os.Result {
 		return error(s.output)
 	}
 	return s
+}
+
+fn repl_pretty_print(command string) string {
+	return term.bright_white(term.bg_cyan(' $command '))
 }

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -5,6 +5,7 @@ module main
 
 import help
 import os
+import term
 import v.pref
 import v.util
 import v.builder
@@ -60,9 +61,16 @@ fn main() {
 		// Running `./v` without args launches repl
 		if args.len == 0 {
 			if os.is_atty(0) != 0 {
-				println('Welcome to the V REPL (for help with V itself, type `exit`, then run `v help`).')
+				v_command := fn (command string) string {
+					return term.bright_white(term.bg_cyan(' $command '))
+				}
+				cmd_exit := v_command('exit')
+				cmd_help := v_command('v help')
+				file_main := v_command('main.v')
+				cmd_run := v_command('v run main.v')
+				println('Welcome to the V REPL (for help with V itself, type $cmd_exit, then run $cmd_help).')
 				eprintln('  NB: the REPL is highly experimental. For best V experience, use a text editor,')
-				eprintln('  save your code in a `main.v` file and do: `v run main.v`')
+				eprintln('  save your code in a $file_main file and execute: $cmd_run')
 			} else {
 				mut args_and_flags := util.join_env_vflags_and_os_args()[1..].clone()
 				args_and_flags << ['run', '-']

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -5,7 +5,6 @@ module main
 
 import help
 import os
-import term
 import v.pref
 import v.util
 import v.builder
@@ -61,10 +60,10 @@ fn main() {
 		// Running `./v` without args launches repl
 		if args.len == 0 {
 			if os.is_atty(0) != 0 {
-				cmd_exit := repl_pretty_print('exit')
-				cmd_help := repl_pretty_print('v help')
-				file_main := repl_pretty_print('main.v')
-				cmd_run := repl_pretty_print('v run main.v')
+				cmd_exit := util.pretty_print('exit')
+				cmd_help := util.pretty_print('v help')
+				file_main := util.pretty_print('main.v')
+				cmd_run := util.pretty_print('v run main.v')
 				println('Welcome to the V REPL (for help with V itself, type $cmd_exit, then run $cmd_help).')
 				eprintln('  NB: the REPL is highly experimental. For best V experience, use a text editor,')
 				eprintln('  save your code in a $file_main file and execute: $cmd_run')
@@ -129,7 +128,7 @@ fn main() {
 	if prefs.is_help {
 		invoke_help_and_exit(args)
 	}
-	eprintln('v $command: unknown command\nRun ${repl_pretty_print('v help')} for usage.')
+	eprintln('v $command: unknown command\nRun ${util.pretty_print('v help')} for usage.')
 	exit(1)
 }
 
@@ -139,11 +138,7 @@ fn invoke_help_and_exit(remaining []string) {
 		2 { help.print_and_exit(remaining[1]) }
 		else {}
 	}
-	println('${repl_pretty_print('v help')}: provide only one help topic.')
-	println('For usage information, use ${repl_pretty_print('v help')}.')
+	println('${util.pretty_print('v help')}: provide only one help topic.')
+	println('For usage information, use ${util.pretty_print('v help')}.')
 	exit(1)
-}
-
-fn repl_pretty_print(command string) string {
-	return term.bright_white(term.bg_cyan(' $command '))
 }

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -61,13 +61,10 @@ fn main() {
 		// Running `./v` without args launches repl
 		if args.len == 0 {
 			if os.is_atty(0) != 0 {
-				v_command := fn (command string) string {
-					return term.bright_white(term.bg_cyan(' $command '))
-				}
-				cmd_exit := v_command('exit')
-				cmd_help := v_command('v help')
-				file_main := v_command('main.v')
-				cmd_run := v_command('v run main.v')
+				cmd_exit := repl_pretty_print('exit')
+				cmd_help := repl_pretty_print('v help')
+				file_main := repl_pretty_print('main.v')
+				cmd_run := repl_pretty_print('v run main.v')
 				println('Welcome to the V REPL (for help with V itself, type $cmd_exit, then run $cmd_help).')
 				eprintln('  NB: the REPL is highly experimental. For best V experience, use a text editor,')
 				eprintln('  save your code in a $file_main file and execute: $cmd_run')
@@ -132,7 +129,7 @@ fn main() {
 	if prefs.is_help {
 		invoke_help_and_exit(args)
 	}
-	eprintln('v $command: unknown command\nRun "v help" for usage.')
+	eprintln('v $command: unknown command\nRun ${repl_pretty_print('v help')} for usage.')
 	exit(1)
 }
 
@@ -142,7 +139,11 @@ fn invoke_help_and_exit(remaining []string) {
 		2 { help.print_and_exit(remaining[1]) }
 		else {}
 	}
-	println('`v help`: provide only one help topic.')
-	println('For usage information, use `v help`.')
+	println('${repl_pretty_print('v help')}: provide only one help topic.')
+	println('For usage information, use ${repl_pretty_print('v help')}.')
 	exit(1)
+}
+
+fn repl_pretty_print(command string) string {
+	return term.bright_white(term.bg_cyan(' $command '))
 }

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -5,6 +5,7 @@ module util
 
 import os
 import time
+import term
 import v.pref
 import v.vmod
 import v.util.recompilation
@@ -568,4 +569,10 @@ pub fn find_all_v_files(roots []string) ?[]string {
 		files << file
 	}
 	return files
+}
+
+// Highlight a command with an on-brand background to make CLI
+// commands immediately recognizable.
+pub fn pretty_print(command string) string {
+	return term.bright_white(term.bg_cyan(' $command '))
 }


### PR DESCRIPTION
I thought some color might make the prompt nicer. This uses cyan ANSI colors to make the terminal commands more obvious. Previously they were marked by backticks, which I don't think is necessarily intuitive unless you're looking at markdown.

Looks like this in my terminal now:
![Screenshot_20210716_124733](https://user-images.githubusercontent.com/1811218/125982250-1fffaee6-b7e0-404c-8a25-add66e02f9da.png)

This approach should be readable with weird dark themes, too. As a side effect, I changed the instructions on the first line for running a `help` command into running `v help` because that's almost certainly what is intended.