### PR TITLE
fix: adding a bytes convenience method to runes just like for strings

### DIFF
--- a/vlib/builtin/rune.v
+++ b/vlib/builtin/rune.v
@@ -54,6 +54,10 @@ pub fn (c rune) repeat(count int) string {
 	return res.repeat(count)
 }
 
+pub fn (c rune) bytes() []byte {
+	return c.str().bytes()
+}
+
 pub fn (c rune) length_in_bytes() int {
 	code := u32(c)
 	if code <= 0x7F {

--- a/vlib/builtin/rune_test.v
+++ b/vlib/builtin/rune_test.v
@@ -35,3 +35,8 @@ fn test_length_in_bytes() {
 	//
 	assert rune(0x110000).length_in_bytes() == -1
 }
+
+fn test_bytes() {
+	r1 := `★`
+	assert r1.bytes() == [byte(0xe2), 0x98, 0x85]
+}


### PR DESCRIPTION
It can be helpful to get the utf-8 bytes from a unicode rune, so this makes it one step easier.

```v
// previously
utf8_bytes := `★`.str().bytes() // [0xe2, 0x98, 0x85]

// now
utf8_bytes := `★`.bytes() // [0xe2, 0x98, 0x85]
```