### PR TITLE
ast, checker, cgen: fix nested struct embed error (fix #12659)

### DIFF
--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -1345,7 +1345,7 @@ fn (t Tree) selector_expr(node ast.SelectorExpr) &Node {
 	obj.add('typ', t.type_node(node.typ))
 	obj.add('name_type', t.type_node(node.name_type))
 	obj.add('gkind_field', t.enum_node(node.gkind_field))
-	obj.add('from_embed_types', t.type_node(node.from_embed_types))
+	obj.add('from_embed_types', t.array_node_type(node.from_embed_types))
 	obj.add('next_token', t.token_node(node.next_token))
 	obj.add('pos', t.position(node.pos))
 	obj.add('scope', t.number_node(int(node.scope)))

--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -1345,7 +1345,7 @@ fn (t Tree) selector_expr(node ast.SelectorExpr) &Node {
 	obj.add('typ', t.type_node(node.typ))
 	obj.add('name_type', t.type_node(node.name_type))
 	obj.add('gkind_field', t.enum_node(node.gkind_field))
-	obj.add('from_embed_type', t.type_node(node.from_embed_type))
+	obj.add('from_embed_types', t.type_node(node.from_embed_types))
 	obj.add('next_token', t.token_node(node.next_token))
 	obj.add('pos', t.position(node.pos))
 	obj.add('scope', t.number_node(int(node.scope)))

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -223,13 +223,13 @@ pub:
 	mut_pos    token.Position
 	next_token token.Kind
 pub mut:
-	expr            Expr // expr.field_name
-	expr_type       Type // type of `Foo` in `Foo.bar`
-	typ             Type // type of the entire thing (`Foo.bar`)
-	name_type       Type // T in `T.name` or typeof in `typeof(expr).name`
-	gkind_field     GenericKindField // `T.name` => ast.GenericKindField.name, `T.typ` => ast.GenericKindField.typ, or .unknown
-	scope           &Scope
-	from_embed_type Type // holds the type of the embed that the method is called from
+	expr             Expr // expr.field_name
+	expr_type        Type // type of `Foo` in `Foo.bar`
+	typ              Type // type of the entire thing (`Foo.bar`)
+	name_type        Type // T in `T.name` or typeof in `typeof(expr).name`
+	gkind_field      GenericKindField // `T.name` => ast.GenericKindField.name, `T.typ` => ast.GenericKindField.typ, or .unknown
+	scope            &Scope
+	from_embed_types []Type // holds the type of the embed that the method is called from
 }
 
 // root_ident returns the origin ident where the selector started.

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3460,15 +3460,15 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 		} else {
 			// look for embedded field
 			has_field = true
-			mut embed_type := ast.Type(0)
-			field, embed_type = c.table.find_field_from_embeds(sym, field_name) or {
+			mut embed_types := []ast.Type{}
+			field, embed_types = c.table.find_field_from_embeds_recursive(sym, field_name) or {
 				if err.msg != '' {
 					c.error(err.msg, node.pos)
 				}
 				has_field = false
-				ast.StructField{}, ast.Type(0)
+				ast.StructField{}, []ast.Type{}
 			}
-			node.from_embed_type = embed_type
+			node.from_embed_types = embed_types
 			if sym.kind in [.aggregate, .sum_type] {
 				unknown_field_msg = err.msg
 			}
@@ -3489,15 +3489,15 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 			} else {
 				// look for embedded field
 				has_field = true
-				mut embed_type := ast.Type(0)
-				field, embed_type = c.table.find_field_from_embeds(gs, field_name) or {
+				mut embed_types := []ast.Type{}
+				field, embed_types = c.table.find_field_from_embeds_recursive(gs, field_name) or {
 					if err.msg != '' {
 						c.error(err.msg, node.pos)
 					}
 					has_field = false
-					ast.StructField{}, ast.Type(0)
+					ast.StructField{}, []ast.Type{}
 				}
-				node.from_embed_type = embed_type
+				node.from_embed_types = embed_types
 			}
 		}
 	}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4226,8 +4226,8 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	}
 	// struct embedding
 	if sym.info in [ast.Struct, ast.Aggregate] {
-		if node.from_embed_type != 0 {
-			embed_sym := g.table.get_type_symbol(node.from_embed_type)
+		for embed in node.from_embed_types {
+			embed_sym := g.table.get_type_symbol(embed)
 			embed_name := embed_sym.embed_name()
 			if node.expr_type.is_ptr() {
 				g.write('->')
@@ -4237,7 +4237,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 			g.write(embed_name)
 		}
 	}
-	if (node.expr_type.is_ptr() || sym.kind == .chan) && node.from_embed_type == 0 {
+	if (node.expr_type.is_ptr() || sym.kind == .chan) && node.from_embed_types.len == 0 {
 		g.write('->')
 	} else {
 		// g.write('. /*typ=  $it.expr_type */') // ${g.typ(it.expr_type)} /')

--- a/vlib/v/tests/nested_struct_embed_test.v
+++ b/vlib/v/tests/nested_struct_embed_test.v
@@ -1,0 +1,20 @@
+struct Foo {
+mut:
+	x int
+}
+
+struct Bar {
+	Foo
+}
+
+struct Baz {
+	Bar
+}
+
+fn test_nested_struct_embed() {
+	mut baz := Baz{}
+	baz.x = 3
+
+	println(baz.x)
+	assert baz.x == 3
+}


### PR DESCRIPTION
This PR fix nested struct embed error (fix #12659).

- Fix nested struct embed error.
- Add test.

```vlang
struct Foo {
mut:
	x int
}

struct Bar {
	Foo
}

struct Baz {
	Bar
}

fn test_nested_struct_embed() {
	mut baz := Baz{}
	baz.x = 3

	println(baz.x)
	assert baz.x == 3
}

PS D:\Test\v\tt1> v run .
3
```