### PR TITLE
toml: fix comment ends with crlf

### DIFF
--- a/vlib/toml/scanner/scanner.v
+++ b/vlib/toml/scanner/scanner.v
@@ -341,12 +341,12 @@ fn (mut s Scanner) ignore_line() ?string {
 	util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, ' ignoring until EOL...')
 	start := s.pos
 	for c := s.at(); c != scanner.end_of_text && c != `\n`; c = s.at() {
-		s.next()
 		util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'skipping "${byte(c).ascii_str()} / $c"')
 		if s.at_crlf() {
 			util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'letting `\\r\\n` slip through')
 			break
 		}
+		s.next()
 	}
 	return s.text[start..s.pos]
 }


### PR DESCRIPTION
Feel free to close the PR if it doesn't make sense to you.

Allows the Toml test cases to be passed again under Windows.

![image](https://user-images.githubusercontent.com/47723516/148649237-bfb55be3-6780-45d1-aefb-1633877ca254.png)
