### PR TITLE
cgen: fix for in mut val in array.index() (fix #12403)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -762,6 +762,9 @@ fn (mut g Gen) gen_array_index(node ast.CallExpr) {
 	}
 	g.expr(node.left)
 	g.write(', ')
+	if node.args[0].expr.is_auto_deref_var() {
+		g.write('*')
+	}
 	g.expr(node.args[0].expr)
 	g.write(')')
 }

--- a/vlib/v/tests/for_in_mut_array_index_test.v
+++ b/vlib/v/tests/for_in_mut_array_index_test.v
@@ -1,0 +1,12 @@
+fn test_for_in_mut_array_index() {
+	mut arr := [1, 2, 3, 4, 5]
+	mut rets := []int{}
+
+	for mut val in arr {
+		inx := arr.index(val)
+		println(inx)
+		rets << inx
+	}
+
+	assert rets == [0, 1, 2, 3, 4]
+}


### PR DESCRIPTION
This PR fix for in mut val in array.index() (fix #12403).

- Fix for in mut val in array.index().
- Add test.

```vlang
fn main() {
	mut arr := [1, 2, 3, 4, 5]
	mut rets := []int{}

	for mut val in arr {
		inx := arr.index(val)
		println(inx)
		rets << inx
	}

	assert rets == [0, 1, 2, 3, 4]
}

PS D:\Test\v\tt1> v run .
0
1
2
3
4
```