### PR TITLE
v/parser: error if parameter name starts with a capital

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -834,7 +834,8 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 			mut arg_pos := [p.tok.pos()]
 			mut arg_names := [p.check_name()]
 			if arg_names[0][0].is_capital() {
-				p.error_with_pos('parameter name must not begin with upper case letter (`${arg_names[0]}`)', p.prev_tok.pos())
+				p.error_with_pos('parameter name must not begin with upper case letter (`${arg_names[0]}`)',
+					p.prev_tok.pos())
 			}
 			mut type_pos := [p.tok.pos()]
 			// `a, b, c int`

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -832,8 +832,9 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 				p.next()
 			}
 			mut arg_pos := [p.tok.pos()]
-			mut arg_names := [p.check_name()]
-			if arg_names[0][0].is_capital() {
+			name := p.check_name()
+			mut arg_names := [name]
+			if name.len > 0 && name[0].is_capital() {
 				p.error_with_pos('parameter name must not begin with upper case letter (`${arg_names[0]}`)',
 					p.prev_tok.pos())
 			}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -833,6 +833,9 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 			}
 			mut arg_pos := [p.tok.pos()]
 			mut arg_names := [p.check_name()]
+			if arg_names[0][0].is_capital() {
+				p.error_with_pos('parameter name must not begin with upper case letter (`${arg_names[0]}`)', p.prev_tok.pos())
+			}
 			mut type_pos := [p.tok.pos()]
 			// `a, b, c int`
 			for p.tok.kind == .comma {

--- a/vlib/v/parser/tests/fn_param_name_cap.out
+++ b/vlib/v/parser/tests/fn_param_name_cap.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/fn_param_name_cap.vv:6:9: error: parameter name must not begin with upper case letter (`T`)
+    4 | fn f(Type)
+    5 | 
+    6 | fn g<T>(T v) {
+      |         ^
+    7 |     
+    8 | }

--- a/vlib/v/parser/tests/fn_param_name_cap.vv
+++ b/vlib/v/parser/tests/fn_param_name_cap.vv
@@ -1,0 +1,10 @@
+type Type = int
+
+// OK
+fn f(Type)
+
+fn g<T>(T v) {
+	
+}
+
+g(5)


### PR DESCRIPTION
Before the error was confusing for `fn g<T>(T v)`:
error: cannot use `int literal` as `v` in argument 1 to `g`

I've made that mistake using C declaration order syntax. The error seemed to not be telling me the type of `v` which I thought was the parameter name. Note for a generic function there's no error 'unknown type `v`'.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
