### PR TITLE
toml: check for exponents starting with an underscore

### DIFF
--- a/vlib/toml/checker/checker.v
+++ b/vlib/toml/checker/checker.v
@@ -160,6 +160,10 @@ fn (c Checker) check_number(num ast.Number) ? {
 	}
 
 	if has_exponent_notation {
+		if lit.to_lower().all_after('e').starts_with('_') {
+			return error(@MOD + '.' + @STRUCT + '.' + @FN +
+				' the exponent in "$lit" can not start with an underscore in ...${c.excerpt(num.pos)}...')
+		}
 		if lit.to_lower().all_after('e').contains('.') {
 			return error(@MOD + '.' + @STRUCT + '.' + @FN +
 				' numbers like "$lit" (with exponent) can not have a decimal point in ...${c.excerpt(num.pos)}...')

--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -22,8 +22,6 @@ const (
 		// Encoding
 		'encoding/bad-utf8-in-comment.toml',
 		'encoding/bad-utf8-in-string.toml',
-		// Float
-		'float/exp-leading-us.toml',
 		// Table
 		'table/rrbrace.toml',
 		'table/duplicate-table-array2.toml',


### PR DESCRIPTION
This PR disallows exponents starting with `_`:
```toml
exp-leading-us = 1e_23
```
This also squashes the last invalid float test :partying_face: 