### PR TITLE
cgen: fix error for interface with multi-nested embed struct (fix #13340)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3604,10 +3604,15 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	}
 	// struct embedding
 	if sym.info in [ast.Struct, ast.Aggregate] {
-		for embed in node.from_embed_types {
+		for i, embed in node.from_embed_types {
 			embed_sym := g.table.sym(embed)
 			embed_name := embed_sym.embed_name()
-			if node.expr_type.is_ptr() {
+			is_left_ptr := if i == 0 {
+				node.expr_type.is_ptr()
+			} else {
+				node.from_embed_types[i - 1].is_ptr()
+			}
+			if is_left_ptr {
 				g.write('->')
 			} else {
 				g.write('.')
@@ -6831,6 +6836,7 @@ static inline __shared__$interface_name ${shared_fn_name}(__shared__$cctype* x) 
 				styp := g.cc_type(method.params[0].typ, true)
 				mut method_call := '${styp}_$name'
 				if !method.params[0].typ.is_ptr() {
+					method_call = '${cctype}_$name'
 					// inline void Cat_speak_Interface_Animal_method_wrapper(Cat c) { return Cat_speak(*c); }
 					iwpostfix := '_Interface_${interface_name}_method_wrapper'
 					methods_wrapper.write_string('static inline ${g.typ(method.return_type)} ${cctype}_$name${iwpostfix}(')

--- a/vlib/v/tests/interface_with_multi_nested_embed_1_test.v
+++ b/vlib/v/tests/interface_with_multi_nested_embed_1_test.v
@@ -1,4 +1,4 @@
-fn test_interface_struct_with_multi_nested_embed() {
+fn test_interface_with_multi_nested_embed() {
 	mut win := &Window{}
 	mut ll := &LinearLayout{}
 	mut lbl := &Label{

--- a/vlib/v/tests/interface_with_multi_nested_embed_2_test.v
+++ b/vlib/v/tests/interface_with_multi_nested_embed_2_test.v
@@ -1,0 +1,57 @@
+fn test_interface_with_multi_nested_embed() {
+	mut ll := &LinearLayout{}
+	mut lbl := &Label{
+		x: 10
+		y: 20
+	}
+	ll.add(mut lbl)
+
+	println(ll)
+
+	assert ll.x == 10
+	assert ll.y == 20
+}
+
+pub struct Rect {
+mut:
+	x int
+	y int
+}
+
+pub fn (r Rect) get_pos() (int, int) {
+	return r.x, r.y
+}
+
+pub struct LayoutBase {
+	Rect
+}
+
+pub struct Base {
+	LayoutBase
+}
+
+pub fn (mut b Base) init() {}
+
+[heap]
+pub struct Label {
+	Base
+}
+
+pub interface Layoutable {
+	get_pos() (int, int)
+mut:
+	init()
+}
+
+[heap]
+pub struct LinearLayout {
+	Base
+mut:
+	layoutables []Layoutable
+}
+
+pub fn (mut ll LinearLayout) add(mut l Layoutable) {
+	x, y := l.get_pos()
+	ll.x += x
+	ll.y += y
+}


### PR DESCRIPTION
This PR fix error for interface with multi-nested embed struct (fix #13340).

- Fix error for interface with multi-nested embed struct.
- Add test.

```vlang
fn main() {
	mut ll := &LinearLayout{}
	mut lbl := &Label{
		x: 10
		y: 20
	}
	ll.add(mut lbl)

	println(ll)

	assert ll.x == 10
	assert ll.y == 20
}

pub struct Rect {
mut:
	x int
	y int
}

pub fn (r Rect) get_pos() (int, int) {
	return r.x, r.y
}

pub struct LayoutBase {
	Rect
}

pub struct Base {
	LayoutBase
}

pub fn (mut b Base) init() {}

[heap]
pub struct Label {
	Base
}

pub interface Layoutable {
	get_pos() (int, int)
mut:
	init()
}

[heap]
pub struct LinearLayout {
	Base
mut:
	layoutables []Layoutable
}

pub fn (mut ll LinearLayout) add(mut l Layoutable) {
	x, y := l.get_pos()
	ll.x += x
	ll.y += y
}

----------------------------------------------------------------------
PS D:\Test\v\tt1> v run .
&LinearLayout{
    Base: Base{
        LayoutBase: LayoutBase{
            Rect: Rect{
                x: 10
                y: 20
            }
        }
    }
    layoutables: []
}
```