### PR TITLE
Struct init: fix struct init with multiple branches bug, fixes #11564

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4799,6 +4799,7 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 		}
 	}
 	g.writeln('}')
+	g.stmt_path_pos << g.out.len
 	if needs_tmp_var {
 		if g.infix_left_var_name.len > 0 {
 			g.indent--

--- a/vlib/v/tests/init_multiple_branches_test.v
+++ b/vlib/v/tests/init_multiple_branches_test.v
@@ -1,0 +1,29 @@
+// fixes https://github.com/vlang/v/issues/11564, test is copied from the code by https://github.com/ken0x0a
+import x.json2
+
+struct SA {}
+struct SB {}
+struct SC {}
+type Sum = SA | SB | SC
+struct App {
+	s map[string]Sum
+	t bool
+}
+fn test_init_multiple_branches() ? {
+	mut m := map[string]json2.Any{}
+	app := App {
+		t: m['t'] or { 0 }.bool()
+		s: if a := m['a'] {
+			println('a => $a')
+			b := return_optional(a) ? // Fails only if the expr in this line has or_block (or_block kind (.propagation or .block) doesn't matter)
+			b
+		} else {
+			map[string]Sum{}
+		}
+	}
+	println('app => $app')
+}
+
+fn return_optional(input json2.Any) ?map[string]Sum {
+	return map[string]Sum{}
+}

--- a/vlib/v/tests/init_multiple_branches_test.v
+++ b/vlib/v/tests/init_multiple_branches_test.v
@@ -1,17 +1,22 @@
-// fixes https://github.com/vlang/v/issues/11564, test is copied from the code by https://github.com/ken0x0a
+// fixes https://github.com/vlang/v/issues/11564, test is copied from the code by https://github.com/ken0x0a and formatted
 import x.json2
 
 struct SA {}
+
 struct SB {}
+
 struct SC {}
+
 type Sum = SA | SB | SC
+
 struct App {
 	s map[string]Sum
 	t bool
 }
+
 fn test_init_multiple_branches() ? {
 	mut m := map[string]json2.Any{}
-	app := App {
+	app := App{
 		t: m['t'] or { 0 }.bool()
 		s: if a := m['a'] {
 			println('a => $a')


### PR DESCRIPTION
with adding a location to `stmt_path_pos` after some `}` in `if_stmt` in cgen.v .


fixes https://github.com/vlang/v/issues/11564
used the test from the issue
