### PR TITLE
checker: cleanup 'map = {}' processing

### DIFF
--- a/vlib/net/socket.v
+++ b/vlib/net/socket.v
@@ -1,7 +1,7 @@
 module net
 
 pub struct Socket {
-	pub:
+pub:
 	handle int
 }
 

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -92,22 +92,6 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			}
 			left_type = c.expr(left)
 			c.expected_type = c.unwrap_generic(left_type)
-			// `map = {}`
-			if left_type != 0 {
-				sym := c.table.sym(left_type)
-				if sym.kind == .map {
-					if node.right.len <= i {
-						// `map_1, map_2, map_3 = f()`, where f returns (map[int]int, map[int]int, map[int]int)
-						// i.e. 3 left parts of the assignment, but just 1 right part
-					} else {
-						if node.right[i] is ast.StructInit {
-							c.warn('assigning a struct literal to a map is deprecated - use `map{}` instead',
-								node.right[i].pos())
-							node.right[i] = ast.MapInit{}
-						}
-					}
-				}
-			}
 		}
 		if node.right_types.len < node.left.len { // first type or multi return types added above
 			old_inside_ref_lit := c.inside_ref_lit


### PR DESCRIPTION
This PR makes cleanup of `map = {}` processing.

- Remove useless codes of `map = {}` processing.