### PR TITLE
v.scanner: remove the restriction for \x00 in strings

### DIFF
--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -980,3 +980,7 @@ fn test_string_f32() {
 	assert '-123'.f32() - (-123) < f32_epsilon
 	assert '-123.456'.f32() - (-123.456) <= f32_epsilon
 }
+
+fn test_string_with_zero_byte_escape() {
+	assert '\x00'.bytes() == [byte(0)]
+}

--- a/vlib/v/checker/tests/string_char_null_err.out
+++ b/vlib/v/checker/tests/string_char_null_err.out
@@ -1,5 +1,0 @@
-vlib/v/checker/tests/string_char_null_err.vv:2:31: error: cannot use `\0` (NULL character) in the string literal
-    1 | fn main() {
-    2 |     println('Null character: \0')
-      |                               ^
-    3 | }

--- a/vlib/v/checker/tests/string_char_null_err.vv
+++ b/vlib/v/checker/tests/string_char_null_err.vv
@@ -1,3 +1,0 @@
-fn main() {
-    println('Null character: \0')
-}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1204,21 +1204,6 @@ fn (mut s Scanner) ident_string() string {
 		if c == scanner.b_lf {
 			s.inc_line_number()
 		}
-		// Don't allow \0
-		if c == `0` && s.pos > 2 && prevc == scanner.backslash {
-			if (s.pos < s.text.len - 1 && s.text[s.pos + 1].is_digit())
-				|| s.count_symbol_before(s.pos - 1, scanner.backslash) % 2 == 0 {
-			} else if !is_cstr && !is_raw {
-				s.error(r'cannot use `\0` (NULL character) in the string literal')
-			}
-		}
-		// Don't allow \x00
-		if c == `0` && s.pos > 5 && s.expect('\\x0', s.pos - 3) {
-			if s.count_symbol_before(s.pos - 3, scanner.backslash) % 2 == 0 {
-			} else if !is_cstr && !is_raw {
-				s.error(r'cannot use `\x00` (NULL character) in the string literal')
-			}
-		}
 		// Escape `\x` `\u`
 		if backslash_count % 2 == 1 && !is_raw && !is_cstr {
 			// Escape `\x`


### PR DESCRIPTION
Allow for `assert 'A \x00 B'.bytes().hex() == '4120002042'`

Previously that was mainly a problem because println() stopped at 0
bytes in strings, and the values in the generated C code were not
escaped properly. Now these limitations are gone, so the restriction
can be lifted.