### PR TITLE
all: fix formating Foo<A,B> to Foo<A, B>

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -202,7 +202,7 @@ pub fn (t &Table) fn_type_signature(f &Fn) string {
 		typ := arg.typ.set_nr_muls(0)
 		arg_type_sym := t.get_type_symbol(typ)
 		sig += arg_type_sym.str().to_lower().replace_each(['.', '__', '&', '', '[]', 'arr_', 'chan ',
-			'chan_', 'map[', 'map_of_', ']', '_to_', '<', '_T_', ',', '_', '>', ''])
+			'chan_', 'map[', 'map_of_', ']', '_to_', '<', '_T_', ',', '_', ' ', '', '>', ''])
 		if i < f.params.len - 1 {
 			sig += '_'
 		}
@@ -1428,7 +1428,7 @@ pub fn (mut t Table) resolve_generic_to_concrete(generic_type Type, generic_name
 						gts := t.get_type_symbol(ct)
 						nrt += gts.name
 						if i != sym.info.generic_types.len - 1 {
-							nrt += ','
+							nrt += ', '
 						}
 					}
 				}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -696,7 +696,7 @@ fn (mut c Checker) unwrap_generic_type(typ ast.Type, generic_names []string, con
 					nrt += gts.name
 					c_nrt += gts.cname
 					if i != ts.info.generic_types.len - 1 {
-						nrt += ','
+						nrt += ', '
 						c_nrt += '_'
 					}
 				}

--- a/vlib/v/checker/tests/generic_sumtype_invalid_variant.out
+++ b/vlib/v/checker/tests/generic_sumtype_invalid_variant.out
@@ -1,11 +1,11 @@
-vlib/v/checker/tests/generic_sumtype_invalid_variant.vv:5:7: error: `MultiGeneric<bool,int,string>` has no variant `u64`
+vlib/v/checker/tests/generic_sumtype_invalid_variant.vv:5:7: error: `MultiGeneric<bool, int, string>` has no variant `u64`
     3 | fn main() {
     4 |     mut m := MultiGeneric<bool, int, string>(true)
     5 |     if m is u64 {
       |          ~~
     6 |         println('hi')
     7 |     }
-vlib/v/checker/tests/generic_sumtype_invalid_variant.vv:8:7: error: `MultiGeneric<bool,int,string>` has no variant `X`
+vlib/v/checker/tests/generic_sumtype_invalid_variant.vv:8:7: error: `MultiGeneric<bool, int, string>` has no variant `X`
     6 |         println('hi')
     7 |     }
     8 |     if m is X {

--- a/vlib/v/fmt/tests/generic_structs_keep.vv
+++ b/vlib/v/fmt/tests/generic_structs_keep.vv
@@ -31,7 +31,7 @@ fn main() {
 	assert foo_int.value() == '2'
 	println(foo_int)
 	//
-	x := Repo<int,f64>{'abc', 3, 1.5}
+	x := Repo<int, f64>{'abc', 3, 1.5}
 	println(x.db)
 	println(x.model)
 	println(x.permission)

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -543,7 +543,7 @@ pub fn (mut p Parser) parse_generic_inst_type(name string) ast.Type {
 			break
 		}
 		p.next()
-		bs_name += ','
+		bs_name += ', '
 		bs_cname += '_'
 	}
 	p.check(.gt)

--- a/vlib/v/tests/generics_interface_with_multi_generic_types_test.v
+++ b/vlib/v/tests/generics_interface_with_multi_generic_types_test.v
@@ -20,7 +20,7 @@ fn (mut it ArrIter<T, U>) next<T, U>() ?(T, U) {
 }
 
 fn iter<T, U>(t []T, u []U) Iter<T, U> {
-	return ArrIter<T,U>{
+	return ArrIter<T, U>{
 		t: t
 		u: u
 	}

--- a/vlib/v/tests/generics_return_multiple_generics_struct_test.v
+++ b/vlib/v/tests/generics_return_multiple_generics_struct_test.v
@@ -5,7 +5,7 @@ mut:
 }
 
 fn new_foo<A, B>(a A, b B) Foo<A, B> {
-	return Foo<A,B>{
+	return Foo<A, B>{
 		a: a
 		b: b
 	}

--- a/vlib/v/tests/generics_with_anon_generics_fn_test.v
+++ b/vlib/v/tests/generics_with_anon_generics_fn_test.v
@@ -50,7 +50,7 @@ fn test_generics_with_anon_generics_fn() {
 	assert call(consume, 1) == 1
 	assert call(consume_str, '1') == '1'
 
-	pair := Pair<int,string>{1, 's'}
+	pair := Pair<int, string>{1, 's'}
 	assert call(fn (v Pair<int, string>) Pair<int, string> {
 		return v
 	}, pair) == pair

--- a/vlib/v/tests/generics_with_multiple_generics_struct_receiver_test.v
+++ b/vlib/v/tests/generics_with_multiple_generics_struct_receiver_test.v
@@ -12,7 +12,7 @@ fn (num Foo<A, B>) get_foo2<B, A>() (A, B) {
 }
 
 fn test_generics_with_multi_generics_struct_receiver() {
-	num := Foo<int,string>{
+	num := Foo<int, string>{
 		a: 3
 		b: 'aaa'
 	}


### PR DESCRIPTION
This PR fix formating generic struct Foo<A,B> to Foo<A, B>.