### PR TITLE
parser: check error for defer propagate (fix #13534)

### DIFF
--- a/vlib/net/unix/use_net_and_net_unix_together_test.v
+++ b/vlib/net/unix/use_net_and_net_unix_together_test.v
@@ -11,12 +11,12 @@ fn test_that_net_and_net_unix_can_be_imported_together_without_conflicts() ? {
 	mut l := unix.listen_stream(test_port) or { panic(err) }
 	go echo_server(mut l)
 	defer {
-		l.close() ?
+		l.close() or {}
 	}
 	//
 	mut c := unix.connect_stream(test_port) ?
 	defer {
-		c.close() ?
+		c.close() or {}
 	}
 	//
 	data := 'Hello from vlib/net!'

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2694,6 +2694,10 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 		// `foo()?`
 		if p.tok.kind == .question {
 			p.next()
+			if p.inside_defer {
+				p.error_with_pos('error propagation not allowed inside `defer` blocks',
+					p.prev_tok.pos())
+			}
 			or_kind = .propagate
 		}
 		//

--- a/vlib/v/parser/tests/defer_propagate2.out
+++ b/vlib/v/parser/tests/defer_propagate2.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/defer_propagate2.vv:16:13: error: error propagation not allowed inside `defer` blocks
+   14 |     dump(s.x)
+   15 |     defer {
+   16 |         s.close() ?
+      |                   ^
+   17 |     }
+   18 |     return s.x

--- a/vlib/v/parser/tests/defer_propagate2.vv
+++ b/vlib/v/parser/tests/defer_propagate2.vv
@@ -1,0 +1,23 @@
+struct Abc {
+mut:
+	x int = 123
+}
+
+fn (mut s Abc) close() ? {
+	println('> CLOSE 1 s.x: $s.x')
+	s.x = -1
+	println('> CLOSE 2 s.x: $s.x')
+}
+
+fn opt2() ?int {
+	mut s := Abc{}
+	dump(s.x)
+	defer {
+		s.close() ?
+	}
+	return s.x
+}
+
+fn main() {
+	println(opt2() ?)
+}


### PR DESCRIPTION
This PR check error for defer propagate (fix #13534).

- Check error for defer propagate.
- Add test.

```vlang
struct Abc {
mut:
	x int = 123
}

fn (mut s Abc) close() ? {
	println('> CLOSE 1 s.x: $s.x')
	s.x = -1
	println('> CLOSE 2 s.x: $s.x')
}

fn opt2() ?int {
	mut s := Abc{}
	dump(s.x)
	defer {
		s.close() ?
	}
	return s.x
}

fn main() {
	println(opt2() ?)
}

./tt1.v:16:13: error: error propagation not allowed inside `defer` blocks
   14 |     dump(s.x)
   15 |     defer {
   16 |         s.close() ?
      |                   ^
   17 |     }
   18 |     return s.x
```