### PR TITLE
parser: check error of anon fn argument type (fix #13096)

### DIFF
--- a/vlib/v/checker/tests/anon_fn_arg_type_err.out
+++ b/vlib/v/checker/tests/anon_fn_arg_type_err.out
@@ -1,0 +1,20 @@
+vlib/v/checker/tests/anon_fn_arg_type_err.vv:7:10: error: undefined ident: `i`
+    5 |
+    6 |     func := fn (i) int {
+    7 |         return i
+      |                ^
+    8 |     }
+    9 |
+vlib/v/checker/tests/anon_fn_arg_type_err.vv:6:14: error: unknown type `i`
+    4 |     mut i := 1
+    5 |
+    6 |     func := fn (i) int {
+      |                 ^
+    7 |         return i
+    8 |     }
+vlib/v/checker/tests/anon_fn_arg_type_err.vv:10:15: error: cannot use `int` as `i` in argument 1 to `func`
+    8 |     }
+    9 |
+   10 |     println(func(i) == 1)
+      |                  ^
+   11 | }

--- a/vlib/v/checker/tests/anon_fn_arg_type_err.vv
+++ b/vlib/v/checker/tests/anon_fn_arg_type_err.vv
@@ -1,0 +1,11 @@
+module main
+
+fn main() {
+	mut i := 1
+
+	func := fn (i) int {
+		return i
+	}
+
+	println(func(i) == 1)
+}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -642,7 +642,7 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 	// TODO generics
 	args, _, is_variadic := p.fn_args()
 	for arg in args {
-		if arg.name.len == 0 {
+		if arg.name.len == 0 && p.table.sym(arg.typ).kind != .placeholder {
 			p.error_with_pos('use `_` to name an unused parameter', arg.pos)
 		}
 		is_stack_obj := !arg.typ.has_flag(.shared_f) && (arg.is_mut || arg.typ.is_ptr())
@@ -811,6 +811,7 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 				name: ''
 				is_mut: is_mut
 				typ: arg_type
+				type_pos: pos
 			}
 			arg_no++
 			if arg_no > 1024 {


### PR DESCRIPTION
This PR check error of anon fn argument type (fix #13096).

- Check error of anon fn argument type.
- Add test.

```vlang
module main

fn main() {
	mut i := 1

	func := fn (i) int {
		return i
	}

	println(func(i) == 1)
}

PS D:\Test\v\tt1> v run .
.\tt1.v:8:10: error: undefined ident: `i`
    6 |
    7 |     func := fn (i) int {
    8 |         return i
      |                ^
    9 |     }
   10 |
.\tt1.v:7:14: error: unknown type `i`
    5 |     mut i := 1
    6 |
    7 |     func := fn (i) int {
      |                 ^
    8 |         return i
    9 |     }
.\tt1.v:11:15: error: cannot use `int` as `i` in argument 1 to `func`
    9 |     }
   10 |
   11 |     println(func(i) == 1) // true
      |                  ^
   12 | }
```