### PR TITLE
fmt: keep char literal, `'`

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -44,7 +44,7 @@ fn (mut r Repl) checks() bool {
 	mut in_string := false
 	was_indent := r.indent > 0
 	for i := 0; i < r.line.len; i++ {
-		if r.line[i] == `\'` && (i == 0 || r.line[i - 1] != `\\`) {
+		if r.line[i] == `'` && (i == 0 || r.line[i - 1] != `\\`) {
 			in_string = !in_string
 		}
 		if r.line[i] == `{` && !in_string {

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -651,7 +651,7 @@ fn test_for_loop_two() {
 }
 
 fn test_quote() {
-	a := `\'`
+	a := `'`
 	println('testing double quotes')
 	b := 'hi'
 	assert b == 'hi'

--- a/vlib/net/html/parser.v
+++ b/vlib/net/html/parser.v
@@ -111,10 +111,10 @@ pub fn (mut parser Parser) split_parse(data string) {
 	parser.init()
 	for chr in data {
 		// returns true if byte is a " or '
-		is_quote := chr == `"` || chr == `\'`
+		is_quote := chr == `"` || chr == `'`
 		string_code := match chr {
 			`"` { 1 } // "
-			`\'` { 2 } // '
+			`'` { 2 } // '
 			else { 0 }
 		}
 		if parser.lexical_attributes.open_code { // here will verify all needed to know if open_code finishes and string in code

--- a/vlib/strconv/vprintf.v
+++ b/vlib/strconv/vprintf.v
@@ -113,7 +113,7 @@ pub fn v_sprintf(str string, pt ...voidptr) string {
 				}
 				i++
 				continue
-			} else if ch == `\'` {
+			} else if ch == `'` {
 				i++
 				continue
 			} else if ch == `.` && fc_ch1 >= `1` && fc_ch1 <= `9` {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -521,7 +521,11 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 			f.chan_init(mut node)
 		}
 		ast.CharLiteral {
-			f.write('`$node.val`')
+			if node.val == r"\'" {
+				f.write("`'`")
+			} else {
+				f.write('`$node.val`')
+			}
 		}
 		ast.Comment {
 			f.comment(node, inline: true)

--- a/vlib/v/fmt/tests/char_literal_backtick_keep.vv
+++ b/vlib/v/fmt/tests/char_literal_backtick_keep.vv
@@ -1,3 +1,0 @@
-fn char_backtick() {
-	println(`\``)
-}

--- a/vlib/v/fmt/tests/char_literal_keep.vv
+++ b/vlib/v/fmt/tests/char_literal_keep.vv
@@ -1,0 +1,3 @@
+println(`"`)
+printrn(`'`)
+println(`\``)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5069,7 +5069,7 @@ fn (mut g Gen) const_decl_precomputed(mod string, name string, ct_value ast.Comp
 		rune {
 			rune_code := u32(ct_value)
 			if rune_code <= 255 {
-				if rune_code in [`"`, `\\`, `\'`] {
+				if rune_code in [`"`, `\\`, `'`] {
 					return false
 				}
 				escval := util.smart_quote(byte(rune_code).ascii_str(), false)

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -13,7 +13,7 @@ import v.vet
 import v.errors
 
 const (
-	single_quote = `\'`
+	single_quote = `'`
 	double_quote = `"`
 	// char used as number separator
 	num_sep      = `_`
@@ -677,7 +677,7 @@ fn (mut s Scanner) text_scan() token.Token {
 			// end of `$expr`
 			// allow `'$a.b'` and `'$a.c()'`
 			if s.is_inter_start && next_char == `\\`
-				&& s.look_ahead(2) !in [`x`, `n`, `r`, `\\`, `t`, `e`, `"`, `\'`] {
+				&& s.look_ahead(2) !in [`x`, `n`, `r`, `\\`, `t`, `e`, `"`, `'`] {
 				s.warn('unknown escape sequence \\${s.look_ahead(2)}')
 			}
 			if s.is_inter_start && next_char == `(` {

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -75,7 +75,7 @@ pub fn resolve_env_value(str string, check_for_presence bool) ?string {
 		if ch.is_letter() || ch.is_digit() || ch == `_` {
 			env_lit += ch.ascii_str()
 		} else {
-			if !(ch == `\'` || ch == `)`) {
+			if !(ch == `'` || ch == `)`) {
 				if ch == `$` {
 					return error('cannot use string interpolation in compile time \$env() expression')
 				}

--- a/vlib/v/vmod/parser.v
+++ b/vlib/v/vmod/parser.v
@@ -130,7 +130,7 @@ fn (mut s Scanner) scan_all() {
 				continue
 			}
 		}
-		if c in [`\'`, `\"`] && !s.peek_char(`\\`) {
+		if c in [`'`, `\"`] && !s.peek_char(`\\`) {
 			s.pos++
 			str := s.create_string(c)
 			s.tokenize(.str, str)


### PR DESCRIPTION
vfmt replaces ``` `'` ``` with ``` `\'` ```. but ``` `'` ``` works and there is no need to escape single quote

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
