### PR TITLE
Include vls.log in list of files to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ flake.nix
 .envrc
 
 thirdparty/stdatomic/nix/cpp/*.h
+
+# ignore VLS log
+vls.log

--- a/cmd/tools/vcreate.v
+++ b/cmd/tools/vcreate.v
@@ -74,6 +74,7 @@ fn gen_gitignore(name string) string {
 		'*.so',
 		'*.dylib',
 		'*.dll',
+		'vls.log',
 		'',
 	].join('\n')
 }

--- a/cmd/tools/vcreate_test.v
+++ b/cmd/tools/vcreate_test.v
@@ -34,6 +34,7 @@ fn init_and_check() ? {
 		'*.so',
 		'*.dylib',
 		'*.dll',
+		'vls.log',
 		'',
 	].join('\n')
 }


### PR DESCRIPTION
Includes `vls.log` in the `.gitignore` list.

The VLS log file is generated while using the [V Language Server](https://github.com/vlang/vls). It is helpful for obtaining diagnostic information but does not serve a purpose relevant to the user's project.