### PR TITLE
time: reproduce bug on time module when unix2 is called

### DIFF
--- a/vlib/time/parse_test.v
+++ b/vlib/time/parse_test.v
@@ -161,3 +161,17 @@ fn test_invalid_dates_should_error_during_parse() {
 	check_invalid_date('2008-12-01 00:60:00')
 	check_invalid_date('2008-12-01 00:01:60')
 }
+
+fn test_ad_second_to_parse_result_in_2001() ? {
+	now_tm := time.parse('2001-01-01 04:00:00') ?
+	future_tm := now_tm.add_seconds(60)
+	assert future_tm.str() == '2001-01-01 04:01:00'
+	assert now_tm.unix < future_tm.unix
+}
+
+fn test_ad_second_to_parse_result_pre_2001() ? {
+	now_tm := time.parse('2000-01-01 04:00:00') ?
+	future_tm := now_tm.add_seconds(60)
+	assert future_tm.str() == '2000-01-01 04:01:00'
+	assert now_tm.unix < future_tm.unix
+}

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -267,3 +267,9 @@ fn test_recursive_local_call() {
 fn test_strftime() {
 	assert '1980 July 11' == time_to_test.strftime('%Y %B %d')
 }
+
+fn test_add_seconds_to_time() {
+	now_tm := time.now()
+	future_tm := now_tm.add_seconds(60)
+	assert now_tm.unix < future_tm.unix
+}


### PR DESCRIPTION
Fixes https://github.com/vlang/v/issues/14019

This will reproduce the bug and in particular when a date is converted from UNIX to a time. The error happens only then it is called time.unix2 over a UNIX timestamp before 2021.

Do you have any idea how the logic inside the method `calculate_date_from_offset` works @spytheman ?

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
