### PR TITLE
checker: check array init with void type value (fix #13095)

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -85,6 +85,9 @@ pub fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 		// }
 		for i, mut expr in node.exprs {
 			typ := c.check_expr_opt_call(expr, c.expr(expr))
+			if typ == ast.void_type {
+				c.error('invalid void array element type', expr.position())
+			}
 			node.expr_types << typ
 			// The first element's type
 			if expecting_interface_array {

--- a/vlib/v/checker/tests/array_init_with_void_value_err.out
+++ b/vlib/v/checker/tests/array_init_with_void_value_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/array_init_with_void_value_err.vv:4:8: error: invalid void array element type
+    2 |
+    3 | fn main() {
+    4 |     a := [yo()]
+      |           ~~~~
+    5 |     println(a)
+    6 | }

--- a/vlib/v/checker/tests/array_init_with_void_value_err.vv
+++ b/vlib/v/checker/tests/array_init_with_void_value_err.vv
@@ -1,0 +1,8 @@
+module main
+
+fn main() {
+	a := [yo()]
+	println(a)
+}
+
+fn yo() {}


### PR DESCRIPTION
This PR check array init with void type value (fix #13095).

- Check array init with void type value.
- Add test.

```vlang
module main

fn main() {
	a := [yo()]
	println(a)
}

fn yo() {}

PS D:\Test\v\tt1> v run .
.\tt1.v:4:8: error: invalid void array element type
    2 | 
    3 | fn main() {
    4 |     a := [yo()]
      |           ~~~~
    5 |     println(a)
    6 | }
```