### PR TITLE
builtin: remove methods that can be autogenerated

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -592,27 +592,6 @@ pub fn copy(dst []byte, src []byte) int {
 	return min
 }
 
-// Private function. Comparator for int type.
-fn compare_ints(a &int, b &int) int {
-	if *a < *b {
-		return -1
-	}
-	if *a > *b {
-		return 1
-	}
-	return 0
-}
-
-fn compare_ints_reverse(a &int, b &int) int {
-	if *a > *b {
-		return -1
-	}
-	if *a < *b {
-		return 1
-	}
-	return 0
-}
-
 // reduce executes a given reducer function on each element of the array,
 // resulting in a single output value.
 pub fn (a []int) reduce(iter fn (int, int) int, accum_start int) int {

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -613,18 +613,6 @@ fn compare_ints_reverse(a &int, b &int) int {
 	return 0
 }
 
-// index returns the first index at which a given element can be found in the array
-// or -1 if the value is not found.
-[direct_array_access]
-pub fn (a []string) index(v string) int {
-	for i in 0 .. a.len {
-		if a[i] == v {
-			return i
-		}
-	}
-	return -1
-}
-
 // reduce executes a given reducer function on each element of the array,
 // resulting in a single output value.
 pub fn (a []int) reduce(iter fn (int, int) int, accum_start int) int {

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -613,11 +613,6 @@ fn compare_ints_reverse(a &int, b &int) int {
 	return 0
 }
 
-// sort sorts an array of int in place in ascending order.
-pub fn (mut a []int) sort() {
-	a.sort_with_compare(compare_ints)
-}
-
 // index returns the first index at which a given element can be found in the array
 // or -1 if the value is not found.
 [direct_array_access]

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -647,25 +647,6 @@ pub fn (mut a array) grow_len(amount int) {
 	a.len += amount
 }
 
-// eq checks if the arrays have the same elements or not.
-// TODO: make it work with all types.
-pub fn (a1 []string) eq(a2 []string) bool {
-	// return array_eq(a, a2)
-	if a1.len != a2.len {
-		return false
-	}
-	size_of_string := int(sizeof(string))
-	for i in 0 .. a1.len {
-		offset := i * size_of_string
-		s1 := unsafe { &string(&byte(a1.data) + offset) }
-		s2 := unsafe { &string(&byte(a2.data) + offset) }
-		if *s1 != *s2 {
-			return false
-		}
-	}
-	return true
-}
-
 // pointers returns a new array, where each element
 // is the address of the corresponding element in the array.
 [unsafe]

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1176,17 +1176,6 @@ pub fn compare_strings(a &string, b &string) int {
 	return 0
 }
 
-// compare_strings_reverse returns `1` if `a < b`, `-1` if `a > b` else `0`.
-fn compare_strings_reverse(a &string, b &string) int {
-	if a < b {
-		return 1
-	}
-	if a > b {
-		return -1
-	}
-	return 0
-}
-
 // compare_strings_by_len returns `-1` if `a.len < b.len`, `1` if `a.len > b.len` else `0`.
 fn compare_strings_by_len(a &string, b &string) int {
 	if a.len < b.len {

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -340,22 +340,6 @@ struct RepIndex {
 	val_idx int
 }
 
-// compare_rep_index returns the result of comparing RepIndex `a` and `b`.
-fn compare_rep_index(a &RepIndex, b &RepIndex) int {
-	if a.idx < b.idx {
-		return -1
-	}
-	if a.idx > b.idx {
-		return 1
-	}
-	return 0
-}
-
-// sort2 sorts the RepIndex array using `compare_rep_index`.
-fn (mut a []RepIndex) sort2() {
-	a.sort_with_compare(compare_rep_index)
-}
-
 // replace_each replaces all occurences of the string pairs given in `vals`.
 // Example: assert 'ABCD'.replace_each(['B','C/','C','D','D','C']) == 'AC/DC'
 [direct_array_access]
@@ -404,7 +388,7 @@ pub fn (s string) replace_each(vals []string) string {
 	if idxs.len == 0 {
 		return s.clone()
 	}
-	idxs.sort2()
+	idxs.sort(a.idx < b.idx)
 	mut b := unsafe { malloc_noscan(new_len + 1) } // add space for 0 terminator
 	// Fill the new string
 	mut idx_pos := 0

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1221,11 +1221,6 @@ fn compare_lower_strings(a &string, b &string) int {
 	return compare_strings(&aa, &bb)
 }
 
-// sort sorts the string array.
-pub fn (mut s []string) sort() {
-	s.sort_with_compare(compare_strings)
-}
-
 // sort_ignore_case sorts the string array using case insesitive comparing.
 pub fn (mut s []string) sort_ignore_case() {
 	s.sort_with_compare(compare_lower_strings)

--- a/vlib/os/cmdline/cmdline_test.v
+++ b/vlib/os/cmdline/cmdline_test.v
@@ -3,7 +3,7 @@ import os.cmdline
 fn test_options() {
 	args := ['v', '-d', 'aa', '-d', 'bb', '-d', 'cc']
 	ret := cmdline.options(args, '-d')
-	assert ret.eq(['aa', 'bb', 'cc'])
+	assert ret == ['aa', 'bb', 'cc']
 }
 
 fn test_option() {
@@ -15,23 +15,23 @@ fn test_option() {
 fn test_options_before() {
 	args := ['-stat', 'test', 'aaa.v']
 	ret := cmdline.options_before(args, ['test'])
-	assert ret.eq(['-stat'])
+	assert ret == ['-stat']
 }
 
 fn test_options_after() {
 	args := ['-stat', 'test', 'aaa.v']
 	ret := cmdline.options_after(args, ['test'])
-	assert ret.eq(['aaa.v'])
+	assert ret == ['aaa.v']
 }
 
 fn test_only_non_options() {
 	args := ['-d', 'aa', '--help', 'bb']
 	ret := cmdline.only_non_options(args)
-	assert ret.eq(['aa', 'bb'])
+	assert ret == ['aa', 'bb']
 }
 
 fn test_only_options() {
 	args := ['-d', 'aa', '--help', 'bb']
 	ret := cmdline.only_options(args)
-	assert ret.eq(['-d', '--help'])
+	assert ret == ['-d', '--help']
 }

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -221,6 +221,10 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 		// println(rec_sym.kind)
 		verror('.sort() is an array method')
 	}
+	if g.pref.is_bare {
+		g.writeln('bare_panic(_SLIT("sort does not work with -freestanding"))')
+		return
+	}
 	info := rec_sym.info as ast.Array
 	// `users.sort(a.age > b.age)`
 	// Generate a comparison function for a custom type


### PR DESCRIPTION
Remove
- `compare_{ints,string}` (unused)
- `[]string.index/1` (autogenerated)
- `[]string.eq/1` (replaced by `==`)
- `[]string.sort/0` (autogenerated)
- `[]int.sort/0` (autogenerated)

A panic is generated when using `-freestanding` instead of `qsort`, similar to [`array.sort_with_compare`](https://github.com/vlang/v/blob/1a555ab89836fcd728d743995b44b8fb3b36f1a5/vlib/builtin/array.v#L151), so that programs can still compile.