### PR TITLE
ast, checker, cgen, parser: add `$include_str()`

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1565,7 +1565,8 @@ pub:
 	is_vweb   bool
 	vweb_tmpl File
 	//
-	is_embed bool
+	is_embed   bool
+	is_include bool
 	//
 	is_env  bool
 	env_pos token.Position

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -18,6 +18,9 @@ fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) ast.Type {
 		node.env_value = env_value
 		return ast.string_type
 	}
+	if node.is_include {
+		return ast.string_type
+	}
 	if node.is_embed {
 		// c.file.embedded_files << node.embed_file
 		if node.embed_file.compression_type !in valid_comptime_compression_types {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1709,6 +1709,8 @@ pub fn (mut f Fmt) comptime_call(node ast.ComptimeCall) {
 			} else {
 				f.write("\$embed_file('$node.embed_file.rpath', .$node.embed_file.compression_type)")
 			}
+		} else if node.is_include {
+			f.write("\$include_str('$node.args_var')")
 		} else if node.is_env {
 			f.write("\$env('$node.args_var')")
 		} else if node.is_pkgconfig {

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -34,6 +34,13 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 		g.gen_embed_file_init(mut node)
 		return
 	}
+	if node.is_include {
+		// $include_str('/path/to/file')
+		val := os.read_file(node.embed_file.apath) or { panic(err) }
+		escaped_val := cescape_nonascii(util.smart_quote(val, true))
+		g.write('_SLIT("$escaped_val")')
+		return
+	}
 	if node.method_name == 'env' {
 		// $env('ENV_VAR_NAME')
 		val := util.cescaped_path(os.getenv(node.args_var))

--- a/vlib/v/tests/comptime_include_str_test.v
+++ b/vlib/v/tests/comptime_include_str_test.v
@@ -1,0 +1,5 @@
+import os
+
+fn test_comptime_include() ? {
+	assert os.read_file('./v.mod') ? == $include_str('./v.mod')
+}


### PR DESCRIPTION
This PR adds `$include_str()` as comptime call fn.

I created this PR as feature request, to receive comments.

Please close this if you think this is inappropriate.


Expected usage is sth like follows

```v
const sql = $include_str('./101_create_migration_table.sql')

fn main() {
	sqlite.exec(sql)
}
```

`$embed_file()` is not easy to use at `const` decl, need to define `fn` for each const is lots of work.
The name `include_str()` is picked from Rust as example, so anything other is fine.

