### PR TITLE
cgen: support closures with any number of parameters of any size on amd64

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -132,6 +132,7 @@ const (
 		'do_not_remove',
 	]
 	skip_on_arm64                 = [
+		'vlib/v/tests/closure_generator_test.v',
 		'do_not_remove',
 	]
 	skip_on_non_amd64_or_arm64    = [

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -109,6 +109,7 @@ const (
 		'vlib/orm/orm_test.v',
 		'vlib/v/tests/orm_sub_struct_test.v',
 		'vlib/v/tests/closure_test.v',
+		'vlib/v/tests/closure_generator_test.v',
 		'vlib/net/websocket/ws_test.v',
 		'vlib/net/unix/unix_test.v',
 		'vlib/net/websocket/websocket_test.v',

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -224,7 +224,7 @@ static void __closure_set_function(void *closure, void *f) {
 
 static inline int __closure_check_nargs(int nargs) {
 	if (nargs > (int)_ARR_LEN(__closure_thunk)) {
-		_v_panic(_SLIT("Closure too largs. Try reducing the number of parameters or pass the parameters by reference."));
+		_v_panic(_SLIT("Closure too large. Reduce the number of parameters, or pass the parameters by reference."));
 		VUNREACHABLE();
 	}
 	return nargs;

--- a/vlib/v/tests/closure_generator_test.v
+++ b/vlib/v/tests/closure_generator_test.v
@@ -64,7 +64,7 @@ fn test_closures_with_n_args() ? {
 	os.chdir(wrkdir) ?
 	os.write_file('closure_args_test.v', code) ?
 	vexe := os.getenv('VEXE')
-	res := os.execute('$vexe closure_args_test.v')
+	res := os.execute('"$vexe" closure_args_test.v')
 	if res.exit_code != 0 {
 		eprintln(res.output)
 		assert false

--- a/vlib/v/tests/closure_generator_test.v
+++ b/vlib/v/tests/closure_generator_test.v
@@ -1,0 +1,76 @@
+import strings
+import os
+
+const (
+	max_params       = 16
+	all_param_names  = []string{len: max_params, init: '${`a` + it}'}
+	all_param_values = []string{len: max_params, init: '${it + 1}'}
+)
+
+// test_closures_with_n_args generates a new V file containing closures of `i`
+// and parameters of type `typ`, to makes sure that all combinations work correctly
+fn test_closures_with_n_args() ? {
+	mut v_code := strings.new_builder(1024)
+	// NB: the type or value of the captured arg doesn't matter for this test,
+	// as the entire closure context is always passed as one pointer anyways
+
+	for typ in ['byte', 'u16', 'int', 'i64', 'voidptr', 'string'] {
+		for i in 0 .. max_params {
+			param_names := all_param_names[..i]
+			params := param_names.map('$it $typ')
+
+			mut values := all_param_values[..i]
+			if typ == 'string' {
+				values = values.map("'$it'")
+			}
+			values = values.map('${typ}($it)')
+
+			mut expected_val := if typ == 'string' {
+				s := all_param_values[..i].join('')
+				"'127' + '$s'"
+			} else {
+				'127 + ${i * (i + 1) / 2}'
+			}
+
+			init_val, return_type := if typ != 'string' {
+				'u64(127)', 'u64'
+			} else {
+				"'127'", 'string'
+			}
+
+			// NB: the captured arg doesn't matter for this test, as closures always receive
+			// a pointer to the entire closure context as their last argument anyways
+			v_code.writeln("
+	fn test_big_closure_${typ}_${i}() {
+		println('test_big_closure_${typ}_$i')
+		mut z := $init_val
+		c := fn [z] (${params.join(', ')}) $return_type {
+			mut sum := z")
+			for j in 0 .. i {
+				v_code.writeln('\t\tsum += ${return_type}(${param_names[j]})')
+			}
+			v_code.writeln('
+			return sum
+		}
+		assert c(${values.join(', ')}) == $expected_val
+	}')
+		}
+	}
+
+	code := v_code.str()
+	println('Compiling V code (${code.count('\n')} lines) ...')
+	wrkdir := os.join_path(os.temp_dir(), 'vtests', 'closures')
+	os.mkdir_all(wrkdir) ?
+	os.chdir(wrkdir) ?
+	os.write_file('closure_args_test.v', code) ?
+	vexe := os.getenv('VEXE')
+	res := os.execute('$vexe closure_args_test.v')
+	if res.exit_code != 0 {
+		eprintln(res.output)
+		assert false
+	}
+	println('Process exited with code $res.exit_code')
+
+	os.chdir(os.dir(vexe)) or {}
+	os.rmdir_all(wrkdir) or {}
+}


### PR DESCRIPTION
This doesn't work on master:
```v
x := 1
f := fn [x] (a string) {
    println('x: $i')
    println('a: $a')
}
f('hi')
```

And neither does this:
```v
x := 1
f := fn [x] (a int, b int, c int, d int, e int, f int, g int, h int) {
    println('x: $i')
    println('$a $b $c $d $e $f $g $h')
}
f(1, 2, 3, 4, 5, 6, 7, 8)
```

With this PR, both of those examples (and any combination of the two) now work (on amd64 only, currently).

***

Closes #12351 (string arg)
Closes #11990 (struct arg)