### PR TITLE
cgen: minor cleanup of infix_expr.v

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -495,14 +495,14 @@ fn (mut g Gen) infix_expr_in_optimization(left ast.Expr, right ast.ArrayInit) {
 
 // infix_expr_is_op generates code for `is` and `!is`
 fn (mut g Gen) infix_expr_is_op(node ast.InfixExpr) {
-	mut sym := g.table.sym(node.left_type)
-	is_aggregate := sym.kind == .aggregate
+	mut left_sym := g.table.sym(node.left_type)
+	is_aggregate := left_sym.kind == .aggregate
 	if is_aggregate {
-		parent_left_type := (sym.info as ast.Aggregate).sum_type
-		sym = g.table.sym(parent_left_type)
+		parent_left_type := (left_sym.info as ast.Aggregate).sum_type
+		left_sym = g.table.sym(parent_left_type)
 	}
 	right_sym := g.table.sym(node.right_type)
-	if sym.kind == .interface_ && right_sym.kind == .interface_ {
+	if left_sym.kind == .interface_ && right_sym.kind == .interface_ {
 		g.gen_interface_is_op(node)
 		return
 	}
@@ -520,7 +520,7 @@ fn (mut g Gen) infix_expr_is_op(node ast.InfixExpr) {
 	} else {
 		g.write('.')
 	}
-	if sym.kind == .interface_ {
+	if left_sym.kind == .interface_ {
 		g.write('_typ $cmp_op ')
 		// `_Animal_Dog_index`
 		sub_type := match node.right {
@@ -535,9 +535,9 @@ fn (mut g Gen) infix_expr_is_op(node ast.InfixExpr) {
 			}
 		}
 		sub_sym := g.table.sym(sub_type)
-		g.write('_${sym.cname}_${sub_sym.cname}_index')
+		g.write('_${left_sym.cname}_${sub_sym.cname}_index')
 		return
-	} else if sym.kind == .sum_type {
+	} else if left_sym.kind == .sum_type {
 		g.write('_typ $cmp_op ')
 	}
 	g.expr(node.right)


### PR DESCRIPTION
This PR makes minor cleanup of infix_expr.v.

- Change `infix_expr.v` to `infix.v` just like others.
- Change `sym` to `left_sym` in infix_expr_is_op().