### PR TITLE
parser: allow adding extra `|` before sumtype

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3189,6 +3189,11 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 	generic_types := p.parse_generic_type_list()
 	decl_pos_with_generics := decl_pos.extend(p.prev_tok.position())
 	p.check(.assign)
+	if p.tok.kind == .pipe {
+		// allow starting sum-type with `|`, for better formatting.
+		// for other types of alias, just ignore it, `vfmt` will remove it.
+		p.next()
+	}
 	mut type_pos := p.tok.position()
 	mut comments := []ast.Comment{}
 	if p.tok.kind == .key_fn {


### PR DESCRIPTION
This is a proposal for a new way to format sum-types.
I personally think it is more readable. It is the default way Prettier format sum-types in TypeScript.

```v
import v.ast

type ManyExpr =
        | ast.AnonFn
        | ast.ArrayDecompose
        | ast.ArrayInit
        | ast.AsCast
        | ast.AtExpr
        | ast.BoolLiteral
        | ast.CTempVar
        | ast.CallExpr
        | ast.CastExpr
```
It requires two separate PRs since some code in vlib is affected, and therefore couldn't be parsed currently.
The next part is on my [*sumtype-type-2* branch](https://github.com/Gladear/v/tree/sumtype-pipe-2).