### PR TITLE
cgen: minor cleanup of struct.v

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4359,10 +4359,6 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 	}
 }
 
-fn (mut g Gen) go_back_out(n int) {
-	g.out.go_back(n)
-}
-
 fn (mut g Gen) assoc(node ast.Assoc) {
 	g.writeln('// assoc')
 	if node.typ == 0 {

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -5,16 +5,14 @@ module c
 
 import v.ast
 
-const (
-	skip_struct_init = ['struct stat', 'struct addrinfo']
-)
+const skip_struct_init = ['struct stat', 'struct addrinfo']
 
 fn (mut g Gen) struct_init(node ast.StructInit) {
 	styp := g.typ(node.typ)
 	mut shared_styp := '' // only needed for shared x := St{...
 	if styp in c.skip_struct_init {
 		// needed for c++ compilers
-		g.go_back_out(3)
+		g.out.go_back(3)
 		return
 	}
 	mut sym := g.table.final_sym(g.unwrap_generic(node.typ))


### PR DESCRIPTION
This PR makes minor cleanup of struct.v.

- Remove `g.go_back_out(n)` and unified using `g.out.go_back (n)`.