### PR TITLE
native: initial support for cast statements

### DIFF
--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -983,6 +983,20 @@ fn (mut g Gen) assign_stmt(node ast.AssignStmt) {
 			ast.GoExpr {
 				g.v_error('threads not implemented for the native backend', node.pos)
 			}
+			ast.CastExpr {
+				g.warning('cast expressions are work in progress', right.pos)
+				match right.typname {
+					'u64' {
+						g.allocate_var(name, 8, right.expr.str().int())
+					}
+					'int' {
+						g.allocate_var(name, 4, right.expr.str().int())
+					}
+					else {
+						g.v_error('unsupported cast type $right.typ', node.pos)
+					}
+				}
+			}
 			else {
 				// dump(node)
 				g.v_error('unhandled assign_stmt expression: $right.type_name()', right.position())

--- a/vlib/v/gen/native/tests/general.vv
+++ b/vlib/v/gen/native/tests/general.vv
@@ -1,3 +1,10 @@
+fn cast_test() {
+	a := int(1)
+	assert a == 1
+	b := u64(2)
+	assert b == 2
+}
+
 fn if_test() {
 	mut a := 1
 	if a == 1 {
@@ -81,6 +88,7 @@ struct User {
 
 fn main() {
 	if_test()
+	cast_test()
 	loop()
 	args()
 	// expr()


### PR DESCRIPTION
This PR introduces very basic support for handling the cast expressions in the native backend also adds the new `.warning()` method that fills the (until now unused) field that holds all the warnings during the compilation (errors did that already)