### PR TITLE
orm: fix other int types

### DIFF
--- a/examples/database/orm.v
+++ b/examples/database/orm.v
@@ -12,7 +12,7 @@ struct Module {
 
 struct User {
 	id             int    [primary; sql: serial]
-	age            int    [unique: 'user']
+	age            u32    [unique: 'user']
 	name           string [sql: 'username'; unique]
 	is_customer    bool   [sql: 'abc'; unique: 'user']
 	skipped_string string [skip]

--- a/vlib/orm/orm_test.v
+++ b/vlib/orm/orm_test.v
@@ -8,6 +8,7 @@ struct Module {
 	id           int    [primary; sql: serial]
 	name         string
 	nr_downloads int
+	test_id      u64
 	user         User
 }
 
@@ -33,7 +34,7 @@ fn test_orm_sqlite() {
 	db := sqlite.connect(':memory:') or { panic(err) }
 	db.exec('drop table if exists User')
 	sql db {
-		create table User
+		create table Module
 	}
 
 	name := 'Peter'
@@ -313,4 +314,20 @@ fn test_orm_sqlite() {
 	}
 
 	assert data.len == 1
+
+	mod := Module{}
+
+	sql db {
+		insert mod into Module
+	}
+
+	sql db {
+		update Module set test_id = 11 where id == 1
+	}
+
+	test_id_mod := sql db {
+		select from Module where id == 1
+	}
+
+	assert test_id_mod.test_id == 11
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -8088,7 +8088,8 @@ fn (mut c Checker) sql_stmt_line(mut node ast.SqlStmtLine) ast.Type {
 }
 
 fn (mut c Checker) fetch_and_verify_orm_fields(info ast.Struct, pos token.Position, table_name string) []ast.StructField {
-	fields := info.fields.filter((it.typ in [ast.string_type, ast.int_type, ast.bool_type]
+	fields := info.fields.filter(
+		(it.typ in [ast.string_type, ast.bool_type] || int(it.typ) in ast.number_type_idxs
 		|| c.table.type_symbols[int(it.typ)].kind == .struct_
 		|| (c.table.get_type_symbol(it.typ).kind == .array
 		&& c.table.get_type_symbol(c.table.get_type_symbol(it.typ).array_info().elem_type).kind == .struct_))


### PR DESCRIPTION
This PR fixes the detection of other integer types than int. It was a fault in the checker and is tested in `vlib/orm/orm_test.v`