### PR TITLE
cgen: fix string interliteral of the comptime selector

### DIFF
--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -140,7 +140,13 @@ fn (mut g Gen) str_val(node ast.StringInterLiteral, i int) {
 			g.expr(expr)
 		}
 	} else if node.fmts[i] == `s` || typ.has_flag(.variadic) {
-		g.gen_expr_to_string(expr, typ)
+		mut exp_typ := typ
+		if expr is ast.Ident && g.comptime_var_type_map.len > 0 {
+			if expr.obj is ast.Var {
+				exp_typ = expr.obj.typ
+			}
+		}
+		g.gen_expr_to_string(expr, exp_typ)
 	} else if typ.is_number() || typ.is_pointer() || node.fmts[i] == `d` {
 		if typ.is_signed() && node.fmts[i] in [`x`, `X`, `o`] {
 			// convert to unsigned first befors C's integer propagation strikes

--- a/vlib/v/tests/comptime_for_in_field_selector_test.v
+++ b/vlib/v/tests/comptime_for_in_field_selector_test.v
@@ -2,6 +2,7 @@ fn print_field_values<T>(s T) {
 	mut value_list := []string{}
 	mut value_type_list := []string{}
 	mut var_value_list := []string{}
+	mut var_intp_value_list := []string{}
 
 	$for field in T.fields {
 		println(s.$(field.name))
@@ -13,6 +14,7 @@ fn print_field_values<T>(s T) {
 		val := s.$(field.name)
 		println(val)
 		var_value_list << val.str()
+		var_intp_value_list << 'field value: $val'
 	}
 	assert value_list.len == 4
 	assert value_list[0] == 'Simon'
@@ -31,6 +33,12 @@ fn print_field_values<T>(s T) {
 	assert var_value_list[1] == 'simon1234'
 	assert var_value_list[2] == 'simon@gmail.com'
 	assert var_value_list[3] == '15'
+
+	assert var_intp_value_list.len == 4
+	assert var_intp_value_list[0] == 'field value: Simon'
+	assert var_intp_value_list[1] == 'field value: simon1234'
+	assert var_intp_value_list[2] == 'field value: simon@gmail.com'
+	assert var_intp_value_list[3] == 'field value: 15'
 }
 
 struct Foo {


### PR DESCRIPTION
This PR fix string interliteral of the comptime selector.

- Fix string interliteral of the comptime selector.
- Add test.

```vlang
fn print_field_values<T>(s T) {
	mut value_list := []string{}
	mut value_type_list := []string{}
	mut var_value_list := []string{}
	mut var_intp_value_list := []string{}

	$for field in T.fields {
		println(s.$(field.name))
		value_list << s.$(field.name).str()

		println(typeof(s.$(field.name)).name)
		value_type_list << typeof(s.$(field.name)).name

		val := s.$(field.name)
		println(val)
		var_value_list << val.str()
		var_intp_value_list << 'field value: $val'
	}

	assert value_list.len == 4
	assert value_list[0] == 'Simon'
	assert value_list[1] == 'simon1234'
	assert value_list[2] == 'simon@gmail.com'
	assert value_list[3] == '15'

	assert value_type_list.len == 4
	assert value_type_list[0] == 'string'
	assert value_type_list[1] == 'string'
	assert value_type_list[2] == 'string'
	assert value_type_list[3] == 'int'

	assert var_value_list.len == 4
	assert var_value_list[0] == 'Simon'
	assert var_value_list[1] == 'simon1234'
	assert var_value_list[2] == 'simon@gmail.com'
	assert var_value_list[3] == '15'

	assert var_intp_value_list.len == 4
	assert var_intp_value_list[0] == 'field value: Simon'
	assert var_intp_value_list[1] == 'field value: simon1234'
	assert var_intp_value_list[2] == 'field value: simon@gmail.com'
	assert var_intp_value_list[3] == 'field value: 15'
}

struct Foo {
	name     string
	password string
	email    string
	age      int
}

fn main() {
	bar := Foo{
		name: 'Simon'
		password: 'simon1234'
		email: 'simon@gmail.com'
		age: 15
	}
	print_field_values<Foo>(bar)
}

PS D:\Test\v\tt1> v run .
Simon
string
Simon
simon1234
string
simon1234
simon@gmail.com
string
simon@gmail.com
15
int
15
```