### PR TITLE
builtin: cleanup array.v

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -510,6 +510,31 @@ pub fn (a &array) free() {
 	unsafe { free(mblock_ptr) }
 }
 
+// filter creates a new array with all elements that pass the test implemented by the provided function
+pub fn (a array) filter(predicate fn (voidptr) bool) array
+
+// any tests whether at least one element in the array passes the test implemented by the
+// provided function. It returns true if, in the array, it finds an element for which the provided
+// function returns true; otherwise it returns false. It doesn't modify the array
+pub fn (a array) any(predicate fn (voidptr) bool) bool
+
+// all tests whether all elements in the array pass the test implemented by the provided function
+pub fn (a array) all(predicate fn (voidptr) bool) bool
+
+// map creates a new array populated with the results of calling a provided function
+// on every element in the calling array
+pub fn (a array) map(callback fn (voidptr) voidptr) array
+
+// sort sorts an array in place in ascending order.
+pub fn (mut a array) sort(callback fn (voidptr, voidptr) int)
+
+// contains determines whether an array includes a certain value among its entries
+pub fn (a array) contains(val voidptr) bool
+
+// index returns the first index at which a given element can be found in the array
+// or -1 if the value is not found.
+pub fn (a array) index(value voidptr) int
+
 [unsafe]
 pub fn (mut a []string) free() {
 	$if prealloc {

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -510,43 +510,6 @@ pub fn (a &array) free() {
 	unsafe { free(mblock_ptr) }
 }
 
-// filter creates a new array with all elements that pass the test implemented by the provided function
-pub fn (a array) filter(predicate fn (voidptr) bool) array
-
-struct ZZZTmp1 {}
-
-// any tests whether at least one element in the array passes the test implemented by the
-// provided function. It returns true if, in the array, it finds an element for which the provided
-// function returns true; otherwise it returns false. It doesn't modify the array
-pub fn (a array) any(predicate fn (voidptr) bool) bool
-
-struct ZZZTmp2 {}
-
-// all tests whether all elements in the array pass the test implemented by the provided function
-pub fn (a array) all(predicate fn (voidptr) bool) bool
-
-struct ZZZTmp3 {}
-
-// map creates a new array populated with the results of calling a provided function
-// on every element in the calling array
-pub fn (a array) map(callback fn (voidptr) voidptr) array
-
-struct ZZZTmp4 {}
-
-// sort sorts an array in place in ascending order.
-pub fn (mut a array) sort(callback fn (voidptr, voidptr) int)
-
-struct ZZZTmp5 {}
-
-// contains determines whether an array includes a certain value among its entries
-pub fn (a array) contains(val voidptr) bool
-
-struct ZZZTmp6 {}
-
-// index returns the first index at which a given element can be found in the array
-// or -1 if the value is not found.
-pub fn (a array) index(value voidptr) int
-
 [unsafe]
 pub fn (mut a []string) free() {
 	$if prealloc {


### PR DESCRIPTION
This PR cleanup array.v in builtin module.

- Remove obsolete code that is not used. (Not sure if it has other uses)

```vlang
// filter creates a new array with all elements that pass the test implemented by the provided function
pub fn (a array) filter(predicate fn (voidptr) bool) array

struct ZZZTmp1 {}

// any tests whether at least one element in the array passes the test implemented by the
// provided function. It returns true if, in the array, it finds an element for which the provided
// function returns true; otherwise it returns false. It doesn't modify the array
pub fn (a array) any(predicate fn (voidptr) bool) bool

struct ZZZTmp2 {}

// all tests whether all elements in the array pass the test implemented by the provided function
pub fn (a array) all(predicate fn (voidptr) bool) bool

struct ZZZTmp3 {}

// map creates a new array populated with the results of calling a provided function
// on every element in the calling array
pub fn (a array) map(callback fn (voidptr) voidptr) array

struct ZZZTmp4 {}

// sort sorts an array in place in ascending order.
pub fn (mut a array) sort(callback fn (voidptr, voidptr) int)

struct ZZZTmp5 {}

// contains determines whether an array includes a certain value among its entries
pub fn (a array) contains(val voidptr) bool

struct ZZZTmp6 {}

// index returns the first index at which a given element can be found in the array
// or -1 if the value is not found.
pub fn (a array) index(value voidptr) int
```