### PR TITLE
ast: fix reference of alias char type (fix #12946)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -671,7 +671,7 @@ pub fn (t &Table) unalias_num_type(typ Type) Type {
 	sym := t.sym(typ)
 	if sym.kind == .alias {
 		pt := (sym.info as Alias).parent_type
-		if pt <= f64_type && pt >= void_type {
+		if pt <= char_type && pt >= void_type {
 			return pt
 		}
 	}

--- a/vlib/v/tests/alias_char_type_reference_test.v
+++ b/vlib/v/tests/alias_char_type_reference_test.v
@@ -1,0 +1,12 @@
+module main
+
+type ALchar = char
+
+fn test_alias_char_type_reference() {
+	c1 := &char(0)
+	c2 := &ALchar(0)
+	println('${typeof(c1).name} $c1')
+	assert '$c1' == '0'
+	println('${typeof(c2).name} $c2')
+	assert '$c2' == '0'
+}


### PR DESCRIPTION
This PR fix reference of alias char type (fix #12946).

- Fix reference of alias char type.
- Add test.

```vlang
module main

type ALchar = char

fn main() {
	c1 := &char(0)
	c2 := &ALchar(0)
	println('${typeof(c1).name} $c1')
	assert '$c1' == '0'
	println('${typeof(c2).name} $c2')
	assert '$c2' == '0'
}

PS D:\Test\v\tt1> v run .
&char 0
&ALchar 0
```