### PR TITLE
parser, checker: correct error message of fixed array size using non constant (fix #13219)

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -163,7 +163,7 @@ pub fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 				}
 			}
 			else {
-				c.error('expecting `int` for fixed size', node.pos)
+				c.error('fixed array size cannot use non-constant value', init_expr.position())
 			}
 		}
 		if fixed_size <= 0 {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -59,7 +59,7 @@ pub fn (mut p Parser) parse_array_type(expecting token.Kind) ast.Type {
 					}
 				}
 				else {
-					p.error('expecting `int` for fixed size')
+					p.error_with_pos('fixed array size cannot use non-constant value', size_expr.position())
 				}
 			}
 		}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -59,7 +59,8 @@ pub fn (mut p Parser) parse_array_type(expecting token.Kind) ast.Type {
 					}
 				}
 				else {
-					p.error_with_pos('fixed array size cannot use non-constant value', size_expr.position())
+					p.error_with_pos('fixed array size cannot use non-constant value',
+						size_expr.position())
 				}
 			}
 		}

--- a/vlib/v/parser/tests/fixed_array_size_using_non_constant_err.out
+++ b/vlib/v/parser/tests/fixed_array_size_using_non_constant_err.out
@@ -1,0 +1,6 @@
+vlib/v/parser/tests/fixed_array_size_using_non_constant_err.vv:9:25: error: fixed array size cannot use non-constant value
+    7 |     println(typeof(t.len).name)
+    8 |
+    9 |     mut score := [t.len][t.len]int{}
+      |                            ~~~
+   10 | }

--- a/vlib/v/parser/tests/fixed_array_size_using_non_constant_err.vv
+++ b/vlib/v/parser/tests/fixed_array_size_using_non_constant_err.vv
@@ -1,0 +1,10 @@
+module main
+
+fn main() {
+	mut t := [0, 0]
+
+	println(t.len)
+	println(typeof(t.len).name)
+
+	mut score := [t.len][t.len]int{}
+}


### PR DESCRIPTION
This PR correct error message of fixed array size using non constant (fix #13219).

- Correct error message of fixed array size using non constant.
- Add test.

```vlang
module main

fn main() {
	mut t := [0, 0]

	println(t.len)
	println(typeof(t.len).name)

	mut score := [t.len][t.len]int{}
}

PS D:\Test\v\tt1> v run .
.\tt1.v:10:28: error: fixed array size cannot use non-constant value
    8 |     println(typeof(t.len).name)
    9 |
   10 |     mut score := [t.len][t.len]int{}
      |                            ~~~
   11 | }
```