### PR TITLE
symlink: fix batch script if path contains spaces on windows

### DIFF
--- a/cmd/tools/vsymlink.v
+++ b/cmd/tools/vsymlink.v
@@ -70,7 +70,7 @@ fn setup_symlink_windows(vexe string) {
 			if os.exists(vsymlink) {
 				os.rm(vsymlink) or { panic(err) }
 			}
-			os.write_file(vsymlink, '@echo off\n$vexe %*') or { panic(err) }
+			os.write_file(vsymlink, '@echo off\n"$vexe" %*') or { panic(err) }
 			eprintln('$vsymlink file written.')
 		}
 		if !os.exists(vsymlink) {


### PR DESCRIPTION
previously, if you installed V in path that contained spaces, and ran `.\v.exe symlink`, the generated .bat script would not account for this. i'd have to manually edit said batch script to do so. 
this PR aims to fix this behaviour by adding quotes around the path regardless.
