### PR TITLE
cgen: make `dump(x)` use a single write call, fix memleaks for autogenerated .str() methods of nested structs

### DIFF
--- a/vlib/v/tests/valgrind/dump_nested_structs.v
+++ b/vlib/v/tests/valgrind/dump_nested_structs.v
@@ -1,0 +1,21 @@
+struct NestedInner {
+	x int
+	y int
+}
+
+struct Inner {
+	x           int
+	y           int
+	nestedinner NestedInner
+}
+
+struct Outer {
+	x     int
+	y     int
+	inner Inner
+}
+
+fn main() {
+	a := Outer{123, 456, Inner{789, 999, NestedInner{111, 222}}}
+	dump(a)
+}

--- a/vlib/v/util/surrounder.v
+++ b/vlib/v/util/surrounder.v
@@ -1,0 +1,70 @@
+module util
+
+import strings
+
+[noinit]
+pub struct Surrounder {
+pub mut:
+	befores []string
+	afters  []string
+}
+
+pub fn new_surrounder(expected_length int) Surrounder {
+	return Surrounder{
+		befores: []string{cap: expected_length}
+		afters: []string{cap: expected_length}
+	}
+}
+
+pub fn (mut s Surrounder) add(before string, after string) {
+	s.befores << before
+	s.afters << after
+}
+
+[manualfree]
+pub fn (s &Surrounder) before() string {
+	len := s.befores.len
+	if len > 0 {
+		mut res := strings.new_builder(len * 100)
+		defer {
+			unsafe { res.free() }
+		}
+		for i := 0; i < len; i++ {
+			x := &s.befores[i]
+			if x.len > 0 {
+				res.writeln(x)
+			}
+		}
+		ret := res.str()
+		return ret
+	}
+	return ''
+}
+
+[manualfree]
+pub fn (s &Surrounder) after() string {
+	len := s.afters.len
+	if len > 0 {
+		mut res := strings.new_builder(len * 100)
+		defer {
+			unsafe { res.free() }
+		}
+		for i := len - 1; i >= 0; i-- {
+			x := &s.afters[i]
+			if x.len > 0 {
+				res.writeln(x)
+			}
+		}
+		ret := res.str()
+		return ret
+	}
+	return ''
+}
+
+[unsafe]
+pub fn (mut s Surrounder) free() {
+	unsafe {
+		s.befores.free()
+		s.afters.free()
+	}
+}


### PR DESCRIPTION
I've also added a regression test in vlib/v/tests/valgrind/dump_nested_structs.v , which is now leak free under -autofree .