### PR TITLE
vlib/crypto/blowfish: add doc blowfish

### DIFF
--- a/vlib/crypto/blowfish/block.v
+++ b/vlib/crypto/blowfish/block.v
@@ -1,6 +1,6 @@
 module blowfish
 
-// expand_key performs a key expansion on the given Blowfish.
+// expand_key performs a key expansion on the given Blowfish cipher.
 pub fn expand_key(key []byte, mut bf Blowfish) {
 	mut j := 0
 	for i := 0; i < 18; i++ {
@@ -18,29 +18,29 @@ pub fn expand_key(key []byte, mut bf Blowfish) {
 	mut l := u32(0)
 	mut r := u32(0)
 	for i := 0; i < 18; i += 2 {
-		arr := encrypt_block(l, r, mut bf)
+		arr := setup_tables(l, r, mut bf)
 		bf.p[i], bf.p[i + 1] = arr[0], arr[1]
 	}
 
 	for i := 0; i < 256; i += 2 {
-		arr := encrypt_block(l, r, mut bf)
+		arr := setup_tables(l, r, mut bf)
 		bf.s[0][i], bf.s[0][i + 1] = arr[0], arr[1]
 	}
 	for i := 0; i < 256; i += 2 {
-		arr := encrypt_block(l, r, mut bf)
+		arr := setup_tables(l, r, mut bf)
 		bf.s[1][i], bf.s[1][i + 1] = arr[0], arr[1]
 	}
 	for i := 0; i < 256; i += 2 {
-		arr := encrypt_block(l, r, mut bf)
+		arr := setup_tables(l, r, mut bf)
 		bf.s[2][i], bf.s[2][i + 1] = arr[0], arr[1]
 	}
 	for i := 0; i < 256; i += 2 {
-		arr := encrypt_block(l, r, mut bf)
+		arr := setup_tables(l, r, mut bf)
 		bf.s[3][i], bf.s[3][i + 1] = arr[0], arr[1]
 	}
 }
 
-// expand_key_with_salt folds the salt during the key schedule.
+// expand_key_with_salt using salt to expand the key.
 pub fn expand_key_with_salt(key []byte, salt []byte, mut bf Blowfish) {
 	mut j := 0
 	for i := 0; i < 18; i++ {
@@ -54,38 +54,38 @@ pub fn expand_key_with_salt(key []byte, salt []byte, mut bf Blowfish) {
 	for i := 0; i < 18; i += 2 {
 		l ^= get_next_word(key, &j)
 		r ^= get_next_word(key, &j)
-		arr := encrypt_block(l, r, mut bf)
+		arr := setup_tables(l, r, mut bf)
 		bf.p[i], bf.p[i + 1] = arr[0], arr[1]
 	}
 
 	for i := 0; i < 256; i += 2 {
 		l ^= get_next_word(key, &j)
 		r ^= get_next_word(key, &j)
-		arr := encrypt_block(l, r, mut bf)
+		arr := setup_tables(l, r, mut bf)
 		bf.s[0][i], bf.s[0][i + 1] = arr[0], arr[1]
 	}
 	for i := 0; i < 256; i += 2 {
 		l ^= get_next_word(key, &j)
 		r ^= get_next_word(key, &j)
-		arr := encrypt_block(l, r, mut bf)
+		arr := setup_tables(l, r, mut bf)
 		bf.s[1][i], bf.s[1][i + 1] = arr[0], arr[1]
 	}
 	for i := 0; i < 256; i += 2 {
 		l ^= get_next_word(key, &j)
 		r ^= get_next_word(key, &j)
-		arr := encrypt_block(l, r, mut bf)
+		arr := setup_tables(l, r, mut bf)
 		bf.s[2][i], bf.s[2][i + 1] = arr[0], arr[1]
 	}
 	for i := 0; i < 256; i += 2 {
 		l ^= get_next_word(key, &j)
 		r ^= get_next_word(key, &j)
-		arr := encrypt_block(l, r, mut bf)
+		arr := setup_tables(l, r, mut bf)
 		bf.s[3][i], bf.s[3][i + 1] = arr[0], arr[1]
 	}
 }
 
-// encrypt_block sets up the Blowfish's pi and substitution tables.
-fn encrypt_block(l u32, r u32, mut bf Blowfish) []u32 {
+// setup_tables sets up the Blowfish cipher's pi and substitution tables.
+fn setup_tables(l u32, r u32, mut bf Blowfish) []u32 {
 	mut xl := l
 	mut xr := r
 	xl ^= bf.p[0]
@@ -126,7 +126,7 @@ fn encrypt_block(l u32, r u32, mut bf Blowfish) []u32 {
 	return res
 }
 
-// get_next_word returns the next big-endian uint32 value from the byte
+// get_next_word returns the next big-endian u32 value from the byte
 // slice at the given position in a circular manner, updating the position.
 fn get_next_word(b []byte, pos &int) u32 {
 	mut w := u32(0)

--- a/vlib/crypto/blowfish/block.v
+++ b/vlib/crypto/blowfish/block.v
@@ -1,5 +1,6 @@
 module blowfish
 
+// expand_key performs a key expansion on the given Blowfish.
 pub fn expand_key(key []byte, mut bf Blowfish) {
 	mut j := 0
 	for i := 0; i < 18; i++ {
@@ -39,6 +40,7 @@ pub fn expand_key(key []byte, mut bf Blowfish) {
 	}
 }
 
+// expand_key_with_salt folds the salt during the key schedule.
 pub fn expand_key_with_salt(key []byte, salt []byte, mut bf Blowfish) {
 	mut j := 0
 	for i := 0; i < 18; i++ {
@@ -82,6 +84,7 @@ pub fn expand_key_with_salt(key []byte, salt []byte, mut bf Blowfish) {
 	}
 }
 
+// encrypt_block sets up the Blowfish's pi and substitution tables.
 fn encrypt_block(l u32, r u32, mut bf Blowfish) []u32 {
 	mut xl := l
 	mut xr := r
@@ -123,6 +126,8 @@ fn encrypt_block(l u32, r u32, mut bf Blowfish) []u32 {
 	return res
 }
 
+// get_next_word returns the next big-endian uint32 value from the byte
+// slice at the given position in a circular manner, updating the position.
 fn get_next_word(b []byte, pos &int) u32 {
 	mut w := u32(0)
 	mut j := 0

--- a/vlib/crypto/blowfish/blowfish.v
+++ b/vlib/crypto/blowfish/blowfish.v
@@ -6,7 +6,7 @@ pub mut:
 	s [4][256]u32
 }
 
-// new_cipher creates and returns a Blowfish.
+// new_cipher creates and returns a new Blowfish cipher.
 // The key argument should be the Blowfish key, from 1 to 56 bytes.
 pub fn new_cipher(key []byte) ?Blowfish {
 	mut bf := Blowfish{}
@@ -20,7 +20,7 @@ pub fn new_cipher(key []byte) ?Blowfish {
 	return bf
 }
 
-// new_salted_cipher creates a returns a Blowfish that folds a salt into its key schedule.
+// new_salted_cipher returns a new Blowfish cipher that folds a salt into its key schedule.
 pub fn new_salted_cipher(key []byte, salt []byte) ?Blowfish {
 	if salt.len == 0 {
 		return new_cipher(key)
@@ -39,7 +39,7 @@ pub fn new_salted_cipher(key []byte, salt []byte) ?Blowfish {
 pub fn (mut bf Blowfish) encrypt(mut dst []byte, src []byte) {
 	l := u32(src[0]) << 24 | u32(src[1]) << 16 | u32(src[2]) << 8 | u32(src[3])
 	r := u32(src[4]) << 24 | u32(src[5]) << 16 | u32(src[6]) << 8 | u32(src[7])
-	arr := encrypt_block(l, r, mut bf)
+	arr := setup_tables(l, r, mut bf)
 	dst[0], dst[1], dst[2], dst[3] = byte(arr[0] >> 24), byte(arr[0] >> 16), byte(arr[0] >> 8), byte(arr[0])
 	dst[4], dst[5], dst[6], dst[7] = byte(arr[1] >> 24), byte(arr[1] >> 16), byte(arr[1] >> 8), byte(arr[1])
 }

--- a/vlib/crypto/blowfish/blowfish.v
+++ b/vlib/crypto/blowfish/blowfish.v
@@ -6,6 +6,8 @@ pub mut:
 	s [4][256]u32
 }
 
+// new_cipher creates and returns a Blowfish.
+// The key argument should be the Blowfish key, from 1 to 56 bytes.
 pub fn new_cipher(key []byte) ?Blowfish {
 	mut bf := Blowfish{}
 	unsafe { vmemcpy(&bf.p[0], &p[0], int(sizeof(bf.p))) }
@@ -18,6 +20,7 @@ pub fn new_cipher(key []byte) ?Blowfish {
 	return bf
 }
 
+// new_salted_cipher creates a returns a Blowfish that folds a salt into its key schedule.
 pub fn new_salted_cipher(key []byte, salt []byte) ?Blowfish {
 	if salt.len == 0 {
 		return new_cipher(key)
@@ -32,6 +35,7 @@ pub fn new_salted_cipher(key []byte, salt []byte) ?Blowfish {
 	return bf
 }
 
+// encrypt encrypts the 8-byte buffer src using the key k and stores the result in dst.
 pub fn (mut bf Blowfish) encrypt(mut dst []byte, src []byte) {
 	l := u32(src[0]) << 24 | u32(src[1]) << 16 | u32(src[2]) << 8 | u32(src[3])
 	r := u32(src[4]) << 24 | u32(src[5]) << 16 | u32(src[6]) << 8 | u32(src[7])


### PR DESCRIPTION
add doc blowfish.

```
⫸ v run ./cmd/tools/missdoc.v vlib/crypto/blowfish
/Users/Taillook/project/prjtail/v/vlib/crypto/blowfish/block.v:3:0:pub fn expand_key(key []byte, mut bf Blowfish) 
/Users/Taillook/project/prjtail/v/vlib/crypto/blowfish/block.v:42:0:pub fn expand_key_with_salt(key []byte, salt []byte, mut bf Blowfish) 
/Users/Taillook/project/prjtail/v/vlib/crypto/blowfish/block.v:85:0:fn encrypt_block(l u32, r u32, mut bf Blowfish) []u32 
/Users/Taillook/project/prjtail/v/vlib/crypto/blowfish/block.v:126:0:fn get_next_word(b []byte, pos &int) u32 
/Users/Taillook/project/prjtail/v/vlib/crypto/blowfish/blowfish.v:9:0:pub fn new_cipher(key []byte) ?Blowfish 
/Users/Taillook/project/prjtail/v/vlib/crypto/blowfish/blowfish.v:21:0:pub fn new_salted_cipher(key []byte, salt []byte) ?Blowfish 
/Users/Taillook/project/prjtail/v/vlib/crypto/blowfish/blowfish.v:35:0:pub fn (mut bf Blowfish) encrypt(mut dst []byte, src []byte)
```

to

```
⫸ v run ./cmd/tools/missdoc.v vlib/crypto/blowfish
⫸
```
