### PR TITLE
fmt: remove unnecessary paren in assert stmt

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -711,15 +711,11 @@ fn expr_is_single_line(expr ast.Expr) bool {
 
 pub fn (mut f Fmt) assert_stmt(node ast.AssertStmt) {
 	f.write('assert ')
-	if node.expr is ast.ParExpr {
-		if node.expr.expr is ast.InfixExpr {
-			infix := node.expr.expr
-			f.expr(infix)
-			f.writeln('')
-			return
-		}
+	mut expr := node.expr
+	for expr is ast.ParExpr {
+		expr = (expr as ast.ParExpr).expr
 	}
-	f.expr(node.expr)
+	f.expr(expr)
 	f.writeln('')
 }
 

--- a/vlib/v/fmt/tests/asserts_expected.vv
+++ b/vlib/v/fmt/tests/asserts_expected.vv
@@ -2,4 +2,5 @@ fn f() {
 	assert 0 == 0
 	assert 0 < 1
 	assert (1 + 2) == 3
+	assert true
 }

--- a/vlib/v/fmt/tests/asserts_input.vv
+++ b/vlib/v/fmt/tests/asserts_input.vv
@@ -1,5 +1,6 @@
 fn f() {
 	assert (0 == 0)
 	assert (0 < 1)
-	assert ((1 + 2) == 3)
+	assert (((((1 + 2) == 3))))
+	assert (((true)))
 }

--- a/vlib/v/gen/js/tests/testdata/match.v
+++ b/vlib/v/gen/js/tests/testdata/match.v
@@ -25,16 +25,19 @@ fn match_vec(v Vec) {
 fn match_classic_num() {
 	match 42 {
 		0 {
-			assert (false)
+			assert false
+			(false)
 		}
 		1 {
-			assert (false)
+			assert false
+			(false)
 		}
 		42 {
 			println('life')
 		}
 		else {
-			assert (false)
+			assert false
+			(false)
 		}
 	}
 }


### PR DESCRIPTION
v fmt removes paren for  infix expr. But not for others. 

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
