### PR TITLE
checker: check using redundant parentheses

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3410,8 +3410,8 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 		return ast.void_type
 	}
 	node.expr_type = typ
-	if node.expr_type.has_flag(.optional) && !((node.expr is ast.Ident
-		&& (node.expr as ast.Ident).kind == .constant)) {
+	if node.expr_type.has_flag(.optional) && !(node.expr is ast.Ident
+		&& (node.expr as ast.Ident).kind == .constant) {
 		c.error('cannot access fields of an optional, handle the error with `or {...}` or propagate it with `?`',
 			node.pos)
 	}
@@ -5435,6 +5435,9 @@ pub fn (mut c Checker) expr(node ast.Expr) ast.Type {
 		// return node.typ
 		// }
 		ast.ParExpr {
+			if node.expr is ast.ParExpr {
+				c.warn('redundant parentheses are used', node.pos)
+			}
 			return c.expr(node.expr)
 		}
 		ast.RangeExpr {
@@ -7316,7 +7319,7 @@ pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) ast.Type {
 			if node.left.obj is ast.Var {
 				v := node.left.obj as ast.Var
 				// `mut param []T` function parameter
-				is_ok = ((v.is_mut && v.is_arg)) && !typ.deref().is_ptr()
+				is_ok = v.is_mut && v.is_arg && !typ.deref().is_ptr()
 			}
 		}
 		if !is_ok && !c.pref.translated {

--- a/vlib/v/checker/tests/redundant_parentheses_warning.out
+++ b/vlib/v/checker/tests/redundant_parentheses_warning.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/redundant_parentheses_warning.vv:3:7: error: redundant parentheses are used
+    1 | fn main() {
+    2 |     a := 2
+    3 |     b := ((a + 2))
+      |          ~~~~~~~~~
+    4 |     println(b)
+    5 | }

--- a/vlib/v/checker/tests/redundant_parentheses_warning.vv
+++ b/vlib/v/checker/tests/redundant_parentheses_warning.vv
@@ -1,0 +1,5 @@
+fn main() {
+	a := 2
+	b := ((a + 2))
+	println(b)
+}


### PR DESCRIPTION
This PR check using redundant parentheses.

- Check using redundant parentheses.
- Add redundant_parentheses_warning.vv/out.
- Modify related warning in checker.v.

```vlang
fn main() {
	a := 2
	b := ((a + 2))
	println(b)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:3:7: warning: redundant parentheses are used
    1 | fn main() {
    2 |     a := 2
    3 |     b := ((a + 2))
      |          ~~~~~~~~~
    4 |     println(b)
    5 | }
4
```