### PR TITLE
fmt: improve single line const comment placement

### DIFF
--- a/vlib/crypto/ed25519/internal/edwards25519/scalar.v
+++ b/vlib/crypto/ed25519/internal/edwards25519/scalar.v
@@ -1099,7 +1099,7 @@ fn generate_scalar(size int) ?Scalar {
 	return reflect.ValueOf(s)
 	*/
 	mut s := edwards25519.sc_zero
-	diceroll := rand.intn(100) or {0}
+	diceroll := rand.intn(100) or { 0 }
 	match true {
 		/*
 		case diceroll == 0:

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -846,7 +846,7 @@ pub fn (mut f Fmt) const_decl(node ast.ConstDecl) {
 			f.writeln('')
 		} else {
 			if node.end_comments.len > 0 && node.end_comments[0].text.contains('\n') {
-				f.writeln('')
+				f.writeln('\n')
 			}
 			f.comments(node.end_comments, inline: true)
 		}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -842,10 +842,20 @@ pub fn (mut f Fmt) const_decl(node ast.ConstDecl) {
 		f.write(strings.repeat(` `, align_infos[align_idx].max - field.name.len))
 		f.write('= ')
 		f.expr(field.expr)
-		f.writeln('')
+		if node.is_block {
+			f.writeln('')
+		} else {
+			if node.end_comments.len > 0 && node.end_comments[0].text.contains('\n') {
+				f.writeln('')
+			}
+			f.comments(node.end_comments, inline: true)
+		}
 		prev_field = field
 	}
-	f.comments_after_last_field(node.end_comments)
+
+	if node.is_block {
+		f.comments_after_last_field(node.end_comments)
+	}
 	if node.is_block {
 		f.indent--
 		f.writeln(')\n')

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -845,6 +845,8 @@ pub fn (mut f Fmt) const_decl(node ast.ConstDecl) {
 		if node.is_block {
 			f.writeln('')
 		} else {
+			// Write out single line comments after const expr if present
+			// E.g.: `const x = 1 // <comment>`
 			if node.end_comments.len > 0 && node.end_comments[0].text.contains('\n') {
 				f.writeln('\n')
 			}
@@ -855,6 +857,9 @@ pub fn (mut f Fmt) const_decl(node ast.ConstDecl) {
 
 	if node.is_block {
 		f.comments_after_last_field(node.end_comments)
+	} else if node.end_comments.len == 0 {
+		// If no single line comments after the const expr is present
+		f.writeln('')
 	}
 	if node.is_block {
 		f.indent--

--- a/vlib/v/fmt/tests/consts_with_comments_expected.vv
+++ b/vlib/v/fmt/tests/consts_with_comments_expected.vv
@@ -1,0 +1,14 @@
+// leave
+const one = 1 // leave
+
+// move
+
+const two = 2
+/*
+move
+*/
+
+const three = 3 // rewrite and leave
+
+// leave
+const four = 4 // leave

--- a/vlib/v/fmt/tests/consts_with_comments_expected.vv
+++ b/vlib/v/fmt/tests/consts_with_comments_expected.vv
@@ -4,6 +4,7 @@ const one = 1 // leave
 // move
 
 const two = 2
+
 /*
 move
 */

--- a/vlib/v/fmt/tests/consts_with_comments_input.vv
+++ b/vlib/v/fmt/tests/consts_with_comments_input.vv
@@ -1,0 +1,11 @@
+// leave
+const one = 1 // leave
+// move
+
+const two = 2 /* move
+*/
+
+const three = 3 /* rewrite and leave */
+
+// leave
+const four = 4 // leave

--- a/vlib/v/fmt/tests/consts_with_comments_keep.vv
+++ b/vlib/v/fmt/tests/consts_with_comments_keep.vv
@@ -2,3 +2,8 @@ const (
 	fsm_state_array = ['init', 'state_a', 'state_b', 'state_c', 'exit'] // use as a first half key for map see fsm_state_ev_fn, the same order as in enum FSM_state
 	fsm_event_array = ['ev1', 'ev2', 'ev3', 'ev4', 'ev5'] // use as a second half key for map see fsm_state_ev_fn, the same order as in enum FSM_event
 )
+
+// Keep
+const one = 1 // Keep
+
+// Keep

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3292,6 +3292,8 @@ fn (mut p Parser) const_decl() ast.ConstDecl {
 	p.top_level_statement_end()
 	if is_block {
 		p.check(.rpar)
+	} else {
+		comments << p.eat_comments(same_line: true)
 	}
 	return ast.ConstDecl{
 		pos: start_pos.extend_with_last_line(const_pos, p.prev_tok.line_nr)


### PR DESCRIPTION
This PR improves the placement of tail comments after *single line* const expressions.

Before this PR, the behaviour was:

`input.v`
```v
// leave 1.0
const one = 1 // leave 1.1
// move me 1.2
const two = 2 /* move 2
*/
```

`input.fmt.v`
```v
// leave 1.0
const one = 1

// leave 1.1
// move me 1.2

const two = 2

/*
move 2
*/
```

After this PR:

`input.v`
```v
// leave 1.0
const one = 1 // leave 1.1
// move me 1.2
const two = 2 /* move 2
*/
```

`input.fmt.v`
```v
// leave 1.0
const one = 1 // leave 1.1

// move me 1.2
const two = 2

/*
move 2
*/
```

... I find the behaviour introduced with this PR a bit more logical.
The most important part, to me, is that the trailing comment after the single line const expression is kept:
`const one = 1 // leave this comment`
`const two = 2 /* also leave this comment - but rewrite to use "//" */`

```
const three = 3 /* but
move this */
```

So basically it fixes it to have same behaviour as comments after `type X = y // <comment>` - which is nice