### PR TITLE
checker, cgen: fix generic arrays sum() with operator overload (fix #11493)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4275,9 +4275,9 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		if node.op in [.plus_assign, .minus_assign, .mod_assign, .mult_assign, .div_assign]
 			&& ((left_sym.kind == .struct_ && right_sym.kind == .struct_)
 			|| left_sym.kind == .alias) {
-			left_name := c.table.type_to_str(left_type)
-			right_name := c.table.type_to_str(right_type)
-			parent_sym := c.table.get_final_type_symbol(left_type)
+			left_name := c.table.type_to_str(left_type_unwrapped)
+			right_name := c.table.type_to_str(right_type_unwrapped)
+			parent_sym := c.table.get_final_type_symbol(left_type_unwrapped)
 			if left_sym.kind == .alias && right_sym.kind != .alias {
 				c.error('mismatched types `$left_name` and `$right_name`', node.pos)
 			}
@@ -4293,7 +4293,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				continue
 			}
 			if method := left_sym.find_method(extracted_op) {
-				if method.return_type != left_type {
+				if method.return_type != left_type_unwrapped {
 					c.error('operator `$extracted_op` must return `$left_name` to be used as an assignment operator',
 						node.pos)
 				}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2647,7 +2647,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 		mut ident := ast.Ident{
 			scope: 0
 		}
-		left_sym := g.table.get_type_symbol(var_type)
+		left_sym := g.table.get_type_symbol(g.unwrap_generic(var_type))
 		if left is ast.Ident {
 			ident = left
 			// id_info := ident.var_info()

--- a/vlib/v/tests/generic_arrays_sum_test.v
+++ b/vlib/v/tests/generic_arrays_sum_test.v
@@ -1,0 +1,23 @@
+import arrays
+
+struct Point {
+pub mut:
+	x int
+	y int
+}
+
+fn (p1 Point) + (p2 Point) Point {
+	return Point{
+		x: p1.x + p2.x
+		y: p1.y + p2.y
+	}
+}
+
+fn test_generic_arrays_sum() {
+	ret := arrays.sum<Point>([Point{ x: 1, y: 1 }, Point{
+		x: 2
+		y: 2
+	}]) or { Point{} }
+	println(ret)
+	assert ret == Point{3, 3}
+}


### PR DESCRIPTION
This PR fix generic arrays sum() (fix #11493).

- Fix generic arrays sum() with operator overload.
- Add test.

```vlang
import arrays

struct Point {
pub mut:
	x int
	y int
}

fn (p1 Point) + (p2 Point) Point {
	return Point{
		x: p1.x + p2.x
		y: p1.y + p2.y
	}
}

fn main() {
	ret := arrays.sum<Point>([Point{ x: 1, y: 1 }, Point{
		x: 2
		y: 2
	}]) or { Point{} }
	println(ret)
	assert ret == Point{3, 3}
}

PS D:\Test\v\tt1> v run .
Point{
    x: 3
    y: 3
}
```