### PR TITLE
cgen: fix `expr in shared_array`

### DIFF
--- a/vlib/v/gen/c/infix_expr.v
+++ b/vlib/v/gen/c/infix_expr.v
@@ -328,10 +328,13 @@ fn (mut g Gen) infix_expr_in_op(node ast.InfixExpr) {
 		}
 		fn_name := g.gen_array_contains_method(node.right_type)
 		g.write('(${fn_name}(')
-		if right.typ.is_ptr() {
+		if right.typ.is_ptr() && right.typ.share() != .shared_t {
 			g.write('*')
 		}
 		g.expr(node.right)
+		if right.typ.share() == .shared_t {
+			g.write('->val')
+		}
 		g.write(', ')
 		g.expr(node.left)
 		g.write('))')

--- a/vlib/v/tests/shared_in_test.v
+++ b/vlib/v/tests/shared_in_test.v
@@ -1,0 +1,8 @@
+fn test_shared_in() {
+	shared a := [1, 3, 7, 3]
+	assert 1 in a
+	assert 0 !in a
+	assert 7 in a
+	assert 3 in a
+	assert 1238941 !in a
+}


### PR DESCRIPTION
The whole `array.x` auto generated methods code will become a lot more cleaner in #10844, this is just to generate v.c for #10844 