### PR TITLE
cgen: fix cross assign math big int (fix #12184)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3269,9 +3269,22 @@ fn (mut g Gen) gen_cross_tmp_variable(left []ast.Expr, val ast.Expr) {
 			}
 		}
 		ast.InfixExpr {
-			g.gen_cross_tmp_variable(left, val.left)
-			g.write(val.op.str())
-			g.gen_cross_tmp_variable(left, val.right)
+			sym := g.table.get_type_symbol(val.left_type)
+			if _ := g.table.type_find_method(sym, val.op.str()) {
+				left_styp := g.typ(val.left_type.set_nr_muls(0))
+				g.write(left_styp)
+				g.write('_')
+				g.write(util.replace_op(val.op.str()))
+				g.write('(')
+				g.gen_cross_tmp_variable(left, val.left)
+				g.write(', ')
+				g.gen_cross_tmp_variable(left, val.right)
+				g.write(')')
+			} else {
+				g.gen_cross_tmp_variable(left, val.left)
+				g.write(val.op.str())
+				g.gen_cross_tmp_variable(left, val.right)
+			}
 		}
 		ast.PrefixExpr {
 			g.write(val.op.str())

--- a/vlib/v/tests/cross_assign_test.v
+++ b/vlib/v/tests/cross_assign_test.v
@@ -1,3 +1,5 @@
+import math.big
+
 // Test cross assign of array elements
 fn test_cross_assign_of_array() {
 	mut a := [0, 1]
@@ -156,4 +158,13 @@ fn test_cross_assign_of_complex_types() {
 	assert m['two'] == 3
 	assert x.a == 2
 	assert x.b == -1
+}
+
+fn test_cross_assign_of_big_int() {
+	mut a := big.zero_int
+	mut b := big.one_int
+
+	a, b = a + b, a
+	println(a)
+	assert a == big.one_int
 }


### PR DESCRIPTION
This PR fix cross assign math big int (fix #12184).

- Fix cross assign math big int.
- Add test.

```vlang
import math.big

fn main() {
	mut a := big.zero_int
	mut b := big.one_int

	a, b = a + b, a
	println(a)
	assert a == big.one_int
}

PS D:\Test\v\tt1> v run .
1
```