### PR TITLE
cgen: fix array of threads wait (fix #12350)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -988,6 +988,7 @@ fn (mut g Gen) register_thread_array_wait_call(eltyp string) string {
 void ${fn_name}($thread_arr_typ a) {
 	for (int i = 0; i < a.len; ++i) {
 		$thread_typ t = (($thread_typ*)a.data)[i];
+		if (t == 0) continue;
 		__v_thread_wait(t);
 	}
 }')
@@ -996,8 +997,13 @@ void ${fn_name}($thread_arr_typ a) {
 $ret_typ ${fn_name}($thread_arr_typ a) {
 	$ret_typ res = __new_array_with_default(a.len, a.len, sizeof($eltyp), 0);
 	for (int i = 0; i < a.len; ++i) {
-		$thread_typ t = (($thread_typ*)a.data)[i];
-		(($eltyp*)res.data)[i] = __v_thread_${eltyp}_wait(t);
+		$thread_typ t = (($thread_typ*)a.data)[i];')
+			if g.pref.os == .windows {
+				g.gowrappers.writeln('\t\tif (t.handle == 0) continue;')
+			} else {
+				g.gowrappers.writeln('\t\tif (t == 0) continue;')
+			}
+			g.gowrappers.writeln('\t\t(($eltyp*)res.data)[i] = __v_thread_${eltyp}_wait(t);
 	}
 	return res;
 }')

--- a/vlib/v/tests/array_of_threads_wait_test.v
+++ b/vlib/v/tests/array_of_threads_wait_test.v
@@ -3,7 +3,7 @@ import math { floor, sqrt }
 fn async(arr_size int, init_val f64) f64 {
 	mut val_arr := []f64{}
 
-	for _ in 1..arr_size {
+	for _ in 1 .. arr_size {
 		val_arr << floor((sqrt(init_val) / 2) * 3)
 	}
 
@@ -23,9 +23,9 @@ fn sum(val_arr []f64) f64 {
 fn test_array_of_threads_wait() {
 	size := 2000_000
 	init_val := 123456
-	println("Async")
-	mut results := []thread f64{ cap: 16, len: 16 }
-	for num in 0..15 {
+	println('Async')
+	mut results := []thread f64{len: 16, cap: 16}
+	for num in 0 .. 15 {
 		results << go async(size, init_val + num)
 	}
 	waited_results := results.wait()

--- a/vlib/v/tests/array_of_threads_wait_test.v
+++ b/vlib/v/tests/array_of_threads_wait_test.v
@@ -1,0 +1,36 @@
+import math { floor, sqrt }
+
+fn async(arr_size int, init_val f64) f64 {
+	mut val_arr := []f64{}
+
+	for _ in 1..arr_size {
+		val_arr << floor((sqrt(init_val) / 2) * 3)
+	}
+
+	return sum(val_arr.map(it / 2))
+}
+
+fn sum(val_arr []f64) f64 {
+	mut result := f64(0)
+
+	for val in val_arr {
+		result += val
+	}
+
+	return result
+}
+
+fn test_array_of_threads_wait() {
+	size := 2000_000
+	init_val := 123456
+	println("Async")
+	mut results := []thread f64{ cap: 16, len: 16 }
+	for num in 0..15 {
+		results << go async(size, init_val + num)
+	}
+	waited_results := results.wait()
+
+	println(waited_results)
+	println(sum(waited_results))
+	assert sum(waited_results) == 7.9049960475e+09
+}


### PR DESCRIPTION
This PR fix array of threads wait (fix #12350).

- Fix array of threads wait.
- Add test.

```vlang
import math { floor, sqrt }

fn async(arr_size int, init_val f64) f64 {
	mut val_arr := []f64{}

	for _ in 1..arr_size {
		val_arr << floor((sqrt(init_val) / 2) * 3)
	}

	return sum(val_arr.map(it / 2))
}

fn sum(val_arr []f64) f64 {
	mut result := f64(0)

	for val in val_arr {
		result += val
	}

	return result
}

fn main() {
	size := 2000_000
	init_val := 123456
	println("Async")
	mut results := []thread f64{ cap: 16, len: 16 }
	for num in 0..15 {
		results << go async(size, init_val + num)
	}
	waited_results := results.wait()

	println(waited_results)
	println(sum(waited_results))
	assert sum(waited_results) == 7.9049960475e+09
}

PS D:\Test\v\tt1> v run .
Async[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5.269997365e+08, 5.269997365e+08, 5.269997365e+08, 5.269997365e+08, 5.269997365e+08, 5.269997365e+08, 5.269997365e+08, 5.269997365e+08, 5.269997365e+08, 5.269997365e+08, 5.269997365e+08, 5.269997365e+08, 5.269997365e+08, 5.269997365e+08, 5.269997365e+08]
7.9049960475e+09
```