### PR TITLE
v: fix $tmpl comptime operation only working in return statement

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4829,6 +4829,12 @@ fn (mut g Gen) gen_optional_error(target_type ast.Type, expr ast.Expr) {
 
 fn (mut g Gen) return_stmt(node ast.Return) {
 	g.write_v_source_line_info(node.pos)
+
+	g.inside_return = true
+	defer {
+		g.inside_return = false
+	}
+
 	if node.exprs.len > 0 {
 		// skip `return $vweb.html()`
 		if node.exprs[0] is ast.ComptimeCall {
@@ -4838,10 +4844,6 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 		}
 	}
 
-	g.inside_return = true
-	defer {
-		g.inside_return = false
-	}
 	// got to do a correct check for multireturn
 	sym := g.table.get_type_symbol(g.fn_decl.return_type)
 	fn_return_is_multi := sym.kind == .multi_return

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -42,8 +42,8 @@ fn (mut g Gen) comptime_call(node ast.ComptimeCall) {
 	}
 	if node.is_vweb {
 		is_html := node.method_name == 'html'
-		mut cur_line := ""
-		
+		mut cur_line := ''
+
 		if !is_html {
 			cur_line = g.go_before_stmt(0)
 		}

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -55,7 +55,7 @@ fn (mut g Gen) comptime_call(node ast.ComptimeCall) {
 					if is_html {
 						g.inside_vweb_tmpl = true
 					}
-					g.stmts(stmt.stmts.filter(!(it is ast.Return)))
+					g.stmts(stmt.stmts.filter(it !is ast.Return))
 					g.inside_vweb_tmpl = false
 					break
 				}

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -42,6 +42,12 @@ fn (mut g Gen) comptime_call(node ast.ComptimeCall) {
 	}
 	if node.is_vweb {
 		is_html := node.method_name == 'html'
+		mut cur_line := ""
+		
+		if !is_html {
+			cur_line = g.go_before_stmt(0)
+		}
+
 		for stmt in node.vweb_tmpl.stmts {
 			if stmt is ast.FnDecl {
 				// insert stmts from vweb_tmpl fn
@@ -49,19 +55,24 @@ fn (mut g Gen) comptime_call(node ast.ComptimeCall) {
 					if is_html {
 						g.inside_vweb_tmpl = true
 					}
-					g.stmts(stmt.stmts)
+					g.stmts(stmt.stmts.filter(!(it is ast.Return)))
 					g.inside_vweb_tmpl = false
 					break
 				}
 			}
 		}
+
 		if is_html {
 			// return vweb html template
 			g.writeln('vweb__Context_html(&app->Context, _tmpl_res_$g.fn_decl.name); strings__Builder_free(&sb); string_free(&_tmpl_res_$g.fn_decl.name);')
 		} else {
 			// return $tmpl string
 			fn_name := g.fn_decl.name.replace('.', '__')
-			g.writeln('return _tmpl_res_$fn_name;')
+			g.write(cur_line)
+			if g.inside_return {
+				g.write('return ')
+			}
+			g.write('_tmpl_res_$fn_name')
 		}
 		return
 	}

--- a/vlib/v/parser/tmpl.v
+++ b/vlib/v/parser/tmpl.v
@@ -67,7 +67,7 @@ pub fn (mut p Parser) compile_template_file(template_file string, fn_name string
 	source.writeln('
 import strings
 // === vweb html template ===
-fn vweb_tmpl_${fn_name}() {
+fn vweb_tmpl_${fn_name}() string {
 mut sb := strings.new_builder($lstartlength)\n
 
 ')
@@ -237,6 +237,7 @@ mut sb := strings.new_builder($lstartlength)\n
 	}
 	source.writeln(parser.tmpl_str_end)
 	source.writeln('_tmpl_res_$fn_name := sb.str() ')
+	source.writeln('return _tmpl_res_$fn_name')
 	source.writeln('}')
 	source.writeln('// === end of vweb html template ===')
 	result := source.str()

--- a/vlib/v/tests/tmpl_test.v
+++ b/vlib/v/tests/tmpl_test.v
@@ -10,8 +10,21 @@ fn one() string {
 	return $tmpl('tmpl/base.txt')
 }
 
+fn outside_return() string {
+	name := 'Peter'
+	age := 25
+	numbers := [1, 2, 3]
+	downloads := {
+		'vlang/ui':  '3201'
+		'vlang/vtl': '123'
+	}
+	ignored := true
+	result := $tmpl('tmpl/base.txt')
+	return result
+}
+
 fn test_tmpl() {
-	assert one().trim_space() == "name: Peter
+	expected := "name: Peter
 age: 25
 numbers: [1, 2, 3]
 
@@ -41,6 +54,9 @@ this is not ignored
 
 
 so, it's basically true"
+
+	assert one().trim_space() == expected
+	assert outside_return().trim_space() == expected
 }
 
 fn test_tmpl_in_anon_fn() {
@@ -82,3 +98,5 @@ this is not ignored
 
 so, it's basically true"
 }
+
+

--- a/vlib/v/tests/tmpl_test.v
+++ b/vlib/v/tests/tmpl_test.v
@@ -98,5 +98,3 @@ this is not ignored
 
 so, it's basically true"
 }
-
-


### PR DESCRIPTION
Fixes #11305 
Fixed the code generation for `$tmpl` by prepending the generated string builder statements to the current statement that the operation appears in. It's done the same way that `insert_before_stmt` is implemented.
I also slightly modified `return_stmt` in cgen.v

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
