### PR TITLE
checker: fix generics fn infer nested generic fn (fix #6216)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -614,7 +614,8 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 			if node.args.len <= arg_i {
 				break
 			}
-			arg := node.args[arg_i]
+			mut arg := node.args[arg_i]
+			arg.typ = c.unwrap_generic(arg.typ)
 			param_type_sym := c.table.get_type_symbol(param.typ)
 
 			if param.typ.has_flag(.generic) && param_type_sym.name == gt_name {

--- a/vlib/v/tests/generic_fn_infer_nested_generic_fn_test.v
+++ b/vlib/v/tests/generic_fn_infer_nested_generic_fn_test.v
@@ -1,0 +1,49 @@
+import json
+import os
+
+fn test_generics_fn_infer_nested_generic_fn() {
+	mut spawns := []ItemSpawn{}
+	load_item_spawns(mut spawns)
+	println(spawns)
+	assert spawns.len == 0
+}
+
+fn load_item_spawns(mut spawns []ItemSpawn) {
+	walk<ItemSpawn>('./data/items/spawns/', mut spawns)
+}
+
+fn parse_json<T>(file string, mut array []T) {
+	data := os.read_file(file) or {
+		panic('error reading file $file')
+		return
+	}
+	decoded_data := json.decode([]T, data) or {
+		eprintln('Failed to parse item spawns')
+		return
+	}
+	for d in decoded_data {
+		array << d
+	}
+}
+
+fn walk<T>(path string, mut array []T) {
+	if !os.is_dir(path) {
+		return
+	}
+	mut files := os.ls(path) or { return }
+	for file in files {
+		p := path + os.path_separator + file
+		if os.is_dir(p) && !os.is_link(p) {
+			walk(p, mut array)
+		} else if os.exists(p) {
+			parse_json(p, mut array)
+		}
+	}
+}
+
+struct ItemSpawn {
+	id     int
+	amount int = 1
+	x      int
+	y      int
+}


### PR DESCRIPTION
This PR fix generics fn infer nested generic fn (fix #6216).

- Fix generics fn infer nested generic fn.
- Add test.

```vlang
module main

import vweb
import json
import os

const (
	port = 8081
)

struct App {
	vweb.Context
}

fn main() {
	mut spawns := []ItemSpawn{}
	load_item_spawns(mut spawns)

	vweb.run(&App{}, port)
}

fn load_item_spawns(mut spawns []ItemSpawn) {
	walk<ItemSpawn>('./data/items/spawns/', mut spawns)
}

fn parse_json<T>(file string, mut array []T) {
	data := os.read_file(file) or {
		panic('error reading file $file')
		return
	}
	decoded_data := json.decode([]T, data) or {
		eprintln('Failed to parse item spawns')
		return
	}
	for d in decoded_data {
		array << d
	}
}

fn walk<T>(path string, mut array []T) {
	if !os.is_dir(path) {
		return
	}
	mut files := os.ls(path) or { return }
	for file in files {
		p := path + os.path_separator + file
		if os.is_dir(p) && !os.is_link(p) {
			walk(p, mut array)
		} else if os.exists(p) {
			parse_json(p, mut array)
		}
	}
}

pub fn (mut app App) init_once() {}

pub fn (mut app App) init() {}

pub fn (mut app App) index() {}

struct ItemSpawn {
	id     int
	amount int = 1
	x      int
	y      int
}

PS D:\Test\v\tt1> v run .
[Vweb] Running app on http://localhost:8081
```