### PR TITLE
toml: fix error return in value parsing

### DIFF
--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -650,13 +650,15 @@ pub fn (mut p Parser) value() ?ast.Value {
 				ast.Value(t)
 			}
 			else {
-				error(@MOD + '.' + @STRUCT + '.' + @FN +
-					' value expected .boolean, .quoted, .lsbr, .lcbr or .number got "$p.tok.kind" "$p.tok.lit"')
-				ast.Value(ast.Null{}) // TODO workaround bug
+				ast.Value(ast.Null{})
 			}
 		}
+		if value is ast.Null {
+			return error(@MOD + '.' + @STRUCT + '.' + @FN +
+				' value expected .boolean, .quoted, .lsbr, .lcbr or .number got "$p.tok.kind" "$p.tok.lit"')
+		}
 	}
-	util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'parsed value $value.to_json()')
+	util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'parsed "$p.tok.kind" as value $value.to_json()')
 	return value
 }
 

--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -20,7 +20,6 @@ const (
 		'string/basic-out-of-range-unicode-escape-1.toml',
 		'string/basic-out-of-range-unicode-escape-2.toml',
 		'string/bad-uni-esc.toml',
-		'string/missing-quotes.toml',
 		// Integer
 		'integer/capital-bin.toml',
 		'integer/invalid-bin.toml',


### PR DESCRIPTION
This fixes value parsing to actually return the error encountered instead of ending up as `ast.Null` (which is a type that should never reach the end user)
This also gives the correct error in the invalid BurntSushi test