### PR TITLE
http: Refactor Response struct

### DIFF
--- a/vlib/net/http/download.v
+++ b/vlib/net/http/download.v
@@ -10,8 +10,8 @@ pub fn download_file(url string, out string) ? {
 		println('download file url=$url out=$out')
 	}
 	s := get(url) or { return err }
-	if s.status != .ok {
-		return error('received http code $s.status')
+	if s.status() != .ok {
+		return error('received http code $s.status_code')
 	}
 	os.write_file(out, s.text) ?
 	// download_file_with_progress(url, out, empty, empty)

--- a/vlib/net/http/download.v
+++ b/vlib/net/http/download.v
@@ -10,8 +10,8 @@ pub fn download_file(url string, out string) ? {
 		println('download file url=$url out=$out')
 	}
 	s := get(url) or { return err }
-	if s.status_code != 200 {
-		return error('received http code $s.status_code')
+	if s.status != .ok {
+		return error('received http code $s.status')
 	}
 	os.write_file(out, s.text) ?
 	// download_file_with_progress(url, out, empty, empty)

--- a/vlib/net/http/http_httpbin_test.v
+++ b/vlib/net/http/http_httpbin_test.v
@@ -37,7 +37,7 @@ fn test_http_fetch_bare() {
 	}
 	responses := http_fetch_mock([], FetchConfig{}) or { panic(err) }
 	for response in responses {
-		assert response.status == .ok
+		assert response.status() == .ok
 	}
 }
 
@@ -68,7 +68,7 @@ fn test_http_fetch_with_params() {
 		// payload := json.decode(HttpbinResponseBody,response.text) or {
 		// panic(err)
 		// }
-		assert response.status == .ok
+		assert response.status() == .ok
 		// TODO
 		// assert payload.args['a'] == 'b'
 		// assert payload.args['c'] == 'd'
@@ -88,7 +88,7 @@ fn test_http_fetch_with_headers() ? {
 		// payload := json.decode(HttpbinResponseBody,response.text) or {
 		// panic(err)
 		// }
-		assert response.status == .ok
+		assert response.status() == .ok
 		// TODO
 		// assert payload.headers['Test-Header'] == 'hello world'
 	}

--- a/vlib/net/http/http_httpbin_test.v
+++ b/vlib/net/http/http_httpbin_test.v
@@ -37,7 +37,7 @@ fn test_http_fetch_bare() {
 	}
 	responses := http_fetch_mock([], FetchConfig{}) or { panic(err) }
 	for response in responses {
-		assert response.status_code == 200
+		assert response.status == .ok
 	}
 }
 
@@ -68,7 +68,7 @@ fn test_http_fetch_with_params() {
 		// payload := json.decode(HttpbinResponseBody,response.text) or {
 		// panic(err)
 		// }
-		assert response.status_code == 200
+		assert response.status == .ok
 		// TODO
 		// assert payload.args['a'] == 'b'
 		// assert payload.args['c'] == 'd'
@@ -88,7 +88,7 @@ fn test_http_fetch_with_headers() ? {
 		// payload := json.decode(HttpbinResponseBody,response.text) or {
 		// panic(err)
 		// }
-		assert response.status_code == 200
+		assert response.status == .ok
 		// TODO
 		// assert payload.headers['Test-Header'] == 'hello world'
 	}

--- a/vlib/net/http/http_test.v
+++ b/vlib/net/http/http_test.v
@@ -16,7 +16,7 @@ fn test_http_get_from_vlang_utc_now() {
 	for url in urls {
 		println('Test getting current time from $url by http.get')
 		res := http.get(url) or { panic(err) }
-		assert res.status == .ok
+		assert res.status() == .ok
 		assert res.text.len > 0
 		assert res.text.int() > 1566403696
 		println('Current time is: $res.text.int()')
@@ -38,7 +38,7 @@ fn test_public_servers() {
 	for url in urls {
 		println('Testing http.get on public url: $url ')
 		res := http.get(url) or { panic(err) }
-		assert res.status == .ok
+		assert res.status() == .ok
 		assert res.text.len > 0
 	}
 }
@@ -50,7 +50,7 @@ fn test_relative_redirects() {
 		return
 	} // tempfix periodic: httpbin relative redirects are broken
 	res := http.get('https://httpbin.org/relative-redirect/3?abc=xyz') or { panic(err) }
-	assert res.status == .ok
+	assert res.status() == .ok
 	assert res.text.len > 0
 	assert res.text.contains('"abc": "xyz"')
 }

--- a/vlib/net/http/http_test.v
+++ b/vlib/net/http/http_test.v
@@ -16,7 +16,7 @@ fn test_http_get_from_vlang_utc_now() {
 	for url in urls {
 		println('Test getting current time from $url by http.get')
 		res := http.get(url) or { panic(err) }
-		assert 200 == res.status_code
+		assert res.status == .ok
 		assert res.text.len > 0
 		assert res.text.int() > 1566403696
 		println('Current time is: $res.text.int()')
@@ -38,7 +38,7 @@ fn test_public_servers() {
 	for url in urls {
 		println('Testing http.get on public url: $url ')
 		res := http.get(url) or { panic(err) }
-		assert 200 == res.status_code
+		assert res.status == .ok
 		assert res.text.len > 0
 	}
 }
@@ -50,7 +50,7 @@ fn test_relative_redirects() {
 		return
 	} // tempfix periodic: httpbin relative redirects are broken
 	res := http.get('https://httpbin.org/relative-redirect/3?abc=xyz') or { panic(err) }
-	assert 200 == res.status_code
+	assert res.status == .ok
 	assert res.text.len > 0
 	assert res.text.contains('"abc": "xyz"')
 }

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -56,7 +56,9 @@ pub fn (req &Request) do() ?Response {
 		}
 		qresp := req.method_and_url_to_response(req.method, rurl) ?
 		resp = qresp
-		if resp.status !in [.moved_permanently, .found, .see_other, .temporary_redirect, .permanent_redirect] {
+		if resp.status !in [.moved_permanently, .found, .see_other, .temporary_redirect,
+			.permanent_redirect,
+		] {
 			break
 		}
 		// follow any redirects

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -56,7 +56,7 @@ pub fn (req &Request) do() ?Response {
 		}
 		qresp := req.method_and_url_to_response(req.method, rurl) ?
 		resp = qresp
-		if resp.status_code !in [301, 302, 303, 307, 308] {
+		if resp.status !in [.moved_permanently, .found, .see_other, .temporary_redirect, .permanent_redirect] {
 			break
 		}
 		// follow any redirects

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -56,7 +56,7 @@ pub fn (req &Request) do() ?Response {
 		}
 		qresp := req.method_and_url_to_response(req.method, rurl) ?
 		resp = qresp
-		if resp.status !in [.moved_permanently, .found, .see_other, .temporary_redirect,
+		if resp.status() !in [.moved_permanently, .found, .see_other, .temporary_redirect,
 			.permanent_redirect,
 		] {
 			break

--- a/vlib/net/http/response.v
+++ b/vlib/net/http/response.v
@@ -9,10 +9,10 @@ import strconv
 // Response represents the result of the request
 pub struct Response {
 pub mut:
-	text        string
-	header      Header
-	status      Status
-	version     Version
+	text    string
+	header  Header
+	status  Status
+	version Version
 }
 
 fn (mut resp Response) free() {
@@ -27,14 +27,14 @@ pub fn (resp Response) bytes() []byte {
 
 // Formats resp to a string suitable for HTTP response transmission
 pub fn (resp Response) bytestr() string {
-	return ('$resp.version ${resp.status.int()} $resp.status\r\n' + '${resp.header.render(
+	return ('$resp.version $resp.status.int() $resp.status\r\n' + '${resp.header.render(
 		version: resp.version
 	)}\r\n' + '$resp.text')
 }
 
 // Parse a raw HTTP response into a Response object
 pub fn parse_response(resp string) ?Response {
-	version, status_int, _ := parse_response_line(resp.all_before('\n'))?
+	version, status_int, _ := parse_response_line(resp.all_before('\n')) ?
 	// Build resp header map and separate the body
 	start_idx, end_idx := find_headers_range(resp) ?
 	header := parse_headers(resp.substr(start_idx, end_idx)) ?
@@ -60,7 +60,7 @@ fn parse_response_line(line string) ?(string, int, string) {
 	if data.len != 3 {
 		return error('expected at least 3 tokens')
 	}
-	return data[0], strconv.atoi(data[1])?, data[2]
+	return data[0], strconv.atoi(data[1]) ?, data[2]
 }
 
 // cookies parses the Set-Cookie headers into Cookie objects

--- a/vlib/net/http/response.v
+++ b/vlib/net/http/response.v
@@ -9,10 +9,10 @@ import strconv
 // Response represents the result of the request
 pub struct Response {
 pub mut:
-	text    string
-	header  Header
-	status_code int
-	status_msg string
+	text         string
+	header       Header
+	status_code  int
+	status_msg   string
 	http_version string
 }
 
@@ -69,9 +69,7 @@ fn parse_status_line(line string) ?(string, int, string) {
 		return error('HTTP version malformed')
 	}
 	for digit in digits {
-		strconv.atoi(digit) or {
-			return error('HTTP version must contain only integers')
-		}
+		strconv.atoi(digit) or { return error('HTTP version must contain only integers') }
 	}
 	return version, strconv.atoi(data[1]) ?, data[2]
 }
@@ -108,14 +106,14 @@ pub fn (mut r Response) set_version(v Version) {
 		return
 	}
 	maj, min := v.protos()
-	r.http_version = '${maj}.${min}'
+	r.http_version = '${maj}.$min'
 }
 
 pub struct ResponseConfig {
 	version Version = .v1_1
-	status Status = .ok
-	header Header
-	text string
+	status  Status  = .ok
+	header  Header
+	text    string
 }
 
 // new_response creates a Response object from the configuration. This

--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -24,12 +24,13 @@ pub fn (mut s Server) listen_and_serve() ? {
 			} $else {
 				eprintln('[$time.now()] $req.method $req.url - 200')
 			}
-			return Response{
-				version: req.version
+			mut r := Response{
 				text: req.data
 				header: req.header
-				status: Status.ok
 			}
+			r.set_status(.ok)
+			r.set_version(req.version)
+			return r
 		}
 	}
 	mut l := net.listen_tcp(.ip6, ':$s.port') ?
@@ -63,8 +64,8 @@ fn (mut s Server) parse_and_respond(mut conn net.TcpConn) {
 		return
 	}
 	mut resp := s.handler(req)
-	if resp.version == .unknown {
-		resp.version = req.version
+	if resp.version() == .unknown {
+		resp.set_version(req.version)
 	}
 	conn.write(resp.bytes()) or { eprintln('error sending response: $err') }
 }

--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -28,8 +28,7 @@ pub fn (mut s Server) listen_and_serve() ? {
 				version: req.version
 				text: req.data
 				header: req.header
-				cookies: req.cookies
-				status_code: int(Status.ok)
+				status: Status.ok
 			}
 		}
 	}

--- a/vlib/net/http/version.v
+++ b/vlib/net/http/version.v
@@ -28,3 +28,13 @@ pub fn version_from_str(v string) Version {
 		else { Version.unknown }
 	}
 }
+
+// protos returns the version major and minor numbers
+pub fn (v Version) protos() (int, int) {
+	match v {
+		.v1_1 { return 1, 1 }
+		.v2_0 { return 2, 1 }
+		.v1_0 { return 1, 0 }
+		.unknown { return 0, 0 }
+	}
+}

--- a/vlib/net/http/version.v
+++ b/vlib/net/http/version.v
@@ -33,7 +33,7 @@ pub fn version_from_str(v string) Version {
 pub fn (v Version) protos() (int, int) {
 	match v {
 		.v1_1 { return 1, 1 }
-		.v2_0 { return 2, 1 }
+		.v2_0 { return 2, 0 }
 		.v1_0 { return 1, 0 }
 		.unknown { return 0, 0 }
 	}

--- a/vlib/vweb/tests/vweb_test.v
+++ b/vlib/vweb/tests/vweb_test.v
@@ -109,7 +109,7 @@ fn test_a_simple_tcp_client_html_page() {
 
 // net.http client based tests follow:
 fn assert_common_http_headers(x http.Response) ? {
-	assert x.status == .ok
+	assert x.status() == .ok
 	assert x.header.get(.server) ? == 'VWeb'
 	assert x.header.get(.content_length) ?.int() > 0
 	assert x.header.get(.connection) ? == 'close'
@@ -130,7 +130,7 @@ fn test_http_client_404() ? {
 	]
 	for url in url_404_list {
 		res := http.get(url) or { panic(err) }
-		assert res.status == .not_found
+		assert res.status() == .not_found
 	}
 }
 
@@ -168,7 +168,7 @@ fn test_http_client_user_repo_settings_page() ? {
 	assert y.text == 'username: kent | repository: golang'
 	//
 	z := http.get('http://127.0.0.1:$sport/missing/golang/settings') or { panic(err) }
-	assert z.status == .not_found
+	assert z.status() == .not_found
 }
 
 struct User {
@@ -231,7 +231,7 @@ fn test_http_client_shutdown_does_not_work_without_a_cookie() {
 		assert err.msg == ''
 		return
 	}
-	assert x.status == .not_found
+	assert x.status() == .not_found
 	assert x.text == '404 Not Found'
 }
 
@@ -247,7 +247,7 @@ fn testsuite_end() {
 		assert err.msg == ''
 		return
 	}
-	assert x.status == .ok
+	assert x.status() == .ok
 	assert x.text == 'good bye'
 }
 

--- a/vlib/vweb/tests/vweb_test.v
+++ b/vlib/vweb/tests/vweb_test.v
@@ -109,7 +109,7 @@ fn test_a_simple_tcp_client_html_page() {
 
 // net.http client based tests follow:
 fn assert_common_http_headers(x http.Response) ? {
-	assert x.status_code == 200
+	assert x.status == .ok
 	assert x.header.get(.server) ? == 'VWeb'
 	assert x.header.get(.content_length) ?.int() > 0
 	assert x.header.get(.connection) ? == 'close'
@@ -130,7 +130,7 @@ fn test_http_client_404() ? {
 	]
 	for url in url_404_list {
 		res := http.get(url) or { panic(err) }
-		assert res.status_code == 404
+		assert res.status == .not_found
 	}
 }
 
@@ -168,7 +168,7 @@ fn test_http_client_user_repo_settings_page() ? {
 	assert y.text == 'username: kent | repository: golang'
 	//
 	z := http.get('http://127.0.0.1:$sport/missing/golang/settings') or { panic(err) }
-	assert z.status_code == 404
+	assert z.status == .not_found
 }
 
 struct User {
@@ -231,7 +231,7 @@ fn test_http_client_shutdown_does_not_work_without_a_cookie() {
 		assert err.msg == ''
 		return
 	}
-	assert x.status_code == 404
+	assert x.status == .not_found
 	assert x.text == '404 Not Found'
 }
 
@@ -247,7 +247,7 @@ fn testsuite_end() {
 		assert err.msg == ''
 		return
 	}
-	assert x.status_code == 200
+	assert x.status == .ok
 	assert x.text == 'good bye'
 }
 

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -17,33 +17,30 @@ pub const (
 		http.CommonHeader.connection.str(): 'close'
 	}) or { panic('should never fail') }
 
-	http_400          = http.Response{
-		version: .v1_1
+	http_400          = http.new_response(
 		status: .bad_request
 		text: '400 Bad Request'
-		header: http.new_header_from_map(map{
-			http.CommonHeader.content_type:   'text/plain'
-			http.CommonHeader.content_length: '15'
-		}).join(headers_close)
-	}
-	http_404 = http.Response{
-		version: .v1_1
+		header: http.new_header(
+			key: .content_type
+			value: 'text/plain'
+		).join(headers_close)
+	)
+	http_404 = http.new_response(
 		status: .not_found
 		text: '404 Not Found'
-		header: http.new_header_from_map(map{
-			http.CommonHeader.content_type:   'text/plain'
-			http.CommonHeader.content_length: '13'
-		}).join(headers_close)
-	}
-	http_500 = http.Response{
-		version: .v1_1
+		header: http.new_header(
+			key: .content_type
+			value: 'text/plain'
+		).join(headers_close)
+	)
+	http_500 = http.new_response(
 		status: .internal_server_error
 		text: '500 Internal Server Error'
-		header: http.new_header_from_map(map{
-			http.CommonHeader.content_type:   'text/plain'
-			http.CommonHeader.content_length: '25'
-		}).join(headers_close)
-	}
+		header: http.new_header(
+			key: .content_type
+			value: 'text/plain'
+		).join(headers_close)
+	)
 	mime_types = map{
 		'.css':  'text/css; charset=utf-8'
 		'.gif':  'image/gif'
@@ -134,12 +131,12 @@ pub fn (mut ctx Context) send_response_to_client(mimetype string, res string) bo
 		http.CommonHeader.content_length: res.len.str()
 	}).join(ctx.header)
 
-	resp := http.Response{
-		version: .v1_1
-		status: http.status_from_int(ctx.status.int()) // TODO: change / remove ctx.status
+	mut resp := http.Response{
 		header: header.join(vweb.headers_close)
 		text: res
 	}
+	resp.set_version(.v1_1)
+	resp.set_status(http.status_from_int(ctx.status.int()))
 	send_string(mut ctx.conn, resp.bytestr()) or { return false }
 	return true
 }

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -25,7 +25,7 @@ pub const (
 			value: 'text/plain'
 		).join(headers_close)
 	)
-	http_404 = http.new_response(
+	http_404          = http.new_response(
 		status: .not_found
 		text: '404 Not Found'
 		header: http.new_header(
@@ -33,7 +33,7 @@ pub const (
 			value: 'text/plain'
 		).join(headers_close)
 	)
-	http_500 = http.new_response(
+	http_500          = http.new_response(
 		status: .internal_server_error
 		text: '500 Internal Server Error'
 		header: http.new_header(
@@ -41,7 +41,7 @@ pub const (
 			value: 'text/plain'
 		).join(headers_close)
 	)
-	mime_types = map{
+	mime_types        = map{
 		'.css':  'text/css; charset=utf-8'
 		'.gif':  'image/gif'
 		'.htm':  'text/html; charset=utf-8'

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -19,7 +19,7 @@ pub const (
 
 	http_400          = http.Response{
 		version: .v1_1
-		status_code: 400
+		status: .bad_request
 		text: '400 Bad Request'
 		header: http.new_header_from_map(map{
 			http.CommonHeader.content_type:   'text/plain'
@@ -28,7 +28,7 @@ pub const (
 	}
 	http_404 = http.Response{
 		version: .v1_1
-		status_code: 404
+		status: .not_found
 		text: '404 Not Found'
 		header: http.new_header_from_map(map{
 			http.CommonHeader.content_type:   'text/plain'
@@ -37,7 +37,7 @@ pub const (
 	}
 	http_500 = http.Response{
 		version: .v1_1
-		status_code: 500
+		status: .internal_server_error
 		text: '500 Internal Server Error'
 		header: http.new_header_from_map(map{
 			http.CommonHeader.content_type:   'text/plain'
@@ -136,7 +136,7 @@ pub fn (mut ctx Context) send_response_to_client(mimetype string, res string) bo
 
 	resp := http.Response{
 		version: .v1_1
-		status_code: ctx.status.int() // TODO: change / remove ctx.status
+		status: http.status_from_int(ctx.status.int()) // TODO: change / remove ctx.status
 		header: header.join(vweb.headers_close)
 		text: res
 	}


### PR DESCRIPTION
This PR has multiple changes to the `http.Response` struct:

* removes `cookies[string]string` field
* changes `version Version` field to `http_version string`
* adds `status_msg string` field
* changes `fn parse_response(string) Response` to `fn parse_response(string) ?Response`
* adds `status() Status` and `set_status(Status)` methods
* adds `version() Version` and `set_version(Version)` methods
* adds `cookies() []Cookie` method

**Updated to reflect current state of PR**
