### PR TITLE
strconv: fix bitwise format with ~ operator with -ve sign

### DIFF
--- a/vlib/builtin/string_interpolation.v
+++ b/vlib/builtin/string_interpolation.v
@@ -239,15 +239,16 @@ fn (data StrIntpData) get_fmt_format(mut sb strings.Builder) {
 			} else if typ == .si_i32 {
 				d = i64(data.d.d_i32)
 			}
-			if d < 0 {
-				bf.positive = false
-			}
+
 			if base == 0 {
 				if width == 0 {
 					d_str := d.str()
 					sb.write_string(d_str)
 					d_str.free()
 					return
+				}
+				if d < 0 {
+					bf.positive = false
 				}
 				strconv.format_dec_sb(abs64(d), bf, mut sb)
 			} else {
@@ -264,6 +265,12 @@ fn (data StrIntpData) get_fmt_format(mut sb strings.Builder) {
 				if width == 0 {
 					sb.write_string(hx)
 				} else {
+					if d < 0 {
+						bf.positive = false
+						tmp := hx
+						hx = hx.replace('-', '')
+						tmp.free()
+					}
 					strconv.format_str_sb(hx, bf, mut sb)
 				}
 				hx.free()

--- a/vlib/builtin/string_interpolation.v
+++ b/vlib/builtin/string_interpolation.v
@@ -239,16 +239,15 @@ fn (data StrIntpData) get_fmt_format(mut sb strings.Builder) {
 			} else if typ == .si_i32 {
 				d = i64(data.d.d_i32)
 			}
-
+			if d < 0 {
+				bf.positive = false
+			}
 			if base == 0 {
 				if width == 0 {
 					d_str := d.str()
 					sb.write_string(d_str)
 					d_str.free()
 					return
-				}
-				if d < 0 {
-					bf.positive = false
 				}
 				strconv.format_dec_sb(abs64(d), bf, mut sb)
 			} else {

--- a/vlib/strconv/format_mem.c.v
+++ b/vlib/strconv/format_mem.c.v
@@ -27,7 +27,6 @@ pub fn format_str_sb(s string, p BF_param, mut sb strings.Builder) {
 				sb.write_b(`+`)
 			}
 		} else {
-			s.replace('-', '')
 			sb.write_b(`-`)
 		}
 		for i1 := 0; i1 < dif; i1++ {

--- a/vlib/strconv/format_mem.c.v
+++ b/vlib/strconv/format_mem.c.v
@@ -22,6 +22,14 @@ pub fn format_str_sb(s string, p BF_param, mut sb strings.Builder) {
 	}
 
 	if p.allign == .right {
+		if p.positive {
+			if p.sign_flag {
+				sb.write_b(`+`)
+			}
+		} else {
+			s.replace('-','')
+			sb.write_b(`-`)
+		}
 		for i1 := 0; i1 < dif; i1++ {
 			sb.write_b(p.pad_ch)
 		}

--- a/vlib/strconv/format_mem.c.v
+++ b/vlib/strconv/format_mem.c.v
@@ -27,7 +27,7 @@ pub fn format_str_sb(s string, p BF_param, mut sb strings.Builder) {
 				sb.write_b(`+`)
 			}
 		} else {
-			s.replace('-','')
+			s.replace('-', '')
 			sb.write_b(`-`)
 		}
 		for i1 := 0; i1 < dif; i1++ {

--- a/vlib/strconv/format_test.v
+++ b/vlib/strconv/format_test.v
@@ -107,4 +107,7 @@ fn test_format() {
 		x++
 		cnt++
 	}
+
+	bin0 := ~6
+	assert '${bin0:08b}' == '-00000111'
 }


### PR DESCRIPTION

This is to fix https://github.com/vlang/v/issues/12665.
Details below:
I see formatting problem with bitwise ~ operator when there is a -ve sign.

<!-- It is advisable to update all relevant modules using `v outdated` and `v install` -->
**V doctor:**
```
OS: windows, Microsoft Windows 10 Enterprise v17763 64-bit
Processor: 8 cpus, 64bit, little endian, Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz
CC version: Error: exec failed (CreateProcess) with code 2: The system cannot find the file specified.

 cmd: cc --version

getwd: C:\sources\vv
vmodules: C:\Users\navulep\.vmodules
vroot: C:\v
vexe: C:\v\v.exe
vexe mtime: 2021-12-03 07:22:53
is vroot writable: true
is vmodules writable: true
V full version: V 0.2.4 be5446b

Git version: git version 2.33.0.windows.2
Git vroot status: weekly.2021.48-4-gbe5446bf
.git/config present: true
thirdparty/tcc status: thirdparty-windows-amd64 0f5168cd
```

**What did you do?**
`v -g -o vdbg cmd/v && vdbg bitbet.v`
```v
a := 6
println(~a) // -7
println("${~a:b}") // -111
println("${a:08b}") // 00000110
println("${~a:08b}") // 0000-111 <-- wrongly formatted

```

**What did you expect to see?**

```
-00000111
```

**What did you see instead?**
```
0000-111
```