### PR TITLE
checker: fix vtl compile error

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1954,6 +1954,9 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	node.return_type = left_type
 	node.receiver_type = left_type
 
+	if c.table.cur_fn.generic_names.len > 0 {
+		c.table.unwrap_generic_type(left_type, c.table.cur_fn.generic_names, c.table.cur_concrete_types)
+	}
 	unwrapped_left_type := c.unwrap_generic(left_type)
 	left_sym := c.table.get_type_symbol(unwrapped_left_type)
 	final_left_sym := c.table.get_final_type_symbol(unwrapped_left_type)


### PR DESCRIPTION
This PR fix vtl compile error.
Because the structure is too complex, no test examples are added.

error:
```vlang
fun.v:21:20: error: unknown method or field: `.TensorIterator<f64>.next`
   19 |     mut iter := t.iterator()
   20 |     for {
   21 |         val, pos := iter.next() or { break }
      |                          ~~~~~~~~~~~~~~~~~~~
   22 |         next_val := f(val, pos)
   23 |         t.data.set<T>(pos, next_val)
fun.v:1:1: error: checker.expr(): unhandled EmptyExpr
    1 | module vtl
      | ^
    2 |
    3 | import math
fun.v:22:22: error: cannot use `void` as `int` in argument 2 to `f`
   20 |     for {
   21 |         val, pos := iter.next() or { break }
   22 |         next_val := f(val, pos)
      |                            ~~~
   23 |         t.data.set<T>(pos, next_val)
   24 |     }
fun.v:32:20: error: unknown method or field: `.TensorIterator<f64>.next`
   30 |     mut iter := t.iterator()
   31 |     for {
   32 |         val, pos := iter.next() or { break }
      |                          ~~~~~~~~~~~~~~~~~~~
   33 |         next_val := f(val, pos)
   34 |         ret.data.set<T>(pos, next_val)
fun.v:33:22: error: cannot use `void` as `int` in argument 2 to `f`
   31 |     for {
   32 |         val, pos := iter.next() or { break }
   33 |         next_val := f(val, pos)
      |                            ~~~
   34 |         ret.data.set<T>(pos, next_val)
   35 |     }
fun.v:44:20: error: unknown method or field: `.TensorIterator<f64>.next`
   42 |     mut iter := t.iterator()
   43 |     for {
   44 |         val, pos := iter.next() or { break }
      |                          ~~~~~~~~~~~~~~~~~~~
   45 |         ret = f(ret, val, pos)
   46 |     }
fun.v:45:21: error: cannot use `void` as `int` in argument 3 to `f`
   43 |     for {
   44 |         val, pos := iter.next() or { break }
   45 |         ret = f(ret, val, pos)
      |                           ~~~
   46 |     }
   47 |     return ret
```