### PR TITLE
ast, checker, cgen: fix interface method with struct embed (fix #12771)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -412,6 +412,18 @@ pub fn (t &Table) find_method_from_embeds(sym &TypeSymbol, method_name string) ?
 	return none
 }
 
+// find_method_with_embeds searches for a given method, also looking through embedded fields
+pub fn (t &Table) find_method_with_embeds(sym &TypeSymbol, method_name string) ?Fn {
+	if func := t.find_method(sym, method_name) {
+		return func
+	} else {
+		// look for embedded field
+		first_err := err
+		func, _ := t.find_method_from_embeds(sym, method_name) or { return first_err }
+		return func
+	}
+}
+
 fn (t &Table) register_aggregate_field(mut sym TypeSymbol, name string) ?StructField {
 	if sym.kind != .aggregate {
 		t.panic('Unexpected type symbol: $sym.kind')

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3222,7 +3222,7 @@ fn (mut c Checker) type_implements(typ ast.Type, interface_type ast.Type, pos to
 	if utyp != ast.voidptr_type {
 		// Verify methods
 		for imethod in imethods {
-			method := typ_sym.find_method(imethod.name) or {
+			method := c.table.find_method_with_embeds(typ_sym, imethod.name) or {
 				typ_sym.find_method_with_generic_parent(imethod.name) or {
 					c.error("`$styp` doesn't implement method `$imethod.name` of interface `$inter_sym.name`",
 						pos)

--- a/vlib/v/tests/interface_method_with_struct_embed_test.v
+++ b/vlib/v/tests/interface_method_with_struct_embed_test.v
@@ -1,0 +1,35 @@
+struct Foo {
+	x int
+}
+
+fn (f Foo) get() int {
+	return f.x
+}
+
+struct Bar {
+	Foo
+}
+
+interface Getter {
+	get() int
+}
+
+fn test_interface_method_with_struct_embed() {
+	mut getter := []Getter{}
+
+	foo := Foo{22}
+	getter << foo
+
+	bar := Bar{Foo{11}}
+	getter << bar
+
+	assert getter.len == 2
+
+	println(foo)
+	println(getter[0])
+	assert getter[0].get() == 22
+
+	println(bar)
+	println(getter[1])
+	assert getter[1].get() == 11
+}


### PR DESCRIPTION
This PR fix interface method with struct embed (fix #12771).

- Fix interface method with struct embed.
- Add test.

```vlang
struct Foo {
	x int
}

fn (f Foo) get() int {
	return f.x
}

struct Bar {
	Foo
}

interface Getter {
	get() int
}

fn main() {
	mut getter := []Getter{}

	foo := Foo{22}
	getter << foo

	bar := Bar{Foo{11}}
	getter << bar

	assert getter.len == 2

	println(foo)
	println(getter[0])
	assert getter[0].get() == 22

	println(bar)
	println(getter[1])
	assert getter[1].get() == 11
}

PS D:\Test\v\tt1> v run .
Foo{
    x: 22
}
Getter(Foo{
    x: 22
})
Bar{
    Foo: Foo{
        x: 11
    }
}
Getter(Bar{
    Foo: Foo{
        x: 11
    }
})
```