### PR TITLE
checker, cgen: fix match expr returning optional with error (fix #12556)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6231,14 +6231,14 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 					}
 					expr_type := c.expr(stmt.expr)
 					if first_iteration {
-						if node.is_expr && !node.expected_type.has_flag(.optional)
-							&& c.table.get_type_symbol(node.expected_type).kind == .sum_type {
+						if node.is_expr && (node.expected_type.has_flag(.optional)
+							|| c.table.type_kind(node.expected_type) == .sum_type) {
 							ret_type = node.expected_type
 						} else {
 							ret_type = expr_type
 						}
 						stmt.typ = expr_type
-					} else if node.is_expr && ret_type != expr_type {
+					} else if node.is_expr && ret_type.idx() != expr_type.idx() {
 						if !c.check_types(ret_type, expr_type)
 							&& !c.check_types(expr_type, ret_type) {
 							ret_sym := c.table.get_type_symbol(ret_type)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4423,6 +4423,10 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 		g.inside_ternary++
 	}
 	if is_expr && node.return_type.has_flag(.optional) {
+		old := g.inside_match_optional
+		defer {
+			g.inside_match_optional = old
+		}
 		g.inside_match_optional = true
 	}
 	if node.cond in [ast.Ident, ast.SelectorExpr, ast.IntegerLiteral, ast.StringLiteral,
@@ -4469,9 +4473,6 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 	if is_expr && !need_tmp_var {
 		g.write(')')
 		g.decrement_inside_ternary()
-	}
-	if is_expr && node.return_type.has_flag(.optional) {
-		g.inside_match_optional = false
 	}
 }
 

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -104,6 +104,7 @@ mut:
 	inside_map_index       bool
 	inside_opt_data        bool
 	inside_if_optional     bool
+	inside_match_optional  bool
 	loop_depth             int
 	ternary_names          map[string]string
 	ternary_level_names    map[string][]string
@@ -1372,7 +1373,7 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) {
 	for i, stmt in stmts {
 		if i == stmts.len - 1 && tmp_var != '' {
 			// Handle if expressions, set the value of the last expression to the temp var.
-			if g.inside_if_optional {
+			if g.inside_if_optional || g.inside_match_optional {
 				g.set_current_pos_as_last_stmt_pos()
 				g.skip_stmt_pos = true
 				if stmt is ast.ExprStmt {
@@ -1412,7 +1413,7 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) {
 			}
 		} else {
 			g.stmt(stmt)
-			if g.inside_if_optional && stmt is ast.ExprStmt {
+			if (g.inside_if_optional || g.inside_match_optional) && stmt is ast.ExprStmt {
 				g.writeln(';')
 			}
 		}
@@ -1624,8 +1625,8 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 			// if af {
 			// g.autofree_call_postgen()
 			// }
-			if g.inside_ternary == 0 && !g.inside_if_optional && !node.is_expr
-				&& node.expr !is ast.IfExpr {
+			if g.inside_ternary == 0 && !g.inside_if_optional && !g.inside_match_optional
+				&& !node.is_expr && node.expr !is ast.IfExpr {
 				g.writeln(';')
 			}
 		}
@@ -4377,6 +4378,9 @@ fn (mut g Gen) need_tmp_var_in_match(node ast.MatchExpr) bool {
 		if g.table.type_kind(node.return_type) == .sum_type {
 			return true
 		}
+		if node.return_type.has_flag(.optional) {
+			return true
+		}
 		if sym.kind == .multi_return {
 			return false
 		}
@@ -4417,6 +4421,9 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 	mut cur_line := ''
 	if is_expr && !need_tmp_var {
 		g.inside_ternary++
+	}
+	if is_expr && node.return_type.has_flag(.optional) {
+		g.inside_match_optional = true
 	}
 	if node.cond in [ast.Ident, ast.SelectorExpr, ast.IntegerLiteral, ast.StringLiteral,
 		ast.FloatLiteral] {
@@ -4462,6 +4469,9 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 	if is_expr && !need_tmp_var {
 		g.write(')')
 		g.decrement_inside_ternary()
+	}
+	if is_expr && node.return_type.has_flag(.optional) {
+		g.inside_match_optional = false
 	}
 }
 

--- a/vlib/v/tests/match_expr_returning_optional_test.v
+++ b/vlib/v/tests/match_expr_returning_optional_test.v
@@ -34,3 +34,17 @@ fn test_match_expr_returning_optional() {
 	println(ret2)
 	assert ret2 == Any(1)
 }
+
+fn func() ?string {
+	code := 0
+	return match code {
+		0 { 'zero' }
+		else { error('as we are returning an optional') }
+	}
+}
+
+fn test_match_expr_returning_optional_with_error() {
+	ret := func() or { 'error' }
+	println(ret)
+	assert ret == 'zero'
+}


### PR DESCRIPTION
This PR fix match expr returning optional with error (fix #12556).

- Fix match expr returning optional with error.
- Add test.

```vlang
fn func() ?string {
	code := 0
	return match code {
		0 { 'zero' }
		else { error('as we are returning an optional') }
	}
}

fn main() {
	ret := func() or { 'error' }
	println(ret)
	assert ret == 'zero'
}

PS D:\Test\v\tt1> v run .
zero
```