### PR TITLE
v.builder, v.gen, v.pref: fix iOS compilation from non-macOS

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -523,17 +523,7 @@ pub fn (mut v Builder) cc() {
 		// try to compile with the choosen compiler
 		// if compilation fails, retry again with another
 		mut ccompiler := v.pref.ccompiler
-		if v.pref.os == .ios {
-			ios_sdk := if v.pref.is_ios_simulator { 'iphonesimulator' } else { 'iphoneos' }
-			ios_sdk_path_res := os.execute_or_exit('xcrun --sdk $ios_sdk --show-sdk-path')
-			mut isysroot := ios_sdk_path_res.output.replace('\n', '')
-			arch := if v.pref.is_ios_simulator {
-				'-arch x86_64'
-			} else {
-				'-arch armv7 -arch armv7s -arch arm64'
-			}
-			ccompiler = 'xcrun --sdk iphoneos clang -isysroot $isysroot $arch'
-		} else if v.pref.os == .wasm32 {
+		if v.pref.os == .wasm32 {
 			ccompiler = 'clang'
 		}
 		v.setup_ccompiler_options(ccompiler)
@@ -619,7 +609,7 @@ pub fn (mut v Builder) cc() {
 				}
 				if v.pref.retry_compilation {
 					tcc_output = res
-					v.pref.ccompiler = pref.default_c_compiler()
+					v.pref.default_c_compiler()
 					if v.pref.is_verbose {
 						eprintln('Compilation with tcc failed. Retrying with $v.pref.ccompiler ...')
 					}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -652,6 +652,7 @@ pub fn (mut g Gen) init() {
 				g.cheaders.writeln('#include <stddef.h>')
 			} else {
 				g.cheaders.writeln(get_guarded_include_text('<inttypes.h>', 'The C compiler can not find <inttypes.h>. Please install build-essentials')) // int64_t etc
+				g.cheaders.writeln(get_guarded_include_text('<stdbool.h>', 'The C compiler can not find <stdbool.h>. Please install build-essentials')) // bool, true, false
 				g.cheaders.writeln(get_guarded_include_text('<stddef.h>', 'The C compiler can not find <stddef.h>. Please install build-essentials')) // size_t, ptrdiff_t
 			}
 		}


### PR DESCRIPTION
This has a couple of changes.

First of all, it allows `-cc` to override the default xcode compiler when targeting iOS. This allows for cross compilation to iOS from other systems with the correct environment. I tested this with `v -os ios -cc aarch64-apple-darwin-clang -cflags "-isysroot /usr/home/cameron/Documents/iOS/SDK/iPhoneOS14.3.sdk -isystem /usr/home/cameron/Documents/iOS/include" helloworld.v` and `v -os ios -cc aarch64-apple-darwin-clang -cflags "-isysroot /usr/home/cameron/Documents/iOS/SDK/iPhoneOS14.3.sdk -isystem /usr/home/cameron/Documents/iOS/include" -o v cmd/v`.

I also added `stdbool.h` to the list of includes. This fixes #11087, an issue I also ran into. Because `stdbool.h` is a part of the POSIX standard I feel confident that including it won't limit `v`'s system range, however I was not able to test this on Windows.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
