### PR TITLE
net: properly convert IP address C strings to V strings

### DIFF
--- a/vlib/net/address.v
+++ b/vlib/net/address.v
@@ -66,30 +66,30 @@ const (
 )
 
 fn (a Ip) str() string {
-	buf := []byte{len: net.max_ip_len, init: 0}
+	buf := [net.max_ip_len]char{}
 
-	res := &char(C.inet_ntop(.ip, &a.addr, buf.data, buf.len))
+	res := &char(C.inet_ntop(.ip, &a.addr, &buf[0], buf.len))
 
 	if res == 0 {
 		return '<Unknown>'
 	}
 
-	saddr := unsafe { (&byte(buf.data)).vstring() }
+	saddr := unsafe { cstring_to_vstring(&buf[0]) }
 	port := C.ntohs(a.port)
 
 	return '$saddr:$port'
 }
 
 fn (a Ip6) str() string {
-	buf := []byte{len: net.max_ip6_len, init: 0}
+	buf := [net.max_ip_len]char{}
 
-	res := &char(C.inet_ntop(.ip6, &a.addr, buf.data, buf.len))
+	res := &char(C.inet_ntop(.ip6, &a.addr, &buf[0], buf.len))
 
 	if res == 0 {
 		return '<Unknown>'
 	}
 
-	saddr := unsafe { (&byte(buf.data)).vstring() }
+	saddr := unsafe { cstring_to_vstring(&buf[0]) }
 	port := C.ntohs(a.port)
 
 	return '[$saddr]:$port'

--- a/vlib/net/address.v
+++ b/vlib/net/address.v
@@ -74,7 +74,7 @@ fn (a Ip) str() string {
 		return '<Unknown>'
 	}
 
-	saddr := buf.bytestr()
+	saddr := unsafe { (&byte(buf.data)).vstring() }
 	port := C.ntohs(a.port)
 
 	return '$saddr:$port'
@@ -89,7 +89,7 @@ fn (a Ip6) str() string {
 		return '<Unknown>'
 	}
 
-	saddr := buf.bytestr()
+	saddr := unsafe { (&byte(buf.data)).vstring() }
 	port := C.ntohs(a.port)
 
 	return '[$saddr]:$port'

--- a/vlib/net/address_test.v
+++ b/vlib/net/address_test.v
@@ -96,3 +96,17 @@ fn test_sizes_ipv4() {
 fn test_sizes_unix() {
 	assert sizeof(C.sockaddr_un) == sizeof(Unix) + aoffset
 }
+
+fn test_ip_str() {
+	ip := new_ip(1337, addr_ip_any).str()
+	expected := '0.0.0.0:1337'
+	assert ip.len == expected.len
+	assert ip == expected
+}
+
+fn test_ip6_str() {
+	ip := new_ip6(1337, addr_ip6_any).str()
+	expected := '[::]:1337'
+	assert ip.len == expected.len
+	assert ip == expected
+}


### PR DESCRIPTION
Fixes #12578

Another option is to use `tos2` instead of `vstring`, I'm not sure which is preferred.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
