### PR TITLE
checker: fix generic array.map with generic callback fn (fix #11989)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2683,7 +2683,7 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 			ast.FnType { arg_sym.info.func.return_type }
 			else { arg_type }
 		}
-		node.return_type = c.table.find_or_register_array(ret_type)
+		node.return_type = c.table.find_or_register_array(c.unwrap_generic(ret_type))
 	} else if method_name == 'filter' {
 		// check fn
 		c.check_map_and_filter(false, elem_typ, node)

--- a/vlib/v/tests/generics_array_map_with_generic_callback_test.v
+++ b/vlib/v/tests/generics_array_map_with_generic_callback_test.v
@@ -1,0 +1,21 @@
+fn test_generics_array_map_with_generic_callback() {
+	mut a := []Sth{}
+	a = arr_generic<Sth>(buggy_cb)
+	println(a)
+	assert a.len == 0
+}
+
+fn arr_generic<T>(cb fn (int) T) []T {
+	return []int{}.map(cb(it))
+}
+
+fn buggy_cb(a int) Sth {
+	return Sth{
+		a: a
+	}
+}
+
+struct Sth {
+	a int
+	b string
+}


### PR DESCRIPTION
This PR fix generic array.map with generic callback fn (fix #11989).

- Fix generic array.map with generic callback fn.
- Add test.

```vlang
fn main() {
	mut a := []Sth{}
	a = arr_generic<Sth>(buggy_cb)
	println(a)
	assert a.len == 0
}

fn arr_generic<T>(cb fn (int) T) []T {
	return []int{}.map(cb(it))
}

fn buggy_cb(a int) Sth {
	return Sth{
		a: a
	}
}

struct Sth {
	a int
	b string
}

PS D:\Test\v\tt1> v run .
[]
```