### PR TITLE
checker: fix cast to byte in comptime if (fix #13035)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2629,7 +2629,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 	//        node.typ: `Outside`
 	node.expr_type = c.expr(node.expr) // type to be casted
 
-	mut from_type := node.expr_type
+	mut from_type := c.unwrap_generic(node.expr_type)
 	from_sym := c.table.sym(from_type)
 	final_from_sym := c.table.final_sym(from_type)
 

--- a/vlib/v/tests/cast_in_comptime_if_test.v
+++ b/vlib/v/tests/cast_in_comptime_if_test.v
@@ -1,0 +1,18 @@
+fn test_cast_in_comptime_if() {
+	generic_bool(true)
+}
+
+fn generic_bool<T>(val T) {
+	$if T is bool {
+		println(byte(val))
+		assert byte(val) == 1
+
+		println(i8(val))
+		assert i8(val) == 1
+
+		println(i16(val))
+		assert i16(val) == 1
+	} $else {
+		assert false
+	}
+}


### PR DESCRIPTION
This PR fix cast to byte in comptime if (fix #13035).

- Fix cast to byte in comptime if.
- Add test.

```vlang
fn main() {
	generic_bool(true)
}

fn generic_bool<T>(val T) {
	$if T is bool {
		println(byte(val))
		assert byte(val) == 1

		println(i8(val))
		assert i8(val) == 1

		println(i16(val))
		assert i16(val) == 1
	} $else {
		assert false
	}
}

PS D:\Test\v\tt1> v run .
1
1
1
```