### PR TITLE
checker: check type mismatch of match range branch (fix #11337)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6223,14 +6223,14 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 				low_expr := expr.low
 				high_expr := expr.high
 				if low_expr is ast.IntegerLiteral {
-					if high_expr is ast.IntegerLiteral {
+					if high_expr is ast.IntegerLiteral && cond_type_sym.is_int() {
 						low = low_expr.val.i64()
 						high = high_expr.val.i64()
 					} else {
 						c.error('mismatched range types', low_expr.pos)
 					}
 				} else if low_expr is ast.CharLiteral {
-					if high_expr is ast.CharLiteral {
+					if high_expr is ast.CharLiteral && cond_type_sym.kind in [.byte, .char, .rune] {
 						low = low_expr.val[0]
 						high = high_expr.val[0]
 					} else {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6223,7 +6223,8 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 				low_expr := expr.low
 				high_expr := expr.high
 				if low_expr is ast.IntegerLiteral {
-					if high_expr is ast.IntegerLiteral && cond_type_sym.is_int() {
+					if high_expr is ast.IntegerLiteral
+						&& (cond_type_sym.is_int() || cond_type_sym.info is ast.Enum) {
 						low = low_expr.val.i64()
 						high = high_expr.val.i64()
 					} else {

--- a/vlib/v/checker/tests/match_range_mismatch_type_err.out
+++ b/vlib/v/checker/tests/match_range_mismatch_type_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/match_range_mismatch_type_err.vv:4:3: error: mismatched range types
+    2 |     x := '1'
+    3 |     match x {
+    4 |         `0`...`9` {
+      |         ~~~
+    5 |             println('0-9')
+    6 |         }

--- a/vlib/v/checker/tests/match_range_mismatch_type_err.vv
+++ b/vlib/v/checker/tests/match_range_mismatch_type_err.vv
@@ -1,0 +1,11 @@
+fn main() {
+	x := '1'
+	match x {
+		`0`...`9` {
+			println('0-9')
+		}
+		else {
+			println('!0-9')
+		}
+	}
+}


### PR DESCRIPTION
This PR check type mismatch of match range branch (fix #11337).

- Check type mismatch of match range branch.
- Add test.

```vlang
fn main() {
	x := '1'
	match x {
		`0`...`9` {
			println('0-9')
		}
		else {
			println('!0-9')
		}
	}
}

PS D:\Test\v\tt1> v run .
.\tt1.v:4:3: error: mismatched range types
    2 |     x := '1'
    3 |     match x {
    4 |         `0`...`9` {
      |         ~~~
    5 |             println('0-9')
    6 |         }
```