### PR TITLE
cgen: check call argument on methods

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -654,15 +654,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 			node.expected_arg_types << param.typ
 		}
 	}
-	is_js_backend := match c.pref.backend {
-		.js_node, .js_browser, .js_freestanding {
-			true
-		}
-		else {
-			false
-		}
-	}
-	if !is_js_backend && node.args.len > 0 && func.params.len == 0 {
+	if !c.pref.backend.is_js() && node.args.len > 0 && func.params.len == 0 {
 		c.error('too $c.pref.backend many arguments in call to `$func.name`', node.pos)
 	}
 	for i, mut call_arg in node.args {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -655,7 +655,8 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 		}
 	}
 	if !c.pref.backend.is_js() && node.args.len > 0 && func.params.len == 0 {
-		c.error('too many arguments in call to `$func.name` (non-js backend: $c.pref.backend)', node.pos)
+		c.error('too many arguments in call to `$func.name` (non-js backend: $c.pref.backend)',
+			node.pos)
 	}
 	for i, mut call_arg in node.args {
 		if func.params.len == 0 {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -655,7 +655,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 		}
 	}
 	if !c.pref.backend.is_js() && node.args.len > 0 && func.params.len == 0 {
-		c.error('too $c.pref.backend many arguments in call to `$func.name`', node.pos)
+		c.error('too many arguments in call to `$func.name` (non-js backend: $c.pref.backend)', node.pos)
 	}
 	for i, mut call_arg in node.args {
 		if func.params.len == 0 {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -654,7 +654,21 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 			node.expected_arg_types << param.typ
 		}
 	}
+	is_js_backend := match c.pref.backend {
+		.js_node, .js_browser, .js_freestanding {
+			true
+		}
+		else {
+			false
+		}
+	}
+	if !is_js_backend && node.args.len > 0 && func.params.len == 0 {
+		c.error('too $c.pref.backend many arguments in call to `$func.name`', node.pos)
+	}
 	for i, mut call_arg in node.args {
+		if func.params.len == 0 {
+			continue
+		}
 		param := if func.is_variadic && i >= func.params.len - 1 {
 			func.params[func.params.len - 1]
 		} else {

--- a/vlib/v/checker/tests/js_with_non_js_backend_too_many_arguments.out
+++ b/vlib/v/checker/tests/js_with_non_js_backend_too_many_arguments.out
@@ -1,4 +1,5 @@
-vlib/v/checker/tests/js_with_non_js_backend_too_many_arguments.vv:2:4: error: too many arguments in call to `JS.Foo.bar` (non-js backend: c)
+vlib/v/checker/tests/js_with_non_js_backend_too_many_arguments.vv:3:4: error: too many arguments in call to `JS.Foo.bar` (non-js backend: c)
     1 | fn JS.Foo.bar() bool
-    2 | JS.Foo.bar(123)
+    2 | 
+    3 | JS.Foo.bar(123)
       |    ~~~~~~~~~~~~

--- a/vlib/v/checker/tests/js_with_non_js_backend_too_many_arguments.out
+++ b/vlib/v/checker/tests/js_with_non_js_backend_too_many_arguments.out
@@ -1,0 +1,4 @@
+vlib/v/checker/tests/js_with_non_js_backend_too_many_arguments.vv:2:4: error: too many arguments in call to `JS.Foo.bar` (non-js backend: c)
+    1 | fn JS.Foo.bar() bool
+    2 | JS.Foo.bar(123)
+      |    ~~~~~~~~~~~~

--- a/vlib/v/checker/tests/js_with_non_js_backend_too_many_arguments.vv
+++ b/vlib/v/checker/tests/js_with_non_js_backend_too_many_arguments.vv
@@ -1,2 +1,3 @@
 fn JS.Foo.bar() bool
+
 JS.Foo.bar(123)

--- a/vlib/v/checker/tests/js_with_non_js_backend_too_many_arguments.vv
+++ b/vlib/v/checker/tests/js_with_non_js_backend_too_many_arguments.vv
@@ -1,0 +1,2 @@
+fn JS.Foo.bar() bool
+JS.Foo.bar(123)


### PR DESCRIPTION
Fixes this crash:

```
$ cat a.v
fn JS.Foo.bar() bool

JS.Foo.bar(123)
$
$ v a.v
V panic: array.get: index out of range (i == 0, a.len == 0)
v hash: 3528239
0   v                                   0x000000010ddc2f4c array_get + 252
1   v                                   0x000000010deb05d2 v__checker__Checker_fn_call + 16498
2   v                                   0x000000010dea6f17 v__checker__Checker_call_expr + 119
3   v                                   0x000000010de821a5 v__checker__Checker_expr + 3685
4   v                                   0x000000010de96852 v__checker__Checker_stmt + 2130
5   v                                   0x000000010dea6d71 v__checker__Checker_stmts_ending_with_expression + 289
6   v                                   0x000000010debbe26 v__checker__Checker_stmts + 86
7   v                                   0x000000010debf0e1 v__checker__Checker_fn_decl + 12961
8   v                                   0x000000010de96aa8 v__checker__Checker_stmt + 2728
9   v                                   0x000000010de95ef7 v__checker__Checker_check + 2103
10  v                                   0x000000010de9784a v__checker__Checker_check_files + 378
11  v                                   0x000000010e0234ae v__builder__Builder_middle_stages + 222
12  v                                   0x000000010e025473 v__builder__Builder_front_and_middle_stages + 147
13  v                                   0x000000010e03d622 v__builder__cbuilder__gen_c + 66
14  v                                   0x000000010e03d466 v__builder__cbuilder__build_c + 342
15  v                                   0x000000010e03d2fe v__builder__cbuilder__compile_c + 526
16  v                                   0x000000010e036afe v__builder__compile + 446
17  v                                   0x000000010e03ed72 main__main + 5618
18  v                                   0x000000010e042c2a main + 42
19  v                                   0x000000010ddbeb64 start + 52
$
```