### PR TITLE
fmt: fix comments starting with `

### DIFF
--- a/vlib/datatypes/bstree.v
+++ b/vlib/datatypes/bstree.v
@@ -247,9 +247,7 @@ fn (bst &BSTree<T>) get_node(node &BSTreeNode<T>, value T) &BSTreeNode<T> {
 // otherwise the a false value is returned.
 //
 // An example of usage can be the following one
-//```v
-// left_value, exist := bst.to_left(10)
-//```
+// 	left_value, exist := bst.to_left(10)
 pub fn (bst &BSTree<T>) to_left(value T) ?T {
 	node := bst.get_node(bst.root, value)
 	if !node.is_init {
@@ -263,9 +261,7 @@ pub fn (bst &BSTree<T>) to_left(value T) ?T {
 // otherwise, the boolean value is false
 // An example of usage can be the following one
 //
-//```v
-// left_value, exist := bst.to_right(10)
-//```
+// 	left_value, exist := bst.to_right(10)
 pub fn (bst &BSTree<T>) to_right(value T) ?T {
 	node := bst.get_node(bst.root, value)
 	if !node.is_init {

--- a/vlib/gg/enums.v
+++ b/vlib/gg/enums.v
@@ -80,10 +80,10 @@ pub enum KeyCode {
 	x = 88
 	y = 89
 	z = 90
-	left_bracket = 91 //[
-	backslash = 92 //\
-	right_bracket = 93 //]
-	grave_accent = 96 //`
+	left_bracket = 91 // [
+	backslash = 92 // \
+	right_bracket = 93 // ]
+	grave_accent = 96 // `
 	world_1 = 161 // non-us #1
 	world_2 = 162 // non-us #2
 	escape = 256

--- a/vlib/gg/gg.js.v
+++ b/vlib/gg/gg.js.v
@@ -119,10 +119,10 @@ pub enum DOMKeyCode {
 	x = 88
 	y = 89
 	z = 90
-	left_bracket = 91 //[
-	backslash = 92 //\
-	right_bracket = 93 //]
-	grave_accent = 96 //`
+	left_bracket = 91 // [
+	backslash = 92 // \
+	right_bracket = 93 // ]
+	grave_accent = 96 // `
 	world_1 = 161 // non-us #1
 	world_2 = 162 // non-us #2
 	escape = 256

--- a/vlib/sokol/sapp/enums.v
+++ b/vlib/sokol/sapp/enums.v
@@ -92,10 +92,10 @@ pub enum KeyCode {
 	x = 88
 	y = 89
 	z = 90
-	left_bracket = 91 //[
-	backslash = 92 //\
-	right_bracket = 93 //]
-	grave_accent = 96 //`
+	left_bracket = 91 // [
+	backslash = 92 // \
+	right_bracket = 93 // ]
+	grave_accent = 96 // `
 	world_1 = 161 // non-us #1
 	world_2 = 162 // non-us #2
 	escape = 256

--- a/vlib/v/fmt/comments.v
+++ b/vlib/v/fmt/comments.v
@@ -48,7 +48,7 @@ pub fn (mut f Fmt) comment(node ast.Comment, options CommentsOptions) {
 		mut s := node.text.trim_left('\x01').trim_right(' ')
 		mut out_s := '//'
 		if s != '' {
-			if is_char_alphanumeric(s[0]) {
+			if is_char_alphanumeric(s[0]) || s[0] == `\`` {
 				out_s += ' '
 			}
 			out_s += s


### PR DESCRIPTION
The beginning of the discussion took place in https://github.com/vlang/v/issues/6684.

I agree with all special characters except this one: `

In [Go2V](https://github.com/vlang/go2v) I often write comments of this style
```v
// `for..in` syntax
// `fmt.Println()` -> `println()`
```
It's pretty annoying having to manually put a space at the beginning of each comment of this type. Moreover I don't see any situation where this PR can cause issues.