### PR TITLE
ast: rename 'table.get_type_symbol()' to 'table.sym()' and more related calls

### DIFF
--- a/vlib/v/ast/init.v
+++ b/vlib/v/ast/init.v
@@ -1,7 +1,7 @@
 module ast
 
 pub fn resolve_init(node StructInit, typ Type, t &Table) Expr {
-	type_sym := t.type_symbol(typ)
+	type_sym := t.sym(typ)
 	if type_sym.kind == .array {
 		array_info := type_sym.info as Array
 		mut has_len := false

--- a/vlib/v/ast/init.v
+++ b/vlib/v/ast/init.v
@@ -1,7 +1,7 @@
 module ast
 
 pub fn resolve_init(node StructInit, typ Type, t &Table) Expr {
-	type_sym := t.get_type_symbol(typ)
+	type_sym := t.type_symbol(typ)
 	if type_sym.kind == .array {
 		array_info := type_sym.info as Array
 		mut has_len := false

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -92,9 +92,9 @@ fn stringify_fn_after_name(node &FnDecl, mut f strings.Builder, t &Table, cur_mo
 	mut add_para_types := true
 	if node.generic_names.len > 0 {
 		if node.is_method {
-			sym := t.get_type_symbol(node.params[0].typ)
+			sym := t.type_symbol(node.params[0].typ)
 			if sym.info is Struct {
-				generic_names := sym.info.generic_types.map(t.get_type_symbol(it).name)
+				generic_names := sym.info.generic_types.map(t.type_symbol(it).name)
 				if generic_names == node.generic_names {
 					add_para_types = false
 				}
@@ -132,7 +132,7 @@ fn stringify_fn_after_name(node &FnDecl, mut f strings.Builder, t &Table, cur_mo
 		f.write_string(arg.name)
 		mut s := t.type_to_str(arg.typ.clear_flag(.shared_f))
 		if arg.is_mut {
-			arg_sym := t.get_type_symbol(arg.typ)
+			arg_sym := t.type_symbol(arg.typ)
 			if s.starts_with('&') && ((!arg_sym.is_number() && arg_sym.kind != .bool)
 				|| node.language != .v) {
 				s = s[1..]
@@ -452,7 +452,7 @@ pub fn (x Expr) str() string {
 			return x.var_name + ' := ' + x.expr.str()
 		}
 		StructInit {
-			sname := global_table.get_type_symbol(x.typ).name
+			sname := global_table.type_symbol(x.typ).name
 			return '$sname{....}'
 		}
 		ArrayDecompose {

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -92,9 +92,9 @@ fn stringify_fn_after_name(node &FnDecl, mut f strings.Builder, t &Table, cur_mo
 	mut add_para_types := true
 	if node.generic_names.len > 0 {
 		if node.is_method {
-			sym := t.type_symbol(node.params[0].typ)
+			sym := t.sym(node.params[0].typ)
 			if sym.info is Struct {
-				generic_names := sym.info.generic_types.map(t.type_symbol(it).name)
+				generic_names := sym.info.generic_types.map(t.sym(it).name)
 				if generic_names == node.generic_names {
 					add_para_types = false
 				}
@@ -132,7 +132,7 @@ fn stringify_fn_after_name(node &FnDecl, mut f strings.Builder, t &Table, cur_mo
 		f.write_string(arg.name)
 		mut s := t.type_to_str(arg.typ.clear_flag(.shared_f))
 		if arg.is_mut {
-			arg_sym := t.type_symbol(arg.typ)
+			arg_sym := t.sym(arg.typ)
 			if s.starts_with('&') && ((!arg_sym.is_number() && arg_sym.kind != .bool)
 				|| node.language != .v) {
 				s = s[1..]
@@ -452,7 +452,7 @@ pub fn (x Expr) str() string {
 			return x.var_name + ' := ' + x.expr.str()
 		}
 		StructInit {
-			sname := global_table.type_symbol(x.typ).name
+			sname := global_table.sym(x.typ).name
 			return '$sname{....}'
 		}
 		ArrayDecompose {

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -199,7 +199,7 @@ pub fn (t &Table) fn_type_signature(f &Fn) string {
 	for i, arg in f.params {
 		// TODO: for now ignore mut/pts in sig for now
 		typ := arg.typ.set_nr_muls(0)
-		arg_type_sym := t.type_symbol(typ)
+		arg_type_sym := t.sym(typ)
 		sig += arg_type_sym.str().to_lower().replace_each(['.', '__', '&', '', '[', 'arr_', 'chan ',
 			'chan_', 'map[', 'map_of_', ']', '_to_', '<', '_T_', ',', '_', ' ', '', '>', ''])
 		if i < f.params.len - 1 {
@@ -207,7 +207,7 @@ pub fn (t &Table) fn_type_signature(f &Fn) string {
 		}
 	}
 	if f.return_type != 0 && f.return_type != void_type {
-		sym := t.type_symbol(f.return_type)
+		sym := t.sym(f.return_type)
 		opt := if f.return_type.has_flag(.optional) { 'option_' } else { '' }
 		sig += '__$opt$sym.kind'
 	}
@@ -225,7 +225,7 @@ pub fn (t &Table) fn_type_source_signature(f &Fn) string {
 		if t.is_fmt && arg.name.len > 0 {
 			sig += '$arg.name '
 		}
-		arg_type_sym := t.type_symbol(arg.typ)
+		arg_type_sym := t.sym(arg.typ)
 		sig += arg_type_sym.name
 		if i < f.params.len - 1 {
 			sig += ', '
@@ -235,7 +235,7 @@ pub fn (t &Table) fn_type_source_signature(f &Fn) string {
 	if f.return_type == ovoid_type {
 		sig += ' ?'
 	} else if f.return_type != void_type {
-		return_type_sym := t.type_symbol(f.return_type)
+		return_type_sym := t.sym(f.return_type)
 		if f.return_type.has_flag(.optional) {
 			sig += ' ?$return_type_sym.name'
 		} else {
@@ -260,8 +260,8 @@ pub fn (t &Table) is_same_method(f &Fn, func &Fn) string {
 		// don't check receiver for `.typ`
 		has_unexpected_type := i > 0 && f.params[i].typ != func.params[i].typ
 		// temporary hack for JS ifaces
-		lsym := t.type_symbol(f.params[i].typ)
-		rsym := t.type_symbol(func.params[i].typ)
+		lsym := t.sym(f.params[i].typ)
+		rsym := t.sym(func.params[i].typ)
 		if lsym.language == .js && rsym.language == .js {
 			return ''
 		}
@@ -316,7 +316,7 @@ pub fn (t &Table) register_aggregate_method(mut sym TypeSymbol, name string) ?Fn
 	mut found_once := false
 	mut new_fn := Fn{}
 	for typ in agg_info.types {
-		ts := t.type_symbol(typ)
+		ts := t.sym(typ)
 		if type_method := ts.find_method(name) {
 			if !found_once {
 				found_once = true
@@ -365,10 +365,10 @@ pub struct GetEmbedsOptions {
 // the hierarchy of embeds is returned as a list
 pub fn (t &Table) get_embeds(sym &TypeSymbol, options GetEmbedsOptions) [][]Type {
 	mut embeds := [][]Type{}
-	unalias_sym := if sym.info is Alias { t.type_symbol(sym.info.parent_type) } else { sym }
+	unalias_sym := if sym.info is Alias { t.sym(sym.info.parent_type) } else { sym }
 	if unalias_sym.info is Struct {
 		for embed in unalias_sym.info.embeds {
-			embed_sym := t.type_symbol(embed)
+			embed_sym := t.sym(embed)
 			mut preceding := options.preceding
 			preceding << embed
 			embeds << t.get_embeds(embed_sym, preceding: preceding)
@@ -385,7 +385,7 @@ pub fn (t &Table) find_method_from_embeds(sym &TypeSymbol, method_name string) ?
 		mut found_methods := []Fn{}
 		mut embed_of_found_methods := []Type{}
 		for embed in sym.info.embeds {
-			embed_sym := t.type_symbol(embed)
+			embed_sym := t.sym(embed)
 			if m := t.find_method(embed_sym, method_name) {
 				found_methods << m
 				embed_of_found_methods << embed
@@ -403,7 +403,7 @@ pub fn (t &Table) find_method_from_embeds(sym &TypeSymbol, method_name string) ?
 		}
 	} else if sym.info is Aggregate {
 		for typ in sym.info.types {
-			agg_sym := t.type_symbol(typ)
+			agg_sym := t.sym(typ)
 			method, embed_types := t.find_method_from_embeds(agg_sym, method_name) or { continue }
 			if embed_types.len != 0 {
 				return method, embed_types
@@ -434,7 +434,7 @@ fn (t &Table) register_aggregate_field(mut sym TypeSymbol, name string) ?StructF
 	mut found_once := false
 	mut new_field := StructField{}
 	for typ in agg_info.types {
-		ts := t.type_symbol(typ)
+		ts := t.sym(typ)
 		if type_field := t.find_field(ts, name) {
 			if !found_once {
 				found_once = true
@@ -467,7 +467,7 @@ pub fn (t &Table) struct_fields(sym &TypeSymbol) []StructField {
 	if sym.info is Struct {
 		fields << sym.info.fields
 		for embed in sym.info.embeds {
-			embed_sym := t.type_symbol(embed)
+			embed_sym := t.sym(embed)
 			fields << t.struct_fields(embed_sym)
 		}
 	}
@@ -521,7 +521,7 @@ pub fn (t &Table) find_field_from_embeds(sym &TypeSymbol, field_name string) ?(S
 		mut found_fields := []StructField{}
 		mut embeds_of_found_fields := []Type{}
 		for embed in sym.info.embeds {
-			embed_sym := t.type_symbol(embed)
+			embed_sym := t.sym(embed)
 			if field := t.find_field(embed_sym, field_name) {
 				found_fields << field
 				embeds_of_found_fields << embed
@@ -539,14 +539,14 @@ pub fn (t &Table) find_field_from_embeds(sym &TypeSymbol, field_name string) ?(S
 		}
 	} else if sym.info is Aggregate {
 		for typ in sym.info.types {
-			agg_sym := t.type_symbol(typ)
+			agg_sym := t.sym(typ)
 			field, embed_types := t.find_field_from_embeds(agg_sym, field_name) or { continue }
 			if embed_types.len > 0 {
 				return field, embed_types
 			}
 		}
 	} else if sym.info is Alias {
-		unalias_sym := t.type_symbol(sym.info.parent_type)
+		unalias_sym := t.sym(sym.info.parent_type)
 		return t.find_field_from_embeds(unalias_sym, field_name)
 	}
 	return none
@@ -573,7 +573,7 @@ pub fn (t &Table) resolve_common_sumtype_fields(sym_ &TypeSymbol) {
 	mut field_map := map[string]StructField{}
 	mut field_usages := map[string]int{}
 	for variant in info.variants {
-		mut v_sym := t.final_type_symbol(variant)
+		mut v_sym := t.final_sym(variant)
 		fields := match mut v_sym.info {
 			Struct {
 				t.struct_fields(v_sym)
@@ -629,24 +629,24 @@ pub const invalid_type_symbol = &TypeSymbol{
 }
 
 [inline]
-pub fn (t &Table) type_symbol_by_idx(idx int) &TypeSymbol {
+pub fn (t &Table) sym_by_idx(idx int) &TypeSymbol {
 	return t.type_symbols[idx]
 }
 
-pub fn (t &Table) type_symbol(typ Type) &TypeSymbol {
+pub fn (t &Table) sym(typ Type) &TypeSymbol {
 	idx := typ.idx()
 	if idx > 0 {
 		return t.type_symbols[idx]
 	}
 	// this should never happen
-	t.panic('type_symbol: invalid type (typ=$typ idx=$idx). Compiler bug. This should never happen. Please report the bug using `v bug file.v`.
+	t.panic('sym: invalid type (typ=$typ idx=$idx). Compiler bug. This should never happen. Please report the bug using `v bug file.v`.
 ')
 	return ast.invalid_type_symbol
 }
 
-// final_type_symbol follows aliases until it gets to a "real" Type
+// final_sym follows aliases until it gets to a "real" Type
 [inline]
-pub fn (t &Table) final_type_symbol(typ Type) &TypeSymbol {
+pub fn (t &Table) final_sym(typ Type) &TypeSymbol {
 	mut idx := typ.idx()
 	if idx > 0 {
 		current_symbol := t.type_symbols[idx]
@@ -656,19 +656,19 @@ pub fn (t &Table) final_type_symbol(typ Type) &TypeSymbol {
 		return t.type_symbols[idx]
 	}
 	// this should never happen
-	t.panic('final_type_symbol: invalid type (typ=$typ idx=$idx). Compiler bug. This should never happen. Please report the bug using `v bug file.v`.')
+	t.panic('final_sym: invalid type (typ=$typ idx=$idx). Compiler bug. This should never happen. Please report the bug using `v bug file.v`.')
 	return ast.invalid_type_symbol
 }
 
 [inline]
 pub fn (t &Table) get_type_name(typ Type) string {
-	sym := t.type_symbol(typ)
+	sym := t.sym(typ)
 	return sym.name
 }
 
 [inline]
 pub fn (t &Table) unalias_num_type(typ Type) Type {
-	sym := t.type_symbol(typ)
+	sym := t.sym(typ)
 	if sym.kind == .alias {
 		pt := (sym.info as Alias).parent_type
 		if pt <= f64_type && pt >= void_type {
@@ -751,7 +751,7 @@ pub fn (t &Table) known_type_idx(typ Type) bool {
 	if typ == 0 {
 		return false
 	}
-	sym := t.type_symbol(typ)
+	sym := t.sym(typ)
 	match sym.kind {
 		.placeholder {
 			return sym.language != .v || sym.name.starts_with('C.')
@@ -775,14 +775,14 @@ pub fn (t &Table) known_type_idx(typ Type) bool {
 // e. g. []int
 [inline]
 pub fn (t &Table) array_name(elem_type Type) string {
-	elem_type_sym := t.type_symbol(elem_type)
+	elem_type_sym := t.sym(elem_type)
 	ptr := if elem_type.is_ptr() { '&'.repeat(elem_type.nr_muls()) } else { '' }
 	return '[]$ptr$elem_type_sym.name'
 }
 
 [inline]
 pub fn (t &Table) array_cname(elem_type Type) string {
-	elem_type_sym := t.type_symbol(elem_type)
+	elem_type_sym := t.sym(elem_type)
 	mut res := ''
 	if elem_type.is_ptr() {
 		res = '_ptr'.repeat(elem_type.nr_muls())
@@ -799,7 +799,7 @@ pub fn (t &Table) array_cname(elem_type Type) string {
 // e. g. [16][8]int
 [inline]
 pub fn (t &Table) array_fixed_name(elem_type Type, size int, size_expr Expr) string {
-	elem_type_sym := t.type_symbol(elem_type)
+	elem_type_sym := t.sym(elem_type)
 	ptr := if elem_type.is_ptr() { '&'.repeat(elem_type.nr_muls()) } else { '' }
 	size_str := if size_expr is EmptyExpr || size != 987654321 {
 		size.str()
@@ -811,7 +811,7 @@ pub fn (t &Table) array_fixed_name(elem_type Type, size int, size_expr Expr) str
 
 [inline]
 pub fn (t &Table) array_fixed_cname(elem_type Type, size int) string {
-	elem_type_sym := t.type_symbol(elem_type)
+	elem_type_sym := t.sym(elem_type)
 	mut res := ''
 	if elem_type.is_ptr() {
 		res = '_ptr$elem_type.nr_muls()'
@@ -821,7 +821,7 @@ pub fn (t &Table) array_fixed_cname(elem_type Type, size int) string {
 
 [inline]
 pub fn (t &Table) chan_name(elem_type Type, is_mut bool) string {
-	elem_type_sym := t.type_symbol(elem_type)
+	elem_type_sym := t.sym(elem_type)
 	mut ptr := ''
 	if is_mut {
 		ptr = 'mut '
@@ -833,7 +833,7 @@ pub fn (t &Table) chan_name(elem_type Type, is_mut bool) string {
 
 [inline]
 pub fn (t &Table) chan_cname(elem_type Type, is_mut bool) string {
-	elem_type_sym := t.type_symbol(elem_type)
+	elem_type_sym := t.sym(elem_type)
 	mut suffix := ''
 	if is_mut {
 		suffix = '_mut'
@@ -849,7 +849,7 @@ pub fn (t &Table) promise_name(return_type Type) string {
 		return 'Promise<JS.Any,JS.Any>'
 	}
 
-	return_type_sym := t.type_symbol(return_type)
+	return_type_sym := t.sym(return_type)
 	return 'Promise<$return_type_sym.name, JS.Any>'
 }
 
@@ -859,7 +859,7 @@ pub fn (t &Table) promise_cname(return_type Type) string {
 		return 'Promise_Any_Any'
 	}
 
-	return_type_sym := t.type_symbol(return_type)
+	return_type_sym := t.sym(return_type)
 	return 'Promise_${return_type_sym.name}_Any'
 }
 
@@ -872,7 +872,7 @@ pub fn (t &Table) thread_name(return_type Type) string {
 			return 'thread'
 		}
 	}
-	return_type_sym := t.type_symbol(return_type)
+	return_type_sym := t.sym(return_type)
 	ptr := if return_type.is_ptr() { '&' } else { '' }
 	opt := if return_type.has_flag(.optional) { '?' } else { '' }
 	return 'thread $opt$ptr$return_type_sym.name'
@@ -887,7 +887,7 @@ pub fn (t &Table) thread_cname(return_type Type) string {
 			return '__v_thread'
 		}
 	}
-	return_type_sym := t.type_symbol(return_type)
+	return_type_sym := t.sym(return_type)
 	suffix := if return_type.is_ptr() { '_ptr' } else { '' }
 	prefix := if return_type.has_flag(.optional) { 'Option_' } else { '' }
 	return '__v_thread_$prefix$return_type_sym.cname$suffix'
@@ -897,16 +897,16 @@ pub fn (t &Table) thread_cname(return_type Type) string {
 // e. g. map[string]int
 [inline]
 pub fn (t &Table) map_name(key_type Type, value_type Type) string {
-	key_type_sym := t.type_symbol(key_type)
-	value_type_sym := t.type_symbol(value_type)
+	key_type_sym := t.sym(key_type)
+	value_type_sym := t.sym(value_type)
 	ptr := if value_type.is_ptr() { '&' } else { '' }
 	return 'map[$key_type_sym.name]$ptr$value_type_sym.name'
 }
 
 [inline]
 pub fn (t &Table) map_cname(key_type Type, value_type Type) string {
-	key_type_sym := t.type_symbol(key_type)
-	value_type_sym := t.type_symbol(value_type)
+	key_type_sym := t.sym(key_type)
+	value_type_sym := t.sym(value_type)
 	suffix := if value_type.is_ptr() { '_ptr' } else { '' }
 	return 'Map_${key_type_sym.cname}_$value_type_sym.cname' + suffix
 }
@@ -1055,7 +1055,7 @@ pub fn (mut t Table) find_or_register_multi_return(mr_typs []Type) int {
 	mut name := '('
 	mut cname := 'multi_return'
 	for i, mr_typ in mr_typs {
-		mr_type_sym := t.type_symbol(mr_typ)
+		mr_type_sym := t.sym(mr_typ)
 		name += mr_type_sym.name
 		cname += '_$mr_type_sym.cname'
 		if i < mr_typs.len - 1 {
@@ -1122,7 +1122,7 @@ pub fn (mut t Table) add_placeholder_type(name string, language Language) int {
 
 [inline]
 pub fn (t &Table) value_type(typ Type) Type {
-	sym := t.final_type_symbol(typ)
+	sym := t.final_sym(typ)
 	if typ.has_flag(.variadic) {
 		// ...string => string
 		// return typ.clear_flag(.variadic)
@@ -1183,10 +1183,10 @@ pub fn (mut t Table) register_fn_concrete_types(fn_name string, types []Type) bo
 // TODO: there is a bug when casting sumtype the other way if its pointer
 // so until fixed at least show v (not C) error `x(variant) =  y(SumType*)`
 pub fn (t &Table) sumtype_has_variant(parent Type, variant Type, is_as bool) bool {
-	parent_sym := t.type_symbol(parent)
+	parent_sym := t.sym(parent)
 	if parent_sym.kind == .sum_type {
 		parent_info := parent_sym.info as SumType
-		var_sym := t.type_symbol(variant)
+		var_sym := t.sym(variant)
 		if var_sym.kind == .aggregate {
 			var_info := var_sym.info as Aggregate
 			for var_type in var_info.types {
@@ -1212,7 +1212,7 @@ pub fn (t &Table) known_type_names() []string {
 	for _, idx in t.type_idxs {
 		// Skip `int_literal_type_idx` and `float_literal_type_idx` because they shouldn't be visible to the User.
 		if idx !in [0, int_literal_type_idx, float_literal_type_idx] && t.known_type_idx(idx)
-			&& t.type_symbol(idx).kind != .function {
+			&& t.sym(idx).kind != .function {
 			res << t.type_to_str(idx)
 		}
 	}
@@ -1225,7 +1225,7 @@ pub fn (t &Table) known_type_names() []string {
 pub fn (t &Table) has_deep_child_no_ref(ts &TypeSymbol, name string) bool {
 	if ts.info is Struct {
 		for field in ts.info.fields {
-			sym := t.type_symbol(field.typ)
+			sym := t.sym(field.typ)
 			if !field.typ.is_ptr() && (sym.name == name || t.has_deep_child_no_ref(sym, name)) {
 				return true
 			}
@@ -1257,8 +1257,7 @@ pub fn (mut t Table) complete_interface_check() {
 				continue
 			}
 			// empty interface only generate type cast functions of the current module
-			if idecl.methods.len == 0 && idecl.fields.len == 0
-				&& tsym.mod != t.type_symbol(idecl.typ).mod {
+			if idecl.methods.len == 0 && idecl.fields.len == 0 && tsym.mod != t.sym(idecl.typ).mod {
 				continue
 			}
 			if t.does_type_implement_interface(tk, idecl.typ) {
@@ -1315,7 +1314,7 @@ pub fn (t Table) does_type_implement_interface(typ Type, inter_typ Type) bool {
 		// `none` "implements" the Error interface
 		return true
 	}
-	sym := t.type_symbol(typ)
+	sym := t.sym(typ)
 	if sym.language != .v {
 		return false
 	}
@@ -1325,7 +1324,7 @@ pub fn (t Table) does_type_implement_interface(typ Type, inter_typ Type) bool {
 			return false
 		}
 	}
-	mut inter_sym := t.type_symbol(inter_typ)
+	mut inter_sym := t.sym(inter_typ)
 	if sym.kind == .interface_ && inter_sym.kind == .interface_ {
 		return false
 	}
@@ -1387,7 +1386,7 @@ pub fn (t Table) does_type_implement_interface(typ Type, inter_typ Type) bool {
 // Even map[string]map[string]T can be resolved.
 // This is used for resolving the generic return type of CallExpr white `unwrap_generic` is used to resolve generic usage in FnDecl.
 pub fn (mut t Table) resolve_generic_to_concrete(generic_type Type, generic_names []string, concrete_types []Type) ?Type {
-	mut sym := t.type_symbol(generic_type)
+	mut sym := t.sym(generic_type)
 	if sym.name in generic_names {
 		index := generic_names.index(sym.name)
 		if index >= concrete_types.len {
@@ -1402,12 +1401,12 @@ pub fn (mut t Table) resolve_generic_to_concrete(generic_type Type, generic_name
 	match mut sym.info {
 		Array {
 			mut elem_type := sym.info.elem_type
-			mut elem_sym := t.type_symbol(elem_type)
+			mut elem_sym := t.sym(elem_type)
 			mut dims := 1
 			for mut elem_sym.info is Array {
 				info := elem_sym.info as Array
 				elem_type = info.elem_type
-				elem_sym = t.type_symbol(elem_type)
+				elem_sym = t.sym(elem_type)
 				dims++
 			}
 			if typ := t.resolve_generic_to_concrete(elem_type, generic_names, concrete_types) {
@@ -1498,7 +1497,7 @@ pub fn (mut t Table) resolve_generic_to_concrete(generic_type Type, generic_name
 					if ct := t.resolve_generic_to_concrete(sym.info.generic_types[i],
 						generic_names, concrete_types)
 					{
-						gts := t.type_symbol(ct)
+						gts := t.sym(ct)
 						nrt += gts.name
 						if i != sym.info.generic_types.len - 1 {
 							nrt += ', '
@@ -1523,16 +1522,16 @@ pub fn (mut t Table) unwrap_generic_type(typ Type, generic_names []string, concr
 	mut fields := []StructField{}
 	mut nrt := ''
 	mut c_nrt := ''
-	ts := t.type_symbol(typ)
+	ts := t.sym(typ)
 	match mut ts.info {
 		Array {
 			mut elem_type := ts.info.elem_type
-			mut elem_sym := t.type_symbol(elem_type)
+			mut elem_sym := t.sym(elem_type)
 			mut dims := 1
 			for mut elem_sym.info is Array {
 				info := elem_sym.info as Array
 				elem_type = info.elem_type
-				elem_sym = t.type_symbol(elem_type)
+				elem_sym = t.sym(elem_type)
 				dims++
 			}
 			unwrap_typ := t.unwrap_generic_type(elem_type, generic_names, concrete_types)
@@ -1567,7 +1566,7 @@ pub fn (mut t Table) unwrap_generic_type(typ Type, generic_names []string, concr
 				if ct := t.resolve_generic_to_concrete(ts.info.generic_types[i], generic_names,
 					concrete_types)
 				{
-					gts := t.type_symbol(ct)
+					gts := t.sym(ct)
 					nrt += gts.name
 					c_nrt += gts.cname
 					if i != ts.info.generic_types.len - 1 {
@@ -1585,7 +1584,7 @@ pub fn (mut t Table) unwrap_generic_type(typ Type, generic_names []string, concr
 				fields = ts.info.fields.clone()
 				for i in 0 .. fields.len {
 					if fields[i].typ.has_flag(.generic) {
-						sym := t.type_symbol(fields[i].typ)
+						sym := t.sym(fields[i].typ)
 						if sym.kind == .struct_ && fields[i].typ.idx() != typ.idx() {
 							fields[i].typ = t.unwrap_generic_type(fields[i].typ, generic_names,
 								concrete_types)
@@ -1669,7 +1668,7 @@ pub fn (mut t Table) unwrap_generic_type(typ Type, generic_names []string, concr
 				mod: ts.mod
 				info: info
 			)
-			mut ts_copy := t.type_symbol(new_idx)
+			mut ts_copy := t.sym(new_idx)
 			for method in all_methods {
 				ts_copy.register_method(method)
 			}
@@ -1699,7 +1698,7 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 					}
 					mut fields := parent_info.fields.clone()
 					if parent_info.generic_types.len == info.concrete_types.len {
-						generic_names := parent_info.generic_types.map(t.type_symbol(it).name)
+						generic_names := parent_info.generic_types.map(t.sym(it).name)
 						for i in 0 .. fields.len {
 							if fields[i].typ.has_flag(.generic) {
 								if fields[i].typ.idx() != info.parent_idx {
@@ -1727,7 +1726,7 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 						typ.is_public = true
 						typ.kind = parent.kind
 
-						parent_sym := t.type_symbol(parent_info.parent_type)
+						parent_sym := t.sym(parent_info.parent_type)
 						for method in parent_sym.methods {
 							if method.generic_names.len == info.concrete_types.len {
 								t.register_fn_concrete_types(method.name, info.concrete_types)
@@ -1745,7 +1744,7 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 					}
 					if parent_info.generic_types.len == info.concrete_types.len {
 						mut fields := parent_info.fields.clone()
-						generic_names := parent_info.generic_types.map(t.type_symbol(it).name)
+						generic_names := parent_info.generic_types.map(t.sym(it).name)
 						for i in 0 .. fields.len {
 							if t_typ := t.resolve_generic_to_concrete(fields[i].typ, generic_names,
 								info.concrete_types)
@@ -1803,7 +1802,7 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 					if parent_info.generic_types.len == info.concrete_types.len {
 						mut fields := parent_info.fields.clone()
 						mut variants := parent_info.variants.clone()
-						generic_names := parent_info.generic_types.map(t.type_symbol(it).name)
+						generic_names := parent_info.generic_types.map(t.sym(it).name)
 						for i in 0 .. fields.len {
 							if t_typ := t.resolve_generic_to_concrete(fields[i].typ, generic_names,
 								info.concrete_types)
@@ -1813,7 +1812,7 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 						}
 						for i in 0 .. variants.len {
 							if variants[i].has_flag(.generic) {
-								sym := t.type_symbol(variants[i])
+								sym := t.sym(variants[i])
 								if sym.kind == .struct_ && variants[i].idx() != info.parent_idx {
 									variants[i] = t.unwrap_generic_type(variants[i], generic_names,
 										info.concrete_types)

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -78,7 +78,7 @@ pub fn pref_arch_to_table_language(pref_arch pref.Arch) Language {
 // * Table.type_to_str(typ) not TypeSymbol.name.
 // * Table.type_kind(typ) not TypeSymbol.kind.
 // Each TypeSymbol is entered into `Table.types`.
-// See also: Table.get_type_symbol.
+// See also: Table.type_symbol.
 
 pub struct TypeSymbol {
 pub:
@@ -262,7 +262,7 @@ pub fn (t Type) str() string {
 }
 
 pub fn (t &Table) type_str(typ Type) string {
-	sym := t.get_type_symbol(typ)
+	sym := t.type_symbol(typ)
 	return sym.name
 }
 
@@ -514,7 +514,7 @@ pub fn (t &Table) type_kind(typ Type) Kind {
 	if typ.nr_muls() > 0 || typ.has_flag(.optional) {
 		return Kind.placeholder
 	}
-	return t.get_type_symbol(typ).kind
+	return t.type_symbol(typ).kind
 }
 
 pub enum Kind {
@@ -933,14 +933,14 @@ pub fn (t &Table) type_to_str(typ Type) string {
 // type name in code (for builtin)
 pub fn (mytable &Table) type_to_code(t Type) string {
 	match t {
-		ast.int_literal_type, ast.float_literal_type { return mytable.get_type_symbol(t).kind.str() }
+		ast.int_literal_type, ast.float_literal_type { return mytable.type_symbol(t).kind.str() }
 		else { return mytable.type_to_str_using_aliases(t, map[string]string{}) }
 	}
 }
 
 // import_aliases is a map of imported symbol aliases 'module.Type' => 'Type'
 pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]string) string {
-	sym := t.get_type_symbol(typ)
+	sym := t.type_symbol(typ)
 	mut res := sym.name
 	// Note, that the duplication of code in some of the match branches here
 	// is VERY deliberate. DO NOT be tempted to use `else {}` instead, because
@@ -1039,7 +1039,7 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 					Struct, Interface, SumType {
 						res += '<'
 						for i, gtyp in sym.info.generic_types {
-							res += t.get_type_symbol(gtyp).name
+							res += t.type_symbol(gtyp).name
 							if i != sym.info.generic_types.len - 1 {
 								res += ', '
 							}
@@ -1214,12 +1214,12 @@ pub fn (t &TypeSymbol) find_method_with_generic_parent(name string) ?Fn {
 	match t.info {
 		Struct, Interface, SumType {
 			if t.info.parent_type.has_flag(.generic) {
-				parent_sym := table.get_type_symbol(t.info.parent_type)
+				parent_sym := table.type_symbol(t.info.parent_type)
 				if x := parent_sym.find_method(name) {
 					match parent_sym.info {
 						Struct, Interface, SumType {
 							mut method := x
-							generic_names := parent_sym.info.generic_types.map(table.get_type_symbol(it).name)
+							generic_names := parent_sym.info.generic_types.map(table.type_symbol(it).name)
 							if rt := table.resolve_generic_to_concrete(method.return_type,
 								generic_names, t.info.concrete_types)
 							{
@@ -1262,7 +1262,7 @@ pub fn (t &TypeSymbol) is_js_compatible() bool {
 	match t.info {
 		SumType {
 			for variant in t.info.variants {
-				sym := table.get_final_type_symbol(variant)
+				sym := table.final_type_symbol(variant)
 				if !sym.is_js_compatible() {
 					return false
 				}

--- a/vlib/v/callgraph/callgraph.v
+++ b/vlib/v/callgraph/callgraph.v
@@ -72,7 +72,7 @@ fn (mut m Mapper) fn_name(fname string, receiver_type ast.Type, is_method bool) 
 	if !is_method {
 		return fname
 	}
-	rec_sym := m.table.get_type_symbol(receiver_type)
+	rec_sym := m.table.type_symbol(receiver_type)
 	return '${rec_sym.name}.$fname'
 }
 

--- a/vlib/v/callgraph/callgraph.v
+++ b/vlib/v/callgraph/callgraph.v
@@ -72,7 +72,7 @@ fn (mut m Mapper) fn_name(fname string, receiver_type ast.Type, is_method bool) 
 	if !is_method {
 		return fname
 	}
-	rec_sym := m.table.type_symbol(receiver_type)
+	rec_sym := m.table.sym(receiver_type)
 	return '${rec_sym.name}.$fname'
 }
 

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -24,7 +24,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 					c.check_expr_opt_call(right, right_type0),
 				]
 			}
-			right_type_sym := c.table.type_symbol(right_type)
+			right_type_sym := c.table.sym(right_type)
 			if right_type_sym.kind == .multi_return {
 				if node.right.len > 1 {
 					c.error('cannot use multi-value $right_type_sym.name in single-value context',
@@ -91,7 +91,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			c.expected_type = c.unwrap_generic(left_type)
 			// `map = {}`
 			if left_type != 0 {
-				sym := c.table.type_symbol(left_type)
+				sym := c.table.sym(left_type)
 				if sym.kind == .map {
 					if node.right.len <= i {
 						// `map_1, map_2, map_3 = f()`, where f returns (map[int]int, map[int]int, map[int]int)
@@ -124,7 +124,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		right := if i < node.right.len { node.right[i] } else { node.right[0] }
 		mut right_type := node.right_types[i]
 		if right is ast.Ident {
-			right_sym := c.table.type_symbol(right_type)
+			right_sym := c.table.sym(right_type)
 			if right_sym.info is ast.Struct {
 				if right_sym.info.generic_types.len > 0 {
 					if obj := right.scope.find(right.name) {
@@ -176,7 +176,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 						obj = c.fn_scope.find_var(right.obj.name) or { obj }
 					}
 					if obj.is_stack_obj && !c.inside_unsafe {
-						type_sym := c.table.type_symbol(obj.typ.set_nr_muls(0))
+						type_sym := c.table.sym(obj.typ.set_nr_muls(0))
 						if !type_sym.is_heap() && !c.pref.translated {
 							suggestion := if type_sym.kind == .struct_ {
 								'declaring `$type_sym.name` as `[heap]`'
@@ -193,7 +193,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		// Do not allow `a := 0; b := 0; a = &b`
 		if !is_decl && left is ast.Ident && !is_blank_ident && !left_type.is_real_pointer()
 			&& right_type.is_real_pointer() {
-			left_sym := c.table.type_symbol(left_type)
+			left_sym := c.table.sym(left_type)
 			if left_sym.kind != .function {
 				c.warn(
 					'cannot assign a reference to a value (this will be an error soon) left=${c.table.type_str(left_type)} $left_type.is_ptr() ' +
@@ -246,7 +246,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 									left.obj.is_used = true
 								}
 								if !left_type.is_ptr() {
-									if c.table.type_symbol(left_type).is_heap() {
+									if c.table.sym(left_type).is_heap() {
 										left.obj.is_auto_heap = true
 									}
 								}
@@ -326,8 +326,8 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		if left_type_unwrapped == 0 {
 			continue
 		}
-		left_sym := c.table.type_symbol(left_type_unwrapped)
-		right_sym := c.table.type_symbol(right_type_unwrapped)
+		left_sym := c.table.sym(left_type_unwrapped)
+		right_sym := c.table.sym(right_type_unwrapped)
 		if left_sym.kind == .array && !c.inside_unsafe && node.op in [.assign, .decl_assign]
 			&& right_sym.kind == .array && (left is ast.Ident && !left.is_blank_ident())
 			&& right is ast.Ident {
@@ -398,12 +398,11 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				}
 			}
 			.mult_assign, .div_assign {
-				if !left_sym.is_number() && !c.table.final_type_symbol(left_type_unwrapped).is_int()
+				if !left_sym.is_number() && !c.table.final_sym(left_type_unwrapped).is_int()
 					&& left_sym.kind !in [.struct_, .alias] {
 					c.error('operator $node.op.str() not defined on left operand type `$left_sym.name`',
 						left.position())
-				} else if !right_sym.is_number()
-					&& !c.table.final_type_symbol(left_type_unwrapped).is_int()
+				} else if !right_sym.is_number() && !c.table.final_sym(left_type_unwrapped).is_int()
 					&& left_sym.kind !in [.struct_, .alias] {
 					c.error('operator $node.op.str() not defined on right operand type `$right_sym.name`',
 						right.position())
@@ -411,11 +410,10 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			}
 			.and_assign, .or_assign, .xor_assign, .mod_assign, .left_shift_assign,
 			.right_shift_assign {
-				if !left_sym.is_int() && !c.table.final_type_symbol(left_type_unwrapped).is_int() {
+				if !left_sym.is_int() && !c.table.final_sym(left_type_unwrapped).is_int() {
 					c.error('operator $node.op.str() not defined on left operand type `$left_sym.name`',
 						left.position())
-				} else if !right_sym.is_int()
-					&& !c.table.final_type_symbol(right_type_unwrapped).is_int() {
+				} else if !right_sym.is_int() && !c.table.final_sym(right_type_unwrapped).is_int() {
 					c.error('operator $node.op.str() not defined on right operand type `$right_sym.name`',
 						right.position())
 				}
@@ -427,7 +425,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				}
 
 				modified_left_type := if !left_type.is_int() {
-					c.error('invalid operation: shift on type `${c.table.type_symbol(left_type).name}`',
+					c.error('invalid operation: shift on type `${c.table.sym(left_type).name}`',
 						node.pos)
 					ast.void_type_idx
 				} else if left_type.is_int_literal() {
@@ -481,7 +479,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			|| left_sym.kind == .alias) {
 			left_name := c.table.type_to_str(left_type_unwrapped)
 			right_name := c.table.type_to_str(right_type_unwrapped)
-			parent_sym := c.table.final_type_symbol(left_type_unwrapped)
+			parent_sym := c.table.final_sym(left_type_unwrapped)
 			if left_sym.kind == .alias && right_sym.kind != .alias {
 				c.error('mismatched types `$left_name` and `$right_name`', node.pos)
 			}
@@ -575,7 +573,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			}
 			if right_node.op == .arrow {
 				if assigned_var.is_mut {
-					right_sym := c.table.type_symbol(right_type0)
+					right_sym := c.table.sym(right_type0)
 					if right_sym.kind == .chan {
 						chan_info := right_sym.chan_info()
 						if chan_info.elem_type.is_ptr() && !chan_info.is_mut {

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -24,7 +24,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 					c.check_expr_opt_call(right, right_type0),
 				]
 			}
-			right_type_sym := c.table.get_type_symbol(right_type)
+			right_type_sym := c.table.type_symbol(right_type)
 			if right_type_sym.kind == .multi_return {
 				if node.right.len > 1 {
 					c.error('cannot use multi-value $right_type_sym.name in single-value context',
@@ -91,7 +91,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			c.expected_type = c.unwrap_generic(left_type)
 			// `map = {}`
 			if left_type != 0 {
-				sym := c.table.get_type_symbol(left_type)
+				sym := c.table.type_symbol(left_type)
 				if sym.kind == .map {
 					if node.right.len <= i {
 						// `map_1, map_2, map_3 = f()`, where f returns (map[int]int, map[int]int, map[int]int)
@@ -124,7 +124,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		right := if i < node.right.len { node.right[i] } else { node.right[0] }
 		mut right_type := node.right_types[i]
 		if right is ast.Ident {
-			right_sym := c.table.get_type_symbol(right_type)
+			right_sym := c.table.type_symbol(right_type)
 			if right_sym.info is ast.Struct {
 				if right_sym.info.generic_types.len > 0 {
 					if obj := right.scope.find(right.name) {
@@ -176,7 +176,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 						obj = c.fn_scope.find_var(right.obj.name) or { obj }
 					}
 					if obj.is_stack_obj && !c.inside_unsafe {
-						type_sym := c.table.get_type_symbol(obj.typ.set_nr_muls(0))
+						type_sym := c.table.type_symbol(obj.typ.set_nr_muls(0))
 						if !type_sym.is_heap() && !c.pref.translated {
 							suggestion := if type_sym.kind == .struct_ {
 								'declaring `$type_sym.name` as `[heap]`'
@@ -193,7 +193,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		// Do not allow `a := 0; b := 0; a = &b`
 		if !is_decl && left is ast.Ident && !is_blank_ident && !left_type.is_real_pointer()
 			&& right_type.is_real_pointer() {
-			left_sym := c.table.get_type_symbol(left_type)
+			left_sym := c.table.type_symbol(left_type)
 			if left_sym.kind != .function {
 				c.warn(
 					'cannot assign a reference to a value (this will be an error soon) left=${c.table.type_str(left_type)} $left_type.is_ptr() ' +
@@ -246,7 +246,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 									left.obj.is_used = true
 								}
 								if !left_type.is_ptr() {
-									if c.table.get_type_symbol(left_type).is_heap() {
+									if c.table.type_symbol(left_type).is_heap() {
 										left.obj.is_auto_heap = true
 									}
 								}
@@ -326,8 +326,8 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		if left_type_unwrapped == 0 {
 			continue
 		}
-		left_sym := c.table.get_type_symbol(left_type_unwrapped)
-		right_sym := c.table.get_type_symbol(right_type_unwrapped)
+		left_sym := c.table.type_symbol(left_type_unwrapped)
+		right_sym := c.table.type_symbol(right_type_unwrapped)
 		if left_sym.kind == .array && !c.inside_unsafe && node.op in [.assign, .decl_assign]
 			&& right_sym.kind == .array && (left is ast.Ident && !left.is_blank_ident())
 			&& right is ast.Ident {
@@ -398,13 +398,12 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				}
 			}
 			.mult_assign, .div_assign {
-				if !left_sym.is_number()
-					&& !c.table.get_final_type_symbol(left_type_unwrapped).is_int()
+				if !left_sym.is_number() && !c.table.final_type_symbol(left_type_unwrapped).is_int()
 					&& left_sym.kind !in [.struct_, .alias] {
 					c.error('operator $node.op.str() not defined on left operand type `$left_sym.name`',
 						left.position())
 				} else if !right_sym.is_number()
-					&& !c.table.get_final_type_symbol(left_type_unwrapped).is_int()
+					&& !c.table.final_type_symbol(left_type_unwrapped).is_int()
 					&& left_sym.kind !in [.struct_, .alias] {
 					c.error('operator $node.op.str() not defined on right operand type `$right_sym.name`',
 						right.position())
@@ -412,12 +411,11 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			}
 			.and_assign, .or_assign, .xor_assign, .mod_assign, .left_shift_assign,
 			.right_shift_assign {
-				if !left_sym.is_int()
-					&& !c.table.get_final_type_symbol(left_type_unwrapped).is_int() {
+				if !left_sym.is_int() && !c.table.final_type_symbol(left_type_unwrapped).is_int() {
 					c.error('operator $node.op.str() not defined on left operand type `$left_sym.name`',
 						left.position())
 				} else if !right_sym.is_int()
-					&& !c.table.get_final_type_symbol(right_type_unwrapped).is_int() {
+					&& !c.table.final_type_symbol(right_type_unwrapped).is_int() {
 					c.error('operator $node.op.str() not defined on right operand type `$right_sym.name`',
 						right.position())
 				}
@@ -429,7 +427,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				}
 
 				modified_left_type := if !left_type.is_int() {
-					c.error('invalid operation: shift on type `${c.table.get_type_symbol(left_type).name}`',
+					c.error('invalid operation: shift on type `${c.table.type_symbol(left_type).name}`',
 						node.pos)
 					ast.void_type_idx
 				} else if left_type.is_int_literal() {
@@ -483,7 +481,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			|| left_sym.kind == .alias) {
 			left_name := c.table.type_to_str(left_type_unwrapped)
 			right_name := c.table.type_to_str(right_type_unwrapped)
-			parent_sym := c.table.get_final_type_symbol(left_type_unwrapped)
+			parent_sym := c.table.final_type_symbol(left_type_unwrapped)
 			if left_sym.kind == .alias && right_sym.kind != .alias {
 				c.error('mismatched types `$left_name` and `$right_name`', node.pos)
 			}
@@ -577,7 +575,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			}
 			if right_node.op == .arrow {
 				if assigned_var.is_mut {
-					right_sym := c.table.get_type_symbol(right_type0)
+					right_sym := c.table.type_symbol(right_type0)
 					if right_sym.kind == .chan {
 						chan_info := right_sym.chan_info()
 						if chan_info.elem_type.is_ptr() && !chan_info.is_mut {

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -20,7 +20,7 @@ pub fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 			// return true
 			//}
 			deref := expected.deref()
-			got_sym := c.table.get_type_symbol(got)
+			got_sym := c.table.type_symbol(got)
 			if deref.is_number() && (got_sym.is_number() || got_sym.kind == .enum_) {
 				return true
 			}
@@ -61,7 +61,7 @@ pub fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 		return true
 	}
 	if expected.has_flag(.optional) {
-		sym := c.table.get_type_symbol(got)
+		sym := c.table.type_symbol(got)
 		if (sym.kind == .interface_ && sym.name == 'IError')
 			|| got in [ast.none_type, ast.error_type] {
 			return true
@@ -79,7 +79,7 @@ pub fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 			return true
 		}
 		if c.promote_num(expected, got) != expected {
-			// println('could not promote ${c.table.get_type_symbol(got).name} to ${c.table.get_type_symbol(expected).name}')
+			// println('could not promote ${c.table.type_symbol(got).name} to ${c.table.type_symbol(expected).name}')
 			return false
 		}
 	}
@@ -96,7 +96,7 @@ pub fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type,
 	mut expected := expected_
 	// variadic
 	if expected.has_flag(.variadic) {
-		exp_type_sym := c.table.get_type_symbol(expected_)
+		exp_type_sym := c.table.type_symbol(expected_)
 		exp_info := exp_type_sym.info as ast.Array
 		expected = exp_info.elem_type
 	}
@@ -112,7 +112,7 @@ pub fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type,
 			&& got.idx() in [ast.int_type_idx, ast.int_literal_type_idx]) {
 			return
 		}
-		exp_sym := c.table.get_type_symbol(expected)
+		exp_sym := c.table.type_symbol(expected)
 		// unknown C types are set to int, allow int to be used for types like `&C.FILE`
 		// eg. `C.fflush(C.stderr)` - error: cannot use `int` as `&C.FILE` in argument 1 to `C.fflush`
 		if expected.is_ptr() && exp_sym.language == .c && exp_sym.kind in [.placeholder, .struct_]
@@ -158,7 +158,7 @@ pub fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type,
 	if c.check_types(got, expected) {
 		if language != .v || expected.is_ptr() == got.is_ptr() || arg.is_mut
 			|| arg.expr.is_auto_deref_var() || got.has_flag(.shared_f)
-			|| c.table.get_type_symbol(expected_).kind !in [.array, .map] {
+			|| c.table.type_symbol(expected_).kind !in [.array, .map] {
 			return
 		}
 	}
@@ -184,7 +184,7 @@ pub fn (mut c Checker) check_basic(got ast.Type, expected ast.Type) bool {
 	if expected.idx() == ast.array_type_idx || got.idx() == ast.array_type_idx {
 		return true
 	}
-	got_sym, exp_sym := c.table.get_type_symbol(got), c.table.get_type_symbol(expected)
+	got_sym, exp_sym := c.table.type_symbol(got), c.table.type_symbol(expected)
 	// array/map as argument
 	if got_sym.kind in [.array, .map, .array_fixed] && exp_sym.kind == got_sym.kind {
 		if c.table.type_to_str(got) == c.table.type_to_str(expected).trim('&') {
@@ -261,7 +261,7 @@ pub fn (mut c Checker) check_matching_function_symbols(got_type_sym &ast.TypeSym
 
 fn (mut c Checker) check_shift(mut node ast.InfixExpr, left_type ast.Type, right_type ast.Type) ast.Type {
 	if !left_type.is_int() {
-		left_sym := c.table.get_type_symbol(left_type)
+		left_sym := c.table.type_symbol(left_type)
 		// maybe it's an int alias? TODO move this to is_int() ?
 		if left_sym.kind == .alias && (left_sym.info as ast.Alias).parent_type.is_int() {
 			return left_type
@@ -274,8 +274,8 @@ fn (mut c Checker) check_shift(mut node ast.InfixExpr, left_type ast.Type, right
 		return ast.void_type
 	}
 	if !right_type.is_int() && !c.pref.translated {
-		left_sym := c.table.get_type_symbol(left_type)
-		right_sym := c.table.get_type_symbol(right_type)
+		left_sym := c.table.type_symbol(left_type)
+		right_sym := c.table.type_symbol(right_type)
 		c.error('cannot shift non-integer type `$right_sym.name` into type `$left_sym.name`',
 			node.right.position())
 		return ast.void_type
@@ -315,7 +315,7 @@ fn (mut c Checker) check_shift(mut node ast.InfixExpr, left_type ast.Type, right
 			// non-negative value, the value of the result is the integral
 			// part of the quotient of E1/2^E2. If E1 has a signed type and
 			// a negative value, the resulting value is implementation-defined (ID).
-			left_sym_final := c.table.get_final_type_symbol(left_type)
+			left_sym_final := c.table.final_type_symbol(left_type)
 			left_type_final := ast.Type(left_sym_final.idx)
 			if node.op == .left_shift && left_type_final.is_signed() && !(c.inside_unsafe
 				&& c.is_generated) {
@@ -478,11 +478,11 @@ pub fn (mut c Checker) get_default_fmt(ftyp ast.Type, typ ast.Type) byte {
 	} else if typ.is_pointer() {
 		return `p`
 	} else {
-		mut sym := c.table.get_type_symbol(c.unwrap_generic(ftyp))
+		mut sym := c.table.type_symbol(c.unwrap_generic(ftyp))
 		if sym.kind == .alias {
 			// string aliases should be printable
 			info := sym.info as ast.Alias
-			sym = c.table.get_type_symbol(info.parent_type)
+			sym = c.table.type_symbol(info.parent_type)
 			if info.parent_type == ast.string_type {
 				return `s`
 			}
@@ -692,7 +692,7 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 			mut to_set := ast.void_type
 			// resolve generic struct receiver
 			if i == 0 && node.is_method && param.typ.has_flag(.generic) {
-				sym := c.table.get_type_symbol(node.receiver_type)
+				sym := c.table.type_symbol(node.receiver_type)
 				match sym.info {
 					ast.Struct, ast.Interface, ast.SumType {
 						if c.table.cur_fn.generic_names.len > 0 { // in generic fn
@@ -702,7 +702,7 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 								typ = c.table.cur_concrete_types[idx]
 							}
 						} else { // in non-generic fn
-							receiver_generic_names := sym.info.generic_types.map(c.table.get_type_symbol(it).name)
+							receiver_generic_names := sym.info.generic_types.map(c.table.type_symbol(it).name)
 							if gt_name in receiver_generic_names
 								&& sym.info.generic_types.len == sym.info.concrete_types.len {
 								idx := receiver_generic_names.index(gt_name)
@@ -719,11 +719,11 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 			}
 			mut arg := node.args[arg_i]
 			arg.typ = c.unwrap_generic(arg.typ)
-			param_type_sym := c.table.get_type_symbol(param.typ)
+			param_type_sym := c.table.type_symbol(param.typ)
 
 			if param.typ.has_flag(.generic) && param_type_sym.name == gt_name {
 				to_set = c.table.mktyp(arg.typ)
-				sym := c.table.get_type_symbol(arg.typ)
+				sym := c.table.type_symbol(arg.typ)
 				if sym.info is ast.FnType {
 					mut func_ := sym.info.func
 					func_.name = ''
@@ -742,21 +742,21 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 					to_set = c.unwrap_generic(to_set)
 				}
 			} else if param.typ.has_flag(.generic) {
-				arg_sym := c.table.get_type_symbol(arg.typ)
+				arg_sym := c.table.type_symbol(arg.typ)
 				if param.typ.has_flag(.variadic) {
 					to_set = c.table.mktyp(arg.typ)
 				} else if arg_sym.kind == .array && param_type_sym.kind == .array {
 					mut arg_elem_info := arg_sym.info as ast.Array
 					mut param_elem_info := param_type_sym.info as ast.Array
-					mut arg_elem_sym := c.table.get_type_symbol(arg_elem_info.elem_type)
-					mut param_elem_sym := c.table.get_type_symbol(param_elem_info.elem_type)
+					mut arg_elem_sym := c.table.type_symbol(arg_elem_info.elem_type)
+					mut param_elem_sym := c.table.type_symbol(param_elem_info.elem_type)
 					for {
 						if arg_elem_sym.kind == .array && param_elem_sym.kind == .array
 							&& param_elem_sym.name !in c.table.cur_fn.generic_names {
 							arg_elem_info = arg_elem_sym.info as ast.Array
-							arg_elem_sym = c.table.get_type_symbol(arg_elem_info.elem_type)
+							arg_elem_sym = c.table.type_symbol(arg_elem_info.elem_type)
 							param_elem_info = param_elem_sym.info as ast.Array
-							param_elem_sym = c.table.get_type_symbol(param_elem_info.elem_type)
+							param_elem_sym = c.table.type_symbol(param_elem_info.elem_type)
 						} else {
 							to_set = arg_elem_info.elem_type
 							break
@@ -765,15 +765,15 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 				} else if arg_sym.kind == .array_fixed && param_type_sym.kind == .array_fixed {
 					mut arg_elem_info := arg_sym.info as ast.ArrayFixed
 					mut param_elem_info := param_type_sym.info as ast.ArrayFixed
-					mut arg_elem_sym := c.table.get_type_symbol(arg_elem_info.elem_type)
-					mut param_elem_sym := c.table.get_type_symbol(param_elem_info.elem_type)
+					mut arg_elem_sym := c.table.type_symbol(arg_elem_info.elem_type)
+					mut param_elem_sym := c.table.type_symbol(param_elem_info.elem_type)
 					for {
 						if arg_elem_sym.kind == .array_fixed && param_elem_sym.kind == .array_fixed
 							&& param_elem_sym.name !in c.table.cur_fn.generic_names {
 							arg_elem_info = arg_elem_sym.info as ast.ArrayFixed
-							arg_elem_sym = c.table.get_type_symbol(arg_elem_info.elem_type)
+							arg_elem_sym = c.table.type_symbol(arg_elem_info.elem_type)
 							param_elem_info = param_elem_sym.info as ast.ArrayFixed
-							param_elem_sym = c.table.get_type_symbol(param_elem_info.elem_type)
+							param_elem_sym = c.table.type_symbol(param_elem_info.elem_type)
 						} else {
 							to_set = arg_elem_info.elem_type
 							break
@@ -783,11 +783,11 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 					arg_map_info := arg_sym.info as ast.Map
 					param_map_info := param_type_sym.info as ast.Map
 					if param_map_info.key_type.has_flag(.generic)
-						&& c.table.get_type_symbol(param_map_info.key_type).name == gt_name {
+						&& c.table.type_symbol(param_map_info.key_type).name == gt_name {
 						typ = arg_map_info.key_type
 					}
 					if param_map_info.value_type.has_flag(.generic)
-						&& c.table.get_type_symbol(param_map_info.value_type).name == gt_name {
+						&& c.table.type_symbol(param_map_info.value_type).name == gt_name {
 						typ = arg_map_info.value_type
 					}
 				} else if arg_sym.kind in [.struct_, .interface_, .sum_type] {
@@ -800,7 +800,7 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 						}
 						else {}
 					}
-					generic_names := generic_types.map(c.table.get_type_symbol(it).name)
+					generic_names := generic_types.map(c.table.type_symbol(it).name)
 					if gt_name in generic_names && generic_types.len == concrete_types.len {
 						idx := generic_names.index(gt_name)
 						typ = concrete_types[idx]
@@ -819,7 +819,7 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 						}
 					}
 					if !c.check_types(typ, to_set) {
-						c.error('inferred generic type `$gt_name` is ambiguous: got `${c.table.get_type_symbol(to_set).name}`, expected `${c.table.get_type_symbol(typ).name}`',
+						c.error('inferred generic type `$gt_name` is ambiguous: got `${c.table.type_symbol(to_set).name}`, expected `${c.table.type_symbol(typ).name}`',
 							arg.pos)
 					}
 				}

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -20,7 +20,7 @@ pub fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 			// return true
 			//}
 			deref := expected.deref()
-			got_sym := c.table.type_symbol(got)
+			got_sym := c.table.sym(got)
 			if deref.is_number() && (got_sym.is_number() || got_sym.kind == .enum_) {
 				return true
 			}
@@ -61,7 +61,7 @@ pub fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 		return true
 	}
 	if expected.has_flag(.optional) {
-		sym := c.table.type_symbol(got)
+		sym := c.table.sym(got)
 		if (sym.kind == .interface_ && sym.name == 'IError')
 			|| got in [ast.none_type, ast.error_type] {
 			return true
@@ -79,7 +79,7 @@ pub fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 			return true
 		}
 		if c.promote_num(expected, got) != expected {
-			// println('could not promote ${c.table.type_symbol(got).name} to ${c.table.type_symbol(expected).name}')
+			// println('could not promote ${c.table.sym(got).name} to ${c.table.sym(expected).name}')
 			return false
 		}
 	}
@@ -96,7 +96,7 @@ pub fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type,
 	mut expected := expected_
 	// variadic
 	if expected.has_flag(.variadic) {
-		exp_type_sym := c.table.type_symbol(expected_)
+		exp_type_sym := c.table.sym(expected_)
 		exp_info := exp_type_sym.info as ast.Array
 		expected = exp_info.elem_type
 	}
@@ -112,7 +112,7 @@ pub fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type,
 			&& got.idx() in [ast.int_type_idx, ast.int_literal_type_idx]) {
 			return
 		}
-		exp_sym := c.table.type_symbol(expected)
+		exp_sym := c.table.sym(expected)
 		// unknown C types are set to int, allow int to be used for types like `&C.FILE`
 		// eg. `C.fflush(C.stderr)` - error: cannot use `int` as `&C.FILE` in argument 1 to `C.fflush`
 		if expected.is_ptr() && exp_sym.language == .c && exp_sym.kind in [.placeholder, .struct_]
@@ -158,7 +158,7 @@ pub fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type,
 	if c.check_types(got, expected) {
 		if language != .v || expected.is_ptr() == got.is_ptr() || arg.is_mut
 			|| arg.expr.is_auto_deref_var() || got.has_flag(.shared_f)
-			|| c.table.type_symbol(expected_).kind !in [.array, .map] {
+			|| c.table.sym(expected_).kind !in [.array, .map] {
 			return
 		}
 	}
@@ -184,7 +184,7 @@ pub fn (mut c Checker) check_basic(got ast.Type, expected ast.Type) bool {
 	if expected.idx() == ast.array_type_idx || got.idx() == ast.array_type_idx {
 		return true
 	}
-	got_sym, exp_sym := c.table.type_symbol(got), c.table.type_symbol(expected)
+	got_sym, exp_sym := c.table.sym(got), c.table.sym(expected)
 	// array/map as argument
 	if got_sym.kind in [.array, .map, .array_fixed] && exp_sym.kind == got_sym.kind {
 		if c.table.type_to_str(got) == c.table.type_to_str(expected).trim('&') {
@@ -261,7 +261,7 @@ pub fn (mut c Checker) check_matching_function_symbols(got_type_sym &ast.TypeSym
 
 fn (mut c Checker) check_shift(mut node ast.InfixExpr, left_type ast.Type, right_type ast.Type) ast.Type {
 	if !left_type.is_int() {
-		left_sym := c.table.type_symbol(left_type)
+		left_sym := c.table.sym(left_type)
 		// maybe it's an int alias? TODO move this to is_int() ?
 		if left_sym.kind == .alias && (left_sym.info as ast.Alias).parent_type.is_int() {
 			return left_type
@@ -274,8 +274,8 @@ fn (mut c Checker) check_shift(mut node ast.InfixExpr, left_type ast.Type, right
 		return ast.void_type
 	}
 	if !right_type.is_int() && !c.pref.translated {
-		left_sym := c.table.type_symbol(left_type)
-		right_sym := c.table.type_symbol(right_type)
+		left_sym := c.table.sym(left_type)
+		right_sym := c.table.sym(right_type)
 		c.error('cannot shift non-integer type `$right_sym.name` into type `$left_sym.name`',
 			node.right.position())
 		return ast.void_type
@@ -315,7 +315,7 @@ fn (mut c Checker) check_shift(mut node ast.InfixExpr, left_type ast.Type, right
 			// non-negative value, the value of the result is the integral
 			// part of the quotient of E1/2^E2. If E1 has a signed type and
 			// a negative value, the resulting value is implementation-defined (ID).
-			left_sym_final := c.table.final_type_symbol(left_type)
+			left_sym_final := c.table.final_sym(left_type)
 			left_type_final := ast.Type(left_sym_final.idx)
 			if node.op == .left_shift && left_type_final.is_signed() && !(c.inside_unsafe
 				&& c.is_generated) {
@@ -478,11 +478,11 @@ pub fn (mut c Checker) get_default_fmt(ftyp ast.Type, typ ast.Type) byte {
 	} else if typ.is_pointer() {
 		return `p`
 	} else {
-		mut sym := c.table.type_symbol(c.unwrap_generic(ftyp))
+		mut sym := c.table.sym(c.unwrap_generic(ftyp))
 		if sym.kind == .alias {
 			// string aliases should be printable
 			info := sym.info as ast.Alias
-			sym = c.table.type_symbol(info.parent_type)
+			sym = c.table.sym(info.parent_type)
 			if info.parent_type == ast.string_type {
 				return `s`
 			}
@@ -692,7 +692,7 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 			mut to_set := ast.void_type
 			// resolve generic struct receiver
 			if i == 0 && node.is_method && param.typ.has_flag(.generic) {
-				sym := c.table.type_symbol(node.receiver_type)
+				sym := c.table.sym(node.receiver_type)
 				match sym.info {
 					ast.Struct, ast.Interface, ast.SumType {
 						if c.table.cur_fn.generic_names.len > 0 { // in generic fn
@@ -702,7 +702,7 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 								typ = c.table.cur_concrete_types[idx]
 							}
 						} else { // in non-generic fn
-							receiver_generic_names := sym.info.generic_types.map(c.table.type_symbol(it).name)
+							receiver_generic_names := sym.info.generic_types.map(c.table.sym(it).name)
 							if gt_name in receiver_generic_names
 								&& sym.info.generic_types.len == sym.info.concrete_types.len {
 								idx := receiver_generic_names.index(gt_name)
@@ -719,11 +719,11 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 			}
 			mut arg := node.args[arg_i]
 			arg.typ = c.unwrap_generic(arg.typ)
-			param_type_sym := c.table.type_symbol(param.typ)
+			param_type_sym := c.table.sym(param.typ)
 
 			if param.typ.has_flag(.generic) && param_type_sym.name == gt_name {
 				to_set = c.table.mktyp(arg.typ)
-				sym := c.table.type_symbol(arg.typ)
+				sym := c.table.sym(arg.typ)
 				if sym.info is ast.FnType {
 					mut func_ := sym.info.func
 					func_.name = ''
@@ -742,21 +742,21 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 					to_set = c.unwrap_generic(to_set)
 				}
 			} else if param.typ.has_flag(.generic) {
-				arg_sym := c.table.type_symbol(arg.typ)
+				arg_sym := c.table.sym(arg.typ)
 				if param.typ.has_flag(.variadic) {
 					to_set = c.table.mktyp(arg.typ)
 				} else if arg_sym.kind == .array && param_type_sym.kind == .array {
 					mut arg_elem_info := arg_sym.info as ast.Array
 					mut param_elem_info := param_type_sym.info as ast.Array
-					mut arg_elem_sym := c.table.type_symbol(arg_elem_info.elem_type)
-					mut param_elem_sym := c.table.type_symbol(param_elem_info.elem_type)
+					mut arg_elem_sym := c.table.sym(arg_elem_info.elem_type)
+					mut param_elem_sym := c.table.sym(param_elem_info.elem_type)
 					for {
 						if arg_elem_sym.kind == .array && param_elem_sym.kind == .array
 							&& param_elem_sym.name !in c.table.cur_fn.generic_names {
 							arg_elem_info = arg_elem_sym.info as ast.Array
-							arg_elem_sym = c.table.type_symbol(arg_elem_info.elem_type)
+							arg_elem_sym = c.table.sym(arg_elem_info.elem_type)
 							param_elem_info = param_elem_sym.info as ast.Array
-							param_elem_sym = c.table.type_symbol(param_elem_info.elem_type)
+							param_elem_sym = c.table.sym(param_elem_info.elem_type)
 						} else {
 							to_set = arg_elem_info.elem_type
 							break
@@ -765,15 +765,15 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 				} else if arg_sym.kind == .array_fixed && param_type_sym.kind == .array_fixed {
 					mut arg_elem_info := arg_sym.info as ast.ArrayFixed
 					mut param_elem_info := param_type_sym.info as ast.ArrayFixed
-					mut arg_elem_sym := c.table.type_symbol(arg_elem_info.elem_type)
-					mut param_elem_sym := c.table.type_symbol(param_elem_info.elem_type)
+					mut arg_elem_sym := c.table.sym(arg_elem_info.elem_type)
+					mut param_elem_sym := c.table.sym(param_elem_info.elem_type)
 					for {
 						if arg_elem_sym.kind == .array_fixed && param_elem_sym.kind == .array_fixed
 							&& param_elem_sym.name !in c.table.cur_fn.generic_names {
 							arg_elem_info = arg_elem_sym.info as ast.ArrayFixed
-							arg_elem_sym = c.table.type_symbol(arg_elem_info.elem_type)
+							arg_elem_sym = c.table.sym(arg_elem_info.elem_type)
 							param_elem_info = param_elem_sym.info as ast.ArrayFixed
-							param_elem_sym = c.table.type_symbol(param_elem_info.elem_type)
+							param_elem_sym = c.table.sym(param_elem_info.elem_type)
 						} else {
 							to_set = arg_elem_info.elem_type
 							break
@@ -783,11 +783,11 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 					arg_map_info := arg_sym.info as ast.Map
 					param_map_info := param_type_sym.info as ast.Map
 					if param_map_info.key_type.has_flag(.generic)
-						&& c.table.type_symbol(param_map_info.key_type).name == gt_name {
+						&& c.table.sym(param_map_info.key_type).name == gt_name {
 						typ = arg_map_info.key_type
 					}
 					if param_map_info.value_type.has_flag(.generic)
-						&& c.table.type_symbol(param_map_info.value_type).name == gt_name {
+						&& c.table.sym(param_map_info.value_type).name == gt_name {
 						typ = arg_map_info.value_type
 					}
 				} else if arg_sym.kind in [.struct_, .interface_, .sum_type] {
@@ -800,7 +800,7 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 						}
 						else {}
 					}
-					generic_names := generic_types.map(c.table.type_symbol(it).name)
+					generic_names := generic_types.map(c.table.sym(it).name)
 					if gt_name in generic_names && generic_types.len == concrete_types.len {
 						idx := generic_names.index(gt_name)
 						typ = concrete_types[idx]
@@ -819,7 +819,7 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 						}
 					}
 					if !c.check_types(typ, to_set) {
-						c.error('inferred generic type `$gt_name` is ambiguous: got `${c.table.type_symbol(to_set).name}`, expected `${c.table.type_symbol(typ).name}`',
+						c.error('inferred generic type `$gt_name` is ambiguous: got `${c.table.sym(to_set).name}`, expected `${c.table.sym(typ).name}`',
 							arg.pos)
 					}
 				}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -414,11 +414,11 @@ pub fn (mut c Checker) alias_type_decl(node ast.AliasTypeDecl) {
 		c.check_valid_pascal_case(node.name, 'type alias', node.pos)
 	}
 	c.ensure_type_exists(node.parent_type, node.type_pos) or { return }
-	typ_sym := c.table.get_type_symbol(node.parent_type)
+	typ_sym := c.table.type_symbol(node.parent_type)
 	if typ_sym.kind in [.placeholder, .int_literal, .float_literal] {
 		c.error('unknown type `$typ_sym.name`', node.type_pos)
 	} else if typ_sym.kind == .alias {
-		orig_sym := c.table.get_type_symbol((typ_sym.info as ast.Alias).parent_type)
+		orig_sym := c.table.type_symbol((typ_sym.info as ast.Alias).parent_type)
 		c.error('type `$typ_sym.str()` is an alias, use the original alias type `$orig_sym.name` instead',
 			node.type_pos)
 	} else if typ_sym.kind == .chan {
@@ -428,17 +428,17 @@ pub fn (mut c Checker) alias_type_decl(node ast.AliasTypeDecl) {
 
 pub fn (mut c Checker) fn_type_decl(node ast.FnTypeDecl) {
 	c.check_valid_pascal_case(node.name, 'fn type', node.pos)
-	typ_sym := c.table.get_type_symbol(node.typ)
+	typ_sym := c.table.type_symbol(node.typ)
 	fn_typ_info := typ_sym.info as ast.FnType
 	fn_info := fn_typ_info.func
 	c.ensure_type_exists(fn_info.return_type, fn_info.return_type_pos) or {}
-	ret_sym := c.table.get_type_symbol(fn_info.return_type)
+	ret_sym := c.table.type_symbol(fn_info.return_type)
 	if ret_sym.kind == .placeholder {
 		c.error('unknown type `$ret_sym.name`', fn_info.return_type_pos)
 	}
 	for arg in fn_info.params {
 		c.ensure_type_exists(arg.typ, arg.type_pos) or { return }
-		arg_sym := c.table.get_type_symbol(arg.typ)
+		arg_sym := c.table.type_symbol(arg.typ)
 		if arg_sym.kind == .placeholder {
 			c.error('unknown type `$arg_sym.name`', arg.type_pos)
 		}
@@ -453,7 +453,7 @@ pub fn (mut c Checker) sum_type_decl(node ast.SumTypeDecl) {
 			c.error('sum type cannot hold a reference type', variant.pos)
 		}
 		c.ensure_type_exists(variant.typ, variant.pos) or {}
-		mut sym := c.table.get_type_symbol(variant.typ)
+		mut sym := c.table.type_symbol(variant.typ)
 		if sym.name in names_used {
 			c.error('sum type $node.name cannot hold the type `$sym.name` more than once',
 				variant.pos)
@@ -514,7 +514,7 @@ pub fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 			if embed.typ.has_flag(.generic) {
 				has_generic_types = true
 			}
-			embed_sym := c.table.get_type_symbol(embed.typ)
+			embed_sym := c.table.type_symbol(embed.typ)
 			if embed_sym.kind != .struct_ {
 				c.error('`$embed_sym.name` is not a struct', embed.pos)
 			} else {
@@ -541,7 +541,7 @@ pub fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 			if node.language == .v {
 				c.check_valid_snake_case(field.name, 'field name', field.pos)
 			}
-			sym := c.table.get_type_symbol(field.typ)
+			sym := c.table.type_symbol(field.typ)
 			for j in 0 .. i {
 				if field.name == node.fields[j].name {
 					c.error('field name `$field.name` duplicate', field.pos)
@@ -565,7 +565,7 @@ pub fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 						&& c.type_implements(field_expr_type, field.typ, field.pos) {
 						if !field_expr_type.is_ptr() && !field_expr_type.is_pointer()
 							&& !c.inside_unsafe {
-							field_expr_type_sym := c.table.get_type_symbol(field_expr_type)
+							field_expr_type_sym := c.table.type_symbol(field_expr_type)
 							if field_expr_type_sym.kind != .interface_ {
 								c.mark_as_referenced(mut &node.fields[i].default_expr,
 									true)
@@ -612,14 +612,14 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 			c.error('unexpected short struct syntax', node.pos)
 			return ast.void_type
 		}
-		sym := c.table.get_type_symbol(c.expected_type)
+		sym := c.table.type_symbol(c.expected_type)
 		if sym.kind == .array {
 			node.typ = c.table.value_type(c.expected_type)
 		} else {
 			node.typ = c.expected_type
 		}
 	}
-	struct_sym := c.table.get_type_symbol(node.typ)
+	struct_sym := c.table.type_symbol(node.typ)
 	if struct_sym.info is ast.Struct {
 		if struct_sym.info.generic_types.len > 0 && struct_sym.info.concrete_types.len == 0
 			&& c.table.cur_concrete_types.len == 0 {
@@ -627,7 +627,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 				node.pos)
 		}
 	} else if struct_sym.info is ast.Alias {
-		parent_sym := c.table.get_type_symbol(struct_sym.info.parent_type)
+		parent_sym := c.table.type_symbol(struct_sym.info.parent_type)
 		// e.g. ´x := MyMapAlias{}´, should be a cast to alias type ´x := MyMapAlias(map[...]...)´
 		if parent_sym.kind == .map {
 			alias_str := c.table.type_to_str(node.typ)
@@ -642,7 +642,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 		c.table.unwrap_generic_type(node.typ, c.table.cur_fn.generic_names, c.table.cur_concrete_types)
 	}
 	c.ensure_type_exists(node.typ, node.pos) or {}
-	type_sym := c.table.get_type_symbol(node.typ)
+	type_sym := c.table.type_symbol(node.typ)
 	if !c.inside_unsafe && type_sym.kind == .sum_type {
 		c.note('direct sum type init (`x := SumType{}`) will be removed soon', node.pos)
 	}
@@ -696,7 +696,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 			mut info := ast.Struct{}
 			if type_sym.kind == .alias {
 				info_t := type_sym.info as ast.Alias
-				sym := c.table.get_type_symbol(info_t.parent_type)
+				sym := c.table.type_symbol(info_t.parent_type)
 				if sym.kind == .placeholder { // pending import symbol did not resolve
 					c.error('unknown struct: $type_sym.name', node.pos)
 					return ast.void_type
@@ -752,14 +752,14 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 				mut expr_type := ast.Type(0)
 				mut expected_type := ast.Type(0)
 				inited_fields << field_name
-				field_type_sym := c.table.get_type_symbol(field_info.typ)
+				field_type_sym := c.table.type_symbol(field_info.typ)
 				expected_type = field_info.typ
 				c.expected_type = expected_type
 				expr_type = c.expr(field.expr)
 				if !field_info.typ.has_flag(.optional) {
 					expr_type = c.check_expr_opt_call(field.expr, expr_type)
 				}
-				expr_type_sym := c.table.get_type_symbol(expr_type)
+				expr_type_sym := c.table.type_symbol(expr_type)
 				if field_type_sym.kind == .interface_ {
 					if c.type_implements(expr_type, field_info.typ, field.pos) {
 						if !expr_type.is_ptr() && !expr_type.is_pointer()
@@ -800,7 +800,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 								obj = c.fn_scope.find_var(obj.name) or { obj }
 							}
 							if obj.is_stack_obj && !c.inside_unsafe {
-								sym := c.table.get_type_symbol(obj.typ.set_nr_muls(0))
+								sym := c.table.type_symbol(obj.typ.set_nr_muls(0))
 								if !sym.is_heap() && !c.pref.translated {
 									suggestion := if sym.kind == .struct_ {
 										'declaring `$sym.name` as `[heap]`'
@@ -826,7 +826,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 						node.pos)
 				}
 				// Do not allow empty uninitialized interfaces
-				sym := c.table.get_type_symbol(field.typ)
+				sym := c.table.type_symbol(field.typ)
 				if sym.kind == .interface_ {
 					// TODO: should be an error instead, but first `ui` needs updating.
 					c.note('interface field `${type_sym.name}.$field.name` must be initialized',
@@ -834,7 +834,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 				}
 				// Do not allow empty uninitialized sum types
 				/*
-				sym := c.table.get_type_symbol(field.typ)
+				sym := c.table.type_symbol(field.typ)
 				if sym.kind == .sum_type {
 					c.warn('sum type field `${type_sym.name}.$field.name` must be initialized',
 						node.pos)
@@ -865,8 +865,8 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 			s := c.table.type_to_str(update_type)
 			c.error('expected struct, found `$s`', node.update_expr.position())
 		} else if update_type != node.typ {
-			from_sym := c.table.get_type_symbol(update_type)
-			to_sym := c.table.get_type_symbol(node.typ)
+			from_sym := c.table.type_symbol(update_type)
+			to_sym := c.table.type_symbol(node.typ)
 			from_info := from_sym.info as ast.Struct
 			to_info := to_sym.info as ast.Struct
 			// TODO this check is too strict
@@ -923,10 +923,10 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		&& left_type in [ast.int_literal_type, ast.float_literal_type] {
 		node.left_type = right_type
 	}
-	mut right_sym := c.table.get_type_symbol(right_type)
-	right_final := c.table.get_final_type_symbol(right_type)
-	mut left_sym := c.table.get_type_symbol(left_type)
-	left_final := c.table.get_final_type_symbol(left_type)
+	mut right_sym := c.table.type_symbol(right_type)
+	right_final := c.table.final_type_symbol(right_type)
+	mut left_sym := c.table.type_symbol(left_type)
+	left_final := c.table.final_type_symbol(left_type)
 	left_pos := node.left.position()
 	right_pos := node.right.position()
 	left_right_pos := left_pos.extend(right_pos)
@@ -1002,17 +1002,17 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		.plus, .minus, .mul, .div, .mod, .xor, .amp, .pipe { // binary operators that expect matching types
 			if right_sym.info is ast.Alias && (right_sym.info as ast.Alias).language != .c
 				&& c.mod == c.table.type_to_str(right_type).split('.')[0]
-				&& c.table.get_type_symbol((right_sym.info as ast.Alias).parent_type).is_primitive() {
-				right_sym = c.table.get_type_symbol((right_sym.info as ast.Alias).parent_type)
+				&& c.table.type_symbol((right_sym.info as ast.Alias).parent_type).is_primitive() {
+				right_sym = c.table.type_symbol((right_sym.info as ast.Alias).parent_type)
 			}
 			if left_sym.info is ast.Alias && (left_sym.info as ast.Alias).language != .c
 				&& c.mod == c.table.type_to_str(left_type).split('.')[0]
-				&& c.table.get_type_symbol((left_sym.info as ast.Alias).parent_type).is_primitive() {
-				left_sym = c.table.get_type_symbol((left_sym.info as ast.Alias).parent_type)
+				&& c.table.type_symbol((left_sym.info as ast.Alias).parent_type).is_primitive() {
+				left_sym = c.table.type_symbol((left_sym.info as ast.Alias).parent_type)
 			}
 			// Check if the alias type is not a primitive then allow using operator overloading for aliased `arrays` and `maps`
 			if left_sym.kind == .alias && left_sym.info is ast.Alias
-				&& !(c.table.get_type_symbol((left_sym.info as ast.Alias).parent_type).is_primitive()) {
+				&& !(c.table.type_symbol((left_sym.info as ast.Alias).parent_type).is_primitive()) {
 				if left_sym.has_method(node.op.str()) {
 					if method := left_sym.find_method(node.op.str()) {
 						return_type = method.return_type
@@ -1030,7 +1030,7 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					}
 				}
 			} else if right_sym.kind == .alias && right_sym.info is ast.Alias
-				&& !(c.table.get_type_symbol((right_sym.info as ast.Alias).parent_type).is_primitive()) {
+				&& !(c.table.type_symbol((right_sym.info as ast.Alias).parent_type).is_primitive()) {
 				if right_sym.has_method(node.op.str()) {
 					if method := right_sym.find_method(node.op.str()) {
 						return_type = method.return_type
@@ -1182,7 +1182,7 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				c.check_expr_opt_call(node.right, right_type)
 				node.auto_locked, _ = c.fail_if_immutable(node.left)
 				left_value_type := c.table.value_type(c.unwrap_generic(left_type))
-				left_value_sym := c.table.get_type_symbol(c.unwrap_generic(left_value_type))
+				left_value_sym := c.table.type_symbol(c.unwrap_generic(left_value_type))
 				if left_value_sym.kind == .interface_ {
 					if right_final.kind != .array {
 						// []Animal << Cat
@@ -1221,7 +1221,7 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		}
 		.unsigned_right_shift {
 			modified_left_type := if !left_type.is_int() {
-				c.error('invalid operation: shift on type `${c.table.get_type_symbol(left_type).name}`',
+				c.error('invalid operation: shift on type `${c.table.type_symbol(left_type).name}`',
 					left_pos)
 				ast.void_type_idx
 			} else if left_type.is_int_literal() {
@@ -1278,7 +1278,7 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				}
 			}
 			if typ != ast.Type(0) {
-				typ_sym := c.table.get_type_symbol(typ)
+				typ_sym := c.table.type_symbol(typ)
 				op := node.op.str()
 				if typ_sym.kind == .placeholder {
 					c.error('$op: type `$typ_sym.name` does not exist', right_expr.position())
@@ -1437,7 +1437,7 @@ fn (mut c Checker) fail_if_immutable(expr ast.Expr) (string, token.Position) {
 			}
 		}
 		ast.IndexExpr {
-			left_sym := c.table.get_type_symbol(expr.left_type)
+			left_sym := c.table.type_symbol(expr.left_type)
 			mut elem_type := ast.Type(0)
 			mut kind := ''
 			match left_sym.info {
@@ -1470,7 +1470,7 @@ fn (mut c Checker) fail_if_immutable(expr ast.Expr) (string, token.Position) {
 			}
 			// retrieve ast.Field
 			c.ensure_type_exists(expr.expr_type, expr.pos) or { return '', pos }
-			mut typ_sym := c.table.get_final_type_symbol(c.unwrap_generic(expr.expr_type))
+			mut typ_sym := c.table.final_type_symbol(c.unwrap_generic(expr.expr_type))
 			match typ_sym.kind {
 				.struct_ {
 					mut has_field := true
@@ -1678,8 +1678,8 @@ fn (mut c Checker) type_implements(typ ast.Type, interface_type ast.Type, pos to
 		eprintln('> type_implements typ: $typ.debug() (`${c.table.type_to_str(typ)}`) | inter_typ: $interface_type.debug() (`${c.table.type_to_str(interface_type)}`)')
 	}
 	utyp := c.unwrap_generic(typ)
-	typ_sym := c.table.get_type_symbol(utyp)
-	mut inter_sym := c.table.get_type_symbol(interface_type)
+	typ_sym := c.table.type_symbol(utyp)
+	mut inter_sym := c.table.type_symbol(interface_type)
 
 	// small hack for JS.Any type. Since `any` in regular V is getting deprecated we have our own JS.Any type for JS backend.
 	if typ_sym.name == 'JS.Any' {
@@ -1689,7 +1689,7 @@ fn (mut c Checker) type_implements(typ ast.Type, interface_type ast.Type, pos to
 		mut generic_type := interface_type
 		mut generic_info := inter_sym.info
 		if inter_sym.info.parent_type.has_flag(.generic) {
-			parent_sym := c.table.get_type_symbol(inter_sym.info.parent_type)
+			parent_sym := c.table.type_symbol(inter_sym.info.parent_type)
 			if parent_sym.info is ast.Interface {
 				generic_type = inter_sym.info.parent_type
 				generic_info = parent_sym.info
@@ -1967,7 +1967,7 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 			node.pos)
 	}
 	field_name := node.field_name
-	sym := c.table.get_type_symbol(typ)
+	sym := c.table.type_symbol(typ)
 	if (typ.has_flag(.variadic) || sym.kind == .array_fixed) && field_name == 'len' {
 		node.typ = ast.int_type
 		return ast.int_type
@@ -1988,7 +1988,7 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 		&& sym.language == .v {
 		// x.Foo.y => access the embedded struct
 		for embed in sym.info.embeds {
-			embed_sym := c.table.get_type_symbol(embed)
+			embed_sym := c.table.type_symbol(embed)
 			if embed_sym.embed_name() == field_name {
 				node.typ = embed
 				return embed
@@ -2023,7 +2023,7 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 			}
 		}
 		if typ.has_flag(.generic) && !has_field {
-			gs := c.table.get_type_symbol(c.unwrap_generic(typ))
+			gs := c.table.type_symbol(c.unwrap_generic(typ))
 			if f := c.table.find_field(gs, field_name) {
 				has_field = true
 				field = f
@@ -2044,10 +2044,10 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 	}
 	if has_field {
 		if sym.mod != c.mod && !field.is_pub && sym.language != .c {
-			unwrapped_sym := c.table.get_type_symbol(c.unwrap_generic(typ))
+			unwrapped_sym := c.table.type_symbol(c.unwrap_generic(typ))
 			c.error('field `${unwrapped_sym.name}.$field_name` is not public', node.pos)
 		}
-		field_sym := c.table.get_type_symbol(field.typ)
+		field_sym := c.table.type_symbol(field.typ)
 		if field_sym.kind in [.sum_type, .interface_] {
 			if !prevent_sum_type_unwrapping_once {
 				if scope_field := node.scope.find_struct_field(node.expr.str(), typ, field_name) {
@@ -2060,7 +2060,7 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 	}
 	if sym.kind !in [.struct_, .aggregate, .interface_, .sum_type] {
 		if sym.kind != .placeholder {
-			unwrapped_sym := c.table.get_type_symbol(c.unwrap_generic(typ))
+			unwrapped_sym := c.table.type_symbol(c.unwrap_generic(typ))
 			c.error('`$unwrapped_sym.name` has no property `$node.field_name`', node.pos)
 		}
 	} else {
@@ -2175,14 +2175,14 @@ pub fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 }
 
 fn (mut c Checker) check_array_init_para_type(para string, expr ast.Expr, pos token.Position) {
-	sym := c.table.get_type_symbol(c.expr(expr))
+	sym := c.table.type_symbol(c.expr(expr))
 	if sym.kind !in [.int, .int_literal] {
 		c.error('array $para needs to be an int', pos)
 	}
 }
 
 pub fn (mut c Checker) ensure_sumtype_array_has_default_value(node ast.ArrayInit) {
-	sym := c.table.get_type_symbol(node.elem_type)
+	sym := c.table.type_symbol(node.elem_type)
 	if sym.kind == .sum_type && !node.has_default {
 		c.error('cannot initialize sum type array without default value', node.pos)
 	}
@@ -2209,7 +2209,7 @@ pub fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 		}
 		if node.has_len {
 			if node.has_len && !node.has_default {
-				elem_type_sym := c.table.get_type_symbol(node.elem_type)
+				elem_type_sym := c.table.type_symbol(node.elem_type)
 				if elem_type_sym.kind == .interface_ {
 					c.error('cannot instantiate an array of interfaces without also giving a default `init:` value',
 						node.len_expr.position())
@@ -2233,7 +2233,7 @@ pub fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 		if c.expected_type == ast.void_type && c.expected_or_type != ast.void_type {
 			c.expected_type = c.expected_or_type
 		}
-		mut type_sym := c.table.get_type_symbol(c.expected_type)
+		mut type_sym := c.table.type_symbol(c.expected_type)
 		if type_sym.kind != .array || type_sym.array_info().elem_type == ast.void_type {
 			c.error('array_init: no type specified (maybe: `[]Type{}` instead of `[]`)',
 				node.pos)
@@ -2255,13 +2255,13 @@ pub fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 		mut expecting_interface_array := false
 		if c.expected_type != 0 {
 			expected_value_type = c.table.value_type(c.expected_type)
-			if c.table.get_type_symbol(expected_value_type).kind == .interface_ {
+			if c.table.type_symbol(expected_value_type).kind == .interface_ {
 				// Array of interfaces? (`[dog, cat]`) Save the interface type (`Animal`)
 				expecting_interface_array = true
 			}
 		}
 		// expecting_interface_array := c.expected_type != 0 &&
-		// c.table.get_type_symbol(c.table.value_type(c.expected_type)).kind ==			.interface_
+		// c.table.type_symbol(c.table.value_type(c.expected_type)).kind ==			.interface_
 		//
 		// if expecting_interface_array {
 		// println('ex $c.expected_type')
@@ -2277,7 +2277,7 @@ pub fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 					c.type_implements(typ, elem_type, expr.position())
 				}
 				if !typ.is_ptr() && !typ.is_pointer() && !c.inside_unsafe {
-					typ_sym := c.table.get_type_symbol(typ)
+					typ_sym := c.table.type_symbol(typ)
 					if typ_sym.kind != .interface_ {
 						c.mark_as_referenced(mut &expr, true)
 					}
@@ -2469,7 +2469,7 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 			if !c.pref.is_repl && (c.stmt_level == 1 || (c.stmt_level > 1 && !c.is_last_stmt)) {
 				if node.expr is ast.InfixExpr {
 					if node.expr.op == .left_shift {
-						left_sym := c.table.get_final_type_symbol(node.expr.left_type)
+						left_sym := c.table.final_type_symbol(node.expr.left_type)
 						if left_sym.kind != .array {
 							c.error('unused expression', node.pos)
 						}
@@ -2544,7 +2544,7 @@ fn (mut c Checker) assert_stmt(node ast.AssertStmt) {
 	cur_exp_typ := c.expected_type
 	assert_type := c.check_expr_opt_call(node.expr, c.expr(node.expr))
 	if assert_type != ast.bool_type_idx {
-		atype_name := c.table.get_type_symbol(assert_type).name
+		atype_name := c.table.type_symbol(assert_type).name
 		c.error('assert can be used only with `bool` expressions, but found `$atype_name` instead',
 			node.pos)
 	}
@@ -2593,7 +2593,7 @@ fn (mut c Checker) for_c_stmt(node ast.ForCStmt) {
 
 fn (mut c Checker) comptime_for(node ast.ComptimeFor) {
 	typ := c.unwrap_generic(node.typ)
-	sym := c.table.get_type_symbol(typ)
+	sym := c.table.type_symbol(typ)
 	if sym.kind == .placeholder || typ.has_flag(.generic) {
 		c.error('unknown type `$sym.name`', node.typ_pos)
 	}
@@ -2635,7 +2635,7 @@ fn (mut c Checker) for_in_stmt(mut node ast.ForInStmt) {
 		node.high_type = high_type
 		node.scope.update_var_type(node.val_var, node.val_type)
 	} else {
-		sym := c.table.get_final_type_symbol(typ)
+		sym := c.table.final_type_symbol(typ)
 		if sym.kind == .struct_ {
 			// iterators
 			next_fn := sym.find_method_with_generic_parent('next') or {
@@ -2735,7 +2735,7 @@ fn (mut c Checker) for_stmt(mut node ast.ForStmt) {
 					true
 				}
 				left_type := c.expr(infix.left)
-				left_sym := c.table.get_type_symbol(left_type)
+				left_sym := c.table.type_symbol(left_type)
 				if is_variable {
 					if left_sym.kind in [.sum_type, .interface_] {
 						c.smartcast(infix.left, infix.left_type, infix.right.typ, mut
@@ -2759,7 +2759,7 @@ fn (mut c Checker) global_decl(mut node ast.GlobalDecl) {
 		if field.name in c.global_names {
 			c.error('duplicate global `$field.name`', field.pos)
 		}
-		sym := c.table.get_type_symbol(field.typ)
+		sym := c.table.type_symbol(field.typ)
 		if sym.kind == .placeholder {
 			c.error('unknown type `$sym.name`', field.typ_pos)
 		}
@@ -3138,7 +3138,7 @@ pub fn (mut c Checker) expr(node ast.Expr) ast.Type {
 		}
 		ast.ArrayDecompose {
 			typ := c.expr(node.expr)
-			type_sym := c.table.get_type_symbol(typ)
+			type_sym := c.table.type_symbol(typ)
 			if type_sym.kind != .array {
 				c.error('decomposition can only be used on arrays', node.expr.position())
 				return ast.void_type
@@ -3154,8 +3154,8 @@ pub fn (mut c Checker) expr(node ast.Expr) ast.Type {
 		}
 		ast.AsCast {
 			node.expr_type = c.expr(node.expr)
-			expr_type_sym := c.table.get_type_symbol(node.expr_type)
-			type_sym := c.table.get_type_symbol(node.typ)
+			expr_type_sym := c.table.type_symbol(node.expr_type)
+			type_sym := c.table.type_symbol(node.typ)
 			if expr_type_sym.kind == .sum_type {
 				c.ensure_type_exists(node.typ, node.pos) or {}
 				if !c.table.sumtype_has_variant(node.expr_type, node.typ, true) {
@@ -3225,7 +3225,7 @@ pub fn (mut c Checker) expr(node ast.Expr) ast.Type {
 		ast.ComptimeSelector {
 			node.left_type = c.unwrap_generic(c.expr(node.left))
 			expr_type := c.unwrap_generic(c.expr(node.field_expr))
-			expr_sym := c.table.get_type_symbol(expr_type)
+			expr_sym := c.table.type_symbol(expr_type)
 			if expr_type != ast.string_type {
 				c.error('expected `string` instead of `$expr_sym.name` (e.g. `field.name`)',
 					node.field_expr.position())
@@ -3255,7 +3255,7 @@ pub fn (mut c Checker) expr(node ast.Expr) ast.Type {
 				c.error('dump expression can not be void', node.expr.position())
 				return ast.void_type
 			}
-			tsym := c.table.get_type_symbol(node.expr_type)
+			tsym := c.table.type_symbol(node.expr_type)
 			c.table.dumps[int(node.expr_type)] = tsym.cname
 			node.cname = tsym.cname
 			return node.expr_type
@@ -3403,7 +3403,7 @@ pub fn (mut c Checker) expr(node ast.Expr) ast.Type {
 		ast.Likely {
 			ltype := c.expr(node.expr)
 			if !c.check_types(ltype, ast.bool_type) {
-				ltype_sym := c.table.get_type_symbol(ltype)
+				ltype_sym := c.table.type_symbol(ltype)
 				lname := if node.is_likely { '_likely_' } else { '_unlikely_' }
 				c.error('`${lname}()` expects a boolean expression, instead it got `$ltype_sym.name`',
 					node.pos)
@@ -3439,10 +3439,10 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 	mut from_type := node.expr_type
 	to_type := node.typ
 	//
-	from_type_sym := c.table.get_type_symbol(from_type)
-	from_type_sym_final := c.table.get_final_type_symbol(from_type)
-	to_type_sym := c.table.get_type_symbol(to_type) // type to be used as cast
-	to_type_sym_final := c.table.get_final_type_symbol(to_type)
+	from_type_sym := c.table.type_symbol(from_type)
+	from_type_sym_final := c.table.final_type_symbol(from_type)
+	to_type_sym := c.table.type_symbol(to_type) // type to be used as cast
+	to_type_sym_final := c.table.final_type_symbol(to_type)
 	//
 	if (to_type_sym.is_number() && from_type_sym.name == 'JS.Number')
 		|| (to_type_sym.is_number() && from_type_sym.name == 'JS.BigInt')
@@ -3624,7 +3624,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		}
 	}
 
-	node.typname = c.table.get_type_symbol(to_type).name
+	node.typname = c.table.type_symbol(to_type).name
 
 	return to_type
 }
@@ -3784,7 +3784,7 @@ pub fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 							node.pos)
 					}
 					// if typ == ast.t_type {
-					// sym := c.table.get_type_symbol(c.cur_generic_type)
+					// sym := c.table.type_symbol(c.cur_generic_type)
 					// println('IDENT T unresolved $node.name typ=$sym.name')
 					// Got a var with type T, return current generic type
 					// typ = c.cur_generic_type
@@ -3917,13 +3917,13 @@ pub fn (mut c Checker) concat_expr(mut node ast.ConcatExpr) ast.Type {
 
 // smartcast takes the expression with the current type which should be smartcasted to the target type in the given scope
 fn (c Checker) smartcast(expr ast.Expr, cur_type ast.Type, to_type_ ast.Type, mut scope ast.Scope) {
-	sym := c.table.get_type_symbol(cur_type)
+	sym := c.table.type_symbol(cur_type)
 	to_type := if sym.kind == .interface_ { to_type_.ref() } else { to_type_ }
 	match expr {
 		ast.SelectorExpr {
 			mut is_mut := false
 			mut smartcasts := []ast.Type{}
-			expr_sym := c.table.get_type_symbol(expr.expr_type)
+			expr_sym := c.table.type_symbol(expr.expr_type)
 			mut orig_type := 0
 			if field := c.table.find_field(expr_sym, expr.field_name) {
 				if field.is_mut {
@@ -3993,7 +3993,7 @@ pub fn (mut c Checker) select_expr(mut node ast.SelectExpr) ast.Type {
 			ast.ExprStmt {
 				if branch.is_timeout {
 					if !branch.stmt.typ.is_int() {
-						tsym := c.table.get_type_symbol(branch.stmt.typ)
+						tsym := c.table.type_symbol(branch.stmt.typ)
 						c.error('invalid type `$tsym.name` for timeout - expected integer number of nanoseconds aka `time.Duration`',
 							branch.stmt.pos)
 					}
@@ -4145,7 +4145,7 @@ fn (c &Checker) has_return(stmts []ast.Stmt) ?bool {
 
 pub fn (mut c Checker) postfix_expr(mut node ast.PostfixExpr) ast.Type {
 	typ := c.unwrap_generic(c.expr(node.expr))
-	typ_sym := c.table.get_type_symbol(typ)
+	typ_sym := c.table.type_symbol(typ)
 	is_non_void_pointer := (typ.is_ptr() || typ.is_pointer()) && typ_sym.kind != .voidptr
 	if !c.inside_unsafe && is_non_void_pointer && !node.expr.is_auto_deref_var() {
 		c.warn('pointer arithmetic is only allowed in `unsafe` blocks', node.pos)
@@ -4167,7 +4167,7 @@ pub fn (mut c Checker) mark_as_referenced(mut node ast.Expr, as_interface bool) 
 				if c.fn_scope != voidptr(0) {
 					obj = c.fn_scope.find_var(node.obj.name) or { obj }
 				}
-				type_sym := c.table.get_type_symbol(obj.typ.set_nr_muls(0))
+				type_sym := c.table.type_symbol(obj.typ.set_nr_muls(0))
 				if obj.is_stack_obj && !type_sym.is_heap() && !c.pref.translated {
 					suggestion := if type_sym.kind == .struct_ {
 						'declaring `$type_sym.name` as `[heap]`'
@@ -4258,7 +4258,7 @@ pub fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 			else {}
 		}
 		if mut node.right is ast.IndexExpr {
-			typ_sym := c.table.get_type_symbol(node.right.left_type)
+			typ_sym := c.table.type_symbol(node.right.left_type)
 			mut is_mut := false
 			if mut node.right.left is ast.Ident {
 				ident := node.right.left
@@ -4310,7 +4310,7 @@ pub fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 	// FIXME
 	// there are currently other issues to investigate if right_type
 	// is unwraped directly as initialization, so do it here
-	right_sym := c.table.get_final_type_symbol(c.unwrap_generic(right_type))
+	right_sym := c.table.final_type_symbol(c.unwrap_generic(right_type))
 	if node.op == .minus && !right_sym.is_number() {
 		c.error('- operator can only be used with numeric types', node.pos)
 	}
@@ -4325,7 +4325,7 @@ pub fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 }
 
 fn (mut c Checker) check_index(typ_sym &ast.TypeSymbol, index ast.Expr, index_type ast.Type, pos token.Position, range_index bool) {
-	index_type_sym := c.table.get_type_symbol(index_type)
+	index_type_sym := c.table.type_symbol(index_type)
 	// println('index expr left=$typ_sym.name $node.pos.line_nr')
 	// if typ_sym.kind == .array && (!(ast.type_idx(index_type) in ast.number_type_idxs) &&
 	// index_type_sym.kind != .enum_) {
@@ -4362,7 +4362,7 @@ fn (mut c Checker) check_index(typ_sym &ast.TypeSymbol, index ast.Expr, index_ty
 
 pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) ast.Type {
 	mut typ := c.expr(node.left)
-	mut typ_sym := c.table.get_final_type_symbol(typ)
+	mut typ_sym := c.table.final_type_symbol(typ)
 	node.left_type = typ
 	for {
 		match typ_sym.kind {
@@ -4382,7 +4382,7 @@ pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) ast.Type {
 				gname := typ_sym.name
 				typ = c.unwrap_generic(typ)
 				node.left_type = typ
-				typ_sym = c.table.get_final_type_symbol(typ)
+				typ_sym = c.table.final_type_symbol(typ)
 				if typ.is_ptr() {
 					continue
 				} else {
@@ -4445,7 +4445,7 @@ pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) ast.Type {
 				err := c.expected_msg(index_type, info.key_type)
 				c.error('invalid key: $err', node.pos)
 			}
-			value_sym := c.table.get_type_symbol(info.value_type)
+			value_sym := c.table.type_symbol(info.value_type)
 			if !node.is_setter && value_sym.kind == .sum_type && node.or_expr.kind == .absent
 				&& !c.inside_unsafe && !c.inside_if_guard {
 				c.warn('`or {}` block required when indexing a map with sum type value',
@@ -4496,11 +4496,11 @@ pub fn (mut c Checker) enum_val(mut node ast.EnumVal) ast.Type {
 		c.error('not an enum', node.pos)
 		return ast.void_type
 	}
-	mut typ_sym := c.table.get_type_symbol(typ)
+	mut typ_sym := c.table.type_symbol(typ)
 	if typ_sym.kind == .array && node.enum_name.len == 0 {
 		array_info := typ_sym.info as ast.Array
 		typ = array_info.elem_type
-		typ_sym = c.table.get_type_symbol(typ)
+		typ_sym = c.table.type_symbol(typ)
 	}
 	if typ_sym.kind != .enum_ && !c.pref.translated {
 		// TODO in C int fields can be compared to enums, need to handle that in C2V
@@ -4526,7 +4526,7 @@ pub fn (mut c Checker) enum_val(mut node ast.EnumVal) ast.Type {
 
 pub fn (mut c Checker) chan_init(mut node ast.ChanInit) ast.Type {
 	if node.typ != 0 {
-		info := c.table.get_type_symbol(node.typ).chan_info()
+		info := c.table.type_symbol(node.typ).chan_info()
 		node.elem_type = info.elem_type
 		if node.has_cap {
 			c.check_array_init_para_type('cap', node.cap_expr, node.pos)
@@ -4539,7 +4539,7 @@ pub fn (mut c Checker) chan_init(mut node ast.ChanInit) ast.Type {
 }
 
 pub fn (mut c Checker) offset_of(node ast.OffsetOf) ast.Type {
-	sym := c.table.get_final_type_symbol(node.struct_type)
+	sym := c.table.final_type_symbol(node.struct_type)
 	if sym.kind != .struct_ {
 		c.error('first argument of __offsetof must be struct', node.pos)
 		return ast.u32_type
@@ -4576,7 +4576,7 @@ pub fn (mut c Checker) check_dup_keys(node &ast.MapInit, i int) {
 pub fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 	// `map = {}`
 	if node.keys.len == 0 && node.vals.len == 0 && node.typ == 0 {
-		sym := c.table.get_type_symbol(c.expected_type)
+		sym := c.table.type_symbol(c.expected_type)
 		if sym.kind == .map {
 			info := sym.map_info()
 			node.typ = c.expected_type
@@ -4596,7 +4596,7 @@ pub fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 	}
 	// `x := map[string]string` - set in parser
 	if node.typ != 0 {
-		info := c.table.get_type_symbol(node.typ).map_info()
+		info := c.table.type_symbol(node.typ).map_info()
 		c.ensure_type_exists(info.key_type, node.pos) or {}
 		c.ensure_type_exists(info.value_type, node.pos) or {}
 		node.key_type = info.key_type
@@ -4607,9 +4607,9 @@ pub fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 		mut key0_type := ast.void_type
 		mut val0_type := ast.void_type
 		use_expected_type := c.expected_type != ast.void_type && !c.inside_const
-			&& c.table.get_type_symbol(c.expected_type).kind == .map
+			&& c.table.type_symbol(c.expected_type).kind == .map
 		if use_expected_type {
-			sym := c.table.get_type_symbol(c.expected_type)
+			sym := c.table.type_symbol(c.expected_type)
 			info := sym.map_info()
 			key0_type = c.unwrap_generic(info.key_type)
 			val0_type = c.unwrap_generic(info.value_type)
@@ -4807,7 +4807,7 @@ fn (mut c Checker) fetch_field_name(field ast.StructField) string {
 			break
 		}
 	}
-	sym := c.table.get_type_symbol(field.typ)
+	sym := c.table.type_symbol(field.typ)
 	if sym.kind == .struct_ && sym.name != 'time.Time' {
 		name = '${name}_id'
 	}
@@ -4846,7 +4846,7 @@ fn (mut c Checker) ensure_type_exists(typ ast.Type, pos token.Position) ? {
 		c.error('unknown type', pos)
 		return
 	}
-	sym := c.table.get_type_symbol(typ)
+	sym := c.table.type_symbol(typ)
 	match sym.kind {
 		.placeholder {
 			if sym.language == .v && !sym.name.starts_with('C.') {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -414,11 +414,11 @@ pub fn (mut c Checker) alias_type_decl(node ast.AliasTypeDecl) {
 		c.check_valid_pascal_case(node.name, 'type alias', node.pos)
 	}
 	c.ensure_type_exists(node.parent_type, node.type_pos) or { return }
-	typ_sym := c.table.type_symbol(node.parent_type)
+	typ_sym := c.table.sym(node.parent_type)
 	if typ_sym.kind in [.placeholder, .int_literal, .float_literal] {
 		c.error('unknown type `$typ_sym.name`', node.type_pos)
 	} else if typ_sym.kind == .alias {
-		orig_sym := c.table.type_symbol((typ_sym.info as ast.Alias).parent_type)
+		orig_sym := c.table.sym((typ_sym.info as ast.Alias).parent_type)
 		c.error('type `$typ_sym.str()` is an alias, use the original alias type `$orig_sym.name` instead',
 			node.type_pos)
 	} else if typ_sym.kind == .chan {
@@ -428,17 +428,17 @@ pub fn (mut c Checker) alias_type_decl(node ast.AliasTypeDecl) {
 
 pub fn (mut c Checker) fn_type_decl(node ast.FnTypeDecl) {
 	c.check_valid_pascal_case(node.name, 'fn type', node.pos)
-	typ_sym := c.table.type_symbol(node.typ)
+	typ_sym := c.table.sym(node.typ)
 	fn_typ_info := typ_sym.info as ast.FnType
 	fn_info := fn_typ_info.func
 	c.ensure_type_exists(fn_info.return_type, fn_info.return_type_pos) or {}
-	ret_sym := c.table.type_symbol(fn_info.return_type)
+	ret_sym := c.table.sym(fn_info.return_type)
 	if ret_sym.kind == .placeholder {
 		c.error('unknown type `$ret_sym.name`', fn_info.return_type_pos)
 	}
 	for arg in fn_info.params {
 		c.ensure_type_exists(arg.typ, arg.type_pos) or { return }
-		arg_sym := c.table.type_symbol(arg.typ)
+		arg_sym := c.table.sym(arg.typ)
 		if arg_sym.kind == .placeholder {
 			c.error('unknown type `$arg_sym.name`', arg.type_pos)
 		}
@@ -453,7 +453,7 @@ pub fn (mut c Checker) sum_type_decl(node ast.SumTypeDecl) {
 			c.error('sum type cannot hold a reference type', variant.pos)
 		}
 		c.ensure_type_exists(variant.typ, variant.pos) or {}
-		mut sym := c.table.type_symbol(variant.typ)
+		mut sym := c.table.sym(variant.typ)
 		if sym.name in names_used {
 			c.error('sum type $node.name cannot hold the type `$sym.name` more than once',
 				variant.pos)
@@ -514,7 +514,7 @@ pub fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 			if embed.typ.has_flag(.generic) {
 				has_generic_types = true
 			}
-			embed_sym := c.table.type_symbol(embed.typ)
+			embed_sym := c.table.sym(embed.typ)
 			if embed_sym.kind != .struct_ {
 				c.error('`$embed_sym.name` is not a struct', embed.pos)
 			} else {
@@ -541,7 +541,7 @@ pub fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 			if node.language == .v {
 				c.check_valid_snake_case(field.name, 'field name', field.pos)
 			}
-			sym := c.table.type_symbol(field.typ)
+			sym := c.table.sym(field.typ)
 			for j in 0 .. i {
 				if field.name == node.fields[j].name {
 					c.error('field name `$field.name` duplicate', field.pos)
@@ -565,7 +565,7 @@ pub fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 						&& c.type_implements(field_expr_type, field.typ, field.pos) {
 						if !field_expr_type.is_ptr() && !field_expr_type.is_pointer()
 							&& !c.inside_unsafe {
-							field_expr_type_sym := c.table.type_symbol(field_expr_type)
+							field_expr_type_sym := c.table.sym(field_expr_type)
 							if field_expr_type_sym.kind != .interface_ {
 								c.mark_as_referenced(mut &node.fields[i].default_expr,
 									true)
@@ -612,14 +612,14 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 			c.error('unexpected short struct syntax', node.pos)
 			return ast.void_type
 		}
-		sym := c.table.type_symbol(c.expected_type)
+		sym := c.table.sym(c.expected_type)
 		if sym.kind == .array {
 			node.typ = c.table.value_type(c.expected_type)
 		} else {
 			node.typ = c.expected_type
 		}
 	}
-	struct_sym := c.table.type_symbol(node.typ)
+	struct_sym := c.table.sym(node.typ)
 	if struct_sym.info is ast.Struct {
 		if struct_sym.info.generic_types.len > 0 && struct_sym.info.concrete_types.len == 0
 			&& c.table.cur_concrete_types.len == 0 {
@@ -627,7 +627,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 				node.pos)
 		}
 	} else if struct_sym.info is ast.Alias {
-		parent_sym := c.table.type_symbol(struct_sym.info.parent_type)
+		parent_sym := c.table.sym(struct_sym.info.parent_type)
 		// e.g. ´x := MyMapAlias{}´, should be a cast to alias type ´x := MyMapAlias(map[...]...)´
 		if parent_sym.kind == .map {
 			alias_str := c.table.type_to_str(node.typ)
@@ -642,7 +642,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 		c.table.unwrap_generic_type(node.typ, c.table.cur_fn.generic_names, c.table.cur_concrete_types)
 	}
 	c.ensure_type_exists(node.typ, node.pos) or {}
-	type_sym := c.table.type_symbol(node.typ)
+	type_sym := c.table.sym(node.typ)
 	if !c.inside_unsafe && type_sym.kind == .sum_type {
 		c.note('direct sum type init (`x := SumType{}`) will be removed soon', node.pos)
 	}
@@ -696,7 +696,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 			mut info := ast.Struct{}
 			if type_sym.kind == .alias {
 				info_t := type_sym.info as ast.Alias
-				sym := c.table.type_symbol(info_t.parent_type)
+				sym := c.table.sym(info_t.parent_type)
 				if sym.kind == .placeholder { // pending import symbol did not resolve
 					c.error('unknown struct: $type_sym.name', node.pos)
 					return ast.void_type
@@ -752,14 +752,14 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 				mut expr_type := ast.Type(0)
 				mut expected_type := ast.Type(0)
 				inited_fields << field_name
-				field_type_sym := c.table.type_symbol(field_info.typ)
+				field_type_sym := c.table.sym(field_info.typ)
 				expected_type = field_info.typ
 				c.expected_type = expected_type
 				expr_type = c.expr(field.expr)
 				if !field_info.typ.has_flag(.optional) {
 					expr_type = c.check_expr_opt_call(field.expr, expr_type)
 				}
-				expr_type_sym := c.table.type_symbol(expr_type)
+				expr_type_sym := c.table.sym(expr_type)
 				if field_type_sym.kind == .interface_ {
 					if c.type_implements(expr_type, field_info.typ, field.pos) {
 						if !expr_type.is_ptr() && !expr_type.is_pointer()
@@ -800,7 +800,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 								obj = c.fn_scope.find_var(obj.name) or { obj }
 							}
 							if obj.is_stack_obj && !c.inside_unsafe {
-								sym := c.table.type_symbol(obj.typ.set_nr_muls(0))
+								sym := c.table.sym(obj.typ.set_nr_muls(0))
 								if !sym.is_heap() && !c.pref.translated {
 									suggestion := if sym.kind == .struct_ {
 										'declaring `$sym.name` as `[heap]`'
@@ -826,7 +826,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 						node.pos)
 				}
 				// Do not allow empty uninitialized interfaces
-				sym := c.table.type_symbol(field.typ)
+				sym := c.table.sym(field.typ)
 				if sym.kind == .interface_ {
 					// TODO: should be an error instead, but first `ui` needs updating.
 					c.note('interface field `${type_sym.name}.$field.name` must be initialized',
@@ -834,7 +834,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 				}
 				// Do not allow empty uninitialized sum types
 				/*
-				sym := c.table.type_symbol(field.typ)
+				sym := c.table.sym(field.typ)
 				if sym.kind == .sum_type {
 					c.warn('sum type field `${type_sym.name}.$field.name` must be initialized',
 						node.pos)
@@ -865,8 +865,8 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 			s := c.table.type_to_str(update_type)
 			c.error('expected struct, found `$s`', node.update_expr.position())
 		} else if update_type != node.typ {
-			from_sym := c.table.type_symbol(update_type)
-			to_sym := c.table.type_symbol(node.typ)
+			from_sym := c.table.sym(update_type)
+			to_sym := c.table.sym(node.typ)
 			from_info := from_sym.info as ast.Struct
 			to_info := to_sym.info as ast.Struct
 			// TODO this check is too strict
@@ -923,10 +923,10 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		&& left_type in [ast.int_literal_type, ast.float_literal_type] {
 		node.left_type = right_type
 	}
-	mut right_sym := c.table.type_symbol(right_type)
-	right_final := c.table.final_type_symbol(right_type)
-	mut left_sym := c.table.type_symbol(left_type)
-	left_final := c.table.final_type_symbol(left_type)
+	mut right_sym := c.table.sym(right_type)
+	right_final := c.table.final_sym(right_type)
+	mut left_sym := c.table.sym(left_type)
+	left_final := c.table.final_sym(left_type)
 	left_pos := node.left.position()
 	right_pos := node.right.position()
 	left_right_pos := left_pos.extend(right_pos)
@@ -1002,17 +1002,17 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		.plus, .minus, .mul, .div, .mod, .xor, .amp, .pipe { // binary operators that expect matching types
 			if right_sym.info is ast.Alias && (right_sym.info as ast.Alias).language != .c
 				&& c.mod == c.table.type_to_str(right_type).split('.')[0]
-				&& c.table.type_symbol((right_sym.info as ast.Alias).parent_type).is_primitive() {
-				right_sym = c.table.type_symbol((right_sym.info as ast.Alias).parent_type)
+				&& c.table.sym((right_sym.info as ast.Alias).parent_type).is_primitive() {
+				right_sym = c.table.sym((right_sym.info as ast.Alias).parent_type)
 			}
 			if left_sym.info is ast.Alias && (left_sym.info as ast.Alias).language != .c
 				&& c.mod == c.table.type_to_str(left_type).split('.')[0]
-				&& c.table.type_symbol((left_sym.info as ast.Alias).parent_type).is_primitive() {
-				left_sym = c.table.type_symbol((left_sym.info as ast.Alias).parent_type)
+				&& c.table.sym((left_sym.info as ast.Alias).parent_type).is_primitive() {
+				left_sym = c.table.sym((left_sym.info as ast.Alias).parent_type)
 			}
 			// Check if the alias type is not a primitive then allow using operator overloading for aliased `arrays` and `maps`
 			if left_sym.kind == .alias && left_sym.info is ast.Alias
-				&& !(c.table.type_symbol((left_sym.info as ast.Alias).parent_type).is_primitive()) {
+				&& !(c.table.sym((left_sym.info as ast.Alias).parent_type).is_primitive()) {
 				if left_sym.has_method(node.op.str()) {
 					if method := left_sym.find_method(node.op.str()) {
 						return_type = method.return_type
@@ -1030,7 +1030,7 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					}
 				}
 			} else if right_sym.kind == .alias && right_sym.info is ast.Alias
-				&& !(c.table.type_symbol((right_sym.info as ast.Alias).parent_type).is_primitive()) {
+				&& !(c.table.sym((right_sym.info as ast.Alias).parent_type).is_primitive()) {
 				if right_sym.has_method(node.op.str()) {
 					if method := right_sym.find_method(node.op.str()) {
 						return_type = method.return_type
@@ -1182,7 +1182,7 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				c.check_expr_opt_call(node.right, right_type)
 				node.auto_locked, _ = c.fail_if_immutable(node.left)
 				left_value_type := c.table.value_type(c.unwrap_generic(left_type))
-				left_value_sym := c.table.type_symbol(c.unwrap_generic(left_value_type))
+				left_value_sym := c.table.sym(c.unwrap_generic(left_value_type))
 				if left_value_sym.kind == .interface_ {
 					if right_final.kind != .array {
 						// []Animal << Cat
@@ -1221,7 +1221,7 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		}
 		.unsigned_right_shift {
 			modified_left_type := if !left_type.is_int() {
-				c.error('invalid operation: shift on type `${c.table.type_symbol(left_type).name}`',
+				c.error('invalid operation: shift on type `${c.table.sym(left_type).name}`',
 					left_pos)
 				ast.void_type_idx
 			} else if left_type.is_int_literal() {
@@ -1278,7 +1278,7 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				}
 			}
 			if typ != ast.Type(0) {
-				typ_sym := c.table.type_symbol(typ)
+				typ_sym := c.table.sym(typ)
 				op := node.op.str()
 				if typ_sym.kind == .placeholder {
 					c.error('$op: type `$typ_sym.name` does not exist', right_expr.position())
@@ -1437,7 +1437,7 @@ fn (mut c Checker) fail_if_immutable(expr ast.Expr) (string, token.Position) {
 			}
 		}
 		ast.IndexExpr {
-			left_sym := c.table.type_symbol(expr.left_type)
+			left_sym := c.table.sym(expr.left_type)
 			mut elem_type := ast.Type(0)
 			mut kind := ''
 			match left_sym.info {
@@ -1470,7 +1470,7 @@ fn (mut c Checker) fail_if_immutable(expr ast.Expr) (string, token.Position) {
 			}
 			// retrieve ast.Field
 			c.ensure_type_exists(expr.expr_type, expr.pos) or { return '', pos }
-			mut typ_sym := c.table.final_type_symbol(c.unwrap_generic(expr.expr_type))
+			mut typ_sym := c.table.final_sym(c.unwrap_generic(expr.expr_type))
 			match typ_sym.kind {
 				.struct_ {
 					mut has_field := true
@@ -1678,8 +1678,8 @@ fn (mut c Checker) type_implements(typ ast.Type, interface_type ast.Type, pos to
 		eprintln('> type_implements typ: $typ.debug() (`${c.table.type_to_str(typ)}`) | inter_typ: $interface_type.debug() (`${c.table.type_to_str(interface_type)}`)')
 	}
 	utyp := c.unwrap_generic(typ)
-	typ_sym := c.table.type_symbol(utyp)
-	mut inter_sym := c.table.type_symbol(interface_type)
+	typ_sym := c.table.sym(utyp)
+	mut inter_sym := c.table.sym(interface_type)
 
 	// small hack for JS.Any type. Since `any` in regular V is getting deprecated we have our own JS.Any type for JS backend.
 	if typ_sym.name == 'JS.Any' {
@@ -1689,7 +1689,7 @@ fn (mut c Checker) type_implements(typ ast.Type, interface_type ast.Type, pos to
 		mut generic_type := interface_type
 		mut generic_info := inter_sym.info
 		if inter_sym.info.parent_type.has_flag(.generic) {
-			parent_sym := c.table.type_symbol(inter_sym.info.parent_type)
+			parent_sym := c.table.sym(inter_sym.info.parent_type)
 			if parent_sym.info is ast.Interface {
 				generic_type = inter_sym.info.parent_type
 				generic_info = parent_sym.info
@@ -1967,7 +1967,7 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 			node.pos)
 	}
 	field_name := node.field_name
-	sym := c.table.type_symbol(typ)
+	sym := c.table.sym(typ)
 	if (typ.has_flag(.variadic) || sym.kind == .array_fixed) && field_name == 'len' {
 		node.typ = ast.int_type
 		return ast.int_type
@@ -1988,7 +1988,7 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 		&& sym.language == .v {
 		// x.Foo.y => access the embedded struct
 		for embed in sym.info.embeds {
-			embed_sym := c.table.type_symbol(embed)
+			embed_sym := c.table.sym(embed)
 			if embed_sym.embed_name() == field_name {
 				node.typ = embed
 				return embed
@@ -2023,7 +2023,7 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 			}
 		}
 		if typ.has_flag(.generic) && !has_field {
-			gs := c.table.type_symbol(c.unwrap_generic(typ))
+			gs := c.table.sym(c.unwrap_generic(typ))
 			if f := c.table.find_field(gs, field_name) {
 				has_field = true
 				field = f
@@ -2044,10 +2044,10 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 	}
 	if has_field {
 		if sym.mod != c.mod && !field.is_pub && sym.language != .c {
-			unwrapped_sym := c.table.type_symbol(c.unwrap_generic(typ))
+			unwrapped_sym := c.table.sym(c.unwrap_generic(typ))
 			c.error('field `${unwrapped_sym.name}.$field_name` is not public', node.pos)
 		}
-		field_sym := c.table.type_symbol(field.typ)
+		field_sym := c.table.sym(field.typ)
 		if field_sym.kind in [.sum_type, .interface_] {
 			if !prevent_sum_type_unwrapping_once {
 				if scope_field := node.scope.find_struct_field(node.expr.str(), typ, field_name) {
@@ -2060,7 +2060,7 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 	}
 	if sym.kind !in [.struct_, .aggregate, .interface_, .sum_type] {
 		if sym.kind != .placeholder {
-			unwrapped_sym := c.table.type_symbol(c.unwrap_generic(typ))
+			unwrapped_sym := c.table.sym(c.unwrap_generic(typ))
 			c.error('`$unwrapped_sym.name` has no property `$node.field_name`', node.pos)
 		}
 	} else {
@@ -2175,14 +2175,14 @@ pub fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 }
 
 fn (mut c Checker) check_array_init_para_type(para string, expr ast.Expr, pos token.Position) {
-	sym := c.table.type_symbol(c.expr(expr))
+	sym := c.table.sym(c.expr(expr))
 	if sym.kind !in [.int, .int_literal] {
 		c.error('array $para needs to be an int', pos)
 	}
 }
 
 pub fn (mut c Checker) ensure_sumtype_array_has_default_value(node ast.ArrayInit) {
-	sym := c.table.type_symbol(node.elem_type)
+	sym := c.table.sym(node.elem_type)
 	if sym.kind == .sum_type && !node.has_default {
 		c.error('cannot initialize sum type array without default value', node.pos)
 	}
@@ -2209,7 +2209,7 @@ pub fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 		}
 		if node.has_len {
 			if node.has_len && !node.has_default {
-				elem_type_sym := c.table.type_symbol(node.elem_type)
+				elem_type_sym := c.table.sym(node.elem_type)
 				if elem_type_sym.kind == .interface_ {
 					c.error('cannot instantiate an array of interfaces without also giving a default `init:` value',
 						node.len_expr.position())
@@ -2233,7 +2233,7 @@ pub fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 		if c.expected_type == ast.void_type && c.expected_or_type != ast.void_type {
 			c.expected_type = c.expected_or_type
 		}
-		mut type_sym := c.table.type_symbol(c.expected_type)
+		mut type_sym := c.table.sym(c.expected_type)
 		if type_sym.kind != .array || type_sym.array_info().elem_type == ast.void_type {
 			c.error('array_init: no type specified (maybe: `[]Type{}` instead of `[]`)',
 				node.pos)
@@ -2255,13 +2255,13 @@ pub fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 		mut expecting_interface_array := false
 		if c.expected_type != 0 {
 			expected_value_type = c.table.value_type(c.expected_type)
-			if c.table.type_symbol(expected_value_type).kind == .interface_ {
+			if c.table.sym(expected_value_type).kind == .interface_ {
 				// Array of interfaces? (`[dog, cat]`) Save the interface type (`Animal`)
 				expecting_interface_array = true
 			}
 		}
 		// expecting_interface_array := c.expected_type != 0 &&
-		// c.table.type_symbol(c.table.value_type(c.expected_type)).kind ==			.interface_
+		// c.table.sym(c.table.value_type(c.expected_type)).kind ==			.interface_
 		//
 		// if expecting_interface_array {
 		// println('ex $c.expected_type')
@@ -2277,7 +2277,7 @@ pub fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 					c.type_implements(typ, elem_type, expr.position())
 				}
 				if !typ.is_ptr() && !typ.is_pointer() && !c.inside_unsafe {
-					typ_sym := c.table.type_symbol(typ)
+					typ_sym := c.table.sym(typ)
 					if typ_sym.kind != .interface_ {
 						c.mark_as_referenced(mut &expr, true)
 					}
@@ -2469,7 +2469,7 @@ fn (mut c Checker) stmt(node ast.Stmt) {
 			if !c.pref.is_repl && (c.stmt_level == 1 || (c.stmt_level > 1 && !c.is_last_stmt)) {
 				if node.expr is ast.InfixExpr {
 					if node.expr.op == .left_shift {
-						left_sym := c.table.final_type_symbol(node.expr.left_type)
+						left_sym := c.table.final_sym(node.expr.left_type)
 						if left_sym.kind != .array {
 							c.error('unused expression', node.pos)
 						}
@@ -2544,7 +2544,7 @@ fn (mut c Checker) assert_stmt(node ast.AssertStmt) {
 	cur_exp_typ := c.expected_type
 	assert_type := c.check_expr_opt_call(node.expr, c.expr(node.expr))
 	if assert_type != ast.bool_type_idx {
-		atype_name := c.table.type_symbol(assert_type).name
+		atype_name := c.table.sym(assert_type).name
 		c.error('assert can be used only with `bool` expressions, but found `$atype_name` instead',
 			node.pos)
 	}
@@ -2593,7 +2593,7 @@ fn (mut c Checker) for_c_stmt(node ast.ForCStmt) {
 
 fn (mut c Checker) comptime_for(node ast.ComptimeFor) {
 	typ := c.unwrap_generic(node.typ)
-	sym := c.table.type_symbol(typ)
+	sym := c.table.sym(typ)
 	if sym.kind == .placeholder || typ.has_flag(.generic) {
 		c.error('unknown type `$sym.name`', node.typ_pos)
 	}
@@ -2635,7 +2635,7 @@ fn (mut c Checker) for_in_stmt(mut node ast.ForInStmt) {
 		node.high_type = high_type
 		node.scope.update_var_type(node.val_var, node.val_type)
 	} else {
-		sym := c.table.final_type_symbol(typ)
+		sym := c.table.final_sym(typ)
 		if sym.kind == .struct_ {
 			// iterators
 			next_fn := sym.find_method_with_generic_parent('next') or {
@@ -2735,7 +2735,7 @@ fn (mut c Checker) for_stmt(mut node ast.ForStmt) {
 					true
 				}
 				left_type := c.expr(infix.left)
-				left_sym := c.table.type_symbol(left_type)
+				left_sym := c.table.sym(left_type)
 				if is_variable {
 					if left_sym.kind in [.sum_type, .interface_] {
 						c.smartcast(infix.left, infix.left_type, infix.right.typ, mut
@@ -2759,7 +2759,7 @@ fn (mut c Checker) global_decl(mut node ast.GlobalDecl) {
 		if field.name in c.global_names {
 			c.error('duplicate global `$field.name`', field.pos)
 		}
-		sym := c.table.type_symbol(field.typ)
+		sym := c.table.sym(field.typ)
 		if sym.kind == .placeholder {
 			c.error('unknown type `$sym.name`', field.typ_pos)
 		}
@@ -3138,7 +3138,7 @@ pub fn (mut c Checker) expr(node ast.Expr) ast.Type {
 		}
 		ast.ArrayDecompose {
 			typ := c.expr(node.expr)
-			type_sym := c.table.type_symbol(typ)
+			type_sym := c.table.sym(typ)
 			if type_sym.kind != .array {
 				c.error('decomposition can only be used on arrays', node.expr.position())
 				return ast.void_type
@@ -3154,8 +3154,8 @@ pub fn (mut c Checker) expr(node ast.Expr) ast.Type {
 		}
 		ast.AsCast {
 			node.expr_type = c.expr(node.expr)
-			expr_type_sym := c.table.type_symbol(node.expr_type)
-			type_sym := c.table.type_symbol(node.typ)
+			expr_type_sym := c.table.sym(node.expr_type)
+			type_sym := c.table.sym(node.typ)
 			if expr_type_sym.kind == .sum_type {
 				c.ensure_type_exists(node.typ, node.pos) or {}
 				if !c.table.sumtype_has_variant(node.expr_type, node.typ, true) {
@@ -3225,7 +3225,7 @@ pub fn (mut c Checker) expr(node ast.Expr) ast.Type {
 		ast.ComptimeSelector {
 			node.left_type = c.unwrap_generic(c.expr(node.left))
 			expr_type := c.unwrap_generic(c.expr(node.field_expr))
-			expr_sym := c.table.type_symbol(expr_type)
+			expr_sym := c.table.sym(expr_type)
 			if expr_type != ast.string_type {
 				c.error('expected `string` instead of `$expr_sym.name` (e.g. `field.name`)',
 					node.field_expr.position())
@@ -3255,7 +3255,7 @@ pub fn (mut c Checker) expr(node ast.Expr) ast.Type {
 				c.error('dump expression can not be void', node.expr.position())
 				return ast.void_type
 			}
-			tsym := c.table.type_symbol(node.expr_type)
+			tsym := c.table.sym(node.expr_type)
 			c.table.dumps[int(node.expr_type)] = tsym.cname
 			node.cname = tsym.cname
 			return node.expr_type
@@ -3403,7 +3403,7 @@ pub fn (mut c Checker) expr(node ast.Expr) ast.Type {
 		ast.Likely {
 			ltype := c.expr(node.expr)
 			if !c.check_types(ltype, ast.bool_type) {
-				ltype_sym := c.table.type_symbol(ltype)
+				ltype_sym := c.table.sym(ltype)
 				lname := if node.is_likely { '_likely_' } else { '_unlikely_' }
 				c.error('`${lname}()` expects a boolean expression, instead it got `$ltype_sym.name`',
 					node.pos)
@@ -3439,10 +3439,10 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 	mut from_type := node.expr_type
 	to_type := node.typ
 	//
-	from_type_sym := c.table.type_symbol(from_type)
-	from_type_sym_final := c.table.final_type_symbol(from_type)
-	to_type_sym := c.table.type_symbol(to_type) // type to be used as cast
-	to_type_sym_final := c.table.final_type_symbol(to_type)
+	from_type_sym := c.table.sym(from_type)
+	from_type_sym_final := c.table.final_sym(from_type)
+	to_type_sym := c.table.sym(to_type) // type to be used as cast
+	to_type_sym_final := c.table.final_sym(to_type)
 	//
 	if (to_type_sym.is_number() && from_type_sym.name == 'JS.Number')
 		|| (to_type_sym.is_number() && from_type_sym.name == 'JS.BigInt')
@@ -3624,7 +3624,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		}
 	}
 
-	node.typname = c.table.type_symbol(to_type).name
+	node.typname = c.table.sym(to_type).name
 
 	return to_type
 }
@@ -3784,7 +3784,7 @@ pub fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 							node.pos)
 					}
 					// if typ == ast.t_type {
-					// sym := c.table.type_symbol(c.cur_generic_type)
+					// sym := c.table.sym(c.cur_generic_type)
 					// println('IDENT T unresolved $node.name typ=$sym.name')
 					// Got a var with type T, return current generic type
 					// typ = c.cur_generic_type
@@ -3917,13 +3917,13 @@ pub fn (mut c Checker) concat_expr(mut node ast.ConcatExpr) ast.Type {
 
 // smartcast takes the expression with the current type which should be smartcasted to the target type in the given scope
 fn (c Checker) smartcast(expr ast.Expr, cur_type ast.Type, to_type_ ast.Type, mut scope ast.Scope) {
-	sym := c.table.type_symbol(cur_type)
+	sym := c.table.sym(cur_type)
 	to_type := if sym.kind == .interface_ { to_type_.ref() } else { to_type_ }
 	match expr {
 		ast.SelectorExpr {
 			mut is_mut := false
 			mut smartcasts := []ast.Type{}
-			expr_sym := c.table.type_symbol(expr.expr_type)
+			expr_sym := c.table.sym(expr.expr_type)
 			mut orig_type := 0
 			if field := c.table.find_field(expr_sym, expr.field_name) {
 				if field.is_mut {
@@ -3993,7 +3993,7 @@ pub fn (mut c Checker) select_expr(mut node ast.SelectExpr) ast.Type {
 			ast.ExprStmt {
 				if branch.is_timeout {
 					if !branch.stmt.typ.is_int() {
-						tsym := c.table.type_symbol(branch.stmt.typ)
+						tsym := c.table.sym(branch.stmt.typ)
 						c.error('invalid type `$tsym.name` for timeout - expected integer number of nanoseconds aka `time.Duration`',
 							branch.stmt.pos)
 					}
@@ -4145,7 +4145,7 @@ fn (c &Checker) has_return(stmts []ast.Stmt) ?bool {
 
 pub fn (mut c Checker) postfix_expr(mut node ast.PostfixExpr) ast.Type {
 	typ := c.unwrap_generic(c.expr(node.expr))
-	typ_sym := c.table.type_symbol(typ)
+	typ_sym := c.table.sym(typ)
 	is_non_void_pointer := (typ.is_ptr() || typ.is_pointer()) && typ_sym.kind != .voidptr
 	if !c.inside_unsafe && is_non_void_pointer && !node.expr.is_auto_deref_var() {
 		c.warn('pointer arithmetic is only allowed in `unsafe` blocks', node.pos)
@@ -4167,7 +4167,7 @@ pub fn (mut c Checker) mark_as_referenced(mut node ast.Expr, as_interface bool) 
 				if c.fn_scope != voidptr(0) {
 					obj = c.fn_scope.find_var(node.obj.name) or { obj }
 				}
-				type_sym := c.table.type_symbol(obj.typ.set_nr_muls(0))
+				type_sym := c.table.sym(obj.typ.set_nr_muls(0))
 				if obj.is_stack_obj && !type_sym.is_heap() && !c.pref.translated {
 					suggestion := if type_sym.kind == .struct_ {
 						'declaring `$type_sym.name` as `[heap]`'
@@ -4258,7 +4258,7 @@ pub fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 			else {}
 		}
 		if mut node.right is ast.IndexExpr {
-			typ_sym := c.table.type_symbol(node.right.left_type)
+			typ_sym := c.table.sym(node.right.left_type)
 			mut is_mut := false
 			if mut node.right.left is ast.Ident {
 				ident := node.right.left
@@ -4310,7 +4310,7 @@ pub fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 	// FIXME
 	// there are currently other issues to investigate if right_type
 	// is unwraped directly as initialization, so do it here
-	right_sym := c.table.final_type_symbol(c.unwrap_generic(right_type))
+	right_sym := c.table.final_sym(c.unwrap_generic(right_type))
 	if node.op == .minus && !right_sym.is_number() {
 		c.error('- operator can only be used with numeric types', node.pos)
 	}
@@ -4325,7 +4325,7 @@ pub fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 }
 
 fn (mut c Checker) check_index(typ_sym &ast.TypeSymbol, index ast.Expr, index_type ast.Type, pos token.Position, range_index bool) {
-	index_type_sym := c.table.type_symbol(index_type)
+	index_type_sym := c.table.sym(index_type)
 	// println('index expr left=$typ_sym.name $node.pos.line_nr')
 	// if typ_sym.kind == .array && (!(ast.type_idx(index_type) in ast.number_type_idxs) &&
 	// index_type_sym.kind != .enum_) {
@@ -4362,7 +4362,7 @@ fn (mut c Checker) check_index(typ_sym &ast.TypeSymbol, index ast.Expr, index_ty
 
 pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) ast.Type {
 	mut typ := c.expr(node.left)
-	mut typ_sym := c.table.final_type_symbol(typ)
+	mut typ_sym := c.table.final_sym(typ)
 	node.left_type = typ
 	for {
 		match typ_sym.kind {
@@ -4382,7 +4382,7 @@ pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) ast.Type {
 				gname := typ_sym.name
 				typ = c.unwrap_generic(typ)
 				node.left_type = typ
-				typ_sym = c.table.final_type_symbol(typ)
+				typ_sym = c.table.final_sym(typ)
 				if typ.is_ptr() {
 					continue
 				} else {
@@ -4445,7 +4445,7 @@ pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) ast.Type {
 				err := c.expected_msg(index_type, info.key_type)
 				c.error('invalid key: $err', node.pos)
 			}
-			value_sym := c.table.type_symbol(info.value_type)
+			value_sym := c.table.sym(info.value_type)
 			if !node.is_setter && value_sym.kind == .sum_type && node.or_expr.kind == .absent
 				&& !c.inside_unsafe && !c.inside_if_guard {
 				c.warn('`or {}` block required when indexing a map with sum type value',
@@ -4496,11 +4496,11 @@ pub fn (mut c Checker) enum_val(mut node ast.EnumVal) ast.Type {
 		c.error('not an enum', node.pos)
 		return ast.void_type
 	}
-	mut typ_sym := c.table.type_symbol(typ)
+	mut typ_sym := c.table.sym(typ)
 	if typ_sym.kind == .array && node.enum_name.len == 0 {
 		array_info := typ_sym.info as ast.Array
 		typ = array_info.elem_type
-		typ_sym = c.table.type_symbol(typ)
+		typ_sym = c.table.sym(typ)
 	}
 	if typ_sym.kind != .enum_ && !c.pref.translated {
 		// TODO in C int fields can be compared to enums, need to handle that in C2V
@@ -4526,7 +4526,7 @@ pub fn (mut c Checker) enum_val(mut node ast.EnumVal) ast.Type {
 
 pub fn (mut c Checker) chan_init(mut node ast.ChanInit) ast.Type {
 	if node.typ != 0 {
-		info := c.table.type_symbol(node.typ).chan_info()
+		info := c.table.sym(node.typ).chan_info()
 		node.elem_type = info.elem_type
 		if node.has_cap {
 			c.check_array_init_para_type('cap', node.cap_expr, node.pos)
@@ -4539,7 +4539,7 @@ pub fn (mut c Checker) chan_init(mut node ast.ChanInit) ast.Type {
 }
 
 pub fn (mut c Checker) offset_of(node ast.OffsetOf) ast.Type {
-	sym := c.table.final_type_symbol(node.struct_type)
+	sym := c.table.final_sym(node.struct_type)
 	if sym.kind != .struct_ {
 		c.error('first argument of __offsetof must be struct', node.pos)
 		return ast.u32_type
@@ -4576,7 +4576,7 @@ pub fn (mut c Checker) check_dup_keys(node &ast.MapInit, i int) {
 pub fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 	// `map = {}`
 	if node.keys.len == 0 && node.vals.len == 0 && node.typ == 0 {
-		sym := c.table.type_symbol(c.expected_type)
+		sym := c.table.sym(c.expected_type)
 		if sym.kind == .map {
 			info := sym.map_info()
 			node.typ = c.expected_type
@@ -4596,7 +4596,7 @@ pub fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 	}
 	// `x := map[string]string` - set in parser
 	if node.typ != 0 {
-		info := c.table.type_symbol(node.typ).map_info()
+		info := c.table.sym(node.typ).map_info()
 		c.ensure_type_exists(info.key_type, node.pos) or {}
 		c.ensure_type_exists(info.value_type, node.pos) or {}
 		node.key_type = info.key_type
@@ -4607,9 +4607,9 @@ pub fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 		mut key0_type := ast.void_type
 		mut val0_type := ast.void_type
 		use_expected_type := c.expected_type != ast.void_type && !c.inside_const
-			&& c.table.type_symbol(c.expected_type).kind == .map
+			&& c.table.sym(c.expected_type).kind == .map
 		if use_expected_type {
-			sym := c.table.type_symbol(c.expected_type)
+			sym := c.table.sym(c.expected_type)
 			info := sym.map_info()
 			key0_type = c.unwrap_generic(info.key_type)
 			val0_type = c.unwrap_generic(info.value_type)
@@ -4807,7 +4807,7 @@ fn (mut c Checker) fetch_field_name(field ast.StructField) string {
 			break
 		}
 	}
-	sym := c.table.type_symbol(field.typ)
+	sym := c.table.sym(field.typ)
 	if sym.kind == .struct_ && sym.name != 'time.Time' {
 		name = '${name}_id'
 	}
@@ -4846,7 +4846,7 @@ fn (mut c Checker) ensure_type_exists(typ ast.Type, pos token.Position) ? {
 		c.error('unknown type', pos)
 		return
 	}
-	sym := c.table.type_symbol(typ)
+	sym := c.table.sym(typ)
 	match sym.kind {
 		.placeholder {
 			if sym.language == .v && !sym.name.starts_with('C.') {

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -93,7 +93,7 @@ fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) ast.Type {
 	} else {
 		c.error('todo: not a string literal', node.method_pos)
 	}
-	left_sym := c.table.type_symbol(c.unwrap_generic(node.left_type))
+	left_sym := c.table.sym(c.unwrap_generic(node.left_type))
 	f := left_sym.find_method(method_name) or {
 		c.error('could not find method `$method_name`', node.method_pos)
 		return ast.void_type
@@ -313,7 +313,7 @@ fn (mut c Checker) verify_vweb_params_for_method(node ast.Fn) (bool, int, int) {
 	}
 	if node.params.len > 1 {
 		for param in node.params[1..] {
-			param_sym := c.table.final_type_symbol(param.typ)
+			param_sym := c.table.final_sym(param.typ)
 			if !(param_sym.is_string() || param_sym.is_number() || param_sym.is_float()
 				|| param_sym.kind == .bool) {
 				c.error('invalid type `$param_sym.name` for parameter `$param.name` in vweb app method `$node.name`',
@@ -338,7 +338,7 @@ fn (mut c Checker) verify_all_vweb_routes() {
 	typ_vweb_result := c.table.find_type_idx('vweb.Result')
 	old_file := c.file
 	for vgt in c.vweb_gen_types {
-		sym_app := c.table.type_symbol(vgt)
+		sym_app := c.table.sym(vgt)
 		for m in sym_app.methods {
 			if m.return_type == typ_vweb_result {
 				is_ok, nroute_attributes, nargs := c.verify_vweb_params_for_method(m)
@@ -440,7 +440,7 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Position) bool {
 				.key_is, .not_is {
 					if cond.left is ast.TypeNode && cond.right is ast.TypeNode {
 						// `$if Foo is Interface {`
-						sym := c.table.type_symbol(cond.right.typ)
+						sym := c.table.sym(cond.right.typ)
 						if sym.kind != .interface_ {
 							c.expr(cond.left)
 							// c.error('`$sym.name` is not an interface', cond.right.position())
@@ -577,7 +577,7 @@ fn (mut c Checker) check_map_and_filter(is_map bool, elem_typ ast.Type, node ast
 		// Finish early so that it doesn't fail later
 		return
 	}
-	elem_sym := c.table.type_symbol(elem_typ)
+	elem_sym := c.table.sym(elem_typ)
 	arg_expr := node.args[0].expr
 	match arg_expr {
 		ast.AnonFn {
@@ -733,13 +733,13 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 					'`.sort()` requires a `<` or `>` comparison as the first and only argument' +
 					'\ne.g. `users.sort(a.id < b.id)`', node.pos)
 			}
-		} else if !(c.table.type_symbol(elem_typ).has_method('<')
+		} else if !(c.table.sym(elem_typ).has_method('<')
 			|| c.table.unalias_num_type(elem_typ) in [ast.int_type, ast.int_type.ref(), ast.string_type, ast.string_type.ref(), ast.i8_type, ast.i16_type, ast.i64_type, ast.byte_type, ast.rune_type, ast.u16_type, ast.u32_type, ast.u64_type, ast.f32_type, ast.f64_type, ast.char_type, ast.bool_type, ast.float_literal_type, ast.int_literal_type]) {
 			c.error('custom sorting condition must be supplied for type `${c.table.type_to_str(elem_typ)}`',
 				node.pos)
 		}
 	} else if method_name == 'wait' {
-		elem_sym := c.table.type_symbol(elem_typ)
+		elem_sym := c.table.sym(elem_typ)
 		if elem_sym.kind == .thread {
 			if node.args.len != 0 {
 				c.error('`.wait()` does not have any arguments', node.args[0].pos)
@@ -763,7 +763,7 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 	if method_name == 'map' {
 		// check fn
 		c.check_map_and_filter(true, elem_typ, node)
-		arg_sym := c.table.type_symbol(arg_type)
+		arg_sym := c.table.sym(arg_type)
 		ret_type := match arg_sym.info {
 			ast.FnType { arg_sym.info.func.return_type }
 			else { arg_type }

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -73,7 +73,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				node.pos)
 		}
 		if node.generic_names.len > 0 {
-			gs := c.table.get_type_symbol(node.return_type)
+			gs := c.table.type_symbol(node.return_type)
 			if gs.info is ast.Struct {
 				if gs.info.is_generic && !node.return_type.has_flag(.generic) {
 					c.error('return generic struct in fn declaration must specify the generic type names, e.g. Foo<T>',
@@ -81,10 +81,10 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				}
 			}
 		}
-		return_sym := c.table.get_type_symbol(node.return_type)
+		return_sym := c.table.type_symbol(node.return_type)
 		if return_sym.info is ast.MultiReturn {
 			for multi_type in return_sym.info.types {
-				multi_sym := c.table.get_type_symbol(multi_type)
+				multi_sym := c.table.type_symbol(multi_type)
 				if multi_type == ast.error_type {
 					c.error('type `IError` cannot be used in multi-return, return an option instead',
 						node.return_type_pos)
@@ -106,7 +106,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 		}
 	}
 	if node.is_method {
-		mut sym := c.table.get_type_symbol(node.receiver.typ)
+		mut sym := c.table.type_symbol(node.receiver.typ)
 		if sym.kind == .array && !c.is_builtin_mod && node.name == 'map' {
 			// TODO `node.map in array_builtin_methods`
 			c.error('method overrides built-in array method', node.pos)
@@ -134,7 +134,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 		}
 		if mut sym.info is ast.Struct {
 			if field := c.table.find_field(sym, node.name) {
-				field_sym := c.table.get_type_symbol(field.typ)
+				field_sym := c.table.type_symbol(field.typ)
 				if field_sym.kind == .function {
 					c.error('type `$sym.name` has both field and method named `$node.name`',
 						node.pos)
@@ -171,7 +171,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 					param.pos)
 			}
 			if !param.typ.is_ptr() { // value parameter, i.e. on stack - check for `[heap]`
-				arg_typ_sym := c.table.get_type_symbol(param.typ)
+				arg_typ_sym := c.table.type_symbol(param.typ)
 				if arg_typ_sym.kind == .struct_ {
 					info := arg_typ_sym.info as ast.Struct
 					if info.is_heap { // set auto_heap to promote value parameter
@@ -229,8 +229,8 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 			if node.params.len != 2 {
 				c.error('operator methods should have exactly 1 argument', node.pos)
 			} else {
-				receiver_sym := c.table.get_type_symbol(node.receiver.typ)
-				param_sym := c.table.get_type_symbol(node.params[1].typ)
+				receiver_sym := c.table.type_symbol(node.receiver.typ)
+				param_sym := c.table.type_symbol(node.params[1].typ)
 				if param_sym.kind == .string && receiver_sym.kind == .string {
 					// bypass check for strings
 					// TODO there must be a better way to handle that
@@ -239,7 +239,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 					c.error('operator methods are only allowed for struct and type alias',
 						node.pos)
 				} else {
-					parent_sym := c.table.get_final_type_symbol(node.receiver.typ)
+					parent_sym := c.table.final_type_symbol(node.receiver.typ)
 					if node.rec_mut {
 						c.error('receiver cannot be `mut` for operator overloading', node.receiver_pos)
 					} else if node.params[1].is_mut {
@@ -285,7 +285,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 	// Add return if `fn(...) ? {...}` have no return at end
 	if node.return_type != ast.void_type && node.return_type.has_flag(.optional)
 		&& (node.stmts.len == 0 || node.stmts[node.stmts.len - 1] !is ast.Return) {
-		sym := c.table.get_type_symbol(node.return_type)
+		sym := c.table.type_symbol(node.return_type)
 		if sym.kind == .void {
 			node.stmts << ast.Return{
 				pos: node.pos
@@ -375,7 +375,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 		}
 
 		typ := c.expr(node.args[0].expr)
-		tsym := c.table.get_type_symbol(typ)
+		tsym := c.table.type_symbol(typ)
 
 		if !tsym.name.starts_with('Promise<') {
 			c.error('JS.await: first argument must be a promise, got `$tsym.name`', node.pos)
@@ -405,7 +405,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 		}
 		expr := node.args[0].expr
 		if expr is ast.TypeNode {
-			sym := c.table.get_type_symbol(expr.typ)
+			sym := c.table.type_symbol(expr.typ)
 			if !c.table.known_type(sym.name) {
 				c.error('json.decode: unknown type `$sym.name`', node.pos)
 			}
@@ -435,7 +435,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 		node.name = ''
 		c.expr(node.left)
 		if node.left.typ != ast.Type(0) {
-			anon_fn_sym := c.table.get_type_symbol(node.left.typ)
+			anon_fn_sym := c.table.type_symbol(node.left.typ)
 			func = (anon_fn_sym.info as ast.FnType).func
 			found = true
 		}
@@ -453,10 +453,10 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 	if !found && node.left is ast.IndexExpr {
 		c.expr(node.left)
 		expr := node.left as ast.IndexExpr
-		sym := c.table.get_type_symbol(expr.left_type)
+		sym := c.table.type_symbol(expr.left_type)
 		if sym.kind == .array {
 			info := sym.info as ast.Array
-			elem_typ := c.table.get_type_symbol(info.elem_type)
+			elem_typ := c.table.type_symbol(info.elem_type)
 			if elem_typ.info is ast.FnType {
 				return elem_typ.info.func.return_type
 			} else {
@@ -465,7 +465,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 			}
 		} else if sym.kind == .map {
 			info := sym.info as ast.Map
-			value_typ := c.table.get_type_symbol(info.value_type)
+			value_typ := c.table.type_symbol(info.value_type)
 			if value_typ.info is ast.FnType {
 				return value_typ.info.func.return_type
 			} else {
@@ -473,7 +473,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 			}
 		} else if sym.kind == .array_fixed {
 			info := sym.info as ast.ArrayFixed
-			elem_typ := c.table.get_type_symbol(info.elem_type)
+			elem_typ := c.table.type_symbol(info.elem_type)
 			if elem_typ.info is ast.FnType {
 				return elem_typ.info.func.return_type
 			} else {
@@ -534,14 +534,14 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 		}
 
 		if typ != 0 {
-			generic_vts := c.table.get_final_type_symbol(typ)
+			generic_vts := c.table.final_type_symbol(typ)
 			if generic_vts.kind == .function {
 				info := generic_vts.info as ast.FnType
 				func = info.func
 				found = true
 				found_in_args = true
 			} else {
-				vts := c.table.get_type_symbol(c.unwrap_generic(typ))
+				vts := c.table.type_symbol(c.unwrap_generic(typ))
 				if vts.kind == .function {
 					info := vts.info as ast.FnType
 					func = info.func
@@ -554,7 +554,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 	// global fn?
 	if !found {
 		if obj := c.file.global_scope.find(fn_name) {
-			sym := c.table.get_type_symbol(obj.typ)
+			sym := c.table.type_symbol(obj.typ)
 			if sym.kind == .function {
 				found = true
 				func = (sym.info as ast.FnType).func
@@ -631,7 +631,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 		// `println(T_str(*(T**)array_get(a, 0)));`
 		prexpr := node.args[0].expr
 		prtyp := node.args[0].typ
-		prtyp_sym := c.table.get_type_symbol(prtyp)
+		prtyp_sym := c.table.type_symbol(prtyp)
 		prtyp_is_ptr := prtyp.is_ptr()
 		prhas_str, prexpects_ptr, prnr_args := prtyp_sym.str_method_info()
 		eprintln('>>> println hack typ: ${prtyp} | sym.name: ${prtyp_sym.name} | is_ptr: $prtyp_is_ptr | has_str: $prhas_str | expects_ptr: $prexpects_ptr | nr_args: $prnr_args | expr: ${prexpr.str()} ')
@@ -665,7 +665,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 		}
 		c.expected_type = param.typ
 
-		e_sym := c.table.get_type_symbol(c.expected_type)
+		e_sym := c.table.type_symbol(c.expected_type)
 		if call_arg.expr is ast.MapInit && e_sym.kind == .struct_ {
 			c.error('cannot initialize a struct with a map', call_arg.pos)
 			continue
@@ -676,8 +676,8 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 
 		typ := c.check_expr_opt_call(call_arg.expr, c.expr(call_arg.expr))
 		node.args[i].typ = typ
-		typ_sym := c.table.get_type_symbol(typ)
-		param_typ_sym := c.table.get_type_symbol(param.typ)
+		typ_sym := c.table.type_symbol(typ)
+		param_typ_sym := c.table.type_symbol(param.typ)
 		if func.is_variadic && typ.has_flag(.variadic) && node.args.len - 1 > i {
 			c.error('when forwarding a variadic variable, it must be the final argument',
 				call_arg.pos)
@@ -718,7 +718,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 		mut final_param_typ := param.typ
 		if func.is_variadic && param_typ_sym.info is ast.Array {
 			final_param_typ = param_typ_sym.array_info().elem_type
-			final_param_sym = c.table.get_type_symbol(final_param_typ)
+			final_param_sym = c.table.type_symbol(final_param_typ)
 		}
 		// NB: Casting to voidptr is used as an escape mechanism, so:
 		// 1. allow passing *explicit* voidptr (native or through cast) to functions
@@ -793,7 +793,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 		if func.language != .c && !c.inside_unsafe && typ.nr_muls() != param.typ.nr_muls()
 			&& !(call_arg.is_mut && param.is_mut) && !(!call_arg.is_mut && !param.is_mut)
 			&& param.typ !in [ast.byteptr_type, ast.charptr_type, ast.voidptr_type] {
-			// sym := c.table.get_type_symbol(typ)
+			// sym := c.table.type_symbol(typ)
 			c.warn('automatic referencing/dereferencing is deprecated and will be removed soon (got: $typ.nr_muls() references, expected: $param.typ.nr_muls() references)',
 				call_arg.pos)
 		}
@@ -818,11 +818,11 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 					concrete_types)
 				{
 					utyp := c.unwrap_generic(typ)
-					unwrap_sym := c.table.get_type_symbol(unwrap_typ)
+					unwrap_sym := c.table.type_symbol(unwrap_typ)
 					if unwrap_sym.kind == .interface_ {
 						if c.type_implements(utyp, unwrap_typ, call_arg.expr.position()) {
 							if !utyp.is_ptr() && !utyp.is_pointer() && !c.inside_unsafe
-								&& c.table.get_type_symbol(utyp).kind != .interface_ {
+								&& c.table.type_symbol(utyp).kind != .interface_ {
 								c.mark_as_referenced(mut &call_arg.expr, true)
 							}
 						}
@@ -871,7 +871,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	mut is_generic := left_type.has_flag(.generic)
 	// x is Bar<T>, x.foo() -> x.foo<T>()
 	if is_generic && node.concrete_types.len == 0 {
-		rec_sym := c.table.get_type_symbol(left_type)
+		rec_sym := c.table.type_symbol(left_type)
 		if rec_sym.info is ast.Struct {
 			node.concrete_types = rec_sym.info.generic_types
 		}
@@ -886,8 +886,8 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 		c.table.unwrap_generic_type(left_type, c.table.cur_fn.generic_names, c.table.cur_concrete_types)
 	}
 	unwrapped_left_type := c.unwrap_generic(left_type)
-	left_sym := c.table.get_type_symbol(unwrapped_left_type)
-	final_left_sym := c.table.get_final_type_symbol(unwrapped_left_type)
+	left_sym := c.table.type_symbol(unwrapped_left_type)
+	final_left_sym := c.table.final_type_symbol(unwrapped_left_type)
 
 	method_name := node.name
 	mut unknown_method_msg := if field := c.table.find_field(left_sym, method_name) {
@@ -962,7 +962,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 		info := left_sym.info as ast.Array
 		arg_expr := if method_name == 'insert' { node.args[1].expr } else { node.args[0].expr }
 		arg_type := c.expr(arg_expr)
-		arg_sym := c.table.get_type_symbol(arg_type)
+		arg_sym := c.table.type_symbol(arg_type)
 		if !c.check_types(arg_type, info.elem_type) && !c.check_types(left_type, arg_type) {
 			c.error('cannot $method_name `$arg_sym.name` to `$left_sym.name`', arg_expr.position())
 		}
@@ -1010,7 +1010,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 				parent_type = left_sym.info.parent_type
 			}
 			if parent_type != 0 {
-				type_sym := c.table.get_type_symbol(parent_type)
+				type_sym := c.table.type_symbol(parent_type)
 				if m := c.table.find_method(type_sym, method_name) {
 					method = m
 					has_method = true
@@ -1101,13 +1101,13 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 				param_is_mut = false
 				no_type_promotion = false
 			}
-			exp_arg_sym := c.table.get_type_symbol(exp_arg_typ)
+			exp_arg_sym := c.table.type_symbol(exp_arg_typ)
 			c.expected_type = exp_arg_typ
 			got_arg_typ := c.check_expr_opt_call(arg.expr, c.expr(arg.expr))
 			node.args[i].typ = got_arg_typ
 			if no_type_promotion {
 				if got_arg_typ != exp_arg_typ {
-					c.error('cannot use `${c.table.get_type_symbol(got_arg_typ).name}` as argument for `$method.name` (`$exp_arg_sym.name` expected)',
+					c.error('cannot use `${c.table.type_symbol(got_arg_typ).name}` as argument for `$method.name` (`$exp_arg_sym.name` expected)',
 						arg.pos)
 				}
 			}
@@ -1119,13 +1119,13 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 			mut final_arg_typ := exp_arg_typ
 			if method.is_variadic && exp_arg_sym.info is ast.Array {
 				final_arg_typ = exp_arg_sym.array_info().elem_type
-				final_arg_sym = c.table.get_type_symbol(final_arg_typ)
+				final_arg_sym = c.table.type_symbol(final_arg_typ)
 			}
 			// Handle expected interface
 			if final_arg_sym.kind == .interface_ {
 				if c.type_implements(got_arg_typ, final_arg_typ, arg.expr.position()) {
 					if !got_arg_typ.is_ptr() && !got_arg_typ.is_pointer() && !c.inside_unsafe {
-						got_arg_typ_sym := c.table.get_type_symbol(got_arg_typ)
+						got_arg_typ_sym := c.table.type_symbol(got_arg_typ)
 						if got_arg_typ_sym.kind != .interface_ {
 							c.mark_as_referenced(mut &arg.expr, true)
 						}
@@ -1261,7 +1261,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	// call struct field fn type
 	// TODO: can we use SelectorExpr for all? this dosent really belong here
 	if field := c.table.find_field(left_sym, method_name) {
-		field_sym := c.table.get_type_symbol(c.unwrap_generic(field.typ))
+		field_sym := c.table.type_symbol(c.unwrap_generic(field.typ))
 		if field_sym.kind == .function {
 			node.is_method = false
 			node.is_field = true
@@ -1347,7 +1347,7 @@ pub fn (mut c Checker) check_expected_arg_count(mut node ast.CallExpr, f &ast.Fn
 	if nr_args < min_required_params {
 		if min_required_params == nr_args + 1 {
 			last_typ := f.params.last().typ
-			last_sym := c.table.get_type_symbol(last_typ)
+			last_sym := c.table.type_symbol(last_typ)
 			if last_sym.info is ast.Struct {
 				is_params := last_sym.info.attrs.filter(it.name == 'params' && !it.has_arg).len > 0
 				if is_params {

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -57,7 +57,7 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 						return 0
 					}
 					got_type := c.unwrap_generic((branch.cond.right as ast.TypeNode).typ)
-					sym := c.table.type_symbol(got_type)
+					sym := c.table.sym(got_type)
 					if sym.kind == .placeholder || got_type.has_flag(.generic) {
 						c.error('unknown type `$sym.name`', branch.cond.right.position())
 					}
@@ -187,7 +187,7 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 							}
 						}
 					}
-					if node.is_expr && c.table.type_symbol(former_expected_type).kind == .sum_type {
+					if node.is_expr && c.table.sym(former_expected_type).kind == .sum_type {
 						continue
 					}
 					if is_noreturn_callexpr(last_expr.expr) {
@@ -263,8 +263,8 @@ fn (mut c Checker) smartcast_if_conds(node ast.Expr, mut scope ast.Scope) {
 			}
 			right_type = c.unwrap_generic(right_type)
 			if right_type != ast.Type(0) {
-				left_sym := c.table.type_symbol(node.left_type)
-				right_sym := c.table.type_symbol(right_type)
+				left_sym := c.table.sym(node.left_type)
+				right_sym := c.table.sym(right_type)
 				expr_type := c.unwrap_generic(c.expr(node.left))
 				if left_sym.kind == .interface_ {
 					if right_sym.kind != .interface_ {

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -57,7 +57,7 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 						return 0
 					}
 					got_type := c.unwrap_generic((branch.cond.right as ast.TypeNode).typ)
-					sym := c.table.get_type_symbol(got_type)
+					sym := c.table.type_symbol(got_type)
 					if sym.kind == .placeholder || got_type.has_flag(.generic) {
 						c.error('unknown type `$sym.name`', branch.cond.right.position())
 					}
@@ -187,8 +187,7 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 							}
 						}
 					}
-					if node.is_expr
-						&& c.table.get_type_symbol(former_expected_type).kind == .sum_type {
+					if node.is_expr && c.table.type_symbol(former_expected_type).kind == .sum_type {
 						continue
 					}
 					if is_noreturn_callexpr(last_expr.expr) {
@@ -264,8 +263,8 @@ fn (mut c Checker) smartcast_if_conds(node ast.Expr, mut scope ast.Scope) {
 			}
 			right_type = c.unwrap_generic(right_type)
 			if right_type != ast.Type(0) {
-				left_sym := c.table.get_type_symbol(node.left_type)
-				right_sym := c.table.get_type_symbol(right_type)
+				left_sym := c.table.type_symbol(node.left_type)
+				right_sym := c.table.type_symbol(right_type)
 				expr_type := c.unwrap_generic(c.expr(node.left))
 				if left_sym.kind == .interface_ {
 					if right_sym.kind != .interface_ {

--- a/vlib/v/checker/interface.v
+++ b/vlib/v/checker/interface.v
@@ -8,7 +8,7 @@ import v.token
 
 pub fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 	c.check_valid_pascal_case(node.name, 'interface name', node.pos)
-	mut decl_sym := c.table.type_symbol(node.typ)
+	mut decl_sym := c.table.sym(node.typ)
 	is_js := node.language == .js
 	if mut decl_sym.info is ast.Interface {
 		if node.ifaces.len > 0 {
@@ -31,7 +31,7 @@ pub fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 			}
 			//
 			for iface in all_ifaces {
-				isym := c.table.type_symbol(iface.typ)
+				isym := c.table.sym(iface.typ)
 				if isym.kind != .interface_ {
 					c.error('interface `$node.name` tries to embed `$isym.name`, but `$isym.name` is not an interface, but `$isym.kind`',
 						iface.pos)
@@ -105,7 +105,7 @@ pub fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 			}
 			c.ensure_type_exists(method.return_type, method.return_type_pos) or { return }
 			if is_js {
-				mtyp := c.table.type_symbol(method.return_type)
+				mtyp := c.table.sym(method.return_type)
 				if !mtyp.is_js_compatible() {
 					c.error('method $method.name returns non JS type', method.pos)
 				}
@@ -120,7 +120,7 @@ pub fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 						param.pos)
 				}
 				if is_js {
-					ptyp := c.table.type_symbol(param.typ)
+					ptyp := c.table.sym(param.typ)
 					if !ptyp.is_js_compatible() && !(j == method.params.len - 1
 						&& method.is_variadic) {
 						c.error('method `$method.name` accepts non JS type as parameter',
@@ -129,7 +129,7 @@ pub fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 				}
 			}
 			for field in node.fields {
-				field_sym := c.table.type_symbol(field.typ)
+				field_sym := c.table.sym(field.typ)
 				if field.name == method.name && field_sym.kind == .function {
 					c.error('type `$decl_sym.name` has both field and method named `$method.name`',
 						method.pos)
@@ -147,7 +147,7 @@ pub fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 			}
 			c.ensure_type_exists(field.typ, field.pos) or { return }
 			if is_js {
-				tsym := c.table.type_symbol(field.typ)
+				tsym := c.table.sym(field.typ)
 				if !tsym.is_js_compatible() {
 					c.error('field `$field.name` uses non JS type', field.pos)
 				}
@@ -167,8 +167,8 @@ pub fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 
 fn (mut c Checker) resolve_generic_interface(typ ast.Type, interface_type ast.Type, pos token.Position) ast.Type {
 	utyp := c.unwrap_generic(typ)
-	typ_sym := c.table.type_symbol(utyp)
-	mut inter_sym := c.table.type_symbol(interface_type)
+	typ_sym := c.table.sym(utyp)
+	mut inter_sym := c.table.sym(interface_type)
 
 	if mut inter_sym.info is ast.Interface {
 		if inter_sym.info.is_generic {
@@ -189,8 +189,8 @@ fn (mut c Checker) resolve_generic_interface(typ ast.Type, interface_type ast.Ty
 						typ_sym.find_method_with_generic_parent(imethod.name) or { ast.Fn{} }
 					}
 					if imethod.return_type.has_flag(.generic) {
-						imret_sym := c.table.type_symbol(imethod.return_type)
-						mret_sym := c.table.type_symbol(method.return_type)
+						imret_sym := c.table.sym(imethod.return_type)
+						mret_sym := c.table.sym(method.return_type)
 						if imret_sym.info is ast.MultiReturn && mret_sym.info is ast.MultiReturn {
 							for i, mr_typ in imret_sym.info.types {
 								if mr_typ.has_flag(.generic)

--- a/vlib/v/checker/interface.v
+++ b/vlib/v/checker/interface.v
@@ -8,7 +8,7 @@ import v.token
 
 pub fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 	c.check_valid_pascal_case(node.name, 'interface name', node.pos)
-	mut decl_sym := c.table.get_type_symbol(node.typ)
+	mut decl_sym := c.table.type_symbol(node.typ)
 	is_js := node.language == .js
 	if mut decl_sym.info is ast.Interface {
 		if node.ifaces.len > 0 {
@@ -31,7 +31,7 @@ pub fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 			}
 			//
 			for iface in all_ifaces {
-				isym := c.table.get_type_symbol(iface.typ)
+				isym := c.table.type_symbol(iface.typ)
 				if isym.kind != .interface_ {
 					c.error('interface `$node.name` tries to embed `$isym.name`, but `$isym.name` is not an interface, but `$isym.kind`',
 						iface.pos)
@@ -105,7 +105,7 @@ pub fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 			}
 			c.ensure_type_exists(method.return_type, method.return_type_pos) or { return }
 			if is_js {
-				mtyp := c.table.get_type_symbol(method.return_type)
+				mtyp := c.table.type_symbol(method.return_type)
 				if !mtyp.is_js_compatible() {
 					c.error('method $method.name returns non JS type', method.pos)
 				}
@@ -120,7 +120,7 @@ pub fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 						param.pos)
 				}
 				if is_js {
-					ptyp := c.table.get_type_symbol(param.typ)
+					ptyp := c.table.type_symbol(param.typ)
 					if !ptyp.is_js_compatible() && !(j == method.params.len - 1
 						&& method.is_variadic) {
 						c.error('method `$method.name` accepts non JS type as parameter',
@@ -129,7 +129,7 @@ pub fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 				}
 			}
 			for field in node.fields {
-				field_sym := c.table.get_type_symbol(field.typ)
+				field_sym := c.table.type_symbol(field.typ)
 				if field.name == method.name && field_sym.kind == .function {
 					c.error('type `$decl_sym.name` has both field and method named `$method.name`',
 						method.pos)
@@ -147,7 +147,7 @@ pub fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 			}
 			c.ensure_type_exists(field.typ, field.pos) or { return }
 			if is_js {
-				tsym := c.table.get_type_symbol(field.typ)
+				tsym := c.table.type_symbol(field.typ)
 				if !tsym.is_js_compatible() {
 					c.error('field `$field.name` uses non JS type', field.pos)
 				}
@@ -167,8 +167,8 @@ pub fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 
 fn (mut c Checker) resolve_generic_interface(typ ast.Type, interface_type ast.Type, pos token.Position) ast.Type {
 	utyp := c.unwrap_generic(typ)
-	typ_sym := c.table.get_type_symbol(utyp)
-	mut inter_sym := c.table.get_type_symbol(interface_type)
+	typ_sym := c.table.type_symbol(utyp)
+	mut inter_sym := c.table.type_symbol(interface_type)
 
 	if mut inter_sym.info is ast.Interface {
 		if inter_sym.info.is_generic {
@@ -189,8 +189,8 @@ fn (mut c Checker) resolve_generic_interface(typ ast.Type, interface_type ast.Ty
 						typ_sym.find_method_with_generic_parent(imethod.name) or { ast.Fn{} }
 					}
 					if imethod.return_type.has_flag(.generic) {
-						imret_sym := c.table.get_type_symbol(imethod.return_type)
-						mret_sym := c.table.get_type_symbol(method.return_type)
+						imret_sym := c.table.type_symbol(imethod.return_type)
+						mret_sym := c.table.type_symbol(method.return_type)
 						if imret_sym.info is ast.MultiReturn && mret_sym.info is ast.MultiReturn {
 							for i, mr_typ in imret_sym.info.types {
 								if mr_typ.has_flag(.generic)

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -14,7 +14,7 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 	node.cond_type = c.table.mktyp(cond_type)
 	c.ensure_type_exists(node.cond_type, node.pos) or { return ast.void_type }
 	c.check_expr_opt_call(node.cond, cond_type)
-	cond_type_sym := c.table.get_type_symbol(cond_type)
+	cond_type_sym := c.table.type_symbol(cond_type)
 	node.is_sum_type = cond_type_sym.kind in [.interface_, .sum_type]
 	c.match_exprs(mut node, cond_type_sym)
 	c.expected_type = cond_type
@@ -65,7 +65,7 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 					} else if node.is_expr && ret_type.idx() != expr_type.idx() {
 						if !c.check_types(ret_type, expr_type)
 							&& !c.check_types(expr_type, ret_type) {
-							ret_sym := c.table.get_type_symbol(ret_type)
+							ret_sym := c.table.type_symbol(ret_type)
 							is_noreturn := is_noreturn_callexpr(stmt.expr)
 							if !(node.is_expr && ret_sym.kind == .sum_type) && !is_noreturn {
 								c.error('return type mismatch, it should be `$ret_sym.name`',
@@ -204,7 +204,7 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 				// parser failed, stop checking
 				return
 			}
-			expr_type_sym := c.table.get_type_symbol(expr_type)
+			expr_type_sym := c.table.type_symbol(expr_type)
 			if cond_type_sym.kind == .interface_ {
 				// TODO
 				// This generates a memory issue with TCC

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -14,7 +14,7 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 	node.cond_type = c.table.mktyp(cond_type)
 	c.ensure_type_exists(node.cond_type, node.pos) or { return ast.void_type }
 	c.check_expr_opt_call(node.cond, cond_type)
-	cond_type_sym := c.table.type_symbol(cond_type)
+	cond_type_sym := c.table.sym(cond_type)
 	node.is_sum_type = cond_type_sym.kind in [.interface_, .sum_type]
 	c.match_exprs(mut node, cond_type_sym)
 	c.expected_type = cond_type
@@ -65,7 +65,7 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 					} else if node.is_expr && ret_type.idx() != expr_type.idx() {
 						if !c.check_types(ret_type, expr_type)
 							&& !c.check_types(expr_type, ret_type) {
-							ret_sym := c.table.type_symbol(ret_type)
+							ret_sym := c.table.sym(ret_type)
 							is_noreturn := is_noreturn_callexpr(stmt.expr)
 							if !(node.is_expr && ret_sym.kind == .sum_type) && !is_noreturn {
 								c.error('return type mismatch, it should be `$ret_sym.name`',
@@ -204,7 +204,7 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 				// parser failed, stop checking
 				return
 			}
-			expr_type_sym := c.table.type_symbol(expr_type)
+			expr_type_sym := c.table.sym(expr_type)
 			if cond_type_sym.kind == .interface_ {
 				// TODO
 				// This generates a memory issue with TCC

--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -10,7 +10,7 @@ fn (mut c Checker) sql_expr(mut node ast.SqlExpr) ast.Type {
 	defer {
 		c.inside_sql = false
 	}
-	sym := c.table.get_type_symbol(node.table_expr.typ)
+	sym := c.table.type_symbol(node.table_expr.typ)
 	c.ensure_type_exists(node.table_expr.typ, node.pos) or { return ast.void_type }
 	c.cur_orm_ts = *sym
 	if sym.info !is ast.Struct {
@@ -21,13 +21,13 @@ fn (mut c Checker) sql_expr(mut node ast.SqlExpr) ast.Type {
 	fields := c.fetch_and_verify_orm_fields(info, node.table_expr.pos, sym.name)
 	mut sub_structs := map[int]ast.SqlExpr{}
 	for f in fields.filter((c.table.type_symbols[int(it.typ)].kind == .struct_
-		|| (c.table.get_type_symbol(it.typ).kind == .array
-		&& c.table.get_type_symbol(c.table.get_type_symbol(it.typ).array_info().elem_type).kind == .struct_))
+		|| (c.table.type_symbol(it.typ).kind == .array
+		&& c.table.type_symbol(c.table.type_symbol(it.typ).array_info().elem_type).kind == .struct_))
 		&& c.table.get_type_name(it.typ) != 'time.Time') {
-		typ := if c.table.get_type_symbol(f.typ).kind == .struct_ {
+		typ := if c.table.type_symbol(f.typ).kind == .struct_ {
 			f.typ
-		} else if c.table.get_type_symbol(f.typ).kind == .array {
-			c.table.get_type_symbol(f.typ).array_info().elem_type
+		} else if c.table.type_symbol(f.typ).kind == .array {
+			c.table.type_symbol(f.typ).array_info().elem_type
 		} else {
 			ast.Type(0)
 		}
@@ -113,7 +113,7 @@ fn (mut c Checker) sql_stmt_line(mut node ast.SqlStmtLine) ast.Type {
 		c.inside_sql = false
 	}
 	c.ensure_type_exists(node.table_expr.typ, node.pos) or { return ast.void_type }
-	table_sym := c.table.get_type_symbol(node.table_expr.typ)
+	table_sym := c.table.type_symbol(node.table_expr.typ)
 	c.cur_orm_ts = *table_sym
 	if table_sym.info !is ast.Struct {
 		c.error('unknown type `$table_sym.name`', node.pos)
@@ -123,13 +123,13 @@ fn (mut c Checker) sql_stmt_line(mut node ast.SqlStmtLine) ast.Type {
 	fields := c.fetch_and_verify_orm_fields(info, node.table_expr.pos, table_sym.name)
 	mut sub_structs := map[int]ast.SqlStmtLine{}
 	for f in fields.filter(((c.table.type_symbols[int(it.typ)].kind == .struct_)
-		|| (c.table.get_type_symbol(it.typ).kind == .array
-		&& c.table.get_type_symbol(c.table.get_type_symbol(it.typ).array_info().elem_type).kind == .struct_))
+		|| (c.table.type_symbol(it.typ).kind == .array
+		&& c.table.type_symbol(c.table.type_symbol(it.typ).array_info().elem_type).kind == .struct_))
 		&& c.table.get_type_name(it.typ) != 'time.Time') {
-		typ := if c.table.get_type_symbol(f.typ).kind == .struct_ {
+		typ := if c.table.type_symbol(f.typ).kind == .struct_ {
 			f.typ
-		} else if c.table.get_type_symbol(f.typ).kind == .array {
-			c.table.get_type_symbol(f.typ).array_info().elem_type
+		} else if c.table.type_symbol(f.typ).kind == .array {
+			c.table.type_symbol(f.typ).array_info().elem_type
 		} else {
 			ast.Type(0)
 		}
@@ -178,8 +178,8 @@ fn (mut c Checker) fetch_and_verify_orm_fields(info ast.Struct, pos token.Positi
 	fields := info.fields.filter(
 		(it.typ in [ast.string_type, ast.bool_type] || int(it.typ) in ast.number_type_idxs
 		|| c.table.type_symbols[int(it.typ)].kind == .struct_
-		|| (c.table.get_type_symbol(it.typ).kind == .array
-		&& c.table.get_type_symbol(c.table.get_type_symbol(it.typ).array_info().elem_type).kind == .struct_))
+		|| (c.table.type_symbol(it.typ).kind == .array
+		&& c.table.type_symbol(c.table.type_symbol(it.typ).array_info().elem_type).kind == .struct_))
 		&& !it.attrs.contains('skip'))
 	if fields.len == 0 {
 		c.error('V orm: select: empty fields in `$table_name`', pos)

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -9,7 +9,7 @@ import v.pref
 pub fn (mut c Checker) return_stmt(mut node ast.Return) {
 	c.expected_type = c.table.cur_fn.return_type
 	mut expected_type := c.unwrap_generic(c.expected_type)
-	expected_type_sym := c.table.type_symbol(expected_type)
+	expected_type_sym := c.table.sym(expected_type)
 	if node.exprs.len > 0 && c.table.cur_fn.return_type == ast.void_type {
 		c.error('unexpected argument, current function does not return anything', node.exprs[0].position())
 		return
@@ -38,7 +38,7 @@ pub fn (mut c Checker) return_stmt(mut node ast.Return) {
 			c.error('`$expr` used as value', node.pos)
 		}
 		// Unpack multi return types
-		sym := c.table.type_symbol(typ)
+		sym := c.table.sym(typ)
 		if sym.kind == .multi_return {
 			for t in sym.mr_info().types {
 				got_types << t
@@ -87,8 +87,8 @@ pub fn (mut c Checker) return_stmt(mut node ast.Return) {
 				pos)
 		}
 		if !c.check_types(got_typ, exp_type) {
-			got_typ_sym := c.table.type_symbol(got_typ)
-			mut exp_typ_sym := c.table.type_symbol(exp_type)
+			got_typ_sym := c.table.sym(got_typ)
+			mut exp_typ_sym := c.table.sym(exp_type)
 			if exp_typ_sym.kind == .interface_ {
 				if c.type_implements(got_typ, exp_type, node.pos) {
 					if !got_typ.is_ptr() && !got_typ.is_pointer() && got_typ_sym.kind != .interface_
@@ -130,7 +130,7 @@ pub fn (mut c Checker) return_stmt(mut node ast.Return) {
 						obj = c.fn_scope.find_var(r_expr.obj.name) or { obj }
 					}
 					if obj.is_stack_obj && !c.inside_unsafe {
-						type_sym := c.table.type_symbol(obj.typ.set_nr_muls(0))
+						type_sym := c.table.sym(obj.typ.set_nr_muls(0))
 						if !type_sym.is_heap() && !c.pref.translated {
 							suggestion := if type_sym.kind == .struct_ {
 								'declaring `$type_sym.name` as `[heap]`'

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -9,7 +9,7 @@ import v.pref
 pub fn (mut c Checker) return_stmt(mut node ast.Return) {
 	c.expected_type = c.table.cur_fn.return_type
 	mut expected_type := c.unwrap_generic(c.expected_type)
-	expected_type_sym := c.table.get_type_symbol(expected_type)
+	expected_type_sym := c.table.type_symbol(expected_type)
 	if node.exprs.len > 0 && c.table.cur_fn.return_type == ast.void_type {
 		c.error('unexpected argument, current function does not return anything', node.exprs[0].position())
 		return
@@ -38,7 +38,7 @@ pub fn (mut c Checker) return_stmt(mut node ast.Return) {
 			c.error('`$expr` used as value', node.pos)
 		}
 		// Unpack multi return types
-		sym := c.table.get_type_symbol(typ)
+		sym := c.table.type_symbol(typ)
 		if sym.kind == .multi_return {
 			for t in sym.mr_info().types {
 				got_types << t
@@ -87,8 +87,8 @@ pub fn (mut c Checker) return_stmt(mut node ast.Return) {
 				pos)
 		}
 		if !c.check_types(got_typ, exp_type) {
-			got_typ_sym := c.table.get_type_symbol(got_typ)
-			mut exp_typ_sym := c.table.get_type_symbol(exp_type)
+			got_typ_sym := c.table.type_symbol(got_typ)
+			mut exp_typ_sym := c.table.type_symbol(exp_type)
 			if exp_typ_sym.kind == .interface_ {
 				if c.type_implements(got_typ, exp_type, node.pos) {
 					if !got_typ.is_ptr() && !got_typ.is_pointer() && got_typ_sym.kind != .interface_
@@ -130,7 +130,7 @@ pub fn (mut c Checker) return_stmt(mut node ast.Return) {
 						obj = c.fn_scope.find_var(r_expr.obj.name) or { obj }
 					}
 					if obj.is_stack_obj && !c.inside_unsafe {
-						type_sym := c.table.get_type_symbol(obj.typ.set_nr_muls(0))
+						type_sym := c.table.type_symbol(obj.typ.set_nr_muls(0))
 						if !type_sym.is_heap() && !c.pref.translated {
 							suggestion := if type_sym.kind == .struct_ {
 								'declaring `$type_sym.name` as `[heap]`'

--- a/vlib/v/checker/tests/comparing_typesymbol_to_a_type_should_not_compile.vv
+++ b/vlib/v/checker/tests/comparing_typesymbol_to_a_type_should_not_compile.vv
@@ -3,7 +3,7 @@ import v.ast
 fn main() {
 	t := ast.new_table()
 	ityp := ast.int_type
-	isym := t.get_type_symbol(ityp)
+	isym := t.type_symbol(ityp)
 	println(ityp.debug())
 	println(isym)
 	println(isym.debug())

--- a/vlib/v/checker/tests/comparing_typesymbol_to_a_type_should_not_compile.vv
+++ b/vlib/v/checker/tests/comparing_typesymbol_to_a_type_should_not_compile.vv
@@ -3,7 +3,7 @@ import v.ast
 fn main() {
 	t := ast.new_table()
 	ityp := ast.int_type
-	isym := t.type_symbol(ityp)
+	isym := t.sym(ityp)
 	println(ityp.debug())
 	println(isym)
 	println(isym.debug())

--- a/vlib/v/eval/expr.v
+++ b/vlib/v/eval/expr.v
@@ -263,7 +263,7 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 						}
 					}
 					else {
-						e.error('unknown cast: ${e.table.type_symbol(expr.expr_type).str()} to ${e.table.type_symbol(expr.typ).str()}')
+						e.error('unknown cast: ${e.table.sym(expr.expr_type).str()} to ${e.table.sym(expr.typ).str()}')
 					}
 				}
 			} else if expr.typ in ast.unsigned_integer_type_idxs {
@@ -306,7 +306,7 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 						}
 					}
 					else {
-						e.error('unknown cast: ${e.table.type_symbol(expr.expr_type).str()} to ${e.table.type_symbol(expr.typ).str()}')
+						e.error('unknown cast: ${e.table.sym(expr.expr_type).str()} to ${e.table.sym(expr.typ).str()}')
 					}
 				}
 			} else if expr.typ in ast.float_type_idxs {
@@ -336,7 +336,7 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 						}
 					}
 					else {
-						e.error('unknown cast: ${e.table.type_symbol(expr.expr_type).str()} to ${e.table.type_symbol(expr.typ).str()}')
+						e.error('unknown cast: ${e.table.sym(expr.expr_type).str()} to ${e.table.sym(expr.typ).str()}')
 					}
 				}
 			} else if expr.typ in ast.pointer_type_idxs {
@@ -351,7 +351,7 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 							}
 						}
 						else {
-							e.error('unknown cast: ${e.table.type_symbol(expr.expr_type).str()} to ${e.table.type_symbol(expr.typ).str()}')
+							e.error('unknown cast: ${e.table.sym(expr.expr_type).str()} to ${e.table.sym(expr.typ).str()}')
 						}
 					}
 				} else if expr.typ == ast.voidptr_type_idx {
@@ -362,7 +362,7 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 							}
 						}
 						else {
-							e.error('unknown cast: ${e.table.type_symbol(expr.expr_type).str()} to ${e.table.type_symbol(expr.typ).str()}')
+							e.error('unknown cast: ${e.table.sym(expr.expr_type).str()} to ${e.table.sym(expr.typ).str()}')
 						}
 					}
 				} else if expr.typ == ast.charptr_type_idx {
@@ -375,17 +375,17 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 							}
 						}
 						else {
-							e.error('unknown cast: ${e.table.type_symbol(expr.expr_type).str()} to ${e.table.type_symbol(expr.typ).str()}')
+							e.error('unknown cast: ${e.table.sym(expr.expr_type).str()} to ${e.table.sym(expr.typ).str()}')
 						}
 					}
 				}
-			} else if e.table.type_symbol(expr.typ).kind in [.interface_, .sum_type] {
+			} else if e.table.sym(expr.typ).kind in [.interface_, .sum_type] {
 				if e.pref.is_verbose {
 					eprintln(util.formatted_error('warning:', 'sumtype or interface casts return void currently',
 						e.cur_file, expr.pos))
 				}
 			} else {
-				e.error('unknown cast: ${e.table.type_symbol(expr.expr_type).str()} to ${e.table.type_symbol(expr.typ).str()}')
+				e.error('unknown cast: ${e.table.sym(expr.expr_type).str()} to ${e.table.sym(expr.typ).str()}')
 			}
 		}
 		ast.SelectorExpr {
@@ -540,7 +540,7 @@ fn (e Eval) type_to_size(typ ast.Type) u64 {
 			return u64(math.exp2(f64(typ - 8))) // this formula converts the type number to the bitsize
 		}
 		else {
-			e.error('type_to_size(): unknown type: ${e.table.type_symbol(typ).str()}')
+			e.error('type_to_size(): unknown type: ${e.table.sym(typ).str()}')
 			return -1
 		}
 	}

--- a/vlib/v/eval/expr.v
+++ b/vlib/v/eval/expr.v
@@ -263,7 +263,7 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 						}
 					}
 					else {
-						e.error('unknown cast: ${e.table.get_type_symbol(expr.expr_type).str()} to ${e.table.get_type_symbol(expr.typ).str()}')
+						e.error('unknown cast: ${e.table.type_symbol(expr.expr_type).str()} to ${e.table.type_symbol(expr.typ).str()}')
 					}
 				}
 			} else if expr.typ in ast.unsigned_integer_type_idxs {
@@ -306,7 +306,7 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 						}
 					}
 					else {
-						e.error('unknown cast: ${e.table.get_type_symbol(expr.expr_type).str()} to ${e.table.get_type_symbol(expr.typ).str()}')
+						e.error('unknown cast: ${e.table.type_symbol(expr.expr_type).str()} to ${e.table.type_symbol(expr.typ).str()}')
 					}
 				}
 			} else if expr.typ in ast.float_type_idxs {
@@ -336,7 +336,7 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 						}
 					}
 					else {
-						e.error('unknown cast: ${e.table.get_type_symbol(expr.expr_type).str()} to ${e.table.get_type_symbol(expr.typ).str()}')
+						e.error('unknown cast: ${e.table.type_symbol(expr.expr_type).str()} to ${e.table.type_symbol(expr.typ).str()}')
 					}
 				}
 			} else if expr.typ in ast.pointer_type_idxs {
@@ -351,7 +351,7 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 							}
 						}
 						else {
-							e.error('unknown cast: ${e.table.get_type_symbol(expr.expr_type).str()} to ${e.table.get_type_symbol(expr.typ).str()}')
+							e.error('unknown cast: ${e.table.type_symbol(expr.expr_type).str()} to ${e.table.type_symbol(expr.typ).str()}')
 						}
 					}
 				} else if expr.typ == ast.voidptr_type_idx {
@@ -362,7 +362,7 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 							}
 						}
 						else {
-							e.error('unknown cast: ${e.table.get_type_symbol(expr.expr_type).str()} to ${e.table.get_type_symbol(expr.typ).str()}')
+							e.error('unknown cast: ${e.table.type_symbol(expr.expr_type).str()} to ${e.table.type_symbol(expr.typ).str()}')
 						}
 					}
 				} else if expr.typ == ast.charptr_type_idx {
@@ -375,17 +375,17 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 							}
 						}
 						else {
-							e.error('unknown cast: ${e.table.get_type_symbol(expr.expr_type).str()} to ${e.table.get_type_symbol(expr.typ).str()}')
+							e.error('unknown cast: ${e.table.type_symbol(expr.expr_type).str()} to ${e.table.type_symbol(expr.typ).str()}')
 						}
 					}
 				}
-			} else if e.table.get_type_symbol(expr.typ).kind in [.interface_, .sum_type] {
+			} else if e.table.type_symbol(expr.typ).kind in [.interface_, .sum_type] {
 				if e.pref.is_verbose {
 					eprintln(util.formatted_error('warning:', 'sumtype or interface casts return void currently',
 						e.cur_file, expr.pos))
 				}
 			} else {
-				e.error('unknown cast: ${e.table.get_type_symbol(expr.expr_type).str()} to ${e.table.get_type_symbol(expr.typ).str()}')
+				e.error('unknown cast: ${e.table.type_symbol(expr.expr_type).str()} to ${e.table.type_symbol(expr.typ).str()}')
 			}
 		}
 		ast.SelectorExpr {
@@ -540,7 +540,7 @@ fn (e Eval) type_to_size(typ ast.Type) u64 {
 			return u64(math.exp2(f64(typ - 8))) // this formula converts the type number to the bitsize
 		}
 		else {
-			e.error('type_to_size(): unknown type: ${e.table.get_type_symbol(typ).str()}')
+			e.error('type_to_size(): unknown type: ${e.table.type_symbol(typ).str()}')
 			return -1
 		}
 	}

--- a/vlib/v/eval/gen/infix_gen.v
+++ b/vlib/v/eval/gen/infix_gen.v
@@ -13,7 +13,7 @@ fn(e Eval)infix_expr(left Object,right Object,op token.Kind,expecting ast.Type)O
 	footer = "else{e.error('unknown infix expression: \$op')}}return empty // should e.error before this anyway
 }
 "
-	uk_expect_footer = "else{e.error('unknown infix expectation: \${e.table.get_type_symbol(expecting).str()}')}}"
+	uk_expect_footer = "else{e.error('unknown infix expectation: \${e.table.type_symbol(expecting).str()}')}}"
 	comparison       = {
 		'gt': '>'
 		'lt': '<'

--- a/vlib/v/eval/gen/infix_gen.v
+++ b/vlib/v/eval/gen/infix_gen.v
@@ -13,7 +13,7 @@ fn(e Eval)infix_expr(left Object,right Object,op token.Kind,expecting ast.Type)O
 	footer = "else{e.error('unknown infix expression: \$op')}}return empty // should e.error before this anyway
 }
 "
-	uk_expect_footer = "else{e.error('unknown infix expectation: \${e.table.type_symbol(expecting).str()}')}}"
+	uk_expect_footer = "else{e.error('unknown infix expectation: \${e.table.sym(expecting).str()}')}}"
 	comparison       = {
 		'gt': '>'
 		'lt': '<'

--- a/vlib/v/eval/infix.v
+++ b/vlib/v/eval/infix.v
@@ -262,7 +262,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -277,7 +277,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -292,7 +292,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -307,7 +307,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -322,7 +322,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -344,7 +344,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -359,7 +359,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -374,7 +374,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -389,7 +389,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -404,7 +404,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -426,7 +426,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -441,7 +441,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -456,7 +456,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -471,7 +471,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -486,7 +486,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -508,7 +508,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -523,7 +523,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -538,7 +538,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -553,7 +553,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -568,7 +568,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -590,7 +590,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -605,7 +605,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -620,7 +620,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -635,7 +635,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -650,7 +650,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -679,7 +679,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -694,7 +694,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -709,7 +709,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -724,7 +724,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -739,7 +739,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -761,7 +761,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -776,7 +776,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -791,7 +791,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -806,7 +806,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -821,7 +821,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -843,7 +843,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -858,7 +858,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -873,7 +873,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -888,7 +888,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -903,7 +903,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -925,7 +925,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -940,7 +940,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -955,7 +955,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -970,7 +970,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -985,7 +985,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -1007,7 +1007,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1022,7 +1022,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -1037,7 +1037,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1052,7 +1052,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1067,7 +1067,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -1096,7 +1096,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1111,7 +1111,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -1126,7 +1126,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1141,7 +1141,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1156,7 +1156,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -1178,7 +1178,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1193,7 +1193,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -1208,7 +1208,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1223,7 +1223,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1238,7 +1238,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -1260,7 +1260,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1275,7 +1275,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -1290,7 +1290,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1305,7 +1305,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1320,7 +1320,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -1342,7 +1342,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1357,7 +1357,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -1372,7 +1372,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1387,7 +1387,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1402,7 +1402,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -1424,7 +1424,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1439,7 +1439,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -1454,7 +1454,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1469,7 +1469,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1484,7 +1484,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -1513,7 +1513,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1528,7 +1528,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -1543,7 +1543,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1558,7 +1558,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1573,7 +1573,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -1595,7 +1595,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1610,7 +1610,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -1625,7 +1625,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1640,7 +1640,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1655,7 +1655,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -1677,7 +1677,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1692,7 +1692,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -1707,7 +1707,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1722,7 +1722,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1737,7 +1737,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -1759,7 +1759,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1774,7 +1774,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -1789,7 +1789,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1804,7 +1804,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1819,7 +1819,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -1841,7 +1841,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1856,7 +1856,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Float {
@@ -1871,7 +1871,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1886,7 +1886,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1901,7 +1901,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -1928,7 +1928,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) >> i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1941,7 +1941,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) >> i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1954,7 +1954,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) >> i64(right))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -1974,7 +1974,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) >> i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1987,7 +1987,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) >> i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -2000,7 +2000,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) >> i64(right))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -2020,7 +2020,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left) >> i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -2033,7 +2033,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left) >> i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -2046,7 +2046,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left) >> i64(right))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -2073,7 +2073,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) << i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -2086,7 +2086,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) << i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -2099,7 +2099,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) << i64(right))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -2119,7 +2119,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) << i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -2132,7 +2132,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) << i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -2145,7 +2145,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) << i64(right))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {
@@ -2165,7 +2165,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left) << i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						Uint {
@@ -2178,7 +2178,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left) << i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						i64 {
@@ -2191,7 +2191,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left) << i64(right))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.get_type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
 							}
 						}
 						else {

--- a/vlib/v/eval/infix.v
+++ b/vlib/v/eval/infix.v
@@ -262,7 +262,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -277,7 +277,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -292,7 +292,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -307,7 +307,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -322,7 +322,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -344,7 +344,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -359,7 +359,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -374,7 +374,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -389,7 +389,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -404,7 +404,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -426,7 +426,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -441,7 +441,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -456,7 +456,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -471,7 +471,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -486,7 +486,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -508,7 +508,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -523,7 +523,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -538,7 +538,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -553,7 +553,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -568,7 +568,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -590,7 +590,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -605,7 +605,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -620,7 +620,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -635,7 +635,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -650,7 +650,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -679,7 +679,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -694,7 +694,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -709,7 +709,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -724,7 +724,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -739,7 +739,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -761,7 +761,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -776,7 +776,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -791,7 +791,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -806,7 +806,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -821,7 +821,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -843,7 +843,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -858,7 +858,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -873,7 +873,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -888,7 +888,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -903,7 +903,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -925,7 +925,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -940,7 +940,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -955,7 +955,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -970,7 +970,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -985,7 +985,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -1007,7 +1007,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1022,7 +1022,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -1037,7 +1037,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1052,7 +1052,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1067,7 +1067,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) * f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -1096,7 +1096,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1111,7 +1111,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -1126,7 +1126,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1141,7 +1141,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1156,7 +1156,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -1178,7 +1178,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1193,7 +1193,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -1208,7 +1208,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1223,7 +1223,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1238,7 +1238,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -1260,7 +1260,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1275,7 +1275,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -1290,7 +1290,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1305,7 +1305,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1320,7 +1320,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -1342,7 +1342,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1357,7 +1357,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -1372,7 +1372,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1387,7 +1387,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1402,7 +1402,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -1424,7 +1424,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1439,7 +1439,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -1454,7 +1454,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1469,7 +1469,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1484,7 +1484,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -1513,7 +1513,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1528,7 +1528,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -1543,7 +1543,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1558,7 +1558,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1573,7 +1573,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -1595,7 +1595,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1610,7 +1610,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -1625,7 +1625,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1640,7 +1640,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1655,7 +1655,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -1677,7 +1677,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1692,7 +1692,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -1707,7 +1707,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1722,7 +1722,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1737,7 +1737,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left.val) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -1759,7 +1759,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1774,7 +1774,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -1789,7 +1789,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1804,7 +1804,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1819,7 +1819,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -1841,7 +1841,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1856,7 +1856,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Float {
@@ -1871,7 +1871,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right.val))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1886,7 +1886,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						f64 {
@@ -1901,7 +1901,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 							} else if expecting == ast.float_literal_type_idx {
 								return f64(f64(left) + f64(right))
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -1928,7 +1928,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) >> i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1941,7 +1941,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) >> i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -1954,7 +1954,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) >> i64(right))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -1974,7 +1974,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) >> i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -1987,7 +1987,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) >> i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -2000,7 +2000,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) >> i64(right))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -2020,7 +2020,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left) >> i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -2033,7 +2033,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left) >> i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -2046,7 +2046,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left) >> i64(right))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -2073,7 +2073,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) << i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -2086,7 +2086,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) << i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -2099,7 +2099,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) << i64(right))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -2119,7 +2119,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) << i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -2132,7 +2132,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) << i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -2145,7 +2145,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left.val) << i64(right))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {
@@ -2165,7 +2165,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left) << i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						Uint {
@@ -2178,7 +2178,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left) << i64(right.val))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						i64 {
@@ -2191,7 +2191,7 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 									return i64(i64(left) << i64(right))
 								}
 							} else {
-								e.error('unknown infix expectation: ${e.table.type_symbol(expecting).str()}')
+								e.error('unknown infix expectation: ${e.table.sym(expecting).str()}')
 							}
 						}
 						else {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -244,7 +244,7 @@ pub fn (mut f Fmt) short_module(name string) string {
 //=== Import-related methods ===//
 
 pub fn (mut f Fmt) mark_types_import_as_used(typ ast.Type) {
-	sym := f.table.type_symbol(typ)
+	sym := f.table.sym(typ)
 	if sym.info is ast.Map {
 		map_info := sym.map_info()
 		f.mark_types_import_as_used(map_info.key_type)
@@ -1184,7 +1184,7 @@ pub fn (mut f Fmt) sql_stmt(node ast.SqlStmt) {
 }
 
 pub fn (mut f Fmt) sql_stmt_line(node ast.SqlStmtLine) {
-	table_name := util.strip_mod_name(f.table.type_symbol(node.table_expr.typ).name)
+	table_name := util.strip_mod_name(f.table.sym(node.table_expr.typ).name)
 	f.mark_types_import_as_used(node.table_expr.typ)
 	f.write('\t')
 	match node.kind {
@@ -1245,7 +1245,7 @@ pub fn (mut f Fmt) fn_type_decl(node ast.FnTypeDecl) {
 	if node.is_pub {
 		f.write('pub ')
 	}
-	typ_sym := f.table.type_symbol(node.typ)
+	typ_sym := f.table.sym(node.typ)
 	fn_typ_info := typ_sym.info as ast.FnType
 	fn_info := fn_typ_info.func
 	fn_name := f.no_cur_mod(node.name)
@@ -1621,7 +1621,7 @@ fn (mut f Fmt) write_generic_call_if_require(node ast.CallExpr) {
 		f.write('<')
 		for i, concrete_type in node.concrete_types {
 			mut name := f.table.type_to_str_using_aliases(concrete_type, f.mod2alias)
-			tsym := f.table.type_symbol(concrete_type)
+			tsym := f.table.sym(concrete_type)
 			if tsym.language != .js && !tsym.name.starts_with('JS.') {
 				name = f.short_module(name)
 			} else if tsym.language == .js && !tsym.name.starts_with('JS.') {
@@ -1675,7 +1675,7 @@ pub fn (mut f Fmt) cast_expr(node ast.CastExpr) {
 }
 
 pub fn (mut f Fmt) chan_init(mut node ast.ChanInit) {
-	info := f.table.type_symbol(node.typ).chan_info()
+	info := f.table.sym(node.typ).chan_info()
 	if node.elem_type == 0 && node.typ > 0 {
 		node.elem_type = info.elem_type
 	}
@@ -2081,7 +2081,7 @@ pub fn (mut f Fmt) lock_expr(node ast.LockExpr) {
 pub fn (mut f Fmt) map_init(node ast.MapInit) {
 	if node.keys.len == 0 {
 		if node.typ > ast.void_type {
-			sym := f.table.type_symbol(node.typ)
+			sym := f.table.sym(node.typ)
 			info := sym.info as ast.Map
 			f.mark_types_import_as_used(info.key_type)
 			f.write(f.table.type_to_str_using_aliases(node.typ, f.mod2alias))
@@ -2353,7 +2353,7 @@ pub fn (mut f Fmt) sql_expr(node ast.SqlExpr) {
 	f.expr(node.db_expr)
 	f.writeln(' {')
 	f.write('\tselect ')
-	table_name := util.strip_mod_name(f.table.type_symbol(node.table_expr.typ).name)
+	table_name := util.strip_mod_name(f.table.sym(node.table_expr.typ).name)
 	if node.is_count {
 		f.write('count ')
 	} else {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -244,7 +244,7 @@ pub fn (mut f Fmt) short_module(name string) string {
 //=== Import-related methods ===//
 
 pub fn (mut f Fmt) mark_types_import_as_used(typ ast.Type) {
-	sym := f.table.get_type_symbol(typ)
+	sym := f.table.type_symbol(typ)
 	if sym.info is ast.Map {
 		map_info := sym.map_info()
 		f.mark_types_import_as_used(map_info.key_type)
@@ -1184,7 +1184,7 @@ pub fn (mut f Fmt) sql_stmt(node ast.SqlStmt) {
 }
 
 pub fn (mut f Fmt) sql_stmt_line(node ast.SqlStmtLine) {
-	table_name := util.strip_mod_name(f.table.get_type_symbol(node.table_expr.typ).name)
+	table_name := util.strip_mod_name(f.table.type_symbol(node.table_expr.typ).name)
 	f.mark_types_import_as_used(node.table_expr.typ)
 	f.write('\t')
 	match node.kind {
@@ -1245,7 +1245,7 @@ pub fn (mut f Fmt) fn_type_decl(node ast.FnTypeDecl) {
 	if node.is_pub {
 		f.write('pub ')
 	}
-	typ_sym := f.table.get_type_symbol(node.typ)
+	typ_sym := f.table.type_symbol(node.typ)
 	fn_typ_info := typ_sym.info as ast.FnType
 	fn_info := fn_typ_info.func
 	fn_name := f.no_cur_mod(node.name)
@@ -1621,7 +1621,7 @@ fn (mut f Fmt) write_generic_call_if_require(node ast.CallExpr) {
 		f.write('<')
 		for i, concrete_type in node.concrete_types {
 			mut name := f.table.type_to_str_using_aliases(concrete_type, f.mod2alias)
-			tsym := f.table.get_type_symbol(concrete_type)
+			tsym := f.table.type_symbol(concrete_type)
 			if tsym.language != .js && !tsym.name.starts_with('JS.') {
 				name = f.short_module(name)
 			} else if tsym.language == .js && !tsym.name.starts_with('JS.') {
@@ -1675,7 +1675,7 @@ pub fn (mut f Fmt) cast_expr(node ast.CastExpr) {
 }
 
 pub fn (mut f Fmt) chan_init(mut node ast.ChanInit) {
-	info := f.table.get_type_symbol(node.typ).chan_info()
+	info := f.table.type_symbol(node.typ).chan_info()
 	if node.elem_type == 0 && node.typ > 0 {
 		node.elem_type = info.elem_type
 	}
@@ -2081,7 +2081,7 @@ pub fn (mut f Fmt) lock_expr(node ast.LockExpr) {
 pub fn (mut f Fmt) map_init(node ast.MapInit) {
 	if node.keys.len == 0 {
 		if node.typ > ast.void_type {
-			sym := f.table.get_type_symbol(node.typ)
+			sym := f.table.type_symbol(node.typ)
 			info := sym.info as ast.Map
 			f.mark_types_import_as_used(info.key_type)
 			f.write(f.table.type_to_str_using_aliases(node.typ, f.mod2alias))
@@ -2353,7 +2353,7 @@ pub fn (mut f Fmt) sql_expr(node ast.SqlExpr) {
 	f.expr(node.db_expr)
 	f.writeln(' {')
 	f.write('\tselect ')
-	table_name := util.strip_mod_name(f.table.get_type_symbol(node.table_expr.typ).name)
+	table_name := util.strip_mod_name(f.table.type_symbol(node.table_expr.typ).name)
 	if node.is_count {
 		f.write('count ')
 	} else {

--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -179,7 +179,7 @@ pub fn (mut f Fmt) struct_init(node ast.StructInit) {
 		f.is_struct_init = struct_init_save
 	}
 
-	type_sym := f.table.get_type_symbol(node.typ)
+	type_sym := f.table.type_symbol(node.typ)
 	// f.write('<old name: $type_sym.name>')
 	mut name := type_sym.name
 	if !name.starts_with('C.') && !name.starts_with('JS.') {

--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -179,7 +179,7 @@ pub fn (mut f Fmt) struct_init(node ast.StructInit) {
 		f.is_struct_init = struct_init_save
 	}
 
-	type_sym := f.table.type_symbol(node.typ)
+	type_sym := f.table.sym(node.typ)
 	// f.write('<old name: $type_sym.name>')
 	mut name := type_sym.name
 	if !name.starts_with('C.') && !name.starts_with('JS.') {

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -279,8 +279,8 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 	// println('filter s="$s"')
 	ret_typ := g.typ(node.return_type)
 	// inp_typ := g.typ(node.receiver_type)
-	ret_sym := g.table.get_type_symbol(node.return_type)
-	inp_sym := g.table.get_type_symbol(node.receiver_type)
+	ret_sym := g.table.type_symbol(node.return_type)
+	inp_sym := g.table.type_symbol(node.receiver_type)
 	ret_info := ret_sym.info as ast.Array
 	ret_elem_type := g.typ(ret_info.elem_type)
 	inp_info := inp_sym.info as ast.Array
@@ -321,7 +321,7 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 				g.write('${c_name(expr.name)}(it)')
 			} else if expr.kind == .variable {
 				var_info := expr.var_info()
-				sym := g.table.get_type_symbol(var_info.typ)
+				sym := g.table.type_symbol(var_info.typ)
 				if sym.kind == .function {
 					g.write('${c_name(expr.name)}(it)')
 				} else {
@@ -367,7 +367,7 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 // `users.sort(a.age < b.age)`
 fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 	// println('filter s="$s"')
-	rec_sym := g.table.get_type_symbol(node.receiver_type)
+	rec_sym := g.table.type_symbol(node.receiver_type)
 	if rec_sym.kind != .array {
 		println(node.name)
 		println(g.typ(node.receiver_type))
@@ -479,7 +479,7 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 	s_ends_with_ln := s.ends_with('\n')
 	s = s.trim_space()
 	// println('filter s="$s"')
-	sym := g.table.get_type_symbol(node.return_type)
+	sym := g.table.type_symbol(node.return_type)
 	if sym.kind != .array {
 		verror('filter() requires an array')
 	}
@@ -519,7 +519,7 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 				g.write('${c_name(expr.name)}(it)')
 			} else if expr.kind == .variable {
 				var_info := expr.var_info()
-				sym_t := g.table.get_type_symbol(var_info.typ)
+				sym_t := g.table.type_symbol(var_info.typ)
 				if sym_t.kind == .function {
 					g.write('${c_name(expr.name)}(it)')
 				} else {
@@ -564,10 +564,10 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 
 // `nums.insert(0, 2)` `nums.insert(0, [2,3,4])`
 fn (mut g Gen) gen_array_insert(node ast.CallExpr) {
-	left_sym := g.table.get_type_symbol(node.left_type)
+	left_sym := g.table.type_symbol(node.left_type)
 	left_info := left_sym.info as ast.Array
 	elem_type_str := g.typ(left_info.elem_type)
-	arg2_sym := g.table.get_type_symbol(node.args[1].typ)
+	arg2_sym := g.table.type_symbol(node.args[1].typ)
 	is_arg2_array := arg2_sym.kind == .array && node.args[1].typ == node.left_type
 	noscan := g.check_noscan(left_info.elem_type)
 	if is_arg2_array {
@@ -599,10 +599,10 @@ fn (mut g Gen) gen_array_insert(node ast.CallExpr) {
 
 // `nums.prepend(2)` `nums.prepend([2,3,4])`
 fn (mut g Gen) gen_array_prepend(node ast.CallExpr) {
-	left_sym := g.table.get_type_symbol(node.left_type)
+	left_sym := g.table.type_symbol(node.left_type)
 	left_info := left_sym.info as ast.Array
 	elem_type_str := g.typ(left_info.elem_type)
-	arg_sym := g.table.get_type_symbol(node.args[0].typ)
+	arg_sym := g.table.type_symbol(node.args[0].typ)
 	is_arg_array := arg_sym.kind == .array && node.args[0].typ == node.left_type
 	noscan := g.check_noscan(left_info.elem_type)
 	if is_arg_array {
@@ -625,7 +625,7 @@ fn (mut g Gen) gen_array_prepend(node ast.CallExpr) {
 }
 
 fn (mut g Gen) get_array_contains_method(typ ast.Type) string {
-	t := g.table.get_final_type_symbol(g.unwrap_generic(typ).set_nr_muls(0)).idx
+	t := g.table.final_type_symbol(g.unwrap_generic(typ).set_nr_muls(0)).idx
 	g.array_contains_types << t
 	return g.typ(t) + '_contains'
 }
@@ -633,8 +633,8 @@ fn (mut g Gen) get_array_contains_method(typ ast.Type) string {
 fn (mut g Gen) gen_array_contains_methods() {
 	mut done := []ast.Type{}
 	for t in g.array_contains_types {
-		left_final_sym := g.table.get_final_type_symbol(t)
-		if left_final_sym.idx in done || g.table.get_type_symbol(t).has_method('contains') {
+		left_final_sym := g.table.final_type_symbol(t)
+		if left_final_sym.idx in done || g.table.type_symbol(t).has_method('contains') {
 			continue
 		}
 		done << t
@@ -642,7 +642,7 @@ fn (mut g Gen) gen_array_contains_methods() {
 		fn_name := '${left_type_str}_contains'
 		left_info := left_final_sym.info as ast.Array
 		mut elem_type_str := g.typ(left_info.elem_type)
-		elem_sym := g.table.get_type_symbol(left_info.elem_type)
+		elem_sym := g.table.type_symbol(left_info.elem_type)
 		if elem_sym.kind == .function {
 			left_type_str = 'Array_voidptr'
 			elem_type_str = 'voidptr'
@@ -708,16 +708,16 @@ fn (mut g Gen) get_array_index_method(typ ast.Type) string {
 fn (mut g Gen) gen_array_index_methods() {
 	mut done := []ast.Type{}
 	for t in g.array_index_types {
-		if t in done || g.table.get_type_symbol(t).has_method('index') {
+		if t in done || g.table.type_symbol(t).has_method('index') {
 			continue
 		}
 		done << t
-		final_left_sym := g.table.get_final_type_symbol(t)
+		final_left_sym := g.table.final_type_symbol(t)
 		mut left_type_str := g.typ(t)
 		fn_name := '${left_type_str}_index'
 		info := final_left_sym.info as ast.Array
 		mut elem_type_str := g.typ(info.elem_type)
-		elem_sym := g.table.get_type_symbol(info.elem_type)
+		elem_sym := g.table.type_symbol(info.elem_type)
 		if elem_sym.kind == .function {
 			left_type_str = 'Array_voidptr'
 			elem_type_str = 'voidptr'
@@ -775,11 +775,11 @@ fn (mut g Gen) gen_array_index(node ast.CallExpr) {
 }
 
 fn (mut g Gen) gen_array_wait(node ast.CallExpr) {
-	arr := g.table.get_type_symbol(node.receiver_type)
+	arr := g.table.type_symbol(node.receiver_type)
 	thread_type := arr.array_info().elem_type
-	thread_sym := g.table.get_type_symbol(thread_type)
+	thread_sym := g.table.type_symbol(thread_type)
 	thread_ret_type := thread_sym.thread_info().return_type
-	eltyp := g.table.get_type_symbol(thread_ret_type).cname
+	eltyp := g.table.type_symbol(thread_ret_type).cname
 	fn_name := g.register_thread_array_wait_call(eltyp)
 	g.write('${fn_name}(')
 	g.expr(node.left)
@@ -791,7 +791,7 @@ fn (mut g Gen) gen_array_any(node ast.CallExpr) {
 	mut s := g.go_before_stmt(0)
 	s_ends_with_ln := s.ends_with('\n')
 	s = s.trim_space()
-	sym := g.table.get_type_symbol(node.left_type)
+	sym := g.table.type_symbol(node.left_type)
 	info := sym.info as ast.Array
 	// styp := g.typ(node.return_type)
 	elem_type_str := g.typ(info.elem_type)
@@ -826,7 +826,7 @@ fn (mut g Gen) gen_array_any(node ast.CallExpr) {
 				g.write('${c_name(expr.name)}(it)')
 			} else if expr.kind == .variable {
 				var_info := expr.var_info()
-				sym_t := g.table.get_type_symbol(var_info.typ)
+				sym_t := g.table.type_symbol(var_info.typ)
 				if sym_t.kind == .function {
 					g.write('${c_name(expr.name)}(it)')
 				} else {
@@ -875,7 +875,7 @@ fn (mut g Gen) gen_array_all(node ast.CallExpr) {
 	mut s := g.go_before_stmt(0)
 	s_ends_with_ln := s.ends_with('\n')
 	s = s.trim_space()
-	sym := g.table.get_type_symbol(node.left_type)
+	sym := g.table.type_symbol(node.left_type)
 	info := sym.info as ast.Array
 	// styp := g.typ(node.return_type)
 	elem_type_str := g.typ(info.elem_type)
@@ -911,7 +911,7 @@ fn (mut g Gen) gen_array_all(node ast.CallExpr) {
 				g.write('${c_name(expr.name)}(it)')
 			} else if expr.kind == .variable {
 				var_info := expr.var_info()
-				sym_t := g.table.get_type_symbol(var_info.typ)
+				sym_t := g.table.type_symbol(var_info.typ)
 				if sym_t.kind == .function {
 					g.write('${c_name(expr.name)}(it)')
 				} else {

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -279,8 +279,8 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 	// println('filter s="$s"')
 	ret_typ := g.typ(node.return_type)
 	// inp_typ := g.typ(node.receiver_type)
-	ret_sym := g.table.type_symbol(node.return_type)
-	inp_sym := g.table.type_symbol(node.receiver_type)
+	ret_sym := g.table.sym(node.return_type)
+	inp_sym := g.table.sym(node.receiver_type)
 	ret_info := ret_sym.info as ast.Array
 	ret_elem_type := g.typ(ret_info.elem_type)
 	inp_info := inp_sym.info as ast.Array
@@ -321,7 +321,7 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 				g.write('${c_name(expr.name)}(it)')
 			} else if expr.kind == .variable {
 				var_info := expr.var_info()
-				sym := g.table.type_symbol(var_info.typ)
+				sym := g.table.sym(var_info.typ)
 				if sym.kind == .function {
 					g.write('${c_name(expr.name)}(it)')
 				} else {
@@ -367,7 +367,7 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 // `users.sort(a.age < b.age)`
 fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 	// println('filter s="$s"')
-	rec_sym := g.table.type_symbol(node.receiver_type)
+	rec_sym := g.table.sym(node.receiver_type)
 	if rec_sym.kind != .array {
 		println(node.name)
 		println(g.typ(node.receiver_type))
@@ -479,7 +479,7 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 	s_ends_with_ln := s.ends_with('\n')
 	s = s.trim_space()
 	// println('filter s="$s"')
-	sym := g.table.type_symbol(node.return_type)
+	sym := g.table.sym(node.return_type)
 	if sym.kind != .array {
 		verror('filter() requires an array')
 	}
@@ -519,7 +519,7 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 				g.write('${c_name(expr.name)}(it)')
 			} else if expr.kind == .variable {
 				var_info := expr.var_info()
-				sym_t := g.table.type_symbol(var_info.typ)
+				sym_t := g.table.sym(var_info.typ)
 				if sym_t.kind == .function {
 					g.write('${c_name(expr.name)}(it)')
 				} else {
@@ -564,10 +564,10 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 
 // `nums.insert(0, 2)` `nums.insert(0, [2,3,4])`
 fn (mut g Gen) gen_array_insert(node ast.CallExpr) {
-	left_sym := g.table.type_symbol(node.left_type)
+	left_sym := g.table.sym(node.left_type)
 	left_info := left_sym.info as ast.Array
 	elem_type_str := g.typ(left_info.elem_type)
-	arg2_sym := g.table.type_symbol(node.args[1].typ)
+	arg2_sym := g.table.sym(node.args[1].typ)
 	is_arg2_array := arg2_sym.kind == .array && node.args[1].typ == node.left_type
 	noscan := g.check_noscan(left_info.elem_type)
 	if is_arg2_array {
@@ -599,10 +599,10 @@ fn (mut g Gen) gen_array_insert(node ast.CallExpr) {
 
 // `nums.prepend(2)` `nums.prepend([2,3,4])`
 fn (mut g Gen) gen_array_prepend(node ast.CallExpr) {
-	left_sym := g.table.type_symbol(node.left_type)
+	left_sym := g.table.sym(node.left_type)
 	left_info := left_sym.info as ast.Array
 	elem_type_str := g.typ(left_info.elem_type)
-	arg_sym := g.table.type_symbol(node.args[0].typ)
+	arg_sym := g.table.sym(node.args[0].typ)
 	is_arg_array := arg_sym.kind == .array && node.args[0].typ == node.left_type
 	noscan := g.check_noscan(left_info.elem_type)
 	if is_arg_array {
@@ -625,7 +625,7 @@ fn (mut g Gen) gen_array_prepend(node ast.CallExpr) {
 }
 
 fn (mut g Gen) get_array_contains_method(typ ast.Type) string {
-	t := g.table.final_type_symbol(g.unwrap_generic(typ).set_nr_muls(0)).idx
+	t := g.table.final_sym(g.unwrap_generic(typ).set_nr_muls(0)).idx
 	g.array_contains_types << t
 	return g.typ(t) + '_contains'
 }
@@ -633,8 +633,8 @@ fn (mut g Gen) get_array_contains_method(typ ast.Type) string {
 fn (mut g Gen) gen_array_contains_methods() {
 	mut done := []ast.Type{}
 	for t in g.array_contains_types {
-		left_final_sym := g.table.final_type_symbol(t)
-		if left_final_sym.idx in done || g.table.type_symbol(t).has_method('contains') {
+		left_final_sym := g.table.final_sym(t)
+		if left_final_sym.idx in done || g.table.sym(t).has_method('contains') {
 			continue
 		}
 		done << t
@@ -642,7 +642,7 @@ fn (mut g Gen) gen_array_contains_methods() {
 		fn_name := '${left_type_str}_contains'
 		left_info := left_final_sym.info as ast.Array
 		mut elem_type_str := g.typ(left_info.elem_type)
-		elem_sym := g.table.type_symbol(left_info.elem_type)
+		elem_sym := g.table.sym(left_info.elem_type)
 		if elem_sym.kind == .function {
 			left_type_str = 'Array_voidptr'
 			elem_type_str = 'voidptr'
@@ -708,16 +708,16 @@ fn (mut g Gen) get_array_index_method(typ ast.Type) string {
 fn (mut g Gen) gen_array_index_methods() {
 	mut done := []ast.Type{}
 	for t in g.array_index_types {
-		if t in done || g.table.type_symbol(t).has_method('index') {
+		if t in done || g.table.sym(t).has_method('index') {
 			continue
 		}
 		done << t
-		final_left_sym := g.table.final_type_symbol(t)
+		final_left_sym := g.table.final_sym(t)
 		mut left_type_str := g.typ(t)
 		fn_name := '${left_type_str}_index'
 		info := final_left_sym.info as ast.Array
 		mut elem_type_str := g.typ(info.elem_type)
-		elem_sym := g.table.type_symbol(info.elem_type)
+		elem_sym := g.table.sym(info.elem_type)
 		if elem_sym.kind == .function {
 			left_type_str = 'Array_voidptr'
 			elem_type_str = 'voidptr'
@@ -775,11 +775,11 @@ fn (mut g Gen) gen_array_index(node ast.CallExpr) {
 }
 
 fn (mut g Gen) gen_array_wait(node ast.CallExpr) {
-	arr := g.table.type_symbol(node.receiver_type)
+	arr := g.table.sym(node.receiver_type)
 	thread_type := arr.array_info().elem_type
-	thread_sym := g.table.type_symbol(thread_type)
+	thread_sym := g.table.sym(thread_type)
 	thread_ret_type := thread_sym.thread_info().return_type
-	eltyp := g.table.type_symbol(thread_ret_type).cname
+	eltyp := g.table.sym(thread_ret_type).cname
 	fn_name := g.register_thread_array_wait_call(eltyp)
 	g.write('${fn_name}(')
 	g.expr(node.left)
@@ -791,7 +791,7 @@ fn (mut g Gen) gen_array_any(node ast.CallExpr) {
 	mut s := g.go_before_stmt(0)
 	s_ends_with_ln := s.ends_with('\n')
 	s = s.trim_space()
-	sym := g.table.type_symbol(node.left_type)
+	sym := g.table.sym(node.left_type)
 	info := sym.info as ast.Array
 	// styp := g.typ(node.return_type)
 	elem_type_str := g.typ(info.elem_type)
@@ -826,7 +826,7 @@ fn (mut g Gen) gen_array_any(node ast.CallExpr) {
 				g.write('${c_name(expr.name)}(it)')
 			} else if expr.kind == .variable {
 				var_info := expr.var_info()
-				sym_t := g.table.type_symbol(var_info.typ)
+				sym_t := g.table.sym(var_info.typ)
 				if sym_t.kind == .function {
 					g.write('${c_name(expr.name)}(it)')
 				} else {
@@ -875,7 +875,7 @@ fn (mut g Gen) gen_array_all(node ast.CallExpr) {
 	mut s := g.go_before_stmt(0)
 	s_ends_with_ln := s.ends_with('\n')
 	s = s.trim_space()
-	sym := g.table.type_symbol(node.left_type)
+	sym := g.table.sym(node.left_type)
 	info := sym.info as ast.Array
 	// styp := g.typ(node.return_type)
 	elem_type_str := g.typ(info.elem_type)
@@ -911,7 +911,7 @@ fn (mut g Gen) gen_array_all(node ast.CallExpr) {
 				g.write('${c_name(expr.name)}(it)')
 			} else if expr.kind == .variable {
 				var_info := expr.var_info()
-				sym_t := g.table.type_symbol(var_info.typ)
+				sym_t := g.table.sym(var_info.typ)
 				if sym_t.kind == .function {
 					g.write('${c_name(expr.name)}(it)')
 				} else {

--- a/vlib/v/gen/c/assert.v
+++ b/vlib/v/gen/c/assert.v
@@ -69,7 +69,7 @@ fn (mut g Gen) assert_subexpression_to_ctemp(expr ast.Expr, expr_type ast.Type) 
 		}
 		ast.SelectorExpr {
 			if expr.expr is ast.CallExpr {
-				sym := g.table.final_type_symbol(g.unwrap_generic(expr.expr.return_type))
+				sym := g.table.final_sym(g.unwrap_generic(expr.expr.return_type))
 				if sym.kind == .struct_ {
 					if (sym.info as ast.Struct).is_union {
 						return c.unsupported_ctemp_assert_transform
@@ -149,7 +149,7 @@ fn (mut g Gen) gen_assert_single_expr(expr ast.Expr, typ ast.Type) {
 			}
 		}
 		ast.TypeNode {
-			sym := g.table.type_symbol(g.unwrap_generic(typ))
+			sym := g.table.sym(g.unwrap_generic(typ))
 			g.write(ctoslit('$sym.name'))
 		}
 		else {

--- a/vlib/v/gen/c/assert.v
+++ b/vlib/v/gen/c/assert.v
@@ -69,7 +69,7 @@ fn (mut g Gen) assert_subexpression_to_ctemp(expr ast.Expr, expr_type ast.Type) 
 		}
 		ast.SelectorExpr {
 			if expr.expr is ast.CallExpr {
-				sym := g.table.get_final_type_symbol(g.unwrap_generic(expr.expr.return_type))
+				sym := g.table.final_type_symbol(g.unwrap_generic(expr.expr.return_type))
 				if sym.kind == .struct_ {
 					if (sym.info as ast.Struct).is_union {
 						return c.unsupported_ctemp_assert_transform
@@ -149,7 +149,7 @@ fn (mut g Gen) gen_assert_single_expr(expr ast.Expr, typ ast.Type) {
 			}
 		}
 		ast.TypeNode {
-			sym := g.table.get_type_symbol(g.unwrap_generic(typ))
+			sym := g.table.type_symbol(g.unwrap_generic(typ))
 			g.write(ctoslit('$sym.name'))
 		}
 		else {

--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -19,7 +19,7 @@ fn (mut g Gen) gen_equality_fns() {
 		if needed_typ in g.generated_eq_fns {
 			continue
 		}
-		sym := g.table.get_type_symbol(needed_typ)
+		sym := g.table.type_symbol(needed_typ)
 		match sym.kind {
 			.sum_type {
 				g.gen_sumtype_equality_fn(needed_typ)
@@ -182,7 +182,7 @@ fn (mut g Gen) gen_alias_equality_fn(left_type ast.Type) string {
 
 	mut fn_builder := strings.new_builder(512)
 	fn_builder.writeln('static bool ${ptr_styp}_alias_eq($ptr_styp a, $ptr_styp b) {')
-	sym := g.table.get_type_symbol(info.parent_type)
+	sym := g.table.type_symbol(info.parent_type)
 	if sym.kind == .string {
 		fn_builder.writeln('\treturn string__eq(a, b);')
 	} else if sym.kind == .sum_type && !left.typ.is_ptr() {

--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -19,7 +19,7 @@ fn (mut g Gen) gen_equality_fns() {
 		if needed_typ in g.generated_eq_fns {
 			continue
 		}
-		sym := g.table.type_symbol(needed_typ)
+		sym := g.table.sym(needed_typ)
 		match sym.kind {
 			.sum_type {
 				g.gen_sumtype_equality_fn(needed_typ)
@@ -182,7 +182,7 @@ fn (mut g Gen) gen_alias_equality_fn(left_type ast.Type) string {
 
 	mut fn_builder := strings.new_builder(512)
 	fn_builder.writeln('static bool ${ptr_styp}_alias_eq($ptr_styp a, $ptr_styp b) {')
-	sym := g.table.type_symbol(info.parent_type)
+	sym := g.table.sym(info.parent_type)
 	if sym.kind == .string {
 		fn_builder.writeln('\treturn string__eq(a, b);')
 	} else if sym.kind == .sum_type && !left.typ.is_ptr() {

--- a/vlib/v/gen/c/auto_free_methods.v
+++ b/vlib/v/gen/c/auto_free_methods.v
@@ -7,11 +7,11 @@ import strings
 
 fn (mut g Gen) gen_free_method_for_type(typ ast.Type) string {
 	styp := g.typ(typ).replace('*', '')
-	mut sym := g.table.type_symbol(g.unwrap_generic(typ))
+	mut sym := g.table.sym(g.unwrap_generic(typ))
 	mut fn_name := styp_to_free_fn_name(styp)
 	if mut sym.info is ast.Alias {
 		if sym.info.is_import {
-			sym = g.table.type_symbol(sym.info.parent_type)
+			sym = g.table.sym(sym.info.parent_type)
 		}
 	}
 
@@ -44,7 +44,7 @@ fn (mut g Gen) gen_free_for_struct(info ast.Struct, styp string, fn_name string)
 	}
 	fn_builder.writeln('void ${fn_name}($styp* it) {')
 	for field in info.fields {
-		sym := g.table.type_symbol(g.unwrap_generic(field.typ))
+		sym := g.table.sym(g.unwrap_generic(field.typ))
 
 		if sym.kind !in [.string, .array, .map, .struct_] {
 			continue
@@ -68,7 +68,7 @@ fn (mut g Gen) gen_free_for_array(info ast.Array, styp string, fn_name string) {
 	}
 	fn_builder.writeln('void ${fn_name}($styp* it) {')
 
-	sym := g.table.type_symbol(g.unwrap_generic(info.elem_type))
+	sym := g.table.sym(g.unwrap_generic(info.elem_type))
 	if sym.kind in [.string, .array, .map, .struct_] {
 		fn_builder.writeln('\tfor (int i = 0; i < it->len; i++) {')
 

--- a/vlib/v/gen/c/auto_free_methods.v
+++ b/vlib/v/gen/c/auto_free_methods.v
@@ -7,11 +7,11 @@ import strings
 
 fn (mut g Gen) gen_free_method_for_type(typ ast.Type) string {
 	styp := g.typ(typ).replace('*', '')
-	mut sym := g.table.get_type_symbol(g.unwrap_generic(typ))
+	mut sym := g.table.type_symbol(g.unwrap_generic(typ))
 	mut fn_name := styp_to_free_fn_name(styp)
 	if mut sym.info is ast.Alias {
 		if sym.info.is_import {
-			sym = g.table.get_type_symbol(sym.info.parent_type)
+			sym = g.table.type_symbol(sym.info.parent_type)
 		}
 	}
 
@@ -44,7 +44,7 @@ fn (mut g Gen) gen_free_for_struct(info ast.Struct, styp string, fn_name string)
 	}
 	fn_builder.writeln('void ${fn_name}($styp* it) {')
 	for field in info.fields {
-		sym := g.table.get_type_symbol(g.unwrap_generic(field.typ))
+		sym := g.table.type_symbol(g.unwrap_generic(field.typ))
 
 		if sym.kind !in [.string, .array, .map, .struct_] {
 			continue
@@ -68,7 +68,7 @@ fn (mut g Gen) gen_free_for_array(info ast.Array, styp string, fn_name string) {
 	}
 	fn_builder.writeln('void ${fn_name}($styp* it) {')
 
-	sym := g.table.get_type_symbol(g.unwrap_generic(info.elem_type))
+	sym := g.table.type_symbol(g.unwrap_generic(info.elem_type))
 	if sym.kind in [.string, .array, .map, .struct_] {
 		fn_builder.writeln('\tfor (int i = 0; i < it->len; i++) {')
 

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -142,11 +142,11 @@ fn (mut g Gen) get_str_fn(typ ast.Type) string {
 		unwrapped.set_flag(.optional)
 	}
 	styp := g.typ(unwrapped)
-	mut sym := g.table.get_type_symbol(unwrapped)
+	mut sym := g.table.type_symbol(unwrapped)
 	mut str_fn_name := styp_to_str_fn_name(styp)
 	if mut sym.info is ast.Alias {
 		if sym.info.is_import {
-			sym = g.table.get_type_symbol(sym.info.parent_type)
+			sym = g.table.type_symbol(sym.info.parent_type)
 			str_fn_name = styp_to_str_fn_name(sym.name)
 		}
 	}
@@ -168,7 +168,7 @@ fn (mut g Gen) final_gen_str(typ StrType) {
 		eprintln('> final_gen_str: $typ')
 	}
 	g.generated_str_fns << typ
-	sym := g.table.get_type_symbol(typ.typ)
+	sym := g.table.type_symbol(typ.typ)
 	if sym.has_method_with_generic_parent('str') && !typ.typ.has_flag(.optional) {
 		return
 	}
@@ -230,7 +230,7 @@ fn (mut g Gen) gen_str_for_option(typ ast.Type, styp string, str_fn_name string)
 		eprintln('> gen_str_for_option: $typ.debug() | $styp | $str_fn_name')
 	}
 	parent_type := typ.clear_flag(.optional)
-	sym := g.table.get_type_symbol(parent_type)
+	sym := g.table.type_symbol(parent_type)
 	sym_has_str_method, _, _ := sym.str_method_info()
 	parent_str_fn_name := g.get_str_fn(parent_type)
 
@@ -291,7 +291,7 @@ fn (mut g Gen) gen_str_for_multi_return(info ast.MultiReturn, styp string, str_f
 	fn_builder.writeln('\tstrings__Builder sb = strings__new_builder($info.types.len * 10);')
 	fn_builder.writeln('\tstrings__Builder_write_string(&sb, _SLIT("("));')
 	for i, typ in info.types {
-		sym := g.table.get_type_symbol(typ)
+		sym := g.table.type_symbol(typ)
 		is_arg_ptr := typ.is_ptr()
 		sym_has_str_method, str_method_expects_ptr, _ := sym.str_method_info()
 		arg_str_fn_name := g.get_str_fn(typ)
@@ -384,7 +384,7 @@ fn (mut g Gen) gen_str_for_interface(info ast.Interface, styp string, str_fn_nam
 	clean_interface_v_type_name = util.strip_main_name(clean_interface_v_type_name)
 	fn_builder.writeln('static string indent_${str_fn_name}($styp x, int indent_count) { /* gen_str_for_interface */')
 	for typ in info.types {
-		subtype := g.table.get_type_symbol(typ)
+		subtype := g.table.type_symbol(typ)
 		mut func_name := g.get_str_fn(typ)
 		sym_has_str_method, str_method_expects_ptr, _ := subtype.str_method_info()
 		if should_use_indent_func(subtype.kind) && !sym_has_str_method {
@@ -448,7 +448,7 @@ fn (mut g Gen) gen_str_for_union_sum_type(info ast.SumType, styp string, str_fn_
 	for typ in info.variants {
 		typ_str := g.typ(typ)
 		mut func_name := g.get_str_fn(typ)
-		sym := g.table.get_type_symbol(typ)
+		sym := g.table.type_symbol(typ)
 		sym_has_str_method, str_method_expects_ptr, _ := sym.str_method_info()
 		deref := if sym_has_str_method && str_method_expects_ptr { ' ' } else { '*' }
 		if should_use_indent_func(sym.kind) && !sym_has_str_method {
@@ -559,10 +559,10 @@ fn (mut g Gen) gen_str_for_array(info ast.Array, styp string, str_fn_name string
 		eprintln('> gen_str_for_array: $info.elem_type.debug() | $styp | $str_fn_name')
 	}
 	mut typ := info.elem_type
-	mut sym := g.table.get_type_symbol(info.elem_type)
+	mut sym := g.table.type_symbol(info.elem_type)
 	if mut sym.info is ast.Alias {
 		typ = sym.info.parent_type
-		sym = g.table.get_type_symbol(typ)
+		sym = g.table.type_symbol(typ)
 	}
 	field_styp := g.typ(typ)
 	is_elem_ptr := typ.is_ptr()
@@ -635,10 +635,10 @@ fn (mut g Gen) gen_str_for_array_fixed(info ast.ArrayFixed, styp string, str_fn_
 		eprintln('> gen_str_for_array_fixed: $info.elem_type.debug() | $styp | $str_fn_name')
 	}
 	mut typ := info.elem_type
-	mut sym := g.table.get_type_symbol(info.elem_type)
+	mut sym := g.table.type_symbol(info.elem_type)
 	if mut sym.info is ast.Alias {
 		typ = sym.info.parent_type
-		sym = g.table.get_type_symbol(typ)
+		sym = g.table.type_symbol(typ)
 	}
 	is_elem_ptr := typ.is_ptr()
 	sym_has_str_method, str_method_expects_ptr, _ := sym.str_method_info()
@@ -698,10 +698,10 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 		eprintln('> gen_str_for_map: $info.key_type.debug() -> $info.value_type.debug() | $styp | $str_fn_name')
 	}
 	mut key_typ := info.key_type
-	mut key_sym := g.table.get_type_symbol(key_typ)
+	mut key_sym := g.table.type_symbol(key_typ)
 	if mut key_sym.info is ast.Alias {
 		key_typ = key_sym.info.parent_type
-		key_sym = g.table.get_type_symbol(key_typ)
+		key_sym = g.table.type_symbol(key_typ)
 	}
 	key_styp := g.typ(key_typ)
 	key_str_fn_name := key_styp.replace('*', '') + '_str'
@@ -710,10 +710,10 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 	}
 
 	mut val_typ := info.value_type
-	mut val_sym := g.table.get_type_symbol(val_typ)
+	mut val_sym := g.table.type_symbol(val_typ)
 	if mut val_sym.info is ast.Alias {
 		val_typ = val_sym.info.parent_type
-		val_sym = g.table.get_type_symbol(val_typ)
+		val_sym = g.table.type_symbol(val_typ)
 	}
 	val_styp := g.typ(val_typ)
 	elem_str_fn_name := val_styp.replace('*', '') + '_str'
@@ -790,7 +790,7 @@ fn (g &Gen) type_to_fmt(typ ast.Type) StrIntpType {
 		// return '%C\\000' // a C string
 		return .si_s
 	}
-	sym := g.table.get_type_symbol(typ)
+	sym := g.table.type_symbol(typ)
 	if typ.is_ptr() && (typ.is_int_valptr() || typ.is_float_valptr()) {
 		return .si_s
 	} else if sym.kind in [.struct_, .array, .array_fixed, .map, .bool, .enum_, .interface_,
@@ -866,7 +866,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name stri
 		// manage prefix and quote symbol for the filed
 		mut quote_str := ''
 		mut prefix := ''
-		sym := g.table.get_type_symbol(g.unwrap_generic(field.typ))
+		sym := g.table.type_symbol(g.unwrap_generic(field.typ))
 		if sym.kind == .string {
 			quote_str = "'"
 		} else if field.typ in ast.charptr_types {

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -142,11 +142,11 @@ fn (mut g Gen) get_str_fn(typ ast.Type) string {
 		unwrapped.set_flag(.optional)
 	}
 	styp := g.typ(unwrapped)
-	mut sym := g.table.type_symbol(unwrapped)
+	mut sym := g.table.sym(unwrapped)
 	mut str_fn_name := styp_to_str_fn_name(styp)
 	if mut sym.info is ast.Alias {
 		if sym.info.is_import {
-			sym = g.table.type_symbol(sym.info.parent_type)
+			sym = g.table.sym(sym.info.parent_type)
 			str_fn_name = styp_to_str_fn_name(sym.name)
 		}
 	}
@@ -168,7 +168,7 @@ fn (mut g Gen) final_gen_str(typ StrType) {
 		eprintln('> final_gen_str: $typ')
 	}
 	g.generated_str_fns << typ
-	sym := g.table.type_symbol(typ.typ)
+	sym := g.table.sym(typ.typ)
 	if sym.has_method_with_generic_parent('str') && !typ.typ.has_flag(.optional) {
 		return
 	}
@@ -230,7 +230,7 @@ fn (mut g Gen) gen_str_for_option(typ ast.Type, styp string, str_fn_name string)
 		eprintln('> gen_str_for_option: $typ.debug() | $styp | $str_fn_name')
 	}
 	parent_type := typ.clear_flag(.optional)
-	sym := g.table.type_symbol(parent_type)
+	sym := g.table.sym(parent_type)
 	sym_has_str_method, _, _ := sym.str_method_info()
 	parent_str_fn_name := g.get_str_fn(parent_type)
 
@@ -291,7 +291,7 @@ fn (mut g Gen) gen_str_for_multi_return(info ast.MultiReturn, styp string, str_f
 	fn_builder.writeln('\tstrings__Builder sb = strings__new_builder($info.types.len * 10);')
 	fn_builder.writeln('\tstrings__Builder_write_string(&sb, _SLIT("("));')
 	for i, typ in info.types {
-		sym := g.table.type_symbol(typ)
+		sym := g.table.sym(typ)
 		is_arg_ptr := typ.is_ptr()
 		sym_has_str_method, str_method_expects_ptr, _ := sym.str_method_info()
 		arg_str_fn_name := g.get_str_fn(typ)
@@ -384,7 +384,7 @@ fn (mut g Gen) gen_str_for_interface(info ast.Interface, styp string, str_fn_nam
 	clean_interface_v_type_name = util.strip_main_name(clean_interface_v_type_name)
 	fn_builder.writeln('static string indent_${str_fn_name}($styp x, int indent_count) { /* gen_str_for_interface */')
 	for typ in info.types {
-		subtype := g.table.type_symbol(typ)
+		subtype := g.table.sym(typ)
 		mut func_name := g.get_str_fn(typ)
 		sym_has_str_method, str_method_expects_ptr, _ := subtype.str_method_info()
 		if should_use_indent_func(subtype.kind) && !sym_has_str_method {
@@ -448,7 +448,7 @@ fn (mut g Gen) gen_str_for_union_sum_type(info ast.SumType, styp string, str_fn_
 	for typ in info.variants {
 		typ_str := g.typ(typ)
 		mut func_name := g.get_str_fn(typ)
-		sym := g.table.type_symbol(typ)
+		sym := g.table.sym(typ)
 		sym_has_str_method, str_method_expects_ptr, _ := sym.str_method_info()
 		deref := if sym_has_str_method && str_method_expects_ptr { ' ' } else { '*' }
 		if should_use_indent_func(sym.kind) && !sym_has_str_method {
@@ -559,10 +559,10 @@ fn (mut g Gen) gen_str_for_array(info ast.Array, styp string, str_fn_name string
 		eprintln('> gen_str_for_array: $info.elem_type.debug() | $styp | $str_fn_name')
 	}
 	mut typ := info.elem_type
-	mut sym := g.table.type_symbol(info.elem_type)
+	mut sym := g.table.sym(info.elem_type)
 	if mut sym.info is ast.Alias {
 		typ = sym.info.parent_type
-		sym = g.table.type_symbol(typ)
+		sym = g.table.sym(typ)
 	}
 	field_styp := g.typ(typ)
 	is_elem_ptr := typ.is_ptr()
@@ -635,10 +635,10 @@ fn (mut g Gen) gen_str_for_array_fixed(info ast.ArrayFixed, styp string, str_fn_
 		eprintln('> gen_str_for_array_fixed: $info.elem_type.debug() | $styp | $str_fn_name')
 	}
 	mut typ := info.elem_type
-	mut sym := g.table.type_symbol(info.elem_type)
+	mut sym := g.table.sym(info.elem_type)
 	if mut sym.info is ast.Alias {
 		typ = sym.info.parent_type
-		sym = g.table.type_symbol(typ)
+		sym = g.table.sym(typ)
 	}
 	is_elem_ptr := typ.is_ptr()
 	sym_has_str_method, str_method_expects_ptr, _ := sym.str_method_info()
@@ -698,10 +698,10 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 		eprintln('> gen_str_for_map: $info.key_type.debug() -> $info.value_type.debug() | $styp | $str_fn_name')
 	}
 	mut key_typ := info.key_type
-	mut key_sym := g.table.type_symbol(key_typ)
+	mut key_sym := g.table.sym(key_typ)
 	if mut key_sym.info is ast.Alias {
 		key_typ = key_sym.info.parent_type
-		key_sym = g.table.type_symbol(key_typ)
+		key_sym = g.table.sym(key_typ)
 	}
 	key_styp := g.typ(key_typ)
 	key_str_fn_name := key_styp.replace('*', '') + '_str'
@@ -710,10 +710,10 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 	}
 
 	mut val_typ := info.value_type
-	mut val_sym := g.table.type_symbol(val_typ)
+	mut val_sym := g.table.sym(val_typ)
 	if mut val_sym.info is ast.Alias {
 		val_typ = val_sym.info.parent_type
-		val_sym = g.table.type_symbol(val_typ)
+		val_sym = g.table.sym(val_typ)
 	}
 	val_styp := g.typ(val_typ)
 	elem_str_fn_name := val_styp.replace('*', '') + '_str'
@@ -790,7 +790,7 @@ fn (g &Gen) type_to_fmt(typ ast.Type) StrIntpType {
 		// return '%C\\000' // a C string
 		return .si_s
 	}
-	sym := g.table.type_symbol(typ)
+	sym := g.table.sym(typ)
 	if typ.is_ptr() && (typ.is_int_valptr() || typ.is_float_valptr()) {
 		return .si_s
 	} else if sym.kind in [.struct_, .array, .array_fixed, .map, .bool, .enum_, .interface_,
@@ -866,7 +866,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name stri
 		// manage prefix and quote symbol for the filed
 		mut quote_str := ''
 		mut prefix := ''
-		sym := g.table.type_symbol(g.unwrap_generic(field.typ))
+		sym := g.table.sym(g.unwrap_generic(field.typ))
 		if sym.kind == .string {
 			quote_str = "'"
 		} else if field.typ in ast.charptr_types {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -752,7 +752,7 @@ pub fn (mut g Gen) write_typeof_functions() {
 			if g.pref.build_mode == .build_module {
 				g.writeln('\t\tif( sidx == _v_type_idx_${sym.cname}() ) return "${util.strip_main_name(sym.name)}";')
 				for v in sum_info.variants {
-					subtype := g.table.get_type_symbol(v)
+					subtype := g.table.type_symbol(v)
 					g.writeln('\tif( sidx == _v_type_idx_${subtype.cname}() ) return "${util.strip_main_name(subtype.name)}";')
 				}
 				g.writeln('\treturn "unknown ${util.strip_main_name(sym.name)}";')
@@ -761,7 +761,7 @@ pub fn (mut g Gen) write_typeof_functions() {
 				g.writeln('\tswitch(sidx) {')
 				g.writeln('\t\tcase $tidx: return "${util.strip_main_name(sym.name)}";')
 				for v in sum_info.variants {
-					subtype := g.table.get_type_symbol(v)
+					subtype := g.table.type_symbol(v)
 					g.writeln('\t\tcase $v: return "${util.strip_main_name(subtype.name)}";')
 				}
 				g.writeln('\t\tdefault: return "unknown ${util.strip_main_name(sym.name)}";')
@@ -773,7 +773,7 @@ pub fn (mut g Gen) write_typeof_functions() {
 			if g.pref.build_mode == .build_module {
 				g.writeln('\t\tif( sidx == _v_type_idx_${sym.cname}() ) return ${int(ityp)};')
 				for v in sum_info.variants {
-					subtype := g.table.get_type_symbol(v)
+					subtype := g.table.type_symbol(v)
 					g.writeln('\tif( sidx == _v_type_idx_${subtype.cname}() ) return ${int(v)};')
 				}
 				g.writeln('\treturn ${int(ityp)};')
@@ -799,7 +799,7 @@ pub fn (mut g Gen) write_typeof_functions() {
 			g.definitions.writeln('static char * v_typeof_interface_${sym.cname}(int sidx);')
 			g.writeln('static char * v_typeof_interface_${sym.cname}(int sidx) { /* $sym.name */ ')
 			for t in inter_info.types {
-				subtype := g.table.get_type_symbol(t)
+				subtype := g.table.type_symbol(t)
 				g.writeln('\tif (sidx == _${sym.cname}_${subtype.cname}_index) return "${util.strip_main_name(subtype.name)}";')
 			}
 			g.writeln('\treturn "unknown ${util.strip_main_name(sym.name)}";')
@@ -807,7 +807,7 @@ pub fn (mut g Gen) write_typeof_functions() {
 			g.writeln('')
 			g.writeln('static int v_typeof_interface_idx_${sym.cname}(int sidx) { /* $sym.name */ ')
 			for t in inter_info.types {
-				subtype := g.table.get_type_symbol(t)
+				subtype := g.table.type_symbol(t)
 				g.writeln('\tif (sidx == _${sym.cname}_${subtype.cname}_index) return ${int(t)};')
 			}
 			g.writeln('\treturn ${int(ityp)};')
@@ -1070,7 +1070,7 @@ static inline Option_void __Option_${styp}_pushval($styp ch, $el_type e) {
 
 // cc_type whether to prefix 'struct' or not (C__Foo -> struct Foo)
 fn (mut g Gen) cc_type(typ ast.Type, is_prefix_struct bool) string {
-	sym := g.table.get_type_symbol(g.unwrap_generic(typ))
+	sym := g.table.type_symbol(g.unwrap_generic(typ))
 	mut styp := sym.cname
 	// TODO: this needs to be removed; cgen shouldn't resolve generic types (job of checker)
 	match mut sym.info {
@@ -1078,7 +1078,7 @@ fn (mut g Gen) cc_type(typ ast.Type, is_prefix_struct bool) string {
 			if sym.info.is_generic {
 				mut sgtyps := '_T'
 				for gt in sym.info.generic_types {
-					gts := g.table.get_type_symbol(g.unwrap_generic(gt))
+					gts := g.table.type_symbol(g.unwrap_generic(gt))
 					sgtyps += '_$gts.cname'
 				}
 				styp += sgtyps
@@ -1101,7 +1101,7 @@ fn (mut g Gen) cc_type(typ ast.Type, is_prefix_struct bool) string {
 [inline]
 fn (g &Gen) type_sidx(t ast.Type) string {
 	if g.pref.build_mode == .build_module {
-		sym := g.table.get_type_symbol(t)
+		sym := g.table.type_symbol(t)
 		return '_v_type_idx_${sym.cname}()'
 	}
 	return t.idx().str()
@@ -1116,14 +1116,14 @@ pub fn (mut g Gen) write_typedef_types() {
 		match sym.kind {
 			.array {
 				info := sym.info as ast.Array
-				elem_sym := g.table.get_type_symbol(info.elem_type)
+				elem_sym := g.table.type_symbol(info.elem_type)
 				if elem_sym.kind != .placeholder && !info.elem_type.has_flag(.generic) {
 					g.type_definitions.writeln('typedef array $sym.cname;')
 				}
 			}
 			.array_fixed {
 				info := sym.info as ast.ArrayFixed
-				elem_sym := g.table.get_type_symbol(info.elem_type)
+				elem_sym := g.table.type_symbol(info.elem_type)
 				if elem_sym.is_builtin() {
 					// .array_fixed {
 					styp := sym.cname
@@ -1242,7 +1242,7 @@ pub fn (mut g Gen) write_interface_typesymbol_declaration(sym ast.TypeSymbol) {
 	g.type_definitions.writeln('\tunion {')
 	g.type_definitions.writeln('\t\tvoid* _object;')
 	for variant in info.types {
-		vcname := g.table.get_type_symbol(variant).cname
+		vcname := g.table.type_symbol(variant).cname
 		g.type_definitions.writeln('\t\t$vcname* _$vcname;')
 	}
 	g.type_definitions.writeln('\t};')
@@ -1762,7 +1762,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 		ast.Import {}
 		ast.InterfaceDecl {
 			// definitions are sorted and added in write_types
-			ts := g.table.get_type_symbol(node.typ)
+			ts := g.table.type_symbol(node.typ)
 			if !(ts.info as ast.Interface).is_generic {
 				for method in node.methods {
 					if method.return_type.has_flag(.optional) {
@@ -1798,7 +1798,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 			// g.gen_attrs(node.attrs)
 			// g.writeln('typedef struct {')
 			// for field in it.fields {
-			// field_type_sym := g.table.get_type_symbol(field.typ)
+			// field_type_sym := g.table.type_symbol(field.typ)
 			// g.writeln('\t$field_type_sym.name $field.name;')
 			// }
 			// g.writeln('} $name;')
@@ -1983,7 +1983,7 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 		// `for num in nums {`
 		// g.writeln('// FOR IN array')
 		styp := g.typ(node.val_type)
-		val_sym := g.table.get_type_symbol(node.val_type)
+		val_sym := g.table.type_symbol(node.val_type)
 		mut cond_var := ''
 		if node.cond is ast.Ident || node.cond is ast.SelectorExpr {
 			cond_var = g.expr_string(node.cond)
@@ -2047,11 +2047,11 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 			cond_var = g.expr_string(node.cond)
 		}
 		idx := if node.key_var in ['', '_'] { g.new_tmp_var() } else { node.key_var }
-		cond_sym := g.table.get_type_symbol(node.cond_type)
+		cond_sym := g.table.type_symbol(node.cond_type)
 		info := cond_sym.info as ast.ArrayFixed
 		g.writeln('for (int $idx = 0; $idx != $info.size; ++$idx) {')
 		if node.val_var != '_' {
-			val_sym := g.table.get_type_symbol(node.val_type)
+			val_sym := g.table.type_symbol(node.val_type)
 			is_fixed_array := val_sym.kind == .array_fixed && !node.val_is_mut
 			if val_sym.kind == .function {
 				g.write('\t')
@@ -2120,7 +2120,7 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 			}
 		}
 		if node.val_var != '_' {
-			val_sym := g.table.get_type_symbol(node.val_type)
+			val_sym := g.table.type_symbol(node.val_type)
 			if val_sym.kind == .function {
 				g.write_fn_ptr_decl(val_sym.info as ast.FnType, c_name(node.val_var))
 				g.write(' = (*(voidptr*)')
@@ -2160,7 +2160,7 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 			g.writeln('.str[$i];')
 		}
 	} else if node.kind == .struct_ {
-		cond_type_sym := g.table.get_type_symbol(node.cond_type)
+		cond_type_sym := g.table.type_symbol(node.cond_type)
 		next_fn := cond_type_sym.find_method_with_generic_parent('next') or {
 			verror('`next` method not found')
 			return
@@ -2179,7 +2179,7 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 		receiver_typ := next_fn.params[0].typ
 		receiver_styp := g.typ(receiver_typ)
 		mut fn_name := receiver_styp.replace_each(['*', '', '.', '__']) + '_next'
-		receiver_sym := g.table.get_type_symbol(receiver_typ)
+		receiver_sym := g.table.type_symbol(receiver_typ)
 		if receiver_sym.info is ast.Struct {
 			if receiver_sym.info.concrete_types.len > 0 {
 				fn_name = g.generic_fn_name(receiver_sym.info.concrete_types, fn_name,
@@ -2233,7 +2233,7 @@ struct SumtypeCastingFn {
 fn (mut g Gen) get_sumtype_casting_fn(got_ ast.Type, exp_ ast.Type) string {
 	got, exp := got_.idx(), exp_.idx()
 	i := got | int(u32(exp) << 16)
-	got_cname, exp_cname := g.table.get_type_symbol(got).cname, g.table.get_type_symbol(exp).cname
+	got_cname, exp_cname := g.table.type_symbol(got).cname, g.table.type_symbol(exp).cname
 	fn_name := '${got_cname}_to_sumtype_$exp_cname'
 	if got == exp || g.sumtype_definitions[i] {
 		return fn_name
@@ -2249,7 +2249,7 @@ fn (mut g Gen) get_sumtype_casting_fn(got_ ast.Type, exp_ ast.Type) string {
 
 fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 	got, exp := fun.got, fun.exp
-	got_sym, exp_sym := g.table.get_type_symbol(got), g.table.get_type_symbol(exp)
+	got_sym, exp_sym := g.table.type_symbol(got), g.table.type_symbol(exp)
 	got_cname, exp_cname := got_sym.cname, exp_sym.cname
 	mut sb := strings.new_builder(128)
 	sb.writeln('static inline $exp_cname ${fun.fn_name}($got_cname* x) {')
@@ -2260,7 +2260,7 @@ fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 		mut embed_name := ''
 		mut accessor := '&x->'
 		for j, embed in embed_hierarchy {
-			embed_sym := g.table.get_type_symbol(embed)
+			embed_sym := g.table.type_symbol(embed)
 			embed_cname = embed_sym.cname
 			embed_name = embed_sym.embed_name()
 			if j > 0 {
@@ -2279,7 +2279,7 @@ fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 			ast.StructField{}, []ast.Type{}
 		}
 		if embed_types.len > 0 {
-			embed_sym := g.table.get_type_symbol(embed_types.last())
+			embed_sym := g.table.type_symbol(embed_types.last())
 			ptr = '${embed_sym.embed_name()}_ptr'
 			type_cname = embed_sym.cname
 		}
@@ -2318,8 +2318,8 @@ fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp_is_ptr
 // use instead of expr() when you need to cast to a different type
 fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_type ast.Type) {
 	got_type := g.table.mktyp(got_type_raw)
-	exp_sym := g.table.get_type_symbol(expected_type)
-	got_sym := g.table.get_type_symbol(got_type)
+	exp_sym := g.table.type_symbol(expected_type)
+	got_sym := g.table.type_symbol(got_type)
 	expected_is_ptr := expected_type.is_ptr()
 	got_is_ptr := got_type.is_ptr()
 	// allow using the new Error struct as a string, to avoid a breaking change
@@ -2371,8 +2371,8 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 	if expected_type != ast.void_type {
 		unwrapped_expected_type := g.unwrap_generic(expected_type)
 		unwrapped_got_type := g.unwrap_generic(got_type)
-		unwrapped_exp_sym := g.table.get_type_symbol(unwrapped_expected_type)
-		unwrapped_got_sym := g.table.get_type_symbol(unwrapped_got_type)
+		unwrapped_exp_sym := g.table.type_symbol(unwrapped_expected_type)
+		unwrapped_got_sym := g.table.type_symbol(unwrapped_got_type)
 
 		expected_deref_type := if expected_is_ptr {
 			unwrapped_expected_type.deref()
@@ -2434,7 +2434,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 	if got_is_ptr && !expected_is_ptr && neither_void && exp_sym.kind != .placeholder
 		&& expr !is ast.InfixExpr {
 		got_deref_type := got_type.deref()
-		deref_sym := g.table.get_type_symbol(got_deref_type)
+		deref_sym := g.table.type_symbol(got_deref_type)
 		deref_will_match := expected_type in [got_type, got_deref_type, deref_sym.parent_idx]
 		got_is_opt := got_type.has_flag(.optional)
 		if deref_will_match || got_is_opt || expr.is_auto_deref_var() {
@@ -2732,7 +2732,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 	mut type_to_free := ''
 	if af {
 		first_left_type := assign_stmt.left_types[0]
-		first_left_sym := g.table.get_type_symbol(assign_stmt.left_types[0])
+		first_left_sym := g.table.type_symbol(assign_stmt.left_types[0])
 		if first_left_type == ast.string_type || first_left_sym.kind == .array {
 			type_to_free = if first_left_type == ast.string_type { 'string' } else { 'array' }
 			mut ok := true
@@ -2802,7 +2802,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 	*/
 	// json_test failed w/o this check
 	if return_type != ast.void_type && return_type != 0 {
-		sym := g.table.get_type_symbol(return_type)
+		sym := g.table.type_symbol(return_type)
 		if sym.kind == .multi_return {
 			// multi return
 			// TODO Handle in if_expr
@@ -2886,7 +2886,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 			match left {
 				ast.Ident {
 					left_typ := assign_stmt.left_types[i]
-					left_sym := g.table.get_type_symbol(left_typ)
+					left_sym := g.table.type_symbol(left_typ)
 					if left_sym.kind == .function {
 						g.write_fn_ptr_decl(left_sym.info as ast.FnType, '_var_$left.pos.pos')
 						g.writeln(' = $left.name;')
@@ -2896,13 +2896,13 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					}
 				}
 				ast.IndexExpr {
-					sym := g.table.get_type_symbol(left.left_type)
+					sym := g.table.type_symbol(left.left_type)
 					if sym.kind == .array {
 						info := sym.info as ast.Array
-						elem_typ := g.table.get_type_symbol(info.elem_type)
+						elem_typ := g.table.type_symbol(info.elem_type)
 						if elem_typ.kind == .function {
 							left_typ := assign_stmt.left_types[i]
-							left_sym := g.table.get_type_symbol(left_typ)
+							left_sym := g.table.type_symbol(left_typ)
 							g.write_fn_ptr_decl(left_sym.info as ast.FnType, '_var_$left.pos.pos')
 							g.write(' = *(voidptr*)array_get(')
 						} else {
@@ -2928,10 +2928,10 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 						skeytyp := g.typ(info.key_type)
 						styp := g.typ(info.value_type)
 						zero := g.type_default(info.value_type)
-						val_typ := g.table.get_type_symbol(info.value_type)
+						val_typ := g.table.type_symbol(info.value_type)
 						if val_typ.kind == .function {
 							left_type := assign_stmt.left_types[i]
-							left_sym := g.table.get_type_symbol(left_type)
+							left_sym := g.table.type_symbol(left_type)
 							g.write_fn_ptr_decl(left_sym.info as ast.FnType, '_var_$left.pos.pos')
 							g.write(' = *(voidptr*)map_get(')
 						} else {
@@ -2993,7 +2993,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 		mut ident := ast.Ident{
 			scope: 0
 		}
-		left_sym := g.table.get_type_symbol(g.unwrap_generic(var_type))
+		left_sym := g.table.type_symbol(g.unwrap_generic(var_type))
 		if mut left is ast.Ident {
 			ident = left
 			// id_info := ident.var_info()
@@ -3059,7 +3059,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					g.is_assign_lhs = false
 					g.is_arraymap_set = false
 					if left is ast.IndexExpr {
-						sym := g.table.get_type_symbol(left.left_type)
+						sym := g.table.type_symbol(left.left_type)
 						if sym.kind in [.map, .array] {
 							g.expr(val)
 							g.writeln('});')
@@ -3078,8 +3078,8 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 			else {}
 		}
 		unwrapped_val_type := g.unwrap_generic(val_type)
-		right_sym := g.table.get_type_symbol(unwrapped_val_type)
-		unaliased_right_sym := g.table.get_final_type_symbol(unwrapped_val_type)
+		right_sym := g.table.type_symbol(unwrapped_val_type)
+		unaliased_right_sym := g.table.final_type_symbol(unwrapped_val_type)
 		is_fixed_array_var := unaliased_right_sym.kind == .array_fixed && val !is ast.ArrayInit
 			&& (val in [ast.Ident, ast.IndexExpr, ast.CallExpr, ast.SelectorExpr]
 			|| (val is ast.CastExpr && (val as ast.CastExpr).expr !is ast.ArrayInit))
@@ -3215,7 +3215,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					}
 					mut is_used_var_styp := false
 					if ident.name !in g.defer_vars {
-						val_sym := g.table.get_type_symbol(val_type)
+						val_sym := g.table.type_symbol(val_type)
 						if val_sym.info is ast.Struct {
 							if val_sym.info.generic_types.len > 0 {
 								if val is ast.StructInit {
@@ -3383,7 +3383,7 @@ fn (mut g Gen) gen_cross_tmp_variable(left []ast.Expr, val ast.Expr) {
 			}
 		}
 		ast.InfixExpr {
-			sym := g.table.get_type_symbol(val.left_type)
+			sym := g.table.type_symbol(val.left_type)
 			if _ := g.table.find_method(sym, val.op.str()) {
 				left_styp := g.typ(val.left_type.set_nr_muls(0))
 				g.write(left_styp)
@@ -3452,7 +3452,7 @@ fn (mut g Gen) gen_clone_assignment(val ast.Expr, typ ast.Type, add_eq bool) boo
 	if val !is ast.Ident && val !is ast.SelectorExpr {
 		return false
 	}
-	right_sym := g.table.get_type_symbol(typ)
+	right_sym := g.table.type_symbol(typ)
 	if g.is_autofree {
 		if add_eq {
 			g.write('=')
@@ -3577,7 +3577,7 @@ fn (mut g Gen) autofree_scope_vars2(scope &ast.Scope, start_pos int, end_pos int
 }
 
 fn (mut g Gen) autofree_variable(v ast.Var) {
-	sym := g.table.get_type_symbol(v.typ)
+	sym := g.table.type_symbol(v.typ)
 	// if v.name.contains('output2') {
 	if g.is_autofree {
 		// eprintln('   > var name: ${v.name:-20s} | is_arg: ${v.is_arg.str():6} | var type: ${int(v.typ):8} | type_name: ${sym.name:-33s}')
@@ -3695,9 +3695,9 @@ fn (mut g Gen) map_fn_ptrs(key_typ ast.TypeSymbol) (string, string, string, stri
 		}
 		.voidptr {
 			ts := if g.pref.m64 {
-				unsafe { g.table.get_type_symbol_by_idx(ast.u64_type_idx) }
+				unsafe { g.table.type_symbol_by_idx(ast.u64_type_idx) }
 			} else {
-				unsafe { g.table.get_type_symbol_by_idx(ast.u32_type_idx) }
+				unsafe { g.table.type_symbol_by_idx(ast.u32_type_idx) }
 			}
 			return g.map_fn_ptrs(ts)
 		}
@@ -3766,7 +3766,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 			}
 			mut shared_styp := ''
 			if g.is_shared && !ret_type.has_flag(.shared_f) {
-				ret_sym := g.table.get_type_symbol(ret_type)
+				ret_sym := g.table.type_symbol(ret_type)
 				shared_typ := ret_type.set_flag(.shared_f)
 				shared_styp = g.typ(shared_typ)
 				if ret_sym.kind == .array {
@@ -3913,7 +3913,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 				node.typ
 			}
 			node_typ := g.unwrap_generic(typ)
-			sym := g.table.get_type_symbol(node_typ)
+			sym := g.table.type_symbol(node_typ)
 			if sym.language == .v && sym.kind in [.placeholder, .any] {
 				g.error('unknown type `$sym.name`', node.pos)
 			}
@@ -3981,7 +3981,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 			}
 			if node.op == .arrow {
 				styp := g.typ(node.right_type)
-				right_sym := g.table.get_type_symbol(node.right_type)
+				right_sym := g.table.type_symbol(node.right_type)
 				mut right_inf := right_sym.info as ast.Chan
 				elem_type := right_inf.elem_type
 				is_gen_or_and_assign_rhs := gen_or && !g.discard_or_result
@@ -4037,7 +4037,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 				node.typ
 			}
 			node_typ := g.unwrap_generic(typ)
-			sym := g.table.get_type_symbol(node_typ)
+			sym := g.table.type_symbol(node_typ)
 			if sym.language == .v && sym.kind in [.placeholder, .any] {
 				g.error('unknown type `$sym.name`', node.pos)
 			}
@@ -4066,7 +4066,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 			// g.write('/* Type */')
 			// type_idx := node.typ.idx()
 			typ := g.unwrap_generic(node.typ)
-			sym := g.table.get_type_symbol(typ)
+			sym := g.table.type_symbol(typ)
 			sidx := g.type_sidx(typ)
 			// g.write('$type_idx /* $sym.name */')
 			g.write('$sidx /* $sym.name */')
@@ -4085,7 +4085,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 // T.name, typeof(expr).name
 fn (mut g Gen) type_name(raw_type ast.Type) {
 	typ := if raw_type == g.field_data_type { g.comptime_for_field_value.typ } else { raw_type }
-	sym := g.table.get_type_symbol(typ)
+	sym := g.table.type_symbol(typ)
 	mut s := ''
 	if sym.kind == .function {
 		if typ.is_ptr() {
@@ -4105,7 +4105,7 @@ fn (mut g Gen) typeof_expr(node ast.TypeOf) {
 	} else {
 		node.expr_type
 	}
-	sym := g.table.get_type_symbol(typ)
+	sym := g.table.type_symbol(typ)
 	if sym.kind == .sum_type {
 		// When encountering a .sum_type, typeof() should be done at runtime,
 		// because the subtype of the expression may change:
@@ -4120,7 +4120,7 @@ fn (mut g Gen) typeof_expr(node ast.TypeOf) {
 		info := sym.info as ast.FnType
 		g.write('_SLIT("${g.fn_decl_str(info)}")')
 	} else if typ.has_flag(.variadic) {
-		varg_elem_type_sym := g.table.get_type_symbol(g.table.value_type(typ))
+		varg_elem_type_sym := g.table.type_symbol(g.table.value_type(typ))
 		g.write('_SLIT("...${util.strip_main_name(varg_elem_type_sym.name)}")')
 	} else {
 		x := g.table.type_to_str(typ)
@@ -4170,7 +4170,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	if node.expr_type == 0 {
 		g.checker_bug('unexpected SelectorExpr.expr_type = 0', node.pos)
 	}
-	sym := g.table.get_type_symbol(g.unwrap_generic(node.expr_type))
+	sym := g.table.type_symbol(g.unwrap_generic(node.expr_type))
 	// if node expr is a root ident and an optional
 	mut is_optional := node.expr is ast.Ident && node.expr_type.has_flag(.optional)
 	if is_optional {
@@ -4197,7 +4197,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	mut sum_type_deref_field := ''
 	mut sum_type_dot := '.'
 	if f := g.table.find_field(sym, node.field_name) {
-		field_sym := g.table.get_type_symbol(f.typ)
+		field_sym := g.table.type_symbol(f.typ)
 		if field_sym.kind in [.sum_type, .interface_] {
 			if !prevent_sum_type_unwrapping_once {
 				// check first if field is sum type because scope searching is expensive
@@ -4211,13 +4211,13 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 						if field_sym.kind == .sum_type {
 							g.write('*')
 						}
-						cast_sym := g.table.get_type_symbol(typ)
+						cast_sym := g.table.type_symbol(typ)
 						if i != 0 {
 							dot := if field.typ.is_ptr() { '->' } else { '.' }
 							sum_type_deref_field += ')$dot'
 						}
 						if mut cast_sym.info is ast.Aggregate {
-							agg_sym := g.table.get_type_symbol(cast_sym.info.types[g.aggregate_type_idx])
+							agg_sym := g.table.type_symbol(cast_sym.info.types[g.aggregate_type_idx])
 							sum_type_deref_field += '_$agg_sym.cname'
 						} else {
 							sum_type_deref_field += '_$cast_sym.cname'
@@ -4242,7 +4242,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	// struct embedding
 	if sym.info in [ast.Struct, ast.Aggregate] {
 		for embed in node.from_embed_types {
-			embed_sym := g.table.get_type_symbol(embed)
+			embed_sym := g.table.type_symbol(embed)
 			embed_name := embed_sym.embed_name()
 			if node.expr_type.is_ptr() {
 				g.write('->')
@@ -4388,8 +4388,8 @@ fn (mut g Gen) unlock_locks() {
 
 fn (mut g Gen) need_tmp_var_in_match(node ast.MatchExpr) bool {
 	if node.is_expr && node.return_type != ast.void_type && node.return_type != 0 {
-		cond_sym := g.table.get_final_type_symbol(node.cond_type)
-		sym := g.table.get_type_symbol(node.return_type)
+		cond_sym := g.table.final_type_symbol(node.cond_type)
+		sym := g.table.type_symbol(node.return_type)
 		if g.table.type_kind(node.return_type) == .sum_type {
 			return true
 		}
@@ -4472,7 +4472,7 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 		// brackets needed otherwise '?' will apply to everything on the left
 		g.write('(')
 	}
-	typ := g.table.get_final_type_symbol(node.cond_type)
+	typ := g.table.final_type_symbol(node.cond_type)
 	if node.is_sum_type {
 		g.match_expr_sumtype(node, is_expr, cond_var, tmp_var)
 	} else if typ.kind == .enum_ && g.loop_depth == 0 && node.branches.len > 5 && g.fn_decl != 0 { // do not optimize while in top-level
@@ -4498,7 +4498,7 @@ fn (mut g Gen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var str
 		for {
 			g.aggregate_type_idx = sumtype_index
 			is_last := j == node.branches.len - 1
-			sym := g.table.get_type_symbol(node.cond_type)
+			sym := g.table.type_symbol(node.cond_type)
 			if branch.is_else || (node.is_expr && is_last && tmp_var.len == 0) {
 				if is_expr && tmp_var.len == 0 {
 					// TODO too many branches. maybe separate ?: matches
@@ -4534,7 +4534,7 @@ fn (mut g Gen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var str
 				} else if sym.kind == .interface_ {
 					if branch.exprs[sumtype_index] is ast.TypeNode {
 						typ := branch.exprs[sumtype_index] as ast.TypeNode
-						branch_sym := g.table.get_type_symbol(g.unwrap_generic(typ.typ))
+						branch_sym := g.table.type_symbol(g.unwrap_generic(typ.typ))
 						g.write('${dot_or_ptr}_typ == _${sym.cname}_${branch_sym.cname}_index')
 					} else if branch.exprs[sumtype_index] is ast.None && sym.name == 'IError' {
 						g.write('${dot_or_ptr}_typ == _IError_None___index')
@@ -4546,8 +4546,7 @@ fn (mut g Gen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var str
 					g.writeln(') {')
 				}
 			}
-			if is_expr && tmp_var.len > 0
-				&& g.table.get_type_symbol(node.return_type).kind == .sum_type {
+			if is_expr && tmp_var.len > 0 && g.table.type_symbol(node.return_type).kind == .sum_type {
 				g.expected_cast_type = node.return_type
 			}
 			g.stmts_with_tmp_var(branch.stmts, tmp_var)
@@ -4638,7 +4637,7 @@ fn (mut g Gen) match_expr_switch(node ast.MatchExpr, is_expr bool, cond_var stri
 		}
 		g.indent++
 		g.writeln('{')
-		if is_expr && tmp_var.len > 0 && g.table.get_type_symbol(node.return_type).kind == .sum_type {
+		if is_expr && tmp_var.len > 0 && g.table.type_symbol(node.return_type).kind == .sum_type {
 			g.expected_cast_type = node.return_type
 		}
 		g.stmts_with_tmp_var(branch.stmts, tmp_var)
@@ -4691,7 +4690,7 @@ fn (mut g Gen) match_expr_switch(node ast.MatchExpr, is_expr bool, cond_var stri
 }
 
 fn (mut g Gen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var string, tmp_var string) {
-	type_sym := g.table.get_type_symbol(node.cond_type)
+	type_sym := g.table.type_symbol(node.cond_type)
 	for j, branch in node.branches {
 		is_last := j == node.branches.len - 1
 		if branch.is_else || (node.is_expr && is_last && tmp_var.len == 0) {
@@ -4791,7 +4790,7 @@ fn (mut g Gen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var str
 				g.writeln(') {')
 			}
 		}
-		if is_expr && tmp_var.len > 0 && g.table.get_type_symbol(node.return_type).kind == .sum_type {
+		if is_expr && tmp_var.len > 0 && g.table.type_symbol(node.return_type).kind == .sum_type {
 			g.expected_cast_type = node.return_type
 		}
 		g.stmts_with_tmp_var(branch.stmts, tmp_var)
@@ -4807,8 +4806,8 @@ fn (mut g Gen) map_init(node ast.MapInit) {
 	unwrap_val_typ := g.unwrap_generic(node.value_type)
 	key_typ_str := g.typ(unwrap_key_typ)
 	value_typ_str := g.typ(unwrap_val_typ)
-	value_typ := g.table.get_type_symbol(unwrap_val_typ)
-	key_typ := g.table.get_final_type_symbol(unwrap_key_typ)
+	value_typ := g.table.type_symbol(unwrap_val_typ)
+	key_typ := g.table.final_type_symbol(unwrap_key_typ)
 	hash_fn, key_eq_fn, clone_fn, free_fn := g.map_fn_ptrs(key_typ)
 	size := node.vals.len
 	mut shared_styp := '' // only needed for shared &[]{...}
@@ -5063,7 +5062,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 				g.write('(*(')
 			}
 			if v.smartcasts.len > 0 {
-				v_sym := g.table.get_type_symbol(v.typ)
+				v_sym := g.table.type_symbol(v.typ)
 				if !prevent_sum_type_unwrapping_once {
 					for _ in v.smartcasts {
 						g.write('(')
@@ -5072,7 +5071,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 						}
 					}
 					for i, typ in v.smartcasts {
-						cast_sym := g.table.get_type_symbol(g.unwrap_generic(typ))
+						cast_sym := g.table.type_symbol(g.unwrap_generic(typ))
 						mut is_ptr := false
 						if i == 0 {
 							g.write(name)
@@ -5082,7 +5081,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 						}
 						dot := if is_ptr || is_auto_heap { '->' } else { '.' }
 						if mut cast_sym.info is ast.Aggregate {
-							sym := g.table.get_type_symbol(cast_sym.info.types[g.aggregate_type_idx])
+							sym := g.table.type_symbol(cast_sym.info.types[g.aggregate_type_idx])
 							g.write('${dot}_$sym.cname')
 						} else {
 							g.write('${dot}_$cast_sym.cname')
@@ -5129,7 +5128,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 		g.out.go_back(1)
 	}
 	g.is_amp = false
-	sym := g.table.get_type_symbol(node.typ)
+	sym := g.table.type_symbol(node.typ)
 	if sym.kind in [.sum_type, .interface_] {
 		g.expr_with_cast(node.expr, node.expr_type, node.typ)
 	} else if sym.kind == .struct_ && !node.typ.is_ptr() && !(sym.info as ast.Struct).is_typedef {
@@ -5138,7 +5137,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 		g.write('*(($styp *)(&')
 		g.expr(node.expr)
 		g.write('))')
-	} else if sym.kind == .alias && g.table.get_final_type_symbol(node.typ).kind == .array_fixed {
+	} else if sym.kind == .alias && g.table.final_type_symbol(node.typ).kind == .array_fixed {
 		g.expr(node.expr)
 	} else {
 		styp := g.typ(node.typ)
@@ -5179,7 +5178,7 @@ fn (mut g Gen) concat_expr(node ast.ConcatExpr) {
 	if g.inside_return {
 		styp = g.typ(g.fn_decl.return_type)
 	}
-	sym := g.table.get_type_symbol(node.return_type)
+	sym := g.table.type_symbol(node.return_type)
 	is_multi := sym.kind == .multi_return
 	if !is_multi {
 		g.expr(node.vals[0])
@@ -5213,7 +5212,7 @@ fn (mut g Gen) need_tmp_var_in_if(node ast.IfExpr) bool {
 					}
 					if stmt.expr is ast.CallExpr {
 						if stmt.expr.is_method {
-							left_sym := g.table.get_type_symbol(stmt.expr.receiver_type)
+							left_sym := g.table.type_symbol(stmt.expr.receiver_type)
 							if left_sym.kind in [.array, .array_fixed, .map] {
 								return true
 							}
@@ -5401,7 +5400,7 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 [inline]
 fn (g &Gen) expr_is_multi_return_call(expr ast.Expr) bool {
 	match expr {
-		ast.CallExpr { return g.table.get_type_symbol(expr.return_type).kind == .multi_return }
+		ast.CallExpr { return g.table.type_symbol(expr.return_type).kind == .multi_return }
 		else { return false }
 	}
 }
@@ -5431,7 +5430,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 	}
 
 	// got to do a correct check for multireturn
-	sym := g.table.get_type_symbol(g.fn_decl.return_type)
+	sym := g.table.type_symbol(g.fn_decl.return_type)
 	fn_return_is_multi := sym.kind == .multi_return
 	fn_return_is_optional := g.fn_decl.return_type.has_flag(.optional)
 	mut has_semicolon := false
@@ -5492,7 +5491,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			g.writeln('return $tmpvar;')
 			return
 		}
-		// typ_sym := g.table.get_type_symbol(g.fn_decl.return_type)
+		// typ_sym := g.table.type_symbol(g.fn_decl.return_type)
 		// mr_info := typ_sym.info as ast.MultiReturn
 		mut styp := ''
 		if fn_return_is_optional {
@@ -5515,7 +5514,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			// Check if we are dealing with a multi return and handle it seperately
 			if g.expr_is_multi_return_call(expr) {
 				c := expr as ast.CallExpr
-				expr_sym := g.table.get_type_symbol(c.return_type)
+				expr_sym := g.table.type_symbol(c.return_type)
 				// Create a tmp for this call
 				mut tmp := g.new_tmp_var()
 				if !c.return_type.has_flag(.optional) {
@@ -5581,7 +5580,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 		}
 	} else if node.exprs.len >= 1 {
 		// normal return
-		return_sym := g.table.get_type_symbol(node.types[0])
+		return_sym := g.table.type_symbol(node.types[0])
 		expr0 := node.exprs[0]
 		// `return opt_ok(expr)` for functions that expect an optional
 		expr_type_is_opt := match expr0 {
@@ -5860,7 +5859,7 @@ fn (mut g Gen) const_decl_init_later(mod string, name string, expr ast.Expr, typ
 		}
 	}
 	if g.is_autofree {
-		sym := g.table.get_type_symbol(typ)
+		sym := g.table.type_symbol(typ)
 		if styp.starts_with('Array_') {
 			if sym.has_method_with_generic_parent('free') {
 				g.cleanup.writeln('\t${styp}_free(&$cname);')
@@ -5931,7 +5930,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		g.go_back_out(3)
 		return
 	}
-	mut sym := g.table.get_final_type_symbol(g.unwrap_generic(node.typ))
+	mut sym := g.table.final_type_symbol(g.unwrap_generic(node.typ))
 	is_amp := g.is_amp
 	is_multiline := node.fields.len > 5
 	g.is_amp = false // reset the flag immediately so that other struct inits in this expr are handled correctly
@@ -5987,7 +5986,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 			if field.typ == 0 {
 				g.checker_bug('struct init, field.typ is 0', field.pos)
 			}
-			field_type_sym := g.table.get_type_symbol(field.typ)
+			field_type_sym := g.table.type_symbol(field.typ)
 			mut cloned := false
 			if g.is_autofree && !field.typ.is_ptr() && field_type_sym.kind in [.array, .string] {
 				g.write('/*clone1*/')
@@ -6030,7 +6029,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 			// fields that are initialized but belong to the embedding
 			init_fields_to_embed := node.fields.filter(it.name !in init_field_names)
 			for embed in info.embeds {
-				embed_sym := g.table.get_type_symbol(embed)
+				embed_sym := g.table.type_symbol(embed)
 				embed_name := embed_sym.embed_name()
 				if embed_name !in inited_fields {
 					embed_info := embed_sym.info as ast.Struct
@@ -6085,7 +6084,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 					continue
 				}
 				g.write('.$field_name = ')
-				field_type_sym := g.table.get_type_symbol(sfield.typ)
+				field_type_sym := g.table.type_symbol(sfield.typ)
 				mut cloned := false
 				if g.is_autofree && !sfield.typ.is_ptr() && field_type_sym.kind in [.array, .string] {
 					g.write('/*clone1*/')
@@ -6180,7 +6179,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 }
 
 fn (mut g Gen) zero_struct_field(field ast.StructField) bool {
-	sym := g.table.get_type_symbol(field.typ)
+	sym := g.table.type_symbol(field.typ)
 	if sym.kind == .struct_ {
 		info := sym.info as ast.Struct
 		if info.fields.len == 0 {
@@ -6216,7 +6215,7 @@ fn (mut g Gen) assoc(node ast.Assoc) {
 		inited_fields[field] = i
 	}
 	// Merge inited_fields in the rest of the fields.
-	sym := g.table.get_type_symbol(node.typ)
+	sym := g.table.type_symbol(node.typ)
 	info := sym.info as ast.Struct
 	for field in info.fields {
 		field_name := c_name(field.name)
@@ -6349,7 +6348,7 @@ fn (mut g Gen) write_builtin_types() {
 	// builtin types need to be on top
 	// everything except builtin will get sorted
 	for builtin_name in c.builtins {
-		sym := g.table.get_type_symbol_by_idx(g.table.type_idxs[builtin_name])
+		sym := g.table.type_symbol_by_idx(g.table.type_idxs[builtin_name])
 		if sym.kind == .interface_ {
 			g.write_interface_typedef(sym)
 			g.write_interface_typesymbol_declaration(sym)
@@ -6389,7 +6388,7 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 			g.type_definitions.writeln('};')
 			g.typedefs2.writeln('typedef struct none none;')
 		}
-		// sym := g.table.get_type_symbol(typ)
+		// sym := g.table.type_symbol(typ)
 		mut name := sym.cname
 		match mut sym.info {
 			ast.Struct {
@@ -6498,7 +6497,7 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 				g.type_definitions.writeln('struct $name {')
 				g.type_definitions.writeln('\tunion {')
 				for variant in sym.info.variants {
-					variant_sym := g.table.get_type_symbol(variant)
+					variant_sym := g.table.type_symbol(variant)
 					g.type_definitions.writeln('\t\t${g.typ(variant.ref())} _$variant_sym.cname;')
 				}
 				g.type_definitions.writeln('\t};')
@@ -6513,7 +6512,7 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 				g.type_definitions.writeln('')
 			}
 			ast.ArrayFixed {
-				elem_sym := g.table.get_type_symbol(sym.info.elem_type)
+				elem_sym := g.table.type_symbol(sym.info.elem_type)
 				if !elem_sym.is_builtin() && !sym.info.elem_type.has_flag(.generic) {
 					// .array_fixed {
 					styp := sym.cname
@@ -6567,14 +6566,14 @@ fn (g &Gen) sort_structs(typesa []&ast.TypeSymbol) []&ast.TypeSymbol {
 		mut field_deps := []string{}
 		match mut sym.info {
 			ast.ArrayFixed {
-				dep := g.table.get_type_symbol(sym.info.elem_type).name
+				dep := g.table.type_symbol(sym.info.elem_type).name
 				if dep in type_names {
 					field_deps << dep
 				}
 			}
 			ast.Struct {
 				for embed in sym.info.embeds {
-					dep := g.table.get_type_symbol(embed).name
+					dep := g.table.type_symbol(embed).name
 					// skip if not in types list or already in deps
 					if dep !in type_names || dep in field_deps {
 						continue
@@ -6582,7 +6581,7 @@ fn (g &Gen) sort_structs(typesa []&ast.TypeSymbol) []&ast.TypeSymbol {
 					field_deps << dep
 				}
 				for field in sym.info.fields {
-					dep := g.table.get_type_symbol(field.typ).name
+					dep := g.table.type_symbol(field.typ).name
 					// skip if not in types list or already in deps
 					if dep !in type_names || dep in field_deps || field.typ.is_ptr() {
 						continue
@@ -6609,7 +6608,7 @@ fn (g &Gen) sort_structs(typesa []&ast.TypeSymbol) []&ast.TypeSymbol {
 	// sort types
 	mut sorted_symbols := []&ast.TypeSymbol{cap: dep_graph_sorted.nodes.len}
 	for node in dep_graph_sorted.nodes {
-		sorted_symbols << g.table.get_type_symbol_by_idx(g.table.type_idxs[node.name])
+		sorted_symbols << g.table.type_symbol_by_idx(g.table.type_idxs[node.name])
 	}
 	return sorted_symbols
 }
@@ -6756,7 +6755,7 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 		// Default values for other types are not needed because of mandatory initialization
 		return '0'
 	}
-	sym := g.table.get_type_symbol(typ)
+	sym := g.table.type_symbol(typ)
 	match sym.kind {
 		.string {
 			return '(string){.str=(byteptr)"", .is_lit=1}'
@@ -6783,7 +6782,7 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 			noscan := g.check_noscan(elem_typ)
 			init_str := '__new_array${noscan}(0, 0, sizeof($elem_type_str))'
 			if typ.has_flag(.shared_f) {
-				atyp := '__shared__Array_${g.table.get_type_symbol(elem_typ).cname}'
+				atyp := '__shared__Array_${g.table.type_symbol(elem_typ).cname}'
 				return '($atyp*)__dup_shared_array(&($atyp){.mtx = {0}, .val =$init_str}, sizeof($atyp))'
 			} else {
 				return init_str
@@ -6791,7 +6790,7 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 		}
 		.map {
 			info := sym.map_info()
-			key_typ := g.table.get_type_symbol(info.key_type)
+			key_typ := g.table.type_symbol(info.key_type)
 			hash_fn, key_eq_fn, clone_fn, free_fn := g.map_fn_ptrs(key_typ)
 			noscan_key := g.check_noscan(info.key_type)
 			noscan_value := g.check_noscan(info.value_type)
@@ -6806,7 +6805,7 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 			}
 			init_str := 'new_map${noscan}(sizeof(${g.typ(info.key_type)}), sizeof(${g.typ(info.value_type)}), $hash_fn, $key_eq_fn, $clone_fn, $free_fn)'
 			if typ.has_flag(.shared_f) {
-				mtyp := '__shared__Map_${key_typ.cname}_${g.table.get_type_symbol(info.value_type).cname}'
+				mtyp := '__shared__Map_${key_typ.cname}_${g.table.type_symbol(info.value_type).cname}'
 				return '($mtyp*)__dup_shared_map(&($mtyp){.mtx = {0}, .val =$init_str}, sizeof($mtyp))'
 			} else {
 				return init_str
@@ -6819,13 +6818,13 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 			typ_is_shared_f := typ.has_flag(.shared_f)
 			if sym.language == .v && !typ_is_shared_f {
 				for field in info.fields {
-					field_sym := g.table.get_type_symbol(field.typ)
+					field_sym := g.table.type_symbol(field.typ)
 					if field.has_default_expr
 						|| field_sym.kind in [.array, .map, .string, .bool, .alias, .i8, .i16, .int, .i64, .byte, .u16, .u32, .u64, .char, .voidptr, .byteptr, .charptr, .struct_] {
 						field_name := c_name(field.name)
 						if field.has_default_expr {
 							mut expr_str := ''
-							if g.table.get_type_symbol(field.typ).kind in [.sum_type, .interface_] {
+							if g.table.type_symbol(field.typ).kind in [.sum_type, .interface_] {
 								expr_str = g.expr_string_with_cast(field.default_expr,
 									field.default_expr_typ, field.typ)
 							} else {
@@ -6856,7 +6855,7 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 				init_str += '0}'
 			}
 			if typ.has_flag(.shared_f) {
-				styp := '__shared__${g.table.get_type_symbol(typ).cname}'
+				styp := '__shared__${g.table.type_symbol(typ).cname}'
 				return '($styp*)__dup${styp}(&($styp){.mtx = {0}, .val =$init_str}, sizeof($styp))'
 			} else {
 				return init_str
@@ -6919,7 +6918,7 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 		}
 	}
 	if expr.is_method {
-		receiver_sym := g.table.get_type_symbol(expr.receiver_type)
+		receiver_sym := g.table.type_symbol(expr.receiver_type)
 		name = receiver_sym.name + '_' + name
 	} else if mut expr.left is ast.AnonFn {
 		g.gen_anon_fn_decl(mut expr.left)
@@ -6929,7 +6928,7 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 	if g.pref.obfuscate && g.cur_mod.name == 'main' && name.starts_with('main__') {
 		mut key := expr.name
 		if expr.is_method {
-			sym := g.table.get_type_symbol(expr.receiver_type)
+			sym := g.table.type_symbol(expr.receiver_type)
 			key = sym.name + '.' + expr.name
 		}
 		g.write('/* obf go: $key */')
@@ -6968,7 +6967,7 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 		gohandle_name = if is_opt { '__v_thread_Option_void' } else { '__v_thread' }
 	} else {
 		opt := if is_opt { 'Option_' } else { '' }
-		gohandle_name = '__v_thread_$opt${g.table.get_type_symbol(g.unwrap_generic(node.call_expr.return_type)).cname}'
+		gohandle_name = '__v_thread_$opt${g.table.type_symbol(g.unwrap_generic(node.call_expr.return_type)).cname}'
 	}
 	if g.pref.os == .windows {
 		simple_handle := if node.is_expr && node.call_expr.return_type != ast.void_type {
@@ -7082,7 +7081,7 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 		}
 		if expr.is_method {
 			unwrapped_rec_type := g.unwrap_generic(expr.receiver_type)
-			typ_sym := g.table.get_type_symbol(unwrapped_rec_type)
+			typ_sym := g.table.type_symbol(unwrapped_rec_type)
 			if typ_sym.kind == .interface_
 				&& (typ_sym.info as ast.Interface).defines_method(expr.name) {
 				rec_cc_type := g.cc_type(unwrapped_rec_type, false)
@@ -7107,8 +7106,8 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 		if expr.args.len > 0 {
 			mut has_cast := false
 			for i in 0 .. expr.args.len {
-				if g.table.get_type_symbol(expr.expected_arg_types[i]).kind == .interface_
-					&& g.table.get_type_symbol(expr.args[i].typ).kind != .interface_ {
+				if g.table.type_symbol(expr.expected_arg_types[i]).kind == .interface_
+					&& g.table.type_symbol(expr.args[i].typ).kind != .interface_ {
 					has_cast = true
 					break
 				}
@@ -7155,8 +7154,8 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 	// are the same), otherwise panic.
 	// g.insert_before('
 	styp := g.typ(node.typ)
-	sym := g.table.get_type_symbol(node.typ)
-	mut expr_type_sym := g.table.get_type_symbol(node.expr_type)
+	sym := g.table.type_symbol(node.typ)
+	mut expr_type_sym := g.table.type_symbol(node.expr_type)
 	if mut expr_type_sym.info is ast.SumType {
 		dot := if node.expr_type.is_ptr() { '->' } else { '.' }
 		g.write('/* as */ *($styp*)__as_cast(')
@@ -7171,7 +7170,7 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 		g.write(dot)
 		// g.write('typ, /*expected:*/$node.typ)')
 		sidx := g.type_sidx(node.typ)
-		expected_sym := g.table.get_type_symbol(node.typ)
+		expected_sym := g.table.type_symbol(node.typ)
 		g.write('_typ, $sidx) /*expected idx: $sidx, name: $expected_sym.name */ ')
 
 		// fill as cast name table
@@ -7180,7 +7179,7 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			if idx in g.as_cast_type_names {
 				continue
 			}
-			variant_sym := g.table.get_type_symbol(variant)
+			variant_sym := g.table.type_symbol(variant)
 			g.as_cast_type_names[idx] = variant_sym.name
 		}
 	} else if expr_type_sym.kind == .interface_ && sym.kind == .interface_ {
@@ -7277,7 +7276,7 @@ fn (mut g Gen) interface_table() string {
 		iinidx_minimum_base := 1000 // NB: NOT 0, to avoid map entries set to 0 later, so `if already_generated_mwrappers[name] > 0 {` works.
 		mut current_iinidx := iinidx_minimum_base
 		for st in inter_info.types {
-			st_sym := g.table.get_type_symbol(st)
+			st_sym := g.table.type_symbol(st)
 			// cctype is the Cleaned Concrete Type name, *without ptr*,
 			// i.e. cctype is always just Cat, not Cat_ptr:
 			cctype := g.cc_type(st, true)
@@ -7310,7 +7309,7 @@ fn (mut g Gen) interface_table() string {
 							cast_struct.write_string('/*.... ast.voidptr_type */')
 						} else {
 							for embed_type in st_sym.struct_info().embeds {
-								embed_sym := g.table.get_type_symbol(embed_type)
+								embed_sym := g.table.type_symbol(embed_type)
 								if _ := embed_sym.find_field(field.name) {
 									cast_struct.write_string(' + __offsetof_ptr(x, $cctype, $embed_sym.embed_name()) + __offsetof_ptr(x, $embed_sym.cname, $cname)')
 									break
@@ -7345,7 +7344,7 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 			match st_sym.info {
 				ast.Struct, ast.Interface, ast.SumType {
 					if st_sym.info.parent_type.has_flag(.generic) {
-						parent_sym := g.table.get_type_symbol(st_sym.info.parent_type)
+						parent_sym := g.table.type_symbol(st_sym.info.parent_type)
 						for method in parent_sym.methods {
 							if method.name in methodidx {
 								methods << st_sym.find_method_with_generic_parent(method.name) or {
@@ -7359,7 +7358,7 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 			}
 			if st_sym.info is ast.Struct {
 				for embed in st_sym.info.embeds {
-					embed_sym := g.table.get_type_symbol(embed)
+					embed_sym := g.table.type_symbol(embed)
 					for embed_method in embed_sym.methods {
 						if embed_method.name !in method_names {
 							methods << embed_method
@@ -7370,7 +7369,7 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 			for method in methods {
 				mut name := method.name
 				if inter_info.parent_type.has_flag(.generic) {
-					parent_sym := g.table.get_type_symbol(inter_info.parent_type)
+					parent_sym := g.table.type_symbol(inter_info.parent_type)
 					match mut parent_sym.info {
 						ast.Struct, ast.Interface, ast.SumType {
 							name = g.generic_fn_name(parent_sym.info.concrete_types, method.name,
@@ -7415,11 +7414,11 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 						ast.Fn{}, []ast.Type{}
 					}
 					if embed_types.len > 0 && method.name !in method_names {
-						embed_sym := g.table.get_type_symbol(embed_types.last())
+						embed_sym := g.table.type_symbol(embed_types.last())
 						method_name := '${embed_sym.cname}_$method.name'
 						methods_wrapper.write_string('${method_name}(${fargs[0]}')
 						for embed in embed_types {
-							esym := g.table.get_type_symbol(embed)
+							esym := g.table.type_symbol(embed)
 							methods_wrapper.write_string('->$esym.embed_name()')
 						}
 						methods_wrapper.writeln('${fargs[1..].join(', ')});')
@@ -7445,10 +7444,10 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 			}
 		}
 		for vtyp, variants in inter_info.conversions {
-			vsym := g.table.get_type_symbol(vtyp)
+			vsym := g.table.type_symbol(vtyp)
 			conversion_functions.write_string('static inline bool I_${interface_name}_is_I_${vsym.cname}($interface_name x) {\n\treturn ')
 			for i, variant in variants {
-				variant_sym := g.table.get_type_symbol(variant)
+				variant_sym := g.table.type_symbol(variant)
 				if i > 0 {
 					conversion_functions.write_string(' || ')
 				}
@@ -7458,7 +7457,7 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 
 			conversion_functions.writeln('static inline $vsym.cname I_${interface_name}_as_I_${vsym.cname}($interface_name x) {')
 			for variant in variants {
-				variant_sym := g.table.get_type_symbol(variant)
+				variant_sym := g.table.type_symbol(variant)
 				conversion_functions.writeln('\tif (x._typ == _${interface_name}_${variant_sym.cname}_index) return I_${variant_sym.cname}_to_Interface_${vsym.cname}(x._$variant_sym.cname);')
 			}
 			pmessage := 'string__plus(string__plus(tos3("`as_cast`: cannot convert "), tos3(v_typeof_interface_${interface_name}(x._typ))), tos3(" to ${util.strip_main_name(vsym.name)}"))'
@@ -7532,7 +7531,7 @@ fn (mut g Gen) trace(fbase string, message string) {
 
 pub fn (mut g Gen) get_array_depth(el_typ ast.Type) int {
 	typ := g.unwrap_generic(el_typ)
-	sym := g.table.get_final_type_symbol(typ)
+	sym := g.table.final_type_symbol(typ)
 	if sym.kind == .array {
 		info := sym.info as ast.Array
 		return 1 + g.get_array_depth(info.elem_type)
@@ -7551,7 +7550,7 @@ pub fn (mut g Gen) contains_ptr(el_typ ast.Type) bool {
 	if typ.is_ptr() {
 		return true
 	}
-	sym := g.table.get_final_type_symbol(typ)
+	sym := g.table.final_type_symbol(typ)
 	if sym.language != .v {
 		return true
 	}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -752,7 +752,7 @@ pub fn (mut g Gen) write_typeof_functions() {
 			if g.pref.build_mode == .build_module {
 				g.writeln('\t\tif( sidx == _v_type_idx_${sym.cname}() ) return "${util.strip_main_name(sym.name)}";')
 				for v in sum_info.variants {
-					subtype := g.table.type_symbol(v)
+					subtype := g.table.sym(v)
 					g.writeln('\tif( sidx == _v_type_idx_${subtype.cname}() ) return "${util.strip_main_name(subtype.name)}";')
 				}
 				g.writeln('\treturn "unknown ${util.strip_main_name(sym.name)}";')
@@ -761,7 +761,7 @@ pub fn (mut g Gen) write_typeof_functions() {
 				g.writeln('\tswitch(sidx) {')
 				g.writeln('\t\tcase $tidx: return "${util.strip_main_name(sym.name)}";')
 				for v in sum_info.variants {
-					subtype := g.table.type_symbol(v)
+					subtype := g.table.sym(v)
 					g.writeln('\t\tcase $v: return "${util.strip_main_name(subtype.name)}";')
 				}
 				g.writeln('\t\tdefault: return "unknown ${util.strip_main_name(sym.name)}";')
@@ -773,7 +773,7 @@ pub fn (mut g Gen) write_typeof_functions() {
 			if g.pref.build_mode == .build_module {
 				g.writeln('\t\tif( sidx == _v_type_idx_${sym.cname}() ) return ${int(ityp)};')
 				for v in sum_info.variants {
-					subtype := g.table.type_symbol(v)
+					subtype := g.table.sym(v)
 					g.writeln('\tif( sidx == _v_type_idx_${subtype.cname}() ) return ${int(v)};')
 				}
 				g.writeln('\treturn ${int(ityp)};')
@@ -799,7 +799,7 @@ pub fn (mut g Gen) write_typeof_functions() {
 			g.definitions.writeln('static char * v_typeof_interface_${sym.cname}(int sidx);')
 			g.writeln('static char * v_typeof_interface_${sym.cname}(int sidx) { /* $sym.name */ ')
 			for t in inter_info.types {
-				subtype := g.table.type_symbol(t)
+				subtype := g.table.sym(t)
 				g.writeln('\tif (sidx == _${sym.cname}_${subtype.cname}_index) return "${util.strip_main_name(subtype.name)}";')
 			}
 			g.writeln('\treturn "unknown ${util.strip_main_name(sym.name)}";')
@@ -807,7 +807,7 @@ pub fn (mut g Gen) write_typeof_functions() {
 			g.writeln('')
 			g.writeln('static int v_typeof_interface_idx_${sym.cname}(int sidx) { /* $sym.name */ ')
 			for t in inter_info.types {
-				subtype := g.table.type_symbol(t)
+				subtype := g.table.sym(t)
 				g.writeln('\tif (sidx == _${sym.cname}_${subtype.cname}_index) return ${int(t)};')
 			}
 			g.writeln('\treturn ${int(ityp)};')
@@ -1070,7 +1070,7 @@ static inline Option_void __Option_${styp}_pushval($styp ch, $el_type e) {
 
 // cc_type whether to prefix 'struct' or not (C__Foo -> struct Foo)
 fn (mut g Gen) cc_type(typ ast.Type, is_prefix_struct bool) string {
-	sym := g.table.type_symbol(g.unwrap_generic(typ))
+	sym := g.table.sym(g.unwrap_generic(typ))
 	mut styp := sym.cname
 	// TODO: this needs to be removed; cgen shouldn't resolve generic types (job of checker)
 	match mut sym.info {
@@ -1078,7 +1078,7 @@ fn (mut g Gen) cc_type(typ ast.Type, is_prefix_struct bool) string {
 			if sym.info.is_generic {
 				mut sgtyps := '_T'
 				for gt in sym.info.generic_types {
-					gts := g.table.type_symbol(g.unwrap_generic(gt))
+					gts := g.table.sym(g.unwrap_generic(gt))
 					sgtyps += '_$gts.cname'
 				}
 				styp += sgtyps
@@ -1101,7 +1101,7 @@ fn (mut g Gen) cc_type(typ ast.Type, is_prefix_struct bool) string {
 [inline]
 fn (g &Gen) type_sidx(t ast.Type) string {
 	if g.pref.build_mode == .build_module {
-		sym := g.table.type_symbol(t)
+		sym := g.table.sym(t)
 		return '_v_type_idx_${sym.cname}()'
 	}
 	return t.idx().str()
@@ -1116,14 +1116,14 @@ pub fn (mut g Gen) write_typedef_types() {
 		match sym.kind {
 			.array {
 				info := sym.info as ast.Array
-				elem_sym := g.table.type_symbol(info.elem_type)
+				elem_sym := g.table.sym(info.elem_type)
 				if elem_sym.kind != .placeholder && !info.elem_type.has_flag(.generic) {
 					g.type_definitions.writeln('typedef array $sym.cname;')
 				}
 			}
 			.array_fixed {
 				info := sym.info as ast.ArrayFixed
-				elem_sym := g.table.type_symbol(info.elem_type)
+				elem_sym := g.table.sym(info.elem_type)
 				if elem_sym.is_builtin() {
 					// .array_fixed {
 					styp := sym.cname
@@ -1242,7 +1242,7 @@ pub fn (mut g Gen) write_interface_typesymbol_declaration(sym ast.TypeSymbol) {
 	g.type_definitions.writeln('\tunion {')
 	g.type_definitions.writeln('\t\tvoid* _object;')
 	for variant in info.types {
-		vcname := g.table.type_symbol(variant).cname
+		vcname := g.table.sym(variant).cname
 		g.type_definitions.writeln('\t\t$vcname* _$vcname;')
 	}
 	g.type_definitions.writeln('\t};')
@@ -1762,7 +1762,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 		ast.Import {}
 		ast.InterfaceDecl {
 			// definitions are sorted and added in write_types
-			ts := g.table.type_symbol(node.typ)
+			ts := g.table.sym(node.typ)
 			if !(ts.info as ast.Interface).is_generic {
 				for method in node.methods {
 					if method.return_type.has_flag(.optional) {
@@ -1798,7 +1798,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 			// g.gen_attrs(node.attrs)
 			// g.writeln('typedef struct {')
 			// for field in it.fields {
-			// field_type_sym := g.table.type_symbol(field.typ)
+			// field_type_sym := g.table.sym(field.typ)
 			// g.writeln('\t$field_type_sym.name $field.name;')
 			// }
 			// g.writeln('} $name;')
@@ -1983,7 +1983,7 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 		// `for num in nums {`
 		// g.writeln('// FOR IN array')
 		styp := g.typ(node.val_type)
-		val_sym := g.table.type_symbol(node.val_type)
+		val_sym := g.table.sym(node.val_type)
 		mut cond_var := ''
 		if node.cond is ast.Ident || node.cond is ast.SelectorExpr {
 			cond_var = g.expr_string(node.cond)
@@ -2047,11 +2047,11 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 			cond_var = g.expr_string(node.cond)
 		}
 		idx := if node.key_var in ['', '_'] { g.new_tmp_var() } else { node.key_var }
-		cond_sym := g.table.type_symbol(node.cond_type)
+		cond_sym := g.table.sym(node.cond_type)
 		info := cond_sym.info as ast.ArrayFixed
 		g.writeln('for (int $idx = 0; $idx != $info.size; ++$idx) {')
 		if node.val_var != '_' {
-			val_sym := g.table.type_symbol(node.val_type)
+			val_sym := g.table.sym(node.val_type)
 			is_fixed_array := val_sym.kind == .array_fixed && !node.val_is_mut
 			if val_sym.kind == .function {
 				g.write('\t')
@@ -2120,7 +2120,7 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 			}
 		}
 		if node.val_var != '_' {
-			val_sym := g.table.type_symbol(node.val_type)
+			val_sym := g.table.sym(node.val_type)
 			if val_sym.kind == .function {
 				g.write_fn_ptr_decl(val_sym.info as ast.FnType, c_name(node.val_var))
 				g.write(' = (*(voidptr*)')
@@ -2160,7 +2160,7 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 			g.writeln('.str[$i];')
 		}
 	} else if node.kind == .struct_ {
-		cond_type_sym := g.table.type_symbol(node.cond_type)
+		cond_type_sym := g.table.sym(node.cond_type)
 		next_fn := cond_type_sym.find_method_with_generic_parent('next') or {
 			verror('`next` method not found')
 			return
@@ -2179,7 +2179,7 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 		receiver_typ := next_fn.params[0].typ
 		receiver_styp := g.typ(receiver_typ)
 		mut fn_name := receiver_styp.replace_each(['*', '', '.', '__']) + '_next'
-		receiver_sym := g.table.type_symbol(receiver_typ)
+		receiver_sym := g.table.sym(receiver_typ)
 		if receiver_sym.info is ast.Struct {
 			if receiver_sym.info.concrete_types.len > 0 {
 				fn_name = g.generic_fn_name(receiver_sym.info.concrete_types, fn_name,
@@ -2233,7 +2233,7 @@ struct SumtypeCastingFn {
 fn (mut g Gen) get_sumtype_casting_fn(got_ ast.Type, exp_ ast.Type) string {
 	got, exp := got_.idx(), exp_.idx()
 	i := got | int(u32(exp) << 16)
-	got_cname, exp_cname := g.table.type_symbol(got).cname, g.table.type_symbol(exp).cname
+	got_cname, exp_cname := g.table.sym(got).cname, g.table.sym(exp).cname
 	fn_name := '${got_cname}_to_sumtype_$exp_cname'
 	if got == exp || g.sumtype_definitions[i] {
 		return fn_name
@@ -2249,7 +2249,7 @@ fn (mut g Gen) get_sumtype_casting_fn(got_ ast.Type, exp_ ast.Type) string {
 
 fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 	got, exp := fun.got, fun.exp
-	got_sym, exp_sym := g.table.type_symbol(got), g.table.type_symbol(exp)
+	got_sym, exp_sym := g.table.sym(got), g.table.sym(exp)
 	got_cname, exp_cname := got_sym.cname, exp_sym.cname
 	mut sb := strings.new_builder(128)
 	sb.writeln('static inline $exp_cname ${fun.fn_name}($got_cname* x) {')
@@ -2260,7 +2260,7 @@ fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 		mut embed_name := ''
 		mut accessor := '&x->'
 		for j, embed in embed_hierarchy {
-			embed_sym := g.table.type_symbol(embed)
+			embed_sym := g.table.sym(embed)
 			embed_cname = embed_sym.cname
 			embed_name = embed_sym.embed_name()
 			if j > 0 {
@@ -2279,7 +2279,7 @@ fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 			ast.StructField{}, []ast.Type{}
 		}
 		if embed_types.len > 0 {
-			embed_sym := g.table.type_symbol(embed_types.last())
+			embed_sym := g.table.sym(embed_types.last())
 			ptr = '${embed_sym.embed_name()}_ptr'
 			type_cname = embed_sym.cname
 		}
@@ -2318,8 +2318,8 @@ fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp_is_ptr
 // use instead of expr() when you need to cast to a different type
 fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_type ast.Type) {
 	got_type := g.table.mktyp(got_type_raw)
-	exp_sym := g.table.type_symbol(expected_type)
-	got_sym := g.table.type_symbol(got_type)
+	exp_sym := g.table.sym(expected_type)
+	got_sym := g.table.sym(got_type)
 	expected_is_ptr := expected_type.is_ptr()
 	got_is_ptr := got_type.is_ptr()
 	// allow using the new Error struct as a string, to avoid a breaking change
@@ -2371,8 +2371,8 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 	if expected_type != ast.void_type {
 		unwrapped_expected_type := g.unwrap_generic(expected_type)
 		unwrapped_got_type := g.unwrap_generic(got_type)
-		unwrapped_exp_sym := g.table.type_symbol(unwrapped_expected_type)
-		unwrapped_got_sym := g.table.type_symbol(unwrapped_got_type)
+		unwrapped_exp_sym := g.table.sym(unwrapped_expected_type)
+		unwrapped_got_sym := g.table.sym(unwrapped_got_type)
 
 		expected_deref_type := if expected_is_ptr {
 			unwrapped_expected_type.deref()
@@ -2434,7 +2434,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 	if got_is_ptr && !expected_is_ptr && neither_void && exp_sym.kind != .placeholder
 		&& expr !is ast.InfixExpr {
 		got_deref_type := got_type.deref()
-		deref_sym := g.table.type_symbol(got_deref_type)
+		deref_sym := g.table.sym(got_deref_type)
 		deref_will_match := expected_type in [got_type, got_deref_type, deref_sym.parent_idx]
 		got_is_opt := got_type.has_flag(.optional)
 		if deref_will_match || got_is_opt || expr.is_auto_deref_var() {
@@ -2732,7 +2732,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 	mut type_to_free := ''
 	if af {
 		first_left_type := assign_stmt.left_types[0]
-		first_left_sym := g.table.type_symbol(assign_stmt.left_types[0])
+		first_left_sym := g.table.sym(assign_stmt.left_types[0])
 		if first_left_type == ast.string_type || first_left_sym.kind == .array {
 			type_to_free = if first_left_type == ast.string_type { 'string' } else { 'array' }
 			mut ok := true
@@ -2802,7 +2802,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 	*/
 	// json_test failed w/o this check
 	if return_type != ast.void_type && return_type != 0 {
-		sym := g.table.type_symbol(return_type)
+		sym := g.table.sym(return_type)
 		if sym.kind == .multi_return {
 			// multi return
 			// TODO Handle in if_expr
@@ -2886,7 +2886,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 			match left {
 				ast.Ident {
 					left_typ := assign_stmt.left_types[i]
-					left_sym := g.table.type_symbol(left_typ)
+					left_sym := g.table.sym(left_typ)
 					if left_sym.kind == .function {
 						g.write_fn_ptr_decl(left_sym.info as ast.FnType, '_var_$left.pos.pos')
 						g.writeln(' = $left.name;')
@@ -2896,13 +2896,13 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					}
 				}
 				ast.IndexExpr {
-					sym := g.table.type_symbol(left.left_type)
+					sym := g.table.sym(left.left_type)
 					if sym.kind == .array {
 						info := sym.info as ast.Array
-						elem_typ := g.table.type_symbol(info.elem_type)
+						elem_typ := g.table.sym(info.elem_type)
 						if elem_typ.kind == .function {
 							left_typ := assign_stmt.left_types[i]
-							left_sym := g.table.type_symbol(left_typ)
+							left_sym := g.table.sym(left_typ)
 							g.write_fn_ptr_decl(left_sym.info as ast.FnType, '_var_$left.pos.pos')
 							g.write(' = *(voidptr*)array_get(')
 						} else {
@@ -2928,10 +2928,10 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 						skeytyp := g.typ(info.key_type)
 						styp := g.typ(info.value_type)
 						zero := g.type_default(info.value_type)
-						val_typ := g.table.type_symbol(info.value_type)
+						val_typ := g.table.sym(info.value_type)
 						if val_typ.kind == .function {
 							left_type := assign_stmt.left_types[i]
-							left_sym := g.table.type_symbol(left_type)
+							left_sym := g.table.sym(left_type)
 							g.write_fn_ptr_decl(left_sym.info as ast.FnType, '_var_$left.pos.pos')
 							g.write(' = *(voidptr*)map_get(')
 						} else {
@@ -2993,7 +2993,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 		mut ident := ast.Ident{
 			scope: 0
 		}
-		left_sym := g.table.type_symbol(g.unwrap_generic(var_type))
+		left_sym := g.table.sym(g.unwrap_generic(var_type))
 		if mut left is ast.Ident {
 			ident = left
 			// id_info := ident.var_info()
@@ -3059,7 +3059,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					g.is_assign_lhs = false
 					g.is_arraymap_set = false
 					if left is ast.IndexExpr {
-						sym := g.table.type_symbol(left.left_type)
+						sym := g.table.sym(left.left_type)
 						if sym.kind in [.map, .array] {
 							g.expr(val)
 							g.writeln('});')
@@ -3078,8 +3078,8 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 			else {}
 		}
 		unwrapped_val_type := g.unwrap_generic(val_type)
-		right_sym := g.table.type_symbol(unwrapped_val_type)
-		unaliased_right_sym := g.table.final_type_symbol(unwrapped_val_type)
+		right_sym := g.table.sym(unwrapped_val_type)
+		unaliased_right_sym := g.table.final_sym(unwrapped_val_type)
 		is_fixed_array_var := unaliased_right_sym.kind == .array_fixed && val !is ast.ArrayInit
 			&& (val in [ast.Ident, ast.IndexExpr, ast.CallExpr, ast.SelectorExpr]
 			|| (val is ast.CastExpr && (val as ast.CastExpr).expr !is ast.ArrayInit))
@@ -3215,7 +3215,7 @@ fn (mut g Gen) gen_assign_stmt(assign_stmt ast.AssignStmt) {
 					}
 					mut is_used_var_styp := false
 					if ident.name !in g.defer_vars {
-						val_sym := g.table.type_symbol(val_type)
+						val_sym := g.table.sym(val_type)
 						if val_sym.info is ast.Struct {
 							if val_sym.info.generic_types.len > 0 {
 								if val is ast.StructInit {
@@ -3383,7 +3383,7 @@ fn (mut g Gen) gen_cross_tmp_variable(left []ast.Expr, val ast.Expr) {
 			}
 		}
 		ast.InfixExpr {
-			sym := g.table.type_symbol(val.left_type)
+			sym := g.table.sym(val.left_type)
 			if _ := g.table.find_method(sym, val.op.str()) {
 				left_styp := g.typ(val.left_type.set_nr_muls(0))
 				g.write(left_styp)
@@ -3452,7 +3452,7 @@ fn (mut g Gen) gen_clone_assignment(val ast.Expr, typ ast.Type, add_eq bool) boo
 	if val !is ast.Ident && val !is ast.SelectorExpr {
 		return false
 	}
-	right_sym := g.table.type_symbol(typ)
+	right_sym := g.table.sym(typ)
 	if g.is_autofree {
 		if add_eq {
 			g.write('=')
@@ -3577,7 +3577,7 @@ fn (mut g Gen) autofree_scope_vars2(scope &ast.Scope, start_pos int, end_pos int
 }
 
 fn (mut g Gen) autofree_variable(v ast.Var) {
-	sym := g.table.type_symbol(v.typ)
+	sym := g.table.sym(v.typ)
 	// if v.name.contains('output2') {
 	if g.is_autofree {
 		// eprintln('   > var name: ${v.name:-20s} | is_arg: ${v.is_arg.str():6} | var type: ${int(v.typ):8} | type_name: ${sym.name:-33s}')
@@ -3695,9 +3695,9 @@ fn (mut g Gen) map_fn_ptrs(key_typ ast.TypeSymbol) (string, string, string, stri
 		}
 		.voidptr {
 			ts := if g.pref.m64 {
-				unsafe { g.table.type_symbol_by_idx(ast.u64_type_idx) }
+				unsafe { g.table.sym_by_idx(ast.u64_type_idx) }
 			} else {
-				unsafe { g.table.type_symbol_by_idx(ast.u32_type_idx) }
+				unsafe { g.table.sym_by_idx(ast.u32_type_idx) }
 			}
 			return g.map_fn_ptrs(ts)
 		}
@@ -3766,7 +3766,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 			}
 			mut shared_styp := ''
 			if g.is_shared && !ret_type.has_flag(.shared_f) {
-				ret_sym := g.table.type_symbol(ret_type)
+				ret_sym := g.table.sym(ret_type)
 				shared_typ := ret_type.set_flag(.shared_f)
 				shared_styp = g.typ(shared_typ)
 				if ret_sym.kind == .array {
@@ -3913,7 +3913,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 				node.typ
 			}
 			node_typ := g.unwrap_generic(typ)
-			sym := g.table.type_symbol(node_typ)
+			sym := g.table.sym(node_typ)
 			if sym.language == .v && sym.kind in [.placeholder, .any] {
 				g.error('unknown type `$sym.name`', node.pos)
 			}
@@ -3981,7 +3981,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 			}
 			if node.op == .arrow {
 				styp := g.typ(node.right_type)
-				right_sym := g.table.type_symbol(node.right_type)
+				right_sym := g.table.sym(node.right_type)
 				mut right_inf := right_sym.info as ast.Chan
 				elem_type := right_inf.elem_type
 				is_gen_or_and_assign_rhs := gen_or && !g.discard_or_result
@@ -4037,7 +4037,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 				node.typ
 			}
 			node_typ := g.unwrap_generic(typ)
-			sym := g.table.type_symbol(node_typ)
+			sym := g.table.sym(node_typ)
 			if sym.language == .v && sym.kind in [.placeholder, .any] {
 				g.error('unknown type `$sym.name`', node.pos)
 			}
@@ -4066,7 +4066,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 			// g.write('/* Type */')
 			// type_idx := node.typ.idx()
 			typ := g.unwrap_generic(node.typ)
-			sym := g.table.type_symbol(typ)
+			sym := g.table.sym(typ)
 			sidx := g.type_sidx(typ)
 			// g.write('$type_idx /* $sym.name */')
 			g.write('$sidx /* $sym.name */')
@@ -4085,7 +4085,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 // T.name, typeof(expr).name
 fn (mut g Gen) type_name(raw_type ast.Type) {
 	typ := if raw_type == g.field_data_type { g.comptime_for_field_value.typ } else { raw_type }
-	sym := g.table.type_symbol(typ)
+	sym := g.table.sym(typ)
 	mut s := ''
 	if sym.kind == .function {
 		if typ.is_ptr() {
@@ -4105,7 +4105,7 @@ fn (mut g Gen) typeof_expr(node ast.TypeOf) {
 	} else {
 		node.expr_type
 	}
-	sym := g.table.type_symbol(typ)
+	sym := g.table.sym(typ)
 	if sym.kind == .sum_type {
 		// When encountering a .sum_type, typeof() should be done at runtime,
 		// because the subtype of the expression may change:
@@ -4120,7 +4120,7 @@ fn (mut g Gen) typeof_expr(node ast.TypeOf) {
 		info := sym.info as ast.FnType
 		g.write('_SLIT("${g.fn_decl_str(info)}")')
 	} else if typ.has_flag(.variadic) {
-		varg_elem_type_sym := g.table.type_symbol(g.table.value_type(typ))
+		varg_elem_type_sym := g.table.sym(g.table.value_type(typ))
 		g.write('_SLIT("...${util.strip_main_name(varg_elem_type_sym.name)}")')
 	} else {
 		x := g.table.type_to_str(typ)
@@ -4170,7 +4170,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	if node.expr_type == 0 {
 		g.checker_bug('unexpected SelectorExpr.expr_type = 0', node.pos)
 	}
-	sym := g.table.type_symbol(g.unwrap_generic(node.expr_type))
+	sym := g.table.sym(g.unwrap_generic(node.expr_type))
 	// if node expr is a root ident and an optional
 	mut is_optional := node.expr is ast.Ident && node.expr_type.has_flag(.optional)
 	if is_optional {
@@ -4197,7 +4197,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	mut sum_type_deref_field := ''
 	mut sum_type_dot := '.'
 	if f := g.table.find_field(sym, node.field_name) {
-		field_sym := g.table.type_symbol(f.typ)
+		field_sym := g.table.sym(f.typ)
 		if field_sym.kind in [.sum_type, .interface_] {
 			if !prevent_sum_type_unwrapping_once {
 				// check first if field is sum type because scope searching is expensive
@@ -4211,13 +4211,13 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 						if field_sym.kind == .sum_type {
 							g.write('*')
 						}
-						cast_sym := g.table.type_symbol(typ)
+						cast_sym := g.table.sym(typ)
 						if i != 0 {
 							dot := if field.typ.is_ptr() { '->' } else { '.' }
 							sum_type_deref_field += ')$dot'
 						}
 						if mut cast_sym.info is ast.Aggregate {
-							agg_sym := g.table.type_symbol(cast_sym.info.types[g.aggregate_type_idx])
+							agg_sym := g.table.sym(cast_sym.info.types[g.aggregate_type_idx])
 							sum_type_deref_field += '_$agg_sym.cname'
 						} else {
 							sum_type_deref_field += '_$cast_sym.cname'
@@ -4242,7 +4242,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	// struct embedding
 	if sym.info in [ast.Struct, ast.Aggregate] {
 		for embed in node.from_embed_types {
-			embed_sym := g.table.type_symbol(embed)
+			embed_sym := g.table.sym(embed)
 			embed_name := embed_sym.embed_name()
 			if node.expr_type.is_ptr() {
 				g.write('->')
@@ -4388,8 +4388,8 @@ fn (mut g Gen) unlock_locks() {
 
 fn (mut g Gen) need_tmp_var_in_match(node ast.MatchExpr) bool {
 	if node.is_expr && node.return_type != ast.void_type && node.return_type != 0 {
-		cond_sym := g.table.final_type_symbol(node.cond_type)
-		sym := g.table.type_symbol(node.return_type)
+		cond_sym := g.table.final_sym(node.cond_type)
+		sym := g.table.sym(node.return_type)
 		if g.table.type_kind(node.return_type) == .sum_type {
 			return true
 		}
@@ -4472,7 +4472,7 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 		// brackets needed otherwise '?' will apply to everything on the left
 		g.write('(')
 	}
-	typ := g.table.final_type_symbol(node.cond_type)
+	typ := g.table.final_sym(node.cond_type)
 	if node.is_sum_type {
 		g.match_expr_sumtype(node, is_expr, cond_var, tmp_var)
 	} else if typ.kind == .enum_ && g.loop_depth == 0 && node.branches.len > 5 && g.fn_decl != 0 { // do not optimize while in top-level
@@ -4498,7 +4498,7 @@ fn (mut g Gen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var str
 		for {
 			g.aggregate_type_idx = sumtype_index
 			is_last := j == node.branches.len - 1
-			sym := g.table.type_symbol(node.cond_type)
+			sym := g.table.sym(node.cond_type)
 			if branch.is_else || (node.is_expr && is_last && tmp_var.len == 0) {
 				if is_expr && tmp_var.len == 0 {
 					// TODO too many branches. maybe separate ?: matches
@@ -4534,7 +4534,7 @@ fn (mut g Gen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var str
 				} else if sym.kind == .interface_ {
 					if branch.exprs[sumtype_index] is ast.TypeNode {
 						typ := branch.exprs[sumtype_index] as ast.TypeNode
-						branch_sym := g.table.type_symbol(g.unwrap_generic(typ.typ))
+						branch_sym := g.table.sym(g.unwrap_generic(typ.typ))
 						g.write('${dot_or_ptr}_typ == _${sym.cname}_${branch_sym.cname}_index')
 					} else if branch.exprs[sumtype_index] is ast.None && sym.name == 'IError' {
 						g.write('${dot_or_ptr}_typ == _IError_None___index')
@@ -4546,7 +4546,7 @@ fn (mut g Gen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var str
 					g.writeln(') {')
 				}
 			}
-			if is_expr && tmp_var.len > 0 && g.table.type_symbol(node.return_type).kind == .sum_type {
+			if is_expr && tmp_var.len > 0 && g.table.sym(node.return_type).kind == .sum_type {
 				g.expected_cast_type = node.return_type
 			}
 			g.stmts_with_tmp_var(branch.stmts, tmp_var)
@@ -4637,7 +4637,7 @@ fn (mut g Gen) match_expr_switch(node ast.MatchExpr, is_expr bool, cond_var stri
 		}
 		g.indent++
 		g.writeln('{')
-		if is_expr && tmp_var.len > 0 && g.table.type_symbol(node.return_type).kind == .sum_type {
+		if is_expr && tmp_var.len > 0 && g.table.sym(node.return_type).kind == .sum_type {
 			g.expected_cast_type = node.return_type
 		}
 		g.stmts_with_tmp_var(branch.stmts, tmp_var)
@@ -4690,7 +4690,7 @@ fn (mut g Gen) match_expr_switch(node ast.MatchExpr, is_expr bool, cond_var stri
 }
 
 fn (mut g Gen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var string, tmp_var string) {
-	type_sym := g.table.type_symbol(node.cond_type)
+	type_sym := g.table.sym(node.cond_type)
 	for j, branch in node.branches {
 		is_last := j == node.branches.len - 1
 		if branch.is_else || (node.is_expr && is_last && tmp_var.len == 0) {
@@ -4790,7 +4790,7 @@ fn (mut g Gen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var str
 				g.writeln(') {')
 			}
 		}
-		if is_expr && tmp_var.len > 0 && g.table.type_symbol(node.return_type).kind == .sum_type {
+		if is_expr && tmp_var.len > 0 && g.table.sym(node.return_type).kind == .sum_type {
 			g.expected_cast_type = node.return_type
 		}
 		g.stmts_with_tmp_var(branch.stmts, tmp_var)
@@ -4806,8 +4806,8 @@ fn (mut g Gen) map_init(node ast.MapInit) {
 	unwrap_val_typ := g.unwrap_generic(node.value_type)
 	key_typ_str := g.typ(unwrap_key_typ)
 	value_typ_str := g.typ(unwrap_val_typ)
-	value_typ := g.table.type_symbol(unwrap_val_typ)
-	key_typ := g.table.final_type_symbol(unwrap_key_typ)
+	value_typ := g.table.sym(unwrap_val_typ)
+	key_typ := g.table.final_sym(unwrap_key_typ)
 	hash_fn, key_eq_fn, clone_fn, free_fn := g.map_fn_ptrs(key_typ)
 	size := node.vals.len
 	mut shared_styp := '' // only needed for shared &[]{...}
@@ -5062,7 +5062,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 				g.write('(*(')
 			}
 			if v.smartcasts.len > 0 {
-				v_sym := g.table.type_symbol(v.typ)
+				v_sym := g.table.sym(v.typ)
 				if !prevent_sum_type_unwrapping_once {
 					for _ in v.smartcasts {
 						g.write('(')
@@ -5071,7 +5071,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 						}
 					}
 					for i, typ in v.smartcasts {
-						cast_sym := g.table.type_symbol(g.unwrap_generic(typ))
+						cast_sym := g.table.sym(g.unwrap_generic(typ))
 						mut is_ptr := false
 						if i == 0 {
 							g.write(name)
@@ -5081,7 +5081,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 						}
 						dot := if is_ptr || is_auto_heap { '->' } else { '.' }
 						if mut cast_sym.info is ast.Aggregate {
-							sym := g.table.type_symbol(cast_sym.info.types[g.aggregate_type_idx])
+							sym := g.table.sym(cast_sym.info.types[g.aggregate_type_idx])
 							g.write('${dot}_$sym.cname')
 						} else {
 							g.write('${dot}_$cast_sym.cname')
@@ -5128,7 +5128,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 		g.out.go_back(1)
 	}
 	g.is_amp = false
-	sym := g.table.type_symbol(node.typ)
+	sym := g.table.sym(node.typ)
 	if sym.kind in [.sum_type, .interface_] {
 		g.expr_with_cast(node.expr, node.expr_type, node.typ)
 	} else if sym.kind == .struct_ && !node.typ.is_ptr() && !(sym.info as ast.Struct).is_typedef {
@@ -5137,7 +5137,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 		g.write('*(($styp *)(&')
 		g.expr(node.expr)
 		g.write('))')
-	} else if sym.kind == .alias && g.table.final_type_symbol(node.typ).kind == .array_fixed {
+	} else if sym.kind == .alias && g.table.final_sym(node.typ).kind == .array_fixed {
 		g.expr(node.expr)
 	} else {
 		styp := g.typ(node.typ)
@@ -5178,7 +5178,7 @@ fn (mut g Gen) concat_expr(node ast.ConcatExpr) {
 	if g.inside_return {
 		styp = g.typ(g.fn_decl.return_type)
 	}
-	sym := g.table.type_symbol(node.return_type)
+	sym := g.table.sym(node.return_type)
 	is_multi := sym.kind == .multi_return
 	if !is_multi {
 		g.expr(node.vals[0])
@@ -5212,7 +5212,7 @@ fn (mut g Gen) need_tmp_var_in_if(node ast.IfExpr) bool {
 					}
 					if stmt.expr is ast.CallExpr {
 						if stmt.expr.is_method {
-							left_sym := g.table.type_symbol(stmt.expr.receiver_type)
+							left_sym := g.table.sym(stmt.expr.receiver_type)
 							if left_sym.kind in [.array, .array_fixed, .map] {
 								return true
 							}
@@ -5400,7 +5400,7 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 [inline]
 fn (g &Gen) expr_is_multi_return_call(expr ast.Expr) bool {
 	match expr {
-		ast.CallExpr { return g.table.type_symbol(expr.return_type).kind == .multi_return }
+		ast.CallExpr { return g.table.sym(expr.return_type).kind == .multi_return }
 		else { return false }
 	}
 }
@@ -5430,7 +5430,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 	}
 
 	// got to do a correct check for multireturn
-	sym := g.table.type_symbol(g.fn_decl.return_type)
+	sym := g.table.sym(g.fn_decl.return_type)
 	fn_return_is_multi := sym.kind == .multi_return
 	fn_return_is_optional := g.fn_decl.return_type.has_flag(.optional)
 	mut has_semicolon := false
@@ -5491,7 +5491,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			g.writeln('return $tmpvar;')
 			return
 		}
-		// typ_sym := g.table.type_symbol(g.fn_decl.return_type)
+		// typ_sym := g.table.sym(g.fn_decl.return_type)
 		// mr_info := typ_sym.info as ast.MultiReturn
 		mut styp := ''
 		if fn_return_is_optional {
@@ -5514,7 +5514,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			// Check if we are dealing with a multi return and handle it seperately
 			if g.expr_is_multi_return_call(expr) {
 				c := expr as ast.CallExpr
-				expr_sym := g.table.type_symbol(c.return_type)
+				expr_sym := g.table.sym(c.return_type)
 				// Create a tmp for this call
 				mut tmp := g.new_tmp_var()
 				if !c.return_type.has_flag(.optional) {
@@ -5580,7 +5580,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 		}
 	} else if node.exprs.len >= 1 {
 		// normal return
-		return_sym := g.table.type_symbol(node.types[0])
+		return_sym := g.table.sym(node.types[0])
 		expr0 := node.exprs[0]
 		// `return opt_ok(expr)` for functions that expect an optional
 		expr_type_is_opt := match expr0 {
@@ -5859,7 +5859,7 @@ fn (mut g Gen) const_decl_init_later(mod string, name string, expr ast.Expr, typ
 		}
 	}
 	if g.is_autofree {
-		sym := g.table.type_symbol(typ)
+		sym := g.table.sym(typ)
 		if styp.starts_with('Array_') {
 			if sym.has_method_with_generic_parent('free') {
 				g.cleanup.writeln('\t${styp}_free(&$cname);')
@@ -5930,7 +5930,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		g.go_back_out(3)
 		return
 	}
-	mut sym := g.table.final_type_symbol(g.unwrap_generic(node.typ))
+	mut sym := g.table.final_sym(g.unwrap_generic(node.typ))
 	is_amp := g.is_amp
 	is_multiline := node.fields.len > 5
 	g.is_amp = false // reset the flag immediately so that other struct inits in this expr are handled correctly
@@ -5986,7 +5986,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 			if field.typ == 0 {
 				g.checker_bug('struct init, field.typ is 0', field.pos)
 			}
-			field_type_sym := g.table.type_symbol(field.typ)
+			field_type_sym := g.table.sym(field.typ)
 			mut cloned := false
 			if g.is_autofree && !field.typ.is_ptr() && field_type_sym.kind in [.array, .string] {
 				g.write('/*clone1*/')
@@ -6029,7 +6029,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 			// fields that are initialized but belong to the embedding
 			init_fields_to_embed := node.fields.filter(it.name !in init_field_names)
 			for embed in info.embeds {
-				embed_sym := g.table.type_symbol(embed)
+				embed_sym := g.table.sym(embed)
 				embed_name := embed_sym.embed_name()
 				if embed_name !in inited_fields {
 					embed_info := embed_sym.info as ast.Struct
@@ -6084,7 +6084,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 					continue
 				}
 				g.write('.$field_name = ')
-				field_type_sym := g.table.type_symbol(sfield.typ)
+				field_type_sym := g.table.sym(sfield.typ)
 				mut cloned := false
 				if g.is_autofree && !sfield.typ.is_ptr() && field_type_sym.kind in [.array, .string] {
 					g.write('/*clone1*/')
@@ -6179,7 +6179,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 }
 
 fn (mut g Gen) zero_struct_field(field ast.StructField) bool {
-	sym := g.table.type_symbol(field.typ)
+	sym := g.table.sym(field.typ)
 	if sym.kind == .struct_ {
 		info := sym.info as ast.Struct
 		if info.fields.len == 0 {
@@ -6215,7 +6215,7 @@ fn (mut g Gen) assoc(node ast.Assoc) {
 		inited_fields[field] = i
 	}
 	// Merge inited_fields in the rest of the fields.
-	sym := g.table.type_symbol(node.typ)
+	sym := g.table.sym(node.typ)
 	info := sym.info as ast.Struct
 	for field in info.fields {
 		field_name := c_name(field.name)
@@ -6348,7 +6348,7 @@ fn (mut g Gen) write_builtin_types() {
 	// builtin types need to be on top
 	// everything except builtin will get sorted
 	for builtin_name in c.builtins {
-		sym := g.table.type_symbol_by_idx(g.table.type_idxs[builtin_name])
+		sym := g.table.sym_by_idx(g.table.type_idxs[builtin_name])
 		if sym.kind == .interface_ {
 			g.write_interface_typedef(sym)
 			g.write_interface_typesymbol_declaration(sym)
@@ -6388,7 +6388,7 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 			g.type_definitions.writeln('};')
 			g.typedefs2.writeln('typedef struct none none;')
 		}
-		// sym := g.table.type_symbol(typ)
+		// sym := g.table.sym(typ)
 		mut name := sym.cname
 		match mut sym.info {
 			ast.Struct {
@@ -6497,7 +6497,7 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 				g.type_definitions.writeln('struct $name {')
 				g.type_definitions.writeln('\tunion {')
 				for variant in sym.info.variants {
-					variant_sym := g.table.type_symbol(variant)
+					variant_sym := g.table.sym(variant)
 					g.type_definitions.writeln('\t\t${g.typ(variant.ref())} _$variant_sym.cname;')
 				}
 				g.type_definitions.writeln('\t};')
@@ -6512,7 +6512,7 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 				g.type_definitions.writeln('')
 			}
 			ast.ArrayFixed {
-				elem_sym := g.table.type_symbol(sym.info.elem_type)
+				elem_sym := g.table.sym(sym.info.elem_type)
 				if !elem_sym.is_builtin() && !sym.info.elem_type.has_flag(.generic) {
 					// .array_fixed {
 					styp := sym.cname
@@ -6566,14 +6566,14 @@ fn (g &Gen) sort_structs(typesa []&ast.TypeSymbol) []&ast.TypeSymbol {
 		mut field_deps := []string{}
 		match mut sym.info {
 			ast.ArrayFixed {
-				dep := g.table.type_symbol(sym.info.elem_type).name
+				dep := g.table.sym(sym.info.elem_type).name
 				if dep in type_names {
 					field_deps << dep
 				}
 			}
 			ast.Struct {
 				for embed in sym.info.embeds {
-					dep := g.table.type_symbol(embed).name
+					dep := g.table.sym(embed).name
 					// skip if not in types list or already in deps
 					if dep !in type_names || dep in field_deps {
 						continue
@@ -6581,7 +6581,7 @@ fn (g &Gen) sort_structs(typesa []&ast.TypeSymbol) []&ast.TypeSymbol {
 					field_deps << dep
 				}
 				for field in sym.info.fields {
-					dep := g.table.type_symbol(field.typ).name
+					dep := g.table.sym(field.typ).name
 					// skip if not in types list or already in deps
 					if dep !in type_names || dep in field_deps || field.typ.is_ptr() {
 						continue
@@ -6608,7 +6608,7 @@ fn (g &Gen) sort_structs(typesa []&ast.TypeSymbol) []&ast.TypeSymbol {
 	// sort types
 	mut sorted_symbols := []&ast.TypeSymbol{cap: dep_graph_sorted.nodes.len}
 	for node in dep_graph_sorted.nodes {
-		sorted_symbols << g.table.type_symbol_by_idx(g.table.type_idxs[node.name])
+		sorted_symbols << g.table.sym_by_idx(g.table.type_idxs[node.name])
 	}
 	return sorted_symbols
 }
@@ -6755,7 +6755,7 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 		// Default values for other types are not needed because of mandatory initialization
 		return '0'
 	}
-	sym := g.table.type_symbol(typ)
+	sym := g.table.sym(typ)
 	match sym.kind {
 		.string {
 			return '(string){.str=(byteptr)"", .is_lit=1}'
@@ -6782,7 +6782,7 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 			noscan := g.check_noscan(elem_typ)
 			init_str := '__new_array${noscan}(0, 0, sizeof($elem_type_str))'
 			if typ.has_flag(.shared_f) {
-				atyp := '__shared__Array_${g.table.type_symbol(elem_typ).cname}'
+				atyp := '__shared__Array_${g.table.sym(elem_typ).cname}'
 				return '($atyp*)__dup_shared_array(&($atyp){.mtx = {0}, .val =$init_str}, sizeof($atyp))'
 			} else {
 				return init_str
@@ -6790,7 +6790,7 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 		}
 		.map {
 			info := sym.map_info()
-			key_typ := g.table.type_symbol(info.key_type)
+			key_typ := g.table.sym(info.key_type)
 			hash_fn, key_eq_fn, clone_fn, free_fn := g.map_fn_ptrs(key_typ)
 			noscan_key := g.check_noscan(info.key_type)
 			noscan_value := g.check_noscan(info.value_type)
@@ -6805,7 +6805,7 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 			}
 			init_str := 'new_map${noscan}(sizeof(${g.typ(info.key_type)}), sizeof(${g.typ(info.value_type)}), $hash_fn, $key_eq_fn, $clone_fn, $free_fn)'
 			if typ.has_flag(.shared_f) {
-				mtyp := '__shared__Map_${key_typ.cname}_${g.table.type_symbol(info.value_type).cname}'
+				mtyp := '__shared__Map_${key_typ.cname}_${g.table.sym(info.value_type).cname}'
 				return '($mtyp*)__dup_shared_map(&($mtyp){.mtx = {0}, .val =$init_str}, sizeof($mtyp))'
 			} else {
 				return init_str
@@ -6818,13 +6818,13 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 			typ_is_shared_f := typ.has_flag(.shared_f)
 			if sym.language == .v && !typ_is_shared_f {
 				for field in info.fields {
-					field_sym := g.table.type_symbol(field.typ)
+					field_sym := g.table.sym(field.typ)
 					if field.has_default_expr
 						|| field_sym.kind in [.array, .map, .string, .bool, .alias, .i8, .i16, .int, .i64, .byte, .u16, .u32, .u64, .char, .voidptr, .byteptr, .charptr, .struct_] {
 						field_name := c_name(field.name)
 						if field.has_default_expr {
 							mut expr_str := ''
-							if g.table.type_symbol(field.typ).kind in [.sum_type, .interface_] {
+							if g.table.sym(field.typ).kind in [.sum_type, .interface_] {
 								expr_str = g.expr_string_with_cast(field.default_expr,
 									field.default_expr_typ, field.typ)
 							} else {
@@ -6855,7 +6855,7 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 				init_str += '0}'
 			}
 			if typ.has_flag(.shared_f) {
-				styp := '__shared__${g.table.type_symbol(typ).cname}'
+				styp := '__shared__${g.table.sym(typ).cname}'
 				return '($styp*)__dup${styp}(&($styp){.mtx = {0}, .val =$init_str}, sizeof($styp))'
 			} else {
 				return init_str
@@ -6918,7 +6918,7 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 		}
 	}
 	if expr.is_method {
-		receiver_sym := g.table.type_symbol(expr.receiver_type)
+		receiver_sym := g.table.sym(expr.receiver_type)
 		name = receiver_sym.name + '_' + name
 	} else if mut expr.left is ast.AnonFn {
 		g.gen_anon_fn_decl(mut expr.left)
@@ -6928,7 +6928,7 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 	if g.pref.obfuscate && g.cur_mod.name == 'main' && name.starts_with('main__') {
 		mut key := expr.name
 		if expr.is_method {
-			sym := g.table.type_symbol(expr.receiver_type)
+			sym := g.table.sym(expr.receiver_type)
 			key = sym.name + '.' + expr.name
 		}
 		g.write('/* obf go: $key */')
@@ -6967,7 +6967,7 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 		gohandle_name = if is_opt { '__v_thread_Option_void' } else { '__v_thread' }
 	} else {
 		opt := if is_opt { 'Option_' } else { '' }
-		gohandle_name = '__v_thread_$opt${g.table.type_symbol(g.unwrap_generic(node.call_expr.return_type)).cname}'
+		gohandle_name = '__v_thread_$opt${g.table.sym(g.unwrap_generic(node.call_expr.return_type)).cname}'
 	}
 	if g.pref.os == .windows {
 		simple_handle := if node.is_expr && node.call_expr.return_type != ast.void_type {
@@ -7081,7 +7081,7 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 		}
 		if expr.is_method {
 			unwrapped_rec_type := g.unwrap_generic(expr.receiver_type)
-			typ_sym := g.table.type_symbol(unwrapped_rec_type)
+			typ_sym := g.table.sym(unwrapped_rec_type)
 			if typ_sym.kind == .interface_
 				&& (typ_sym.info as ast.Interface).defines_method(expr.name) {
 				rec_cc_type := g.cc_type(unwrapped_rec_type, false)
@@ -7106,8 +7106,8 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 		if expr.args.len > 0 {
 			mut has_cast := false
 			for i in 0 .. expr.args.len {
-				if g.table.type_symbol(expr.expected_arg_types[i]).kind == .interface_
-					&& g.table.type_symbol(expr.args[i].typ).kind != .interface_ {
+				if g.table.sym(expr.expected_arg_types[i]).kind == .interface_
+					&& g.table.sym(expr.args[i].typ).kind != .interface_ {
 					has_cast = true
 					break
 				}
@@ -7154,8 +7154,8 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 	// are the same), otherwise panic.
 	// g.insert_before('
 	styp := g.typ(node.typ)
-	sym := g.table.type_symbol(node.typ)
-	mut expr_type_sym := g.table.type_symbol(node.expr_type)
+	sym := g.table.sym(node.typ)
+	mut expr_type_sym := g.table.sym(node.expr_type)
 	if mut expr_type_sym.info is ast.SumType {
 		dot := if node.expr_type.is_ptr() { '->' } else { '.' }
 		g.write('/* as */ *($styp*)__as_cast(')
@@ -7170,7 +7170,7 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 		g.write(dot)
 		// g.write('typ, /*expected:*/$node.typ)')
 		sidx := g.type_sidx(node.typ)
-		expected_sym := g.table.type_symbol(node.typ)
+		expected_sym := g.table.sym(node.typ)
 		g.write('_typ, $sidx) /*expected idx: $sidx, name: $expected_sym.name */ ')
 
 		// fill as cast name table
@@ -7179,7 +7179,7 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			if idx in g.as_cast_type_names {
 				continue
 			}
-			variant_sym := g.table.type_symbol(variant)
+			variant_sym := g.table.sym(variant)
 			g.as_cast_type_names[idx] = variant_sym.name
 		}
 	} else if expr_type_sym.kind == .interface_ && sym.kind == .interface_ {
@@ -7276,7 +7276,7 @@ fn (mut g Gen) interface_table() string {
 		iinidx_minimum_base := 1000 // NB: NOT 0, to avoid map entries set to 0 later, so `if already_generated_mwrappers[name] > 0 {` works.
 		mut current_iinidx := iinidx_minimum_base
 		for st in inter_info.types {
-			st_sym := g.table.type_symbol(st)
+			st_sym := g.table.sym(st)
 			// cctype is the Cleaned Concrete Type name, *without ptr*,
 			// i.e. cctype is always just Cat, not Cat_ptr:
 			cctype := g.cc_type(st, true)
@@ -7309,7 +7309,7 @@ fn (mut g Gen) interface_table() string {
 							cast_struct.write_string('/*.... ast.voidptr_type */')
 						} else {
 							for embed_type in st_sym.struct_info().embeds {
-								embed_sym := g.table.type_symbol(embed_type)
+								embed_sym := g.table.sym(embed_type)
 								if _ := embed_sym.find_field(field.name) {
 									cast_struct.write_string(' + __offsetof_ptr(x, $cctype, $embed_sym.embed_name()) + __offsetof_ptr(x, $embed_sym.cname, $cname)')
 									break
@@ -7344,7 +7344,7 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 			match st_sym.info {
 				ast.Struct, ast.Interface, ast.SumType {
 					if st_sym.info.parent_type.has_flag(.generic) {
-						parent_sym := g.table.type_symbol(st_sym.info.parent_type)
+						parent_sym := g.table.sym(st_sym.info.parent_type)
 						for method in parent_sym.methods {
 							if method.name in methodidx {
 								methods << st_sym.find_method_with_generic_parent(method.name) or {
@@ -7358,7 +7358,7 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 			}
 			if st_sym.info is ast.Struct {
 				for embed in st_sym.info.embeds {
-					embed_sym := g.table.type_symbol(embed)
+					embed_sym := g.table.sym(embed)
 					for embed_method in embed_sym.methods {
 						if embed_method.name !in method_names {
 							methods << embed_method
@@ -7369,7 +7369,7 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 			for method in methods {
 				mut name := method.name
 				if inter_info.parent_type.has_flag(.generic) {
-					parent_sym := g.table.type_symbol(inter_info.parent_type)
+					parent_sym := g.table.sym(inter_info.parent_type)
 					match mut parent_sym.info {
 						ast.Struct, ast.Interface, ast.SumType {
 							name = g.generic_fn_name(parent_sym.info.concrete_types, method.name,
@@ -7414,11 +7414,11 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 						ast.Fn{}, []ast.Type{}
 					}
 					if embed_types.len > 0 && method.name !in method_names {
-						embed_sym := g.table.type_symbol(embed_types.last())
+						embed_sym := g.table.sym(embed_types.last())
 						method_name := '${embed_sym.cname}_$method.name'
 						methods_wrapper.write_string('${method_name}(${fargs[0]}')
 						for embed in embed_types {
-							esym := g.table.type_symbol(embed)
+							esym := g.table.sym(embed)
 							methods_wrapper.write_string('->$esym.embed_name()')
 						}
 						methods_wrapper.writeln('${fargs[1..].join(', ')});')
@@ -7444,10 +7444,10 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 			}
 		}
 		for vtyp, variants in inter_info.conversions {
-			vsym := g.table.type_symbol(vtyp)
+			vsym := g.table.sym(vtyp)
 			conversion_functions.write_string('static inline bool I_${interface_name}_is_I_${vsym.cname}($interface_name x) {\n\treturn ')
 			for i, variant in variants {
-				variant_sym := g.table.type_symbol(variant)
+				variant_sym := g.table.sym(variant)
 				if i > 0 {
 					conversion_functions.write_string(' || ')
 				}
@@ -7457,7 +7457,7 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 
 			conversion_functions.writeln('static inline $vsym.cname I_${interface_name}_as_I_${vsym.cname}($interface_name x) {')
 			for variant in variants {
-				variant_sym := g.table.type_symbol(variant)
+				variant_sym := g.table.sym(variant)
 				conversion_functions.writeln('\tif (x._typ == _${interface_name}_${variant_sym.cname}_index) return I_${variant_sym.cname}_to_Interface_${vsym.cname}(x._$variant_sym.cname);')
 			}
 			pmessage := 'string__plus(string__plus(tos3("`as_cast`: cannot convert "), tos3(v_typeof_interface_${interface_name}(x._typ))), tos3(" to ${util.strip_main_name(vsym.name)}"))'
@@ -7531,7 +7531,7 @@ fn (mut g Gen) trace(fbase string, message string) {
 
 pub fn (mut g Gen) get_array_depth(el_typ ast.Type) int {
 	typ := g.unwrap_generic(el_typ)
-	sym := g.table.final_type_symbol(typ)
+	sym := g.table.final_sym(typ)
 	if sym.kind == .array {
 		info := sym.info as ast.Array
 		return 1 + g.get_array_depth(info.elem_type)
@@ -7550,7 +7550,7 @@ pub fn (mut g Gen) contains_ptr(el_typ ast.Type) bool {
 	if typ.is_ptr() {
 		return true
 	}
-	sym := g.table.final_type_symbol(typ)
+	sym := g.table.final_sym(typ)
 	if sym.language != .v {
 		return true
 	}

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -76,7 +76,7 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 		}
 		return
 	}
-	sym := g.table.type_symbol(g.unwrap_generic(node.left_type))
+	sym := g.table.sym(g.unwrap_generic(node.left_type))
 	g.trace_autofree('// \$method call. sym="$sym.name"')
 	if node.method_name == 'method' {
 		// `app.$method()`
@@ -335,11 +335,11 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) bool {
 					// Handle `$if x is Interface {`
 					// mut matches_interface := 'false'
 					if left is ast.TypeNode && cond.right is ast.TypeNode
-						&& g.table.type_symbol(got_type).kind == .interface_ {
+						&& g.table.sym(got_type).kind == .interface_ {
 						// `$if Foo is Interface {`
-						interface_sym := g.table.type_symbol(got_type)
+						interface_sym := g.table.sym(got_type)
 						if interface_sym.info is ast.Interface {
-							// q := g.table.type_symbol(interface_sym.info.types[0])
+							// q := g.table.sym(interface_sym.info.types[0])
 							checked_type := g.unwrap_generic(left.typ)
 							// TODO PERF this check is run twice (also in the checker)
 							// store the result in a field
@@ -408,7 +408,7 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) bool {
 }
 
 fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
-	sym := g.table.type_symbol(g.unwrap_generic(node.typ))
+	sym := g.table.sym(g.unwrap_generic(node.typ))
 	g.writeln('/* \$for $node.val_var in ${sym.name}($node.kind.str()) */ {')
 	g.indent++
 	// vweb_result_type := ast.new_type(g.table.find_type_idx('vweb.Result'))
@@ -509,7 +509,7 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 						'\t${node.val_var}.attrs = new_array_from_c_array($attrs.len, $attrs.len, sizeof(string), _MOV((string[$attrs.len]){' +
 						attrs.join(', ') + '}));\n')
 				}
-				// field_sym := g.table.type_symbol(field.typ)
+				// field_sym := g.table.sym(field.typ)
 				// g.writeln('\t${node.val_var}.typ = _SLIT("$field_sym.name");')
 				styp := field.typ
 				g.writeln('\t${node.val_var}.typ = $styp;')

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -76,7 +76,7 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 		}
 		return
 	}
-	sym := g.table.get_type_symbol(g.unwrap_generic(node.left_type))
+	sym := g.table.type_symbol(g.unwrap_generic(node.left_type))
 	g.trace_autofree('// \$method call. sym="$sym.name"')
 	if node.method_name == 'method' {
 		// `app.$method()`
@@ -335,11 +335,11 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) bool {
 					// Handle `$if x is Interface {`
 					// mut matches_interface := 'false'
 					if left is ast.TypeNode && cond.right is ast.TypeNode
-						&& g.table.get_type_symbol(got_type).kind == .interface_ {
+						&& g.table.type_symbol(got_type).kind == .interface_ {
 						// `$if Foo is Interface {`
-						interface_sym := g.table.get_type_symbol(got_type)
+						interface_sym := g.table.type_symbol(got_type)
 						if interface_sym.info is ast.Interface {
-							// q := g.table.get_type_symbol(interface_sym.info.types[0])
+							// q := g.table.type_symbol(interface_sym.info.types[0])
 							checked_type := g.unwrap_generic(left.typ)
 							// TODO PERF this check is run twice (also in the checker)
 							// store the result in a field
@@ -408,7 +408,7 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) bool {
 }
 
 fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
-	sym := g.table.get_type_symbol(g.unwrap_generic(node.typ))
+	sym := g.table.type_symbol(g.unwrap_generic(node.typ))
 	g.writeln('/* \$for $node.val_var in ${sym.name}($node.kind.str()) */ {')
 	g.indent++
 	// vweb_result_type := ast.new_type(g.table.find_type_idx('vweb.Result'))
@@ -509,7 +509,7 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 						'\t${node.val_var}.attrs = new_array_from_c_array($attrs.len, $attrs.len, sizeof(string), _MOV((string[$attrs.len]){' +
 						attrs.join(', ') + '}));\n')
 				}
-				// field_sym := g.table.get_type_symbol(field.typ)
+				// field_sym := g.table.type_symbol(field.typ)
 				// g.writeln('\t${node.val_var}.typ = _SLIT("$field_sym.name");')
 				styp := field.typ
 				g.writeln('\t${node.val_var}.typ = $styp;')

--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -22,7 +22,7 @@ fn (mut g Gen) dump_expr_definitions() {
 	mut dump_typedefs := map[string]bool{}
 	mut dump_fns := strings.new_builder(100)
 	for dump_type, cname in g.table.dumps {
-		dump_sym := g.table.type_symbol(dump_type)
+		dump_sym := g.table.sym(dump_type)
 		_, str_method_expects_ptr, _ := dump_sym.str_method_info()
 		is_ptr := ast.Type(dump_type).is_ptr()
 		deref, _ := deref_kind(str_method_expects_ptr, is_ptr, dump_type)

--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -22,7 +22,7 @@ fn (mut g Gen) dump_expr_definitions() {
 	mut dump_typedefs := map[string]bool{}
 	mut dump_fns := strings.new_builder(100)
 	for dump_type, cname in g.table.dumps {
-		dump_sym := g.table.get_type_symbol(dump_type)
+		dump_sym := g.table.type_symbol(dump_type)
 		_, str_method_expects_ptr, _ := dump_sym.str_method_info()
 		is_ptr := ast.Type(dump_type).is_ptr()
 		deref, _ := deref_kind(str_method_expects_ptr, is_ptr, dump_type)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -158,7 +158,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 		// loop thru each generic type and generate a function
 		for concrete_types in g.table.fn_generic_types[node.name] {
 			if g.pref.is_verbose {
-				syms := concrete_types.map(g.table.get_type_symbol(it))
+				syms := concrete_types.map(g.table.type_symbol(it))
 				the_type := syms.map(it.name).join(', ')
 				println('gen fn `$node.name` for type `$the_type`')
 			}
@@ -203,12 +203,12 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 		name = util.replace_op(name)
 	}
 	if node.is_method {
-		unwrapped_rec_sym := g.table.get_type_symbol(g.unwrap_generic(node.receiver.typ))
+		unwrapped_rec_sym := g.table.type_symbol(g.unwrap_generic(node.receiver.typ))
 		if unwrapped_rec_sym.kind == .placeholder {
 			return
 		}
 		name = g.cc_type(node.receiver.typ, false) + '_' + name
-		// name = g.table.get_type_symbol(node.receiver.typ).name + '_' + name
+		// name = g.table.type_symbol(node.receiver.typ).name + '_' + name
 	}
 	if node.language == .c {
 		name = util.no_dots(name)
@@ -241,7 +241,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 		&& node.name != 'str' {
 		mut key := node.name
 		if node.is_method {
-			sym := g.table.get_type_symbol(node.receiver.typ)
+			sym := g.table.type_symbol(node.receiver.typ)
 			key = sym.name + '.' + node.name
 		}
 		g.writeln('/* obf: $key */')
@@ -345,7 +345,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 						}
 					}
 					info := var.obj as ast.Var
-					if g.table.get_type_symbol(info.typ).kind != .function {
+					if g.table.type_symbol(info.typ).kind != .function {
 						g.writeln('${g.typ(info.typ)}$deref $var.name;')
 					}
 				}
@@ -529,7 +529,7 @@ fn (mut g Gen) fn_args(args []ast.Param, scope &ast.Scope) ([]string, []string, 
 	for i, arg in args {
 		mut caname := if arg.name == '_' { g.new_tmp_declaration_name() } else { c_name(arg.name) }
 		typ := g.unwrap_generic(arg.typ)
-		arg_type_sym := g.table.get_type_symbol(typ)
+		arg_type_sym := g.table.type_symbol(typ)
 		mut arg_type_name := g.typ(typ) // util.no_dots(arg_type_sym.name)
 		if arg_type_sym.kind == .function {
 			info := arg_type_sym.info as ast.FnType
@@ -622,7 +622,7 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 	if node.is_method && !node.is_field {
 		if node.name == 'writeln' && g.pref.experimental && node.args.len > 0
 			&& node.args[0].expr is ast.StringInterLiteral
-			&& g.table.get_type_symbol(node.receiver_type).name == 'strings.Builder' {
+			&& g.table.type_symbol(node.receiver_type).name == 'strings.Builder' {
 			g.string_inter_literal_sb_optimized(node)
 		} else {
 			g.method_call(node)
@@ -638,7 +638,7 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 		unwrapped_styp := g.typ(unwrapped_typ)
 		if unwrapped_typ == ast.void_type {
 			g.write('\n $cur_line')
-		} else if g.table.get_type_symbol(node.return_type).kind == .multi_return {
+		} else if g.table.type_symbol(node.return_type).kind == .multi_return {
 			g.write('\n $cur_line $tmp_opt /*U*/')
 		} else {
 			if !g.inside_const {
@@ -687,10 +687,10 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	if g.cur_fn != 0 && g.cur_fn.generic_names.len > 0 { // in generic fn
 		unwrapped_rec_type = g.unwrap_generic(node.receiver_type)
 	} else { // in non-generic fn
-		sym := g.table.get_type_symbol(node.receiver_type)
+		sym := g.table.type_symbol(node.receiver_type)
 		match sym.info {
 			ast.Struct, ast.Interface, ast.SumType {
-				generic_names := sym.info.generic_types.map(g.table.get_type_symbol(it).name)
+				generic_names := sym.info.generic_types.map(g.table.type_symbol(it).name)
 				// see comment at top of vlib/v/gen/c/utils.v
 				mut muttable := unsafe { &ast.Table(g.table) }
 				if utyp := muttable.resolve_generic_to_concrete(node.receiver_type, generic_names,
@@ -702,11 +702,11 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			else {}
 		}
 	}
-	mut typ_sym := g.table.get_type_symbol(unwrapped_rec_type)
+	mut typ_sym := g.table.type_symbol(unwrapped_rec_type)
 	// alias type that undefined this method (not include `str`) need to use parent type
 	if typ_sym.kind == .alias && node.name != 'str' && !typ_sym.has_method(node.name) {
 		unwrapped_rec_type = (typ_sym.info as ast.Alias).parent_type
-		typ_sym = g.table.get_type_symbol(unwrapped_rec_type)
+		typ_sym = g.table.type_symbol(unwrapped_rec_type)
 	}
 	rec_cc_type := g.cc_type(unwrapped_rec_type, false)
 	mut receiver_type_name := util.no_dots(rec_cc_type)
@@ -729,8 +729,8 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		g.write(')')
 		return
 	}
-	left_sym := g.table.get_type_symbol(node.left_type)
-	final_left_sym := g.table.get_final_type_symbol(node.left_type)
+	left_sym := g.table.type_symbol(node.left_type)
+	final_left_sym := g.table.final_type_symbol(node.left_type)
 	if left_sym.kind == .array {
 		match node.name {
 			'filter' {
@@ -853,7 +853,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 					g.gen_expr_to_string(node.left, rec_type)
 					return
 				} else if node.left.obj.smartcasts.len > 0 {
-					cast_sym := g.table.get_type_symbol(node.left.obj.smartcasts.last())
+					cast_sym := g.table.type_symbol(node.left.obj.smartcasts.last())
 					if cast_sym.info is ast.Aggregate {
 						rec_type = cast_sym.info.types[g.aggregate_type_idx]
 						g.gen_expr_to_string(node.left, rec_type)
@@ -912,7 +912,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	}
 	if g.pref.obfuscate && g.cur_mod.name == 'main' && name.starts_with('main__')
 		&& node.name != 'str' {
-		sym := g.table.get_type_symbol(node.receiver_type)
+		sym := g.table.type_symbol(node.receiver_type)
 		key := sym.name + '.' + node.name
 		g.write('/* obf method call: $key */')
 		name = g.obf_table[key] or {
@@ -1011,7 +1011,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			g.expr(node.left)
 		}
 		for embed in node.from_embed_types {
-			embed_sym := g.table.get_type_symbol(embed)
+			embed_sym := g.table.type_symbol(embed)
 			embed_name := embed_sym.embed_name()
 			if node.left_type.is_ptr() {
 				g.write('->')
@@ -1037,7 +1037,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	if name.contains('subkeys') {
 	println('call_args $name $node.arg_types.len')
 	for t in node.arg_types {
-		sym := g.table.get_type_symbol(t)
+		sym := g.table.type_symbol(t)
 		print('$sym.name ')
 	}
 	println('')
@@ -1059,7 +1059,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 	mut is_interface_call := false
 	mut is_selector_call := false
 	if node.left_type != 0 {
-		left_sym := g.table.get_type_symbol(node.left_type)
+		left_sym := g.table.type_symbol(node.left_type)
 		if left_sym.kind == .interface_ {
 			is_interface_call = true
 			g.write('(*')
@@ -1167,7 +1167,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 		}
 		if typ != ast.string_type || g.comptime_for_method.len > 0 {
 			expr := node.args[0].expr
-			typ_sym := g.table.get_type_symbol(typ)
+			typ_sym := g.table.type_symbol(typ)
 			if typ_sym.kind == .interface_ && (typ_sym.info as ast.Interface).defines_method('str') {
 				g.write('${c_name(print_method)}(')
 				rec_type_name := util.no_dots(g.cc_type(typ, false))
@@ -1200,7 +1200,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 					if expr.obj is ast.Var {
 						typ = expr.obj.typ
 						if expr.obj.smartcasts.len > 0 {
-							cast_sym := g.table.get_type_symbol(expr.obj.smartcasts.last())
+							cast_sym := g.table.type_symbol(expr.obj.smartcasts.last())
 							if cast_sym.info is ast.Aggregate {
 								typ = cast_sym.info.types[g.aggregate_type_idx]
 							}
@@ -1234,7 +1234,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 								g.write('(*')
 							}
 							for i, typ in obj.smartcasts {
-								cast_sym := g.table.get_type_symbol(g.unwrap_generic(typ))
+								cast_sym := g.table.type_symbol(g.unwrap_generic(typ))
 								mut is_ptr := false
 								if i == 0 {
 									g.write(node.name)
@@ -1244,7 +1244,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 								}
 								dot := if is_ptr { '->' } else { '.' }
 								if mut cast_sym.info is ast.Aggregate {
-									sym := g.table.get_type_symbol(cast_sym.info.types[g.aggregate_type_idx])
+									sym := g.table.type_symbol(cast_sym.info.types[g.aggregate_type_idx])
 									g.write('${dot}_$sym.cname')
 								} else {
 									g.write('${dot}_$cast_sym.cname')
@@ -1479,7 +1479,7 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 	if is_variadic {
 		varg_type := expected_types.last()
 		variadic_count := args.len - arg_nr
-		arr_sym := g.table.get_type_symbol(varg_type)
+		arr_sym := g.table.type_symbol(varg_type)
 		mut arr_info := arr_sym.info as ast.Array
 		if varg_type.has_flag(.generic) {
 			if fn_def := g.table.find_fn(node.name) {
@@ -1530,7 +1530,7 @@ fn (mut g Gen) keep_alive_call_pregen(node ast.CallExpr) int {
 		// save all arguments in temp vars (not only pointers) to make sure the
 		// evaluation order is preserved
 		expected_type := node.expected_arg_types[i]
-		typ := g.table.get_type_symbol(expected_type).cname
+		typ := g.table.type_symbol(expected_type).cname
 		g.write('$typ __tmp_arg_${tmp_cnt_save + i} = ')
 		// g.expr(arg.expr)
 		g.ref_or_deref_arg(arg, expected_type, node.language)
@@ -1556,7 +1556,7 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 	if expected_type == 0 {
 		g.checker_bug('ref_or_deref_arg expected_type is 0', arg.pos)
 	}
-	exp_sym := g.table.get_type_symbol(expected_type)
+	exp_sym := g.table.type_symbol(expected_type)
 	arg_typ := g.unwrap_generic(arg.typ)
 	mut needs_closing := false
 	if arg.is_mut && !arg_is_ptr {
@@ -1582,13 +1582,13 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 			if arg_typ == 0 {
 				g.checker_bug('ref_or_deref_arg arg.typ is 0', arg.pos)
 			}
-			arg_typ_sym := g.table.get_type_symbol(arg_typ)
+			arg_typ_sym := g.table.type_symbol(arg_typ)
 			expected_deref_type := if expected_type.is_ptr() {
 				expected_type.deref()
 			} else {
 				expected_type
 			}
-			deref_sym := g.table.get_type_symbol(expected_deref_type)
+			deref_sym := g.table.type_symbol(expected_deref_type)
 			if !((arg_typ_sym.kind == .function)
 				|| deref_sym.kind in [.sum_type, .interface_]) && lang != .c {
 				if arg.expr.is_lvalue() {

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -10,7 +10,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 	if node.index is ast.RangeExpr {
 		g.range_expr(node, node.index)
 	} else {
-		sym := g.table.get_final_type_symbol(node.left_type)
+		sym := g.table.final_type_symbol(node.left_type)
 		if sym.kind == .array {
 			g.index_of_array(node, sym)
 		} else if sym.kind == .array_fixed {
@@ -58,7 +58,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 }
 
 fn (mut g Gen) range_expr(node ast.IndexExpr, range ast.RangeExpr) {
-	sym := g.table.get_final_type_symbol(node.left_type)
+	sym := g.table.final_type_symbol(node.left_type)
 	if sym.kind == .string {
 		g.write('string_substr(')
 		g.expr(node.left)
@@ -123,7 +123,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 	info := sym.info as ast.Array
 	elem_type_str := g.typ(info.elem_type)
 	elem_type := info.elem_type
-	elem_typ := g.table.get_type_symbol(elem_type)
+	elem_typ := g.table.type_symbol(elem_type)
 	// `vals[i].field = x` is an exception and requires `array_get`:
 	// `(*(Val*)array_get(vals, i)).field = x;`
 	is_selector := node.left is ast.SelectorExpr
@@ -287,7 +287,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 fn (mut g Gen) index_of_fixed_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 	info := sym.info as ast.ArrayFixed
 	elem_type := info.elem_type
-	elem_sym := g.table.get_type_symbol(elem_type)
+	elem_sym := g.table.type_symbol(elem_type)
 	is_fn_index_call := g.is_fn_index_call && elem_sym.info is ast.FnType
 
 	if is_fn_index_call {
@@ -323,7 +323,7 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 	key_type_str := g.typ(info.key_type)
 	elem_type := info.value_type
 	elem_type_str := g.typ(elem_type)
-	elem_typ := g.table.get_type_symbol(elem_type)
+	elem_typ := g.table.type_symbol(elem_type)
 	get_and_set_types := elem_typ.kind in [.struct_, .map]
 	if g.is_assign_lhs && !g.is_arraymap_set && !get_and_set_types {
 		if g.assign_op == .assign || info.value_type == ast.string_type {

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -10,7 +10,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 	if node.index is ast.RangeExpr {
 		g.range_expr(node, node.index)
 	} else {
-		sym := g.table.final_type_symbol(node.left_type)
+		sym := g.table.final_sym(node.left_type)
 		if sym.kind == .array {
 			g.index_of_array(node, sym)
 		} else if sym.kind == .array_fixed {
@@ -58,7 +58,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 }
 
 fn (mut g Gen) range_expr(node ast.IndexExpr, range ast.RangeExpr) {
-	sym := g.table.final_type_symbol(node.left_type)
+	sym := g.table.final_sym(node.left_type)
 	if sym.kind == .string {
 		g.write('string_substr(')
 		g.expr(node.left)
@@ -123,7 +123,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 	info := sym.info as ast.Array
 	elem_type_str := g.typ(info.elem_type)
 	elem_type := info.elem_type
-	elem_typ := g.table.type_symbol(elem_type)
+	elem_typ := g.table.sym(elem_type)
 	// `vals[i].field = x` is an exception and requires `array_get`:
 	// `(*(Val*)array_get(vals, i)).field = x;`
 	is_selector := node.left is ast.SelectorExpr
@@ -287,7 +287,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 fn (mut g Gen) index_of_fixed_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 	info := sym.info as ast.ArrayFixed
 	elem_type := info.elem_type
-	elem_sym := g.table.type_symbol(elem_type)
+	elem_sym := g.table.sym(elem_type)
 	is_fn_index_call := g.is_fn_index_call && elem_sym.info is ast.FnType
 
 	if is_fn_index_call {
@@ -323,7 +323,7 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 	key_type_str := g.typ(info.key_type)
 	elem_type := info.value_type
 	elem_type_str := g.typ(elem_type)
-	elem_typ := g.table.type_symbol(elem_type)
+	elem_typ := g.table.sym(elem_type)
 	get_and_set_types := elem_typ.kind in [.struct_, .map]
 	if g.is_assign_lhs && !g.is_arraymap_set && !get_and_set_types {
 		if g.assign_op == .assign || info.value_type == ast.string_type {

--- a/vlib/v/gen/c/infix_expr.v
+++ b/vlib/v/gen/c/infix_expr.v
@@ -448,7 +448,7 @@ fn (mut g Gen) infix_expr_in_op(node ast.InfixExpr) {
 // i.e. `a in [1,2,3]` => `a == 1 || a == 2 || a == 3`
 fn (mut g Gen) infix_expr_in_optimization(left ast.Expr, right ast.ArrayInit) {
 	is_str := right.elem_type.idx() == ast.string_type_idx
-	elem_sym := g.table.get_type_symbol(right.elem_type)
+	elem_sym := g.table.type_symbol(right.elem_type)
 	is_array := elem_sym.kind == .array
 	for i, array_expr in right.exprs {
 		if is_str {
@@ -475,8 +475,8 @@ fn (mut g Gen) infix_expr_in_optimization(left ast.Expr, right ast.ArrayInit) {
 
 // infix_expr_is_op generates code for `is` and `!is`
 fn (mut g Gen) infix_expr_is_op(node ast.InfixExpr) {
-	sym := g.table.get_type_symbol(node.left_type)
-	right_sym := g.table.get_type_symbol(node.right_type)
+	sym := g.table.type_symbol(node.left_type)
+	right_sym := g.table.type_symbol(node.right_type)
 	if sym.kind == .interface_ && right_sym.kind == .interface_ {
 		g.gen_interface_is_op(node)
 		return
@@ -499,7 +499,7 @@ fn (mut g Gen) infix_expr_is_op(node ast.InfixExpr) {
 			ast.None { g.table.type_idxs['None__'] }
 			else { ast.Type(0) }
 		}
-		sub_sym := g.table.get_type_symbol(sub_type)
+		sub_sym := g.table.type_symbol(sub_type)
 		g.write('_${c_name(sym.name)}_${c_name(sub_sym.name)}_index')
 		return
 	} else if sym.kind == .sum_type {
@@ -509,8 +509,8 @@ fn (mut g Gen) infix_expr_is_op(node ast.InfixExpr) {
 }
 
 fn (mut g Gen) gen_interface_is_op(node ast.InfixExpr) {
-	mut left_sym := g.table.get_type_symbol(node.left_type)
-	right_sym := g.table.get_type_symbol(node.right_type)
+	mut left_sym := g.table.type_symbol(node.left_type)
+	right_sym := g.table.type_symbol(node.right_type)
 
 	mut info := left_sym.info as ast.Interface
 
@@ -595,7 +595,7 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 		} else {
 			// push a single element
 			elem_type_str := g.typ(array_info.elem_type)
-			elem_sym := g.table.get_type_symbol(array_info.elem_type)
+			elem_sym := g.table.type_symbol(array_info.elem_type)
 			g.write('array_push${noscan}((array*)')
 			if node.left_type.has_flag(.shared_f) && !node.left_type.deref().is_ptr() {
 			}
@@ -631,7 +631,7 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 fn (mut g Gen) need_tmp_var_in_array_call(node ast.Expr) bool {
 	match node {
 		ast.CallExpr {
-			if node.left_type != 0 && g.table.get_type_symbol(node.left_type).kind == .array
+			if node.left_type != 0 && g.table.type_symbol(node.left_type).kind == .array
 				&& node.name in ['all', 'any', 'filter', 'map'] {
 				return true
 			}

--- a/vlib/v/gen/c/infix_expr.v
+++ b/vlib/v/gen/c/infix_expr.v
@@ -448,7 +448,7 @@ fn (mut g Gen) infix_expr_in_op(node ast.InfixExpr) {
 // i.e. `a in [1,2,3]` => `a == 1 || a == 2 || a == 3`
 fn (mut g Gen) infix_expr_in_optimization(left ast.Expr, right ast.ArrayInit) {
 	is_str := right.elem_type.idx() == ast.string_type_idx
-	elem_sym := g.table.type_symbol(right.elem_type)
+	elem_sym := g.table.sym(right.elem_type)
 	is_array := elem_sym.kind == .array
 	for i, array_expr in right.exprs {
 		if is_str {
@@ -475,8 +475,8 @@ fn (mut g Gen) infix_expr_in_optimization(left ast.Expr, right ast.ArrayInit) {
 
 // infix_expr_is_op generates code for `is` and `!is`
 fn (mut g Gen) infix_expr_is_op(node ast.InfixExpr) {
-	sym := g.table.type_symbol(node.left_type)
-	right_sym := g.table.type_symbol(node.right_type)
+	sym := g.table.sym(node.left_type)
+	right_sym := g.table.sym(node.right_type)
 	if sym.kind == .interface_ && right_sym.kind == .interface_ {
 		g.gen_interface_is_op(node)
 		return
@@ -499,7 +499,7 @@ fn (mut g Gen) infix_expr_is_op(node ast.InfixExpr) {
 			ast.None { g.table.type_idxs['None__'] }
 			else { ast.Type(0) }
 		}
-		sub_sym := g.table.type_symbol(sub_type)
+		sub_sym := g.table.sym(sub_type)
 		g.write('_${c_name(sym.name)}_${c_name(sub_sym.name)}_index')
 		return
 	} else if sym.kind == .sum_type {
@@ -509,8 +509,8 @@ fn (mut g Gen) infix_expr_is_op(node ast.InfixExpr) {
 }
 
 fn (mut g Gen) gen_interface_is_op(node ast.InfixExpr) {
-	mut left_sym := g.table.type_symbol(node.left_type)
-	right_sym := g.table.type_symbol(node.right_type)
+	mut left_sym := g.table.sym(node.left_type)
+	right_sym := g.table.sym(node.right_type)
 
 	mut info := left_sym.info as ast.Interface
 
@@ -595,7 +595,7 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 		} else {
 			// push a single element
 			elem_type_str := g.typ(array_info.elem_type)
-			elem_sym := g.table.type_symbol(array_info.elem_type)
+			elem_sym := g.table.sym(array_info.elem_type)
 			g.write('array_push${noscan}((array*)')
 			if node.left_type.has_flag(.shared_f) && !node.left_type.deref().is_ptr() {
 			}
@@ -631,7 +631,7 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 fn (mut g Gen) need_tmp_var_in_array_call(node ast.Expr) bool {
 	match node {
 		ast.CallExpr {
-			if node.left_type != 0 && g.table.type_symbol(node.left_type).kind == .array
+			if node.left_type != 0 && g.table.sym(node.left_type).kind == .array
 				&& node.name in ['all', 'any', 'filter', 'map'] {
 				return true
 			}

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -20,7 +20,7 @@ import strings
 // Codegen json_decode/encode funcs
 fn (mut g Gen) gen_json_for_type(typ ast.Type) {
 	utyp := g.unwrap_generic(typ).set_nr_muls(0)
-	sym := g.table.get_type_symbol(utyp)
+	sym := g.table.type_symbol(utyp)
 	if is_js_prim(sym.name) || sym.kind == .enum_ {
 		return
 	}
@@ -37,7 +37,7 @@ fn (mut g Gen) gen_jsons() {
 		done << utyp
 		mut dec := strings.new_builder(100)
 		mut enc := strings.new_builder(100)
-		sym := g.table.get_type_symbol(utyp)
+		sym := g.table.type_symbol(utyp)
 		styp := g.typ(utyp)
 		g.register_optional(utyp)
 		// println('gen_json_for_type($sym.name)')
@@ -85,7 +85,7 @@ $enc_fn_dec {
 		} else if sym.kind == .alias {
 			a := sym.info as ast.Alias
 			parent_typ := a.parent_type
-			psym := g.table.get_type_symbol(parent_typ)
+			psym := g.table.type_symbol(parent_typ)
 			if is_js_prim(g.typ(parent_typ)) {
 				g.gen_json_for_type(parent_typ)
 				continue
@@ -146,7 +146,7 @@ fn (mut g Gen) gen_sumtype_enc_dec(sym ast.TypeSymbol, mut enc strings.Builder, 
 	for variant in info.variants {
 		variant_typ := g.typ(variant)
 		variant_types << variant_typ
-		variant_sym := g.table.get_type_symbol(variant)
+		variant_sym := g.table.type_symbol(variant)
 		variant_symbols << variant_sym
 		at_least_one_prim = at_least_one_prim || is_js_prim(variant_typ)
 			|| variant_sym.kind == .enum_ || variant_sym.name == 'time.Time'
@@ -323,7 +323,7 @@ fn (mut g Gen) gen_struct_enc_dec(type_info ast.TypeInfo, styp string, mut enc s
 			continue
 		}
 		field_type := g.typ(field.typ)
-		field_sym := g.table.get_type_symbol(field.typ)
+		field_sym := g.table.type_symbol(field.typ)
 		// First generate decoding
 		if is_raw {
 			dec.writeln('\tres.${c_name(field.name)} = tos5(cJSON_PrintUnformatted(' +
@@ -470,7 +470,7 @@ fn (mut g Gen) encode_array(value_type ast.Type) string {
 fn (mut g Gen) decode_map(key_type ast.Type, value_type ast.Type) string {
 	styp := g.typ(key_type)
 	styp_v := g.typ(value_type)
-	key_type_symbol := g.table.get_type_symbol(key_type)
+	key_type_symbol := g.table.type_symbol(key_type)
 	hash_fn, key_eq_fn, clone_fn, free_fn := g.map_fn_ptrs(key_type_symbol)
 	fn_name_v := js_dec_name(styp_v)
 	mut s := ''

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -20,7 +20,7 @@ import strings
 // Codegen json_decode/encode funcs
 fn (mut g Gen) gen_json_for_type(typ ast.Type) {
 	utyp := g.unwrap_generic(typ).set_nr_muls(0)
-	sym := g.table.type_symbol(utyp)
+	sym := g.table.sym(utyp)
 	if is_js_prim(sym.name) || sym.kind == .enum_ {
 		return
 	}
@@ -37,7 +37,7 @@ fn (mut g Gen) gen_jsons() {
 		done << utyp
 		mut dec := strings.new_builder(100)
 		mut enc := strings.new_builder(100)
-		sym := g.table.type_symbol(utyp)
+		sym := g.table.sym(utyp)
 		styp := g.typ(utyp)
 		g.register_optional(utyp)
 		// println('gen_json_for_type($sym.name)')
@@ -85,7 +85,7 @@ $enc_fn_dec {
 		} else if sym.kind == .alias {
 			a := sym.info as ast.Alias
 			parent_typ := a.parent_type
-			psym := g.table.type_symbol(parent_typ)
+			psym := g.table.sym(parent_typ)
 			if is_js_prim(g.typ(parent_typ)) {
 				g.gen_json_for_type(parent_typ)
 				continue
@@ -146,7 +146,7 @@ fn (mut g Gen) gen_sumtype_enc_dec(sym ast.TypeSymbol, mut enc strings.Builder, 
 	for variant in info.variants {
 		variant_typ := g.typ(variant)
 		variant_types << variant_typ
-		variant_sym := g.table.type_symbol(variant)
+		variant_sym := g.table.sym(variant)
 		variant_symbols << variant_sym
 		at_least_one_prim = at_least_one_prim || is_js_prim(variant_typ)
 			|| variant_sym.kind == .enum_ || variant_sym.name == 'time.Time'
@@ -323,7 +323,7 @@ fn (mut g Gen) gen_struct_enc_dec(type_info ast.TypeInfo, styp string, mut enc s
 			continue
 		}
 		field_type := g.typ(field.typ)
-		field_sym := g.table.type_symbol(field.typ)
+		field_sym := g.table.sym(field.typ)
 		// First generate decoding
 		if is_raw {
 			dec.writeln('\tres.${c_name(field.name)} = tos5(cJSON_PrintUnformatted(' +
@@ -470,7 +470,7 @@ fn (mut g Gen) encode_array(value_type ast.Type) string {
 fn (mut g Gen) decode_map(key_type ast.Type, value_type ast.Type) string {
 	styp := g.typ(key_type)
 	styp_v := g.typ(value_type)
-	key_type_symbol := g.table.type_symbol(key_type)
+	key_type_symbol := g.table.sym(key_type)
 	hash_fn, key_eq_fn, clone_fn, free_fn := g.map_fn_ptrs(key_type_symbol)
 	fn_name_v := js_dec_name(styp_v)
 	mut s := ''

--- a/vlib/v/gen/c/sql.v
+++ b/vlib/v/gen/c/sql.v
@@ -50,7 +50,7 @@ fn (mut g Gen) sql_stmt(node ast.SqlStmt) {
 fn (mut g Gen) sql_stmt_line(nd ast.SqlStmtLine, expr string) {
 	mut node := nd
 	table_name := g.get_table_name(node.table_expr)
-	g.sql_table_name = g.table.type_symbol(node.table_expr.typ).name
+	g.sql_table_name = g.table.sym(node.table_expr.typ).name
 	res := g.new_tmp_var()
 	mut subs := false
 	mut dcheck := false
@@ -111,7 +111,7 @@ fn (mut g Gen) sql_create_table(node ast.SqlStmtLine, expr string, table_name st
 	if node.fields.len > 0 {
 		g.write(' _MOV((orm__TableField[$node.fields.len]){')
 		for field in node.fields {
-			sym := g.table.type_symbol(field.typ)
+			sym := g.table.sym(field.typ)
 			g.write('(orm__TableField){')
 			g.write('.name = _SLIT("$field.name"),')
 			mut typ := int(field.typ)
@@ -154,7 +154,7 @@ fn (mut g Gen) sql_insert(node ast.SqlStmtLine, expr string, table_name string, 
 	mut field_names := []string{}
 
 	for f in node.fields {
-		sym := g.table.type_symbol(f.typ)
+		sym := g.table.sym(f.typ)
 		if sym.kind == .struct_ && sym.name != 'time.Time' {
 			subs << node.sub_structs[int(f.typ)]
 		} else if sym.kind == .array {
@@ -178,7 +178,7 @@ fn (mut g Gen) sql_insert(node ast.SqlStmtLine, expr string, table_name string, 
 		}
 	}
 
-	fields := node.fields.filter(g.table.type_symbol(it.typ).kind != .array)
+	fields := node.fields.filter(g.table.sym(it.typ).kind != .array)
 
 	for sub in subs {
 		g.sql_stmt_line(sub, expr)
@@ -209,7 +209,7 @@ fn (mut g Gen) sql_insert(node ast.SqlStmtLine, expr string, table_name string, 
 				g.write('$pid, ')
 				continue
 			}
-			mut sym := g.table.type_symbol(f.typ)
+			mut sym := g.table.sym(f.typ)
 			mut typ := sym.cname
 			if sym.kind == .struct_ && typ != 'time__Time' {
 				g.write('(*(orm__Primitive*) array_get($last_ids_arr, $structs)),')
@@ -336,7 +336,7 @@ fn (mut g Gen) sql_expr_to_orm_primitive(expr ast.Expr) {
 }
 
 fn (mut g Gen) sql_write_orm_primitive(t ast.Type, expr ast.Expr) {
-	mut sym := g.table.type_symbol(t)
+	mut sym := g.table.sym(t)
 	mut typ := sym.cname
 	if typ == 'orm__Primitive' {
 		g.expr(expr)
@@ -550,7 +550,7 @@ fn (mut g Gen) sql_select(node ast.SqlExpr, expr string, left string) {
 
 	res := g.new_tmp_var()
 	table_name := g.get_table_name(node.table_expr)
-	g.sql_table_name = g.table.type_symbol(node.table_expr.typ).name
+	g.sql_table_name = g.table.sym(node.table_expr.typ).name
 	g.write('Option_Array_Array_orm__Primitive _o$res = orm__Connection_name_table[${expr}._typ]._method_select(${expr}._object, ')
 	g.write('(orm__SelectConfig){')
 	g.write('.table = _SLIT("$table_name"),')
@@ -572,14 +572,14 @@ fn (mut g Gen) sql_select(node ast.SqlExpr, expr string, left string) {
 	if prim != '' {
 		g.write('.primary = _SLIT("$prim"),')
 	}
-	select_fields := fields.filter(g.table.type_symbol(it.typ).kind != .array)
+	select_fields := fields.filter(g.table.sym(it.typ).kind != .array)
 	g.write('.fields = new_array_from_c_array($select_fields.len, $select_fields.len, sizeof(string),')
 	mut types := []int{}
 	if select_fields.len > 0 {
 		g.write(' _MOV((string[$select_fields.len]){')
 		for field in select_fields {
 			g.write('_SLIT("${g.get_field_name(field)}"),')
-			sym := g.table.type_symbol(field.typ)
+			sym := g.table.sym(field.typ)
 			if sym.name == 'time.Time' {
 				types << -2
 				continue
@@ -648,12 +648,12 @@ fn (mut g Gen) sql_select(node ast.SqlExpr, expr string, left string) {
 		g.writeln('int $idx = 0;')
 		mut typ_str := ''
 		if node.is_array {
-			info := g.table.type_symbol(node.typ).array_info()
+			info := g.table.sym(node.typ).array_info()
 			typ_str = g.typ(info.elem_type)
 			g.writeln('$styp ${tmp}_array = __new_array(0, ${res}.len, sizeof($typ_str));')
 			g.writeln('for (; $idx < ${res}.len; $idx++) {')
 			g.write('\t$typ_str $tmp = ($typ_str) {')
-			inf := g.table.type_symbol(info.elem_type).struct_info()
+			inf := g.table.sym(info.elem_type).struct_info()
 			for i, field in inf.fields {
 				g.zero_struct_field(field)
 				if i != inf.fields.len - 1 {
@@ -663,7 +663,7 @@ fn (mut g Gen) sql_select(node ast.SqlExpr, expr string, left string) {
 			g.writeln('};')
 		} else {
 			g.write('$styp $tmp = ($styp){')
-			info := g.table.type_symbol(node.typ).struct_info()
+			info := g.table.sym(node.typ).struct_info()
 			for i, field in info.fields {
 				g.zero_struct_field(field)
 				if i != info.fields.len - 1 {
@@ -676,7 +676,7 @@ fn (mut g Gen) sql_select(node ast.SqlExpr, expr string, left string) {
 		g.writeln('if (${res}.len > 0) {')
 		for i, field in fields {
 			sel := '(*(orm__Primitive*) array_get((*(Array_orm__Primitive*) array_get($res, $idx)), $i))'
-			sym := g.table.type_symbol(field.typ)
+			sym := g.table.sym(field.typ)
 			if sym.kind == .struct_ && sym.name != 'time.Time' {
 				mut sub := node.sub_structs[int(field.typ)]
 				mut where_expr := sub.where_expr as ast.InfixExpr
@@ -801,8 +801,8 @@ fn (mut g Gen) parse_db_from_type_string(name string) SqlType {
 }
 
 fn (mut g Gen) get_table_name(table_expr ast.TypeNode) string {
-	info := g.table.type_symbol(table_expr.typ).struct_info()
-	mut tablename := util.strip_mod_name(g.table.type_symbol(table_expr.typ).name)
+	info := g.table.sym(table_expr.typ).struct_info()
+	mut tablename := util.strip_mod_name(g.table.sym(table_expr.typ).name)
 	for attr in info.attrs {
 		if attr.kind == .string && attr.name == 'table' && attr.arg != '' {
 			tablename = attr.arg
@@ -813,7 +813,7 @@ fn (mut g Gen) get_table_name(table_expr ast.TypeNode) string {
 }
 
 fn (mut g Gen) get_struct_field(name string) ast.StructField {
-	info := g.table.type_symbol(g.table.type_idxs[g.sql_table_name]).struct_info()
+	info := g.table.sym(g.table.type_idxs[g.sql_table_name]).struct_info()
 	mut f := ast.StructField{}
 	for field in info.fields {
 		if field.name == name {
@@ -831,7 +831,7 @@ fn (mut g Gen) get_field_name(field ast.StructField) string {
 			break
 		}
 	}
-	sym := g.table.type_symbol(field.typ)
+	sym := g.table.sym(field.typ)
 	if sym.kind == .struct_ && sym.name != 'time.Time' {
 		name = '${name}_id'
 	}

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -52,7 +52,7 @@ fn (mut g Gen) string_inter_literal_sb_optimized(call_expr ast.CallExpr) {
 		typ := node.expr_types[i]
 		g.write(g.typ(typ))
 		g.write('_str(')
-		sym := g.table.type_symbol(typ)
+		sym := g.table.sym(typ)
 		if sym.kind != .function {
 			g.expr(node.exprs[i])
 		}
@@ -69,10 +69,10 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 	if is_shared {
 		typ = typ.clear_flag(.shared_f).set_nr_muls(0)
 	}
-	mut sym := g.table.type_symbol(typ)
+	mut sym := g.table.sym(typ)
 	// when type is alias, print the aliased value
 	if mut sym.info is ast.Alias {
-		parent_sym := g.table.type_symbol(sym.info.parent_type)
+		parent_sym := g.table.sym(sym.info.parent_type)
 		if parent_sym.has_method('str') {
 			typ = sym.info.parent_type
 			sym = parent_sym

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -52,7 +52,7 @@ fn (mut g Gen) string_inter_literal_sb_optimized(call_expr ast.CallExpr) {
 		typ := node.expr_types[i]
 		g.write(g.typ(typ))
 		g.write('_str(')
-		sym := g.table.get_type_symbol(typ)
+		sym := g.table.type_symbol(typ)
 		if sym.kind != .function {
 			g.expr(node.exprs[i])
 		}
@@ -69,10 +69,10 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 	if is_shared {
 		typ = typ.clear_flag(.shared_f).set_nr_muls(0)
 	}
-	mut sym := g.table.get_type_symbol(typ)
+	mut sym := g.table.type_symbol(typ)
 	// when type is alias, print the aliased value
 	if mut sym.info is ast.Alias {
-		parent_sym := g.table.get_type_symbol(sym.info.parent_type)
+		parent_sym := g.table.type_symbol(sym.info.parent_type)
 		if parent_sym.has_method('str') {
 			typ = sym.info.parent_type
 			sym = parent_sym

--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -16,7 +16,7 @@ fn (mut g Gen) str_format(node ast.StringInterLiteral, i int) (u64, string) {
 	mut base := 0 // numeric base
 	mut upper_case := false // set upercase for the result string
 	mut typ := g.unwrap_generic(node.expr_types[i])
-	sym := g.table.get_type_symbol(typ)
+	sym := g.table.type_symbol(typ)
 	if sym.kind == .alias {
 		typ = (sym.info as ast.Alias).parent_type
 	}
@@ -125,7 +125,7 @@ fn (mut g Gen) str_val(node ast.StringInterLiteral, i int) {
 	expr := node.exprs[i]
 
 	typ := g.unwrap_generic(node.expr_types[i])
-	typ_sym := g.table.get_type_symbol(typ)
+	typ_sym := g.table.type_symbol(typ)
 	if typ == ast.string_type && g.comptime_for_method.len == 0 {
 		if g.inside_vweb_tmpl {
 			g.write('vweb__filter(')
@@ -156,7 +156,7 @@ fn (mut g Gen) str_val(node ast.StringInterLiteral, i int) {
 				if g.comptime_var_type_map.len > 0 || g.comptime_for_method.len > 0 {
 					exp_typ = expr.obj.typ
 				} else if expr.obj.smartcasts.len > 0 {
-					cast_sym := g.table.get_type_symbol(expr.obj.smartcasts.last())
+					cast_sym := g.table.type_symbol(expr.obj.smartcasts.last())
 					if cast_sym.info is ast.Aggregate {
 						exp_typ = cast_sym.info.types[g.aggregate_type_idx]
 					}

--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -16,7 +16,7 @@ fn (mut g Gen) str_format(node ast.StringInterLiteral, i int) (u64, string) {
 	mut base := 0 // numeric base
 	mut upper_case := false // set upercase for the result string
 	mut typ := g.unwrap_generic(node.expr_types[i])
-	sym := g.table.type_symbol(typ)
+	sym := g.table.sym(typ)
 	if sym.kind == .alias {
 		typ = (sym.info as ast.Alias).parent_type
 	}
@@ -125,7 +125,7 @@ fn (mut g Gen) str_val(node ast.StringInterLiteral, i int) {
 	expr := node.exprs[i]
 
 	typ := g.unwrap_generic(node.expr_types[i])
-	typ_sym := g.table.type_symbol(typ)
+	typ_sym := g.table.sym(typ)
 	if typ == ast.string_type && g.comptime_for_method.len == 0 {
 		if g.inside_vweb_tmpl {
 			g.write('vweb__filter(')
@@ -156,7 +156,7 @@ fn (mut g Gen) str_val(node ast.StringInterLiteral, i int) {
 				if g.comptime_var_type_map.len > 0 || g.comptime_for_method.len > 0 {
 					exp_typ = expr.obj.typ
 				} else if expr.obj.smartcasts.len > 0 {
-					cast_sym := g.table.type_symbol(expr.obj.smartcasts.last())
+					cast_sym := g.table.sym(expr.obj.smartcasts.last())
 					if cast_sym.info is ast.Aggregate {
 						exp_typ = cast_sym.info.types[g.aggregate_type_idx]
 					}

--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -43,7 +43,7 @@ struct Type {
 // * alias unwrapped
 fn (mut g Gen) unwrap(typ ast.Type) Type {
 	no_generic := g.unwrap_generic(typ)
-	no_generic_sym := g.table.get_type_symbol(no_generic)
+	no_generic_sym := g.table.type_symbol(no_generic)
 	if no_generic_sym.kind != .alias {
 		return Type{
 			typ: no_generic
@@ -56,6 +56,6 @@ fn (mut g Gen) unwrap(typ ast.Type) Type {
 		typ: no_generic
 		sym: no_generic_sym
 		unaliased: no_generic_sym.parent_idx
-		unaliased_sym: g.table.get_type_symbol(no_generic_sym.parent_idx)
+		unaliased_sym: g.table.type_symbol(no_generic_sym.parent_idx)
 	}
 }

--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -43,7 +43,7 @@ struct Type {
 // * alias unwrapped
 fn (mut g Gen) unwrap(typ ast.Type) Type {
 	no_generic := g.unwrap_generic(typ)
-	no_generic_sym := g.table.type_symbol(no_generic)
+	no_generic_sym := g.table.sym(no_generic)
 	if no_generic_sym.kind != .alias {
 		return Type{
 			typ: no_generic
@@ -56,6 +56,6 @@ fn (mut g Gen) unwrap(typ ast.Type) Type {
 		typ: no_generic
 		sym: no_generic_sym
 		unaliased: no_generic_sym.parent_idx
-		unaliased_sym: g.table.type_symbol(no_generic_sym.parent_idx)
+		unaliased_sym: g.table.sym(no_generic_sym.parent_idx)
 	}
 }

--- a/vlib/v/gen/js/array.v
+++ b/vlib/v/gen/js/array.v
@@ -15,13 +15,13 @@ const (
 
 fn (mut g JsGen) gen_array_index_method(left_type ast.Type) string {
 	unwrap_left_type := g.unwrap_generic(left_type)
-	mut left_sym := g.table.type_symbol(unwrap_left_type)
+	mut left_sym := g.table.sym(unwrap_left_type)
 	mut left_type_str := g.typ(unwrap_left_type).trim('*')
 	fn_name := '${left_type_str}_index'
 
 	if !left_sym.has_method('index') {
 		info := left_sym.info as ast.Array
-		elem_sym := g.table.type_symbol(info.elem_type)
+		elem_sym := g.table.sym(info.elem_type)
 		if elem_sym.kind == .function {
 			left_type_str = 'Array_voidptr'
 		}
@@ -79,7 +79,7 @@ fn (mut g JsGen) gen_array_method_call(it ast.CallExpr) {
 		}
 		'insert' {
 			g.write('array_')
-			arg2_sym := g.table.type_symbol(node.args[1].typ)
+			arg2_sym := g.table.sym(node.args[1].typ)
 			is_arg2_array := arg2_sym.kind == .array && node.args[1].typ == node.left_type
 			if is_arg2_array {
 				g.write('insert_many(')
@@ -108,7 +108,7 @@ fn (mut g JsGen) gen_array_method_call(it ast.CallExpr) {
 		}
 		'prepend' {
 			g.write('array_')
-			arg_sym := g.table.type_symbol(node.args[0].typ)
+			arg_sym := g.table.sym(node.args[0].typ)
 			is_arg_array := arg_sym.kind == .array && node.args[0].typ == node.left_type
 			if is_arg_array {
 				g.write('prepend_many(')
@@ -165,13 +165,13 @@ fn (mut g JsGen) gen_array_contains_method(left_type ast.Type) string {
 	if unwrap_left_type.share() == .shared_t {
 		unwrap_left_type = unwrap_left_type.clear_flag(.shared_f)
 	}
-	mut left_sym := g.table.type_symbol(unwrap_left_type)
-	left_final_sym := g.table.final_type_symbol(unwrap_left_type)
+	mut left_sym := g.table.sym(unwrap_left_type)
+	left_final_sym := g.table.final_sym(unwrap_left_type)
 	mut left_type_str := g.typ(unwrap_left_type).replace('*', '')
 	fn_name := '${left_type_str}_contains'
 	if !left_sym.has_method('contains') {
 		left_info := left_final_sym.info as ast.Array
-		elem_sym := g.table.type_symbol(left_info.elem_type)
+		elem_sym := g.table.sym(left_info.elem_type)
 		if elem_sym.kind == .function {
 			left_type_str = 'Array_voidptr'
 		}
@@ -214,7 +214,7 @@ fn (mut g JsGen) gen_array_contains_method(left_type ast.Type) string {
 }
 
 fn (mut g JsGen) gen_array_sort(node ast.CallExpr) {
-	rec_sym := g.table.type_symbol(node.receiver_type)
+	rec_sym := g.table.sym(node.receiver_type)
 	if rec_sym.kind != .array {
 		println(node.name)
 		verror('.sort() is an array method')

--- a/vlib/v/gen/js/array.v
+++ b/vlib/v/gen/js/array.v
@@ -15,13 +15,13 @@ const (
 
 fn (mut g JsGen) gen_array_index_method(left_type ast.Type) string {
 	unwrap_left_type := g.unwrap_generic(left_type)
-	mut left_sym := g.table.get_type_symbol(unwrap_left_type)
+	mut left_sym := g.table.type_symbol(unwrap_left_type)
 	mut left_type_str := g.typ(unwrap_left_type).trim('*')
 	fn_name := '${left_type_str}_index'
 
 	if !left_sym.has_method('index') {
 		info := left_sym.info as ast.Array
-		elem_sym := g.table.get_type_symbol(info.elem_type)
+		elem_sym := g.table.type_symbol(info.elem_type)
 		if elem_sym.kind == .function {
 			left_type_str = 'Array_voidptr'
 		}
@@ -79,7 +79,7 @@ fn (mut g JsGen) gen_array_method_call(it ast.CallExpr) {
 		}
 		'insert' {
 			g.write('array_')
-			arg2_sym := g.table.get_type_symbol(node.args[1].typ)
+			arg2_sym := g.table.type_symbol(node.args[1].typ)
 			is_arg2_array := arg2_sym.kind == .array && node.args[1].typ == node.left_type
 			if is_arg2_array {
 				g.write('insert_many(')
@@ -108,7 +108,7 @@ fn (mut g JsGen) gen_array_method_call(it ast.CallExpr) {
 		}
 		'prepend' {
 			g.write('array_')
-			arg_sym := g.table.get_type_symbol(node.args[0].typ)
+			arg_sym := g.table.type_symbol(node.args[0].typ)
 			is_arg_array := arg_sym.kind == .array && node.args[0].typ == node.left_type
 			if is_arg_array {
 				g.write('prepend_many(')
@@ -165,13 +165,13 @@ fn (mut g JsGen) gen_array_contains_method(left_type ast.Type) string {
 	if unwrap_left_type.share() == .shared_t {
 		unwrap_left_type = unwrap_left_type.clear_flag(.shared_f)
 	}
-	mut left_sym := g.table.get_type_symbol(unwrap_left_type)
-	left_final_sym := g.table.get_final_type_symbol(unwrap_left_type)
+	mut left_sym := g.table.type_symbol(unwrap_left_type)
+	left_final_sym := g.table.final_type_symbol(unwrap_left_type)
 	mut left_type_str := g.typ(unwrap_left_type).replace('*', '')
 	fn_name := '${left_type_str}_contains'
 	if !left_sym.has_method('contains') {
 		left_info := left_final_sym.info as ast.Array
-		elem_sym := g.table.get_type_symbol(left_info.elem_type)
+		elem_sym := g.table.type_symbol(left_info.elem_type)
 		if elem_sym.kind == .function {
 			left_type_str = 'Array_voidptr'
 		}
@@ -214,7 +214,7 @@ fn (mut g JsGen) gen_array_contains_method(left_type ast.Type) string {
 }
 
 fn (mut g JsGen) gen_array_sort(node ast.CallExpr) {
-	rec_sym := g.table.get_type_symbol(node.receiver_type)
+	rec_sym := g.table.type_symbol(node.receiver_type)
 	if rec_sym.kind != .array {
 		println(node.name)
 		verror('.sort() is an array method')

--- a/vlib/v/gen/js/auto_eq_methods.v
+++ b/vlib/v/gen/js/auto_eq_methods.v
@@ -134,7 +134,7 @@ fn (mut g JsGen) gen_alias_equality_fn(left_type ast.Type) string {
 		g.definitions.writeln(fn_builder.str())
 	}
 	fn_builder.writeln('function ${ptr_styp}_alias_eq(a,b) {')
-	sym := g.table.get_type_symbol(info.parent_type)
+	sym := g.table.type_symbol(info.parent_type)
 	if sym.kind == .string {
 		fn_builder.writeln('\treturn new bool(a.str == b.str);')
 	} else if sym.kind == .sum_type && !left.typ.is_ptr() {

--- a/vlib/v/gen/js/auto_eq_methods.v
+++ b/vlib/v/gen/js/auto_eq_methods.v
@@ -134,7 +134,7 @@ fn (mut g JsGen) gen_alias_equality_fn(left_type ast.Type) string {
 		g.definitions.writeln(fn_builder.str())
 	}
 	fn_builder.writeln('function ${ptr_styp}_alias_eq(a,b) {')
-	sym := g.table.type_symbol(info.parent_type)
+	sym := g.table.sym(info.parent_type)
 	if sym.kind == .string {
 		fn_builder.writeln('\treturn new bool(a.str == b.str);')
 	} else if sym.kind == .sum_type && !left.typ.is_ptr() {

--- a/vlib/v/gen/js/auto_str_methods.v
+++ b/vlib/v/gen/js/auto_str_methods.v
@@ -26,11 +26,11 @@ fn (mut g JsGen) get_str_fn(typ ast.Type) string {
 		unwrapped.set_flag(.optional)
 	}
 	styp := g.typ(unwrapped)
-	mut sym := g.table.get_type_symbol(unwrapped)
+	mut sym := g.table.type_symbol(unwrapped)
 	mut str_fn_name := styp_to_str_fn_name(styp)
 	if mut sym.info is ast.Alias {
 		if sym.info.is_import {
-			sym = g.table.get_type_symbol(sym.info.parent_type)
+			sym = g.table.type_symbol(sym.info.parent_type)
 			str_fn_name = styp_to_str_fn_name(sym.name)
 		}
 	}
@@ -46,7 +46,7 @@ fn (mut g JsGen) final_gen_str(typ StrType) {
 		return
 	}
 	g.generated_str_fns << typ
-	sym := g.table.get_type_symbol(typ.typ)
+	sym := g.table.type_symbol(typ.typ)
 	if sym.has_method('str') && !typ.typ.has_flag(.optional) {
 		return
 	}
@@ -218,7 +218,7 @@ fn (mut g JsGen) gen_str_default(sym ast.TypeSymbol, styp string, str_fn_name st
 
 fn (mut g JsGen) gen_str_for_option(typ ast.Type, styp string, str_fn_name string) {
 	parent_type := typ.clear_flag(.optional)
-	sym := g.table.get_type_symbol(parent_type)
+	sym := g.table.type_symbol(parent_type)
 	sym_has_str_method, _, _ := sym.str_method_info()
 	parent_str_fn_name := g.get_str_fn(parent_type)
 
@@ -262,7 +262,7 @@ fn (mut g JsGen) gen_str_for_multi_return(info ast.MultiReturn, styp string, str
 	fn_builder.writeln('\tlet sb = strings__new_builder($info.types.len * 10);')
 	fn_builder.writeln('\tstrings__Builder_write_string(sb, new string("("));')
 	for i, typ in info.types {
-		sym := g.table.get_type_symbol(typ)
+		sym := g.table.type_symbol(typ)
 		is_arg_ptr := typ.is_ptr()
 		sym_has_str_method, str_method_expects_ptr, _ := sym.str_method_info()
 		arg_str_fn_name := g.get_str_fn(typ)
@@ -348,7 +348,7 @@ fn (mut g JsGen) gen_str_for_interface(info ast.Interface, styp string, str_fn_n
 	clean_interface_v_type_name = util.strip_main_name(clean_interface_v_type_name)
 	fn_builder.writeln('function indent_${str_fn_name}(x,indent_count) { /* gen_str_for_interface */')
 	for typ in info.types {
-		subtype := g.table.get_type_symbol(typ)
+		subtype := g.table.type_symbol(typ)
 		mut func_name := g.get_str_fn(typ)
 		sym_has_str_method, str_method_expects_ptr, _ := subtype.str_method_info()
 		if should_use_indent_func(subtype.kind) && !sym_has_str_method {
@@ -383,7 +383,7 @@ fn (mut g JsGen) gen_str_for_union_sum_type(info ast.SumType, styp string, str_f
 	for typ in info.variants {
 		typ_str := g.typ(typ)
 		mut func_name := g.get_str_fn(typ)
-		sym := g.table.get_type_symbol(typ)
+		sym := g.table.type_symbol(typ)
 		sym_has_str_method, str_method_expects_ptr, _ := sym.str_method_info()
 		deref := if sym_has_str_method && str_method_expects_ptr {
 			' '
@@ -458,10 +458,10 @@ fn deref_kind(str_method_expects_ptr bool, is_elem_ptr bool, typ ast.Type) (stri
 
 fn (mut g JsGen) gen_str_for_array(info ast.Array, styp string, str_fn_name string) {
 	mut typ := info.elem_type
-	mut sym := g.table.get_type_symbol(info.elem_type)
+	mut sym := g.table.type_symbol(info.elem_type)
 	if mut sym.info is ast.Alias {
 		typ = sym.info.parent_type
-		sym = g.table.get_type_symbol(typ)
+		sym = g.table.type_symbol(typ)
 	}
 	is_elem_ptr := typ.is_ptr()
 	sym_has_str_method, str_method_expects_ptr, _ := sym.str_method_info()
@@ -518,10 +518,10 @@ fn (mut g JsGen) gen_str_for_array(info ast.Array, styp string, str_fn_name stri
 
 fn (mut g JsGen) gen_str_for_array_fixed(info ast.ArrayFixed, styp string, str_fn_name string) {
 	mut typ := info.elem_type
-	mut sym := g.table.get_type_symbol(info.elem_type)
+	mut sym := g.table.type_symbol(info.elem_type)
 	if mut sym.info is ast.Alias {
 		typ = sym.info.parent_type
-		sym = g.table.get_type_symbol(typ)
+		sym = g.table.type_symbol(typ)
 	}
 	is_elem_ptr := typ.is_ptr()
 	sym_has_str_method, str_method_expects_ptr, _ := sym.str_method_info()
@@ -572,10 +572,10 @@ fn (mut g JsGen) gen_str_for_array_fixed(info ast.ArrayFixed, styp string, str_f
 
 fn (mut g JsGen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 	mut key_typ := info.key_type
-	mut key_sym := g.table.get_type_symbol(key_typ)
+	mut key_sym := g.table.type_symbol(key_typ)
 	if mut key_sym.info is ast.Alias {
 		key_typ = key_sym.info.parent_type
-		key_sym = g.table.get_type_symbol(key_typ)
+		key_sym = g.table.type_symbol(key_typ)
 	}
 	key_styp := g.typ(key_typ)
 	key_str_fn_name := key_styp.replace('*', '') + '_str'
@@ -584,10 +584,10 @@ fn (mut g JsGen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) 
 	}
 
 	mut val_typ := info.value_type
-	mut val_sym := g.table.get_type_symbol(val_typ)
+	mut val_sym := g.table.type_symbol(val_typ)
 	if mut val_sym.info is ast.Alias {
 		val_typ = val_sym.info.parent_type
-		val_sym = g.table.get_type_symbol(val_typ)
+		val_sym = g.table.type_symbol(val_typ)
 	}
 	val_styp := g.typ(val_typ)
 	elem_str_fn_name := val_styp.replace('*', '') + '_str'
@@ -656,7 +656,7 @@ fn (g &JsGen) type_to_fmt(typ ast.Type) StrIntpType {
 		// return '%C\\000' // a C string
 		return .si_s
 	}
-	sym := g.table.get_type_symbol(typ)
+	sym := g.table.type_symbol(typ)
 	if typ.is_ptr() && (typ.is_int_valptr() || typ.is_float_valptr()) {
 		return .si_s
 	} else if sym.kind in [.struct_, .array, .array_fixed, .map, .bool, .enum_, .interface_,
@@ -726,7 +726,7 @@ fn (mut g JsGen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name st
 		}
 		quote_str = quote_str
 		*/
-		sym := g.table.get_type_symbol(g.unwrap_generic(field.typ))
+		sym := g.table.type_symbol(g.unwrap_generic(field.typ))
 		// first fields doesn't need \n
 		if i == 0 {
 			fn_builder.write_string('res.str += "    $field.name: $ptr_amp$prefix" + ')

--- a/vlib/v/gen/js/auto_str_methods.v
+++ b/vlib/v/gen/js/auto_str_methods.v
@@ -26,11 +26,11 @@ fn (mut g JsGen) get_str_fn(typ ast.Type) string {
 		unwrapped.set_flag(.optional)
 	}
 	styp := g.typ(unwrapped)
-	mut sym := g.table.type_symbol(unwrapped)
+	mut sym := g.table.sym(unwrapped)
 	mut str_fn_name := styp_to_str_fn_name(styp)
 	if mut sym.info is ast.Alias {
 		if sym.info.is_import {
-			sym = g.table.type_symbol(sym.info.parent_type)
+			sym = g.table.sym(sym.info.parent_type)
 			str_fn_name = styp_to_str_fn_name(sym.name)
 		}
 	}
@@ -46,7 +46,7 @@ fn (mut g JsGen) final_gen_str(typ StrType) {
 		return
 	}
 	g.generated_str_fns << typ
-	sym := g.table.type_symbol(typ.typ)
+	sym := g.table.sym(typ.typ)
 	if sym.has_method('str') && !typ.typ.has_flag(.optional) {
 		return
 	}
@@ -218,7 +218,7 @@ fn (mut g JsGen) gen_str_default(sym ast.TypeSymbol, styp string, str_fn_name st
 
 fn (mut g JsGen) gen_str_for_option(typ ast.Type, styp string, str_fn_name string) {
 	parent_type := typ.clear_flag(.optional)
-	sym := g.table.type_symbol(parent_type)
+	sym := g.table.sym(parent_type)
 	sym_has_str_method, _, _ := sym.str_method_info()
 	parent_str_fn_name := g.get_str_fn(parent_type)
 
@@ -262,7 +262,7 @@ fn (mut g JsGen) gen_str_for_multi_return(info ast.MultiReturn, styp string, str
 	fn_builder.writeln('\tlet sb = strings__new_builder($info.types.len * 10);')
 	fn_builder.writeln('\tstrings__Builder_write_string(sb, new string("("));')
 	for i, typ in info.types {
-		sym := g.table.type_symbol(typ)
+		sym := g.table.sym(typ)
 		is_arg_ptr := typ.is_ptr()
 		sym_has_str_method, str_method_expects_ptr, _ := sym.str_method_info()
 		arg_str_fn_name := g.get_str_fn(typ)
@@ -348,7 +348,7 @@ fn (mut g JsGen) gen_str_for_interface(info ast.Interface, styp string, str_fn_n
 	clean_interface_v_type_name = util.strip_main_name(clean_interface_v_type_name)
 	fn_builder.writeln('function indent_${str_fn_name}(x,indent_count) { /* gen_str_for_interface */')
 	for typ in info.types {
-		subtype := g.table.type_symbol(typ)
+		subtype := g.table.sym(typ)
 		mut func_name := g.get_str_fn(typ)
 		sym_has_str_method, str_method_expects_ptr, _ := subtype.str_method_info()
 		if should_use_indent_func(subtype.kind) && !sym_has_str_method {
@@ -383,7 +383,7 @@ fn (mut g JsGen) gen_str_for_union_sum_type(info ast.SumType, styp string, str_f
 	for typ in info.variants {
 		typ_str := g.typ(typ)
 		mut func_name := g.get_str_fn(typ)
-		sym := g.table.type_symbol(typ)
+		sym := g.table.sym(typ)
 		sym_has_str_method, str_method_expects_ptr, _ := sym.str_method_info()
 		deref := if sym_has_str_method && str_method_expects_ptr {
 			' '
@@ -458,10 +458,10 @@ fn deref_kind(str_method_expects_ptr bool, is_elem_ptr bool, typ ast.Type) (stri
 
 fn (mut g JsGen) gen_str_for_array(info ast.Array, styp string, str_fn_name string) {
 	mut typ := info.elem_type
-	mut sym := g.table.type_symbol(info.elem_type)
+	mut sym := g.table.sym(info.elem_type)
 	if mut sym.info is ast.Alias {
 		typ = sym.info.parent_type
-		sym = g.table.type_symbol(typ)
+		sym = g.table.sym(typ)
 	}
 	is_elem_ptr := typ.is_ptr()
 	sym_has_str_method, str_method_expects_ptr, _ := sym.str_method_info()
@@ -518,10 +518,10 @@ fn (mut g JsGen) gen_str_for_array(info ast.Array, styp string, str_fn_name stri
 
 fn (mut g JsGen) gen_str_for_array_fixed(info ast.ArrayFixed, styp string, str_fn_name string) {
 	mut typ := info.elem_type
-	mut sym := g.table.type_symbol(info.elem_type)
+	mut sym := g.table.sym(info.elem_type)
 	if mut sym.info is ast.Alias {
 		typ = sym.info.parent_type
-		sym = g.table.type_symbol(typ)
+		sym = g.table.sym(typ)
 	}
 	is_elem_ptr := typ.is_ptr()
 	sym_has_str_method, str_method_expects_ptr, _ := sym.str_method_info()
@@ -572,10 +572,10 @@ fn (mut g JsGen) gen_str_for_array_fixed(info ast.ArrayFixed, styp string, str_f
 
 fn (mut g JsGen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 	mut key_typ := info.key_type
-	mut key_sym := g.table.type_symbol(key_typ)
+	mut key_sym := g.table.sym(key_typ)
 	if mut key_sym.info is ast.Alias {
 		key_typ = key_sym.info.parent_type
-		key_sym = g.table.type_symbol(key_typ)
+		key_sym = g.table.sym(key_typ)
 	}
 	key_styp := g.typ(key_typ)
 	key_str_fn_name := key_styp.replace('*', '') + '_str'
@@ -584,10 +584,10 @@ fn (mut g JsGen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) 
 	}
 
 	mut val_typ := info.value_type
-	mut val_sym := g.table.type_symbol(val_typ)
+	mut val_sym := g.table.sym(val_typ)
 	if mut val_sym.info is ast.Alias {
 		val_typ = val_sym.info.parent_type
-		val_sym = g.table.type_symbol(val_typ)
+		val_sym = g.table.sym(val_typ)
 	}
 	val_styp := g.typ(val_typ)
 	elem_str_fn_name := val_styp.replace('*', '') + '_str'
@@ -656,7 +656,7 @@ fn (g &JsGen) type_to_fmt(typ ast.Type) StrIntpType {
 		// return '%C\\000' // a C string
 		return .si_s
 	}
-	sym := g.table.type_symbol(typ)
+	sym := g.table.sym(typ)
 	if typ.is_ptr() && (typ.is_int_valptr() || typ.is_float_valptr()) {
 		return .si_s
 	} else if sym.kind in [.struct_, .array, .array_fixed, .map, .bool, .enum_, .interface_,
@@ -726,7 +726,7 @@ fn (mut g JsGen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name st
 		}
 		quote_str = quote_str
 		*/
-		sym := g.table.type_symbol(g.unwrap_generic(field.typ))
+		sym := g.table.sym(g.unwrap_generic(field.typ))
 		// first fields doesn't need \n
 		if i == 0 {
 			fn_builder.write_string('res.str += "    $field.name: $ptr_amp$prefix" + ')

--- a/vlib/v/gen/js/builtin_types.v
+++ b/vlib/v/gen/js/builtin_types.v
@@ -22,7 +22,7 @@ fn (mut g JsGen) copy_val(t ast.Type, tmp string) string {
 }
 
 fn (mut g JsGen) to_js_typ_val(t ast.Type) string {
-	sym := g.table.get_type_symbol(t)
+	sym := g.table.type_symbol(t)
 	mut styp := ''
 	mut prefix := 'new '
 	match sym.kind {
@@ -135,7 +135,7 @@ fn (mut g JsGen) base_type(_t ast.Type) string {
 }
 
 pub fn (mut g JsGen) typ(t ast.Type) string {
-	sym := g.table.get_final_type_symbol(t)
+	sym := g.table.final_type_symbol(t)
 	if sym.kind == .voidptr {
 		return 'voidptr'
 	}
@@ -146,7 +146,7 @@ pub fn (mut g JsGen) typ(t ast.Type) string {
 
 // V type to JS type
 pub fn (mut g JsGen) doc_typ(t ast.Type) string {
-	sym := g.table.get_type_symbol(t)
+	sym := g.table.type_symbol(t)
 	mut styp := ''
 	match sym.kind {
 		.placeholder {
@@ -214,7 +214,7 @@ pub fn (mut g JsGen) doc_typ(t ast.Type) string {
 			styp = 'union_sym_type'
 		}
 		.alias {
-			fsym := g.table.get_final_type_symbol(t)
+			fsym := g.table.final_type_symbol(t)
 			name := g.js_name(fsym.name)
 			styp += '$name'
 		}

--- a/vlib/v/gen/js/builtin_types.v
+++ b/vlib/v/gen/js/builtin_types.v
@@ -22,7 +22,7 @@ fn (mut g JsGen) copy_val(t ast.Type, tmp string) string {
 }
 
 fn (mut g JsGen) to_js_typ_val(t ast.Type) string {
-	sym := g.table.type_symbol(t)
+	sym := g.table.sym(t)
 	mut styp := ''
 	mut prefix := 'new '
 	match sym.kind {
@@ -135,7 +135,7 @@ fn (mut g JsGen) base_type(_t ast.Type) string {
 }
 
 pub fn (mut g JsGen) typ(t ast.Type) string {
-	sym := g.table.final_type_symbol(t)
+	sym := g.table.final_sym(t)
 	if sym.kind == .voidptr {
 		return 'voidptr'
 	}
@@ -146,7 +146,7 @@ pub fn (mut g JsGen) typ(t ast.Type) string {
 
 // V type to JS type
 pub fn (mut g JsGen) doc_typ(t ast.Type) string {
-	sym := g.table.type_symbol(t)
+	sym := g.table.sym(t)
 	mut styp := ''
 	match sym.kind {
 		.placeholder {
@@ -214,7 +214,7 @@ pub fn (mut g JsGen) doc_typ(t ast.Type) string {
 			styp = 'union_sym_type'
 		}
 		.alias {
-			fsym := g.table.final_type_symbol(t)
+			fsym := g.table.final_sym(t)
 			name := g.js_name(fsym.name)
 			styp += '$name'
 		}

--- a/vlib/v/gen/js/comptime.v
+++ b/vlib/v/gen/js/comptime.v
@@ -96,11 +96,11 @@ fn (mut g JsGen) comptime_if_cond(cond ast.Expr, pkg_exist bool) bool {
 					// Handle `$if x is Interface {`
 					// mut matches_interface := 'false'
 					if left is ast.TypeNode && cond.right is ast.TypeNode
-						&& g.table.type_symbol(got_type).kind == .interface_ {
+						&& g.table.sym(got_type).kind == .interface_ {
 						// `$if Foo is Interface {`
-						interface_sym := g.table.type_symbol(got_type)
+						interface_sym := g.table.sym(got_type)
 						if interface_sym.info is ast.Interface {
-							// q := g.table.type_symbol(interface_sym.info.types[0])
+							// q := g.table.sym(interface_sym.info.types[0])
 							checked_type := g.unwrap_generic(left.typ)
 							// TODO PERF this check is run twice (also in the checker)
 							// store the result in a field

--- a/vlib/v/gen/js/comptime.v
+++ b/vlib/v/gen/js/comptime.v
@@ -96,11 +96,11 @@ fn (mut g JsGen) comptime_if_cond(cond ast.Expr, pkg_exist bool) bool {
 					// Handle `$if x is Interface {`
 					// mut matches_interface := 'false'
 					if left is ast.TypeNode && cond.right is ast.TypeNode
-						&& g.table.get_type_symbol(got_type).kind == .interface_ {
+						&& g.table.type_symbol(got_type).kind == .interface_ {
 						// `$if Foo is Interface {`
-						interface_sym := g.table.get_type_symbol(got_type)
+						interface_sym := g.table.type_symbol(got_type)
 						if interface_sym.info is ast.Interface {
-							// q := g.table.get_type_symbol(interface_sym.info.types[0])
+							// q := g.table.type_symbol(interface_sym.info.types[0])
 							checked_type := g.unwrap_generic(left.typ)
 							// TODO PERF this check is run twice (also in the checker)
 							// store the result in a field

--- a/vlib/v/gen/js/deep_copy.v
+++ b/vlib/v/gen/js/deep_copy.v
@@ -22,11 +22,11 @@ fn (mut g JsGen) get_copy_fn(typ ast.Type) string {
 		unwrapped.set_flag(.optional)
 	}
 	styp := g.typ(unwrapped)
-	mut sym := g.table.get_type_symbol(unwrapped)
+	mut sym := g.table.type_symbol(unwrapped)
 	mut copy_fn_name := styp_to_copy_fn_name(styp)
 	if mut sym.info is ast.Alias {
 		if sym.info.is_import {
-			sym = g.table.get_type_symbol(sym.info.parent_type)
+			sym = g.table.type_symbol(sym.info.parent_type)
 			copy_fn_name = styp_to_copy_fn_name(sym.name)
 		}
 	}
@@ -55,7 +55,7 @@ fn (mut g JsGen) gen_copy_for_multi_return(info ast.MultiReturn, styp string, co
 	fn_builder.writeln('function ${copy_fn_name}(a) {')
 	fn_builder.writeln('\tlet arr = []')
 	for i, typ in info.types {
-		sym := g.table.get_type_symbol(typ)
+		sym := g.table.type_symbol(typ)
 		arg_copy_fn_name := g.get_copy_fn(typ)
 
 		if sym.kind in [.f32, .f64] {
@@ -108,7 +108,7 @@ fn (mut g JsGen) gen_copy_for_interface(info ast.Interface, styp string, copy_fn
 	fn_builder.writeln('function ${copy_fn_name}(x) { return x; }')
 	/*
 	for typ in info.types {
-		subtype := g.table.get_type_symbol(typ)
+		subtype := g.table.type_symbol(typ)
 		mut func_name := g.get_copy_fn(typ)
 		if typ == ast.string_type {
 
@@ -188,7 +188,7 @@ fn (mut g JsGen) final_gen_copy(typ StrType) {
 		return
 	}
 	g.generated_copy_fns << typ
-	sym := g.table.get_type_symbol(typ.typ)
+	sym := g.table.type_symbol(typ.typ)
 	if sym.has_method('\$copy') && !typ.typ.has_flag(.optional) {
 		return
 	}

--- a/vlib/v/gen/js/deep_copy.v
+++ b/vlib/v/gen/js/deep_copy.v
@@ -22,11 +22,11 @@ fn (mut g JsGen) get_copy_fn(typ ast.Type) string {
 		unwrapped.set_flag(.optional)
 	}
 	styp := g.typ(unwrapped)
-	mut sym := g.table.type_symbol(unwrapped)
+	mut sym := g.table.sym(unwrapped)
 	mut copy_fn_name := styp_to_copy_fn_name(styp)
 	if mut sym.info is ast.Alias {
 		if sym.info.is_import {
-			sym = g.table.type_symbol(sym.info.parent_type)
+			sym = g.table.sym(sym.info.parent_type)
 			copy_fn_name = styp_to_copy_fn_name(sym.name)
 		}
 	}
@@ -55,7 +55,7 @@ fn (mut g JsGen) gen_copy_for_multi_return(info ast.MultiReturn, styp string, co
 	fn_builder.writeln('function ${copy_fn_name}(a) {')
 	fn_builder.writeln('\tlet arr = []')
 	for i, typ in info.types {
-		sym := g.table.type_symbol(typ)
+		sym := g.table.sym(typ)
 		arg_copy_fn_name := g.get_copy_fn(typ)
 
 		if sym.kind in [.f32, .f64] {
@@ -108,7 +108,7 @@ fn (mut g JsGen) gen_copy_for_interface(info ast.Interface, styp string, copy_fn
 	fn_builder.writeln('function ${copy_fn_name}(x) { return x; }')
 	/*
 	for typ in info.types {
-		subtype := g.table.type_symbol(typ)
+		subtype := g.table.sym(typ)
 		mut func_name := g.get_copy_fn(typ)
 		if typ == ast.string_type {
 
@@ -188,7 +188,7 @@ fn (mut g JsGen) final_gen_copy(typ StrType) {
 		return
 	}
 	g.generated_copy_fns << typ
-	sym := g.table.type_symbol(typ.typ)
+	sym := g.table.sym(typ.typ)
 	if sym.has_method('\$copy') && !typ.typ.has_flag(.optional) {
 		return
 	}

--- a/vlib/v/gen/js/fn.v
+++ b/vlib/v/gen/js/fn.v
@@ -191,7 +191,7 @@ fn (mut g JsGen) method_call(node ast.CallExpr) {
 		return
 	}
 	is_async := node.name == 'wait'
-		&& g.table.get_type_symbol(node.receiver_type).name.starts_with('Promise<')
+		&& g.table.type_symbol(node.receiver_type).name.starts_with('Promise<')
 	call_return_is_optional := it.return_type.has_flag(.optional)
 	if call_return_is_optional {
 		if is_async {
@@ -215,10 +215,10 @@ fn (mut g JsGen) method_call(node ast.CallExpr) {
 	if g.fn_decl != 0 && g.fn_decl.generic_names.len > 0 { // in generic fn
 		unwrapped_rec_type = g.unwrap_generic(node.receiver_type)
 	} else { // in non-generic fn
-		sym := g.table.get_type_symbol(node.receiver_type)
+		sym := g.table.type_symbol(node.receiver_type)
 		match sym.info {
 			ast.Struct, ast.Interface, ast.SumType {
-				generic_names := sym.info.generic_types.map(g.table.get_type_symbol(it).name)
+				generic_names := sym.info.generic_types.map(g.table.type_symbol(it).name)
 				// see comment at top of vlib/v/gen/c/utils.v
 				mut muttable := unsafe { &ast.Table(g.table) }
 				if utyp := muttable.resolve_generic_to_concrete(node.receiver_type, generic_names,
@@ -231,13 +231,13 @@ fn (mut g JsGen) method_call(node ast.CallExpr) {
 		}
 	}
 
-	mut typ_sym := g.table.get_type_symbol(unwrapped_rec_type)
+	mut typ_sym := g.table.type_symbol(unwrapped_rec_type)
 	rec_cc_type := g.cc_type(unwrapped_rec_type, false)
 	mut receiver_type_name := util.no_dots(rec_cc_type)
 	// alias type that undefined this method (not include `str`) need to use parent type
 	if typ_sym.kind == .alias && node.name != 'str' && !typ_sym.has_method(node.name) {
 		unwrapped_rec_type = (typ_sym.info as ast.Alias).parent_type
-		typ_sym = g.table.get_type_symbol(unwrapped_rec_type)
+		typ_sym = g.table.type_symbol(unwrapped_rec_type)
 	}
 
 	if typ_sym.kind == .interface_ && (typ_sym.info as ast.Interface).defines_method(node.name) {
@@ -254,8 +254,8 @@ fn (mut g JsGen) method_call(node ast.CallExpr) {
 		return
 	}
 
-	left_sym := g.table.get_type_symbol(node.left_type)
-	final_left_sym := g.table.get_final_type_symbol(node.left_type)
+	left_sym := g.table.type_symbol(node.left_type)
+	final_left_sym := g.table.final_type_symbol(node.left_type)
 
 	if final_left_sym.kind == .array {
 		if final_left_sym.kind == .array && it.name in ['map', 'filter'] {
@@ -283,7 +283,7 @@ fn (mut g JsGen) method_call(node ast.CallExpr) {
 						g.write(')')
 						return
 					} else if expr.kind == .variable {
-						v_sym := g.table.get_type_symbol(expr.var_info().typ)
+						v_sym := g.table.type_symbol(expr.var_info().typ)
 						if v_sym.kind == .function {
 							g.write(g.js_name(expr.name))
 							g.write(')')
@@ -376,7 +376,7 @@ fn (mut g JsGen) gen_call_expr(it ast.CallExpr) {
 	if it.should_be_skipped {
 		return
 	}
-	if it.is_method && g.table.get_type_symbol(it.receiver_type).name.starts_with('JS.') {
+	if it.is_method && g.table.type_symbol(it.receiver_type).name.starts_with('JS.') {
 		g.js_method_call(it)
 		return
 	} else if it.name.starts_with('JS.') {
@@ -396,7 +396,7 @@ fn (mut g JsGen) gen_call_expr(it ast.CallExpr) {
 		name = 'builtin__$name'
 	}
 	print_method := name
-	ret_sym := g.table.get_type_symbol(it.return_type)
+	ret_sym := g.table.type_symbol(it.return_type)
 	if it.language == .js && ret_sym.name in v_types && ret_sym.name != 'void' {
 		g.write('new ')
 		g.write(ret_sym.name)
@@ -479,9 +479,9 @@ enum FnGenType {
 }
 
 fn (g &JsGen) fn_gen_type(it &ast.FnDecl) FnGenType {
-	if it.is_method && g.table.get_type_symbol(it.params[0].typ).kind == .alias {
+	if it.is_method && g.table.type_symbol(it.params[0].typ).kind == .alias {
 		return .alias_method
-	} else if it.is_method && g.table.get_type_symbol(it.params[0].typ).kind == .interface_ {
+	} else if it.is_method && g.table.type_symbol(it.params[0].typ).kind == .interface_ {
 		return .iface_method
 	} else if it.is_method || it.no_body {
 		return .struct_method
@@ -572,7 +572,7 @@ fn (mut g JsGen) gen_method_decl(it ast.FnDecl, typ FnGenType) {
 		// loop thru each generic type and generate a function
 		for concrete_types in g.table.fn_generic_types[node.name] {
 			if g.pref.is_verbose {
-				syms := concrete_types.map(g.table.get_type_symbol(it))
+				syms := concrete_types.map(g.table.type_symbol(it))
 				the_type := syms.map(it.name).join(', ')
 				println('gen fn `$node.name` for type `$the_type`')
 			}
@@ -665,7 +665,7 @@ fn (mut g JsGen) gen_method_decl(it ast.FnDecl, typ FnGenType) {
 		if is_varg {
 			g.writeln('$arg_name = new array(new array_buffer({arr: $arg_name,len: new int(${arg_name}.length),index_start: new int(0)}));')
 		} else {
-			asym := g.table.get_type_symbol(arg.typ)
+			asym := g.table.type_symbol(arg.typ)
 			if asym.kind != .interface_ && asym.language != .js {
 				if arg.typ.is_ptr() || arg.is_mut {
 					g.writeln('$arg_name = new \$ref($arg_name)')
@@ -791,7 +791,7 @@ fn (mut g JsGen) gen_anon_fn(mut fun ast.AnonFn) {
 		if is_varg {
 			g.writeln('$arg_name = new array(new array_buffer({arr: $arg_name,len: new int(${arg_name}.length),index_start: new int(0)}));')
 		} else {
-			asym := g.table.get_type_symbol(arg.typ)
+			asym := g.table.type_symbol(arg.typ)
 
 			if arg.typ.is_ptr() || (arg.is_mut && asym.kind != .interface_ && asym.language != .js) {
 				g.writeln('$arg_name = new \$ref($arg_name)')

--- a/vlib/v/gen/js/infix.v
+++ b/vlib/v/gen/js/infix.v
@@ -5,8 +5,8 @@ import v.ast
 
 fn (mut g JsGen) gen_plain_infix_expr(node ast.InfixExpr) {
 	it := node
-	l_sym := g.table.final_type_symbol(it.left_type)
-	r_sym := g.table.final_type_symbol(it.right_type)
+	l_sym := g.table.final_sym(it.left_type)
+	r_sym := g.table.final_sym(it.right_type)
 	greater_typ := g.greater_typ(it.left_type, it.right_type)
 	cast_ty := if greater_typ == it.left_type { l_sym.cname } else { r_sym.cname }
 	g.write('new ${g.js_name(cast_ty)}( ')
@@ -338,7 +338,7 @@ fn (mut g JsGen) infix_in_not_in_op(node ast.InfixExpr) {
 
 fn (mut g JsGen) infix_is_not_is_op(node ast.InfixExpr) {
 	g.expr(node.left)
-	rsym := g.table.type_symbol(g.unwrap(node.right_type).typ)
+	rsym := g.table.sym(g.unwrap(node.right_type).typ)
 
 	g.gen_deref_ptr(node.left_type)
 	g.write(' instanceof ')

--- a/vlib/v/gen/js/infix.v
+++ b/vlib/v/gen/js/infix.v
@@ -5,8 +5,8 @@ import v.ast
 
 fn (mut g JsGen) gen_plain_infix_expr(node ast.InfixExpr) {
 	it := node
-	l_sym := g.table.get_final_type_symbol(it.left_type)
-	r_sym := g.table.get_final_type_symbol(it.right_type)
+	l_sym := g.table.final_type_symbol(it.left_type)
+	r_sym := g.table.final_type_symbol(it.right_type)
 	greater_typ := g.greater_typ(it.left_type, it.right_type)
 	cast_ty := if greater_typ == it.left_type { l_sym.cname } else { r_sym.cname }
 	g.write('new ${g.js_name(cast_ty)}( ')
@@ -338,7 +338,7 @@ fn (mut g JsGen) infix_in_not_in_op(node ast.InfixExpr) {
 
 fn (mut g JsGen) infix_is_not_is_op(node ast.InfixExpr) {
 	g.expr(node.left)
-	rsym := g.table.get_type_symbol(g.unwrap(node.right_type).typ)
+	rsym := g.table.type_symbol(g.unwrap(node.right_type).typ)
 
 	g.gen_deref_ptr(node.left_type)
 	g.write(' instanceof ')

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -177,9 +177,9 @@ pub fn gen(files []&ast.File, table &ast.Table, pref &pref.Preferences) string {
 	for iface_name, iface_types in g.table.iface_types {
 		iface := g.table.find_type(iface_name) or { panic('unreachable: interface must exist') }
 		for ty in iface_types {
-			sym := g.table.get_type_symbol(ty)
+			sym := g.table.type_symbol(ty)
 			for method in iface.methods {
-				p_sym := g.table.get_type_symbol(ty)
+				p_sym := g.table.type_symbol(ty)
 
 				mname := if p_sym.has_method(method.name) {
 					g.js_name(p_sym.name) + '_' + method.name
@@ -907,7 +907,7 @@ fn (mut g JsGen) expr(node ast.Expr) {
 			g.write('/* ast.DumpExpr: $node.expr */')
 		}
 		ast.EnumVal {
-			sym := g.table.get_type_symbol(node.typ)
+			sym := g.table.type_symbol(node.typ)
 			styp := g.js_name(sym.name)
 			g.write('${styp}.$node.val')
 		}
@@ -1036,7 +1036,7 @@ fn (mut g JsGen) expr(node ast.Expr) {
 		}
 		ast.TypeNode {
 			typ := g.unwrap_generic(node.typ)
-			sym := g.table.get_type_symbol(typ)
+			sym := g.table.type_symbol(typ)
 
 			g.write('${g.js_name(sym.name)}')
 		}
@@ -1069,7 +1069,7 @@ fn (mut g JsGen) assert_subexpression_to_ctemp(expr ast.Expr, expr_type ast.Type
 		}
 		ast.SelectorExpr {
 			if expr.expr is ast.CallExpr {
-				sym := g.table.get_final_type_symbol(g.unwrap_generic(expr.expr.return_type))
+				sym := g.table.final_type_symbol(g.unwrap_generic(expr.expr.return_type))
 				if sym.kind == .struct_ {
 					if (sym.info as ast.Struct).is_union {
 						return js.unsupported_ctemp_assert_transform
@@ -1158,7 +1158,7 @@ fn (mut g JsGen) gen_assert_single_expr(expr ast.Expr, typ ast.Type) {
 			}
 		}
 		ast.TypeNode {
-			sym := g.table.get_type_symbol(g.unwrap_generic(typ))
+			sym := g.table.type_symbol(g.unwrap_generic(typ))
 			g.write('new string("$sym.name"')
 		}
 		else {
@@ -1276,7 +1276,7 @@ fn (mut g JsGen) gen_assign_stmt(stmt ast.AssignStmt, semicolon bool) {
 			}
 
 			mut styp := if stmt.left_types.len > i { g.typ(stmt.left_types[i]) } else { '' }
-			// l_sym := g.table.get_type_symbol(stmt.left_types[i])
+			// l_sym := g.table.type_symbol(stmt.left_types[i])
 			if !g.inside_loop && styp.len > 0 {
 				g.doc.gen_typ(styp)
 			}
@@ -1297,7 +1297,7 @@ fn (mut g JsGen) gen_assign_stmt(stmt ast.AssignStmt, semicolon bool) {
 					}
 					array_set = true
 
-					if g.table.get_type_symbol(left.left_type).kind == .map {
+					if g.table.type_symbol(left.left_type).kind == .map {
 						g.writeln('.length++;')
 						g.expr(left.left)
 						g.write('.map[')
@@ -1338,7 +1338,7 @@ fn (mut g JsGen) gen_assign_stmt(stmt ast.AssignStmt, semicolon bool) {
 				if is_assign && array_set {
 					g.write('new ${styp}(')
 					g.expr(left)
-					l_sym := g.table.get_type_symbol(stmt.left_types[i])
+					l_sym := g.table.type_symbol(stmt.left_types[i])
 					if l_sym.kind == .string {
 						g.write('.str')
 					} else {
@@ -1381,7 +1381,7 @@ fn (mut g JsGen) gen_assign_stmt(stmt ast.AssignStmt, semicolon bool) {
 						}
 					}
 				} else if is_assign && !array_set {
-					l_sym := g.table.get_type_symbol(stmt.left_types[i])
+					l_sym := g.table.type_symbol(stmt.left_types[i])
 					if l_sym.kind == .string {
 						g.write('.str')
 					} else {
@@ -1558,14 +1558,14 @@ fn (mut g JsGen) gen_expr_stmt_no_semi(it ast.ExprStmt) {
 
 // cc_type whether to prefix 'struct' or not (C__Foo -> struct Foo)
 fn (mut g JsGen) cc_type(typ ast.Type, is_prefix_struct bool) string {
-	sym := g.table.get_type_symbol(g.unwrap_generic(typ))
+	sym := g.table.type_symbol(g.unwrap_generic(typ))
 	mut styp := sym.cname.replace('>', '').replace('<', '')
 	match mut sym.info {
 		ast.Struct, ast.Interface, ast.SumType {
 			if sym.info.is_generic {
 				mut sgtyps := '_T'
 				for gt in sym.info.generic_types {
-					gts := g.table.get_type_symbol(g.unwrap_generic(gt))
+					gts := g.table.type_symbol(g.unwrap_generic(gt))
 					sgtyps += '_$gts.cname'
 				}
 				styp += sgtyps
@@ -1761,7 +1761,7 @@ fn (mut g JsGen) gen_optional_error(expr ast.Expr) {
 
 fn (mut g JsGen) gen_return_stmt(it ast.Return) {
 	node := it
-	// sym := g.table.get_type_symbol(g.fn_decl.return_type)
+	// sym := g.table.type_symbol(g.fn_decl.return_type)
 	fn_return_is_optional := g.fn_decl.return_type.has_flag(.optional)
 	if node.exprs.len == 0 {
 		if fn_return_is_optional {
@@ -1873,7 +1873,7 @@ fn (mut g JsGen) gen_struct_decl(node ast.StructDecl) {
 	for iface, iface_types in g.table.iface_types {
 		if iface.starts_with('JS.') {
 			for ty in iface_types {
-				sym := g.table.get_type_symbol(ty)
+				sym := g.table.type_symbol(ty)
 
 				if sym.name == node.name {
 					g.writeln('...${g.js_name(iface)}.prototype,')
@@ -2057,8 +2057,8 @@ fn (mut g JsGen) gen_lock_expr(node ast.LockExpr) {
 
 fn (mut g JsGen) need_tmp_var_in_match(node ast.MatchExpr) bool {
 	if node.is_expr && node.return_type != ast.void_type && node.return_type != 0 {
-		cond_sym := g.table.get_final_type_symbol(node.cond_type)
-		sym := g.table.get_type_symbol(node.return_type)
+		cond_sym := g.table.final_type_symbol(node.cond_type)
+		sym := g.table.type_symbol(node.return_type)
 		if sym.kind == .multi_return {
 			return false
 		}
@@ -2085,7 +2085,7 @@ fn (mut g JsGen) need_tmp_var_in_match(node ast.MatchExpr) bool {
 }
 
 fn (mut g JsGen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var MatchCond, tmp_var string) {
-	type_sym := g.table.get_type_symbol(node.cond_type)
+	type_sym := g.table.type_symbol(node.cond_type)
 	for j, branch in node.branches {
 		is_last := j == node.branches.len - 1
 		if branch.is_else || (node.is_expr && is_last && tmp_var.len == 0) {
@@ -2293,7 +2293,7 @@ fn (mut g JsGen) match_expr(node ast.MatchExpr) {
 	if is_expr && !need_tmp_var {
 		g.write('(')
 	}
-	typ := g.table.get_final_type_symbol(node.cond_type)
+	typ := g.table.final_type_symbol(node.cond_type)
 	if node.is_sum_type {
 		g.match_expr_sumtype(node, is_expr, cond_var, tmp_var)
 	} else if typ.kind == .enum_ && !g.inside_loop && node.branches.len > 5 && g.fn_decl != 0 { // do not optimize while in top-level
@@ -2359,7 +2359,7 @@ fn (mut g JsGen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var M
 		mut sumtype_index := 0
 		for {
 			is_last := j == node.branches.len - 1
-			sym := g.table.get_type_symbol(node.cond_type)
+			sym := g.table.type_symbol(node.cond_type)
 			if branch.is_else || (node.is_expr && is_last && tmp_var.len == 0) {
 				if is_expr && tmp_var.len == 0 {
 					g.write(' : ')
@@ -2387,7 +2387,7 @@ fn (mut g JsGen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var M
 					if x is ast.TypeNode {
 						typ := g.unwrap_generic(x.typ)
 
-						tsym := g.table.get_type_symbol(typ)
+						tsym := g.table.type_symbol(typ)
 						if tsym.language == .js && (tsym.name == 'JS.Number'
 							|| tsym.name == 'JS.Boolean' || tsym.name == 'JS.String') {
 							g.write('typeof ')
@@ -2399,7 +2399,7 @@ fn (mut g JsGen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var M
 					x := branch.exprs[sumtype_index]
 					if x is ast.TypeNode {
 						typ := g.unwrap_generic(x.typ)
-						tsym := g.table.get_type_symbol(typ)
+						tsym := g.table.type_symbol(typ)
 						if tsym.language == .js && (tsym.name == 'JS.Number'
 							|| tsym.name == 'JS.Boolean' || tsym.name == 'JS.String') {
 							g.write(' === "${tsym.name[3..].to_lower()}"')
@@ -2418,7 +2418,7 @@ fn (mut g JsGen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var M
 					x := branch.exprs[sumtype_index]
 					if x is ast.TypeNode {
 						typ := g.unwrap_generic(x.typ)
-						tsym := g.table.get_type_symbol(typ)
+						tsym := g.table.type_symbol(typ)
 						if tsym.language == .js && (tsym.name == 'Number'
 							|| tsym.name == 'Boolean' || tsym.name == 'String') {
 							g.write(' === $tsym.name.to_lower()')
@@ -2585,7 +2585,7 @@ fn (mut g JsGen) need_tmp_var_in_if(node ast.IfExpr) bool {
 					stmt := branch.stmts[0] as ast.ExprStmt
 					if stmt.expr is ast.CallExpr {
 						if stmt.expr.is_method {
-							left_sym := g.table.get_type_symbol(stmt.expr.receiver_type)
+							left_sym := g.table.type_symbol(stmt.expr.receiver_type)
 							if left_sym.kind in [.array, .array_fixed, .map] {
 								return true
 							}
@@ -2729,7 +2729,7 @@ fn (mut g JsGen) gen_if_expr(node ast.IfExpr) {
 }
 
 fn (mut g JsGen) gen_index_expr(expr ast.IndexExpr) {
-	left_typ := g.table.get_type_symbol(expr.left_type)
+	left_typ := g.table.type_symbol(expr.left_type)
 	// TODO: Handle splice setting if it's implemented
 	if expr.index is ast.RangeExpr {
 		if left_typ.kind == .string {
@@ -2828,8 +2828,8 @@ fn (mut g JsGen) expr_string(expr ast.Expr) string {
 }
 
 fn (mut g JsGen) gen_infix_expr(it ast.InfixExpr) {
-	l_sym := g.table.get_final_type_symbol(it.left_type)
-	r_sym := g.table.get_final_type_symbol(it.right_type)
+	l_sym := g.table.final_type_symbol(it.left_type)
+	r_sym := g.table.final_type_symbol(it.right_type)
 
 	is_not := it.op in [.not_in, .not_is, .ne]
 	if is_not {
@@ -3082,8 +3082,8 @@ fn (mut g JsGen) greater_typ(left ast.Type, right ast.Type) ast.Type {
 }
 
 fn (mut g JsGen) gen_map_init_expr(it ast.MapInit) {
-	// key_typ_sym := g.table.get_type_symbol(it.key_type)
-	// value_typ_sym := g.table.get_type_symbol(it.value_type)
+	// key_typ_sym := g.table.type_symbol(it.key_type)
+	// value_typ_sym := g.table.type_symbol(it.value_type)
 	// key_typ_str := util.no_dots(key_typ_sym.name)
 	// value_typ_str := util.no_dots(value_typ_sym.name)
 	g.writeln('new map(')
@@ -3114,7 +3114,7 @@ fn (mut g JsGen) gen_map_init_expr(it ast.MapInit) {
 
 fn (mut g JsGen) type_name(raw_type ast.Type) {
 	typ := raw_type
-	sym := g.table.get_type_symbol(typ)
+	sym := g.table.type_symbol(typ)
 	mut s := ''
 	if sym.kind == .function {
 		// todo: properly print function signatures
@@ -3161,7 +3161,7 @@ fn (mut g JsGen) gen_selector_expr(it ast.SelectorExpr) {
 	}
 	g.expr(it.expr)
 	mut ltyp := it.expr_type
-	lsym := g.table.get_type_symbol(ltyp)
+	lsym := g.table.type_symbol(ltyp)
 	if lsym.kind != .interface_ && lsym.language != .js {
 		for ltyp.is_ptr() {
 			g.write('.val')
@@ -3237,7 +3237,7 @@ fn (mut g JsGen) gen_string_literal(it ast.StringLiteral) {
 }
 
 fn (mut g JsGen) gen_struct_init(it ast.StructInit) {
-	type_sym := g.table.get_type_symbol(it.typ)
+	type_sym := g.table.type_symbol(it.typ)
 	mut name := type_sym.name
 	if name.contains('<') {
 		name = name[0..name.index('<') or { name.len }]
@@ -3290,7 +3290,7 @@ fn (mut g JsGen) gen_struct_init(it ast.StructInit) {
 }
 
 fn (mut g JsGen) gen_typeof_expr(it ast.TypeOf) {
-	sym := g.table.get_type_symbol(it.expr_type)
+	sym := g.table.type_symbol(it.expr_type)
 	if sym.kind == .sum_type {
 		// TODO: JS sumtypes not implemented yet
 	} else if sym.kind == .array_fixed {
@@ -3319,7 +3319,7 @@ fn (mut g JsGen) gen_typeof_expr(it ast.TypeOf) {
 
 fn (mut g JsGen) gen_cast_tmp(tmp string, typ_ ast.Type) {
 	// Skip cast if type is the same as the parrent caster
-	tsym := g.table.get_final_type_symbol(typ_)
+	tsym := g.table.final_type_symbol(typ_)
 	if !g.pref.output_es5 && (tsym.kind == .i64 || tsym.kind == .u64) {
 		g.write('new ')
 
@@ -3354,8 +3354,8 @@ fn (mut g JsGen) gen_cast_tmp(tmp string, typ_ ast.Type) {
 fn (mut g JsGen) gen_type_cast_expr(it ast.CastExpr) {
 	is_literal := ((it.expr is ast.IntegerLiteral && it.typ in ast.integer_type_idxs)
 		|| (it.expr is ast.FloatLiteral && it.typ in ast.float_type_idxs))
-	from_type_sym := g.table.get_type_symbol(it.expr_type)
-	to_type_sym := g.table.get_type_symbol(it.typ) // type to be used as cast
+	from_type_sym := g.table.type_symbol(it.expr_type)
+	to_type_sym := g.table.type_symbol(it.typ) // type to be used as cast
 	if it.typ.is_bool() && from_type_sym.name == 'JS.Boolean' {
 		g.write('new bool(')
 		g.expr(it.expr)
@@ -3540,7 +3540,7 @@ fn replace_op(s string) string {
 }
 
 fn (mut g JsGen) gen_postfix_index_expr(expr ast.IndexExpr, op token.Kind) {
-	left_typ := g.table.get_type_symbol(expr.left_type)
+	left_typ := g.table.type_symbol(expr.left_type)
 	// TODO: Handle splice setting if it's implemented
 	if expr.index is ast.RangeExpr {
 		if left_typ.kind == .array {
@@ -3585,7 +3585,7 @@ fn (mut g JsGen) gen_postfix_index_expr(expr ast.IndexExpr, op token.Kind) {
 			g.write(')')
 		} else {
 			g.write(',')
-			lsym := g.table.get_type_symbol(expr.left_type)
+			lsym := g.table.type_symbol(expr.left_type)
 			key_typ := match lsym.info {
 				ast.Map {
 					lsym.info.value_type

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -177,9 +177,9 @@ pub fn gen(files []&ast.File, table &ast.Table, pref &pref.Preferences) string {
 	for iface_name, iface_types in g.table.iface_types {
 		iface := g.table.find_type(iface_name) or { panic('unreachable: interface must exist') }
 		for ty in iface_types {
-			sym := g.table.type_symbol(ty)
+			sym := g.table.sym(ty)
 			for method in iface.methods {
-				p_sym := g.table.type_symbol(ty)
+				p_sym := g.table.sym(ty)
 
 				mname := if p_sym.has_method(method.name) {
 					g.js_name(p_sym.name) + '_' + method.name
@@ -907,7 +907,7 @@ fn (mut g JsGen) expr(node ast.Expr) {
 			g.write('/* ast.DumpExpr: $node.expr */')
 		}
 		ast.EnumVal {
-			sym := g.table.type_symbol(node.typ)
+			sym := g.table.sym(node.typ)
 			styp := g.js_name(sym.name)
 			g.write('${styp}.$node.val')
 		}
@@ -1036,7 +1036,7 @@ fn (mut g JsGen) expr(node ast.Expr) {
 		}
 		ast.TypeNode {
 			typ := g.unwrap_generic(node.typ)
-			sym := g.table.type_symbol(typ)
+			sym := g.table.sym(typ)
 
 			g.write('${g.js_name(sym.name)}')
 		}
@@ -1069,7 +1069,7 @@ fn (mut g JsGen) assert_subexpression_to_ctemp(expr ast.Expr, expr_type ast.Type
 		}
 		ast.SelectorExpr {
 			if expr.expr is ast.CallExpr {
-				sym := g.table.final_type_symbol(g.unwrap_generic(expr.expr.return_type))
+				sym := g.table.final_sym(g.unwrap_generic(expr.expr.return_type))
 				if sym.kind == .struct_ {
 					if (sym.info as ast.Struct).is_union {
 						return js.unsupported_ctemp_assert_transform
@@ -1158,7 +1158,7 @@ fn (mut g JsGen) gen_assert_single_expr(expr ast.Expr, typ ast.Type) {
 			}
 		}
 		ast.TypeNode {
-			sym := g.table.type_symbol(g.unwrap_generic(typ))
+			sym := g.table.sym(g.unwrap_generic(typ))
 			g.write('new string("$sym.name"')
 		}
 		else {
@@ -1276,7 +1276,7 @@ fn (mut g JsGen) gen_assign_stmt(stmt ast.AssignStmt, semicolon bool) {
 			}
 
 			mut styp := if stmt.left_types.len > i { g.typ(stmt.left_types[i]) } else { '' }
-			// l_sym := g.table.type_symbol(stmt.left_types[i])
+			// l_sym := g.table.sym(stmt.left_types[i])
 			if !g.inside_loop && styp.len > 0 {
 				g.doc.gen_typ(styp)
 			}
@@ -1297,7 +1297,7 @@ fn (mut g JsGen) gen_assign_stmt(stmt ast.AssignStmt, semicolon bool) {
 					}
 					array_set = true
 
-					if g.table.type_symbol(left.left_type).kind == .map {
+					if g.table.sym(left.left_type).kind == .map {
 						g.writeln('.length++;')
 						g.expr(left.left)
 						g.write('.map[')
@@ -1338,7 +1338,7 @@ fn (mut g JsGen) gen_assign_stmt(stmt ast.AssignStmt, semicolon bool) {
 				if is_assign && array_set {
 					g.write('new ${styp}(')
 					g.expr(left)
-					l_sym := g.table.type_symbol(stmt.left_types[i])
+					l_sym := g.table.sym(stmt.left_types[i])
 					if l_sym.kind == .string {
 						g.write('.str')
 					} else {
@@ -1381,7 +1381,7 @@ fn (mut g JsGen) gen_assign_stmt(stmt ast.AssignStmt, semicolon bool) {
 						}
 					}
 				} else if is_assign && !array_set {
-					l_sym := g.table.type_symbol(stmt.left_types[i])
+					l_sym := g.table.sym(stmt.left_types[i])
 					if l_sym.kind == .string {
 						g.write('.str')
 					} else {
@@ -1558,14 +1558,14 @@ fn (mut g JsGen) gen_expr_stmt_no_semi(it ast.ExprStmt) {
 
 // cc_type whether to prefix 'struct' or not (C__Foo -> struct Foo)
 fn (mut g JsGen) cc_type(typ ast.Type, is_prefix_struct bool) string {
-	sym := g.table.type_symbol(g.unwrap_generic(typ))
+	sym := g.table.sym(g.unwrap_generic(typ))
 	mut styp := sym.cname.replace('>', '').replace('<', '')
 	match mut sym.info {
 		ast.Struct, ast.Interface, ast.SumType {
 			if sym.info.is_generic {
 				mut sgtyps := '_T'
 				for gt in sym.info.generic_types {
-					gts := g.table.type_symbol(g.unwrap_generic(gt))
+					gts := g.table.sym(g.unwrap_generic(gt))
 					sgtyps += '_$gts.cname'
 				}
 				styp += sgtyps
@@ -1761,7 +1761,7 @@ fn (mut g JsGen) gen_optional_error(expr ast.Expr) {
 
 fn (mut g JsGen) gen_return_stmt(it ast.Return) {
 	node := it
-	// sym := g.table.type_symbol(g.fn_decl.return_type)
+	// sym := g.table.sym(g.fn_decl.return_type)
 	fn_return_is_optional := g.fn_decl.return_type.has_flag(.optional)
 	if node.exprs.len == 0 {
 		if fn_return_is_optional {
@@ -1873,7 +1873,7 @@ fn (mut g JsGen) gen_struct_decl(node ast.StructDecl) {
 	for iface, iface_types in g.table.iface_types {
 		if iface.starts_with('JS.') {
 			for ty in iface_types {
-				sym := g.table.type_symbol(ty)
+				sym := g.table.sym(ty)
 
 				if sym.name == node.name {
 					g.writeln('...${g.js_name(iface)}.prototype,')
@@ -2057,8 +2057,8 @@ fn (mut g JsGen) gen_lock_expr(node ast.LockExpr) {
 
 fn (mut g JsGen) need_tmp_var_in_match(node ast.MatchExpr) bool {
 	if node.is_expr && node.return_type != ast.void_type && node.return_type != 0 {
-		cond_sym := g.table.final_type_symbol(node.cond_type)
-		sym := g.table.type_symbol(node.return_type)
+		cond_sym := g.table.final_sym(node.cond_type)
+		sym := g.table.sym(node.return_type)
 		if sym.kind == .multi_return {
 			return false
 		}
@@ -2085,7 +2085,7 @@ fn (mut g JsGen) need_tmp_var_in_match(node ast.MatchExpr) bool {
 }
 
 fn (mut g JsGen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var MatchCond, tmp_var string) {
-	type_sym := g.table.type_symbol(node.cond_type)
+	type_sym := g.table.sym(node.cond_type)
 	for j, branch in node.branches {
 		is_last := j == node.branches.len - 1
 		if branch.is_else || (node.is_expr && is_last && tmp_var.len == 0) {
@@ -2293,7 +2293,7 @@ fn (mut g JsGen) match_expr(node ast.MatchExpr) {
 	if is_expr && !need_tmp_var {
 		g.write('(')
 	}
-	typ := g.table.final_type_symbol(node.cond_type)
+	typ := g.table.final_sym(node.cond_type)
 	if node.is_sum_type {
 		g.match_expr_sumtype(node, is_expr, cond_var, tmp_var)
 	} else if typ.kind == .enum_ && !g.inside_loop && node.branches.len > 5 && g.fn_decl != 0 { // do not optimize while in top-level
@@ -2359,7 +2359,7 @@ fn (mut g JsGen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var M
 		mut sumtype_index := 0
 		for {
 			is_last := j == node.branches.len - 1
-			sym := g.table.type_symbol(node.cond_type)
+			sym := g.table.sym(node.cond_type)
 			if branch.is_else || (node.is_expr && is_last && tmp_var.len == 0) {
 				if is_expr && tmp_var.len == 0 {
 					g.write(' : ')
@@ -2387,7 +2387,7 @@ fn (mut g JsGen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var M
 					if x is ast.TypeNode {
 						typ := g.unwrap_generic(x.typ)
 
-						tsym := g.table.type_symbol(typ)
+						tsym := g.table.sym(typ)
 						if tsym.language == .js && (tsym.name == 'JS.Number'
 							|| tsym.name == 'JS.Boolean' || tsym.name == 'JS.String') {
 							g.write('typeof ')
@@ -2399,7 +2399,7 @@ fn (mut g JsGen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var M
 					x := branch.exprs[sumtype_index]
 					if x is ast.TypeNode {
 						typ := g.unwrap_generic(x.typ)
-						tsym := g.table.type_symbol(typ)
+						tsym := g.table.sym(typ)
 						if tsym.language == .js && (tsym.name == 'JS.Number'
 							|| tsym.name == 'JS.Boolean' || tsym.name == 'JS.String') {
 							g.write(' === "${tsym.name[3..].to_lower()}"')
@@ -2418,7 +2418,7 @@ fn (mut g JsGen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var M
 					x := branch.exprs[sumtype_index]
 					if x is ast.TypeNode {
 						typ := g.unwrap_generic(x.typ)
-						tsym := g.table.type_symbol(typ)
+						tsym := g.table.sym(typ)
 						if tsym.language == .js && (tsym.name == 'Number'
 							|| tsym.name == 'Boolean' || tsym.name == 'String') {
 							g.write(' === $tsym.name.to_lower()')
@@ -2585,7 +2585,7 @@ fn (mut g JsGen) need_tmp_var_in_if(node ast.IfExpr) bool {
 					stmt := branch.stmts[0] as ast.ExprStmt
 					if stmt.expr is ast.CallExpr {
 						if stmt.expr.is_method {
-							left_sym := g.table.type_symbol(stmt.expr.receiver_type)
+							left_sym := g.table.sym(stmt.expr.receiver_type)
 							if left_sym.kind in [.array, .array_fixed, .map] {
 								return true
 							}
@@ -2729,7 +2729,7 @@ fn (mut g JsGen) gen_if_expr(node ast.IfExpr) {
 }
 
 fn (mut g JsGen) gen_index_expr(expr ast.IndexExpr) {
-	left_typ := g.table.type_symbol(expr.left_type)
+	left_typ := g.table.sym(expr.left_type)
 	// TODO: Handle splice setting if it's implemented
 	if expr.index is ast.RangeExpr {
 		if left_typ.kind == .string {
@@ -2828,8 +2828,8 @@ fn (mut g JsGen) expr_string(expr ast.Expr) string {
 }
 
 fn (mut g JsGen) gen_infix_expr(it ast.InfixExpr) {
-	l_sym := g.table.final_type_symbol(it.left_type)
-	r_sym := g.table.final_type_symbol(it.right_type)
+	l_sym := g.table.final_sym(it.left_type)
+	r_sym := g.table.final_sym(it.right_type)
 
 	is_not := it.op in [.not_in, .not_is, .ne]
 	if is_not {
@@ -3082,8 +3082,8 @@ fn (mut g JsGen) greater_typ(left ast.Type, right ast.Type) ast.Type {
 }
 
 fn (mut g JsGen) gen_map_init_expr(it ast.MapInit) {
-	// key_typ_sym := g.table.type_symbol(it.key_type)
-	// value_typ_sym := g.table.type_symbol(it.value_type)
+	// key_typ_sym := g.table.sym(it.key_type)
+	// value_typ_sym := g.table.sym(it.value_type)
 	// key_typ_str := util.no_dots(key_typ_sym.name)
 	// value_typ_str := util.no_dots(value_typ_sym.name)
 	g.writeln('new map(')
@@ -3114,7 +3114,7 @@ fn (mut g JsGen) gen_map_init_expr(it ast.MapInit) {
 
 fn (mut g JsGen) type_name(raw_type ast.Type) {
 	typ := raw_type
-	sym := g.table.type_symbol(typ)
+	sym := g.table.sym(typ)
 	mut s := ''
 	if sym.kind == .function {
 		// todo: properly print function signatures
@@ -3161,7 +3161,7 @@ fn (mut g JsGen) gen_selector_expr(it ast.SelectorExpr) {
 	}
 	g.expr(it.expr)
 	mut ltyp := it.expr_type
-	lsym := g.table.type_symbol(ltyp)
+	lsym := g.table.sym(ltyp)
 	if lsym.kind != .interface_ && lsym.language != .js {
 		for ltyp.is_ptr() {
 			g.write('.val')
@@ -3237,7 +3237,7 @@ fn (mut g JsGen) gen_string_literal(it ast.StringLiteral) {
 }
 
 fn (mut g JsGen) gen_struct_init(it ast.StructInit) {
-	type_sym := g.table.type_symbol(it.typ)
+	type_sym := g.table.sym(it.typ)
 	mut name := type_sym.name
 	if name.contains('<') {
 		name = name[0..name.index('<') or { name.len }]
@@ -3290,7 +3290,7 @@ fn (mut g JsGen) gen_struct_init(it ast.StructInit) {
 }
 
 fn (mut g JsGen) gen_typeof_expr(it ast.TypeOf) {
-	sym := g.table.type_symbol(it.expr_type)
+	sym := g.table.sym(it.expr_type)
 	if sym.kind == .sum_type {
 		// TODO: JS sumtypes not implemented yet
 	} else if sym.kind == .array_fixed {
@@ -3319,7 +3319,7 @@ fn (mut g JsGen) gen_typeof_expr(it ast.TypeOf) {
 
 fn (mut g JsGen) gen_cast_tmp(tmp string, typ_ ast.Type) {
 	// Skip cast if type is the same as the parrent caster
-	tsym := g.table.final_type_symbol(typ_)
+	tsym := g.table.final_sym(typ_)
 	if !g.pref.output_es5 && (tsym.kind == .i64 || tsym.kind == .u64) {
 		g.write('new ')
 
@@ -3354,8 +3354,8 @@ fn (mut g JsGen) gen_cast_tmp(tmp string, typ_ ast.Type) {
 fn (mut g JsGen) gen_type_cast_expr(it ast.CastExpr) {
 	is_literal := ((it.expr is ast.IntegerLiteral && it.typ in ast.integer_type_idxs)
 		|| (it.expr is ast.FloatLiteral && it.typ in ast.float_type_idxs))
-	from_type_sym := g.table.type_symbol(it.expr_type)
-	to_type_sym := g.table.type_symbol(it.typ) // type to be used as cast
+	from_type_sym := g.table.sym(it.expr_type)
+	to_type_sym := g.table.sym(it.typ) // type to be used as cast
 	if it.typ.is_bool() && from_type_sym.name == 'JS.Boolean' {
 		g.write('new bool(')
 		g.expr(it.expr)
@@ -3540,7 +3540,7 @@ fn replace_op(s string) string {
 }
 
 fn (mut g JsGen) gen_postfix_index_expr(expr ast.IndexExpr, op token.Kind) {
-	left_typ := g.table.type_symbol(expr.left_type)
+	left_typ := g.table.sym(expr.left_type)
 	// TODO: Handle splice setting if it's implemented
 	if expr.index is ast.RangeExpr {
 		if left_typ.kind == .array {
@@ -3585,7 +3585,7 @@ fn (mut g JsGen) gen_postfix_index_expr(expr ast.IndexExpr, op token.Kind) {
 			g.write(')')
 		} else {
 			g.write(',')
-			lsym := g.table.type_symbol(expr.left_type)
+			lsym := g.table.sym(expr.left_type)
 			key_typ := match lsym.info {
 				ast.Map {
 					lsym.info.value_type

--- a/vlib/v/gen/js/str.v
+++ b/vlib/v/gen/js/str.v
@@ -10,10 +10,10 @@ fn (mut g JsGen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		typ = typ.clear_flag(.shared_f).set_nr_muls(0)
 	}
 
-	mut sym := g.table.get_type_symbol(typ)
+	mut sym := g.table.type_symbol(typ)
 	// when type is alias, print the aliased value
 	if mut sym.info is ast.Alias {
-		parent_sym := g.table.get_type_symbol(sym.info.parent_type)
+		parent_sym := g.table.type_symbol(sym.info.parent_type)
 		if parent_sym.has_method('str') {
 			typ = sym.info.parent_type
 			sym = parent_sym
@@ -81,10 +81,10 @@ fn (mut g JsGen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 	if is_shared {
 		typ = typ.clear_flag(.shared_f).set_nr_muls(0)
 	}
-	mut sym := g.table.get_type_symbol(typ)
+	mut sym := g.table.type_symbol(typ)
 	// when type is alias, print the aliased value
 	if mut sym.info is ast.Alias {
-		parent_sym := g.table.get_type_symbol(sym.info.parent_type)
+		parent_sym := g.table.type_symbol(sym.info.parent_type)
 		if parent_sym.has_method('str') {
 			typ = sym.info.parent_type
 			sym = parent_sym

--- a/vlib/v/gen/js/str.v
+++ b/vlib/v/gen/js/str.v
@@ -10,10 +10,10 @@ fn (mut g JsGen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		typ = typ.clear_flag(.shared_f).set_nr_muls(0)
 	}
 
-	mut sym := g.table.type_symbol(typ)
+	mut sym := g.table.sym(typ)
 	// when type is alias, print the aliased value
 	if mut sym.info is ast.Alias {
-		parent_sym := g.table.type_symbol(sym.info.parent_type)
+		parent_sym := g.table.sym(sym.info.parent_type)
 		if parent_sym.has_method('str') {
 			typ = sym.info.parent_type
 			sym = parent_sym
@@ -81,10 +81,10 @@ fn (mut g JsGen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 	if is_shared {
 		typ = typ.clear_flag(.shared_f).set_nr_muls(0)
 	}
-	mut sym := g.table.type_symbol(typ)
+	mut sym := g.table.sym(typ)
 	// when type is alias, print the aliased value
 	if mut sym.info is ast.Alias {
-		parent_sym := g.table.type_symbol(sym.info.parent_type)
+		parent_sym := g.table.sym(sym.info.parent_type)
 		if parent_sym.has_method('str') {
 			typ = sym.info.parent_type
 			sym = parent_sym

--- a/vlib/v/gen/js/util.v
+++ b/vlib/v/gen/js/util.v
@@ -17,7 +17,7 @@ struct Type {
 // * alias unwrapped
 fn (mut g JsGen) unwrap(typ ast.Type) Type {
 	no_generic := g.unwrap_generic(typ)
-	no_generic_sym := g.table.type_symbol(no_generic)
+	no_generic_sym := g.table.sym(no_generic)
 	if no_generic_sym.kind != .alias {
 		return Type{
 			typ: no_generic
@@ -30,6 +30,6 @@ fn (mut g JsGen) unwrap(typ ast.Type) Type {
 		typ: no_generic
 		sym: no_generic_sym
 		unaliased: no_generic_sym.parent_idx
-		unaliased_sym: g.table.type_symbol(no_generic_sym.parent_idx)
+		unaliased_sym: g.table.sym(no_generic_sym.parent_idx)
 	}
 }

--- a/vlib/v/gen/js/util.v
+++ b/vlib/v/gen/js/util.v
@@ -17,7 +17,7 @@ struct Type {
 // * alias unwrapped
 fn (mut g JsGen) unwrap(typ ast.Type) Type {
 	no_generic := g.unwrap_generic(typ)
-	no_generic_sym := g.table.get_type_symbol(no_generic)
+	no_generic_sym := g.table.type_symbol(no_generic)
 	if no_generic_sym.kind != .alias {
 		return Type{
 			typ: no_generic
@@ -30,6 +30,6 @@ fn (mut g JsGen) unwrap(typ ast.Type) Type {
 		typ: no_generic
 		sym: no_generic_sym
 		unaliased: no_generic_sym.parent_idx
-		unaliased_sym: g.table.get_type_symbol(no_generic_sym.parent_idx)
+		unaliased_sym: g.table.type_symbol(no_generic_sym.parent_idx)
 	}
 }

--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -1089,7 +1089,7 @@ g.v_error('oops', node.pos)
 				// a += b
 			}
 			ast.StructInit {
-				sym := g.table.type_symbol(right.typ)
+				sym := g.table.sym(right.typ)
 				info := sym.info as ast.Struct
 				for field in info.fields {
 					field_name := name + '.' + field.name

--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -1089,7 +1089,7 @@ g.v_error('oops', node.pos)
 				// a += b
 			}
 			ast.StructInit {
-				sym := g.table.get_type_symbol(right.typ)
+				sym := g.table.type_symbol(right.typ)
 				info := sym.info as ast.Struct
 				for field in info.fields {
 					field_name := name + '.' + field.name

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -294,7 +294,7 @@ pub fn mark_used(mut table ast.Table, pref &pref.Preferences, ast_files []&ast.F
 		typ_vweb_context := ast.Type(table.find_type_idx('vweb.Context')).set_nr_muls(1)
 		all_fn_root_names << '${int(typ_vweb_context)}.html'
 		for vgt in table.used_vweb_types {
-			sym_app := table.type_symbol(vgt)
+			sym_app := table.sym(vgt)
 			for m in sym_app.methods {
 				if m.return_type == typ_vweb_result {
 					pvgt := vgt.set_nr_muls(1)

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -294,7 +294,7 @@ pub fn mark_used(mut table ast.Table, pref &pref.Preferences, ast_files []&ast.F
 		typ_vweb_context := ast.Type(table.find_type_idx('vweb.Context')).set_nr_muls(1)
 		all_fn_root_names << '${int(typ_vweb_context)}.html'
 		for vgt in table.used_vweb_types {
-			sym_app := table.get_type_symbol(vgt)
+			sym_app := table.type_symbol(vgt)
 			for m in sym_app.methods {
 				if m.return_type == typ_vweb_result {
 					pvgt := vgt.set_nr_muls(1)

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -142,7 +142,7 @@ pub fn (mut w Walker) stmt(node ast.Stmt) {
 			}
 			if node.kind == .struct_ {
 				// the .next() method of the struct will be used for iteration:
-				cond_type_sym := w.table.get_type_symbol(node.cond_type)
+				cond_type_sym := w.table.type_symbol(node.cond_type)
 				if next_fn := cond_type_sym.find_method('next') {
 					w.fn_decl(mut &ast.FnDecl(next_fn.source_fn))
 				}
@@ -275,7 +275,7 @@ fn (mut w Walker) expr(node ast.Expr) {
 			w.expr(node.left)
 			w.expr(node.index)
 			w.or_block(node.or_expr)
-			sym := w.table.get_final_type_symbol(node.left_type)
+			sym := w.table.final_type_symbol(node.left_type)
 			if sym.kind == .map {
 				w.table.used_maps++
 			}
@@ -287,13 +287,13 @@ fn (mut w Walker) expr(node ast.Expr) {
 			if node.left_type == 0 {
 				return
 			}
-			sym := w.table.get_type_symbol(node.left_type)
+			sym := w.table.type_symbol(node.left_type)
 			if sym.kind == .struct_ {
 				if opmethod := sym.find_method(node.op.str()) {
 					w.fn_decl(mut &ast.FnDecl(opmethod.source_fn))
 				}
 			}
-			right_sym := w.table.get_type_symbol(node.right_type)
+			right_sym := w.table.type_symbol(node.right_type)
 			if node.op in [.not_in, .key_in] && right_sym.kind == .map {
 				w.table.used_maps++
 			}
@@ -375,14 +375,14 @@ fn (mut w Walker) expr(node ast.Expr) {
 			w.expr(node.where_expr)
 		}
 		ast.StructInit {
-			sym := w.table.get_type_symbol(node.typ)
+			sym := w.table.type_symbol(node.typ)
 			if sym.kind == .struct_ {
 				info := sym.info as ast.Struct
 				for ifield in info.fields {
 					if ifield.has_default_expr {
 						w.expr(ifield.default_expr)
 					}
-					fsym := w.table.get_type_symbol(ifield.typ)
+					fsym := w.table.type_symbol(ifield.typ)
 					if fsym.kind == .map {
 						w.table.used_maps++
 					}

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -142,7 +142,7 @@ pub fn (mut w Walker) stmt(node ast.Stmt) {
 			}
 			if node.kind == .struct_ {
 				// the .next() method of the struct will be used for iteration:
-				cond_type_sym := w.table.type_symbol(node.cond_type)
+				cond_type_sym := w.table.sym(node.cond_type)
 				if next_fn := cond_type_sym.find_method('next') {
 					w.fn_decl(mut &ast.FnDecl(next_fn.source_fn))
 				}
@@ -275,7 +275,7 @@ fn (mut w Walker) expr(node ast.Expr) {
 			w.expr(node.left)
 			w.expr(node.index)
 			w.or_block(node.or_expr)
-			sym := w.table.final_type_symbol(node.left_type)
+			sym := w.table.final_sym(node.left_type)
 			if sym.kind == .map {
 				w.table.used_maps++
 			}
@@ -287,13 +287,13 @@ fn (mut w Walker) expr(node ast.Expr) {
 			if node.left_type == 0 {
 				return
 			}
-			sym := w.table.type_symbol(node.left_type)
+			sym := w.table.sym(node.left_type)
 			if sym.kind == .struct_ {
 				if opmethod := sym.find_method(node.op.str()) {
 					w.fn_decl(mut &ast.FnDecl(opmethod.source_fn))
 				}
 			}
-			right_sym := w.table.type_symbol(node.right_type)
+			right_sym := w.table.sym(node.right_type)
 			if node.op in [.not_in, .key_in] && right_sym.kind == .map {
 				w.table.used_maps++
 			}
@@ -375,14 +375,14 @@ fn (mut w Walker) expr(node ast.Expr) {
 			w.expr(node.where_expr)
 		}
 		ast.StructInit {
-			sym := w.table.type_symbol(node.typ)
+			sym := w.table.sym(node.typ)
 			if sym.kind == .struct_ {
 				info := sym.info as ast.Struct
 				for ifield in info.fields {
 					if ifield.has_default_expr {
 						w.expr(ifield.default_expr)
 					}
-					fsym := w.table.type_symbol(ifield.typ)
+					fsym := w.table.sym(ifield.typ)
 					if fsym.kind == .map {
 						w.table.used_maps++
 					}

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -169,7 +169,7 @@ pub fn (mut p Parser) check_expr(precedence int) ?ast.Expr {
 			} else if p.is_amp && p.peek_tok.kind == .rsbr && p.peek_token(3).kind != .lcbr {
 				pos := p.tok.position()
 				typ := p.parse_type()
-				typname := p.table.type_symbol(typ).name
+				typname := p.table.sym(typ).name
 				p.check(.lpar)
 				expr := p.expr(0)
 				p.check(.rpar)
@@ -632,6 +632,6 @@ fn (mut p Parser) prefix_expr() ast.Expr {
 
 fn (mut p Parser) recast_as_pointer(mut cast_expr ast.CastExpr, pos token.Position) {
 	cast_expr.typ = cast_expr.typ.ref()
-	cast_expr.typname = p.table.type_symbol(cast_expr.typ).name
+	cast_expr.typname = p.table.sym(cast_expr.typ).name
 	cast_expr.pos = pos.extend(cast_expr.pos)
 }

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -169,7 +169,7 @@ pub fn (mut p Parser) check_expr(precedence int) ?ast.Expr {
 			} else if p.is_amp && p.peek_tok.kind == .rsbr && p.peek_token(3).kind != .lcbr {
 				pos := p.tok.position()
 				typ := p.parse_type()
-				typname := p.table.get_type_symbol(typ).name
+				typname := p.table.type_symbol(typ).name
 				p.check(.lpar)
 				expr := p.expr(0)
 				p.check(.rpar)
@@ -632,6 +632,6 @@ fn (mut p Parser) prefix_expr() ast.Expr {
 
 fn (mut p Parser) recast_as_pointer(mut cast_expr ast.CastExpr, pos token.Position) {
 	cast_expr.typ = cast_expr.typ.ref()
-	cast_expr.typname = p.table.get_type_symbol(cast_expr.typ).name
+	cast_expr.typname = p.table.type_symbol(cast_expr.typ).name
 	cast_expr.pos = pos.extend(cast_expr.pos)
 }

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -262,7 +262,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 				scope: 0
 			}
 		}
-		type_sym := p.table.get_type_symbol(rec.typ)
+		type_sym := p.table.type_symbol(rec.typ)
 		if is_method {
 			mut is_duplicate := type_sym.has_method(name)
 			// make sure this is a normal method and not an interface method
@@ -313,9 +313,9 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	_, mut generic_names := p.parse_generic_types()
 	// generic names can be infer with receiver's generic names
 	if is_method && rec.typ.has_flag(.generic) {
-		sym := p.table.get_type_symbol(rec.typ)
+		sym := p.table.type_symbol(rec.typ)
 		if sym.info is ast.Struct {
-			rec_generic_names := sym.info.generic_types.map(p.table.get_type_symbol(it).name)
+			rec_generic_names := sym.info.generic_types.map(p.table.type_symbol(it).name)
 			for gname in rec_generic_names {
 				if gname !in generic_names {
 					generic_names << gname
@@ -372,14 +372,14 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	file_mode := p.file_backend_mode
 	// Register
 	if is_method {
-		mut type_sym := p.table.get_type_symbol(rec.typ)
+		mut type_sym := p.table.type_symbol(rec.typ)
 		// Do not allow to modify / add methods to types from other modules
 		// arrays/maps dont belong to a module only their element types do
 		// we could also check if kind is .array,  .array_fixed, .map instead of mod.len
 		mut is_non_local := type_sym.mod.len > 0 && type_sym.mod != p.mod && type_sym.language == .v
 		// check maps & arrays, must be defined in same module as the elem type
 		if !is_non_local && !(p.builtin_mod && p.pref.is_fmt) && type_sym.kind in [.array, .map] {
-			elem_type_sym := p.table.get_type_symbol(p.table.value_type(rec.typ))
+			elem_type_sym := p.table.type_symbol(p.table.value_type(rec.typ))
 			is_non_local = elem_type_sym.mod.len > 0 && elem_type_sym.mod != p.mod
 				&& elem_type_sym.language == .v
 		}
@@ -588,7 +588,7 @@ fn (mut p Parser) fn_receiver(mut params []ast.Param, mut rec ReceiverParsingInf
 		rec.typ = rec.typ.set_flag(.atomic_f)
 	}
 	// optimize method `automatic use fn (a &big_foo) instead of fn (a big_foo)`
-	type_sym := p.table.get_type_symbol(rec.typ)
+	type_sym := p.table.type_symbol(rec.typ)
 	mut is_auto_rec := false
 	if type_sym.kind == .struct_ {
 		info := type_sym.info as ast.Struct
@@ -793,7 +793,7 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 				}
 				p.next()
 			}
-			alanguage := p.table.get_type_symbol(arg_type).language
+			alanguage := p.table.type_symbol(arg_type).language
 			if alanguage != .v {
 				p.check_for_impure_v(alanguage, pos)
 			}
@@ -882,7 +882,7 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 				typ = ast.new_type(p.table.find_or_register_array(typ)).derive(typ).set_flag(.variadic)
 			}
 			for i, arg_name in arg_names {
-				alanguage := p.table.get_type_symbol(typ).language
+				alanguage := p.table.type_symbol(typ).language
 				if alanguage != .v {
 					p.check_for_impure_v(alanguage, type_pos[i])
 				}
@@ -958,7 +958,7 @@ fn (mut p Parser) closure_vars() []ast.Param {
 }
 
 fn (mut p Parser) check_fn_mutable_arguments(typ ast.Type, pos token.Position) {
-	sym := p.table.get_type_symbol(typ)
+	sym := p.table.type_symbol(typ)
 	if sym.kind in [.array, .array_fixed, .interface_, .map, .placeholder, .struct_, .generic_inst,
 		.sum_type] {
 		return
@@ -981,7 +981,7 @@ fn (mut p Parser) check_fn_mutable_arguments(typ ast.Type, pos token.Position) {
 }
 
 fn (mut p Parser) check_fn_shared_arguments(typ ast.Type, pos token.Position) {
-	sym := p.table.get_type_symbol(typ)
+	sym := p.table.type_symbol(typ)
 	if sym.kind !in [.array, .struct_, .map, .placeholder] && !typ.is_ptr() {
 		p.error_with_pos('shared arguments are only allowed for arrays, maps, and structs\n',
 			pos)
@@ -989,7 +989,7 @@ fn (mut p Parser) check_fn_shared_arguments(typ ast.Type, pos token.Position) {
 }
 
 fn (mut p Parser) check_fn_atomic_arguments(typ ast.Type, pos token.Position) {
-	sym := p.table.get_type_symbol(typ)
+	sym := p.table.type_symbol(typ)
 	if sym.kind !in [.u32, .int, .u64] {
 		p.error_with_pos('atomic arguments are only allowed for 32/64 bit integers\n' +
 			'use shared arguments instead: `fn foo(atomic n $sym.name) {` => `fn foo(shared n $sym.name) {`',

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -262,7 +262,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 				scope: 0
 			}
 		}
-		type_sym := p.table.type_symbol(rec.typ)
+		type_sym := p.table.sym(rec.typ)
 		if is_method {
 			mut is_duplicate := type_sym.has_method(name)
 			// make sure this is a normal method and not an interface method
@@ -313,9 +313,9 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	_, mut generic_names := p.parse_generic_types()
 	// generic names can be infer with receiver's generic names
 	if is_method && rec.typ.has_flag(.generic) {
-		sym := p.table.type_symbol(rec.typ)
+		sym := p.table.sym(rec.typ)
 		if sym.info is ast.Struct {
-			rec_generic_names := sym.info.generic_types.map(p.table.type_symbol(it).name)
+			rec_generic_names := sym.info.generic_types.map(p.table.sym(it).name)
 			for gname in rec_generic_names {
 				if gname !in generic_names {
 					generic_names << gname
@@ -372,14 +372,14 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	file_mode := p.file_backend_mode
 	// Register
 	if is_method {
-		mut type_sym := p.table.type_symbol(rec.typ)
+		mut type_sym := p.table.sym(rec.typ)
 		// Do not allow to modify / add methods to types from other modules
 		// arrays/maps dont belong to a module only their element types do
 		// we could also check if kind is .array,  .array_fixed, .map instead of mod.len
 		mut is_non_local := type_sym.mod.len > 0 && type_sym.mod != p.mod && type_sym.language == .v
 		// check maps & arrays, must be defined in same module as the elem type
 		if !is_non_local && !(p.builtin_mod && p.pref.is_fmt) && type_sym.kind in [.array, .map] {
-			elem_type_sym := p.table.type_symbol(p.table.value_type(rec.typ))
+			elem_type_sym := p.table.sym(p.table.value_type(rec.typ))
 			is_non_local = elem_type_sym.mod.len > 0 && elem_type_sym.mod != p.mod
 				&& elem_type_sym.language == .v
 		}
@@ -588,7 +588,7 @@ fn (mut p Parser) fn_receiver(mut params []ast.Param, mut rec ReceiverParsingInf
 		rec.typ = rec.typ.set_flag(.atomic_f)
 	}
 	// optimize method `automatic use fn (a &big_foo) instead of fn (a big_foo)`
-	type_sym := p.table.type_symbol(rec.typ)
+	type_sym := p.table.sym(rec.typ)
 	mut is_auto_rec := false
 	if type_sym.kind == .struct_ {
 		info := type_sym.info as ast.Struct
@@ -793,7 +793,7 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 				}
 				p.next()
 			}
-			alanguage := p.table.type_symbol(arg_type).language
+			alanguage := p.table.sym(arg_type).language
 			if alanguage != .v {
 				p.check_for_impure_v(alanguage, pos)
 			}
@@ -882,7 +882,7 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 				typ = ast.new_type(p.table.find_or_register_array(typ)).derive(typ).set_flag(.variadic)
 			}
 			for i, arg_name in arg_names {
-				alanguage := p.table.type_symbol(typ).language
+				alanguage := p.table.sym(typ).language
 				if alanguage != .v {
 					p.check_for_impure_v(alanguage, type_pos[i])
 				}
@@ -958,7 +958,7 @@ fn (mut p Parser) closure_vars() []ast.Param {
 }
 
 fn (mut p Parser) check_fn_mutable_arguments(typ ast.Type, pos token.Position) {
-	sym := p.table.type_symbol(typ)
+	sym := p.table.sym(typ)
 	if sym.kind in [.array, .array_fixed, .interface_, .map, .placeholder, .struct_, .generic_inst,
 		.sum_type] {
 		return
@@ -981,7 +981,7 @@ fn (mut p Parser) check_fn_mutable_arguments(typ ast.Type, pos token.Position) {
 }
 
 fn (mut p Parser) check_fn_shared_arguments(typ ast.Type, pos token.Position) {
-	sym := p.table.type_symbol(typ)
+	sym := p.table.sym(typ)
 	if sym.kind !in [.array, .struct_, .map, .placeholder] && !typ.is_ptr() {
 		p.error_with_pos('shared arguments are only allowed for arrays, maps, and structs\n',
 			pos)
@@ -989,7 +989,7 @@ fn (mut p Parser) check_fn_shared_arguments(typ ast.Type, pos token.Position) {
 }
 
 fn (mut p Parser) check_fn_atomic_arguments(typ ast.Type, pos token.Position) {
-	sym := p.table.type_symbol(typ)
+	sym := p.table.sym(typ)
 	if sym.kind !in [.u32, .int, .u64] {
 		p.error_with_pos('atomic arguments are only allowed for 32/64 bit integers\n' +
 			'use shared arguments instead: `fn foo(atomic n $sym.name) {` => `fn foo(shared n $sym.name) {`',

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -68,7 +68,7 @@ pub fn (mut p Parser) parse_array_type() ast.Type {
 		if fixed_size <= 0 {
 			p.error_with_pos('fixed size cannot be zero or negative', size_expr.position())
 		}
-		// sym := p.table.get_type_symbol(elem_type)
+		// sym := p.table.type_symbol(elem_type)
 		idx := p.table.find_or_register_array_fixed(elem_type, fixed_size, size_expr)
 		if elem_type.has_flag(.generic) {
 			return ast.new_type(idx).set_flag(.generic)
@@ -107,7 +107,7 @@ pub fn (mut p Parser) parse_map_type() ast.Type {
 	}
 	p.check(.lsbr)
 	key_type := p.parse_type()
-	key_sym := p.table.get_type_symbol(key_type)
+	key_sym := p.table.type_symbol(key_type)
 	is_alias := key_sym.kind == .alias
 	if key_type.idx() == 0 {
 		// error is reported in parse_type
@@ -551,7 +551,7 @@ pub fn (mut p Parser) parse_generic_inst_type(name string) ast.Type {
 		if !gt.has_flag(.generic) {
 			is_instance = true
 		}
-		gts := p.table.get_type_symbol(gt)
+		gts := p.table.type_symbol(gt)
 		bs_name += gts.name
 		bs_cname += gts.cname
 		concrete_types << gt
@@ -577,7 +577,7 @@ pub fn (mut p Parser) parse_generic_inst_type(name string) ast.Type {
 		if parent_idx == 0 {
 			parent_idx = p.table.add_placeholder_type(name, .v)
 		}
-		parent_sym := p.table.get_type_symbol(ast.new_type(parent_idx))
+		parent_sym := p.table.type_symbol(ast.new_type(parent_idx))
 		match parent_sym.info {
 			ast.Struct {
 				if parent_sym.info.generic_types.len == 0 {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -68,7 +68,7 @@ pub fn (mut p Parser) parse_array_type() ast.Type {
 		if fixed_size <= 0 {
 			p.error_with_pos('fixed size cannot be zero or negative', size_expr.position())
 		}
-		// sym := p.table.type_symbol(elem_type)
+		// sym := p.table.sym(elem_type)
 		idx := p.table.find_or_register_array_fixed(elem_type, fixed_size, size_expr)
 		if elem_type.has_flag(.generic) {
 			return ast.new_type(idx).set_flag(.generic)
@@ -107,7 +107,7 @@ pub fn (mut p Parser) parse_map_type() ast.Type {
 	}
 	p.check(.lsbr)
 	key_type := p.parse_type()
-	key_sym := p.table.type_symbol(key_type)
+	key_sym := p.table.sym(key_type)
 	is_alias := key_sym.kind == .alias
 	if key_type.idx() == 0 {
 		// error is reported in parse_type
@@ -551,7 +551,7 @@ pub fn (mut p Parser) parse_generic_inst_type(name string) ast.Type {
 		if !gt.has_flag(.generic) {
 			is_instance = true
 		}
-		gts := p.table.type_symbol(gt)
+		gts := p.table.sym(gt)
 		bs_name += gts.name
 		bs_cname += gts.cname
 		concrete_types << gt
@@ -577,7 +577,7 @@ pub fn (mut p Parser) parse_generic_inst_type(name string) ast.Type {
 		if parent_idx == 0 {
 			parent_idx = p.table.add_placeholder_type(name, .v)
 		}
-		parent_sym := p.table.type_symbol(ast.new_type(parent_idx))
+		parent_sym := p.table.sym(ast.new_type(parent_idx))
 		match parent_sym.info {
 			ast.Struct {
 				if parent_sym.info.generic_types.len == 0 {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2233,7 +2233,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 			p.check(.rpar)
 			node = ast.CastExpr{
 				typ: to_typ
-				typname: p.table.type_symbol(to_typ).name
+				typname: p.table.sym(to_typ).name
 				expr: expr
 				arg: arg
 				has_arg: has_arg
@@ -3384,7 +3384,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		// function type: `type mycallback = fn(string, int)`
 		fn_name := p.prepend_mod(name)
 		fn_type := p.parse_fn_type(fn_name)
-		p.table.type_symbol(fn_type).is_public = is_pub
+		p.table.sym(fn_type).is_public = is_pub
 		type_pos = type_pos.extend(p.tok.position())
 		comments = p.eat_comments(same_line: true)
 		return ast.FnTypeDecl{
@@ -3459,7 +3459,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		return ast.AliasTypeDecl{}
 	}
 	parent_type := first_type
-	parent_sym := p.table.type_symbol(parent_type)
+	parent_sym := p.table.sym(parent_type)
 	pidx := parent_type.idx()
 	p.check_for_impure_v(parent_sym.language, decl_pos)
 	prepend_mod_name := p.prepend_mod(name)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2233,7 +2233,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 			p.check(.rpar)
 			node = ast.CastExpr{
 				typ: to_typ
-				typname: p.table.get_type_symbol(to_typ).name
+				typname: p.table.type_symbol(to_typ).name
 				expr: expr
 				arg: arg
 				has_arg: has_arg
@@ -3384,7 +3384,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		// function type: `type mycallback = fn(string, int)`
 		fn_name := p.prepend_mod(name)
 		fn_type := p.parse_fn_type(fn_name)
-		p.table.get_type_symbol(fn_type).is_public = is_pub
+		p.table.type_symbol(fn_type).is_public = is_pub
 		type_pos = type_pos.extend(p.tok.position())
 		comments = p.eat_comments(same_line: true)
 		return ast.FnTypeDecl{
@@ -3459,7 +3459,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		return ast.AliasTypeDecl{}
 	}
 	parent_type := first_type
-	parent_sym := p.table.get_type_symbol(parent_type)
+	parent_sym := p.table.type_symbol(parent_type)
 	pidx := parent_type.idx()
 	p.check_for_impure_v(parent_sym.language, decl_pos)
 	prepend_mod_name := p.prepend_mod(name)

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -193,7 +193,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 						type_pos)
 					return ast.StructDecl{}
 				}
-				sym := p.table.get_type_symbol(typ)
+				sym := p.table.type_symbol(typ)
 				if typ in embed_types {
 					p.error_with_pos('cannot embed `$sym.name` more than once', type_pos)
 					return ast.StructDecl{}
@@ -339,7 +339,7 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 	first_pos := (if short_syntax && p.prev_tok.kind == .lcbr { p.prev_tok } else { p.tok }).position()
 	typ := if short_syntax { ast.void_type } else { p.parse_type() }
 	p.expr_mod = ''
-	// sym := p.table.get_type_symbol(typ)
+	// sym := p.table.type_symbol(typ)
 	// p.warn('struct init typ=$sym.name')
 	if !short_syntax {
 		p.check(.lcbr)
@@ -486,7 +486,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		return ast.InterfaceDecl{}
 	}
 	typ := ast.new_type(reg_idx)
-	mut ts := p.table.get_type_symbol(typ)
+	mut ts := p.table.type_symbol(typ)
 	mut info := ts.info as ast.Interface
 	// if methods were declared before, it's an error, ignore them
 	ts.methods = []ast.Fn{cap: 20}
@@ -502,7 +502,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			mut iface_name := p.tok.lit
 			iface_type := p.parse_type()
 			if iface_name == 'JS' {
-				iface_name = p.table.get_type_symbol(iface_type).name
+				iface_name = p.table.type_symbol(iface_type).name
 			}
 			comments := p.eat_comments()
 			ifaces << ast.InterfaceEmbedding{

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -193,7 +193,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 						type_pos)
 					return ast.StructDecl{}
 				}
-				sym := p.table.type_symbol(typ)
+				sym := p.table.sym(typ)
 				if typ in embed_types {
 					p.error_with_pos('cannot embed `$sym.name` more than once', type_pos)
 					return ast.StructDecl{}
@@ -339,7 +339,7 @@ fn (mut p Parser) struct_init(short_syntax bool) ast.StructInit {
 	first_pos := (if short_syntax && p.prev_tok.kind == .lcbr { p.prev_tok } else { p.tok }).position()
 	typ := if short_syntax { ast.void_type } else { p.parse_type() }
 	p.expr_mod = ''
-	// sym := p.table.type_symbol(typ)
+	// sym := p.table.sym(typ)
 	// p.warn('struct init typ=$sym.name')
 	if !short_syntax {
 		p.check(.lcbr)
@@ -486,7 +486,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		return ast.InterfaceDecl{}
 	}
 	typ := ast.new_type(reg_idx)
-	mut ts := p.table.type_symbol(typ)
+	mut ts := p.table.sym(typ)
 	mut info := ts.info as ast.Interface
 	// if methods were declared before, it's an error, ignore them
 	ts.methods = []ast.Fn{cap: 20}
@@ -502,7 +502,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			mut iface_name := p.tok.lit
 			iface_type := p.parse_type()
 			if iface_name == 'JS' {
-				iface_name = p.table.type_symbol(iface_type).name
+				iface_name = p.table.sym(iface_type).name
 			}
 			comments := p.eat_comments()
 			ifaces << ast.InterfaceEmbedding{


### PR DESCRIPTION
This PR rename `table.get_type_symbol()` to `table.sym()` and more related calls.

- Rename `table.get_type_symbol()` to `table.sym()`.
- Rename `table.get_final_type_symbol()` to `table.final_sym()`.
- Rename `table.get_type_symbol_by_idx()` to `table.sym_by_idx()`.