### PR TITLE
vlib/arrays: fix `copy` to not use memcpy for array, map, string

### DIFF
--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -536,9 +536,27 @@ fn swap_nonoverlapping<T>(x_ &T, y_ &T, count int) {
 // Returns the number of elements copied.
 pub fn copy<T>(mut dst []T, src []T) int {
 	min := if dst.len < src.len { dst.len } else { src.len }
-	if min > 0 {
+	if min <= 0 {
+		return 0
+	}
+	if can_copy_bits<T>() {
 		blen := min * int(sizeof(T))
 		unsafe { vmemmove(&T(dst.data), src.data, blen) }
+	} else {
+		for i in 0 .. min {
+			dst[i] = src[i]
+		}
 	}
 	return min
+}
+
+// determines if T can be copied using `memcpy`
+// false if autofree needs to intervene
+// false if type is not copyable e.g. map
+fn can_copy_bits<T>() bool {
+	// references, C pointers, integers, floats, runes
+	if T.name[0] in [`&`, `b`, `c`, `f`, `i`, `r`, `u`, `v`] {
+		return true
+	}
+	return false
 }

--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -534,7 +534,7 @@ fn swap_nonoverlapping<T>(x_ &T, y_ &T, count int) {
 // copy copies the `src` array elements to the `dst` array.
 // The number of the elements copied is the minimum of the length of both arrays.
 // Returns the number of elements copied.
-pub fn copy<T>(dst []T, src []T) int {
+pub fn copy<T>(mut dst []T, src []T) int {
 	min := if dst.len < src.len { dst.len } else { src.len }
 	if min > 0 {
 		blen := min * int(sizeof(T))

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -281,3 +281,15 @@ fn test_copy() {
 	assert copy(mut b, [8, 9]) == 2
 	assert b == [8, 9, 3, 7]
 }
+
+fn test_can_copy_bits() {
+	assert can_copy_bits<byte>()
+	assert can_copy_bits<int>()
+	assert can_copy_bits<voidptr>()
+	assert can_copy_bits<&byte>()
+	// autofree needs to intercept assign
+	assert !can_copy_bits<string>()
+	assert !can_copy_bits<[]int>()
+	// map not copyable
+	assert !can_copy_bits<map[string]int>()
+}

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -268,16 +268,16 @@ fn test_rotate_left_string() {
 fn test_copy() {
 	mut a := [1, 2, 3]
 	mut b := [4, 5, 6]
-	assert copy(b, a) == 3
+	assert copy(mut b, a) == 3
 	assert b == [1, 2, 3]
 	// check independent copies
 	b[0] = 99
 	assert a[0] == 1
 	// check longer src
 	b << 7
-	assert copy(a, b) == 3
+	assert copy(mut a, b) == 3
 	assert a == [99, 2, 3]
 	// check longer dst
-	assert copy(b, [8, 9]) == 2
+	assert copy(mut b, [8, 9]) == 2
 	assert b == [8, 9, 3, 7]
 }


### PR DESCRIPTION
autofree needs to intervene for those types, so use element assignment.
Also map is not copyable.

Follows on from https://github.com/vlang/v/pull/13677

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
