### PR TITLE
toml: correct documentation

### DIFF
--- a/vlib/toml/any.v
+++ b/vlib/toml/any.v
@@ -5,7 +5,7 @@ module toml
 
 import time
 
-// Pretty much all json2 types plus time.Time
+// Pretty much all the same builtin types as the `json2.Any` type plus `time.Time`
 pub type Any = Null
 	| []Any
 	| bool

--- a/vlib/toml/ast/types.v
+++ b/vlib/toml/ast/types.v
@@ -58,12 +58,13 @@ pub fn (v Value) to_json() string {
 // found in a TOML document.
 pub type DateTimeType = Date | DateTime | Time
 
+// str returns the `string` representation of the `DateTimeType` type.
 pub fn (dtt DateTimeType) str() string {
 	return dtt.text
 }
 
 // value queries a value from the map.
-// `key` should be in "dotted" form e.g.: `"a.b.c.d"`
+// `key` should be in "dotted" form (`a.b.c`).
 pub fn (v map[string]Value) value(key string) &Value {
 	null := &Value(Null{})
 	key_split := key.split('.')
@@ -88,7 +89,7 @@ pub fn (v map[string]Value) value(key string) &Value {
 	// TODO return error(@MOD + '.' + @STRUCT + '.' + @FN + ' key "$key" does not exist')
 }
 
-// value queries a value from the map.
+// exists returns true if the "dotted" `key` path exists in the map.
 pub fn (v map[string]Value) exists(key string) bool {
 	key_split := key.split('.')
 	if key_split[0] in v.keys() {
@@ -107,12 +108,14 @@ pub fn (v map[string]Value) exists(key string) bool {
 	return false
 }
 
+// Comment is the data representation of a TOML comment (`# This is a comment`).
 pub struct Comment {
 pub:
 	text string
 	pos  token.Position
 }
 
+// str returns the `string` representation of the `Comment` type.
 pub fn (c Comment) str() string {
 	mut s := typeof(c).name + '{\n'
 	s += '  text:  \'$c.text\'\n'
@@ -128,16 +131,20 @@ pub:
 	pos  token.Position
 }
 
+// str returns the `string` representation of the `Null` type
 pub fn (n Null) str() string {
 	return n.text
 }
 
+// Quoted is the data representation of a TOML quoted type (`"quoted-key" = "I'm a quoted value"`).
+// Quoted types can appear both as keys and values in TOML documents.
 pub struct Quoted {
 pub:
 	text string
 	pos  token.Position
 }
 
+// str returns the `string` representation of the `Quoted` type.
 pub fn (q Quoted) str() string {
 	mut str := typeof(q).name + '{\n'
 	str += '  text:  \'$q.text\'\n'
@@ -146,12 +153,16 @@ pub fn (q Quoted) str() string {
 	return str
 }
 
+// Bare is the data representation of a TOML bare type (`bare_key = ...`).
+// Bare types can appear only as keys in TOML documents. Otherwise they take the
+// form of Bool or Numbers.
 pub struct Bare {
 pub:
 	text string
 	pos  token.Position
 }
 
+// str returns the `string` representation of the `Bare` type.
 pub fn (b Bare) str() string {
 	mut str := typeof(b).name + '{\n'
 	str += '  text:  \'$b.text\'\n'
@@ -160,12 +171,16 @@ pub fn (b Bare) str() string {
 	return str
 }
 
+// Bool is the data representation of a TOML boolean type (`... = true`).
+// Bool types can appear only as values in TOML documents. Keys named `true` or `false`
+// are considered as Bare types.
 pub struct Bool {
 pub:
 	text string
 	pos  token.Position
 }
 
+// str returns the `string` representation of the `Bool` type.
 pub fn (b Bool) str() string {
 	mut str := typeof(b).name + '{\n'
 	str += '  text:  \'$b.text\'\n'
@@ -174,12 +189,16 @@ pub fn (b Bool) str() string {
 	return str
 }
 
+// Number is the data representation of a TOML number type (`25 = 5e2`).
+// Number types can appear both as keys and values in TOML documents.
+// Number can be integers, floats, infinite, NaN - they can have exponents (`5e2`) and be sign prefixed (`+2`).
 pub struct Number {
 pub:
 	text string
 	pos  token.Position
 }
 
+// str returns the `string` representation of the `Number` type.
 pub fn (n Number) str() string {
 	mut str := typeof(n).name + '{\n'
 	str += '  text:  \'$n.text\'\n'
@@ -188,12 +207,16 @@ pub fn (n Number) str() string {
 	return str
 }
 
+// Date is the data representation of a TOML date type (`YYYY-MM-DD`).
+// Date types can appear both as keys and values in TOML documents.
+// Keys named like dates e.g. `1980-12-29` are considered Bare key types.
 pub struct Date {
 pub:
 	text string
 	pos  token.Position
 }
 
+// str returns the `string` representation of the `Date` type.
 pub fn (d Date) str() string {
 	mut str := typeof(d).name + '{\n'
 	str += '  text:  \'$d.text\'\n'
@@ -202,6 +225,8 @@ pub fn (d Date) str() string {
 	return str
 }
 
+// Time is the data representation of a TOML time type (`HH:MM:SS.milli`).
+// Time types can appear only as values in TOML documents.
 pub struct Time {
 pub:
 	text   string
@@ -209,6 +234,7 @@ pub:
 	pos    token.Position
 }
 
+// str returns the `string` representation of the `Time` type.
 pub fn (t Time) str() string {
 	mut str := typeof(t).name + '{\n'
 	str += '  text:  \'$t.text\'\n'
@@ -218,6 +244,8 @@ pub fn (t Time) str() string {
 	return str
 }
 
+// DateTime is the data representation of a TOML date-time type (`YYYY-MM-DDTHH:MM:SS.milli`).
+// DateTime types can appear only as values in TOML documents.
 pub struct DateTime {
 pub:
 	text string
@@ -226,6 +254,7 @@ pub:
 	time Time
 }
 
+// str returns the `string` representation of the `DateTime` type.
 pub fn (dt DateTime) str() string {
 	mut str := typeof(dt).name + '{\n'
 	str += '  text:  \'$dt.text\'\n'
@@ -236,11 +265,13 @@ pub fn (dt DateTime) str() string {
 	return str
 }
 
+// EOF is the data representation of the end of the TOML document.
 pub struct EOF {
 pub:
 	pos token.Position
 }
 
+// str returns the `string` representation of the `EOF` type.
 pub fn (e EOF) str() string {
 	mut str := typeof(e).name + '{\n'
 	str += '  pos:  $e.pos\n'

--- a/vlib/toml/checker/checker.v
+++ b/vlib/toml/checker/checker.v
@@ -14,6 +14,8 @@ pub struct Checker {
 	scanner &scanner.Scanner
 }
 
+// check checks the `ast.Value` and all it's children
+// for common errors.
 pub fn (c Checker) check(n &ast.Value) ? {
 	walker.walk(c, n) ?
 }

--- a/vlib/toml/input/input.v
+++ b/vlib/toml/input/input.v
@@ -11,6 +11,8 @@ pub:
 	file_path string // '/path/to/file.toml'
 }
 
+// validate returns an optional error if more than one of the fields
+// in `Config` has a non-default value (empty string).
 pub fn (c Config) validate() ? {
 	if c.file_path != '' && c.text != '' {
 		error(@MOD + '.' + @FN +

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -67,9 +67,9 @@ pub fn parse_text(text string) ?Doc {
 	}
 }
 
-// parse parses the TOML document provided in `input`.
-// parse automatically try to determine if the type of `input` is a file or text.
-// For explicit parsing of input see `parse_file` or `parse_text`.
+// parse parses the TOML document provided in `toml`.
+// parse automatically try to determine if the type of `toml` is a file or text.
+// For explicit parsing of input types see `parse_file` or `parse_text`.
 pub fn parse(toml string) ?Doc {
 	mut input_config := input.Config{}
 	if !toml.contains('\n') && os.is_file(toml) {
@@ -95,7 +95,7 @@ pub fn parse(toml string) ?Doc {
 	}
 }
 
-// to_json returns a compact json string of the complete document
+// to_json returns a compact json string of the complete document.
 pub fn (d Doc) to_json() string {
 	return d.ast.to_json()
 }
@@ -119,7 +119,7 @@ fn (d Doc) ast_to_any(value ast.Value) Any {
 				return Any(Null{})
 				// TODO decide this
 				// panic(@MOD + '.' + @STRUCT + '.' + @FN +
-				//	' failed converting "$date_str" to iso8601: $err')
+				//	' failed converting "$date_str" to rfc3339: $err')
 			}
 		} else if value is ast.Time {
 			time_str := (value as ast.Time).text


### PR DESCRIPTION
A few documentation fixes and corrections for the `toml` module