### PR TITLE
parser: check the receiver error of method call (fix #13201)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2317,6 +2317,10 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 				scope: p.scope
 			}
 		}
+		if p.peek_token(2).kind == .name && p.peek_token(3).kind == .lpar && !known_var {
+			p.error_with_pos('the receiver of the method call must be an instantiated object, e.g. `foo.bar()`',
+				p.tok.position())
+		}
 		// `Color.green`
 		mut enum_name := p.check_name()
 		enum_name_pos := p.prev_tok.position()

--- a/vlib/v/parser/tests/method_call_receiver_err.out
+++ b/vlib/v/parser/tests/method_call_receiver_err.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/method_call_receiver_err.vv:9:11: error: the receiver of the method call must be an instantiated object, e.g. `foo.bar()`
+    7 |
+    8 |     $for method in S1.methods {
+    9 |         println(S1.method_hello('yo'))
+      |                 ~~
+   10 |     }
+   11 | }

--- a/vlib/v/parser/tests/method_call_receiver_err.vv
+++ b/vlib/v/parser/tests/method_call_receiver_err.vv
@@ -1,0 +1,15 @@
+module main
+
+struct S1{}
+
+fn main() {
+	s1 := S1{}
+
+	$for method in S1.methods {
+		println(S1.method_hello('yo'))
+	}
+}
+
+fn (t S1) method_hello() string {
+	return 'Hello'
+}


### PR DESCRIPTION
This PR check the receiver error of method call (fix #13201).

- Check the receiver error of method call.
- Add test.

```vlang
module main

struct S1{}

fn main() {
	s1 := S1{}

	$for method in S1.methods {
		println(S1.method_hello('yo'))
	}
}

fn (t S1) method_hello() string {
	return 'Hello'
}

PS D:\Test\v\tt1> v run .
.\tt1.v:9:11: error: the receiver of the method call must be an instantiated object, e.g. `foo.bar()`
    7 |
    8 |     $for method in S1.methods {
    9 |         println(S1.method_hello('yo'))
      |                 ~~
   10 |     }
   11 | }
```