### PR TITLE
cgen: fix array of fixed array  (fix #13895)

### DIFF
--- a/vlib/v/gen/c/infix_expr.v
+++ b/vlib/v/gen/c/infix_expr.v
@@ -613,7 +613,7 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 			// push a single element
 			elem_type_str := g.typ(array_info.elem_type)
 			elem_sym := g.table.sym(array_info.elem_type)
-			elem_is_array := elem_sym.kind in [.array, .array_fixed] && node.right !is ast.ArrayInit
+			elem_is_array_var := elem_sym.kind in [.array, .array_fixed] && node.right is ast.Ident
 			g.write('array_push${noscan}((array*)')
 			if !left.typ.is_ptr()
 				|| (node.left_type.has_flag(.shared_f) && !node.left_type.deref().is_ptr()) {
@@ -625,7 +625,7 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 			}
 			if elem_sym.kind == .function {
 				g.write(', _MOV((voidptr[]){ ')
-			} else if elem_is_array {
+			} else if elem_is_array_var {
 				g.write(', &')
 			} else {
 				g.write(', _MOV(($elem_type_str[]){ ')
@@ -639,7 +639,7 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 			if needs_clone {
 				g.write(')')
 			}
-			if elem_is_array {
+			if elem_is_array_var {
 				g.write(')')
 			} else {
 				g.write(' }))')

--- a/vlib/v/gen/c/infix_expr.v
+++ b/vlib/v/gen/c/infix_expr.v
@@ -613,9 +613,8 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 			// push a single element
 			elem_type_str := g.typ(array_info.elem_type)
 			elem_sym := g.table.sym(array_info.elem_type)
+			elem_is_array := elem_sym.kind in [.array, .array_fixed] && node.right !is ast.ArrayInit
 			g.write('array_push${noscan}((array*)')
-			if node.left_type.has_flag(.shared_f) && !node.left_type.deref().is_ptr() {
-			}
 			if !left.typ.is_ptr()
 				|| (node.left_type.has_flag(.shared_f) && !node.left_type.deref().is_ptr()) {
 				g.write('&')
@@ -626,6 +625,8 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 			}
 			if elem_sym.kind == .function {
 				g.write(', _MOV((voidptr[]){ ')
+			} else if elem_is_array {
+				g.write(', &')
 			} else {
 				g.write(', _MOV(($elem_type_str[]){ ')
 			}
@@ -638,7 +639,11 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 			if needs_clone {
 				g.write(')')
 			}
-			g.write(' }))')
+			if elem_is_array {
+				g.write(')')
+			} else {
+				g.write(' }))')
+			}
 		}
 	} else {
 		g.gen_plain_infix_expr(node)

--- a/vlib/v/tests/array_of_fixed_array_test.v
+++ b/vlib/v/tests/array_of_fixed_array_test.v
@@ -1,0 +1,15 @@
+fn test_array_of_fixed_array() {
+	mut arr := [][3]int{}
+
+	fixed_arr1 := [3]int{}
+	arr << fixed_arr1
+
+	fixed_arr2 := [1, 2, 3]!
+	arr << fixed_arr2
+
+	println(arr)
+
+	assert arr.len == 2
+	assert '${arr[0]}' == '[0, 0, 0]'
+	assert '${arr[1]}' == '[1, 2, 3]'
+}


### PR DESCRIPTION
This PR fix array of fixed array  (fix #13895).

- Fix array of fixed array.
- Add test.

```v
fn main() {
	mut arr := [][3]int{}

	fixed_arr1 := [3]int{}
	arr << fixed_arr1

	fixed_arr2 := [1, 2, 3]!
	arr << fixed_arr2

	println(arr)
	
	assert arr.len == 2
	assert '${arr[0]}' == '[0, 0, 0]'
	assert '${arr[1]}' == '[1, 2, 3]'
}

PS D:\Test\v\tt1> v run .
[[0, 0, 0], [1, 2, 3]]
```