### PR TITLE
scanner: check error of float literals 1.

### DIFF
--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -745,7 +745,7 @@ pub fn dpi_scale() f32 {
 	// NB: on older X11, `Xft.dpi` from ~/.Xresources, that sokol uses,
 	// may not be set which leads to sapp.dpi_scale reporting incorrectly 0.0
 	if s < 0.1 {
-		s = 1.
+		s = 1.0
 	}
 	return s
 }

--- a/vlib/strconv/f32_f64_to_string_test.v
+++ b/vlib/strconv/f32_f64_to_string_test.v
@@ -53,7 +53,7 @@ fn test_float_to_str() {
 		1e23,
 		f32_from_bits1(0x0080_0000), // smallest float32
 		math.max_f32,
-		383260575764816448.,
+		383260575764816448.0,
 	]
 
 	exp_result_f32 := [

--- a/vlib/sync/channel_push_or_2_test.v
+++ b/vlib/sync/channel_push_or_2_test.v
@@ -1,7 +1,7 @@
 const n = 1000
 
 fn f(ch chan f64) {
-	mut s := 0.
+	mut s := 0.0
 	for _ in 0 .. n {
 		s += <-ch
 	}

--- a/vlib/sync/channel_select_6_test.v
+++ b/vlib/sync/channel_select_6_test.v
@@ -6,8 +6,8 @@
 fn do_select(ch1 chan int, ch2 chan int, chf1 chan f64, chf2 chan f64, sumch1 chan i64, sumch2 chan i64) {
 	mut sum1 := i64(0)
 	mut sum2 := i64(0)
-	f1 := 17.
-	f2 := 7.
+	f1 := 17.0
+	f2 := 7.0
 	for _ in 0 .. 20000 + chf1.cap / 3 {
 		select {
 			chf1 <- f1 {}
@@ -31,7 +31,7 @@ fn do_send_int(ch chan int, factor int) {
 }
 
 fn do_rec_f64(ch chan f64, sumch chan f64) {
-	mut sum := 0.
+	mut sum := 0.0
 	for _ in 0 .. 10000 {
 		sum += <-ch
 	}
@@ -70,6 +70,6 @@ fn test_select() {
 	expected_sum := i64(10000) * (10000 - 1) / 2
 	assert sum1 == 3 * expected_sum
 	assert sum2 == (7 + 17) * expected_sum
-	assert sumf1 == 17. * f64(10000 + chf1.cap)
-	assert sumf2 == 7. * 20000
+	assert sumf1 == 17.0 * f64(10000 + chf1.cap)
+	assert sumf2 == 7.0 * 20000
 }

--- a/vlib/v/fmt/tests/array_init_eol_comments_keep.vv
+++ b/vlib/v/fmt/tests/array_init_eol_comments_keep.vv
@@ -19,7 +19,7 @@ fn abc() {
 		1e23,
 		f32_from_bits1(0x0080_0000), // smallest float32
 		math.max_f32,
-		383260575764816448.,
+		383260575764816448.0,
 	]
 
 	exp_result_f32 := [

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -438,6 +438,7 @@ fn (mut s Scanner) ident_dec_number() string {
 				s.pos--
 			} else {
 				// 5.
+				s.error('float literals should have a digit after the decimal point, e.g. `5.0`')
 			}
 		}
 	}

--- a/vlib/v/scanner/scanner_test.v
+++ b/vlib/v/scanner/scanner_test.v
@@ -45,7 +45,7 @@ fn test_float_conversion_and_reading() {
 	mut e := 1.2E3 * -1e-1
 	assert e == -120.0
 	e = 1.2E3 * 1e-1
-	x := 55.
+	x := 55.0
 	assert e == 120.0
 	assert 1.23e+10 == 1.23e10
 	assert 1.23e+10 == 1.23e0010
@@ -54,18 +54,18 @@ fn test_float_conversion_and_reading() {
 }
 
 fn test_float_without_fraction() {
-	mut result := scan_kinds('x := 10.')
+	mut result := scan_kinds('x := 10.0')
 	assert result.len == 3
 	assert result[0] == .name
 	assert result[1] == .decl_assign
 	assert result[2] == .number
-	result = scan_kinds('return 3., 4.')
+	result = scan_kinds('return 3.0, 4.0')
 	assert result.len == 4
 	assert result[0] == .key_return
 	assert result[1] == .number
 	assert result[2] == .comma
 	assert result[3] == .number
-	result = scan_kinds('fun(5.)')
+	result = scan_kinds('fun(5.0)')
 	assert result.len == 4
 	assert result[0] == .name
 	assert result[1] == .lpar

--- a/vlib/v/scanner/tests/float_literals_dot_err.out
+++ b/vlib/v/scanner/tests/float_literals_dot_err.out
@@ -1,0 +1,6 @@
+vlib/v/scanner/tests/float_literals_dot_err.vv:2:9: error: float literals should have a digit after the decimal point, e.g. `5.0`
+    1 | fn main() {
+    2 |     a := 1.
+      |            ^
+    3 |     println(a)
+    4 | }

--- a/vlib/v/scanner/tests/float_literals_dot_err.vv
+++ b/vlib/v/scanner/tests/float_literals_dot_err.vv
@@ -1,0 +1,4 @@
+fn main() {
+	a := 1.
+	println(a)
+}

--- a/vlib/v/tests/for_in_mut_val_test.v
+++ b/vlib/v/tests/for_in_mut_val_test.v
@@ -97,13 +97,13 @@ fn test_for_in_mut_val_of_string() {
 }
 
 fn test_for_in_mut_val_of_float() {
-	mut values := [1., 2, 3]
+	mut values := [1.0, 2, 3]
 	println(values)
 
 	for mut v in values {
-		v = 1.
-		v = v + 1.
+		v = 1.0
+		v = v + 1.0
 	}
 	println(values)
-	assert values == [2., 2, 2]
+	assert values == [2.0, 2, 2]
 }

--- a/vlib/v/tests/sumtype_literal_test.v
+++ b/vlib/v/tests/sumtype_literal_test.v
@@ -20,7 +20,7 @@ fn test_assign_mut() {
 	mut c := Foo(f32(1))
 	a = 12.3
 	b = -123456
-	c = 33.
+	c = 33.0
 	assert a is f64
 	assert b is int
 	assert c is f64
@@ -75,7 +75,7 @@ fn gen_foo(n int) Foo {
 		return -17.3e23
 	}
 	if n == 2 {
-		return 32.
+		return 32.0
 	}
 	if n == 3 {
 		return i16(13)


### PR DESCRIPTION
This PR check error of float literals `1.`.

- Check error of float literals `1.`.
- Add test.
- Fixed all the related.

```vlang
fn main() {
	a := 1.
	println(a)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:2:9: error: float literals should have a digit after the decimal point, e.g. `5.0`
    1 | fn main() {
    2 |     a := 1.
      |            ^
    3 |     println(a)
    4 | }
```