### PR TITLE
cgen: emit a const variable instead of a define

### DIFF
--- a/vlib/rand/constants/constants.v
+++ b/vlib/rand/constants/constants.v
@@ -3,7 +3,7 @@ module constants
 // Commonly used constants across RNGs - some taken from "Numerical Recipes".
 pub const (
 	lower_mask     = u64(0x00000000FFFFFFFF)
-	max_u32        = 0xFFFFFFFF
+	max_u32        = u32(0xFFFFFFFF)
 	max_u64        = u64(0xFFFFFFFFFFFFFFFF)
 	max_u32_as_f32 = f32(max_u32) + 1
 	max_u64_as_f64 = f64(max_u64) + 1


### PR DESCRIPTION
i have removed the comment because i think its saner for the compilers to have a single symbol to track instead of creating a new symbol in memory every time the variable is accessed.

This change introduces some regressions because of bad code:

* spotted some signed vs unsigned comparisons (define -> int)
  * this is why the code is commented if `if true {` 
* enforces `const` at C level (not just at V)
* using more const (and maybe we should also add `static` for non-pub constants)

This program generates the following C:

```v
$ cat constexpr.v
const myvar = 0 // define instead of const
const mybar = 0.2
const myuar = u64(32)
const myarr = ['123','456']
const mystr = Foo{0}
const mymsg = 'hello'
struct Foo { a int }
$
```

```c
#define _const_main__myvar 0
f64 _const_main__mybar = 0.2; // precomputed
u64 _const_main__myuar = 32U; // precomputed
Array_string _const_main__myarr; // inited later
main__Foo _const_main__mystr; // inited later
string _const_main__mymsg; // a string literal, inited later
```
for consistency, and also, in order to export symbols it's better to use `const` instead of a `#define`

after this patch it generates:
```c
const int _const_main__myvar = 0;
const f64 _const_main__mybar = 0.2; // precomputed
const u64 _const_main__myuar = 32U; // precomputed
Array_string _const_main__myarr; // inited later
main__Foo _const_main__mystr; // inited later
string _const_main__mymsg; // a string literal, inited later
```