### PR TITLE
cgen: fix error for fn with fixed array argument  (fix #13976)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -238,11 +238,12 @@ fn (mut g Gen) gen_assign_stmt(node_ ast.AssignStmt) {
 			} else {
 				g.out.go_back_to(pos)
 				is_var_mut := !is_decl && left.is_auto_deref_var()
-				addr := if is_var_mut { '' } else { '&' }
+				addr_left := if is_var_mut { '' } else { '&' }
 				g.writeln('')
-				g.write('memcpy($addr')
+				g.write('memcpy($addr_left')
 				g.expr(left)
-				g.writeln(', &$v_var, sizeof($arr_typ));')
+				addr_val := if is_fixed_array_var { '' } else { '&' }
+				g.writeln(', $addr_val$v_var, sizeof($arr_typ));')
 			}
 			g.is_assign_lhs = false
 		} else {

--- a/vlib/v/gen/c/infix_expr.v
+++ b/vlib/v/gen/c/infix_expr.v
@@ -626,7 +626,8 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 			if elem_sym.kind == .function {
 				g.write(', _MOV((voidptr[]){ ')
 			} else if elem_is_array_var {
-				g.write(', &')
+				addr := if elem_sym.kind == .array_fixed { '' } else { '&' }
+				g.write(', $addr')
 			} else {
 				g.write(', _MOV(($elem_type_str[]){ ')
 			}

--- a/vlib/v/tests/fn_with_fixed_array_args_test.v
+++ b/vlib/v/tests/fn_with_fixed_array_args_test.v
@@ -1,0 +1,20 @@
+struct Test {
+mut:
+	value [4]int
+}
+
+fn (mut t Test) set(new_value [4]int) {
+	t.value = new_value
+}
+
+fn test_fn_with_fixed_array_argument() {
+	mut t := Test{}
+
+	println(t)
+	assert '$t.value' == '[0, 0, 0, 0]'
+
+	t.set([1, 2, 3, 4]!)
+
+	println(t)
+	assert '$t.value' == '[1, 2, 3, 4]'
+}

--- a/vlib/v/tests/fn_with_fixed_array_args_test.v
+++ b/vlib/v/tests/fn_with_fixed_array_args_test.v
@@ -1,14 +1,14 @@
-struct Test {
+struct Test1 {
 mut:
 	value [4]int
 }
 
-fn (mut t Test) set(new_value [4]int) {
+fn (mut t Test1) set(new_value [4]int) {
 	t.value = new_value
 }
 
-fn test_fn_with_fixed_array_argument() {
-	mut t := Test{}
+fn test_fn_with_fixed_array_argument_1() {
+	mut t := Test1{}
 
 	println(t)
 	assert '$t.value' == '[0, 0, 0, 0]'
@@ -17,4 +17,28 @@ fn test_fn_with_fixed_array_argument() {
 
 	println(t)
 	assert '$t.value' == '[1, 2, 3, 4]'
+}
+
+struct Test2 {
+mut:
+	fixed_value   [2][4]int
+	dynamic_value [][4]int
+}
+
+fn (mut t Test2) set(index int, new_value [4]int) {
+	t.fixed_value[index] = new_value
+	t.dynamic_value << new_value
+}
+
+fn test_fn_with_fixed_array_argument_2() {
+	mut t := Test2{}
+
+	println(t)
+	assert '$t.fixed_value' == '[[0, 0, 0, 0], [0, 0, 0, 0]]'
+	assert '$t.dynamic_value' == '[]'
+
+	t.set(0, [1, 2, 3, 4]!)
+	println(t)
+	assert '$t.fixed_value' == '[[1, 2, 3, 4], [0, 0, 0, 0]]'
+	assert '$t.dynamic_value' == '[[1, 2, 3, 4]]'
 }


### PR DESCRIPTION
This PR fix error for fn with fixed array argument  (fix #13976).

- Fix error for fn with fixed array argument.
- Add test.

```v
struct Test {
mut:
	value [4]int
}

fn (mut t Test) set(new_value [4]int) {
	t.value = new_value
}

fn main() {
	mut t := Test{}

	println(t)
	assert '$t.value' == '[0, 0, 0, 0]'

	t.set([1, 2, 3, 4]!)
	
	println(t)
	assert '$t.value' == '[1, 2, 3, 4]'
}

PS D:\Test\v\tt1> v run .
Test{
    value: [0, 0, 0, 0]
}
Test{
    value: [1, 2, 3, 4]
}
```
```v
struct Test2 {
mut:
	fixed_value   [2][4]int
	dynamic_value [][4]int
}

fn (mut t Test2) set(index int, new_value [4]int) {
	t.fixed_value[index] = new_value
	t.dynamic_value << new_value
}

fn main() {
	mut t := Test2{}

	println(t)
	assert '$t.fixed_value' == '[[0, 0, 0, 0], [0, 0, 0, 0]]'
	assert '$t.dynamic_value' == '[]'

	t.set(0, [1, 2, 3, 4]!)
	println(t)
	assert '$t.fixed_value' == '[[1, 2, 3, 4], [0, 0, 0, 0]]'
	assert '$t.dynamic_value' == '[[1, 2, 3, 4]]'
}

PS D:\Test\v\tt1> v run .
Test2{
    fixed_value: [[0, 0, 0, 0], [0, 0, 0, 0]]
    dynamic_value: []
}
Test2{
    fixed_value: [[1, 2, 3, 4], [0, 0, 0, 0]]
    dynamic_value: [[1, 2, 3, 4]]
}
```