### PR TITLE
builtin/array: don't `memdup` returned element of `pop`

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -402,12 +402,13 @@ pub fn (mut a array) pop() voidptr {
 	a.len = new_len
 	// Note: a.cap is not changed here *on purpose*, so that
 	// further << ops on that array will be more efficient.
-	return unsafe { memdup(last_elem, a.element_size) }
+	return last_elem
 }
 
 // delete_last efficiently deletes the last element of the array.
 // It does it simply by reducing the length of the array by 1.
 // If the array is empty, this will panic.
+// See also: [trim](#array.trim)
 pub fn (mut a array) delete_last() {
 	// copy pasting code for performance
 	$if !no_bounds_checking ? {


### PR DESCRIPTION
The voidptr returned is immediately dereferenced in cgen so the memory is copied before the array can be appended to: `*(int*)array_pop(&a)`



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
