### PR TITLE
examples/vweb: use map instead of string in call to app.json

### DIFF
--- a/examples/vweb/vweb_example.v
+++ b/examples/vweb/vweb_example.v
@@ -26,7 +26,9 @@ fn main() {
 ['/users/:user']
 pub fn (mut app App) user_endpoint(user string) vweb.Result {
 	id := rand.intn(100)
-	return app.json({user: id})
+	return app.json({
+		user: id
+	})
 }
 
 pub fn (mut app App) index() vweb.Result {

--- a/examples/vweb/vweb_example.v
+++ b/examples/vweb/vweb_example.v
@@ -26,7 +26,7 @@ fn main() {
 ['/users/:user']
 pub fn (mut app App) user_endpoint(user string) vweb.Result {
 	id := rand.intn(100)
-	return app.json('{"$user": $id}')
+	return app.json({user: id})
 }
 
 pub fn (mut app App) index() vweb.Result {


### PR DESCRIPTION
Now that vweb encodes the object in `Context.json`, the example was JSON encoding a manually JSON-encoded string.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
