### PR TITLE
builtin: fix leak in rune.str(), fix leaks in most assert x == y statements in tests

### DIFF
--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -55,6 +55,21 @@ pub:
 	rvalue  string // the stringified *actual value* of the right side of a failed assertion
 }
 
+// free allows for manually freeing the memory occupied by the string
+[manualfree; unsafe]
+pub fn (ami &VAssertMetaInfo) free() {
+	unsafe {
+		ami.fpath.free()
+		ami.fn_name.free()
+		ami.src.free()
+		ami.op.free()
+		ami.llabel.free()
+		ami.rlabel.free()
+		ami.lvalue.free()
+		ami.rvalue.free()
+	}
+}
+
 fn __print_assert_failure(i &VAssertMetaInfo) {
 	eprintln('$i.fpath:${i.line_nr + 1}: FAIL: fn $i.fn_name: assert $i.src')
 	if i.op.len > 0 && i.op != 'call' {

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -55,7 +55,9 @@ pub:
 	rvalue  string // the stringified *actual value* of the right side of a failed assertion
 }
 
-// free allows for manually freeing the memory occupied by the string
+// free is used to free the memory occupied by the assertion meta data.
+// It is called by cb_assertion_failed, and cb_assertion_ok in the preludes,
+// once they are done with reporting/formatting the meta data.
 [manualfree; unsafe]
 pub fn (ami &VAssertMetaInfo) free() {
 	unsafe {

--- a/vlib/clipboard/clipboard_darwin.c.v
+++ b/vlib/clipboard/clipboard_darwin.c.v
@@ -60,7 +60,7 @@ pub fn (mut cb Clipboard) get_text() string {
 		return ''
 	}
 	utf8_clip := C.darwin_get_pasteboard_text(cb.pb)
-	return unsafe { utf8_clip.vstring() }
+	return unsafe { tos_clone(&byte(utf8_clip)) }
 }
 
 // new_primary returns a new X11 `PRIMARY` type `Clipboard` instance allocated on the heap.

--- a/vlib/term/term.v
+++ b/vlib/term/term.v
@@ -181,11 +181,13 @@ fn supports_escape_sequences(fd int) bool {
 	if vcolors_override == 'never' {
 		return false
 	}
-	if os.getenv('TERM') == 'dumb' {
+	env_term := os.getenv('TERM')
+	if env_term == 'dumb' {
 		return false
 	}
 	$if windows {
-		if os.getenv('ConEmuANSI') == 'ON' {
+		env_conemu := os.getenv('ConEmuANSI')
+		if env_conemu == 'ON' {
 			return true
 		}
 		// 4 is enable_virtual_terminal_processing

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -290,16 +290,17 @@ pub fn (x Expr) str() string {
 		}
 		CallExpr {
 			sargs := args2str(x.args)
+			propagate_suffix := if x.or_block.kind == .propagate { ' ?' } else { '' }
 			if x.is_method {
-				return '${x.left.str()}.${x.name}($sargs)'
+				return '${x.left.str()}.${x.name}($sargs)$propagate_suffix'
 			}
 			if x.name.starts_with('${x.mod}.') {
-				return util.strip_main_name('${x.name}($sargs)')
+				return util.strip_main_name('${x.name}($sargs)$propagate_suffix')
 			}
 			if x.mod == '' && x.name == '' {
-				return x.left.str() + '($sargs)'
+				return x.left.str() + '($sargs)$propagate_suffix'
 			}
-			return '${x.mod}.${x.name}($sargs)'
+			return '${x.mod}.${x.name}($sargs)$propagate_suffix'
 		}
 		CharLiteral {
 			return '`$x.val`'

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3625,7 +3625,7 @@ fn (mut g Gen) typeof_expr(node ast.TypeOf) {
 	if sym.kind == .sum_type {
 		// When encountering a .sum_type, typeof() should be done at runtime,
 		// because the subtype of the expression may change:
-		g.write('tos3( /* $sym.name */ v_typeof_sumtype_${sym.cname}( (')
+		g.write('charptr_vstring_literal( /* $sym.name */ v_typeof_sumtype_${sym.cname}( (')
 		g.expr(node.expr)
 		g.write(')._typ ))')
 	} else if sym.kind == .array_fixed {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -745,14 +745,14 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	}
 
 	if left_sym.kind == .sum_type && node.name == 'type_name' {
-		g.write('tos3( /* $left_sym.name */ v_typeof_sumtype_${typ_sym.cname}( (')
+		g.write('charptr_vstring_literal( /* $left_sym.name */ v_typeof_sumtype_${typ_sym.cname}( (')
 		g.expr(node.left)
 		dot := if node.left_type.is_ptr() { '->' } else { '.' }
 		g.write(')${dot}_typ ))')
 		return
 	}
 	if left_sym.kind == .interface_ && node.name == 'type_name' {
-		g.write('tos3( /* $left_sym.name */ v_typeof_interface_${typ_sym.cname}( (')
+		g.write('charptr_vstring_literal( /* $left_sym.name */ v_typeof_interface_${typ_sym.cname}( (')
 		g.expr(node.left)
 		dot := if node.left_type.is_ptr() { '->' } else { '.' }
 		g.write(')${dot}_typ ))')

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -49,8 +49,10 @@ pub fn mark_used(mut table ast.Table, pref &pref.Preferences, ast_files []&ast.F
 		// byteptr and charptr
 		'3.vstring',
 		'3.vstring_with_len',
+		'3.vstring_literal',
 		'4.vstring',
 		'4.vstring_with_len',
+		'4.vstring_literal',
 		// byte. methods
 		'9.str_escaped',
 		// string. methods

--- a/vlib/v/preludes/tests_assertions.v
+++ b/vlib/v/preludes/tests_assertions.v
@@ -62,6 +62,7 @@ fn cb_assertion_failed(i &VAssertMetaInfo) {
 		eprintln('    $final_src')
 	}
 	eprintln('')
+	unsafe { i.free() }
 }
 
 fn cb_assertion_ok(i &VAssertMetaInfo) {
@@ -85,6 +86,7 @@ fn cb_assertion_ok(i &VAssertMetaInfo) {
 	}
 	println('$final_funcname ($final_filepath)')
 	*/
+	unsafe { i.free() }
 }
 
 fn cb_propagate_test_error(line_nr int, file string, mod string, fn_name string, errmsg string) {

--- a/vlib/v/tests/valgrind/base64.v
+++ b/vlib/v/tests/valgrind/base64.v
@@ -1,6 +1,6 @@
 import encoding.base64
 
-fn test_long_encoding() {
+fn main() {
 	repeats := 1000
 	input_size := 3000
 

--- a/vlib/v/tests/valgrind/buffer_passed_in_fn_that_uses_tos_on_it.v
+++ b/vlib/v/tests/valgrind/buffer_passed_in_fn_that_uses_tos_on_it.v
@@ -1,0 +1,7 @@
+fn main() {
+	unsafe {
+		mut buffer := malloc_noscan(5)
+		s := utf32_to_str_no_malloc(77, buffer)
+		println(s)
+	}
+}

--- a/vlib/v/tests/valgrind/rune_str_method.v
+++ b/vlib/v/tests/valgrind/rune_str_method.v
@@ -1,0 +1,4 @@
+fn main() {
+	a := `Y`.str()
+	println(a)
+}

--- a/vlib/v/tests/valgrind/string_str_method.v
+++ b/vlib/v/tests/valgrind/string_str_method.v
@@ -1,0 +1,4 @@
+fn main() {
+	a := 'Y'.str()
+	println(a)
+}


### PR DESCRIPTION
Also add more vlib/v/tests/valgrind/ tests (a copy from vlib/encoding/base64/base64_memory_test.v)