### PR TITLE
parser: fix warning

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -23,9 +23,9 @@ pub fn (x usize) str() string {
 	return u64(x).str()
 }
 
-pub fn (x size_t) str() string {
-	return u64(x).str()
-}
+// pub fn (x size_t) str() string {
+// 	return u64(x).str()
+// }
 
 pub fn (cptr &char) str() string {
 	return u64(cptr).hex()

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -498,9 +498,9 @@ pub fn (mut p Parser) find_type_or_add_placeholder(name string, language ast.Lan
 	// struct / enum / placeholder
 	mut idx := p.table.find_type_idx(name)
 	if idx > 0 {
-		if idx == ast.size_t_type_idx {
+		if !p.builtin_mod && idx == ast.size_t_type_idx {
 			// don't warn in builtin, there is still the `.str` method
-			if !p.pref.is_fmt && !p.builtin_mod {
+			if !p.pref.is_fmt {
 				p.warn_with_pos('`size_t` is deprecated, use `usize` instead', p.prev_tok.position())
 			}
 			return ast.new_type(ast.usize_type_idx)


### PR DESCRIPTION
~~Not sure if it should be merged before or after #11444~~
In the end, this one should be enough.
Once VC is generated, `size_t.str()` can be brought back.

I'm sorry I broke compilation 😓