### PR TITLE
parser: notice unnecessary parenthesis of reference (fix #11179)

### DIFF
--- a/vlib/builtin/string_interpolation.v
+++ b/vlib/builtin/string_interpolation.v
@@ -660,7 +660,7 @@ pub fn str_intp(data_len int, in_data voidptr) string {
 	mut res := strings.new_builder(256)
 	input_base := &StrIntpData(in_data)
 	for i := 0; i < data_len; i++ {
-		data := unsafe { &(input_base[i]) }
+		data := unsafe { &input_base[i] }
 		// avoid empty strings
 		if data.str.len != 0 {
 			res.write_string(data.str)

--- a/vlib/v/checker/tests/unnecessary_parenthesis_of_reference.out
+++ b/vlib/v/checker/tests/unnecessary_parenthesis_of_reference.out
@@ -1,0 +1,35 @@
+vlib/v/checker/tests/unnecessary_parenthesis_of_reference.vv:29:10: notice: unnecessary `()`, use `&Quad{....}` instead of `&(Quad{....})`
+   27 | // ritorna una nuova Quadrica somma del ricevente e di un'altra
+   28 | fn (q &Quad) add(other &Quad) &Quad {
+   29 |     return &(Quad{q.x + other.x, q.y + other.y, q.z + other.z, q.w + other.w})
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   30 | }
+   31 |
+vlib/v/checker/tests/unnecessary_parenthesis_of_reference.vv:34:10: notice: unnecessary `()`, use `&Quad{....}` instead of `&(Quad{....})`
+   32 | // ritorna una nuova Quadrica differenza tra il ricevente e un'altra
+   33 | fn (q &Quad) sub(other &Quad) &Quad {
+   34 |     return &(Quad{q.x - other.x, q.y - other.y, q.z - other.z, q.w - other.w})
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   35 | }
+   36 |
+vlib/v/checker/tests/unnecessary_parenthesis_of_reference.vv:39:10: notice: unnecessary `()`, use `&Quad{....}` instead of `&(Quad{....})`
+   37 | // ritorna una nuova Quadrica ottenuta negando il ricevente
+   38 | fn (q &Quad) neg() &Quad {
+   39 |     return &(Quad{-q.x, -q.y, -q.z, -q.w})
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   40 | }
+   41 |
+vlib/v/checker/tests/unnecessary_parenthesis_of_reference.vv:44:10: notice: unnecessary `()`, use `&Quad{....}` instead of `&(Quad{....})`
+   42 | // ritorna una nuova Quadrica ottenuta moltiplicando il ricevente per una costante
+   43 | fn (q &Quad) mult(factor f64) &Quad {
+   44 |     return &(Quad{q.x * factor, q.y * factor, q.z * factor, q.w * factor})
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   45 | }
+   46 |
+vlib/v/checker/tests/unnecessary_parenthesis_of_reference.vv:49:10: notice: unnecessary `()`, use `&Quad{....}` instead of `&(Quad{....})`
+   47 | // ritorna una nuova Quadrica ottenuta dividendo il ricevente per una costante
+   48 | fn (q &Quad) div(factor f64) &Quad {
+   49 |     return &(Quad{q.x / factor, q.y / factor, q.z / factor, q.w / factor})
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   50 | }
+   51 |

--- a/vlib/v/checker/tests/unnecessary_parenthesis_of_reference.vv
+++ b/vlib/v/checker/tests/unnecessary_parenthesis_of_reference.vv
@@ -1,0 +1,69 @@
+struct Quad {
+mut:
+	x f64
+	y f64
+	z f64
+	w f64
+}
+
+fn (q Quad) get(i int) f64 {
+	return match i {
+		0 { q.x }
+		1 { q.y }
+		2 { q.z }
+		else { q.w }
+	}
+}
+
+fn (mut q Quad) set(i int, v f64) {
+	match i {
+		0 { q.x = v }
+		1 { q.y = v }
+		2 { q.z = v }
+		else { q.w = v }
+	}
+}
+
+// ritorna una nuova Quadrica somma del ricevente e di un'altra
+fn (q &Quad) add(other &Quad) &Quad {
+	return &(Quad{q.x + other.x, q.y + other.y, q.z + other.z, q.w + other.w})
+}
+
+// ritorna una nuova Quadrica differenza tra il ricevente e un'altra
+fn (q &Quad) sub(other &Quad) &Quad {
+	return &(Quad{q.x - other.x, q.y - other.y, q.z - other.z, q.w - other.w})
+}
+
+// ritorna una nuova Quadrica ottenuta negando il ricevente
+fn (q &Quad) neg() &Quad {
+	return &(Quad{-q.x, -q.y, -q.z, -q.w})
+}
+
+// ritorna una nuova Quadrica ottenuta moltiplicando il ricevente per una costante
+fn (q &Quad) mult(factor f64) &Quad {
+	return &(Quad{q.x * factor, q.y * factor, q.z * factor, q.w * factor})
+}
+
+// ritorna una nuova Quadrica ottenuta dividendo il ricevente per una costante
+fn (q &Quad) div(factor f64) &Quad {
+	return &(Quad{q.x / factor, q.y / factor, q.z / factor, q.w / factor})
+}
+
+fn main() {
+	mut n := Quad{1, 2, 3, 4}
+
+	println(n)
+	println(n.get(0))
+	println(n.get(1))
+	println(n.get(2))
+	println(n.get(3))
+	n.set(0, 5)
+	n.set(1, 6)
+	n.set(2, 7)
+	n.set(3, 8)
+	println(n)
+	println(n.get(0))
+	println(n.get(1))
+	println(n.get(2))
+	println(n.get(3))
+}

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -604,6 +604,13 @@ fn (mut p Parser) prefix_expr() ast.Expr {
 				return right
 			}
 		}
+		if mut right is ast.ParExpr {
+			if right.expr in [ast.Ident, ast.StructInit, ast.IndexExpr] {
+				p.note_with_pos('unnecessary `()`, use `&$right.expr` instead of `&($right.expr)`',
+					right.pos)
+				right = right.expr
+			}
+		}
 	}
 	mut or_stmts := []ast.Stmt{}
 	mut or_kind := ast.OrKind.absent

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -605,7 +605,7 @@ fn (mut p Parser) prefix_expr() ast.Expr {
 			}
 		}
 		if mut right is ast.ParExpr {
-			if right.expr in [ast.Ident, ast.StructInit, ast.IndexExpr] {
+			if right.expr in [ast.Ident, ast.StructInit, ast.IndexExpr, ast.SelectorExpr] {
 				p.note_with_pos('unnecessary `()`, use `&$right.expr` instead of `&($right.expr)`',
 					right.pos)
 				right = right.expr


### PR DESCRIPTION
This PR notice unnecessary parenthesis of reference (fix #11179).

- Notice unnecessary parenthesis of reference.
- Add test.

```v
struct Quad {
mut:
	x f64
	y f64
	z f64
	w f64
}

fn (q Quad) get(i int) f64 {
	return match i {
		0 { q.x }
		1 { q.y }
		2 { q.z }
		else { q.w }
	}
}

fn (mut q Quad) set(i int, v f64) {
	match i {
		0 { q.x = v }
		1 { q.y = v }
		2 { q.z = v }
		else { q.w = v }
	}
}

// ritorna una nuova Quadrica somma del ricevente e di un'altra
fn (q &Quad) add(other &Quad) &Quad {
	return &(Quad{q.x + other.x, q.y + other.y, q.z + other.z, q.w + other.w})
}

// ritorna una nuova Quadrica differenza tra il ricevente e un'altra
fn (q &Quad) sub(other &Quad) &Quad {
	return &(Quad{q.x - other.x, q.y - other.y, q.z - other.z, q.w - other.w})
}

// ritorna una nuova Quadrica ottenuta negando il ricevente
fn (q &Quad) neg() &Quad {
	return &(Quad{-q.x, -q.y, -q.z, -q.w})
}

// ritorna una nuova Quadrica ottenuta moltiplicando il ricevente per una costante
fn (q &Quad) mult(factor f64) &Quad {
	return &(Quad{q.x * factor, q.y * factor, q.z * factor, q.w * factor})
}

// ritorna una nuova Quadrica ottenuta dividendo il ricevente per una costante
fn (q &Quad) div(factor f64) &Quad {
	return &(Quad{q.x / factor, q.y / factor, q.z / factor, q.w / factor})
}

fn main() {
	mut n := Quad{1, 2, 3, 4}

	println(n)
	println(n.get(0))
	println(n.get(1))
	println(n.get(2))
	println(n.get(3))
	n.set(0, 5)
	n.set(1, 6)
	n.set(2, 7)
	n.set(3, 8)
	println(n)
	println(n.get(0))
	println(n.get(1))
	println(n.get(2))
	println(n.get(3))
}

PS D:\Test\v\tt1> v run .
./tt1.v:34:10: notice: unnecessary `()`, use `&Quad{....}` instead of `&(Quad{....})`
   32 | // ritorna una nuova Quadrica differenza tra il ricevente e un'altra
   33 | fn (q &Quad) sub(other &Quad) &Quad {
   34 |     return &(Quad{q.x - other.x, q.y - other.y, q.z - other.z, q.w - other.w})
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   35 | }
   36 |
./tt1.v:39:10: notice: unnecessary `()`, use `&Quad{....}` instead of `&(Quad{....})`
   37 | // ritorna una nuova Quadrica ottenuta negando il ricevente
   38 | fn (q &Quad) neg() &Quad {
   39 |     return &(Quad{-q.x, -q.y, -q.z, -q.w})
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   40 | }
   41 |
./tt1.v:44:10: notice: unnecessary `()`, use `&Quad{....}` instead of `&(Quad{....})`
   42 | // ritorna una nuova Quadrica ottenuta moltiplicando il ricevente per una costante
   43 | fn (q &Quad) mult(factor f64) &Quad {
   44 |     return &(Quad{q.x * factor, q.y * factor, q.z * factor, q.w * factor})
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   45 | }
   46 |
./tt1.v:49:10: notice: unnecessary `()`, use `&Quad{....}` instead of `&(Quad{....})`
   47 | // ritorna una nuova Quadrica ottenuta dividendo il ricevente per una costante
   48 | fn (q &Quad) div(factor f64) &Quad {
   49 |     return &(Quad{q.x / factor, q.y / factor, q.z / factor, q.w / factor})
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   50 | }
   51 |
Quad{
    x: 1
    y: 2
    z: 3
    w: 4
}
1.
2.
3.
4.
Quad{
    x: 5
    y: 6
    z: 7
    w: 8
}
5.
6.
7.
8.
```