### PR TITLE
cgen: format gen_str_for_union_sum_type() generated c codes

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -472,7 +472,7 @@ fn (mut g Gen) gen_str_for_union_sum_type(info ast.SumType, styp string, str_fn_
 				{_SLIT("${clean_sum_type_v_type_name}(\'"), $c.si_s_code, {.d_s = $val}},
 				{_SLIT("\')"), 0, {.d_c = 0 }}
 			}))'
-			fn_builder.write_string('\t\tcase $typ.idx(): return $res;')
+			fn_builder.write_string('\t\tcase $typ.idx(): return $res;\n')
 		} else {
 			mut val := '${func_name}(${deref}($typ_str*)x._$sym.cname'
 			if should_use_indent_func(sym.kind) && !sym_has_str_method {
@@ -483,7 +483,7 @@ fn (mut g Gen) gen_str_for_union_sum_type(info ast.SumType, styp string, str_fn_
 				{_SLIT("${clean_sum_type_v_type_name}("), $c.si_s_code, {.d_s = $val}},
 				{_SLIT(")"), 0, {.d_c = 0 }}
 			}))'
-			fn_builder.write_string('\t\tcase $typ.idx(): return $res;')
+			fn_builder.write_string('\t\tcase $typ.idx(): return $res;\n')
 		}
 	}
 	fn_builder.writeln('\t\tdefault: return _SLIT("unknown sum type value");')


### PR DESCRIPTION
This PR format gen_str_for_union_sum_type() generated c codes.

before:
```v
static string indent_main__Test_str(main__Test x, int indent_count) {
	switch(x._typ) {
		case 35: return str_intp(2, _MOV((StrIntpData[]){
				{_SLIT("Test("), 0xfe10, {.d_s = Array_string_str(*(Array_string*)x._Array_string)}},
				{_SLIT(")"), 0, {.d_c = 0 }}
			}));		case 20: return str_intp(2, _MOV((StrIntpData[]){
				{_SLIT("Test('"), 0xfe10, {.d_s = string_str(*(string*)x._string)}},
				{_SLIT("')"), 0, {.d_c = 0 }}
			}));		default: return _SLIT("unknown sum type value");
	}
}
```
now:
```v
static string indent_main__Test_str(main__Test x, int indent_count) {
	switch(x._typ) {
		case 35: return str_intp(2, _MOV((StrIntpData[]){
				{_SLIT("Test("), 0xfe10, {.d_s = Array_string_str(*(Array_string*)x._Array_string)}},
				{_SLIT(")"), 0, {.d_c = 0 }}
			}));
		case 20: return str_intp(2, _MOV((StrIntpData[]){
				{_SLIT("Test('"), 0xfe10, {.d_s = string_str(*(string*)x._string)}},
				{_SLIT("')"), 0, {.d_c = 0 }}
			}));
		default: return _SLIT("unknown sum type value");
	}
}
```