### PR TITLE
String: add insert_first_in method

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -739,7 +739,7 @@ fn (s string) index_kmp(p string) int {
 
 // index_any returns the position of any of the characters in the input string - if found.
 pub fn (s string) index_any(chars string) int {
-	for i, ss  in s {
+	for i, ss in s {
 		for c in chars {
 			if c == ss {
 				return i

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -739,12 +739,12 @@ fn (s string) index_kmp(p string) int {
 
 // index_any returns the position of any of the characters in the input string - if found.
 pub fn (s string) index_any(chars string) int {
-	for c in chars {
-		idx := s.index_(c.ascii_str())
-		if idx == -1 {
-			continue
+	for i, ss  in s {
+		for c in chars {
+			if c == ss {
+				return i
+			}
 		}
-		return idx
 	}
 	return -1
 }

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -910,3 +910,9 @@ fn test_string_to_rune() {
 	x := 'Hello World 👋'
 	assert x.runes().len == 13
 }
+
+fn test_index_any() {
+	x := 'abcdefghij'
+	assert x.index_any("ef") == 4
+	assert x.index_any("fe") == 4
+}

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -913,6 +913,6 @@ fn test_string_to_rune() {
 
 fn test_index_any() {
 	x := 'abcdefghij'
-	assert x.index_any("ef") == 4
-	assert x.index_any("fe") == 4
+	assert x.index_any('ef') == 4
+	assert x.index_any('fe') == 4
 }


### PR DESCRIPTION
**Context**
I want to find the index of some characters in a string.

###What's wrong with index_any()
index_any() check all the string, order of characters matter

###What's with new index_first_in()
index_first_in() give the first occurrence in the string, the order of characters doesn't matter.
It's closer to a regex syntax.

**What did you do?**
With index_any()
```v
fn main() {

	s := "<class=\"hello\">"

	println(s.index_any(">="))
	println(s.index_any("=>"))   // chars get just character position inverted 
}
```

**What did you expect to see?**
```
6
6
```
**What did you see instead?**
```
14
6
```

**With the new method**
It's ok:
```v
fn main() {

	s := "<class=\"hello\">"

	println(s.index_first_in(">="))
	println(s.index_first_in("=>"))
}
```
Give:
```
6
6
```


If it's ok to add this method, I will add tests.
If index_first_in() is not the good naming, I will change it.

**Naming**
It's just a personal feedback, by what I could understand by the naming:
index_first_in() should get the logic of index_any()
And vice versa.

Because, "Any" mean any characters. Order doesn't matter so much.
And with "First In", the naming could make understand that the order matter.

Except in someone used index_any(">=") especially with the intention the check first ">" then "=", maybe it is n problem to change the naming.
I'm not sure if this method is used in the v core, or in some extensions or not.









