### PR TITLE
Disallow `mut` keyword in right-hand side of assignment

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3717,6 +3717,11 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 					right.pos)
 			}
 		}
+		if right is ast.Ident {
+			if right.is_mut {
+				c.error('unexpected `mut` on right-hand side of assignment', right.mut_pos)
+			}
+		}
 	}
 	if node.left.len != right_len {
 		if right_first is ast.CallExpr {

--- a/vlib/v/checker/tests/right_hand_side_mut.out
+++ b/vlib/v/checker/tests/right_hand_side_mut.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/right_hand_side_mut.vv:4:19: error: unexpected `mut` on right-hand side of assignment
+    2 |     mut flubbel := 123
+    3 |     mut wubbel := 234
+    4 |     _, _ := flubbel, mut wubbel
+      |                      ~~~
+    5 |     print(wubbel)
+    6 | }

--- a/vlib/v/checker/tests/right_hand_side_mut.vv
+++ b/vlib/v/checker/tests/right_hand_side_mut.vv
@@ -1,0 +1,6 @@
+fn main() {
+	mut flubbel := 123
+	mut wubbel := 234
+	_, _ := flubbel, mut wubbel
+	print(wubbel)
+}


### PR DESCRIPTION
Fixes #12311
Related to #8187

I'm not entirely sure if somethings missing, as I'm not very familiar with the code base / language as of yet :D Some feedback would be most welcome!