### PR TITLE
cgen: fix error for const using nested optionals (fix #13914)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -121,6 +121,7 @@ mut:
 	inside_comptime_for_field bool
 	inside_cast_in_heap       int // inside cast to interface type in heap (resolve recursive calls)
 	inside_const              bool
+	inside_const_optional     bool
 	inside_lambda             bool
 	loop_depth                int
 	ternary_names             map[string]string
@@ -4174,11 +4175,13 @@ fn (mut g Gen) const_decl(node ast.ConstDecl) {
 			}
 			ast.CallExpr {
 				if field.expr.return_type.has_flag(.optional) {
+					g.inside_const_optional = true
 					unwrap_option := field.expr.or_block.kind != .absent
 					g.const_decl_init_later(field.mod, name, field.expr, field.typ, unwrap_option)
 				} else {
 					g.const_decl_init_later(field.mod, name, field.expr, field.typ, false)
 				}
+				g.inside_const_optional = false
 			}
 			else {
 				// Note: -usecache uses prebuilt modules, each compiled with:

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -698,7 +698,7 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 		} else if g.table.sym(node.return_type).kind == .multi_return {
 			g.write('\n $cur_line $tmp_opt /*U*/')
 		} else {
-			if !g.inside_const {
+			if !g.inside_const || !g.inside_const_optional {
 				g.write('\n $cur_line (*($unwrapped_styp*)${tmp_opt}.data)')
 			} else {
 				g.write('\n $cur_line $tmp_opt')

--- a/vlib/v/tests/const_use_nested_optionals_test.v
+++ b/vlib/v/tests/const_use_nested_optionals_test.v
@@ -1,0 +1,10 @@
+module main
+
+import os
+
+const iterations = (os.getenv_opt('ITERATIONS') or { '5' }).int()
+
+fn test_const_use_nested_optionals() {
+	println('Number of iterations: $iterations')
+	assert iterations == 5
+}


### PR DESCRIPTION
This PR fix error for const using nested optionals (fix #13914).

- Fix error for const using nested optionals.
- Add test.

```v
module main

import os

const iterations = (os.getenv_opt('ITERATIONS') or { '5' }).int()

fn main() {
	println('Number of iterations: $iterations')
	assert iterations == 5
}

PS D:\Test\v\tt1> v run .
Number of iterations: 5
```