### PR TITLE
checker: fix error for cast to u8

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2669,7 +2669,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		}
 	} else if mut to_sym.info is ast.Alias {
 		if !c.check_types(from_type, to_sym.info.parent_type) && !(final_to_sym.is_int()
-			&& final_from_sym.kind in [.enum_, .bool]) {
+			&& final_from_sym.kind in [.enum_, .bool, .i8, .char]) {
 			c.error('cannot convert type `$from_sym.name` to `$to_sym.name` (alias to `$final_to_sym.name`)',
 				node.pos)
 		}

--- a/vlib/v/tests/cast_to_u8_test.v
+++ b/vlib/v/tests/cast_to_u8_test.v
@@ -12,4 +12,16 @@ fn test_cast_to_alias() {
 	r3 := u8(true)
 	println(r3)
 	assert '$r3' == '1'
+
+	r4 := u8(char(1))
+	println(r4)
+	assert r4 == 1
+
+	r5 := u8(char(-1))
+	println(r5)
+	assert '$r5' == '255'
+
+	r6 := u8(i8(-1))
+	println(r6)
+	assert r6 == 255
 }


### PR DESCRIPTION
This PR fix error for cast to u8.

* Fix error for cast `i8` & `char` to u8.  (related to #13058)
* Add test.
