### PR TITLE
toml: add more checks for table redeclarations

### DIFF
--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -271,6 +271,12 @@ fn (p Parser) build_abs_dotted_key(key DottedKey) DottedKey {
 	return key
 }
 
+// todo_msvc_astring2dkey worksaround a MSVC compile error.
+// TODO remove.
+fn todo_msvc_astring2dkey(s []string) DottedKey {
+	return s
+}
+
 // check_explicitly_declared returns an error if `key` has been explicitly declared.
 fn (p Parser) check_explicitly_declared(key DottedKey) ? {
 	if p.explicit_declared.len > 0 && p.explicit_declared.has(key) {
@@ -506,7 +512,7 @@ pub fn (mut p Parser) root_table() ? {
 					// Register implicit declaration
 					mut dotted_key_copy := dotted_key.clone()
 					dotted_key_copy.pop()
-					implicit_keys := DottedKey(dotted_key_copy)
+					implicit_keys := todo_msvc_astring2dkey(dotted_key_copy)
 					mut abs_dotted_key := p.build_abs_dotted_key(implicit_keys)
 					if !p.implicit_declared.has(abs_dotted_key) {
 						p.implicit_declared << abs_dotted_key

--- a/vlib/toml/tests/iarna.toml-spec-tests_test.v
+++ b/vlib/toml/tests/iarna.toml-spec-tests_test.v
@@ -14,11 +14,7 @@ const (
 
 	// Kept for easier handling of future updates to the tests
 	valid_exceptions       = []string{}
-	invalid_exceptions     = [
-		'errors/table-3.toml',
-		'errors/table-4.toml',
-		'errors/table-invalid-4.toml',
-	]
+	invalid_exceptions     = []string{}
 
 	valid_value_exceptions = []string{}
 


### PR DESCRIPTION
This PR adds a few more checks for (sub)table redefining.

It also squashes the last exceptions. Further value test passing of the remaining iarna tests will require a YAML parser or some sort of YAML -> JSON conversion tool. But until that it looks like we pass, what is regarded as, the official TOML test suite(s).

:partying_face: 