### PR TITLE
fmt: fix bug that break generics call in string inter

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -201,7 +201,7 @@ pub fn (lit &StringInterLiteral) get_fspec_braces(i int) (string, bool) {
 					break
 				}
 				CallExpr {
-					if sub_expr.args.len != 0 {
+					if sub_expr.args.len != 0 || sub_expr.concrete_types.len != 0 {
 						needs_braces = true
 					} else if sub_expr.left is CallExpr {
 						sub_expr = sub_expr.left

--- a/vlib/v/fmt/tests/string_interpolation_keep.vv
+++ b/vlib/v/fmt/tests/string_interpolation_keep.vv
@@ -14,4 +14,6 @@ fn main() {
 	println('(${some_struct.@type}, $some_struct.y)')
 	_ := 'CastExpr ${int(d.e).str()}'
 	println('${f[0..4].bytestr()}')
+	_ := '${generic_fn<int>()}'
+	_ := '${foo.generic_method<int>()}'
 }


### PR DESCRIPTION
Fix this bug
```
┏ zakuro   ~/src/github.com/zakuro9715/v   master
┗━━⮞ cat main.v
import math

fn const_min<T>() T {
        $if T is i64 {
                return math.min_i64
        } $ else $if T is int {
                return math.min_i32
        } $else $if T is i16 {
                return math.min_i16
        } $else $if T is i8 {
                return math.min_i8
        }
        panic('invalid type')
}

println('int min is ${const_min<int>()}')
┏ zakuro   ~/src/github.com/zakuro9715/v   master
┗━━⮞ v run main.v
int min is -2147483648
┏ zakuro   ~/src/github.com/zakuro9715/v   master
┗━━⮞ v fmt main.v | v run -
int min is fn () T<int>()
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
