### PR TITLE
cgen: fix infix generics bug

### DIFF
--- a/vlib/v/gen/c/infix_expr.v
+++ b/vlib/v/gen/c/infix_expr.v
@@ -515,9 +515,15 @@ fn (mut g Gen) infix_expr_is_op(node ast.InfixExpr) {
 		g.write('_typ $cmp_op ')
 		// `_Animal_Dog_index`
 		sub_type := match node.right {
-			ast.TypeNode { node.right.typ }
-			ast.None { g.table.type_idxs['None__'] }
-			else { ast.Type(0) }
+			ast.TypeNode {
+				g.unwrap_generic(node.right.typ)
+			}
+			ast.None {
+				g.table.type_idxs['None__']
+			}
+			else {
+				ast.Type(0)
+			}
 		}
 		sub_sym := g.table.sym(sub_type)
 		g.write('_${sym.cname}_${sub_sym.cname}_index')

--- a/vlib/v/tests/generic_empty_interface_to_struct_test.v
+++ b/vlib/v/tests/generic_empty_interface_to_struct_test.v
@@ -1,0 +1,25 @@
+interface Any {}
+
+struct Concrete {
+	a int
+}
+
+struct Container {
+	concrete Any
+}
+
+fn (container &Container) get_first_struct<T>() ?&T {
+	concrete := container.concrete
+	if concrete is T {
+		println(concrete.a)
+		return concrete
+	}
+	return error("can't cast")
+}
+
+fn test_generic_empty_interface_to_struct() {
+	concrete := Concrete{12345}
+	container := Container{concrete}
+	cast_concrete := container.get_first_struct<Concrete>() or { &Concrete{} }
+	assert 12345 == cast_concrete.a
+}


### PR DESCRIPTION
Using the `is` operator with generics result in C error.
```
fn (container &Container) get_first_struct<T>() ?&T {
	concrete := container.concrete
	if concrete is T {
		println(concrete.a)
		return concrete
	}
	return error("can't cast")
}
```
Throws error `error: '_main__Any_T_index' undeclared`. Fixed by unwrapping `T` into  `_main__Any_Concrete_index`.
