### PR TITLE
android: fix and test compilation to raw Android C code

### DIFF
--- a/.github/workflows/ci_cross.yml
+++ b/.github/workflows/ci_cross.yml
@@ -41,6 +41,11 @@ jobs:
           ./v -os windows cmd/v
           ./v -os windows examples/2048/2048.v
 
+      - name: Compile to raw Android (non-graphic) compatible
+        run: |
+          # Test that V can compile non-graphic app to Android compatible code *without* using the -apk flag
+          ./v -os android examples/toml.v
+
   linux-cross:
     runs-on: ubuntu-20.04
     timeout-minutes: 15
@@ -87,6 +92,12 @@ jobs:
         run: |
           ./v -os windows examples/2048/2048.v
           ls -lart examples/2048/2048.exe
+
+      - name: toml.v can be compiled to raw Android C
+        run: |
+          # Test that V can compile non-graphic app to Android compatible code *without* using the -apk flag
+          ./v -os android examples/toml.v
+
 
   windows-cross:
     runs-on: windows-2019

--- a/vlib/os/os_android.c.v
+++ b/vlib/os/os_android.c.v
@@ -19,21 +19,25 @@ fn C.AAsset_read(&C.AAsset, voidptr, int) int
 fn C.AAsset_close(&C.AAsset)
 
 pub fn read_apk_asset(file string) ?[]byte {
-	act := &C.ANativeActivity(C.sapp_android_get_native_activity())
-	if isnil(act) {
-		return error('Could not get reference to Android activity')
-	}
-	asset := C.AAssetManager_open(&C.AAssetManager(act.assetManager), file.str, C.AASSET_MODE_STREAMING)
-	if isnil(asset) {
-		return error('File `$file` not found')
-	}
-	len := C.AAsset_getLength(asset)
-	buf := []byte{len: len}
-	for {
-		if C.AAsset_read(asset, buf.data, len) > 0 {
-			break
+	$if apk {
+		act := &C.ANativeActivity(C.sapp_android_get_native_activity())
+		if isnil(act) {
+			return error('Could not get reference to Android activity')
 		}
+		asset := C.AAssetManager_open(&C.AAssetManager(act.assetManager), file.str, C.AASSET_MODE_STREAMING)
+		if isnil(asset) {
+			return error('File `$file` not found')
+		}
+		len := C.AAsset_getLength(asset)
+		buf := []byte{len: len}
+		for {
+			if C.AAsset_read(asset, buf.data, len) > 0 {
+				break
+			}
+		}
+		C.AAsset_close(asset)
+		return buf
+	} $else {
+		return error(@FN + ' can only be used with APK/AAB packaged Android apps')
 	}
-	C.AAsset_close(asset)
-	return buf
 }


### PR DESCRIPTION
This PR fixes a bug with raw (non-graphics/non-packaged) Android compatible code.
This didn't work before:
`v -os android examples/toml.v`
Tests are also included.
The raw compatible code is important if you want to compile the C code via the NDK manually (or without `vab`).