### PR TITLE
cmd/tools: add support for ./v symlink -githubci

### DIFF
--- a/cmd/tools/vsymlink.v
+++ b/cmd/tools/vsymlink.v
@@ -21,10 +21,11 @@ fn main() {
 
 	ci_mode := if os.args.len == 3 {
 		if os.args[2] in supported_flags {
-			return true
+			true
 		} else {
 			print('Unsupported flag: ' + os.args[2])
 			exit(1)
+			false
 		}
 	} else {
 		false

--- a/cmd/tools/vsymlink.v
+++ b/cmd/tools/vsymlink.v
@@ -57,7 +57,7 @@ fn setup_symlink_windows_github() {
 
 		// See: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
 		os.execute_or_panic('pwsh -c "echo \$pwd | Out-File -FilePath \$env:GITHUB_PATH -Append"')
-		os.execute_or_panic('refreshenv')
+		os.execute_or_panic('pwsh -c "refreshenv"')
 	}
 }
 

--- a/cmd/v/help/symlink.txt
+++ b/cmd/v/help/symlink.txt
@@ -1,5 +1,7 @@
-Usage: v symlink
+Usage: v symlink [OPTIONS]
 
 This command adds a symlink for the V compiler executable.
 
 Note that on Unix systems this command requires write permissions to /usr/local/bin to work.
+
+For GitHub Actions, the option -githubci needs to be specified.


### PR DESCRIPTION
Allows `./v symlink` to be used on GitHub Actions using the `-githubci` tag. It does not make use of elevated privileges. Instead, we add the location of V's installation to path and invoke `refreshenv` that comes pre-installed with Chocolatey on WIndows CI runners.