### PR TITLE
checker: fix if expr with enum value

### DIFF
--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -21,6 +21,12 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 	}
 	expr_required := c.expected_type != ast.void_type
 	former_expected_type := c.expected_type
+	if node_is_expr {
+		c.expected_expr_type = c.expected_type
+		defer {
+			c.expected_expr_type = ast.void_type
+		}
+	}
 	node.typ = ast.void_type
 	mut nbranches_with_return := 0
 	mut nbranches_without_return := 0

--- a/vlib/v/tests/if_expr_with_enum_test.v
+++ b/vlib/v/tests/if_expr_with_enum_test.v
@@ -1,0 +1,19 @@
+enum Foo {
+	a
+	b
+}
+
+fn get() Foo {
+	return .a
+}
+
+fn foo(f Foo) string {
+	println(f)
+	return '$f'
+}
+
+fn test_if_expr_with_enum_value() {
+	ret := foo(if get() == .a { .b } else { .a })
+	println(ret)
+	assert ret == 'b'
+}


### PR DESCRIPTION
This PR fix if expr with enum value.

- Fix if expr with enum value.
- Add if_expr_with_enum_test.v.

```vlang
enum Foo {
	a
	b
}

fn get() Foo {
	return .a
}

fn foo(f Foo) string {
	println(f)
	return '$f'
}

fn main() {
	ret := foo(if get() == .a { .b } else { .a })
	println(ret)
	assert ret == 'b'
}

PS D:\Test\v\tt1> v run .
b
b
```