### PR TITLE
examples: Improve sendbus example

### DIFF
--- a/examples/eventbus/eventbus.v
+++ b/examples/eventbus/eventbus.v
@@ -2,12 +2,27 @@ module main
 
 import some_module
 
-fn main() {
-	mut sub := some_module.get_subscriber()
-	sub.subscribe('error', on_error)
-	some_module.do_work()
+struct Receiver {
+mut:
+	ok bool
 }
 
-fn on_error(sender voidptr, e &some_module.MyError, x voidptr) {
-	println(e.message)
+fn main() {
+	mut sub := some_module.get_subscriber()
+	r := Receiver{}
+	sub.subscribe_method('event_foo', on_foo, r)
+	sub.subscribe('event_bar', on_bar)
+	
+	println("Receiver ok: "+r.ok.str())
+	some_module.do_work()
+	println("Receiver ok: "+r.ok.str())
+}
+
+fn on_foo(mut receiver &Receiver, e &some_module.Event, sender voidptr) {
+	receiver.ok = true
+	println('on_foo :: ' +e.message)
+}
+
+fn on_bar(receiver voidptr, e &some_module.Event, sender voidptr) {
+	println('on_bar :: ' +e.message)
 }

--- a/examples/eventbus/eventbus.v
+++ b/examples/eventbus/eventbus.v
@@ -13,19 +13,19 @@ fn main() {
 	sub.subscribe_method('event_foo', on_foo, r)
 	sub.subscribe('event_bar', on_bar)
 	sub.subscribe('event_baz', on_baz)
-	
-	println("Receiver ok: "+r.ok.str())
+
+	println('Receiver ok: ' + r.ok.str())
 	some_module.do_work()
-	println("Receiver ok: "+r.ok.str())
+	println('Receiver ok: ' + r.ok.str())
 }
 
-fn on_foo(mut receiver &Receiver, e &some_module.EventMetadata, sender voidptr) {
+fn on_foo(mut receiver Receiver, e &some_module.EventMetadata, sender voidptr) {
 	receiver.ok = true
-	println('on_foo :: ' +e.message)
+	println('on_foo :: ' + e.message)
 }
 
 fn on_bar(receiver voidptr, e &some_module.EventMetadata, sender voidptr) {
-	println('on_bar :: ' +e.message)
+	println('on_bar :: ' + e.message)
 }
 
 fn on_baz(receiver voidptr, event voidptr, d &some_module.Duration) {

--- a/examples/eventbus/eventbus.v
+++ b/examples/eventbus/eventbus.v
@@ -12,17 +12,22 @@ fn main() {
 	r := Receiver{}
 	sub.subscribe_method('event_foo', on_foo, r)
 	sub.subscribe('event_bar', on_bar)
+	sub.subscribe('event_baz', on_baz)
 	
 	println("Receiver ok: "+r.ok.str())
 	some_module.do_work()
 	println("Receiver ok: "+r.ok.str())
 }
 
-fn on_foo(mut receiver &Receiver, e &some_module.Event, sender voidptr) {
+fn on_foo(mut receiver &Receiver, e &some_module.EventMetadata, sender voidptr) {
 	receiver.ok = true
 	println('on_foo :: ' +e.message)
 }
 
-fn on_bar(receiver voidptr, e &some_module.Event, sender voidptr) {
+fn on_bar(receiver voidptr, e &some_module.EventMetadata, sender voidptr) {
 	println('on_bar :: ' +e.message)
+}
+
+fn on_baz(receiver voidptr, event voidptr, d &some_module.Duration) {
+	println('on_baz :: ' + d.hours.str())
 }

--- a/examples/eventbus/modules/some_module/some_module.v
+++ b/examples/eventbus/modules/some_module/some_module.v
@@ -21,7 +21,7 @@ pub fn do_work() {
 	for i in 0 .. 10 {
 		println('working...')
 		if i == 5 {
-			event_metadata := &EventMetadata{'Iteration '+i.str()}
+			event_metadata := &EventMetadata{'Iteration ' + i.str()}
 			some_module.eb.publish('event_foo', duration, event_metadata)
 			some_module.eb.publish('event_bar', duration, event_metadata)
 		}

--- a/examples/eventbus/modules/some_module/some_module.v
+++ b/examples/eventbus/modules/some_module/some_module.v
@@ -6,27 +6,27 @@ const (
 	eb = eventbus.new()
 )
 
-pub struct Work {
+pub struct Duration {
 pub:
 	hours int
 }
 
-pub struct Event {
+pub struct EventMetadata {
 pub:
 	message string
 }
 
 pub fn do_work() {
-	work := Work{10}
+	duration := Duration{10}
 	for i in 0 .. 10 {
 		println('working...')
 		if i == 5 {
-			error := &Event{'Iteration '+i.str()}
-			some_module.eb.publish('event_foo', work, error)
-			some_module.eb.publish('event_bar', work, error)
+			event_metadata := &EventMetadata{'Iteration '+i.str()}
+			some_module.eb.publish('event_foo', duration, event_metadata)
+			some_module.eb.publish('event_bar', duration, event_metadata)
 		}
 	}
-	some_module.eb.publish('event_bar', &Work{42}, &Event{'Additional data at the end.'})
+	some_module.eb.publish('event_baz', &Duration{42}, &EventMetadata{'Additional data at the end.'})
 }
 
 pub fn get_subscriber() eventbus.Subscriber {

--- a/examples/eventbus/modules/some_module/some_module.v
+++ b/examples/eventbus/modules/some_module/some_module.v
@@ -11,22 +11,22 @@ pub:
 	hours int
 }
 
-pub struct MyError {
+pub struct Event {
 pub:
 	message string
 }
 
 pub fn do_work() {
-	work := Work{20}
-	for i in 0 .. 20 {
+	work := Work{10}
+	for i in 0 .. 10 {
 		println('working...')
-		if i == 15 {
-			error := &MyError{'There was an error.'}
-			some_module.eb.publish('error', work, error)
-			some_module.eb.publish('error', work, error)
-			return
+		if i == 5 {
+			error := &Event{'Iteration '+i.str()}
+			some_module.eb.publish('event_foo', work, error)
+			some_module.eb.publish('event_bar', work, error)
 		}
 	}
+	some_module.eb.publish('event_bar', &Work{42}, &Event{'Additional data at the end.'})
 }
 
 pub fn get_subscriber() eventbus.Subscriber {


### PR DESCRIPTION
This PR improves the readability of the `sendbus` example.
It adds 3 examples of handlers, covering a client-defined receiver, a server-defined structure and additional information.
