### PR TITLE
parser: check variable redefinition error (fix #12991)

### DIFF
--- a/vlib/v/checker/tests/assign_var_redefinition_err.out
+++ b/vlib/v/checker/tests/assign_var_redefinition_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/assign_var_redefinition_err.vv:6:2: error: redefinition of `aaaa`
+    4 |
+    5 | fn test(aaaa string) string {
+    6 |     aaaa := 'bbbb' + aaaa
+      |     ~~~~
+    7 |     return aaaa
+    8 | }

--- a/vlib/v/checker/tests/assign_var_redefinition_err.vv
+++ b/vlib/v/checker/tests/assign_var_redefinition_err.vv
@@ -1,0 +1,8 @@
+fn main() {
+	println(test('whatever'))
+}
+
+fn test(aaaa string) string {
+	aaaa := 'bbbb' + aaaa
+	return aaaa
+}

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -144,24 +144,6 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr, left_comments []ast.Comme
 	comments << right_comments
 	end_comments := p.eat_comments(same_line: true)
 	mut has_cross_var := false
-	if op == .decl_assign {
-		// a, b := a + 1, b
-		for r in right {
-			p.check_undefined_variables(left, r) or { return p.error_with_pos(err.msg, pos) }
-		}
-	} else if left.len > 1 {
-		// a, b = b, a
-		for r in right {
-			has_cross_var = p.check_cross_variables(left, r)
-			if op !in [.assign, .decl_assign] {
-				return p.error_with_pos('unexpected $op.str(), expecting := or = or comma',
-					pos)
-			}
-			if has_cross_var {
-				break
-			}
-		}
-	}
 	mut is_static := false
 	mut is_volatile := false
 	for i, lx in left {
@@ -229,6 +211,24 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr, left_comments []ast.Comme
 			else {
 				// TODO: parexpr ( check vars)
 				// else { p.error_with_pos('unexpected `${typeof(lx)}`', lx.position()) }
+			}
+		}
+	}
+	if op == .decl_assign {
+		// a, b := a + 1, b
+		for r in right {
+			p.check_undefined_variables(left, r) or { return p.error_with_pos(err.msg, pos) }
+		}
+	} else if left.len > 1 {
+		// a, b = b, a
+		for r in right {
+			has_cross_var = p.check_cross_variables(left, r)
+			if op !in [.assign, .decl_assign] {
+				return p.error_with_pos('unexpected $op.str(), expecting := or = or comma',
+					pos)
+			}
+			if has_cross_var {
+				break
 			}
 		}
 	}


### PR DESCRIPTION
This PR check variable redefinition error (fix #12991).

- Check variable redefinition error.
- Add test.

```vlang
fn main() {
	println(test('whatever'))
}

fn test(aaaa string) string {
	aaaa := 'bbbb' + aaaa
	return aaaa
}

PS D:\Test\v\tt1> v run .
.\tt1.v:6:2: error: redefinition of `aaaa`
    4 |
    5 | fn test(aaaa string) string {
    6 |     aaaa := 'bbbb' + aaaa
      |     ~~~~
    7 |     return aaaa
    8 | }
```