### PR TITLE
cgen: fix match sumtype print var aggregate error  (fix #12651)

### DIFF
--- a/vlib/v/tests/match_sumtype_var_aggregate_print_var_test.v
+++ b/vlib/v/tests/match_sumtype_var_aggregate_print_var_test.v
@@ -1,0 +1,13 @@
+type Bug = i64 | u64
+
+fn test_match_sumtype_var_aggregate_print_var() {
+	f := Bug(i64(-17))
+	ret := match f {
+		u64, i64 {
+			println(f)
+			println(f.str())
+			f.str()
+		}
+	}
+	assert ret == '-17'
+}


### PR DESCRIPTION
This PR fix match sumtype print var aggregate error  (fix #12651).

- Fix match sumtype print var aggregate error.
- Add test.

```vlang
type Bug = i64 | u64

fn main() {
	f := Bug(i64(-17))
	ret := match f {
		u64, i64 {
			println(f)
			println(f.str())
			f.str()
		}
	}
	assert ret == '-17'
}

PS D:\Test\v\tt1> v run .
-17
-17
```