### PR TITLE
gg: breaking `draw_arc()` and `draw_ring()` renaming + code consistency improvements

### DIFF
--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -406,7 +406,7 @@ pub fn (ctx &Context) draw_circle_with_segments(x f32, y f32, r f32, segments in
 }
 
 // Draws a circle slice/pie.
-pub fn (ctx &Context) draw_slice(x f32, y f32, r int, start_angle f32, arc_angle f32, segments int, c gx.Color) {
+pub fn (ctx &Context) draw_slice(x f32, y f32, r f32, start_angle f32, arc_angle f32, segments int, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
 	}
@@ -416,8 +416,8 @@ pub fn (ctx &Context) draw_slice(x f32, y f32, r int, start_angle f32, arc_angle
 	theta := f32(arc_angle / f32(segments))
 	tan_factor := math.tanf(theta)
 	rad_factor := math.cosf(theta)
-	mut xx := f32(r * math.cosf(start_angle))
-	mut yy := f32(r * math.sinf(start_angle))
+	mut xx := r * math.cosf(start_angle)
+	mut yy := r * math.sinf(start_angle)
 	sgl.begin_triangle_strip()
 	for i := 0; i < segments + 1; i++ {
 		sgl.v2f(xx + nx, yy + ny)
@@ -433,7 +433,7 @@ pub fn (ctx &Context) draw_slice(x f32, y f32, r int, start_angle f32, arc_angle
 }
 
 // Draws the outline of a circle slice/pie.
-pub fn (ctx &Context) draw_empty_slice(x f32, y f32, r int, start_angle f32, arc_angle f32, segments int, c gx.Color) {
+pub fn (ctx &Context) draw_empty_slice(x f32, y f32, r f32, start_angle f32, arc_angle f32, segments int, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
 	}
@@ -443,8 +443,8 @@ pub fn (ctx &Context) draw_empty_slice(x f32, y f32, r int, start_angle f32, arc
 	rad_factor := math.cosf(theta)
 	nx := x * ctx.scale
 	ny := y * ctx.scale
-	mut xx := f32(r * math.cosf(start_angle))
-	mut yy := f32(r * math.sinf(start_angle))
+	mut xx := r * math.cosf(start_angle)
+	mut yy := r * math.sinf(start_angle)
 	sgl.begin_line_strip()
 	for i := 0; i < segments + 1; i++ {
 		sgl.v2f(xx + nx, yy + ny)

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -266,25 +266,6 @@ pub fn (mut ctx Context) set_bg_color(c gx.Color) {
 		f32(c.a) / 255.0)
 }
 
-pub fn (ctx &Context) draw_empty_triangle(x f32, y f32, x2 f32, y2 f32, x3 f32, y3 f32, c gx.Color) {
-	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
-	}
-
-	sgl.c4b(c.r, c.g, c.b, c.a)
-	sgl.begin_line_strip()
-	sgl.v2f(x * ctx.scale, y * ctx.scale)
-	sgl.v2f(x2 * ctx.scale, y2 * ctx.scale)
-	sgl.v2f(x3 * ctx.scale, y3 * ctx.scale)
-	sgl.v2f(x * ctx.scale, y * ctx.scale)
-	sgl.end()
-}
-
-[inline]
-pub fn (ctx &Context) draw_square(x f32, y f32, s f32, c gx.Color) {
-	ctx.draw_rect(x, y, s, s, c)
-}
-
 [inline]
 pub fn (ctx &Context) set_pixel(x f32, y f32, c gx.Color) {
 	if c.a != 255 {
@@ -327,6 +308,30 @@ pub fn (ctx &Context) draw_triangle(x f32, y f32, x2 f32, y2 f32, x3 f32, y3 f32
 	sgl.end()
 }
 
+pub fn (ctx &Context) draw_empty_triangle(x f32, y f32, x2 f32, y2 f32, x3 f32, y3 f32, c gx.Color) {
+	if c.a != 255 {
+		sgl.load_pipeline(ctx.timage_pip)
+	}
+
+	sgl.c4b(c.r, c.g, c.b, c.a)
+	sgl.begin_line_strip()
+	sgl.v2f(x * ctx.scale, y * ctx.scale)
+	sgl.v2f(x2 * ctx.scale, y2 * ctx.scale)
+	sgl.v2f(x3 * ctx.scale, y3 * ctx.scale)
+	sgl.v2f(x * ctx.scale, y * ctx.scale)
+	sgl.end()
+}
+
+[inline]
+pub fn (ctx &Context) draw_square(x f32, y f32, s f32, c gx.Color) {
+	ctx.draw_rect(x, y, s, s, c)
+}
+
+[inline]
+pub fn (ctx &Context) draw_empty_square(x f32, y f32, s f32, c gx.Color) {
+	ctx.draw_empty_rect(x, y, s, s, c)
+}
+
 pub fn (ctx &Context) draw_empty_rect(x f32, y f32, w f32, h f32, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
@@ -339,11 +344,6 @@ pub fn (ctx &Context) draw_empty_rect(x f32, y f32, w f32, h f32, c gx.Color) {
 	sgl.v2f(x * ctx.scale, (y + h) * ctx.scale)
 	sgl.v2f(x * ctx.scale, (y - 1) * ctx.scale)
 	sgl.end()
-}
-
-[inline]
-pub fn (ctx &Context) draw_empty_square(x f32, y f32, s f32, c gx.Color) {
-	ctx.draw_empty_rect(x, y, s, s, c)
 }
 
 pub fn (ctx &Context) draw_circle(x f32, y f32, r f32, c gx.Color) {
@@ -372,32 +372,7 @@ pub fn (ctx &Context) draw_circle_with_segments(x f32, y f32, r f32, segments in
 	sgl.end()
 }
 
-pub fn (ctx &Context) draw_arc_line(x f32, y f32, r int, start_angle f32, arc_angle f32, segments int, c gx.Color) {
-	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
-	}
-	sgl.c4b(c.r, c.g, c.b, c.a)
-	theta := f32(arc_angle / f32(segments))
-	tan_factor := math.tanf(theta)
-	rad_factor := math.cosf(theta)
-	nx := x * ctx.scale
-	ny := y * ctx.scale
-	mut xx := f32(r * math.cosf(start_angle))
-	mut yy := f32(r * math.sinf(start_angle))
-	sgl.begin_line_strip()
-	for i := 0; i < segments + 1; i++ {
-		sgl.v2f(xx + nx, yy + ny)
-		tx := -yy
-		ty := xx
-		xx += tx * tan_factor
-		yy += ty * tan_factor
-		xx *= rad_factor
-		yy *= rad_factor
-	}
-	sgl.end()
-}
-
-pub fn (ctx &Context) draw_arc(x f32, y f32, r int, start_angle f32, arc_angle f32, segments int, c gx.Color) {
+pub fn (ctx &Context) draw_slice(x f32, y f32, r int, start_angle f32, arc_angle f32, segments int, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
 	}
@@ -413,6 +388,31 @@ pub fn (ctx &Context) draw_arc(x f32, y f32, r int, start_angle f32, arc_angle f
 	for i := 0; i < segments + 1; i++ {
 		sgl.v2f(xx + nx, yy + ny)
 		sgl.v2f(nx, ny)
+		tx := -yy
+		ty := xx
+		xx += tx * tan_factor
+		yy += ty * tan_factor
+		xx *= rad_factor
+		yy *= rad_factor
+	}
+	sgl.end()
+}
+
+pub fn (ctx &Context) draw_empty_slice(x f32, y f32, r int, start_angle f32, arc_angle f32, segments int, c gx.Color) {
+	if c.a != 255 {
+		sgl.load_pipeline(ctx.timage_pip)
+	}
+	sgl.c4b(c.r, c.g, c.b, c.a)
+	theta := f32(arc_angle / f32(segments))
+	tan_factor := math.tanf(theta)
+	rad_factor := math.cosf(theta)
+	nx := x * ctx.scale
+	ny := y * ctx.scale
+	mut xx := f32(r * math.cosf(start_angle))
+	mut yy := f32(r * math.sinf(start_angle))
+	sgl.begin_line_strip()
+	for i := 0; i < segments + 1; i++ {
+		sgl.v2f(xx + nx, yy + ny)
 		tx := -yy
 		ty := xx
 		xx += tx * tan_factor
@@ -529,7 +529,7 @@ pub fn (ctx &Context) draw_line_with_config(x f32, y f32, x2 f32, y2 f32, config
 	sgl.pop_matrix()
 }
 
-pub fn (ctx &Context) draw_ring(x f32, y f32, inner_r f32, outer_r f32, start_angle f32, end_angle f32, segments int, color gx.Color) {
+pub fn (ctx &Context) draw_arc(x f32, y f32, inner_r f32, outer_r f32, start_angle f32, end_angle f32, segments int, color gx.Color) {
 	if start_angle == end_angle || outer_r <= 0.0 {
 		return
 	}
@@ -553,7 +553,7 @@ pub fn (ctx &Context) draw_ring(x f32, y f32, inner_r f32, outer_r f32, start_an
 	}
 
 	if r1 <= 0.0 {
-		ctx.draw_arc(x, y, int(r2), a1, a2, segments, color)
+		ctx.draw_slice(x, y, int(r2), a1, a2, segments, color)
 		return
 	}
 

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -256,6 +256,30 @@ pub fn (ctx &Context) run() {
 	sapp.run(&ctx.window)
 }
 
+// Prepares the context for drawing
+pub fn (gg &Context) begin() {
+	if gg.render_text && gg.font_inited {
+		gg.ft.flush()
+	}
+	sgl.defaults()
+	sgl.matrix_mode_projection()
+	sgl.ortho(0.0, f32(sapp.width()), f32(sapp.height()), 0.0, -1.0, 1.0)
+}
+
+// Finishes drawing for the context
+pub fn (gg &Context) end() {
+	gfx.begin_default_pass(gg.clear_pass, sapp.width(), sapp.height())
+	sgl.draw()
+	gfx.end_pass()
+	gfx.commit()
+	/*
+	if gg.config.wait_events {
+		// println('gg: waiting')
+		wait_events()
+	}
+	*/
+}
+
 // quit closes the context window and exits the event loop for it
 pub fn (ctx &Context) quit() {
 	sapp.request_quit() // does not require ctx right now, but sokol multi-window might in the future
@@ -266,6 +290,7 @@ pub fn (mut ctx Context) set_bg_color(c gx.Color) {
 		f32(c.a) / 255.0)
 }
 
+// Sets a pixel
 [inline]
 pub fn (ctx &Context) set_pixel(x f32, y f32, c gx.Color) {
 	if c.a != 255 {
@@ -278,6 +303,7 @@ pub fn (ctx &Context) set_pixel(x f32, y f32, c gx.Color) {
 	sgl.end()
 }
 
+// Sets pixels from an array of points [x, y, x2, y2, etc...]
 [direct_array_access; inline]
 pub fn (ctx &Context) set_pixels(points []f32, c gx.Color) {
 	assert points.len % 2 == 0
@@ -296,6 +322,7 @@ pub fn (ctx &Context) set_pixels(points []f32, c gx.Color) {
 	sgl.end()
 }
 
+// Draws a filled triangle
 pub fn (ctx &Context) draw_triangle(x f32, y f32, x2 f32, y2 f32, x3 f32, y3 f32, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
@@ -308,6 +335,7 @@ pub fn (ctx &Context) draw_triangle(x f32, y f32, x2 f32, y2 f32, x3 f32, y3 f32
 	sgl.end()
 }
 
+// Draws the outline of a triangle
 pub fn (ctx &Context) draw_empty_triangle(x f32, y f32, x2 f32, y2 f32, x3 f32, y3 f32, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
@@ -322,16 +350,19 @@ pub fn (ctx &Context) draw_empty_triangle(x f32, y f32, x2 f32, y2 f32, x3 f32, 
 	sgl.end()
 }
 
+// Draws a filled square
 [inline]
 pub fn (ctx &Context) draw_square(x f32, y f32, s f32, c gx.Color) {
 	ctx.draw_rect(x, y, s, s, c)
 }
 
+// Draws the outline of a square
 [inline]
 pub fn (ctx &Context) draw_empty_square(x f32, y f32, s f32, c gx.Color) {
 	ctx.draw_empty_rect(x, y, s, s, c)
 }
 
+// Draws the outline of a rectangle
 pub fn (ctx &Context) draw_empty_rect(x f32, y f32, w f32, h f32, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
@@ -346,10 +377,12 @@ pub fn (ctx &Context) draw_empty_rect(x f32, y f32, w f32, h f32, c gx.Color) {
 	sgl.end()
 }
 
+// Draws a circle
 pub fn (ctx &Context) draw_circle(x f32, y f32, r f32, c gx.Color) {
 	ctx.draw_circle_with_segments(x, y, r, 10, c)
 }
 
+// Draws a circle with a specific number of segments (affects how smooth/round the circle is)
 pub fn (ctx &Context) draw_circle_with_segments(x f32, y f32, r f32, segments int, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
@@ -372,6 +405,7 @@ pub fn (ctx &Context) draw_circle_with_segments(x f32, y f32, r f32, segments in
 	sgl.end()
 }
 
+// Draws a circle slice/pie.
 pub fn (ctx &Context) draw_slice(x f32, y f32, r int, start_angle f32, arc_angle f32, segments int, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
@@ -398,6 +432,7 @@ pub fn (ctx &Context) draw_slice(x f32, y f32, r int, start_angle f32, arc_angle
 	sgl.end()
 }
 
+// Draws the outline of a circle slice/pie.
 pub fn (ctx &Context) draw_empty_slice(x f32, y f32, r int, start_angle f32, arc_angle f32, segments int, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
@@ -423,36 +458,15 @@ pub fn (ctx &Context) draw_empty_slice(x f32, y f32, r int, start_angle f32, arc
 	sgl.end()
 }
 
-pub fn (gg &Context) begin() {
-	if gg.render_text && gg.font_inited {
-		gg.ft.flush()
-	}
-	sgl.defaults()
-	sgl.matrix_mode_projection()
-	sgl.ortho(0.0, f32(sapp.width()), f32(sapp.height()), 0.0, -1.0, 1.0)
-}
 
-pub fn (gg &Context) end() {
-	gfx.begin_default_pass(gg.clear_pass, sapp.width(), sapp.height())
-	sgl.draw()
-	gfx.end_pass()
-	gfx.commit()
-	/*
-	if gg.config.wait_events {
-		// println('gg: waiting')
-		wait_events()
-	}
-	*/
-}
-
-// resize the context's Window
+// Resize the context's Window
 pub fn (mut ctx Context) resize(width int, height int) {
 	ctx.width = width
 	ctx.height = height
 	// C.sapp_resize_window(width, height)
 }
 
-// draw_line draws a line between the points provided
+// Draws a line between the points provided
 pub fn (ctx &Context) draw_line(x f32, y f32, x2 f32, y2 f32, c gx.Color) {
 	$if macos {
 		if ctx.native_rendering {
@@ -478,7 +492,7 @@ pub fn (ctx &Context) draw_line(x f32, y f32, x2 f32, y2 f32, c gx.Color) {
 	sgl.end()
 }
 
-// draw_line_with_config draws a line between the points provided with the PenConfig
+// Draws a line between the points provided with the PenConfig
 pub fn (ctx &Context) draw_line_with_config(x f32, y f32, x2 f32, y2 f32, config PenConfig) {
 	if config.color.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
@@ -529,6 +543,7 @@ pub fn (ctx &Context) draw_line_with_config(x f32, y f32, x2 f32, y2 f32, config
 	sgl.pop_matrix()
 }
 
+// Draws an arc
 pub fn (ctx &Context) draw_arc(x f32, y f32, inner_r f32, outer_r f32, start_angle f32, end_angle f32, segments int, color gx.Color) {
 	if start_angle == end_angle || outer_r <= 0.0 {
 		return
@@ -576,6 +591,7 @@ pub fn (ctx &Context) draw_arc(x f32, y f32, inner_r f32, outer_r f32, start_ang
 	sgl.end()
 }
 
+// Draws a filled rounded rectangle
 pub fn (ctx &Context) draw_rounded_rect(x f32, y f32, w f32, h f32, radius f32, color gx.Color) {
 	sgl.c4b(color.r, color.g, color.b, color.a)
 	sgl.begin_triangle_strip()
@@ -644,6 +660,7 @@ pub fn (ctx &Context) draw_rounded_rect(x f32, y f32, w f32, h f32, radius f32, 
 	sgl.end()
 }
 
+// Draws the outline of a rounded rectangle
 pub fn (ctx &Context) draw_empty_rounded_rect(x f32, y f32, w f32, h f32, radius f32, border_color gx.Color) {
 	mut theta := f32(0)
 	mut xx := f32(0)

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -458,7 +458,6 @@ pub fn (ctx &Context) draw_empty_slice(x f32, y f32, r f32, start_angle f32, arc
 	sgl.end()
 }
 
-
 // Resize the context's Window
 pub fn (mut ctx Context) resize(width int, height int) {
 	ctx.width = width

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -544,7 +544,7 @@ pub fn (ctx &Context) draw_line_with_config(x f32, y f32, x2 f32, y2 f32, config
 }
 
 // Draws an arc
-pub fn (ctx &Context) draw_arc(x f32, y f32, inner_r f32, outer_r f32, start_angle f32, end_angle f32, segments int, color gx.Color) {
+pub fn (ctx &Context) draw_arc(x f32, y f32, inner_r f32, outer_r f32, start_angle f32, end_angle f32, segments int, c gx.Color) {
 	if start_angle == end_angle || outer_r <= 0.0 {
 		return
 	}
@@ -568,7 +568,7 @@ pub fn (ctx &Context) draw_arc(x f32, y f32, inner_r f32, outer_r f32, start_ang
 	}
 
 	if r1 <= 0.0 {
-		ctx.draw_slice(x, y, int(r2), a1, a2, segments, color)
+		ctx.draw_slice(x, y, int(r2), a1, a2, segments, c)
 		return
 	}
 
@@ -576,7 +576,7 @@ pub fn (ctx &Context) draw_arc(x f32, y f32, inner_r f32, outer_r f32, start_ang
 	mut angle := a1
 
 	sgl.begin_quads()
-	sgl.c4b(color.r, color.g, color.b, color.a)
+	sgl.c4b(c.r, c.g, c.b, c.a)
 	for _ in 0 .. segments {
 		sgl.v2f(x + f32(math.sin(angle)) * r1, y + f32(math.cos(angle) * r1))
 		sgl.v2f(x + f32(math.sin(angle)) * r2, y + f32(math.cos(angle) * r2))
@@ -592,8 +592,8 @@ pub fn (ctx &Context) draw_arc(x f32, y f32, inner_r f32, outer_r f32, start_ang
 }
 
 // Draws a filled rounded rectangle
-pub fn (ctx &Context) draw_rounded_rect(x f32, y f32, w f32, h f32, radius f32, color gx.Color) {
-	sgl.c4b(color.r, color.g, color.b, color.a)
+pub fn (ctx &Context) draw_rounded_rect(x f32, y f32, w f32, h f32, radius f32, c gx.Color) {
+	sgl.c4b(c.r, c.g, c.b, c.a)
 	sgl.begin_triangle_strip()
 	mut theta := f32(0)
 	mut xx := f32(0)
@@ -661,7 +661,7 @@ pub fn (ctx &Context) draw_rounded_rect(x f32, y f32, w f32, h f32, radius f32, 
 }
 
 // Draws the outline of a rounded rectangle
-pub fn (ctx &Context) draw_empty_rounded_rect(x f32, y f32, w f32, h f32, radius f32, border_color gx.Color) {
+pub fn (ctx &Context) draw_empty_rounded_rect(x f32, y f32, w f32, h f32, radius f32, c gx.Color) {
 	mut theta := f32(0)
 	mut xx := f32(0)
 	mut yy := f32(0)
@@ -676,7 +676,7 @@ pub fn (ctx &Context) draw_empty_rounded_rect(x f32, y f32, w f32, h f32, radius
 	lb := int(rb + segdiv)
 	lt := int(lb + segdiv)
 	rt := int(lt + segdiv)
-	sgl.c4b(border_color.r, border_color.g, border_color.b, border_color.a)
+	sgl.c4b(c.r, c.g, c.b, c.a)
 	sgl.begin_line_strip()
 	// left top
 	lx := nx + r


### PR DESCRIPTION
Alright, so here are the changes:
- Added some documentation comments
- Renamed `draw_arc()` -> `draw_slice()`
- Renamed `draw_arc_lines()` -> `draw_empty_slice()`
- Renamed `draw_ring()` -> `draw_arc()`
- Changed `r` in `draw_slice()` to use `f32` instead of `int` as is done in other functions
- Changed `color` in drawing functions to `c`, so that it matches most other functions
- Grouped some related functions together, to avoid the confusion when looking for specific functions. Before there were some functions like `draw_empty_[shape]()` and `draw_[shape]()` that were spread different places in the code. `begin()` and `end()` were also in the middle of the code between all drawing functions, and they were so small I've moved them above the drawing functions.

`gg` seems to be working as it is supposed to, none of the examples (if I checked correctly) use the `draw_arc()` functions, so that should not be breaking the examples. Some changes will have to be added to V UI, but I can go ahead and convert those over if wanted.