### PR TITLE
gen: fix comptime selector reserved field names

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -20,7 +20,7 @@ fn (mut g Gen) comptime_selector(node ast.ComptimeSelector) {
 		if node.field_expr.expr is ast.Ident {
 			if node.field_expr.expr.name == g.comp_for_field_var
 				&& node.field_expr.field_name == 'name' {
-				g.write(g.comp_for_field_value.name)
+				g.write(c_name(g.comp_for_field_value.name))
 				return
 			}
 		}

--- a/vlib/v/tests/comptime_for_over_struct_with_C_reserved_word_fields_test.v
+++ b/vlib/v/tests/comptime_for_over_struct_with_C_reserved_word_fields_test.v
@@ -1,0 +1,25 @@
+struct StructWithCReservedWord {
+	error  string
+	while  int
+	extern int
+	switch bool
+}
+
+fn test_structs_that_have_fields_that_are_reserved_c_words_can_be_iterated() {
+	foo := StructWithCReservedWord{
+		error: 'this is an error message'
+		while: 123
+		extern: 456
+		switch: true
+	}
+	$for field in StructWithCReservedWord.fields {
+		$if field.typ is string {
+			println(foo.$(field.name))
+		}
+	}
+	assert foo.switch
+	assert foo.extern == 456
+	assert foo.while == 123
+	assert foo.error == 'this is an error message'
+	println(foo)
+}


### PR DESCRIPTION
This pr fixes reserved c names in comptime field selection
close #11186 