### PR TITLE
examples: use `fontstash` wrapper calls

### DIFF
--- a/examples/gg/raven_text_rendering.v
+++ b/examples/gg/raven_text_rendering.v
@@ -75,7 +75,7 @@ fn main() {
 		width: win_width
 		height: win_height
 		create_window: true
-		window_title: 'Empty window'
+		window_title: 'Raven text'
 		user_data: app
 		bg_color: bg_color
 		frame_fn: frame

--- a/examples/sokol/fonts.v
+++ b/examples/sokol/fonts.v
@@ -51,7 +51,7 @@ fn init(mut state AppState) {
 		'RobotoMono-Regular.ttf')))
 	{
 		println('loaded font: $bytes.len')
-		state.font_normal = state.fons.add_font_mem(c'sans', bytes.data, bytes.len, false)
+		state.font_normal = state.fons.add_font_mem('sans', bytes, false)
 	}
 }
 
@@ -92,22 +92,21 @@ fn (state &AppState) render_font() {
 	dx = sx
 	dy += lh
 	fons.set_color(white)
-	dx = fons.draw_text(dx, dy, c'The quick ', &char(0))
+	dx = fons.draw_text(dx, dy, 'The quick ')
 	fons.set_font(state.font_normal)
 	fons.set_size(48.0)
 	fons.set_color(brown)
-	dx = fons.draw_text(dx, dy, c'brown ', &char(0))
+	dx = fons.draw_text(dx, dy, 'brown ')
 	fons.set_font(state.font_normal)
 	fons.set_size(24.0)
 	fons.set_color(white)
-	dx = fons.draw_text(dx, dy, c'fox ', &char(0))
+	dx = fons.draw_text(dx, dy, 'fox ')
 	dx = sx
 	dy += lh * 1.2
 	fons.set_size(20.0)
 	fons.set_font(state.font_normal)
 	fons.set_color(blue)
-	fons.draw_text(dx, dy, c'Now is the time for all good men to come to the aid of the party.',
-		&char(0))
+	fons.draw_text(dx, dy, 'Now is the time for all good men to come to the aid of the party.')
 	dx = 300
 	dy = 350
 	fons.set_align(C.FONS_ALIGN_LEFT | C.FONS_ALIGN_BASELINE)
@@ -116,7 +115,7 @@ fn (state &AppState) render_font() {
 	fons.set_color(white)
 	fons.set_spacing(5.0)
 	fons.set_blur(6.0)
-	fons.draw_text(dx, dy, c'Blurry...', &char(0))
+	fons.draw_text(dx, dy, 'Blurry...')
 	dx = 300
 	dy += 50.0
 	fons.set_size(28.0)
@@ -124,10 +123,10 @@ fn (state &AppState) render_font() {
 	fons.set_color(white)
 	fons.set_spacing(0.0)
 	fons.set_blur(3.0)
-	fons.draw_text(dx, dy + 2, c'DROP SHADOW', &char(0))
+	fons.draw_text(dx, dy + 2, 'DROP SHADOW')
 	fons.set_color(black)
 	fons.set_blur(0)
-	fons.draw_text(dx, dy, c'DROP SHADOW', &char(0))
+	fons.draw_text(dx, dy, 'DROP SHADOW')
 	fons.set_size(18.0)
 	fons.set_font(state.font_normal)
 	fons.set_color(white)
@@ -135,27 +134,27 @@ fn (state &AppState) render_font() {
 	dy = 350
 	line(f32(dx - 10), f32(dy), f32(dx + 250), f32(dy))
 	fons.set_align(C.FONS_ALIGN_LEFT | C.FONS_ALIGN_TOP)
-	dx = fons.draw_text(dx, dy, c'Top', &char(0))
+	dx = fons.draw_text(dx, dy, 'Top')
 	dx += 10
 	fons.set_align(C.FONS_ALIGN_LEFT | C.FONS_ALIGN_MIDDLE)
-	dx = fons.draw_text(dx, dy, c'Middle', &char(0))
+	dx = fons.draw_text(dx, dy, 'Middle')
 	dx += 10
 	fons.set_align(C.FONS_ALIGN_LEFT | C.FONS_ALIGN_BASELINE)
-	dx = fons.draw_text(dx, dy, c'Baseline', &char(0))
+	dx = fons.draw_text(dx, dy, 'Baseline')
 	dx += 10
 	fons.set_align(C.FONS_ALIGN_LEFT | C.FONS_ALIGN_BOTTOM)
-	fons.draw_text(dx, dy, c'Bottom', &char(0))
+	fons.draw_text(dx, dy, 'Bottom')
 	dx = 150
 	dy = 400
 	line(f32(dx), f32(dy - 30), f32(dx), f32(dy + 80.0))
 	fons.set_align(C.FONS_ALIGN_LEFT | C.FONS_ALIGN_BASELINE)
-	fons.draw_text(dx, dy, c'Left', &char(0))
+	fons.draw_text(dx, dy, 'Left')
 	dy += 30
 	fons.set_align(C.FONS_ALIGN_CENTER | C.FONS_ALIGN_BASELINE)
-	fons.draw_text(dx, dy, c'Center', &char(0))
+	fons.draw_text(dx, dy, 'Center')
 	dy += 30
 	fons.set_align(C.FONS_ALIGN_RIGHT | C.FONS_ALIGN_BASELINE)
-	fons.draw_text(dx, dy, c'Right', &char(0))
+	fons.draw_text(dx, dy, 'Right')
 	C.sfons_flush(fons)
 }
 

--- a/examples/sokol/fonts.v
+++ b/examples/sokol/fonts.v
@@ -28,7 +28,7 @@ fn main() {
 	pass_action.colors[0] = color_action
 	state := &AppState{
 		pass_action: pass_action
-		fons: voidptr(0) // &sfons.Context(0)
+		fons: voidptr(0) // &fontstash.Context(0)
 	}
 	title := 'V Metal/GL Text Rendering'
 	desc := C.sapp_desc{

--- a/examples/sokol/fonts.v
+++ b/examples/sokol/fonts.v
@@ -2,13 +2,14 @@ import sokol
 import sokol.sapp
 import sokol.gfx
 import sokol.sgl
+import fontstash
 import sokol.sfons
 import os
 
 struct AppState {
 mut:
 	pass_action C.sg_pass_action
-	fons        &sfons.Context
+	fons        &fontstash.Context
 	font_normal int
 }
 

--- a/examples/sokol/fonts.v
+++ b/examples/sokol/fonts.v
@@ -8,7 +8,7 @@ import os
 struct AppState {
 mut:
 	pass_action C.sg_pass_action
-	fons        &C.FONScontext
+	fons        &sfons.Context
 	font_normal int
 }
 
@@ -27,7 +27,7 @@ fn main() {
 	pass_action.colors[0] = color_action
 	state := &AppState{
 		pass_action: pass_action
-		fons: &C.FONScontext(0)
+		fons: voidptr(0) // &sfons.Context(0)
 	}
 	title := 'V Metal/GL Text Rendering'
 	desc := C.sapp_desc{
@@ -51,8 +51,7 @@ fn init(mut state AppState) {
 		'RobotoMono-Regular.ttf')))
 	{
 		println('loaded font: $bytes.len')
-		state.font_normal = C.fonsAddFontMem(state.fons, c'sans', bytes.data, bytes.len,
-			false)
+		state.font_normal = state.fons.add_font_mem(c'sans', bytes.data, bytes.len, false)
 	}
 }
 
@@ -66,96 +65,98 @@ fn frame(user_data voidptr) {
 }
 
 fn (state &AppState) render_font() {
-	mut sx := 0.0
-	mut sy := 0.0
-	mut dx := 0.0
-	mut dy := 0.0
+	mut sx := f32(0.0)
+	mut sy := f32(0.0)
+	mut dx := f32(0.0)
+	mut dy := f32(0.0)
 	lh := f32(0.0)
-	white := C.sfons_rgba(255, 255, 255, 255)
-	black := C.sfons_rgba(0, 0, 0, 255)
-	brown := C.sfons_rgba(192, 128, 0, 128)
-	blue := C.sfons_rgba(0, 192, 255, 255)
-	state.fons.clear_state()
+	white := sfons.rgba(255, 255, 255, 255)
+	black := sfons.rgba(0, 0, 0, 255)
+	brown := sfons.rgba(192, 128, 0, 128)
+	blue := sfons.rgba(0, 192, 255, 255)
+
+	fons := state.fons
+	fons.clear_state()
 	sgl.defaults()
 	sgl.matrix_mode_projection()
-	sgl.ortho(0.0, f32(C.sapp_width()), f32(C.sapp_height()), 0.0, -1.0, 1.0)
+	sgl.ortho(0.0, f32(sapp.width()), f32(sapp.height()), 0.0, -1.0, 1.0)
 	sx = 0
 	sy = 50
 	dx = sx
 	dy = sy
-	state.fons.set_font(state.font_normal)
-	state.fons.set_size(100.0)
+	fons.set_font(state.font_normal)
+	fons.set_size(100.0)
 	ascender := f32(0.0)
 	descender := f32(0.0)
-	state.fons.vert_metrics(&ascender, &descender, &lh)
+	fons.vert_metrics(&ascender, &descender, &lh)
 	dx = sx
 	dy += lh
-	C.fonsSetColor(state.fons, white)
-	dx = C.fonsDrawText(state.fons, dx, dy, c'The quick ', C.NULL)
-	C.fonsSetFont(state.fons, state.font_normal)
-	C.fonsSetSize(state.fons, 48.0)
-	C.fonsSetColor(state.fons, brown)
-	dx = C.fonsDrawText(state.fons, dx, dy, c'brown ', C.NULL)
-	C.fonsSetFont(state.fons, state.font_normal)
-	C.fonsSetSize(state.fons, 24.0)
-	C.fonsSetColor(state.fons, white)
-	dx = C.fonsDrawText(state.fons, dx, dy, c'fox ', C.NULL)
+	fons.set_color(white)
+	dx = fons.draw_text(dx, dy, c'The quick ', &char(0))
+	fons.set_font(state.font_normal)
+	fons.set_size(48.0)
+	fons.set_color(brown)
+	dx = fons.draw_text(dx, dy, c'brown ', &char(0))
+	fons.set_font(state.font_normal)
+	fons.set_size(24.0)
+	fons.set_color(white)
+	dx = fons.draw_text(dx, dy, c'fox ', &char(0))
 	dx = sx
 	dy += lh * 1.2
-	C.fonsSetSize(state.fons, 20.0)
-	C.fonsSetFont(state.fons, state.font_normal)
-	C.fonsSetColor(state.fons, blue)
-	C.fonsDrawText(state.fons, dx, dy, c'Now is the time for all good men to come to the aid of the party.',
-		C.NULL)
+	fons.set_size(20.0)
+	fons.set_font(state.font_normal)
+	fons.set_color(blue)
+	fons.draw_text(dx, dy, c'Now is the time for all good men to come to the aid of the party.',
+		&char(0))
 	dx = 300
 	dy = 350
-	C.fonsSetAlign(state.fons, C.FONS_ALIGN_LEFT | C.FONS_ALIGN_BASELINE)
-	C.fonsSetSize(state.fons, 60.0)
-	C.fonsSetFont(state.fons, state.font_normal)
-	C.fonsSetColor(state.fons, white)
-	C.fonsSetSpacing(state.fons, 5.0)
-	C.fonsSetBlur(state.fons, 6.0)
-	C.fonsDrawText(state.fons, dx, dy, c'Blurry...', C.NULL)
+	fons.set_align(C.FONS_ALIGN_LEFT | C.FONS_ALIGN_BASELINE)
+	fons.set_size(60.0)
+	fons.set_font(state.font_normal)
+	fons.set_color(white)
+	fons.set_spacing(5.0)
+	fons.set_blur(6.0)
+	fons.draw_text(dx, dy, c'Blurry...', &char(0))
 	dx = 300
 	dy += 50.0
-	C.fonsSetSize(state.fons, 28.0)
-	C.fonsSetFont(state.fons, state.font_normal)
-	C.fonsSetColor(state.fons, white)
-	C.fonsSetSpacing(state.fons, 0.0)
-	C.fonsSetBlur(state.fons, 3.0)
-	C.fonsDrawText(state.fons, dx, dy + 2, c'DROP SHADOW', C.NULL)
-	C.fonsSetColor(state.fons, black)
-	C.fonsSetBlur(state.fons, 0)
-	C.fonsDrawText(state.fons, dx, dy, c'DROP SHADOW', C.NULL)
-	C.fonsSetSize(state.fons, 18.0)
-	C.fonsSetFont(state.fons, state.font_normal)
-	C.fonsSetColor(state.fons, white)
+	fons.set_size(28.0)
+	fons.set_font(state.font_normal)
+	fons.set_color(white)
+	fons.set_spacing(0.0)
+	fons.set_blur(3.0)
+	fons.draw_text(dx, dy + 2, c'DROP SHADOW', &char(0))
+	fons.set_color(black)
+	fons.set_blur(0)
+	fons.draw_text(dx, dy, c'DROP SHADOW', &char(0))
+	fons.set_size(18.0)
+	fons.set_font(state.font_normal)
+	fons.set_color(white)
 	dx = 50
 	dy = 350
 	line(f32(dx - 10), f32(dy), f32(dx + 250), f32(dy))
-	C.fonsSetAlign(state.fons, C.FONS_ALIGN_LEFT | C.FONS_ALIGN_TOP)
-	dx = C.fonsDrawText(state.fons, dx, dy, c'Top', C.NULL)
+	fons.set_align(C.FONS_ALIGN_LEFT | C.FONS_ALIGN_TOP)
+	dx = fons.draw_text(dx, dy, c'Top', &char(0))
 	dx += 10
-	C.fonsSetAlign(state.fons, C.FONS_ALIGN_LEFT | C.FONS_ALIGN_MIDDLE)
-	dx = C.fonsDrawText(state.fons, dx, dy, c'Middle', C.NULL)
+	fons.set_align(C.FONS_ALIGN_LEFT | C.FONS_ALIGN_MIDDLE)
+	dx = fons.draw_text(dx, dy, c'Middle', &char(0))
 	dx += 10
-	C.fonsSetAlign(state.fons, C.FONS_ALIGN_LEFT | C.FONS_ALIGN_BASELINE)
-	dx = C.fonsDrawText(state.fons, dx, dy, c'Baseline', C.NULL)
+	fons.set_align(C.FONS_ALIGN_LEFT | C.FONS_ALIGN_BASELINE)
+	dx = fons.draw_text(dx, dy, c'Baseline', &char(0))
 	dx += 10
-	C.fonsSetAlign(state.fons, C.FONS_ALIGN_LEFT | C.FONS_ALIGN_BOTTOM)
-	C.fonsDrawText(state.fons, dx, dy, c'Bottom', C.NULL)
+	fons.set_align(C.FONS_ALIGN_LEFT | C.FONS_ALIGN_BOTTOM)
+	fons.draw_text(dx, dy, c'Bottom', &char(0))
 	dx = 150
 	dy = 400
 	line(f32(dx), f32(dy - 30), f32(dx), f32(dy + 80.0))
-	C.fonsSetAlign(state.fons, C.FONS_ALIGN_LEFT | C.FONS_ALIGN_BASELINE)
-	C.fonsDrawText(state.fons, dx, dy, c'Left', C.NULL)
+	fons.set_align(C.FONS_ALIGN_LEFT | C.FONS_ALIGN_BASELINE)
+	fons.draw_text(dx, dy, c'Left', &char(0))
 	dy += 30
-	C.fonsSetAlign(state.fons, C.FONS_ALIGN_CENTER | C.FONS_ALIGN_BASELINE)
-	C.fonsDrawText(state.fons, dx, dy, c'Center', C.NULL)
+	fons.set_align(C.FONS_ALIGN_CENTER | C.FONS_ALIGN_BASELINE)
+	fons.draw_text(dx, dy, c'Center', &char(0))
 	dy += 30
-	C.fonsSetAlign(state.fons, C.FONS_ALIGN_RIGHT | C.FONS_ALIGN_BASELINE)
-	C.fonsDrawText(state.fons, dx, dy, c'Right', C.NULL)
-	C.sfons_flush(state.fons)
+	fons.set_align(C.FONS_ALIGN_RIGHT | C.FONS_ALIGN_BASELINE)
+	fons.draw_text(dx, dy, c'Right', &char(0))
+	C.sfons_flush(fons)
 }
 
 fn line(sx f32, sy f32, ex f32, ey f32) {

--- a/examples/sokol/freetype_raven.v
+++ b/examples/sokol/freetype_raven.v
@@ -109,7 +109,7 @@ fn init(user_data voidptr) {
 }
 
 fn frame(user_data voidptr) {
-	t := time.ticks()
+	// t := time.ticks()
 	mut state := &AppState(user_data)
 	state.render_font()
 	gfx.begin_default_pass(&state.pass_action, sapp.width(), sapp.height())

--- a/examples/sokol/freetype_raven.v
+++ b/examples/sokol/freetype_raven.v
@@ -4,7 +4,6 @@ import sokol.gfx
 import sokol.sgl
 import sokol.sfons
 import os
-import time
 
 const (
 	text = '
@@ -109,14 +108,12 @@ fn init(user_data voidptr) {
 }
 
 fn frame(user_data voidptr) {
-	// t := time.ticks()
 	mut state := &AppState(user_data)
 	state.render_font()
 	gfx.begin_default_pass(&state.pass_action, sapp.width(), sapp.height())
 	sgl.draw()
 	gfx.end_pass()
 	gfx.commit()
-	// println('delta ${time.ticks() - t}')
 }
 
 const (

--- a/examples/sokol/freetype_raven.v
+++ b/examples/sokol/freetype_raven.v
@@ -56,7 +56,7 @@ Let my heart be still a moment and this mystery explore;—
 struct AppState {
 mut:
 	pass_action C.sg_pass_action
-	fons        &C.FONScontext
+	fons        &sfons.Context
 	font_normal int
 	inited      bool
 }
@@ -76,7 +76,7 @@ fn main() {
 	pass_action.colors[0] = color_action
 	state := &AppState{
 		pass_action: pass_action
-		fons: &C.FONScontext(0)
+		fons: voidptr(0) // &sfons.Context(0)
 	}
 	title := 'V Metal/GL Text Rendering'
 	desc := C.sapp_desc{
@@ -104,8 +104,7 @@ fn init(user_data voidptr) {
 		'RobotoMono-Regular.ttf')))
 	{
 		println('loaded font: $bytes.len')
-		state.font_normal = C.fonsAddFontMem(state.fons, c'sans', bytes.data, bytes.len,
-			false)
+		state.font_normal = state.fons.add_font_mem(c'sans', bytes.data, bytes.len, false)
 	}
 }
 
@@ -117,34 +116,35 @@ fn frame(user_data voidptr) {
 	sgl.draw()
 	gfx.end_pass()
 	gfx.commit()
-	println(time.ticks() - t)
+	// println('delta ${time.ticks() - t}')
 }
 
 const (
-	black = C.sfons_rgba(0, 0, 0, 255)
+	black = sfons.rgba(0, 0, 0, 255)
 )
 
 fn (mut state AppState) render_font() {
 	lh := 30
 	mut dy := lh
+	mut fons := state.fons
 	if !state.inited {
-		state.fons.clear_state()
+		fons.clear_state()
 		sgl.defaults()
 		sgl.matrix_mode_projection()
-		sgl.ortho(0.0, f32(C.sapp_width()), f32(C.sapp_height()), 0.0, -1.0, 1.0)
-		state.fons.set_font(state.font_normal)
-		state.fons.set_size(100.0)
-		C.fonsSetColor(state.fons, black)
-		C.fonsSetFont(state.fons, state.font_normal)
-		C.fonsSetSize(state.fons, 35.0)
+		sgl.ortho(0.0, f32(sapp.width()), f32(sapp.height()), 0.0, -1.0, 1.0)
+		fons.set_font(state.font_normal)
+		fons.set_size(100.0)
+		fons.set_color(black)
+		fons.set_font(state.font_normal)
+		fons.set_size(35.0)
 		state.inited = true
 	}
 
 	for line in lines {
-		C.fonsDrawText(state.fons, 40, dy, line.str, C.NULL)
+		fons.draw_text(40, dy, line.str, &char(0))
 		dy += lh
 	}
-	C.sfons_flush(state.fons)
+	sfons.flush(fons)
 }
 
 fn line(sx f32, sy f32, ex f32, ey f32) {

--- a/examples/sokol/freetype_raven.v
+++ b/examples/sokol/freetype_raven.v
@@ -2,6 +2,7 @@ import sokol
 import sokol.sapp
 import sokol.gfx
 import sokol.sgl
+import fontstash
 import sokol.sfons
 import os
 
@@ -55,7 +56,7 @@ Let my heart be still a moment and this mystery explore;—
 struct AppState {
 mut:
 	pass_action C.sg_pass_action
-	fons        &sfons.Context
+	fons        &fontstash.Context
 	font_normal int
 	inited      bool
 }

--- a/examples/sokol/freetype_raven.v
+++ b/examples/sokol/freetype_raven.v
@@ -103,7 +103,7 @@ fn init(user_data voidptr) {
 		'RobotoMono-Regular.ttf')))
 	{
 		println('loaded font: $bytes.len')
-		state.font_normal = state.fons.add_font_mem(c'sans', bytes.data, bytes.len, false)
+		state.font_normal = state.fons.add_font_mem('sans', bytes, false)
 	}
 }
 
@@ -138,7 +138,7 @@ fn (mut state AppState) render_font() {
 	}
 
 	for line in lines {
-		fons.draw_text(40, dy, line.str, &char(0))
+		fons.draw_text(40, dy, line)
 		dy += lh
 	}
 	sfons.flush(fons)

--- a/examples/sokol/freetype_raven.v
+++ b/examples/sokol/freetype_raven.v
@@ -76,7 +76,7 @@ fn main() {
 	pass_action.colors[0] = color_action
 	state := &AppState{
 		pass_action: pass_action
-		fons: voidptr(0) // &sfons.Context(0)
+		fons: voidptr(0) // &fontstash.Context(0)
 	}
 	title := 'V Metal/GL Text Rendering'
 	desc := C.sapp_desc{

--- a/vlib/fontstash/fontstash.c.v
+++ b/vlib/fontstash/fontstash.c.v
@@ -18,6 +18,8 @@ $if windows {
 	#flag -lm
 }
 
+pub type Context = C.FONScontext
+
 //#flag -lfreetype
 pub const (
 	// TODO: fontstash.used_import is used to keep v from warning about unused imports
@@ -26,23 +28,23 @@ pub const (
 
 // Contructor and destructor.
 [inline]
-pub fn create_internal(params &C.FONSparams) &C.FONScontext {
+pub fn create_internal(params &C.FONSparams) &Context {
 	return C.fonsCreateInternal(params)
 }
 
 [inline]
-pub fn delete_internal(s &C.FONScontext) {
+pub fn delete_internal(s &Context) {
 	C.fonsDeleteInternal(s)
 }
 
 [inline]
-pub fn (s &C.FONScontext) set_error_callback(callback fn (voidptr, int, int), uptr voidptr) {
+pub fn (s &Context) set_error_callback(callback fn (voidptr, int, int), uptr voidptr) {
 	C.fonsSetErrorCallback(s, callback, uptr)
 }
 
 // Returns current atlas size.
 [inline]
-pub fn (s &C.FONScontext) get_atlas_size() (int, int) {
+pub fn (s &Context) get_atlas_size() (int, int) {
 	mut width := 0
 	mut height := 0
 	C.fonsGetAtlasSize(s, &width, &height)
@@ -51,125 +53,125 @@ pub fn (s &C.FONScontext) get_atlas_size() (int, int) {
 
 // Expands the atlas size.
 [inline]
-pub fn (s &C.FONScontext) expand_atlas(width int, height int) int {
+pub fn (s &Context) expand_atlas(width int, height int) int {
 	return C.fonsExpandAtlas(s, width, height)
 }
 
 // Resets the whole stash.
 [inline]
-pub fn (s &C.FONScontext) reset_atlas(width int, height int) int {
+pub fn (s &Context) reset_atlas(width int, height int) int {
 	return C.fonsResetAtlas(s, width, height)
 }
 
 // Add fonts
 [inline]
-pub fn (s &C.FONScontext) get_font_by_name(name string) int {
+pub fn (s &Context) get_font_by_name(name string) int {
 	return C.fonsGetFontByName(s, &char(name.str))
 }
 
 [inline]
-pub fn (s &C.FONScontext) add_fallback_font(base int, fallback int) int {
+pub fn (s &Context) add_fallback_font(base int, fallback int) int {
 	return C.fonsAddFallbackFont(s, base, fallback)
 }
 
 [inline]
-pub fn (s &C.FONScontext) add_font_mem(name string, data []byte, free_data bool) int {
+pub fn (s &Context) add_font_mem(name string, data []byte, free_data bool) int {
 	return C.fonsAddFontMem(s, &char(name.str), data.data, data.len, int(free_data))
 }
 
 // State handling
 [inline]
-pub fn (s &C.FONScontext) push_state() {
+pub fn (s &Context) push_state() {
 	C.fonsPushState(s)
 }
 
 [inline]
-pub fn (s &C.FONScontext) pop_state() {
+pub fn (s &Context) pop_state() {
 	C.fonsPopState(s)
 }
 
 [inline]
-pub fn (s &C.FONScontext) clear_state() {
+pub fn (s &Context) clear_state() {
 	C.fonsClearState(s)
 }
 
 // State setting
 [inline]
-pub fn (s &C.FONScontext) set_size(size f32) {
+pub fn (s &Context) set_size(size f32) {
 	C.fonsSetSize(s, size)
 }
 
 [inline]
-pub fn (s &C.FONScontext) set_color(color u32) {
+pub fn (s &Context) set_color(color u32) {
 	C.fonsSetColor(s, color)
 }
 
 [inline]
-pub fn (s &C.FONScontext) set_spacing(spacing f32) {
+pub fn (s &Context) set_spacing(spacing f32) {
 	C.fonsSetSpacing(s, spacing)
 }
 
 [inline]
-pub fn (s &C.FONScontext) set_blur(blur f32) {
+pub fn (s &Context) set_blur(blur f32) {
 	C.fonsSetBlur(s, blur)
 }
 
 [inline]
-pub fn (s &C.FONScontext) set_align(align int) {
+pub fn (s &Context) set_align(align int) {
 	C.fonsSetAlign(s, align)
 }
 
 [inline]
-pub fn (s &C.FONScontext) set_font(font int) {
+pub fn (s &Context) set_font(font int) {
 	C.fonsSetFont(s, font)
 }
 
 // Draw text
 [inline]
-pub fn (s &C.FONScontext) draw_text(x f32, y f32, text string) f32 {
+pub fn (s &Context) draw_text(x f32, y f32, text string) f32 {
 	return C.fonsDrawText(s, x, y, &char(text.str), &char(0))
 }
 
 // Measure text
 [inline]
-pub fn (s &C.FONScontext) text_bounds(x f32, y f32, text string, bounds &f32) f32 {
+pub fn (s &Context) text_bounds(x f32, y f32, text string, bounds &f32) f32 {
 	return C.fonsTextBounds(s, x, y, &char(text.str), &char(0), bounds)
 }
 
 [inline]
-pub fn (s &C.FONScontext) line_bounds(y f32, miny &f32, maxy &f32) {
+pub fn (s &Context) line_bounds(y f32, miny &f32, maxy &f32) {
 	C.fonsLineBounds(s, y, miny, maxy)
 }
 
 [inline]
-pub fn (s &C.FONScontext) vert_metrics(ascender &f32, descender &f32, lineh &f32) {
+pub fn (s &Context) vert_metrics(ascender &f32, descender &f32, lineh &f32) {
 	C.fonsVertMetrics(s, ascender, descender, lineh)
 }
 
 // Text iterator
 [inline]
-pub fn (s &C.FONScontext) text_iter_init(iter &C.FONStextIter, x f32, y f32, str &char, end &char) int {
+pub fn (s &Context) text_iter_init(iter &C.FONStextIter, x f32, y f32, str &char, end &char) int {
 	return C.fonsTextIterInit(s, iter, x, y, str, end)
 }
 
 [inline]
-pub fn (s &C.FONScontext) text_iter_next(iter &C.FONStextIter, quad &C.FONSquad) int {
+pub fn (s &Context) text_iter_next(iter &C.FONStextIter, quad &C.FONSquad) int {
 	return C.fonsTextIterNext(s, iter, quad)
 }
 
 // Pull texture changes
 [inline]
-pub fn (s &C.FONScontext) get_texture_data(width &int, height &int) &byte {
+pub fn (s &Context) get_texture_data(width &int, height &int) &byte {
 	return &byte(C.fonsGetTextureData(s, width, height))
 }
 
 [inline]
-pub fn (s &C.FONScontext) validate_texture(dirty &int) int {
+pub fn (s &Context) validate_texture(dirty &int) int {
 	return C.fonsValidateTexture(s, dirty)
 }
 
 // Draws the stash texture for debugging
 [inline]
-pub fn (s &C.FONScontext) draw_debug(x f32, y f32) {
+pub fn (s &Context) draw_debug(x f32, y f32) {
 	C.fonsDrawDebug(s, x, y)
 }

--- a/vlib/fontstash/fontstash.c.v
+++ b/vlib/fontstash/fontstash.c.v
@@ -42,8 +42,11 @@ pub fn (s &C.FONScontext) set_error_callback(callback fn (voidptr, int, int), up
 
 // Returns current atlas size.
 [inline]
-pub fn (s &C.FONScontext) get_atlas_size(width &int, height &int) {
-	C.fonsGetAtlasSize(s, width, height)
+pub fn (s &C.FONScontext) get_atlas_size() (int,int) {
+	mut width := 0
+	mut height := 0
+	C.fonsGetAtlasSize(s, &width, &height)
+	return width, height
 }
 
 // Expands the atlas size.
@@ -60,8 +63,8 @@ pub fn (s &C.FONScontext) reset_atlas(width int, height int) int {
 
 // Add fonts
 [inline]
-pub fn (s &C.FONScontext) get_font_by_name(name &char) int {
-	return C.fonsGetFontByName(s, name)
+pub fn (s &C.FONScontext) get_font_by_name(name string) int {
+	return C.fonsGetFontByName(s, name.str)
 }
 
 [inline]
@@ -70,8 +73,8 @@ pub fn (s &C.FONScontext) add_fallback_font(base int, fallback int) int {
 }
 
 [inline]
-pub fn (s &C.FONScontext) add_font_mem(name &char, data &byte, data_size int, free_data bool) int {
-	return C.fonsAddFontMem(s, name, data, data_size, int(free_data))
+pub fn (s &C.FONScontext) add_font_mem(name string, data []byte, free_data bool) int {
+	return C.fonsAddFontMem(s, name.str, data.data, data.len, int(free_data))
 }
 
 // State handling
@@ -123,14 +126,14 @@ pub fn (s &C.FONScontext) set_font(font int) {
 
 // Draw text
 [inline]
-pub fn (s &C.FONScontext) draw_text(x f32, y f32, str &char, end &char) f32 {
-	return C.fonsDrawText(s, x, y, str, end)
+pub fn (s &C.FONScontext) draw_text(x f32, y f32, text string) f32 {
+	return C.fonsDrawText(s, x, y, text.str, &char(0))
 }
 
 // Measure text
 [inline]
-pub fn (s &C.FONScontext) text_bounds(x f32, y f32, str &char, end &char, bounds &f32) f32 {
-	return C.fonsTextBounds(s, x, y, str, end, bounds)
+pub fn (s &C.FONScontext) text_bounds(x f32, y f32, text string, bounds &f32) f32 {
+	return C.fonsTextBounds(s, x, y, text.str,  &char(0), bounds)
 }
 
 [inline]

--- a/vlib/fontstash/fontstash.c.v
+++ b/vlib/fontstash/fontstash.c.v
@@ -42,7 +42,7 @@ pub fn (s &C.FONScontext) set_error_callback(callback fn (voidptr, int, int), up
 
 // Returns current atlas size.
 [inline]
-pub fn (s &C.FONScontext) get_atlas_size() (int,int) {
+pub fn (s &C.FONScontext) get_atlas_size() (int, int) {
 	mut width := 0
 	mut height := 0
 	C.fonsGetAtlasSize(s, &width, &height)
@@ -133,7 +133,7 @@ pub fn (s &C.FONScontext) draw_text(x f32, y f32, text string) f32 {
 // Measure text
 [inline]
 pub fn (s &C.FONScontext) text_bounds(x f32, y f32, text string, bounds &f32) f32 {
-	return C.fonsTextBounds(s, x, y, text.str,  &char(0), bounds)
+	return C.fonsTextBounds(s, x, y, text.str, &char(0), bounds)
 }
 
 [inline]

--- a/vlib/fontstash/fontstash.c.v
+++ b/vlib/fontstash/fontstash.c.v
@@ -64,7 +64,7 @@ pub fn (s &C.FONScontext) reset_atlas(width int, height int) int {
 // Add fonts
 [inline]
 pub fn (s &C.FONScontext) get_font_by_name(name string) int {
-	return C.fonsGetFontByName(s, name.str)
+	return C.fonsGetFontByName(s, &char(name.str))
 }
 
 [inline]
@@ -74,7 +74,7 @@ pub fn (s &C.FONScontext) add_fallback_font(base int, fallback int) int {
 
 [inline]
 pub fn (s &C.FONScontext) add_font_mem(name string, data []byte, free_data bool) int {
-	return C.fonsAddFontMem(s, name.str, data.data, data.len, int(free_data))
+	return C.fonsAddFontMem(s, &char(name.str), data.data, data.len, int(free_data))
 }
 
 // State handling
@@ -127,13 +127,13 @@ pub fn (s &C.FONScontext) set_font(font int) {
 // Draw text
 [inline]
 pub fn (s &C.FONScontext) draw_text(x f32, y f32, text string) f32 {
-	return C.fonsDrawText(s, x, y, text.str, &char(0))
+	return C.fonsDrawText(s, x, y, &char(text.str), &char(0))
 }
 
 // Measure text
 [inline]
 pub fn (s &C.FONScontext) text_bounds(x f32, y f32, text string, bounds &f32) f32 {
-	return C.fonsTextBounds(s, x, y, text.str, &char(0), bounds)
+	return C.fonsTextBounds(s, x, y, &char(text.str), &char(0), bounds)
 }
 
 [inline]

--- a/vlib/fontstash/fontstash.c.v
+++ b/vlib/fontstash/fontstash.c.v
@@ -70,8 +70,8 @@ pub fn (s &C.FONScontext) add_fallback_font(base int, fallback int) int {
 }
 
 [inline]
-pub fn (s &C.FONScontext) add_font_mem(name &char, data &byte, data_size int, free_data int) int {
-	return C.fonsAddFontMem(s, name, data, data_size, free_data)
+pub fn (s &C.FONScontext) add_font_mem(name &char, data &byte, data_size int, free_data bool) int {
+	return C.fonsAddFontMem(s, name, data, data_size, int(free_data))
 }
 
 // State handling

--- a/vlib/gg/text_rendering.c.v
+++ b/vlib/gg/text_rendering.c.v
@@ -43,14 +43,10 @@ fn new_ft(c FTConfig) ?&FT {
 
 			return &FT{
 				fons: fons
-				font_normal: fons.add_font_mem(c'sans', bytes_normal.data, bytes_normal.len,
-					false)
-				font_bold: fons.add_font_mem(c'sans', bytes_bold.data, bytes_bold.len,
-					false)
-				font_mono: fons.add_font_mem(c'sans', bytes_mono.data, bytes_mono.len,
-					false)
-				font_italic: fons.add_font_mem(c'sans', bytes_italic.data, bytes_italic.len,
-					false)
+				font_normal: fons.add_font_mem('sans', bytes_normal, false)
+				font_bold: fons.add_font_mem('sans', bytes_bold, false)
+				font_mono: fons.add_font_mem('sans', bytes_mono, false)
+				font_italic: fons.add_font_mem('sans', bytes_italic, false)
 				scale: c.scale
 			}
 		} else {
@@ -112,10 +108,10 @@ fn new_ft(c FTConfig) ?&FT {
 	debug_font_println('Font used for font_italic : $italic_path')
 	return &FT{
 		fons: fons
-		font_normal: fons.add_font_mem(c'sans', bytes.data, bytes.len, false)
-		font_bold: fons.add_font_mem(c'sans', bytes_bold.data, bytes_bold.len, false)
-		font_mono: fons.add_font_mem(c'sans', bytes_mono.data, bytes_mono.len, false)
-		font_italic: fons.add_font_mem(c'sans', bytes_italic.data, bytes_italic.len, false)
+		font_normal: fons.add_font_mem('sans', bytes, false)
+		font_bold: fons.add_font_mem('sans', bytes_bold, false)
+		font_mono: fons.add_font_mem('sans', bytes_mono, false)
+		font_italic: fons.add_font_mem('sans', bytes_italic, false)
 		scale: c.scale
 	}
 }
@@ -171,7 +167,7 @@ pub fn (ctx &Context) draw_text(x int, y int, text_ string, cfg gx.TextCfg) {
 	// }
 	ctx.set_cfg(cfg)
 	scale := if ctx.ft.scale == 0 { f32(1) } else { ctx.ft.scale }
-	ctx.ft.fons.draw_text(x * scale, y * scale, &char(text_.str), &char(0)) // TODO: check offsets/alignment
+	ctx.ft.fons.draw_text(x * scale, y * scale, text_) // TODO: check offsets/alignment
 }
 
 pub fn (ctx &Context) draw_text_def(x int, y int, text string) {
@@ -197,7 +193,7 @@ pub fn (ctx &Context) text_width(s string) int {
 		return 0
 	}
 	mut buf := [4]f32{}
-	ctx.ft.fons.text_bounds(0, 0, &char(s.str), &char(0), &buf[0])
+	ctx.ft.fons.text_bounds(0, 0, s, &buf[0])
 	if s.ends_with(' ') {
 		return int((buf[2] - buf[0]) / ctx.scale) +
 			ctx.text_width('i') // TODO fix this in fontstash?
@@ -218,7 +214,7 @@ pub fn (ctx &Context) text_height(s string) int {
 		return 0
 	}
 	mut buf := [4]f32{}
-	ctx.ft.fons.text_bounds(0, 0, &char(s.str), &char(0), &buf[0])
+	ctx.ft.fons.text_bounds(0, 0, s, &buf[0])
 	return int((buf[3] - buf[1]) / ctx.scale)
 }
 
@@ -228,6 +224,6 @@ pub fn (ctx &Context) text_size(s string) (int, int) {
 		return 0, 0
 	}
 	mut buf := [4]f32{}
-	ctx.ft.fons.text_bounds(0, 0, &char(s.str), &char(0), &buf[0])
+	ctx.ft.fons.text_bounds(0, 0, s, &buf[0])
 	return int((buf[2] - buf[0]) / ctx.scale), int((buf[3] - buf[1]) / ctx.scale)
 }

--- a/vlib/gg/text_rendering.c.v
+++ b/vlib/gg/text_rendering.c.v
@@ -2,6 +2,7 @@
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module gg
 
+import fontstash
 import sokol.sfons
 import sokol.sgl
 import gx
@@ -9,7 +10,7 @@ import os
 
 struct FT {
 pub:
-	fons        &sfons.Context
+	fons        &fontstash.Context
 	font_normal int
 	font_bold   int
 	font_mono   int

--- a/vlib/gg/text_rendering.c.v
+++ b/vlib/gg/text_rendering.c.v
@@ -197,7 +197,7 @@ pub fn (ctx &Context) text_width(s string) int {
 		return 0
 	}
 	mut buf := [4]f32{}
-	ctx.ft.fons.text_bounds(0, 0, &char(s.str), 0, &buf[0])
+	ctx.ft.fons.text_bounds(0, 0, &char(s.str), &char(0), &buf[0])
 	if s.ends_with(' ') {
 		return int((buf[2] - buf[0]) / ctx.scale) +
 			ctx.text_width('i') // TODO fix this in fontstash?
@@ -218,7 +218,7 @@ pub fn (ctx &Context) text_height(s string) int {
 		return 0
 	}
 	mut buf := [4]f32{}
-	ctx.ft.fons.text_bounds(0, 0, &char(s.str), 0, &buf[0])
+	ctx.ft.fons.text_bounds(0, 0, &char(s.str), &char(0), &buf[0])
 	return int((buf[3] - buf[1]) / ctx.scale)
 }
 
@@ -228,6 +228,6 @@ pub fn (ctx &Context) text_size(s string) (int, int) {
 		return 0, 0
 	}
 	mut buf := [4]f32{}
-	ctx.ft.fons.text_bounds(0, 0, &char(s.str), 0, &buf[0])
+	ctx.ft.fons.text_bounds(0, 0, &char(s.str), &char(0), &buf[0])
 	return int((buf[2] - buf[0]) / ctx.scale), int((buf[3] - buf[1]) / ctx.scale)
 }

--- a/vlib/sokol/sfons/sfons.c.v
+++ b/vlib/sokol/sfons/sfons.c.v
@@ -2,18 +2,16 @@ module sfons
 
 import fontstash
 
-type Context = C.FONScontext
-
 // keep v from warning about unused imports
 const used_import = fontstash.used_import + 1
 
 [inline]
-pub fn create(width int, height int, flags int) &Context {
+pub fn create(width int, height int, flags int) &fontstash.Context {
 	return C.sfons_create(width, height, flags)
 }
 
 [inline]
-pub fn destroy(ctx &Context) {
+pub fn destroy(ctx &fontstash.Context) {
 	C.sfons_destroy(ctx)
 }
 
@@ -23,6 +21,6 @@ pub fn rgba(r byte, g byte, b byte, a byte) u32 {
 }
 
 [inline]
-pub fn flush(ctx &Context) {
+pub fn flush(ctx &fontstash.Context) {
 	C.sfons_flush(ctx)
 }

--- a/vlib/sokol/sfons/sfons.c.v
+++ b/vlib/sokol/sfons/sfons.c.v
@@ -2,16 +2,18 @@ module sfons
 
 import fontstash
 
+type Context = C.FONScontext
+
 // keep v from warning about unused imports
 const used_import = fontstash.used_import + 1
 
 [inline]
-pub fn create(width int, height int, flags int) &C.FONScontext {
+pub fn create(width int, height int, flags int) &Context {
 	return C.sfons_create(width, height, flags)
 }
 
 [inline]
-pub fn destroy(ctx &C.FONScontext) {
+pub fn destroy(ctx &Context) {
 	C.sfons_destroy(ctx)
 }
 
@@ -21,6 +23,6 @@ pub fn rgba(r byte, g byte, b byte, a byte) u32 {
 }
 
 [inline]
-pub fn flush(ctx &C.FONScontext) {
+pub fn flush(ctx &Context) {
 	C.sfons_flush(ctx)
 }

--- a/vlib/sokol/sfons/sfons_funcs.c.v
+++ b/vlib/sokol/sfons/sfons_funcs.c.v
@@ -1,6 +1,6 @@
 module sfons
 
-fn C.sfons_create(width int, height int, flags int) &C.FONScontext
-fn C.sfons_destroy(ctx &C.FONScontext)
+fn C.sfons_create(width int, height int, flags int) &Context
+fn C.sfons_destroy(ctx &Context)
 fn C.sfons_rgba(r byte, g byte, b byte, a byte) u32
-fn C.sfons_flush(ctx &C.FONScontext)
+fn C.sfons_flush(ctx &Context)

--- a/vlib/sokol/sfons/sfons_funcs.c.v
+++ b/vlib/sokol/sfons/sfons_funcs.c.v
@@ -1,6 +1,8 @@
 module sfons
 
-fn C.sfons_create(width int, height int, flags int) &Context
-fn C.sfons_destroy(ctx &Context)
+import fontstash
+
+fn C.sfons_create(width int, height int, flags int) &fontstash.Context
+fn C.sfons_destroy(ctx &fontstash.Context)
 fn C.sfons_rgba(r byte, g byte, b byte, a byte) u32
-fn C.sfons_flush(ctx &Context)
+fn C.sfons_flush(ctx &fontstash.Context)


### PR DESCRIPTION
This PR replaces the use of `C.fonsXXX` / `C.sfons_XXX` calls with their wrapped V equivalents.
I have checked that the changed examples still run under Linux.

V UI fixes in https://github.com/vlang/ui/pull/401