### PR TITLE
ci: add report-missing-fn-doc job, to prevent adding new undocumented pub symbols in vlib

### DIFF
--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Check against parent commit
         run: |
-          ./v               run cmd/tools/missdoc.v vlib/ | sort > /tmp/n_v.txt
-          cd pv/ && ../v run ../cmd/tools/missdoc.v vlib/ | sort > /tmp/o_v.txt
+          ./v run cmd/tools/missdoc.v vlib/    | sed 's@^.*/vlib/@@p' | sort > /tmp/n_v.txt
+          ./v run cmd/tools/missdoc.v pv/vlib/ | sed 's@^.*/vlib/@@p' | sort > /tmp/o_v.txt
           count_new=$(cat /tmp/n_v.txt | wc -l)
           count_old=$(cat /tmp/o_v.txt | wc -l)
           echo "new pubs: $count_new | old pubs: $count_old"

--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -16,3 +16,31 @@ jobs:
         run: ./v check-md -hide-warnings .
       ## NB: -hide-warnings is used here, so that the output is less noisy,
       ## thus real errors are easier to spot.
+
+  report-missing-fn-doc:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build V
+        run: make
+
+      - name: Checkout previous v
+        uses: actions/checkout@v2
+        with:
+          repository: vlang/v
+          path: pv
+
+      - name: Check against parent commit
+        run: |
+          ./v run cmd/tools/missdoc.v ./vlib/ > /tmp/n_v.txt
+          ./v run cmd/tools/missdoc.v ./pv/vlib/ > /tmp/o_v.txt
+          count_new=$(cat /tmp/n_v.txt | wc -l)
+          count_old=$(cat /tmp/o_v.txt | wc -l)
+          if [[ ${count_new} -gt ${count_old} ]]; then
+            echo "The following $((count_new-count_old)) function(s) is introduced with no documentation:"
+            sed -n 's/^.*\/vlib\///p' /tmp/n_v.txt > /tmp/tn_v.txt
+            sed -n 's/^.*\/vlib\///p' /tmp/o_v.txt > /tmp/to_v.txt
+            sort /tmp/tn_v.txt /tmp/to_v.txt | uniq -u
+            exit 1
+          fi

--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Check against parent commit
         run: |
-          ./v run cmd/tools/missdoc.v vlib/    | sed 's@^.*/vlib/@@p' | sort > /tmp/n_v.txt
-          ./v run cmd/tools/missdoc.v pv/vlib/ | sed 's@^.*/vlib/@@p' | sort > /tmp/o_v.txt
+          ./v run cmd/tools/missdoc.v vlib/    | sed -n 's@^.*/vlib/@vlib/@p' | sort > /tmp/n_v.txt
+          ./v run cmd/tools/missdoc.v pv/vlib/ | sed -n 's@^.*/vlib/@vlib/@p' | sort > /tmp/o_v.txt
           count_new=$(cat /tmp/n_v.txt | wc -l)
           count_old=$(cat /tmp/o_v.txt | wc -l)
           echo "new pubs: $count_new | old pubs: $count_old"

--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -33,14 +33,14 @@ jobs:
 
       - name: Check against parent commit
         run: |
-          ./v run cmd/tools/missdoc.v ./vlib/ > /tmp/n_v.txt
-          ./v run cmd/tools/missdoc.v ./pv/vlib/ > /tmp/o_v.txt
+          ./v               run cmd/tools/missdoc.v vlib/ | sort > /tmp/n_v.txt
+          cd pv/ && ../v run ../cmd/tools/missdoc.v vlib/ | sort > /tmp/o_v.txt
           count_new=$(cat /tmp/n_v.txt | wc -l)
           count_old=$(cat /tmp/o_v.txt | wc -l)
+          echo "new pubs: $count_new | old pubs: $count_old"
+          echo "new head: $(head -n1 /tmp/n_v.txt)"
+          echo "old head: $(head -n1 /tmp/o_v.txt)"
           if [[ ${count_new} -gt ${count_old} ]]; then
             echo "The following $((count_new-count_old)) function(s) is introduced with no documentation:"
-            sed -n 's/^.*\/vlib\///p' /tmp/n_v.txt | sort > /tmp/tn_v.txt
-            sed -n 's/^.*\/vlib\///p' /tmp/o_v.txt | sort > /tmp/to_v.txt
-            diff /tmp/tn_v.txt /tmp/to_v.txt
-            exit 1
+            diff /tmp/n_v.txt /tmp/o_v.txt ## diff does exit(1) when files are different
           fi

--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -39,8 +39,8 @@ jobs:
           count_old=$(cat /tmp/o_v.txt | wc -l)
           if [[ ${count_new} -gt ${count_old} ]]; then
             echo "The following $((count_new-count_old)) function(s) is introduced with no documentation:"
-            sed -n 's/^.*\/vlib\///p' /tmp/n_v.txt > /tmp/tn_v.txt
-            sed -n 's/^.*\/vlib\///p' /tmp/o_v.txt > /tmp/to_v.txt
-            sort /tmp/tn_v.txt /tmp/to_v.txt | uniq -u
+            sed -n 's/^.*\/vlib\///p' /tmp/n_v.txt | sort > /tmp/tn_v.txt
+            sed -n 's/^.*\/vlib\///p' /tmp/o_v.txt | sort > /tmp/to_v.txt
+            diff /tmp/tn_v.txt /tmp/to_v.txt
             exit 1
           fi

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -208,5 +208,6 @@ pub fn (mut l Log) debug(s string) {
 	l.send_output(s, .debug)
 }
 
+// test_undoc_alarm tests the CI alarm
 pub fn test_undoc_alarm() {
 }

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -207,7 +207,3 @@ pub fn (mut l Log) debug(s string) {
 	}
 	l.send_output(s, .debug)
 }
-
-// test_undoc_alarm tests the CI alarm
-pub fn test_undoc_alarm() {
-}

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -207,3 +207,6 @@ pub fn (mut l Log) debug(s string) {
 	}
 	l.send_output(s, .debug)
 }
+
+pub fn test_undoc_alarm() {
+}


### PR DESCRIPTION
This PR introduce a CI step that'll prevent any *undocumented* `pub fn` functions going into `vlib/`.
It works by comparing the count of undocumented public functions in the fork/branch the PR is forked from with the count of the PR itself. If the count for the PR is greater than that of the fork, CI will fail in the following way:
![image](https://user-images.githubusercontent.com/768942/152685850-fdbf8e2b-958d-41a9-b427-468fc2f6b46a.png)

Test runs can be found here from the commmits in this PR's history:

Failed:
https://github.com/Larpon/v/actions/runs/1802505599

Ok (function introduced had docs added):
https://github.com/Larpon/v/runs/5083957234

Currently the numbers speak for themselves:
```
v run cmd/tools/missdoc.v vlib/ | wc -l
1724
```
Currently we have 1724 undocumented functions in vlib - and that number will keep growing if we don't stop it - since very few PR's is currently *adding* documentation.

This PR is, thus, also related to #7047 