### PR TITLE
builtin: Use dlmalloc for freestanding backend

### DIFF
--- a/cmd/tools/vtest-all.v
+++ b/cmd/tools/vtest-all.v
@@ -158,6 +158,12 @@ fn get_all_commands() []Command {
 			okmsg: 'V can compile with -freestanding on Linux with GCC.'
 			rmfile: 'bel'
 		}
+
+		res << Command{
+			line: '$vexe -cc gcc -keepc -freestanding -o str_array vlib/strconv/bare/str_array_example.v'
+			okmsg: 'V can compile & allocate memory with -freestanding on Linux with GCC.'
+			rmfile: 'str_array'
+		}
 	}
 	res << Command{
 		line: '$vexe $vargs -progress test-cleancode'

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -292,13 +292,9 @@ pub fn malloc(n int) &byte {
 			res = C.GC_MALLOC(n)
 		}
 	} $else $if freestanding {
-		mut e := Errno{}
-		res, e = mm_alloc(u64(n))
-		if e != .enoerror {
-			eprint('malloc($n) failed: ')
-			eprintln(e.str())
-			panic('malloc($n) failed')
-		}
+		// todo: is this safe to call malloc there? We export __malloc as malloc and it uses dlmalloc behind the scenes
+		// so theoretically it is safe
+		res = unsafe { __malloc(usize(n)) }
 	} $else {
 		res = unsafe { C.malloc(n) }
 	}

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -341,13 +341,7 @@ pub fn malloc_noscan(n int) &byte {
 			}
 		}
 	} $else $if freestanding {
-		mut e := Errno{}
-		res, e = mm_alloc(u64(n))
-		if e != .enoerror {
-			eprint('malloc_noscan($n) failed: ')
-			eprintln(e.str())
-			panic('malloc_noscan($n) failed')
-		}
+		res = unsafe { __malloc(usize(n)) }
 	} $else {
 		res = unsafe { C.malloc(n) }
 	}

--- a/vlib/builtin/linux_bare/libc_impl.v
+++ b/vlib/builtin/linux_bare/libc_impl.v
@@ -1,5 +1,9 @@
 module builtin
 
+import dlmalloc
+
+__global global_allocator dlmalloc.Dlmalloc
+
 [unsafe]
 pub fn memcpy(dest &C.void, src &C.void, n usize) &C.void {
 	dest_ := unsafe { &byte(dest) }
@@ -15,7 +19,7 @@ pub fn memcpy(dest &C.void, src &C.void, n usize) &C.void {
 [export: 'malloc']
 [unsafe]
 fn __malloc(n usize) &C.void {
-	return unsafe { malloc(int(n)) }
+	return unsafe { global_allocator.malloc(n) }
 }
 
 [unsafe]
@@ -107,10 +111,14 @@ fn memcmp(a &C.void, b &C.void, n usize) int {
 [export: 'free']
 [unsafe]
 fn __free(ptr &C.void) {
+	/*
 	err := mm_free(ptr)
 	if err != .enoerror {
 		eprintln('free error:')
 		panic(err)
+	}*/
+	unsafe {
+		global_allocator.free_(ptr)
 	}
 }
 
@@ -127,7 +135,7 @@ fn bare_read(buf &byte, count u64) (i64, Errno) {
 	return sys_read(0, buf, count)
 }
 
-fn bare_print(buf &byte, len u64) {
+pub fn bare_print(buf &byte, len u64) {
 	sys_write(1, buf, len)
 }
 
@@ -159,4 +167,8 @@ fn __exit(code int) {
 [export: 'qsort']
 fn __qsort(base voidptr, nmemb usize, size usize, sort_cb FnSortCB) {
 	panic('qsort() is not yet implemented in `-freestanding`')
+}
+
+fn init_global_allocator() {
+	global_allocator = dlmalloc.new(get_linux_allocator())
 }

--- a/vlib/builtin/linux_bare/linux_syscalls.v
+++ b/vlib/builtin/linux_bare/linux_syscalls.v
@@ -262,6 +262,13 @@ fn sys_munmap(addr voidptr, len u64) Errno {
 	return Errno(-sys_call2(11, u64(addr), len))
 }
 
+// 25 sys_mremap
+fn sys_mremap(old_addr voidptr, old_len u64, new_len u64, flags u64) (&byte, Errno) {
+	rc := sys_call4(25, u64(old_addr), old_len, new_len, flags)
+	a, e := split_int_errno(rc)
+	return &byte(a), e
+}
+
 // 22  sys_pipe
 fn sys_pipe(filedes &int) Errno {
 	return Errno(sys_call1(22, u64(filedes)))

--- a/vlib/builtin/linux_bare/memory_managment.v
+++ b/vlib/builtin/linux_bare/memory_managment.v
@@ -1,5 +1,7 @@
 module builtin
 
+import dlmalloc
+
 fn mm_alloc(size u64) (&byte, Errno) {
 	// BEGIN CONSTS
 	// the constants need to be here, since the initialization of other constants,
@@ -25,5 +27,66 @@ fn mm_free(addr &byte) Errno {
 		ap := &u64(addr - sizeof(u64))
 		size := *ap
 		return sys_munmap(addr - sizeof(u64), size + sizeof(u64))
+	}
+}
+
+fn system_alloc(_ voidptr, size usize) (voidptr, usize, u32) {
+	// BEGIN CONSTS
+	// the constants need to be here, since the initialization of other constants,
+	// which happen before these ones would, require malloc
+	mem_prot := MemProt(int(MemProt.prot_read) | int(MemProt.prot_write))
+	map_flags := MapFlags(int(MapFlags.map_private) | int(MapFlags.map_anonymous))
+	// END CONSTS
+
+	a, e := sys_mmap(&byte(0), u64(size + sizeof(u64)), mem_prot, map_flags, -1, 0)
+
+	if e == .enoerror {
+		return a, size, 0
+	}
+	return voidptr(0), 0, 0
+}
+
+fn system_remap(_ voidptr, ptr voidptr, oldsize usize, newsize usize, can_move bool) voidptr {
+	return voidptr(0)
+}
+
+fn system_free_part(_ voidptr, ptr voidptr, oldsize usize, newsize usize) bool {
+	_, e := sys_mremap(ptr, u64(oldsize), u64(newsize), 0)
+	if e == .enoerror {
+		return true
+	}
+	e2 := sys_munmap(voidptr(usize(ptr) + newsize), u64(oldsize - newsize))
+
+	return e2 == .enoerror
+}
+
+fn system_free(_ voidptr, ptr voidptr, size usize) bool {
+	unsafe {
+		return sys_munmap(ptr, u64(size)) == .enoerror
+	}
+}
+
+fn system_can_release_part(_ voidptr, _ u32) bool {
+	return true
+}
+
+fn system_allocates_zeros(_ voidptr) bool {
+	return true
+}
+
+fn system_page_size(_ voidptr) usize {
+	return 4096
+}
+
+fn get_linux_allocator() dlmalloc.Allocator {
+	return dlmalloc.Allocator{
+		alloc: system_alloc
+		remap: system_remap
+		free_part: system_free_part
+		free_: system_free
+		can_release_part: system_can_release_part
+		allocates_zeros: system_allocates_zeros
+		page_size: system_page_size
+		data: voidptr(0)
 	}
 }

--- a/vlib/dlmalloc/global.v
+++ b/vlib/dlmalloc/global.v
@@ -54,7 +54,7 @@ pub fn realloc(ptr voidptr, oldsize usize, newsize usize) voidptr {
 [unsafe]
 pub fn memalign(size usize, align usize) voidptr {
 	unsafe {
-		if align <= malloc_alignment {
+		if align <= malloc_alignment() {
 			return global.malloc(size)
 		} else {
 			return global.memalign(align, size)

--- a/vlib/strconv/bare/str_array_example.v
+++ b/vlib/strconv/bare/str_array_example.v
@@ -1,0 +1,7 @@
+fn main() {
+	mut x := []int{cap: 100}
+	x << 42
+	x << 41
+	x << 40
+	println(x)
+}

--- a/vlib/v/builder/rebuilding.v
+++ b/vlib/v/builder/rebuilding.v
@@ -211,7 +211,7 @@ fn (mut b Builder) handle_usecache(vexe string) {
 			// strconv is already imported inside builtin, so skip generating its object file
 			// TODO: incase we have other modules with the same name, make sure they are vlib
 			// is this even doign anything?
-			if imp in ['strconv', 'strings'] {
+			if imp in ['strconv', 'strings', 'dlmalloc'] {
 				continue
 			}
 			if imp in built_modules {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1774,7 +1774,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 		}
 		ast.Module {
 			// g.is_builtin_mod = node.name == 'builtin'
-			g.is_builtin_mod = node.name in ['builtin', 'strconv', 'strings']
+			g.is_builtin_mod = node.name in ['builtin', 'strconv', 'strings', 'dlmalloc']
 			// g.cur_mod = node.name
 			g.cur_mod = node
 		}
@@ -5202,7 +5202,7 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 				g.definitions.writeln('$mod$styp $attributes $field.name = {0}; // global')
 			} else {
 				g.definitions.writeln('$mod$styp $attributes $field.name; // global')
-				if field.name !in ['as_cast_type_indexes', 'g_memory_block'] {
+				if field.name !in ['as_cast_type_indexes', 'g_memory_block', 'global_allocator'] {
 					g.global_init.writeln('\t$field.name = *($styp*)&(($styp[]){${g.type_default(field.typ)}}[0]); // global')
 				}
 			}
@@ -5565,6 +5565,10 @@ fn (mut g Gen) write_init_function() {
 		// 11 is SIGSEGV. It is hardcoded here, to avoid FreeBSD compilation errors for trivial examples.
 		g.writeln('#if __STDC_HOSTED__ == 1\n\tsignal(11, v_segmentation_fault_handler);\n#endif')
 	}
+	if g.pref.is_bare {
+		g.writeln('init_global_allocator();')
+	}
+
 	if g.pref.prealloc {
 		g.writeln('prealloc_vinit();')
 	}

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -11,7 +11,7 @@ import v.util.recompilation
 
 // math.bits is needed by strconv.ftoa
 pub const (
-	builtin_module_parts = ['math.bits', 'strconv', 'strconv.ftoa', 'strings', 'builtin']
+	builtin_module_parts = ['math.bits', 'strconv', 'dlmalloc', 'strconv.ftoa', 'strings', 'builtin']
 	bundle_modules       = ['clipboard', 'fontstash', 'gg', 'gx', 'sokol', 'szip', 'ui']
 )
 


### PR DESCRIPTION
In this PR when code is compiled with `-freestanding` flag, `malloc` and `free` calls will use dlmalloc as default allocator instead of mmap/munmap. In the future this should allow us to get freestanding work on Windows/macOS/WASM/etc and not only Linux