### PR TITLE
ast: fix fmt 'bytestr' to '&byte' (fix #12004)

### DIFF
--- a/cmd/tools/vtest-cleancode.v
+++ b/cmd/tools/vtest-cleancode.v
@@ -31,8 +31,6 @@ const (
 		'vlib/sqlite/orm.v' /* mut c &int -> mut c int */,
 		'vlib/builtin/int_test.v' /* special number formatting that should be tested */,
 		// TODOs and unfixed vfmt bugs
-		'vlib/builtin/int.v' /* TODO byteptr: vfmt converts `pub fn (nn byteptr) str() string {` to `nn &byte` and that conflicts with `nn byte` */,
-		'vlib/builtin/string_charptr_byteptr_helpers.v' /* TODO byteptr: a temporary shim to ease the byteptr=>&byte transition */,
 		'vlib/v/tests/interop_test.v', /* bad comment formatting */
 		'vlib/v/gen/js/tests/js.v', /* local `hello` fn, gets replaced with module `hello` aliased as `hl` */
 	]

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -313,7 +313,6 @@ pub fn (nn i8) hex() string {
 		return '00'
 	}
 	return u64_to_hex(u64(nn), 2)
-	//return byte(nn).hex()
 }
 
 // hex returns the value of the `u16` as a hexadecimal `string`.

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -948,17 +948,9 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 	// *clearly*, and that when a new kind is added, it should also be handled
 	// explicitly.
 	match sym.kind {
-		.int_literal, .float_literal {
-			res = sym.name
-		}
-		.byteptr {
-			res = '&byte'
-		}
-		.charptr {
-			res = '&char'
-		}
+		.int_literal, .float_literal {}
 		.i8, .i16, .int, .i64, .isize, .byte, .u8, .u16, .u32, .u64, .usize, .f32, .f64, .char,
-		.rune, .string, .bool, .none_, .voidptr {
+		.rune, .string, .bool, .none_, .voidptr, .byteptr, .charptr {
 			// primitive types
 			res = sym.kind.str()
 		}


### PR DESCRIPTION
This PR fix fmt 'bytestr' to '&byte' (fix #12004).

- Fix fmt 'bytestr' to '&byte'.
- Format `vlib/builtin/int.v`.
- Remove `vlib/builtin/int.v` and `vlib/builtin/string_charptr_byteptr_helpers.v` from vtest-cleancode exceaption list.