### PR TITLE
cgen: fix fn call with mut sumtype argument (fix #13122)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1602,6 +1602,7 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 		g.write('&/*mut*/')
 	} else if arg_is_ptr && !expr_is_ptr {
 		if arg.is_mut {
+			arg_sym := g.table.sym(arg_typ)
 			if exp_sym.kind == .array {
 				if (arg.expr is ast.Ident && (arg.expr as ast.Ident).kind == .variable)
 					|| arg.expr is ast.SelectorExpr {
@@ -1614,6 +1615,11 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 					g.expr(arg.expr)
 					g.write('}[0]')
 				}
+				return
+			} else if arg_sym.kind == .sum_type && exp_sym.kind == .sum_type
+				&& arg.expr is ast.Ident {
+				g.write('&')
+				g.expr(arg.expr)
 				return
 			}
 		}

--- a/vlib/v/tests/fn_call_mut_sumtype_args_test.v
+++ b/vlib/v/tests/fn_call_mut_sumtype_args_test.v
@@ -1,0 +1,30 @@
+type Sum = Struct1 | int
+
+struct Struct1 {
+mut:
+	value int
+}
+
+fn update_sum(mut sum Sum) {
+	match mut sum {
+		Struct1 {
+			sum.value = 42
+		}
+		else {}
+	}
+}
+
+fn test_fn_call_mut_sumtype_args() {
+	mut s := Sum(Struct1{
+		value: 6
+	})
+
+	update_sum(mut s)
+
+	if mut s is Struct1 {
+		println(s.value)
+		assert s.value == 42
+	} else {
+		assert false
+	}
+}


### PR DESCRIPTION
This PR fix fn call with mut sumtype argument (fix #13122).

- Fix fn call with mut sumtype argument.
- Add test.

```vlang
type Sum = Struct1 | int

struct Struct1 {
mut:
	value int
}

fn update_sum(mut sum Sum) {
	match mut sum {
		Struct1 {
			sum.value = 42
		}
		else {}
	}
}

fn main() {
	mut s := Sum(Struct1{
		value: 6
	})

	update_sum(mut s)

	if mut s is Struct1 {
		println(s.value)
		assert s.value == 42
	} else {
		assert false
	}
}

PS D:\Test\v\tt1> v run .
42
```