### PR TITLE
Regex: added replace_n function

### DIFF
--- a/vlib/regex/README.md
+++ b/vlib/regex/README.md
@@ -606,7 +606,7 @@ pub fn (mut re RE) replace_simple(in_txt string, repl string) string
 
 If it is needed to replace N instances of the found strings it is possible to use:
 ```v ignore
-// replace_n return a string where the first N matches are replaced with the repl_str string,
+// replace_n return a string where the firts `count` matches are replaced with the repl_str string
 // `count` indicate the number of max replacements that will be done.
 // if count is > 0 the replace began from the start of the string toward the end
 // if count is < 0 the replace began from the end of the string toward the start

--- a/vlib/regex/README.md
+++ b/vlib/regex/README.md
@@ -614,7 +614,6 @@ If it is needed to replace N instances of the found strings it is possible to us
 pub fn (mut re RE) replace_n(in_txt string, repl_str string, count int) string
 ```
 
-
 #### Custom replace function
 
 For complex find and replace operations, you can use `replace_by_fn` .

--- a/vlib/regex/README.md
+++ b/vlib/regex/README.md
@@ -604,6 +604,17 @@ to use a quick function:
 pub fn (mut re RE) replace_simple(in_txt string, repl string) string
 ```
 
+If it is needed to replace N instances of the found strings it is possible to use:
+```v ignore
+// replace_n return a string where the first N matches are replaced with the repl_str string,
+// `count` indicate the number of max replacements that will be done.
+// if count is > 0 the replace began from the start of the string toward the end
+// if count is < 0 the replace began from the end of the string toward the start
+// if count is 0 do nothing
+pub fn (mut re RE) replace_n(in_txt string, repl_str string, count int) string
+```
+
+
 #### Custom replace function
 
 For complex find and replace operations, you can use `replace_by_fn` .

--- a/vlib/regex/regex_test.v
+++ b/vlib/regex/regex_test.v
@@ -623,6 +623,25 @@ fn test_regex_func_replace(){
 	assert result == txt2
 }
 
+fn rest_regex_replace_n(){
+	s := "dario 1234 pepep 23454 pera"
+    query := r"\d+"
+
+    mut re := regex.regex_opt(query) or { panic(err) }
+
+    assert re.replace_n(s, "[repl]", 0) == "dario 1234 pepep 23454 pera"
+    assert re.replace_n(s, "[repl]", -1) == "dario 1234 pepep [repl] pera"
+    assert re.replace_n(s, "[repl]", 1) == "dario [repl] pepep 23454 pera"
+    assert re.replace_n(s, "[repl]", 2) == "dario [repl] pepep [repl] pera"
+    assert re.replace_n(s, "[repl]", -2) == "dario [repl] pepep [repl] pera"
+    assert re.replace_n(s, "[repl]", 3) == "dario [repl] pepep [repl] pera"
+    assert re.replace_n(s, "[repl]", -3) == "dario [repl] pepep [repl] pera"
+
+    //mut res := re.replace_n(s, "[repl]", -1)
+    //println("source: ${s}")
+    //println("res   : ${res}")
+}
+
 // test quantifier wrong sequences
 const(
 	test_quantifier_sequences_list = [

--- a/vlib/regex/regex_util.v
+++ b/vlib/regex/regex_util.v
@@ -463,3 +463,26 @@ pub fn (mut re RE) replace(in_txt string, repl_str string) string {
 	}
 	return res.str()
 }
+
+pub fn (mut re RE) replace_n(in_txt string, repl_str string, count int) string {
+	mut i := 0
+	mut index := 0
+	mut i_p := 0
+	mut n := count
+	mut res := strings.new_builder(in_txt.len)
+    lst := re.find_all(in_txt)
+    println("found: ${lst}")
+    for index < lst.len && n > 0 {
+    	i = lst[index]
+    	res.write_string(in_txt[i_p..i])
+    	res.write_string(repl_str)
+    	index ++
+    	i_p = lst[index]
+    	index++
+    	n--
+    }
+    i = i_p
+    res.write_string(in_txt[i..])
+
+    return res.str()
+}

--- a/vlib/regex/regex_util.v
+++ b/vlib/regex/regex_util.v
@@ -464,25 +464,36 @@ pub fn (mut re RE) replace(in_txt string, repl_str string) string {
 	return res.str()
 }
 
+// replace return a string where the matches are replaced count instances with the repl_str string,
+// if count is > 0 the replace began from the start of the string toward the end
+// if count is < 0 the replace began from the end of the string toward the start
+// if count is 0 do nothing
 pub fn (mut re RE) replace_n(in_txt string, repl_str string, count int) string {
 	mut i := 0
 	mut index := 0
 	mut i_p := 0
-	mut n := count
 	mut res := strings.new_builder(in_txt.len)
-    lst := re.find_all(in_txt)
-    println("found: ${lst}")
-    for index < lst.len && n > 0 {
-    	i = lst[index]
-    	res.write_string(in_txt[i_p..i])
-    	res.write_string(repl_str)
-    	index ++
-    	i_p = lst[index]
-    	index++
-    	n--
-    }
-    i = i_p
-    res.write_string(in_txt[i..])
+	mut lst := re.find_all(in_txt)
 
-    return res.str()
+	if count < 0 { // start from the right of the string
+		lst = lst#[count * 2..] // limitate the number of substitions
+	} else if count > 0 { // start from the left of the string
+		lst = lst#[..count * 2] // limitate the number of substitions
+	} else if count == 0 { // no replace
+		return in_txt
+	}
+
+	// println("found: ${lst}")
+	for index < lst.len {
+		i = lst[index]
+		res.write_string(in_txt[i_p..i])
+		res.write_string(repl_str)
+		index++
+		i_p = lst[index]
+		index++
+	}
+	i = i_p
+	res.write_string(in_txt[i..])
+
+	return res.str()
 }

--- a/vlib/regex/regex_util.v
+++ b/vlib/regex/regex_util.v
@@ -464,7 +464,7 @@ pub fn (mut re RE) replace(in_txt string, repl_str string) string {
 	return res.str()
 }
 
-// replace_n return a string where the matches are replaced count instances with the repl_str string,
+// replace_n return a string where the firts count matches are replaced with the repl_str string,
 // if count is > 0 the replace began from the start of the string toward the end
 // if count is < 0 the replace began from the end of the string toward the start
 // if count is 0 do nothing

--- a/vlib/regex/regex_util.v
+++ b/vlib/regex/regex_util.v
@@ -464,7 +464,7 @@ pub fn (mut re RE) replace(in_txt string, repl_str string) string {
 	return res.str()
 }
 
-// replace return a string where the matches are replaced count instances with the repl_str string,
+// replace_n return a string where the matches are replaced count instances with the repl_str string,
 // if count is > 0 the replace began from the start of the string toward the end
 // if count is < 0 the replace began from the end of the string toward the start
 // if count is 0 do nothing


### PR DESCRIPTION
**What's inside**
- Added a replace N instances function:
```v
// replace_n return a string where the firts `count` matches are replaced with the repl_str string
// `count` indicate the number of max replacements that will be done.
// if count is > 0 the replace began from the start of the string toward the end
// if count is < 0 the replace began from the end of the string toward the start
// if count is 0 do nothing
pub fn (mut re RE) replace_n(in_txt string, repl_str string, count int) string
```

example:
```v
fn rest_regex_replace_n(){
    s := "dario 1234 pepep 23454 pera"
    query := r"\d+"

    mut re := regex.regex_opt(query) or { panic(err) }

    assert re.replace_n(s, "[repl]", 0) == "dario 1234 pepep 23454 pera"
    assert re.replace_n(s, "[repl]", -1) == "dario 1234 pepep [repl] pera"
    assert re.replace_n(s, "[repl]", 1) == "dario [repl] pepep 23454 pera"
    assert re.replace_n(s, "[repl]", 2) == "dario [repl] pepep [repl] pera"
    assert re.replace_n(s, "[repl]", -2) == "dario [repl] pepep [repl] pera"
    assert re.replace_n(s, "[repl]", 3) == "dario [repl] pepep [repl] pera"
    assert re.replace_n(s, "[repl]", -3) == "dario [repl] pepep [repl] pera"

    //mut res := re.replace_n(s, "[repl]", -1)
    //println("source: ${s}")
    //println("res   : ${res}")
}
```