### PR TITLE
vgret: add support for config via `toml` and root path

### DIFF
--- a/.github/workflows/gfx_ci.yml
+++ b/.github/workflows/gfx_ci.yml
@@ -44,7 +44,7 @@ jobs:
         continue-on-error: true
         run: |
           Xvfb $DISPLAY -screen 0 1280x1024x24 &
-          ./v gret -v ./gg-sample_images ./gg-regression-images
+          ./v gret -t ./gg-regression-images/vgret.v_examples.toml -v ./gg-sample_images ./gg-regression-images
 
       - name: Upload regression to imgur
         if: steps.compare.outcome != 'success'

--- a/cmd/tools/vgret.defaults.toml
+++ b/cmd/tools/vgret.defaults.toml
@@ -1,0 +1,74 @@
+# Defaults
+[compare]
+  method = 'idiff'
+  flags = ['-p','-fail 0.001','-failpercent 0.2']
+
+[capture]
+  method = 'gg_record'
+  flags = [] # ['-prod','-d ...'] etc.
+
+[capture.env]
+  VGG_STOP_AT_FRAME = '8'
+  VGG_SCREENSHOT_FOLDER = '$OUT_PATH'
+  VGG_SCREENSHOT_FRAMES = '5'
+
+# List of apps to run and capture
+[[apps]]
+  path = 'examples/game_of_life/life_gg.v'
+
+[[apps]]
+  path = 'examples/gg/bezier.v'
+
+[[apps]]
+  path = 'examples/gg/mandelbrot.v'
+
+[[apps]]
+  path = 'examples/gg/rectangles.v'
+
+[[apps]]
+  path = 'examples/gg/raven_text_rendering.v'
+
+[[apps]]
+  path = 'examples/gg/worker_thread.v'
+
+[[apps]]
+  path = 'examples/gg/polygons.v'
+
+[[apps]]
+  path = 'examples/gg/bezier_anim.v'
+
+[[apps]]
+  path = 'examples/gg/drag_n_drop.v'
+
+[[apps]]
+  path = 'examples/ttf_font/example_ttf.v'
+
+# Reasons for ex- or inclusion:
+#
+# 'examples/snek/snek.v'                // Inacurrate captures
+# 'examples/game_of_life/life_gg.v'     // OK
+# 'examples/tetris/tetris.v'            // Uses random start block
+# 'examples/fireworks/fireworks.v'      // Uses rand for placement
+# 'examples/gg/bezier.v',               // OK
+# 'examples/gg/mandelbrot.v',           // OK
+# 'examples/gg/rectangles.v',           // OK
+# 'examples/gg/set_pixels.v'            // Has problem in CI software render (blank, no pixels set)
+# 'examples/gg/random.v'                // Always random
+# 'examples/gg/stars.v'                 // Uses rand for placement
+# 'examples/gg/raven_text_rendering.v', // OK
+# 'examples/gg/worker_thread.v',        // OK
+# 'examples/gg/polygons.v',             // OK
+# 'examples/gg/bezier_anim.v',          // OK
+# 'examples/gg/drag_n_drop.v'           // OK
+# 'examples/2048/2048.v'                // Random start tiles
+# 'examples/clock/clock.v'              // Can only be tested on exact points in time :)
+# 'examples/flappylearning/game.v'      // Random movement
+# 'examples/hot_reload/bounce.v'        // Inacurrate captures
+# 'examples/hot_reload/graph.v'         // Inacurrate captures
+# 'examples/ttf_font/example_ttf.v',    // OK
+# 'examples/sokol/01_cubes/cube.v',     // Can pass with a warning and diff at around 1.2%
+# 'examples/sokol/02_cubes_glsl/cube_glsl.v',       // Inacurrate captures
+# 'examples/sokol/03_march_tracing_glsl/rt_glsl.v', // Inacurrate captures
+# 'examples/sokol/04_multi_shader_glsl/rt_glsl.v',  // Inacurrate captures
+# 'examples/sokol/05_instancing_glsl/rt_glsl.v',    // Inacurrate captures
+# 'examples/sokol/06_obj_viewer/show_obj.v',        // Inacurrate captures

--- a/cmd/tools/vgret.v
+++ b/cmd/tools/vgret.v
@@ -35,7 +35,6 @@
 import os
 import flag
 import toml
-import toml.to
 
 const (
 	tool_name        = os.file_name(os.executable())


### PR DESCRIPTION
This PR will add support for testing of arbitrary `gg` based apps for graphical regressions.

The default is just like before (comparing `examples` in V root folder) - and it still works:  `vgret -v -c /tmp/1 /tmp/2`.

I had to introduce a way to list the apps you want tested/grabbed and a way to tweak the parameters for the tools involved.

Most importantly testing V UI graphics regressions is now supported:

`~/.vmodules/ui/vgret.ui_examples.toml`:

```toml
[compare]
  method = 'idiff'
  flags = ['-p','-fail 0.001','-failpercent 0.2']

[capture]
  method = 'gg_record'

[capture.env]
  VGG_STOP_AT_FRAME = '8'
  VGG_SCREENSHOT_FOLDER = '$OUT_PATH'
  VGG_SCREENSHOT_FRAMES = '5'

[[apps]]
  path = 'examples/calculator_resizable.v'

[[apps]]
  path = 'examples/demo_canvaslayout.v'
```


Run: `~/.vmodules/ui$  v gret -v --root-path . --toml-config ./vgret.ui_examples.toml /tmp/ui-src`

```
...
Compiling shaders (if needed) for `examples/calculator_resizable.v`
Creating output path `/tmp/ui-src`
Taking screenshot(s) of `examples/calculator_resizable.v` to `/tmp/ui-src/examples`
Setting ENV `VGG_STOP_AT_FRAME` = 8 ...
Setting ENV `VGG_SCREENSHOT_FOLDER` = /tmp/ui-src/examples ...
Setting ENV `VGG_SCREENSHOT_FRAMES` = 5 ...
Running `v  -d gg_record run "examples/calculator_resizable.v"`
Compiling shaders (if needed) for `examples/demo_canvaslayout.v`
Taking screenshot(s) of `examples/demo_canvaslayout.v` to `/tmp/ui-src/examples`
Setting ENV `VGG_STOP_AT_FRAME` = 8 ...
Setting ENV `VGG_SCREENSHOT_FOLDER` = /tmp/ui-src/examples ...
Setting ENV `VGG_SCREENSHOT_FRAMES` = 5 ...
Running `v  -d gg_record run "examples/demo_canvaslayout.v"`
```

Run: `~/.vmodules/ui$  v gret -v --root-path . --toml-config ./vgret.ui_examples.toml /tmp/ui-now /tmp/ui-src`:

```
Compiling shaders (if needed) for `examples/calculator_resizable.v`
Creating output path `/tmp/ui-now`
Taking screenshot(s) of `examples/calculator_resizable.v` to `/tmp/ui-now/examples`
Setting ENV `VGG_STOP_AT_FRAME` = 8 ...
Setting ENV `VGG_SCREENSHOT_FOLDER` = /tmp/ui-now/examples ...
Setting ENV `VGG_SCREENSHOT_FRAMES` = 5 ...
Running `v  -d gg_record run "~/.vmodules/ui/examples/calculator_resizable.v"`
Compiling shaders (if needed) for `examples/demo_canvaslayout.v`
Taking screenshot(s) of `examples/demo_canvaslayout.v` to `/tmp/ui-now/examples`
Setting ENV `VGG_STOP_AT_FRAME` = 8 ...
Setting ENV `VGG_SCREENSHOT_FOLDER` = /tmp/ui-now/examples ...
Setting ENV `VGG_SCREENSHOT_FRAMES` = 5 ...
Running `v  -d gg_record run "~/.vmodules/ui/examples/demo_canvaslayout.v"`
Comparing 1 screenshots in `/tmp/ui-now` with `/tmp/ui-src`
Comparing `/tmp/ui-now/examples/calculator_resizable_5.png` with `/tmp/ui-src/examples/calculator_resizable_5.png` with idiff
Running: /usr/bin/idiff -p -fail 0.001 -failpercent 0.2 -od -o "/dev/shm/calculator_resizable_5.diff.tif" -abs "/tmp/ui-now/examples/calculator_resizable_5.png" "/tmp/ui-src/examples/calculator_resizable_5.png"
Comparing "/tmp/ui-now/examples/calculator_resizable_5.png" and "/tmp/ui-src/examples/calculator_resizable_5.png"
PASS

Comparing 1 screenshots in `/tmp/ui-now` with `/tmp/ui-src`
Comparing `/tmp/ui-now/examples/demo_canvaslayout_5.png` with `/tmp/ui-src/examples/demo_canvaslayout_5.png` with idiff
Running: /usr/bin/idiff -p -fail 0.001 -failpercent 0.2 -od -o "/dev/shm/demo_canvaslayout_5.diff.tif" -abs "/tmp/ui-now/examples/demo_canvaslayout_5.png" "/tmp/ui-src/examples/demo_canvaslayout_5.png"
Comparing "/tmp/ui-now/examples/demo_canvaslayout_5.png" and "/tmp/ui-src/examples/demo_canvaslayout_5.png"
PASS
```

For the expense of a little added complexity in configuring via TOML - we can now test arbitrary `gg` apps.
This also allows users to do their own testing/CI setups utilizing `vgret`. I think the PROS outweighs the CONS in this case.

I have prepared the format to allow for addition of other capture methods.
I think it could be beneficial to, maybe, write a `sokol.record` module that you could call in your `frame()` callback:
```v
fn frame(user_data voidptr) {
	...
	record.frame() // Support similar env vars like `gg_record`
}
```
... or maybe even add an option for an external tool like `xwd` ... 

It's an overall starting-point/attempt to get capturing of all of V's builtin render methods covered.

Another added benefit is that it is now possible to have the TOML configuration bundled as as payload if e.g. run on  CI servers.
The current setup requires both `Larpon/gg-regression-images` and `vlang/v` to be updated when we add new images to the test suite - making it hard to let CI pass with green lights :) By having the TOML configuration as payload in `Larpon/gg-regression-images` updating `vlang/v` can be avoided. (This possibility is **not** activated with this PR - but I can make it so if you like the idea)

The TOML format currently support overwriting of defaults:
```toml
# Defaults
[compare]
  method = 'idiff'
  flags = ['-p','-fail 0.001','-failpercent 0.2']

[capture]
  method = 'gg_record'

[capture.env]
  VGG_STOP_AT_FRAME = '8'
  VGG_SCREENSHOT_FOLDER = '$OUT_PATH'
  VGG_SCREENSHOT_FRAMES = '5'

# List of apps to run and capture
[[apps]]
  path = 'examples/game_of_life/life_gg.v'

[[apps]]
  path = 'examples/gg/bezier.v'
  # Overwrites defaults above for `bezier.v` only
  [apps.compare]
    flags = ['-fail 10.0','-failpercent 10']
  [apps.capture.env]
    VGG_STOP_AT_FRAME = '800'
    VGG_SCREENSHOT_FOLDER = '$OUT_PATH'
    VGG_SCREENSHOT_FRAMES = '5,6,7,8,100,200'

[[apps]]
  path = 'examples/gg/mandelbrot.v'

```