### PR TITLE
checker: fix comptime if expr of sync.threads (fix #12349)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4500,7 +4500,7 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 		stmt_pos := node.pos
 		eprintln('checking file: ${c.file.path:-30} | stmt pos: ${stmt_pos.str():-45} | stmt')
 	}
-	// c.expected_type = ast.void_type
+	c.expected_type = ast.void_type
 	match mut node {
 		ast.EmptyStmt {
 			if c.pref.is_verbose {

--- a/vlib/v/tests/comptime_if_expr_threads_test.v
+++ b/vlib/v/tests/comptime_if_expr_threads_test.v
@@ -1,0 +1,27 @@
+import math { floor, sqrt }
+import arrays { sum }
+
+fn async(arr_size int, init_val f64) f64 {
+	mut val_arr := []f64{}
+	for _ in 1 .. arr_size {
+		val_arr << floor((sqrt(init_val) / 2) * 3)
+	}
+
+	return sum(val_arr.map(it / 2)) or { f64(1) }
+}
+
+fn test_comptime_if_expr_of_threads() {
+	size := 2000_000
+
+	println('Async')
+	mut results := []thread f64{cap: 16}
+	for num in 0 .. 15 {
+		results << go async(size, num)
+	}
+	waited_results := results.wait()
+
+	println(waited_results)
+	sum_result := sum(waited_results) or { 1 }
+	println(sum_result)
+	assert sum_result == 4.7999976e+07
+}


### PR DESCRIPTION
This PR fix comptime if expr of sync.threads (fix #12349).

- Fix comptime if expr of sync.threads.
- Add test.

```vlang
import math { floor, sqrt }
import arrays { sum }

fn async(arr_size int, init_val f64) f64 {
	mut val_arr := []f64{}
	for _ in 1 .. arr_size {
		val_arr << floor((sqrt(init_val) / 2) * 3)
	}

	return sum(val_arr.map(it / 2)) or { f64(1) }
}

fn main() {
	size := 2000_000

	println('Async')
	mut results := []thread f64{cap: 16}
	for num in 0 .. 15 {
		results << go async(size, num)
	}
	waited_results := results.wait()

	println(waited_results)
	sum_result := sum(waited_results) or { 1 }
	println(sum_result)
	assert sum_result == 4.7999976e+07
}

PS D:\Test\v\tt1> v run .
Async
[0, 999999.5, 1.999999e+06, 1.999999e+06, 2.9999985e+06, 2.9999985e+06, 2.9999985e+06, 2.9999985e+06, 3.999998e+06, 3.999998e+06, 3.999998e+06, 3.999998e+06, 4.9999975e+06, 4.9999975e+06, 4.9999975e+06]
4.7999976e+07
```