### PR TITLE
sync: Only release semaphore in WaitGroup when there are waiters

### DIFF
--- a/vlib/sync/waitgroup.v
+++ b/vlib/sync/waitgroup.v
@@ -9,6 +9,9 @@ fn C.atomic_fetch_add_u32(voidptr, u32) u32
 [trusted]
 fn C.atomic_load_u32(voidptr) u32
 
+[trusted]
+fn C.atomic_store_u32(voidptr, u32)
+
 // WaitGroup
 // Do not copy an instance of WaitGroup, use a ref instead.
 //
@@ -50,6 +53,8 @@ pub fn (mut wg WaitGroup) add(delta int) {
 		panic('Negative number of jobs in waitgroup')
 	}
 	if new_nrjobs == 0 && num_waiters > 0 {
+		// clear waiters
+		C.atomic_store_u32(&wg.wait_count, 0)
 		for (num_waiters > 0) {
 			wg.sem.post()
 			num_waiters--

--- a/vlib/sync/waitgroup.v
+++ b/vlib/sync/waitgroup.v
@@ -69,6 +69,11 @@ pub fn (mut wg WaitGroup) done() {
 
 // wait blocks until all tasks are done (task count becomes zero)
 pub fn (mut wg WaitGroup) wait() {
+	nrjobs := int(C.atomic_load_u32(&wg.task_count))
+	if nrjobs == 0 {
+		// no need to wait
+		return
+	}
 	C.atomic_fetch_add_u32(&wg.wait_count, 1)
 	wg.sem.wait() // blocks until task_count becomes 0
 }

--- a/vlib/sync/waitgroup.v
+++ b/vlib/sync/waitgroup.v
@@ -48,7 +48,7 @@ pub fn (mut wg WaitGroup) init() {
 pub fn (mut wg WaitGroup) add(delta int) {
 	old_nrjobs := int(C.atomic_fetch_add_u32(&wg.task_count, u32(delta)))
 	new_nrjobs := old_nrjobs + delta
-	mut num_waiters := int(C.atomic_load_u32(&wg.wait_count))
+	mut num_waiters := C.atomic_load_u32(&wg.wait_count)
 	if new_nrjobs < 0 {
 		panic('Negative number of jobs in waitgroup')
 	}

--- a/vlib/sync/waitgroup_test.v
+++ b/vlib/sync/waitgroup_test.v
@@ -27,7 +27,7 @@ fn test_waitgroup_reuse() {
 
 fn test_waitgroup_no_use() {
 	mut done := false
-	go fn(done voidptr) {
+	go fn (done voidptr) {
 		time.sleep(1 * time.second)
 		if *(&bool(done)) == false {
 			panic('test_waitgroup_no_use did not complete in time')

--- a/vlib/sync/waitgroup_test.v
+++ b/vlib/sync/waitgroup_test.v
@@ -10,6 +10,7 @@ fn test_waitgroup_reuse() {
 	mut executed := false
 	go fn (mut wg WaitGroup, executed voidptr) {
 		defer {
+			assert wg.wait_count == 1
 			wg.done()
 		}
 		unsafe {
@@ -19,4 +20,5 @@ fn test_waitgroup_reuse() {
 
 	wg.wait()
 	assert executed
+	assert wg.wait_count == 0
 }

--- a/vlib/sync/waitgroup_test.v
+++ b/vlib/sync/waitgroup_test.v
@@ -12,12 +12,13 @@ fn test_waitgroup_reuse() {
 	mut executed := false
 	go fn (mut wg WaitGroup, executed voidptr) {
 		defer {
-			assert wg.wait_count == 1
 			wg.done()
 		}
 		unsafe {
 			*(&bool(executed)) = true
 		}
+		time.sleep(100 * time.millisecond)
+		assert wg.wait_count == 1
 	}(mut wg, voidptr(&executed))
 
 	wg.wait()

--- a/vlib/sync/waitgroup_test.v
+++ b/vlib/sync/waitgroup_test.v
@@ -1,0 +1,22 @@
+module sync
+
+fn test_waitgroup_reuse() {
+	mut wg := new_waitgroup()
+
+	wg.add(1)
+	wg.done()
+
+	wg.add(1)
+	mut executed := false
+	go fn (mut wg WaitGroup, executed voidptr) {
+		defer {
+			wg.done()
+		}
+		unsafe {
+			*(&bool(executed)) = true
+		}
+	}(mut wg, voidptr(&executed))
+
+	wg.wait()
+	assert executed
+}

--- a/vlib/sync/waitgroup_test.v
+++ b/vlib/sync/waitgroup_test.v
@@ -1,5 +1,7 @@
 module sync
 
+import time
+
 fn test_waitgroup_reuse() {
 	mut wg := new_waitgroup()
 
@@ -21,4 +23,18 @@ fn test_waitgroup_reuse() {
 	wg.wait()
 	assert executed
 	assert wg.wait_count == 0
+}
+
+fn test_waitgroup_no_use() {
+	mut done := false
+	go fn(done voidptr) {
+		time.sleep(1 * time.second)
+		if *(&bool(done)) == false {
+			panic('test_waitgroup_no_use did not complete in time')
+		}
+	}(voidptr(&done))
+
+	mut wg := new_waitgroup()
+	wg.wait()
+	done = true
 }


### PR DESCRIPTION
Closes https://github.com/vlang/v/issues/10959

```v
import sync

fn main() {
	mut wg := sync.new_waitgroup()

	wg.add(1)
	wg.done()

	wg.add(1)
	go fn (mut wg sync.WaitGroup) {
		defer {
			assert false
			wg.done()
		}
		println('executed')
	}(mut wg)

	wg.wait()

	assert true
}
```
```
executed
test.v:12: FAIL: fn anon_fn_8ce6aadc8523cb25_sync__waitgroup_123: assert false
V panic: Assertion failed...
```