### PR TITLE
encoding.base64: speed up encoding and decoding

### DIFF
--- a/vlib/encoding/base64/base64.v
+++ b/vlib/encoding/base64/base64.v
@@ -145,7 +145,7 @@ pub fn decode_in_buffer_bytes(data []byte, buffer &byte) int {
 // Please note: This function does NOT allocate new memory, and is thus suitable for handling very large strings.
 // Please note: This function is for internal base64 decoding
 fn decode_from_buffer(dest &byte, src &byte, src_len int) int {
-	if src_len == 0 {
+	if src_len < 4 {
 		return 0
 	}
 

--- a/vlib/encoding/base64/base64.v
+++ b/vlib/encoding/base64/base64.v
@@ -223,37 +223,29 @@ fn decode_from_buffer(dest &byte, src &byte, src_len int) int {
 		mut si := 0
 
 		for src_len - si >= 8 {
-			dn := assemble64(
-				byte(base64.index[d[si+0]]),
-				byte(base64.index[d[si+1]]),
-				byte(base64.index[d[si+2]]),
-				byte(base64.index[d[si+3]]),
-				byte(base64.index[d[si+4]]),
-				byte(base64.index[d[si+5]]),
-				byte(base64.index[d[si+6]]),
-				byte(base64.index[d[si+7]]))
+			dn := assemble64(byte(base64.index[d[si + 0]]), byte(base64.index[d[si + 1]]),
+				byte(base64.index[d[si + 2]]), byte(base64.index[d[si + 3]]), byte(base64.index[d[
+				si + 4]]), byte(base64.index[d[si + 5]]), byte(base64.index[d[si + 6]]),
+				byte(base64.index[d[si + 7]]))
 
 			// binary.big_endian_put_u64(mut b[n_decoded_bytes..(n_decoded_bytes+8)], dn)
-//			_ = b[n_decoded_bytes + 7] // bounds check
+			//			_ = b[n_decoded_bytes + 7] // bounds check
 			b[n_decoded_bytes + 0] = byte(dn >> u64(56))
 			b[n_decoded_bytes + 1] = byte(dn >> u64(48))
 			b[n_decoded_bytes + 2] = byte(dn >> u64(40))
 			b[n_decoded_bytes + 3] = byte(dn >> u64(32))
 			b[n_decoded_bytes + 4] = byte(dn >> u64(24))
 			b[n_decoded_bytes + 5] = byte(dn >> u64(16))
-//			b[n_decoded_bytes + 6] = byte(dn >> u64(8))
-//			b[n_decoded_bytes + 7] = byte(dn)
+			//			b[n_decoded_bytes + 6] = byte(dn >> u64(8))
+			//			b[n_decoded_bytes + 7] = byte(dn)
 
 			n_decoded_bytes += 6
 			si += 8
 		}
 
 		for src_len - si >= 4 {
-			dn := assemble32(
-				byte(base64.index[d[si+0]]),
-				byte(base64.index[d[si+1]]),
-				byte(base64.index[d[si+2]]),
-				byte(base64.index[d[si+3]]))
+			dn := assemble32(byte(base64.index[d[si + 0]]), byte(base64.index[d[si + 1]]),
+				byte(base64.index[d[si + 2]]), byte(base64.index[d[si + 3]]))
 
 			// binary.big_endian_put_u32(mut b []byte, v u32)
 			_ = b[n_decoded_bytes + 3] // bounds check

--- a/vlib/encoding/base64/base64.v
+++ b/vlib/encoding/base64/base64.v
@@ -223,10 +223,16 @@ fn decode_from_buffer(dest &byte, src &byte, src_len int) int {
 		mut si := 0
 
 		for src_len - si >= 8 {
-			dn := assemble64(byte(base64.index[d[si + 0]]), byte(base64.index[d[si + 1]]),
-				byte(base64.index[d[si + 2]]), byte(base64.index[d[si + 3]]), byte(base64.index[d[
-				si + 4]]), byte(base64.index[d[si + 5]]), byte(base64.index[d[si + 6]]),
-				byte(base64.index[d[si + 7]]))
+			dn := assemble64(
+				byte(base64.index[d[si+0]]),
+				byte(base64.index[d[si+1]]),
+				byte(base64.index[d[si+2]]),
+				byte(base64.index[d[si+3]]),
+				byte(base64.index[d[si+4]]),
+				byte(base64.index[d[si+5]]),
+				byte(base64.index[d[si+6]]),
+				byte(base64.index[d[si+7]]))
+
 			// binary.big_endian_put_u64(mut b[n_decoded_bytes..(n_decoded_bytes+8)], dn)
 			_ = b[n_decoded_bytes + 7] // bounds check
 			b[n_decoded_bytes + 0] = byte(dn >> u64(56))
@@ -243,8 +249,12 @@ fn decode_from_buffer(dest &byte, src &byte, src_len int) int {
 		}
 
 		for src_len - si >= 4 {
-			dn := assemble32(byte(base64.index[d[si + 0]]), byte(base64.index[d[si + 1]]),
-				byte(base64.index[d[si + 2]]), byte(base64.index[d[si + 3]]))
+			dn := assemble32(
+				byte(base64.index[d[si+0]]),
+				byte(base64.index[d[si+1]]),
+				byte(base64.index[d[si+2]]),
+				byte(base64.index[d[si+3]]))
+
 			// binary.big_endian_put_u32(mut b []byte, v u32)
 			_ = b[n_decoded_bytes + 3] // bounds check
 			b[n_decoded_bytes + 0] = byte(dn >> u32(24))

--- a/vlib/encoding/base64/base64.v
+++ b/vlib/encoding/base64/base64.v
@@ -163,6 +163,25 @@ pub fn decode_in_buffer(data &string, buffer &byte) int {
 	return output_length
 }
 
+// decode_from_buffer decodes the base64 encoded ASCII bytes from `data` into `buffer`.
+// decode_from_buffer returns the size of the decoded data in the buffer.
+// Please note: The `buffer` should be large enough (i.e. 3/4 of the data.len, or larger)
+// to hold the decoded data.
+// Please note: This function does NOT allocate new memory, and is thus suitable for handling very large strings.
+pub fn decode_in_buffer_bytes(data []byte, buffer &byte) int {
+	return decode_from_buffer(buffer, data.data, data.len)
+}
+
+// decode_from_buffer decodes the base64 encoded ASCII bytes from `src` into `dest`.
+// decode_from_buffer returns the size of the decoded data in the buffer.
+// Please note: The `dest` buffer should be large enough (i.e. 3/4 of the `src_len`, or larger)
+// to hold the decoded data.
+// Please note: This function does NOT allocate new memory, and is thus suitable for handling very large strings.
+// Please note: This function is for internal base64 decoding
+fn decode_from_buffer(dest &byte, src &byte, src_len int) int {
+	return -1
+}
+
 // encode_in_buffer base64 encodes the `[]byte` passed in `data` into `buffer`.
 // encode_in_buffer returns the size of the encoded data in the buffer.
 // Please note: The buffer should be large enough (i.e. 4/3 of the data.len, or larger) to hold the encoded data.

--- a/vlib/encoding/base64/base64.v
+++ b/vlib/encoding/base64/base64.v
@@ -1,6 +1,8 @@
 // Copyright (c) 2019-2021 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
+// Based off:   https://github.com/golang/go/blob/master/src/encoding/base64/base64.go
+// Last commit: https://github.com/golang/go/commit/9a93baf4d7d13d7d5c67388c93960d78abc8e11e
 module base64
 
 const (
@@ -115,7 +117,7 @@ fn assemble64(n1 byte, n2 byte, n3 byte, n4 byte, n5 byte, n6 byte, n7 byte, n8 
 // Each digit comes from the decode map.
 // Please note: Invalid base64 digits are not expected and not handled.
 fn assemble32(n1 byte, n2 byte, n3 byte, n4 byte) u32 {
-	return u32(n1)<<26 | u32(n2)<<20 | u32(n3)<<14 | u32(n4)<<8
+	return u32(n1) << 26 | u32(n2) << 20 | u32(n3) << 14 | u32(n4) << 8
 }
 
 // decode_in_buffer decodes the base64 encoded `string` reference passed in `data` into `buffer`.
@@ -159,7 +161,7 @@ fn decode_micro(dest &byte, src &byte, src_len int, si int) int {
 	mut j := 0 + si
 	mut d := unsafe { src }
 	mut b := unsafe { dest }
-	
+
 	for i < input_length {
 		mut char_a := 0
 		mut char_b := 0
@@ -221,15 +223,10 @@ fn decode_from_buffer(dest &byte, src &byte, src_len int) int {
 		mut si := 0
 
 		for src_len - si >= 8 {
-			dn := assemble64(
-				byte(base64.index[d[si+0]]),
-				byte(base64.index[d[si+1]]),
-				byte(base64.index[d[si+2]]),
-				byte(base64.index[d[si+3]]),
-				byte(base64.index[d[si+4]]),
-				byte(base64.index[d[si+5]]),
-				byte(base64.index[d[si+6]]),
-				byte(base64.index[d[si+7]]))
+			dn := assemble64(byte(base64.index[d[si + 0]]), byte(base64.index[d[si + 1]]),
+				byte(base64.index[d[si + 2]]), byte(base64.index[d[si + 3]]), byte(base64.index[d[
+				si + 4]]), byte(base64.index[d[si + 5]]), byte(base64.index[d[si + 6]]),
+				byte(base64.index[d[si + 7]]))
 			// binary.big_endian_put_u64(mut b[n_decoded_bytes..(n_decoded_bytes+8)], dn)
 			_ = b[n_decoded_bytes + 7] // bounds check
 			b[n_decoded_bytes + 0] = byte(dn >> u64(56))
@@ -246,11 +243,8 @@ fn decode_from_buffer(dest &byte, src &byte, src_len int) int {
 		}
 
 		for src_len - si >= 4 {
-			dn := assemble32(
-				byte(base64.index[d[si+0]]),
-				byte(base64.index[d[si+1]]),
-				byte(base64.index[d[si+2]]),
-				byte(base64.index[d[si+3]]))
+			dn := assemble32(byte(base64.index[d[si + 0]]), byte(base64.index[d[si + 1]]),
+				byte(base64.index[d[si + 2]]), byte(base64.index[d[si + 3]]))
 			// binary.big_endian_put_u32(mut b []byte, v u32)
 			_ = b[n_decoded_bytes + 3] // bounds check
 			b[n_decoded_bytes + 0] = byte(dn >> u32(24))

--- a/vlib/encoding/base64/base64.v
+++ b/vlib/encoding/base64/base64.v
@@ -234,15 +234,15 @@ fn decode_from_buffer(dest &byte, src &byte, src_len int) int {
 				byte(base64.index[d[si+7]]))
 
 			// binary.big_endian_put_u64(mut b[n_decoded_bytes..(n_decoded_bytes+8)], dn)
-			_ = b[n_decoded_bytes + 7] // bounds check
+//			_ = b[n_decoded_bytes + 7] // bounds check
 			b[n_decoded_bytes + 0] = byte(dn >> u64(56))
 			b[n_decoded_bytes + 1] = byte(dn >> u64(48))
 			b[n_decoded_bytes + 2] = byte(dn >> u64(40))
 			b[n_decoded_bytes + 3] = byte(dn >> u64(32))
 			b[n_decoded_bytes + 4] = byte(dn >> u64(24))
 			b[n_decoded_bytes + 5] = byte(dn >> u64(16))
-			b[n_decoded_bytes + 6] = byte(dn >> u64(8))
-			b[n_decoded_bytes + 7] = byte(dn)
+//			b[n_decoded_bytes + 6] = byte(dn >> u64(8))
+//			b[n_decoded_bytes + 7] = byte(dn)
 
 			n_decoded_bytes += 6
 			si += 8

--- a/vlib/encoding/base64/base64_memory_test.v
+++ b/vlib/encoding/base64/base64_memory_test.v
@@ -11,16 +11,37 @@ fn test_long_encoding() {
 	assert s_encoded.len > s_original.len
 	assert s_original == s_decoded
 
-	mut s := 0
-
 	ebuffer := unsafe { malloc(s_encoded.len) }
+	dbuffer := unsafe { malloc(s_decoded.len) }
+	//
+	encoded_size := base64.encode_in_buffer(s_original, ebuffer)
+	mut encoded_in_buf := []byte{len: encoded_size}
+	unsafe { C.memcpy(encoded_in_buf.data, ebuffer, encoded_size) }
+	assert input_size * 4 / 3 == encoded_size
+	assert encoded_in_buf[0] == `Y`
+	assert encoded_in_buf[1] == `W`
+	assert encoded_in_buf[2] == `F`
+	assert encoded_in_buf[3] == `h`
+
+	assert encoded_in_buf[encoded_size - 4] == `Y`
+	assert encoded_in_buf[encoded_size - 3] == `W`
+	assert encoded_in_buf[encoded_size - 2] == `F`
+	assert encoded_in_buf[encoded_size - 1] == `h`
+	assert encoded_in_buf == s_encoded.bytes()
+
+	decoded_size := base64.decode_in_buffer(s_encoded, dbuffer)
+	assert decoded_size == input_size
+	mut decoded_in_buf := []byte{len: decoded_size}
+	unsafe { C.memcpy(decoded_in_buf.data, dbuffer, decoded_size) }
+	assert decoded_in_buf == s_original
+
+	mut s := 0
 	for _ in 0 .. repeats {
 		resultsize := base64.encode_in_buffer(s_original, ebuffer)
 		s += resultsize
 		assert resultsize == s_encoded.len
 	}
 
-	dbuffer := unsafe { malloc(s_decoded.len) }
 	for _ in 0 .. repeats {
 		resultsize := base64.decode_in_buffer(s_encoded, dbuffer)
 		s += resultsize

--- a/vlib/encoding/base64/base64_test.v
+++ b/vlib/encoding/base64/base64_test.v
@@ -130,3 +130,21 @@ fn test_decode_null_byte_str() {
 	s := [byte(`A`), 0, `C`].bytestr()
 	assert base64.decode_str('QQBD') == s
 }
+
+fn test_decode_in_buffer_bytes() {
+	rfc4648_pairs := [
+		TestPair{'foob', 'Zm9vYg=='},
+		TestPair{'fooba', 'Zm9vYmE='},
+		TestPair{'foobar', 'Zm9vYmFy'},
+	]
+	mut src_dec_buf := []byte{len: 8}
+	mut src_enc_buf := []byte{len: 8}
+	mut out_buf := []byte{len: 8}
+
+	for p in rfc4648_pairs {
+		src_dec_buf = p.decoded.bytes()
+		src_enc_buf = p.encoded.bytes()
+		n := base64.decode_in_buffer_bytes(src_enc_buf, out_buf.data)
+		assert src_dec_buf == out_buf[..n]
+	}
+}


### PR DESCRIPTION
## Replacing the previous implementation

This PR started as the result of me writing the V core-util `base64` implementation and noticing that the library code wasn't exactly fast.

With this PR I ripped out the previous implementation and replaced it with GO's implementation. Both projects are MIT licensed and I mentioned that I copied and adapted the code from the GO source in the beginning of the file - as it is also done in the crypto modules.

## Benchmarks and Comparison

Testing was performed on these files, which are the encoded / decoded form of each other, respectively:
```
523M -rw-rw-r-- 1 basti basti 523M Aug  4 14:16 /tmp/base64data.txt
388M -rw-rw-r-- 1 basti basti 388M Aug  4 14:07 /tmp/randomtext.txt
```

Important excerpts from the profiling logs: (Here I used the V implementation of the base64 core-util)

#### Encoding:

- Old Implementation:
```
26422       1366.857ms          51732ns encoding__base64__encode_in_buffer 
26422       1365.009ms          51662ns encoding__base64__encode_from_buffer 
```
- New Implementation:

```
26422        925.792ms          35039ns encoding__base64__encode_in_buffer 
26422        923.648ms          34958ns encoding__base64__encode_from_buffer 
```
#### Decoding:

- Old Implementation:
```
33029      45320.907ms        1372155ns os__File_read_bytes_into_newline
33028      42052.360ms        1273234ns encoding__base64__decode_in_buffer
```
- New Implementation:
```
33029      43124.751ms        1305663ns os__File_read_bytes_into_newline
33028      45464.197ms        1376535ns encoding__base64__decode_in_buffer 
33028      45461.255ms        1376446ns encoding__base64__decode_from_buffer 
```

As you have probably noticed, the decoding function seems to be very slow. I don't think the benchmark is really helpful in this situation.
I think the problem here is that the file reading function is much slower, if not run with the `-prod` flag. Sadly benchmarking does not support running optimized code to my knowledge.
To sum it up, I don't believe the benchmark is showing accurate/helpful results for the decoding functions.

So to provide a more accurate example, I compiled the code with the `-prod` flag and just used `time` to get results.

```
// new base64:
time ./base64 -d /tmp/base64data.txt > /dev/null 
real 2.20s, user 2.06s, sys 0.14s, mem 2132KB, cpu 99%

// old base64:
time ./base64 -d /tmp/base64data.txt > /dev/null 
real 2.64s, user 2.50s, sys 0.14s, mem 2192KB, cpu 100%
```

So there is definitely a speed up by using the newer code.

#### Remaining problems

~~I had to copy code from the binary module to make it work on the buffers, as the buffers are not slices/array, but basically just C style pointers. I could have used slices, but all the other functions did not do that either, so for now I stuck with function parameters in the way it was implemented before.~~

~~The `base64_memory_test.v` fails and I cannot pinpoint the problem. Seems to be related to the use of malloc for the buffer. So it seems like it's a problem with the C code of malloc, but it works on master. Please help.~~