### PR TITLE
builtin: allow Windows users to link against gc boehm

### DIFF
--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -29,6 +29,9 @@ $if static_boehm ? {
 			#flag -I@VEXEROOT/thirdparty/libgc/include
 			#flag -L@VEXEROOT/thirdparty/libgc
 			#flag -lgc
+		} $else $if msvc {
+			#flag -DGC_BUILTIN_ATOMIC=1
+			#flag -I@VEXEROOT/thirdparty/libgc/include
 		} $else {
 			#flag -DGC_BUILTIN_ATOMIC=1
 			#flag -I@VEXEROOT/thirdparty/libgc
@@ -49,6 +52,9 @@ $if static_boehm ? {
 			#flag -I@VEXEROOT/thirdparty/libgc/include
 			#flag -L@VEXEROOT/thirdparty/libgc
 			#flag -lgc
+		} $else $if msvc {
+			#flag -DGC_BUILTIN_ATOMIC=1
+			#flag -I@VEXEROOT/thirdparty/libgc/include
 		} $else {
 			#flag -DGC_BUILTIN_ATOMIC=1
 			#flag -I@VEXEROOT/thirdparty/libgc


### PR DESCRIPTION
If this does not make sense from the project's point of view, please just close it.

This workaround allows Windows users to link against gc boehm with self-compiled shared or static gc boehm libs.
To do this, one just needs to add an additional flag to the v-source, such as.
~~~V
$if msvc {
	// #flag -lD:\\ProgramData\\Compiler\\gc-8.0.4\\gc64_dll  // 64bit dll usage
	#flag -lD:\\ProgramData\\Compiler\\gc-8.0.4\\gc        // static lib usage
}

fn main() { 
	println('I was build with boehm')
}
~~~