### PR TITLE
checker: allow noreturn in if expr

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6870,6 +6870,10 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 						&& c.table.get_type_symbol(former_expected_type).kind == .sum_type {
 						continue
 					}
+					if is_noreturn_callexpr(last_expr.expr) {
+						continue
+					}
+
 					c.error('mismatched types `${c.table.type_to_str(node.typ)}` and `${c.table.type_to_str(last_expr.typ)}`',
 						node.pos)
 				}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5139,6 +5139,9 @@ fn (mut g Gen) need_tmp_var_in_if(node ast.IfExpr) bool {
 			if branch.stmts.len == 1 {
 				if branch.stmts[0] is ast.ExprStmt {
 					stmt := branch.stmts[0] as ast.ExprStmt
+					if is_noreturn_callexpr(stmt.expr) {
+						return true
+					}
 					if stmt.expr is ast.CallExpr {
 						if stmt.expr.is_method {
 							left_sym := g.table.get_type_symbol(stmt.expr.receiver_type)

--- a/vlib/v/tests/if_expression_test.v
+++ b/vlib/v/tests/if_expression_test.v
@@ -234,3 +234,32 @@ fn test_if_expr_with_or_block() {
 	a := if arr.len == 0 || arr[0] == '-' { 123 } else { return_optional() or { -1 } }
 	assert a == 1
 }
+
+type Num = f32 | f64 | i64 | int
+
+[noreturn]
+fn assert_false_noreturn() {
+	assert false
+	exit(1)
+}
+
+fn test_noreturn() {
+	n := Num(int(0))
+	_ := if n is int {
+		n
+	} else if n is f32 {
+		int(n)
+	} else {
+		exit(1)
+	}
+
+	_ := if 1 == 0 {
+		0
+	} else if 1 == 1 {
+		1
+	} else if 1 == 2 {
+		panic('err')
+	} else {
+		assert_false_noreturn()
+	}
+}


### PR DESCRIPTION
noreturn can be used as branch in match expr. But not for if expr.

see also #11126

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
