### PR TITLE
toml: disallow multiline keys

### DIFF
--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -42,7 +42,6 @@ const (
 		'key/without-value-2.toml',
 		'key/no-eol.toml',
 		'key/after-array.toml',
-		'key/multiline.toml',
 	]
 )
 


### PR DESCRIPTION
This PR disallow the following TOML:
```toml
"""long
key""" = 1
```