### PR TITLE
cgen: fix multiple embed struct init (fix #12786)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6020,8 +6020,8 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 						&& it.name in embed_field_names)
 					used_embed_fields << fields_to_embed.map(it.name)
 					default_init := ast.StructInit{
+						...struct_init
 						typ: embed
-						fields: fields_to_embed
 					}
 					g.write('.$embed_name = ')
 					g.struct_init(default_init)

--- a/vlib/v/tests/multiple_embed_struct_init_test.v
+++ b/vlib/v/tests/multiple_embed_struct_init_test.v
@@ -1,0 +1,31 @@
+pub struct Boundary {
+mut:
+	x        int
+	y        int
+	offset_x int
+	offset_y int
+	width    int
+	height   int
+}
+
+pub struct WidgetBase {
+	Boundary
+mut:
+	id      string
+	z_index int
+	hidden  bool
+}
+
+pub struct Label {
+	WidgetBase
+}
+
+fn test_multiple_embed_struct_init() {
+	l := Label{
+		x: 100
+		y: 200
+	}
+	println(l)
+	assert l.x == 100
+	assert l.y == 200
+}


### PR DESCRIPTION
This PR fix multiple nested embed struct init (fix #12786).

- Fix multiple nested embed struct init.
- Add test.

```vlang
pub struct Boundary {
mut:
	x        int
	y        int
	offset_x int
	offset_y int
	width    int
	height   int
}

pub struct WidgetBase {
	Boundary
mut:
	id      string
	z_index int
	hidden  bool
}

pub struct Label {
	WidgetBase
}

fn main() {
	l := Label{
		x: 100
		y: 200
	}
	println(l)
	assert l.x == 100
	assert l.y == 200
}

PS D:\Test\v\tt1> v run .
Label{
    WidgetBase: WidgetBase{
        Boundary: Boundary{
            x: 100
            y: 200
            offset_x: 0
            offset_y: 0
            width: 0
            height: 0
        }
        id: ''
        z_index: 0
        hidden: false
    }
}
```