### PR TITLE
v: use `-skip-unused` by default, add `-no-skip-unused` to turn it off

### DIFF
--- a/cmd/v/help/build.txt
+++ b/cmd/v/help/build.txt
@@ -125,8 +125,11 @@ NB: the build flags are shared with the run command too:
    -skip-unused
       Skip generating C/JS code for functions, that are provably not used by your project.
       This speeds up compilation, and reduces the generated output size.
-      It is still experimental, due to historical reasons, but please do try it,
-      and report issues, if compilation breaks with that option for your program.
+      Turned on by default since 2022/02/03. Please report issues, if compilation breaks
+      for your program, but is successfull with `-no-skip-unused`.
+	  
+   -no-skip-unused
+      Turn off skipping of unused C/JS code. Used for diagnosing problems with the skip unused mode.
 
    -stats
       Enable more detailed statistics reporting, while compiling test files.

--- a/vlib/v/checker/tests/cannot_cast_to_alias.out
+++ b/vlib/v/checker/tests/cannot_cast_to_alias.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/cannot_cast_to_alias.vv:6:7: error: cannot convert type `int literal` to `MyType` (alias to `string`)
-    4 |
+vlib/v/checker/tests/cannot_cast_to_alias.vv:6:7: error: cannot cast `int literal` to `MyType` (alias to `string`)
+    4 | 
     5 | fn main() {
     6 |     _ := MyType(5)
       |          ~~~~~~~~~

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -184,7 +184,7 @@ pub mut:
 	only_check_syntax   bool // when true, just parse the files, then stop, before running checker
 	check_only          bool // same as only_check_syntax, but also runs the checker
 	experimental        bool // enable experimental features
-	skip_unused         bool // skip generating C code for functions, that are not used
+	skip_unused         bool = true // skip generating C code for functions, that are not used
 	show_timings        bool // show how much time each compiler stage took
 	is_ios_simulator    bool
 	is_apk              bool     // build as Android .apk format
@@ -400,6 +400,9 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 			}
 			'-skip-unused' {
 				res.skip_unused = true
+			}
+			'-no-skip-unused' {
+				res.skip_unused = false
 			}
 			'-compress' {
 				res.compress = true


### PR DESCRIPTION
Turns on -skip-unused by default, to shake out remaining possible
problems with it.