### PR TITLE
checker, cgen: fix error for if expr with generic sumtype (fix #14038)

### DIFF
--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -204,6 +204,7 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 						}
 					}
 					if node.is_expr && c.table.sym(former_expected_type).kind == .sum_type {
+						node.typ = former_expected_type
 						continue
 					}
 					if is_noreturn_callexpr(last_expr.expr) {

--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -74,7 +74,12 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 				g.expr(branch.cond)
 				g.write(' ? ')
 			}
+			prev_expected_cast_type := g.expected_cast_type
+			if node.is_expr && g.table.sym(node.typ).kind == .sum_type {
+				g.expected_cast_type = node.typ
+			}
 			g.stmts(branch.stmts)
+			g.expected_cast_type = prev_expected_cast_type
 		}
 		if node.branches.len == 1 {
 			g.write(': 0')
@@ -195,11 +200,12 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 			}
 		}
 		if needs_tmp_var {
+			prev_expected_cast_type := g.expected_cast_type
 			if node.is_expr && g.table.sym(node.typ).kind == .sum_type {
 				g.expected_cast_type = node.typ
 			}
 			g.stmts_with_tmp_var(branch.stmts, tmp)
-			g.expected_cast_type = 0
+			g.expected_cast_type = prev_expected_cast_type
 		} else {
 			// restore if_expr stmt header pos
 			stmt_pos := g.nth_stmt_pos(0)

--- a/vlib/v/tests/if_expr_with_generic_sumtype_test.v
+++ b/vlib/v/tests/if_expr_with_generic_sumtype_test.v
@@ -1,0 +1,17 @@
+type Opt<T> = None<T> | Some<T>
+
+struct None<T> {}
+
+struct Some<T> {
+mut:
+	value T
+}
+
+fn operation(r int) Opt<int> {
+	return if r > 0 { Some<int>{r} } else { None<int>{} }
+}
+
+fn test_if_expr_with_generic_sumtype() {
+	op := operation(1)
+	assert Opt<int>(Some<int>{1}) == op
+}


### PR DESCRIPTION
This PR fix error for if expr with generic sumtype (fix #14038).

- Fix error for if expr with generic sumtype.
- Add test.

```v
type Opt<T> = None<T> | Some<T>

struct None<T> {}

struct Some<T> {
mut:
	value T
}

fn operation(r int) Opt<int> {
	return if r > 0 { Some<int>{r} } else { None<int>{} }
}

fn main() {
	op := operation(1)
	println(op)
	assert Opt<int>(Some<int>{1}) == op
}

PS D:\Test\v\tt1> v run .
Opt<int>(Some<int>{
    value: 1
})
```