### PR TITLE
builtin/array: make push_many private

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -594,7 +594,7 @@ fn (mut a array) push(val voidptr) {
 // push_many implements the functionality for pushing another array.
 // `val` is array.data and user facing usage is `a << [1,2,3]`
 [unsafe]
-pub fn (mut a3 array) push_many(val voidptr, size int) {
+fn (mut a3 array) push_many(val voidptr, size int) {
 	a3.ensure_cap(a3.len + size)
 	if a3.data == val && !isnil(a3.data) {
 		// handle `arr << arr`

--- a/vlib/term/ui/ui.v
+++ b/vlib/term/ui/ui.v
@@ -28,7 +28,8 @@ pub fn (mut ctx Context) write(s string) {
 	if s == '' {
 		return
 	}
-	unsafe { ctx.print_buf.push_many(s.str, s.len) }
+	tmp := unsafe { s.str.vbytes(s.len) }
+	ctx.print_buf << tmp
 }
 
 // flush displays the accumulated print buffer to the screen.


### PR DESCRIPTION
Instead a temporary array can be made with `ptr.vbytes(len)` and be pushed with `<<`.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
