### PR TITLE
ast: fix error for interface embedding call (fix #12766)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -426,6 +426,26 @@ pub fn (t &Table) find_method_from_embeds(sym &TypeSymbol, method_name string) ?
 		} else if found_methods.len > 1 {
 			return error('ambiguous method `$method_name`')
 		}
+	} else if sym.info is Interface {
+		mut found_methods := []Fn{}
+		mut embed_of_found_methods := []Type{}
+		for embed in sym.info.ifaces {
+			embed_sym := t.sym(embed)
+			if m := t.find_method(embed_sym, method_name) {
+				found_methods << m
+				embed_of_found_methods << embed
+			} else {
+				method, types := t.find_method_from_embeds(embed_sym, method_name) or { continue }
+				found_methods << method
+				embed_of_found_methods << embed
+				embed_of_found_methods << types
+			}
+		}
+		if found_methods.len == 1 {
+			return found_methods[0], embed_of_found_methods
+		} else if found_methods.len > 1 {
+			return error('ambiguous method `$method_name`')
+		}
 	} else if sym.info is Aggregate {
 		for typ in sym.info.types {
 			agg_sym := t.sym(typ)

--- a/vlib/v/tests/interface_embedding_call_test.v
+++ b/vlib/v/tests/interface_embedding_call_test.v
@@ -1,0 +1,26 @@
+module main
+
+fn test_interface_embedding_call() {
+	g1 := G1{}
+	do_the_greet(g1)
+}
+
+struct G1 {}
+
+fn (g G1) greet() string {
+	return 'hello from G1'
+}
+
+fn do_the_greet(g ParentGreeter) {
+	greet := g.greet()
+	println('Someone says: $greet')
+	assert greet == 'hello from G1'
+}
+
+interface ParentGreeter {
+	Greeter
+}
+
+interface Greeter {
+	greet() string
+}


### PR DESCRIPTION
This PR fix error for interface embedding call (fix #12766).

- Fix error for interface embedding call.
- Add test.

```vlang
module main

fn main() {
	g1 := G1{}
	do_the_greet(g1)
}

struct G1 {}

fn (g G1) greet() string {
	return 'hello from G1'
}

fn do_the_greet(g ParentGreeter) {
	greet := g.greet()
	println('Someone says: $greet')
	assert greet == 'hello from G1'
}

interface ParentGreeter {
	Greeter
}

interface Greeter {
	greet() string
}

PS D:\Test\v\tt1> v run .
Someone says: hello from G1
```