### PR TITLE
gen: fix mut sumtype arguments for fields

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1647,8 +1647,8 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 				}
 				return
 			} else if arg_sym.kind == .sum_type && exp_sym.kind == .sum_type
-				&& arg.expr is ast.Ident {
-				g.write('&')
+				&& (arg.expr is ast.Ident || arg.expr is ast.SelectorExpr) {
+				g.write('&/*sum*/')
 				g.expr(arg.expr)
 				return
 			}

--- a/vlib/v/tests/fn_call_mut_sumtype_args_test.v
+++ b/vlib/v/tests/fn_call_mut_sumtype_args_test.v
@@ -1,11 +1,18 @@
-type Sum = Struct1 | int
+type Sum1 = Struct1 | int
 
 struct Struct1 {
 mut:
 	value int
 }
 
-fn update_sum(mut sum Sum) {
+type Sum2 = Struct1 | Struct2 | int
+
+struct Struct2 {
+mut:
+	sum Sum2
+}
+
+fn update_sum_1(mut sum Sum1) {
 	match mut sum {
 		Struct1 {
 			sum.value = 42
@@ -14,16 +21,49 @@ fn update_sum(mut sum Sum) {
 	}
 }
 
+fn update_sum_2(mut sum Sum2) {
+	match mut sum {
+		Struct1 {
+			sum.value = 42
+		}
+		Struct2 {
+			update_sum_2(mut sum.sum)
+		}
+		else {}
+	}
+}
+
 fn test_fn_call_mut_sumtype_args() {
-	mut s := Sum(Struct1{
+	mut s := Sum1(Struct1{
 		value: 6
 	})
 
-	update_sum(mut s)
+	update_sum_1(mut s)
 
 	if mut s is Struct1 {
 		println(s.value)
 		assert s.value == 42
+	} else {
+		assert false
+	}
+}
+
+fn test_fn_call_mut_sumtype_args_field() {
+	mut s := Sum2(Struct2{
+		sum: Sum2(Struct1{
+			value: 6
+		})
+	})
+
+	update_sum_2(mut s)
+
+	if mut s is Struct2 {
+		if mut s.sum is Struct1 {
+			println(s.sum.value)
+			assert s.sum.value == 42
+		} else {
+			assert false
+		}
 	} else {
 		assert false
 	}


### PR DESCRIPTION
Fixes the C error when passing a sumtype from a field
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
