### PR TITLE
checker: add a warning if start value is higher than end value

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6365,6 +6365,9 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 						&& (cond_type_sym.is_int() || cond_type_sym.info is ast.Enum) {
 						low = low_expr.val.i64()
 						high = high_expr.val.i64()
+						if low > high {
+							c.warn('start value is higher than end value', branch.pos)
+						}
 					} else {
 						c.error('mismatched range types', low_expr.pos)
 					}
@@ -6372,6 +6375,9 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 					if high_expr is ast.CharLiteral && cond_type_sym.kind in [.byte, .char, .rune] {
 						low = low_expr.val[0]
 						high = high_expr.val[0]
+						if low > high {
+							c.warn('start value is higher than end value', branch.pos)
+						}
 					} else {
 						c.error('mismatched range types', low_expr.pos)
 					}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6366,7 +6366,7 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 						low = low_expr.val.i64()
 						high = high_expr.val.i64()
 						if low > high {
-							c.warn('start value is higher than end value', branch.pos)
+							c.error('start value is higher than end value', branch.pos)
 						}
 					} else {
 						c.error('mismatched range types', low_expr.pos)
@@ -6376,7 +6376,7 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 						low = low_expr.val[0]
 						high = high_expr.val[0]
 						if low > high {
-							c.warn('start value is higher than end value', branch.pos)
+							c.error('start value is higher than end value', branch.pos)
 						}
 					} else {
 						c.error('mismatched range types', low_expr.pos)

--- a/vlib/v/checker/tests/match_expr_range_low_higher_than_high.out
+++ b/vlib/v/checker/tests/match_expr_range_low_higher_than_high.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/match_expr_range_low_higher_than_high.vv:5:3: error: start value is higher than end value
+    3 |     value := 10
+    4 |     match value {
+    5 |         20...10 {}
+      |         ~~~~~~~
+    6 |         else {}
+    7 |     }

--- a/vlib/v/checker/tests/match_expr_range_low_higher_than_high.vv
+++ b/vlib/v/checker/tests/match_expr_range_low_higher_than_high.vv
@@ -1,0 +1,8 @@
+
+fn main() {
+	value := 10
+	match value {
+		20...10 {}
+		else {}
+	}
+}


### PR DESCRIPTION
```v
fn main() {
    value := 10
    match value {
        20...10 {}  // wont match anything
    }
}
```

Fixes #12601.