### PR TITLE
checker: fix comptime `$else` `[noreturn]` function

### DIFF
--- a/vlib/v/tests/comptime_no_return.v
+++ b/vlib/v/tests/comptime_no_return.v
@@ -1,0 +1,16 @@
+[noreturn]
+fn no_return() {
+	exit(0)
+}
+
+fn abc() bool {
+	$if x64 {
+		no_return()
+	} $else {
+		no_return()
+	}
+}
+
+fn main() {
+	abc()
+}


### PR DESCRIPTION
fixes #13689 
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
