### PR TITLE
cgen: fix struct init with multi nested embed update expr (fix #13523)

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -230,13 +230,19 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 					g.write('.')
 				}
 				if node.is_update_embed {
-					embed_sym := g.table.sym(node.typ)
-					embed_name := embed_sym.embed_name()
-					g.write(embed_name)
-					if node.typ.is_ptr() {
-						g.write('->')
-					} else {
-						g.write('.')
+					update_sym := g.table.sym(node.update_expr_type)
+					_, embeds := g.table.find_field_from_embeds(update_sym, field.name) or {
+						ast.StructField{}, []ast.Type{}
+					}
+					for embed in embeds {
+						esym := g.table.sym(embed)
+						ename := esym.embed_name()
+						g.write(ename)
+						if embed.is_ptr() {
+							g.write('->')
+						} else {
+							g.write('.')
+						}
 					}
 				}
 				g.write(field.name)

--- a/vlib/v/tests/struct_init_with_multi_nested_embed_update_test.v
+++ b/vlib/v/tests/struct_init_with_multi_nested_embed_update_test.v
@@ -1,0 +1,28 @@
+module main
+
+struct Animal {
+	Duck
+	id int
+}
+
+struct Duck {
+	RedDuck
+	action string
+}
+
+struct RedDuck {
+	color string
+}
+
+fn test_struct_init_with_multi_nested_embed_update() {
+	d := Animal{Duck{RedDuck{'red'}, 'fly'}, 1}
+	println(d)
+
+	e := Animal{
+		...d
+		id: 2
+	}
+	println(e)
+	assert d.id == 1
+	assert e.id == 2
+}


### PR DESCRIPTION
This PR fix struct init with multi nested embed update expr (fix #13523).

- Fix struct init with multi nested embed update expr.
- Add test.

```vlang
module main

struct Animal {
	Duck
	id int
}

struct Duck {
	RedDuck
	action string
}

struct RedDuck {
	color string
}

fn main() {
	d := Animal{Duck{RedDuck{'red'}, 'fly'}, 1}
	println(d)

	e := Animal{
		...d
		id: 2
	}
	println(e)
	assert d.id == 1
	assert e.id == 2
}

PS D:\Test\v\tt1> v run .
Animal{
    Duck: Duck{
        RedDuck: RedDuck{
            color: 'red'
        }
        action: 'fly'
    }
    id: 1
}
Animal{
    Duck: Duck{
        RedDuck: RedDuck{
            color: 'red'
        }
        action: 'fly'
    }
    id: 2
}
```