### PR TITLE
checker: check mut interface arguments (fix #13437, #13456)

### DIFF
--- a/vlib/v/checker/tests/mut_interface_param_err.out
+++ b/vlib/v/checker/tests/mut_interface_param_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/mut_interface_param_err.vv:19:10: error: `add` parameter `widget` is `mut`, you need to provide `mut` e.g. `mut arg1`
+   17 |     mut win := Window{}
+   18 |     mut btn := Button{}
+   19 |     win.add(btn)  // should be an error here
+      |             ~~~
+   20 | }

--- a/vlib/v/checker/tests/mut_interface_param_err.vv
+++ b/vlib/v/checker/tests/mut_interface_param_err.vv
@@ -1,0 +1,20 @@
+interface Widget{
+mut:
+	init()
+}
+
+struct Button{}
+fn (mut b Button) init(){}
+
+struct Window{
+mut:
+	widgets []Widget
+}
+
+fn (mut w Window) add(mut widget Widget){}
+
+fn main(){
+	mut win := Window{}
+	mut btn := Button{}
+	win.add(btn)  // should be an error here
+}


### PR DESCRIPTION
This PR check mut interface arguments (fix #13437, fix #13456).

- Check mut interface arguments.
- Add test.

```vlang
interface Widget{
mut:
	init()
}

struct Button{}
fn (mut b Button) init(){}

struct Label{}
fn (mut l Label) init(){}

struct Window{
mut:
	widgets []Widget
}

fn (mut w Window) add_all(mut widgets []Widget){
	for mut wd in widgets{
		wd.init()
		w.widgets << wd
	}
}

fn main(){
	mut win := Window{}
	mut btn := Button{}
	mut lbl := Label{}
	mut arr := []Widget{}
	arr << btn
	arr << lbl
	win.add_all(arr)  // This should be `mut` error, not refernce issue.
	dump(win)
}

PS D:\Test\v\tt1> v run .
./tt1.v:31:14: error: `add_all` parameter `widgets` is `mut`, you need to provide `mut` e.g. `mut arg1`
   29 |     arr << btn
   30 |     arr << lbl
   31 |     win.add_all(arr)  // This should be `mut` error, not refernce issue.
      |                 ~~~
   32 |     dump(win)
   33 | }
```
```vlang
interface Widget{
mut:
	init()
}

struct Button{}
fn (mut b Button) init(){}

struct Window{
mut:
	widgets []Widget
}

fn (mut w Window) add(mut widget Widget){}

fn main(){
	mut win := Window{}
	mut btn := Button{}
	win.add(btn)  // should be an error here
}

PS D:\Test\v\tt1> v run .
./tt1.v:19:10: error: `add` parameter `widget` is `mut`, you need to provide `mut` e.g. `mut arg1`
   17 |     mut win := Window{}
   18 |     mut btn := Button{}
   19 |     win.add(btn)  // should be an error here
      |             ~~~
   20 | }
```