### PR TITLE
cgen: fix reference of array_init (fix #11455)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -131,7 +131,7 @@ fn (mut g Gen) array_init(node ast.ArrayInit) {
 	if g.is_shared {
 		g.write('}, sizeof($shared_styp))')
 	} else if is_amp {
-		g.write('), sizeof($array_styp))')
+		g.write(')')
 	}
 }
 

--- a/vlib/v/tests/ref_array_init_test.v
+++ b/vlib/v/tests/ref_array_init_test.v
@@ -1,0 +1,9 @@
+fn test_reference_array_init() {
+	mut b := &[5, 6, 7]
+	{
+		a := [1, 2, 3]
+		b = &a
+	}
+	println(b)
+	assert '$b' == '&[1, 2, 3]'
+}


### PR DESCRIPTION
This PR fix reference of array_init (fix #11455).

- Fix reference of array_init.
- Add test.

```vlang
fn main() {
	mut b := &[5, 6, 7]
	{
		a := [1, 2, 3]
		b = &a
	}
	println(b)
	assert '$b' == '&[1, 2, 3]'
}

PS D:\Test\v\tt1> v run .
&[1, 2, 3]
```