### PR TITLE
globals: hot fix for hanging test case

### DIFF
--- a/vlib/v/tests/init_global_test.v
+++ b/vlib/v/tests/init_global_test.v
@@ -115,7 +115,7 @@ fn switch2() u64 {
 	return 0
 }
 
-fn test_global_mutex() {
+fn ktest_global_mutex() {
 	t := go switch2()
 	for _ in 0 .. 2500000 {
 		mtx.@lock()
@@ -128,6 +128,7 @@ fn test_global_mutex() {
 	} else {
 		f2 = 17.0
 	}
+	mtx.unlock()
 	mtx.@rlock()
 	assert (f1 == 17.0 && f2 == 34.0625) || (f1 == 34.0625 && f2 == 17.0)
 	mtx.runlock()

--- a/vlib/v/tests/init_global_test.v
+++ b/vlib/v/tests/init_global_test.v
@@ -115,7 +115,7 @@ fn switch2() u64 {
 	return 0
 }
 
-fn ktest_global_mutex() {
+fn test_global_mutex() {
 	t := go switch2()
 	for _ in 0 .. 2500000 {
 		mtx.@lock()


### PR DESCRIPTION
This is a hot fix for a test case concerning a `__global` mutex &ndash; for manual locking/unlocking.
One `unlock()` was missing which made the test case wait forever...
Fortunately we have the `lock { ... }` syntax for normal cases...
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
