### PR TITLE
ast, checker, cgen: fix error for aggregate is nodetype (fix #12936)

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -937,7 +937,8 @@ pub struct Aggregate {
 mut:
 	fields []StructField // used for faster lookup inside the module
 pub:
-	types []Type
+	sum_type Type
+	types    []Type
 }
 
 pub struct Array {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1013,6 +1013,10 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				if typ_sym.kind == .placeholder {
 					c.error('$op: type `$typ_sym.name` does not exist', right_expr.pos())
 				}
+				if left_sym.kind == .aggregate {
+					parent_left_type := (left_sym.info as ast.Aggregate).sum_type
+					left_sym = c.table.sym(parent_left_type)
+				}
 				if left_sym.kind !in [.interface_, .sum_type] {
 					c.error('`$op` can only be used with interfaces and sum types', node.pos)
 				} else if mut left_sym.info is ast.SumType {

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -296,7 +296,10 @@ fn (mut c Checker) smartcast_if_conds(node ast.Expr, mut scope ast.Scope) {
 			if right_type != ast.Type(0) {
 				left_sym := c.table.sym(node.left_type)
 				right_sym := c.table.sym(right_type)
-				expr_type := c.unwrap_generic(c.expr(node.left))
+				mut expr_type := c.unwrap_generic(c.expr(node.left))
+				if left_sym.kind == .aggregate {
+					expr_type = (left_sym.info as ast.Aggregate).sum_type
+				}
 				if left_sym.kind == .interface_ {
 					if right_sym.kind != .interface_ {
 						c.type_implements(right_type, expr_type, node.pos)

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -282,6 +282,7 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 							kind: .aggregate
 							mod: c.mod
 							info: ast.Aggregate{
+								sum_type: node.cond_type
 								types: expr_types.map(it.typ)
 							}
 						})

--- a/vlib/v/tests/aggregate_is_nodetype_test.v
+++ b/vlib/v/tests/aggregate_is_nodetype_test.v
@@ -1,0 +1,19 @@
+type Abc = bool | int | string
+
+fn test_aggregate_is_nodetype() {
+	x := Abc('test')
+
+	match x {
+		string, int {
+			if x is string {
+				println('it is a string')
+				assert true
+			} else {
+				assert false
+			}
+		}
+		else {
+			assert false
+		}
+	}
+}


### PR DESCRIPTION
This PR fix error for aggregate is nodetype (fix #12936).

- Fix error for aggregate is nodetype.
- Add test.

```v
type Abc = bool | int | string

fn main() {
	x := Abc('test')
	
	match x {
		string, int {
			if x is string {
				println('it is a string')
				assert true
			} else {
				assert false
			}
		}
		else {
			assert false
		}
	}
}

PS D:\Test\v\tt1> v run .
it is a string
```