### PR TITLE
cgen:ensure that the different gdi32 notations are always matched

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1612,7 +1612,7 @@ fn (mut g Gen) is_gui_app() bool {
 			return false
 		}
 		for cf in g.table.cflags {
-			if cf.value == 'gdi32' {
+			if cf.value.to_lower() == 'gdi32' {
 				return true
 			}
 		}


### PR DESCRIPTION
Windows allows to link as gdi32, Gdi32, GDI32 ... using lowercase always ensures it matches always.
