### PR TITLE
v.builder: fix linker flags for systems with Procursus

### DIFF
--- a/vlib/net/openssl/c.v
+++ b/vlib/net/openssl/c.v
@@ -23,6 +23,9 @@ $if $pkgconfig('openssl') {
 // Brew arm64
 #flag darwin -I /opt/homebrew/opt/openssl/include
 #flag darwin -L /opt/homebrew/opt/openssl/lib
+// Procursus
+#flag darwin -I/opt/procursus/include
+#flag darwin -L/opt/procursus/lib
 //
 #include <openssl/rand.h> # Please install OpenSSL development headers
 #include <openssl/ssl.h>

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -203,6 +203,9 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	if v.pref.os == .ios {
 		ccoptions.args << '-fobjc-arc'
 	}
+	if v.pref.os == .macos && os.exists('/opt/procursus') {
+		ccoptions.linker_flags << '-Wl,-rpath,/opt/procursus/lib'
+	}
 	ccoptions.debug_mode = v.pref.is_debug
 	ccoptions.guessed_compiler = v.pref.ccompiler
 	if ccoptions.guessed_compiler == 'cc' && v.pref.is_prod {


### PR DESCRIPTION
[Procursus](https://github.com/ProcursusTeam/Procursus) installs libraries such as openssl with `@rpath/libssl.3.dylib` install names, this means that programs linking these libraries have to add the correct path to the `rpath` of the executable.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
