### PR TITLE
Makefile: fix tcc: undefined reference __atomic_* and execinfo not found on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VFLAGS ?=
 all:
 	rm -rf vc/
 	git clone --depth 1 --quiet https://github.com/vlang/vc
-	$(CC) -std=gnu11 -w -I ./thirdparty/stdatomic/nix -o v1 vc/v.c -lm -lexecinfo -lpthread
+	$(CC) -std=gnu11 -w -I ./thirdparty/stdatomic/nix -o v1 vc/v.c -lm -latomic -lpthread
 	./v1 -no-parallel -o v2 $(VFLAGS) cmd/v
 	./v2 -o v $(VFLAGS) cmd/v
 	rm -rf v1 v2 vc/


### PR DESCRIPTION
Removes -lexecinfo and adds -latomic to the tcc compilation command. Because:
execinfo.h is already present on Linux, and libexecinfo doesn't exist.
libatomic is necessary to compile.
This bug doesn't concern the v compiler itself, but rather tcc, so I couldn't provide any 'v test-all'. Sorry.
Output of 'make':

rm -rf vc/
git clone --depth 1 --quiet https://github.com/vlang/vc
tcc -g -std=gnu11 -w -I ./thirdparty/stdatomic/nix -o v1 vc/v.c -lm -lpthread
tcc: error: undefined symbol 'tcc_backtrace'
tcc: error: undefined symbol '__atomic_load_8'
tcc: error: undefined symbol '__atomic_store_8'
tcc: error: undefined symbol '__atomic_compare_exchange_8'
tcc: error: undefined symbol '__atomic_exchange_8'
tcc: error: undefined symbol '__atomic_fetch_add_8'
tcc: error: undefined symbol '__atomic_fetch_sub_8'
tcc: error: undefined symbol '__atomic_load_4'
tcc: error: undefined symbol '__atomic_compare_exchange_4'
tcc: error: undefined symbol '__atomic_fetch_add_4'
tcc: error: undefined symbol '__atomic_load_2'
tcc: error: undefined symbol '__atomic_store_2'
tcc: error: undefined symbol '__atomic_compare_exchange_2'
tcc: error: undefined symbol '__dso_handle'

