### PR TITLE
checker, cgen: fix generic struct with non_generic interface (fix #11235)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -845,6 +845,10 @@ pub fn (mut c Checker) generic_insts_to_concrete() {
 						typ.is_public = true
 						typ.kind = parent.kind
 					}
+					parent_sym := c.table.get_type_symbol(parent_info.parent_type)
+					for method in parent_sym.methods {
+						c.table.register_fn_concrete_types(method.name, info.concrete_types)
+					}
 				}
 				ast.Interface {
 					mut parent_info := parent.info as ast.Interface

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6652,6 +6652,12 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 					continue
 				}
 				// .speak = Cat_speak
+				if st_sym.info is ast.Struct {
+					if st_sym.info.parent_type.has_flag(.generic) {
+						name = g.generic_fn_name(st_sym.info.concrete_types, method.name,
+							false)
+					}
+				}
 				mut method_call := '${cctype}_$name'
 				if !method.params[0].typ.is_ptr() {
 					// inline void Cat_speak_Interface_Animal_method_wrapper(Cat c) { return Cat_speak(*c); }

--- a/vlib/v/tests/generics_struct_with_non_generic_interface_test.v
+++ b/vlib/v/tests/generics_struct_with_non_generic_interface_test.v
@@ -1,0 +1,25 @@
+interface Box {
+	transform(input int) int
+}
+
+struct Test<T> {
+	data T
+	salt int
+}
+
+fn (t Test<T>) transform(input int) int {
+	return input + t.salt
+}
+
+fn box_transform(b Box) int {
+	return b.transform(100)
+}
+
+fn test_generic_struct_with_non_generic_interface() {
+	ret := box_transform(Test<string>{
+		data: 'hello'
+		salt: 6
+	})
+	println(ret)
+	assert ret == 106
+}


### PR DESCRIPTION
This PR fix generic struct with non_generic interface (fix #11235).

- Fix generic struct with non_generic interface.
- Add test.

```vlang
interface Box {
	transform(input int) int
}

struct Test<T> {
	data T
	salt int
}

fn (t Test<T>) transform(input int) int {
	return input + t.salt
}

fn box_transform(b Box) int {
	return b.transform(100)
}

fn main() {
	ret := box_transform(Test<string>{
		data: 'hello'
		salt: 6
	})
	println(ret)
	assert ret == 106
}

PS D:\Test\v\tt1> v run .
106
```