### PR TITLE
cgen: fix expr_as_cast for int/float literals

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2246,7 +2246,6 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 				'f64' { 'float_literal' }
 				else { got_styp }
 			}
-			println('$got_type $got_styp')
 			exp_styp := exp_sym.cname
 			mut fname := '/*$exp_sym*/I_${got_styp}_to_Interface_$exp_styp'
 			if exp_sym.info.is_generic {
@@ -6889,7 +6888,6 @@ fn (mut g Gen) interface_table() string {
 			// cctype is the Cleaned Concrete Type name, *without ptr*,
 			// i.e. cctype is always just Cat, not Cat_ptr:
 			cctype := g.cc_type(st, true)
-			println('$st, $cctype')
 			$if debug_interface_table ? {
 				eprintln(
 					'>> interface name: $ityp.name | concrete type: $st.debug() | st symname: ' +

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2242,9 +2242,9 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 		} else {
 			mut got_styp := g.cc_type(got_type, true)
 			got_styp = match got_styp {
-				 'int' { 'int_literal' }
-				 'f64' { 'float_literal' }
-				 else { got_styp }
+				'int' { 'int_literal' }
+				'f64' { 'float_literal' }
+				else { got_styp }
 			}
 			println('$got_type $got_styp')
 			exp_styp := exp_sym.cname

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2240,7 +2240,13 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 				got_styp)
 			g.inside_cast_in_heap--
 		} else {
-			got_styp := g.cc_type(got_type, true)
+			mut got_styp := g.cc_type(got_type, true)
+			got_styp = match got_styp {
+				 'int' { 'int_literal' }
+				 'f64' { 'float_literal' }
+				 else { got_styp }
+			}
+			println('$got_type $got_styp')
 			exp_styp := exp_sym.cname
 			mut fname := '/*$exp_sym*/I_${got_styp}_to_Interface_$exp_styp'
 			if exp_sym.info.is_generic {
@@ -6883,6 +6889,7 @@ fn (mut g Gen) interface_table() string {
 			// cctype is the Cleaned Concrete Type name, *without ptr*,
 			// i.e. cctype is always just Cat, not Cat_ptr:
 			cctype := g.cc_type(st, true)
+			println('$st, $cctype')
 			$if debug_interface_table ? {
 				eprintln(
 					'>> interface name: $ityp.name | concrete type: $st.debug() | st symname: ' +

--- a/vlib/v/tests/as_cast_literal.v
+++ b/vlib/v/tests/as_cast_literal.v
@@ -1,17 +1,12 @@
 interface IExample {}
 
-struct Example {
-	n int
-}
-
-fn test(a IExample) bool {
+fn thing(a IExample) bool {
 	return true
 }
 
-fn main() {
-	assert test(Example{123})
-	assert test(true)
-	assert test(123)
-	assert test(12.3)
-	assert test('abc')
+fn test_as_cast_with_literals() {
+	assert thing(true)
+	assert thing(123)
+	assert thing(12.3)
+	assert thing('abc')
 }

--- a/vlib/v/tests/as_cast_literal.v
+++ b/vlib/v/tests/as_cast_literal.v
@@ -1,0 +1,17 @@
+interface IExample {}
+
+struct Example {
+	n int
+}
+
+fn test(a IExample) bool {
+	return true
+}
+
+fn main() {
+	assert test(Example{123})
+	assert test(true)
+	assert test(123)
+	assert test(12.3)
+	assert test('abc')
+}


### PR DESCRIPTION
Fixes #12056 
```v
interface IExample {}

fn thing(a IExample) bool {
        return true
}

fn main() {
        assert thing(true)
        assert thing(123) // previously c error
        assert thing(12.3) // previously c error
}
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
