### PR TITLE
parser: implement generics method with auto multi generic types

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -315,10 +315,15 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	// <T>
 	mut generic_names := p.parse_generic_names()
 	// generic names can be infer with receiver's generic names
-	if is_method && rec.typ.has_flag(.generic) && generic_names.len == 0 {
+	if is_method && rec.typ.has_flag(.generic) {
 		sym := p.table.get_type_symbol(rec.typ)
 		if sym.info is ast.Struct {
-			generic_names = sym.info.generic_types.map(p.table.get_type_symbol(it).name)
+			rec_generic_names := sym.info.generic_types.map(p.table.get_type_symbol(it).name)
+			for gname in rec_generic_names {
+				if gname !in generic_names {
+					generic_names << gname
+				}
+			}
 		}
 	}
 	// Args

--- a/vlib/v/tests/generics_method_with_multi_types_test.v
+++ b/vlib/v/tests/generics_method_with_multi_types_test.v
@@ -10,7 +10,27 @@ struct App<M> {
 	f M
 }
 
-fn (mut self App<M>) next<M, T>(input T) f64 {
+fn (mut self App<M>) next1<M, T>(input T) f64 {
+	$if M is Something {
+		return 0
+	} $else {
+		panic('${typeof(M.typ).name} is not supported')
+		return 1
+	}
+	return 1
+}
+
+fn (mut self App<M>) next2<T, M>(input T) f64 {
+	$if M is Something {
+		return 0
+	} $else {
+		panic('${typeof(M.typ).name} is not supported')
+		return 1
+	}
+	return 1
+}
+
+fn (mut self App<M>) next3<T>(input T) f64 {
 	$if M is Something {
 		return 0
 	} $else {
@@ -26,5 +46,7 @@ fn test_generic_method_with_multi_types() {
 			i: 10
 		}
 	}
-	assert app.next(1) == 0
+	assert app.next1(1) == 0
+	assert app.next2(1) == 0
+	assert app.next3(1) == 0
 }


### PR DESCRIPTION
This PR implement generics method with auto multi generic types.

- Implement generics method with auto multi generic types.
- Add test.

```vlang
interface Something {
	i int
}

struct Some {
	i int
}

struct App<M> {
	f M
}

fn (mut self App<M>) next1<M, T>(input T) f64 {
	$if M is Something {
		return 0
	} $else {
		panic('${typeof(M.typ).name} is not supported')
		return 1
	}
	return 1
}

fn (mut self App<M>) next2<T, M>(input T) f64 {
	$if M is Something {
		return 0
	} $else {
		panic('${typeof(M.typ).name} is not supported')
		return 1
	}
	return 1
}

fn (mut self App<M>) next3<T>(input T) f64 {
	$if M is Something {
		return 0
	} $else {
		panic('${typeof(M.typ).name} is not supported')
		return 1
	}
	return 1
}

fn main() {
	mut app := App<Some>{
		f: Some{
			i: 10
		}
	}
	assert app.next1(1) == 0
	assert app.next2(1) == 0
	assert app.next3(1) == 0
}

PS D:\Test\v\tt1> v run .
```