### PR TITLE
cgen: fix match sumtype var returning sumtype value (fix #13175)

### DIFF
--- a/vlib/v/tests/match_sumtype_var_return_sumtype_test.v
+++ b/vlib/v/tests/match_sumtype_var_return_sumtype_test.v
@@ -1,0 +1,30 @@
+module main
+
+type Sum = Struct | int
+
+struct Struct {
+mut:
+	value int
+}
+
+fn sum(mut s Sum) Sum {
+	match mut s {
+		Struct {
+			return s
+		}
+		else {
+			return s
+		}
+	}
+}
+
+fn test_match_sumtype_var_return_sumtype() {
+	mut s := Sum(Struct{
+		value: 42
+	})
+	s = sum(mut s)
+	dump(s)
+	ret := '$s'
+	assert ret.contains('Sum(Struct{')
+	assert ret.contains('value: 42')
+}


### PR DESCRIPTION
This PR fix match sumtype var returning sumtype value (fix #13175).

- Fix match sumtype var returning sumtype value.
- Add test.

```vlang
module main

type Sum = Struct | int

struct Struct {
mut:
	value int
}

fn sum(mut s Sum) Sum {
	match mut s {
		Struct {
			return s
		}
		else {
			return s
		}
	}
}

fn main() {
	mut s := Sum(Struct{
		value: 42
	})
	s = sum(mut s)
	dump(s)
	ret := '$s'
	assert ret.contains('Sum(Struct{')
	assert ret.contains('value: 42')
}

------------------------------------------------
PS D:\Test\v\tt1> v run .
[.\\tt1.v:26] s: Sum(Struct{
    value: 42
})
```