### PR TITLE
parser: check error of if guard condition expression (fix #13756)

### DIFF
--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -107,6 +107,10 @@ fn (mut p Parser) if_expr(is_comptime bool) ast.IfExpr {
 			p.check(.decl_assign)
 			comments << p.eat_comments()
 			expr := p.expr(0)
+			if expr !in [ast.CallExpr, ast.IndexExpr, ast.PrefixExpr] {
+				p.error_with_pos('if guard condition expression is illegal, it should return optional',
+					expr.pos())
+			}
 
 			cond = ast.IfGuardExpr{
 				vars: vars

--- a/vlib/v/parser/tests/if_guard_cond_err.out
+++ b/vlib/v/parser/tests/if_guard_cond_err.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/if_guard_cond_err.vv:16:16: error: if guard condition expression is illegal, it should return optional
+   14 |     fp.usage_example('GOOG AAPL')
+   15 |     _ := fp.bool('version', `v`, false, 'version information.')
+   16 |     if args := fp.finalize() && args.len > 0 {
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   17 |         return args
+   18 |     } else {

--- a/vlib/v/parser/tests/if_guard_cond_err.vv
+++ b/vlib/v/parser/tests/if_guard_cond_err.vv
@@ -1,0 +1,28 @@
+import os
+import flag
+
+const version = "v0.1.0"
+
+// getting command line options and arguments
+// returns the arguments
+fn get_args() ?[]string {
+	mut fp := flag.new_flag_parser(os.args)
+	fp.application('ticker')
+	fp.version(version)
+	fp.description('A CLI yahoo ticker app')
+	fp.skip_executable()
+	fp.usage_example('GOOG AAPL')
+	_ := fp.bool('version', `v`, false, 'version information.')
+	if args := fp.finalize() && args.len > 0 {
+		return args
+	} else {
+		eprintln(err.msg())
+		println(fp.usage())
+		return none
+	}
+}
+
+fn main() {
+	tickers := get_args() or { return }
+	println(tickers)
+}


### PR DESCRIPTION
This PR check error of if guard condition expression (fix #13756).

- Check error of if guard condition expression.
- Add test.

```v
import os
import flag

const version = "v0.1.0"

// getting command line options and arguments
// returns the arguments
fn get_args() ?[]string {
	mut fp := flag.new_flag_parser(os.args)
	fp.application('ticker')
	fp.version(version)
	fp.description('A CLI yahoo ticker app')
	fp.skip_executable()
	fp.usage_example('GOOG AAPL')
	_ := fp.bool('version', `v`, false, 'version information.')
	if args := fp.finalize() && args.len > 0 {
		return args
	} else {
		eprintln(err.msg())
		println(fp.usage())
		return none
	}
}

fn main() {
	tickers := get_args() or { return }
	println(tickers)
}

PS D:\Test\v\tt1> v run .
./tt1.v:16:16: error: if guard condition expression is illegal, it should return optional
   14 |     fp.usage_example('GOOG AAPL')
   15 |     _ := fp.bool('version', `v`, false, 'version information.')
   16 |     if args := fp.finalize() && args.len > 0 {
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~
   17 |         return args
   18 |     } else {
```