### PR TITLE
tmpl.v: fix of is_html_open_tag function and allow usage of V template sign '@' in JS code

### DIFF
--- a/vlib/v/parser/tmpl.v
+++ b/vlib/v/parser/tmpl.v
@@ -239,7 +239,8 @@ fn vweb_tmpl_${fn_name}() string {
 				source.writeln(insert_template_code(fn_name, tmpl_str_start, line))
 			} else {
 				// replace `$` to `\$` at first to escape JavaScript template literal syntax
-				source.writeln(line.replace(r'$', r'\$').replace(r'$$', r'@').replace(r'.$', r'.@').replace(r"'", r"\'"))
+				source.writeln(line.replace(r'$', r'\$').replace(r'$$', r'@').replace(r'.$',
+					r'.@').replace(r"'", r"\'"))
 			}
 		} else if state == .css {
 			// disable template variable declaration in inline stylesheet

--- a/vlib/v/parser/tmpl.v
+++ b/vlib/v/parser/tmpl.v
@@ -7,6 +7,7 @@ import v.token
 import v.errors
 import os
 import strings
+import regex
 
 enum State {
 	html
@@ -18,36 +19,29 @@ enum State {
 // check HTML open tag `<name attr="x" >`
 fn is_html_open_tag(name string, s string) bool {
 	mut len := s.len
+
 	if len < name.len {
 		return false
 	}
-	mut sub := s[0..1]
-	if sub != '<' { // not start with '<'
-		return false
+
+	return find_open_html_tag(name, s)
+}
+
+fn find_open_html_tag(tag_name string, line string) bool {
+	// This regex will check if a string is HTML open tag
+	// Will not found self-closing tag
+	// Will not found 'bad' tag (e.g. `<name <bad> >`)
+	// 06.01.2022. Artem Yurchenko
+	open_html_tag_regex := '\\s*<\\s*{0}[^</>]*>'
+	regex_query := open_html_tag_regex.replace(r'{0}', tag_name)
+
+	mut regex_executor := regex.regex_opt(regex_query) or {
+		panic('Something went wrong while creating regex to check if line is HTML open tag -> $err')
 	}
-	sub = s[len - 1..len]
-	if sub != '>' { // not end with '<'
-		return false
-	}
-	sub = s[len - 2..len - 1]
-	if sub == '/' { // self-closing
-		return false
-	}
-	sub = s[1..len - 1]
-	if sub.contains_any('<>') { // `<name <bad> >`
-		return false
-	}
-	if sub == name { // `<name>`
-		return true
-	} else {
-		len = name.len
-		if sub.len <= len { // `<nam>` or `<meme>`
-			return false
-		}
-		if sub[..len + 1] != '$name ' { // not `<name ...>`
-			return false
-		}
-		return true
+
+	start_position, _ := regex_executor.find(line)
+	return start_position != -1
+}
 	}
 }
 

--- a/vlib/v/parser/tmpl.v
+++ b/vlib/v/parser/tmpl.v
@@ -16,6 +16,8 @@ enum State {
 	// span // span.{
 }
 
+const tmpl_str_end = "')\n"
+
 // check HTML open tag `<name attr="x" >`
 fn is_html_open_tag(name string, s string) bool {
 	mut len := s.len
@@ -42,7 +44,20 @@ fn find_open_html_tag(tag_name string, line string) bool {
 	start_position, _ := regex_executor.find(line)
 	return start_position != -1
 }
+
+fn insert_template_code(fn_name string, tmpl_str_start string, line string) string {
+	// HTML, may include `@var`
+	// escaped by cgen, unless it's a `vweb.RawHtml` string
+	trailing_bs := parser.tmpl_str_end + 'sb_${fn_name}.write_b(92)\n' + tmpl_str_start
+	round1 := ['\\', '\\\\', r"'", "\\'", r'@', r'$']
+	round2 := [r'$$', r'\@', r'.$', r'.@']
+	mut rline := line.replace_each(round1).replace_each(round2)
+
+	if rline.ends_with('\\') {
+		rline = rline[0..rline.len - 2] + trailing_bs
 	}
+
+	return rline
 }
 
 // compile_file compiles the content of a file by the given path as a template
@@ -54,7 +69,6 @@ pub fn (mut p Parser) compile_template_file(template_file string, fn_name string
 	basepath := os.dir(template_file)
 	lstartlength := lines.len * 30
 	tmpl_str_start := "sb_${fn_name}.write_string('"
-	tmpl_str_end := "')\n"
 	mut source := strings.new_builder(1000)
 	source.writeln('
 import strings
@@ -164,24 +178,24 @@ fn vweb_tmpl_${fn_name}() string {
 			source.write_string(line[pos + 6..line.len - 1])
 			source.writeln('" rel="stylesheet" type="text/css">')
 		} else if line.contains('@if ') {
-			source.writeln(tmpl_str_end)
+			source.writeln(parser.tmpl_str_end)
 			pos := line.index('@if') or { continue }
 			source.writeln('if ' + line[pos + 4..] + '{')
 			source.writeln(tmpl_str_start)
 		} else if line.contains('@end') {
 			// Remove new line byte
 			source.go_back(1)
-			source.writeln(tmpl_str_end)
+			source.writeln(parser.tmpl_str_end)
 			source.writeln('}')
 			source.writeln(tmpl_str_start)
 		} else if line.contains('@else') {
 			// Remove new line byte
 			source.go_back(1)
-			source.writeln(tmpl_str_end)
+			source.writeln(parser.tmpl_str_end)
 			source.writeln(' } else { ')
 			source.writeln(tmpl_str_start)
 		} else if line.contains('@for') {
-			source.writeln(tmpl_str_end)
+			source.writeln(parser.tmpl_str_end)
 			pos := line.index('@for') or { continue }
 			source.writeln('for ' + line[pos + 4..] + '{')
 			source.writeln(tmpl_str_start)
@@ -210,28 +224,21 @@ fn vweb_tmpl_${fn_name}() string {
 				source.writeln('</div>')
 			}
 		} else if state == .js {
-			// replace `$` to `\$` at first to escape JavaScript template literal syntax
-			source.writeln(line.replace(r'$', r'\$').replace(r'$$', r'@').replace(r'.$',
-				r'.@').replace(r"'", r"\'"))
+			if line.contains('//V_TEMPLATE') {
+				source.writeln(insert_template_code(fn_name, tmpl_str_start, line))
+			} else {
+				// replace `$` to `\$` at first to escape JavaScript template literal syntax
+				source.writeln(line.replace(r'$', r'\$').replace(r'$$', r'@').replace(r'.$', r'.@').replace(r"'", r"\'"))
+			}
 		} else if state == .css {
 			// disable template variable declaration in inline stylesheet
 			// because of  some CSS rules prefixed with `@`.
 			source.writeln(line.replace(r'.$', r'.@').replace(r"'", r"\'"))
 		} else {
-			// HTML, may include `@var`
-			// escaped by cgen, unless it's a `vweb.RawHtml` string
-			trailing_bs := tmpl_str_end + 'sb_${fn_name}.write_b(92)\n' + tmpl_str_start
-			round1 := ['\\', '\\\\', r"'", "\\'", r'@', r'$']
-			round2 := [r'$$', r'\@', r'.$', r'.@']
-			rline := line.replace_each(round1).replace_each(round2)
-			if rline.ends_with('\\') {
-				source.writeln(rline[0..rline.len - 2] + trailing_bs)
-			} else {
-				source.writeln(rline)
-			}
+			source.writeln(insert_template_code(fn_name, tmpl_str_start, line))
 		}
 	}
-	source.writeln(tmpl_str_end)
+	source.writeln(parser.tmpl_str_end)
 	source.writeln('_tmpl_res_$fn_name := sb_${fn_name}.str() ')
 	source.writeln('return _tmpl_res_$fn_name')
 	source.writeln('}')

--- a/vlib/v/tests/tmpl/selective_interpolation_in_script_tag.html
+++ b/vlib/v/tests/tmpl/selective_interpolation_in_script_tag.html
@@ -1,0 +1,11 @@
+// V won't parse that
+<script>
+   var non_interpolated_labels = @benchmark_plot_data.dates;
+   var non_interpolated_values = @benchmark_plot_data.numerical_result;
+</script>
+
+// V will parse that
+<script>
+   var real_labels = @benchmark_plot_data.dates; //V_TEMPLATE
+   var real_values = @benchmark_plot_data.numerical_result; //V_TEMPLATE
+</script>

--- a/vlib/v/tests/tmpl_script_tag_interpolation_test.v
+++ b/vlib/v/tests/tmpl_script_tag_interpolation_test.v
@@ -1,0 +1,16 @@
+module main
+
+struct PlotData {
+	dates []string
+	numerical_result []int
+}
+	
+fn test_template_interpolation_can_be_selectively_turned_on_in_script_tags() {
+	benchmark_plot_data := PlotData{['2012-11-30', '2022-12-29'], [5,6,7,1]}
+	text := $tmpl('tmpl/selective_interpolation_in_script_tag.html')
+	// dump(text)
+	assert text.contains("var non_interpolated_labels = @benchmark_plot_data.dates;")
+	assert text.contains("var non_interpolated_values = @benchmark_plot_data.numerical_result;")
+	assert text.contains("var real_labels = ['2012-11-30', '2022-12-29']; //V_TEMPLATE")
+	assert text.contains("var real_values = [5, 6, 7, 1]; //V_TEMPLATE")
+}

--- a/vlib/v/tests/tmpl_script_tag_interpolation_test.v
+++ b/vlib/v/tests/tmpl_script_tag_interpolation_test.v
@@ -1,16 +1,16 @@
 module main
 
 struct PlotData {
-	dates []string
+	dates            []string
 	numerical_result []int
 }
-	
+
 fn test_template_interpolation_can_be_selectively_turned_on_in_script_tags() {
-	benchmark_plot_data := PlotData{['2012-11-30', '2022-12-29'], [5,6,7,1]}
+	benchmark_plot_data := PlotData{['2012-11-30', '2022-12-29'], [5, 6, 7, 1]}
 	text := $tmpl('tmpl/selective_interpolation_in_script_tag.html')
 	// dump(text)
-	assert text.contains("var non_interpolated_labels = @benchmark_plot_data.dates;")
-	assert text.contains("var non_interpolated_values = @benchmark_plot_data.numerical_result;")
+	assert text.contains('var non_interpolated_labels = @benchmark_plot_data.dates;')
+	assert text.contains('var non_interpolated_values = @benchmark_plot_data.numerical_result;')
 	assert text.contains("var real_labels = ['2012-11-30', '2022-12-29']; //V_TEMPLATE")
-	assert text.contains("var real_values = [5, 6, 7, 1]; //V_TEMPLATE")
+	assert text.contains('var real_values = [5, 6, 7, 1]; //V_TEMPLATE')
 }


### PR DESCRIPTION
## Fix of is_html_open_tag function

Trimming spaces (with trim_space method) in line before the start of searching of tag was done because the method will fail to recognize tag if there are spaces (tabs) before the tag.

For example, the next tag hasn't been recognized as _script_ tag because of formatting, and the **<script>** section contained a wrong code after template processing.
```
        <script>
````

## Allow usage of V template sign '@' in JS code

V templates were turned off for **<script>** and **<style>** blocks because CSS and JS have their own '@' sign.
This PR provides a way to allow treat '@' sign as a V template and behaves in the same way as HTML V templates. To do that, a user should provide a comment //V_TEMPLATE in a line where '@' sing was used.

```html
// V won't parse that
<script>
   var labels = @benchmark_plot_data.dates;
   var values = @benchmark_plot_data.numerical_result;
</script>

// V will parse that
<script>
   var labels = @benchmark_plot_data.dates; //V_TEMPLATE
   var values = @benchmark_plot_data.numerical_result; //V_TEMPLATE
</script>
```