### PR TITLE
checker: check struct field using 'any' type (fix #6096)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -638,6 +638,9 @@ pub fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 			}
 		}
 		for i, field in node.fields {
+			if field.typ == ast.any_type {
+				c.error('struct field cannot be the `any` type, use generics instead', field.type_pos)
+			}
 			c.ensure_type_exists(field.typ, field.type_pos) or { return }
 			if field.typ.has_flag(.generic) {
 				has_generic_types = true

--- a/vlib/v/checker/tests/struct_field_with_any_type_err.out
+++ b/vlib/v/checker/tests/struct_field_with_any_type_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/struct_field_with_any_type_err.vv:2:6: error: struct field cannot be the `any` type, use generics instead
+    1 | struct My_type {
+    2 |     fld any
+      |         ~~~
+    3 | }
+    4 |

--- a/vlib/v/checker/tests/struct_field_with_any_type_err.vv
+++ b/vlib/v/checker/tests/struct_field_with_any_type_err.vv
@@ -1,0 +1,8 @@
+struct My_type {
+	fld any
+}
+
+fn main() {
+	a := My_type{}
+	println(a)
+}


### PR DESCRIPTION
This PR check struct field using 'any' type (fix #6096).

- Check struct field using 'any' type.
- Add test.

```vlang
struct My_type {
	fld any
}

fn main() {
	a := My_type{}
	println(a)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:2:6: error: struct field cannot be the `any` type, use generics instead
    1 | struct My_type {
    2 |     fld any
      |         ~~~
    3 | }
    4 |
```