### PR TITLE
strings: add write_byte

### DIFF
--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -60,6 +60,10 @@ pub fn (mut b Builder) write_u8(data byte) {
 	b << data
 }
 
+pub fn (mut b Builder) write_byte(data u8) {
+	b << data
+}
+
 // write implements the Writer interface
 pub fn (mut b Builder) write(data []u8) ?int {
 	if data.len == 0 {


### PR DESCRIPTION
recover `write_byte` method for `strings.Builder`
