### PR TITLE
checker: ensure that the variant SubType exists 

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2464,17 +2464,6 @@ fn (mut c Checker) stmts_ending_with_expression(stmts []ast.Stmt) {
 	c.scope_returns = false
 }
 
-pub fn (mut c Checker) unwrap_generic(typ ast.Type) ast.Type {
-	if typ.has_flag(.generic) {
-		if t_typ := c.table.resolve_generic_to_concrete(typ, c.table.cur_fn.generic_names,
-			c.table.cur_concrete_types)
-		{
-			return t_typ
-		}
-	}
-	return typ
-}
-
 // TODO node must be mut
 pub fn (mut c Checker) expr(node_ ast.Expr) ast.Type {
 	c.expr_level++
@@ -4156,48 +4145,6 @@ fn (mut c Checker) fetch_field_name(field ast.StructField) string {
 fn (mut c Checker) trace(fbase string, message string) {
 	if c.file.path_base == fbase {
 		println('> c.trace | ${fbase:-10s} | $message')
-	}
-}
-
-fn (mut c Checker) ensure_type_exists(typ ast.Type, pos token.Pos) ? {
-	if typ == 0 {
-		c.error('unknown type', pos)
-		return
-	}
-	sym := c.table.sym(typ)
-	match sym.kind {
-		.placeholder {
-			if sym.language == .v && !sym.name.starts_with('C.') {
-				c.error(util.new_suggestion(sym.name, c.table.known_type_names()).say('unknown type `$sym.name`'),
-					pos)
-				return
-			}
-		}
-		.int_literal, .float_literal {
-			// Separate error condition for `int_literal` and `float_literal` because `util.suggestion` may give different
-			// suggestions due to f32 comparision issue.
-			if !c.is_builtin_mod {
-				msg := if sym.kind == .int_literal {
-					'unknown type `$sym.name`.\nDid you mean `int`?'
-				} else {
-					'unknown type `$sym.name`.\nDid you mean `f64`?'
-				}
-				c.error(msg, pos)
-				return
-			}
-		}
-		.array {
-			c.ensure_type_exists((sym.info as ast.Array).elem_type, pos) ?
-		}
-		.array_fixed {
-			c.ensure_type_exists((sym.info as ast.ArrayFixed).elem_type, pos) ?
-		}
-		.map {
-			info := sym.info as ast.Map
-			c.ensure_type_exists(info.key_type, pos) ?
-			c.ensure_type_exists(info.value_type, pos) ?
-		}
-		else {}
 	}
 }
 

--- a/vlib/v/checker/tests/undefined_type_on_sumtype.out
+++ b/vlib/v/checker/tests/undefined_type_on_sumtype.out
@@ -1,0 +1,13 @@
+vlib/v/checker/tests/undefined_type_on_sumtype.vv:1:17: error: unknown type `Token`.
+Did you mean `Ok<[]Token>`?
+    1 | type ParseRes = Result<[]Token, ParseErr>
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~
+    2 | 
+    3 | // Token type is unknown
+vlib/v/checker/tests/undefined_type_on_sumtype.vv:30:4: error: unused variable: `rx`
+   28 |     match r {
+   29 |         Some<ParseRes> {
+   30 |             rx := r.value
+      |             ~~
+   31 |         }
+   32 |         None<ParseRes> {}

--- a/vlib/v/checker/tests/undefined_type_on_sumtype.vv
+++ b/vlib/v/checker/tests/undefined_type_on_sumtype.vv
@@ -1,6 +1,7 @@
 type ParseRes = Result<[]Token, ParseErr>
 
-struct Token {}
+// Token type is unknown
+//struct Token {}
 
 struct ParseErr {}
 
@@ -22,12 +23,11 @@ struct Err<U> {
 	value U
 }
 
-fn main() {
+fn test_report() {
 	r := Opt<ParseRes>(None<ParseRes>{})
 	match r {
 		Some<ParseRes> {
-			// make possible cast fo the same type!
-			rx := Result<[]Token, ParseErr>(r.value)
+			rx := r.value
 		}
 		None<ParseRes> {}
 	}

--- a/vlib/v/checker/utils.v
+++ b/vlib/v/checker/utils.v
@@ -1,0 +1,66 @@
+module checker
+
+import v.ast
+import v.token
+import v.util
+
+// unwrap_generic unwrap the concrete type.
+fn (mut c Checker) unwrap_generic(typ ast.Type) ast.Type {
+	if typ.has_flag(.generic) {
+		if t_typ := c.table.resolve_generic_to_concrete(typ, c.table.cur_fn.generic_names,
+			c.table.cur_concrete_types)
+		{
+			return t_typ
+		}
+	}
+	return typ
+}
+
+// ensure_type_exists check if the type was found somewhere before.
+fn (mut c Checker) ensure_type_exists(typ ast.Type, pos token.Pos) ? {
+	if typ == 0 {
+		c.error('unknown type', pos)
+		return
+	}
+	sym := c.table.sym(typ)
+	match sym.kind {
+		.placeholder {
+			if sym.language == .v && !sym.name.starts_with('C.') {
+				c.error(util.new_suggestion(sym.name, c.table.known_type_names()).say('unknown type `$sym.name`'),
+					pos)
+				return
+			}
+		}
+		.int_literal, .float_literal {
+			// Separate error condition for `int_literal` and `float_literal` because `util.suggestion` may give different
+			// suggestions due to f32 comparision issue.
+			if !c.is_builtin_mod {
+				msg := if sym.kind == .int_literal {
+					'unknown type `$sym.name`.\nDid you mean `int`?'
+				} else {
+					'unknown type `$sym.name`.\nDid you mean `f64`?'
+				}
+				c.error(msg, pos)
+				return
+			}
+		}
+		.array {
+			c.ensure_type_exists((sym.info as ast.Array).elem_type, pos) ?
+		}
+		.array_fixed {
+			c.ensure_type_exists((sym.info as ast.ArrayFixed).elem_type, pos) ?
+		}
+		.map {
+			info := sym.info as ast.Map
+			c.ensure_type_exists(info.key_type, pos) ?
+			c.ensure_type_exists(info.value_type, pos) ?
+		}
+		.sum_type {
+			info := sym.info as ast.SumType
+			for concrete_typ in info.concrete_types {
+				c.ensure_type_exists(concrete_typ, pos) ?
+			}
+		}
+		else {}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/vlang/v/issues/14002

When we have a sum type with generics value inside an alias we skip to check if the generic value inside the sumtype exists, in this way we have a type checking leak in if one of the type is node defined anywhere.

Example of a valid program before this PR

```
type ParseRes = Result<[]Token, ParseErr>

// Token type is unknown
//struct Token {}

struct ParseErr {}

type Opt<T> = None<T> | Some<T>

struct None<T> {}

struct Some<T> {
	value T
}

type Result<T, U> = Err<U> | Ok<T>

struct Ok<T> {
	value T
}

struct Err<U> {
	value U
}
```

Now the compiler will generate an error like the following one 

```
vlib/v/checker/tests/undefined_type_on_sumtype.vv:1:17: error: unknown type `Token`.
Did you mean `Ok<[]Token>`?
    1 | type ParseRes = Result<[]Token, ParseErr>
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~
    2 | 
    3 | // Token type is unknown
```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
