### PR TITLE
toml: streamline scanner.at() return type, fixes #12344

### DIFF
--- a/vlib/toml/tests/types_test.v
+++ b/vlib/toml/tests/types_test.v
@@ -79,3 +79,14 @@ fn test_hex_values() {
 	assert value as i64 == 11
 	assert value.i64() == 11
 }
+
+fn test_comment_as_last_value() {
+	toml_txt := '
+test = 42
+# this line has comment as last thing'
+	toml_doc := toml.parse(toml_txt) or { panic(err) }
+
+	value := toml_doc.value('test')
+	assert value as i64 == 42
+	assert value.i64() == 42
+}


### PR DESCRIPTION
This PR will fix a minor return type inconsistency in the `scanner.at()` function so that the return type matches the character look-up family of calls.
 
This PR closes #12344 
