### PR TITLE
cgen: fix error for map get anon fn value  (fix #10911)

### DIFF
--- a/vlib/v/tests/map_get_anon_fn_value_test.v
+++ b/vlib/v/tests/map_get_anon_fn_value_test.v
@@ -1,0 +1,25 @@
+const numbers = {
+	'one': fn () int {
+		return 1
+	}
+}
+
+fn test_map_get_anon_fn_value() {
+	num1 := numbers['one'] or {
+		fn () int {
+			return 2
+		}
+	}
+	ret1 := num1()
+	println(ret1)
+	assert ret1 == 1
+
+	num2 := numbers['two'] or {
+		fn () int {
+			return 2
+		}
+	}
+	ret2 := num2()
+	println(ret2)
+	assert ret2 == 2
+}


### PR DESCRIPTION
This PR fix error for map get anon fn value  (fix #10911).

- Fix error for map get anon fn value.
- Add test.

```v
const numbers = {
	'one': fn () int {
		return 1
	}
}

fn main() {
	num1 := numbers['one'] or {
		fn () int {
			return 2
		}
	}
	ret1 := num1()
	println(ret1)
	assert ret1 == 1

	num2 := numbers['two'] or {
		fn () int {
			return 2
		}
	}
	ret2 := num2()
	println(ret2)
	assert ret2 == 2
}

PS D:\Test\v\tt1> v run .
1
2
```