### PR TITLE
table: fix generic sumtype insts (fix #12199 #12200)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1771,10 +1771,18 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 							}
 						}
 						for i in 0 .. variants.len {
-							if t_typ := t.resolve_generic_to_concrete(variants[i], generic_names,
-								info.concrete_types)
-							{
-								variants[i] = t_typ
+							if variants[i].has_flag(.generic) {
+								sym := t.get_type_symbol(variants[i])
+								if sym.kind == .struct_ && variants[i].idx() != info.parent_idx {
+									variants[i] = t.unwrap_generic_type(variants[i], generic_names,
+										info.concrete_types)
+								} else {
+									if t_typ := t.resolve_generic_to_concrete(variants[i],
+										generic_names, info.concrete_types)
+									{
+										variants[i] = t_typ
+									}
+								}
 							}
 						}
 						typ.info = SumType{

--- a/vlib/v/tests/generic_sumtype_insts_test.v
+++ b/vlib/v/tests/generic_sumtype_insts_test.v
@@ -1,0 +1,16 @@
+struct Foo<T> {
+	x T
+}
+
+struct Bar<T> {
+	x T
+}
+
+type MyType<T> = Bar<T> | Foo<T>
+
+fn test_generic_sumtype_insts() {
+	f := Foo<string>{'hi'}
+	t := MyType<string>(f)
+	println(t.type_name())
+	assert t.type_name() == 'Foo<string>'
+}


### PR DESCRIPTION
This PR fix generic sumtype insts (fix #12199, fix #12200).

- Fix generic sumtype insts.
- Add test.

```vlang
struct Foo<T> {
	x T
}

struct Bar<T> {
	x T
}

type MyType<T> = Bar<T> | Foo<T>

fn main() {
	f := Foo<string>{'hi'}
	t := MyType<string>(f)
	println(t.type_name())
	assert t.type_name() == 'Foo<string>'
}

PS D:\Test\v\tt1> v run .
Foo<string>
```
```vlang
struct Foo<T> {
	x T
}

struct Bar<T> {
	x T
}

type MyType<T> = Bar<T> | Foo<T>

fn main() {
	f := Foo<string>{'hi'}
	t := MyType<string>(f)
	println(t.x)
}

PS D:\Test\v\tt1> v run .
hi
```