### PR TITLE
regex: define the predicate matches_string

### DIFF
--- a/vlib/regex/regex_test.v
+++ b/vlib/regex/regex_test.v
@@ -556,6 +556,13 @@ fn test_regex(){
 			continue
 		}
 
+		// test the match predicate
+		if to.s >= 0 {
+			assert re.matches_string(to.src)
+		} else {
+			assert !re.matches_string(to.src)
+		}
+
 		// rerun to test consistency
 		tmp_str1 := to.src.clone()
 		start1, end1 := re.match_string(tmp_str1)

--- a/vlib/regex/regex_util.v
+++ b/vlib/regex/regex_util.v
@@ -144,6 +144,12 @@ pub fn (mut re RE) match_string(in_txt string) (int, int) {
 	return start, end
 }
 
+// matches_string Checks if the pattern matches the in_txt string
+pub fn (mut re RE) matches_string(in_txt string) bool {
+	start, _ := re.match_string(in_txt)
+	return start != no_match_found
+}
+
 /******************************************************************************
 *
 * Finders


### PR DESCRIPTION
In some AoC exercises I have needed to match patterns, caring only about whether they matched. Worst case was:

```v
for line in os.get_lines() {
    mut start, _ := cpy_val_re.match_string(line)
    if start >= 0 {
        program << CpyVal{
            val: cpy_val_re.get_group_by_id(line, 0).int()
            to: cpy_val_re.get_group_by_id(line, 1)
        }
        continue
    }

    start, _ = cpy_reg_re.match_string(line)
    if start >= 0 {
        program << CpyReg{
            from: cpy_reg_re.get_group_by_id(line, 0)
            to: cpy_reg_re.get_group_by_id(line, 1)
        }
        continue
    }
    ...
}
```

With this predicate, that becomes easier:

```v
for line in os.get_lines() {
    if cpy_val_re.matches_string(line) {
        program << CpyVal{
            val: cpy_val_re.get_group_by_id(line, 0).int()
            to: cpy_val_re.get_group_by_id(line, 1)
        }
    } else if cpy_reg_re.matches_string(line) {
        program << CpyReg{
            from: cpy_reg_re.get_group_by_id(line, 0)
            to: cpy_reg_re.get_group_by_id(line, 1)
        }
     }
    ...
}
```

This is my first PR, tried to follow existing style. The test suite seems to pass, but I was not able to use the new function in a program. How can I get a `v` that uses my just patched `vlib`?