### PR TITLE
cgen: fix multiple nested embed struct with duplicate field init (fix #12789)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6023,6 +6023,7 @@ fn (mut g Gen) struct_init(struct_init ast.StructInit) {
 					default_init := ast.StructInit{
 						...struct_init
 						typ: embed
+						fields: init_fields_to_embed
 					}
 					g.write('.$embed_name = ')
 					g.struct_init(default_init)

--- a/vlib/v/tests/multiple_embed_struct_with_duplicate_field_init_test.v
+++ b/vlib/v/tests/multiple_embed_struct_with_duplicate_field_init_test.v
@@ -1,0 +1,19 @@
+struct Foo {
+mut:
+	x int
+}
+
+struct Bar {
+	Foo
+mut:
+	x int
+}
+
+fn test_multiple_embed_struct_with_duplicate_field_init() {
+	mut b := Bar{
+		x: 2
+	}
+	println(b)
+	assert b.x == 2
+	assert b.Foo.x == 0
+}


### PR DESCRIPTION
This PR fix multiple nested embed struct with duplicate field init (fix #12789).

- Fix multiple nested embed struct with duplicate field init.
- Add test.

```vlang
struct Foo {
mut:
	x int
}

struct Bar {
	Foo
mut:
	x int
}

fn main() {
	mut b := Bar{
		x: 2
	}
	println(b)
	assert b.x == 2
	assert b.Foo.x == 0
}

PS D:\Test\v\tt1> v run .
Bar{
    Foo: Foo{
        x: 0
    }
    x: 2
}
```