### PR TITLE
cgen: avoid generating typedef generic array type

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1105,7 +1105,7 @@ pub fn (mut g Gen) write_typedef_types() {
 			.array {
 				info := typ.info as ast.Array
 				elem_sym := g.table.get_type_symbol(info.elem_type)
-				if elem_sym.kind != .placeholder {
+				if elem_sym.kind != .placeholder && !info.elem_type.has_flag(.generic) {
 					g.type_definitions.writeln('typedef array $typ.cname;')
 				}
 			}


### PR DESCRIPTION
This PR avoid generating typedef generic array type.

before:
```vlang
typedef array Array_main__Foo;
typedef map Map_string_int;
typedef array Array_main__Foo_T_string;
...
```
`typedef array Array_main__Foo;` is unnecessary, and in some cases, mistakes can be made.