### PR TITLE
cgen: fix comptime for_in methods call using str_intp

### DIFF
--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -126,7 +126,7 @@ fn (mut g Gen) str_val(node ast.StringInterLiteral, i int) {
 
 	typ := g.unwrap_generic(node.expr_types[i])
 	typ_sym := g.table.get_type_symbol(typ)
-	if typ == ast.string_type {
+	if typ == ast.string_type && g.comptime_for_method.len == 0 {
 		if g.inside_vweb_tmpl {
 			g.write('vweb__filter(')
 			if expr.is_auto_deref_var() {
@@ -153,7 +153,7 @@ fn (mut g Gen) str_val(node ast.StringInterLiteral, i int) {
 		mut exp_typ := typ
 		if expr is ast.Ident {
 			if expr.obj is ast.Var {
-				if g.comptime_var_type_map.len > 0 {
+				if g.comptime_var_type_map.len > 0 || g.comptime_for_method.len > 0 {
 					exp_typ = expr.obj.typ
 				} else if expr.obj.smartcasts.len > 0 {
 					cast_sym := g.table.get_type_symbol(expr.obj.smartcasts.last())

--- a/vlib/v/tests/comptime_for_method_call_test.v
+++ b/vlib/v/tests/comptime_for_method_call_test.v
@@ -14,10 +14,17 @@ fn test_comptime_for_method_call() {
 
 	$for method in Foo.methods {
 		x := f.$method()
+
 		println(x)
+		println(x.str())
+		println('$x')
+
 		rets << x.str()
+		rets << '$x'
 	}
-	assert rets.len == 2
+	assert rets.len == 4
 	assert rets[0] == '1'
-	assert rets[1] == '2'
+	assert rets[1] == '1'
+	assert rets[2] == '2'
+	assert rets[3] == '2'
 }


### PR DESCRIPTION
This PR fix comptime for_in methods call using str_intp.

- Fix comptime for_in methods call using str_intp.
- Add test.

```vlang
struct Foo {}

fn (f Foo) a() int {
	return 1
}

fn (f Foo) b() int {
	return 2
}

fn main() {
	f := Foo{}
	mut rets := []string{}

	$for method in Foo.methods {
		x := f.$method()
		
		println(x)
		println(x.str())
		println('$x')

		rets << x.str()
		rets << '$x'
	}
	assert rets.len == 4
	assert rets[0] == '1'
	assert rets[1] == '1'
	assert rets[2] == '2'
	assert rets[3] == '2'
}

PS D:\Test\v\tt1> v run .
1
1
1
2
2
2
```