### PR TITLE
sqlite: make constants public

### DIFF
--- a/vlib/sqlite/sqlite.v
+++ b/vlib/sqlite/sqlite.v
@@ -14,7 +14,7 @@ $if windows {
 
 #include "sqlite3.h"
 
-const (
+pub const (
 	sqlite_ok    = 0
 	sqlite_error = 1
 	sqlite_row   = 100

--- a/vlib/sqlite/sqlite_test.v
+++ b/vlib/sqlite/sqlite_test.v
@@ -1,3 +1,5 @@
+module test
+
 import sqlite
 
 fn test_sqlite() {
@@ -28,4 +30,11 @@ fn test_sqlite() {
 	assert user.vals.len == 2
 	db.close() or { panic(err) }
 	assert !db.is_open
+}
+
+fn test_can_access_sqlite_result_consts() {
+	assert sqlite.sqlite_ok == 0
+	assert sqlite.sqlite_error == 1
+	assert sqlite.sqlite_row == 100
+	assert sqlite.sqlite_done == 101
 }

--- a/vlib/sqlite/sqlite_test.v
+++ b/vlib/sqlite/sqlite_test.v
@@ -1,5 +1,3 @@
-module test
-
 import sqlite
 
 fn test_sqlite() {


### PR DESCRIPTION
This PRs make sqlite constants to be public. We can share the result codes used on this module within any calling code to check for the same results.

Before:

```v
import sqlite

fn main() ? {
  db := sqlite.connect("database.sqlite3") ?

  users, code := db.exec("SELECT id, name FROM users")

  if code != 101 {
    panic("Query failed")
  }
}
```

After

```v
import sqlite

fn main() ? {
  db := sqlite.connect("database.sqlite3") ?

  users, code := db.exec("SELECT id, name FROM users")

  if code != sqlite.sqlite_done {
    panic("Query failed")
  }
}
```