### PR TITLE
os: remove trim_space() to make execute() implementations consistent

### DIFF
--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -366,7 +366,7 @@ pub fn execute(cmd string) Result {
 			break
 		}
 	}
-	soutput := read_data.str().trim_space()
+	soutput := read_data.str()
 	unsafe { read_data.free() }
 	exit_code := u32(0)
 	C.WaitForSingleObject(proc_info.h_process, C.INFINITE)

--- a/vlib/v/builder/msvc.v
+++ b/vlib/v/builder/msvc.v
@@ -188,10 +188,10 @@ fn find_vs_by_reg(vswhere_dir string, host_arch string, target_arch string) ?VsI
 		version2 := version // TODO remove. cgen option bug if expr
 		// println('version: $version')
 		v := if version.ends_with('\n') { version2[..version.len - 2] } else { version2 }
-		lib_path := '$res.output\\VC\\Tools\\MSVC\\$v\\lib\\$target_arch'
-		include_path := '$res.output\\VC\\Tools\\MSVC\\$v\\include'
+		lib_path := '$res_output\\VC\\Tools\\MSVC\\$v\\lib\\$target_arch'
+		include_path := '$res_output\\VC\\Tools\\MSVC\\$v\\include'
 		if os.exists('$lib_path\\vcruntime.lib') {
-			p := '$res.output\\VC\\Tools\\MSVC\\$v\\bin\\Host$host_arch\\$target_arch'
+			p := '$res_output\\VC\\Tools\\MSVC\\$v\\bin\\Host$host_arch\\$target_arch'
 			// println('$lib_path $include_path')
 			return VsInstallation{
 				exe_path: p


### PR DESCRIPTION
I was encountering weird errors on Windows (both on local machines and on [GitHub Actions](https://github.com/hungrybluedev/geo/runs/4927929749?check_suite_focus=true#step:8:11)) regarding the output retrieved from `os.execute()` and the related family of functions.

I observed that there is a `trim_space` call on the output result on the windows implementation, but for the unix one. In order to make the two implementations consistent, I removed the call to the trim function. This is important when comparing the outputs generated by a command against an expected output.

This PR also updates the `msvc.v` to use the trimmed paths.