### PR TITLE
v.parser: fix if expr with struct_init (fix #11088)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2147,6 +2147,10 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 			return map_init
 		}
 		return p.struct_init(false) // short_syntax: false
+	} else if p.peek_tok.kind == .lcbr && p.inside_if && lit0_is_capital && !known_var
+		&& language == .v {
+		// if a == Foo{} {...}
+		return p.struct_init(false)
 	} else if p.peek_tok.kind == .dot && (lit0_is_capital && !known_var && language == .v) {
 		// T.name
 		if p.is_generic_name() {

--- a/vlib/v/tests/if_expr_with_struct_init_test.v
+++ b/vlib/v/tests/if_expr_with_struct_init_test.v
@@ -1,0 +1,11 @@
+struct Foo {
+	bar int
+}
+
+fn test_if_expr_with_struct_init() {
+	a := Foo{}
+	if a == Foo{} {
+		println(true)
+		assert true
+	}
+}


### PR DESCRIPTION
This PR fix if expr with struct_init (fix #11088).

- Fix if expr with struct_init.
- Add test.

```vlang
struct Foo {
	bar int
}

fn main() {
	a := Foo{}
	if a == Foo{} {
		println(true)
		assert true
	}
}

PS D:\Test\v\tt1> v run .
true
```