### PR TITLE
toml: fix scanning of short unicode escapes

### DIFF
--- a/vlib/toml/scanner/scanner.v
+++ b/vlib/toml/scanner/scanner.v
@@ -516,7 +516,7 @@ fn (mut s Scanner) handle_escapes(quote byte, is_multiline bool) (string, int) {
 			&& byte(s.peek(4)).is_hex_digit() && byte(s.peek(5)).is_hex_digit() {
 			lit += s.text[s.pos + 1..s.pos + 6] //.ascii_str()
 			util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'gulp escaped unicode `$lit`')
-			return lit, 4
+			return lit, 5
 		} else if s.peek(1) == quote {
 			if (!is_multiline && s.peek(2) == `\n`)
 				|| (is_multiline && s.peek(2) == quote && s.peek(3) == quote && s.peek(4) == `\n`) {

--- a/vlib/toml/tests/strings_test.v
+++ b/vlib/toml/tests/strings_test.v
@@ -28,6 +28,8 @@ two
 three
 four
 '''"
+	toml_unicode_escapes = r'short = "\u03B4"
+long = "\U000003B4"'
 )
 
 fn test_multiline_strings() {
@@ -64,6 +66,15 @@ fn test_multiline_strings() {
 	assert value.string() == 'aaa' + "'''" + 'bbb'
 	value = toml_doc.value('mismatch2')
 	assert value.string() == 'aaa' + '"""' + 'bbb'
+}
+
+fn test_unicode_escapes() {
+	mut toml_doc := toml.parse(toml_unicode_escapes) or { panic(err) }
+
+	mut value := toml_doc.value('short')
+	assert value.string() == r'\u03B4'
+	value = toml_doc.value('long')
+	assert value.string() == r'\U000003B4'
 }
 
 fn test_literal_strings() {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -639,7 +639,8 @@ pub fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 		}
 		for i, field in node.fields {
 			if field.typ == ast.any_type {
-				c.error('struct field cannot be the `any` type, use generics instead', field.type_pos)
+				c.error('struct field cannot be the `any` type, use generics instead',
+					field.type_pos)
 			}
 			c.ensure_type_exists(field.typ, field.type_pos) or { return }
 			if field.typ.has_flag(.generic) {


### PR DESCRIPTION
This PR fixes a small bug in `scanner` where `\uXXXX` sequences caused the scanner to be left one character behind after the parsing of the sequence.