### PR TITLE
parser: fix optional expr with array value

### DIFF
--- a/vlib/crypto/ed25519/internal/edwards25519/scalar.v
+++ b/vlib/crypto/ed25519/internal/edwards25519/scalar.v
@@ -1099,7 +1099,7 @@ fn generate_scalar(size int) ?Scalar {
 	return reflect.ValueOf(s)
 	*/
 	mut s := edwards25519.sc_zero
-	diceroll := rand.intn(100) or {0}
+	diceroll := rand.intn(100) or { 0 }
 	match true {
 		/*
 		case diceroll == 0:

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -376,9 +376,7 @@ pub fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_iden
 				return node
 			}
 			p.is_stmt_ident = is_stmt_ident
-		} else if p.tok.kind in [.lsbr, .nilsbr]
-			&& (p.inside_fn || p.tok.line_nr == p.prev_tok.line_nr) {
-			// node = p.index_expr(node)
+		} else if p.tok.kind in [.lsbr, .nilsbr] && p.tok.line_nr == p.prev_tok.line_nr {
 			if p.tok.kind == .nilsbr {
 				node = p.index_expr(node, true)
 			} else {

--- a/vlib/v/parser/tests/const_index.vv
+++ b/vlib/v/parser/tests/const_index.vv
@@ -3,9 +3,7 @@ const x = 4
 [deprecated]
 fn g() {
 	a := [3]
-	// indexing is currently allowed on next line
-	_ = a
-	[0]
+	_ = a[0]
 }
 
 const y = 5
@@ -16,7 +14,5 @@ const z = 6
 [typedef]
 struct C.Foo{}
 
-// test implicit main allows indexing on next line
 a := [3]
-_ := a
-[0]
+_ := a[0]

--- a/vlib/v/tests/option_expr_with_array_value_test.v
+++ b/vlib/v/tests/option_expr_with_array_value_test.v
@@ -1,0 +1,23 @@
+struct Empty {
+	empty string
+}
+
+fn print_error() ?[]Empty {
+	mut test := []Empty{}
+	test << Empty{
+		empty: 'Test'
+	}
+	if test[0].empty != '' {
+		return error('Not empty')
+	}
+	return test
+}
+
+fn test_option_expr_with_array_value() {
+	test_error := print_error() or {
+		eprintln(err)
+		[]Empty{}
+	}
+	println(test_error)
+	assert '$test_error' == '[]'
+}


### PR DESCRIPTION
This PR fix optional expr with array value.

- Fix optional expr with array value.
- Add test.

```vlang
pub struct Empty {
	empty string
}

fn print_error() ?[]Empty {
	mut test := []Empty{}
	test << Empty{
		empty: 'Test'
	}
	if test[0].empty != '' {
		return error('Not empty')
	}
	return test
}

pub fn main() {
	test_error := print_error() or {
		eprintln(err)
		[]Empty{}
	}
	println(test_error)
	assert '$test_error' == '[]'
}

PS D:\Test\v\tt1> v run .
Not empty
[]
```