### PR TITLE
fmt: fix error of generic struct_init using module (fix #12893)

### DIFF
--- a/vlib/js/js.js.v
+++ b/vlib/js/js.js.v
@@ -24,7 +24,7 @@ pub interface JS.Response {
 
 pub fn fetch(input string, init map[string]JS.Any) promise.Promise<JS.Response, JS.String> {
 	p_init := JS.Any(voidptr(0))
-	p := promise.Promise<JS.Response,String>{p_init}
+	p := promise.Promise<JS.Response, String>{p_init}
 
 	#let obj = {}; for (let [key,val] of init.map) { obj[key] = val; }
 	#p.promise = fetch(input.str,obj);

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -213,7 +213,7 @@ pub fn (mut f Fmt) short_module(name string) string {
 		generic_levels := name.trim_suffix('>').split('<')
 		mut res := '${f.short_module(generic_levels[0])}'
 		for i in 1 .. generic_levels.len {
-			genshorts := generic_levels[i].split(',').map(f.short_module(it)).join(',')
+			genshorts := generic_levels[i].split(', ').map(f.short_module(it)).join(', ')
 			res += '<$genshorts'
 		}
 		res += '>'

--- a/vlib/v/fmt/tests/generic_structs_keep.vv
+++ b/vlib/v/fmt/tests/generic_structs_keep.vv
@@ -36,7 +36,7 @@ fn main() {
 	println(x.model)
 	println(x.permission)
 	//
-	mut a := Repo<User,Permission>{
+	mut a := Repo<User, Permission>{
 		model: User{
 			name: 'joe'
 		}

--- a/vlib/v/fmt/tests/generic_structs_using_mod_keep.vv
+++ b/vlib/v/fmt/tests/generic_structs_using_mod_keep.vv
@@ -1,0 +1,8 @@
+import obj
+
+struct GenericStruct<A, B> {
+}
+
+fn main() {
+	_ := GenericStruct<obj.Test, obj.Test>{}
+}

--- a/vlib/v/fmt/tests/generic_structs_using_mod_keep.vv
+++ b/vlib/v/fmt/tests/generic_structs_using_mod_keep.vv
@@ -1,4 +1,4 @@
-import obj
+import v.fmt.tests.obj
 
 struct GenericStruct<A, B> {
 }

--- a/vlib/v/fmt/tests/obj/obj.v
+++ b/vlib/v/fmt/tests/obj/obj.v
@@ -1,0 +1,3 @@
+module obj
+
+pub struct Test {}

--- a/vlib/v/tests/generics_test.v
+++ b/vlib/v/tests/generics_test.v
@@ -306,13 +306,13 @@ pub mut:
 // return Repo<T,Permission>{db: db}
 // }
 fn test_generic_struct() {
-	mut a := Repo<User,Permission>{
+	mut a := Repo<User, Permission>{
 		model: User{
 			name: 'joe'
 		}
 	}
 	assert a.model.name == 'joe'
-	mut b := Repo<Group,Permission>{
+	mut b := Repo<Group, Permission>{
 		permission: Permission{
 			name: 'superuser'
 		}
@@ -573,8 +573,8 @@ fn test_generic_detection() {
 	})
 
 	// this final case challenges your scanner :-)
-	assert boring_function<TandU<TandU<int, MultiLevel<Empty_>>, map[string][]int>>(TandU<TandU<int,MultiLevel<Empty_>>, map[string][]int>{
-		t: TandU<int,MultiLevel<Empty_>>{
+	assert boring_function<TandU<TandU<int, MultiLevel<Empty_>>, map[string][]int>>(TandU<TandU<int, MultiLevel<Empty_>>, map[string][]int>{
+		t: TandU<int, MultiLevel<Empty_>>{
 			t: 20
 			u: MultiLevel<Empty_>{
 				foo: Empty_{}

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -321,7 +321,7 @@ struct MultiGenericStruct<T, X> {
 }
 
 fn test_multi_generic_struct() {
-	x := MultiGenericStruct<TestStruct,TestStruct>{}
+	x := MultiGenericStruct<TestStruct, TestStruct>{}
 	assert '$x' == 'MultiGenericStruct<TestStruct, TestStruct>{\n    t: TestStruct{\n        x: 0\n    }\n    x: TestStruct{\n        x: 0\n    }\n}'
 	assert x.str() == 'MultiGenericStruct<TestStruct, TestStruct>{\n    t: TestStruct{\n        x: 0\n    }\n    x: TestStruct{\n        x: 0\n    }\n}'
 }


### PR DESCRIPTION
This PR fix error of generic struct_init using module. (fix #12893)

- Fix error of generic struct_init using module.
- Add test.

```vlang
import obj

struct GenericStruct<A, B> {
}

fn main() {
	_ := GenericStruct<obj.Test, obj.Test>{}
}

PS D:\Test\v\tt1> v fmt tt1.v
import obj

struct GenericStruct<A, B> {
}

fn main() {
        _ := GenericStruct<obj.Test, obj.Test>{}
}
```