### PR TITLE
example: fix 180 turn in snek

### DIFF
--- a/examples/snek/snek.v
+++ b/examples/snek/snek.v
@@ -55,6 +55,7 @@ mut:
 	best       HighScore
 	snake      []Pos
 	dir        Direction
+	last_dir   Direction
 	food       Pos
 	start_time i64
 	last_tick  i64
@@ -70,6 +71,7 @@ fn (mut app App) reset_game() {
 		Pos{0, 8},
 	]
 	app.dir = .right
+	app.last_dir = app.dir
 	app.food = Pos{10, 8}
 	app.start_time = time.ticks()
 	app.last_tick = time.ticks()
@@ -91,22 +93,22 @@ fn (mut app App) move_food() {
 fn on_keydown(key gg.KeyCode, mod gg.Modifier, mut app App) {
 	match key {
 		.w, .up {
-			if app.dir != .down {
+			if app.last_dir != .down {
 				app.dir = .up
 			}
 		}
 		.s, .down {
-			if app.dir != .up {
+			if app.last_dir != .up {
 				app.dir = .down
 			}
 		}
 		.a, .left {
-			if app.dir != .right {
+			if app.last_dir != .right {
 				app.dir = .left
 			}
 		}
 		.d, .right {
-			if app.dir != .left {
+			if app.last_dir != .left {
 				app.dir = .right
 			}
 		}
@@ -150,6 +152,8 @@ fn on_frame(mut app App) {
 			}
 			app.snake << app.snake.last() + app.snake.last() - app.snake[app.snake.len - 2]
 		}
+
+		app.last_dir = app.dir
 	}
 	// drawing snake
 	for pos in app.snake {


### PR DESCRIPTION
Closes https://github.com/vlang/v/issues/12285

Fix movement in snek example. Do not allow the snake to move 180 degrees (into itself) in a single tick.

Current logic does not take previous movement direction into account. It only avoids reversing the direction in a single event. One can thus reverse the direction in a single tick by doing two 90 degree turns.

To avoid the snake reversing into itself, the suggestion stores the previous movement direction and uses it to avoid reversing the direction inside of a single tick.