### PR TITLE
strconv: change atof64 to return an error, if the parsed value is not a valid number

### DIFF
--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -148,21 +148,21 @@ fn test_bin() {
 fn test_oct() {
 	x1 := 0o12
 	assert x1 == 10
-	x2 := 00000o350
+	x2 := 0o350
 	assert x2 == 232
-	x3 := 000o00073
+	x3 := 0o00073
 	assert x3 == 59
-	x4 := 00000000
+	x4 := 0
 	assert x4 == 0
-	x5 := 00000195
+	x5 := 195
 	assert x5 == 195
 	x6 := -0o744
 	assert x6 == -484
-	x7 := -000o000042
+	x7 := -0o000042
 	assert x7 == -34
-	x8 := -0000112
+	x8 := -112
 	assert x8 == -112
-	x9 := -000
+	x9 := -0
 	assert x9 == 0
 }
 

--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -148,21 +148,21 @@ fn test_bin() {
 fn test_oct() {
 	x1 := 0o12
 	assert x1 == 10
-	x2 := 0o350
+	x2 := 00000o350
 	assert x2 == 232
-	x3 := 0o00073
+	x3 := 000o00073
 	assert x3 == 59
-	x4 := 0
+	x4 := 00000000
 	assert x4 == 0
-	x5 := 195
+	x5 := 00000195
 	assert x5 == 195
 	x6 := -0o744
 	assert x6 == -484
-	x7 := -0o000042
+	x7 := -000o000042
 	assert x7 == -34
-	x8 := -112
+	x8 := -0000112
 	assert x8 == -112
-	x9 := -0
+	x9 := -000
 	assert x9 == 0
 }
 

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -511,12 +511,15 @@ pub fn (s string) i16() i16 {
 
 // f32 returns the value of the string as f32 `'1.0'.f32() == f32(1)`.
 pub fn (s string) f32() f32 {
-	return f32(strconv.atof64(s))
+	value := strconv.atof64(s) or {
+		return f32(0)
+	}
+	return f32(value)
 }
 
 // f64 returns the value of the string as f64 `'1.0'.f64() == f64(1)`.
 pub fn (s string) f64() f64 {
-	return strconv.atof64(s)
+	return strconv.atof64(s) or {return f64(0)}
 }
 
 // u8 returns the value of the string as u8 `'1'.u8() == u8(1)`.

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -511,15 +511,12 @@ pub fn (s string) i16() i16 {
 
 // f32 returns the value of the string as f32 `'1.0'.f32() == f32(1)`.
 pub fn (s string) f32() f32 {
-	value := strconv.atof64(s) or {
-		return f32(0)
-	}
-	return f32(value)
+	return f32(strconv.atof64(s) or { return 0 })
 }
 
 // f64 returns the value of the string as f64 `'1.0'.f64() == f64(1)`.
 pub fn (s string) f64() f64 {
-	return strconv.atof64(s) or {return f64(0)}
+	return strconv.atof64(s) or { return 0 }
 }
 
 // u8 returns the value of the string as u8 `'1'.u8() == u8(1)`.

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -511,12 +511,12 @@ pub fn (s string) i16() i16 {
 
 // f32 returns the value of the string as f32 `'1.0'.f32() == f32(1)`.
 pub fn (s string) f32() f32 {
-	return f32(strconv.atof64(s) or { return 0 })
+	return f32(strconv.atof64(s) or { 0 })
 }
 
 // f64 returns the value of the string as f64 `'1.0'.f64() == f64(1)`.
 pub fn (s string) f64() f64 {
-	return strconv.atof64(s) or { return 0 }
+	return strconv.atof64(s) or { 0 }
 }
 
 // u8 returns the value of the string as u8 `'1'.u8() == u8(1)`.

--- a/vlib/strconv/atof.c.v
+++ b/vlib/strconv/atof.c.v
@@ -104,6 +104,7 @@ pub const (
 	parser_mzero          = 2 // number is negative, module smaller
 	parser_pinf           = 3 // number is higher than +HUGE_VAL
 	parser_minf           = 4 // number is lower than -HUGE_VAL
+	parser_invalid_number = 5 // invalid number, used for '#@%^' for example
 	//
 	// char constants
 	// Note: Modify these if working with non-ASCII encoding
@@ -231,6 +232,9 @@ fn parser(s string) (int, PrepNumber) {
 		} else {
 			result = strconv.parser_pzero
 		}
+	}
+	if i == 0 && s.len > 0 {
+		return strconv.parser_invalid_number, pn
 	}
 	return result, pn
 }

--- a/vlib/strconv/atof.c.v
+++ b/vlib/strconv/atof.c.v
@@ -405,7 +405,7 @@ fn converter(mut pn PrepNumber) u64 {
 // atof64 return a f64 from a string doing a parsing operation
 pub fn atof64(s string) ?f64 {
 	if s.len == 0 {
-		return error('expected a number found an empity string')
+		return error('expected a number found an empty string')
 	}
 	mut pn := PrepNumber{}
 	mut res_parsing := 0
@@ -429,7 +429,7 @@ pub fn atof64(s string) ?f64 {
 			res.u = strconv.double_minus_infinity
 		}
 		else {
-			return error('conversion from string $s to f64 not possible, %s is not a number')
+			return error('not a number')
 		}
 	}
 	return unsafe { res.f }

--- a/vlib/strconv/atof.c.v
+++ b/vlib/strconv/atof.c.v
@@ -403,9 +403,9 @@ fn converter(mut pn PrepNumber) u64 {
 // Public functions
 
 // atof64 return a f64 from a string doing a parsing operation
-pub fn atof64(s string) f64 {
+pub fn atof64(s string) ?f64 {
 	if s.len == 0 {
-		return 0
+		return error('expected a number found an empity string')
 	}
 	mut pn := PrepNumber{}
 	mut res_parsing := 0
@@ -428,7 +428,9 @@ pub fn atof64(s string) f64 {
 		strconv.parser_minf {
 			res.u = strconv.double_minus_infinity
 		}
-		else {}
+		else {
+			return error('conversion from string $s to f64 not possible, %s is not a number')
+		}
 	}
 	return unsafe { res.f }
 }

--- a/vlib/strconv/atof.js.v
+++ b/vlib/strconv/atof.js.v
@@ -1,7 +1,10 @@
 module strconv
 
 // atof64 return a f64 from a string doing a parsing operation
-pub fn atof64(s string) f64 {
+pub fn atof64(s string) ?f64 {
+	// TODO: handle parsing invalid numbers as close as possible to the pure V version
+	// that may be slower, but more portable, and will guarantee that higher level code
+	// works the same in the JS version, as well as in the C and Native versions.
 	res := 0.0
 	#res.val = Number(s.str)
 

--- a/vlib/strconv/atof_test.v
+++ b/vlib/strconv/atof_test.v
@@ -75,3 +75,18 @@ fn test_atof() {
 	assert *ptr == u64(0x8000000000000000)
 	println('DONE!')
 }
+
+fn test_atof_errors() {
+	if x := strconv.atof64('') {
+		eprintln('> x: $x')
+		assert false // strconv.atof64 should have failed
+	} else {
+		assert err.str() == 'expected a number found an empty string'
+	}
+	if x := strconv.atof64('####') {
+		eprintln('> x: $x')
+		assert false // strconv.atof64 should have failed
+	} else {
+		assert err.str() == 'not a number'
+	}
+}

--- a/vlib/strconv/atof_test.v
+++ b/vlib/strconv/atof_test.v
@@ -36,7 +36,10 @@ fn test_atof() {
 	// check conversion case 1 string <=> string
 	for c, x in src_num {
 		// slow atof
-		assert strconv.atof64(src_num_str[c]).strlong() == x.strlong()
+		val := strconv.atof64(src_num_str[c]) ? or {
+			panic(err)
+		}
+		assert val.strlong() == x.strlong()
 
 		// quick atof
 		mut s1 := (strconv.atof_quick(src_num_str[c]).str())
@@ -56,7 +59,10 @@ fn test_atof() {
 	// we don't test atof_quick beacuse we already know the rounding error
 	for c, x in src_num_str {
 		b := src_num[c].strlong()
-		a1 := strconv.atof64(x).strlong()
+		value := strconv.atof64(x) ? {
+			panic(err)
+		}
+		a1 := value.strlong()
 		assert a1 == b
 	}
 

--- a/vlib/strconv/atof_test.v
+++ b/vlib/strconv/atof_test.v
@@ -36,9 +36,7 @@ fn test_atof() {
 	// check conversion case 1 string <=> string
 	for c, x in src_num {
 		// slow atof
-		val := strconv.atof64(src_num_str[c]) ? or {
-			panic(err)
-		}
+		val := strconv.atof64(src_num_str[c]) or { panic(err) }
 		assert val.strlong() == x.strlong()
 
 		// quick atof
@@ -59,9 +57,7 @@ fn test_atof() {
 	// we don't test atof_quick beacuse we already know the rounding error
 	for c, x in src_num_str {
 		b := src_num[c].strlong()
-		value := strconv.atof64(x) ? {
-			panic(err)
-		}
+		value := strconv.atof64(x) or { panic(err) }
 		a1 := value.strlong()
 		assert a1 == b
 	}

--- a/vlib/v/eval/expr.v
+++ b/vlib/v/eval/expr.v
@@ -191,9 +191,7 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 			}) // TODO: numbers larger than 2^63 (for u64)
 		}
 		ast.FloatLiteral {
-			return f64(strconv.atof64(expr.val) or {
-				e.error(err.str())
-			})
+			return f64(strconv.atof64(expr.val) or { e.error(err.str()) })
 		}
 		ast.BoolLiteral {
 			return expr.val

--- a/vlib/v/eval/expr.v
+++ b/vlib/v/eval/expr.v
@@ -191,7 +191,9 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 			}) // TODO: numbers larger than 2^63 (for u64)
 		}
 		ast.FloatLiteral {
-			return f64(strconv.atof64(expr.val))
+			return f64(strconv.atof64(expr.val) or {
+				e.error(err.str())
+			})
 		}
 		ast.BoolLiteral {
 			return expr.val


### PR DESCRIPTION
Fixes https://github.com/vlang/v/issues/13417

Maybe it is also a good moment to move all this conversion to the same API with a result?

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
