### PR TITLE
cgen: fix error of the interface str method (fix #12538)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7295,13 +7295,13 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 			if g.pref.build_mode != .build_module {
 				methods_struct.writeln('\t{')
 			}
-			if st == ast.voidptr_type {
-				for mname, _ in methodidx {
-					if g.pref.build_mode != .build_module {
-						methods_struct.writeln('\t\t._method_${c_name(mname)} = (void*) 0,')
-					}
-				}
-			}
+			// if st == ast.voidptr_type {
+			// 	for mname, _ in methodidx {
+			// 		if g.pref.build_mode != .build_module {
+			// 			methods_struct.writeln('\t\t._method_${c_name(mname)} = (void*) 0,')
+			// 		}
+			// 	}
+			// }
 			mut methods := st_sym.methods
 			match st_sym.info {
 				ast.Struct, ast.Interface, ast.SumType {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7295,13 +7295,13 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 			if g.pref.build_mode != .build_module {
 				methods_struct.writeln('\t{')
 			}
-			// if st == ast.voidptr_type {
-			// 	for mname, _ in methodidx {
-			// 		if g.pref.build_mode != .build_module {
-			// 			methods_struct.writeln('\t\t._method_${c_name(mname)} = (void*) 0,')
-			// 		}
-			// 	}
-			// }
+			if st == ast.voidptr_type {
+				for mname, _ in methodidx {
+					if g.pref.build_mode != .build_module {
+						methods_struct.writeln('\t\t._method_${c_name(mname)} = (void*) 0,')
+					}
+				}
+			}
 			mut methods := st_sym.methods
 			match st_sym.info {
 				ast.Struct, ast.Interface, ast.SumType {
@@ -7367,7 +7367,7 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 					// .speak = Cat_speak_Interface_Animal_method_wrapper
 					method_call += iwpostfix
 				}
-				if g.pref.build_mode != .build_module {
+				if g.pref.build_mode != .build_module && st != ast.voidptr_type {
 					methods_struct.writeln('\t\t._method_${c_name(method.name)} = (void*) $method_call,')
 				}
 			}

--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -125,6 +125,7 @@ fn (mut g Gen) str_val(node ast.StringInterLiteral, i int) {
 	expr := node.exprs[i]
 
 	typ := g.unwrap_generic(node.expr_types[i])
+	typ_sym := g.table.get_type_symbol(typ)
 	if typ == ast.string_type {
 		if g.inside_vweb_tmpl {
 			g.write('vweb__filter(')
@@ -139,6 +140,15 @@ fn (mut g Gen) str_val(node ast.StringInterLiteral, i int) {
 			}
 			g.expr(expr)
 		}
+	} else if typ_sym.kind == .interface_ && (typ_sym.info as ast.Interface).defines_method('str') {
+		rec_type_name := util.no_dots(g.cc_type(typ, false))
+		g.write('${c_name(rec_type_name)}_name_table[')
+		g.expr(expr)
+		dot := if typ.is_ptr() { '->' } else { '.' }
+		g.write('${dot}_typ]._method_str(')
+		g.expr(expr)
+		g.write('${dot}_object')
+		g.write(')')
 	} else if node.fmts[i] == `s` || typ.has_flag(.variadic) {
 		mut exp_typ := typ
 		if expr is ast.Ident && g.comptime_var_type_map.len > 0 {

--- a/vlib/v/tests/interface_str_method_test.v
+++ b/vlib/v/tests/interface_str_method_test.v
@@ -1,0 +1,20 @@
+interface Str {
+	str() string
+}
+
+struct St {}
+
+fn (s St) str() string {
+	return 's'
+}
+
+fn printer(s Str) string {
+	println(s)
+	return '$s'
+}
+
+fn test_interface_str_method() {
+	s := St{}
+	ret := printer(s)
+	assert ret == 's'
+}


### PR DESCRIPTION
This PR fix error of the interface str method (fix #12538).

- Fix interface str method error.
- Add test.

```vlang
interface Str {
	str() string
}

struct St {}

fn (s St) str() string {
	return 's'
}

fn printer(s Str) string {
	println(s)
	return '$s'
}

fn main() {
	s := St{}
	ret := printer(s)
	assert ret == 's'
}

PS D:\Test\v\tt1> v run .
s
```