### PR TITLE
parser: check using 'mut' on fn_decl return type

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -353,7 +353,9 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	same_line := p.tok.line_nr == p.prev_tok.line_nr
 	if (p.tok.kind.is_start_of_type() && (same_line || p.tok.kind != .lsbr))
 		|| (same_line && p.tok.kind == .key_fn) {
+		p.inside_fn_return = true
 		return_type = p.parse_type()
+		p.inside_fn_return = false
 		return_type_pos = return_type_pos.extend(p.prev_tok.pos())
 	}
 	mut type_sym_method_idx := 0

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -376,6 +376,9 @@ pub fn (mut p Parser) parse_type() ast.Type {
 		p.register_auto_import('sync')
 	}
 	mut nr_muls := 0
+	if p.inside_fn_return && p.tok.kind == .key_mut {
+		p.error_with_pos('cannot use `mut` in fn return parameter', p.tok.pos())
+	}
 	if p.tok.kind == .key_mut || is_shared || is_atomic {
 		nr_muls++
 		p.next()

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -377,7 +377,7 @@ pub fn (mut p Parser) parse_type() ast.Type {
 	}
 	mut nr_muls := 0
 	if p.inside_fn_return && p.tok.kind == .key_mut {
-		p.error_with_pos('cannot use `mut` in fn return parameter', p.tok.pos())
+		p.error_with_pos('cannot use `mut` on fn return type', p.tok.pos())
 	}
 	if p.tok.kind == .key_mut || is_shared || is_atomic {
 		nr_muls++

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -40,6 +40,7 @@ mut:
 	inside_or_expr            bool
 	inside_for                bool
 	inside_fn                 bool // true even with implicit main
+	inside_fn_return          bool
 	inside_unsafe_fn          bool
 	inside_str_interp         bool
 	inside_array_lit          bool

--- a/vlib/v/parser/tests/fn_decl_return_type_err_a.out
+++ b/vlib/v/parser/tests/fn_decl_return_type_err_a.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/fn_decl_return_type_err_a.vv:3:13: error: cannot use `mut` in fn return parameter
+    1 | struct Foo{}
+    2 |
+    3 | fn maker() ?mut Foo {
+      |             ~~~
+    4 |     inner := &Foo{}
+    5 |     return *inner

--- a/vlib/v/parser/tests/fn_decl_return_type_err_a.out
+++ b/vlib/v/parser/tests/fn_decl_return_type_err_a.out
@@ -1,4 +1,4 @@
-vlib/v/parser/tests/fn_decl_return_type_err_a.vv:3:13: error: cannot use `mut` in fn return parameter
+vlib/v/parser/tests/fn_decl_return_type_err_a.vv:3:13: error: cannot use `mut` on fn return type
     1 | struct Foo{}
     2 |
     3 | fn maker() ?mut Foo {

--- a/vlib/v/parser/tests/fn_decl_return_type_err_a.vv
+++ b/vlib/v/parser/tests/fn_decl_return_type_err_a.vv
@@ -1,0 +1,9 @@
+struct Foo{}
+
+fn maker() ?mut Foo {
+	inner := &Foo{}
+	return *inner
+}
+
+fn main() {
+}

--- a/vlib/v/parser/tests/fn_decl_return_type_err_b.out
+++ b/vlib/v/parser/tests/fn_decl_return_type_err_b.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/fn_decl_return_type_err_b.vv:3:13: error: cannot use `mut` in fn return parameter
+    1 | struct Foo{}
+    2 |
+    3 | fn maker() (mut Foo) {
+      |             ~~~
+    4 |     inner := &Foo{}
+    5 |     return *inner

--- a/vlib/v/parser/tests/fn_decl_return_type_err_b.out
+++ b/vlib/v/parser/tests/fn_decl_return_type_err_b.out
@@ -1,4 +1,4 @@
-vlib/v/parser/tests/fn_decl_return_type_err_b.vv:3:13: error: cannot use `mut` in fn return parameter
+vlib/v/parser/tests/fn_decl_return_type_err_b.vv:3:13: error: cannot use `mut` on fn return type
     1 | struct Foo{}
     2 |
     3 | fn maker() (mut Foo) {

--- a/vlib/v/parser/tests/fn_decl_return_type_err_b.vv
+++ b/vlib/v/parser/tests/fn_decl_return_type_err_b.vv
@@ -1,0 +1,9 @@
+struct Foo{}
+
+fn maker() (mut Foo) {
+	inner := &Foo{}
+	return *inner
+}
+
+fn main() {
+}


### PR DESCRIPTION
This PR check using 'mut' on fn_decl return type.

- Check using 'mut' on fn_decl return type.
- Add test.

```vlang
struct Foo{}

fn maker() ?mut Foo {
	inner := &Foo{}
	return *inner
}

fn main() {
}

PS D:\Test\v\tt1> v run .
./tt1.v:3:13: error: cannot use `mut` on fn return type
    1 | struct Foo{}
    2 |
    3 | fn maker() ?mut Foo {
      |             ~~~
    4 |     inner := &Foo{}
    5 |     return *inner
```
```vlang
struct Foo{}

fn maker() (mut Foo) {
	inner := &Foo{}
	return *inner
}

fn main() {
}

PS D:\Test\v\tt1> v run .
./tt1.v:3:13: error: cannot use `mut` on fn return type
    1 | struct Foo{}
    2 | 
    3 | fn maker() (mut Foo) {
      |             ~~~
    4 |     inner := &Foo{}
    5 |     return *inner
```