### PR TITLE
cgen: fix optional with empty struct

### DIFF
--- a/vlib/json/json_decode_with_optional_arg_test.v
+++ b/vlib/json/json_decode_with_optional_arg_test.v
@@ -1,9 +1,7 @@
 import json
 import os
 
-struct DbConfig {
-	foo int
-}
+struct DbConfig {}
 
 fn test_json_decode_with_optional_arg() {
 	if ret := print_info() {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -972,7 +972,7 @@ fn (g Gen) optional_type_text(styp string, base string) string {
 	ret := 'struct $styp {
 	byte state;
 	IError err;
-	byte data[sizeof($size)];
+	byte data[sizeof($size) > 0 ? sizeof($size) : 1];
 }'
 	return ret
 }


### PR DESCRIPTION
This PR fix optional with empty struct.

- Fix optional with empty struct.
- Add test.

```v
import json
import os

struct DbConfig {}

fn test_json_decode_with_optional_arg() {
	if ret := print_info() {
		println(ret)
	} else {
		println(err)
	}
	assert true
}

fn print_info() ?string {
	dbconf := json.decode(DbConfig, os.read_file('dbconf.json') ?) ?
	println(dbconf)
	return '$dbconf'
}

PS D:\Test\v\tt1> v run .
failed to open file "dbconf.json"
```