### PR TITLE
checker: fix generics fn selector expr with unexpected symbol (fix #10850)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1780,7 +1780,7 @@ fn (mut c Checker) fail_if_immutable(expr ast.Expr) (string, token.Position) {
 						c.error('`$typ_sym.kind` can not be modified', expr.pos)
 					}
 				}
-				.aggregate {
+				.aggregate, .placeholder {
 					c.fail_if_immutable(expr.expr)
 				}
 				else {

--- a/vlib/v/tests/generics_fn_return_generic_interface_test.v
+++ b/vlib/v/tests/generics_fn_return_generic_interface_test.v
@@ -4,18 +4,22 @@ interface Iter<T> {
 
 struct ArrayIter<T> {
 	data []T
+mut:
+	index int
 }
 
 fn (mut i ArrayIter<T>) next<T>() ?T {
 	if i.data.len == 0 {
 		return none
 	}
-	return i.data[0]
+	i.index += 1
+	return i.data[i.index]
 }
 
 fn iter<T>(arr []T) Iter<T> {
 	return ArrayIter<T>{
 		data: arr
+		index: 0
 	}
 }
 
@@ -24,5 +28,5 @@ fn test_generics_fn_return_generic_interface() {
 	println(x)
 	y := x.next() or { 0 }
 	println(y)
-	assert y == 1
+	assert y == 2
 }


### PR DESCRIPTION
This PR fix generics fn selector expr with unexpected symbol (fix #10850).

- Fix generics fn selector expr with unexpected symbol.
- Change test.

```vlang
interface Iter<T> {
	next() ?T
}

struct ArrayIter<T> {
	data []T
mut:
	index int
}

fn (mut i ArrayIter<T>) next<T>() ?T {
	if i.data.len == 0 {
		return none
	}
	i.index += 1
	return i.data[i.index]
}

fn iter<T>(arr []T) Iter<T> {
	return ArrayIter<T>{
		data: arr
		index: 0
	}
}

fn main() {
	x := iter([1, 2, 3])
	println(x)
	y := x.next() or { 0 }
	println(y)
	assert y == 2
}

PS D:\Test\v\tt1> v run .
Iter<int>(ArrayIter<int>{
    data: [1, 2, 3]
    index: 0
})
2
```