### PR TITLE
builtin: add method `byte()` to string

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -459,6 +459,11 @@ pub fn (s string) f64() f64 {
 	return strconv.atof64(s)
 }
 
+// u8 returns the value of the string as u8 `'1'.u8() == u8(1)`.
+pub fn (s string) byte() u8 {
+	return byte(strconv.common_parse_uint(s, 0, 8, false, false) or { 0 })
+}
+
 // u16 returns the value of the string as u16 `'1'.u16() == u16(1)`.
 pub fn (s string) u16() u16 {
 	return u16(strconv.common_parse_uint(s, 0, 16, false, false) or { 0 })

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -418,6 +418,7 @@ fn test_arr_contains() {
 fn test_to_num() {
 	s := '7'
 	assert s.int() == 7
+	assert s.byte() == 7
 	assert s.u64() == 7
 	f := '71.5 hasdf'
 	// QTODO


### PR DESCRIPTION
This PR adds `byte()` method to string.

There are methods for `u16`, `u32`, &... all other number types already, except for `byte`.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
