### PR TITLE
checker: check fn returning void type (fix #12076)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3706,6 +3706,9 @@ pub fn (mut c Checker) return_stmt(mut node ast.Return) {
 	mut got_types := []ast.Type{}
 	for expr in node.exprs {
 		typ := c.expr(expr)
+		if typ == ast.void_type {
+			c.error('cannot return a void type `$expr`', node.pos)
+		}
 		// Unpack multi return types
 		sym := c.table.get_type_symbol(typ)
 		if sym.kind == .multi_return {

--- a/vlib/v/checker/tests/return_void_type_err.out
+++ b/vlib/v/checker/tests/return_void_type_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/return_void_type_err.vv:2:2: error: cannot return a void type `println(msg)`
+    1 | fn hello(msg string) ? {
+    2 |     return println(msg)
+      |     ~~~~~~~~~~~~~~~~~~~
+    3 | }
+    4 |

--- a/vlib/v/checker/tests/return_void_type_err.vv
+++ b/vlib/v/checker/tests/return_void_type_err.vv
@@ -1,0 +1,7 @@
+fn hello(msg string) ? {
+	return println(msg)
+}
+
+fn main() {
+	hello('test') ?
+}


### PR DESCRIPTION
This PR check fn returning void type (fix #12076).

- Check fn returning void type.
- Add test.

```vlang
fn hello(msg string) ? {
	return println(msg)
}

fn main() {
	hello('test') ?
}

PS D:\Test\v\tt1> v run .
.\tt1.v:2:2: error: cannot return a void type `println(msg)`
    1 | fn hello(msg string) ? {
    2 |     return println(msg)
      |     ~~~~~~~~~~~~~~~~~~~
    3 | }
```