### PR TITLE
cgen: format generated code of shared struct

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -877,7 +877,10 @@ fn (mut g Gen) write_shareds() {
 		done_types << typ
 		sh_typ := '__shared__$base'
 		mtx_typ := 'sync__RwMutex'
-		g.shared_types.writeln('struct $sh_typ { $mtx_typ mtx; $base val; };')
+		g.shared_types.writeln('struct $sh_typ {')
+		g.shared_types.writeln('\t$mtx_typ mtx;')
+		g.shared_types.writeln('\t$base val;')
+		g.shared_types.writeln('};')
 		g.shared_functions.writeln('static inline voidptr __dup${sh_typ}(voidptr src, int sz) {')
 		g.shared_functions.writeln('\t$sh_typ* dest = memdup(src, sz);')
 		g.shared_functions.writeln('\tsync__RwMutex_init(&dest->mtx);')

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -23,14 +23,20 @@ const c_current_commit_hash_default = '
 
 const c_concurrency_helpers = '
 typedef struct __shared_map __shared_map;
-struct __shared_map { sync__RwMutex mtx; map val; };
+struct __shared_map {
+	sync__RwMutex mtx;
+	map val;
+};
 static inline voidptr __dup_shared_map(voidptr src, int sz) {
 	__shared_map* dest = memdup(src, sz);
 	sync__RwMutex_init(&dest->mtx);
 	return dest;
 }
 typedef struct __shared_array __shared_array;
-struct __shared_array { sync__RwMutex mtx; array val; };
+struct __shared_array {
+	sync__RwMutex mtx;
+	array val;
+};
 static inline voidptr __dup_shared_array(voidptr src, int sz) {
 	__shared_array* dest = memdup(src, sz);
 	sync__RwMutex_init(&dest->mtx);


### PR DESCRIPTION
This PR format generated code of shared struct.

before:
```vlang
// V shared types:
struct __shared__Array_int { sync__RwMutex mtx; Array_int val; };

struct __shared_map { sync__RwMutex mtx; map val; };
struct __shared_array { sync__RwMutex mtx; array val; };
```

formated:
```vlang
// V shared types:
struct __shared__Array_int {
	sync__RwMutex mtx;
	Array_int val;
};

struct __shared_map {
	sync__RwMutex mtx;
	map val;
};

struct __shared_array {
	sync__RwMutex mtx;
	array val;
};
```