### PR TITLE
tutorial: fix missing & in README.md

### DIFF
--- a/tutorials/building_a_simple_web_blog_with_vweb/README.md
+++ b/tutorials/building_a_simple_web_blog_with_vweb/README.md
@@ -263,7 +263,7 @@ Let's fetch the articles in the `index()` action:
 
 ```v ignore
 // blog.v
-pub fn (app App) index() vweb.Result {
+pub fn (app &App) index() vweb.Result {
 	articles := app.find_all_articles()
 	return $vweb.html()
 }

--- a/tutorials/building_a_simple_web_blog_with_vweb/README.md
+++ b/tutorials/building_a_simple_web_blog_with_vweb/README.md
@@ -233,6 +233,7 @@ fn main() {
 		insert first_article into Article
 		insert second_article into Article
 	}
+	vweb.run(app, 8080)
 }
 ```
 


### PR DESCRIPTION
While following the tutorial "tutorials/building_a_simple_web_blog_with_vweb" I get `error: pointer expected` the first time I run "Fetching data with V ORM"
I fixed it by adding a `&` before `App` in `index()`