### PR TITLE
js,parser: Allow declaring methods on JS interfaces for easier FFI

### DIFF
--- a/vlib/v/gen/js/fn.v
+++ b/vlib/v/gen/js/fn.v
@@ -404,7 +404,7 @@ fn (mut g JsGen) is_used_by_main(node ast.FnDecl) bool {
 
 fn (mut g JsGen) gen_fn_decl(it ast.FnDecl) {
 	res := g.fn_gen_type(it)
-	if it.language == .js {
+	if it.language == .js && it.no_body {
 		for attr in it.attrs {
 			match attr.name {
 				'wasm_import' {
@@ -415,7 +415,6 @@ fn (mut g JsGen) gen_fn_decl(it ast.FnDecl) {
 				else {}
 			}
 		}
-
 		return
 	}
 	if g.inside_builtin {
@@ -483,17 +482,21 @@ fn (mut g JsGen) gen_method_decl(it ast.FnDecl, typ FnGenType) {
 		}
 		name = g.cc_type(node.receiver.typ, false) + '_' + name
 	}
-
 	name = g.js_name(name)
 
 	name = g.generic_fn_name(g.table.cur_concrete_types, name, true)
 	if name in parser.builtin_functions {
 		name = 'builtin__$name'
 	}
-	has_go := fn_has_go(it)
 	if it.is_pub && !it.is_method {
 		g.push_pub_var(name)
 	}
+	if it.language == .js && it.is_method {
+		g.writeln('${g.typ(it.receiver.typ)}.prototype.$it.name = ')
+	}
+
+	has_go := fn_has_go(it)
+
 	is_main := it.name == 'main.main'
 	g.gen_attrs(it.attrs)
 	if is_main {

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -465,7 +465,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	mut stmts := []ast.Stmt{}
 	body_start_pos := p.peek_tok.position()
 	if p.tok.kind == .lcbr {
-		if language != .v {
+		if language != .v && language != .js {
 			p.error_with_pos('interop functions cannot have a body', p.tok.position())
 		}
 		p.inside_fn = true


### PR DESCRIPTION
This PR allows to declare methods on JS interfaces, this allows to create high-level wrappers without wrapping interfaces in another V struct. For example: 
```v
pub interface JS.CanvasRenderingContext2D {
	setLineDash(JS.Array)
}

pub fn (ctx JS.CanvasRenderingContext2D) set_line_dash(arr []f64) {
	tmp := JS.Array.prototype.constructor()

	for x in arr {
		tmp.push(JS.Number(x))
	}
	ctx.setLineDash(tmp)
}

```
