### PR TITLE
ast: fix generic nested struct init (fix #12400)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1661,16 +1661,14 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 						generic_names := parent_info.generic_types.map(t.get_type_symbol(it).name)
 						for i in 0 .. fields.len {
 							if fields[i].typ.has_flag(.generic) {
-								sym := t.get_type_symbol(fields[i].typ)
-								if sym.kind == .struct_ && fields[i].typ.idx() != info.parent_idx {
+								if fields[i].typ.idx() != info.parent_idx {
 									fields[i].typ = t.unwrap_generic_type(fields[i].typ,
 										generic_names, info.concrete_types)
-								} else {
-									if t_typ := t.resolve_generic_to_concrete(fields[i].typ,
-										generic_names, info.concrete_types)
-									{
-										fields[i].typ = t_typ
-									}
+								}
+								if t_typ := t.resolve_generic_to_concrete(fields[i].typ,
+									generic_names, info.concrete_types)
+								{
+									fields[i].typ = t_typ
 								}
 							}
 						}

--- a/vlib/v/tests/generics_nested_struct_init_test.v
+++ b/vlib/v/tests/generics_nested_struct_init_test.v
@@ -1,0 +1,25 @@
+struct Foo<T> {
+	foo T
+}
+
+struct Bar<T> {
+mut:
+	foos []Foo<T>
+}
+
+fn (mut b Bar<T>) add(v T) {
+	b.foos << Foo<T>{
+		foo: v
+	}
+}
+
+fn test_nested_generics_struct_init() {
+	mut bar := Bar<string>{}
+	bar.add('bar')
+	println(bar)
+
+	result := '$bar'
+	assert result.contains('Bar<string>{')
+	assert result.contains('foos: [Foo<string>{')
+	assert result.contains("foo: 'bar'")
+}


### PR DESCRIPTION
This PR fix generic nested struct init (fix #12400).

- Fix generic nested struct init.
- Add test.

```vlang
struct Foo<T> {
	foo T
}

struct Bar<T> {
mut:
	foos []Foo<T>
}

fn (mut b Bar<T>) add(v T) {
	b.foos << Foo<T>{
		foo: v
	}
}

fn main() {
	mut bar := Bar<string>{}
	bar.add('bar')
	println(bar)

	result := '$bar'
	assert result.contains('Bar<string>{')
	assert result.contains('foos: [Foo<string>{')
	assert result.contains("foo: 'bar'")
}

PS D:\Test\v\tt1> v run .
Bar<string>{
    foos: [Foo<string>{
        foo: 'bar'
    }]
}
```