### PR TITLE
checker: prohibit returning a fixed array

### DIFF
--- a/vlib/v/checker/tests/return_fixed_array.out
+++ b/vlib/v/checker/tests/return_fixed_array.out
@@ -1,0 +1,12 @@
+vlib/v/checker/tests/return_fixed_array.vv:1:25: error: fixed array cannot be returned by function
+    1 | fn return_fixed_array() [3]int {
+      |                         ~~~~~~
+    2 |     return [1, 2, 3]!
+    3 | }
+vlib/v/checker/tests/return_fixed_array.vv:5:41: error: fixed array cannot be used in multi-return
+    3 | }
+    4 | 
+    5 | fn return_fixed_array_in_multi_return() ([3]int, [3]int) {
+      |                                         ~~~~~~~~~~~~~~~~
+    6 |     return [1, 2, 3]!, [4, 5, 6]!
+    7 | }

--- a/vlib/v/checker/tests/return_fixed_array.vv
+++ b/vlib/v/checker/tests/return_fixed_array.vv
@@ -1,0 +1,7 @@
+fn return_fixed_array() [3]int {
+	return [1, 2, 3]!
+}
+
+fn return_fixed_array_in_multi_return() ([3]int, [3]int) {
+	return [1, 2, 3]!, [4, 5, 6]!
+}


### PR DESCRIPTION
this pr prohibits returning a fixed array because of undefined behavior, (currently only works on tcc and returning a stack array isn't typically possible in c). closes #10879.