### PR TITLE
checker: notice incorrect smartcast (fix #12058)

### DIFF
--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -3,6 +3,7 @@
 module checker
 
 import v.ast
+import v.token
 
 fn (mut c Checker) for_c_stmt(node ast.ForCStmt) {
 	c.in_for_count++
@@ -164,4 +165,7 @@ fn (mut c Checker) for_stmt(mut node ast.ForStmt) {
 	c.stmts(node.stmts)
 	c.loop_label = prev_loop_label
 	c.in_for_count--
+	if c.smartcast_mut_pos != token.Pos{} {
+		c.smartcast_mut_pos = token.Pos{}
+	}
 }

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -4,6 +4,7 @@ module checker
 
 import v.ast
 import v.pref
+import v.token
 
 pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 	if_kind := if node.is_comptime { '\$if' } else { 'if' }
@@ -144,6 +145,9 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 				c.stmts_ending_with_expression(branch.stmts)
 			} else {
 				c.stmts(branch.stmts)
+			}
+			if c.smartcast_mut_pos != token.Pos{} {
+				c.smartcast_mut_pos = token.Pos{}
 			}
 		}
 		if expr_required {

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -3,6 +3,7 @@ module checker
 import v.ast
 import v.pref
 import v.util
+import v.token
 import strings
 
 pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
@@ -31,6 +32,9 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 			c.stmts_ending_with_expression(branch.stmts)
 		} else {
 			c.stmts(branch.stmts)
+		}
+		if c.smartcast_mut_pos != token.Pos{} {
+			c.smartcast_mut_pos = token.Pos{}
 		}
 		if node.is_expr {
 			if branch.stmts.len > 0 {

--- a/vlib/v/checker/tests/incorrect_smartcast_err.out
+++ b/vlib/v/checker/tests/incorrect_smartcast_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/incorrect_smartcast_err.vv:10:5: notice: smartcasting requires either an immutable value, or an explicit mut keyword before the value
+    8 | fn main(){
+    9 |     mut example := IExample(Example{field:"test"})
+   10 |     if example is Example{
+      |        ~~~~~~~
+   11 |         println(example.field)
+   12 |     }
+vlib/v/checker/tests/incorrect_smartcast_err.vv:11:19: error: type `IExample` has no field named `field`
+    9 |     mut example := IExample(Example{field:"test"})
+   10 |     if example is Example{
+   11 |         println(example.field)
+      |                         ~~~~~
+   12 |     }
+   13 | }

--- a/vlib/v/checker/tests/incorrect_smartcast_err.vv
+++ b/vlib/v/checker/tests/incorrect_smartcast_err.vv
@@ -1,0 +1,13 @@
+interface IExample{
+}
+
+struct Example{
+	field string
+}
+
+fn main(){
+	mut example := IExample(Example{field:"test"})
+	if example is Example{
+		println(example.field)
+	}
+}


### PR DESCRIPTION
This PR notice incorrect smartcast (fix #12058).

- Notice incorrect smartcast.
- Add test.

```vlang
interface IExample{
}

struct Example{
	field string
}

fn main(){
	mut example := IExample(Example{field:"test"})
	if example is Example{
		println(example.field)
	}
}

PS D:\Test\v\tt1> v run .
./tt1.v:10:5: notice: smartcasting requires either an immutable value, or an explicit mut keyword before the value
    8 | fn main(){
    9 |     mut example := IExample(Example{field:"test"})
   10 |     if example is Example{
      |        ~~~~~~~
   11 |         println(example.field)
   12 |     }
./tt1.v:11:19: error: type `IExample` has no field named `field`
    9 |     mut example := IExample(Example{field:"test"})
   10 |     if example is Example{
   11 |         println(example.field)
      |                         ~~~~~
   12 |     }
   13 | }
```