### PR TITLE
time: implement Time.strftime(fmt string) as a wrapper for strftime(3)

### DIFF
--- a/vlib/time/time.c.v
+++ b/vlib/time/time.c.v
@@ -16,6 +16,7 @@ fn C.localtime_r(t &C.time_t, tm &C.tm)
 
 fn C.time(t &C.time_t) C.time_t
 
+fn C.gmtime(t &C.time_t) &C.tm
 fn C.gmtime_r(t &C.time_t, res &C.tm) &C.tm
 fn C.strftime(buf &C.char, maxsize C.size_t, fmt &C.char, tm &C.tm) C.size_t
 

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -263,3 +263,7 @@ fn test_recursive_local_call() {
 	assert now_tm.str() == now_tm.local().str()
 	assert now_tm.local().str() == now_tm.local().local().str()
 }
+
+fn test_strftime() {
+	assert '1980 July 11' == time_to_test.strftime('%Y %B %d')
+}


### PR DESCRIPTION
I have not tested this on Windows, so if the CI fails I will have to do that. It should work though, as it is entirely POSIX.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
