### PR TITLE
net/http: Use [params] for header Config structs

### DIFF
--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -432,17 +432,16 @@ pub fn (mut h Header) delete_custom(key string) {
 	}
 }
 
+[params]
 pub struct HeaderCoerceConfig {
 	canonicalize bool
 }
 
 // coerce coerces data in the Header by joining keys that match
 // case-insensitively into one entry.
-pub fn (mut h Header) coerce(flags ...HeaderCoerceConfig) {
-	canon := flags.any(it.canonicalize)
-
+pub fn (mut h Header) coerce(flags HeaderCoerceConfig) {
 	for kl, data_keys in h.keys {
-		master_key := if canon { canonicalize(kl) } else { data_keys[0] }
+		master_key := if flags.canonicalize { canonicalize(kl) } else { data_keys[0] }
 
 		// save master data
 		master_data := h.data[master_key]
@@ -465,13 +464,14 @@ pub fn (h Header) contains(key CommonHeader) bool {
 	return h.contains_custom(key.str())
 }
 
+[params]
 pub struct HeaderQueryConfig {
 	exact bool
 }
 
 // contains_custom returns whether the custom header key exists in the map.
-pub fn (h Header) contains_custom(key string, flags ...HeaderQueryConfig) bool {
-	if flags.any(it.exact) {
+pub fn (h Header) contains_custom(key string, flags HeaderQueryConfig) bool {
+	if flags.exact {
 		return key in h.data
 	}
 	return key.to_lower() in h.keys
@@ -485,9 +485,9 @@ pub fn (h Header) get(key CommonHeader) ?string {
 
 // get_custom gets the first value for the custom header, or none if
 // the key does not exist.
-pub fn (h Header) get_custom(key string, flags ...HeaderQueryConfig) ?string {
+pub fn (h Header) get_custom(key string, flags HeaderQueryConfig) ?string {
 	mut data_key := key
-	if !flags.any(it.exact) {
+	if !flags.exact {
 		// get the first key from key metadata
 		k := key.to_lower()
 		if h.keys[k].len == 0 {
@@ -518,8 +518,8 @@ pub fn (h Header) values(key CommonHeader) []string {
 }
 
 // custom_values gets all values for the custom header.
-pub fn (h Header) custom_values(key string, flags ...HeaderQueryConfig) []string {
-	if flags.any(it.exact) {
+pub fn (h Header) custom_values(key string, flags HeaderQueryConfig) []string {
+	if flags.exact {
 		return h.data[key]
 	}
 	// case insensitive lookup


### PR DESCRIPTION
Previous methods were abusing ellipses to make the argument optional.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
