### PR TITLE
cgen: fix error for struct with reference alias fields (fix #8977 #13369)

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -916,7 +916,8 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name stri
 			funcprefix += 'isnil(it.${c_name(field.name)})'
 			funcprefix += ' ? _SLIT("nil") : '
 			// struct, floats and ints have a special case through the _str function
-			if sym.kind != .struct_ && !field.typ.is_int_valptr() && !field.typ.is_float_valptr() {
+			if sym.kind !in [.struct_, .alias] && !field.typ.is_int_valptr()
+				&& !field.typ.is_float_valptr() {
 				funcprefix += '*'
 			}
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5519,6 +5519,9 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 							|| sfield.typ.is_pointer()) && !sfield.typ.is_number() {
 							g.write('/* autoref */&')
 						}
+						if sfield.typ.is_ptr() && field_type_sym.kind == .alias {
+							g.write('&')
+						}
 						g.expr_with_cast(sfield.expr, sfield.typ, sfield.expected_type)
 					}
 				}

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -85,6 +85,9 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		g.expr(expr)
 		g.write(')')
 	} else if typ == ast.string_type {
+		if etype.is_ptr() {
+			g.write('*')
+		}
 		g.expr(expr)
 	} else if typ == ast.bool_type {
 		g.expr(expr)

--- a/vlib/v/tests/struct_with_reference_alias_fields.v
+++ b/vlib/v/tests/struct_with_reference_alias_fields.v
@@ -1,0 +1,13 @@
+type SS = string
+
+struct ST {
+	data &SS
+}
+
+fn test_struct_with_reference_alias_fields() {
+	mut val := ST{
+		data: &SS('hi')
+	}
+	println(val.data)
+	assert '$val.data' == 'hi'
+}


### PR DESCRIPTION
This PR fix error for struct with reference alias fields (fix #8977, fix #13369)

- Fix error for struct with reference alias fields.
- Add test.
- It cannot output informations with gg imported.

```vlang
type SS = string

struct ST {
	data &SS
}

fn main() {
	mut val := ST{
		data: &SS('hi')
	}
	println(val.data)
	assert '$val.data' == 'hi'
}

-------------------------------------------------
PS D:\Test\v\tt1> v run .
hi
```