### PR TITLE
android: hide printf hijack for android logging behind define

### DIFF
--- a/thirdparty/sokol/sokol_v.pre.h
+++ b/thirdparty/sokol/sokol_v.pre.h
@@ -1,4 +1,4 @@
-#ifndef V_ANDROID_LOG_PRINT_OFF
+#if defined(V_ANDROID_LOG_PRINT)
 	#if defined(__ANDROID__)
 		// Adapted from https://stackoverflow.com/a/196018/1904615
 		#define V_ANDROID_LOG_STR_VALUE(arg) #arg


### PR DESCRIPTION
With this PR I'm trying to resolve a [vab issue](https://github.com/vlang/vab/issues/130) where user @xandro0777 can't log to a file instead of the default device log because of [the `printf` re-define](https://github.com/vlang/v/blob/76ff708cf83bba06e42921c94b616ef6ebe3015d/thirdparty/sokol/sokol_v.pre.h#L17). Since the `printf` hi-jack is a little hacky and was unexpected behaviour to an end user I think the best option right now might be to hide the functionality behind `-DV_ANDROID_LOG_PRINT` - my thought is then to bake it into `vab` as default behaviour - but add an option to disable it (so we enable it per default in `vab` builds - letting `vab` pass the define automagically). We then avoid confusing users but keep and document the functionality.

An alternative is to introduce a dedicated `android` module that wraps the log calls?
Or maybe implement it so the existing `log` module (that has the same log levels as android) will use the `__android_log` calls on Android :man_shrugging: 

I'd prefer that the `printf` redefine stays since it makes debugging APK/AAB's easier in the current setup (so `println()` works flawlessly) and thus doesn't introduce an alternative logging/output method for Android. I think most users expect their `println('...')` to end up in the android device log.

Since `vab` is an official tool I think it's alright to lay the burden of enabling the `printf` re-define in the tool's hands - and provide an option for users to disable it and do whatever they want with their `printf` :slightly_smiling_face:  