### PR TITLE
fix: handle trailing backslash on windows path when quoting

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -761,7 +761,11 @@ pub fn execute_or_exit(cmd string) Result {
 // quoted path - return a quoted version of the path, depending on the platform.
 pub fn quoted_path(path string) string {
 	$if windows {
-		return '"$path"'
+		if path.ends_with(path_separator) {
+			return '"${path + path_separator}"'
+		} else {
+			return '"$path"'
+		}
 	} $else {
 		return "'$path'"
 	}

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -761,11 +761,13 @@ pub fn execute_or_exit(cmd string) Result {
 // quoted path - return a quoted version of the path, depending on the platform.
 pub fn quoted_path(path string) string {
 	$if windows {
+		mut quoted_path := ''
 		if path.ends_with(path_separator) {
-			return '"${path + path_separator}"'
+			quoted_path = '"${path + path_separator}"'
 		} else {
-			return '"$path"'
+			quoted_path = '"$path"'
 		}
+		return quoted_path
 	} $else {
 		return "'$path'"
 	}

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -761,13 +761,7 @@ pub fn execute_or_exit(cmd string) Result {
 // quoted path - return a quoted version of the path, depending on the platform.
 pub fn quoted_path(path string) string {
 	$if windows {
-		mut quoted_path := ''
-		if path.ends_with(path_separator) {
-			quoted_path = '"${path + path_separator}"'
-		} else {
-			quoted_path = '"$path"'
-		}
-		return quoted_path
+		return if path.ends_with(path_separator) { '"${path + path_separator}"' } else { '"$path"' }
 	} $else {
 		return "'$path'"
 	}


### PR DESCRIPTION
Fixes an issue with calling `os.quoted_path` on Windows, if the path has a trailing backslash.

Before the fix, quoting `foo\` would return `"foo\"`... which just forces the trailing `"` as part of the path string.

After the fix, quoting `foo\` returns `"foo\\"`... preserving the trailing backslash.