### PR TITLE
cmd/tools: modify .gitattributes to categorize *.vsh and v.mod files properly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
 *.v linguist-language=V text=auto eol=lf
 *.vv linguist-language=V text=auto eol=lf
+*.vsh linguist-language=V text=auto eol=lf
+**/v.mod linguist-language=V text=auto eol=lf
 *.bat text=auto eol=crlf
  Dockerfile.* linguist-language=Dockerfile
 *.toml text eol=lf

--- a/cmd/tools/vcreate.v
+++ b/cmd/tools/vcreate.v
@@ -77,6 +77,8 @@ vls.log
 fn gitattributes_content() string {
 	return '*.v linguist-language=V text=auto eol=lf
 *.vv linguist-language=V text=auto eol=lf
+*.vsh linguist-language=V text=auto eol=lf
+**/v.mod linguist-language=V text=auto eol=lf
 '
 }
 

--- a/cmd/tools/vcreate_test.v
+++ b/cmd/tools/vcreate_test.v
@@ -41,7 +41,7 @@ fn init_and_check() ? {
 		'*.v linguist-language=V text=auto eol=lf',
 		'*.vv linguist-language=V text=auto eol=lf',
 		'*.vsh linguist-language=V text=auto eol=lf',
-		'**/v.mod linguist-language=V text=auto eol=lf'
+		'**/v.mod linguist-language=V text=auto eol=lf',
 		'',
 	].join_lines()
 

--- a/cmd/tools/vcreate_test.v
+++ b/cmd/tools/vcreate_test.v
@@ -40,6 +40,8 @@ fn init_and_check() ? {
 	assert os.read_file('.gitattributes') ? == [
 		'*.v linguist-language=V text=auto eol=lf',
 		'*.vv linguist-language=V text=auto eol=lf',
+		'*.vsh linguist-language=V text=auto eol=lf',
+		'**/v.mod linguist-language=V text=auto eol=lf'
 		'',
 	].join_lines()
 


### PR DESCRIPTION
1. It's annoying to see `v.mod` files being marked as AMPL so the `.gitattributes` correctly assigns the V language to them.
2. The `.vsh` files were initially excluded from the `.gitattributes` list. It wasn't a severe problem but when cloning on Windows machines, the line endings were set to `crlf` which would break `v fmt` by adding unnecessary lines. Setting line endings to `lf` solves the CI issues too.