### PR TITLE
parser: cleanup map syntax

### DIFF
--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -46,12 +46,8 @@ pub fn (mut p Parser) check_expr(precedence int) ?ast.Expr {
 				p.inside_match = false
 			} else if p.tok.lit == 'map' && p.peek_tok.kind == .lcbr && !(p.builtin_mod
 				&& p.file_base in ['map.v', 'map_d_gcboehm_opt.v']) {
-				p.warn_with_pos("deprecated map syntax, use syntax like `{'age': 20}`",
+				p.error_with_pos("deprecated map syntax, use syntax like `{'age': 20}`",
 					p.tok.pos())
-				p.next() // `map`
-				p.next() // `{`
-				node = p.map_init()
-				p.check(.rcbr) // `}`
 			} else {
 				if p.inside_if && p.is_generic_name() && p.peek_tok.kind != .dot {
 					// $if T is string {}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2320,17 +2320,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 	} else if (p.peek_tok.kind == .lcbr || (p.peek_tok.kind == .lt && lit0_is_capital))
 		&& (!p.inside_match || (p.inside_select && prev_tok_kind == .arrow && lit0_is_capital))
 		&& !p.inside_match_case && (!p.inside_if || p.inside_select)
-		&& (!p.inside_for || p.inside_select) && !known_var { // && (p.tok.lit[0].is_capital() || p.builtin_mod) {
-		// map.v has struct literal: map{field: expr}
-		if p.peek_tok.kind == .lcbr && !(p.builtin_mod
-			&& p.file_base in ['map.v', 'map_d_gcboehm_opt.v']) && p.tok.lit == 'map' {
-			// map{key_expr: val_expr}
-			p.check(.name)
-			p.check(.lcbr)
-			map_init := p.map_init()
-			p.check(.rcbr)
-			return map_init
-		}
+		&& (!p.inside_for || p.inside_select) && !known_var {
 		return p.struct_init(p.mod + '.' + p.tok.lit, false) // short_syntax: false
 	} else if p.peek_tok.kind == .lcbr && p.inside_if && lit0_is_capital && !known_var
 		&& language == .v {

--- a/vlib/v/parser/tests/map_syntax_err.out
+++ b/vlib/v/parser/tests/map_syntax_err.out
@@ -1,0 +1,6 @@
+vlib/v/parser/tests/map_syntax_err.vv:2:7: error: deprecated map syntax, use syntax like `{'age': 20}`
+    1 | fn main() {
+    2 |     m := map{"aaa": 1}
+      |          ~~~
+    3 |     println(m)
+    4 | }

--- a/vlib/v/parser/tests/map_syntax_err.vv
+++ b/vlib/v/parser/tests/map_syntax_err.vv
@@ -1,0 +1,4 @@
+fn main() {
+	m := map{"aaa": 1}
+	println(m)
+}


### PR DESCRIPTION
This PR makes cleanup of map syntax.

- Map syntax error changed from warning to error.
- Remove redundant judgment processing.
- Add check error test.

```vlang
fn main() {
	m := map{"aaa": 1}
	println(m)
}

PS D:\Test\v\tt1> v run .
./tt1.v:2:7: error: deprecated map syntax, use syntax like `{'age': 20}`
    1 | fn main() {
    2 |     x := map{"aaa": 1}
      |          ~~~
    3 |     println(x)
    4 | }
```