### PR TITLE
builtin: Convert IError interface to methods

### DIFF
--- a/cmd/tools/vbin2v.v
+++ b/cmd/tools/vbin2v.v
@@ -77,7 +77,7 @@ fn (context Context) bname_and_bytes(file string) ?(string, []byte) {
 	fname := os.file_name(file)
 	fname_escaped := fname.replace_each(['.', '_', '-', '_'])
 	byte_name := '$context.prefix$fname_escaped'.to_lower()
-	fbytes := os.read_bytes(file) or { return error('Error: $err.msg') }
+	fbytes := os.read_bytes(file) or { return error('Error: $err.msg()') }
 	return byte_name, fbytes
 }
 
@@ -108,7 +108,7 @@ fn main() {
 		exit(0)
 	}
 	files := fp.finalize() or {
-		eprintln('Error: $err.msg')
+		eprintln('Error: $err.msg()')
 		exit(1)
 	}
 	real_files := files.filter(it != 'bin2v')
@@ -123,7 +123,7 @@ fn main() {
 	mut file_byte_map := map[string][]byte{}
 	for file in real_files {
 		bname, fbytes := context.bname_and_bytes(file) or {
-			eprintln(err.msg)
+			eprintln(err.msg())
 			exit(1)
 		}
 		file_byte_map[bname] = fbytes

--- a/cmd/tools/vbuild-tools.v
+++ b/cmd/tools/vbuild-tools.v
@@ -66,8 +66,8 @@ fn main() {
 		}
 		target_path := os.join_path(tfolder, texe)
 		os.mv_by_cp(tpath, target_path) or {
-			if !err.msg.contains('vbuild-tools') && !err.msg.contains('vtest-all') {
-				eprintln('error while moving $tpath to $target_path: $err.msg')
+			if !err.msg().contains('vbuild-tools') && !err.msg().contains('vtest-all') {
+				eprintln('error while moving $tpath to $target_path: $err.msg()')
 			}
 			continue
 		}

--- a/cmd/tools/vcreate.v
+++ b/cmd/tools/vcreate.v
@@ -82,7 +82,7 @@ fn gen_gitignore(name string) string {
 fn (c &Create) write_vmod(new bool) {
 	vmod_path := if new { '$c.name/v.mod' } else { 'v.mod' }
 	mut vmod := os.create(vmod_path) or {
-		cerror(err.msg)
+		cerror(err.msg())
 		exit(1)
 	}
 	vmod.write_string(vmod_content(c)) or { panic(err) }
@@ -95,7 +95,7 @@ fn (c &Create) write_main(new bool) {
 	}
 	main_path := if new { '$c.name/${c.name}.v' } else { '${c.name}.v' }
 	mut mainfile := os.create(main_path) or {
-		cerror(err.msg)
+		cerror(err.msg())
 		exit(2)
 	}
 	mainfile.write_string(main_content()) or { panic(err) }

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -224,8 +224,8 @@ fn (vd VDoc) get_readme(path string) string {
 
 fn (vd VDoc) emit_generate_err(err IError) {
 	cfg := vd.cfg
-	mut err_msg := err.msg
-	if err.code == 1 {
+	mut err_msg := err.msg()
+	if err.code() == 1 {
 		mod_list := get_modules_list(cfg.input_path, []string{})
 		println('Available modules:\n==================')
 		for mod in mod_list {
@@ -441,7 +441,7 @@ fn parse_arguments(args []string) Config {
 					exit(1)
 				}
 				selected_platform := doc.platform_from_string(platform_str) or {
-					eprintln(err.msg)
+					eprintln(err.msg())
 					exit(1)
 				}
 				cfg.platform = selected_platform

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -80,7 +80,7 @@ fn main() {
 		eprintln('vfmt possible_files: ' + possible_files.str())
 	}
 	files := util.find_all_v_files(possible_files) or {
-		verror(err.msg)
+		verror(err.msg())
 		return
 	}
 	if os.is_atty(0) == 0 && files.len == 0 {

--- a/cmd/tools/vgret.v
+++ b/cmd/tools/vgret.v
@@ -211,7 +211,7 @@ fn generate_screenshots(mut opt Options, output_path string) ? {
 
 		app_config.screenshots_path = screenshot_path
 		app_config.screenshots = take_screenshots(opt, app_config) or {
-			return error('Failed taking screenshots of `$app_path`:\n$err.msg')
+			return error('Failed taking screenshots of `$app_path`:\n$err.msg()')
 		}
 	}
 }

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -434,7 +434,7 @@ fn vpm_remove(module_names []string) {
 		println('Removing module "$name"...')
 		verbose_println('removing folder $final_module_path')
 		os.rmdir_all(final_module_path) or {
-			verbose_println('error while removing "$final_module_path": $err.msg')
+			verbose_println('error while removing "$final_module_path": $err.msg()')
 		}
 		// delete author directory if it is empty
 		author := name.split('.')[0]
@@ -445,7 +445,7 @@ fn vpm_remove(module_names []string) {
 		if os.is_dir_empty(author_dir) {
 			verbose_println('removing author folder $author_dir')
 			os.rmdir(author_dir) or {
-				verbose_println('error while removing "$author_dir": $err.msg')
+				verbose_println('error while removing "$author_dir": $err.msg()')
 			}
 		}
 	}

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -26,7 +26,7 @@ fn main() {
 		// The user just wants an independent copy of v, and so we are done.
 		return
 	}
-	backup_old_version_and_rename_newer() or { panic(err.msg) }
+	backup_old_version_and_rename_newer() or { panic(err) }
 	println('V built successfully!')
 }
 
@@ -67,17 +67,17 @@ fn backup_old_version_and_rename_newer() ?bool {
 
 	list_folder('before:', 'removing $bak_file ...')
 	if os.exists(bak_file) {
-		os.rm(bak_file) or { errors << 'failed removing $bak_file: $err.msg' }
+		os.rm(bak_file) or { errors << 'failed removing $bak_file: $err.msg()' }
 	}
 
 	list_folder('', 'moving $v_file to $bak_file ...')
-	os.mv(v_file, bak_file) or { errors << err.msg }
+	os.mv(v_file, bak_file) or { errors << err.msg() }
 
 	list_folder('', 'removing $v_file ...')
 	os.rm(v_file) or {}
 
 	list_folder('', 'moving $v2_file to $v_file ...')
-	os.mv_by_cp(v2_file, v_file) or { panic(err.msg) }
+	os.mv_by_cp(v2_file, v_file) or { panic(err) }
 
 	list_folder('after:', '')
 

--- a/cmd/tools/vsymlink.v
+++ b/cmd/tools/vsymlink.v
@@ -79,7 +79,7 @@ fn setup_symlink_windows(vexe string) {
 		println('Symlink $vsymlink to $vexe created.')
 		println('Checking system %PATH%...')
 		reg_sys_env_handle := get_reg_sys_env_handle() or {
-			warn_and_exit(err.msg)
+			warn_and_exit(err.msg())
 			return
 		}
 		// TODO: Fix defers inside ifs
@@ -106,7 +106,7 @@ fn setup_symlink_windows(vexe string) {
 			println('Adding symlink directory to system %PATH%...')
 			set_reg_value(reg_sys_env_handle, 'Path', new_sys_env_path) or {
 				C.RegCloseKey(reg_sys_env_handle)
-				warn_and_exit(err.msg)
+				warn_and_exit(err.msg())
 			}
 			println('Done.')
 		}

--- a/cmd/tools/vtest-parser.v
+++ b/cmd/tools/vtest-parser.v
@@ -121,7 +121,7 @@ fn process_cli_args() &Context {
 		exit(0)
 	}
 	context.all_paths = fp.finalize() or {
-		context.error(err.msg)
+		context.error(err.msg())
 		exit(1)
 	}
 	if !context.is_worker && context.all_paths.len == 0 {

--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -124,9 +124,9 @@ fn (app App) show_current_v_version() {
 fn (app App) backup(file string) {
 	backup_file := '${file}_old.exe'
 	if os.exists(backup_file) {
-		os.rm(backup_file) or { eprintln('failed removing $backup_file: $err.msg') }
+		os.rm(backup_file) or { eprintln('failed removing $backup_file: $err.msg()') }
 	}
-	os.mv(file, backup_file) or { eprintln('failed moving $file: $err.msg') }
+	os.mv(file, backup_file) or { eprintln('failed moving $file: $err.msg()') }
 }
 
 fn (app App) git_command(command string) {

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1678,7 +1678,7 @@ import os
 
 fn read_log() {
 	mut ok := false
-	mut f := os.open('log.txt') or { panic(err.msg) }
+	mut f := os.open('log.txt') or { panic(err) }
 	defer {
 		f.close()
 	}
@@ -3098,7 +3098,7 @@ to break from the current block.
 Note that `break` and `continue` can only be used inside a `for` loop.
 
 V does not have a way to forcibly "unwrap" an optional (as other languages do,
-for instance Rust's `unwrap()` or Swift's `!`). To do this, use `or { panic(err.msg) }` instead.
+for instance Rust's `unwrap()` or Swift's `!`). To do this, use `or { panic(err) }` instead.
 
 ---
 The third method is to provide a default value at the end of the `or` block.
@@ -5144,7 +5144,7 @@ eprintln('file: ' + @FILE + ' | line: ' + @LINE + ' | fn: ' + @MOD + '.' + @FN)
 Another example, is if you want to embed the version/name from v.mod *inside* your executable:
 ```v ignore
 import v.vmod
-vm := vmod.decode( @VMOD_FILE ) or { panic(err.msg) }
+vm := vmod.decode( @VMOD_FILE ) or { panic(err) }
 eprintln('$vm.name $vm.version\n $vm.description')
 ```
 

--- a/examples/sokol/06_obj_viewer/modules/obj/obj.v
+++ b/examples/sokol/06_obj_viewer/modules/obj/obj.v
@@ -564,7 +564,7 @@ pub fn tst() {
 	//fname := "Orange Robot 3D ObjPart.obj"
 	
 	mut obj := ObjPart{}
-	buf := os.read_lines(fname) or { panic(err.msg) }
+	buf := os.read_lines(fname) or { panic(err) }
 	obj.parse_obj_buffer(buf)
 	obj.summary()
 	*/

--- a/examples/v_script.vsh
+++ b/examples/v_script.vsh
@@ -13,14 +13,14 @@ mkdir('v_script_dir') ?
 
 println("\nEntering into v_script_dir and listing it's files.")
 chdir('v_script_dir') ?
-files := ls('.') or { panic(err.msg) }
+files := ls('.') or { panic(err) }
 println(files)
 
 println('\nCreating foo.txt')
 create('foo.txt') ?
 
 println('\nFiles:')
-again_ls := ls('.') or { panic(err.msg) }
+again_ls := ls('.') or { panic(err) }
 println(again_ls)
 
 println('\nRemoving foo.txt and v_script_dir')

--- a/vlib/builtin/js/builtin.v
+++ b/vlib/builtin/js/builtin.v
@@ -14,8 +14,29 @@ pub fn panic(s string) {
 
 // IError holds information about an error instance
 pub interface IError {
-	msg string
-	code int
+	msg() string
+	code() int
+}
+
+pub fn (err IError) str() string {
+	return match err {
+		None__ { 'none' }
+		Error { err.msg() }
+		else { 'Error: $err.msg()' }
+	}
+}
+
+// BaseError is an empty implementation of the IError interface, it is used to make custom error types simpler
+pub struct BaseError {}
+
+[inline]
+pub fn (err BaseError) msg() string {
+	return ''
+}
+
+[inline]
+pub fn (err BaseError) code() int {
+	return 0
 }
 
 // Error is the default implementation of IError, that is returned by e.g. `error()`
@@ -25,28 +46,36 @@ pub:
 	code int
 }
 
+pub fn (err Error) msg() string {
+	return err.msg
+}
+
+pub fn (err Error) code() int {
+	return err.code
+}
+
 struct None__ {
 	msg  string
 	code int
+}
+
+fn (n None__) msg() string {
+	return n.str()
+}
+
+fn (_ None__) code() int {
+	return 0
 }
 
 fn (_ None__) str() string {
 	return 'none'
 }
 
-pub const none__ = IError(None__{'', 0})
+pub const none__ = IError(None__{})
 
 pub struct Option {
 	state byte
 	err   IError = none__
-}
-
-pub fn (err IError) str() string {
-	return match err {
-		None__ { 'none' }
-		Error { err.msg }
-		else { 'Error: $err.msg' }
-	}
 }
 
 pub fn (o Option) str() string {

--- a/vlib/builtin/option.c.v
+++ b/vlib/builtin/option.c.v
@@ -8,7 +8,6 @@ struct C.IError {
 [unsafe]
 pub fn (ie &IError) free() {
 	unsafe {
-		ie.msg.free()
 		cie := &C.IError(ie)
 		free(cie._object)
 	}

--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -5,35 +5,69 @@ module builtin
 
 // IError holds information about an error instance
 pub interface IError {
-	msg string
-	code int
+	msg() string
+	code() int
 }
 
-// Error is the default implementation of IError, that is returned by e.g. `error()`
+pub fn (err IError) str() string {
+	return match err {
+		None__ { 'none' }
+		Error { err.msg() }
+		else { '$err.type_name(): $err.msg()' }
+	}
+}
+
+// BaseError is an empty implementation of the IError interface, it is used to make custom error types simpler
+pub struct BaseError {}
+
+[inline]
+pub fn (err BaseError) msg() string {
+	return ''
+}
+
+[inline]
+pub fn (err BaseError) code() int {
+	return 0
+}
+
+// Error is the default implementation of IError with `msg` and `code` fields, that is returned by e.g. `error()`
 pub struct Error {
 pub:
 	msg  string
 	code int
 }
 
-pub fn (err IError) str() string {
-	return match err {
-		None__ { 'none' }
-		Error { err.msg }
-		else { '$err.type_name(): $err.msg' }
-	}
+[inline]
+pub fn (err Error) msg() string {
+	return err.msg
 }
 
-const none__ = IError(&None__{})
+[inline]
+pub fn (err Error) code() int {
+	return err.code
+}
 
+// None__ must contain `msg` and `code` fields because currently some compiler magic depends on it.
 struct None__ {
 	msg  string
 	code int
 }
 
-fn (_ None__) str() string {
+[inline]
+fn (n None__) msg() string {
+	return n.msg
+}
+
+[inline]
+fn (n None__) code() int {
+	return n.code
+}
+
+fn (n None__) str() string {
 	return 'none'
 }
+
+const none__ = IError(&None__{})
 
 [if trace_error ?]
 fn trace_error(x string) {

--- a/vlib/crypto/rand/rand.v
+++ b/vlib/crypto/rand/rand.v
@@ -5,6 +5,9 @@
 module rand
 
 struct ReadError {
-	msg  string = 'crypto.rand.read() error reading random bytes'
-	code int
+	BaseError
+}
+
+fn (err ReadError) msg() string {
+	return 'crypto.rand.read() error reading random bytes'
 }

--- a/vlib/encoding/csv/reader.v
+++ b/vlib/encoding/csv/reader.v
@@ -6,24 +6,36 @@ module csv
 // Once interfaces are further along the idea would be to have something similar to
 // go's io.reader & bufio.reader rather than reading the whole file into string, this
 // would then satisfy that interface. I designed it this way to be easily adapted.
-struct ErrCommentIsDelimiter {
-	msg  string = 'encoding.csv: comment cannot be the same as delimiter'
-	code int
+struct CommentIsDelimiterError {
+	BaseError
 }
 
-struct ErrInvalidDelimiter {
-	msg  string = 'encoding.csv: invalid delimiter'
-	code int
+fn (err CommentIsDelimiterError) msg() string {
+	return 'encoding.csv: comment cannot be the same as delimiter'
 }
 
-struct ErrEndOfFile {
-	msg  string = 'encoding.csv: end of file'
-	code int
+struct InvalidDelimiterError {
+	BaseError
 }
 
-struct ErrInvalidLineEnding {
-	msg  string = 'encoding.csv: could not find any valid line endings'
-	code int
+fn (err InvalidDelimiterError) msg() string {
+	return 'encoding.csv: invalid delimiter'
+}
+
+struct EndOfFileError {
+	BaseError
+}
+
+fn (err EndOfFileError) msg() string {
+	return 'encoding.csv: end of file'
+}
+
+struct InvalidLineEndingError {
+	BaseError
+}
+
+fn (err InvalidLineEndingError) msg() string {
+	return 'encoding.csv: could not find any valid line endings'
 }
 
 struct Reader {
@@ -72,7 +84,7 @@ pub fn (mut r Reader) read() ?[]string {
 fn (mut r Reader) read_line() ?string {
 	// last record
 	if r.row_pos == r.data.len {
-		return IError(&ErrEndOfFile{})
+		return IError(&EndOfFileError{})
 	}
 	le := if r.is_mac_pre_osx_le { '\r' } else { '\n' }
 	mut i := r.data.index_after(le, r.row_pos)
@@ -84,7 +96,7 @@ fn (mut r Reader) read_line() ?string {
 				r.is_mac_pre_osx_le = true
 			} else {
 				// no valid line endings found
-				return IError(&ErrInvalidLineEnding{})
+				return IError(&InvalidLineEndingError{})
 			}
 		} else {
 			// No line ending on file
@@ -102,10 +114,10 @@ fn (mut r Reader) read_line() ?string {
 
 fn (mut r Reader) read_record() ?[]string {
 	if r.delimiter == r.comment {
-		return IError(&ErrCommentIsDelimiter{})
+		return IError(&CommentIsDelimiterError{})
 	}
 	if !valid_delim(r.delimiter) {
-		return IError(&ErrInvalidDelimiter{})
+		return IError(&InvalidDelimiterError{})
 	}
 	mut need_read := true
 	mut keep_raw := false
@@ -185,7 +197,7 @@ fn (mut r Reader) read_record() ?[]string {
 			}
 		}
 		if i <= -1 && fields.len == 0 {
-			return IError(&ErrInvalidDelimiter{})
+			return IError(&InvalidDelimiterError{})
 		}
 	}
 	return fields

--- a/vlib/encoding/csv/writer.v
+++ b/vlib/encoding/csv/writer.v
@@ -23,7 +23,7 @@ pub fn new_writer() &Writer {
 // write writes a single record
 pub fn (mut w Writer) write(record []string) ?bool {
 	if !valid_delim(w.delimiter) {
-		return IError(&ErrInvalidDelimiter{})
+		return IError(&InvalidDelimiterError{})
 	}
 	le := if w.use_crlf { '\r\n' } else { '\n' }
 	for n, field_ in record {

--- a/vlib/flag/flag.v
+++ b/vlib/flag/flag.v
@@ -11,23 +11,28 @@ pub:
 }
 
 struct UnkownFlagError {
-	msg  string
-	code int
+	BaseError
+	flag string
 }
 
-struct MinimumArgsCountError {
-	msg  string
-	code int
+fn (err UnkownFlagError) msg() string {
+	return 'Unknown flag `$err.flag`'
 }
 
-struct MaximumArgsCountError {
-	msg  string
-	code int
+struct ArgsCountError {
+	BaseError
+	got  int
+	want int
 }
 
-struct NoArgsExpectedError {
-	msg  string
-	code int
+fn (err ArgsCountError) msg() string {
+	if err.want == 0 {
+		return 'Expected no arguments, but got $err.got'
+	} else if err.got > err.want {
+		return 'Expected at most $err.want arguments, but got $err.got'
+	} else {
+		return 'Expected at least $err.want arguments, but got $err.got'
+	}
 }
 
 // free frees the resources associated with a given Flag
@@ -617,24 +622,27 @@ pub fn (mut fs FlagParser) finalize() ?[]string {
 		for a in remaining {
 			if (a.len >= 2 && a[..2] == '--') || (a.len == 2 && a[0] == `-`) {
 				return IError(&UnkownFlagError{
-					msg: 'Unknown flag `$a`'
+					flag: a
 				})
 			}
 		}
 	}
 	if remaining.len < fs.min_free_args && fs.min_free_args > 0 {
-		return IError(&MinimumArgsCountError{
-			msg: 'Expected at least $fs.min_free_args arguments, but given $remaining.len'
+		return IError(&ArgsCountError{
+			want: fs.min_free_args
+			got: remaining.len
 		})
 	}
 	if remaining.len > fs.max_free_args && fs.max_free_args > 0 {
-		return IError(&MaximumArgsCountError{
-			msg: 'Expected at most $fs.max_free_args arguments, but given $remaining.len'
+		return IError(&ArgsCountError{
+			want: fs.max_free_args
+			got: remaining.len
 		})
 	}
 	if remaining.len > 0 && fs.max_free_args == 0 && fs.min_free_args == 0 {
-		return IError(&NoArgsExpectedError{
-			msg: 'Expected no arguments, but given $remaining.len'
+		return IError(&ArgsCountError{
+			want: 0
+			got: remaining.len
 		})
 	}
 	remaining << fs.all_after_dashdash
@@ -648,7 +656,7 @@ pub fn (mut fs FlagParser) finalize() ?[]string {
 // you want more control over the error handling.
 pub fn (mut fs FlagParser) remaining_parameters() []string {
 	return fs.finalize() or {
-		eprintln(err.msg)
+		eprintln(err.msg())
 		println(fs.usage())
 		exit(1)
 	}

--- a/vlib/flag/flag_test.v
+++ b/vlib/flag/flag_test.v
@@ -137,7 +137,7 @@ fn test_finalize_returns_error_for_unknown_flags_long() {
 	mut fp := flag.new_flag_parser(['--known', '--unknown'])
 	fp.bool('known', 0, false, '')
 	finalized := fp.finalize() or {
-		assert err.msg == 'Unknown flag `--unknown`'
+		assert err.msg() == 'Unknown flag `--unknown`'
 		return
 	}
 	assert finalized.len < 0 // expect error to be returned
@@ -147,7 +147,7 @@ fn test_finalize_returns_error_for_unknown_flags_short() {
 	mut fp := flag.new_flag_parser(['--known', '-x'])
 	fp.bool('known', 0, false, '')
 	finalized := fp.finalize() or {
-		assert err.msg == 'Unknown flag `-x`'
+		assert err.msg() == 'Unknown flag `-x`'
 		return
 	}
 	assert finalized.len < 0 // expect error to be returned
@@ -210,7 +210,7 @@ fn test_error_for_to_few_free_args() ? {
 	mut fp1 := flag.new_flag_parser(['a', 'b', 'c'])
 	fp1.limit_free_args(5, 6) ?
 	args := fp1.finalize() or {
-		assert err.msg.starts_with('Expected at least 5 arguments')
+		assert err.msg().starts_with('Expected at least 5 arguments')
 		return
 	}
 	assert args.len < 0 // expect an error and need to use args
@@ -220,7 +220,7 @@ fn test_error_for_to_much_free_args() ? {
 	mut fp1 := flag.new_flag_parser(['a', 'b', 'c'])
 	fp1.limit_free_args(1, 2) ?
 	args := fp1.finalize() or {
-		assert err.msg.starts_with('Expected at most 2 arguments')
+		assert err.msg().starts_with('Expected at most 2 arguments')
 		return
 	}
 	assert args.len < 0 // expect an error and need to use args
@@ -230,7 +230,7 @@ fn test_could_expect_no_free_args() ? {
 	mut fp1 := flag.new_flag_parser(['a'])
 	fp1.limit_free_args(0, 0) ?
 	args := fp1.finalize() or {
-		assert err.msg.starts_with('Expected no arguments')
+		assert err.msg().starts_with('Expected no arguments')
 		return
 	}
 	assert args.len < 0 // expect an error and need to use args

--- a/vlib/io/util/util.v
+++ b/vlib/io/util/util.v
@@ -24,7 +24,7 @@ pub fn temp_file(tfo TempFileOptions) ?(os.File, string) {
 			' could not create temporary file in "$d". Please ensure write permissions.')
 	}
 	d = d.trim_right(os.path_separator)
-	prefix, suffix := prefix_and_suffix(tfo.pattern) or { return error(@FN + ' ' + err.msg) }
+	prefix, suffix := prefix_and_suffix(tfo.pattern) or { return error(@FN + ' ' + err.msg()) }
 	for retry := 0; retry < util.retries; retry++ {
 		path := os.join_path(d, prefix + random_number() + suffix)
 		mut mode := 'rw+'
@@ -57,7 +57,7 @@ pub fn temp_dir(tdo TempFileOptions) ?string {
 			' could not create temporary directory "$d". Please ensure write permissions.')
 	}
 	d = d.trim_right(os.path_separator)
-	prefix, suffix := prefix_and_suffix(tdo.pattern) or { return error(@FN + ' ' + err.msg) }
+	prefix, suffix := prefix_and_suffix(tdo.pattern) or { return error(@FN + ' ' + err.msg()) }
 	for retry := 0; retry < util.retries; retry++ {
 		path := os.join_path(d, prefix + random_number() + suffix)
 		os.mkdir_all(path) or { continue }

--- a/vlib/json/json_decode_test.v
+++ b/vlib/json/json_decode_test.v
@@ -14,7 +14,7 @@ mut:
 fn test_json_decode_fails_to_decode_unrecognised_array_of_dicts() {
 	data := '[{"twins":[{"id":123,"seed":"abcde","pubkey":"xyzasd"},{"id":456,"seed":"dfgdfgdfgd","pubkey":"skjldskljh45sdf"}]}]'
 	json.decode(TestTwins, data) or {
-		assert err.msg == "expected field 'twins' is missing"
+		assert err.msg() == "expected field 'twins' is missing"
 		return
 	}
 	assert false

--- a/vlib/json/json_test.v
+++ b/vlib/json/json_test.v
@@ -333,7 +333,7 @@ fn test_errors() {
 		data := '{"countries":[{"cities":[{"name":"London"},{"name":"Manchester"}],"name":"UK"},{"cities":{"name":"Donlon"},"name":"KU"}],"users":{"Foo":{"age":10,"nums":[1,2,3],"lastName":"Johnson","IsRegistered":true,"type":0,"pet_animals":"little foo"},"Boo":{"age":20,"nums":[5,3,1],"lastName":"Smith","IsRegistered":false,"type":4,"pet_animals":"little boo"}},"extra":{"2":{"n1":2,"n2":4,"n3":8,"n4":16},"3":{"n1":3,"n2":9,"n3":27,"n4":81}}}'
 		json.decode(Data, data) or {
 			println(err)
-			assert err.msg.starts_with('Json element is not an array:')
+			assert err.msg().starts_with('Json element is not an array:')
 			return
 		}
 		assert false
@@ -342,7 +342,7 @@ fn test_errors() {
 		data := '{"countries":[{"cities":[{"name":"London"},{"name":"Manchester"}],"name":"UK"},{"cities":[{"name":"Donlon"},{"name":"Termanches"}],"name":"KU"}],"users":[{"age":10,"nums":[1,2,3],"lastName":"Johnson","IsRegistered":true,"type":0,"pet_animals":"little foo"},{"age":20,"nums":[5,3,1],"lastName":"Smith","IsRegistered":false,"type":4,"pet_animals":"little boo"}],"extra":{"2":{"n1":2,"n2":4,"n3":8,"n4":16},"3":{"n1":3,"n2":9,"n3":27,"n4":81}}}'
 		json.decode(Data, data) or {
 			println(err)
-			assert err.msg.starts_with('Json element is not an object:')
+			assert err.msg().starts_with('Json element is not an object:')
 			return
 		}
 		assert false

--- a/vlib/mysql/mysql.v
+++ b/vlib/mysql/mysql.v
@@ -20,8 +20,7 @@ pub enum ConnectionFlag {
 }
 
 struct SQLError {
-	msg  string
-	code int
+	Error
 }
 
 // TODO: Documentation

--- a/vlib/net/common.v
+++ b/vlib/net/common.v
@@ -74,7 +74,7 @@ fn select_with_retry(handle int, test Select, timeout time.Duration) ?bool {
 	mut retries := 10
 	for retries > 0 {
 		ready := @select(handle, test, timeout) or {
-			if err.code == 4 {
+			if err.code() == 4 {
 				// signal! lets retry max 10 times
 				// suspend thread with sleep to let the gc get
 				// cycles in the case the Bohem gc is interupting

--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -633,6 +633,16 @@ struct HeaderKeyError {
 	invalid_char byte
 }
 
+// FIXME shouldn't be required once `Error` embedding works correctly
+fn (err HeaderKeyError) msg() string {
+	return err.msg
+}
+
+// FIXME shouldn't be required once `Error` embedding works correctly
+fn (err HeaderKeyError) code() int {
+	return err.code
+}
+
 // is_valid checks if the header token contains all valid bytes
 fn is_valid(header string) ? {
 	for _, c in header {

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -252,15 +252,23 @@ pub:
 }
 
 pub struct UnexpectedExtraAttributeError {
-pub:
-	msg  string
-	code int
+	Error
+}
+
+fn (err UnexpectedExtraAttributeError) msg() string {
+	return err.msg
+}
+
+fn (err UnexpectedExtraAttributeError) code() int {
+	return err.code
 }
 
 pub struct MultiplePathAttributesError {
-pub:
-	msg  string = 'Expected at most one path attribute'
-	code int
+	BaseError
+}
+
+fn (err MultiplePathAttributesError) msg() string {
+	return 'Expected at most one path attribute'
 }
 
 // multipart_form_body converts form and file data into a multipart/form

--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -48,7 +48,7 @@ pub fn (mut s Server) listen_and_serve() ? {
 			break
 		}
 		mut conn := s.listener.accept() or {
-			if err.msg != 'net: op timed out' {
+			if err.msg() != 'net: op timed out' {
 				eprintln('accept() failed: $err; skipping')
 			}
 			continue

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -410,7 +410,7 @@ fn split_by_scheme(rawurl string) ?[]string {
 }
 
 fn get_scheme(rawurl string) ?string {
-	split := split_by_scheme(rawurl) or { return err.msg }
+	split := split_by_scheme(rawurl) or { return err.msg() }
 	return split[0]
 }
 
@@ -593,9 +593,9 @@ fn parse_host(host string) ?string {
 		// We do impose some restrictions on the zone, to avoid stupidity
 		// like newlines.
 		if zone := host[..i].index('%25') {
-			host1 := unescape(host[..zone], .encode_host) or { return err.msg }
-			host2 := unescape(host[zone..i], .encode_zone) or { return err.msg }
-			host3 := unescape(host[i..], .encode_host) or { return err.msg }
+			host1 := unescape(host[..zone], .encode_host) or { return err.msg() }
+			host2 := unescape(host[zone..i], .encode_zone) or { return err.msg() }
+			host3 := unescape(host[i..], .encode_host) or { return err.msg() }
 			return host1 + host2 + host3
 		}
 		if idx := host.last_index(':') {
@@ -606,7 +606,7 @@ fn parse_host(host string) ?string {
 			}
 		}
 	}
-	h := unescape(host, .encode_host) or { return err.msg }
+	h := unescape(host, .encode_host) or { return err.msg() }
 	return h
 	// host = h
 	// return host

--- a/vlib/net/websocket/io.v
+++ b/vlib/net/websocket/io.v
@@ -15,7 +15,7 @@ fn (mut ws Client) socket_read(mut buffer []byte) ?int {
 		} else {
 			for {
 				r := ws.conn.read(mut buffer) or {
-					if err.code == net.err_timed_out_code {
+					if err.code() == net.err_timed_out_code {
 						continue
 					}
 					return err
@@ -39,7 +39,7 @@ fn (mut ws Client) socket_read_ptr(buf_ptr &byte, len int) ?int {
 		} else {
 			for {
 				r := ws.conn.read_ptr(buf_ptr, len) or {
-					if err.code == net.err_timed_out_code {
+					if err.code() == net.err_timed_out_code {
 						continue
 					}
 					return err
@@ -63,7 +63,7 @@ fn (mut ws Client) socket_write(bytes []byte) ?int {
 		} else {
 			for {
 				n := ws.conn.write(bytes) or {
-					if err.code == net.err_timed_out_code {
+					if err.code() == net.err_timed_out_code {
 						continue
 					}
 					return err

--- a/vlib/net/websocket/websocket_server.v
+++ b/vlib/net/websocket/websocket_server.v
@@ -122,7 +122,7 @@ fn (mut s Server) serve_client(mut c Client) ? {
 	}
 	s.setup_callbacks(mut server_client)
 	c.listen() or {
-		s.logger.error(err.msg)
+		s.logger.error(err.msg())
 		return err
 	}
 }

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -478,22 +478,28 @@ pub fn (mut f File) flush() {
 	C.fflush(f.cfile)
 }
 
-pub struct ErrFileNotOpened {
-	msg  string = 'os: file not opened'
-	code int
+pub struct FileNotOpenedError {
+	BaseError
 }
 
-pub struct ErrSizeOfTypeIs0 {
-	msg  string = 'os: size of type is 0'
-	code int
+fn (err FileNotOpenedError) msg() string {
+	return 'os: file not opened'
+}
+
+pub struct SizeOfTypeIs0Error {
+	BaseError
+}
+
+fn (err SizeOfTypeIs0Error) msg() string {
+	return 'os: size of type is 0'
 }
 
 fn error_file_not_opened() IError {
-	return IError(&ErrFileNotOpened{})
+	return IError(&FileNotOpenedError{})
 }
 
 fn error_size_of_type_0() IError {
-	return IError(&ErrSizeOfTypeIs0{})
+	return IError(&SizeOfTypeIs0Error{})
 }
 
 // read_struct reads a single struct of type `T`

--- a/vlib/os/file.js.v
+++ b/vlib/os/file.js.v
@@ -11,19 +11,19 @@ pub mut:
 
 // todo(playX):   __as_cast is broken here
 /*
-pub struct ErrFileNotOpened {
+pub struct FileNotOpenedError {
 	msg  string = 'os: file not opened'
 	code int
 }
-pub struct ErrSizeOfTypeIs0 {
+pub struct SizeOfTypeIs0Error {
 	msg  string = 'os: size of type is 0'
 	code int
 }
 fn error_file_not_opened() IError {
-	return IError(&ErrFileNotOpened{})
+	return IError(&FileNotOpenedError{})
 }
 fn error_size_of_type_0() IError {
-	return IError(&ErrSizeOfTypeIs0{})
+	return IError(&SizeOfTypeIs0Error{})
 }
 */
 pub fn open_file(path string, mode string, options ...int) ?File {

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -273,7 +273,10 @@ fn test_write_raw_at_negative_pos() ? {
 	if _ := f.write_raw_at(another_point, -1) {
 		assert false
 	}
-	f.write_raw_at(another_point, -234) or { assert err.msg == 'Invalid argument' }
+	f.write_raw_at(another_point, -234) or {
+		msg := err.msg() // FIXME: `err.msg()` should not require a special variable
+		assert msg == 'Invalid argument'
+	}
 	f.close()
 }
 
@@ -328,7 +331,10 @@ fn test_read_raw_at_negative_pos() ? {
 	if _ := f.read_raw_at<Point>(-1) {
 		assert false
 	}
-	f.read_raw_at<Point>(-234) or { assert err.msg == 'Invalid argument' }
+	f.read_raw_at<Point>(-234) or {
+		msg := err.msg() // FIXME: `err.msg()` should not require a special variable
+		assert msg == 'Invalid argument'
+	}
 	f.close()
 }
 

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -139,12 +139,12 @@ pub fn rmdir_all(path string) ? {
 	for item in items {
 		fullpath := join_path_single(path, item)
 		if is_dir(fullpath) && !is_link(fullpath) {
-			rmdir_all(fullpath) or { ret_err = err.msg }
+			rmdir_all(fullpath) or { ret_err = err.msg() }
 		} else {
-			rm(fullpath) or { ret_err = err.msg }
+			rm(fullpath) or { ret_err = err.msg() }
 		}
 	}
-	rmdir(path) or { ret_err = err.msg }
+	rmdir(path) or { ret_err = err.msg() }
 	if ret_err.len > 0 {
 		return error(ret_err)
 	}
@@ -394,8 +394,11 @@ fn executable_fallback() string {
 }
 
 pub struct ErrExecutableNotFound {
-	msg  string = 'os: failed to find executable'
-	code int
+	BaseError
+}
+
+fn (err ErrExecutableNotFound) msg() string {
+	return 'os: failed to find executable'
 }
 
 fn error_failed_to_find_executable() IError {

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -35,7 +35,8 @@ fn test_open_file() {
 	filename := './test1.txt'
 	hello := 'hello world!'
 	os.open_file(filename, 'r+', 0o666) or {
-		assert err.msg == 'No such file or directory'
+		msg := err.msg() // FIXME: `err.msg()` should not require a special variable
+		assert msg == 'No such file or directory'
 		os.File{}
 	}
 	mut file := os.open_file(filename, 'w+', 0o666) or { panic(err) }
@@ -51,8 +52,8 @@ fn test_open_file_binary() {
 	filename := './test1.dat'
 	hello := 'hello \n world!'
 	os.open_file(filename, 'r+', 0o666) or {
-		assert err.msg == 'No such file or directory'
-		os.File{}
+		msg := err.msg() // FIXME: `err.msg()` should not require a special variable
+		assert msg == 'No such file or directory'
 	}
 	mut file := os.open_file(filename, 'wb+', 0o666) or { panic(err) }
 	bytes := hello.bytes()

--- a/vlib/os/signal_test.v
+++ b/vlib/os/signal_test.v
@@ -20,8 +20,10 @@ fn test_signal_opt_invalid_argument() {
 		assert false
 	}
 	os.signal_opt(.kill, default_handler) or {
-		assert err.msg == 'Invalid argument'
-		assert err.code == 22
+		msg := err.msg() // FIXME: `err.msg()` should not require a special variable
+		code := err.code() // FIXME: `err.code()` should not require a special variable
+		assert msg == 'Invalid argument'
+		assert code == 22
 	}
 }
 

--- a/vlib/semver/range.v
+++ b/vlib/semver/range.v
@@ -30,13 +30,11 @@ struct Range {
 }
 
 struct InvalidComparatorCountError {
-	msg  string
-	code int
+	Error
 }
 
 struct InvalidComparatorFormatError {
-	msg  string
-	code int
+	Error
 }
 
 fn (r Range) satisfies(ver Version) bool {

--- a/vlib/semver/semver.v
+++ b/vlib/semver/semver.v
@@ -20,13 +20,15 @@ pub enum Increment {
 }
 
 struct EmptyInputError {
-	msg  string = 'Empty input'
-	code int
+	BaseError
+}
+
+fn (err EmptyInputError) msg() string {
+	return 'Empty input'
 }
 
 struct InvalidVersionFormatError {
-	msg  string
-	code int
+	Error
 }
 
 // * Constructor.

--- a/vlib/sqlite/sqlite.v
+++ b/vlib/sqlite/sqlite.v
@@ -33,8 +33,7 @@ struct Stmt {
 }
 
 struct SQLError {
-	msg  string
-	code int
+	Error
 }
 
 //

--- a/vlib/sync/channel_opt_propagate_test.v
+++ b/vlib/sync/channel_opt_propagate_test.v
@@ -14,7 +14,7 @@ fn do_rec_calc_send(chs []chan i64, mut sem sync.Semaphore) {
 	mut msg := ''
 	for {
 		mut s := get_val_from_chan(chs[0]) or {
-			msg = err.msg
+			msg = err.msg()
 			break
 		}
 		s++

--- a/vlib/time/parse.v
+++ b/vlib/time/parse.v
@@ -4,13 +4,20 @@
 module time
 
 pub struct TimeParseError {
-	msg  string
+	BaseError
 	code int
+}
+
+fn (err TimeParseError) msg() string {
+	return 'Invalid time format code: $err.code'
+}
+
+fn (err TimeParseError) code() int {
+	return err.code
 }
 
 fn error_invalid_time(code int) IError {
 	return TimeParseError{
-		msg: 'Invalid time format code: $code'
 		code: code
 	}
 }

--- a/vlib/toml/checker/checker.v
+++ b/vlib/toml/checker/checker.v
@@ -477,14 +477,14 @@ fn (c Checker) check_quoted_escapes(q ast.Quoted) ? {
 					c.check_unicode_escape(s.text[pos..pos + 11]) or {
 						st := s.state()
 						return error(@MOD + '.' + @STRUCT + '.' + @FN +
-							' escaped Unicode is invalid. $err.msg.capitalize() ($st.line_nr,$st.col) in ...${c.excerpt(q.pos)}...')
+							' escaped Unicode is invalid. $err.msg().capitalize() ($st.line_nr,$st.col) in ...${c.excerpt(q.pos)}...')
 					}
 				} else {
 					pos := s.state().pos
 					c.check_unicode_escape(s.text[pos..]) or {
 						st := s.state()
 						return error(@MOD + '.' + @STRUCT + '.' + @FN +
-							' escaped Unicode is invalid. $err.msg.capitalize() ($st.line_nr,$st.col) in ...${c.excerpt(q.pos)}...')
+							' escaped Unicode is invalid. $err.msg().capitalize() ($st.line_nr,$st.col) in ...${c.excerpt(q.pos)}...')
 					}
 				}
 			}

--- a/vlib/toml/input/input.v
+++ b/vlib/toml/input/input.v
@@ -47,7 +47,7 @@ pub fn (c Config) read_input() ?string {
 	if os.is_file(c.file_path) {
 		text = os.read_file(c.file_path) or {
 			return error(@MOD + '.' + @STRUCT + '.' + @FN +
-				' Could not read "$c.file_path": "$err.msg"')
+				' Could not read "$c.file_path": "$err.msg()"')
 		}
 	}
 	return text

--- a/vlib/toml/scanner/scanner.v
+++ b/vlib/toml/scanner/scanner.v
@@ -55,7 +55,7 @@ pub fn new_scanner(config Config) ?&Scanner {
 	if os.is_file(file_path) {
 		text = os.read_file(file_path) or {
 			return error(@MOD + '.' + @STRUCT + '.' + @FN +
-				' Could not read "$file_path": "$err.msg"')
+				' Could not read "$file_path": "$err.msg()"')
 		}
 	}
 	mut s := &Scanner{

--- a/vlib/toml/tests/alexcrichton.toml-rs-tests_test.v
+++ b/vlib/toml/tests/alexcrichton.toml-rs-tests_test.v
@@ -135,12 +135,12 @@ fn test_alexcrichton_toml_rs() {
 
 					v_normalized_json := run([jq, '-S', '-f "$jq_normalize_path"', v_toml_json_path]) or {
 						contents := os.read_file(v_toml_json_path) or { panic(err) }
-						panic(err.msg + '\n$contents')
+						panic(err.msg() + '\n$contents')
 					}
 					alexcrichton_normalized_json := run([jq, '-S', '-f "$jq_normalize_path"',
 						alexcrichton_toml_json_path]) or {
 						contents := os.read_file(v_toml_json_path) or { panic(err) }
-						panic(err.msg + '\n$contents')
+						panic(err.msg() + '\n$contents')
 					}
 
 					assert alexcrichton_normalized_json == v_normalized_json
@@ -176,7 +176,7 @@ fn test_alexcrichton_toml_rs() {
 					println('     This TOML should have failed:\n${'-'.repeat(40)}\n$content_that_should_have_failed\n${'-'.repeat(40)}')
 					assert false
 				} else {
-					println('     $err.msg')
+					println('     $err.msg()')
 					assert true
 				}
 				invalid++

--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -114,11 +114,11 @@ fn test_burnt_sushi_tomltest() {
 
 					v_normalized_json := run([jq, '-S', '-f "$jq_normalize_path"', v_toml_json_path]) or {
 						contents := os.read_file(v_toml_json_path) or { panic(err) }
-						panic(err.msg + '\n$contents')
+						panic(err.msg() + '\n$contents')
 					}
 					bs_normalized_json := run([jq, '-S', '-f "$jq_normalize_path"', bs_toml_json_path]) or {
 						contents := os.read_file(v_toml_json_path) or { panic(err) }
-						panic(err.msg + '\n$contents')
+						panic(err.msg() + '\n$contents')
 					}
 
 					assert bs_normalized_json == v_normalized_json
@@ -154,7 +154,7 @@ fn test_burnt_sushi_tomltest() {
 					println('     This TOML should have failed:\n${'-'.repeat(40)}\n$content_that_should_have_failed\n${'-'.repeat(40)}')
 					assert false
 				} else {
-					println('     $err.msg')
+					println('     $err.msg()')
 					assert true
 				}
 				invalid++

--- a/vlib/toml/tests/iarna.toml-spec-tests_test.v
+++ b/vlib/toml/tests/iarna.toml-spec-tests_test.v
@@ -149,7 +149,7 @@ fn test_iarna_toml_spec_tests() {
 								// NOTE there's known errors with the python convertion method.
 								// For now we just ignore them as it's a broken tool - not a wrong test-case.
 								// Uncomment this print to see/check them.
-								// eprintln(err.msg + '\n$contents')
+								// eprintln(err.msg() + '\n$contents')
 								e++
 								println('ERR  [${i + 1}/$valid_test_files.len] "$valid_test_file" EXCEPTION [$e/$valid_value_exceptions.len]...')
 								continue
@@ -178,12 +178,12 @@ fn test_iarna_toml_spec_tests() {
 
 					v_normalized_json := run([jq, '-S', '-f "$jq_normalize_path"', v_toml_json_path]) or {
 						contents := os.read_file(v_toml_json_path) or { panic(err) }
-						panic(err.msg + '\n$contents')
+						panic(err.msg() + '\n$contents')
 					}
 					iarna_normalized_json := run([jq, '-S', '-f "$jq_normalize_path"',
 						iarna_toml_json_path]) or {
 						contents := os.read_file(v_toml_json_path) or { panic(err) }
-						panic(err.msg + '\n$contents')
+						panic(err.msg() + '\n$contents')
 					}
 
 					assert iarna_normalized_json == v_normalized_json
@@ -218,7 +218,7 @@ fn test_iarna_toml_spec_tests() {
 					println('     This TOML should have failed:\n${'-'.repeat(40)}\n$content_that_should_have_failed\n${'-'.repeat(40)}')
 					assert false
 				} else {
-					println('     $err.msg')
+					println('     $err.msg()')
 					assert true
 				}
 				invalid++

--- a/vlib/toml/tests/toml_bom_test.v
+++ b/vlib/toml/tests/toml_bom_test.v
@@ -37,13 +37,13 @@ fn test_toml_with_bom() {
 	// Re-cycle bad_toml_doc
 	mut bad_toml_doc := empty_toml_document
 	bad_toml_doc = toml.parse(toml_text_with_utf16_bom) or {
-		println('     $err.msg')
+		println('     $err.msg()')
 		assert true
 		empty_toml_document
 	}
 
 	bad_toml_doc = toml.parse(toml_text_with_utf32_bom) or {
-		println('     $err.msg')
+		println('     $err.msg()')
 		assert true
 		empty_toml_document
 	}

--- a/vlib/v/builder/cbuilder/cbuilder.v
+++ b/vlib/v/builder/cbuilder/cbuilder.v
@@ -36,8 +36,8 @@ pub fn compile_c(mut b builder.Builder) {
 
 pub fn gen_c(mut b builder.Builder, v_files []string) string {
 	b.front_and_middle_stages(v_files) or {
-		if err.code != 9999 {
-			builder.verror(err.msg)
+		if err.code() != 9999 {
+			builder.verror(err.msg())
 		}
 		return ''
 	}

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -22,7 +22,7 @@ pub fn compile(command string, pref &pref.Preferences, backend_cb FnBackend) {
 	}
 	os.is_writable_folder(output_folder) or {
 		// An early error here, is better than an unclear C error later:
-		verror(err.msg)
+		verror(err.msg())
 	}
 	// Construct the V object from command line arguments
 	mut b := new_builder(pref)

--- a/vlib/v/builder/rebuilding.v
+++ b/vlib/v/builder/rebuilding.v
@@ -181,7 +181,7 @@ fn (mut b Builder) rebuild_cached_module(vexe string, imp_path string) string {
 		}
 		b.v_build_module(vexe, imp_path)
 		rebuilded_o := b.pref.cache_manager.exists('.o', imp_path) or {
-			panic('could not rebuild cache module for $imp_path, error: $err.msg')
+			panic('could not rebuild cache module for $imp_path, error: $err.msg()')
 		}
 		return rebuilded_o
 	}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -529,7 +529,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 							node.pos)
 					}
 				} else {
-					c.error('cannot assign to `$left`: $err.msg', right.position())
+					c.error('cannot assign to `$left`: $err.msg()', right.position())
 				}
 			}
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -572,7 +572,7 @@ pub fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 							}
 						}
 					} else {
-						c.error('incompatible initializer for field `$field.name`: $err.msg',
+						c.error('incompatible initializer for field `$field.name`: $err.msg()',
 							field.default_expr.position())
 					}
 				}
@@ -769,7 +769,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 					}
 				} else if expr_type != ast.void_type && expr_type_sym.kind != .placeholder {
 					c.check_expected(c.unwrap_generic(expr_type), c.unwrap_generic(field_info.typ)) or {
-						c.error('cannot assign to field `$field_info.name`: $err.msg',
+						c.error('cannot assign to field `$field_info.name`: $err.msg()',
 							field.pos)
 					}
 				}
@@ -979,7 +979,7 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					if left_sym.kind !in [.sum_type, .interface_] {
 						elem_type := right_final.array_info().elem_type
 						c.check_expected(left_type, elem_type) or {
-							c.error('left operand to `$node.op` does not match the array element type: $err.msg',
+							c.error('left operand to `$node.op` does not match the array element type: $err.msg()',
 								left_right_pos)
 						}
 					}
@@ -987,7 +987,7 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				.map {
 					map_info := right_final.map_info()
 					c.check_expected(left_type, map_info.key_type) or {
-						c.error('left operand to `$node.op` does not match the map key type: $err.msg',
+						c.error('left operand to `$node.op` does not match the map key type: $err.msg()',
 							left_right_pos)
 					}
 					node.left_type = map_info.key_type
@@ -2003,15 +2003,15 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 			has_field = true
 			mut embed_types := []ast.Type{}
 			field, embed_types = c.table.find_field_from_embeds(sym, field_name) or {
-				if err.msg != '' {
-					c.error(err.msg, node.pos)
+				if err.msg() != '' {
+					c.error(err.msg(), node.pos)
 				}
 				has_field = false
 				ast.StructField{}, []ast.Type{}
 			}
 			node.from_embed_types = embed_types
 			if sym.kind in [.aggregate, .sum_type] {
-				unknown_field_msg = err.msg
+				unknown_field_msg = err.msg()
 			}
 		}
 		if !c.inside_unsafe {
@@ -2032,8 +2032,8 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 				has_field = true
 				mut embed_types := []ast.Type{}
 				field, embed_types = c.table.find_field_from_embeds(gs, field_name) or {
-					if err.msg != '' {
-						c.error(err.msg, node.pos)
+					if err.msg() != '' {
+						c.error(err.msg(), node.pos)
 					}
 					has_field = false
 					ast.StructField{}, []ast.Type{}
@@ -2204,7 +2204,7 @@ pub fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 			default_expr := node.default_expr
 			default_typ := c.check_expr_opt_call(default_expr, c.expr(default_expr))
 			c.check_expected(default_typ, node.elem_type) or {
-				c.error(err.msg, default_expr.position())
+				c.error(err.msg(), default_expr.position())
 			}
 		}
 		if node.has_len {
@@ -2296,7 +2296,7 @@ pub fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 			}
 			if expr !is ast.TypeNode {
 				c.check_expected(typ, elem_type) or {
-					c.error('invalid array element: $err.msg', expr.position())
+					c.error('invalid array element: $err.msg()', expr.position())
 				}
 			}
 		}
@@ -2924,7 +2924,7 @@ fn (mut c Checker) hash_stmt(mut node ast.HashStmt) {
 			if flag.contains('@VROOT') {
 				// c.note(checker.vroot_is_deprecated_message, node.pos)
 				vroot := util.resolve_vmodroot(flag.replace('@VROOT', '@VMODROOT'), c.file.path) or {
-					c.error(err.msg, node.pos)
+					c.error(err.msg(), node.pos)
 					return
 				}
 				node.val = 'include $vroot'
@@ -2939,7 +2939,7 @@ fn (mut c Checker) hash_stmt(mut node ast.HashStmt) {
 			}
 			if flag.contains('@VMODROOT') {
 				vroot := util.resolve_vmodroot(flag, c.file.path) or {
-					c.error(err.msg, node.pos)
+					c.error(err.msg(), node.pos)
 					return
 				}
 				node.val = 'include $vroot'
@@ -2948,7 +2948,7 @@ fn (mut c Checker) hash_stmt(mut node ast.HashStmt) {
 			}
 			if flag.contains('\$env(') {
 				env := util.resolve_env_value(flag, true) or {
-					c.error(err.msg, node.pos)
+					c.error(err.msg(), node.pos)
 					return
 				}
 				node.main = env
@@ -2967,15 +2967,15 @@ fn (mut c Checker) hash_stmt(mut node ast.HashStmt) {
 				'--cflags --libs $node.main'.split(' ')
 			}
 			mut m := pkgconfig.main(args) or {
-				c.error(err.msg, node.pos)
+				c.error(err.msg(), node.pos)
 				return
 			}
 			cflags := m.run() or {
-				c.error(err.msg, node.pos)
+				c.error(err.msg(), node.pos)
 				return
 			}
 			c.table.parse_cflag(cflags, c.mod, c.pref.compile_defines_all) or {
-				c.error(err.msg, node.pos)
+				c.error(err.msg(), node.pos)
 				return
 			}
 		}
@@ -2985,7 +2985,7 @@ fn (mut c Checker) hash_stmt(mut node ast.HashStmt) {
 			if flag.contains('@VROOT') {
 				// c.note(checker.vroot_is_deprecated_message, node.pos)
 				flag = util.resolve_vmodroot(flag.replace('@VROOT', '@VMODROOT'), c.file.path) or {
-					c.error(err.msg, node.pos)
+					c.error(err.msg(), node.pos)
 					return
 				}
 			}
@@ -2995,13 +2995,13 @@ fn (mut c Checker) hash_stmt(mut node ast.HashStmt) {
 			}
 			if flag.contains('@VMODROOT') {
 				flag = util.resolve_vmodroot(flag, c.file.path) or {
-					c.error(err.msg, node.pos)
+					c.error(err.msg(), node.pos)
 					return
 				}
 			}
 			if flag.contains('\$env(') {
 				flag = util.resolve_env_value(flag, true) or {
-					c.error(err.msg, node.pos)
+					c.error(err.msg(), node.pos)
 					return
 				}
 			}
@@ -3015,7 +3015,7 @@ fn (mut c Checker) hash_stmt(mut node ast.HashStmt) {
 			}
 			// println('adding flag "$flag"')
 			c.table.parse_cflag(flag, c.mod, c.pref.compile_defines_all) or {
-				c.error(err.msg, node.pos)
+				c.error(err.msg(), node.pos)
 			}
 		}
 		else {
@@ -3775,14 +3775,14 @@ pub fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 						typ: typ
 						is_optional: is_optional
 					}
-					if typ == ast.error_type && c.expected_type == ast.string_type
-						&& !c.using_new_err_struct && !c.inside_selector_expr
-						&& !c.inside_println_arg && !c.file.mod.name.contains('v.')
-						&& !c.is_builtin_mod {
-						//                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <- TODO: remove; this prevents a failure in the `performance-regressions` CI job
-						c.warn('string errors are deprecated; use `err.msg` instead',
-							node.pos)
-					}
+					// if typ == ast.error_type && c.expected_type == ast.string_type
+					// 	&& !c.using_new_err_struct && !c.inside_selector_expr
+					// 	&& !c.inside_println_arg && !c.file.mod.name.contains('v.')
+					// 	&& !c.is_builtin_mod {
+					// 	//                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <- TODO: remove; this prevents a failure in the `performance-regressions` CI job
+					// 	c.warn('string errors are deprecated; use `err.msg()` instead',
+					// 		node.pos)
+					// }
 					// if typ == ast.t_type {
 					// sym := c.table.get_type_symbol(c.cur_generic_type)
 					// println('IDENT T unresolved $node.name typ=$sym.name')

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -12,7 +12,7 @@ fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) ast.Type {
 	node.left_type = c.expr(node.left)
 	if node.is_env {
 		env_value := util.resolve_env_value("\$env('$node.args_var')", false) or {
-			c.error(err.msg, node.env_pos)
+			c.error(err.msg(), node.env_pos)
 			return ast.string_type
 		}
 		node.env_value = env_value
@@ -463,7 +463,7 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Position) bool {
 						left_type := c.expr(cond.left)
 						right_type := c.expr(cond.right)
 						expr := c.find_definition(cond.left) or {
-							c.error(err.msg, cond.left.pos)
+							c.error(err.msg(), cond.left.pos)
 							return false
 						}
 						if !c.check_types(right_type, left_type) {
@@ -543,7 +543,7 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Position) bool {
 					return false
 				}
 				expr := c.find_obj_definition(cond.obj) or {
-					c.error(err.msg, cond.pos)
+					c.error(err.msg(), cond.pos)
 					return false
 				}
 				if !c.check_types(typ, ast.bool_type) {
@@ -558,7 +558,7 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Position) bool {
 		ast.ComptimeCall {
 			if cond.is_pkgconfig {
 				mut m := pkgconfig.main([cond.args_var]) or {
-					c.error(err.msg, cond.pos)
+					c.error(err.msg(), cond.pos)
 					return true
 				}
 				m.run() or { return true }
@@ -674,7 +674,7 @@ fn (mut c Checker) map_builtin_method_call(mut node ast.CallExpr, left_type ast.
 			info := left_sym.info as ast.Map
 			arg_type := c.expr(node.args[0].expr)
 			c.check_expected_call_arg(arg_type, info.key_type, node.language, node.args[0]) or {
-				c.error('$err.msg in argument 1 to `Map.delete`', node.args[0].pos)
+				c.error('$err.msg() in argument 1 to `Map.delete`', node.args[0].pos)
 			}
 		}
 		else {}

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -787,7 +787,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 					continue
 				}
 			}
-			c.error('$err.msg in argument ${i + 1} to `$fn_name`', call_arg.pos)
+			c.error('$err.msg() in argument ${i + 1} to `$fn_name`', call_arg.pos)
 		}
 		// Warn about automatic (de)referencing, which will be removed soon.
 		if func.language != .c && !c.inside_unsafe && typ.nr_muls() != param.typ.nr_muls()
@@ -829,7 +829,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 						continue
 					}
 					c.check_expected_call_arg(utyp, unwrap_typ, node.language, call_arg) or {
-						c.error('$err.msg in argument ${i + 1} to `$fn_name`', call_arg.pos)
+						c.error('$err.msg() in argument ${i + 1} to `$fn_name`', call_arg.pos)
 					}
 				}
 			}
@@ -1022,8 +1022,8 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 			has_method = true
 			mut embed_types := []ast.Type{}
 			method, embed_types = c.table.find_method_from_embeds(left_sym, method_name) or {
-				if err.msg != '' {
-					c.error(err.msg, node.pos)
+				if err.msg() != '' {
+					c.error(err.msg(), node.pos)
 				}
 				has_method = false
 				ast.Fn{}, []ast.Type{}
@@ -1035,7 +1035,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 		}
 		if left_sym.kind == .aggregate {
 			// the error message contains the problematic type
-			unknown_method_msg = err.msg
+			unknown_method_msg = err.msg()
 		}
 	}
 	if has_method {
@@ -1145,7 +1145,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 				// continue
 				// }
 				if got_arg_typ != ast.void_type {
-					c.error('$err.msg in argument ${i + 1} to `${left_sym.name}.$method_name`',
+					c.error('$err.msg() in argument ${i + 1} to `${left_sym.name}.$method_name`',
 						arg.pos)
 				}
 			}
@@ -1281,7 +1281,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 					c.check_expected_call_arg(targ, c.unwrap_generic(exp_arg_typ), node.language,
 						arg) or {
 						if targ != ast.void_type {
-							c.error('$err.msg in argument ${i + 1} to `${left_sym.name}.$method_name`',
+							c.error('$err.msg() in argument ${i + 1} to `${left_sym.name}.$method_name`',
 								arg.pos)
 						}
 					}

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -204,7 +204,7 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 			}
 			for st in branch.stmts {
 				// must not contain C statements
-				st.check_c_expr() or { c.error('`if` expression branch has $err.msg', st.pos) }
+				st.check_c_expr() or { c.error('`if` expression branch has $err.msg()', st.pos) }
 			}
 		}
 		// Also check for returns inside a comp.if's statements, even if its contents aren't parsed

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -37,7 +37,7 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 				for st in branch.stmts[0..branch.stmts.len - 1] {
 					// must not contain C statements
 					st.check_c_expr() or {
-						c.error('`match` expression branch has $err.msg', st.pos)
+						c.error('`match` expression branch has $err.msg()', st.pos)
 					}
 				}
 			} else if ret_type != ast.void_type {

--- a/vlib/v/doc/doc_private_fn_test.v
+++ b/vlib/v/doc/doc_private_fn_test.v
@@ -11,7 +11,7 @@ fn test_get_parent_mod_on_root_folder() {
 	// TODO: add an equivalent windows check for c:\
 	$if !windows {
 		assert '---' == get_parent_mod('/') or {
-			assert err.msg == 'root folder reached'
+			assert err.msg() == 'root folder reached'
 			'---'
 		}
 	}
@@ -20,7 +20,7 @@ fn test_get_parent_mod_on_root_folder() {
 fn test_get_parent_mod_current_folder() {
 	// TODO: this should may be return '' reliably on windows too:
 	// assert '' == get_parent_mod('.') or {
-	//	assert err.msg == 'No V files found.'
+	//	assert err.msg() == 'No V files found.'
 	//	'---'
 	// }
 }
@@ -34,7 +34,7 @@ fn test_get_parent_mod_on_temp_dir() ? {
 
 fn test_get_parent_mod_normal_cases() ? {
 	assert '---' == get_parent_mod(os.join_path(@VMODROOT, 'vlib/v')) or {
-		assert err.msg == 'No V files found.'
+		assert err.msg() == 'No V files found.'
 		'---'
 	}
 	// TODO: WTF?

--- a/vlib/v/fmt/fmt_keep_test.v
+++ b/vlib/v/fmt/fmt_keep_test.v
@@ -67,7 +67,7 @@ fn test_fmt() {
 				continue
 			}
 			vfmt_result_file := os.join_path(tmpfolder, 'vfmt_run_over_$ifilename')
-			os.write_file(vfmt_result_file, result_ocontent) or { panic(err.msg) }
+			os.write_file(vfmt_result_file, result_ocontent) or { panic(err.msg()) }
 			eprintln(diff.color_compare_files(diff_cmd, opath, vfmt_result_file))
 			continue
 		}
@@ -75,7 +75,7 @@ fn test_fmt() {
 		eprintln(fmt_bench.step_message_ok(vrelpath))
 	}
 	restore_bin2v_placeholder() or {
-		eprintln('failed restoring vbin2v_keep.vv placeholder: $err.msg')
+		eprintln('failed restoring vbin2v_keep.vv placeholder: $err.msg()')
 	}
 	fmt_bench.stop()
 	eprintln(term.h_divider('-'))
@@ -90,7 +90,7 @@ fn prepare_bin2v_file(mut fmt_bench benchmark.Benchmark) {
 	fmt_bench.step()
 	write_bin2v_keep_content() or {
 		fmt_bench.fail()
-		eprintln(fmt_bench.step_message_fail('Failed preparing bin2v_keep.vv: $err.msg'))
+		eprintln(fmt_bench.step_message_fail('Failed preparing bin2v_keep.vv: $err.msg()'))
 		return
 	}
 	fmt_bench.ok()

--- a/vlib/v/fmt/tests/match_keep.vv
+++ b/vlib/v/fmt/tests/match_keep.vv
@@ -34,13 +34,13 @@ fn branches_are_struct_inits() {
 
 fn branches_are_call_exprs_with_or_blocks() {
 	match 'a' {
-		'b' { foo() or { panic(err.msg) } }
+		'b' { foo() or { panic(err) } }
 	}
 	match 'a' {
 		'b' {
 			foo() or {
 				// do stuff
-				panic(err.msg)
+				panic(err)
 			}
 		}
 	}
@@ -48,7 +48,7 @@ fn branches_are_call_exprs_with_or_blocks() {
 		'b' {
 			foo() or {
 				another_stmt()
-				panic(err.msg)
+				panic(err)
 			}
 		}
 	}

--- a/vlib/v/gen/c/assert.v
+++ b/vlib/v/gen/c/assert.v
@@ -51,8 +51,15 @@ fn (mut g Gen) gen_assert_stmt(original_assert_statement ast.AssertStmt) {
 }
 
 struct UnsupportedAssertCtempTransform {
-	msg  string
-	code int
+	Error
+}
+
+fn (err UnsupportedAssertCtempTransform) msg() string {
+	return err.msg
+}
+
+fn (err UnsupportedAssertCtempTransform) code() int {
+	return err.code
 }
 
 const unsupported_ctemp_assert_transform = IError(UnsupportedAssertCtempTransform{})

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7262,9 +7262,7 @@ fn (mut g Gen) interface_table() string {
 			// i.e. cctype is always just Cat, not Cat_ptr:
 			cctype := g.cc_type(st, true)
 			$if debug_interface_table ? {
-				eprintln(
-					'>> interface name: $isym.name | concrete type: $st.debug() | st symname: ' +
-					st_sym.name)
+				eprintln('>> interface name: $isym.name | concrete type: $st.debug() | st symname: $st_sym.name')
 			}
 			// Speaker_Cat_index = 0
 			interface_index_name := '_${interface_name}_${cctype}_index'
@@ -7396,7 +7394,7 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 					_, embed_types := g.table.find_method_from_embeds(st_sym, method.name) or {
 						ast.Fn{}, []ast.Type{}
 					}
-					if embed_types.len > 0 {
+					if embed_types.len > 0 && !g.table.has_method(st_sym, method.name) {
 						embed_sym := g.table.get_type_symbol(embed_types.last())
 						method_name := '${embed_sym.cname}_$method.name'
 						methods_wrapper.write_string('${method_name}(${fargs[0]}')

--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -156,19 +156,21 @@ pub fn (mut g Gen) write_tests_definitions() {
 
 pub fn (mut g Gen) gen_failing_error_propagation_for_test_fn(or_block ast.OrExpr, cvar_name string) {
 	// in test_() functions, an `opt()?` call is sugar for
-	// `or { cb_propagate_test_error(@LINE, @FILE, @MOD, @FN, err.msg) }`
+	// `or { cb_propagate_test_error(@LINE, @FILE, @MOD, @FN, err.msg()) }`
 	// and the test is considered failed
 	paline, pafile, pamod, pafn := g.panic_debug_info(or_block.pos)
-	g.writeln('\tmain__TestRunner_name_table[test_runner._typ]._method_fn_error(test_runner._object, $paline, tos3("$pafile"), tos3("$pamod"), tos3("$pafn"), *(${cvar_name}.err.msg) );')
+	err_msg := 'IError_name_table[${cvar_name}.err._typ]._method_msg(${cvar_name}.err._object)'
+	g.writeln('\tmain__TestRunner_name_table[test_runner._typ]._method_fn_error(test_runner._object, $paline, tos3("$pafile"), tos3("$pamod"), tos3("$pafn"), $err_msg );')
 	g.writeln('\tlongjmp(g_jump_buffer, 1);')
 }
 
 pub fn (mut g Gen) gen_failing_return_error_for_test_fn(return_stmt ast.Return, cvar_name string) {
 	// in test_() functions, a `return error('something')` is sugar for
-	// `or { err := error('something') cb_propagate_test_error(@LINE, @FILE, @MOD, @FN, err.msg) return err }`
+	// `or { err := error('something') cb_propagate_test_error(@LINE, @FILE, @MOD, @FN, err.msg()) return err }`
 	// and the test is considered failed
 	paline, pafile, pamod, pafn := g.panic_debug_info(return_stmt.pos)
-	g.writeln('\tmain__TestRunner_name_table[test_runner._typ]._method_fn_error(test_runner._object, $paline, tos3("$pafile"), tos3("$pamod"), tos3("$pafn"), *(${cvar_name}.err.msg) );')
+	err_msg := 'IError_name_table[${cvar_name}.err._typ]._method_msg(${cvar_name}.err._object)'
+	g.writeln('\tmain__TestRunner_name_table[test_runner._typ]._method_fn_error(test_runner._object, $paline, tos3("$pafile"), tos3("$pamod"), tos3("$pafn"), $err_msg );')
 	g.writeln('\tlongjmp(g_jump_buffer, 1);')
 }
 

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -313,7 +313,7 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) bool {
 		}
 		ast.PostfixExpr {
 			ifdef := g.comptime_if_to_ifdef((cond.expr as ast.Ident).name, true) or {
-				verror(err.msg)
+				verror(err.msg())
 				return false
 			}
 			g.write('defined($ifdef)')

--- a/vlib/v/gen/js/comptime.v
+++ b/vlib/v/gen/js/comptime.v
@@ -74,7 +74,7 @@ fn (mut g JsGen) comptime_if_cond(cond ast.Expr, pkg_exist bool) bool {
 		}
 		ast.PostfixExpr {
 			ifdef := g.comptime_if_to_ifdef((cond.expr as ast.Ident).name, true) or {
-				verror(err.msg)
+				verror(err.msg())
 				return false
 			}
 			g.write('$ifdef')

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -1051,8 +1051,7 @@ fn (mut g JsGen) expr(node ast.Expr) {
 }
 
 struct UnsupportedAssertCtempTransform {
-	msg  string
-	code int
+	Error
 }
 
 const unsupported_ctemp_assert_transform = IError(UnsupportedAssertCtempTransform{})

--- a/vlib/v/pkgconfig/pkgconfig_test.v
+++ b/vlib/v/pkgconfig/pkgconfig_test.v
@@ -21,7 +21,9 @@ fn test_dependency_resolution_fails_correctly() {
 	mut errors := []string{}
 	for pc in pc_files {
 		pcname := os.file_name(pc).replace('.pc', '')
-		pkgconfig.load(pcname, use_default_paths: false, path: samples_dir) or { errors << err.msg }
+		pkgconfig.load(pcname, use_default_paths: false, path: samples_dir) or {
+			errors << err.msg()
+		}
 	}
 	assert errors.len < pc_files.len
 	assert errors == ['could not resolve dependency xyz-unknown-package']

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -109,7 +109,7 @@ pub fn new_scanner_file(file_path string, comments_mode CommentsMode, pref &pref
 		verror('$file_path is not a file')
 	}
 	raw_text := util.read_file(file_path) or {
-		verror(err.msg)
+		verror(err.msg())
 		return voidptr(0)
 	}
 	mut s := &Scanner{

--- a/vlib/v/tests/fn_multiple_returns_test.v
+++ b/vlib/v/tests/fn_multiple_returns_test.v
@@ -51,7 +51,7 @@ fn test_multiple_ret() {
 	// none case
 	wrapper1 := fn () (string, string) {
 		res2_1, res2_2 := split_to_two('') or {
-			assert err.msg == ''
+			assert err.msg() == ''
 			return 'replaced', 'val'
 		}
 		return res2_1, res2_2
@@ -63,7 +63,7 @@ fn test_multiple_ret() {
 	// error case
 	wrapper2 := fn () (string, string) {
 		res3_1, res3_2 := split_to_two('fishhouse') or {
-			assert err.msg == 'error'
+			assert err.msg() == 'error'
 			return 'replaced', 'val'
 		}
 		return res3_1, res3_2

--- a/vlib/v/tests/if_expr_of_optional_test.v
+++ b/vlib/v/tests/if_expr_of_optional_test.v
@@ -26,7 +26,7 @@ fn test_if_expr_of_optional() {
 	if _ := foo3() {
 		assert false
 	} else {
-		assert err.msg == 'foo3 error'
+		assert err.msg() == 'foo3 error'
 	}
 
 	a4 := foo4() or { panic('error') }

--- a/vlib/v/tests/inout/os.vv
+++ b/vlib/v/tests/inout/os.vv
@@ -3,7 +3,7 @@ import os
 fn main() {
 	vexe := os.getenv('VEXE')
 	vroot := os.dir(vexe)
-	mut files := os.ls(vroot) or { panic(err.msg) }
+	mut files := os.ls(vroot) or { panic(err.msg()) }
 	files.sort()
 	for file in files {
 		if file.ends_with('.md') {

--- a/vlib/v/tests/interface_embedded_struct_test.v
+++ b/vlib/v/tests/interface_embedded_struct_test.v
@@ -1,0 +1,65 @@
+module main
+
+interface Getter {
+	get() string
+}
+
+struct Struct {
+	msg string
+}
+
+fn (s Struct) get() string {
+	return s.msg
+}
+
+struct OverwritingStruct {
+	Struct
+}
+
+fn (s OverwritingStruct) get() string {
+	return 'overwritten $s.msg'
+}
+
+struct EmptyStruct {
+	Struct
+}
+
+fn test_struct_embedding() {
+	getter1 := Getter(&OverwritingStruct{
+		msg: '1'
+	})
+	getter2 := Getter(&EmptyStruct{
+		msg: '2'
+	})
+	getter3 := Getter(OverwritingStruct{
+		msg: '3'
+	})
+	getter4 := Getter(EmptyStruct{
+		msg: '4'
+	})
+	s5 := &OverwritingStruct{
+		msg: '5'
+	}
+	getter5 := Getter(s5)
+	s6 := &EmptyStruct{
+		msg: '6'
+	}
+	getter6 := Getter(s6)
+	s7 := OverwritingStruct{
+		msg: '7'
+	}
+	getter7 := Getter(s7)
+	s8 := EmptyStruct{
+		msg: '8'
+	}
+	getter8 := Getter(s8)
+
+	assert getter1.get() == 'overwritten 1'
+	assert getter2.get() == '2'
+	assert getter3.get() == 'overwritten 3'
+	assert getter4.get() == '4'
+	assert getter5.get() == 'overwritten 5'
+	assert getter6.get() == '6'
+	assert getter7.get() == 'overwritten 7'
+	assert getter8.get() == '8'
+}

--- a/vlib/v/tests/interface_method_with_struct_embed_test.v
+++ b/vlib/v/tests/interface_method_with_struct_embed_test.v
@@ -22,7 +22,6 @@ fn (b Baz) get() int {
 	return 42
 }
 
-
 fn test_interface_method_with_struct_embed() {
 	foo := Foo{11}
 	bar := Bar{Foo{22}}

--- a/vlib/v/tests/interface_method_with_struct_embed_test.v
+++ b/vlib/v/tests/interface_method_with_struct_embed_test.v
@@ -1,3 +1,7 @@
+interface Getter {
+	get() int
+}
+
 struct Foo {
 	x int
 }
@@ -10,26 +14,21 @@ struct Bar {
 	Foo
 }
 
-interface Getter {
-	get() int
+struct Baz {
+	Foo
 }
 
+fn (b Baz) get() int {
+	return 42
+}
+
+
 fn test_interface_method_with_struct_embed() {
-	mut getter := []Getter{}
+	foo := Foo{11}
+	bar := Bar{Foo{22}}
+	baz := Baz{Foo{33}}
 
-	foo := Foo{22}
-	getter << foo
-
-	bar := Bar{Foo{11}}
-	getter << bar
-
-	assert getter.len == 2
-
-	println(foo)
-	println(getter[0])
-	assert getter[0].get() == 22
-
-	println(bar)
-	println(getter[1])
-	assert getter[1].get() == 11
+	assert Getter(foo).get() == 11
+	assert Getter(bar).get() == 22
+	assert Getter(baz).get() == 42
 }

--- a/vlib/v/tests/option_2_test.v
+++ b/vlib/v/tests/option_2_test.v
@@ -12,7 +12,7 @@ fn test_lhs_option() {
 }
 
 fn ret_no_opt(n int) int {
-	return f(n) or { panic(err.msg) }
+	return f(n) or { panic(err.msg()) }
 }
 
 fn test_opt_return_no_opt() {

--- a/vlib/v/tests/option_print_errors_test.v
+++ b/vlib/v/tests/option_print_errors_test.v
@@ -4,7 +4,7 @@ fn test_error_can_be_converted_to_string() {
 
 fn test_error_can_be_assigned_to_a_variable() {
 	f := error('an error')
-	assert 'an error' == f.msg
+	assert 'an error' == f.msg()
 }
 
 fn test_error_can_be_printed() {

--- a/vlib/v/tests/option_test.v
+++ b/vlib/v/tests/option_test.v
@@ -7,12 +7,12 @@ fn test_err_with_code() {
 		assert false
 		_ := w
 	} else {
-		assert err.msg == 'hi'
-		assert err.code == 137
+		assert err.msg() == 'hi'
+		assert err.code() == 137
 	}
 	v := opt_err_with_code() or {
-		assert err.msg == 'hi'
-		assert err.code == 137
+		assert err.msg() == 'hi'
+		assert err.code() == 137
 		return
 	}
 	assert false
@@ -25,7 +25,7 @@ fn opt_err() ?string {
 
 fn test_err() {
 	v := opt_err() or {
-		assert err.msg == 'hi'
+		assert err.msg() == 'hi'
 		return
 	}
 	assert false
@@ -74,7 +74,7 @@ fn test_if_else_opt() {
 	if _ := err_call(false) {
 		assert false
 	} else {
-		assert err.msg.len != 0
+		assert err.msg().len != 0
 	}
 }
 
@@ -151,12 +151,12 @@ fn test_or_return() {
 	if _ := or_return_error() {
 		assert false
 	} else {
-		assert err.msg.len != 0
+		assert err.msg().len != 0
 	}
 	if _ := or_return_none() {
 		assert false
 	} else {
-		assert err.msg.len == 0
+		assert err.msg().len == 0
 	}
 }
 
@@ -283,7 +283,7 @@ fn test_optional_void_return_types_of_anon_fn() {
 	}
 
 	f(0) or {
-		assert err.msg == '0'
+		assert err.msg() == '0'
 		return
 	}
 }
@@ -304,7 +304,7 @@ fn test_option_void_return_types_of_anon_fn_in_struct() {
 	}
 
 	foo.f(0) or {
-		assert err.msg == '0'
+		assert err.msg() == '0'
 		return
 	}
 }

--- a/vlib/v/tests/option_void_test.v
+++ b/vlib/v/tests/option_void_test.v
@@ -5,7 +5,7 @@ fn foo() ? {
 fn test_optional_void() {
 	foo() or {
 		println(err)
-		assert err.msg == 'something'
+		assert err.msg() == 'something'
 		return
 	}
 }
@@ -17,7 +17,7 @@ fn bar() ? {
 fn test_optional_void_only_question() {
 	bar() or {
 		println(err)
-		assert err.msg == 'bar error'
+		assert err.msg() == 'bar error'
 		return
 	}
 }
@@ -38,12 +38,12 @@ fn option_void(a int) ? {
 fn test_optional_void_with_return() {
 	option_void(0) or {
 		println(err)
-		assert err.msg == 'zero error'
+		assert err.msg() == 'zero error'
 		return
 	}
 	option_void(-1) or {
 		println(err)
-		assert err.msg == 'zero error'
+		assert err.msg() == 'zero error'
 		return
 	}
 	assert true

--- a/vlib/v/tests/prod_test.v
+++ b/vlib/v/tests/prod_test.v
@@ -15,7 +15,7 @@ fn test_all_v_prod_files() {
 		bmark.step()
 		fres := runner.run_prod_file(options.wd, options.vexec, file) or {
 			bmark.fail()
-			eprintln(bmark.step_message_fail(err.msg))
+			eprintln(bmark.step_message_fail(err.msg()))
 			assert false
 			continue
 		}

--- a/vlib/v/tests/repl/repl_test.v
+++ b/vlib/v/tests/repl/repl_test.v
@@ -75,7 +75,7 @@ fn worker_repl(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 		session.bmark.fail()
 		tls_bench.fail()
 		os.rmdir_all(tfolder) or { panic(err) }
-		eprintln(tls_bench.step_message_fail(err.msg))
+		eprintln(tls_bench.step_message_fail(err.msg()))
 		assert false
 		return pool.no_result
 	}

--- a/vlib/v/tests/repl/runner/runner.v
+++ b/vlib/v/tests/repl/runner/runner.v
@@ -35,7 +35,7 @@ pub fn full_path_to_v(dirs_in int) string {
 }
 
 fn diff_files(file_result string, file_expected string) string {
-	diffcmd := diff.find_working_diff_command() or { return err.msg }
+	diffcmd := diff.find_working_diff_command() or { return err.msg() }
 	return diff.color_compare_files(diffcmd, file_result, file_expected)
 }
 

--- a/vlib/v/tests/struct_test.v
+++ b/vlib/v/tests/struct_test.v
@@ -374,7 +374,7 @@ fn test_fields_anon_fn_with_optional_void_return_type() {
 		}
 	}
 
-	foo.f() or { assert err.msg == 'oops' }
+	foo.f() or { assert err.msg() == 'oops' }
 
 	foo.g() or { assert false }
 }

--- a/vlib/v/tests/vmod_parser_test.v
+++ b/vlib/v/tests/vmod_parser_test.v
@@ -38,7 +38,7 @@ fn test_decode() {
 	assert data.dependencies[0] == 'hello'
 	assert data.unknown['test'][0] == 'foo'
 	vmod.decode('') or {
-		assert err.msg == 'vmod: no content.'
+		assert err.msg() == 'vmod: no content.'
 		exit(0)
 	}
 }

--- a/vlib/vweb/tests/vweb_test.v
+++ b/vlib/vweb/tests/vweb_test.v
@@ -67,7 +67,7 @@ fn assert_common_headers(received string) {
 
 fn test_a_simple_tcp_client_can_connect_to_the_vweb_server() {
 	received := simple_tcp_client(path: '/') or {
-		assert err.msg == ''
+		assert err.msg() == ''
 		return
 	}
 	assert_common_headers(received)
@@ -78,7 +78,7 @@ fn test_a_simple_tcp_client_can_connect_to_the_vweb_server() {
 
 fn test_a_simple_tcp_client_simple_route() {
 	received := simple_tcp_client(path: '/simple') or {
-		assert err.msg == ''
+		assert err.msg() == ''
 		return
 	}
 	assert_common_headers(received)
@@ -91,7 +91,7 @@ fn test_a_simple_tcp_client_zero_content_length() {
 	// tests that sending a content-length header of 0 doesn't hang on a read timeout
 	watch := time.new_stopwatch(auto_start: true)
 	simple_tcp_client(path: '/', headers: 'Content-Length: 0\r\n\r\n') or {
-		assert err.msg == ''
+		assert err.msg() == ''
 		return
 	}
 	assert watch.elapsed() < 1 * time.second
@@ -99,7 +99,7 @@ fn test_a_simple_tcp_client_zero_content_length() {
 
 fn test_a_simple_tcp_client_html_page() {
 	received := simple_tcp_client(path: '/html_page') or {
-		assert err.msg == ''
+		assert err.msg() == ''
 		return
 	}
 	assert_common_headers(received)
@@ -229,7 +229,7 @@ $contents\r
 
 fn test_http_client_shutdown_does_not_work_without_a_cookie() {
 	x := http.get('http://127.0.0.1:$sport/shutdown') or {
-		assert err.msg == ''
+		assert err.msg() == ''
 		return
 	}
 	assert x.status() == .not_found
@@ -246,7 +246,7 @@ fn testsuite_end() {
 			'skey': 'superman'
 		}
 	) or {
-		assert err.msg == ''
+		assert err.msg() == ''
 		return
 	}
 	assert x.status() == .ok

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -255,7 +255,7 @@ pub fn (mut ctx Context) json_pretty<T>(j T) Result {
 pub fn (mut ctx Context) file(f_path string) Result {
 	ext := os.file_ext(f_path)
 	data := os.read_file(f_path) or {
-		eprint(err.msg)
+		eprint(err.msg())
 		ctx.server_error(500)
 		return Result{}
 	}
@@ -379,13 +379,13 @@ interface DbInterface {
 // run_app
 [manualfree]
 pub fn run<T>(global_app &T, port int) {
-	mut l := net.listen_tcp(.ip6, ':$port') or { panic('failed to listen $err.code $err') }
+	mut l := net.listen_tcp(.ip6, ':$port') or { panic('failed to listen $err.code() $err.msg()') }
 
 	// Parsing methods attributes
 	mut routes := map[string]Route{}
 	$for method in T.methods {
 		http_methods, route_path := parse_attrs(method.name, method.attrs) or {
-			eprintln('error parsing method attributes: $err')
+			eprintln('error parsing method attributes: $err.msg()')
 			return
 		}
 
@@ -411,7 +411,7 @@ pub fn run<T>(global_app &T, port int) {
 		request_app.Context = global_app.Context // copy the context ref that contains static files map etc
 		mut conn := l.accept() or {
 			// failures should not panic
-			eprintln('accept() failed with error: $err.msg')
+			eprintln('accept() failed with error: $err.msg()')
 			continue
 		}
 		go handle_conn<T>(mut conn, mut request_app, routes)

--- a/vlib/x/json2/decoder.v
+++ b/vlib/x/json2/decoder.v
@@ -22,13 +22,11 @@ mut:
 }
 
 struct InvalidTokenError {
-	msg  string
-	code int
+	Error
 }
 
 struct UnknownTokenError {
-	msg  string
-	code int
+	Error
 }
 
 fn (mut p Parser) next() {

--- a/vlib/x/json2/decoder_test.v
+++ b/vlib/x/json2/decoder_test.v
@@ -43,7 +43,7 @@ fn test_raw_decode_null() ? {
 
 fn test_raw_decode_invalid() ? {
 	raw_decode('1z') or {
-		assert err.msg == '[x.json2] invalid token `z` (0:17)'
+		assert err.msg() == '[x.json2] invalid token `z` (0:17)'
 		return
 	}
 	assert false


### PR DESCRIPTION
## Changes
This converts the `IError` interface from 
```v
interface IError {
  msg string
  code int
}
```
to
```v
interface IError {
  msg() string
  code() int
}
```
Futhermore the commit fixes some cgen issues that arose from some 'compiler magic' expecting errors to have a message field. These now call the `msg()` method.

## Justification
Especially for the `msg` field, this allows much more flexibility and consistency in how custom errors generate their error messages.
An example of this can be seen in the changes to `vlib/flag/flag.v`

```v
struct UnkownFlagError {
	BaseError
	flag string
}

fn (err UnkownFlagError) msg() string {
	return 'Unknown flag `$err.flag`'
}

struct ArgsCountError {
	BaseError
	got  int
	want int
}

fn (err ArgsCountError) msg() string {
	if err.want == 0 {
		return 'Expected no arguments, but got $err.got'
	} else if err.got > err.want {
		return 'Expected at most $err.want arguments, but got $err.got'
	} else {
		return 'Expected at least $err.want arguments, but got $err.got'
	}
}
```

## Potential further changes
In the current version I left the implementation of the builtin `Error` unchanged (i.e. it has `msg` and `code` fields that can be set in the same way they can be currently) and added `BaseError` as the most basic/empty implementation. To make custom error types more readable I think it could be a good idea to rename `BaseError` to just `Error` and rename the current `Error` to something like `MessageError` or `DefaultError`. This change would be transparent in most cases (i.e. use of the default `error()` function), so would require minimal changes in general.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
