### PR TITLE
cgen: Fix closure code gen with if statement in definition

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -425,20 +425,22 @@ fn (mut g Gen) gen_anon_fn(mut node ast.AnonFn) {
 		return
 	}
 	// it may be possible to optimize `memdup` out if the closure never leaves current scope
-	ctx_var := g.new_tmp_var()
+	// ctx_var := g.new_tmp_var()
 	cur_line := g.go_before_stmt(0)
 	ctx_struct := closure_ctx_struct(node.decl)
-	g.writeln('$ctx_struct* $ctx_var = ($ctx_struct*) memdup(&($ctx_struct){')
+
+	// TODO in case of an assignment, this should only call "__closure_set_data" and "__closure_set_function" (and free the former data)
+	g.write('__closure_create($node.decl.name, ${node.decl.params.len + 1}, ')
+	g.writeln('($ctx_struct*) memdup(&($ctx_struct){')
 	g.indent++
 	for var in node.inherited_vars {
 		g.writeln('.$var.name = $var.name,')
 	}
 	g.indent--
-	g.writeln('}, sizeof($ctx_struct));')
+	g.writeln('}, sizeof($ctx_struct)));')
 	g.empty_line = false
 	g.write(cur_line)
-	// TODO in case of an assignment, this should only call "__closure_set_data" and "__closure_set_function" (and free the former data)
-	g.write('__closure_create($node.decl.name, ${node.decl.params.len + 1}, $ctx_var)')
+	//g.write('__closure_create($node.decl.name, ${node.decl.params.len + 1}, $ctx_var)')
 }
 
 fn (mut g Gen) gen_anon_fn_decl(mut node ast.AnonFn) {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -426,7 +426,7 @@ fn (mut g Gen) gen_anon_fn(mut node ast.AnonFn) {
 	}
 	// it may be possible to optimize `memdup` out if the closure never leaves current scope
 	// ctx_var := g.new_tmp_var()
-	cur_line := g.go_before_stmt(0)
+	// cur_line := g.go_before_stmt(0)
 	ctx_struct := closure_ctx_struct(node.decl)
 
 	// TODO in case of an assignment, this should only call "__closure_set_data" and "__closure_set_function" (and free the former data)
@@ -437,9 +437,9 @@ fn (mut g Gen) gen_anon_fn(mut node ast.AnonFn) {
 		g.writeln('.$var.name = $var.name,')
 	}
 	g.indent--
-	g.writeln('}, sizeof($ctx_struct)));')
+	g.write('}, sizeof($ctx_struct)))')
 	g.empty_line = false
-	g.write(cur_line)
+	// g.write(cur_line)
 	//g.write('__closure_create($node.decl.name, ${node.decl.params.len + 1}, $ctx_var)')
 }
 

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -425,10 +425,7 @@ fn (mut g Gen) gen_anon_fn(mut node ast.AnonFn) {
 		return
 	}
 	// it may be possible to optimize `memdup` out if the closure never leaves current scope
-	// ctx_var := g.new_tmp_var()
-	// cur_line := g.go_before_stmt(0)
 	ctx_struct := closure_ctx_struct(node.decl)
-
 	// TODO in case of an assignment, this should only call "__closure_set_data" and "__closure_set_function" (and free the former data)
 	g.write('__closure_create($node.decl.name, ${node.decl.params.len + 1}, ')
 	g.writeln('($ctx_struct*) memdup(&($ctx_struct){')
@@ -439,8 +436,6 @@ fn (mut g Gen) gen_anon_fn(mut node ast.AnonFn) {
 	g.indent--
 	g.write('}, sizeof($ctx_struct)))')
 	g.empty_line = false
-	// g.write(cur_line)
-	//g.write('__closure_create($node.decl.name, ${node.decl.params.len + 1}, $ctx_var)')
 }
 
 fn (mut g Gen) gen_anon_fn_decl(mut node ast.AnonFn) {

--- a/vlib/v/tests/closure_test.v
+++ b/vlib/v/tests/closure_test.v
@@ -155,11 +155,14 @@ fn test_go_call_closure() {
 fn test_closures_with_ifstmt() {
 	a := 1
 	f := fn [a] (x int) int {
-		if a > x { return 1 }
-		else { return -1 }
+		if a > x { return 1
+		 } else { return -1
+		 }
 	}
 	g := fn [a] () int {
-		if true { return 1 }
+		if true {
+			return 1
+		}
 		return 0
 	}
 	assert f(0) == 1

--- a/vlib/v/tests/closure_test.v
+++ b/vlib/v/tests/closure_test.v
@@ -151,3 +151,16 @@ fn test_go_call_closure() {
 	assert <-ch == 15
 }
 */
+
+fn test_closures_with_ifstmt() {
+	a := 1
+	f := fn [a] (x int) int {
+		if a > x { return 1 }
+		else { return -1 }
+	}
+	g := fn [a] () int {
+		return 1
+	}
+	assert f(0) == 1
+	assert g() == 1
+}

--- a/vlib/v/tests/closure_test.v
+++ b/vlib/v/tests/closure_test.v
@@ -159,7 +159,8 @@ fn test_closures_with_ifstmt() {
 		else { return -1 }
 	}
 	g := fn [a] () int {
-		return 1
+		if true { return 1 }
+		return 0
 	}
 	assert f(0) == 1
 	assert g() == 1


### PR DESCRIPTION
Fixes #11244
Not sure how else to describe this bug, but it should be fixed now (for other statements as well).
Used examples from issue for one of the tests.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
