### PR TITLE
cgen: fix reserved keywords as struct field (fix #11368)

### DIFF
--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -85,30 +85,31 @@ fn (mut g Gen) gen_struct_equality_fn(left_type ast.Type) string {
 				fn_builder.write_string('\n\t\t&& ')
 			}
 			field_type := g.unwrap(field.typ)
+			field_name := c_name(field.name)
 			if field_type.sym.kind == .string {
-				fn_builder.write_string('string__eq(a.$field.name, b.$field.name)')
+				fn_builder.write_string('string__eq(a.$field_name, b.$field_name)')
 			} else if field_type.sym.kind == .sum_type && !field.typ.is_ptr() {
 				eq_fn := g.gen_sumtype_equality_fn(field.typ)
-				fn_builder.write_string('${eq_fn}_sumtype_eq(a.$field.name, b.$field.name)')
+				fn_builder.write_string('${eq_fn}_sumtype_eq(a.$field_name, b.$field_name)')
 			} else if field_type.sym.kind == .struct_ && !field.typ.is_ptr() {
 				eq_fn := g.gen_struct_equality_fn(field.typ)
-				fn_builder.write_string('${eq_fn}_struct_eq(a.$field.name, b.$field.name)')
+				fn_builder.write_string('${eq_fn}_struct_eq(a.$field_name, b.$field_name)')
 			} else if field_type.sym.kind == .array && !field.typ.is_ptr() {
 				eq_fn := g.gen_array_equality_fn(field.typ)
-				fn_builder.write_string('${eq_fn}_arr_eq(a.$field.name, b.$field.name)')
+				fn_builder.write_string('${eq_fn}_arr_eq(a.$field_name, b.$field_name)')
 			} else if field_type.sym.kind == .array_fixed && !field.typ.is_ptr() {
 				eq_fn := g.gen_fixed_array_equality_fn(field.typ)
-				fn_builder.write_string('${eq_fn}_arr_eq(a.$field.name, b.$field.name)')
+				fn_builder.write_string('${eq_fn}_arr_eq(a.$field_name, b.$field_name)')
 			} else if field_type.sym.kind == .map && !field.typ.is_ptr() {
 				eq_fn := g.gen_map_equality_fn(field.typ)
-				fn_builder.write_string('${eq_fn}_map_eq(a.$field.name, b.$field.name)')
+				fn_builder.write_string('${eq_fn}_map_eq(a.$field_name, b.$field_name)')
 			} else if field_type.sym.kind == .alias && !field.typ.is_ptr() {
 				eq_fn := g.gen_alias_equality_fn(field.typ)
-				fn_builder.write_string('${eq_fn}_alias_eq(a.$field.name, b.$field.name)')
+				fn_builder.write_string('${eq_fn}_alias_eq(a.$field_name, b.$field_name)')
 			} else if field_type.sym.kind == .function {
-				fn_builder.write_string('*((voidptr*)(a.$field.name)) == *((voidptr*)(b.$field.name))')
+				fn_builder.write_string('*((voidptr*)(a.$field_name)) == *((voidptr*)(b.$field_name))')
 			} else {
-				fn_builder.write_string('a.$field.name == b.$field.name')
+				fn_builder.write_string('a.$field_name == b.$field_name')
 			}
 		}
 	} else {

--- a/vlib/v/tests/reserved_keywords_as_struct_field_test.v
+++ b/vlib/v/tests/reserved_keywords_as_struct_field_test.v
@@ -1,0 +1,58 @@
+struct Empty {}
+
+// LLNode is struct which holds data and links
+struct LLNode {
+	data int
+	link LinkedList
+}
+
+// LinkedList represent a linked list
+type LinkedList = Empty | LLNode
+
+// insert performs inserting of the value into the LinkedList
+fn insert(ll LinkedList, val int) LinkedList {
+	match ll {
+		Empty {
+			return LLNode{val, Empty{}}
+		}
+		LLNode {
+			return LLNode{
+				...ll
+				link: insert(ll.link, val)
+			}
+		}
+	}
+}
+
+// prepend performs inserting of the value on the top of the LinkedList
+fn prepend(ll LinkedList, val int) LinkedList {
+	match ll {
+		Empty {
+			return LLNode{val, Empty{}}
+		}
+		LLNode {
+			return LLNode{
+				data: val
+				link: ll
+			}
+		}
+	}
+}
+
+fn test_reserved_keywords_as_struct_field() {
+	mut ll := LinkedList(Empty{})
+	ll = insert(ll, 997)
+	ll = insert(ll, 998)
+	ll = insert(ll, 999)
+	mut desired_ll := LinkedList(LLNode{
+		data: 997
+		link: LinkedList(LLNode{
+			data: 998
+			link: LinkedList(LLNode{
+				data: 999
+				link: Empty{}
+			})
+		})
+	})
+	assert ll == desired_ll
+}


### PR DESCRIPTION
This PR fix reserved keywords as struct field (fix #11368).

- Fix reserved keywords as struct field.
- Add test.

```vlang
struct Empty {}

// LLNode is struct which holds data and links
struct LLNode {
	data int
	link LinkedList
}

// LinkedList represent a linked list
type LinkedList = Empty | LLNode

// insert performs inserting of the value into the LinkedList
fn insert(ll LinkedList, val int) LinkedList {
	match ll {
		Empty {
			return LLNode{val, Empty{}}
		}
		LLNode {
			return LLNode{
				...ll
				link: insert(ll.link, val)
			}
		}
	}
}

// prepend performs inserting of the value on the top of the LinkedList
fn prepend(ll LinkedList, val int) LinkedList {
	match ll {
		Empty {
			return LLNode{val, Empty{}}
		}
		LLNode {
			return LLNode{
				data: val
				link: ll
			}
		}
	}
}

fn main() {
	mut ll := LinkedList(Empty{})
	ll = insert(ll, 997)
	ll = insert(ll, 998)
	ll = insert(ll, 999)
	mut desired_ll := LinkedList(LLNode{
		data: 997
		link: LinkedList(LLNode{
			data: 998
			link: LinkedList(LLNode{
				data: 999
				link: Empty{}
			})
		})
	})
	println(ll)
	assert ll == desired_ll
}

PS D:\Test\v\tt1> v run .
LinkedList(LLNode{
    data: 997
    link: LinkedList(LLNode{
        data: 998
        link: LinkedList(LLNode{
            data: 999
            link: LinkedList(Empty{})
        })
    })
})
```