### PR TITLE
cgen: fix error for cross assign of the reserved name variable (fix #13881)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -584,10 +584,10 @@ fn (mut g Gen) gen_cross_var_assign(node &ast.AssignStmt) {
 				left_sym := g.table.sym(left_typ)
 				if left_sym.kind == .function {
 					g.write_fn_ptr_decl(left_sym.info as ast.FnType, '_var_$left.pos.pos')
-					g.writeln(' = $left.name;')
+					g.writeln(' = ${c_name(left.name)};')
 				} else {
 					styp := g.typ(left_typ)
-					g.writeln('$styp _var_$left.pos.pos = $left.name;')
+					g.writeln('$styp _var_$left.pos.pos = ${c_name(left.name)};')
 				}
 			}
 			ast.IndexExpr {

--- a/vlib/v/tests/cross_assign_test.v
+++ b/vlib/v/tests/cross_assign_test.v
@@ -168,3 +168,24 @@ fn test_cross_assign_of_big_int() {
 	println(a)
 	assert a == big.one_int
 }
+
+fn test_cross_assign_of_reserved_name_variable() {
+	mut small := 1
+	mut big := 2
+	mut sum := 2
+
+	for big < 4_000_000 {
+		small, big = big, small + big
+		if big % 2 == 0 {
+			sum += big
+		}
+	}
+	println(small)
+	assert small == 3524578
+
+	println(big)
+	assert big == 5702887
+
+	println(sum)
+	assert sum == 4613732
+}


### PR DESCRIPTION
This PR fix error for cross assign of the reserved name variable (fix #13881).

- Fix error for cross assign of the reserved name variable.
- Add test.

```v
fn main() {
	mut small := 1
	mut big := 2
	mut sum := 2

	for big < 4_000_000 {
		small, big = big, small + big
		if big % 2 == 0 {
			sum += big
		}
	}
	println(small)
	assert small == 3524578

	println(big)
	assert big == 5702887
	
	println(sum)
	assert sum == 4613732
}

PS D:\Test\v\tt1> v run .
3524578
5702887
4613732
```