### PR TITLE
Checking smart cases in if: fixes `_likely_` / `_unlikely` case from #11485

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6709,6 +6709,8 @@ fn (mut c Checker) smartcast_if_conds(node ast.Expr, mut scope ast.Scope) {
 				}
 			}
 		}
+	} else if node is ast.Likely {
+		c.smartcast_if_conds(node.expr, mut scope)
 	}
 }
 

--- a/vlib/v/tests/if_smartcast_likely_test.v
+++ b/vlib/v/tests/if_smartcast_likely_test.v
@@ -1,0 +1,17 @@
+// fixes https://github.com/vlang/v/issues/11485 based on code example by https://github.com/Wertzui123
+interface IExample {
+}
+
+struct Example {
+	value string
+}
+
+fn test_if_smartcast_likely() {
+	print_value(Example{ value: 'Hello' })
+}
+
+fn print_value(example IExample) {
+	if _likely_(example is Example) {
+		print('Value: ' + example.value)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/vlang/v/issues/11485

Adds a case to `smartcast_if_conds` and test