### PR TITLE
rand: add missing pub modifiers to musl and pcg32

### DIFF
--- a/vlib/rand/musl/musl_rng.v
+++ b/vlib/rand/musl/musl_rng.v
@@ -29,7 +29,7 @@ pub fn (mut rng MuslRNG) seed(seed_data []u32) {
 
 // byte returns a uniformly distributed pseudorandom 8-bit unsigned positive `byte`.
 [inline]
-fn (mut rng MuslRNG) byte() byte {
+pub fn (mut rng MuslRNG) byte() byte {
 	if rng.bytes_left >= 1 {
 		rng.bytes_left -= 1
 		value := byte(rng.buffer)
@@ -70,7 +70,7 @@ fn temper(prev u32) u32 {
 }
 
 // u32 returns a pseudorandom 32-bit unsigned integer (`u32`).
-fn (mut rng MuslRNG) u32() u32 {
+pub fn (mut rng MuslRNG) u32() u32 {
 	rng.state = rng.state * 1103515245 + 12345
 	// We are not dividing by 2 (or shifting right by 1)
 	// because we want all 32-bits of random data

--- a/vlib/rand/pcg32/pcg32.v
+++ b/vlib/rand/pcg32/pcg32.v
@@ -39,7 +39,7 @@ pub fn (mut rng PCG32RNG) seed(seed_data []u32) {
 
 // byte returns a uniformly distributed pseudorandom 8-bit unsigned positive `byte`.
 [inline]
-fn (mut rng PCG32RNG) byte() byte {
+pub fn (mut rng PCG32RNG) byte() byte {
 	if rng.bytes_left >= 1 {
 		rng.bytes_left -= 1
 		value := byte(rng.buffer)
@@ -70,7 +70,7 @@ pub fn (mut rng PCG32RNG) u16() u16 {
 
 // u32 returns a pseudorandom unsigned `u32`.
 [inline]
-fn (mut rng PCG32RNG) u32() u32 {
+pub fn (mut rng PCG32RNG) u32() u32 {
 	oldstate := rng.state
 	rng.state = oldstate * (6364136223846793005) + rng.inc
 	xorshifted := u32(((oldstate >> u64(18)) ^ oldstate) >> u64(27))


### PR DESCRIPTION
Adds the missing `pub` keyword to the RNGs: MUSL and PCG32.