### PR TITLE
builtin/string: split_any

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -620,8 +620,8 @@ fn (s string) + (a string) string {
 
 // split_any splits the string to an array by any of the `delim` chars.
 // Example: "first row\nsecond row".split_any(" \n") == ['first', 'row', 'second', 'row']
-// Split a string using the chars in the delimiter string as delimiters.
-// If teh delimeter string is empty the `.split()` is used. 
+// Split a string using the chars in the delimiter string as delimiters chars.
+// If the delimiter string is empty the `.split()` is used.
 [direct_array_access]
 pub fn (s string) split_any(delim string) []string {
 	mut res := []string{}
@@ -632,7 +632,7 @@ pub fn (s string) split_any(delim string) []string {
 	}
 	// if empty delimiter string using defautl split
 	if delim.len <= 0 {
-		return s.split("")
+		return s.split('')
 	}
 	for index, ch in s {
 		for delim_ch in delim {

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -621,30 +621,29 @@ fn (s string) + (a string) string {
 // split_any splits the string to an array by any of the `delim` chars.
 // Example: "first row\nsecond row".split_any(" \n") == ['first', 'row', 'second', 'row']
 // Split a string using the chars in the delimiter string as delimiters chars.
-// If the delimiter string is empty the `.split()` is used.
+// If the delimiter string is empty then `.split()` is used.
 [direct_array_access]
 pub fn (s string) split_any(delim string) []string {
 	mut res := []string{}
 	mut i := 0
 	// check empty source string
-	if s.len <= 0 {
-		return res
-	}
-	// if empty delimiter string using defautl split
-	if delim.len <= 0 {
-		return s.split('')
-	}
-	for index, ch in s {
-		for delim_ch in delim {
-			if ch == delim_ch {
-				res << s[i..index]
-				i = index + 1
-				break
+	if s.len > 0 {
+		// if empty delimiter string using defautl split
+		if delim.len <= 0 {
+			return s.split('')
+		}
+		for index, ch in s {
+			for delim_ch in delim {
+				if ch == delim_ch {
+					res << s[i..index]
+					i = index + 1
+					break
+				}
 			}
 		}
-	}
-	if i < s.len {
-		res << s[i..]
+		if i < s.len {
+			res << s[i..]
+		}
 	}
 	return res
 }

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -618,6 +618,37 @@ fn (s string) + (a string) string {
 	return res
 }
 
+// split_any splits the string to an array by any of the `delim` chars.
+// Example: "first row\nsecond row".split_any(" \n") == ['first', 'row', 'second', 'row']
+// Split a string using the chars in the delimiter string as delimiters.
+// If teh delimeter string is empty the `.split()` is used. 
+[direct_array_access]
+pub fn (s string) split_any(delim string) []string {
+	mut res := []string{}
+	mut i := 0
+	// check empty source string
+	if s.len <= 0 {
+		return res
+	}
+	// if empty delimiter string using defautl split
+	if delim.len <= 0 {
+		return s.split("")
+	}
+	for index, ch in s {
+		for delim_ch in delim {
+			if ch == delim_ch {
+				res << s[i..index]
+				i = index + 1
+				break
+			}
+		}
+	}
+	if i < s.len {
+		res << s[i..]
+	}
+	return res
+}
+
 // split splits the string to an array by `delim`.
 // Example: assert 'A B C'.split(' ') == ['A','B','C']
 // If `delim` is empty the string is split by it's characters.

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -230,16 +230,15 @@ fn test_split() {
 }
 
 fn test_split_any() {
-	assert "ABC".split_any("") == ['A', 'B', 'C']
-	assert "".split_any(' ') == []
-	assert " ".split_any(' ') == ['']
-	assert "  ".split_any(' ') == ['',  '']
-	assert "Ciao come stai? ".split_any(' ') == ['Ciao', 'come', 'stai?']
-	assert "Ciao+come*stai? ".split_any('+*') == ['Ciao', 'come', 'stai? ']
-	assert "Ciao+come*stai? ".split_any('+* ') == ['Ciao', 'come', 'stai?']
-	assert "first row\nsecond row".split_any(" \n") == ['first', 'row', 'second', 'row']
+	assert 'ABC'.split_any('') == ['A', 'B', 'C']
+	assert ''.split_any(' ') == []
+	assert ' '.split_any(' ') == ['']
+	assert '  '.split_any(' ') == ['', '']
+	assert 'Ciao come stai? '.split_any(' ') == ['Ciao', 'come', 'stai?']
+	assert 'Ciao+come*stai? '.split_any('+*') == ['Ciao', 'come', 'stai? ']
+	assert 'Ciao+come*stai? '.split_any('+* ') == ['Ciao', 'come', 'stai?']
+	assert 'first row\nsecond row'.split_any(' \n') == ['first', 'row', 'second', 'row']
 }
-
 
 fn test_trim_space() {
 	a := ' a '

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -229,6 +229,18 @@ fn test_split() {
 	assert vals[1] == ''
 }
 
+fn test_split_any() {
+	assert "ABC".split_any("") == ['A', 'B', 'C']
+	assert "".split_any(' ') == []
+	assert " ".split_any(' ') == ['']
+	assert "  ".split_any(' ') == ['',  '']
+	assert "Ciao come stai? ".split_any(' ') == ['Ciao', 'come', 'stai?']
+	assert "Ciao+come*stai? ".split_any('+*') == ['Ciao', 'come', 'stai? ']
+	assert "Ciao+come*stai? ".split_any('+* ') == ['Ciao', 'come', 'stai?']
+	assert "first row\nsecond row".split_any(" \n") == ['first', 'row', 'second', 'row']
+}
+
+
 fn test_trim_space() {
 	a := ' a '
 	assert a.trim_space() == 'a'


### PR DESCRIPTION
**What's inside**
- `split_any()` implementation
- tests for `split_any`

examples:
```v
assert 'ABC'.split_any('') == ['A', 'B', 'C']
assert ''.split_any(' ') == []
assert ' '.split_any(' ') == ['']
assert '  '.split_any(' ') == ['', '']
assert 'Ciao come stai? '.split_any(' ') == ['Ciao', 'come', 'stai?']
assert 'Ciao+come*stai? '.split_any('+*') == ['Ciao', 'come', 'stai? ']
assert 'Ciao+come*stai? '.split_any('+* ') == ['Ciao', 'come', 'stai?']
assert 'first row\nsecond row'.split_any(' \n') == ['first', 'row', 'second', 'row']
```