### PR TITLE
all: remove `size_t`

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -24,10 +24,6 @@ pub fn (x usize) str() string {
 	return u64(x).str()
 }
 
-pub fn (x size_t) str() string {
-	return u64(x).str()
-}
-
 pub fn (cptr &char) str() string {
 	return u64(cptr).hex()
 }

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -416,13 +416,12 @@ pub const (
 	array_type_idx         = 22
 	map_type_idx           = 23
 	chan_type_idx          = 24
-	size_t_type_idx        = 25
-	any_type_idx           = 26
-	float_literal_type_idx = 27
-	int_literal_type_idx   = 28
-	thread_type_idx        = 29
-	error_type_idx         = 30
-	u8_type_idx            = 31
+	any_type_idx           = 25
+	float_literal_type_idx = 26
+	int_literal_type_idx   = 27
+	thread_type_idx        = 28
+	error_type_idx         = 29
+	u8_type_idx            = 30
 )
 
 pub const (
@@ -493,9 +492,7 @@ pub const (
 	// must be in the same order as the idx consts above
 	builtin_type_names = ['void', 'voidptr', 'byteptr', 'charptr', 'i8', 'i16', 'int', 'i64', 'isize',
 		'byte', 'u16', 'u32', 'u64', 'usize', 'f32', 'f64', 'char', 'bool', 'none', 'string', 'rune',
-		'array', 'map', 'chan', 'size_t', 'any', 'float_literal', 'int_literal', 'thread', 'Error',
-		'u8',
-	]
+		'array', 'map', 'chan', 'any', 'float_literal', 'int_literal', 'thread', 'Error', 'u8']
 )
 
 pub struct MultiReturn {
@@ -538,7 +535,6 @@ pub enum Kind {
 	f32
 	f64
 	char
-	size_t
 	rune
 	bool
 	none_
@@ -680,7 +676,6 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 	t.register_type_symbol(kind: .array, name: 'array', cname: 'array', mod: 'builtin')
 	t.register_type_symbol(kind: .map, name: 'map', cname: 'map', mod: 'builtin')
 	t.register_type_symbol(kind: .chan, name: 'chan', cname: 'chan', mod: 'builtin')
-	t.register_type_symbol(kind: .size_t, name: 'size_t', cname: 'size_t', mod: 'builtin')
 	t.register_type_symbol(kind: .any, name: 'any', cname: 'any', mod: 'builtin')
 	t.register_type_symbol(
 		kind: .float_literal
@@ -775,7 +770,6 @@ pub fn (k Kind) str() string {
 		.string { 'string' }
 		.char { 'char' }
 		.bool { 'bool' }
-		.size_t { 'size_t' }
 		.none_ { 'none' }
 		.array { 'array' }
 		.array_fixed { 'array_fixed' }
@@ -1095,7 +1089,7 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 				res = 'thread ' + t.type_to_str_using_aliases(rtype, import_aliases)
 			}
 		}
-		.alias, .any, .size_t, .aggregate, .placeholder, .enum_ {
+		.alias, .any, .aggregate, .placeholder, .enum_ {
 			res = t.shorten_user_defined_typenames(res, import_aliases)
 		}
 	}

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -19,14 +19,6 @@ pub fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type,
 		if got.is_number() && expected.is_number() {
 			return
 		}
-		// mode_t - currently using u32 as mode_t for C fns
-		// if got.idx() in [ast.int_type_idx, ast.u32_type_idx] && expected.idx() in [ast.int_type_idx, ast.u32_type_idx] {
-		// 	return
-		// }
-		// allow number to be used as size_t
-		if got.is_number() && expected.idx() == ast.size_t_type_idx {
-			return
-		}
 		// allow bool & int to be used interchangeably for C functions
 		if (got.idx() == ast.bool_type_idx
 			&& expected.idx() in [ast.int_type_idx, ast.int_literal_type_idx])

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2572,7 +2572,7 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 					'\ne.g. `users.sort(a.id < b.id)`', node.pos)
 			}
 		} else if !(c.table.get_type_symbol(elem_typ).has_method('<')
-			|| c.table.unalias_num_type(elem_typ) in [ast.int_type, ast.int_type.to_ptr(), ast.string_type, ast.string_type.to_ptr(), ast.i8_type, ast.i16_type, ast.i64_type, ast.byte_type, ast.rune_type, ast.u16_type, ast.u32_type, ast.u64_type, ast.f32_type, ast.f64_type, ast.char_type, ast.bool_type, ast.float_literal_type, ast.int_literal_type, ast.size_t_type_idx]) {
+			|| c.table.unalias_num_type(elem_typ) in [ast.int_type, ast.int_type.to_ptr(), ast.string_type, ast.string_type.to_ptr(), ast.i8_type, ast.i16_type, ast.i64_type, ast.byte_type, ast.rune_type, ast.u16_type, ast.u32_type, ast.u64_type, ast.f32_type, ast.f64_type, ast.char_type, ast.bool_type, ast.float_literal_type, ast.int_literal_type]) {
 			c.error('custom sorting condition must be supplied for type `${c.table.type_to_str(elem_typ)}`',
 				node.pos)
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6155,7 +6155,7 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 				for field in info.fields {
 					field_sym := g.table.get_type_symbol(field.typ)
 					if field.has_default_expr
-						|| field_sym.kind in [.array, .map, .string, .bool, .alias, .size_t, .i8, .i16, .int, .i64, .byte, .u16, .u32, .u64, .char, .voidptr, .byteptr, .charptr, .struct_] {
+						|| field_sym.kind in [.array, .map, .string, .bool, .alias, .i8, .i16, .int, .i64, .byte, .u16, .u32, .u64, .char, .voidptr, .byteptr, .charptr, .struct_] {
 						field_name := c_name(field.name)
 						if field.has_default_expr {
 							expr_str := g.expr_string(field.default_expr)
@@ -6837,8 +6837,7 @@ pub fn (mut g Gen) contains_ptr(el_typ ast.Type) bool {
 		return true
 	}
 	match sym.kind {
-		.i8, .i16, .int, .i64, .byte, .u16, .u32, .u64, .f32, .f64, .char, .size_t, .rune, .bool,
-		.enum_ {
+		.i8, .i16, .int, .i64, .byte, .u16, .u32, .u64, .f32, .f64, .char, .rune, .bool, .enum_ {
 			return false
 		}
 		.array_fixed {

--- a/vlib/v/gen/js/builtin_types.v
+++ b/vlib/v/gen/js/builtin_types.v
@@ -20,7 +20,7 @@ fn (mut g JsGen) to_js_typ_val(t ast.Type) string {
 	mut prefix := 'new '
 	match sym.kind {
 		.i8, .i16, .int, .i64, .byte, .u8, .u16, .u32, .u64, .f32, .f64, .int_literal,
-		.float_literal, .size_t {
+		.float_literal {
 			styp = '$prefix${g.sym_to_js_typ(sym)}(0)'
 		}
 		.bool {
@@ -88,9 +88,6 @@ fn (mut g JsGen) sym_to_js_typ(sym ast.TypeSymbol) string {
 		.float_literal {
 			styp = 'float_literal'
 		}
-		.size_t {
-			styp = 'size_t'
-		}
 		.bool {
 			styp = 'bool'
 		}
@@ -147,7 +144,7 @@ pub fn (mut g JsGen) doc_typ(t ast.Type) string {
 			styp = '${g.sym_to_js_typ(sym)}'
 		}
 		.i8, .i16, .int, .i64, .isize, .byte, .u8, .u16, .u32, .u64, .usize, .f32, .f64,
-		.int_literal, .float_literal, .size_t {
+		.int_literal, .float_literal {
 			styp = '${g.sym_to_js_typ(sym)}'
 		}
 		.bool {
@@ -315,7 +312,7 @@ fn (mut g JsGen) gen_builtin_type_defs() {
 	for typ_name in v_types {
 		// TODO: JsDoc
 		match typ_name {
-			'i8', 'i16', 'int', 'u16', 'u32', 'int_literal', 'size_t' {
+			'i8', 'i16', 'int', 'u16', 'u32', 'int_literal' {
 				// TODO: Bounds checking
 				g.gen_builtin_prototype(
 					typ_name: typ_name

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -25,9 +25,9 @@ const (
 		'Array', 'Map']
 	// used to generate type structs
 	v_types            = ['i8', 'i16', 'int', 'i64', 'byte', 'u16', 'u32', 'u64', 'f32', 'f64',
-		'int_literal', 'float_literal', 'size_t', 'bool', 'string', 'map', 'array', 'any']
+		'int_literal', 'float_literal', 'bool', 'string', 'map', 'array', 'any']
 	shallow_equatables = [ast.Kind.i8, .i16, .int, .i64, .byte, .u16, .u32, .u64, .f32, .f64,
-		.int_literal, .float_literal, .size_t, .bool, .string]
+		.int_literal, .float_literal, .bool, .string]
 )
 
 struct SourcemapHelper {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -498,13 +498,6 @@ pub fn (mut p Parser) find_type_or_add_placeholder(name string, language ast.Lan
 	// struct / enum / placeholder
 	mut idx := p.table.find_type_idx(name)
 	if idx > 0 {
-		if !p.builtin_mod && idx == ast.size_t_type_idx {
-			// don't warn in builtin, there is still the `.str` method
-			if !p.pref.is_fmt {
-				p.warn_with_pos('`size_t` is deprecated, use `usize` instead', p.prev_tok.position())
-			}
-			return ast.new_type(ast.usize_type_idx)
-		}
 		return ast.new_type(idx)
 	}
 	// not found - add placeholder


### PR DESCRIPTION
Remove all references to former type `size_t`.
I don't know when this should be merged. It's probably better to keep some time after `size_t` deprecation, which happened on September, the 8th (see #11443).
I keep it as draft for now, and let the maintainers decide when the right time has come.