### PR TITLE
checker: fix method call errors for generic struct instances (fix #13252)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1369,6 +1369,13 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 				node.concrete_list_pos)
 		}
 		if method.generic_names.len > 0 {
+			if !left_type.has_flag(.generic) {
+				if left_sym.info is ast.Struct {
+					if method.generic_names.len == left_sym.info.concrete_types.len {
+						node.concrete_types = left_sym.info.concrete_types
+					}
+				}
+			}
 			return node.return_type
 		}
 		return method.return_type

--- a/vlib/v/tests/generics_struct_inst_method_call_test.v
+++ b/vlib/v/tests/generics_struct_inst_method_call_test.v
@@ -1,0 +1,29 @@
+fn test_generics_struct_inst_method_call() {
+	v1 := V2d<f32>{100}
+	r1 := v1.in_bounds(tp_lft, bt_rigt)
+	println(r1)
+	assert r1
+}
+
+const (
+	tp_lft  = V2d<f32>{20}
+	bt_rigt = V2d<f32>{650}
+)
+
+struct V2d<T> {
+mut:
+	x T
+}
+
+pub fn (v1 V2d<T>) unpack() T {
+	return v1.x
+}
+
+pub fn (v1 V2d<T>) less_than(v2 V2d<T>) V2d<bool> {
+	return V2d<bool>{v1.x < v2.x}
+}
+
+pub fn (v1 V2d<T>) in_bounds(top_left V2d<T>, bottom_right V2d<T>) bool {
+	v1.less_than(bottom_right).unpack()
+	return true
+}


### PR DESCRIPTION
This PR fix method call errors for generic struct instances (fix #13252).

- Fix method call errors for generic struct instances.
- Add test.

```vlang
fn main() {
	v1 := V2d<f32>{100}
	r1 := v1.in_bounds(tp_lft, bt_rigt)
	println(r1)
	assert r1
}

const (
	tp_lft  = V2d<f32>{20}
	bt_rigt = V2d<f32>{650}
)

struct V2d<T> {
mut:
	x T
}

pub fn (v1 V2d<T>) unpack() T {
	return v1.x
}

pub fn (v1 V2d<T>) less_than(v2 V2d<T>) V2d<bool> {
	return V2d<bool>{v1.x < v2.x}
}

pub fn (v1 V2d<T>) in_bounds(top_left V2d<T>, bottom_right V2d<T>) bool {
	v1.less_than(bottom_right).unpack()
	return true
}

PS D:\Test\v\tt1> v run .
true
```