### PR TITLE
Regex: added error on OR token case with char classes

### DIFF
--- a/vlib/regex/README.md
+++ b/vlib/regex/README.md
@@ -28,6 +28,7 @@ simple token, is a single character.
 `abc` OR `ebc`. Instead it is evaluated like `ab`, followed by `c OR e`,
 followed by `bc`, because the **token is the base element**,
 not the sequence of symbols.
+Note: **Two char classes with an `OR` in the middle is a syntax error.**
 
 - The **match operation stops at the end of the string**. It does *NOT* stop 
 at new line characters.
@@ -155,6 +156,7 @@ match too, finally test the token `c`.
 
 NB: ** unlike in PCRE, the OR operation works at token level!** 
 It doesn't work at concatenation level!
+NB2: **Two char classes with an `OR` in the middle is a syntax error.**
 
 That also means, that a query string like `abc|bde` is not equal to 
 `(abc)|(bde)`, but instead to `ab(c|b)de.
@@ -474,21 +476,21 @@ the behavior of the parser itself.
 ```v ignore
 // example of flag settings
 mut re := regex.new()
-re.flag = regex.F_BIN
+re.flag = regex.f_bin
 ```
 
-- `F_BIN`: parse a string as bytes, utf-8 management disabled.
+- `f_bin`: parse a string as bytes, utf-8 management disabled.
 
-- `F_EFM`: exit on the first char matches in the query, used by the 
+- `f_efm`: exit on the first char matches in the query, used by the 
            find function.
 	
-- `F_MS`:  matches only if the index of the start match is 0,
+- `f_ms`:  matches only if the index of the start match is 0,
            same as `^` at the start of the query string.
 	
-- `F_ME`:  matches only if the end index of the match is the last char
+- `f_me`:  matches only if the end index of the match is the last char
            of the input string, same as `$` end of query string.
 	
-- `F_NL`:  stop the matching if found a new line char `\n` or `\r`
+- `f_nl`:  stop the matching if found a new line char `\n` or `\r`
 
 ## Functions
 

--- a/vlib/regex/regex_test.v
+++ b/vlib/regex/regex_test.v
@@ -389,9 +389,8 @@ fn test_regex(){
 		}
 
 		if start != to.s || end != to.e {
-			//println("#$c [$to.src] q[$to.q] res[$tmp_str] $start, $end")
+			println("#$c [$to.src] q[$to.q] res[$tmp_str] base:[${to.s},${to.e}] $start, $end")
 			eprintln("ERROR!")
-			//C.printf("ERROR!! res:(%d, %d) refh:(%d, %d)\n",start, end, to.s, to.e)
 			assert false
 			continue
 		}	
@@ -430,8 +429,8 @@ fn test_regex(){
 			for ln:=0; ln < re.groups.len; ln++ {
 				if re.groups[ln] != to.cg[ln] {
 					eprintln("Capture group doesn't match:")
-					eprintln("true ground: [${to.cg}]")
-					eprintln("elaborated : [${re.groups}]")
+					eprintln("true ground: ${to.cg}")
+					eprintln("elaborated : ${re.groups}")
 					assert false
 				}
 			} 
@@ -551,7 +550,6 @@ fn test_regex(){
 		if start != to.s || end != to.e {
 			eprintln("#$c [$to.src] q[$to.q] res[$tmp_str] $start, $end")
 			eprintln("ERROR!")
-			//C.printf("ERROR!! res:(%d, %d) refh:(%d, %d)\n",start, end, to.s, to.e)
 			assert false
 			continue
 		}
@@ -705,4 +703,20 @@ fn test_groups_in_find(){
 		assert end == test_obj.e
 		assert re.groups == test_obj.res
 	}
+}
+
+const(
+	err_query_list = [
+		r'([a]|[b])*'
+	]
+)
+fn test_errors(){
+	mut count := 0
+	for query in err_query_list {
+		_, err, _ := regex.regex_base(query)
+		if err != regex.compile_ok {
+			count++
+		}
+	}
+	assert count == err_query_list.len
 }


### PR DESCRIPTION
**What's inside**
This PR manage the syntax error for the case of `[a-c]|[df]`, this must be written as `[a-cd-f]`
- added the error management for this case
- added test for the errors management
- improved errors management
- small update to the doc