### PR TITLE
cgen: fix assigning to mut receiver of sumtype (fix #13202)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -435,7 +435,12 @@ fn (mut g Gen) gen_assign_stmt(node ast.AssignStmt) {
 						if op_overloaded {
 							g.op_arg(val, op_expected_right, val_type)
 						} else {
-							g.expr_with_cast(val, val_type, var_type)
+							exp_type := if left.is_auto_deref_var() {
+								var_type.deref()
+							} else {
+								var_type
+							}
+							g.expr_with_cast(val, val_type, exp_type)
 						}
 					}
 				}

--- a/vlib/v/tests/mut_receiver_of_sumtype_test.v
+++ b/vlib/v/tests/mut_receiver_of_sumtype_test.v
@@ -1,0 +1,17 @@
+pub type Foo = Bar | Baz
+
+fn (mut f Foo) set_baz() {
+	f = Baz{}
+}
+
+pub struct Bar {}
+
+pub struct Baz {}
+
+fn test_mut_receiver_of_sumtype() {
+	mut x := Foo(Bar{})
+	x.set_baz()
+
+	println(x)
+	assert '$x' == 'Foo(Baz{})'
+}


### PR DESCRIPTION
This PR fix assigning to mut receiver of sumtype (fix #13202).

- Fix assigning to mut receiver of sumtype.
- Add test.

```vlang
pub type Foo = Bar | Baz

fn (mut f Foo) set_baz() {
	f = Baz{}
}

pub struct Bar {}

pub struct Baz {}

fn main() {
	mut x := Foo(Bar{})
	x.set_baz()

	println(x)
	assert '$x' == 'Foo(Baz{})'
}


PS D:\Test\v\tt1> v run .
Foo(Baz{})
```