### PR TITLE
ast, parser, fmt: fix error for vfmt of consts with embeded comments (fix #6949)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -323,9 +323,10 @@ pub:
 	is_markused bool // an explict `[markused]` tag; the const will NOT be removed by `-skip-unused`, no matter what
 	pos         token.Pos
 pub mut:
-	expr     Expr      // the value expr of field; everything after `=`
-	typ      Type      // the type of the const field, it can be any type in V
-	comments []Comment // comments before current const field
+	expr         Expr      // the value expr of field; everything after `=`
+	typ          Type      // the type of the const field, it can be any type in V
+	comments     []Comment // comments before current const field
+	end_comments []Comment // comments that after const field
 	// the comptime_expr_value field is filled by the checker, when it has enough
 	// info to evaluate the constant at compile time
 	comptime_expr_value ComptTimeConstValue = empty_comptime_const_expr()

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -843,7 +843,8 @@ pub fn (mut f Fmt) const_decl(node ast.ConstDecl) {
 		f.write(strings.repeat(` `, align_infos[align_idx].max - field.name.len))
 		f.write('= ')
 		f.expr(field.expr)
-		if node.is_block {
+		f.comments(field.end_comments, inline: true)
+		if node.is_block && field.end_comments.len == 0 {
 			f.writeln('')
 		} else {
 			// Write out single line comments after const expr if present

--- a/vlib/v/fmt/tests/consts_with_embeded_comments_expected.vv
+++ b/vlib/v/fmt/tests/consts_with_embeded_comments_expected.vv
@@ -1,0 +1,7 @@
+import gx
+
+const (
+	color = gx.rgb(50, 90, 110) // gx.rgb(167,236,82)
+)
+
+fn main() {}

--- a/vlib/v/fmt/tests/consts_with_embeded_comments_input.vv
+++ b/vlib/v/fmt/tests/consts_with_embeded_comments_input.vv
@@ -1,0 +1,8 @@
+import gx
+
+const (
+        color = //gx.rgb(167,236,82)
+                gx.rgb(50, 90, 110)
+)
+
+fn main() {}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3247,6 +3247,7 @@ fn (mut p Parser) const_decl() ast.ConstDecl {
 	}
 	mut fields := []ast.ConstField{}
 	mut comments := []ast.Comment{}
+	mut end_comments := []ast.Comment{}
 	for {
 		comments = p.eat_comments()
 		if is_block && p.tok.kind == .eof {
@@ -3258,12 +3259,14 @@ fn (mut p Parser) const_decl() ast.ConstDecl {
 		}
 		pos := p.tok.pos()
 		name := p.check_name()
+		end_comments << p.eat_comments()
 		if util.contains_capital(name) {
 			p.warn_with_pos('const names cannot contain uppercase letters, use snake_case instead',
 				pos)
 		}
 		full_name := p.prepend_mod(name)
 		p.check(.assign)
+		end_comments << p.eat_comments()
 		if p.tok.kind == .key_fn {
 			p.error('const initializer fn literal is not a constant')
 			return ast.ConstDecl{}
@@ -3280,6 +3283,7 @@ fn (mut p Parser) const_decl() ast.ConstDecl {
 			expr: expr
 			pos: pos.extend(expr.pos())
 			comments: comments
+			end_comments: end_comments
 			is_markused: is_markused
 		}
 		fields << field


### PR DESCRIPTION
This PR fix error for vfmt of consts with embeded comments (fix #6949).

- Fix error for vfmt of consts with embeded comments.
- Add test.

```v
import gx

const (
        color = //gx.rgb(167,236,82)
                gx.rgb(50, 90, 110)
)

fn main() {}
```
vfmt ->
```v
import gx

const (
	color = gx.rgb(50, 90, 110) // gx.rgb(167,236,82)
)

fn main() {}
```