### PR TITLE
checker: check invalid fn parameter name (fix #12536)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -31,8 +31,8 @@ const (
 	valid_comptime_not_user_defined = all_valid_comptime_idents()
 	array_builtin_methods           = ['filter', 'clone', 'repeat', 'reverse', 'map', 'slice',
 		'sort', 'contains', 'index', 'wait', 'any', 'all', 'first', 'last', 'pop']
-	reserved_type_names             = ['bool', 'i8', 'i16', 'int', 'i64', 'byte', 'u16', 'u32',
-		'u64', 'f32', 'f64', 'map', 'string', 'rune']
+	reserved_type_names             = ['bool', 'char', 'i8', 'i16', 'int', 'i64', 'byte', 'u16',
+		'u32', 'u64', 'f32', 'f64', 'map', 'string', 'rune']
 	vroot_is_deprecated_message     = '@VROOT is deprecated, use @VMODROOT or @VEXEROOT instead'
 )
 
@@ -566,6 +566,10 @@ pub fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 					continue // no need to check first param
 				}
 				c.ensure_type_exists(param.typ, param.pos) or { return }
+				if param.name in checker.reserved_type_names {
+					c.error('invalid use of reserved type `$param.name` as a parameter name',
+						param.pos)
+				}
 				if is_js {
 					ptyp := c.table.get_type_symbol(param.typ)
 					if !ptyp.is_js_compatible() && !(j == method.params.len - 1
@@ -8242,6 +8246,10 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 		// Make sure all types are valid
 		for mut param in node.params {
 			c.ensure_type_exists(param.typ, param.type_pos) or { return }
+			if param.name in checker.reserved_type_names {
+				c.error('invalid use of reserved type `$param.name` as a parameter name',
+					param.pos)
+			}
 			if !param.typ.is_ptr() { // value parameter, i.e. on stack - check for `[heap]`
 				arg_typ_sym := c.table.get_type_symbol(param.typ)
 				if arg_typ_sym.kind == .struct_ {

--- a/vlib/v/checker/tests/invalid_parameter_name_err.out
+++ b/vlib/v/checker/tests/invalid_parameter_name_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/invalid_parameter_name_err.vv:4:24: error: invalid use of reserved type `char` as a parameter name
+    2 | }
+    3 |
+    4 | fn (mut b Buffer) put8(char u8) ? {
+      |                        ~~~~
+    5 |     return error('-')
+    6 | }
+vlib/v/checker/tests/invalid_parameter_name_err.vv:10:6: error: invalid use of reserved type `char` as a parameter name
+    8 | interface Writer {
+    9 | mut:
+   10 |     put(char u8) ?
+      |         ~~~~
+   11 | }
+   12 |

--- a/vlib/v/checker/tests/invalid_parameter_name_err.vv
+++ b/vlib/v/checker/tests/invalid_parameter_name_err.vv
@@ -1,0 +1,14 @@
+struct Buffer {
+}
+
+fn (mut b Buffer) put8(char u8) ? {
+	return error('-')
+}
+
+interface Writer {
+mut:
+	put(char u8) ?
+}
+
+fn main() {
+}

--- a/vlib/v/tests/for_loops_test.v
+++ b/vlib/v/tests/for_loops_test.v
@@ -4,16 +4,16 @@ const (
 
 fn test_for_char_in() {
 	mut sum := 0
-	for char in nums {
-		sum += char
+	for ch in nums {
+		sum += ch
 	}
 	assert sum == 6
 }
 
 fn test_for_char_in_range() {
 	mut sum := 0
-	for char in 0 .. nums.len {
-		sum += nums[char]
+	for ch in 0 .. nums.len {
+		sum += nums[ch]
 	}
 	assert sum == 6
 }
@@ -28,8 +28,8 @@ fn test_for_blank_in_range() {
 
 fn test_for_char_complex() {
 	mut sum := 0
-	for char := 0; char < nums.len; char++ {
-		sum += nums[char]
+	for ch := 0; ch < nums.len; ch++ {
+		sum += nums[ch]
 	}
 	assert sum == 6
 }
@@ -37,8 +37,8 @@ fn test_for_char_complex() {
 fn test_for_char_in_string() {
 	s := 'abcd'
 	mut sum := 0
-	for char in s {
-		sum += char
+	for ch in s {
+		sum += ch
 	}
 	assert sum == 394 // ascii codes of `a` + `b` + `c` + `d`
 }


### PR DESCRIPTION
This PR check invalid fn parameter name (fix #12536).

- Check invalid fn parameter name.
- Add test.

```vlang
struct Buffer {
}

fn (mut b Buffer) put8(char u8) ? {
	return error('-')
}

interface Writer {
mut:
	put(char u8) ?
}

fn main() {
}

PS D:\Test\v\tt1> v run .
.\tt1.v:4:24: error: invalid use of reserved type `char` as a parameter name
    2 | }
    3 |
    4 | fn (mut b Buffer) put8(char u8) ? {
      |                        ~~~~
    5 |     return error('-')
    6 | }
.\tt1.v:10:6: error: invalid use of reserved type `char` as a parameter name
    8 | interface Writer {
    9 | mut:
   10 |     put(char u8) ?
      |         ~~~~
   11 | }
   12 |
```