### PR TITLE
cgen: fix error for array of reference auto_str (fix #13662)

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -610,7 +610,11 @@ fn (mut g Gen) gen_str_for_array(info ast.Array, styp string, str_fn_name string
 			// Rune are managed at this level as strings
 			g.auto_str_funcs.writeln('\t\tstring x = str_intp(2, _MOV((StrIntpData[]){{_SLIT("\`"), $c.si_s_code, {.d_s = ${elem_str_fn_name}(it) }}, {_SLIT("\`"), 0, {.d_c = 0 }}}));\n')
 		} else if sym.kind == .string {
-			g.auto_str_funcs.writeln('\t\tstring x = str_intp(2, _MOV((StrIntpData[]){{_SLIT("\'"), $c.si_s_code, {.d_s = it }}, {_SLIT("\'"), 0, {.d_c = 0 }}}));\n')
+			if is_elem_ptr {
+				g.auto_str_funcs.writeln('\t\tstring x = str_intp(2, _MOV((StrIntpData[]){{_SLIT("&\'"), $c.si_s_code, {.d_s = *it }}, {_SLIT("\'"), 0, {.d_c = 0 }}}));\n')
+			} else {
+				g.auto_str_funcs.writeln('\t\tstring x = str_intp(2, _MOV((StrIntpData[]){{_SLIT("\'"), $c.si_s_code, {.d_s = it }}, {_SLIT("\'"), 0, {.d_c = 0 }}}));\n')
+			}
 		} else {
 			// There is a custom .str() method, so use it.
 			// NB: we need to take account of whether the user has defined

--- a/vlib/v/tests/str_array_of_reference_test.v
+++ b/vlib/v/tests/str_array_of_reference_test.v
@@ -1,0 +1,7 @@
+fn test_str_array_of_reference() {
+	names := ['John', 'Paul', 'George', 'Ringo']
+	a := unsafe { [&names[0], &names[1]] }
+	println(a[0])
+	println(a)
+	assert '$a' == "[&'John', &'Paul']"
+}


### PR DESCRIPTION
This PR fix error for array of reference auto_str (fix #13662).

- Fix error for array of reference auto_str.
- Add test.

```vlang
fn main() {
	names := ['John', 'Paul', 'George', 'Ringo']
	a := unsafe { [&names[0], &names[1]] }
	println(a[0])
	println(a)
	assert '$a' == "[&'John', &'Paul']"
}

PS D:\Test\v\tt1> v run .
&John
[&'John', &'Paul']
```