### PR TITLE
vcreate: Allow custom default license

### DIFF
--- a/cmd/tools/vcreate.v
+++ b/cmd/tools/vcreate.v
@@ -160,7 +160,7 @@ fn create(args []string) {
 	if c.version == '' {
 		c.version = default_version
 	}
-	default_license := 'MIT'
+	default_license := os.getenv_opt('VLICENSE') or {'MIT'}
 	c.license = os.input('Input your project license: ($default_license) ')
 	if c.license == '' {
 		c.license = default_license


### PR DESCRIPTION
This allows setting a different default license when using `v init`/`v new`.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
