### PR TITLE
checker, cgen: minor cleanup of last expr stmt expression

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1533,14 +1533,12 @@ fn (mut c Checker) check_or_last_stmt(stmt ast.Stmt, ret_type ast.Type, expr_ret
 				if stmt.typ == ast.void_type {
 					if stmt.expr is ast.IfExpr {
 						for branch in stmt.expr.branches {
-							last_stmt := branch.stmts[branch.stmts.len - 1]
-							c.check_or_last_stmt(last_stmt, ret_type, expr_return_type)
+							c.check_or_last_stmt(branch.stmts.last(), ret_type, expr_return_type)
 						}
 						return
 					} else if stmt.expr is ast.MatchExpr {
 						for branch in stmt.expr.branches {
-							last_stmt := branch.stmts[branch.stmts.len - 1]
-							c.check_or_last_stmt(last_stmt, ret_type, expr_return_type)
+							c.check_or_last_stmt(branch.stmts.last(), ret_type, expr_return_type)
 						}
 						return
 					}
@@ -1570,14 +1568,12 @@ fn (mut c Checker) check_or_last_stmt(stmt ast.Stmt, ret_type ast.Type, expr_ret
 		match stmt.expr {
 			ast.IfExpr {
 				for branch in stmt.expr.branches {
-					last_stmt := branch.stmts[branch.stmts.len - 1]
-					c.check_or_last_stmt(last_stmt, ret_type, expr_return_type)
+					c.check_or_last_stmt(branch.stmts.last(), ret_type, expr_return_type)
 				}
 			}
 			ast.MatchExpr {
 				for branch in stmt.expr.branches {
-					last_stmt := branch.stmts[branch.stmts.len - 1]
-					c.check_or_last_stmt(last_stmt, ret_type, expr_return_type)
+					c.check_or_last_stmt(branch.stmts.last(), ret_type, expr_return_type)
 				}
 			}
 			else {

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -156,8 +156,8 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 			c.smartcast_cond_pos = token.Pos{}
 		}
 		if expr_required {
-			if branch.stmts.len > 0 && branch.stmts[branch.stmts.len - 1] is ast.ExprStmt {
-				mut last_expr := branch.stmts[branch.stmts.len - 1] as ast.ExprStmt
+			if branch.stmts.len > 0 && branch.stmts.last() is ast.ExprStmt {
+				mut last_expr := branch.stmts.last() as ast.ExprStmt
 				c.expected_type = former_expected_type
 				if c.expected_type.has_flag(.optional) {
 					if node.typ == ast.void_type {

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -51,7 +51,7 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 				// currently the last statement in a match branch does not have an
 				// expected value set, so e.g. IfExpr.is_expr is not set.
 				// probably any mismatch will be caught by not producing a value instead
-				for st in branch.stmts[0..branch.stmts.len - 1] {
+				for st in branch.stmts[..branch.stmts.len - 1] {
 					// must not contain C statements
 					st.check_c_expr() or {
 						c.error('`match` expression branch has $err.msg()', st.pos)
@@ -64,7 +64,7 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 		}
 		// If the last statement is an expression, return its type
 		if branch.stmts.len > 0 {
-			mut stmt := branch.stmts[branch.stmts.len - 1]
+			mut stmt := branch.stmts.last()
 			if mut stmt is ast.ExprStmt {
 				if node.is_expr {
 					c.expected_type = node.expected_type

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -263,14 +263,14 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 		if node.is_expr {
 			len := branch.stmts.len
 			if len > 0 {
-				last := branch.stmts[len - 1] as ast.ExprStmt
+				last := branch.stmts.last() as ast.ExprStmt
 				if len > 1 {
 					tmp := g.new_tmp_var()
 					styp := g.typ(last.typ)
 					g.indent++
 					g.writeln('$styp $tmp;')
 					g.writeln('{')
-					g.stmts(branch.stmts[0..len - 1])
+					g.stmts(branch.stmts[..len - 1])
 					g.write('\t$tmp = ')
 					g.stmt(last)
 					g.writeln('}')

--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -148,7 +148,7 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 				} else {
 					mut is_auto_heap := false
 					if branch.stmts.len > 0 {
-						scope := g.file.scope.innermost(ast.Node(branch.stmts[branch.stmts.len - 1]).pos().pos)
+						scope := g.file.scope.innermost(ast.Node(branch.stmts.last()).pos().pos)
 						if v := scope.find_var(branch.cond.vars[0].name) {
 							is_auto_heap = v.is_auto_heap
 						}

--- a/vlib/v/gen/js/comptime.v
+++ b/vlib/v/gen/js/comptime.v
@@ -28,13 +28,13 @@ fn (mut g JsGen) comptime_if(node ast.IfExpr) {
 			print('$branch.stmts')
 			len := branch.stmts.len
 			if len > 0 {
-				last := branch.stmts[len - 1] as ast.ExprStmt
+				last := branch.stmts.last() as ast.ExprStmt
 				if len > 1 {
 					tmp := g.new_tmp_var()
 					g.inc_indent()
 					g.writeln('let $tmp;')
 					g.writeln('{')
-					g.stmts(branch.stmts[0..len - 1])
+					g.stmts(branch.stmts[..len - 1])
 					g.write('\t$tmp = ')
 					g.stmt(last)
 					g.writeln('}')


### PR DESCRIPTION
This PR makes minor cleanup of last expr stmt expression.

- Use `branch.stmts.last()` instead of `branch.stmts[branch.stmts.len-1]`.