### PR TITLE
cgen: Fix infix_expr_in_optimization compile error when treating some kind cannot directly use '=='

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -675,11 +675,7 @@ fn (mut g Gen) gen_array_contains_methods() {
 		fn_name := '${left_type_str}_contains'
 		left_info := left_final_sym.info as ast.Array
 		mut elem_type_str := g.typ(left_info.elem_type)
-		mut elem_sym := g.table.sym(left_info.elem_type)
-		if elem_sym.kind == .alias {
-			info := elem_sym.info as ast.Alias
-			elem_sym = g.table.sym(info.parent_type)
-		}
+		elem_sym := g.table.sym(left_info.elem_type)
 		if elem_sym.kind == .function {
 			left_type_str = 'Array_voidptr'
 			elem_type_str = 'voidptr'
@@ -707,6 +703,9 @@ fn (mut g Gen) gen_array_contains_methods() {
 		} else if elem_sym.kind == .sum_type && left_info.elem_type.nr_muls() == 0 {
 			ptr_typ := g.equality_fn(left_info.elem_type)
 			fn_builder.writeln('\t\tif (${ptr_typ}_sumtype_eq((($elem_type_str*)a.data)[i], v)) {')
+		} else if elem_sym.kind == .alias && left_info.elem_type.nr_muls() == 0 {
+			ptr_typ := g.equality_fn(left_info.elem_type)
+			fn_builder.writeln('\t\tif (${ptr_typ}_alias_eq((($elem_type_str*)a.data)[i], v)) {')
 		} else {
 			fn_builder.writeln('\t\tif ((($elem_type_str*)a.data)[i] == v) {')
 		}
@@ -757,11 +756,7 @@ fn (mut g Gen) gen_array_index_methods() {
 		fn_name := '${left_type_str}_index'
 		info := final_left_sym.info as ast.Array
 		mut elem_type_str := g.typ(info.elem_type)
-		mut elem_sym := g.table.sym(info.elem_type)
-		if elem_sym.kind == .alias {
-			info_t := elem_sym.info as ast.Alias
-			elem_sym = g.table.sym(info_t.parent_type)
-		}
+		elem_sym := g.table.sym(info.elem_type)
 		if elem_sym.kind == .function {
 			left_type_str = 'Array_voidptr'
 			elem_type_str = 'voidptr'
@@ -790,6 +785,9 @@ fn (mut g Gen) gen_array_index_methods() {
 		} else if elem_sym.kind == .sum_type {
 			ptr_typ := g.equality_fn(info.elem_type)
 			fn_builder.writeln('\t\tif (${ptr_typ}_sumtype_eq(*pelem, v)) {')
+		} else if elem_sym.kind == .alias {
+			ptr_typ := g.equality_fn(info.elem_type)
+			fn_builder.writeln('\t\tif (${ptr_typ}_alias_eq(*pelem, v)) {')
 		} else {
 			fn_builder.writeln('\t\tif (*pelem == v) {')
 		}

--- a/vlib/v/tests/in_expression_test.v
+++ b/vlib/v/tests/in_expression_test.v
@@ -289,9 +289,8 @@ fn test_in_sumtype_array() {
 }
 
 fn test_in_struct_array() {
-	assert Foo1{} in [Foo1{}]
+	assert Foo1{} == Foo1{}
 }
-
 
 fn fn1() {}
 
@@ -308,5 +307,5 @@ type Struct = Foo1
 
 fn test_in_alias_array() {
 	assert Str('') in [Str(''), Str('a')]
-	assert Struct{} in [Struct{}]
+	assert Struct{} == Struct{}
 }

--- a/vlib/v/tests/in_expression_test.v
+++ b/vlib/v/tests/in_expression_test.v
@@ -287,3 +287,26 @@ fn test_in_sumtype_array() {
 	assert Foo1{} in foos
 	assert Foo2{} !in foos
 }
+
+fn test_in_struct_array() {
+	assert Foo1{} in [Foo1{}]
+}
+
+
+fn fn1() {}
+
+fn fn2() {}
+
+fn fn3() {}
+
+fn test_in_func_array() {
+	assert fn1 in [fn1, fn2, fn3]
+}
+
+type Str = string
+type Struct = Foo1
+
+fn test_in_alias_array() {
+	assert Str('') in [Str(''), Str('a')]
+	assert Struct{} in [Struct{}]
+}


### PR DESCRIPTION

Fix infix_expr_in_optimization compile error when treating struct arrays or alias arrays.

```
module main

struct Foo1 {}

fn main() {
	assert Foo1{} in [Foo1{}]
}
```

error output:
```
==================
   ^~~~~~~~~~~~~~~
/tmp/v_501/test7.13461198918855249079.tmp.c:11404:53: error: invalid operands to binary expression ('main__Foo1' (aka 'struct main__Foo1') and 'main__Foo1')
        if (!((((main__Foo1){EMPTY_STRUCT_INITIALIZATION}) == ((main__Foo1){EMPTY_STRUCT_INITIALIZATION})))) {
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning and 1 error generated.
...
==================
(Use `v -cg` to print the entire error message)
```
