### PR TITLE
openssl: use pkgconfig instead of hardcoded path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,7 @@ jobs:
     timeout-minutes: 121
     env:
       VFLAGS: -cc clang
+      PKG_CONFIG_PATH="/usr/local/opt/openssl@3/lib/pkgconfig"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -271,6 +272,7 @@ jobs:
           brew uninstall --ignore-dependencies libpq ## libpq is a dependency of PHP
           brew install postgresql openssl
           export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/openssl/lib/"
+          echo "PKG_CONFIG_PATH is '$PKG_CONFIG_PATH'"
       - name: Build V
         run: make -j4 && ./v -cg -cstrict -o v cmd/v
       - name: Run sanitizers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,7 @@ jobs:
     timeout-minutes: 121
     env:
       VFLAGS: -cc clang
-      PKG_CONFIG_PATH="/usr/local/opt/openssl@3/lib/pkgconfig"
+      PKG_CONFIG_PATH: /usr/local/opt/openssl@3/lib/pkgconfig
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/vlib/net/openssl/c.v
+++ b/vlib/net/openssl/c.v
@@ -5,7 +5,8 @@ module openssl
 // openssl from libssl-dev. If there is no local openssl,
 // the next flag is harmless, since it will still use the
 // (older) system openssl.
-#flag linux -I/usr/local/include/openssl -L/usr/local/lib
+#pkgconfig openssl
+#flag linux -L/usr/local/lib
 #flag windows -l libssl -l libcrypto
 #flag -lssl -lcrypto
 #flag linux -ldl -lpthread


### PR DESCRIPTION
my openssl wasn't installed in this directory, thus didn't work. we should use #pkgconfig to find it instead