### PR TITLE
builtin/array: fix multiple array init (fix #10918)

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -55,7 +55,7 @@ fn __new_array_with_array_default(mylen int, cap int, elm_size int, val array) a
 		cap: cap_
 	}
 	for i in 0 .. arr.len {
-		val_clone := val.clone()
+		val_clone := unsafe { val.clone_to_depth(1) }
 		unsafe { arr.set_unsafe(i, &val_clone) }
 	}
 	return arr
@@ -382,7 +382,7 @@ pub fn (a &array) clone_to_depth(depth int) array {
 		cap: a.cap
 	}
 	// Recursively clone-generated elements if array element is array type
-	if depth > 0 {
+	if depth > 0 && a.element_size == sizeof(array) && a.len >= 0 && a.cap >= a.len {
 		for i in 0 .. a.len {
 			ar := array{}
 			unsafe { C.memcpy(&ar, a.get_unsafe(i), int(sizeof(array))) }

--- a/vlib/v/tests/array_init_test.v
+++ b/vlib/v/tests/array_init_test.v
@@ -250,3 +250,10 @@ fn test_array_init_inferred_from_optional() {
 fn read() ?[]string {
 	return error('failed')
 }
+
+fn test_multi_array_update_data() {
+	mut a := [][][]int{len: 2, init: [][]int{len: 3, init: []int{len: 2}}}
+	a[0][1][1] = 2
+	println(a)
+	assert '$a' == '[[[0, 0], [0, 2], [0, 0]], [[0, 0], [0, 0], [0, 0]]]'
+}


### PR DESCRIPTION
This PR fix multiple array init (fix #10918).

- Fix multiple array init.
- Add test.

```vlang
fn main() {
	mut a := [][][]int{len: 2, init: [][]int{len: 3, init: []int{len: 2}}}
	a[0][1][1] = 2
	println(a)
	assert '$a' == '[[[0, 0], [0, 2], [0, 0]], [[0, 0], [0, 0], [0, 0]]]'
}

PS D:\Test\v\tt1> v run .
[[[0, 0], [0, 2], [0, 0]], [[0, 0], [0, 0], [0, 0]]]
```