### PR TITLE
transformer: only enable array optimisation with -prod

### DIFF
--- a/vlib/v/tests/array_access_optimisation_test.v
+++ b/vlib/v/tests/array_access_optimisation_test.v
@@ -25,7 +25,8 @@ fn access(line string) {
 }
 
 fn test_array_optimisation() {
-	mut args := []string{cap: 3}
+	mut args := []string{cap: 4}
+	args << '-prod'
 	args << test
 	args << '-o'
 	args << '-'

--- a/vlib/v/tests/testdata/test_array_bound.v
+++ b/vlib/v/tests/testdata/test_array_bound.v
@@ -93,6 +93,8 @@ fn check_for_c_init_1(a []byte) {
 	for access_it := a[34]; a[34] == 0; {
 		direct(a[34])
 		access(a[35])
+		// work around https://github.com/vlang/v/issues/12832
+		println(access_it)
 		return
 	}
 }

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -156,6 +156,9 @@ pub fn (mut t Transformer) transform(mut ast_file ast.File) {
 }
 
 pub fn (mut t Transformer) find_new_array_len(node ast.AssignStmt) {
+	if !t.pref.is_prod {
+		return
+	}
 	// looking for, array := []type{len:int}
 	mut right := node.right[0]
 	if mut right is ast.ArrayInit {
@@ -185,6 +188,9 @@ pub fn (mut t Transformer) find_new_array_len(node ast.AssignStmt) {
 }
 
 pub fn (mut t Transformer) find_new_range(node ast.AssignStmt) {
+	if !t.pref.is_prod {
+		return
+	}
 	// looking for, array := []type{len:int}
 	mut right := node.right[0]
 	if mut right is ast.IndexExpr {
@@ -214,10 +220,16 @@ pub fn (mut t Transformer) find_new_range(node ast.AssignStmt) {
 }
 
 pub fn (mut t Transformer) find_mut_self_assign(node ast.AssignStmt) {
+	if !t.pref.is_prod {
+		return
+	}
 	// even if mutable we can be sure than `a[1] = a[2] is safe
 }
 
 pub fn (mut t Transformer) find_assert_len(node ast.InfixExpr) {
+	if !t.pref.is_prod {
+		return
+	}
 	right := node.right
 	match right {
 		ast.IntegerLiteral {
@@ -265,6 +277,9 @@ pub fn (mut t Transformer) find_assert_len(node ast.InfixExpr) {
 }
 
 pub fn (mut t Transformer) check_safe_array(mut node ast.IndexExpr) {
+	if !t.pref.is_prod {
+		return
+	}
 	if !node.is_array {
 		return
 	}


### PR DESCRIPTION
It was noticed that the impact of performing array analysis increased overall code generation time by 3/4% which is not negligeable.

The array optimisation is therefore only enabled when the `-prod` flag is used to reduce this overhead.
