### PR TITLE
v.gen.c: fix fn variadic of reference param (fix #11110)

### DIFF
--- a/cmd/tools/vtest-cleancode.v
+++ b/cmd/tools/vtest-cleancode.v
@@ -34,6 +34,7 @@ const (
 		'vlib/builtin/int.v' /* TODO byteptr: vfmt converts `pub fn (nn byteptr) str() string {` to `nn &byte` and that conflicts with `nn byte` */,
 		'vlib/builtin/string_charptr_byteptr_helpers.v' /* TODO byteptr: a temporary shim to ease the byteptr=>&byte transition */,
 		'vlib/v/tests/interop_test.v', /* bad comment formatting */
+		'vlib/v/tests/vargs_reference_param_test.v', /* variadic reference params */
 		'vlib/v/gen/js/tests/js.v', /* local `hello` fn, gets replaced with module `hello` aliased as `hl` */
 	]
 	vfmt_verify_list                = [

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -588,9 +588,11 @@ fn (mut g Gen) base_type(t ast.Type) string {
 	if t.has_flag(.shared_f) {
 		styp = g.find_or_register_shared(t, styp)
 	}
-	nr_muls := g.unwrap_generic(t).nr_muls()
-	if nr_muls > 0 {
-		styp += strings.repeat(`*`, nr_muls)
+	if !t.has_flag(.variadic) {
+		nr_muls := g.unwrap_generic(t).nr_muls()
+		if nr_muls > 0 {
+			styp += strings.repeat(`*`, nr_muls)
+		}
 	}
 	return styp
 }

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -775,8 +775,10 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			g.write('${name}(')
 		}
 	}
-	if node.receiver_type.is_ptr() && (!node.left_type.is_ptr()
-		|| node.from_embed_type != 0 || (node.left_type.has_flag(.shared_f) && node.name != 'str')) {
+	if node.receiver_type.is_ptr()
+		&& (!node.left_type.is_ptr() || node.left_type.has_flag(.variadic)
+		|| node.from_embed_type != 0
+		|| (node.left_type.has_flag(.shared_f) && node.name != 'str')) {
 		// The receiver is a reference, but the caller provided a value
 		// Add `&` automatically.
 		// TODO same logic in call_args()

--- a/vlib/v/tests/vargs_reference_param_test.v
+++ b/vlib/v/tests/vargs_reference_param_test.v
@@ -1,0 +1,27 @@
+[heap]
+struct Foo {
+	name string
+}
+
+fn agg_stuff(stuffs ...&Foo) []&Foo {
+	stuffs2 := stuffs.clone()
+	return stuffs2
+}
+
+fn arr_stuff(stuffs []&Foo) []&Foo {
+	stuffs2 := stuffs.clone()
+	return stuffs2
+}
+
+fn test_vargs_with_reference_params() {
+	foo1 := &Foo{'foo'}
+	foo2 := &Foo{'bar'}
+
+	foo11 := agg_stuff(foo1, foo2)
+	println(foo11)
+
+	foo22 := arr_stuff([foo1, foo2])
+	println(foo22)
+
+	assert '$foo11' == '$foo22'
+}


### PR DESCRIPTION
This PR fix fn variadic of reference param (fix #11110).

- Fix fn variadic of reference param.
- Add test.

```vlang
[heap]
struct Foo {
	name string
}

fn agg_stuff(stuffs ...&Foo) []&Foo {
	stuffs2 := stuffs.clone()
	return stuffs2
}

fn arr_stuff(stuffs []&Foo) []&Foo {
	stuffs2 := stuffs.clone()
	return stuffs2
}

fn main() {
	foo1 := &Foo{'foo'}
	foo2 := &Foo{'bar'}

	foo11 := agg_stuff(foo1, foo2)
	println(foo11)

	foo22 := arr_stuff([foo1, foo2])
	println(foo22)

	assert '$foo11' == '$foo22'
}

PS D:\Test\v\tt1> v run .
[Foo{
    name: 'foo'
}, Foo{
    name: 'bar'
}]
[Foo{
    name: 'foo'
}, Foo{
    name: 'bar'
}]
```