### PR TITLE
doc: tweak built-in functions section & move `dump` section here

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -105,7 +105,8 @@ For more details and troubleshooting, please visit the [vab GitHub repository](h
 * [References](#references)
 * [Constants](#constants)
 * [Builtin functions](#builtin-functions)
-* [Printing custom types](#printing-custom-types)
+    * [println](#println)
+    * [Dumping expressions at runtime](#dumping-expressions-at-runtime)
 * [Modules](#modules)
 * [Type Declarations](#type-declarations)
     * [Interfaces](#interfaces)
@@ -137,7 +138,6 @@ For more details and troubleshooting, please visit the [vab GitHub repository](h
 * [Package Management](#package-management)
 	* [Publish package](#publish-package)
 * [Advanced Topics](#advanced-topics)
-    * [Dumping expressions at runtime](#dumping-expressions-at-runtime)
     * [Memory-unsafe code](#memory-unsafe-code)
     * [Structs with reference fields](#structs-with-reference-fields)
     * [sizeof and __offsetof](#sizeof-and-__offsetof)
@@ -196,7 +196,7 @@ In this case `main` doesn't return anything, so there is no return type.
 
 As in many other languages (such as C, Go, and Rust), `main` is the entry point of your program.
 
-`println` is one of the few built-in functions.
+[`println`](#println) is one of the few [built-in functions](#builtin-functions).
 It prints the value passed to it to standard output.
 
 `fn main()` declaration can be skipped in one file programs.
@@ -2607,16 +2607,21 @@ println('Top cities: ${top_cities.filter(.usa)}')
 Some functions are builtin like `println`. Here is the complete list:
 
 ```v ignore
-fn print(s string) // print anything on sdtout
-fn println(s string) // print anything and a newline on sdtout
+fn print(s IStr) // prints anything on stdout
+fn println(s IStr) // prints anything and a newline on stdout
 
-fn eprint(s string) // same as print(), but use stderr
-fn eprintln(s string) // same as println(), but use stderr
+fn eprint(s IStr) // same as print(), but uses stderr
+fn eprintln(s IStr) // same as println(), but uses stderr
 
-fn exit(code int) // terminate the program with a custom error code
-fn panic(s string) // print a message and backtraces on stderr, and terminate the program with error code 1
-fn print_backtrace() // print backtraces on stderr
+fn dump(expr Expr) // prints file, line, expression source code and expression value
+
+fn exit(code int) // terminates the program with a custom error code
+fn panic(s string) // prints a message and backtraces on stderr, and terminates the program with error code 1
+fn print_backtrace() // prints backtraces on stderr
 ```
+Note: the types IStr and Expr above are not public types - see below for usage.
+
+### println
 
 `println` is a simple yet powerful builtin function, that can print anything:
 strings, numbers, arrays, maps, structs.
@@ -2635,10 +2640,10 @@ println(User{ name: 'Bob', age: 20 }) // "User{name:'Bob', age:20}"
 
 <a id='custom-print-of-types' />
 
-## Printing custom types
+### Printing custom types
 
 If you want to define a custom print value for your type, simply define a
-`.str() string` method:
+`str() string` method:
 
 ```v
 struct Color {
@@ -2658,6 +2663,40 @@ red := Color{
 }
 println(red)
 ```
+
+### Dumping expressions at runtime
+
+You can dump/trace the value of any V expression using `dump(expr)`.
+For example, save this code sample as `factorial.v`, then run it with
+`v run factorial.v`:
+```v
+fn factorial(n u32) u32 {
+	if dump(n <= 1) {
+		return dump(1)
+	}
+	return dump(n * factorial(n - 1))
+}
+
+fn main() {
+	println(factorial(5))
+}
+```
+You will get:
+```
+[factorial.v:2] n <= 1: false
+[factorial.v:2] n <= 1: false
+[factorial.v:2] n <= 1: false
+[factorial.v:2] n <= 1: false
+[factorial.v:2] n <= 1: true
+[factorial.v:3] 1: 1
+[factorial.v:5] n * factorial(n - 1): 2
+[factorial.v:5] n * factorial(n - 1): 6
+[factorial.v:5] n * factorial(n - 1): 24
+[factorial.v:5] n * factorial(n - 1): 120
+120
+```
+Note that `dump(expr)` will trace both the source location,
+the expression itself, and the expression value.
 
 ## Modules
 
@@ -4659,39 +4698,6 @@ Modules are up to date.
 to allow for a better search experience.
 
 # Advanced Topics
-
-## Dumping expressions at runtime
-You can dump/trace the value of any V expression using `dump(expr)`.
-For example, save this code sample as `factorial.v`, then run it with
-`v run factorial.v`:
-```v
-fn factorial(n u32) u32 {
-	if dump(n <= 1) {
-		return dump(1)
-	}
-	return dump(n * factorial(n - 1))
-}
-
-fn main() {
-	println(factorial(5))
-}
-```
-You will get:
-```
-[factorial.v:2] n <= 1: false
-[factorial.v:2] n <= 1: false
-[factorial.v:2] n <= 1: false
-[factorial.v:2] n <= 1: false
-[factorial.v:2] n <= 1: true
-[factorial.v:3] 1: 1
-[factorial.v:5] n * factorial(n - 1): 2
-[factorial.v:5] n * factorial(n - 1): 6
-[factorial.v:5] n * factorial(n - 1): 24
-[factorial.v:5] n * factorial(n - 1): 120
-120
-```
-Note that `dump(expr)` will trace both the source location,
-the expression itself, and the expression value.
 
 ## Memory-unsafe code
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2607,19 +2607,20 @@ println('Top cities: ${top_cities.filter(.usa)}')
 Some functions are builtin like `println`. Here is the complete list:
 
 ```v ignore
-fn print(s IStr) // prints anything on stdout
-fn println(s IStr) // prints anything and a newline on stdout
+fn print(s string) // prints anything on stdout
+fn println(s string) // prints anything and a newline on stdout
 
-fn eprint(s IStr) // same as print(), but uses stderr
-fn eprintln(s IStr) // same as println(), but uses stderr
-
-fn dump(expr Expr) // prints file, line, expression source code and expression value
+fn eprint(s string) // same as print(), but uses stderr
+fn eprintln(s string) // same as println(), but uses stderr
 
 fn exit(code int) // terminates the program with a custom error code
 fn panic(s string) // prints a message and backtraces on stderr, and terminates the program with error code 1
 fn print_backtrace() // prints backtraces on stderr
 ```
-Note: the types IStr and Expr above are not public types - see below for usage.
+Note: Although the `print` functions take a string, V accepts other printable types too.
+See below for details.
+
+There is also a special built-in function called [`dump`](#dumping-expressions-at-runtime).
 
 ### println
 


### PR DESCRIPTION
`dump` is mentioned in the interface docs and isn't really an 'advanced' feature. It belongs as a built-in function even though it has special semantics (just like `it` methods are still methods).

Add `println` subheading.
Make 'Printing custom types' a subheading of `println`.
~~Change `print` functions to take IStr, not string and note IStr is not public.~~ Note that `print` functions can take other printable types.
Mention `dump` in built-in functions list.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
