### PR TITLE
checker: add support for apk in comptime if

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -24,7 +24,7 @@ const (
 	valid_comptime_if_compilers      = ['gcc', 'tinyc', 'clang', 'mingw', 'msvc', 'cplusplus']
 	valid_comptime_if_platforms      = ['amd64', 'i386', 'aarch64', 'arm64', 'arm32', 'rv64', 'rv32']
 	valid_comptime_if_cpu_features   = ['x64', 'x32', 'little_endian', 'big_endian']
-	valid_comptime_if_other          = ['js', 'debug', 'prod', 'test', 'glibc', 'prealloc',
+	valid_comptime_if_other          = ['apk', 'js', 'debug', 'prod', 'test', 'glibc', 'prealloc',
 		'no_bounds_checking', 'freestanding', 'threads', 'js_node', 'js_browser', 'js_freestanding',
 		'interpreter', 'es5']
 	valid_comptime_not_user_defined  = all_valid_comptime_idents()

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -528,6 +528,7 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Position) bool {
 				return false
 			} else if cname in valid_comptime_if_other {
 				match cname {
+					'apk' { return !c.pref.is_apk }
 					'js' { return !c.pref.backend.is_js() }
 					'debug' { return !c.pref.is_debug }
 					'prod' { return !c.pref.is_prod }


### PR DESCRIPTION
This PR will add support for using `apk` in comptime ifs - like this:
```v
pub fn read_apk_asset(file string) ?[]byte {
	$if apk {
		...
		buf := []byte{}
		...
		return buf
	} $else {
		return []byte{len: 0}
	}
}
```

This is a preparation to fix a bug regarding the use of `-os android` *without* the `-apk` flag which is currently broken:
`v -os android -o /tmp/android_v.c examples/toml.v`
```
vlib/os/os_android.c.v:22:30: error: unknown function: C.sapp_android_get_native_activity
   20 | 
   21 | pub fn read_apk_asset(file string) ?[]byte {
   22 |     act := &C.ANativeActivity(C.sapp_android_get_native_activity())
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   23 |     if isnil(act) {
   24 |         return error('Could not get reference to Android activity')
```

A follow up PR for fixing `os_android.c.v` will be inbound if this PR pass and gets merged.