### PR TITLE
parser, fmt: fix formatting fn headers with inline comments (fix #13679)

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -952,8 +952,11 @@ fn (mut f Fmt) fn_body(node ast.FnDecl) {
 	if node.language == .v {
 		if !node.no_body {
 			f.write(' {')
+			f.comments(node.comments, inline: true)
 			if node.stmts.len > 0 || node.pos.line_nr < node.pos.last_line {
-				f.writeln('')
+				if node.comments.len == 0 {
+					f.writeln('')
+				}
 				f.stmts(node.stmts)
 			}
 			f.write('}')

--- a/vlib/v/fmt/tests/fn_headers_with_inline_comments_expected.vv
+++ b/vlib/v/fmt/tests/fn_headers_with_inline_comments_expected.vv
@@ -1,0 +1,7 @@
+fn main() { // main
+	return
+}
+
+fn print_hi() { // hi
+	println('hi')
+}

--- a/vlib/v/fmt/tests/fn_headers_with_inline_comments_input.vv
+++ b/vlib/v/fmt/tests/fn_headers_with_inline_comments_input.vv
@@ -1,0 +1,6 @@
+fn /*main*/main() {
+	return
+}
+
+fn // hi
+print_hi(){println('hi')}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -182,6 +182,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	mut is_ctor_new := false
 	mut is_c2v_variadic := false
 	mut is_markused := false
+	mut comments := []ast.Comment{}
 	for fna in p.attrs {
 		match fna.name {
 			'noreturn' { is_noreturn = true }
@@ -205,6 +206,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		p.next()
 	}
 	p.check(.key_fn)
+	comments << p.eat_comments()
 	p.open_scope()
 	// C. || JS.
 	mut language := ast.Language.v
@@ -530,6 +532,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		scope: p.scope
 		label_names: p.label_names
 		end_comments: p.eat_comments(same_line: true)
+		comments: comments
 	}
 	if generic_names.len > 0 {
 		p.table.register_fn_generic_types(fn_decl.fkey())


### PR DESCRIPTION
This PR fix formatting fn headers with inline comments (fix #13679).

- Fix formatting fn headers with inline comments.
- Add test.

```v
fn /*main*/main() {
	return
}

fn // hi
print_hi(){println('hi')}
```
vfmt ->
```v
fn main() { // main
	return
}

fn print_hi() { // hi
	println('hi')
}
```