### PR TITLE
gg: add a `color` field to gg.DrawImageConfig

### DIFF
--- a/vlib/gg/image.v
+++ b/vlib/gg/image.v
@@ -37,7 +37,7 @@ pub:
 	part_rect Rect // defines the size and position of part of the image to use when rendering
 	rotate    int  // amount to rotate the image in degrees
 	z         f32
-	color     gx.Color
+	color     gx.Color = gx.white
 }
 
 pub struct Rect {

--- a/vlib/gg/image.v
+++ b/vlib/gg/image.v
@@ -2,8 +2,9 @@
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module gg
 
-// import gx
+
 // import sokol.sapp
+import gx
 import sokol.gfx
 import os
 import sokol
@@ -37,6 +38,7 @@ pub:
 	part_rect Rect // defines the size and position of part of the image to use when rendering
 	rotate    int  // amount to rotate the image in degrees
 	z         f32
+	color     gx.Color
 }
 
 pub struct Rect {
@@ -303,7 +305,7 @@ pub fn (ctx &Context) draw_image_with_config(config DrawImageConfig) {
 	}
 
 	sgl.begin_quads()
-	sgl.c4b(255, 255, 255, 255)
+	sgl.c4b(config.color.r, config.color.g, config.color.b, config.color.a)
 	sgl.v3f_t2f(x0, y0, config.z, u0f, v0f)
 	sgl.v3f_t2f(x1, y0, config.z, u1f, v0f)
 	sgl.v3f_t2f(x1, y1, config.z, u1f, v1f)

--- a/vlib/gg/image.v
+++ b/vlib/gg/image.v
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module gg
 
-
 // import sokol.sapp
 import gx
 import sokol.gfx


### PR DESCRIPTION
This patch adds `color` (a gx.Color struct) into `DrawImageConfig` struct for it to use in `Context.draw_image_with_config` method. With this patch `Context.draw_image_with_config` method can now draw an image with color and alpha value.

# Example:
### Color{r: 255, g: 0: b: 0, a: 255}
![image](https://user-images.githubusercontent.com/44401509/129144681-9e8c66e9-ff2c-4288-8fce-8a68e93b701a.png)

### Color{r: 0: g: 255, b: 0, a: 100}
![image](https://user-images.githubusercontent.com/44401509/129144820-9f907eb4-ba87-4b32-bf38-9f8262e16d87.png)
