### PR TITLE
ast: rename `register_type_symbol` to `register_sym`

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -739,7 +739,7 @@ fn (mut t Table) rewrite_already_registered_symbol(typ TypeSymbol, existing_idx 
 }
 
 [inline]
-pub fn (mut t Table) register_type_symbol(sym TypeSymbol) int {
+pub fn (mut t Table) register_sym(sym TypeSymbol) int {
 	mut idx := -2
 	mut existing_idx := t.type_idxs[sym.name]
 	if existing_idx > 0 {
@@ -958,7 +958,7 @@ pub fn (mut t Table) find_or_register_chan(elem_type Type, is_mut bool) int {
 			is_mut: is_mut
 		}
 	}
-	return t.register_type_symbol(chan_typ)
+	return t.register_sym(chan_typ)
 }
 
 pub fn (mut t Table) find_or_register_map(key_type Type, value_type Type) int {
@@ -980,7 +980,7 @@ pub fn (mut t Table) find_or_register_map(key_type Type, value_type Type) int {
 			value_type: value_type
 		}
 	}
-	return t.register_type_symbol(map_typ)
+	return t.register_sym(map_typ)
 }
 
 pub fn (mut t Table) find_or_register_thread(return_type Type) int {
@@ -1001,7 +1001,7 @@ pub fn (mut t Table) find_or_register_thread(return_type Type) int {
 			return_type: return_type
 		}
 	}
-	return t.register_type_symbol(thread_typ)
+	return t.register_sym(thread_typ)
 }
 
 pub fn (mut t Table) find_or_register_promise(return_type Type) int {
@@ -1025,7 +1025,7 @@ pub fn (mut t Table) find_or_register_promise(return_type Type) int {
 	}
 
 	// register
-	return t.register_type_symbol(promise_type)
+	return t.register_sym(promise_type)
 }
 
 pub fn (mut t Table) find_or_register_array(elem_type Type) int {
@@ -1047,7 +1047,7 @@ pub fn (mut t Table) find_or_register_array(elem_type Type) int {
 			elem_type: elem_type
 		}
 	}
-	return t.register_type_symbol(array_type_)
+	return t.register_sym(array_type_)
 }
 
 pub fn (mut t Table) find_or_register_array_with_dims(elem_type Type, nr_dims int) int {
@@ -1076,7 +1076,7 @@ pub fn (mut t Table) find_or_register_array_fixed(elem_type Type, size int, size
 			size_expr: size_expr
 		}
 	}
-	return t.register_type_symbol(array_fixed_type)
+	return t.register_sym(array_fixed_type)
 }
 
 pub fn (mut t Table) find_or_register_multi_return(mr_typs []Type) int {
@@ -1106,7 +1106,7 @@ pub fn (mut t Table) find_or_register_multi_return(mr_typs []Type) int {
 			types: mr_typs
 		}
 	}
-	return t.register_type_symbol(mr_type)
+	return t.register_sym(mr_type)
 }
 
 pub fn (mut t Table) find_or_register_fn_type(mod string, f Fn, is_anon bool, has_decl bool) int {
@@ -1121,7 +1121,7 @@ pub fn (mut t Table) find_or_register_fn_type(mod string, f Fn, is_anon bool, ha
 	if existing_idx > 0 && t.type_symbols[existing_idx].kind != .placeholder {
 		return existing_idx
 	}
-	return t.register_type_symbol(
+	return t.register_sym(
 		kind: .function
 		name: name
 		cname: cname
@@ -1146,7 +1146,7 @@ pub fn (mut t Table) add_placeholder_type(name string, language Language) int {
 		language: language
 		mod: modname
 	}
-	return t.register_type_symbol(ph_type)
+	return t.register_sym(ph_type)
 }
 
 [inline]
@@ -1656,7 +1656,7 @@ pub fn (mut t Table) unwrap_generic_type(typ Type, generic_names []string, concr
 			info.concrete_types = final_concrete_types
 			info.parent_type = typ
 			info.fields = fields
-			new_idx := t.register_type_symbol(
+			new_idx := t.register_sym(
 				kind: .struct_
 				name: nrt
 				cname: util.no_dots(c_nrt)
@@ -1699,7 +1699,7 @@ pub fn (mut t Table) unwrap_generic_type(typ Type, generic_names []string, concr
 			info.parent_type = typ
 			info.fields = fields
 			info.methods = imethods
-			new_idx := t.register_type_symbol(
+			new_idx := t.register_sym(
 				kind: .interface_
 				name: nrt
 				cname: util.no_dots(c_nrt)

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -715,45 +715,45 @@ pub fn (t &TypeSymbol) is_heap() bool {
 pub fn (mut t Table) register_builtin_type_symbols() {
 	// reserve index 0 so nothing can go there
 	// save index check, 0 will mean not found
-	t.register_type_symbol(kind: .placeholder, name: 'reserved_0')
-	t.register_type_symbol(kind: .void, name: 'void', cname: 'void', mod: 'builtin')
-	t.register_type_symbol(kind: .voidptr, name: 'voidptr', cname: 'voidptr', mod: 'builtin')
-	t.register_type_symbol(kind: .byteptr, name: 'byteptr', cname: 'byteptr', mod: 'builtin')
-	t.register_type_symbol(kind: .charptr, name: 'charptr', cname: 'charptr', mod: 'builtin')
-	t.register_type_symbol(kind: .i8, name: 'i8', cname: 'i8', mod: 'builtin')
-	t.register_type_symbol(kind: .i16, name: 'i16', cname: 'i16', mod: 'builtin')
-	t.register_type_symbol(kind: .int, name: 'int', cname: 'int', mod: 'builtin')
-	t.register_type_symbol(kind: .i64, name: 'i64', cname: 'i64', mod: 'builtin')
-	t.register_type_symbol(kind: .isize, name: 'isize', cname: 'isize', mod: 'builtin')
-	t.register_type_symbol(kind: .byte, name: 'byte', cname: 'byte', mod: 'builtin')
-	t.register_type_symbol(kind: .u16, name: 'u16', cname: 'u16', mod: 'builtin')
-	t.register_type_symbol(kind: .u32, name: 'u32', cname: 'u32', mod: 'builtin')
-	t.register_type_symbol(kind: .u64, name: 'u64', cname: 'u64', mod: 'builtin')
-	t.register_type_symbol(kind: .usize, name: 'usize', cname: 'usize', mod: 'builtin')
-	t.register_type_symbol(kind: .f32, name: 'f32', cname: 'f32', mod: 'builtin')
-	t.register_type_symbol(kind: .f64, name: 'f64', cname: 'f64', mod: 'builtin')
-	t.register_type_symbol(kind: .char, name: 'char', cname: 'char', mod: 'builtin')
-	t.register_type_symbol(kind: .bool, name: 'bool', cname: 'bool', mod: 'builtin')
-	t.register_type_symbol(kind: .none_, name: 'none', cname: 'none', mod: 'builtin')
-	t.register_type_symbol(kind: .string, name: 'string', cname: 'string', mod: 'builtin')
-	t.register_type_symbol(kind: .rune, name: 'rune', cname: 'rune', mod: 'builtin')
-	t.register_type_symbol(kind: .array, name: 'array', cname: 'array', mod: 'builtin')
-	t.register_type_symbol(kind: .map, name: 'map', cname: 'map', mod: 'builtin')
-	t.register_type_symbol(kind: .chan, name: 'chan', cname: 'chan', mod: 'builtin')
-	t.register_type_symbol(kind: .any, name: 'any', cname: 'any', mod: 'builtin')
-	t.register_type_symbol(
+	t.register_sym(kind: .placeholder, name: 'reserved_0')
+	t.register_sym(kind: .void, name: 'void', cname: 'void', mod: 'builtin')
+	t.register_sym(kind: .voidptr, name: 'voidptr', cname: 'voidptr', mod: 'builtin')
+	t.register_sym(kind: .byteptr, name: 'byteptr', cname: 'byteptr', mod: 'builtin')
+	t.register_sym(kind: .charptr, name: 'charptr', cname: 'charptr', mod: 'builtin')
+	t.register_sym(kind: .i8, name: 'i8', cname: 'i8', mod: 'builtin')
+	t.register_sym(kind: .i16, name: 'i16', cname: 'i16', mod: 'builtin')
+	t.register_sym(kind: .int, name: 'int', cname: 'int', mod: 'builtin')
+	t.register_sym(kind: .i64, name: 'i64', cname: 'i64', mod: 'builtin')
+	t.register_sym(kind: .isize, name: 'isize', cname: 'isize', mod: 'builtin')
+	t.register_sym(kind: .byte, name: 'byte', cname: 'byte', mod: 'builtin')
+	t.register_sym(kind: .u16, name: 'u16', cname: 'u16', mod: 'builtin')
+	t.register_sym(kind: .u32, name: 'u32', cname: 'u32', mod: 'builtin')
+	t.register_sym(kind: .u64, name: 'u64', cname: 'u64', mod: 'builtin')
+	t.register_sym(kind: .usize, name: 'usize', cname: 'usize', mod: 'builtin')
+	t.register_sym(kind: .f32, name: 'f32', cname: 'f32', mod: 'builtin')
+	t.register_sym(kind: .f64, name: 'f64', cname: 'f64', mod: 'builtin')
+	t.register_sym(kind: .char, name: 'char', cname: 'char', mod: 'builtin')
+	t.register_sym(kind: .bool, name: 'bool', cname: 'bool', mod: 'builtin')
+	t.register_sym(kind: .none_, name: 'none', cname: 'none', mod: 'builtin')
+	t.register_sym(kind: .string, name: 'string', cname: 'string', mod: 'builtin')
+	t.register_sym(kind: .rune, name: 'rune', cname: 'rune', mod: 'builtin')
+	t.register_sym(kind: .array, name: 'array', cname: 'array', mod: 'builtin')
+	t.register_sym(kind: .map, name: 'map', cname: 'map', mod: 'builtin')
+	t.register_sym(kind: .chan, name: 'chan', cname: 'chan', mod: 'builtin')
+	t.register_sym(kind: .any, name: 'any', cname: 'any', mod: 'builtin')
+	t.register_sym(
 		kind: .float_literal
 		name: 'float literal'
 		cname: 'float_literal'
 		mod: 'builtin'
 	)
-	t.register_type_symbol(
+	t.register_sym(
 		kind: .int_literal
 		name: 'int literal'
 		cname: 'int_literal'
 		mod: 'builtin'
 	)
-	t.register_type_symbol(
+	t.register_sym(
 		kind: .thread
 		name: 'thread'
 		cname: '__v_thread'
@@ -762,8 +762,8 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 			return_type: ast.void_type
 		}
 	)
-	t.register_type_symbol(kind: .interface_, name: 'IError', cname: 'IError', mod: 'builtin')
-	t.register_type_symbol(kind: .u8, name: 'zu8', cname: 'zu8', mod: 'builtin')
+	t.register_sym(kind: .interface_, name: 'IError', cname: 'IError', mod: 'builtin')
+	t.register_sym(kind: .u8, name: 'zu8', cname: 'zu8', mod: 'builtin')
 }
 
 [inline]

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -264,7 +264,7 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 					if existing_idx > 0 {
 						expr_type = existing_idx
 					} else {
-						expr_type = c.table.register_type_symbol(ast.TypeSymbol{
+						expr_type = c.table.register_sym(ast.TypeSymbol{
 							name: name
 							cname: agg_cname.str()
 							kind: .aggregate

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -308,7 +308,7 @@ pub fn (mut p Parser) parse_inline_sum_type() ast.Type {
 		if idx > 0 {
 			return ast.new_type(idx)
 		}
-		idx = p.table.register_type_symbol(ast.TypeSymbol{
+		idx = p.table.register_sym(ast.TypeSymbol{
 			kind: .sum_type
 			name: prepend_mod_name
 			cname: util.no_dots(prepend_mod_name)
@@ -601,7 +601,7 @@ pub fn (mut p Parser) parse_generic_type(name string) ast.Type {
 	if idx > 0 {
 		return ast.new_type(idx).set_flag(.generic)
 	}
-	idx = p.table.register_type_symbol(ast.TypeSymbol{
+	idx = p.table.register_sym(ast.TypeSymbol{
 		name: name
 		cname: util.no_dots(name)
 		mod: p.mod
@@ -684,7 +684,7 @@ pub fn (mut p Parser) parse_generic_inst_type(name string) ast.Type {
 			else {}
 		}
 
-		idx := p.table.register_type_symbol(ast.TypeSymbol{
+		idx := p.table.register_sym(ast.TypeSymbol{
 			kind: .generic_inst
 			name: bs_name
 			cname: util.no_dots(bs_cname)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2746,7 +2746,7 @@ fn (mut p Parser) parse_generic_types() ([]ast.Type, []string) {
 
 		mut idx := p.table.find_type_idx(name)
 		if idx == 0 {
-			idx = p.table.register_type_symbol(ast.TypeSymbol{
+			idx = p.table.register_sym(ast.TypeSymbol{
 				name: name
 				cname: util.no_dots(name)
 				mod: p.mod
@@ -3453,7 +3453,7 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 //
 ')
 	}
-	idx := p.table.register_type_symbol(ast.TypeSymbol{
+	idx := p.table.register_sym(ast.TypeSymbol{
 		kind: .enum_
 		name: name
 		cname: util.no_dots(name)
@@ -3542,7 +3542,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		}
 		variant_types := sum_variants.map(it.typ)
 		prepend_mod_name := p.prepend_mod(name)
-		typ := p.table.register_type_symbol(ast.TypeSymbol{
+		typ := p.table.register_sym(ast.TypeSymbol{
 			kind: .sum_type
 			name: prepend_mod_name
 			cname: util.no_dots(prepend_mod_name)
@@ -3582,7 +3582,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 	pidx := parent_type.idx()
 	p.check_for_impure_v(parent_sym.language, decl_pos)
 	prepend_mod_name := p.prepend_mod(name)
-	idx := p.table.register_type_symbol(ast.TypeSymbol{
+	idx := p.table.register_sym(ast.TypeSymbol{
 		kind: .alias
 		name: prepend_mod_name
 		cname: util.no_dots(prepend_mod_name)

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -308,7 +308,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 	}
 	mut ret := 0
 	// println('reg type symbol $name mod=$p.mod')
-	ret = p.table.register_type_symbol(t)
+	ret = p.table.register_sym(t)
 	// allow duplicate c struct declarations
 	if ret == -1 && language != .c {
 		p.error_with_pos('cannot register struct `$name`, another type with this name exists',
@@ -468,7 +468,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		return ast.InterfaceDecl{}
 	}
 	// Declare the type
-	reg_idx := p.table.register_type_symbol(
+	reg_idx := p.table.register_sym(
 		is_public: is_pub
 		kind: .interface_
 		name: interface_name


### PR DESCRIPTION
This PR rename `register_type_symbol` to `register_sym`.

- Rename `register_type_symbol` to `register_sym`.
- Modify related called.