### PR TITLE
ast, parser, checker: fix generic fn in builtin module (fix #12760)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1153,8 +1153,12 @@ pub fn (t &Table) mktyp(typ Type) Type {
 	}
 }
 
+pub fn (mut t Table) register_fn_generic_types(fn_name string) {
+	t.fn_generic_types[fn_name] = [][]Type{}
+}
+
 pub fn (mut t Table) register_fn_concrete_types(fn_name string, types []Type) bool {
-	mut a := t.fn_generic_types[fn_name]
+	mut a := t.fn_generic_types[fn_name] or { return false }
 	if types in a {
 		return false
 	}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -40,14 +40,6 @@ pub fn (mut p Parser) call_expr(language ast.Language, mod string) ast.CallExpr 
 		p.expr_mod = ''
 		concrete_types = p.parse_concrete_types()
 		concrete_list_pos = concrete_list_pos.extend(p.prev_tok.position())
-		// In case of `foo<T>()`
-		// T is unwrapped and registered in the checker.
-		full_generic_fn_name := if fn_name.contains('.') { fn_name } else { p.prepend_mod(fn_name) }
-		has_generic := concrete_types.any(it.has_flag(.generic))
-		if !has_generic {
-			// will be added in checker
-			p.table.register_fn_concrete_types(full_generic_fn_name, concrete_types)
-		}
 	}
 	p.check(.lpar)
 	args := p.call_args()
@@ -527,6 +519,9 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		is_builtin: p.builtin_mod || p.mod in util.builtin_module_parts
 		scope: p.scope
 		label_names: p.label_names
+	}
+	if generic_names.len > 0 {
+		p.table.register_fn_generic_types(name)
 	}
 	p.label_names = []
 	p.close_scope()


### PR DESCRIPTION
This PR fix generic fn in builtin module (fix #12760).

- Fix generic fn in builtin module.
- Add `table.register_fn_generic_types()` to register generic fn informations.
- `register_fn_concrete_types()` process in checker phase.
- Testing locally.

builtin.v
```vlang
pub struct Foo<T> {
	x T 
}

pub fn foo<T>(x T) Foo<T> {
	return Foo<T>{x}
}
```
tt1.v
```vlang
fn main() {
	foo<int>(42)
}

PS D:\Test\v\tt1> v run .
```