### PR TITLE
v/tests: add test that returns optional

### DIFF
--- a/vlib/v/tests/option_test.v
+++ b/vlib/v/tests/option_test.v
@@ -127,8 +127,8 @@ fn test_propagation() {
 	println(6)
 }
 
-fn test_q() {
-	// assert foo_ok()? == true
+fn test_q() ? {
+	assert foo_ok() ? == 777
 }
 
 fn or_return_val() int {


### PR DESCRIPTION
IMHO, It is better that there are tests that return optional in `vlib/v/tests`. It doesn't exist on current master. This PR add it.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
