### PR TITLE
vup.v: Update os.chdir call to handle error

### DIFF
--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -26,7 +26,7 @@ fn new_app() App {
 fn main() {
 	app := new_app()
 	recompilation.must_be_enabled(app.vroot, 'Please install V from source, to use `v up` .')
-	os.chdir(app.vroot)
+	os.chdir(app.vroot) ?
 	println('Updating V...')
 	app.update_from_master()
 	v_hash := version.githash(false)


### PR DESCRIPTION
Fixes call to os.chdir so that `v up` works again