### PR TITLE
checker: fix map init with enum keys (fix #12636)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7710,6 +7710,7 @@ pub fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 				continue
 			}
 			val := node.vals[i]
+			c.expected_type = key0_type
 			key_type := c.expr(key)
 			c.expected_type = val0_type
 			val_type := c.expr(val)

--- a/vlib/v/tests/map_init_with_enum_keys_test.v
+++ b/vlib/v/tests/map_init_with_enum_keys_test.v
@@ -1,0 +1,20 @@
+enum En {
+	ea
+	eb
+}
+
+struct St {
+mut:
+	m map[En]string
+}
+
+fn test_map_init_with_enum_keys() {
+	mut st := St{}
+
+	st.m = {
+		.ea: 'a'
+	}
+
+	println(st.m)
+	assert '$st.m' == "{ea: 'a'}"
+}


### PR DESCRIPTION
This PR fix map init with enum keys (fix #12636).

- Fix map init with enum keys.
- Add test.

```vlang
enum En {
	ea
	eb
}

struct St {
mut:
	m map[En]string
}

fn main() {
	mut st := St{}

	st.m = {
		.ea: 'a'
	}

	println(st.m)
	assert '$st.m' == "{ea: 'a'}"
}

PS D:\Test\v\tt1> v run .
{ea: 'a'}
```