### PR TITLE
parser: check the redefinition of built-in `IError` (fix #12834)

### DIFF
--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -47,6 +47,10 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 			name_pos)
 		return ast.StructDecl{}
 	}
+	if name == 'IError' && p.mod != 'builtin' {
+		p.error_with_pos('cannot register struct `IError`, it is builtin interface type',
+			name_pos)
+	}
 	generic_types, _ := p.parse_generic_types()
 	no_body := p.tok.kind != .lcbr
 	if language == .v && no_body {
@@ -453,6 +457,10 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 	name_pos := p.tok.pos()
 	p.check_for_impure_v(language, name_pos)
 	modless_name := p.check_name()
+	if modless_name == 'IError' && p.mod != 'builtin' {
+		p.error_with_pos('cannot register interface `IError`, it is builtin interface type',
+			name_pos)
+	}
 	mut interface_name := ''
 	if language == .js {
 		interface_name = 'JS.' + modless_name

--- a/vlib/v/parser/tests/register_ierror_interface.out
+++ b/vlib/v/parser/tests/register_ierror_interface.out
@@ -1,0 +1,5 @@
+vlib/v/parser/tests/register_ierror_interface.vv:1:11: error: cannot register interface `IError`, it is builtin interface type
+    1 | interface IError {
+      |           ~~~~~~
+    2 |     foo() string
+    3 | }

--- a/vlib/v/parser/tests/register_ierror_interface.vv
+++ b/vlib/v/parser/tests/register_ierror_interface.vv
@@ -1,0 +1,7 @@
+interface IError {
+	foo() string
+}
+
+fn main() {
+	println('Hello World')
+}

--- a/vlib/v/parser/tests/register_ierror_struct.out
+++ b/vlib/v/parser/tests/register_ierror_struct.out
@@ -1,0 +1,5 @@
+vlib/v/parser/tests/register_ierror_struct.vv:1:8: error: cannot register struct `IError`, it is builtin interface type
+    1 | struct IError {
+      |        ~~~~~~
+    2 |     msg string
+    3 | }

--- a/vlib/v/parser/tests/register_ierror_struct.vv
+++ b/vlib/v/parser/tests/register_ierror_struct.vv
@@ -1,0 +1,7 @@
+struct IError {
+	msg string
+}
+
+fn main() {
+	println('Hello World')
+}


### PR DESCRIPTION
This PR check the redefinition of built-in `IError` (fix #12834).

- Check the redefinition of built-in `IError`.
- Add test.

```vlang
interface IError {
	foo() string
}

fn main() {
	println('Hello World')
}

PS D:\Test\v\tt1> v run .
./tt1.v:1:11: error: cannot register interface `IError`, it is builtin interface type
    1 | interface IError {
      |           ~~~~~~
    2 |     foo() string
    3 | }
```
```vlang
struct IError {
	msg string
}

fn main() {
	println('Hello World')
}

PS D:\Test\v\tt1> v run .
./tt1.v:1:8: error: cannot register struct `IError`, it is builtin interface type
    1 | struct IError {
      |        ~~~~~~
    2 |     msg string
    3 | }
```