### PR TITLE
parser: show better position for sort struct init warning

### DIFF
--- a/vlib/v/checker/tests/struct_short_init_warning.out
+++ b/vlib/v/checker/tests/struct_short_init_warning.out
@@ -1,0 +1,13 @@
+vlib/v/checker/tests/struct_short_init_warning.vv:6:9: warning: short struct initalization is deprecated, use explicit struct name
+    4 |
+    5 | fn f(foo Foo) Foo {
+    6 |     return {v: foo.v}
+      |            ~~~~~~~~~~
+    7 | }
+    8 |
+vlib/v/checker/tests/struct_short_init_warning.vv:10:4: warning: short struct initalization is deprecated, use explicit struct name
+    8 |
+    9 | fn main() {
+   10 |     f({v: 10})
+      |       ~~~~~~~
+   11 | }

--- a/vlib/v/checker/tests/struct_short_init_warning.vv
+++ b/vlib/v/checker/tests/struct_short_init_warning.vv
@@ -1,0 +1,11 @@
+struct Foo {
+	v int
+}
+
+fn f(foo Foo) Foo {
+	return {v: foo.v}
+}
+
+fn main() {
+	f({v: 10})
+}

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -312,9 +312,9 @@ pub fn (mut p Parser) check_expr(precedence int) ?ast.Expr {
 					node = p.assoc()
 				} else if (p.tok.kind == .name && p.peek_tok.kind == .colon)
 					|| p.tok.kind in [.rcbr, .comment, .ellipsis] {
-					p.warn_with_pos('short struct initalization is deprecated, use explicit struct name',
-						p.prev_tok.position())
 					node = p.struct_init(true) // short_syntax: true
+					p.warn_with_pos('short struct initalization is deprecated, use explicit struct name',
+						node.position())
 				} else if p.tok.kind == .name {
 					p.next()
 					return p.error_with_pos('unexpected $p.tok, expecting `:` after struct field name',

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -329,7 +329,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 }
 
 fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
-	first_pos := p.tok.position()
+	first_pos := (if short_syntax && p.prev_tok.kind == .lcbr { p.prev_tok } else { p.tok }).position()
 	typ := if short_syntax { ast.void_type } else { p.parse_type() }
 	p.expr_mod = ''
 	// sym := p.table.get_type_symbol(typ)


### PR DESCRIPTION
Current master prints below error for added test:

```
./vlib/v/checker/tests/struct_short_init_warning.vv:6:9: warning: short struct initalization is deprecated, use explicit struct name
    4 |
    5 | fn f(foo Foo) Foo {
    6 |     return {v: foo.v}
      |            ^
    7 | }
    8 |
./vlib/v/checker/tests/struct_short_init_warning.vv:10:4: warning: short struct initalization is deprecated, use explicit struct name
    8 |
    9 | fn main() {
   10 |     f({v: 10})
      |       ^
   11 | }

```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
