### PR TITLE
checker: check error for infix compare optional (fix #13695)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -842,6 +842,9 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 						}
 					}
 				}
+			} else if left_type.has_flag(.optional) && right_type.has_flag(.optional) {
+				c.error('unwrapped optional cannot be compared in an infix expression',
+					left_right_pos)
 			}
 		}
 		.left_shift {

--- a/vlib/v/checker/tests/infix_compare_optional_err.out
+++ b/vlib/v/checker/tests/infix_compare_optional_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/infix_compare_optional_err.vv:6:5: error: unwrapped optional cannot be compared in an infix expression
+    4 |
+    5 | fn main(){
+    6 |     if foo() > foo() {}
+      |        ~~~~~~~~~~~~~
+    7 | }

--- a/vlib/v/checker/tests/infix_compare_optional_err.vv
+++ b/vlib/v/checker/tests/infix_compare_optional_err.vv
@@ -1,0 +1,7 @@
+fn foo() ?int{
+	return 0
+}
+
+fn main(){
+	if foo() > foo() {}
+}


### PR DESCRIPTION
This PR check error for infix compare optional (fix #13695).

- Check error for infix compare optional.
- Add test.

```vlang
fn foo() ?int{
	return 0
}

fn main(){
	if foo() > foo() {}
}

PS D:\Test\v\tt1> v run .
./tt1.v:6:5: error: unwrapped optional cannot be compared in an infix expression
    4 | 
    5 | fn main(){
    6 |     if foo() > foo() {}
      |        ~~~~~~~~~~~~~
    7 | }
```