### PR TITLE
encode ascii chars < 0x20 in JSON

### DIFF
--- a/vlib/x/json2/decoder_test.v
+++ b/vlib/x/json2/decoder_test.v
@@ -5,6 +5,13 @@ fn test_raw_decode_string() ? {
 	assert str.str() == 'Hello!'
 }
 
+fn test_raw_decode_string_escape() ? {
+	jstr := raw_decode('"\u001b"') ?
+	str := jstr.str()
+	assert str.len == 1
+	assert str[0] == 27
+}
+
 fn test_raw_decode_number() ? {
 	num := raw_decode('123') ?
 	assert num.int() == 123

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -150,6 +150,9 @@ fn json_string(s string) string {
 				}
 			} else if chr == `"` || chr == `/` || chr == `\\` {
 				sb.write_string('\\' + chr.ascii_str())
+			} else if int(chr) < 0x20 {
+				hex_code := chr.hex()
+				sb.write_string('\\u00$hex_code')
 			} else {
 				sb.write_b(chr)
 			}

--- a/vlib/x/json2/encoder_test.v
+++ b/vlib/x/json2/encoder_test.v
@@ -5,6 +5,13 @@ fn test_json_string_characters() {
 	assert text.json_str() == '\\n\\r\\b\\f\\t\\\\\\"\\/'
 }
 
+fn test_json_escape_low_chars() {
+	esc := '\u001b'
+	assert esc.len == 1
+	text := json2.Any(esc)
+	assert text.json_str() == r'\u001b'
+}
+
 fn test_json_string() {
 	text := json2.Any('te✔st')
 	assert text.json_str() == r'te\u2714st'


### PR DESCRIPTION
the json2 encoder handles the few special escapes in the json spec \n \r \t etc, but does not handle all characters 0x20 or lower, which should be \uXXXX encoded. I ran into this because ESC was not being encoded. This patch catches chars less than 0x20 that are not already handled by the special \n \r \t etc codes.