### PR TITLE
ast: minor cleanup of struct Field

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -275,15 +275,13 @@ pub mut:
 	typ              Type
 }
 
-/*
-pub struct Field {
-pub:
-	name string
-	pos  token.Position
-pub mut:
-	typ Type
+pub fn (f &StructField) equals(o &StructField) bool {
+	// TODO: f.is_mut == o.is_mut was removed here to allow read only access
+	// to (mut/not mut), but otherwise equal fields; some other new checks are needed:
+	// - if node is declared mut, and we mutate node.stmts, all stmts fields must be mutable
+	// - same goes for pub and global, if we call the field from another module
+	return f.name == o.name && f.typ == o.typ && f.is_pub == o.is_pub && f.is_global == o.is_global
 }
-*/
 
 // const field in const declaration group
 pub struct ConstField {

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -922,31 +922,6 @@ pub:
 	types []Type
 }
 
-/*
-pub struct Field {
-pub:
-	name string
-pub mut:
-	typ              Type
-	default_expr     Expr
-	has_default_expr bool
-	default_expr_typ Type
-	default_val      string
-	attrs            []Attr
-	is_pub           bool
-	is_mut           bool
-	is_global        bool
-}
-*/
-
-pub fn (f &StructField) equals(o &StructField) bool {
-	// TODO: f.is_mut == o.is_mut was removed here to allow read only access
-	// to (mut/not mut), but otherwise equal fields; some other new checks are needed:
-	// - if node is declared mut, and we mutate node.stmts, all stmts fields must be mutable
-	// - same goes for pub and global, if we call the field from another module
-	return f.name == o.name && f.typ == o.typ && f.is_pub == o.is_pub && f.is_global == o.is_global
-}
-
 pub struct Array {
 pub:
 	nr_dims int


### PR DESCRIPTION
This PR makes minor cleanup of struct Field.

- Remove struct Field definitions that have been commented out.