### PR TITLE
cgen: simplify in index_of_array() and add test

### DIFF
--- a/vlib/v/tests/array_get_anon_fn_value_test.v
+++ b/vlib/v/tests/array_get_anon_fn_value_test.v
@@ -1,0 +1,20 @@
+const numbers = [
+	fn () int {
+		return 1
+	},
+	fn () int {
+		return 2
+	},
+]
+
+fn test_array_get_anon_fn_value() {
+	num1 := numbers[0]
+	ret1 := num1()
+	println(ret1)
+	assert ret1 == 1
+
+	num2 := numbers[1]
+	ret2 := num2()
+	println(ret2)
+	assert ret2 == 2
+}


### PR DESCRIPTION
This PR simplify in index_of_array() and add test.

```v
const numbers = [
	fn () int {
		return 1
	},
	fn () int {
		return 2
	},
]

fn main() {
	num1 := numbers[0]
	ret1 := num1()
	println(ret1)
	assert ret1 == 1

	num2 := numbers[1]
	ret2 := num2()
	println(ret2)
	assert ret2 == 2
}

PS D:\Test\v\tt1> v run .
1
2
```