### PR TITLE
ci: introduce v benchmarks inside the ci workflow

### DIFF
--- a/.github/workflows/ci_v_benchmark.yml
+++ b/.github/workflows/ci_v_benchmark.yml
@@ -1,0 +1,35 @@
+name: vlang benchmarks
+
+on:
+  push:
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
+
+jobs:
+  run:
+    name: Run
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install google benchmark
+      run: |
+          git clone https://github.com/google/benchmark.git
+          cd benchmark
+          cmake -E make_directory "build"
+          cmake -E chdir "build" cmake -DBENCHMARK_DOWNLOAD_DEPENDENCIES=on -DCMAKE_BUILD_TYPE=Release ../
+          sudo cmake --build "build" --config Release --target install
+    - name: Run V benchmark
+      run: |
+        make
+        sudo ./v symlink
+        git clone https://github.com/vincenzopalazzo/benchmarks.git
+        cd benchmarks
+        make vdep && make v
+    - uses: actions/upload-artifact@v3
+      with:
+        name: vlang-benchmark
+        path: benchmarks/vlang/*.json


### PR DESCRIPTION
This is one of many steps that bring inside the CI a complete benchmarks about V lang where will be possible to check if any feature introduced or bug fixed will introduce a decrease of performance with a gap that is accepted we will discuss when the checker is ready.

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
