### PR TITLE
cgen: fix comptime for in field selector (fix #12440)

### DIFF
--- a/vlib/v/tests/comptime_for_in_field_selector_test.v
+++ b/vlib/v/tests/comptime_for_in_field_selector_test.v
@@ -1,0 +1,30 @@
+fn print_field_values<T>(s T) {
+	mut value_list := []string{}
+
+	$for field in T.fields {
+		println(s.$(field.name))
+		value_list << s.$(field.name).str()
+	}
+	assert value_list.len == 4
+	assert value_list[0] == 'Simon'
+	assert value_list[1] == 'simon1234'
+	assert value_list[2] == 'simon@gmail.com'
+	assert value_list[3] == '15'
+}
+
+struct Foo {
+	name     string
+	password string
+	email    string
+	age      int
+}
+
+fn test_comptime_for_in_field_selector() {
+	bar := Foo{
+		name: 'Simon'
+		password: 'simon1234'
+		email: 'simon@gmail.com'
+		age: 15
+	}
+	print_field_values<Foo>(bar)
+}


### PR DESCRIPTION
This PR fix comptime for in field selector (fix #12440).

- Fix comptime for in field selector.
- Add test.

```vlang
fn print_field_values<T>(s T) {
	mut value_list := []string{}

	$for field in T.fields {
		println(s.$(field.name))
		value_list << s.$(field.name).str()
	}
	assert value_list.len == 4
	assert value_list[0] == 'Simon'
	assert value_list[1] == 'simon1234'
	assert value_list[2] == 'simon@gmail.com'
	assert value_list[3] == '15'
}

struct Foo {
	name     string
	password string
	email    string
	age      int
}

fn main() {
	bar := Foo{
		name: 'Simon'
		password: 'simon1234'
		email: 'simon@gmail.com'
		age: 15
	}
	print_field_values<Foo>(bar)
}

PS D:\Test\v\tt1> v run .
Simon
simon1234
simon@gmail.com
15
```