### PR TITLE
builtin: add byte.repeat() and rune.repeat()

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -507,3 +507,25 @@ pub fn (b []byte) bytestr() string {
 		return tos(buf, b.len)
 	}
 }
+
+// repeat returns a new string with `count` number of copies of the byte it was called on.
+pub fn (b byte) repeat(count int) string {
+	if count < 0 {
+		panic('byte.repeat: count is negative: $count')
+	} else if count == 0 {
+		return ''
+	} else if count == 1 {
+		return b.ascii_str()
+	}
+	mut ret := unsafe { malloc_noscan(count + 1) }
+	for i in 0 .. count {
+		unsafe{
+			ret[i] = b
+		}
+	}
+	new_len := count
+	unsafe {
+		ret[new_len] = 0
+	}
+	return unsafe { ret.vstring_with_len(new_len) }
+}

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -519,7 +519,7 @@ pub fn (b byte) repeat(count int) string {
 	}
 	mut ret := unsafe { malloc_noscan(count + 1) }
 	for i in 0 .. count {
-		unsafe{
+		unsafe {
 			ret[i] = b
 		}
 	}

--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -239,3 +239,10 @@ fn test_int_to_hex() {
 	assert i64(-1).hex() == 'ffffffffffffffff'
 	assert u64(18446744073709551615).hex() == 'ffffffffffffffff'
 }
+
+fn test_repeat() {
+	b := byte(`V`)
+	assert b.repeat(5) == 'VVVVV'
+	assert b.repeat(1) == b.ascii_str()
+	assert b.repeat(0) == ''
+}

--- a/vlib/builtin/rune.v
+++ b/vlib/builtin/rune.v
@@ -39,3 +39,17 @@ pub fn (ra []rune) string() string {
 	unsafe { sb.free() }
 	return res
 }
+
+// repeat returns a new string with `count` number of copies of the rune it was called on.
+pub fn (c rune) repeat(count int) string {
+	if count < 0 {
+		panic('rune.repeat: count is negative: $count')
+	} else if count == 0 {
+		return ''
+	} else if count == 1 {
+		return c.str()
+	}
+	mut buffer := [5]byte{}
+	res := unsafe { utf32_to_str_no_malloc(u32(c), &buffer[0]) }
+	return res.repeat(count)
+}

--- a/vlib/builtin/rune_test.v
+++ b/vlib/builtin/rune_test.v
@@ -1,0 +1,13 @@
+fn test_repeat() {
+	r1 := `V`
+	r2 := `👋`
+
+	assert r1.repeat(5) == 'VVVVV'
+	assert r2.repeat(5) == '👋👋👋👋👋'
+
+	assert r1.repeat(1) == r1.str()
+	assert r2.repeat(1) == r2.str()
+
+	assert r1.repeat(0) == ''
+	assert r2.repeat(0) == ''
+}


### PR DESCRIPTION
This pull request adds the `byte.repeat()` and `rune.repeat()` methods analogous to the `string.repeat()` method.
Thanks to @spytheman for the main `rune.repeat()` implementation.
Both tests pass on my machine.
(This is my second PR for this because I didn't manage to resolve the merge conflicts in the first one.)