### PR TITLE
fmt: fix embedfile compression

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1700,7 +1700,11 @@ pub fn (mut f Fmt) comptime_call(node ast.ComptimeCall) {
 		}
 	} else {
 		if node.is_embed {
-			f.write("\$embed_file('$node.embed_file.rpath')")
+			if node.embed_file.compression_type == 'none' {
+				f.write("\$embed_file('$node.embed_file.rpath')")
+			} else {
+				f.write("\$embed_file('$node.embed_file.rpath', .$node.embed_file.compression_type)")
+			}
 		} else if node.is_env {
 			f.write("\$env('$node.args_var')")
 		} else if node.is_pkgconfig {

--- a/vlib/v/fmt/tests/embed_file_keep.vv
+++ b/vlib/v/fmt/tests/embed_file_keep.vv
@@ -5,4 +5,5 @@ fn main() {
 	eprintln('content: ${ptr_str(content)}')
 	eprintln(unsafe { the_png.data().vbytes(the_png.len) }.hex())
 	println(the_png)
+	the_other_png := $embed_file('v.png', .zlib)
 }


### PR DESCRIPTION
v fmt removes the compression type from `$embed_file`.

```diff
- the_other_png := $embed_file('v.png', .zlib)
+ the_other_png := $embed_file('v.png')
```
