### PR TITLE
eventbus: Improve eventbus parameter order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 -## V 0.2.5
 -*Not yet released, changelog is not full*
-- Introduce `isize` and `usize` types, deprecate `size_t` in favor of `usize`
+- Introduce `isize` and `usize` types, deprecate `size_t` in favor of `usize`.
+- eventbus: event metadata after event in formal parameter order.
 
 -## V 0.2.4
 -*Not yet released, changelog is not full*

--- a/examples/eventbus/eventbus.v
+++ b/examples/eventbus/eventbus.v
@@ -19,15 +19,15 @@ fn main() {
 	println('Receiver ok: ' + r.ok.str())
 }
 
-fn on_foo(mut receiver Receiver, e &some_module.EventMetadata, sender voidptr) {
+fn on_foo(mut receiver Receiver, sender voidptr, e &some_module.EventMetadata) {
 	receiver.ok = true
 	println('on_foo :: ' + e.message)
 }
 
-fn on_bar(receiver voidptr, e &some_module.EventMetadata, sender voidptr) {
+fn on_bar(receiver voidptr, sender voidptr, e &some_module.EventMetadata) {
 	println('on_bar :: ' + e.message)
 }
 
-fn on_baz(receiver voidptr, event voidptr, d &some_module.Duration) {
+fn on_baz(receiver voidptr, d &some_module.Duration, e voidptr) {
 	println('on_baz :: ' + d.hours.str())
 }

--- a/vlib/eventbus/eventbus.v
+++ b/vlib/eventbus/eventbus.v
@@ -1,6 +1,6 @@
 module eventbus
 
-pub type EventHandlerFn = fn (receiver voidptr, args voidptr, sender voidptr)
+pub type EventHandlerFn = fn (receiver voidptr, sender voidptr, args voidptr)
 
 pub struct Publisher {
 mut:
@@ -57,7 +57,7 @@ pub fn (eb &EventBus) has_subscriber(name string) bool {
 fn (mut pb Publisher) publish(name string, sender voidptr, args voidptr) {
 	for event in pb.registry.events {
 		if event.name == name {
-			event.handler(event.receiver, args, sender)
+			event.handler(event.receiver, sender, args)
 		}
 	}
 	pb.registry.events = pb.registry.events.filter(!(it.name == name && it.once))

--- a/vlib/eventbus/eventbus_test.v
+++ b/vlib/eventbus/eventbus_test.v
@@ -96,13 +96,13 @@ fn test_unsubscribe_reveiver() {
 	assert !eb.subscriber.is_subscribed_method('on_test', r)
 }
 
-fn on_test(receiver voidptr, ev &EventData, sender voidptr) {
+fn on_test(receiver voidptr, sender voidptr, ev &EventData) {
 	assert receiver == 0
 	assert sender != 0
 	assert ev.data == 'hello'
 }
 
-fn on_test_with_receiver(receiver &FakeReceiver, ev &EventData, sender voidptr) {
+fn on_test_with_receiver(receiver &FakeReceiver, sender voidptr, ev &EventData) {
 	assert receiver.ok == false
 	assert sender != 0
 	assert ev.data == 'hello'


### PR DESCRIPTION
Current eventbus parameter order can be improved by putting the event first and its metadata/parameters next, instead of the other way around.
While this is purely cosmetic, it enables better looking event handler callbacks on the client side.
