### PR TITLE
ast: fix vtl compile error of generic array type cname

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -812,7 +812,12 @@ pub fn (t &Table) array_cname(elem_type Type) string {
 	if elem_type.is_ptr() {
 		res = '_ptr'.repeat(elem_type.nr_muls())
 	}
-	return 'Array_$elem_type_sym.cname' + res
+	if elem_type_sym.cname.contains('<') {
+		type_name := elem_type_sym.cname.replace_each(['<', '_T_', ', ', '_', '>', ''])
+		return 'Array_$type_name' + res
+	} else {
+		return 'Array_$elem_type_sym.cname' + res
+	}
 }
 
 // array_fixed_source_name generates the original name for the v source.


### PR DESCRIPTION
This PR fix vtl compile error of generic array type cname.

```vlang
PS D:\vtl> v test .
---- Testing... --------------------------------------------------------------------------------------------------------
 OK    [1/8]  1521.065 ms D:/vtl/creation_test.v
 OK    [2/8]  1521.200 ms D:/vtl/build_test.v
 OK    [3/8]  1520.991 ms D:/vtl/split_test.v
 OK    [4/8]  1520.876 ms D:/vtl/stats/stats_test.v
 OK    [5/8]  1521.441 ms D:/vtl/broadcast_test.v
 OK    [6/8]  1521.204 ms D:/vtl/stack_test.v
 OK    [7/8]  1529.970 ms D:/vtl/fun_test.v
 OK    [8/8]   344.837 ms D:/vtl/storage/storage_test.v
------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 8 passed, 8 total. Runtime: 1867 ms, on 7 parallel jobs.
```