### PR TITLE
strconv: fix error for string interpolation of float format (fix #13794)

### DIFF
--- a/vlib/strconv/format_mem.c.v
+++ b/vlib/strconv/format_mem.c.v
@@ -274,10 +274,13 @@ pub fn f64_to_str_lnd1(f f64, dec_digit int) string {
 
 		// println("r_i-d_pos: ${r_i - d_pos}")
 		if dot_res_sp >= 0 {
-			if (r_i - dot_res_sp) > dec_digit {
-				r_i = dot_res_sp + dec_digit + 1
-			}
+			r_i = dot_res_sp + dec_digit + 1
 			res[r_i] = 0
+			for c1 in 1 .. dec_digit + 1 {
+				if res[r_i - c1] == 0 {
+					res[r_i - c1] = `0`
+				}
+			}
 			// println("result: [${tos(&res[0],r_i)}]")
 			tmp_res := tos(res.data, r_i).clone()
 			res.free()

--- a/vlib/v/tests/string_interpolation_float_fmt_test.v
+++ b/vlib/v/tests/string_interpolation_float_fmt_test.v
@@ -1,0 +1,13 @@
+fn test_string_interpolation_float_fmt() {
+	mut a := 76.295
+	eprintln('${a:8.2}')
+	assert '${a:8.2}' == '   76.30'
+	eprintln('${a:8.2f}')
+	assert '${a:8.2f}' == '   76.30'
+
+	a = 76.296
+	eprintln('${a:8.2}')
+	assert '${a:8.2}' == '   76.30'
+	eprintln('${a:8.2f}')
+	assert '${a:8.2f}' == '   76.30'
+}


### PR DESCRIPTION
This PR fix error for string interpolation of float format (fix #13794).

- Fix error for string interpolation of float format.
- Add test.

```v
fn main() {
	mut a := 76.295
	eprintln('${a:8.2}')
	assert '${a:8.2}' == '   76.30'
	eprintln('${a:8.2f}')
	assert '${a:8.2f}' == '   76.30'

	a = 76.296
	eprintln('${a:8.2}')
	assert '${a:8.2}' == '   76.30'
	eprintln('${a:8.2f}')
	assert '${a:8.2f}' == '   76.30'
}

PS D:\Test\v\tt1> v run .
   76.30
   76.30
   76.30
   76.30
```