### PR TITLE
ast, cgen: fix const fixed array of reference value

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -835,7 +835,7 @@ pub fn (t &Table) array_fixed_cname(elem_type Type, size int) string {
 	if elem_type.is_ptr() {
 		res = '_ptr$elem_type.nr_muls()'
 	}
-	return 'Array_fixed_${elem_type_sym.cname}_$size' + res
+	return 'Array_fixed_$elem_type_sym.cname${res}_$size'
 }
 
 [inline]

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1138,6 +1138,9 @@ pub fn (mut g Gen) write_typedef_types() {
 					if fixed.starts_with('C__') {
 						fixed = fixed[3..]
 					}
+					if fixed.contains('ptr') {
+						fixed = 'void*'
+					}
 					if elem_sym.info is ast.FnType {
 						pos := g.out.len
 						g.write_fn_ptr_decl(&elem_sym.info, '')

--- a/vlib/v/tests/const_fixed_array_of_reference_value_test.v
+++ b/vlib/v/tests/const_fixed_array_of_reference_value_test.v
@@ -1,0 +1,10 @@
+const (
+	foo         = u32(1)
+	bar         = u32(2)
+	weapon_keys = [&foo, &bar]!
+)
+
+fn test_const_fixed_array_of_ref_value() {
+	assert weapon_keys[0] == &foo
+	assert weapon_keys[1] == &bar
+}


### PR DESCRIPTION
This PR fix const fixed array of reference value.

- Fix const fixed array of reference value.
- Add test.

```vlang
const (
	foo         = u32(1)
	bar         = u32(2)
	weapon_keys = [&foo, &bar]!
)

fn main() {
	assert weapon_keys[0] == &foo
	assert weapon_keys[1] == &bar
}

PS D:\Test\v\tt1> v run .
```