### PR TITLE
vdoc: don't highlight less than expression as generic function

### DIFF
--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -326,8 +326,8 @@ fn html_highlight(code string, tb &ast.Table) string {
 						tok_typ = .builtin
 					} else if next_tok.kind == .lcbr {
 						tok_typ = .symbol
-					} else if next_tok.kind == .lpar
-						|| (!tok.lit[0].is_capital() && next_tok.kind == .lt && next_tok.pos == tok.pos + tok.lit.len) {
+					} else if next_tok.kind == .lpar || (!tok.lit[0].is_capital()
+						&& next_tok.kind == .lt && next_tok.pos == tok.pos + tok.lit.len) {
 						tok_typ = .function
 					} else {
 						tok_typ = .name

--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -327,7 +327,7 @@ fn html_highlight(code string, tb &ast.Table) string {
 					} else if next_tok.kind == .lcbr {
 						tok_typ = .symbol
 					} else if next_tok.kind == .lpar
-						|| (!tok.lit[0].is_capital() && next_tok.kind == .lt) {
+						|| (!tok.lit[0].is_capital() && next_tok.kind == .lt && next_tok.pos == tok.pos + tok.lit.len) {
 						tok_typ = .function
 					} else {
 						tok_typ = .name

--- a/cmd/tools/vdoc/utils.v
+++ b/cmd/tools/vdoc/utils.v
@@ -208,7 +208,8 @@ fn color_highlight(code string, tb &ast.Table) string {
 						&& prev.kind in [.name, .amp, .rsbr, .key_type, .assign, .dot, .question, .rpar, .key_struct, .key_enum, .pipe, .key_interface]
 						&& (tok.lit[0].is_capital() || prev_prev.lit in ['C', 'JS']) {
 						tok_typ = .symbol
-					} else if next_tok.kind in [.lpar, .lt] {
+					} else if next_tok.kind == .lpar
+						|| (!tok.lit[0].is_capital() && next_tok.kind == .lt && next_tok.pos == tok.pos + tok.lit.len) {
 						tok_typ = .function
 					} else if next_tok.kind == .dot {
 						if tok.lit in ['C', 'JS'] {

--- a/cmd/tools/vdoc/utils.v
+++ b/cmd/tools/vdoc/utils.v
@@ -208,8 +208,8 @@ fn color_highlight(code string, tb &ast.Table) string {
 						&& prev.kind in [.name, .amp, .rsbr, .key_type, .assign, .dot, .question, .rpar, .key_struct, .key_enum, .pipe, .key_interface]
 						&& (tok.lit[0].is_capital() || prev_prev.lit in ['C', 'JS']) {
 						tok_typ = .symbol
-					} else if next_tok.kind == .lpar
-						|| (!tok.lit[0].is_capital() && next_tok.kind == .lt && next_tok.pos == tok.pos + tok.lit.len) {
+					} else if next_tok.kind == .lpar || (!tok.lit[0].is_capital()
+						&& next_tok.kind == .lt && next_tok.pos == tok.pos + tok.lit.len) {
 						tok_typ = .function
 					} else if next_tok.kind == .dot {
 						if tok.lit in ['C', 'JS'] {


### PR DESCRIPTION
Refinement of merged #13923.
For both HTML and color terminal - the latter needs #13937 for example highlighting:

![image](https://user-images.githubusercontent.com/1107820/161539028-0936ba42-1805-42e7-a71f-c261370d4cd8.png)

Use whitespace as a heuristic.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
