### PR TITLE
checker: check error for unknown type in anon fn field of struct (fix #9328)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -55,6 +55,16 @@ pub fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 							field.type_pos)
 					}
 				}
+				field_sym := c.table.sym(field.typ)
+				if field_sym.kind == .function {
+					fn_info := field_sym.info as ast.FnType
+					c.ensure_type_exists(fn_info.func.return_type, fn_info.func.return_type_pos) or {
+						return
+					}
+					for param in fn_info.func.params {
+						c.ensure_type_exists(param.typ, param.type_pos) or { return }
+					}
+				}
 			}
 			if sym.kind == .struct_ {
 				info := sym.info as ast.Struct

--- a/vlib/v/checker/tests/unknown_type_in_anon_fn.out
+++ b/vlib/v/checker/tests/unknown_type_in_anon_fn.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/unknown_type_in_anon_fn.vv:5:10: error: unknown type `Another`
+    3 | struct Struc{
+    4 | mut:
+    5 |     f fn (s Another, i int) ?
+      |             ~~~~~~~
+    6 | }
+    7 |

--- a/vlib/v/checker/tests/unknown_type_in_anon_fn.vv
+++ b/vlib/v/checker/tests/unknown_type_in_anon_fn.vv
@@ -1,0 +1,8 @@
+module main
+
+struct Struc{
+mut:
+	f fn (s Another, i int) ?
+}
+
+fn main() {}


### PR DESCRIPTION
This PR check error for unknown type in anon fn field of struct (fix #9328).

- Check error for unknown type in anon fn field of struct.
- Add test.

```v
module main

struct Struc{
mut:
	f fn (s Another, i int) ?
}

fn main() {}

PS D:\Test\v\tt1> v run .
./tt1.v:5:10: error: unknown type `Another`
    3 | struct Struc{
    4 | mut:
    5 |     f fn (s Another, i int) ?
      |             ~~~~~~~
    6 | }
    7 |
```