### PR TITLE
ci: fix undoc pub fn diff output

### DIFF
--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Check against parent commit
         run: |
-          ./v run cmd/tools/missdoc.v vlib/    | sed -n 's@^.*/vlib/@vlib/@p' | sort > /tmp/n_v.txt
-          ./v run cmd/tools/missdoc.v pv/vlib/ | sed -n 's@^.*/vlib/@vlib/@p' | sort > /tmp/o_v.txt
+          ./v run cmd/tools/missdoc.v --no-line-numbers vlib/    | sed -n 's@^.*/vlib/@vlib/@p' | sort > /tmp/n_v.txt
+          ./v run cmd/tools/missdoc.v --no-line-numbers pv/vlib/ | sed -n 's@^.*/vlib/@vlib/@p' | sort > /tmp/o_v.txt
           count_new=$(cat /tmp/n_v.txt | wc -l)
           count_old=$(cat /tmp/o_v.txt | wc -l)
           echo "new pubs: $count_new | old pubs: $count_old"

--- a/cmd/tools/missdoc.v
+++ b/cmd/tools/missdoc.v
@@ -17,11 +17,12 @@ struct UndocumentedFN {
 }
 
 struct Options {
-	show_help    bool
-	collect_tags bool
-	deprecated   bool
-	private      bool
-	js           bool
+	show_help       bool
+	collect_tags    bool
+	deprecated      bool
+	private         bool
+	js              bool
+	no_line_numbers bool
 }
 
 fn collect(path string, mut l []string, f fn (string, mut []string)) {
@@ -94,16 +95,20 @@ fn report_undocumented_functions_in_file(opt Options, file string) {
 	}
 	if info.len > 0 {
 		for undocumented_fn in info {
+			mut line_numbers := '$undocumented_fn.line:0:'
+			if opt.no_line_numbers {
+				line_numbers = ''
+			}
 			tags_str := if opt.collect_tags && undocumented_fn.tags.len > 0 {
 				'$undocumented_fn.tags'
 			} else {
 				''
 			}
 			if opt.deprecated {
-				println('$file:$undocumented_fn.line:0:$undocumented_fn.signature $tags_str')
+				println('$file:$line_numbers$undocumented_fn.signature $tags_str')
 			} else {
 				if 'deprecated' !in undocumented_fn.tags {
-					println('$file:$undocumented_fn.line:0:$undocumented_fn.signature $tags_str')
+					println('$file:$line_numbers$undocumented_fn.signature $tags_str')
 				}
 			}
 		}
@@ -132,6 +137,7 @@ fn main() {
 		deprecated: fp.bool('deprecated', `d`, false, 'Include deprecated functions in output.')
 		private: fp.bool('private', `p`, false, 'Include private functions in output.')
 		js: fp.bool('js', 0, false, 'Include JavaScript functions in output.')
+		no_line_numbers: fp.bool('no-line-numbers', 0, false, 'Exclude line numbers in output.')
 		collect_tags: fp.bool('tags', `t`, false, 'Also print function tags if any is found.')
 	}
 	if opt.show_help {


### PR DESCRIPTION
This PR adds an option to `missdoc` to tell it to omit line number information in it's output - fixing a situation in `docs_ci` where output could be very verbose and confusing.