### PR TITLE
array: minor optimization of push() and push_noscan()

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -587,7 +587,7 @@ fn (mut a array) push(val voidptr) {
 	if a.len >= a.cap {
 		a.ensure_cap(a.len + 1)
 	}
-	unsafe { vmemmove(&byte(a.data) + a.element_size * a.len, val, a.element_size) }
+	unsafe { vmemcpy(&byte(a.data) + a.element_size * a.len, val, a.element_size) }
 	a.len++
 }
 

--- a/vlib/builtin/array_d_gcboehm_opt.v
+++ b/vlib/builtin/array_d_gcboehm_opt.v
@@ -213,7 +213,7 @@ fn (a &array) clone_to_depth_noscan(depth int) array {
 
 fn (mut a array) push_noscan(val voidptr) {
 	a.ensure_cap_noscan(a.len + 1)
-	unsafe { vmemmove(&byte(a.data) + a.element_size * a.len, val, a.element_size) }
+	unsafe { vmemcpy(&byte(a.data) + a.element_size * a.len, val, a.element_size) }
 	a.len++
 }
 


### PR DESCRIPTION
This PR makes a minor optimization of push() and push_noscan().

- Use `vmemcpy` instead of `vmemmove`.