### PR TITLE
parser: fix generic detection of `foo < bar<T>()`

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1872,7 +1872,7 @@ fn (p &Parser) is_typename(t token.Token) bool {
 // 1. `f<[]` is generic(e.g. `f<[]int>`) because `var < []` is invalid
 // 2. `f<map[` is generic(e.g. `f<map[string]string>)
 // 3. `f<foo>` is generic because `v1 < foo > v2` is invalid syntax
-// 4. `f<foo<bar` is generic when bar is not typename (f<foo<T>(), in contrast, is not generic!)
+// 4. `f<foo<bar` is generic when bar is not generic T (f<foo<T>(), in contrast, is not generic!)
 // 5. `f<Foo,` is generic when Foo is typename.
 //	   otherwise it is not generic because it may be multi-value (e.g. `return f < foo, 0`).
 // 6. `f<mod.Foo>` is same as case 3
@@ -1913,7 +1913,7 @@ fn (p &Parser) is_generic_call() bool {
 		}
 		return match kind3 {
 			.gt { true } // case 3
-			.lt { !p.is_typename(tok4) } // case 4
+			.lt { !(tok4.lit.len == 1 && tok4.lit[0].is_capital()) } // case 4
 			.comma { p.is_typename(tok2) } // case 5
 			// case 6 and 7
 			.dot { kind4 == .name && (kind5 == .gt || (kind5 == .comma && p.is_typename(tok4))) }

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1876,7 +1876,7 @@ fn (p &Parser) is_typename(t token.Token) bool {
 // 5. `f<Foo,` is generic when Foo is typename.
 //	   otherwise it is not generic because it may be multi-value (e.g. `return f < foo, 0`).
 // 6. `f<mod.Foo>` is same as case 3
-// 7. `f<mod.Foo,` is same as case 4
+// 7. `f<mod.Foo,` is same as case 5
 // 8. if there is a &, ignore the & and see if it is a type
 // 9. otherwise, it's not generic
 // see also test_generic_detection in vlib/v/tests/generics_test.v

--- a/vlib/v/tests/generic_complex_sumtype_test.v
+++ b/vlib/v/tests/generic_complex_sumtype_test.v
@@ -65,7 +65,7 @@ fn min<T>(tree Tree<T>) T {
 			1e100
 		}
 		Node<T> {
-			if tree.value < (min<T>(tree.left)) {
+			if tree.value < min<T>(tree.left) {
 				tree.value
 			} else {
 				min<T>(tree.left)

--- a/vlib/v/tests/generics_test.v
+++ b/vlib/v/tests/generics_test.v
@@ -469,9 +469,9 @@ fn test_generic_init() {
 	assert c.name == 'c'
 }
 
-fn return_true<T>(rec int, useless T) T {
+fn return_one<T>(rec int, useless T) T {
 	// foo < bar<T>() should work
-	if rec==0 || 0 < return_true<T>(rec-1, useless) {
+	if rec==0 || 0 < return_one<T>(rec-1, useless) {
 		return T(1)
 	}
 	return T(0)

--- a/vlib/v/tests/generics_test.v
+++ b/vlib/v/tests/generics_test.v
@@ -469,6 +469,14 @@ fn test_generic_init() {
 	assert c.name == 'c'
 }
 
+fn return_true<T>(rec int, useless T) T {
+	// foo < bar<T>() should work
+	if rec==0 || 0 < return_true<T>(rec-1, useless) {
+		return T(1)
+	}
+	return T(0)
+}
+
 fn test_generic_detection() {
 	v1, v2 := -1, 1
 
@@ -487,4 +495,5 @@ fn test_generic_detection() {
 	assert multi_generic_args<int, simplemodule.Data>(0, simplemodule.Data{})
 	assert multi_generic_args<[]int, int>([]int{}, 0)
 	assert multi_generic_args<map[int]int, int>(map[int]int{}, 0)
+	assert 0 < return_one<int>(10, 0)
 }

--- a/vlib/v/tests/generics_test.v
+++ b/vlib/v/tests/generics_test.v
@@ -68,6 +68,7 @@ fn test_postfix_expr() {
 	assert minus_one(i16(-7)) == -8
 	assert minus_one(int(-6)) == -7
 	assert minus_one(i64(-5)) == -6
+
 	// the point is to see if it compiles, more than if the result
 	// is correct, so 1e-6 isn't necessarily the right value to do this
 	// but it's not important
@@ -370,6 +371,7 @@ fn test_generic_fn_with_variadics() {
 	s := 'abc'
 	i := 1
 	abc := Abc{1, 2, 3}
+
 	// these calls should all compile, and print the arguments,
 	// even though the arguments are all a different type and arity:
 	p(s)
@@ -457,12 +459,14 @@ fn test_generic_init() {
 	a << 'a'
 	assert a.len == 1
 	assert a[0] == 'a'
+
 	// map init
 	mut b := new<map[string]string>()
 	assert b.len == 0
 	b['b'] = 'b'
 	assert b.len == 1
 	assert b['b'] == 'b'
+
 	// struct init
 	mut c := new<User>()
 	c.name = 'c'
@@ -471,7 +475,7 @@ fn test_generic_init() {
 
 fn return_one<T>(rec int, useless T) T {
 	// foo < bar<T>() should work
-	if rec==0 || 0 < return_one<T>(rec-1, useless) {
+	if rec == 0 || 0 < return_one<T>(rec - 1, useless) {
 		return T(1)
 	}
 	return T(0)
@@ -490,6 +494,7 @@ fn test_generic_detection() {
 	assert multi_generic_args<int, string>(0, 's')
 	assert multi_generic_args<Foo1, Foo2>(Foo1{}, Foo2{})
 	assert multi_generic_args<Foo<int>, Foo<int> >(Foo<int>{}, Foo<int>{})
+
 	// TODO: assert multi_generic_args<Foo<int>, Foo<int>>(Foo1{}, Foo2{})
 	assert multi_generic_args<simplemodule.Data, int>(simplemodule.Data{}, 0)
 	assert multi_generic_args<int, simplemodule.Data>(0, simplemodule.Data{})


### PR DESCRIPTION
This PR parses `foo < bar<T>()` non generic (which is previously wrongly parsed generic).
So before this PR in the generic version of binary_search_tree you have to write
```V
if tree.value < (min<T>(tree.left)) {
```
Now the extra parentheses are no longer needed.
```V
if tree.value < min<T>(tree.left) {
```