### PR TITLE
map: make exists() public and generate c code for it

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -531,7 +531,7 @@ fn (m &map) get_check(key voidptr) voidptr {
 }
 
 // Checks whether a particular key exists in the map.
-fn (m &map) exists(key voidptr) bool {
+pub fn (m &map) exists(key voidptr) bool {
 	mut index, mut meta := m.key_to_index(key)
 	for {
 		if meta == unsafe { m.metas[index] } {

--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -943,3 +943,33 @@ fn test_map_set_fixed_array_variable() {
 	println(m2)
 	assert '$m2' == "{'A': [1.1, 2.2]}"
 }
+
+fn test_map_exists() {
+	m1 := {11: '11', 22: '22'}
+
+	assert m1.exists(11)
+	k11 := 11
+	assert m1.exists(k11)
+
+	assert m1.exists(22)
+	k12 := 22
+	assert m1.exists(k12)
+
+	assert !m1.exists(33)
+	k13 := 33
+	assert !m1.exists(k13)
+
+	m2 := {'11': 11, '22': 22}
+
+	assert m2.exists('11')
+	k21 := '11'
+	assert m2.exists(k21)
+
+	assert m2.exists('22')
+	k22 := '22'
+	assert m2.exists(k22)
+
+	assert !m2.exists('33')
+	k23 := '33'
+	assert !m2.exists(k23)
+}

--- a/vlib/v/checker/tests/import_symbol_private_err.out
+++ b/vlib/v/checker/tests/import_symbol_private_err.out
@@ -22,10 +22,10 @@ vlib/v/checker/tests/import_symbol_private_err.vv:4:13: error: module `io` type 
     3 | import time { vpc_now }
     4 | import io { ReaderWriterImpl }
       |             ~~~~~~~~~~~~~~~~
-    5 | 
+    5 |
     6 | fn main() {
 vlib/v/checker/tests/import_symbol_private_err.vv:7:18: error: constant `v.scanner.single_quote` is private
-    5 | 
+    5 |
     6 | fn main() {
     7 |     println(scanner.single_quote)
       |                     ~~~~~~~~~~~~
@@ -45,13 +45,6 @@ vlib/v/checker/tests/import_symbol_private_err.vv:9:2: error: function `time.vpc
       |     ~~~~~~~~~
    10 |     _ = {
    11 |         'h': 2
-vlib/v/checker/tests/import_symbol_private_err.vv:12:4: error: method `map[string]int.exists` is private
-   10 |     _ = {
-   11 |         'h': 2
-   12 |     }.exists('h')
-      |       ~~~~~~~~~~~
-   13 |     _ = ReaderWriterImpl{}
-   14 | }
 vlib/v/checker/tests/import_symbol_private_err.vv:13:6: error: type `io.ReaderWriterImpl` is private
    11 |         'h': 2
    12 |     }.exists('h')

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -800,20 +800,40 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		}
 	}
 
-	if left_sym.kind == .map && node.name == 'delete' {
-		left_info := left_sym.info as ast.Map
-		elem_type_str := g.typ(left_info.key_type)
-		g.write('map_delete(')
-		if node.left_type.is_ptr() {
-			g.expr(node.left)
-		} else {
-			g.write('&')
-			g.expr(node.left)
+	if left_sym.kind == .map {
+		match node.name {
+			'delete' {
+				left_info := left_sym.info as ast.Map
+				elem_type_str := g.typ(left_info.key_type)
+				g.write('map_delete(')
+				if node.left_type.is_ptr() {
+					g.expr(node.left)
+				} else {
+					g.write('&')
+					g.expr(node.left)
+				}
+				g.write(', &($elem_type_str[]){')
+				g.expr(node.args[0].expr)
+				g.write('})')
+				return
+			}
+			'exists' {
+				left_info := left_sym.info as ast.Map
+				elem_type_str := g.typ(left_info.key_type)
+				g.write('map_exists(')
+				if node.left_type.is_ptr() {
+					g.expr(node.left)
+				} else {
+					g.write('&')
+					g.expr(node.left)
+				}
+				g.write(', &($elem_type_str[]){')
+				g.expr(node.args[0].expr)
+				g.write('})')
+				return
+			}
+			else {}
 		}
-		g.write(', &($elem_type_str[]){')
-		g.expr(node.args[0].expr)
-		g.write('})')
-		return
 	} else if left_sym.kind == .array && node.name == 'delete' {
 		g.write('array_delete(')
 		if node.left_type.is_ptr() {


### PR DESCRIPTION
This PR makes exists() public and generate c code for it. (fix #13147)

- Makes exists() public and generate c code for it.
- Add test.

```vlang
fn test_map_exists() {
	m1 := {11: '11', 22: '22'}

	assert m1.exists(11)
	k11 := 11
	assert m1.exists(k11)

	assert m1.exists(22)
	k12 := 22
	assert m1.exists(k12)

	assert !m1.exists(33)
	k13 := 33
	assert !m1.exists(k13)

	m2 := {'11': 11, '22': 22}

	assert m2.exists('11')
	k21 := '11'
	assert m2.exists(k21)

	assert m2.exists('22')
	k22 := '22'
	assert m2.exists(k22)

	assert !m2.exists('33')
	k23 := '33'
	assert !m2.exists(k23)
}
```