### PR TITLE
vweb: serves correct page on http error 404

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -503,7 +503,8 @@ fn handle_conn<T>(mut conn net.TcpConn, mut app T) {
 		}
 	}
 	// site not found
-	send_string(mut conn, vweb.http_404.bytestr()) or {}
+	// send_string(mut conn, vweb.http_404.bytestr()) or {}
+	app.not_found()
 }
 
 fn route_matches(url_words []string, route_words []string) ?[]string {


### PR DESCRIPTION
The module `vweb` now displays the content from `fn (mut ctx Context) not_found() Result` if the URL route provided does not match any of the defined routes/attributes. Previously, it would return an empty page with a string that reads
 "404 Not Found".