### PR TITLE
cgen: push function arguments in fn_args()

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -426,6 +426,8 @@ fn (mut g Gen) fn_args(args []ast.Param, is_variadic bool, scope &ast.Scope) ([]
 			g.fn_args(func.params, func.is_variadic, voidptr(0))
 			g.write(')')
 			g.definitions.write_string(')')
+			fargs << caname
+			fargtypes << arg_type_name
 		} else {
 			mut heap_prom := false
 			if scope != voidptr(0) {


### PR DESCRIPTION
fixes a bug that skipped function arguments in export thunks