### PR TITLE
cgen: properly support `typeof()`, sizeof(), ... in compile time `for`

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3424,7 +3424,8 @@ fn (mut g Gen) expr(node ast.Expr) {
 			g.select_expr(node)
 		}
 		ast.SizeOf {
-			node_typ := g.unwrap_generic(node.typ)
+			typ := if node.typ == g.field_data_type { g.comp_for_field_value.typ } else { node.typ }
+			node_typ := g.unwrap_generic(typ)
 			sym := g.table.get_type_symbol(node_typ)
 			if sym.language == .v && sym.kind in [.placeholder, .any] {
 				g.error('unknown type `$sym.name`', node.pos)
@@ -3433,7 +3434,8 @@ fn (mut g Gen) expr(node ast.Expr) {
 			g.write('/*SizeOf*/ sizeof(${util.no_dots(styp)})')
 		}
 		ast.IsRefType {
-			node_typ := g.unwrap_generic(node.typ)
+			typ := if node.typ == g.field_data_type { g.comp_for_field_value.typ } else { node.typ }
+			node_typ := g.unwrap_generic(typ)
 			sym := g.table.get_type_symbol(node_typ)
 			if sym.language == .v && sym.kind in [.placeholder, .any] {
 				g.error('unknown type `$sym.name`', node.pos)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3497,7 +3497,8 @@ fn (mut g Gen) expr(node ast.Expr) {
 }
 
 // T.name, typeof(expr).name
-fn (mut g Gen) type_name(typ ast.Type) {
+fn (mut g Gen) type_name(raw_type ast.Type) {
+	typ := if raw_type == g.field_data_type { g.comp_for_field_value.typ } else { raw_type }
 	sym := g.table.get_type_symbol(typ)
 	mut s := ''
 	if sym.kind == .function {

--- a/vlib/v/tests/comptime_for_test.v
+++ b/vlib/v/tests/comptime_for_test.v
@@ -64,6 +64,7 @@ fn test_comptime_for_with_if() {
 
 fn test_comptime_for_fields() {
 	println(@FN)
+	mut fields_found := 0
 	$for field in App.fields {
 		println('  field: $field.name | ' + no_lines('$field'))
 		$if field.typ is string {
@@ -81,5 +82,19 @@ fn test_comptime_for_fields() {
 		if field.is_pub && field.is_mut {
 			assert field.name in ['g', 'h']
 		}
+		if field.name == 'f' {
+			assert sizeof(field) == 8
+			assert isreftype(field) == false
+			// assert typeof(field) == 'u64'
+			assert typeof(field).name == 'u64'
+			fields_found++
+		}
+		if field.name == 'g' {
+			// assert typeof(field) == 'string'
+			assert typeof(field).name == 'string'
+			assert isreftype(field) == true
+			fields_found++
+		}
 	}
+	assert fields_found == 2
 }


### PR DESCRIPTION
This PR allows using special "type-functions" for iterated fields in a compile time for loop. Example:
```v
struct Foo {
    a int
    b f32
    t []f64
    c string
}

fn main() {
    $for field in Foo.fields {
        println(field.name)         // a, b, t, c
        println(typeof(field).name) // int, f32, []f64, string
        println(typeof(field))      // same as above but deprecated
        println(sizeof(field))      // 4, 4, 32, 16
        println(isreftype(field))   // false, false, true, true
    }
}
```
This fixes #10854
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
