### PR TITLE
fmt: fix removal of comment before embed in struct

### DIFF
--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -57,11 +57,16 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl) {
 	for embed in node.embeds {
 		f.mark_types_import_as_used(embed.typ)
 		styp := f.table.type_to_str_using_aliases(embed.typ, f.mod2alias)
-		if embed.comments.len == 0 {
+
+		pre_comments := embed.comments.filter(it.pos.pos < embed.pos.pos)
+		comments := embed.comments[pre_comments.len..]
+
+		f.comments_before_field(pre_comments)
+		if comments.len == 0 {
 			f.writeln('\t$styp')
 		} else {
 			f.write('\t$styp')
-			f.comments(embed.comments, level: .indent)
+			f.comments(comments, level: .indent)
 		}
 	}
 	mut field_align_i := 0

--- a/vlib/v/fmt/tests/struct_embed_keep.vv
+++ b/vlib/v/fmt/tests/struct_embed_keep.vv
@@ -5,7 +5,9 @@ struct Foo {
 struct Test {}
 
 struct Bar {
+	// comment before Fooo
 	Foo // comment for Foo
+	// comment before Test
 	Test // comment for Test
 	// another comment for Test
 	y int

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -181,7 +181,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 				// struct embedding
 				type_pos = p.tok.position()
 				typ = p.parse_type()
-				ecomments := p.eat_comments()
+				comments << p.eat_comments()
 				type_pos = type_pos.extend(p.prev_tok.position())
 				if !is_on_top {
 					p.error_with_pos('struct embedding must be declared at the beginning of the struct body',
@@ -203,7 +203,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 				embeds << ast.Embed{
 					typ: typ
 					pos: type_pos
-					comments: ecomments
+					comments: comments
 				}
 			} else {
 				// struct field


### PR DESCRIPTION
v fmt removes comment before embed in struct for now. This PR fix this problem
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
