### PR TITLE
cgen: fix struct_init with fixed array field (fix #11097)

### DIFF
--- a/vlib/v/tests/struct_init_with_fixed_array_field_test.v
+++ b/vlib/v/tests/struct_init_with_fixed_array_field_test.v
@@ -1,0 +1,28 @@
+enum Piece {
+	free
+	x
+	o
+}
+
+struct Game {
+mut:
+	board [9]Piece
+}
+
+fn test_struct_init_with_fixed_array_field() {
+	s := 'xoxooxxxo'
+	mut board := [9]Piece{}
+	for i, char in s {
+		board[i] = match char {
+			`x` { Piece.x }
+			`o` { Piece.o }
+			else { Piece.free }
+		}
+	}
+	println(board)
+	assert '$board' == '[x, o, x, o, o, x, x, x, o]'
+
+	game := Game{board}
+	println(game.board)
+	assert '$game.board' == '[x, o, x, o, o, x, x, x, o]'
+}


### PR DESCRIPTION
This PR fix struct_init with fixed array field (fix #11097).

- Fix struct_init with fixed array field.
- Add test.

```vlang
enum Piece {
	free
	x
	o
}

struct Game {
mut:
	board [9]Piece
}

fn main() {
	s := 'xoxooxxxo'
	mut board := [9]Piece{}
	for i, char in s {
		board[i] = match char {
			`x` { Piece.x }
			`o` { Piece.o }
			else { Piece.free }
		}
	}
	println(board)
	assert '$board' == '[x, o, x, o, o, x, x, x, o]'

	game := Game{board}
	println(game.board)
	assert '$game.board' == '[x, o, x, o, o, x, x, x, o]'
}

PS D:\Test\v\tt1> v run .
[x, o, x, o, o, x, x, x, o]
[x, o, x, o, o, x, x, x, o]
```