### PR TITLE
vdoc: add `-comments` and new comment merger

### DIFF
--- a/cmd/tools/vdoc/tests/testdata/basic/main.comments.out
+++ b/cmd/tools/vdoc/tests/testdata/basic/main.comments.out
@@ -1,0 +1,7 @@
+module main
+
+const (
+	source_root = 'temp'
+)
+fn funky()
+    funky - comment for function below

--- a/cmd/tools/vdoc/tests/testdata/basic/main.out
+++ b/cmd/tools/vdoc/tests/testdata/basic/main.out
@@ -1,0 +1,6 @@
+module main
+
+const (
+	source_root = 'temp'
+)
+fn funky()

--- a/cmd/tools/vdoc/tests/testdata/basic/main.v
+++ b/cmd/tools/vdoc/tests/testdata/basic/main.v
@@ -1,8 +1,8 @@
-const (
+pub const (
 	source_root = 'temp'
 )
 
 // funky - comment for function below
-fn funky() {
+pub fn funky() {
 	println('hi')
 }

--- a/cmd/tools/vdoc/tests/testdata/multiline/main.comments.out
+++ b/cmd/tools/vdoc/tests/testdata/multiline/main.comments.out
@@ -1,10 +1,9 @@
 module main
 
-fn funky()
-    Hello!
-fn veryfunky()
-    normal comment 1
-    
-    multiline comment 2
-    
-    normal comment 3
+fn a1()
+    normal comment
+fn a2()
+    this should be merged into the same line
+fn a3()
+    This should be its own parapgraph, because it ends with a dot.  
+    This should be another paragraph.

--- a/cmd/tools/vdoc/tests/testdata/multiline/main.comments.out
+++ b/cmd/tools/vdoc/tests/testdata/multiline/main.comments.out
@@ -1,0 +1,10 @@
+module main
+
+fn funky()
+    Hello!
+fn veryfunky()
+    normal comment 1
+    
+    multiline comment 2
+    
+    normal comment 3

--- a/cmd/tools/vdoc/tests/testdata/multiline/main.out
+++ b/cmd/tools/vdoc/tests/testdata/multiline/main.out
@@ -1,4 +1,5 @@
 module main
 
-fn funky()
-fn veryfunky()
+fn a1()
+fn a2()
+fn a3()

--- a/cmd/tools/vdoc/tests/testdata/multiline/main.out
+++ b/cmd/tools/vdoc/tests/testdata/multiline/main.out
@@ -1,0 +1,4 @@
+module main
+
+fn funky()
+fn veryfunky()

--- a/cmd/tools/vdoc/tests/testdata/multiline/main.v
+++ b/cmd/tools/vdoc/tests/testdata/multiline/main.v
@@ -1,0 +1,15 @@
+/*
+Hello!
+*/
+pub fn funky() {
+	println('hi')
+}
+
+// normal comment 1
+/*
+multiline comment 2
+*/
+// normal comment 3
+pub fn veryfunky() {
+	println('hey!')
+}

--- a/cmd/tools/vdoc/tests/testdata/multiline/main.v
+++ b/cmd/tools/vdoc/tests/testdata/multiline/main.v
@@ -1,15 +1,16 @@
-/*
-Hello!
-*/
-pub fn funky() {
+// normal comment
+pub fn a1() {
 	println('hi')
 }
 
-// normal comment 1
-/*
-multiline comment 2
-*/
-// normal comment 3
-pub fn veryfunky() {
-	println('hey!')
+// this should be merged
+// into the same line
+pub fn a2() {
+	println('hi')
+}
+
+// This should be its own parapgraph, because it ends with a dot.
+// This should be another paragraph.
+pub fn a3() {
+	println('hi')
 }

--- a/cmd/tools/vdoc/tests/testdata/newlines/main.comments.out
+++ b/cmd/tools/vdoc/tests/testdata/newlines/main.comments.out
@@ -10,7 +10,8 @@ fn funky()
     code
     ```
     
-    test ====
+    test
+    ====
     - foo
     - bar
     # test

--- a/cmd/tools/vdoc/tests/testdata/newlines/main.comments.out
+++ b/cmd/tools/vdoc/tests/testdata/newlines/main.comments.out
@@ -1,7 +1,6 @@
 module main
 
 fn funky()
-    newline using two spaces  
     hello
     
     empty line

--- a/cmd/tools/vdoc/tests/testdata/newlines/main.comments.out
+++ b/cmd/tools/vdoc/tests/testdata/newlines/main.comments.out
@@ -1,0 +1,22 @@
+module main
+
+fn funky()
+    newline using two spaces  
+    hello
+    
+    empty line
+    newline using a full stop.  
+    ```v
+    code
+    ```
+    
+    test ====
+    - foo
+    - bar
+    # test
+    ########### deep test
+    #a shouldnt have a newline test
+    
+    | foo bar   |  yes   |
+    |-----------|--------|
+    |  working  |  yup   |

--- a/cmd/tools/vdoc/tests/testdata/newlines/main.out
+++ b/cmd/tools/vdoc/tests/testdata/newlines/main.out
@@ -1,0 +1,3 @@
+module main
+
+fn funky()

--- a/cmd/tools/vdoc/tests/testdata/newlines/main.v
+++ b/cmd/tools/vdoc/tests/testdata/newlines/main.v
@@ -1,6 +1,5 @@
-// newline using two spaces  
 // hello
-// 
+//
 // empty line
 // newline using a full stop.
 // ```v
@@ -15,7 +14,7 @@
 // ########### deep test
 // #a shouldnt have a newline
 // test
-// 
+//
 // | foo bar   |  yes   |
 // |-----------|--------|
 // |  working  |  yup   |

--- a/cmd/tools/vdoc/tests/testdata/newlines/main.v
+++ b/cmd/tools/vdoc/tests/testdata/newlines/main.v
@@ -1,0 +1,24 @@
+// newline using two spaces  
+// hello
+// 
+// empty line
+// newline using a full stop.
+// ```v
+// code
+// ```
+//
+// test
+// ====
+// - foo
+// - bar
+// # test
+// ########### deep test
+// #a shouldnt have a newline
+// test
+// 
+// | foo bar   |  yes   |
+// |-----------|--------|
+// |  working  |  yup   |
+pub fn funky() {
+	println('hi')
+}

--- a/cmd/tools/vdoc/tests/testdata/project1/main.out
+++ b/cmd/tools/vdoc/tests/testdata/project1/main.out
@@ -1,1 +1,0 @@
-vdoc: No documentation found for /v/vmaster/cmd/tools/vdoc/tests/testdata/project1/main.v

--- a/cmd/tools/vdoc/tests/vdoc_file_test.v
+++ b/cmd/tools/vdoc/tests/vdoc_file_test.v
@@ -43,23 +43,41 @@ fn check_path(vexe string, dir string, tests []string) int {
 		expected = clean_line_endings(expected)
 		found := clean_line_endings(res.output)
 		if expected != found {
-			println(term.red('FAIL'))
-			println('============')
-			println('expected:')
-			println(expected)
-			println('============')
-			println('found:')
-			println(found)
-			println('============\n')
-			println('diff:')
-			println(diff.color_compare_strings(diff_cmd, rand.ulid(), found, expected))
-			println('============\n')
-			nb_fail++
-		} else {
+			print_compare(expected, found)
+		}
+
+		res_comments := os.execute('$vexe doc -comments $program')
+		if res_comments.exit_code < 0 {
+			panic(res_comments.output)
+		}
+		mut expected_comments := os.read_file(program.replace('main.v', 'main.comments.out')) or { panic(err) }
+		expected_comments = clean_line_endings(expected_comments)
+		found_comments := clean_line_endings(res_comments.output)
+		if expected_comments != found_comments {
+			print_compare(expected_comments, found_comments)
+		}
+
+		if expected == found && expected_comments == found_comments {
 			println(term.green('OK'))
+		} else {
+			nb_fail++
 		}
 	}
 	return nb_fail
+}
+
+fn print_compare(expected string, found string) {
+	println(term.red('FAIL'))
+	println('============')
+	println('expected:')
+	println(expected)
+	println('============')
+	println('found:')
+	println(found)
+	println('============\n')
+	println('diff:')
+	println(diff.color_compare_strings(diff_cmd, rand.ulid(), found, expected))
+	println('============\n')
 }
 
 fn clean_line_endings(s string) string {

--- a/cmd/tools/vdoc/tests/vdoc_file_test.v
+++ b/cmd/tools/vdoc/tests/vdoc_file_test.v
@@ -50,7 +50,9 @@ fn check_path(vexe string, dir string, tests []string) int {
 		if res_comments.exit_code < 0 {
 			panic(res_comments.output)
 		}
-		mut expected_comments := os.read_file(program.replace('main.v', 'main.comments.out')) or { panic(err) }
+		mut expected_comments := os.read_file(program.replace('main.v', 'main.comments.out')) or {
+			panic(err)
+		}
 		expected_comments = clean_line_endings(expected_comments)
 		found_comments := clean_line_endings(res_comments.output)
 		if expected_comments != found_comments {

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -51,6 +51,7 @@ mut:
 	is_verbose       bool
 	include_readme   bool
 	include_examples bool = true
+	include_comments bool // for plaintext
 	inline_assets    bool
 	no_timestamp     bool
 	output_path      string
@@ -95,13 +96,15 @@ fn (vd VDoc) gen_plaintext(d doc.Doc) string {
 	} else {
 		pw.writeln('$d.head.content\n')
 	}
-	comments := if cfg.include_examples {
-		d.head.merge_comments()
-	} else {
-		d.head.merge_comments_without_examples()
-	}
-	if comments.trim_space().len > 0 && !cfg.pub_only {
-		pw.writeln(comments.split_into_lines().map('    ' + it).join('\n'))
+	if cfg.include_comments {
+		comments := if cfg.include_examples {
+			d.head.merge_comments()
+		} else {
+			d.head.merge_comments_without_examples()
+		}
+		if comments.trim_space().len > 0 {
+			pw.writeln(comments.split_into_lines().map('    ' + it).join('\n'))
+		}
 	}
 	vd.write_plaintext_content(d.contents.arr(), mut pw)
 	return pw.str()
@@ -116,7 +119,7 @@ fn (vd VDoc) write_plaintext_content(contents []doc.DocNode, mut pw strings.Buil
 			} else {
 				pw.writeln(cn.content)
 			}
-			if cn.comments.len > 0 && !cfg.pub_only {
+			if cn.comments.len > 0 && cfg.include_comments {
 				comments := if cfg.include_examples {
 					cn.merge_comments()
 				} else {
@@ -413,6 +416,9 @@ fn parse_arguments(args []string) Config {
 			}
 			'-l' {
 				cfg.show_loc = true
+			}
+			'-comments' {
+				cfg.include_comments = true
 			}
 			'-m' {
 				cfg.is_multi = true

--- a/cmd/v/help/doc.txt
+++ b/cmd/v/help/doc.txt
@@ -21,8 +21,8 @@ Options:
   -o              Specifies the output file/folder path where to store the generated docs.
                   Set it to "stdout" to print the output instead of saving the contents
                   to a file.
-  -color          Force stdout colorize output.
-  -no-color       Force plain text output, without ANSI colors.
+  -color          Forces stdout colorize output.
+  -no-color       Forces plain text output, without ANSI colors.
   -readme         Include README.md to docs if present.
   -v              Enables verbose logging. For debugging purposes.
   -no-timestamp   Omits the timestamp in the output file.
@@ -31,5 +31,5 @@ For HTML mode:
   -inline-assets  Embeds the contents of the CSS and JS assets into the webpage directly.
 
 For plain text mode:
-  -l              Show the locations of the generated signatures.
+  -l              Shows the locations of the generated signatures.
   -comments       Includes comments in the output.

--- a/cmd/v/help/doc.txt
+++ b/cmd/v/help/doc.txt
@@ -32,3 +32,4 @@ For HTML mode:
 
 For plain text mode:
   -l              Show the locations of the generated signatures.
+  -comments       Includes comments in the output.

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -4105,11 +4105,34 @@ fn copy_all(dupes bool) {
 }
 ```
 
+It also possible to use multiline comments with `/* */` (they can also be mixed with single line comments)
+
+```v
+/*
+copy_all recursively copies all elements of the array by their value,
+if `dupes` is false all duplicate values are eliminated in the process.
+*/
+fn copy_all(dupes bool) {
+	// ...
+}
+```
+
 By convention it is preferred that comments are written in *present tense*.
 
 An overview of the module must be placed in the first comment right after the module's name.
 
 To generate documentation use vdoc, for example `v doc net.http`.
+
+### Newlines in Documentation Comments
+
+Comments spanning multiple lines are merged together using spaces, unless
+
+- the line is empty
+- the line ends with a `.` (end of sentence)
+- the line is contains purely of at least 3 of `-`, `=`, `_`, `*`, `~` (horizontal rule)
+- the line starts with at least one `#` followed by a space (header)
+- the line starts and ends with a `|` (table)
+- the line starts with `- ` (list)
 
 ## Tools
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -4106,7 +4106,7 @@ fn copy_all(dupes bool) {
 ```
 
 It is also possible to use multiline comments with `/* */`
-(they can also be mixed with single line comments).
+(they can be mixed with single line comments).
 
 ```v
 /*

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -4105,7 +4105,8 @@ fn copy_all(dupes bool) {
 }
 ```
 
-It also possible to use multiline comments with `/* */` (they can also be mixed with single line comments)
+It is also possible to use multiline comments with `/* */`
+(they can also be mixed with single line comments).
 
 ```v
 /*

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -4105,19 +4105,6 @@ fn copy_all(dupes bool) {
 }
 ```
 
-It is also possible to use multiline comments with `/* */`
-(they can be mixed with single line comments).
-
-```v
-/*
-copy_all recursively copies all elements of the array by their value,
-if `dupes` is false all duplicate values are eliminated in the process.
-*/
-fn copy_all(dupes bool) {
-	// ...
-}
-```
-
 By convention it is preferred that comments are written in *present tense*.
 
 An overview of the module must be placed in the first comment right after the module's name.

--- a/vlib/v/doc/utils.v
+++ b/vlib/v/doc/utils.v
@@ -47,9 +47,9 @@ pub fn merge_doc_comments(comments []DocComment) string {
 	mut last_comment_line_nr := 0
 	for i := comments.len - 1; i >= 0; i-- {
 		cmt := comments[i]
-		if last_comment_line_nr != 0 && (cmt.pos.line_nr + 1 < last_comment_line_nr - 1
-			|| (cmt.is_multi
-			&& cmt.pos.line_nr + cmt.text.count('\n') + 1 < last_comment_line_nr - 1)) {
+		if (!cmt.is_multi && last_comment_line_nr != 0
+			&& cmt.pos.line_nr + 1 < last_comment_line_nr - 1) || (cmt.is_multi
+			&& cmt.pos.line_nr + cmt.text.count('\n') + 1 < last_comment_line_nr - 1) {
 			// skip comments that are not part of a continuous block,
 			// located right above the top level statement.
 			break
@@ -59,8 +59,13 @@ pub fn merge_doc_comments(comments []DocComment) string {
 			if cmt_content.len == 0 {
 				continue
 			}
-			multilines := cmt_content.split_into_lines()
+			mut multilines := cmt_content.split_into_lines()
+			if multilines[0] == '' {
+				multilines.delete(0)
+			}
+			commentlines << ''
 			commentlines << multilines.reverse()
+			commentlines << ''
 		} else {
 			if cmt_content.starts_with(' ') {
 				cmt_content = cmt_content[1..]

--- a/vlib/v/doc/utils.v
+++ b/vlib/v/doc/utils.v
@@ -92,7 +92,7 @@ pub fn merge_doc_comments(comments []DocComment) string {
 
 		mut is_horizontalrule := false
 		line_no_spaces := line_trimmed.replace(' ', '')
-		for char in ['+', '-', '*', '_', '~'] {
+		for char in ['-', '=', '*', '_', '~'] {
 			if line_no_spaces.starts_with(char.repeat(3))
 				&& line_no_spaces.count(char) == line_no_spaces.len {
 				is_horizontalrule = true

--- a/vlib/v/doc/utils.v
+++ b/vlib/v/doc/utils.v
@@ -43,43 +43,72 @@ pub fn merge_doc_comments(comments []DocComment) string {
 	if comments.len == 0 {
 		return ''
 	}
-	mut comment := ''
+	mut commentlines := []string{}
 	mut last_comment_line_nr := 0
 	for i := comments.len - 1; i >= 0; i-- {
 		cmt := comments[i]
-		if last_comment_line_nr != 0 && cmt.pos.line_nr + 1 < last_comment_line_nr - 1 {
+		if last_comment_line_nr != 0 && (cmt.pos.line_nr + 1 < last_comment_line_nr - 1
+			|| (cmt.is_multi
+			&& cmt.pos.line_nr + cmt.text.count('\n') + 1 < last_comment_line_nr - 1)) {
 			// skip comments that are not part of a continuous block,
 			// located right above the top level statement.
-			// break
+			break
 		}
 		mut cmt_content := cmt.text.trim_left('\x01')
 		if cmt.is_multi {
-			// ignore /* */ style comments for now
-			continue
-			// if cmt_content.len == 0 {
-			// continue
-			// }
-			// mut new_cmt_content := ''
-			// mut is_codeblock := false
-			// // println(cmt_content)
-			// lines := cmt_content.split_into_lines()
-			// for j, line in lines {
-			// trimmed := line.trim_space().trim_left(cmt_prefix)
-			// if trimmed.starts_with('- ') || (trimmed.len >= 2 && trimmed[0].is_digit() && trimmed[1] == `.`) || is_codeblock {
-			// new_cmt_content += line + '\n'
-			// } else if line.starts_with('```') {
-			// is_codeblock = !is_codeblock
-			// new_cmt_content += line + '\n'
-			// } else {
-			// new_cmt_content += trimmed + '\n'
-			// }
-			// }
-			// return new_cmt_content
+			if cmt_content.len == 0 {
+				continue
+			}
+			multilines := cmt_content.split_into_lines()
+			commentlines << multilines.reverse()
+		} else {
+			if cmt_content.starts_with(' ') {
+				cmt_content = cmt_content[1..]
+			}
+			commentlines << cmt_content
 		}
-		// eprintln('cmt: $cmt')
-		cseparator := if cmt_content.starts_with('```') { '\n' } else { ' ' }
-		comment = cmt_content + cseparator + comment
 		last_comment_line_nr = cmt.pos.line_nr + 1
+	}
+	commentlines = commentlines.reverse()
+	mut is_codeblock := false
+	mut previously_newline := true
+	mut comment := ''
+	for line in commentlines {
+		if line.starts_with('```') {
+			is_codeblock = !is_codeblock
+			comment = comment + '\n' + line
+			continue
+		} else if is_codeblock {
+			comment = comment + '\n' + line
+			continue
+		}
+
+		line_trimmed := line.trim(' ')
+
+		mut is_horizontalrule := false
+		line_no_spaces := line_trimmed.replace(' ', '')
+		for char in ['+', '-', '*', '_', '~'] {
+			if line_no_spaces.starts_with(char.repeat(3))
+				&& line_no_spaces.count(char) == line_no_spaces.len {
+				is_horizontalrule = true
+				break
+			}
+		}
+
+		if line.ends_with('  ') || line_trimmed == '' || is_horizontalrule
+			|| (line.starts_with('#') && line.before(' ').count('#') == line.before(' ').len)
+			|| (line_trimmed.starts_with('|') && line_trimmed.ends_with('|'))
+			|| line_trimmed.starts_with('- ') {
+			comment = comment + '\n' + line
+			previously_newline = true
+		} else if line.ends_with('.') {
+			comment = comment + '\n' + line + '  '
+			previously_newline = true
+		} else {
+			sep := if previously_newline { '\n' } else { ' ' }
+			comment = comment + sep + line
+			previously_newline = false
+		}
 	}
 	return comment
 }

--- a/vlib/v/doc/utils.v
+++ b/vlib/v/doc/utils.v
@@ -100,7 +100,7 @@ pub fn merge_doc_comments(comments []DocComment) string {
 			}
 		}
 
-		if line.ends_with('  ') || line_trimmed == '' || is_horizontalrule
+		if line_trimmed == '' || is_horizontalrule
 			|| (line.starts_with('#') && line.before(' ').count('#') == line.before(' ').len)
 			|| (line_trimmed.starts_with('|') && line_trimmed.ends_with('|'))
 			|| line_trimmed.starts_with('- ') {

--- a/vlib/v/doc/utils.v
+++ b/vlib/v/doc/utils.v
@@ -56,16 +56,9 @@ pub fn merge_doc_comments(comments []DocComment) string {
 		}
 		mut cmt_content := cmt.text.trim_left('\x01')
 		if cmt.is_multi {
-			if cmt_content.len == 0 {
-				continue
-			}
-			mut multilines := cmt_content.split_into_lines()
-			if multilines[0] == '' {
-				multilines.delete(0)
-			}
-			commentlines << ''
-			commentlines << multilines.reverse()
-			commentlines << ''
+			// /**/ comments are deliberately NOT supported as vdoc comments,
+			// so just ignore them:
+			continue
 		} else {
 			if cmt_content.starts_with(' ') {
 				cmt_content = cmt_content[1..]


### PR DESCRIPTION
This adds `-comments` and a new comment merger.

You can enable comments in plaintext mode using `-comments` (previously `-all` was used, which didn't make sense)

New features of the comment merger:

- support for `/* */` comments
- smart newlines for markdown
  - ~~two spaces at the end of line~~ (removed due to v fmt not liking it and comments shouldnt be markdown)
  - empty lines
  - horizontal rules (`---`)
  - headers
  - tables
  - lists
  - after line ends with `.` (just looks WAY better)

This allows for *actually* putting new lines or multi line markdown in docs that are not part of the README.

Feedback welcome! 😄 
