### PR TITLE
toml: check for invalid placement of underscores around exponent

### DIFF
--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -19,8 +19,6 @@ const (
 		'string/basic-out-of-range-unicode-escape-1.toml',
 		'string/basic-out-of-range-unicode-escape-2.toml',
 		'string/bad-uni-esc.toml',
-		// Float
-		'float/trailing-us-exp.toml',
 		// Encoding
 		'encoding/bad-utf8-in-comment.toml',
 		'encoding/bad-utf8-in-string.toml',


### PR DESCRIPTION
This PR fixes the recent test addition that was made in the BurntSushi testsuite