### PR TITLE
json: fix json decode with sumtype of multi array type

### DIFF
--- a/vlib/json/json_decode_with_sumtype_test.v
+++ b/vlib/json/json_decode_with_sumtype_test.v
@@ -9,13 +9,13 @@ struct Some {
 fn test_json_decode_with_sumtype() ? {
 	v1 := json.decode(Some, '{"t": ["string", "string2"]}') ?
 	println(v1)
-	assert '$v1.t' == "Test(['string', 'string2'])"
+	assert v1.t == Test(['string', 'string2'])
 
 	v2 := json.decode(Some, '{"t": [11, 22]}') ?
 	println(v2)
-	assert '$v2.t' == 'Test([11, 22])'
+	assert v2.t == Test([11, 22])
 
 	v3 := json.decode(Some, '{"t": [true, false]}') ?
 	println(v3)
-	assert '$v3.t' == 'Test([true, false])'
+	assert v3.t == Test([true, false])
 }

--- a/vlib/json/json_decode_with_sumtype_test.v
+++ b/vlib/json/json_decode_with_sumtype_test.v
@@ -1,13 +1,21 @@
 import json
 
-type Test = []string | string
+type Test = []bool | []int | []string | string
 
 struct Some {
 	t Test
 }
 
 fn test_json_decode_with_sumtype() ? {
-	v := json.decode(Some, '{"t": ["string", "string2"]}') ?
-	println(v)
-	assert '$v.t' == "Test(['string', 'string2'])"
+	v1 := json.decode(Some, '{"t": ["string", "string2"]}') ?
+	println(v1)
+	assert '$v1.t' == "Test(['string', 'string2'])"
+
+	v2 := json.decode(Some, '{"t": [11, 22]}') ?
+	println(v2)
+	assert '$v2.t' == 'Test([11, 22])'
+
+	v3 := json.decode(Some, '{"t": [true, false]}') ?
+	println(v3)
+	assert '$v3.t' == 'Test([true, false])'
 }

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -311,14 +311,21 @@ fn (mut g Gen) gen_sumtype_enc_dec(sym ast.TypeSymbol, mut enc strings.Builder, 
 					dec.writeln('\t\t}')
 				}
 
-				if var_t == 'Array_string' {
+				if var_t.starts_with('Array_') {
 					tmp := g.new_tmp_var()
-					dec.writeln('\t\tif (cJSON_IsArray(root)) {')
-					dec.writeln('\t\t\tOption_Array_string $tmp = ${js_dec_name(var_t)}(root);')
+					judge_elem_typ := if var_t.ends_with('string') {
+						'cJSON_IsString(root->child)'
+					} else if var_t.ends_with('bool') {
+						'cJSON_IsBool(root->child)'
+					} else {
+						'cJSON_IsNumber(root->child)'
+					}
+					dec.writeln('\t\tif (cJSON_IsArray(root) && $judge_elem_typ) {')
+					dec.writeln('\t\t\tOption_$var_t $tmp = ${js_dec_name(var_t)}(root);')
 					dec.writeln('\t\t\tif (${tmp}.state != 0) {')
 					dec.writeln('\t\t\t\treturn (Option_$sym.cname){ .state = ${tmp}.state, .err = ${tmp}.err, .data = {0} };')
 					dec.writeln('\t\t\t}')
-					dec.writeln('\t\t\tres = Array_string_to_sumtype_${sym.cname}(($var_t*)${tmp}.data);')
+					dec.writeln('\t\t\tres = ${var_t}_to_sumtype_${sym.cname}(($var_t*)${tmp}.data);')
 					dec.writeln('\t\t}')
 				}
 


### PR DESCRIPTION
This PR fix json decode with sumtype of multi array type.

- Fix json decode with sumtype of multi array type.
- Add test.

```v
import json

type Test = []bool | []int | []string | string

struct Some {
	t Test
}

fn main() {
	v1 := json.decode(Some, '{"t": ["string", "string2"]}') ?
	println(v1)
	assert '$v1.t' == "Test(['string', 'string2'])"

	v2 := json.decode(Some, '{"t": [11, 22]}') ?
	println(v2)
	assert '$v2.t' == 'Test([11, 22])'

	v3 := json.decode(Some, '{"t": [true, false]}') ?
	println(v3)
	assert '$v3.t' == 'Test([true, false])'
}

PS D:\Test\v\tt1> v run .
Some{
    t: Test(['string', 'string2'])
}
Some{
    t: Test([11, 22])
}
Some{
    t: Test([true, false])
}
```