### PR TITLE
vweb: add json_pretty method

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -244,6 +244,7 @@ pub fn (mut ctx Context) json<T>(j T) Result {
 	return Result{}
 }
 
+// Response HTTP_OK with a pretty-printed JSON result
 pub fn (mut ctx Context) json_pretty<T>(j T) Result {
 	json_s := json.encode_pretty(j)
 	ctx.send_response_to_client('application/json', json_s)

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -244,6 +244,12 @@ pub fn (mut ctx Context) json<T>(j T) Result {
 	return Result{}
 }
 
+pub fn (mut ctx Context) json_pretty<T>(j T) Result {
+	json_s := json.encode_pretty(j)
+	ctx.send_response_to_client('application/json', json_s)
+	return Result{}
+}
+
 // Response HTTP_OK with file as payload
 pub fn (mut ctx Context) file(f_path string) Result {
 	ext := os.file_ext(f_path)

--- a/vlib/vweb/vweb_app_test.v
+++ b/vlib/vweb/vweb_app_test.v
@@ -64,3 +64,15 @@ pub fn (mut app App) new_article() vweb.Result {
 fn (mut app App) time() {
 	app.text(time.now().format())
 }
+
+fn (mut app App) time_json() {
+	app.json({
+		'time': time.now().format()
+	})
+}
+
+fn (mut app App) time_json_pretty() {
+	app.json_pretty({
+		'time': time.now().format()
+	})
+}


### PR DESCRIPTION
Small change to add the `json_pretty()` method to vweb.

If you want to return a pretty-printed JSON response from an endpoint, this allows for a slightly nicer syntax:

Before:
```v
	res := json.encode_pretty(&MyStruct{
		foo: 'some value'
	})

	s.set_content_type(vweb.mime_types['.json'])
	return s.ok(res)
```
After:
```v
	return s.json_pretty(&MyStruct{
		foo: 'some value'
	})
```