### PR TITLE
checker: fix error for array of interface init in for_in (fix #11542)

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -134,6 +134,11 @@ pub fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 				continue
 			}
 			if expr !is ast.TypeNode {
+				if c.table.type_kind(elem_type) == .interface_ {
+					if c.type_implements(typ, elem_type, expr.pos()) {
+						continue
+					}
+				}
 				c.check_expected(typ, elem_type) or {
 					c.error('invalid array element: $err.msg()', expr.pos())
 				}

--- a/vlib/v/tests/array_of_interface_init_test.v
+++ b/vlib/v/tests/array_of_interface_init_test.v
@@ -1,0 +1,36 @@
+struct Dog {
+	breed string
+}
+
+struct Cat {
+	breed string
+}
+
+fn (d Dog) speak() string {
+	return 'woof'
+}
+
+fn (c Cat) speak() string {
+	return 'meow'
+}
+
+interface Speaker {
+	breed string
+	speak() string
+}
+
+fn test_array_of_interface_init() {
+	dog := Dog{'Leonberger'}
+	cat := Cat{'Siamese'}
+
+	mut rets := []string{}
+
+	for item in [Speaker(dog), cat] {
+		println(item.speak())
+		rets << item.speak()
+	}
+
+	assert rets.len == 2
+	assert rets[0] == 'woof'
+	assert rets[1] == 'meow'
+}


### PR DESCRIPTION
This PR fix error for array of interface init in for_in (fix #11542).

- Fix error for array of interface init in for_in.
- Add test.

```vlang
struct Dog {
	breed string
}

struct Cat {
	breed string
}

fn (d Dog) speak() string {
	return 'woof'
}

fn (c Cat) speak() string {
	return 'meow'
}

interface Speaker {
	breed string
	speak() string
}

fn main() {
	dog := Dog{'Leonberger'}
	cat := Cat{'Siamese'}

	mut rets := []string{}

	for item in [Speaker(dog), cat] {
		println(item.speak())
		rets << item.speak()
	}

	assert rets.len == 2
	assert rets[0] == 'woof'
	assert rets[1] == 'meow'
}

PS D:\Test\v\tt1> v run .
woof
meow
```