### PR TITLE
v.parser: improve error message when no arch is set 'asm{}'

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -875,6 +875,9 @@ fn (mut p Parser) asm_stmt(is_top_level bool) ast.AsmStmt {
 		p.next()
 	}
 	if arch == ._auto && !p.pref.is_fmt {
+		if p.tok.lit == '' {
+			p.error('missing assembly architecture. Try i386, amd64 or arm64.')
+		}
 		p.error('unknown assembly architecture')
 	}
 	if p.tok.kind != .name {


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
