### PR TITLE
fix Context.mount_static_folder_at  

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -644,7 +644,7 @@ pub fn (mut ctx Context) mount_static_folder_at(directory_path string, mount_pat
 		return false
 	}
 	dir_path := directory_path.trim_right('/')
-	
+
 	trim_mount_path := mount_path.trim_left('/').trim_right('/')
 	ctx.scan_static_directory(dir_path, '/' + trim_mount_path)
 	return true

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -644,7 +644,9 @@ pub fn (mut ctx Context) mount_static_folder_at(directory_path string, mount_pat
 		return false
 	}
 	dir_path := directory_path.trim_right('/')
-	ctx.scan_static_directory(dir_path, mount_path[1..])
+	
+	trim_mount_path := mount_path.trim_left('/').trim_right('/')
+	ctx.scan_static_directory(dir_path, '/' + trim_mount_path)
 	return true
 }
 

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -646,7 +646,7 @@ pub fn (mut ctx Context) mount_static_folder_at(directory_path string, mount_pat
 	dir_path := directory_path.trim_right('/')
 
 	trim_mount_path := mount_path.trim_left('/').trim_right('/')
-	ctx.scan_static_directory(dir_path, '/' + trim_mount_path)
+	ctx.scan_static_directory(dir_path, '/$trim_mount_path')
 	return true
 }
 


### PR DESCRIPTION
method "**mount_static_folder_at**"  produces wrong mount_path,

for example , "/public/assets/img"  will get "public/assets/img" , and this result will later used in method **scan_static_directory**, and then produce url "public/assets/img/a.png" , and this result is wrong for method  **serve_static**, as url must start with "/", in this example is "public/assets/img/a.png"



