### PR TITLE
cgen: fix array of interfaces equality error (fix #12867)

### DIFF
--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -236,6 +236,9 @@ fn (mut g Gen) gen_array_equality_fn(left_type ast.Type) string {
 	} else if elem.sym.kind == .struct_ && !elem.typ.is_ptr() {
 		eq_fn := g.gen_struct_equality_fn(elem.typ)
 		fn_builder.writeln('\t\tif (!${eq_fn}_struct_eq((($ptr_elem_styp*)a.data)[i], (($ptr_elem_styp*)b.data)[i])) {')
+	} else if elem.sym.kind == .interface_ && !elem.typ.is_ptr() {
+		eq_fn := g.gen_interface_equality_fn(elem.typ)
+		fn_builder.writeln('\t\tif (!${eq_fn}_interface_eq((($ptr_elem_styp*)a.data)[i], (($ptr_elem_styp*)b.data)[i])) {')
 	} else if elem.sym.kind == .array && !elem.typ.is_ptr() {
 		eq_fn := g.gen_array_equality_fn(elem.typ)
 		fn_builder.writeln('\t\tif (!${eq_fn}_arr_eq((($ptr_elem_styp*)a.data)[i], (($ptr_elem_styp*)b.data)[i])) {')

--- a/vlib/v/tests/array_of_interfaces_equality_test.v
+++ b/vlib/v/tests/array_of_interfaces_equality_test.v
@@ -1,0 +1,31 @@
+interface IObject {
+	foo()
+}
+
+struct Foo {}
+
+fn (f Foo) foo() {
+}
+
+struct Array {
+mut:
+	array []IObject
+}
+
+fn (a Array) contains(x IObject) bool {
+	for element in a.array {
+		if element == x {
+			return true
+		}
+	}
+	return false
+}
+
+fn test_array_of_interfaces_equality() {
+	foo := Foo{}
+	mut ary := Array{}
+	ary.array << foo
+	ret := ary.contains(foo)
+	println(ret)
+	assert ret
+}


### PR DESCRIPTION
This PR fix array of interfaces equality error (fix #12867).

- Fix array of interfaces equality error.
- Add test.

```vlang
interface IObject {
	foo()
}

struct Foo {}

fn (f Foo) foo() {
}

struct Array {
mut:
	array []IObject
}

fn (a Array) contains(x IObject) bool {
	for element in a.array {
		if element == x {
			return true
		}
	}
	return false
}

fn main() {
	foo := Foo{}
	mut ary := Array{}
	ary.array << foo
	ret := ary.contains(foo)
	println(ret)
}

PS D:\Test\v\tt1> v run .
true
```