### PR TITLE
net.conv: cast result of C.ntohs to return type

### DIFF
--- a/vlib/net/conv/conv.c.v
+++ b/vlib/net/conv/conv.c.v
@@ -2,12 +2,12 @@ module conv
 
 // host to net 32 (htonl)
 pub fn htn32(host &u32) u32 {
-	return C.htonl(host)
+	return u32(C.htonl(host))
 }
 
 // host to net 16 (htons)
 pub fn htn16(host &u16) u16 {
-	return C.htons(host)
+	return u16(C.htons(host))
 }
 
 // net to host 32 (ntohl)
@@ -17,5 +17,5 @@ pub fn nth32(host &u32) u32 {
 
 // net to host 16 (ntohs)
 pub fn nth16(host &u16) u16 {
-	return C.ntohs(host)
+	return u16(C.ntohs(host))
 }


### PR DESCRIPTION
workaround for this error
```v
vlib/net/conv/conv.c.v:5:11: error: cannot use `int` as type `u32` in return argument
    3 | // host to net 32 (htonl)
    4 | pub fn htn32(host &u32) u32 {
    5 |     return C.htonl(host)
      |              ~~~~~~~~~~~
    6 | }
    7 |
vlib/net/conv/conv.c.v:10:11: error: cannot use `int` as type `u16` in return argument
    8 | // host to net 16 (htons)
    9 | pub fn htn16(host &u16) u16 {
   10 |     return C.htons(host)
      |              ~~~~~~~~~~~
   11 | }
   12 |
vlib/net/conv/conv.c.v:20:11: error: cannot use `int` as type `u16` in return argument
   18 | // net to host 16 (ntohs)
   19 | pub fn nth16(host &u16) u16 {
   20 |     return C.ntohs(host)
      |              ~~~~~~~~~~~
   21 | }
   ```