### PR TITLE
cgen: fix error of 'map_a[map_b[key]] += 2' (fix #12845)

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -350,7 +350,13 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 			g.write('->val')
 		}
 		g.write(', &($key_type_str[]){')
+		old_is_arraymap_set := g.is_arraymap_set
+		old_is_assign_lhs := g.is_assign_lhs
+		g.is_arraymap_set = false
+		g.is_assign_lhs = false
 		g.expr(node.index)
+		g.is_arraymap_set = old_is_arraymap_set
+		g.is_assign_lhs = old_is_assign_lhs
 		g.write('}')
 		if elem_typ.kind == .function {
 			g.write(', &(voidptr[]) { ')

--- a/vlib/v/tests/nested_map_test.v
+++ b/vlib/v/tests/nested_map_test.v
@@ -32,3 +32,15 @@ fn test_map_of_map_to_struct() {
 	foos['zza']['zzb'].name = 'baz'
 	assert foos['zza']['zzb'].name == 'baz'
 }
+
+fn test_map_of_map_key_plus_assign() {
+	m := {
+		'a': 'x'
+	}
+	mut n := {
+		'x': 1
+	}
+	n[m['a']] += 2
+	println(n)
+	assert n['x'] == 3
+}


### PR DESCRIPTION
This PR fix error of `map_a[map_b[key]] += 2` (fix #12845).

- Fix error of `map_a[map_b[key]] += 2`.
- Add test.

```vlang
fn main() {
	m := {
		'a': 'x'
	}
	mut n := {
		'x': 1
	}
	n[m['a']] += 2
	println(n)
	assert n['x'] == 3
}

PS D:\Test\v\tt1> v run .
{'x': 3}
```