### PR TITLE
cgen: fix fn call with fixed array literal arguments (fix #13220)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -78,6 +78,16 @@ fn (mut g Gen) array_init(node ast.ArrayInit) {
 			g.inside_lambda = false
 			return
 		}
+		need_tmp_var := g.inside_call && !g.inside_struct_init
+		mut stmt_str := ''
+		mut tmp_var := ''
+		if need_tmp_var {
+			tmp_var = g.new_tmp_var()
+			stmt_str = g.go_before_stmt(0)
+			ret_typ := g.typ(node.typ)
+			g.empty_line = true
+			g.write('$ret_typ $tmp_var = ')
+		}
 		g.write('{')
 		if node.has_val {
 			for i, expr in node.exprs {
@@ -100,6 +110,11 @@ fn (mut g Gen) array_init(node ast.ArrayInit) {
 			g.write('0')
 		}
 		g.write('}')
+		if need_tmp_var {
+			g.writeln(';')
+			g.write(stmt_str)
+			g.write(tmp_var)
+		}
 		return
 	}
 	elem_styp := g.typ(elem_type.typ)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -113,6 +113,7 @@ mut:
 	inside_match_optional  bool
 	inside_vweb_tmpl       bool
 	inside_return          bool
+	inside_struct_init     bool
 	inside_or_block        bool
 	inside_call            bool
 	inside_for_c_stmt      bool
@@ -3390,7 +3391,9 @@ fn (mut g Gen) expr(node ast.Expr) {
 				g.expr(ast.resolve_init(node, g.unwrap_generic(node.typ), g.table))
 			} else {
 				// `user := User{name: 'Bob'}`
+				g.inside_struct_init = true
 				g.struct_init(node)
+				g.inside_struct_init = false
 			}
 		}
 		ast.TypeNode {

--- a/vlib/v/tests/fn_call_fixed_array_literal_args_test.v
+++ b/vlib/v/tests/fn_call_fixed_array_literal_args_test.v
@@ -1,0 +1,9 @@
+fn test_fn_call_fixed_array_literal_args() {
+	ret := get_str([1]!)
+	assert ret == '[1]'
+}
+
+fn get_str(t [1]int) string {
+	println(t)
+	return '$t'
+}


### PR DESCRIPTION
This PR fix fn call with fixed array literal arguments (fix #13220).

- Fix fn call with fixed array literal arguments.
- Add test.

```vlang
fn main() {
	ret := get_str([1]!)
	assert ret == '[1]'
}

fn get_str(t [1]int) string {
	println(t)
	return '$t'
}

PS D:\Test\v\tt1> v run .
[1]
```