### PR TITLE
cgen: fix generated the error C codes of '_ = map[key]' (fix #11999)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2925,6 +2925,8 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 			g.right_is_opt = true
 		}
 		if blank_assign {
+			pre_assign_op := g.assign_op
+			g.assign_op = .decl_assign
 			if is_call {
 				old_is_void_expr_stmt := g.is_void_expr_stmt
 				g.is_void_expr_stmt = true
@@ -2935,6 +2937,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 				g.expr(val)
 				g.writeln(';}')
 			}
+			g.assign_op = pre_assign_op
 			g.is_assign_lhs = false
 		} else if assign_stmt.op == .assign
 			&& (is_fixed_array_init || (right_sym.kind == .array_fixed && val is ast.Ident)) {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2925,8 +2925,9 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 			g.right_is_opt = true
 		}
 		if blank_assign {
-			pre_assign_op := g.assign_op
-			g.assign_op = .decl_assign
+			if val is ast.IndexExpr {
+				g.assign_op = .decl_assign
+			}
 			if is_call {
 				old_is_void_expr_stmt := g.is_void_expr_stmt
 				g.is_void_expr_stmt = true
@@ -2937,7 +2938,6 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 				g.expr(val)
 				g.writeln(';}')
 			}
-			g.assign_op = pre_assign_op
 			g.is_assign_lhs = false
 		} else if assign_stmt.op == .assign
 			&& (is_fixed_array_init || (right_sym.kind == .array_fixed && val is ast.Ident)) {

--- a/vlib/v/tests/map_get_assign_blank_test.v
+++ b/vlib/v/tests/map_get_assign_blank_test.v
@@ -1,8 +1,17 @@
 type Abc = int | string
 
-fn test_map_get_assign_blank() {
+fn test_map_get_decl_assign_blank() {
 	x := map[string]Abc{}
 	_ := x['nonexisting']
+	if y := x['nonexisting'] {
+		println(y)
+	}
+	assert true
+}
+
+fn test_map_get_assign_blank() {
+	x := map[string]Abc{}
+	_ = x['nonexisting']
 	if y := x['nonexisting'] {
 		println(y)
 	}


### PR DESCRIPTION
This PR fix generated the error C codes of '_ = map[key]' (fix #11999).

- Fix generated the error C codes of '_ = map[key]'.
- Add test.

```vlang
type Abc = int | string

fn main() {
	x := map[string]Abc{}
	_ = x['nonexisting']
	if y := x['nonexisting'] {
		println(y)
	}
	assert true
}

PS D:\Test\v\tt1> v run .
.\tt1.v:5:7: warning: `or {}` block required when indexing a map with sum type value
    3 | fn main() {
    4 |     x := map[string]Abc{}
    5 |     _ = x['nonexisting']
      |          ~~~~~~~~~~~~~~~
    6 |     if y := x['nonexisting'] {
    7 |         println(y)
```