### PR TITLE
cgen: fix fn mut args with interface type (fix #12002)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2292,13 +2292,13 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 		g.writeln('}, sizeof($shared_styp))')
 		return
 	}
-	if got_is_ptr && !expected_is_ptr && neither_void
-		&& exp_sym.kind !in [.interface_, .placeholder] && expr !is ast.InfixExpr {
+	if got_is_ptr && !expected_is_ptr && neither_void && exp_sym.kind != .placeholder
+		&& expr !is ast.InfixExpr {
 		got_deref_type := got_type.deref()
 		deref_sym := g.table.get_type_symbol(got_deref_type)
 		deref_will_match := expected_type in [got_type, got_deref_type, deref_sym.parent_idx]
 		got_is_opt := got_type.has_flag(.optional)
-		if deref_will_match || got_is_opt {
+		if deref_will_match || got_is_opt || expr.is_auto_deref_var() {
 			g.write('*')
 		}
 	}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1306,10 +1306,6 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 					g.write('/*af arg*/' + name)
 				}
 			} else {
-				if node.concrete_types.len > 0 && arg.expr.is_auto_deref_var() && !arg.is_mut
-					&& !expected_types[i].is_ptr() {
-					g.write('*')
-				}
 				g.ref_or_deref_arg(arg, expected_types[i], node.language)
 			}
 		} else {

--- a/vlib/v/gen/c/infix_expr.v
+++ b/vlib/v/gen/c/infix_expr.v
@@ -580,9 +580,6 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 			if needs_clone {
 				g.write('string_clone(')
 			}
-			if right.unaliased_sym.kind == .interface_ && node.right.is_auto_deref_var() {
-				g.write('*')
-			}
 			g.expr_with_cast(node.right, node.right_type, array_info.elem_type)
 			if needs_clone {
 				g.write(')')

--- a/vlib/v/tests/fn_mut_args_test.v
+++ b/vlib/v/tests/fn_mut_args_test.v
@@ -67,3 +67,23 @@ fn test_fn_mut_args_of_interface() {
 	println(x.children[0].data)
 	assert x.children[0].data == 123
 }
+
+struct LinuxFile {
+}
+
+interface File {
+}
+
+fn b(parent File) {
+	println(parent)
+	assert '$parent' == 'File(LinuxFile{})'
+}
+
+fn a(mut parent File) {
+	b(parent)
+}
+
+fn test_fn_mut_args_of_interface2() {
+	mut file := LinuxFile{}
+	a(mut file)
+}


### PR DESCRIPTION
This PR fix fn mut args with interface type (fix #12002).

- Fix fn mut args with interface type.
- Add test.

```vlang
struct LinuxFile {
}

interface File {
}

fn b(parent File) {
	println(parent)
	assert '$parent' == 'File(LinuxFile{})'
}

fn a(mut parent File) {
	b(parent)
}

fn main() {
	mut file := LinuxFile{}
	a(mut file)
}

PS D:\Test\v\tt1> v run .
File(LinuxFile{})
```