### PR TITLE
vfmt: enforce add comma in multi-line brace-less struct init fields

### DIFF
--- a/vlib/term/ui/README.md
+++ b/vlib/term/ui/README.md
@@ -35,9 +35,9 @@ fn frame(x voidptr) {
 
 mut app := &App{}
 app.tui = tui.init(
-	user_data: app
-	event_fn: event
-	frame_fn: frame
+	user_data: app,
+	event_fn: event,
+	frame_fn: frame,
 	hide_cursor: true
 )
 app.tui.run() ?

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -322,6 +322,7 @@ pub:
 	name_pos token.Position
 	is_short bool
 pub mut:
+	in_call_expr		 bool
 	unresolved           bool
 	pre_comments         []Comment
 	typ                  Type

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -40,7 +40,6 @@ pub mut:
 	used_imports       []string          // to remove unused imports
 	import_syms_used   map[string]bool   // to remove unused import symbols.
 	mod2alias          map[string]string // for `import time as t`, will contain: 'time'=>'t'
-	use_short_fn_args  bool
 	single_line_fields bool   // should struct fields be on a single line
 	it_name            string // the name to replace `it` with
 	inside_lambda      bool
@@ -1547,18 +1546,8 @@ fn (mut f Fmt) write_generic_call_if_require(node ast.CallExpr) {
 
 pub fn (mut f Fmt) call_args(args []ast.CallArg) {
 	f.single_line_fields = true
-	old_short_arg_state := f.use_short_fn_args
-	f.use_short_fn_args = false
-	defer {
-		f.single_line_fields = false
-		f.use_short_fn_args = old_short_arg_state
-	}
+	defer { f.single_line_fields = false }
 	for i, arg in args {
-		if i == args.len - 1 && arg.expr is ast.StructInit {
-			if arg.expr.typ == ast.void_type {
-				f.use_short_fn_args = true
-			}
-		}
 		if arg.is_mut {
 			f.write(arg.share.str() + ' ')
 		}

--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -193,7 +193,7 @@ pub fn (mut f Fmt) struct_init(node ast.StructInit) {
 		}
 		f.mark_import_as_used(name)
 	} else if node.is_short {
-		// `Foo{1,2,3}` (short syntax )
+		// `Foo{1,2,3}` (short syntax)
 		f.write('$name{')
 		f.mark_import_as_used(name)
 		if node.has_update_expr {
@@ -209,14 +209,12 @@ pub fn (mut f Fmt) struct_init(node ast.StructInit) {
 		}
 		f.write('}')
 	} else {
-		use_short_args := f.use_short_fn_args && !node.has_update_expr
-		f.use_short_fn_args = false
 		mut single_line_fields := f.single_line_fields
 		f.single_line_fields = false
 		if node.pos.line_nr < node.pos.last_line || node.pre_comments.len > 0 {
 			single_line_fields = false
 		}
-		if !use_short_args {
+		if !node.in_call_expr {
 			f.write('$name{')
 			f.mark_import_as_used(name)
 			if single_line_fields {
@@ -226,10 +224,10 @@ pub fn (mut f Fmt) struct_init(node ast.StructInit) {
 		fields_start := f.out.len
 		fields_loop: for {
 			if !single_line_fields {
-				if use_short_args && f.out[f.out.len - 1] == ` ` {
+				if node.in_call_expr && f.out[f.out.len - 1] == ` ` {
 					//           v Remove space at tail of line
 					// f(a, b, c, \n
-					//     f1: 0\n
+					//     f1: 0,\n
 					//     f2: 1\n
 					// )
 					f.out.go_back(1)
@@ -258,6 +256,11 @@ pub fn (mut f Fmt) struct_init(node ast.StructInit) {
 					if i < node.fields.len - 1 {
 						f.write(', ')
 					}
+				} else if node.in_call_expr {
+					if i < node.fields.len - 1 {
+						f.write(',')
+					}
+					f.writeln('')
 				} else {
 					f.writeln('')
 				}
@@ -278,7 +281,7 @@ pub fn (mut f Fmt) struct_init(node ast.StructInit) {
 		if !single_line_fields {
 			f.indent--
 		}
-		if !use_short_args {
+		if !node.in_call_expr {
 			if single_line_fields {
 				f.write(' ')
 			}

--- a/vlib/v/fmt/tests/fn_trailing_arg_syntax_expected.vv
+++ b/vlib/v/fmt/tests/fn_trailing_arg_syntax_expected.vv
@@ -12,11 +12,11 @@ struct Baz {
 fn main() {
 	bar_func(x: 'this line is short enough', y: 13)
 	bar_func(
-		x: 'a very long content should cause vfmt to use multiple lines instead of one.'
+		x: 'a very long content should cause vfmt to use multiple lines instead of one.',
 		y: 123456789
 	)
 	bar_func(
-		x: 'some string'
+		x: 'some string',
 		b: Baz{
 			x: 0
 			y: 0
@@ -27,7 +27,7 @@ fn main() {
 		x: 's'
 	)
 	baz_func('foo', 'bar',
-		x: 0
+		x: 0,
 		y: 0
 	)
 	ui.row(

--- a/vlib/v/fmt/tests/fn_trailing_arg_syntax_keep.vv
+++ b/vlib/v/fmt/tests/fn_trailing_arg_syntax_keep.vv
@@ -18,8 +18,8 @@ fn foo_func(f Foo) {}
 fn main() {
 	bar_func(x: 'bar', y: 13, z: 42)
 	bar_func(
-		x: 'bar'
-		y: 13
+		x: 'bar',
+		y: 13,
 		z: 42
 	)
 	foo_func(Baz{
@@ -31,7 +31,7 @@ fn main() {
 		x: 'struct has a pre comment'
 	)
 	bar_func(
-		x: 'first field'
+		x: 'first field',
 		// comment between fields
 		y: 100
 	)
@@ -44,7 +44,7 @@ fn main() {
 		}
 	)
 	ui.button(
-		width: 70
+		width: 70,
 		onclick: fn (a voidptr, b voidptr) {
 			webview.new_window(url: 'https://vlang.io', title: 'The V programming language')
 		}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -134,7 +134,7 @@ pub fn (mut p Parser) call_args() []ast.CallArg {
 		mut expr := ast.empty_expr()
 		if p.tok.kind == .name && p.peek_tok.kind == .colon {
 			// `foo(key:val, key2:val2)`
-			expr = p.struct_init(true) // short_syntax:true
+			expr = p.struct_init(true) // in_call_expr:true
 		} else {
 			expr = p.expr(0)
 		}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2161,7 +2161,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 			p.check(.rcbr)
 			return map_init
 		}
-		return p.struct_init(false) // short_syntax: false
+		return p.struct_init(false) // in_call_expr: false
 	} else if p.peek_tok.kind == .lcbr && p.inside_if && lit0_is_capital && !known_var
 		&& language == .v {
 		// if a == Foo{} {...}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -328,13 +328,13 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 	}
 }
 
-fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
-	first_pos := (if short_syntax && p.prev_tok.kind == .lcbr { p.prev_tok } else { p.tok }).position()
-	typ := if short_syntax { ast.void_type } else { p.parse_type() }
+fn (mut p Parser) struct_init(in_call_expr bool) ast.StructInit {
+	first_pos := (if in_call_expr && p.prev_tok.kind == .lcbr { p.prev_tok } else { p.tok }).position()
+	typ := if in_call_expr { ast.void_type } else { p.parse_type() }
 	p.expr_mod = ''
 	// sym := p.table.get_type_symbol(typ)
 	// p.warn('struct init typ=$sym.name')
-	if !short_syntax {
+	if !in_call_expr {
 		p.check(.lcbr)
 	}
 	pre_comments := p.eat_comments()
@@ -403,7 +403,7 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 			}
 		}
 	}
-	if !short_syntax {
+	if !in_call_expr {
 		p.check(.rcbr)
 	}
 	p.is_amp = saved_is_amp
@@ -415,8 +415,9 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 		update_expr_comments: update_expr_comments
 		has_update_expr: has_update_expr
 		name_pos: first_pos
-		pos: first_pos.extend(if short_syntax { p.tok.position() } else { p.prev_tok.position() })
+		pos: first_pos.extend(if in_call_expr { p.tok.position() } else { p.prev_tok.position() })
 		is_short: no_keys
+		in_call_expr: in_call_expr && !has_update_expr
 		pre_comments: pre_comments
 	}
 }

--- a/vlib/x/ttf/README.md
+++ b/vlib/x/ttf/README.md
@@ -274,15 +274,14 @@ fn main() {
 	}
 
 	app.gg = gg.new_context(
-		width: win_width
-		height: win_height
-		create_window: true
-		window_title: 'Test TTF module'
-		user_data: app
-		bg_color: bg_color
-		frame_fn: draw_frame
-		init_fn: my_init
-	)
+		width: win_width,
+		height: win_height,
+		create_window: true,
+		window_title: 'Test TTF module',
+		user_data: app,
+		bg_color: bg_color,
+		frame_fn: draw_frame,
+		init_fn: my_init)
 
 	// load TTF fonts
 	for font_path in font_paths {


### PR DESCRIPTION
This PR enforces adding comma's to multi-line, brace-less struct init fields as per agreement in the [Discord server](https://discord.com/channels/592103645835821068/700746775962714232/876119009253294091).  For those who did not read, this is part of our efforts to adapt the V syntax into a [context-free grammar](https://github.com/nedpals/tree-sitter-v).

On a side-note, I have called this a "brace-less" init fields, instead of "short struct init" syntax since this is both referring to the established `Foo{x, y}` and the one this PR is tackling on which is `func(x: 1, y: 2)` which can be confusing to me (and might be to others). I might have called this `named arguments`-esque struct init but others may have a different interpretation of it. In relation to this, I have renamed the `short_syntax` variable to `in_call_expr` in order to prevent such confusion.

Another side note is that I'm not sure if `in_call_expr` field is an appropriate name to detect if the struct init is "brace-less" and within the call expression arguments.