### PR TITLE
flag: fix panic when given an empty string as args

### DIFF
--- a/vlib/flag/flag.v
+++ b/vlib/flag/flag.v
@@ -212,7 +212,7 @@ fn (mut fs FlagParser) parse_value(longhand string, shorthand byte) []string {
 			should_skip_one = false
 			continue
 		}
-		if arg[0] != `-` {
+		if arg.len == 0 || arg[0] != `-` {
 			continue
 		}
 		if (arg.len == 2 && arg[0] == `-` && arg[1] == shorthand) || arg == full {

--- a/vlib/flag/flag_test.v
+++ b/vlib/flag/flag_test.v
@@ -405,3 +405,8 @@ fn test_dashdash_acts_as_parser_full_stop_dashdash_at_end() ? {
 	args := fp.finalize() ?
 	assert args.len > 0
 }
+
+fn test_empty_string_with_flag() {
+	mut fp := flag.new_flag_parser([''])
+	s := fp.string('something', `s`, 'default', 'Hey parse me')
+}


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

When having a flag which requires to run parse_value and '' is given as a command argument, it will panic due to out of range error.
