### PR TITLE
examples: fix segmentation fault crash on exit in sokol 0X_ examples

### DIFF
--- a/examples/sokol/01_cubes/cube.v
+++ b/examples/sokol/01_cubes/cube.v
@@ -379,10 +379,6 @@ fn my_init(mut app App) {
 	}
 }
 
-fn cleanup(mut app App) {
-	gfx.shutdown()
-}
-
 /******************************************************************************
 *
 * event
@@ -424,7 +420,6 @@ fn main() {
 		bg_color: bg_color
 		frame_fn: frame
 		init_fn: my_init
-		cleanup_fn: cleanup
 		event_fn: my_event_manager
 	)
 

--- a/examples/sokol/02_cubes_glsl/cube_glsl.v
+++ b/examples/sokol/02_cubes_glsl/cube_glsl.v
@@ -553,10 +553,6 @@ fn my_init(mut app App) {
 	app.init_flag = true
 }
 
-fn cleanup(mut app App) {
-	gfx.shutdown()
-}
-
 /******************************************************************************
 *
 * event
@@ -601,7 +597,6 @@ fn main() {
 		bg_color: bg_color
 		frame_fn: frame
 		init_fn: my_init
-		cleanup_fn: cleanup
 		event_fn: my_event_manager
 	)
 

--- a/examples/sokol/03_march_tracing_glsl/rt_glsl.v
+++ b/examples/sokol/03_march_tracing_glsl/rt_glsl.v
@@ -372,10 +372,6 @@ fn my_init(mut app App) {
 	app.init_flag = true
 }
 
-fn cleanup(mut app App) {
-	gfx.shutdown()
-}
-
 /******************************************************************************
 * events handling
 ******************************************************************************/
@@ -412,7 +408,6 @@ fn main() {
 		bg_color: bg_color
 		frame_fn: frame
 		init_fn: my_init
-		cleanup_fn: cleanup
 		event_fn: my_event_manager
 	)
 

--- a/examples/sokol/04_multi_shader_glsl/rt_glsl.v
+++ b/examples/sokol/04_multi_shader_glsl/rt_glsl.v
@@ -560,10 +560,6 @@ fn my_init(mut app App) {
 	app.init_flag = true
 }
 
-fn cleanup(mut app App) {
-	gfx.shutdown()
-}
-
 /******************************************************************************
 * events handling
 ******************************************************************************/
@@ -606,7 +602,6 @@ fn main() {
 		bg_color: bg_color
 		frame_fn: frame
 		init_fn: my_init
-		cleanup_fn: cleanup
 		event_fn: my_event_manager
 	)
 

--- a/examples/sokol/05_instancing_glsl/rt_glsl.v
+++ b/examples/sokol/05_instancing_glsl/rt_glsl.v
@@ -437,10 +437,6 @@ fn my_init(mut app App) {
 	app.init_flag = true
 }
 
-fn cleanup(mut app App) {
-	gfx.shutdown()
-}
-
 /******************************************************************************
 * events handling
 ******************************************************************************/
@@ -495,7 +491,6 @@ fn main(){
 		bg_color:      bg_color
 		frame_fn:      frame
 		init_fn:       my_init
-		cleanup_fn:    cleanup
 		event_fn:      my_event_manager
 	)
 

--- a/examples/sokol/06_obj_viewer/show_obj.v
+++ b/examples/sokol/06_obj_viewer/show_obj.v
@@ -233,7 +233,6 @@ fn my_init(mut app App) {
 }
 
 fn cleanup(mut app App) {
-	gfx.shutdown()
 	/*
 	for _, mat in app.obj_part.texture {
 		obj.destroy_texture(mat)


### PR DESCRIPTION
This PR fixes the crashes that occur when closing the example sokol "0x_*" apps.
The reason they crash on close is that they use `gg` which wraps setup and shutdown of `sokol.gfx` - and these examples also called `gfx.shutdown()` on their exit/cleanup call - resulting in double call/freeing and a message like this:
```
01_cubes: /home/user/v/thirdparty/sokol/sokol_gfx.h:13751: _sg_context_at: Assertion `(slot_index > (0)) && (slot_index < p->context_pool.size)' failed.
7f44dff4b18b : at ???: RUNTIME ERROR: abort() called
4173257325203a75 : by ???
signal 11: segmentation fault
/dev/shm/v_1000/01_cubes.132947864327463290.tmp.c:9478: at print_backtrace: Backtrace
/dev/shm/v_1000/01_cubes.132947864327463290.tmp.c:9544: by v_segmentation_fault_handler
7f44dff4b210 : by ???
005017f9 : by ???
00501ac3 : by ???
00501c77 : by ???
7f44e010c3c0 : by ???
4173257325203a75 : by ???
```