### PR TITLE
checker: check generic struct field fn args type mismatch

### DIFF
--- a/vlib/v/checker/tests/generics_struct_field_fn_args_err.out
+++ b/vlib/v/checker/tests/generics_struct_field_fn_args_err.out
@@ -18,10 +18,31 @@ vlib/v/checker/tests/generics_struct_field_fn_args_err.vv:29:15: error: expected
    29 |     println(fun1.call())
       |                  ~~~~~~
    30 |     println(fun1.call(42, 43))
-   31 | }
+   31 |
 vlib/v/checker/tests/generics_struct_field_fn_args_err.vv:30:24: error: expected 1 arguments, but got 2
    28 |     println(fun1.call(42))
    29 |     println(fun1.call())
    30 |     println(fun1.call(42, 43))
       |                           ~~
-   31 | }
+   31 |
+   32 |     println(fun1.call(true))
+vlib/v/checker/tests/generics_struct_field_fn_args_err.vv:32:20: error: cannot use `bool` as `int` in argument 1 to `Fun<fn (int) int>.call`
+   30 |     println(fun1.call(42, 43))
+   31 |
+   32 |     println(fun1.call(true))
+      |                       ~~~~
+   33 |     println(fun1.call('text'))
+   34 |     println(fun1.call(22.2))
+vlib/v/checker/tests/generics_struct_field_fn_args_err.vv:33:20: error: cannot use `string` as `int` in argument 1 to `Fun<fn (int) int>.call`
+   31 |
+   32 |     println(fun1.call(true))
+   33 |     println(fun1.call('text'))
+      |                       ~~~~~~
+   34 |     println(fun1.call(22.2))
+   35 | }
+vlib/v/checker/tests/generics_struct_field_fn_args_err.vv:34:20: error: cannot use `float literal` as `int` in argument 1 to `Fun<fn (int) int>.call`
+   32 |     println(fun1.call(true))
+   33 |     println(fun1.call('text'))
+   34 |     println(fun1.call(22.2))
+      |                       ~~~~
+   35 | }

--- a/vlib/v/checker/tests/generics_struct_field_fn_args_err.vv
+++ b/vlib/v/checker/tests/generics_struct_field_fn_args_err.vv
@@ -28,4 +28,8 @@ fn main() {
 	println(fun1.call(42))
 	println(fun1.call())
 	println(fun1.call(42, 43))
+
+	println(fun1.call(true))
+	println(fun1.call('text'))
+	println(fun1.call(22.2))
 }


### PR DESCRIPTION
This PR check generic struct field fn args type mismatch.

- Check generic struct field fn args type mismatch.
- Add test.

```vlang
fn get_int() int {
	return 42
}

fn dub_int(i int) int {
	return i * 2
}

struct Fun<F> {
mut:
	call F
}

type FunZero = fn () int

fn main() {
	fun0 := Fun<FunZero>{
		call: get_int
	}
	println(fun0.call())
	println(fun0.call(1234))
	println(fun0.call(1234, 5678))

	fun1 := Fun<fn (int) int>{
		call: dub_int
	}

	println(fun1.call(42))
	println(fun1.call())
	println(fun1.call(42, 43))

	println(fun1.call(true))
	println(fun1.call('text'))
	println(fun1.call(22.2))
}

PS D:\Test\v\tt1> v run .
.\tt1.v:21:20: error: expected 0 arguments, but got 1
   19 |     }
   20 |     println(fun0.call())
   21 |     println(fun0.call(1234))
      |                       ~~~~
   22 |     println(fun0.call(1234, 5678))
.\tt1.v:22:20: error: expected 0 arguments, but got 2
   20 |     println(fun0.call())
   21 |     println(fun0.call(1234))
   22 |     println(fun0.call(1234, 5678))
      |                       ~~~~~~~~~~
   23 |
   24 |     fun1 := Fun<fn (int) int>{
.\tt1.v:29:15: error: expected 1 arguments, but got 0
   27 |
   28 |     println(fun1.call(42))
   29 |     println(fun1.call())
      |                  ~~~~~~
   30 |     println(fun1.call(42, 43))
   31 |
.\tt1.v:30:24: error: expected 1 arguments, but got 2
   28 |     println(fun1.call(42))
   29 |     println(fun1.call())
   30 |     println(fun1.call(42, 43))
      |                           ~~
   31 |
   32 |     println(fun1.call(true))
.\tt1.v:32:20: error: cannot use `bool` as `int` in argument 1 to `Fun<fn (int) int>.call`
   30 |     println(fun1.call(42, 43))
   31 |
   32 |     println(fun1.call(true))
      |                       ~~~~
   33 |     println(fun1.call('text'))
   34 |     println(fun1.call(22.2))
.\tt1.v:33:20: error: cannot use `string` as `int` in argument 1 to `Fun<fn (int) int>.call`
   31 |
   32 |     println(fun1.call(true))
   33 |     println(fun1.call('text'))
      |                       ~~~~~~
   34 |     println(fun1.call(22.2))
   35 | }
.\tt1.v:34:20: error: cannot use `float literal` as `int` in argument 1 to `Fun<fn (int) int>.call`
   32 |     println(fun1.call(true))
   33 |     println(fun1.call('text'))
   34 |     println(fun1.call(22.2))
      |                       ~~~~
   35 | }
```