### PR TITLE
checker: check the sumtype mismatch returned by match expr (fix #13750)

### DIFF
--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -85,7 +85,10 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 							&& !c.check_types(expr_type, ret_type) {
 							ret_sym := c.table.sym(ret_type)
 							is_noreturn := is_noreturn_callexpr(stmt.expr)
-							if !(node.is_expr && ret_sym.kind == .sum_type) && !is_noreturn {
+							if !(node.is_expr && ret_sym.kind == .sum_type
+								&& (ret_type.has_flag(.generic)
+								|| c.table.is_sumtype_or_in_variant(ret_type, expr_type)))
+								&& !is_noreturn {
 								c.error('return type mismatch, it should be `$ret_sym.name`',
 									stmt.expr.pos())
 							}

--- a/vlib/v/checker/tests/match_return_sumtype_mismatch_err.out
+++ b/vlib/v/checker/tests/match_return_sumtype_mismatch_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/match_return_sumtype_mismatch_err.vv:15:11: error: return type mismatch, it should be `Myt`
+   13 |     return match b {
+   14 |         true { St('TRUE') }
+   15 |         false { `F` }
+      |                 ~~~
+   16 |     }
+   17 | }

--- a/vlib/v/checker/tests/match_return_sumtype_mismatch_err.vv
+++ b/vlib/v/checker/tests/match_return_sumtype_mismatch_err.vv
@@ -1,0 +1,19 @@
+type St = string
+type Ru = rune
+type Myt = Ru | St
+
+fn myt_t1(b bool) Myt {
+	match b {
+		true { return St('TRUE') }
+		false { return Ru(`F`) }
+	}
+}
+
+fn myt_t2(b bool) Myt {
+	return match b {
+		true { St('TRUE') }
+		false { `F` }
+	}
+}
+
+fn main() {}


### PR DESCRIPTION
This PR check the sumtype mismatch returned by match expr (fix #13750).

- Check the sumtype mismatch returned by match expr.
- Add test.

```v
type St = string
type Ru = rune
type Myt = Ru | St

fn myt_t1(b bool) Myt {
	match b {
		true { return St('TRUE') }
		false { return Ru(`F`) }
	}
}

fn myt_t2(b bool) Myt {
	return match b {
		true { St('TRUE') }
		false { `F` }
	}
}

fn main() {}

PS D:\Test\v\tt1> v run .
./tt1.v:15:11: error: return type mismatch, it should be `Myt`
   13 |     return match b {
   14 |         true { St('TRUE') }
   15 |         false { `F` }
      |                 ~~~
   16 |     }
   17 | }
```