### PR TITLE
v/doc: parse multi-line examples (so they get highlighted)

### DIFF
--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -175,7 +175,7 @@ pub struct WindowAttribute {
 // - `size` - snapshot size
 // - `step` - gap size between each snapshot, default is 1.
 //
-// Example: arrays.window([1, 2, 3, 4], size: 2) => [[1, 2], [2, 3], [3, 4]]
+// Example: arrays.window([1, 2, 3, 4], size: 2) // => [[1, 2], [2, 3], [3, 4]]
 // Example: arrays.window([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], size: 3, step: 2) // => [[1, 2, 3], [3, 4, 5], [5, 6, 7], [7, 8, 9]]
 pub fn window<T>(list []T, attr WindowAttribute) [][]T {
 	// allocate snapshot array
@@ -394,7 +394,7 @@ pub fn binary_search<T>(arr []T, target T) ?int {
 // Example:
 // ```v
 // mut x := [1,2,3,4,5,6]
-// arrays.rotate_left(mut x,2)
+// arrays.rotate_left(mut x, 2)
 // println(x) // [3, 4, 5, 6, 1, 2]
 // ```
 pub fn rotate_left<T>(mut arr []T, mid int) {

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -555,7 +555,6 @@ pub fn (s string) u64() u64 {
 // This method directly exposes the `parse_uint` function from `strconv`
 // as a method on `string`. For more advanced features,
 // consider calling `strconv.common_parse_uint` directly.
-// Example:
 pub fn (s string) parse_uint(_base int, _bit_size int) ?u64 {
 	return strconv.parse_uint(s, _base, _bit_size)
 }
@@ -1823,13 +1822,15 @@ pub fn (s string) fields() []string {
 // the value in ``.
 //
 // Example:
+// ```v
 // st := 'Hello there,
 // |this is a string,
 // |    Everything before the first | is removed'.strip_margin()
-// Returns:
-// Hello there,
+//
+// assert st == 'Hello there,
 // this is a string,
-// Everything before the first | is removed
+// Everything before the first | is removed'
+// ```
 pub fn (s string) strip_margin() string {
 	return s.strip_margin_custom(`|`)
 }

--- a/vlib/v/doc/comment.v
+++ b/vlib/v/doc/comment.v
@@ -33,4 +33,3 @@ pub fn (dc DocComment) is_multi_line_example() bool {
 pub fn (dc DocComment) has_triple_backtick() bool {
 	return dc.text.starts_with('\x01 ```')
 }
-

--- a/vlib/v/doc/comment.v
+++ b/vlib/v/doc/comment.v
@@ -24,10 +24,12 @@ pub fn (dc DocComment) example() string {
 	return dc.text.all_after(doc.example_pattern)
 }
 
+// is_multi_line_example returns true if an example line has no inline code
 pub fn (dc DocComment) is_multi_line_example() bool {
 	return dc.text == '\x01 Example:'
 }
 
+// has_triple_backtick returns true if the comment starts or ends a markdown code block
 pub fn (dc DocComment) has_triple_backtick() bool {
 	return dc.text.starts_with('\x01 ```')
 }

--- a/vlib/v/doc/comment.v
+++ b/vlib/v/doc/comment.v
@@ -16,7 +16,7 @@ pub mut:
 // is_example returns true if the contents of this comment is an inline doc example.
 // The current convention is '// Example: <content>'
 pub fn (dc DocComment) is_example() bool {
-	return dc.text.starts_with(doc.example_pattern)
+	return dc.text.trim_space().starts_with(doc.example_pattern)
 }
 
 // example returns the content of the inline example body
@@ -26,7 +26,7 @@ pub fn (dc DocComment) example() string {
 
 // is_multi_line_example returns true if an example line has no inline code
 pub fn (dc DocComment) is_multi_line_example() bool {
-	return dc.text == '\x01 Example:'
+	return dc.text.trim_space() == '\x01 Example:'
 }
 
 // has_triple_backtick returns true if the comment starts or ends a markdown code block

--- a/vlib/v/doc/comment.v
+++ b/vlib/v/doc/comment.v
@@ -13,13 +13,22 @@ pub mut:
 	pos      token.Pos
 }
 
-// is_example returns true if the contents of this comment is a doc example.
+// is_example returns true if the contents of this comment is an inline doc example.
 // The current convention is '// Example: <content>'
 pub fn (dc DocComment) is_example() bool {
 	return dc.text.starts_with(doc.example_pattern)
 }
 
-// example returns the content of the example body
+// example returns the content of the inline example body
 pub fn (dc DocComment) example() string {
 	return dc.text.all_after(doc.example_pattern)
 }
+
+pub fn (dc DocComment) is_multi_line_example() bool {
+	return dc.text == '\x01 Example:'
+}
+
+pub fn (dc DocComment) has_triple_backtick() bool {
+	return dc.text.starts_with('\x01 ```')
+}
+

--- a/vlib/v/doc/node.v
+++ b/vlib/v/doc/node.v
@@ -61,9 +61,30 @@ pub fn (dc DocNode) merge_comments_without_examples() string {
 // examples returns a `[]string` containing examples parsed from `DocNode.comments`.
 pub fn (dn DocNode) examples() []string {
 	mut output := []string{}
-	for comment in dn.comments {
+	for i, comment in dn.comments {
 		if comment.is_example() {
 			output << comment.example()
+		} else if comment.text == '\x01 Example:' {
+			mut j := i + 1
+			//~ comments = dn.comments
+			mut ml_ex := ''
+			mdcode := '\x01 ```'
+			if j + 2 < dn.comments.len && dn.comments[j].text == mdcode + 'v'
+			{
+				j++
+				for j < dn.comments.len && dn.comments[j].text != mdcode {
+			//~ println(dn.comments[j].text)
+					if ml_ex.len > 0 {
+						ml_ex += '\n'
+					}
+					s := dn.comments[j].text
+					if s.len > 2 { ml_ex += s[2..] }
+					j++
+				}
+				println(ml_ex)
+				output << ml_ex
+				break
+			}
 		}
 	}
 	return output

--- a/vlib/v/doc/node.v
+++ b/vlib/v/doc/node.v
@@ -54,13 +54,15 @@ pub fn (dc DocNode) merge_comments() string {
 // merge_comments_without_examples returns a `string` with the
 // combined contents of `DocNode.comments` - excluding any examples.
 pub fn (dc DocNode) merge_comments_without_examples() string {
-	mut sans_examples := []DocComment{cap:dc.comments.len}
+	mut sans_examples := []DocComment{cap: dc.comments.len}
 	for i := 0; i < dc.comments.len; i++ {
-		if dc.comments[i].is_example() { continue }
+		if dc.comments[i].is_example() {
+			continue
+		}
 		if dc.comments[i].is_multi_line_example() {
 			i++
 			if i == dc.comments.len || !dc.comments[i].has_triple_backtick() {
-				eprintln('${dc.file_path}: Expected code block after empty example line:')
+				eprintln('$dc.file_path: Expected code block after empty example line:')
 				eprintln('// ```')
 				if i < dc.comments.len {
 					eprintln('Found:')
@@ -88,15 +90,16 @@ pub fn (dn DocNode) examples() []string {
 		} else if comment.is_multi_line_example() {
 			mut j := i + 1
 			mut ml_ex := ''
-			if j + 2 < dn.comments.len && dn.comments[j].has_triple_backtick()
-			{
+			if j + 2 < dn.comments.len && dn.comments[j].has_triple_backtick() {
 				j++
 				for j < dn.comments.len && !dn.comments[j].has_triple_backtick() {
 					if ml_ex.len > 0 {
 						ml_ex += '\n'
 					}
 					s := dn.comments[j].text
-					if s.len > 2 { ml_ex += s[2..] }
+					if s.len > 2 {
+						ml_ex += s[2..]
+					}
 					j++
 				}
 				output << ml_ex

--- a/vlib/v/doc/node.v
+++ b/vlib/v/doc/node.v
@@ -87,13 +87,11 @@ pub fn (dn DocNode) examples() []string {
 			output << comment.example()
 		} else if comment.is_multi_line_example() {
 			mut j := i + 1
-			//~ comments = dn.comments
 			mut ml_ex := ''
 			if j + 2 < dn.comments.len && dn.comments[j].has_triple_backtick()
 			{
 				j++
 				for j < dn.comments.len && !dn.comments[j].has_triple_backtick() {
-			//~ println(dn.comments[j].text)
 					if ml_ex.len > 0 {
 						ml_ex += '\n'
 					}
@@ -101,7 +99,6 @@ pub fn (dn DocNode) examples() []string {
 					if s.len > 2 { ml_ex += s[2..] }
 					j++
 				}
-				println(ml_ex)
 				output << ml_ex
 				break
 			}

--- a/vlib/v/doc/node.v
+++ b/vlib/v/doc/node.v
@@ -62,7 +62,7 @@ pub fn (dc DocNode) merge_comments_without_examples() string {
 		if dc.comments[i].is_multi_line_example() {
 			i++
 			if i == dc.comments.len || !dc.comments[i].has_triple_backtick() {
-				eprintln('$dc.file_path: Expected code block after empty example line:')
+				eprintln('$dc.file_path:$dc.pos.line_nr: Expected code block after empty example line:')
 				eprintln('// ```')
 				if i < dc.comments.len {
 					eprintln('Found:')

--- a/vlib/v/doc/node.v
+++ b/vlib/v/doc/node.v
@@ -84,26 +84,26 @@ pub fn (dc DocNode) merge_comments_without_examples() string {
 // examples returns a `[]string` containing examples parsed from `DocNode.comments`.
 pub fn (dn DocNode) examples() []string {
 	mut output := []string{}
-	for i, comment in dn.comments {
+	for i := 0; i < dn.comments.len; i++ {
+		comment := dn.comments[i]
 		if comment.is_example() {
 			output << comment.example()
 		} else if comment.is_multi_line_example() {
-			mut j := i + 1
-			mut ml_ex := ''
-			if j + 2 < dn.comments.len && dn.comments[j].has_triple_backtick() {
-				j++
-				for j < dn.comments.len && !dn.comments[j].has_triple_backtick() {
+			i++
+			if i + 2 < dn.comments.len && dn.comments[i].has_triple_backtick() {
+				i++
+				mut ml_ex := ''
+				for i < dn.comments.len && !dn.comments[i].has_triple_backtick() {
 					if ml_ex.len > 0 {
 						ml_ex += '\n'
 					}
-					s := dn.comments[j].text
+					s := dn.comments[i].text
 					if s.len > 2 {
 						ml_ex += s[2..]
 					}
-					j++
+					i++
 				}
 				output << ml_ex
-				break
 			}
 		}
 	}


### PR DESCRIPTION
Part of https://github.com/vlang/v/issues/13851.

Added an error when a multi-line example isn't formatted in markdown backticks, e.g.:
```v
// Example:
// st := 'Hello there,
// |this is a string,
// |    Everything before the first | is removed'.strip_margin()
```
```
C:\git\v\vlib\builtin\string.v: Expected code block after empty example line:
// ```
Found:
// st := 'Hello there,
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
