### PR TITLE
checker: revert part of small_unsigned == signed (#13967)

### DIFF
--- a/vlib/bitfield/bitfield_test.v
+++ b/vlib/bitfield/bitfield_test.v
@@ -161,7 +161,7 @@ fn test_bf_from_str() {
 	output := bitfield.from_str(input)
 	mut result := 1
 	for i in 0 .. len {
-		if input[i] != u8(output.get_bit(i)) + 48 {
+		if input[i] != output.get_bit(i) + 48 {
 			result = 0
 		}
 	}

--- a/vlib/term/ui/input_windows.c.v
+++ b/vlib/term/ui/input_windows.c.v
@@ -288,8 +288,8 @@ fn (mut ctx Context) parse_events() {
 				if !C.GetConsoleScreenBufferInfo(ctx.stdout_handle, &sb) {
 					panic('could not get screenbuffer info')
 				}
-				w := int(sb.srWindow.Right - sb.srWindow.Left + 1)
-				h := int(sb.srWindow.Bottom - sb.srWindow.Top + 1)
+				w := sb.srWindow.Right - sb.srWindow.Left + 1
+				h := sb.srWindow.Bottom - sb.srWindow.Top + 1
 				utf8 := '($ctx.window_width, $ctx.window_height) -> ($w, $h)'
 				if w != ctx.window_width || h != ctx.window_height {
 					ctx.window_width, ctx.window_height = w, h

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -639,15 +639,6 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 						rt := c.table.sym(right_type).name
 						c.error('negative value cannot be compared with `$rt`', node.left.pos)
 					}
-				} else if is_left_type_signed != is_right_type_signed
-					&& left_type.flip_signedness() != right_type {
-					// prevent e.g. `u16(-1) == int(-1)` which is false in C
-					if (is_right_type_signed && left_type in ast.int_promoted_type_idxs)
-						|| (is_left_type_signed && right_type in ast.int_promoted_type_idxs) {
-						lt := c.table.sym(left_type).name
-						rt := c.table.sym(right_type).name
-						c.error('`$lt` cannot be compared with `$rt`', node.pos)
-					}
 				}
 			}
 		}

--- a/vlib/v/checker/tests/compare_unsigned_signed.out
+++ b/vlib/v/checker/tests/compare_unsigned_signed.out
@@ -17,24 +17,10 @@ vlib/v/checker/tests/compare_unsigned_signed.vv:10:16: error: `u8` cannot be com
    10 |     _ = u8(-1) == -1 // false!
       |                   ~~
    11 |     _ = -1 == u16(-1) // false!
-   12 |
+   12 | }
 vlib/v/checker/tests/compare_unsigned_signed.vv:11:6: error: negative value cannot be compared with `u16`
     9 |     // unsigned == literal
    10 |     _ = u8(-1) == -1 // false!
    11 |     _ = -1 == u16(-1) // false!
       |         ~~
-   12 | 
-   13 |     // unsigned == signed
-vlib/v/checker/tests/compare_unsigned_signed.vv:14:14: error: `u16` cannot be compared with `int`
-   12 | 
-   13 |     // unsigned == signed
-   14 |     _ = u16(-1) == int(-1)
-      |                 ~~
-   15 |     _ = int(-1) != u8(-1)
-   16 | }
-vlib/v/checker/tests/compare_unsigned_signed.vv:15:14: error: `int` cannot be compared with `u8`
-   13 |     // unsigned == signed
-   14 |     _ = u16(-1) == int(-1)
-   15 |     _ = int(-1) != u8(-1)
-      |                 ~~
-   16 | }
+   12 | }

--- a/vlib/v/checker/tests/compare_unsigned_signed.vv
+++ b/vlib/v/checker/tests/compare_unsigned_signed.vv
@@ -9,8 +9,4 @@ fn main() {
 	// unsigned == literal
 	_ = u8(-1) == -1 // false!
 	_ = -1 == u16(-1) // false!
-
-	// unsigned == signed
-	_ = u16(-1) == int(-1)
-	_ = int(-1) != u8(-1)
 }

--- a/vlib/x/ttf/render_bmp.v
+++ b/vlib/x/ttf/render_bmp.v
@@ -778,7 +778,7 @@ pub fn (mut bmp BitMap) draw_glyph(index u16) (int, int) {
 			}
 		}
 
-		if count == int(glyph.contour_ends[c]) {
+		if count == glyph.contour_ends[c] {
 			// dprintln("count == glyph.contour_ends[count]")
 			if s == 2 { // final point was off-curve. connect to start
 


### PR DESCRIPTION
`gcc -W` doesn't error for e.g. u16 == i32, only for u32 == i16.
Any u16 value can fit in an i32. So I changed my mind, I think we should actually allow `u16 == i32`. (The `u32 == i16` check hasn't been implemented yet).

This keeps the check for unsigned == negative literal. See #13967.



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
