### PR TITLE
cgen: fix error of reference struct str() (fix #11498)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -883,6 +883,10 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	// }
 	if !node.receiver_type.is_ptr() && node.left_type.is_ptr() && node.name == 'str' {
 		g.write('ptr_str(')
+	} else if node.receiver_type.is_ptr() && node.left_type.is_ptr() && node.name == 'str'
+		&& !left_sym.has_method('str') {
+		g.gen_expr_to_string(node.left, node.left_type)
+		return
 	} else {
 		if left_sym.kind == .array {
 			if array_depth >= 0 {

--- a/vlib/v/tests/str_reference_struct_test.v
+++ b/vlib/v/tests/str_reference_struct_test.v
@@ -1,0 +1,12 @@
+struct Example {
+}
+
+fn test_str_reference_struct() {
+	c1 := Example{}
+	println((&c1).str())
+	assert (&c1).str() == '&Example{}'
+
+	c2 := &Example{}
+	println(c2.str())
+	assert c2.str() == '&Example{}'
+}


### PR DESCRIPTION
This PR fix error of reference struct str() (fix #11498).

- Fix error of reference struct str().
- Add test.

```vlang
struct Example {
}

fn main() {
	c1 := Example{}
	println((&c1).str())
	assert (&c1).str() == '&Example{}'

	c2 := &Example{}
	println(c2.str())
	assert c2.str() == '&Example{}'
}

PS D:\Test\v\tt1> v run .
&Example{}
&Example{}
```