### PR TITLE
checker: check generic struct field fn args error (fix #12359)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2277,7 +2277,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	if field := c.table.find_field(left_type_sym, method_name) {
 		field_type_sym := c.table.get_type_symbol(c.unwrap_generic(field.typ))
 		if field_type_sym.kind == .function {
-			// node.is_method = false
+			node.is_method = false
 			node.is_field = true
 			info := field_type_sym.info as ast.FnType
 			node.return_type = info.func.return_type
@@ -2288,6 +2288,8 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 				earg_types << targ
 			}
 			node.expected_arg_types = earg_types
+			c.check_expected_arg_count(mut node, info.func) or { return info.func.return_type }
+			node.is_method = true
 			return info.func.return_type
 		}
 	}

--- a/vlib/v/checker/tests/generics_struct_field_fn_args_err.out
+++ b/vlib/v/checker/tests/generics_struct_field_fn_args_err.out
@@ -1,0 +1,27 @@
+vlib/v/checker/tests/generics_struct_field_fn_args_err.vv:21:20: error: expected 0 arguments, but got 1
+   19 |     }
+   20 |     println(fun0.call())
+   21 |     println(fun0.call(1234))
+      |                       ~~~~
+   22 |     println(fun0.call(1234, 5678))
+   23 |
+vlib/v/checker/tests/generics_struct_field_fn_args_err.vv:22:20: error: expected 0 arguments, but got 2
+   20 |     println(fun0.call())
+   21 |     println(fun0.call(1234))
+   22 |     println(fun0.call(1234, 5678))
+      |                       ~~~~~~~~~~
+   23 |
+   24 |     fun1 := Fun<fn (int) int>{
+vlib/v/checker/tests/generics_struct_field_fn_args_err.vv:29:15: error: expected 1 arguments, but got 0
+   27 |
+   28 |     println(fun1.call(42))
+   29 |     println(fun1.call())
+      |                  ~~~~~~
+   30 |     println(fun1.call(42, 43))
+   31 | }
+vlib/v/checker/tests/generics_struct_field_fn_args_err.vv:30:24: error: expected 1 arguments, but got 2
+   28 |     println(fun1.call(42))
+   29 |     println(fun1.call())
+   30 |     println(fun1.call(42, 43))
+      |                           ~~
+   31 | }

--- a/vlib/v/checker/tests/generics_struct_field_fn_args_err.vv
+++ b/vlib/v/checker/tests/generics_struct_field_fn_args_err.vv
@@ -1,0 +1,31 @@
+fn get_int() int {
+	return 42
+}
+
+fn dub_int(i int) int {
+	return i * 2
+}
+
+struct Fun<F> {
+mut:
+	call F
+}
+
+type FunZero = fn () int
+
+fn main() {
+	fun0 := Fun<FunZero>{
+		call: get_int
+	}
+	println(fun0.call())
+	println(fun0.call(1234))
+	println(fun0.call(1234, 5678))
+
+	fun1 := Fun<fn (int) int>{
+		call: dub_int
+	}
+
+	println(fun1.call(42))
+	println(fun1.call())
+	println(fun1.call(42, 43))
+}


### PR DESCRIPTION
This PR check generic struct field fn args error (fix #12359).

- Check generic struct field fn args error.
- Add test.

```vlang
fn get_int() int {
	return 42
}

fn dub_int(i int) int {
	return i * 2
}

struct Fun<F> {
mut:
	call F
}

type FunZero = fn () int

fn main() {
	fun0 := Fun<FunZero>{
		call: get_int
	}
	println(fun0.call())
	println(fun0.call(1234))
	println(fun0.call(1234, 5678))

	fun1 := Fun<fn (int) int>{
		call: dub_int
	}

	println(fun1.call(42))
	println(fun1.call())
	println(fun1.call(42, 43))
}

PS D:\Test\v\tt1> v run .
.\tt1.v:21:20: error: expected 0 arguments, but got 1
   19 |     }
   20 |     println(fun0.call())
   21 |     println(fun0.call(1234))
      |                       ~~~~
   22 |     println(fun0.call(1234, 5678))
   23 |
.\tt1.v:22:20: error: expected 0 arguments, but got 2
   20 |     println(fun0.call())
   21 |     println(fun0.call(1234))
   22 |     println(fun0.call(1234, 5678))
      |                       ~~~~~~~~~~
   23 |
   24 |     fun1 := Fun<fn (int) int>{
.\tt1.v:29:15: error: expected 1 arguments, but got 0
   27 |
   28 |     println(fun1.call(42))
   29 |     println(fun1.call())
      |                  ~~~~~~
   30 |     println(fun1.call(42, 43))
   31 | }
.\tt1.v:30:24: error: expected 1 arguments, but got 2
   28 |     println(fun1.call(42))
   29 |     println(fun1.call())
   30 |     println(fun1.call(42, 43))
      |                           ~~
   31 | }
```