### PR TITLE
checker: check struct field reference type mismatch (fix #13571)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -319,7 +319,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 					}
 				} else {
 					if field_info.typ.is_ptr() && !expr_type.is_ptr() && !expr_type.is_pointer()
-						&& !expr_type.is_number() {
+						&& field.expr.str() != '0' {
 						c.error('reference field must be initialized with reference',
 							field.pos)
 					}

--- a/vlib/v/checker/tests/struct_field_reference_type_err.out
+++ b/vlib/v/checker/tests/struct_field_reference_type_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/struct_field_reference_type_err.vv:17:3: error: reference field must be initialized with reference
+   15 |
+   16 |     animal.duck = Duck{
+   17 |         age: animal.ageee
+      |         ~~~~~~~~~~~~~~~~~
+   18 |     }
+   19 |     dump(animal.duck.age)

--- a/vlib/v/checker/tests/struct_field_reference_type_err.vv
+++ b/vlib/v/checker/tests/struct_field_reference_type_err.vv
@@ -1,0 +1,20 @@
+struct Animal {
+mut:
+	ageee int
+	duck  Duck
+}
+
+struct Duck {
+	age &int
+}
+
+fn main() {
+	mut animal := Animal{
+		ageee: 20
+	}
+
+	animal.duck = Duck{
+		age: animal.ageee
+	}
+	dump(animal.duck.age)
+}


### PR DESCRIPTION
This PR check struct field reference type mismatch (fix #13571).

- Check struct field reference type mismatch.
- Add test.

```vlang
struct Animal {
mut:
	ageee int
	duck  Duck
}

struct Duck {
	age &int
}

fn main() {
	mut animal := Animal{
		ageee: 20
	}

	animal.duck = Duck{
		age: animal.ageee
	}
	dump(animal.duck.age)
}

PS D:\Test\v\tt1> v run .
./tt1.v:17:3: error: reference field must be initialized with reference
   15 |
   16 |     animal.duck = Duck{
   17 |         age: animal.ageee
      |         ~~~~~~~~~~~~~~~~~
   18 |     }
   19 |     dump(animal.duck.age)
```