### PR TITLE
checker: fix detection of invalid insertions, fixes #3600.

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1586,20 +1586,16 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				}
 				// []T << T or []T << []T
 				unwrapped_right_type := c.unwrap_generic(right_type)
-				mut hint := ''
-
 				if c.check_types(unwrapped_right_type, left_value_type) {
 					// []&T << T is wrong: we check for that, !(T.is_ptr()) && ?(&T).is_ptr()
-					if !unwrapped_right_type.is_ptr() && left_value_type.is_ptr()
-						&& left_value_type.share() == .mut_t {
-						hint = '. you can prefix the right argument with &.'
-					} else {
+					if unwrapped_right_type.is_ptr() || left_value_type.is_ptr()
+						|| left_value_type.share() == .mut_t {
 						return ast.void_type
 					}
 				} else if c.check_types(unwrapped_right_type, c.unwrap_generic(left_type)) {
 					return ast.void_type
 				}
-				c.error('cannot append `$right_sym.name` to `$left_sym.name`$hint', right_pos)
+				c.error('cannot append `$right_sym.name` to `$left_sym.name`', right_pos)
 				return ast.void_type
 			} else {
 				return c.check_shift(left_type, right_type, left_pos, right_pos)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1588,8 +1588,8 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				unwrapped_right_type := c.unwrap_generic(right_type)
 				if c.check_types(unwrapped_right_type, left_value_type) {
 					// []&T << T is wrong: we check for that, !(T.is_ptr()) && ?(&T).is_ptr()
-					if unwrapped_right_type.is_ptr() || left_value_type.is_ptr()
-						|| left_value_type.share() == .mut_t {
+					if !(!unwrapped_right_type.is_ptr() && left_value_type.is_ptr()
+						&& left_value_type.share() == .mut_t) {
 						return ast.void_type
 					}
 				} else if c.check_types(unwrapped_right_type, c.unwrap_generic(left_type)) {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1586,12 +1586,13 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				}
 				// []T << T or []T << []T
 				unwrapped_right_type := c.unwrap_generic(right_type)
-				mut hint := ""
+				mut hint := ''
 
 				if c.check_types(unwrapped_right_type, left_value_type) {
 					// []&T << T is wrong: we check for that, !(T.is_ptr()) && ?(&T).is_ptr()
-					if !unwrapped_right_type.is_ptr() && left_value_type.is_ptr() && left_value_type.share() == .mut_t {
-						hint = ". you can prefix the right argument with &."
+					if !unwrapped_right_type.is_ptr() && left_value_type.is_ptr()
+						&& left_value_type.share() == .mut_t {
+						hint = '. you can prefix the right argument with &.'
 					} else {
 						return ast.void_type
 					}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1586,11 +1586,19 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				}
 				// []T << T or []T << []T
 				unwrapped_right_type := c.unwrap_generic(right_type)
-				if c.check_types(unwrapped_right_type, left_value_type)
-					|| c.check_types(unwrapped_right_type, c.unwrap_generic(left_type)) {
+				mut hint := ""
+
+				if c.check_types(unwrapped_right_type, left_value_type) {
+					// []&T << T is wrong: we check for that, !(T.is_ptr()) && ?(&T).is_ptr()
+					if !unwrapped_right_type.is_ptr() && left_value_type.is_ptr() && left_value_type.share() == .mut_t {
+						hint = ". you can prefix the right argument with &."
+					} else {
+						return ast.void_type
+					}
+				} else if c.check_types(unwrapped_right_type, c.unwrap_generic(left_type)) {
 					return ast.void_type
 				}
-				c.error('cannot append `$right_sym.name` to `$left_sym.name`', right_pos)
+				c.error('cannot append `$right_sym.name` to `$left_sym.name`$hint', right_pos)
 				return ast.void_type
 			} else {
 				return c.check_shift(left_type, right_type, left_pos, right_pos)

--- a/vlib/v/checker/tests/invalid_insert_references_test.out
+++ b/vlib/v/checker/tests/invalid_insert_references_test.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/invalid_insert_references_test.vv:8:7: error: cannot append `int literal` to `[]&int`. you can prefix the right argument with &.
+    6 |     a << &c
+    7 |     c = 2
+    8 |     a << 1
+      |          ^
+    9 |     println(a)
+   10 | }

--- a/vlib/v/checker/tests/invalid_insert_references_test.out
+++ b/vlib/v/checker/tests/invalid_insert_references_test.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/invalid_insert_references_test.vv:8:7: error: cannot append `int literal` to `[]&int`. you can prefix the right argument with &.
+vlib/v/checker/tests/invalid_insert_references_test.vv:8:7: error: cannot append `int literal` to `[]&int`
     6 |     a << &c
     7 |     c = 2
     8 |     a << 1

--- a/vlib/v/checker/tests/invalid_insert_references_test.vv
+++ b/vlib/v/checker/tests/invalid_insert_references_test.vv
@@ -1,0 +1,14 @@
+// fixes https://github.com/vlang/v/issues/3600, test based on a simplified version of example by https://github.com/radare
+fn test_invalid_insert_references() {
+	b := 0
+	mut a := [&b]
+	mut c := 1
+	a << &c
+	c = 2
+	a << 1
+	println(a)
+}
+
+fn main() {
+	test_invalid_insert_references()
+}


### PR DESCRIPTION
fixes detection of insertion of invalid references , example in https://github.com/vlang/v/issues/3600

i experimented until i got to this place and check: please review. it's not general enough. changing `check_types` would be better, but it seems to break a lot of code for me (or maybe it requires a bigger change)

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
