### PR TITLE
docs: change medvednikov/libsodium to vlang/libsodium

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5297,7 +5297,7 @@ This will generate a directory `libsodium` with a V module.
 
 Example of a C2V generated libsodium wrapper:
 
-https://github.com/medvednikov/libsodium
+https://github.com/vlang/libsodium
 
 <br>
 


### PR DESCRIPTION
The link was still valid, but no longer up to date.