### PR TITLE
cgen: fix error of nested match expr (fix #12263)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1557,7 +1557,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 			// }
 			old_is_void_expr_stmt := g.is_void_expr_stmt
 			g.is_void_expr_stmt = !node.is_expr
-			if node.typ != ast.void_type && g.expected_cast_type != 0 {
+			if node.typ != ast.void_type && g.expected_cast_type != 0 && node.expr !is ast.MatchExpr {
 				g.expr_with_cast(node.expr, node.typ, g.expected_cast_type)
 			} else {
 				g.expr(node.expr)

--- a/vlib/v/tests/match_expr_nested_test.v
+++ b/vlib/v/tests/match_expr_nested_test.v
@@ -1,0 +1,35 @@
+struct Abc {}
+
+type Test = Abc | bool | int
+
+fn test(a Test) Test {
+	return match a {
+		Abc {
+			20
+		}
+		int {
+			match a {
+				1 { true }
+				2 { false }
+				else { -1 }
+			}
+		}
+		bool {
+			1
+		}
+	}
+}
+
+fn test_nested_match_expr() {
+	println(test(1))
+	assert test(1) == Test(true)
+
+	println(test(2))
+	assert test(2) == Test(false)
+
+	println(test(3))
+	assert test(3) == Test(-1)
+
+	println(test(true))
+	assert test(true) == Test(1)
+}


### PR DESCRIPTION
This PR fix error of nested match expr (fix #12263).

- Fix error of nested match expr.
- Add test.

```vlang
struct Abc {}

type Test = Abc | bool | int

fn test(a Test) Test {
	return match a {
		Abc {
			20
		}
		int {
			match a {
				1 { true }
				2 { false }
				else { -1 }
			}
		}
		bool {
			1
		}
	}
}

fn main() {
	println(test(1))
	assert test(1) == Test(true)

	println(test(2))
	assert test(2) == Test(false)

	println(test(3))
	assert test(3) == Test(-1)

	println(test(true))
	assert test(true) == Test(1)
}

PS D:\Test\v\tt1> v run .
Test(true)
Test(false)
Test(-1)
Test(1)
```