### PR TITLE
ast: fix error for 'struct embed is interface'  (fix #13306)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1384,7 +1384,7 @@ pub fn (t Table) does_type_implement_interface(typ Type, inter_typ Type) bool {
 		}
 		// verify methods
 		for imethod in inter_sym.info.methods {
-			if method := sym.find_method(imethod.name) {
+			if method := t.find_method_with_embeds(sym, imethod.name) {
 				msg := t.is_same_method(imethod, method)
 				if msg.len > 0 {
 					return false

--- a/vlib/v/tests/struct_embed_is_interface_test.v
+++ b/vlib/v/tests/struct_embed_is_interface_test.v
@@ -1,0 +1,53 @@
+pub struct Base {
+mut:
+	x int
+	y int
+}
+
+pub fn (mut b Base) init() {}
+
+pub fn (b Base) get_pos() (int, int) {
+	return b.x, b.y
+}
+
+pub struct Label {
+	Base
+}
+
+pub interface Widget {
+mut:
+	init()
+}
+
+pub interface Layoutable {
+	get_pos() (int, int)
+}
+
+pub struct Layout {
+	Base
+mut:
+	widgets []Widget
+}
+
+pub fn (mut l Layout) layout() {
+	for wd in l.widgets {
+		if wd is Layoutable {
+			lw := wd as Layoutable
+			dump(lw.get_pos())
+			x, y := lw.get_pos()
+			assert x == 10
+			assert y == 20
+		} else {
+			println('wd is NOT Layoutable')
+		}
+	}
+}
+
+fn test_struct_embed_is_interface() {
+	mut l := Layout{}
+	l.widgets << Label{
+		x: 10
+		y: 20
+	}
+	l.layout()
+}


### PR DESCRIPTION
This PR fix error for 'struct embed is interface'  (fix #13306).

- Fix error for 'struct embed is interface'.
- Add test.

```vlang
pub struct Base {
mut:
	x int
	y int
}

pub fn (mut b Base) init() {}

pub fn (b Base) get_pos() (int, int) {
	return b.x, b.y
}

pub struct Label {
	Base
}

pub interface Widget {
mut:
	init()
}

pub interface Layoutable {
	get_pos() (int, int)
}

pub struct Layout {
	Base
mut:
	widgets []Widget
}

pub fn (mut l Layout) layout() {
	for wd in l.widgets {
		if wd is Layoutable {
			lw := wd as Layoutable
			dump(lw.get_pos())
			x, y := lw.get_pos()
			assert x == 10
			assert y == 20
		} else {
			println('wd is NOT Layoutable')
		}
	}
}

fn main() {
	mut l := Layout{}
	l.widgets << Label{
		x: 10
		y: 20
	}
	l.layout()
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:36] lw.get_pos(): (10, 20)
```