### PR TITLE
builtin: make `array.delete()` reallocate, provide `.delete_many()`

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -862,6 +862,9 @@ There are further built in methods for arrays:
 * `a.prepend(arr)` insert elements of array `arr` at beginning
 * `a.trim(new_len)` truncate the length (if `new_length < a.len`, otherwise do nothing)
 * `a.clear()` empty the array (without changing `cap`, equivalent to `a.trim(0)`)
+* `a.delete_many(start, size)` removes `size` consecutive elements beginning with index `start`
+  &ndash; triggers reallocation
+* `a.delete(index)` equivalent to `a.delete_many(index, 1)`
 * `v := a.first()` equivalent to `v := a[0]`
 * `v := a.last()` equivalent to `v := a[a.len - 1]`
 * `v := a.pop()` get last element and remove it from array

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -207,8 +207,13 @@ pub fn (mut a array) delete(i int) {
 	}
 	// NB: if a is [12,34], a.len = 2, a.delete(0)
 	// should move (2-0-1) elements = 1 element (the 34) forward
-	unsafe { C.memmove(a.get_unsafe(i), a.get_unsafe(i + 1), (a.len - i - 1) * a.element_size) }
+	old_data := a.data
+	a.data = vcalloc((a.len - 1) * a.element_size)
+	unsafe { C.memcpy(a.data, old_data, i * a.element_size) }
+	unsafe { C.memcpy(&byte(a.data) + i * a.element_size, &byte(old_data) + (i + 1) * a.element_size,
+		(a.len - i - 1) * a.element_size) }
 	a.len--
+	a.cap = a.len
 }
 
 // clear clears the array without deallocating the allocated data.

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -214,14 +214,16 @@ pub fn (mut a array) delete_many(i int, size int) {
 	// NB: if a is [12,34], a.len = 2, a.delete(0)
 	// should move (2-0-1) elements = 1 element (the 34) forward
 	old_data := a.data
-	a.data = vcalloc((a.len - size) * a.element_size)
+	new_size := a.len - size
+	new_cap := if new_size == 0 { 1 } else { new_size }
+	a.data = vcalloc(new_cap * a.element_size)
 	unsafe { C.memcpy(a.data, old_data, i * a.element_size) }
 	unsafe {
 		C.memcpy(&byte(a.data) + i * a.element_size, &byte(old_data) + (i + size) * a.element_size,
 			(a.len - i - size) * a.element_size)
 	}
-	a.len -= size
-	a.cap = a.len
+	a.len = new_size
+	a.cap = new_cap
 }
 
 // clear clears the array without deallocating the allocated data.

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -78,6 +78,19 @@ fn test_slice_delete() {
 	assert c == [3.75, 4.25, -1.5]
 }
 
+fn test_delete_many() {
+	mut a := [1, 2, 3, 4, 5, 6, 7, 8, 9]
+	b := a[2..6]
+	a.delete_many(4, 3)
+	assert a == [1, 2, 3, 4, 8, 9]
+	assert b == [3, 4, 5, 6]
+	c := a[..a.len]
+	a.delete_many(2, 0) // this should just clone
+	a[1] = 17
+	assert a == [1, 17, 3, 4, 8, 9]
+	assert c == [1, 2, 3, 4, 8, 9]
+}
+
 fn test_short() {
 	a := [1, 2, 3]
 	assert a.len == 3

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -65,6 +65,19 @@ fn test_deleting() {
 	assert a.len == 2
 }
 
+fn test_slice_delete() {
+	mut a := [1.5, 2.5, 3.25, 4.5, 5.75]
+	b := a[2..4]
+	a.delete(0)
+	assert a == [2.5, 3.25, 4.5, 5.75]
+	assert b == [3.25, 4.5]
+	a = [3.75, 4.25, -1.5, 2.25, 6.0]
+	c := a[..3]
+	a.delete(2)
+	assert a == [3.75, 4.25, 2.25, 6.0]
+	assert c == [3.75, 4.25, -1.5]
+}
+
 fn test_short() {
 	a := [1, 2, 3]
 	assert a.len == 3

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -89,6 +89,8 @@ fn test_delete_many() {
 	a[1] = 17
 	assert a == [1, 17, 3, 4, 8, 9]
 	assert c == [1, 2, 3, 4, 8, 9]
+	a.delete_many(0, a.len)
+	assert a == []int{}
 }
 
 fn test_short() {


### PR DESCRIPTION
For array slices a "copy on growth" approach has been introduced in #10219. However unexpected behaviour could still occur when `delete()` was used. This PR forces reallocation of the array data when `.delete()` is called on an array.
Furthermore a new array method `.delete_many(index, size)` is added that allows deleting several elements with only one reallocation.
Example:
```v
mut a := [1, 2, 3, 4, 5, 6, 7, 8, 9]
b := a[2..6]
a.delete_many(4, 3)
assert a == [1, 2, 3, 4, 8, 9]
assert b == [3, 4, 5, 6] // `b` was not affected by `delete_many()`
c := a[..a.len]
a.delete(0)
assert a == [2, 3, 4, 8, 9]
assert c == [1, 2, 3, 4, 8, 9] // `c` was not affected by `delete()`
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
