### PR TITLE
js: add missing start_digraph() for the js backend

### DIFF
--- a/vlib/v/dotgraph/dotgraph.js.v
+++ b/vlib/v/dotgraph/dotgraph.js.v
@@ -1,0 +1,6 @@
+module dotgraph
+
+pub fn start_digraph() {
+	println('digraph G {')
+	#JS.process.on('exit', fn () { println('}') })
+}


### PR DESCRIPTION
Found this while trying to compile V itself into js `v -b js cmd/v`. There still some more things to fix to get it ready, but at least that's one step closer