### PR TITLE
cli: fix bug that caused help to crash.

### DIFF
--- a/vlib/cli/help.v
+++ b/vlib/cli/help.v
@@ -78,7 +78,9 @@ fn (cmd Command) help_message() string {
 	mut name_len := cli.min_description_indent_len
 	if cmd.posix_mode {
 		for flag in cmd.flags {
-			abbrev_len = max(abbrev_len, flag.abbrev.len + cli.spacing + 1) // + 1 for '-' in front
+			if flag.abbrev != '' {
+				abbrev_len = max(abbrev_len, flag.abbrev.len + cli.spacing + 1) // + 1 for '-' in front
+			}
 			name_len = max(name_len, abbrev_len + flag.name.len + cli.spacing + 2) // + 2 for '--' in front
 		}
 		for command in cmd.commands {
@@ -86,6 +88,9 @@ fn (cmd Command) help_message() string {
 		}
 	} else {
 		for flag in cmd.flags {
+			if flag.abbrev != '' {
+				abbrev_len = max(abbrev_len, flag.abbrev.len + cli.spacing + 1) // + 1 for '-' in front
+			}
 			name_len = max(name_len, abbrev_len + flag.name.len + cli.spacing + 1) // + 1 for '-' in front
 		}
 		for command in cmd.commands {

--- a/vlib/cli/help_test.v
+++ b/vlib/cli/help_test.v
@@ -1,0 +1,65 @@
+module cli
+
+fn test_help_message() {
+	mut cmd := Command{
+		name: 'command'
+		description: 'description'
+		commands: [
+			Command{
+				name: 'sub'
+				description: 'subcommand'
+			},
+			Command{
+				name: 'sub2'
+				description: 'another subcommand'
+			},
+		]
+		flags: [
+			Flag{
+				flag: .string
+				name: 'str'
+				description: 'str flag'
+			},
+			Flag{
+				flag: .bool
+				name: 'bool'
+				description: 'bool flag'
+				abbrev: 'b'
+			},
+			Flag{
+				flag: .string
+				name: 'required'
+				abbrev: 'r'
+				required: true
+			},
+		]
+	}
+	assert cmd.help_message() == r'Usage: command [flags] [commands]
+
+description
+
+Flags:
+      -str            str flag
+  -b  -bool           bool flag
+  -r  -required       (required)
+
+Commands:
+  sub                 subcommand
+  sub2                another subcommand
+'
+
+	cmd.posix_mode = true
+	assert cmd.help_message() == r'Usage: command [flags] [commands]
+
+description
+
+Flags:
+      --str           str flag
+  -b  --bool          bool flag
+  -r  --required      (required)
+
+Commands:
+  sub                 subcommand
+  sub2                another subcommand
+'
+}


### PR DESCRIPTION
Fix this error
```
---- Testing... ----------------------------------------------------------------------------------------------------------------------------- 
FAIL   536.596 ms vlib/cli/help_test.v
V panic: string.repeat: count is negative: -2
v hash: 90adf4d
                                                        |       0x41fc1f | /tmp/v/test_session_34064848695600/help_test()
                                                        |       0x437a60 | /tmp/v/test_session_34064848695600/help_test()
                                                        |       0x436787 | /tmp/v/test_session_34064848695600/help_test()
                                                        |       0x440722 | /tmp/v/test_session_34064848695600/help_test()
                                                        | 0x7fc3e1efd0b3 | /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3)
                                                        |       0x4025ee | /tmp/v/test_session_34064848695600/help_test()

-------------------------------------------------------------------------------------------------------------------------------------------
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
