### PR TITLE
checker: disallow labels in defer statements

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4468,9 +4468,6 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 			c.inside_const = false
 		}
 		ast.DeferStmt {
-			if c.inside_defer {
-				c.error('defers are not allowed in defer statements', node.pos)
-			}
 			if node.idx_in_fn < 0 {
 				node.idx_in_fn = c.table.cur_fn.defer_stmts.len
 				c.table.cur_fn.defer_stmts << unsafe { &node }

--- a/vlib/v/checker/tests/defer_in_for.out
+++ b/vlib/v/checker/tests/defer_in_for.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/defer_in_for.vv:4:13: error: `break` is not allowed in defer statements
+    2 |     for true {
+    3 |         defer {
+    4 |             break
+      |             ~~~~~
+    5 |         }
+    6 |     }

--- a/vlib/v/checker/tests/defer_in_for.vv
+++ b/vlib/v/checker/tests/defer_in_for.vv
@@ -1,0 +1,7 @@
+fn main() {
+    for true {
+        defer {
+            break
+        }
+    }
+}


### PR DESCRIPTION
This PR disallow `break`, `continue` and `goto` labels in loops inside a defer statement, close #10711 