### PR TITLE
gen: fix automatic generation of `[]string.index/1`

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -526,7 +526,7 @@ fn (mut g Gen) gen_array_index_method(left_type ast.Type) string {
 		fn_builder.writeln('\t$elem_type_str* pelem = a.data;')
 		fn_builder.writeln('\tfor (int i = 0; i < a.len; ++i, ++pelem) {')
 		if elem_sym.kind == .string {
-			fn_builder.writeln('\t\tif (fast_string_eq(( *pelem, v))) {')
+			fn_builder.writeln('\t\tif (fast_string_eq(*pelem, v)) {')
 		} else if elem_sym.kind == .array && !info.elem_type.is_ptr() {
 			ptr_typ := g.gen_array_equality_fn(info.elem_type)
 			fn_builder.writeln('\t\tif (${ptr_typ}_arr_eq( *pelem, v)) {')


### PR DESCRIPTION
Generating `[]string.index/1` would have failed.
The generation never happened because `[]string.index/1` is defined in [`vlib/builtin/array.v`](https://github.com/vlang/v/blob/1f3f7705a297e6efe91950348965b3866dab994f/vlib/builtin/array.v#L624), but I plan to remove all possibly automatically generated functions from builtin, to clean up a bit, and remove redundant documentation ([1](https://modules.vlang.io/#array.index) and [2](https://modules.vlang.io/#[]string.index))