### PR TITLE
checker: error if signed integer<,>,<=,>= small unsigned

### DIFF
--- a/vlib/net/util.v
+++ b/vlib/net/util.v
@@ -7,7 +7,7 @@ const (
 // validate_port checks whether a port is valid
 // and returns the port or an error
 pub fn validate_port(port int) ?u16 {
-	if port <= net.socket_max_port {
+	if port <= int(net.socket_max_port) {
 		return u16(port)
 	} else {
 		return err_port_out_of_range

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -556,12 +556,16 @@ fn (mut c Checker) compare_ints(node &ast.InfixExpr, left_type ast.Type, right_t
 	is_left_type_signed := left_type in ast.signed_integer_type_idxs
 	is_right_type_signed := right_type in ast.signed_integer_type_idxs
 	if !is_left_type_signed && node.right is ast.IntegerLiteral {
-		if node.right.val[0] == `-` && left_type in ast.int_promoted_type_idxs {
+		// TODO remove promoted, eq/ne check
+		if node.right.val[0] == `-`
+			&& (left_type in ast.int_promoted_type_idxs || node.op !in [.eq, .ne]) {
 			lt := c.table.sym(left_type).name
 			c.error('`$lt` cannot be compared with negative value', node.right.pos)
 		}
 	} else if !is_right_type_signed && node.left is ast.IntegerLiteral {
-		if node.left.val[0] == `-` && right_type in ast.int_promoted_type_idxs {
+		// ditto
+		if node.left.val[0] == `-`
+			&& (right_type in ast.int_promoted_type_idxs || node.op !in [.eq, .ne]) {
 			rt := c.table.sym(right_type).name
 			c.error('negative value cannot be compared with `$rt`', node.left.pos)
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -556,12 +556,12 @@ fn (mut c Checker) compare_ints(node &ast.InfixExpr, left_type ast.Type, right_t
 	is_left_type_signed := left_type in ast.signed_integer_type_idxs
 	is_right_type_signed := right_type in ast.signed_integer_type_idxs
 	if !is_left_type_signed && node.right is ast.IntegerLiteral {
-		if node.right.val.int() < 0 && left_type in ast.int_promoted_type_idxs {
+		if node.right.val[0] == `-` && left_type in ast.int_promoted_type_idxs {
 			lt := c.table.sym(left_type).name
 			c.error('`$lt` cannot be compared with negative value', node.right.pos)
 		}
 	} else if !is_right_type_signed && node.left is ast.IntegerLiteral {
-		if node.left.val.int() < 0 && right_type in ast.int_promoted_type_idxs {
+		if node.left.val[0] == `-` && right_type in ast.int_promoted_type_idxs {
 			rt := c.table.sym(right_type).name
 			c.error('negative value cannot be compared with `$rt`', node.left.pos)
 		}

--- a/vlib/v/checker/str.v
+++ b/vlib/v/checker/str.v
@@ -166,7 +166,7 @@ pub fn (mut c Checker) int_lit(mut node ast.IntegerLiteral) ast.Type {
 		return ast.int_literal_type
 	}
 	lit := node.val.replace('_', '').all_after('-')
-	is_neg := node.val.starts_with('-')
+	is_neg := node.val[0] == `-`
 	limit := if is_neg { '9223372036854775808' } else { '18446744073709551615' }
 	message := 'integer literal $node.val overflows int'
 

--- a/vlib/v/checker/tests/compare_unsigned_signed.out
+++ b/vlib/v/checker/tests/compare_unsigned_signed.out
@@ -1,10 +1,10 @@
-vlib/v/checker/tests/compare_unsigned_signed.vv:2:14: error: unsigned integer cannot be compared with negative value
+vlib/v/checker/tests/compare_unsigned_signed.vv:2:14: error: `u32` cannot be compared with negative value
     1 | fn main() {
     2 |     if u32(1) < -1 {
       |                 ~~
     3 |         println('unexpected')
     4 |     }
-vlib/v/checker/tests/compare_unsigned_signed.vv:6:5: error: unsigned integer cannot be compared with negative value
+vlib/v/checker/tests/compare_unsigned_signed.vv:6:5: error: negative value cannot be compared with `u32`
     4 |     }
     5 | 
     6 |     if -1 > u32(1) {


### PR DESCRIPTION
Follows on from #13967.

Refactor checks so that less than/greater than checks also check non-literal values, like the equals checks.
Also speed up checking if a literal is < 0.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
