### PR TITLE
toml: improve parsing of bare keys to include `-` and `_`

### DIFF
--- a/vlib/toml/tests/iarna.toml-spec-tests_test.v
+++ b/vlib/toml/tests/iarna.toml-spec-tests_test.v
@@ -15,7 +15,6 @@ const (
 
 	// Kept for easier handling of future updates to the tests
 	valid_exceptions       = [
-		'values/spec-key-value-pair-8.toml',
 		'values/spec-float-3.toml',
 		'values/spec-float-10.toml',
 		'values/spec-float-11.toml',
@@ -23,7 +22,6 @@ const (
 		'values/spec-float-13.toml',
 		'values/spec-float-14.toml',
 		'values/spec-float-15.toml',
-		'values/spec-key-value-pair-6.toml',
 	]
 	invalid_exceptions     = [
 		'errors/table-3.toml',


### PR DESCRIPTION
This PR fixes parsing of bare keys with `-` and `_` - allowing:

```toml
-_-_-_-_-=1
```