### PR TITLE
builtin: move byte methods from rune.v to int.v

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -484,3 +484,27 @@ pub fn (b byte) str_escaped() string {
 	}
 	return str
 }
+
+// Define this on byte as well, so that we can do `s[0].is_capital()`
+pub fn (c byte) is_capital() bool {
+	return c >= `A` && c <= `Z`
+}
+
+pub fn (b []byte) clone() []byte {
+	mut res := []byte{len: b.len}
+	// mut res := make([]byte, {repeat:b.len})
+	for i in 0 .. b.len {
+		res[i] = b[i]
+	}
+	return res
+}
+
+// TODO: remove this once runes are implemented
+pub fn (b []byte) bytestr() string {
+	unsafe {
+		buf := malloc_noscan(b.len + 1)
+		vmemcpy(buf, b.data, b.len)
+		buf[b.len] = 0
+		return tos(buf, b.len)
+	}
+}

--- a/vlib/builtin/rune.v
+++ b/vlib/builtin/rune.v
@@ -39,27 +39,3 @@ pub fn (ra []rune) string() string {
 	unsafe { sb.free() }
 	return res
 }
-
-// Define this on byte as well, so that we can do `s[0].is_capital()`
-pub fn (c byte) is_capital() bool {
-	return c >= `A` && c <= `Z`
-}
-
-pub fn (b []byte) clone() []byte {
-	mut res := []byte{len: b.len}
-	// mut res := make([]byte, {repeat:b.len})
-	for i in 0 .. b.len {
-		res[i] = b[i]
-	}
-	return res
-}
-
-// TODO: remove this once runes are implemented
-pub fn (b []byte) bytestr() string {
-	unsafe {
-		buf := malloc_noscan(b.len + 1)
-		vmemcpy(buf, b.data, b.len)
-		buf[b.len] = 0
-		return tos(buf, b.len)
-	}
-}


### PR DESCRIPTION
This PR moves multiple `byte` methods that were previously located in `rune.v` to `int.v`