### PR TITLE
ci: run the full V test suite on arm64

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,8 @@
 freebsd_instance:
   image_family: freebsd-13-0
 
-task:
+freebsd_task:
+  name: Code CI / freebsd
   install_script: pkg install -y git
   script: |
     echo 'Building V'

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,3 +12,71 @@ task:
     ##tcc -v -v
     echo 'Build cmd/tools/fast'
     cd cmd/tools/fast && ../../../v fast.v && ./fast -clang
+
+
+arm64_task:
+  name: Code CI / arm64-ubuntu-tcc
+  arm_container:
+    image: ubuntu:latest
+  install_script: apt-get update -y && apt-get install --quiet -y build-essential pkg-config wget git valgrind libsqlite3-dev libssl-dev libxi-dev libxcursor-dev libfreetype6-dev libxi-dev libxcursor-dev libgl-dev xfonts-75dpi xfonts-base libmysqlclient-dev libpq-dev
+  env:
+    DEBIAN_FRONTEND: noninteractive
+    VFLAGS: -cc tcc -no-retry-compilation
+    VJOBS: 2
+  script: |
+    set -e
+
+    wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_arm64.deb
+    apt install --fix-missing -y ./wkhtmltox_0.12.6-1.focal_arm64.deb
+
+    # ensure that a V binary can be built, even if tcc has broken for some reason
+    VFLAGS='-cc gcc' make
+
+    ./v -g self
+    ./v -g self
+
+    ./v -d debug_malloc -d debug_realloc -o v cmd/v
+    ./v -cg -cstrict -o v cmd/v
+    #Test v->c
+    thirdparty/tcc/tcc.exe -version
+    ./v -cg -o v cmd/v # Make sure vtcc can build itself twice
+
+    # - name: v self compilation
+    ./v -o v2 cmd/v && ./v2 -o v3 cmd/v && ./v3 -o v4 cmd/v
+
+    # - name: v self compilation with -skip-unused
+    ./v -skip-unused -o v2 cmd/v && ./v2 -skip-unused -o v3 cmd/v && ./v3 -skip-unused -o v4 cmd/v
+
+    # - name: v doctor
+    ./v doctor
+
+    # - name: Verify `v test` works
+    ./v cmd/tools/test_if_v_test_system_works.v
+    ./cmd/tools/test_if_v_test_system_works
+
+    # - name: Self tests
+    ./v -silent test-self
+
+    ## - name: Self tests (-cstrict)
+    ## ./v -cstrict test-self
+
+    # - name: Test time functions in a timezone UTC-12
+    TZ=Etc/GMT+12 ./v test vlib/time/
+    # - name: Test time functions in a timezone UTC-3
+    TZ=Etc/GMT+3 ./v test vlib/time/
+    # - name: Test time functions in a timezone UTC+3
+    TZ=Etc/GMT-3 ./v test vlib/time/
+    # - name: Test time functions in a timezone UTC+12
+    TZ=Etc/GMT-12 ./v test vlib/time/
+    # - name: Test time functions in a timezone using daylight saving (Europe/Paris)
+    TZ=Europe/Paris ./v test vlib/time/
+    # - name: Build examples
+    ./v -W build-examples
+    # - name: Test building v tools
+    ./v -W build-tools
+    # - name: Test v binaries
+    ./v build-vbinaries
+    # - name: Run a VSH script
+    ./v run examples/v_script.vsh
+    # - name: Test v tutorials
+    ./v tutorials/building_a_simple_web_blog_with_vweb/code/blog

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,49 +114,6 @@ jobs:
       - name: Build cmd/tools/fast
         run: cd cmd/tools/fast && ../../../v fast.v && ./fast
 
-  ubuntu-tcc-arm64:
-    needs: no-scheduling
-    runs-on: ubuntu-20.04
-    timeout-minutes: 121
-    steps:
-      - uses: actions/checkout@v2
-      - uses: uraimo/run-on-arch-action@v2.0.5
-        name: Run commands
-        id: runcmd
-        with:
-          arch: aarch64
-          distro: ubuntu20.04
-          env: |
-            VFLAGS: -cc tcc -no-retry-compilation -g
-
-          run: |
-            # - name: Install dependencies
-            apt-get update -y
-            apt-get install --quiet -y build-essential git
-
-            ## -name:  Build v
-            make
-            ./v -d debug_malloc -d debug_realloc -o v cmd/v
-            ./v -cg -cstrict -o v cmd/v
-            # Test v -realloc arena allocation
-            ./v -o vrealloc -prealloc cmd/v && ./vrealloc -o v3 cmd/v && ./v3 -o v4 cmd/v
-            #Test v->c
-            thirdparty/tcc/tcc.exe -version
-            ./v -cg -o v cmd/v # Make sure vtcc can build itself twice
-
-            # - name: v self compilation
-            ./v -o v2 cmd/v && ./v2 -o v3 cmd/v && ./v3 -o v4 cmd/v
-
-            # - name: v self compilation with -skip-unused
-            ./v -skip-unused -o v2 cmd/v && ./v2 -skip-unused -o v3 cmd/v && ./v3 -skip-unused -o v4 cmd/v
-
-            # - name: v doctor
-            ./v doctor
-
-            # TODO: run the full V test suite
-            # qemu is very slow, and it also sometimes produces failures that do not occur on real CPUs
-
-
   ubuntu-tcc-boehm-gc:
     needs: no-scheduling
     runs-on: ubuntu-20.04

--- a/vlib/v/pkgconfig/pkgconfig.v
+++ b/vlib/v/pkgconfig/pkgconfig.v
@@ -10,6 +10,7 @@ const (
 		'/usr/local/lib/pkgconfig',
 		'/usr/local/share/pkgconfig',
 		'/usr/lib/x86_64-linux-gnu/pkgconfig',
+		'/usr/lib/aarch64-linux-gnu/pkgconfig',
 		'/usr/lib64/pkgconfig',
 		'/usr/lib/pkgconfig',
 		'/usr/share/pkgconfig',


### PR DESCRIPTION
Cirrus CI (the system that we currently use to test V on freebsd) supports running jobs natively on arm64 CPUs, so this PR replaces the Github Actions workflow introduced in #12841 (which instead used qemu to emulate an arm CPU). 

Note that running V and all its tests via this new workflow (7-9 mins) is faster than just building V in the previous one (10 mins).

This also means that this new workflow will still run even if GH Actions is overloaded and queues regular workflows, as it runs in a different CI platform.

***

Example workflow run: https://cirrus-ci.com/task/6514150863011840

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
