### PR TITLE
checker: check array sort with fancy args (fix #11360)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2555,6 +2555,15 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 				} else if left_name == right_name {
 					c.error('`.sort()` cannot use same argument', node.pos)
 				}
+				if (node.args[0].expr.left !is ast.Ident
+					&& node.args[0].expr.left !is ast.SelectorExpr
+					&& node.args[0].expr.left !is ast.IndexExpr)
+					|| (node.args[0].expr.right !is ast.Ident
+					&& node.args[0].expr.right !is ast.SelectorExpr
+					&& node.args[0].expr.right !is ast.IndexExpr) {
+					c.error('`.sort()` can only use ident, index or selector as argument, \ne.g. `arr.sort(a < b)`, `arr.sort(a.id < b.id)`, `arr.sort(a[0] < b[0])`',
+						node.pos)
+				}
 			} else {
 				c.error(
 					'`.sort()` requires a `<` or `>` comparison as the first and only argument' +

--- a/vlib/v/checker/tests/array_fancy_sort_err.out
+++ b/vlib/v/checker/tests/array_fancy_sort_err.out
@@ -1,0 +1,8 @@
+vlib/v/checker/tests/array_fancy_sort_err.vv:6:8: error: `.sort()` can only use ident, index or selector as argument,
+e.g. `arr.sort(a < b)`, `arr.sort(a.id < b.id)`, `arr.sort(a[0] < b[0])`
+    4 |     text := os.read_file(os.args[0]) ?
+    5 |     mut lines := text.split_into_lines()
+    6 |     lines.sort(a.split('/').last() < b.split('/').last())
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    7 |     println(lines.join('\n'))
+    8 | }

--- a/vlib/v/checker/tests/array_fancy_sort_err.vv
+++ b/vlib/v/checker/tests/array_fancy_sort_err.vv
@@ -1,0 +1,8 @@
+import os
+
+fn main() {
+	text := os.read_file(os.args[0]) ?
+	mut lines := text.split_into_lines()
+	lines.sort(a.split('/').last() < b.split('/').last())
+	println(lines.join('\n'))
+}


### PR DESCRIPTION
This PR check array sort with fancy args (fix #11360).

- Check array sort with fancy args.
- Add test.

```vlang
import os

fn main() {
	text := os.read_file(os.args[0]) ?
	mut lines := text.split_into_lines()
	lines.sort(a.split('/').last() < b.split('/').last())
	println(lines.join('\n'))
}

PS D:\Test\v\tt1> v run .
.\tt1.v:6:8: error: `.sort()` can only use ident, index or selector as argument, 
e.g. `arr.sort(a < b)`, `arr.sort(a.id < b.id)`, `arr.sort(a[0] < b[0])`
    4 |     text := os.read_file(os.args[0]) ?
    5 |     mut lines := text.split_into_lines()
    6 |     lines.sort(a.split('/').last() < b.split('/').last())
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    7 |     println(lines.join('\n'))
    8 | }
```