### PR TITLE
ci: run sanitized CI when "vtest*" tools are modified

### DIFF
--- a/.github/workflows/ci_sanitized.yml
+++ b/.github/workflows/ci_sanitized.yml
@@ -15,6 +15,7 @@ on:
   push:
     paths:
       - '!**'
+      - 'cmd/tools/vtest*'
       - 'vlib/builtin/**.v'
       - 'vlib/strconv/**.v'
       - 'vlib/strings/**.v'
@@ -34,6 +35,7 @@ on:
   pull_request:
     paths:
       - '!**'
+      - 'cmd/tools/vtest*'
       - 'vlib/builtin/**.v'
       - 'vlib/strconv/**.v'
       - 'vlib/strings/**.v'


### PR DESCRIPTION
I just came across a case where I had to skip a test file on Windows, and the Sanitized CI wasn't re-run.