### PR TITLE
builder: remove fPic from shared build arguments on windows

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -307,7 +307,9 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	}
 	if v.pref.is_shared {
 		ccoptions.linker_flags << '-shared'
-		ccoptions.args << '-fPIC' // -Wl,-z,defs'
+		$if !windows {
+			ccoptions.args << '-fPIC' // -Wl,-z,defs'
+		}
 	}
 	if v.pref.is_bare {
 		ccoptions.args << '-fno-stack-protector'


### PR DESCRIPTION
fPic is an unsupported argument when using clang and [is ignored when using gcc](https://gcc.gnu.org/legacy-ml/gcc-patches/2015-08/msg00836.html)  to create shared libraries aka dlls on windows. tcc seems also not to miss it and msvc has no equivalent either.


