### PR TITLE
v: initial support for closures (x64 / linux-only)

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -97,6 +97,7 @@ const (
 	skip_on_windows               = [
 		'vlib/orm/orm_test.v',
 		'vlib/v/tests/orm_sub_struct_test.v',
+		'vlib/v/tests/closure_test.v',
 		'vlib/net/websocket/ws_test.v',
 		'vlib/net/unix/unix_test.v',
 		'vlib/net/websocket/websocket_test.v',

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -351,9 +351,10 @@ pub:
 // anonymous function
 pub struct AnonFn {
 pub mut:
-	decl    FnDecl
-	typ     Type // the type of anonymous fn. Both .typ and .decl.name are auto generated
-	has_gen bool // has been generated
+	decl           FnDecl
+	inherited_vars []Param
+	typ            Type // the type of anonymous fn. Both .typ and .decl.name are auto generated
+	has_gen        bool // has been generated
 }
 
 // function or method declaration
@@ -496,6 +497,7 @@ pub:
 	is_autofree_tmp bool
 	is_arg          bool // fn args should not be autofreed
 	is_auto_deref   bool
+	is_inherited    bool
 pub mut:
 	typ        Type
 	orig_type  Type   // original sumtype type; 0 if it's not a sumtype

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -22,8 +22,6 @@ pub type Stmt = AsmStmt | AssertStmt | AssignStmt | Block | BranchStmt | CompFor
 	GlobalDecl | GotoLabel | GotoStmt | HashStmt | Import | InterfaceDecl | Module | NodeError |
 	Return | SqlStmt | StructDecl | TypeDecl
 
-// NB: when you add a new Expr or Stmt type with a .pos field, remember to update
-// the .position() token.Position methods too.
 pub type ScopeObject = AsmRegister | ConstField | GlobalField | Var
 
 // TODO: replace Param
@@ -1539,7 +1537,7 @@ pub fn (expr Expr) position() token.Position {
 		AnonFn {
 			return expr.decl.pos
 		}
-		EmptyExpr {
+		CTempVar, EmptyExpr {
 			// println('compiler bug, unhandled EmptyExpr position()')
 			return token.Position{}
 		}
@@ -1570,9 +1568,6 @@ pub fn (expr Expr) position() token.Position {
 				col: left_pos.col
 				last_line: right_pos.last_line
 			}
-		}
-		CTempVar {
-			return token.Position{}
 		}
 		// Please, do NOT use else{} here.
 		// This match is exhaustive *on purpose*, to help force

--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -41,20 +41,6 @@ fn (s &Scope) dont_lookup_parent() bool {
 	return isnil(s.parent) || s.detached_from_parent
 }
 
-pub fn (s &Scope) find_with_scope(name string) ?(ScopeObject, &Scope) {
-	mut sc := s
-	for {
-		if name in sc.objects {
-			return sc.objects[name], sc
-		}
-		if sc.dont_lookup_parent() {
-			break
-		}
-		sc = sc.parent
-	}
-	return none
-}
-
 pub fn (s &Scope) find(name string) ?ScopeObject {
 	for sc := s; true; sc = sc.parent {
 		if name in sc.objects {
@@ -80,14 +66,6 @@ pub fn (s &Scope) find_struct_field(name string, struct_type Type, field_name st
 		}
 	}
 	return none
-}
-
-pub fn (s &Scope) is_known(name string) bool {
-	if _ := s.find(name) {
-		return true
-	} else {
-	}
-	return false
 }
 
 pub fn (s &Scope) find_var(name string) ?&Var {
@@ -121,23 +99,16 @@ pub fn (s &Scope) find_const(name string) ?&ConstField {
 }
 
 pub fn (s &Scope) known_var(name string) bool {
-	if _ := s.find_var(name) {
-		return true
-	}
-	return false
+	s.find_var(name) or { return false }
+	return true
 }
 
 pub fn (mut s Scope) update_var_type(name string, typ Type) {
-	s.end_pos = s.end_pos // TODO mut bug
 	mut obj := s.objects[name]
-	match mut obj {
-		Var {
-			if obj.typ == typ {
-				return
-			}
+	if mut obj is Var {
+		if obj.typ != typ {
 			obj.typ = typ
 		}
-		else {}
 	}
 }
 
@@ -152,29 +123,10 @@ pub fn (mut s Scope) register_struct_field(name string, field ScopeStructField) 
 }
 
 pub fn (mut s Scope) register(obj ScopeObject) {
-	name := if obj is ConstField {
-		obj.name
-	} else if obj is GlobalField {
-		obj.name
-	} else {
-		(obj as Var).name
-	}
-	if name == '_' {
+	if obj.name == '_' || obj.name in s.objects {
 		return
 	}
-	if name in s.objects {
-		// println('existing obect: $name')
-		return
-	}
-	s.objects[name] = obj
-}
-
-pub fn (s &Scope) outermost() &Scope {
-	mut sc := s
-	for !sc.dont_lookup_parent() {
-		sc = sc.parent
-	}
-	return sc
+	s.objects[obj.name] = obj
 }
 
 // returns the innermost scope containing pos

--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -163,6 +163,17 @@ pub fn (s &Scope) contains(pos int) bool {
 	return pos >= s.start_pos && pos <= s.end_pos
 }
 
+pub fn (s &Scope) has_inherited_vars() bool {
+	for _, obj in s.objects {
+		if obj is Var {
+			if obj.is_inherited {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 pub fn (sc Scope) show(depth int, max_depth int) string {
 	mut out := ''
 	mut indent := ''

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -34,50 +34,61 @@ pub fn (node &CallExpr) fkey() string {
 }
 
 // These methods are used only by vfmt, vdoc, and for debugging.
+pub fn (node &AnonFn) stringify(t &Table, cur_mod string, m2a map[string]string) string {
+	mut f := strings.new_builder(30)
+	f.write_string('fn ')
+	if node.inherited_vars.len > 0 {
+		f.write_string('[')
+		for i, var in node.inherited_vars {
+			if i > 0 {
+				f.write_string(', ')
+			}
+			if var.is_mut {
+				f.write_string('mut ')
+			}
+			f.write_string(var.name)
+		}
+		f.write_string('] ')
+	}
+	stringify_fn_after_name(node.decl, mut f, t, cur_mod, m2a)
+	return f.str()
+}
+
 pub fn (node &FnDecl) stringify(t &Table, cur_mod string, m2a map[string]string) string {
 	mut f := strings.new_builder(30)
 	if node.is_pub {
 		f.write_string('pub ')
 	}
-	mut receiver := ''
+	f.write_string('fn ')
 	if node.is_method {
+		f.write_string('(')
 		mut styp := util.no_cur_mod(t.type_to_code(node.receiver.typ.clear_flag(.shared_f)),
 			cur_mod)
-		m := if node.rec_mut { node.receiver.typ.share().str() + ' ' } else { '' }
 		if node.rec_mut {
+			f.write_string(node.receiver.typ.share().str() + ' ')
 			styp = styp[1..] // remove &
 		}
+		f.write_string(node.receiver.name + ' ')
 		styp = util.no_cur_mod(styp, cur_mod)
 		if node.params[0].is_auto_rec {
 			styp = styp.trim('&')
 		}
-		receiver = '($m$node.receiver.name $styp) '
-		/*
-		sym := t.get_type_symbol(node.receiver.typ)
-		name := sym.name.after('.')
-		mut m := if node.rec_mut { 'mut ' } else { '' }
-		if !node.rec_mut && node.receiver.typ.is_ptr() {
-			m = '&'
-		}
-		receiver = '($node.receiver.name $m$name) '
-		*/
+		f.write_string(styp + ') ')
 	}
-	mut name := if node.is_anon { '' } else { node.name }
-	if !node.is_anon && !node.is_method && node.language == .v {
-		name = node.name.all_after_last('.')
+	name := if !node.is_method && node.language == .v {
+		node.name.all_after_last('.')
+	} else {
+		node.name
 	}
-	// mut name := if node.is_anon { '' } else { node.name.after_char(`.`) }
-	// if !node.is_method {
-	// 	if node.language == .c {
-	// 		name = 'C.$name'
-	// 	} else if node.language == .js {
-	// 		name = 'JS.$name'
-	// 	}
-	// }
-	f.write_string('fn $receiver$name')
+	f.write_string(name)
 	if name in ['+', '-', '*', '/', '%', '<', '>', '==', '!=', '>=', '<='] {
 		f.write_string(' ')
 	}
+	stringify_fn_after_name(node, mut f, t, cur_mod, m2a)
+	return f.str()
+}
+
+fn stringify_fn_after_name(node &FnDecl, mut f strings.Builder, t &Table, cur_mod string, m2a map[string]string) {
 	mut add_para_types := true
 	if node.generic_names.len > 0 {
 		if node.is_method {
@@ -151,7 +162,6 @@ pub fn (node &FnDecl) stringify(t &Table, cur_mod string, m2a map[string]string)
 		}
 		f.write_string(' ' + rs)
 	}
-	return f.str()
 }
 
 // Expressions in string interpolations may have to be put in braces if they

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2737,7 +2737,7 @@ pub fn (mut c Checker) fn_call(mut call_expr ast.CallExpr) ast.Type {
 	}
 	call_expr.is_noreturn = func.is_noreturn
 	if !found_in_args {
-		if _ := call_expr.scope.find_var(fn_name) {
+		if call_expr.scope.known_var(fn_name) {
 			c.error('ambiguous call to: `$fn_name`, may refer to fn `$fn_name` or variable `$fn_name`',
 				call_expr.pos)
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5210,14 +5210,7 @@ pub fn (mut c Checker) expr(node ast.Expr) ast.Type {
 			return node.typ
 		}
 		ast.AnonFn {
-			c.inside_anon_fn = true
-			keep_fn := c.table.cur_fn
-			c.table.cur_fn = unsafe { &node.decl }
-			c.stmts(node.decl.stmts)
-			c.fn_decl(mut node.decl)
-			c.table.cur_fn = keep_fn
-			c.inside_anon_fn = false
-			return node.typ
+			return c.anon_fn(mut node)
 		}
 		ast.ArrayDecompose {
 			typ := c.expr(node.expr)
@@ -8165,6 +8158,30 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 		}
 	}
 	node.source_file = c.file
+}
+
+fn (mut c Checker) anon_fn(mut node ast.AnonFn) ast.Type {
+	keep_fn := c.table.cur_fn
+	keep_inside_anon := c.inside_anon_fn
+	defer {
+		c.table.cur_fn = keep_fn
+		c.inside_anon_fn = keep_inside_anon
+	}
+	c.table.cur_fn = unsafe { &node.decl }
+	c.inside_anon_fn = true
+	for mut var in node.inherited_vars {
+		parent_var := node.decl.scope.parent.find_var(var.name) or {
+			panic('unexpected checker error: cannot find parent of inherited variable `$var.name`')
+		}
+		if var.is_mut && !parent_var.is_mut {
+			c.error('original `$parent_var.name` is immutable, declare it with `mut` to make it mutable',
+				var.pos)
+		}
+		var.typ = parent_var.typ
+	}
+	c.stmts(node.decl.stmts)
+	c.fn_decl(mut node.decl)
+	return node.typ
 }
 
 // NB: has_top_return/1 should be called on *already checked* stmts,

--- a/vlib/v/checker/tests/closure_immutable.out
+++ b/vlib/v/checker/tests/closure_immutable.out
@@ -1,0 +1,21 @@
+vlib/v/checker/tests/closure_immutable.vv:4:3: error: `a` is immutable, declare it with `mut` to make it mutable
+    2 |     a := 1
+    3 |     f1 := fn [a] () {
+    4 |         a++
+      |         ^
+    5 |         println(a)
+    6 |     }
+vlib/v/checker/tests/closure_immutable.vv:7:16: error: original `a` is immutable, declare it with `mut` to make it mutable
+    5 |         println(a)
+    6 |     }
+    7 |     f2 := fn [mut a] () {
+      |                   ^
+    8 |         a++
+    9 |         println(a)
+vlib/v/checker/tests/closure_immutable.vv:13:3: error: `b` is immutable, declare it with `mut` to make it mutable
+   11 |     mut b := 2
+   12 |     f3 := fn [b] () {
+   13 |         b++
+      |         ^
+   14 |         println(b)
+   15 |     }

--- a/vlib/v/checker/tests/closure_immutable.vv
+++ b/vlib/v/checker/tests/closure_immutable.vv
@@ -1,0 +1,19 @@
+fn my_fn() {
+	a := 1
+	f1 := fn [a] () {
+		a++
+		println(a)
+	}
+	f2 := fn [mut a] () {
+		a++
+		println(a)
+	}
+	mut b := 2
+	f3 := fn [b] () {
+		b++
+		println(b)
+	}
+	f1()
+	f2()
+	f3()
+}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -490,7 +490,7 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 		ast.NodeError {}
 		ast.EmptyExpr {}
 		ast.AnonFn {
-			f.fn_decl(node.decl)
+			f.anon_fn(node)
 		}
 		ast.ArrayDecompose {
 			f.array_decompose(node)
@@ -867,6 +867,15 @@ pub fn (mut f Fmt) enum_decl(node ast.EnumDecl) {
 pub fn (mut f Fmt) fn_decl(node ast.FnDecl) {
 	f.attrs(node.attrs)
 	f.write(node.stringify(f.table, f.cur_mod, f.mod2alias)) // `Expr` instead of `ast.Expr` in mod ast
+	f.fn_body(node)
+}
+
+pub fn (mut f Fmt) anon_fn(node ast.AnonFn) {
+	f.write(node.stringify(f.table, f.cur_mod, f.mod2alias)) // `Expr` instead of `ast.Expr` in mod ast
+	f.fn_body(node.decl)
+}
+
+fn (mut f Fmt) fn_body(node ast.FnDecl) {
 	if node.language == .v {
 		if !node.no_body {
 			f.write(' {')
@@ -1006,7 +1015,7 @@ pub fn (mut f Fmt) global_decl(node ast.GlobalDecl) {
 
 pub fn (mut f Fmt) go_expr(node ast.GoExpr) {
 	f.write('go ')
-	f.expr(node.call_expr)
+	f.call_expr(node.call_expr)
 }
 
 pub fn (mut f Fmt) goto_label(node ast.GotoLabel) {
@@ -1499,7 +1508,7 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 	} else {
 		f.write_language_prefix(node.language)
 		if node.left is ast.AnonFn {
-			f.fn_decl(node.left.decl)
+			f.anon_fn(node.left)
 		} else if node.language != .v {
 			f.write('${node.name.after_char(`.`)}')
 		} else {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -391,8 +391,7 @@ pub fn (mut f Fmt) stmt(node ast.Stmt) {
 		eprintln('stmt: ${node.pos:-42} | node: ${node.type_name():-20}')
 	}
 	match node {
-		ast.NodeError {}
-		ast.EmptyStmt {}
+		ast.EmptyStmt, ast.NodeError {}
 		ast.AsmStmt {
 			f.asm_stmt(node)
 		}

--- a/vlib/v/fmt/tests/closure_keep.vv
+++ b/vlib/v/fmt/tests/closure_keep.vv
@@ -1,0 +1,10 @@
+my_var := 1
+my_simple_closure := fn [my_var] () {
+	println(my_var)
+}
+my_closure_returns := fn [my_var] () int {
+	return my_var
+}
+my_closure_has_params := fn [my_var, my_closure_returns] (add int) {
+	println(my_var + my_closure_returns() + add)
+}

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -1,5 +1,7 @@
 module c
 
+import strings
+
 // NB: @@@ here serve as placeholders.
 // They will be replaced with correct strings
 // for each constant, during C code generation.
@@ -48,6 +50,82 @@ static inline void __sort_ptr(uintptr_t a[], bool b[], int l) {
 	}
 }
 '
+
+// Heavily based on Chris Wellons's work
+// https://nullprogram.com/blog/2017/01/08/
+
+fn c_closure_helpers() string {
+	$if windows {
+		verror('closures are not implemented on Windows yet')
+	}
+	$if !x64 {
+		verror('closures are not implemented on this architecture yet')
+	}
+	mut builder := strings.new_builder(1024)
+	$if !windows {
+		builder.writeln('#include <sys/mman.h>')
+	}
+	$if x64 {
+		builder.write_string('
+static unsigned char __closure_thunk[6][13] = {
+    {
+        0x48, 0x8b, 0x3d, 0xe9, 0xff, 0xff, 0xff,
+        0xff, 0x25, 0xeb, 0xff, 0xff, 0xff
+    }, {
+        0x48, 0x8b, 0x35, 0xe9, 0xff, 0xff, 0xff,
+        0xff, 0x25, 0xeb, 0xff, 0xff, 0xff
+    }, {
+        0x48, 0x8b, 0x15, 0xe9, 0xff, 0xff, 0xff,
+        0xff, 0x25, 0xeb, 0xff, 0xff, 0xff
+    }, {
+        0x48, 0x8b, 0x0d, 0xe9, 0xff, 0xff, 0xff,
+        0xff, 0x25, 0xeb, 0xff, 0xff, 0xff
+    }, {
+        0x4C, 0x8b, 0x05, 0xe9, 0xff, 0xff, 0xff,
+        0xff, 0x25, 0xeb, 0xff, 0xff, 0xff
+    }, {
+        0x4C, 0x8b, 0x0d, 0xe9, 0xff, 0xff, 0xff,
+        0xff, 0x25, 0xeb, 0xff, 0xff, 0xff
+    },
+};
+')
+	}
+	builder.write_string('
+static void __closure_set_data(void *closure, void *data) {
+    void **p = closure;
+    p[-2] = data;
+}
+
+static void __closure_set_function(void *closure, void *f) {
+    void **p = closure;
+    p[-1] = f;
+}
+')
+	$if !windows {
+		builder.write_string('
+static void * __closure_create(void *f, int nargs, void *userdata) {
+    long page_size = sysconf(_SC_PAGESIZE);
+    int prot = PROT_READ | PROT_WRITE;
+    int flags = MAP_ANONYMOUS | MAP_PRIVATE;
+    char *p = mmap(0, page_size * 2, prot, flags, -1, 0);
+    if (p == MAP_FAILED)
+        return 0;
+    void *closure = p + page_size;
+    memcpy(closure, __closure_thunk[nargs - 1], sizeof(__closure_thunk[0]));
+    mprotect(closure, page_size, PROT_READ | PROT_EXEC);
+    __closure_set_function(closure, f);
+    __closure_set_data(closure, userdata);
+    return closure;
+}
+
+static void __closure_destroy(void *closure) {
+    long page_size = sysconf(_SC_PAGESIZE);
+    munmap((char *)closure - page_size, page_size * 2);
+}
+')
+	}
+	return builder.str()
+}
 
 const c_common_macros = '
 #define EMPTY_VARG_INITIALIZATION 0

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -3,6 +3,7 @@
 // that can be found in the LICENSE file.
 module c
 
+import strings
 import v.ast
 import v.util
 
@@ -39,7 +40,6 @@ fn (mut g Gen) process_fn_decl(node ast.FnDecl) {
 		return
 	}
 	g.gen_attrs(node.attrs)
-	// g.tmp_count = 0 TODO
 	mut skip := false
 	pos := g.out.len
 	should_bundle_module := util.should_bundle_module(node.mod)
@@ -166,6 +166,15 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 		g.table.cur_fn = node
 	}
 	fn_start_pos := g.out.len
+	is_closure := node.scope.has_inherited_vars()
+	mut cur_closure_ctx := ''
+	if is_closure {
+		cur_closure_ctx = closure_ctx_struct(node)
+		// declare the struct before its implementation
+		g.definitions.write_string(cur_closure_ctx)
+		g.definitions.writeln(';')
+	}
+
 	g.write_v_source_line_info(node.pos)
 	msvc_attrs := g.write_fn_attrs(node.attrs)
 	// Live
@@ -265,6 +274,18 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 	}
 	arg_start_pos := g.out.len
 	fargs, fargtypes, heap_promoted := g.fn_args(node.params, node.scope)
+	if is_closure {
+		mut s := '$cur_closure_ctx *$c.closure_ctx'
+		if node.params.len > 0 {
+			s = ', ' + s
+		} else {
+			// remove generated `void`
+			g.out.cut_to(arg_start_pos)
+		}
+		g.definitions.write_string(s)
+		g.write(s)
+		g.nr_closures++
+	}
 	arg_str := g.out.after(arg_start_pos)
 	if node.no_body || ((g.pref.use_cache && g.pref.build_mode != .build_module) && node.is_builtin
 		&& !g.is_test) || skip {
@@ -386,18 +407,57 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 	}
 }
 
+const closure_ctx = '_V_closure_ctx'
+
+fn closure_ctx_struct(node ast.FnDecl) string {
+	return 'struct _V_${node.name}_Ctx'
+}
+
+fn (mut g Gen) gen_anon_fn(mut node ast.AnonFn) {
+	g.gen_anon_fn_decl(mut node)
+	if !node.decl.scope.has_inherited_vars() {
+		g.write(node.decl.name)
+		return
+	}
+	// it may be possible to optimize `memdup` out if the closure never leaves current scope
+	ctx_var := g.new_tmp_var()
+	cur_line := g.go_before_stmt(0)
+	ctx_struct := closure_ctx_struct(node.decl)
+	g.writeln('$ctx_struct* $ctx_var = ($ctx_struct*) memdup(&($ctx_struct){')
+	g.indent++
+	for var in node.inherited_vars {
+		g.writeln('.$var.name = $var.name,')
+	}
+	g.indent--
+	g.writeln('}, sizeof($ctx_struct));')
+	g.empty_line = false
+	g.write(cur_line)
+	// TODO in case of an assignment, this should only call "__closure_set_data" and "__closure_set_function" (and free the former data)
+	g.write('__closure_create($node.decl.name, ${node.decl.params.len + 1}, $ctx_var)')
+}
+
 fn (mut g Gen) gen_anon_fn_decl(mut node ast.AnonFn) {
 	if node.has_gen {
 		return
 	}
+	node.has_gen = true
+	mut builder := strings.new_builder(256)
+	if node.inherited_vars.len > 0 {
+		ctx_struct := closure_ctx_struct(node.decl)
+		builder.writeln('$ctx_struct {')
+		for var in node.inherited_vars {
+			styp := g.typ(var.typ)
+			builder.writeln('\t$styp $var.name;')
+		}
+		builder.writeln('};\n')
+	}
 	pos := g.out.len
 	was_anon_fn := g.anon_fn
 	g.anon_fn = true
-	g.stmt(node.decl)
+	g.process_fn_decl(node.decl)
 	g.anon_fn = was_anon_fn
-	fn_body := g.out.cut_to(pos)
-	g.anon_fn_definitions << fn_body
-	node.has_gen = true
+	builder.write_string(g.out.cut_to(pos))
+	g.anon_fn_definitions << builder.str()
 }
 
 fn (g &Gen) defer_flag_var(stmt &ast.DeferStmt) string {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1784,49 +1784,49 @@ pub fn (mut p Parser) parse_ident(language ast.Language) ast.Ident {
 	if is_static {
 		p.next()
 	}
-	if p.tok.kind == .name {
-		pos := p.tok.position()
-		mut name := p.check_name()
-		if name == '_' {
-			return ast.Ident{
-				tok_kind: p.tok.kind
-				name: '_'
-				comptime: p.comp_if_cond
-				kind: .blank_ident
-				pos: pos
-				info: ast.IdentVar{
-					is_mut: false
-					is_static: false
-				}
-				scope: p.scope
-			}
+	if p.tok.kind != .name {
+		p.error('unexpected token `$p.tok.lit`')
+		return ast.Ident{
+			scope: p.scope
 		}
-		if p.inside_match_body && name == 'it' {
-			// p.warn('it')
-		}
-		if p.expr_mod.len > 0 {
-			name = '${p.expr_mod}.$name'
-		}
+	}
+	pos := p.tok.position()
+	mut name := p.check_name()
+	if name == '_' {
 		return ast.Ident{
 			tok_kind: p.tok.kind
-			kind: .unresolved
-			name: name
+			name: '_'
 			comptime: p.comp_if_cond
-			language: language
-			mod: p.mod
+			kind: .blank_ident
 			pos: pos
-			is_mut: is_mut
-			mut_pos: mut_pos
 			info: ast.IdentVar{
-				is_mut: is_mut
-				is_static: is_static
-				share: ast.sharetype_from_flags(is_shared, is_atomic)
+				is_mut: false
+				is_static: false
 			}
 			scope: p.scope
 		}
 	}
-	p.error('unexpected token `$p.tok.lit`')
+	if p.inside_match_body && name == 'it' {
+		// p.warn('it')
+	}
+	if p.expr_mod.len > 0 {
+		name = '${p.expr_mod}.$name'
+	}
 	return ast.Ident{
+		tok_kind: p.tok.kind
+		kind: .unresolved
+		name: name
+		comptime: p.comp_if_cond
+		language: language
+		mod: p.mod
+		pos: pos
+		is_mut: is_mut
+		mut_pos: mut_pos
+		info: ast.IdentVar{
+			is_mut: is_mut
+			is_static: is_static
+			share: ast.sharetype_from_flags(is_shared, is_atomic)
+		}
 		scope: p.scope
 	}
 }

--- a/vlib/v/parser/tests/closure_not_declared.out
+++ b/vlib/v/parser/tests/closure_not_declared.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/closure_not_declared.vv:4:9: error: undefined ident: `a`
+    2 |     a := 1
+    3 |     f := fn () {
+    4 |         print(a)
+      |               ^
+    5 |     }
+    6 |     f()

--- a/vlib/v/parser/tests/closure_not_declared.vv
+++ b/vlib/v/parser/tests/closure_not_declared.vv
@@ -1,0 +1,8 @@
+fn my_fn() {
+	a := 1
+	f := fn () {
+		print(a)
+	}
+	f()
+	_ = a
+}

--- a/vlib/v/parser/tests/closure_not_used.out
+++ b/vlib/v/parser/tests/closure_not_used.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/closure_not_used.vv:3:11: error: unused variable: `a`
+    1 | fn my_fn() {
+    2 |     a := 1
+    3 |     f := fn [a] () {
+      |              ^
+    4 |         print("hello")
+    5 |     }

--- a/vlib/v/parser/tests/closure_not_used.vv
+++ b/vlib/v/parser/tests/closure_not_used.vv
@@ -1,0 +1,7 @@
+fn my_fn() {
+	a := 1
+	f := fn [a] () {
+		print("hello")
+	}
+	f()
+}

--- a/vlib/v/parser/tests/closure_undefined_var.out
+++ b/vlib/v/parser/tests/closure_undefined_var.out
@@ -1,0 +1,6 @@
+vlib/v/parser/tests/closure_undefined_var.vv:2:11: error: undefined ident: `dont_exist`
+    1 | fn my_fn() {
+    2 |     f := fn [dont_exist] () {
+      |              ~~~~~~~~~~
+    3 |         print(dont_exist)
+    4 |     }

--- a/vlib/v/parser/tests/closure_undefined_var.vv
+++ b/vlib/v/parser/tests/closure_undefined_var.vv
@@ -1,0 +1,6 @@
+fn my_fn() {
+	f := fn [dont_exist] () {
+		print(dont_exist)
+	}
+	f()
+}

--- a/vlib/v/tests/closure_test.v
+++ b/vlib/v/tests/closure_test.v
@@ -1,0 +1,127 @@
+/*
+fn test_decl_assignment() {
+	my_var := 12
+	c1 := fn [my_var] () int {
+		return my_var
+	}
+	assert c1() == 12
+}
+*/
+
+/*
+fn test_assignment() {
+	v1 := 1
+	mut c := fn [v1] () int {
+		return v1
+	}
+	v2 := 3
+	c = fn [v2] () int {
+		return v2
+	}
+	assert c() == 3
+}
+*/
+
+/*
+fn call_anon_with_3(f fn (int) int) int {
+	return f(3)
+}
+
+fn test_closure_in_call() {
+	my_var := int(12)
+	r1 := call_anon_with_3(fn [my_var] (add int) int {
+		return my_var + add
+	})
+	assert r1 == 15
+}
+*/
+
+/*
+fn test_vars_are_changed() {
+	mut my_var := 1
+	f1 := fn [mut my_var] (expected int) {
+		assert my_var == expected
+	}
+	f1(1)
+	my_var = 3
+	f1(1)
+	my_var = -1
+	f1(1)
+}
+*/
+
+struct Counter {
+mut:
+	i u64
+}
+
+fn (mut c Counter) incr() {
+	c.i++
+}
+
+fn (mut c Counter) next() u64 {
+	c.incr()
+	return c.i
+}
+
+/*
+fn test_call_methods() {
+	mut c := Counter{}
+	f1 := fn [c] () u64 {
+		return c.next()
+	}
+	assert f1() == 1
+	assert f1() == 2
+	c.incr()
+	assert f1() == 3
+}
+*/
+
+/*
+fn test_methods_as_variables() {
+	mut c := Counter{}
+	f1 := c.next
+	assert f1() == 1
+	assert f1() == 2
+	c.incr()
+	assert f1() == 3
+}
+*/
+
+/*
+fn takes_callback(get fn () u64) u64 {
+	return get()
+}
+
+fn test_methods_as_callback() {
+	mut c := Counter{}
+	assert takes_callback(c.next) == 1
+}
+*/
+
+/*
+struct ZeroSize {}
+
+fn test_zero_size_ctx() {
+	ctx := ZeroSize{}
+	c1 := fn [ctx] () int {
+		return 123
+	}
+	assert c1() == 123
+}
+*/
+
+/*
+fn test_go_call_closure() {
+	my_var := 12
+	ch := chan int{}
+	go fn [my_var, ch] () {
+		ch <- my_var
+	}()
+	assert <-ch == 12
+	go fn [ch] (arg int) {
+		ch <- arg
+	}(15)
+	assert <-ch == 15
+}
+*/

--- a/vlib/v/tests/closure_test.v
+++ b/vlib/v/tests/closure_test.v
@@ -1,4 +1,3 @@
-/*
 fn test_decl_assignment() {
 	my_var := 12
 	c1 := fn [my_var] () int {
@@ -6,9 +5,7 @@ fn test_decl_assignment() {
 	}
 	assert c1() == 12
 }
-*/
 
-/*
 fn test_assignment() {
 	v1 := 1
 	mut c := fn [v1] () int {
@@ -20,9 +17,7 @@ fn test_assignment() {
 	}
 	assert c() == 3
 }
-*/
 
-/*
 fn call_anon_with_3(f fn (int) int) int {
 	return f(3)
 }
@@ -34,9 +29,34 @@ fn test_closure_in_call() {
 	})
 	assert r1 == 15
 }
-*/
 
-/*
+fn create_simple_counter() fn () int {
+	mut c := -1
+	return fn [mut c] () int {
+		c++
+		return c
+	}
+}
+
+fn override_stack() {
+	// just create some variables to modify the stack
+	a := 1
+	b := a + 2
+	c := b + 3
+	d := c + 4
+	e := d + 5
+	f := e + 6
+	g := f + 7
+	_ = g
+}
+
+fn test_closure_exit_original_scope() {
+	mut c := create_simple_counter()
+	assert c() == 0
+	override_stack()
+	assert c() == 1
+}
+
 fn test_vars_are_changed() {
 	mut my_var := 1
 	f1 := fn [mut my_var] (expected int) {
@@ -48,7 +68,6 @@ fn test_vars_are_changed() {
 	my_var = -1
 	f1(1)
 }
-*/
 
 struct Counter {
 mut:
@@ -64,10 +83,9 @@ fn (mut c Counter) next() u64 {
 	return c.i
 }
 
-/*
 fn test_call_methods() {
 	mut c := Counter{}
-	f1 := fn [c] () u64 {
+	f1 := fn [mut c] () u64 {
 		return c.next()
 	}
 	assert f1() == 1
@@ -75,7 +93,17 @@ fn test_call_methods() {
 	c.incr()
 	assert f1() == 3
 }
-*/
+
+fn test_call_methods_on_pointer() {
+	mut c := &Counter{}
+	f1 := fn [mut c] () u64 {
+		return c.next()
+	}
+	assert f1() == 1
+	assert f1() == 2
+	c.incr()
+	assert f1() == 4
+}
 
 /*
 fn test_methods_as_variables() {
@@ -99,7 +127,6 @@ fn test_methods_as_callback() {
 }
 */
 
-/*
 struct ZeroSize {}
 
 fn test_zero_size_ctx() {
@@ -109,7 +136,6 @@ fn test_zero_size_ctx() {
 	}
 	assert c1() == 123
 }
-*/
 
 /*
 fn test_go_call_closure() {

--- a/vlib/v/token/position.v
+++ b/vlib/v/token/position.v
@@ -13,10 +13,6 @@ pub mut:
 	last_line int // the line number where the ast object ends (used by vfmt)
 }
 
-pub fn (pos Position) str() string {
-	return 'Position{ line_nr: $pos.line_nr, last_line: $pos.last_line, pos: $pos.pos, col: $pos.col, len: $pos.len }'
-}
-
 pub fn (pos Position) extend(end Position) Position {
 	return Position{
 		...pos
@@ -29,9 +25,9 @@ pub fn (pos Position) extend_with_last_line(end Position, last_line int) Positio
 	return Position{
 		len: end.pos - pos.pos + end.len
 		line_nr: pos.line_nr
-		last_line: last_line - 1
 		pos: pos.pos
 		col: pos.col
+		last_line: last_line - 1
 	}
 }
 


### PR DESCRIPTION
Add closure support for the V language 🎉
The support is very limited right now, and I'll need help to support Windows and other architectures than x64, due to my lack of knowledge in assembly 😓
An attempt at supporting Windows is available [on my `windows-closure` branch](https://github.com/Gladear/v/tree/windows-closure).

Edit: I suggest reviewing the PR commit by commit instead of as a whole. The commits were carefully separated to make the changes as clear as possible.

The syntax implemented is the following:
```v
a := 1
my_closure := fn [a] () {
    println(a)
}
```

There is a lot to discuss, especially whether variables should be copied when the closure is created, or "captured", so if their values change outside, they change inside too.

Currently, variables are copied, but shared between closure calls. So this will return `0`, then `1`, `2`...
```v
fn create_simple_counter() fn () int {
    mut c := -1
    closure := fn [mut c] () int {
        c++
        return c
    }
    c = 10
    return closure
}
```

This points are represented in still commented tests:
```v
// TODO discuss expected behavior here
/*
fn test_vars_are_changed() {
    mut my_var := 1
    f1 := fn [mut my_var] (expected int) {
        assert my_var == expected
    }
    f1(1)
    my_var = 3
    f1(3)
    my_var = -1
    f1(-1)
}
*/

// ...

// TODO discuss expected behavior here
/*
fn test_call_methods() {
    mut c := Counter{}
    f1 := fn [mut c] () u64 {
        return c.next()
    }
    assert f1() == 1
    assert f1() == 2
    c.incr()
    assert f1() == 4
}
*/
```