### PR TITLE
cgen: fix generic struct free() (fix #12484)

### DIFF
--- a/vlib/v/gen/c/auto_free_methods.v
+++ b/vlib/v/gen/c/auto_free_methods.v
@@ -15,7 +15,7 @@ fn (mut g Gen) gen_free_method_for_type(typ ast.Type) string {
 		}
 	}
 
-	if sym.has_method('free') {
+	if sym.has_method_with_generic_parent('free') {
 		return fn_name
 	}
 	match mut sym.info {

--- a/vlib/v/tests/generics_struct_free_test.v
+++ b/vlib/v/tests/generics_struct_free_test.v
@@ -1,0 +1,29 @@
+struct List<T> {
+pub mut:
+	head &ListNode<T> = 0
+}
+
+struct ListNode<T> {
+pub mut:
+	value T
+	next  &ListNode<T> = 0
+}
+
+fn list_new<T>() List<T> {
+	return List<T>{}
+}
+
+fn listnode_new<T>() &ListNode<T> {
+	return &ListNode<T>{0, 0}
+}
+
+fn (mut l List<T>) free() {
+	//
+}
+
+fn test_generic_struct_free() {
+	mut list := list_new<string>()
+	println(list)
+	list.free()
+	assert true
+}


### PR DESCRIPTION
This PR fix generic struct free() (fix #12484).

- Fix generic struct free().
- Add test.

```vlang
struct List<T> {
pub mut:
	head &ListNode<T> = 0
}

struct ListNode<T> {
pub mut:
	value T
	next  &ListNode<T> = 0
}

fn list_new<T>() List<T> {
	return List<T>{}
}

fn listnode_new<T>() &ListNode<T> {
	return &ListNode<T>{0, 0}
}

fn (mut l List<T>) free() {
	println('free list')
}

fn main() {
	mut list := list_new<string>()
	println(list)
	list.free()
}

PS D:\Test\v\tt1> v run .
List<string>{
    head: &nil
}
free list
```