### PR TITLE
ci: remove vls master branch test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -847,8 +847,6 @@ jobs:
         run: make && sudo ./v symlink
 
       ## vls
-      - name: Clone tree-sitter-v to ~/.vmodules/tree_sitter_v
-        run: git clone --depth 1 https://github.com/nedpals/tree-sitter-v ~/.vmodules/tree_sitter_v
       - name: Clone VLS tree-sitter
         run: git clone --depth 1 --no-single-branch https://github.com/vlang/vls
       - name: Checkout branch tree-sitter
@@ -857,12 +855,6 @@ jobs:
         run: pushd vls; v cmd/vls ; popd
       - name: Build VLS tree-sitter with -prod
         run: pushd vls; v -prod cmd/vls; popd
-      - name: Checkout branch master
-        run: pushd vls; git checkout master; popd
-      - name: Build VLS master
-        run: pushd vls; v cmd/vls ; popd
-      - name: Build VLS master with -prod
-        run: pushd vls; v -prod cmd/vls ; popd
 
       ## vab
       - name: Clone vab


### PR DESCRIPTION
This PR remove vls master branch test and `tree-sitter-v` in ci.yml.