### PR TITLE
checker, cgen: fix for_in_mut iterator val (fix #12530)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2183,7 +2183,7 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 		val := if node.val_var in ['', '_'] { g.new_tmp_var() } else { node.val_var }
 		val_styp := g.typ(node.val_type)
 		if node.val_is_mut {
-			g.writeln('\t$val_styp* $val = ($val_styp*)${t_var}.data;')
+			g.writeln('\t$val_styp $val = ($val_styp)${t_var}.data;')
 		} else {
 			g.writeln('\t$val_styp $val = *($val_styp*)${t_var}.data;')
 		}

--- a/vlib/v/tests/for_in_mut_iterator_val_test.v
+++ b/vlib/v/tests/for_in_mut_iterator_val_test.v
@@ -1,0 +1,50 @@
+const (
+	packets = {
+		0: &Packet{
+			pid: 2
+		}
+		1: &Packet{
+			pid: 1
+		}
+	}
+)
+
+struct Packet {
+	pid        int
+	handle     fn () string
+	restricted bool
+}
+
+struct Reader {
+	foo int
+	bar string
+mut:
+	index int
+}
+
+fn (mut p Reader) next() ?&Packet {
+	if p.index + 1 > packets.len {
+		return error('')
+	}
+	if p.index !in packets {
+		return error('')
+	}
+
+	p.index++
+	return packets[p.index - 1]
+}
+
+fn test_for_in_mut_interator_val() {
+	r := Reader{}
+	mut rets := []string{}
+
+	for mut packet in r {
+		println(packet.pid)
+		rets << '$packet.pid'
+	}
+
+	println(rets)
+	assert rets.len == 2
+	assert rets[0] == '2'
+	assert rets[1] == '1'
+}


### PR DESCRIPTION
This PR fix for_in_mut iterator val (fix #12530).

- Fix for_in_mut iterator val.
- Add test.

```vlang
const (
	packets = {
		0: &Packet{
			pid: 2
		}
		1: &Packet{
			pid: 1
		}
	}
)

struct Packet {
	pid        int
	handle     fn () string
	restricted bool
}

struct Reader {
	foo int
	bar string
mut:
	index int
}

fn (mut p Reader) next() ?&Packet {
	if p.index + 1 > packets.len {
		return error('')
	}
	if p.index !in packets {
		return error('')
	}

	p.index++
	return packets[p.index - 1]
}

fn main() {
	r := Reader{}
	mut rets := []string{}

	for mut packet in r {
		println(packet.pid)
		rets << '$packet.pid'
	}

	println(rets)
	assert rets.len == 2
	assert rets[0] == '2'
	assert rets[1] == '1'
}

PS D:\Test\v\tt1> v run .
2
1
['2', '1']
```