### PR TITLE
checker: fix c error on improper string to rune cast (#13197)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2732,6 +2732,11 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 			node.pos)
 	}
 
+	if to_sym.kind == .rune && from_sym.is_string() {
+		snexpr := node.expr.str()
+		c.error('cannot cast `$from_sym.name` to rune, use `${snexpr}.runes()` instead.', node.pos)
+	}
+
 	if to_type == ast.string_type {
 		if from_type in [ast.byte_type, ast.bool_type] {
 			snexpr := node.expr.str()

--- a/vlib/v/checker/tests/cast_string_to_rune_err.out
+++ b/vlib/v/checker/tests/cast_string_to_rune_err.out
@@ -1,24 +1,24 @@
-../err.v:2:7: error: cannot cast `string` to rune, use `'0'.runes()` instead.
+vlib/v/checker/tests/cast_string_to_rune_err.vv:2:7: error: cannot cast `string` to rune, use `'0'.runes()` instead.
     1 | fn main() {
     2 |     _ := rune('0')
       |          ~~~~~~~~~
     3 |     _ := rune('012345')
     4 |     _ := rune('v')
-../err.v:3:7: error: cannot cast `string` to rune, use `'012345'.runes()` instead.
+vlib/v/checker/tests/cast_string_to_rune_err.vv:3:7: error: cannot cast `string` to rune, use `'012345'.runes()` instead.
     1 | fn main() {
     2 |     _ := rune('0')
     3 |     _ := rune('012345')
       |          ~~~~~~~~~~~~~~
     4 |     _ := rune('v')
     5 |     _ := rune('abcd')
-../err.v:4:7: error: cannot cast `string` to rune, use `'v'.runes()` instead.
+vlib/v/checker/tests/cast_string_to_rune_err.vv:4:7: error: cannot cast `string` to rune, use `'v'.runes()` instead.
     2 |     _ := rune('0')
     3 |     _ := rune('012345')
     4 |     _ := rune('v')
       |          ~~~~~~~~~
     5 |     _ := rune('abcd')
     6 | }
-../err.v:5:7: error: cannot cast `string` to rune, use `'abcd'.runes()` instead.
+vlib/v/checker/tests/cast_string_to_rune_err.vv:5:7: error: cannot cast `string` to rune, use `'abcd'.runes()` instead.
     3 |     _ := rune('012345')
     4 |     _ := rune('v')
     5 |     _ := rune('abcd')

--- a/vlib/v/checker/tests/cast_string_to_rune_err.out
+++ b/vlib/v/checker/tests/cast_string_to_rune_err.out
@@ -1,0 +1,26 @@
+../err.v:2:7: error: cannot cast `string` to rune, use `'0'.runes()` instead.
+    1 | fn main() {
+    2 |     _ := rune('0')
+      |          ~~~~~~~~~
+    3 |     _ := rune('012345')
+    4 |     _ := rune('v')
+../err.v:3:7: error: cannot cast `string` to rune, use `'012345'.runes()` instead.
+    1 | fn main() {
+    2 |     _ := rune('0')
+    3 |     _ := rune('012345')
+      |          ~~~~~~~~~~~~~~
+    4 |     _ := rune('v')
+    5 |     _ := rune('abcd')
+../err.v:4:7: error: cannot cast `string` to rune, use `'v'.runes()` instead.
+    2 |     _ := rune('0')
+    3 |     _ := rune('012345')
+    4 |     _ := rune('v')
+      |          ~~~~~~~~~
+    5 |     _ := rune('abcd')
+    6 | }
+../err.v:5:7: error: cannot cast `string` to rune, use `'abcd'.runes()` instead.
+    3 |     _ := rune('012345')
+    4 |     _ := rune('v')
+    5 |     _ := rune('abcd')
+      |          ~~~~~~~~~~~~
+    6 | }

--- a/vlib/v/checker/tests/cast_string_to_rune_err.vv
+++ b/vlib/v/checker/tests/cast_string_to_rune_err.vv
@@ -1,0 +1,6 @@
+fn main() {
+	_ := rune('0')
+	_ := rune('012345')
+	_ := rune('v')
+	_ := rune('abcd')
+}


### PR DESCRIPTION
This PR fixed the c error that was thrown on an improper string to rune cast (fix #13197)

- Add detailed error message for improper string to rune cast
- Add test

```v
println(rune('9'))
```
will now produce
```
../file.v:1:9: error: cannot cast `string` to rune, use `'9'.runes()` instead.
    1 | println(rune('9'))
      |         ~~~~~~~~~
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
