### PR TITLE
v.ast.types: fix formating fn variadic of reference param

### DIFF
--- a/cmd/tools/vtest-cleancode.v
+++ b/cmd/tools/vtest-cleancode.v
@@ -34,7 +34,6 @@ const (
 		'vlib/builtin/int.v' /* TODO byteptr: vfmt converts `pub fn (nn byteptr) str() string {` to `nn &byte` and that conflicts with `nn byte` */,
 		'vlib/builtin/string_charptr_byteptr_helpers.v' /* TODO byteptr: a temporary shim to ease the byteptr=>&byte transition */,
 		'vlib/v/tests/interop_test.v', /* bad comment formatting */
-		'vlib/v/tests/vargs_reference_param_test.v', /* variadic reference params */
 		'vlib/v/gen/js/tests/js.v', /* local `hello` fn, gets replaced with module `hello` aliased as `hl` */
 	]
 	vfmt_verify_list                = [

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1064,7 +1064,7 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 		nr_muls--
 		res = 'shared ' + res
 	}
-	if nr_muls > 0 {
+	if nr_muls > 0 && !typ.has_flag(.variadic) {
 		res = strings.repeat(`&`, nr_muls) + res
 	}
 	if typ.has_flag(.optional) {

--- a/vlib/v/fmt/tests/vargs_reference_param_keep.vv
+++ b/vlib/v/fmt/tests/vargs_reference_param_keep.vv
@@ -1,0 +1,27 @@
+[heap]
+struct Foo {
+	name string
+}
+
+fn agg_stuff(stuffs ...&Foo) []&Foo {
+	stuffs2 := stuffs.clone()
+	return stuffs2
+}
+
+fn arr_stuff(stuffs []&Foo) []&Foo {
+	stuffs2 := stuffs.clone()
+	return stuffs2
+}
+
+fn main() {
+	foo1 := &Foo{'foo'}
+	foo2 := &Foo{'bar'}
+
+	foo11 := agg_stuff(foo1, foo2)
+	println(foo11)
+
+	foo22 := arr_stuff([foo1, foo2])
+	println(foo22)
+
+	assert '$foo11' == '$foo22'
+}


### PR DESCRIPTION
This PR fix formating fn variadic of reference param.

- Fix formating fn variadic of reference param.
- Add test `vargs_reference_param_keep.vv`.

before:
`fn agg_stuff(stuffs ...&Foo) []&Foo {`  fmt to `fn agg_stuff(stuffs ...&&Foo) []&Foo {`