### PR TITLE
gg: use sgl.begin_triangles when drawing triangles

### DIFF
--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -299,7 +299,7 @@ pub fn (ctx &Context) draw_triangle(x f32, y f32, x2 f32, y2 f32, x3 f32, y3 f32
 		sgl.load_pipeline(ctx.timage_pip)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
-	sgl.begin_quads()
+	sgl.begin_triangles()
 	sgl.v2f(x * ctx.scale, y * ctx.scale)
 	sgl.v2f(x2 * ctx.scale, y2 * ctx.scale)
 	sgl.v2f(x3 * ctx.scale, y3 * ctx.scale)


### PR DESCRIPTION
A small logical fix. While Sokol's `sgl_begin_quads` is [techincally the same](https://github.com/floooh/sokol/blob/f84a68af1362493331678f9158d6ec06474b16e0/util/sokol_gl.h#L2483) as `sgl_begin_triangle_strip` and yields the same visual result - I think it's better for readability and logic to use the right primitive wording/call in this case.