### PR TITLE
parser: don't require unary `>` prefix for `select` timeout

### DIFF
--- a/cmd/tools/vwatch.v
+++ b/cmd/tools/vwatch.v
@@ -270,7 +270,7 @@ fn (mut context Context) compilation_runner_loop() {
 							return
 						}
 					}
-					> 100 * time.millisecond {
+					100 * time.millisecond {
 						should_restart := RerunCommand.restart in cmds
 						cmds = []
 						if should_restart {

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -3350,7 +3350,7 @@ fn main() {
 			time.sleep(5 * time.millisecond)
 			eprintln('> c: $c was send on channel ch3')
 		}
-		> 500 * time.millisecond {
+		500 * time.millisecond {
 			// do something if no channel has become ready within 0.5s
 			eprintln('> more than 0.5s passed without a channel being ready')
 		}

--- a/vlib/context/README.md
+++ b/vlib/context/README.md
@@ -99,7 +99,7 @@ fn example_with_deadline() {
 	ctx_ch := ctx.done()
 	select {
 		_ := <-ctx_ch {}
-		> 1 * time.second {
+		1 * time.second {
 			panic('This should not happen')
 		}
 	}
@@ -130,7 +130,7 @@ fn example_with_timeout() {
 	ctx_ch := ctx.done()
 	select {
 		_ := <-ctx_ch {}
-		> 1 * time.second {
+		1 * time.second {
 			panic('This should not happen')
 		}
 	}

--- a/vlib/context/deadline_test.v
+++ b/vlib/context/deadline_test.v
@@ -22,7 +22,7 @@ fn test_with_deadline() {
 	ctx_ch := ctx.done()
 	select {
 		_ := <-ctx_ch {}
-		> 1 * time.second {
+		1 * time.second {
 			panic('This should not happen')
 		}
 	}
@@ -41,7 +41,7 @@ fn test_with_timeout() {
 	ctx_ch := ctx.done()
 	select {
 		_ := <-ctx_ch {}
-		> 1 * time.second {
+		1 * time.second {
 			panic('This should not happen')
 		}
 	}

--- a/vlib/sync/channel_select_3_test.v
+++ b/vlib/sync/channel_select_3_test.v
@@ -32,7 +32,7 @@ fn f1(ch1 chan int, ch2 chan St, ch3 chan int, ch4 chan int, ch5 chan int, mut s
 		ch5 <- getint() {
 			a = 9
 		}
-		> 300 * time.millisecond {
+		300 * time.millisecond {
 			a = 3
 		}
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6319,7 +6319,7 @@ pub fn (mut c Checker) select_expr(mut node ast.SelectExpr) ast.Type {
 				if branch.is_timeout {
 					if !branch.stmt.typ.is_int() {
 						tsym := c.table.get_type_symbol(branch.stmt.typ)
-						c.error('invalid type `$tsym.name` for timeout - expected integer type aka `time.Duration`',
+						c.error('invalid type `$tsym.name` for timeout - expected integer number of nanoseconds aka `time.Duration`',
 							branch.stmt.pos)
 					}
 				} else {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2169,9 +2169,6 @@ pub fn (mut f Fmt) select_expr(node ast.SelectExpr) {
 		if branch.is_else {
 			f.write('else {')
 		} else {
-			if branch.is_timeout {
-				f.write('> ')
-			}
 			f.single_line_if = true
 			match branch.stmt {
 				ast.ExprStmt { f.expr(branch.stmt.expr) }

--- a/vlib/v/fmt/tests/select_keep.vv
+++ b/vlib/v/fmt/tests/select_keep.vv
@@ -34,7 +34,7 @@ fn f1(ch1 chan int, ch2 chan St, ch3 chan int, ch4 chan int, ch5 chan int, sem s
 		ch5 <- getint() {
 			a = 9
 		}
-		> 300 * time.millisecond {
+		300 * time.millisecond {
 			a = 3
 		}
 		// post comment

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -310,7 +310,7 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 			has_else = true
 			p.next()
 			/*
-		} else if p.tok.kind == .gt {
+			} else if p.tok.kind == .gt {
 			if has_else {
 				p.error_with_pos('`else` and timeout `> t` are mutually exclusive `select` keys',
 					p.tok.position())
@@ -332,7 +332,7 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 				pos: expr.position()
 				comments: [comment]
 				is_expr: true
-			} */
+			}*/
 		} else {
 			mut is_gt := false
 			if p.tok.kind == .gt {
@@ -377,7 +377,8 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 									*/
 									check_timeout = true
 								} else if is_gt {
-									p.error_with_pos('send expression cannot be used as timeout', stmt.pos)
+									p.error_with_pos('send expression cannot be used as timeout',
+										stmt.pos)
 								}
 							}
 							else {
@@ -423,7 +424,8 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 					}
 				}
 				else {
-					p.error_with_pos('select: transmission statement, timeout (in ns) or `else` expected', stmt.pos)
+					p.error_with_pos('select: transmission statement, timeout (in ns) or `else` expected',
+						stmt.pos)
 					return ast.SelectExpr{}
 				}
 			}

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -309,6 +309,7 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 			is_else = true
 			has_else = true
 			p.next()
+			/*
 		} else if p.tok.kind == .gt {
 			if has_else {
 				p.error_with_pos('`else` and timeout `> t` are mutually exclusive `select` keys',
@@ -331,8 +332,15 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 				pos: expr.position()
 				comments: [comment]
 				is_expr: true
-			}
+			} */
 		} else {
+			mut is_gt := false
+			if p.tok.kind == .gt {
+				is_gt = true
+				p.note_with_pos('`>` is deprecated and will soon be forbidden - just state the timeout in nonoseconds',
+					p.tok.position())
+				p.next()
+			}
 			p.inside_match = true
 			p.inside_select = true
 			exprs, comments := p.expr_list()
@@ -354,6 +362,7 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 			p.inside_select = false
 			match mut stmt {
 				ast.ExprStmt {
+					mut check_timeout := false
 					if !stmt.is_expr {
 						p.error_with_pos('select: invalid expression', stmt.pos)
 						return ast.SelectExpr{}
@@ -361,17 +370,39 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 						match mut stmt.expr {
 							ast.InfixExpr {
 								if stmt.expr.op != .arrow {
+									/*
 									p.error_with_pos('select key: `<-` operator expected',
 										stmt.expr.pos)
 									return ast.SelectExpr{}
+									*/
+									check_timeout = true
+								} else if is_gt {
+									p.error_with_pos('send expression cannot be used as timeout', stmt.pos)
 								}
 							}
 							else {
+								check_timeout = true
+								/*
 								p.error_with_pos('select key: send expression (`ch <- x`) expected',
 									stmt.pos)
 								return ast.SelectExpr{}
+								*/
 							}
 						}
+					}
+					if check_timeout {
+						if has_else {
+							p.error_with_pos('`else` and timeout value are mutually exclusive `select` keys',
+								p.tok.position())
+							return ast.SelectExpr{}
+						}
+						if has_timeout {
+							p.error_with_pos('at most one timeout branch allowed in `select` block',
+								p.tok.position())
+							return ast.SelectExpr{}
+						}
+						is_timeout = true
+						has_timeout = true
 					}
 				}
 				ast.AssignStmt {
@@ -392,7 +423,7 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 					}
 				}
 				else {
-					p.error_with_pos('select: transmission statement expected', stmt.pos)
+					p.error_with_pos('select: transmission statement, timeout (in ns) or `else` expected', stmt.pos)
 					return ast.SelectExpr{}
 				}
 			}

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -313,7 +313,7 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 			mut is_gt := false
 			if p.tok.kind == .gt {
 				is_gt = true
-				p.note_with_pos('`>` is deprecated and will soon be forbidden - just state the timeout in nonoseconds',
+				p.note_with_pos('`>` is deprecated and will soon be forbidden - just state the timeout in nanoseconds',
 					p.tok.position())
 				p.next()
 			}

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -309,30 +309,6 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 			is_else = true
 			has_else = true
 			p.next()
-			/*
-			} else if p.tok.kind == .gt {
-			if has_else {
-				p.error_with_pos('`else` and timeout `> t` are mutually exclusive `select` keys',
-					p.tok.position())
-				return ast.SelectExpr{}
-			}
-			if has_timeout {
-				p.error_with_pos('at most one timeout `> t` branch allowed in `select` block',
-					p.tok.position())
-				return ast.SelectExpr{}
-			}
-			is_timeout = true
-			has_timeout = true
-			p.next()
-			p.inside_match = true
-			expr := p.expr(0)
-			p.inside_match = false
-			stmt = ast.ExprStmt{
-				expr: expr
-				pos: expr.position()
-				comments: [comment]
-				is_expr: true
-			}*/
 		} else {
 			mut is_gt := false
 			if p.tok.kind == .gt {
@@ -370,11 +346,6 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 						match mut stmt.expr {
 							ast.InfixExpr {
 								if stmt.expr.op != .arrow {
-									/*
-									p.error_with_pos('select key: `<-` operator expected',
-										stmt.expr.pos)
-									return ast.SelectExpr{}
-									*/
 									check_timeout = true
 								} else if is_gt {
 									p.error_with_pos('send expression cannot be used as timeout',
@@ -383,11 +354,6 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 							}
 							else {
 								check_timeout = true
-								/*
-								p.error_with_pos('select key: send expression (`ch <- x`) expected',
-									stmt.pos)
-								return ast.SelectExpr{}
-								*/
 							}
 						}
 					}

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -393,12 +393,12 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 					if check_timeout {
 						if has_else {
 							p.error_with_pos('`else` and timeout value are mutually exclusive `select` keys',
-								p.tok.position())
+								stmt.pos)
 							return ast.SelectExpr{}
 						}
 						if has_timeout {
 							p.error_with_pos('at most one timeout branch allowed in `select` block',
-								p.tok.position())
+								stmt.pos)
 							return ast.SelectExpr{}
 						}
 						is_timeout = true

--- a/vlib/v/parser/tests/select_bad_key_1.out
+++ b/vlib/v/parser/tests/select_bad_key_1.out
@@ -1,3 +1,10 @@
+vlib/v/parser/tests/select_bad_key_1.vv:19:3: notice: `>` is deprecated and will soon be forbidden - just state the timeout in nonoseconds
+   17 |             a++
+   18 |         }
+   19 |         > 50 * time.millisecond {
+      |         ^
+   20 |             println('timeout')
+   21 |         }
 vlib/v/parser/tests/select_bad_key_1.vv:39:8: error: select key: receive expression expected
    37 | fn f3_bad(ch1 chan St) {
    38 |     select {

--- a/vlib/v/parser/tests/select_bad_key_1.out
+++ b/vlib/v/parser/tests/select_bad_key_1.out
@@ -1,4 +1,4 @@
-vlib/v/parser/tests/select_bad_key_1.vv:19:3: notice: `>` is deprecated and will soon be forbidden - just state the timeout in nonoseconds
+vlib/v/parser/tests/select_bad_key_1.vv:19:3: notice: `>` is deprecated and will soon be forbidden - just state the timeout in nanoseconds
    17 |             a++
    18 |         }
    19 |         > 50 * time.millisecond {

--- a/vlib/v/parser/tests/select_bad_key_2.out
+++ b/vlib/v/parser/tests/select_bad_key_2.out
@@ -1,7 +1,7 @@
-vlib/v/parser/tests/select_bad_key_2.vv:7:5: error: select key: `<-` operator expected
+vlib/v/parser/tests/select_bad_key_2.vv:7:3: error: invalid type `f64` for timeout - expected integer number of nanoseconds aka `time.Duration`
     5 |             println(b)
     6 |         }
     7 |         a + 7 {
-      |           ^
+      |         ~~~~~
     8 |             println("shouldn't get here")
     9 |         }

--- a/vlib/v/parser/tests/select_bad_key_2.vv
+++ b/vlib/v/parser/tests/select_bad_key_2.vv
@@ -1,5 +1,5 @@
 fn f3_bad(ch1 chan int) {
-	a := 5
+	a := 3.75
 	select {
 		b := <-ch1 {
 			println(b)

--- a/vlib/v/parser/tests/select_bad_key_3.out
+++ b/vlib/v/parser/tests/select_bad_key_3.out
@@ -1,7 +1,7 @@
-vlib/v/parser/tests/select_bad_key_3.vv:7:3: error: select key: send expression (`ch <- x`) expected
-    5 |             println(b)
-    6 |         }
-    7 |         println(7) {
+vlib/v/parser/tests/select_bad_key_3.vv:6:3: error: invalid type `void` for timeout - expected integer number of nanoseconds aka `time.Duration`
+    4 |             println(b)
+    5 |         }
+    6 |         println(7) {
       |         ~~~~~~~~~~
-    8 |             println("shouldn't get here")
-    9 |         }
+    7 |             println("shouldn't get here")
+    8 |         }

--- a/vlib/v/parser/tests/select_bad_key_3.vv
+++ b/vlib/v/parser/tests/select_bad_key_3.vv
@@ -1,5 +1,4 @@
 fn f3_bad(ch1 chan int) {
-	a := 5
 	select {
 		b := <-ch1 {
 			println(b)

--- a/vlib/v/parser/tests/select_else_1.out
+++ b/vlib/v/parser/tests/select_else_1.out
@@ -1,7 +1,7 @@
-vlib/v/parser/tests/select_else_1.vv:12:3: error: `else` and timeout `> t` are mutually exclusive `select` keys
+vlib/v/parser/tests/select_else_1.vv:12:3: error: `else` and timeout value are mutually exclusive `select` keys
    10 |             println("shouldn't get here")
    11 |         }
-   12 |         > 30 * time.millisecond {
-      |         ^
+   12 |         30 * time.millisecond {
+      |         ~~~~~~~~~~~~~~~~~~~~~
    13 |             println('bad')
    14 |         }

--- a/vlib/v/parser/tests/select_else_1.vv
+++ b/vlib/v/parser/tests/select_else_1.vv
@@ -9,7 +9,7 @@ fn f3_bad(ch1 chan int) {
 		else {
 			println("shouldn't get here")
 		}
-		> 30 * time.millisecond {
+		30 * time.millisecond {
 			println('bad')
 		}
 	}

--- a/vlib/v/parser/tests/select_else_2.out
+++ b/vlib/v/parser/tests/select_else_2.out
@@ -1,4 +1,4 @@
-vlib/v/parser/tests/select_else_2.vv:9:3: notice: `>` is deprecated and will soon be forbidden - just state the timeout in nonoseconds
+vlib/v/parser/tests/select_else_2.vv:9:3: notice: `>` is deprecated and will soon be forbidden - just state the timeout in nanoseconds
     7 |             println(b)
     8 |         }
     9 |         > 30 * time.millisecond {

--- a/vlib/v/parser/tests/select_else_2.out
+++ b/vlib/v/parser/tests/select_else_2.out
@@ -1,3 +1,10 @@
+vlib/v/parser/tests/select_else_2.vv:9:3: notice: `>` is deprecated and will soon be forbidden - just state the timeout in nonoseconds
+    7 |             println(b)
+    8 |         }
+    9 |         > 30 * time.millisecond {
+      |         ^
+   10 |             println('bad')
+   11 |         }
 vlib/v/parser/tests/select_else_2.vv:12:3: error: timeout `> t` and `else` are mutually exclusive `select` keys
    10 |             println('bad')
    11 |         }


### PR DESCRIPTION
The syntax to specify a timeout in a `select` block used to require a `>` as prefix:
```v
select {
    ch <- a {
        // ...
    }
    > 100 * time.millisecond { // old syntax
        // ...
    }
}
```
This PR deprecates the `>` prefix and allows to just specify the timeout value:
```v
select {
    b := <-ch {
        // ...
    }
    ch2 <- a {
        // ...
    }
    100 * time.millisecond { // new syntax
        // ...
    }
}
```
Any integer expression is accepted and interpreted as time in nanoseconds.

`vfmt` removes the `>` prefix from existing code.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
