### PR TITLE
v test: allow testing files from a relative directory

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -266,8 +266,7 @@ fn worker_trunner(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 		p.set_thread_context(idx, tls_bench)
 	}
 	tls_bench.no_cstep = true
-	dot_relative_file := p.get_item<string>(idx)
-	mut relative_file := os.real_path(dot_relative_file)
+	mut relative_file := os.real_path(p.get_item<string>(idx))
 	mut cmd_options := [ts.vargs]
 	if relative_file.contains('global') && !ts.vargs.contains('fmt') {
 		cmd_options << ' -enable-globals'

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -212,8 +212,7 @@ pub fn (mut ts TestSession) test() {
 	ts.init()
 	mut remaining_files := []string{}
 	for dot_relative_file in ts.files {
-		relative_file := dot_relative_file.replace('./', '')
-		file := os.real_path(relative_file)
+		file := os.real_path(dot_relative_file)
 		$if windows {
 			if file.contains('sqlite') || file.contains('httpbin') {
 				continue
@@ -268,7 +267,7 @@ fn worker_trunner(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 	}
 	tls_bench.no_cstep = true
 	dot_relative_file := p.get_item<string>(idx)
-	mut relative_file := dot_relative_file.replace('./', '')
+	mut relative_file := os.real_path(dot_relative_file)
 	mut cmd_options := [ts.vargs]
 	if relative_file.contains('global') && !ts.vargs.contains('fmt') {
 		cmd_options << ' -enable-globals'

--- a/cmd/tools/test_if_v_test_system_works.v
+++ b/cmd/tools/test_if_v_test_system_works.v
@@ -51,6 +51,9 @@ fn main() {
 	check_fail('"$vexe" $fail_fpath')
 	check_fail('"$vexe" test $fail_fpath')
 	check_fail('"$vexe" test $tdir')
+	rel_dir := os.join_path(tdir, rand.ulid())
+	os.mkdir(rel_dir) ?
+	check_ok('cd $rel_dir && "$vexe" test ..${os.path_separator + os.base(ok_fpath)}')
 }
 
 fn check_ok(cmd string) string {

--- a/cmd/tools/test_if_v_test_system_works.v
+++ b/cmd/tools/test_if_v_test_system_works.v
@@ -37,10 +37,13 @@ fn new_tdir() string {
 
 fn cleanup_tdir() {
 	println('... removing tdir: $tdir')
-	os.rmdir_all(tdir) or { panic(err) }
+	os.rmdir_all(tdir) or { eprintln(err) }
 }
 
 fn main() {
+	defer {
+		os.chdir(os.wd_at_startup) or {}
+	}
 	println('> vroot: $vroot | vexe: $vexe | tdir: $tdir')
 	ok_fpath := os.join_path(tdir, 'single_test.v')
 	os.write_file(ok_fpath, 'fn test_ok(){ assert true }') ?

--- a/cmd/tools/test_if_v_test_system_works.v
+++ b/cmd/tools/test_if_v_test_system_works.v
@@ -53,7 +53,8 @@ fn main() {
 	check_fail('"$vexe" test $tdir')
 	rel_dir := os.join_path(tdir, rand.ulid())
 	os.mkdir(rel_dir) ?
-	check_ok('cd $rel_dir && "$vexe" test ..${os.path_separator + os.base(ok_fpath)}')
+	os.chdir(rel_dir) ?
+	check_ok('"$vexe" test ..${os.path_separator + os.base(ok_fpath)}')
 }
 
 fn check_ok(cmd string) string {


### PR DESCRIPTION
Before this PR:
```
[~/v/examples]$ v test ../vlib/vweb/request_test.v
---- Testing... --------------------------------------------------------------------------------------------------------------------------------------------------------------
 FAIL     4.960 ms .vlib/vweb/request_test.v
builder error: .vlib/vweb/request_test.v does not exist

------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Failed command 1:    "/home/me/src/v/v"   -o "/tmp/v/test_session_273242908934603/request_test" ".vlib/vweb/request_test.v"
Summary for all V _test.v files: 1 failed, 1 total. Runtime: 5 ms.
```
After this PR:
```
[~/v/examples]$ v test ../vlib/vweb/request_test.v
---- Testing... --------------------------------------------------------------------------------------------------------------------------------------------------------------
 OK     501.293 ms /home/me/src/v/vlib/vweb/request_test.v
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Runtime: 501 ms.
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
