### PR TITLE
parser, checker: optimize checking generic struct type mismatch error with position.

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -932,6 +932,8 @@ pub fn (mut c Checker) generic_insts_to_concrete() {
 						typ.is_public = true
 						typ.kind = parent.kind
 						typ.methods = all_methods
+					} else {
+						util.verror('generic error', 'the number of generic types of interface `$parent.name` is inconsistent with the concrete types')
 					}
 				}
 				ast.SumType {
@@ -968,6 +970,8 @@ pub fn (mut c Checker) generic_insts_to_concrete() {
 						}
 						typ.is_public = true
 						typ.kind = parent.kind
+					} else {
+						util.verror('generic error', 'the number of generic types of sumtype `$parent.name` is inconsistent with the concrete types')
 					}
 				}
 				else {}

--- a/vlib/v/checker/tests/generics_inst_non_generic_struct_err.out
+++ b/vlib/v/checker/tests/generics_inst_non_generic_struct_err.out
@@ -1,1 +1,6 @@
-generic error: struct `main.Test` is not a generic struct, cannot instantiate to the concrete types
+vlib/v/checker/tests/generics_inst_non_generic_struct_err.vv:5:14: error: struct `Test` is not a generic struct, cannot instantiate to the concrete types
+    3 |
+    4 | fn main() {
+    5 |     println(Test<string>{})
+      |                 ~~~~~~~~
+    6 | }

--- a/vlib/v/checker/tests/generics_struct_type_mismatch_err.out
+++ b/vlib/v/checker/tests/generics_struct_type_mismatch_err.out
@@ -1,1 +1,7 @@
-generic error: the number of generic types of struct `main.Example` is inconsistent with the concrete types
+vlib/v/checker/tests/generics_struct_type_mismatch_err.vv:7:20: error: the number of generic types of struct `Example` is inconsistent with the concrete types
+    5 |
+    6 | fn main() {
+    7 |     example := Example<string>{
+      |                       ~~~~~~~~
+    8 |         key: 'key'
+    9 |         value: 'value'

--- a/vlib/v/fmt/tests/generics_keep.vv
+++ b/vlib/v/fmt/tests/generics_keep.vv
@@ -14,12 +14,6 @@ fn (_ Foo) simple<T>() T {
 	return T{}
 }
 
-struct NonGenericStruct {}
-
-fn use_as_generic(ngs NonGenericStruct<V>) NonGenericStruct<V> {
-	return NonGenericStruct{}
-}
-
 struct GenericStruct<A, B> {}
 
 fn proper_generics(gs GenericStruct<A, B>) GenericStruct<A, B> {


### PR DESCRIPTION
This PR optimize checking generic struct type mismatch error with position.

```vlang
struct Example<T, V> {
	key   T
	value V
}

fn main() {
	example := Example<string>{
		key: 'key'
		value: 'value'
	}
}

PS D:\Test\v\tt1> v run .
.\tt1.v:7:20: error: the number of generic types of struct `Example` is inconsistent with the concrete types
    5 |
    6 | fn main() {
    7 |     example := Example<string>{
      |                       ~~~~~~~~
    8 |         key: 'key'
    9 |         value: 'value'
```
```vlang
struct Test {
}

fn main() {
	println(Test<string>{})
}

PS D:\Test\v\tt1> v run .
.\tt1.v:5:14: error: struct `Test` is not a generic struct, cannot instantiate to the concrete types
    3 | 
    4 | fn main() {
    5 |     println(Test<string>{})
      |                 ~~~~~~~~
    6 | }
```