### PR TITLE
cgen: fix cast in the index of reference fixed array (fix #13128)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4437,10 +4437,6 @@ fn (mut g Gen) ident(node ast.Ident) {
 }
 
 fn (mut g Gen) cast_expr(node ast.CastExpr) {
-	if node.typname.starts_with('&') {
-		// &Foo(0) => ((Foo*)0)
-		g.out.go_back(1)
-	}
 	sym := g.table.sym(node.typ)
 	if sym.kind in [.sum_type, .interface_] {
 		g.expr_with_cast(node.expr, node.expr_type, node.typ)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4437,11 +4437,10 @@ fn (mut g Gen) ident(node ast.Ident) {
 }
 
 fn (mut g Gen) cast_expr(node ast.CastExpr) {
-	if g.is_amp {
+	if node.typname.starts_with('&') {
 		// &Foo(0) => ((Foo*)0)
 		g.out.go_back(1)
 	}
-	g.is_amp = false
 	sym := g.table.sym(node.typ)
 	if sym.kind in [.sum_type, .interface_] {
 		g.expr_with_cast(node.expr, node.expr_type, node.typ)

--- a/vlib/v/tests/cast_in_index_of_ref_fixed_array_test.v
+++ b/vlib/v/tests/cast_in_index_of_ref_fixed_array_test.v
@@ -1,0 +1,16 @@
+type Entity = int
+
+struct Component {
+	vals [256]int
+}
+
+fn (c Component) get_broken(e Entity) &int {
+	return &c.vals[int(e)]
+}
+
+fn test_cast_in_ref_fixed_array() {
+	c := Component{}
+	a := c.get_broken(Entity(10))
+	println(*a)
+	assert *a == 0
+}


### PR DESCRIPTION
This PR fix cast in the index of reference fixed array (fix #13128).

- Fix cast in the index of reference fixed array.
- Add test.

```vlang
type Entity = int

struct Component {
	vals [256]int
}

fn (c Component) get_broken(e Entity) &int {
	return &c.vals[int(e)]
}

fn main() {
	c := Component{}
	a := c.get_broken(Entity(10))
	println(*a)
	assert *a == 0
}

PS D:\Test\v\tt1> v run .
0
```