### PR TITLE
fmt: format explicit map init with parameter

### DIFF
--- a/vlib/v/fmt/tests/maps_expected.vv
+++ b/vlib/v/fmt/tests/maps_expected.vv
@@ -14,3 +14,9 @@ numbers := {
 	'sevenhundredseventyseven':            777
 	'fivethousandthreehundredtwentyseven': 5327
 }
+
+explicit_init := map[string]string{}
+
+explicit_init_with_value := {
+	'abc': 0
+}

--- a/vlib/v/fmt/tests/maps_input.vv
+++ b/vlib/v/fmt/tests/maps_input.vv
@@ -14,3 +14,9 @@ numbers := {
   'sevenhundredseventyseven': 777
 'fivethousandthreehundredtwentyseven': 5327
 }
+
+explicit_init := map[string]string{}
+
+explicit_init_with_value := map[string]int{
+	'abc': 0
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2029,6 +2029,11 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 			if p.tok.kind == .rcbr {
 				p.next()
 			} else {
+				if p.pref.is_fmt {
+					map_init := p.map_init()
+					p.check(.rcbr)
+					return map_init
+				}
 				p.error('`}` expected; explicit `map` initialization does not support parameters')
 			}
 		}


### PR DESCRIPTION
format `map[key]value{ key: value }` to `{ key: value }` instead of parser error


<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
