### PR TITLE
toml: add excerpt to value parse errors

### DIFF
--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -874,7 +874,7 @@ pub fn (mut p Parser) value() ?ast.Value {
 		}
 		if value is ast.Null {
 			return error(@MOD + '.' + @STRUCT + '.' + @FN +
-				' value expected .boolean, .quoted, .lsbr, .lcbr or .number got "$p.tok.kind" "$p.tok.lit"')
+				' value expected .boolean, .quoted, .lsbr, .lcbr or .number got "$p.tok.kind" "$p.tok.lit" in this (excerpt): "...${p.excerpt()}..."')
 		}
 	}
 	util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'parsed "$p.tok.kind" as value $value.to_json()')


### PR DESCRIPTION
Before:
```
OK   [32/189] "/home/user/v/vlib/toml/tests/testdata/burntsushi/toml-test/tests/invalid/integer/double-sign-plus.toml"...
     toml.parser.Parser.value value expected .boolean, .quoted, .lsbr, .lcbr or .number got "plus" "+"
```
After:
```
OK   [32/189] "/home/user/v/vlib/toml/tests/testdata/burntsushi/toml-test/tests/invalid/integer/double-sign-plus.toml"...
     toml.parser.Parser.value value expected .boolean, .quoted, .lsbr, .lcbr or .number got "plus" "+" in this (excerpt): "...n-plus = ++99\n..."
```

(My plan, btw - is to polish the error excerpts to be more like V's sometime in the future)