### PR TITLE
cgen: fix error for interface with multi nested embed struct (fix #13331)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -446,6 +446,18 @@ pub fn (t &Table) find_method_with_embeds(sym &TypeSymbol, method_name string) ?
 	}
 }
 
+pub fn (t &Table) get_methods_with_embeds(sym &TypeSymbol) []Fn {
+	mut methods := []Fn{}
+	if sym.info is Struct {
+		for embed in sym.info.embeds {
+			embed_sym := t.sym(embed)
+			methods << embed_sym.methods
+			methods << t.get_methods_with_embeds(embed_sym)
+		}
+	}
+	return methods
+}
+
 fn (t &Table) register_aggregate_field(mut sym TypeSymbol, name string) ?StructField {
 	if sym.kind != .aggregate {
 		t.panic('Unexpected type symbol: $sym.kind')

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -446,13 +446,13 @@ pub fn (t &Table) find_method_with_embeds(sym &TypeSymbol, method_name string) ?
 	}
 }
 
-pub fn (t &Table) get_methods_with_embeds(sym &TypeSymbol) []Fn {
+pub fn (t &Table) get_embed_methods(sym &TypeSymbol) []Fn {
 	mut methods := []Fn{}
 	if sym.info is Struct {
 		for embed in sym.info.embeds {
 			embed_sym := t.sym(embed)
 			methods << embed_sym.methods
-			methods << t.get_methods_with_embeds(embed_sym)
+			methods << t.get_embed_methods(embed_sym)
 		}
 	}
 	return methods

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6797,7 +6797,7 @@ static inline __shared__$interface_name ${shared_fn_name}(__shared__$cctype* x) 
 				}
 				else {}
 			}
-			t_methods := g.table.get_methods_with_embeds(st_sym)
+			t_methods := g.table.get_embed_methods(st_sym)
 			for t_method in t_methods {
 				if t_method.name !in method_names {
 					methods << t_method

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6797,16 +6797,13 @@ static inline __shared__$interface_name ${shared_fn_name}(__shared__$cctype* x) 
 				}
 				else {}
 			}
-			if st_sym.info is ast.Struct {
-				for embed in st_sym.info.embeds {
-					embed_sym := g.table.sym(embed)
-					for embed_method in embed_sym.methods {
-						if embed_method.name !in method_names {
-							methods << embed_method
-						}
-					}
+			t_methods := g.table.get_methods_with_embeds(st_sym)
+			for t_method in t_methods {
+				if t_method.name !in method_names {
+					methods << t_method
 				}
 			}
+
 			for method in methods {
 				mut name := method.name
 				if inter_info.parent_type.has_flag(.generic) {

--- a/vlib/v/tests/interface_struct_with_multi_nested_embed_test.v
+++ b/vlib/v/tests/interface_struct_with_multi_nested_embed_test.v
@@ -1,0 +1,91 @@
+fn test_interface_struct_with_multi_nested_embed() {
+	mut win := &Window{}
+	mut ll := &LinearLayout{}
+	mut lbl := &Label{
+		x: 10
+		y: 20
+	}
+
+	ll.add(mut lbl)
+	win.add(mut ll)
+
+	win.init()
+}
+
+[heap]
+pub struct Window {
+mut:
+	initables []&Initable
+}
+
+interface Initable {
+mut:
+	init(&Window)
+}
+
+pub fn (mut w Window) add(mut initable Initable) {
+	w.initables << initable
+}
+
+interface Container {
+mut:
+	layout()
+}
+
+fn (mut w Window) init() {
+	for wd in w.initables {
+		if mut wd is Container {
+			mut c := wd as Container
+			c.layout()
+		}
+	}
+}
+
+pub struct Rect {
+mut:
+	x int
+	y int
+}
+
+pub fn (r Rect) get_pos() (int, int) {
+	return r.x, r.y
+}
+
+pub struct LayoutBase {
+	Rect
+}
+
+pub struct Base {
+	LayoutBase
+}
+
+pub fn (mut b Base) init(window &Window) {}
+
+[heap]
+pub struct Label {
+	Base
+}
+
+pub interface Layoutable {
+	get_pos() (int, int)
+}
+
+[heap]
+pub struct LinearLayout {
+	Base
+mut:
+	layoutables []Layoutable
+}
+
+pub fn (mut ll LinearLayout) add(mut l Layoutable) {
+	ll.layoutables << l
+}
+
+pub fn (mut ll LinearLayout) layout() {
+	for mut wl in ll.layoutables {
+		x, y := wl.get_pos()
+		println('$x, $y')
+		assert x == 10
+		assert y == 20
+	}
+}


### PR DESCRIPTION
This PR fix error for interface with multi nested embed struct (fix #13331).

- Fix error for interface with multi nested embed struct.
- Add test.

```vlang
fn main() {
	mut win := &Window{}
	mut ll := &LinearLayout{}
	mut lbl := &Label{
		x: 10
		y: 20
	}

	ll.add(mut lbl)
	win.add(mut ll)

	win.init()
}

[heap]
pub struct Window {
mut:
	initables []&Initable
}

interface Initable {
mut:
	init(&Window)
}

pub fn (mut w Window) add(mut initable Initable) {
	w.initables << initable
}

interface Container {
mut:
	layout()
}

fn (mut w Window) init() {
	for wd in w.initables {
		if mut wd is Container {
			mut c := wd as Container
			c.layout()
		}
	}
}

pub struct Rect {
mut:
	x int
	y int
}

pub fn (r Rect) get_pos() (int, int) {
	return r.x, r.y
}

pub struct LayoutBase {
	Rect
}

pub struct Base {
	LayoutBase
}

pub fn (mut b Base) init(window &Window) {}

[heap]
pub struct Label {
	Base
}

pub interface Layoutable {
	get_pos() (int, int)
}

[heap]
pub struct LinearLayout {
	Base
mut:
	layoutables []Layoutable
}

pub fn (mut ll LinearLayout) add(mut l Layoutable) {
	ll.layoutables << l
}

pub fn (mut ll LinearLayout) layout() {
	for mut wl in ll.layoutables {
		x, y := wl.get_pos()
		println('$x, $y')
		assert x == 10
		assert y == 20
	}
}

---------------------------------------------
PS D:\Test\v\tt1> v run .
10, 20
```