### PR TITLE
net: fix errors of new_ip(), new_ip6() and ip6.str()

### DIFF
--- a/vlib/net/address.v
+++ b/vlib/net/address.v
@@ -24,7 +24,7 @@ fn new_ip6(port u16, addr [16]byte) Addr {
 		}
 	}
 
-	copy(a.addr.Ip6.addr[..], addr[..])
+	unsafe { vmemcpy(&a.addr.Ip6.addr[0], &addr[0], 16) }
 
 	return a
 }
@@ -39,7 +39,7 @@ fn new_ip(port u16, addr [4]byte) Addr {
 		}
 	}
 
-	copy(a.addr.Ip.addr[..], addr[..])
+	unsafe { vmemcpy(&a.addr.Ip.addr[0], &addr[0], 4) }
 
 	return a
 }
@@ -81,7 +81,7 @@ fn (a Ip) str() string {
 }
 
 fn (a Ip6) str() string {
-	buf := [net.max_ip_len]char{}
+	buf := [net.max_ip6_len]char{}
 
 	res := &char(C.inet_ntop(.ip6, &a.addr, &buf[0], buf.len))
 

--- a/vlib/net/address_test.v
+++ b/vlib/net/address_test.v
@@ -98,15 +98,28 @@ fn test_sizes_unix() {
 }
 
 fn test_ip_str() {
-	ip := new_ip(1337, addr_ip_any).str()
-	expected := '0.0.0.0:1337'
-	assert ip.len == expected.len
-	assert ip == expected
+	ip1 := new_ip(1337, addr_ip_any).str()
+	expected1 := '0.0.0.0:1337'
+	assert ip1.len == expected1.len
+	assert ip1 == expected1
+
+	addr := [byte(2), 0, 2, 2]!
+	ip2 := new_ip(2202, addr).str()
+	expected2 := '2.0.2.2:2202'
+	assert ip2.len == expected2.len
+	assert ip2 == expected2
 }
 
 fn test_ip6_str() {
-	ip := new_ip6(1337, addr_ip6_any).str()
-	expected := '[::]:1337'
-	assert ip.len == expected.len
-	assert ip == expected
+	ip1 := new_ip6(1337, addr_ip6_any).str()
+	expected1 := '[::]:1337'
+	assert ip1.len == expected1.len
+	assert ip1 == expected1
+
+	addr := [byte(2), 0, 2, 2, 2, 0, 1, 1, 2, 3, 2, 1, 2, 3, 5, 2]!
+	ip2 := new_ip6(2022, addr).str()
+	println(ip2)
+	expected2 := '[200:202:200:101:203:201:203:502]:2022'
+	assert ip2.len == expected2.len
+	assert ip2 == expected2
 }


### PR DESCRIPTION
This PR fix errors of new_ip(), new_ip6() and ip6.str().

- `copy(a.addr.Ip.addr[..], addr[..])` cannot change fixed array `a.addr.Ip.addr`.
- use `unsafe { vmemcpy(&a.addr.Ip.addr[0], &addr[0], 4) }`.
- Fix ip6.str().
- Add tests in address_test.v.