### PR TITLE
cgen: fix error for interface and embedded struct build (fix #13527)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5633,6 +5633,9 @@ static inline __shared__$interface_name ${shared_fn_name}(__shared__$cctype* x) 
 								methods_wrapper.write_string('.$esym.embed_name()')
 							}
 						}
+						if fargs.len > 1 {
+							methods_wrapper.write_string(', ')
+						}
 						methods_wrapper.writeln('${fargs[1..].join(', ')});')
 					} else {
 						if parameter_name.starts_with('__shared__') {

--- a/vlib/v/tests/interface_and_embedded_struct_build_test.v
+++ b/vlib/v/tests/interface_and_embedded_struct_build_test.v
@@ -1,0 +1,17 @@
+pub struct Event {}
+
+pub struct ViewBase {}
+
+pub fn (vb ViewBase) point_inside(e Event) {}
+
+pub struct ContainerBase {
+	ViewBase
+}
+
+interface Focusable {
+	point_inside(Event)
+}
+
+fn test_interface_and_embedded_struct_build() {
+	assert true
+}


### PR DESCRIPTION
This PR fix error for interface and embedded struct build (fix #13527).

- Fix error for interface and embedded struct build.
- Add test.

```vlang
pub struct Event {}

pub struct ViewBase {}

pub fn (vb ViewBase) point_inside(e Event) {}

pub struct ContainerBase {
	ViewBase
}

interface Focusable {
	point_inside(Event)
}

fn main() {
	assert true
}

PS D:\Test\v\tt1> v run .

```