### PR TITLE
js: Time module: utc,now,local

### DIFF
--- a/vlib/time/time.c.v
+++ b/vlib/time/time.c.v
@@ -119,3 +119,7 @@ fn convert_ctime(t C.tm, microsecond int) Time {
 		unix: make_unix_time(t)
 	}
 }
+
+pub const (
+	infinite = Duration(C.INT64_MAX)
+)

--- a/vlib/time/time.js.v
+++ b/vlib/time/time.js.v
@@ -1,0 +1,38 @@
+module time
+
+pub fn now() Time {
+	mut res := Time{}
+	#let date = new Date()
+	#res.year.val = date.getFullYear()
+	#res.month.val = date.getMonth()
+	#res.day.val = date.getDay()
+	#res.hour.val = date.getHours()
+	#res.minute.val = date.getMinutes()
+	#res.second.val = date.getSeconds()
+	#res.microsecond.val = date.getMilliseconds() * 1000
+	#res.unix.val = (date.getTime() / 1000).toFixed(0)
+
+	return res
+}
+
+pub fn utc() Time {
+	mut res := Time{}
+	#let date = new Date()
+	#res.year.val = date.getUTCFullYear()
+	#res.month.val = date.getUTCMonth()
+	#res.day.val = date.getUTCDay()
+	#res.hour.val = date.getUTCHours()
+	#res.minute.val = date.getUTCMinutes()
+	#res.second.val = date.getUTCSeconds()
+	#res.microsecond.val = date.getUTCMilliseconds() * 1000
+	#res.unix.val = (date.getTime() / 1000).toFixed(0)
+
+	return res
+}
+
+/// Returns local time
+pub fn (t Time) local() Time {
+	// TODO: Does this actually correct? JS clock is always set to timezone or no?
+	// if it is not we should try to use Intl for getting local time.
+	return t
+}

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -267,7 +267,6 @@ pub const (
 	second      = Duration(1000 * millisecond)
 	minute      = Duration(60 * second)
 	hour        = Duration(60 * minute)
-	infinite    = Duration(C.INT64_MAX)
 )
 
 // nanoseconds returns the duration as an integer number of nanoseconds.

--- a/vlib/time/time_js.js.v
+++ b/vlib/time/time_js.js.v
@@ -1,0 +1,31 @@
+module time
+
+#var $timeOff = 0;
+#var $seen = 0
+#function $sys_mono_new_Date() {
+#var t = Date.now()
+#if (t < seen)
+#timeOff += (seen - t)
+#
+#seen = t
+#return t + timeOff
+#}
+
+pub fn sys_mono_now() u64 {
+	$if js_browser {
+		mut res := u64(0)
+		#res = new u64(window.performance.now() * 1000000)
+
+		return res
+	} $else $if js_node {
+		mut res := u64(0)
+		#res.val = Number($process.hrtime.bigint())
+
+		return res
+	} $else {
+		mut res := u64(0)
+		#res = new u64($sys_mono_new_Date() * 1000000)
+
+		return res
+	}
+}

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -327,6 +327,7 @@ pub fn (mut g JsGen) init() {
 		g.definitions.writeln('const \$os = require("os");')
 		g.definitions.writeln('const \$process = process;')
 	}
+	g.definitions.writeln('function alias(value) { return value; } ')
 }
 
 pub fn (g JsGen) hashes() string {
@@ -406,13 +407,41 @@ fn (mut g JsGen) get_alias(name string) string {
 
 fn (mut g JsGen) js_name(name_ string) string {
 	mut is_js := false
+	is_overload := ['+', '-', '*', '/', '==', '<', '>']
 	mut name := name_
 	if name.starts_with('JS.') {
 		name = name[3..]
 		is_js = true
 	}
 	ns := get_ns(name)
-	name = if g.ns == 0 {
+	name = if name in is_overload {
+		match name {
+			'+' {
+				'\$add'
+			}
+			'-' {
+				'\$sub'
+			}
+			'/' {
+				'\$div'
+			}
+			'*' {
+				'\$mul'
+			}
+			'==' {
+				'eq'
+			}
+			'>' {
+				'\$gt'
+			}
+			'<' {
+				'\$lt'
+			}
+			else {
+				''
+			}
+		}
+	} else if g.ns == 0 {
 		name
 	} else if ns == g.ns.name {
 		name.split('.').last()


### PR DESCRIPTION
Implements `utc`,`now` and `local`. Plus fixed codegen for operator overloaded functions and aliases. 

P.S Operator overloading still does not work but at least does not make JS to fail on SyntaxError. I'll work on it in a separate PR