### PR TITLE
Revert "builtin: add `.str` method for `i/usize` (#11441)"

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -15,13 +15,14 @@ pub fn ptr_str(ptr voidptr) string {
 	return buf1
 }
 
-pub fn (x isize) str() string {
-	return i64(x).str()
-}
-
-pub fn (x usize) str() string {
-	return u64(x).str()
-}
+// TODO uncomment to have string representation of i/usize
+// pub fn (x isize) str() string {
+// 	return u64(x).str()
+// }
+//
+// pub fn (x usize) str() string {
+// 	return u64(x).str()
+// }
 
 pub fn (x size_t) str() string {
 	return u64(x).str()

--- a/vlib/v/tests/integer_size_test.v
+++ b/vlib/v/tests/integer_size_test.v
@@ -1,22 +1,36 @@
 fn f(u usize) usize
 fn g(i isize) isize
 
+// TODO refactor once `str` method is implemented
+
 fn test_usize() {
 	mut u := usize(3)
 	u += u32(1)
-	assert u == 4
+	// assert u == 4
+	if u != 4 {
+		assert false
+	}
 	u = 4
 	u++
-	assert u == 5
-	assert u.str() == '5'
+	// assert u == 5
+	if u != 5 {
+		assert false
+	}
+	// assert u.str() == '5'
 }
 
 fn test_isize() {
 	mut i := isize(-3)
 	i -= int(1)
-	assert i == -4
+	// assert i == -4
+	if i != -4 {
+		assert false
+	}
 	i = -5
 	i += 2
-	assert i == -3
-	assert i.str() == '-3'
+	// assert i == -3
+	if i != -3 {
+		assert false
+	}
+	// assert i.str() == '-2'
 }


### PR DESCRIPTION
This reverts commit 56ad5d72ef25eda99e205a2ee840988ef38445f9.

I'll add a fix, then it can be added again