### PR TITLE
cgen: fix if expr of multi stmts

### DIFF
--- a/vlib/v/gen/c/assert.v
+++ b/vlib/v/gen/c/assert.v
@@ -104,7 +104,7 @@ fn (mut g Gen) gen_assert_single_expr(expr ast.Expr, typ ast.Type) {
 	// eprintln('> gen_assert_single_expr typ: $typ | expr: $expr | typeof(expr): ${typeof(expr)}')
 	unknown_value := '*unknown value*'
 	match expr {
-		ast.CastExpr, ast.IndexExpr, ast.MatchExpr {
+		ast.CastExpr, ast.IfExpr, ast.IndexExpr, ast.MatchExpr {
 			g.write(ctoslit(unknown_value))
 		}
 		ast.PrefixExpr {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4584,7 +4584,7 @@ fn (mut g Gen) need_tmp_var_in_if(node ast.IfExpr) bool {
 			return true
 		}
 		for branch in node.branches {
-			if branch.cond is ast.IfGuardExpr {
+			if branch.cond is ast.IfGuardExpr || branch.stmts.len > 1 {
 				return true
 			}
 			if branch.stmts.len == 1 {

--- a/vlib/v/gen/c/infix_expr.v
+++ b/vlib/v/gen/c/infix_expr.v
@@ -506,6 +506,8 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 fn (mut g Gen) infix_expr_and_or_op(node ast.InfixExpr) {
 	if node.right is ast.IfExpr {
 		// b := a && if true { a = false ...} else {...}
+		prev_inside_ternary := g.inside_ternary
+		g.inside_ternary = 0
 		if g.need_tmp_var_in_if(node.right) {
 			tmp := g.new_tmp_var()
 			cur_line := g.go_before_stmt(0).trim_space()
@@ -518,8 +520,10 @@ fn (mut g Gen) infix_expr_and_or_op(node ast.InfixExpr) {
 			g.infix_left_var_name = if node.op == .and { tmp } else { '!$tmp' }
 			g.expr(node.right)
 			g.infix_left_var_name = ''
+			g.inside_ternary = prev_inside_ternary
 			return
 		}
+		g.inside_ternary = prev_inside_ternary
 	}
 	g.gen_plain_infix_expr(node)
 }

--- a/vlib/v/tests/if_expr_of_multi_stmts_test.v
+++ b/vlib/v/tests/if_expr_of_multi_stmts_test.v
@@ -1,0 +1,15 @@
+fn test_if_expr_of_multi_stmts() {
+	a := 2
+	ret := if a > 1 {
+		mut b := 1
+		b *= 10
+		println(b)
+		b
+	} else {
+		mut c := 0
+		c += 2
+		println(c)
+		c
+	}
+	assert ret == 10
+}


### PR DESCRIPTION
This PR fix if expr of multi stmts.

- If branch stmts.len > 1, use tmp var instead of ternary operator.
- Add test.

```vlang
fn main() {
	a := 2
	ret := if a > 1 {
		mut b := 1
		b *= 10
		println(b)
		b
	} else {
		mut c := 0
		c += 2
		println(c)
		c
	}
	assert ret == 10
}

PS D:\Test\v\tt1> v run .
10
```