### PR TITLE
toml: fix bin, oct and hex capital identifier check

### DIFF
--- a/vlib/toml/checker/checker.v
+++ b/vlib/toml/checker/checker.v
@@ -101,6 +101,10 @@ fn (c Checker) check_number(num ast.Number) ? {
 	} else {
 		if !hex_bin_oct {
 			if !is_float && lit[0] == `0` {
+				if lit[1] in [`B`, `O`, `X`] {
+					return error(@MOD + '.' + @STRUCT + '.' + @FN +
+						' numbers like "$lit" only lowercase notation in ...${c.excerpt(num.pos)}...')
+				}
 				return error(@MOD + '.' + @STRUCT + '.' + @FN +
 					' numbers like "$lit" can not start with a zero in ...${c.excerpt(num.pos)}...')
 			}

--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -21,7 +21,6 @@ const (
 		'string/basic-out-of-range-unicode-escape-2.toml',
 		'string/bad-uni-esc.toml',
 		// Integer
-		'integer/capital-bin.toml',
 		'integer/invalid-bin.toml',
 		'integer/invalid-oct.toml',
 		// Encoding


### PR DESCRIPTION
TOML format doesn't accept `0X`, `0B` and `0O` as hex, bin and oct notation prefixes - this PR fixes that