### PR TITLE
fmt: fix unnecessary line break of array_init

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1377,6 +1377,8 @@ pub fn (mut f Fmt) array_init(node ast.ArrayInit) {
 		if i == 0 {
 			if f.array_init_depth > f.array_init_break.len {
 				f.array_init_break << pos.line_nr > last_line_nr
+					&& (f.line_len + expr.position().len < fmt.max_len[3]
+					|| expr in [ast.ArrayInit, ast.StructInit, ast.MapInit, ast.CallExpr])
 			}
 		}
 		line_break := f.array_init_break[f.array_init_depth - 1]
@@ -1462,6 +1464,8 @@ pub fn (mut f Fmt) array_init(node ast.ArrayInit) {
 				}
 				last_comment_was_inline = cmt.is_inline
 			}
+		} else if i == node.exprs.len - 1 && !line_break {
+			is_new_line = false
 		}
 		mut put_comma := !set_comma
 		if has_comments && !last_comment_was_inline {

--- a/vlib/v/fmt/tests/array_init_comment_ending_keep.vv
+++ b/vlib/v/fmt/tests/array_init_comment_ending_keep.vv
@@ -11,8 +11,7 @@ const (
 				name: 'special-7'
 				value: ','
 				raw: 'special-8=","'
-			},
-			]
+			}]
 		}
 		// (bradfitz): users have reported seeing this in the
 		// wild, but do browsers handle it? RFC 6265 just says "don't

--- a/vlib/v/fmt/tests/array_init_expected.vv
+++ b/vlib/v/fmt/tests/array_init_expected.vv
@@ -11,8 +11,7 @@ fn wrapping_tests() {
 	my_arr := ['Lorem ipsum dolor sit amet, consectetur adipiscing',
 		'elit. Donec varius purus leo, vel maximus diam',
 		'finibus sed. Etiam eu urna ante. Nunc quis vehicula',
-		'velit. Sed at mauris et quam ornare tristique.',
-	]
+		'velit. Sed at mauris et quam ornare tristique.']
 }
 
 fn array_init_without_commas() {

--- a/vlib/v/fmt/tests/consts_expected.vv
+++ b/vlib/v/fmt/tests/consts_expected.vv
@@ -23,8 +23,7 @@ const (
 
 const (
 	i_am_a_very_long_constant_name_so_i_stand_alone_and_my_length_is_over_90_characters = [
-		'testforit',
-	]
+		'testforit']
 )
 
 pub const (

--- a/vlib/v/fmt/tests/if_array_contains_expected.vv
+++ b/vlib/v/fmt/tests/if_array_contains_expected.vv
@@ -1,0 +1,6 @@
+fn main() {
+	if ['aaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbb', 'ccccccccccccccccccccccccc',
+		'dddddddddddddddddddddd'].contains('foo')
+	{
+	}
+}

--- a/vlib/v/fmt/tests/if_array_contains_input.vv
+++ b/vlib/v/fmt/tests/if_array_contains_input.vv
@@ -1,0 +1,3 @@
+fn main() {
+	if ['aaaaaaaaaaaaaaaaaaa','bbbbbbbbbbbbbbbbbbbbbbb','ccccccccccccccccccccccccc','dddddddddddddddddddddd'].contains('foo'){}
+}


### PR DESCRIPTION
This PR fix unnecessary line break of array_init.

- Fix unnecessary line break of array_init.
- Add test.

```vlang
fn main() {
	if ['aaaaaaaaaaaaaaaaaaa','bbbbbbbbbbbbbbbbbbbbbbb','ccccccccccccccccccccccccc','dddddddddddddddddddddd'].contains('foo'){}
}
```
format to:
```vlang
fn main() {
	if ['aaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbb', 'ccccccccccccccccccccccccc',
		'dddddddddddddddddddddd'].contains('foo')
	{
	}
}
```