### PR TITLE
toml: fix parsing formatting on Windows with crlf line endings

### DIFF
--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -10,7 +10,7 @@ import toml.token
 import toml.scanner
 
 pub const (
-	all_formatting   = [token.Kind.whitespace, .tab, .nl]
+	all_formatting   = [token.Kind.whitespace, .tab, .cr, .nl]
 	space_formatting = [token.Kind.whitespace, .tab]
 )
 


### PR DESCRIPTION
As [validated on Discord](https://discord.com/channels/592103645835821068/592320321995014154/909788578240946176) this PR fixes some failing tests on Windows (related to CRLF line endings)