### PR TITLE
toml: check for single-key reassignment in inline tables

### DIFF
--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -502,8 +502,13 @@ pub fn (mut p Parser) inline_table(mut tbl map[string]ast.Value) ? {
 				} else {
 					p.ignore_while(parser.space_formatting)
 					key, val := p.key_value() ?
-					util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'inserting @5 "$key.str()" = $val.to_json() into ${ptr_str(tbl)}')
-					tbl[key.str()] = val
+					key_str := key.str()
+					if _ := tbl[key_str] {
+						return error(@MOD + '.' + @STRUCT + '.' + @FN +
+							' key "$key_str" is already initialized with a value. At "$p.tok.kind" "$p.tok.lit" in this (excerpt): "...${p.excerpt()}..."')
+					}
+					util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'inserting @5 "$key_str" = $val.to_json() into ${ptr_str(tbl)}')
+					tbl[key_str] = val
 				}
 				previous_token_was_value = true
 			}

--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -19,8 +19,6 @@ const (
 		'table/injection-2.toml',
 		'table/injection-1.toml',
 		'table/duplicate-table-array.toml',
-		// Inline-table
-		'inline-table/duplicate-key.toml',
 		// Array
 		'array/tables-1.toml',
 		'array/text-after-array-entries.toml',


### PR DESCRIPTION
This PR disallows reassigning new values to keys that have already been assigned a value, in inline-tables:
```toml
a={b=1, b=2}
```