### PR TITLE
checker: fix error for 'or expr with nested match expr' (fix #13628)

### DIFF
--- a/vlib/v/checker/tests/or_err.out
+++ b/vlib/v/checker/tests/or_err.out
@@ -1,10 +1,10 @@
-vlib/v/checker/tests/or_err.vv:4:10: error: last statement in the `or {}` block should be an expression of type `&int` or exit parent scope
-    2 |     return none
+vlib/v/checker/tests/or_err.vv:5:2: error: last statement in the `or {}` block should be an expression of type `&int` or exit parent scope
     3 | }
     4 | a := f() or {
-      |          ~~~~
     5 |     {}
+      |     ^
     6 | }
+    7 | _ = f() or {
 vlib/v/checker/tests/or_err.vv:11:2: error: wrong return type `rune` in the `or {}` block, expected `&int`
     9 | }
    10 | _ = f() or {

--- a/vlib/v/parser/tests/or_default_missing.out
+++ b/vlib/v/parser/tests/or_default_missing.out
@@ -5,10 +5,10 @@ vlib/v/parser/tests/or_default_missing.vv:4:3: error: `or` block must provide a 
       |         ~~~~~~~~~~~~~~~~
     5 |     }
     6 |     println(el)
-vlib/v/parser/tests/or_default_missing.vv:16:16: error: last statement in the `or {}` block should be an expression of type `int` or exit parent scope
-   14 |     }
+vlib/v/parser/tests/or_default_missing.vv:17:11: error: last statement in the `or {}` block should be an expression of type `int` or exit parent scope
    15 |     mut testvar := 0
    16 |     el := m['pp'] or {
-      |                   ~~~~
    17 |         testvar = 12
+      |                 ^
    18 |     }
+   19 |     println('$el $testvar')

--- a/vlib/v/parser/tests/prefix_first.out
+++ b/vlib/v/parser/tests/prefix_first.out
@@ -13,16 +13,16 @@ vlib/v/parser/tests/prefix_first.vv:27:3: warning: move infix `&` operator befor
    28 |     }
    29 | }
 vlib/v/parser/tests/prefix_first.vv:13:6: error: `if` expression requires an expression as the last statement of every branch
-   11 | 
+   11 |
    12 |     // later this should compile correctly
    13 |     _ = if true {
       |         ~~~~~~~
    14 |         v = 1
    15 |         -1
-vlib/v/parser/tests/prefix_first.vv:25:12: error: last statement in the `or {}` block should be an expression of type `&int` or exit parent scope
-   23 |     // later this should compile correctly
+vlib/v/parser/tests/prefix_first.vv:26:5: error: last statement in the `or {}` block should be an expression of type `&int` or exit parent scope
    24 |     v := 3
    25 |     _ = opt() or {
-      |               ~~~~
    26 |         _ = 1
+      |           ^
    27 |         &v
+   28 |     }

--- a/vlib/v/tests/or_expr_with_nested_match_expr_test.v
+++ b/vlib/v/tests/or_expr_with_nested_match_expr_test.v
@@ -1,0 +1,33 @@
+struct API_error {
+pub mut:
+	errors []string
+}
+
+fn delete_secret_v1() API_error {
+	response := req_do() or {
+		match err.msg {
+			'dial_tcp failed' {
+				return API_error{
+					errors: ['Vault server not started']
+				}
+			}
+			else {
+				return API_error{
+					errors: [err.msg]
+				}
+			}
+		}
+	}
+	println(response)
+}
+
+fn req_do() ?string {
+	return error('dial_tcp failed')
+}
+
+fn test_or_expr_with_nested_match_expr() {
+	err := delete_secret_v1()
+	println(err)
+	assert err.errors.len == 1
+	assert err.errors[0] == 'Vault server not started'
+}


### PR DESCRIPTION
This PR fix error for 'or expr with nested match expr' (fix #13628).

- Fix error for 'or expr with nested match expr'.
- Add test.

```vlang
pub struct API_error {
pub mut:
	errors []string
}

pub fn delete_secret_v1() API_error {
	response := req_do() or {
		match err.msg {
			'dial_tcp failed' {
				return API_error{
					errors: ['Vault server not started']
				}
			}
			else {
				return API_error{
					errors: [err.msg]
				}
			}
		}
	}
	println(response)
}

pub fn req_do() ?string {
	return error('dial_tcp failed')
}

pub fn main() {
	err := delete_secret_v1()
	println(err)
	assert err.errors.len == 1
	assert err.errors[0] == 'Vault server not started'
}

PS D:\Test\v\tt1> v run .
API_error{
    errors: ['Vault server not started']
}
```
```vlang
import net.http

pub struct API_error {
pub mut:
	errors []string
}

pub fn delete_secret_v1(mountpoint string, secret string) API_error {
	mut header := http.new_header()

	mut req := http.Request{
		method: .delete,
		header: header,
		url: 'http://127.0.0.1:8200/v1/$mountpoint/$secret'
	}

	response := req.do() or {
		match err.msg {
			'dial_tcp failed' {
				return API_error{errors: ['Vault server not started']}
			}
			else { return API_error{errors: [err.msg]} }
		}
	}
	println(response)
}

pub fn main() {
	println(delete_secret_v1('cubbyhole', 'foo'))
}

PS D:\Test\v\tt1> v run .
API_error{
    errors: ['dial_tcp failed for address 127.0.0.1:8200']
}
```