### PR TITLE
builtin: add charptr str() and change string format (fix #12959)

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -391,14 +391,18 @@ pub fn (nn int_literal) hex() string {
 // hex returns the value of the `voidptr` as a hexadecimal `string`.
 // Note that the output is ***not*** zero padded.
 pub fn (nn voidptr) str() string {
-	return u64(nn).hex()
+	return '0x' + u64(nn).hex()
 }
 
 // hex returns the value of the `byteptr` as a hexadecimal `string`.
 // Note that the output is ***not*** zero padded.
 // pub fn (nn byteptr) str() string {
 pub fn (nn byteptr) str() string {
-	return u64(nn).hex()
+	return '0x' + u64(nn).hex()
+}
+
+pub fn (nn charptr) str() string {
+	return '0x' + u64(nn).hex()
 }
 
 pub fn (nn byte) hex_full() string {

--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -29,12 +29,14 @@ fn test_str_methods() {
 	assert u32(-1).str() == '4294967295'
 	assert u64(1).str() == '1'
 	assert u64(-1).str() == '18446744073709551615'
-	assert voidptr(-1).str() == 'ffffffffffffffff'
-	assert voidptr(1).str() == '1'
+	assert voidptr(-1).str() == '0xffffffffffffffff'
+	assert voidptr(1).str() == '0x1'
 	assert (&byte(-1)).str() == 'ffffffffffffffff'
 	assert (&byte(1)).str() == '1'
-	assert byteptr(-1).str() == 'ffffffffffffffff'
-	assert byteptr(1).str() == '1'
+	assert byteptr(-1).str() == '0xffffffffffffffff'
+	assert byteptr(1).str() == '0x1'
+	assert charptr(-1).str() == '0xffffffffffffffff'
+	assert charptr(1).str() == '0x1'
 }
 
 fn test_and_precendence() {

--- a/vlib/v/tests/interface_edge_cases/pass_voidptr_as_interface_reference_test.v
+++ b/vlib/v/tests/interface_edge_cases/pass_voidptr_as_interface_reference_test.v
@@ -15,5 +15,5 @@ fn test_passing_voidptr_as_an_interface_reference() {
 	assert f(&i) == '&IAbc(Abc{})'
 	// a voidptr() cast is an escape hatch, that should be allowed
 	// but perhaps it should be forced by the compiler to be in unsafe{}
-	assert f(unsafe { voidptr(0) }) == '&IAbc(0)'
+	assert f(unsafe { voidptr(0) }) == '&IAbc(0x0)'
 }

--- a/vlib/v/tests/interface_edge_cases/voidptr_casted_as_an_interface_test.v
+++ b/vlib/v/tests/interface_edge_cases/voidptr_casted_as_an_interface_test.v
@@ -17,7 +17,7 @@ fn f(i &IAbc) string {
 fn test_voidptr_casted_as_an_interface_reference() {
 	mut pi := &IAbc(voidptr(0))
 	dump(pi)
-	assert f(pi) == '&IAbc(0)'
+	assert f(pi) == '&IAbc(0x0)'
 	//
 	i := IAbc(Abc{})
 	pi = &i

--- a/vlib/v/tests/pointers_multilevel_casts_test.v
+++ b/vlib/v/tests/pointers_multilevel_casts_test.v
@@ -9,10 +9,10 @@ fn test_byte_pointer_casts() {
 		ppb := &&byte(2)
 		pppb := &&&byte(3)
 		ppppb := &&&&byte(4)
-		assert voidptr(pb).str() == '1'
-		assert voidptr(ppb).str() == '2'
-		assert voidptr(pppb).str() == '3'
-		assert voidptr(ppppb).str() == '4'
+		assert voidptr(pb).str() == '0x1'
+		assert voidptr(ppb).str() == '0x2'
+		assert voidptr(pppb).str() == '0x3'
+		assert voidptr(ppppb).str() == '0x4'
 	}
 }
 
@@ -22,10 +22,10 @@ fn test_char_pointer_casts() {
 		ppc := &&char(6)
 		pppc := &&&char(7)
 		ppppc := &&&&char(8)
-		assert voidptr(pc).str() == '5'
-		assert voidptr(ppc).str() == '6'
-		assert voidptr(pppc).str() == '7'
-		assert voidptr(ppppc).str() == '8'
+		assert voidptr(pc).str() == '0x5'
+		assert voidptr(ppc).str() == '0x6'
+		assert voidptr(pppc).str() == '0x7'
+		assert voidptr(ppppc).str() == '0x8'
 	}
 }
 
@@ -35,10 +35,10 @@ fn test_struct_pointer_casts() {
 		pps := &&Struct(10)
 		ppps := &&&Struct(11)
 		pppps := &&&&Struct(12)
-		assert voidptr(ps).str() == '9'
-		assert voidptr(pps).str() == 'a'
-		assert voidptr(ppps).str() == 'b'
-		assert voidptr(pppps).str() == 'c'
+		assert voidptr(ps).str() == '0x9'
+		assert voidptr(pps).str() == '0xa'
+		assert voidptr(ppps).str() == '0xb'
+		assert voidptr(pppps).str() == '0xc'
 	}
 }
 


### PR DESCRIPTION
This PR add charptr str() and change string format (fix #12959).

- Add charptr str() and change string format.
- Modify voidptr/byteptr str() format, `0x2`.
- Add test.

```vlang
fn main() {
	ohm := charptr(0)
	println(ohm.str())
}

PS D:\Test\v\tt1> v run .
0x0
```