### PR TITLE
string: fix splitting empty string (fix #13696)

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -692,6 +692,9 @@ pub fn (s string) split(delim string) []string {
 // the remainder contains more `delim` substrings.
 [direct_array_access]
 pub fn (s string) split_nth(delim string, nth int) []string {
+	if s.len == 0 {
+		return []
+	}
 	mut res := []string{}
 	mut i := 0
 

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -178,6 +178,8 @@ fn test_split_nth() {
 	assert e.split_nth(',,', 3).len == 3
 	assert e.split_nth(',', -1).len == 12
 	assert e.split_nth(',', 3).len == 3
+	f := ''
+	assert f.split(',').len == 0
 }
 
 fn test_split_nth_values() {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -263,6 +263,9 @@ pub fn (mut f Fmt) mark_types_import_as_used(typ ast.Type) {
 // `name` is a function (`foo.bar()`) or type (`foo.Bar{}`)
 pub fn (mut f Fmt) mark_import_as_used(name string) {
 	parts := name.split('.')
+	if parts.len == 0 {
+		return
+	}
 	last := parts.last()
 	if last in f.import_syms_used {
 		f.import_syms_used[last] = true


### PR DESCRIPTION
This PR fix splitting empty string (fix #13696).

- Fix splitting empty string.
- Add test.

```vlang
fn main(){
	s := '\n'
	col := s.trim(' \r\n').split(',')
	println(col)
}

PS D:\Test\v\tt1> v run .
[]
```