### PR TITLE
vfmt: fix fn return unnecessary parentheses (fix #11423)

### DIFF
--- a/examples/flappylearning/modules/neuroevolution/neuronevolution.v
+++ b/examples/flappylearning/modules/neuroevolution/neuronevolution.v
@@ -9,7 +9,7 @@ fn random_clamped() f64 {
 
 pub fn activation(a f64) f64 {
 	ap := (-a) / 1
-	return (1 / (1 + math.exp(ap)))
+	return 1 / (1 + math.exp(ap))
 }
 
 fn round(a int, b f64) int {

--- a/examples/path_tracing.v
+++ b/examples/path_tracing.v
@@ -327,7 +327,7 @@ fn intersect(r Ray, spheres &Sphere, nspheres int) (bool, f64, int) {
 			id = i
 		}
 	}
-	return (t < inf), t, id
+	return t < inf, t, id
 }
 
 // some casual random function, try to avoid the 0

--- a/examples/spectral.v
+++ b/examples/spectral.v
@@ -15,7 +15,7 @@ import os
 import strconv
 
 fn evala(i int, j int) int {
-	return ((i + j) * (i + j + 1) / 2 + i + 1)
+	return (i + j) * (i + j + 1) / 2 + i + 1
 }
 
 fn times(mut v []f64, u []f64) {

--- a/vlib/math/bits/bits.v
+++ b/vlib/math/bits/bits.v
@@ -150,7 +150,7 @@ pub fn ones_count_64(x u64) int {
 pub fn rotate_left_8(x byte, k int) byte {
 	n := byte(8)
 	s := byte(k) & (n - byte(1))
-	return ((x << s) | (x >> (n - s)))
+	return (x << s) | (x >> (n - s))
 }
 
 // rotate_left_16 returns the value of x rotated left by (k mod 16) bits.
@@ -161,7 +161,7 @@ pub fn rotate_left_8(x byte, k int) byte {
 pub fn rotate_left_16(x u16, k int) u16 {
 	n := u16(16)
 	s := u16(k) & (n - u16(1))
-	return ((x << s) | (x >> (n - s)))
+	return (x << s) | (x >> (n - s))
 }
 
 // rotate_left_32 returns the value of x rotated left by (k mod 32) bits.
@@ -172,7 +172,7 @@ pub fn rotate_left_16(x u16, k int) u16 {
 pub fn rotate_left_32(x u32, k int) u32 {
 	n := u32(32)
 	s := u32(k) & (n - u32(1))
-	return ((x << s) | (x >> (n - s)))
+	return (x << s) | (x >> (n - s))
 }
 
 // rotate_left_64 returns the value of x rotated left by (k mod 64) bits.
@@ -183,7 +183,7 @@ pub fn rotate_left_32(x u32, k int) u32 {
 pub fn rotate_left_64(x u64, k int) u64 {
 	n := u64(64)
 	s := u64(k) & (n - u64(1))
-	return ((x << s) | (x >> (n - s)))
+	return (x << s) | (x >> (n - s))
 }
 
 // --- Reverse ---

--- a/vlib/net/http/response.v
+++ b/vlib/net/http/response.v
@@ -28,9 +28,9 @@ pub fn (resp Response) bytes() []byte {
 
 // Formats resp to a string suitable for HTTP response transmission
 pub fn (resp Response) bytestr() string {
-	return ('HTTP/$resp.http_version $resp.status_code $resp.status_msg\r\n' + '${resp.header.render(
+	return 'HTTP/$resp.http_version $resp.status_code $resp.status_msg\r\n' + '${resp.header.render(
 		version: resp.version()
-	)}\r\n' + '$resp.text')
+	)}\r\n' + '$resp.text'
 }
 
 // Parse a raw HTTP response into a Response object

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -215,7 +215,7 @@ pub fn (mut f File) writeln(s string) ?int {
 	if x < 0 {
 		return error('could not add newline')
 	}
-	return (written + 1)
+	return written + 1
 }
 
 // write_string writes the string `s` into the file

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -426,7 +426,7 @@ pub fn is_executable(path string) bool {
 		// 04 Read-only
 		// 06 Read and write
 		p := real_path(path)
-		return (exists(p) && p.ends_with('.exe'))
+		return exists(p) && p.ends_with('.exe')
 	}
 	$if solaris {
 		statbuf := C.stat{}

--- a/vlib/rand/pcg32/pcg32.v
+++ b/vlib/rand/pcg32/pcg32.v
@@ -39,7 +39,7 @@ pub fn (mut rng PCG32RNG) u32() u32 {
 	rng.state = oldstate * (6364136223846793005) + rng.inc
 	xorshifted := u32(((oldstate >> u64(18)) ^ oldstate) >> u64(27))
 	rot := u32(oldstate >> u64(59))
-	return ((xorshifted >> rot) | (xorshifted << ((-rot) & u32(31))))
+	return (xorshifted >> rot) | (xorshifted << ((-rot) & u32(31)))
 }
 
 // u64 returns a pseudorandom 64-bit unsigned `u64`.
@@ -66,7 +66,7 @@ pub fn (mut rng PCG32RNG) u32n(max u32) u32 {
 	for {
 		r := rng.u32()
 		if r >= threshold {
-			return (r % max)
+			return r % max
 		}
 	}
 	return u32(0)
@@ -83,7 +83,7 @@ pub fn (mut rng PCG32RNG) u64n(max u64) u64 {
 	for {
 		r := rng.u64()
 		if r >= threshold {
-			return (r % max)
+			return r % max
 		}
 	}
 	return u64(0)

--- a/vlib/strconv/atof.c.v
+++ b/vlib/strconv/atof.c.v
@@ -128,7 +128,7 @@ fn is_digit(x byte) bool {
 }
 
 fn is_space(x byte) bool {
-	return (x == `\t` || x == `\n` || x == `\v` || x == `\f` || x == `\r` || x == ` `)
+	return x == `\t` || x == `\n` || x == `\v` || x == `\f` || x == `\r` || x == ` `
 }
 
 fn is_exp(x byte) bool {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1130,7 +1130,11 @@ pub fn (mut f Fmt) return_stmt(node ast.Return) {
 		f.write(' ')
 		// Loop over all return values. In normal returns this will only run once.
 		for i, expr in node.exprs {
-			f.expr(expr)
+			if expr is ast.ParExpr {
+				f.expr(expr.expr)
+			} else {
+				f.expr(expr)
+			}
 			if i < node.exprs.len - 1 {
 				f.write(', ')
 			}

--- a/vlib/v/fmt/tests/fn_return_parentheses_expected.vv
+++ b/vlib/v/fmt/tests/fn_return_parentheses_expected.vv
@@ -1,0 +1,8 @@
+fn is_ascii_upper_alpha(char int) bool {
+	return char >= 65 && char <= 90
+}
+
+fn main() {
+	ret := is_ascii_upper_alpha(`a`)
+	println(ret)
+}

--- a/vlib/v/fmt/tests/fn_return_parentheses_input.vv
+++ b/vlib/v/fmt/tests/fn_return_parentheses_input.vv
@@ -1,0 +1,8 @@
+fn is_ascii_upper_alpha(char int) bool {
+	return (char >= 65 && char <= 90)
+}
+
+fn main() {
+	ret := is_ascii_upper_alpha(`a`)
+	println(ret)
+}


### PR DESCRIPTION
This PR fix fn return unnecessary parentheses (fix #11423).

- Fix fn return unnecessary parentheses.
- Add test.
