### PR TITLE
checker: fix notice of eval.infix.v on windows

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -245,6 +245,10 @@ pub fn (mut c Checker) check_matching_function_symbols(got_type_sym &ast.TypeSym
 	return true
 }
 
+// TODO: remove this exception, by using a more general mechanism for opting out
+// generated code, from warnings/notices, that are targeted at humans:
+const infix_v_exception = os.join_path('vlib', 'v', 'eval', 'infix.v')
+
 fn (mut c Checker) check_shift(mut node ast.InfixExpr, left_type ast.Type, right_type ast.Type) ast.Type {
 	if !left_type.is_int() {
 		left_sym := c.table.get_type_symbol(left_type)
@@ -304,7 +308,7 @@ fn (mut c Checker) check_shift(mut node ast.InfixExpr, left_type ast.Type, right
 			left_sym_final := c.table.get_final_type_symbol(left_type)
 			left_type_final := ast.Type(left_sym_final.idx)
 			if node.op == .left_shift && left_type_final.is_signed() && !(c.inside_unsafe
-				&& c.file.path.contains(os.join_path('vlib', 'v', 'eval', 'infix.v'))) {
+				&& c.file.path.ends_with(checker.infix_v_exception)) {
 				c.note('shifting a value from a signed type `$left_sym_final.name` can change the sign',
 					node.left.position())
 			}

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -5,6 +5,7 @@ module checker
 
 import v.ast
 import v.token
+import os
 
 // TODO: promote(), check_types(), symmetric_check() and check() overlap - should be rearranged
 pub fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
@@ -302,7 +303,8 @@ fn (mut c Checker) check_shift(mut node ast.InfixExpr, left_type ast.Type, right
 			// a negative value, the resulting value is implementation-defined (ID).
 			left_sym_final := c.table.get_final_type_symbol(left_type)
 			left_type_final := ast.Type(left_sym_final.idx)
-			if node.op == .left_shift && left_type_final.is_signed() && !c.inside_unsafe {
+			if node.op == .left_shift && left_type_final.is_signed() && !(c.inside_unsafe
+				&& c.file.path.contains(os.join_path('vlib', 'v', 'eval', 'infix.v'))) {
 				c.note('shifting a value from a signed type `$left_sym_final.name` can change the sign',
 					node.left.position())
 			}

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -302,8 +302,7 @@ fn (mut c Checker) check_shift(mut node ast.InfixExpr, left_type ast.Type, right
 			// a negative value, the resulting value is implementation-defined (ID).
 			left_sym_final := c.table.get_final_type_symbol(left_type)
 			left_type_final := ast.Type(left_sym_final.idx)
-			if node.op == .left_shift && left_type_final.is_signed() && !(c.inside_unsafe
-				&& c.file.path.contains('vlib/v/eval/infix.v')) {
+			if node.op == .left_shift && left_type_final.is_signed() && !c.inside_unsafe {
 				c.note('shifting a value from a signed type `$left_sym_final.name` can change the sign',
 					node.left.position())
 			}


### PR DESCRIPTION
This PR fix notice of eval.infix.v on windows.

before notice:
```vlang
......
vlib\v\eval\infix.v:2177:21: notice: shifting a value from a signed type `i64` can change the sign
 2175 |                             } else if expecting == ast.int_literal_type_idx {
 2176 |                                 unsafe {
 2177 |                                     return i64(i64(left) << i64(right.val))
      |                                                ~~~~~~~~~
 2178 |                                 }
 2179 |                             } else {
vlib\v\eval\infix.v:2190:21: notice: shifting a value from a signed type `i64` can change the sign
 2188 |                             } else if expecting == ast.int_literal_type_idx {
 2189 |                                 unsafe {
 2190 |                                     return i64(i64(left) << i64(right))
      |                                                ~~~~~~~~~
 2191 |                                 }
 2192 |                             } else {
vlib\v\eval\infix.v:2190:21: notice: shifting a value from a signed type `i64` can change the sign
 2188 |                             } else if expecting == ast.int_literal_type_idx {
 2189 |                                 unsafe {
 2190 |                                     return i64(i64(left) << i64(right))
      |                                                ~~~~~~~~~
 2191 |                                 }
 2192 |                             } else {
V built successfully!
```