### PR TITLE
fmt: fix removal of selective imported generic type

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -235,7 +235,8 @@ pub fn (mut f Fmt) short_module(name string) string {
 
 pub fn (mut f Fmt) mark_types_import_as_used(typ ast.Type) {
 	sym := f.table.get_type_symbol(typ)
-	f.mark_import_as_used(sym.name)
+	name := sym.name.split('<')[0] // take `Type` from `Type<T>`
+	f.mark_import_as_used(name)
 }
 
 // `name` is a function (`foo.bar()`) or type (`foo.Bar{}`)

--- a/vlib/v/fmt/tests/import_selective_expected.vv
+++ b/vlib/v/fmt/tests/import_selective_expected.vv
@@ -8,7 +8,9 @@ import os {
 import mod {
 	Enum,
 	FnArg,
+	FnArgGeneric,
 	FnRet,
+	FnRetGeneric,
 	InterfaceField,
 	InterfaceMethodArg,
 	InterfaceMethodRet,
@@ -17,7 +19,9 @@ import mod {
 	StructEmbed,
 	StructField,
 	StructMethodArg,
+	StructMethodArgGeneric,
 	StructMethodRet,
+	StructMethodRetGeneric,
 	StructRefField,
 }
 
@@ -29,6 +33,10 @@ struct Struct {
 
 fn (s Struct) method(v StructMethodArg) StructMethodRet {
 	return StructMethodRet{}
+}
+
+fn (s Struct) method_generic<T>(v StructMethodArgGeneric<T>) StructMethodRetGeneric<T> {
+	return StructMethodRet<T>{}
 }
 
 interface Interface {
@@ -44,6 +52,10 @@ fn f(v FnArg) FnRet {
 	println(Enum.val)
 
 	return FnRet{}
+}
+
+fn f_generic<T>(v FnArgGeneric<T>) FnRetGeneric<T> {
+	return FnRetGeneric<T>{}
 }
 
 struct App {

--- a/vlib/v/fmt/tests/import_selective_input.vv
+++ b/vlib/v/fmt/tests/import_selective_input.vv
@@ -11,14 +11,18 @@ import mod {
 	Unused,
 	StructEmbed, StructField, StructRefField
 	StructMethodArg,
-	StructMethodRet
+	StructMethodArgGeneric,
+	StructMethodRet,
+	StructMethodRetGeneric,
 
 	InterfaceField,
 	InterfaceMethodArg,
 	InterfaceMethodRet,
 
 	FnArg,
+	FnArgGeneric
 	FnRet,
+	FnRetGeneric
 
 	RightOfIs,
 	RightOfAs,
@@ -36,6 +40,10 @@ fn (s Struct) method(v StructMethodArg) StructMethodRet {
 	return StructMethodRet{}
 }
 
+fn (s Struct) method_generic<T>(v StructMethodArgGeneric<T>) StructMethodRetGeneric<T> {
+	return StructMethodRet<T>{}
+}
+
 interface Interface {
 	v InterfaceField
 	f(InterfaceMethodArg) InterfaceMethodRet
@@ -48,6 +56,10 @@ fn f(v FnArg) FnRet {
 	println(Enum.val)
 
 	return FnRet{}
+}
+
+fn f_generic<T>(v FnArgGeneric<T>) FnRetGeneric<T> {
+	return FnRetGeneric<T>{}
 }
 
 struct App {


### PR DESCRIPTION
On current master, v fmt removes generic type like this

```
import data { Data }

fn f(v Data<T>) Data<T> {
        return v
}
```
output is:

```
import data

fn f(v Data<T>) Data<T> {
        return v
}
```

This PR fix this problem.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
