### PR TITLE
checker: fix error for returning optional (fix #13896)

### DIFF
--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -148,7 +148,7 @@ pub fn (mut c Checker) return_stmt(mut node ast.Return) {
 	if exp_is_optional && node.exprs.len > 0 {
 		expr0 := node.exprs[0]
 		if expr0 is ast.CallExpr {
-			if expr0.or_block.kind == .propagate {
+			if expr0.or_block.kind == .propagate && node.exprs.len == 1 {
 				c.error('`?` is not needed, use `return ${expr0.name}()`', expr0.pos)
 			}
 		}

--- a/vlib/v/tests/return_optional_test.v
+++ b/vlib/v/tests/return_optional_test.v
@@ -1,0 +1,14 @@
+fn func1() ?int {
+	return 0
+}
+
+fn func2() ?(int, int) {
+	return func1() ?, 1
+}
+
+fn test_return_optional() ? {
+	a, b := func2() ?
+	println('$a, $b')
+	assert a == 0
+	assert b == 1
+}


### PR DESCRIPTION
This PR fix error for returning optional (fix #13896).

- Fix error for returning optional.
- Add test.

```v
fn func1() ?int {
	return 0
}

fn func2() ?(int, int) {
	return func1() ?, 1
}

fn main() {
	a, b := func2() ?
	println('$a, $b')
	assert a == 0
	assert b == 1
}

PS D:\Test\v\tt1> v run .
0, 1
```