### PR TITLE
vpm: simplify `v list` output

### DIFF
--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -445,12 +445,11 @@ fn vpm_outdated() {
 fn vpm_list() {
 	module_names := get_installed_modules()
 	if module_names.len == 0 {
-		println('You have no modules installed.')
+		eprintln('You have no modules installed.')
 		exit(0)
 	}
-	println('Installed modules:')
 	for mod in module_names {
-		println('  $mod')
+		println(mod)
 	}
 }
 


### PR DESCRIPTION
i think that `v list` should print the output without indenting or header, so its easier for 3rd party tools to reuse its output.