### PR TITLE
toml: rename ast.Node -> ast.Value

### DIFF
--- a/vlib/toml/ast/ast.v
+++ b/vlib/toml/ast/ast.v
@@ -11,7 +11,7 @@ pub struct Root {
 pub:
 	input input.Config // User input configuration
 pub mut:
-	table Node
+	table Value
 	// errors           []errors.Error    // all the checker errors in the file
 }
 

--- a/vlib/toml/ast/types.v
+++ b/vlib/toml/ast/types.v
@@ -15,7 +15,15 @@ pub fn (k Key) str() string {
 
 // Value is a sumtype representing all possible value types
 // found in a TOML document.
-pub type Value = Bool | Date | DateTime | Null | Number | Quoted | Time | []Value | map[string]Value
+pub type Value = Bool
+	| Date
+	| DateTime
+	| Null
+	| Number
+	| Quoted
+	| Time
+	| []Value
+	| map[string]Value
 
 pub fn (v Value) to_json() string {
 	match v {

--- a/vlib/toml/ast/types.v
+++ b/vlib/toml/ast/types.v
@@ -13,11 +13,11 @@ pub fn (k Key) str() string {
 	return k.text
 }
 
-// Node is a sumtype representing all possible value types
+// Value is a sumtype representing all possible value types
 // found in a TOML document.
-pub type Node = Bool | Date | DateTime | Null | Number | Quoted | Time | []Node | map[string]Node
+pub type Value = Bool | Date | DateTime | Null | Number | Quoted | Time | []Value | map[string]Value
 
-pub fn (v Node) to_json() string {
+pub fn (v Value) to_json() string {
 	match v {
 		Quoted, Date, DateTime, Time {
 			return '"$v.text"'
@@ -25,7 +25,7 @@ pub fn (v Node) to_json() string {
 		Bool, Null, Number {
 			return v.text
 		}
-		map[string]Node {
+		map[string]Value {
 			mut str := '{'
 			for key, val in v {
 				str += ' "$key": $val.to_json(),'
@@ -34,7 +34,7 @@ pub fn (v Node) to_json() string {
 			str += ' }'
 			return str
 		}
-		[]Node {
+		[]Value {
 			mut str := '['
 			for val in v {
 				str += ' $val.to_json(),'
@@ -56,8 +56,8 @@ pub fn (dtt DateTimeType) str() string {
 
 // value queries a value from the map.
 // `key` should be in "dotted" form e.g.: `"a.b.c.d"`
-pub fn (v map[string]Node) value(key string) &Node {
-	null := &Node(Null{})
+pub fn (v map[string]Value) value(key string) &Value {
+	null := &Value(Null{})
 	key_split := key.split('.')
 	// util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, ' retreiving value at "$key"')
 	if key_split[0] in v.keys() {
@@ -66,8 +66,8 @@ pub fn (v map[string]Node) value(key string) &Node {
 			// TODO return error(@MOD + '.' + @STRUCT + '.' + @FN + ' key "$key" does not exist')
 		}
 		// `match` isn't currently very suitable for these types of sum type constructs...
-		if value is map[string]Node {
-			m := (value as map[string]Node)
+		if value is map[string]Value {
+			m := (value as map[string]Value)
 			next_key := key_split[1..].join('.')
 			if next_key == '' {
 				return &value
@@ -81,13 +81,13 @@ pub fn (v map[string]Node) value(key string) &Node {
 }
 
 // value queries a value from the map.
-pub fn (v map[string]Node) exists(key string) bool {
+pub fn (v map[string]Value) exists(key string) bool {
 	key_split := key.split('.')
 	if key_split[0] in v.keys() {
 		value := v[key_split[0]] or { return false }
 		// `match` isn't currently very suitable for these types of sum type constructs...
-		if value is map[string]Node {
-			m := (value as map[string]Node)
+		if value is map[string]Value {
+			m := (value as map[string]Value)
 			next_key := key_split[1..].join('.')
 			if next_key == '' {
 				return true

--- a/vlib/toml/ast/walker/walker.v
+++ b/vlib/toml/ast/walker/walker.v
@@ -2,12 +2,12 @@ module walker
 
 import toml.ast
 
-// Visitor defines a visit method which is invoked by the walker in each node it encounters.
+// Visitor defines a visit method which is invoked by the walker in each Value node it encounters.
 pub interface Visitor {
-	visit(node &ast.Node) ?
+	visit(value &ast.Value) ?
 }
 
-pub type InspectorFn = fn (node &ast.Node, data voidptr) ?
+pub type InspectorFn = fn (value &ast.Value, data voidptr) ?
 
 struct Inspector {
 	inspector_callback InspectorFn
@@ -15,23 +15,23 @@ mut:
 	data voidptr
 }
 
-pub fn (i &Inspector) visit(node &ast.Node) ? {
-	i.inspector_callback(node, i.data) or { return err }
+pub fn (i &Inspector) visit(value &ast.Value) ? {
+	i.inspector_callback(value, i.data) or { return err }
 }
 
-// inspect traverses and checks the AST node on a depth-first order and based on the data given
-pub fn inspect(node &ast.Node, data voidptr, inspector_callback InspectorFn) ? {
-	walk(Inspector{inspector_callback, data}, node) ?
+// inspect traverses and checks the AST Value node on a depth-first order and based on the data given
+pub fn inspect(value &ast.Value, data voidptr, inspector_callback InspectorFn) ? {
+	walk(Inspector{inspector_callback, data}, value) ?
 }
 
 // walk traverses the AST using the given visitor
-pub fn walk(visitor Visitor, node &ast.Node) ? {
-	if node is map[string]ast.Node {
-		n := node as map[string]ast.Node
-		for _, nn in n {
-			walk(visitor, &nn) ?
+pub fn walk(visitor Visitor, value &ast.Value) ? {
+	if value is map[string]ast.Value {
+		value_map := value as map[string]ast.Value
+		for _, val in value_map {
+			walk(visitor, &val) ?
 		}
 	} else {
-		visitor.visit(node) ?
+		visitor.visit(value) ?
 	}
 }

--- a/vlib/toml/checker/checker.v
+++ b/vlib/toml/checker/checker.v
@@ -9,22 +9,22 @@ import toml.ast.walker
 import toml.token
 import toml.scanner
 
-// Checker checks a tree of TOML `ast.Node`'s for common errors.
+// Checker checks a tree of TOML `ast.Value`'s for common errors.
 pub struct Checker {
 	scanner &scanner.Scanner
 }
 
-pub fn (c Checker) check(n &ast.Node) ? {
+pub fn (c Checker) check(n &ast.Value) ? {
 	walker.walk(c, n) ?
 }
 
-fn (c Checker) visit(node &ast.Node) ? {
-	match node {
+fn (c Checker) visit(value &ast.Value) ? {
+	match value {
 		ast.Number {
-			c.check_number(node) ?
+			c.check_number(value) ?
 		}
 		ast.Bool {
-			c.check_boolean(node) ?
+			c.check_boolean(value) ?
 		}
 		else {
 			// TODO add more checks to make BurntSushi/toml-test invalid TOML pass

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -102,13 +102,13 @@ pub fn (d Doc) to_json() string {
 
 // value queries a value from the TOML document.
 pub fn (d Doc) value(key string) Any {
-	values := d.ast.table as map[string]ast.Node
+	values := d.ast.table as map[string]ast.Value
 	// any_values := d.ast_to_any(values) as map[string]Any
 	return d.get_map_value_as_any(values, key)
 }
 
-// ast_to_any_value converts `from` ast.Node to toml.Any value.
-fn (d Doc) ast_to_any(value ast.Node) Any {
+// ast_to_any_value converts `from` ast.Value to toml.Any value.
+fn (d Doc) ast_to_any(value ast.Value) Any {
 	// `match` isn't currently very suitable for further unwrapping sumtypes in the if's...
 	if value is ast.Date || value is ast.Time || value is ast.DateTime {
 		mut tim := time.Time{}
@@ -162,8 +162,8 @@ fn (d Doc) ast_to_any(value ast.Node) Any {
 			}
 			return Any(false)
 		}
-		map[string]ast.Node {
-			m := (value as map[string]ast.Node)
+		map[string]ast.Value {
+			m := (value as map[string]ast.Value)
 			mut am := map[string]Any{}
 			for k, v in m {
 				am[k] = d.ast_to_any(v)
@@ -171,8 +171,8 @@ fn (d Doc) ast_to_any(value ast.Node) Any {
 			return am
 			// return d.get_map_value(m, key_split[1..].join('.'))
 		}
-		[]ast.Node {
-			a := (value as []ast.Node)
+		[]ast.Value {
+			a := (value as []ast.Value)
 			mut aa := []Any{}
 			for val in a {
 				aa << d.ast_to_any(val)
@@ -191,7 +191,7 @@ fn (d Doc) ast_to_any(value ast.Node) Any {
 }
 
 // get_map_value_as_any returns the value found at `key` in the map `values` as `Any` type.
-fn (d Doc) get_map_value_as_any(values map[string]ast.Node, key string) Any {
+fn (d Doc) get_map_value_as_any(values map[string]ast.Value, key string) Any {
 	key_split := key.split('.')
 	util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, ' getting "${key_split[0]}"')
 	if key_split[0] in values.keys() {
@@ -201,8 +201,8 @@ fn (d Doc) get_map_value_as_any(values map[string]ast.Node, key string) Any {
 			// panic(@MOD + '.' + @STRUCT + '.' + @FN + ' key "$key" does not exist')
 		}
 		// `match` isn't currently very suitable for these types of sum type constructs...
-		if value is map[string]ast.Node {
-			m := (value as map[string]ast.Node)
+		if value is map[string]ast.Value {
+			m := (value as map[string]ast.Value)
 			next_key := key_split[1..].join('.')
 			if next_key == '' {
 				return d.ast_to_any(value)


### PR DESCRIPTION
I made a mistake by renaming what is currently the `ast.Node` type, just before PRing the `toml` module.
TOML is a format for storing key/value pairs in "tables" (maps in V terms) and thus `Key/Node` makes much less sense than `Key/Value`. This PR simply renames Node back to Value (as it originally was).

Luckily `ast.Node` is not a prominent user facing type so hopefully this doesn't cause much havok :grimacing: 