### PR TITLE
toml: simplify bool keys in scanner and parser

### DIFF
--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -463,7 +463,7 @@ pub fn (mut p Parser) root_table() ? {
 				util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'skipping formatting "$p.tok.kind" "$p.tok.lit"')
 				continue
 			}
-			.bare, .quoted, .boolean, .number, .minus, .underscore { // NOTE .boolean allows for use of "true" and "false" as table keys
+			.bare, .quoted, .number, .minus, .underscore {
 				// Peek forward as far as we can skipping over space formatting tokens.
 				peek_tok, _ := p.peek_over(1, parser.keys_and_space_formatting) ?
 
@@ -652,7 +652,7 @@ pub fn (mut p Parser) table_contents(mut tbl map[string]ast.Value) ? {
 				util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'skipping formatting "$p.tok.kind" "$p.tok.lit"')
 				continue
 			}
-			.bare, .quoted, .boolean, .number, .minus, .underscore { // NOTE .boolean allows for use of "true" and "false" as table keys
+			.bare, .quoted, .number, .minus, .underscore {
 				// Peek forward as far as we can skipping over space formatting tokens.
 				peek_tok, _ := p.peek_over(1, parser.keys_and_space_formatting) ?
 
@@ -735,7 +735,7 @@ pub fn (mut p Parser) inline_table(mut tbl map[string]ast.Value) ? {
 				// '}' bracket
 				return
 			}
-			.bare, .quoted, .boolean, .number, .minus, .underscore {
+			.bare, .quoted, .number, .minus, .underscore {
 				// Peek forward as far as we can skipping over space formatting tokens.
 				peek_tok, _ := p.peek_over(1, parser.space_formatting) ?
 
@@ -836,7 +836,7 @@ pub fn (mut p Parser) array_of_tables_contents() ?[]ast.Value {
 		util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'parsing token "$p.tok.kind"')
 
 		match p.tok.kind {
-			.bare, .quoted, .boolean, .number, .minus, .underscore {
+			.bare, .quoted, .number, .minus, .underscore {
 				// Peek forward as far as we can skipping over space formatting tokens.
 				peek_tok, _ := p.peek_over(1, parser.space_formatting) ?
 
@@ -972,7 +972,7 @@ pub fn (mut p Parser) double_array_of_tables_contents(target_key DottedKey) ?[]a
 		}
 
 		match p.tok.kind {
-			.bare, .quoted, .boolean, .number, .minus, .underscore {
+			.bare, .quoted, .number, .minus, .underscore {
 				// Peek forward as far as we can skipping over space formatting tokens.
 				peek_tok, _ = p.peek_over(1, parser.space_formatting) ?
 

--- a/vlib/toml/scanner/scanner.v
+++ b/vlib/toml/scanner/scanner.v
@@ -125,8 +125,7 @@ pub fn (mut s Scanner) scan() ?token.Token {
 
 		if util.is_key_char(byte_c) {
 			key := s.extract_key()
-			key_lower_case := key.to_lower()
-			if key_lower_case == 'true' || key_lower_case == 'false' {
+			if !s.is_left_of_assign && (key == 'true' || key == 'false') {
 				util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'identified a boolean "$key" ($key.len)')
 				return s.new_token(.boolean, key, key.len)
 			}


### PR DESCRIPTION
This PR simplifies the scanner and parser in regards to keys that looks like booleans by having the scanner identifying them as boolean *only* when they're values.
```toml
true = true
false = false
```