### PR TITLE
all: disable automatic dereference of mut var in `for mut` or `fn(mut)` (part 1)

### DIFF
--- a/examples/snek/snek.v
+++ b/examples/snek/snek.v
@@ -45,7 +45,7 @@ fn (mut h HighScore) save() {
 }
 
 fn (mut h HighScore) load() {
-	h = (os.read_file(high_score_file_path) or { '' }).int()
+	unsafe { *h = (os.read_file(high_score_file_path) or { '' }).int() }
 }
 
 struct App {

--- a/examples/snek/snek.v
+++ b/examples/snek/snek.v
@@ -45,7 +45,9 @@ fn (mut h HighScore) save() {
 }
 
 fn (mut h HighScore) load() {
-	unsafe { *h = (os.read_file(high_score_file_path) or { '' }).int() }
+	unsafe {
+		*h = (os.read_file(high_score_file_path) or { '' }).int()
+	}
 }
 
 struct App {

--- a/vlib/cli/command.v
+++ b/vlib/cli/command.v
@@ -60,20 +60,20 @@ pub fn (cmd Command) str() string {
 }
 
 // is_root returns `true` if this `Command` has no parents.
-pub fn (cmd Command) is_root() bool {
+pub fn (cmd &Command) is_root() bool {
 	return isnil(cmd.parent)
 }
 
 // root returns the root `Command` of the command chain.
-pub fn (cmd Command) root() Command {
+pub fn (cmd &Command) root() Command {
 	if cmd.is_root() {
-		return cmd
+		return *cmd
 	}
 	return cmd.parent.root()
 }
 
 // full_name returns the full `string` representation of all commands int the chain.
-pub fn (cmd Command) full_name() string {
+pub fn (cmd &Command) full_name() string {
 	if cmd.is_root() {
 		return cmd.name
 	}

--- a/vlib/math/big/big.v
+++ b/vlib/math/big/big.v
@@ -212,11 +212,11 @@ pub fn (a &Number) is_zero() bool {
 }
 
 pub fn (mut a Number) inc() {
-	C.bignum_inc(&a)
+	C.bignum_inc(a)
 }
 
 pub fn (mut a Number) dec() {
-	C.bignum_dec(&a)
+	C.bignum_dec(a)
 }
 
 pub fn pow(a &Number, b &Number) Number {

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -518,7 +518,9 @@ fn test_rmdir_all() {
 	mut dirs := ['some/dir', 'some/.hidden/directory']
 	$if windows {
 		for mut d in dirs {
-			d = d.replace('/', '\\')
+			unsafe {
+				*d = d.replace('/', '\\')
+			}
 		}
 	}
 	for d in dirs {

--- a/vlib/sqlite/orm.v
+++ b/vlib/sqlite/orm.v
@@ -94,12 +94,12 @@ fn sqlite_stmt_worker(db DB, query string, data orm.QueryData, where orm.QueryDa
 
 fn sqlite_stmt_binder(stmt Stmt, d orm.QueryData, query string, mut c &int) ? {
 	for data in d.data {
-		err := bind(stmt, c, data)
+		err := bind(stmt, *c, data)
 
 		if err != 0 {
 			return stmt.db.error_message(err, query)
 		}
-		c++
+		(*c)++
 	}
 }
 

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1611,21 +1611,21 @@ pub fn (expr Expr) is_lit() bool {
 }
 
 pub fn (expr Expr) is_auto_deref_var() bool {
-	match expr {
-		Ident {
-			if expr.obj is Var {
-				if expr.obj.is_auto_deref {
-					return true
-				}
-			}
-		}
-		PrefixExpr {
-			if expr.op == .amp && expr.right.is_auto_deref_var() {
-				return true
-			}
-		}
-		else {}
-	}
+	// match expr {
+	// 	Ident {
+	// 		if expr.obj is Var {
+	// 			if expr.obj.is_auto_deref {
+	// 				return true
+	// 			}
+	// 		}
+	// 	}
+	// 	PrefixExpr {
+	// 		if expr.op == .amp && expr.right.is_auto_deref_var() {
+	// 			return true
+	// 		}
+	// 	}
+	// 	else {}
+	// }
 	return false
 }
 

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -118,8 +118,8 @@ pub mut:
 	typ Type
 }
 
-pub fn (f Fn) new_method_with_receiver_type(new_type Type) Fn {
-	mut new_method := f
+pub fn (f &Fn) new_method_with_receiver_type(new_type Type) Fn {
+	mut new_method := *f
 	new_method.params = f.params.clone()
 	for i in 1 .. new_method.params.len {
 		if new_method.params[i].typ == new_method.params[0].typ {
@@ -130,8 +130,8 @@ pub fn (f Fn) new_method_with_receiver_type(new_type Type) Fn {
 	return new_method
 }
 
-pub fn (f FnDecl) new_method_with_receiver_type(new_type Type) FnDecl {
-	mut new_method := f
+pub fn (f &FnDecl) new_method_with_receiver_type(new_type Type) FnDecl {
+	mut new_method := *f
 	new_method.params = f.params.clone()
 	for i in 1 .. new_method.params.len {
 		if new_method.params[i].typ == new_method.params[0].typ {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -762,7 +762,9 @@ fn (mut c Checker) unwrap_generic_type(typ ast.Type, generic_names []string, con
 			for imethod in imethods {
 				for mut method in all_methods {
 					if imethod.name == method.name {
-						method = imethod
+						unsafe {
+							*method = imethod
+						}
 					}
 				}
 			}
@@ -870,7 +872,9 @@ pub fn (mut c Checker) generic_insts_to_concrete() {
 						for imethod in imethods {
 							for mut method in all_methods {
 								if imethod.name == method.name {
-									method = imethod
+									unsafe {
+										*method = imethod
+									}
 								}
 							}
 						}
@@ -4381,7 +4385,7 @@ pub fn (mut c Checker) array_init(mut array_init ast.ArrayInit) ast.Type {
 				if !typ.is_ptr() && !typ.is_pointer() && !c.inside_unsafe {
 					typ_sym := c.table.get_type_symbol(typ)
 					if typ_sym.kind != .interface_ {
-						c.mark_as_referenced(mut &expr, true)
+						c.mark_as_referenced(mut expr, true)
 					}
 				}
 				continue

--- a/vlib/v/checker/tests/array_or_map_assign_err.out
+++ b/vlib/v/checker/tests/array_or_map_assign_err.out
@@ -29,7 +29,7 @@ vlib/v/checker/tests/array_or_map_assign_err.vv:10:7: error: cannot copy map: ca
 vlib/v/checker/tests/array_or_map_assign_err.vv:25:8: error: cannot copy map: call `move` or `clone` method (or use a reference)
    23 |
    24 | fn foo(mut m map[string]int) {
-   25 |     m2 := m
+   25 |     m2 := *m
       |           ^
    26 |     m['foo'] = 100
-   27 |     println(m)
+   27 |     println(*m)

--- a/vlib/v/checker/tests/array_or_map_assign_err.vv
+++ b/vlib/v/checker/tests/array_or_map_assign_err.vv
@@ -22,8 +22,8 @@ fn main() {
 }
 
 fn foo(mut m map[string]int) {
-	m2 := m
+	m2 := *m
 	m['foo'] = 100
-	println(m)
+	println(*m)
 	println(m2)
 }

--- a/vlib/v/checker/tests/for_in_mut_val_type.out
+++ b/vlib/v/checker/tests/for_in_mut_val_type.out
@@ -3,40 +3,40 @@ vlib/v/checker/tests/for_in_mut_val_type.vv:3:15: error: `a1` is immutable, it c
     2 |     a1 := [1, 2, 3]
     3 |     for mut j in a1 {
       |                  ~~
-    4 |         j *= 2
+    4 |         unsafe { *j *= 2 }
     5 |     }
 vlib/v/checker/tests/for_in_mut_val_type.vv:7:15: error: `a2` is immutable, it cannot be changed
     5 |     }
     6 |     a2 := [1, 2, 3]!
     7 |     for mut j in a2 {
       |                  ~~
-    8 |         j *= 2
+    8 |         unsafe { *j *= 2 }
     9 |     }
 vlib/v/checker/tests/for_in_mut_val_type.vv:11:18: error: `m` is immutable, it cannot be changed
     9 |     }
    10 |     m := map{'aa': 1, 'bb': 2}
    11 |     for _, mut j in m {
       |                     ^
-   12 |         j *= 2
+   12 |         unsafe { *j *= 2 }
    13 |     }
 vlib/v/checker/tests/for_in_mut_val_type.vv:14:15: error: array literal is immutable, it cannot be changed
-   12 |         j *= 2
+   12 |         unsafe { *j *= 2 }
    13 |     }
    14 |     for mut j in [1, 2, 3] {
       |                  ~~~~~~~~~
-   15 |         j *= 2
+   15 |         unsafe { *j *= 2 }
    16 |     }
 vlib/v/checker/tests/for_in_mut_val_type.vv:17:15: error: array literal is immutable, it cannot be changed
-   15 |         j *= 2
+   15 |         unsafe { *j *= 2 }
    16 |     }
    17 |     for mut j in [1, 2, 3]! {
       |                  ~~~~~~~~~~
-   18 |         j *= 2
+   18 |         unsafe { *j *= 2 }
    19 |     }
 vlib/v/checker/tests/for_in_mut_val_type.vv:20:21: error: map literal is immutable, it cannot be changed
-   18 |         j *= 2
+   18 |         unsafe { *j *= 2 }
    19 |     }
    20 |     for _, mut j in map{'aa': 1, 'bb': 2} {
       |                        ~~~~~~~~~~~~~~~~~~
-   21 |         j *= 2
+   21 |         unsafe { *j *= 2 }
    22 |     }

--- a/vlib/v/checker/tests/for_in_mut_val_type.vv
+++ b/vlib/v/checker/tests/for_in_mut_val_type.vv
@@ -1,23 +1,23 @@
 fn main() {
 	a1 := [1, 2, 3]
 	for mut j in a1 {
-		j *= 2
+		unsafe { *j *= 2 }
 	}
 	a2 := [1, 2, 3]!
 	for mut j in a2 {
-		j *= 2
+		unsafe { *j *= 2 }
 	}
 	m := map{'aa': 1, 'bb': 2}
 	for _, mut j in m {
-		j *= 2
+		unsafe { *j *= 2 }
 	}
 	for mut j in [1, 2, 3] {
-		j *= 2
+		unsafe { *j *= 2 }
 	}
 	for mut j in [1, 2, 3]! {
-		j *= 2
+		unsafe { *j *= 2 }
 	}
 	for _, mut j in map{'aa': 1, 'bb': 2} {
-		j *= 2
+		unsafe { *j *= 2 }
 	}
 }

--- a/vlib/v/checker/tests/no_warning_for_in_mut_var_unused.vv
+++ b/vlib/v/checker/tests/no_warning_for_in_mut_var_unused.vv
@@ -1,7 +1,7 @@
 fn main() {
 	mut arr := [1, 2, 3]
 	for mut v in arr {
-		v = 2
+		unsafe { *v = 2 }
 	}
 	println(arr)
 }

--- a/vlib/v/gen/js/sourcemap/mappings.v
+++ b/vlib/v/gen/js/sourcemap/mappings.v
@@ -109,12 +109,12 @@ fn (mut m Mappings) export_mappings(mut output io.Writer) ? {
 			}
 		}
 
-		vlq.encode(i64(mapping.gen_column - previous_generated_column), mut &output) ?
+		vlq.encode(i64(mapping.gen_column - previous_generated_column), mut output) ?
 		previous_generated_column = mapping.gen_column
 		match mapping.source_position {
 			Empty {}
 			SourcePosition {
-				vlq.encode(i64(mapping.sources_ind - previous_source_index), mut &output) ?
+				vlq.encode(i64(mapping.sources_ind - previous_source_index), mut output) ?
 				previous_source_index = mapping.sources_ind
 				// lines are stored 0-based in SourceMap spec version 3
 				vlq.encode(i64(mapping.source_position.source_line - 1 - previous_source_line), mut
@@ -127,7 +127,7 @@ fn (mut m Mappings) export_mappings(mut output io.Writer) ? {
 				match mapping.names_ind {
 					Empty {}
 					IndexNumber {
-						vlq.encode(i64(mapping.names_ind - previous_name_index), mut &output) ?
+						vlq.encode(i64(mapping.names_ind - previous_name_index), mut output) ?
 						previous_name_index = mapping.names_ind
 					}
 				}

--- a/vlib/v/tests/array_test.v
+++ b/vlib/v/tests/array_test.v
@@ -5,7 +5,9 @@ fn test_for_in_array_named_array() {
 	}
 	for mut elem in array {
 		assert *elem == 1
-		elem = 2
+		unsafe {
+			*elem = 2
+		}
 		assert *elem == 2
 	}
 }

--- a/vlib/v/tests/defer_return_test.v
+++ b/vlib/v/tests/defer_return_test.v
@@ -9,7 +9,7 @@ fn mut_x(mut x Hwe) &Hwe {
 	// defer statement should not have run, yet
 	assert n == 10
 	x.n += 5
-	return &x
+	return x
 }
 
 fn deferer() &Hwe {
@@ -61,7 +61,7 @@ fn option_return_good(mut a Qwe) ?Qwe {
 		a.n += 7
 	}
 	a.n += 3
-	return a
+	return *a
 }
 
 fn test_defer_opt_return() {

--- a/vlib/v/tests/fn_mut_args_test.v
+++ b/vlib/v/tests/fn_mut_args_test.v
@@ -1,7 +1,9 @@
 fn func(mut a []int) {
-	a = [1, 2, 3, 4]
-	println('inside fn: $a')
-	assert '$a' == '[1, 2, 3, 4]'
+	unsafe {
+		*a = [1, 2, 3, 4]
+	}
+	println('inside fn: ${*a}')
+	assert '${*a}' == '[1, 2, 3, 4]'
 }
 
 fn test_fn_mut_args_of_array() {
@@ -12,8 +14,10 @@ fn test_fn_mut_args_of_array() {
 }
 
 fn init_map(mut n map[string]int) {
-	n = map{
-		'one': 1
+	unsafe {
+		*n = map{
+			'one': 1
+		}
 	}
 }
 
@@ -32,7 +36,7 @@ pub mut:
 }
 
 fn pass_array_mut(mut ar []int) int {
-	if ar.len > 0 && ar.last() == 99 {
+	if ar.len > 0 && (*ar).last() == 99 {
 		return 99
 	}
 	return 0
@@ -58,7 +62,7 @@ mut:
 }
 
 fn (mut p Parent) add(mut x ChildInterface) {
-	p.children << x
+	p.children << *x
 }
 
 fn test_fn_mut_args_of_interface() {

--- a/vlib/v/tests/for_in_containers_of_fixed_array_test.v
+++ b/vlib/v/tests/for_in_containers_of_fixed_array_test.v
@@ -16,8 +16,8 @@ fn test_for_mut_in_array_of_fixed_array() {
 	mut arr := [][2]int{len: 3}
 
 	for mut pair in arr {
-		println(pair)
-		rets << '$pair'
+		println(*pair)
+		rets << '${*pair}'
 	}
 	assert rets[0] == '[0, 0]'
 	assert rets[1] == '[0, 0]'
@@ -42,8 +42,8 @@ fn test_for_mut_in_fixed_array_of_fixed_array() {
 	mut arr := [[1, 2]!, [3, 4]!, [5, 6]!]!
 
 	for mut pair in arr {
-		println(pair)
-		rets << '$pair'
+		println(*pair)
+		rets << '${*pair}'
 	}
 	assert rets[0] == '[1, 2]'
 	assert rets[1] == '[3, 4]'
@@ -104,8 +104,8 @@ fn test_for_mut_in_map_of_fixed_array() {
 	}
 
 	for k, mut v in m {
-		println('$k, $v')
-		rets << '$k, $v'
+		println('$k, ${*v}')
+		rets << '$k, ${*v}'
 	}
 	assert rets[0] == 'aa, [1, 2]'
 	assert rets[1] == 'bb, [3, 4]'

--- a/vlib/v/tests/for_in_mut_val_test.v
+++ b/vlib/v/tests/for_in_mut_val_test.v
@@ -1,6 +1,8 @@
 fn foo1(mut arr []int) {
 	for _, mut j in arr {
-		j *= 2
+		unsafe {
+			*j *= 2
+		}
 	}
 }
 
@@ -13,7 +15,9 @@ fn test_for_in_mut_val_of_array() {
 
 fn foo2(mut arr [3]int) {
 	for _, mut j in arr {
-		j *= 2
+		unsafe {
+			*j *= 2
+		}
 	}
 }
 
@@ -41,7 +45,9 @@ fn test_fn_mut_val_of_map() {
 
 fn foo4(mut m map[string][3]int) {
 	for _, mut j in m['hello'] {
-		j *= 2
+		unsafe {
+			*j *= 2
+		}
 	}
 }
 
@@ -60,7 +66,9 @@ fn test_for_in_mut_val_of_map_direct() {
 		'bar': 2
 	}
 	for _, mut j in m {
-		j = 3
+		unsafe {
+			*j = 3
+		}
 	}
 	println(m)
 	assert '$m' == "{'foo': 3, 'bar': 3}"
@@ -76,9 +84,11 @@ fn test_for_in_mut_val_of_map_fixed_array() {
 		}]!
 	}
 	for _, mut j in m {
-		j = [map{
-			'c': 3
-		}]!
+		unsafe {
+			*j = [map{
+				'c': 3
+			}]!
+		}
 	}
 	println(m)
 	assert '$m' == "{'foo': [{'c': 3}], 'bar': [{'c': 3}]}"
@@ -89,8 +99,10 @@ fn test_for_in_mut_val_of_string() {
 	mut c := ['a', 'b']
 	mut ret := []string{}
 	for mut a in c {
-		a = a + b
-		ret << a
+		unsafe {
+			*a = *a + b
+		}
+		ret << *a
 	}
 	println(ret)
 	assert ret == ['ac', 'bc']
@@ -101,8 +113,10 @@ fn test_for_in_mut_val_of_float() {
 	println(values)
 
 	for mut v in values {
-		v = 1.
-		v = v + 1.
+		unsafe {
+			*v = 1.
+			*v = *v + 1.
+		}
 	}
 	println(values)
 	assert values == [2., 2, 2]

--- a/vlib/v/tests/generic_fn_infer_multi_paras_test.v
+++ b/vlib/v/tests/generic_fn_infer_multi_paras_test.v
@@ -20,19 +20,21 @@ fn get_keys_and_values<T>(mut keys []string, mut values []string, mut data T) ([
 			values << data.$(field.name)
 		}
 	}
-	return keys, values, data
+	return *keys, *values, *data
 }
 
 fn awesome<T>(mut data T) {
 	mut keys := []string{}
 	mut values := []string{}
-	keys, values, data = get_keys_and_values(mut keys, mut values, mut data)
+	unsafe {
+		keys, values, *data = get_keys_and_values(mut keys, mut values, mut data)
+	}
 	println(keys)
 	assert keys == ['lang', 'page', 'var_one', 'var_two']
 	println(values)
 	assert values == ['vlang', 'one', 'variable one', 'variable two']
-	println(data)
-	assert '$data'.contains("title: 'what a title'")
+	println(*data)
+	assert '${*data}'.contains("title: 'what a title'")
 }
 
 fn test_generic_fn_infer_multi_paras() {
@@ -41,7 +43,7 @@ fn test_generic_fn_infer_multi_paras() {
 		page: 'one'
 		var_one: 'variable one'
 		var_two: 'variable two'
-		var_three: {
+		var_three: Two_data{
 			title: 'what a title'
 			content: 'what a content'
 		}

--- a/vlib/v/tests/map_complex_fixed_array_test.v
+++ b/vlib/v/tests/map_complex_fixed_array_test.v
@@ -36,9 +36,11 @@ fn test_complex_map_high_order_fixed_array() {
 		}]!]!
 	}
 	for _, mut j in m {
-		j = [[map{
-			'c': 3
-		}]!]!
+		unsafe {
+			*j = [[map{
+				'c': 3
+			}]!]!
+		}
 	}
 	println(m)
 	assert '$m' == "{'foo': [[{'c': 3}]], 'bar': [[{'c': 3}]]}"

--- a/vlib/v/tests/mut_receiver_returned_as_reference_test.v
+++ b/vlib/v/tests/mut_receiver_returned_as_reference_test.v
@@ -18,7 +18,7 @@ fn (mut p Player) set_position(x int, y int) &Player {
 	// TODO: from the point of view of the V programmer,
 	// `p` has still type &Player.
 	// assert typeof(p).name == 'Player'
-	return unsafe { &p }
+	return unsafe { p }
 }
 
 fn test_mut_receiver() {

--- a/vlib/v/tests/mut_test.v
+++ b/vlib/v/tests/mut_test.v
@@ -53,10 +53,12 @@ fn test_mut_3() {
 	mut results := []string{}
 
 	for i, mut v in indices {
-		v = i
-		a := v
-		println('$i $v $a')
-		results << '$i $v $a'
+		unsafe {
+			*v = i
+		}
+		a := *v
+		println('$i ${*v} $a')
+		results << '$i ${*v} $a'
 	}
 	assert results[0] == '0 0 0'
 	assert results[1] == '1 1 1'
@@ -72,7 +74,7 @@ fn f(mut x St) {
 	mut y := St{
 		n: 2
 	}
-	a := x
+	a := *x
 	b := y
 	x.n = 3
 	y.n = 4
@@ -94,15 +96,19 @@ fn test_mut_5() {
 
 	for i, mut v in arr1 {
 		for ii, mut vv in arr2 {
-			v = i
-			a := v
-			println('$i $v $a')
-			results << '$i $v $a'
+			unsafe {
+				*v = i
+			}
+			a := *v
+			println('$i ${*v} $a')
+			results << '$i ${*v} $a'
 
-			vv = ii
-			aa := vv
-			println('$ii $vv $aa')
-			results << '$ii $vv $aa'
+			unsafe {
+				*vv = ii
+			}
+			aa := *vv
+			println('$ii ${*vv} $aa')
+			results << '$ii ${*vv} $aa'
 		}
 	}
 
@@ -120,9 +126,11 @@ fn test_mut_6() {
 	mut results := []int{}
 	mut arr := []int{len: 3}
 	for _, mut v in arr {
-		v = v + 1
-		println(v)
-		results << v
+		unsafe {
+			*v = *v + 1
+		}
+		println(*v)
+		results << *v
 	}
 	assert results[0] == 1
 	assert results[1] == 1
@@ -133,12 +141,14 @@ fn test_mut_7() {
 	mut arr := []int{len: 3}
 	mut results := []int{}
 	for _, mut v in arr {
-		v = v + 1 // v: 1
-		mut vv := v // vv: 1, v: 1
-		vv = vv + v // vv: 2, v: 1
-		println(v)
+		unsafe {
+			*v = *v + 1
+		} // v: 1
+		mut vv := *v // vv: 1, v: 1
+		vv = vv + *v // vv: 2, v: 1
+		println(*v)
 		println(vv)
-		results << v
+		results << *v
 		results << vv
 	}
 	assert results[0] == 1
@@ -152,12 +162,14 @@ fn test_mut_7() {
 fn test_mut_8() {
 	mut indices := []int{len: 1}
 	for i, mut v in indices {
-		v = i
-		mut b := v
+		unsafe {
+			*v = i
+		}
+		mut b := *v
 		println(typeof(i).name)
-		println(typeof(v).name)
+		println(typeof(*v).name)
 		println(typeof(b).name)
-		u := [v, 5, 6]
+		u := [*v, 5, 6]
 		println(typeof(u).name)
 		println(u)
 		assert typeof(b).name == 'int'
@@ -170,17 +182,19 @@ fn test_mut_9() {
 	mut arr := [0, 0, 0]
 	mut results := []string{}
 	for _, mut v in arr {
-		v = v + 1 // v: 1
-		mut vv := v // vv: 1, v: 1
-		vv = vv + v // vv: 2, v: 1
+		unsafe {
+			*v = *v + 1
+		} // v: 1
+		mut vv := *v // vv: 1, v: 1
+		vv = vv + *v // vv: 2, v: 1
 		foo := map{
-			'a': v
+			'a': *v
 			'b': vv
 		}
-		println(v)
+		println(*v)
 		println(vv)
 		println(foo)
-		results << '$v'
+		results << '${*v}'
 		results << '$vv'
 		results << '$foo'
 	}
@@ -199,14 +213,16 @@ fn foo1(mut arr [][]int) {
 	mut results := []int{}
 	for _, mut j in arr {
 		for _, mut k in j {
-			k = k + 1 // k: 1
-			mut kk := k // kk: 1, k: 1
-			kk = kk + k // kk: 2, k: 1
-			k++ // kk: 2, k: 2
+			unsafe {
+				*k = *k + 1
+			} // k: 1
+			mut kk := *k // kk: 1, k: 1
+			kk = kk + *k // kk: 2, k: 1
+			(*k)++ // kk: 2, k: 2
 			kk++ // kk: 3, k: 2
-			println(k)
+			println(*k)
 			println(kk)
-			results << k
+			results << *k
 			results << kk
 		}
 	}
@@ -225,14 +241,16 @@ fn foo2(mut arr [][]int) {
 	mut results := []int{}
 	for _, mut j in arr {
 		for _, mut k in j {
-			k = k + 1 // k: 1
-			mut kk := k // kk: 1, k: 1
-			kk = kk + k // kk: 2, k: 1
-			k-- // kk: 2, k: 2
+			unsafe {
+				*k = *k + 1
+			} // k: 1
+			mut kk := *k // kk: 1, k: 1
+			kk = kk + *k // kk: 2, k: 1
+			(*k)-- // kk: 2, k: 2
 			kk-- // kk: 3, k: 2
-			println(k)
+			println(*k)
 			println(kk)
-			results << k
+			results << *k
 			results << kk
 		}
 	}
@@ -250,9 +268,11 @@ fn test_mut_11() {
 fn foo3(mut arr [][]int) {
 	mut results := []string{}
 	for _, mut j in arr {
-		j[0] += 2
-		println(j) // [2, 0]
-		results << '$j'
+		unsafe {
+			j[0] += 2
+		}
+		println(*j) // [2, 0]
+		results << '${*j}'
 	}
 	assert results[0] == '[2, 0]'
 }
@@ -284,7 +304,7 @@ fn test_mut_13() {
 }
 
 fn foo5(mut arr []int) {
-	arr2 := unsafe { &arr }
+	arr2 := unsafe { arr }
 	arr[0] = 0
 	println(arr[0]) // 0
 	assert arr[0] == 0
@@ -300,7 +320,7 @@ fn test_mut_14() {
 }
 
 fn foo6(mut arr [3]int) {
-	arr2 := unsafe { &arr }
+	arr2 := unsafe { arr }
 	arr[0] = 0
 	println(arr[0]) // 0
 	assert arr[0] == 0
@@ -316,8 +336,10 @@ fn test_mut_15() {
 }
 
 fn foo7(mut m map[string]int) {
-	m2 := unsafe { &m }
-	m['one'] = 1
+	m2 := unsafe { m }
+	unsafe {
+		m['one'] = 1
+	}
 	println(m['one']) // 1
 	assert m['one'] == 1
 	unsafe {
@@ -339,14 +361,16 @@ fn test_mut_17() {
 		'foo': 1
 	}]
 	for _, mut j in arr {
-		mut k := j.clone()
-		j['foo'] = 0
+		mut k := (*j).clone()
+		unsafe {
+			j['foo'] = 0
+		}
 		unsafe {
 			k['foo'] = 10
 		}
-		println(j)
+		println(*j)
 		println(k)
-		assert j == map{
+		assert *j == map{
 			'foo': 0
 		}
 		assert k == map{
@@ -355,16 +379,16 @@ fn test_mut_17() {
 	}
 }
 
-fn foo8(mut a [1]int) {
-	a2 := a
-	a[0] = 100
-	println(a)
-	println(a2)
-	assert '$a' == '[100]'
-	assert '$a2' == '[1]'
-}
+// fn foo8(mut a [1]int) {
+// 	a2 := *a
+// 	a[0] = 100
+// 	println(*a)
+// 	println(a2)
+// 	assert '$(*a)' == '[100]'
+// 	assert '$a2' == '[1]'
+// }
 
-fn test_mut_18() {
-	mut a := [1]!
-	foo8(mut a)
-}
+// fn test_mut_18() {
+// 	mut a := [1]!
+// 	foo8(mut a)
+// }

--- a/vlib/v/tests/type_alias_of_pointer_types_test.v
+++ b/vlib/v/tests/type_alias_of_pointer_types_test.v
@@ -68,7 +68,9 @@ fn mut_alias(mut ps PZZMyStructInt) int {
 	//	dump(ptr_str(voidptr(ps)))
 	another := &MyStructInt{789}
 	//	dump(ptr_str(voidptr(another)))
-	ps = PZZMyStructInt(another)
+	unsafe {
+		*ps = PZZMyStructInt(another)
+	}
 	//	dump(ptr_str(voidptr(ps)))
 	return 123
 }


### PR DESCRIPTION
This PR disable automatic dereference of mut var in `for mut` or `fn(mut)` (part 1).

part 1:
- Disable `is_auto_deref_var()` to return false.
- Modify all the related call.

part 2 (next pr):
- Remove `is_auto_deref_var()`.
- Modify all the related call.