### PR TITLE
toml: parse formatting

### DIFF
--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -576,14 +576,11 @@ pub fn (mut p Parser) double_array_of_tables(mut table map[string]ast.Value) ? {
 			p.last_aot_index = 0
 		}
 
-		util.printdbg('xxx', '1 now at "$p.tok.kind" "$p.tok.lit"')
 		mut t_arr := &(table[p.last_aot] as []ast.Value)
-		util.printdbg('xxx', '2 now at "$p.tok.kind" "$p.tok.lit"')
 		mut t_map := ast.Value(map[string]ast.Value{})
 		if t_arr.len > 0 {
 			t_map = t_arr[p.last_aot_index]
 		}
-		util.printdbg('xxx', '3 now at "$p.tok.kind" "$p.tok.lit"')
 		mut t := &(t_map as map[string]ast.Value)
 
 		if last in t.keys() {

--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -523,7 +523,7 @@ pub fn (mut p Parser) array_of_tables(mut table map[string]ast.Value) ? {
 			{
 				if val is []ast.Value {
 					arr := &(table[key_str] as []ast.Value)
-					arr << p.double_bracket_array() ?
+					arr << p.array_of_tables_contents() ?
 					table[key_str] = arr
 				} else {
 					return error(@MOD + '.' + @STRUCT + '.' + @FN +
@@ -531,7 +531,7 @@ pub fn (mut p Parser) array_of_tables(mut table map[string]ast.Value) ? {
 				}
 			}
 		} else {
-			table[key_str] = p.double_bracket_array() ?
+			table[key_str] = p.array_of_tables_contents() ?
 		}
 	}
 	p.last_aot = key_str
@@ -594,7 +594,7 @@ pub fn (mut p Parser) double_array_of_tables(mut table map[string]ast.Value) ? {
 			{
 				if val is []ast.Value {
 					arr := &(val as []ast.Value)
-					arr << p.double_bracket_array() ?
+					arr << p.array_of_tables_contents() ?
 					t[last] = arr
 				} else {
 					return error(@MOD + '.' + @STRUCT + '.' + @FN +
@@ -602,7 +602,7 @@ pub fn (mut p Parser) double_array_of_tables(mut table map[string]ast.Value) ? {
 				}
 			}
 		} else {
-			t[last] = p.double_bracket_array() ?
+			t[last] = p.array_of_tables_contents() ?
 		}
 		if t_arr.len == 0 {
 			t_arr << t
@@ -612,7 +612,7 @@ pub fn (mut p Parser) double_array_of_tables(mut table map[string]ast.Value) ? {
 }
 
 // array parses next tokens into an array of `ast.Value`s.
-pub fn (mut p Parser) double_bracket_array() ?[]ast.Value {
+pub fn (mut p Parser) array_of_tables_contents() ?[]ast.Value {
 	util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'parsing array of tables contents from "$p.tok.kind" "$p.tok.lit"')
 	mut tbl := map[string]ast.Value{}
 	for p.tok.kind in [.bare, .quoted, .boolean, .number] {

--- a/vlib/toml/scanner/scanner.v
+++ b/vlib/toml/scanner/scanner.v
@@ -232,7 +232,7 @@ pub fn (s &Scanner) remaining() int {
 }
 
 // next returns the next character code from the input text.
-// next returns `-1` if it can't reach the next character.
+// next returns `end_of_text` if it can't reach the next character.
 [direct_array_access; inline]
 pub fn (mut s Scanner) next() int {
 	if s.pos < s.text.len {
@@ -242,7 +242,7 @@ pub fn (mut s Scanner) next() int {
 		c := s.text[opos]
 		return c
 	}
-	return -1
+	return scanner.end_of_text
 }
 
 // skip skips one character ahead.
@@ -267,14 +267,14 @@ pub fn (mut s Scanner) skip_n(n int) {
 }
 
 // at returns the *current* character code from the input text.
-// at returns `-1` if it can't get the current character.
+// at returns `end_of_text` if it can't get the current character.
 // unlike `next()`, `at()` does not change the state of the scanner.
 [direct_array_access; inline]
 pub fn (s &Scanner) at() int {
 	if s.pos < s.text.len {
 		return s.text[s.pos]
 	}
-	return -1
+	return scanner.end_of_text
 }
 
 // at_crlf returns `true` if the scanner is at a `\r` character
@@ -284,7 +284,7 @@ fn (s Scanner) at_crlf() bool {
 }
 
 // peek returns the character code from the input text at position + `n`.
-// peek returns `-1` if it can't peek `n` characters ahead.
+// peek returns `end_of_text` if it can't peek `n` characters ahead.
 [direct_array_access; inline]
 pub fn (s &Scanner) peek(n int) int {
 	if s.pos + n < s.text.len {
@@ -295,7 +295,7 @@ pub fn (s &Scanner) peek(n int) int {
 		}
 		return s.text[s.pos + n]
 	}
-	return -1
+	return scanner.end_of_text
 }
 
 // reset resets the internal state of the scanner.

--- a/vlib/toml/scanner/scanner.v
+++ b/vlib/toml/scanner/scanner.v
@@ -40,8 +40,8 @@ pub:
 // Only one of the fields `text` and `file_path` is allowed to be set at time of configuration.
 pub struct Config {
 pub:
-	input              input.Config
-	tokenize_formating bool // if true, generate tokens for `\n`, ` `, `\t`, `\r` etc.
+	input               input.Config
+	tokenize_formatting bool = true // if true, generate tokens for `\n`, ` `, `\t`, `\r` etc.
 }
 
 // new_scanner returns a new *heap* allocated `Scanner` instance.
@@ -136,14 +136,16 @@ pub fn (mut s Scanner) scan() ?token.Token {
 					util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'identified, what could be, a space between a RFC 3339 date and time ("$ascii") ($ascii.len)')
 					return s.new_token(token.Kind.whitespace, ascii, ascii.len)
 				}
-				if s.config.tokenize_formating {
+				if s.config.tokenize_formatting {
 					mut kind := token.Kind.whitespace
 					if c == `\t` {
 						kind = token.Kind.tab
+					} else if c == `\r` {
+						kind = token.Kind.cr
 					} else if c == `\n` {
 						kind = token.Kind.nl
 					}
-					util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'identified one of " ", "\\t" or "\\n" ("$ascii") ($ascii.len)')
+					util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'identified formatting character ("$ascii") ($ascii.len)')
 					return s.new_token(kind, ascii, ascii.len)
 				} else {
 					util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'skipping " ", "\\t" or "\\n" ("$ascii") ($ascii.len)')

--- a/vlib/toml/tests/array_of_tables_1_level_test.v
+++ b/vlib/toml/tests/array_of_tables_1_level_test.v
@@ -1,0 +1,28 @@
+import os
+import toml
+
+const (
+	toml_table_text = '
+[[products]]
+name = "Hammer"
+sku = 738594937
+
+[[products]]  # empty table within the array
+
+[[products]]
+name = "Nail"
+sku = 284758393
+
+color = "gray"'
+)
+
+fn test_tables() {
+	mut toml_doc := toml.parse(toml_table_text) or { panic(err) }
+
+	toml_json := toml_doc.to_json()
+
+	eprintln(toml_json)
+	assert toml_json == os.read_file(
+		os.real_path(os.join_path(os.dir(@FILE), 'testdata', os.file_name(@FILE).all_before_last('.'))) +
+		'.out') or { panic(err) }
+}

--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -23,7 +23,6 @@ const (
 		'table/duplicate-table-array.toml',
 		// Array
 		'array/tables-1.toml',
-		//'array/missing-separator.toml',
 		'array/text-after-array-entries.toml',
 		'array/text-before-array-separator.toml',
 		// Date / Time

--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -13,7 +13,6 @@ const (
 	]
 	invalid_exceptions = [
 		// Table
-		'table/rrbrace.toml',
 		'table/duplicate-table-array2.toml',
 		'table/duplicate.toml',
 		'table/array-implicit.toml',

--- a/vlib/toml/tests/table_test.v
+++ b/vlib/toml/tests/table_test.v
@@ -67,6 +67,9 @@ fn test_tables() {
 	value = m.value('x.a.b.c.d.e') or { panic(err) }
 	assert value.int() == 1
 
+	/*
+	TODO BUG
+
 	arr := toml_doc.value('arr') as []toml.Any
 
 	arr0 := arr[0] as map[string]toml.Any
@@ -84,4 +87,6 @@ fn test_tables() {
 	arr3 := arr[3] as map[string]toml.Any
 	value = arr3.value('T.a.b') or { panic(err) }
 	assert value.int() == 2
+	*/
+	return
 }

--- a/vlib/toml/tests/table_test.v
+++ b/vlib/toml/tests/table_test.v
@@ -67,26 +67,25 @@ fn test_tables() {
 	value = m.value('x.a.b.c.d.e') or { panic(err) }
 	assert value.int() == 1
 
-	/*
-	TODO BUG
-
 	arr := toml_doc.value('arr') as []toml.Any
+
+	for i := 0; i < arr.len; i++ {
+		entry := (arr[i] as map[string]toml.Any)
+		value = entry.value('t.a.b') or { panic(err) }
+		assert value.int() == i + 1
+		value = entry.value('T.a.b') or { panic(err) }
+		assert value.int() == i + 1
+	}
 
 	arr0 := arr[0] as map[string]toml.Any
 	value = arr0.value('t.a.b') or { panic(err) }
 	assert value.int() == 1
-
-	arr1 := arr[1] as map[string]toml.Any
-	value = arr1.value('T.a.b') or { panic(err) }
+	value = arr0.value('T.a.b') or { panic(err) }
 	assert value.int() == 1
 
-	arr2 := arr[2] as map[string]toml.Any
-	value = arr2.value('t.a.b') or { panic(err) }
+	arr1 := arr[1] as map[string]toml.Any
+	value = arr1.value('t.a.b') or { panic(err) }
 	assert value.int() == 2
-
-	arr3 := arr[3] as map[string]toml.Any
-	value = arr3.value('T.a.b') or { panic(err) }
+	value = arr1.value('T.a.b') or { panic(err) }
 	assert value.int() == 2
-	*/
-	return
 }

--- a/vlib/toml/tests/testdata/array_of_tables_1_level_test.out
+++ b/vlib/toml/tests/testdata/array_of_tables_1_level_test.out
@@ -1,0 +1,1 @@
+{ "products": [ { "name": "Hammer", "sku": 738594937 }, { }, { "name": "Nail", "sku": 284758393, "color": "gray" } ] }


### PR DESCRIPTION
This PR introduces format parsing - adding the possibility to forward formatting characters from the scanner to the parser.
This is needed to be able to validate the formatting of TOML documents in more detail. Before, formatting characters like:
` `,`\t` and `\n` was ignored completely in the parser - resulting in wrong output values (in a few cases).