### PR TITLE
cgen: fix interface embedding method call (fix #13535)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -755,7 +755,9 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		}
 
 		left_is_shared := node.left_type.has_flag(.shared_f)
-		g.write('${c_name(receiver_type_name)}_name_table[')
+		left_cc_type := g.cc_type(node.left_type, false)
+		left_type_name := util.no_dots(left_cc_type)
+		g.write('${c_name(left_type_name)}_name_table[')
 		g.expr(node.left)
 		dot := if left_is_shared {
 			'->val.'

--- a/vlib/v/tests/interface_embedding_method_call_test.v
+++ b/vlib/v/tests/interface_embedding_method_call_test.v
@@ -1,0 +1,59 @@
+fn test_interface_embedding_method_call() {
+	mut window := &Window{}
+	btn := &Button{}
+	window.initables << btn
+	window.run()
+}
+
+[heap]
+pub struct Window {
+mut:
+	initables []Initable
+	popview   PopView = DummyPopup{}
+}
+
+interface Initable {
+mut:
+	init(&Window)
+}
+
+interface Drawable {
+	draw()
+}
+
+pub fn (mut window Window) run() {
+	for mut i in window.initables {
+		i.init(window)
+	}
+	for wd in window.initables {
+		if wd is Drawable {
+			d := wd as Drawable
+			d.draw()
+		}
+	}
+	window.popview.draw()
+}
+
+struct DummyPopup {}
+
+fn (d DummyPopup) draw() {}
+
+interface PopView {
+	Drawable
+}
+
+[heap]
+pub struct Button {
+mut:
+	window &Window = voidptr(0)
+}
+
+pub fn (mut b Button) init(window &Window) {
+	b.window = window
+}
+
+pub fn (b Button) draw() {
+	g := b.window.initables
+	println(g.len)
+	assert g.len == 1
+}


### PR DESCRIPTION
This PR fix interface embedding method call (fix #13535).

- Fix interface embedding method call.
- Add test.

```vlang
fn main() {
	mut window := &Window{}
	btn := &Button{}
	window.initables << btn
	window.run()
}

[heap]
pub struct Window {
mut:
	initables []Initable
	popview   PopView = DummyPopup{}
}

interface Initable {
mut:
	init(&Window)
}

interface Drawable {
	draw()
}

pub fn (mut window Window) run() {
	for mut i in window.initables {
		i.init(window)
	}
	for wd in window.initables {
		if wd is Drawable {
			d := wd as Drawable
			d.draw()
		}
	}
	window.popview.draw()
}

struct DummyPopup {}

fn (d DummyPopup) draw() {}

interface PopView {
	Drawable
}

[heap]
pub struct Button {
mut:
	window &Window = voidptr(0)
}

pub fn (mut b Button) init(window &Window) {
	b.window = window
}

pub fn (b Button) draw() {
	g := b.window.initables
	println(g.len)
	assert g.len == 1
}

PS D:\Test\v\tt1> v run .
1
```