### PR TITLE
ast: minor cleanup in is_blank_ident()

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1692,10 +1692,10 @@ pub:
 
 [inline]
 pub fn (expr Expr) is_blank_ident() bool {
-	match expr {
-		Ident { return expr.kind == .blank_ident }
-		else { return false }
+	if expr is Ident {
+		return expr.kind == .blank_ident
 	}
+	return false
 }
 
 pub fn (expr Expr) pos() token.Pos {


### PR DESCRIPTION
This PR makes a minor cleanup in is_blank_ident().

- Use `if expr is Ident` instead of `match expr {...}`.