### PR TITLE
os: fix debugger_present for solaris

### DIFF
--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -7,8 +7,10 @@ import strings
 #include <fcntl.h>
 #include <sys/utsname.h>
 #include <sys/types.h>
-#include <sys/ptrace.h>
 #include <utime.h>
+$if !solaris {
+	#include <sys/ptrace.h>
+}
 
 pub const (
 	path_separator = '/'


### PR DESCRIPTION
- Solaris has no `sys/ptrace.h`, instead `ptrace` is included in  `sys/types.h` and `unistd.h`

see https://github.com/vlang/v/pull/10257



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
