### PR TITLE
gg: add draw_ellipse() + draw_ellipse_empty() APIs

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -70,6 +70,7 @@ const (
 	]
 	skip_on_musl                  = [
 		'vlib/v/tests/profile/profile_test.v',
+		'vlib/gg/draw_fns_api_test.v',
 	]
 	skip_on_ubuntu_musl           = [
 		//'vlib/v/gen/js/jsgen_test.v',

--- a/vlib/gg/draw_fns_api_test.v
+++ b/vlib/gg/draw_fns_api_test.v
@@ -1,0 +1,24 @@
+import os
+
+fn test_all_samples_can_be_compiled() {
+	vexe := @VEXE
+	vroot := os.dir(vexe)
+	samples := os.walk_ext('$vroot/vlib/gg/testdata', '.vv')
+	mut fails := []string{}
+	for program_source in samples {
+		compile_cmd := '"$vexe" "$program_source"'
+		res := os.execute(compile_cmd)
+		if res.exit_code != 0 {
+			eprintln('>>> FAIL $compile_cmd')
+			fails << compile_cmd
+		}
+		println('OK $compile_cmd')
+	}
+	if fails.len > 0 {
+		eprintln('> Failed summary:')
+		for f in fails {
+			eprintln('   failed cmd: $f')
+		}
+		assert false
+	}
+}

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -1029,3 +1029,38 @@ pub fn dpi_scale() f32 {
 	}
 	return s
 }
+
+// Draws an ellipse
+pub fn (ctx &Context) draw_ellipse(x f32, y f32, r_horizontal f32, r_vertical f32, c gx.Color) {
+	if c.a != 255 {
+		sgl.load_pipeline(ctx.timage_pip)
+	}
+
+	sgl.c4b(c.r, c.g, c.b, c.a)
+	sgl.begin_triangle_strip()
+	for i := 0; i < 360; i += 10 {
+		sgl.v2f(x, y)
+		sgl.v2f(x + math.sinf(f32(math.radians(i))) * r_horizontal, y +
+			math.cosf(f32(math.radians(i))) * r_vertical)
+		sgl.v2f(x + math.sinf(f32(math.radians(i + 10))) * r_horizontal, y +
+			math.cosf(f32(math.radians(i + 10))) * r_vertical)
+	}
+	sgl.end()
+}
+
+// Draws the outline of an ellipse
+pub fn (ctx &Context) draw_empty_ellipse(x f32, y f32, r_horizontal f32, r_vertical f32, c gx.Color) {
+	if c.a != 255 {
+		sgl.load_pipeline(ctx.timage_pip)
+	}
+
+	sgl.c4b(c.r, c.g, c.b, c.a)
+	sgl.begin_line_strip()
+	for i := 0; i < 360; i += 10 {
+		sgl.v2f(x + math.sinf(f32(math.radians(i))) * r_horizontal, y +
+			math.cosf(f32(math.radians(i))) * r_vertical)
+		sgl.v2f(x + math.sinf(f32(math.radians(i + 10))) * r_horizontal, y +
+			math.cosf(f32(math.radians(i + 10))) * r_vertical)
+	}
+	sgl.end()
+}

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -1030,8 +1030,8 @@ pub fn dpi_scale() f32 {
 	return s
 }
 
-// Draws an ellipse
-pub fn (ctx &Context) draw_ellipse(x f32, y f32, r_horizontal f32, r_vertical f32, c gx.Color) {
+// draw_ellipse_filled draws an opaque elipse, with a center at x,y , filled with the color `c`
+pub fn (ctx &Context) draw_ellipse_filled(x f32, y f32, r_horizontal f32, r_vertical f32, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
 	}
@@ -1048,7 +1048,7 @@ pub fn (ctx &Context) draw_ellipse(x f32, y f32, r_horizontal f32, r_vertical f3
 	sgl.end()
 }
 
-// Draws the outline of an ellipse
+// draw_ellipse_empty draws the outline of an ellipse, with a center at x,y
 pub fn (ctx &Context) draw_ellipse_empty(x f32, y f32, r_horizontal f32, r_vertical f32, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -1049,7 +1049,7 @@ pub fn (ctx &Context) draw_ellipse(x f32, y f32, r_horizontal f32, r_vertical f3
 }
 
 // Draws the outline of an ellipse
-pub fn (ctx &Context) draw_empty_ellipse(x f32, y f32, r_horizontal f32, r_vertical f32, c gx.Color) {
+pub fn (ctx &Context) draw_ellipse_empty(x f32, y f32, r_horizontal f32, r_vertical f32, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
 	}

--- a/vlib/gg/testdata/draw_elipses.vv
+++ b/vlib/gg/testdata/draw_elipses.vv
@@ -1,0 +1,21 @@
+module main
+
+import gg
+import gx
+
+fn main() {
+	mut context := gg.new_context(
+		width: 200
+		height: 200
+		window_title: 'Elipses'
+		frame_fn: frame
+	)
+	context.run()
+}
+
+fn frame(mut ctx gg.Context) {
+	ctx.begin()
+	ctx.draw_ellipse(100, 100, 100, 50, gx.red)
+	ctx.draw_empty_ellipse(100, 100, 50, 25, gx.black)
+	ctx.end()
+}

--- a/vlib/gg/testdata/draw_elipses.vv
+++ b/vlib/gg/testdata/draw_elipses.vv
@@ -15,7 +15,7 @@ fn main() {
 
 fn frame(mut ctx gg.Context) {
 	ctx.begin()
-	ctx.draw_ellipse(100, 100, 100, 50, gx.red)
+	ctx.draw_ellipse_filled(100, 100, 100, 50, gx.red)
 	ctx.draw_ellipse_empty(100, 100, 50, 25, gx.black)
 	ctx.end()
 }

--- a/vlib/gg/testdata/draw_elipses.vv
+++ b/vlib/gg/testdata/draw_elipses.vv
@@ -16,6 +16,6 @@ fn main() {
 fn frame(mut ctx gg.Context) {
 	ctx.begin()
 	ctx.draw_ellipse(100, 100, 100, 50, gx.red)
-	ctx.draw_empty_ellipse(100, 100, 50, 25, gx.black)
+	ctx.draw_ellipse_empty(100, 100, 50, 25, gx.black)
 	ctx.end()
 }

--- a/vlib/gg/testdata/draw_polygons.vv
+++ b/vlib/gg/testdata/draw_polygons.vv
@@ -1,0 +1,24 @@
+module main
+
+import gg
+import gx
+
+fn main() {
+	mut context := gg.new_context(
+		bg_color: gx.rgb(174, 198, 255)
+		width: 600
+		height: 400
+		window_title: 'Polygons'
+		frame_fn: frame
+	)
+	context.run()
+}
+
+fn frame(mut ctx gg.Context) {
+	ctx.begin()
+	ctx.draw_convex_poly([f32(100.0), 100.0, 200.0, 100.0, 300.0, 200.0, 200.0, 300.0, 100.0, 300.0],
+		gx.blue)
+	ctx.draw_empty_poly([f32(50.0), 50.0, 70.0, 60.0, 90.0, 80.0, 70.0, 110.0], gx.black)
+	ctx.draw_triangle(450, 142, 530, 280, 370, 280, gx.red)
+	ctx.end()
+}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/24865450/146466099-0a69ea18-d756-4b6b-9207-cf47c2112ee9.png)

```v
import gg
import gx
import math

struct App {
mut:
	gg     &gg.Context
}

fn main() {
	mut app := &App{
		gg: 0
	}
	
	app.gg = gg.new_context(
		width: 200
		height: 200
		window_title: 'Draw Ellipse'
		frame_fn: frame
		user_data: app
	)
	
	app.gg.run()
}

fn frame(mut app App) {
	app.gg.begin()
	app.gg.draw_ellipse(100, 100, 100, 50, gx.red)
	app.gg.draw_empty_ellipse(100, 100, 50, 25, gx.black)
	app.gg.end()
}
```