### PR TITLE
cgen: fix assign map get to blank (fix #11508)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2748,6 +2748,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 				g.expr(val)
 				g.writeln(';}')
 			}
+			g.is_assign_lhs = false
 		} else if assign_stmt.op == .assign
 			&& (is_fixed_array_init || (right_sym.kind == .array_fixed && val is ast.Ident)) {
 			mut v_var := ''

--- a/vlib/v/tests/map_get_assign_blank_test.v
+++ b/vlib/v/tests/map_get_assign_blank_test.v
@@ -1,4 +1,4 @@
-type Abc = string | int
+type Abc = int | string
 
 fn test_map_get_assign_blank() {
 	x := map[string]Abc{}

--- a/vlib/v/tests/map_get_assign_blank_test.v
+++ b/vlib/v/tests/map_get_assign_blank_test.v
@@ -1,0 +1,10 @@
+type Abc = string | int
+
+fn test_map_get_assign_blank() {
+	x := map[string]Abc{}
+	_ := x['nonexisting']
+	if y := x['nonexisting'] {
+		println(y)
+	}
+	assert true
+}


### PR DESCRIPTION
This PR fix assign map get to blank (fix #11508).

- Fix assign map get to blank.
- Add test.

```vlang
type Abc = string | int

fn main() {
	x := map[string]Abc{}
	_ := x['nonexisting']
	if y := x['nonexisting'] {
		println(y)
	}
	assert true
}

PS D:\Test\v\tt1> v run .
.\tt1.v:5:8: warning: `or {}` block required when indexing a map with sum type value
    3 | fn main() {
    4 |     x := map[string]Abc{}
    5 |     _ := x['nonexisting']
      |           ~~~~~~~~~~~~~~~
    6 |     if y := x['nonexisting'] {
    7 |         println(y)
```