### PR TITLE
cgen: Added __fastcall attribute

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2150,6 +2150,9 @@ fn (mut g Gen) write_fn_attrs(attrs []ast.Attr) string {
 				// prefixed by windows to indicate they're for advanced users only and not really supported by V.
 				fn_attrs += '__stdcall '
 			}
+			'_fastcall' {
+				fn_attrs += '__fastcall '
+			}
 			'console' {
 				g.force_main_console = true
 			}


### PR DESCRIPTION
This pr add the __fastcall attribute, I'm not very sure about the same if it should have two "_" or only one in the attribute name.
it may not be useful for a lot of people but it can be useful for some cases with c++ to pass/get the "this" argument since there is no __thiscall in c.
Thanks for reading :)
