### PR TITLE
checker, cgen: fix fn type call of match expr (fix #12543)

### DIFF
--- a/vlib/v/tests/fn_type_call_of_match_expr_test.v
+++ b/vlib/v/tests/fn_type_call_of_match_expr_test.v
@@ -1,0 +1,29 @@
+type FnZ = fn () string
+
+type FnO = fn (int) string
+
+type FnQ = FnO | FnZ
+
+fn fnz_z() string {
+	return 'Got zero'
+}
+
+fn fnz_o(one int) string {
+	return 'Got one $one'
+}
+
+fn test_fn_type_call_of_match_expr() {
+	mut arr := [FnQ(FnZ(fnz_z)), FnQ(FnO(fnz_o))]
+	for item in arr {
+		match item {
+			FnZ {
+				println(item())
+				assert item() == 'Got zero'
+			}
+			FnO {
+				println(item(42))
+				assert item(42) == 'Got one 42'
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR fix fn type call of match expr (fix #12543).

- Fix fn type call of match expr.
- Add test.

```vlang
type FnZ = fn () string

type FnO = fn (int) string

type FnQ = FnO | FnZ

fn fnz_z() string {
	return 'Got zero'
}

fn fnz_o(one int) string {
	return 'Got one $one'
}

fn main() {
	mut arr := [FnQ(FnZ(fnz_z)), FnQ(FnO(fnz_o))]
	for item in arr {
		match item {
			FnZ {
				println(item())
				assert item() == 'Got zero'
			}
			FnO {
				println(item(42))
				assert item(42) == 'Got one 42'
			}
		}
	}
}

PS D:\Test\v\tt1> v run .
Got zero
Got one 42
```