### PR TITLE
toml: support for `[a."b.c"]` quoted keys

### DIFF
--- a/vlib/toml/any.v
+++ b/vlib/toml/any.v
@@ -4,6 +4,7 @@
 module toml
 
 import time
+import toml.util
 
 // Pretty much all the same builtin types as the `json2.Any` type plus `time.Time`
 pub type Any = Null
@@ -150,22 +151,27 @@ pub fn (a Any) datetime() time.Time {
 	}
 }
 
+// value queries a value from the map.
+// `key` should be in "dotted" form (`a.b.c`).
+// `key` supports quoted keys like `a."b.c"`.
 pub fn (m map[string]Any) value(key string) ?Any {
-	// return m[key] ?
-	key_split := key.split('.')
-	// util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, ' getting "${key_split[0]}"')
-	if key_split[0] in m.keys() {
-		value := m[key_split[0]] or {
-			return error(@MOD + '.' + @STRUCT + '.' + @FN + ' key "$key" does not exist')
+	key_split := util.parse_dotted_key(key) ?
+	return m.value_(key_split)
+}
+
+fn (m map[string]Any) value_(key []string) ?Any {
+	// util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, ' getting "${key[0]}"')
+	if key[0] in m.keys() {
+		value := m[key[0]] or {
+			return error(@MOD + '.' + @STRUCT + '.' + @FN + ' key "${key[0]}" does not exist')
 		}
 		// `match` isn't currently very suitable for these types of sum type constructs...
 		if value is map[string]Any {
-			nm := (value as map[string]Any)
-			next_key := key_split[1..].join('.')
-			if next_key == '' {
+			if key.len <= 1 {
 				return value
 			}
-			return nm.value(next_key)
+			nm := (value as map[string]Any)
+			return nm.value_(key[1..])
 		}
 		return value
 	}

--- a/vlib/toml/any.v
+++ b/vlib/toml/any.v
@@ -161,7 +161,7 @@ pub fn (m map[string]Any) value(key string) ?Any {
 
 fn (m map[string]Any) value_(key []string) ?Any {
 	// util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, ' getting "${key[0]}"')
-	if key[0] in m.keys() {
+	if key[0] in m {
 		value := m[key[0]] or {
 			return error(@MOD + '.' + @STRUCT + '.' + @FN + ' key "${key[0]}" does not exist')
 		}

--- a/vlib/toml/any.v
+++ b/vlib/toml/any.v
@@ -160,22 +160,18 @@ pub fn (m map[string]Any) value(key string) ?Any {
 }
 
 fn (m map[string]Any) value_(key []string) ?Any {
-	// util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, ' getting "${key[0]}"')
-	if key[0] in m {
-		value := m[key[0]] or {
-			return error(@MOD + '.' + @STRUCT + '.' + @FN + ' key "${key[0]}" does not exist')
-		}
-		// `match` isn't currently very suitable for these types of sum type constructs...
-		if value is map[string]Any {
-			if key.len <= 1 {
-				return value
-			}
-			nm := (value as map[string]Any)
-			return nm.value_(key[1..])
-		}
-		return value
+	value := m[key[0]] or {
+		return error(@MOD + '.' + @STRUCT + '.' + @FN + ' key "${key[0]}" does not exist')
 	}
-	return error(@MOD + '.' + @STRUCT + '.' + @FN + ' key "$key" does not exist')
+	// `match` isn't currently very suitable for these types of sum type constructs...
+	if value is map[string]Any {
+		if key.len <= 1 {
+			return value
+		}
+		nm := (value as map[string]Any)
+		return nm.value_(key[1..])
+	}
+	return value
 }
 
 pub fn (a []Any) as_strings() []string {

--- a/vlib/toml/ast/types.v
+++ b/vlib/toml/ast/types.v
@@ -63,51 +63,6 @@ pub fn (dtt DateTimeType) str() string {
 	return dtt.text
 }
 
-// value queries a value from the map.
-// `key` should be in "dotted" form (`a.b.c`).
-pub fn (v map[string]Value) value(key string) &Value {
-	null := &Value(Null{})
-	key_split := key.split('.')
-	// util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, ' retreiving value at "$key"')
-	if key_split[0] in v.keys() {
-		value := v[key_split[0]] or {
-			return null
-			// TODO return error(@MOD + '.' + @STRUCT + '.' + @FN + ' key "$key" does not exist')
-		}
-		// `match` isn't currently very suitable for these types of sum type constructs...
-		if value is map[string]Value {
-			m := (value as map[string]Value)
-			next_key := key_split[1..].join('.')
-			if next_key == '' {
-				return &value
-			}
-			return m.value(next_key)
-		}
-		return &value
-	}
-	return null
-	// TODO return error(@MOD + '.' + @STRUCT + '.' + @FN + ' key "$key" does not exist')
-}
-
-// exists returns true if the "dotted" `key` path exists in the map.
-pub fn (v map[string]Value) exists(key string) bool {
-	key_split := key.split('.')
-	if key_split[0] in v.keys() {
-		value := v[key_split[0]] or { return false }
-		// `match` isn't currently very suitable for these types of sum type constructs...
-		if value is map[string]Value {
-			m := (value as map[string]Value)
-			next_key := key_split[1..].join('.')
-			if next_key == '' {
-				return true
-			}
-			return m.exists(next_key)
-		}
-		return true
-	}
-	return false
-}
-
 // Comment is the data representation of a TOML comment (`# This is a comment`).
 pub struct Comment {
 pub:

--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -247,7 +247,8 @@ pub fn (mut p Parser) find_table() ?&map[string]ast.Value {
 // use with the `find_sub_table` method.
 pub fn (mut p Parser) sub_table_key(key DottedKey) (DottedKey, DottedKey) {
 	last := DottedKey([key.last()])
-	first := DottedKey(key[..key.len - 1])
+	all_before_last := key[..key.len - 1]
+	first := DottedKey(all_before_last)
 	return first, last
 }
 

--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -246,9 +246,8 @@ pub fn (mut p Parser) find_table() ?&map[string]ast.Value {
 // sub_table_key returns the logic parts of a dotted key (`a.b.c`) for
 // use with the `find_sub_table` method.
 pub fn (mut p Parser) sub_table_key(key DottedKey) (DottedKey, DottedKey) {
-	last := DottedKey([key.last()])
-	all_before_last := key[..key.len - 1]
-	first := DottedKey(all_before_last)
+	last := [key.last()]
+	first := key[..key.len - 1]
 	return first, last
 }
 

--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -13,7 +13,6 @@ const (
 	invalid_exceptions = [
 		// Table
 		'table/duplicate-table-array2.toml',
-		'table/duplicate.toml', // TODO
 		'table/array-implicit.toml',
 		'table/injection-2.toml',
 		'table/injection-1.toml',

--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -13,7 +13,7 @@ const (
 	invalid_exceptions = [
 		// Table
 		'table/duplicate-table-array2.toml',
-		'table/duplicate.toml',
+		'table/duplicate.toml', // TODO
 		'table/array-implicit.toml',
 		'table/injection-2.toml',
 		'table/injection-1.toml',
@@ -40,7 +40,7 @@ fn test_burnt_sushi_tomltest() {
 				relative = relative.replace('/', '\\')
 			}
 			if relative !in valid_exceptions {
-				println('OK   [$i/$valid_test_files.len] "$valid_test_file"...')
+				println('OK   [${i + 1}/$valid_test_files.len] "$valid_test_file"...')
 				toml_doc := toml.parse_file(valid_test_file) or { panic(err) }
 
 				// parsed_json := toml_doc.to_json().replace(' ','')
@@ -51,7 +51,7 @@ fn test_burnt_sushi_tomltest() {
 				valid++
 			} else {
 				e++
-				println('SKIP [$i/$valid_test_files.len] "$valid_test_file" EXCEPTION [$e/$valid_exceptions.len]...')
+				println('SKIP [${i + 1}/$valid_test_files.len] "$valid_test_file" EXCEPTION [$e/$valid_exceptions.len]...')
 			}
 		}
 		println('$valid/$valid_test_files.len TOML files was parsed correctly')
@@ -74,7 +74,7 @@ fn test_burnt_sushi_tomltest() {
 				relative = relative.replace('/', '\\')
 			}
 			if relative !in invalid_exceptions {
-				println('OK   [$i/$invalid_test_files.len] "$invalid_test_file"...')
+				println('OK   [${i + 1}/$invalid_test_files.len] "$invalid_test_file"...')
 				if toml_doc := toml.parse_file(invalid_test_file) {
 					content_that_should_have_failed := os.read_file(invalid_test_file) or {
 						panic(err)
@@ -88,7 +88,7 @@ fn test_burnt_sushi_tomltest() {
 				invalid++
 			} else {
 				e++
-				println('SKIP [$i/$invalid_test_files.len] "$invalid_test_file" EXCEPTION [$e/$invalid_exceptions.len]...')
+				println('SKIP [${i + 1}/$invalid_test_files.len] "$invalid_test_file" EXCEPTION [$e/$invalid_exceptions.len]...')
 			}
 		}
 		println('$invalid/$invalid_test_files.len TOML files was parsed correctly')

--- a/vlib/toml/tests/quoted_keys_test.v
+++ b/vlib/toml/tests/quoted_keys_test.v
@@ -1,0 +1,12 @@
+import toml
+
+fn test_quoted_keys() {
+	str_value := 'V rocks!'
+	toml_txt := 'a."b.c" = "V rocks!"'
+	toml_doc := toml.parse(toml_txt) or { panic(err) }
+
+	value := toml_doc.value('a."b.c"')
+	assert value == toml.Any(str_value)
+	assert value as string == str_value
+	assert value.string() == str_value
+}

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -101,25 +101,20 @@ pub fn (d Doc) value(key string) Any {
 // value_ returns the value found at `key` in the map `values` as `Any` type.
 fn (d Doc) value_(values map[string]ast.Value, key []string) Any {
 	util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, ' getting "${key[0]}"')
-	if key[0] in values.keys() {
-		value := values[key[0]] or {
-			return Any(Null{})
-			// TODO decide this
-			// panic(@MOD + '.' + @STRUCT + '.' + @FN + ' key "$key[0]" does not exist')
-		}
-		// `match` isn't currently very suitable for these types of sum type constructs...
-		if value is map[string]ast.Value {
-			if key.len <= 1 {
-				return d.ast_to_any(value)
-			}
-			m := (value as map[string]ast.Value)
-			return d.value_(m, key[1..])
-		}
-		return d.ast_to_any(value)
+	value := values[key[0]] or {
+		return Any(Null{})
+		// TODO decide this
+		// panic(@MOD + '.' + @STRUCT + '.' + @FN + ' key "$key[0]" does not exist')
 	}
-	return Any(Null{})
-	// TODO decide this
-	// panic(@MOD + '.' + @STRUCT + '.' + @FN + ' key "$key" does not exist')
+	// `match` isn't currently very suitable for these types of sum type constructs...
+	if value is map[string]ast.Value {
+		if key.len <= 1 {
+			return d.ast_to_any(value)
+		}
+		m := (value as map[string]ast.Value)
+		return d.value_(m, key[1..])
+	}
+	return d.ast_to_any(value)
 }
 
 // ast_to_any_value converts `from` ast.Value to toml.Any value.

--- a/vlib/toml/util/util.v
+++ b/vlib/toml/util/util.v
@@ -25,3 +25,44 @@ pub fn is_illegal_ascii_control_character(byte_char byte) bool {
 pub fn printdbg(id string, message string) {
 	eprintln(id + ' ' + message)
 }
+
+// parse_dotted_key converts `key` string to an array of strings.
+// parse_dotted_key preserves strings delimited by both `"` and `'`.
+pub fn parse_dotted_key(key string) ?[]string {
+	mut out := []string{}
+	mut buf := ''
+	mut in_string := false
+	mut delim := byte(` `)
+	for ch in key {
+		if ch in [`"`, `'`] {
+			if !in_string {
+				delim = ch
+			}
+			in_string = !in_string && ch == delim
+			if !in_string {
+				if buf != '' && buf != ' ' {
+					out << buf
+				}
+				buf = ''
+				delim = ` `
+			}
+			continue
+		}
+		buf += ch.ascii_str()
+		if !in_string && ch == `.` {
+			if buf != '' && buf != ' ' {
+				out << buf[..buf.len - 1]
+			}
+			buf = ''
+			continue
+		}
+	}
+	if buf != '' && buf != ' ' {
+		out << buf
+	}
+	if in_string {
+		return error(@FN +
+			': could not parse key, missing closing string delimiter `$delim.ascii_str()`')
+	}
+	return out
+}


### PR DESCRIPTION
This PR fixes support for TOML's quoted keys - both internally (keys were "dequoted" before: `a."b.c"` became `a.b.c`) and externally (via the user facing `.value('...')` retrieval call).
A few examples:
```toml
"b.c".d = "V"
'c.b'.d = "V"
[a."B.C"]
d = "V"
```