### PR TITLE
fmt: fix bug that add unnecessary module name to generic type.

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1054,16 +1054,15 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 		}
 		.generic_inst {
 			info := sym.info as GenericInst
-			res = sym.name.all_before('<')
+			res = t.shorten_user_defined_typenames(sym.name.all_before('<'), import_aliases)
 			res += '<'
 			for i, ctyp in info.concrete_types {
-				res += t.get_type_symbol(ctyp).name
+				res += t.type_to_str_using_aliases(ctyp, import_aliases)
 				if i != info.concrete_types.len - 1 {
 					res += ', '
 				}
 			}
 			res += '>'
-			res = t.shorten_user_defined_typenames(res, import_aliases)
 		}
 		.void {
 			if typ.has_flag(.optional) {

--- a/vlib/v/fmt/tests/generics_keep.vv
+++ b/vlib/v/fmt/tests/generics_keep.vv
@@ -1,4 +1,4 @@
-import mymod { ImpNode }
+import mymod { Data, ImpNode }
 
 fn foobar_mymod<U>(inode ImpNode<U>) ImpNode<U> {
 	return ImpNode{}
@@ -14,7 +14,9 @@ fn (_ Foo) simple<T>() T {
 	return T{}
 }
 
-struct GenericStruct<A, B> {}
+struct GenericStruct<A, B> {
+	v Data<Data<A>, B>
+}
 
 fn proper_generics(gs GenericStruct<A, B>) GenericStruct<A, B> {
 	return gs

--- a/vlib/v/tests/generics_test.v
+++ b/vlib/v/tests/generics_test.v
@@ -573,7 +573,7 @@ fn test_generic_detection() {
 	})
 
 	// this final case challenges your scanner :-)
-	assert boring_function<TandU<TandU<int,MultiLevel<Empty_>>, map[string][]int>>(TandU<TandU<int,MultiLevel<Empty_>>, map[string][]int>{
+	assert boring_function<TandU<TandU<int, MultiLevel<Empty_>>, map[string][]int>>(TandU<TandU<int,MultiLevel<Empty_>>, map[string][]int>{
 		t: TandU<int,MultiLevel<Empty_>>{
 			t: 20
 			u: MultiLevel<Empty_>{


### PR DESCRIPTION
fix below behavior

```
$ v fmt vlib/v/fmt/tests/generics_keep.vv
import mymod { Data, ImpNode }

fn foobar_mymod<U>(inode ImpNode<U>) ImpNode<U> {
        return ImpNode{}
}

fn simple<T>() T {
        return T{}
}

struct Foo {}

fn (_ Foo) simple<T>() T {
        return T{}
}

struct GenericStruct<A, B> {
        v mymod.Data<mymod.Data<A>, B>
}

fn proper_generics(gs GenericStruct<A, B>) GenericStruct<A, B> {
        return gs
}

fn main() {
        simple<int>()
        Foo{}.simple<int>()
}

```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
