### PR TITLE
vweb: straight forward middleware implementation

### DIFF
--- a/vlib/vweb/parse.v
+++ b/vlib/vweb/parse.v
@@ -9,7 +9,7 @@ fn parse_attrs(name string, attrs []string) ?([]http.Method, string) {
 		return [http.Method.get], '/$name'
 	}
 
-	mut x := attrs.clone()
+	mut x := attrs.clone().filter(it.to_lower() != 'use')
 	mut methods := []http.Method{}
 	mut path := ''
 

--- a/vlib/vweb/parse.v
+++ b/vlib/vweb/parse.v
@@ -8,7 +8,7 @@ fn parse_middleware(args []MethodArgs, attrs []string) ?string {
 		for arg in args {
 			// ast.string_type_idx = 20
 			if arg.typ != 20 {
-				return error("middleware arguments should be string type, `$arg.name` does not meet that rule")
+				return error('middleware arguments should be string type, `$arg.name` does not meet that rule')
 			}
 		}
 

--- a/vlib/vweb/parse.v
+++ b/vlib/vweb/parse.v
@@ -3,6 +3,32 @@ module vweb
 import net.urllib
 import net.http
 
+fn parse_middleware(args []MethodArgs, attrs []string) ?string {
+	if 'use' in attrs {
+		for arg in args {
+			// ast.string_type_idx = 20
+			if arg.typ != 20 {
+				return error("middleware arguments should be string type, `$arg.name` does not meet that rule")
+			}
+		}
+
+		for attr in attrs {
+			if attr.starts_with('/') {
+				params_len := attr.split('/').filter(it != '' && it.starts_with(':')).len
+				if params_len != args.len {
+					return error('number of middleware arguments does not meet with number of path params')
+				}
+
+				return attr
+			}
+		}
+
+		return error("please specify path as attribute for middleware, example: ['/admin']")
+	}
+
+	return none
+}
+
 // Parsing function attributes for methods and path.
 fn parse_attrs(name string, attrs []string) ?([]http.Method, string) {
 	if attrs.len == 0 {

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -606,7 +606,7 @@ fn fire_middlewares<T>(mut app T, url_words []string, middlewares map[string]str
 		}
 	}
 
-	fire_those.sort(a.path_len > b.path_len)
+	fire_those.sort(a.path_len < b.path_len)
 
 	for f in fire_those {
 		fire_middleware(mut app, f.method, f.params)

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -558,8 +558,8 @@ fn handle_conn<T>(mut conn net.TcpConn, mut app T, routes map[string]Route, midd
 }
 
 struct Firable_middleware {
-	method string
-	params []string
+	method   string
+	params   []string
 	path_len int
 }
 


### PR DESCRIPTION
Basic implementation of middleware *guards*, with that you cannot call **next** handler and see what result is, but some basic auth stuff should work.

Works like a charm:
```v
module main

import net.http
import vweb

struct App {
	vweb.Context
}

fn (mut app App) index() vweb.Result {
	return app.text('Hello from index handler')
} 

['/:some...']
fn (mut app App) some(some string) vweb.Result {
	return app.text('Hello from some handler')
}

['/'; use]
fn (mut app App) index_mid() {
	if 'hello' in app.query {
		app.done = true
		app.conn.write(http.new_response(
			status: .ok
			text: 'Hello from index middleware'
		).bytes()) or {}
	}
}

['/:some...'; use]
fn (mut app App) mid(some string) {
	if 'hello' in app.query {
		app.done = true
		app.conn.write(http.new_response(
			status: .ok
			text: 'Hello from some middleware $some'
		).bytes()) or {}
	}
}

['/exact'; use]
fn (mut app App) exact_mid() {
	app.done = true
	app.conn.write(http.new_response(
		status: .ok
		text: 'Hello from middleware with `exact` path'
	).bytes()) or {}
}

fn main() {
	vweb.run(App{}, 8089)
}
```
![vweb-middleware-demo](https://user-images.githubusercontent.com/26527529/146869539-33cadf2a-95f6-466b-af90-2bd784b18a00.gif)

