### PR TITLE
math: add fn clamp

### DIFF
--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -87,6 +87,18 @@ pub fn minmax(a f64, b f64) (f64, f64) {
 	return b, a
 }
 
+// clamp returns x constrained between a and b
+[inline]
+pub fn clamp(x f64, a f64, b f64) f64 {
+	if x < a {
+		return a
+	}
+	if x > b {
+		return b
+	}
+	return x
+}
+
 // sign returns the corresponding sign -1.0, 1.0 of the provided number.
 // if n is not a number, its sign is nan too.
 [inline]

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -435,6 +435,14 @@ fn test_min() {
 	}
 }
 
+fn test_clamp() {
+	assert clamp(2, 5, 10) == 5
+	assert clamp(7, 5, 10) == 7
+	assert clamp(15, 5, 10) == 10
+	assert clamp(5, 5, 10) == 5
+	assert clamp(10, 5, 10) == 10
+}
+
 fn test_signi() {
 	assert signi(inf(-1)) == -1
 	assert signi(-72234878292.4586129) == -1


### PR DESCRIPTION
PR adds function `math.clamp(x, a, b)`, because writing `math.min(math.max(x, a), b)` is inconvenient.

References:
- [Unity Mathf.Clamp](https://docs.unity3d.com/ScriptReference/Mathf.Clamp.html)
- [GLSL clamp](https://docs.gl/sl4/clamp)
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
