### PR TITLE
parser: fix struct init and assign using `sql` variable (fix #10958)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -674,7 +674,7 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 			return p.for_stmt()
 		}
 		.name {
-			if p.tok.lit == 'sql' {
+			if p.tok.lit == 'sql' && p.peek_tok.kind == .name {
 				return p.sql_stmt()
 			}
 			if p.peek_tok.kind == .colon {

--- a/vlib/v/parser/tests/sql_no_db_expr_a.out
+++ b/vlib/v/parser/tests/sql_no_db_expr_a.out
@@ -1,6 +1,5 @@
-vlib/v/parser/tests/sql_no_db_expr_a.vv:3:6: error: invalid expression: unexpected token `:=`, expecting database
-    1 | fn x() {
+vlib/v/parser/tests/sql_no_db_expr_a.vv:4:1: error: invalid expression: unexpected token `}`
     2 |     // SqlStmt
     3 |     sql :=
-      |         ~~
     4 | }
+      | ^

--- a/vlib/v/tests/struct_init_and_assign_test.v
+++ b/vlib/v/tests/struct_init_and_assign_test.v
@@ -1,0 +1,26 @@
+struct FooFoo {
+pub mut:
+	conn Foo
+}
+
+struct Foo {
+	host     string = '127.0.0.1'
+	port     u32    = 3306
+	username string
+	password string
+	dbname   string
+}
+
+fn test_struct_init_and_assign() {
+	mut sql := FooFoo{}
+	sql.conn = Foo{
+		username: 'username'
+		password: 'abc'
+		dbname: 'test'
+	}
+	assert sql.conn.host == '127.0.0.1'
+	assert sql.conn.port == 3306
+	assert sql.conn.username == 'username'
+	assert sql.conn.password == 'abc'
+	assert sql.conn.dbname == 'test'
+}


### PR DESCRIPTION
This PR fix struct init and assign using `sql` variable (fix #10958).

- Fix struct init and assign using `sql` variable.
- Add test.

```vlang
struct FooFoo {
pub mut:
	conn Foo
}

struct Foo {
	host     string = '127.0.0.1'
	port     u32    = 3306
	username string
	password string
	dbname   string
}

fn main() {
	mut sql := FooFoo{}
	sql.conn = Foo{
		username: 'username'
		password: 'abc'
		dbname: 'test'
	}
	assert sql.conn.host == '127.0.0.1'
	assert sql.conn.port == 3306
	assert sql.conn.username == 'username'
	assert sql.conn.password == 'abc'
	assert sql.conn.dbname == 'test'
}

PS D:\Test\v\tt1> v run .
```