### PR TITLE
cgen: fix error for optional cast to interface (fix #12905, #13116)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2001,7 +2001,7 @@ fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp_is_ptr
 	if !got_is_ptr {
 		if !expr.is_lvalue()
 			|| (expr is ast.Ident && (expr as ast.Ident).obj.is_simple_define_const()) {
-			g.write('ADDR($got_styp, (')
+			g.write('HEAP($got_styp, (')
 			rparen_n += 2
 		} else {
 			g.write('&')

--- a/vlib/v/tests/cast_optional_to_interface_test.v
+++ b/vlib/v/tests/cast_optional_to_interface_test.v
@@ -1,0 +1,40 @@
+[heap]
+struct Package {
+	str string
+}
+
+interface Parser {
+	main &Package
+}
+
+struct ParserV1 {
+mut:
+	main &Package
+}
+
+fn new_0_parser() ?ParserV1 {
+	return ParserV1{
+		main: &Package{
+			str: 'test'
+		}
+	}
+}
+
+fn new_parser() ?Parser {
+	return Parser(new_0_parser() ?)
+}
+
+struct Engine {
+	parser Parser
+}
+
+fn test_cast_optional_to_interface() ? {
+	parser := new_parser() ?
+	assert parser.main.str == 'test'
+	eprintln(voidptr(parser.main))
+	e := Engine{
+		parser: parser
+	}
+	assert e.parser.main.str == 'test'
+	eprintln(voidptr(e.parser.main))
+}


### PR DESCRIPTION
This PR fix error for optional cast to interface (fix #12905, fix #13116).

- Fix error for optional cast to interface.
- Add test.

```vlang
[heap]
struct Package {
	str string
}

interface Parser {
	main &Package
}

struct ParserV1 {
mut:
	main &Package
}

fn new_0_parser() ?ParserV1 {
	return ParserV1{
		main: &Package{
			str: 'test'
		}
	}
}

fn new_parser() ?Parser {
	return Parser(new_0_parser() ?)
}

struct Engine {
	parser Parser
}

fn main() {
	parser := new_parser() ?
	assert parser.main.str == 'test'
	eprintln(voidptr(parser.main))
	e := Engine{
		parser: parser
	}
	assert e.parser.main.str == 'test'
	eprintln(voidptr(e.parser.main))
}

PS D:\Test\v\tt1> v run .
0x8a6890
0x8a6890
```
```vlang
module main

[heap]
struct Package {
	str string
}

interface ParserInterface {
	main &Package
}

struct Parser {
mut:
	main &Package
}

struct Engine {
	parser ParserInterface
}

fn  main() {
	parser := selectparser()
	eprintln(voidptr(parser.main))

	e := Engine{ parser: parser }
	println(e.parser.main.str)
}

fn selectparser() ParserInterface {
	return ParserInterface(newparser())
}

fn newparser() Parser {
	return Parser{main: &Package{ str: "test" }}
}

PS D:\Test\v\tt1> v run .
0x8d6890
test
```