### PR TITLE
parser, checker: cleanup struct short syntax processing

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -116,9 +116,9 @@ pub fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 
 pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 	if node.typ == ast.void_type {
-		// Short syntax `({foo: bar})`
+		// short syntax `foo(key:val, key2:val2)`
 		if c.expected_type == ast.void_type {
-			c.error('unexpected short struct syntax', node.pos)
+			c.error('the expected type of short struct syntax is invalid', node.pos)
 			return ast.void_type
 		}
 		sym := c.table.sym(c.expected_type)

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -126,7 +126,7 @@ pub fn (mut p Parser) call_args() []ast.CallArg {
 		mut expr := ast.empty_expr()
 		if p.tok.kind == .name && p.peek_tok.kind == .colon {
 			// `foo(key:val, key2:val2)`
-			expr = p.struct_init(p.mod + '.' + p.tok.lit, true) // short_syntax:true
+			expr = p.struct_init('void_type', true) // short_syntax:true
 		} else {
 			expr = p.expr(0)
 		}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -340,8 +340,6 @@ fn (mut p Parser) struct_init(typ_str string, short_syntax bool) ast.StructInit 
 	p.struct_init_generic_types = []ast.Type{}
 	typ := if short_syntax { ast.void_type } else { p.parse_type() }
 	p.expr_mod = ''
-	// sym := p.table.sym(typ)
-	// p.warn('struct init typ=$sym.name')
 	if !short_syntax {
 		p.check(.lcbr)
 	}


### PR DESCRIPTION
This PR makes cleanup for struct short syntax processing.

- Remove useless comments.
- Correct comments of struct short syntax.
- `{key: val}` is just for map, so `foo({key: val})` is not syntax error.