### PR TITLE
toml.scanner: make end_of_text, at, next and peek return u32

### DIFF
--- a/vlib/toml/scanner/scanner.v
+++ b/vlib/toml/scanner/scanner.v
@@ -10,7 +10,7 @@ import toml.util
 
 pub const (
 	digit_extras = [`_`, `.`, `x`, `o`, `b`, `e`, `E`]
-	end_of_text  = -1
+	end_of_text  = math.max_u32
 )
 
 // Scanner contains the necessary fields for the state of the scan process.
@@ -263,7 +263,7 @@ pub fn (s &Scanner) remaining() int {
 // next returns the next character code from the input text.
 // next returns `end_of_text` if it can't reach the next character.
 [direct_array_access; inline]
-pub fn (mut s Scanner) next() int {
+pub fn (mut s Scanner) next() u32 {
 	if s.pos < s.text.len {
 		opos := s.pos
 		s.pos++
@@ -299,7 +299,7 @@ pub fn (mut s Scanner) skip_n(n int) {
 // at returns `end_of_text` if it can't get the current character.
 // unlike `next()`, `at()` does not change the state of the scanner.
 [direct_array_access; inline]
-pub fn (s &Scanner) at() int {
+pub fn (s &Scanner) at() u32 {
 	if s.pos < s.text.len {
 		return s.text[s.pos]
 	}

--- a/vlib/toml/scanner/scanner.v
+++ b/vlib/toml/scanner/scanner.v
@@ -315,7 +315,7 @@ fn (s Scanner) at_crlf() bool {
 // peek returns the character code from the input text at position + `n`.
 // peek returns `end_of_text` if it can't peek `n` characters ahead.
 [direct_array_access; inline]
-pub fn (s &Scanner) peek(n int) int {
+pub fn (s &Scanner) peek(n int) u32 {
 	if s.pos + n < s.text.len {
 		// Allow peeking back - needed for spaces between date and time in RFC 3339 format :/
 		if n - 1 < 0 && s.pos + n - 1 >= 0 {

--- a/vlib/toml/scanner/scanner_test.v
+++ b/vlib/toml/scanner/scanner_test.v
@@ -25,9 +25,9 @@ fn test_next() {
 	assert s.next() == `a`
 	assert s.next() == `b`
 	assert s.next() == `c`
-	assert s.next() == -1
-	assert s.next() == -1
-	assert s.next() == -1
+	assert s.next() == scanner.end_of_text
+	assert s.next() == scanner.end_of_text
+	assert s.next() == scanner.end_of_text
 }
 
 fn test_skip() {
@@ -35,14 +35,14 @@ fn test_skip() {
 	assert s.next() == `a`
 	s.skip()
 	assert s.next() == `c`
-	assert s.next() == -1
+	assert s.next() == scanner.end_of_text
 }
 
 fn test_skip_n() {
 	mut s := scanner.new_scanner(input: scan_input) or { panic(err) }
 	s.skip_n(2)
 	assert s.next() == `c`
-	assert s.next() == -1
+	assert s.next() == scanner.end_of_text
 }
 
 fn test_at() {
@@ -54,7 +54,7 @@ fn test_at() {
 	assert s.next() == `a`
 	assert s.next() == `b`
 	assert s.next() == `c`
-	assert s.next() == -1
+	assert s.next() == scanner.end_of_text
 }
 
 fn test_peek() {
@@ -62,13 +62,13 @@ fn test_peek() {
 	assert s.peek(0) == `a`
 	assert s.peek(1) == `b`
 	assert s.peek(2) == `c`
-	assert s.peek(3) == -1
-	assert s.peek(4) == -1
+	assert s.peek(3) == scanner.end_of_text
+	assert s.peek(4) == scanner.end_of_text
 	//
 	assert s.next() == `a`
 	assert s.next() == `b`
 	assert s.next() == `c`
-	assert s.next() == -1
+	assert s.next() == scanner.end_of_text
 }
 
 fn test_reset() {
@@ -76,7 +76,7 @@ fn test_reset() {
 	assert s.next() == `a`
 	s.next()
 	s.next()
-	assert s.next() == -1
+	assert s.next() == scanner.end_of_text
 	s.reset()
 	assert s.next() == `a`
 }


### PR DESCRIPTION
Split out from #13967.

The 3 functions return a byte from a string or `end_of_text`. byte is unsigned. Returning int will cause an error when comparing the result with a byte when we implement unsigned == signed errors. So return u32 instead.

Note this pull doesn't break any running code that checks against a literal `-1`, because `math.max_u32 == -1`. That code will just fail to compile when the unsigned == signed errors are implemented.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
