### PR TITLE
checker: fix comptime if T is interface (fix #12279)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6678,6 +6678,7 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 						is_comptime_type_is_expr = true
 					} else if branch.cond.right is ast.TypeNode && left is ast.TypeNode
 						&& sym.kind == .interface_ {
+						is_comptime_type_is_expr = true
 						// is interface
 						checked_type := c.unwrap_generic(left.typ)
 						should_skip = !c.table.does_type_implement_interface(checked_type,

--- a/vlib/v/tests/comptime_if_is_interface_test.v
+++ b/vlib/v/tests/comptime_if_is_interface_test.v
@@ -1,0 +1,29 @@
+interface Something {
+	i int
+}
+
+struct Some {
+	i int
+}
+
+struct App {
+mut:
+	count u8
+}
+
+fn (mut self App) next<T>(input T) string {
+	$if T is Something {
+		return 'Something'
+	} $else $if T is f64 {
+		return 'f64'
+	} $else {
+		panic('${typeof(T.typ).name} is not supported')
+	}
+	panic('Unreachable')
+}
+
+fn test_comptime_if_is_interface() {
+	mut app := App{}
+	assert app.next(Something(Some{1})) == 'Something'
+	assert app.next(1.0) == 'f64'
+}


### PR DESCRIPTION
This PR fix comptime if T is interface (fix #12279).

- Fix comptime if T is interface.
- Add test.

```vlang
interface Something {
	i int
}

struct Some {
	i int
}

struct App {
mut:
	count u8
}

fn (mut self App) next<T>(input T) string {
	$if T is Something {
		return 'Something'
	} $else $if T is f64 {
		return 'f64'
	} $else {
		panic('${typeof(T.typ).name} is not supported')
	}
	panic('Unreachable')
}

fn main() {
	mut app := App{}
	assert app.next(Something(Some{1})) == 'Something'
	assert app.next(1.0) == 'f64'
}

PS D:\Test\v\tt1> v run .
```