### PR TITLE
Regex: fixed dot char problems on groups with *

### DIFF
--- a/vlib/regex/regex.v
+++ b/vlib/regex/regex.v
@@ -2024,6 +2024,11 @@ pub fn (mut re RE) match_base(in_txt &byte, in_txt_len int) (int, int) {
 
 					re.prog[state.pc].group_rep++ // increase repetitions
 					// println("GROUP $group_index END ${re.prog[state.pc].group_rep}")
+					if re.prog[state.pc].group_rep > in_txt_len - 1 {
+						m_state = .ist_quant_ng
+						continue
+					}
+
 					m_state = .ist_quant_pg
 					continue
 				}

--- a/vlib/regex/regex_test.v
+++ b/vlib/regex/regex_test.v
@@ -160,6 +160,10 @@ match_test_suite = [
     TestItem{"a", r"\S+",0,1},
     TestItem{"aaaa", r"\S+",0,4},
     TestItem{"aaaa ", r"\S+",0,4},
+
+    // multiple dot char
+    TestItem{"aba", r"a*(b*)*a",0,3},
+    TestItem{"/*x*/", r"/\**(.*)\**/",0,5},
 ]
 )
 

--- a/vlib/regex/regex_test.v
+++ b/vlib/regex/regex_test.v
@@ -164,6 +164,7 @@ match_test_suite = [
     // multiple dot char
     TestItem{"aba", r"a*(b*)*a",0,3},
     TestItem{"/*x*/", r"/\**(.*)\**/",0,5},
+    TestItem{"/*x*/", r"/*(.*)*/",0,5},
 ]
 )
 


### PR DESCRIPTION
**What's inside **
- fix for `a*(b*)*a` query string problem
- added more tests 

test code:
```v
import regex
fn main() {
        input := '/*x*/'
        query := r'/\**(.*)\**/'
        mut re := regex.regex_opt(query) ?
        println(re.get_query())
        println(re.get_code())
        re.debug = 2 // max debug info
        s, e := re.match_string(input)
        println("$s $e")
}

```