### PR TITLE
json: fix error for json encoding sumtype value (fix #13242)

### DIFF
--- a/vlib/json/json_test.v
+++ b/vlib/json/json_test.v
@@ -430,3 +430,27 @@ fn test_omit_empty() {
 	// println('omitempty:')
 	// println(json.encode_pretty(foo))
 }
+
+struct Asdasd {
+	data GamePacketData
+}
+
+type GamePacketData = GPEquipItem | GPScale
+
+struct GPScale {
+	value f32
+}
+
+struct GPEquipItem {
+	name string
+}
+
+fn create_game_packet(data &GamePacketData) string {
+	return json.encode(data)
+}
+
+fn test_encode_sumtype_defined_ahead() {
+	ret := create_game_packet(&GamePacketData(GPScale{}))
+	println(ret)
+	assert ret == '{"value":0,"_type":"GPScale"}'
+}

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -128,7 +128,7 @@ $enc_fn_dec {
 fn (mut g Gen) gen_sumtype_enc_dec(sym ast.TypeSymbol, mut enc strings.Builder, mut dec strings.Builder) {
 	info := sym.info as ast.SumType
 	type_var := g.new_tmp_var()
-	typ := sym.idx
+	typ := g.table.type_idxs[sym.name]
 
 	// DECODING (inline)
 	$if !json_no_inline_sumtypes ? {


### PR DESCRIPTION
This PR fix error for json encoding sumtype value (fix #13242).

- Fix error for json encoding sumtype value.
- Add test.

```vlang
module main

import json

struct Asdasd {
	data GamePacketData
}

type GamePacketData = GPEquipItem | GPScale

struct GPScale {
	value f32
}

struct GPEquipItem {
	name string
}

fn create_game_packet(data &GamePacketData) string {
	return json.encode(data)
}

fn main() {
	ret := create_game_packet(&GamePacketData(GPScale{}))
	println(ret)
	assert ret == '{"value":0,"_type":"GPScale"}'
}

PS D:\Test\v\tt1> v run .
{"value":0,"_type":"GPScale"}
```