### PR TITLE
ast: solves fixed array typedef generation issue

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -207,7 +207,7 @@ pub fn (t &Table) fn_type_signature(f &Fn) string {
 		// TODO: for now ignore mut/pts in sig for now
 		typ := arg.typ.set_nr_muls(0)
 		arg_type_sym := t.get_type_symbol(typ)
-		sig += arg_type_sym.str().to_lower().replace_each(['.', '__', '&', '', '[]', 'arr_', 'chan ',
+		sig += arg_type_sym.str().to_lower().replace_each(['.', '__', '&', '', '[', 'arr_', 'chan ',
 			'chan_', 'map[', 'map_of_', ']', '_to_', '<', '_T_', ',', '_', ' ', '', '>', ''])
 		if i < f.params.len - 1 {
 			sig += '_'

--- a/vlib/v/tests/anon_fn_with_array_arguments_test.v
+++ b/vlib/v/tests/anon_fn_with_array_arguments_test.v
@@ -1,5 +1,5 @@
 struct Test {
-	fn_test fn(x int, y [10]int, z []int) bool = fixed_array_fn
+	fn_test fn (x int, y [10]int, z []int) bool = fixed_array_fn
 }
 
 fn fixed_array_fn(x int, y [10]int, z []int) bool {

--- a/vlib/v/tests/anon_fn_with_array_arguments_test.v
+++ b/vlib/v/tests/anon_fn_with_array_arguments_test.v
@@ -1,3 +1,15 @@
+struct Test {
+	fn_test fn(x int, y [10]int, z []int) bool = fixed_array_fn
+}
+
+fn fixed_array_fn(x int, y [10]int, z []int) bool {
+	return true
+}
+
+fn test_anon_fn_with_fixed_array_arguments() {
+	assert true
+}
+
 fn fn_arg(f fn ([]int) int) int {
 	return f([1, 2, 3])
 }


### PR DESCRIPTION

An anonymous function with a fixed array parameter generates a c gen error because 
of the creation of a C typedef which contains [ as part of the function name.

