### PR TITLE
vdoc: add v/preludes_js/ to .vdocignore

### DIFF
--- a/vlib/.vdocignore
+++ b/vlib/.vdocignore
@@ -12,4 +12,5 @@ v/checker/tests/
 v/gen/js/tests/
 v/gen/x64/tests/
 v/gen/tests/
+v/preludes_js/
 vweb/tests


### PR DESCRIPTION
This removes the unwanted `main` documentation and the duplicate `v` module in the TOC

Currently on [modules.vlang.io](https://modules.vlang.io):
![image](https://user-images.githubusercontent.com/40232557/128028831-05ad9f19-6749-4b53-b541-ba849bd6ebff.png)


To prevent this from reoccuring in the future, a warning could be added at either of these places (not too sure how that would impact other people though):
- https://github.com/vlang/v/blob/a39962a6b9680541f5f83787531a331c268b0958/vlib/v/doc/doc.v#L455-L459

```v
if module_name == "main" {
    eprintln("warn: module name is main, did you forget to add $d.filename to .vdocignore?")
    // return error("error: module name is main, did you forget to add $d.filename to .vdocignore?")
}
```

- https://github.com/vlang/v/blob/a39962a6b9680541f5f83787531a331c268b0958/cmd/tools/vdoc/vdoc.v#L318 (should be safer)

```v
if dcs.head.name == "main" {
    eprintln("warn: module name is main, did you forget to add $dirpath to .vdocignore?")
    // exit(1)
}
```
