### PR TITLE
v.gen.c: fix generic method on alias struct receiver (fix #7809)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -577,7 +577,12 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			else {}
 		}
 	}
-	typ_sym := g.table.get_type_symbol(unwrapped_rec_type)
+	mut typ_sym := g.table.get_type_symbol(unwrapped_rec_type)
+	// alias type that undefined this method (not include `str`) need to use parent type
+	if typ_sym.kind == .alias && node.name != 'str' && !typ_sym.has_method(node.name) {
+		unwrapped_rec_type = (typ_sym.info as ast.Alias).parent_type
+		typ_sym = g.table.get_type_symbol(unwrapped_rec_type)
+	}
 	rec_cc_type := g.cc_type(unwrapped_rec_type, false)
 	mut receiver_type_name := util.no_dots(rec_cc_type)
 	if typ_sym.kind == .interface_ && (typ_sym.info as ast.Interface).defines_method(node.name) {

--- a/vlib/v/tests/generics_method_on_alias_struct_receiver_test.v
+++ b/vlib/v/tests/generics_method_on_alias_struct_receiver_test.v
@@ -1,0 +1,22 @@
+struct Base {}
+
+pub fn (base Base) hello() string {
+	return 'hello'
+}
+
+type Message = Base
+
+fn hello<T>(hello_impl T) string {
+	return hello_impl.hello()
+}
+
+fn test_generic_method_on_alias_struct_receiver() {
+	mut message := Message(Base{})
+	ret1 := hello(message)
+	println(ret1)
+	assert ret1 == 'hello'
+
+	ret2 := message.hello()
+	println(ret2)
+	assert ret2 == 'hello'
+}


### PR DESCRIPTION
This PR fix generic method on alias struct receiver (fix #7809).

- Fix generic method on alias struct receiver.
- Add test.

```vlang
struct Base {}

pub fn (base Base) hello() string {
	return 'hello'
}

type Message = Base

fn hello<T>(hello_impl T) string {
	return hello_impl.hello()
}

fn main() {
	mut message := Message(Base{})
	ret1 := hello(message)
	println(ret1)
	assert ret1 == 'hello'

	ret2 := message.hello()
	println(ret2)
	assert ret2 == 'hello'
}

PS D:\Test\v\tt1> v run .
hello
hello
```