### PR TITLE
toml: support checking and decoding quoted keys

### DIFF
--- a/vlib/toml/checker/checker.v
+++ b/vlib/toml/checker/checker.v
@@ -366,7 +366,7 @@ fn (c Checker) check_time(t ast.Time) ? {
 }
 
 // check_quoted returns an error if `q` is not a valid quoted TOML string.
-fn (c Checker) check_quoted(q ast.Quoted) ? {
+pub fn (c Checker) check_quoted(q ast.Quoted) ? {
 	lit := q.text
 	quote := q.quote.ascii_str()
 	triple_quote := quote + quote + quote

--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -1058,16 +1058,25 @@ pub fn (mut p Parser) key() ?ast.Key {
 			' key expected .bare, .underscore, .number, .quoted or .boolean but got "$p.tok.kind"')
 	}
 
-	// A small exception that can't easily be done via `checker`
-	// since the `is_multiline` information is lost when using the key.text as a
+	// A few small exceptions that can't easily be done via `checker` or `decoder` *after* the
+	// main table has been build since information like `is_multiline` is lost when using the key.text as a
 	// V `map` key directly.
-	if p.config.run_checks {
-		if key is ast.Quoted {
+	if key is ast.Quoted {
+		if p.config.run_checks {
 			quoted := key as ast.Quoted
 			if quoted.is_multiline {
 				return error(@MOD + '.' + @STRUCT + '.' + @FN +
 					' multiline string as key is not allowed. (excerpt): "...${p.excerpt()}..."')
 			}
+			chckr := checker.Checker{
+				scanner: p.scanner
+			}
+			chckr.check_quoted(quoted) ?
+		}
+		if p.config.decode_values {
+			mut quoted := key as ast.Quoted
+			decoder.decode_quoted_escapes(mut quoted) ?
+			key = ast.Key(quoted)
 		}
 	}
 

--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -23,8 +23,6 @@ const (
 		'table/array-implicit.toml',
 		// Date-time
 		'datetime/milliseconds.toml',
-		// Key
-		'key/escapes.toml',
 	]
 
 	jq                     = os.find_abs_path_of_executable('jq') or { '' }


### PR DESCRIPTION
This PR will support checking and decoding of quoted keys (as opposed to only values).
The checking and decoding of the keys is dis- and enabled on the same conditions as when used on the values.