### PR TITLE
builtin/array: add `drop` method

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -339,6 +339,9 @@ pub fn (mut a array) trim(index int) {
 // assert a.cap > a.len
 // ```
 pub fn (mut a array) drop(num int) {
+	if num <= 0 {
+		return
+	}
 	n := if num <= a.len { num } else { a.len }
 	blen := n * a.element_size
 	a.data = unsafe { &byte(a.data) + blen }

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -330,7 +330,7 @@ pub fn (mut a array) trim(index int) {
 
 // drop advances the array past the first `num` elements whilst preserving spare capacity.
 // If `num` is greater than `len` the array will be emptied.
-// Example: 
+// Example:
 // ```v
 // mut a := [1,2]
 // a << 3
@@ -339,7 +339,7 @@ pub fn (mut a array) trim(index int) {
 // assert a.cap > a.len
 // ```
 pub fn (mut a array) drop(num int) {
-	n := if num <= a.len { num } else {a.len}
+	n := if num <= a.len { num } else { a.len }
 	blen := n * a.element_size
 	a.data = unsafe { &byte(a.data) + blen }
 	a.offset += blen

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -328,6 +328,25 @@ pub fn (mut a array) trim(index int) {
 	}
 }
 
+// drop advances the array past the first `num` elements whilst preserving spare capacity.
+// If `num` is greater than `len` the array will be emptied.
+// Example: 
+// ```v
+// mut a := [1,2]
+// a << 3
+// a.drop(2)
+// assert a == [3]
+// assert a.cap > a.len
+// ```
+pub fn (mut a array) drop(num int) {
+	n := if num <= a.len { num } else {a.len}
+	blen := n * a.element_size
+	a.data = unsafe { &byte(a.data) + blen }
+	a.offset += blen
+	a.len -= n
+	a.cap -= n
+}
+
 // we manually inline this for single operations for performance without -prod
 [inline; unsafe]
 fn (a array) get_unsafe(i int) voidptr {

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1047,17 +1047,17 @@ fn test_trim() {
 }
 
 fn test_drop() {
-	mut a := [1,2]
+	mut a := [1, 2]
 	a << 3 // should reallocate
-	
+
 	a.drop(2)
 	assert a == [3]
 	assert a.cap > a.len
-	
+
 	a.drop(10)
 	assert a == []
 	assert a.cap > a.len
-	
+
 	unsafe { a.free() } // test offset OK
 }
 

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1046,6 +1046,21 @@ fn test_trim() {
 	assert arr.last() == 2
 }
 
+fn test_drop() {
+	mut a := [1,2]
+	a << 3 // should reallocate
+	
+	a.drop(2)
+	assert a == [3]
+	assert a.cap > a.len
+	
+	a.drop(10)
+	assert a == []
+	assert a.cap > a.len
+	
+	unsafe { a.free() } // test offset OK
+}
+
 fn test_hex() {
 	// array hex
 	st := [byte(`V`), `L`, `A`, `N`, `G`]

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1046,17 +1046,36 @@ fn test_trim() {
 	assert arr.last() == 2
 }
 
+[manualfree]
 fn test_drop() {
 	mut a := [1, 2]
-	a << 3 // should reallocate
+	a << 3 // pushing assures reallocation; a.cap now should be bigger:
+	assert a.cap > 3
+	// eprintln('>>> a.cap: $a.cap | a.len: $a.len')
+
+	a.drop(-1000)
+	assert a == [1, 2, 3] // a.drop( negative ) should NOT modify the array
+	// eprintln('>>> a.cap: $a.cap | a.len: $a.len')
 
 	a.drop(2)
 	assert a == [3]
 	assert a.cap > a.len
+	// eprintln('>>> a.cap: $a.cap | a.len: $a.len')
 
 	a.drop(10)
 	assert a == []
 	assert a.cap > a.len
+	// eprintln('>>> a.cap: $a.cap | a.len: $a.len')
+
+	a << 123
+	a << 456
+	a << 789
+	// eprintln('>>> a.cap: $a.cap | a.len: $a.len')
+	assert a == [123, 456, 789]
+
+	a.drop(10)
+	assert a == []
+	// eprintln('>>> a.cap: $a.cap | a.len: $a.len')
 
 	unsafe { a.free() } // test offset OK
 }


### PR DESCRIPTION
Skip elements at the start of the array.
Any spare capacity is preserved, unlike slicing.
This is the counterpart of [`trim`](https://modules.vlang.io/index.html#array.trim).

### Naming
`drop` is used in Haskell, D, Scala, Kotlin.
`shift` is used in JS but `num` is always 1.
`shift` is used in bash with optional `num` but the array is implicit.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
