### PR TITLE
toml: check for more wrong line ending cases

### DIFF
--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -28,12 +28,6 @@ const (
 		'datetime/impossible-date.toml',
 		'datetime/no-leads-with-milli.toml',
 		'datetime/no-leads.toml',
-		// Key
-		'key/after-table.toml',
-		'key/after-value.toml',
-		//'key/no-eol.toml',
-		'key/no-eol.toml',
-		'key/after-array.toml',
 	]
 )
 


### PR DESCRIPTION
This PR makes the TOML parser check for invalid ways to end a line after values and a few left square bracket cases.
Disallowing data like the following (among other cases):
```toml
first = "Tom" last = "Jerry"
```