### PR TITLE
checker: fix generic fn with assign of nested generic method call (fix #12332)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2226,13 +2226,15 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 			concrete_types = node.concrete_types
 		}
 		// resolve return generics struct to concrete type
-		if method.generic_names.len > 0 && method.return_type.has_flag(.generic) {
+		if method.generic_names.len > 0 && method.return_type.has_flag(.generic)
+			&& c.table.cur_fn.generic_names.len == 0 {
 			node.return_type = c.table.unwrap_generic_type(method.return_type, method.generic_names,
 				concrete_types)
 		} else {
 			node.return_type = method.return_type
 		}
-		if node.concrete_types.len > 0 && method.return_type != 0 {
+		if node.concrete_types.len > 0 && method.return_type != 0
+			&& c.table.cur_fn.generic_names.len == 0 {
 			if typ := c.table.resolve_generic_to_concrete(method.return_type, method.generic_names,
 				concrete_types)
 			{

--- a/vlib/v/tests/generics_with_nested_generics_method_call_assign_test.v
+++ b/vlib/v/tests/generics_with_nested_generics_method_call_assign_test.v
@@ -1,0 +1,24 @@
+struct SSS<T> {
+mut:
+	x T
+}
+
+fn (s SSS<T>) inner() T {
+	return s.x
+}
+
+fn (s SSS<T>) outer() string {
+	ret := s.inner<T>()
+	println(ret)
+	return '$ret'
+}
+
+fn test_generics_with_nested_generic_method_call_assign() {
+	s1 := SSS<int>{100}
+	s1.outer()
+	assert s1.outer() == '100'
+
+	s2 := SSS<string>{'hello'}
+	s2.outer()
+	assert s2.outer() == 'hello'
+}


### PR DESCRIPTION
This PR fix generic fn with assign of nested generic method call (fix #12332).

- Fix generic fn with assign of nested generic method call.
- Add test.

```vlang
struct SSS<T> {
mut:
	x T
}

fn (s SSS<T>) inner() T {
	return s.x
}

fn (s SSS<T>) outer() string {
	ret := s.inner<T>()
	println(ret)
	return '$ret'
}

fn main() {
	s1 := SSS<int>{100}
	s1.outer()
	assert s1.outer() == '100'

	s2 := SSS<string>{'hello'}
	s2.outer()
	assert s2.outer() == 'hello'
}

PS D:\Test\v\tt1> v run .
100
100
hello
hello
```