### PR TITLE
time: fix error for time.local() on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,22 @@ jobs:
         run: .\v.exe test-self
         #    - name: Test
         #      run: .\v.exe test-all
+      - name: Test time functions in a timezone UTC-12
+        run: |
+          tzutil /s "Dateline Standard Time"
+          ./v test vlib/time/
+      - name: Test time functions in a timezone UTC-3
+        run: |
+          tzutil /s "Greenland Standard Time"
+          ./v test vlib/time/
+      - name: Test time functions in a timezone UTC+3
+        run: |
+          tzutil /s "Russian Standard Time"
+          ./v test vlib/time/
+      - name: Test time functions in a timezone UTC+12
+        run: |
+          tzutil /s "New Zealand Standard Time"
+          ./v test vlib/time/
       - name: Test v->js
         run: ./v -o hi.js examples/hello_v_js.v && node hi.js
       - name: Test v binaries

--- a/vlib/time/time_windows.c.v
+++ b/vlib/time/time_windows.c.v
@@ -97,6 +97,9 @@ fn local_as_unix_time() i64 {
 
 // local - return the time `t`, converted to the currently active local timezone
 pub fn (t Time) local() Time {
+	if t.is_local {
+		return t
+	}
 	st_utc := SystemTime{
 		year: u16(t.year)
 		month: u16(t.month)
@@ -140,6 +143,7 @@ fn win_now() Time {
 		second: st_local.second
 		microsecond: st_local.millisecond * 1000
 		unix: st_local.unix_time()
+		is_local: true
 	}
 	return t
 }
@@ -161,6 +165,7 @@ fn win_utc() Time {
 		second: st_utc.second
 		microsecond: st_utc.millisecond * 1000
 		unix: st_utc.unix_time()
+		is_local: false
 	}
 	return t
 }


### PR DESCRIPTION
This PR fixes error for time.local() on windows.

error on windows :
```v
 FAIL  [223/927]   508.175 ms vlib/time/time_test.v
D:\\v\\vlib\\time\\time_test.v:263: ✗ fn test_recursive_local_call
   > assert now_tm.str() == now_tm.local().str()
     Left value: 2022-04-01 11:31:02
    Right value: 2022-04-01 19:31:02
```