### PR TITLE
arrays: switch panics to optionals

### DIFF
--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -8,10 +8,10 @@ module arrays
 // - window - get snapshots of the window of the given size sliding along array with the given step, where each snapshot is an array
 // - zip - concat two arrays into one map
 
-// min returns the minimum
-pub fn min<T>(a []T) T {
+// min returns the minimum value in the array
+pub fn min<T>(a []T) ?T {
 	if a.len == 0 {
-		panic('.min called on an empty array')
+		return error('.min called on an empty array')
 	}
 	mut val := a[0]
 	for e in a {
@@ -22,10 +22,10 @@ pub fn min<T>(a []T) T {
 	return val
 }
 
-// max returns the maximum
-pub fn max<T>(a []T) T {
+// max returns the maximum the maximum value in the array
+pub fn max<T>(a []T) ?T {
 	if a.len == 0 {
-		panic('.max called on an empty array')
+		return error('.max called on an empty array')
 	}
 	mut val := a[0]
 	for e in a {
@@ -36,10 +36,10 @@ pub fn max<T>(a []T) T {
 	return val
 }
 
-// idx_min returns the index of the first minimum
-pub fn idx_min<T>(a []T) int {
+// idx_min returns the index of the minimum value in the array
+pub fn idx_min<T>(a []T) ?int {
 	if a.len == 0 {
-		panic('.idx_min called on an empty array')
+		return error('.idx_min called on an empty array')
 	}
 	mut idx := 0
 	mut val := a[0]
@@ -52,10 +52,10 @@ pub fn idx_min<T>(a []T) int {
 	return idx
 }
 
-// idx_max returns the index of the first maximum
-pub fn idx_max<T>(a []T) int {
+// idx_max returns the index of the maximum value in the array
+pub fn idx_max<T>(a []T) ?int {
 	if a.len == 0 {
-		panic('.idx_max called on an empty array')
+		return error('.idx_max called on an empty array')
 	}
 	mut idx := 0
 	mut val := a[0]

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -1,45 +1,63 @@
 module arrays
 
-fn test_min() {
+fn test_min()? {
 	a := [8, 2, 6, 4]
-	assert min<int>(a) == 2
-	assert min<int>(a[2..]) == 4
+	mut ri := min(a)?
+	assert ri == 2
+	ri = min(a[2..])?
+	assert ri == 4
 	b := [f32(5.1), 3.1, 1.1, 9.1]
-	assert min<f32>(b) == f32(1.1)
-	assert min<f32>(b[..2]) == f32(3.1)
+	mut rf := min(b)?
+	assert rf == f32(1.1)
+	rf = min(b[..2])?
+	assert rf == f32(3.1)
 	c := [byte(4), 9, 3, 1]
-	assert min<byte>(c) == byte(1)
-	assert min<byte>(c[..3]) == byte(3)
+	mut rb := min(c)?
+	assert rb == byte(1)
+	rb = min(c[..3])?
+	assert rb == byte(3)
 }
 
-fn test_max() {
+fn test_max()? {
 	a := [8, 2, 6, 4]
-	assert max<int>(a) == 8
-	assert max<int>(a[1..]) == 6
+	mut ri := max(a)?
+	assert ri == 8
+	ri = max(a[1..])?
+	assert ri == 6
 	b := [f32(5.1), 3.1, 1.1, 9.1]
-	assert max<f32>(b) == f32(9.1)
-	assert max<f32>(b[..3]) == f32(5.1)
+	mut rf := max(b)?
+	assert rf == f32(9.1)
+	rf = max(b[..3])?
+	assert rf == f32(5.1)
 	c := [byte(4), 9, 3, 1]
-	assert max<byte>(c) == byte(9)
-	assert max<byte>(c[2..]) == byte(3)
+	mut rb := max(c)?
+	assert rb == byte(9)
+	rb = max(c[2..])?
+	assert rb == byte(3)
 }
 
-fn test_idx_min() {
+fn test_idx_min()? {
 	a := [8, 2, 6, 4]
-	assert idx_min<int>(a) == 1
+	ri := idx_min(a)?
+	assert ri == 1
 	b := [f32(5.1), 3.1, 1.1, 9.1]
-	assert idx_min<f32>(b) == 2
+	rf := idx_min(b)?
+	assert rf == 2
 	c := [byte(4), 9, 3, 1]
-	assert idx_min<byte>(c) == 3
+	rb := idx_min(c)?
+	assert rb == 3
 }
 
-fn test_idx_max() {
+fn test_idx_max()? {
 	a := [8, 2, 6, 4]
-	assert idx_max<int>(a) == 0
+	ri := idx_max(a)?
+	assert ri == 0
 	b := [f32(5.1), 3.1, 1.1, 9.1]
-	assert idx_max<f32>(b) == 3
+	rf := idx_max(b)?
+	assert rf == 3
 	c := [byte(4), 9, 3, 1]
-	assert idx_max<byte>(c) == 1
+	rb := idx_max(c)?
+	assert rb == 1
 }
 
 fn test_merge() {

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -1,62 +1,62 @@
 module arrays
 
-fn test_min()? {
+fn test_min() ? {
 	a := [8, 2, 6, 4]
-	mut ri := min(a)?
+	mut ri := min(a) ?
 	assert ri == 2
-	ri = min(a[2..])?
+	ri = min(a[2..]) ?
 	assert ri == 4
 	b := [f32(5.1), 3.1, 1.1, 9.1]
-	mut rf := min(b)?
+	mut rf := min(b) ?
 	assert rf == f32(1.1)
-	rf = min(b[..2])?
+	rf = min(b[..2]) ?
 	assert rf == f32(3.1)
 	c := [byte(4), 9, 3, 1]
-	mut rb := min(c)?
+	mut rb := min(c) ?
 	assert rb == byte(1)
-	rb = min(c[..3])?
+	rb = min(c[..3]) ?
 	assert rb == byte(3)
 }
 
-fn test_max()? {
+fn test_max() ? {
 	a := [8, 2, 6, 4]
-	mut ri := max(a)?
+	mut ri := max(a) ?
 	assert ri == 8
-	ri = max(a[1..])?
+	ri = max(a[1..]) ?
 	assert ri == 6
 	b := [f32(5.1), 3.1, 1.1, 9.1]
-	mut rf := max(b)?
+	mut rf := max(b) ?
 	assert rf == f32(9.1)
-	rf = max(b[..3])?
+	rf = max(b[..3]) ?
 	assert rf == f32(5.1)
 	c := [byte(4), 9, 3, 1]
-	mut rb := max(c)?
+	mut rb := max(c) ?
 	assert rb == byte(9)
-	rb = max(c[2..])?
+	rb = max(c[2..]) ?
 	assert rb == byte(3)
 }
 
-fn test_idx_min()? {
+fn test_idx_min() ? {
 	a := [8, 2, 6, 4]
-	ri := idx_min(a)?
+	ri := idx_min(a) ?
 	assert ri == 1
 	b := [f32(5.1), 3.1, 1.1, 9.1]
-	rf := idx_min(b)?
+	rf := idx_min(b) ?
 	assert rf == 2
 	c := [byte(4), 9, 3, 1]
-	rb := idx_min(c)?
+	rb := idx_min(c) ?
 	assert rb == 3
 }
 
-fn test_idx_max()? {
+fn test_idx_max() ? {
 	a := [8, 2, 6, 4]
-	ri := idx_max(a)?
+	ri := idx_max(a) ?
 	assert ri == 0
 	b := [f32(5.1), 3.1, 1.1, 9.1]
-	rf := idx_max(b)?
+	rf := idx_max(b) ?
 	assert rf == 3
 	c := [byte(4), 9, 3, 1]
-	rb := idx_max(c)?
+	rb := idx_max(c) ?
 	assert rb == 1
 }
 


### PR DESCRIPTION
As the title says, this changes some routines from doing panics to returning optionals.
Tests changed to match.