### PR TITLE
doc: add note on converting byte to escaped string

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -484,12 +484,12 @@ s[0] = `H` // not allowed
 
 Note that indexing a string will produce a `byte`, not a `rune` nor another `string`. 
 Indexes correspond to bytes in the string, not Unicode code points. If you want to 
-convert the `byte` to a `string`, use the `str_escaped()` method:
+convert the `byte` to a `string`, use the `ascii_str()` method:
 
 ```v
 country := 'Netherlands'
 println(country[0]) // Output: 78
-println(country[0].str_escaped()) // Output: N
+println(country[0].ascii_str()) // Output: N
 ```
 
 Character literals have type `rune`. To denote them, use `

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -482,8 +482,15 @@ s[0] = `H` // not allowed
 ```
 > error: cannot assign to `s[i]` since V strings are immutable
 
-Note that indexing a string will produce a `byte`, not a `rune`. Indexes correspond
-to bytes in the string, not Unicode code points.
+Note that indexing a string will produce a `byte`, not a `rune` nor another `string`. 
+Indexes correspond to bytes in the string, not Unicode code points. If you want to 
+convert the `byte` to a `string`, use the `str_escaped()` method:
+
+```v
+country := 'Netherlands'
+println(country[0]) // Output: 78
+println(country[0].str_escaped()) // Output: N
+```
 
 Character literals have type `rune`. To denote them, use `
 


### PR DESCRIPTION
This small pull request mainly involves indexing a string. I spent an hour trying to figure out how to print the result of an indexed string to the terminal (basically converting the byte to a string), and I think others users will very likely face the same problem. Without the `str_escaped()` method it will always output the ASCII code (e.g. 78) instead of the actual character literal (e.g. N).

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
