### PR TITLE
toml: squash recently fixed invalid tests

### DIFF
--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -23,16 +23,7 @@ const (
 		'encoding/bad-utf8-in-comment.toml',
 		'encoding/bad-utf8-in-string.toml',
 		// Float
-		'float/exp-double-us.toml',
 		'float/exp-leading-us.toml',
-		'float/nan_underscore.toml',
-		'float/nan-incomplete-1.toml',
-		'invalid/float/exp-point-1.toml',
-		'float/trailing-us.toml',
-		'float/us-after-point.toml',
-		'float/exp-double-e-1.toml',
-		'float/inf-incomplete-1.toml',
-		'float/inf_underscore.toml',
 		// Table
 		'table/rrbrace.toml',
 		'table/duplicate-table-array2.toml',


### PR DESCRIPTION
This PR removes some previously skipped invalid tests that now pass because of recent updates to the `toml` module :partying_face: 