### PR TITLE
ast: fix anon fn with alias arguments

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -199,17 +199,26 @@ pub fn (t &Table) fn_type_signature(f &Fn) string {
 	for i, arg in f.params {
 		// TODO: for now ignore mut/pts in sig for now
 		typ := arg.typ.set_nr_muls(0)
-		arg_type_sym := t.final_sym(typ)
-		sig += arg_type_sym.str().to_lower().replace_each(['.', '__', '&', '', '[', 'arr_', 'chan ',
-			'chan_', 'map[', 'map_of_', ']', '_to_', '<', '_T_', ',', '_', ' ', '', '>', ''])
+		arg_type_sym := t.sym(typ)
+		if arg_type_sym.kind == .alias {
+			sig += arg_type_sym.name.replace('.', '__')
+		} else {
+			sig += arg_type_sym.str().to_lower().replace_each(['.', '__', '&', '', '[', 'arr_',
+				'chan ', 'chan_', 'map[', 'map_of_', ']', '_to_', '<', '_T_', ',', '_', ' ', '',
+				'>', ''])
+		}
 		if i < f.params.len - 1 {
 			sig += '_'
 		}
 	}
 	if f.return_type != 0 && f.return_type != void_type {
-		sym := t.final_sym(f.return_type)
+		sym := t.sym(f.return_type)
 		opt := if f.return_type.has_flag(.optional) { 'option_' } else { '' }
-		sig += '__$opt$sym.kind'
+		if sym.kind == .alias {
+			sig += '__$opt${sym.name.replace('.', '__')}'
+		} else {
+			sig += '__$opt$sym.kind'
+		}
 	}
 	return sig
 }

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -199,7 +199,7 @@ pub fn (t &Table) fn_type_signature(f &Fn) string {
 	for i, arg in f.params {
 		// TODO: for now ignore mut/pts in sig for now
 		typ := arg.typ.set_nr_muls(0)
-		arg_type_sym := t.sym(typ)
+		arg_type_sym := t.final_sym(typ)
 		sig += arg_type_sym.str().to_lower().replace_each(['.', '__', '&', '', '[', 'arr_', 'chan ',
 			'chan_', 'map[', 'map_of_', ']', '_to_', '<', '_T_', ',', '_', ' ', '', '>', ''])
 		if i < f.params.len - 1 {
@@ -207,7 +207,7 @@ pub fn (t &Table) fn_type_signature(f &Fn) string {
 		}
 	}
 	if f.return_type != 0 && f.return_type != void_type {
-		sym := t.sym(f.return_type)
+		sym := t.final_sym(f.return_type)
 		opt := if f.return_type.has_flag(.optional) { 'option_' } else { '' }
 		sig += '__$opt$sym.kind'
 	}

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -201,7 +201,7 @@ pub fn (t &Table) fn_type_signature(f &Fn) string {
 		typ := arg.typ.set_nr_muls(0)
 		arg_type_sym := t.sym(typ)
 		if arg_type_sym.kind == .alias {
-			sig += arg_type_sym.name.replace('.', '__')
+			sig += arg_type_sym.cname
 		} else {
 			sig += arg_type_sym.str().to_lower().replace_each(['.', '__', '&', '', '[', 'arr_',
 				'chan ', 'chan_', 'map[', 'map_of_', ']', '_to_', '<', '_T_', ',', '_', ' ', '',
@@ -215,7 +215,7 @@ pub fn (t &Table) fn_type_signature(f &Fn) string {
 		sym := t.sym(f.return_type)
 		opt := if f.return_type.has_flag(.optional) { 'option_' } else { '' }
 		if sym.kind == .alias {
-			sig += '__$opt${sym.name.replace('.', '__')}'
+			sig += '__$opt$sym.cname'
 		} else {
 			sig += '__$opt$sym.kind'
 		}

--- a/vlib/v/tests/anon_fn_with_alias_args_test.v
+++ b/vlib/v/tests/anon_fn_with_alias_args_test.v
@@ -1,0 +1,36 @@
+type MyString = string
+type MyInt = int
+
+struct S1 {
+	x fn (a int) MyString
+}
+
+struct S2 {
+	y fn (a int) MyInt
+}
+
+fn get_string(a int) MyString {
+	return '$a'
+}
+
+fn get_int(a int) MyInt {
+	return a
+}
+
+fn test_anon_fn_with_alias_args() {
+	s1 := S1{
+		x: get_string
+	}
+	println(s1.x)
+	ret1 := s1.x(22)
+	println(ret1)
+	assert ret1 == '22'
+
+	s2 := S2{
+		y: get_int
+	}
+	println(s2.y)
+	ret2 := s2.y(22)
+	println(ret2)
+	assert ret2 == 22
+}


### PR DESCRIPTION
This PR fix anon fn with alias arguments.

- Fix anon fn with alias arguments.
- Add test.

```vlang
type MyString = string
type MyInt = int

struct S1 {
	x fn (a int) MyString
}

struct S2 {
	y fn (a int) MyInt
}

fn get_string(a int) MyString {
	return '$a'
}

fn get_int(a int) MyInt {
	return a
}

fn main() {
	s1 := S1{
		x: get_string
	}
	println(s1.x)
	ret1 := s1.x(22)
	println(ret1)
	assert ret1 == '22'

	s2 := S2{
		y: get_int
	}
	println(s2.y)
	ret2 := s2.y(22)
	println(ret2)
	assert ret2 == 22
}

PS D:\Test\v\tt1> v run .
fn (int) MyString
22
fn (int) MyInt
22
```
```vlang
typedef main__MyString (*anon_fn_int__main__MyString)(int);
typedef main__MyInt (*anon_fn_int__main__MyInt)(int);
```