### PR TITLE
checker: fix checking array.map() with void fn_call (fix #10982)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1985,7 +1985,7 @@ fn (mut c Checker) check_map_and_filter(is_map bool, elem_typ ast.Type, call_exp
 			}
 		}
 		ast.CallExpr {
-			if is_map && arg_expr.return_type == ast.void_type {
+			if is_map && arg_expr.return_type in [ast.void_type, 0] {
 				c.error('type mismatch, `$arg_expr.name` does not return anything', arg_expr.pos)
 			} else if !is_map && arg_expr.return_type != ast.bool_type {
 				c.error('type mismatch, `$arg_expr.name` must return a bool', arg_expr.pos)
@@ -2767,6 +2767,7 @@ pub fn (mut c Checker) fn_call(mut call_expr ast.CallExpr) ast.Type {
 		}
 		c.fail_if_unreadable(arg.expr, arg.typ, 'argument to print')
 		c.inside_println_arg = false
+		call_expr.return_type = ast.void_type
 		/*
 		// TODO: optimize `struct T{} fn (t &T) str() string {return 'abc'} mut a := []&T{} a << &T{} println(a[0])`
 		// It currently generates:

--- a/vlib/v/checker/tests/array_map_void_fn_err.out
+++ b/vlib/v/checker/tests/array_map_void_fn_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/array_map_void_fn_err.vv:3:12: error: type mismatch, `println` does not return anything
+    1 | fn main(){
+    2 |     array := [1,2,3,4]
+    3 |     array.map(println(it))
+      |               ~~~~~~~~~~~
+    4 | }

--- a/vlib/v/checker/tests/array_map_void_fn_err.vv
+++ b/vlib/v/checker/tests/array_map_void_fn_err.vv
@@ -1,0 +1,4 @@
+fn main(){
+	array := [1,2,3,4]
+	array.map(println(it))
+}


### PR DESCRIPTION
This PR fix checking array.map() with void fn_call (fix #10982).

- Fix checking array.map() with void fn_call.
- Add test.

```vlang
fn main(){
	array := [1,2,3,4]
	array.map(println(it))
}

PS D:\Test\v\tt1> v run .
.\tt1.v:3:12: error: type mismatch, `println` does not return anything
    1 | fn main(){
    2 |     array := [1,2,3,4]
    3 |     array.map(println(it))
      |               ~~~~~~~~~~~
    4 | }
```