### PR TITLE
checker: fix cast enum to alias (fix #12947)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3483,7 +3483,8 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 			c.error('cannot cast `$from_type_sym.name` to `$to_type_sym.name`', node.pos)
 		}
 	} else if mut to_type_sym.info is ast.Alias {
-		if !c.check_types(from_type, to_type_sym.info.parent_type) {
+		if !c.check_types(from_type, to_type_sym.info.parent_type) && !(to_type_sym_final.is_int()
+			&& from_type_sym_final.kind == .enum_) {
 			c.error('cannot convert type `$from_type_sym.name` to `$to_type_sym.name` (alias to `$to_type_sym_final.name`)',
 				node.pos)
 		}

--- a/vlib/v/tests/cast_to_alias_test.v
+++ b/vlib/v/tests/cast_to_alias_test.v
@@ -1,0 +1,36 @@
+module main
+
+type CEnum = int
+
+enum Enum {
+	value = 1
+}
+
+fn foo(n int) string {
+	return '$n'
+}
+
+fn bar(n CEnum) string {
+	return '$n'
+}
+
+fn test_cast_to_alias() {
+	e := Enum.value
+	mut ret_str := ''
+
+	ret_str = foo(int(e))
+	println(ret_str)
+	assert ret_str == '1'
+
+	ret_str = bar(int(e))
+	println(ret_str)
+	assert ret_str == '1'
+
+	ret_str = foo(CEnum(e))
+	println(ret_str)
+	assert ret_str == '1'
+
+	ret_str = bar(CEnum(e))
+	println(ret_str)
+	assert ret_str == '1'
+}


### PR DESCRIPTION
This PR fix cast enum to alias (fix #12947).

- Fix cast enum to alias.
- Add test.

```vlang
module main

type CEnum = int

enum Enum {
	value = 1
}

fn foo(n int) string {
	return '$n'
}

fn bar(n CEnum) string {
	return '$n'
}

fn test_cast_to_alias() {
	e := Enum.value
	mut ret_str := ''

	ret_str = foo(int(e))
	println(ret_str)
	assert ret_str == '1'

	ret_str = bar(int(e))
	println(ret_str)
	assert ret_str == '1'

	ret_str = foo(CEnum(e))
	println(ret_str)
	assert ret_str == '1'

	ret_str = bar(CEnum(e))
	println(ret_str)
	assert ret_str == '1'
}

PS D:\Test\v\tt1> v run .
1
1
1
1
```