### PR TITLE
mysql/orm: Fix last_id() call

### DIFF
--- a/vlib/mysql/orm.v
+++ b/vlib/mysql/orm.v
@@ -105,7 +105,7 @@ pub fn (db Connection) delete(table string, where orm.QueryData) ? {
 }
 
 pub fn (db Connection) last_id() orm.Primitive {
-	query := 'SELECT last_insert_rowid();'
+	query := 'SELECT last_insert_id();'
 	id := db.query(query) or {
 		Result{
 			result: 0


### PR DESCRIPTION
Seems there was an error and SQLite's call was put here as well. Replacing `last_insert_rowid` (SQLite) with `last_insert_id` (MySQL) worked for me. The others' all seemed to be correct. I'm sure this isn't optimal, but a simple test could be added to orm/mysql_orm_test.v like:
```go 
    val := db.last_id()
    assert val is int
    if val is int {
        assert val == 1
    }
```