### PR TITLE
checker: check using reserved type name as the variable name

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -31,6 +31,8 @@ const (
 	valid_comp_not_user_defined = all_valid_comptime_idents()
 	array_builtin_methods       = ['filter', 'clone', 'repeat', 'reverse', 'map', 'slice', 'sort',
 		'contains', 'index', 'wait', 'any', 'all', 'first', 'last', 'pop']
+	reserved_type_names         = ['bool', 'i8', 'i16', 'int', 'i64', 'byte', 'u16', 'u32', 'u64',
+		'f32', 'f64', 'string', 'tune']
 	vroot_is_deprecated_message = '@VROOT is deprecated, use @VMODROOT or @VEXEROOT instead'
 )
 
@@ -4026,6 +4028,10 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				} else {
 					if is_decl {
 						c.check_valid_snake_case(left.name, 'variable name', left.pos)
+						if left.name in checker.reserved_type_names {
+							c.error('`$left.name` is reserved type name, cannot be used as the variable name',
+								left.pos)
+						}
 					}
 					mut ident_var_info := left.info as ast.IdentVar
 					if ident_var_info.share == .shared_t {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4029,7 +4029,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 					if is_decl {
 						c.check_valid_snake_case(left.name, 'variable name', left.pos)
 						if left.name in checker.reserved_type_names {
-							c.error('`$left.name` is reserved type name, cannot be used as the variable name',
+							c.error('invalid use of reserved type `$left.name` as a variable name',
 								left.pos)
 						}
 					}

--- a/vlib/v/checker/tests/invalid_variable_name_err.out
+++ b/vlib/v/checker/tests/invalid_variable_name_err.out
@@ -1,31 +1,31 @@
-vlib/v/checker/tests/invalid_variable_name_err.vv:2:2: error: `string` is reserved type name, cannot be used as the variable name
+vlib/v/checker/tests/invalid_variable_name_err.vv:2:2: error: invalid use of reserved type `string` as a variable name
     1 | fn main() {
     2 |     string := 'hello, world'
       |     ~~~~~~
     3 |     println(string)
     4 |
-vlib/v/checker/tests/invalid_variable_name_err.vv:5:2: error: `bool` is reserved type name, cannot be used as the variable name
+vlib/v/checker/tests/invalid_variable_name_err.vv:5:2: error: invalid use of reserved type `bool` as a variable name
     3 |     println(string)
     4 |
     5 |     bool := true
       |     ~~~~
     6 |     println(bool)
     7 |
-vlib/v/checker/tests/invalid_variable_name_err.vv:8:2: error: `int` is reserved type name, cannot be used as the variable name
+vlib/v/checker/tests/invalid_variable_name_err.vv:8:2: error: invalid use of reserved type `int` as a variable name
     6 |     println(bool)
     7 |
     8 |     int := 22
       |     ~~~
     9 |     println(int)
    10 |
-vlib/v/checker/tests/invalid_variable_name_err.vv:11:2: error: `u64` is reserved type name, cannot be used as the variable name
+vlib/v/checker/tests/invalid_variable_name_err.vv:11:2: error: invalid use of reserved type `u64` as a variable name
     9 |     println(int)
    10 |
    11 |     u64 := 222
       |     ~~~
    12 |     println(u64)
    13 |
-vlib/v/checker/tests/invalid_variable_name_err.vv:14:2: error: `f64` is reserved type name, cannot be used as the variable name
+vlib/v/checker/tests/invalid_variable_name_err.vv:14:2: error: invalid use of reserved type `f64` as a variable name
    12 |     println(u64)
    13 |
    14 |     f64 := 2.22

--- a/vlib/v/checker/tests/invalid_variable_name_err.out
+++ b/vlib/v/checker/tests/invalid_variable_name_err.out
@@ -1,0 +1,34 @@
+vlib/v/checker/tests/invalid_variable_name_err.vv:2:2: error: `string` is reserved type name, cannot be used as the variable name
+    1 | fn main() {
+    2 |     string := 'hello, world'
+      |     ~~~~~~
+    3 |     println(string)
+    4 |
+vlib/v/checker/tests/invalid_variable_name_err.vv:5:2: error: `bool` is reserved type name, cannot be used as the variable name
+    3 |     println(string)
+    4 |
+    5 |     bool := true
+      |     ~~~~
+    6 |     println(bool)
+    7 |
+vlib/v/checker/tests/invalid_variable_name_err.vv:8:2: error: `int` is reserved type name, cannot be used as the variable name
+    6 |     println(bool)
+    7 |
+    8 |     int := 22
+      |     ~~~
+    9 |     println(int)
+   10 |
+vlib/v/checker/tests/invalid_variable_name_err.vv:11:2: error: `u64` is reserved type name, cannot be used as the variable name
+    9 |     println(int)
+   10 |
+   11 |     u64 := 222
+      |     ~~~
+   12 |     println(u64)
+   13 |
+vlib/v/checker/tests/invalid_variable_name_err.vv:14:2: error: `f64` is reserved type name, cannot be used as the variable name
+   12 |     println(u64)
+   13 |
+   14 |     f64 := 2.22
+      |     ~~~
+   15 |     println(f64)
+   16 | }

--- a/vlib/v/checker/tests/invalid_variable_name_err.vv
+++ b/vlib/v/checker/tests/invalid_variable_name_err.vv
@@ -1,0 +1,16 @@
+fn main() {
+	string := 'hello, world'
+	println(string)
+
+	bool := true
+	println(bool)
+
+	int := 22
+	println(int)
+
+	u64 := 222
+	println(u64)
+
+	f64 := 2.22
+	println(f64)
+}

--- a/vlib/v/tests/reserved_keywords_array_test.v
+++ b/vlib/v/tests/reserved_keywords_array_test.v
@@ -6,8 +6,4 @@ fn test_reserved_keywords_array_and_string() {
 	assert res1 == [3, 6, 9, 12]
 	println(res2)
 	assert res2 == [3, 4]
-
-	string := 'hello'
-	println(string)
-	assert string == 'hello'
 }


### PR DESCRIPTION
This PR check using reserved type name as the variable name.

- Check using reserved type name as the variable name.
- Add test.

```vlang
fn main() {
	string := 'hello, world'
	println(string)

	bool := true
	println(bool)

	int := 22
	println(int)

	u64 := 222
	println(u64)
	
	f64 := 2.22
	println(f64)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:2:2: error: invalid use of reserved type `string` as a variable name
    1 | fn main() {
    2 |     string := 'hello, world'
      |     ~~~~~~
    3 |     println(string)
    4 |
.\tt1.v:5:2: error: invalid use of reserved type `bool` as a variable name
    3 |     println(string)
    4 | 
    5 |     bool := true
      |     ~~~~
    6 |     println(bool)
    7 |
.\tt1.v:8:2: error: invalid use of reserved type `int` as a variable name
    6 |     println(bool)
    7 | 
    8 |     int := 22
      |     ~~~
    9 |     println(int)
   10 |
.\tt1.v:11:2: error: invalid use of reserved type `u64` as a variable name
    9 |     println(int)
   10 | 
   11 |     u64 := 222
      |     ~~~
   12 |     println(u64)
   13 |
.\tt1.v:14:2: error: invalid use of reserved type `f64` as a variable name
   12 |     println(u64)
   13 | 
   14 |     f64 := 2.22
      |     ~~~
   15 |     println(f64)
   16 | }
```