### PR TITLE
builtin: use a pure V version of string.to_wide() on != windows

### DIFF
--- a/vlib/builtin/utf8.c.v
+++ b/vlib/builtin/utf8.c.v
@@ -17,7 +17,14 @@ pub fn (_str string) to_wide() &u16 {
 			return wstr
 		}
 	} $else {
-		return 0
+		srunes := _str.runes()
+		unsafe {
+			mut result := &u16(vcalloc_noscan((srunes.len + 1) * 2))
+			for i, r in srunes {
+				result[i] = u16(r)
+			}
+			return result
+		}
 	}
 }
 

--- a/vlib/builtin/utf8_test.v
+++ b/vlib/builtin/utf8_test.v
@@ -26,3 +26,31 @@ fn test_utf8_wide_char() {
 		assert val[2].hex() == '94'
 	}
 }
+
+fn test_to_wide_latin() {
+	s := 'abc 123'
+	w := s.to_wide()
+	unsafe {
+		assert w[0] == 97
+		assert w[1] == 98
+		assert w[2] == 99
+		assert w[3] == 32
+		assert w[4] == 49
+		assert w[5] == 50
+		assert w[6] == 51
+		assert w[7] == 0
+	}
+}
+
+fn test_to_wide_cyrillic() {
+	s := 'Проба'
+	w := s.to_wide()
+	unsafe {
+		assert w[0] == 1055
+		assert w[1] == 1088
+		assert w[2] == 1086
+		assert w[3] == 1073
+		assert w[4] == 1072
+		assert w[5] == 0
+	}
+}


### PR DESCRIPTION
With this PR, 'abc'.to_wide() now can be used on non windows too.
(it returned a 0 pointer before).

It returns a &u16 pointer to a WTF-16 encoded version of the string:
consecutive runes, each casted to u16, finished with a u16(0).