### PR TITLE
hex() functions: Optimization, more tests

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -304,7 +304,11 @@ pub fn (nn byte) hex() string {
 // Example: assert i8(10).hex() == '0a'
 // Example: assert i8(15).hex() == '0f'
 pub fn (nn i8) hex() string {
-	return byte(nn).hex()
+	if nn == 0 {
+		return '00'
+	}
+	return u64_to_hex(u64(nn), 2)
+	//return byte(nn).hex()
 }
 
 // hex returns the value of the `u16` as a hexadecimal `string`.

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -256,13 +256,12 @@ pub fn (b bool) str() string {
 [direct_array_access; inline]
 fn u64_to_hex(nn u64, len byte) string {
 	mut n := nn
-	mut buf := [256]byte{}
+	mut buf := [17]byte{}
 	buf[len] = 0
 	mut i := 0
 	for i = len - 1; i >= 0; i-- {
 		d := byte(n & 0xF)
-		x := if d < 10 { d + `0` } else { d + 87 }
-		buf[i] = x
+		buf[i] = if d < 10 { d + `0` } else { d + 87 }
 		n = n >> 4
 	}
 	return unsafe { tos(memdup(&buf[0], len + 1), len) }
@@ -272,13 +271,12 @@ fn u64_to_hex(nn u64, len byte) string {
 [direct_array_access; inline]
 fn u64_to_hex_no_leading_zeros(nn u64, len byte) string {
 	mut n := nn
-	mut buf := [256]byte{}
+	mut buf := [17]byte{}
 	buf[len] = 0
 	mut i := 0
 	for i = len - 1; i >= 0; i-- {
 		d := byte(n & 0xF)
-		x := if d < 10 { d + `0` } else { d + 87 }
-		buf[i] = x
+		buf[i] = if d < 10 { d + `0` } else { d + 87 }
 		n = n >> 4
 		if n == 0 {
 			break

--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -33,8 +33,8 @@ fn test_str_methods() {
 	assert u64(-1).str() == '18446744073709551615'
 	assert voidptr(-1).str() == 'ffffffffffffffff'
 	assert voidptr(1).str() == '1'
-	assert byteptr(-1).str() == 'ffffffffffffffff'
-	assert byteptr(1).str() == '1'
+	assert &byte(-1).str() == 'ffffffffffffffff'
+	assert &byte(1).str() == '1'
 }
 
 fn test_and_precendence() {
@@ -105,6 +105,14 @@ fn test_hex() {
 	assert b.hex() == '4d2'
 	b1 := -1
 	assert b1.hex() == 'ffffffff'
+	// unsigned tests
+	assert u16(65535).hex() == 'ffff'
+	assert u32(-1).hex() == 'ffffffff'
+	assert u64(-1).hex() == 'ffffffffffffffff'
+	// signed tests
+	assert i16(32767).hex() == '7fff'
+	assert int(2147483647).hex() == '7fffffff'
+	assert i64(9223372036854775807).hex() == '7fffffffffffffff'
 }
 
 fn test_bin() {
@@ -129,21 +137,21 @@ fn test_bin() {
 fn test_oct() {
 	x1 := 0o12
 	assert x1 == 10
-	x2 := 00000o350
+	x2 := 0o350
 	assert x2 == 232
-	x3 := 000o00073
+	x3 := 0o00073
 	assert x3 == 59
-	x4 := 00000000
+	x4 := 0
 	assert x4 == 0
-	x5 := 00000195
+	x5 := 195
 	assert x5 == 195
 	x6 := -0o744
 	assert x6 == -484
-	x7 := -000o000042
+	x7 := -0o000042
 	assert x7 == -34
-	x8 := -0000112
+	x8 := -112
 	assert x8 == -112
-	x9 := -000
+	x9 := -0
 	assert x9 == 0
 }
 
@@ -168,7 +176,6 @@ fn test_num_separator() {
 	// f32 or f64
 	assert 312_2.55 == 3122.55
 	assert 312_2.55 == 3122.55
-
 }
 
 fn test_int_decl() {

--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -23,8 +23,6 @@ fn test_str_methods() {
 	assert int(-2147483648).str() == '-2147483648'
 	assert i64(1).str() == '1'
 	assert i64(-1).str() == '-1'
-	// assert byte(1).str() == '1'
-	// assert byte(-1).str() == '255'
 	assert u16(1).str() == '1'
 	assert u16(-1).str() == '65535'
 	assert u32(1).str() == '1'
@@ -33,8 +31,10 @@ fn test_str_methods() {
 	assert u64(-1).str() == '18446744073709551615'
 	assert voidptr(-1).str() == 'ffffffffffffffff'
 	assert voidptr(1).str() == '1'
-	//assert &byte(-1).str() == 'ffffffffffffffff'
-	//assert &byte(1).str() == '1'
+	assert (&byte(-1)).str() == 'ffffffffffffffff'
+	assert (&byte(1)).str() == '1'
+	assert byteptr(-1).str() == 'ffffffffffffffff'
+	assert byteptr(1).str() == '1'
 }
 
 fn test_and_precendence() {

--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -141,21 +141,21 @@ fn test_bin() {
 fn test_oct() {
 	x1 := 0o12
 	assert x1 == 10
-	x2 := 0o350
+	x2 := 00000o350
 	assert x2 == 232
-	x3 := 0o00073
+	x3 := 000o00073
 	assert x3 == 59
-	x4 := 0
+	x4 := 00000000
 	assert x4 == 0
-	x5 := 195
+	x5 := 00000195
 	assert x5 == 195
 	x6 := -0o744
 	assert x6 == -484
-	x7 := -0o000042
+	x7 := -000o000042
 	assert x7 == -34
-	x8 := -112
+	x8 := -0000112
 	assert x8 == -112
-	x9 := -0
+	x9 := -000
 	assert x9 == 0
 }
 

--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -33,8 +33,8 @@ fn test_str_methods() {
 	assert u64(-1).str() == '18446744073709551615'
 	assert voidptr(-1).str() == 'ffffffffffffffff'
 	assert voidptr(1).str() == '1'
-	assert &byte(-1).str() == 'ffffffffffffffff'
-	assert &byte(1).str() == '1'
+	//assert &byte(-1).str() == 'ffffffffffffffff'
+	//assert &byte(1).str() == '1'
 }
 
 fn test_and_precendence() {
@@ -106,10 +106,14 @@ fn test_hex() {
 	b1 := -1
 	assert b1.hex() == 'ffffffff'
 	// unsigned tests
+	assert u8(12).hex() == '0c'
+	assert u8(255).hex() == 'ff'
 	assert u16(65535).hex() == 'ffff'
 	assert u32(-1).hex() == 'ffffffff'
 	assert u64(-1).hex() == 'ffffffffffffffff'
 	// signed tests
+	assert i8(-1).hex() == 'ff'
+	assert i8(12).hex() == '0c'
 	assert i16(32767).hex() == '7fff'
 	assert int(2147483647).hex() == '7fffffff'
 	assert i64(9223372036854775807).hex() == '7fffffffffffffff'


### PR DESCRIPTION
**What's inside**
- optimization for the `hex()` builtin functions
- reduced memory usage for the `hex()` functions
- added more tests

Note:
persist the problem with the `fmt` and the `&byte` and `byteptr`, must be addressed this issue.