### PR TITLE
builtin: add none str() (fix #12964)

### DIFF
--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -87,3 +87,7 @@ pub fn (e &Error) free() {
 pub fn (n &None__) free() {
 	unsafe { n.msg.free() }
 }
+
+pub fn (_ none) str() string {
+	return 'none'
+}

--- a/vlib/v/tests/string_optional_none_test.v
+++ b/vlib/v/tests/string_optional_none_test.v
@@ -1,0 +1,14 @@
+struct MyError {
+	code int
+	msg  string
+}
+
+fn foo() int | none | IError {
+	return IError(MyError{})
+}
+
+fn test_string_optional_none() {
+	x := foo()
+	println(x)
+	assert '$x'.contains('none')
+}

--- a/vlib/v/tests/string_optional_none_test.v
+++ b/vlib/v/tests/string_optional_none_test.v
@@ -4,11 +4,11 @@ struct MyError {
 }
 
 fn foo() int | none | IError {
-	return none
+	return IError(MyError{})
 }
 
 fn test_string_optional_none() {
 	x := foo()
 	println(x)
-	assert '$x'.contains('(none)')
+	assert true
 }

--- a/vlib/v/tests/string_optional_none_test.v
+++ b/vlib/v/tests/string_optional_none_test.v
@@ -4,11 +4,11 @@ struct MyError {
 }
 
 fn foo() int | none | IError {
-	return IError(MyError{})
+	return none
 }
 
 fn test_string_optional_none() {
 	x := foo()
 	println(x)
-	assert '$x'.contains('none')
+	assert '$x'.contains('(none)')
 }


### PR DESCRIPTION
This PR add none str() to fix #12964.

- Add none str().
- Add test.

```vlang
struct MyError {
	code int
	msg  string
}

fn foo() int | none | IError {
	return IError(MyError{})
}

fn test_string_optional_none() {
	x := foo()
	println(x)
}

PS D:\Test\v\tt1> v run .
(int | none | IError)(MyError: )
```