### PR TITLE
toml: support multi-level map keys in arrays-of-tables

### DIFF
--- a/vlib/toml/tests/alexcrichton.toml-rs-tests_test.v
+++ b/vlib/toml/tests/alexcrichton.toml-rs-tests_test.v
@@ -13,7 +13,6 @@ const (
 		'valid/example-v0.3.0.toml',
 		'valid/example-v0.4.0.toml',
 		'valid/datetime-truncate.toml', // Not considered valid since RFC 3339 doesn't permit > 6 ms digits ??
-		'valid/table-array-nest-no-keys.toml',
 	]
 	invalid_exceptions     = [
 		'invalid/string-bad-line-ending-escape.toml',
@@ -35,6 +34,7 @@ const (
 		'valid/table-array-many.toml',
 		'valid/table-array-one.toml',
 		'valid/table-array-nest.toml',
+		'valid/table-array-nest-no-keys.toml',
 	]
 
 	jq                     = os.find_abs_path_of_executable('jq') or { '' }

--- a/vlib/toml/tests/array_of_tables_edge_case_2_test.v
+++ b/vlib/toml/tests/array_of_tables_edge_case_2_test.v
@@ -1,0 +1,18 @@
+import os
+import toml
+import toml.to
+
+fn test_array_of_tables_edge_case_file() {
+	toml_file :=
+		os.real_path(os.join_path(os.dir(@FILE), 'testdata', os.file_name(@FILE).all_before_last('.'))) +
+		'.toml'
+	toml_doc := toml.parse(toml_file) or { panic(err) }
+
+	toml_json := to.json(toml_doc)
+	out_file :=
+		os.real_path(os.join_path(os.dir(@FILE), 'testdata', os.file_name(@FILE).all_before_last('.'))) +
+		'.out'
+	out_file_json := os.read_file(out_file) or { panic(err) }
+	println(toml_json)
+	assert toml_json == out_file_json
+}

--- a/vlib/toml/tests/testdata/array_of_tables_edge_case_2_test.out
+++ b/vlib/toml/tests/testdata/array_of_tables_edge_case_2_test.out
@@ -1,0 +1,1 @@
+{ "albums": [ { "songs": [ { }, { } ] } ], "artists": [ { "home": { "address": { } } } ] }

--- a/vlib/toml/tests/testdata/array_of_tables_edge_case_2_test.toml
+++ b/vlib/toml/tests/testdata/array_of_tables_edge_case_2_test.toml
@@ -1,0 +1,6 @@
+[[ albums ]]
+  [[ albums.songs ]]
+  [[ albums.songs ]]
+
+[[ artists ]]
+  [ artists.home.address ]


### PR DESCRIPTION
Improve support for this syntax:
```toml
[[ albums ]] # <- This PR fixes parsing the whitespace on each side of the key here
  [[ albums.songs ]] # <- ... and here.
  [[ albums.songs ]] # <- Current implementation allows for 2 levels only

[[ artists ]]
  [ artists.home.address ] # <- This will work after this PR - where key nesting level is > 2
```