### PR TITLE
gg: use sgl.begin_points for pixels + improve pixels example

### DIFF
--- a/examples/gg/set_pixels.v
+++ b/examples/gg/set_pixels.v
@@ -5,12 +5,28 @@ import gx
 
 struct App {
 mut:
-	gg &gg.Context
+	gg     &gg.Context
+	pixels []f32
 }
 
 fn main() {
+	mut pixels := []f32{}
+	density := 4
+	for x in 30 .. 60 {
+		if x % density == 0 {
+			continue
+		}
+		for y in 30 .. 60 {
+			if y % density == 0 {
+				continue
+			}
+			pixels << f32(x + density)
+			pixels << f32(y + density)
+		}
+	}
 	mut app := &App{
 		gg: 0
+		pixels: pixels
 	}
 	app.gg = gg.new_context(
 		bg_color: gx.rgb(174, 198, 255)
@@ -24,16 +40,13 @@ fn main() {
 }
 
 fn frame(mut app App) {
-	mut pixels := []f32{}
-
-	for x in 30 .. 60 {
-		for y in 30 .. 60 {
-			pixels << f32(x)
-			pixels << f32(y)
-		}
-	}
-
 	app.gg.begin()
-	app.gg.set_pixels(pixels, gx.red)
+	// Set a blue pixel near each corner. (Find your magnifying glass)
+	app.gg.set_pixel(2, 2, gx.blue)
+	app.gg.set_pixel(app.gg.width - 2, 2, gx.blue)
+	app.gg.set_pixel(app.gg.width - 2, app.gg.height - 2, gx.blue)
+	app.gg.set_pixel(2, app.gg.height - 2, gx.blue)
+	// Set pixels in a grid-like pattern.
+	app.gg.set_pixels(app.pixels, gx.red)
 	app.gg.end()
 }

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -270,9 +270,17 @@ pub fn (ctx &Context) draw_square(x f32, y f32, s f32, c gx.Color) {
 
 [inline]
 pub fn (ctx &Context) set_pixel(x f32, y f32, c gx.Color) {
-	ctx.draw_square(x, y, 1, c)
+	if c.a != 255 {
+		sgl.load_pipeline(ctx.timage_pip)
+	}
+
+	sgl.c4b(c.r, c.g, c.b, c.a)
+	sgl.begin_points()
+	sgl.v2f(x * ctx.scale, y * ctx.scale)
+	sgl.end()
 }
 
+[direct_array_access; inline]
 pub fn (ctx &Context) set_pixels(points []f32, c gx.Color) {
 	assert points.len % 2 == 0
 	len := points.len / 2
@@ -282,14 +290,10 @@ pub fn (ctx &Context) set_pixels(points []f32, c gx.Color) {
 	}
 
 	sgl.c4b(c.r, c.g, c.b, c.a)
-	sgl.begin_quads()
+	sgl.begin_points()
 	for i in 0 .. len {
 		x, y := points[i * 2], points[i * 2 + 1]
-
 		sgl.v2f(x * ctx.scale, y * ctx.scale)
-		sgl.v2f((x + 1) * ctx.scale, y * ctx.scale)
-		sgl.v2f((x + 1) * ctx.scale, (y + 1) * ctx.scale)
-		sgl.v2f(x * ctx.scale, (y + 1) * ctx.scale)
 	}
 	sgl.end()
 }


### PR DESCRIPTION
Like #12083 this PR corrects some logic/wording in what is done.

On top it improves the `set_pixels.v` example to actually show the cluster of pixels - instead of a rectangle.
Before PR:
![image](https://user-images.githubusercontent.com/768942/136226132-d476c857-1e2a-46fb-8c64-910f74d8ddb2.png)
After PR:
![image](https://user-images.githubusercontent.com/768942/136225954-d64bc7e7-57a0-4c6f-91e1-5b57f1ea3576.png)

One major change is that `ctx.scale` isn't affecting the pixel size like previously.
To me this is correct behaviour for putting a raw pixel on screen. If you want to scale your pixels I think draw_rect should be used like in the previous version. An added benefit to this new behaviour is that `set_pixel(s)` now uses less calls/instructions - so this is also a little optimization.