### PR TITLE
Update indent style and size for md files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,6 +21,8 @@ trim_trailing_whitespace = false
 # the longest normal line is specified with this constant:
 # `too_long_line_length_other     = 100`
 max_line_length = 100
+indent_style = space
+indent_size = 4
 
 [*.{txt,out}]
 insert_final_newline = false


### PR DESCRIPTION
Default indent style and size for doc https://github.com/vlang/v/blob/master/doc/docs.md looks ugly 
<img width="1042" alt="Screenshot 2022-01-30 at 21 37 06" src="https://user-images.githubusercontent.com/477114/151712824-30cb235f-69ca-4a6b-bb89-97919fb28214.png">

I propose to use these values for md indent style and size 

```
indent_style = space
indent_size = 4
```
