### PR TITLE
checker: fix error for cast to u8 (fix #13057)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2669,7 +2669,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		}
 	} else if mut to_sym.info is ast.Alias {
 		if !c.check_types(from_type, to_sym.info.parent_type) && !(final_to_sym.is_int()
-			&& final_from_sym.kind == .enum_) {
+			&& final_from_sym.kind in [.enum_, .bool]) {
 			c.error('cannot convert type `$from_sym.name` to `$to_sym.name` (alias to `$final_to_sym.name`)',
 				node.pos)
 		}

--- a/vlib/v/tests/cast_to_u8_test.v
+++ b/vlib/v/tests/cast_to_u8_test.v
@@ -1,0 +1,16 @@
+module main
+
+fn test_cast_to_alias() {
+	r1 := u8(byte(1))
+	println(r1)
+	assert '$r1' == '1'
+
+
+	r2 := u8(byte(true))
+	println(r2)
+	assert '$r2' == '1'
+
+	r3 := u8(true)
+	println(r3)
+	assert '$r3' == '1'
+}


### PR DESCRIPTION
This PR fix error for cast to u8 (fix #13057).

- Fix error for cast to u8.
- Add test.

```vlang
module main

fn main() {
	r1 := u8(byte(1))
	println(r1)
	assert '$r1' == '1'


	r2 := u8(byte(true))
	println(r2)
	assert '$r2' == '1'

	r3 := u8(true)
	println(r3)
	assert '$r3' == '1'
}

PS D:\Test\v\tt1> v run .
1
1
1
```