### PR TITLE
builtin: add `size_t.str()` back

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -23,9 +23,9 @@ pub fn (x usize) str() string {
 	return u64(x).str()
 }
 
-// pub fn (x size_t) str() string {
-// 	return u64(x).str()
-// }
+pub fn (x size_t) str() string {
+	return u64(x).str()
+}
 
 pub fn (cptr &char) str() string {
 	return u64(cptr).hex()


### PR DESCRIPTION
Now that VC is correctly generated, this can be added back 🙂 