### PR TITLE
parser: check assign expr with undefined variable (fix #13648)

### DIFF
--- a/vlib/v/checker/tests/assign_expr_undefined_err_m.out
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_m.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/assign_expr_undefined_err_m.vv:5:14: error: undefined variable: `x`
+    3 |     n := 2
+    4 |     x := match a {
+    5 |         'add'{ n + x }
+      |                    ^
+    6 |         else{0}
+    7 |     }

--- a/vlib/v/checker/tests/assign_expr_undefined_err_m.vv
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_m.vv
@@ -1,0 +1,9 @@
+fn main(){
+	a := 'add'
+	n := 2
+	x := match a {
+		'add'{ n + x }
+		else{0}
+	}
+	println(x)
+}

--- a/vlib/v/checker/tests/assign_expr_undefined_err_n.out
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_n.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/assign_expr_undefined_err_n.vv:4:27: error: undefined variable: `x`
+    2 |     a := 'add'
+    3 |     n := 2
+    4 |     x := if a == 'add' { n + x } else { 0 }
+      |                              ^
+    5 |     println(x)
+    6 | }

--- a/vlib/v/checker/tests/assign_expr_undefined_err_n.vv
+++ b/vlib/v/checker/tests/assign_expr_undefined_err_n.vv
@@ -1,0 +1,6 @@
+fn main(){
+	a := 'add'
+	n := 2
+	x := if a == 'add' { n + x } else { 0 }
+	println(x)
+}

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -63,12 +63,36 @@ fn (mut p Parser) check_undefined_variables(exprs []ast.Expr, val ast.Expr) ? {
 			p.check_undefined_variables(exprs, val.left) ?
 			p.check_undefined_variables(exprs, val.right) ?
 		}
+		ast.IfExpr {
+			p.check_undefined_variables(exprs, val.left) ?
+			for branch in val.branches {
+				p.check_undefined_variables(exprs, branch.cond) ?
+				for stmt in branch.stmts {
+					if stmt is ast.ExprStmt {
+						p.check_undefined_variables(exprs, stmt.expr) ?
+					}
+				}
+			}
+		}
 		ast.MapInit {
 			for key in val.keys {
 				p.check_undefined_variables(exprs, key) ?
 			}
 			for value in val.vals {
 				p.check_undefined_variables(exprs, value) ?
+			}
+		}
+		ast.MatchExpr {
+			p.check_undefined_variables(exprs, val.cond) ?
+			for branch in val.branches {
+				for expr in branch.exprs {
+					p.check_undefined_variables(exprs, expr) ?
+				}
+				for stmt in branch.stmts {
+					if stmt is ast.ExprStmt {
+						p.check_undefined_variables(exprs, stmt.expr) ?
+					}
+				}
 			}
 		}
 		ast.ParExpr {


### PR DESCRIPTION
This PR check assign expr with undefined variable (fix #13648).

- Check assign expr with undefined variable.
- Add test.

```vlang
fn main(){
	a := 'add'
	n := 2
	x := match a {
		'add'{ n + x }
		else{ 0 }
	}
	println(x)
}

PS D:\Test\v\tt1> v run .
./tt1.v:5:14: error: undefined variable: `x`
    3 |     n := 2
    4 |     x := match a {
    5 |         'add'{ n + x }
      |                    ^
    6 |         else{ 0 }
    7 |     }
```

```vlang
fn main(){
	a := 'add'
	n := 2
	x := if a == 'add' { n + x } else { 0 }
	println(x)
}

PS D:\Test\v\tt1> v run .
./tt1.v:4:27: error: undefined variable: `x`
    2 |     a := 'add'
    3 |     n := 2
    4 |     x := if a == 'add' { n + x } else { 0 }
      |                              ^
    5 |     println(x)
    6 | }
```