### PR TITLE
cgen: fix error of struct multi embed method call (fix #13291)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1047,10 +1047,15 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		} else {
 			g.expr(node.left)
 		}
-		for embed in node.from_embed_types {
+		for i, embed in node.from_embed_types {
 			embed_sym := g.table.sym(embed)
 			embed_name := embed_sym.embed_name()
-			if node.left_type.is_ptr() {
+			is_left_ptr := if i == 0 {
+				node.left_type.is_ptr()
+			} else {
+				node.from_embed_types[i - 1].is_ptr()
+			}
+			if is_left_ptr {
 				g.write('->')
 			} else {
 				g.write('.')

--- a/vlib/v/tests/struct_multi_embed_method_call_test.v
+++ b/vlib/v/tests/struct_multi_embed_method_call_test.v
@@ -1,0 +1,33 @@
+pub struct Boundary {}
+
+pub fn (b Boundary) contains(x int, y int) bool {
+	return false
+}
+
+pub struct Base {
+	Boundary
+}
+
+pub fn (mut b Base) on_event(x int, y int) {
+	if b.Boundary.contains(x, y) {
+	}
+	if b.contains(x, y) {
+	}
+}
+
+pub struct ListBox {
+	Base
+}
+
+pub fn (mut lb ListBox) on_event(x int, y int) {
+	if lb.Base.Boundary.contains(x, y) {
+	}
+	if lb.contains(x, y) {
+	}
+}
+
+fn test_struct_multi_embed_method_call() {
+	mut list_box := ListBox{}
+	list_box.on_event(11, 22)
+	assert true
+}


### PR DESCRIPTION
This PR fix error of struct multi embed method call (fix #13291).

- Fix error of struct multi embed method call.
- Add test.

```vlang
pub struct Boundary {}

pub fn (b Boundary) contains(x int, y int) bool {
	return false
}

pub struct Base {
	Boundary
}

pub fn (mut b Base) on_event(x int, y int) {
	if b.Boundary.contains(x, y) {
	}
	if b.contains(x, y) {
	}
}

pub struct ListBox {
	Base
}

pub fn (mut lb ListBox) on_event(x int, y int) {
	if lb.Base.Boundary.contains(x, y) {
	}
	if lb.contains(x, y) {
	}
}

fn main() {
	mut list_box := ListBox{}
	list_box.on_event(11, 22)
	println(list_box)
	assert true
}

-------------------------------------------------------
PS D:\Test\v\tt1> v run .
ListBox{
    Base: Base{
        Boundary: Boundary{}
    }
}
```