### PR TITLE
v.parser: fix generics type name in if_expr (fix #11154)

### DIFF
--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -57,7 +57,7 @@ pub fn (mut p Parser) check_expr(precedence int) ?ast.Expr {
 				node = p.map_init()
 				p.check(.rcbr) // `}`
 			} else {
-				if p.inside_if && p.is_generic_name() {
+				if p.inside_if && p.is_generic_name() && p.peek_tok.kind != .dot {
 					// $if T is string {}
 					p.expecting_type = true
 				}

--- a/vlib/v/tests/type_name_in_if_test.v
+++ b/vlib/v/tests/type_name_in_if_test.v
@@ -1,0 +1,13 @@
+struct Flag<T> {}
+
+fn (f Flag<T>) verify() {
+	if T.name == 'int' {
+		println('It is an int!')
+		assert true
+	}
+}
+
+fn test_generic_type_name_in_if() {
+	flag := Flag<int>{}
+	flag.verify()
+}


### PR DESCRIPTION
This PR fix generics type name in if_expr (fix #11154).

- Fix generics type name in if_expr.
- Add test.

```vlang
module main

struct Flag<T> {}

fn (f Flag<T>) verify() {
	assert T.name != 'bool' // Success
	if T.name == 'int' { // error: unknown module `T`
		println('It is an int!')
	}
}

fn main() {
	flag := Flag<int>{}
	flag.verify()
}

PS D:\Test\v\tt1> v run .
It is an int!
```