### PR TITLE
checker: fix generic fn infer variadic parameter with arrays (fix #11322)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -633,7 +633,9 @@ pub fn (mut c Checker) infer_fn_generic_types(f ast.Fn, mut call_expr ast.CallEx
 				}
 			} else if param.typ.has_flag(.generic) {
 				arg_sym := c.table.get_type_symbol(arg.typ)
-				if arg_sym.kind == .array && param_type_sym.kind == .array {
+				if param.typ.has_flag(.variadic) {
+					to_set = c.table.mktyp(arg.typ)
+				} else if arg_sym.kind == .array && param_type_sym.kind == .array {
 					mut arg_elem_info := arg_sym.info as ast.Array
 					mut param_elem_info := param_type_sym.info as ast.Array
 					mut arg_elem_sym := c.table.get_type_symbol(arg_elem_info.elem_type)
@@ -678,8 +680,6 @@ pub fn (mut c Checker) infer_fn_generic_types(f ast.Fn, mut call_expr ast.CallEx
 						&& c.table.get_type_symbol(param_map_info.value_type).name == gt_name {
 						typ = arg_map_info.value_type
 					}
-				} else if param.typ.has_flag(.variadic) {
-					to_set = c.table.mktyp(arg.typ)
 				} else if arg_sym.kind in [.struct_, .interface_, .sum_type] {
 					mut generic_types := []ast.Type{}
 					mut concrete_types := []ast.Type{}

--- a/vlib/v/checker/tests/generics_fn_called_variadic_arg_mismatch.out
+++ b/vlib/v/checker/tests/generics_fn_called_variadic_arg_mismatch.out
@@ -1,14 +1,7 @@
-vlib/v/checker/tests/generics_fn_called_variadic_arg_mismatch.vv:12:11: error: cannot use `[]int` as `int` in argument 1 to `max`
+vlib/v/checker/tests/generics_fn_called_variadic_arg_mismatch.vv:12:16: error: cannot use `[]int` as `int` in argument 1 to `max`
    10 |
    11 | fn main() {
-   12 |     a := max([1, 2, 3, 4])
-      |              ~~~~~~~~~~~~
-   13 |     println(a)
-   14 |
-vlib/v/checker/tests/generics_fn_called_variadic_arg_mismatch.vv:15:16: error: cannot use `[]int` as `int` in argument 1 to `max`
-   13 |     println(a)
-   14 |
-   15 |     b := max<int>([1, 2, 3, 4])
+   12 |     b := max<int>([1, 2, 3, 4])
       |                   ~~~~~~~~~~~~
-   16 |     println(b)
-   17 | }
+   13 |     println(b)
+   14 | }

--- a/vlib/v/checker/tests/generics_fn_called_variadic_arg_mismatch.vv
+++ b/vlib/v/checker/tests/generics_fn_called_variadic_arg_mismatch.vv
@@ -9,9 +9,6 @@ fn max<T>(a ...T) T {
 }
 
 fn main() {
-	a := max([1, 2, 3, 4])
-	println(a)
-
 	b := max<int>([1, 2, 3, 4])
 	println(b)
 }

--- a/vlib/v/tests/generic_fn_infer_variadic_test.v
+++ b/vlib/v/tests/generic_fn_infer_variadic_test.v
@@ -1,0 +1,17 @@
+fn generic<T>(items ...T) string {
+	return '$items'
+}
+
+fn test_generic_fn_infer_variadic() {
+	ret1 := generic([1, 2, 3], [4, 5, 6])
+	println(ret1)
+	assert ret1 == '[[1, 2, 3], [4, 5, 6]]'
+
+	ret2 := generic(['a', 'b'], ['c', 'd'])
+	println(ret2)
+	assert ret2 == "[['a', 'b'], ['c', 'd']]"
+
+	ret3 := generic(1.1, 2.2, 3.3)
+	println(ret3)
+	assert ret3 == '[1.1, 2.2, 3.3]'
+}


### PR DESCRIPTION
This PR fix generic fn infer variadic parameter with arrays (fix #11322).

- Fix generic fn infer variadic parameter with arrays.
- Add test.

```vlang
fn generic<T>(items ...T) string {
	return '$items'
}

fn main() {
	ret1 := generic([1, 2, 3], [4, 5, 6])
	println(ret1)
	assert ret1 == '[[1, 2, 3], [4, 5, 6]]'

	ret2 := generic(['a', 'b'], ['c', 'd'])
	println(ret2)
	assert ret2 == "[['a', 'b'], ['c', 'd']]"

	ret3 := generic(1.1, 2.2, 3.3)
	println(ret3)
	assert ret3 == '[1.1, 2.2, 3.3]'
}

PS D:\Test\v\tt1> v run .
[[1, 2, 3], [4, 5, 6]]
[['a', 'b'], ['c', 'd']]
[1.1, 2.2, 3.3]
```