### PR TITLE
cgen: fix error of embedded struct generating interface_table (fix #12839)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7325,7 +7325,12 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 			if st_sym.info is ast.Struct {
 				for embed in st_sym.info.embeds {
 					embed_sym := g.table.get_type_symbol(embed)
-					methods << embed_sym.methods
+					method_names := methods.map(it.name)
+					for embed_method in embed_sym.methods {
+						if embed_method.name !in method_names {
+							methods << embed_method
+						}
+					}
 				}
 			}
 			for method in methods {


### PR DESCRIPTION
This PR fix error of embedded struct generating interface_table (fix #12839).

```vlang
import ui

struct App {
mut:
	window &ui.Window
	fc     &FooWidget
}

fn main() {
	mut app := &App{
		window: 0
		fc: &FooWidget{}
	}
	app.window = ui.window(
		width: 300
		height: 300
		state: app
		children: [app.fc]
	)

	ui.run(app.window)
}

//---------------------------

struct Foo {
mut:
	x      int
	y      int
	width  int
	height int
}

fn (mut c Foo) draw() {}

//-----------------------------------

struct FooWidget {
	Foo
mut:
	id       string
	z_index  int
	offset_x int
	offset_y int
	hidden   bool
}
fn (mut c FooWidget) init(parent ui.Layout) {}
fn (mut c FooWidget) set_pos(x int, y int) {}
fn (c FooWidget) get_pos() (int, int) { return 0, 0 }

fn (c FooWidget) size() (int, int) { return 0, 0 }
fn (mut c FooWidget) draw() {}

fn (mut c FooWidget) propose_size(w int, h int) (int, int) { return 0, 0 }
fn (c FooWidget) focus() {}
fn (c FooWidget) is_focused() bool { return false }
fn (c FooWidget) unfocus() {}
fn (c FooWidget) point_inside(x f64, y f64) bool { return false }
fn (mut cw FooWidget) set_visible(b bool)  {}
fn (cw FooWidget) cleanup() {}

PS D:\Test\v\tt1> v run .
```
![image](https://user-images.githubusercontent.com/6949593/146135031-082890e7-90da-4987-9b9a-ce6f0e22d0d1.png)
