### PR TITLE
v/builder: implement "check-only" mode

### DIFF
--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -94,6 +94,7 @@ const (
 		'-apk',
 		'-show-timings',
 		'-check-syntax',
+		'-check',
 		'-v',
 		'-progress',
 		'-silent',

--- a/cmd/v/help/build.txt
+++ b/cmd/v/help/build.txt
@@ -125,6 +125,9 @@ NB: the build flags are shared with the run command too:
       that it uses to detect whether or not to use ANSI colors may not work in all cases.
       These options allow you to override the default detection.
 
+   -check
+      Scans, parses, and checks the files without compiling the program.
+
    -check-syntax
       Only scan and parse the files, but then stop. Useful for very quick syntax checks.
 

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -89,6 +89,9 @@ pub fn (mut b Builder) middle_stages() ? {
 	b.checker.check_files(b.parsed_files)
 	util.timing_measure('CHECK')
 	b.print_warnings_and_errors()
+	if b.pref.check_all {
+		return error('stop_after_checker')
+	}
 	util.timing_start('TRANSFORM')
 	b.transformer.transform_files(b.parsed_files)
 	util.timing_measure('TRANSFORM')

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -90,7 +90,7 @@ pub fn (mut b Builder) middle_stages() ? {
 	b.checker.check_files(b.parsed_files)
 	util.timing_measure('CHECK')
 	b.print_warnings_and_errors()
-	if b.pref.check_all {
+	if b.pref.check_only {
 		return error('stop_after_checker')
 	}
 	util.timing_start('TRANSFORM')
@@ -351,7 +351,7 @@ fn (b &Builder) show_total_warns_and_errors_stats() {
 		mut nr_warnings := b.checker.warnings.len
 		mut nr_notices := b.checker.notices.len
 
-		if b.pref.check_all {
+		if b.pref.check_only {
 			nr_errors = b.nr_errors
 			nr_warnings = b.nr_warnings
 			nr_notices = b.nr_notices
@@ -361,7 +361,7 @@ fn (b &Builder) show_total_warns_and_errors_stats() {
 		wstring := util.bold(nr_warnings.str())
 		nstring := util.bold(nr_notices.str())
 		
-		if b.pref.check_all {
+		if b.pref.check_only {
 			println('summary: $estring V errors, $wstring V warnings, $nstring V notices')
 		} else {
 			println('checker summary: $estring V errors, $wstring V warnings, $nstring V notices')
@@ -387,7 +387,7 @@ fn (mut b Builder) print_warnings_and_errors() {
 		return
 	}
 
-	if b.pref.check_all {
+	if b.pref.check_only {
 		for file in b.parsed_files {
 			if !b.pref.skip_warnings {
 				for err in file.notices {
@@ -541,7 +541,7 @@ struct FunctionRedefinition {
 }
 
 fn (b &Builder) error_with_pos(s string, fpath string, pos token.Position) errors.Error {
-	if !b.pref.check_all {
+	if !b.pref.check_only {
 		ferror := util.formatted_error('builder error:', s, fpath, pos)
 		eprintln(ferror)
 		exit(1)

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -26,6 +26,9 @@ mut:
 	out_name_js string
 	stats_lines int // size of backend generated source code in lines
 	stats_bytes int // size of backend generated source code in bytes
+	nr_errors   int // accumulated error count of scanner, parser, checker, and builder
+	nr_warnings int // accumulated warning count of scanner, parser, checker, and builder
+	nr_notices  int // accumulated notice count of scanner, parser, checker, and builder
 pub mut:
 	module_search_paths []string
 	parsed_files        []&ast.File

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -140,7 +140,8 @@ pub fn (mut b Builder) parse_imports() {
 		for imp in ast_file.imports {
 			mod := imp.mod
 			if mod == 'builtin' {
-				b.parsed_files[i].errors << b.error_with_pos('cannot import module "builtin"', ast_file.path, imp.pos)
+				b.parsed_files[i].errors << b.error_with_pos('cannot import module "builtin"',
+					ast_file.path, imp.pos)
 				break
 			}
 			if mod in done_imports {
@@ -149,8 +150,8 @@ pub fn (mut b Builder) parse_imports() {
 			import_path := b.find_module_path(mod, ast_file.path) or {
 				// v.parsers[i].error_with_token_index('cannot import module "$mod" (not found)', v.parsers[i].import_ast.get_import_tok_idx(mod))
 				// break
-				b.parsed_files[i].errors << b.error_with_pos('cannot import module "$mod" (not found)', ast_file.path,
-					imp.pos)
+				b.parsed_files[i].errors << b.error_with_pos('cannot import module "$mod" (not found)',
+					ast_file.path, imp.pos)
 				break
 			}
 			v_files := b.v_files_from_dir(import_path)
@@ -360,7 +361,7 @@ fn (b &Builder) show_total_warns_and_errors_stats() {
 		estring := util.bold(nr_errors.str())
 		wstring := util.bold(nr_warnings.str())
 		nstring := util.bold(nr_notices.str())
-		
+
 		if b.pref.check_only {
 			println('summary: $estring V errors, $wstring V warnings, $nstring V notices')
 		} else {
@@ -546,7 +547,7 @@ fn (b &Builder) error_with_pos(s string, fpath string, pos token.Position) error
 		eprintln(ferror)
 		exit(1)
 	}
-	
+
 	return errors.Error{
 		file_path: fpath
 		pos: pos

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -489,9 +489,9 @@ fn (mut v Builder) cc() {
 		}
 		return
 	}
-	if v.pref.check_all {
+	if v.pref.check_only {
 		if v.pref.is_verbose {
-			println('builder.cc returning early, since pref.check_all is true')
+			println('builder.cc returning early, since pref.check_only is true')
 		}
 		return
 	}

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -489,6 +489,12 @@ fn (mut v Builder) cc() {
 		}
 		return
 	}
+	if v.pref.check_all {
+		if v.pref.is_verbose {
+			println('builder.cc returning early, since pref.check_all is true')
+		}
+		return
+	}
 	if v.pref.should_output_to_stdout() {
 		// output to stdout
 		content := os.read_file(v.out_name_c) or { panic(err) }

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -106,7 +106,7 @@ fn (mut b Builder) run_compiled_executable_and_exit() {
 	if b.pref.skip_running {
 		return
 	}
-	if b.pref.only_check_syntax {
+	if b.pref.only_check_syntax || b.pref.check_all {
 		return
 	}
 	if b.pref.should_output_to_stdout() {

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -106,7 +106,7 @@ fn (mut b Builder) run_compiled_executable_and_exit() {
 	if b.pref.skip_running {
 		return
 	}
-	if b.pref.only_check_syntax || b.pref.check_all {
+	if b.pref.only_check_syntax || b.pref.check_only {
 		return
 	}
 	if b.pref.should_output_to_stdout() {

--- a/vlib/v/errors/errors.v
+++ b/vlib/v/errors/errors.v
@@ -6,6 +6,7 @@ pub enum Reporter {
 	scanner
 	parser
 	checker
+	builder
 	gen
 }
 

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -278,7 +278,7 @@ pub fn (mut p Parser) parse() &ast.File {
 	mut warnings := p.warnings
 	mut notices := p.notices 
 
-	if p.pref.check_all {
+	if p.pref.check_only {
 		errors << p.scanner.errors
 		warnings << p.scanner.warnings
 		notices << p.scanner.notices
@@ -1625,7 +1625,7 @@ pub fn (mut p Parser) error_with_pos(s string, pos token.Position) ast.NodeError
 		exit(1)
 	}
 	mut kind := 'error:'
-	if p.pref.output_mode == .stdout && !p.pref.check_all {
+	if p.pref.output_mode == .stdout && !p.pref.check_only {
 		if p.pref.is_verbose {
 			print_backtrace()
 			kind = 'parser error:'
@@ -1643,7 +1643,7 @@ pub fn (mut p Parser) error_with_pos(s string, pos token.Position) ast.NodeError
 
 		// To avoid getting stuck after an error, the parser
 		// will proceed to the next token.
-		if p.pref.check_all {
+		if p.pref.check_only {
 			p.next()
 		}
 	}
@@ -1665,7 +1665,7 @@ pub fn (mut p Parser) error_with_error(error errors.Error) {
 		exit(1)
 	}
 	mut kind := 'error:'
-	if p.pref.output_mode == .stdout && !p.pref.check_all {
+	if p.pref.output_mode == .stdout && !p.pref.check_only {
 		if p.pref.is_verbose {
 			print_backtrace()
 			kind = 'parser error:'
@@ -1697,7 +1697,7 @@ pub fn (mut p Parser) warn_with_pos(s string, pos token.Position) {
 	if p.pref.skip_warnings {
 		return
 	}
-	if p.pref.output_mode == .stdout && !p.pref.check_all {
+	if p.pref.output_mode == .stdout && !p.pref.check_only {
 		ferror := util.formatted_error('warning:', s, p.file_name, pos)
 		eprintln(ferror)
 	} else {
@@ -1718,7 +1718,7 @@ pub fn (mut p Parser) note_with_pos(s string, pos token.Position) {
 	if p.pref.skip_warnings {
 		return
 	}
-	if p.pref.output_mode == .stdout && !p.pref.check_all {
+	if p.pref.output_mode == .stdout && !p.pref.check_only {
 		ferror := util.formatted_error('notice:', s, p.file_name, pos)
 		eprintln(ferror)
 	} else {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -276,7 +276,7 @@ pub fn (mut p Parser) parse() &ast.File {
 
 	mut errors := p.errors
 	mut warnings := p.warnings
-	mut notices := p.notices 
+	mut notices := p.notices
 
 	if p.pref.check_only {
 		errors << p.scanner.errors

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -273,6 +273,17 @@ pub fn (mut p Parser) parse() &ast.File {
 		}
 	}
 	p.scope.end_pos = p.tok.pos
+
+	mut errors := p.errors
+	mut warnings := p.warnings
+	mut notices := p.notices 
+
+	if p.pref.check_all {
+		errors << p.scanner.errors
+		warnings << p.scanner.warnings
+		notices << p.scanner.notices
+	}
+
 	return &ast.File{
 		path: p.file_name
 		path_base: p.file_base
@@ -286,8 +297,9 @@ pub fn (mut p Parser) parse() &ast.File {
 		stmts: stmts
 		scope: p.scope
 		global_scope: p.table.global_scope
-		errors: p.errors
-		warnings: p.warnings
+		errors: errors
+		warnings: warnings
+		notices: notices
 		global_labels: p.global_labels
 	}
 }

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1625,7 +1625,7 @@ pub fn (mut p Parser) error_with_pos(s string, pos token.Position) ast.NodeError
 		exit(1)
 	}
 	mut kind := 'error:'
-	if p.pref.output_mode == .stdout {
+	if p.pref.output_mode == .stdout && !p.pref.check_all {
 		if p.pref.is_verbose {
 			print_backtrace()
 			kind = 'parser error:'
@@ -1639,6 +1639,12 @@ pub fn (mut p Parser) error_with_pos(s string, pos token.Position) ast.NodeError
 			pos: pos
 			reporter: .parser
 			message: s
+		}
+
+		// To avoid getting stuck after an error, the parser
+		// will proceed to the next token.
+		if p.pref.check_all {
+			p.next()
 		}
 	}
 	if p.pref.output_mode == .silent {
@@ -1659,7 +1665,7 @@ pub fn (mut p Parser) error_with_error(error errors.Error) {
 		exit(1)
 	}
 	mut kind := 'error:'
-	if p.pref.output_mode == .stdout {
+	if p.pref.output_mode == .stdout && !p.pref.check_all {
 		if p.pref.is_verbose {
 			print_backtrace()
 			kind = 'parser error:'
@@ -1691,7 +1697,7 @@ pub fn (mut p Parser) warn_with_pos(s string, pos token.Position) {
 	if p.pref.skip_warnings {
 		return
 	}
-	if p.pref.output_mode == .stdout {
+	if p.pref.output_mode == .stdout && !p.pref.check_all {
 		ferror := util.formatted_error('warning:', s, p.file_name, pos)
 		eprintln(ferror)
 	} else {
@@ -1712,7 +1718,7 @@ pub fn (mut p Parser) note_with_pos(s string, pos token.Position) {
 	if p.pref.skip_warnings {
 		return
 	}
-	if p.pref.output_mode == .stdout {
+	if p.pref.output_mode == .stdout && !p.pref.check_all {
 		ferror := util.formatted_error('notice:', s, p.file_name, pos)
 		eprintln(ferror)
 	} else {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -178,7 +178,7 @@ pub mut:
 	is_parallel         bool
 	is_vweb             bool // skip _ var warning in templates
 	only_check_syntax   bool // when true, just parse the files, then stop, before running checker
-	check_all           bool // same as only_check_syntax, but also runs the checker
+	check_only          bool // same as only_check_syntax, but also runs the checker
 	experimental        bool // enable experimental features
 	skip_unused         bool // skip generating C code for functions, that are not used
 	show_timings        bool // show how much time each compiler stage took
@@ -247,7 +247,7 @@ pub fn parse_args(known_external_commands []string, args []string) (&Preferences
 				res.only_check_syntax = true
 			}
 			'-check' {
-				res.check_all = true
+				res.check_only = true
 			}
 			'-h', '-help', '--help' {
 				// NB: help is *very important*, just respond to all variations:

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -178,6 +178,7 @@ pub mut:
 	is_parallel         bool
 	is_vweb             bool // skip _ var warning in templates
 	only_check_syntax   bool // when true, just parse the files, then stop, before running checker
+	check_all           bool // same as only_check_syntax, but also runs the checker
 	experimental        bool // enable experimental features
 	skip_unused         bool // skip generating C code for functions, that are not used
 	show_timings        bool // show how much time each compiler stage took
@@ -244,6 +245,9 @@ pub fn parse_args(known_external_commands []string, args []string) (&Preferences
 			}
 			'-check-syntax' {
 				res.only_check_syntax = true
+			}
+			'-check' {
+				res.check_all = true
 			}
 			'-h', '-help', '--help' {
 				// NB: help is *very important*, just respond to all variations:

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1336,7 +1336,7 @@ pub fn (mut s Scanner) note(msg string) {
 		line_nr: s.line_nr
 		pos: s.pos
 	}
-	if s.pref.output_mode == .stdout {
+	if s.pref.output_mode == .stdout && !s.pref.check_all {
 		eprintln(util.formatted_error('notice:', msg, s.file_path, pos))
 	} else {
 		s.notices << errors.Notice{
@@ -1358,7 +1358,7 @@ pub fn (mut s Scanner) warn(msg string) {
 		pos: s.pos
 		col: s.current_column() - 1
 	}
-	if s.pref.output_mode == .stdout {
+	if s.pref.output_mode == .stdout && !s.pref.check_all {
 		eprintln(util.formatted_error('warning:', msg, s.file_path, pos))
 	} else {
 		if s.pref.message_limit >= 0 && s.warnings.len >= s.pref.message_limit {
@@ -1380,7 +1380,7 @@ pub fn (mut s Scanner) error(msg string) {
 		pos: s.pos
 		col: s.current_column() - 1
 	}
-	if s.pref.output_mode == .stdout {
+	if s.pref.output_mode == .stdout && !s.pref.check_all {
 		eprintln(util.formatted_error('error:', msg, s.file_path, pos))
 		exit(1)
 	} else {

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1336,7 +1336,7 @@ pub fn (mut s Scanner) note(msg string) {
 		line_nr: s.line_nr
 		pos: s.pos
 	}
-	if s.pref.output_mode == .stdout && !s.pref.check_all {
+	if s.pref.output_mode == .stdout && !s.pref.check_only {
 		eprintln(util.formatted_error('notice:', msg, s.file_path, pos))
 	} else {
 		s.notices << errors.Notice{
@@ -1358,7 +1358,7 @@ pub fn (mut s Scanner) warn(msg string) {
 		pos: s.pos
 		col: s.current_column() - 1
 	}
-	if s.pref.output_mode == .stdout && !s.pref.check_all {
+	if s.pref.output_mode == .stdout && !s.pref.check_only {
 		eprintln(util.formatted_error('warning:', msg, s.file_path, pos))
 	} else {
 		if s.pref.message_limit >= 0 && s.warnings.len >= s.pref.message_limit {
@@ -1380,7 +1380,7 @@ pub fn (mut s Scanner) error(msg string) {
 		pos: s.pos
 		col: s.current_column() - 1
 	}
-	if s.pref.output_mode == .stdout && !s.pref.check_all {
+	if s.pref.output_mode == .stdout && !s.pref.check_only {
 		eprintln(util.formatted_error('error:', msg, s.file_path, pos))
 		exit(1)
 	} else {


### PR DESCRIPTION
This PR implements a "check-only" mode a.k.a `-check` flag. This is similar to the `-check-syntax` option but the difference is that it also proceeds to the checker and prints the messages from different components all at once. This is very handy for tools such as VLS and for people who would like to check their projects without compiling the project.

## TODO
- [x] Document `-check` in the V CLI
- [ ] Additional refactors