### PR TITLE
math: move the `math.mathutil` generic `min`/`max`/`abs` fns to `math`

### DIFF
--- a/examples/2048/2048.v
+++ b/examples/2048/2048.v
@@ -1,7 +1,6 @@
 import gg
 import gx
 import math
-import math.mathutil as mu
 import os
 import rand
 import time
@@ -563,7 +562,7 @@ fn (mut app App) resize() {
 	window_size := gg.window_size()
 	w := window_size.width
 	h := window_size.height
-	m := f32(mu.min(w, h))
+	m := f32(math.min(w, h))
 	app.ui.dpi_scale = s
 	app.ui.window_width = w
 	app.ui.window_height = h
@@ -587,7 +586,7 @@ fn (app &App) draw() {
 	xpad, ypad := app.ui.x_padding, app.ui.y_padding
 	ww := app.ui.window_width
 	wh := app.ui.window_height
-	m := mu.min(ww, wh)
+	m := math.min(ww, wh)
 	labelx := xpad + app.ui.border_size
 	labely := ypad + app.ui.border_size / 2
 	app.draw_tiles()
@@ -621,7 +620,7 @@ fn (app &App) draw_tiles() {
 	xstart := app.ui.x_padding + app.ui.border_size
 	ystart := app.ui.y_padding + app.ui.border_size + app.ui.header_size
 	toffset := app.ui.tile_size + app.ui.padding_size
-	tiles_size := mu.min(app.ui.window_width, app.ui.window_height) - app.ui.border_size * 2
+	tiles_size := math.min(app.ui.window_width, app.ui.window_height) - app.ui.border_size * 2
 	// Draw the padding around the tiles
 	app.gg.draw_rounded_rect_filled(xstart, ystart, tiles_size, tiles_size, tiles_size / 24,
 		app.theme.padding_color)
@@ -683,8 +682,8 @@ fn (app &App) draw_tiles() {
 
 fn (mut app App) handle_touches() {
 	s, e := app.touch.start, app.touch.end
-	adx, ady := mu.abs(e.pos.x - s.pos.x), mu.abs(e.pos.y - s.pos.y)
-	if mu.max(adx, ady) < 10 {
+	adx, ady := math.abs(e.pos.x - s.pos.x), math.abs(e.pos.y - s.pos.y)
+	if math.max(adx, ady) < 10 {
 		app.handle_tap()
 	} else {
 		app.handle_swipe()
@@ -694,7 +693,7 @@ fn (mut app App) handle_touches() {
 fn (mut app App) handle_tap() {
 	_, ypad := app.ui.x_padding, app.ui.y_padding
 	w, h := app.ui.window_width, app.ui.window_height
-	m := mu.min(w, h)
+	m := math.min(w, h)
 	s, e := app.touch.start, app.touch.end
 	avgx, avgy := avg(s.pos.x, e.pos.x), avg(s.pos.y, e.pos.y)
 	// TODO: Replace "touch spots" with actual buttons
@@ -732,12 +731,12 @@ fn (mut app App) handle_swipe() {
 	s, e := app.touch.start, app.touch.end
 	w, h := app.ui.window_width, app.ui.window_height
 	dx, dy := e.pos.x - s.pos.x, e.pos.y - s.pos.y
-	adx, ady := mu.abs(dx), mu.abs(dy)
-	dmin := if mu.min(adx, ady) > 0 { mu.min(adx, ady) } else { 1 }
-	dmax := if mu.max(adx, ady) > 0 { mu.max(adx, ady) } else { 1 }
+	adx, ady := math.abs(dx), math.abs(dy)
+	dmin := if math.min(adx, ady) > 0 { math.min(adx, ady) } else { 1 }
+	dmax := if math.max(adx, ady) > 0 { math.max(adx, ady) } else { 1 }
 	tdiff := int(e.time.unix_time_milli() - s.time.unix_time_milli())
 	// TODO: make this calculation more accurate (don't use arbitrary numbers)
-	min_swipe_distance := int(math.sqrt(mu.min(w, h) * tdiff / 100)) + 20
+	min_swipe_distance := int(math.sqrt(math.min(w, h) * tdiff / 100)) + 20
 	if dmax < min_swipe_distance {
 		return
 	}

--- a/examples/term.ui/text_editor.v
+++ b/examples/term.ui/text_editor.v
@@ -3,8 +3,8 @@
 // Don't use this editor for any serious work.
 // A lot of funtionality is missing compared to your favourite editor :)
 import strings
-import math.mathutil as mu
 import os
+import math
 import term.ui as tui
 
 enum Movement {
@@ -330,11 +330,11 @@ fn (mut b Buffer) move_cursor(amount int, movement Movement) {
 			}
 		}
 		.page_up {
-			dlines := mu.min(b.cursor.pos_y, amount)
+			dlines := math.min(b.cursor.pos_y, amount)
 			b.move_updown(-dlines)
 		}
 		.page_down {
-			dlines := mu.min(b.lines.len - 1, b.cursor.pos_y + amount) - b.cursor.pos_y
+			dlines := math.min(b.lines.len - 1, b.cursor.pos_y + amount) - b.cursor.pos_y
 			b.move_updown(dlines)
 		}
 		.left {

--- a/vlib/math/abs.v
+++ b/vlib/math/abs.v
@@ -1,15 +1,6 @@
 module math
 
-// Returns the absolute value.
-[inline]
-pub fn abs(x f64) f64 {
-	if x > 0.0 {
-		return x
-	}
-	return -x
-}
-
-[inline]
+[deprecated: 'use math.abs() instead']
 pub fn fabs(x f64) f64 {
 	if x > 0.0 {
 		return x

--- a/vlib/math/big/array_ops.v
+++ b/vlib/math/big/array_ops.v
@@ -1,6 +1,6 @@
 module big
 
-import math.util
+import math
 
 // Compares the magnitude of the two unsigned integers represented the given
 // digit arrays. Returns -1 if a < b, 0 if a == b and +1 if a > b. Here
@@ -40,8 +40,8 @@ fn add_digit_array(operand_a []u32, operand_b []u32, mut sum []u32) {
 	}
 
 	// First pass intersects with both operands
-	smaller_limit := util.imin(operand_a.len, operand_b.len)
-	larger_limit := util.imax(operand_a.len, operand_b.len)
+	smaller_limit := math.min(operand_a.len, operand_b.len)
+	larger_limit := math.max(operand_a.len, operand_b.len)
 	mut a, mut b := if operand_a.len >= operand_b.len {
 		operand_a, operand_b
 	} else {
@@ -316,7 +316,7 @@ fn bitwise_or_digit_array(operand_a []u32, operand_b []u32, mut storage []u32) {
 }
 
 fn bitwise_and_digit_array(operand_a []u32, operand_b []u32, mut storage []u32) {
-	lower := util.imin(operand_a.len, operand_b.len)
+	lower := math.min(operand_a.len, operand_b.len)
 	for index in 0 .. lower {
 		storage[index] = operand_a[index] & operand_b[index]
 	}

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -1,6 +1,6 @@
 module big
 
-import math.util
+import math
 import math.bits
 import strings
 import strconv
@@ -37,7 +37,7 @@ pub fn integer_from_int(value int) Integer {
 		return zero_int
 	}
 	return Integer{
-		digits: [u32(util.iabs(value))]
+		digits: [u32(math.abs(value))]
 		signum: int_signum(value)
 	}
 }
@@ -295,7 +295,7 @@ pub fn (integer Integer) - (subtrahend Integer) Integer {
 fn (integer Integer) add(addend Integer) Integer {
 	a := integer.digits
 	b := addend.digits
-	mut storage := []u32{len: util.imax(a.len, b.len) + 1}
+	mut storage := []u32{len: math.max(a.len, b.len) + 1}
 	add_digit_array(a, b, mut storage)
 	return Integer{
 		...integer
@@ -468,7 +468,7 @@ fn check_sign(a Integer) {
 pub fn (a Integer) bitwise_or(b Integer) Integer {
 	check_sign(a)
 	check_sign(b)
-	mut result := []u32{len: util.imax(a.digits.len, b.digits.len), init: 0}
+	mut result := []u32{len: math.max(a.digits.len, b.digits.len), init: 0}
 	bitwise_or_digit_array(a.digits, b.digits, mut result)
 	return Integer{
 		digits: result
@@ -479,7 +479,7 @@ pub fn (a Integer) bitwise_or(b Integer) Integer {
 pub fn (a Integer) bitwise_and(b Integer) Integer {
 	check_sign(a)
 	check_sign(b)
-	mut result := []u32{len: util.imax(a.digits.len, b.digits.len), init: 0}
+	mut result := []u32{len: math.max(a.digits.len, b.digits.len), init: 0}
 	bitwise_and_digit_array(a.digits, b.digits, mut result)
 	return Integer{
 		digits: result
@@ -500,7 +500,7 @@ pub fn (a Integer) bitwise_not() Integer {
 pub fn (a Integer) bitwise_xor(b Integer) Integer {
 	check_sign(a)
 	check_sign(b)
-	mut result := []u32{len: util.imax(a.digits.len, b.digits.len), init: 0}
+	mut result := []u32{len: math.max(a.digits.len, b.digits.len), init: 0}
 	bitwise_xor_digit_array(a.digits, b.digits, mut result)
 	return Integer{
 		digits: result
@@ -817,7 +817,7 @@ pub fn (x Integer) gcd_binary(y Integer) Integer {
 
 	mut az := a.msb()
 	bz := b.msb()
-	shift := util.umin(az, bz)
+	shift := math.min(az, bz)
 	b = b.rshift(bz)
 
 	for a.signum != 0 {

--- a/vlib/math/big/special_array_ops.v
+++ b/vlib/math/big/special_array_ops.v
@@ -1,7 +1,7 @@
 module big
 
+import math
 import math.bits
-import math.util
 import strings
 
 // suppose operand_a bigger than operand_b and both not null.
@@ -96,7 +96,7 @@ fn karatsuba_multiply_digit_array(operand_a []u32, operand_b []u32, mut storage 
 	}
 	// karatsuba
 	// thanks to the base cases we can pass zero-length arrays to the mult func
-	half := util.imax(operand_a.len, operand_b.len) / 2
+	half := math.max(operand_a.len, operand_b.len) / 2
 	if half <= 0 {
 		panic('Unreachable. Both array have 1 length and multiply_array_by_digit should have been called')
 	}
@@ -118,8 +118,8 @@ fn karatsuba_multiply_digit_array(operand_a []u32, operand_b []u32, mut storage 
 	mut p_3 := []u32{len: a_l.len + b_l.len + 1, init: 0}
 	multiply_digit_array(a_l, b_l, mut p_3)
 
-	mut tmp_1 := []u32{len: util.imax(a_h.len, a_l.len) + 1, init: 0}
-	mut tmp_2 := []u32{len: util.imax(b_h.len, b_l.len) + 1, init: 0}
+	mut tmp_1 := []u32{len: math.max(a_h.len, a_l.len) + 1, init: 0}
+	mut tmp_2 := []u32{len: math.max(b_h.len, b_l.len) + 1, init: 0}
 	add_digit_array(a_h, a_l, mut tmp_1)
 	add_digit_array(b_h, b_l, mut tmp_2)
 
@@ -170,8 +170,8 @@ fn lshift_byte_in_place(mut a []u32, byte_nb int) {
 fn add_in_place(mut a []u32, b []u32) {
 	len_a := a.len
 	len_b := b.len
-	max := util.imax(len_a, len_b)
-	min := util.imin(len_a, len_b)
+	max := math.max(len_a, len_b)
+	min := math.min(len_a, len_b)
 	mut carry := u64(0)
 	for index in 0 .. min {
 		partial := carry + a[index] + b[index]
@@ -197,8 +197,8 @@ fn add_in_place(mut a []u32, b []u32) {
 fn subtract_in_place(mut a []u32, b []u32) {
 	len_a := a.len
 	len_b := b.len
-	max := util.imax(len_a, len_b)
-	min := util.imin(len_a, len_b)
+	max := math.max(len_a, len_b)
+	min := math.min(len_a, len_b)
 	mut carry := u32(0)
 	mut new_carry := u32(0)
 	for index in 0 .. min {

--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -61,24 +61,6 @@ pub fn digits(_n int, base int) []int {
 	return res
 }
 
-// max returns the maximum value of the two provided.
-[inline]
-pub fn max(a f64, b f64) f64 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-// min returns the minimum value of the two provided.
-[inline]
-pub fn min(a f64, b f64) f64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // minmax returns the minimum and maximum value of the two provided.
 pub fn minmax(a f64, b f64) (f64, f64) {
 	if a < b {

--- a/vlib/math/mathutil.v
+++ b/vlib/math/mathutil.v
@@ -1,24 +1,21 @@
 // Copyright (c) 2019-2022 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
-module mathutil
+module math
 
-[deprecated: 'use math.min instead']
-[deprecated_after: '2022-01-19']
+// min returns the minimum of `a` and `b`
 [inline]
 pub fn min<T>(a T, b T) T {
 	return if a < b { a } else { b }
 }
 
-[deprecated: 'use math.max instead']
-[deprecated_after: '2022-01-19']
+// max returns the maximum of `a` and `b`
 [inline]
 pub fn max<T>(a T, b T) T {
 	return if a > b { a } else { b }
 }
 
-[deprecated: 'use math.abs instead']
-[deprecated_after: '2022-01-19']
+// abs returns the absolute value of `a`
 [inline]
 pub fn abs<T>(a T) T {
 	return if a > 0 { a } else { -a }

--- a/vlib/math/mathutil_test.v
+++ b/vlib/math/mathutil_test.v
@@ -1,0 +1,22 @@
+import math
+
+fn test_min() {
+	assert math.min(42, 13) == 13
+	assert math.min(5, -10) == -10
+	assert math.min(7.1, 7.3) == 7.1
+	assert math.min(u32(32), u32(17)) == 17
+}
+
+fn test_max() {
+	assert math.max(42, 13) == 42
+	assert math.max(5, -10) == 5
+	assert math.max(7.1, 7.3) == 7.3
+	assert math.max(u32(60), u32(17)) == 60
+}
+
+fn test_abs() {
+	assert math.abs(99) == 99
+	assert math.abs(-10) == 10
+	assert math.abs(1.2345) == 1.2345
+	assert math.abs(-5.5) == 5.5
+}

--- a/vlib/math/util/util.v
+++ b/vlib/math/util/util.v
@@ -4,36 +4,48 @@
 module util
 
 // imin returns the smallest of two integer values
+[deprecated: 'use math.min instead']
+[deprecated_after: '2022-01-19']
 [inline]
 pub fn imin(a int, b int) int {
 	return if a < b { a } else { b }
 }
 
 // imin returns the biggest of two integer values
+[deprecated: 'use math.max instead']
+[deprecated_after: '2022-01-19']
 [inline]
 pub fn imax(a int, b int) int {
 	return if a > b { a } else { b }
 }
 
 // iabs returns an integer as absolute value
+[deprecated: 'use math.abs instead']
+[deprecated_after: '2022-01-19']
 [inline]
 pub fn iabs(v int) int {
 	return if v > 0 { v } else { -v }
 }
 
 // umin returns the smallest of two u32 values
+[deprecated: 'use math.min instead']
+[deprecated_after: '2022-01-19']
 [inline]
 pub fn umin(a u32, b u32) u32 {
 	return if a < b { a } else { b }
 }
 
 // umax returns the biggest of two u32 values
+[deprecated: 'use math.max instead']
+[deprecated_after: '2022-01-19']
 [inline]
 pub fn umax(a u32, b u32) u32 {
 	return if a > b { a } else { b }
 }
 
 // uabs returns an u32 as absolute value
+[deprecated: 'use math.abs instead']
+[deprecated_after: '2022-01-19']
 [inline]
 pub fn uabs(v u32) u32 {
 	return if v > 0 { v } else { -v }
@@ -41,6 +53,8 @@ pub fn uabs(v u32) u32 {
 
 // fmin_32 returns the smallest `f32` of input `a` and `b`.
 // Example: assert fmin_32(2.0,3.0) == 2.0
+[deprecated: 'use math.min instead']
+[deprecated_after: '2022-01-19']
 [inline]
 pub fn fmin_32(a f32, b f32) f32 {
 	return if a < b { a } else { b }
@@ -48,6 +62,8 @@ pub fn fmin_32(a f32, b f32) f32 {
 
 // fmax_32 returns the largest `f32` of input `a` and `b`.
 // Example: assert fmax_32(2.0,3.0) == 3.0
+[deprecated: 'use math.max instead']
+[deprecated_after: '2022-01-19']
 [inline]
 pub fn fmax_32(a f32, b f32) f32 {
 	return if a > b { a } else { b }
@@ -55,6 +71,8 @@ pub fn fmax_32(a f32, b f32) f32 {
 
 // fabs_32 returns the absolute value of `a` as a `f32` value.
 // Example: assert fabs_32(-2.0) == 2.0
+[deprecated: 'use math.abs instead']
+[deprecated_after: '2022-01-19']
 [inline]
 pub fn fabs_32(v f32) f32 {
 	return if v > 0 { v } else { -v }
@@ -62,6 +80,8 @@ pub fn fabs_32(v f32) f32 {
 
 // fmin_64 returns the smallest `f64` of input `a` and `b`.
 // Example: assert fmin_64(2.0,3.0) == 2.0
+[deprecated: 'use math.min instead']
+[deprecated_after: '2022-01-19']
 [inline]
 pub fn fmin_64(a f64, b f64) f64 {
 	return if a < b { a } else { b }
@@ -69,6 +89,8 @@ pub fn fmin_64(a f64, b f64) f64 {
 
 // fmax_64 returns the largest `f64` of input `a` and `b`.
 // Example: assert fmax_64(2.0,3.0) == 3.0
+[deprecated: 'use math.max instead']
+[deprecated_after: '2022-01-19']
 [inline]
 pub fn fmax_64(a f64, b f64) f64 {
 	return if a > b { a } else { b }
@@ -76,6 +98,8 @@ pub fn fmax_64(a f64, b f64) f64 {
 
 // fabs_64 returns the absolute value of `a` as a `f64` value.
 // Example: assert fabs_64(-2.0) == f64(2.0)
+[deprecated: 'use math.abs instead']
+[deprecated_after: '2022-01-19']
 [inline]
 pub fn fabs_64(v f64) f64 {
 	return if v > 0 { v } else { -v }

--- a/vlib/net/openssl/ssl_connection.v
+++ b/vlib/net/openssl/ssl_connection.v
@@ -179,12 +179,6 @@ pub fn (mut s SSLConn) socket_read_into_ptr(buf_ptr &byte, len int) ?int {
 	return res
 }
 
-[deprecated: 'call SSLConn.read instead']
-[deprecated_after: '2021-11-04']
-pub fn (mut s SSLConn) read_into(mut buffer []byte) ?int {
-	return s.read(mut buffer)
-}
-
 pub fn (mut s SSLConn) read(mut buffer []byte) ?int {
 	res := s.socket_read_into_ptr(&byte(buffer.data), buffer.len) ?
 	return res

--- a/vlib/toml/scanner/scanner.v
+++ b/vlib/toml/scanner/scanner.v
@@ -4,7 +4,7 @@
 module scanner
 
 import os
-import math.mathutil
+import math
 import toml.input
 import toml.token
 import toml.util
@@ -328,7 +328,7 @@ fn (mut s Scanner) new_token(kind token.Kind, lit string, len int) token.Token {
 	return token.Token{
 		kind: kind
 		lit: lit
-		col: mathutil.max(1, col)
+		col: math.max(1, col)
 		line_nr: s.line_nr + 1
 		pos: s.pos - s.header_len - len + 1
 		len: len

--- a/vlib/v/fmt/align.v
+++ b/vlib/v/fmt/align.v
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file.
 module fmt
 
-import math.mathutil
+import v.mathutil
 
 const struct_field_align_threshold = 8
 

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -3,11 +3,11 @@
 // that can be found in the LICENSE file.
 module fmt
 
-import math.mathutil
-import v.ast
 import strings
+import v.ast
 import v.util
 import v.pref
+import v.mathutil
 
 const (
 	bs      = '\\'

--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -3,9 +3,9 @@
 // that can be found in the LICENSE file.
 module fmt
 
-import math.mathutil as mu
 import strings
 import v.ast
+import v.mathutil as mu
 
 pub fn (mut f Fmt) struct_decl(node ast.StructDecl) {
 	f.attrs(node.attrs)

--- a/vlib/v/mathutil/mathutil.v
+++ b/vlib/v/mathutil/mathutil.v
@@ -3,22 +3,16 @@
 // that can be found in the LICENSE file.
 module mathutil
 
-[deprecated: 'use math.min instead']
-[deprecated_after: '2022-01-19']
 [inline]
 pub fn min<T>(a T, b T) T {
 	return if a < b { a } else { b }
 }
 
-[deprecated: 'use math.max instead']
-[deprecated_after: '2022-01-19']
 [inline]
 pub fn max<T>(a T, b T) T {
 	return if a > b { a } else { b }
 }
 
-[deprecated: 'use math.abs instead']
-[deprecated_after: '2022-01-19']
 [inline]
 pub fn abs<T>(a T) T {
 	return if a > 0 { a } else { -a }

--- a/vlib/v/mathutil/mathutil_test.v
+++ b/vlib/v/mathutil/mathutil_test.v
@@ -1,4 +1,4 @@
-import math as mu
+import v.mathutil as mu
 
 fn test_min() {
 	assert mu.min(42, 13) == 13

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -3,7 +3,6 @@
 // that can be found in the LICENSE file.
 module scanner
 
-import math.mathutil
 import os
 import strconv
 import v.token
@@ -12,6 +11,7 @@ import v.util
 import v.vet
 import v.errors
 import v.ast
+import v.mathutil
 
 const (
 	single_quote = `'`

--- a/vlib/v/tests/generics_method_on_generic_structs_test.v
+++ b/vlib/v/tests/generics_method_on_generic_structs_test.v
@@ -1,5 +1,5 @@
+import math
 import datatypes
-import math.mathutil
 
 struct Foo {
 	a int
@@ -26,7 +26,7 @@ fn test_datatypes_can_be_used_without_interfering_with_local_generic_structs() {
 
 fn test_generic_type_inference_on_generic_function_from_another_module_still_works() {
 	x := -123
-	a := mathutil.abs(x)
+	a := math.abs(x)
 	assert x == -123
 	assert a == 123
 }

--- a/vlib/v/util/errors.v
+++ b/vlib/v/util/errors.v
@@ -3,11 +3,11 @@
 // that can be found in the LICENSE file.
 module util
 
-import math.mathutil as mu
 import os
 import strings
 import term
 import v.token
+import v.mathutil as mu
 
 // The filepath:line:col: format is the default C compiler error output format.
 // It allows editors and IDE's like emacs to quickly find the errors in the

--- a/vlib/x/ttf/render_bmp.v
+++ b/vlib/x/ttf/render_bmp.v
@@ -15,7 +15,6 @@ module ttf
 **********************************************************************/
 import encoding.utf8
 import math
-import math.mathutil as mu
 
 pub struct BitMap {
 pub mut:
@@ -227,7 +226,7 @@ pub fn (mut bmp BitMap) aline(in_x0 int, in_y0 int, in_x1 int, in_y1 int, c u32)
 
 	dist := f32(0.4)
 
-	if mu.abs(dx) > mu.abs(dy) {
+	if math.abs(dx) > math.abs(dy) {
 		if x1 < x0 {
 			tmp = x0
 			x0 = x1
@@ -247,18 +246,18 @@ pub fn (mut bmp BitMap) aline(in_x0 int, in_y0 int, in_x1 int, in_y1 int, c u32)
 		mut x := x0
 		for x <= x1 + 0.5 {
 			y := m * (x - x0) + y0
-			e := 1 - mu.abs(y - 0.5 - int(y))
+			e := 1 - math.abs(y - 0.5 - int(y))
 			bmp.plot(int(x), int(y), color_multiply_alpha(c, e * 0.75))
 
 			ys1 := y + dist
 			if int(ys1) != int(y) {
-				v1 := mu.abs(ys1 - y) / dist * (1 - e)
+				v1 := math.abs(ys1 - y) / dist * (1 - e)
 				bmp.plot(int(x), int(ys1), color_multiply_alpha(c, v1))
 			}
 
 			ys2 := y - dist
 			if int(ys2) != int(y) {
-				v2 := mu.abs(y - ys2) / dist * (1 - e)
+				v2 := math.abs(y - ys2) / dist * (1 - e)
 				bmp.plot(int(x), int(ys2), color_multiply_alpha(c, v2))
 			}
 
@@ -284,18 +283,18 @@ pub fn (mut bmp BitMap) aline(in_x0 int, in_y0 int, in_x1 int, in_y1 int, c u32)
 		mut y := y0
 		for y <= y1 + 0.5 {
 			x := n * (y - y0) + x0
-			e := f32(1 - mu.abs(x - 0.5 - int(x)))
+			e := f32(1 - math.abs(x - 0.5 - int(x)))
 			bmp.plot(int(x), int(y), color_multiply_alpha(c, f32(e * 0.75)))
 
 			xs1 := x + dist
 			if int(xs1) != int(x) {
-				v1 := mu.abs(xs1 - x) / dist * (1 - e)
+				v1 := math.abs(xs1 - x) / dist * (1 - e)
 				bmp.plot(int(xs1), int(y), color_multiply_alpha(c, f32(v1)))
 			}
 
 			xs2 := x - dist
 			if int(xs2) != int(x) {
-				v2 := mu.abs(x - xs1) / dist * (1 - e)
+				v2 := math.abs(x - xs1) / dist * (1 - e)
 				bmp.plot(int(xs2), int(y), color_multiply_alpha(c, f32(v2)))
 			}
 			y += 1.0
@@ -336,9 +335,9 @@ pub fn (mut bmp BitMap) line(in_x0 int, in_y0 int, in_x1 int, in_y1 int, c u32) 
 	mut x := x0
 	mut y := y0
 
-	dx := mu.abs(x1 - x0)
+	dx := math.abs(x1 - x0)
 	sx := if x0 < x1 { 1 } else { -1 }
-	dy := -mu.abs(y1 - y0)
+	dy := -math.abs(y1 - y0)
 	sy := if y0 < y1 { 1 } else { -1 }
 
 	// verical line
@@ -412,8 +411,8 @@ pub fn (mut bmp BitMap) quadratic(in_x0 int, in_y0 int, in_x1 int, in_y1 int, in
 	cy := int(in_cy)
 
 	mut division := f64(1.0)
-	dx := mu.abs(x0 - x1)
-	dy := mu.abs(y0 - y1)
+	dx := math.abs(x0 - x1)
+	dy := math.abs(y0 - y1)
 
 	// if few pixel draw a simple line
 	// if dx == 0 && dy == 0 {
@@ -521,10 +520,10 @@ pub fn (mut bmp BitMap) get_chars_bbox(in_string string) []int {
 		x_min, x_max, _, _ := bmp.tf.read_glyph_dim(c_index)
 		//-----------------
 
-		width := int((mu.abs(x_max + x_min) + ax) * bmp.scale)
+		width := int((math.abs(x_max + x_min) + ax) * bmp.scale)
 		// width := int((cw+ax) * bmp.scale)
 		w += width + div_space_cw
-		h := int(mu.abs(int(bmp.tf.y_max - bmp.tf.y_min)) * bmp.scale)
+		h := int(math.abs(int(bmp.tf.y_max - bmp.tf.y_min)) * bmp.scale)
 		res << w
 		res << h
 
@@ -592,7 +591,7 @@ pub fn (mut bmp BitMap) get_bbox(in_string string) (int, int) {
 		// x_max := 2
 		//-----------------
 
-		width := int((mu.abs(x_max + x_min) + ax) * bmp.scale)
+		width := int((math.abs(x_max + x_min) + ax) * bmp.scale)
 		// width := int((cw+ax) * bmp.scale)
 		w += width + div_space_cw
 
@@ -601,7 +600,7 @@ pub fn (mut bmp BitMap) get_bbox(in_string string) (int, int) {
 
 	// dprintln("y_min: $bmp.tf.y_min y_max: $bmp.tf.y_max res: ${int((bmp.tf.y_max - bmp.tf.y_min)*buf.scale)} width: ${int( (cw) * buf.scale)}")
 	// buf.box(0,y_base - int((bmp.tf.y_min)*buf.scale), int( (x_max) * buf.scale), y_base-int((bmp.tf.y_max)*buf.scale), u32(0xFF00_0000) )
-	return w, int(mu.abs(int(bmp.tf.y_max - bmp.tf.y_min)) * bmp.scale)
+	return w, int(math.abs(int(bmp.tf.y_max - bmp.tf.y_min)) * bmp.scale)
 }
 
 /******************************************************************************
@@ -621,7 +620,7 @@ fn (mut bmp BitMap) draw_notdef_glyph(in_x int, in_w int) {
 	bmp.ch_matrix[7] = int(y1)
 	x, y := bmp.trf_ch(p)
 
-	y_h := mu.abs(bmp.tf.y_max - bmp.tf.y_min) * bmp.scale * 0.5
+	y_h := math.abs(bmp.tf.y_max - bmp.tf.y_min) * bmp.scale * 0.5
 
 	bmp.box(int(x), int(y), int(x - in_w), int(y - y_h), bmp.color)
 	bmp.line(int(x), int(y), int(x - in_w), int(y - y_h), bmp.color)
@@ -690,7 +689,7 @@ pub fn (mut bmp BitMap) draw_text(in_string string) (int, int) {
 		// x_max := 2
 		//-----------------
 
-		mut width := int((mu.abs(x_max + x_min) + ax) * bmp.scale)
+		mut width := int((math.abs(x_max + x_min) + ax) * bmp.scale)
 		if bmp.use_font_metrics {
 			width = int((cw + ax) * bmp.scale)
 		}
@@ -700,7 +699,7 @@ pub fn (mut bmp BitMap) draw_text(in_string string) (int, int) {
 
 	// dprintln("y_min: $bmp.tf.y_min y_max: $bmp.tf.y_max res: ${int((bmp.tf.y_max - bmp.tf.y_min)*buf.scale)} width: ${int( (cw) * buf.scale)}")
 	// buf.box(0,y_base - int((bmp.tf.y_min)*buf.scale), int( (x_max) * buf.scale), y_base-int((bmp.tf.y_max)*buf.scale), u32(0xFF00_0000) )
-	return w, int(mu.abs(int(bmp.tf.y_max - bmp.tf.y_min)) * bmp.scale)
+	return w, int(math.abs(int(bmp.tf.y_max - bmp.tf.y_min)) * bmp.scale)
 }
 
 pub fn (mut bmp BitMap) draw_glyph(index u16) (int, int) {

--- a/vlib/x/ttf/ttf_test.v
+++ b/vlib/x/ttf/ttf_test.v
@@ -215,15 +215,15 @@ fn test_main() {
 fn get_raw_data(data string) []byte {
 	mut buf := []byte{}
 	mut c := 0
-	mut b := 0
+	mut b := u32(0)
 	for ch in data {
 		if ch >= `0` && ch <= `9` {
 			b = b << 4
-			b += int(ch - `0`)
+			b += u32(ch - `0`)
 			c++
 		} else if ch >= `a` && ch <= `f` {
 			b = b << 4
-			b += int(ch - `a` + 10)
+			b += u32(ch - `a` + 10)
 			c++
 		}
 


### PR DESCRIPTION
This PR deprecates both `math.mathutil` and `math.util`, by moving the generic
functions min/max/abs to `math`.