### PR TITLE
parser/scanner: make codegen impl use own parser. closes #12857

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -309,7 +309,7 @@ pub fn (mut p Parser) parse() &ast.File {
 	// codegen
 	if p.codegen_text.len > 0 && !p.pref.is_fmt {
 		ptext := 'module ' + p.mod.all_after('.') + p.codegen_text
-		codegen_file := parse_text(ptext, 'codegen_$p.file_name', p.table, p.comments_mode,
+		codegen_file := parse_text(ptext, p.file_name, p.table, p.comments_mode,
 			p.pref)
 		stmts << codegen_file.stmts
 	}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -309,8 +309,7 @@ pub fn (mut p Parser) parse() &ast.File {
 	// codegen
 	if p.codegen_text.len > 0 && !p.pref.is_fmt {
 		ptext := 'module ' + p.mod.all_after('.') + p.codegen_text
-		codegen_file := parse_text(ptext, p.file_name, p.table, p.comments_mode,
-			p.pref)
+		codegen_file := parse_text(ptext, p.file_name, p.table, p.comments_mode, p.pref)
 		stmts << codegen_file.stmts
 	}
 

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -308,7 +308,7 @@ pub fn (mut p Parser) parse() &ast.File {
 
 	// codegen
 	if p.codegen_text.len > 0 && !p.pref.is_fmt {
-		ptext := 'module $p.mod' + p.codegen_text
+		ptext := 'module ' + p.mod.all_after('.') + p.codegen_text
 		codegen_file := parse_text(ptext, 'codegen_$p.file_name', p.table, p.comments_mode,
 			p.pref)
 		stmts << codegen_file.stmts

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -83,6 +83,7 @@ mut:
 	comptime_if_cond    bool
 	defer_vars          []ast.Ident
 	should_abort        bool // when too many errors/warnings/notices are accumulated, should_abort becomes true, and the parser should stop
+	codegen_text        string
 }
 
 // for tests
@@ -305,6 +306,14 @@ pub fn (mut p Parser) parse() &ast.File {
 		notices << p.scanner.notices
 	}
 
+	// codegen
+	if p.codegen_text.len > 0 && !p.pref.is_fmt {
+		ptext := 'module $p.mod' + p.codegen_text
+		codegen_file := parse_text(ptext, 'codegen_$p.file_name', p.table, p.comments_mode,
+			p.pref)
+		stmts << codegen_file.stmts
+	}
+
 	return &ast.File{
 		path: p.file_name
 		path_base: p.file_base
@@ -394,6 +403,15 @@ pub fn parse_files(paths []string, table &ast.Table, pref &pref.Preferences) []&
 		timers.show('parse_file $path')
 	}
 	return files
+}
+
+// codegen allows you to generate V code, so that it can be parsed,
+// checked, markused, cgen-ed etc further, just like user's V code.
+pub fn (mut p Parser) codegen(code string) {
+	$if debug_codegen ? {
+		eprintln('parser.codegen:\n $code')
+	}
+	p.codegen_text += '\n' + code
 }
 
 pub fn (mut p Parser) init_parse_fns() {
@@ -3309,7 +3327,7 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 			}
 		}
 		pubfn := if p.mod == 'main' { 'fn' } else { 'pub fn' }
-		p.scanner.codegen('
+		p.codegen('
 //
 [inline] $pubfn (    e &$enum_name) is_empty() bool           { return  int(*e) == 0 }
 [inline] $pubfn (    e &$enum_name) has(flag $enum_name) bool { return  (int(*e) &  (int(flag))) != 0 }

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1460,27 +1460,6 @@ pub fn verror(s string) {
 	util.verror('scanner error', s)
 }
 
-// codegen allows you to generate V code, so that it can be parsed,
-// checked, markused, cgen-ed etc further, just like user's V code.
-pub fn (mut s Scanner) codegen(newtext string) {
-	$if debug_codegen ? {
-		eprintln('scanner.codegen:\n $newtext')
-	}
-	if s.comments_mode == .skip_comments {
-		// Calling codegen makes sense only during normal compilation, since
-		// feeding code generated V code to vfmt or vdoc will cause them to
-		// output/document ephemeral stuff.
-		for s.all_tokens.len > 0 && s.all_tokens.last().kind == .eof {
-			s.all_tokens.delete_last()
-		}
-		s.text += newtext
-		old_tidx := s.tidx
-		s.tidx = s.all_tokens.len
-		s.scan_remaining_text()
-		s.tidx = old_tidx
-	}
-}
-
 fn (mut s Scanner) trace(fbase string, message string) {
 	if s.file_base == fbase {
 		println('> s.trace | ${fbase:-10s} | $message')


### PR DESCRIPTION
Change the codegen implementation to use its own parser instance.
Fixes #12857.
Codegen errors should now be displayed properly.