### PR TITLE
cgen: fix struct type dependency sorting, when struct field types, are aliases to struct types from other modules

### DIFF
--- a/vlib/v/tests/modules/alias_to_another_module/alias.v
+++ b/vlib/v/tests/modules/alias_to_another_module/alias.v
@@ -1,0 +1,9 @@
+module alias_to_another_module
+
+import another_module
+
+pub type MyAlias = another_module.SomeStruct
+
+pub fn (m MyAlias) alias_method() int {
+	return 42
+}

--- a/vlib/v/tests/modules/another_module/module.v
+++ b/vlib/v/tests/modules/another_module/module.v
@@ -1,0 +1,12 @@
+module another_module
+
+pub struct SomeStruct {
+pub mut:
+	x int
+	y int
+	z int
+}
+
+pub fn (s SomeStruct) some_method() int {
+	return 999 + s.x + s.y + s.z
+}

--- a/vlib/v/tests/use_alias_from_another_module_in_struct_field_test.v
+++ b/vlib/v/tests/use_alias_from_another_module_in_struct_field_test.v
@@ -1,0 +1,14 @@
+import alias_to_another_module
+
+struct MyStruct {
+	myfield alias_to_another_module.MyAlias
+}
+
+fn test_using_struct_with_alias() {
+	m := MyStruct{
+		myfield: alias_to_another_module.MyAlias{1, 2, 3}
+	}
+	dump(m)
+	assert m.myfield.alias_method() == 42
+	assert m.myfield.some_method() == 1005
+}


### PR DESCRIPTION
Previously, there was a cgen error for the following case:

```v
import another
struct Abc {
	field another.AliasOfThirdModuleStruct
}	
```

The reason was that Abc depended only on another.AliasOfThirdModuleStruct,
but since that was not a struct, but instead an alias to another struct `third_module.Struct`,
the generated definition of Abc, could be put *before* the definition for
`third_module.Struct`, leading to a failing C compilation.

This PR adds the dependency to the parent struct too, so that after
the topological sort, the struct definitions are now generated in the
proper order - first the ones from the modules, and only after that,
the ones that depend on them.

fix #13775 