### PR TITLE
checker: show errors for index calls to values which are not functions

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2811,19 +2811,29 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr) ast.Type {
 			elem_typ := c.table.get_type_symbol(info.elem_type)
 			if elem_typ.info is ast.FnType {
 				return elem_typ.info.func.return_type
+			} else {
+				c.error('cannot call the element of the array, it is not a function',
+					node.pos)
 			}
 		} else if sym.kind == .map {
 			info := sym.info as ast.Map
 			value_typ := c.table.get_type_symbol(info.value_type)
 			if value_typ.info is ast.FnType {
 				return value_typ.info.func.return_type
+			} else {
+				c.error('cannot call the value of the map, it is not a function', node.pos)
 			}
 		} else if sym.kind == .array_fixed {
 			info := sym.info as ast.ArrayFixed
 			elem_typ := c.table.get_type_symbol(info.elem_type)
 			if elem_typ.info is ast.FnType {
 				return elem_typ.info.func.return_type
+			} else {
+				c.error('cannot call the element of the array, it is not a function',
+					node.pos)
 			}
+		} else {
+			// TODO: assert? is this possible?
 		}
 		found = true
 		return ast.string_type

--- a/vlib/v/checker/tests/index_invalid_call.out
+++ b/vlib/v/checker/tests/index_invalid_call.out
@@ -1,0 +1,13 @@
+vlib/v/checker/tests/index_invalid_call.vv:4:20: error: cannot call the value of the map, it is not a function
+    2 | fn main() {
+    3 |     m := map[string]string
+    4 |     eprintln(m['abc']())
+      |                       ^
+    5 |     array := ["", "1"]
+    6 |     array[0]()
+vlib/v/checker/tests/index_invalid_call.vv:6:11: error: cannot call the element of the array, it is not a function
+    4 |     eprintln(m['abc']())
+    5 |     array := ["", "1"]
+    6 |     array[0]()
+      |              ^
+    7 | }

--- a/vlib/v/checker/tests/index_invalid_call.vv
+++ b/vlib/v/checker/tests/index_invalid_call.vv
@@ -1,0 +1,7 @@
+// fixes https://github.com/vlang/v/issues/11539 , copied example map test code from https://github.com/spytheman
+fn main() {
+	m := map[string]string
+	eprintln(m['abc']())
+	array := ["", "1"]
+	array[0]()
+}


### PR DESCRIPTION
fixes #11539 https://github.com/vlang/v/issues/11539

show checker errors instead of getting codegen errors

logic structure was already there, i just had to add the errors

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
