### PR TITLE
checker: fix error for embedded struct method is private (fix #13607)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1176,7 +1176,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	if has_method {
 		node.is_noreturn = method.is_noreturn
 		node.is_ctor_new = method.is_ctor_new
-		if !method.is_pub && !c.pref.is_test && method.mod != c.mod {
+		if !method.is_pub && !is_method_from_embed && !c.pref.is_test && method.mod != c.mod {
 			// If a private method is called outside of the module
 			// its receiver type is defined in, show an error.
 			// println('warn $method_name lef.mod=$left_type_sym.mod c.mod=$c.mod')

--- a/vlib/v/tests/struct_embed_method_is_private_test.v
+++ b/vlib/v/tests/struct_embed_method_is_private_test.v
@@ -1,4 +1,4 @@
-import view
+import v.tests.view
 
 pub struct TextBox {
 	view.TextDrawer

--- a/vlib/v/tests/struct_embed_method_is_private_test.v
+++ b/vlib/v/tests/struct_embed_method_is_private_test.v
@@ -1,0 +1,18 @@
+import view
+
+pub struct TextBox {
+	view.TextDrawer
+}
+
+fn (mut tb TextBox) set(x int, y int) {
+	tb.runes << `A`
+	tb.calc_wordwrap()
+}
+
+fn test_struct_embed_method_is_private() {
+	mut tb := TextBox{}
+	tb.set(11, 22)
+	println(tb)
+	assert tb.runes.len == 1
+	assert tb.runes[0] == `A`
+}

--- a/vlib/v/tests/view/view.v
+++ b/vlib/v/tests/view/view.v
@@ -1,0 +1,8 @@
+module view
+
+pub struct TextDrawer {
+mut:
+	runes []rune
+}
+
+fn (mut td TextDrawer) calc_wordwrap() {}


### PR DESCRIPTION
This PR fix error for embedded struct method is private (fix #13607).

- Fix error for embedded struct method is private.
- Add test.

```vlang
import view

pub struct TextBox {
	view.TextDrawer
}

fn (mut tb TextBox) set(x int, y int) {
	tb.runes << `A`
	tb.calc_wordwrap()
}

fn main() {
	mut tb := TextBox{}
	tb.set(11, 22)
	println(tb)
	assert tb.runes.len == 1
	assert tb.runes[0] == `A`
}

PS D:\Test\v\tt1> v run .
TextBox{
    TextDrawer: view.TextDrawer{
        runes: [`A`]
    }
}
```
```vlang
module view

pub struct TextDrawer {
mut:
	runes []rune
}

fn (mut td TextDrawer) calc_wordwrap() {}
```