### PR TITLE
fmt: fix removal of selective imported types used as type parameter

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -251,6 +251,11 @@ pub fn (mut f Fmt) mark_types_import_as_used(typ ast.Type) {
 		f.mark_types_import_as_used(map_info.value_type)
 		return
 	}
+	if sym.info is ast.GenericInst {
+		for concrete_typ in sym.info.concrete_types {
+			f.mark_types_import_as_used(concrete_typ)
+		}
+	}
 	name := sym.name.split('<')[0] // take `Type` from `Type<T>`
 	f.mark_import_as_used(name)
 }

--- a/vlib/v/fmt/tests/import_selective_expected.vv
+++ b/vlib/v/fmt/tests/import_selective_expected.vv
@@ -9,8 +9,12 @@ import mod {
 	Enum,
 	FnArg,
 	FnArgGeneric,
+	FnArgTypeParam1,
+	FnArgTypeParam2,
 	FnRet,
 	FnRetGeneric,
+	FnRetTypeParam1,
+	FnRetTypeParam2,
 	InterfaceField,
 	InterfaceMethodArg,
 	InterfaceMethodRet,
@@ -56,6 +60,8 @@ fn f(v FnArg) FnRet {
 
 	return FnRet{}
 }
+
+fn f2(v Generic<FnArgTypeParam1, FnArgTypeParam2>) Generic<FnRetTypeParam1, FnRetTypeParam2> {}
 
 fn f_generic<T>(v FnArgGeneric<T>) FnRetGeneric<T> {
 	return FnRetGeneric<T>{}

--- a/vlib/v/fmt/tests/import_selective_input.vv
+++ b/vlib/v/fmt/tests/import_selective_input.vv
@@ -22,8 +22,12 @@ import mod {
 
 	FnArg,
 	FnArgGeneric
+	FnArgTypeParam1
+	FnArgTypeParam2
 	FnRet,
 	FnRetGeneric
+	FnRetTypeParam1,
+	FnRetTypeParam2,
 
 	RightOfIs,
 	RightOfAs,
@@ -59,6 +63,8 @@ fn f(v FnArg) FnRet {
 
 	return FnRet{}
 }
+
+fn f2(v Generic<FnArgTypeParam1, FnArgTypeParam2>) Generic<FnRetTypeParam1, FnRetTypeParam2> {}
 
 fn f_generic<T>(v FnArgGeneric<T>) FnRetGeneric<T> {
 	return FnRetGeneric<T>{}


### PR DESCRIPTION
On current master, v fmt behaves like this
```
┏ zakuro   ~/src/github.com/zakuro9715/v   master
┗━━⮞ cat main.v
import x { Abc }

struct St<T> {}

fn f(v St<Abc>) {
}
┏ zakuro   ~/src/github.com/zakuro9715/v   master
┗━━⮞ v fmt main.v
import x

struct St<T> {}

fn f(v St<Abc>) {
}
```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
