### PR TITLE
builder,cgen: iOS fixes

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -347,7 +347,11 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	if v.pref.os == .macos {
 		ccoptions.post_args << '-mmacosx-version-min=10.7'
 	} else if v.pref.os == .ios {
-		ccoptions.post_args << '-miphoneos-version-min=10.0'
+		if v.pref.is_ios_simulator {
+			ccoptions.post_args << '-miphonesimulator-version-min=10.0'
+		} else {
+			ccoptions.post_args << '-miphoneos-version-min=10.0'
+		}
 	} else if v.pref.os == .windows {
 		ccoptions.post_args << '-municode'
 	}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -652,7 +652,9 @@ pub fn (mut g Gen) init() {
 				g.cheaders.writeln('#include <stddef.h>')
 			} else {
 				g.cheaders.writeln(get_guarded_include_text('<inttypes.h>', 'The C compiler can not find <inttypes.h>. Please install build-essentials')) // int64_t etc
-				// g.cheaders.writeln(get_guarded_include_text('<stdbool.h>', 'The C compiler can not find <stdbool.h>. Please install build-essentials')) // bool, true, false
+				if g.pref.os == .ios {
+					g.cheaders.writeln(get_guarded_include_text('<stdbool.h>', 'The C compiler can not find <stdbool.h>. Please install build-essentials')) // bool, true, false
+				}
 				g.cheaders.writeln(get_guarded_include_text('<stddef.h>', 'The C compiler can not find <stddef.h>. Please install build-essentials')) // size_t, ptrdiff_t
 			}
 		}

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -219,11 +219,14 @@ pub fn (mut p Preferences) default_c_compiler() {
 			ios_sdk_path_res := os.execute_or_exit('xcrun --sdk $ios_sdk --show-sdk-path')
 			mut isysroot := ios_sdk_path_res.output.replace('\n', '')
 			arch := if p.is_ios_simulator {
-				'-arch x86_64'
+				'-arch x86_64 -arch arm64'
 			} else {
 				'-arch armv7 -arch armv7s -arch arm64'
 			}
-			p.ccompiler = 'xcrun --sdk iphoneos clang -isysroot $isysroot $arch'
+			// On macOS, /usr/bin/cc is a hardlink/wrapper for xcrun. clang on darwin hosts
+			// will automatically change the build target based off of the selected sdk, making xcrun -sdk iphoneos pointless
+			p.ccompiler = '/usr/bin/cc'
+			p.cflags = '-isysroot $isysroot $arch' + p.cflags
 			return
 		}
 	}


### PR DESCRIPTION
cgen: re-add stdbool.h for iOS only, this will fix windows tcc builds

builder: fix building for iOS and simulator from macOS
The compiler was being set as `xcrun --sdk iphoneos clang -isysroot path/iPhoneOS.sdk -arch arm64 -arch etc`, then when executed, the compiler string was wrapped in single quotes, causing that whole string to be searched for in the `PATH`, which would fail. Because the SDK is being specified explicitly, the usage of xcrun was useless.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
