### PR TITLE
ast: fix error for typeof aggregate (fix #12828)

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1122,9 +1122,10 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 				res = 'thread ' + t.type_to_str_using_aliases(rtype, import_aliases)
 			}
 		}
-		.alias, .any, .aggregate, .placeholder, .enum_ {
+		.alias, .any, .placeholder, .enum_ {
 			res = t.shorten_user_defined_typenames(res, import_aliases)
 		}
+		.aggregate {}
 	}
 	mut nr_muls := typ.nr_muls()
 	if typ.has_flag(.shared_f) {

--- a/vlib/v/tests/typeof_aggregate_test.v
+++ b/vlib/v/tests/typeof_aggregate_test.v
@@ -1,0 +1,46 @@
+struct Foo {
+}
+
+struct Bar {
+	text string
+}
+
+struct Baz {
+	text string
+}
+
+struct Bazaar {
+	text string
+}
+
+type FBB = Bar | Baz | Bazaar | Foo
+
+fn test_typeof_aggregate() {
+	mut arr := []FBB{}
+	arr << Foo{}
+	arr << Bar{
+		text: 'bar'
+	}
+	arr << Baz{
+		text: 'baz'
+	}
+
+	mut rets := []string{}
+	for a in arr {
+		match a {
+			Foo {
+				println('The type of `a` is `${typeof(a).name}`')
+				rets << 'The type of `a` is `${typeof(a).name}`'
+			}
+			Bar, Baz, Bazaar {
+				println('The type of `a` is `${typeof(a).name}` and its text says $a.text')
+				rets << 'The type of `a` is `${typeof(a).name}` and its text says $a.text'
+			}
+		}
+	}
+
+	assert rets.len == 3
+	assert rets[0] == 'The type of `a` is `Foo`'
+	assert rets[1] == 'The type of `a` is `(Bar | Baz | Bazaar)` and its text says bar'
+	assert rets[2] == 'The type of `a` is `(Bar | Baz | Bazaar)` and its text says baz'
+}


### PR DESCRIPTION
This PR fix error for typeof aggregate (fix #12828).

- Fix error for typeof aggregate.
- Add test.

```vlang
struct Foo {
}

struct Bar {
	text string
}

struct Baz {
	text string
}

struct Bazaar {
	text string
}

type FBB = Bar | Baz | Bazaar | Foo

fn main() {
	mut arr := []FBB{}
	arr << Foo{}
	arr << Bar{
		text: 'bar'
	}
	arr << Baz{
		text: 'baz'
	}

	mut rets := []string{}
	for a in arr {
		match a {
			Foo {
				println('The type of `a` is `${typeof(a).name}`')
				rets << 'The type of `a` is `${typeof(a).name}`'
			}
			Bar, Baz, Bazaar {
				println('The type of `a` is `${typeof(a).name}` and its text says $a.text')
				rets << 'The type of `a` is `${typeof(a).name}` and its text says $a.text'
			}
		}
	}

	assert rets.len == 3
	assert rets[0] == 'The type of `a` is `Foo`'
	assert rets[1] == 'The type of `a` is `(Bar | Baz | Bazaar)` and its text says bar'
	assert rets[2] == 'The type of `a` is `(Bar | Baz | Bazaar)` and its text says baz'
}

PS D:\Test\v\tt1> v run .
The type of `a` is `Foo`
The type of `a` is `(Bar | Baz | Bazaar)` and its text says bar
The type of `a` is `(Bar | Baz | Bazaar)` and its text says baz
```