### PR TITLE
all: cleanup interface embedding

### DIFF
--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -674,8 +674,8 @@ fn (t Tree) interface_decl(node ast.InterfaceDecl) &Node {
 	obj.add('name_pos', t.pos(node.name_pos))
 	obj.add_terse('language', t.enum_node(node.language))
 	obj.add('pos', t.pos(node.pos))
-	obj.add('are_ifaces_expanded', t.bool_node(node.are_ifaces_expanded))
-	obj.add_terse('ifaces', t.array_node_interface_embedding(node.ifaces))
+	obj.add('are_embeds_expanded', t.bool_node(node.are_embeds_expanded))
+	obj.add_terse('embeds', t.array_node_interface_embedding(node.embeds))
 	obj.add_terse('attrs', t.array_node_attr(node.attrs))
 	return obj
 }

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -362,11 +362,10 @@ pub:
 	generic_types []Type
 	attrs         []Attr
 pub mut:
-	methods []FnDecl
-	fields  []StructField
-	//
-	ifaces              []InterfaceEmbedding
-	are_ifaces_expanded bool
+	methods             []FnDecl
+	fields              []StructField
+	embeds              []InterfaceEmbedding
+	are_embeds_expanded bool
 }
 
 pub struct StructInitField {

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -429,7 +429,7 @@ pub fn (t &Table) find_method_from_embeds(sym &TypeSymbol, method_name string) ?
 	} else if sym.info is Interface {
 		mut found_methods := []Fn{}
 		mut embed_of_found_methods := []Type{}
-		for embed in sym.info.ifaces {
+		for embed in sym.info.embeds {
 			embed_sym := t.sym(embed)
 			if m := t.find_method(embed_sym, method_name) {
 				found_methods << m

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -891,7 +891,7 @@ pub mut:
 	types   []Type // all types that implement this interface
 	fields  []StructField
 	methods []Fn
-	ifaces  []Type
+	embeds  []Type
 	// `I1 is I2` conversions
 	conversions map[int][]Type
 	// generic interface support

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -500,11 +500,11 @@ pub fn (mut c Checker) expand_iface_embeds(idecl &ast.InterfaceDecl, level int, 
 	mut ares := []ast.InterfaceEmbedding{}
 	for ie in iface_embeds {
 		if iface_decl := c.table.interfaces[ie.typ] {
-			mut list := iface_decl.ifaces
-			if !iface_decl.are_ifaces_expanded {
-				list = c.expand_iface_embeds(idecl, level + 1, iface_decl.ifaces)
-				c.table.interfaces[ie.typ].ifaces = list
-				c.table.interfaces[ie.typ].are_ifaces_expanded = true
+			mut list := iface_decl.embeds
+			if !iface_decl.are_embeds_expanded {
+				list = c.expand_iface_embeds(idecl, level + 1, iface_decl.embeds)
+				c.table.interfaces[ie.typ].embeds = list
+				c.table.interfaces[ie.typ].are_embeds_expanded = true
 			}
 			for partial in list {
 				res[partial.typ] = partial

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1071,9 +1071,9 @@ pub fn (mut f Fmt) interface_decl(node ast.InterfaceDecl) {
 		f.writeln('')
 	}
 	f.comments_before_field(node.pre_comments)
-	for iface in node.ifaces {
-		f.write('\t$iface.name')
-		f.comments(iface.comments, inline: true, has_nl: false, level: .indent)
+	for embed in node.embeds {
+		f.write('\t$embed.name')
+		f.comments(embed.comments, inline: true, has_nl: false, level: .indent)
 		f.writeln('')
 	}
 	immut_fields := if node.mut_pos < 0 { node.fields } else { node.fields[..node.mut_pos] }

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -648,7 +648,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			}
 		}
 	}
-	info.ifaces = ifaces.map(it.typ)
+	info.embeds = ifaces.map(it.typ)
 	ts.info = info
 	p.top_level_statement_end()
 	p.check(.rcbr)
@@ -659,7 +659,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		typ: typ
 		fields: fields
 		methods: methods
-		ifaces: ifaces
+		embeds: ifaces
 		is_pub: is_pub
 		attrs: attrs
 		pos: pos


### PR DESCRIPTION
This PR makes cleanup of `interface embedding`.

- Change `ifaces` to `embeds` just like struct embedding.
- Modify all the related calls.