### PR TITLE
strings: Builder.write_b() -> Builder.write_byte()

### DIFF
--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -421,7 +421,7 @@ fn html_highlight(code string, tb &ast.Table) string {
 				break
 			}
 		} else {
-			buf.write_b(code[i])
+			buf.write_byte(code[i])
 			i++
 		}
 	}

--- a/cmd/tools/vdoc/utils.v
+++ b/cmd/tools/vdoc/utils.v
@@ -266,7 +266,7 @@ fn color_highlight(code string, tb &ast.Table) string {
 			tok = next_tok
 			next_tok = s.scan()
 		} else {
-			buf.write_b(code[i])
+			buf.write_byte(code[i])
 			i++
 		}
 	}

--- a/examples/vpwgen.v
+++ b/examples/vpwgen.v
@@ -13,7 +13,7 @@ fn main() {
 			x := rand.read(blocksize) ?
 			for c in x {
 				if c >= `0` && c <= `~` {
-					sb.write_b(c)
+					sb.write_byte(c)
 				}
 			}
 			if sb.len > size {

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -769,17 +769,17 @@ pub fn (a []string) str() string {
 	}
 	sb_len += 2 // 1x[ + 1x]
 	mut sb := strings.new_builder(sb_len)
-	sb.write_b(`[`)
+	sb.write_byte(`[`)
 	for i in 0 .. a.len {
 		val := a[i]
-		sb.write_b(`'`)
+		sb.write_byte(`'`)
 		sb.write_string(val)
-		sb.write_b(`'`)
+		sb.write_byte(`'`)
 		if i < a.len - 1 {
 			sb.write_string(', ')
 		}
 	}
-	sb.write_b(`]`)
+	sb.write_byte(`]`)
 	res := sb.str()
 	unsafe { sb.free() }
 	return res

--- a/vlib/builtin/string_interpolation.v
+++ b/vlib/builtin/string_interpolation.v
@@ -268,7 +268,7 @@ fn (data &StrIntpData) process_str_intp_data(mut sb strings.Builder) {
 					tmp.free()
 				}
 				if write_minus {
-					sb.write_b(`-`)
+					sb.write_byte(`-`)
 					bf.len0-- // compensate for the `-` above
 				}
 				if width == 0 {

--- a/vlib/net/html/parser.v
+++ b/vlib/net/html/parser.v
@@ -118,7 +118,7 @@ pub fn (mut parser Parser) split_parse(data string) {
 			else { 0 }
 		}
 		if parser.lexical_attributes.open_code { // here will verify all needed to know if open_code finishes and string in code
-			parser.lexical_attributes.lexeme_builder.write_b(chr)
+			parser.lexical_attributes.lexeme_builder.write_byte(chr)
 			if parser.lexical_attributes.open_string > 0
 				&& parser.lexical_attributes.open_string == string_code {
 				parser.lexical_attributes.open_string = 0
@@ -141,12 +141,12 @@ pub fn (mut parser Parser) split_parse(data string) {
 				parser.lexical_attributes.open_comment = false
 				parser.lexical_attributes.open_tag = false
 			} else {
-				parser.lexical_attributes.lexeme_builder.write_b(chr)
+				parser.lexical_attributes.lexeme_builder.write_byte(chr)
 			}
 		} else if parser.lexical_attributes.open_string > 0 {
 			if parser.lexical_attributes.open_string == string_code {
 				parser.lexical_attributes.open_string = 0
-				parser.lexical_attributes.lexeme_builder.write_b(chr)
+				parser.lexical_attributes.lexeme_builder.write_byte(chr)
 				temp_lexeme := parser.builder_str()
 				if parser.lexical_attributes.current_tag.last_attribute != '' {
 					lattr := parser.lexical_attributes.current_tag.last_attribute
@@ -159,12 +159,12 @@ pub fn (mut parser Parser) split_parse(data string) {
 				}
 				parser.lexical_attributes.lexeme_builder.go_back_to(0)
 			} else {
-				parser.lexical_attributes.lexeme_builder.write_b(chr)
+				parser.lexical_attributes.lexeme_builder.write_byte(chr)
 			}
 		} else if parser.lexical_attributes.open_tag {
 			if parser.lexical_attributes.lexeme_builder.len == 0 && is_quote {
 				parser.lexical_attributes.open_string = string_code
-				parser.lexical_attributes.lexeme_builder.write_b(chr)
+				parser.lexical_attributes.lexeme_builder.write_byte(chr)
 			} else if chr == `>` { // close tag >
 				complete_lexeme := parser.builder_str().to_lower()
 				parser.lexical_attributes.current_tag.closed = (complete_lexeme.len > 0
@@ -190,7 +190,7 @@ pub fn (mut parser Parser) split_parse(data string) {
 				}
 				// parser.print_debug(parser.lexical_attributes.current_tag.name)
 			} else if chr !in [byte(9), ` `, `=`, `\n`] { // Tab, space, = and \n
-				parser.lexical_attributes.lexeme_builder.write_b(chr)
+				parser.lexical_attributes.lexeme_builder.write_byte(chr)
 			} else if chr != 10 {
 				complete_lexeme := parser.builder_str().to_lower()
 				if parser.lexical_attributes.current_tag.name == '' {
@@ -226,7 +226,7 @@ pub fn (mut parser Parser) split_parse(data string) {
 			parser.generate_tag()
 			parser.lexical_attributes.open_tag = true
 		} else {
-			parser.lexical_attributes.lexeme_builder.write_b(chr)
+			parser.lexical_attributes.lexeme_builder.write_byte(chr)
 		}
 	}
 }

--- a/vlib/net/smtp/smtp.v
+++ b/vlib/net/smtp/smtp.v
@@ -144,9 +144,9 @@ fn (mut c Client) send_auth() ? {
 		return
 	}
 	mut sb := strings.new_builder(100)
-	sb.write_b(0)
+	sb.write_byte(0)
 	sb.write_string(c.username)
-	sb.write_b(0)
+	sb.write_byte(0)
 	sb.write_string(c.password)
 	a := sb.str()
 	auth := 'AUTH PLAIN ${base64.encode_str(a)}\r\n'

--- a/vlib/regex/regex_test.v
+++ b/vlib/regex/regex_test.v
@@ -748,9 +748,9 @@ fn test_long_query() {
     base_string := rand.string(test_len)
 
     for c in base_string {
-        buf.write_b(`(`)
-        buf.write_b(c)
-        buf.write_b(`)`)
+        buf.write_byte(`(`)
+        buf.write_byte(c)
+        buf.write_byte(`)`)
     }
 
     mut query := buf.str()
@@ -767,11 +767,11 @@ fn test_long_query() {
     // test 2
     buf.clear()
     for c in base_string {
-        buf.write_b(`(`)
-        buf.write_b(c)
+        buf.write_byte(`(`)
+        buf.write_byte(c)
     }
     for _ in 0..base_string.len {
-        buf.write_b(`)`)
+        buf.write_byte(`)`)
     }
     query = buf.str()
     re = regex.regex_opt(query) or { panic(err) }

--- a/vlib/strconv/format.v
+++ b/vlib/strconv/format.v
@@ -103,13 +103,13 @@ pub fn format_str(s string, p BF_param) string {
 	}
 	if p.allign == .right {
 		for i1 := 0; i1 < dif; i1++ {
-			res.write_b(p.pad_ch)
+			res.write_byte(p.pad_ch)
 		}
 	}
 	res.write_string(s)
 	if p.allign == .left {
 		for i1 := 0; i1 < dif; i1++ {
-			res.write_b(p.pad_ch)
+			res.write_byte(p.pad_ch)
 		}
 	}
 	return res.str()

--- a/vlib/strconv/format_mem.c.v
+++ b/vlib/strconv/format_mem.c.v
@@ -23,13 +23,13 @@ pub fn format_str_sb(s string, p BF_param, mut sb strings.Builder) {
 
 	if p.allign == .right {
 		for i1 := 0; i1 < dif; i1++ {
-			sb.write_b(p.pad_ch)
+			sb.write_byte(p.pad_ch)
 		}
 	}
 	sb.write_string(s)
 	if p.allign == .left {
 		for i1 := 0; i1 < dif; i1++ {
-			sb.write_b(p.pad_ch)
+			sb.write_byte(p.pad_ch)
 		}
 	}
 }
@@ -53,17 +53,17 @@ pub fn format_dec_sb(d u64, p BF_param, mut res strings.Builder) {
 		if p.pad_ch == `0` {
 			if p.positive {
 				if p.sign_flag {
-					res.write_b(`+`)
+					res.write_byte(`+`)
 					sign_written = true
 				}
 			} else {
-				res.write_b(`-`)
+				res.write_byte(`-`)
 				sign_written = true
 			}
 		}
 		// write the pad chars
 		for i1 := 0; i1 < dif; i1++ {
-			res.write_b(p.pad_ch)
+			res.write_byte(p.pad_ch)
 		}
 	}
 
@@ -71,10 +71,10 @@ pub fn format_dec_sb(d u64, p BF_param, mut res strings.Builder) {
 		// no pad char, write the sign before the number
 		if p.positive {
 			if p.sign_flag {
-				res.write_b(`+`)
+				res.write_byte(`+`)
 			}
 		} else {
-			res.write_b(`-`)
+			res.write_byte(`-`)
 		}
 	}
 
@@ -123,13 +123,13 @@ pub fn format_dec_sb(d u64, p BF_param, mut res strings.Builder) {
 		unsafe { res.write_ptr(&buf[i], n_char) }
 	} else {
 		// we have a zero no need of more code!
-		res.write_b(`0`)
+		res.write_byte(`0`)
 	}
 	//===========================================
 
 	if p.allign == .left {
 		for i1 := 0; i1 < dif; i1++ {
-			res.write_b(p.pad_ch)
+			res.write_byte(p.pad_ch)
 		}
 	}
 	return

--- a/vlib/strconv/format_mem.js.v
+++ b/vlib/strconv/format_mem.js.v
@@ -17,7 +17,7 @@ pub fn format_str_sb(s string, p BF_param, mut sb strings.Builder) {
 
 	if p.allign == .right {
 		for i1 := 0; i1 < dif; i1++ {
-			sb.write_b(p.pad_ch)
+			sb.write_byte(p.pad_ch)
 		}
 	}
 
@@ -25,7 +25,7 @@ pub fn format_str_sb(s string, p BF_param, mut sb strings.Builder) {
 
 	if p.allign == .left {
 		for i1 := 0; i1 < dif; i1++ {
-			sb.write_b(p.pad_ch)
+			sb.write_byte(p.pad_ch)
 		}
 	}
 }
@@ -49,17 +49,17 @@ pub fn format_dec_sb(d u64, p BF_param, mut res strings.Builder) {
 		if p.pad_ch == `0` {
 			if p.positive {
 				if p.sign_flag {
-					res.write_b(`+`)
+					res.write_byte(`+`)
 					sign_written = true
 				}
 			} else {
-				res.write_b(`-`)
+				res.write_byte(`-`)
 				sign_written = true
 			}
 		}
 		// write the pad chars
 		for i1 := 0; i1 < dif; i1++ {
-			res.write_b(p.pad_ch)
+			res.write_byte(p.pad_ch)
 		}
 	}
 
@@ -67,10 +67,10 @@ pub fn format_dec_sb(d u64, p BF_param, mut res strings.Builder) {
 		// no pad char, write the sign before the number
 		if p.positive {
 			if p.sign_flag {
-				res.write_b(`+`)
+				res.write_byte(`+`)
 			}
 		} else {
-			res.write_b(`-`)
+			res.write_byte(`-`)
 		}
 	}
 
@@ -88,7 +88,7 @@ pub fn format_dec_sb(d u64, p BF_param, mut res strings.Builder) {
 
 	for _ in 0 .. n_char {
 		i++
-		res.write_b(buf[i])
+		res.write_byte(buf[i])
 	}
 	i++
 
@@ -96,7 +96,7 @@ pub fn format_dec_sb(d u64, p BF_param, mut res strings.Builder) {
 
 	if p.allign == .left {
 		for i1 := 0; i1 < dif; i1++ {
-			res.write_b(p.pad_ch)
+			res.write_byte(p.pad_ch)
 		}
 	}
 	return

--- a/vlib/strconv/vprintf.c.v
+++ b/vlib/strconv/vprintf.c.v
@@ -61,7 +61,7 @@ pub fn v_sprintf(str string, pt ...voidptr) string {
 
 		ch := str[i]
 		if ch != `%` && status == .norm_char {
-			res.write_b(ch)
+			res.write_byte(ch)
 			i++
 			continue
 		}
@@ -75,7 +75,7 @@ pub fn v_sprintf(str string, pt ...voidptr) string {
 		if ch == `c` && status == .field_char {
 			v_sprintf_panic(p_index, pt.len)
 			d1 := unsafe { *(&byte(pt[p_index])) }
-			res.write_b(d1)
+			res.write_byte(d1)
 			status = .reset_params
 			p_index++
 			i++
@@ -542,11 +542,11 @@ pub fn format_fl_old(f f64, p BF_param) string {
 		if p.pad_ch == `0` {
 			if p.positive {
 				if p.sign_flag {
-					res.write_b(`+`)
+					res.write_byte(`+`)
 					sign_len_diff = -1
 				}
 			} else {
-				res.write_b(`-`)
+				res.write_byte(`-`)
 				sign_len_diff = -1
 			}
 			tmp := s
@@ -574,13 +574,13 @@ pub fn format_fl_old(f f64, p BF_param) string {
 
 		if p.allign == .right {
 			for i1 := 0; i1 < dif; i1++ {
-				res.write_b(p.pad_ch)
+				res.write_byte(p.pad_ch)
 			}
 		}
 		res.write_string(s)
 		if p.allign == .left {
 			for i1 := 0; i1 < dif; i1++ {
-				res.write_b(p.pad_ch)
+				res.write_byte(p.pad_ch)
 			}
 		}
 
@@ -607,11 +607,11 @@ pub fn format_es_old(f f64, p BF_param) string {
 		if p.pad_ch == `0` {
 			if p.positive {
 				if p.sign_flag {
-					res.write_b(`+`)
+					res.write_byte(`+`)
 					sign_len_diff = -1
 				}
 			} else {
-				res.write_b(`-`)
+				res.write_byte(`-`)
 				sign_len_diff = -1
 			}
 			tmp := s
@@ -638,13 +638,13 @@ pub fn format_es_old(f f64, p BF_param) string {
 		dif := p.len0 - s.len + sign_len_diff
 		if p.allign == .right {
 			for i1 := 0; i1 < dif; i1++ {
-				res.write_b(p.pad_ch)
+				res.write_byte(p.pad_ch)
 			}
 		}
 		res.write_string(s)
 		if p.allign == .left {
 			for i1 := 0; i1 < dif; i1++ {
-				res.write_b(p.pad_ch)
+				res.write_byte(p.pad_ch)
 			}
 		}
 		s.free()
@@ -704,11 +704,11 @@ pub fn format_dec_old(d u64, p BF_param) string {
 	if p.pad_ch == `0` {
 		if p.positive {
 			if p.sign_flag {
-				res.write_b(`+`)
+				res.write_byte(`+`)
 				sign_len_diff = -1
 			}
 		} else {
-			res.write_b(`-`)
+			res.write_byte(`-`)
 			sign_len_diff = -1
 		}
 		s = d.str()
@@ -727,13 +727,13 @@ pub fn format_dec_old(d u64, p BF_param) string {
 
 	if p.allign == .right {
 		for i1 := 0; i1 < dif; i1++ {
-			res.write_b(p.pad_ch)
+			res.write_byte(p.pad_ch)
 		}
 	}
 	res.write_string(s)
 	if p.allign == .left {
 		for i1 := 0; i1 < dif; i1++ {
-			res.write_b(p.pad_ch)
+			res.write_byte(p.pad_ch)
 		}
 	}
 	return res.str()

--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -49,7 +49,7 @@ pub fn (mut b Builder) write_runes(runes []rune) {
 }
 
 // write_b appends a single `data` byte to the accumulated buffer
-[deprecated: "Use write_byte() instead"]
+[deprecated: 'Use write_byte() instead']
 pub fn (mut b Builder) write_b(data byte) {
 	b << data
 }

--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -49,7 +49,13 @@ pub fn (mut b Builder) write_runes(runes []rune) {
 }
 
 // write_b appends a single `data` byte to the accumulated buffer
+[deprecated: "Use write_byte() instead"]
 pub fn (mut b Builder) write_b(data byte) {
+	b << data
+}
+
+// write_byte appends a single `data` byte to the accumulated buffer
+pub fn (mut b Builder) write_byte(data byte) {
 	b << data
 }
 

--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -50,6 +50,7 @@ pub fn (mut b Builder) write_runes(runes []rune) {
 
 // write_b appends a single `data` byte to the accumulated buffer
 [deprecated: 'Use write_byte() instead']
+[deprecated_after: '2022-02-11']
 pub fn (mut b Builder) write_b(data byte) {
 	b << data
 }

--- a/vlib/strings/builder.js.v
+++ b/vlib/strings/builder.js.v
@@ -18,7 +18,12 @@ pub fn new_builder(initial_size int) Builder {
 	return []byte{cap: initial_size}
 }
 
+[deprecated: "Use write_byte() instead"]
 pub fn (mut b Builder) write_b(data byte) {
+	b << data
+}
+
+pub fn (mut b Builder) write_byte(data byte) {
 	b << data
 }
 

--- a/vlib/strings/builder.js.v
+++ b/vlib/strings/builder.js.v
@@ -18,7 +18,7 @@ pub fn new_builder(initial_size int) Builder {
 	return []byte{cap: initial_size}
 }
 
-[deprecated: "Use write_byte() instead"]
+[deprecated: 'Use write_byte() instead']
 pub fn (mut b Builder) write_b(data byte) {
 	b << data
 }

--- a/vlib/strings/builder_test.js.v
+++ b/vlib/strings/builder_test.js.v
@@ -65,7 +65,7 @@ fn test_byte_write() {
 	temp_str := 'byte testing'
 	mut count := 0
 	for word in temp_str {
-		sb.write_b(word)
+		sb.write_byte(word)
 		count++
 		assert count == sb.len
 	}

--- a/vlib/strings/builder_test.v
+++ b/vlib/strings/builder_test.v
@@ -65,7 +65,7 @@ fn test_byte_write() {
 	temp_str := 'byte testing'
 	mut count := 0
 	for word in temp_str {
-		sb.write_b(word)
+		sb.write_byte(word)
 		count++
 		assert count == sb.len
 	}

--- a/vlib/v/builder/rebuilding.v
+++ b/vlib/v/builder/rebuilding.v
@@ -37,9 +37,9 @@ pub fn (mut b Builder) rebuild_modules() {
 		chash := hash.sum64_string(ccontent, 7).hex_full()
 		new_hashes[cpath] = chash
 		sb_new_hashes.write_string(chash)
-		sb_new_hashes.write_b(` `)
+		sb_new_hashes.write_byte(` `)
 		sb_new_hashes.write_string(cpath)
-		sb_new_hashes.write_b(`\n`)
+		sb_new_hashes.write_byte(`\n`)
 	}
 	snew_hashes := sb_new_hashes.str()
 	// eprintln('new_hashes: $new_hashes')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2538,7 +2538,7 @@ fn cescape_nonascii(original string) string {
 			write_octal_escape(mut b, c)
 			continue
 		}
-		b.write_b(c)
+		b.write_byte(c)
 	}
 	res := b.str()
 	return res

--- a/vlib/v/parser/tmpl.v
+++ b/vlib/v/parser/tmpl.v
@@ -76,7 +76,7 @@ fn is_html_open_tag(name string, s string) bool {
 fn insert_template_code(fn_name string, tmpl_str_start string, line string) string {
 	// HTML, may include `@var`
 	// escaped by cgen, unless it's a `vweb.RawHtml` string
-	trailing_bs := parser.tmpl_str_end + 'sb_${fn_name}.write_b(92)\n' + tmpl_str_start
+	trailing_bs := parser.tmpl_str_end + 'sb_${fn_name}.write_byte(92)\n' + tmpl_str_start
 	round1 := ['\\', '\\\\', r"'", "\\'", r'@', r'$']
 	round2 := [r'$$', r'\@', r'.$', r'.@']
 	mut rline := line.replace_each(round1).replace_each(round2)

--- a/vlib/v/util/errors.v
+++ b/vlib/v/util/errors.v
@@ -149,7 +149,7 @@ pub fn source_file_context(kind string, filepath string, pos token.Pos) []string
 			mut pointerline_builder := strings.new_builder(sline.len)
 			for i := 0; i < start_column; {
 				if sline[i].is_space() {
-					pointerline_builder.write_b(sline[i])
+					pointerline_builder.write_byte(sline[i])
 					i++
 				} else {
 					char_len := utf8_char_len(sline[i])

--- a/vlib/v/util/quote.v
+++ b/vlib/v/util/quote.v
@@ -65,8 +65,8 @@ pub fn smart_quote(str string, raw bool) string {
 		}
 		if current == util.double_quote {
 			current = 0
-			result.write_b(util.backslash)
-			result.write_b(util.double_quote)
+			result.write_byte(util.backslash)
+			result.write_byte(util.double_quote)
 			continue
 		}
 		if current == util.backslash {
@@ -88,26 +88,26 @@ pub fn smart_quote(str string, raw bool) string {
 				}
 				if next in util.invalid_escapes {
 					skip_next = true
-					result.write_b(next)
+					result.write_byte(next)
 					continue
 				}
 				// keep all valid escape sequences
 				skip_next = true
-				result.write_b(current)
-				result.write_b(next)
+				result.write_byte(current)
+				result.write_byte(next)
 				continue
 			}
 		}
 		if current == util.backslash_n {
 			// keep newlines in string
 			current = 0
-			result.write_b(util.backslash)
-			result.write_b(`n`)
+			result.write_byte(util.backslash)
+			result.write_byte(`n`)
 			continue
 		}
 		if current == util.backslash_r && next == util.backslash_n {
-			result.write_b(current)
-			result.write_b(next)
+			result.write_byte(current)
+			result.write_byte(next)
 			current = 0
 			skip_next = true
 			continue
@@ -115,20 +115,20 @@ pub fn smart_quote(str string, raw bool) string {
 		if !raw {
 			if current == `$` {
 				if last == util.backslash {
-					result.write_b(last)
-					result.write_b(current)
+					result.write_byte(last)
+					result.write_byte(current)
 					continue
 				}
 			}
 			if current == util.backslash_r && next == util.backslash_n {
 				// Windows style new line \r\n
 				skip_next = true
-				result.write_b(util.backslash)
-				result.write_b(`n`)
+				result.write_byte(util.backslash)
+				result.write_byte(`n`)
 				continue
 			}
 		}
-		result.write_b(current)
+		result.write_byte(current)
 	}
 	return result.str()
 }

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -15,21 +15,21 @@ fn write_value(v Any, i int, len int, mut wr strings.Builder) {
 	if i >= len - 1 {
 		return
 	}
-	wr.write_b(`,`)
+	wr.write_byte(`,`)
 }
 
 // str returns the string representation of the `map[string]Any`.
 [manualfree]
 pub fn (flds map[string]Any) str() string {
 	mut wr := strings.new_builder(200)
-	wr.write_b(`{`)
+	wr.write_byte(`{`)
 	mut i := 0
 	for k, v in flds {
 		wr.write_string('"$k":')
 		write_value(v, i, flds.len, mut wr)
 		i++
 	}
-	wr.write_b(`}`)
+	wr.write_byte(`}`)
 	defer {
 		unsafe { wr.free() }
 	}
@@ -41,11 +41,11 @@ pub fn (flds map[string]Any) str() string {
 [manualfree]
 pub fn (flds []Any) str() string {
 	mut wr := strings.new_builder(200)
-	wr.write_b(`[`)
+	wr.write_byte(`[`)
 	for i, v in flds {
 		write_value(v, i, flds.len, mut wr)
 	}
-	wr.write_b(`]`)
+	wr.write_byte(`]`)
 	defer {
 		unsafe { wr.free() }
 	}
@@ -157,7 +157,7 @@ fn json_string(s string) string {
 				hex_code := chr.hex()
 				sb.write_string('\\u00$hex_code')
 			} else {
-				sb.write_b(chr)
+				sb.write_byte(chr)
 			}
 		} else {
 			slice := s[i..i + char_len]
@@ -170,7 +170,7 @@ fn json_string(s string) string {
 			} else {
 				// TODO: still figuring out what
 				// to do with more than 4 chars
-				sb.write_b(` `)
+				sb.write_byte(` `)
 			}
 			unsafe {
 				slice.free()

--- a/vlib/x/ttf/ttf.v
+++ b/vlib/x/ttf/ttf.v
@@ -552,10 +552,10 @@ fn (mut tf TTF_File) get_unicode_string(length int) string {
 		c_len := ((0xe5000000 >> ((c >> 3) & 0x1e)) & 3) + 1
 		real_len += c_len
 		if c_len == 1 {
-			tmp_txt.write_b(byte(c & 0xff))
+			tmp_txt.write_byte(byte(c & 0xff))
 		} else {
-			tmp_txt.write_b(byte((c >> 8) & 0xff))
-			tmp_txt.write_b(byte(c & 0xff))
+			tmp_txt.write_byte(byte((c >> 8) & 0xff))
+			tmp_txt.write_byte(byte(c & 0xff))
 		}
 		// dprintln("c: ${c:c}|${ byte(c &0xff) :c} c_len: ${c_len} str_len: ${real_len} in_len: ${length}")
 	}


### PR DESCRIPTION
This deprecates `Builder.write_b()` for `Builder.write_byte()`. This adds consistency with the other functions, and it's just more descriptive.

_Note: this is my first V PR that's not for `gg`. I think I got it all right, but there's a possibility I didn't_ 