### PR TITLE
checker: check invalid `map` variable name (fix #12469)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -32,7 +32,7 @@ const (
 	array_builtin_methods           = ['filter', 'clone', 'repeat', 'reverse', 'map', 'slice',
 		'sort', 'contains', 'index', 'wait', 'any', 'all', 'first', 'last', 'pop']
 	reserved_type_names             = ['bool', 'i8', 'i16', 'int', 'i64', 'byte', 'u16', 'u32',
-		'u64', 'f32', 'f64', 'string', 'rune']
+		'u64', 'f32', 'f64', 'map', 'string', 'rune']
 	vroot_is_deprecated_message     = '@VROOT is deprecated, use @VMODROOT or @VEXEROOT instead'
 )
 

--- a/vlib/v/checker/tests/invalid_variable_name_err.out
+++ b/vlib/v/checker/tests/invalid_variable_name_err.out
@@ -31,4 +31,11 @@ vlib/v/checker/tests/invalid_variable_name_err.vv:14:2: error: invalid use of re
    14 |     f64 := 2.22
       |     ~~~
    15 |     println(f64)
-   16 | }
+   16 |
+vlib/v/checker/tests/invalid_variable_name_err.vv:17:2: error: invalid use of reserved type `map` as a variable name
+   15 |     println(f64)
+   16 |
+   17 |     map := map[string]string
+      |     ~~~
+   18 |     println(map)
+   19 | }

--- a/vlib/v/checker/tests/invalid_variable_name_err.vv
+++ b/vlib/v/checker/tests/invalid_variable_name_err.vv
@@ -13,4 +13,7 @@ fn main() {
 
 	f64 := 2.22
 	println(f64)
+
+	map := map[string]string
+	println(map)
 }


### PR DESCRIPTION
This PR check invalid `map` variable name (fix #12469).

- Check invalid `map` variable name.
- Add test.

```vlang
fn main()
{
	map := map[string]string
	println("nope" in map)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:3:2: error: invalid use of reserved type `map` as a variable name
    1 | fn main()
    2 | {
    3 |     map := map[string]string
      |     ~~~
    4 |     println("nope" in map)
    5 | }
```