### PR TITLE
net.urllib: fix double free in escape()

### DIFF
--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -272,14 +272,8 @@ fn escape(s string, mode EncodingMode) string {
 	if space_count == 0 && hex_count == 0 {
 		return s
 	}
-	buf := []byte{len: (64)}
-	mut t := []byte{}
 	required := s.len + 2 * hex_count
-	if required <= buf.len {
-		t = buf[..required]
-	} else {
-		t = []byte{len: required}
-	}
+	mut t := []byte{len: required}
 	if hex_count == 0 {
 		copy(t, s.bytes())
 		for i in 0 .. s.len {


### PR DESCRIPTION
Fix net.urllib so vweb_example.c can be compiled with -autofree.
Closes #11163.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
