### PR TITLE
arrays: add chunk, window, zip functions

### DIFF
--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -4,6 +4,9 @@ module arrays
 // - min / max - return the value of the minumum / maximum
 // - idx_min / idx_max - return the index of the first minumum / maximum
 // - merge - combine two sorted arrays and maintain sorted order
+// - chunk - chunk array to arrays with n elements
+// - window - get snapshots of the window of the given size sliding along array with the given step, where each snapshot is an array
+// - zip - concat two arrays into one map
 
 // min returns the minimum
 pub fn min<T>(a []T) T {
@@ -152,8 +155,8 @@ pub fn chunk<T>(list []T, size int) [][]T {
 }
 
 pub struct WindowAttribute {
-	size	int
-	step	int = 1
+	size int
+	step int = 1
 }
 
 // get snapshots of the window of the given size sliding along array with the given step, where each snapshot is an array.
@@ -193,7 +196,7 @@ pub fn zip<K, V>(list1 []K, list2 []V) map[K]V {
 		list1.len
 	}
 
-	for i in 0..size {
+	for i in 0 .. size {
 		zipped[list1[i]] = list2[i]
 	}
 

--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -190,8 +190,6 @@ pub fn zip<K, V>(list1 []K, list2 []V) map[K]V {
 
 	size := if list1.len > list2.len {
 		list2.len
-	} else if list1.len < list2.len {
-		list1.len
 	} else {
 		list1.len
 	}

--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -180,19 +180,3 @@ pub fn window<T>(list []T, attr WindowAttribute) [][]T {
 
 	return windows
 }
-
-// concat two arrays into one map.
-// map size will be the array size with less size than another.
-// example: arrays.zip<string, int>(['V', 'Lang'], [1, 0, 2]) => {'V': 1, 'Lang': 0}
-pub fn zip<K, V>(list1 []K, list2 []V) map[K]V {
-	// allocate zip map
-	mut zipped := map[K]V{}
-
-	size := if list1.len > list2.len { list2.len } else { list1.len }
-
-	for i in 0 .. size {
-		zipped[list1[i]] = list2[i]
-	}
-
-	return zipped
-}

--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -162,10 +162,11 @@ pub struct WindowAttribute {
 // example A: arrays.window([1, 2, 3, 4], size: 2) => [[1, 2], [2, 3], [3, 4]]
 // example B: arrays.window([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], size: 3, step: 2) => [[1, 2, 3], [3, 4, 5], [5, 6, 7], [7, 8, 9]]
 pub fn window<T>(list []T, attr WindowAttribute) [][]T {
-	// allocate window array
+	// allocate snapshot array
 	mut windows := [][]T{cap: list.len - attr.size + 1}
 
 	for i := 0; true; {
+		// check remaining elements size is less than snapshot size
 		if list.len < i + attr.size {
 			break
 		}
@@ -175,4 +176,26 @@ pub fn window<T>(list []T, attr WindowAttribute) [][]T {
 	}
 
 	return windows
+}
+
+// concat two arrays into one map.
+// map size will be the array size with less size than another.
+// example: arrays.zip<string, int>(['V', 'Lang'], [1, 0, 2]) => {'V': 1, 'Lang': 0}
+pub fn zip<K, V>(list1 []K, list2 []V) map[K]V {
+	// allocate zip map
+	mut zipped := map[K]V{}
+
+	size := if list1.len > list2.len {
+		list2.len
+	} else if list1.len < list2.len {
+		list1.len
+	} else {
+		list1.len
+	}
+
+	for i in 0..size {
+		zipped[list1[i]] = list2[i]
+	}
+
+	return zipped
 }

--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -124,3 +124,55 @@ pub fn group<T>(lists ...[]T) [][]T {
 
 	return [][]T{}
 }
+
+// chunk array to arrays with n elements
+// example: arrays.chunk([1, 2, 3], 2) => [[1, 2], [3]]
+pub fn chunk<T>(list []T, size int) [][]T {
+	// allocate chunk array
+	mut chunks := [][]T{cap: list.len / size + if list.len % size == 0 { 0 } else { 1 }}
+
+	for i := 0; true; {
+		// check chunk size is greater than remaining element size
+		if list.len < i + size {
+			// check if there's no more element to chunk
+			if list.len <= i {
+				break
+			}
+
+			chunks << list[i..]
+
+			break
+		}
+
+		chunks << list[i..i + size]
+		i += size
+	}
+
+	return chunks
+}
+
+pub struct WindowAttribute {
+	size	int
+	step	int = 1
+}
+
+// get snapshots of the window of the given size sliding along array with the given step, where each snapshot is an array.
+// - `size` - snapshot size
+// - `step` - gap size between each snapshot, default is 1.
+// example A: arrays.window([1, 2, 3, 4], size: 2) => [[1, 2], [2, 3], [3, 4]]
+// example B: arrays.window([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], size: 3, step: 2) => [[1, 2, 3], [3, 4, 5], [5, 6, 7], [7, 8, 9]]
+pub fn window<T>(list []T, attr WindowAttribute) [][]T {
+	// allocate window array
+	mut windows := [][]T{cap: list.len - attr.size + 1}
+
+	for i := 0; true; {
+		if list.len < i + attr.size {
+			break
+		}
+
+		windows << list[i..i + attr.size]
+		i += attr.step
+	}
+
+	return windows
+}

--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -188,11 +188,7 @@ pub fn zip<K, V>(list1 []K, list2 []V) map[K]V {
 	// allocate zip map
 	mut zipped := map[K]V{}
 
-	size := if list1.len > list2.len {
-		list2.len
-	} else {
-		list1.len
-	}
+	size := if list1.len > list2.len { list2.len } else { list1.len }
 
 	for i in 0 .. size {
 		zipped[list1[i]] = list2[i]

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -106,24 +106,3 @@ fn test_window() {
 	assert window<int>(x, size: 3, step: 2) == [[1, 2, 3], [3, 4, 5]]
 	assert window<int>([]int{}, size: 2) == [][]int{}
 }
-
-fn test_zip() {
-	mut x := [1, 2, 3]
-	mut y := ['one', 'two', 'three']
-
-	assert zip<int, string>(x, y) == {
-		1: 'one'
-		2: 'two'
-		3: 'three'
-	}
-
-	x << [4, 5]
-	y << 'four'
-
-	assert zip<int, string>(x, y) == {
-		1: 'one'
-		2: 'two'
-		3: 'three'
-		4: 'four'
-	}
-}

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -100,7 +100,9 @@ fn test_chunk() {
 fn test_window() {
 	x := [1, 2, 3, 4, 5, 6]
 
-	assert window<int>(x, size: 3) == [[1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6]]
+	assert window<int>(x, size: 3) == [[1, 2, 3], [2, 3, 4], [3, 4, 5],
+		[4, 5, 6],
+	]
 	assert window<int>(x, size: 3, step: 2) == [[1, 2, 3], [3, 4, 5]]
 	assert window<int>([]int{}, size: 2) == [][]int{}
 }
@@ -110,8 +112,8 @@ fn test_zip() {
 	mut y := ['one', 'two', 'three']
 
 	assert zip<int, string>(x, y) == {
-		1: 'one',
-		2: 'two',
+		1: 'one'
+		2: 'two'
 		3: 'three'
 	}
 
@@ -119,9 +121,9 @@ fn test_zip() {
 	y << 'four'
 
 	assert zip<int, string>(x, y) == {
-		1: 'one',
-		2: 'two',
-		3: 'three',
+		1: 'one'
+		2: 'two'
+		3: 'three'
 		4: 'four'
 	}
 }

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -85,3 +85,43 @@ fn test_group() {
 	assert z2 == [[8, 2], [9, 1]]
 	assert group<int>(x, []int{}) == [][]int{}
 }
+
+fn test_chunk() {
+	x := [1, 2, 3, 4, 5]
+	y := ['a', 'b', 'c', 'd', 'e', 'f']
+
+	z1 := chunk<int>(x, 2)
+	assert z1 == [[1, 2], [3, 4], [5]]
+	z2 := chunk<string>(y, 3)
+	assert z2 == [['a', 'b', 'c'], ['d', 'e', 'f']]
+	assert chunk<int>([]int{}, 2) == [][]int{}
+}
+
+fn test_window() {
+	x := [1, 2, 3, 4, 5, 6]
+
+	assert window<int>(x, size: 3) == [[1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6]]
+	assert window<int>(x, size: 3, step: 2) == [[1, 2, 3], [3, 4, 5]]
+	assert window<int>([]int{}, size: 2) == [][]int{}
+}
+
+fn test_zip() {
+	mut x := [1, 2, 3]
+	mut y := ['one', 'two', 'three']
+
+	assert zip<int, string>(x, y) == {
+		1: 'one',
+		2: 'two',
+		3: 'three'
+	}
+
+	x << [4, 5]
+	y << 'four'
+
+	assert zip<int, string>(x, y) == {
+		1: 'one',
+		2: 'two',
+		3: 'three',
+		4: 'four'
+	}
+}

--- a/vlib/encoding/utf8/utf8_util.v
+++ b/vlib/encoding/utf8/utf8_util.v
@@ -73,9 +73,6 @@ pub fn get_uchar(s string, index int) int {
 }
 
 // raw_index - get the raw chracter from the string by the given index value.
-// example: '我是V Lang'.raw_index(1) => '是'
-
-// raw_index - get the raw chracter from the string by the given index value.
 // example: utf8.raw_index('我是V Lang', 1) => '是'
 pub fn raw_index(s string, index int) string {
 	mut r := []rune{}


### PR DESCRIPTION
Since arrays module does not covered most modern array operations, in this PR, I added first three functions: chunk, window, ~~and zip~~.

~~Worth to mention difference between zip and group, group returns arrays of arrays which the inner 1D array's length is not always 2, zip returns a map (for just pure zipping operation).~~

- chunk
```v
arrays.chunk<int>([1, 2, 3], 2) => [[1, 2], [3]]
```
- window
```v
arrays.window<int>([1, 2, 3, 4], size: 2) => [[1, 2], [2, 3], [3, 4]]
```
- ~~zip~~ (Removed)
```v
arrays.zip<int, int>([1, 2, 3], [4, 5, 6]) => { 1: 4, 2: 5, 3: 6}
```


