### PR TITLE
table: fix generic method with multi generic types (fix #12275)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1690,7 +1690,9 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 
 						parent_sym := t.get_type_symbol(parent_info.parent_type)
 						for method in parent_sym.methods {
-							t.register_fn_concrete_types(method.name, info.concrete_types)
+							if method.generic_names.len == info.concrete_types.len {
+								t.register_fn_concrete_types(method.name, info.concrete_types)
+							}
 						}
 					} else {
 						util.verror('generic error', 'the number of generic types of struct `$parent.name` is inconsistent with the concrete types')

--- a/vlib/v/tests/generics_method_with_multi_types_test.v
+++ b/vlib/v/tests/generics_method_with_multi_types_test.v
@@ -1,0 +1,30 @@
+interface Something {
+	i int
+}
+
+struct Some {
+	i int
+}
+
+struct App<M> {
+	f M
+}
+
+fn (mut self App<M>) next<M, T>(input T) f64 {
+	$if M is Something {
+		return 0
+	} $else {
+		panic('${typeof(M.typ).name} is not supported')
+		return 1
+	}
+	return 1
+}
+
+fn test_generic_method_with_multi_types() {
+	mut app := App<Some>{
+		f: Some{
+			i: 10
+		}
+	}
+	assert app.next(1) == 0
+}


### PR DESCRIPTION
This PR fix generic method with multi generic types (fix #12275).

- Fix generic method with multi generic types.
- Add test.

```vlang
interface Something {
	i int
}

struct Some {
	i int
}

struct App<M> {
	f M
}

fn (mut self App<M>) next<M, T>(input T) f64 {
	$if M is Something {
		return 0
	} $else {
		panic('${typeof(M.typ).name} is not supported')
		return 1
	}
	return 1
}

fn main() {
	mut app := App<Some>{
		f: Some{
			i: 10
		}
	}
	assert app.next(1) == 0
}

PS D:\Test\v\tt1> v run .
```