### PR TITLE
cgen: fix embedded struct init with complex fields (fix #12823)

### DIFF
--- a/vlib/v/tests/struct_init_with_complex_fields_test.v
+++ b/vlib/v/tests/struct_init_with_complex_fields_test.v
@@ -1,0 +1,21 @@
+struct Bar {}
+
+type Fnc = fn ()
+
+struct Foo {
+	Bar
+	fnc_fn Fnc = voidptr(0)
+}
+
+struct App {
+mut:
+	foo Foo
+}
+
+fn test_struct_init_with_complex_fields() {
+	mut app := App{}
+	println(app)
+	ret := '$app'
+	assert ret.contains('Bar: Bar{}')
+	assert ret.contains('fnc_fn: fn ()')
+}


### PR DESCRIPTION
This PR fix embedded struct init with complex fields (fix #12823).

- Fix embedded struct init with complex fields.
- Add test.

```vlang
struct Bar {}

type Fnc = fn ()

struct Foo {
	Bar
	fnc_fn Fnc = voidptr(0)
}

struct App {
mut:
	foo Foo
}

fn main() {
	mut app := App{}
	println(app)
	ret := '$app'
	assert ret.contains('Bar: Bar{}')
	assert ret.contains('fnc_fn: fn ()')
}

PS D:\Test\v\tt1> v run .
App{
    foo: Foo{
        Bar: Bar{}
        fnc_fn: fn ()
    }
}
```