### PR TITLE
cgen: initialize globals directly for simple cases

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1991,7 +1991,7 @@ fn gen_all_registers(mut t Table, without_numbers []string, with_numbers map[str
 }
 
 // is `expr` a literal, i.e. it does not depend on any other declarations (C compile time constant)
-fn (expr Expr) is_literal() bool {
+pub fn (expr Expr) is_literal() bool {
 	match expr {
 		BoolLiteral, CharLiteral, FloatLiteral, IntegerLiteral {
 			return true

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1989,3 +1989,32 @@ fn gen_all_registers(mut t Table, without_numbers []string, with_numbers map[str
 	}
 	return res
 }
+
+// is `expr` a literal, i.e. it does not depend on any other declarations (C compile time constant)
+fn (expr Expr) is_literal() bool {
+	match expr {
+		BoolLiteral, CharLiteral, FloatLiteral, IntegerLiteral {
+			return true
+		}
+		PrefixExpr {
+			return expr.right.is_literal()
+		}
+		InfixExpr {
+			return expr.left.is_literal() && expr.right.is_literal()
+		}
+		ParExpr {
+			return expr.expr.is_literal()
+		}
+		CastExpr {
+			return !expr.has_arg && expr.expr.is_literal()
+				&& (expr.typ.is_ptr() || expr.typ.is_pointer()
+				|| expr.typ in [i8_type, i16_type, int_type, i64_type, byte_type, u8_type, u16_type, u32_type, u64_type, f32_type, f64_type, char_type, bool_type, rune_type])
+		}
+		SizeOf, IsRefType {
+			return expr.is_type || expr.expr.is_literal()
+		}
+		else {
+			return false
+		}
+	}
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5135,8 +5135,13 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 		}
 		styp := g.typ(field.typ)
 		if field.has_expr {
-			g.definitions.writeln('$mod$styp $field.name;')
-			g.global_inits[key].writeln('\t$field.name = ${g.expr_string(field.expr)}; // global')
+			g.definitions.write_string('$mod$styp $field.name')
+			if field.expr.is_literal() {
+				g.definitions.writeln(' = ${g.expr_string(field.expr)}; // global')
+			} else {
+				g.definitions.writeln(';')
+				g.global_inits[key].writeln('\t$field.name = ${g.expr_string(field.expr)}; // global')
+			}
 		} else {
 			default_initializer := g.type_default(field.typ)
 			if default_initializer == '{0}' {

--- a/vlib/v/tests/init_global_test.v
+++ b/vlib/v/tests/init_global_test.v
@@ -36,7 +36,7 @@ __global (
 	sem       sync.Semaphore
 	shmap     shared map[string]f64
 	mtx       sync.RwMutex
-	f1        = f64(34.0625)
+	f1        = f64(545 / (sizeof(f64) + f32(8))) // directly initialized
 	f2        f64
 )
 
@@ -116,6 +116,7 @@ fn switch2() u64 {
 }
 
 fn test_global_mutex() {
+	assert f1 == 34.0625
 	t := go switch2()
 	for _ in 0 .. 2500000 {
 		mtx.@lock()


### PR DESCRIPTION
This PR makes globals be initialized "in place" if the initializer is a C compile time constant.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
