### PR TITLE
cgen: fix overwriting methods of embedded structs + empty struct for interfaces

### DIFF
--- a/vlib/v/tests/interface_struct_embedding_test.v
+++ b/vlib/v/tests/interface_struct_embedding_test.v
@@ -1,0 +1,67 @@
+module main
+
+interface Getter {
+	get() string
+}
+
+struct Struct {
+	msg string
+}
+
+fn (s Struct) get() string {
+	return s.msg
+}
+
+struct EmbeddingStruct {
+	Struct
+}
+
+fn (s EmbeddingStruct) get() string {
+	return 'embedded: $s.msg'
+}
+
+fn test_struct_embedding() {
+	s1 := EmbeddingStruct{
+		msg: '1'
+	}
+	getter1 := Getter(s1)
+	s2 := &EmbeddingStruct{
+		msg: '2'
+	}
+	getter2 := Getter(s2)
+	getter3 := Getter(EmbeddingStruct{
+		msg: '3'
+	})
+	getter4 := Getter(&EmbeddingStruct{
+		msg: '4'
+	})
+
+	assert getter1.get() == 'embedded: 1'
+	assert getter2.get() == 'embedded: 2'
+	assert getter3.get() == 'embedded: 3'
+	assert getter4.get() == 'embedded: 4'
+}
+
+struct EmptyStruct {}
+
+fn (s EmptyStruct) get() string {
+	return 'empty'
+}
+
+struct EmbeddingEmptyStruct {
+	EmptyStruct
+}
+
+fn test_empty_struct_embedding() {
+	s1 := EmbeddingEmptyStruct{}
+	getter1 := Getter(s1)
+	s2 := &EmbeddingEmptyStruct{}
+	getter2 := Getter(s2)
+	getter3 := Getter(EmbeddingEmptyStruct{})
+	getter4 := Getter(&EmbeddingEmptyStruct{})
+
+	assert getter1.get() == 'empty'
+	assert getter2.get() == 'empty'
+	assert getter3.get() == 'empty'
+	assert getter4.get() == 'empty'
+}


### PR DESCRIPTION
Fixes overwriting methods being ignore by interfaces
Fixes issue where empty methods throw c error in strict mode
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
