### PR TITLE
cgen: fix generics interface with multi generic structs (fix #10940)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -180,6 +180,10 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 		name = util.replace_op(name)
 	}
 	if node.is_method {
+		unwrapped_rec_sym := g.table.get_type_symbol(g.unwrap_generic(node.receiver.typ))
+		if unwrapped_rec_sym.kind == .placeholder {
+			return
+		}
 		name = g.cc_type(node.receiver.typ, false) + '_' + name
 		// name = g.table.get_type_symbol(node.receiver.typ).name + '_' + name
 	}

--- a/vlib/v/tests/generics_interface_with_multi_generic_structs_test.v
+++ b/vlib/v/tests/generics_interface_with_multi_generic_structs_test.v
@@ -1,0 +1,58 @@
+interface Iter<T> {
+	next() ?T
+}
+
+fn (it Iter<T>) skip<T>(n int) Iter<T> {
+	return SkipIter<T>{
+		n: n
+	}
+}
+
+struct ArrIter<T> {
+	data []T
+mut:
+	index int
+}
+
+fn (mut it ArrIter<T>) next<T>() ?T {
+	if it.index >= it.data.len {
+		return none
+	}
+	defer {
+		it.index++
+	}
+	return it.data[it.index]
+}
+
+struct SkipIter<T> {
+mut:
+	n    int
+	iter Iter<T>
+}
+
+fn (mut it SkipIter<T>) next<T>() ?T {
+	for it.n > 0 {
+		it.iter.next() ?
+		it.n--
+	}
+	return it.iter.next()
+}
+
+fn test_generics_interface_with_multi_generic_structs() {
+	x := Iter<int>(ArrIter<int>{
+		data: [1, 2, 3]
+	})
+	println(x)
+
+	mut ret := x.next() or { 0 }
+	println(ret)
+	assert ret == 1
+
+	ret = x.next() or { 0 }
+	println(ret)
+	assert ret == 2
+
+	ret = x.next() or { 0 }
+	println(ret)
+	assert ret == 3
+}


### PR DESCRIPTION
This PR fix generics interface with multi generic structs (fix #10940).

- Fix generics interface with multi generic structs.
- Add test.

```vlang
interface Iter<T> {
	next() ?T
}

fn (it Iter<T>) skip<T>(n int) Iter<T> {
	return SkipIter<T>{
		n: n
	}
}

struct ArrIter<T> {
	data []T
mut:
	index int
}

fn (mut it ArrIter<T>) next<T>() ?T {
	if it.index >= it.data.len {
		return none
	}
	defer {
		it.index++
	}
	return it.data[it.index]
}

struct SkipIter<T> {
mut:
	n    int
	iter Iter<T>
}

fn (mut it SkipIter<T>) next<T>() ?T {
	for it.n > 0 {
		it.iter.next() ?
		it.n--
	}
	return it.iter.next()
}

fn main() {
	x := Iter<int>(ArrIter<int>{
		data: [1, 2, 3]
	})
	println(x)

	mut ret := x.next() ?
	println(ret)
	assert ret == 1

	ret = x.next() ?
	println(ret)
	assert ret == 2

	ret = x.next() ?
	println(ret)
	assert ret == 3
}

PS D:\Test\v\tt1> v run .
Iter<int>(ArrIter<int>{
    data: [1, 2, 3]
    index: 0
})
1
2
3
```