### PR TITLE
crypto: implement Counter (CTR) Mode for AES and DES

### DIFF
--- a/vlib/crypto/cipher/aes_ctr_test.v
+++ b/vlib/crypto/cipher/aes_ctr_test.v
@@ -1,0 +1,29 @@
+import crypto.aes
+import crypto.cipher
+
+fn test_aes_ctr() {
+	key := '6368616e676520746869732070617373'.bytes()
+	iv := '1234567890123456'.bytes()
+	str := '73c86d43a9d700a253a96c85b0f6b03ac9792e0e757f869cca306bd3cba1c62b'
+
+	mut src := str.bytes()
+
+	aes_ctr_en(mut src, key, iv)
+	assert src.hex() == '04380c1470ab2d8a0b3f9b4c1949b8ace811f22bc0a455a8946a3ea7a03e9f8440820f273ce749e955e4adb9e8f6ffde82bae507e0b6164b531d3eeb32f5beb5'
+
+	aes_ctr_de(mut src, key, iv)
+	assert src.bytestr() == str
+	println('test_aes_ctr ok')
+}
+
+fn aes_ctr_en(mut src []byte, key []byte, iv []byte) {
+	block := aes.new_cipher(key)
+	mode := cipher.new_ctr(block, iv)
+	mode.xor_key_stream(mut src, src.clone())
+}
+
+fn aes_ctr_de(mut src []byte, key []byte, iv []byte) {
+	block := aes.new_cipher(key)
+	mode := cipher.new_ctr(block, iv)
+	mode.xor_key_stream(mut src, src.clone())
+}

--- a/vlib/crypto/cipher/ctr.v
+++ b/vlib/crypto/cipher/ctr.v
@@ -16,28 +16,21 @@ import crypto.internal.subtle
 struct Ctr {
 mut:
 	b        Block
-	ctr      []byte
+	next     []byte
 	out      []byte
 	out_used int
 }
 
-const stream_buffer_size = 512
-
-// new_ctr returns a Ctr which encrypts/decrypts using the given Block in
-// counter mode. The length of iv must be the same as the Block's block size.
 pub fn new_ctr(b Block, iv []byte) Ctr {
-	if iv.len != b.block_size {
-		panic('cipher.new_ctr: IV length must equal block size')
-	}
-	mut buf_size := cipher.stream_buffer_size
-	if buf_size < b.block_size {
-		buf_size = b.block_size
+	block_size := b.block_size
+	if iv.len != block_size {
+		panic('cipher.new_cfb: IV length must be equal block size')
 	}
 	return Ctr{
 		b: b
-		ctr: iv.clone()
 		out: []byte{len: b.block_size}
-		out_used: 0
+		next: iv.clone()
+		out_used: block_size
 	}
 }
 
@@ -45,39 +38,28 @@ pub fn (x &Ctr) xor_key_stream(mut dst_ []byte, src_ []byte) {
 	unsafe {
 		mut dst := *dst_
 		mut src := src_
-
 		if dst.len < src.len {
 			panic('crypto.cipher.xor_key_stream: output smaller than input')
 		}
+
 		if subtle.inexact_overlap(dst[..src.len], src) {
 			panic('crypto.cipher.xor_key_stream: invalid buffer overlap')
 		}
 
 		for src.len > 0 {
-			if x.out_used >= x.out.len - x.b.block_size {
-				mut remain := x.out.len - x.out_used
-				copy(x.out, x.out[x.out_used..])
-
-				x.out = x.out[..x.out.cap]
-				bs := x.b.block_size
-
-				for remain <= x.out.len - bs {
-					x.b.encrypt(mut x.out[remain..], x.ctr)
-					remain += bs
-
-					// increment counter
-					for i := x.ctr.len - 1; i >= 0; i-- {
-						x.ctr[i]++
-						if x.ctr[i] != 0 {
-							break
-						}
-					}
-				}
-				x.out = x.out[..remain]
+			if x.out_used == x.out.len {
+				x.b.encrypt(mut x.out, x.next)
 				x.out_used = 0
 			}
 
 			n := xor_bytes(mut dst, src, x.out[x.out_used..])
+
+			for i := x.next.len - 1; i >= 0; i-- {
+				x.next[i]++
+				if x.next[i] != 0 {
+					break
+				}
+			}
 
 			dst = dst[n..]
 			src = src[n..]

--- a/vlib/crypto/cipher/ctr.v
+++ b/vlib/crypto/cipher/ctr.v
@@ -1,0 +1,87 @@
+// The source code refers to the go standard library, which will be combined with AES in the future.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+//
+// Counter (CTR) mode.
+//
+// CTR converts a block cipher into a stream cipher by
+// repeatedly encrypting an incrementing counter and
+// xoring the resulting stream of data with the input.
+//
+// See NIST SP 800-38A, pp 13-15
+module cipher
+
+import crypto.internal.subtle
+
+struct Ctr {
+mut:
+	b        Block
+	ctr      []byte
+	out      []byte
+	out_used int
+}
+
+const stream_buffer_size = 512
+
+// new_ctr returns a Ctr which encrypts/decrypts using the given Block in
+// counter mode. The length of iv must be the same as the Block's block size.
+pub fn new_ctr(b Block, iv []byte) Ctr {
+	if iv.len != b.block_size {
+		panic('cipher.new_ctr: IV length must equal block size')
+	}
+	mut buf_size := cipher.stream_buffer_size
+	if buf_size < b.block_size {
+		buf_size = b.block_size
+	}
+	return Ctr{
+		b: b
+		ctr: iv.clone()
+		out: []byte{len: b.block_size}
+		out_used: 0
+	}
+}
+
+pub fn (x &Ctr) xor_key_stream(mut dst_ []byte, src_ []byte) {
+	unsafe {
+		mut dst := *dst_
+		mut src := src_
+
+		if dst.len < src.len {
+			panic('crypto.cipher.xor_key_stream: output smaller than input')
+		}
+		if subtle.inexact_overlap(dst[..src.len], src) {
+			panic('crypto.cipher.xor_key_stream: invalid buffer overlap')
+		}
+
+		for src.len > 0 {
+			if x.out_used >= x.out.len - x.b.block_size {
+				mut remain := x.out.len - x.out_used
+				copy(x.out, x.out[x.out_used..])
+
+				x.out = x.out[..x.out.cap]
+				bs := x.b.block_size
+
+				for remain <= x.out.len - bs {
+					x.b.encrypt(mut x.out[remain..], x.ctr)
+					remain += bs
+
+					// increment counter
+					for i := x.ctr.len - 1; i >= 0; i-- {
+						x.ctr[i]++
+						if x.ctr[i] != 0 {
+							break
+						}
+					}
+				}
+				x.out = x.out[..remain]
+				x.out_used = 0
+			}
+
+			n := xor_bytes(mut dst, src, x.out[x.out_used..])
+
+			dst = dst[n..]
+			src = src[n..]
+			x.out_used += n
+		}
+	}
+}

--- a/vlib/crypto/cipher/ctr.v
+++ b/vlib/crypto/cipher/ctr.v
@@ -21,6 +21,8 @@ mut:
 	out_used int
 }
 
+// new_ctr returns a Ctr which encrypts/decrypts using the given Block in
+// counter mode. The length of iv must be the same as the Block's block size.
 pub fn new_ctr(b Block, iv []byte) Ctr {
 	block_size := b.block_size
 	if iv.len != block_size {
@@ -54,6 +56,7 @@ pub fn (x &Ctr) xor_key_stream(mut dst_ []byte, src_ []byte) {
 
 			n := xor_bytes(mut dst, src, x.out[x.out_used..])
 
+			// increment counter
 			for i := x.next.len - 1; i >= 0; i-- {
 				x.next[i]++
 				if x.next[i] != 0 {

--- a/vlib/crypto/cipher/des_ctr_test.v
+++ b/vlib/crypto/cipher/des_ctr_test.v
@@ -1,0 +1,54 @@
+import crypto.des
+import crypto.cipher
+
+const (
+	key = '123456789012345678901234'.bytes()
+	iv  = 'abcdegfh'.bytes()
+	str = '73c86d43a9d700a253a96c85b0f6b03ac9792e0e757f869cca306bd3cba1c62b'
+)
+
+fn test_triple_des_ctr() {
+	mut src := str.bytes()
+
+	triple_des_ctr_en(mut src, key, iv)
+	assert src.hex() == '00d963619a67c84e5aa688174f259f4615768a516ec3fd10c98848f8626120db27fd2932130a4ba5e90acd5c347583bd4705770d41465b1ba11b4a523f449beb'
+
+	triple_des_ctr_de(mut src, key, iv)
+	assert src.bytestr() == str
+	println('test_triple_des_ctr ok')
+}
+
+fn test_des_ctr() {
+	mut src := str.bytes()
+
+	des_ctr_en(mut src, key[..8], iv)
+	assert src.hex() == '2743e2164b8604565f34bb120eb5dcd0f9db5f9a6498bdb678497c68c3cdda70500f4028159903d77d6b2a7ee4eb710c60e0f816deab4d919287c6a0cd9d2cd3'
+
+	des_ctr_de(mut src, key[..8], iv)
+	assert src.bytestr() == str
+	println('test_des_ctr ok')
+}
+
+fn des_ctr_en(mut src []byte, key []byte, iv []byte) {
+	block := des.new_cipher(key)
+	mode := cipher.new_ctr(block, iv)
+	mode.xor_key_stream(mut src, src.clone())
+}
+
+fn des_ctr_de(mut src []byte, key []byte, iv []byte) {
+	block := des.new_cipher(key)
+	mode := cipher.new_ctr(block, iv)
+	mode.xor_key_stream(mut src, src.clone())
+}
+
+fn triple_des_ctr_en(mut src []byte, key []byte, iv []byte) {
+	block := des.new_triple_des_cipher(key)
+	mode := cipher.new_ctr(block, iv)
+	mode.xor_key_stream(mut src, src.clone())
+}
+
+fn triple_des_ctr_de(mut src []byte, key []byte, iv []byte) {
+	block := des.new_triple_des_cipher(key)
+	mode := cipher.new_ctr(block, iv)
+	mode.xor_key_stream(mut src, src.clone())
+}


### PR DESCRIPTION
This PR implements the Counter (CTR) Mode (ported from go standard library (simplified)) for block ciphers such as AES or DES.
To check the correctness of the simplification, use the following Go test: https://go.dev/play/p/KQEz5B8Cb6I

```v
import crypto.aes
import crypto.cipher

fn test_aes_ctr() {
	key := '6368616e676520746869732070617373'.bytes()
	iv := '1234567890123456'.bytes()
	str := '73c86d43a9d700a253a96c85b0f6b03ac9792e0e757f869cca306bd3cba1c62b'

	mut src := str.bytes()

	aes_ctr_en(mut src, key, iv)
	assert src.hex() == '04380c1470ab2d8a0b3f9b4c1949b8ace811f22bc0a455a8946a3ea7a03e9f8440820f273ce749e955e4adb9e8f6ffde82bae507e0b6164b531d3eeb32f5beb5'

	aes_ctr_de(mut src, key, iv)
	assert src.bytestr() == str
	println('test_aes_ctr ok')
}

fn aes_ctr_en(mut src []byte, key []byte, iv []byte) {
	block := aes.new_cipher(key)
	mode := cipher.new_ctr(block, iv)
	mode.xor_key_stream(mut src, src.clone())
}

fn aes_ctr_de(mut src []byte, key []byte, iv []byte) {
	block := aes.new_cipher(key)
	mode := cipher.new_ctr(block, iv)
	mode.xor_key_stream(mut src, src.clone())
}
```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
