### PR TITLE
crypto: implement Output Feedback (OFB) Mode for AES and DES

### DIFF
--- a/vlib/crypto/cipher/aes_ofb_test.v
+++ b/vlib/crypto/cipher/aes_ofb_test.v
@@ -10,9 +10,11 @@ fn test_aes_ofb() {
 
 	aes_ofb_en(mut src, key, iv)
 	assert src.hex() == '04380c1470ab2d8a0b3f9b4c1949b8aca120db226fa0a848236f9904f786dfc39bc433b5d3870d1cfdef36debdee5e6f39b0e8e9462b0151d61e822944181b51'
-
-	aes_ofb_de(mut src, key, iv)
-	assert src.bytestr() == str
+	dump(src.hex())
+	mut plaintext := src.clone()
+	aes_ofb_de(mut plaintext, key, iv)
+	assert plaintext.bytestr() == str
+	dump(plaintext.bytestr())
 	println('test_aes_ofb ok')
 }
 

--- a/vlib/crypto/cipher/aes_ofb_test.v
+++ b/vlib/crypto/cipher/aes_ofb_test.v
@@ -1,7 +1,7 @@
 import crypto.aes
 import crypto.cipher
 
-fn test_aes_cbc() {
+fn test_aes_ofb() {
 	key := '6368616e676520746869732070617373'.bytes()
 	iv := '1234567890123456'.bytes()
 	str := '73c86d43a9d700a253a96c85b0f6b03ac9792e0e757f869cca306bd3cba1c62b'

--- a/vlib/crypto/cipher/aes_ofb_test.v
+++ b/vlib/crypto/cipher/aes_ofb_test.v
@@ -1,0 +1,29 @@
+import crypto.aes
+import crypto.cipher
+
+fn test_aes_cbc() {
+	key := '6368616e676520746869732070617373'.bytes()
+	iv := '1234567890123456'.bytes()
+	str := '73c86d43a9d700a253a96c85b0f6b03ac9792e0e757f869cca306bd3cba1c62b'
+
+	mut src := str.bytes()
+
+	aes_ofb_en(mut src, key, iv)
+	assert src.hex() == '04380c1470ab2d8a0b3f9b4c1949b8aca120db226fa0a848236f9904f786dfc39bc433b5d3870d1cfdef36debdee5e6f39b0e8e9462b0151d61e822944181b51'
+
+	aes_ofb_de(mut src, key, iv)
+	assert src.bytestr() == str
+	println('test_aes_ofb ok')
+}
+
+fn aes_ofb_en(mut src []byte, key []byte, iv []byte) {
+	block := aes.new_cipher(key)
+	mode := cipher.new_ofb(block, iv)
+	mode.xor_key_stream(mut src, src.clone())
+}
+
+fn aes_ofb_de(mut src []byte, key []byte, iv []byte) {
+	block := aes.new_cipher(key)
+	mut mode := cipher.new_ofb(block, iv)
+	mode.xor_key_stream(mut src, src.clone())
+}

--- a/vlib/crypto/cipher/des_ofb_test.v
+++ b/vlib/crypto/cipher/des_ofb_test.v
@@ -22,7 +22,7 @@ fn test_des_ofb() {
 	mut src := str.bytes()
 
 	des_ofb_en(mut src, key[..8], iv)
-	assert src.hex() == '2743e2164b8604562f4ab73dd3d1bccb1fc08e77f34560b920ec8cce5c6a110ea1fcdc2a7ddd812e35387435de2985f6e636893db25a9d0683748edc145e1ef0'
+	assert src.hex() == '2743e2164b860456c1313fb9b1196a70bb217dfad57be81cb10f368dd1ee13b06bb776eb52e0b4f6b1af32f44b8f094cfd3c0892021a2aa93f6a9e2139ba26f3'
 
 	des_ofb_de(mut src, key[..8], iv)
 	assert src.bytestr() == str

--- a/vlib/crypto/cipher/des_ofb_test.v
+++ b/vlib/crypto/cipher/des_ofb_test.v
@@ -1,0 +1,54 @@
+import crypto.des
+import crypto.cipher
+
+const (
+	key = '123456789012345678901234'.bytes()
+	iv  = 'abcdegfh'.bytes()
+	str = '73c86d43a9d700a253a96c85b0f6b03ac9792e0e757f869cca306bd3cba1c62b'
+)
+
+fn test_triple_des_ofb() {
+	mut src := str.bytes()
+
+	triple_des_ofb_en(mut src, key, iv)
+	assert src.hex() == '00d963619a67c84e46741a47e972e407121885af78b8ef64a9b835366e5314b8031940a9c33a4c0e1ce3b417c9fd04c3f99f31821ebfc9f8cb9e80cc50cfd91e'
+
+	triple_des_ofb_de(mut src, key, iv)
+	assert src.bytestr() == str
+	println('test_triple_des_ofb ok')
+}
+
+fn test_des_ofb() {
+	mut src := str.bytes()
+
+	des_ofb_en(mut src, key[..8], iv)
+	assert src.hex() == '2743e2164b8604562f4ab73dd3d1bccb1fc08e77f34560b920ec8cce5c6a110ea1fcdc2a7ddd812e35387435de2985f6e636893db25a9d0683748edc145e1ef0'
+
+	des_ofb_de(mut src, key[..8], iv)
+	assert src.bytestr() == str
+	println('test_des_ofb ok')
+}
+
+fn des_ofb_en(mut src []byte, key []byte, iv []byte) {
+	block := des.new_cipher(key)
+	mode := cipher.new_ofb(block, iv)
+	mode.xor_key_stream(mut src, src.clone())
+}
+
+fn des_ofb_de(mut src []byte, key []byte, iv []byte) {
+	block := des.new_cipher(key)
+	mut mode := cipher.new_ofb(block, iv)
+	mode.xor_key_stream(mut src, src.clone())
+}
+
+fn triple_des_ofb_en(mut src []byte, key []byte, iv []byte) {
+	block := des.new_triple_des_cipher(key)
+	mode := cipher.new_ofb(block, iv)
+	mode.xor_key_stream(mut src, src.clone())
+}
+
+fn triple_des_ofb_de(mut src []byte, key []byte, iv []byte) {
+	block := des.new_triple_des_cipher(key)
+	mut mode := cipher.new_ofb(block, iv)
+	mode.xor_key_stream(mut src, src.clone())
+}

--- a/vlib/crypto/cipher/ofb.v
+++ b/vlib/crypto/cipher/ofb.v
@@ -1,0 +1,81 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// OFB (Output Feedback) Mode.
+module cipher
+
+import crypto.internal.subtle
+
+struct Ofb {
+mut:
+	b        Block
+	cipher   []byte
+	out      []byte
+	out_used int
+}
+
+// new_ofb returns a Ofb that encrypts or decrypts using the block cipher b
+// in output feedback mode. The initialization vector iv's length must be equal
+// to b's block size.
+pub fn new_ofb(b Block, iv []byte) Ofb {
+	block_size := b.block_size
+	if iv.len != block_size {
+		panic('cipher.new_ofb: IV length must be equal block size')
+	}
+	mut buf_size := cipher.stream_buffer_size
+	if buf_size < block_size {
+		buf_size = block_size
+	}
+
+	x := Ofb{
+		b: b
+		cipher: []byte{len: block_size}
+		out: []byte{len: buf_size}
+		out_used: 0
+	}
+
+	copy(x.cipher, iv)
+	return x
+}
+
+pub fn (x &Ofb) xor_key_stream(mut dst_ []byte, src_ []byte) {
+	unsafe {
+		mut dst := *dst_
+		mut src := src_
+
+		if dst.len < src.len {
+			panic('crypto.cipher.xor_key_stream: output smaller than input')
+		}
+
+		if subtle.inexact_overlap(dst[..src.len], src) {
+			panic('crypto.cipher.xor_key_stream: invalid buffer overlap')
+		}
+
+		for src.len > 0 {
+			if x.out_used >= x.out.len - x.b.block_size {
+				bs := x.b.block_size
+				mut remain := x.out.len - x.out_used
+				if remain <= x.out_used {
+					copy(x.out, x.out[x.out_used..])
+
+					x.out = x.out[..x.out.cap]
+
+					for remain < x.out.len - bs {
+						x.b.encrypt(mut x.cipher, x.cipher)
+						copy(x.out[remain..], x.cipher)
+						remain += bs
+					}
+					x.out = x.out[..remain]
+					x.out_used = 0
+				}
+			}
+
+			n := xor_bytes(mut dst, src, x.out[x.out_used..])
+
+			dst = dst[n..]
+			src = src[n..]
+			x.out_used += n
+		}
+	}
+}


### PR DESCRIPTION
This PR implements the Output Feedback (OFB) Mode (ported from go standard library (simplified)) for block ciphers such as AES or DES.
To check the correctness of the simplification, use the following Go test: https://go.dev/play/p/u5whVghNoU7

```v
import crypto.aes
import crypto.cipher

fn test_aes_ofb() {
	key := '6368616e676520746869732070617373'.bytes()
	iv := '1234567890123456'.bytes()
	str := '73c86d43a9d700a253a96c85b0f6b03ac9792e0e757f869cca306bd3cba1c62b'

	mut src := str.bytes()

	aes_ofb_en(mut src, key, iv)
	assert src.hex() == '04380c1470ab2d8a0b3f9b4c1949b8aca120db226fa0a848236f9904f786dfc39bc433b5d3870d1cfdef36debdee5e6f39b0e8e9462b0151d61e822944181b51'

	aes_ofb_de(mut src, key, iv)
	assert src.bytestr() == str
	println('test_aes_ofb ok')
}

fn aes_ofb_en(mut src []byte, key []byte, iv []byte) {
	block := aes.new_cipher(key)
	mode := cipher.new_ofb(block, iv)
	mode.xor_key_stream(mut src, src.clone())
}

fn aes_ofb_de(mut src []byte, key []byte, iv []byte) {
	block := aes.new_cipher(key)
	mut mode := cipher.new_ofb(block, iv)
	mode.xor_key_stream(mut src, src.clone())
}
``` 
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
