### PR TITLE
all: simplify global_scope processing

### DIFF
--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -142,8 +142,8 @@ fn json(file string) string {
 
 // the ast tree
 struct Tree {
-	table        &ast.Table
-	pref         &pref.Preferences
+	table &ast.Table
+	pref  &pref.Preferences
 mut:
 	root Node // the root of tree
 }

--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -131,13 +131,9 @@ fn json(file string) string {
 		root: new_object()
 		table: ast.new_table()
 		pref: pref
-		global_scope: &ast.Scope{
-			start_pos: 0
-			parent: 0
-		}
 	}
 	// parse file with comment
-	ast_file := parser.parse_file(file, t.table, .parse_comments, t.pref, t.global_scope)
+	ast_file := parser.parse_file(file, t.table, .parse_comments, t.pref)
 	t.root = t.ast_file(ast_file)
 	// generate the ast string
 	s := json_print(t.root)
@@ -148,7 +144,6 @@ fn json(file string) string {
 struct Tree {
 	table        &ast.Table
 	pref         &pref.Preferences
-	global_scope &ast.Scope
 mut:
 	root Node // the root of tree
 }

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -151,9 +151,7 @@ fn (foptions &FormatOptions) format_file(file string) {
 	}
 	table := ast.new_table()
 	// checker := checker.new_checker(table, prefs)
-	file_ast := parser.parse_file(file, table, .parse_comments, prefs, &ast.Scope{
-		parent: 0
-	})
+	file_ast := parser.parse_file(file, table, .parse_comments, prefs)
 	// checker.check(file_ast)
 	formatted_content := fmt.fmt(file_ast, table, prefs, foptions.is_debug)
 	file_name := os.file_name(file)
@@ -175,9 +173,7 @@ fn (foptions &FormatOptions) format_pipe() {
 	input_text := os.get_raw_lines_joined()
 	table := ast.new_table()
 	// checker := checker.new_checker(table, prefs)
-	file_ast := parser.parse_text(input_text, '', table, .parse_comments, prefs, &ast.Scope{
-		parent: 0
-	})
+	file_ast := parser.parse_text(input_text, '', table, .parse_comments, prefs)
 	// checker.check(file_ast)
 	formatted_content := fmt.fmt(file_ast, table, prefs, foptions.is_debug)
 	print(formatted_content)

--- a/cmd/tools/vtest-parser.v
+++ b/cmd/tools/vtest-parser.v
@@ -61,8 +61,7 @@ fn main() {
 			time.sleep(ms * time.millisecond)
 			exit(ecode_timeout)
 		}(context.timeout_ms)
-		_ := parser.parse_text(source, context.path, context.table, .skip_comments, context.pref,
-			context.scope)
+		_ := parser.parse_text(source, context.path, context.table, .skip_comments, context.pref)
 		context.log('> worker ${pid:5} finished parsing $context.path')
 		exit(0)
 	} else {

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -16,6 +16,7 @@ pub mut:
 	dumps              map[int]string // needed for efficiently generating all _v_dump_expr_TNAME() functions
 	imports            []string       // List of all imports
 	modules            []string       // Topologically sorted list of all modules registered by the application
+	global_scope       &Scope
 	cflags             []cflag.CFlag
 	redefined_fns      []string
 	fn_generic_types   map[string][][]Type // for generic functions
@@ -167,6 +168,9 @@ mut:
 pub fn new_table() &Table {
 	mut t := &Table{
 		type_symbols: []TypeSymbol{cap: 64000}
+		global_scope: &Scope{
+			parent: 0
+		}
 		cur_fn: 0
 	}
 	t.register_builtin_type_symbols()

--- a/vlib/v/ast/walker/walker_test.v
+++ b/vlib/v/ast/walker/walker_test.v
@@ -6,10 +6,7 @@ import v.pref
 fn parse_text(text string) &ast.File {
 	tbl := ast.new_table()
 	prefs := pref.new_preferences()
-	scope := &ast.Scope{
-		parent: 0
-	}
-	return parser.parse_text(text, '', tbl, .skip_comments, prefs, scope)
+	return parser.parse_text(text, '', tbl, .skip_comments, prefs)
 }
 
 struct NodeByOffset {

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -18,7 +18,6 @@ pub:
 mut:
 	pref          &pref.Preferences
 	checker       &checker.Checker
-	global_scope  &ast.Scope
 	out_name_c    string
 	out_name_js   string
 	max_nr_errors int = 100
@@ -56,9 +55,6 @@ pub fn new_builder(pref &pref.Preferences) Builder {
 		pref: pref
 		table: table
 		checker: checker.new_checker(table, pref)
-		global_scope: &ast.Scope{
-			parent: 0
-		}
 		compiled_dir: compiled_dir
 		max_nr_errors: if pref.error_limit > 0 { pref.error_limit } else { 100 }
 		cached_msvc: msvc
@@ -68,7 +64,7 @@ pub fn new_builder(pref &pref.Preferences) Builder {
 
 pub fn (mut b Builder) front_stages(v_files []string) ? {
 	util.timing_start('PARSE')
-	b.parsed_files = parser.parse_files(v_files, b.table, b.pref, b.global_scope)
+	b.parsed_files = parser.parse_files(v_files, b.table, b.pref)
 	b.parse_imports()
 	mut timers := util.get_timers()
 	timers.show('SCAN')
@@ -146,7 +142,7 @@ pub fn (mut b Builder) parse_imports() {
 					ast_file.path, imp.pos)
 			}
 			// Add all imports referenced by these libs
-			parsed_files := parser.parse_files(v_files, b.table, b.pref, b.global_scope)
+			parsed_files := parser.parse_files(v_files, b.table, b.pref)
 			for file in parsed_files {
 				mut name := file.mod.name
 				if name == '' {

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -96,7 +96,7 @@ pub struct Doc {
 pub mut:
 	prefs     &pref.Preferences = new_vdoc_preferences()
 	base_path string
-	table     &ast.Table      = &ast.Table{}
+	table     &ast.Table      = ast.new_table()
 	checker   checker.Checker = checker.Checker{
 		table: 0
 		pref: 0
@@ -431,15 +431,12 @@ pub fn (mut d Doc) generate() ? {
 	if d.with_comments {
 		comments_mode = .toplevel_comments
 	}
-	global_scope := &ast.Scope{
-		parent: 0
-	}
 	mut file_asts := []ast.File{}
 	for i, file_path in v_files {
 		if i == 0 {
 			d.parent_mod_name = get_parent_mod(d.base_path) or { '' }
 		}
-		file_asts << parser.parse_file(file_path, d.table, comments_mode, d.prefs, global_scope)
+		file_asts << parser.parse_file(file_path, d.table, comments_mode, d.prefs)
 	}
 	return d.file_asts(file_asts)
 }

--- a/vlib/v/doc/module.v
+++ b/vlib/v/doc/module.v
@@ -40,10 +40,7 @@ fn get_parent_mod(input_dir string) ?string {
 		return error('No V files found.')
 	}
 	tbl := ast.new_table()
-	scope := &ast.Scope{
-		parent: 0
-	}
-	file_ast := parser.parse_file(v_files[0], tbl, .skip_comments, prefs, scope)
+	file_ast := parser.parse_file(v_files[0], tbl, .skip_comments, prefs)
 	if file_ast.mod.name == 'main' {
 		return ''
 	}

--- a/vlib/v/fmt/fmt_keep_test.v
+++ b/vlib/v/fmt/fmt_keep_test.v
@@ -54,9 +54,7 @@ fn test_fmt() {
 			continue
 		}
 		table := ast.new_table()
-		file_ast := parser.parse_file(ipath, table, .parse_comments, fpref, &ast.Scope{
-			parent: 0
-		})
+		file_ast := parser.parse_file(ipath, table, .parse_comments, fpref)
 		result_ocontent := fmt.fmt(file_ast, table, fpref, false)
 		if expected_ocontent != result_ocontent {
 			fmt_bench.fail()

--- a/vlib/v/fmt/fmt_test.v
+++ b/vlib/v/fmt/fmt_test.v
@@ -49,9 +49,7 @@ fn test_fmt() {
 			continue
 		}
 		table := ast.new_table()
-		file_ast := parser.parse_file(ipath, table, .parse_comments, fpref, &ast.Scope{
-			parent: 0
-		})
+		file_ast := parser.parse_file(ipath, table, .parse_comments, fpref)
 		result_ocontent := fmt.fmt(file_ast, table, fpref, false)
 		if expected_ocontent != result_ocontent {
 			fmt_bench.fail()

--- a/vlib/v/fmt/fmt_vlib_test.v
+++ b/vlib/v/fmt/fmt_vlib_test.v
@@ -47,9 +47,7 @@ fn test_vlib_fmt() {
 			continue
 		}
 		table := ast.new_table()
-		file_ast := parser.parse_file(ipath, table, .parse_comments, fpref, &ast.Scope{
-			parent: 0
-		})
+		file_ast := parser.parse_file(ipath, table, .parse_comments, fpref)
 		result_ocontent := fmt.fmt(file_ast, table, fpref, false)
 		if expected_ocontent != result_ocontent {
 			fmt_bench.fail()

--- a/vlib/v/gen/native/macho_test.v
+++ b/vlib/v/gen/native/macho_test.v
@@ -8,9 +8,7 @@ fn test_macho() {
 	mut g := native.Gen{
 		pref: &pref.Preferences{}
 		out_name: 'test.bin'
-		table: &ast.Table{
-			cur_fn: 0
-		}
+		table: ast.new_table()
 	}
 	g.generate_macho_header()
 	g.generate_macho_footer()

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -188,7 +188,7 @@ fn (mut p Parser) comp_call() ast.ComptimeCall {
 	}
 	mut scope := &ast.Scope{
 		start_pos: 0
-		parent: p.global_scope
+		parent: p.table.global_scope
 	}
 	$if trace_comptime ? {
 		println('')
@@ -197,7 +197,7 @@ fn (mut p Parser) comp_call() ast.ComptimeCall {
 		println('>>> end of template END')
 		println('')
 	}
-	mut file := parse_comptime(v_code, p.table, p.pref, scope, p.global_scope)
+	mut file := parse_comptime(v_code, p.table, p.pref, scope)
 	file.path = tmpl_path
 	// copy vars from current fn scope into vweb_tmpl scope
 	for stmt in file.stmts {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -22,7 +22,7 @@ pub fn (mut p Parser) parse_array_type() ast.Type {
 				}
 				ast.Ident {
 					mut show_non_const_error := false
-					if const_field := p.global_scope.find_const('${p.mod}.$size_expr.name') {
+					if const_field := p.table.global_scope.find_const('${p.mod}.$size_expr.name') {
 						if const_field.expr is ast.IntegerLiteral {
 							fixed_size = const_field.expr.val.int()
 						} else {

--- a/vlib/v/parser/v_parser_test.v
+++ b/vlib/v/parser/v_parser_test.v
@@ -74,14 +74,9 @@ x := 10
 5+7
 8+4
 '
-	table := &ast.Table{
-		cur_fn: 0
-	}
+	table := ast.new_table()
 	vpref := &pref.Preferences{}
-	gscope := &ast.Scope{
-		parent: 0
-	}
-	prog := parse_file(s, table, .skip_comments, vpref, gscope)
+	prog := parse_file(s, table, .skip_comments, vpref)
 	mut checker := checker.new_checker(table, vpref)
 	checker.check(prog)
 	res := c.gen([prog], table, vpref)


### PR DESCRIPTION
This PR makes simplification of global_scope processing.

- Move `global_scope` from builder to table.
- Simplify all related fn call with global_scope parameter.
- VLS must be also changed.