### PR TITLE
tools: implement `cgen` tag for Markdown examples in `v check-md`

### DIFF
--- a/cmd/v/help/check-md.txt
+++ b/cmd/v/help/check-md.txt
@@ -13,6 +13,7 @@ Flags:
 NB: There are several special keywords, which you can put after the code fences for v.
 These are:
 	compile      - Default, can be omitted. The example will be compiled and formatting is verified.
+	cgen         - The example produces C code, which may not be compilable (when external libs are not installed). Formatting is verified.
 	live         - Compile hot reload examples with the ´-live´ flag set and verify formatting.
 	ignore       - Ignore the example, useful for examples that just use the syntax highlighting
 	failcompile  - Known failing compilation. Useful for examples demonstrating compiler errors.

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -163,7 +163,7 @@ For more details and troubleshooting, please visit the [vab GitHub repository](h
 
 <!--
 NB: there are several special keywords, which you can put after the code fences for v:
-compile, live, ignore, failcompile, oksyntax, badsyntax, wip, nofmt
+compile, cgen, live, ignore, failcompile, oksyntax, badsyntax, wip, nofmt
 For more details, do: `v check-md`
 -->
 
@@ -1393,7 +1393,7 @@ println(s)
 You can check the current type of a sum type using `is` and its negated form `!is`.
 
 You can do it either in an `if`:
-```v
+```v cgen
 struct Abc {
 	val string
 }
@@ -5102,40 +5102,42 @@ For all supported options check the latest help:
 
 #### `$if` condition
 ```v
-// Support for multiple conditions in one branch
-$if ios || android {
-	println('Running on a mobile device!')
-}
-$if linux && x64 {
-	println('64-bit Linux.')
-}
-// Usage as expression
-os := $if windows { 'Windows' } $else { 'UNIX' }
-println('Using $os')
-// $else-$if branches
-$if tinyc {
-	println('tinyc')
-} $else $if clang {
-	println('clang')
-} $else $if gcc {
-	println('gcc')
-} $else {
-	println('different compiler')
-}
-$if test {
-	println('testing')
-}
-// v -cg ...
-$if debug {
-	println('debugging')
-}
-// v -prod ...
-$if prod {
-	println('production build')
-}
-// v -d option ...
-$if option ? {
-	println('custom option')
+fn main() {
+	// Support for multiple conditions in one branch
+	$if ios || android {
+		println('Running on a mobile device!')
+	}
+	$if linux && x64 {
+		println('64-bit Linux.')
+	}
+	// Usage as expression
+	os := $if windows { 'Windows' } $else { 'UNIX' }
+	println('Using $os')
+	// $else-$if branches
+	$if tinyc {
+		println('tinyc')
+	} $else $if clang {
+		println('clang')
+	} $else $if gcc {
+		println('gcc')
+	} $else {
+		println('different compiler')
+	}
+	$if test {
+		println('testing')
+	}
+	// v -cg ...
+	$if debug {
+		println('debugging')
+	}
+	// v -prod ...
+	$if prod {
+		println('production build')
+	}
+	// v -d option ...
+	$if option ? {
+		println('custom option')
+	}
 }
 ```
 

--- a/vlib/gg/README.md
+++ b/vlib/gg/README.md
@@ -7,7 +7,7 @@ user's keyboard/mouse input.
 
 ## Example:
 
-```v
+```v cgen
 module main
 
 import gg

--- a/vlib/sokol/README.md
+++ b/vlib/sokol/README.md
@@ -11,7 +11,7 @@ Each `.h` file in the sokol source code is well-documented as can be seen here:
 
 ## Example from `@VROOTDIR/examples/sokol/sounds/simple_sin_tones.v`:
 
-```v
+```v cgen
 import time
 import math
 import sokol.audio


### PR DESCRIPTION
Previously `compile` behaved, as the new `cgen` mode does, by just producing an `x.c` file, but not compiling it, trusting that it would remain compilable. That is faster, but has the problem, that it can NOT spot cgen *regressions* in pure V examples in the documentation.

The default `compile`, will now try to actually *compile* with the backend C compiler, not just generate a x.c file.

See also https://github.com/vlang/v/issues/13322