### PR TITLE
cgen: fix threads array wait without go calls (fix #12009)

### DIFF
--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -70,6 +70,9 @@ pub fn (mut p Parser) parse_array_type() ast.Type {
 		// error is set in parse_type
 		return 0
 	}
+	if elem_type.idx() == ast.thread_type_idx {
+		p.register_auto_import('sync.threads')
+	}
 	mut nr_dims := 1
 	// detect attr
 	not_attr := p.peek_tok.kind != .name && p.peek_token(2).kind !in [.semicolon, .rsbr]

--- a/vlib/v/tests/go_array_wait_without_go_test.v
+++ b/vlib/v/tests/go_array_wait_without_go_test.v
@@ -1,0 +1,27 @@
+fn test_go_array_wait_without_go() {
+	sa := SA{}
+	sb := SA{}
+
+	sa.wait()
+	sb.wait()
+
+	assert true
+}
+
+struct SA {
+mut:
+	threads []thread
+}
+
+pub fn (self SA) wait() {
+	self.threads.wait()
+}
+
+struct SB {
+mut:
+	threads []thread
+}
+
+pub fn (self SB) wait() {
+	self.threads.wait()
+}


### PR DESCRIPTION
This PR fix go array wait without go calls (fix #12009).

- Fix go array wait without go calls.
- Add test.

```vlang
fn main() {
	sa := SA{}
	sb := SA{}

	sa.wait()
	sb.wait()

	assert true
}

struct SA {
mut:
	threads []thread
}

pub fn (self SA) wait() {
	self.threads.wait()
}

struct SB {
mut:
	threads []thread
}

pub fn (self SB) wait() {
	self.threads.wait()
}

PS D:\Test\v\tt1> v run .
```