### PR TITLE
checker: check error for match conditions with parenthesis (fix #13121)

### DIFF
--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -8,6 +8,10 @@ import strings
 pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 	node.is_expr = c.expected_type != ast.void_type
 	node.expected_type = c.expected_type
+	if node.cond is ast.ParExpr {
+		c.error('unnecessary `()` in `match` condition, use `match expr {` instead of `match (expr) {`.',
+			node.cond.pos)
+	}
 	cond_type := c.expr(node.cond)
 	// we setting this here rather than at the end of the method
 	// since it is used in c.match_exprs() it saves checking twice

--- a/vlib/v/checker/tests/match_cond_with_parenthesis_err.out
+++ b/vlib/v/checker/tests/match_cond_with_parenthesis_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/match_cond_with_parenthesis_err.vv:14:15: error: unnecessary `()` in `match` condition, use `match expr {` instead of `match (expr) {`.
+   12 |
+   13 | fn bar() bool {
+   14 |     return match (foo()) {
+      |                  ~~~~~~~
+   15 |         .a { true }
+   16 |         .b, .c { false }

--- a/vlib/v/checker/tests/match_cond_with_parenthesis_err.vv
+++ b/vlib/v/checker/tests/match_cond_with_parenthesis_err.vv
@@ -1,0 +1,22 @@
+module main
+
+enum Enum {
+	a
+	b
+	c
+}
+
+fn foo() ?Enum {
+	return .a
+}
+
+fn bar() bool {
+	return match (foo()) {
+		.a { true }
+		.b, .c { false }
+	}
+}
+
+fn main() {
+	bar()
+}


### PR DESCRIPTION
This PR check error for match conditions with parenthesis (fix #13121).

- Check error for match conditions with parenthesis.
- Add test.

```vlang
module main

enum Enum {
	a
	b
	c
}

fn foo() ?Enum {
	return .a
}

fn bar() bool {
	return match (foo()) {
		.a { true }
		.b, .c { false }
	}
}

fn main() {
	bar()
}

PS D:\Test\v\tt1> v run .
.\tt1.v:14:15: error: unnecessary `()` in `match` condition, use `match expr {` instead of `match (expr) {`.
   12 |
   13 | fn bar() bool {
   14 |     return match (foo()) {
      |                  ~~~~~~~
   15 |         .a { true }
   16 |         .b, .c { false }
```