### PR TITLE
checker: check fn_call().sort() (fix #11040)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2466,7 +2466,8 @@ fn (mut c Checker) array_builtin_method_call(mut call_expr ast.CallExpr, left_ty
 		scope_register_it(mut call_expr.scope, call_expr.pos, elem_typ)
 	} else if method_name == 'sort' {
 		if call_expr.left is ast.CallExpr {
-			c.error('the `sort()` method can be called only on mutable receivers, but `$call_expr.left` is a call expression', call_expr.pos)
+			c.error('the `sort()` method can be called only on mutable receivers, but `$call_expr.left` is a call expression',
+				call_expr.pos)
 		}
 		c.fail_if_immutable(call_expr.left)
 		// position of `a` and `b` doesn't matter, they're the same

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2466,7 +2466,7 @@ fn (mut c Checker) array_builtin_method_call(mut call_expr ast.CallExpr, left_ty
 		scope_register_it(mut call_expr.scope, call_expr.pos, elem_typ)
 	} else if method_name == 'sort' {
 		if call_expr.left is ast.CallExpr {
-			c.error('`$call_expr.left` cannot call `sort()` method directly', call_expr.pos)
+			c.error('the `sort()` method can be called only on mutable receivers, but `$call_expr.left` is a call expression', call_expr.pos)
 		}
 		c.fail_if_immutable(call_expr.left)
 		// position of `a` and `b` doesn't matter, they're the same

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2465,6 +2465,9 @@ fn (mut c Checker) array_builtin_method_call(mut call_expr ast.CallExpr, left_ty
 		// position of `it` doesn't matter
 		scope_register_it(mut call_expr.scope, call_expr.pos, elem_typ)
 	} else if method_name == 'sort' {
+		if call_expr.left is ast.CallExpr {
+			c.error('`$call_expr.left` cannot call `sort()` method directly', call_expr.pos)
+		}
 		c.fail_if_immutable(call_expr.left)
 		// position of `a` and `b` doesn't matter, they're the same
 		scope_register_a_b(mut call_expr.scope, call_expr.pos, elem_typ)

--- a/vlib/v/checker/tests/fn_return_array_sort_err.out
+++ b/vlib/v/checker/tests/fn_return_array_sort_err.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/fn_return_array_sort_err.vv:6:14: error: `ret_array()` cannot call `sort()` method directly
-    4 |
+vlib/v/checker/tests/fn_return_array_sort_err.vv:6:14: error: the `sort()` method can be called only on mutable receivers, but `ret_array()` is a call expression
+    4 | 
     5 | fn main() {
     6 |     ret_array().sort()
       |                 ~~~~~~

--- a/vlib/v/checker/tests/fn_return_array_sort_err.out
+++ b/vlib/v/checker/tests/fn_return_array_sort_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/fn_return_array_sort_err.vv:6:14: error: `ret_array()` cannot call `sort()` method directly
+    4 |
+    5 | fn main() {
+    6 |     ret_array().sort()
+      |                 ~~~~~~
+    7 | }

--- a/vlib/v/checker/tests/fn_return_array_sort_err.vv
+++ b/vlib/v/checker/tests/fn_return_array_sort_err.vv
@@ -1,0 +1,7 @@
+fn ret_array() []int {
+	return [1, 3, 2]
+}
+
+fn main() {
+	ret_array().sort()
+}


### PR DESCRIPTION
This PR check fn_call().sort() (fix #11040).

- Check fn_call().sort().
- Add test.

```vlang
fn ret_array() []int {
	return [1, 3, 2]
}

fn main() {
	ret_array().sort()
}

PS D:\Test\v\tt1> v run .
.\tt1.v:7:14: error: `ret_array()` can not call `sort()` method directly
    5 |
    6 | fn main() {
    7 |     ret_array().sort()
      |                 ~~~~~~
    8 | }
```