### PR TITLE
checker: check error for map of generic struct init

### DIFF
--- a/vlib/v/checker/tests/map_of_generic_struct_init_err.out
+++ b/vlib/v/checker/tests/map_of_generic_struct_init_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/map_of_generic_struct_init_err.vv:6:11: error: generic struct `Item` must specify type parameter, e.g. Foo<int>
+    4 |
+    5 | fn main() {
+    6 |     mut m := map[string]Item{}
+      |              ~~~~~~~~~~~~~~~~~
+    7 | }

--- a/vlib/v/checker/tests/map_of_generic_struct_init_err.vv
+++ b/vlib/v/checker/tests/map_of_generic_struct_init_err.vv
@@ -1,0 +1,7 @@
+struct Item<T>{
+	val T
+}
+
+fn main() {
+	mut m := map[string]Item{}
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2140,10 +2140,12 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 	p.expr_mod = ''
 	// `map[string]int` initialization
 	if p.tok.lit == 'map' && p.peek_tok.kind == .lsbr {
+		mut pos := p.tok.pos()
 		map_type := p.parse_map_type()
 		if p.tok.kind == .lcbr {
 			p.next()
 			if p.tok.kind == .rcbr {
+				pos = pos.extend(p.tok.pos())
 				p.next()
 			} else {
 				if p.pref.is_fmt {
@@ -2156,7 +2158,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 		}
 		return ast.MapInit{
 			typ: map_type
-			pos: p.prev_tok.pos()
+			pos: pos
 		}
 	}
 	// `chan typ{...}`


### PR DESCRIPTION
This PR check error for map of generic struct init.

- Check error for map of generic struct init.
- Add test.

```v
struct Item<T>{
	val T
}

fn main() {
	mut m := map[string]Item{}
}

PS D:\Test\v\tt1> v run .
./tt1.v:6:6: warning: unused variable: `m`
    4 | 
    5 | fn main() {
    6 |     mut m := map[string]Item{}
      |         ^
    7 | }
./tt1.v:6:11: error: generic struct `Item` must specify type parameter, e.g. Foo<int>
    4 | 
    5 | fn main() {
    6 |     mut m := map[string]Item{}
      |              ~~~~~~~~~~~~~~~~~
    7 | }
```