### PR TITLE
cgen: fix error for generics struct that parent has str to string (fix #14034)

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -896,7 +896,12 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name stri
 		sftyp := g.typ(field.typ)
 		mut field_styp := sftyp.replace('*', '')
 		field_styp_fn_name := if sym_has_str_method {
-			'${field_styp}_str'
+			mut field_fn_name := '${field_styp}_str'
+			if sym.info is ast.Struct {
+				field_fn_name = g.generic_fn_name(sym.info.concrete_types, field_fn_name,
+					false)
+			}
+			field_fn_name
 		} else {
 			g.get_str_fn(field.typ)
 		}

--- a/vlib/v/tests/generics_struct_parent_has_str_to_string_test.v
+++ b/vlib/v/tests/generics_struct_parent_has_str_to_string_test.v
@@ -1,0 +1,36 @@
+import datatypes
+
+const (
+	w = 64
+	h = 32
+)
+
+interface Display {
+mut:
+	pixel(x int, y int, val bool)
+	clear()
+	refresh()
+}
+
+struct Vm {
+mut:
+	display Display
+	stack   datatypes.Stack<u16>
+}
+
+struct Pattern {
+	pattern []byte
+	handler fn (mut m Vm)
+}
+
+fn new_pattern(pattern string, handler fn (mut m Vm)) Pattern {
+	return Pattern{pattern.runes().map(byte('0x$it'.int())), handler}
+}
+
+fn test_generics_struct_parent_has_str_to_string() {
+	p := new_pattern('00E0', fn (mut m Vm) {
+		println(m)
+	})
+	println(p)
+	assert true
+}


### PR DESCRIPTION
This PR fix error for generics struct that parent has str to string (fix #14034).

- Fix error for generics struct that parent has str to string.
- Add test.

```v
import datatypes

const (
	w = 64
	h = 32
)

interface Display {
mut:
	pixel(x int, y int, val bool)
	clear()
	refresh()
}

struct Vm {
mut:
	display Display
	stack   datatypes.Stack<u16>
}

struct Pattern {
	pattern []byte
	handler fn (mut m Vm)
}

fn new_pattern(pattern string, handler fn (mut m Vm)) Pattern {
	return Pattern{pattern.runes().map(byte('0x$it'.int())), handler}
}

fn main() {
	p := new_pattern('00E0', fn (mut m Vm) {
		println(m)
	})
	println(p)
	assert true
}

PS D:\Test\v\tt1> v run .
Pattern{
    pattern: [`\0`, `\0`, 0x0e, `\0`]
    handler: fn (mut Vm)
}
```