### PR TITLE
cgen: fix variable name are 'array' or 'string' (fix #10991 #11343)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1495,8 +1495,10 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 		ast.StructDecl {
 			name := if node.language == .c {
 				util.no_dots(node.name)
+			} else if node.name in ['array', 'string'] {
+				node.name
 			} else {
-				if node.name in ['array', 'string'] { node.name } else { c_name(node.name) }
+				c_name(node.name)
 			}
 			// TODO For some reason, build fails with autofree with this line
 			// as it's only informative, comment it for now

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -15,12 +15,12 @@ import v.depgraph
 const (
 	// NB: some of the words in c_reserved, are not reserved in C,
 	// but are in C++, or have special meaning in V, thus need escaping too.
-	c_reserved     = ['auto', 'break', 'calloc', 'case', 'char', 'class', 'const', 'continue',
-		'default', 'delete', 'do', 'double', 'else', 'enum', 'error', 'exit', 'export', 'extern',
-		'float', 'for', 'free', 'goto', 'if', 'inline', 'int', 'link', 'long', 'malloc', 'namespace',
-		'new', 'panic', 'register', 'restrict', 'return', 'short', 'signed', 'sizeof', 'static',
-		'struct', 'switch', 'typedef', 'typename', 'union', 'unix', 'unsigned', 'void', 'volatile',
-		'while', 'template', 'stdout', 'stdin', 'stderr']
+	c_reserved     = ['array', 'auto', 'break', 'calloc', 'case', 'char', 'class', 'const',
+		'continue', 'default', 'delete', 'do', 'double', 'else', 'enum', 'error', 'exit', 'export',
+		'extern', 'float', 'for', 'free', 'goto', 'if', 'inline', 'int', 'link', 'long', 'malloc',
+		'namespace', 'new', 'panic', 'register', 'restrict', 'return', 'short', 'signed', 'sizeof',
+		'static', 'string', 'struct', 'switch', 'typedef', 'typename', 'union', 'unix', 'unsigned',
+		'void', 'volatile', 'while', 'template', 'stdout', 'stdin', 'stderr']
 	c_reserved_map = string_array_to_map(c_reserved)
 	// same order as in token.Kind
 	cmp_str        = ['eq', 'ne', 'gt', 'lt', 'ge', 'le']
@@ -1493,7 +1493,11 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 			g.sql_stmt(node)
 		}
 		ast.StructDecl {
-			name := if node.language == .c { util.no_dots(node.name) } else { c_name(node.name) }
+			name := if node.language == .c {
+				util.no_dots(node.name)
+			} else {
+				if node.name in ['array', 'string'] { node.name } else { c_name(node.name) }
+			}
 			// TODO For some reason, build fails with autofree with this line
 			// as it's only informative, comment it for now
 			// g.gen_attrs(node.attrs)

--- a/vlib/v/tests/reserved_keywords_array_and_string_test.v
+++ b/vlib/v/tests/reserved_keywords_array_and_string_test.v
@@ -1,0 +1,13 @@
+fn test_reserved_keywords_array_and_string() {
+	array := [1, 2, 3, 4]
+	mut res1 := array.map(it * 3)
+	mut res2 := array.filter(it > 2)
+	println(res1)
+	assert res1 == [3, 6, 9, 12]
+	println(res2)
+	assert res2 == [3, 4]
+
+	string := 'hello'
+	println(string)
+	assert string == 'hello'
+}


### PR DESCRIPTION
This PR fix variable name are 'array' or 'string' (fix #10991 fix #11343).

- Fix variable name are 'array' or 'string'.
- Add test.

```vlang
fn main() {
	array := [1, 2, 3, 4]
	mut res1 := array.map(it * 3)
	mut res2 := array.filter(it > 2)
	println(res1)
	assert res1 == [3, 6, 9, 12]
	println(res2)
	assert res2 == [3, 4]

	string := 'hello'
	println(string)
	assert string == 'hello'
}

PS D:\Test\v\tt1> v run .
[3, 6, 9, 12]
[3, 4]
hello
```