### PR TITLE
ast: fix generics with nested generic type parameter  (fix #13077)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1634,10 +1634,6 @@ pub fn (mut t Table) unwrap_generic_type(typ Type, generic_names []string, concr
 									concrete_types)
 							}
 						}
-						if method.return_type.has_flag(.generic)
-							&& method.return_type != method.params[0].typ {
-							t.unwrap_generic_type(method.return_type, generic_names, concrete_types)
-						}
 						t.register_fn_concrete_types(method.fkey(), final_concrete_types)
 					}
 				}

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1627,6 +1627,17 @@ pub fn (mut t Table) unwrap_generic_type(typ Type, generic_names []string, concr
 				}
 				if final_concrete_types.len > 0 {
 					for method in ts.methods {
+						for i in 1 .. method.params.len {
+							if method.params[i].typ.has_flag(.generic)
+								&& method.params[i].typ != method.params[0].typ {
+								t.unwrap_generic_type(method.params[i].typ, generic_names,
+									concrete_types)
+							}
+						}
+						if method.return_type.has_flag(.generic)
+							&& method.return_type != method.params[0].typ {
+							t.unwrap_generic_type(method.return_type, generic_names, concrete_types)
+						}
 						t.register_fn_concrete_types(method.fkey(), final_concrete_types)
 					}
 				}

--- a/vlib/v/tests/generics_with_nested_generic_type_parameter_test.v
+++ b/vlib/v/tests/generics_with_nested_generic_type_parameter_test.v
@@ -1,0 +1,20 @@
+module main
+
+pub struct Randomizer<T> {
+}
+
+pub struct Element<T> {
+}
+
+fn test_generics_with_nested_generic_type_parameter() {
+	a := new_randomizer<int>()
+	println(a)
+	assert '$a' == '&Randomizer<int>{}'
+}
+
+pub fn new_randomizer<T>() &Randomizer<T> {
+	return &Randomizer<T>{}
+}
+
+pub fn (mut r Randomizer<T>) add_multiple(elements []Element<T>) {
+}


### PR DESCRIPTION
This PR fix generics with nested generic type parameter  (fix #13077).

- Fix generics with nested generic type parameter.
- Add test.

```vlang
module main

pub struct Randomizer<T> {
}

pub struct Element<T> {
}

fn main() {
	a := new_randomizer<int>()
	println(a)
	assert '$a' == '&Randomizer<int>{}'
}

pub fn new_randomizer<T>() &Randomizer<T> {
	return &Randomizer<T>{}
}

pub fn (mut r Randomizer<T>) add_multiple(elements []Element<T>) {
}

PS D:\Test\v\tt1> v run .
&Randomizer<int>{}
```