### PR TITLE
table, checker: fix sumtype array appending aggregate type values (fix #11197)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1139,9 +1139,20 @@ pub fn (t &Table) sumtype_has_variant(parent Type, variant Type) bool {
 	parent_sym := t.get_type_symbol(parent)
 	if parent_sym.kind == .sum_type {
 		parent_info := parent_sym.info as SumType
-		for v in parent_info.variants {
-			if v.idx() == variant.idx() {
-				return true
+		var_sym := t.get_type_symbol(variant)
+		if var_sym.kind == .aggregate {
+			var_info := var_sym.info as Aggregate
+			for var_type in var_info.types {
+				if t.sumtype_has_variant(parent, var_type) {
+					return true
+				}
+			}
+			return false
+		} else {
+			for v in parent_info.variants {
+				if v.idx() == variant.idx() {
+					return true
+				}
 			}
 		}
 	}

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1143,11 +1143,11 @@ pub fn (t &Table) sumtype_has_variant(parent Type, variant Type) bool {
 		if var_sym.kind == .aggregate {
 			var_info := var_sym.info as Aggregate
 			for var_type in var_info.types {
-				if t.sumtype_has_variant(parent, var_type) {
-					return true
+				if !t.sumtype_has_variant(parent, var_type) {
+					return false
 				}
 			}
-			return false
+			return true
 		} else {
 			for v in parent_info.variants {
 				if v.idx() == variant.idx() {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1555,6 +1555,10 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					}
 					return ast.void_type
 				}
+				if left_value_sym.kind == .sum_type
+					&& c.table.sumtype_has_variant(left_value_type, right_type) {
+					return ast.void_type
+				}
 				// []T << T or []T << []T
 				unwrapped_right_type := c.unwrap_generic(right_type)
 				if c.check_types(unwrapped_right_type, left_value_type)

--- a/vlib/v/checker/tests/sumtype_mismatch_of_aggregate_err.out
+++ b/vlib/v/checker/tests/sumtype_mismatch_of_aggregate_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/sumtype_mismatch_of_aggregate_err.vv:7:11: error: cannot use `(i8 | i16 | int | i64)` as type `SimpleInt` in return argument
+    5 |     match s {
+    6 |         i8, i16, int, i64 {
+    7 |             return s
+      |                    ^
+    8 |         }
+    9 |     }

--- a/vlib/v/checker/tests/sumtype_mismatch_of_aggregate_err.vv
+++ b/vlib/v/checker/tests/sumtype_mismatch_of_aggregate_err.vv
@@ -1,0 +1,13 @@
+type SimpleInt = i64 | int
+type SuperInt = i16 | i64 | i8 | int
+
+fn ret_super(s SuperInt) SimpleInt {
+	match s {
+		i8, i16, int, i64 {
+			return s
+		}
+	}
+}
+
+fn main() {
+}

--- a/vlib/v/tests/array_of_sumtype_append_aggregate_type_test.v
+++ b/vlib/v/tests/array_of_sumtype_append_aggregate_type_test.v
@@ -1,0 +1,29 @@
+struct StructA {
+	value int
+}
+
+struct StructB {
+	value  int
+	offset int
+}
+
+type AB = StructA | StructB
+
+fn test_sumtype_array_append_aggregate_type() {
+	mut arr := []AB{}
+	arr << StructA{0}
+	arr << StructB{0, 1}
+
+	mut arr2 := []AB{}
+
+	for a_or_b in arr {
+		match a_or_b {
+			StructA, StructB {
+				arr2 << a_or_b
+			}
+		}
+	}
+
+	println(arr2)
+	assert arr2.len == 2
+}

--- a/vlib/v/tests/match_sumtype_var_aggregate_test.v
+++ b/vlib/v/tests/match_sumtype_var_aggregate_test.v
@@ -1,0 +1,21 @@
+struct Foo {}
+
+struct Bar {}
+
+struct Baz {}
+
+type Sum = Bar | Baz | Foo
+
+fn foo(s Sum) Sum {
+	match s {
+		Foo, Bar { return s }
+		Baz { return Baz{} }
+	}
+}
+
+fn test_match_sumtype_var_aggregate() {
+	a := Foo{}
+	ret := foo(a)
+	println(ret)
+	assert '$ret' == 'Sum(Foo{})'
+}


### PR DESCRIPTION
This PR fix sumtype array appending aggregate type values (fix #11197 fix #11217).

- Fix sumtype array appending aggregate type values.
- Add test.

```vlang
struct StructA {
	value int
}

struct StructB {
	value  int
	offset int
}

type AB = StructA | StructB

fn main() {
	mut arr := []AB{}
	arr << StructA{0}
	arr << StructB{0, 1}

	mut arr2 := []AB{}

	for a_or_b in arr {
		match a_or_b {
			StructA, StructB {
				arr2 << a_or_b
			}
		}
	}

	println(arr2)
	assert arr2.len == 2
}

PS D:\Test\v\tt1> v run .
[AB(StructA{
    value: 0
}), AB(StructB{
    value: 0
    offset: 1
})]
```

```vlang
struct Foo {}
struct Bar {}
struct Baz {}

type Sum = Foo | Bar | Baz

fn foo(s Sum) Sum {
	match s {
		Foo, Bar { return s }
		Baz { return Baz{} }
	}
}

fn main() {
	a1 := Foo{}
	ret := foo(a1)
	println(ret)
}

PS D:\Test\v\tt1> v run .
Sum(Foo{})
```