### PR TITLE
maths: rename small to small_ to prevent C errors

### DIFF
--- a/vlib/math/erf.v
+++ b/vlib/math/erf.v
@@ -164,7 +164,7 @@ const (
 pub fn erf(a f64) f64 {
 	mut x := a
 	very_tiny := 2.848094538889218e-306 // 0x0080000000000000
-	_small := 1.0 / f64(u64(1) << 28) // 2**-28
+	small_ := 1.0 / f64(u64(1) << 28) // 2**-28
 	if is_nan(x) {
 		return nan()
 	}
@@ -181,7 +181,7 @@ pub fn erf(a f64) f64 {
 	}
 	if x < 0.84375 { // |x| < 0.84375
 		mut temp := 0.0
-		if x < _small { // |x| < 2**-28
+		if x < small_ { // |x| < 2**-28
 			if x < very_tiny {
 				temp = 0.125 * (8.0 * x + math.efx8 * x) // avoid underflow
 			} else {

--- a/vlib/math/erf.v
+++ b/vlib/math/erf.v
@@ -164,7 +164,7 @@ const (
 pub fn erf(a f64) f64 {
 	mut x := a
 	very_tiny := 2.848094538889218e-306 // 0x0080000000000000
-	small := 1.0 / f64(u64(1) << 28) // 2**-28
+	_small := 1.0 / f64(u64(1) << 28) // 2**-28
 	if is_nan(x) {
 		return nan()
 	}
@@ -181,7 +181,7 @@ pub fn erf(a f64) f64 {
 	}
 	if x < 0.84375 { // |x| < 0.84375
 		mut temp := 0.0
-		if x < small { // |x| < 2**-28
+		if x < _small { // |x| < 2**-28
 			if x < very_tiny {
 				temp = 0.125 * (8.0 * x + math.efx8 * x) // avoid underflow
 			} else {

--- a/vlib/math/gamma.v
+++ b/vlib/math/gamma.v
@@ -93,7 +93,7 @@ pub fn gamma(a f64) f64 {
 	for x < 0 {
 		if x > -1e-09 {
 			unsafe {
-				goto _small
+				goto small_
 			}
 		}
 		z = z / x
@@ -102,7 +102,7 @@ pub fn gamma(a f64) f64 {
 	for x < 2 {
 		if x < 1e-09 {
 			unsafe {
-				goto _small
+				goto small_
 			}
 		}
 		z = z / x
@@ -119,7 +119,7 @@ pub fn gamma(a f64) f64 {
 	if true {
 		return z * p / q
 	}
-	_small:
+	small_:
 	if x == 0 {
 		return inf(1)
 	}

--- a/vlib/math/gamma.v
+++ b/vlib/math/gamma.v
@@ -93,7 +93,7 @@ pub fn gamma(a f64) f64 {
 	for x < 0 {
 		if x > -1e-09 {
 			unsafe {
-				goto small
+				goto _small
 			}
 		}
 		z = z / x
@@ -102,7 +102,7 @@ pub fn gamma(a f64) f64 {
 	for x < 2 {
 		if x < 1e-09 {
 			unsafe {
-				goto small
+				goto _small
 			}
 		}
 		z = z / x
@@ -119,7 +119,7 @@ pub fn gamma(a f64) f64 {
 	if true {
 		return z * p / q
 	}
-	small:
+	_small:
 	if x == 0 {
 		return inf(1)
 	}


### PR DESCRIPTION
This change is a workaround for this bug:
```v
import math
import net.websocket

#flag windows -IC:\Program Files\OpenSSL-Win64\include
#flag windows -LC:\Program Files\OpenSSL-Win64\lib
#flag windows -lssl -lcrypto

fn main(){
}
```
```
error: too many basic types
```
This bug occurs because `C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\shared\rpcndr.h` adds a `#define small char`; thus, `small` cannot be used as an identifier anymore (which vlib currently does though).