### PR TITLE
ast: support attributes for `ast.SumType`

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1092,6 +1092,7 @@ pub:
 	comments      []Comment
 	typ           Type
 	generic_types []Type
+	attrs         []Attr // attributes of type declaration
 pub mut:
 	variants []TypeNode
 }

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1293,6 +1293,7 @@ pub fn (mut f Fmt) fn_type_decl(node ast.FnTypeDecl) {
 }
 
 pub fn (mut f Fmt) sum_type_decl(node ast.SumTypeDecl) {
+	f.attrs(node.attrs)
 	start_pos := f.out.len
 	if node.is_pub {
 		f.write('pub ')

--- a/vlib/v/fmt/tests/sum_attributes_keep.vv
+++ b/vlib/v/fmt/tests/sum_attributes_keep.vv
@@ -1,0 +1,14 @@
+[derive: 'DeserBincode,SerBincode']
+type OneOf = ItemA | ItemB
+
+[derive: 'DeserBincode,SerBincode']
+struct ItemA {
+	a string
+}
+
+[derive: 'DeserBincode,SerBincode']
+struct ItemB {
+	b   int
+	bb  u64
+	bbb string
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3459,6 +3459,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 			is_pub: is_pub
 			variants: sum_variants
 			generic_types: generic_types
+			attrs: p.attrs
 			pos: decl_pos
 			comments: comments
 		}


### PR DESCRIPTION
This PR adds a field `attrs` to `v.ast.SumType`

- add field to `v.ast.SumType`
- set value at `v.parser`

```v
[attr; name: 'it works!']
type SumTyp = Aiu | None
// ...
```
```
v.ast.TypeDecl(v.ast.SumTypeDecl{
    name: 'SumTyp'
    is_pub: false
    pos: v.token.Position{
        len: 11
        line_nr: 1
        pos: 26
        col: 0
        last_line: 1
    }
    comments: []
    typ: ast.Type(0x21 = 33)
    generic_types: []
    attrs: [attr, name: 'it works!']
...
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
