### PR TITLE
fmt: format long sum-type with a line for each type

### DIFF
--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -37,8 +37,20 @@ pub const (
 	string_max_len = 2048
 )
 
-pub type Primitive = InfixType | bool | byte | f32 | f64 | i16 | i64 | i8 | int | string |
-	time.Time | u16 | u32 | u64
+pub type Primitive = InfixType
+	| bool
+	| byte
+	| f32
+	| f64
+	| i16
+	| i64
+	| i8
+	| int
+	| string
+	| time.Time
+	| u16
+	| u32
+	| u64
 
 pub enum OperationKind {
 	neq // !=

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -9,25 +9,104 @@ import v.pref
 
 pub type TypeDecl = AliasTypeDecl | FnTypeDecl | SumTypeDecl
 
-pub type Expr = AnonFn | ArrayDecompose | ArrayInit | AsCast | Assoc | AtExpr | BoolLiteral |
-	CTempVar | CallExpr | CastExpr | ChanInit | CharLiteral | Comment | ComptimeCall |
-	ComptimeSelector | ConcatExpr | DumpExpr | EmptyExpr | EnumVal | FloatLiteral | GoExpr |
-	Ident | IfExpr | IfGuardExpr | IndexExpr | InfixExpr | IntegerLiteral | IsRefType |
-	Likely | LockExpr | MapInit | MatchExpr | NodeError | None | OffsetOf | OrExpr | ParExpr |
-	PostfixExpr | PrefixExpr | RangeExpr | SelectExpr | SelectorExpr | SizeOf | SqlExpr |
-	StringInterLiteral | StringLiteral | StructInit | TypeNode | TypeOf | UnsafeExpr
+pub type Expr = AnonFn
+	| ArrayDecompose
+	| ArrayInit
+	| AsCast
+	| Assoc
+	| AtExpr
+	| BoolLiteral
+	| CTempVar
+	| CallExpr
+	| CastExpr
+	| ChanInit
+	| CharLiteral
+	| Comment
+	| ComptimeCall
+	| ComptimeSelector
+	| ConcatExpr
+	| DumpExpr
+	| EmptyExpr
+	| EnumVal
+	| FloatLiteral
+	| GoExpr
+	| Ident
+	| IfExpr
+	| IfGuardExpr
+	| IndexExpr
+	| InfixExpr
+	| IntegerLiteral
+	| IsRefType
+	| Likely
+	| LockExpr
+	| MapInit
+	| MatchExpr
+	| NodeError
+	| None
+	| OffsetOf
+	| OrExpr
+	| ParExpr
+	| PostfixExpr
+	| PrefixExpr
+	| RangeExpr
+	| SelectExpr
+	| SelectorExpr
+	| SizeOf
+	| SqlExpr
+	| StringInterLiteral
+	| StringLiteral
+	| StructInit
+	| TypeNode
+	| TypeOf
+	| UnsafeExpr
 
-pub type Stmt = AsmStmt | AssertStmt | AssignStmt | Block | BranchStmt | CompFor | ConstDecl |
-	DeferStmt | EmptyStmt | EnumDecl | ExprStmt | FnDecl | ForCStmt | ForInStmt | ForStmt |
-	GlobalDecl | GotoLabel | GotoStmt | HashStmt | Import | InterfaceDecl | Module | NodeError |
-	Return | SqlStmt | StructDecl | TypeDecl
+pub type Stmt = AsmStmt
+	| AssertStmt
+	| AssignStmt
+	| Block
+	| BranchStmt
+	| CompFor
+	| ConstDecl
+	| DeferStmt
+	| EmptyStmt
+	| EnumDecl
+	| ExprStmt
+	| FnDecl
+	| ForCStmt
+	| ForInStmt
+	| ForStmt
+	| GlobalDecl
+	| GotoLabel
+	| GotoStmt
+	| HashStmt
+	| Import
+	| InterfaceDecl
+	| Module
+	| NodeError
+	| Return
+	| SqlStmt
+	| StructDecl
+	| TypeDecl
 
 pub type ScopeObject = AsmRegister | ConstField | GlobalField | Var
 
 // TODO: replace Param
-pub type Node = CallArg | ConstField | EmptyNode | EnumField | Expr | File | GlobalField |
-	IfBranch | MatchBranch | NodeError | Param | ScopeObject | SelectBranch | Stmt | StructField |
-	StructInitField
+pub type Node = CallArg
+	| ConstField
+	| EmptyNode
+	| EnumField
+	| Expr
+	| File
+	| GlobalField
+	| IfBranch
+	| MatchBranch
+	| NodeError
+	| Param
+	| ScopeObject
+	| SelectBranch
+	| Stmt
+	| StructField
+	| StructInitField
 
 pub struct TypeNode {
 pub:
@@ -1155,8 +1234,15 @@ pub mut:
 }
 
 // [eax+5] | j | displacement literal (e.g. 123 in [rax + 123] ) | eax | true | `a` | 0.594 | 123 | label_name
-pub type AsmArg = AsmAddressing | AsmAlias | AsmDisp | AsmRegister | BoolLiteral | CharLiteral |
-	FloatLiteral | IntegerLiteral | string
+pub type AsmArg = AsmAddressing
+	| AsmAlias
+	| AsmDisp
+	| AsmRegister
+	| BoolLiteral
+	| CharLiteral
+	| FloatLiteral
+	| IntegerLiteral
+	| string
 
 pub struct AsmRegister {
 pub mut:

--- a/vlib/v/ast/comptime_const_values.v
+++ b/vlib/v/ast/comptime_const_values.v
@@ -1,7 +1,18 @@
 module ast
 
-pub type ComptTimeConstValue = EmptyExpr | byte | f32 | f64 | i16 | i64 | i8 | int | rune |
-	string | u16 | u32 | u64
+pub type ComptTimeConstValue = EmptyExpr
+	| byte
+	| f32
+	| f64
+	| i16
+	| i64
+	| i8
+	| int
+	| rune
+	| string
+	| u16
+	| u32
+	| u64
 
 pub fn empty_comptime_const_expr() ComptTimeConstValue {
 	return EmptyExpr{}

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -16,8 +16,20 @@ import v.pref
 
 pub type Type = int
 
-pub type TypeInfo = Aggregate | Alias | Array | ArrayFixed | Chan | Enum | FnType | GenericInst |
-	Interface | Map | MultiReturn | Struct | SumType | Thread
+pub type TypeInfo = Aggregate
+	| Alias
+	| Array
+	| ArrayFixed
+	| Chan
+	| Enum
+	| FnType
+	| GenericInst
+	| Interface
+	| Map
+	| MultiReturn
+	| Struct
+	| SumType
+	| Thread
 
 pub enum Language {
 	v

--- a/vlib/v/fmt/tests/long_sumtype_expected.vv
+++ b/vlib/v/fmt/tests/long_sumtype_expected.vv
@@ -1,0 +1,13 @@
+import v.ast
+
+type ManyExpr = ast.AnonFn
+	| ast.ArrayDecompose
+	| ast.ArrayInit
+	| ast.AsCast
+	| ast.AtExpr
+	| ast.BoolLiteral
+	| ast.CTempVar
+	| ast.CallExpr
+	| ast.CastExpr
+
+type SomeStmt = ast.AsmStmt | ast.AssertStmt

--- a/vlib/v/fmt/tests/long_sumtype_input.vv
+++ b/vlib/v/fmt/tests/long_sumtype_input.vv
@@ -1,0 +1,6 @@
+import v.ast
+
+type ManyExpr = ast.AnonFn | ast.ArrayDecompose | ast.ArrayInit | ast.AsCast | ast.AtExpr | ast.BoolLiteral | ast.CTempVar | ast.CallExpr | ast.CastExpr
+
+type SomeStmt = ast.AsmStmt
+	| ast.AssertStmt

--- a/vlib/x/json2/decoder.v
+++ b/vlib/x/json2/decoder.v
@@ -4,8 +4,7 @@
 module json2
 
 // `Any` is a sum type that lists the possible types to be decoded and used.
-pub type Any = Null | []Any | bool | f32 | f64 | i64 | int | map[string]Any | string |
-	u64
+pub type Any = Null | []Any | bool | f32 | f64 | i64 | int | map[string]Any | string | u64
 
 // `Null` struct is a simple representation of the `null` value in JSON.
 pub struct Null {


### PR DESCRIPTION
Change formatting of multi-line sum-type to have a line for each type

e.g.
```v
pub type Primitive = InfixType | bool | byte | f32 | f64 | i16 | i64 | i8 | int | string |
	time.Time | u16 | u32 | u64
```
becomes
```v
pub type Primitive = InfixType
	| bool
	| byte
	| f32
	| f64
	| i16
	// ...
```