### PR TITLE
fmt: fix removal of selective imported type used in map

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -245,6 +245,12 @@ pub fn (mut f Fmt) short_module(name string) string {
 
 pub fn (mut f Fmt) mark_types_import_as_used(typ ast.Type) {
 	sym := f.table.get_type_symbol(typ)
+	if sym.info is ast.Map {
+		map_info := sym.map_info()
+		f.mark_types_import_as_used(map_info.key_type)
+		f.mark_types_import_as_used(map_info.value_type)
+		return
+	}
 	name := sym.name.split('<')[0] // take `Type` from `Type<T>`
 	f.mark_import_as_used(name)
 }

--- a/vlib/v/fmt/tests/import_selective_expected.vv
+++ b/vlib/v/fmt/tests/import_selective_expected.vv
@@ -18,6 +18,8 @@ import mod {
 	RightOfIs,
 	StructEmbed,
 	StructField,
+	StructMapFieldKey,
+	StructMapFieldValue,
 	StructMethodArg,
 	StructMethodArgGeneric,
 	StructMethodRet,
@@ -29,6 +31,7 @@ struct Struct {
 	StructEmbed
 	v   StructField
 	ref &StructRefField
+	map map[StructMapFieldKey]StructMapFieldValue
 }
 
 fn (s Struct) method(v StructMethodArg) StructMethodRet {

--- a/vlib/v/fmt/tests/import_selective_input.vv
+++ b/vlib/v/fmt/tests/import_selective_input.vv
@@ -10,6 +10,7 @@ import os {
 import mod {
 	Unused,
 	StructEmbed, StructField, StructRefField
+	StructMapFieldKey, StructMapFieldValue,
 	StructMethodArg,
 	StructMethodArgGeneric,
 	StructMethodRet,
@@ -34,6 +35,7 @@ struct Struct {
 	StructEmbed
 	v StructField
 	ref &StructRefField
+	map map[StructMapFieldKey]StructMapFieldValue
 }
 
 fn (s Struct) method(v StructMethodArg) StructMethodRet {


### PR DESCRIPTION
On current master, v fmt removes selective imported type used in map like this

input:
```
import x { Xyz }

struct Abc {
        x map[Xyz]int
}
```

output:

```
import x

struct Abc {
        x map[Xyz]int
}
```

This PR fix this problem.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
