### PR TITLE
checker: fix Immutable array can be mutated via slices

### DIFF
--- a/vlib/crypto/md5/md5block_generic.v
+++ b/vlib/crypto/md5/md5block_generic.v
@@ -19,8 +19,7 @@ fn block_generic(mut dig Digest, p []byte) {
 	mut d := dig.s[3]
 
 	for i := 0; i <= p.len - block_size; i += block_size {
-		mut q := p[i..]
-		q = q[..block_size]
+		q := p[i..][..block_size]
 		// save current state
 		aa := a
 		bb := b

--- a/vlib/flag/flag.v
+++ b/vlib/flag/flag.v
@@ -131,7 +131,7 @@ pub const (
 
 // new_flag_parser - create a new flag parser for the given args
 pub fn new_flag_parser(args []string) &FlagParser {
-	original_args := args.clone()
+	mut original_args := args.clone()
 	idx_dashdash := args.index('--')
 	mut all_before_dashdash := args.clone()
 	mut all_after_dashdash := []string{}

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -792,7 +792,18 @@ pub mut:
 	name   string
 	kind   IdentKind
 	info   IdentInfo
-	is_mut bool
+	is_mut bool // if mut *token* is before name. Use `is_mut()` to lookup mut variable
+}
+
+pub fn (i &Ident) is_mut() bool {
+	match i.obj {
+		Var { return i.obj.is_mut }
+		ConstField { return false }
+		GlobalField { return true }
+		else {
+			panic('TODO')
+		}
+	}
 }
 
 pub fn (i &Ident) var_info() IdentVar {

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -797,9 +797,15 @@ pub mut:
 
 pub fn (i &Ident) is_mut() bool {
 	match i.obj {
-		Var { return i.obj.is_mut }
-		ConstField { return false }
-		GlobalField { return true }
+		Var {
+			return i.obj.is_mut
+		}
+		ConstField {
+			return false
+		}
+		GlobalField {
+			return true
+		}
 		else {
 			panic('TODO')
 		}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -338,7 +338,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		if left_sym.kind == .array && mut left is ast.Ident && mut right is ast.IndexExpr {
 			sym := c.table.sym(right.left_type)
 			if sym.kind == .array && mut right.left is ast.Ident {
-				if left.is_mut && !right.left.is_mut {
+				if left.is_mut && !right.left.is_mut() {
 					if right.index is ast.RangeExpr {
 						c.error('cannot mutate immutable slice', right.left.pos)
 					} else {

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -338,7 +338,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		if left_sym.kind == .array && mut left is ast.Ident && mut right is ast.IndexExpr {
 			sym := c.table.sym(right.left_type)
 			if sym.kind == .array && mut right.left is ast.Ident {
-				if left.is_mut && !right.left.is_mut() {
+				if left.is_mut() && !right.left.is_mut() {
 					if right.index is ast.RangeExpr {
 						c.error('cannot mutate immutable slice', right.left.pos)
 					} else {

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -335,6 +335,18 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			c.error('use `array2 $node.op.str() array1.clone()` instead of `array2 $node.op.str() array1` (or use `unsafe`)',
 				node.pos)
 		}
+		if left_sym.kind == .array && mut left is ast.Ident && mut right is ast.IndexExpr {
+			sym := c.table.sym(right.left_type)
+			if sym.kind == .array && mut right.left is ast.Ident {
+				if left.is_mut && !right.left.is_mut {
+					if right.index is ast.RangeExpr {
+						c.error('cannot mutate immutable slice', right.left.pos)
+					} else {
+						c.error('cannot mutate immutable element', right.left.pos)
+					}
+				}
+			}
+		}
 		if left_sym.kind == .array_fixed && !c.inside_unsafe && node.op in [.assign, .decl_assign]
 			&& right_sym.kind == .array_fixed && (left is ast.Ident && !left.is_blank_ident())
 			&& right is ast.Ident {

--- a/vlib/v/checker/tests/index_expr_mutation.out
+++ b/vlib/v/checker/tests/index_expr_mutation.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/index_expr_mutation.vv:3:11: error: cannot mutate immutable slice
+    1 | fn test_immutable_slice() {
+    2 |     arr := [1, 2, 3, 4, 5]
+    3 |     mut s := arr[1..2]
+      |              ~~~
+    4 |     s[0] = 0
+    5 | }
+vlib/v/checker/tests/index_expr_mutation.vv:9:11: error: cannot mutate immutable element
+    7 | fn test_immutable_element() {
+    8 |     a := [[1]]
+    9 |     mut b := a[0]
+      |              ^
+   10 |     b[0] = 0
+   11 | }

--- a/vlib/v/checker/tests/index_expr_mutation.out
+++ b/vlib/v/checker/tests/index_expr_mutation.out
@@ -1,14 +1,28 @@
-vlib/v/checker/tests/index_expr_mutation.vv:3:11: error: cannot mutate immutable slice
-    1 | fn test_immutable_slice() {
-    2 |     arr := [1, 2, 3, 4, 5]
-    3 |     mut s := arr[1..2]
+vlib/v/checker/tests/index_expr_mutation.vv:5:11: error: cannot mutate immutable slice
+    3 | fn test_immutable_slice() {
+    4 |     arr := [1, 2, 3, 4, 5]
+    5 |     mut s := arr[1..2]
       |              ~~~
-    4 |     s[0] = 0
-    5 | }
-vlib/v/checker/tests/index_expr_mutation.vv:9:11: error: cannot mutate immutable element
-    7 | fn test_immutable_element() {
-    8 |     a := [[1]]
-    9 |     mut b := a[0]
+    6 |     s[0] = 0
+    7 |     s = arr[1..2]
+vlib/v/checker/tests/index_expr_mutation.vv:7:6: error: cannot mutate immutable slice
+    5 |     mut s := arr[1..2]
+    6 |     s[0] = 0
+    7 |     s = arr[1..2]
+      |         ~~~
+    8 |     mut s2 := imm_arr[..]
+    9 |     s2[0] = 0
+vlib/v/checker/tests/index_expr_mutation.vv:8:12: error: cannot mutate immutable slice
+    6 |     s[0] = 0
+    7 |     s = arr[1..2]
+    8 |     mut s2 := imm_arr[..]
+      |               ~~~~~~~
+    9 |     s2[0] = 0
+   10 | }
+vlib/v/checker/tests/index_expr_mutation.vv:14:11: error: cannot mutate immutable element
+   12 | fn test_immutable_element() {
+   13 |     a := [[1]]
+   14 |     mut b := a[0]
       |              ^
-   10 |     b[0] = 0
-   11 | }
+   15 |     b[0] = 0
+   16 | }

--- a/vlib/v/checker/tests/index_expr_mutation.vv
+++ b/vlib/v/checker/tests/index_expr_mutation.vv
@@ -1,0 +1,11 @@
+fn test_immutable_slice() {
+	arr := [1, 2, 3, 4, 5]
+	mut s := arr[1..2]
+	s[0] = 0
+}
+
+fn test_immutable_element() {
+	a := [[1]]
+	mut b := a[0]
+	b[0] = 0
+}

--- a/vlib/v/checker/tests/index_expr_mutation.vv
+++ b/vlib/v/checker/tests/index_expr_mutation.vv
@@ -1,7 +1,11 @@
+const imm_arr = [10, 20]
+
 fn test_immutable_slice() {
 	arr := [1, 2, 3, 4, 5]
 	mut s := arr[1..2]
 	s[0] = 0
+	mut s2 := imm_arr[..]
+	s2[0] = 0
 }
 
 fn test_immutable_element() {

--- a/vlib/v/checker/tests/index_expr_mutation.vv
+++ b/vlib/v/checker/tests/index_expr_mutation.vv
@@ -4,6 +4,7 @@ fn test_immutable_slice() {
 	arr := [1, 2, 3, 4, 5]
 	mut s := arr[1..2]
 	s[0] = 0
+	s = arr[1..2]
 	mut s2 := imm_arr[..]
 	s2[0] = 0
 }


### PR DESCRIPTION
Fixes #13791
Also prevents `mut arr := jarr[i]` where jarr is an immutable array of arrays.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
