### PR TITLE
cgen: remove the extra generated parentheses of single in_expr (fix #12158)

### DIFF
--- a/vlib/v/gen/c/infix_expr.v
+++ b/vlib/v/gen/c/infix_expr.v
@@ -388,14 +388,9 @@ fn (mut g Gen) infix_expr_in_op(node ast.InfixExpr) {
 			if node.right.exprs.len > 0 {
 				// `a in [1,2,3]` optimization => `a == 1 || a == 2 || a == 3`
 				// avoids an allocation
-				need_par := node.op == .not_in || !g.is_single_infix_in_if
-				if need_par {
-					g.write('(')
-				}
+				g.write('(')
 				g.infix_expr_in_optimization(node.left, node.right)
-				if need_par {
-					g.write(')')
-				}
+				g.write(')')
 				return
 			}
 		}


### PR DESCRIPTION
This PR remove the extra generated parentheses of single in_expr (fix #12158).

- Remove the extra generated parentheses of single in_expr.

```vlang
enum Foo {
	jojo
	jeje
}
fn main() {
	a := Foo.jeje
	if a in [.jojo ] {
		println('winrar')
	}
}
```
generated codes:
```vlang
VV_LOCAL_SYMBOL void main__main(void) {
	main__Foo a = main__Foo__jeje;
	if (a == main__Foo__jojo) {
		println(_SLIT("winrar"));
	}
}
```
