### PR TITLE
checker: check invalid 'mut' keyword in infix expr (related #8187)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -594,11 +594,19 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		match mut node.left {
 			ast.Ident, ast.SelectorExpr {
 				if node.left.is_mut {
-					c.error('remove unnecessary `mut`', node.left.mut_pos)
+					c.error('the `mut` keyword is invalid here', node.left.mut_pos)
 				}
 			}
 			else {}
 		}
+	}
+	match mut node.right {
+		ast.Ident, ast.SelectorExpr {
+			if node.right.is_mut {
+				c.error('the `mut` keyword is invalid here', node.right.mut_pos)
+			}
+		}
+		else {}
 	}
 	eq_ne := node.op in [.eq, .ne]
 	// Single side check

--- a/vlib/v/checker/tests/invalid_mut.out
+++ b/vlib/v/checker/tests/invalid_mut.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/invalid_mut.vv:3:5: error: the `mut` keyword is invalid here
+    1 | fn main() {
+    2 |     mut x := 0
+    3 |     if mut x == 0 {
+      |        ~~~
+    4 |         println(true)
+    5 |     }
+vlib/v/checker/tests/invalid_mut.vv:6:10: error: the `mut` keyword is invalid here
+    4 |         println(true)
+    5 |     }
+    6 |     if 0 == mut x {
+      |             ~~~
+    7 |         println(true)
+    8 |     }

--- a/vlib/v/checker/tests/invalid_mut.vv
+++ b/vlib/v/checker/tests/invalid_mut.vv
@@ -3,5 +3,8 @@ fn main() {
 	if mut x == 0 {
 		println(true)
 	}
+	if 0 == mut x {
+		println(true)
+	}
 	_ = x
 }

--- a/vlib/v/parser/tests/unnecessary_mut.out
+++ b/vlib/v/parser/tests/unnecessary_mut.out
@@ -1,7 +1,0 @@
-vlib/v/parser/tests/unnecessary_mut.vv:3:5: error: remove unnecessary `mut`
-    1 | fn main() {
-    2 |     mut x := 0
-    3 |     if mut x == 0 {
-      |        ~~~
-    4 |         println(true)
-    5 |     }


### PR DESCRIPTION
This PR check invalid 'mut' keyword in infix expr (related #8187).

- Check invalid 'mut' keyword in infix expr.
- Add test.

```v
fn main() {
	mut x := 0
	if mut x == 0 {
		println(true)
	}
	if 0 == mut x {
		println(true)
	}
	_ = x
}

PS D:\Test\v\tt1> v run .
./tt1.v:3:5: error: the `mut` keyword is invalid here
    1 | fn main() {
    2 |     mut x := 0
    3 |     if mut x == 0 {
      |        ~~~
    4 |         println(true)
    5 |     }
./tt1.v:6:10: error: the `mut` keyword is invalid here
    4 |         println(true)
    5 |     }
    6 |     if 0 == mut x {
      |             ~~~
    7 |         println(true)
    8 |     }
```