### PR TITLE
cgen: fix error for if expr returning sumtype (fix #9215)

### DIFF
--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -200,7 +200,11 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 			}
 		}
 		if needs_tmp_var {
+			if node.is_expr && g.table.sym(node.typ).kind == .sum_type {
+				g.expected_cast_type = node.typ
+			}
 			g.stmts_with_tmp_var(branch.stmts, tmp)
+			g.expected_cast_type = 0
 		} else {
 			// restore if_expr stmt header pos
 			stmt_pos := g.nth_stmt_pos(0)

--- a/vlib/v/tests/if_expr_with_sumtype_test.v
+++ b/vlib/v/tests/if_expr_with_sumtype_test.v
@@ -1,0 +1,23 @@
+struct A_str {}
+
+struct B_str {}
+
+type Token = A_str | B_str
+
+fn next(mut v []Token) Token {
+	return if v.len > 0 { v.pop() } else { A_str{} }
+}
+
+fn test_if_expr_with_sumtype() {
+	mut arr := []Token{}
+	ret1 := next(mut arr)
+	println(ret1)
+	assert '$ret1' == 'Token(A_str{})'
+
+	arr << A_str{}
+	arr << B_str{}
+
+	ret2 := next(mut arr)
+	println(ret2)
+	assert '$ret2' == 'Token(B_str{})'
+}


### PR DESCRIPTION
This PR fix error for if expr returning sumtype (fix #9215).

- Fix error for if expr returning sumtype.
- Add test.

```v
struct A_str {}

struct B_str {}

type Token = A_str | B_str

fn next(mut v []Token) Token {
	return if v.len > 0 { v.pop() } else { A_str{} }
}

fn main() {
	mut arr := []Token{}
	ret1 := next(mut arr)
	println(ret1)
	assert '$ret1' == 'Token(A_str{})'

	arr << A_str{}
	arr << B_str{}

	ret2 := next(mut arr)
	println(ret2)
	assert '$ret2' == 'Token(B_str{})'
}

PS D:\Test\v\tt1> v run .
Token(A_str{})
Token(B_str{})
```