### PR TITLE
checker: allow mut arg on C functions

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2938,7 +2938,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr) ast.Type {
 			c.error('function with `shared` arguments cannot be called inside `lock`/`rlock` block',
 				call_arg.pos)
 		}
-		if call_arg.is_mut && func.language == .v {
+		if call_arg.is_mut {
 			to_lock, pos := c.fail_if_immutable(call_arg.expr)
 			if !call_arg.expr.is_lvalue() {
 				c.error('cannot pass expression as `mut`', call_arg.expr.position())

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -216,6 +216,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	} else if p.tok.kind == .name && p.tok.lit == 'JS' {
 		language = .js
 	}
+	p.fn_language = language
 	if language != .v {
 		for fna in p.attrs {
 			if fna.name == 'export' {
@@ -249,6 +250,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		// rec.language was initialized with language variable.
 		// So language is changed only if rec.language has been changed.
 		language = rec.language
+		p.fn_language = language
 	}
 	mut name := ''
 	name_pos := p.tok.position()
@@ -992,6 +994,9 @@ fn (mut p Parser) check_fn_mutable_arguments(typ ast.Type, pos token.Position) {
 	if sym.kind == .alias {
 		atyp := (sym.info as ast.Alias).parent_type
 		p.check_fn_mutable_arguments(atyp, pos)
+		return
+	}
+	if p.fn_language == .c {
 		return
 	}
 	p.error_with_pos(

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -33,6 +33,7 @@ mut:
 	peek_tok            token.Token
 	table               &ast.Table
 	language            ast.Language
+	fn_language         ast.Language // .c for `fn C.abcd()` declarations
 	inside_test_file    bool // when inside _test.v or _test.vv file
 	inside_if           bool
 	inside_if_expr      bool

--- a/vlib/v/tests/c_function_mut_param/code.c
+++ b/vlib/v/tests/c_function_mut_param/code.c
@@ -1,0 +1,3 @@
+void mut_arg(const byte *_key, size_t *val) {
+	*val = 5;
+}

--- a/vlib/v/tests/c_function_mut_param/code_test.v
+++ b/vlib/v/tests/c_function_mut_param/code_test.v
@@ -1,0 +1,12 @@
+module main
+
+#include "@VMODROOT/code.c"
+
+fn C.mut_arg(key byteptr, mut val &size_t)
+
+fn test_c_function_mut_param() {
+	key := byteptr(1)
+	mut val := size_t(1)
+	C.mut_arg(key, mut &val)
+	assert val == size_t(5)
+}

--- a/vlib/v/tests/c_function_mut_param/code_test.v
+++ b/vlib/v/tests/c_function_mut_param/code_test.v
@@ -2,11 +2,11 @@ module main
 
 #include "@VMODROOT/code.c"
 
-fn C.mut_arg(key &byte, mut val size_t)
+fn C.mut_arg(key &byte, mut val usize)
 
 fn test_c_function_mut_param() {
 	key := &byte(1)
-	mut val := size_t(1)
+	mut val := usize(1)
 	C.mut_arg(key, mut &val)
-	assert val == size_t(5)
+	assert val == usize(5)
 }

--- a/vlib/v/tests/c_function_mut_param/code_test.v
+++ b/vlib/v/tests/c_function_mut_param/code_test.v
@@ -2,10 +2,10 @@ module main
 
 #include "@VMODROOT/code.c"
 
-fn C.mut_arg(key byteptr, mut val &size_t)
+fn C.mut_arg(key &byte, mut val &size_t)
 
 fn test_c_function_mut_param() {
-	key := byteptr(1)
+	key := &byte(1)
 	mut val := size_t(1)
 	C.mut_arg(key, mut &val)
 	assert val == size_t(5)

--- a/vlib/v/tests/c_function_mut_param/code_test.v
+++ b/vlib/v/tests/c_function_mut_param/code_test.v
@@ -2,7 +2,7 @@ module main
 
 #include "@VMODROOT/code.c"
 
-fn C.mut_arg(key &byte, mut val &size_t)
+fn C.mut_arg(key &byte, mut val size_t)
 
 fn test_c_function_mut_param() {
 	key := &byte(1)

--- a/vlib/v/tests/c_function_mut_param/v.mod
+++ b/vlib/v/tests/c_function_mut_param/v.mod
@@ -1,0 +1,7 @@
+Module {
+	name: 'c_function_mut_param'
+	description: ''
+	version: ''
+	license: ''
+	dependencies: []
+}


### PR DESCRIPTION
Fixes #11153

I'm not sure how to add tests for this, it should basically pass the checker, but not go further since the C function would be a non-existing function, therefore failing C compilation