### PR TITLE
parser: fix error for 'for smartcast' - part 1

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1489,7 +1489,7 @@ pub fn (mut t Table) resolve_generic_to_concrete(generic_type Type, generic_name
 			mut elem_type := sym.info.elem_type
 			mut elem_sym := t.sym(elem_type)
 			mut dims := 1
-			for mut elem_sym.info is Array {
+			for elem_sym.info is Array {
 				info := elem_sym.info as Array
 				elem_type = info.elem_type
 				elem_sym = t.sym(elem_type)
@@ -1646,7 +1646,7 @@ pub fn (mut t Table) unwrap_generic_type(typ Type, generic_names []string, concr
 			mut elem_type := ts.info.elem_type
 			mut elem_sym := t.sym(elem_type)
 			mut dims := 1
-			for mut elem_sym.info is Array {
+			for elem_sym.info is Array {
 				info := elem_sym.info as Array
 				elem_type = info.elem_type
 				elem_sym = t.sym(elem_type)
@@ -1857,7 +1857,7 @@ pub fn (mut t Table) replace_generic_type(typ Type, generic_types []Type) {
 			mut elem_type := ts.info.elem_type
 			mut elem_sym := t.sym(elem_type)
 			mut dims := 1
-			for mut elem_sym.info is Array {
+			for elem_sym.info is Array {
 				info := elem_sym.info as Array
 				elem_type = info.elem_type
 				elem_sym = t.sym(elem_type)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2734,7 +2734,7 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 	}
 	mut is_mut := false
 	mut mut_pos := token.Pos{}
-	if p.inside_match || p.inside_if_expr {
+	if p.inside_match || p.inside_if_expr || p.inside_for {
 		match left {
 			ast.Ident, ast.SelectorExpr {
 				is_mut = left.is_mut


### PR DESCRIPTION
This PR fix error for 'for smartcast' - part 1.

```vlang
			mut elem_type := ts.info.elem_type
			mut elem_sym := t.sym(elem_type)
			mut dims := 1
			for mut elem_sym.info is Array {
				info := elem_sym.info as Array
				elem_type = info.elem_type
				elem_sym = t.sym(elem_type)
				dims++
			}
```
The `for smartcast` cannot work before.
Fix it must use 2 steps commit and this is step 1.