### PR TITLE
readline: fix bug that full-width spaces is treated as eof

### DIFF
--- a/vlib/readline/readline_linux.c.v
+++ b/vlib/readline/readline_linux.c.v
@@ -200,6 +200,9 @@ pub fn read_line(prompt string) ?string {
 
 // analyse returns an `Action` based on the type of input byte given in `c`.
 fn (r Readline) analyse(c int) Action {
+	if c > 255 {
+		return Action.insert_character
+	}
 	match byte(c) {
 		`\0`, 0x3, 0x4, 255 {
 			return .eof

--- a/vlib/v/tests/repl/println.repl
+++ b/vlib/v/tests/repl/println.repl
@@ -1,3 +1,3 @@
-println('Hello, world! | Привет, мир! | 你好世界')
+println('Hello, world! | Привет, мир! | 你好世界 ｜　こんにちは、世界。')
 ===output===
-Hello, world! | Привет, мир! | 你好世界
+Hello, world! | Привет, мир! | 你好世界 ｜　こんにちは、世界。


### PR DESCRIPTION
Japanese IME has full-width mode. When I pressed the space key in full-width mode, vrepl terminated.

Readline converts int to byte in some places. Full-width space is '0x3000'. So it will be converted to '0x00'. 
Therefore, if a full-width space is entered, readline will treat it as an eof.

This PR fix that bug.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
