### PR TITLE
parser: fix $tmpl(absolute path) error (fix #12727)

### DIFF
--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -161,7 +161,11 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 	path += '.html'
 	path = os.real_path(path)
 	if !is_html {
-		path = os.join_path_single(dir, tmpl_path)
+		if os.is_abs_path(tmpl_path) {
+			path = tmpl_path
+		} else {
+			path = os.join_path_single(dir, tmpl_path)
+		}
 	}
 	if !os.exists(path) {
 		if is_html {


### PR DESCRIPTION
This PR fix $tmpl(absolute path) error (fix #12727).

- Fix $tmpl(absolute path) error.

```vlang
fn main() {
	name := 'V'
	res := $tmpl('d:/test/1.txt')
	println(res)
}

PS D:\Test\v\tt1> v run .
V
```

1.txt
```vlang
@name
```