### PR TITLE
Fix typo in vscode documentation

### DIFF
--- a/doc/vscode.md
+++ b/doc/vscode.md
@@ -88,7 +88,7 @@ or create the file `.vscode/launch.json`:
 **Optional:** use `"program": "${fileDirname}/${fileBasenameNoExtension}"` to debug 
 any current open source file with an existing binary with the same name but without any extension.
 
-#### Step2: Configure the task.json file
+#### Step2: Configure the tasks.json file
 Generally, you can manually compile the application with: `v -b c -g hello.v -o hello`,
 or for short: `v -g hello.v`, and then call the debugger.
 
@@ -102,7 +102,7 @@ a task before the start of a debug session, set this attribute to the label of a
 in [task.json](https://code.visualstudio.com/docs/editor/tasks) (in the workspace's .vscode folder).
 Or, this can be set to `${defaultBuildTask}`, to use your default build task.
 
-As explained, the `"preLaunchTask": "build"` needs to work with a `.vscode/task.json`
+As explained, the `"preLaunchTask": "build"` needs to work with a `.vscode/tasks.json`
 with a label named `build`. 
 ```json
 {


### PR DESCRIPTION
The task configuration file is tasks.json not task.json



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
