### PR TITLE
all: add limit to errors / warnings

### DIFF
--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -131,6 +131,7 @@ const (
 		'-w',
 		'-print-v-files',
 		'-error-limit',
+		'-warn-error-limit',
 		'-os',
 		'-printfn',
 		'-cflags',

--- a/cmd/v/help/build.txt
+++ b/cmd/v/help/build.txt
@@ -82,6 +82,10 @@ NB: the build flags are shared with the run command too:
          d) the function name
       NB: if you want to output the profile info to stdout, use `-profile -`.
 
+   -warn-error-limit <limit>
+      Limit of warnings / errors that will be accumulated (defaults to 100).
+      Settings this to a negative value will disable the limit.
+
    -profile-no-inline
       Skip [inline] functions when profiling.
 

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7622,7 +7622,7 @@ fn (mut c Checker) warn_or_error(message string, pos token.Position, warn bool) 
 	}
 	if warn && !c.pref.skip_warnings {
 		c.nr_warnings++
-		if c.nr_warnings < c.pref.checker_warn_error_limit || c.pref.checker_warn_error_limit < 0 {
+		if c.nr_warnings < c.pref.warn_error_limit || c.pref.warn_error_limit < 0 {
 			wrn := errors.Warning{
 				reporter: errors.Reporter.checker
 				pos: pos
@@ -7640,7 +7640,7 @@ fn (mut c Checker) warn_or_error(message string, pos token.Position, warn bool) 
 			exit(1)
 		}
 		c.nr_errors++
-		if c.nr_errors < c.pref.checker_warn_error_limit || c.pref.warn_error_limit < 0 {
+		if c.nr_errors < c.pref.warn_error_limit || c.pref.warn_error_limit < 0 {
 			if pos.line_nr !in c.error_lines {
 				err := errors.Error{
 					reporter: errors.Reporter.checker

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7622,15 +7622,17 @@ fn (mut c Checker) warn_or_error(message string, pos token.Position, warn bool) 
 	}
 	if warn && !c.pref.skip_warnings {
 		c.nr_warnings++
-		wrn := errors.Warning{
-			reporter: errors.Reporter.checker
-			pos: pos
-			file_path: c.file.path
-			message: message
-			details: details
+		if c.nr_warnings < c.pref.checker_warn_error_limit {
+			wrn := errors.Warning{
+				reporter: errors.Reporter.checker
+				pos: pos
+				file_path: c.file.path
+				message: message
+				details: details
+			}
+			c.file.warnings << wrn
+			c.warnings << wrn
 		}
-		c.file.warnings << wrn
-		c.warnings << wrn
 		return
 	}
 	if !warn {
@@ -7638,17 +7640,19 @@ fn (mut c Checker) warn_or_error(message string, pos token.Position, warn bool) 
 			exit(1)
 		}
 		c.nr_errors++
-		if pos.line_nr !in c.error_lines {
-			err := errors.Error{
-				reporter: errors.Reporter.checker
-				pos: pos
-				file_path: c.file.path
-				message: message
-				details: details
+		if c.nr_errors < c.pref.checker_warn_error_limit {
+			if pos.line_nr !in c.error_lines {
+				err := errors.Error{
+					reporter: errors.Reporter.checker
+					pos: pos
+					file_path: c.file.path
+					message: message
+					details: details
+				}
+				c.file.errors << err
+				c.errors << err
+				c.error_lines << pos.line_nr
 			}
-			c.file.errors << err
-			c.errors << err
-			c.error_lines << pos.line_nr
 		}
 	}
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7622,7 +7622,7 @@ fn (mut c Checker) warn_or_error(message string, pos token.Position, warn bool) 
 	}
 	if warn && !c.pref.skip_warnings {
 		c.nr_warnings++
-		if c.nr_warnings < c.pref.checker_warn_error_limit {
+		if c.nr_warnings < c.pref.checker_warn_error_limit || c.pref.checker_warn_error_limit < 0 {
 			wrn := errors.Warning{
 				reporter: errors.Reporter.checker
 				pos: pos
@@ -7640,7 +7640,7 @@ fn (mut c Checker) warn_or_error(message string, pos token.Position, warn bool) 
 			exit(1)
 		}
 		c.nr_errors++
-		if c.nr_errors < c.pref.checker_warn_error_limit {
+		if c.nr_errors < c.pref.checker_warn_error_limit || c.pref.checker_warn_error_limit < 0 {
 			if pos.line_nr !in c.error_lines {
 				err := errors.Error{
 					reporter: errors.Reporter.checker

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7640,7 +7640,7 @@ fn (mut c Checker) warn_or_error(message string, pos token.Position, warn bool) 
 			exit(1)
 		}
 		c.nr_errors++
-		if c.nr_errors < c.pref.checker_warn_error_limit || c.pref.checker_warn_error_limit < 0 {
+		if c.nr_errors < c.pref.checker_warn_error_limit || c.pref.warn_error_limit < 0 {
 			if pos.line_nr !in c.error_lines {
 				err := errors.Error{
 					reporter: errors.Reporter.checker

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7622,17 +7622,18 @@ fn (mut c Checker) warn_or_error(message string, pos token.Position, warn bool) 
 	}
 	if warn && !c.pref.skip_warnings {
 		c.nr_warnings++
-		if c.nr_warnings < c.pref.warn_error_limit || c.pref.warn_error_limit < 0 {
-			wrn := errors.Warning{
-				reporter: errors.Reporter.checker
-				pos: pos
-				file_path: c.file.path
-				message: message
-				details: details
-			}
-			c.file.warnings << wrn
-			c.warnings << wrn
+		if c.nr_warnings >= c.pref.warn_error_limit && c.pref.warn_error_limit >= 0 {
+			return
 		}
+		wrn := errors.Warning{
+			reporter: errors.Reporter.checker
+			pos: pos
+			file_path: c.file.path
+			message: message
+			details: details
+		}
+		c.file.warnings << wrn
+		c.warnings << wrn
 		return
 	}
 	if !warn {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1649,7 +1649,7 @@ pub fn (mut p Parser) error_with_error(error errors.Error) {
 		eprintln(ferror)
 		exit(1)
 	} else {
-		if p.errors.len < c.pref.warn_error_limit || c.pref.warn_error_limit < 0 {
+		if p.errors.len < p.pref.warn_error_limit || p.pref.warn_error_limit < 0 {
 			p.errors << error
 		}
 	}
@@ -1674,7 +1674,7 @@ pub fn (mut p Parser) warn_with_pos(s string, pos token.Position) {
 		ferror := util.formatted_error('warning:', s, p.file_name, pos)
 		eprintln(ferror)
 	} else {
-		if p.warnings.len < c.pref.warn_error_limit || c.pref.warn_error_limit < 0 {
+		if p.warnings.len < p.pref.warn_error_limit || p.pref.warn_error_limit < 0 {
 			p.warnings << errors.Warning{
 				file_path: p.file_name
 				pos: pos

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1649,7 +1649,9 @@ pub fn (mut p Parser) error_with_error(error errors.Error) {
 		eprintln(ferror)
 		exit(1)
 	} else {
-		p.errors << error
+		if p.errors.len < c.pref.checker_warn_error_limit || c.pref.checker_warn_error_limit < 0 {
+			p.errors << error
+		}
 	}
 	if p.pref.output_mode == .silent {
 		// Normally, parser errors mean that the parser exits immediately, so there can be only 1 parser error.
@@ -1672,11 +1674,13 @@ pub fn (mut p Parser) warn_with_pos(s string, pos token.Position) {
 		ferror := util.formatted_error('warning:', s, p.file_name, pos)
 		eprintln(ferror)
 	} else {
-		p.warnings << errors.Warning{
-			file_path: p.file_name
-			pos: pos
-			reporter: .parser
-			message: s
+		if p.warnings.len < c.pref.checker_warn_error_limit || c.pref.checker_warn_error_limit < 0 {
+			p.warnings << errors.Warning{
+				file_path: p.file_name
+				pos: pos
+				reporter: .parser
+				message: s
+			}
 		}
 	}
 }

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1649,7 +1649,7 @@ pub fn (mut p Parser) error_with_error(error errors.Error) {
 		eprintln(ferror)
 		exit(1)
 	} else {
-		if p.errors.len < c.pref.checker_warn_error_limit || c.pref.checker_warn_error_limit < 0 {
+		if p.errors.len < c.pref.warn_error_limit || c.pref.warn_error_limit < 0 {
 			p.errors << error
 		}
 	}
@@ -1674,7 +1674,7 @@ pub fn (mut p Parser) warn_with_pos(s string, pos token.Position) {
 		ferror := util.formatted_error('warning:', s, p.file_name, pos)
 		eprintln(ferror)
 	} else {
-		if p.warnings.len < c.pref.checker_warn_error_limit || c.pref.checker_warn_error_limit < 0 {
+		if p.warnings.len < c.pref.warn_error_limit || c.pref.warn_error_limit < 0 {
 			p.warnings << errors.Warning{
 				file_path: p.file_name
 				pos: pos

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -189,9 +189,9 @@ pub mut:
 	gc_mode             GarbageCollectionMode = .no_gc // .no_gc, .boehm, .boehm_leak, ...
 	is_cstrict          bool                  // turn on more C warnings; slightly slower
 	assert_failure_mode AssertFailureMode // whether to call abort() or print_backtrace() after an assertion failure
+	warn_error_limit    int = 100  // limit of warnings/errors to be accumulated
 	// checker settings:
 	checker_match_exhaustive_cutoff_limit int = 12
-	checker_warn_error_limit              int = 100
 }
 
 pub fn parse_args(known_external_commands []string, args []string) (&Preferences, string) {
@@ -520,6 +520,10 @@ pub fn parse_args(known_external_commands []string, args []string) (&Preferences
 				}
 				i++
 			}
+			'-warn-error-limit' {
+				res.warn_error_limit = cmdline.option(current_args, arg, '10').int()
+				i++
+			}
 			'-cc' {
 				res.ccompiler = cmdline.option(current_args, '-cc', 'cc')
 				res.build_options << '$arg "$res.ccompiler"'
@@ -528,10 +532,6 @@ pub fn parse_args(known_external_commands []string, args []string) (&Preferences
 			'-checker-match-exhaustive-cutoff-limit' {
 				res.checker_match_exhaustive_cutoff_limit = cmdline.option(current_args,
 					arg, '10').int()
-				i++
-			}
-			'-checker-warn-error-limit' {
-				res.checker_warn_error_limit = cmdline.option(current_args, arg, '10').int()
 				i++
 			}
 			'-o', '-output' {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -191,6 +191,7 @@ pub mut:
 	assert_failure_mode AssertFailureMode // whether to call abort() or print_backtrace() after an assertion failure
 	// checker settings:
 	checker_match_exhaustive_cutoff_limit int = 12
+	checker_warn_error_limit              int = 100
 }
 
 pub fn parse_args(known_external_commands []string, args []string) (&Preferences, string) {
@@ -527,6 +528,10 @@ pub fn parse_args(known_external_commands []string, args []string) (&Preferences
 			'-checker-match-exhaustive-cutoff-limit' {
 				res.checker_match_exhaustive_cutoff_limit = cmdline.option(current_args,
 					arg, '10').int()
+				i++
+			}
+			'-checker-warn-error-limit' {
+				res.checker_warn_error_limit = cmdline.option(current_args, arg, '10').int()
 				i++
 			}
 			'-o', '-output' {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -189,7 +189,7 @@ pub mut:
 	gc_mode             GarbageCollectionMode = .no_gc // .no_gc, .boehm, .boehm_leak, ...
 	is_cstrict          bool                  // turn on more C warnings; slightly slower
 	assert_failure_mode AssertFailureMode // whether to call abort() or print_backtrace() after an assertion failure
-	warn_error_limit    int = 100  // limit of warnings/errors to be accumulated
+	warn_error_limit    int = 100 // limit of warnings/errors to be accumulated
 	// checker settings:
 	checker_match_exhaustive_cutoff_limit int = 12
 }

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1354,11 +1354,13 @@ pub fn (mut s Scanner) warn(msg string) {
 	if s.pref.output_mode == .stdout {
 		eprintln(util.formatted_error('warning:', msg, s.file_path, pos))
 	} else {
-		s.warnings << errors.Warning{
-			file_path: s.file_path
-			pos: pos
-			reporter: .scanner
-			message: msg
+		if s.warnings.len < c.pref.checker_warn_error_limit || c.pref.checker_warn_error_limit < 0 {
+			s.warnings << errors.Warning{
+				file_path: s.file_path
+				pos: pos
+				reporter: .scanner
+				message: msg
+			}
 		}
 	}
 }
@@ -1376,11 +1378,13 @@ pub fn (mut s Scanner) error(msg string) {
 		if s.pref.fatal_errors {
 			exit(1)
 		}
-		s.errors << errors.Error{
-			file_path: s.file_path
-			pos: pos
-			reporter: .scanner
-			message: msg
+		if s.errors.len < c.pref.checker_warn_error_limit || c.pref.checker_warn_error_limit < 0 {
+			s.errors << errors.Error{
+				file_path: s.file_path
+				pos: pos
+				reporter: .scanner
+				message: msg
+			}
 		}
 	}
 }

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1354,7 +1354,7 @@ pub fn (mut s Scanner) warn(msg string) {
 	if s.pref.output_mode == .stdout {
 		eprintln(util.formatted_error('warning:', msg, s.file_path, pos))
 	} else {
-		if s.warnings.len < c.pref.checker_warn_error_limit || c.pref.checker_warn_error_limit < 0 {
+		if s.warnings.len < c.pref.warn_error_limit || c.pref.warn_error_limit < 0 {
 			s.warnings << errors.Warning{
 				file_path: s.file_path
 				pos: pos
@@ -1378,7 +1378,7 @@ pub fn (mut s Scanner) error(msg string) {
 		if s.pref.fatal_errors {
 			exit(1)
 		}
-		if s.errors.len < c.pref.checker_warn_error_limit || c.pref.checker_warn_error_limit < 0 {
+		if s.errors.len < c.pref.warn_error_limit || c.pref.warn_error_limit < 0 {
 			s.errors << errors.Error{
 				file_path: s.file_path
 				pos: pos

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1354,7 +1354,7 @@ pub fn (mut s Scanner) warn(msg string) {
 	if s.pref.output_mode == .stdout {
 		eprintln(util.formatted_error('warning:', msg, s.file_path, pos))
 	} else {
-		if s.warnings.len < c.pref.warn_error_limit || c.pref.warn_error_limit < 0 {
+		if s.warnings.len < s.pref.warn_error_limit || s.pref.warn_error_limit < 0 {
 			s.warnings << errors.Warning{
 				file_path: s.file_path
 				pos: pos
@@ -1378,7 +1378,7 @@ pub fn (mut s Scanner) error(msg string) {
 		if s.pref.fatal_errors {
 			exit(1)
 		}
-		if s.errors.len < c.pref.warn_error_limit || c.pref.warn_error_limit < 0 {
+		if s.errors.len < s.pref.warn_error_limit || s.pref.warn_error_limit < 0 {
 			s.errors << errors.Error{
 				file_path: s.file_path
 				pos: pos


### PR DESCRIPTION
This fixes V from taking *ages* on long files with a lot errors.

The default limit is 100, but can be changed with `-warn-error-limit`. Changing the limit to a negative value allows infinite warnings/errors.
