### PR TITLE
repl: use the most common compiler

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -543,7 +543,10 @@ fn repl_run_vfile(file string) ?os.Result {
 	$if trace_repl_temp_files ? {
 		eprintln('>> repl_run_vfile file: $file')
 	}
-	s := os.execute('${os.quoted_path(vexe)} -repl run ${os.quoted_path(file)}')
+	// FIXME: gcc is slower so we could make the check on witch compiler
+	// is available and pick the best one, but overall the repl should not compiler
+	// the code, so why not focusing on a real repl?
+	s := os.execute('${os.quoted_path(vexe)} -repl -cc gcc run ${os.quoted_path(file)}')
 	if s.exit_code < 0 {
 		rerror(s.output)
 		return error(s.output)


### PR DESCRIPTION
Fixes https://github.com/vlang/v/issues/14028

This was easy, but the solution is too bad because the reply is slower now!

Hopefully, this change doesn't break the CI with the different compiler error

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
