### PR TITLE
cgen: fix returning map init expression in function with optional return

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4907,7 +4907,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 				expr0.return_type.has_flag(.optional) && expr0.or_block.kind == .absent
 			}
 			else {
-				node.types[0].has_flag(.optional)
+				expr0 !is ast.MapInit && node.types[0].has_flag(.optional)
 			}
 		}
 		if fn_return_is_optional && !expr_type_is_opt && return_sym.name != 'Option' {

--- a/vlib/v/tests/return_mapinit_optional_test.v
+++ b/vlib/v/tests/return_mapinit_optional_test.v
@@ -1,0 +1,13 @@
+fn a() ?map[string]string {
+	return {}
+}
+
+fn b() ?map[string]string {
+	a := map[string]string{}
+	return a
+}
+
+fn test_all() ? {
+	assert a()? == {}
+	assert b()? == {}
+}

--- a/vlib/v/tests/return_mapinit_optional_test.v
+++ b/vlib/v/tests/return_mapinit_optional_test.v
@@ -8,6 +8,6 @@ fn b() ?map[string]string {
 }
 
 fn test_all() ? {
-	assert a()? == {}
-	assert b()? == {}
+	assert a() ? == {}
+	assert b() ? == {}
 }


### PR DESCRIPTION
Fixes #13111

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
