### PR TITLE
cgen/auto_str: use heuristic to detect circular reference

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -834,6 +834,9 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name stri
 			if field.typ in ast.charptr_types {
 				fn_builder.write_string('tos2((byteptr)$func)')
 			} else {
+				if field.typ.is_ptr() && sym.kind == .struct_ {
+					fn_builder.write_string('(indent_count > 25) ? _SLIT("<probably circular>") : ')
+				}
 				fn_builder.write_string(func)
 			}
 		}

--- a/vlib/v/tests/str_circular_test.v
+++ b/vlib/v/tests/str_circular_test.v
@@ -1,0 +1,21 @@
+[heap]
+struct Aa {
+mut:
+	bs []Bb
+}
+
+struct Bb {
+mut:
+	a &Aa
+}
+
+fn test_circular() {
+	mut b := Bb{
+		a: &Aa{
+			bs: []Bb{cap: 1}
+		}
+	}
+	b.a.bs << b
+	s := b.str()
+	assert s.len < 3500
+}


### PR DESCRIPTION
Automatically generated `.str()` methods used to do infinite recursions on non-trivial circular references (trivial cases were already detected).
Example:
```v
[heap]
struct Aa {
mut:
    bs []Bb
}

struct Bb {
mut:
    a &Aa
}

fn main() {
    mut b := Bb{a: &Aa{bs: []Bb{cap: 1}}}
    b.a.bs << b
    s := b.str()
    println(s)
}
```
This PR uses a heuristic &ndash; when the indention level becomes > 25 the recursion is aborted and `<probably circular>` is inserted instead.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
