### PR TITLE
json: fix error for json decode with sumtype (fix #14017)

### DIFF
--- a/vlib/json/json_decode_with_sumtype_test.v
+++ b/vlib/json/json_decode_with_sumtype_test.v
@@ -1,0 +1,13 @@
+import json
+
+type Test = []string | string
+
+struct Some {
+	t Test
+}
+
+fn test_json_decode_with_sumtype() ? {
+	v := json.decode(Some, '{"t": ["string", "string2"]}') ?
+	println(v)
+	assert '$v.t' == "Test(['string', 'string2'])"
+}

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -311,6 +311,17 @@ fn (mut g Gen) gen_sumtype_enc_dec(sym ast.TypeSymbol, mut enc strings.Builder, 
 					dec.writeln('\t\t}')
 				}
 
+				if var_t == 'Array_string' {
+					tmp := g.new_tmp_var()
+					dec.writeln('\t\tif (cJSON_IsArray(root)) {')
+					dec.writeln('\t\t\tOption_Array_string $tmp = ${js_dec_name(var_t)}(root);')
+					dec.writeln('\t\t\tif (${tmp}.state != 0) {')
+					dec.writeln('\t\t\t\treturn (Option_$sym.cname){ .state = ${tmp}.state, .err = ${tmp}.err, .data = {0} };')
+					dec.writeln('\t\t\t}')
+					dec.writeln('\t\t\tres = Array_string_to_sumtype_${sym.cname}(($var_t*)${tmp}.data);')
+					dec.writeln('\t\t}')
+				}
+
 				if var_t in ['i64', 'int', 'i8', 'u64', 'u32', 'u16', 'byte', 'u8', 'rune', 'f64',
 					'f32'] {
 					if number_is_met {


### PR DESCRIPTION
This PR fix error for json decode with sumtype (fix #14017).

- Fix error for json decode with sumtype.
- Add test.

```v
import json

type Test = []string | string

struct Some {
	t Test
}

fn main() {
	v := json.decode(Some, '{"t": ["string", "string2"]}') ?
	println(v)
	assert '$v.t' == "Test(['string', 'string2'])"
}

PS D:\Test\v\tt1> v run .
Some{
    t: Test(['string', 'string2'])
}
```