### PR TITLE
net.http: add deprecated attribute for old un/escape functions

### DIFF
--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -197,22 +197,22 @@ fn build_url_from_fetch(config FetchConfig) ?string {
 	return url.str()
 }
 
-// unescape_url is deprecated, use urllib.query_unescape() instead
+[deprecated: 'unescape_url is deprecated, use urllib.query_unescape() instead']
 pub fn unescape_url(s string) string {
 	panic('http.unescape_url() was replaced with urllib.query_unescape()')
 }
 
-// escape_url is deprecated, use urllib.query_escape() instead
+[deprecated: 'escape_url is deprecated, use urllib.query_escape() instead']
 pub fn escape_url(s string) string {
 	panic('http.escape_url() was replaced with urllib.query_escape()')
 }
 
-// unescape is deprecated, use urllib.query_escape() instead
+[deprecated: 'unescape is deprecated, use urllib.query_escape() instead']
 pub fn unescape(s string) string {
 	panic('http.unescape() was replaced with http.unescape_url()')
 }
 
-// escape is deprecated, use urllib.query_unescape() instead
+[deprecated: 'escape is deprecated, use urllib.query_unescape() instead']
 pub fn escape(s string) string {
 	panic('http.escape() was replaced with http.escape_url()')
 }


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
