### PR TITLE
gg: renaming drawing functions

### DIFF
--- a/.github/workflows/sdl_ci.yml
+++ b/.github/workflows/sdl_ci.yml
@@ -8,10 +8,6 @@ on:
     paths-ignore:
       - "**.md"
 
-concurrency:
-  group: build-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: true
-
 jobs:
   v-compiles-sdl-examples:
     runs-on: ubuntu-18.04

--- a/examples/2048/2048.v
+++ b/examples/2048/2048.v
@@ -593,7 +593,7 @@ fn (app &App) draw() {
 	app.draw_tiles()
 	// TODO: Make transparency work in `gg`
 	if app.state == .over {
-		app.gg.draw_rect(0, 0, ww, wh, gx.rgba(10, 0, 0, 180))
+		app.gg.draw_rect_filled(0, 0, ww, wh, gx.rgba(10, 0, 0, 180))
 		app.gg.draw_text(ww / 2, (m * 4 / 10) + ypad, 'Game Over', app.label_format(.game_over))
 		f := app.label_format(.tile)
 		msg := $if android { 'Tap to restart' } $else { 'Press `r` to restart' }
@@ -604,7 +604,7 @@ fn (app &App) draw() {
 		})
 	}
 	if app.state == .victory {
-		app.gg.draw_rect(0, 0, ww, wh, gx.rgba(0, 10, 0, 180))
+		app.gg.draw_rect_filled(0, 0, ww, wh, gx.rgba(0, 10, 0, 180))
 		app.gg.draw_text(ww / 2, (m * 4 / 10) + ypad, 'Victory!', app.label_format(.victory))
 		// f := app.label_format(.tile)
 		msg1 := $if android { 'Tap to continue' } $else { 'Press `space` to continue' }
@@ -623,7 +623,7 @@ fn (app &App) draw_tiles() {
 	toffset := app.ui.tile_size + app.ui.padding_size
 	tiles_size := mu.min(app.ui.window_width, app.ui.window_height) - app.ui.border_size * 2
 	// Draw the padding around the tiles
-	app.gg.draw_rounded_rect(xstart, ystart, tiles_size, tiles_size, tiles_size / 24,
+	app.gg.draw_rounded_rect_filled(xstart, ystart, tiles_size, tiles_size, tiles_size / 24,
 		app.theme.padding_color)
 	// Draw the actual tiles
 	for y in 0 .. 4 {
@@ -640,7 +640,7 @@ fn (app &App) draw_tiles() {
 			th := tw // square tiles, w == h
 			xoffset := xstart + app.ui.padding_size + x * toffset + (app.ui.tile_size - tw) / 2
 			yoffset := ystart + app.ui.padding_size + y * toffset + (app.ui.tile_size - th) / 2
-			app.gg.draw_rounded_rect(xoffset, yoffset, tw, th, tw / 8, tile_color)
+			app.gg.draw_rounded_rect_filled(xoffset, yoffset, tw, th, tw / 8, tile_color)
 			if tidx != 0 { // 0 == blank spot
 				xpos := xoffset + tw / 2
 				ypos := yoffset + th / 2

--- a/examples/fireworks/modules/objects/particle.v
+++ b/examples/fireworks/modules/objects/particle.v
@@ -13,7 +13,7 @@ pub mut:
 }
 
 pub fn (particle Particle) draw(mut ctx gg.Context) {
-	ctx.draw_circle(particle.pos.x, get_params().height - particle.pos.y, get_params().particle_radius,
+	ctx.draw_circle_filled(particle.pos.x, get_params().height - particle.pos.y, get_params().particle_radius,
 		particle.color)
 }
 

--- a/examples/fireworks/modules/objects/rocket.v
+++ b/examples/fireworks/modules/objects/rocket.v
@@ -16,7 +16,7 @@ pub mut:
 }
 
 pub fn (rocket Rocket) draw(mut ctx gg.Context) {
-	ctx.draw_circle(rocket.pos.x, get_params().height - rocket.pos.y, get_params().rocket_radius,
+	ctx.draw_circle_filled(rocket.pos.x, get_params().height - rocket.pos.y, get_params().rocket_radius,
 		rocket.color)
 }
 

--- a/examples/game_of_life/life_gg.v
+++ b/examples/game_of_life/life_gg.v
@@ -17,7 +17,7 @@ fn print_automaton(app &App) {
 		for x := 1; x < app.a.field.maxx; x++ {
 			cell := app.a.field.get(x, y)
 			if cell == 1 {
-				app.gg.draw_rect(f32(square_size * x), f32(square_size * y), f32(square_size),
+				app.gg.draw_rect_filled(f32(square_size * x), f32(square_size * y), f32(square_size),
 					f32(square_size), filled_color)
 			}
 		}

--- a/examples/gg/draw_pixels.v
+++ b/examples/gg/draw_pixels.v
@@ -41,12 +41,14 @@ fn main() {
 
 fn frame(mut app App) {
 	app.gg.begin()
-	// Set a blue pixel near each corner. (Find your magnifying glass)
-	app.gg.set_pixel(2, 2, gx.blue)
-	app.gg.set_pixel(app.gg.width - 2, 2, gx.blue)
-	app.gg.set_pixel(app.gg.width - 2, app.gg.height - 2, gx.blue)
-	app.gg.set_pixel(2, app.gg.height - 2, gx.blue)
-	// Set pixels in a grid-like pattern.
-	app.gg.set_pixels(app.pixels, gx.red)
+	
+	// Draw a blue pixel near each corner. (Find your magnifying glass)
+	app.gg.draw_pixel(2, 2, gx.blue)
+	app.gg.draw_pixel(app.gg.width - 2, 2, gx.blue)
+	app.gg.draw_pixel(app.gg.width - 2, app.gg.height - 2, gx.blue)
+	app.gg.draw_pixel(2, app.gg.height - 2, gx.blue)
+	
+	// Draw pixels in a grid-like pattern.
+	app.gg.draw_pixels(app.pixels, gx.red)
 	app.gg.end()
 }

--- a/examples/gg/draw_pixels.v
+++ b/examples/gg/draw_pixels.v
@@ -41,13 +41,13 @@ fn main() {
 
 fn frame(mut app App) {
 	app.gg.begin()
-	
+
 	// Draw a blue pixel near each corner. (Find your magnifying glass)
 	app.gg.draw_pixel(2, 2, gx.blue)
 	app.gg.draw_pixel(app.gg.width - 2, 2, gx.blue)
 	app.gg.draw_pixel(app.gg.width - 2, app.gg.height - 2, gx.blue)
 	app.gg.draw_pixel(2, app.gg.height - 2, gx.blue)
-	
+
 	// Draw pixels in a grid-like pattern.
 	app.gg.draw_pixels(app.pixels, gx.red)
 	app.gg.end()

--- a/examples/gg/polygons.v
+++ b/examples/gg/polygons.v
@@ -18,7 +18,7 @@ fn frame(mut ctx gg.Context) {
 	ctx.begin()
 	ctx.draw_convex_poly([f32(100.0), 100.0, 200.0, 100.0, 300.0, 200.0, 200.0, 300.0, 100.0, 300.0],
 		gx.blue)
-	ctx.draw_empty_poly([f32(50.0), 50.0, 70.0, 60.0, 90.0, 80.0, 70.0, 110.0], gx.black)
-	ctx.draw_triangle(450, 142, 530, 280, 370, 280, gx.red)
+	ctx.draw_poly_empty([f32(50.0), 50.0, 70.0, 60.0, 90.0, 80.0, 70.0, 110.0], gx.black)
+	ctx.draw_triangle_filled(450, 142, 530, 280, 370, 280, gx.red)
 	ctx.end()
 }

--- a/examples/gg/rectangles.v
+++ b/examples/gg/rectangles.v
@@ -47,7 +47,7 @@ fn frame(app &App) {
 fn (app &App) draw() {
 	// app.gg.draw_text_def(200,20, 'hello world!')
 	// app.gg.draw_text_def(300,300, 'привет')
-	app.gg.draw_rect(10, 10, 100, 30, gx.blue)
-	app.gg.draw_empty_rect(110, 150, 80, 40, gx.black)
+	app.gg.draw_rect_filled(10, 10, 100, 30, gx.blue)
+	app.gg.draw_rect_empty(110, 150, 80, 40, gx.black)
 	app.gg.draw_image(230, 30, app.image.width, app.image.height, app.image)
 }

--- a/examples/hot_reload/bounce.v
+++ b/examples/hot_reload/bounce.v
@@ -56,10 +56,11 @@ fn main() {
 fn frame(mut game Game) {
 	game.gg.begin()
 	game.gg.draw_text_def(10, 5, 'Modify examples/hot_reload/bounce.v to get instant updates')
-	game.gg.draw_rect(game.x, game.y, width, width, gx.blue)
-	game.gg.draw_rect(window_width - width - game.x + 10, 200 - game.y + width, width,
-		width, gx.rgb(228, 10, 55))
-	game.gg.draw_rect(game.x - 25, 250 - game.y, width, width, gx.rgb(28, 240, 55))
+	game.gg.draw_rect_filled(game.x, game.y, width, width, gx.blue)
+	game.gg.draw_rect_filled(window_width - width - game.x + 10, 200 - game.y + width,
+		width, width, gx.rgb(228, 10, 55))
+	game.gg.draw_rect_filled(game.x - 25, 250 - game.y, width, width, gx.rgb(28, 240,
+		55))
 	game.gg.end()
 }
 

--- a/examples/hot_reload/graph.v
+++ b/examples/hot_reload/graph.v
@@ -77,10 +77,10 @@ fn (ctx &Context) draw() {
 		// y = (x + 3) * (x + 3) / stime + stime*2.5
 		// y = math.sqrt(30.0 - x * x) * stime
 		// y -= (stime-0.5) + stime
-		// ctx.gg.draw_rect(f32((w/2) + x * scale), f32((h/2) - y * scale), 2, 2, blue)
-		ctx.gg.draw_rect(f32((w / 2) + x * scale), f32((h / 2) - y * scale), 2, (f32(y) * scale),
-			blue)
-		ctx.gg.draw_rect(f32((w / 2) + x * scale), f32((h / 2) + y * scale), 2, (f32(y) * scale) +
-			32, red)
+		// ctx.gg.draw_rect_filled(f32((w/2) + x * scale), f32((h/2) - y * scale), 2, 2, blue)
+		ctx.gg.draw_rect_filled(f32((w / 2) + x * scale), f32((h / 2) - y * scale), 2,
+			(f32(y) * scale), blue)
+		ctx.gg.draw_rect_filled(f32((w / 2) + x * scale), f32((h / 2) + y * scale), 2,
+			(f32(y) * scale) + 32, red)
 	}
 }

--- a/examples/snek/snek.v
+++ b/examples/snek/snek.v
@@ -157,16 +157,16 @@ fn on_frame(mut app App) {
 	}
 	// drawing snake
 	for pos in app.snake {
-		app.gg.draw_rect(tile_size * pos.x, tile_size * pos.y + top_height, tile_size,
+		app.gg.draw_rect_filled(tile_size * pos.x, tile_size * pos.y + top_height, tile_size,
 			tile_size, gx.blue)
 	}
 
 	// drawing food
-	app.gg.draw_rect(tile_size * app.food.x, tile_size * app.food.y + top_height, tile_size,
-		tile_size, gx.red)
+	app.gg.draw_rect_filled(tile_size * app.food.x, tile_size * app.food.y + top_height,
+		tile_size, tile_size, gx.red)
 
 	// drawing top
-	app.gg.draw_rect(0, 0, canvas_size, top_height, gx.black)
+	app.gg.draw_rect_filled(0, 0, canvas_size, top_height, gx.black)
 	app.gg.draw_text(150, top_height / 2, 'Score: $app.score', gx.TextCfg{
 		color: gx.white
 		align: .center

--- a/examples/tetris/tetris.v
+++ b/examples/tetris/tetris.v
@@ -354,7 +354,7 @@ fn (g &Game) draw_next_tetro() {
 }
 
 fn (g &Game) draw_block_color(i int, j int, color gx.Color) {
-	g.gg.draw_rect(f32((j - 1) * g.block_size) + g.margin, f32((i - 1) * g.block_size),
+	g.gg.draw_rect_filled(f32((j - 1) * g.block_size) + g.margin, f32((i - 1) * g.block_size),
 		f32(g.block_size - 1), f32(g.block_size - 1), color)
 }
 
@@ -380,11 +380,11 @@ fn (mut g Game) draw_ui() {
 	lines := g.lines.str()
 	g.gg.draw_text(ws.width - lines.len * textsize, 3, lines, text_cfg)
 	if g.state == .gameover {
-		g.gg.draw_rect(0, ws.height / 2 - textsize, ws.width, 5 * textsize, ui_color)
+		g.gg.draw_rect_filled(0, ws.height / 2 - textsize, ws.width, 5 * textsize, ui_color)
 		g.gg.draw_text(1, ws.height / 2 + 0 * textsize, 'Game Over', over_cfg)
 		g.gg.draw_text(1, ws.height / 2 + 2 * textsize, 'Space to restart', over_cfg)
 	} else if g.state == .paused {
-		g.gg.draw_rect(0, ws.height / 2 - textsize, ws.width, 5 * textsize, ui_color)
+		g.gg.draw_rect_filled(0, ws.height / 2 - textsize, ws.width, 5 * textsize, ui_color)
 		g.gg.draw_text(1, ws.height / 2 + 0 * textsize, 'Game Paused', text_cfg)
 		g.gg.draw_text(1, ws.height / 2 + 2 * textsize, 'SPACE to resume', text_cfg)
 	}

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -781,7 +781,7 @@ pub fn (ctx &Context) draw_line(x f32, y f32, x2 f32, y2 f32, c gx.Color) {
 			} else if height == 0 {
 				height = 1
 			}
-			ctx.draw_rect(x, y, f32(width), f32(height), c)
+			ctx.draw_rect_filled(x, y, f32(width), f32(height), c)
 			return
 		}
 	}
@@ -822,7 +822,7 @@ pub fn (ctx &Context) draw_line_with_config(x f32, y f32, x2 f32, y2 f32, config
 	sgl.translate(-nx, -ny, 0)
 
 	if config.line_type == .solid {
-		ctx.draw_rect(x, y, length, config.thickness, config.color)
+		ctx.draw_rect_filled(x, y, length, config.thickness, config.color)
 	} else {
 		size := if config.line_type == .dotted { config.thickness } else { config.thickness * 3 }
 		space := if size == 1 { 2 } else { size }
@@ -832,7 +832,7 @@ pub fn (ctx &Context) draw_line_with_config(x f32, y f32, x2 f32, y2 f32, config
 
 		for i := 0; available > 0; i++ {
 			if i % 2 == 0 {
-				ctx.draw_rect(start_x, y, size, config.thickness, config.color)
+				ctx.draw_rect_filled(start_x, y, size, config.thickness, config.color)
 				available -= size
 				start_x += size
 				continue
@@ -876,7 +876,7 @@ pub fn (ctx &Context) draw_arc_filled(x f32, y f32, inner_r f32, outer_r f32, st
 	}
 
 	if r1 <= 0.0 {
-		ctx.draw_slice(x, y, int(r2), a1, a2, segments, c)
+		ctx.draw_slice_filled(x, y, int(r2), a1, a2, segments, c)
 		return
 	}
 
@@ -928,7 +928,7 @@ pub fn (ctx &Context) draw_arc_empty(x f32, y f32, inner_r f32, outer_r f32, sta
 	}
 
 	if r1 <= 0.0 {
-		ctx.draw_empty_slice(x, y, int(r2), a1, a2, segments, c)
+		ctx.draw_slice_empty(x, y, int(r2), a1, a2, segments, c)
 		return
 	}
 

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -631,7 +631,7 @@ pub fn (ctx &Context) draw_square(x f32, y f32, s f32, c gx.Color) {
 
 [inline]
 pub fn (ctx &Context) draw_square_filled(x f32, y f32, s f32, c gx.Color) {
-	ctx.draw_rect(x, y, s, s, c)
+	ctx.draw_rect_filled(x, y, s, s, c)
 }
 
 // Draws the outline of a square

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -325,7 +325,12 @@ pub fn wait_events() {
 */
 
 // TODO: Fix alpha
+[deprecated: 'use draw_rect_filled() instead']
 pub fn (ctx &Context) draw_rect(x f32, y f32, w f32, h f32, c gx.Color) {
+	ctx.draw_rect_filled(x, y, w, h, c)
+}
+
+pub fn (ctx &Context) draw_rect_filled(x f32, y f32, w f32, h f32, c gx.Color) {
 	$if macos {
 		if ctx.native_rendering {
 			C.darwin_draw_rect(x, ctx.height - (y + h), w, h, c)
@@ -539,8 +544,13 @@ pub fn (mut ctx Context) set_bg_color(c gx.Color) {
 }
 
 // Sets a pixel
-[inline]
+[deprecated: 'use draw_pixel() instead']
 pub fn (ctx &Context) set_pixel(x f32, y f32, c gx.Color) {
+	ctx.draw_pixel(x, y, c)
+}
+
+[inline]
+pub fn (ctx &Context) draw_pixel(x f32, y f32, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
 	}
@@ -551,9 +561,14 @@ pub fn (ctx &Context) set_pixel(x f32, y f32, c gx.Color) {
 	sgl.end()
 }
 
+[deprecated: 'use draw_pixels() instead']
+pub fn (ctx &Context) set_pixels(points []f32, c gx.Color) {
+	ctx.draw_pixels(points, c)
+}
+
 // Sets pixels from an array of points [x, y, x2, y2, etc...]
 [direct_array_access; inline]
-pub fn (ctx &Context) set_pixels(points []f32, c gx.Color) {
+pub fn (ctx &Context) draw_pixels(points []f32, c gx.Color) {
 	assert points.len % 2 == 0
 	len := points.len / 2
 
@@ -571,7 +586,12 @@ pub fn (ctx &Context) set_pixels(points []f32, c gx.Color) {
 }
 
 // Draws a filled triangle
+[deprecated: 'use draw_triangle_filled() instead']
 pub fn (ctx &Context) draw_triangle(x f32, y f32, x2 f32, y2 f32, x3 f32, y3 f32, c gx.Color) {
+	ctx.draw_triangle_filled(x, y, x2, y2, x3, y3, c)
+}
+
+pub fn (ctx &Context) draw_triangle_filled(x f32, y f32, x2 f32, y2 f32, x3 f32, y3 f32, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
 	}
@@ -584,7 +604,12 @@ pub fn (ctx &Context) draw_triangle(x f32, y f32, x2 f32, y2 f32, x3 f32, y3 f32
 }
 
 // Draws the outline of a triangle
+[deprecated: 'use draw_triangle_empty() instead']
 pub fn (ctx &Context) draw_empty_triangle(x f32, y f32, x2 f32, y2 f32, x3 f32, y3 f32, c gx.Color) {
+	ctx.draw_triangle_empty(x, y, x2, y2, x3, y3, c)
+}
+
+pub fn (ctx &Context) draw_triangle_empty(x f32, y f32, x2 f32, y2 f32, x3 f32, y3 f32, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
 	}
@@ -599,19 +624,34 @@ pub fn (ctx &Context) draw_empty_triangle(x f32, y f32, x2 f32, y2 f32, x3 f32, 
 }
 
 // Draws a filled square
-[inline]
+[deprecated: 'use draw_square_filled() instead']
 pub fn (ctx &Context) draw_square(x f32, y f32, s f32, c gx.Color) {
+	ctx.draw_square_filled(x, y, s, c)
+}
+
+[inline]
+pub fn (ctx &Context) draw_square_filled(x f32, y f32, s f32, c gx.Color) {
 	ctx.draw_rect(x, y, s, s, c)
 }
 
 // Draws the outline of a square
-[inline]
+[deprecated: 'use draw_square_empty() instead']
 pub fn (ctx &Context) draw_empty_square(x f32, y f32, s f32, c gx.Color) {
-	ctx.draw_empty_rect(x, y, s, s, c)
+	ctx.draw_square_empty(x, y, s, c)
+}
+
+[inline]
+pub fn (ctx &Context) draw_square_empty(x f32, y f32, s f32, c gx.Color) {
+	ctx.draw_rect_empty(x, y, s, s, c)
 }
 
 // Draws the outline of a rectangle
+[deprecated: 'use draw_rect_empty() instead']
 pub fn (ctx &Context) draw_empty_rect(x f32, y f32, w f32, h f32, c gx.Color) {
+	ctx.draw_rect_empty(x, y, w, h, c)
+}
+
+pub fn (ctx &Context) draw_rect_empty(x f32, y f32, w f32, h f32, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
 	}
@@ -625,8 +665,13 @@ pub fn (ctx &Context) draw_empty_rect(x f32, y f32, w f32, h f32, c gx.Color) {
 	sgl.end()
 }
 
-// Draws a circle
+// Draws a filled circle
+[deprecated: 'use draw_circle_filled() instead']
 pub fn (ctx &Context) draw_circle(x f32, y f32, r f32, c gx.Color) {
+	ctx.draw_circle_filled(x, y, r, c)
+}
+
+pub fn (ctx &Context) draw_circle_filled(x f32, y f32, r f32, c gx.Color) {
 	ctx.draw_circle_with_segments(x, y, r, 10, c)
 }
 
@@ -653,8 +698,13 @@ pub fn (ctx &Context) draw_circle_with_segments(x f32, y f32, r f32, segments in
 	sgl.end()
 }
 
-// Draws a circle slice/pie.
+// Draws a filled circle slice/pie.
+[deprecated: 'use draw_slice_filled() instead']
 pub fn (ctx &Context) draw_slice(x f32, y f32, r f32, start_angle f32, arc_angle f32, segments int, c gx.Color) {
+	ctx.draw_slice_filled(x, y, r, start_angle, arc_angle, segments, c)
+}
+
+pub fn (ctx &Context) draw_slice_filled(x f32, y f32, r f32, start_angle f32, arc_angle f32, segments int, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
 	}
@@ -681,7 +731,13 @@ pub fn (ctx &Context) draw_slice(x f32, y f32, r f32, start_angle f32, arc_angle
 }
 
 // Draws the outline of a circle slice/pie.
+[deprecated: 'use draw_slice_empty() instead']
 pub fn (ctx &Context) draw_empty_slice(x f32, y f32, r f32, start_angle f32, arc_angle f32, segments int, c gx.Color) {
+	ctx.draw_slice_empty(x, y, r, start_angle, arc_angle, segments, c)
+}
+
+// TODO: Add inner angle to empty shape
+pub fn (ctx &Context) draw_slice_empty(x f32, y f32, r f32, start_angle f32, arc_angle f32, segments int, c gx.Color) {
 	if c.a != 255 {
 		sgl.load_pipeline(ctx.timage_pip)
 	}
@@ -790,8 +846,13 @@ pub fn (ctx &Context) draw_line_with_config(x f32, y f32, x2 f32, y2 f32, config
 	sgl.pop_matrix()
 }
 
-// Draws an arc
+// Draws a filled arc
+[deprecated: 'use draw_arc_filled() instead']
 pub fn (ctx &Context) draw_arc(x f32, y f32, inner_r f32, outer_r f32, start_angle f32, end_angle f32, segments int, c gx.Color) {
+	ctx.draw_arc_filled(x, y, inner_r, outer_r, start_angle, end_angle, segments, c)
+}
+
+pub fn (ctx &Context) draw_arc_filled(x f32, y f32, inner_r f32, outer_r f32, start_angle f32, end_angle f32, segments int, c gx.Color) {
 	if start_angle == end_angle || outer_r <= 0.0 {
 		return
 	}
@@ -839,6 +900,11 @@ pub fn (ctx &Context) draw_arc(x f32, y f32, inner_r f32, outer_r f32, start_ang
 }
 
 // Draws the outline of an arc
+[deprecated: 'use draw_arc_empty() instead']
+pub fn (ctx &Context) draw_empty_arc(x f32, y f32, inner_r f32, outer_r f32, start_angle f32, end_angle f32, segments int, c gx.Color) {
+	ctx.draw_arc_empty(x, y, inner_r, outer_r, start_angle, end_angle, segments, c)
+}
+
 pub fn (ctx &Context) draw_arc_empty(x f32, y f32, inner_r f32, outer_r f32, start_angle f32, end_angle f32, segments int, c gx.Color) {
 	if start_angle == end_angle || outer_r <= 0.0 {
 		return
@@ -897,7 +963,12 @@ pub fn (ctx &Context) draw_arc_empty(x f32, y f32, inner_r f32, outer_r f32, sta
 }
 
 // Draws a filled rounded rectangle
+[deprecated: 'use draw_rounded_rect_filled()']
 pub fn (ctx &Context) draw_rounded_rect(x f32, y f32, w f32, h f32, radius f32, c gx.Color) {
+	ctx.draw_rounded_rect_filled(x, y, w, h, radius, c)
+}
+
+pub fn (ctx &Context) draw_rounded_rect_filled(x f32, y f32, w f32, h f32, radius f32, c gx.Color) {
 	sgl.c4b(c.r, c.g, c.b, c.a)
 	sgl.begin_triangle_strip()
 	mut theta := f32(0)
@@ -966,7 +1037,12 @@ pub fn (ctx &Context) draw_rounded_rect(x f32, y f32, w f32, h f32, radius f32, 
 }
 
 // Draws the outline of a rounded rectangle
+[deprecated: 'use draw_rounded_rect_empty()']
 pub fn (ctx &Context) draw_empty_rounded_rect(x f32, y f32, w f32, h f32, radius f32, c gx.Color) {
+	ctx.draw_rounded_rect_empty(x, y, w, h, radius, c)
+}
+
+pub fn (ctx &Context) draw_rounded_rect_empty(x f32, y f32, w f32, h f32, radius f32, c gx.Color) {
 	mut theta := f32(0)
 	mut xx := f32(0)
 	mut yy := f32(0)
@@ -1052,7 +1128,12 @@ pub fn (ctx &Context) draw_convex_poly(points []f32, c gx.Color) {
 
 // draw_empty_poly - draws the borders of a polygon, given an array of points, and a color.
 // Note that the points must be given in clockwise order.
+[deprecated: 'use draw_poly_empty() instead']
 pub fn (ctx &Context) draw_empty_poly(points []f32, c gx.Color) {
+	ctx.draw_poly_empty(points, c)
+}
+
+pub fn (ctx &Context) draw_poly_empty(points []f32, c gx.Color) {
 	assert points.len % 2 == 0
 	len := points.len / 2
 	assert len >= 3
@@ -1145,6 +1226,11 @@ pub fn dpi_scale() f32 {
 	return s
 }
 
+[deprecated: 'use draw_ellipse_filled() instead']
+pub fn (ctx &Context) draw_ellipse(x f32, y f32, r_horizontal f32, r_vertical f32, c gx.Color) {
+	ctx.draw_ellipse_filled(x, y, r_horizontal, r_vertical, c)
+}
+
 // draw_ellipse_filled draws an opaque elipse, with a center at x,y , filled with the color `c`
 pub fn (ctx &Context) draw_ellipse_filled(x f32, y f32, r_horizontal f32, r_vertical f32, c gx.Color) {
 	if c.a != 255 {
@@ -1161,6 +1247,11 @@ pub fn (ctx &Context) draw_ellipse_filled(x f32, y f32, r_horizontal f32, r_vert
 			math.cosf(f32(math.radians(i + 10))) * r_vertical)
 	}
 	sgl.end()
+}
+
+[deprecated: 'use draw_ellipse_empty() instead']
+pub fn (ctx &Context) draw_empty_ellipse(x f32, y f32, r_horizontal f32, r_vertical f32, c gx.Color) {
+	ctx.draw_ellipse_empty(x, y, r_horizontal, r_vertical, c)
 }
 
 // draw_ellipse_empty draws the outline of an ellipse, with a center at x,y

--- a/vlib/gg/testdata/draw_arcs.vv
+++ b/vlib/gg/testdata/draw_arcs.vv
@@ -16,7 +16,7 @@ fn main() {
 
 fn frame(mut ctx gg.Context) {
 	ctx.begin()
-	ctx.draw_arc(100, 100, 35, 45, 0, f32(math.radians(290)), 30, gx.red)
+	ctx.draw_arc_filled(100, 100, 35, 45, 0, f32(math.radians(290)), 30, gx.red)
 	ctx.draw_arc_empty(100, 100, 30, 50, 0, f32(math.radians(290)), 30, gx.white)
 	ctx.end()
 }

--- a/vlib/gg/testdata/draw_polygons.vv
+++ b/vlib/gg/testdata/draw_polygons.vv
@@ -18,7 +18,7 @@ fn frame(mut ctx gg.Context) {
 	ctx.begin()
 	ctx.draw_convex_poly([f32(100.0), 100.0, 200.0, 100.0, 300.0, 200.0, 200.0, 300.0, 100.0, 300.0],
 		gx.blue)
-	ctx.draw_empty_poly([f32(50.0), 50.0, 70.0, 60.0, 90.0, 80.0, 70.0, 110.0], gx.black)
-	ctx.draw_triangle(450, 142, 530, 280, 370, 280, gx.red)
+	ctx.draw_poly_empty([f32(50.0), 50.0, 70.0, 60.0, 90.0, 80.0, 70.0, 110.0], gx.black)
+	ctx.draw_triangle_filled(450, 142, 530, 280, 370, 280, gx.red)
 	ctx.end()
 }


### PR DESCRIPTION
```v
import gg
import gx
import math

struct App {
mut:
	gg &gg.Context
}

fn main() {
	mut app := &App{
		gg: 0
	}
	
	app.gg = gg.new_context(
		width: 200
		height: 200
		window_title: 'Renaming Test'
		frame_fn: frame
		user_data: app
	)
	
	app.gg.run()
}

fn frame(mut app App) {
	app.gg.begin()
	
	app.gg.draw_rect_empty(8, 8, 25, 25, gx.white)
	app.gg.draw_rect_filled(10, 10, 20, 20, gx.red)
	
	app.gg.draw_triangle_empty(60, 8, 80, 34, 40, 34, gx.white)
	app.gg.draw_triangle_filled(60, 12, 74, 30, 46, 30, gx.red)
	
	//app.gg.draw_circle_empty(110, 10, 10, gx.white) // Not implemented yet
	app.gg.draw_circle_filled(110, 20, 8, gx.red)
	
	app.gg.draw_arc_empty(26, 70, 10, 20, f32(math.radians(270)), f32(math.radians(90)), 30, gx.white)
	app.gg.draw_arc_filled(26, 70, 12, 18, f32(math.radians(260)), f32(math.radians(100)), 30, gx.red)
	
	app.gg.draw_slice_empty(74, 60, 12, 90, f32(math.radians(270)), 30, gx.white)
	app.gg.draw_slice_filled(74, 60, 8, 90, f32(math.radians(270)), 30, gx.red)
	
	app.gg.draw_poly_empty([f32(30), 100, 40, 110, 40, 120, 30, 130, 20, 130, 10, 120, 10, 110, 10, 100], gx.white)
	//app.gg.draw_poly([...]) // Not implemented yet
	
	app.gg.draw_ellipse_empty(120, 115, 40, 20, gx.white)
	app.gg.draw_ellipse_filled(120, 115, 36, 16, gx.red)
	
	/*
	// Deprecated
	app.gg.draw_empty_rect(8, 8, 25, 25, gx.white)
	app.gg.draw_rect(10, 10, 20, 20, gx.red)
	
	app.gg.draw_empty_triangle(60, 8, 80, 34, 40, 34, gx.white)
	app.gg.draw_triangle(60, 12, 74, 30, 46, 30, gx.red)
	
	//app.gg.draw_empty_circle(110, 10, 10, gx.white) // Not implemented yet
	app.gg.draw_circle(110, 20, 8, gx.red)
	
	app.gg.draw_empty_arc(26, 70, 10, 20, f32(math.radians(270)), f32(math.radians(90)), 30, gx.white)
	app.gg.draw_arc(26, 70, 12, 18, f32(math.radians(260)), f32(math.radians(100)), 30, gx.red)
	
	app.gg.draw_empty_slice(74, 60, 12, 90, f32(math.radians(270)), 30, gx.white)
	app.gg.draw_slice(74, 60, 8, 90, f32(math.radians(270)), 30, gx.red)
	
	app.gg.draw_empty_poly([f32(30), 100, 40, 110, 40, 120, 30, 130, 20, 130, 10, 120, 10, 110, 10, 100], gx.white)
	//app.gg.draw_poly([...]) // Not implemented yet
	
	app.gg.draw_empty_ellipse(120, 115, 40, 20, gx.white)
	app.gg.draw_ellipse(120, 115, 36, 16, gx.red)
	*/
	
	app.gg.end()
}
```
![image](https://user-images.githubusercontent.com/24865450/146843719-b567bc23-b811-47a1-9f8a-1e01f6bbb2a3.png)
