### PR TITLE
ast: fix checking generic fn call with fntype arg mismatch (fix #12114)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1397,6 +1397,7 @@ pub fn (mut t Table) resolve_generic_to_concrete(generic_type Type, generic_name
 					}
 				}
 			}
+			func.name = ''
 			idx := t.find_or_register_fn_type('', func, true, false)
 			return new_type(idx).derive_add_muls(generic_type).clear_flag(.generic)
 		}

--- a/vlib/v/checker/tests/generics_fn_called_fntype_arg_mismatch.out
+++ b/vlib/v/checker/tests/generics_fn_called_fntype_arg_mismatch.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/generics_fn_called_fntype_arg_mismatch.vv:24:37: error: cannot use `fn (int) f64` as `fn (int) Point3D` in argument 2 to `new_array`
+   22 |     println(good_cloud)
+   23 |     // this should be a compilation error, because the function signature does not match:
+   24 |     bad_cloud := new_array<Point3D>(3, fn (idx int) f64 {
+      |                                        ~~~~~~~~~~~~~~~~~~
+   25 |         return 12345
+   26 |     })

--- a/vlib/v/checker/tests/generics_fn_called_fntype_arg_mismatch.vv
+++ b/vlib/v/checker/tests/generics_fn_called_fntype_arg_mismatch.vv
@@ -1,0 +1,28 @@
+pub type FnArrayInit = fn (idx int) T
+
+pub fn new_array<T>(len int, initfn FnArrayInit<T>) []T {
+	mut res := []T{len: len}
+	for idx in 0 .. res.len {
+		res[idx] = initfn(idx)
+	}
+	return res
+}
+
+struct Point3D {
+	x f32
+	y f32
+	z f32
+}
+
+fn main() {
+	// this works as expected:
+	good_cloud := new_array<Point3D>(3, fn (idx int) Point3D {
+		return Point3D{idx, idx * 10, idx * -10}
+	})
+	println(good_cloud)
+	// this should be a compilation error, because the function signature does not match:
+	bad_cloud := new_array<Point3D>(3, fn (idx int) f64 {
+		return 12345
+	})
+	println(bad_cloud)
+}


### PR DESCRIPTION
This PR fix checking generic fn call with fntype arg mismatch (fix #12114).

- Fix checking generic fn call with fntype arg mismatch.
- Add test.

```vlang
pub type FnArrayInit = fn (idx int) T

pub fn new_array<T>(len int, initfn FnArrayInit<T>) []T {
	mut res := []T{len: len}
	for idx in 0 .. res.len {
		res[idx] = initfn(idx)
	}
	return res
}

struct Point3D {
	x f32
	y f32
	z f32
}

fn main() {
	// this works as expected:
	good_cloud := new_array<Point3D>(3, fn (idx int) Point3D {
		return Point3D{idx, idx * 10, idx * -10}
	})
	println(good_cloud)
	// this should be a compilation error, because the function signature does not match:
	bad_cloud := new_array<Point3D>(3, fn (idx int) f64 {
		return 12345
	})
	println(bad_cloud)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:24:37: error: cannot use `fn (int) f64` as `fn (int) Point3D` in argument 2 to `new_array`
   22 |     println(good_cloud)
   23 |     // this should be a compilation error, because the function signature does not match:
   24 |     bad_cloud := new_array<Point3D>(3, fn (idx int) f64 {
      |                                        ~~~~~~~~~~~~~~~~~~
   25 |         return 12345
   26 |     })
```