### PR TITLE
parser: fix checking unexpected name

### DIFF
--- a/vlib/v/checker/tests/error_with_comment_with_crlf_ending.out
+++ b/vlib/v/checker/tests/error_with_comment_with_crlf_ending.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/error_with_comment_with_crlf_ending.vv:2:6: error: unexpected name `should`
+vlib/v/checker/tests/error_with_comment_with_crlf_ending.vv:2:1: error: unexpected name `This`
     1 | // Empty lines don't cause an issue but as soon as there's a comment with a CRLF ending, it fails
     2 | This should cause an error!
-      |      ~~~~~~
+      | ~~~~

--- a/vlib/v/checker/tests/error_with_comment_with_lf_ending.out
+++ b/vlib/v/checker/tests/error_with_comment_with_lf_ending.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/error_with_comment_with_lf_ending.vv:2:6: error: unexpected name `should`
+vlib/v/checker/tests/error_with_comment_with_lf_ending.vv:2:1: error: unexpected name `This`
     1 | // Empty lines don't cause an issue but as soon as there's a comment with a CRLF ending, it fails
     2 | This should cause an error!
-      |      ~~~~~~
+      | ~~~~

--- a/vlib/v/checker/tests/multi_names_err.out
+++ b/vlib/v/checker/tests/multi_names_err.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/multi_names_err.vv:2:4: error: unexpected name `a`
+vlib/v/checker/tests/multi_names_err.vv:2:2: error: unexpected name `a`
     1 | fn main() {
     2 |     a a a a := 1
-      |       ^
+      |     ^
     3 | }

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -734,7 +734,7 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 					pos: spos.extend(p.tok.position())
 				}
 			} else if p.peek_tok.kind == .name {
-				return p.error_with_pos('unexpected name `$p.peek_tok.lit`', p.peek_tok.position())
+				return p.error_with_pos('unexpected name `$p.tok.lit`', p.tok.position())
 			} else if !p.inside_if_expr && !p.inside_match_body && !p.inside_or_expr
 				&& p.peek_tok.kind in [.rcbr, .eof] && !p.mark_var_as_used(p.tok.lit) {
 				return p.error_with_pos('`$p.tok.lit` evaluated but not used', p.tok.position())

--- a/vlib/v/parser/tests/unexpected_name_err.out
+++ b/vlib/v/parser/tests/unexpected_name_err.out
@@ -1,0 +1,6 @@
+vlib/v/parser/tests/unexpected_name_err.vv:2:2: error: unexpected name `asfasfasfsfa`
+    1 | fn main() {
+    2 |     asfasfasfsfa
+      |     ~~~~~~~~~~~~
+    3 |     println('text')
+    4 | }

--- a/vlib/v/parser/tests/unexpected_name_err.vv
+++ b/vlib/v/parser/tests/unexpected_name_err.vv
@@ -1,0 +1,4 @@
+fn main() {
+	asfasfasfsfa
+	println('text')
+}


### PR DESCRIPTION
This PR fix checking unexpected name.

- Fix checking unexpected name.
- Add test.

```vlang
fn main() {
	asfasfasfsfasf
	println('text')
}

PS D:\Test\v\tt1> v run .
.\tt1.v:2:2: error: unexpected name `asfasfasfsfasf`
    1 | fn main() {
    2 |     asfasfasfsfasf
      |     ~~~~~~~~~~~~~~
    3 |     println('text')
    4 | }
```