### PR TITLE
sokol: define a pixel color format

### DIFF
--- a/vlib/sokol/sapp/sapp.v
+++ b/vlib/sokol/sapp/sapp.v
@@ -27,6 +27,7 @@ pub fn create_desc() C.sg_desc {
 		context: C.sg_context_desc{
 			metal: metal_desc
 			d3d11: d3d11_desc
+			color_format: .bgra8
 		}
 		image_pool_size: 1000
 	}


### PR DESCRIPTION
Pixel color format previously undefined, reverting automatically to the default (`rgba8`).

Setting the pixel color format to `bgra8` does not affect `gg` or `gx`, since `gg` passes color components to `sokol` to handle.

Setting the pixel color format to `bgra8` in particular makes `sokol.sapp`, `gg`, and `ui` compatible with common external graphics libraries, assisting V's pattern of sensible defaults and minimal setup.