### PR TITLE
os: add font module, move from gg

### DIFF
--- a/examples/gg/worker_thread.v
+++ b/examples/gg/worker_thread.v
@@ -8,7 +8,6 @@ import gg
 import gx
 import math
 import time
-import os.font
 
 const (
 	win_width   = 600
@@ -37,7 +36,6 @@ fn main() {
 		bg_color: bg_color
 		frame_fn: frame
 		init_fn: init
-		font_path: font.system_path()
 	)
 	app.gg.run()
 }

--- a/examples/gg/worker_thread.v
+++ b/examples/gg/worker_thread.v
@@ -8,6 +8,7 @@ import gg
 import gx
 import math
 import time
+import os.font
 
 const (
 	win_width   = 600
@@ -36,7 +37,7 @@ fn main() {
 		bg_color: bg_color
 		frame_fn: frame
 		init_fn: init
-		font_path: gg.system_font_path()
+		font_path: font.system_path()
 	)
 	app.gg.run()
 }

--- a/examples/hot_reload/bounce.v
+++ b/examples/hot_reload/bounce.v
@@ -5,6 +5,7 @@ module main
 import gx
 import gg
 import time
+import os.font
 
 struct Game {
 mut:
@@ -42,7 +43,7 @@ fn main() {
 		create_window: true
 		frame_fn: frame
 		bg_color: gx.white
-		font_path: gg.system_font_path()
+		font_path: font.system_path()
 	)
 	// window.onkeydown(key_down)
 	println('Starting the game loop...')

--- a/examples/hot_reload/bounce.v
+++ b/examples/hot_reload/bounce.v
@@ -5,7 +5,6 @@ module main
 import gx
 import gg
 import time
-import os.font
 
 struct Game {
 mut:
@@ -43,7 +42,6 @@ fn main() {
 		create_window: true
 		frame_fn: frame
 		bg_color: gx.white
-		font_path: font.system_path()
 	)
 	// window.onkeydown(key_down)
 	println('Starting the game loop...')

--- a/examples/hot_reload/graph.v
+++ b/examples/hot_reload/graph.v
@@ -4,7 +4,6 @@ import gx
 import gg
 import time
 import math
-import os.font
 
 const (
 	size  = 700
@@ -30,7 +29,6 @@ fn main() {
 		frame_fn: frame
 		resizable: true
 		bg_color: gx.white
-		font_path: font.system_path()
 	)
 	context.gg.run()
 }

--- a/examples/hot_reload/graph.v
+++ b/examples/hot_reload/graph.v
@@ -4,6 +4,7 @@ import gx
 import gg
 import time
 import math
+import os.font
 
 const (
 	size  = 700
@@ -29,7 +30,7 @@ fn main() {
 		frame_fn: frame
 		resizable: true
 		bg_color: gx.white
-		font_path: gg.system_font_path()
+		font_path: font.system_path()
 	)
 	context.gg.run()
 }

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -183,7 +183,7 @@ fn gg_init_sokol_window(user_data voidptr) {
 			) or { panic(err) }
 			g.font_inited = true
 		} else {
-			sfont := font.system_path()
+			sfont := font.default()
 			if g.config.font_path != '' {
 				eprintln('font file "$g.config.font_path" does not exist, the system font ($sfont) was used instead.')
 			}

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -4,6 +4,7 @@
 module gg
 
 import os
+import os.font
 import gx
 import sokol
 import sokol.sapp
@@ -182,7 +183,7 @@ fn gg_init_sokol_window(user_data voidptr) {
 			) or { panic(err) }
 			g.font_inited = true
 		} else {
-			sfont := system_font_path()
+			sfont := font.system_path()
 			if g.config.font_path != '' {
 				eprintln('font file "$g.config.font_path" does not exist, the system font ($sfont) was used instead.')
 			}

--- a/vlib/gg/text_rendering.v
+++ b/vlib/gg/text_rendering.v
@@ -4,13 +4,6 @@ module gg
 
 import gx
 
-enum FontVariant {
-	normal = 0
-	bold
-	mono
-	italic
-}
-
 struct FTConfig {
 	font_path             string
 	custom_bold_font_path string

--- a/vlib/os/font/font.v
+++ b/vlib/os/font/font.v
@@ -1,0 +1,128 @@
+// Copyright (c) 2019-2022 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license that can be found in the LICENSE file.
+
+module font
+
+import os
+
+pub enum Variant {
+	normal = 0
+	bold
+	mono
+	italic
+}
+
+[if debug_font ?]
+fn debug_font_println(s string) {
+	println(s)
+}
+
+pub fn system_path() string {
+	env_font := os.getenv('VUI_FONT')
+	if env_font != '' && os.exists(env_font) {
+		return env_font
+	}
+	$if windows {
+		debug_font_println('Using font "C:\\Windows\\Fonts\\arial.ttf"')
+		return 'C:\\Windows\\Fonts\\arial.ttf'
+	}
+	$if macos {
+		fonts := ['/System/Library/Fonts/SFNS.ttf', '/System/Library/Fonts/SFNSText.ttf',
+			'/Library/Fonts/Arial.ttf']
+		for font in fonts {
+			if os.is_file(font) {
+				debug_font_println('Using font "$font"')
+				return font
+			}
+		}
+	}
+	$if android {
+		xml_files := ['/system/etc/system_fonts.xml', '/system/etc/fonts.xml',
+			'/etc/system_fonts.xml', '/etc/fonts.xml', '/data/fonts/fonts.xml',
+			'/etc/fallback_fonts.xml']
+		font_locations := ['/system/fonts', '/data/fonts']
+		for xml_file in xml_files {
+			if os.is_file(xml_file) && os.is_readable(xml_file) {
+				xml := os.read_file(xml_file) or { continue }
+				lines := xml.split('\n')
+				mut candidate_font := ''
+				for line in lines {
+					if line.contains('<font') {
+						candidate_font = line.all_after('>').all_before('<').trim(' \n\t\r')
+						if candidate_font.contains('.ttf') {
+							for location in font_locations {
+								candidate_path := os.join_path(location, candidate_font)
+								if os.is_file(candidate_path) && os.is_readable(candidate_path) {
+									debug_font_println('Using font "$candidate_path"')
+									return candidate_path
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	mut fm := os.execute("fc-match --format='%{file}\n' -s")
+	if fm.exit_code == 0 {
+		lines := fm.output.split('\n')
+		for l in lines {
+			if !l.contains('.ttc') {
+				debug_font_println('Using font "$l"')
+				return l
+			}
+		}
+	} else {
+		panic('fc-match failed to fetch system font')
+	}
+	panic('failed to init the font')
+}
+
+pub fn get_path_variant(font_path string, variant Variant) string {
+	// TODO: find some way to make this shorter and more eye-pleasant
+	// NotoSans, LiberationSans, DejaVuSans, Arial and SFNS should work
+	mut file := os.file_name(font_path)
+	mut fpath := font_path.replace(file, '')
+	file = file.replace('.ttf', '')
+
+	match variant {
+		.normal {}
+		.bold {
+			if fpath.ends_with('-Regular') {
+				file = file.replace('-Regular', '-Bold')
+			} else if file.starts_with('DejaVuSans') {
+				file += '-Bold'
+			} else if file.to_lower().starts_with('arial') {
+				file += 'bd'
+			} else {
+				file += '-bold'
+			}
+			$if macos {
+				if os.exists('SFNS-bold') {
+					file = 'SFNS-bold'
+				}
+			}
+		}
+		.italic {
+			if file.ends_with('-Regular') {
+				file = file.replace('-Regular', '-Italic')
+			} else if file.starts_with('DejaVuSans') {
+				file += '-Oblique'
+			} else if file.to_lower().starts_with('arial') {
+				file += 'i'
+			} else {
+				file += 'Italic'
+			}
+		}
+		.mono {
+			if !file.ends_with('Mono-Regular') && file.ends_with('-Regular') {
+				file = file.replace('-Regular', 'Mono-Regular')
+			} else if file.to_lower().starts_with('arial') {
+				// Arial has no mono variant
+			} else {
+				file += 'Mono'
+			}
+		}
+	}
+	return fpath + file + '.ttf'
+}

--- a/vlib/os/font/font.v
+++ b/vlib/os/font/font.v
@@ -18,11 +18,11 @@ fn debug_font_println(s string) {
 	println(s)
 }
 
-// system_path returns an absolute path the default system TTF font.
+// default returns an absolute path the default system TTF font.
 // If the env variable `VUI_FONT` is set this is used instead.
 // NOTE that, in some cases, the function calls out to external OS programs
 // so running this in a hot loop is not advised.
-pub fn system_path() string {
+pub fn default() string {
 	env_font := os.getenv('VUI_FONT')
 	if env_font != '' && os.exists(env_font) {
 		return env_font

--- a/vlib/os/font/font.v
+++ b/vlib/os/font/font.v
@@ -5,6 +5,7 @@ module font
 
 import os
 
+// Variant enumerates the different variants a font can have.
 pub enum Variant {
 	normal = 0
 	bold
@@ -17,6 +18,10 @@ fn debug_font_println(s string) {
 	println(s)
 }
 
+// system_path returns an absolute path the default system TTF font.
+// If the env variable `VUI_FONT` is set this is used instead.
+// NOTE that, in some cases, the function calls out to external OS programs
+// so running this in a hot loop is not advised.
 pub fn system_path() string {
 	env_font := os.getenv('VUI_FONT')
 	if env_font != '' && os.exists(env_font) {
@@ -78,6 +83,8 @@ pub fn system_path() string {
 	panic('failed to init the font')
 }
 
+// get_path_variant returns the `font_path` file name replaced with the
+// file name of the font's `variant` version if it exists.
 pub fn get_path_variant(font_path string, variant Variant) string {
 	// TODO: find some way to make this shorter and more eye-pleasant
 	// NotoSans, LiberationSans, DejaVuSans, Arial and SFNS should work


### PR DESCRIPTION
As discussed on [Discord](<https://discord.com/channels/592103645835821068/592320321995014154/930791812514328576>) this PR will move a few font related functions out in their own module under `os.font`.

One of the reasons is that fonts and font paths aren't always solely needed for graphical apps - so importing `gg` everytime you need to get a default font is not good in systems that doesn't need (or even have) graphics available.

A relevant example is currently if you want to get a default font for your `vlang/sdl` app you'll need to import all of `gg` as well - although we only need `sdl`.