### PR TITLE
ast: cleanup in find_method_with_generic_parent()

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1290,7 +1290,6 @@ pub fn (t &TypeSymbol) find_method_with_generic_parent(name string) ?Fn {
 						}
 						else {}
 					}
-				} else {
 				}
 			}
 		}

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1267,7 +1267,7 @@ pub fn (t &TypeSymbol) find_method_with_generic_parent(name string) ?Fn {
 							mut method := x
 							generic_names := parent_sym.info.generic_types.map(table.sym(it).name)
 							return_sym := table.sym(method.return_type)
-							if return_sym.kind == .struct_ {
+							if return_sym.kind in [.struct_, .interface_, .sum_type] {
 								method.return_type = table.unwrap_generic_type(method.return_type,
 									generic_names, t.info.concrete_types)
 							} else {


### PR DESCRIPTION
This PR makes cleanup in find_method_with_generic_parent().

- Also unwrap `interface` and `sum_type`  method generic return type.