### PR TITLE
checker: notice invalid smartcast with if/match none ident or selector (fix #12317)

### DIFF
--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -152,12 +152,8 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 			} else {
 				c.stmts(branch.stmts)
 			}
-			if c.smartcast_mut_pos != token.Pos{} {
-				c.smartcast_mut_pos = token.Pos{}
-			}
-			if c.smartcast_cond_pos != token.Pos{} {
-				c.smartcast_cond_pos = token.Pos{}
-			}
+			c.smartcast_mut_pos = token.Pos{}
+			c.smartcast_cond_pos = token.Pos{}
 		}
 		if expr_required {
 			if branch.stmts.len > 0 && branch.stmts[branch.stmts.len - 1] is ast.ExprStmt {

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -155,6 +155,9 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 			if c.smartcast_mut_pos != token.Pos{} {
 				c.smartcast_mut_pos = token.Pos{}
 			}
+			if c.smartcast_cond_pos != token.Pos{} {
+				c.smartcast_cond_pos = token.Pos{}
+			}
 		}
 		if expr_required {
 			if branch.stmts.len > 0 && branch.stmts[branch.stmts.len - 1] is ast.ExprStmt {

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -46,6 +46,9 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 		if c.smartcast_mut_pos != token.Pos{} {
 			c.smartcast_mut_pos = token.Pos{}
 		}
+		if c.smartcast_cond_pos != token.Pos{} {
+			c.smartcast_cond_pos = token.Pos{}
+		}
 		if node.is_expr {
 			if branch.stmts.len > 0 {
 				// ignore last statement - workaround

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -43,12 +43,8 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 		} else {
 			c.stmts(branch.stmts)
 		}
-		if c.smartcast_mut_pos != token.Pos{} {
-			c.smartcast_mut_pos = token.Pos{}
-		}
-		if c.smartcast_cond_pos != token.Pos{} {
-			c.smartcast_cond_pos = token.Pos{}
-		}
+		c.smartcast_mut_pos = token.Pos{}
+		c.smartcast_cond_pos = token.Pos{}
 		if node.is_expr {
 			if branch.stmts.len > 0 {
 				// ignore last statement - workaround

--- a/vlib/v/checker/tests/incorrect_smartcast2_err.out
+++ b/vlib/v/checker/tests/incorrect_smartcast2_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/incorrect_smartcast2_err.vv:24:9: notice: smartcast can only be used on the ident or selector, e.g. match foo, match foo.bar
+   22 |
+   23 | fn doesntwork(v []Either<int, int>) {
+   24 |     match v[0] {
+      |            ~~~
+   25 |         Left<int> {
+   26 |             println(v[0].error)
+vlib/v/checker/tests/incorrect_smartcast2_err.vv:26:17: error: field `error` does not exist or have the same type in all sumtype variants
+   24 |     match v[0] {
+   25 |         Left<int> {
+   26 |             println(v[0].error)
+      |                          ~~~~~
+   27 |         }
+   28 |         else {}

--- a/vlib/v/checker/tests/incorrect_smartcast2_err.vv
+++ b/vlib/v/checker/tests/incorrect_smartcast2_err.vv
@@ -1,0 +1,32 @@
+struct Left<E> {
+	error E
+}
+
+struct Right<T> {
+	inner T
+}
+
+type Either<T, E> =
+	Left<E> |
+	Right<T>
+
+fn works(v []Either<int, int>) {
+	first := v[0]
+	match first {
+		Left<int> {
+			println(first.error)
+		}
+		else {}
+	}
+}
+
+fn doesntwork(v []Either<int, int>) {
+	match v[0] {
+		Left<int> {
+			println(v[0].error)
+		}
+		else {}
+	}
+}
+
+fn main() {}


### PR DESCRIPTION
This PR notice invalid smartcast with if/match none ident or selector (fix #12317).

- Notice invalid smartcast with if/match none ident or selector.
- Add test.

```v
struct Left<E> {
	error E
}

struct Right<T> {
	inner T
}

type Either<T, E> =
	Left<E> |
	Right<T>

fn works(v []Either<int, int>) {
	first := v[0]
	match first {
		Left<int> {
			println(first.error)
		}
		else {}
	}
}

fn doesntwork(v []Either<int, int>) {
	match v[0] {
		Left<int> {
			println(v[0].error)
		}
		else {}
	}
}

fn main() {}

PS D:\Test\v\tt1> v run .
./tt1.v:24:9: notice: smartcast can only be used on the ident or selector, e.g. match foo, match foo.bar
   22 |
   23 | fn doesntwork(v []Either<int, int>) {
   24 |     match v[0] {
      |            ~~~
   25 |         Left<int> {
   26 |             println(v[0].error)
./tt1.v:26:17: error: field `error` does not exist or have the same type in all sumtype variants
   24 |     match v[0] {
   25 |         Left<int> {
   26 |             println(v[0].error)
      |                          ~~~~~
   27 |         }
   28 |         else {}
```