### PR TITLE
builtin: add `.str()` method for `i/usize`

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -15,14 +15,13 @@ pub fn ptr_str(ptr voidptr) string {
 	return buf1
 }
 
-// TODO uncomment to have string representation of i/usize
-// pub fn (x isize) str() string {
-// 	return u64(x).str()
-// }
-//
-// pub fn (x usize) str() string {
-// 	return u64(x).str()
-// }
+pub fn (x isize) str() string {
+	return i64(x).str()
+}
+
+pub fn (x usize) str() string {
+	return u64(x).str()
+}
 
 pub fn (x size_t) str() string {
 	return u64(x).str()

--- a/vlib/v/tests/integer_size_test.v
+++ b/vlib/v/tests/integer_size_test.v
@@ -1,36 +1,22 @@
 fn f(u usize) usize
 fn g(i isize) isize
 
-// TODO refactor once `str` method is implemented
-
 fn test_usize() {
 	mut u := usize(3)
 	u += u32(1)
-	// assert u == 4
-	if u != 4 {
-		assert false
-	}
+	assert u == 4
 	u = 4
 	u++
-	// assert u == 5
-	if u != 5 {
-		assert false
-	}
-	// assert u.str() == '5'
+	assert u == 5
+	assert u.str() == '5'
 }
 
 fn test_isize() {
 	mut i := isize(-3)
 	i -= int(1)
-	// assert i == -4
-	if i != -4 {
-		assert false
-	}
+	assert i == -4
 	i = -5
 	i += 2
-	// assert i == -3
-	if i != -3 {
-		assert false
-	}
-	// assert i.str() == '-2'
+	assert i == -3
+	assert i.str() == '-3'
 }


### PR DESCRIPTION
Add string representation for `isize` and `usize`.
They can now be used in string interpolation, `print`s, and debug/test `assert` statements.

Follow up of #11437