### PR TITLE
checker: fix goto label with comptime tmpl (fix #12842)

### DIFF
--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -30,6 +30,7 @@ fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) ast.Type {
 	}
 	if node.is_vweb {
 		// TODO assoc parser bug
+		save_cur_fn := c.table.cur_fn
 		pref_ := *c.pref
 		pref2 := &pref.Preferences{
 			...pref_
@@ -56,6 +57,8 @@ fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) ast.Type {
 		c.nr_warnings += c2.nr_warnings
 		c.nr_errors += c2.nr_errors
 		c.nr_notices += c2.nr_notices
+
+		c.table.cur_fn = save_cur_fn
 	}
 	if node.method_name == 'html' {
 		rtyp := c.table.find_type_idx('vweb.Result')

--- a/vlib/v/tests/goto_test.v
+++ b/vlib/v/tests/goto_test.v
@@ -36,3 +36,19 @@ pub fn test_goto_after_return() {
 	finally_ok:
 	assert true
 }
+
+fn test_goto_with_comptime_tmpl() {
+	a := 22
+	_ := $tmpl('./tmpl/a.txt')
+	println('before goto')
+
+	unsafe {
+		goto label
+	}
+	println('failed goto')
+	assert false
+
+	label:
+	println('goto label')
+	assert true
+}


### PR DESCRIPTION
This PR fix goto label with comptime tmpl (fix #12842).

- Fix goto label with comptime tmpl.
- Add test.

```vlang
fn main() {
	_ := $tmpl('foo.txt')
	println('before goto')

	unsafe {
		goto label
	}
	println('failed goto')
	assert false

	label:
	println('goto label')
	assert true
}

PS D:\Test\v\tt1> v run .
before goto
goto label
```