### PR TITLE
strings: add find_between_pair

### DIFF
--- a/vlib/strings/strings.v
+++ b/vlib/strings/strings.v
@@ -11,3 +11,116 @@ pub fn random(n int) string {
 	return tos(buf)
 }
 */
+
+pub type Mark = byte | rune | string
+
+fn find_between_pair_byte(input string, start byte, end byte) string {
+	mut marks := 0
+	mut start_index := -1
+	for i, b in input {
+		if b == start {
+			if start_index == -1 {
+				start_index = i + 1
+			}
+			marks++
+			continue
+		}
+		if start_index > 0 {
+			if b == end {
+				marks--
+				if marks == 0 {
+					return input[start_index..i]
+				}
+			}
+		}
+	}
+	return ''
+}
+
+fn find_between_pair_rune(input string, start rune, end rune) string {
+	mut marks := 0
+	mut start_index := -1
+	runes := input.runes()
+	for i, r in runes {
+		if r == start {
+			if start_index == -1 {
+				start_index = i + 1
+			}
+			marks++
+			continue
+		}
+		if start_index > 0 {
+			if r == end {
+				marks--
+				if marks == 0 {
+					return runes[start_index..i].string()
+				}
+			}
+		}
+	}
+	return ''
+}
+
+fn find_between_pair_string(input string, start string, end string) string {
+	mut start_index := -1
+	mut marks := 0
+	start_runes := start.runes()
+	end_runes := end.runes()
+	runes := input.runes()
+	mut i := 0
+	for ; i < runes.len; i++ {
+		start_slice := runes#[i..i + start_runes.len]
+		if start_slice == start_runes {
+			i = i + start_runes.len - 1
+			if start_index < 0 {
+				start_index = i + 1
+			}
+			marks++
+			continue
+		}
+		if start_index > 0 {
+			end_slice := runes#[i..i + end_runes.len]
+			if end_slice == end_runes {
+				marks--
+				if marks == 0 {
+					return runes[start_index..i].string()
+				}
+				i = i + end_runes.len - 1
+				continue
+			}
+		}
+	}
+	return ''
+}
+
+// find_between_pair returns the string found between the pair of marks defined
+// by `start` and `end`.
+// As opposed to the `find_between`, `all_after*`, `all_before*` methods defined on the
+// `string` type, this function can extract content between *nested* marks in `input`.
+// If `start` and `end` marks are nested in `input` the characters
+// between the *outermost* mark pair is returned. It is expected that `start` and `end`
+// marks are *balanced*, meaning that both `start` and `end` are of the same type **and**
+// the amount of `start` marks equal the amount of `end` marks in the `input`.
+// An empty string is returned otherwise. Using two identical marks as `start` and `end`
+// results in undefined output behavior.
+// find_between_pair works the fastest with marks of type `byte`
+// find_between_pair works the slowest with marks of type `string`
+// find_between_pair works at speeds inbetween with marks of type `rune`
+// Example: assert strings.find_between_pair('/* /*V*/ */','/*','*/') == 'V'
+// Example: assert strings.find_between_pair('s {X}',`{`,`}`) == 'X'
+pub fn find_between_pair(input string, start Mark, end Mark) string {
+	if input == '' {
+		return ''
+	}
+	return match start {
+		byte {
+			find_between_pair_byte(input, start, end as byte)
+		}
+		rune {
+			find_between_pair_rune(input, start, end as rune)
+		}
+		string {
+			find_between_pair_string(input, start, end as string)
+		}
+	}
+}

--- a/vlib/strings/strings.v
+++ b/vlib/strings/strings.v
@@ -106,8 +106,8 @@ fn find_between_pair_string(input string, start string, end string) string {
 // find_between_pair works the fastest with marks of type `byte`
 // find_between_pair works the slowest with marks of type `string`
 // find_between_pair works at speeds inbetween with marks of type `rune`
-// Example: assert strings.find_between_pair('/* /*V*/ */','/*','*/') == 'V'
-// Example: assert strings.find_between_pair('s {X}',`{`,`}`) == 'X'
+// Example: assert strings.find_between_pair('/*V*/ /*NOT V*/','/*','*/') == 'V'
+// Example: assert strings.find_between_pair('s {X{Y}} s',`{`,`}`) == 'X{Y}'
 pub fn find_between_pair(input string, start Mark, end Mark) string {
 	if input == '' {
 		return ''

--- a/vlib/strings/strings.v
+++ b/vlib/strings/strings.v
@@ -12,9 +12,20 @@ pub fn random(n int) string {
 }
 */
 
-pub type Mark = byte | rune | string
-
-fn find_between_pair_byte(input string, start byte, end byte) string {
+// find_between_pair_byte returns the string found between the pair of marks defined
+// by `start` and `end`.
+// As opposed to the `find_between`, `all_after*`, `all_before*` methods defined on the
+// `string` type, this function can extract content between *nested* marks in `input`.
+// If `start` and `end` marks are nested in `input`, the characters
+// between the *outermost* mark pair is returned. It is expected that `start` and `end`
+// marks are *balanced*, meaning that both `start` and `end` are of the same type **and**
+// the amount of `start` marks equal the amount of `end` marks in the `input`.
+// An empty string is returned otherwise. Using two identical marks as `start` and `end`
+// results in undefined output behavior.
+// find_between_pair_byte is the fastest in the find_between_pair_* family of functions.
+// Example: assert strings.find_between_pair_byte('(V) (NOT V)',`(`,`)`) == 'V'
+// Example: assert strings.find_between_pair_byte('s {X{Y}} s',`{`,`}`) == 'X{Y}'
+pub fn find_between_pair_byte(input string, start byte, end byte) string {
 	mut marks := 0
 	mut start_index := -1
 	for i, b in input {
@@ -37,7 +48,20 @@ fn find_between_pair_byte(input string, start byte, end byte) string {
 	return ''
 }
 
-fn find_between_pair_rune(input string, start rune, end rune) string {
+// find_between_pair_rune returns the string found between the pair of marks defined
+// by `start` and `end`.
+// As opposed to the `find_between`, `all_after*`, `all_before*` methods defined on the
+// `string` type, this function can extract content between *nested* marks in `input`.
+// If `start` and `end` marks are nested in `input`, the characters
+// between the *outermost* mark pair is returned. It is expected that `start` and `end`
+// marks are *balanced*, meaning that both `start` and `end` are of the same type **and**
+// the amount of `start` marks equal the amount of `end` marks in the `input`.
+// An empty string is returned otherwise. Using two identical marks as `start` and `end`
+// results in undefined output behavior.
+// find_between_pair_rune is inbetween the fastest and slowest in the find_between_pair_* family of functions.
+// Example: assert strings.find_between_pair_rune('(V) (NOT V)',`(`,`)`) == 'V'
+// Example: assert strings.find_between_pair_rune('s {X{Y}} s',`{`,`}`) == 'X{Y}'
+pub fn find_between_pair_rune(input string, start rune, end rune) string {
 	mut marks := 0
 	mut start_index := -1
 	runes := input.runes()
@@ -61,7 +85,20 @@ fn find_between_pair_rune(input string, start rune, end rune) string {
 	return ''
 }
 
-fn find_between_pair_string(input string, start string, end string) string {
+// find_between_pair_string returns the string found between the pair of marks defined
+// by `start` and `end`.
+// As opposed to the `find_between`, `all_after*`, `all_before*` methods defined on the
+// `string` type, this function can extract content between *nested* marks in `input`.
+// If `start` and `end` marks are nested in `input`, the characters
+// between the *outermost* mark pair is returned. It is expected that `start` and `end`
+// marks are *balanced*, meaning that both `start` and `end` are of the same type **and**
+// the amount of `start` marks equal the amount of `end` marks in the `input`.
+// An empty string is returned otherwise. Using two identical marks as `start` and `end`
+// results in undefined output behavior.
+// find_between_pair_string is the slowest in the find_between_pair_* function family.
+// Example: assert strings.find_between_pair_string('/*V*/ /*NOT V*/','/*','*/') == 'V'
+// Example: assert strings.find_between_pair_string('s {{X{{Y}}}} s','{{','}}') == 'X{{Y}}'
+pub fn find_between_pair_string(input string, start string, end string) string {
 	mut start_index := -1
 	mut marks := 0
 	start_runes := start.runes()
@@ -91,36 +128,4 @@ fn find_between_pair_string(input string, start string, end string) string {
 		}
 	}
 	return ''
-}
-
-// find_between_pair returns the string found between the pair of marks defined
-// by `start` and `end`.
-// As opposed to the `find_between`, `all_after*`, `all_before*` methods defined on the
-// `string` type, this function can extract content between *nested* marks in `input`.
-// If `start` and `end` marks are nested in `input` the characters
-// between the *outermost* mark pair is returned. It is expected that `start` and `end`
-// marks are *balanced*, meaning that both `start` and `end` are of the same type **and**
-// the amount of `start` marks equal the amount of `end` marks in the `input`.
-// An empty string is returned otherwise. Using two identical marks as `start` and `end`
-// results in undefined output behavior.
-// find_between_pair works the fastest with marks of type `byte`
-// find_between_pair works the slowest with marks of type `string`
-// find_between_pair works at speeds inbetween with marks of type `rune`
-// Example: assert strings.find_between_pair('/*V*/ /*NOT V*/','/*','*/') == 'V'
-// Example: assert strings.find_between_pair('s {X{Y}} s',`{`,`}`) == 'X{Y}'
-pub fn find_between_pair(input string, start Mark, end Mark) string {
-	if input == '' {
-		return ''
-	}
-	return match start {
-		byte {
-			find_between_pair_byte(input, start, end as byte)
-		}
-		rune {
-			find_between_pair_rune(input, start, end as rune)
-		}
-		string {
-			find_between_pair_string(input, start, end as string)
-		}
-	}
 }

--- a/vlib/strings/strings.v
+++ b/vlib/strings/strings.v
@@ -18,10 +18,9 @@ pub fn random(n int) string {
 // `string` type, this function can extract content between *nested* marks in `input`.
 // If `start` and `end` marks are nested in `input`, the characters
 // between the *outermost* mark pair is returned. It is expected that `start` and `end`
-// marks are *balanced*, meaning that both `start` and `end` are of the same type **and**
-// the amount of `start` marks equal the amount of `end` marks in the `input`.
-// An empty string is returned otherwise. Using two identical marks as `start` and `end`
-// results in undefined output behavior.
+// marks are *balanced*, meaning that the amount of `start` marks equal the
+// amount of `end` marks in the `input`. An empty string is returned otherwise.
+// Using two identical marks as `start` and `end` results in undefined output behavior.
 // find_between_pair_byte is the fastest in the find_between_pair_* family of functions.
 // Example: assert strings.find_between_pair_byte('(V) (NOT V)',`(`,`)`) == 'V'
 // Example: assert strings.find_between_pair_byte('s {X{Y}} s',`{`,`}`) == 'X{Y}'
@@ -54,10 +53,9 @@ pub fn find_between_pair_byte(input string, start byte, end byte) string {
 // `string` type, this function can extract content between *nested* marks in `input`.
 // If `start` and `end` marks are nested in `input`, the characters
 // between the *outermost* mark pair is returned. It is expected that `start` and `end`
-// marks are *balanced*, meaning that both `start` and `end` are of the same type **and**
-// the amount of `start` marks equal the amount of `end` marks in the `input`.
-// An empty string is returned otherwise. Using two identical marks as `start` and `end`
-// results in undefined output behavior.
+// marks are *balanced*, meaning that the amount of `start` marks equal the
+// amount of `end` marks in the `input`. An empty string is returned otherwise.
+// Using two identical marks as `start` and `end` results in undefined output behavior.
 // find_between_pair_rune is inbetween the fastest and slowest in the find_between_pair_* family of functions.
 // Example: assert strings.find_between_pair_rune('(V) (NOT V)',`(`,`)`) == 'V'
 // Example: assert strings.find_between_pair_rune('s {X{Y}} s',`{`,`}`) == 'X{Y}'
@@ -91,10 +89,9 @@ pub fn find_between_pair_rune(input string, start rune, end rune) string {
 // `string` type, this function can extract content between *nested* marks in `input`.
 // If `start` and `end` marks are nested in `input`, the characters
 // between the *outermost* mark pair is returned. It is expected that `start` and `end`
-// marks are *balanced*, meaning that both `start` and `end` are of the same type **and**
-// the amount of `start` marks equal the amount of `end` marks in the `input`.
-// An empty string is returned otherwise. Using two identical marks as `start` and `end`
-// results in undefined output behavior.
+// marks are *balanced*, meaning that the amount of `start` marks equal the
+// amount of `end` marks in the `input`. An empty string is returned otherwise.
+// Using two identical marks as `start` and `end` results in undefined output behavior.
 // find_between_pair_string is the slowest in the find_between_pair_* function family.
 // Example: assert strings.find_between_pair_string('/*V*/ /*NOT V*/','/*','*/') == 'V'
 // Example: assert strings.find_between_pair_string('s {{X{{Y}}}} s','{{','}}') == 'X{{Y}}'

--- a/vlib/strings/strings_test.v
+++ b/vlib/strings/strings_test.v
@@ -13,7 +13,7 @@ fn test_repeat_string() {
 	assert strings.repeat_string('', 200) == ''
 }
 
-const test_runes = [
+const test_rune_and_byte = [
 	'xxx[ok1]xxx',
 	'xxx[[ok2]okok]',
 	'xxx[ok3[[[ok]okok]]]',
@@ -41,7 +41,7 @@ const test_strings = [
 	xxx*/xxx',
 ]
 
-const expected_rune_outputs = [
+const expected_rune_and_byte_outputs = [
 	'ok1',
 	'[ok2]okok',
 	'ok3[[[ok]okok]]',
@@ -69,21 +69,27 @@ const expected_string_outputs = [
 	xxx',
 ]
 
-fn test_find_between_pair() {
-	assert strings.find_between_pair('xx♡ok❦yy', `♡`, `❦`) == 'ok'
-	assert strings.find_between_pair('xx{ok}yy', byte(`{`), byte(`}`)) == 'ok'
-	assert strings.find_between_pair('xx/*ok*/yy', '/*', '*/') == 'ok'
-	assert strings.find_between_pair('xx{ok}yy', `{`, `}`) == 'ok'
-	assert strings.find_between_pair('xxxxokyyyy', 'xxx', 'yyy') == 'xok'
+fn test_find_between_pair_family() {
+	assert strings.find_between_pair_rune('xx♡ok❦yy', `♡`, `❦`) == 'ok'
+	assert strings.find_between_pair_byte('xx{ok}yy', `{`, `}`) == 'ok'
+	assert strings.find_between_pair_string('xx/*ok*/yy', '/*', '*/') == 'ok'
+	assert strings.find_between_pair_byte('xx{ok}yy', `{`, `}`) == 'ok'
+	assert strings.find_between_pair_string('xxxxokyyyy', 'xxx', 'yyy') == 'xok'
 
-	for i, tstr in test_runes {
-		e1 := strings.find_between_pair(tstr, `[`, `]`)
-		e2 := expected_rune_outputs[i]
+	for i, tstr in test_rune_and_byte {
+		e1 := strings.find_between_pair_rune(tstr, `[`, `]`)
+		e2 := expected_rune_and_byte_outputs[i]
+		assert '$e1' == '$e2'
+	}
+
+	for i, tstr in test_rune_and_byte {
+		e1 := strings.find_between_pair_byte(tstr, `[`, `]`)
+		e2 := expected_rune_and_byte_outputs[i]
 		assert '$e1' == '$e2'
 	}
 
 	for i, tstr in test_strings {
-		e1 := strings.find_between_pair(tstr, '/*', '*/')
+		e1 := strings.find_between_pair_string(tstr, '/*', '*/')
 		e2 := expected_string_outputs[i]
 		assert '$e1' == '$e2'
 	}

--- a/vlib/strings/strings_test.v
+++ b/vlib/strings/strings_test.v
@@ -12,3 +12,79 @@ fn test_repeat_string() {
 	assert strings.repeat_string('abc', 0) == ''
 	assert strings.repeat_string('', 200) == ''
 }
+
+const test_runes = [
+	'xxx[ok1]xxx',
+	'xxx[[ok2]okok]',
+	'xxx[ok3[[[ok]okok]]]',
+	'yyy[ok4]',
+	'[]',
+	']',
+	'[',
+	'yyy[ok5][]zzz',
+	'yyy[xxx',
+	'xxx[xxx
+	xxx]',
+]
+
+const test_strings = [
+	'xxx/*ok1*/xxx',
+	'xxx/*/*ok2*/okok*/',
+	'xxx/*ok3/*/*/*ok*/okok*/*/*/',
+	'yyy/*ok4*/',
+	'/**/',
+	'*/',
+	'/*',
+	'yyy/*ok5*//**/zzz',
+	'yyy/*xxx',
+	'xxx/*xxx
+	xxx*/xxx',
+]
+
+const expected_rune_outputs = [
+	'ok1',
+	'[ok2]okok',
+	'ok3[[[ok]okok]]',
+	'ok4',
+	'',
+	'',
+	'',
+	'ok5',
+	'',
+	'xxx
+	xxx',
+]
+
+const expected_string_outputs = [
+	'ok1',
+	'/*ok2*/okok',
+	'ok3/*/*/*ok*/okok*/*/',
+	'ok4',
+	'',
+	'',
+	'',
+	'ok5',
+	'',
+	'xxx
+	xxx',
+]
+
+fn test_find_between_pair() {
+	assert strings.find_between_pair('xx♡ok❦yy', `♡`, `❦`) == 'ok'
+	assert strings.find_between_pair('xx{ok}yy', byte(`{`), byte(`}`)) == 'ok'
+	assert strings.find_between_pair('xx/*ok*/yy', '/*', '*/') == 'ok'
+	assert strings.find_between_pair('xx{ok}yy', `{`, `}`) == 'ok'
+	assert strings.find_between_pair('xx{ok}yy', `{`, `}`) == 'ok'
+
+	for i, tstr in test_runes {
+		e1 := strings.find_between_pair(tstr, `[`, `]`)
+		e2 := expected_rune_outputs[i]
+		assert '$e1' == '$e2'
+	}
+
+	for i, tstr in test_strings {
+		e1 := strings.find_between_pair(tstr, '/*', '*/')
+		e2 := expected_string_outputs[i]
+		assert '$e1' == '$e2'
+	}
+}

--- a/vlib/strings/strings_test.v
+++ b/vlib/strings/strings_test.v
@@ -74,7 +74,7 @@ fn test_find_between_pair() {
 	assert strings.find_between_pair('xx{ok}yy', byte(`{`), byte(`}`)) == 'ok'
 	assert strings.find_between_pair('xx/*ok*/yy', '/*', '*/') == 'ok'
 	assert strings.find_between_pair('xx{ok}yy', `{`, `}`) == 'ok'
-	assert strings.find_between_pair('xx{ok}yy', byte(`{`), byte(`}`)) == 'ok'
+	assert strings.find_between_pair('xxxxokyyyy', 'xxx', 'yyy') == 'xok'
 
 	for i, tstr in test_runes {
 		e1 := strings.find_between_pair(tstr, `[`, `]`)

--- a/vlib/strings/strings_test.v
+++ b/vlib/strings/strings_test.v
@@ -74,7 +74,7 @@ fn test_find_between_pair() {
 	assert strings.find_between_pair('xx{ok}yy', byte(`{`), byte(`}`)) == 'ok'
 	assert strings.find_between_pair('xx/*ok*/yy', '/*', '*/') == 'ok'
 	assert strings.find_between_pair('xx{ok}yy', `{`, `}`) == 'ok'
-	assert strings.find_between_pair('xx{ok}yy', `{`, `}`) == 'ok'
+	assert strings.find_between_pair('xx{ok}yy', byte(`{`), byte(`}`)) == 'ok'
 
 	for i, tstr in test_runes {
 		e1 := strings.find_between_pair(tstr, `[`, `]`)


### PR DESCRIPTION
This PR adds a function I've personally missed a lot while working with strings in V. It introduces a way to extract content between two marks in a string in a "balanced" way. It makes it possible to extract "block" or "scope" content in a way that is currently not possible with either of the `find_between`, `all_after*`, `all_before*` methods defined on the `string` type.

My personal use case has been mostly to extract blocks of `enum` or `struct` contents from C (and V) code.
E.g. getting the contents between the opening `{` and closing `}` of the `SDL_RWops` struct in the following was not easy before without extensive parsing (or position/format hacks):
```c
typedef struct SDL_RWops
{
...
    int (SDLCALL * close) (struct SDL_RWops * context);
    Uint32 type;
    union
    {
#if defined(__ANDROID__)
        struct
        {
            void *fileNameRef;
            void *inputStreamRef;
            ...
            int fd;
        } androidio;
#elif defined(__WIN32__)
        struct
        {
            SDL_bool append;
            void *h;
            struct
            {
                ...
            } buffer;
        } windowsio;
#endif
        struct
        {
            void *data1;
            void *data2;
        } unknown;
    } hidden;
} SDL_RWops;
```
It's also good for things like (nested) block comments:
```c
/*
 /* hello */
*/
```

... and for grabbing various parts of V function signatures like:
`fn fn_with_anon_fn(i int, callback fn (num int, s string))` <- arguments can be grabbed quickly (including the callback signature) with:
`arg_str := strings.find_between_pair(signature,'(',')') // i int, callback fn (num int, s string) ` 

I decided to use a sumtype as mark types as both the performance **and** use-cases differ for the three types I've had use for:
(10000 iterations)
![image](https://user-images.githubusercontent.com/768942/153876402-84cf6057-ab14-464e-a34e-cf8ace815b48.png)

The benchmark I've used is included here: [bmark_find_between_pair.zip](https://github.com/vlang/v/files/8061225/bmark_find_between_pair.zip)

I guess it can be discussed what results should be if the input/marks is "unbalanced"/missing marks/uneven/the same:
I.e what should the result be in the following input cases?:
`strings.find_between_pair('( blank ( or full ( or half of it','(','') == ??`
`strings.find_between_pair('* this part * or this *','*','*') == ??`
These can be decided later on - right now these will result in blank or "undefined" (untested) return output.