### PR TITLE
fraction: fix numerator and denominator to be public

### DIFF
--- a/vlib/math/fractions/fraction.v
+++ b/vlib/math/fractions/fraction.v
@@ -15,9 +15,9 @@ import math.bits
 // 2. d cannot be set to zero. The factory function will panic.
 // 3. If provided d is negative, it will be made positive. n will change as well.
 struct Fraction {
+pub:
 	n i64
 	d i64
-pub:
 	is_reduced bool
 }
 

--- a/vlib/math/fractions/fraction.v
+++ b/vlib/math/fractions/fraction.v
@@ -16,8 +16,8 @@ import math.bits
 // 3. If provided d is negative, it will be made positive. n will change as well.
 struct Fraction {
 pub:
-	n i64
-	d i64
+	n          i64
+	d          i64
 	is_reduced bool
 }
 


### PR DESCRIPTION
I had to modify the vlang source to get this feature for this gist https://gist.github.com/ubershmekel/4ac792e73cbf68fce766ebe8dafb7156

I want to access the numerator and denominator without resorting to string operations.