### PR TITLE
js: JS.await support 

### DIFF
--- a/cmd/tools/vtest.v
+++ b/cmd/tools/vtest.v
@@ -114,6 +114,9 @@ fn should_test(path string, backend string) ShouldTestStatus {
 	if path.ends_with('_test.v') {
 		return .test
 	}
+	if path.ends_with('_test.js.v') {
+		return .test
+	}
 	if path.ends_with('.v') && path.count('.') == 2 {
 		if !path.all_before_last('.v').all_before_last('.').ends_with('_test') {
 			return .ignore

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -485,8 +485,9 @@ pub mut:
 	return_type_pos   token.Position // `string` in `fn (u User) name() string` position
 	has_return        bool
 	should_be_skipped bool
+	has_await         bool           // 'true' if this function uses JS.await
 	//
-	comments      []Comment      // comments *after* the header, but *before* `{`; used for InterfaceDecl
+	comments      []Comment // comments *after* the header, but *before* `{`; used for InterfaceDecl
 	next_comments []Comment // coments that are one line after the decl; used for InterfaceDecl
 	//
 	source_file &File = 0

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -321,6 +321,7 @@ pub fn gen(files []&ast.File, table &ast.Table, pref &pref.Preferences) string {
 	if g.pref.sourcemap {
 		out += g.create_sourcemap()
 	}
+
 	return out
 }
 
@@ -335,7 +336,7 @@ fn (g JsGen) create_sourcemap() string {
 
 pub fn (mut g JsGen) gen_js_main_for_tests() {
 	g.enter_namespace('main')
-	g.writeln('function js_main() {  ')
+	g.writeln('async function js_main() {  ')
 	g.inc_indent()
 	all_tfuncs := g.get_all_test_function_names()
 
@@ -351,7 +352,7 @@ pub fn (mut g JsGen) gen_js_main_for_tests() {
 			g.writeln('main__BenchedTests_testing_step_start(bt,new string("$tcname"))')
 		}
 
-		g.writeln('try { ${tcname}(); } catch (_e) {} ')
+		g.writeln('try { let res = ${tcname}(); if (res instanceof Promise) { await res; } } catch (_e) {} ')
 		if g.pref.is_stats {
 			g.writeln('main__BenchedTests_testing_step_end(bt);')
 		}


### PR DESCRIPTION
This PR adds initial support for JS.await. The next step is to add support for using It together with the `go` expr and add tests for JS promises and `go` expressions.