### PR TITLE
checker: check error for array of generic struct init (fix #13935)

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -9,6 +9,22 @@ pub fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 	mut elem_type := ast.void_type
 	// []string - was set in parser
 	if node.typ != ast.void_type {
+		if node.elem_type != 0 {
+			elem_sym := c.table.sym(node.elem_type)
+			if elem_sym.kind == .struct_ {
+				elem_info := elem_sym.info as ast.Struct
+				if elem_info.generic_types.len > 0 && elem_info.concrete_types.len == 0
+					&& !node.elem_type.has_flag(.generic) {
+					if c.table.cur_concrete_types.len == 0 {
+						c.error('generic struct must specify type parameter, e.g. Foo<int>',
+							node.elem_type_pos)
+					} else {
+						c.error('generic struct must specify type parameter, e.g. Foo<T>',
+							node.elem_type_pos)
+					}
+				}
+			}
+		}
 		if node.exprs.len == 0 {
 			if node.has_cap {
 				c.check_array_init_para_type('cap', node.cap_expr, node.pos)

--- a/vlib/v/checker/tests/array_of_generic_struct_init_err.out
+++ b/vlib/v/checker/tests/array_of_generic_struct_init_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/array_of_generic_struct_init_err.vv:6:15: error: generic struct must specify type parameter, e.g. Foo<int>
+    4 |
+    5 | fn main() {
+    6 |     mut arr := []Item{}
+      |                  ~~~~
+    7 | }

--- a/vlib/v/checker/tests/array_of_generic_struct_init_err.vv
+++ b/vlib/v/checker/tests/array_of_generic_struct_init_err.vv
@@ -1,0 +1,7 @@
+struct Item<T>{
+	val T
+}
+
+fn main() {
+	mut arr := []Item{}
+}


### PR DESCRIPTION
This PR check error for array of generic struct init (fix #13935).

- Check error for array of generic struct init.
- Add test.

```v
struct Item<T>{
	val T
}

fn main() {
	mut arr := []Item{}
}

PS D:\Test\v\tt1> v run .
./tt1.v:7:6: warning: unused variable: `arr`
    5 | fn main() {
    6 |     //a := Item{42} // <int> missing error
    7 |     mut arr := []Item{} // builder error:
      |         ~~~
    8 | }
./tt1.v:7:15: error: generic struct must specify type parameter, e.g. Foo<int>
    5 | fn main() {
    6 |     //a := Item{42} // <int> missing error
    7 |     mut arr := []Item{} // builder error:
      |                  ~~~~
    8 | }
```