### PR TITLE
checker, cgen: Fix shared array,maps can be cloned without lock and generated c codes are not correct if a method receiver have shared typed arg.

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -404,7 +404,9 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 	if node.args.len == 0 {
 		comparison_type = g.unwrap(info.elem_type.set_nr_muls(0))
 		shared a := g.array_sort_fn
-		array_sort_fn := a.clone()
+		array_sort_fn := rlock a {
+			a.clone()
+		}
 		if compare_fn in array_sort_fn {
 			g.gen_array_sort_call(node, compare_fn)
 			return
@@ -425,7 +427,9 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 			compare_fn += '_reverse'
 		}
 		shared a := g.array_sort_fn
-		array_sort_fn := a.clone()
+		array_sort_fn := rlock a {
+			a.clone()
+		}
 		if compare_fn in array_sort_fn {
 			g.gen_array_sort_call(node, compare_fn)
 			return

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -958,7 +958,9 @@ fn (mut g Gen) register_optional(t ast.Type) string {
 }
 
 fn (mut g Gen) write_optionals() {
-	mut done := g.done_optionals.clone()
+	mut done := rlock g.done_optionals {
+		g.done_optionals.clone()
+	}
 	for base, styp in g.optionals {
 		if base in done {
 			continue

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1006,7 +1006,8 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			if !node.left.is_lvalue() {
 				g.write('ADDR($rec_cc_type, ')
 				has_cast = true
-			} else {
+				// if receiver has shared_f, the struct ptr itself is passed directly.
+			} else if !node.receiver_type.has_flag(.shared_f) {
 				g.write('&')
 			}
 		}
@@ -1062,7 +1063,8 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			}
 			g.write(embed_name)
 		}
-		if node.left_type.has_flag(.shared_f) {
+		// if receiver has shared_f, the struct ptr itself is passed directly.
+		if node.left_type.has_flag(.shared_f) && !node.receiver_type.has_flag(.shared_f) {
 			g.write('->val')
 		}
 	}

--- a/vlib/v/tests/shared_lock_2_test.v
+++ b/vlib/v/tests/shared_lock_2_test.v
@@ -50,3 +50,27 @@ fn test_shared_receiver_lock() {
 		assert x.a == 7 && y.a == 5
 	}
 }
+
+struct St2 {
+mut:
+	a map[string]int
+}
+
+fn (shared x St2) f() {
+	lock x {
+		x.a["a"] = 123
+	}
+}
+
+fn test_shared_receiver_lock_2() {
+	shared x := St2 {
+		a: map[string]int
+	}
+
+	x.f()
+
+	rlock x {
+		assert x.a["a"] == 123
+	}
+}
+

--- a/vlib/v/tests/shared_lock_expr_test.v
+++ b/vlib/v/tests/shared_lock_expr_test.v
@@ -121,3 +121,14 @@ fn test_shared_lock_chan_rec_expr() {
 		}
 	}
 }
+
+fn test_shared_array_clone() {
+	shared a := []string{}
+	lock a {
+		a << "test"
+	}
+	b := rlock a {
+		a.clone()
+	}
+	assert b[0] == "test"
+}


### PR DESCRIPTION
This PR fixes issues related to `shared` typed variables.

- Fix #13329 (shared array,map can be cloned without locks.) 
- Fix #13320 (methods having shared typed args in receiver generates not correct c codes)