### PR TITLE
cgen: fix 'for in mut val' with 'if val in' (fix #13262)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -710,6 +710,9 @@ fn (mut g Gen) gen_array_contains(typ ast.Type, left ast.Expr, right ast.Expr) {
 		g.write('->val')
 	}
 	g.write(', ')
+	if right.is_auto_deref_var() {
+		g.write('*')
+	}
 	g.expr(right)
 	g.write(')')
 }

--- a/vlib/v/tests/for_in_mut_val_with_if_val_in_test.v
+++ b/vlib/v/tests/for_in_mut_val_with_if_val_in_test.v
@@ -1,0 +1,13 @@
+fn test_for_in_mut_val_with_if_val_in() {
+	array := ['e']
+	mut splited := ['h', 'f', 's', 'e']
+	mut has_e := false
+
+	for mut s in splited {
+		if s in array {
+			println('Hello')
+			has_e = true
+		}
+	}
+	assert has_e
+}


### PR DESCRIPTION
This PR fix 'for in mut val' with 'if val in' (fix #13262).

- Fix 'for in mut val' with 'if val in'.
- Add test.

```vlang
fn main() {
	array := ['e']
	mut splited := ['h', 'f', 's', 'e']
	mut has_e := false

	for mut s in splited {
		if s in array {
			println('Hello')
			has_e = true
		}
	}
	assert has_e
}

PS D:\Test\v\tt1> v run .
Hello
```