### PR TITLE
array: fix autofree of fn returning array slice (fix #10420)

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -10,10 +10,11 @@ pub struct array {
 pub:
 	element_size int // size in bytes of one element in the array.
 pub mut:
-	data   voidptr
-	offset int // in bytes (should be `size_t`)
-	len    int // length of the array.
-	cap    int // capacity of the array.
+	data     voidptr
+	is_slice bool // slice cannot free
+	offset   int  // in bytes (should be `size_t`)
+	len      int  // length of the array.
+	cap      int  // capacity of the array.
 }
 
 // array.data uses a void pointer, which allows implementing arrays without generics and without generating
@@ -341,6 +342,7 @@ fn (a array) slice(start int, _end int) array {
 	res := array{
 		element_size: a.element_size
 		data: data
+		is_slice: true
 		offset: a.offset + offset
 		len: l
 		cap: l
@@ -482,9 +484,9 @@ pub fn (a &array) free() {
 	$if prealloc {
 		return
 	}
-	// if a.is_slice {
-	// return
-	// }
+	if a.is_slice {
+		return
+	}
 	unsafe { free(&byte(a.data) - a.offset) }
 }
 

--- a/vlib/v/tests/array_slice_test.v
+++ b/vlib/v/tests/array_slice_test.v
@@ -107,3 +107,23 @@ fn test_predictable_reallocation_parent() {
 	assert a == [i64(-25), 8, 13, -25, 5, -7, 9]
 	assert b == [i64(8), -19]
 }
+
+fn take_slice1(s []int) []int {
+	return s[..1]
+}
+
+fn take_slice2(s []int) []int {
+	return s[1..]
+}
+
+fn test_fn_return_array_slice() {
+	a := [1, 2]
+
+	b1 := take_slice1(a)
+	println(b1)
+	assert b1 == [1]
+
+	b2 := take_slice2(a)
+	println(b2)
+	assert b2 == [2]
+}


### PR DESCRIPTION
This PR fix autofree of fn returning array slice (fix #10420).

- Fix autofree of fn returning array slice.
- Add test.

```vlang
fn take_slice1(s []int) []int {
	return s[..1]
}

fn take_slice2(s []int) []int {
	return s[1..]
}

fn main() {
	a := [1, 2]

	b1 := take_slice1(a)
	println(b1)
	assert b1 == [1]

	b2 := take_slice2(a)
	println(b2)
	assert b2 == [2]
}

PS D:\Test\v\tt1> v -autofree run .
[1]
[2]
```