### PR TITLE
cgen: fix channel of sumtype (fix #12894)

### DIFF
--- a/vlib/v/gen/c/infix_expr.v
+++ b/vlib/v/gen/c/infix_expr.v
@@ -70,7 +70,11 @@ fn (mut g Gen) infix_expr_arrow_op(node ast.InfixExpr) {
 	}
 	g.expr(node.left)
 	g.write(', ')
-	g.expr(node.right)
+	if g.table.sym(elem_type).kind in [.sum_type, .interface_] {
+		g.expr_with_cast(node.right, node.right_type, elem_type)
+	} else {
+		g.expr(node.right)
+	}
 	g.write(')')
 	if gen_or {
 		g.or_block(tmp_opt, node.or_block, ast.void_type)

--- a/vlib/v/tests/channels_test.v
+++ b/vlib/v/tests/channels_test.v
@@ -27,3 +27,21 @@ fn test_printing_of_channels() {
 	fch.close()
 	assert fch.str() == 'chan f64{cap: 100, closed: 1}'
 }
+
+struct Aa {}
+
+struct Ab {}
+
+type As = Aa | Ab
+
+fn func(ch chan As) {
+	ch <- Aa{}
+}
+
+fn test_chan_of_sumtype() {
+	a := chan As{}
+	go func(a)
+	ret := <-a
+	println(ret)
+	assert '$ret' == 'As(Aa{})'
+}


### PR DESCRIPTION
This PR fix channel of sumtype (fix #12894).

- Fix channel of sumtype.
- Add test.

```vlang
struct Aa {}

struct Ab {}

type As = Aa | Ab

fn func(ch chan As) {
	ch <- Aa{}
}

fn main() {
	a := chan As{}
	go func(a)
	ret := <-a
	println(ret)
	assert '$ret' == 'As(Aa{})'
}

PS D:\Test\v\tt1> v run .
As(Aa{})
```