### PR TITLE
parser: check error for struct field name (fix #13986)

### DIFF
--- a/vlib/v/checker/tests/struct_field_name_err.out
+++ b/vlib/v/checker/tests/struct_field_name_err.out
@@ -1,0 +1,13 @@
+vlib/v/checker/tests/struct_field_name_err.vv:2:2: error: field name `Architecture` cannot contain uppercase letters, use snake_case instead
+    1 | struct Release {
+    2 |     Architecture []string
+      |     ~~~~~~~~~~~~~~~~~~~~~
+    3 |     Components   []string
+    4 | }
+vlib/v/checker/tests/struct_field_name_err.vv:3:2: error: field name `Components` cannot contain uppercase letters, use snake_case instead
+    1 | struct Release {
+    2 |     Architecture []string
+    3 |     Components   []string
+      |     ~~~~~~~~~~~~~~~~~~~~~
+    4 | }
+    5 |

--- a/vlib/v/checker/tests/struct_field_name_err.vv
+++ b/vlib/v/checker/tests/struct_field_name_err.vv
@@ -1,0 +1,9 @@
+struct Release {
+	Architecture []string
+	Components   []string
+}
+
+fn main() {
+	r := Release{}
+	println(r)
+}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -184,7 +184,8 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 				p.next()
 				is_field_volatile = true
 			}
-			is_embed := ((p.tok.lit.len > 1 && p.tok.lit[0].is_capital())
+			is_embed := ((p.tok.lit.len > 1 && p.tok.lit[0].is_capital()
+				&& (p.peek_tok.kind != .lsbr || p.peek_token(2).kind != .rsbr))
 				|| p.peek_tok.kind == .dot) && language == .v && p.peek_tok.kind != .key_fn
 			is_on_top := ast_fields.len == 0 && !(is_field_mut || is_field_global)
 			mut field_name := ''


### PR DESCRIPTION
This PR check error for struct field name (fix #13986).

- Check error for struct field name.
- Add test.

```v
struct Release {
	Architecture []string
	Components   []string
}

fn main() {
	r := Release{}
	println(r)
}

PS D:\Test\v\tt1> v run .
./tt1.v:2:2: error: field name `Architecture` cannot contain uppercase letters, use snake_case instead
    1 | struct Release {
    2 |     Architecture []string
      |     ~~~~~~~~~~~~~~~~~~~~~
    3 |     Components   []string
    4 | }
./tt1.v:3:2: error: field name `Components` cannot contain uppercase letters, use snake_case instead
    1 | struct Release {
    2 |     Architecture []string
    3 |     Components   []string
      |     ~~~~~~~~~~~~~~~~~~~~~
    4 | }
    5 |
```