### PR TITLE
gg: expose sapp_desc.swap_interval via gg.Config

### DIFF
--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -198,6 +198,7 @@ pub fn new_context(cfg Config) &Context {
 		enable_dragndrop: cfg.enable_dragndrop
 		max_dropped_files: cfg.max_dropped_files
 		max_dropped_file_path_length: cfg.max_dropped_file_path_length
+		swap_interval: cfg.swap_interval
 	}
 	g.window = window
 	return g

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -63,9 +63,10 @@ pub:
 	resized_fn FNEvent   = voidptr(0)
 	scroll_fn  FNEvent   = voidptr(0)
 	// wait_events       bool // set this to true for UIs, to save power
-	fullscreen   bool
-	scale        f32 = 1.0
-	sample_count int
+	fullscreen    bool
+	scale         f32 = 1.0
+	sample_count  int
+	swap_interval int = 1 // 1 = 60fps, 2 = 30fps etc. The preferred swap interval (ignored on some platforms)
 	// ved needs this
 	// init_text bool
 	font_path             string


### PR DESCRIPTION
This PR allows the user to set the `swap_interval` of Sokol via `gg.Config` thus allowing users to run rendering at lower fps than the default 60. Higher `swap_interval` values = lower FPS. So as an example `swap_interval = 2` will result in a refresh rate at 30fps.

Also please note that currently the fps can't be changed dynamically at runtime nor can it be set higher than 60fps due to how Sokol implement it currently.

I have visually checked that a few `gg` examples still run at 60fps as default after this change.