### PR TITLE
cgen: fix interface method using struct embed  (fix #12918)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7383,11 +7383,12 @@ static inline $interface_name I_${cctype}_to_Interface_${interface_name}($cctype
 							false)
 					}
 				}
-				mut method_call := '${cctype}_$name'
+				styp := g.cc_type(method.params[0].typ, true)
+				mut method_call := '${styp}_$name'
 				if !method.params[0].typ.is_ptr() {
 					// inline void Cat_speak_Interface_Animal_method_wrapper(Cat c) { return Cat_speak(*c); }
 					iwpostfix := '_Interface_${interface_name}_method_wrapper'
-					methods_wrapper.write_string('static inline ${g.typ(method.return_type)} $method_call${iwpostfix}(')
+					methods_wrapper.write_string('static inline ${g.typ(method.return_type)} ${cctype}_$name${iwpostfix}(')
 					//
 					params_start_pos := g.out.len
 					mut params := method.params.clone()

--- a/vlib/v/tests/interface_method_using_struct_embed_test.v
+++ b/vlib/v/tests/interface_method_using_struct_embed_test.v
@@ -1,0 +1,34 @@
+module main
+
+pub interface IObject {
+mut:
+	do_stuff()
+	do_something_with_int(int)
+	do_something_with_string(string)
+}
+
+pub struct BaseObject {
+mut:
+	some_attr int
+}
+
+pub fn (mut base BaseObject) do_stuff() {}
+
+pub fn (mut base BaseObject) do_something_with_int(n int) {}
+
+pub fn (mut base BaseObject) do_something_with_string(s string) {}
+
+pub fn (mut base BaseObject) method_thats_available_to_all_object() {}
+
+pub struct GameObject {
+	BaseObject
+pub mut:
+	some_attr_for_game int
+}
+
+fn test_interface_method_using_struct_embed() {
+	mut common_object := []IObject{}
+	common_object << GameObject{}
+	println(common_object)
+	assert common_object.len == 1
+}


### PR DESCRIPTION
This PR fix interface method using struct embed  (fix #12918).

- Fix interface method using struct embed.
- Add test.

```vlang
module main

pub interface IObject {
mut:
	do_stuff()
	do_something_with_int(int)
	do_something_with_string(string)
}

pub struct BaseObject {
mut:
	some_attr int
}

pub fn (mut base BaseObject) do_stuff() {}

pub fn (mut base BaseObject) do_something_with_int(n int) {}

pub fn (mut base BaseObject) do_something_with_string(s string) {}

pub fn (mut base BaseObject) method_thats_available_to_all_object() {}

pub struct GameObject {
	BaseObject
pub mut:
	some_attr_for_game int
}

fn main() {
	mut common_object := []IObject{}
	common_object << GameObject{}
	println(common_object)
	assert common_object.len == 1
}

PS D:\Test\v\tt1> v run .
[IObject(GameObject{
    BaseObject: BaseObject{        some_attr: 0
    }
    some_attr_for_game: 0
})]
```