### PR TITLE
checker, cgen: fix alias of map keys() (fix #12389)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1963,8 +1963,15 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	// FIXME: Argument count != 1 will break these
 	if left_type_sym.kind == .array && method_name in checker.array_builtin_methods {
 		return c.array_builtin_method_call(mut node, left_type, left_type_sym)
-	} else if left_type_sym.kind == .map && method_name in ['clone', 'keys', 'move', 'delete'] {
-		return c.map_builtin_method_call(mut node, left_type, left_type_sym)
+	} else if (left_type_sym.kind == .map || c.table.get_final_type_symbol(left_type).kind == .map)
+		&& method_name in ['clone', 'keys', 'move', 'delete'] {
+		if left_type_sym.kind == .map {
+			return c.map_builtin_method_call(mut node, left_type, left_type_sym)
+		} else {
+			parent_type := (left_type_sym.info as ast.Alias).parent_type
+			parent_sym := c.table.get_type_symbol(parent_type)
+			return c.map_builtin_method_call(mut node, parent_type, parent_sym)
+		}
 	} else if left_type_sym.kind == .array && method_name in ['insert', 'prepend'] {
 		if method_name == 'insert' {
 			if node.args.len != 2 {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -853,7 +853,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		if node.name in ['close', 'try_pop', 'try_push'] {
 			name = 'sync__Channel_$node.name'
 		}
-	} else if left_sym.kind == .map {
+	} else if final_left_sym.kind == .map {
 		if node.name == 'keys' {
 			name = 'map_keys'
 		}

--- a/vlib/v/tests/alias_map_keys_test.v
+++ b/vlib/v/tests/alias_map_keys_test.v
@@ -1,0 +1,12 @@
+type Foo = map[string]string
+
+fn test_alias_map_keys() {
+	keys_list := Foo({
+		'foo1': 'bar1'
+		'foo2': 'bar2'
+		'foo3': 'bar3'
+	}).keys()
+
+	println(keys_list)
+	assert keys_list == ['foo1', 'foo2', 'foo3']
+}


### PR DESCRIPTION
This PR fix alias of map keys() (fix #12389).

- Fix alias of map keys().
- Add test.

```vlang
type Foo = map[string]string

fn main() {
	keys_list := Foo({
		'foo1': 'bar1'
		'foo2': 'bar2'
		'foo3': 'bar3'
	}).keys()

	println(keys_list)
	assert keys_list == ['foo1', 'foo2', 'foo3']
}

PS D:\Test\v\tt1> v run .
['foo1', 'foo2', 'foo3']
```