### PR TITLE
checker: fix error for cast to alias of reference struct

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2661,7 +2661,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		if !c.table.sumtype_has_variant(to_type, from_type, false) && !to_type.has_flag(.optional) {
 			c.error('cannot cast `$from_sym.name` to `$to_sym.name`', node.pos)
 		}
-	} else if mut to_sym.info is ast.Alias {
+	} else if mut to_sym.info is ast.Alias && !(final_to_sym.kind == .struct_ && to_type.is_ptr()) {
 		if !c.check_types(from_type, to_sym.info.parent_type) && !(final_to_sym.is_int()
 			&& final_from_sym.kind in [.enum_, .bool, .i8, .char]) {
 			c.error('cannot convert type `$from_sym.name` to `$to_sym.name` (alias to `$final_to_sym.name`)',

--- a/vlib/v/tests/cast_to_alias_test.v
+++ b/vlib/v/tests/cast_to_alias_test.v
@@ -34,3 +34,20 @@ fn test_cast_to_alias() {
 	println(ret_str)
 	assert ret_str == '1'
 }
+
+struct Foo {
+	x int
+	y string
+}
+
+type Alias = Foo
+
+fn test_cast_to_alias_of_ref_struct() {
+	foo := &Foo(0)
+	println(typeof(foo).name)
+	assert typeof(foo).name == '&Foo'
+
+	bar := &Alias(0)
+	println(typeof(bar).name)
+	assert typeof(bar).name == '&Alias'
+}


### PR DESCRIPTION
This PR fix error for cast to alias of reference struct.

- Fix error for cast to alias of reference struct.
- Add test.

```vlang
struct Foo {
	x int
	y string
}

type Alias = Foo

fn main() {
	foo := &Foo(0)
	println(typeof(foo).name)
	assert typeof(foo).name == '&Foo'

	bar := &Alias(0)
	println(typeof(bar).name)
	assert typeof(bar).name == '&Alias'
}

PS D:\Test\v\tt1> v run .
&Foo
&Alias
```