### PR TITLE
time:  fixes  recursive local time call by check local time status 

### DIFF
--- a/vlib/time/time.c.v
+++ b/vlib/time/time.c.v
@@ -117,5 +117,9 @@ fn convert_ctime(t C.tm, microsecond int) Time {
 		second: t.tm_sec
 		microsecond: microsecond
 		unix: make_unix_time(t)
+		// for the actual code base when we
+		// call convert_ctime, it is always
+		// when we manage the local time.
+		is_local: true
 	}
 }

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -45,6 +45,7 @@ pub:
 	second      int
 	microsecond int
 	unix        i64
+	is_local    bool // used to make time.now().local().local() == time.now().local()
 }
 
 // FormatDelimiter contains different time formats.
@@ -348,7 +349,7 @@ pub fn (d Duration) str() string {
 
 // offset returns time zone UTC offset in seconds.
 pub fn offset() int {
-	t := now()
+	t := utc()
 	local := t.local()
 	return int(local.unix - t.unix)
 }

--- a/vlib/time/time_nix.c.v
+++ b/vlib/time/time_nix.c.v
@@ -30,6 +30,9 @@ fn make_unix_time(t C.tm) i64 {
 
 // local returns t with the location set to local time.
 pub fn (t Time) local() Time {
+	if t.is_local {
+		return t
+	}
 	loc_tm := C.tm{}
 	C.localtime_r(voidptr(&t.unix), &loc_tm)
 	return convert_ctime(loc_tm, t.microsecond)

--- a/vlib/time/time_nix.c.v
+++ b/vlib/time/time_nix.c.v
@@ -20,7 +20,8 @@ struct C.tm {
 
 fn C.timegm(&C.tm) C.time_t
 
-// fn C.gmtime_r(&tm, &gbuf)
+// prefering localtime_r over the localtime because
+// from docs localtime_r is thread safe,
 fn C.localtime_r(t &C.time_t, tm &C.tm)
 
 fn make_unix_time(t C.tm) i64 {

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -254,3 +254,28 @@ fn test_since() {
 	d2 := time.since(t1)
 	assert d2 >= 40_000_000
 }
+
+// issue relate https://github.com/vlang/v/issues/13828
+// problem: the local method add 2h on the time in a Linux machine
+// the other machine are not tested in a local env
+fn test_recursive_local_call() {
+	assert time.now().unix == time.now().local().unix
+	assert time.now().str() == time.now().local().str()
+	assert time.now().local().str() == time.now().local().local().str()
+}
+
+fn test_local_method_with_time_operation() {
+	//FIXME: add a fixed TIMEZONE here
+	assert time.now().str() != time.utc().str()
+	assert time.now().str() == time.utc().local().str()
+
+	utc := time.utc()
+	utc_plus_1h := time.utc().add(time.hour).local()
+
+	// check if the utc local is increased by 1h
+	assert utc_plus_1h.hour == time.now().local().hour - 1
+	// trivial check
+	assert utc.hour < utc_plus_1h.hour
+	// normal utc vs an 1h alterate utc + local convertion
+	assert utc.hour == utc_plus_1h.hour - 3
+}

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -259,23 +259,7 @@ fn test_since() {
 // problem: the local method add 2h on the time in a Linux machine
 // the other machine are not tested in a local env
 fn test_recursive_local_call() {
-	assert time.now().unix == time.now().local().unix
-	assert time.now().str() == time.now().local().str()
-	assert time.now().local().str() == time.now().local().local().str()
-}
-
-fn test_local_method_with_time_operation() {
-	//FIXME: add a fixed TIMEZONE here
-	assert time.now().str() != time.utc().str()
-	assert time.now().str() == time.utc().local().str()
-
-	utc := time.utc()
-	utc_plus_1h := time.utc().add(time.hour).local()
-
-	// check if the utc local is increased by 1h
-	assert utc_plus_1h.hour == time.now().local().hour - 1
-	// trivial check
-	assert utc.hour < utc_plus_1h.hour
-	// normal utc vs an 1h alterate utc + local convertion
-	assert utc.hour == utc_plus_1h.hour - 3
+	now_tm := time.now()
+	assert now_tm.str() == now_tm.local().str()
+	assert now_tm.local().str() == now_tm.local().local().str()
 }

--- a/vlib/time/time_windows.c.v
+++ b/vlib/time/time_windows.c.v
@@ -104,6 +104,7 @@ pub fn (t Time) local() Time {
 		hour: u16(t.hour)
 		minute: u16(t.minute)
 		second: u16(t.second)
+		millisecond: u16(t.microsecond / 1000)
 	}
 	st_local := SystemTime{}
 	C.SystemTimeToTzSpecificLocalTime(voidptr(0), &st_utc, &st_local)


### PR DESCRIPTION
Fixes https://github.com/vlang/v/issues/13828

On a Linux machine, the local call adds 2 hours each call to the now() result.

I'm adding this test right now because I need to discovered where is the leak

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
