### PR TITLE
cgen: fix embed struct init with complex fields (fix #12823)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6807,8 +6807,13 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 						|| field_sym.kind in [.array, .map, .string, .bool, .alias, .i8, .i16, .int, .i64, .byte, .u16, .u32, .u64, .char, .voidptr, .byteptr, .charptr, .struct_] {
 						field_name := c_name(field.name)
 						if field.has_default_expr {
-							expr_str := g.expr_string_with_cast(field.default_expr, field.default_expr_typ,
-								field.typ)
+							mut expr_str := ''
+							if g.table.get_type_symbol(field.typ).kind in [.sum_type, .interface_] {
+								expr_str = g.expr_string_with_cast(field.default_expr,
+									field.default_expr_typ, field.typ)
+							} else {
+								expr_str = g.expr_string(field.default_expr)
+							}
 							init_str += '.$field_name = $expr_str,'
 						} else {
 							init_str += '.$field_name = ${g.type_default(field.typ)},'

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6816,7 +6816,11 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 							}
 							init_str += '.$field_name = $expr_str,'
 						} else {
-							init_str += '.$field_name = ${g.type_default(field.typ)},'
+							mut zero_str := g.type_default(field.typ)
+							if zero_str == '{0}' {
+								zero_str = '{EMPTY_STRUCT_INITIALIZATION}'
+							}
+							init_str += '.$field_name = $zero_str,'
 						}
 						has_none_zero = true
 					}

--- a/vlib/v/tests/struct_init_with_complex_fields_test.v
+++ b/vlib/v/tests/struct_init_with_complex_fields_test.v
@@ -1,6 +1,4 @@
-struct Bar {
-	x int
-}
+struct Bar {}
 
 type Fnc = fn ()
 
@@ -18,6 +16,6 @@ fn test_struct_init_with_complex_fields() {
 	mut app := App{}
 	println(app)
 	ret := '$app'
-	assert ret.contains('Bar: Bar{')
+	assert ret.contains('Bar: Bar{}')
 	assert ret.contains('fnc_fn: fn ()')
 }

--- a/vlib/v/tests/struct_init_with_complex_fields_test.v
+++ b/vlib/v/tests/struct_init_with_complex_fields_test.v
@@ -1,4 +1,6 @@
-struct Bar {}
+struct Bar {
+	x int
+}
 
 type Fnc = fn ()
 
@@ -16,6 +18,6 @@ fn test_struct_init_with_complex_fields() {
 	mut app := App{}
 	println(app)
 	ret := '$app'
-	assert ret.contains('Bar: Bar{}')
+	assert ret.contains('Bar: Bar{')
 	assert ret.contains('fnc_fn: fn ()')
 }

--- a/vlib/v/tests/struct_init_with_complex_fields_test.v
+++ b/vlib/v/tests/struct_init_with_complex_fields_test.v
@@ -1,0 +1,21 @@
+struct Bar {}
+
+type Fnc = fn ()
+
+struct Foo {
+	Bar
+	fnc_fn Fnc = voidptr(0)
+}
+
+struct App {
+mut:
+	foo Foo
+}
+
+fn test_struct_init_with_complex_fields() {
+	mut app := App{}
+	println(app)
+	ret := '$app'
+	assert ret.contains('Bar: Bar{}')
+	assert ret.contains('fnc_fn: fn ()')
+}


### PR DESCRIPTION
This PR fix embed struct init with complex fields (fix #12823).

- Fix embed struct init with complex fields.
- Add test.

```vlang
struct Bar {}

type Fnc = fn ()

struct Foo {
	Bar
	fnc_fn Fnc = voidptr(0)
}

struct App {
mut:
	foo Foo
}

fn main() {
	mut app := App{}
	println(app)
	ret := '$app'
	assert ret.contains('Bar: Bar{}')
	assert ret.contains('fnc_fn: fn ()')
}

PS D:\Test\v\tt1> v run .
App{
    foo: Foo{
        Bar: Bar{}
        fnc_fn: fn ()
    }
}
```