### PR TITLE
all: initial implementation of compile-time types

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -122,6 +122,8 @@ pub enum ComptimeTypeKind {
 	struct_
 	iface
 	array
+	sum_type
+	enum_
 }
 
 pub struct ComptimeType {
@@ -138,6 +140,8 @@ pub fn (cty ComptimeType) str() string {
 		.struct_ { '\$Struct' }
 		.iface { '\$Interface' }
 		.array { '\$Array' }
+		.sum_type { '\$Sumtype' }
+		.enum_ { '\$Enum' }
 	}
 }
 

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -24,6 +24,7 @@ pub type Expr = AnonFn
 	| Comment
 	| ComptimeCall
 	| ComptimeSelector
+	| ComptimeType
 	| ConcatExpr
 	| DumpExpr
 	| EmptyExpr
@@ -112,6 +113,32 @@ pub struct TypeNode {
 pub:
 	typ Type
 	pos token.Pos
+}
+
+pub enum ComptimeTypeKind {
+	map_
+	int
+	float
+	struct_
+	iface
+	array
+}
+
+pub struct ComptimeType {
+pub:
+	kind ComptimeTypeKind
+	pos  token.Pos
+}
+
+pub fn (cty ComptimeType) str() string {
+	return match cty.kind {
+		.map_ { '\$Map' }
+		.int { '\$Int' }
+		.float { '\$Float' }
+		.struct_ { '\$Struct' }
+		.iface { '\$Interface' }
+		.array { '\$Array' }
+	}
 }
 
 pub struct EmptyExpr {
@@ -1678,7 +1705,7 @@ pub fn (expr Expr) pos() token.Pos {
 		EnumVal, DumpExpr, FloatLiteral, GoExpr, Ident, IfExpr, IntegerLiteral, IsRefType, Likely,
 		LockExpr, MapInit, MatchExpr, None, OffsetOf, OrExpr, ParExpr, PostfixExpr, PrefixExpr,
 		RangeExpr, SelectExpr, SelectorExpr, SizeOf, SqlExpr, StringInterLiteral, StringLiteral,
-		StructInit, TypeNode, TypeOf, UnsafeExpr {
+		StructInit, TypeNode, TypeOf, UnsafeExpr, ComptimeType {
 			return expr.pos
 		}
 		IndexExpr {

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -261,6 +261,9 @@ pub fn (x Expr) str() string {
 		AnonFn {
 			return 'anon_fn'
 		}
+		ComptimeType {
+			return x.str()
+		}
 		DumpExpr {
 			return 'dump($x.expr.str())'
 		}

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -2044,3 +2044,43 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 		}
 	}
 }
+
+pub fn (t &Table) is_comptime_type(x Type, y ComptimeType) bool {
+	x_kind := t.type_kind(x)
+	match y.kind {
+		.map_ {
+			return x_kind == .map
+		}
+		.int {
+			return x_kind in [
+				.i8,
+				.i16,
+				.int,
+				.i64,
+				.byte,
+				.u8,
+				.u16,
+				.u32,
+				.u64,
+				.usize,
+				.int_literal,
+			]
+		}
+		.float {
+			return x_kind in [
+				.f32,
+				.f64,
+				.float_literal,
+			]
+		}
+		.struct_ {
+			return x_kind == .struct_
+		}
+		.iface {
+			return x_kind == .interface_
+		}
+		.array {
+			return x_kind in [.array, .array_fixed]
+		}
+	}
+}

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -2082,5 +2082,11 @@ pub fn (t &Table) is_comptime_type(x Type, y ComptimeType) bool {
 		.array {
 			return x_kind in [.array, .array_fixed]
 		}
+		.sum_type {
+			return x_kind == .sum_type
+		}
+		.enum_ {
+			return x_kind == .enum_
+		}
 	}
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2384,6 +2384,9 @@ pub fn (mut c Checker) expr(node ast.Expr) ast.Type {
 	}
 	match mut node {
 		ast.NodeError {}
+		ast.ComptimeType {
+			c.error('incorrect use of compile-time type', node.pos)
+		}
 		ast.EmptyExpr {
 			c.error('checker.expr(): unhandled EmptyExpr', token.Pos{})
 		}

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -471,7 +471,7 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Pos) bool {
 					} else if cond.left is ast.TypeNode && cond.right is ast.ComptimeType {
 						left := cond.left as ast.TypeNode
 						checked_type := c.unwrap_generic(left.typ)
-						return c.is_comptime_type(checked_type, cond.right)
+						return c.table.is_comptime_type(checked_type, cond.right)
 					} else if cond.left in [ast.SelectorExpr, ast.TypeNode] {
 						// `$if method.@type is string`
 						c.expr(cond.left)
@@ -597,44 +597,4 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Pos) bool {
 		}
 	}
 	return false
-}
-
-fn (mut c Checker) is_comptime_type(x ast.Type, y ast.ComptimeType) bool {
-	x_kind := c.table.type_kind(x)
-	match y.kind {
-		.map_ {
-			return x_kind == .map
-		}
-		.int {
-			return x_kind in [
-				.i8,
-				.i16,
-				.int,
-				.i64,
-				.byte,
-				.u8,
-				.u16,
-				.u32,
-				.u64,
-				.usize,
-				.int_literal,
-			]
-		}
-		.float {
-			return x_kind in [
-				.f32,
-				.f64,
-				.float_literal,
-			]
-		}
-		.struct_ {
-			return x_kind == .struct_
-		}
-		.iface {
-			return x_kind == .interface_
-		}
-		.array {
-			return x_kind in [.array, .array_fixed]
-		}
-	}
 }

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -468,6 +468,10 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Pos) bool {
 							// c.error('`$sym.name` is not an interface', cond.right.pos())
 						}
 						return false
+					} else if cond.left is ast.TypeNode && cond.right is ast.ComptimeType {
+						left := cond.left as ast.TypeNode
+						checked_type := c.unwrap_generic(left.typ)
+						return c.is_comptime_type(checked_type, cond.right)
 					} else if cond.left in [ast.SelectorExpr, ast.TypeNode] {
 						// `$if method.@type is string`
 						c.expr(cond.left)
@@ -593,4 +597,44 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Pos) bool {
 		}
 	}
 	return false
+}
+
+fn (mut c Checker) is_comptime_type(x ast.Type, y ast.ComptimeType) bool {
+	x_kind := c.table.type_kind(x)
+	match y.kind {
+		.map_ {
+			return x_kind == .map
+		}
+		.int {
+			return x_kind in [
+				.i8,
+				.i16,
+				.int,
+				.i64,
+				.byte,
+				.u8,
+				.u16,
+				.u32,
+				.u64,
+				.usize,
+				.int_literal,
+			]
+		}
+		.float {
+			return x_kind in [
+				.f32,
+				.f64,
+				.float_literal,
+			]
+		}
+		.struct_ {
+			return x_kind == .struct_
+		}
+		.iface {
+			return x_kind == .interface_
+		}
+		.array {
+			return x_kind in [.array, .array_fixed]
+		}
+	}
 }

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -60,7 +60,7 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 					if branch.cond.right is ast.ComptimeType && left is ast.TypeNode {
 						is_comptime_type_is_expr = true
 						checked_type := c.unwrap_generic(left.typ)
-						should_skip = !c.is_comptime_type(checked_type, branch.cond.right as ast.ComptimeType)
+						should_skip = !c.table.is_comptime_type(checked_type, branch.cond.right as ast.ComptimeType)
 					} else {
 						got_type := c.unwrap_generic((branch.cond.right as ast.TypeNode).typ)
 						sym := c.table.sym(got_type)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -668,6 +668,8 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 				.map_ { f.write('\$Map') }
 				.int { f.write('\$Int') }
 				.float { f.write('\$Float') }
+				.sum_type { f.write('\$Sumtype') }
+				.enum_ { f.write('\$Enum') }
 			}
 		}
 	}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -660,6 +660,16 @@ pub fn (mut f Fmt) expr(node ast.Expr) {
 		ast.UnsafeExpr {
 			f.unsafe_expr(node)
 		}
+		ast.ComptimeType {
+			match node.kind {
+				.array { f.write('\$Array') }
+				.struct_ { f.write('\$Struct') }
+				.iface { f.write('\$Interface') }
+				.map_ { f.write('\$Map') }
+				.int { f.write('\$Int') }
+				.float { f.write('\$Float') }
+			}
+		}
 	}
 }
 

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2740,6 +2740,9 @@ fn (mut g Gen) expr(node ast.Expr) {
 	}
 	// NB: please keep the type names in the match here in alphabetical order:
 	match mut node {
+		ast.ComptimeType {
+			g.error('g.expr(): Unhandled ComptimeType', node.pos)
+		}
 		ast.EmptyExpr {
 			g.error('g.expr(): unhandled EmptyExpr', token.Pos{})
 		}

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -339,7 +339,7 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) bool {
 					mut name := ''
 					if left is ast.TypeNode && cond.right is ast.ComptimeType {
 						checked_type := g.unwrap_generic(left.typ)
-						is_true := g.is_comptime_type(checked_type, cond.right)
+						is_true := g.table.is_comptime_type(checked_type, cond.right)
 						if cond.op == .key_is {
 							if is_true {
 								g.write('1')
@@ -722,44 +722,4 @@ fn (mut g Gen) comptime_if_to_ifdef(name string, is_comptime_optional bool) ?str
 		}
 	}
 	return none
-}
-
-fn (mut g Gen) is_comptime_type(x ast.Type, y ast.ComptimeType) bool {
-	x_kind := g.table.type_kind(x)
-	match y.kind {
-		.map_ {
-			return x_kind == .map
-		}
-		.int {
-			return x_kind in [
-				.i8,
-				.i16,
-				.int,
-				.i64,
-				.byte,
-				.u8,
-				.u16,
-				.u32,
-				.u64,
-				.usize,
-				.int_literal,
-			]
-		}
-		.float {
-			return x_kind in [
-				.f32,
-				.f64,
-				.float_literal,
-			]
-		}
-		.struct_ {
-			return x_kind == .struct_
-		}
-		.iface {
-			return x_kind == .interface_
-		}
-		.array {
-			return x_kind in [.array, .array_fixed]
-		}
-	}
 }

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -337,6 +337,25 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) bool {
 				.key_is, .not_is {
 					left := cond.left
 					mut name := ''
+					if left is ast.TypeNode && cond.right is ast.ComptimeType {
+						checked_type := g.unwrap_generic(left.typ)
+						is_true := g.is_comptime_type(checked_type, cond.right)
+						if cond.op == .key_is {
+							if is_true {
+								g.write('1')
+							} else {
+								g.write('0')
+							}
+							return is_true
+						} else {
+							if is_true {
+								g.write('0')
+							} else {
+								g.write('1')
+							}
+							return !is_true
+						}
+					}
 					mut exp_type := ast.Type(0)
 					got_type := (cond.right as ast.TypeNode).typ
 					// Handle `$if x is Interface {`
@@ -703,4 +722,44 @@ fn (mut g Gen) comptime_if_to_ifdef(name string, is_comptime_optional bool) ?str
 		}
 	}
 	return none
+}
+
+fn (mut g Gen) is_comptime_type(x ast.Type, y ast.ComptimeType) bool {
+	x_kind := g.table.type_kind(x)
+	match y.kind {
+		.map_ {
+			return x_kind == .map
+		}
+		.int {
+			return x_kind in [
+				.i8,
+				.i16,
+				.int,
+				.i64,
+				.byte,
+				.u8,
+				.u16,
+				.u32,
+				.u64,
+				.usize,
+				.int_literal,
+			]
+		}
+		.float {
+			return x_kind in [
+				.f32,
+				.f64,
+				.float_literal,
+			]
+		}
+		.struct_ {
+			return x_kind == .struct_
+		}
+		.iface {
+			return x_kind == .interface_
+		}
+		.array {
+			return x_kind in [.array, .array_fixed]
+		}
+	}
 }

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -856,6 +856,9 @@ fn (mut g JsGen) stmt(node ast.Stmt) {
 fn (mut g JsGen) expr(node ast.Expr) {
 	// NB: please keep the type names in the match here in alphabetical order:
 	match mut node {
+		ast.ComptimeType {
+			verror('not yet implemented')
+		}
 		ast.EmptyExpr {}
 		ast.AnonFn {
 			g.gen_anon_fn(mut node)

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -221,6 +221,7 @@ fn (mut w Walker) expr(node ast.Expr) {
 			// TODO make sure this doesn't happen
 			// panic('Walker: EmptyExpr')
 		}
+		ast.ComptimeType {}
 		ast.AnonFn {
 			w.fn_decl(mut node.decl)
 		}

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -10,8 +10,49 @@ import v.token
 
 const (
 	supported_comptime_calls = ['html', 'tmpl', 'env', 'embed_file', 'pkgconfig']
-	comptime_types           = ['Map', 'Array', 'Int', 'Float', 'Struct', 'Interface']
+	comptime_types           = ['Map', 'Array', 'Int', 'Float', 'Struct', 'Interface', 'Enum',
+		'Sumtype']
 )
+
+pub fn (mut p Parser) parse_comptime_type() ast.ComptimeType {
+	mut node := ast.ComptimeType{ast.ComptimeTypeKind.map_, p.tok.pos()}
+
+	p.check(.dollar)
+	name := p.check_name()
+	if name !in parser.comptime_types {
+		p.error('unsupported compile-time type `$name`: only $parser.comptime_types are supported')
+	}
+	mut cty := ast.ComptimeTypeKind.map_
+	match name {
+		'Map' {
+			cty = .map_
+		}
+		'Struct' {
+			cty = .struct_
+		}
+		'Interface' {
+			cty = .iface
+		}
+		'Int' {
+			cty = .int
+		}
+		'Float' {
+			cty = .float
+		}
+		'Array' {
+			cty = .array
+		}
+		'Enum' {
+			cty = .enum_
+		}
+		'Sumtype' {
+			cty = .sum_type
+		}
+		else {}
+	}
+	node = ast.ComptimeType{cty, node.pos}
+	return node
+}
 
 // // #include, #flag, #v
 fn (mut p Parser) hash() ast.HashStmt {

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -10,6 +10,7 @@ import v.token
 
 const (
 	supported_comptime_calls = ['html', 'tmpl', 'env', 'embed_file', 'pkgconfig']
+	comptime_types           = ['Map', 'Array', 'Int', 'Float', 'Struct', 'Interface']
 )
 
 // // #include, #flag, #v
@@ -39,7 +40,7 @@ fn (mut p Parser) hash() ast.HashStmt {
 	}
 }
 
-fn (mut p Parser) comptime_call() ast.ComptimeCall {
+fn (mut p Parser) comptime_call(name string) ast.ComptimeCall {
 	err_node := ast.ComptimeCall{
 		scope: 0
 	}
@@ -47,7 +48,7 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 	start_pos := p.prev_tok.pos()
 	error_msg := 'only `\$tmpl()`, `\$env()`, `\$embed_file()`, `\$pkgconfig()` and `\$vweb.html()` comptime functions are supported right now'
 	if p.peek_tok.kind == .dot {
-		name := p.check_name() // skip `vweb.html()` TODO
+		// name := p.check_name() // skip `vweb.html()` TODO
 		if name != 'vweb' {
 			p.error(error_msg)
 			return err_node

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -40,7 +40,7 @@ fn (mut p Parser) hash() ast.HashStmt {
 	}
 }
 
-fn (mut p Parser) comptime_call(name string) ast.ComptimeCall {
+fn (mut p Parser) comptime_call() ast.ComptimeCall {
 	err_node := ast.ComptimeCall{
 		scope: 0
 	}
@@ -48,7 +48,7 @@ fn (mut p Parser) comptime_call(name string) ast.ComptimeCall {
 	start_pos := p.prev_tok.pos()
 	error_msg := 'only `\$tmpl()`, `\$env()`, `\$embed_file()`, `\$pkgconfig()` and `\$vweb.html()` comptime functions are supported right now'
 	if p.peek_tok.kind == .dot {
-		// name := p.check_name() // skip `vweb.html()` TODO
+		name := p.check_name() // skip `vweb.html()` TODO
 		if name != 'vweb' {
 			p.error(error_msg)
 			return err_node

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -79,38 +79,11 @@ pub fn (mut p Parser) check_expr(precedence int) ?ast.Expr {
 			match p.peek_tok.kind {
 				.name {
 					if p.peek_tok.lit in comptime_types {
-						p.check(.dollar)
-						name := p.check_name()
-						mut cty := ast.ComptimeTypeKind.map_
-						match name {
-							'Map' {
-								cty = .map_
-							}
-							'Struct' {
-								cty = .struct_
-							}
-							'Interface' {
-								cty = .iface
-							}
-							'Int' {
-								cty = .int
-							}
-							'Float' {
-								cty = .float
-							}
-							'Array' {
-								cty = .array
-							}
-							else {
-								p.error('unknown comptile-time type: `$name`')
-							}
-						}
-						node = ast.ComptimeType{cty, p.tok.pos()}
-						p.is_stmt_ident = is_stmt_ident
+						node = p.parse_comptime_type()
 					} else {
 						node = p.comptime_call()
-						p.is_stmt_ident = is_stmt_ident
 					}
+					p.is_stmt_ident = is_stmt_ident
 				}
 				.key_if {
 					return p.if_expr(true)

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -78,9 +78,9 @@ pub fn (mut p Parser) check_expr(precedence int) ?ast.Expr {
 		.dollar {
 			match p.peek_tok.kind {
 				.name {
-					p.check(.dollar)
-					name := p.check_name()
-					if name in comptime_types {
+					if p.peek_tok.lit in comptime_types {
+						p.check(.dollar)
+						name := p.check_name()
 						mut cty := ast.ComptimeTypeKind.map_
 						match name {
 							'Map' {
@@ -108,7 +108,7 @@ pub fn (mut p Parser) check_expr(precedence int) ?ast.Expr {
 						node = ast.ComptimeType{cty, p.tok.pos()}
 						p.is_stmt_ident = is_stmt_ident
 					} else {
-						node = p.comptime_call(name)
+						node = p.comptime_call()
 						p.is_stmt_ident = is_stmt_ident
 					}
 				}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2106,36 +2106,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 	mut node := ast.empty_expr()
 	if p.expecting_type {
 		if p.tok.kind == .dollar {
-			p.check(.dollar)
-			name := p.check_name()
-			if name !in comptime_types {
-				p.error('unsupported compile-time type `$name`: only $comptime_types are supported')
-			}
-			mut cty := ast.ComptimeTypeKind.map_
-			match name {
-				'Map' {
-					cty = .map_
-				}
-				'Struct' {
-					cty = .struct_
-				}
-				'Interface' {
-					cty = .iface
-				}
-				'Int' {
-					cty = .int
-				}
-				'Float' {
-					cty = .float
-				}
-				'Array' {
-					cty = .array
-				}
-				else {
-					panic('unreachable')
-				}
-			}
-			node = ast.ComptimeType{cty, p.tok.pos()}
+			node = p.parse_comptime_type()
 			p.expecting_type = false
 			return node
 		}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -849,9 +849,7 @@ pub fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 				}
 				.name {
 					mut pos := p.tok.pos()
-					name := p.check_name() // TODO: Supper ComptimeType in stmt position too?
-					println('name $name')
-					expr := p.comptime_call(name)
+					expr := p.comptime_call()
 					pos.update_last_line(p.prev_tok.line_nr)
 					return ast.ExprStmt{
 						expr: expr
@@ -2137,7 +2135,6 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 					panic('unreachable')
 				}
 			}
-			println('CTY $cty')
 			node = ast.ComptimeType{cty, p.tok.pos()}
 			p.expecting_type = false
 			return node

--- a/vlib/v/tests/comptime_kinds_test.v
+++ b/vlib/v/tests/comptime_kinds_test.v
@@ -1,0 +1,47 @@
+fn assert_map<T>() {
+	$if T is $Map {
+		assert true
+	} $else {
+		assert false
+	}
+}
+
+fn assert_array<T>() {
+	$if T is $Array {
+		assert true
+	} $else {
+		assert false
+	}
+}
+
+fn assert_struct<T>() {
+	$if T is $Struct {
+		assert true
+	} $else {
+		assert false
+	}
+}
+
+fn test_kind_map() {
+	assert_map<map[int]int>()
+	assert_map<map[string]int>()
+	assert_map<map[i64]i8>()
+}
+
+fn test_kind_array() {
+	assert_array<[]int>()
+	assert_array<[]f32>()
+	assert_array<[]string>()
+}
+
+struct Abc {}
+
+struct Bc {}
+
+struct Cd {}
+
+fn test_kind_struct() {
+	assert_struct<Abc>()
+	assert_struct<Bc>()
+	assert_struct<Cd>()
+}

--- a/vlib/v/tests/comptime_kinds_test.v
+++ b/vlib/v/tests/comptime_kinds_test.v
@@ -22,16 +22,28 @@ fn assert_struct<T>() {
 	}
 }
 
-fn test_kind_map() {
-	assert_map<map[int]int>()
-	assert_map<map[string]int>()
-	assert_map<map[i64]i8>()
+fn assert_not_struct<T>() {
+	$if T is $Struct {
+		assert false
+	} $else {
+		assert true
+	}
 }
 
-fn test_kind_array() {
-	assert_array<[]int>()
-	assert_array<[]f32>()
-	assert_array<[]string>()
+fn assert_not_map<T>() {
+	$if T is $Map {
+		assert false
+	} $else {
+		assert true
+	}
+}
+
+fn assert_not_array<T>() {
+	$if T is $Array {
+		assert false
+	} $else {
+		assert true
+	}
 }
 
 struct Abc {}
@@ -40,8 +52,33 @@ struct Bc {}
 
 struct Cd {}
 
+fn test_kind_map() {
+	assert_map<map[int]int>()
+	assert_map<map[string]int>()
+	assert_map<map[i64]i8>()
+
+	assert_not_map<Abc>()
+	assert_not_map<int>()
+	assert_not_map<[]int>()
+}
+
+fn test_kind_array() {
+	assert_array<[]int>()
+	assert_array<[]f32>()
+	assert_array<[]string>()
+
+	assert_not_array<Abc>()
+	assert_not_array<string>()
+	assert_not_array<int>()
+	assert_not_array<map[int]int>()
+}
+
 fn test_kind_struct() {
 	assert_struct<Abc>()
 	assert_struct<Bc>()
 	assert_struct<Cd>()
+
+	assert_not_struct<int>()
+	assert_not_struct<[]int>()
+	assert_not_struct<map[int]int>()
 }


### PR DESCRIPTION
This PR implements simple generic compile-time types. There are 6 kinds of types: Array,Map,Interface,Struct,Int,Float. 
When you do `$if T is $Int`, compiler checks if T is of any possible integer type, same applies to other kinds of types.

In the next PRs additional fields will be introduced to these kinds. For example `Map` will get `key` and `element` fields that would allow you to match on them and this would allow to write complex code that depends on compile-time reflection (i.e it will be possible to finally make `x.json2` module work without user and compiler support)
