### PR TITLE
cgen: add gen_free_for_type_array/map()

### DIFF
--- a/vlib/v/tests/autogen_free_test.v
+++ b/vlib/v/tests/autogen_free_test.v
@@ -2,7 +2,7 @@ struct Info {
 	name  string
 	notes []string
 	maps  map[int]int
-	info  SubInfo
+	info  []SubInfo
 }
 
 struct SubInfo {


### PR DESCRIPTION
This PR add gen_free_for_type_array/map().

```vlang
struct Info {
	name  string
	notes []string
	maps  map[int]int
	info  []SubInfo
}

struct SubInfo {
	path  string
	files []string
}

fn main() {
	info := &Info{}
	info.free()
}
```
gen codes:
```vlang
void Map_int_int_free(Map_int_int* it) {
	map_free(it);
}

void main__SubInfo_free(main__SubInfo* it) {
	string_free(&(it->path));
	Array_string_free(&(it->files));
}

void Array_main__SubInfo_free(Array_main__SubInfo* it) {
	for (int i = 0; i < it->len; i++) {
		main__SubInfo_free(&(((main__SubInfo*)it->data)[i]));
	}
	array_free(it);
}

void main__Info_free(main__Info* it) {
	string_free(&(it->name));
	Array_string_free(&(it->notes));
	Map_int_int_free(&(it->maps));
	Array_main__SubInfo_free(&(it->info));
}
```