### PR TITLE
checker: fix generics fn inferring map type (fix #10835)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -667,6 +667,17 @@ pub fn (mut c Checker) infer_fn_generic_types(f ast.Fn, mut call_expr ast.CallEx
 							break
 						}
 					}
+				} else if arg_sym.kind == .map && param_type_sym.kind == .map {
+					arg_map_info := arg_sym.info as ast.Map
+					param_map_info := param_type_sym.info as ast.Map
+					if param_map_info.key_type.has_flag(.generic)
+						&& c.table.get_type_symbol(param_map_info.key_type).name == gt_name {
+						typ = arg_map_info.key_type
+					}
+					if param_map_info.value_type.has_flag(.generic)
+						&& c.table.get_type_symbol(param_map_info.value_type).name == gt_name {
+						typ = arg_map_info.value_type
+					}
 				} else if param.typ.has_flag(.variadic) {
 					to_set = c.table.mktyp(arg.typ)
 				} else if arg_sym.kind in [.struct_, .interface_, .sum_type] {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -99,7 +99,7 @@ pub fn (mut p Parser) parse_map_type() ast.Type {
 		return 0
 	}
 	key_type_supported := key_type in [ast.string_type_idx, ast.voidptr_type_idx]
-		|| key_sym.kind == .enum_ || key_sym.kind == .placeholder
+		|| key_sym.kind in [.enum_, .placeholder, .any]
 		|| ((key_type.is_int() || key_type.is_float() || is_alias) && !key_type.is_ptr())
 	if !key_type_supported {
 		if is_alias {

--- a/vlib/v/tests/generic_fn_infer_map_test.v
+++ b/vlib/v/tests/generic_fn_infer_map_test.v
@@ -1,4 +1,4 @@
-fn print_map<T>(x map[string]T) string {
+fn print_map<K, V>(x map[K]V) string {
 	println(x)
 	return '$x'
 }
@@ -18,4 +18,19 @@ fn test_generics_infer_map_type() {
 		'one': 'a'
 	}
 	assert print_map(m3) == "{'one': 'a'}"
+
+	m4 := map{
+		1: 'one'
+	}
+	assert print_map(m4) == "{1: 'one'}"
+
+	m5 := map{
+		1.1: 'one'
+	}
+	assert print_map(m5) == "{1.1: 'one'}"
+
+	m6 := map{
+		'a': 'one'
+	}
+	assert print_map(m6) == "{'a': 'one'}"
 }

--- a/vlib/v/tests/generic_fn_infer_map_test.v
+++ b/vlib/v/tests/generic_fn_infer_map_test.v
@@ -1,0 +1,21 @@
+fn print_map<T>(x map[string]T) string {
+	println(x)
+	return '$x'
+}
+
+fn test_generics_infer_map_type() {
+	m1 := map{
+		'one': 1
+	}
+	assert print_map(m1) == "{'one': 1}"
+
+	m2 := map{
+		'one': 1.1
+	}
+	assert print_map(m2) == "{'one': 1.1}"
+
+	m3 := map{
+		'one': 'a'
+	}
+	assert print_map(m3) == "{'one': 'a'}"
+}


### PR DESCRIPTION
This PR fix generics fn inferring map type (fix #10835, fix #10836).

- Fix generics fn inferring map type.
- Add test.

```vlang
fn print_map<K, V>(x map[K]V) string {
	println(x)
	return '$x'
}

fn main() {
	m1 := map{'one': 1}
	assert print_map(m1) == "{'one': 1}"

	m2 := map{'one': 1.1}
	assert print_map(m2) == "{'one': 1.1}"

	m3 := map{'one': 'a'}
	assert print_map(m3) == "{'one': 'a'}"

	m4 := map{1: 'one'}
	assert print_map(m4) == "{1: 'one'}"

	m5 := map{1.1: 'one'}
	assert print_map(m5) == "{1.1: 'one'}"

	m6 := map{'a': 'one'}
	assert print_map(m6) == "{'a': 'one'}"
}

PS D:\Test\v\tt1> v run .
{'one': 1}
{'one': 1.1}
{'one': 'a'}
{1: 'one'}
{1.1: 'one'}
{'a': 'one'}
```