### PR TITLE
Regex: added documentation about multiple dots syntax error

### DIFF
--- a/vlib/regex/README.md
+++ b/vlib/regex/README.md
@@ -141,8 +141,8 @@ parsing source string.
 | `ab.{3} .*e` | `abccc dde` |
 The dot matches any character, until the next token match is satisfied.
 
-**Important Note:** *Consecutive dots, for example `...`, are not allowed.  This will cause a syntax error.*
-*Use a quantifier instead.*
+**Important Note:** *Consecutive dots, for example `...`, are not allowed.*
+*This will cause a syntax error. Use a quantifier instead.*
 
 ### OR token
 

--- a/vlib/regex/README.md
+++ b/vlib/regex/README.md
@@ -141,9 +141,8 @@ parsing source string.
 | `ab.{3} .*e` | `abccc dde` |
 The dot matches any character, until the next token match is satisfied.
 
-**Important Note:** *multiple consecutive like `..` are not allowed, it is managed as syntax error.*
-*instead of multiple `.` use the quntifier.`
-
+**Important Note:** *Consecutive dots, for example `...`, are not allowed.  This will cause a syntax error.*
+*Use a quantifier instead.*
 
 ### OR token
 

--- a/vlib/regex/README.md
+++ b/vlib/regex/README.md
@@ -133,16 +133,17 @@ Suppose you have `abccc ddeef` as a source string, that you want to parse
 with a regex. The following table show the query strings and the result of
 parsing source string.
 
-+--------------+-------------+
 | query string |   result    |
 |--------------|-------------|
 | `.*c`        | `abc`       |
 | `.*dd`	   | `abcc dd`   |
 | `ab.*e`      | `abccc dde` |
 | `ab.{3} .*e` | `abccc dde` |
-+--------------+-------------+
-
 The dot matches any character, until the next token match is satisfied.
+
+**Important Note:** *multiple consecutive like `..` are not allowed, it is managed as syntax error.*
+*instead of multiple `.` use the quntifier.`
+
 
 ### OR token
 
@@ -481,13 +482,13 @@ re.flag = regex.F_BIN
 
 - `F_EFM`: exit on the first char matches in the query, used by the 
            find function.
-		   
+	
 - `F_MS`:  matches only if the index of the start match is 0,
            same as `^` at the start of the query string.
-		   
+	
 - `F_ME`:  matches only if the end index of the match is the last char
            of the input string, same as `$` end of query string.
-		   
+	
 - `F_NL`:  stop the matching if found a new line char `\n` or `\r`
 
 ## Functions


### PR DESCRIPTION
**What's inside**
- an explanation of the fact that in v-regex multiple dots are errors and the user must use instead the quantifiers.

issue #10885