### PR TITLE
cgen: panic with error message when `go` command fails

### DIFF
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -103,7 +103,7 @@ pub fn panic(s string) {
 
 // return a C-API error message matching to `errnum` 
 pub fn c_error_number_str(errnum int) string {
-	c_msg := C.strerror(errnum)
+	c_msg := &byte(C.strerror(errnum))
 	err_msg := string{
 		str: c_msg
 		len: unsafe { C.strlen(c_msg) }

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -101,7 +101,7 @@ pub fn panic(s string) {
 	vhalt()
 }
 
-// return a C-API error message matching to `errnum` 
+// return a C-API error message matching to `errnum`
 pub fn c_error_number_str(errnum int) string {
 	mut err_msg := ''
 	$if freestanding {

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -3,7 +3,7 @@ module builtin
 type FnExitCb = fn ()
 
 fn C.atexit(f FnExitCb) int
-fn C.strerror(int) &byte
+fn C.strerror(int) voidptr
 
 [noreturn]
 fn vhalt() {

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -3,6 +3,7 @@ module builtin
 type FnExitCb = fn ()
 
 fn C.atexit(f FnExitCb) int
+fn C.strerror(int) voidptr
 
 [noreturn]
 fn vhalt() {
@@ -98,6 +99,23 @@ pub fn panic(s string) {
 		}
 	}
 	vhalt()
+}
+
+// return an error message matching the thread local value of `C.errno`
+pub fn c_errno_str() string {
+	c_msg := C.strerror(C.errno)
+	err_msg := string{
+		str: c_msg
+		len: unsafe { C.strlen(c_msg) }
+		is_lit: 1
+	}
+	return err_msg
+}
+
+// panic with an error message matching the thread local value of `C.errno`
+[noreturn]
+pub fn panic_errno() {
+	panic(c_errno_str())
 }
 
 // eprintln prints a message with a line end, to stderr. Both stderr and stdout are flushed.

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -103,13 +103,17 @@ pub fn panic(s string) {
 
 // return a C-API error message matching to `errnum` 
 pub fn c_error_number_str(errnum int) string {
-	c_msg := C.strerror(errnum)
-	err_msg := string{
-		str: &byte(c_msg)
-		len: unsafe { C.strlen(c_msg) }
-		is_lit: 1
+	$if freestanding {
+		return 'error $errnum'
+	} $else {
+		c_msg := C.strerror(errnum)
+		err_msg := string{
+			str: &byte(c_msg)
+			len: unsafe { C.strlen(c_msg) }
+			is_lit: 1
+		}
+		return err_msg
 	}
-	return err_msg
 }
 
 // panic with a C-API error message matching `errnum`

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -3,7 +3,7 @@ module builtin
 type FnExitCb = fn ()
 
 fn C.atexit(f FnExitCb) int
-fn C.strerror(int) voidptr
+fn C.strerror(int) &char
 
 [noreturn]
 fn vhalt() {
@@ -103,9 +103,9 @@ pub fn panic(s string) {
 
 // return a C-API error message matching to `errnum` 
 pub fn c_error_number_str(errnum int) string {
-	c_msg := &byte(C.strerror(errnum))
+	c_msg := C.strerror(errnum)
 	err_msg := string{
-		str: c_msg
+		str: &byte(c_msg)
 		len: unsafe { C.strlen(c_msg) }
 		is_lit: 1
 	}

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -103,17 +103,18 @@ pub fn panic(s string) {
 
 // return a C-API error message matching to `errnum` 
 pub fn c_error_number_str(errnum int) string {
+	mut err_msg := ''
 	$if freestanding {
-		return 'error $errnum'
+		err_msg = 'error $errnum'
 	} $else {
 		c_msg := C.strerror(errnum)
-		err_msg := string{
+		err_msg = string{
 			str: &byte(c_msg)
 			len: unsafe { C.strlen(c_msg) }
 			is_lit: 1
 		}
-		return err_msg
 	}
+	return err_msg
 }
 
 // panic with a C-API error message matching `errnum`

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -3,7 +3,7 @@ module builtin
 type FnExitCb = fn ()
 
 fn C.atexit(f FnExitCb) int
-fn C.strerror(int) voidptr
+fn C.strerror(int) &byte
 
 [noreturn]
 fn vhalt() {

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -101,9 +101,9 @@ pub fn panic(s string) {
 	vhalt()
 }
 
-// return an error message matching the thread local value of `C.errno`
-pub fn c_errno_str() string {
-	c_msg := C.strerror(C.errno)
+// return a C-API error message matching to `errnum` 
+pub fn c_error_number_str(errnum int) string {
+	c_msg := C.strerror(errnum)
 	err_msg := string{
 		str: c_msg
 		len: unsafe { C.strlen(c_msg) }
@@ -112,10 +112,10 @@ pub fn c_errno_str() string {
 	return err_msg
 }
 
-// panic with an error message matching the thread local value of `C.errno`
+// panic with a C-API error message matching `errnum`
 [noreturn]
-pub fn panic_errno() {
-	panic(c_errno_str())
+pub fn panic_error_number(basestr string, errnum int) {
+	panic(basestr + c_error_number_str(errnum))
 }
 
 // eprintln prints a message with a line end, to stderr. Both stderr and stdout are flushed.

--- a/vlib/builtin/builtin_nix.c.v
+++ b/vlib/builtin/builtin_nix.c.v
@@ -136,7 +136,9 @@ fn break_if_debugger_attached() {
 }
 
 // These functions are Windows specific - provide dummys for *nix
-pub fn winapi_lasterr_str() string {}
+pub fn winapi_lasterr_str() string {
+	return ''
+}
 
 [noreturn]
 pub fn panic_lasterr() {}

--- a/vlib/builtin/builtin_nix.c.v
+++ b/vlib/builtin/builtin_nix.c.v
@@ -134,3 +134,9 @@ fn break_if_debugger_attached() {
 		_ = ptr
 	}
 }
+
+// These functions are Windows specific - provide dummys for *nix
+pub fn winapi_lasterr_str() string {}
+
+[noreturn]
+pub fn panic_lasterr() {}

--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -54,6 +54,8 @@ fn C.SymFromAddr(h_process voidptr, address u64, p_displacement voidptr, p_symbo
 
 fn C.SymGetLineFromAddr64(h_process voidptr, address u64, p_displacement voidptr, p_line &Line64) int
 
+fn C.FormatMessage(dwFlags u32, lpSource voidptr, dwMessageId u32, dwLanguageId u32, lpBuffer &voidptr, nSize u32, Arguments voidptr) u32
+
 // Ref - https://docs.microsoft.com/en-us/windows/win32/api/dbghelp/nf-dbghelp-symsetoptions
 const (
 	symopt_undname               = 0x00000002
@@ -276,4 +278,26 @@ fn break_if_debugger_attached() {
 			C.__debugbreak()
 		}
 	}
+}
+
+// return an error message generated from WinAPI's `LastError`
+pub fn winapi_lasterr_str() string {
+	mut msgbuf := &byte(0)
+	err_msg_id := C.GetLastError()
+	res := C.FormatMessage(C.FORMAT_MESSAGE_ALLOCATE_BUFFER | C.FORMAT_MESSAGE_FROM_SYSTEM, C.NULL, err_msg_id, 0, &msgbuf, 0, C.NULL)
+	err_msg := if res == 0 {
+		'unknown error $err_msg_id'
+	} else {
+		string{
+			str: msgbuf
+			len: int(res)
+		}
+	}
+	return err_msg
+}
+
+// panic with an error message generated from WinAPI's `LastError`
+[noreturn]
+pub fn panic_lasterr() {
+	panic(winapi_lasterr_str())
 }

--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -298,6 +298,6 @@ pub fn winapi_lasterr_str() string {
 
 // panic with an error message generated from WinAPI's `LastError`
 [noreturn]
-pub fn panic_lasterr() {
-	panic(winapi_lasterr_str())
+pub fn panic_lasterr(base string) {
+	panic(base + winapi_lasterr_str())
 }

--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -289,7 +289,7 @@ pub fn winapi_lasterr_str() string {
 		'unknown error $err_msg_id'
 	} else {
 		string{
-			str: &byte(msgbuf)
+			str: msgbuf
 			len: int(res)
 		}
 	}

--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -289,7 +289,7 @@ pub fn winapi_lasterr_str() string {
 		'unknown error $err_msg_id'
 	} else {
 		string{
-			str: msgbuf
+			str: &byte(msgbuf)
 			len: int(res)
 		}
 	}

--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -284,7 +284,8 @@ fn break_if_debugger_attached() {
 pub fn winapi_lasterr_str() string {
 	mut msgbuf := &byte(0)
 	err_msg_id := C.GetLastError()
-	res := C.FormatMessage(C.FORMAT_MESSAGE_ALLOCATE_BUFFER | C.FORMAT_MESSAGE_FROM_SYSTEM, C.NULL, err_msg_id, 0, &msgbuf, 0, C.NULL)
+	res := C.FormatMessage(C.FORMAT_MESSAGE_ALLOCATE_BUFFER | C.FORMAT_MESSAGE_FROM_SYSTEM,
+		C.NULL, err_msg_id, 0, &msgbuf, 0, C.NULL)
 	err_msg := if res == 0 {
 		'unknown error $err_msg_id'
 	} else {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6597,7 +6597,7 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 			}
 			c.skip_flags = cur_skip_flags
 			if c.fn_level == 0 && c.pref.output_cross_c && c.ct_cond_stack.len > 0 {
-				c.ct_cond_stack.pop()
+				c.ct_cond_stack.delete_last()
 			}
 		} else {
 			// smartcast sumtypes and interfaces when using `is`

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6087,7 +6087,7 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 			'thread_$tmp'
 		}
 		g.writeln('HANDLE $simple_handle = CreateThread(0,0, (LPTHREAD_START_ROUTINE)$wrapper_fn_name, $arg_tmp_var, 0,0);')
-		g.writeln('if (!$simple_handle) panic_lasterr(tos3("`go ${name}()`: ");')
+		g.writeln('if (!$simple_handle) panic_lasterr(tos3("`go ${name}()`: "));')
 		if node.is_expr && node.call_expr.return_type != ast.void_type {
 			g.writeln('$gohandle_name thread_$tmp = {')
 			g.writeln('\t.ret_ptr = $arg_tmp_var->ret_ptr,')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6087,6 +6087,7 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 			'thread_$tmp'
 		}
 		g.writeln('HANDLE $simple_handle = CreateThread(0,0, (LPTHREAD_START_ROUTINE)$wrapper_fn_name, $arg_tmp_var, 0,0);')
+		g.writeln('if (!$simple_handle) panic_lasterr(tos3("`go ${name}()`: ");')
 		if node.is_expr && node.call_expr.return_type != ast.void_type {
 			g.writeln('$gohandle_name thread_$tmp = {')
 			g.writeln('\t.ret_ptr = $arg_tmp_var->ret_ptr,')
@@ -6098,7 +6099,8 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 		}
 	} else {
 		g.writeln('pthread_t thread_$tmp;')
-		g.writeln('pthread_create(&thread_$tmp, NULL, (void*)$wrapper_fn_name, $arg_tmp_var);')
+		g.writeln('int ${tmp}_thr_res = pthread_create(&thread_$tmp, NULL, (void*)$wrapper_fn_name, $arg_tmp_var);')
+		g.writeln('if (${tmp}_thr_res) panic_error_number(tos3("`go ${name}()`: "), ${tmp}_thr_res);')
 		if !node.is_expr {
 			g.writeln('pthread_detach(thread_$tmp);')
 		}

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -280,6 +280,7 @@ pub fn mark_used(mut table ast.Table, pref &pref.Preferences, ast_files []&ast.F
 		files: ast_files
 		all_fns: all_fns
 		all_consts: all_consts
+		pref: pref
 	}
 	// println( all_fns.keys() )
 	walker.mark_exported_fns()


### PR DESCRIPTION
Failing to create a new thread with a `go` call used to be silently ignored. This has not really been a problem since it is usually possible to create ten thousands of threads on modern operating systems.
There are, however, situations like low-memory (Windows), or number of threads exceeded (Linux - typically >30000) when the `go` command fails and continuing in this case leads to an inconsistent state and might cause the program to hang.

This PR makes a program panic in this case with an error message.

As a side effect four new functions are introduced:
- `c_error_number_str(errnum int)` &ndash; returns the system error message that corresponds to `errnum` (typically `C.errno` or value returned from a system call) as V `string`
- `panic_error_number(basestr string, errnum int)` &ndash; panics with an error message that starts with `basestr` and continues with the system error message that corresponds to `errnum`.
- `winapi_lasterr_str()` - Windows specific function that returns the error message for the last Win-API error
- `panic_lasterr(basestr string)` - Windows specific function that panics with an error message that starts with `basestr` and continues with the error message for the last Win-API error