### PR TITLE
fix: adding arrays.zip

### DIFF
--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -281,13 +281,43 @@ pub fn group_by<K, V>(list []V, grouping_op fn (v V) K) map[K][]V {
 	return result
 }
 
-// concatenate two arrays
+// concatenate an array with an arbitrary number of additional values
+//
+// NOTE: if you have two arrays, you should simply use the `<<` operator directly
+// Example: arrays.concat([1, 2, 3], 4, 5, 6) == [1, 2, 3, 4, 5, 6] // => true
+// Example: arrays.concat([1, 2, 3], ...[4, 5, 6]) == [1, 2, 3, 4, 5, 6] // => true
+// Example: arr << [4, 5, 6] // does what you need if arr is mutable
+[deprecated]
 pub fn concat<T>(a []T, b ...T) []T {
 	mut m := []T{cap: a.len + b.len}
 
 	m << a
 	m << b
 
+	return m
+}
+
+// zip returns a new array by interleaving the source arrays.
+//
+// NOTE: The two arrays do not need to be equal sizes
+// Example: arrays.zip([1, 3, 5, 7], [2, 4, 6, 8, 10]) // => [1, 2, 3, 4, 5, 6, 7, 8, 10]
+pub fn zip<T>(a []T, b []T) []T {
+	mut m := []T{cap: a.len + b.len}
+	mut i := 0
+	for i < m.cap {
+		// short-circuit the rest of the loop as soon as we can
+		if i >= a.len {
+			m << b[i..]
+			break
+		}
+		if i >= b.len {
+			m << a[i..]
+			break
+		}
+		m << a[i]
+		m << b[i]
+		i++
+	}
 	return m
 }
 

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -195,6 +195,12 @@ fn test_concat_string() {
 	assert concat(a, ...b) == ['1', '2', '3', '3', '2', '1']
 }
 
+fn test_zip_int() {
+	mut a := [1, 3, 5, 7]
+	mut b := [2, 4, 6, 8, 10]
+	assert zip(a, b) == [1, 2, 3, 4, 5, 6, 7, 8, 10]
+}
+
 fn test_binary_search() ? {
 	a := [1, 3, 3, 4, 5, 6, 7, 8, 10]
 	assert binary_search(a, 3) ? == 1


### PR DESCRIPTION

New function:

in `vlib/arrays/arrays.v`

```v
// zip returns a new array by interleaving the source arrays.
//
// NOTE: The two arrays do not need to be equal sizes
// Example: arrays.zip([1, 3, 5, 7], [2, 4, 6, 8, 10]) // => [1, 2, 3, 4, 5, 6, 7, 8, 10]
pub fn zip<T>(a []T, b []T) []T {
	mut m := []T{cap: a.len + b.len}
	mut i := 0
	for i < m.cap {
		// short-circuit the rest of the loop as soon as we can
		if i >= a.len {
			m << b[i..]
			break
		}
		if i >= b.len {
			m << a[i..]
			break
		}
		m << a[i]
		m << b[i]
		i++
	}
	return m
}
```


`arrays_test.v`

```v
fn test_zip_int() {
	mut a := [1, 3, 5, 7]
	mut b := [2, 4, 6, 8, 10]
	assert zip(a, b) == [1, 2, 3, 4, 5, 6, 7, 8, 10]
}
```
