### PR TITLE
checker: fix ui struct init error with default field value is const var (fix #13209)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -330,10 +330,16 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 					continue
 				}
 				if field.has_default_expr {
-					if field.default_expr is ast.StructInit && field.default_expr_typ == 0 {
-						idx := c.table.find_type_idx(field.default_expr.typ_str)
-						if idx != 0 {
-							info.fields[i].default_expr_typ = ast.new_type(idx)
+					if field.default_expr_typ == 0 {
+						if field.default_expr is ast.StructInit {
+							idx := c.table.find_type_idx(field.default_expr.typ_str)
+							if idx != 0 {
+								info.fields[i].default_expr_typ = ast.new_type(idx)
+							}
+						} else {
+							if const_field := c.table.global_scope.find_const('$field.default_expr') {
+								info.fields[i].default_expr_typ = const_field.typ
+							}
 						}
 					}
 					continue


### PR DESCRIPTION
This PR fix ui struct init error with default field value is const var (fix #13209).

```vlang
module ui

import gx

pub struct Foo{ x int }  // Added

[heap]
pub struct Label {
	Foo     // Added
pub mut:
	id         string
	text       string
...
}

module main

import ui

fn main(){
	lbl := ui.label(text: 'Hello')
	w := ui.window(
		width: 300
		height: 200
		children: [lbl]
	)
	ui.run(w)
}
```
![image](https://user-images.githubusercontent.com/6949593/150126201-eb23fd4c-12e9-4b11-ad19-6d5494cdde1a.png)
