### PR TITLE
cgen: fix autofree error of array init with string variable (fix #10427)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -110,7 +110,14 @@ fn (mut g Gen) array_init(node ast.ArrayInit) {
 		g.write('\t\t')
 	}
 	for i, expr in node.exprs {
-		g.expr_with_cast(expr, node.expr_types[i], node.elem_type)
+		if node.expr_types[i] == ast.string_type && expr !is ast.StringLiteral
+			&& expr !is ast.StringInterLiteral {
+			g.write('string_clone(')
+			g.expr(expr)
+			g.write(')')
+		} else {
+			g.expr_with_cast(expr, node.expr_types[i], node.elem_type)
+		}
 		if i != len - 1 {
 			if i > 0 && i & 7 == 0 { // i > 0 && i % 8 == 0
 				g.writeln(',')

--- a/vlib/v/tests/valgrind/array_init_with_string_variable.v
+++ b/vlib/v/tests/valgrind/array_init_with_string_variable.v
@@ -7,6 +7,5 @@ fn main() {
 
 	d := [a, b, c]
 
-	println(c)
-	println(d)
+	println(d.len)
 }

--- a/vlib/v/tests/valgrind/array_init_with_string_variable.v
+++ b/vlib/v/tests/valgrind/array_init_with_string_variable.v
@@ -1,0 +1,12 @@
+module main
+
+fn main() {
+	a := 'Hello, '
+	b := 'World!'
+	c := a + b
+
+	d := [a, b, c]
+
+	println(c)
+	println(d)
+}


### PR DESCRIPTION
This PR fix autofree error of array init with string variable (fix #10427).

- Fix autofree error of array init with string variable.
- Add test.

```vlang
module main

fn main() {
	a := 'Hello, '
	b := 'World!'
	c := a + b

	d := [a, b, c]

	println(c)
	println(d)
}

PS D:\Test\v\tt1> v -autofree run .
Hello, World!
['Hello, ', 'World!', 'Hello, World!']
```