### PR TITLE
checker: fix generics with nested generic fn inst call (fix #13056)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -957,7 +957,14 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 			node.concrete_list_pos)
 	}
 	if func.generic_names.len > 0 {
-		return node.return_type
+		if has_generic {
+			return node.return_type
+		} else if typ := c.table.resolve_generic_to_concrete(func.return_type, func.generic_names,
+			concrete_types)
+		{
+			node.return_type = typ
+			return typ
+		}
 	}
 	return func.return_type
 }

--- a/vlib/v/tests/generics_with_nested_generics_fn_inst_call_test.v
+++ b/vlib/v/tests/generics_with_nested_generics_fn_inst_call_test.v
@@ -1,0 +1,30 @@
+fn test_generics_with_nested_generic_fn_inst_call() {
+	value := [byte(105), 116, 32, 119, 111, 114, 107, 115, 33, 33]
+	decoded := decode_arr<string>(value)
+	dump(decoded)
+	assert decoded.len == 4
+	assert decoded[0] == 'it works!!'
+	assert decoded[1] == 'it works!!'
+	assert decoded[2] == 'it works!!'
+	assert decoded[3] == 'it works!!'
+}
+
+fn decode_arr<T>(buf []byte) []T {
+	arr_size := decode<u32>(buf[0..4])
+	mut ret := []T{cap: int(arr_size)}
+
+	for _ in 0 .. arr_size {
+		ret << decode<T>(buf[..])
+	}
+	return ret
+}
+
+fn decode<T>(buf []byte) T {
+	$if T is u32 {
+		return u32(buf.len)
+	} $else $if T is string {
+		return buf.bytestr()
+	} $else {
+		panic('"$T.name" is not supported for `decode`')
+	}
+}


### PR DESCRIPTION
This PR fix generics with nested generic fn inst call (fix #13056).

- Fix generics with nested generic fn inst call.
- Add test.

```vlang
fn main() {
	value := [byte(105), 116, 32, 119, 111, 114, 107, 115, 33, 33]
	decoded := decode_arr<string>(value)
	dump(decoded)
	assert decoded.len == 4
	assert decoded[0] == 'it works!!'
	assert decoded[1] == 'it works!!'
	assert decoded[2] == 'it works!!'
	assert decoded[3] == 'it works!!'
}

fn decode_arr<T>(buf []byte) []T {
	arr_size := decode<u32>(buf[0..4])
	mut ret := []T{cap: int(arr_size)}

	for _ in 0 .. arr_size {
		ret << decode<T>(buf[..])
	}
	return ret
}

fn decode<T>(buf []byte) T {
	$if T is u32 {
		return u32(buf.len)
	} $else $if T is string {
		return buf.bytestr()
	} $else {
		panic('"$T.name" is not supported for `decode`')
	}
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:4] decoded: ['it works!!', 'it works!!', 'it works!!', 'it works!!']
```