### PR TITLE
gg: add the gg.Context.remove_cached_image_by_idx() method

### DIFF
--- a/vlib/gg/image.v
+++ b/vlib/gg/image.v
@@ -38,6 +38,10 @@ pub fn (mut ctx Context) get_cached_image_by_idx(image_idx int) &Image {
 	return &ctx.image_cache[image_idx]
 }
 
+pub fn (mut ctx Context) remove_cached_image_by_idx(image_idx int) {
+	ctx.image_cache.delete(image_idx)
+}
+
 // Draw part of an image using uv coordinates
 // img_rect is the size and position (in pixels on screen) of the displayed rectangle (ie the draw_image args)
 // part_rect is the size and position (in absolute pixels in the image) of the wanted part

--- a/vlib/gg/testdata/remove_image_from_cache.vv
+++ b/vlib/gg/testdata/remove_image_from_cache.vv
@@ -35,7 +35,7 @@ fn frame(mut ctx gg.Context) {
 	ctx.remove_cached_image_by_idx(id)
 	ctx.end()
 	gfx.destroy_image(img.simg)
-	unsafe{
+	unsafe {
 		free(&bytes[0])
 	}
 }

--- a/vlib/gg/testdata/remove_image_from_cache.vv
+++ b/vlib/gg/testdata/remove_image_from_cache.vv
@@ -1,0 +1,41 @@
+module main
+
+import gg
+import sokol.gfx
+
+[console]
+fn main() {
+	mut context := gg.new_context(
+		frame_fn: frame
+		width: 500
+		height: 500
+	)
+	context.run()
+}
+
+fn frame(mut ctx gg.Context) {
+	ctx.begin()
+	id := ctx.new_streaming_image(ctx.width, ctx.height, 4, pixel_format: .rgba8)
+	mut img := ctx.get_cached_image_by_idx(id)
+	mut bytes := []byte{len: img.width * img.height * 4, cap: img.width * img.height * 4}
+	for y in 0 .. img.height {
+		for x in 0 .. img.width {
+			unsafe {
+				bytes[(x + img.width * y) * 4] = 100
+				bytes[(x + img.width * y) * 4 + 1] = 100
+				bytes[(x + img.width * y) * 4 + 2] = 100
+				bytes[(x + img.width * y) * 4 + 3] = 255
+			}
+		}
+	}
+	unsafe {
+		img.update_pixel_data(&bytes[0])
+	}
+	ctx.draw_image(0, 0, ctx.width, ctx.height, img)
+	ctx.remove_cached_image_by_idx(id)
+	ctx.end()
+	gfx.destroy_image(img.simg)
+	unsafe{
+		free(&bytes[0])
+	}
+}


### PR DESCRIPTION
This is needed if you want to draw on the screen but cannot use a streaming image (for example, because the window has been resized).
I've tested this and it works.