### PR TITLE
cgen: fix other generic pointer cases

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -575,7 +575,7 @@ fn (mut g Gen) base_type(t ast.Type) string {
 	if t.has_flag(.shared_f) {
 		styp = g.find_or_register_shared(t, styp)
 	}
-	nr_muls := t.nr_muls()
+	nr_muls := g.unwrap_generic(t).nr_muls()
 	if nr_muls > 0 {
 		styp += strings.repeat(`*`, nr_muls)
 	}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -590,11 +590,7 @@ fn (mut g Gen) generic_fn_name(types []ast.Type, before string, is_decl bool) st
 	// `foo<int>()` => `foo_T_int()`
 	mut name := before + '_T'
 	for typ in types {
-		nr_muls := typ.nr_muls()
-		if is_decl && nr_muls > 0 {
-			name = strings.repeat(`*`, nr_muls) + name
-		}
-		name += '_' + strings.repeat_string('__ptr__', nr_muls) + g.typ(typ.set_nr_muls(0))
+		name += '_' + strings.repeat_string('__ptr__', typ.nr_muls()) + g.typ(typ.set_nr_muls(0))
 	}
 	return name
 }

--- a/vlib/v/tests/generics_test.v
+++ b/vlib/v/tests/generics_test.v
@@ -16,7 +16,10 @@ fn test_identity() {
 	})['a'] == 'b'
 
 	assert simple<simplemodule.Data>(simplemodule.Data{ value: 8 }).value == 8
-	assert simple<&simplemodule.Data>(&simplemodule.Data{ value: 123 }).value == 123
+	x := &simplemodule.Data{
+		value: 123
+	}
+	assert simple<&simplemodule.Data>(x).value == 123
 }
 
 fn plus<T>(xxx T, b T) T {


### PR DESCRIPTION
Fixes `sync.pool.PoolProcessor.get_item` for pointer types, needed to regen v.c in upcoming parallel cgen PR (#10685).