### PR TITLE
checker: fix error for array of anon fn call (fix #13849)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -531,6 +531,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 			info := sym.info as ast.Array
 			elem_typ := c.table.sym(info.elem_type)
 			if elem_typ.info is ast.FnType {
+				node.return_type = elem_typ.info.func.return_type
 				return elem_typ.info.func.return_type
 			} else {
 				c.error('cannot call the element of the array, it is not a function',
@@ -540,6 +541,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 			info := sym.info as ast.Map
 			value_typ := c.table.sym(info.value_type)
 			if value_typ.info is ast.FnType {
+				node.return_type = value_typ.info.func.return_type
 				return value_typ.info.func.return_type
 			} else {
 				c.error('cannot call the value of the map, it is not a function', node.pos)
@@ -548,13 +550,12 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 			info := sym.info as ast.ArrayFixed
 			elem_typ := c.table.sym(info.elem_type)
 			if elem_typ.info is ast.FnType {
+				node.return_type = elem_typ.info.func.return_type
 				return elem_typ.info.func.return_type
 			} else {
 				c.error('cannot call the element of the array, it is not a function',
 					node.pos)
 			}
-		} else {
-			// TODO: assert? is this possible?
 		}
 		found = true
 		return ast.string_type

--- a/vlib/v/tests/array_of_anon_fn_call_test.v
+++ b/vlib/v/tests/array_of_anon_fn_call_test.v
@@ -1,0 +1,8 @@
+fn test_array_of_anon_fn_call() {
+	xs := [fn (s string) (string, u32) {
+		return s, 0
+	}]
+	r, n := xs[0]('e')
+	assert n == 0
+	assert r == 'e'
+}


### PR DESCRIPTION
This PR fix error for array of anon fn call (fix #13849).

- Fix error for array of anon fn call.
- Add test.

```v
fn main() {
	xs := [fn (s string) (string, u32) {
		return s, 0
	}]
	r, n := xs[0]('e')
	println(n)
	assert n == 0
	println(r)
	assert r == 'e'
}

PS D:\Test\v\tt1> v run .
0
e
```