### PR TITLE
Regex: fix bug in replace_by_fn

### DIFF
--- a/vlib/regex/regex_test.v
+++ b/vlib/regex/regex_test.v
@@ -620,9 +620,6 @@ fn my_repl(re regex.RE, in_txt string, start int, end int) string {
 
 // test regex replace function
 fn test_regex_func_replace(){
-	if debug {
-		eprintln("test_regex_func_replace")
-	}
 	filler := "E il primo dei tre regni dell'Oltretomba cristiano visitato da Dante nel corso del viaggio, con la guida di Virgilio."
 	txt    := r'"content": "They dont necessarily flag "you will be buying these shares on margin!"", "channel_id"'
 	query := r'"(content":\s+")(.*)(, "channel_id")'
@@ -643,7 +640,6 @@ fn test_regex_func_replace(){
 		eprintln(txt2)
 	}
 	assert result == txt2
-	eprintln("test_regex_func_replace DONE!")
 }
 
 fn rest_regex_replace_n(){

--- a/vlib/regex/regex_test.v
+++ b/vlib/regex/regex_test.v
@@ -596,6 +596,21 @@ fn test_regex_func(){
 	}
 }
 
+fn my_repl_1(re regex.RE, in_txt string, start int, end int) string {
+	s0 := re.get_group_by_id(in_txt,0)
+	println("[$start, $end] => ${s0}")
+	return "a" + s0.to_upper()
+}
+
+fn test_regex_func_replace1(){
+	txt := "abbabbbabbbbaabba"
+	query := r"a(b+)"
+	mut re := regex.regex_opt(query) or { panic(err) }
+	result := re.replace_by_fn(txt, my_repl_1)
+
+	assert result == "aBBaBBBaBBBBaaBBa"
+}
+
 fn my_repl(re regex.RE, in_txt string, start int, end int) string {
 	s0 := re.get_group_by_id(in_txt,0)[0..1] + "X"
 	s1 := re.get_group_by_id(in_txt,1)[0..1] + "X"
@@ -603,9 +618,11 @@ fn my_repl(re regex.RE, in_txt string, start int, end int) string {
 	return "${s0}${s1}${s2}"
 }
 
-
 // test regex replace function
 fn test_regex_func_replace(){
+	if debug {
+		eprintln("test_regex_func_replace")
+	}
 	filler := "E il primo dei tre regni dell'Oltretomba cristiano visitato da Dante nel corso del viaggio, con la guida di Virgilio."
 	txt    := r'"content": "They dont necessarily flag "you will be buying these shares on margin!"", "channel_id"'
 	query := r'"(content":\s+")(.*)(, "channel_id")'
@@ -626,6 +643,7 @@ fn test_regex_func_replace(){
 		eprintln(txt2)
 	}
 	assert result == txt2
+	eprintln("test_regex_func_replace DONE!")
 }
 
 fn rest_regex_replace_n(){

--- a/vlib/regex/regex_util.v
+++ b/vlib/regex/regex_util.v
@@ -212,7 +212,7 @@ pub fn (mut re RE) find(in_txt string) (int, int) {
 [direct_array_access]
 pub fn (mut re RE) find_from(in_txt string, start int) (int, int) {
 	old_flag := re.flag
-	//re.flag |= f_src // enable search mode
+	// re.flag |= f_src // enable search mode
 
 	mut i := start
 	if i < 0 {

--- a/vlib/regex/regex_util.v
+++ b/vlib/regex/regex_util.v
@@ -361,7 +361,7 @@ pub fn (mut re RE) replace_simple(in_txt string, repl string) string {
 pub type FnReplace = fn (re RE, in_txt string, start int, end int) string
 
 // replace_by_fn return a string where the matches are replaced with the string from the repl_fn callback function
-pub fn (mut re RE) replace_by_fn1(in_txt string, repl_fn FnReplace) string {
+pub fn (mut re RE) replace_by_fn(in_txt string, repl_fn FnReplace) string {
 	mut i := 0
 	mut res := strings.new_builder(in_txt.len)
 	mut last_end := 0
@@ -400,32 +400,6 @@ pub fn (mut re RE) replace_by_fn1(in_txt string, repl_fn FnReplace) string {
 	}
 	return res.str()
 }
-
-pub fn (mut re RE) replace_by_fn(in_txt string, repl_fn FnReplace) string {
-	mut res := strings.new_builder(in_txt.len)
-	find_index_list := re.find_all(in_txt)
-	println("Find indexes: ${find_index_list}")
-	mut i := 0
-	mut i1 := 0
-	mut i2 := 0
-	mut i3 := 0
-	for i < find_index_list.len {
-		i2 = find_index_list[i]
-		i++	
-		i3 = find_index_list[i]
-		i++
-
-		res.write_string(in_txt#[i1..i2])
-		repl := repl_fn(re, in_txt, i2, i3)
-		res.write_string(repl)
-		i1 = i3
-	}
-
-
-	res.write_string(in_txt[i3..])
-	return res.str()
-}
-
 
 fn (re RE) parsed_replace_string(in_txt string, repl string) string {
 	str_lst := repl.split('\\')

--- a/vlib/regex/regex_util.v
+++ b/vlib/regex/regex_util.v
@@ -212,7 +212,7 @@ pub fn (mut re RE) find(in_txt string) (int, int) {
 [direct_array_access]
 pub fn (mut re RE) find_from(in_txt string, start int) (int, int) {
 	old_flag := re.flag
-	re.flag |= f_src // enable search mode
+	//re.flag |= f_src // enable search mode
 
 	mut i := start
 	if i < 0 {
@@ -361,7 +361,7 @@ pub fn (mut re RE) replace_simple(in_txt string, repl string) string {
 pub type FnReplace = fn (re RE, in_txt string, start int, end int) string
 
 // replace_by_fn return a string where the matches are replaced with the string from the repl_fn callback function
-pub fn (mut re RE) replace_by_fn(in_txt string, repl_fn FnReplace) string {
+pub fn (mut re RE) replace_by_fn1(in_txt string, repl_fn FnReplace) string {
 	mut i := 0
 	mut res := strings.new_builder(in_txt.len)
 	mut last_end := 0
@@ -400,6 +400,32 @@ pub fn (mut re RE) replace_by_fn(in_txt string, repl_fn FnReplace) string {
 	}
 	return res.str()
 }
+
+pub fn (mut re RE) replace_by_fn(in_txt string, repl_fn FnReplace) string {
+	mut res := strings.new_builder(in_txt.len)
+	find_index_list := re.find_all(in_txt)
+	println("Find indexes: ${find_index_list}")
+	mut i := 0
+	mut i1 := 0
+	mut i2 := 0
+	mut i3 := 0
+	for i < find_index_list.len {
+		i2 = find_index_list[i]
+		i++	
+		i3 = find_index_list[i]
+		i++
+
+		res.write_string(in_txt#[i1..i2])
+		repl := repl_fn(re, in_txt, i2, i3)
+		res.write_string(repl)
+		i1 = i3
+	}
+
+
+	res.write_string(in_txt[i3..])
+	return res.str()
+}
+
 
 fn (re RE) parsed_replace_string(in_txt string, repl string) string {
 	str_lst := repl.split('\\')


### PR DESCRIPTION
**What's inside**
- Fix for missing find in `replace_by_fn`
- added tests

test code:
```v
import regex
fn main() {
import regex
fn main() {
    s := 
'typedef enum
{
    SDL_BLENDMODE_NONE = 0x00000000,     /**< no blending
                                              dstRGBA = srcRGBA */
    SDL_BLENDMODE_BLEND = 0x00000001,    /**< alpha blending
                                              dstRGB = (srcRGB * srcA) + (dstRGB * (1-srcA))
                                              dstA = srcA + (dstA * (1-srcA)) */
    /* Additional custom blend modes can be returned by SDL_ComposeCustomBlendMode() */
} SDL_BlendMode;
/* finish comment */
'
    q := r'/[*]{1,2}(.*)[*]/'
    mut re := regex.regex_opt(q) or {panic(err)}
    
    flat_blocks := re.replace_by_fn(s, fn (re regex.RE, in_txt string, start int, end int) string {
        mut re1 := regex.regex_opt(r'\s{2,}') or {panic(err)}
        res :=re1.replace(re.get_group_by_id(in_txt, 0).replace('\n', ' '), ' ')
        return "// $res"
    })
    println(flat_blocks)
}
```

output:
```
typedef enum
{
    SDL_BLENDMODE_NONE = 0x00000000,     // < no blending dstRGBA = srcRGBA 
    SDL_BLENDMODE_BLEND = 0x00000001,    // < alpha blending dstRGB = (srcRGB * srcA) + (dstRGB * (1-srcA)) dstA = srcA + (dstA * (1-srcA)) 
    //  Additional custom blend modes can be returned by SDL_ComposeCustomBlendMode() 
} SDL_BlendMode;
//  finish comment 

```