### PR TITLE
fmt: fix fmt of 'fn(mut a &int)'

### DIFF
--- a/cmd/tools/vtest-cleancode.v
+++ b/cmd/tools/vtest-cleancode.v
@@ -28,7 +28,6 @@ const (
 		'vlib/gg/m4/graphic.v',
 		'vlib/gg/m4/m4_test.v',
 		'vlib/gg/m4/matrix.v',
-		'vlib/sqlite/orm.v' /* mut c &int -> mut c int */,
 		'vlib/builtin/int_test.v' /* special number formatting that should be tested */,
 		// TODOs and unfixed vfmt bugs
 		'vlib/v/tests/interop_test.v', /* bad comment formatting */
@@ -42,7 +41,6 @@ const (
 	]
 	vfmt_known_failing_exceptions   = arrays.merge(verify_known_failing_exceptions, [
 		'vlib/regex/regex_test.v' /* contains meaningfull formatting of the test case data */,
-		'vlib/glm/glm.v' /* `mut res &f32` => `mut res f32`, which then fails to compile */,
 		'vlib/crypto/sha512/sha512block_generic.v' /* formatting of large constant arrays wraps to too many lines */,
 		'vlib/crypto/aes/const.v' /* formatting of large constant arrays wraps to too many lines */,
 	])

--- a/vlib/glm/glm.v
+++ b/vlib/glm/glm.v
@@ -63,7 +63,7 @@ pub fn (m Mat4) str() string {
 			s += '  '
 		}
 		for j in 0 .. 4 {
-			val := unsafe {m.data[i * 4 + j]}
+			val := unsafe { m.data[i * 4 + j] }
 			s += '${val:5.2f} '
 		}
 		if i != 3 {
@@ -249,7 +249,7 @@ pub fn mult(a Mat4, b Mat4) Mat4 {
 		for r in 0 .. 4 {
 			mut prod := f32(0)
 			for c in 0 .. 4 {
-				prod += unsafe {a.data[c * 4 + r] * b.data[i * 4 + c]}
+				prod += unsafe { a.data[c * 4 + r] * b.data[i * 4 + c] }
 			}
 			unsafe {
 				out[i * 4 + r] = prod

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -132,8 +132,8 @@ fn stringify_fn_after_name(node &FnDecl, mut f strings.Builder, t &Table, cur_mo
 		f.write_string(arg.name)
 		mut s := t.type_to_str(arg.typ.clear_flag(.shared_f))
 		if arg.is_mut {
-			// f.write_string(' mut')
-			if s.starts_with('&') {
+			arg_sym := t.get_type_symbol(arg.typ)
+			if s.starts_with('&') && !arg_sym.is_number() && arg_sym.kind != .bool {
 				s = s[1..]
 			}
 		}


### PR DESCRIPTION
This PR fix fmt of 'fn(mut a &int)'.

- Fix fmt of 'fn(mut a &int)'.
- Remove `glm/glm.v` `sqlite/orm.v` from vtest-cleancode exception list.
- Format glm.v.
- Format orm.v.