### PR TITLE
gg: document pub functions in text_rendering and m4/vector

### DIFF
--- a/vlib/gg/m4/vector.v
+++ b/vlib/gg/m4/vector.v
@@ -22,6 +22,7 @@ pub mut:
 * Utility
 *
 *********************************************************************/
+// str returns a `string` representation of `Vec4`.
 pub fn (x Vec4) str() string {
 	return '|${x.e[0]:-6.3},${x.e[1]:-6.3},${x.e[2]:-6.3},${x.e[3]:-6.3}|'
 }

--- a/vlib/gg/text_rendering.c.v
+++ b/vlib/gg/text_rendering.c.v
@@ -118,6 +118,7 @@ fn new_ft(c FTConfig) ?&FT {
 	}
 }
 
+// set_cfg sets the current text configuration
 pub fn (ctx &Context) set_cfg(cfg gx.TextCfg) {
 	if !ctx.font_inited {
 		return
@@ -146,6 +147,8 @@ pub fn (ctx &Context) set_cfg(cfg gx.TextCfg) {
 	ctx.ft.fons.vert_metrics(&ascender, &descender, &lh)
 }
 
+// draw_text draws the string in `text_` starting at top-left position `x`,`y`.
+// Text settings can be provided with `cfg`.
 pub fn (ctx &Context) draw_text(x int, y int, text_ string, cfg gx.TextCfg) {
 	$if macos {
 		if ctx.native_rendering {
@@ -172,18 +175,18 @@ pub fn (ctx &Context) draw_text(x int, y int, text_ string, cfg gx.TextCfg) {
 	ctx.ft.fons.draw_text(x * scale, y * scale, text_) // TODO: check offsets/alignment
 }
 
+// draw_text draws the string in `text_` starting at top-left position `x`,`y` using
+// default text settings.
 pub fn (ctx &Context) draw_text_def(x int, y int, text string) {
 	ctx.draw_text(x, y, text)
 }
 
-/*
-pub fn (mut gg FT) init_font() {
-}
-*/
+// flush prepares the font for use.
 pub fn (ft &FT) flush() {
 	sfons.flush(ft.fons)
 }
 
+// text_width returns the width of the `string` `s` in pixels.
 pub fn (ctx &Context) text_width(s string) int {
 	$if macos {
 		if ctx.native_rendering {
@@ -210,6 +213,7 @@ pub fn (ctx &Context) text_width(s string) int {
 	return int((buf[2] - buf[0]) / ctx.scale)
 }
 
+// text_height returns the height of the `string` `s` in pixels.
 pub fn (ctx &Context) text_height(s string) int {
 	// ctx.set_cfg(cfg) TODO
 	if !ctx.font_inited {
@@ -220,6 +224,7 @@ pub fn (ctx &Context) text_height(s string) int {
 	return int((buf[3] - buf[1]) / ctx.scale)
 }
 
+// text_size returns the width and height of the `string` `s` in pixels.
 pub fn (ctx &Context) text_size(s string) (int, int) {
 	// ctx.set_cfg(cfg) TODO
 	if !ctx.font_inited {


### PR DESCRIPTION
This should tick off all of `gg` in #7047
(The rest of the functions reported by `missdoc` is false positives in block comments)