### PR TITLE
term.ui: add support for multi byte/UTF-8 events

### DIFF
--- a/vlib/term/ui/input_nix.c.v
+++ b/vlib/term/ui/input_nix.c.v
@@ -6,6 +6,9 @@ module ui
 struct ExtraContext {
 mut:
 	read_buf []byte
+	// read_all_bytes causes all the raw bytes to be read as one event unit.
+	// This is cruicial for UTF-8 support since Unicode codepoints can span several bytes.
+	read_all_bytes bool = true
 }
 
 const ctx_ptr = &Context(0)


### PR DESCRIPTION
This PR adds support for multi byte buffer reads in the event system - and thus fixes a bug with the use of `single_char` in the event loop.

Before this PR the event system would emit single byte events with full contents of the `Event.utf8` field sat - but as the loop reads events until it's empty - the events emitted afterwards would contain only the last half of a 2 byte UTF-8 character.
I.e. the UTF-8 bytes was emitted in as 1 byte pieces, split in two at every loop cycle:

From my debug output when pressing the `æ` key:
```
Raw event bytes: "c3a6" = [0xc3, 0xa6]
Raw event bytes: "a6" = [0xa6]
```
In `text_editor.v` this would result in the sequence of bytes `[0xc3, 0xa6, 0xa6]` resulting in junk output.

This PR makes it the default to read the complete buffer into the event resulting in all bytes for one key press is transmitted as one event resulting in only e.g. `[0xc3, 0xa6]` to be sent - in contrast to two consecutive events resulting in `[0xc3, 0xa6]` **+** `[0xa6]`.

After this PR and #13269 is merged - I'll submit a PR that removes [this hack](https://github.com/vlang/v/pull/13269/files#diff-02de6676eda0d00c410aabea3270fb8a5ef3bc499032705292f20d857da9d633R581-R602) hopefully enabling UTF-8 support in `text_editor.v` for all keyboard layouts and terminals that support UTF-8.

The effect of the changes can also be seen with `event_viewer.v`:

On `master` pressing `æ` on my keyboard:
(The event viewer shows the last of the events in the 2 events sequence `[0xc3, 0xa6]` **+** `[0xa6]` )
![image](https://user-images.githubusercontent.com/768942/150973308-cfd9524c-c32e-482c-91ba-cf1dfaf53be0.png)

On this branch pressing `æ` on my keyboard:
![image](https://user-images.githubusercontent.com/768942/150973440-370394d8-a735-4f80-9a4e-ba79dceec0bb.png)
