### PR TITLE
math: Allow acos(0) - fixes 13876

### DIFF
--- a/vlib/math/invtrig.v
+++ b/vlib/math/invtrig.v
@@ -206,9 +206,6 @@ pub fn acos(x f64) f64 {
 	if (x < -1.0) || (x > 1.0) {
 		return nan()
 	}
-	if x == 0.0 {
-		return nan()
-	}
 	if x > 0.5 {
 		return f64(2.0) * asin(sqrt(0.5 - 0.5 * x))
 	}


### PR DESCRIPTION
Fixes [#13876](https://github.com/vlang/v/issues/13876)

Current acos fn return ```nan``` when calculating acos(0.0) instead of π/2 radians. Removes the check from the function