### PR TITLE
gg: add draw_arc_empty

### DIFF
--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -781,6 +781,64 @@ pub fn (ctx &Context) draw_arc(x f32, y f32, inner_r f32, outer_r f32, start_ang
 	sgl.end()
 }
 
+// Draws the outline of an arc
+pub fn (ctx &Context) draw_arc_empty(x f32, y f32, inner_r f32, outer_r f32, start_angle f32, end_angle f32, segments int, c gx.Color) {
+	if start_angle == end_angle || outer_r <= 0.0 {
+		return
+	}
+
+	mut r1 := inner_r
+	mut r2 := outer_r
+	mut a1 := start_angle
+	mut a2 := end_angle
+
+	if outer_r < inner_r {
+		r1, r2 = r2, r1
+
+		if r2 <= 0.0 {
+			r2 = 0.1
+		}
+	}
+
+	if a2 < a1 {
+		a1, a2 = a2, a1
+	}
+
+	if r1 <= 0.0 {
+		ctx.draw_empty_slice(x, y, int(r2), a1, a2, segments, c)
+		return
+	}
+
+	mut step_length := (a2 - a1) / f32(segments)
+	mut angle := a1
+
+	sgl.begin_line_strip()
+	sgl.c4b(c.r, c.g, c.b, c.a)
+
+	// Outer circle
+	for _ in 0 .. segments {
+		sgl.v2f(x + f32(math.sin(angle)) * r2, y + f32(math.cos(angle) * r2))
+		sgl.v2f(x + f32(math.sin(angle + step_length)) * r2, y + f32(math.cos(angle +
+			step_length) * r2))
+
+		angle += step_length
+	}
+
+	// Inner circle
+	for _ in 0 .. segments {
+		sgl.v2f(x + f32(math.sin(angle)) * r1, y + f32(math.cos(angle) * r1))
+		sgl.v2f(x + f32(math.sin(angle - step_length)) * r1, y +
+			f32(math.cos(angle - step_length) * r1))
+
+		angle -= step_length
+	}
+
+	// Closing end
+	sgl.v2f(x + f32(math.sin(angle)) * r1, y + f32(math.cos(angle) * r1))
+	sgl.v2f(x + f32(math.sin(angle)) * r2, y + f32(math.cos(angle) * r2))
+	sgl.end()
+}
+
 // Draws a filled rounded rectangle
 pub fn (ctx &Context) draw_rounded_rect(x f32, y f32, w f32, h f32, radius f32, c gx.Color) {
 	sgl.c4b(c.r, c.g, c.b, c.a)

--- a/vlib/gg/testdata/draw_arcs.vv
+++ b/vlib/gg/testdata/draw_arcs.vv
@@ -20,4 +20,3 @@ fn frame(mut ctx gg.Context) {
 	ctx.draw_arc_empty(100, 100, 30, 50, 0, f32(math.radians(290)), 30, gx.white)
 	ctx.end()
 }
-

--- a/vlib/gg/testdata/draw_arcs.vv
+++ b/vlib/gg/testdata/draw_arcs.vv
@@ -1,0 +1,23 @@
+module main
+
+import math
+import gg
+import gx
+
+fn main() {
+	mut context := gg.new_context(
+		width: 200
+		height: 200
+		window_title: 'Arcs'
+		frame_fn: frame
+	)
+	context.run()
+}
+
+fn frame(mut ctx gg.Context) {
+	ctx.begin()
+	ctx.draw_arc(100, 100, 35, 45, 0, f32(math.radians(290)), 30, gx.red)
+	ctx.draw_arc_empty(100, 100, 30, 50, 0, f32(math.radians(290)), 30, gx.white)
+	ctx.end()
+}
+


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24865450/146623465-568c8900-58a8-45f4-ae4b-bd4ac372f06a.png)

```V
module main

import math
import gg
import gx

fn main() {
	mut context := gg.new_context(
		width: 200
		height: 200
		window_title: 'Arcs'
		frame_fn: frame
	)
	context.run()
}

fn frame(mut ctx gg.Context) {
	ctx.begin()
	ctx.draw_arc(100, 100, 35, 45, 0, f32(math.radians(290)), 30, gx.red)
	ctx.draw_arc_empty(100, 100, 30, 50, 0, f32(math.radians(290)), 30, gx.white)
	ctx.end()
}
```

After this PR, I'll be making a PR that renames stuff to use `gg.draw_[shape]_[filltype]`.