### PR TITLE
Improve error message when trying to assign the result of a push to a variable

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3713,8 +3713,10 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		}
 		if right is ast.InfixExpr {
 			if right.op == .arrow {
-				c.error('cannot use `<-` on the right-hand side of an assignment, as it does not return any values',
-					right.pos)
+				c.error(
+					'Trying to assign the result of a channel push operation (<-) to a variable. ' +
+					'This is invalid, because the push operation does not return a result.',
+					node.pos)
 			}
 		}
 	}

--- a/vlib/v/checker/tests/assign_expr_channel_push.out
+++ b/vlib/v/checker/tests/assign_expr_channel_push.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/assign_expr_channel_push.vv:2:9: error: cannot use `<-` on the right-hand side of an assignment, as it does not return any values
+vlib/v/checker/tests/assign_expr_channel_push.vv:2:3: error: Trying to assign the result of a channel push operation (<-) to a variable. This is invalid, because the push operation does not return a result.
     1 | ch := chan f64{}
     2 | _ := ch <- 4.56
-      |         ~~
+      |   ~~


### PR DESCRIPTION
As @JalonSolov pointed out in #12318, the error message I came up with wasn't great, since `<-` can indeed be used on the right-hand side of an assignment when it's pulling from a channel. I thus reworded the error message.

Related to: #12309



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
