### PR TITLE
cgen: fix error of if_expr in infix_expr

### DIFF
--- a/vlib/v/tests/valgrind/if_expr_skip.v
+++ b/vlib/v/tests/valgrind/if_expr_skip.v
@@ -1,0 +1,13 @@
+fn main() {
+	mut a := false
+	b := a && if true {
+		a = true
+		true
+	} else {
+		false
+	}
+	println(b)
+	assert b == false
+	println(a)
+	assert a == false
+}


### PR DESCRIPTION
This PR fix error of if_expr in infix_expr.

- Fix error of if_expr in infix_expr.
- Add test.

```vlang
fn main() {
	mut a := false
	b := a && if true {
		a = true
		true
	} else {
		false
	}
	println(b)
	assert b == false
	println(a)
	assert a == false
}

PS D:\Test\v\tt1> v -autofree run .
false
false
```

generated c codes:
```vlang
VV_LOCAL_SYMBOL void main__main(void) {
	bool a = false;
	bool _t1 = (a);
	bool _t2; /* if prepend */
	if (_t1) {
		if (true) {
			a = true;
			_t2 = true;
		} else {
			_t2 = false;
		}
	}
	bool b = _t1 &&  _t2;
	string _t3 = b ? _SLIT("true") : _SLIT("false"); println(_t3); string_free(&_t3);
	;
        ......
```