### PR TITLE
vdoc: show `//` comment prefix and hide any \x01 character for HTML

### DIFF
--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -298,6 +298,8 @@ fn html_highlight(code string, tb &ast.Table) string {
 			"'$tok.lit'"
 		} else if typ == .char {
 			'`$tok.lit`'
+		} else if typ == .comment {
+			if tok.lit[0] == 1 { '//${tok.lit[1..]}' } else { '//$tok.lit' }
 		} else {
 			tok.lit
 		}


### PR DESCRIPTION
https://modules.vlang.io/vweb.html#Context
The above link has:
```
pub:
 HTTP Request
	req http.Request
 TODO Response
```
This hides the  character and shows `//` instead.

This still isn't ideal as the indent is missing, and multi-line comments are shown as line comments. I'm not sure how to detect them.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
