### PR TITLE
make.bat: prevents tcc to be downloaded and installed when choosing another compiler than default (for example msvc)

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -98,7 +98,6 @@ exit /b %ERRORLEVEL%
 
 :build
 if !flag_local! NEQ 1 (
-    call :download_tcc
     if %ERRORLEVEL% NEQ 0 goto :error
     pushd "%vc_dir%" && (
         echo Updating vc...
@@ -118,6 +117,7 @@ if not [!compiler!] == [] goto :!compiler!_strap
 REM By default, use tcc, since we have it prebuilt:
 :tcc_strap
 :tcc32_strap
+call :download_tcc
 echo  ^> Attempting to build v_win.c with "!tcc_exe!"
 "!tcc_exe!" -Bthirdparty/tcc -Ithirdparty/stdatomic/win -bt10 -g -w -o v.exe vc\v_win.c -ladvapi32
 if %ERRORLEVEL% NEQ 0 goto :compile_error


### PR DESCRIPTION
When choosing another compiler than the default tcc (ie. -msvc), this change will prevent make.bat to automatically download and install tcc.

