### PR TITLE
toml: fix date-time and time ms test inconsistency

### DIFF
--- a/vlib/toml/tests/iarna.toml-spec-tests_test.v
+++ b/vlib/toml/tests/iarna.toml-spec-tests_test.v
@@ -188,8 +188,8 @@ fn test_iarna_toml_spec_tests() {
 // to_iarna_time
 fn to_iarna_time(time_str string) string {
 	if time_str.contains('.') {
-		date_and_time := json_text.all_before('.')
-		mut ms := json_text.all_after('.')
+		date_and_time := time_str.all_before('.')
+		mut ms := time_str.all_after('.')
 		z := if ms.contains('Z') { 'Z' } else { '' }
 		ms = ms.replace('Z', '')
 		if ms.len > 3 {


### PR DESCRIPTION
This PR fixes a small inconsistency between the iarna and BurntSushi test suites.
It seems like iarna is using 3 digit millisecond endings (which might be the sanest) but Burntsushi test expects 6 digits endings.
I *think* the format is implementation specific - since RFC 3339 allows for both versions of the endings.

For now I've chosen to keep the 6 digits since it'll take way more changes to fix all the tests to expect 3.