### PR TITLE
checker: fix match expr with enum type value (fix #13667)

### DIFF
--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -13,6 +13,12 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 		c.error('unnecessary `()` in `match` condition, use `match expr {` instead of `match (expr) {`.',
 			node.cond.pos)
 	}
+	if node.is_expr {
+		c.expected_expr_type = c.expected_type
+		defer {
+			c.expected_expr_type = ast.void_type
+		}
+	}
 	cond_type := c.expr(node.cond)
 	// we setting this here rather than at the end of the method
 	// since it is used in c.match_exprs() it saves checking twice

--- a/vlib/v/tests/match_expr_with_enum_test.v
+++ b/vlib/v/tests/match_expr_with_enum_test.v
@@ -1,0 +1,24 @@
+enum Foo {
+	a
+	b
+	c
+}
+
+fn get() Foo {
+	return .a
+}
+
+fn foo(f Foo) string {
+	println(f)
+	return '$f'
+}
+
+fn test_match_expr_with_enum() {
+	ret := foo(match get() {
+		.a { .b }
+		.b { .c }
+		.c { .a }
+	})
+	println(ret)
+	assert ret == 'b'
+}


### PR DESCRIPTION
This PR fix match expr with enum type value (fix #13667).

- Fix match expr with enum type value.
- Add test.

```vlang
enum Foo {
	a
	b
	c
}

fn get() Foo {
	return .a
}

fn foo(f Foo) string {
	println(f)
	return '$f'
}

fn main() {
	ret := foo(match get() {
		.a { .b }
		.b { .c }
		.c { .a }
	})
	println(ret)
	assert ret == 'b'
}

PS D:\Test\v\tt1> v run .
b
b
```