### PR TITLE
net.urllib: make unescape() autofree compatible

### DIFF
--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -212,7 +212,7 @@ fn unescape(s_ string, mode EncodingMode) ?string {
 		}
 	}
 	if n == 0 && !has_plus {
-		return '$s'
+		return '$s' // TODO `return s` once an autofree bug is fixed
 	}
 	if s.len < 2 * n {
 		return error(error_msg('unescape: invalid escape sequence', ''))

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -212,7 +212,7 @@ fn unescape(s_ string, mode EncodingMode) ?string {
 		}
 	}
 	if n == 0 && !has_plus {
-		return s
+		return '$s'
 	}
 	if s.len < 2 * n {
 		return error(error_msg('unescape: invalid escape sequence', ''))


### PR DESCRIPTION
Fixes #11504.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
