### PR TITLE
fix: changes math.big.divmod to return (quotient, remainder)

### DIFF
--- a/vlib/math/big/big.v
+++ b/vlib/math/big/big.v
@@ -135,9 +135,9 @@ pub fn (n &Number) str() string {
 	}
 	mut digits := []byte{}
 	mut x := n.clone()
-	
+
 	for !x.is_zero() {
-		//changes to reflect new api
+		// changes to reflect new api
 		div, mod := divmod(&x, &big.ten)
 		digits << byte(mod.int()) + `0`
 		x = div

--- a/vlib/math/big/big.v
+++ b/vlib/math/big/big.v
@@ -135,9 +135,10 @@ pub fn (n &Number) str() string {
 	}
 	mut digits := []byte{}
 	mut x := n.clone()
-	div := Number{}
+	
 	for !x.is_zero() {
-		mod := divmod(&x, &big.ten, &div)
+		//changes to reflect new api
+		div, mod := divmod(&x, &big.ten)
 		digits << byte(mod.int()) + `0`
 		x = div
 	}
@@ -192,10 +193,13 @@ pub fn (a &Number) % (b &Number) Number {
 	return c
 }
 
-pub fn divmod(a &Number, b &Number, c &Number) Number {
+// divmod returns a pair of quotient and remainder from div modulo operation
+// between two bignums `a` and `b`
+pub fn divmod(a &Number, b &Number) (Number, Number) {
+	c := Number{}
 	d := Number{}
-	C.bignum_divmod(a, b, c, &d)
-	return d
+	C.bignum_divmod(a, b, &c, &d)
+	return c, d
 }
 
 // //////////////////////////////////////////////////////////

--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -90,7 +90,6 @@ fn test_mod() {
 	assert (big.from_u64(7) % big.from_u64(5)).int() == 2
 }
 
-
 fn test_divmod() {
 	x, y := big.divmod(big.from_u64(13), big.from_u64(10))
 	assert x.int() == 1
@@ -101,9 +100,7 @@ fn test_divmod() {
 	c, d := big.divmod(big.from_u64(7), big.from_u64(5))
 	assert c.int() == 1
 	assert d.int() == 2
-
 }
-
 
 fn test_from_str() {
 	assert big.from_string('9870123').str() == '9870123'

--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -90,6 +90,21 @@ fn test_mod() {
 	assert (big.from_u64(7) % big.from_u64(5)).int() == 2
 }
 
+
+fn test_divmod() {
+	x, y := big.divmod(big.from_u64(13), big.from_u64(10))
+	assert x.int() == 1
+	assert y.int() == 3
+	p, q := big.divmod(big.from_u64(13), big.from_u64(9))
+	assert p.int() == 1
+	assert q.int() == 4
+	c, d := big.divmod(big.from_u64(7), big.from_u64(5))
+	assert c.int() == 1
+	assert d.int() == 2
+
+}
+
+
 fn test_from_str() {
 	assert big.from_string('9870123').str() == '9870123'
 	assert big.from_string('').str() == '0'


### PR DESCRIPTION
The current `divmod` function from `math.big` module was in the form `pub fn divmod(a &Number, b &Number, c &Number) Number`, return only the remainder part of the results. 

This situation doesn't  reflects underlying `C.bignum_divmod` function being wrapped, it should return quotient and remainder instead. 
This pull changes above situation, especially, the `divmod` function to return pair of quotient and remainder. As a notes, this changes  **change signature of divmod API** and makes it reflect how `C.bignum_divmod` works, and make its consistent and in accordance with the other languages of divmod operation.
See python divmod function or golang version of math.bits.Div and math.big.DivMod
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
