### PR TITLE
transformer: perform direct access to array when the index is known as safe

### DIFF
--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -1341,6 +1341,7 @@ fn (t Tree) index_expr(node ast.IndexExpr) &Node {
 	obj.add_terse('left_type', t.type_node(node.left_type))
 	obj.add_terse('index', t.expr(node.index))
 	obj.add_terse('is_setter', t.bool_node(node.is_setter))
+	obj.add_terse('is_direct', t.bool_node(node.is_direct))
 	obj.add_terse('or_expr', t.or_expr(node.or_expr))
 	obj.add('pos', t.position(node.pos))
 	return obj

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -816,6 +816,7 @@ pub mut:
 	is_array  bool
 	is_farray bool
 	is_option bool // IfGuard
+	is_direct bool // Set if the underlying memory can be safely accessed
 }
 
 pub struct IfExpr {

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -18,7 +18,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 		} else if sym.kind == .map {
 			g.index_of_map(node, sym)
 		} else if sym.kind == .string && !node.left_type.is_ptr() {
-			is_direct_array_access := g.fn_decl != 0 && g.fn_decl.is_direct_arr
+			is_direct_array_access := (g.fn_decl != 0 && g.fn_decl.is_direct_arr) || node.is_direct
 			if is_direct_array_access {
 				g.expr(node.left)
 				g.write('.str[ ')
@@ -128,7 +128,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 	// `(*(Val*)array_get(vals, i)).field = x;`
 	is_selector := node.left is ast.SelectorExpr
 	if g.is_assign_lhs && !is_selector && node.is_setter {
-		is_direct_array_access := g.fn_decl != 0 && g.fn_decl.is_direct_arr
+		is_direct_array_access := (g.fn_decl != 0 && g.fn_decl.is_direct_arr) || node.is_direct
 		is_op_assign := g.assign_op != .assign && info.elem_type != ast.string_type
 		array_ptr_type_str := match elem_typ.kind {
 			.function { 'voidptr*' }
@@ -195,7 +195,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 			}
 		}
 	} else {
-		is_direct_array_access := g.fn_decl != 0 && g.fn_decl.is_direct_arr
+		is_direct_array_access := (g.fn_decl != 0 && g.fn_decl.is_direct_arr) || node.is_direct
 		array_ptr_type_str := match elem_typ.kind {
 			.function { 'voidptr*' }
 			else { '$elem_type_str*' }

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -28,7 +28,7 @@ pub fn (mut p Parser) parse_array_type() ast.Type {
 							fixed_size = const_field.expr.val.int()
 						} else {
 							if const_field.expr is ast.InfixExpr {
-								t := transformer.new_transformer(p.pref)
+								mut t := transformer.new_transformer(p.pref)
 								folded_expr := t.infix_expr(const_field.expr)
 
 								if folded_expr is ast.IntegerLiteral {

--- a/vlib/v/tests/array_access_optimisation_test.v
+++ b/vlib/v/tests/array_access_optimisation_test.v
@@ -1,0 +1,48 @@
+import os
+
+const (
+	test = @VROOT + '/vlib/v/tests/testdata/test_array_bound.v'
+)
+
+fn direct(line string) {
+	if !line.contains('\tmain__direct(') {
+		return
+	}
+	trimmed := line.trim_space()
+	if trimmed.contains('array_get') {
+		assert trimmed == 'this should have been a direct access in $test line $line'
+	}
+}
+
+fn access(line string) {
+	if !line.contains('\tmain__access(') {
+		return
+	}
+	trimmed := line.trim_space()
+	if !trimmed.contains('array_get') {
+		assert trimmed == 'this should have been an array access in $test line $line'
+	}
+}
+
+fn test_array_optimisation() {
+	mut args := []string{cap: 3}
+	args << test
+	args << '-o'
+	args << '-'
+
+	mut p := os.new_process(@VEXE)
+	p.set_args(args)
+	p.set_redirect_stdio()
+	p.run()
+	stdout := p.stdout_slurp()
+	p.wait()
+	p.close()
+
+	assert stdout.contains('// THE END.')
+
+	for line in stdout.split('\n') {
+		direct(line)
+		access(line)
+	}
+	println('ok, could not detect any wrong memory access optimisation')
+}

--- a/vlib/v/tests/testdata/test_array_bound.v
+++ b/vlib/v/tests/testdata/test_array_bound.v
@@ -1,0 +1,147 @@
+enum Index {
+	one
+	two
+}
+
+fn direct(b byte) bool {
+	return true
+}
+
+fn access(b byte) bool {
+	return false
+}
+
+fn check_underscore(a []byte) {
+	_ = a[1]
+	direct(a[0])
+}
+
+fn check_fn(a []byte) {
+	access(a[2])
+	direct(a[2])
+	direct(a[1])
+}
+
+fn check_if_access(a []byte) {
+	access(a[3])
+	if a[3] == `0` {
+	}
+}
+
+fn check_if_fn_access(a []byte) {
+	access(a[4])
+	if direct(a[4]) {
+		direct(a[4])
+	}
+}
+
+fn check_if_test_in_branch(a []byte) {
+	if a[6] == `0` {
+		direct(a[5])
+		access(a[7])
+	}
+}
+
+fn check_if_fn_branch(a []byte) {
+	if access(a[8]) {
+		direct(a[7])
+	}
+}
+
+fn check_for_branch(a []byte) {
+	access(a[9])
+	for _ in 0 .. 1 {
+		access(a[10])
+	}
+	direct(a[9])
+	access(a[10])
+}
+
+fn check_assert(a []byte) {
+	assert a.len >= 19
+	direct(a[18])
+
+	assert 21 <= a.len
+	_ = a[20]
+}
+
+fn check_range_access(a []byte) {
+	access(a[23])
+	range := a[20..25]
+	direct(range[3])
+	access(range[4])
+	direct(range[4])
+}
+
+fn check_for(a []byte) {
+	for access(a[30]) == false {
+		direct(a[30])
+		access(a[31])
+		return
+	}
+}
+
+fn check_for_c_init_0(a []byte) {
+	for a[32] == 0 {
+		direct(a[32])
+		access(a[33])
+		return
+	}
+}
+
+fn check_for_c_init_1(a []byte) {
+	for access_it := a[34]; a[34] == 0; {
+		direct(a[34])
+		access(a[35])
+		return
+	}
+}
+
+// fn check_for_c_init_2(a []byte) {
+// 	mut run := true
+// 	for x := a[36]; a[36] == 0 && run; x = a[38] {
+// 		direct(a[36])
+// 		access(a[37])
+// 		run = false
+// 	}
+// 	direct(a[38])
+// }
+
+// fn skip_clone(a []byte) {
+// 	access(a[30])
+// 	fn_local := a.clone()
+// 	direct(fn_local[30])
+// }
+
+// fn skip_mut_self_assign(a []byte) {
+// 	mut fn_local := a.clone()
+// 	fn_local[31] = fn_local[32]
+// 	direct(fn_local[31])
+// }
+
+// fn skip_enum (a []byte) {
+// 	access(a[33])
+// 	direct(a[Index.two])
+// }
+
+fn main() {
+	a := []byte{len: 50}
+	direct(a[49])
+
+	check_underscore(a)
+	check_fn(a)
+	check_if_access(a)
+	check_if_fn_access(a)
+	check_if_test_in_branch(a)
+	check_if_fn_branch(a)
+	check_for_branch(a)
+	check_assert(a)
+	check_range_access(a)
+	check_for(a)
+	check_for_c_init_0(a)
+	check_for_c_init_1(a)
+	// check_for_c_init_2(a)
+	// skip_clone(a)
+	// skip_mut_self_assign(a)
+	// skip_enum (a)
+}


### PR DESCRIPTION
This PR removes boundary checks for array access when using integer literals such as is found in the binary module (and is common in Go).
```
[inline]
pub fn little_endian_u32(b []byte) u32 {
	_ = b[3] // bounds check
	return u32(b[0]) | (u32(b[1]) << u32(8)) | (u32(b[2]) << u32(16)) | (u32(b[3]) << u32(24))
}
```

The code is also analysing `assert` which may be a preferable way to perform the check, the following code may be considered more idiomatic:
```
[inline]
pub fn little_endian_u32(b []byte) u32 {
	assert b.len >= 4
	return u32(b[0]) | (u32(b[1]) << u32(8)) | (u32(b[2]) << u32(16)) | (u32(b[3]) << u32(24))
}
```

The AST tree is analysed during the transformer pass, where `IndexExpr` nodes are annotated with a new `is_direct` boolean, indicating that the array index can be safely generated, similarly to when the function is annotated with `[direct_array_access]`.

The c_gen code check was changed to handle this annotation. The following cases are considered valid for this optimisation:
1. the array was created with a `len` larger than the index requested
2. the array was previously accessed with a higher value which would have reported the issue already
3. the array is the result of a range (such as `a := b[0..5]`) and the offset was safe in the original array (any further access to the created array will not update maximum access to the parent)

Current limitations:
 * any function using break/continue or goto/label stopped from being optimised as soon as the relevant AST nodes are found as the code can not be ensured to be sequential
 * `enum` and `ident` indexes are not optimised (`enum` could probably be looked up)
 * the init and inc of for are not analysed (ATM)