### PR TITLE
sokol: type alias all `gfx` structs

### DIFF
--- a/cmd/tools/vshader.v
+++ b/cmd/tools/vshader.v
@@ -203,7 +203,7 @@ fn compile_shader(opt CompileOptions, shader_file string) ? {
 	}
 	if opt.verbose {
 		program_name := shader_program_name(shader_file)
-		eprintln('$tool_name usage example in V:\n\nimport sokol.gfx\n\n#include "$header_name"\n\nfn C.${program_name}_shader_desc(gfx.Backend) &C.sg_shader_desc\n')
+		eprintln('$tool_name usage example in V:\n\nimport sokol.gfx\n\n#include "$header_name"\n\nfn C.${program_name}_shader_desc(gfx.Backend) &gfx.ShaderDesc\n')
 	}
 }
 

--- a/examples/sokol/01_cubes/cube.v
+++ b/examples/sokol/01_cubes/cube.v
@@ -27,7 +27,7 @@ struct App {
 mut:
 	gg          &gg.Context
 	pip_3d      C.sgl_pipeline
-	texture     C.sg_image
+	texture     gfx.Image
 	init_flag   bool
 	frame_count int
 	mouse_x     int = -1
@@ -39,9 +39,9 @@ mut:
 * Texture functions
 *
 ******************************************************************************/
-fn create_texture(w int, h int, buf &u8) C.sg_image {
+fn create_texture(w int, h int, buf &u8) gfx.Image {
 	sz := w * h * 4
-	mut img_desc := C.sg_image_desc{
+	mut img_desc := gfx.ImageDesc{
 		width: w
 		height: h
 		num_mipmaps: 0
@@ -54,28 +54,28 @@ fn create_texture(w int, h int, buf &u8) C.sg_image {
 		d3d11_texture: 0
 	}
 	// commen if .dynamic is enabled
-	img_desc.data.subimage[0][0] = C.sg_range{
+	img_desc.data.subimage[0][0] = gfx.Range{
 		ptr: buf
 		size: usize(sz)
 	}
 
-	sg_img := C.sg_make_image(&img_desc)
+	sg_img := gfx.make_image(&img_desc)
 	return sg_img
 }
 
-fn destroy_texture(sg_img C.sg_image) {
-	C.sg_destroy_image(sg_img)
+fn destroy_texture(sg_img gfx.Image) {
+	gfx.destroy_image(sg_img)
 }
 
 // Use only if usage: .dynamic is enabled
-fn update_text_texture(sg_img C.sg_image, w int, h int, buf &byte) {
+fn update_text_texture(sg_img gfx.Image, w int, h int, buf &byte) {
 	sz := w * h * 4
-	mut tmp_sbc := C.sg_image_data{}
-	tmp_sbc.subimage[0][0] = C.sg_range{
+	mut tmp_sbc := gfx.ImageData{}
+	tmp_sbc.subimage[0][0] = gfx.Range{
 		ptr: buf
 		size: usize(sz)
 	}
-	C.sg_update_image(sg_img, &tmp_sbc)
+	gfx.update_image(sg_img, &tmp_sbc)
 }
 
 /******************************************************************************
@@ -321,21 +321,21 @@ fn my_init(mut app App) {
 	sgl.setup(&sgl_desc)
 
 	// 3d pipeline
-	mut pipdesc := C.sg_pipeline_desc{}
+	mut pipdesc := gfx.PipelineDesc{}
 	unsafe { C.memset(&pipdesc, 0, sizeof(pipdesc)) }
 
-	color_state := C.sg_color_state{
-		blend: C.sg_blend_state{
+	color_state := gfx.ColorState{
+		blend: gfx.BlendState{
 			enabled: true
-			src_factor_rgb: gfx.BlendFactor(C.SG_BLENDFACTOR_SRC_ALPHA)
-			dst_factor_rgb: gfx.BlendFactor(C.SG_BLENDFACTOR_ONE_MINUS_SRC_ALPHA)
+			src_factor_rgb: .src_alpha
+			dst_factor_rgb: .one_minus_src_alpha
 		}
 	}
 	pipdesc.colors[0] = color_state
 
-	pipdesc.depth = C.sg_depth_state{
+	pipdesc.depth = gfx.DepthState{
 		write_enabled: true
-		compare: gfx.CompareFunc(C.SG_COMPAREFUNC_LESS_EQUAL)
+		compare: .less_equal
 	}
 	pipdesc.cull_mode = .back
 	app.pip_3d = sgl.make_pipeline(&pipdesc)

--- a/examples/sokol/02_cubes_glsl/cube_glsl.v
+++ b/examples/sokol/02_cubes_glsl/cube_glsl.v
@@ -26,7 +26,7 @@ import gg.m4
 #flag -I @VMODROOT/.
 #include "cube_glsl.h" # Should be generated with `v shader .` (see the instructions at the top of this file)
 
-fn C.cube_shader_desc(gfx.Backend) &C.sg_shader_desc
+fn C.cube_shader_desc(gfx.Backend) &gfx.ShaderDesc
 
 const (
 	win_width  = 800
@@ -38,14 +38,14 @@ struct App {
 mut:
 	gg          &gg.Context
 	pip_3d      C.sgl_pipeline
-	texture     C.sg_image
+	texture     gfx.Image
 	init_flag   bool
 	frame_count int
 	mouse_x     int = -1
 	mouse_y     int = -1
 	// glsl
-	cube_pip_glsl C.sg_pipeline
-	cube_bind     C.sg_bindings
+	cube_pip_glsl gfx.Pipeline
+	cube_bind     gfx.Bindings
 	// time
 	ticks i64
 }
@@ -55,9 +55,9 @@ mut:
 * Texture functions
 *
 ******************************************************************************/
-fn create_texture(w int, h int, buf &byte) C.sg_image {
+fn create_texture(w int, h int, buf &byte) gfx.Image {
 	sz := w * h * 4
-	mut img_desc := C.sg_image_desc{
+	mut img_desc := gfx.ImageDesc{
 		width: w
 		height: h
 		num_mipmaps: 0
@@ -70,28 +70,28 @@ fn create_texture(w int, h int, buf &byte) C.sg_image {
 		d3d11_texture: 0
 	}
 	// comment if .dynamic is enabled
-	img_desc.data.subimage[0][0] = C.sg_range{
+	img_desc.data.subimage[0][0] = gfx.Range{
 		ptr: buf
 		size: usize(sz)
 	}
 
-	sg_img := C.sg_make_image(&img_desc)
+	sg_img := gfx.make_image(&img_desc)
 	return sg_img
 }
 
-fn destroy_texture(sg_img C.sg_image) {
-	C.sg_destroy_image(sg_img)
+fn destroy_texture(sg_img gfx.Image) {
+	gfx.destroy_image(sg_img)
 }
 
 // Use only if usage: .dynamic is enabled
-fn update_text_texture(sg_img C.sg_image, w int, h int, buf &byte) {
+fn update_text_texture(sg_img gfx.Image, w int, h int, buf &byte) {
 	sz := w * h * 4
-	mut tmp_sbc := C.sg_image_data{}
-	tmp_sbc.subimage[0][0] = C.sg_range{
+	mut tmp_sbc := gfx.ImageData{}
+	tmp_sbc.subimage[0][0] = gfx.Range{
 		ptr: buf
 		size: usize(sz)
 	}
-	C.sg_update_image(sg_img, &tmp_sbc)
+	gfx.update_image(sg_img, &tmp_sbc)
 }
 
 /******************************************************************************
@@ -276,11 +276,11 @@ fn init_cube_glsl(mut app App) {
 		Vertex_t{ 1.0,  1.0, -1.0, c,  0, d},
 	]
 
-	mut vert_buffer_desc := C.sg_buffer_desc{label: c'cube-vertices'}
+	mut vert_buffer_desc := gfx.BufferDesc{label: c'cube-vertices'}
 	unsafe { C.memset(&vert_buffer_desc, 0, sizeof(vert_buffer_desc)) }
 
 	vert_buffer_desc.size = usize(vertices.len * int(sizeof(Vertex_t)))
-	vert_buffer_desc.data = C.sg_range{
+	vert_buffer_desc.data = gfx.Range{
 		ptr: vertices.data
 		size: usize(vertices.len * int(sizeof(Vertex_t)))
 	}
@@ -299,11 +299,11 @@ fn init_cube_glsl(mut app App) {
 		22, 21, 20,    23, 22, 20
 	]
 
-	mut index_buffer_desc := C.sg_buffer_desc{label: c'cube-indices'}
+	mut index_buffer_desc := gfx.BufferDesc{label: c'cube-indices'}
 	unsafe { C.memset(&index_buffer_desc, 0, sizeof(index_buffer_desc)) }
 
 	index_buffer_desc.size = usize(indices.len * int(sizeof(u16)))
-	index_buffer_desc.data = C.sg_range{
+	index_buffer_desc.data = gfx.Range{
 		ptr: indices.data
 		size: usize(indices.len * int(sizeof(u16)))
 	}
@@ -314,7 +314,7 @@ fn init_cube_glsl(mut app App) {
 	// create shader
 	shader := gfx.make_shader(C.cube_shader_desc(C.sg_query_backend()))
 
-	mut pipdesc := C.sg_pipeline_desc{}
+	mut pipdesc := gfx.PipelineDesc{}
 	unsafe { C.memset(&pipdesc, 0, sizeof(pipdesc)) }
 
 	pipdesc.layout.buffers[0].stride = int(sizeof(Vertex_t))
@@ -327,9 +327,9 @@ fn init_cube_glsl(mut app App) {
 	pipdesc.shader = shader
 	pipdesc.index_type = .uint16
 
-	pipdesc.depth = C.sg_depth_state{
+	pipdesc.depth = gfx.DepthState{
 		write_enabled: true
-		compare: gfx.CompareFunc(C.SG_COMPAREFUNC_LESS_EQUAL)
+		compare: .less_equal
 	}
 	pipdesc.cull_mode = .back
 
@@ -366,7 +366,7 @@ fn draw_cube_glsl(app App) {
 	//***************
 	// passing the view matrix as uniform
 	// res is a 4x4 matrix of f32 thus: 4*16 byte of size
-	vs_uniforms_range := C.sg_range{
+	vs_uniforms_range := gfx.Range{
 		ptr: &tr_matrix
 		size: usize(4 * 16)
 	}
@@ -380,7 +380,7 @@ fn draw_cube_glsl(app App) {
 		time_ticks, /* time as f32 */
 		0 /* padding 4 Bytes == 1 f32 */,
 	]!
-	fs_uniforms_range := C.sg_range{
+	fs_uniforms_range := gfx.Range{
 		ptr: unsafe { &text_res }
 		size: usize(4 * 4)
 	}
@@ -457,16 +457,16 @@ fn frame(mut app App) {
 	app.gg.end()
 
 	// clear
-	mut color_action := C.sg_color_attachment_action{
+	mut color_action := gfx.ColorAttachmentAction{
 		action: gfx.Action(C.SG_ACTION_DONTCARE) // C.SG_ACTION_CLEAR)
-		value: C.sg_color{
+		value: gfx.Color{
 			r: 1.0
 			g: 1.0
 			b: 1.0
 			a: 1.0
 		}
 	}
-	mut pass_action := C.sg_pass_action{}
+	mut pass_action := gfx.PassAction{}
 	pass_action.colors[0] = color_action
 	gfx.begin_default_pass(&pass_action, ws.width, ws.height)
 
@@ -492,21 +492,21 @@ fn my_init(mut app App) {
 	sgl.setup(&sgl_desc)
 
 	// 3d pipeline
-	mut pipdesc := C.sg_pipeline_desc{}
+	mut pipdesc := gfx.PipelineDesc{}
 	unsafe { C.memset(&pipdesc, 0, sizeof(pipdesc)) }
 
-	color_state := C.sg_color_state{
-		blend: C.sg_blend_state{
+	color_state := gfx.ColorState{
+		blend: gfx.BlendState{
 			enabled: true
-			src_factor_rgb: gfx.BlendFactor(C.SG_BLENDFACTOR_SRC_ALPHA)
-			dst_factor_rgb: gfx.BlendFactor(C.SG_BLENDFACTOR_ONE_MINUS_SRC_ALPHA)
+			src_factor_rgb: .src_alpha
+			dst_factor_rgb: .one_minus_src_alpha
 		}
 	}
 	pipdesc.colors[0] = color_state
 
-	pipdesc.depth = C.sg_depth_state{
+	pipdesc.depth = gfx.DepthState{
 		write_enabled: true
-		compare: gfx.CompareFunc(C.SG_COMPAREFUNC_LESS_EQUAL)
+		compare: .less_equal
 	}
 	pipdesc.cull_mode = .back
 

--- a/examples/sokol/03_march_tracing_glsl/rt_glsl.v
+++ b/examples/sokol/03_march_tracing_glsl/rt_glsl.v
@@ -27,7 +27,7 @@ import time
 #flag -I @VMODROOT/.
 #include "rt_glsl.h" # Should be generated with `v shader .` (see the instructions at the top of this file)
 
-fn C.rt_shader_desc(gfx.Backend) &C.sg_shader_desc
+fn C.rt_shader_desc(gfx.Backend) &gfx.ShaderDesc
 
 const (
 	win_width  = 800
@@ -38,15 +38,15 @@ const (
 struct App {
 mut:
 	gg          &gg.Context
-	texture     C.sg_image
+	texture     gfx.Image
 	init_flag   bool
 	frame_count int
 
 	mouse_x int = -1
 	mouse_y int = -1
 	// glsl
-	cube_pip_glsl C.sg_pipeline
-	cube_bind     C.sg_bindings
+	cube_pip_glsl gfx.Pipeline
+	cube_bind     gfx.Bindings
 	// time
 	ticks i64
 }
@@ -54,9 +54,9 @@ mut:
 /******************************************************************************
 * Texture functions
 ******************************************************************************/
-fn create_texture(w int, h int, buf &byte) C.sg_image {
+fn create_texture(w int, h int, buf &byte) gfx.Image {
 	sz := w * h * 4
-	mut img_desc := C.sg_image_desc{
+	mut img_desc := gfx.ImageDesc{
 		width: w
 		height: h
 		num_mipmaps: 0
@@ -69,28 +69,28 @@ fn create_texture(w int, h int, buf &byte) C.sg_image {
 		d3d11_texture: 0
 	}
 	// comment if .dynamic is enabled
-	img_desc.data.subimage[0][0] = C.sg_range{
+	img_desc.data.subimage[0][0] = gfx.Range{
 		ptr: buf
 		size: usize(sz)
 	}
 
-	sg_img := C.sg_make_image(&img_desc)
+	sg_img := gfx.make_image(&img_desc)
 	return sg_img
 }
 
-fn destroy_texture(sg_img C.sg_image) {
-	C.sg_destroy_image(sg_img)
+fn destroy_texture(sg_img gfx.Image) {
+	gfx.destroy_image(sg_img)
 }
 
 // Use only if usage: .dynamic is enabled
-fn update_text_texture(sg_img C.sg_image, w int, h int, buf &byte) {
+fn update_text_texture(sg_img gfx.Image, w int, h int, buf &byte) {
 	sz := w * h * 4
-	mut tmp_sbc := C.sg_image_data{}
-	tmp_sbc.subimage[0][0] = C.sg_range{
+	mut tmp_sbc := gfx.ImageData{}
+	tmp_sbc.subimage[0][0] = gfx.Range{
 		ptr: buf
 		size: usize(sz)
 	}
-	C.sg_update_image(sg_img, &tmp_sbc)
+	gfx.update_image(sg_img, &tmp_sbc)
 }
 
 /******************************************************************************
@@ -155,11 +155,11 @@ fn init_cube_glsl(mut app App) {
 		Vertex_t{ 1.0,  1.0, -1.0, c,  0, d},
 	]
 
-	mut vert_buffer_desc := C.sg_buffer_desc{label: c'cube-vertices'}
+	mut vert_buffer_desc := gfx.BufferDesc{label: c'cube-vertices'}
 	unsafe { C.memset(&vert_buffer_desc, 0, sizeof(vert_buffer_desc)) }
 
 	vert_buffer_desc.size = usize(vertices.len * int(sizeof(Vertex_t)))
-	vert_buffer_desc.data = C.sg_range{
+	vert_buffer_desc.data = gfx.Range{
 		ptr: vertices.data
 		size: usize(vertices.len * int(sizeof(Vertex_t)))
 	}
@@ -177,11 +177,11 @@ fn init_cube_glsl(mut app App) {
 			22,	21,	20,		23,	22,	20,
 	]
 
-	mut index_buffer_desc := C.sg_buffer_desc{label: c'cube-indices'}
+	mut index_buffer_desc := gfx.BufferDesc{label: c'cube-indices'}
 	unsafe {C.memset(&index_buffer_desc, 0, sizeof(index_buffer_desc))}
 
 	index_buffer_desc.size = usize(indices.len * int(sizeof(u16)))
-	index_buffer_desc.data = C.sg_range{
+	index_buffer_desc.data = gfx.Range{
 		ptr: indices.data
 		size: usize(indices.len * int(sizeof(u16)))
 	}
@@ -192,7 +192,7 @@ fn init_cube_glsl(mut app App) {
 	// create shader
 	shader := gfx.make_shader(C.rt_shader_desc(C.sg_query_backend()))
 
-	mut pipdesc := C.sg_pipeline_desc{}
+	mut pipdesc := gfx.PipelineDesc{}
 	unsafe { C.memset(&pipdesc, 0, sizeof(pipdesc)) }
 	pipdesc.layout.buffers[0].stride = int(sizeof(Vertex_t))
 
@@ -205,9 +205,9 @@ fn init_cube_glsl(mut app App) {
 	pipdesc.shader = shader
 	pipdesc.index_type = .uint16
 
-	pipdesc.depth = C.sg_depth_state{
+	pipdesc.depth = gfx.DepthState{
 		write_enabled: true
-		compare: gfx.CompareFunc(C.SG_COMPAREFUNC_LESS_EQUAL)
+		compare: .less_equal
 	}
 	pipdesc.cull_mode = .back
 
@@ -264,7 +264,7 @@ fn draw_cube_glsl(app App) {
 	// *** vertex shadeer uniforms ***
 	// passing the view matrix as uniform
 	// res is a 4x4 matrix of f32 thus: 4*16 byte of size
-	vs_uniforms_range := C.sg_range{
+	vs_uniforms_range := gfx.Range{
 		ptr: &tr_matrix
 		size: usize(4 * 16)
 	}
@@ -282,7 +282,7 @@ fn draw_cube_glsl(app App) {
 		0,
 		0 // padding bytes , see "fs_params" struct paddings in rt_glsl.h
 	]!
-	fs_uniforms_range := C.sg_range{
+	fs_uniforms_range := gfx.Range{
 		ptr: unsafe { &tmp_fs_params }
 		size: usize(sizeof(tmp_fs_params))
 	}
@@ -298,9 +298,9 @@ fn frame(mut app App) {
 	ws := gg.window_size_real_pixels()
 
 	// clear
-	mut color_action := C.sg_color_attachment_action{
+	mut color_action := gfx.ColorAttachmentAction{
 		action: gfx.Action(C.SG_ACTION_CLEAR)
-		value: C.sg_color{
+		value: gfx.Color{
 			r: 0.0
 			g: 0.0
 			b: 0.0
@@ -308,7 +308,7 @@ fn frame(mut app App) {
 		}
 	}
 
-	mut pass_action := C.sg_pass_action{}
+	mut pass_action := gfx.PassAction{}
 	pass_action.colors[0] = color_action
 	gfx.begin_default_pass(&pass_action, ws.width, ws.height)
 

--- a/examples/sokol/03_march_tracing_glsl/rt_glsl.v
+++ b/examples/sokol/03_march_tracing_glsl/rt_glsl.v
@@ -299,7 +299,7 @@ fn frame(mut app App) {
 
 	// clear
 	mut color_action := gfx.ColorAttachmentAction{
-		action: gfx.Action(C.SG_ACTION_CLEAR)
+		action: .clear
 		value: gfx.Color{
 			r: 0.0
 			g: 0.0

--- a/examples/sokol/04_multi_shader_glsl/rt_glsl.v
+++ b/examples/sokol/04_multi_shader_glsl/rt_glsl.v
@@ -26,8 +26,8 @@ import time
 #flag -I @VMODROOT/.
 #include "rt_glsl_march.h" # Should be generated with `v shader .` (see the instructions at the top of this file)
 #include "rt_glsl_puppy.h" # Should be generated with `v shader .` (see the instructions at the top of this file)
-fn C.rt_march_shader_desc(gfx.Backend) &C.sg_shader_desc
-fn C.rt_puppy_shader_desc(gfx.Backend) &C.sg_shader_desc
+fn C.rt_march_shader_desc(gfx.Backend) &gfx.ShaderDesc
+fn C.rt_puppy_shader_desc(gfx.Backend) &gfx.ShaderDesc
 
 const (
 	win_width  = 800
@@ -38,17 +38,17 @@ const (
 struct App {
 mut:
 	gg          &gg.Context
-	texture     C.sg_image
+	texture     gfx.Image
 	init_flag   bool
 	frame_count int
 	mouse_x     int = -1
 	mouse_y     int = -1
 	mouse_down  bool
 	// glsl
-	cube_pip_glsl   C.sg_pipeline
-	cube_bind       C.sg_bindings
-	pipe map[string]C.sg_pipeline
-	bind map[string]C.sg_bindings
+	cube_pip_glsl   gfx.Pipeline
+	cube_bind       gfx.Bindings
+	pipe map[string]gfx.Pipeline
+	bind map[string]gfx.Bindings
 	// time
 	ticks i64
 }
@@ -56,9 +56,9 @@ mut:
 /******************************************************************************
 * Texture functions
 ******************************************************************************/
-fn create_texture(w int, h int, buf byteptr) C.sg_image {
+fn create_texture(w int, h int, buf byteptr) gfx.Image {
 	sz := w * h * 4
-	mut img_desc := C.sg_image_desc{
+	mut img_desc := gfx.ImageDesc{
 		width: w
 		height: h
 		num_mipmaps: 0
@@ -71,28 +71,28 @@ fn create_texture(w int, h int, buf byteptr) C.sg_image {
 		d3d11_texture: 0
 	}
 	// comment if .dynamic is enabled
-	img_desc.data.subimage[0][0] = C.sg_range{
+	img_desc.data.subimage[0][0] = gfx.Range{
 		ptr: buf
 		size: usize(sz)
 	}
 
-	sg_img := C.sg_make_image(&img_desc)
+	sg_img := gfx.make_image(&img_desc)
 	return sg_img
 }
 
-fn destroy_texture(sg_img C.sg_image) {
-	C.sg_destroy_image(sg_img)
+fn destroy_texture(sg_img gfx.Image) {
+	gfx.destroy_image(sg_img)
 }
 
 // Use only if usage: .dynamic is enabled
-fn update_text_texture(sg_img C.sg_image, w int, h int, buf byteptr) {
+fn update_text_texture(sg_img gfx.Image, w int, h int, buf byteptr) {
 	sz := w * h * 4
-	mut tmp_sbc := C.sg_image_data{}
-	tmp_sbc.subimage[0][0] = C.sg_range{
+	mut tmp_sbc := gfx.ImageData{}
+	tmp_sbc.subimage[0][0] = gfx.Range{
 		ptr: buf
 		size: usize(sz)
 	}
-	C.sg_update_image(sg_img, &tmp_sbc)
+	gfx.update_image(sg_img, &tmp_sbc)
 }
 
 /******************************************************************************
@@ -157,10 +157,10 @@ fn init_cube_glsl_m(mut app App) {
 		Vertex_t{ 1.0,  1.0, -1.0, c,  0, d},
 	]
 
-	mut vert_buffer_desc := C.sg_buffer_desc{label: c'cube-vertices'}
+	mut vert_buffer_desc := gfx.BufferDesc{label: c'cube-vertices'}
 	unsafe { C.memset(&vert_buffer_desc, 0, sizeof(vert_buffer_desc)) }
 	vert_buffer_desc.size = usize(vertices.len * int(sizeof(Vertex_t)))
-	vert_buffer_desc.data = C.sg_range{
+	vert_buffer_desc.data = gfx.Range{
 		ptr: vertices.data
 		size: usize(vertices.len * int(sizeof(Vertex_t)))
 	}
@@ -179,10 +179,10 @@ fn init_cube_glsl_m(mut app App) {
 */
 	]
 
-	mut index_buffer_desc := C.sg_buffer_desc{label: c'cube-indices'}
+	mut index_buffer_desc := gfx.BufferDesc{label: c'cube-indices'}
 	unsafe { C.memset(&index_buffer_desc, 0, sizeof(index_buffer_desc)) }
 	index_buffer_desc.size = usize(indices.len * int(sizeof(u16)))
-	index_buffer_desc.data = C.sg_range{
+	index_buffer_desc.data = gfx.Range{
 		ptr: indices.data
 		size: usize(indices.len * int(sizeof(u16)))
 	}
@@ -192,7 +192,7 @@ fn init_cube_glsl_m(mut app App) {
 	// create shader
 	shader := gfx.make_shader(C.rt_march_shader_desc(C.sg_query_backend()))
 
-	mut pipdesc := C.sg_pipeline_desc{}
+	mut pipdesc := gfx.PipelineDesc{}
 	unsafe { C.memset(&pipdesc, 0, sizeof(pipdesc)) }
 	pipdesc.layout.buffers[0].stride = int(sizeof(Vertex_t))
 
@@ -205,14 +205,14 @@ fn init_cube_glsl_m(mut app App) {
 	pipdesc.shader = shader
 	pipdesc.index_type = .uint16
 
-	pipdesc.depth = C.sg_depth_state{
+	pipdesc.depth = gfx.DepthState{
 		write_enabled: true
-		compare: gfx.CompareFunc(C.SG_COMPAREFUNC_LESS_EQUAL)
+		compare: .less_equal
 	}
 	pipdesc.cull_mode = .back
 	pipdesc.label = 'glsl_shader pipeline'.str
 
-	mut bind := C.sg_bindings{}
+	mut bind := gfx.Bindings{}
 	unsafe { C.memset(&bind, 0, sizeof(bind)) }
 	bind.vertex_buffers[0] = vbuf
 	bind.index_buffer = ibuf
@@ -263,10 +263,10 @@ fn init_cube_glsl_p(mut app App) {
 		Vertex_t{ 1.0,  1.0, -1.0, c,  0, d},
 	]
 
-	mut vert_buffer_desc := C.sg_buffer_desc{label: c'cube-vertices'}
+	mut vert_buffer_desc := gfx.BufferDesc{label: c'cube-vertices'}
 	unsafe { C.memset(&vert_buffer_desc, 0, sizeof(vert_buffer_desc)) }
 	vert_buffer_desc.size = usize(vertices.len * int(sizeof(Vertex_t)))
-	vert_buffer_desc.data = C.sg_range{
+	vert_buffer_desc.data = gfx.Range{
 		ptr: vertices.data
 		size: usize(vertices.len * int(sizeof(Vertex_t)))
 	}
@@ -286,10 +286,10 @@ fn init_cube_glsl_p(mut app App) {
 
 	]
 
-	mut index_buffer_desc := C.sg_buffer_desc{label: c'cube-indices'}
+	mut index_buffer_desc := gfx.BufferDesc{label: c'cube-indices'}
 	unsafe { C.memset(&index_buffer_desc, 0, sizeof(index_buffer_desc)) }
 	index_buffer_desc.size = usize(indices.len * int(sizeof(u16)))
-	index_buffer_desc.data = C.sg_range{
+	index_buffer_desc.data = gfx.Range{
 		ptr: indices.data
 		size: usize(indices.len * int(sizeof(u16)))
 	}
@@ -299,7 +299,7 @@ fn init_cube_glsl_p(mut app App) {
 	// create shader
 	shader := gfx.make_shader(C.rt_puppy_shader_desc(C.sg_query_backend()))
 
-	mut pipdesc := C.sg_pipeline_desc{}
+	mut pipdesc := gfx.PipelineDesc{}
 	unsafe { C.memset(&pipdesc, 0, sizeof(pipdesc)) }
 	pipdesc.layout.buffers[0].stride = int(sizeof(Vertex_t))
 
@@ -312,15 +312,15 @@ fn init_cube_glsl_p(mut app App) {
 	pipdesc.shader = shader
 	pipdesc.index_type = .uint16
 
-	pipdesc.depth = C.sg_depth_state{
+	pipdesc.depth = gfx.DepthState{
 		write_enabled: true
-		compare: gfx.CompareFunc(C.SG_COMPAREFUNC_LESS_EQUAL)
+		compare: .less_equal
 	}
 	pipdesc.cull_mode = .back
 
 	pipdesc.label = 'glsl_shader pipeline'.str
 
-	mut bind := C.sg_bindings{}
+	mut bind := gfx.Bindings{}
 	unsafe { C.memset(&bind, 0, sizeof(bind)) }
 	bind.vertex_buffers[0] = vbuf
 	bind.index_buffer = ibuf
@@ -373,7 +373,7 @@ fn draw_cube_glsl_m(app App) {
 	// *** vertex shadeer uniforms ***
 	// passing the view matrix as uniform
 	// res is a 4x4 matrix of f32 thus: 4*16 byte of size
-	vs_uniforms_range := C.sg_range{
+	vs_uniforms_range := gfx.Range{
 		ptr: &tr_matrix
 		size: usize(4 * 16)
 	}
@@ -393,7 +393,7 @@ fn draw_cube_glsl_m(app App) {
 		0,
 		0 // padding bytes , see "fs_params" struct paddings in rt_glsl.h
 	]!
-	fs_uniforms_range := C.sg_range{
+	fs_uniforms_range := gfx.Range{
 		ptr: unsafe { &tmp_fs_params }
 		size: usize(sizeof(tmp_fs_params))
 	}
@@ -425,7 +425,7 @@ fn draw_cube_glsl_p(app App) {
 	// *** vertex shadeer uniforms ***
 	// passing the view matrix as uniform
 	// res is a 4x4 matrix of f32 thus: 4*16 byte of size
-	vs_uniforms_range := C.sg_range{
+	vs_uniforms_range := gfx.Range{
 		ptr: &tr_matrix
 		size: usize(4 * 16)
 	}
@@ -445,7 +445,7 @@ fn draw_cube_glsl_p(app App) {
 		0,
 		0 // padding bytes , see "fs_params" struct paddings in rt_glsl.h
 	]!
-	fs_uniforms_range := C.sg_range{
+	fs_uniforms_range := gfx.Range{
 		ptr: unsafe { &tmp_fs_params }
 		size: usize(sizeof(tmp_fs_params))
 	}
@@ -477,16 +477,16 @@ fn frame(mut app App) {
 	ws := gg.window_size_real_pixels()
 
 	// clear
-	mut color_action := C.sg_color_attachment_action{
+	mut color_action := gfx.ColorAttachmentAction{
 		action: gfx.Action(C.SG_ACTION_CLEAR)
-		value: C.sg_color{
+		value: gfx.Color{
 			r: 0.0
 			g: 0.0
 			b: 0.0
 			a: 1.0
 		}
 	}
-	mut pass_action := C.sg_pass_action{}
+	mut pass_action := gfx.PassAction{}
 	pass_action.colors[0] = color_action
 	gfx.begin_default_pass(&pass_action, ws.width, ws.height)
 

--- a/examples/sokol/04_multi_shader_glsl/rt_glsl.v
+++ b/examples/sokol/04_multi_shader_glsl/rt_glsl.v
@@ -478,7 +478,7 @@ fn frame(mut app App) {
 
 	// clear
 	mut color_action := gfx.ColorAttachmentAction{
-		action: gfx.Action(C.SG_ACTION_CLEAR)
+		action: .clear
 		value: gfx.Color{
 			r: 0.0
 			g: 0.0

--- a/examples/sokol/05_instancing_glsl/rt_glsl.v
+++ b/examples/sokol/05_instancing_glsl/rt_glsl.v
@@ -372,7 +372,7 @@ fn frame(mut app App) {
 
 	// clear
 	mut color_action := gfx.ColorAttachmentAction{
-		action: gfx.Action(C.SG_ACTION_CLEAR)
+		action: .clear
 		value: gfx.Color{
 			r: 0.0
 			g: 0.0

--- a/examples/sokol/05_instancing_glsl/rt_glsl.v
+++ b/examples/sokol/05_instancing_glsl/rt_glsl.v
@@ -33,7 +33,7 @@ const (
 struct App {
 mut:
 	gg            &gg.Context
-	texture       C.sg_image
+	texture       gfx.Image
 	init_flag     bool
 	frame_count   int
 
@@ -42,11 +42,11 @@ mut:
 	mouse_down    bool
 
 	// glsl
-	cube_pip_glsl C.sg_pipeline
-	cube_bind     C.sg_bindings
+	cube_pip_glsl gfx.Pipeline
+	cube_bind     gfx.Bindings
 
-	pipe          map[string]C.sg_pipeline
-	bind          map[string]C.sg_bindings
+	pipe          map[string]gfx.Pipeline
+	bind          map[string]gfx.Bindings
 
 	// time
 	ticks         i64
@@ -64,14 +64,14 @@ mut:
 ******************************************************************************/
 #flag -I @VMODROOT/.
 #include "rt_glsl_instancing.h" # Should be generated with `v shader .` (see the instructions at the top of this file)
-fn C.instancing_shader_desc(gfx.Backend) &C.sg_shader_desc
+fn C.instancing_shader_desc(gfx.Backend) &gfx.ShaderDesc
 
 /******************************************************************************
 * Texture functions
 ******************************************************************************/
-fn create_texture(w int, h int, buf byteptr) C.sg_image{
+fn create_texture(w int, h int, buf byteptr) gfx.Image{
 	sz := w * h * 4
-	mut img_desc := C.sg_image_desc{
+	mut img_desc := gfx.ImageDesc{
 		width:         w
 		height:        h
 		num_mipmaps:   0
@@ -84,28 +84,28 @@ fn create_texture(w int, h int, buf byteptr) C.sg_image{
 		d3d11_texture: 0
 	}
 	// comment if .dynamic is enabled
-	img_desc.data.subimage[0][0] = C.sg_range{
+	img_desc.data.subimage[0][0] = gfx.Range{
 		ptr:  buf
 		size: usize(sz)
 	}
 
-	sg_img := C.sg_make_image(&img_desc)
+	sg_img := gfx.make_image(&img_desc)
 	return sg_img
 }
 
-fn destroy_texture(sg_img C.sg_image){
-	C.sg_destroy_image(sg_img)
+fn destroy_texture(sg_img gfx.Image){
+	gfx.destroy_image(sg_img)
 }
 
 // Use only if usage: .dynamic is enabled
-fn update_text_texture(sg_img C.sg_image, w int, h int, buf byteptr){
+fn update_text_texture(sg_img gfx.Image, w int, h int, buf byteptr){
 	sz := w * h * 4
-	mut tmp_sbc := C.sg_image_data{}
-	tmp_sbc.subimage[0][0] = C.sg_range{
+	mut tmp_sbc := gfx.ImageData{}
+	tmp_sbc.subimage[0][0] = gfx.Range{
 		ptr: buf
 		size: usize(sz)
 	}
-	C.sg_update_image(sg_img, &tmp_sbc)
+	gfx.update_image(sg_img, &tmp_sbc)
 }
 
 /******************************************************************************
@@ -172,10 +172,10 @@ fn init_cube_glsl_i(mut app App) {
 		Vertex_t{ 1.0,  1.0, -1.0, c,  0, d},
 	]
 
-	mut vert_buffer_desc := C.sg_buffer_desc{label: c'cube-vertices'}
+	mut vert_buffer_desc := gfx.BufferDesc{label: c'cube-vertices'}
 	unsafe {C.memset(&vert_buffer_desc, 0, sizeof(vert_buffer_desc))}
 	vert_buffer_desc.size = usize(vertices.len * int(sizeof(Vertex_t)))
-	vert_buffer_desc.data = C.sg_range{
+	vert_buffer_desc.data = gfx.Range{
 		ptr: vertices.data
 		size: usize(vertices.len * int(sizeof(Vertex_t)))
 	}
@@ -183,7 +183,7 @@ fn init_cube_glsl_i(mut app App) {
 	vbuf := gfx.make_buffer(&vert_buffer_desc)
 
 	/* create an instance buffer for the cube */
-	mut inst_buffer_desc := C.sg_buffer_desc{label: c'instance-data'}
+	mut inst_buffer_desc := gfx.BufferDesc{label: c'instance-data'}
 	unsafe {C.memset(&inst_buffer_desc, 0, sizeof(inst_buffer_desc))}
 
 	inst_buffer_desc.size = usize(num_inst * int(sizeof(m4.Vec4)))
@@ -202,10 +202,10 @@ fn init_cube_glsl_i(mut app App) {
 		22, 21, 20,    23, 22, 20
 	]
 
-	mut index_buffer_desc := C.sg_buffer_desc{label: c'cube-indices'}
+	mut index_buffer_desc := gfx.BufferDesc{label: c'cube-indices'}
 	unsafe {C.memset(&index_buffer_desc, 0, sizeof(index_buffer_desc))}
 	index_buffer_desc.size    = usize(indices.len * int(sizeof(u16)))
-	index_buffer_desc.data = C.sg_range{
+	index_buffer_desc.data = gfx.Range{
 		ptr: indices.data
 		size: usize(indices.len * int(sizeof(u16)))
 	}
@@ -215,7 +215,7 @@ fn init_cube_glsl_i(mut app App) {
 	/* create shader */
 	shader := gfx.make_shader(C.instancing_shader_desc(C.sg_query_backend()))
 
-	mut pipdesc := C.sg_pipeline_desc{}
+	mut pipdesc := gfx.PipelineDesc{}
 	unsafe {C.memset(&pipdesc, 0, sizeof(pipdesc))}
 	pipdesc.layout.buffers[0].stride = int(sizeof(Vertex_t))
 
@@ -237,15 +237,15 @@ fn init_cube_glsl_i(mut app App) {
 	pipdesc.shader = shader
 	pipdesc.index_type = .uint16
 
-	pipdesc.depth = C.sg_depth_state{
+	pipdesc.depth = gfx.DepthState{
 		write_enabled: true
-		compare: gfx.CompareFunc(C.SG_COMPAREFUNC_LESS_EQUAL)
+		compare: .less_equal
 	}
 	pipdesc.cull_mode = .back
 
 	pipdesc.label = "glsl_shader pipeline".str
 
-	mut bind := C.sg_bindings{}
+	mut bind := gfx.Bindings{}
 	unsafe {C.memset(&bind, 0, sizeof(bind))}
 	bind.vertex_buffers[0] = vbuf      // vertex buffer
 	bind.vertex_buffers[1] = inst_buf  // instance buffer
@@ -310,7 +310,7 @@ fn draw_cube_glsl_i(mut app App){
 		spare_param := f32(index % 10)
 		app.inst_pos[index] = m4.Vec4{e:[f32((x - cx - app.camera_x) * cube_size),y ,f32( (z - cz - app.camera_z) * cube_size),spare_param]!}
 	}
-	range := C.sg_range{
+	range := gfx.Range{
 		ptr: unsafe { &app.inst_pos }
 		size: usize(num_inst * int(sizeof(m4.Vec4)))
 	}
@@ -320,7 +320,7 @@ fn draw_cube_glsl_i(mut app App){
 	// *** vertex shadeer uniforms ***
 	// passing the view matrix as uniform
 	// res is a 4x4 matrix of f32 thus: 4*16 byte of size
-	vs_uniforms_range := C.sg_range{
+	vs_uniforms_range := gfx.Range{
 		ptr: unsafe { &tr_matrix }
 		size: usize(4 * 16)
 	}
@@ -338,7 +338,7 @@ fn draw_cube_glsl_i(mut app App){
 		app.frame_count,           // frame count
 		0,0                        // padding bytes , see "fs_params" struct paddings in rt_glsl.h
 	]!
-	fs_uniforms_range := C.sg_range{
+	fs_uniforms_range := gfx.Range{
 		ptr: unsafe { &tmp_fs_params }
 		size: usize(sizeof(tmp_fs_params))
 	}
@@ -371,16 +371,16 @@ fn frame(mut app App) {
 	ws := gg.window_size_real_pixels()
 
 	// clear
-	mut color_action := C.sg_color_attachment_action{
+	mut color_action := gfx.ColorAttachmentAction{
 		action: gfx.Action(C.SG_ACTION_CLEAR)
-		value: C.sg_color{
+		value: gfx.Color{
 			r: 0.0
 			g: 0.0
 			b: 0.0
 			a: 1.0
 		}
 	}
-	mut pass_action := C.sg_pass_action{}
+	mut pass_action := gfx.PassAction{}
 	pass_action.colors[0] = color_action
 	gfx.begin_default_pass(&pass_action, ws.width, ws.height)
 

--- a/examples/sokol/06_obj_viewer/modules/obj/struct.v
+++ b/examples/sokol/06_obj_viewer/modules/obj/struct.v
@@ -11,6 +11,7 @@
 module obj
 
 import gg.m4
+import sokol.gfx
 
 // part struct mantain the fae indexes list
 pub struct Part {

--- a/examples/sokol/06_obj_viewer/modules/obj/struct.v
+++ b/examples/sokol/06_obj_viewer/modules/obj/struct.v
@@ -32,8 +32,8 @@ pub mut:
 // render data used for the rendering
 pub struct Render_data {
 pub mut:
-	pipeline C.sg_pipeline
-	bind     C.sg_bindings
+	pipeline gfx.Pipeline
+	bind     gfx.Bindings
 	n_vert   u32
 	material string
 }
@@ -50,7 +50,7 @@ pub mut:
 	part          []Part                // parts of the ObjPart
 	mat           []Material            // list of the materials of the ObjPart
 	mat_map       map[string]int        // maping material name to its material index
-	texture       map[string]C.sg_image // GPU loaded texture map
+	texture       map[string]gfx.Image // GPU loaded texture map
 	material_file string // .mtl file name for the .obj
 
 	rend_data []Render_data // render data used for the rendering

--- a/examples/sokol/06_obj_viewer/modules/obj/struct.v
+++ b/examples/sokol/06_obj_viewer/modules/obj/struct.v
@@ -47,9 +47,9 @@ pub mut:
 	vt []m4.Vec4 // textures
 
 	name          string
-	part          []Part                // parts of the ObjPart
-	mat           []Material            // list of the materials of the ObjPart
-	mat_map       map[string]int        // maping material name to its material index
+	part          []Part               // parts of the ObjPart
+	mat           []Material           // list of the materials of the ObjPart
+	mat_map       map[string]int       // maping material name to its material index
 	texture       map[string]gfx.Image // GPU loaded texture map
 	material_file string // .mtl file name for the .obj
 

--- a/examples/sokol/06_obj_viewer/show_obj.v
+++ b/examples/sokol/06_obj_viewer/show_obj.v
@@ -150,7 +150,7 @@ fn frame(mut app App) {
 
 	// clear
 	mut color_action := gfx.ColorAttachmentAction{
-		action: gfx.Action(C.SG_ACTION_CLEAR)
+		action: .clear
 		value: gfx.Color{
 			r: 0.0
 			g: 0.0

--- a/examples/sokol/06_obj_viewer/show_obj.v
+++ b/examples/sokol/06_obj_viewer/show_obj.v
@@ -35,7 +35,7 @@ import obj
 #flag -I @VMODROOT/.
 #include "gouraud.h" # Should be generated with `v shader .` (see the instructions at the top of this file)
 
-fn C.gouraud_shader_desc(gfx.Backend) &C.sg_shader_desc
+fn C.gouraud_shader_desc(gfx.Backend) &gfx.ShaderDesc
 
 const (
 	win_width  = 600
@@ -46,7 +46,7 @@ const (
 struct App {
 mut:
 	gg          &gg.Context
-	texture     C.sg_image
+	texture     gfx.Image
 	init_flag   bool
 	frame_count int
 
@@ -149,9 +149,9 @@ fn frame(mut app App) {
 	ws := gg.window_size_real_pixels()
 
 	// clear
-	mut color_action := C.sg_color_attachment_action{
+	mut color_action := gfx.ColorAttachmentAction{
 		action: gfx.Action(C.SG_ACTION_CLEAR)
-		value: C.sg_color{
+		value: gfx.Color{
 			r: 0.0
 			g: 0.0
 			b: 0.0
@@ -159,7 +159,7 @@ fn frame(mut app App) {
 		}
 	}
 
-	mut pass_action := C.sg_pass_action{}
+	mut pass_action := gfx.PassAction{}
 	pass_action.colors[0] = color_action
 	gfx.begin_default_pass(&pass_action, ws.width, ws.height)
 

--- a/examples/sokol/drawing.v
+++ b/examples/sokol/drawing.v
@@ -4,7 +4,7 @@ import sokol.gfx
 import sokol.sgl
 
 struct AppState {
-	pass_action C.sg_pass_action
+	pass_action gfx.PassAction
 }
 
 const (
@@ -27,7 +27,7 @@ fn main() {
 }
 
 fn init(user_data voidptr) {
-	desc := sapp.create_desc() // C.sg_desc{
+	desc := sapp.create_desc() // gfx.Desc{
 	gfx.setup(&desc)
 	sgl_desc := C.sgl_desc_t{}
 	sgl.setup(&sgl_desc)

--- a/examples/sokol/fonts.v
+++ b/examples/sokol/fonts.v
@@ -16,7 +16,7 @@ mut:
 [console]
 fn main() {
 	mut color_action := gfx.ColorAttachmentAction{
-		action: gfx.Action(C.SG_ACTION_CLEAR)
+		action: .clear
 		value: gfx.Color{
 			r: 0.3
 			g: 0.3

--- a/examples/sokol/fonts.v
+++ b/examples/sokol/fonts.v
@@ -8,23 +8,23 @@ import os
 
 struct AppState {
 mut:
-	pass_action C.sg_pass_action
+	pass_action gfx.PassAction
 	fons        &fontstash.Context
 	font_normal int
 }
 
 [console]
 fn main() {
-	mut color_action := C.sg_color_attachment_action{
+	mut color_action := gfx.ColorAttachmentAction{
 		action: gfx.Action(C.SG_ACTION_CLEAR)
-		value: C.sg_color{
+		value: gfx.Color{
 			r: 0.3
 			g: 0.3
 			b: 0.32
 			a: 1.0
 		}
 	}
-	mut pass_action := C.sg_pass_action{}
+	mut pass_action := gfx.PassAction{}
 	pass_action.colors[0] = color_action
 	state := &AppState{
 		pass_action: pass_action

--- a/examples/sokol/freetype_raven.v
+++ b/examples/sokol/freetype_raven.v
@@ -64,7 +64,7 @@ mut:
 [console]
 fn main() {
 	mut color_action := gfx.ColorAttachmentAction{
-		action: gfx.Action(C.SG_ACTION_CLEAR)
+		action: .clear
 		value: gfx.Color{
 			r: 1.0
 			g: 1.0

--- a/examples/sokol/freetype_raven.v
+++ b/examples/sokol/freetype_raven.v
@@ -55,7 +55,7 @@ Let my heart be still a moment and this mystery explore;—
 
 struct AppState {
 mut:
-	pass_action C.sg_pass_action
+	pass_action gfx.PassAction
 	fons        &fontstash.Context
 	font_normal int
 	inited      bool
@@ -63,16 +63,16 @@ mut:
 
 [console]
 fn main() {
-	mut color_action := C.sg_color_attachment_action{
+	mut color_action := gfx.ColorAttachmentAction{
 		action: gfx.Action(C.SG_ACTION_CLEAR)
-		value: C.sg_color{
+		value: gfx.Color{
 			r: 1.0
 			g: 1.0
 			b: 1.0
 			a: 1.0
 		}
 	}
-	mut pass_action := C.sg_pass_action{}
+	mut pass_action := gfx.PassAction{}
 	pass_action.colors[0] = color_action
 	state := &AppState{
 		pass_action: pass_action

--- a/examples/sokol/particles/particles.v
+++ b/examples/sokol/particles/particles.v
@@ -24,7 +24,7 @@ fn main() {
 }
 
 struct App {
-	pass_action C.sg_pass_action
+	pass_action gfx.PassAction
 mut:
 	width     int
 	height    int
@@ -79,14 +79,14 @@ fn init(user_data voidptr) {
 		max_vertices: 50 * 65536
 	}
 	sgl.setup(&sgl_desc)
-	mut pipdesc := C.sg_pipeline_desc{}
+	mut pipdesc := gfx.PipelineDesc{}
 	unsafe { C.memset(&pipdesc, 0, sizeof(pipdesc)) }
 
-	color_state := C.sg_color_state{
-		blend: C.sg_blend_state{
+	color_state := gfx.ColorState{
+		blend: gfx.BlendState{
 			enabled: true
-			src_factor_rgb: gfx.BlendFactor(C.SG_BLENDFACTOR_SRC_ALPHA)
-			dst_factor_rgb: gfx.BlendFactor(C.SG_BLENDFACTOR_ONE_MINUS_SRC_ALPHA)
+			src_factor_rgb: .src_alpha
+			dst_factor_rgb: .one_minus_src_alpha
 		}
 	}
 	pipdesc.colors[0] = color_state

--- a/examples/ttf_font/example_ttf.v
+++ b/examples/ttf_font/example_ttf.v
@@ -2,6 +2,7 @@ import gg
 import gx
 import sokol.sapp
 import sokol.sgl
+import sokol.gfx
 import x.ttf
 import os
 
@@ -20,7 +21,7 @@ const (
 struct App_data {
 pub mut:
 	gg              &gg.Context
-	sg_img          C.sg_image
+	sg_img          gfx.Image
 	init_flag       bool
 	frame_c         int
 	tf              []ttf.TTF_File

--- a/examples/viewer/view.v
+++ b/examples/viewer/view.v
@@ -62,7 +62,7 @@ struct App {
 mut:
 	gg          &gg.Context
 	pip_viewer  C.sgl_pipeline
-	texture     C.sg_image
+	texture     gfx.Image
 	init_flag   bool
 	frame_count int
 	mouse_x     int = -1
@@ -102,7 +102,7 @@ mut:
 	font_path string // path to the temp font file
 	// logo
 	logo_path    string // path of the temp font logo
-	logo_texture C.sg_image
+	logo_texture gfx.Image
 	logo_w       int
 	logo_h       int
 	logo_ratio   f32 = 1.0
@@ -115,9 +115,9 @@ mut:
 * Texture functions
 *
 ******************************************************************************/
-fn create_texture(w int, h int, buf &u8) C.sg_image {
+fn create_texture(w int, h int, buf &u8) gfx.Image {
 	sz := w * h * 4
-	mut img_desc := C.sg_image_desc{
+	mut img_desc := gfx.ImageDesc{
 		width: w
 		height: h
 		num_mipmaps: 0
@@ -130,28 +130,28 @@ fn create_texture(w int, h int, buf &u8) C.sg_image {
 		d3d11_texture: 0
 	}
 	// comment if .dynamic is enabled
-	img_desc.data.subimage[0][0] = C.sg_range{
+	img_desc.data.subimage[0][0] = gfx.Range{
 		ptr: buf
 		size: usize(sz)
 	}
 
-	sg_img := C.sg_make_image(&img_desc)
+	sg_img := gfx.make_image(&img_desc)
 	return sg_img
 }
 
-fn destroy_texture(sg_img C.sg_image) {
-	C.sg_destroy_image(sg_img)
+fn destroy_texture(sg_img gfx.Image) {
+	gfx.destroy_image(sg_img)
 }
 
 // Use only if: .dynamic is enabled
-fn update_text_texture(sg_img C.sg_image, w int, h int, buf &byte) {
+fn update_text_texture(sg_img gfx.Image, w int, h int, buf &byte) {
 	sz := w * h * 4
-	mut tmp_sbc := C.sg_image_data{}
-	tmp_sbc.subimage[0][0] = C.sg_range{
+	mut tmp_sbc := gfx.ImageData{}
+	tmp_sbc.subimage[0][0] = gfx.Range{
 		ptr: buf
 		size: usize(sz)
 	}
-	C.sg_update_image(sg_img, &tmp_sbc)
+	gfx.update_image(sg_img, &tmp_sbc)
 }
 
 /******************************************************************************
@@ -225,7 +225,7 @@ pub fn read_bytes_from_file(file_path string) []byte {
 	return buffer
 }
 
-fn (mut app App) load_texture_from_buffer(buf voidptr, buf_len int) (C.sg_image, int, int) {
+fn (mut app App) load_texture_from_buffer(buf voidptr, buf_len int) (gfx.Image, int, int) {
 	// load image
 	stbi.set_flip_vertically_on_load(true)
 	img := stbi.load_from_memory(buf, buf_len) or {
@@ -240,7 +240,7 @@ fn (mut app App) load_texture_from_buffer(buf voidptr, buf_len int) (C.sg_image,
 	return res, int(img.width), int(img.height)
 }
 
-pub fn (mut app App) load_texture_from_file(file_name string) (C.sg_image, int, int) {
+pub fn (mut app App) load_texture_from_file(file_name string) (gfx.Image, int, int) {
 	app.read_bytes(file_name)
 	return app.load_texture_from_buffer(app.mem_buf, app.mem_buf_size)
 }
@@ -315,21 +315,21 @@ fn app_init(mut app App) {
 	app.init_flag = true
 
 	// 3d pipeline
-	mut pipdesc := C.sg_pipeline_desc{}
+	mut pipdesc := gfx.PipelineDesc{}
 	unsafe { C.memset(&pipdesc, 0, sizeof(pipdesc)) }
 
-	color_state := C.sg_color_state{
-		blend: C.sg_blend_state{
+	color_state := gfx.ColorState{
+		blend: gfx.BlendState{
 			enabled: true
-			src_factor_rgb: gfx.BlendFactor(C.SG_BLENDFACTOR_SRC_ALPHA)
-			dst_factor_rgb: gfx.BlendFactor(C.SG_BLENDFACTOR_ONE_MINUS_SRC_ALPHA)
+			src_factor_rgb: .src_alpha
+			dst_factor_rgb: .one_minus_src_alpha
 		}
 	}
 	pipdesc.colors[0] = color_state
 
-	pipdesc.depth = C.sg_depth_state{
+	pipdesc.depth = gfx.DepthState{
 		write_enabled: true
-		compare: gfx.CompareFunc(C.SG_COMPAREFUNC_LESS_EQUAL)
+		compare: .less_equal
 	}
 	pipdesc.cull_mode = .back
 	app.pip_viewer = sgl.make_pipeline(&pipdesc)

--- a/examples/viewer/zip_container.v
+++ b/examples/viewer/zip_container.v
@@ -8,6 +8,7 @@
 *
 * TODO:
 **********************************************************************/
+import sokol.gfx
 import szip
 
 fn (mut il Item_list) scan_zip(path string, in_index int) ? {
@@ -46,7 +47,7 @@ fn (mut il Item_list) scan_zip(path string, in_index int) ? {
 	zp.close()
 }
 
-fn (mut app App) load_texture_from_zip() ?(C.sg_image, int, int) {
+fn (mut app App) load_texture_from_zip() ?(gfx.Image, int, int) {
 	item := app.item_list.lst[app.item_list.item_index]
 	// println("Load from zip [${item.path}]")
 

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -109,7 +109,7 @@ pub mut:
 	// will get set to 2.0 for retina, will remain 1.0 for normal
 	width       int
 	height      int
-	clear_pass  C.sg_pass_action
+	clear_pass  gfx.PassAction
 	window      sapp.Desc
 	timage_pip  C.sgl_pipeline
 	config      Config
@@ -139,7 +139,7 @@ fn gg_init_sokol_window(user_data voidptr) {
 	mut g := unsafe { &Context(user_data) }
 	desc := sapp.create_desc()
 	/*
-	desc := C.sg_desc{
+	desc := gfx.Desc{
 		mtl_device: sapp.metal_get_device()
 		mtl_renderpass_descriptor_cb: sapp.metal_get_renderpass_descriptor
 		mtl_drawable_cb: sapp.metal_get_drawable
@@ -196,16 +196,16 @@ fn gg_init_sokol_window(user_data voidptr) {
 		}
 	}
 	//
-	mut pipdesc := C.sg_pipeline_desc{
+	mut pipdesc := gfx.PipelineDesc{
 		label: c'alpha_image'
 	}
 	unsafe { vmemset(&pipdesc, 0, int(sizeof(pipdesc))) }
 
-	color_state := C.sg_color_state{
-		blend: C.sg_blend_state{
+	color_state := gfx.ColorState{
+		blend: gfx.BlendState{
 			enabled: true
-			src_factor_rgb: gfx.BlendFactor(C.SG_BLENDFACTOR_SRC_ALPHA)
-			dst_factor_rgb: gfx.BlendFactor(C.SG_BLENDFACTOR_ONE_MINUS_SRC_ALPHA)
+			src_factor_rgb: .src_alpha
+			dst_factor_rgb: .one_minus_src_alpha
 		}
 	}
 	pipdesc.colors[0] = color_state

--- a/vlib/gg/image.c.v
+++ b/vlib/gg/image.c.v
@@ -18,7 +18,7 @@ pub mut:
 	data        voidptr
 	ext         string
 	simg_ok     bool
-	simg        C.sg_image
+	simg        gfx.Image
 	path        string
 }
 
@@ -64,7 +64,7 @@ pub fn (mut ctx Context) create_image(file string) Image {
 
 pub fn (mut img Image) init_sokol_image() &Image {
 	// println('\n init sokol image $img.path ok=$img.simg_ok')
-	mut img_desc := C.sg_image_desc{
+	mut img_desc := gfx.ImageDesc{
 		width: img.width
 		height: img.height
 		num_mipmaps: 0
@@ -73,11 +73,11 @@ pub fn (mut img Image) init_sokol_image() &Image {
 		label: img.path.str
 		d3d11_texture: 0
 	}
-	img_desc.data.subimage[0][0] = C.sg_range{
+	img_desc.data.subimage[0][0] = gfx.Range{
 		ptr: img.data
 		size: usize(img.nr_channels * img.width * img.height)
 	}
-	img.simg = C.sg_make_image(&img_desc)
+	img.simg = gfx.make_image(&img_desc)
 	img.simg_ok = true
 	img.ok = true
 	return img
@@ -118,7 +118,7 @@ pub fn (mut ctx Context) new_streaming_image(w int, h int, channels int, sicfg S
 	img.width = w
 	img.height = h
 	img.nr_channels = channels // 4 bytes per pixel for .rgba8, see pixel_format
-	mut img_desc := C.sg_image_desc{
+	mut img_desc := gfx.ImageDesc{
 		width: img.width
 		height: img.height
 		pixel_format: sicfg.pixel_format
@@ -132,11 +132,11 @@ pub fn (mut ctx Context) new_streaming_image(w int, h int, channels int, sicfg S
 		label: img.path.str
 	}
 	// Sokol requires that streamed images have NO .ptr/.size initially:
-	img_desc.data.subimage[0][0] = C.sg_range{
+	img_desc.data.subimage[0][0] = gfx.Range{
 		ptr: 0
 		size: usize(0)
 	}
-	img.simg = C.sg_make_image(&img_desc)
+	img.simg = gfx.make_image(&img_desc)
 	img.simg_ok = true
 	img.ok = true
 	img_idx := ctx.cache_image(img)
@@ -151,7 +151,7 @@ pub fn (mut ctx Context) update_pixel_data(cached_image_idx int, buf &byte) {
 }
 
 pub fn (mut img Image) update_pixel_data(buf &byte) {
-	mut data := C.sg_image_data{}
+	mut data := gfx.ImageData{}
 	data.subimage[0][0].ptr = buf
 	data.subimage[0][0].size = usize(img.width * img.height * img.nr_channels)
 	gfx.update_image(img.simg, &data)

--- a/vlib/sokol/gfx/gfx.c.v
+++ b/vlib/sokol/gfx/gfx.c.v
@@ -9,7 +9,7 @@ pub const (
 
 // setup and misc functions
 [inline]
-pub fn setup(desc &C.sg_desc) {
+pub fn setup(desc &Desc) {
 	C.sg_setup(desc)
 }
 
@@ -30,83 +30,83 @@ pub fn reset_state_cache() {
 
 // resource creation, destruction and updating
 [inline]
-pub fn make_buffer(desc &C.sg_buffer_desc) C.sg_buffer {
+pub fn make_buffer(desc &BufferDesc) Buffer {
 	return C.sg_make_buffer(desc)
 }
 
 [inline]
-pub fn make_image(desc &C.sg_image_desc) C.sg_image {
+pub fn make_image(desc &ImageDesc) Image {
 	return C.sg_make_image(desc)
 }
 
 [inline]
-pub fn make_shader(desc &C.sg_shader_desc) C.sg_shader {
+pub fn make_shader(desc &ShaderDesc) Shader {
 	return C.sg_make_shader(desc)
 }
 
 [inline]
-pub fn make_pipeline(desc &C.sg_pipeline_desc) C.sg_pipeline {
+pub fn make_pipeline(desc &PipelineDesc) Pipeline {
 	return C.sg_make_pipeline(desc)
 }
 
 [inline]
-pub fn make_pass(desc &C.sg_pass_desc) C.sg_pass {
+pub fn make_pass(desc &PassDesc) Pass {
 	return C.sg_make_pass(desc)
 }
 
 [inline]
-pub fn destroy_buffer(buf C.sg_buffer) {
+pub fn destroy_buffer(buf Buffer) {
 	C.sg_destroy_buffer(buf)
 }
 
 [inline]
-pub fn destroy_image(img C.sg_image) {
+pub fn destroy_image(img Image) {
 	C.sg_destroy_image(img)
 }
 
 [inline]
-pub fn destroy_shader(shd C.sg_shader) {
+pub fn destroy_shader(shd Shader) {
 	C.sg_destroy_shader(shd)
 }
 
 [inline]
-pub fn destroy_pipeline(pip C.sg_pipeline) {
+pub fn destroy_pipeline(pip Pipeline) {
 	C.sg_destroy_pipeline(pip)
 }
 
 [inline]
-pub fn destroy_pass(pass C.sg_pass) {
+pub fn destroy_pass(pass Pass) {
 	C.sg_destroy_pass(pass)
 }
 
 [inline]
-pub fn update_buffer(buf C.sg_buffer, data &C.sg_range) {
+pub fn update_buffer(buf Buffer, data &Range) {
 	C.sg_update_buffer(buf, data)
 }
 
 [inline]
-pub fn update_image(img C.sg_image, data &C.sg_image_data) {
+pub fn update_image(img Image, data &ImageData) {
 	C.sg_update_image(img, data)
 }
 
 [inline]
-pub fn append_buffer(buf C.sg_buffer, data &C.sg_range) int {
+pub fn append_buffer(buf Buffer, data &Range) int {
 	return C.sg_append_buffer(buf, data)
 }
 
 [inline]
-pub fn query_buffer_overflow(buf C.sg_buffer) bool {
+pub fn query_buffer_overflow(buf Buffer) bool {
 	return C.sg_query_buffer_overflow(buf)
 }
 
 // rendering functions
 [inline]
-pub fn begin_default_pass(actions &C.sg_pass_action, width int, height int) {
+pub fn begin_default_pass(actions &PassAction, width int, height int) {
 	C.sg_begin_default_pass(actions, width, height)
 }
 
 [inline]
-pub fn begin_pass(pass C.sg_pass, actions &C.sg_pass_action) {
+pub fn begin_pass(pass Pass, actions &PassAction) {
 	C.sg_begin_pass(pass, actions)
 }
 
@@ -121,17 +121,17 @@ pub fn apply_scissor_rect(x int, y int, width int, height int, origin_top_left b
 }
 
 [inline]
-pub fn apply_pipeline(pip C.sg_pipeline) {
+pub fn apply_pipeline(pip Pipeline) {
 	C.sg_apply_pipeline(pip)
 }
 
 [inline]
-pub fn apply_bindings(bindings &C.sg_bindings) {
+pub fn apply_bindings(bindings &Bindings) {
 	C.sg_apply_bindings(bindings)
 }
 
 [inline]
-pub fn apply_uniforms(stage int, ub_index int, data &C.sg_range) {
+pub fn apply_uniforms(stage int, ub_index int, data &Range) {
 	C.sg_apply_uniforms(stage, ub_index, data)
 }
 
@@ -152,120 +152,120 @@ pub fn commit() {
 
 // getting information
 [inline]
-pub fn query_desc() C.sg_desc {
+pub fn query_desc() Desc {
 	return C.sg_query_desc()
 }
 
 [inline]
 pub fn query_backend() Backend {
-	return Backend(C.sg_query_backend())
+	return C.sg_query_backend()
 }
 
 [inline]
-pub fn query_features() C.sg_features {
+pub fn query_features() Features {
 	return C.sg_query_features()
 }
 
 [inline]
-pub fn query_limits() C.sg_limits {
+pub fn query_limits() Limits {
 	return C.sg_query_limits()
 }
 
 [inline]
-pub fn query_pixelformat(fmt PixelFormat) C.sg_pixelformat_info {
+pub fn query_pixelformat(fmt PixelFormat) PixelFormatInfo {
 	return C.sg_query_pixelformat(fmt)
 }
 
 // get current state of a resource (INITIAL, ALLOC, VALID, FAILED, INVALID)
 [inline]
-pub fn query_buffer_state(buf C.sg_buffer) C.sg_resource_state {
-	return C.sg_query_buffer_state(buf)
+pub fn query_buffer_state(buf Buffer) ResourceState {
+	return ResourceState(C.sg_query_buffer_state(buf))
 }
 
 [inline]
-pub fn query_image_state(img C.sg_image) C.sg_resource_state {
-	return C.sg_query_image_state(img)
+pub fn query_image_state(img Image) ResourceState {
+	return ResourceState(C.sg_query_image_state(img))
 }
 
 [inline]
-pub fn query_shader_state(shd C.sg_shader) C.sg_resource_state {
-	return C.sg_query_shader_state(shd)
+pub fn query_shader_state(shd Shader) ResourceState {
+	return ResourceState(C.sg_query_shader_state(shd))
 }
 
 [inline]
-pub fn query_pipeline_state(pip C.sg_pipeline) C.sg_resource_state {
-	return C.sg_query_pipeline_state(pip)
+pub fn query_pipeline_state(pip Pipeline) ResourceState {
+	return ResourceState(C.sg_query_pipeline_state(pip))
 }
 
 [inline]
-pub fn query_pass_state(pass C.sg_pass) C.sg_resource_state {
-	return C.sg_query_pass_state(pass)
+pub fn query_pass_state(pass Pass) ResourceState {
+	return ResourceState(C.sg_query_pass_state(pass))
 }
 
 // get runtime information about a resource
 [inline]
-pub fn query_buffer_info(buf C.sg_buffer) C.sg_buffer_info {
+pub fn query_buffer_info(buf Buffer) BufferInfo {
 	return C.sg_query_buffer_info(buf)
 }
 
 [inline]
-pub fn query_image_info(img C.sg_image) C.sg_image_info {
+pub fn query_image_info(img Image) ImageInfo {
 	return C.sg_query_image_info(img)
 }
 
 [inline]
-pub fn query_shader_info(shd C.sg_shader) C.sg_shader_info {
+pub fn query_shader_info(shd Shader) ShaderInfo {
 	return C.sg_query_shader_info(shd)
 }
 
 [inline]
-pub fn query_pipeline_info(pip C.sg_pipeline) C.sg_pipeline_info {
+pub fn query_pipeline_info(pip Pipeline) PipelineInfo {
 	return C.sg_query_pipeline_info(pip)
 }
 
 [inline]
-pub fn query_pass_info(pass C.sg_pass) C.sg_pass_info {
+pub fn query_pass_info(pass Pass) PassInfo {
 	return C.sg_query_pass_info(pass)
 }
 
 // get resource creation desc struct with their default values replaced
 [inline]
-pub fn query_buffer_defaults(desc &C.sg_buffer) C.sg_buffer_desc {
-	return C.sg_query_buffer_defaults(unsafe { &C.sg_buffer_desc(desc) })
+pub fn query_buffer_defaults(desc &Buffer) BufferDesc {
+	return C.sg_query_buffer_defaults(unsafe { &BufferDesc(voidptr(desc)) })
 }
 
 [inline]
-pub fn query_image_defaults(desc &C.sg_image) C.sg_image_desc {
-	return C.sg_query_image_defaults(unsafe { &C.sg_image_desc(desc) })
+pub fn query_image_defaults(desc &Image) ImageDesc {
+	return C.sg_query_image_defaults(unsafe { &ImageDesc(voidptr(desc)) })
 }
 
 [inline]
-pub fn query_shader_defaults(desc &C.sg_shader) C.sg_shader_desc {
-	return C.sg_query_shader_defaults(unsafe { &C.sg_shader_desc(desc) })
+pub fn query_shader_defaults(desc &Shader) ShaderDesc {
+	return C.sg_query_shader_defaults(unsafe { &ShaderDesc(voidptr(desc)) })
 }
 
 [inline]
-pub fn query_pipeline_defaults(desc &C.sg_pipeline) C.sg_pipeline_desc {
-	return C.sg_query_pipeline_defaults(unsafe { &C.sg_pipeline_desc(desc) })
+pub fn query_pipeline_defaults(desc &Pipeline) PipelineDesc {
+	return C.sg_query_pipeline_defaults(unsafe { &PipelineDesc(voidptr(desc)) })
 }
 
 [inline]
-pub fn query_pass_defaults(desc &C.sg_pass) C.sg_pass_desc {
-	return C.sg_query_pass_defaults(unsafe { &C.sg_pass_desc(desc) })
+pub fn query_pass_defaults(desc &Pass) PassDesc {
+	return C.sg_query_pass_defaults(unsafe { &PassDesc(voidptr(desc)) })
 }
 
 // rendering contexts (optional)
 [inline]
-pub fn setup_context() C.sg_context {
+pub fn setup_context() Context {
 	return C.sg_setup_context()
 }
 
 [inline]
-pub fn activate_context(ctx_id C.sg_context) {
+pub fn activate_context(ctx_id Context) {
 	C.sg_activate_context(ctx_id)
 }
 
 [inline]
-pub fn discard_context(ctx_id C.sg_context) {
+pub fn discard_context(ctx_id Context) {
 	C.sg_discard_context(ctx_id)
 }

--- a/vlib/sokol/gfx/gfx_structs.c.v
+++ b/vlib/sokol/gfx/gfx_structs.c.v
@@ -1,6 +1,6 @@
 module gfx
 
-pub struct C.sg_desc {
+struct C.sg_desc {
 	_start_canary      u32
 	buffer_pool_size   int
 	image_pool_size    int
@@ -8,7 +8,7 @@ pub struct C.sg_desc {
 	pipeline_pool_size int
 	pass_pool_size     int
 	context_pool_size  int
-	context            C.sg_context_desc
+	context            ContextDesc
 	/*
 	// GL specific
     gl_force_gles2 bool
@@ -27,7 +27,9 @@ pub struct C.sg_desc {
 	_end_canary u32
 }
 
-pub struct C.sg_context_desc {
+pub type Desc = C.sg_desc
+
+struct C.sg_context_desc {
 	/*
 	sg_pixel_format color_format;
     sg_pixel_format depth_format;
@@ -35,115 +37,133 @@ pub struct C.sg_context_desc {
     sg_wgpu_context_desc wgpu;
 	*/
 	sample_count int
-	gl           C.sg_gl_context_desc
-	metal        C.sg_metal_context_desc
-	d3d11        C.sg_d3d11_context_desc
+	gl           GLContextDesc
+	metal        MetalContextDesc
+	d3d11        D3D11ContextDesc
 	color_format PixelFormat
 	depth_format PixelFormat
 }
 
-pub struct C.sg_gl_context_desc {
+pub type ContextDesc = C.sg_context_desc
+
+struct C.sg_gl_context_desc {
 	force_gles2 bool
 }
 
-pub struct C.sg_metal_context_desc {
+pub type GLContextDesc = C.sg_gl_context_desc
+
+struct C.sg_metal_context_desc {
 	device                   voidptr
 	renderpass_descriptor_cb fn () voidptr
 	drawable_cb              fn () voidptr
 }
 
-pub struct C.sg_d3d11_context_desc {
+pub type MetalContextDesc = C.sg_metal_context_desc
+
+struct C.sg_d3d11_context_desc {
 	device                voidptr
 	device_context        voidptr
 	render_target_view_cb fn () voidptr
 	depth_stencil_view_cb fn () voidptr
 }
 
-pub struct C.sg_color_state {
+pub type D3D11ContextDesc = C.sg_d3d11_context_desc
+
+struct C.sg_color_state {
 pub mut:
 	pixel_format PixelFormat
 	write_mask   ColorMask
-	blend        C.sg_blend_state
+	blend        BlendState
 }
 
-pub struct C.sg_pipeline_desc {
+pub type ColorState = C.sg_color_state
+
+struct C.sg_pipeline_desc {
 pub mut:
 	_start_canary             u32
-	shader                    C.sg_shader
-	layout                    C.sg_layout_desc
-	depth                     C.sg_depth_state
-	stencil                   C.sg_stencil_state
+	shader                    Shader
+	layout                    LayoutDesc
+	depth                     DepthState
+	stencil                   StencilState
 	color_count               int
-	colors                    [4]C.sg_color_state // C.SG_MAX_COLOR_ATTACHMENTS
+	colors                    [4]ColorState // C.SG_MAX_COLOR_ATTACHMENTS
 	primitive_type            PrimitiveType
 	index_type                IndexType
 	cull_mode                 CullMode
 	face_winding              FaceWinding
 	sample_count              int
-	blend_color               C.sg_color
+	blend_color               Color
 	alpha_to_coverage_enabled bool
 	label                     &char = &char(0)
 	_end_canary               u32
 }
 
-pub struct C.sg_pipeline_info {
+pub type PipelineDesc = C.sg_pipeline_desc
+
+struct C.sg_pipeline_info {
 }
 
-pub struct C.sg_pipeline {
+pub type PipelineInfo = C.sg_pipeline_info
+
+struct C.sg_pipeline {
 pub:
 	id u32
 }
+
+pub type Pipeline = C.sg_pipeline
 
 pub fn (mut p C.sg_pipeline) free() {
 	C.sg_destroy_pipeline(*p)
 }
 
-pub struct C.sg_bindings {
+struct C.sg_bindings {
 pub mut:
 	_start_canary         u32
-	vertex_buffers        [8]C.sg_buffer
+	vertex_buffers        [8]Buffer
 	vertex_buffer_offsets [8]int
-	index_buffer          C.sg_buffer
+	index_buffer          Buffer
 	index_buffer_offset   int
-	vs_images             [8]C.sg_image
-	fs_images             [8]C.sg_image
+	vs_images             [8]Image
+	fs_images             [8]Image
 	_end_canary           u32
 }
 
-pub fn (mut b C.sg_bindings) set_vert_image(index int, img C.sg_image) {
+pub type Bindings = C.sg_bindings
+
+pub fn (mut b Bindings) set_vert_image(index int, img Image) {
 	b.vs_images[index] = img
 }
 
-pub fn (mut b C.sg_bindings) set_frag_image(index int, img C.sg_image) {
+pub fn (mut b Bindings) set_frag_image(index int, img Image) {
 	b.fs_images[index] = img
 }
 
-pub fn (b &C.sg_bindings) update_vert_buffer(index int, data voidptr, element_size int, element_count int) {
-	range := C.sg_range{
+pub fn (b &Bindings) update_vert_buffer(index int, data voidptr, element_size int, element_count int) {
+	range := Range{
 		ptr: data
 		size: usize(element_size * element_count)
 	}
 	C.sg_update_buffer(b.vertex_buffers[index], &range)
 }
 
-pub fn (b &C.sg_bindings) append_vert_buffer(index int, data voidptr, element_size int, element_count int) int {
-	range := C.sg_range{
+pub fn (b &Bindings) append_vert_buffer(index int, data voidptr, element_size int, element_count int) int {
+	range := Range{
 		ptr: data
 		size: usize(element_size * element_count)
 	}
 	return C.sg_append_buffer(b.vertex_buffers[index], &range)
 }
 
-pub fn (b &C.sg_bindings) update_index_buffer(data voidptr, element_size int, element_count int) {
-	range := C.sg_range{
+pub fn (b &Bindings) update_index_buffer(data voidptr, element_size int, element_count int) {
+	range := Range{
 		ptr: data
 		size: usize(element_size * element_count)
 	}
 	C.sg_update_buffer(b.index_buffer, &range)
 }
 
-pub fn (b &C.sg_bindings) append_index_buffer(data voidptr, element_size int, element_count int) int {
-	range := C.sg_range{
+pub fn (b &Bindings) append_index_buffer(data voidptr, element_size int, element_count int) int {
+	range := Range{
 		ptr: data
 		size: usize(element_size * element_count)
 	}
@@ -151,119 +171,137 @@ pub fn (b &C.sg_bindings) append_index_buffer(data voidptr, element_size int, el
 }
 
 [heap]
-pub struct C.sg_shader_desc {
+struct C.sg_shader_desc {
 pub mut:
 	_start_canary u32
-	attrs         [16]C.sg_shader_attr_desc
-	vs            C.sg_shader_stage_desc
-	fs            C.sg_shader_stage_desc
+	attrs         [16]ShaderAttrDesc
+	vs            ShaderStageDesc
+	fs            ShaderStageDesc
 	label         &char
 	_end_canary   u32
 }
 
-pub fn (mut desc C.sg_shader_desc) set_vert_src(src string) &C.sg_shader_desc {
+pub type ShaderDesc = C.sg_shader_desc
+
+pub fn (mut desc C.sg_shader_desc) set_vert_src(src string) &ShaderDesc {
 	desc.vs.source = &char(src.str)
 	return desc
 }
 
-pub fn (mut desc C.sg_shader_desc) set_frag_src(src string) &C.sg_shader_desc {
+pub fn (mut desc C.sg_shader_desc) set_frag_src(src string) &ShaderDesc {
 	desc.fs.source = &char(src.str)
 	return desc
 }
 
-pub fn (mut desc C.sg_shader_desc) set_vert_image(index int, name string) &C.sg_shader_desc {
+pub fn (mut desc C.sg_shader_desc) set_vert_image(index int, name string) &ShaderDesc {
 	desc.vs.images[index].name = &char(name.str)
 	desc.vs.images[index].image_type = ._2d
 	return desc
 }
 
-pub fn (mut desc C.sg_shader_desc) set_frag_image(index int, name string) &C.sg_shader_desc {
+pub fn (mut desc C.sg_shader_desc) set_frag_image(index int, name string) &ShaderDesc {
 	desc.fs.images[index].name = &char(name.str)
 	desc.fs.images[index].image_type = ._2d
 	return desc
 }
 
-pub fn (mut desc C.sg_shader_desc) set_vert_uniform_block_size(block_index int, size usize) &C.sg_shader_desc {
+pub fn (mut desc C.sg_shader_desc) set_vert_uniform_block_size(block_index int, size usize) &ShaderDesc {
 	desc.vs.uniform_blocks[block_index].size = size
 	return desc
 }
 
-pub fn (mut desc C.sg_shader_desc) set_frag_uniform_block_size(block_index int, size usize) &C.sg_shader_desc {
+pub fn (mut desc C.sg_shader_desc) set_frag_uniform_block_size(block_index int, size usize) &ShaderDesc {
 	desc.fs.uniform_blocks[block_index].size = size
 	return desc
 }
 
-pub fn (mut desc C.sg_shader_desc) set_vert_uniform(block_index int, uniform_index int, name string, @type UniformType, array_count int) &C.sg_shader_desc {
+pub fn (mut desc C.sg_shader_desc) set_vert_uniform(block_index int, uniform_index int, name string, @type UniformType, array_count int) &ShaderDesc {
 	desc.vs.uniform_blocks[block_index].uniforms[uniform_index].name = &char(name.str)
 	desc.vs.uniform_blocks[block_index].uniforms[uniform_index].@type = @type
 	return desc
 }
 
-pub fn (mut desc C.sg_shader_desc) set_frag_uniform(block_index int, uniform_index int, name string, @type UniformType, array_count int) &C.sg_shader_desc {
+pub fn (mut desc C.sg_shader_desc) set_frag_uniform(block_index int, uniform_index int, name string, @type UniformType, array_count int) &ShaderDesc {
 	desc.fs.uniform_blocks[block_index].uniforms[uniform_index].name = &char(name.str)
 	desc.fs.uniform_blocks[block_index].uniforms[uniform_index].@type = @type
 	return desc
 }
 
-pub fn (desc &C.sg_shader_desc) make_shader() C.sg_shader {
+pub fn (desc &ShaderDesc) make_shader() Shader {
 	return C.sg_make_shader(desc)
 }
 
-pub struct C.sg_shader_attr_desc {
+struct C.sg_shader_attr_desc {
 pub mut:
 	name      &char // GLSL vertex attribute name (only required for GLES2)
 	sem_name  &char // HLSL semantic name
 	sem_index int   // HLSL semantic index
 }
 
-pub struct C.sg_shader_stage_desc {
+pub type ShaderAttrDesc = C.sg_shader_attr_desc
+
+struct C.sg_shader_stage_desc {
 pub mut:
 	source         &char
-	bytecode       C.sg_range
+	bytecode       Range
 	entry          &char
-	uniform_blocks [4]C.sg_shader_uniform_block_desc
-	images         [12]C.sg_shader_image_desc
+	uniform_blocks [4]ShaderUniformBlockDesc
+	images         [12]ShaderImageDesc
 }
 
-pub fn (mut desc C.sg_shader_stage_desc) set_image(index int, name string) C.sg_shader_stage_desc {
+pub type ShaderStageDesc = C.sg_shader_stage_desc
+
+pub fn (mut desc ShaderStageDesc) set_image(index int, name string) ShaderStageDesc {
 	desc.images[index].name = &char(name.str)
 	desc.images[index].image_type = ._2d
 	return *desc
 }
 
-pub struct C.sg_shader_uniform_block_desc {
+struct C.sg_shader_uniform_block_desc {
 pub mut:
 	size     usize
-	uniforms [16]C.sg_shader_uniform_desc
+	uniforms [16]ShaderUniformDesc
 }
 
-pub struct C.sg_shader_uniform_desc {
+pub type ShaderUniformBlockDesc = C.sg_shader_uniform_block_desc
+
+struct C.sg_shader_uniform_desc {
 pub mut:
 	name        &char
 	@type       UniformType
 	array_count int
 }
 
-pub struct C.sg_shader_image_desc {
+pub type ShaderUniformDesc = C.sg_shader_uniform_desc
+
+struct C.sg_shader_image_desc {
 pub mut:
 	name       &char
 	image_type ImageType
 }
 
-pub struct C.sg_shader_info {
+pub type ShaderImageDesc = C.sg_shader_image_desc
+
+struct C.sg_shader_info {
 }
 
-pub struct C.sg_context {
+pub type ShaderInfo = C.sg_shader_info
+
+struct C.sg_context {
 	id u32
 }
 
-pub struct C.sg_range {
+pub type Context = C.sg_context
+
+struct C.sg_range {
 pub mut:
 	ptr  voidptr
 	size usize
 }
 
-pub struct C.sg_color {
+pub type Range = C.sg_range
+
+struct C.sg_color {
 pub mut:
 	r f32
 	g f32
@@ -271,52 +309,64 @@ pub mut:
 	a f32
 }
 
-pub struct C.sg_shader {
+pub type Color = C.sg_color
+
+struct C.sg_shader {
 pub:
 	id u32
 }
 
-pub fn (mut s C.sg_shader) free() {
+pub type Shader = C.sg_shader
+
+pub fn (mut s Shader) free() {
 	C.sg_destroy_shader(*s)
 }
 
-pub struct C.sg_pass_desc {
+struct C.sg_pass_desc {
 pub mut:
 	_start_canary            u32
-	color_attachments        [4]C.sg_pass_attachment_desc
-	depth_stencil_attachment C.sg_pass_attachment_desc
+	color_attachments        [4]PassAttachmentDesc
+	depth_stencil_attachment PassAttachmentDesc
 	label                    &char
 	_end_canary              u32
 }
 
-pub struct C.sg_pass_info {
-	info C.sg_slot_info
+pub type PassDesc = C.sg_pass_desc
+
+struct C.sg_pass_info {
+	info SlotInfo
 }
 
-pub struct C.sg_pass_action {
+pub type PassInfo = C.sg_pass_info
+
+struct C.sg_pass_action {
 pub mut:
 	_start_canary u32
-	colors        [4]C.sg_color_attachment_action
-	depth         C.sg_depth_attachment_action
-	stencil       C.sg_stencil_attachment_action
+	colors        [4]ColorAttachmentAction
+	depth         DepthAttachmentAction
+	stencil       StencilAttachmentAction
 	_end_canary   u32
 }
 
-pub struct C.sg_pass {
+pub type PassAction = C.sg_pass_action
+
+struct C.sg_pass {
 	id u32
 }
 
-pub fn (mut p C.sg_pass) free() {
+pub type Pass = C.sg_pass
+
+pub fn (mut p Pass) free() {
 	C.sg_destroy_pass(*p)
 }
 
-pub struct C.sg_buffer_desc {
+struct C.sg_buffer_desc {
 pub mut:
 	_start_canary u32
 	size          usize
 	@type         BufferType
 	usage         Usage
-	data          C.sg_range
+	data          Range
 	label         &char
 	// GL specific
 	gl_buffers [2]u32
@@ -327,23 +377,32 @@ pub mut:
 	_end_canary  u32
 }
 
-pub struct C.sg_buffer_info {
+pub type BufferDesc = C.sg_buffer_desc
+
+struct C.sg_slot_info {
+    state ResourceState
+    res_id u32
+    ctx_id u32
 }
 
-pub struct C.sg_buffer {
+pub type SlotInfo = C.sg_slot_info
+
+struct C.sg_buffer_info {
+}
+
+pub type BufferInfo = C.sg_buffer_info
+
+struct C.sg_buffer {
 	id u32
 }
 
-pub fn (mut b C.sg_buffer) free() {
+pub type Buffer = C.sg_buffer
+
+pub fn (mut b Buffer) free() {
 	C.sg_destroy_buffer(*b)
 }
 
-pub struct DepthLayers {
-	depth  int
-	layers int
-}
-
-pub struct C.sg_image_desc {
+struct C.sg_image_desc {
 pub mut:
 	_start_canary  u32
 	@type          ImageType
@@ -364,7 +423,7 @@ pub mut:
 	max_anisotropy u32
 	min_lod        f32
 	max_lod        f32
-	data           C.sg_image_data
+	data           ImageData
 	label          &char
 	// GL specific
 	gl_textures       [2]u32
@@ -379,20 +438,26 @@ pub mut:
 	_end_canary  u32
 }
 
-pub struct C.sg_image_info {
+pub type ImageDesc = C.sg_image_desc
+
+struct C.sg_image_info {
 pub mut:
-	slot            C.sg_slot_info // resource pool slot info
+	slot            SlotInfo // resource pool slot info
 	upd_frame_index u32 // frame index of last sg_update_image()
 	num_slots       int // number of renaming-slots for dynamically updated images
 	active_slot     int // currently active write-slot for dynamically updated images
 }
 
-pub struct C.sg_image {
+pub type ImageInfo = C.sg_image_info
+
+struct C.sg_image {
 pub:
 	id u32
 }
 
-pub fn (mut i C.sg_image) free() {
+pub type Image = C.sg_image
+
+pub fn (mut i Image) free() {
 	C.sg_destroy_image(*i)
 }
 
@@ -400,12 +465,14 @@ pub const sg_cubeface_num = 6
 
 pub const sg_max_mipmaps = 16
 
-pub struct C.sg_image_data {
+struct C.sg_image_data {
 pub mut:
-	subimage [sg_cubeface_num][sg_max_mipmaps]C.sg_range
+	subimage [sg_cubeface_num][sg_max_mipmaps]Range
 }
 
-pub struct C.sg_features {
+pub type ImageData = C.sg_image_data
+
+struct C.sg_features {
 pub:
 	instancing                  bool // hardware instancing supported
 	origin_top_left             bool // framebuffer and texture origin is in top left corner
@@ -418,7 +485,9 @@ pub:
 	mrt_independent_write_mask  bool // multiple-render-target rendering can use per-render-target color write masks
 }
 
-pub struct C.sg_limits {
+pub type Features = C.sg_features
+
+struct C.sg_limits {
 pub:
 	max_image_size_2d      u32 // max width/height of SG_IMAGETYPE_2D images
 	max_image_size_cube    u32 // max width/height of SG_IMAGETYPE_CUBE images
@@ -428,36 +497,46 @@ pub:
 	max_vertex_attrs       u32 // <= SG_MAX_VERTEX_ATTRIBUTES (only on some GLES2 impls)
 }
 
-pub struct C.sg_layout_desc {
+pub type Limits = C.sg_limits
+
+struct C.sg_layout_desc {
 pub mut:
-	buffers [8]C.sg_buffer_layout_desc
-	attrs   [16]C.sg_vertex_attr_desc
+	buffers [8]BufferLayoutDesc
+	attrs   [16]VertexAttrDesc
 }
 
-pub struct C.sg_buffer_layout_desc {
+pub type LayoutDesc = C.sg_layout_desc
+
+struct C.sg_buffer_layout_desc {
 pub mut:
 	stride    int
 	step_func VertexStep
 	step_rate int
 }
 
-pub struct C.sg_vertex_attr_desc {
+pub type BufferLayoutDesc = C.sg_buffer_layout_desc
+
+struct C.sg_vertex_attr_desc {
 pub mut:
 	buffer_index int
 	offset       int
 	format       VertexFormat
 }
 
-pub struct C.sg_stencil_state {
+pub type VertexAttrDesc = C.sg_vertex_attr_desc
+
+struct C.sg_stencil_state {
 	enabled    bool
-	front      C.sg_stencil_face_state
-	back       C.sg_stencil_face_state
+	front      StencilFaceState
+	back       StencilFaceState
 	read_mask  byte
 	write_mask byte
 	ref        byte
 }
 
-pub struct C.sg_depth_state {
+pub type StencilState = C.sg_stencil_state
+
+struct C.sg_depth_state {
 	pixel_format     PixelFormat
 	compare          CompareFunc
 	write_enabled    bool
@@ -466,14 +545,18 @@ pub struct C.sg_depth_state {
 	bias_clamp       f32
 }
 
-pub struct C.sg_stencil_face_state {
+pub type DepthState = C.sg_depth_state
+
+struct C.sg_stencil_face_state {
 	fail_op       StencilOp
 	depth_fail_op StencilOp
 	pass_op       StencilOp
 	compare_func  CompareFunc
 }
 
-pub struct C.sg_blend_state {
+pub type StencilFaceState = C.sg_stencil_face_state
+
+struct C.sg_blend_state {
 pub mut:
 	enabled          bool
 	src_factor_rgb   BlendFactor
@@ -484,11 +567,15 @@ pub mut:
 	op_alpha         BlendOp
 }
 
-pub struct C.sg_color_attachment_action {
+pub type BlendState = C.sg_blend_state
+
+struct C.sg_color_attachment_action {
 pub mut:
 	action Action
-	value  C.sg_color
+	value  Color
 }
+
+pub type ColorAttachmentAction = C.sg_color_attachment_action
 
 /*
 pub fn (mut action C.sg_color_attachment_action) set_color_values(r, g, b, a f32) {
@@ -498,19 +585,23 @@ pub fn (mut action C.sg_color_attachment_action) set_color_values(r, g, b, a f32
     action.val[3] = a
 }
 */
-pub struct C.sg_depth_attachment_action {
+struct C.sg_depth_attachment_action {
 pub mut:
 	action Action
 	value  f32
 }
 
-pub struct C.sg_stencil_attachment_action {
+pub type DepthAttachmentAction = C.sg_depth_attachment_action
+
+struct C.sg_stencil_attachment_action {
 pub mut:
 	action Action
 	value  byte
 }
 
-pub struct C.sg_pixelformat_info {
+pub type StencilAttachmentAction = C.sg_stencil_attachment_action
+
+struct C.sg_pixelformat_info {
 pub:
 	sample bool // pixel format can be sampled in shaders
 	filter bool // pixel format can be sampled with filtering
@@ -520,9 +611,11 @@ pub:
 	depth  bool // pixel format is a depth format
 }
 
-pub struct C.sg_pass_attachment_desc {
+pub type PixelFormatInfo = C.sg_pixelformat_info
+
+struct C.sg_pass_attachment_desc {
 pub mut:
-	image     C.sg_image
+	image     Image
 	mip_level int
 	face      int
 	// image sg_image
@@ -533,3 +626,5 @@ pub mut:
 	// slice int
 	// }
 }
+
+pub type PassAttachmentDesc = C.sg_pass_attachment_desc

--- a/vlib/sokol/gfx/gfx_structs.c.v
+++ b/vlib/sokol/gfx/gfx_structs.c.v
@@ -380,9 +380,9 @@ pub mut:
 pub type BufferDesc = C.sg_buffer_desc
 
 struct C.sg_slot_info {
-    state ResourceState
-    res_id u32
-    ctx_id u32
+	state  ResourceState
+	res_id u32
+	ctx_id u32
 }
 
 pub type SlotInfo = C.sg_slot_info
@@ -443,9 +443,9 @@ pub type ImageDesc = C.sg_image_desc
 struct C.sg_image_info {
 pub mut:
 	slot            SlotInfo // resource pool slot info
-	upd_frame_index u32 // frame index of last sg_update_image()
-	num_slots       int // number of renaming-slots for dynamically updated images
-	active_slot     int // currently active write-slot for dynamically updated images
+	upd_frame_index u32      // frame index of last sg_update_image()
+	num_slots       int      // number of renaming-slots for dynamically updated images
+	active_slot     int      // currently active write-slot for dynamically updated images
 }
 
 pub type ImageInfo = C.sg_image_info

--- a/vlib/sokol/gfx/gfx_utils.c.v
+++ b/vlib/sokol/gfx/gfx_utils.c.v
@@ -1,9 +1,9 @@
 module gfx
 
-pub fn create_clear_pass(r f32, g f32, b f32, a f32) C.sg_pass_action {
-	mut color_action := C.sg_color_attachment_action{
+pub fn create_clear_pass(r f32, g f32, b f32, a f32) PassAction {
+	mut color_action := ColorAttachmentAction{
 		action: Action(C.SG_ACTION_CLEAR)
-		value: C.sg_color{
+		value: Color{
 			r: r
 			g: g
 			b: b
@@ -11,7 +11,7 @@ pub fn create_clear_pass(r f32, g f32, b f32, a f32) C.sg_pass_action {
 		}
 	}
 	// color_action.set_color_values(r, g, b, a)
-	mut pass_action := C.sg_pass_action{}
+	mut pass_action := PassAction{}
 	pass_action.colors[0] = color_action
 	return pass_action
 }

--- a/vlib/sokol/sapp/sapp.c.v
+++ b/vlib/sokol/sapp/sapp.c.v
@@ -8,20 +8,20 @@ pub const used_import = gfx.used_import
 // Android needs a global reference to `g_desc`
 __global g_desc C.sapp_desc
 
-pub fn create_desc() C.sg_desc {
-	metal_desc := C.sg_metal_context_desc{
+pub fn create_desc() gfx.Desc {
+	metal_desc := gfx.MetalContextDesc{
 		device: metal_get_device()
 		renderpass_descriptor_cb: metal_get_renderpass_descriptor
 		drawable_cb: metal_get_drawable
 	}
-	d3d11_desc := C.sg_d3d11_context_desc{
+	d3d11_desc := gfx.D3D11ContextDesc{
 		device: d3d11_get_device()
 		device_context: d3d11_get_device_context()
 		render_target_view_cb: d3d11_get_render_target_view
 		depth_stencil_view_cb: d3d11_get_depth_stencil_view
 	}
-	return C.sg_desc{
-		context: C.sg_context_desc{
+	return gfx.Desc{
+		context: gfx.ContextDesc{
 			metal: metal_desc
 			d3d11: d3d11_desc
 			color_format: .bgra8

--- a/vlib/sokol/sgl/sgl.c.v
+++ b/vlib/sokol/sgl/sgl.c.v
@@ -39,7 +39,7 @@ pub fn deg(rad f32) f32 {
 
 // create and destroy pipeline objects
 [inline]
-pub fn make_pipeline(desc &C.sg_pipeline_desc) C.sgl_pipeline {
+pub fn make_pipeline(desc &gfx.PipelineDesc) C.sgl_pipeline {
 	return C.sgl_make_pipeline(desc)
 }
 
@@ -70,7 +70,7 @@ pub fn disable_texture() {
 }
 
 [inline]
-pub fn texture(img C.sg_image) {
+pub fn texture(img gfx.Image) {
 	C.sgl_texture(img)
 }
 

--- a/vlib/v/fmt/tests/c_struct_init_keep.vv
+++ b/vlib/v/fmt/tests/c_struct_init_keep.vv
@@ -15,7 +15,7 @@ fn abc() {
 }
 
 fn init(user_data voidptr) {
-	desc := gfx.Desc{
+	desc := C.sg_desc{
 		mtl_device: sapp.metal_get_device()
 		mtl_renderpass_descriptor_cb: sapp.metal_get_renderpass_descriptor
 		mtl_drawable_cb: sapp.metal_get_drawable

--- a/vlib/v/fmt/tests/c_struct_init_keep.vv
+++ b/vlib/v/fmt/tests/c_struct_init_keep.vv
@@ -15,7 +15,7 @@ fn abc() {
 }
 
 fn init(user_data voidptr) {
-	desc := C.sg_desc{
+	desc := gfx.Desc{
 		mtl_device: sapp.metal_get_device()
 		mtl_renderpass_descriptor_cb: sapp.metal_get_renderpass_descriptor
 		mtl_drawable_cb: sapp.metal_get_drawable

--- a/vlib/x/ttf/README.md
+++ b/vlib/x/ttf/README.md
@@ -218,6 +218,7 @@ import gg
 import gx
 import sokol.sapp
 import sokol.sgl
+import sokol.gfx
 import x.ttf
 import os
 

--- a/vlib/x/ttf/README.md
+++ b/vlib/x/ttf/README.md
@@ -233,7 +233,7 @@ const (
 struct App_data {
 pub mut:
 	gg        &gg.Context
-	sg_img    C.sg_image
+	sg_img    gfx.Image
 	init_flag bool
 	frame_c   int
 

--- a/vlib/x/ttf/render_sokol_cpu.v
+++ b/vlib/x/ttf/render_sokol_cpu.v
@@ -15,12 +15,13 @@ module ttf
 import math
 import gg
 import sokol.sgl
+import sokol.gfx
 
 pub struct TTF_render_Sokol {
 pub mut:
 	bmp &BitMap // Base bitmap render
 	// rendering fields
-	sg_img       C.sg_image // sokol image
+	sg_img       gfx.Image // sokol image
 	scale_reduct f32 = 2.0 // scale of the cpu texture for filtering
 	device_dpi   int = 72 // device DPI
 }
@@ -118,7 +119,7 @@ pub fn (mut tf_skl TTF_render_Sokol) create_texture() {
 	w := tf_skl.bmp.width
 	h := tf_skl.bmp.height
 	sz := tf_skl.bmp.width * tf_skl.bmp.height * tf_skl.bmp.bp
-	mut img_desc := C.sg_image_desc{
+	mut img_desc := gfx.ImageDesc{
 		width: w
 		height: h
 		num_mipmaps: 0
@@ -131,29 +132,29 @@ pub fn (mut tf_skl TTF_render_Sokol) create_texture() {
 		d3d11_texture: 0
 	}
 	// comment for dynamic
-	img_desc.data.subimage[0][0] = C.sg_range{
+	img_desc.data.subimage[0][0] = gfx.Range{
 		ptr: tf_skl.bmp.buf
 		size: usize(sz)
 	}
 
-	simg := C.sg_make_image(&img_desc)
+	simg := gfx.make_image(&img_desc)
 	// free(tf_skl.bmp.buf)  // DONT FREE IF Dynamic
 	tf_skl.sg_img = simg
 }
 
 pub fn (tf_skl TTF_render_Sokol) destroy_texture() {
-	C.sg_destroy_image(tf_skl.sg_img)
+	gfx.destroy_image(tf_skl.sg_img)
 }
 
 // Use only if usage: .dynamic
 pub fn (mut tf_skl TTF_render_Sokol) update_text_texture() {
 	sz := tf_skl.bmp.width * tf_skl.bmp.height * tf_skl.bmp.bp
-	mut tmp_sbc := C.sg_image_data{}
-	tmp_sbc.subimage[0][0] = C.sg_range{
+	mut tmp_sbc := gfx.ImageData{}
+	tmp_sbc.subimage[0][0] = gfx.Range{
 		ptr: tf_skl.bmp.buf
 		size: usize(sz)
 	}
-	C.sg_update_image(tf_skl.sg_img, &tmp_sbc)
+	gfx.update_image(tf_skl.sg_img, &tmp_sbc)
 }
 
 pub fn (tf_skl TTF_render_Sokol) draw_text_bmp(ctx &gg.Context, x f32, y f32) {


### PR DESCRIPTION
This PR adds public type aliases for all exposed sokol_gfx structs - resulting in significantly less `C.` prefixes in existing code.
