### PR TITLE
v.parser: support bool values in attributes

### DIFF
--- a/vlib/v/ast/attr.v
+++ b/vlib/v/ast/attr.v
@@ -9,6 +9,7 @@ pub enum AttrKind {
 	plain // [name]
 	string // ['name']
 	number // [123]
+	bool // [true] || [false]
 	comptime_define // [if name]
 }
 
@@ -41,7 +42,7 @@ pub fn (a Attr) str() string {
 		a.name
 	}
 	s += match a.kind {
-		.plain, .number { arg }
+		.plain, .number, .bool { arg }
 		.string { "'$arg'" }
 		.comptime_define { 'if $arg' }
 	}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1596,17 +1596,20 @@ fn (mut p Parser) parse_attr() ast.Attr {
 		if p.tok.kind == .colon {
 			has_arg = true
 			p.next()
-			// `name: arg`
-			if p.tok.kind == .name {
+			if p.tok.kind == .name { // `name: arg`
 				kind = .plain
 				arg = p.check_name()
-			} else if p.tok.kind == .number {
+			} else if p.tok.kind == .number { // `name: 123`
 				kind = .number
 				arg = p.tok.lit
 				p.next()
 			} else if p.tok.kind == .string { // `name: 'arg'`
 				kind = .string
 				arg = p.tok.lit
+				p.next()
+			} else if p.tok.kind == .key_true || p.tok.kind == .key_false { // `name: true`
+				kind = .bool
+				arg = p.tok.kind.str()
 				p.next()
 			} else {
 				p.error('unexpected $p.tok, an argument is expected after `:`')

--- a/vlib/v/tests/attribute_test.v
+++ b/vlib/v/tests/attribute_test.v
@@ -10,6 +10,12 @@ pub struct PubStructAttrTest {
 	bar int
 }
 
+struct StructFieldAttrTest {
+	foo string [attr: bar; attr0; attr1: 'foo']
+	bar int    [attr0: 123; attr1: true; attr2: false]
+	baz bool   [prefix.attr0] = false
+}
+
 [testing]
 enum EnumAttrTest {
 	one


### PR DESCRIPTION
Support boolean values in attributes
```v
struct Test {
  foo string [attr0: true; attr1: false]
}
```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
