### PR TITLE
checker: check generics undefined operation of the infix expression (fix #13221)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -679,31 +679,25 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				}
 			}
 			if left_sym.kind in [.array, .array_fixed, .map, .struct_] {
-				if left_sym.has_method(node.op.str()) {
-					if method := left_sym.find_method(node.op.str()) {
+				if left_sym.has_method_with_generic_parent(node.op.str()) {
+					if method := left_sym.find_method_with_generic_parent(node.op.str()) {
 						return_type = method.return_type
 					} else {
 						return_type = left_type
 					}
 				} else {
-					if left_sym.kind == .struct_
-						&& (left_sym.info as ast.Struct).generic_types.len > 0 {
-						return_type = left_type
+					left_name := c.table.type_to_str(left_type)
+					right_name := c.table.type_to_str(right_type)
+					if left_name == right_name {
+						c.error('undefined operation `$left_name` $node.op.str() `$right_name`',
+							left_right_pos)
 					} else {
-						left_name := c.table.type_to_str(left_type)
-						right_name := c.table.type_to_str(right_type)
-						if left_name == right_name {
-							c.error('undefined operation `$left_name` $node.op.str() `$right_name`',
-								left_right_pos)
-						} else {
-							c.error('mismatched types `$left_name` and `$right_name`',
-								left_right_pos)
-						}
+						c.error('mismatched types `$left_name` and `$right_name`', left_right_pos)
 					}
 				}
 			} else if right_sym.kind in [.array, .array_fixed, .map, .struct_] {
-				if right_sym.has_method(node.op.str()) {
-					if method := right_sym.find_method(node.op.str()) {
+				if right_sym.has_method_with_generic_parent(node.op.str()) {
+					if method := right_sym.find_method_with_generic_parent(node.op.str()) {
 						return_type = method.return_type
 					} else {
 						return_type = right_type

--- a/vlib/v/checker/tests/generics_undefined_operation.out
+++ b/vlib/v/checker/tests/generics_undefined_operation.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/generics_undefined_operation.vv:12:5: error: undefined operation `V2d<int>` * `V2d<int>`
+   10 |     v3 := V2d<int>{4, 6}
+   11 |
+   12 |     if v1 * v2 == v3 {
+      |        ~~~~~~~
+   13 |     }
+   14 | }

--- a/vlib/v/checker/tests/generics_undefined_operation.vv
+++ b/vlib/v/checker/tests/generics_undefined_operation.vv
@@ -1,0 +1,14 @@
+struct V2d<T> {
+mut:
+	x T
+	y T
+}
+
+fn main() {
+	v1 := V2d<int>{2, 2}
+	v2 := V2d<int>{2, 3}
+	v3 := V2d<int>{4, 6}
+
+	if v1 * v2 == v3 {
+	}
+}


### PR DESCRIPTION
This PR check generics undefined operation of the infix expression (fix #13221).

- Check generics undefined operation of the infix expression.
- Add test.

```vlang
struct V2d<T> {
mut:
	x T
	y T
}

fn main() {
	v1 := V2d<int>{2, 2}
	v2 := V2d<int>{2, 3}
	v3 := V2d<int>{4, 6}
	
	if v1 * v2 == v3 {
	}
}

PS D:\Test\v\tt1> v run .
.\tt1.v:12:5: error: undefined operation `V2d<int>` * `V2d<int>`
   10 |     v3 := V2d<int>{4, 6}
   11 |
   12 |     if v1 * v2 == v3 {
      |        ~~~~~~~
   13 |     }
   14 | }
```