### PR TITLE
time_nix: use C var in C call

### DIFF
--- a/vlib/time/time_nix.c.v
+++ b/vlib/time/time_nix.c.v
@@ -21,7 +21,7 @@ struct C.tm {
 fn C.timegm(&C.tm) C.time_t
 
 // fn C.gmtime_r(&tm, &gbuf)
-fn C.localtime_r(t &time_t, tm &C.tm)
+fn C.localtime_r(t &C.time_t, tm &C.tm)
 
 fn make_unix_time(t C.tm) i64 {
 	return i64(C.timegm(&t))


### PR DESCRIPTION
Minor change to use `C.time_t` instead of `time_t` in `C.localtime_r`.

Pushing for @hungrybluedev per Discord discussion.