### PR TITLE
cgen: fix map get assign blank var with optional (fix #12942)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -197,6 +197,7 @@ fn (mut g Gen) gen_assign_stmt(node ast.AssignStmt) {
 			if val is ast.IndexExpr {
 				g.assign_op = .decl_assign
 			}
+			g.is_assign_lhs = false
 			if is_call {
 				old_is_void_expr_stmt := g.is_void_expr_stmt
 				g.is_void_expr_stmt = true
@@ -209,7 +210,6 @@ fn (mut g Gen) gen_assign_stmt(node ast.AssignStmt) {
 				g.expr(val)
 				g.writeln(';}')
 			}
-			g.is_assign_lhs = false
 		} else if node.op == .assign
 			&& (is_fixed_array_init || (right_sym.kind == .array_fixed && val is ast.Ident)) {
 			mut v_var := ''

--- a/vlib/v/tests/map_get_assign_blank_test.v
+++ b/vlib/v/tests/map_get_assign_blank_test.v
@@ -17,3 +17,16 @@ fn test_map_get_assign_blank() {
 	}
 	assert true
 }
+
+fn get_value() int {
+	mut m := map[string]int{}
+	_ := m['a'] or { return 1 }
+	println('a')
+	return 0
+}
+
+fn test_map_get_assign_blank_with_or_expr() {
+	ret := get_value()
+	println(ret)
+	assert ret == 1
+}


### PR DESCRIPTION
This PR fix map get assign blank var with optional (fix #12942).

- Fix map get assign blank var with optional.
- Add test.

```vlang
fn get_value() int {
	mut m := map[string]int{}
	_ := m['a'] or { return 1 }
	println('a')
	return 0
}

fn main() {
	ret := get_value()
	println(ret)
	assert ret == 1
}

PS D:\Test\v\tt1> v run .
1
```