### PR TITLE
compilation: introduce a known error regarding the references mismatch

### DIFF
--- a/vlib/v/tests/known_errors/testdata/c_err_with_def.vv
+++ b/vlib/v/tests/known_errors/testdata/c_err_with_def.vv
@@ -1,0 +1,61 @@
+import math
+
+struct Vector{
+	x f64
+	y f64
+}
+
+struct Vector3d{
+	x f64
+	y f64
+	z f64
+}
+
+struct Position{
+	x f64
+	y f64
+}
+
+struct Position3d{
+	x f64
+	y f64
+	z f64
+}
+
+fn new_position (v &Vector, p &Position, time f32) Vector{
+	x := v.x*time
+	y := v.y*time
+	return Vector{p.x + x, p.y + y}
+}
+
+fn acceleration(u &Vector, v &Vector, time f32) Vector{
+	x := u.x+v.x/time
+	y := u.y+u.y/time
+	return Vector{x, y}
+}
+
+fn magnitude3d(v3d &Vector3d) f64{
+	return math.sqrt(math.pow(v3d.x,2)+math.pow(v3d.y,2)+math.pow(v3d.z,2))
+}
+
+fn magnitude(v &Vector) f64{
+	return math.sqrt(math.pow(v.x, 2)+math.pow(v.y, 2))
+
+}
+
+fn unit_vector(v &Vector) Vector{
+	x := v.x/magnitude(v)
+	y := v.y/magnitude(v)
+	return Vector{x, y}
+}
+
+fn unit_vector3d(v &Vector3d) Vector3d{
+	x := v.x/magnitude3d(v)
+	y := v.y/magnitude3d(v)
+	z := v.z/magnitude3d(v)
+	return Vector3d{x, y, z}
+}
+
+mut object := Vector{4,3}
+
+println(acceleration(Vector{0,0}, object, 5))


### PR DESCRIPTION
This PR introduces only a known problem that we had mentioned in this issue https://github.com/vlang/v/issues/13947 but doesn't solve it because the solution is pretty tricky, a draft of it can be found [here](https://github.com/vincenzopalazzo/v/tree/macros/reference_solution)

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
