### PR TITLE
checker: abort prematurely on many errors

### DIFF
--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -131,7 +131,6 @@ const (
 		'-w',
 		'-print-v-files',
 		'-error-limit',
-		'-warn-error-limit',
 		'-os',
 		'-printfn',
 		'-cflags',

--- a/cmd/v/help/build.txt
+++ b/cmd/v/help/build.txt
@@ -83,7 +83,8 @@ NB: the build flags are shared with the run command too:
       NB: if you want to output the profile info to stdout, use `-profile -`.
 
    -warn-error-limit <limit>
-      Limit of warnings / errors that will be accumulated (defaults to 100).
+      Limit of warnings / errors that will be accumulated (defaults to 100),
+      the checker will abort prematurely once this limit has been reached.
       Settings this to a negative value will disable the limit.
 
    -profile-no-inline

--- a/cmd/v/help/build.txt
+++ b/cmd/v/help/build.txt
@@ -82,10 +82,10 @@ NB: the build flags are shared with the run command too:
          d) the function name
       NB: if you want to output the profile info to stdout, use `-profile -`.
 
-   -warn-error-limit <limit>
-      Limit of warnings / errors that will be accumulated (defaults to 100).
+   -error-limit <limit>
+      The maximum amount of warnings / errors / notices, that will be accumulated (defaults to 100).
       The checker will abort prematurely once this limit has been reached.
-      Setting this to a negative value will disable the limit.
+      Setting this to 0 or a negative value, will disable the limit.
 
    -profile-no-inline
       Skip [inline] functions when profiling.

--- a/cmd/v/help/build.txt
+++ b/cmd/v/help/build.txt
@@ -83,9 +83,9 @@ NB: the build flags are shared with the run command too:
       NB: if you want to output the profile info to stdout, use `-profile -`.
 
    -warn-error-limit <limit>
-      Limit of warnings / errors that will be accumulated (defaults to 100),
-      the checker will abort prematurely once this limit has been reached.
-      Settings this to a negative value will disable the limit.
+      Limit of warnings / errors that will be accumulated (defaults to 100).
+      The checker will abort prematurely once this limit has been reached.
+      Setting this to a negative value will disable the limit.
 
    -profile-no-inline
       Skip [inline] functions when profiling.

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -19,14 +19,13 @@ pub:
 	compiled_dir string // contains os.real_path() of the dir of the final file beeing compiled, or the dir itself when doing `v .`
 	module_path  string
 mut:
-	pref          &pref.Preferences
-	checker       &checker.Checker
-	transformer   &transformer.Transformer
-	out_name_c    string
-	out_name_js   string
-	max_nr_errors int = 100
-	stats_lines   int // size of backend generated source code in lines
-	stats_bytes   int // size of backend generated source code in bytes
+	pref        &pref.Preferences
+	checker     &checker.Checker
+	transformer &transformer.Transformer
+	out_name_c  string
+	out_name_js string
+	stats_lines int // size of backend generated source code in lines
+	stats_bytes int // size of backend generated source code in bytes
 pub mut:
 	module_search_paths []string
 	parsed_files        []&ast.File
@@ -64,10 +63,8 @@ pub fn new_builder(pref &pref.Preferences) Builder {
 		checker: checker.new_checker(table, pref)
 		transformer: transformer.new_transformer(pref)
 		compiled_dir: compiled_dir
-		max_nr_errors: if pref.error_limit > 0 { pref.error_limit } else { 100 }
 		cached_msvc: msvc
 	}
-	// max_nr_errors: pref.error_limit ?? 100 TODO potential syntax?
 }
 
 pub fn (mut b Builder) front_stages(v_files []string) ? {
@@ -366,7 +363,7 @@ fn (b &Builder) print_warnings_and_errors() {
 		println('$b.checker.nr_notices notices')
 	}
 	if b.checker.nr_notices > 0 && !b.pref.skip_warnings {
-		for i, err in b.checker.notices {
+		for err in b.checker.notices {
 			kind := if b.pref.is_verbose {
 				'$err.reporter notice #$b.checker.nr_notices:'
 			} else {
@@ -377,13 +374,10 @@ fn (b &Builder) print_warnings_and_errors() {
 			if err.details.len > 0 {
 				eprintln('Details: $err.details')
 			}
-			if i > b.max_nr_errors {
-				return
-			}
 		}
 	}
 	if b.checker.nr_warnings > 0 && !b.pref.skip_warnings {
-		for i, err in b.checker.warnings {
+		for err in b.checker.warnings {
 			kind := if b.pref.is_verbose {
 				'$err.reporter warning #$b.checker.nr_warnings:'
 			} else {
@@ -394,10 +388,6 @@ fn (b &Builder) print_warnings_and_errors() {
 			if err.details.len > 0 {
 				eprintln('Details: $err.details')
 			}
-			// eprintln('')
-			if i > b.max_nr_errors {
-				return
-			}
 		}
 	}
 	//
@@ -405,7 +395,7 @@ fn (b &Builder) print_warnings_and_errors() {
 		println('$b.checker.nr_errors errors')
 	}
 	if b.checker.nr_errors > 0 {
-		for i, err in b.checker.errors {
+		for err in b.checker.errors {
 			kind := if b.pref.is_verbose {
 				'$err.reporter error #$b.checker.nr_errors:'
 			} else {
@@ -415,10 +405,6 @@ fn (b &Builder) print_warnings_and_errors() {
 			eprintln(ferror)
 			if err.details.len > 0 {
 				eprintln('Details: $err.details')
-			}
-			// eprintln('')
-			if i > b.max_nr_errors {
-				return
 			}
 		}
 		b.show_total_warns_and_errors_stats()

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -118,16 +118,9 @@ pub fn new_checker(table &ast.Table, pref &pref.Preferences) &Checker {
 }
 
 fn (c Checker) should_abort() bool {
-	if c.nr_notices >= c.pref.warn_error_limit && c.pref.warn_error_limit >= 0 {
-		return true
-	}
-	if c.nr_warnings >= c.pref.warn_error_limit && c.pref.warn_error_limit >= 0 {
-		return true
-	}
-	if c.errors.len >= c.pref.warn_error_limit && c.pref.warn_error_limit >= 0 {
-		return true
-	}
-	return false
+	return ((c.nr_notices >= c.pref.warn_error_limit && c.pref.warn_error_limit >= 0)
+		|| (c.nr_warnings >= c.pref.warn_error_limit && c.pref.warn_error_limit >= 0)
+		|| (c.errors.len >= c.pref.warn_error_limit && c.pref.warn_error_limit >= 0))
 }
 
 pub fn (mut c Checker) check(ast_file &ast.File) {
@@ -152,21 +145,27 @@ pub fn (mut c Checker) check(ast_file &ast.File) {
 			c.expr_level = 0
 			c.stmt(stmt)
 		}
-		if c.should_abort() { return }
+		if c.should_abort() {
+			return
+		}
 	}
 	for mut stmt in ast_file.stmts {
 		if stmt is ast.GlobalDecl {
 			c.expr_level = 0
 			c.stmt(stmt)
 		}
-		if c.should_abort() { return }
+		if c.should_abort() {
+			return
+		}
 	}
 	for mut stmt in ast_file.stmts {
 		if stmt !is ast.ConstDecl && stmt !is ast.GlobalDecl && stmt !is ast.ExprStmt {
 			c.expr_level = 0
 			c.stmt(stmt)
 		}
-		if c.should_abort() { return }
+		if c.should_abort() {
+			return
+		}
 	}
 	c.check_scope_vars(c.file.scope)
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -118,9 +118,9 @@ pub fn new_checker(table &ast.Table, pref &pref.Preferences) &Checker {
 }
 
 fn (c Checker) should_abort() bool {
-	return ((c.nr_notices >= c.pref.warn_error_limit && c.pref.warn_error_limit >= 0)
-		|| (c.nr_warnings >= c.pref.warn_error_limit && c.pref.warn_error_limit >= 0)
-		|| (c.errors.len >= c.pref.warn_error_limit && c.pref.warn_error_limit >= 0))
+	return c.pref.warn_error_limit >= 0 && (c.nr_notices >= c.pref.warn_error_limit
+		|| c.nr_warnings >= c.pref.warn_error_limit
+		|| c.errors.len >= c.pref.warn_error_limit)
 }
 
 pub fn (mut c Checker) check(ast_file &ast.File) {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -176,7 +176,6 @@ pub mut:
 	no_std              bool        // when true, do not pass -std=c99 to the C backend
 	use_color           ColorOutput // whether the warnings/errors should use ANSI color escapes.
 	is_parallel         bool
-	error_limit         int
 	is_vweb             bool // skip _ var warning in templates
 	only_check_syntax   bool // when true, just parse the files, then stop, before running checker
 	experimental        bool // enable experimental features
@@ -494,9 +493,6 @@ pub fn parse_args(known_external_commands []string, args []string) (&Preferences
 			}
 			'-print-v-files' {
 				res.print_v_files = true
-			}
-			'-error-limit' {
-				res.error_limit = cmdline.option(current_args, '-error-limit', '0').int()
 			}
 			'-os' {
 				target_os := cmdline.option(current_args, '-os', '')

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -190,7 +190,7 @@ pub mut:
 	gc_mode             GarbageCollectionMode = .no_gc // .no_gc, .boehm, .boehm_leak, ...
 	is_cstrict          bool                  // turn on more C warnings; slightly slower
 	assert_failure_mode AssertFailureMode // whether to call abort() or print_backtrace() after an assertion failure
-	warn_error_limit    int = 100 // limit of warnings/errors to be accumulated
+	message_limit       int = 100 // the maximum amount of warnings/errors/notices that will be accumulated
 	// checker settings:
 	checker_match_exhaustive_cutoff_limit int = 12
 }
@@ -524,8 +524,8 @@ pub fn parse_args(known_external_commands []string, args []string) (&Preferences
 				}
 				i++
 			}
-			'-warn-error-limit' {
-				res.warn_error_limit = cmdline.option(current_args, arg, '10').int()
+			'-message-limit' {
+				res.message_limit = cmdline.option(current_args, arg, '5').int()
 				i++
 			}
 			'-cc' {


### PR DESCRIPTION
This PR improves performance on large files with many errors by aborting the check prematurely once the limit of warnings/errors is reached (decreased time on my errorhell.v from 45s to 50**ms**).

Thanks to @BenStigsen for helping me on my quest to make this faster!
