### PR TITLE
vpm: support full urls in v.mod's dependencies field

### DIFF
--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -6,6 +6,7 @@ module main
 import os
 import os.cmdline
 import net.http
+import net.urllib
 import json
 import vhelp
 import v.vmod
@@ -664,6 +665,17 @@ fn verbose_println(s string) {
 
 fn get_module_meta_info(name string) ?Mod {
 	mut errors := []string{}
+
+	if purl := urllib.parse(name) {
+		verbose_println('purl: $purl')
+		mod := Mod{
+			name: purl.path.trim_left('/').trim_right('/')
+			url: name
+		}
+		verbose_println(mod.str())
+		return mod
+	}
+
 	for server_url in default_vpm_server_urls {
 		modurl := server_url + '/jsmod/$name'
 		verbose_println('Retrieving module metadata from: $modurl ...')


### PR DESCRIPTION
With this PR, vpm will support full urls that can be cloned in v.mod's
dependencies field too. For example:
`dependencies: ['https://github.com/spytheman/vperlin', 'vtl', 'ui', 'gporrata.rambo']`

The above, will clone https://github.com/spytheman/vperlin into
~/.vmodules/spytheman/vperlin , when you do `v update` over the
module/project that has it.


Currently on master, that does not work, since it will try to query
https://vpm.vlang.io/ even for urls, not just for `user.modname` type
of specifiers.