### PR TITLE
native: fix stackframe bug on return statements

### DIFF
--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -1369,8 +1369,8 @@ fn (mut g Gen) fn_decl(node ast.FnDecl) {
 	g.push(.rbp)
 	g.mov_rbp_rsp()
 	locals_count := node.scope.objects.len + node.params.len
-	stackframe_size := (locals_count * 8) + 0x10
-	g.sub8(.rsp, stackframe_size)
+	g.stackframe_size = (locals_count * 8) + 0x10
+	g.sub8(.rsp, g.stackframe_size)
 
 	if node.params.len > 0 {
 		// g.mov(.r12, 0x77777777)
@@ -1395,7 +1395,7 @@ fn (mut g Gen) fn_decl(node ast.FnDecl) {
 		return
 	}
 	// g.leave()
-	g.add8(.rsp, stackframe_size)
+	g.add8(.rsp, g.stackframe_size)
 	g.pop(.rbp)
 	g.ret()
 }

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -32,6 +32,7 @@ mut:
 	sect_header_name_pos int
 	offset               i64
 	str_pos              []i64
+	stackframe_size      int
 	strings              []string // TODO use a map and don't duplicate strings
 	file_size_pos        i64
 	main_fn_addr         i64
@@ -477,7 +478,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 				}
 			}
 			// intel specific
-			g.add8(.rsp, 0x20) // XXX depends on scope frame size
+			g.add8(.rsp, g.stackframe_size)
 			g.pop(.rbp)
 			g.ret()
 		}


### PR DESCRIPTION
This patch makes this program work:

```
fn res() int {
	return 3
}

fn main() {
	a := res ()
	exit(a)
}
```