### PR TITLE
checker: fix error for marking as referenced (fix #13857)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3556,6 +3556,9 @@ pub fn (mut c Checker) mark_as_referenced(mut node ast.Expr, as_interface bool) 
 				if c.fn_scope != voidptr(0) {
 					obj = c.fn_scope.find_var(node.obj.name) or { obj }
 				}
+				if obj.typ == 0 {
+					return
+				}
 				type_sym := c.table.sym(obj.typ.set_nr_muls(0))
 				if obj.is_stack_obj && !type_sym.is_heap() && !c.pref.translated
 					&& !c.file.is_translated {

--- a/vlib/v/tests/mark_as_referenced_test.v
+++ b/vlib/v/tests/mark_as_referenced_test.v
@@ -1,0 +1,24 @@
+module main
+
+fn test_mark_as_referenced() {
+	if true {
+		a := Type{}
+		ret := f(a)
+		println(ret)
+		assert ret == 'Interface(Type{})'
+	}
+	a := Type{}
+	ret := f(a)
+	println(ret)
+	assert ret == 'Interface(Type{})'
+}
+
+struct Type {
+}
+
+interface Interface {
+}
+
+fn f(b Interface) string {
+	return '$b'
+}


### PR DESCRIPTION
This PR fix error for marking as referenced (fix #13857).

- Fix error for marking as referenced.
- Add test.

```v
module main

fn main() {
	if true {
		a := Type{}
		ret := f(a)
		println(ret)
		assert ret == 'Interface(Type{})'
	}
	a := Type{}
	ret := f(a)
	println(ret)
	assert ret == 'Interface(Type{})'
}

struct Type {
}

interface Interface {
}

fn f(b Interface) string {
	return '$b'
}

PS D:\Test\v\tt1> v run .
Interface(Type{})
Interface(Type{})
```