### PR TITLE
table: fix alias of sumtype method_call (fix #10501)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -474,7 +474,7 @@ pub fn (t &Table) find_field(s &TypeSymbol, name string) ?StructField {
 				}
 			}
 			SumType {
-				t.resolve_common_sumtype_fields(s)
+				t.resolve_common_sumtype_fields(ts)
 				if field := ts.info.find_field(name) {
 					return field
 				}

--- a/vlib/v/tests/alias_sumtype_method_call_test.v
+++ b/vlib/v/tests/alias_sumtype_method_call_test.v
@@ -1,0 +1,16 @@
+import x.json2
+
+type MyType = json2.Any
+
+struct Data {
+	prop MyType
+}
+
+fn test_alias_sumtype_method_call() {
+	a := '{"a":"a","b":1}'
+	json := json2.raw_decode(a) or { panic(err) }
+	data := Data{json}
+	json_str := data.prop.str()
+	println(json_str)
+	assert json_str == '{"a":"a","b":1}'
+}


### PR DESCRIPTION
This PR fix alias of sumtype method_call (fix #10501).

- Fix alias of sumtype method_call.
- Add test.

```vlang
import x.json2

type MyType = json2.Any

struct Data {
	prop MyType
}

fn main() {
	a := '{"a":"a","b":1}'
	json := json2.raw_decode(a) or { panic(err) }
	data := Data{json}
	json_str := data.prop.str()
	println(json_str)
	assert json_str == '{"a":"a","b":1}'
}

PS D:\Test\v\tt1> v run .
{"a":"a","b":1}
```