### PR TITLE
gg: Text rendering, keyboard event handling for JS and other fixes

### DIFF
--- a/examples/snek/README.md
+++ b/examples/snek/README.md
@@ -1,0 +1,17 @@
+# snek
+
+Snake game implemented using `gg` module. 
+
+# Compiling & running
+
+## Compiling to binary
+```sh
+v -prod examples/snek/snek.v
+./examples/snek/snek # run snek game!
+```
+
+## Compiling to JS
+```sh
+v -b js_browser examples/snek/snek.js.v
+```
+And then open `examples/snek/index.html` in your favourite browser.

--- a/examples/snek/index.html
+++ b/examples/snek/index.html
@@ -1,0 +1,6 @@
+<body class="main">
+    <title>gg</title>
+    <canvas style="border: 1px solid black;" width="700" height="800" id="canvas"></canvas>
+    <script type="text/javascript" src="snek.js"></script>
+
+</body>

--- a/examples/snek/snek.js.v
+++ b/examples/snek/snek.js.v
@@ -1,0 +1,197 @@
+import gg
+import gx
+// import sokol.sapp
+import time
+import rand
+
+// constants
+const (
+	top_height   = 100
+	canvas_size  = 700
+	game_size    = 17
+	tile_size    = canvas_size / game_size
+	tick_rate_ms = 100
+)
+
+// types
+struct Pos {
+	x int
+	y int
+}
+
+fn (a Pos) + (b Pos) Pos {
+	return Pos{a.x + b.x, a.y + b.y}
+}
+
+fn (a Pos) - (b Pos) Pos {
+	return Pos{a.x - b.x, a.y - b.y}
+}
+
+enum Direction {
+	up
+	down
+	left
+	right
+}
+
+struct App {
+mut:
+	gg         &gg.Context
+	score      int
+	snake      []Pos
+	dir        Direction
+	last_dir   Direction
+	food       Pos
+	start_time i64
+	last_tick  i64
+}
+
+// utility
+fn (mut app App) reset_game() {
+	app.score = 0
+	app.snake = [
+		Pos{3, 8},
+		Pos{2, 8},
+		Pos{1, 8},
+		Pos{0, 8},
+	]
+	app.dir = .right
+	app.last_dir = app.dir
+	app.food = Pos{10, 8}
+	app.start_time = time.ticks()
+	app.last_tick = time.ticks()
+}
+
+fn (mut app App) move_food() {
+	for {
+		x := rand.int_in_range(0, game_size)
+		y := rand.int_in_range(0, game_size)
+		app.food = Pos{x, y}
+
+		if app.food !in app.snake {
+			return
+		}
+	}
+}
+
+// events
+fn on_keydown(key gg.KeyCode, mod gg.Modifier, mut app App) {
+	match key {
+		.w, .up {
+			if app.last_dir != .down {
+				app.dir = .up
+			}
+		}
+		.s, .down {
+			if app.last_dir != .up {
+				app.dir = .down
+			}
+		}
+		.a, .left {
+			if app.last_dir != .right {
+				app.dir = .left
+			}
+		}
+		.d, .right {
+			if app.last_dir != .left {
+				app.dir = .right
+			}
+		}
+		else {}
+	}
+}
+
+fn on_frame(mut app App) {
+	app.gg.begin()
+
+	now := time.ticks()
+
+	if now - app.last_tick >= tick_rate_ms {
+		app.last_tick = now
+
+		// finding delta direction
+		delta_dir := match app.dir {
+			.up { Pos{0, -1} }
+			.down { Pos{0, 1} }
+			.left { Pos{-1, 0} }
+			.right { Pos{1, 0} }
+		}
+
+		// "snaking" along
+		mut prev := app.snake[0]
+		app.snake[0] = app.snake[0] + delta_dir
+
+		for i in 1 .. app.snake.len {
+			tmp := app.snake[i]
+			app.snake[i] = prev
+			prev = tmp
+		}
+
+		// adding last segment
+		if app.snake[0] == app.food {
+			app.move_food()
+			app.score++
+			/*
+			if app.score > app.best {
+				app.best = app.score
+				app.best.save()
+			}*/
+			app.snake << app.snake.last() + app.snake.last() - app.snake[app.snake.len - 2]
+		}
+
+		app.last_dir = app.dir
+	}
+	// drawing snake
+	for pos in app.snake {
+		app.gg.draw_rect(tile_size * pos.x, tile_size * pos.y + top_height, tile_size,
+			tile_size, gx.blue)
+	}
+
+	// drawing food
+	app.gg.draw_rect(tile_size * app.food.x, tile_size * app.food.y + top_height, tile_size,
+		tile_size, gx.red)
+
+	// drawing top
+	app.gg.draw_rect(0, 0, canvas_size, top_height, gx.black)
+	app.gg.draw_text(350, top_height / 2, 'Score: $app.score', gx.TextCfg{
+		color: gx.white
+		align: .center
+		vertical_align: .middle
+		size: 80
+	})
+
+	// checking if snake bit itself
+	if app.snake[0] in app.snake[1..] {
+		app.reset_game()
+	}
+	// checking if snake hit a wall
+	if app.snake[0].x < 0 || app.snake[0].x >= game_size || app.snake[0].y < 0
+		|| app.snake[0].y >= game_size {
+		app.reset_game()
+	}
+
+	app.gg.end()
+}
+
+// setup
+fn main() {
+	mut app := App{
+		gg: &gg.Context{}
+	}
+	app.reset_game()
+
+	app.gg = gg.new_context(
+		bg_color: gx.white
+		frame_fn: on_frame
+		keydown_fn: on_keydown
+		user_data: &app
+		width: canvas_size
+		height: top_height + canvas_size
+		create_window: true
+		resizable: false
+		window_title: 'snek'
+		canvas: 'canvas'
+	)
+
+	app.gg.run()
+}

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -30,7 +30,7 @@ pub struct PenConfig {
 }
 
 pub struct Size {
-pub:
+pub mut:
 	width  int
 	height int
 }

--- a/vlib/gg/text_rendering.js.v
+++ b/vlib/gg/text_rendering.js.v
@@ -1,0 +1,9 @@
+module gg
+
+import gx
+
+pub fn (mut ctx Context) draw_text(x int, y int, text_ string, cfg gx.TextCfg) {
+	ctx.context.fillStyle = cfg.color.to_css_string().str
+	ctx.context.font = cfg.to_css_string().str
+	ctx.context.fillText(text_.str, x, y)
+}

--- a/vlib/gx/color.v
+++ b/vlib/gx/color.v
@@ -234,5 +234,5 @@ pub fn color_from_string(s string) Color {
 }
 
 pub fn (c Color) to_css_string() string {
-	return 'rgb($c.r,$c.g,$c.b)'
+	return 'rgba($c.r,$c.g,$c.b,$c.a)'
 }

--- a/vlib/gx/text.v
+++ b/vlib/gx/text.v
@@ -19,3 +19,17 @@ pub:
 	mono           bool
 	italic         bool
 }
+
+pub fn (cfg TextCfg) to_css_string() string {
+	mut font_style := ''
+	if cfg.bold {
+		font_style += 'bold '
+	}
+	if cfg.mono {
+		font_style += 'mono '
+	}
+	if cfg.italic {
+		font_style += 'italic '
+	}
+	return '$font_style ${cfg.size}px $cfg.family'
+}

--- a/vlib/js/dom/dom.js.v
+++ b/vlib/js/dom/dom.js.v
@@ -462,6 +462,7 @@ pub interface JS.CanvasRenderingContext2D {
 	translate(x JS.Number, y JS.Number)
 	drawFocusIfNeeded(path JS.Path2D, element JS.Element)
 	stroke()
+	fillText(text JS.String, x JS.Number, y JS.Number)
 mut:
 	lineCap JS.String
 	lineDashOffset JS.Number
@@ -472,6 +473,7 @@ mut:
 	strokeStyle FillStyle
 	globalAlpha JS.Number
 	globalCompositeOperation JS.String
+	font JS.String
 }
 
 pub interface JS.CanvasGradient {
@@ -989,4 +991,17 @@ pub interface JS.ProgressEvent {
 	loaded JS.Number
 	target JS.Any
 	total JS.Number
+}
+
+pub interface JS.KeyboardEvent {
+	JS.UIEvent
+	altKey JS.Boolean
+	code JS.String
+	ctrlKey JS.Boolean
+	isComposing JS.Boolean
+	key JS.String
+	location JS.Number
+	metaKey JS.Boolean
+	repeat JS.Boolean
+	shiftKey JS.Boolean
 }

--- a/vlib/time/time.js.v
+++ b/vlib/time/time.js.v
@@ -42,3 +42,10 @@ pub fn sleep(dur Duration) {
 	#let toWait = BigInt(dur.val) / BigInt(time__millisecond)
 	#while (new Date().getTime() < now + Number(toWait)) {}
 }
+
+pub fn ticks() i64 {
+	t := i64(0)
+	#t.val = BigInt(new Date().getTime())
+
+	return t
+}

--- a/vlib/time/time_js.js.v
+++ b/vlib/time/time_js.js.v
@@ -14,7 +14,7 @@ module time
 pub fn sys_mono_now() u64 {
 	$if js_browser {
 		mut res := u64(0)
-		#res = new u64(window.performance.now() * 1000000)
+		#res = new u64(Math.floor(window.performance.now() * 1000000))
 
 		return res
 	} $else $if js_node {

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -3426,7 +3426,7 @@ fn (mut g JsGen) gen_type_cast_expr(it ast.CastExpr) {
 	}
 
 	if (from_type_sym.name == 'Any' && from_type_sym.language == .js)
-		|| from_type_sym.name == 'JS.Any' {
+		|| from_type_sym.name == 'JS.Any' || from_type_sym.name == 'voidptr' {
 		if it.typ.is_ptr() {
 			g.write('new \$ref(')
 		}


### PR DESCRIPTION
- Fixed `voidptr` to any other type cast for JS backend
- Added `time.ticks()` for JS backend, fixed exception thrown on `window.performance.now()` use in `time`
- Added `snek.js.v` to examples/snek. This is exactly the same `snek.v` except all `os` usage was removed so it is possible to run it on browser