### PR TITLE
clipboard: fix segfault when pasting to some X11 apps

### DIFF
--- a/vlib/clipboard/x11/clipboard.c.v
+++ b/vlib/clipboard/x11/clipboard.c.v
@@ -330,7 +330,7 @@ fn (mut cb Clipboard) start_listener() {
 						property: xsre.property
 					}
 					if !cb.transmit_selection(&xse) {
-						xse.property = new_atom(0)
+						xse.property = Atom(0)
 					}
 					C.XSendEvent(cb.display, xse.requestor, 0, C.PropertyChangeMask, voidptr(&xse))
 					C.XFlush(cb.display)
@@ -477,10 +477,6 @@ fn (cb &Clipboard) get_target_index(target Atom) int {
 
 fn (cb &Clipboard) get_supported_targets() []Atom {
 	return cb.get_atoms(AtomType.utf8_string, .xa_string, .text, .text_plain, .text_html)
-}
-
-fn new_atom(value int) &Atom {
-	return unsafe { &Atom(&u64(u64(value))) }
 }
 
 fn create_xwindow(display &C.Display) Window {


### PR DESCRIPTION
This PR fixes #13891

What I find a bit strange is that V let the old code even compile.

The source of the bug is the assignment done in: `xse.property = new_atom(0)`.

The weird thing is that `property` of `C.XSelectionEvent` is of type `Atom` - and `new_atom` returns `&Atom`??

Anyway - this PR fixes it so the Atom assigned is now on the stack of the running thread (I suspect that the crash was because the address of the previous &Atom messed with memory across the UI and event thread started with `go`).