### PR TITLE
checker: changes related to warn/error limit

### DIFF
--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -342,8 +342,8 @@ fn (b &Builder) show_total_warns_and_errors_stats() {
 		return
 	}
 	if b.pref.is_stats {
-		estring := util.bold(b.checker.nr_errors.str())
-		wstring := util.bold(b.checker.nr_warnings.str())
+		estring := util.bold(b.checker.errors.len.str())
+		wstring := util.bold(b.checker.warnings.len.str())
 		nstring := util.bold(b.checker.nr_notices.str())
 		println('checker summary: $estring V errors, $wstring V warnings, $nstring V notices')
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7593,6 +7593,9 @@ fn (c &Checker) check_struct_signature(from ast.Struct, to ast.Struct) bool {
 }
 
 pub fn (mut c Checker) note(message string, pos token.Position) {
+	if c.nr_notices >= c.pref.warn_error_limit && c.pref.warn_error_limit >= 0 {
+		return
+	}
 	mut details := ''
 	if c.error_details.len > 0 {
 		details = c.error_details.join('\n')

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7641,7 +7641,7 @@ fn (mut c Checker) warn_or_error(message string, pos token.Position, warn bool) 
 			exit(1)
 		}
 		c.nr_errors++
-		if c.nr_errors < c.pref.warn_error_limit || c.pref.warn_error_limit < 0 {
+		if c.errors.len < c.pref.warn_error_limit || c.pref.warn_error_limit < 0 {
 			if pos.line_nr !in c.error_lines {
 				err := errors.Error{
 					reporter: errors.Reporter.checker


### PR DESCRIPTION
Followup of #11183.

This PR fixes one issue with errors being limited too early.

Additionally,

- notices are now also limited
- `-stats` now shows the amount of warnings/errors that were actually shown

