### PR TITLE
cgen: fix crash for casting bool to int  (fix #13825)

### DIFF
--- a/vlib/os/process_windows.c.v
+++ b/vlib/os/process_windows.c.v
@@ -190,10 +190,8 @@ fn (mut p Process) win_read_string(idx int, maxbytes int) (string, int) {
 		return '', 0
 	}
 	mut bytes_avail := int(0)
-	unsafe {
-		if C.PeekNamedPipe(rhandle, voidptr(0), int(0), voidptr(0), &bytes_avail, voidptr(0)) == false {
-			return '', 0
-		}
+	if !C.PeekNamedPipe(rhandle, voidptr(0), int(0), voidptr(0), &bytes_avail, voidptr(0)) {
+		return '', 0
 	}
 	if bytes_avail == 0 {
 		return '', 0

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3771,8 +3771,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 		g.write('))')
 	} else if sym.kind == .alias && g.table.final_sym(node.typ).kind == .array_fixed {
 		g.expr(node.expr)
-	} else if node.expr_type != 0 && g.table.final_sym(node.expr_type).kind == .bool
-		&& node.typ.is_int() {
+	} else if node.expr_type == ast.bool_type && node.typ.is_int() {
 		styp := g.typ(node.typ)
 		tmp := g.new_tmp_var()
 		g.empty_line = true

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3771,6 +3771,18 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 		g.write('))')
 	} else if sym.kind == .alias && g.table.final_sym(node.typ).kind == .array_fixed {
 		g.expr(node.expr)
+	} else if node.expr_type != 0 && g.table.final_sym(node.expr_type).kind == .bool
+		&& node.typ.is_int() {
+		styp := g.typ(node.typ)
+		tmp := g.new_tmp_var()
+		g.empty_line = true
+		s := g.go_before_stmt(0)
+		g.write('$styp $tmp = (')
+		g.expr(node.expr)
+		g.writeln(')?1:0;')
+		g.empty_line = false
+		g.write(s)
+		g.write(tmp)
 	} else {
 		styp := g.typ(node.typ)
 		if (g.pref.translated || g.file.is_translated) && sym.kind == .function {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3773,15 +3773,9 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 		g.expr(node.expr)
 	} else if node.expr_type == ast.bool_type && node.typ.is_int() {
 		styp := g.typ(node.typ)
-		tmp := g.new_tmp_var()
-		g.empty_line = true
-		s := g.go_before_stmt(0)
-		g.write('$styp $tmp = (')
+		g.write('($styp[]){(')
 		g.expr(node.expr)
-		g.writeln(')?1:0;')
-		g.empty_line = false
-		g.write(s)
-		g.write(tmp)
+		g.write(')?1:0}[0]')
 	} else {
 		styp := g.typ(node.typ)
 		if (g.pref.translated || g.file.is_translated) && sym.kind == .function {

--- a/vlib/v/gen/c/sql.v
+++ b/vlib/v/gen/c/sql.v
@@ -120,7 +120,7 @@ fn (mut g Gen) sql_create_table(node ast.SqlStmtLine, expr string, table_name st
 			}
 			g.write('.typ = $typ,')
 			g.write('.is_arr = ${sym.kind == .array}, ')
-			g.write('.is_time = ${int(g.table.get_type_name(field.typ) == 'time__Time')},')
+			g.write('.is_time = ${g.table.get_type_name(field.typ) == 'time__Time'},')
 			g.write('.default_val = (string){.str = (byteptr) "$field.default_val", .is_lit = 1},')
 			g.write('.attrs = new_array_from_c_array($field.attrs.len, $field.attrs.len, sizeof(StructAttribute),')
 			if field.attrs.len > 0 {
@@ -128,7 +128,7 @@ fn (mut g Gen) sql_create_table(node ast.SqlStmtLine, expr string, table_name st
 				for attr in field.attrs {
 					g.write('(StructAttribute){')
 					g.write('.name = _SLIT("$attr.name"),')
-					g.write('.has_arg = ${int(attr.has_arg)},')
+					g.write('.has_arg = $attr.has_arg,')
 					g.write('.arg = _SLIT("$attr.arg"),')
 					g.write('.kind = ${int(attr.kind)},')
 					g.write('},')

--- a/vlib/v/tests/cast_bool_to_int_test.v
+++ b/vlib/v/tests/cast_bool_to_int_test.v
@@ -1,0 +1,12 @@
+module main
+
+fn test_cast_bool_to_int() {
+	i := true
+	a := [1, 2, 3]
+
+	println(a[int(!i)])
+	assert a[int(!i)] == 1
+
+	println(a[int(i)])
+	assert a[int(i)] == 2
+}


### PR DESCRIPTION
This PR fix crash for casting bool to int  (fix #13825).

- Fix crash for casting bool to int.
- Add test.
- Use `array_get(a, (int[]){(!i)?1:0}[0]))`.

```v
fn main() {
	i := true
	a := [1, 2, 3]

	println(a[int(!i)])
	assert a[int(!i)] == 1

	println(a[int(i)])
	assert a[int(i)] == 2
}

PS D:\Test\v\tt1> v run .
1
2
```