### PR TITLE
cgen: fix comptime for_in methods call (fix #12621)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3003,6 +3003,10 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 							left.obj.typ = var_type
 						}
 					}
+				} else if val is ast.ComptimeCall {
+					key_str := '${val.method_name}.return_type'
+					var_type = g.comptime_var_type_map[key_str] or { var_type }
+					left.obj.typ = var_type
 				}
 				is_auto_heap = left.obj.is_auto_heap
 			}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1146,12 +1146,12 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 	// g.generate_tmp_autofree_arg_vars(node, name)
 	// Handle `print(x)`
 	mut print_auto_str := false
-	if is_print && node.args[0].typ != ast.string_type { // && !free_tmp_arg_vars {
+	if is_print && (node.args[0].typ != ast.string_type || g.comptime_for_method.len > 0) { // && !free_tmp_arg_vars {
 		mut typ := node.args[0].typ
 		if typ == 0 {
 			g.checker_bug('print arg.typ is 0', node.pos)
 		}
-		if typ != ast.string_type {
+		if typ != ast.string_type || g.comptime_for_method.len > 0 {
 			expr := node.args[0].expr
 			typ_sym := g.table.get_type_symbol(typ)
 			if typ_sym.kind == .interface_ && (typ_sym.info as ast.Interface).defines_method('str') {

--- a/vlib/v/tests/comptime_for_method_call_test.v
+++ b/vlib/v/tests/comptime_for_method_call_test.v
@@ -1,0 +1,23 @@
+struct Foo {}
+
+fn (f Foo) a() int {
+	return 1
+}
+
+fn (f Foo) b() int {
+	return 2
+}
+
+fn test_comptime_for_method_call() {
+	f := Foo{}
+	mut rets := []string{}
+
+	$for method in Foo.methods {
+		x := f.$method()
+		println(x)
+		rets << x.str()
+	}
+	assert rets.len == 2
+	assert rets[0] == '1'
+	assert rets[1] == '2'
+}


### PR DESCRIPTION
This PR fix comptime for_in methods call (fix #12621).

- Fix comptime for_in methods call.
- Add test.

```vlang
struct Foo {}

fn (f Foo) a() int {
	return 1
}

fn (f Foo) b() int {
	return 2
}

fn main() {
	f := Foo{}
	mut rets := []string{}

	$for method in Foo.methods {
		x := f.$method()
		println(x)
		rets << x.str()
	}
	assert rets.len == 2
	assert rets[0] == '1'
	assert rets[1] == '2'
}

PS D:\Test\v\tt1> v run .
1
2
```