### PR TITLE
docs: fix typo in Array slice

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -963,7 +963,7 @@ println(nums[..4]) // [0, 10, 20, 30]
 println(nums[1..]) // [10, 20, 30, 40]
 ```
 
-In V slices are arrays themselves (they are no distinct types). As a result
+In V slices are arrays themselves (they are not distinct types). As a result
 all array operations may be performed on them. E.g. they can be pushed onto an
 array of the same type:
 


### PR DESCRIPTION
Fixed a small typo I found while reading the docs. I just discovered V a few hours ago and wanted to get my feet wet! :)