### PR TITLE
parser: check orm using undefined variable in where expr (fix #13367)

### DIFF
--- a/vlib/v/checker/tests/orm_using_undefined_var_in_where_err.out
+++ b/vlib/v/checker/tests/orm_using_undefined_var_in_where_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/orm_using_undefined_var_in_where_err.vv:24:35: error: undefined variable: `email`
+   22 |
+   23 |     _ := sql db {
+   24 |         select from User where email == email
+      |                                         ~~~~~
+   25 |     }
+   26 | }

--- a/vlib/v/checker/tests/orm_using_undefined_var_in_where_err.vv
+++ b/vlib/v/checker/tests/orm_using_undefined_var_in_where_err.vv
@@ -1,0 +1,26 @@
+import time
+import sqlite
+
+struct User {
+	id         int       [primary; sql: serial]
+	created_at time.Time
+	updated_at time.Time
+	email      string
+	password   string
+	name       string
+}
+
+fn main() {
+	db := sqlite.connect(':memory:') ?
+	sql db {
+		create table User
+	}
+	m := User{}
+	sql db {
+		insert m into User
+	}
+
+	_ := sql db {
+		select from User where email == email
+	}
+}

--- a/vlib/v/parser/sql.v
+++ b/vlib/v/parser/sql.v
@@ -33,6 +33,9 @@ fn (mut p Parser) sql_expr() ast.Expr {
 		// `id == x` means that a single object is returned
 		if !is_count && where_expr is ast.InfixExpr {
 			e := where_expr as ast.InfixExpr
+			p.check_undefined_variables([e.left], e.right) or {
+				return p.error_with_pos(err.msg, e.right.pos())
+			}
 			if e.op == .eq && e.left is ast.Ident {
 				if e.left.name == 'id' {
 					query_one = true

--- a/vlib/v/parser/sql.v
+++ b/vlib/v/parser/sql.v
@@ -33,12 +33,16 @@ fn (mut p Parser) sql_expr() ast.Expr {
 		// `id == x` means that a single object is returned
 		if !is_count && where_expr is ast.InfixExpr {
 			e := where_expr as ast.InfixExpr
-			p.check_undefined_variables([e.left], e.right) or {
-				return p.error_with_pos(err.msg, e.right.pos())
-			}
 			if e.op == .eq && e.left is ast.Ident {
 				if e.left.name == 'id' {
 					query_one = true
+				}
+			}
+			if e.right is ast.Ident {
+				if !p.scope.known_var(e.right.name) {
+					p.check_undefined_variables([e.left], e.right) or {
+						return p.error_with_pos(err.msg, e.right.pos)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This PR check orm using undefined variable in where expr (fix #13367).

- Check orm using undefined variable in where expr.
- Add test.

```vlang
import time
import sqlite

struct User {
	id         int       [primary; sql: serial]
	created_at time.Time
	updated_at time.Time
	email      string
	password   string
	name       string
}

fn main() {
	db := sqlite.connect(':memory:') ?
	sql db {
		create table User
	}
	m := User{}
	sql db {
		insert m into User
	}

	_ := sql db {
		select from User where email == email
	}
}

PS D:\Test\v\tt1> v run .
./tt1.v:24:35: error: undefined variable: `email`
   22 |
   23 |     _ := sql db {
   24 |         select from User where email == email
      |                                         ~~~~~
   25 |     }
   26 | }
```