### PR TITLE
gen/c: avoid double evaluation of string being sliced

### DIFF
--- a/vlib/v/tests/fixed_array_test.v
+++ b/vlib/v/tests/fixed_array_test.v
@@ -16,6 +16,7 @@ fn test_fixed_array_can_be_assigned() {
 	}
 	v = [8]f64{init: 3.0}
 	assert v[1] == 3.0
+	assert v[..].len == 8
 }
 
 fn test_fixed_array_assignment() {

--- a/vlib/v/tests/slice_rval_test.v
+++ b/vlib/v/tests/slice_rval_test.v
@@ -6,3 +6,23 @@ fn test_arr_rval() {
 	b := unsafe { *&[]int(&a) }[..]
 	assert b == a
 }
+
+fn geta(mut n []int) []int {
+	n[0]++
+	return [1]
+}
+
+fn gets(mut n []int) string {
+	n[0]++
+	return "1"
+}
+
+fn test_double_eval() {
+	mut n := [0]
+	r := geta(mut n)[..]
+	assert n[0] == 1
+	
+	s := gets(mut n)[..]
+	assert s.len == 1 // use s
+	assert n[0] == 2
+}


### PR DESCRIPTION
Use common code as for temp array variable from #13737.
Add test for double evaluation of array.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
