### PR TITLE
checker: check array insert or prepend arguments error (fix #11294)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2129,6 +2129,26 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	} else if left_type_sym.kind == .map && method_name in ['clone', 'keys', 'move', 'delete'] {
 		return c.map_builtin_method_call(mut node, left_type, left_type_sym)
 	} else if left_type_sym.kind == .array && method_name in ['insert', 'prepend'] {
+		if method_name == 'insert' {
+			if node.args.len != 2 {
+				c.error('`array.insert()` should have 2 arguments, e.g. `insert(1, val)`',
+					node.pos)
+				return ast.void_type
+			} else {
+				arg_type := c.expr(node.args[0].expr)
+				if arg_type !in [ast.int_type, ast.int_literal_type] {
+					c.error('the first argument of `array.insert()` should be integer',
+						node.args[0].expr.position())
+					return ast.void_type
+				}
+			}
+		} else {
+			if node.args.len != 1 {
+				c.error('`array.prepend()` should have 1 argument, e.g. `prepend(val)`',
+					node.pos)
+				return ast.void_type
+			}
+		}
 		info := left_type_sym.info as ast.Array
 		arg_expr := if method_name == 'insert' { node.args[1].expr } else { node.args[0].expr }
 		arg_type := c.expr(arg_expr)

--- a/vlib/v/checker/tests/array_insert_prepend_args_err.out
+++ b/vlib/v/checker/tests/array_insert_prepend_args_err.out
@@ -1,0 +1,34 @@
+vlib/v/checker/tests/array_insert_prepend_args_err.vv:8:13: error: `array.insert()` should have 2 arguments, e.g. `insert(1, val)`
+    6 | fn main() {
+    7 |     tree := Node{}
+    8 |     tree.child.insert(Node{})
+      |                ~~~~~~~~~~~~~~
+    9 |     tree.child.insert(2.1, Node{})
+   10 |     tree.child.insert('abc', Node{})
+vlib/v/checker/tests/array_insert_prepend_args_err.vv:9:20: error: the first argument of `array.insert()` should be integer
+    7 |     tree := Node{}
+    8 |     tree.child.insert(Node{})
+    9 |     tree.child.insert(2.1, Node{})
+      |                       ~~~
+   10 |     tree.child.insert('abc', Node{})
+   11 |     tree.child.insert(Node{}, 2)
+vlib/v/checker/tests/array_insert_prepend_args_err.vv:10:20: error: the first argument of `array.insert()` should be integer
+    8 |     tree.child.insert(Node{})
+    9 |     tree.child.insert(2.1, Node{})
+   10 |     tree.child.insert('abc', Node{})
+      |                       ~~~~~
+   11 |     tree.child.insert(Node{}, 2)
+   12 |     tree.child.prepend()
+vlib/v/checker/tests/array_insert_prepend_args_err.vv:11:20: error: the first argument of `array.insert()` should be integer
+    9 |     tree.child.insert(2.1, Node{})
+   10 |     tree.child.insert('abc', Node{})
+   11 |     tree.child.insert(Node{}, 2)
+      |                       ~~~~~~
+   12 |     tree.child.prepend()
+   13 | }
+vlib/v/checker/tests/array_insert_prepend_args_err.vv:12:13: error: `array.prepend()` should have 1 argument, e.g. `prepend(val)`
+   10 |     tree.child.insert('abc', Node{})
+   11 |     tree.child.insert(Node{}, 2)
+   12 |     tree.child.prepend()
+      |                ~~~~~~~~~
+   13 | }

--- a/vlib/v/checker/tests/array_insert_prepend_args_err.vv
+++ b/vlib/v/checker/tests/array_insert_prepend_args_err.vv
@@ -1,0 +1,13 @@
+struct Node {
+mut:
+	child []Node
+}
+
+fn main() {
+	tree := Node{}
+	tree.child.insert(Node{})
+	tree.child.insert(2.1, Node{})
+	tree.child.insert('abc', Node{})
+	tree.child.insert(Node{}, 2)
+	tree.child.prepend()
+}


### PR DESCRIPTION
This PR check array insert or prepend arguments error (fix #11294).

- Check array insert or prepend arguments error.
- Add test.

```vlang
struct Node {
mut:
	child []Node
}

fn main() {
	tree := Node{}
	tree.child.insert(Node{})
	tree.child.insert(2.1, Node{})
	tree.child.insert('abc', Node{})
	tree.child.insert(Node{}, 2)
	tree.child.prepend()
}

PS D:\Test\v\tt1> v run .
.\tt1.v:8:13: error: `array.insert()` should have 2 arguments, e.g. `insert(1, val)`
    6 | fn main() {
    7 |     tree := Node{}
    8 |     tree.child.insert(Node{})
      |                ~~~~~~~~~~~~~~
    9 |     tree.child.insert(2.1, Node{})
   10 |     tree.child.insert('abc', Node{})
.\tt1.v:9:20: error: the first argument of `array.insert()` should be integer
    7 |     tree := Node{}
    8 |     tree.child.insert(Node{})
    9 |     tree.child.insert(2.1, Node{})
      |                       ~~~
   10 |     tree.child.insert('abc', Node{})
   11 |     tree.child.insert(Node{}, 2)
.\tt1.v:10:20: error: the first argument of `array.insert()` should be integer
    8 |     tree.child.insert(Node{})
    9 |     tree.child.insert(2.1, Node{})
   10 |     tree.child.insert('abc', Node{})
      |                       ~~~~~
   11 |     tree.child.insert(Node{}, 2)
   12 |     tree.child.prepend()
.\tt1.v:11:20: error: the first argument of `array.insert()` should be integer
    9 |     tree.child.insert(2.1, Node{})
   10 |     tree.child.insert('abc', Node{})
   11 |     tree.child.insert(Node{}, 2)
      |                       ~~~~~~
   12 |     tree.child.prepend()
   13 | }
.\tt1.v:12:13: error: `array.prepend()` should have 1 argument, e.g. `prepend(val)`
   10 |     tree.child.insert('abc', Node{})
   11 |     tree.child.insert(Node{}, 2)
   12 |     tree.child.prepend()
      |                ~~~~~~~~~
   13 | }
```