### PR TITLE
sokol: type alias all `sgl` structs, support `sgl_context`

### DIFF
--- a/examples/sokol/01_cubes/cube.v
+++ b/examples/sokol/01_cubes/cube.v
@@ -26,7 +26,7 @@ const (
 struct App {
 mut:
 	gg          &gg.Context
-	pip_3d      C.sgl_pipeline
+	pip_3d      sgl.Pipeline
 	texture     gfx.Image
 	init_flag   bool
 	frame_count int
@@ -315,7 +315,7 @@ fn my_init(mut app App) {
 	// for a large number of the same type of object it is better use the instances!!
 	desc := sapp.create_desc()
 	gfx.setup(&desc)
-	sgl_desc := C.sgl_desc_t{
+	sgl_desc := sgl.Desc{
 		max_vertices: 50 * 65536
 	}
 	sgl.setup(&sgl_desc)

--- a/examples/sokol/02_cubes_glsl/cube_glsl.v
+++ b/examples/sokol/02_cubes_glsl/cube_glsl.v
@@ -37,7 +37,7 @@ const (
 struct App {
 mut:
 	gg          &gg.Context
-	pip_3d      C.sgl_pipeline
+	pip_3d      sgl.Pipeline
 	texture     gfx.Image
 	init_flag   bool
 	frame_count int
@@ -486,7 +486,7 @@ fn my_init(mut app App) {
 	// for a large number of the same type of object it is better use the instances!!
 	desc := sapp.create_desc()
 	gfx.setup(&desc)
-	sgl_desc := C.sgl_desc_t{
+	sgl_desc := sgl.Desc{
 		max_vertices: 50 * 65536
 	}
 	sgl.setup(&sgl_desc)

--- a/examples/sokol/03_march_tracing_glsl/rt_glsl.v
+++ b/examples/sokol/03_march_tracing_glsl/rt_glsl.v
@@ -325,7 +325,7 @@ fn my_init(mut app App) {
 	// for a large number of the same type of object it is better use the instances!!
 	desc := sapp.create_desc()
 	gfx.setup(&desc)
-	sgl_desc := C.sgl_desc_t{
+	sgl_desc := sgl.Desc{
 		max_vertices: 50 * 65536
 	}
 	sgl.setup(&sgl_desc)

--- a/examples/sokol/04_multi_shader_glsl/rt_glsl.v
+++ b/examples/sokol/04_multi_shader_glsl/rt_glsl.v
@@ -513,7 +513,7 @@ fn my_init(mut app App) {
 	// for a large number of the same type of object it is better use the instances!!
 	desc := sapp.create_desc()
 	gfx.setup(&desc)
-	sgl_desc := C.sgl_desc_t{
+	sgl_desc := sgl.Desc{
 		max_vertices: 50 * 65536
 	}
 	sgl.setup(&sgl_desc)

--- a/examples/sokol/06_obj_viewer/show_obj.v
+++ b/examples/sokol/06_obj_viewer/show_obj.v
@@ -212,7 +212,7 @@ fn my_init(mut app App) {
 	// for a large number of the same type of object it is better use the instances!!
 	desc := sapp.create_desc()
 	gfx.setup(&desc)
-	sgl_desc := C.sgl_desc_t{
+	sgl_desc := sgl.Desc{
 		max_vertices: 128 * 65536
 	}
 	sgl.setup(&sgl_desc)

--- a/examples/sokol/drawing.v
+++ b/examples/sokol/drawing.v
@@ -29,7 +29,7 @@ fn main() {
 fn init(user_data voidptr) {
 	desc := sapp.create_desc() // gfx.Desc{
 	gfx.setup(&desc)
-	sgl_desc := C.sgl_desc_t{}
+	sgl_desc := sgl.Desc{}
 	sgl.setup(&sgl_desc)
 }
 

--- a/examples/sokol/fonts.v
+++ b/examples/sokol/fonts.v
@@ -44,7 +44,7 @@ fn main() {
 fn init(mut state AppState) {
 	desc := sapp.create_desc()
 	gfx.setup(&desc)
-	s := &C.sgl_desc_t{}
+	s := &sgl.Desc{}
 	C.sgl_setup(s)
 	state.fons = sfons.create(512, 512, 1)
 	// or use DroidSerif-Regular.ttf

--- a/examples/sokol/freetype_raven.v
+++ b/examples/sokol/freetype_raven.v
@@ -96,7 +96,7 @@ fn init(user_data voidptr) {
 	mut state := &AppState(user_data)
 	desc := sapp.create_desc()
 	gfx.setup(&desc)
-	s := &C.sgl_desc_t{}
+	s := &sgl.Desc{}
 	C.sgl_setup(s)
 	state.fons = sfons.create(512, 512, 1)
 	// or use DroidSerif-Regular.ttf

--- a/examples/sokol/particles/particles.v
+++ b/examples/sokol/particles/particles.v
@@ -31,7 +31,7 @@ mut:
 	frame     i64
 	last      i64
 	ps        particle.System
-	alpha_pip C.sgl_pipeline
+	alpha_pip sgl.Pipeline
 }
 
 fn (mut a App) init() {
@@ -75,7 +75,7 @@ fn init(user_data voidptr) {
 	mut app := &App(user_data)
 	desc := sapp.create_desc()
 	gfx.setup(&desc)
-	sgl_desc := C.sgl_desc_t{
+	sgl_desc := sgl.Desc{
 		max_vertices: 50 * 65536
 	}
 	sgl.setup(&sgl_desc)

--- a/examples/viewer/view.v
+++ b/examples/viewer/view.v
@@ -61,7 +61,7 @@ enum Viewer_state {
 struct App {
 mut:
 	gg          &gg.Context
-	pip_viewer  C.sgl_pipeline
+	pip_viewer  sgl.Pipeline
 	texture     gfx.Image
 	init_flag   bool
 	frame_count int

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -111,7 +111,7 @@ pub mut:
 	height      int
 	clear_pass  gfx.PassAction
 	window      sapp.Desc
-	timage_pip  C.sgl_pipeline
+	timage_pip  sgl.Pipeline
 	config      Config
 	user_data   voidptr
 	ft          &FT
@@ -150,7 +150,7 @@ fn gg_init_sokol_window(user_data voidptr) {
 	}
 	*/
 	gfx.setup(&desc)
-	sgl_desc := C.sgl_desc_t{}
+	sgl_desc := sgl.Desc{}
 	sgl.setup(&sgl_desc)
 	g.scale = dpi_scale()
 	// is_high_dpi := sapp.high_dpi()

--- a/vlib/sokol/gfx/enums.v
+++ b/vlib/sokol/gfx/enums.v
@@ -11,6 +11,7 @@ pub enum Backend {
 	dummy
 }
 
+// PixelFormat is C.sg_pixel_format
 pub enum PixelFormat {
 	_default // value 0 reserved for default-init
 	@none
@@ -216,6 +217,7 @@ pub enum CullMode {
 	_num
 }
 
+// FaceWindin is C.sg_face_winding
 pub enum FaceWinding {
 	_facewinding_default // value 0 reserved for default-init
 	facewinding_ccw

--- a/vlib/sokol/sgl/enums.v
+++ b/vlib/sokol/sgl/enums.v
@@ -1,0 +1,12 @@
+module sgl
+
+// Error is C.sgl_error_t
+pub enum SglError {
+	no_error = C.SGL_NO_ERROR // 0
+	vertices_full = C.SGL_ERROR_VERTICES_FULL
+	uniforms_full = C.SGL_ERROR_UNIFORMS_FULL
+	commands_full = C.SGL_ERROR_COMMANDS_FULL
+	stack_overflow = C.SGL_ERROR_STACK_OVERFLOW
+	stack_underfloat = C.SGL_ERROR_STACK_UNDERFLOW
+	no_context = C.SGL_ERROR_NO_CONTEXT
+}

--- a/vlib/sokol/sgl/sgl.c.v
+++ b/vlib/sokol/sgl/sgl.c.v
@@ -4,11 +4,12 @@ import sokol.gfx
 
 pub const (
 	version = gfx.version + 1
+	context = Context{0x00010001} // C.SGL_DEFAULT_CONTEXT = { 0x00010001 }
 )
 
 // setup/shutdown/misc
 [inline]
-pub fn setup(desc &C.sgl_desc_t) {
+pub fn setup(desc &Desc) {
 	C.sgl_setup(desc)
 }
 
@@ -18,13 +19,13 @@ pub fn shutdown() {
 }
 
 [inline]
-pub fn error() C.sgl_error_t {
-	return C.sgl_error()
+pub fn error() SglError {
+	return SglError(int(C.sgl_error()))
 }
 
 [inline]
-pub fn defaults() {
-	C.sgl_defaults()
+pub fn context_error(ctx Context) SglError {
+	return SglError(int(C.sgl_context_error(ctx)))
 }
 
 [inline]
@@ -37,18 +38,54 @@ pub fn deg(rad f32) f32 {
 	return C.sgl_deg(rad)
 }
 
+// context functions
+[inline]
+pub fn make_context(desc &ContextDesc) Context {
+	return C.sgl_make_context(desc)
+}
+
+[inline]
+pub fn destroy_context(ctx Context) {
+	C.sgl_destroy_context(ctx)
+}
+
+[inline]
+pub fn set_context(ctx Context) {
+	C.sgl_set_context(ctx)
+}
+
+[inline]
+pub fn get_context() Context {
+	return C.sgl_get_context()
+}
+
+[inline]
+pub fn default_context() Context {
+	return C.sgl_default_context()
+}
+
 // create and destroy pipeline objects
 [inline]
-pub fn make_pipeline(desc &gfx.PipelineDesc) C.sgl_pipeline {
+pub fn make_pipeline(desc &gfx.PipelineDesc) Pipeline {
 	return C.sgl_make_pipeline(desc)
 }
 
 [inline]
-pub fn destroy_pipeline(pip C.sgl_pipeline) {
+pub fn context_make_pipeline(ctx Context, desc &gfx.PipelineDesc) Pipeline {
+	return C.sgl_context_make_pipeline(ctx, desc)
+}
+
+[inline]
+pub fn destroy_pipeline(pip Pipeline) {
 	C.sgl_destroy_pipeline(pip)
 }
 
 // render state functions
+[inline]
+pub fn defaults() {
+	C.sgl_defaults()
+}
+
 [inline]
 pub fn viewport(x int, y int, w int, h int, origin_top_left bool) {
 	C.sgl_viewport(x, y, w, h, origin_top_left)
@@ -86,7 +123,7 @@ pub fn default_pipeline() {
 }
 
 [inline]
-pub fn load_pipeline(pip C.sgl_pipeline) {
+pub fn load_pipeline(pip Pipeline) {
 	C.sgl_load_pipeline(pip)
 }
 
@@ -373,8 +410,13 @@ pub fn end() {
 	C.sgl_end()
 }
 
-// render everything
+// render recorded commands
 [inline]
 pub fn draw() {
 	C.sgl_draw()
+}
+
+[inline]
+pub fn context_draw(ctx Context) {
+	C.sgl_context_draw(ctx)
 }

--- a/vlib/sokol/sgl/sgl_funcs.c.v
+++ b/vlib/sokol/sgl/sgl_funcs.c.v
@@ -4,15 +4,24 @@ module sgl
 fn C.sgl_setup(desc &C.sgl_desc_t)
 fn C.sgl_shutdown()
 fn C.sgl_error() C.sgl_error_t
-fn C.sgl_defaults()
+fn C.sgl_context_error(ctx C.sgl_context) C.sgl_error_t
 fn C.sgl_rad(deg f32) f32
 fn C.sgl_deg(rad f32) f32
 
+// context functions
+fn C.sgl_make_context(desc &C.sgl_context_desc_t) C.sgl_context
+fn C.sgl_destroy_context(ctx C.sgl_context)
+fn C.sgl_set_context(ctx C.sgl_context)
+fn C.sgl_get_context() C.sgl_context
+fn C.sgl_default_context() C.sgl_context
+
 // create and destroy pipeline objects
 fn C.sgl_make_pipeline(desc &C.sg_pipeline_desc) C.sgl_pipeline
+fn C.sgl_context_make_pipeline(ctx C.sgl_context, desc &C.sg_pipeline_desc) C.sgl_pipeline
 fn C.sgl_destroy_pipeline(pip C.sgl_pipeline)
 
 // render state functions
+fn C.sgl_defaults()
 fn C.sgl_viewport(x int, y int, w int, h int, origin_top_left bool)
 fn C.sgl_viewportf(x f32, y f32, w f32, h f32, origin_top_left bool)
 fn C.sgl_scissor_rect(x int, y int, w int, h int, origin_top_left bool)
@@ -87,5 +96,6 @@ fn C.sgl_v3f_t2f_c4b(x f32, y f32, z f32, u f32, v f32, r byte, g byte, b byte, 
 fn C.sgl_v3f_t2f_c1i(x f32, y f32, z f32, u f32, v f32, rgba u32)
 fn C.sgl_end()
 
-// render everything
+// render recorded commands
 fn C.sgl_draw()
+fn C.sgl_context_draw(ctx C.sgl_context)

--- a/vlib/sokol/sgl/sgl_structs.c.v
+++ b/vlib/sokol/sgl/sgl_structs.c.v
@@ -1,24 +1,47 @@
 module sgl
 
-// should be in a proper module
-pub enum SglError {
-	no_error
-	vertices_full
-	commands_full
-	stack_overflow
-	stack_underfloat
-}
+import sokol.gfx
 
-pub struct C.sgl_pipeline {
+[typedef]
+struct C.sgl_pipeline {
 	id u32
 }
 
-pub struct C.sgl_desc_t {
+pub type Pipeline = C.sgl_pipeline
+
+[typedef]
+struct C.sgl_context {
+	id u32
+}
+
+pub type Context = C.sgl_context
+
+// ContextDesc
+//
+// Describes the initialization parameters of a rendering context.
+// Creating additional contexts is useful if you want to render
+// in separate sokol-gfx passes.
+// ContextDesc is sgl_context_desc_t
+pub type ContextDesc = C.sgl_context_desc_t
+
+[typedef]
+struct C.sgl_context_desc_t {
+	max_vertices int // default: 64k
+	max_commands int // default: 16k
+	color_format gfx.PixelFormat // C.sg_pixel_format
+	depth_format gfx.PixelFormat // C.sg_pixel_format
+	sample_count int
+}
+
+pub type Desc = C.sgl_desc_t
+
+[typedef]
+struct C.sgl_desc_t {
 	max_vertices       int // size for vertex buffer
 	max_commands       int // size of uniform- and command-buffers
 	pipeline_pool_size int // size of the internal pipeline pool, default is 64
-	color_format       C.sg_pixel_format
-	depth_format       C.sg_pixel_format
+	color_format       gfx.PixelFormat // C.sg_pixel_format
+	depth_format       gfx.PixelFormat // C.sg_pixel_format
 	sample_count       int
-	face_winding       C.sg_face_winding // default front face winding is CCW
+	face_winding       gfx.FaceWinding // C.sg_face_winding // default front face winding is CCW
 }


### PR DESCRIPTION
This PR is much like #13014, though it adds support for the new `sgl_context` type also.
The type makes it possible to render with different render passes with sokol_gl.h.

More on `sgl_context` [here](https://github.com/floooh/sokol-samples/blob/master/sapp/sgl-context-sapp.c) and an example [here](https://floooh.github.io/sokol-html5/sgl-context-sapp.html)