### PR TITLE
Fix pipe unused result warning

### DIFF
--- a/vlib/os/process_nix.c.v
+++ b/vlib/os/process_nix.c.v
@@ -5,9 +5,10 @@ fn C.setpgid(pid int, pgid int) int
 fn (mut p Process) unix_spawn_process() int {
 	mut pipeset := [6]int{}
 	if p.use_stdio_ctl {
-		_ = C.pipe(&pipeset[0]) // pipe read end 0 <- 1 pipe write end
-		_ = C.pipe(&pipeset[2]) // pipe read end 2 <- 3 pipe write end
-		_ = C.pipe(&pipeset[4]) // pipe read end 4 <- 5 pipe write end
+		mut dont_care := C.pipe(&pipeset[0]) // pipe read end 0 <- 1 pipe write end
+		dont_care = C.pipe(&pipeset[2]) // pipe read end 2 <- 3 pipe write end
+		dont_care = C.pipe(&pipeset[4]) // pipe read end 4 <- 5 pipe write end
+		_ = dont_care // using `_` directly on each above `pipe` fails to avoid C compiler generate an `-Wunused-result` warning
 	}
 	pid := fork()
 	if pid != 0 {


### PR DESCRIPTION
This trivial PR removes a C compiler (eg: GCC) warning about `pipe` result not being used (-Wunused-result), in C code generated by V.

This is because the related function (Process unix_spawn_process) uses naive `_ = pipe(...)` constructs, that in turn generates
C code that indeed does not use the return value, eg: when compiling in optimized mode.

Here is the typical C warnings generated:
```
cc -o main14.elf main14_v.c -O3 -fno-plt -flto -DNDEBUG -lm
main14_v.c: In function ‘os__Process_unix_spawn_process’:
main14_v.c:14765:3: warning: ignoring return value of ‘pipe’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
14765 |   pipe(&pipeset[0]);
      |   ^~~~~~~~~~~~~~~~~
main14_v.c:14766:3: warning: ignoring return value of ‘pipe’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
14766 |   pipe(&pipeset[2]);
      |   ^~~~~~~~~~~~~~~~~
main14_v.c:14767:3: warning: ignoring return value of ‘pipe’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
14767 |   pipe(&pipeset[4]);
      |   ^~~~~~~~~~~~~~~~~
```
The trivial fix consists in declaring a temporary variable to store the results, then finally to store into `_` to ignore it.
