### PR TITLE
cgen: fix fn mut argument of interface type (fix #12537)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1709,6 +1709,11 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 				g.write('&/*sum*/')
 				g.expr(arg.expr)
 				return
+			} else if arg_sym.kind == .interface_ && exp_sym.kind == .interface_
+				&& (arg.expr is ast.Ident || arg.expr is ast.SelectorExpr) {
+				g.write('&/*iface*/')
+				g.expr(arg.expr)
+				return
 			}
 		}
 		if !g.is_json_fn {

--- a/vlib/v/tests/fn_mut_arg_of_interface_test.v
+++ b/vlib/v/tests/fn_mut_arg_of_interface_test.v
@@ -1,0 +1,27 @@
+interface TheInterface {
+mut:
+	an_interface() ?
+}
+
+struct Implementation {
+}
+
+fn (mut i Implementation) an_interface() ? {
+	return
+}
+
+fn maker() ?TheInterface {
+	inner := Implementation{}
+	return inner
+}
+
+fn do(mut inter TheInterface) string {
+	return 'ok'
+}
+
+fn test_fn_mut_arg_of_interface() ? {
+	mut inner := maker() ?
+	ret := do(mut inner)
+	println(ret)
+	assert ret == 'ok'
+}


### PR DESCRIPTION
This PR fix fn mut argument of interface type (fix #12537).

- Fix fn mut argument of interface type.
- Add test.

```vlang
module main

interface TheInterface {
mut:
	an_interface() ?
}

struct Implementation {
}

fn (mut i Implementation) an_interface() ? {
	return
}

fn maker() ?TheInterface {
	inner := Implementation{}
	return inner
}

fn do(mut inter TheInterface) string {
	return 'ok'
}

fn main() {
	mut inner := maker() ?
	ret := do(mut inner)
	println(ret)
	assert ret == 'ok'
}

PS D:\Test\v\tt1> v run .
ok
```