### PR TITLE
cgen: fix non empty struct zero init

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6818,7 +6818,12 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 						} else {
 							mut zero_str := g.type_default(field.typ)
 							if zero_str == '{0}' {
-								zero_str = '{EMPTY_STRUCT_INITIALIZATION}'
+								if mut field_sym.info is ast.Struct {
+									if field_sym.info.fields.len == 0
+										&& field_sym.info.embeds.len == 0 {
+										zero_str = '{EMPTY_STRUCT_INITIALIZATION}'
+									}
+								}
 							}
 							init_str += '.$field_name = $zero_str,'
 						}


### PR DESCRIPTION
This PR fix non empty struct zero init.