### PR TITLE
WIP: js: eval takes a JS.String, not `string`, which fails in Frida

### DIFF
--- a/vlib/builtin/js/jsfns.js.v
+++ b/vlib/builtin/js/jsfns.js.v
@@ -123,7 +123,7 @@ fn native_str_arr_len(arr []JS.String) int {
 }
 
 // Top level functions
-fn JS.eval(string) any
+fn JS.eval(JS.String) any
 fn JS.parseInt(string, f64) JS.Number
 fn JS.parseFloat(string) JS.Number
 fn JS.isNaN(f64) bool


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
