### PR TITLE
anon_fn: fixed unrecognized empty argnames

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -323,6 +323,11 @@ fn (mut c Checker) anon_fn(mut node ast.AnonFn) ast.Type {
 		c.table.cur_fn = keep_fn
 		c.inside_anon_fn = keep_inside_anon
 	}
+	for param in node.decl.params {
+		if param.name.len == 0 {
+			c.error('use `_` to name an unused parameter', param.pos)
+		}
+	}
 	c.table.cur_fn = unsafe { &node.decl }
 	c.inside_anon_fn = true
 	for mut var in node.inherited_vars {

--- a/vlib/v/checker/tests/anon_fn_arg_type_err.out
+++ b/vlib/v/checker/tests/anon_fn_arg_type_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/anon_fn_arg_type_err.vv:6:14: error: use `_` to name an unused parameter
+    4 |     mut i := 1
+    5 |
+    6 |     func := fn (i) int {
+      |                 ^
+    7 |         return i
+    8 |     }
 vlib/v/checker/tests/anon_fn_arg_type_err.vv:7:10: error: undefined ident: `i`
     5 |
     6 |     func := fn (i) int {
@@ -5,13 +12,6 @@ vlib/v/checker/tests/anon_fn_arg_type_err.vv:7:10: error: undefined ident: `i`
       |                ^
     8 |     }
     9 |
-vlib/v/checker/tests/anon_fn_arg_type_err.vv:6:14: error: unknown type `i`
-    4 |     mut i := 1
-    5 |
-    6 |     func := fn (i) int {
-      |                 ^
-    7 |         return i
-    8 |     }
 vlib/v/checker/tests/anon_fn_arg_type_err.vv:10:15: error: cannot use `int` as `i` in argument 1 to `func`
     8 |     }
     9 |


### PR DESCRIPTION
Anon functions didn't properly check for unnamed args in some cases(e.g. struct types) and therefor resulted in a C compiler error. I already closed my associated issue( #13148 )