### PR TITLE
cgen: fix multiple matchs in one expr (fix #12513)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4444,6 +4444,7 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 	} else {
 		g.match_expr_classic(node, is_expr, cond_var, tmp_var)
 	}
+	g.set_current_pos_as_last_stmt_pos()
 	g.write(cur_line)
 	if need_tmp_var {
 		g.write('$tmp_var')

--- a/vlib/v/tests/multiple_matchs_in_one_expr_test.v
+++ b/vlib/v/tests/multiple_matchs_in_one_expr_test.v
@@ -1,0 +1,26 @@
+fn hex_to_bytes(s string) ?[]byte {
+	mut ret := []byte{cap: s.len}
+	for read := 0; read < s.len; read += 2 {
+		high := s[read]
+		low := s[read + 1]
+
+		ret << match high {
+			48...57 { (high - 48) << 4 }
+			65...70 { (high - 65) << 4 }
+			97...102 { (high - 97) << 4 }
+			else { panic('impossible') }
+		} + match low {
+			48...57 { low - 48 }
+			65...70 { low - 65 }
+			97...102 { low - 97 }
+			else { panic('impossible') }
+		}
+	}
+	return ret
+}
+
+fn test_multiple_matchs_in_one_expr() {
+	ret := hex_to_bytes('FFFF') or { 'error'.bytes() }
+	println(ret)
+	assert '$ret' == '[U, U]'
+}


### PR DESCRIPTION
This PR fix multiple matchs in one expr (fix #12513).

- Fix multiple matchs in one expr.
- Add test.

```vlang
fn hex_to_bytes(s string) ?[]byte {
	mut ret := []byte{cap: s.len}
	for read := 0; read < s.len; read += 2 {
		high := s[read]
		low := s[read + 1]

		ret << match high {
			48...57 { (high - 48) << 4 }
			65...70 { (high - 65) << 4 }
			97...102 { (high - 97) << 4 }
			else { panic('impossible') }
		} + match low {
			48...57 { low - 48 }
			65...70 { low - 65 }
			97...102 { low - 97 }
			else { panic('impossible') }
		}
	}
	return ret
}

fn main() {
	ret := hex_to_bytes('FFFF') or { 'error'.bytes() }
	println(ret)
	assert '$ret' == '[U, U]'
}

PS D:\Test\v\tt1> v run .
[U, U]
```