### PR TITLE
builder: remove os.system() in v run

### DIFF
--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -121,7 +121,8 @@ fn (mut b Builder) run_compiled_executable_and_exit() {
 	if b.pref.is_test || b.pref.is_run {
 		compiled_file := os.real_path(b.pref.out_name)
 		run_file := if b.pref.backend.is_js() {
-			os.find_abs_path_of_executable('node') or {
+			node_basename := $if windows { 'node.exe' } $else { 'node' }
+			os.find_abs_path_of_executable(node_basename) or {
 				panic('Could not find `node` in system path. Do you have Node.js installed?')
 			}
 		} else {


### PR DESCRIPTION
Fixes #12206 
PR removes `os.system()` call in `run_compiled_executable_and_exit()` in favor of `os.new_process()`.

Before PR, arguments with dollar signs, quotes, double quotes, backticks, semicolons, asterisks, newlines, and maybe some other symbols I don't know about would work incorrectly.
For example, command `v run examples/cli.v 'version$(cat /etc/passwd >&2)'` results in following output (note that the argument is enclosed in single quotes and thus not expanded by my shell):
```
root:x:0:0:root:/root:/bin/bash
nobody:x:99:99:Unprivileged User:/dev/null:/bin/false
<...>
cli version 1.0.0
```
Here, cli.v is called with `os.args: ['/v/examples/cli', 'version']`


For more verbose info/reasoning see #12206


<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
