### PR TITLE
gen/c/fn: fix error of print(alias of struct)  (fix #10335)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -962,12 +962,6 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 		if typ == 0 {
 			g.checker_bug('print arg.typ is 0', node.pos)
 		}
-		mut sym := g.table.get_type_symbol(typ)
-		if mut sym.info is ast.Alias {
-			typ = sym.info.parent_type
-			sym = g.table.get_type_symbol(typ)
-		}
-		// check if alias parent also not a string
 		if typ != ast.string_type {
 			expr := node.args[0].expr
 			if g.is_autofree && !typ.has_flag(.optional) {

--- a/vlib/v/tests/string_alias_of_struct_test.v
+++ b/vlib/v/tests/string_alias_of_struct_test.v
@@ -1,0 +1,27 @@
+interface Foo {
+	add(x int)
+}
+
+struct Base {
+mut:
+	i int
+}
+
+fn (mut b Base) add(x int) {
+	b.i += x
+}
+
+type Alias = Base
+
+fn (mut a Alias) add(x int) {
+	a.i += x * x
+}
+
+fn test_string_alias_of_struct() {
+	mut a := Alias{
+		i: 2
+	}
+	a.add(3)
+	println(a)
+	assert '$a'.contains('Alias')
+}


### PR DESCRIPTION
This PR fix error of print(alias of struct)  (fix #10335).

Is gen_str_for_alias() correct? 

- Fix error of print(alias of struct).
- Add test.

```vlang
interface Foo {
	add(x int)
}

struct Base {
mut:
	i int
}

fn (mut b Base) add(x int) {
	b.i += x
}

type Alias = Base

fn (mut a Alias) add(x int) {
	a.i += x * x
}

fn test_string_alias_of_struct() {
	mut a := Alias{
		i: 2
	}
	a.add(3)
	println(a)
	assert '$a'.contains('Alias')
}

PS D:\Test\v\tt1> v run .
Alias(Base{
    i: 11
})
```