### PR TITLE
checker: fix returning optional empty map (fix #13111)

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -202,7 +202,7 @@ pub fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 		sym := c.table.sym(c.expected_type)
 		if sym.kind == .map {
 			info := sym.map_info()
-			node.typ = c.expected_type
+			node.typ = c.expected_type.clear_flag(.optional)
 			node.key_type = info.key_type
 			node.value_type = info.value_type
 			return node.typ

--- a/vlib/v/tests/option_empty_map_test.v
+++ b/vlib/v/tests/option_empty_map_test.v
@@ -1,0 +1,13 @@
+fn opt() ?map[string]string {
+	return {}
+}
+
+fn test_option_empty_map() {
+	x := opt() or {
+		assert false
+		return
+	}
+
+	dump(x)
+	assert '$x' == '{}'
+}


### PR DESCRIPTION
This PR fix returning optional empty map (fix #13111).

- Fix returning optional empty map.
- Add test.

```vlang
fn opt() ?map[string]string {
	return {}
}

fn main() {
	x := opt() or {
		assert false
		return
	}
	dump(x)
	assert '$x' == '{}'
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:10] x: {}
```