### PR TITLE
Doc: hot reload section - run command example

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5590,7 +5590,9 @@ fn main() {
 ```
 
 Build this example with `v -live message.v`.
-You can also run this example with `v -live run message.v`. Make sure that in command you use a path to a V's file, **not** a path to a folder (like `v -live run .`) - in that case you need to modify content of a folder (add new file, for example), because changes in *message.v* will have no effect.
+You can also run this example with `v -live run message.v`. 
+	Make sure that in command you use a path to a V's file, **not** a path to a folder (like `v -live run .`) - 
+	in that case you need to modify content of a folder (add new file, for example), because changes in *message.v* will have no effect.
 
 Functions that you want to be reloaded must have `[live]` attribute
 before their definition.

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5590,6 +5590,7 @@ fn main() {
 ```
 
 Build this example with `v -live message.v`.
+You can also run this example with `v -live run message.v`. Make sure that in command you use a path to a V's file, **not** a path to a folder (like `v -live run .`) - in that case you need to modify content of a folder (add new file, for example), because changes in *message.v* will have no effect.
 
 Functions that you want to be reloaded must have `[live]` attribute
 before their definition.

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5590,9 +5590,12 @@ fn main() {
 ```
 
 Build this example with `v -live message.v`.
+	
 You can also run this example with `v -live run message.v`. 
-	Make sure that in command you use a path to a V's file, **not** a path to a folder (like `v -live run .`) - 
-	in that case you need to modify content of a folder (add new file, for example), because changes in *message.v* will have no effect.
+	Make sure that in command you use a path to a V's file, 
+	**not** a path to a folder (like `v -live run .`) - 
+	in that case you need to modify content of a folder (add new file, for example), 
+	because changes in *message.v* will have no effect.
 
 Functions that you want to be reloaded must have `[live]` attribute
 before their definition.


### PR DESCRIPTION
Just a small example of a `v run` command in the hot reload section of the documentation to show a difference between `v -live run message.v` and `v -live run .` commands