### PR TITLE
checker: check generic struct using in non-generic fn (fix #12117)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4592,6 +4592,9 @@ pub fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 			c.ensure_sumtype_array_has_default_value(node)
 		}
 		c.ensure_type_exists(node.elem_type, node.elem_type_pos) or {}
+		if node.typ.has_flag(.generic) && c.table.cur_fn.generic_names.len == 0 {
+			c.error('generic struct cannot use in non-generic function', node.pos)
+		}
 		return node.typ
 	}
 	if node.is_fixed {

--- a/vlib/v/checker/tests/generics_struct_in_non_generic_fn_err.out
+++ b/vlib/v/checker/tests/generics_struct_in_non_generic_fn_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/generics_struct_in_non_generic_fn_err.vv:5:7: error: generic struct cannot use in non-generic function
+    3 |
+    4 | fn main() {
+    5 |     _ := []Example<T>{}
+      |          ~~~~~~~~~~~~~
+    6 | }

--- a/vlib/v/checker/tests/generics_struct_in_non_generic_fn_err.vv
+++ b/vlib/v/checker/tests/generics_struct_in_non_generic_fn_err.vv
@@ -1,0 +1,6 @@
+struct Example<T> {
+}
+
+fn main() {
+	_ := []Example<T>{}
+}


### PR DESCRIPTION
This PR check generic struct using in non-generic fn (fix #12117).

- Check generic struct using in non-generic fn.
- Add test.

```vlang
struct Example<T> {
}

fn main() {
	_ := []Example<T>{}
}

PS D:\Test\v\tt1> v run .
.\tt1.v:5:7: error: generic struct cannot use in non-generic function
    3 |
    4 | fn main() {
    5 |     _ := []Example<T>{}
      |          ~~~~~~~~~~~~~
    6 | }
```