### PR TITLE
vfmt: fmt '!(a in/is b)' to 'a !in/is b'

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -551,8 +551,8 @@ fn test_in() {
 	assert 1 in a
 	assert 2 in a
 	assert 3 in a
-	assert !(4 in a)
-	assert !(0 in a)
+	assert 4 !in a
+	assert 0 !in a
 	assert 0 !in a
 	assert 4 !in a
 	b := [1, 4, 0]

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2195,6 +2195,26 @@ pub fn (mut f Fmt) postfix_expr(node ast.PostfixExpr) {
 }
 
 pub fn (mut f Fmt) prefix_expr(node ast.PrefixExpr) {
+	// !(a in b) => a !in b, !(a is b) => a !is b
+	if node.op == .not && node.right is ast.ParExpr {
+		if node.right.expr is ast.InfixExpr {
+			if node.right.expr.op in [.key_in, .not_in, .key_is, .not_is]
+				&& node.right.expr.right !is ast.InfixExpr {
+				f.expr(node.right.expr.left)
+				if node.right.expr.op == .key_in {
+					f.write(' !in ')
+				} else if node.right.expr.op == .not_in {
+					f.write(' in ')
+				} else if node.right.expr.op == .key_is {
+					f.write(' !is ')
+				} else if node.right.expr.op == .not_is {
+					f.write(' is ')
+				}
+				f.expr(node.right.expr.right)
+				return
+			}
+		}
+	}
 	f.write(node.op.str())
 	f.prefix_expr_cast_expr(node.right)
 	f.or_expr(node.or_block)

--- a/vlib/v/fmt/tests/if_not_in_is_expected.vv
+++ b/vlib/v/fmt/tests/if_not_in_is_expected.vv
@@ -1,0 +1,17 @@
+struct Foo1 {}
+
+struct Foo2 {}
+
+type Foo = Foo1 | Foo2
+
+fn main() {
+	a := [1, 2, 3]
+	if 4 !in a {
+		println('4 not in a')
+	}
+
+	foo := Foo(Foo1{})
+	if foo !is Foo2 {
+		println('foo is not Foo2')
+	}
+}

--- a/vlib/v/fmt/tests/if_not_in_is_input.vv
+++ b/vlib/v/fmt/tests/if_not_in_is_input.vv
@@ -1,0 +1,17 @@
+struct Foo1{}
+
+struct Foo2{}
+
+type Foo = Foo1 | Foo2
+
+fn main() {
+	a := [1, 2, 3]
+	if !(4 in a) {
+		println('4 not in a')
+	}
+
+	foo := Foo(Foo1{})
+	if !(foo is Foo2) {
+		println('foo is not Foo2')
+	}
+}

--- a/vlib/v/gen/js/tests/testdata/array.v
+++ b/vlib/v/gen/js/tests/testdata/array.v
@@ -537,8 +537,8 @@ fn main() {
 		println(1 in a)
 		println(2 in a)
 		println(3 in a)
-		println(!(4 in a))
-		println(!(0 in a))
+		println(4 !in a)
+		println(0 !in a)
 		println(0 !in a)
 		println(4 !in a)
 		b := [1, 4, 0]

--- a/vlib/v/tests/sum_type_test.v
+++ b/vlib/v/tests/sum_type_test.v
@@ -553,7 +553,7 @@ fn sumtype_match_with_string_interpolation(code int) string {
 fn handle(e Expr) string {
 	is_literal := e is IntegerLiteral
 	assert is_literal
-	assert !(e !is IntegerLiteral)
+	assert e is IntegerLiteral
 	if e is IntegerLiteral {
 		assert typeof(e.val).name == 'string'
 	}


### PR DESCRIPTION
This PR fmt '!(a in/is b)' to 'a !in/is b'.

- v fmt '!(a in/is b)' to 'a !in/is b'.
- Add test.

```vlang
struct Foo1{}

struct Foo2{}

type Foo = Foo1 | Foo2

fn main() {
	a := [1, 2, 3]
	if !(4 in a) {
		println('4 not in a')
	}

	foo := Foo(Foo1{})
	if !(foo is Foo2) {
		println('foo is not Foo2')
	}
}
```
fmt to:
```vlang
struct Foo1 {}

struct Foo2 {}

type Foo = Foo1 | Foo2

fn main() {
	a := [1, 2, 3]
	if 4 !in a {
		println('4 not in a')
	}

	foo := Foo(Foo1{})
	if foo !is Foo2 {
		println('foo is not Foo2')
	}
}
```