### PR TITLE
cgen: fix comptime if expr T.typ is type (fix #13118)

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -375,7 +375,11 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) bool {
 						}
 					} else if left is ast.SelectorExpr {
 						name = '${left.expr}.$left.field_name'
-						exp_type = g.comptime_var_type_map[name]
+						if left.gkind_field == .typ {
+							exp_type = g.unwrap_generic(left.name_type)
+						} else {
+							exp_type = g.comptime_var_type_map[name]
+						}
 					} else if left is ast.TypeNode {
 						// this is only allowed for generics currently, otherwise blocked by checker
 						exp_type = g.unwrap_generic(left.typ)

--- a/vlib/v/tests/comptime_if_expr_generic_typ_is_type_test.v
+++ b/vlib/v/tests/comptime_if_expr_generic_typ_is_type_test.v
@@ -1,0 +1,18 @@
+module main
+
+fn write<T>(out T) string {
+	$if T.typ is bool {
+		println('FOO')
+		return 'FOO'
+	} $else $if T.typ !is bool {
+		println('BAR')
+		return 'BAR'
+	}
+	return 'EMPTY'
+}
+
+fn test_comptime_if_expr_generic_typ_is_type() {
+	mut val := false
+	ret := write<bool>(val)
+	assert ret == 'FOO'
+}


### PR DESCRIPTION
This PR fix comptime if expr T.typ is type (fix #13118).

- Fix comptime if expr T.typ is type.
- Add test.

```vlang
module main

fn write<T>(out T) string {
	$if T.typ is bool {
		println('FOO')
		return 'FOO'
	} $else $if T.typ !is bool {
		println('BAR')
		return 'BAR'
	}
	return 'EMPTY'
}

fn main() {
	mut val := false
	ret := write<bool>(val)
	assert ret == 'FOO'
}

PS D:\Test\v\tt1> v run .
FOO
```