### PR TITLE
sync: enable tcc compilation of sync programs on Amazon Linux 2 by default

### DIFF
--- a/vlib/sync/stdatomic/1.declarations.c.v
+++ b/vlib/sync/stdatomic/1.declarations.c.v
@@ -21,6 +21,13 @@ $if linux {
 			#flag -L/usr/lib/gcc/x86_64-linux-gnu/10
 			#flag -L/usr/lib/gcc/x86_64-linux-gnu/11
 			#flag -L/usr/lib/gcc/x86_64-linux-gnu/12
+			#flag -L/usr/lib/gcc/x86_64-redhat-linux/6
+			#flag -L/usr/lib/gcc/x86_64-redhat-linux/7
+			#flag -L/usr/lib/gcc/x86_64-redhat-linux/8
+			#flag -L/usr/lib/gcc/x86_64-redhat-linux/9
+			#flag -L/usr/lib/gcc/x86_64-redhat-linux/10
+			#flag -L/usr/lib/gcc/x86_64-redhat-linux/11
+			#flag -L/usr/lib/gcc/x86_64-redhat-linux/12
 		} $else $if arm64 {
 			#flag -L/usr/lib/gcc/aarch64-linux-gnu/6
 			#flag -L/usr/lib/gcc/aarch64-linux-gnu/7
@@ -29,6 +36,13 @@ $if linux {
 			#flag -L/usr/lib/gcc/aarch64-linux-gnu/10
 			#flag -L/usr/lib/gcc/aarch64-linux-gnu/11
 			#flag -L/usr/lib/gcc/aarch64-linux-gnu/12
+			#flag -L/usr/lib/gcc/aarch64-redhat-linux/6
+			#flag -L/usr/lib/gcc/aarch64-redhat-linux/7
+			#flag -L/usr/lib/gcc/aarch64-redhat-linux/8
+			#flag -L/usr/lib/gcc/aarch64-redhat-linux/9
+			#flag -L/usr/lib/gcc/aarch64-redhat-linux/10
+			#flag -L/usr/lib/gcc/aarch64-redhat-linux/11
+			#flag -L/usr/lib/gcc/aarch64-redhat-linux/12
 		}
 		#flag -latomic
 	}


### PR DESCRIPTION
It may also benefit other Red Hat based distros like CentOS and Fedora.