### PR TITLE
builder: Pass -std=gnu99 to the C backend under linux.

### DIFF
--- a/cmd/v/help/build-c.txt
+++ b/cmd/v/help/build-c.txt
@@ -243,7 +243,7 @@ see also `v help build`.
       compiler, on the command line, without writing an .rsp file first.
 
    -no-std
-      By default, V passes -std=c99 to the C backend, but some compilers do
+      By default, V passes -std=gnu99(linux)/-std=c99 to the C backend, but some compilers do
       not support that, even though they may be able to compile the produced
       code, or have other options that can be tuned to allow it.
       Passing -no-std will remove that flag, and you can then use -cflags ''

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -162,7 +162,11 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	// arguments for the C compiler
 	ccoptions.args = [v.pref.cflags]
 	if !v.pref.no_std {
-		ccoptions.args << '-std=c99 -D_DEFAULT_SOURCE'
+		if v.pref.os == .linux {
+			ccoptions.args << '-std=gnu99 -D_DEFAULT_SOURCE'
+		} else {
+			ccoptions.args << '-std=c99 -D_DEFAULT_SOURCE'
+		}
 	}
 	ccoptions.wargs = [
 		'-Wall',

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -176,7 +176,7 @@ pub mut:
 	fatal_errors        bool        // unconditionally exit after the first error with exit(1)
 	reuse_tmpc          bool        // do not use random names for .tmp.c and .tmp.c.rsp files, and do not remove them
 	no_rsp              bool        // when true, pass C backend options directly on the CLI (do not use `.rsp` files for them, some older C compilers do not support them)
-	no_std              bool        // when true, do not pass -std=c99 to the C backend
+	no_std              bool        // when true, do not pass -std=gnu99(linux)/-std=c99 to the C backend
 	use_color           ColorOutput // whether the warnings/errors should use ANSI color escapes.
 	no_parallel         bool
 	is_vweb             bool // skip _ var warning in templates


### PR DESCRIPTION
With some linux toolchains pthreads read-write locks are conditionally defined. 
Using -std-gnu99 with linux unlocks that functionality that for some reason ANSI C does not.
https://git.iem.at/cm/aoo/-/issues/9

gnu99 should be fine for linux builds.  We were using gnu99 universally until this commit anyway.
https://github.com/vlang/v/commit/eef7eea7bc13b53f190d8540247959ab548ce4dd

Partially fixes my issue here.
https://github.com/vlang/v/commit/eef7eea7bc13b53f190d8540247959ab548ce4dd

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
