### PR TITLE
ast: rename TypeSymbol.is_public to TypeSymbol.is_pub

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1933,7 +1933,7 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 							fields: fields
 							parent_type: new_type(info.parent_idx).set_flag(.generic)
 						}
-						typ.is_public = true
+						typ.is_pub = true
 						typ.kind = parent.kind
 
 						parent_sym := t.sym(parent_info.parent_type)
@@ -1996,7 +1996,7 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 							methods: imethods
 							parent_type: new_type(info.parent_idx).set_flag(.generic)
 						}
-						typ.is_public = true
+						typ.is_pub = true
 						typ.kind = parent.kind
 						typ.methods = all_methods
 					} else {
@@ -2043,7 +2043,7 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 							variants: variants
 							parent_type: new_type(info.parent_idx).set_flag(.generic)
 						}
-						typ.is_public = true
+						typ.is_pub = true
 						typ.kind = parent.kind
 					} else {
 						util.verror('generic error', 'the number of generic types of sumtype `$parent.name` is inconsistent with the concrete types')

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -84,15 +84,15 @@ pub struct TypeSymbol {
 pub:
 	parent_idx int
 pub mut:
-	info      TypeInfo
-	kind      Kind
-	name      string // the internal & source name of the type, i.e. `[5]int`.
-	cname     string // the name with no dots for use in the generated C code
-	methods   []Fn
-	mod       string
-	is_public bool
-	language  Language
-	idx       int
+	info     TypeInfo
+	kind     Kind
+	name     string // the internal & source name of the type, i.e. `[5]int`.
+	cname    string // the name with no dots for use in the generated C code
+	methods  []Fn
+	mod      string
+	is_pub   bool
+	language Language
+	idx      int
 }
 
 // max of 8
@@ -253,7 +253,7 @@ fn (ts TypeSymbol) dbg_common(mut res []string) {
 	res << 'name: $ts.name'
 	res << 'cname: $ts.cname'
 	res << 'kind: $ts.kind'
-	res << 'is_public: $ts.is_public'
+	res << 'is_pub: $ts.is_pub'
 	res << 'language: $ts.language'
 }
 

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2357,7 +2357,7 @@ fn (mut c Checker) import_stmt(node ast.Import) {
 		if sym.name[0].is_capital() {
 			if type_sym := c.table.find_sym(name) {
 				if type_sym.kind != .placeholder {
-					if !type_sym.is_public {
+					if !type_sym.is_pub {
 						c.error('module `$node.mod` type `$sym.name` is private', sym.pos)
 					}
 					continue
@@ -3886,7 +3886,7 @@ pub fn (mut c Checker) enum_val(mut node ast.EnumVal) ast.Type {
 		c.error('not an enum', node.pos)
 		return ast.void_type
 	}
-	if !(typ_sym.is_public || typ_sym.mod == c.mod) {
+	if !(typ_sym.is_pub || typ_sym.mod == c.mod) {
 		c.error('enum `$typ_sym.name` is private', node.pos)
 	}
 	info := typ_sym.enum_info()

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -210,7 +210,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 		}
 	}
 	// allow init structs from generic if they're private except the type is from builtin module
-	if !type_sym.is_public && type_sym.kind != .placeholder && type_sym.language != .c
+	if !type_sym.is_pub && type_sym.kind != .placeholder && type_sym.language != .c
 		&& (type_sym.mod != c.mod && !(node.typ.has_flag(.generic) && type_sym.mod != 'builtin')) {
 		c.error('type `$type_sym.name` is private', node.pos)
 	}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -611,7 +611,7 @@ pub fn (mut p Parser) parse_generic_type(name string) ast.Type {
 		cname: util.no_dots(name)
 		mod: p.mod
 		kind: .any
-		is_public: true
+		is_pub: true
 	})
 	return ast.new_type(idx).set_flag(.generic)
 }

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2798,7 +2798,7 @@ fn (mut p Parser) parse_generic_types() ([]ast.Type, []string) {
 				cname: util.no_dots(name)
 				mod: p.mod
 				kind: .any
-				is_public: true
+				is_pub: true
 			})
 		}
 		types << ast.new_type(idx).set_flag(.generic)
@@ -3517,7 +3517,7 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 			is_flag: is_flag
 			is_multi_allowed: is_multi_allowed
 		}
-		is_public: is_pub
+		is_pub: is_pub
 	})
 	if idx == -1 {
 		p.error_with_pos('cannot register enum `$name`, another type with this name exists',
@@ -3571,7 +3571,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		// function type: `type mycallback = fn(string, int)`
 		fn_name := p.prepend_mod(name)
 		fn_type := p.parse_fn_type(fn_name)
-		p.table.sym(fn_type).is_public = is_pub
+		p.table.sym(fn_type).is_pub = is_pub
 		type_pos = type_pos.extend(p.tok.pos())
 		comments = p.eat_comments(same_line: true)
 		return ast.FnTypeDecl{
@@ -3606,7 +3606,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 				is_generic: generic_types.len > 0
 				generic_types: generic_types
 			}
-			is_public: is_pub
+			is_pub: is_pub
 		})
 		if typ == ast.invalid_type_idx {
 			p.error_with_pos('cannot register sum type `$name`, another type with this name exists',
@@ -3646,7 +3646,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 			parent_type: parent_type
 			language: parent_sym.language
 		}
-		is_public: is_pub
+		is_pub: is_pub
 	})
 	type_end_pos := p.prev_tok.pos()
 	if idx == ast.invalid_type_idx {

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -304,7 +304,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 			generic_types: generic_types
 			attrs: attrs
 		}
-		is_public: is_pub
+		is_pub: is_pub
 	}
 	if p.table.has_deep_child_no_ref(&t, name) {
 		p.error_with_pos('invalid recursive struct `$orig_name`', name_pos)
@@ -478,7 +478,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 	}
 	// Declare the type
 	reg_idx := p.table.register_sym(
-		is_public: is_pub
+		is_pub: is_pub
 		kind: .interface_
 		name: interface_name
 		cname: util.no_dots(interface_name)


### PR DESCRIPTION
This PR rename TypeSymbol.is_public to TypeSymbol.is_pub.

- Maintain customary consistency with overall usage.