### PR TITLE
checker: check generics fn arguments count (fix #13850)

### DIFF
--- a/vlib/v/checker/tests/generics_fn_arguments_count_err.out
+++ b/vlib/v/checker/tests/generics_fn_arguments_count_err.out
@@ -1,0 +1,41 @@
+vlib/v/checker/tests/generics_fn_arguments_count_err.vv:12:18: error: too little generic parameters got 1, expected 2
+   10 |
+   11 | fn main() {
+   12 |     ret1 := get_name<int>(11, 22)
+      |                     ~~~~~
+   13 |     println(ret1)
+   14 |
+vlib/v/checker/tests/generics_fn_arguments_count_err.vv:15:18: error: too many generic parameters got 3, expected 2
+   13 |     println(ret1)
+   14 |
+   15 |     ret2 := get_name<int, int, string>(11, 22, 'hello')
+      |                     ~~~~~~~~~~~~~~~~~~
+   16 |     println(ret2)
+   17 |
+vlib/v/checker/tests/generics_fn_arguments_count_err.vv:19:22: error: too little generic parameters got 1, expected 2
+   17 |
+   18 |     foo := Foo{}
+   19 |     ret3 := foo.get_name<int>(11, 22)
+      |                         ~~~~~
+   20 |     println(ret3)
+   21 |
+vlib/v/checker/tests/generics_fn_arguments_count_err.vv:22:22: error: too many generic parameters got 3, expected 2
+   20 |     println(ret3)
+   21 |
+   22 |     ret4 := foo.get_name<int, int, string>(11, 22, 'hello')
+      |                         ~~~~~~~~~~~~~~~~~~
+   23 |     println(ret4)
+   24 | }
+vlib/v/checker/tests/generics_fn_arguments_count_err.vv:2:15: error: no known default format for type `B`
+    1 | fn get_name<A, B>(a A, b B) string {
+    2 |     return '$a, $b'
+      |                  ^
+    3 | }
+    4 |
+vlib/v/checker/tests/generics_fn_arguments_count_err.vv:8:15: error: no known default format for type `B`
+    6 |
+    7 | fn (f Foo) get_name<A, B>(a A, b B) string {
+    8 |     return '$a, $b'
+      |                  ^
+    9 | }
+   10 |

--- a/vlib/v/checker/tests/generics_fn_arguments_count_err.vv
+++ b/vlib/v/checker/tests/generics_fn_arguments_count_err.vv
@@ -1,0 +1,24 @@
+fn get_name<A, B>(a A, b B) string {
+	return '$a, $b'
+}
+
+struct Foo {}
+
+fn (f Foo) get_name<A, B>(a A, b B) string {
+	return '$a, $b'
+}
+
+fn main() {
+	ret1 := get_name<int>(11, 22)
+	println(ret1)
+
+	ret2 := get_name<int, int, string>(11, 22, 'hello')
+	println(ret2)
+
+	foo := Foo{}
+	ret3 := foo.get_name<int>(11, 22)
+	println(ret3)
+
+	ret4 := foo.get_name<int, int, string>(11, 22, 'hello')
+	println(ret4)
+}


### PR DESCRIPTION
This PR check generics fn arguments count (fix #13850).

- Check generics fn arguments count.
- Add test.

```v
fn get_name<A, B>(a A, b B) string {
	return '$a, $b'
}

struct Foo {}

fn (f Foo) get_name<A, B>(a A, b B) string {
	return '$a, $b'
}

fn main() {
	ret1 := get_name<int>(11, 22)
	println(ret1)

	ret2 := get_name<int, int, string>(11, 22, 'hello')
	println(ret2)

	foo := Foo{}
	ret3 := foo.get_name<int>(11, 22)
	println(ret3)

	ret4 := foo.get_name<int, int, string>(11, 22, 'hello')
	println(ret4)
}

PS D:\Test\v\tt1> v run .
./tt1.v:12:18: error: too little generic parameters got 1, expected 2
   10 | 
   11 | fn main() {
   12 |     ret1 := get_name<int>(11, 22)
      |                     ~~~~~
   13 |     println(ret1)
   14 |
./tt1.v:15:18: error: too many generic parameters got 3, expected 2
   13 |     println(ret1)
   14 | 
   15 |     ret2 := get_name<int, int, string>(11, 22, 'hello')
      |                     ~~~~~~~~~~~~~~~~~~
   16 |     println(ret2)
   17 |
./tt1.v:19:22: error: too little generic parameters got 1, expected 2
   17 | 
   18 |     foo := Foo{}
   19 |     ret3 := foo.get_name<int>(11, 22)
      |                         ~~~~~
   20 |     println(ret3)
   21 |
./tt1.v:22:22: error: too many generic parameters got 3, expected 2
   20 |     println(ret3)
   21 | 
   22 |     ret4 := foo.get_name<int, int, string>(11, 22, 'hello')
      |                         ~~~~~~~~~~~~~~~~~~
   23 |     println(ret4)
   24 | }
./tt1.v:2:15: error: no known default format for type `B`
    1 | fn get_name<A, B>(a A, b B) string {
    2 |     return '$a, $b'
      |                  ^
    3 | }
    4 |
./tt1.v:8:15: error: no known default format for type `B`
    6 | 
    7 | fn (f Foo) get_name<A, B>(a A, b B) string {
    8 |     return '$a, $b'
      |                  ^
    9 | }
   10 |
```