### PR TITLE
all: implement if foo in [Foo1, Foo2, Foo3]

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -138,7 +138,7 @@ pub fn (mut c Checker) check(ast_file &ast.File) {
 		}
 	}
 	for mut stmt in ast_file.stmts {
-		if stmt in [ast.ConstDecl, ast.ExprStmt] {
+		if stmt is ast.ConstDecl || stmt is ast.ExprStmt {
 			c.expr_level = 0
 			c.stmt(stmt)
 		}
@@ -1358,7 +1358,6 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				.array {
 					if left_sym.kind !in [.sum_type, .interface_] {
 						elem_type := right_final.array_info().elem_type
-						// if left_default.kind != right_sym.kind {
 						c.check_expected(left_type, elem_type) or {
 							c.error('left operand to `$node.op` does not match the array element type: $err.msg',
 								left_right_pos)
@@ -1962,7 +1961,8 @@ pub fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 			if arg.typ != ast.string_type {
 				continue
 			}
-			if arg.expr in [ast.Ident, ast.StringLiteral, ast.SelectorExpr] {
+			if arg.expr is ast.Ident || arg.expr is ast.StringLiteral
+				|| arg.expr is ast.SelectorExpr {
 				// Simple expressions like variables, string literals, selector expressions
 				// (`x.field`) can't result in allocations and don't need to be assigned to
 				// temporary vars.
@@ -1972,8 +1972,8 @@ pub fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 			node.args[i].is_tmp_autofree = true
 		}
 		// TODO copy pasta from above
-		if node.receiver_type == ast.string_type
-			&& node.left !in [ast.Ident, ast.StringLiteral, ast.SelectorExpr] {
+		if node.receiver_type == ast.string_type && !(node.left is ast.Ident
+			|| node.left is ast.StringLiteral || node.left is ast.SelectorExpr) {
 			node.free_receiver = true
 		}
 	}
@@ -4921,7 +4921,8 @@ fn (mut c Checker) for_stmt(mut node ast.ForStmt) {
 	if node.cond is ast.InfixExpr {
 		infix := node.cond
 		if infix.op == .key_is {
-			if infix.left in [ast.Ident, ast.SelectorExpr] && infix.right is ast.TypeNode {
+			if (infix.left is ast.Ident || infix.left is ast.SelectorExpr)
+				&& infix.right is ast.TypeNode {
 				is_variable := if mut infix.left is ast.Ident {
 					infix.left.kind == .variable
 				} else {
@@ -6674,7 +6675,8 @@ fn (mut c Checker) smartcast_if_conds(node ast.Expr, mut scope ast.Scope) {
 					expr_str := c.table.type_to_str(expr_type)
 					c.error('cannot use type `$expect_str` as type `$expr_str`', node.pos)
 				}
-				if node.left in [ast.Ident, ast.SelectorExpr] && node.right is ast.TypeNode {
+				if (node.left is ast.Ident || node.left is ast.SelectorExpr)
+					&& node.right is ast.TypeNode {
 					is_variable := if mut node.left is ast.Ident {
 						node.left.kind == .variable
 					} else {
@@ -6959,7 +6961,7 @@ fn (mut c Checker) comp_if_branch(cond ast.Expr, pos token.Position) bool {
 							// c.error('`$sym.name` is not an interface', cond.right.position())
 						}
 						return false
-					} else if cond.left in [ast.SelectorExpr, ast.TypeNode] {
+					} else if cond.left is ast.SelectorExpr || cond.left is ast.TypeNode {
 						// `$if method.@type is string`
 						c.expr(cond.left)
 						return false
@@ -7123,7 +7125,7 @@ fn (c &Checker) has_return(stmts []ast.Stmt) ?bool {
 	mut has_complexity := false
 	for s in stmts {
 		if s is ast.ExprStmt {
-			if s.expr in [ast.IfExpr, ast.MatchExpr] {
+			if s.expr is ast.IfExpr || s.expr is ast.MatchExpr {
 				has_complexity = true
 				break
 			}

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -472,7 +472,15 @@ fn (mut p Parser) infix_expr(left ast.Expr) ast.Expr {
 	if op in [.key_is, .not_is] {
 		p.expecting_type = true
 	}
+	is_key_in := op in [.key_in, .not_in]
+	if is_key_in {
+		p.inside_in_array = true
+	}
 	right = p.expr(precedence)
+	if is_key_in {
+		p.inside_in_array = false
+	}
+
 	p.expecting_type = prev_expecting_type
 	if p.pref.is_vet && op in [.key_in, .not_in] && right is ast.ArrayInit
 		&& (right as ast.ArrayInit).exprs.len == 1 {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -44,6 +44,7 @@ mut:
 	inside_unsafe_fn    bool
 	inside_str_interp   bool
 	inside_array_lit    bool
+	inside_in_array     bool
 	or_is_handled       bool       // ignore `or` in this expression
 	builtin_mod         bool       // are we in the `builtin` module?
 	mod                 string     // current module name
@@ -2232,6 +2233,18 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 		// JS. function call with more than 1 dot
 		node = p.call_expr(language, mod)
 	} else {
+		if p.inside_in_array && ((lit0_is_capital && !known_var && language == .v)
+			|| (p.peek_tok.kind == .dot && p.peek_token(2).lit.len > 0
+			&& p.peek_token(2).lit[0].is_capital())
+			|| p.table.find_type_idx(p.mod + '.' + p.tok.lit) > 0) {
+			type_pos := p.tok.position()
+			typ := p.parse_type()
+			return ast.TypeNode{
+				typ: typ
+				pos: type_pos
+			}
+		}
+		
 		ident := p.parse_ident(language)
 		node = ident
 		if p.inside_defer {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2244,7 +2244,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 				pos: type_pos
 			}
 		}
-		
+
 		ident := p.parse_ident(language)
 		node = ident
 		if p.inside_defer {

--- a/vlib/v/tests/in_expression_test.v
+++ b/vlib/v/tests/in_expression_test.v
@@ -264,3 +264,20 @@ fn test_in_expression_numeric() {
 	assert 1.0625 in f2
 	assert 3.5 !in f2
 }
+
+struct Foo1 {}
+
+struct Foo2 {}
+
+struct Foo3 {}
+
+type Foo = Foo1 | Foo2 | Foo3
+
+fn test_in_sumtype_array() {
+	foo := Foo(Foo3{})
+
+	if foo in [Foo1, Foo3] {
+		println(foo)
+		assert true
+	}
+}


### PR DESCRIPTION
This PR implement if foo in [Foo1, Foo2, Foo3].

- Implement in/!in array of sumtype or interface.
- Modify the related calls in checker.v.

```vlang
struct Foo1 {}

struct Foo2 {}

struct Foo3 {}

type Foo = Foo1 | Foo2 | Foo3

fn main() {
	foo := Foo(Foo3{})

	if foo in [Foo1, Foo3] {
		println(foo)
		assert true
	}
}

PS D:\Test\v\tt1> v run .
Foo(Foo3{})
```