### PR TITLE
checker: fix generic array append (fix #11462)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1572,7 +1572,7 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				// []T << T or []T << []T
 				unwrapped_right_type := c.unwrap_generic(right_type)
 				if c.check_types(unwrapped_right_type, left_value_type)
-					|| c.check_types(unwrapped_right_type, left_type) {
+					|| c.check_types(unwrapped_right_type, c.unwrap_generic(left_type)) {
 					return ast.void_type
 				}
 				c.error('cannot append `$right_sym.name` to `$left_sym.name`', right_pos)

--- a/vlib/v/tests/generics_array_append_test.v
+++ b/vlib/v/tests/generics_array_append_test.v
@@ -1,0 +1,9 @@
+fn g<T>(arr []T) {
+	mut r := []T{}
+	r << arr
+	assert arr.len > 0
+}
+
+fn test_generic_array_append() {
+	g([1, 2, 3])
+}


### PR DESCRIPTION
This PR fix generic array append (fix #11462).

- Fix generic array append.
- Add test.

```vlang
fn g<T>(arr []T) {
	mut r := []T{}
	r << arr
	assert arr.len > 0
	println(r)
}

fn main() {
	g([1, 2, 3])
}

PS D:\Test\v\tt1> v run .
[1, 2, 3]
```