### PR TITLE
cgen: fix error for fn argument of optional  (fix #6708)

### DIFF
--- a/examples/net_raw_http.v
+++ b/examples/net_raw_http.v
@@ -8,8 +8,8 @@ fn main() {
 		conn.close() or {}
 	}
 
-	println(' peer: $conn.peer_addr()')
-	println('local: $conn.addr()')
+	println(' peer: ${conn.peer_addr() ?}')
+	println('local: ${conn.addr() ?}')
 
 	// Simple http HEAD request for a file
 	conn.write_string('HEAD /index.html HTTP/1.0\r\n\r\n') ?

--- a/examples/random_ips.v
+++ b/examples/random_ips.v
@@ -2,6 +2,6 @@ import rand
 
 fn main() {
 	for _ in 0 .. 10 {
-		println('${rand.intn(255)}.${rand.intn(255)}.${rand.intn(255)}.${rand.intn(255)}')
+		println('${rand.intn(255) ?}.${rand.intn(255) ?}.${rand.intn(255) ?}.${rand.intn(255) ?}')
 	}
 }

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -209,7 +209,8 @@ pub fn (lit &StringInterLiteral) get_fspec_braces(i int) (string, bool) {
 					break
 				}
 				CallExpr {
-					if sub_expr.args.len != 0 || sub_expr.concrete_types.len != 0 {
+					if sub_expr.args.len != 0 || sub_expr.concrete_types.len != 0
+						|| sub_expr.or_block.kind == .propagate || sub_expr.or_block.stmts.len > 0 {
 						needs_braces = true
 					} else if sub_expr.left is CallExpr {
 						sub_expr = sub_expr.left

--- a/vlib/v/tests/fn_arg_of_optional_test.v
+++ b/vlib/v/tests/fn_arg_of_optional_test.v
@@ -1,0 +1,9 @@
+fn optional_arg(x ?int) {
+	println('int type')
+	assert true
+}
+
+fn test_fn_arg_of_optional() {
+	optional_arg(1)
+	optional_arg(none)
+}


### PR DESCRIPTION
This PR fix error for fn argument of optional  (fix #6708).

- Fix error for fn argument of optional.
- Add test.

```v
fn optional_arg(x ?int) {
	println('int type')
	assert true
}

fn main() {
	optional_arg(1)
	optional_arg(none)
}

PS D:\Test\v\tt1> v run .
int type
int type
```