### PR TITLE
math.big: fix comparison and add tests

### DIFF
--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -149,6 +149,24 @@ fn test_divmod() {
 	assert h.str() == '2900204736088469'
 }
 
+fn test_comparison() {
+	values := [-3, 13, 52, 6, 41]
+	for value in values {
+		x := big.integer_from_int(value)
+		assert x == x
+		assert x <= x
+		assert x >= x
+	}
+
+	a := big.integer_from_int(-45)
+	b := big.integer_from_int(35)
+
+	assert a < b
+	assert a <= b
+	assert b > a
+	assert b >= a
+}
+
 fn test_conversion() {
 	ten := big.integer_from_int(10)
 

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -454,7 +454,7 @@ pub fn (a Integer) < (b Integer) bool {
 		return false
 	}
 	// If they are negative, the one with the larger absolute value is smaller
-	cmp := a.abs_cmp()
+	cmp := a.abs_cmp(b)
 	return if signum < 0 { cmp > 0 } else { cmp < 0 }
 }
 


### PR DESCRIPTION
Fixes the missing argument in: https://github.com/vlang/v/blob/master/vlib/math/big/integer.v#L457

Adds a unit test.