### PR TITLE
parser: make codegen generates correct module name

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -308,7 +308,7 @@ pub fn (mut p Parser) parse() &ast.File {
 
 	// codegen
 	if p.codegen_text.len > 0 && !p.pref.is_fmt {
-		ptext := 'module ' + p.mod.all_after('.') + p.codegen_text
+		ptext := 'module ' + p.mod.all_after_last('.') + p.codegen_text
 		codegen_file := parse_text(ptext, p.file_name, p.table, p.comments_mode, p.pref)
 		stmts << codegen_file.stmts
 	}


### PR DESCRIPTION
`'a.b.c'.all_after('.')` returns `b.c`. So current codogen generates `module b.c` from `module a.b.c` . This PR fix it
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
