### PR TITLE
cgen: fix if infix expr with array.all/any() (fix #11557)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -602,11 +602,15 @@ fn (mut g Gen) gen_array_any(node ast.CallExpr) {
 	// styp := g.typ(node.return_type)
 	elem_type_str := g.typ(info.elem_type)
 	g.empty_line = true
+	g.writeln('bool $tmp = false;')
+	if g.infix_left_var_name.len > 0 {
+		g.writeln('if ($g.infix_left_var_name) {')
+		g.indent++
+	}
 	g.write('${g.typ(node.left_type)} ${tmp}_orig = ')
 	g.expr(node.left)
 	g.writeln(';')
 	g.writeln('int ${tmp}_len = ${tmp}_orig.len;')
-	g.writeln('bool $tmp = false;')
 	i := g.new_tmp_var()
 	g.writeln('for (int $i = 0; $i < ${tmp}_len; ++$i) {')
 	g.writeln('\t$elem_type_str it = (($elem_type_str*) ${tmp}_orig.data)[$i];')
@@ -654,6 +658,10 @@ fn (mut g Gen) gen_array_any(node ast.CallExpr) {
 		g.stmt_path_pos << g.out.len
 	}
 	g.write('\n')
+	if g.infix_left_var_name.len > 0 {
+		g.indent--
+		g.writeln('}')
+	}
 	g.write(s)
 	g.write(tmp)
 }
@@ -666,11 +674,15 @@ fn (mut g Gen) gen_array_all(node ast.CallExpr) {
 	// styp := g.typ(node.return_type)
 	elem_type_str := g.typ(info.elem_type)
 	g.empty_line = true
+	g.writeln('bool $tmp = true;')
+	if g.infix_left_var_name.len > 0 {
+		g.writeln('if ($g.infix_left_var_name) {')
+		g.indent++
+	}
 	g.write('${g.typ(node.left_type)} ${tmp}_orig = ')
 	g.expr(node.left)
 	g.writeln(';')
 	g.writeln('int ${tmp}_len = ${tmp}_orig.len;')
-	g.writeln('bool $tmp = true;')
 	i := g.new_tmp_var()
 	g.writeln('for (int $i = 0; $i < ${tmp}_len; ++$i) {')
 	g.writeln('\t$elem_type_str it = (($elem_type_str*) ${tmp}_orig.data)[$i];')
@@ -718,6 +730,10 @@ fn (mut g Gen) gen_array_all(node ast.CallExpr) {
 		g.stmt_path_pos << g.out.len
 	}
 	g.write('\n')
+	if g.infix_left_var_name.len > 0 {
+		g.indent--
+		g.writeln('}')
+	}
 	g.write(s)
 	g.write(tmp)
 }

--- a/vlib/v/tests/if_expr_with_array_call_test.v
+++ b/vlib/v/tests/if_expr_with_array_call_test.v
@@ -1,0 +1,17 @@
+fn test_if_expr_with_array_all_any() {
+	arr := ['']
+
+	for i in arr {
+		if i.len == 0 || i[1..].bytes().all(it.is_letter()) {
+			println('empty or all char from second is letter!')
+			assert true
+		}
+	}
+
+	for i in arr {
+		if i.len == 0 || i[1..].bytes().any(it.is_letter()) {
+			println('empty or all char from second is letter!')
+			assert true
+		}
+	}
+}


### PR DESCRIPTION
This PR fix if infix expr with array.all/any() (fix #11557).

- Fix if infix expr with array.all/any().
- `map` and `filter` will resolve in another PR.
- Add test.

```vlang
fn main() {
	arr := ['']

	for i in arr {
		if i.len == 0 || i[1..].bytes().all(it.is_letter()) {
			println('empty or all char from second is letter!')
			assert true
		}
	}

	for i in arr {
		if i.len == 0 || i[1..].bytes().any(it.is_letter()) {
			println('empty or all char from second is letter!')
			assert true
		}
	}
}

PS D:\Test\v\tt1> v run .
empty or all char from second is letter!
empty or all char from second is letter!
```