### PR TITLE
clipboard: add doc strings to all implementations

### DIFF
--- a/vlib/clipboard/clipboard_android.c.v
+++ b/vlib/clipboard/clipboard_android.c.v
@@ -4,8 +4,7 @@ import clipboard.dummy
 
 // Clipboard represents a system clipboard.
 //
-// The system clipboard is what "copy" and "paste" actions
-// utilize.
+// System "copy" and "paste" actions utilize the clipboard for temporary storage.
 pub type Clipboard = dummy.Clipboard
 
 fn new_clipboard() &Clipboard {

--- a/vlib/clipboard/clipboard_android.c.v
+++ b/vlib/clipboard/clipboard_android.c.v
@@ -2,6 +2,9 @@ module clipboard
 
 import clipboard.dummy
 
+// Clipboard represents a system clipboard.
+// The system clipboard is what "copy" and "paste" actions
+// utilize.
 pub type Clipboard = dummy.Clipboard
 
 fn new_clipboard() &Clipboard {

--- a/vlib/clipboard/clipboard_android.c.v
+++ b/vlib/clipboard/clipboard_android.c.v
@@ -3,6 +3,7 @@ module clipboard
 import clipboard.dummy
 
 // Clipboard represents a system clipboard.
+//
 // The system clipboard is what "copy" and "paste" actions
 // utilize.
 pub type Clipboard = dummy.Clipboard

--- a/vlib/clipboard/clipboard_darwin.c.v
+++ b/vlib/clipboard/clipboard_darwin.c.v
@@ -5,6 +5,9 @@ module clipboard
 #flag -framework Cocoa
 #include "@VEXEROOT/vlib/clipboard/clipboard_darwin.m"
 
+// Clipboard represents a system clipboard.
+// The system clipboard is what "copy" and "paste" actions
+// utilize.
 pub struct Clipboard {
 	pb             voidptr
 	last_cb_serial i64
@@ -25,21 +28,28 @@ fn new_clipboard() &Clipboard {
 	return cb
 }
 
+// check_availability returns true if the clipboard is ready to be used
+// on the current platform.
 pub fn (cb &Clipboard) check_availability() bool {
 	return cb.pb != C.NULL
 }
 
+// clear clears the clipboard contents.
 pub fn (mut cb Clipboard) clear() {
 	cb.foo = 0
 	cb.set_text('')
 	//#[cb->pb clearContents];
 }
 
+// free frees all memory associated with the clipboard
+// instance.
 pub fn (mut cb Clipboard) free() {
 	cb.foo = 0
 	// nothing to free
 }
 
+// has_ownership returns true if the contents of
+// the clipboard was issued by this clipboard instance.
 pub fn (cb &Clipboard) has_ownership() bool {
 	if cb.last_cb_serial == 0 {
 		return false
@@ -50,10 +60,15 @@ pub fn (cb &Clipboard) has_ownership() bool {
 
 fn C.OSAtomicCompareAndSwapLong()
 
+// set_text transfers `text` to the system clipboard.
+// This is often associated with a *copy* action (`Ctrl` + `C`).
 pub fn (mut cb Clipboard) set_text(text string) bool {
 	return C.darwin_set_pasteboard_text(cb.pb, text)
 }
 
+// get_text retrieves the contents of the system clipboard
+// as a `string`.
+// This is often associated with a *paste* action (`Ctrl` + `V`).
 pub fn (mut cb Clipboard) get_text() string {
 	cb.foo = 0
 	if isnil(cb.pb) {

--- a/vlib/clipboard/clipboard_darwin.c.v
+++ b/vlib/clipboard/clipboard_darwin.c.v
@@ -61,14 +61,14 @@ pub fn (cb &Clipboard) has_ownership() bool {
 fn C.OSAtomicCompareAndSwapLong()
 
 // set_text transfers `text` to the system clipboard.
-// This is often associated with a *copy* action (`Ctrl` + `C`).
+// This is often associated with a *copy* action (`Cmd` + `C`).
 pub fn (mut cb Clipboard) set_text(text string) bool {
 	return C.darwin_set_pasteboard_text(cb.pb, text)
 }
 
 // get_text retrieves the contents of the system clipboard
 // as a `string`.
-// This is often associated with a *paste* action (`Ctrl` + `V`).
+// This is often associated with a *paste* action (`Cmd` + `V`).
 pub fn (mut cb Clipboard) get_text() string {
 	cb.foo = 0
 	if isnil(cb.pb) {

--- a/vlib/clipboard/clipboard_darwin.c.v
+++ b/vlib/clipboard/clipboard_darwin.c.v
@@ -7,8 +7,7 @@ module clipboard
 
 // Clipboard represents a system clipboard.
 //
-// The system clipboard is what "copy" and "paste" actions
-// utilize.
+// System "copy" and "paste" actions utilize the clipboard for temporary storage.
 pub struct Clipboard {
 	pb             voidptr
 	last_cb_serial i64
@@ -29,20 +28,19 @@ fn new_clipboard() &Clipboard {
 	return cb
 }
 
-// check_availability returns true if the clipboard is ready to be used
-// on the current platform.
+// check_availability returns true if the clipboard is ready to be used.
 pub fn (cb &Clipboard) check_availability() bool {
 	return cb.pb != C.NULL
 }
 
-// clear clears the clipboard contents.
+// clear empties the clipboard contents.
 pub fn (mut cb Clipboard) clear() {
 	cb.foo = 0
 	cb.set_text('')
 	//#[cb->pb clearContents];
 }
 
-// free frees all memory associated with the clipboard
+// free releases all memory associated with the clipboard
 // instance.
 pub fn (mut cb Clipboard) free() {
 	cb.foo = 0
@@ -50,7 +48,7 @@ pub fn (mut cb Clipboard) free() {
 }
 
 // has_ownership returns true if the contents of
-// the clipboard was issued by this clipboard instance.
+// the clipboard were created by this clipboard instance.
 pub fn (cb &Clipboard) has_ownership() bool {
 	if cb.last_cb_serial == 0 {
 		return false

--- a/vlib/clipboard/clipboard_darwin.c.v
+++ b/vlib/clipboard/clipboard_darwin.c.v
@@ -6,6 +6,7 @@ module clipboard
 #include "@VEXEROOT/vlib/clipboard/clipboard_darwin.m"
 
 // Clipboard represents a system clipboard.
+//
 // The system clipboard is what "copy" and "paste" actions
 // utilize.
 pub struct Clipboard {

--- a/vlib/clipboard/clipboard_default.c.v
+++ b/vlib/clipboard/clipboard_default.c.v
@@ -3,6 +3,7 @@ module clipboard
 import clipboard.x11
 
 // Clipboard represents a system clipboard.
+//
 // The system clipboard is what "copy" and "paste" actions
 // utilize.
 pub type Clipboard = x11.Clipboard

--- a/vlib/clipboard/clipboard_default.c.v
+++ b/vlib/clipboard/clipboard_default.c.v
@@ -4,8 +4,7 @@ import clipboard.x11
 
 // Clipboard represents a system clipboard.
 //
-// The system clipboard is what "copy" and "paste" actions
-// utilize.
+// System "copy" and "paste" actions utilize the clipboard for temporary storage.
 pub type Clipboard = x11.Clipboard
 
 fn new_clipboard() &Clipboard {

--- a/vlib/clipboard/clipboard_default.c.v
+++ b/vlib/clipboard/clipboard_default.c.v
@@ -2,6 +2,9 @@ module clipboard
 
 import clipboard.x11
 
+// Clipboard represents a system clipboard.
+// The system clipboard is what "copy" and "paste" actions
+// utilize.
 pub type Clipboard = x11.Clipboard
 
 fn new_clipboard() &Clipboard {

--- a/vlib/clipboard/clipboard_solaris.c.v
+++ b/vlib/clipboard/clipboard_solaris.c.v
@@ -4,8 +4,7 @@ import clipboard.dummy
 
 // Clipboard represents a system clipboard.
 //
-// The system clipboard is what "copy" and "paste" actions
-// utilize.
+// System "copy" and "paste" actions utilize the clipboard for temporary storage.
 pub type Clipboard = dummy.Clipboard
 
 fn new_clipboard() &Clipboard {

--- a/vlib/clipboard/clipboard_solaris.c.v
+++ b/vlib/clipboard/clipboard_solaris.c.v
@@ -2,6 +2,9 @@ module clipboard
 
 import clipboard.dummy
 
+// Clipboard represents a system clipboard.
+// The system clipboard is what "copy" and "paste" actions
+// utilize.
 pub type Clipboard = dummy.Clipboard
 
 fn new_clipboard() &Clipboard {

--- a/vlib/clipboard/clipboard_solaris.c.v
+++ b/vlib/clipboard/clipboard_solaris.c.v
@@ -3,6 +3,7 @@ module clipboard
 import clipboard.dummy
 
 // Clipboard represents a system clipboard.
+//
 // The system clipboard is what "copy" and "paste" actions
 // utilize.
 pub type Clipboard = dummy.Clipboard

--- a/vlib/clipboard/clipboard_windows.c.v
+++ b/vlib/clipboard/clipboard_windows.c.v
@@ -52,6 +52,7 @@ fn C.OpenClipboard(hwnd C.HWND) int
 fn C.DestroyWindow(hwnd C.HWND)
 
 // Clipboard represents a system clipboard.
+//
 // The system clipboard is what "copy" and "paste" actions
 // utilize.
 struct Clipboard {

--- a/vlib/clipboard/clipboard_windows.c.v
+++ b/vlib/clipboard/clipboard_windows.c.v
@@ -53,8 +53,7 @@ fn C.DestroyWindow(hwnd C.HWND)
 
 // Clipboard represents a system clipboard.
 //
-// The system clipboard is what "copy" and "paste" actions
-// utilize.
+// System "copy" and "paste" actions utilize the clipboard for temporary storage.
 struct Clipboard {
 	max_retries int
 	retry_delay int
@@ -108,19 +107,18 @@ fn new_clipboard() &Clipboard {
 	return cb
 }
 
-// check_availability returns true if the clipboard is ready to be used
-// on the current platform.
+// check_availability returns true if the clipboard is ready to be used.
 pub fn (cb &Clipboard) check_availability() bool {
 	return cb.hwnd != C.HWND(C.NULL)
 }
 
 // has_ownership returns true if the contents of
-// the clipboard was issued by this clipboard instance.
+// the clipboard were created by this clipboard instance.
 pub fn (cb &Clipboard) has_ownership() bool {
 	return C.GetClipboardOwner() == cb.hwnd
 }
 
-// clear clears the clipboard contents.
+// clear empties the clipboard contents.
 pub fn (mut cb Clipboard) clear() {
 	if !cb.get_clipboard_lock() {
 		return
@@ -130,7 +128,7 @@ pub fn (mut cb Clipboard) clear() {
 	cb.foo = 0
 }
 
-// free frees all memory associated with the clipboard
+// free releases all memory associated with the clipboard
 // instance.
 pub fn (mut cb Clipboard) free() {
 	C.DestroyWindow(cb.hwnd)

--- a/vlib/clipboard/clipboard_windows.c.v
+++ b/vlib/clipboard/clipboard_windows.c.v
@@ -51,6 +51,9 @@ fn C.OpenClipboard(hwnd C.HWND) int
 
 fn C.DestroyWindow(hwnd C.HWND)
 
+// Clipboard represents a system clipboard.
+// The system clipboard is what "copy" and "paste" actions
+// utilize.
 struct Clipboard {
 	max_retries int
 	retry_delay int
@@ -104,14 +107,19 @@ fn new_clipboard() &Clipboard {
 	return cb
 }
 
+// check_availability returns true if the clipboard is ready to be used
+// on the current platform.
 pub fn (cb &Clipboard) check_availability() bool {
 	return cb.hwnd != C.HWND(C.NULL)
 }
 
+// has_ownership returns true if the contents of
+// the clipboard was issued by this clipboard instance.
 pub fn (cb &Clipboard) has_ownership() bool {
 	return C.GetClipboardOwner() == cb.hwnd
 }
 
+// clear clears the clipboard contents.
 pub fn (mut cb Clipboard) clear() {
 	if !cb.get_clipboard_lock() {
 		return
@@ -121,6 +129,8 @@ pub fn (mut cb Clipboard) clear() {
 	cb.foo = 0
 }
 
+// free frees all memory associated with the clipboard
+// instance.
 pub fn (mut cb Clipboard) free() {
 	C.DestroyWindow(cb.hwnd)
 	cb.foo = 0
@@ -143,6 +153,8 @@ fn to_wide(text string) C.HGLOBAL {
 	return buf
 }
 
+// set_text transfers `text` to the system clipboard.
+// This is often associated with a *copy* action (`Ctrl` + `C`).
 pub fn (mut cb Clipboard) set_text(text string) bool {
 	cb.foo = 0
 	buf := to_wide(text)
@@ -164,6 +176,9 @@ pub fn (mut cb Clipboard) set_text(text string) bool {
 	return true
 }
 
+// get_text retrieves the contents of the system clipboard
+// as a `string`.
+// This is often associated with a *paste* action (`Ctrl` + `V`).
 pub fn (mut cb Clipboard) get_text() string {
 	cb.foo = 0
 	if !cb.get_clipboard_lock() {

--- a/vlib/clipboard/dummy/dummy_clipboard.v
+++ b/vlib/clipboard/dummy/dummy_clipboard.v
@@ -1,8 +1,8 @@
 module dummy
 
 // Clipboard represents a system clipboard.
-// The system clipboard is what "copy" and "paste" actions
-// utilize.
+//
+// System "copy" and "paste" actions utilize the clipboard for temporary storage.
 pub struct Clipboard {
 mut:
 	text     string // text data sent or received
@@ -38,25 +38,24 @@ pub fn (mut cb Clipboard) get_text() string {
 	return cb.text
 }
 
-// clear clears the clipboard contents.
+// clear empties the clipboard contents.
 pub fn (mut cb Clipboard) clear() {
 	cb.text = ''
 	cb.is_owner = false
 }
 
-// free frees all memory associated with the clipboard
+// free releases all memory associated with the clipboard
 // instance.
 pub fn (mut cb Clipboard) free() {
 }
 
 // has_ownership returns true if the contents of
-// the clipboard was issued by this clipboard instance.
+// the clipboard were created by this clipboard instance.
 pub fn (cb &Clipboard) has_ownership() bool {
 	return cb.is_owner
 }
 
-// check_availability returns true if the clipboard is ready to be used
-// on the current platform.
+// check_availability returns true if the clipboard is ready to be used.
 pub fn (cb &Clipboard) check_availability() bool {
 	// This is a dummy clipboard implementation,
 	// which can be always used, although it does not do much...

--- a/vlib/clipboard/dummy/dummy_clipboard.v
+++ b/vlib/clipboard/dummy/dummy_clipboard.v
@@ -1,5 +1,8 @@
 module dummy
 
+// Clipboard represents a system clipboard.
+// The system clipboard is what "copy" and "paste" actions
+// utilize.
 pub struct Clipboard {
 mut:
 	text     string // text data sent or received
@@ -19,6 +22,8 @@ pub fn new_primary() &Clipboard {
 	return &Clipboard{}
 }
 
+// set_text transfers `text` to the system clipboard.
+// This is often associated with a *copy* action (`Ctrl` + `C`).
 pub fn (mut cb Clipboard) set_text(text string) bool {
 	cb.text = text
 	cb.is_owner = true
@@ -26,22 +31,32 @@ pub fn (mut cb Clipboard) set_text(text string) bool {
 	return true
 }
 
+// get_text retrieves the contents of the system clipboard
+// as a `string`.
+// This is often associated with a *paste* action (`Ctrl` + `V`).
 pub fn (mut cb Clipboard) get_text() string {
 	return cb.text
 }
 
+// clear clears the clipboard contents.
 pub fn (mut cb Clipboard) clear() {
 	cb.text = ''
 	cb.is_owner = false
 }
 
+// free frees all memory associated with the clipboard
+// instance.
 pub fn (mut cb Clipboard) free() {
 }
 
+// has_ownership returns true if the contents of
+// the clipboard was issued by this clipboard instance.
 pub fn (cb &Clipboard) has_ownership() bool {
 	return cb.is_owner
 }
 
+// check_availability returns true if the clipboard is ready to be used
+// on the current platform.
 pub fn (cb &Clipboard) check_availability() bool {
 	// This is a dummy clipboard implementation,
 	// which can be always used, although it does not do much...


### PR DESCRIPTION
Ticks a few boxes in #7047 when merged