### PR TITLE
ci: auto-cancel previous workflows when a new commit is pushed

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,0 +1,15 @@
+name: Cancel previous workflows
+
+on:
+  workflow_run:
+    workflows: ["Code CI", "Sanitized CI"] # the other workflows finish quickly - no need to skip them for now
+    types:
+      - requested
+
+jobs:
+  cancel-previous-workflows:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: styfle/cancel-workflow-action@0.9.0
+      with:
+        workflow_id: ${{ github.event.workflow.id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,14 @@ on:
       - "**.md"
 
 jobs:
+  no-scheduling:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dont schedule all jobs
+        run: sleep 10
+
   code-formatting-perf-regressions:
+    needs: no-scheduling
     runs-on: ubuntu-20.04
     timeout-minutes: 15
     env:
@@ -40,6 +47,7 @@ jobs:
         run: cmd/tools/repeat --max_time 1201 --series 3 --count 20 --nmins 2 --nmaxs 5 --warmup 3 --fail_percent 10 -t 'cd {T} ; ./v -show-timings -o v.c cmd/v' . ./vmaster
 
   ubuntu-tcc:
+    needs: no-scheduling
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     env:
@@ -106,6 +114,7 @@ jobs:
         run: cd cmd/tools/fast && ../../../v fast.v && ./fast
 
   ubuntu-tcc-boehm-gc:
+    needs: no-scheduling
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     env:
@@ -160,6 +169,7 @@ jobs:
           [ "$(stat -c %s leaks.txt)" = "0" ]
 
   misc-tooling:
+    needs: no-scheduling
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     env:
@@ -230,6 +240,7 @@ jobs:
 
 
   alpine-docker-musl-gcc:
+    needs: no-scheduling
     name: alpine-musl
     runs-on: ubuntu-20.04
     timeout-minutes: 60
@@ -259,6 +270,7 @@ jobs:
           ./v -silent test-self
 
   macos:
+    needs: no-scheduling
     runs-on: macOS-latest
     timeout-minutes: 60
     env:
@@ -347,6 +359,7 @@ jobs:
           ../v run examples/build_examples.vsh
 
   ubuntu:
+    needs: no-scheduling
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:
@@ -442,6 +455,7 @@ jobs:
   #        github-token: ${{ secrets.GITHUB_TOKEN }}
 
   ubuntu-clang:
+    needs: no-scheduling
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     env:
@@ -537,6 +551,7 @@ jobs:
 
   # Ubuntu docker pre-built container
   ubuntu-musl:
+    needs: no-scheduling
     name: ubuntu-musl
     runs-on: ubuntu-20.04
     timeout-minutes: 60
@@ -589,6 +604,7 @@ jobs:
   #       run: ./v -silent test-self
 
   windows-gcc:
+    needs: no-scheduling
     runs-on: windows-2019
     timeout-minutes: 60
     env:
@@ -631,6 +647,7 @@ jobs:
         run: .\v.exe -o v2.exe cmd/v && .\v2.exe -o v3.exe cmd/v
 
   windows-msvc:
+    needs: no-scheduling
     runs-on: windows-2019
     timeout-minutes: 60
     env:
@@ -674,6 +691,7 @@ jobs:
         run: .\v.exe -o v2.exe cmd/v && .\v2.exe -o v3.exe cmd/v
 
   windows-tcc:
+    needs: no-scheduling
     runs-on: windows-2019
     timeout-minutes: 60
     env:
@@ -761,6 +779,7 @@ jobs:
         run: .\v.exe -o v2.exe cmd/v && .\v2.exe -o v3.exe cmd/v
 
   parser-silent:
+    needs: no-scheduling
     name: Parser silent mode
     runs-on: ubuntu-20.04
     timeout-minutes: 60
@@ -800,6 +819,7 @@ jobs:
           ./v test-parser -S examples/2048/2048_fuzz.v
 
   v-apps-compile:
+    needs: no-scheduling
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:

--- a/.github/workflows/ci_sanitized.yml
+++ b/.github/workflows/ci_sanitized.yml
@@ -9,7 +9,14 @@ on:
       - "**.md"
 
 jobs:
+  no-scheduling:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dont schedule all jobs
+        run: sleep 10
+
   tests-sanitize-undefined-clang:
+    needs: no-scheduling
     runs-on: ubuntu-20.04
     timeout-minutes: 120
     env:
@@ -35,6 +42,7 @@ jobs:
         run: ./v2 build-examples
 
   tests-sanitize-undefined-gcc:
+    needs: no-scheduling
     runs-on: ubuntu-20.04
     timeout-minutes: 120
     env:
@@ -59,6 +67,7 @@ jobs:
         run: ./v2 build-examples
 
   tests-sanitize-address-clang:
+    needs: no-scheduling
     runs-on: ubuntu-20.04
     timeout-minutes: 120
     env:
@@ -88,6 +97,7 @@ jobs:
         run: ASAN_OPTIONS=detect_leaks=0 ./v build-examples
 
   tests-sanitize-address-msvc:
+    needs: no-scheduling
     runs-on: windows-2019
     timeout-minutes: 120
     env:
@@ -114,6 +124,7 @@ jobs:
           .\v.exe -cflags -fsanitize=address test-self
 
   tests-sanitize-address-gcc:
+    needs: no-scheduling
     runs-on: ubuntu-20.04
     timeout-minutes: 120
     env:
@@ -143,6 +154,7 @@ jobs:
         run: ASAN_OPTIONS=detect_leaks=0 ./v build-examples
 
   tests-sanitize-memory-clang:
+    needs: no-scheduling
     runs-on: ubuntu-20.04
     timeout-minutes: 120
     env:


### PR DESCRIPTION
this should reduce the pending job queue length (and thus make ci startup faster for PRs)



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
