### PR TITLE
checker: fix error of map selector assign (fix #12900)

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -300,6 +300,13 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 					c.error('non-name on the left side of `:=`', left.pos)
 				}
 			}
+			ast.SelectorExpr {
+				if mut left.expr is ast.IndexExpr {
+					if left.expr.is_map {
+						left.expr.is_setter = true
+					}
+				}
+			}
 			else {
 				if mut left is ast.IndexExpr {
 					// eprintln('>>> left.is_setter: ${left.is_setter:10} | left.is_map: ${left.is_map:10} | left.is_array: ${left.is_array:10}')

--- a/vlib/v/tests/map_selector_assign_test.v
+++ b/vlib/v/tests/map_selector_assign_test.v
@@ -1,0 +1,11 @@
+struct Test {
+mut:
+	data int
+}
+
+fn test_map_selector_assign() {
+	mut m := map[int]Test{}
+	m[0].data = 1
+	println(m[0].data)
+	assert m[0].data == 1
+}


### PR DESCRIPTION
This PR fix error of map selector assign (fix #12900).

- Fix error of map selector assign.
- Add test.

```vlang
struct Test {
mut:
	data int
}

fn main() {
	mut m := map[int]Test{}
	m[0].data = 1
	println(m[0].data)
	assert m[0].data == 1
}

PS D:\Test\v\tt1> v run .
1
```