### PR TITLE
builder: clang fails to link on windows due to an -ftlo error

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -234,7 +234,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 		}
 		optimization_options = ['-O3']
 		mut have_flto := true
-		$if openbsd || windows{
+		$if openbsd || windows {
 			have_flto = false
 		}
 		if have_flto {

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -234,7 +234,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 		}
 		optimization_options = ['-O3']
 		mut have_flto := true
-		$if openbsd {
+		$if openbsd || windows{
 			have_flto = false
 		}
 		if have_flto {


### PR DESCRIPTION
the cmd ` v -cc clang -prod .` will fail with the error:
```
clang: error: 'x86_64-w64-windows-gnu': unable to pass LLVM bit-code files to linker
```
on windows for any V project fails without this patch.

