### PR TITLE
cgen: fix error for fixed array index (fix #13009)

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -85,7 +85,7 @@ fn (mut g Gen) range_expr(node ast.IndexExpr, range ast.RangeExpr) {
 		} else {
 			g.write('array_slice(')
 		}
-		g.write('new_array_from_c_array${noscan}(')
+		g.write('new_array_from_c_array_no_alloc${noscan}(')
 		g.write('$info.size')
 		g.write(', $info.size')
 		g.write(', sizeof(')

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -26,6 +26,7 @@ pub fn mark_used(mut table ast.Table, pref &pref.Preferences, ast_files []&ast.F
 		'vcalloc',
 		'vcalloc_noscan',
 		'new_array_from_c_array',
+		'new_array_from_c_array_no_alloc',
 		'v_fixed_index',
 		'memdup',
 		'vstrlen',

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -139,6 +139,7 @@ pub fn mark_used(mut table ast.Table, pref &pref.Preferences, ast_files []&ast.F
 			'__new_array_with_default_noscan',
 			'__new_array_with_array_default_noscan',
 			'new_array_from_c_array_noscan',
+			'new_array_from_c_array_no_alloc_noscan',
 			'22.clone_static_to_depth_noscan',
 			'22.clone_to_depth_noscan',
 			'22.reverse_noscan',

--- a/vlib/v/tests/fixed_array_index_test.v
+++ b/vlib/v/tests/fixed_array_index_test.v
@@ -1,0 +1,12 @@
+fn test_fixed_array_index() {
+	aa := [byte(0), 0xFF, 0xFF]
+	mut bufa := [8]byte{}
+	copy(bufa[..], aa)
+	println(bufa)
+	assert bufa == [byte(0), 0xFF, 0xFF, 0, 0, 0, 0, 0]!
+
+	mut bufb := []byte{len: 8}
+	copy(bufb[..], aa)
+	println(bufb)
+	assert bufb == [byte(0), 0xFF, 0xFF, 0, 0, 0, 0, 0]
+}


### PR DESCRIPTION
This PR fix error for fixed array index (fix #13009).

- Fix error for fixed array index.
- Add test.

```vlang
fn main() {
	aa := [byte(0), 0xFF, 0xFF]
	mut bufa := [8]byte{}
	copy(bufa[..], aa)
	println(bufa)
	assert bufa == [byte(0), 0xFF, 0xFF, 0, 0, 0, 0, 0]!

	mut bufb := []byte{len: 8}
	copy(bufb[..], aa)
	println(bufb)
	assert bufb == [byte(0), 0xFF, 0xFF, 0, 0, 0, 0, 0]
}

PS D:\Test\v\tt1> v run .
[0, 255, 255, 0, 0, 0, 0, 0]
[`\0`, 0xff, 0xff, `\0`, `\0`, `\0`, `\0`, `\0`]
```