### PR TITLE
v.pref: normalise the input path received by the user

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -771,7 +771,16 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 	res.build_options = m.keys()
 	// eprintln('>> res.build_options: $res.build_options')
 	res.fill_with_defaults()
+	res.path = normalise_path(res.path)
 	return res, command
+}
+
+fn normalise_path(path string) string {
+	$if windows {
+		return path.replace('/', '\\')
+	} $else {
+		return path.replace('\\', '/')
+	}
 }
 
 pub fn eprintln_cond(condition bool, s string) {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -776,11 +776,10 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 }
 
 fn normalise_path(path string) string {
-	$if windows {
+	if os.user_os() == 'windows' {
 		return path.replace('/', '\\')
-	} $else {
-		return path.replace('\\', '/')
 	}
+	return path.replace('\\', '/')
 }
 
 pub fn eprintln_cond(condition bool, s string) {


### PR DESCRIPTION
Fixes `v vlib/v/checker/tests/modules/deprecated_module` on windows.