### PR TITLE
picoev: close connection after callback

### DIFF
--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -173,6 +173,7 @@ fn rw_callback(loop &C.picoev_loop, fd int, events int, context voidptr) {
 
 		// Callback (should call .end() itself)
 		p.cb(mut p.user_data, req, mut &res)
+		close_conn(loop, fd)
 	}
 }
 


### PR DESCRIPTION
This PR fixes `io.read`'s hang

close: #12194
