### PR TITLE
cgen: minor cleanup in go_expr()

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5156,7 +5156,8 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 			panic('cgen: obf name "$key" not found, this should never happen')
 		}
 	}
-	g.writeln('// go')
+	g.empty_line = true
+	g.writeln('// start go')
 	wrapper_struct_name := 'thread_arg_' + name
 	wrapper_fn_name := name + '_thread_wrapper'
 	arg_tmp_var := 'arg_' + tmp
@@ -5195,7 +5196,7 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 		} else {
 			'thread_$tmp'
 		}
-		g.writeln('HANDLE $simple_handle = CreateThread(0,0, (LPTHREAD_START_ROUTINE)$wrapper_fn_name, $arg_tmp_var, 0,0);')
+		g.writeln('HANDLE $simple_handle = CreateThread(0, 0, (LPTHREAD_START_ROUTINE)$wrapper_fn_name, $arg_tmp_var, 0, 0);')
 		g.writeln('if (!$simple_handle) panic_lasterr(tos3("`go ${name}()`: "));')
 		if node.is_expr && node.call_expr.return_type != ast.void_type {
 			g.writeln('$gohandle_name thread_$tmp = {')
@@ -5214,7 +5215,7 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 			g.writeln('pthread_detach(thread_$tmp);')
 		}
 	}
-	g.writeln('// endgo\n')
+	g.writeln('// end go')
 	if node.is_expr {
 		handle = 'thread_$tmp'
 		// create wait handler for this return type if none exists


### PR DESCRIPTION
This PR makes minor cleanup in go_expr().

- Format generated c codes.

before:
```v
VV_LOCAL_SYMBOL int main__sum(int a, int b) {
	int (*sum_func) (int a, int b) = 	anon_fn_1315efd87adb6e70_int_int__int_137;
// go
	thread_arg_anon_fn_1315efd87adb6e70_int_int__int_137 *arg__t1 = malloc(sizeof(thread_arg_anon_fn_1315efd87adb6e70_int_int__int_137));
	arg__t1->arg1 = a;
	arg__t1->arg2 = b;
	arg__t1->ret_ptr = malloc(sizeof(int));
	HANDLE thread_handle__t1 = CreateThread(0,0, (LPTHREAD_START_ROUTINE)anon_fn_1315efd87adb6e70_int_int__int_137_thread_wrapper, arg__t1, 0,0);
	if (!thread_handle__t1) panic_lasterr(tos3("`go anon_fn_1315efd87adb6e70_int_int__int_137()`: "));
	__v_thread_int thread__t1 = {
		.ret_ptr = arg__t1->ret_ptr,
		.handle = thread_handle__t1
	};
	// endgo

	__v_thread_int g = thread__t1;
	int result = __v_thread_int_wait(g);
	int _t2 = result;
	return _t2;
}
```
now:
```v
VV_LOCAL_SYMBOL int main__sum(int a, int b) {
	int (*sum_func) (int a, int b) = 	anon_fn_1315efd87adb6e70_int_int__int_137;
	// start go
	thread_arg_anon_fn_1315efd87adb6e70_int_int__int_137 *arg__t1 = malloc(sizeof(thread_arg_anon_fn_1315efd87adb6e70_int_int__int_137));
	arg__t1->arg1 = a;
	arg__t1->arg2 = b;
	arg__t1->ret_ptr = malloc(sizeof(int));
	HANDLE thread_handle__t1 = CreateThread(0, 0, (LPTHREAD_START_ROUTINE)anon_fn_1315efd87adb6e70_int_int__int_137_thread_wrapper, arg__t1, 0, 0);
	if (!thread_handle__t1) panic_lasterr(tos3("`go anon_fn_1315efd87adb6e70_int_int__int_137()`: "));
	__v_thread_int thread__t1 = {
		.ret_ptr = arg__t1->ret_ptr,
		.handle = thread_handle__t1
	};
	// end go
	__v_thread_int g = thread__t1;
	int result = __v_thread_int_wait(g);
	int _t2 = result;
	return _t2;
}
```