### PR TITLE
table: fix error of generics interface declaration (fix #9714)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1121,6 +1121,12 @@ pub fn (mut t Table) does_type_implement_interface(typ Type, inter_typ Type) boo
 	if typ_sym.language != .v {
 		return false
 	}
+	// generic struct don't generate cast interface fn
+	if typ_sym.info is Struct {
+		if typ_sym.info.is_generic {
+			return false
+		}
+	}
 	mut inter_sym := t.get_type_symbol(inter_typ)
 	if typ_sym.kind == .interface_ && inter_sym.kind == .interface_ {
 		return false

--- a/vlib/v/tests/generics_interface_decl_test.v
+++ b/vlib/v/tests/generics_interface_decl_test.v
@@ -1,0 +1,23 @@
+interface Depends {
+	depends() []Depends
+}
+
+struct Signal<T> {
+}
+
+fn (x Signal<T>) depends() []Depends {
+	return []
+}
+
+struct Add<T> {
+	a Signal<T>
+	b Signal<T>
+}
+
+fn (a Add<T>) depends() []Depends {
+	return [a.a, a.b]
+}
+
+fn test_generics_interface_decl() {
+	assert true
+}


### PR DESCRIPTION
This PR fix error of generics interface declaration (fix #9714).

- Fix error of generics interface declaration.
- Add test.

```vlang
interface Depends {
	depends() []Depends
}

struct Signal<T> {
}

fn (x Signal<T>) depends() []Depends {
	return []
}

struct Add<T> {
	a Signal<T>
	b Signal<T>
}

fn (a Add<T>) depends() []Depends {
	return [a.a, a.b]
}

fn main() {
	assert true
}

PS D:\Test\v\tt1> v run .

```