### PR TITLE
toml: add quote details to ast.Quoted

### DIFF
--- a/vlib/toml/ast/types.v
+++ b/vlib/toml/ast/types.v
@@ -143,7 +143,7 @@ pub:
 	text         string
 	pos          token.Position
 	is_multiline bool
-	quote        string
+	quote        byte
 }
 
 // str returns the `string` representation of the `Quoted` type.

--- a/vlib/toml/ast/types.v
+++ b/vlib/toml/ast/types.v
@@ -140,8 +140,10 @@ pub fn (n Null) str() string {
 // Quoted types can appear both as keys and values in TOML documents.
 pub struct Quoted {
 pub:
-	text string
-	pos  token.Position
+	text         string
+	pos          token.Position
+	is_multiline bool
+	quote        string
 }
 
 // str returns the `string` representation of the `Quoted` type.
@@ -149,6 +151,8 @@ pub fn (q Quoted) str() string {
 	mut str := typeof(q).name + '{\n'
 	str += '  text:  \'$q.text\'\n'
 	str += '  pos:  $q.pos\n'
+	str += '  is_multiline:  $q.is_multiline\n'
+	str += '  quote: \'$q.quote\'\n'
 	str += '}'
 	return str
 }

--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -695,15 +695,14 @@ pub fn (mut p Parser) quoted() ast.Quoted {
 	// the scanner is returning the literal *with* single- or double-quotes.
 	mut quote := p.tok.lit[0]
 	is_multiline := p.tok.lit.len >= 6 && p.tok.lit[1] == quote && p.tok.lit[2] == quote
-	mut quote_lit := quote.ascii_str()
+	mut lit := p.tok.lit[1..p.tok.lit.len - 1]
 	if is_multiline {
-		quote_lit += quote_lit + quote_lit
+		lit = p.tok.lit[3..p.tok.lit.len - 3]
 	}
-	mut lit := p.tok.lit[quote_lit.len..p.tok.lit.len - quote_lit.len]
 	return ast.Quoted{
 		text: lit
 		pos: p.tok.position()
-		quote: quote_lit
+		quote: quote
 		is_multiline: is_multiline
 	}
 }

--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -691,9 +691,20 @@ pub fn (mut p Parser) bare() ast.Bare {
 
 // quoted parse and returns an `ast.Quoted` type.
 pub fn (mut p Parser) quoted() ast.Quoted {
+	// To get more info about the quote type and enable better checking,
+	// the scanner is returning the literal *with* single- or double-quotes.
+	mut quote := p.tok.lit[0]
+	is_multiline := p.tok.lit.len >= 6 && p.tok.lit[1] == quote && p.tok.lit[2] == quote
+	mut quote_lit := quote.ascii_str()
+	if is_multiline {
+		quote_lit += quote_lit + quote_lit
+	}
+	mut lit := p.tok.lit[quote_lit.len..p.tok.lit.len - quote_lit.len]
 	return ast.Quoted{
-		text: p.tok.lit
+		text: lit
 		pos: p.tok.position()
+		quote: quote_lit
+		is_multiline: is_multiline
 	}
 }
 


### PR DESCRIPTION
This PR will let the scanner return a quoted literal *with* all the quotes.
Details is then added in the parser to ast.Quoted. This is necessary to be able to give better error messages about invalid strings in the checker.

I have a follow-up PR after this one is merged that will pass a few of the invalid tests in the BurntSushi test suite that I'm chasing to get to zero.