### PR TITLE
v.gen.c: fix error of if expr (fix #7337)

### DIFF
--- a/vlib/v/tests/valgrind/if_expr.v
+++ b/vlib/v/tests/valgrind/if_expr.v
@@ -1,0 +1,11 @@
+fn main() {
+	mut a := true
+	b := a && if true {
+		a = false
+		true
+	} else {
+		false
+	}
+	println(b)
+	assert b == true
+}


### PR DESCRIPTION
This PR fix error of if expr (fix #7337).

- Fix error of if expr.
- Add test.

```vlang
fn main() {
	mut a := true
	b := a && if true {
		a = false
		true
	} else {
		false
	}
	println(b)
	assert b == true
}

PS D:\Test\v\tt1> v -autofree run .
true
```
generated codes:
```vlang
VV_LOCAL_SYMBOL void main__main(void) {
	bool a = true;
	bool _t1 = a;
	bool _t2; /* if prepend */
	if (true) {
		a = false;
		_t2 = true;
	} else {
		_t2 = false;
	}
		bool b =  _t1 &&  _t2;
	string _t3 = b ? _SLIT("true") : _SLIT("false"); println(_t3); string_free(&_t3);
	;
}
```