### PR TITLE
cgen: fix error for optional multi return (fix #13956)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -471,7 +471,7 @@ fn (mut g Gen) gen_multi_return_assign(node &ast.AssignStmt, return_type ast.Typ
 	// TODO Handle in if_expr
 	is_opt := return_type.has_flag(.optional)
 	mr_var_name := 'mr_$node.pos.pos'
-	mr_styp := g.typ(return_type)
+	mr_styp := g.typ(return_type.clear_flag(.optional))
 	g.write('$mr_styp $mr_var_name = ')
 	g.expr(node.right[0])
 	g.writeln(';')
@@ -505,9 +505,9 @@ fn (mut g Gen) gen_multi_return_assign(node &ast.AssignStmt, return_type ast.Typ
 			if is_opt {
 				mr_base_styp := g.base_type(return_type)
 				if is_auto_heap {
-					g.writeln('HEAP${noscan}($mr_base_styp, *($mr_base_styp*)${mr_var_name}.data).arg$i) });')
+					g.writeln('HEAP${noscan}($mr_base_styp, ${mr_var_name}.arg$i) });')
 				} else {
-					g.writeln('(*($mr_base_styp*)${mr_var_name}.data).arg$i });')
+					g.writeln('${mr_var_name}.arg$i });')
 				}
 			} else {
 				if is_auto_heap {
@@ -520,9 +520,9 @@ fn (mut g Gen) gen_multi_return_assign(node &ast.AssignStmt, return_type ast.Typ
 			if is_opt {
 				mr_base_styp := g.base_type(return_type)
 				if is_auto_heap {
-					g.writeln(' = HEAP${noscan}($mr_base_styp, *($mr_base_styp*)${mr_var_name}.data).arg$i);')
+					g.writeln(' = HEAP${noscan}($mr_base_styp, ${mr_var_name}.arg$i);')
 				} else {
-					g.writeln(' = (*($mr_base_styp*)${mr_var_name}.data).arg$i;')
+					g.writeln(' = ${mr_var_name}.arg$i;')
 				}
 			} else {
 				if is_auto_heap {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -695,8 +695,6 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 		unwrapped_styp := g.typ(unwrapped_typ)
 		if unwrapped_typ == ast.void_type {
 			g.write('\n $cur_line')
-		} else if g.table.sym(node.return_type).kind == .multi_return {
-			g.write('\n $cur_line $tmp_opt /*U*/')
 		} else {
 			if !g.inside_const_optional {
 				g.write('\n $cur_line (*($unwrapped_styp*)${tmp_opt}.data)')

--- a/vlib/v/tests/optional_multi_return_test.v
+++ b/vlib/v/tests/optional_multi_return_test.v
@@ -1,0 +1,10 @@
+fn tuple() ?(int, int) {
+	return 1, 2
+}
+
+fn test_optional_multi_return() ? {
+	println(tuple() ?)
+	a, b := tuple() ?
+	assert a == 1
+	assert b == 2
+}


### PR DESCRIPTION
This PR fix error for optional multi return (fix #13956).

- Fix error for optional multi return.
- Add test.

```v
fn tuple() ?(int, int) {
	return 1, 2
}

fn main() {
	println(tuple() ?)
	a, b := tuple() ?
	assert a == 1
	assert b == 2
}

PS D:\Test\v\tt1> v run .
(1, 2)
```