### PR TITLE
toml: check for mutation of immutable inline tables

### DIFF
--- a/vlib/toml/tests/iarna.toml-spec-tests_test.v
+++ b/vlib/toml/tests/iarna.toml-spec-tests_test.v
@@ -18,7 +18,6 @@ const (
 		'errors/table-3.toml',
 		'errors/table-4.toml',
 		'errors/table-invalid-4.toml',
-		'errors/inline-table-imutable-1.toml',
 	]
 
 	valid_value_exceptions = []string{}


### PR DESCRIPTION
This PR will check for the following condition:
```toml
[product]
type = { name = "Nail" }
type.edible = false  # This is invalid since `type` has been explicitly declared as an inline table (which are immutable)
```
