### PR TITLE
cgen: fix cgen remove random chars from you parameter_name

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6742,7 +6742,7 @@ static inline __shared__$interface_name ${shared_fn_name}(__shared__$cctype* x) 
 					mut parameter_name := g.out.cut_last(g.out.len - params_start_pos)
 
 					if st.is_ptr() {
-						parameter_name = parameter_name.trim_prefix('__shared__')
+						parameter_name = parameter_name.trim_string_left('__shared__')
 					}
 
 					methods_wrapper.write_string(parameter_name)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6742,7 +6742,7 @@ static inline __shared__$interface_name ${shared_fn_name}(__shared__$cctype* x) 
 					mut parameter_name := g.out.cut_last(g.out.len - params_start_pos)
 
 					if st.is_ptr() {
-						parameter_name = parameter_name.trim_left('__shared__')
+						parameter_name = parameter_name.trim_prefix('__shared__')
 					}
 
 					methods_wrapper.write_string(parameter_name)


### PR DESCRIPTION
It probably needs to be discussed if `trim_left` needs to be renamed to something like `trim_charset_left`, to distinguish it from `trim_prefix`, to prevent hard to catch bugs.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
