### PR TITLE
examples: game of life: remove unused work-around

### DIFF
--- a/examples/game_of_life/modules/automaton/automaton.v
+++ b/examples/game_of_life/modules/automaton/automaton.v
@@ -23,7 +23,6 @@ pub fn (a &A2D) set(x int, y int, newval int) {
 		mut e := &int(0)
 		e = a.data + y * a.maxx + x
 		*e = newval
-		_ = e // TODO compiler bug, this is not necessary
 	}
 }
 


### PR DESCRIPTION
The line seems to not affect the compilation anymore and the program still runs without it.