### PR TITLE
cgen: fix generics with reference generic arguments (fix #13510)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3852,7 +3852,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 		return
 	}
 	tmpvar := g.new_tmp_var()
-	ret_typ := g.typ(g.fn_decl.return_type)
+	ret_typ := g.typ(g.unwrap_generic(g.fn_decl.return_type))
 	mut use_tmp_var := g.defer_stmts.len > 0 || g.defer_profile_code.len > 0
 	// handle promoting none/error/function returning 'Option'
 	if fn_return_is_optional {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -214,7 +214,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 	}
 	//
 	mut name := g.c_fn_name(node) or { return }
-	mut type_name := g.typ(node.return_type)
+	mut type_name := g.typ(g.unwrap_generic(node.return_type))
 
 	if g.pref.obfuscate && g.cur_mod.name == 'main' && name.starts_with('main__') && !node.is_main
 		&& node.name != 'str' {

--- a/vlib/v/tests/generics_with_reference_generic_args_test.v
+++ b/vlib/v/tests/generics_with_reference_generic_args_test.v
@@ -1,0 +1,15 @@
+module main
+
+fn foo<T>(val T) ?T {
+	return val
+}
+
+struct Bar {
+	num int
+}
+
+fn test_generics_with_reference_generic_args() {
+	ret := foo<&Bar>(&Bar{ num: 123 }) or { panic(err) }
+	println(ret)
+	assert ret.num == 123
+}


### PR DESCRIPTION
This PR fix generics with reference generic arguments (fix #13510).

- Fix generics with reference generic arguments.
- Add test.

```vlang
module main

fn foo<T>(val T) ?T {
	return val
}

struct Bar {
	num int
}

fn main() {
	ret := foo<&Bar>(&Bar{ num: 123 }) or { panic(err) }
	println(ret)
	assert ret.num == 123
}

PS D:\Test\v\tt1> v run .
&Bar{
    num: 123
}
```