### PR TITLE
vfmt: updated to keep file permissions on !windows

### DIFF
--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -259,7 +259,15 @@ fn (foptions &FormatOptions) post_process_file(file string, formatted_file_path 
 				file_bak := '${file}.bak'
 				os.cp(file, file_bak) or {}
 			}
+			mut perms_to_restore := u32(0)
+			$if !windows {
+				fm := os.inode(file)
+				perms_to_restore = fm.bitmask()
+			}
 			os.mv_by_cp(formatted_file_path, file) or { panic(err) }
+			$if !windows {
+				os.chmod(file, int(perms_to_restore)) or { panic(err) }
+			}
 			eprintln('Reformatted file: $file')
 		} else {
 			eprintln('Already formatted file: $file')

--- a/vlib/os/inode.c.v
+++ b/vlib/os/inode.c.v
@@ -20,6 +20,8 @@ pub:
 	execute bool
 }
 
+// bitmask returns a 3 bit sequence in the order RWE where
+// the bit is set to 1 if the value is true or 0 otherwise.
 pub fn (p FilePermission) bitmask() u32 {
 	mut mask := u32(0)
 	if p.read {
@@ -42,6 +44,8 @@ pub:
 	others FilePermission
 }
 
+// bitmask returns a 9 bit sequence in the order owner + group + others.
+// This is a valid bitmask to use with `os.chmod`.
 pub fn (m FileMode) bitmask() u32 {
 	return m.owner.bitmask() << 6 | m.group.bitmask() << 3 | m.others.bitmask()
 }

--- a/vlib/os/inode.c.v
+++ b/vlib/os/inode.c.v
@@ -20,12 +20,30 @@ pub:
 	execute bool
 }
 
+pub fn (p FilePermission) bitmask() u32 {
+	mut mask := u32(0)
+	if p.read {
+		mask |= 4
+	}
+	if p.write {
+		mask |= 2
+	}
+	if p.execute {
+		mask |= 1
+	}
+	return mask
+}
+
 struct FileMode {
 pub:
 	typ    FileType
 	owner  FilePermission
 	group  FilePermission
 	others FilePermission
+}
+
+pub fn (m FileMode) bitmask() u32 {
+	return m.owner.bitmask() << 6 | m.group.bitmask() << 3 | m.others.bitmask()
 }
 
 // inode returns the mode of the file/inode containing inode type and permission information

--- a/vlib/os/inode_test.v
+++ b/vlib/os/inode_test.v
@@ -43,6 +43,10 @@ fn test_inode_file_owner_permission() {
 }
 
 fn test_inode_file_permissions_bitmask() {
+	if user_os() == 'windows' {
+		println('> skipping ${@FN} on windows')
+		return
+	}
 	filename := './test3.txt'
 	mut file := open_file(filename, 'w', 0o641) or { return }
 	file.close()

--- a/vlib/os/inode_test.v
+++ b/vlib/os/inode_test.v
@@ -41,3 +41,12 @@ fn test_inode_file_owner_permission() {
 	assert mode.owner.write
 	assert !mode.owner.execute
 }
+
+fn test_inode_file_permissions_bitmask() {
+	filename := './test3.txt'
+	mut file := open_file(filename, 'w', 0o641) or { return }
+	file.close()
+	mode := inode(filename)
+	rm(filename) or {}
+	assert mode.bitmask() == 0o641
+}


### PR DESCRIPTION
The problem:
After running `v fmt -w <filepath>` on linux the file is overwritten and the file permissions are lost.

The solution:
This update read the file permissions before saving (`os.inode`) and after `os.mv_by_cp` the permission is restored using `os.chmod`.