### PR TITLE
v.gen.c.fn: fix fn mut arg of array (fix #11101)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1296,7 +1296,8 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 	} else if arg_is_ptr && !expr_is_ptr {
 		if arg.is_mut {
 			if exp_sym.kind == .array {
-				if arg.expr is ast.Ident && (arg.expr as ast.Ident).kind == .variable {
+				if (arg.expr is ast.Ident && (arg.expr as ast.Ident).kind == .variable)
+					|| arg.expr is ast.SelectorExpr {
 					g.write('&/*arr*/')
 					g.expr(arg.expr)
 				} else {

--- a/vlib/v/tests/fn_mut_arg_of_array_test.v
+++ b/vlib/v/tests/fn_mut_arg_of_array_test.v
@@ -1,0 +1,24 @@
+fn test_fn_mut_arg_of_array() {
+	mut a := App{}
+	a.data << 1
+	a.do_something()
+	assert a.data.len == 2
+}
+
+struct App {
+pub mut:
+	data []int
+}
+
+fn (mut a App) do_something() {
+	assert a.data.len == 1
+	mut p := Proc{}
+	p.make_a(mut a.data)
+	assert a.data.len == 2
+}
+
+struct Proc {}
+
+fn (mut p Proc) make_a(mut data []int) {
+	data << 2
+}


### PR DESCRIPTION
This PR fix fn mut arg of array (fix #11101).

- Fix fn mut arg of array.
- Add test.

```vlang
fn main() {
	mut a := App{}
	a.data << 1
	a.do_something()
	assert a.data.len == 2
}

struct App {
pub mut:
	data []int
}

fn (mut a App) do_something() {
	assert a.data.len == 1
	mut p := Proc{}
	p.make_a(mut a.data)
	assert a.data.len == 2
}

struct Proc {}

fn (mut p Proc) make_a(mut data []int) {
	data << 2
}

PS D:\Test\v\tt1> v run .
```