### PR TITLE
stbi: fixed panic when trying to load JPG

### DIFF
--- a/vlib/stbi/stbi.c.v
+++ b/vlib/stbi/stbi.c.v
@@ -93,7 +93,7 @@ pub fn load(path string) ?Image {
 		data: 0
 	}
 	// flag := if ext == 'png' { C.STBI_rgb_alpha } else { 0 }
-	desired_channels := if ext == 'png' { 4 } else { 0 }
+	desired_channels := if ext in ['png', 'jpg', 'jpeg'] { 4 } else { 0 }
 	res.data = C.stbi_load(&char(path.str), &res.width, &res.height, &res.nr_channels,
 		desired_channels)
 	if desired_channels == 4 && res.nr_channels == 3 {


### PR DESCRIPTION
`fn load` in `stbi.c.v` creates an error when trying to load a JPG file. (See https://discord.com/channels/592103645835821068/592294828432424960/951999502364061737)



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
