### PR TITLE
checker: fix checking fn prototype mismatch (fix #11367)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -164,8 +164,10 @@ pub fn (mut c Checker) check_matching_function_symbols(got_type_sym &ast.TypeSym
 			got_arg_pointedness := if got_arg_is_ptr { 'a pointer' } else { 'NOT a pointer' }
 			c.add_error_detail('`$exp_fn.name`\'s expected fn argument: `$exp_arg.name` is $exp_arg_pointedness, but the passed fn argument: `$got_arg.name` is $got_arg_pointedness')
 			return false
+		} else if exp_arg_is_ptr && got_arg_is_ptr {
+			continue
 		}
-		if !c.check_basic(got_arg.typ, exp_arg.typ) {
+		if got_arg.typ != exp_arg.typ {
 			return false
 		}
 	}

--- a/vlib/v/checker/tests/fn_type_mismatch.out
+++ b/vlib/v/checker/tests/fn_type_mismatch.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/fn_type_mismatch.vv:11:15: error: invalid array element: expected `fn (int, int) f32`, not `fn (f32, f32) f32`
+    9 |
+   10 | fn main() {
+   11 |     fns := [add, div]
+      |                  ~~~
+   12 |     println(fns[0](10.0, 5.0))
+   13 |     println(fns[1](10.0, 5.0))

--- a/vlib/v/checker/tests/fn_type_mismatch.vv
+++ b/vlib/v/checker/tests/fn_type_mismatch.vv
@@ -1,0 +1,14 @@
+fn add(a int, b int) f32 {
+	return (a + b)
+}
+
+fn div(a f32, b f32) f32 {
+	println('div: $a $b')
+	return (a / b)
+}
+
+fn main() {
+	fns := [add, div]
+	println(fns[0](10.0, 5.0))
+	println(fns[1](10.0, 5.0))
+}


### PR DESCRIPTION
This PR fix checking fn prototype mismatch (fix #11367).

- Fix checking fn prototype mismatch.
- Add test.

```vlang
fn add(a int, b int) f32 {
	return (a + b)
}

fn div(a f32, b f32) f32 {
	println('div: $a $b')
	return (a / b)
}

fn main() {
	fns := [add, div]
	println(fns[0](10.0, 5.0))
	println(fns[1](10.0, 5.0))
}

PS D:\Test\v\tt1> v run .
.\tt1.v:11:15: error: invalid array element: expected `fn (int, int) f32`, not `fn (f32, f32) f32`
    9 | 
   10 | fn main() {
   11 |     fns := [add, div]
      |                  ~~~
   12 |     println(fns[0](10.0, 5.0))
   13 |     println(fns[1](10.0, 5.0))
```