### PR TITLE
checker: fix generic struct with non-generic interface in generic fn (fix #11235)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -731,6 +731,11 @@ fn (mut c Checker) unwrap_generic_type(typ ast.Type, generic_names []string, con
 						final_concrete_types << t_typ
 					}
 				}
+				if final_concrete_types.len > 0 {
+					for method in ts.methods {
+						c.table.register_fn_concrete_types(method.name, final_concrete_types)
+					}
+				}
 			}
 		}
 		else {}

--- a/vlib/v/tests/generics_struct_with_non_generic_interface_test.v
+++ b/vlib/v/tests/generics_struct_with_non_generic_interface_test.v
@@ -23,3 +23,17 @@ fn test_generic_struct_with_non_generic_interface() {
 	println(ret)
 	assert ret == 106
 }
+
+fn run<T>(data T) {
+	t := Test<T>{
+		data: data
+		salt: 6
+	}
+	x := box_transform(t)
+	println(x)
+	assert x == 106
+}
+
+fn test_generic_struct_with_non_generic_interface_in_generic_fn() {
+	run('foo')
+}


### PR DESCRIPTION
This PR fix generic struct with non-generic interface in generic fn (fix #11235).

- Fix generic struct with non-generic interface in generic fn.
- Add test.

```vlang
interface Box {
	transform(input int) int
}

struct Test<T> {
	data T
	salt int
}

fn (t Test<T>) transform(input int) int {
	return input + t.salt
}

fn box_transform(b Box) int {
	return b.transform(100)
}

fn run<T>(data T) {
	t := Test<T>{
		data: data
		salt: 6
	}
	x := box_transform(t)
	println(x)
	assert x == 106
}

fn main() {
	run('foo')
}

PS D:\Test\v\tt1> v run .
106
```