### PR TITLE
cgen: fix error for empty interface (fix #13760)

### DIFF
--- a/vlib/v/gen/c/infix_expr.v
+++ b/vlib/v/gen/c/infix_expr.v
@@ -507,7 +507,7 @@ fn (mut g Gen) infix_expr_is_op(node ast.InfixExpr) {
 			else { ast.Type(0) }
 		}
 		sub_sym := g.table.sym(sub_type)
-		g.write('_${c_name(sym.name)}_${c_name(sub_sym.name)}_index')
+		g.write('_${sym.cname}_${sub_sym.cname}_index')
 		return
 	} else if sym.kind == .sum_type {
 		g.write('_typ $cmp_op ')

--- a/vlib/v/tests/empty_interface_test.v
+++ b/vlib/v/tests/empty_interface_test.v
@@ -1,0 +1,14 @@
+interface Any {}
+
+fn print_out(x Any) string {
+	if x is string {
+		println(x)
+		return '$x'
+	}
+	return ''
+}
+
+fn test_empty_interface() {
+	ret := print_out('12345')
+	assert ret == '&12345'
+}


### PR DESCRIPTION
This PR fix error for empty interface (fix #13760).

- Fix error for empty interface.
- Add test.

```v
interface Any{}

fn print_out(x Any) string {
	if x is string {
		println(x)
		return '$x'
	}
	return ''
}

fn main(){
	ret := print_out('12345')
	assert ret == '&12345'
}

PS D:\Test\v\tt1> v run .
&12345
```