### PR TITLE
fmt: preserve formatting with comments in a empty map

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2097,7 +2097,13 @@ pub fn (mut f Fmt) map_init(node ast.MapInit) {
 			f.mark_types_import_as_used(info.key_type)
 			f.write(f.table.type_to_str_using_aliases(node.typ, f.mod2alias))
 		}
-		f.write('{}')
+		if node.pos.line_nr == node.pos.last_line {
+			f.write('{}')
+		} else {
+			f.writeln('{')
+			f.comments(node.pre_cmnts, level: .indent)
+			f.write('}')
+		}
 		return
 	}
 	f.writeln('{')

--- a/vlib/v/fmt/tests/empty_map_fmt_keep.vv
+++ b/vlib/v/fmt/tests/empty_map_fmt_keep.vv
@@ -1,0 +1,11 @@
+struct Foo {
+	bar map[int]int
+}
+
+fn main() {
+	foo := Foo{
+		bar: {
+			// comment
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/vlang/v/issues/13281

how the result now looks like

```
➜  v git:(master) ✗ ./v self && ./v fmt .debug/test.v
V self compiling ...
V built successfully as executable "v".
struct Foo {
	bar map[int]int
}

fn main() {
	foo := Foo{
		bar: {
			// comment
		}
	}
}
```


Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>
