### PR TITLE
ast: fix error for struct embedding with interface (fix #13411)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1293,14 +1293,7 @@ pub fn (mut t Table) complete_interface_check() {
 		if tsym.kind != .struct_ {
 			continue
 		}
-		info := tsym.info as Struct
 		for _, mut idecl in t.interfaces {
-			if idecl.methods.len > tsym.methods.len {
-				continue
-			}
-			if idecl.fields.len > info.fields.len {
-				continue
-			}
 			if idecl.typ == 0 {
 				continue
 			}

--- a/vlib/v/tests/struct_embedding_with_interface_test.v
+++ b/vlib/v/tests/struct_embedding_with_interface_test.v
@@ -1,0 +1,60 @@
+fn test_struct_embedding_with_interface() {
+	mut ll := LinearLayout{}
+	mut lv := ListView{}
+	ll.add(lv)
+	ret := ll.layout()
+
+	println(ret)
+	assert ret.count('ListView') == 2
+}
+
+interface Container {
+mut:
+	layout() string
+}
+
+interface Layoutable {
+	get_pos() (int, int)
+mut:
+	set_pos(int, int)
+}
+
+pub struct LayouterBase {
+mut:
+	layoutables []Layoutable
+}
+
+pub fn (mut lb LayouterBase) add(layoutable Layoutable) {
+	lb.layoutables << layoutable
+}
+
+pub fn (lb LayouterBase) get_pos() (int, int) {
+	return 0, 0
+}
+
+pub fn (mut lb LayouterBase) set_pos(x int, y int) {}
+
+pub struct LinearLayout {
+	LayouterBase
+}
+
+pub fn (mut ll LinearLayout) layout() string {
+	mut output := ''
+	for mut l in ll.layoutables {
+		dump(l.type_name())
+		output += '$l.type_name()\n'
+		if l is Container {
+			dump(l.type_name())
+			output += '$l.type_name()\n'
+		}
+	}
+	return output
+}
+
+pub struct ListView {
+	LayouterBase
+}
+
+pub fn (mut lv ListView) layout() string {
+	return ''
+}


### PR DESCRIPTION
This PR fix error for struct embedding with interface (fix #13411).

- Fix error for struct embedding with interface.
- Add test.

```vlang
fn main() {
	mut ll := LinearLayout{}
	mut lv := ListView{}
	ll.add(lv)
	ret := ll.layout()

	println(ret)
	assert ret.count('ListView') == 2
}

interface Container {
mut:
	layout() string
}

interface Layoutable {
	get_pos() (int, int)
mut:
	set_pos(int, int)
}

pub struct LayouterBase {
mut:
	layoutables []Layoutable
}

pub fn (mut lb LayouterBase) add(layoutable Layoutable) {
	lb.layoutables << layoutable
}

pub fn (lb LayouterBase) get_pos() (int, int) {
	return 0, 0
}

pub fn (mut lb LayouterBase) set_pos(x int, y int) {}

pub struct LinearLayout {
	LayouterBase
}

pub fn (mut ll LinearLayout) layout() string {
	mut output := ''
	for mut l in ll.layoutables {
		dump(l.type_name())
		output += '$l.type_name()\n'
		if l is Container {
			dump(l.type_name())
			output += '$l.type_name()\n'
		}
	}
	return output
}

pub struct ListView {
	LayouterBase
}

pub fn (mut lv ListView) layout() string {
	return ''
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:44] l.type_name(): ListView
[.\\tt1.v:47] l.type_name(): ListView
ListView
ListView
```