### PR TITLE
toml: improve number conversion

### DIFF
--- a/vlib/toml/ast/types.v
+++ b/vlib/toml/ast/types.v
@@ -4,6 +4,7 @@
 module ast
 
 import toml.token
+import strconv
 
 // Key is a sumtype representing all types of keys that
 // can be found in a TOML document.
@@ -166,6 +167,26 @@ pub fn (n Number) str() string {
 	str += '  pos:  $n.pos\n'
 	str += '}'
 	return str
+}
+
+// i64 returns the `n Number` as an `i64` value.
+pub fn (n Number) i64() i64 {
+	if n.text.starts_with('0x') {
+		hex := n.text.all_after('0x').to_upper().replace('_', '')
+		return strconv.parse_int(hex, 16, 64) or { i64(0) }
+	} else if n.text.starts_with('0o') {
+		oct := n.text.all_after('0o').replace('_', '')
+		return strconv.parse_int(oct, 8, 64) or { i64(0) }
+	} else if n.text.starts_with('0b') {
+		bin := n.text.all_after('0b').replace('_', '')
+		return strconv.parse_int(bin, 2, 64) or { i64(0) }
+	}
+	return strconv.parse_int(n.text, 0, 0) or { i64(0) }
+}
+
+// f64 returns the `n Number` as an `f64` value.
+pub fn (n Number) f64() f64 {
+	return n.text.replace('_', '').f64()
 }
 
 // Date is the data representation of a TOML date type (`YYYY-MM-DD`).

--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -1,6 +1,5 @@
 import os
 import toml
-import toml.util
 import toml.ast
 import toml.scanner
 import x.json2
@@ -30,7 +29,7 @@ const (
 		'comment/tricky.toml',
 		// Table
 		'table/array-implicit.toml',
-		'table/names.toml',
+		//'table/names.toml',
 		// Date-time
 		'datetime/milliseconds.toml',
 		// Inline-table

--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -29,7 +29,7 @@ const (
 		'comment/tricky.toml',
 		// Table
 		'table/array-implicit.toml',
-		//'table/names.toml',
+		'table/names.toml',
 		// Date-time
 		'datetime/milliseconds.toml',
 		// Inline-table

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -7,7 +7,6 @@ import toml.ast
 import toml.input
 import toml.scanner
 import toml.parser
-import strconv
 
 // Null is used in sumtype checks as a "default" value when nothing else is possible.
 pub struct Null {

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -199,11 +199,14 @@ pub fn (d Doc) ast_to_any(value ast.Value) Any {
 			return Any(value.text)
 		}
 		ast.Number {
-			if value.text.contains('.') || value.text.to_lower().contains('e') {
-				return Any(value.text.f64())
+			// if value.text.contains('inf') || value.text.contains('nan') {
+			// return Any() // TODO
+			//}
+			if !value.text.starts_with('0x')
+				&& (value.text.contains('.') || value.text.to_lower().contains('e')) {
+				return Any(value.f64())
 			}
-			v := strconv.parse_int(value.text, 0, 0) or { i64(0) }
-			return Any(v)
+			return Any(value.i64())
 		}
 		ast.Bool {
 			str := (value as ast.Bool).text


### PR DESCRIPTION
This PR fixes conversion of different number formats to their respective values.
The following pass their value tests, as an example:
```toml
bin1 = 0b11010110
bin2 = 0b1_0_1

oct1 = 0o01234567
oct2 = 0o755
oct3 = 0o7_6_5

hex1 = 0xDEADBEEF
hex2 = 0xdeadbeef
hex3 = 0xdead_beef
hex4 = 0x00987
```