### PR TITLE
checker, cgen: fix error for struct embed with fn type (fix #11520)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1422,7 +1422,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	}
 	// call struct field fn type
 	// TODO: can we use SelectorExpr for all? this dosent really belong here
-	if field := c.table.find_field(left_sym, method_name) {
+	if field := c.table.find_field_with_embeds(left_sym, method_name) {
 		field_sym := c.table.sym(c.unwrap_generic(field.typ))
 		if field_sym.kind == .function {
 			node.is_method = false
@@ -1451,6 +1451,9 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 			}
 			node.expected_arg_types = earg_types
 			node.is_method = true
+			_, node.from_embed_types = c.table.find_field_from_embeds(left_sym, method_name) or {
+				return info.func.return_type
+			}
 			return info.func.return_type
 		}
 	}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1118,6 +1118,16 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 		} else {
 			g.write('.')
 		}
+		for embed in node.from_embed_types {
+			embed_sym := g.table.sym(embed)
+			embed_name := embed_sym.embed_name()
+			g.write(embed_name)
+			if embed.is_ptr() {
+				g.write('->')
+			} else {
+				g.write('.')
+			}
+		}
 		is_selector_call = true
 	}
 	if g.inside_comptime_for_field {

--- a/vlib/v/tests/struct_embed_fn_type_test.v
+++ b/vlib/v/tests/struct_embed_fn_type_test.v
@@ -1,0 +1,29 @@
+type FnClick = fn () string
+
+struct Widget {
+mut:
+	x     int
+	y     int
+	click FnClick = click
+}
+
+fn click() string {
+	return 'click me'
+}
+
+struct Button {
+	Widget
+	title string
+}
+
+fn test_struct_embed_fn_type() {
+	mut button := Button{
+		title: 'Click me'
+	}
+
+	button.x = 3
+	ret := button.click()
+
+	println(ret)
+	assert ret == 'click me'
+}


### PR DESCRIPTION
This PR fix error for struct embed with fn type (fix #11520).

- Fix error for struct embed with fn type.
- Add test.

```vlang
type FnClick = fn () string

struct Widget {
mut:
	x     int
	y     int
	click FnClick = click
}

fn click() string {
	return 'click me'
}

struct Button {
	Widget
	title string
}

fn main() {
	mut button := Button{
		title: 'Click me'
	}

	button.x = 3
	ret := button.click()

	println(ret)
	assert ret == 'click me'
}

PS D:\Test\v\tt1> v run .
click me
```