### PR TITLE
gg: add draw_arc_empty()

### DIFF
--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -423,6 +423,23 @@ pub fn (ctx &Context) draw_ellipse(x f32, y f32, r_horizontal f32, r_vertical f3
 	sgl.end()
 }
 
+// Draws the outline of an ellipse
+pub fn (ctx &Context) draw_empty_ellipse(x f32, y f32, r_horizontal f32, r_vertical f32, c gx.Color) {
+	if c.a != 255 {
+		sgl.load_pipeline(ctx.timage_pip)
+	}
+
+	sgl.c4b(c.r, c.g, c.b, c.a)
+	sgl.begin_line_strip()
+	for i := 0; i < 360; i += 10 {
+		sgl.v2f(x + math.sinf(f32(math.radians(i))) * r_horizontal, y +
+			math.cosf(f32(math.radians(i))) * r_vertical)
+		sgl.v2f(x + math.sinf(f32(math.radians(i + 10))) * r_horizontal, y +
+			math.cosf(f32(math.radians(i + 10))) * r_vertical)
+	}
+	sgl.end()
+}
+
 // Draws a circle slice/pie.
 pub fn (ctx &Context) draw_slice(x f32, y f32, r f32, start_angle f32, arc_angle f32, segments int, c gx.Color) {
 	if c.a != 255 {

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -410,13 +410,15 @@ pub fn (ctx &Context) draw_ellipse(x f32, y f32, r_horizontal f32, r_vertical f3
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
 	}
-	
+
 	sgl.c4b(c.r, c.g, c.b, c.a)
 	sgl.begin_triangle_strip()
 	for i := 0; i < 360; i += 10 {
 		sgl.v2f(x, y)
-		sgl.v2f(x + math.sinf(f32(math.radians(i))) * r_horizontal, y + math.cosf(f32(math.radians(i))) * r_vertical)
-		sgl.v2f(x + math.sinf(f32(math.radians(i + 10))) * r_horizontal, y + math.cosf(f32(math.radians(i + 10))) * r_vertical)
+		sgl.v2f(x + math.sinf(f32(math.radians(i))) * r_horizontal, y +
+			math.cosf(f32(math.radians(i))) * r_vertical)
+		sgl.v2f(x + math.sinf(f32(math.radians(i + 10))) * r_horizontal, y +
+			math.cosf(f32(math.radians(i + 10))) * r_vertical)
 	}
 	sgl.end()
 }

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -626,7 +626,7 @@ pub fn (ctx &Context) draw_arc(x f32, y f32, inner_r f32, outer_r f32, start_ang
 
 // Draws the outline of an arc
 // TODO: Should be possible to simplify the code below quite heavily
-pub fn (ctx &Context) draw_empty_arc(x f32, y f32, inner_r f32, outer_r f32, start_angle f32, end_angle f32, segments int, c gx.Color) {
+pub fn (ctx &Context) draw_arc_empty(x f32, y f32, inner_r f32, outer_r f32, start_angle f32, end_angle f32, segments int, c gx.Color) {
 	if start_angle == end_angle || outer_r <= 0.0 {
 		return
 	}

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -658,7 +658,7 @@ pub fn (ctx &Context) draw_arc_empty(x f32, y f32, inner_r f32, outer_r f32, sta
 
 	sgl.begin_line_strip()
 	sgl.c4b(c.r, c.g, c.b, c.a)
-	
+
 	// Outer circle
 	for _ in 0 .. segments {
 		sgl.v2f(x + f32(math.sin(angle)) * r2, y + f32(math.cos(angle) * r2))
@@ -671,12 +671,12 @@ pub fn (ctx &Context) draw_arc_empty(x f32, y f32, inner_r f32, outer_r f32, sta
 	// Inner circle
 	for _ in 0 .. segments {
 		sgl.v2f(x + f32(math.sin(angle)) * r1, y + f32(math.cos(angle) * r1))
-		sgl.v2f(x + f32(math.sin(angle - step_length)) * r1, y + f32(math.cos(angle -
-			step_length) * r1))
+		sgl.v2f(x + f32(math.sin(angle - step_length)) * r1, y +
+			f32(math.cos(angle - step_length) * r1))
 
 		angle -= step_length
 	}
-	
+
 	// Closing end
 	sgl.v2f(x + f32(math.sin(angle)) * r1, y + f32(math.cos(angle) * r1))
 	sgl.v2f(x + f32(math.sin(angle)) * r2, y + f32(math.cos(angle) * r2))

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -588,7 +588,6 @@ pub fn (ctx &Context) draw_arc(x f32, y f32, inner_r f32, outer_r f32, start_ang
 	mut a1 := start_angle
 	mut a2 := end_angle
 
-	// TODO: Maybe this does not make since inner_r and outer_r is actually integers?
 	if outer_r < inner_r {
 		r1, r2 = r2, r1
 
@@ -624,6 +623,83 @@ pub fn (ctx &Context) draw_arc(x f32, y f32, inner_r f32, outer_r f32, start_ang
 	}
 	sgl.end()
 }
+
+// Draws the outline of an arc
+// TODO: Should be possible to simplify the code below quite heavily
+pub fn (ctx &Context) draw_empty_arc(x f32, y f32, inner_r f32, outer_r f32, start_angle f32, end_angle f32, segments int, c gx.Color) {
+	if start_angle == end_angle || outer_r <= 0.0 {
+		return
+	}
+
+	mut r1 := inner_r
+	mut r2 := outer_r
+	mut a1 := start_angle
+	mut a2 := end_angle
+
+	if outer_r < inner_r {
+		r1, r2 = r2, r1
+
+		if r2 <= 0.0 {
+			r2 = 0.1
+		}
+	}
+
+	if a2 < a1 {
+		a1, a2 = a2, a1
+	}
+
+	if r1 <= 0.0 {
+		ctx.draw_empty_slice(x, y, int(r2), a1, a2, segments, c)
+		return
+	}
+
+	mut step_length := (a2 - a1) / f32(segments)
+	mut angle := a1
+
+	// Outer circle
+	sgl.begin_line_strip()
+	sgl.c4b(c.r, c.g, c.b, c.a)
+	for _ in 0 .. segments {
+		sgl.v2f(x + f32(math.sin(angle)) * r2, y + f32(math.cos(angle) * r2))
+		sgl.v2f(x + f32(math.sin(angle + step_length)) * r2, y + f32(math.cos(angle +
+			step_length) * r2))
+
+		angle += step_length
+	}
+	sgl.end()
+	
+	// Inner circle
+	angle = 0
+	sgl.begin_line_strip()
+	sgl.c4b(c.r, c.g, c.b, c.a)
+	for _ in 0 .. segments {
+		sgl.v2f(x + f32(math.sin(angle)) * r1, y + f32(math.cos(angle) * r1))
+		sgl.v2f(x + f32(math.sin(angle + step_length)) * r1, y + f32(math.cos(angle +
+			step_length) * r1))
+
+		angle += step_length
+	}
+	sgl.end()
+	
+	// First end
+	sgl.begin_line_strip()
+	sgl.c4b(c.r, c.g, c.b, c.a)	
+	angle = 0
+	
+	sgl.v2f(x + f32(math.sin(angle)) * r1, y + f32(math.cos(angle) * r1))
+	sgl.v2f(x + f32(math.sin(angle)) * r2, y + f32(math.cos(angle) * r2))
+	sgl.end()
+	
+	// Second end
+	sgl.begin_line_strip()
+	sgl.c4b(c.r, c.g, c.b, c.a)
+	angle = segments * step_length
+	sgl.v2f(x + f32(math.sin(angle)) * r1, y + f32(math.cos(angle) * r1))
+	sgl.v2f(x + f32(math.sin(angle)) * r2, y + f32(math.cos(angle) * r2))
+
+	sgl.end()
+}
+
 
 // Draws a filled rounded rectangle
 pub fn (ctx &Context) draw_rounded_rect(x f32, y f32, w f32, h f32, radius f32, c gx.Color) {

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -666,37 +666,17 @@ pub fn (ctx &Context) draw_arc_empty(x f32, y f32, inner_r f32, outer_r f32, sta
 
 		angle += step_length
 	}
-	sgl.end()
 
-	// Inner circle
-	angle = 0
-	sgl.begin_line_strip()
-	sgl.c4b(c.r, c.g, c.b, c.a)
 	for _ in 0 .. segments {
 		sgl.v2f(x + f32(math.sin(angle)) * r1, y + f32(math.cos(angle) * r1))
-		sgl.v2f(x + f32(math.sin(angle + step_length)) * r1, y + f32(math.cos(angle +
+		sgl.v2f(x + f32(math.sin(angle - step_length)) * r1, y + f32(math.cos(angle -
 			step_length) * r1))
 
-		angle += step_length
+		angle -= step_length
 	}
-	sgl.end()
-
-	// First end
-	sgl.begin_line_strip()
-	sgl.c4b(c.r, c.g, c.b, c.a)
-	angle = 0
 
 	sgl.v2f(x + f32(math.sin(angle)) * r1, y + f32(math.cos(angle) * r1))
 	sgl.v2f(x + f32(math.sin(angle)) * r2, y + f32(math.cos(angle) * r2))
-	sgl.end()
-
-	// Second end
-	sgl.begin_line_strip()
-	sgl.c4b(c.r, c.g, c.b, c.a)
-	angle = segments * step_length
-	sgl.v2f(x + f32(math.sin(angle)) * r1, y + f32(math.cos(angle) * r1))
-	sgl.v2f(x + f32(math.sin(angle)) * r2, y + f32(math.cos(angle) * r2))
-
 	sgl.end()
 }
 

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -405,6 +405,22 @@ pub fn (ctx &Context) draw_circle_with_segments(x f32, y f32, r f32, segments in
 	sgl.end()
 }
 
+// Draws an ellipse
+pub fn (ctx &Context) draw_ellipse(x f32, y f32, r_horizontal f32, r_vertical f32, c gx.Color) {
+	if c.a != 255 {
+		sgl.load_pipeline(ctx.timage_pip)
+	}
+	
+	sgl.c4b(c.r, c.g, c.b, c.a)
+	sgl.begin_triangle_strip()
+	for i := 0; i < 360; i += 10 {
+		sgl.v2f(x, y)
+		sgl.v2f(x + math.sinf(f32(math.radians(i))) * r_horizontal, y + math.cosf(f32(math.radians(i))) * r_vertical)
+		sgl.v2f(x + math.sinf(f32(math.radians(i + 10))) * r_horizontal, y + math.cosf(f32(math.radians(i + 10))) * r_vertical)
+	}
+	sgl.end()
+}
+
 // Draws a circle slice/pie.
 pub fn (ctx &Context) draw_slice(x f32, y f32, r f32, start_angle f32, arc_angle f32, segments int, c gx.Color) {
 	if c.a != 255 {

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -667,7 +667,7 @@ pub fn (ctx &Context) draw_empty_arc(x f32, y f32, inner_r f32, outer_r f32, sta
 		angle += step_length
 	}
 	sgl.end()
-	
+
 	// Inner circle
 	angle = 0
 	sgl.begin_line_strip()
@@ -680,16 +680,16 @@ pub fn (ctx &Context) draw_empty_arc(x f32, y f32, inner_r f32, outer_r f32, sta
 		angle += step_length
 	}
 	sgl.end()
-	
+
 	// First end
 	sgl.begin_line_strip()
-	sgl.c4b(c.r, c.g, c.b, c.a)	
+	sgl.c4b(c.r, c.g, c.b, c.a)
 	angle = 0
-	
+
 	sgl.v2f(x + f32(math.sin(angle)) * r1, y + f32(math.cos(angle) * r1))
 	sgl.v2f(x + f32(math.sin(angle)) * r2, y + f32(math.cos(angle) * r2))
 	sgl.end()
-	
+
 	// Second end
 	sgl.begin_line_strip()
 	sgl.c4b(c.r, c.g, c.b, c.a)
@@ -699,7 +699,6 @@ pub fn (ctx &Context) draw_empty_arc(x f32, y f32, inner_r f32, outer_r f32, sta
 
 	sgl.end()
 }
-
 
 // Draws a filled rounded rectangle
 pub fn (ctx &Context) draw_rounded_rect(x f32, y f32, w f32, h f32, radius f32, c gx.Color) {

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -656,9 +656,10 @@ pub fn (ctx &Context) draw_arc_empty(x f32, y f32, inner_r f32, outer_r f32, sta
 	mut step_length := (a2 - a1) / f32(segments)
 	mut angle := a1
 
-	// Outer circle
 	sgl.begin_line_strip()
 	sgl.c4b(c.r, c.g, c.b, c.a)
+	
+	// Outer circle
 	for _ in 0 .. segments {
 		sgl.v2f(x + f32(math.sin(angle)) * r2, y + f32(math.cos(angle) * r2))
 		sgl.v2f(x + f32(math.sin(angle + step_length)) * r2, y + f32(math.cos(angle +
@@ -667,6 +668,7 @@ pub fn (ctx &Context) draw_arc_empty(x f32, y f32, inner_r f32, outer_r f32, sta
 		angle += step_length
 	}
 
+	// Inner circle
 	for _ in 0 .. segments {
 		sgl.v2f(x + f32(math.sin(angle)) * r1, y + f32(math.cos(angle) * r1))
 		sgl.v2f(x + f32(math.sin(angle - step_length)) * r1, y + f32(math.cos(angle -
@@ -674,7 +676,8 @@ pub fn (ctx &Context) draw_arc_empty(x f32, y f32, inner_r f32, outer_r f32, sta
 
 		angle -= step_length
 	}
-
+	
+	// Closing end
 	sgl.v2f(x + f32(math.sin(angle)) * r1, y + f32(math.cos(angle) * r1))
 	sgl.v2f(x + f32(math.sin(angle)) * r2, y + f32(math.cos(angle) * r2))
 	sgl.end()

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -625,7 +625,6 @@ pub fn (ctx &Context) draw_arc(x f32, y f32, inner_r f32, outer_r f32, start_ang
 }
 
 // Draws the outline of an arc
-// TODO: Should be possible to simplify the code below quite heavily
 pub fn (ctx &Context) draw_arc_empty(x f32, y f32, inner_r f32, outer_r f32, start_angle f32, end_angle f32, segments int, c gx.Color) {
 	if start_angle == end_angle || outer_r <= 0.0 {
 		return


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/24865450/146617483-b517e096-2b3a-4378-8793-9f17400ea4bc.png)

```v
import gg
import gx
import math

struct App {
mut:
	gg &gg.Context
}

fn main() {
	mut app := &App{
		gg: 0
	}
	
	app.gg = gg.new_context(
		width: 200
		height: 200
		window_title: 'Draw Arc'
		frame_fn: frame
		user_data: app
	)
	
	app.gg.run()
}

fn frame(mut app App) {
	app.gg.begin()
	app.gg.draw_arc(100, 100, 35, 45, 0, f32(math.radians(290)), 30, gx.red)
	app.gg.draw_arc_empty(100, 100, 30, 50, 0, f32(math.radians(290)), 30, gx.white)
	app.gg.end()
}
```
With the naming as the next PR where drawing functions get changed from `draw_empty_rect` to `draw_rect_empty`