### PR TITLE
parser: fix printing slice of multiline raw string (fix #13854)

### DIFF
--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -372,7 +372,9 @@ pub fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_iden
 				return node
 			}
 			p.is_stmt_ident = is_stmt_ident
-		} else if p.tok.kind in [.lsbr, .nilsbr] && p.tok.line_nr == p.prev_tok.line_nr {
+		} else if p.tok.kind in [.lsbr, .nilsbr] && (p.tok.line_nr == p.prev_tok.line_nr
+			|| (p.prev_tok.kind == .string
+			&& p.tok.line_nr == p.prev_tok.line_nr + p.prev_tok.lit.count('\n'))) {
 			if p.tok.kind == .nilsbr {
 				node = p.index_expr(node, true)
 			} else {

--- a/vlib/v/tests/inout/printing_slice_of_multiline_raw_string.out
+++ b/vlib/v/tests/inout/printing_slice_of_multiline_raw_string.out
@@ -1,0 +1,3 @@
+foo
+bar
+hi

--- a/vlib/v/tests/inout/printing_slice_of_multiline_raw_string.vv
+++ b/vlib/v/tests/inout/printing_slice_of_multiline_raw_string.vv
@@ -1,0 +1,5 @@
+fn main() {
+	println(r'foo
+bar
+hi'[..])
+}


### PR DESCRIPTION
This PR fix printing slice of multiline raw string (fix #13854).

- Fix printing slice of multiline raw string.
- Add test.

```v
fn main() {
	println(r'foo
bar
hi'[..])
}

PS D:\Test\v\tt1> v run .
foo
bar
hi
```