### PR TITLE
gen/c: fix double evaluation of rvalue array expression in slice

### DIFF
--- a/.github/workflows/other_ci.yml
+++ b/.github/workflows/other_ci.yml
@@ -81,7 +81,7 @@ jobs:
         run: make
 
       - name: Ensure V can be compiled with -autofree
-        run: ./v -autofree -o v2 cmd/v  ## NB: this does not mean it runs, but at least keeps it from regressing
+        run: ./v -autofree -cc gcc -cg -o v2 cmd/v  ## NB: this does not mean it runs, but at least keeps it from regressing
 
       - name: Shader examples can be build
         run: |

--- a/.github/workflows/other_ci.yml
+++ b/.github/workflows/other_ci.yml
@@ -81,7 +81,7 @@ jobs:
         run: make
 
       - name: Ensure V can be compiled with -autofree
-        run: ./v -autofree -cc gcc -cg -o v2 cmd/v  ## NB: this does not mean it runs, but at least keeps it from regressing
+        run: ./v -autofree -o v2 cmd/v  ## NB: this does not mean it runs, but at least keeps it from regressing
 
       - name: Shader examples can be build
         run: |

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5643,7 +5643,8 @@ static inline __shared__$interface_name ${shared_fn_name}(__shared__$cctype* x) 
 						if fargs.len > 1 {
 							methods_wrapper.write_string(', ')
 						}
-						methods_wrapper.writeln('${fargs[1..].join(', ')});')
+						args := fargs[1..].join(', ')
+						methods_wrapper.writeln('$args);')
 					} else {
 						if parameter_name.starts_with('__shared__') {
 							methods_wrapper.writeln('${method_call}(${fargs.join(', ')}->val);')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4795,7 +4795,7 @@ fn (mut g Gen) go_before_ternary() string {
 }
 
 fn (mut g Gen) insert_before_stmt(s string) {
-	cur_line := g.go_before_stmt(0)
+	cur_line := g.go_before_stmt(g.inside_ternary)
 	g.writeln(s)
 	g.write(cur_line)
 }

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -85,7 +85,7 @@ fn (mut g Gen) range_expr(node ast.IndexExpr, range ast.RangeExpr) {
 	} else if sym.kind == .array {
 		if !range.has_high {
 			tmp_left = g.new_tmp_var()
-			line := g.go_before_stmt(0)
+			line := g.go_before_ternary()
 			g.out.write_string(util.tabs(g.indent))
 			tmp_type := g.typ(node.left_type)
 			g.write('$tmp_type $tmp_left = ')

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -148,7 +148,7 @@ fn (mut g Gen) range_expr(node ast.IndexExpr, range ast.RangeExpr) {
 		g.write('$info.size')
 	} else if sym.kind == .array {
 		if node.left_type.is_ptr() {
-			g.write('${tmp_left}->len')
+			g.write('$tmp_left->len')
 		} else {
 			g.write('${tmp_left}.len')
 		}

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -85,12 +85,12 @@ fn (mut g Gen) range_expr(node ast.IndexExpr, range ast.RangeExpr) {
 	} else if sym.kind == .array {
 		if !range.has_high {
 			tmp_left = g.new_tmp_var()
-			line := g.go_before_ternary()
-			g.out.write_string(util.tabs(g.indent))
 			tmp_type := g.typ(node.left_type)
-			g.write('$tmp_type $tmp_left = ')
+			g.insert_before_stmt('${util.tabs(g.indent)}$tmp_type $tmp_left;')
+			// (tmp = expr, array_slice(...))
+			g.write('($tmp_left = ')
 			g.expr(node.left)
-			g.write(';\n$line')
+			g.write(', ')
 		}
 		if node.is_gated {
 			g.write('array_slice_ni(')
@@ -148,10 +148,11 @@ fn (mut g Gen) range_expr(node ast.IndexExpr, range ast.RangeExpr) {
 		g.write('$info.size')
 	} else if sym.kind == .array {
 		if node.left_type.is_ptr() {
-			g.write('$tmp_left->len')
+			g.write('$tmp_left->')
 		} else {
-			g.write('${tmp_left}.len')
+			g.write('${tmp_left}.')
 		}
+		g.write('len)')
 	} else {
 		g.write('(')
 		g.expr(node.left)

--- a/vlib/v/tests/slice_rval_test.v
+++ b/vlib/v/tests/slice_rval_test.v
@@ -1,0 +1,8 @@
+fn test_arr_rval() {
+	a := [1,2]
+	s := (*&a)[..]
+	assert s == a
+	
+	b := unsafe {*&[]int(&a)}[..]
+	assert b == a
+}

--- a/vlib/v/tests/slice_rval_test.v
+++ b/vlib/v/tests/slice_rval_test.v
@@ -1,8 +1,8 @@
 fn test_arr_rval() {
-	a := [1,2]
+	a := [1, 2]
 	s := (*&a)[..]
 	assert s == a
-	
-	b := unsafe {*&[]int(&a)}[..]
+
+	b := unsafe { *&[]int(&a) }[..]
 	assert b == a
 }


### PR DESCRIPTION
Use a temporary variable when the high index expression is missing to avoid double evaluation.

Note: Double evaluation still happens slicing a string or fixed array, I can fix that separately. BTW I'm not sure what the `else` case is, what else can be sliced?
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
