### PR TITLE
checker: check error for index of optional (fix #13780)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3775,6 +3775,9 @@ pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) ast.Type {
 		&& typ !in [ast.byteptr_type, ast.charptr_type] && !typ.has_flag(.variadic) {
 		c.error('type `$typ_sym.name` does not support indexing', node.pos)
 	}
+	if typ.has_flag(.optional) {
+		c.error('type `?$typ_sym.name` is optional, it does not support indexing', node.left.pos())
+	}
 	if typ_sym.kind == .string && !typ.is_ptr() && node.is_setter {
 		c.error('cannot assign to s[i] since V strings are immutable\n' +
 			'(note, that variables may be mutable but string values are always immutable, like in Go and Java)',

--- a/vlib/v/checker/tests/index_of_optional_err.out
+++ b/vlib/v/checker/tests/index_of_optional_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/index_of_optional_err.vv:6:7: error: type `?[]int` is optional, it does not support indexing
+    4 |
+    5 | fn main() {
+    6 |     a := abc()[0] or { 5 }
+      |          ~~~~~
+    7 |     dump(a)
+    8 | }

--- a/vlib/v/checker/tests/index_of_optional_err.vv
+++ b/vlib/v/checker/tests/index_of_optional_err.vv
@@ -1,0 +1,8 @@
+fn abc() ?[]int {
+	return [1, 2, 3]
+}
+
+fn main() {
+	a := abc()[0] or { 5 }
+	dump(a)
+}


### PR DESCRIPTION
This PR check error for index of optional (fix #13780).

- Check error for index of optional.
- Add test.

```v
fn abc() ?[]int {
	return [1, 2, 3]
}

fn main() {
	a := abc()[0] or { 5 }
	dump(a)
}

PS D:\Test\v\tt1> v run .
./tt1.v:6:7: error: type `?[]int` is optional, it does not support indexing
    4 |
    5 | fn main() {
    6 |     a := abc()[0] or { 5 }
      |          ~~~~~
    7 |     dump(a)
    8 | }
```