### PR TITLE
vschannel: add missing guards against multiple calls to vschannel_cle…

### DIFF
--- a/thirdparty/vschannel/vschannel.c
+++ b/thirdparty/vschannel/vschannel.c
@@ -60,11 +60,13 @@ void vschannel_cleanup(TlsContext *tls_ctx) {
 	// Close socket.
 	if(tls_ctx->socket != INVALID_SOCKET) {
 		closesocket(tls_ctx->socket);
+		tls_ctx->socket = INVALID_SOCKET;
 	}
 	
 	// Close "MY" certificate store.
 	if(tls_ctx->cert_store) {
 		CertCloseStore(tls_ctx->cert_store, 0);
+		tls_ctx->cert_store = NULL;
 	}
 }
 


### PR DESCRIPTION
Without these, a 2nd (or later) call to vschannel_cleanup will attempt to close an already closed socket (a NOOP), and cause an Access Violation (`0xC0000005`) error when CertCloseStore is called (trying to free already freed memory).