### PR TITLE
checker, cgen: fix for in iterator of generic struct (fix #12439)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4816,7 +4816,7 @@ fn (mut c Checker) for_in_stmt(mut node ast.ForInStmt) {
 		sym := c.table.get_final_type_symbol(typ)
 		if sym.kind == .struct_ {
 			// iterators
-			next_fn := sym.find_method('next') or {
+			next_fn := sym.find_method_with_generic_parent('next') or {
 				c.error('a struct must have a `next()` method to be an iterator', node.cond.position())
 				return
 			}

--- a/vlib/v/tests/for_in_iterator_of_generic_struct_test.v
+++ b/vlib/v/tests/for_in_iterator_of_generic_struct_test.v
@@ -1,0 +1,39 @@
+struct Split<T> {
+	arr  []T
+	pred fn (T) bool
+mut:
+	idx int
+}
+
+fn (mut iter Split<T>) next() ?[]T {
+	start := iter.idx
+	for iter.idx < iter.arr.len {
+		if iter.pred(iter.arr[iter.idx]) {
+			iter.idx++
+			return iter.arr[start..iter.idx]
+		}
+		iter.idx++
+	}
+	return none
+}
+
+fn split<T>(arr []T, pred fn (T) bool) Split<T> {
+	return Split<T>{arr, pred, 0}
+}
+
+fn test_for_in_iterator_of_generic_struct() {
+	items := [0, 1, 2, 3, 4, 5, 6, 7, 8]
+	mut iter := split<int>(items, fn (item int) bool {
+		return item % 3 == 0
+	})
+	iter.next() or {}
+	mut ret_list := [][]int{}
+	for item in iter {
+		dump(item)
+		ret_list << item
+	}
+	println(ret_list)
+	assert ret_list.len == 2
+	assert ret_list[0] == [1, 2, 3]
+	assert ret_list[1] == [4, 5, 6]
+}


### PR DESCRIPTION
This PR fix for in iterator of generic struct (fix #12439).

- Fix for in iterator of generic struct.
- Add test.

```vlang
struct Split<T> {
	arr  []T
	pred fn (T) bool
mut:
	idx int
}

fn (mut iter Split<T>) next() ?[]T {
	start := iter.idx
	for iter.idx < iter.arr.len {
		if iter.pred(iter.arr[iter.idx]) {
			iter.idx++
			return iter.arr[start..iter.idx]
		}
		iter.idx++
	}
	return none
}

fn split<T>(arr []T, pred fn (T) bool) Split<T> {
	return Split<T>{arr, pred, 0}
}

fn main() {
	items := [0, 1, 2, 3, 4, 5, 6, 7, 8]
	mut iter := split<int>(items, fn (item int) bool {
		return item % 3 == 0
	})
	iter.next() ?
	mut ret_list := [][]int{}
	for item in iter {
		dump(item)
		ret_list << item
	}
	println(ret_list)
	assert ret_list.len == 2
	assert ret_list[0] == [1, 2, 3]
	assert ret_list[1] == [4, 5, 6]
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:34] item: [1, 2, 3]
[.\\tt1.v:34] item: [4, 5, 6]
[[1, 2, 3], [4, 5, 6]]
```