### PR TITLE
toml: add better float validation

### DIFF
--- a/vlib/toml/checker/checker.v
+++ b/vlib/toml/checker/checker.v
@@ -210,6 +210,14 @@ fn (c Checker) check_number(num ast.Number) ? {
 			return error(@MOD + '.' + @STRUCT + '.' + @FN +
 				' numbers like "$lit" (float) can not have decimal points on either side of the exponent notation in ...${c.excerpt(num.pos)}...')
 		}
+		// Check if it contains other chars than the allowed
+		for r in lit {
+			if r !in [`0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, `.`, `e`, `E`, `-`, `+`,
+				`_`] {
+				return error(@MOD + '.' + @STRUCT + '.' + @FN +
+					' numbers like "$lit" (float) can not contain `${byte(r).ascii_str()}` in ...${c.excerpt(num.pos)}...')
+			}
+		}
 	} else {
 		if lit.len > 1 && lit.starts_with('0') && lit[1] !in [`b`, `o`, `x`] {
 			ascii = byte(lit[0]).ascii_str()

--- a/vlib/toml/tests/alexcrichton.toml-rs-tests_test.v
+++ b/vlib/toml/tests/alexcrichton.toml-rs-tests_test.v
@@ -2,6 +2,7 @@ import os
 import toml
 import toml.ast
 import x.json2
+import strconv
 
 // Instructions for developers:
 // The actual tests and data can be obtained by doing:
@@ -17,15 +18,12 @@ const (
 	]
 	invalid_exceptions     = [
 		'invalid/string-bad-line-ending-escape.toml',
-		'invalid/float-no-suffix.toml',
 	]
 
 	valid_value_exceptions = [
 		'valid/unicode-escape.toml',
 		// These have correct values, and should've passed, but the format of arrays is *mixed* in the JSON ??
 		'valid/example2.toml',
-		// Float
-		'valid/float-exponent.toml',
 	]
 
 	// These have correct values, and should've passed as-is, but the format of arrays changes in the JSON ??
@@ -259,14 +257,17 @@ fn to_alexcrichton(value ast.Value, array_type int) string {
 			return '{ "type": "null", "value": "$json_text" }'
 		}
 		ast.Number {
-			if value.text.contains('inf') || value.text.contains('nan') {
+			text := value.text
+			if text.contains('inf') || text.contains('nan') {
 				return '{ "type": "float", "value": "$value.text" }'
 			}
-			if !value.text.starts_with('0x')
-				&& (value.text.contains('.') || value.text.to_lower().contains('e')) {
-				mut val := '$value.f64()'.replace('.e+', '.0e') // json notation
-				if !val.contains('.') && val != '0' { // json notation
-					val += '.0'
+			if !text.starts_with('0x') && (text.contains('.') || text.to_lower().contains('e')) {
+				mut val := ''
+				if text.to_lower().contains('e') && !text.contains('-') {
+					f64val := value.f64()
+					val = strconv.v_sprintf('%.1f', f64val)
+				} else {
+					val = '$value.f64()'
 				}
 				return '{ "type": "float", "value": "$val" }'
 			}

--- a/vlib/toml/tests/alexcrichton.toml-rs-tests_test.v
+++ b/vlib/toml/tests/alexcrichton.toml-rs-tests_test.v
@@ -2,7 +2,6 @@ import os
 import toml
 import toml.ast
 import x.json2
-import strconv
 
 // Instructions for developers:
 // The actual tests and data can be obtained by doing:
@@ -264,8 +263,7 @@ fn to_alexcrichton(value ast.Value, array_type int) string {
 			if !text.starts_with('0x') && (text.contains('.') || text.to_lower().contains('e')) {
 				mut val := ''
 				if text.to_lower().contains('e') && !text.contains('-') {
-					f64val := value.f64()
-					val = strconv.v_sprintf('%.1f', f64val)
+					val = '${value.f64():.1f}'
 				} else {
 					val = '$value.f64()'
 				}


### PR DESCRIPTION
This PR will disallow "floats" like these:
```toml
val0 = 1.2f
val1 = 1.2g
val2 = 1.2abc
```