### PR TITLE
strings,builder: reduce V cgen and parser memory consumption, fix strings.Builder leak

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -5,19 +5,26 @@ module builtin
 
 import strings
 
-// array is a struct used for denoting array types in V
+// `array` is a struct, used for denoting all array types in V.
+// `.data` is a void pointer to the backing heap memory block,
+// which avoids using generics and thus without generating extra
+// code for every type.
 pub struct array {
 pub:
 	element_size int // size in bytes of one element in the array.
 pub mut:
 	data   voidptr
 	offset int // in bytes (should be `usize`)
-	len    int // length of the array.
-	cap    int // capacity of the array.
+	len    int // length of the array in elements.
+	cap    int // capacity of the array in elements.
+	flags  ArrayFlags
 }
 
-// array.data uses a void pointer, which allows implementing arrays without generics and without generating
-// extra code for every type.
+[flag]
+pub enum ArrayFlags {
+	noslices
+}
+
 // Internal function, used by V (`nums := []int`)
 fn __new_array(mylen int, cap int, elm_size int) array {
 	cap_ := if cap < mylen { mylen } else { cap }
@@ -104,6 +111,11 @@ fn (mut a array) ensure_cap(required int) {
 	if a.data != voidptr(0) {
 		unsafe { vmemcpy(new_data, a.data, a.len * a.element_size) }
 		// TODO: the old data may be leaked when no GC is used (ref-counting?)
+		if a.flags.has(.noslices) {
+			unsafe {
+				free(a.data)
+			}
+		}
 	}
 	a.data = new_data
 	a.offset = 0

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -238,6 +238,11 @@ pub fn (mut a array) delete_many(i int, size int) {
 		vmemcpy(&byte(a.data) + i * a.element_size, &byte(old_data) + (i + size) * a.element_size,
 			(a.len - i - size) * a.element_size)
 	}
+	if a.flags.has(.noslices) {
+		unsafe {
+			free(old_data)
+		}
+	}
 	a.len = new_size
 	a.cap = new_cap
 }

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -510,7 +510,7 @@ pub fn memdup_noscan(src voidptr, sz int) voidptr {
 		return vcalloc_noscan(1)
 	}
 	unsafe {
-		mem := vcalloc_noscan(sz)
+		mem := malloc_noscan(sz)
 		return C.memcpy(mem, src, sz)
 	}
 }

--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -11,7 +11,9 @@ pub type Builder = []byte
 
 // new_builder returns a new string builder, with an initial capacity of `initial_size`
 pub fn new_builder(initial_size int) Builder {
-	return Builder([]byte{cap: initial_size})
+	mut res := Builder([]byte{cap: initial_size})
+	unsafe { res.flags.set(.noslices) }
+	return res
 }
 
 // write_ptr writes `len` bytes provided byteptr to the accumulated buffer
@@ -161,9 +163,8 @@ pub fn (mut b Builder) str() string {
 pub fn (mut b Builder) free() {
 	if b.data != 0 {
 		unsafe { free(b.data) }
-		mut pd := &b.data
 		unsafe {
-			(*pd) = voidptr(0)
+			b.data = voidptr(0)
 		}
 	}
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1663,8 +1663,9 @@ fn (mut c Checker) fail_if_immutable(expr ast.Expr) (string, token.Position) {
 					c.fail_if_immutable(expr.expr)
 				}
 				.array, .string {
-					// This should only happen in `builtin`
-					if c.file.mod.name != 'builtin' {
+					// should only happen in `builtin` and unsafe blocks
+					inside_builtin := c.file.mod.name == 'builtin'
+					if !inside_builtin && !c.inside_unsafe {
 						c.error('`$typ_sym.kind` can not be modified', expr.pos)
 						return '', expr.pos
 					}

--- a/vlib/v/depgraph/depgraph.v
+++ b/vlib/v/depgraph/depgraph.v
@@ -25,6 +25,12 @@ mut:
 	data map[string][]string
 }
 
+pub fn new_ordered_dependency_map() OrderedDepMap {
+	mut res := OrderedDepMap{}
+	unsafe { res.keys.flags.set(.noslices) }
+	return res
+}
+
 pub fn (mut o OrderedDepMap) set(name string, deps []string) {
 	if name !in o.data {
 		o.keys << name
@@ -92,8 +98,8 @@ pub fn (mut graph DepGraph) add(mod string, deps []string) {
 }
 
 pub fn (graph &DepGraph) resolve() &DepGraph {
-	mut node_names := OrderedDepMap{}
-	mut node_deps := OrderedDepMap{}
+	mut node_names := new_ordered_dependency_map()
+	mut node_deps := new_ordered_dependency_map()
 	for node in graph.nodes {
 		node_names.add(node.name, node.deps)
 		node_deps.add(node.name, node.deps)

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -151,7 +151,11 @@ fn (mut s Scanner) init_scanner() {
 [unsafe]
 pub fn (mut s Scanner) free() {
 	unsafe {
-		s.text.free()
+		// NB: s.text is not freed here, because it is shared with all other util.read_file instances,
+		// and strings are not reference counted yet:
+		// s.text.free()
+		// .all_tokens however are not shared with anything, and can be freed:
+		s.all_tokens.free()
 	}
 }
 

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1455,15 +1455,19 @@ pub fn verror(s string) {
 	util.verror('scanner error', s)
 }
 
+// codegen allows you to generate V code, so that it can be parsed,
+// checked, markused, cgen-ed etc further, just like user's V code.
 pub fn (mut s Scanner) codegen(newtext string) {
 	$if debug_codegen ? {
 		eprintln('scanner.codegen:\n $newtext')
 	}
-	// codegen makes sense only during normal compilation
-	// feeding code generated V code to vfmt or vdoc will
-	// cause them to output/document ephemeral stuff.
 	if s.comments_mode == .skip_comments {
-		s.all_tokens.delete_last() // remove .eof from end of .all_tokens
+		// Calling codegen makes sense only during normal compilation, since
+		// feeding code generated V code to vfmt or vdoc will cause them to
+		// output/document ephemeral stuff.
+		for s.all_tokens.len > 0 && s.all_tokens.last().kind == .eof {
+			s.all_tokens.delete_last()
+		}
 		s.text += newtext
 		old_tidx := s.tidx
 		s.tidx = s.all_tokens.len

--- a/vlib/v/tests/valgrind/strings_builder.v
+++ b/vlib/v/tests/valgrind/strings_builder.v
@@ -1,0 +1,22 @@
+import strings
+
+fn main() {
+	mut sb := strings.new_builder(4)
+	sb.write_string('abcd')
+	sb.write_string('abcd')
+	sb.write_string('abcd')
+	sb.write_string('abcd')
+	sb.write_string('abcd')
+	sb.write_string('abcd')
+	sb.write_string('abcd')
+	sb.write_string('abcd')
+	sb.write_string('abcd')
+	sb.write_string('abcd')
+	sb.write_string('abcd')
+	sb.write_string('abcd')
+	sb.write_string('abcd')
+	sb.write_string('abcd')
+	sb.write_string('abcd')
+	sb.write_string('abcd')
+	println(sb.str())
+}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/26967/139576175-139792d6-3fd6-414f-b4cf-4a5cd929369d.png)

After:
![image](https://user-images.githubusercontent.com/26967/139576186-6360eedd-fbdf-4dd8-a52f-d494dc1e8bf9.png)
