### PR TITLE
gg: change draw_cubic_bezier* call signatures

### DIFF
--- a/examples/gg/bezier.v
+++ b/examples/gg/bezier.v
@@ -4,8 +4,7 @@ import gg
 import gx
 
 const (
-	p1_and_p2      = [f32(200.0), 200.0, 400.0, 300.0]
-	ctrl_p1_and_p2 = [f32(200.0), 100.0, 400.0, 100.0]
+	points = [f32(200.0), 200.0, 200.0, 100.0, 400.0, 100.0, 400.0, 300.0]
 )
 
 struct App {
@@ -30,6 +29,6 @@ fn main() {
 
 fn frame(mut app App) {
 	app.gg.begin()
-	app.gg.draw_cubic_bezier(p1_and_p2, ctrl_p1_and_p2, gx.blue)
+	app.gg.draw_cubic_bezier(points, gx.blue)
 	app.gg.end()
 }

--- a/examples/gg/bezier_anim.v
+++ b/examples/gg/bezier_anim.v
@@ -48,13 +48,21 @@ fn main() {
 fn frame(mut app App) {
 	time := app.anim.time
 
-	ctrl_p1_x := f32(200.0) + (40 * time)
-	ctrl_p2_x := f32(400.0) + (-40 * time)
+	p1_x := f32(200.0)
+	p1_y := f32(200.0) + (10 * time)
 
-	p1_and_p2 := [f32(200.0), 200.0 + (10 * time), 400.0, 200.0 + (10 * time)]
+	p2_x := f32(400.0)
+	p2_y := f32(200.0) + (10 * time)
+
+	ctrl_p1_x := f32(200.0) + (40 * time)
+	ctrl_p1_y := f32(100.0)
+	ctrl_p2_x := f32(400.0) + (-40 * time)
+	ctrl_p2_y := f32(100.0)
+
+	points := [p1_x, p1_y, ctrl_p1_x, ctrl_p1_y, ctrl_p2_x, ctrl_p2_y, p2_x, p2_y]
 
 	app.gg.begin()
-	app.gg.draw_cubic_bezier(p1_and_p2, [ctrl_p1_x, 100.0, ctrl_p2_x, 100.0], gx.blue)
+	app.gg.draw_cubic_bezier(points, gx.blue)
 	app.gg.end()
 	app.anim.advance()
 }

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -675,22 +675,21 @@ pub fn (ctx &Context) draw_empty_poly(points []f32, c gx.Color) {
 }
 
 // draw_cubic_bezier draws a cubic Bézier curve, also known as a spline, from four points.
-// The four points is provided as two arrays; `points` and `control_points`, which is both pairs of x and y coordinates.
-// Thus a coordinate pair could be declared like: `points := [x1, y1, x2, y2]`.
+// The four points is provided as one `points` array which contains a stream of point pairs (x and y coordinates).
+// Thus a cubic Bézier could be declared as: `points := [x1, y1, control_x1, control_y1, control_x2, control_y2, x2, y2]`.
 // Please see `draw_cubic_bezier_in_steps` to control the amount of steps (segments) used to draw the curve.
-pub fn (ctx &Context) draw_cubic_bezier(points []f32, control_points []f32, c gx.Color) {
-	ctx.draw_cubic_bezier_in_steps(points, control_points, u32(30 * ctx.scale), c)
+pub fn (ctx &Context) draw_cubic_bezier(points []f32, c gx.Color) {
+	ctx.draw_cubic_bezier_in_steps(points, u32(30 * ctx.scale), c)
 }
 
 // draw_cubic_bezier_in_steps draws a cubic Bézier curve, also known as a spline, from four points.
 // The smoothness of the curve can be controlled with the `steps` parameter. `steps` determines how many iterations is
 // taken to draw the curve.
-// The four points is provided as two arrays; `points` and `control_points`, which is both pairs of x and y coordinates.
-// Thus a coordinate pair could be declared like: `points := [x1, y1, x2, y2]`.
-pub fn (ctx &Context) draw_cubic_bezier_in_steps(points []f32, control_points []f32, steps u32, c gx.Color) {
+// The four points is provided as one `points` array which contains a stream of point pairs (x and y coordinates).
+// Thus a cubic Bézier could be declared as: `points := [x1, y1, control_x1, control_y1, control_x2, control_y2, x2, y2]`.
+pub fn (ctx &Context) draw_cubic_bezier_in_steps(points []f32, steps u32, c gx.Color) {
 	assert steps > 0
-	assert points.len == 4
-	assert points.len == control_points.len
+	assert points.len == 8
 
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
@@ -700,10 +699,10 @@ pub fn (ctx &Context) draw_cubic_bezier_in_steps(points []f32, control_points []
 	sgl.begin_line_strip()
 
 	p1_x, p1_y := points[0], points[1]
-	p2_x, p2_y := points[2], points[3]
+	p2_x, p2_y := points[6], points[7]
 
-	ctrl_p1_x, ctrl_p1_y := control_points[0], control_points[1]
-	ctrl_p2_x, ctrl_p2_y := control_points[2], control_points[3]
+	ctrl_p1_x, ctrl_p1_y := points[2], points[3]
+	ctrl_p2_x, ctrl_p2_y := points[4], points[5]
 
 	// The constant 3 is actually points.len() - 1;
 


### PR DESCRIPTION
… for better memory layout, a little speed up and to match the polygon draw calls.
On top of this, as I can see subjectively, it's also a more frequently used data structure and coordinate order when I look around the net.

Instead of passing two arrays - use one with the following layout:
`[x1, y1, ctrl_x1, ctrl_y1, ctrl_x2, ctrl_y2, x2, y2]`
