### PR TITLE
toml: clean up and improve spaced and dotted key parsing

### DIFF
--- a/vlib/toml/tests/spaced_keys_test.v
+++ b/vlib/toml/tests/spaced_keys_test.v
@@ -1,0 +1,26 @@
+import toml
+
+fn test_spaced_keys() {
+	str_value := 'V rocks!'
+
+	toml_txt := '
+	  "o"   .   	pq  .  r     =    "Yuk"
+
+[[ a . "b.c" ]]
+	d . e = "V rocks!"
+
+[ tube . test . "test.test" ]
+	 h  .	"i.j."  .   "k"  =   	 "Cryptic"
+'
+	toml_doc := toml.parse(toml_txt) or { panic(err) }
+	mut value := toml_doc.value('a."b.c"[0].d.e')
+	assert value == toml.Any(str_value)
+	assert value as string == str_value
+	assert value.string() == str_value
+
+	value = toml_doc.value('"o".pq.r')
+	assert value.string() == 'Yuk'
+
+	value = toml_doc.value('tube.test."test.test".h."i.j."."k"')
+	assert value.string() == 'Cryptic'
+}

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -180,7 +180,6 @@ pub fn (d Doc) to_any() Any {
 // Arrays can be queried with `a[0].b[1].[2]`.
 pub fn (d Doc) value(key string) Any {
 	key_split := parse_dotted_key(key) or { return Any(Null{}) }
-	println('XXX -> $key_split')
 	return d.value_(d.ast.table, key_split)
 }
 
@@ -191,7 +190,6 @@ fn (d Doc) value_(value ast.Value, key []string) Any {
 	k, index := parse_array_key(key[0])
 
 	if k == '' {
-		println('YYY ${key[0]} / $key')
 		a := value as []ast.Value
 		ast_value = a[index] or { return Any(Null{}) }
 	}

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -134,7 +134,10 @@ pub fn parse_dotted_key(key string) ?[]string {
 		buf += ch.ascii_str()
 		if !in_string && ch == `.` {
 			if buf != '' && buf != ' ' {
-				out << buf[..buf.len - 1]
+				buf = buf[..buf.len - 1]
+				if buf != '' && buf != ' ' {
+					out << buf
+				}
 			}
 			buf = ''
 			continue
@@ -177,6 +180,7 @@ pub fn (d Doc) to_any() Any {
 // Arrays can be queried with `a[0].b[1].[2]`.
 pub fn (d Doc) value(key string) Any {
 	key_split := parse_dotted_key(key) or { return Any(Null{}) }
+	println('XXX -> $key_split')
 	return d.value_(d.ast.table, key_split)
 }
 
@@ -187,6 +191,7 @@ fn (d Doc) value_(value ast.Value, key []string) Any {
 	k, index := parse_array_key(key[0])
 
 	if k == '' {
+		println('YYY ${key[0]} / $key')
 		a := value as []ast.Value
 		ast_value = a[index] or { return Any(Null{}) }
 	}


### PR DESCRIPTION
This PR encapsulates the parsing of dotted keys - which is then reused across the parser.
Now spaced keys works everywhere, even in (ugly, but valid) TOML like this:
```toml
"o"   .   	pq  .  r     =    "Yuk"

[[ a . "b.c" ]]
	d . e = "V rocks!"

[ tube . test . "test.test" ]
	 h  .	"i.j."  .   "k"  =   	 "Cryptic"
```
