### PR TITLE
doc: update struct access modifiers

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2084,9 +2084,9 @@ __global:
 	f int // public and mutable both inside and outside parent module
 }
 ```
-Private fields are available only inside the same [module](#modules), the attempt
-to access it from another module will cause an error during compilation.
-Immutable fields are readonly from anywhere.
+Private fields are available only inside the same [module](#modules), any attempt
+to directly access them from another module will cause an error during compilation.
+Public immutable fields are readonly everywhere.
 
 ### Methods
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2084,29 +2084,9 @@ __global:
 	f int // public and mutable both inside and outside parent module
 }
 ```
-
-For example, here's the `string` type defined in the `builtin` module:
-
-```v ignore
-struct string {
-    str &byte
-pub:
-    len int
-}
-```
-
-It's easy to see from this definition that `string` is an immutable type.
-The byte pointer with the string data is not accessible outside `builtin` at all.
-The `len` field is public, but immutable:
-```v failcompile
-fn main() {
-	str := 'hello'
-	len := str.len // OK
-	str.len++ // Compilation error
-}
-```
-
-This means that defining public readonly fields is very easy in V.
+Private fields are available only inside the same [module](#modules), the attempt
+to access it from another module will cause an error during compilation.
+Immutable fields are readonly from anywhere.
 
 ### Methods
 


### PR DESCRIPTION
Examples for struct field access modifiers are out of date, the builtin string
has no private methods anymore. Instead it's proposed to explain behavior
of access modifiers, because there is no exhaustive definition of visibility
and mutability for struct fields.