### PR TITLE
checker: check array pop immutable (fix #12456)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2493,6 +2493,7 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 	} else if method_name in ['first', 'last', 'pop'] {
 		node.return_type = array_info.elem_type
 		if method_name == 'pop' {
+			c.fail_if_immutable(node.left)
 			node.receiver_type = left_type.ref()
 		} else {
 			node.receiver_type = left_type

--- a/vlib/v/checker/tests/array_pop_immutable_err.out
+++ b/vlib/v/checker/tests/array_pop_immutable_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/array_pop_immutable_err.vv:5:2: error: `a` is immutable, declare it with `mut` to make it mutable
+    3 |     dump(a)
+    4 |
+    5 |     a.pop()
+      |     ^
+    6 |     dump(a)
+    7 | }

--- a/vlib/v/checker/tests/array_pop_immutable_err.vv
+++ b/vlib/v/checker/tests/array_pop_immutable_err.vv
@@ -1,0 +1,7 @@
+fn main() {
+	a := [1,2,3]
+	dump(a)
+
+	a.pop()
+	dump(a)
+}


### PR DESCRIPTION
This PR check array pop immutable (fix #12456).

- Check array pop immutable.
- Add test.

```vlang
fn main() {
	a := [1,2,3]
	dump(a)

	a.pop()
	dump(a)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:5:2: error: `a` is immutable, declare it with `mut` to make it mutable
    3 |     dump(a)
    4 |
    5 |     a.pop()
      |     ^
    6 |     dump(a)
    7 | }
```