### PR TITLE
checker: check redefinition of global 'main' function (fix #11373)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2097,6 +2097,10 @@ fn (mut c Checker) global_decl(mut node ast.GlobalDecl) {
 			c.error('unknown type `$sym.name`', field.typ_pos)
 		}
 		if field.has_expr {
+			if field.expr is ast.AnonFn && field.name == 'main' {
+				c.error('the `main` function is the program entry point, cannot redefine it',
+					field.pos)
+			}
 			field.typ = c.expr(field.expr)
 			mut v := c.file.global_scope.find_global(field.name) or {
 				panic('internal compiler error - could not find global in scope')

--- a/vlib/v/checker/tests/globals/redefine_main.out
+++ b/vlib/v/checker/tests/globals/redefine_main.out
@@ -1,0 +1,3 @@
+vlib/v/checker/tests/globals/redefine_main.vv:1:10: error: the `main` function is the program entry point, cannot redefine it
+    1 | __global main = fn () int { return 22 }
+      |          ~~~~

--- a/vlib/v/checker/tests/globals/redefine_main.vv
+++ b/vlib/v/checker/tests/globals/redefine_main.vv
@@ -1,0 +1,1 @@
+__global main = fn () int { return 22 }


### PR DESCRIPTION
This PR check redefinition of global 'main' function (fix #11373).

- Check redefinition of global 'main' function.
- Add test.

```v
__global main = fn () int { return 22 }

fn main() {
}

PS D:\Test\v\tt1> v -enable-globals run .
./tt1.v:1:10: error: the `main` function is the program entry point, cannot redefine it
    1 | __global main = fn () int { return 22 }
      |          ~~~~
    2 |
    3 | fn main() {
```