### PR TITLE
scanner, fmt: fix multi-level generics

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -148,11 +148,7 @@ fn stringify_fn_after_name(node &FnDecl, mut f strings.Builder, t &Table, cur_mo
 			if node.is_variadic && is_last_arg {
 				f.write_string('...')
 			}
-			if s[s.len - 1] == `>` {
-				f.write_string(s.split('<').map(it.after('.')).join('<'))
-			} else {
-				f.write_string(s)
-			}
+			f.write_string(s)
 		}
 		if !is_last_arg {
 			f.write_string(', ')

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -149,8 +149,7 @@ fn stringify_fn_after_name(node &FnDecl, mut f strings.Builder, t &Table, cur_mo
 				f.write_string('...')
 			}
 			if s[s.len - 1] == `>` {
-				short_module_s := s.split('<').map(it.after('.')).join('<')
-				f.write_string(short_module_s)
+				f.write_string(s.split('<').map(it.after('.')).join('<'))
 			} else {
 				f.write_string(s)
 			}

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -148,7 +148,12 @@ fn stringify_fn_after_name(node &FnDecl, mut f strings.Builder, t &Table, cur_mo
 			if node.is_variadic && is_last_arg {
 				f.write_string('...')
 			}
-			f.write_string(s)
+			if s[s.len - 1] == `>` {
+				short_module_s := s.trim_suffix('>').split('<').map(it.after('.')).join('<') + '>'
+				f.write_string(short_module_s)
+			} else {
+				f.write_string(s)
+			}
 		}
 		if !is_last_arg {
 			f.write_string(', ')

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -149,7 +149,7 @@ fn stringify_fn_after_name(node &FnDecl, mut f strings.Builder, t &Table, cur_mo
 				f.write_string('...')
 			}
 			if s[s.len - 1] == `>` {
-				short_module_s := s.trim_suffix('>').split('<').map(it.after('.')).join('<') + '>'
+				short_module_s := s.split('<').map(it.after('.')).join('<')
 				f.write_string(short_module_s)
 			} else {
 				f.write_string(s)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1590,10 +1590,6 @@ fn (mut f Fmt) write_generic_call_if_require(node ast.CallExpr) {
 				f.write(', ')
 			}
 		}
-		// avoid `<Foo<int>>` => `<Foo<int> >`
-		if f.out.last_n(1) == '>' {
-			f.write(' ')
-		}
 		f.write('>')
 	}
 }

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1588,7 +1588,7 @@ fn (mut f Fmt) write_generic_call_if_require(node ast.CallExpr) {
 	if node.concrete_types.len > 0 {
 		f.write('<')
 		for i, concrete_type in node.concrete_types {
-			f.write(f.table.type_to_str_using_aliases(concrete_type, f.mod2alias))
+			f.write(f.short_module(f.table.type_to_str_using_aliases(concrete_type, f.mod2alias)))
 			if i != node.concrete_types.len - 1 {
 				f.write(', ')
 			}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -211,7 +211,7 @@ pub fn (mut f Fmt) short_module(name string) string {
 	}
 	if name.ends_with('>') {
 		generic_levels := name.trim_suffix('>').split('<')
-		mut res := '${f.short_module(x[0])}'
+		mut res := '${f.short_module(generic_levels[0])}'
 		for i in 1 .. generic_levels.len {
 			genshorts := generic_levels[i].split(',').map(f.short_module(it)).join(',')
 			res += '<$genshorts'

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -210,12 +210,10 @@ pub fn (mut f Fmt) short_module(name string) string {
 		return f.mod2alias[name]
 	}
 	if name.ends_with('>') {
-		x := name.trim_suffix('>').split('<')
-		main := f.short_module(x[0])
-		mut res := '$main'
-		for i in 1 .. x.len {
-			genlist := x[i].split(',')
-			genshorts := genlist.map(f.short_module(it)).join(',')
+		generic_levels := name.trim_suffix('>').split('<')
+		mut res := '${f.short_module(x[0])}'
+		for i in 1 .. generic_levels.len {
+			genshorts := generic_levels[i].split(',').map(f.short_module(it)).join(',')
 			res += '<$genshorts'
 		}
 		res += '>'

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -211,12 +211,15 @@ pub fn (mut f Fmt) short_module(name string) string {
 	}
 	if name.ends_with('>') {
 		x := name.trim_suffix('>').split('<')
-		if x.len == 2 {
-			main := f.short_module(x[0])
-			genlist := x[1].split(',')
+		main := f.short_module(x[0])
+		mut res := '$main'
+		for i in 1..x.len {
+			genlist := x[i].split(',')
 			genshorts := genlist.map(f.short_module(it)).join(',')
-			return '$main<$genshorts>'
+			res += '<$genshorts'
 		}
+		res += '>'
+		return res
 	}
 	vals := name.split('.')
 	if vals.len < 2 {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -213,7 +213,7 @@ pub fn (mut f Fmt) short_module(name string) string {
 		x := name.trim_suffix('>').split('<')
 		main := f.short_module(x[0])
 		mut res := '$main'
-		for i in 1..x.len {
+		for i in 1 .. x.len {
 			genlist := x[i].split(',')
 			genshorts := genlist.map(f.short_module(it)).join(',')
 			res += '<$genshorts'

--- a/vlib/v/fmt/tests/generics_cascade_types_keep.vv
+++ b/vlib/v/fmt/tests/generics_cascade_types_keep.vv
@@ -23,5 +23,5 @@ fn main() {
 	// generic
 	assert multi_generic_args<int, string>(0, 's')
 	assert multi_generic_args<Foo1, Foo2>(Foo1{}, Foo2{})
-	assert multi_generic_args<Foo<int>, Foo<int> >(Foo<int>{}, Foo<int>{})
+	assert multi_generic_args<Foo<int>, Foo<int>>(Foo<int>{}, Foo<int>{})
 }

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -920,7 +920,7 @@ fn (mut s Scanner) text_scan() token.Token {
 						if s.text[s.pos + 2] == `=` {
 							s.pos += 2
 							return s.new_token(.right_shift_assign, '', 3)
-						} else if s.text[s.pos + 2] in [`(`, `)`, `{`, `}`, `>`, `,`] {
+						} else if s.text[s.pos + 2] in [`(`, `)`, `{`, `>`, `,`] {
 							// multi-level generics such as Foo<Bar<baz>>{ }, func<Bar<baz>>( ), etc
 							return s.new_token(.gt, '', 1)
 						}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -916,9 +916,14 @@ fn (mut s Scanner) text_scan() token.Token {
 					s.pos++
 					return s.new_token(.ge, '', 2)
 				} else if nextc == `>` {
-					if s.pos + 2 < s.text.len && s.text[s.pos + 2] == `=` {
-						s.pos += 2
-						return s.new_token(.right_shift_assign, '', 3)
+					if s.pos + 2 < s.text.len {
+						if s.text[s.pos + 2] == `=` {
+							s.pos += 2
+							return s.new_token(.right_shift_assign, '', 3)
+						} else if s.text[s.pos + 2] in [`(`, `{`, `<`] {
+							// multi-level generics such as Foo<Bar<baz>>{ }, func<Bar<baz>>( ), etc
+							return s.new_token(.gt, '', 1)
+						}
 					}
 					s.pos++
 					return s.new_token(.right_shift, '', 2)

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -920,7 +920,7 @@ fn (mut s Scanner) text_scan() token.Token {
 						if s.text[s.pos + 2] == `=` {
 							s.pos += 2
 							return s.new_token(.right_shift_assign, '', 3)
-						} else if s.text[s.pos + 2] in [`(`, `{`, `>`] {
+						} else if s.text[s.pos + 2] in [`(`, `)`, `{`, `}`, `>`, `,`] {
 							// multi-level generics such as Foo<Bar<baz>>{ }, func<Bar<baz>>( ), etc
 							return s.new_token(.gt, '', 1)
 						}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -920,7 +920,7 @@ fn (mut s Scanner) text_scan() token.Token {
 						if s.text[s.pos + 2] == `=` {
 							s.pos += 2
 							return s.new_token(.right_shift_assign, '', 3)
-						} else if s.text[s.pos + 2] in [`(`, `{`, `<`] {
+						} else if s.text[s.pos + 2] in [`(`, `{`, `>`] {
 							// multi-level generics such as Foo<Bar<baz>>{ }, func<Bar<baz>>( ), etc
 							return s.new_token(.gt, '', 1)
 						}

--- a/vlib/v/tests/generics_test.v
+++ b/vlib/v/tests/generics_test.v
@@ -481,7 +481,6 @@ fn return_one<T>(rec int, useless T) T {
 	return T(0)
 }
 
-/*
 struct MultiLevel<T> {
 	foo T
 }
@@ -504,7 +503,6 @@ fn test_multi_level_generics() {
 	assert three.foo.foo.foo == 10
 	assert print_multilevel_foo<MultiLevel<int>>(two) == 10
 }
-*/
 
 fn test_generic_detection() {
 	v1, v2 := -1, 1

--- a/vlib/v/tests/generics_test.v
+++ b/vlib/v/tests/generics_test.v
@@ -481,6 +481,31 @@ fn return_one<T>(rec int, useless T) T {
 	return T(0)
 }
 
+/*
+struct MultiLevel<T> {
+	foo T
+}
+
+fn print_multilevel_foo<T>(bar MultiLevel<T>) int {
+	return bar.foo.foo
+}
+
+fn test_multi_level_generics() {
+	one := MultiLevel<int>{
+		foo: 10
+	}
+	two := MultiLevel<MultiLevel<int>>{
+		foo: one
+	}
+	assert two.foo.foo == 10
+	three := MultiLevel<MultiLevel<MultiLevel<int>>>{
+		foo: two
+	}
+	assert three.foo.foo.foo == 10
+	assert print_multilevel_foo<MultiLevel<int>>(two) == 10
+}
+*/
+
 fn test_generic_detection() {
 	v1, v2 := -1, 1
 
@@ -493,7 +518,7 @@ fn test_generic_detection() {
 	// generic
 	assert multi_generic_args<int, string>(0, 's')
 	assert multi_generic_args<Foo1, Foo2>(Foo1{}, Foo2{})
-	assert multi_generic_args<Foo<int>, Foo<int> >(Foo<int>{}, Foo<int>{})
+	assert multi_generic_args<Foo<int>, Foo<int>>(Foo<int>{}, Foo<int>{})
 
 	// TODO: assert multi_generic_args<Foo<int>, Foo<int>>(Foo1{}, Foo2{})
 	assert multi_generic_args<simplemodule.Data, int>(simplemodule.Data{}, 0)

--- a/vlib/v/tests/generics_test.v
+++ b/vlib/v/tests/generics_test.v
@@ -485,8 +485,12 @@ struct MultiLevel<T> {
 	foo T
 }
 
-fn print_multilevel_foo<T>(bar MultiLevel<T>) int {
+fn get_multilevel_foo<T>(bar MultiLevel<T>) int {
 	return bar.foo.foo
+}
+
+fn get_multilevel_foo_2<T, U>(bar T, baz U) int {
+	return bar.foo.foo + baz.foo.foo
 }
 
 fn test_multi_level_generics() {
@@ -501,7 +505,9 @@ fn test_multi_level_generics() {
 		foo: two
 	}
 	assert three.foo.foo.foo == 10
-	assert print_multilevel_foo<MultiLevel<int>>(two) == 10
+	assert get_multilevel_foo<MultiLevel<int>>(two) == 10
+	assert get_multilevel_foo_2<MultiLevel<MultiLevel<int>>, MultiLevel<MultiLevel<int>>>(two,
+		two) == 20
 }
 
 fn test_generic_detection() {


### PR DESCRIPTION
This PR fixes scanning of multi-level generics cases (such as `Foo<Bar<int>>`) whose tails were wrongly understood as shift-right (`>>`).  So before this PR you must add an extra strange space (`Foo<Bar<int> >`) to avoid this scanner issue. 
Fmt for these cases is also fixed.