### PR TITLE
cgen: fix interface embedding complex cases (fix #13467)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5536,7 +5536,7 @@ static inline __shared__$interface_name ${shared_fn_name}(__shared__$cctype* x) 
 			}
 			t_methods := g.table.get_embed_methods(st_sym)
 			for t_method in t_methods {
-				if t_method.name !in method_names {
+				if t_method.name !in methods.map(it.name) {
 					methods << t_method
 				}
 			}

--- a/vlib/v/tests/interface_embedding_complex_test.v
+++ b/vlib/v/tests/interface_embedding_complex_test.v
@@ -1,0 +1,57 @@
+fn test_interface_embedding_complex() {
+	mut win := &Window{}
+	ll := &LinearLayout{}
+	win.initables << ll
+	win.init()
+}
+
+//----------------------------------
+
+[heap]
+pub struct Window {
+mut:
+	initables []Initable
+}
+
+interface Initable {
+	get_ptr()
+mut:
+	init(&Window)
+}
+
+fn (mut w Window) init() {
+	for mut i in w.initables {
+		i.init(w)
+	}
+}
+
+//----------------------------------
+
+pub struct ViewBase {}
+
+pub fn (mut vb ViewBase) init(window &Window) {
+	dump(@METHOD)
+	assert false
+}
+
+pub fn (vb ViewBase) get_ptr() {}
+
+//-------------------------------------
+
+[heap]
+pub struct ContainerBase {
+	ViewBase
+}
+
+// want to excute this method
+pub fn (mut cb ContainerBase) init(window &Window) {
+	dump(@METHOD)
+	assert true
+}
+
+//--------------------------------------
+
+[heap]
+pub struct LinearLayout {
+	ContainerBase
+}


### PR DESCRIPTION
This PR fix interface embedding complex cases (fix #13467).

- Fix interface embedding complex cases.
- Add test.

```vlang
fn main() {
	mut win := &Window{}
	ll := &LinearLayout{}
	win.initables << ll
	win.init()
}

//----------------------------------

[heap]
pub struct Window {
mut:
	initables []Initable
}

interface Initable {
	get_ptr()
mut:
	init(&Window)
}

fn (mut w Window) init() {
	for mut i in w.initables {
		i.init(w)
	}
}

//----------------------------------

pub struct ViewBase {}

pub fn (mut vb ViewBase) init(window &Window) {
	dump(@METHOD)
	assert false
}

pub fn (vb ViewBase) get_ptr() {}

//-------------------------------------

[heap]
pub struct ContainerBase {
	ViewBase
}

// want to excute this method
pub fn (mut cb ContainerBase) init(window &Window) {
	dump(@METHOD)
	assert true
}

//--------------------------------------

[heap]
pub struct LinearLayout {
	ContainerBase
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:48] ContainerBase.init: ContainerBase.init
```