### PR TITLE
v.readline: fix key delete panic'king on linux

### DIFF
--- a/vlib/readline/readline_linux.c.v
+++ b/vlib/readline/readline_linux.c.v
@@ -424,7 +424,7 @@ fn (mut r Readline) delete_character() {
 
 // suppr_character removes (suppresses) the character in front of the cursor.
 fn (mut r Readline) suppr_character() {
-	if r.cursor > r.current.len {
+	if r.cursor >= r.current.len {
 		return
 	}
 	r.current.delete(r.cursor)


### PR DESCRIPTION
This fixes readline panic'king when pressing the delete key and being on the very right of the current input.

Fixes #11201.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
