### PR TITLE
checker: fix return type checking being skipped for mutable method receivers

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3758,10 +3758,6 @@ pub fn (mut c Checker) return_stmt(mut node ast.Return) {
 		if !c.check_types(got_typ, exp_type) {
 			got_typ_sym := c.table.get_type_symbol(got_typ)
 			mut exp_typ_sym := c.table.get_type_symbol(exp_type)
-			pos := node.exprs[i].position()
-			if node.exprs[i].is_auto_deref_var() {
-				continue
-			}
 			if exp_typ_sym.kind == .interface_ {
 				if c.type_implements(got_typ, exp_type, node.pos) {
 					if !got_typ.is_ptr() && !got_typ.is_pointer() && got_typ_sym.kind != .interface_
@@ -3771,6 +3767,7 @@ pub fn (mut c Checker) return_stmt(mut node ast.Return) {
 				}
 				continue
 			}
+			pos := node.exprs[i].position()
 			c.error('cannot use `$got_typ_sym.name` as type `${c.table.type_to_str(exp_type)}` in return argument',
 				pos)
 		}

--- a/vlib/v/checker/tests/mut_receiver_wrong_return_type.out
+++ b/vlib/v/checker/tests/mut_receiver_wrong_return_type.out
@@ -1,0 +1,13 @@
+vlib/v/checker/tests/mut_receiver_wrong_return_type.vv:4:9: error: cannot use `Test` as type `?int` in return argument
+    2 |
+    3 | fn (mut test Test) test() ?int {
+    4 |     return test
+      |            ~~~~
+    5 | }
+    6 |
+vlib/v/checker/tests/mut_receiver_wrong_return_type.vv:8:9: error: cannot use `Test` as type `int` in return argument
+    6 |
+    7 | fn (mut test Test) test2() int {
+    8 |     return test
+      |            ~~~~
+    9 | }

--- a/vlib/v/checker/tests/mut_receiver_wrong_return_type.vv
+++ b/vlib/v/checker/tests/mut_receiver_wrong_return_type.vv
@@ -1,0 +1,9 @@
+struct Test {}
+
+fn (mut test Test) test() ?int {
+	return test
+}
+
+fn (mut test Test) test2() int {
+	return test
+}


### PR DESCRIPTION
Fixes #11341

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
