### PR TITLE
cgen: fix string range index in for mut var in (fix #13074)

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -65,6 +65,9 @@ fn (mut g Gen) range_expr(node ast.IndexExpr, range ast.RangeExpr) {
 		} else {
 			g.write('string_substr(')
 		}
+		if node.left_type.is_ptr() {
+			g.write('*')
+		}
 		g.expr(node.left)
 	} else if sym.kind == .array {
 		if node.is_gated {

--- a/vlib/v/tests/string_index_in_for_mut_in_test.v
+++ b/vlib/v/tests/string_index_in_for_mut_in_test.v
@@ -1,0 +1,25 @@
+module main
+
+[heap]
+pub struct Grid {
+pub mut:
+	header []string
+}
+
+fn test_string_index_in_for_mut_in() {
+	h := ['yore', 'yaya']
+
+	mut grid := Grid{
+		header: h
+	}
+	wrap_text(mut grid)
+}
+
+fn wrap_text(mut gv Grid) {
+	for mut ch in gv.header {
+		ch = ch[1..2]
+	}
+
+	println(gv)
+	assert gv.header == ['o', 'a']
+}


### PR DESCRIPTION
This PR fix string range index in for mut var in (fix #13074).

- Fix string range index in for mut var in.
- Add test.

```vlang
module main

[heap]
pub struct Grid {
pub mut:
	header []string
}

fn main() {
	h := ['yore', 'yaya']

	mut grid := Grid{
		header: h
	}
	wrap_text(mut grid)
}

fn wrap_text(mut gv Grid) {
	for mut ch in gv.header {
		ch = ch[1..2]
	}

	println(gv)
	assert gv.header == ['o', 'a']
}

PS D:\Test\v\tt1> v run .
Grid{
    header: ['o', 'a']
}
```