### PR TITLE
fmt: format vlib/v/token/token.v

### DIFF
--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -134,8 +134,7 @@ pub enum Kind {
 pub const (
 	assign_tokens = [Kind.assign, .plus_assign, .minus_assign, .mult_assign, .div_assign, .xor_assign,
 		.mod_assign, .or_assign, .and_assign, .right_shift_assign, .left_shift_assign,
-		.unsigned_right_shift_assign,
-	]
+		.unsigned_right_shift_assign]
 )
 
 const (


### PR DESCRIPTION
This PR format vlib/v/token/token.v to solve ci test error.