### PR TITLE
cgen: fix generics method with sumtype arguments (fix #13155)

### DIFF
--- a/vlib/v/tests/generics_method_with_sumtype_args_test.v
+++ b/vlib/v/tests/generics_method_with_sumtype_args_test.v
@@ -1,0 +1,26 @@
+module main
+
+fn test_generics_method_with_sumtype_args() {
+	mut me := CatDad{}
+	ret := me.adopt<CatType, Cat>(CatType.black, BlackCat{})
+	println(ret)
+	assert ret == 22
+}
+
+[flag]
+enum CatType {
+	black
+	white
+}
+
+type Cat = BlackCat | WhiteCat
+
+struct BlackCat {}
+
+struct WhiteCat {}
+
+struct CatDad {}
+
+fn (mut foo CatDad) adopt<D, T>(d D, t T) int {
+	return 22
+}


### PR DESCRIPTION
This PR fix generics method with sumtype arguments (fix #13155).

- Fix generics method with sumtype arguments.
- Add test.

```vlang
module main

fn main() {
	mut me := CatDad{}
	ret := me.adopt<CatType, Cat>(CatType.black, BlackCat{})
	println(ret)
	assert ret == 22
}

[flag]
enum CatType {
	black
	white
}

type Cat = BlackCat | WhiteCat

struct BlackCat {}

struct WhiteCat {}

struct CatDad {}

fn (mut foo CatDad) adopt<D, T>(d D, t T) int {
	return 22
}

------------
PS D:\Test\v\tt1> v run .
22
```