### PR TITLE
ast: fix generic fn with multiple return (fix #12960)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1056,8 +1056,9 @@ pub fn (mut t Table) find_or_register_multi_return(mr_typs []Type) int {
 	mut cname := 'multi_return'
 	for i, mr_typ in mr_typs {
 		mr_type_sym := t.sym(mr_typ)
-		name += mr_type_sym.name
-		cname += '_$mr_type_sym.cname'
+		ref, cref := if mr_typ.is_ptr() { '&', 'ref_' } else { '', '' }
+		name += '$ref$mr_type_sym.name'
+		cname += '_$cref$mr_type_sym.cname'
 		if i < mr_typs.len - 1 {
 			name += ', '
 		}

--- a/vlib/v/tests/generic_fn_multi_return_test.v
+++ b/vlib/v/tests/generic_fn_multi_return_test.v
@@ -1,0 +1,53 @@
+fn test_generic_fn_multi_return() {
+	mut a1 := GenRef<u32, u32>{32, 99}
+	b1, c1 := a1.generic_reference() or {
+		assert false
+		return
+	}
+	println(b1)
+	assert b1 == 32
+	println(c1)
+	assert *c1 == 99
+
+	mut a2 := GenRef<u64, u64>{322, 999}
+	b2, c2 := a2.generic_reference() or {
+		assert false
+		return
+	}
+	println(b2)
+	assert b2 == 322
+	println(c2)
+	assert *c2 == 999
+
+	mut a3 := GenRef<i32, u64>{22, 77}
+	b3, c3 := a3.generic_reference() or {
+		assert false
+		return
+	}
+	println(b3)
+	assert b3 == 22
+	println(c3)
+	assert *c3 == 77
+
+	mut a4 := GenRef<f64, u64>{2.2, 777}
+	b4, c4 := a4.generic_reference() or {
+		assert false
+		return
+	}
+	println(b4)
+	assert b4 == 2.2
+	println(c4)
+	assert *c4 == 777
+}
+
+struct GenRef<K, V> {
+	key K
+	val V
+}
+
+fn (mut self GenRef<K, V>) generic_reference() ?(K, &V) {
+	if false {
+		return none
+	}
+	return self.key, unsafe { &self.val }
+}


### PR DESCRIPTION
This PR fix generic fn with multiple return (fix #12960).

- Fix generic fn with multiple return.
- Add test.

```vlang
fn main() {
	mut a1 := GenRef<u32, u32>{32, 99}
	b1, c1 := a1.generic_reference() ?
	println(b1)
	assert b1 == 32
	println(c1)
	assert *c1 == 99

	mut a2 := GenRef<u64, u64>{322, 999}
	b2, c2 := a2.generic_reference() ?
	println(b2)
	assert b2 == 322
	println(c2)
	assert *c2 == 999

	mut a3 := GenRef<i32, u64>{22, 77}
	b3, c3 := a3.generic_reference() ?
	println(b3)
	assert b3 == 22
	println(c3)
	assert *c3 == 77

	mut a4 := GenRef<f64, u64>{2.2, 777}
	b4, c4 := a4.generic_reference() ?
	println(b4)
	assert b4 == 2.2
	println(c4)
	assert *c4 == 777
}

struct GenRef<K, V> {
	key K
	val V
}

fn (mut self GenRef<K, V>) generic_reference() ?(K, &V) {
	if false {
		return none
	}
	return self.key, unsafe { &self.val }
}

PS D:\Test\v\tt1> v run .
32
&99
322
&999
22
&77
2.2
&777
```