### PR TITLE
checker: fix const type with raw string literal (fix #12604)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -8729,7 +8729,7 @@ fn (mut c Checker) eval_comptime_const_expr(expr ast.Expr, nlevel int) ?ast.Comp
 			return expr.val.i64()
 		}
 		ast.StringLiteral {
-			return expr.val
+			return util.smart_quote(expr.val, expr.is_raw)
 		}
 		ast.CharLiteral {
 			runes := expr.val.runes()

--- a/vlib/v/tests/const_many_pluses_with_raw_string_literal_test.v
+++ b/vlib/v/tests/const_many_pluses_with_raw_string_literal_test.v
@@ -1,0 +1,29 @@
+const ca = r'x\n'
+
+const cb = 'x\n'
+
+const cc = ca + cb
+
+const cd = cc + cc
+
+const ce = cd + cd
+
+fn test_many_pluses_with_raw_string_literal() {
+	a := r'x\n'
+	assert a == ca
+	b := 'x\n'
+	assert b == cb
+	c := a + b
+	assert c == cc
+	d := c + c
+	assert d == cd
+	e := d + d
+	assert e == ce
+	println(e)
+	result := r'x\nx
+x\nx
+x\nx
+x\nx
+'
+	assert e == result
+}


### PR DESCRIPTION
This PR fix const type with raw string literal (fix #12604).

- Fix const type with raw string literal.
- Add test.

```vlang
const ca = r'x\n'

const cb = 'x\n'

const cc = ca + cb

const cd = cc + cc

const ce = cd + cd

fn main() {
	a := r'x\n'
	assert a == ca
	b := 'x\n'
	assert b == cb
	c := a + b
	assert c == cc
	d := c + c
	assert d == cd
	e := d + d
	assert e == ce
	println(e)
	result := r'x\nx
x\nx
x\nx
x\nx
'
	assert e == result
}

PS D:\Test\v\tt1> v run .
x\nx
x\nx
x\nx
x\nx

```