### PR TITLE
cgen: fix multiple return with sumtype (fix #12927)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4758,8 +4758,8 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			g.writeln('return $tmpvar;')
 			return
 		}
-		// typ_sym := g.table.sym(g.fn_decl.return_type)
-		// mr_info := typ_sym.info as ast.MultiReturn
+		typ_sym := g.table.sym(g.fn_decl.return_type)
+		mr_info := typ_sym.info as ast.MultiReturn
 		mut styp := ''
 		if fn_return_is_optional {
 			g.writeln('$ret_typ $tmpvar;')
@@ -4821,7 +4821,11 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			if expr.is_auto_deref_var() {
 				g.write('*')
 			}
-			g.expr(expr)
+			if g.table.sym(mr_info.types[i]).kind in [.sum_type, .interface_] {
+				g.expr_with_cast(expr, node.types[i], mr_info.types[i])
+			} else {
+				g.expr(expr)
+			}
 			arg_idx++
 			if i < node.exprs.len - 1 {
 				g.write(', ')

--- a/vlib/v/tests/multiret_with_sumtype_test.v
+++ b/vlib/v/tests/multiret_with_sumtype_test.v
@@ -1,0 +1,15 @@
+module main
+
+type Abc = int | rune | string | u32
+
+fn cyz() (Abc, string) {
+	return 'a', 'b'
+}
+
+fn test_multiret_with_sumtype() {
+	x, y := cyz()
+	println(x)
+	println(y)
+	assert x == Abc('a')
+	assert y == 'b'
+}


### PR DESCRIPTION
This PR fix multiple return with sumtype (fix #12927).

- Fix multiple return with sumtype.
- Add test.

```vlang
module main

type Abc = int | rune | string | u32

fn cyz() (Abc, string) {
	return 'a', 'b'
}

fn main() {
	x, y := cyz()
	println(x)
	println(y)
	assert x == Abc('a')
	assert y == 'b'
}

PS D:\Test\v\tt1> v run .
Abc('a')
b
```