### PR TITLE
toml: add convenience convertion of Doc to map[string]toml.Any

### DIFF
--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -89,6 +89,12 @@ pub fn (d Doc) to_json() string {
 	return d.ast.to_json()
 }
 
+// to_any converts the `Doc` to map[string]toml.Any type.
+fn (d Doc) to_any() Any {
+	values := d.ast.table as map[string]ast.Value
+	return d.ast_to_any(values)
+}
+
 // value queries a value from the TOML document.
 // `key` should be in "dotted" form (`a.b.c`).
 // `key` supports quoted keys like `a."b.c"`.

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -89,8 +89,8 @@ pub fn (d Doc) to_json() string {
 	return d.ast.to_json()
 }
 
-// to_any converts the `Doc` to map[string]toml.Any type.
-fn (d Doc) to_any() Any {
+// to_any converts the `Doc` to toml.Any type.
+pub fn (d Doc) to_any() Any {
 	values := d.ast.table as map[string]ast.Value
 	return d.ast_to_any(values)
 }


### PR DESCRIPTION
This PR adds a convenience function for converting the whole `toml.Doc` to `toml.Any` (this is currently not possible with `Doc.value()`)