### PR TITLE
cgen: fix error for print comptime for method call (fix #13093)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -869,6 +869,15 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 					return
 				}
 			}
+		} else if node.left is ast.ComptimeCall {
+			if node.left.method_name == 'method' {
+				sym := g.table.sym(g.unwrap_generic(node.left.left_type))
+				if m := sym.find_method(g.comptime_for_method) {
+					rec_type = m.return_type
+					g.gen_expr_to_string(node.left, rec_type)
+					return
+				}
+			}
 		} else if node.left is ast.Ident {
 			if node.left.obj is ast.Var {
 				if g.comptime_var_type_map.len > 0 {
@@ -1217,6 +1226,13 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 						if expr.field_expr.expr is ast.Ident {
 							key_str := '${expr.field_expr.expr.name}.typ'
 							typ = g.comptime_var_type_map[key_str] or { typ }
+						}
+					}
+				} else if expr is ast.ComptimeCall {
+					if expr.method_name == 'method' {
+						sym := g.table.sym(g.unwrap_generic(expr.left_type))
+						if m := sym.find_method(g.comptime_for_method) {
+							typ = m.return_type
 						}
 					}
 				} else if expr is ast.Ident {

--- a/vlib/v/tests/comptime_for_method_call_in_print_call_test.v
+++ b/vlib/v/tests/comptime_for_method_call_in_print_call_test.v
@@ -1,0 +1,34 @@
+module main
+
+struct S1 {}
+
+fn test_comptime_for_method_call_str() {
+	s1 := S1{}
+	mut rets := []string{}
+
+	$for method in S1.methods {
+		println(s1.$method('ll'))
+		rets << s1.$method('ll').str()
+	}
+	assert rets.len == 4
+	assert rets[0] == '7'
+	assert rets[1] == '7.7'
+	assert rets[2] == 'foo'
+	assert rets[3] == 'true'
+}
+
+fn (t S1) m1(s string) int {
+	return 7
+}
+
+fn (t S1) m2(s string) f64 {
+	return 7.7
+}
+
+fn (t S1) m3(s string) string {
+	return 'foo'
+}
+
+fn (t S1) m4(s string) bool {
+	return true
+}


### PR DESCRIPTION
This PR fix error for print comptime for method call (fix #13093).

- Fix error for print comptime for method call.
- Add test.

```vlang
module main

struct S1 {}

fn main() {
	s1 := S1{}
	mut rets := []string{}

	$for method in S1.methods {
		println(s1.$method('ll'))
		rets << s1.$method('ll').str()
	}
	assert rets.len == 4
	assert rets[0] == '7'
	assert rets[1] == '7.7'
	assert rets[2] == 'foo'
	assert rets[3] == 'true'
}

fn (t S1) m1(s string) int {
	return 7
}

fn (t S1) m2(s string) f64 {
	return 7.7
}

fn (t S1) m3(s string) string {
	return 'foo'
}

fn (t S1) m4(s string) bool {
	return true
}

PS D:\Test\v\tt1> v run .
7
7.7
foo
true
```