### PR TITLE
cli: add automatic manpage generation

### DIFF
--- a/vlib/cli/man.v
+++ b/vlib/cli/man.v
@@ -1,0 +1,181 @@
+module cli
+
+import time
+
+fn man_flag() Flag {
+	return Flag{
+		flag: .bool
+		name: 'man'
+		description: 'Prints the auto-generated manpage.'
+	}
+}
+
+fn man_cmd() Command {
+	return Command{
+		name: 'man'
+		usage: '<subcommand>'
+		description: 'Prints the auto-generated manpage.'
+		execute: print_manpage_for_command
+	}
+}
+
+// print_manpage_for_command prints the manpage for the
+// command or subcommand in `man_cmd` to stdout
+pub fn print_manpage_for_command(man_cmd Command) ? {
+	if man_cmd.args.len > 0 {
+		mut cmd := man_cmd.parent
+		for arg in man_cmd.args {
+			mut found := false
+			for sub_cmd in cmd.commands {
+				if sub_cmd.name == arg {
+					cmd = unsafe { &sub_cmd }
+					found = true
+					break
+				}
+			}
+			if !found {
+				args := man_cmd.args.join(' ')
+				println('Invalid command: $args')
+				return
+			}
+		}
+		print(cmd.manpage())
+	} else {
+		if man_cmd.parent != 0 {
+			print(man_cmd.parent.manpage())
+		}
+	}
+}
+
+// manpage returns a `string` containing the mdoc(7) manpage for
+// this `Command`
+pub fn (cmd Command) manpage() string {
+	mut mdoc := '.Dd ${time.now().strftime('%B %d, %Y')}\n'
+	mdoc += '.Dt ${cmd.full_name().replace(' ', '-').to_upper()} 1\n'
+	mdoc += '.Os\n.Sh NAME\n.Nm ${cmd.full_name().replace(' ', '-')}\n.Nd $cmd.description\n'
+	mdoc += '.Sh SYNOPSIS\n'
+	mdoc += '.Nm $cmd.root().name\n'
+	if cmd.parent != 0 {
+		mut parents := []Command{}
+		if !cmd.parent.is_root() {
+			parents.prepend(cmd.parent)
+			for {
+				p := parents[0]
+				if p.parent.is_root() {
+					break
+				} else {
+					parents.prepend(p.parent)
+				}
+			}
+			for c in parents {
+				mdoc += '.Ar $c.name\n'
+			}
+		}
+		mdoc += '.Ar $cmd.name\n'
+	}
+	for flag in cmd.flags {
+		mdoc += '.Op'
+		if flag.abbrev != '' {
+			mdoc += ' Fl $flag.abbrev'
+		} else {
+			if cmd.posix_mode {
+				mdoc += ' Fl -$flag.name'
+			} else {
+				mdoc += ' Fl $flag.name'
+			}
+		}
+		match flag.flag {
+			.int, .float, .int_array, .float_array { mdoc += ' Ar num' }
+			.string, .string_array { mdoc += ' Ar string' }
+			else {}
+		}
+		mdoc += '\n'
+	}
+	for i in 0 .. cmd.required_args {
+		mdoc += '.Ar arg$i\n'
+	}
+	if cmd.commands.len > 0 {
+		mdoc += '.Nm $cmd.root().name\n'
+		if cmd.parent != 0 {
+			mut parents := []Command{}
+			if !cmd.parent.is_root() {
+				parents.prepend(cmd.parent)
+				for {
+					p := parents[0]
+					if p.parent.is_root() {
+						break
+					} else {
+						parents.prepend(p.parent)
+					}
+				}
+				for c in parents {
+					mdoc += '.Ar $c.name\n'
+				}
+			}
+			mdoc += '.Ar $cmd.name\n'
+		}
+		mdoc += '.Ar subcommand\n'
+	}
+
+	mdoc += '.Sh DESCRIPTION\n'
+	if cmd.man_description != '' {
+		mdoc += '$cmd.man_description\n'
+	} else if cmd.description != '' {
+		mdoc += '$cmd.description\n'
+	}
+	if cmd.flags.len > 0 {
+		mdoc += '.Pp\nThe options are as follows:\n'
+		mdoc += '.Bl -tag -width indent\n'
+		for flag in cmd.flags {
+			mdoc += '.It'
+			if flag.abbrev != '' {
+				mdoc += ' Fl $flag.abbrev'
+			}
+			if cmd.posix_mode {
+				mdoc += ' Fl -$flag.name'
+			} else {
+				mdoc += ' Fl $flag.name'
+			}
+			mdoc += '\n'
+			if flag.description != '' {
+				mdoc += '$flag.description\n'
+			}
+		}
+		mdoc += '.El\n'
+	}
+	if cmd.commands.len > 0 {
+		mdoc += '.Pp\nThe subcommands are as follows:\n'
+		mdoc += '.Bl -tag -width indent\n'
+		for c in cmd.commands {
+			mdoc += '.It Cm $c.name\n'
+			if c.description != '' {
+				mdoc += '$c.description\n'
+			}
+		}
+		mdoc += '.El\n'
+	}
+
+	if cmd.commands.len > 0 {
+		mdoc += '.Sh SEE ALSO\n'
+		mut cmds := []string{}
+		if cmd.parent != 0 {
+			cmds << cmd.parent.full_name().replace(' ', '-')
+		}
+		for c in cmd.commands {
+			cmds << c.full_name().replace(' ', '-')
+		}
+		cmds.sort()
+		mut i := 1
+		for c in cmds {
+			mdoc += '.Xr $c 1'
+			if i == cmds.len {
+				mdoc += '\n'
+			} else {
+				mdoc += ' ,\n'
+			}
+			i++
+		}
+	}
+
+	return mdoc
+}

--- a/vlib/cli/man_test.v
+++ b/vlib/cli/man_test.v
@@ -1,0 +1,110 @@
+module cli
+
+fn test_manpage() {
+	mut cmd := Command{
+		name: 'command'
+		description: 'description'
+		commands: [
+			Command{
+				name: 'sub'
+				description: 'subcommand'
+			},
+			Command{
+				name: 'sub2'
+				description: 'another subcommand'
+			},
+		]
+		flags: [
+			Flag{
+				flag: .string
+				name: 'str'
+				description: 'str flag'
+			},
+			Flag{
+				flag: .bool
+				name: 'bool'
+				description: 'bool flag'
+				abbrev: 'b'
+			},
+			Flag{
+				flag: .string
+				name: 'required'
+				abbrev: 'r'
+				required: true
+			},
+		]
+	}
+	cmd.setup()
+	assert cmd.manpage().after_char(`\n`) == r'.Dt COMMAND 1
+.Os
+.Sh NAME
+.Nm command
+.Nd description
+.Sh SYNOPSIS
+.Nm command
+.Op Fl str Ar string
+.Op Fl b
+.Op Fl r Ar string
+.Nm command
+.Ar subcommand
+.Sh DESCRIPTION
+description
+.Pp
+The options are as follows:
+.Bl -tag -width indent
+.It Fl str
+str flag
+.It Fl b Fl bool
+bool flag
+.It Fl r Fl required
+.El
+.Pp
+The subcommands are as follows:
+.Bl -tag -width indent
+.It Cm sub
+subcommand
+.It Cm sub2
+another subcommand
+.El
+.Sh SEE ALSO
+.Xr command-sub 1 ,
+.Xr command-sub2 1
+'
+
+	cmd.posix_mode = true
+	assert cmd.manpage().after_char(`\n`) == r'.Dt COMMAND 1
+.Os
+.Sh NAME
+.Nm command
+.Nd description
+.Sh SYNOPSIS
+.Nm command
+.Op Fl -str Ar string
+.Op Fl b
+.Op Fl r Ar string
+.Nm command
+.Ar subcommand
+.Sh DESCRIPTION
+description
+.Pp
+The options are as follows:
+.Bl -tag -width indent
+.It Fl -str
+str flag
+.It Fl b Fl -bool
+bool flag
+.It Fl r Fl -required
+.El
+.Pp
+The subcommands are as follows:
+.Bl -tag -width indent
+.It Cm sub
+subcommand
+.It Cm sub2
+another subcommand
+.El
+.Sh SEE ALSO
+.Xr command-sub 1 ,
+.Xr command-sub2 1
+'
+}

--- a/vlib/v/tests/inout/cli_root_default_help.vv
+++ b/vlib/v/tests/inout/cli_root_default_help.vv
@@ -3,5 +3,6 @@ import os
 
 fn main() {
 	mut cmd := Command {}
+	cmd.disable_man = true
 	cmd.parse(os.args)
 }


### PR DESCRIPTION
This will generate a man page in the mdoc(7) format based off of the
cli.Command{} struct.

Example output:
```
%  v run test.v | mandoc -Owidth=46 -Ios=V | col -b
COMMAND(1)  General Commands Manual COMMAND(1)

NAME
     command – description

SYNOPSIS
     command [-str string] [-b] [-r string]
     command subcommand

DESCRIPTION
     description

     The options are as follows:

     -str    str flag

     -b -bool
             bool flag

     -r -required

     The subcommands are as follows:

     sub     subcommand

     sub2    another subcommand

SEE ALSO
     command-sub(1), command-sub2(1)

V                April 2, 2022               V
```



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
