### PR TITLE
net.smtp: add STARTTLS and implicit SSL support

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -157,6 +157,7 @@ pub fn new_test_session(_vargs string, will_compile bool) TestSession {
 		$if windows {
 			skip_files << 'examples/database/mysql.v'
 			skip_files << 'examples/database/orm.v'
+			skip_files << 'examples/smtp/mail.v' // requires OpenSSL
 			skip_files << 'examples/websocket/ping.v' // requires OpenSSL
 			skip_files << 'examples/websocket/client-server/client.v' // requires OpenSSL
 			skip_files << 'examples/websocket/client-server/server.v' // requires OpenSSL

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -96,6 +96,7 @@ const (
 		'vlib/net/http/server_test.v',
 		'vlib/net/http/response_test.v',
 		'vlib/builtin/js/array_test.js.v',
+		'vlib/net/smtp/smtp_test.v',
 	]
 	skip_on_linux                 = [
 		'do_not_remove',
@@ -121,6 +122,7 @@ const (
 		'vlib/vweb/route_test.v',
 		'vlib/sync/many_times_test.v',
 		'vlib/sync/once_test.v',
+		'vlib/net/smtp/smtp_test.v',
 	]
 	skip_on_non_windows           = [
 		'do_not_remove',

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -53,6 +53,7 @@ const (
 		'vlib/vweb/route_test.v',
 		'vlib/net/websocket/websocket_test.v',
 		'vlib/crypto/rand/crypto_rand_read_test.v',
+		'vlib/net/smtp/smtp_test.v',
 	]
 	skip_with_fsanitize_address   = [
 		'vlib/net/websocket/websocket_test.v',

--- a/vlib/net/smtp/smtp_test.v
+++ b/vlib/net/smtp/smtp_test.v
@@ -8,21 +8,14 @@ fn fn_errors(mut c smtp.Client, m smtp.Mail) bool {
 	return false
 }
 
-/*
-*
-* smtp_test
-* Created by: nedimf (07/2020)
-*/
-fn test_smtp() {
-	$if !network ? {
-		return
-	}
-
+fn send_mail(starttls bool) {
 	client_cfg := smtp.Client{
 		server: 'smtp.mailtrap.io'
+		port: 465
 		from: 'dev@vlang.io'
 		username: os.getenv('VSMTP_TEST_USER')
 		password: os.getenv('VSMTP_TEST_PASS')
+		starttls: starttls
 	}
 	if client_cfg.username == '' && client_cfg.password == '' {
 		eprintln('Please set VSMTP_TEST_USER and VSMTP_TEST_PASS before running this test')
@@ -86,4 +79,47 @@ fn test_smtp() {
 		return
 	}
 	assert true
+}
+
+/*
+*
+* smtp_test
+* Created by: nedimf (07/2020)
+*/
+fn test_smtp() {
+	$if !network ? {
+		return
+	}
+
+	// Test sending without STARTTLS
+	send_mail(false)
+
+	// Sleep for 10 seconds to reset the Mailtrap rate limit counter
+	// See: https://help.mailtrap.io/article/44-features-and-limits#rate-limit
+	time.sleep(10000 * time.millisecond)
+
+	// Test with STARTTLS
+	send_mail(true)
+}
+
+fn test_smtp_implicit_ssl() {
+	$if !network ? {
+		return
+	}
+
+	client_cfg := smtp.Client{
+		server: 'smtp.gmail.com'
+		port: 465
+		from: ''
+		username: ''
+		password: ''
+		ssl: true
+	}
+
+	mut client := smtp.new_client(client_cfg) or {
+		assert false
+		return
+	}
+
+	assert client.is_open && client.encrypted
 }


### PR DESCRIPTION
This PR fixes the smtp module and adds STARTTLS and implicit SSL support