### PR TITLE
cgen,json2: Better -nofloat support

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -645,6 +645,9 @@ pub fn (mut g Gen) init() {
 				g.cheaders.writeln(get_guarded_include_text('<stddef.h>', 'The C compiler can not find <stddef.h>. Please install build-essentials')) // size_t, ptrdiff_t
 			}
 		}
+		if g.pref.nofloat {
+			g.cheaders.writeln('#define VNOFLOAT 1')
+		}
 		g.cheaders.writeln(c_builtin_types)
 		if g.pref.is_bare {
 			g.cheaders.writeln(c_bare_headers)

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -656,10 +656,19 @@ typedef uint8_t byte;
 typedef uint32_t rune;
 typedef size_t usize;
 typedef ptrdiff_t isize;
+#ifndef VNOFLOAT 
 typedef float f32;
 typedef double f64;
+#else
+typedef int32_t f32;
+typedef int64_t f64;
+#endif
 typedef int64_t int_literal;
+#ifndef VNOFLOAT
 typedef double float_literal;
+#else
+typedef int64_t float_literal;
+#endif
 typedef unsigned char* byteptr;
 typedef void* voidptr;
 typedef char* charptr;

--- a/vlib/x/json2/decoder.v
+++ b/vlib/x/json2/decoder.v
@@ -106,8 +106,10 @@ fn (mut p Parser) decode_value() ?Any {
 			kind := p.tok.kind
 			p.next_with_err() ?
 			if p.convert_type {
-				if kind == .float {
-					return Any(tl.f64())
+				$if !nofloat ? {
+					if kind == .float {
+						return Any(tl.f64())
+					}
 				}
 				return Any(tl.i64())
 			}

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -73,18 +73,25 @@ pub fn (f Any) json_str() string {
 			return f.str()
 		}
 		f32 {
-			str_f32 := f.str()
-			if str_f32.ends_with('.') {
-				return '${str_f32}0'
+			$if !nofloat ? {
+				str_f32 := f.str()
+				if str_f32.ends_with('.') {
+					return '${str_f32}0'
+				}
+				return str_f32
 			}
-			return str_f32
+
+			return '0'
 		}
 		f64 {
-			str_f64 := f.str()
-			if str_f64.ends_with('.') {
-				return '${str_f64}0'
+			$if !nofloat ? {
+				str_f64 := f.str()
+				if str_f64.ends_with('.') {
+					return '${str_f64}0'
+				}
+				return str_f64
 			}
-			return str_f64
+			return '0'
 		}
 		map[string]Any {
 			return f.str()


### PR DESCRIPTION
Adds `VNOFLOAT` define to output C file and typedefs f32 and f64 to int32_t and int64_t so if you compile to target that does not have support for float and double compiler will not panic. Also changes `json2` part of usage of f32 and f64 so it works with -nofloat properly