### PR TITLE
cgen: dont generate function if its flag is false

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -392,12 +392,13 @@ pub:
 	attrs           []Attr
 	ctdefine_idx    int = -1 // the index in fn.attrs of `[if xyz]`, when such attribute exists
 pub mut:
-	params          []Param
-	stmts           []Stmt
-	defer_stmts     []DeferStmt
-	return_type     Type
-	return_type_pos token.Position // `string` in `fn (u User) name() string` position
-	has_return      bool
+	params            []Param
+	stmts             []Stmt
+	defer_stmts       []DeferStmt
+	return_type       Type
+	return_type_pos   token.Position // `string` in `fn (u User) name() string` position
+	has_return        bool
+	should_be_skipped bool
 	//
 	comments      []Comment      // comments *after* the header, but *before* `{`; used for InterfaceDecl
 	next_comments []Comment // coments that are one line after the decl; used for InterfaceDecl

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7983,7 +7983,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 	} else {
 		for mut a in node.attrs {
 			if a.kind == .comptime_define {
-				c.evaluate_once_comptime_if_attribute(mut a)
+				node.should_be_skipped = c.evaluate_once_comptime_if_attribute(mut a)
 			}
 		}
 	}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -31,6 +31,9 @@ fn (mut g Gen) process_fn_decl(node ast.FnDecl) {
 	if !g.is_used_by_main(node) {
 		return
 	}
+	if node.should_be_skipped {
+		return
+	}
 	if g.is_builtin_mod && g.pref.gc_mode == .boehm_leak && node.name == 'malloc' {
 		g.definitions.write_string('#define _v_malloc GC_MALLOC\n')
 		return


### PR DESCRIPTION
This pull request fixes conditional functions being generated regardless of whether its flag was set.

```v
// test.v
[if foobar ?]
fn test_function() {
    println("Test successful")
}

fn main() {
    println("Hello world")
    test_function()
}
```
Always compiles `test_function`:
```c
// v -o test.c test.v

// Attr: [foobar ?]
VV_LOCAL_SYMBOL void main__test_function(void) {
    println(_SLIT("Test successful"));
}

VV_LOCAL_SYMBOL void main__main(void) {
    println(_SLIT("Hello world"));
    ;
}
```
With this pr however, `test_function` is only compiled with `-d foobar`
```c
// v -o test.c test.v
VV_LOCAL_SYMBOL void main__main(void) {
    println(_SLIT("Hello world"));
    ;
}
```
```c
// v -o test.c -d foobar test.v

// Attr: [foobar ?]
VV_LOCAL_SYMBOL void main__test_function(void) {
    println(_SLIT("Test successful"));
}

VV_LOCAL_SYMBOL void main__main(void) {
    println(_SLIT("Hello world"));
    main__test_function();
}
```

