### PR TITLE
ast, checker, cgen: fix error for map sumtype value init (fix #13284)

### DIFF
--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -1589,6 +1589,7 @@ fn (t Tree) map_init(node ast.MapInit) &Node {
 	obj.add_terse('value_type', t.type_node(node.value_type))
 	obj.add_terse('keys', t.array_node_expr(node.keys))
 	obj.add_terse('vals', t.array_node_expr(node.vals))
+	obj.add_terse('val_types', t.array_node_type(node.val_types))
 	obj.add('comments', t.two_dimension_comment(node.comments))
 	obj.add('pre_cmnts', t.array_node_comment(node.pre_cmnts))
 	obj.add('pos', t.pos(node.pos))

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1200,6 +1200,7 @@ pub:
 pub mut:
 	keys       []Expr
 	vals       []Expr
+	val_types  []Type
 	typ        Type
 	key_type   Type
 	value_type Type

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -247,6 +247,7 @@ pub fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 			if node.vals[0].is_auto_deref_var() {
 				val0_type = val0_type.deref()
 			}
+			node.val_types << val0_type
 		}
 		mut same_key_type := true
 		for i, key in node.keys {
@@ -258,6 +259,7 @@ pub fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 			key_type := c.expr(key)
 			c.expected_type = val0_type
 			val_type := c.expr(val)
+			node.val_types << val_type
 			if !c.check_types(key_type, key0_type) || (i == 0 && key_type.is_number()
 				&& key0_type.is_number() && key0_type != ast.mktyp(key_type)) {
 				msg := c.expected_msg(key_type, key0_type)

--- a/vlib/v/tests/map_sumtype_value_init_test.v
+++ b/vlib/v/tests/map_sumtype_value_init_test.v
@@ -1,0 +1,18 @@
+type Child = Tree | string
+
+struct Tree {
+	name  string
+	child map[string]Child
+}
+
+fn test_map_sumtype_value_init() {
+	tree := Tree{
+		name: 'foo'
+		child: {
+			'a': 'value'
+		}
+	}
+	println(tree)
+	ret := tree.child['a'] or { Child('') }
+	assert ret == Child('value')
+}


### PR DESCRIPTION
This PR fix error for map sumtype value init (fix #13284).

- Fix error for map sumtype value init.
- Add test.

```vlang
type Child = Tree | string

struct Tree {
	name  string
	child map[string]Child
}

fn main() {
	tree := Tree{
		name: 'foo'
		child: {
			'a': 'value'
		}
	}
	println(tree)
	ret := tree.child['a'] or { Child('') }
	assert ret == Child('value')
}

---------------------------------------------------------
PS D:\Test\v\tt1> v run .
Tree{
    name: 'foo'
    child: {'a': Child('value')}
}
```