### PR TITLE
checker: fix generic array builtin method call (fix #12955)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -931,7 +931,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	// TODO: remove this for actual methods, use only for compiler magic
 	// FIXME: Argument count != 1 will break these
 	if left_sym.kind == .array && method_name in array_builtin_methods {
-		return c.array_builtin_method_call(mut node, left_type, left_sym)
+		return c.array_builtin_method_call(mut node, left_type, c.table.sym(left_type))
 	} else if (left_sym.kind == .map || final_left_sym.kind == .map)
 		&& method_name in ['clone', 'keys', 'move', 'delete'] {
 		if left_sym.kind == .map {

--- a/vlib/v/tests/generics_array_builtin_method_call_test.v
+++ b/vlib/v/tests/generics_array_builtin_method_call_test.v
@@ -1,0 +1,32 @@
+struct Container<T> {
+mut:
+	items []T
+}
+
+fn (mut c Container<T>) pop() ?T {
+	return c.items.pop()
+}
+
+struct Item {
+	data     string
+	priority int
+}
+
+fn test_generic_array_pop_call() {
+	mut a1 := Container<int>{
+		items: [11, 22]
+	}
+	println(a1)
+	ret1 := a1.pop() or { 0 }
+	println(ret1)
+	assert ret1 == 22
+
+	item1 := Item{'a', 1}
+	item2 := Item{'b', 2}
+	mut a2 := Container<Item>{
+		items: [item1, item2]
+	}
+	println(a2)
+	ret2 := a2.pop() or { Item{} }
+	assert ret2 == item2
+}


### PR DESCRIPTION
This PR fix generic array builtin method call (fix #12955).

- Fix generic array builtin method call.
- Add test.

```vlang
struct Container<T> {
mut:
	items []T
}

fn (mut c Container<T>) pop() ?T {
	x := c.items.pop()
	return x
}

struct Item {
	data     string
	priority int
}

fn main() {
	mut a1 := Container<int>{
		items: [11, 22]
	}
	println(a1)
	ret1 := a1.pop() or { 0 }
	println(ret1)
	assert ret1 == 22

	item1 := Item{'a', 1}
	item2 := Item{'b', 2}
	mut a2 := Container<Item>{
		items: [item1, item2]
	}
	println(a2)
	ret2 := a2.pop() or { Item{} }
	assert ret2 == item2
}

PS D:\Test\v\tt1> v run .
Container<int>{
    items: [11, 22]
}
22
Container<Item>{
    items: [Item{
        data: 'a'
        priority: 1
    }, Item{
        data: 'b'
        priority: 2
    }]
}
```