### PR TITLE
checker: fix generic fn using generic type in if expr (fix #13026)

### DIFF
--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -547,7 +547,7 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Position) bool {
 					return false
 				}
 				// `$if some_var {}`, or `[if user_defined_tag] fn abc(){}`
-				typ := c.expr(cond)
+				typ := c.unwrap_generic(c.expr(cond))
 				if cond.obj !is ast.Var && cond.obj !is ast.ConstField
 					&& cond.obj !is ast.GlobalField {
 					if !c.inside_ct_attr {

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -39,7 +39,7 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 			} else {
 				// check condition type is boolean
 				c.expected_type = ast.bool_type
-				cond_typ := c.expr(branch.cond)
+				cond_typ := c.unwrap_generic(c.expr(branch.cond))
 				if (cond_typ.idx() != ast.bool_type_idx || cond_typ.has_flag(.optional))
 					&& !c.pref.translated {
 					c.error('non-bool type `${c.table.type_to_str(cond_typ)}` used as if condition',

--- a/vlib/v/tests/generic_fn_using_generic_type_in_if_test.v
+++ b/vlib/v/tests/generic_fn_using_generic_type_in_if_test.v
@@ -1,0 +1,16 @@
+fn test_generic_fn_using_generic_type_in_if() {
+	ret := generic_bool(true)
+	assert ret == 'true'
+}
+
+fn generic_bool<T>(val T) string {
+	$if T is bool {
+		if val {
+			println('is true')
+			return 'true'
+		} else {
+			println('is false')
+			return 'false'
+		}
+	}
+}


### PR DESCRIPTION
This PR fix generic fn using generic type in if expr (fix #13026).

- Fix generic fn using generic type in if expr.
- Add test.

```vlang
fn main() {
	ret := generic_bool(true)
	assert ret == 'true'
}

fn generic_bool<T>(val T) string {
	$if T is bool {
		if val {
			println('is true')
			return 'true'
		} else {
			println('is false')
			return 'false'
		}
	}
}

PS D:\Test\v\tt1> v run .
is true
```