### PR TITLE
cgen: fix blank ident in for_c_stmt (fix #12832)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -202,6 +202,8 @@ fn (mut g Gen) gen_assign_stmt(node ast.AssignStmt) {
 				g.is_void_expr_stmt = true
 				g.expr(val)
 				g.is_void_expr_stmt = old_is_void_expr_stmt
+			} else if g.inside_for_c_stmt {
+				g.expr(val)
 			} else {
 				g.write('{$styp _ = ')
 				g.expr(val)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -111,6 +111,7 @@ mut:
 	inside_return          bool
 	inside_or_block        bool
 	inside_call            bool
+	inside_for_c_stmt      bool
 	inside_cast_in_heap    int // inside cast to interface type in heap (resolve recursive calls)
 	inside_const           bool
 	inside_lambda          bool
@@ -1857,6 +1858,7 @@ fn (mut g Gen) for_c_stmt(node ast.ForCStmt) {
 	g.loop_depth++
 	if node.is_multi {
 		g.is_vlines_enabled = false
+		g.inside_for_c_stmt = true
 		if node.label.len > 0 {
 			g.writeln('$node.label:')
 		}
@@ -1883,6 +1885,7 @@ fn (mut g Gen) for_c_stmt(node ast.ForCStmt) {
 			g.writeln(')) break;')
 		}
 		g.is_vlines_enabled = true
+		g.inside_for_c_stmt = false
 		g.stmts(node.stmts)
 		if node.label.len > 0 {
 			g.writeln('${node.label}__continue: {}')
@@ -1895,6 +1898,7 @@ fn (mut g Gen) for_c_stmt(node ast.ForCStmt) {
 		}
 	} else {
 		g.is_vlines_enabled = false
+		g.inside_for_c_stmt = true
 		if node.label.len > 0 {
 			g.writeln('$node.label:')
 		}
@@ -1919,6 +1923,7 @@ fn (mut g Gen) for_c_stmt(node ast.ForCStmt) {
 		}
 		g.writeln(') {')
 		g.is_vlines_enabled = true
+		g.inside_for_c_stmt = false
 		g.stmts(node.stmts)
 		if node.label.len > 0 {
 			g.writeln('${node.label}__continue: {}')

--- a/vlib/v/tests/blank_ident_test.v
+++ b/vlib/v/tests/blank_ident_test.v
@@ -321,3 +321,10 @@ fn test_blank_multi_return() {
 	assert d == '3'
 	assert g == '3'
 }
+
+fn test_blank_in_for_c_init_stmt() {
+	a := []int{len: 2}
+	for _ := a[1]; a[1] != 0; {
+	}
+	assert true
+}


### PR DESCRIPTION
This PR fix blank ident in for_c_stmt (fix #12832).

- Fix blank ident in for_c_stmt.
- Add test.

```vlang
fn main() {
	a := []int{len: 2}
	for _ := a[1]; a[1] != 0; {
	}
}

PS D:\Test\v\tt1> v run .
PS D:\Test\v\tt1> 
```