### PR TITLE
orm: refactor insert part of orm_stmt_gen method

### DIFF
--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -136,24 +136,22 @@ pub fn orm_stmt_gen(table string, para string, kind StmtKind, num bool, qm strin
 
 	match kind {
 		.insert {
-			str += 'INSERT INTO $para$table$para ('
-			for i, field in data.fields {
-				str += '$para$field$para'
-				if i < data.fields.len - 1 {
-					str += ', '
-				}
-			}
-			str += ') VALUES ('
-			for i, _ in data.fields {
-				str += qm
+			mut values := []string{}
+
+			for _ in 0 .. data.fields.len {
+				// loop over the length of data.field and generate ?0, ?1 or just ? based on the $num parameter for value placeholders
 				if num {
-					str += '$c'
+					values << '$qm$c'
 					c++
-				}
-				if i < data.fields.len - 1 {
-					str += ', '
+				} else {
+					values << '$qm'
 				}
 			}
+
+			str += 'INSERT INTO $para$table$para ('
+			str += data.fields.map('$para$it$para').join(', ')
+			str += ') VALUES ('
+			str += values.join(', ')
 			str += ')'
 		}
 		.update {


### PR DESCRIPTION
This is a super small refactoring on the ORM part of vlang. I have refactored the `insert` statement generation part of the `orm_stmt_gen`. This should make the piece of code a little more readable. If something like this is welcome I could go ahead and try to clean up the ORM and add more SQL functionalities (Of course through other PRs as required). 

Also, I haven't touched the tests since this is just a refactor

This is more of testing the water type of PR. 