### PR TITLE
Improve logging

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,2 +1,3 @@
-*.ppm
 *.js
+*.log
+*.ppm

--- a/examples/log.v
+++ b/examples/log.v
@@ -11,8 +11,14 @@ fn main() {
 	l.info('info')
 	l.warn('warn')
 	l.error('error')
-	l.debug('no debug')
+	l.debug('no output for debug')
 	l.set_level(.debug)
-	l.debug('debug')
-	l.fatal('fatal')
+	l.debug('debug now')
+	l.set_level(log.level_from_tag('INFO') or { log.Level.disabled }) // set level from string, sample
+	l.info('info again')
+	l.set_level(log.level_from_tag('') or { log.Level.disabled }) // set level from string, sample
+	l.error('no output anymore')
+	l.fatal('fatal') // panic, next statements won't be executed
+	l.set_level(.info)
+	l.warn('warn')
 }

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -48,15 +48,16 @@ fn tag_to_file(l Level) string {
 	}
 }
 
-// level_from_tag returns the log level from the given string or disabled if no match.
-pub fn level_from_tag(tag string) Level {
+// level_from_tag returns the log level from the given string if matches.
+pub fn level_from_tag(tag string) ?Level {
 	return match tag {
-		'FATAL' { .fatal }
-		'ERROR' { .error }
-		'WARN' { .warn }
-		'INFO'  { .info }
-		'DEBUG' { .debug }
-		else { .disabled }
+		'DISABLED' { Level.disabled }
+		'FATAL' { Level.fatal }
+		'ERROR' { Level.error }
+		'WARN' { Level.warn }
+		'INFO'  { Level.info }
+		'DEBUG' { Level.debug }
+		else { none }
 	}
 }
 
@@ -165,12 +166,12 @@ pub fn (mut l Log) send_output(s &string, level Level) {
 }
 
 // fatal logs line `s` via `send_output` if `Log.level` is greater than or equal to the `Level.fatal` category.
+// Note that this method performs a panic at the end, even if log level is not enabled.
 pub fn (mut l Log) fatal(s string) {
-	if int(l.level) < int(Level.fatal) {
-		return
+	if int(l.level) >= int(Level.fatal) {
+		l.send_output(s, .fatal)
+		l.ofile.close()
 	}
-	l.send_output(s, .fatal)
-	l.ofile.close()
 	panic('$l.output_label: $s')
 }
 

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -9,22 +9,25 @@ import term
 
 // Level defines possible log levels used by `Log`
 pub enum Level {
-	fatal = 1
+	disabled = 0
+	fatal
 	error
 	warn
 	info
 	debug
 }
 
+// LogTarget defines possible log targets
 pub enum LogTarget {
 	console
 	file
 	both
 }
 
-// tag returns the tag for log level `l` as a string.
+// tag_to_cli returns the tag for log level `l` as a colored string.
 fn tag_to_cli(l Level) string {
 	return match l {
+		.disabled { '' }
 		.fatal { term.red('FATAL') }
 		.error { term.red('ERROR') }
 		.warn { term.yellow('WARN ') }
@@ -33,9 +36,10 @@ fn tag_to_cli(l Level) string {
 	}
 }
 
-// tag returns the tag for log level `l` as a string.
+// tag_to_file returns the tag for log level `l` as a string.
 fn tag_to_file(l Level) string {
 	return match l {
+		.disabled { '     ' }
 		.fatal { 'FATAL' }
 		.error { 'ERROR' }
 		.warn { 'WARN ' }
@@ -44,7 +48,20 @@ fn tag_to_file(l Level) string {
 	}
 }
 
-interface Logger {
+// level_from_tag returns the log level from the given string or disabled if no match.
+pub fn level_from_tag(tag string) Level {
+	return match tag {
+		'FATAL' { .fatal }
+		'ERROR' { .error }
+		'WARN' { .warn }
+		'INFO'  { .info }
+		'DEBUG' { .debug }
+		else { .disabled }
+	}
+}
+
+// Logger is an interface that describes a generic Logger
+pub interface Logger {
 	fatal(s string)
 	error(s string)
 	warn(s string)
@@ -58,7 +75,7 @@ mut:
 	level         Level
 	output_label  string
 	ofile         os.File
-	output_target LogTarget // if true output to file else use stdout/stderr.
+	output_target LogTarget // output to console (stdout/stderr) or file or both.
 pub mut:
 	output_file_name string // log output to this file
 }

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -55,7 +55,7 @@ pub fn level_from_tag(tag string) ?Level {
 		'FATAL' { Level.fatal }
 		'ERROR' { Level.error }
 		'WARN' { Level.warn }
-		'INFO'  { Level.info }
+		'INFO' { Level.info }
 		'DEBUG' { Level.debug }
 		else { none }
 	}


### PR DESCRIPTION
Hi,
with this PR I did some small updates to log and related example.

Log interface now is public, so other logging implementations could implement it as a standard signature; I'm looking if/how to write an async logger implementation so at least same signature and other stuff could be used from this base/standard implementation.
There is a new function that given a string, returns related logging level or none, it could be useful when reading log level from a config file for example.
Added a disabled level, it could be useful when logging is not needed (for example during a benchmark, when execution must not slow down with logging and enabled only when needed or only in some code portions, etc); hope you find it useful.

Note that I changed the `fatal` method so even when related logging level is not enabled (or better, its output is not desired), the panic is triggered the same; not sure this is the best behaviour (other logging libraries like Log4J does not trigger a panic/exit when `fatal` logging is executed) but could be consistent with previous code here ... otherwise for example I could remove panic from `fatal` and add in an additional method `fatal_with_panic` (or similar) specific to this implementation, or other ...

Hope it's good enough.
Bye
