### PR TITLE
cgen: fix generic fn with anon fn in body (fix #12639)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -217,7 +217,9 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 	}
 	mut type_name := g.typ(node.return_type)
 
-	name = g.generic_fn_name(g.cur_concrete_types, name, true)
+	if node.generic_names.len > 0 {
+		name = g.generic_fn_name(g.cur_concrete_types, name, true)
+	}
 
 	if g.pref.translated && node.attrs.contains('c') {
 		// This fixes unknown symbols errors when building separate .c => .v files

--- a/vlib/v/tests/generic_fn_with_anon_fn_test.v
+++ b/vlib/v/tests/generic_fn_with_anon_fn_test.v
@@ -1,0 +1,11 @@
+fn foo<T>() string {
+	x := fn () string {
+		return 'ok'
+	}
+	return x()
+}
+
+fn test_generic_fn_with_anon_fn() {
+	ret := foo<int>()
+	assert ret == 'ok'
+}


### PR DESCRIPTION
This PR fix generic fn with anon fn in body (fix #12639).

- Fix generic fn with anon fn in body.
- Add test.

```vlang
fn foo<T>() string {
	x := fn () string {
		return 'ok'
	}
	return x()
}

fn main() {
	ret := foo<int>()
	assert ret == 'ok'
}

PS D:\Test\v\tt1> v run .
```