### PR TITLE
checker: check error for struct field init with nobody anon fn (fix #9858)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -324,6 +324,15 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 							field.pos)
 					}
 				}
+				if field_type_sym.kind == .function && field_type_sym.language == .v {
+					pos := field.expr.pos()
+					if mut field.expr is ast.AnonFn {
+						if field.expr.decl.no_body {
+							c.error('cannot initialize the fn field with anonymous fn that does not have a body',
+								pos)
+						}
+					}
+				}
 				node.fields[i].typ = expr_type
 				node.fields[i].expected_type = field_info.typ
 

--- a/vlib/v/checker/tests/struct_field_init_with_nobody_anon_fn_err.out
+++ b/vlib/v/checker/tests/struct_field_init_with_nobody_anon_fn_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/struct_field_init_with_nobody_anon_fn_err.vv:7:7: error: cannot initialize the fn field with anonymous fn that does not have a body
+    5 | fn main() {
+    6 |     _ = App{
+    7 |         cb: fn(x int)  // Note the missing `{}` (the function body) here
+      |             ~~~~~~~~~
+    8 |     }
+    9 | }

--- a/vlib/v/checker/tests/struct_field_init_with_nobody_anon_fn_err.vv
+++ b/vlib/v/checker/tests/struct_field_init_with_nobody_anon_fn_err.vv
@@ -1,0 +1,9 @@
+struct App {
+	cb fn(x int) // the function signature doesn't make a difference
+}
+
+fn main() {
+	_ = App{
+		cb: fn(x int)  // Note the missing `{}` (the function body) here
+	}
+}


### PR DESCRIPTION
This PR check error for struct field init with nobody anon fn (fix #9858).

- Check error for struct field init with nobody anon fn.
- Add test.

```v
struct App {
	cb fn(x int) // the function signature doesn't make a difference
}

fn main() {
	_ = App{
		cb: fn(x int)  // Note the missing `{}` (the function body) here
	}
}

PS D:\Test\v\tt1> v run .
./tt1.v:7:7: error: cannot initialize the fn field with anonymous fn that does not have a body
    5 | fn main() {
    6 |     _ = App{
    7 |         cb: fn(x int)  // Note the missing `{}` (the function body) here
      |             ~~~~~~~~~
    8 |     }
    9 | }
```