### PR TITLE
cgen: fix illegal character encoding with rune consts above 127

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5208,7 +5208,7 @@ fn (mut g Gen) const_decl_precomputed(mod string, name string, ct_value ast.Comp
 		}
 		rune {
 			rune_code := u32(ct_value)
-			if rune_code <= 255 {
+			if rune_code <= 127 {
 				if rune_code in [`"`, `\\`, `'`] {
 					return false
 				}

--- a/vlib/v/tests/high_ascii_const_rune_test.v
+++ b/vlib/v/tests/high_ascii_const_rune_test.v
@@ -1,0 +1,5 @@
+const accented = `á`
+
+fn test_high_ascii_const() {
+	assert u32(accented) == 225
+}


### PR DESCRIPTION
This PR fixes clang (with -cstrict) throwing an illegal character error in a character literal when a rune with value above 127 but below 256 is saved into a const - which is technically neither valid ASCII, nor UTF-8. See [this CI run](https://github.com/ChAoSUnItY/v/runs/3645736016) for an example.