### PR TITLE
vweb: Use Response struct for 302 response

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -89,6 +89,7 @@ const (
 		'vlib/net/http/http_httpbin_test.v',
 		'vlib/net/http/header_test.v',
 		'vlib/net/http/server_test.v',
+		'vlib/net/http/response_test.v',
 	]
 	skip_on_linux                 = [
 		'do_not_remove',

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -47,6 +47,7 @@ const (
 		'vlib/vweb/tests/vweb_test.v',
 		'vlib/vweb/request_test.v',
 		'vlib/net/http/request_test.v',
+		'vlib/net/http/response_test.v',
 		'vlib/vweb/route_test.v',
 		'vlib/net/websocket/websocket_test.v',
 		'vlib/crypto/rand/crypto_rand_read_test.v',

--- a/vlib/net/http/response_test.v
+++ b/vlib/net/http/response_test.v
@@ -1,0 +1,36 @@
+module http
+
+fn test_response_bytestr() ? {
+	{
+		resp := new_response(
+			status: .ok
+			text: 'Foo'
+		)
+		assert resp.bytestr() == 'HTTP/1.1 200 OK\r\n' + 'Content-Length: 3\r\n' + '\r\n' + 'Foo'
+	}
+	{
+		resp := new_response(
+			status: .found
+			text: 'Foo'
+			header: new_header(key: .location, value: '/')
+		)
+		lines := resp.bytestr().split_into_lines()
+		assert lines[0] == 'HTTP/1.1 302 Found'
+		// header order is not guaranteed
+		check_headers(['Location: /', 'Content-Length: 3'], lines[1..3]) ?
+		assert lines[3] == ''
+		assert lines[4] == 'Foo'
+	}
+}
+
+// check_headers is a helper function for asserting all expected headers
+// are found because rendered header order is not guaranteed. The check
+// is O(n^2) which is fine for small lists.
+fn check_headers(expected []string, found []string) ? {
+	assert expected.len == found.len
+	for header in expected {
+		if !found.contains(header) {
+			return error('expected header "$header" not in $found')
+		}
+	}
+}

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -17,6 +17,11 @@ pub const (
 		http.CommonHeader.connection.str(): 'close'
 	}) or { panic('should never fail') }
 
+	http_302          = http.new_response(
+		status: .found
+		text: '302 Found'
+		header: headers_close
+	)
 	http_400          = http.new_response(
 		status: .bad_request
 		text: '400 Bad Request'
@@ -246,9 +251,10 @@ pub fn (mut ctx Context) redirect(url string) Result {
 		return Result{}
 	}
 	ctx.done = true
-	send_string(mut ctx.conn, 'HTTP/1.1 302 Found\r\nLocation: $url\r\n$ctx.header\r\n$vweb.headers_close\r\n') or {
-		return Result{}
-	}
+	mut resp := vweb.http_302
+	resp.header = resp.header.join(ctx.header)
+	resp.header.add(.location, url)
+	send_string(mut ctx.conn, resp.bytestr()) or { return Result{} }
 	return Result{}
 }
 


### PR DESCRIPTION
Fixes newline bugs.

The recent fix made me realize there was an extra newline in the headers causing some of them to be part of the body. Using `Response{}` will prevent these bugs and makes the output testable.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
