### PR TITLE
readline: fix typo

### DIFF
--- a/vlib/readline/README.md
+++ b/vlib/readline/README.md
@@ -1,15 +1,10 @@
 # Readline
 
-The `readline` module let you await and read user input
-from a terminal in an easy and structured manner.
+The `readline` module lets you await and read user input from a terminal in an easy and structured manner.
 
-The module provides an easy way to prompt the user for
-questions or even make a REPL or an embedded console.
+The module provides an easy way to prompt the user for questions or even make a REPL or an embedded console.
 
-Use `readline.Readline` if you want to include more
-advanced features such as history or simply use
-`readline.read_line('Please confirm (y/n):')` directly
-for one-off user interactions.
+Use `readline.Readline` if you want to include more advanced features such as history or simply use `readline.read_line('Please confirm (y/n):')` directly for one-off user interactions.
 
 # Usage
 

--- a/vlib/readline/README.md
+++ b/vlib/readline/README.md
@@ -1,10 +1,15 @@
 # Readline
 
-The `readline` module lets you await and read user input from a terminal in an easy and structured manner.
+The `readline` module lets you await and read user input
+from a terminal in an easy and structured manner.
 
-The module provides an easy way to prompt the user for questions or even make a REPL or an embedded console.
+The module provides an easy way to prompt the user for
+questions or even make a REPL or an embedded console.
 
-Use `readline.Readline` if you want to include more advanced features such as history or simply use `readline.read_line('Please confirm (y/n):')` directly for one-off user interactions.
+Use `readline.Readline` if you want to include more
+advanced features such as history or simply use
+`readline.read_line('Please confirm (y/n):')` directly
+for one-off user interactions.
 
 # Usage
 


### PR DESCRIPTION
This pr fixes a typo and removes multiple unnecessary line-breaks in the readline README.