### PR TITLE
parser: Forbid empty match statements 'match cond.op {else {}}'

### DIFF
--- a/vlib/v/checker/tests/return_missing_match_simple.out
+++ b/vlib/v/checker/tests/return_missing_match_simple.out
@@ -1,12 +1,7 @@
-vlib/v/checker/tests/return_missing_match_simple.vv:4:3: warning: `match` must have at least one non `else` branch
+vlib/v/checker/tests/return_missing_match_simple.vv:4:3: error: `match` must have at least one non `else` branch
     2 |     a := 1
     3 |     match a {
     4 |         else { println('abc') }
       |         ~~~~
     5 |     }
     6 |     println('hello')
-vlib/v/checker/tests/return_missing_match_simple.vv:1:1: error: missing return at end of function `h`
-    1 | fn h() int {
-      | ~~~~~~~~~~
-    2 |     a := 1
-    3 |     match a {

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -250,7 +250,7 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 			scope: branch_scope
 		}
 		if is_else && branches.len == 1 {
-			p.warn_with_pos('`match` must have at least one non `else` branch', pos)
+			p.error_with_pos('`match` must have at least one non `else` branch', pos)
 		}
 		if p.tok.kind == .rcbr || (is_else && no_lcbr) {
 			break


### PR DESCRIPTION
An extra brace is added in the c output when `match a{else{}}` is found, but the parser just shows a warning. imho it should be an error.

<img width="1031" alt="Screenshot 2021-11-30 at 01 03 45" src="https://user-images.githubusercontent.com/6431515/143961830-dd1e34f7-ba86-496d-9249-7081d14f3aa5.png">
Fixes this cgen problem. as long as those constructions shouldnt be valid (imho) there's no need to fix the cgen side (or it dies?)

```
$ cat a.v
fn main() {
	a := 0
	match a {
	else {
}
	}
}

$ v run a.v
a.v:4:2: warning: `match` must have at least one non `else` branch
    2 |     a := 0
    3 |     match a {
    4 |     else {
      |     ~~~~
    5 | }
    6 |     }
==================
/tmp/v_501/a.15883627273481714965.tmp.c:10601:1: error: extraneous closing brace ('}')
}
^
1 error generated.
...
==================
(Use `v -cg` to print the entire error message)

builder error:
==================
C error. This should never happen.

This is a compiler bug, please report it using `v bug file.v`.

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

$
```