### PR TITLE
cgen: fix fixed array of interfaces equality

### DIFF
--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -191,6 +191,9 @@ fn (mut g Gen) gen_alias_equality_fn(left_type ast.Type) string {
 	} else if sym.kind == .struct_ && !left.typ.is_ptr() {
 		eq_fn := g.gen_struct_equality_fn(info.parent_type)
 		fn_builder.writeln('\treturn ${eq_fn}_struct_eq(a, b);')
+	} else if sym.kind == .interface_ && !left.typ.is_ptr() {
+		eq_fn := g.gen_interface_equality_fn(info.parent_type)
+		fn_builder.writeln('\treturn ${eq_fn}_interface_eq(a, b);')
 	} else if sym.kind == .array && !left.typ.is_ptr() {
 		eq_fn := g.gen_array_equality_fn(info.parent_type)
 		fn_builder.writeln('\treturn ${eq_fn}_arr_eq(a, b);')
@@ -289,6 +292,9 @@ fn (mut g Gen) gen_fixed_array_equality_fn(left_type ast.Type) string {
 	} else if elem.sym.kind == .struct_ && !elem.typ.is_ptr() {
 		eq_fn := g.gen_struct_equality_fn(elem.typ)
 		fn_builder.writeln('\t\tif (!${eq_fn}_struct_eq(a[i], b[i])) {')
+	} else if elem.sym.kind == .interface_ && !elem.typ.is_ptr() {
+		eq_fn := g.gen_interface_equality_fn(elem.typ)
+		fn_builder.writeln('\t\tif (!${eq_fn}_interface_eq(a[i], b[i])) {')
 	} else if elem.sym.kind == .array && !elem.typ.is_ptr() {
 		eq_fn := g.gen_array_equality_fn(elem.typ)
 		fn_builder.writeln('\t\tif (!${eq_fn}_arr_eq(a[i], b[i])) {')
@@ -363,6 +369,10 @@ fn (mut g Gen) gen_map_equality_fn(left_type ast.Type) string {
 		.struct_ {
 			eq_fn := g.gen_struct_equality_fn(value.typ)
 			fn_builder.writeln('\t\tif (!${eq_fn}_struct_eq(*($ptr_value_styp*)map_get(&b, k, &($ptr_value_styp[]){ 0 }), v)) {')
+		}
+		.interface_ {
+			eq_fn := g.gen_interface_equality_fn(value.typ)
+			fn_builder.writeln('\t\tif (!${eq_fn}_interface_eq(*($ptr_value_styp*)map_get(&b, k, &($ptr_value_styp[]){ 0 }), v)) {')
 		}
 		.array {
 			eq_fn := g.gen_array_equality_fn(value.typ)

--- a/vlib/v/tests/fixed_array_of_interfaces_equality_test.v
+++ b/vlib/v/tests/fixed_array_of_interfaces_equality_test.v
@@ -1,0 +1,31 @@
+interface IObject {
+	foo()
+}
+
+struct Foo {}
+
+fn (f Foo) foo() {
+}
+
+struct Array {
+mut:
+	array [1]IObject
+}
+
+fn (a Array) contains(x IObject) bool {
+	for element in a.array {
+		if element == x {
+			return true
+		}
+	}
+	return false
+}
+
+fn test_fixed_array_of_interfaces_equality() {
+	foo := Foo{}
+	mut ary := Array{}
+	ary.array[0] = foo
+	ret := ary.contains(foo)
+	println(ret)
+	assert ret
+}


### PR DESCRIPTION
This PR fix fixed array/alias/map of interfaces equality.

- Fix fixed array/alias/map of interfaces equality.
- Add test.

```vlang
interface IObject {
	foo()
}

struct Foo {}

fn (f Foo) foo() {
}

struct Array {
mut:
	array [1]IObject
}

fn (a Array) contains(x IObject) bool {
	for element in a.array {
		if element == x {
			return true
		}
	}
	return false
}

fn main() {
	foo := Foo{}
	mut ary := Array{}
	ary.array[0] = foo
	ret := ary.contains(foo)
	println(ret)
	assert ret
}

PS D:\Test\v\tt1> v run .
true
```