### PR TITLE
os: add an .exit_code field to os.Command

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -24,6 +24,17 @@ pub:
 	// stderr string // TODO
 }
 
+pub struct Command {
+mut:
+	f voidptr
+pub mut:
+	eof       bool
+	exit_code int
+pub:
+	path            string
+	redirect_stdout bool
+}
+
 [unsafe]
 pub fn (mut result Result) free() {
 	unsafe { result.output.free() }

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -368,7 +368,8 @@ pub struct Command {
 mut:
 	f voidptr
 pub mut:
-	eof bool
+	eof       bool
+	exit_code int
 pub:
 	path            string
 	redirect_stdout bool
@@ -412,9 +413,9 @@ pub fn (mut c Command) read_line() string {
 	return final
 }
 
-pub fn (c &Command) close() ? {
-	exit_code := vpclose(c.f)
-	if exit_code == 127 {
+pub fn (mut c Command) close() ? {
+	c.exit_code = vpclose(c.f)
+	if c.exit_code == 127 {
 		return error_with_code('error', 127)
 	}
 }

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -364,17 +364,6 @@ pub fn execute(cmd string) Result {
 	}
 }
 
-pub struct Command {
-mut:
-	f voidptr
-pub mut:
-	eof       bool
-	exit_code int
-pub:
-	path            string
-	redirect_stdout bool
-}
-
 [manualfree]
 pub fn (mut c Command) start() ? {
 	pcmd := c.path + ' 2>&1'

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -861,3 +861,30 @@ fn test_execute() ? {
 	assert hexresult.starts_with('7374617274004d4944444c450066696e697368')
 	assert hexresult.ends_with('0a7878')
 }
+
+fn test_command() {
+	mut cmd := os.Command{
+		path:'ls'
+	}
+
+	cmd.start() or { panic(err) }
+	for !cmd.eof {
+		cmd.read_line()
+	}
+
+	cmd.close() or { panic(err) }
+	assert cmd.exit_code == 0
+
+	// This will return a non 0 code
+	mut cmd_to_fail := os.Command{
+		path:'ls -M'
+	}
+
+	cmd_to_fail.start() or { panic(err) }
+	for !cmd_to_fail.eof {
+		cmd_to_fail.read_line()
+	}
+
+	cmd_to_fail.close() or { panic(err) }
+	assert cmd_to_fail.exit_code == 2
+}

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -863,6 +863,10 @@ fn test_execute() ? {
 }
 
 fn test_command() {
+	if os.user_os() == 'windows' {
+		eprintln('>>> os.Command is not implemented fully on Windows yet')
+		return
+	}
 	mut cmd := os.Command{
 		path: 'ls'
 	}
@@ -873,6 +877,7 @@ fn test_command() {
 	}
 
 	cmd.close() or { panic(err) }
+	// dump( cmd )
 	assert cmd.exit_code == 0
 
 	// This will return a non 0 code
@@ -886,5 +891,6 @@ fn test_command() {
 	}
 
 	cmd_to_fail.close() or { panic(err) }
-	assert cmd_to_fail.exit_code == 2
+	// dump( cmd_to_fail )
+	assert cmd_to_fail.exit_code != 0 // 2 on linux, 1 on macos
 }

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -864,7 +864,7 @@ fn test_execute() ? {
 
 fn test_command() {
 	mut cmd := os.Command{
-		path:'ls'
+		path: 'ls'
 	}
 
 	cmd.start() or { panic(err) }
@@ -877,7 +877,7 @@ fn test_command() {
 
 	// This will return a non 0 code
 	mut cmd_to_fail := os.Command{
-		path:'ls -M'
+		path: 'ls -M'
 	}
 
 	cmd_to_fail.start() or { panic(err) }

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -543,3 +543,17 @@ pub fn getegid() int {
 pub fn posix_set_permission_bit(path_s string, mode u32, enable bool) {
 	// windows has no concept of a permission mask, so do nothing
 }
+
+//
+
+pub fn (mut c Command) start() ? {
+	panic('not implemented')
+}
+
+pub fn (mut c Command) read_line() string {
+	panic('not implemented')
+}
+
+pub fn (mut c Command) close() ? {
+	panic('not implemented')
+}


### PR DESCRIPTION
At current, we are unable to retrieve the exit code with commands dispatched by os.Command.
The exit code is pretty important in some cases as it allows us to handle certain errors accordingly without panicking.

This PR adds the exit_code property to os.Command and updates the os.Command.close() method to set the 
exit code, rather than let it drop off.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
