### PR TITLE
cgen: cleanup generated thread wait C codes

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6627,8 +6627,6 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 				g.gowrappers.writeln('\t$s_ret_typ ret = *ret_ptr;')
 				g.gowrappers.writeln('\tfree(ret_ptr);')
 				g.gowrappers.writeln('\treturn ret;')
-			} else {
-				g.gowrappers.writeln('\treturn;')
 			}
 			g.gowrappers.writeln('}')
 			g.waiter_fns << waiter_fn_name


### PR DESCRIPTION
This PR cleanup generated thread wait C codes.

- Remove the extra `return;` at the end of the function.
```vlang
void __v_thread_wait(__v_thread thread) {
	u32 stat = WaitForSingleObject(thread, INFINITE);
	if (stat != 0) { _v_panic(_SLIT("unable to join thread")); }
	CloseHandle(thread);
	return;
}
```