### PR TITLE
cgen: fix error for time struct init with update (fix #13659)

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -245,7 +245,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 						}
 					}
 				}
-				g.write(field.name)
+				g.write(c_name(field.name))
 			} else {
 				if !g.zero_struct_field(field) {
 					nr_fields--

--- a/vlib/v/tests/struct_of_time_init_with_update_test.v
+++ b/vlib/v/tests/struct_of_time_init_with_update_test.v
@@ -1,0 +1,12 @@
+import time
+
+fn test_struct_of_time_init_with_update() {
+	utc := time.utc()
+
+	t := time.Time{
+		...utc
+	}
+	println(utc)
+	println(t)
+	assert t == utc
+}


### PR DESCRIPTION
This PR fix error for time struct init with update (fix #13659).

- Fix error for time struct init with update.
- Add test.

```vlang
import time

fn main() {
	utc := time.utc()

	t := time.Time{
		...utc
	}
	println(utc)
	println(t)
	assert t == utc
}

PS D:\Test\v\tt1> v run .
2022-03-05 10:44:50
2022-03-05 10:44:50
```