### PR TITLE
ci: minor optimization in the cancel workflow

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -2,7 +2,7 @@ name: Cancel previous workflows
 
 on:
   workflow_run:
-    workflows: ["Code CI", "Sanitized CI"] # the other workflows finish quickly - no need to skip them for now
+    workflows: ["Code CI"]
     types:
       - requested
 
@@ -14,4 +14,5 @@ jobs:
       # don't cancel CI for commits pushed to vlang/v#master (if ci is still too slow, this can be removed safely)
       if: ${{ github.event.workflow_run.head_repository.full_name != 'vlang/v' || github.event.workflow_run.head_branch != 'master' }}
       with:
-        workflow_id: ${{ github.event.workflow.id }}
+        # workflow ids for `Code CI` and `Sanitized CI` (from https://api.github.com/repos/vlang/v/actions/workflows):
+        workflow_id: 4577,7940868 # the other workflows finish quickly - no need to skip them


### PR DESCRIPTION
before this we scheduled two additional workflows - one cancelled the `Code CI` workflow, and the other `Sanitized CI`.
This PR now schedules a single `cancel` job which in turn cancels both workflows.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
