### PR TITLE
cgen: fix error for sql statement inside fn call (fix #13330)

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -45,7 +45,7 @@ const (
 		'vlib/sqlite/sqlite_orm_test.v',
 		'vlib/v/tests/orm_sub_struct_test.v',
 		'vlib/v/tests/orm_sub_array_struct_test.v',
-		'vlib/v/tests/sql_statement_inside_fn_call_test.v'
+		'vlib/v/tests/sql_statement_inside_fn_call_test.v',
 		'vlib/vweb/tests/vweb_test.v',
 		'vlib/vweb/request_test.v',
 		'vlib/net/http/request_test.v',
@@ -84,7 +84,7 @@ const (
 		'vlib/orm/orm_test.v',
 		'vlib/v/tests/orm_sub_struct_test.v',
 		'vlib/v/tests/orm_sub_array_struct_test.v',
-		'vlib/v/tests/sql_statement_inside_fn_call_test.v'
+		'vlib/v/tests/sql_statement_inside_fn_call_test.v',
 		'vlib/clipboard/clipboard_test.v',
 		'vlib/vweb/tests/vweb_test.v',
 		'vlib/vweb/request_test.v',

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -45,6 +45,7 @@ const (
 		'vlib/sqlite/sqlite_orm_test.v',
 		'vlib/v/tests/orm_sub_struct_test.v',
 		'vlib/v/tests/orm_sub_array_struct_test.v',
+		'vlib/v/tests/sql_statement_inside_fn_call_test.v'
 		'vlib/vweb/tests/vweb_test.v',
 		'vlib/vweb/request_test.v',
 		'vlib/net/http/request_test.v',
@@ -83,6 +84,7 @@ const (
 		'vlib/orm/orm_test.v',
 		'vlib/v/tests/orm_sub_struct_test.v',
 		'vlib/v/tests/orm_sub_array_struct_test.v',
+		'vlib/v/tests/sql_statement_inside_fn_call_test.v'
 		'vlib/clipboard/clipboard_test.v',
 		'vlib/vweb/tests/vweb_test.v',
 		'vlib/vweb/request_test.v',

--- a/vlib/v/gen/c/sql.v
+++ b/vlib/v/gen/c/sql.v
@@ -759,7 +759,9 @@ fn (mut g Gen) sql_select(node ast.SqlExpr, expr string, left string) {
 		if node.is_array {
 			g.write('_array')
 		}
-		g.writeln(';')
+		if !g.inside_call {
+			g.writeln(';')
+		}
 	}
 }
 

--- a/vlib/v/tests/sql_statement_inside_fn_call_test.v
+++ b/vlib/v/tests/sql_statement_inside_fn_call_test.v
@@ -1,0 +1,24 @@
+import sqlite
+
+struct Movie {
+	id   int    [primary]
+	name string
+}
+
+fn x(m Movie) int {
+	return m.id
+}
+
+fn test_sql_statement_inside_fn_call() {
+	db := sqlite.connect(':memory:') or { panic('failed') }
+	sql db {
+		create table Movie
+	}
+	m := Movie{1, 'Maria'}
+	sql db {
+		insert m into Movie
+	}
+	dump(x(sql db {
+		select from Movie where id == 1
+	}))
+}


### PR DESCRIPTION
This PR fix error for sql statement inside fn call (fix #13330).

- Fix error for sql statement inside fn call.
- Add test.

```vlang
import sqlite

struct Movie {
	id   int    [primary]
	name string
}

fn x(m Movie) int {
	return m.id
}

fn main() {
	db := sqlite.connect(':memory:') ?
	sql db {
		create table Movie
	}
	m := Movie{1, 'Maria'}
	sql db {
		insert m into Movie
	}
	dump(x(sql db {
		select from Movie where id == 1
	}))
}
---------------------------------------------------
PS D:\Test\v\tt1> v run .
[.\\tt1.v:21] x(ast.SqlExpr): 1
```
```vlang
import vweb
import sqlite

struct App {
	vweb.Context
pub mut:
	db sqlite.DB
}

fn main() {
	mut app := App{
		db: sqlite.connect(':memory:') or { panic(err) }
	}
	sql app.db {
		create table Movie
	}
	vweb.run(app, 8081)
}

struct Movie {
	id          int    [primary; sql: serial]
	name        string
	rating      f32
	tagline     string
	summary     string
	description string
	hash        string
	imdbid      int
	tmdbid      int
	video_id    int
}

['/movie/:movie_id']
fn (mut app App) movie(movie_id int) vweb.Result {
	return app.json(sql app.db {
		select from Movie where id == movie_id
	})
}
------------------------------------------------------
PS D:\Test\v\tt1> v run .
[Vweb] Running app on http://localhost:8081

```