### PR TITLE
strings: add `Builder.ensure_cap()` method

### DIFF
--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -179,7 +179,7 @@ pub fn (mut b Builder) str() string {
 // ensure_cap ensures that the buffer has enough space for at least `n` bytes by growing the buffer if necessary
 pub fn (mut b Builder) ensure_cap(n int) {
 	// code adapted from vlib/builtin/array.v
-	if n < 0 || n <= b.cap {
+	if n <= b.cap {
 		return
 	}
 

--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -176,6 +176,30 @@ pub fn (mut b Builder) str() string {
 	return s
 }
 
+// grow ensures that the buffer has enough space for at least `n` bytes by growing the buffer if necessary
+pub fn (mut b Builder) grow(n int) {
+	// code adapted from vlib/builtin/array.v
+	if n < 0 || b.cap - b.len >= n {
+		return
+	}
+
+	cap := 2 * b.cap + n
+	new_size := cap * b.element_size
+	new_data := vcalloc(new_size)
+	if b.data != voidptr(0) {
+		unsafe { vmemcpy(new_data, b.data, b.len * b.element_size) }
+		// TODO: the old data may be leaked when no GC is used (ref-counting?)
+		if b.flags.has(.noslices) {
+			unsafe { free(b.data) }
+		}
+	}
+	unsafe {
+		b.data = new_data
+		b.offset = 0
+		b.cap = cap
+	}
+}
+
 // free is for manually freeing the contents of the buffer
 [unsafe]
 pub fn (mut b Builder) free() {

--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -177,15 +177,13 @@ pub fn (mut b Builder) str() string {
 }
 
 // grow ensures that the buffer has enough space for at least `n` bytes by growing the buffer if necessary
-pub fn (mut b Builder) grow(n int) {
+pub fn (mut b Builder) ensure_cap(n int) {
 	// code adapted from vlib/builtin/array.v
-	if n < 0 || b.cap - b.len >= n {
+	if n < 0 || n <= b.cap {
 		return
 	}
 
-	cap := 2 * b.cap + n
-	new_size := cap * b.element_size
-	new_data := vcalloc(new_size)
+	new_data := vcalloc(n * b.element_size)
 	if b.data != voidptr(0) {
 		unsafe { vmemcpy(new_data, b.data, b.len * b.element_size) }
 		// TODO: the old data may be leaked when no GC is used (ref-counting?)
@@ -196,7 +194,7 @@ pub fn (mut b Builder) grow(n int) {
 	unsafe {
 		b.data = new_data
 		b.offset = 0
-		b.cap = cap
+		b.cap = n
 	}
 }
 

--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -176,7 +176,7 @@ pub fn (mut b Builder) str() string {
 	return s
 }
 
-// grow ensures that the buffer has enough space for at least `n` bytes by growing the buffer if necessary
+// ensure_cap ensures that the buffer has enough space for at least `n` bytes by growing the buffer if necessary
 pub fn (mut b Builder) ensure_cap(n int) {
 	// code adapted from vlib/builtin/array.v
 	if n < 0 || n <= b.cap {

--- a/vlib/strings/builder_test.v
+++ b/vlib/strings/builder_test.v
@@ -113,13 +113,17 @@ fn test_write_runes() {
 	assert x == 'hello world'
 }
 
-fn test_grow() {
+fn test_ensure_cap() {
 	mut sb := strings.new_builder(0)
 	assert sb.cap == 0
-	sb.grow(10)
+	sb.ensure_cap(10)
 	assert sb.cap == 10
-	sb.grow(10)
+	sb.ensure_cap(10)
 	assert sb.cap == 10
-	sb.grow(15)
-	assert sb.cap == 35
+	sb.ensure_cap(15)
+	assert sb.cap == 15
+	sb.ensure_cap(10)
+	assert sb.cap == 15
+	sb.ensure_cap(-1)
+	assert sb.cap == 15
 }

--- a/vlib/strings/builder_test.v
+++ b/vlib/strings/builder_test.v
@@ -112,3 +112,14 @@ fn test_write_runes() {
 	x := sb.str()
 	assert x == 'hello world'
 }
+
+fn test_grow() {
+	mut sb := strings.new_builder(0)
+	assert sb.cap == 0
+	sb.grow(10)
+	assert sb.cap == 10
+	sb.grow(10)
+	assert sb.cap == 10
+	sb.grow(15)
+	assert sb.cap == 35
+}


### PR DESCRIPTION
This function behaves exactly the same way as the ones in Go ([`strings.Builder.grow()`](https://pkg.go.dev/strings#Builder.Cap) & [`bytes.Buffer.grow()`](https://pkg.go.dev/bytes?utm_source=gopls#Buffer.Grow)) apart that when giving a negative number it doesn't panic, it just do nothing.

I've also added tests.