### PR TITLE
builtin: Make all string.index methods return ?int

### DIFF
--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -570,16 +570,16 @@ fn get_all_modules() []string {
 		mut start_token := '<a href="/mod'
 		end_token := '</a>'
 		// get the start index of the module entry
-		mut start_index := s.index_after(start_token, read_len)
+		mut start_index := s.index_after(start_token, read_len) or { -1 }
 		if start_index == -1 {
 			break
 		}
 		// get the index of the end of anchor (a) opening tag
 		// we use the previous start_index to make sure we are getting a module and not just a random 'a' tag
 		start_token = '">'
-		start_index = s.index_after(start_token, start_index) + start_token.len
+		start_index = s.index_after(start_token, start_index) or { -1 } + start_token.len
 		// get the index of the end of module entry
-		end_index := s.index_after(end_token, start_index)
+		end_index := s.index_after(end_token, start_index) or { -1 }
 		if end_index == -1 {
 			break
 		}

--- a/examples/links_scraper.v
+++ b/examples/links_scraper.v
@@ -4,11 +4,11 @@ fn main() {
 	html := http.get_text('https://news.ycombinator.com')
 	mut pos := 0
 	for {
-		pos = html.index_after('https://', pos + 1)
+		pos = html.index_after('https://', pos + 1) or { -1 }
 		if pos == -1 {
 			break
 		}
-		end := html.index_after('"', pos)
+		end := html.index_after('"', pos) or { html.len }
 		println(html[pos..end])
 	}
 }

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -961,8 +961,12 @@ fn test_string_to_rune() {
 
 fn test_index_any() {
 	x := 'abcdefghij'
-	assert x.index_any('ef') == 4
-	assert x.index_any('fe') == 4
+	if idx := x.index_any('ef') {
+		assert idx == 4
+	}
+	if idx := x.index_any('fe') {
+		assert idx == 4
+	}
 }
 
 fn test_string_f64() {

--- a/vlib/encoding/base58/base58.v
+++ b/vlib/encoding/base58/base58.v
@@ -94,8 +94,7 @@ pub fn decode_int_walpha(input string, alphabet Alphabet) ?int {
 	mut total := 0 // to hold the results
 	b58 := input.reverse()
 	for i, ch in b58 {
-		ch_i := alphabet.encode.bytestr().index_byte(ch)
-		if ch_i == -1 {
+		ch_i := alphabet.encode.bytestr().index_byte(ch) or {
 			return error(@MOD + '.' + @FN +
 				': input string contains values not found in the provided alphabet')
 		}

--- a/vlib/encoding/csv/reader.v
+++ b/vlib/encoding/csv/reader.v
@@ -87,11 +87,11 @@ fn (mut r Reader) read_line() ?string {
 		return IError(&EndOfFileError{})
 	}
 	le := if r.is_mac_pre_osx_le { '\r' } else { '\n' }
-	mut i := r.data.index_after(le, r.row_pos)
+	mut i := r.data.index_after(le, r.row_pos) or { -1 }
 	if i == -1 {
 		if r.row_pos == 0 {
 			// check for pre osx mac line endings
-			i = r.data.index_after('\r', r.row_pos)
+			i = r.data.index_after('\r', r.row_pos) or { -1 }
 			if i != -1 {
 				r.is_mac_pre_osx_le = true
 			} else {

--- a/vlib/encoding/csv/writer.v
+++ b/vlib/encoding/csv/writer.v
@@ -37,10 +37,7 @@ pub fn (mut w Writer) write(record []string) ?bool {
 		}
 		w.sb.write_string('"')
 		for field.len > 0 {
-			mut i := field.index_any('"\r\n')
-			if i < 0 {
-				i = field.len
-			}
+			mut i := field.index_any('"\r\n') or { field.len }
 			w.sb.write_string(field[..i])
 			field = field[i..]
 			if field.len > 0 {
@@ -69,7 +66,10 @@ fn (w &Writer) field_needs_quotes(field string) bool {
 	if field == '' {
 		return false
 	}
-	if field.contains(w.delimiter.ascii_str()) || (field.index_any('"\r\n') != -1) {
+	if field.contains(w.delimiter.ascii_str()) {
+		return true
+	}
+	if _ := field.index_any('"\r\n') {
 		return true
 	}
 	return false

--- a/vlib/flag/flag.v
+++ b/vlib/flag/flag.v
@@ -305,7 +305,8 @@ fn (mut fs FlagParser) parse_bool_value(longhand string, shorthand byte) ?string
 				fs.args.delete(i)
 				return val
 			}
-			if arg.len > 1 && arg[0] == `-` && arg[1] != `-` && arg.index_byte(shorthand) != -1 {
+			if arg.len > 1 && arg[0] == `-` && arg[1] != `-`
+				&& arg.index_byte(shorthand) or { -1 } != -1 {
 				// -abc is equivalent to -a -b -c
 				return 'true'
 			}

--- a/vlib/net/http/cookie.v
+++ b/vlib/net/http/cookie.v
@@ -68,7 +68,7 @@ pub fn read_cookies(h map[string][]string, filter string) []&Cookie {
 		mut line := line_.trim_space()
 		mut part := ''
 		for line.len > 0 {
-			if line.index_any(';') > 0 {
+			if _ := line.index_any(';') {
 				line_parts := line.split(';')
 				part = line_parts[0]
 				line = line_parts[1]

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -418,10 +418,7 @@ fn get_scheme(rawurl string) ?string {
 // sep. If cutc is true then sep is included with the second substring.
 // If sep does not occur in s then s and the empty string is returned.
 fn split(s string, sep byte, cutc bool) (string, string) {
-	i := s.index_byte(sep)
-	if i < 0 {
-		return s, ''
-	}
+	i := s.index_byte(sep) or { return s, '' }
 	if cutc {
 		return s[..i], s[i + 1..]
 	}
@@ -746,11 +743,10 @@ pub fn (u URL) str() string {
 			// it would be mistaken for a scheme name. Such a segment must be
 			// preceded by a dot-segment (e.g., './this:that') to make a relative-
 			// path reference.
-			i := path.index_byte(`:`)
-			if i > -1 {
+			if i := path.index_byte(`:`) {
 				// TODO remove this when autofree handles tmp
 				// expressions like this
-				if i > -1 && path[..i].index_byte(`/`) == -1 {
+				if i > -1 && path[..i].index_byte(`/`) or { -1 } == -1 {
 					buf.write_string('./')
 				}
 			}
@@ -800,7 +796,7 @@ fn parse_query_values(mut m Values, query string) ?bool {
 	mut q := query
 	for q != '' {
 		mut key := q
-		mut i := key.index_any('&;')
+		mut i := key.index_any('&;') or { -1 }
 		if i >= 0 {
 			q = key[i + 1..]
 			key = key[..i]
@@ -1006,8 +1002,7 @@ pub fn (u &URL) port() string {
 fn split_host_port(hostport string) (string, string) {
 	mut host := hostport
 	mut port := ''
-	colon := host.last_index_byte(`:`)
-	if colon != -1 {
+	if colon := host.last_index_byte(`:`) {
 		if valid_optional_port(host[colon..]) {
 			port = host[colon + 1..]
 			host = host[..colon]

--- a/vlib/os/environment.c.v
+++ b/vlib/os/environment.c.v
@@ -109,8 +109,7 @@ pub fn environ() map[string]string {
 				break
 			}
 			eline := unsafe { cstring_to_vstring(x) }
-			eq_index := eline.index_byte(`=`)
-			if eq_index > 0 {
+			if eq_index := eline.index_byte(`=`) {
 				res[eline[0..eq_index]] = eline[eq_index + 1..]
 			}
 			i++

--- a/vlib/os/environment.c.v
+++ b/vlib/os/environment.c.v
@@ -91,8 +91,7 @@ pub fn environ() map[string]string {
 		mut eline := ''
 		for c := estrings; *c != 0; {
 			eline = unsafe { string_from_wide(c) }
-			eq_index := eline.index_byte(`=`)
-			if eq_index > 0 {
+			if eq_index := eline.index_byte(`=`) {
 				res[eline[0..eq_index]] = eline[eq_index + 1..]
 			}
 			unsafe {

--- a/vlib/semver/range.v
+++ b/vlib/semver/range.v
@@ -130,9 +130,7 @@ fn parse_comparator(input string) ?Comparator {
 fn parse_xrange(input string) ?Version {
 	mut raw_ver := parse(input).complete()
 	for typ in versions {
-		if raw_ver.raw_ints[typ].index_any(semver.x_range_symbols) == -1 {
-			continue
-		}
+		raw_ver.raw_ints[typ].index_any(semver.x_range_symbols) or { continue }
 		match typ {
 			ver_major {
 				raw_ver.raw_ints[ver_major] = '0'
@@ -156,8 +154,9 @@ fn parse_xrange(input string) ?Version {
 }
 
 fn can_expand(input string) bool {
-	return input[0] == `~` || input[0] == `^` || input.contains(semver.hyphen_range_sep)
-		|| input.index_any(semver.x_range_symbols) > -1
+	return input[0] == `~` || input[0] == `^` || input.contains(semver.hyphen_range_sep) || input.index_any(semver.x_range_symbols) or {
+		-1
+	} > -1
 }
 
 fn expand_comparator_set(input string) ?ComparatorSet {

--- a/vlib/v/ast/cflags.v
+++ b/vlib/v/ast/cflags.v
@@ -63,7 +63,7 @@ pub fn (mut t Table) parse_cflag(cflg string, mod string, ctimedefines []string)
 			if has_next {
 				break
 			}
-			index = flag.index_after(' -', index + 1)
+			index = flag.index_after(' -', index + 1) or { -1 }
 		}
 		if index == -1 {
 			value = flag.trim_space()

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2975,7 +2975,7 @@ fn (mut p Parser) parse_number_literal() ast.Expr {
 	lit := p.tok.lit
 	full_lit := if is_neg { '-' + lit } else { lit }
 	mut node := ast.empty_expr()
-	if lit.index_any('.eE') >= 0 && lit[..2] !in ['0x', '0X', '0o', '0O', '0b', '0B'] {
+	if lit.index_any('.eE') or { -1 } >= 0 && lit[..2] !in ['0x', '0X', '0o', '0O', '0b', '0B'] {
 		node = ast.FloatLiteral{
 			val: full_lit
 			pos: pos

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1334,13 +1334,9 @@ fn trim_slash_line_break(s string) string {
 	mut start := 0
 	mut ret_str := s
 	for {
-		idx := ret_str.index_after('\\\n', start)
-		if idx != -1 {
-			ret_str = ret_str[..idx] + ret_str[idx + 2..].trim_left(' \n\t\v\f\r')
-			start = idx
-		} else {
-			break
-		}
+		idx := ret_str.index_after('\\\n', start) or { break }
+		ret_str = ret_str[..idx] + ret_str[idx + 2..].trim_left(' \n\t\v\f\r')
+		start = idx
 	}
 	return ret_str
 }


### PR DESCRIPTION
The string type has come _index_ methods like (index, index_after, etc) and some return `int` and others return `?int`.

This MR makes all of them return `?int`.

The tests (`v test-all`) have beem updated to work with the changes but there are some tests that were skipped in my machine.