### PR TITLE
checker, cgen: fix generic operator overload of 'cmp' operation

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1527,6 +1527,9 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		.gt, .lt, .ge, .le {
 			if left_sym.kind in [.array, .array_fixed] && right_sym.kind in [.array, .array_fixed] {
 				c.error('only `==` and `!=` are defined on arrays', node.pos)
+			} else if left_sym.kind == .struct_
+				&& (left_sym.info as ast.Struct).generic_types.len > 0 {
+				return ast.bool_type
 			} else if left_sym.kind == .struct_ && right_sym.kind == .struct_
 				&& node.op in [.eq, .lt] {
 				if !(left_sym.has_method(node.op.str()) && right_sym.has_method(node.op.str())) {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4288,6 +4288,9 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				.mult_assign { '*' }
 				else { 'unknown op' }
 			}
+			if left_sym.kind == .struct_ && (left_sym.info as ast.Struct).generic_types.len > 0 {
+				continue
+			}
 			if method := left_sym.find_method(extracted_op) {
 				if method.return_type != left_type {
 					c.error('operator `$extracted_op` must return `$left_name` to be used as an assignment operator',

--- a/vlib/v/gen/c/infix_expr.v
+++ b/vlib/v/gen/c/infix_expr.v
@@ -267,15 +267,30 @@ fn (mut g Gen) infix_expr_cmp_op(node ast.InfixExpr) {
 	right := g.unwrap(node.right_type)
 	has_operator_overloading := g.table.type_has_method(left.sym, '<')
 	if left.sym.kind == .struct_ && (left.sym.info as ast.Struct).generic_types.len > 0 {
+		if node.op in [.le, .ge] {
+			g.write('!')
+		}
 		concrete_types := (left.sym.info as ast.Struct).concrete_types
-		mut method_name := left.sym.cname + '_' + util.replace_op(node.op.str())
+		mut method_name := left.sym.cname + '__lt'
 		method_name = g.generic_fn_name(concrete_types, method_name, true)
 		g.write(method_name)
-		g.write('(')
-		g.expr(node.left)
-		g.write(', ')
-		g.expr(node.right)
-		g.write(')')
+		if node.op in [.lt, .ge] {
+			g.write('(')
+			g.write('*'.repeat(left.typ.nr_muls()))
+			g.expr(node.left)
+			g.write(', ')
+			g.write('*'.repeat(right.typ.nr_muls()))
+			g.expr(node.right)
+			g.write(')')
+		} else {
+			g.write('(')
+			g.write('*'.repeat(right.typ.nr_muls()))
+			g.expr(node.right)
+			g.write(', ')
+			g.write('*'.repeat(left.typ.nr_muls()))
+			g.expr(node.left)
+			g.write(')')
+		}
 	} else if left.sym.kind == right.sym.kind && has_operator_overloading {
 		if node.op in [.le, .ge] {
 			g.write('!')

--- a/vlib/v/gen/c/infix_expr.v
+++ b/vlib/v/gen/c/infix_expr.v
@@ -266,7 +266,17 @@ fn (mut g Gen) infix_expr_cmp_op(node ast.InfixExpr) {
 	left := g.unwrap(node.left_type)
 	right := g.unwrap(node.right_type)
 	has_operator_overloading := g.table.type_has_method(left.sym, '<')
-	if left.sym.kind == right.sym.kind && has_operator_overloading {
+	if left.sym.kind == .struct_ && (left.sym.info as ast.Struct).generic_types.len > 0 {
+		concrete_types := (left.sym.info as ast.Struct).concrete_types
+		mut method_name := left.sym.cname + '_' + util.replace_op(node.op.str())
+		method_name = g.generic_fn_name(concrete_types, method_name, true)
+		g.write(method_name)
+		g.write('(')
+		g.expr(node.left)
+		g.write(', ')
+		g.expr(node.right)
+		g.write(')')
+	} else if left.sym.kind == right.sym.kind && has_operator_overloading {
 		if node.op in [.le, .ge] {
 			g.write('!')
 		}

--- a/vlib/v/tests/generic_operator_overload_test.v
+++ b/vlib/v/tests/generic_operator_overload_test.v
@@ -26,10 +26,33 @@ fn (m1 Matrix<T>) + (m2 Matrix<T>) Matrix<T> {
 	return res
 }
 
+fn (m1 Matrix<T>) == (m2 Matrix<T>) bool {
+	return m1.row == m2.row && m1.col == m2.col && m1.data == m2.data
+}
+
+fn (m1 Matrix<T>) < (m2 Matrix<T>) bool {
+	return m1.row < m2.row && m1.col < m2.col
+}
+
 fn test_generic_operator_overload() {
-	result := from_array([[1, 2, 3], [4, 5, 6]]) + from_array([[7, 8, 9], [10, 11, 12]])
-	println(result)
-	assert result.row == 2
-	assert result.col == 3
-	assert result.data == [[8, 10, 12], [14, 16, 18]]
+	a1 := from_array([[1, 2, 3], [4, 5, 6]])
+	a2 := from_array([[7, 8, 9], [10, 11, 12]])
+
+	plus_ret := a1 + a2
+	println(plus_ret)
+	assert plus_ret.row == 2
+	assert plus_ret.col == 3
+	assert plus_ret.data == [[8, 10, 12], [14, 16, 18]]
+
+	eq_ret := a1 == a2
+	println(eq_ret)
+	assert !eq_ret
+
+	ne_ret := a1 != a2
+	println(ne_ret)
+	assert ne_ret
+
+	lt_ret := a1 < a2
+	println(lt_ret)
+	assert !lt_ret
 }

--- a/vlib/v/tests/generic_operator_overload_test.v
+++ b/vlib/v/tests/generic_operator_overload_test.v
@@ -35,7 +35,7 @@ fn (m1 Matrix<T>) < (m2 Matrix<T>) bool {
 }
 
 fn test_generic_operator_overload() {
-	a1 := from_array([[1, 2, 3], [4, 5, 6]])
+	mut a1 := from_array([[1, 2, 3], [4, 5, 6]])
 	a2 := from_array([[7, 8, 9], [10, 11, 12]])
 
 	plus_ret := a1 + a2
@@ -43,6 +43,12 @@ fn test_generic_operator_overload() {
 	assert plus_ret.row == 2
 	assert plus_ret.col == 3
 	assert plus_ret.data == [[8, 10, 12], [14, 16, 18]]
+
+	a1 += a2
+	println(a1)
+	assert a1.row == 2
+	assert a1.col == 3
+	assert a1.data == [[15, 18, 21], [24, 27, 30]]
 
 	eq_ret := a1 == a2
 	println(eq_ret)

--- a/vlib/v/tests/generic_operator_overload_test.v
+++ b/vlib/v/tests/generic_operator_overload_test.v
@@ -55,4 +55,16 @@ fn test_generic_operator_overload() {
 	lt_ret := a1 < a2
 	println(lt_ret)
 	assert !lt_ret
+
+	le_ret := a1 <= a2
+	println(le_ret)
+	assert le_ret
+
+	gt_ret := a1 > a2
+	println(gt_ret)
+	assert !gt_ret
+
+	ge_ret := a1 >= a2
+	println(ge_ret)
+	assert ge_ret
 }


### PR DESCRIPTION
This PR fix generic operator overload of 'cmp' operation.

- Fix operator overload of 'cmp' operation.
- Add test.

```vlang
struct Matrix<T> {
	row int
	col int
mut:
	data [][]T
}

fn from_array<T>(arr [][]T) Matrix<T> {
	return Matrix<T>{
		row: arr.len
		col: arr[0].len
		data: arr.clone()
	}
}

fn (m1 Matrix<T>) + (m2 Matrix<T>) Matrix<T> {
	if m1.row != m2.row || m1.col != m2.col {
		panic('Addition can only be performed on matrix with same size')
	}
	mut res := m1
	for i in 0 .. m2.row {
		for j in 0 .. m2.col {
			res.data[i][j] += m2.data[i][j]
		}
	}
	return res
}

fn (m1 Matrix<T>) == (m2 Matrix<T>) bool {
	return m1.row == m2.row && m1.col == m2.col && m1.data == m2.data
}

fn (m1 Matrix<T>) < (m2 Matrix<T>) bool {
	return m1.row < m2.row && m1.col < m2.col
}

fn main() {
	mut a1 := from_array([[1, 2, 3], [4, 5, 6]])
	a2 := from_array([[7, 8, 9], [10, 11, 12]])

	plus_ret := a1 + a2
	println(plus_ret)
	assert plus_ret.row == 2
	assert plus_ret.col == 3
	assert plus_ret.data == [[8, 10, 12], [14, 16, 18]]

	a1 += a2
	println(a1)
	assert a1.row == 2
	assert a1.col == 3
	assert a1.data == [[15, 18, 21], [24, 27, 30]]

	eq_ret := a1 == a2
	println(eq_ret)
	assert !eq_ret

	ne_ret := a1 != a2
	println(ne_ret)
	assert ne_ret

	lt_ret := a1 < a2
	println(lt_ret)
	assert !lt_ret

	le_ret := a1 <= a2
	println(le_ret)
	assert le_ret

	gt_ret := a1 > a2
	println(gt_ret)
	assert !gt_ret

	ge_ret := a1 >= a2
	println(ge_ret)
	assert ge_ret
}

PS D:\Test\v\tt1> v run .
Matrix<int>{
    row: 2
    col: 3
    data: [[8, 10, 12], [14, 16, 18]]
}
Matrix<int>{
    row: 2
    col: 3
    data: [[15, 18, 21], [24, 27, 30]]
}
false
true
false
true
false
true
```