### PR TITLE
parser: fix error for fn with type only argument (fix #13704)

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -736,7 +736,7 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 		|| (p.peek_tok.kind == .comma && p.table.known_type(argname))
 		|| p.peek_tok.kind == .dot || p.peek_tok.kind == .rpar
 		|| (p.tok.kind == .key_mut && (p.peek_token(2).kind == .comma
-		|| p.peek_token(2).kind == .rpar))
+		|| p.peek_token(2).kind == .rpar || p.peek_token(2).kind == .dot))
 	// TODO copy pasta, merge 2 branches
 	if types_only {
 		mut arg_no := 1

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -736,7 +736,8 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 		|| (p.peek_tok.kind == .comma && p.table.known_type(argname))
 		|| p.peek_tok.kind == .dot || p.peek_tok.kind == .rpar
 		|| (p.tok.kind == .key_mut && (p.peek_token(2).kind == .comma
-		|| p.peek_token(2).kind == .rpar || p.peek_token(2).kind == .dot))
+		|| p.peek_token(2).kind == .rpar || (p.peek_token(1).kind == .name
+		&& p.peek_token(2).kind == .dot)))
 	// TODO copy pasta, merge 2 branches
 	if types_only {
 		mut arg_no := 1

--- a/vlib/v/tests/fn_type_only_argument_test.v
+++ b/vlib/v/tests/fn_type_only_argument_test.v
@@ -1,0 +1,28 @@
+module main
+
+import gg
+import gx
+
+struct Game {
+	update fn (mut gg.Context) = fn (mut gg gg.Context) {}
+	draw   fn (mut gg.Context) = fn (mut gg gg.Context) {}
+mut:
+	gg gg.Context
+}
+
+fn test_fn_type_only_argument() {
+	mut game := Game{}
+	game.gg = gg.new_context(
+		bg_color: gx.rgb(230, 230, 240)
+		frame_fn: frame
+	)
+	assert true
+}
+
+fn frame(mut game Game) {
+	game.gg.begin()
+	game.gg.draw_triangle_filled(450, 142, 530, 280, 370, 280, gx.red)
+	game.update(mut game.gg)
+	game.draw(mut game.gg)
+	game.gg.end()
+}

--- a/vlib/v/tests/fn_type_only_argument_test.v
+++ b/vlib/v/tests/fn_type_only_argument_test.v
@@ -1,28 +1,16 @@
 module main
 
-import gg
-import gx
+import time
 
 struct Game {
-	update fn (mut gg.Context) = fn (mut gg gg.Context) {}
-	draw   fn (mut gg.Context) = fn (mut gg gg.Context) {}
+	update fn (mut time.Time) = fn (mut time time.Time) {}
+	draw   fn (mut time.Time) = fn (mut time time.Time) {}
 mut:
-	gg gg.Context
+	time time.Time
 }
 
 fn test_fn_type_only_argument() {
 	mut game := Game{}
-	game.gg = gg.new_context(
-		bg_color: gx.rgb(230, 230, 240)
-		frame_fn: frame
-	)
+	game.time = time.Time{}
 	assert true
-}
-
-fn frame(mut game Game) {
-	game.gg.begin()
-	game.gg.draw_triangle_filled(450, 142, 530, 280, 370, 280, gx.red)
-	game.update(mut game.gg)
-	game.draw(mut game.gg)
-	game.gg.end()
 }


### PR DESCRIPTION
This PR fix error for fn with type only argument (fix #13704).

- Fix error for fn with type only argument.
- Add test.

```vlang
module main

import gg
import gx

struct Game {
	update fn (mut gg.Context) = fn (mut gg gg.Context) {}
	draw   fn (mut gg.Context) = fn (mut gg gg.Context) {}
mut:
	gg gg.Context
}

fn main() {
	mut game := Game{}
	game.gg = gg.new_context(
		bg_color: gx.rgb(230, 230, 240)
		frame_fn: frame
	)
	assert true
}

fn frame(mut game Game) {
	game.gg.begin()
	game.gg.draw_triangle_filled(450, 142, 530, 280, 370, 280, gx.red)
	game.update(mut game.gg)
	game.draw(mut game.gg)
	game.gg.end()
}

PS D:\Test\v\tt1> v run .

```