### PR TITLE
parser: error on generic type aliases (until implemented)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3107,6 +3107,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 	}
 	mut sum_variants := []ast.TypeNode{}
 	generic_types := p.parse_generic_type_list()
+	decl_pos_with_generics := decl_pos.extend(p.prev_tok.position())
 	p.check(.assign)
 	mut type_pos := p.tok.position()
 	mut comments := []ast.Comment{}
@@ -3179,6 +3180,10 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		}
 	}
 	// type MyType = int
+	if generic_types.len > 0 {
+		p.error_with_pos('generic type aliases are not yet implemented', decl_pos_with_generics)
+		return ast.AliasTypeDecl{}
+	}
 	parent_type := first_type
 	parent_sym := p.table.get_type_symbol(parent_type)
 	pidx := parent_type.idx()

--- a/vlib/v/parser/tests/generic_type_alias_decl.out
+++ b/vlib/v/parser/tests/generic_type_alias_decl.out
@@ -1,0 +1,3 @@
+vlib/v/parser/tests/generic_type_alias_decl.vv:1:1: error: generic type aliases are not yet implemented
+    1 | type Pointer<T> = &T
+      | ~~~~~~~~~~~~~~~

--- a/vlib/v/parser/tests/generic_type_alias_decl.vv
+++ b/vlib/v/parser/tests/generic_type_alias_decl.vv
@@ -1,0 +1,1 @@
+type Pointer<T> = &T


### PR DESCRIPTION
this pr checks for generic type aliases and raises an unimplemented error. fixes #10915.