### PR TITLE
ci: update sdl ci to compile shader example

### DIFF
--- a/.github/workflows/sdl_ci.yml
+++ b/.github/workflows/sdl_ci.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Build sdl examples
         run: |
+          v shader sdl/examples/sdl_opengl_and_sokol
           for example in sdl/examples/*; do
               echo "v $example"
               v "$example";


### PR DESCRIPTION
[I've just added](https://github.com/vlang/sdl/pull/224) an example that uses shaders - so this PR fixes any potential errors the sdl CI step will give