### PR TITLE
ast: change 'type.to_ptr()' to 'type.ref()'

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -183,12 +183,12 @@ pub fn (t Type) set_nr_muls(nr_muls int) Type {
 	return int(t) & 0xff00ffff | (nr_muls << 16)
 }
 
-// increments nr_nuls on `t` and return it
+// increments nr_muls on `t` and return it
 [inline]
-pub fn (t Type) to_ptr() Type {
+pub fn (t Type) ref() Type {
 	nr_muls := (int(t) >> 16) & 0xff
 	if nr_muls == 255 {
-		panic('to_ptr: nr_muls is already at max of 255')
+		panic('ref: nr_muls is already at max of 255')
 	}
 	return int(t) & 0xff00ffff | ((nr_muls + 1) << 16)
 }

--- a/vlib/v/ast/types_test.v
+++ b/vlib/v/ast/types_test.v
@@ -18,10 +18,10 @@ fn test_muls() {
 	t = t.set_nr_muls(0)
 	assert t.nr_muls() == 0
 	assert t.is_ptr() == false
-	t = t.to_ptr()
+	t = t.ref()
 	assert t.nr_muls() == 1
 	assert t.is_ptr() == true
-	t = t.to_ptr()
+	t = t.ref()
 	assert t.nr_muls() == 2
 	assert t.is_ptr() == true
 	t = t.deref()

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -291,7 +291,7 @@ pub fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 			return true
 		}
 	}
-	if expected == ast.charptr_type && got == ast.char_type.to_ptr() {
+	if expected == ast.charptr_type && got == ast.char_type.ref() {
 		return true
 	}
 	if expected.has_flag(.optional) {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2361,7 +2361,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 		if left_type_sym.kind == .chan {
 			elem_typ := (left_type_sym.info as ast.Chan).elem_type
 			if method_name == 'try_push' {
-				exp_arg_typ = elem_typ.to_ptr()
+				exp_arg_typ = elem_typ.ref()
 			} else if method_name == 'try_pop' {
 				exp_arg_typ = elem_typ
 				param_is_mut = true
@@ -2594,7 +2594,7 @@ fn (mut c Checker) map_builtin_method_call(mut node ast.CallExpr, left_type ast.
 		}
 		else {}
 	}
-	node.receiver_type = left_type.to_ptr()
+	node.receiver_type = left_type.ref()
 	node.return_type = ret_type
 	return node.return_type
 }
@@ -2649,7 +2649,7 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 					'\ne.g. `users.sort(a.id < b.id)`', node.pos)
 			}
 		} else if !(c.table.get_type_symbol(elem_typ).has_method('<')
-			|| c.table.unalias_num_type(elem_typ) in [ast.int_type, ast.int_type.to_ptr(), ast.string_type, ast.string_type.to_ptr(), ast.i8_type, ast.i16_type, ast.i64_type, ast.byte_type, ast.rune_type, ast.u16_type, ast.u32_type, ast.u64_type, ast.f32_type, ast.f64_type, ast.char_type, ast.bool_type, ast.float_literal_type, ast.int_literal_type]) {
+			|| c.table.unalias_num_type(elem_typ) in [ast.int_type, ast.int_type.ref(), ast.string_type, ast.string_type.ref(), ast.i8_type, ast.i16_type, ast.i64_type, ast.byte_type, ast.rune_type, ast.u16_type, ast.u32_type, ast.u64_type, ast.f32_type, ast.f64_type, ast.char_type, ast.bool_type, ast.float_literal_type, ast.int_literal_type]) {
 			c.error('custom sorting condition must be supplied for type `${c.table.type_to_str(elem_typ)}`',
 				node.pos)
 		}
@@ -2693,7 +2693,7 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 	} else if method_name == 'clone' {
 		// need to return `array_xxx` instead of `array`
 		// in ['clone', 'str'] {
-		node.receiver_type = left_type.to_ptr()
+		node.receiver_type = left_type.ref()
 		if node.left.is_auto_deref_var() {
 			node.return_type = left_type.deref()
 		} else {
@@ -2709,7 +2709,7 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 	} else if method_name in ['first', 'last', 'pop'] {
 		node.return_type = array_info.elem_type
 		if method_name == 'pop' {
-			node.receiver_type = left_type.to_ptr()
+			node.receiver_type = left_type.ref()
 		} else {
 			node.receiver_type = left_type
 		}
@@ -4531,13 +4531,13 @@ fn scope_register_a_b(mut s ast.Scope, pos token.Position, typ ast.Type) {
 	s.register(ast.Var{
 		name: 'a'
 		pos: pos
-		typ: typ.to_ptr()
+		typ: typ.ref()
 		is_used: true
 	})
 	s.register(ast.Var{
 		name: 'b'
 		pos: pos
-		typ: typ.to_ptr()
+		typ: typ.ref()
 		is_used: true
 	})
 }
@@ -5028,7 +5028,7 @@ fn (mut c Checker) for_in_stmt(mut node ast.ForInStmt) {
 				}
 			}
 			if node.val_is_mut {
-				value_type = value_type.to_ptr()
+				value_type = value_type.ref()
 				match node.cond {
 					ast.Ident {
 						if node.cond.obj is ast.Var {
@@ -6619,7 +6619,7 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 // smartcast takes the expression with the current type which should be smartcasted to the target type in the given scope
 fn (c Checker) smartcast(expr ast.Expr, cur_type ast.Type, to_type_ ast.Type, mut scope ast.Scope) {
 	sym := c.table.get_type_symbol(cur_type)
-	to_type := if sym.kind == .interface_ { to_type_.to_ptr() } else { to_type_ }
+	to_type := if sym.kind == .interface_ { to_type_.ref() } else { to_type_ }
 	match expr {
 		ast.SelectorExpr {
 			mut is_mut := false
@@ -7428,7 +7428,7 @@ pub fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 		if !c.inside_fn_arg && !c.inside_unsafe {
 			c.mark_as_referenced(mut &node.right, false)
 		}
-		return right_type.to_ptr()
+		return right_type.ref()
 	} else if node.op == .amp && node.right !is ast.CastExpr {
 		if !c.inside_fn_arg && !c.inside_unsafe {
 			c.mark_as_referenced(mut &node.right, false)
@@ -7436,7 +7436,7 @@ pub fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 		if node.right.is_auto_deref_var() {
 			return right_type
 		} else {
-			return right_type.to_ptr()
+			return right_type.ref()
 		}
 	}
 	if node.op == .mul {
@@ -8368,7 +8368,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 			}
 			if c.pref.translated && node.is_variadic && node.params.len == 1 && param.typ.is_ptr() {
 				// TODO c2v hack to fix `(const char *s, ...)`
-				param.typ = ast.int_type.to_ptr()
+				param.typ = ast.int_type.ref()
 			}
 		}
 	}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2236,7 +2236,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 		&& !expected_type.has_flag(.optional) {
 		if expr is ast.StructInit && !got_type.is_ptr() {
 			g.inside_cast_in_heap++
-			got_styp := g.cc_type(got_type.to_ptr(), true)
+			got_styp := g.cc_type(got_type.ref(), true)
 			// TODO: why does cc_type even add this in the first place?
 			exp_styp := exp_sym.cname
 			mut fname := 'I_${got_styp}_to_Interface_$exp_styp'
@@ -3099,7 +3099,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 									is_used_var_styp = true
 								} else if val is ast.PrefixExpr {
 									if val.op == .amp && val.right is ast.StructInit {
-										var_styp := g.typ(val.right.typ.to_ptr())
+										var_styp := g.typ(val.right.typ.ref())
 										g.write('$var_styp ')
 										is_used_var_styp = true
 									}
@@ -6147,14 +6147,14 @@ fn (mut g Gen) write_types(types []ast.TypeSymbol) {
 				g.type_definitions.writeln('\tunion {')
 				for variant in typ.info.variants {
 					variant_sym := g.table.get_type_symbol(variant)
-					g.type_definitions.writeln('\t\t${g.typ(variant.to_ptr())} _$variant_sym.cname;')
+					g.type_definitions.writeln('\t\t${g.typ(variant.ref())} _$variant_sym.cname;')
 				}
 				g.type_definitions.writeln('\t};')
 				g.type_definitions.writeln('\tint _typ;')
 				if typ.info.fields.len > 0 {
 					g.writeln('\t// pointers to common sumtype fields')
 					for field in typ.info.fields {
-						g.type_definitions.writeln('\t${g.typ(field.typ.to_ptr())} $field.name;')
+						g.type_definitions.writeln('\t${g.typ(field.typ.ref())} $field.name;')
 					}
 				}
 				g.type_definitions.writeln('};')

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -629,7 +629,7 @@ fn (mut p Parser) prefix_expr() ast.Expr {
 }
 
 fn (mut p Parser) recast_as_pointer(mut cast_expr ast.CastExpr, pos token.Position) {
-	cast_expr.typ = cast_expr.typ.to_ptr()
+	cast_expr.typ = cast_expr.typ.ref()
 	cast_expr.typname = p.table.get_type_symbol(cast_expr.typ).name
 	cast_expr.pos = pos.extend(cast_expr.pos)
 }

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -578,7 +578,7 @@ fn (mut p Parser) fn_receiver(mut params []ast.Param, mut rec ReceiverParsingInf
 	if type_sym.kind == .struct_ {
 		info := type_sym.info as ast.Struct
 		if !rec.is_mut && !rec.typ.is_ptr() && info.fields.len > 8 {
-			rec.typ = rec.typ.to_ptr()
+			rec.typ = rec.typ.ref()
 			is_auto_rec = true
 		}
 	}
@@ -801,7 +801,7 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 				// if arg_type.is_ptr() {
 				// p.error('cannot mut')
 				// }
-				// arg_type = arg_type.to_ptr()
+				// arg_type = arg_type.ref()
 				arg_type = arg_type.set_nr_muls(1)
 				if is_shared {
 					arg_type = arg_type.set_flag(.shared_f)


### PR DESCRIPTION
This PR change 'type.to_ptr()' to 'type.ref()' in ast.

- `to_ptr()` is not appropriate to express it when it's already a pointer.
- This corresponds to `deref()`.
- Modify all the related calls.