### PR TITLE
cgen: check error for comptime call method argument (fix #13107)

### DIFF
--- a/vlib/v/checker/tests/comptime_call_method_args_err.out
+++ b/vlib/v/checker/tests/comptime_call_method_args_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/comptime_call_method_args_err.vv:9:14: cgen error: expected 0 arguments to method S1.method_hello, but got 1
+    7 |
+    8 |     $for method in S1.methods {
+    9 |         println(s1.$method('yo'))
+      |                    ~~~~~~~~~~~~~
+   10 |     }
+   11 | }

--- a/vlib/v/checker/tests/comptime_call_method_args_err.vv
+++ b/vlib/v/checker/tests/comptime_call_method_args_err.vv
@@ -1,0 +1,15 @@
+module main
+
+struct S1 {}
+
+fn main() {
+	s1 := S1{}
+
+	$for method in S1.methods {
+		println(s1.$method('yo'))
+	}
+}
+
+fn (t S1) method_hello() string {
+	return 'Hello'
+}

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -99,12 +99,17 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 		}
 		// check argument length and types
 		if m.params.len - 1 != node.args.len && !expand_strs {
-			// do not generate anything if the argument lengths don't match
-			g.writeln('/* skipping ${sym.name}.$m.name due to mismatched arguments list */')
-			// g.writeln('println(_SLIT("skipping ${node.sym.name}.$m.name due to mismatched arguments list"));')
-			// eprintln('info: skipping ${node.sym.name}.$m.name due to mismatched arguments list\n' +
-			//'method.params: $m.params, args: $node.args\n\n')
-			// verror('expected ${m.params.len-1} arguments to method ${node.sym.name}.$m.name, but got $node.args.len')
+			if g.inside_call {
+				g.error('expected ${m.params.len - 1} arguments to method ${sym.name}.$m.name, but got $node.args.len',
+					node.pos)
+			} else {
+				// do not generate anything if the argument lengths don't match
+				g.writeln('/* skipping ${sym.name}.$m.name due to mismatched arguments list */')
+				// g.writeln('println(_SLIT("skipping ${node.sym.name}.$m.name due to mismatched arguments list"));')
+				// eprintln('info: skipping ${node.sym.name}.$m.name due to mismatched arguments list\n' +
+				//'method.params: $m.params, args: $node.args\n\n')
+				// verror('expected ${m.params.len-1} arguments to method ${node.sym.name}.$m.name, but got $node.args.len')
+			}
 			return
 		}
 		// TODO: check argument types


### PR DESCRIPTION
This PR check error for comptime call method argument (fix #13107).

- Check error for comptime call method argument.
- Add test.

```vlang
module main

struct S1 {}

fn main() {
	s1 := S1{}

	$for method in S1.methods {
		println(s1.$method('yo'))
	}
}

fn (t S1) method_hello() string {
	return 'Hello'
}

PS D:\Test\v\tt1> v run .
.\tt1.v:9:14: cgen error: expected 0 arguments to method S1.method_hello, but got 1
    7 |
    8 |     $for method in S1.methods {
    9 |         println(s1.$method('yo'))
      |                    ~~~~~~~~~~~~~
   10 |     }
   11 | }
```