### PR TITLE
parser: deprecate `size_t`

### DIFF
--- a/cmd/v/help/build-c.txt
+++ b/cmd/v/help/build-c.txt
@@ -44,27 +44,27 @@ see also `v help build`.
          bare_panic(msg string)
             Print "V panic: " + msg, along with an optional backtrace and/or the V commit hash, and then exit.
          [export: 'malloc']
-         __malloc(n size_t) &C.void
+         __malloc(n usize) &C.void
             Allocates n bytes of memory and returns the pointer to the first byte
          [export: 'free']
          __free(ptr &C.void)
             Free the block of memory ptr allocated by malloc.
-         realloc(old_area &C.void, new_size size_t) &C.void
+         realloc(old_area &C.void, new_size usize) &C.void
             Allocates a new area of size new_size, copies old_area
             to the new area, and returns a pointer to the new area.
          [export: 'calloc']
-         __calloc(nmemb size_t, size size_t) &C.void
+         __calloc(nmemb usize, size usize) &C.void
             Like malloc, but sets all the bytes to `0` first.
-         memcpy(dest &C.void, src &C.void, n size_t) &C.void
+         memcpy(dest &C.void, src &C.void, n usize) &C.void
             Moves n bytes from dest to src, and returns dest
-         memmove(dest &C.void, src &C.void, n size_t) &C.void
+         memmove(dest &C.void, src &C.void, n usize) &C.void
             Like memcpy, but guaranteed to work if dest and src overlap.
-         memcmp(a &C.void, b &C.void, n size_t) int
+         memcmp(a &C.void, b &C.void, n usize) int
             Compare two buffers of length n. If a and b are equal, return 0.
             Otherwise, return the difference between the first different letter.
-         strlen(s &C.void) size_t
+         strlen(s &C.void) usize
             Returns the amount of bytes until the first `0`, starting at s
-         memset(s &C.void, c int, n size_t) &C.void
+         memset(s &C.void, c int, n usize) &C.void
             Sets n bytes starting at s to c (c is casted to a char)
             and returns s.
          getchar() int
@@ -72,7 +72,7 @@ see also `v help build`.
             Print "V Panic" + msg, along with an optional backtrace, and then exit.
          vsprintf(str &char, format &char, ap va_list) int
             See `man vsprintf`.
-         vsnprintf(str &char, size size_t, format &char, ap va_list) int
+         vsnprintf(str &char, size usize, format &char, ap va_list) int
             See `man vsnprintf`.
          bare_backtrace() string
             Return a backtrace that can be printed. If backtraces are not

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -421,7 +421,7 @@ f32 f64
 
 isize, usize // platform-dependent, the size is how many bytes it takes to reference any location in memory
 
-voidptr, size_t // these are mostly used for C interoperability
+voidptr // this one is mostly used for C interoperability
 
 any // similar to C's void* and Go's interface{}
 ```
@@ -4706,7 +4706,7 @@ struct C.SomeCStruct {
 	// union {
 	// struct {
 	data voidptr
-	size size_t
+	size usize
 	// }
 	view C.DataView
 	// }

--- a/examples/sokol/01_cubes/cube.v
+++ b/examples/sokol/01_cubes/cube.v
@@ -56,7 +56,7 @@ fn create_texture(w int, h int, buf &u8) C.sg_image {
 	// commen if .dynamic is enabled
 	img_desc.data.subimage[0][0] = C.sg_range{
 		ptr: buf
-		size: size_t(sz)
+		size: usize(sz)
 	}
 
 	sg_img := C.sg_make_image(&img_desc)
@@ -73,7 +73,7 @@ fn update_text_texture(sg_img C.sg_image, w int, h int, buf &byte) {
 	mut tmp_sbc := C.sg_image_data{}
 	tmp_sbc.subimage[0][0] = C.sg_range{
 		ptr: buf
-		size: size_t(sz)
+		size: usize(sz)
 	}
 	C.sg_update_image(sg_img, &tmp_sbc)
 }

--- a/examples/sokol/02_cubes_glsl/cube_glsl.v
+++ b/examples/sokol/02_cubes_glsl/cube_glsl.v
@@ -89,7 +89,7 @@ fn create_texture(w int, h int, buf &byte) C.sg_image {
 	// comment if .dynamic is enabled
 	img_desc.data.subimage[0][0] = C.sg_range{
 		ptr: buf
-		size: size_t(sz)
+		size: usize(sz)
 	}
 
 	sg_img := C.sg_make_image(&img_desc)
@@ -106,7 +106,7 @@ fn update_text_texture(sg_img C.sg_image, w int, h int, buf &byte) {
 	mut tmp_sbc := C.sg_image_data{}
 	tmp_sbc.subimage[0][0] = C.sg_range{
 		ptr: buf
-		size: size_t(sz)
+		size: usize(sz)
 	}
 	C.sg_update_image(sg_img, &tmp_sbc)
 }
@@ -296,10 +296,10 @@ fn init_cube_glsl(mut app App) {
 	mut vert_buffer_desc := C.sg_buffer_desc{label: c'cube-vertices'}
 	unsafe { C.memset(&vert_buffer_desc, 0, sizeof(vert_buffer_desc)) }
 
-	vert_buffer_desc.size = size_t(vertices.len * int(sizeof(Vertex_t)))
+	vert_buffer_desc.size = usize(vertices.len * int(sizeof(Vertex_t)))
 	vert_buffer_desc.data = C.sg_range{
 		ptr: vertices.data
-		size: size_t(vertices.len * int(sizeof(Vertex_t)))
+		size: usize(vertices.len * int(sizeof(Vertex_t)))
 	}
 
 	vert_buffer_desc.@type = .vertexbuffer
@@ -319,10 +319,10 @@ fn init_cube_glsl(mut app App) {
 	mut index_buffer_desc := C.sg_buffer_desc{label: c'cube-indices'}
 	unsafe { C.memset(&index_buffer_desc, 0, sizeof(index_buffer_desc)) }
 
-	index_buffer_desc.size = size_t(indices.len * int(sizeof(u16)))
+	index_buffer_desc.size = usize(indices.len * int(sizeof(u16)))
 	index_buffer_desc.data = C.sg_range{
 		ptr: indices.data
-		size: size_t(indices.len * int(sizeof(u16)))
+		size: usize(indices.len * int(sizeof(u16)))
 	}
 
 	index_buffer_desc.@type = .indexbuffer
@@ -385,7 +385,7 @@ fn draw_cube_glsl(app App) {
 	// res is a 4x4 matrix of f32 thus: 4*16 byte of size
 	vs_uniforms_range := C.sg_range{
 		ptr: &tr_matrix
-		size: size_t(4 * 16)
+		size: usize(4 * 16)
 	}
 	gfx.apply_uniforms(C.SG_SHADERSTAGE_VS, C.SLOT_vs_params, &vs_uniforms_range)
 
@@ -399,7 +399,7 @@ fn draw_cube_glsl(app App) {
 	]!
 	fs_uniforms_range := C.sg_range{
 		ptr: unsafe { &text_res }
-		size: size_t(4 * 4)
+		size: usize(4 * 4)
 	}
 	gfx.apply_uniforms(C.SG_SHADERSTAGE_FS, C.SLOT_fs_params, &fs_uniforms_range)
 

--- a/examples/sokol/03_march_tracing_glsl/rt_glsl.v
+++ b/examples/sokol/03_march_tracing_glsl/rt_glsl.v
@@ -88,7 +88,7 @@ fn create_texture(w int, h int, buf &byte) C.sg_image {
 	// comment if .dynamic is enabled
 	img_desc.data.subimage[0][0] = C.sg_range{
 		ptr: buf
-		size: size_t(sz)
+		size: usize(sz)
 	}
 
 	sg_img := C.sg_make_image(&img_desc)
@@ -105,7 +105,7 @@ fn update_text_texture(sg_img C.sg_image, w int, h int, buf &byte) {
 	mut tmp_sbc := C.sg_image_data{}
 	tmp_sbc.subimage[0][0] = C.sg_range{
 		ptr: buf
-		size: size_t(sz)
+		size: usize(sz)
 	}
 	C.sg_update_image(sg_img, &tmp_sbc)
 }
@@ -175,10 +175,10 @@ fn init_cube_glsl(mut app App) {
 	mut vert_buffer_desc := C.sg_buffer_desc{label: c'cube-vertices'}
 	unsafe { C.memset(&vert_buffer_desc, 0, sizeof(vert_buffer_desc)) }
 
-	vert_buffer_desc.size = size_t(vertices.len * int(sizeof(Vertex_t)))
+	vert_buffer_desc.size = usize(vertices.len * int(sizeof(Vertex_t)))
 	vert_buffer_desc.data = C.sg_range{
 		ptr: vertices.data
-		size: size_t(vertices.len * int(sizeof(Vertex_t)))
+		size: usize(vertices.len * int(sizeof(Vertex_t)))
 	}
 
 	vert_buffer_desc.@type = .vertexbuffer
@@ -197,10 +197,10 @@ fn init_cube_glsl(mut app App) {
 	mut index_buffer_desc := C.sg_buffer_desc{label: c'cube-indices'}
 	unsafe {C.memset(&index_buffer_desc, 0, sizeof(index_buffer_desc))}
 
-	index_buffer_desc.size = size_t(indices.len * int(sizeof(u16)))
+	index_buffer_desc.size = usize(indices.len * int(sizeof(u16)))
 	index_buffer_desc.data = C.sg_range{
 		ptr: indices.data
-		size: size_t(indices.len * int(sizeof(u16)))
+		size: usize(indices.len * int(sizeof(u16)))
 	}
 
 	index_buffer_desc.@type   = .indexbuffer
@@ -283,7 +283,7 @@ fn draw_cube_glsl(app App) {
 	// res is a 4x4 matrix of f32 thus: 4*16 byte of size
 	vs_uniforms_range := C.sg_range{
 		ptr: &tr_matrix
-		size: size_t(4 * 16)
+		size: usize(4 * 16)
 	}
 	gfx.apply_uniforms(C.SG_SHADERSTAGE_VS, C.SLOT_vs_params, &vs_uniforms_range)
 
@@ -301,7 +301,7 @@ fn draw_cube_glsl(app App) {
 	]!
 	fs_uniforms_range := C.sg_range{
 		ptr: unsafe { &tmp_fs_params }
-		size: size_t(sizeof(tmp_fs_params))
+		size: usize(sizeof(tmp_fs_params))
 	}
 	gfx.apply_uniforms(C.SG_SHADERSTAGE_FS, C.SLOT_fs_params, &fs_uniforms_range)
 

--- a/examples/sokol/04_multi_shader_glsl/rt_glsl.v
+++ b/examples/sokol/04_multi_shader_glsl/rt_glsl.v
@@ -92,7 +92,7 @@ fn create_texture(w int, h int, buf byteptr) C.sg_image {
 	// comment if .dynamic is enabled
 	img_desc.data.subimage[0][0] = C.sg_range{
 		ptr: buf
-		size: size_t(sz)
+		size: usize(sz)
 	}
 
 	sg_img := C.sg_make_image(&img_desc)
@@ -109,7 +109,7 @@ fn update_text_texture(sg_img C.sg_image, w int, h int, buf byteptr) {
 	mut tmp_sbc := C.sg_image_data{}
 	tmp_sbc.subimage[0][0] = C.sg_range{
 		ptr: buf
-		size: size_t(sz)
+		size: usize(sz)
 	}
 	C.sg_update_image(sg_img, &tmp_sbc)
 }
@@ -178,10 +178,10 @@ fn init_cube_glsl_m(mut app App) {
 
 	mut vert_buffer_desc := C.sg_buffer_desc{label: c'cube-vertices'}
 	unsafe { C.memset(&vert_buffer_desc, 0, sizeof(vert_buffer_desc)) }
-	vert_buffer_desc.size = size_t(vertices.len * int(sizeof(Vertex_t)))
+	vert_buffer_desc.size = usize(vertices.len * int(sizeof(Vertex_t)))
 	vert_buffer_desc.data = C.sg_range{
 		ptr: vertices.data
-		size: size_t(vertices.len * int(sizeof(Vertex_t)))
+		size: usize(vertices.len * int(sizeof(Vertex_t)))
 	}
 	vert_buffer_desc.@type = .vertexbuffer
 	vbuf := gfx.make_buffer(&vert_buffer_desc)
@@ -200,10 +200,10 @@ fn init_cube_glsl_m(mut app App) {
 
 	mut index_buffer_desc := C.sg_buffer_desc{label: c'cube-indices'}
 	unsafe { C.memset(&index_buffer_desc, 0, sizeof(index_buffer_desc)) }
-	index_buffer_desc.size = size_t(indices.len * int(sizeof(u16)))
+	index_buffer_desc.size = usize(indices.len * int(sizeof(u16)))
 	index_buffer_desc.data = C.sg_range{
 		ptr: indices.data
-		size: size_t(indices.len * int(sizeof(u16)))
+		size: usize(indices.len * int(sizeof(u16)))
 	}
 	index_buffer_desc.@type = .indexbuffer
 	ibuf := gfx.make_buffer(&index_buffer_desc)
@@ -284,10 +284,10 @@ fn init_cube_glsl_p(mut app App) {
 
 	mut vert_buffer_desc := C.sg_buffer_desc{label: c'cube-vertices'}
 	unsafe { C.memset(&vert_buffer_desc, 0, sizeof(vert_buffer_desc)) }
-	vert_buffer_desc.size = size_t(vertices.len * int(sizeof(Vertex_t)))
+	vert_buffer_desc.size = usize(vertices.len * int(sizeof(Vertex_t)))
 	vert_buffer_desc.data = C.sg_range{
 		ptr: vertices.data
-		size: size_t(vertices.len * int(sizeof(Vertex_t)))
+		size: usize(vertices.len * int(sizeof(Vertex_t)))
 	}
 	vert_buffer_desc.@type = .vertexbuffer
 	vbuf := gfx.make_buffer(&vert_buffer_desc)
@@ -307,10 +307,10 @@ fn init_cube_glsl_p(mut app App) {
 
 	mut index_buffer_desc := C.sg_buffer_desc{label: c'cube-indices'}
 	unsafe { C.memset(&index_buffer_desc, 0, sizeof(index_buffer_desc)) }
-	index_buffer_desc.size = size_t(indices.len * int(sizeof(u16)))
+	index_buffer_desc.size = usize(indices.len * int(sizeof(u16)))
 	index_buffer_desc.data = C.sg_range{
 		ptr: indices.data
-		size: size_t(indices.len * int(sizeof(u16)))
+		size: usize(indices.len * int(sizeof(u16)))
 	}
 	index_buffer_desc.@type = .indexbuffer
 	ibuf := gfx.make_buffer(&index_buffer_desc)
@@ -394,7 +394,7 @@ fn draw_cube_glsl_m(app App) {
 	// res is a 4x4 matrix of f32 thus: 4*16 byte of size
 	vs_uniforms_range := C.sg_range{
 		ptr: &tr_matrix
-		size: size_t(4 * 16)
+		size: usize(4 * 16)
 	}
 	gfx.apply_uniforms(C.SG_SHADERSTAGE_VS, C.SLOT_vs_params_m, &vs_uniforms_range)
 
@@ -414,7 +414,7 @@ fn draw_cube_glsl_m(app App) {
 	]!
 	fs_uniforms_range := C.sg_range{
 		ptr: unsafe { &tmp_fs_params }
-		size: size_t(sizeof(tmp_fs_params))
+		size: usize(sizeof(tmp_fs_params))
 	}
 	gfx.apply_uniforms(C.SG_SHADERSTAGE_FS, C.SLOT_fs_params_p, &fs_uniforms_range)
 
@@ -446,7 +446,7 @@ fn draw_cube_glsl_p(app App) {
 	// res is a 4x4 matrix of f32 thus: 4*16 byte of size
 	vs_uniforms_range := C.sg_range{
 		ptr: &tr_matrix
-		size: size_t(4 * 16)
+		size: usize(4 * 16)
 	}
 	gfx.apply_uniforms(C.SG_SHADERSTAGE_VS, C.SLOT_vs_params_p, &vs_uniforms_range)
 
@@ -466,7 +466,7 @@ fn draw_cube_glsl_p(app App) {
 	]!
 	fs_uniforms_range := C.sg_range{
 		ptr: unsafe { &tmp_fs_params }
-		size: size_t(sizeof(tmp_fs_params))
+		size: usize(sizeof(tmp_fs_params))
 	}
 	gfx.apply_uniforms(C.SG_SHADERSTAGE_FS, C.SLOT_fs_params_p, &fs_uniforms_range)
 

--- a/examples/sokol/05_instancing_glsl/rt_glsl.v
+++ b/examples/sokol/05_instancing_glsl/rt_glsl.v
@@ -103,7 +103,7 @@ fn create_texture(w int, h int, buf byteptr) C.sg_image{
 	// comment if .dynamic is enabled
 	img_desc.data.subimage[0][0] = C.sg_range{
 		ptr:  buf
-		size: size_t(sz)
+		size: usize(sz)
 	}
 
 	sg_img := C.sg_make_image(&img_desc)
@@ -120,7 +120,7 @@ fn update_text_texture(sg_img C.sg_image, w int, h int, buf byteptr){
 	mut tmp_sbc := C.sg_image_data{}
 	tmp_sbc.subimage[0][0] = C.sg_range{
 		ptr: buf
-		size: size_t(sz)
+		size: usize(sz)
 	}
 	C.sg_update_image(sg_img, &tmp_sbc)
 }
@@ -191,10 +191,10 @@ fn init_cube_glsl_i(mut app App) {
 
 	mut vert_buffer_desc := C.sg_buffer_desc{label: c'cube-vertices'}
 	unsafe {C.memset(&vert_buffer_desc, 0, sizeof(vert_buffer_desc))}
-	vert_buffer_desc.size = size_t(vertices.len * int(sizeof(Vertex_t)))
+	vert_buffer_desc.size = usize(vertices.len * int(sizeof(Vertex_t)))
 	vert_buffer_desc.data = C.sg_range{
 		ptr: vertices.data
-		size: size_t(vertices.len * int(sizeof(Vertex_t)))
+		size: usize(vertices.len * int(sizeof(Vertex_t)))
 	}
 	vert_buffer_desc.@type   = .vertexbuffer
 	vbuf := gfx.make_buffer(&vert_buffer_desc)
@@ -203,7 +203,7 @@ fn init_cube_glsl_i(mut app App) {
 	mut inst_buffer_desc := C.sg_buffer_desc{label: c'instance-data'}
 	unsafe {C.memset(&inst_buffer_desc, 0, sizeof(inst_buffer_desc))}
 
-	inst_buffer_desc.size = size_t(num_inst * int(sizeof(m4.Vec4)))
+	inst_buffer_desc.size = usize(num_inst * int(sizeof(m4.Vec4)))
 	inst_buffer_desc.@type   = .vertexbuffer
 	inst_buffer_desc.usage   = .stream
 	inst_buf := gfx.make_buffer(&inst_buffer_desc)
@@ -221,10 +221,10 @@ fn init_cube_glsl_i(mut app App) {
 
 	mut index_buffer_desc := C.sg_buffer_desc{label: c'cube-indices'}
 	unsafe {C.memset(&index_buffer_desc, 0, sizeof(index_buffer_desc))}
-	index_buffer_desc.size    = size_t(indices.len * int(sizeof(u16)))
+	index_buffer_desc.size    = usize(indices.len * int(sizeof(u16)))
 	index_buffer_desc.data = C.sg_range{
 		ptr: indices.data
-		size: size_t(indices.len * int(sizeof(u16)))
+		size: usize(indices.len * int(sizeof(u16)))
 	}
 	index_buffer_desc.@type   = .indexbuffer
 	ibuf := gfx.make_buffer(&index_buffer_desc)
@@ -329,7 +329,7 @@ fn draw_cube_glsl_i(mut app App){
 	}
 	range := C.sg_range{
 		ptr: unsafe { &app.inst_pos }
-		size: size_t(num_inst * int(sizeof(m4.Vec4)))
+		size: usize(num_inst * int(sizeof(m4.Vec4)))
 	}
 	gfx.update_buffer(app.bind['inst'].vertex_buffers[1], &range )
 
@@ -339,7 +339,7 @@ fn draw_cube_glsl_i(mut app App){
 	// res is a 4x4 matrix of f32 thus: 4*16 byte of size
 	vs_uniforms_range := C.sg_range{
 		ptr: unsafe { &tr_matrix }
-		size: size_t(4 * 16)
+		size: usize(4 * 16)
 	}
 	gfx.apply_uniforms(C.SG_SHADERSTAGE_VS, C.SLOT_vs_params_i, &vs_uniforms_range)
 
@@ -357,7 +357,7 @@ fn draw_cube_glsl_i(mut app App){
 	]!
 	fs_uniforms_range := C.sg_range{
 		ptr: unsafe { &tmp_fs_params }
-		size: size_t(sizeof(tmp_fs_params))
+		size: usize(sizeof(tmp_fs_params))
 	}
 	gfx.apply_uniforms(C.SG_SHADERSTAGE_FS, C.SLOT_fs_params, &fs_uniforms_range)
 */

--- a/examples/sokol/06_obj_viewer/modules/obj/rend.v
+++ b/examples/sokol/06_obj_viewer/modules/obj/rend.v
@@ -35,7 +35,7 @@ pub fn create_texture(w int, h int, buf &byte) C.sg_image {
 	// comment if .dynamic is enabled
 	img_desc.data.subimage[0][0] = C.sg_range{
 		ptr: buf
-		size: size_t(sz)
+		size: usize(sz)
 	}
 
 	sg_img := C.sg_make_image(&img_desc)
@@ -73,10 +73,10 @@ pub fn (mut obj_part ObjPart) create_pipeline(in_part []int, shader C.sg_shader,
 	}
 	unsafe { C.memset(&vert_buffer_desc, 0, sizeof(vert_buffer_desc)) }
 
-	vert_buffer_desc.size = size_t(obj_buf.vbuf.len * int(sizeof(Vertex_pnct)))
+	vert_buffer_desc.size = usize(obj_buf.vbuf.len * int(sizeof(Vertex_pnct)))
 	vert_buffer_desc.data = C.sg_range{
 		ptr: obj_buf.vbuf.data
-		size: size_t(obj_buf.vbuf.len * int(sizeof(Vertex_pnct)))
+		size: usize(obj_buf.vbuf.len * int(sizeof(Vertex_pnct)))
 	}
 
 	vert_buffer_desc.@type = .vertexbuffer
@@ -89,10 +89,10 @@ pub fn (mut obj_part ObjPart) create_pipeline(in_part []int, shader C.sg_shader,
 	}
 	unsafe { C.memset(&index_buffer_desc, 0, sizeof(index_buffer_desc)) }
 
-	index_buffer_desc.size = size_t(obj_buf.ibuf.len * int(sizeof(u32)))
+	index_buffer_desc.size = usize(obj_buf.ibuf.len * int(sizeof(u32)))
 	index_buffer_desc.data = C.sg_range{
 		ptr: obj_buf.ibuf.data
-		size: size_t(obj_buf.ibuf.len * int(sizeof(u32)))
+		size: usize(obj_buf.ibuf.len * int(sizeof(u32)))
 	}
 
 	index_buffer_desc.@type = .indexbuffer
@@ -236,11 +236,11 @@ pub fn (obj_part ObjPart) bind_and_draw(rend_data_index int, in_data Shader_data
 
 	vs_uniforms_range := C.sg_range{
 		ptr: in_data.vs_data
-		size: size_t(in_data.vs_len)
+		size: usize(in_data.vs_len)
 	}
 	fs_uniforms_range := C.sg_range{
 		ptr: unsafe { &tmp_fs_params }
-		size: size_t(in_data.fs_len)
+		size: usize(in_data.fs_len)
 	}
 
 	gfx.apply_uniforms(C.SG_SHADERSTAGE_VS, C.SLOT_vs_params, &vs_uniforms_range)

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -150,7 +150,7 @@ pub fn (mut a array) sort_with_compare(callback fn (voidptr, voidptr) int) {
 	$if freestanding {
 		panic('sort does not work with -freestanding')
 	} $else {
-		unsafe { vqsort(a.data, size_t(a.len), size_t(a.element_size), callback) }
+		unsafe { vqsort(a.data, usize(a.len), usize(a.element_size), callback) }
 	}
 }
 

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -11,7 +11,7 @@ pub:
 	element_size int // size in bytes of one element in the array.
 pub mut:
 	data   voidptr
-	offset int // in bytes (should be `size_t`)
+	offset int // in bytes (should be `usize`)
 	len    int // length of the array.
 	cap    int // capacity of the array.
 }

--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -58,13 +58,13 @@ $if gcboehm_leak ? {
 // for use with Boehm-GC
 // Do not use them manually. They are automatically chosen when
 // compiled with `-gc boehm` or `-gc boehm_leak`.
-fn C.GC_MALLOC(n size_t) voidptr
+fn C.GC_MALLOC(n usize) voidptr
 
-fn C.GC_MALLOC_ATOMIC(n size_t) voidptr
+fn C.GC_MALLOC_ATOMIC(n usize) voidptr
 
-fn C.GC_MALLOC_UNCOLLECTABLE(n size_t) voidptr
+fn C.GC_MALLOC_UNCOLLECTABLE(n usize) voidptr
 
-fn C.GC_REALLOC(ptr voidptr, n size_t) voidptr
+fn C.GC_REALLOC(ptr voidptr, n usize) voidptr
 
 fn C.GC_FREE(ptr voidptr)
 

--- a/vlib/builtin/builtin_notd_gcboehm.c.v
+++ b/vlib/builtin/builtin_notd_gcboehm.c.v
@@ -4,13 +4,13 @@ module builtin
 
 // NB: they will NOT be used, since calls to them are wrapped with `$if gcboehm ? { }`
 
-fn C.GC_MALLOC(n size_t) voidptr
+fn C.GC_MALLOC(n usize) voidptr
 
-fn C.GC_MALLOC_ATOMIC(n size_t) voidptr
+fn C.GC_MALLOC_ATOMIC(n usize) voidptr
 
-fn C.GC_MALLOC_UNCOLLECTABLE(n size_t) voidptr
+fn C.GC_MALLOC_UNCOLLECTABLE(n usize) voidptr
 
-fn C.GC_REALLOC(ptr voidptr, n size_t) voidptr
+fn C.GC_REALLOC(ptr voidptr, n usize) voidptr
 
 fn C.GC_FREE(ptr voidptr)
 

--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -1,13 +1,13 @@
 module builtin
 
 // <string.h>
-fn C.memcpy(dest voidptr, const_src voidptr, n size_t) voidptr
+fn C.memcpy(dest voidptr, const_src voidptr, n usize) voidptr
 
-fn C.memcmp(const_s1 voidptr, const_s2 voidptr, n size_t) int
+fn C.memcmp(const_s1 voidptr, const_s2 voidptr, n usize) int
 
-fn C.memmove(dest voidptr, const_src voidptr, n size_t) voidptr
+fn C.memmove(dest voidptr, const_src voidptr, n usize) voidptr
 
-fn C.memset(str voidptr, c int, n size_t) voidptr
+fn C.memset(str voidptr, c int, n usize) voidptr
 
 [trusted]
 fn C.calloc(int, int) &byte
@@ -21,7 +21,7 @@ fn C.free(ptr voidptr)
 [noreturn; trusted]
 fn C.exit(code int)
 
-fn C.qsort(base voidptr, items size_t, item_size size_t, cb C.qsort_callback_func)
+fn C.qsort(base voidptr, items usize, item_size usize, cb C.qsort_callback_func)
 
 fn C.sprintf(a ...voidptr) int
 
@@ -65,9 +65,9 @@ fn C.fopen(filename &char, mode &char) &C.FILE
 
 fn C.fileno(&C.FILE) int
 
-fn C.fread(ptr voidptr, item_size size_t, items size_t, stream &C.FILE) size_t
+fn C.fread(ptr voidptr, item_size usize, items usize, stream &C.FILE) usize
 
-fn C.fwrite(ptr voidptr, item_size size_t, items size_t, stream &C.FILE) size_t
+fn C.fwrite(ptr voidptr, item_size usize, items usize, stream &C.FILE) usize
 
 fn C.fclose(stream &C.FILE) int
 
@@ -130,7 +130,7 @@ fn C.fgets(str &char, n int, stream &C.FILE) int
 [trusted]
 fn C.sigemptyset() int
 
-fn C.getcwd(buf &char, size size_t) &char
+fn C.getcwd(buf &char, size usize) &char
 
 [trusted]
 fn C.mktime() int
@@ -173,7 +173,7 @@ fn C.getchar() int
 [trusted]
 fn C.strerror(int) &char
 
-fn C.snprintf(str &char, size size_t, format &char, opt ...voidptr) int
+fn C.snprintf(str &char, size usize, format &char, opt ...voidptr) int
 
 fn C.fprintf(voidptr, &char, ...voidptr)
 
@@ -194,7 +194,7 @@ fn C.isatty(fd int) int
 
 fn C.syscall(number int, va ...voidptr) int
 
-fn C.sysctl(name &int, namelen u32, oldp voidptr, oldlenp voidptr, newp voidptr, newlen size_t) int
+fn C.sysctl(name &int, namelen u32, oldp voidptr, oldlenp voidptr, newp voidptr, newlen usize) int
 
 [trusted]
 fn C._fileno(int) int
@@ -444,9 +444,9 @@ fn C.dispatch_time(u64, i64) u64
 fn C.dispatch_release(voidptr)
 
 // file descriptor based reading/writing
-fn C.read(fd int, buf voidptr, count size_t) int
+fn C.read(fd int, buf voidptr, count usize) int
 
-fn C.write(fd int, buf voidptr, count size_t) int
+fn C.write(fd int, buf voidptr, count usize) int
 
 fn C.close(fd int) int
 

--- a/vlib/builtin/cfns_wrapper.c.v
+++ b/vlib/builtin/cfns_wrapper.c.v
@@ -67,6 +67,6 @@ pub fn vmemset(s voidptr, c int, n int) voidptr {
 type FnSortCB = fn (const_a voidptr, const_b voidptr) int
 
 [inline; unsafe]
-fn vqsort(base voidptr, nmemb size_t, size size_t, sort_cb FnSortCB) {
+fn vqsort(base voidptr, nmemb usize, size usize, sort_cb FnSortCB) {
 	C.qsort(base, nmemb, size, voidptr(sort_cb))
 }

--- a/vlib/builtin/linux_bare/libc_impl.v
+++ b/vlib/builtin/linux_bare/libc_impl.v
@@ -1,7 +1,7 @@
 module builtin
 
 [unsafe]
-pub fn memcpy(dest &C.void, src &C.void, n size_t) &C.void {
+pub fn memcpy(dest &C.void, src &C.void, n usize) &C.void {
 	dest_ := unsafe { &byte(dest) }
 	src_ := unsafe { &byte(src) }
 	unsafe {
@@ -14,24 +14,24 @@ pub fn memcpy(dest &C.void, src &C.void, n size_t) &C.void {
 
 [export: 'malloc']
 [unsafe]
-fn __malloc(n size_t) &C.void {
+fn __malloc(n usize) &C.void {
 	return unsafe { malloc(int(n)) }
 }
 
 [unsafe]
-fn strlen(_s &C.void) size_t {
+fn strlen(_s &C.void) usize {
 	s := unsafe { &byte(_s) }
 	mut i := 0
 	for ; unsafe { s[i] } != 0; i++ {}
-	return size_t(i)
+	return usize(i)
 }
 
 [unsafe]
-fn realloc(old_area &C.void, new_size size_t) &C.void {
+fn realloc(old_area &C.void, new_size usize) &C.void {
 	if old_area == 0 {
 		return unsafe { malloc(int(new_size)) }
 	}
-	if new_size == size_t(0) {
+	if new_size == usize(0) {
 		unsafe { free(old_area) }
 		return 0
 	}
@@ -40,14 +40,14 @@ fn realloc(old_area &C.void, new_size size_t) &C.void {
 		return unsafe { old_area }
 	} else {
 		new_area := unsafe { malloc(int(new_size)) }
-		unsafe { memmove(new_area, old_area, size_t(old_size)) }
+		unsafe { memmove(new_area, old_area, usize(old_size)) }
 		unsafe { free(old_area) }
 		return new_area
 	}
 }
 
 [unsafe]
-fn memset(s &C.void, c int, n size_t) &C.void {
+fn memset(s &C.void, c int, n usize) &C.void {
 	mut s_ := unsafe { &char(s) }
 	for i in 0 .. int(n) {
 		unsafe {
@@ -58,7 +58,7 @@ fn memset(s &C.void, c int, n size_t) &C.void {
 }
 
 [unsafe]
-fn memmove(dest &C.void, src &C.void, n size_t) &C.void {
+fn memmove(dest &C.void, src &C.void, n usize) &C.void {
 	dest_ := unsafe { &byte(dest) }
 	src_ := unsafe { &byte(src) }
 	mut temp_buf := unsafe { malloc(int(n)) }
@@ -79,7 +79,7 @@ fn memmove(dest &C.void, src &C.void, n size_t) &C.void {
 
 [export: 'calloc']
 [unsafe]
-fn __calloc(nmemb size_t, size size_t) &C.void {
+fn __calloc(nmemb usize, size usize) &C.void {
 	new_area := unsafe { malloc(int(nmemb) * int(size)) }
 	unsafe { memset(new_area, 0, nmemb * size) }
 	return new_area
@@ -91,7 +91,7 @@ fn getchar() int {
 	return int(x)
 }
 
-fn memcmp(a &C.void, b &C.void, n size_t) int {
+fn memcmp(a &C.void, b &C.void, n usize) int {
 	a_ := unsafe { &byte(a) }
 	b_ := unsafe { &byte(b) }
 	for i in 0 .. int(n) {
@@ -118,7 +118,7 @@ fn vsprintf(str &char, format &char, ap &byte) int {
 	panic('vsprintf(): string interpolation is not supported in `-freestanding`')
 }
 
-fn vsnprintf(str &char, size size_t, format &char, ap &byte) int {
+fn vsnprintf(str &char, size usize, format &char, ap &byte) int {
 	panic('vsnprintf(): string interpolation is not supported in `-freestanding`')
 }
 
@@ -157,6 +157,6 @@ fn __exit(code int) {
 }
 
 [export: 'qsort']
-fn __qsort(base voidptr, nmemb size_t, size size_t, sort_cb FnSortCB) {
+fn __qsort(base voidptr, nmemb usize, size usize, sort_cb FnSortCB) {
 	panic('qsort() is not yet implemented in `-freestanding`')
 }

--- a/vlib/crypto/rand/rand_darwin.c.v
+++ b/vlib/crypto/rand/rand_darwin.c.v
@@ -8,7 +8,7 @@ module rand
 
 #flag darwin -framework Security
 
-fn C.SecRandomCopyBytes(rnd C.SecRandomRef, count size_t, bytes voidptr) int
+fn C.SecRandomCopyBytes(rnd C.SecRandomRef, count usize, bytes voidptr) int
 
 // read returns an array of `bytes_needed` random bytes read from the OS.
 pub fn read(bytes_needed int) ?[]byte {

--- a/vlib/crypto/rand/rand_solaris.c.v
+++ b/vlib/crypto/rand/rand_solaris.c.v
@@ -6,7 +6,7 @@ module rand
 
 #include <sys/random.h>
 
-fn C.getrandom(p &byte, n size_t, flags u32) int
+fn C.getrandom(p &byte, n usize, flags u32) int
 
 const (
 	read_batch_size = 256

--- a/vlib/gg/image.c.v
+++ b/vlib/gg/image.c.v
@@ -61,7 +61,7 @@ pub fn (mut img Image) init_sokol_image() &Image {
 	}
 	img_desc.data.subimage[0][0] = C.sg_range{
 		ptr: img.data
-		size: size_t(img.nr_channels * img.width * img.height)
+		size: usize(img.nr_channels * img.width * img.height)
 	}
 	img.simg = C.sg_make_image(&img_desc)
 	img.simg_ok = true
@@ -120,7 +120,7 @@ pub fn (mut ctx Context) new_streaming_image(w int, h int, channels int, sicfg S
 	// Sokol requires that streamed images have NO .ptr/.size initially:
 	img_desc.data.subimage[0][0] = C.sg_range{
 		ptr: 0
-		size: size_t(0)
+		size: usize(0)
 	}
 	img.simg = C.sg_make_image(&img_desc)
 	img.simg_ok = true
@@ -139,7 +139,7 @@ pub fn (mut ctx Context) update_pixel_data(cached_image_idx int, buf &byte) {
 pub fn (mut img Image) update_pixel_data(buf &byte) {
 	mut data := C.sg_image_data{}
 	data.subimage[0][0].ptr = buf
-	data.subimage[0][0].size = size_t(img.width * img.height * img.nr_channels)
+	data.subimage[0][0].size = usize(img.width * img.height * img.nr_channels)
 	gfx.update_image(img.simg, &data)
 }
 

--- a/vlib/net/aasocket.c.v
+++ b/vlib/net/aasocket.c.v
@@ -54,16 +54,16 @@ fn C.freeaddrinfo(info &C.addrinfo)
 // fn C.connect(sockfd int, addr &C.sockaddr, addrlen C.socklen_t) int
 fn C.connect(sockfd int, addr &Addr, addrlen u32) int
 
-// fn C.send(sockfd int, buf voidptr, len size_t, flags int) size_t
+// fn C.send(sockfd int, buf voidptr, len usize, flags int) usize
 fn C.send(sockfd int, buf voidptr, len usize, flags int) int
 
-// fn C.sendto(sockfd int, buf voidptr, len size_t, flags int, dest_add &C.sockaddr, addrlen C.socklen_t) size_t
+// fn C.sendto(sockfd int, buf voidptr, len usize, flags int, dest_add &C.sockaddr, addrlen C.socklen_t) usize
 fn C.sendto(sockfd int, buf voidptr, len usize, flags int, dest_add &Addr, addrlen u32) int
 
-// fn C.recv(sockfd int, buf voidptr, len size_t, flags int) size_t
+// fn C.recv(sockfd int, buf voidptr, len usize, flags int) usize
 fn C.recv(sockfd int, buf voidptr, len usize, flags int) int
 
-// fn C.recvfrom(sockfd int, buf voidptr, len size_t, flags int, src_addr &C.sockaddr, addrlen &C.socklen_t) size_t
+// fn C.recvfrom(sockfd int, buf voidptr, len usize, flags int, src_addr &C.sockaddr, addrlen &C.socklen_t) usize
 fn C.recvfrom(sockfd int, buf voidptr, len usize, flags int, src_addr &Addr, addrlen &u32) int
 
 fn C.shutdown(socket int, how int) int

--- a/vlib/net/aasocket.c.v
+++ b/vlib/net/aasocket.c.v
@@ -55,16 +55,16 @@ fn C.freeaddrinfo(info &C.addrinfo)
 fn C.connect(sockfd int, addr &Addr, addrlen u32) int
 
 // fn C.send(sockfd int, buf voidptr, len size_t, flags int) size_t
-fn C.send(sockfd int, buf voidptr, len size_t, flags int) int
+fn C.send(sockfd int, buf voidptr, len usize, flags int) int
 
 // fn C.sendto(sockfd int, buf voidptr, len size_t, flags int, dest_add &C.sockaddr, addrlen C.socklen_t) size_t
-fn C.sendto(sockfd int, buf voidptr, len size_t, flags int, dest_add &Addr, addrlen u32) int
+fn C.sendto(sockfd int, buf voidptr, len usize, flags int, dest_add &Addr, addrlen u32) int
 
 // fn C.recv(sockfd int, buf voidptr, len size_t, flags int) size_t
-fn C.recv(sockfd int, buf voidptr, len size_t, flags int) int
+fn C.recv(sockfd int, buf voidptr, len usize, flags int) int
 
 // fn C.recvfrom(sockfd int, buf voidptr, len size_t, flags int, src_addr &C.sockaddr, addrlen &C.socklen_t) size_t
-fn C.recvfrom(sockfd int, buf voidptr, len size_t, flags int, src_addr &Addr, addrlen &u32) int
+fn C.recvfrom(sockfd int, buf voidptr, len usize, flags int, src_addr &Addr, addrlen &u32) int
 
 fn C.shutdown(socket int, how int) int
 

--- a/vlib/net/http/download_nix.c.v
+++ b/vlib/net/http/download_nix.c.v
@@ -13,7 +13,7 @@ mut:
 	cb      DownloadFn
 }
 */
-fn download_cb(ptr voidptr, size size_t, nmemb size_t, userp voidptr) {
+fn download_cb(ptr voidptr, size usize, nmemb usize, userp voidptr) {
 	/*
 	mut data := &DownloadStruct(userp)
 	written := C.fwrite(ptr, size, nmemb, data.stream)

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -221,7 +221,7 @@ pub fn (mut f File) writeln(s string) ?int {
 // write_string writes the string `s` into the file
 // It returns how many bytes were actually written.
 pub fn (mut f File) write_string(s string) ?int {
-	unsafe { f.write_full_buffer(s.str, size_t(s.len)) ? }
+	unsafe { f.write_full_buffer(s.str, usize(s.len)) ? }
 	return s.len
 }
 
@@ -274,8 +274,8 @@ pub fn (mut f File) write_ptr(data voidptr, size int) int {
 // write_full_buffer writes a whole buffer of data to the file, starting from the
 // address in `buffer`, no matter how many tries/partial writes it would take.
 [unsafe]
-pub fn (mut f File) write_full_buffer(buffer voidptr, buffer_len size_t) ? {
-	if buffer_len <= size_t(0) {
+pub fn (mut f File) write_full_buffer(buffer voidptr, buffer_len usize) ? {
+	if buffer_len <= usize(0) {
 		return
 	}
 	if !f.is_opened {

--- a/vlib/os/file.js.v
+++ b/vlib/os/file.js.v
@@ -133,4 +133,4 @@ pub fn (mut f File) close() {
 	#f.valueOf().fd.close()
 }
 
-pub fn (mut f File) write_full_buffer(s voidptr, buffer_len size_t) ? {}
+pub fn (mut f File) write_full_buffer(s voidptr, buffer_len usize) ? {}

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -13,7 +13,7 @@ struct C.dirent {
 
 fn C.readdir(voidptr) &C.dirent
 
-fn C.readlink(pathname &char, buf &char, bufsiz size_t) int
+fn C.readlink(pathname &char, buf &char, bufsiz usize) int
 
 fn C.getline(voidptr, voidptr, voidptr) int
 
@@ -531,7 +531,7 @@ pub fn get_raw_line() string {
 			return buf.vstring_with_len(offset)
 		}
 	} $else {
-		max := size_t(0)
+		max := usize(0)
 		buf := &char(0)
 		nr_chars := unsafe { C.getline(&buf, &max, C.stdin) }
 		return unsafe { tos(&byte(buf), if nr_chars < 0 { 0 } else { nr_chars }) }
@@ -567,7 +567,7 @@ pub fn get_raw_stdin() []byte {
 			}
 		}
 	} $else {
-		max := size_t(0)
+		max := usize(0)
 		buf := &char(0)
 		nr_chars := unsafe { C.getline(&buf, &max, C.stdin) }
 		return array{
@@ -996,7 +996,7 @@ pub fn is_atty(fd int) int {
 // write_file_array writes the data in `buffer` to a file in `path`.
 pub fn write_file_array(path string, buffer array) ? {
 	mut f := create(path) ?
-	unsafe { f.write_full_buffer(buffer.data, size_t(buffer.len * buffer.element_size)) ? }
+	unsafe { f.write_full_buffer(buffer.data, usize(buffer.len * buffer.element_size)) ? }
 	f.close()
 }
 

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -352,7 +352,7 @@ pub fn expand_tilde_to_home(path string) string {
 // write_file writes `text` data to a file in `path`.
 pub fn write_file(path string, text string) ? {
 	mut f := create(path) ?
-	unsafe { f.write_full_buffer(text.str, size_t(text.len)) ? }
+	unsafe { f.write_full_buffer(text.str, usize(text.len)) ? }
 	f.close()
 }
 

--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -30,7 +30,7 @@ struct C.sockaddr_storage {}
 
 fn C.atoi() int
 
-fn C.strncasecmp(s1 &char, s2 &char, n size_t) int
+fn C.strncasecmp(s1 &char, s2 &char, n usize) int
 
 struct C.picoev_loop {}
 

--- a/vlib/picohttpparser/picohttpparser.v
+++ b/vlib/picohttpparser/picohttpparser.v
@@ -21,14 +21,14 @@ type PPchar = &&char
 
 struct C.phr_header_t {}
 
-fn C.phr_parse_request(buf &char, len size_t, method PPchar, method_len &size_t, path PPchar, path_len &size_t, minor_version &int, headers &C.phr_header, num_headers &size_t, last_len size_t) int
+fn C.phr_parse_request(buf &char, len usize, method PPchar, method_len &usize, path PPchar, path_len &usize, minor_version &int, headers &C.phr_header, num_headers &usize, last_len usize) int
 
-fn C.phr_parse_response(buf &char, len size_t, minor_version &int, status &int, msg PPchar, msg_len &size_t, headers &C.phr_header, num_headers &size_t, last_len size_t) int
+fn C.phr_parse_response(buf &char, len usize, minor_version &int, status &int, msg PPchar, msg_len &usize, headers &C.phr_header, num_headers &usize, last_len usize) int
 
-fn C.phr_parse_headers(buf &char, len size_t, headers &C.phr_header, num_headers &size_t, last_len size_t) int
+fn C.phr_parse_headers(buf &char, len usize, headers &C.phr_header, num_headers &usize, last_len usize) int
 
-fn C.phr_parse_request_path(buf_start &char, len size_t, method PPchar, method_len &size_t, path PPchar, path_len &size_t) int
-fn C.phr_parse_request_path_pipeline(buf_start &char, len size_t, method PPchar, method_len &size_t, path PPchar, path_len &size_t) int
+fn C.phr_parse_request_path(buf_start &char, len usize, method PPchar, method_len &usize, path PPchar, path_len &usize) int
+fn C.phr_parse_request_path_pipeline(buf_start &char, len usize, method PPchar, method_len &usize, path PPchar, path_len &usize) int
 fn C.get_date() &byte
 
 // static inline int u64toa(char* buf, uint64_t value) {

--- a/vlib/picohttpparser/request.v
+++ b/vlib/picohttpparser/request.v
@@ -13,10 +13,10 @@ pub mut:
 
 [inline]
 pub fn (mut r Request) parse_request(s string, max_headers int) int {
-	method_len := size_t(0)
-	path_len := size_t(0)
+	method_len := usize(0)
+	path_len := usize(0)
 	minor_version := 0
-	num_headers := size_t(max_headers)
+	num_headers := usize(max_headers)
 
 	pret := C.phr_parse_request(s.str, s.len, PPchar(&r.method.str), &method_len, PPchar(&r.path.str),
 		&path_len, &minor_version, &r.headers[0], &num_headers, r.prev_len)
@@ -34,8 +34,8 @@ pub fn (mut r Request) parse_request(s string, max_headers int) int {
 
 [inline]
 pub fn (mut r Request) parse_request_path(s string) int {
-	method_len := size_t(0)
-	path_len := size_t(0)
+	method_len := usize(0)
+	path_len := usize(0)
 
 	pret := C.phr_parse_request_path(s.str, s.len, PPchar(&r.method.str), &method_len,
 		PPchar(&r.path.str), &path_len)
@@ -50,8 +50,8 @@ pub fn (mut r Request) parse_request_path(s string) int {
 
 [inline]
 pub fn (mut r Request) parse_request_path_pipeline(s string) int {
-	method_len := size_t(0)
-	path_len := size_t(0)
+	method_len := usize(0)
+	path_len := usize(0)
 
 	pret := C.phr_parse_request_path_pipeline(s.str, s.len, PPchar(&r.method.str), &method_len,
 		PPchar(&r.path.str), &path_len)

--- a/vlib/sokol/gfx/gfx_structs.c.v
+++ b/vlib/sokol/gfx/gfx_structs.c.v
@@ -121,7 +121,7 @@ pub fn (mut b C.sg_bindings) set_frag_image(index int, img C.sg_image) {
 pub fn (b &C.sg_bindings) update_vert_buffer(index int, data voidptr, element_size int, element_count int) {
 	range := C.sg_range{
 		ptr: data
-		size: size_t(element_size * element_count)
+		size: usize(element_size * element_count)
 	}
 	C.sg_update_buffer(b.vertex_buffers[index], &range)
 }
@@ -129,7 +129,7 @@ pub fn (b &C.sg_bindings) update_vert_buffer(index int, data voidptr, element_si
 pub fn (b &C.sg_bindings) append_vert_buffer(index int, data voidptr, element_size int, element_count int) int {
 	range := C.sg_range{
 		ptr: data
-		size: size_t(element_size * element_count)
+		size: usize(element_size * element_count)
 	}
 	return C.sg_append_buffer(b.vertex_buffers[index], &range)
 }
@@ -137,7 +137,7 @@ pub fn (b &C.sg_bindings) append_vert_buffer(index int, data voidptr, element_si
 pub fn (b &C.sg_bindings) update_index_buffer(data voidptr, element_size int, element_count int) {
 	range := C.sg_range{
 		ptr: data
-		size: size_t(element_size * element_count)
+		size: usize(element_size * element_count)
 	}
 	C.sg_update_buffer(b.index_buffer, &range)
 }
@@ -145,7 +145,7 @@ pub fn (b &C.sg_bindings) update_index_buffer(data voidptr, element_size int, el
 pub fn (b &C.sg_bindings) append_index_buffer(data voidptr, element_size int, element_count int) int {
 	range := C.sg_range{
 		ptr: data
-		size: size_t(element_size * element_count)
+		size: usize(element_size * element_count)
 	}
 	return C.sg_append_buffer(b.index_buffer, &range)
 }
@@ -183,12 +183,12 @@ pub fn (mut desc C.sg_shader_desc) set_frag_image(index int, name string) &C.sg_
 	return desc
 }
 
-pub fn (mut desc C.sg_shader_desc) set_vert_uniform_block_size(block_index int, size size_t) &C.sg_shader_desc {
+pub fn (mut desc C.sg_shader_desc) set_vert_uniform_block_size(block_index int, size usize) &C.sg_shader_desc {
 	desc.vs.uniform_blocks[block_index].size = size
 	return desc
 }
 
-pub fn (mut desc C.sg_shader_desc) set_frag_uniform_block_size(block_index int, size size_t) &C.sg_shader_desc {
+pub fn (mut desc C.sg_shader_desc) set_frag_uniform_block_size(block_index int, size usize) &C.sg_shader_desc {
 	desc.fs.uniform_blocks[block_index].size = size
 	return desc
 }
@@ -233,7 +233,7 @@ pub fn (mut desc C.sg_shader_stage_desc) set_image(index int, name string) C.sg_
 
 pub struct C.sg_shader_uniform_block_desc {
 pub mut:
-	size     size_t
+	size     usize
 	uniforms [16]C.sg_shader_uniform_desc
 }
 
@@ -260,7 +260,7 @@ pub struct C.sg_context {
 pub struct C.sg_range {
 pub mut:
 	ptr  voidptr
-	size size_t
+	size usize
 }
 
 pub struct C.sg_color {
@@ -313,7 +313,7 @@ pub fn (p C.sg_pass) free() {
 pub struct C.sg_buffer_desc {
 pub mut:
 	_start_canary u32
-	size          size_t
+	size          usize
 	@type         BufferType
 	usage         Usage
 	data          C.sg_range

--- a/vlib/szip/szip.v
+++ b/vlib/szip/szip.v
@@ -31,13 +31,13 @@ fn C.zip_entry_size(&Zip) u64
 
 fn C.zip_entry_crc32(&Zip) u32
 
-fn C.zip_entry_write(&Zip, voidptr, size_t) int
+fn C.zip_entry_write(&Zip, voidptr, usize) int
 
 fn C.zip_entry_fwrite(&Zip, &char) int
 
-fn C.zip_entry_read(&Zip, &voidptr, &size_t) int
+fn C.zip_entry_read(&Zip, &voidptr, &usize) int
 
-fn C.zip_entry_noallocread(&Zip, voidptr, size_t) int
+fn C.zip_entry_noallocread(&Zip, voidptr, usize) int
 
 fn C.zip_entry_fread(&Zip, &char) int
 
@@ -196,7 +196,7 @@ pub fn (mut zentry Zip) create_entry(name string) ? {
 // for large entries, please take a look at zip_entry_extract function.
 pub fn (mut zentry Zip) read_entry() ?voidptr {
 	mut buf := &byte(0)
-	mut bsize := size_t(0)
+	mut bsize := usize(0)
 	res := C.zip_entry_read(zentry, unsafe { &voidptr(&buf) }, &bsize)
 	if res == -1 {
 		return error('szip: cannot read properly data from entry')
@@ -206,7 +206,7 @@ pub fn (mut zentry Zip) read_entry() ?voidptr {
 
 // read_entry_buf extracts the current zip entry into user specified buffer
 pub fn (mut zentry Zip) read_entry_buf(buf voidptr, in_bsize int) ?int {
-	bsize := size_t(in_bsize)
+	bsize := usize(in_bsize)
 	res := C.zip_entry_noallocread(zentry, buf, bsize)
 	if res == -1 {
 		return error('szip: cannot read properly data from entry')

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -469,10 +469,11 @@ pub fn merge_types(params ...[]Type) []Type {
 
 pub const (
 	// must be in the same order as the idx consts above
-	builtin_type_names = ['void', 'voidptr', 'charptr', 'byteptr', 'i8', 'i16', 'int', 'i64', 'u16',
-		'u32', 'u64', 'int_literal', 'f32', 'f64', 'float_literal', 'string', 'char', 'byte', 'bool',
-		'none', 'array', 'array_fixed', 'map', 'chan', 'any', 'struct', 'mapnode', 'size_t', 'rune',
-		'thread', 'Error', 'u8']
+	builtin_type_names = ['void', 'voidptr', 'byteptr', 'charptr', 'i8', 'i16', 'int', 'i64', 'isize',
+		'byte', 'u16', 'u32', 'u64', 'usize', 'f32', 'f64', 'char', 'bool', 'none', 'string', 'rune',
+		'array', 'map', 'chan', 'size_t', 'any', 'float_literal', 'int_literal', 'thread', 'Error',
+		'u8',
+	]
 )
 
 pub struct MultiReturn {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -498,6 +498,13 @@ pub fn (mut p Parser) find_type_or_add_placeholder(name string, language ast.Lan
 	// struct / enum / placeholder
 	mut idx := p.table.find_type_idx(name)
 	if idx > 0 {
+		if idx == ast.size_t_type_idx {
+			// don't warn in builtin, there is still the `.str` method
+			if !p.pref.is_fmt && !p.builtin_mod {
+				p.warn_with_pos('`size_t` is deprecated, use `usize` instead', p.prev_tok.position())
+			}
+			return ast.new_type(ast.usize_type_idx)
+		}
 		return ast.new_type(idx)
 	}
 	// not found - add placeholder

--- a/vlib/x/ttf/render_sokol_cpu.v
+++ b/vlib/x/ttf/render_sokol_cpu.v
@@ -133,7 +133,7 @@ pub fn (mut tf_skl TTF_render_Sokol) create_texture() {
 	// comment for dynamic
 	img_desc.data.subimage[0][0] = C.sg_range{
 		ptr: tf_skl.bmp.buf
-		size: size_t(sz)
+		size: usize(sz)
 	}
 
 	simg := C.sg_make_image(&img_desc)
@@ -151,7 +151,7 @@ pub fn (mut tf_skl TTF_render_Sokol) update_text_texture() {
 	mut tmp_sbc := C.sg_image_data{}
 	tmp_sbc.subimage[0][0] = C.sg_range{
 		ptr: tf_skl.bmp.buf
-		size: size_t(sz)
+		size: usize(sz)
 	}
 	C.sg_update_image(tf_skl.sg_img, &tmp_sbc)
 }


### PR DESCRIPTION
Adds a warning when encountering `size_t`.
Make `vfmt` replaces `size_t` with `usize`.