### PR TITLE
toml: solidify "multi to single"-line escape validation

### DIFF
--- a/vlib/toml/tests/alexcrichton.toml-rs-tests_test.v
+++ b/vlib/toml/tests/alexcrichton.toml-rs-tests_test.v
@@ -15,9 +15,7 @@ const (
 		'valid/datetime-truncate.toml', // Not considered valid since RFC 3339 doesn't permit > 6 ms digits ??
 		'valid/table-array-nest-no-keys.toml',
 	]
-	invalid_exceptions     = [
-		'invalid/string-bad-line-ending-escape.toml',
-	]
+	invalid_exceptions     = []string{}
 
 	valid_value_exceptions = [
 		'valid/unicode-escape.toml',


### PR DESCRIPTION
TOML allows for escaping multi-line strings to be decoded as a single line:
```toml
equivalent_one = "The quick brown fox jumps over the lazy dog."
equivalent_two = """
The quick brown \


  fox jumps over \
    the lazy dog."""

equivalent_three = """\
       The quick brown \
       fox jumps over \
       the lazy dog.\
       """

whitespace-after-bs = """\
       The quick brown \
       fox jumps over \   
       the lazy dog.\	
       """
```
The above variables should all have the value `The quick brown fox jumps over the lazy dog.`

This has worked so far but this PR will solidify the validation process and fix an edge case that slipped through before:
```toml
bug = """
Hello \     a # <- ouch this should have failed - but it didn't   
      World
"""
```