### PR TITLE
cgen: fix comptime call in fn call  (fix #13073)

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -150,7 +150,11 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 				}
 			}
 		}
-		g.write(' ); // vweb action call with args')
+		if g.inside_call {
+			g.write(')')
+		} else {
+			g.write(');')
+		}
 		return
 	}
 	mut j := 0

--- a/vlib/v/tests/comptime_call_in_fn_call_test.v
+++ b/vlib/v/tests/comptime_call_in_fn_call_test.v
@@ -1,0 +1,29 @@
+struct Foo {}
+
+fn (f Foo) a() string {
+	return 'method_a'
+}
+
+fn (f Foo) b() string {
+	return 'method_b'
+}
+
+fn test_comptime_call_in_fn_call() {
+	f := Foo{}
+
+	mut rets := []string{}
+
+	$for method in Foo.methods {
+		x := f.$method()
+		println(x)
+		println(f.$method())
+		rets << get_string(f.$method())
+	}
+	assert rets.len == 2
+	assert rets[0] == 'method_a'
+	assert rets[1] == 'method_b'
+}
+
+fn get_string(s string) string {
+	return s
+}


### PR DESCRIPTION
This PR fix comptime call in fn call  (fix #13073).

- Fix comptime call in fn call.
- Add test.

```vlang
struct Foo {}

fn (f Foo) a() string {
	return 'method_a'
}

fn (f Foo) b() string {
	return 'method_b'
}

fn main() {
	f := Foo{}

	mut rets := []string{}

	$for method in Foo.methods {
		x := f.$method()
		println(x)
		println(f.$method())
		rets << get_string(f.$method())
	}
	assert rets.len == 2
	assert rets[0] == 'method_a'
	assert rets[1] == 'method_b'
}

fn get_string(s string) string {
	return s
}

PS D:\Test\v\tt1> v run .
method_a
method_a
method_b
method_b
```