### PR TITLE
ast, checker, cgen: fix error for printing alias that has str method (fix #5683)

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -257,10 +257,6 @@ fn (ts TypeSymbol) dbg_common(mut res []string) {
 	res << 'language: $ts.language'
 }
 
-pub fn (t Type) str() string {
-	return 'ast.Type(0x$t.hex() = ${u32(t)})'
-}
-
 pub fn (t &Table) type_str(typ Type) string {
 	sym := t.sym(typ)
 	return sym.name

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -580,7 +580,12 @@ pub fn (mut c Checker) string_inter_lit(mut node ast.StringInterLiteral) ast.Typ
 		}
 		c.fail_if_unreadable(expr, ftyp, 'interpolation object')
 		node.expr_types << ftyp
-		typ := c.table.unalias_num_type(ftyp)
+		ftyp_sym := c.table.sym(ftyp)
+		typ := if ftyp_sym.kind == .alias && !ftyp_sym.has_method('str') {
+			c.table.unalias_num_type(ftyp)
+		} else {
+			ftyp
+		}
 		mut fmt := node.fmts[i]
 		// analyze and validate format specifier
 		if fmt !in [`E`, `F`, `G`, `e`, `f`, `g`, `d`, `u`, `x`, `X`, `o`, `c`, `s`, `S`, `p`,

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -144,7 +144,7 @@ fn (mut g Gen) get_str_fn(typ ast.Type) string {
 	styp := g.typ(unwrapped)
 	mut sym := g.table.sym(unwrapped)
 	mut str_fn_name := styp_to_str_fn_name(styp)
-	if mut sym.info is ast.Alias {
+	if mut sym.info is ast.Alias && !sym.has_method('str') {
 		if sym.info.is_import {
 			sym = g.table.sym(sym.info.parent_type)
 			str_fn_name = styp_to_str_fn_name(sym.name)

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -70,8 +70,8 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		typ = typ.clear_flag(.shared_f).set_nr_muls(0)
 	}
 	mut sym := g.table.sym(typ)
-	// when type is alias, print the aliased value
-	if mut sym.info is ast.Alias {
+	// when type is alias and doesn't has `str()`, print the aliased value
+	if mut sym.info is ast.Alias && !sym.has_method('str') {
 		parent_sym := g.table.sym(sym.info.parent_type)
 		if parent_sym.has_method('str') {
 			typ = sym.info.parent_type

--- a/vlib/v/tests/inout/printing_alias_has_str_method.out
+++ b/vlib/v/tests/inout/printing_alias_has_str_method.out
@@ -1,0 +1,3 @@
+hello
+hello
+hello

--- a/vlib/v/tests/inout/printing_alias_has_str_method.vv
+++ b/vlib/v/tests/inout/printing_alias_has_str_method.vv
@@ -1,0 +1,12 @@
+type Byte = byte
+
+fn (b Byte) str() string {
+	return 'hello'
+}
+
+fn main() {
+	b := Byte(`a`)
+	println(b)
+	println(b.str())
+	println('$b')
+}


### PR DESCRIPTION
This PR fix error for printing alias that has str method (fix #5683).

- Fix error for printing alias that has str method.
- Add test.

```v
type Byte = byte

fn (b Byte) str() string {
	return 'hello'
}

fn main() {
	b := Byte(`a`)
	println(b)
	println(b.str())
	println('$b')
}

PS D:\Test\v\tt1> v run .
hello
hello
hello
```