### PR TITLE
net.websocket: Fix server not listening for IPv4

### DIFF
--- a/vlib/net/address.v
+++ b/vlib/net/address.v
@@ -164,12 +164,14 @@ pub fn resolve_ipaddrs(addr string, family AddrFamily, typ SocketType) ?[]Addr {
 	address, port := split_address(addr) ?
 
 	if addr[0] == `:` {
-		if family == .ip6 {
-			// Use in6addr_any
-			return [new_ip6(port, net.addr_ip6_any)]
-		}
-		if family == .ip {
-			return [new_ip(port, net.addr_ip_any)]
+		match family {
+			.ip6 {
+				return [new_ip6(port, net.addr_ip6_any)]
+			}
+			.ip, .unspec {
+				return [new_ip(port, net.addr_ip_any)]
+			}
+			else {}
 		}
 	}
 

--- a/vlib/net/address.v
+++ b/vlib/net/address.v
@@ -207,7 +207,18 @@ pub fn resolve_ipaddrs(addr string, family AddrFamily, typ SocketType) ?[]Addr {
 
 	for result := results; !isnil(result); result = result.ai_next {
 		match AddrFamily(result.ai_family) {
-			.ip, .ip6 {
+			.ip {
+				new_addr := Addr{
+					addr: AddrData{
+						Ip: Ip{}
+					}
+				}
+				unsafe {
+					C.memcpy(&new_addr, result.ai_addr, result.ai_addrlen)
+				}
+				addresses << new_addr
+			}
+			.ip6 {
 				new_addr := Addr{
 					addr: AddrData{
 						Ip6: Ip6{}

--- a/vlib/net/address.v
+++ b/vlib/net/address.v
@@ -164,8 +164,13 @@ pub fn resolve_ipaddrs(addr string, family AddrFamily, typ SocketType) ?[]Addr {
 	address, port := split_address(addr) ?
 
 	if addr[0] == `:` {
-		// Use in6addr_any
-		return [new_ip6(port, net.addr_ip6_any)]
+		if family == .ip6 {
+			// Use in6addr_any
+			return [new_ip6(port, net.addr_ip6_any)]
+		}
+		if family == .ip {
+			return [new_ip(port, net.addr_ip_any)]
+		}
 	}
 
 	mut hints := C.addrinfo{

--- a/vlib/net/udp.v
+++ b/vlib/net/udp.v
@@ -230,17 +230,23 @@ fn new_udp_socket(local_addr Addr) ?&UdpSocket {
 
 fn new_udp_socket_for_remote(raddr Addr) ?&UdpSocket {
 	// Invent a sutible local address for this remote addr
-	addr := match raddr.family() {
+	// Appease compiler
+	mut addr := Addr{
+		addr: AddrData{
+			Ip6: Ip6{}
+		}
+	}
+	match raddr.family() {
 		.ip {
 			// Use ip dualstack
-			new_ip(0, addr_ip_any)
+			addr = new_ip(0, addr_ip_any)
 		}
 		.ip6 {
 			// Use ip6 dualstack
-			new_ip6(0, addr_ip6_any)
+			addr = new_ip6(0, addr_ip6_any)
 		}
 		.unix {
-			temp_unix() ?
+			addr = temp_unix() ?
 		}
 		else {
 			panic('Invalid family')

--- a/vlib/net/udp.v
+++ b/vlib/net/udp.v
@@ -230,19 +230,17 @@ fn new_udp_socket(local_addr Addr) ?&UdpSocket {
 
 fn new_udp_socket_for_remote(raddr Addr) ?&UdpSocket {
 	// Invent a sutible local address for this remote addr
-	// Appease compiler
-	mut addr := Addr{
-		addr: AddrData{
-			Ip6: Ip6{}
+	addr := match raddr.family() {
+		.ip {
+			// Use ip dualstack
+			new_ip(0, addr_ip_any)
 		}
-	}
-	match raddr.family() {
-		.ip, .ip6 {
+		.ip6 {
 			// Use ip6 dualstack
-			addr = new_ip6(0, addr_ip6_any)
+			new_ip6(0, addr_ip6_any)
 		}
 		.unix {
-			addr = temp_unix() ?
+			temp_unix() ?
 		}
 		else {
 			panic('Invalid family')

--- a/vlib/net/udp_test.v
+++ b/vlib/net/udp_test.v
@@ -15,21 +15,20 @@ fn echo_server(mut c net.UdpConn) {
 }
 
 const (
-	local_addr  = ':40003'
-	remote_addr = 'localhost:40003'
+	server_addr = '127.0.0.1:40003'
 )
 
 fn echo() ? {
-	mut c := net.dial_udp(remote_addr) ?
+	mut c := net.dial_udp(server_addr) or { panic('could not net.dial_udp: $err') }
 	defer {
 		c.close() or {}
 	}
 	data := 'Hello from vlib/net!'
 
-	c.write_string(data) ?
+	c.write_string(data) or { panic('could not write_string: $err') }
 
 	mut buf := []byte{len: 100, init: 0}
-	read, addr := c.read(mut buf) ?
+	read, addr := c.read(mut buf) or { panic('could not read: $err') }
 
 	assert read == data.len
 	println('Got address $addr')
@@ -47,17 +46,10 @@ fn echo() ? {
 }
 
 fn test_udp() {
-	mut l := net.listen_udp(local_addr) or {
-		println(err)
-		assert false
-		panic('')
-	}
+	mut l := net.listen_udp(server_addr) or { panic('could not listen_udp: $err') }
 
 	go echo_server(mut l)
-	echo() or {
-		println(err)
-		assert false
-	}
+	echo() or { panic('could not echo: $err') }
 
 	l.close() or {}
 }

--- a/vlib/net/websocket/websocket_test.v
+++ b/vlib/net/websocket/websocket_test.v
@@ -4,11 +4,6 @@ import net.websocket
 import time
 import rand
 
-// TODO: fix connecting to ipv4 websockets
-// (the server seems to work with .ip, but
-// Client can not connect, it needs to be passed
-// .ip too?)
-
 struct WebsocketTestResults {
 pub mut:
 	nr_messages      int

--- a/vlib/net/websocket/websocket_test.v
+++ b/vlib/net/websocket/websocket_test.v
@@ -34,8 +34,7 @@ fn test_ws_ipv6() {
 
 // tests with internal ws servers
 fn test_ws_ipv4() {
-	// TODO: fix client
-	if true || should_skip {
+	if should_skip {
 		return
 	}
 	port := 30000 + rand.intn(1024)
@@ -68,7 +67,7 @@ fn start_server(family net.AddrFamily, listen_port int) ? {
 	s.on_close(fn (mut ws websocket.Client, code int, reason string) ? {
 		// not used
 	})
-	s.listen() or {}
+	s.listen() or { panic('websocket server could not listen') }
 }
 
 // ws_test tests connect to the websocket server from websocket client


### PR DESCRIPTION
The websocket client tests were being skipped for IPv4, with a comment saying "fix client". This was a little misleading, because it wasn't actually the websocket client that was broken, but the server.

The problem was that an IPv6 address was being returned, even though an IPv4 address was being requested.

After changing that, I ran into problems with `udp_test.v` running on Windows (failed in CI), so I added more code to address that.