### PR TITLE
toml: fix paths in skipped tests for Windows compatibility

### DIFF
--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -93,7 +93,7 @@ fn test_burnt_sushi_tomltest() {
 		mut invalid := 0
 		e = 0
 		for i, invalid_test_file in invalid_test_files {
-			relative := invalid_test_file.all_after(os.join_path('toml-test', 'tests',
+			mut relative := invalid_test_file.all_after(os.join_path('toml-test', 'tests',
 				'invalid')).trim_left(os.path_separator)
 			$if windows {
 				relative = relative.replace('/', '\\')


### PR DESCRIPTION
This should fix some of the issues running the test suite on Windows (Related: #12300)