### PR TITLE
vdoc: allow output path as output file name

### DIFF
--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -268,10 +268,10 @@ fn (vd VDoc) gen_html(d doc.Doc) string {
 			}
 			names := dc.head.name.split('.')
 			submod_prefix = if names.len > 1 { names[0] } else { dc.head.name }
-			mut href_name := './${dc.head.name}.html'
+			mut href_name := './' + dc.head.name + file_ext_html
 			if (cfg.is_vlib && dc.head.name == 'builtin' && !cfg.include_readme)
 				|| dc.head.name == 'README' {
-				href_name = './index.html'
+				href_name = './index' + file_ext_html
 			} else if submod_prefix !in vd.docs.map(it.head.name) {
 				href_name = '#'
 			}

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -29,6 +29,24 @@ enum OutputType {
 	stdout
 }
 
+const (
+	file_ext_html = '.html'
+	file_ext_markdown = '.md'
+	file_ext_json = '.json'
+	file_ext_unknown = '.txt'
+)
+
+// file_ext returns the corresponding file extension
+// for that specific OutputType enum member
+fn (typ OutputType) file_ext() string {
+	return match typ {
+		.html { file_ext_html }
+		.markdown { file_ext_markdown }
+		.json { file_ext_json }
+		else { file_ext_unknown }
+	}
+}
+
 struct VDoc {
 	cfg Config [required]
 mut:
@@ -151,16 +169,12 @@ fn (vd VDoc) get_file_name(mod string, out Output) string {
 	cfg := vd.cfg
 	mut name := mod
 	// since builtin is generated first, ignore it
-	if (cfg.is_vlib && mod == 'builtin' && !cfg.include_readme) || mod == 'README' {
-		name = 'index'
-	} else if !cfg.is_multi && !os.is_dir(out.path) {
-		name = os.file_name(out.path)
-	}
-	name = name + match out.typ {
-		.html { '.html' }
-		.markdown { '.md' }
-		.json { '.json' }
-		else { '.txt' }
+	name = if (cfg.is_vlib && mod == 'builtin' && !cfg.include_readme) || mod == 'README' {
+		'index' + out.typ.file_ext()
+	} else if !cfg.is_multi && (!os.is_dir(out.path) || out.path_ends_with_file_ext()) {
+		os.file_name(out.path)
+	} else {
+		name + out.typ.file_ext()
 	}
 	return name
 }

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -277,6 +277,10 @@ fn (mut vd VDoc) generate_docs_from_file() {
 		ext := os.file_ext(out.path)
 		out.typ = set_output_type_from_str(ext.all_after('.'))
 	}
+	if cfg.is_multi && out.path_ends_with_file_ext() {
+		eprintln('vdoc: Custom output file name (e.g. `./README.md`) is only availble in single module mode.')
+		exit(1)
+	}
 	if cfg.include_readme && out.typ !in [.html, .stdout] {
 		eprintln('vdoc: Including README.md for doc generation is supported on HTML output, or when running directly in the terminal.')
 		exit(1)

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -378,6 +378,8 @@ fn (mut vd VDoc) generate_docs_from_file() {
 			} else if !os.is_dir(out.path) {
 				out.path = os.real_path('.')
 			}
+		} else if cfg.output_type == .html {
+			out.path = os.dir(out.path)
 		}
 		if cfg.is_multi {
 			out.path = os.join_path(out.path, '_docs')

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -372,10 +372,12 @@ fn (mut vd VDoc) generate_docs_from_file() {
 			println(outputs[first])
 		}
 	} else {
-		if !os.exists(out.path) && !out.path_ends_with_file_ext() {
-			os.mkdir_all(out.path) or { panic(err) }
-		} else if !os.is_dir(out.path) && (!cfg.is_multi && !out.path_ends_with_file_ext()) {
-			out.path = os.real_path('.')
+		if !out.path_ends_with_file_ext() {
+			if !os.exists(out.path) {
+				os.mkdir_all(out.path) or { panic(err) }
+			} else if !os.is_dir(out.path) {
+				out.path = os.real_path('.')
+			}
 		}
 		if cfg.is_multi {
 			out.path = os.join_path(out.path, '_docs')

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -30,10 +30,10 @@ enum OutputType {
 }
 
 const (
-	file_ext_html = '.html'
+	file_ext_html     = '.html'
 	file_ext_markdown = '.md'
-	file_ext_json = '.json'
-	file_ext_unknown = '.txt'
+	file_ext_json     = '.json'
+	file_ext_unknown  = '.txt'
 )
 
 // file_ext returns the corresponding file extension
@@ -195,7 +195,11 @@ fn (vd VDoc) work_processor(mut work sync.Channel, mut wg sync.WaitGroup) {
 			break
 		}
 		file_name, content := vd.render_doc(pdoc.d, pdoc.out)
-		output_path := if pdoc.out.path_ends_with_file_ext() { pdoc.out.path } else { os.join_path(pdoc.out.path, file_name) }
+		output_path := if pdoc.out.path_ends_with_file_ext() {
+			pdoc.out.path
+		} else {
+			os.join_path(pdoc.out.path, file_name)
+		}
 		println('Generating $pdoc.out.typ in "$output_path"')
 		os.write_file(output_path, content) or { panic(err) }
 	}


### PR DESCRIPTION
This PR allows using output path such as `./README.md` to be used as a custom output file name. Instead of creating a folder, the tool will check first if the path ends with the appropriate file extension based on the output type (if output type is markdown, path should check if path ends with `.md`). Otherwise it will still create a folder with the said path.

## Notes
- I added an error message that prevents users from using the path in multi-module mode.
- If the output mode is HTML, the directory of that path is used (if path is `./README.html`, then `.` is used)