### PR TITLE
builder: remove panics when cleaning up tmp files after tests

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -92,7 +92,7 @@ fn (mut v Builder) post_process_c_compiler_output(res os.Result) {
 				if v.pref.is_verbose {
 					eprintln('>> remove tmp file: $tmpfile')
 				}
-				os.rm(tmpfile) or { panic(err) }
+				os.rm(tmpfile) or {}
 			}
 		}
 		return

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -149,7 +149,7 @@ fn (mut v Builder) cleanup_run_executable_after_exit(exefile string) {
 		return
 	}
 	v.pref.vrun_elog('remove run executable: $exefile')
-	os.rm(exefile) or { panic(err) }
+	os.rm(exefile) or {}
 }
 
 // 'strings' => 'VROOT/vlib/strings'

--- a/vlib/v/builder/msvc.v
+++ b/vlib/v/builder/msvc.v
@@ -387,7 +387,7 @@ pub fn (mut v Builder) cc_msvc() {
 	// println(res)
 	// println('C OUTPUT:')
 	// Always remove the object file - it is completely unnecessary
-	os.rm(out_name_obj) or { panic(err) }
+	os.rm(out_name_obj) or {}
 }
 
 fn (mut v Builder) build_thirdparty_obj_file_with_msvc(path string, moduleflags []cflag.CFlag) {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -674,7 +674,7 @@ pub fn parse_args(known_external_commands []string, args []string) (&Preferences
 				os.rm(tmp_exe_file_path) or {}
 			}
 			res.vrun_elog('remove tmp v file: $tmp_v_file_path')
-			os.rm(tmp_v_file_path) or { panic(err) }
+			os.rm(tmp_v_file_path) or {}
 			exit(tmp_result)
 		}
 		must_exist(res.path)

--- a/vlib/v/tests/repl/runner/runner.v
+++ b/vlib/v/tests/repl/runner/runner.v
@@ -52,10 +52,10 @@ pub fn run_repl_file(wd string, vexec string, file string) ?string {
 	rcmd := '"$vexec" repl -replfolder "$wd" -replprefix "${fname}." < $input_temporary_filename'
 	r := os.execute(rcmd)
 	if r.exit_code < 0 {
-		os.rm(input_temporary_filename) or { panic(err) }
+		os.rm(input_temporary_filename) ?
 		return error('Could not execute: $rcmd')
 	}
-	os.rm(input_temporary_filename) or { panic(err) }
+	os.rm(input_temporary_filename) ?
 	result := r.output.replace('\r', '').replace('>>> ', '').replace('>>>', '').replace('... ',
 		'').replace(wd + os.path_separator, '').replace(vexec_folder, '').replace('\\',
 		'/').trim_right('\n\r')


### PR DESCRIPTION
This PR remove panics when cleaning up tmp files after tests.

Problem: the following often happens when runing `v test-self` on Windows.
```vlang
 OK    [528/659]  1626.192 ms vlib/v/tests/project_with_c_code_3/main_test.v
 FAIL  [529/659]  1827.782 ms vlib/v/tests/project_with_c_code/main_test.v
V panic: Failed to remove "C:\Users\yuyi9\AppData\Local\Temp\v\test_session_24725100\main_test.exe": No such file or directory
v hash: 92bb292
C:/Users/yuyi9/AppData/Local/Temp/v/v2.15830381870341978936.tmp.c:17131: at _v_panic: Backtrace
C:/Users/yuyi9/AppData/Local/Temp/v/v2.15830381870341978936.tmp.c:20685: by v__builder__Builder_cleanup_run_executable_after_exit
C:/Users/yuyi9/AppData/Local/Temp/v/v2.15830381870341978936.tmp.c:20668: by v__builder__Builder_run_compiled_executable_and_exit
C:/Users/yuyi9/AppData/Local/Temp/v/v2.15830381870341978936.tmp.c:20605: by v__builder__compile
C:/Users/yuyi9/AppData/Local/Temp/v/v2.15830381870341978936.tmp.c:21457: by main__main
C:/Users/yuyi9/AppData/Local/Temp/v/v2.15830381870341978936.tmp.c:22207: by wmain
00903ea0 : by ???
00904003 : by ???
7fff26666d50 : by ???
```