### PR TITLE
cgen: fix generics array delete (fix #11420)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -749,6 +749,18 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		g.expr(node.args[0].expr)
 		g.write('})')
 		return
+	} else if left_sym.kind == .array && node.name == 'delete' {
+		g.write('array_delete(')
+		if node.left_type.is_ptr() {
+			g.expr(node.left)
+		} else {
+			g.write('&')
+			g.expr(node.left)
+		}
+		g.write(', ')
+		g.expr(node.args[0].expr)
+		g.write(')')
+		return
 	}
 
 	if left_sym.kind in [.sum_type, .interface_] {

--- a/vlib/v/tests/generics_array_delete_test.v
+++ b/vlib/v/tests/generics_array_delete_test.v
@@ -1,0 +1,48 @@
+struct Set<T> {
+mut:
+	field []T
+}
+
+fn (mut s Set<T>) add<T>(value T) bool {
+	mut result := false
+
+	if value !in s.field {
+		s.field << value
+		result = true
+	}
+
+	return result
+}
+
+fn (mut s Set<T>) remove<T>(value T) bool {
+	mut result := false
+
+	if value in s.field {
+		ndx := s.field.index(value)
+		s.field.delete(ndx)
+		result = true
+	}
+
+	return result
+}
+
+fn test_generics_array_delete() {
+	mut set := Set<int>{}
+
+	mut added := set.add(4)
+	println(added)
+	assert added
+
+	added = set.add(3)
+	println(added)
+	assert added
+
+	added = set.add(3)
+	println(added)
+	assert !added
+
+	println(set)
+	mut removed := set.remove(4)
+	println(removed)
+	assert removed
+}


### PR DESCRIPTION
This PR fix generics array delete (fix #11420).

- Fix generics array delete.
- Add test.

```vlang
struct Set<T> {
mut:
	field []T
}

fn (mut s Set<T>) add<T>(value T) bool {
	mut result := false

	if value !in s.field {
		s.field << value
		result = true
	}

	return result
}

fn (mut s Set<T>) remove<T>(value T) bool {
	mut result := false

	if value in s.field {
		ndx := s.field.index(value)
		s.field.delete(ndx)
		result = true
	}

	return result
}

fn main() {
	mut set := Set<int>{}

	mut added := set.add(4)
	println(added)
	assert added

	added = set.add(3)
	println(added)
	assert added

	added = set.add(3)
	println(added)
	assert !added

	println(set)
	mut removed := set.remove(4)
	println(removed)
	assert removed
}

PS D:\Test\v\tt1> v run .
true
true
false
Set<int>{
    field: [4, 3]
}
true
```