### PR TITLE
v.gen.c: support `typeof(x).idx`, as well as `iface.type_idx()`

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2081,8 +2081,13 @@ pub fn (mut c Checker) method_call(mut call_expr ast.CallExpr) ast.Type {
 		c.error('optional type cannot be called directly', call_expr.left.position())
 		return ast.void_type
 	}
-	if left_type_sym.kind in [.sum_type, .interface_] && method_name == 'type_name' {
-		return ast.string_type
+	if left_type_sym.kind in [.sum_type, .interface_] {
+		if method_name == 'type_name' {
+			return ast.string_type
+		}
+		if method_name == 'type_idx' {
+			return ast.int_type
+		}
 	}
 	if left_type == ast.void_type {
 		c.error('`void` type has no methods', call_expr.left.position())
@@ -3374,10 +3379,12 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 				return ast.int_type
 			}
 			else {
-				if node.field_name != 'name' {
-					c.error('invalid field `.$node.field_name` for type `$node.expr`',
-						node.pos)
+				if node.field_name == 'name' {
+					return ast.string_type
+				} else if node.field_name == 'idx' {
+					return ast.int_type
 				}
+				c.error('invalid field `.$node.field_name` for type `$node.expr`', node.pos)
 				return ast.string_type
 			}
 		}
@@ -8006,6 +8013,8 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 			// TODO `node.map in array_builtin_methods`
 			c.error('method overrides built-in array method', node.pos)
 		} else if sym.kind == .sum_type && node.name == 'type_name' {
+			c.error('method overrides built-in sum type method', node.pos)
+		} else if sym.kind == .sum_type && node.name == 'type_idx' {
 			c.error('method overrides built-in sum type method', node.pos)
 		} else if sym.kind == .multi_return {
 			c.error('cannot define method on multi-value', node.method_type_pos)

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -514,8 +514,8 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			line_nr := p.tok.line_nr
 			name := p.check_name()
 
-			if name == 'type_name' {
-				p.error_with_pos('cannot override built-in method `type_name`', method_start_pos)
+			if name in ['type_name', 'type_idx'] {
+				p.error_with_pos('cannot override built-in method `$name`', method_start_pos)
 				return ast.InterfaceDecl{}
 			}
 			if ts.has_method(name) {

--- a/vlib/v/tests/type_idx_test.v
+++ b/vlib/v/tests/type_idx_test.v
@@ -1,0 +1,101 @@
+// NB: .type_name() and .type_idx() called on an interface instance are more expensive
+// than typeof(instance).name and typeof(instance).idx, since they will search and return
+// the name and type index of the concrete interface instance.
+//
+// typeof(interface_instance).name returns the interface name, in the example here it will
+// be always 'Animal'.
+//
+// interface_instance.type_name() will return 'Dog' or 'Cat' in this example, depending on
+// what instance it is called.
+//
+// Similarly, typeof(interface_instance).idx will always return the same type index for all
+// kinds of Animal.
+
+interface Animal {
+	name string
+}
+
+struct Dog {
+	name string
+}
+
+struct Cat {
+	name string
+}
+
+type SumType = int | string
+
+fn test_type_idx() {
+	d := Dog{
+		name: 'Carlos'
+	}
+	c := Cat{
+		name: 'Tom'
+	}
+	ad := Animal(d)
+	ac := Animal(c)
+	dump(ad)
+	dump(ac)
+	divider___()
+	dump(typeof(ad).name)
+	dump(typeof(ac).name)
+	assert typeof(ad).name == 'Animal'
+	assert typeof(ac).name == 'Animal'
+	dump(typeof(ad).idx)
+	dump(typeof(ac).idx)
+	assert typeof(ad).idx == typeof(ac).idx
+	divider___()
+	dump(ad.type_name())
+	dump(ac.type_name())
+	assert ad.type_name() == 'Dog'
+	assert ac.type_name() == 'Cat'
+	dump(ad.type_idx())
+	dump(ac.type_idx())
+	assert ad.type_idx() != ac.type_idx()
+	assert ac.type_idx() != typeof(ad).idx
+	divider___()
+	dump(typeof(d).name)
+	dump(typeof(c).name)
+	assert typeof(d).name == 'Dog'
+	assert typeof(c).name == 'Cat'
+	dump(typeof(d).idx)
+	dump(typeof(c).idx)
+	assert typeof(d).idx != typeof(c).idx
+	assert typeof(d).idx != typeof(ad).idx
+}
+
+fn test_sumtype_type_idx() {
+	s := 'abc'
+	i := 123
+	ss := SumType(s)
+	si := SumType(i)
+	divider___()
+	dump(s)
+	dump(i)
+	dump(ss)
+	dump(si)
+	dump(typeof(s).idx)
+	dump(typeof(i).idx)
+	dump(typeof(ss).idx)
+	dump(typeof(si).idx)
+	assert typeof(ss).idx != typeof(s).idx
+	assert typeof(s).idx != typeof(i).idx
+	assert typeof(ss).idx == typeof(si).idx
+	divider___()
+	dump(ss.type_name())
+	dump(si.type_name())
+	assert ss.type_name() == 'string'
+	assert si.type_name() == 'int'
+	assert ss.type_name() != si.type_name()
+	dump(ss.type_idx())
+	dump(si.type_idx())
+	assert ss.type_idx() == typeof(s).idx
+	assert si.type_idx() == typeof(i).idx
+	assert ss.type_idx() != si.type_idx()
+	assert typeof(ss).idx != ss.type_idx()
+	assert typeof(si).idx != si.type_idx()
+}
+
+fn divider___() {
+	println('------------------------------------------------------------')
+}


### PR DESCRIPTION
This PR enables the following tests (i.e. integer comparisons for interfaces and sumtype instance matching):

```v
interface Animal { name string }

struct Dog { name string }

struct Cat { name string }

type SumType = int | string

fn test_type_idx() {
	d := Dog{ name: 'Carlos' }
	c := Cat{ name: 'Tom' }
	ad := Animal(d)
	ac := Animal(c)
	assert typeof(ad).name == 'Animal'
	assert typeof(ac).name == 'Animal'
	assert typeof(ad).idx == typeof(ac).idx
	assert ad.type_name() == 'Dog'
	assert ac.type_name() == 'Cat'
	assert ad.type_idx() != ac.type_idx()
	assert ac.type_idx() != typeof(ad).idx
	assert typeof(d).name == 'Dog'
	assert typeof(c).name == 'Cat'
	assert typeof(d).idx != typeof(c).idx
	assert typeof(d).idx != typeof(ad).idx
}

fn test_sumtype_type_idx() {
	s := 'abc'
	i := 123
	ss := SumType(s)
	si := SumType(i)
	assert typeof(ss).idx != typeof(s).idx
	assert typeof(s).idx != typeof(i).idx
	assert typeof(ss).idx == typeof(si).idx
	assert ss.type_name() == 'string'
	assert si.type_name() == 'int'
	assert ss.type_name() != si.type_name()
	assert ss.type_idx() == typeof(s).idx
	assert si.type_idx() == typeof(i).idx
	assert ss.type_idx() != si.type_idx()
	assert typeof(ss).idx != ss.type_idx()
	assert typeof(si).idx != si.type_idx()
}
```