### PR TITLE
vlib/arrays: add generic copy fn

### DIFF
--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -530,3 +530,15 @@ fn swap_nonoverlapping<T>(x_ &T, y_ &T, count int) {
 		memswap(x, y, len)
 	}
 }
+
+// copy copies the `src` array elements to the `dst` array.
+// The number of the elements copied is the minimum of the length of both arrays.
+// Returns the number of elements copied.
+pub fn copy<T>(dst []T, src []T) int {
+	min := if dst.len < src.len { dst.len } else { src.len }
+	if min > 0 {
+		blen := min * int(sizeof(T))
+		unsafe { vmemmove(&T(dst.data), src.data, blen) }
+	}
+	return min
+}

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -266,18 +266,18 @@ fn test_rotate_left_string() {
 }
 
 fn test_copy() {
-	mut a := [1,2,3]
-	mut b := [4,5,6]
+	mut a := [1, 2, 3]
+	mut b := [4, 5, 6]
 	assert copy(b, a) == 3
-	assert b == [1,2,3]
+	assert b == [1, 2, 3]
 	// check independent copies
 	b[0] = 99
 	assert a[0] == 1
 	// check longer src
 	b << 7
 	assert copy(a, b) == 3
-	assert a == [99,2,3]
+	assert a == [99, 2, 3]
 	// check longer dst
-	assert copy(b, [8,9]) == 2
-	assert b == [8,9,3,7]
+	assert copy(b, [8, 9]) == 2
+	assert b == [8, 9, 3, 7]
 }

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -264,3 +264,20 @@ fn test_rotate_left_string() {
 	rotate_left(mut x, 2)
 	assert x == ['x3', 'x4', 'x5', 'x6', 'x1', 'x2']
 }
+
+fn test_copy() {
+	mut a := [1,2,3]
+	mut b := [4,5,6]
+	assert copy(b, a) == 3
+	assert b == [1,2,3]
+	// check independent copies
+	b[0] = 99
+	assert a[0] == 1
+	// check longer src
+	b << 7
+	assert copy(a, b) == 3
+	assert a == [99,2,3]
+	// check longer dst
+	assert copy(b, [8,9]) == 2
+	assert b == [8,9,3,7]
+}

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -815,11 +815,11 @@ pub fn (b []byte) hex() string {
 // The number of the elements copied is the minimum of the length of both arrays.
 // Returns the number of elements copied.
 // NOTE: This is not an `array` method. It is a function that takes two arrays of bytes.
-// TODO: implement for all types
+// See also: `arrays.copy`.
 pub fn copy(dst []byte, src []byte) int {
 	min := if dst.len < src.len { dst.len } else { src.len }
 	if min > 0 {
-		unsafe { vmemcpy(&byte(dst.data), src.data, min) }
+		unsafe { vmemmove(&byte(dst.data), src.data, min) }
 	}
 	return min
 }


### PR DESCRIPTION
Implement generic version of builtin `fn copy`. Has same semantics as https://pkg.go.dev/builtin#copy.

Make builtin `copy` use `memmove` not `memcpy` as arrays could overlap when sliced.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
