### PR TITLE
cgen: fix generic array of interface method call (fix #12882)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1545,6 +1545,7 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 		g.checker_bug('ref_or_deref_arg expected_type is 0', arg.pos)
 	}
 	exp_sym := g.table.get_type_symbol(expected_type)
+	arg_typ := g.unwrap_generic(arg.typ)
 	mut needs_closing := false
 	if arg.is_mut && !arg_is_ptr {
 		g.write('&/*mut*/')
@@ -1566,10 +1567,10 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 			}
 		}
 		if !g.is_json_fn {
-			if arg.typ == 0 {
+			if arg_typ == 0 {
 				g.checker_bug('ref_or_deref_arg arg.typ is 0', arg.pos)
 			}
-			arg_typ_sym := g.table.get_type_symbol(arg.typ)
+			arg_typ_sym := g.table.get_type_symbol(arg_typ)
 			expected_deref_type := if expected_type.is_ptr() {
 				expected_type.deref()
 			} else {
@@ -1594,7 +1595,7 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 				}
 			}
 		}
-	} else if arg.typ.has_flag(.shared_f) && !expected_type.has_flag(.shared_f) {
+	} else if arg_typ.has_flag(.shared_f) && !expected_type.has_flag(.shared_f) {
 		if expected_type.is_ptr() {
 			g.write('&')
 		}
@@ -1602,7 +1603,7 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 		g.write('->val')
 		return
 	}
-	g.expr_with_cast(arg.expr, arg.typ, expected_type)
+	g.expr_with_cast(arg.expr, arg_typ, expected_type)
 	if needs_closing {
 		g.write(')')
 	}

--- a/vlib/v/tests/generics_array_of_interface_method_call_test.v
+++ b/vlib/v/tests/generics_array_of_interface_method_call_test.v
@@ -1,0 +1,35 @@
+struct Array<T> {
+pub mut:
+	elements []T
+}
+
+struct String {
+	str string
+}
+
+interface IObject {
+	equals(IObject) bool
+}
+
+pub fn (s1 String) equals(s2 IObject) bool {
+	if s2 is String {
+		return s1.str == s2.str
+	}
+	return false
+}
+
+pub fn (mut m Array<T>) contains(e T) bool {
+	for mut element in m.elements {
+		if element.equals(e) {
+			return true
+		}
+	}
+	return false
+}
+
+fn test_generic_array_of_interface_method_call() {
+	s := String{'hello'}
+	mut a := Array<IObject>{[s]}
+	ret := a.contains(IObject(s))
+	println(ret)
+}

--- a/vlib/v/tests/generics_array_of_interface_method_call_test.v
+++ b/vlib/v/tests/generics_array_of_interface_method_call_test.v
@@ -32,4 +32,5 @@ fn test_generic_array_of_interface_method_call() {
 	mut a := Array<IObject>{[s]}
 	ret := a.contains(IObject(s))
 	println(ret)
+	assert ret
 }


### PR DESCRIPTION
This PR fix generic array of interface method call (fix #12882).

- Fix generic array of interface method call.
- Add test.

```vlang
struct Array<T> {
pub mut:
	elements []T
}

struct String {
	str string
}

interface IObject {
	equals(IObject) bool
}

pub fn (s1 String) equals(s2 IObject) bool {
	if s2 is String {
		return s1.str == s2.str
	}
	return false
}

pub fn (mut m Array<T>) contains(e T) bool {
	for mut element in m.elements {
		if element.equals(e) {
			return true
		}
	}
	return false
}

fn main() {
	s := String{'hello'}
	mut a := Array<IObject>{[s]}
	ret := a.contains(IObject(s))
	println(ret)
}

PS D:\Test\v\tt1> v run .
true
```