### PR TITLE
cgen, fmt, scanner: fix and use nested lambda in scanner

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1724,7 +1724,7 @@ pub fn (mut f Fmt) ident(node ast.Ident) {
 		}
 	}
 	f.write_language_prefix(node.language)
-	if node.name == 'it' && f.it_name != '' && f.inside_lambda == 0 { // allow `it` in lambdas
+	if node.name == 'it' && f.it_name != '' && f.in_lambda_depth == 0 { // allow `it` in lambdas
 		f.write(f.it_name)
 	} else if node.kind == .blank_ident {
 		f.write('_')

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -43,7 +43,7 @@ pub mut:
 	use_short_fn_args  bool
 	single_line_fields bool   // should struct fields be on a single line
 	it_name            string // the name to replace `it` with
-	inside_lambda      bool
+	in_lambda_depth    int
 	inside_const       bool
 	is_mbranch_expr    bool // match a { x...y { } }
 	fn_scope           &ast.Scope = voidptr(0)
@@ -1539,9 +1539,9 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 	}
 	if node.is_method {
 		if node.name in ['map', 'filter', 'all', 'any'] {
-			f.inside_lambda = true
+			f.in_lambda_depth++
 			defer {
-				f.inside_lambda = false
+				f.in_lambda_depth--
 			}
 		}
 		if node.left is ast.Ident {
@@ -1724,7 +1724,7 @@ pub fn (mut f Fmt) ident(node ast.Ident) {
 		}
 	}
 	f.write_language_prefix(node.language)
-	if node.name == 'it' && f.it_name != '' && !f.inside_lambda { // allow `it` in lambdas
+	if node.name == 'it' && f.it_name != '' && f.inside_lambda == 0 { // allow `it` in lambdas
 		f.write(f.it_name)
 	} else if node.kind == .blank_ident {
 		f.write('_')

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -196,7 +196,7 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 			}
 		}
 		ast.CallExpr {
-			if expr.name in ['map', 'filter'] {
+			if expr.name in ['map', 'filter', 'all', 'any'] {
 				is_embed_map_filter = true
 				g.stmt_path_pos << g.out.len
 			}
@@ -387,7 +387,7 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 			}
 		}
 		ast.CallExpr {
-			if expr.name in ['map', 'filter'] {
+			if expr.name in ['map', 'filter', 'all', 'any'] {
 				is_embed_map_filter = true
 				g.stmt_path_pos << g.out.len
 			}
@@ -678,7 +678,7 @@ fn (mut g Gen) gen_array_any(node ast.CallExpr) {
 			}
 		}
 		ast.CallExpr {
-			if expr.name in ['map', 'filter'] {
+			if expr.name in ['map', 'filter', 'all', 'any'] {
 				is_embed_map_filter = true
 				g.stmt_path_pos << g.out.len
 			}
@@ -761,7 +761,7 @@ fn (mut g Gen) gen_array_all(node ast.CallExpr) {
 			}
 		}
 		ast.CallExpr {
-			if expr.name in ['map', 'filter'] {
+			if expr.name in ['map', 'filter', 'all', 'any'] {
 				is_embed_map_filter = true
 				g.stmt_path_pos << g.out.len
 			}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -926,20 +926,14 @@ fn (mut s Scanner) text_scan() token.Token {
 						// here we set the limit 100 which should be nice for real cases
 						// e.g. ...Bar<int, []Foo<int>, Baz_, [20]f64, map[string][]bool>> =>
 						// <int, Baz_, [20]f64, map[string][]bool => int, Baz_, f64, bool
-						mut is_generic := true
-						if s.last_lt >= 0 && s.pos - s.last_lt < 100 {
+						is_generic := if s.last_lt >= 0 && s.pos - s.last_lt < 100 {
 							typs := s.text[s.last_lt + 1..s.pos].split(',').map(it.trim_space().trim_right('>').after(']'))
 							// if any typ is neither Type nor builtin, then the case is non-generic
-							for typ in typs {
-								if typ.len == 0
-									|| (!(typ[0].is_capital() && typ[1..].bytes().all(it.is_alnum()
-									|| it == `_`)) && typ !in ast.builtin_type_names) {
-									is_generic = false
-									break
-								}
-							}
+							typs.all(it.len > 0
+								&& ((it[0].is_capital() && it[1..].bytes().all(it.is_alnum()
+								|| it == `_`)) || it in ast.builtin_type_names))
 						} else {
-							is_generic = false
+							false
 						}
 						if is_generic {
 							return s.new_token(.gt, '', 1)


### PR DESCRIPTION
This PR further fixes nested lambda so that it's mature enough to be introduced into V's code.
You can feel functional programming's greater power on reducing code lines.

Before in scanner.v:
```V
mut is_generic := true
if s.last_lt >= 0 && s.pos - s.last_lt < 100 {
	typs := s.text[s.last_lt + 1..s.pos].split(',').map(it.trim_space().trim_right('>').after(']'))
	for typ in typs {
		if typ.len == 0 || (!(typ[0].is_capital() && typ[1..].bytes().all(it.is_alnum() || it == `_`)) && typ !in ast.builtin_type_names) {
	                is_generic = false
			break
		}
	}
} else {
	is_generic = false
}
```
After in scanner.v:
```V
is_generic := if s.last_lt >= 0 && s.pos - s.last_lt < 100 {
	typs := s.text[s.last_lt + 1..s.pos].split(',').map(it.trim_space().trim_right('>').after(']'))
	typs.all(it.len > 0 && ((it[0].is_capital() && it[1..].bytes().all(it.is_alnum() || it == `_`)) || it in ast.builtin_type_names))
} else {
	false
}
```
And actually with this PR the case could even be reduced into only one line! However for understandability I didn't do that.
```V
is_generic := s.last_lt >= 0 && s.pos - s.last_lt < 100 && s.text[s.last_lt + 1..s.pos].split(',').map(it.trim_space().trim_right('>').after(']')).all(it.len > 0 && ((it[0].is_capital() && it[1..].bytes().all(it.is_alnum() || it == `_`)) || it in ast.builtin_type_names))
```
fix #11956 