### PR TITLE
parser: fix reference var followed block expr (fix #11454)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2170,7 +2170,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 	} else if (p.peek_tok.kind == .lcbr || (p.peek_tok.kind == .lt && lit0_is_capital))
 		&& (!p.inside_match || (p.inside_select && prev_tok_kind == .arrow && lit0_is_capital))
 		&& !p.inside_match_case && (!p.inside_if || p.inside_select)
-		&& (!p.inside_for || p.inside_select) { // && (p.tok.lit[0].is_capital() || p.builtin_mod) {
+		&& (!p.inside_for || p.inside_select) && !known_var { // && (p.tok.lit[0].is_capital() || p.builtin_mod) {
 		// map.v has struct literal: map{field: expr}
 		if p.peek_tok.kind == .lcbr && !(p.builtin_mod
 			&& p.file_base in ['map.v', 'map_d_gcboehm_opt.v']) && p.tok.lit == 'map' {

--- a/vlib/v/tests/reference_var_followed_block_expr.v
+++ b/vlib/v/tests/reference_var_followed_block_expr.v
@@ -1,0 +1,8 @@
+fn test_reference_var_followed_block_expr() {
+	mut b := [5, 6, 7]
+	mut c := &b
+	{
+	}
+	println(c)
+	assert '$c' == '&[5, 6, 7]'
+}


### PR DESCRIPTION
This PR fix reference var followed block expr (fix #11454).

- Fix reference var followed block expr.
- Add test.

```vlang
fn main() {
	mut b := [5, 6, 7]
	mut c := &b
	{
	}
	println(c)
	assert '$c' == '&[5, 6, 7]'
}

PS D:\Test\v\tt1> v run .
&[5, 6, 7]
```