### PR TITLE
tmpl: enforce stricter line checking for html interpolation

### DIFF
--- a/vlib/v/parser/tmpl.v
+++ b/vlib/v/parser/tmpl.v
@@ -193,16 +193,16 @@ mut sb := strings.new_builder($lstartlength)\n
 			pos := line.index('@for') or { continue }
 			source.writeln('for ' + line[pos + 4..] + '{')
 			source.writeln(parser.tmpl_str_start)
-		} else if state == .html && line.contains('span.') && line.ends_with('{') {
+		} else if state == .html && line.starts_with('span.') && line.ends_with('{') {
 			// `span.header {` => `<span class='header'>`
 			class := line.find_between('span.', '{').trim_space()
 			source.writeln('<span class="$class">')
 			in_span = true
-		} else if state == .html && line.contains('.') && line.ends_with('{') {
+		} else if state == .html && line.starts_with('.') && line.ends_with('{') {
 			// `.header {` => `<div class='header'>`
 			class := line.find_between('.', '{').trim_space()
 			source.writeln('<div class="$class">')
-		} else if state == .html && line.contains('#') && line.ends_with('{') {
+		} else if state == .html && line.starts_with('#') && line.ends_with('{') {
 			// `#header {` => `<div id='header'>`
 			class := line.find_between('#', '{').trim_space()
 			source.writeln('<div id="$class">')

--- a/vlib/v/tests/inout/file.md
+++ b/vlib/v/tests/inout/file.md
@@ -3,7 +3,7 @@
 This is the main content:
 -------------------------
 @content
-Name: @p1.name
+Name: @{p1.name}
 -------------------------
 
 @include './footer.md'

--- a/vlib/v/tests/inout/file.md
+++ b/vlib/v/tests/inout/file.md
@@ -3,6 +3,7 @@
 This is the main content:
 -------------------------
 @content
+Name: @p1.name
 -------------------------
 
 @include './footer.md'

--- a/vlib/v/tests/inout/tmpl_all_in_one_folder.out
+++ b/vlib/v/tests/inout/tmpl_all_in_one_folder.out
@@ -3,6 +3,7 @@ my header
 This is the main content:
 -------------------------
 some string
+Name: Peter
 -------------------------
 
 my footer

--- a/vlib/v/tests/inout/tmpl_all_in_one_folder.vv
+++ b/vlib/v/tests/inout/tmpl_all_in_one_folder.vv
@@ -1,4 +1,11 @@
+struct Person {
+mut:
+	name string
+}
+
 fn abc() string {
+	mut p1 := Person{}
+	p1.name = 'Peter'
 	content := 'some string'
 	return $tmpl('file.md')
 }


### PR DESCRIPTION
Fix #11143.
Enforce stricter line checking for html interpolation in text template.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
