### PR TITLE
math: allow i64 in digits function and add count_digits function

### DIFF
--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -48,10 +48,14 @@ pub struct DigitParams {
 	reverse bool
 }
 
-// digits returns an array of the digits of n in the given base b.
-// Number argument accepts any integer type (i8|i16|int|isize|i64) and will be cast to i64
-// The base argument is optional, if no value is given it will default to base 10.
-// digits returns an array with the digits in reverse order i.e. digits(12345, 10) == [5,4,3,2,1]
+// digits returns an array of the digits of `num` in the given optional `base`.
+// The `num` argument accepts any integer type (i8|i16|int|isize|i64), and will be cast to i64
+// The `base:` argument is optional, it will default to base: 10.
+// This function returns an array of the digits in reverse order i.e.:
+// Example: assert math.digits(12345, base: 10) == [5,4,3,2,1]
+// You can also use it, with an explicit `reverse: true` parameter,
+// (it will do a reverse of the result array internally => slower):
+// Example: assert math.digits(12345, reverse: true) == [1,2,3,4,5]
 pub fn digits(num i64, params DigitParams) []int {
 	// set base to 10 initially and change only if base is explicitly set.
 	mut b := params.base

--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -44,7 +44,8 @@ pub fn degrees(radians f64) f64 {
 
 [params]
 pub struct DigitParams {
-	base int = 10
+	base    int = 10
+	reverse bool
 }
 
 // digits returns an array of the digits of n in the given base b.
@@ -72,6 +73,10 @@ pub fn digits(num i64, params DigitParams) []int {
 	for n != 0 {
 		res << int((n % b) * sign)
 		n /= b
+	}
+
+	if params.reverse {
+		res = res.reverse()
 	}
 
 	return res

--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -79,7 +79,7 @@ pub fn digits(_n i64, _b ...int) []int {
 // count_digits return the number of digits in the number passed.
 // Number argument accepts any integer type (i8|i16|int|isize|i64) and will be cast to i64
 pub fn count_digits(n i64) int {
-	return int(math.ceil(math.log(f64(n) + 1 ) / math.log(10.0)))
+	return int(math.ceil(math.log(math.abs(f64(_n) + 1 )) / math.log(10.0)))
 }
 
 // minmax returns the minimum and maximum value of the two provided.

--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -47,8 +47,7 @@ pub fn degrees(radians f64) f64 {
 // The base argument is optional, if no value is given it will default to base 10.
 // digits returns an array with the digits in reverse order i.e. digits(12345, 10) == [5,4,3,2,1]
 pub fn digits(num i64, base ...int) []int {
-	
-	//set base to 10 initially and change only if base is explicitly set.
+	// set base to 10 initially and change only if base is explicitly set.
 	mut b := 10
 	if base.len != 0 {
 		b = base[0]
@@ -72,14 +71,14 @@ pub fn digits(num i64, base ...int) []int {
 		res << int((n % b) * sign)
 		n /= b
 	}
-	
+
 	return res
 }
 
 // count_digits return the number of digits in the number passed.
 // Number argument accepts any integer type (i8|i16|int|isize|i64) and will be cast to i64
 pub fn count_digits(n i64) int {
-	return int(math.ceil(math.log(math.abs(f64(n) + 1 )) / math.log(10.0)))
+	return int(ceil(log(abs(f64(n) + 1)) / log(10.0)))
 }
 
 // minmax returns the minimum and maximum value of the two provided.

--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -68,15 +68,21 @@ pub fn digits(num i64, params DigitParams) []int {
 		sign = -1
 		n = -n
 	}
+
 	mut res := []int{}
-	// if number passed to function is 0 then short-circuit and return 0
 	if n == 0 {
+		// short-circuit and return 0
 		res << 0
 		return res
 	}
 	for n != 0 {
-		res << int((n % b) * sign)
-		n /= b
+		next_n := n / b
+		res << int(n - next_n * b)
+		n = next_n
+	}
+
+	if sign == -1 {
+		res[res.len - 1] *= sign
 	}
 
 	if params.reverse {
@@ -88,8 +94,17 @@ pub fn digits(num i64, params DigitParams) []int {
 
 // count_digits return the number of digits in the number passed.
 // Number argument accepts any integer type (i8|i16|int|isize|i64) and will be cast to i64
-pub fn count_digits(n i64) int {
-	return int(ceil(log(abs(f64(n) + 1)) / log(10.0)))
+pub fn count_digits(number i64) int {
+	mut n := number
+	if n == 0 {
+		return 1
+	}
+	mut c := 0
+	for n != 0 {
+		n = n / 10
+		c++
+	}
+	return c
 }
 
 // minmax returns the minimum and maximum value of the two provided.

--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -42,18 +42,20 @@ pub fn degrees(radians f64) f64 {
 	return radians * (180.0 / pi)
 }
 
+[params]
+pub struct DigitParams {
+	base int = 10
+}
+
 // digits returns an array of the digits of n in the given base b.
 // Number argument accepts any integer type (i8|i16|int|isize|i64) and will be cast to i64
 // The base argument is optional, if no value is given it will default to base 10.
 // digits returns an array with the digits in reverse order i.e. digits(12345, 10) == [5,4,3,2,1]
-pub fn digits(num i64, base ...int) []int {
+pub fn digits(num i64, params DigitParams) []int {
 	// set base to 10 initially and change only if base is explicitly set.
-	mut b := 10
-	if base.len != 0 {
-		b = base[0]
-	}
+	mut b := params.base
 	if b < 2 {
-		panic('digits: Cannot find digits of n with base $base')
+		panic('digits: Cannot find digits of n with base $b')
 	}
 	mut n := num
 	mut sign := 1

--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -46,17 +46,17 @@ pub fn degrees(radians f64) f64 {
 // Number argument accepts any integer type (i8|i16|int|isize|i64) and will be cast to i64
 // The base argument is optional, if no value is given it will default to base 10.
 // digits returns an array with the digits in reverse order i.e. digits(12345, 10) == [5,4,3,2,1]
-pub fn digits(_n i64, _b ...int) []int {
+pub fn digits(num i64, base ...int) []int {
 	
 	//set base to 10 initially and change only if base is explicitly set.
-	mut base := 10
-	if _b.len != 0 {
-		base = _b[0]
+	mut b := 10
+	if base.len != 0 {
+		b = base[0]
 	}
-	if base < 2 {
+	if b < 2 {
 		panic('digits: Cannot find digits of n with base $base')
 	}
-	mut n := _n
+	mut n := num
 	mut sign := 1
 	if n < 0 {
 		sign = -1
@@ -69,8 +69,8 @@ pub fn digits(_n i64, _b ...int) []int {
 		return res
 	}
 	for n != 0 {
-		res << int((n % base) * sign)
-		n /= base
+		res << int((n % b) * sign)
+		n /= b
 	}
 	
 	return res
@@ -79,7 +79,7 @@ pub fn digits(_n i64, _b ...int) []int {
 // count_digits return the number of digits in the number passed.
 // Number argument accepts any integer type (i8|i16|int|isize|i64) and will be cast to i64
 pub fn count_digits(n i64) int {
-	return int(math.ceil(math.log(math.abs(f64(_n) + 1 )) / math.log(10.0)))
+	return int(math.ceil(math.log(math.abs(f64(n) + 1 )) / math.log(10.0)))
 }
 
 // minmax returns the minimum and maximum value of the two provided.

--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -42,8 +42,17 @@ pub fn degrees(radians f64) f64 {
 	return radians * (180.0 / pi)
 }
 
-// digits returns an array of the digits of n in the given base.
-pub fn digits(_n int, base int) []int {
+// digits returns an array of the digits of n in the given base b.
+// Number argument accepts any integer type (i8|i16|int|isize|i64) and will be cast to i64
+// The base argument is optional, if no value is given it will default to base 10.
+// digits returns an array with the digits in reverse order i.e. digits(12345, 10) == [5,4,3,2,1]
+pub fn digits(_n i64, _b ...int) []int {
+	
+	//set base to 10 initially and change only if base is explicitly set.
+	mut base := 10
+	if _b.len != 0 {
+		base = _b[0]
+	}
 	if base < 2 {
 		panic('digits: Cannot find digits of n with base $base')
 	}
@@ -54,11 +63,23 @@ pub fn digits(_n int, base int) []int {
 		n = -n
 	}
 	mut res := []int{}
+	// if number passed to function is 0 then short-circuit and return 0
+	if n == 0 {
+		res << 0
+		return res
+	}
 	for n != 0 {
-		res << (n % base) * sign
+		res << int((n % base) * sign)
 		n /= base
 	}
+	
 	return res
+}
+
+// count_digits return the number of digits in the number passed.
+// Number argument accepts any integer type (i8|i16|int|isize|i64) and will be cast to i64
+pub fn count_digits(n i64) int {
+	return int(math.ceil(math.log(f64(n) + 1 ) / math.log(10.0)))
 }
 
 // minmax returns the minimum and maximum value of the two provided.

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -982,3 +982,9 @@ fn test_powi() {
 	assert powi(0, -2) == -1 // div by 0
 	assert powi(2, -1) == 0
 }
+
+fn test_count_digits() {
+	assert count_digits(12345) == 5
+	assert count_digits(i64(1234567890)) == 10
+	assert count_digits(-67345) == 5
+}

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -914,31 +914,24 @@ fn test_lcm() {
 }
 
 fn test_digits() {
-	//int - 10th base (125)
-	digits_in_10th_base := digits(125, 10)
-	assert digits_in_10th_base[0] == 5
-	assert digits_in_10th_base[1] == 2
-	assert digits_in_10th_base[2] == 1
-	//int - 16th base (15 - f)
-	digits_in_16th_base := digits(15, 16)
-	assert digits_in_16th_base[0] == 15
-	//int - negative base 2 (100)
-	negative_digits := digits(-4, 2)
-	assert negative_digits[2] == -1
-	//i64 - default base 10 - no arg given
-	i64_digits_in_10th_base := digits(i64(1234432112344321))
-	assert i64_digits_in_10th_base[7] == 1
-	assert i64_digits_in_10th_base[14] == 3
-	//i8 - 7th base (453)
-	i8_digits_in_7th_base := digits(i8(234), 7)
-	assert i8_digits_in_7th_base[0] == 3
-	assert i8_digits_in_7th_base[2] == 4
-	//i16 - 12th base (33034)
-	i16_digits_in_12th_base := digits(i16(67432), 16)
-	assert i16_digits_in_12th_base[0] == 4
-	assert i16_digits_in_12th_base[2] == 0
-	assert i16_digits_in_12th_base[3] == 3
+	palindrom_digits_in_10th_base := digits(i64(1234432112344321)).reverse()
+	assert palindrom_digits_in_10th_base == [1, 2, 3, 4, 4, 3, 2, 1, 1, 2, 3, 4, 4, 3, 2, 1]
 
+	digits_in_10th_base := digits(125, 10).reverse()
+	assert digits_in_10th_base == [1, 2, 5]
+
+	digits_in_16th_base := digits(15, 16).reverse()
+	assert digits_in_16th_base == [15]
+
+	negative_digits := digits(-4, 2).reverse()
+	assert negative_digits == [-1, 0, 0]
+
+	digits_in_7th_base := digits(234, 7).reverse()
+	assert digits_in_7th_base == [4, 5, 3]
+
+	digits_in_12th_base := digits(67432, 12).reverse()
+	assert i64_digits_in_12th_base == [3, 3, 0, 3, 4]
+}
 
 // Check that math functions of high angle values
 // return accurate results. [since (vf_[i] + large) - large != vf_[i],

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -914,8 +914,10 @@ fn test_lcm() {
 }
 
 fn test_digits() {
-	palindrom_digits_in_10th_base := digits(i64(1234432112344321)).reverse()
+	palindrom_digits_in_10th_base := digits(i64(1234432112344321))
 	assert palindrom_digits_in_10th_base == [1, 2, 3, 4, 4, 3, 2, 1, 1, 2, 3, 4, 4, 3, 2, 1]
+
+	assert digits(125, base: 10, reverse: true) == [1, 2, 5]
 
 	digits_in_10th_base := digits(125, base: 10).reverse()
 	assert digits_in_10th_base == [1, 2, 5]

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -917,20 +917,20 @@ fn test_digits() {
 	palindrom_digits_in_10th_base := digits(i64(1234432112344321)).reverse()
 	assert palindrom_digits_in_10th_base == [1, 2, 3, 4, 4, 3, 2, 1, 1, 2, 3, 4, 4, 3, 2, 1]
 
-	digits_in_10th_base := digits(125, 10).reverse()
+	digits_in_10th_base := digits(125, base: 10).reverse()
 	assert digits_in_10th_base == [1, 2, 5]
 
-	digits_in_16th_base := digits(15, 16).reverse()
+	digits_in_16th_base := digits(15, base: 16).reverse()
 	assert digits_in_16th_base == [15]
 
-	negative_digits := digits(-4, 2).reverse()
+	negative_digits := digits(-4, base: 2).reverse()
 	assert negative_digits == [-1, 0, 0]
 
-	digits_in_7th_base := digits(234, 7).reverse()
+	digits_in_7th_base := digits(234, base: 7).reverse()
 	assert digits_in_7th_base == [4, 5, 3]
 
-	digits_in_12th_base := digits(67432, 12).reverse()
-	assert i64_digits_in_12th_base == [3, 3, 0, 3, 4]
+	digits_in_12th_base := digits(67432, base: 12).reverse()
+	assert digits_in_12th_base == [3, 3, 0, 3, 4]
 }
 
 // Check that math functions of high angle values

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -930,25 +930,24 @@ fn test_digits() {
 	assert digits(100, base: 128, reverse: true) == [100]
 	assert digits(100, base: 256, reverse: true) == [100]
 
-	palindrom_digits_in_10th_base := digits(i64(1234432112344321))
-	assert palindrom_digits_in_10th_base == [1, 2, 3, 4, 4, 3, 2, 1, 1, 2, 3, 4, 4, 3, 2, 1]
+	assert digits(1234432112344321) == digits(1234432112344321, reverse: true)
+	assert digits(1234432112344321) == [1, 2, 3, 4, 4, 3, 2, 1, 1, 2, 3, 4, 4, 3, 2, 1]
 
 	assert digits(125, base: 10, reverse: true) == [1, 2, 5]
+	assert digits(125, base: 10).reverse() == [1, 2, 5]
 
-	digits_in_10th_base := digits(125, base: 10).reverse()
-	assert digits_in_10th_base == [1, 2, 5]
+	assert digits(15, base: 16, reverse: true) == [15]
+	assert digits(127, base: 16, reverse: true) == [7, 15]
+	assert digits(65535, base: 16, reverse: true) == [15, 15, 15, 15]
+	assert digits(-65535, base: 16, reverse: true) == [-15, 15, 15, 15]
 
-	digits_in_16th_base := digits(15, base: 16).reverse()
-	assert digits_in_16th_base == [15]
+	assert digits(-127) == [7, 2, -1]
+	assert digits(-127).reverse() == [-1, 2, 7]
+	assert digits(-127, reverse: true) == [-1, 2, 7]
 
-	negative_digits := digits(-4, base: 2).reverse()
-	assert negative_digits == [-1, 0, 0]
+	assert digits(234, base: 7).reverse() == [4, 5, 3]
 
-	digits_in_7th_base := digits(234, base: 7).reverse()
-	assert digits_in_7th_base == [4, 5, 3]
-
-	digits_in_12th_base := digits(67432, base: 12).reverse()
-	assert digits_in_12th_base == [3, 3, 0, 3, 4]
+	assert digits(67432, base: 12).reverse() == [3, 3, 0, 3, 4]
 }
 
 // Check that math functions of high angle values
@@ -995,7 +994,19 @@ fn test_powi() {
 }
 
 fn test_count_digits() {
+	assert count_digits(-999) == 3
+	assert count_digits(-100) == 3
+	assert count_digits(-99) == 2
+	assert count_digits(-10) == 2
+	assert count_digits(-1) == 1
+	assert count_digits(0) == 1
+	assert count_digits(1) == 1
+	assert count_digits(10) == 2
+	assert count_digits(99) == 2
+	assert count_digits(100) == 3
+	assert count_digits(999) == 3
+	//
 	assert count_digits(12345) == 5
-	assert count_digits(i64(1234567890)) == 10
+	assert count_digits(123456789012345) == 15
 	assert count_digits(-67345) == 5
 }

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -914,15 +914,31 @@ fn test_lcm() {
 }
 
 fn test_digits() {
+	//int - 10th base (125)
 	digits_in_10th_base := digits(125, 10)
 	assert digits_in_10th_base[0] == 5
 	assert digits_in_10th_base[1] == 2
 	assert digits_in_10th_base[2] == 1
+	//int - 16th base (15 - f)
 	digits_in_16th_base := digits(15, 16)
 	assert digits_in_16th_base[0] == 15
+	//int - negative base 2 (100)
 	negative_digits := digits(-4, 2)
 	assert negative_digits[2] == -1
-}
+	//i64 - default base 10 - no arg given
+	i64_digits_in_10th_base := digits(i64(1234432112344321))
+	assert i64_digits_in_10th_base[7] == 1
+	assert i64_digits_in_10th_base[14] == 3
+	//i8 - 7th base (453)
+	i8_digits_in_7th_base := digits(i8(234), 7)
+	assert i8_digits_in_7th_base[0] == 3
+	assert i8_digits_in_7th_base[2] == 4
+	//i16 - 12th base (33034)
+	i16_digits_in_12th_base := digits(i16(67432), 16)
+	assert i16_digits_in_12th_base[0] == 4
+	assert i16_digits_in_12th_base[2] == 0
+	assert i16_digits_in_12th_base[3] == 3
+
 
 // Check that math functions of high angle values
 // return accurate results. [since (vf_[i] + large) - large != vf_[i],

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -914,6 +914,22 @@ fn test_lcm() {
 }
 
 fn test_digits() {
+	// a small sanity check with a known number like 100,
+	// just written in different base systems:
+	assert digits(100, reverse: true) == [1, 0, 0]
+	assert digits(100, base: 2, reverse: true) == [1, 1, 0, 0, 1, 0, 0]
+	assert digits(100, base: 3, reverse: true) == [1, 0, 2, 0, 1]
+	assert digits(100, base: 4, reverse: true) == [1, 2, 1, 0]
+	assert digits(100, base: 8, reverse: true) == [1, 4, 4]
+	assert digits(100, base: 10, reverse: true) == [1, 0, 0]
+	assert digits(100, base: 12, reverse: true) == [8, 4]
+	assert digits(100, base: 16, reverse: true) == [6, 4]
+	assert digits(100, base: 20, reverse: true) == [5, 0]
+	assert digits(100, base: 32, reverse: true) == [3, 4]
+	assert digits(100, base: 64, reverse: true) == [1, 36]
+	assert digits(100, base: 128, reverse: true) == [100]
+	assert digits(100, base: 256, reverse: true) == [100]
+
 	palindrom_digits_in_10th_base := digits(i64(1234432112344321))
 	assert palindrom_digits_in_10th_base == [1, 2, 3, 4, 4, 3, 2, 1, 1, 2, 3, 4, 4, 3, 2, 1]
 


### PR DESCRIPTION
The PR improves a function in math library to accept larger numbers. The current math.digits function only accepts int type. This PR changes that to accept i64 allowing larger numbers to be converted e.g. telephone numbers, credit card numbers, barcode numbers. The base argument is optional and defaults to base 10 which should satisfy most cases.

PR also adds a small convenience function count_digits which will return the number of digits in a given integer. 

```
digits(12345)  => [5,4,3,2,1]
digits(i16(5478), 7) => [4, 5, 6, 1, 2]
digits(i64(1_800_275_227), 10) => [7, 2, 2, 5, 7, 2, 0, 0, 8, 1]

count_digits(12345) => 5
count_digits(i16(5478))  => 4
count_digits(i64(1_800_275_227)) => 10
count_digits(-12345) => 5

```



