### PR TITLE
math/big: Add from_bytes function

### DIFF
--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -165,3 +165,17 @@ fn test_bytes_trimmed() {
 	assert big.from_int(1024).bytes_trimmed() == [byte(0x00), 0x04]
 	assert big.from_int(1048576).bytes_trimmed() == [byte(0x00), 0x00, 0x10]
 }
+
+fn test_from_bytes() ? {
+	assert big.from_bytes([]) ?.hexstr() == '0'
+	assert big.from_bytes([byte(0x13)]) ?.hexstr() == '13'
+	assert big.from_bytes([byte(0x13), 0x37]) ?.hexstr() == '1337'
+	assert big.from_bytes([byte(0x13), 0x37, 0xca]) ?.hexstr() == '1337ca'
+	assert big.from_bytes([byte(0x13), 0x37, 0xca, 0xfe]) ?.hexstr() == '1337cafe'
+	assert big.from_bytes([byte(0x13), 0x37, 0xca, 0xfe, 0xba]) ?.hexstr() == '1337cafeba'
+	assert big.from_bytes([byte(0x13), 0x37, 0xca, 0xfe, 0xba, 0xbe]) ?.hexstr() == '1337cafebabe'
+	assert big.from_bytes([]byte{len: 128, init: 0x0}) ?.hexstr() == '0'
+	if x := big.from_bytes([]byte{len: 129, init: 0x0}) {
+		return error('expected error, got $x')
+	}
+}


### PR DESCRIPTION
Useful with the encoding modules.

```v
import encoding.base64
import math.big

bytes := base64.decode('ZgrQjUr/Dsxkiu56NgYTaWi53qGT3Nsk4x9jjmru/ZJ89lJaPFFtIyy5sCcDWDp/VJuGmuEnp5S3cc3nWYSgUA==')
n := big.from_bytes(bytes) ?
println(n.str())
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
