### PR TITLE
doc: add how to get reallocated array by slicing

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1145,7 +1145,7 @@ println(a) // `[2, 2, 2, 13, 2, 3, 4]`
 println(b) // `[2, 3, 13]`
 ```
 
-for immidaite realoocation and become independent you can call `.clone()` after slice brackets:
+for immidaite reallocation and become independent you can call `.clone()` after slice brackets:
 ```v
 mut a := [0, 1, 2, 3, 4, 5]
 mut b := a[2..4].colne()

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1145,13 +1145,13 @@ println(a) // `[2, 2, 2, 13, 2, 3, 4]`
 println(b) // `[2, 3, 13]`
 ```
 
-for immidaite reallocation and become independent you can call `.clone()` after slice brackets:
+You can call .clone() on the slice, if you do want to have an independent copy:
 ```v
 mut a := [0, 1, 2, 3, 4, 5]
 mut b := a[2..4].clone()
-b[0] = 7 // `b[0]` is not referring to `a[2]`
-println(a) // `[0, 1, 2, 3, 4, 5]
-```
+b[0] = 7 // NB: `b[0]` is NOT referring to `a[2]`, as it would be, without the .clone()
+println(a) // [0, 1, 2, 3, 4, 5]
+println(b) // [7, 3]
 
 ### Slices with negative indexes
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1148,7 +1148,7 @@ println(b) // `[2, 3, 13]`
 for immidaite reallocation and become independent you can call `.clone()` after slice brackets:
 ```v
 mut a := [0, 1, 2, 3, 4, 5]
-mut b := a[2..4].colne()
+mut b := a[2..4].clone()
 b[0] = 7 // `b[0]` is not referring to `a[2]`
 println(a) // `[0, 1, 2, 3, 4, 5]
 ```

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1145,13 +1145,14 @@ println(a) // `[2, 2, 2, 13, 2, 3, 4]`
 println(b) // `[2, 3, 13]`
 ```
 
-You can call .clone() on the slice, if you do want to have an independent copy:
+You can call .clone() on the slice, if you do want to have an independent copy right away:
 ```v
 mut a := [0, 1, 2, 3, 4, 5]
 mut b := a[2..4].clone()
-b[0] = 7 // NB: `b[0]` is NOT referring to `a[2]`, as it would be, without the .clone()
+b[0] = 7 // NB: `b[0]` is NOT referring to `a[2]`, as it would have been, without the .clone()
 println(a) // [0, 1, 2, 3, 4, 5]
 println(b) // [7, 3]
+```
 
 ### Slices with negative indexes
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1145,6 +1145,14 @@ println(a) // `[2, 2, 2, 13, 2, 3, 4]`
 println(b) // `[2, 3, 13]`
 ```
 
+for immidaite realoocation and become independent you can call `.clone()` after slice brackets:
+```v
+mut a := [0, 1, 2, 3, 4, 5]
+mut b := a[2..4].colne()
+b[0] = 7 // `b[0]` is not referring to `a[2]`
+println(a) // `[0, 1, 2, 3, 4, 5]
+```
+
 ### Slices with negative indexes
 
 V supports array and string slices with negative indexes.


### PR DESCRIPTION
added:
for immidaite realoocation and become independent you can call .clone() after slice brackets:

mut a := [0, 1, 2, 3, 4, 5]
mut b := a[2..4].clone()
b[0] = 7 // `b[0]` is not referring to `a[2]`
println(a) // `[0, 1, 2, 3, 4, 5]