### PR TITLE
toml: support complex array-tables-array constructs

### DIFF
--- a/vlib/toml/tests/array_of_tables_array_test.v
+++ b/vlib/toml/tests/array_of_tables_array_test.v
@@ -1,0 +1,24 @@
+import os
+import toml
+
+const (
+	toml_text = '[[a]]
+    [[a.b]]
+        [a.b.c]
+            d = "val0"
+    [[a.b]]
+        [a.b.c]
+            d = "val1"
+'
+)
+
+fn test_nested_array_of_tables() {
+	mut toml_doc := toml.parse(toml_text) or { panic(err) }
+
+	toml_json := toml_doc.to_json()
+
+	eprintln(toml_json)
+	assert toml_json == os.read_file(
+		os.real_path(os.join_path(os.dir(@FILE), 'testdata', os.file_name(@FILE).all_before_last('.'))) +
+		'.out') or { panic(err) }
+}

--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -8,9 +8,8 @@ import toml
 // See also the CI toml tests
 // TODO Goal: make parsing AND value retrieval of all of https://github.com/BurntSushi/toml-test/test/ pass
 const (
-	valid_exceptions   = [''
-		//'table/array-table-array.toml',
-	]
+	// Kept for easier handling of future updates to the tests
+	valid_exceptions   = ['']
 	invalid_exceptions = [
 		// Table
 		'table/duplicate-table-array2.toml',

--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -8,8 +8,8 @@ import toml
 // See also the CI toml tests
 // TODO Goal: make parsing AND value retrieval of all of https://github.com/BurntSushi/toml-test/test/ pass
 const (
-	valid_exceptions   = [
-		'table/array-table-array.toml',
+	valid_exceptions   = [''
+		//'table/array-table-array.toml',
 	]
 	invalid_exceptions = [
 		// Table

--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -9,7 +9,7 @@ import toml
 // TODO Goal: make parsing AND value retrieval of all of https://github.com/BurntSushi/toml-test/test/ pass
 const (
 	// Kept for easier handling of future updates to the tests
-	valid_exceptions   = ['']
+	valid_exceptions   = []string{}
 	invalid_exceptions = [
 		// Table
 		'table/duplicate-table-array2.toml',

--- a/vlib/toml/tests/testdata/array_of_tables_array_test.out
+++ b/vlib/toml/tests/testdata/array_of_tables_array_test.out
@@ -1,0 +1,1 @@
+{ "a": [ { "b": [ { "c": { "d": { "type": "string", "value": "val0" } } }, { "c": { "d": { "type": "string", "value": "val1" } } } ] } ] }

--- a/vlib/toml/tests/testdata/array_of_tables_array_test.out
+++ b/vlib/toml/tests/testdata/array_of_tables_array_test.out
@@ -1,1 +1,1 @@
-{ "a": [ { "b": [ { "c": { "d": { "type": "string", "value": "val0" } } }, { "c": { "d": { "type": "string", "value": "val1" } } } ] } ] }
+{ "a": [ { "b": [ { "c": { "d": "val0" } }, { "c": { "d": "val1" } } ] } ] }


### PR DESCRIPTION
Add support for these kinds of alien constructs:
```toml
[[a]]
    [[a.b]]
        [a.b.c]
            d = "val0"
    [[a.b]]
        [a.b.c]
            d = "val1"
```
With this, a "small but big" goal is achieved - because the parser can now parse *all* the *valid* `.toml` files from the BurntSushi test suite (`valid_exceptions = []string{}`) :partying_face: 