### PR TITLE
pref: fix access in invalid position when an empty cmd is given to `v`

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -110,7 +110,7 @@ pub mut:
 	test_runner       string   // can be 'simple' (fastest, but much less detailed), 'tap', 'normal'
 	profile_file      string   // the profile results will be stored inside profile_file
 	profile_no_inline bool     // when true, [inline] functions would not be profiled
-	profile_fns       []string // when set, profiling will be off by default, but inside these functions (and what they call) it will be on.	
+	profile_fns       []string // when set, profiling will be off by default, but inside these functions (and what they call) it will be on.
 	translated        bool     // `v translate doom.v` are we running V code translated from C? allow globals, ++ expressions, etc
 	is_prod           bool     // use "-O2"
 	obfuscate         bool     // `v -obf program.v`, renames functions to "f_XXX"
@@ -634,7 +634,7 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 					eprintln('Use `v $arg` instead.')
 					exit(1)
 				}
-				if arg[0] == `-` {
+				if arg.len != 0 && arg[0] == `-` {
 					if arg[1..] in pref.list_of_flags_with_param {
 						// skip parameter
 						i++

--- a/vlib/v/pref/pref_test.v
+++ b/vlib/v/pref/pref_test.v
@@ -1,0 +1,8 @@
+module pref
+
+fn test_check_parametes() {
+	// reproducing issue https://github.com/vlang/v/issues/13983
+	_, cmd := parse_args_and_show_errors(['help'], [''], true)
+	// no command found from args
+	assert cmd == ''
+}


### PR DESCRIPTION
Fixes https://github.com/vlang/v/issues/13983

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
