### PR TITLE
checker, cgen: fix generics interface method (fix #10857)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1470,8 +1470,8 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				// `array << elm`
 				c.check_expr_opt_call(node.right, right_type)
 				node.auto_locked, _ = c.fail_if_immutable(node.left)
-				left_value_type := c.table.value_type(left_type)
-				left_value_sym := c.table.get_type_symbol(left_value_type)
+				left_value_type := c.table.value_type(c.unwrap_generic(left_type))
+				left_value_sym := c.table.get_type_symbol(c.unwrap_generic(left_value_type))
 				if left_value_sym.kind == .interface_ {
 					if right_final.kind != .array {
 						// []Animal << Cat
@@ -1489,8 +1489,9 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					return ast.void_type
 				}
 				// []T << T or []T << []T
-				if c.check_types(right_type, left_value_type)
-					|| c.check_types(right_type, left_type) {
+				unwrapped_right_type := c.unwrap_generic(right_type)
+				if c.check_types(unwrapped_right_type, left_value_type)
+					|| c.check_types(unwrapped_right_type, left_type) {
 					return ast.void_type
 				}
 				c.error('cannot append `$right_sym.name` to `$left_sym.name`', right_pos)

--- a/vlib/v/tests/generics_interface_method_test.v
+++ b/vlib/v/tests/generics_interface_method_test.v
@@ -1,0 +1,35 @@
+interface Iter<T> {
+	next() ?T
+}
+
+fn (mut it Iter<T>) collect<T>() []T {
+	mut data := []T{}
+	for {
+		val := it.next() or { break }
+		data << val
+	}
+	return data
+}
+
+struct ArrayIter<T> {
+	data []T
+mut:
+	index int
+}
+
+fn (mut it ArrayIter<T>) next<T>() ?T {
+	if it.index >= it.data.len {
+		return none
+	}
+	defer {
+		it.index++
+	}
+	return it.data[it.index]
+}
+
+fn test_generics_interface_method() {
+	mut iter := Iter<int>(ArrayIter<int>{
+		data: [1, 2, 3]
+	})
+	assert iter.collect() == [1, 2, 3]
+}


### PR DESCRIPTION
This PR fix generics interface method (fix #10857).

- Fix generics interface method.
- Add test.

```vlang
interface Iter<T> {
	next() ?T
}

fn (mut it Iter<T>) collect<T>() []T {
	mut data := []T{}
	for {
		val := it.next() or { break }
		data << val
	}
	return data
}

struct ArrayIter<T> {
	data []T
mut:
	index int
}

fn (mut it ArrayIter<T>) next<T>() ?T {
	if it.index >= it.data.len {
		return none
	}
	defer {
		it.index++
	}
	return it.data[it.index]
}

fn main() {
	mut iter := Iter<int>(ArrayIter<int>{
		data: [1, 2, 3]
	})
	ret := iter.collect()
	println(ret)
	assert ret == [1, 2, 3]
}

PS D:\Test\v\tt1> v run .
[1, 2, 3]
```