### PR TITLE
vweb: add TrueType and OpenType mime types

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -57,6 +57,8 @@ pub const (
 		'.wasm': 'application/wasm'
 		'.xml':  'text/xml; charset=utf-8'
 		'.ico':  'img/x-icon'
+		'.ttf':  'font/ttf'
+		'.otf':  'font/opentype'
 	}
 	max_http_post_size = 1024 * 1024
 	default_port       = 8080


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
Adds TrueType (.ttf) and OpenType (.otf) font mime types in the vweb module to allow use with `handle_static`, `mount_static_folder_at`, and `serve_static` functions.