### PR TITLE
vdoc: highlight terminal examples for `-comments -color`

### DIFF
--- a/cmd/tools/vdoc/utils.v
+++ b/cmd/tools/vdoc/utils.v
@@ -161,6 +161,13 @@ fn color_highlight(code string, tb &ast.Table) string {
 			.char {
 				lit = term.yellow('`$tok.lit`')
 			}
+			.comment {
+				lit = if tok.lit[0] == 1 {
+					'//${tok.lit[1..]}'
+				} else {
+					'//$tok.lit'
+				}
+			}
 			.keyword {
 				lit = term.bright_blue(tok.lit)
 			}

--- a/cmd/tools/vdoc/utils.v
+++ b/cmd/tools/vdoc/utils.v
@@ -162,11 +162,7 @@ fn color_highlight(code string, tb &ast.Table) string {
 				lit = term.yellow('`$tok.lit`')
 			}
 			.comment {
-				lit = if tok.lit[0] == 1 {
-					'//${tok.lit[1..]}'
-				} else {
-					'//$tok.lit'
-				}
+				lit = if tok.lit[0] == 1 { '//${tok.lit[1..]}' } else { '//$tok.lit' }
 			}
 			.keyword {
 				lit = term.bright_blue(tok.lit)

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -104,11 +104,15 @@ fn (vd VDoc) gen_plaintext(d doc.Doc) string {
 			d.head.merge_comments_without_examples()
 		}
 		if comments.trim_space().len > 0 {
-			pw.writeln(comments.split_into_lines().map('    ' + it).join('\n'))
+			pw.writeln(indent(comments))
 		}
 	}
 	vd.write_plaintext_content(d.contents.arr(), mut pw)
 	return pw.str()
+}
+
+fn indent(s string) string {
+	return '    ' + s.replace('\n', '\n    ')
 }
 
 fn (vd VDoc) write_plaintext_content(contents []doc.DocNode, mut pw strings.Builder) {
@@ -121,12 +125,24 @@ fn (vd VDoc) write_plaintext_content(contents []doc.DocNode, mut pw strings.Buil
 				pw.writeln(cn.content)
 			}
 			if cn.comments.len > 0 && cfg.include_comments {
-				comments := if cfg.include_examples {
-					cn.merge_comments()
-				} else {
-					cn.merge_comments_without_examples()
+				comments := cn.merge_comments_without_examples()
+				pw.writeln(indent(comments.trim_space()))
+				if cfg.include_examples {
+					examples := cn.examples()
+					for ex in examples {
+						pw.write_string('    Example: ')
+						mut fex := ex
+						if ex.index_byte(`\n`) >= 0 {
+							// multi-line example
+							pw.write_byte(`\n`)
+							fex = indent(ex)
+						}
+						if cfg.is_color {
+							fex = color_highlight(fex, vd.docs[0].table)
+						}
+						pw.writeln(fex)
+					}
 				}
-				pw.writeln(comments.trim_space().split_into_lines().map('    ' + it).join('\n'))
 			}
 			if cfg.show_loc {
 				pw.writeln('Location: $cn.file_path:${cn.pos.line_nr + 1}\n')

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1098,6 +1098,7 @@ pub fn (s string) count(substr string) int {
 }
 
 // contains returns `true` if the string contains `substr`.
+// See also: [`string.index`](#string.index)
 pub fn (s string) contains(substr string) bool {
 	if substr.len == 0 {
 		return true


### PR DESCRIPTION
Screenshot from my test module:
![image](https://user-images.githubusercontent.com/1107820/161532840-a78fa29e-5f94-464a-9477-f609d983814d.png)

I'm not sure why the `// hi` comment is one char to the left.

Also use string.replace instead of split/map/join to indent.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
