### PR TITLE
cgen: fix return of mut symtype

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5004,6 +5004,8 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			if g.fn_decl.return_type.is_ptr() {
 				var_str := g.expr_string(expr0)
 				g.write(var_str.trim('&'))
+			} else if g.table.sym(g.fn_decl.return_type).kind in [.sum_type, .interface_] {
+				g.expr_with_cast(expr0, node.types[0], g.fn_decl.return_type)
 			} else {
 				g.write('*')
 				g.expr(expr0)

--- a/vlib/v/tests/fn_return_mut_sumtype_test.v
+++ b/vlib/v/tests/fn_return_mut_sumtype_test.v
@@ -1,0 +1,23 @@
+type Sum = Struct | int
+
+struct Struct {
+mut:
+	value int
+}
+
+fn update(mut s Struct) Sum {
+	s.value += 1
+	return s
+}
+
+fn test_fn_return_mut_sumtype() {
+	mut s := Sum(Struct{
+		value: 1
+	})
+	if mut s is Struct {
+		s = update(mut s)
+		assert s.value == 2
+	} else {
+		assert false
+	}
+}


### PR DESCRIPTION
Fixes C error when returning a mutable symtype
```
==================
/tmp/v/test_session_27434421237759/fn_return_mut_sumtype_test.15792886877278215264.tmp.c:16576: error: '{' expected (got ";")
...
=================
```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
