### PR TITLE
Str_int: float memory leak fix

### DIFF
--- a/vlib/builtin/string_interpolation.v
+++ b/vlib/builtin/string_interpolation.v
@@ -383,7 +383,7 @@ fn (data StrIntpData) get_fmt_format(mut sb strings.Builder) {
 			}
 			.si_f64 {
 				$if !nofloat ? {
-					//println("HERE: f64")
+					// println("HERE: f64")
 					if use_default_str {
 						mut f := data.d.d_f64.str()
 						if upper_case {
@@ -394,7 +394,6 @@ fn (data StrIntpData) get_fmt_format(mut sb strings.Builder) {
 						sb.write_string(f)
 						f.free()
 					} else {
-						//println("NO Default str!")
 						if data.d.d_f64 < 0 {
 							bf.positive = false
 						}

--- a/vlib/builtin/string_interpolation.v
+++ b/vlib/builtin/string_interpolation.v
@@ -383,7 +383,7 @@ fn (data StrIntpData) get_fmt_format(mut sb strings.Builder) {
 			}
 			.si_f64 {
 				$if !nofloat ? {
-					// println("HERE: f64")
+					//println("HERE: f64")
 					if use_default_str {
 						mut f := data.d.d_f64.str()
 						if upper_case {
@@ -394,6 +394,7 @@ fn (data StrIntpData) get_fmt_format(mut sb strings.Builder) {
 						sb.write_string(f)
 						f.free()
 					} else {
+						//println("NO Default str!")
 						if data.d.d_f64 < 0 {
 							bf.positive = false
 						}

--- a/vlib/strconv/format_mem.c.v
+++ b/vlib/strconv/format_mem.c.v
@@ -299,16 +299,11 @@ pub fn f64_to_str_lnd1(f f64, dec_digit int) string {
 // strings.Builder version of format_fl
 [manualfree]
 pub fn format_fl(f f64, p BF_param) string {
-	unsafe {
-		mut s := ''
-		// mut fs := "1.2343"
-		mut fs := f64_to_str_lnd1(if f >= 0.0 { f } else { -f }, p.len1)
-		// println("Dario")
-		// println(fs)
+	unsafe {		
+		fs := f64_to_str_lnd1(if f >= 0.0 { f } else { -f }, p.len1)
 
 		// error!!
 		if fs[0] == `[` {
-			s.free()
 			return fs
 		}
 
@@ -317,59 +312,64 @@ pub fn format_fl(f f64, p BF_param) string {
 			fs = remove_tail_zeros(fs)
 			tmp.free()
 		}
-		mut res := strings.new_builder(if p.len0 > fs.len { p.len0 } else { fs.len })
+
+		mut buf := [64]u8{} // write temp float buffer in stack
+		mut out := [64]u8{} // out buffer
+		mut buf_i := 0 // index temporary string
+		mut out_i := 0 // index output string
 
 		mut sign_len_diff := 0
 		if p.pad_ch == `0` {
 			if p.positive {
 				if p.sign_flag {
-					res.write_b(`+`)
+					out[out_i] = `+`
+					out_i++
 					sign_len_diff = -1
 				}
 			} else {
-				res.write_b(`-`)
+				out[out_i] = `-`
+				out_i++
 				sign_len_diff = -1
 			}
-			tmp := s
-			s = fs.clone()
-			tmp.free()
 		} else {
 			if p.positive {
 				if p.sign_flag {
-					tmp := s
-					s = '+' + fs
-					tmp.free()
-				} else {
-					tmp := s
-					s = fs.clone()
-					tmp.free()
-				}
+					buf[buf_i] = `+`
+					buf_i++
+				} 
 			} else {
-				tmp := s
-				s = '-' + fs
-				tmp.free()
+				buf[buf_i] = `-`
+				buf_i++
+				
 			}
 		}
+		// copy the float
+		vmemcpy(&buf[buf_i], fs.str, fs.len)
+		buf_i += fs.len
 
-		dif := p.len0 - s.len + sign_len_diff
-
+		// make the padding if needed
+		dif := p.len0 - buf_i + sign_len_diff
 		if p.allign == .right {
 			for i1 := 0; i1 < dif; i1++ {
-				res.write_b(p.pad_ch)
+				out[out_i] = p.pad_ch
+				out_i++
 			}
 		}
-		res.write_string(s)
+		vmemcpy(&out[out_i], &buf[0], buf_i)
+		out_i += buf_i
 		if p.allign == .left {
 			for i1 := 0; i1 < dif; i1++ {
-				res.write_b(p.pad_ch)
+				out[out_i] = p.pad_ch
+				out_i++
 			}
 		}
+		out[out_i] = 0
 
-		s.free()
-		fs.free()
-		tmp_res := res.str()
-		res.free()
-		return tmp_res
+		// return and free
+		tmp := fs
+		fs = tos_clone(&out[0])
+		tmp.free()
+		return fs
 	}
 }
 

--- a/vlib/strconv/format_mem.c.v
+++ b/vlib/strconv/format_mem.c.v
@@ -37,7 +37,7 @@ pub fn format_str_sb(s string, p BF_param, mut sb strings.Builder) {
 const (
 	max_size_f64_char = 32 // the f64 max representation is -36,028,797,018,963,968e1023, 21 chars, 32 is faster for the memory manger
 	// digit pairs in reverse order
-	digit_pairs = '00102030405060708090011121314151617181910212223242526272829203132333435363738393041424344454647484940515253545556575859506162636465666768696071727374757677787970818283848586878889809192939495969798999'
+	digit_pairs       = '00102030405060708090011121314151617181910212223242526272829203132333435363738393041424344454647484940515253545556575859506162636465666768696071727374757677787970818283848586878889809192939495969798999'
 )
 
 // format_dec_sb format a u64
@@ -300,7 +300,7 @@ pub fn f64_to_str_lnd1(f f64, dec_digit int) string {
 // strings.Builder version of format_fl
 [direct_array_access; manualfree]
 pub fn format_fl(f f64, p BF_param) string {
-	unsafe {		
+	unsafe {
 		mut fs := f64_to_str_lnd1(if f >= 0.0 { f } else { -f }, p.len1)
 
 		// error!!
@@ -314,8 +314,8 @@ pub fn format_fl(f f64, p BF_param) string {
 			tmp.free()
 		}
 
-		mut buf := [max_size_f64_char]u8{} // write temp float buffer in stack
-		mut out := [max_size_f64_char]u8{} // out buffer
+		mut buf := [strconv.max_size_f64_char]u8{} // write temp float buffer in stack
+		mut out := [strconv.max_size_f64_char]u8{} // out buffer
 		mut buf_i := 0 // index temporary string
 		mut out_i := 0 // index output string
 
@@ -337,11 +337,10 @@ pub fn format_fl(f f64, p BF_param) string {
 				if p.sign_flag {
 					buf[buf_i] = `+`
 					buf_i++
-				} 
+				}
 			} else {
 				buf[buf_i] = `-`
 				buf_i++
-				
 			}
 		}
 
@@ -385,8 +384,8 @@ pub fn format_es(f f64, p BF_param) string {
 			tmp.free()
 		}
 
-		mut buf := [max_size_f64_char]u8{} // write temp float buffer in stack
-		mut out := [max_size_f64_char]u8{} // out buffer
+		mut buf := [strconv.max_size_f64_char]u8{} // write temp float buffer in stack
+		mut out := [strconv.max_size_f64_char]u8{} // out buffer
 		mut buf_i := 0 // index temporary string
 		mut out_i := 0 // index output string
 
@@ -408,11 +407,10 @@ pub fn format_es(f f64, p BF_param) string {
 				if p.sign_flag {
 					buf[buf_i] = `+`
 					buf_i++
-				} 
+				}
 			} else {
 				buf[buf_i] = `-`
 				buf_i++
-				
 			}
 		}
 

--- a/vlib/strconv/format_mem.c.v
+++ b/vlib/strconv/format_mem.c.v
@@ -35,6 +35,7 @@ pub fn format_str_sb(s string, p BF_param, mut sb strings.Builder) {
 }
 
 const (
+	max_size_f64_char = 32 // the f64 max representation is -36,028,797,018,963,968e1023, 21 chars, 32 is faster for the memory manger
 	// digit pairs in reverse order
 	digit_pairs = '00102030405060708090011121314151617181910212223242526272829203132333435363738393041424344454647484940515253545556575859506162636465666768696071727374757677787970818283848586878889809192939495969798999'
 )
@@ -313,8 +314,8 @@ pub fn format_fl(f f64, p BF_param) string {
 			tmp.free()
 		}
 
-		mut buf := [64]u8{} // write temp float buffer in stack
-		mut out := [64]u8{} // out buffer
+		mut buf := [max_size_f64_char]u8{} // write temp float buffer in stack
+		mut out := [max_size_f64_char]u8{} // out buffer
 		mut buf_i := 0 // index temporary string
 		mut out_i := 0 // index output string
 
@@ -384,8 +385,8 @@ pub fn format_es(f f64, p BF_param) string {
 			tmp.free()
 		}
 
-		mut buf := [64]u8{} // write temp float buffer in stack
-		mut out := [64]u8{} // out buffer
+		mut buf := [max_size_f64_char]u8{} // write temp float buffer in stack
+		mut out := [max_size_f64_char]u8{} // out buffer
 		mut buf_i := 0 // index temporary string
 		mut out_i := 0 // index output string
 


### PR DESCRIPTION
**What's inside**
This PR fix the memory leaks with `-autofree` of the floating point string interpolation functions and increase the elaboration speed for the floats of the 9%.
- Rewritten the functions `format_fl`,`format_es` without memory allocations
- Some minor fixes.