### PR TITLE
cgen: fix struct init with embed field update (fix #10588)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -409,6 +409,7 @@ pub mut:
 	update_expr          Expr
 	update_expr_type     Type
 	update_expr_comments []Comment
+	is_update_embed      bool
 	has_update_expr      bool
 	fields               []StructInitField
 	embeds               []StructInitEmbed

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5456,6 +5456,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 					default_init := ast.StructInit{
 						...node
 						typ: embed
+						is_update_embed: true
 						fields: init_fields_to_embed
 					}
 					inside_cast_in_heap := g.inside_cast_in_heap
@@ -5556,6 +5557,16 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 					g.write('->')
 				} else {
 					g.write('.')
+				}
+				if node.is_update_embed {
+					embed_sym := g.table.sym(node.typ)
+					embed_name := embed_sym.embed_name()
+					g.write(embed_name)
+					if node.typ.is_ptr() {
+						g.write('->')
+					} else {
+						g.write('.')
+					}
 				}
 				g.write(field.name)
 			} else {

--- a/vlib/v/tests/struct_init_with_embed_update_test.v
+++ b/vlib/v/tests/struct_init_with_embed_update_test.v
@@ -1,0 +1,32 @@
+struct Button {
+	width  int
+	height int
+}
+
+enum Color {
+	red
+	blue
+	yellow
+}
+
+struct ColoredButton {
+	Button
+	color Color
+}
+
+fn change_color(cb ColoredButton, color Color) ColoredButton {
+	return ColoredButton{
+		...cb
+		color: color
+	}
+}
+
+fn test_struct_update_with_embed_field() {
+	red_button := ColoredButton{Button{100, 100}, .red}
+	blue_button := change_color(red_button, .blue)
+
+	println(red_button)
+	println(blue_button)
+
+	assert blue_button == ColoredButton{Button{100, 100}, .blue}
+}


### PR DESCRIPTION
This PR fix struct init with embed field update (fix #10588).

- Fix struct init with embed field update.
- Add test.

```vlang
struct Button {
	width  int
	height int
}

enum Color {
	red
	blue
	yellow
}

struct ColoredButton {
	Button
	color Color
}

fn change_color(cb ColoredButton, color Color) ColoredButton {
	return ColoredButton{
		...cb
		color: color
	}
}

fn main() {
	red_button := ColoredButton{Button{100, 100}, .red}
	blue_button := change_color(red_button, .blue)
	
	println(red_button)
	println(blue_button)

	assert blue_button == ColoredButton{Button{100, 100}, .blue}
}

PS D:\Test\v\tt1> v run .
ColoredButton{
    Button: Button{
        width: 100
        height: 100
    }
    color: red
}
ColoredButton{
    Button: Button{
        width: 100
        height: 100
    }
    color: blue
}
```