### PR TITLE
vlib: cli errors now print in red

### DIFF
--- a/vlib/cli/command.v
+++ b/vlib/cli/command.v
@@ -232,11 +232,7 @@ fn (mut cmd Command) parse_commands() {
 fn (mut cmd Command) handle_cb(cb FnCommandCallback, label string) {
 	if !isnil(cb) {
 		cb(*cmd) or {
-			label_message := if term.can_show_color_on_stderr() {
-				term.bright_red('cli $label error:')
-			} else {
-				'cli $label error:'
-			}
+			label_message := term.ecolorize(term.bright_red, 'cli $label error:')
 			eprintln_exit('$label_message $err')
 		}
 	}

--- a/vlib/cli/command.v
+++ b/vlib/cli/command.v
@@ -228,24 +228,30 @@ fn (mut cmd Command) parse_commands() {
 		}
 	}
 	cmd.check_required_flags()
+
+	color_support := term.can_show_color_on_stderr()
 	if !isnil(cmd.pre_execute) {
 		cmd.pre_execute(*cmd) or {
-			eprintln('${term.bright_red('cli preexecution error:')} $err')
+			eprintln('${get_error_msg('preexecution', color_support)} $err')
 			exit(1)
 		}
 	}
 	if !isnil(cmd.execute) {
 		cmd.execute(*cmd) or {
-			eprintln('${term.bright_red('cli execution error:')} $err')
+			eprintln('${get_error_msg('execution', color_support)} $err')
 			exit(1)
 		}
 	}
 	if !isnil(cmd.post_execute) {
 		cmd.post_execute(*cmd) or {
-			eprintln('${term.bright_red('cli postexecution error:')} $err')
+			eprintln('${get_error_msg('postexecution', color_support)} $err')
 			exit(1)
 		}
 	}
+}
+
+fn get_error_msg(name string, color_support bool) string {
+	return if color_support { term.bright_red('cli $name error:') } else { 'cli $name error:' }
 }
 
 fn (cmd Command) check_help_flag() {

--- a/vlib/cli/command.v
+++ b/vlib/cli/command.v
@@ -1,5 +1,7 @@
 module cli
 
+import term
+
 type FnCommandCallback = fn (cmd Command) ?
 
 // str returns the `string` representation of the callback.
@@ -228,19 +230,19 @@ fn (mut cmd Command) parse_commands() {
 	cmd.check_required_flags()
 	if !isnil(cmd.pre_execute) {
 		cmd.pre_execute(*cmd) or {
-			eprintln('cli preexecution error: $err')
+			eprintln('${term.bright_red('cli preexecution error:')} $err')
 			exit(1)
 		}
 	}
 	if !isnil(cmd.execute) {
 		cmd.execute(*cmd) or {
-			eprintln('cli execution error: $err')
+			eprintln('${term.bright_red('cli execution error:')} $err')
 			exit(1)
 		}
 	}
 	if !isnil(cmd.post_execute) {
 		cmd.post_execute(*cmd) or {
-			eprintln('cli postexecution error: $err')
+			eprintln('${term.bright_red('cli postexecution error:')} $err')
 			exit(1)
 		}
 	}

--- a/vlib/term/term.v
+++ b/vlib/term/term.v
@@ -61,10 +61,20 @@ pub fn warn_message(s string) string {
 }
 
 // colorize returns a colored string by running the specified `cfn` over
-// the message `s`, only if colored output is supported by the terminal.
+// the message `s`, only if colored stdout is supported by the terminal.
 // Example: term.colorize(term.yellow, 'the message')
 pub fn colorize(cfn fn (string) string, s string) string {
 	if can_show_color_on_stdout() {
+		return cfn(s)
+	}
+	return s
+}
+
+// ecolorize returns a colored string by running the specified `cfn` over
+// the message `s`, only if colored stderr is supported by the terminal.
+// Example: term.ecolorize(term.bright_red, 'the message')
+pub fn ecolorize(cfn fn (string) string, s string) string {
+	if can_show_color_on_stderr() {
 		return cfn(s)
 	}
 	return s


### PR DESCRIPTION
Errors are now way prettier, see an example with [Go2V](https://github.com/vlang/go2v):

![Screenshot 2022-03-03 at 19 54 01](https://user-images.githubusercontent.com/38606542/156632787-9ab1896a-37f7-40f5-8726-b43f67bc6807.png)

