### PR TITLE
checker: fixes cast comparison between generics

### DIFF
--- a/vlib/v/checker/tests/generic_cast_complex_interface.vv
+++ b/vlib/v/checker/tests/generic_cast_complex_interface.vv
@@ -1,0 +1,34 @@
+type ParseRes = Result<[]Token, ParseErr>
+
+struct ParseErr{
+
+}
+
+type Opt<T> = None<T> | Some<T>
+
+struct None<T> {}
+
+struct Some<T> {
+	value T
+}
+
+type Result<T, U> = Err<U> | Ok<T>
+
+struct Ok<T> {
+	value T
+}
+
+struct Err<U> {
+	value U
+}
+
+fn main() {
+	r := Opt<ParseRes>(None<ParseRes>{})
+	match r {
+		Some<ParseRes> {
+			rx := Result<[]Token, ParseErr>(r)
+			println(rx)
+		}
+		None<ParseRes> {}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/vlang/v/issues/13863

This is an example of stacktrace

```
➜  v git:(macros/generic_cast) ✗ ./v vlib/v/checker/tests/generic_cast_complex_interface.vv
vlib/v/checker/tests/generic_cast_complex_interface.vv:29:10: error: cannot cast `Some<ParseRes>` to `Token, ParseErr>`
   27 |     match r {
   28 |         Some<ParseRes> {
   29 |             rx := Result<[]Token, ParseErr>(r)
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   30 |             println(rx)
   31 |         }
```

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
