### PR TITLE
checker: check errors of cast to byte

### DIFF
--- a/vlib/v/checker/tests/cast_alias_to_byte_err.out
+++ b/vlib/v/checker/tests/cast_alias_to_byte_err.out
@@ -1,7 +1,0 @@
-vlib/v/checker/tests/cast_alias_to_byte_err.vv:5:7: error: cannot cast type `Foo` to `byte`
-    3 | fn main() {
-    4 |     a := Foo('hello')
-    5 |     b := byte(a)
-      |          ~~~~~~~
-    6 |     println(b)
-    7 | }

--- a/vlib/v/checker/tests/cast_alias_to_byte_err.vv
+++ b/vlib/v/checker/tests/cast_alias_to_byte_err.vv
@@ -1,7 +1,0 @@
-type Foo = string
-
-fn main() {
-	a := Foo('hello')
-	b := byte(a)
-	println(b)
-}

--- a/vlib/v/checker/tests/cast_string_err.out
+++ b/vlib/v/checker/tests/cast_string_err.out
@@ -12,7 +12,7 @@ vlib/v/checker/tests/cast_string_err.vv:18:9: error: cannot cast sumtype `Sumtyp
       |            ~~~~~~~~~~
    19 |     println(sst)
    20 |     //
-vlib/v/checker/tests/cast_string_err.vv:22:10: error: cannot cast struct `Abc` to `string`, use `abc.str()` instead.
+vlib/v/checker/tests/cast_string_err.vv:22:10: error: cannot cast struct `Abc` to `string`
    20 |     //
    21 |     abc := Abc{}
    22 |     sabc := string(abc)

--- a/vlib/v/checker/tests/cast_to_byte_err.out
+++ b/vlib/v/checker/tests/cast_to_byte_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/cast_to_byte_err.vv:10:7: error: cannot cast type `string` to `byte`
+    8 | fn main() {
+    9 |     // should be errors:
+   10 |     _ := byte('hello')
+      |          ~~~~~~~~~~~~~
+   11 |     _ := byte(SAlias('hello'))
+   12 |
+vlib/v/checker/tests/cast_to_byte_err.vv:11:7: error: cannot cast type `SAlias` to `byte`
+    9 |     // should be errors:
+   10 |     _ := byte('hello')
+   11 |     _ := byte(SAlias('hello'))
+      |          ~~~~~~~~~~~~~~~~~~~~~
+   12 |
+   13 |     // should be allowed:

--- a/vlib/v/checker/tests/cast_to_byte_err.vv
+++ b/vlib/v/checker/tests/cast_to_byte_err.vv
@@ -1,0 +1,23 @@
+type SAlias = string
+
+type CAlias = char
+type IAlias = int
+type UAlias = u32
+type FAlias = f32
+
+fn main() {
+	// should be errors:
+	_ := byte('hello')
+	_ := byte(SAlias('hello'))
+
+	// should be allowed:
+	_ := byte(char(1))
+	_ := byte(int(1))
+	_ := byte(u32(1))
+	_ := byte(f32(1.0))
+
+	_ := byte(CAlias(1))
+	_ := byte(IAlias(1))
+	_ := byte(UAlias(1))
+	_ := byte(FAlias(1))
+}

--- a/vlib/v/checker/tests/struct_type_cast_err.out
+++ b/vlib/v/checker/tests/struct_type_cast_err.out
@@ -1,60 +1,60 @@
-vlib/v/checker/tests/struct_type_cast_err.vv:5:10: error: cannot cast struct `Foo` to `string`, use `foo.str()` instead.
+vlib/v/checker/tests/struct_type_cast_err.vv:5:10: error: cannot cast struct `Foo` to `string`
     3 | fn main() {
     4 |     foo := Foo{}
     5 |     _ := string(foo)
       |          ~~~~~~~~~~~
     6 |     _ := int(foo)
     7 |     _ := u64(foo)
-vlib/v/checker/tests/struct_type_cast_err.vv:6:10: error: cannot cast struct `Foo` to `int`, use `foo.str()` instead.
+vlib/v/checker/tests/struct_type_cast_err.vv:6:10: error: cannot cast struct `Foo` to `int`
     4 |     foo := Foo{}
     5 |     _ := string(foo)
     6 |     _ := int(foo)
       |          ~~~~~~~~
     7 |     _ := u64(foo)
     8 |     _ := u32(foo)
-vlib/v/checker/tests/struct_type_cast_err.vv:7:10: error: cannot cast struct `Foo` to `u64`, use `foo.str()` instead.
+vlib/v/checker/tests/struct_type_cast_err.vv:7:10: error: cannot cast struct `Foo` to `u64`
     5 |     _ := string(foo)
     6 |     _ := int(foo)
     7 |     _ := u64(foo)
       |          ~~~~~~~~
     8 |     _ := u32(foo)
     9 |     _ := rune(foo)
-vlib/v/checker/tests/struct_type_cast_err.vv:8:10: error: cannot cast struct `Foo` to `u32`, use `foo.str()` instead.
+vlib/v/checker/tests/struct_type_cast_err.vv:8:10: error: cannot cast struct `Foo` to `u32`
     6 |     _ := int(foo)
     7 |     _ := u64(foo)
     8 |     _ := u32(foo)
       |          ~~~~~~~~
     9 |     _ := rune(foo)
    10 |     _ := byte(foo)
-vlib/v/checker/tests/struct_type_cast_err.vv:9:10: error: cannot cast struct `Foo` to `rune`, use `foo.str()` instead.
+vlib/v/checker/tests/struct_type_cast_err.vv:9:10: error: cannot cast struct `Foo` to `rune`
     7 |     _ := u64(foo)
     8 |     _ := u32(foo)
     9 |     _ := rune(foo)
       |          ~~~~~~~~~
    10 |     _ := byte(foo)
    11 |     _ := i8(foo)
-vlib/v/checker/tests/struct_type_cast_err.vv:10:10: error: cannot cast struct `Foo` to `byte`, use `foo.str()` instead.
+vlib/v/checker/tests/struct_type_cast_err.vv:10:10: error: cannot cast struct `Foo` to `byte`
     8 |     _ := u32(foo)
     9 |     _ := rune(foo)
    10 |     _ := byte(foo)
       |          ~~~~~~~~~
    11 |     _ := i8(foo)
    12 |     _ := i64(foo)
-vlib/v/checker/tests/struct_type_cast_err.vv:11:10: error: cannot cast struct `Foo` to `i8`, use `foo.str()` instead.
+vlib/v/checker/tests/struct_type_cast_err.vv:11:10: error: cannot cast struct `Foo` to `i8`
     9 |     _ := rune(foo)
    10 |     _ := byte(foo)
    11 |     _ := i8(foo)
       |          ~~~~~~~
    12 |     _ := i64(foo)
    13 |     _ := int(foo)
-vlib/v/checker/tests/struct_type_cast_err.vv:12:10: error: cannot cast struct `Foo` to `i64`, use `foo.str()` instead.
+vlib/v/checker/tests/struct_type_cast_err.vv:12:10: error: cannot cast struct `Foo` to `i64`
    10 |     _ := byte(foo)
    11 |     _ := i8(foo)
    12 |     _ := i64(foo)
       |          ~~~~~~~~
    13 |     _ := int(foo)
    14 |     _ = &I1(foo)
-vlib/v/checker/tests/struct_type_cast_err.vv:13:10: error: cannot cast struct `Foo` to `int`, use `foo.str()` instead.
+vlib/v/checker/tests/struct_type_cast_err.vv:13:10: error: cannot cast struct `Foo` to `int`
    11 |     _ := i8(foo)
    12 |     _ := i64(foo)
    13 |     _ := int(foo)


### PR DESCRIPTION
This PR check errors of cast to byte.

- Check errors of cast to byte.
- Add test.

```vlang
type SAlias = string

type CAlias = char
type IAlias = int
type UAlias = u32
type FAlias = f32

fn main() {
	// should be errors:
	_ := byte('hello')
	_ := byte(SAlias('hello'))

	// should be allowed:
	_ := byte(char(1))
	_ := byte(int(1))
	_ := byte(u32(1))
	_ := byte(f32(1.0))

	_ := byte(CAlias(1))
	_ := byte(IAlias(1))
	_ := byte(UAlias(1))
	_ := byte(FAlias(1))
}

PS D:\Test\v\tt1> v run .
.\tt1.v:10:10: error: cannot cast type `string` to `byte`
    8 | fn main() {
    9 |     // should be errors:
   10 |     _ := byte('hello')
      |          ~~~~~~~~~~~~~
   11 |     _ := byte(SAlias('hello'))
   12 |
.\tt1.v:11:10: error: cannot cast type `SAlias` to `byte`
    9 |     // should be errors:
   10 |     _ := byte('hello')
   11 |     _ := byte(SAlias('hello'))
      |          ~~~~~~~~~~~~~~~~~~~~~
   12 |
   13 |     // This should be allowed:
```