### PR TITLE
cgen: add true and false to C reserved words 

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -20,10 +20,11 @@ const (
 	// `small` should not be needed, but see: https://stackoverflow.com/questions/5874215/what-is-rpcndr-h
 	c_reserved     = ['array', 'auto', 'bool', 'break', 'calloc', 'case', 'char', 'class', 'complex',
 		'const', 'continue', 'default', 'delete', 'do', 'double', 'else', 'enum', 'error', 'exit',
-		'export', 'extern', 'float', 'for', 'free', 'goto', 'if', 'inline', 'int', 'link', 'long',
-		'malloc', 'namespace', 'new', 'panic', 'register', 'restrict', 'return', 'short', 'signed',
-		'sizeof', 'static', 'string', 'struct', 'switch', 'typedef', 'typename', 'union', 'unix',
-		'unsigned', 'void', 'volatile', 'while', 'template', 'small', 'stdout', 'stdin', 'stderr']
+		'export', 'extern', 'false', 'float', 'for', 'free', 'goto', 'if', 'inline', 'int', 'link',
+		'long', 'malloc', 'namespace', 'new', 'panic', 'register', 'restrict', 'return', 'short',
+		'signed', 'sizeof', 'static', 'string', 'struct', 'switch', 'typedef', 'typename', 'union',
+		'unix', 'unsigned', 'void', 'volatile', 'while', 'template', 'true', 'small', 'stdout',
+		'stdin', 'stderr']
 	c_reserved_map = string_array_to_map(c_reserved)
 	// same order as in token.Kind
 	cmp_str        = ['eq', 'ne', 'gt', 'lt', 'ge', 'le']

--- a/vlib/v/gen/c/testdata/keyword_escaping.vv
+++ b/vlib/v/gen/c/testdata/keyword_escaping.vv
@@ -1,0 +1,10 @@
+fn main() {
+	@if := 0
+	@for := 0
+	auto := 0
+	calloc := 0
+	stdout := 0
+	signed := 0
+	@true := 0
+	@false := 0
+}

--- a/vlib/v/tests/keyword_escaping_test.v
+++ b/vlib/v/tests/keyword_escaping_test.v
@@ -1,4 +1,4 @@
-fn main() {
+fn test_escapes() {
 	@if := 0
 	@for := 0
 	auto := 0
@@ -7,4 +7,5 @@ fn main() {
 	signed := 0
 	@true := 0
 	@false := 0
+	assert true
 }


### PR DESCRIPTION
This PR fixes #13722, by making `true` and `false` reserved.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
