### PR TITLE
cgen: fix order of comptime reflection fields

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -492,9 +492,7 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 	} else if node.kind == .fields {
 		// TODO add fields
 		if sym.info is ast.Struct {
-			mut fields := sym.info.fields.filter(it.attrs.len == 0)
-			fields_with_attrs := sym.info.fields.filter(it.attrs.len > 0)
-			fields << fields_with_attrs
+			mut fields := sym.info.fields.clone()
 			if fields.len > 0 {
 				g.writeln('\tFieldData $node.val_var = {0};')
 			}

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -492,11 +492,10 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 	} else if node.kind == .fields {
 		// TODO add fields
 		if sym.info is ast.Struct {
-			mut fields := sym.info.fields.clone()
-			if fields.len > 0 {
+			if sym.info.fields.len > 0 {
 				g.writeln('\tFieldData $node.val_var = {0};')
 			}
-			for field in fields {
+			for field in sym.info.fields {
 				g.comptime_for_field_var = node.val_var
 				g.comptime_for_field_value = field
 				g.writeln('/* field $i */ {')

--- a/vlib/v/tests/comptime_for_in_field_selector_test.v
+++ b/vlib/v/tests/comptime_for_in_field_selector_test.v
@@ -43,7 +43,7 @@ fn print_field_values<T>(s T) {
 
 struct Foo {
 	name     string
-	password string
+	password string [this_will_not_change_the_order]
 	email    string
 	age      int
 }


### PR DESCRIPTION
This fixes fields with attributes appearing at the end of `.fields`.

## Example

```v
module main

struct Abc {
  a byte  [test]
  b byte
  c byte
}

fn decode<T>() {
  $for field in T.fields {
    println(field.name)
  }
}

fn main() {
    decode<Abc>()
}
```
Prints
```
b
c
a
```
Instead of 
```
a
b
c
```