### PR TITLE
ast: fix error for generic sumtype init in generic fn call (fix #13211)

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -980,14 +980,13 @@ pub mut:
 }
 
 pub struct SumType {
-pub:
-	variants []Type
 pub mut:
 	fields       []StructField
 	found_fields bool
 	is_anon      bool
 	// generic sumtype support
 	is_generic     bool
+	variants       []Type
 	generic_types  []Type
 	concrete_types []Type
 	parent_type    Type

--- a/vlib/v/tests/generic_sumtype_init_in_generic_fn_call_test.v
+++ b/vlib/v/tests/generic_sumtype_init_in_generic_fn_call_test.v
@@ -1,0 +1,28 @@
+pub type Result<S> = Ok<S> | string
+
+pub fn (x Result<S>) unwrap<S>() ?S {
+	match x {
+		Ok<S> {
+			return x.value
+		}
+		string {
+			return error(x)
+		}
+	}
+}
+
+struct Ok<S> {
+	value S
+}
+
+pub fn ok<S>(value S) Result<S> {
+	return Ok<S>{value}
+}
+
+fn test_generic_symtype_init_in_generic_fn_call() {
+	x := ok<int>(42)
+	ret := x.unwrap() or { 0 }
+
+	println(ret)
+	assert ret == 42
+}


### PR DESCRIPTION
This PR fix error for generic sumtype init in generic fn call (fix #13211).

- Fix error for generic sumtype init in generic fn call.
- Add test.

```vlang
pub type Result<S> = Ok<S> | string

pub fn (x Result<S>) unwrap<S>() ?S {
	match x {
		Ok<S> {
			return x.value
		}
		string {
			return error(x)
		}
	}
}

struct Ok<S> {
	value S
}

pub fn ok<S>(value S) Result<S> {
	return Ok<S>{value}
}

fn main() {
	x := ok<int>(42)
	ret := x.unwrap() or { 0 }

	println(ret)
	assert ret == 42
}

PS D:\Test\v\tt1> v run .
42
```