### PR TITLE
toml: fix float checker bug for `-0.01`

### DIFF
--- a/vlib/toml/checker/checker.v
+++ b/vlib/toml/checker/checker.v
@@ -118,8 +118,7 @@ fn (c Checker) check_number(num ast.Number) ? {
 			return error(@MOD + '.' + @STRUCT + '.' + @FN +
 				' numbers like "$lit" (hex, octal and binary) can not start with `$ascii` in ...${c.excerpt(num.pos)}...')
 		}
-		// is_first_digit = byte(lit_sans_sign[0]).is_digit()
-		if lit.len > 1 && lit_sans_sign.starts_with('0') {
+		if lit.len > 1 && lit_sans_sign.starts_with('0') && !lit_sans_sign.starts_with('0.') {
 			ascii = byte(lit_sans_sign[0]).ascii_str()
 			return error(@MOD + '.' + @STRUCT + '.' + @FN +
 				' numbers like "$lit" can not start with `$ascii` in ...${c.excerpt(num.pos)}...')

--- a/vlib/toml/tests/iarna.toml-spec-tests_test.v
+++ b/vlib/toml/tests/iarna.toml-spec-tests_test.v
@@ -15,7 +15,6 @@ const (
 
 	// Kept for easier handling of future updates to the tests
 	valid_exceptions       = [
-		'values/spec-float-3.toml',
 		'values/spec-float-10.toml',
 		'values/spec-float-11.toml',
 		'values/spec-float-12.toml',


### PR DESCRIPTION
Small fix for wrongly checked float values < 1