### PR TITLE
toml: improve array parsing

### DIFF
--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -23,7 +23,7 @@ const (
 		'table/duplicate-table-array.toml',
 		// Array
 		'array/tables-1.toml',
-		'array/missing-separator.toml',
+		//'array/missing-separator.toml',
 		'array/text-after-array-entries.toml',
 		'array/text-before-array-separator.toml',
 		// Date / Time


### PR DESCRIPTION
This PR improves array parsing by checking for some invalid cases.
It also now actually add parsed inline-tables to the arrays... :roll_eyes: :grimacing: 