### PR TITLE
checker: check using const var as function (fix #13002)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -637,10 +637,12 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 	// global fn?
 	if !found {
 		if obj := c.file.global_scope.find(fn_name) {
-			sym := c.table.sym(obj.typ)
-			if sym.kind == .function {
-				found = true
-				func = (sym.info as ast.FnType).func
+			if obj.typ != 0 {
+				sym := c.table.sym(obj.typ)
+				if sym.kind == .function {
+					found = true
+					func = (sym.info as ast.FnType).func
+				}
 			}
 		}
 	}

--- a/vlib/v/checker/tests/unknown_function.out
+++ b/vlib/v/checker/tests/unknown_function.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/unknown_function.vv:4:15: error: unknown function: math.max_i64
+    2 |
+    3 | fn main() {
+    4 |     println(math.max_i64())
+      |                  ~~~~~~~~~
+    5 | }

--- a/vlib/v/checker/tests/unknown_function.vv
+++ b/vlib/v/checker/tests/unknown_function.vv
@@ -1,0 +1,5 @@
+import math
+
+fn main() {
+	println(math.max_i64())
+}


### PR DESCRIPTION
This PR check using const var as function (fix #13002).

- Check using const var as function.
- Add test.

```vlang
import math

fn main() {
	println(math.max_i64())
}

PS D:\Test\v\tt1> v run .
.\tt1.v:4:15: error: unknown function: math.max_i64
    2 |
    3 | fn main() {
    4 |     println(math.max_i64())
      |                  ~~~~~~~~~
    5 | }
```