### PR TITLE
checker: check error for fn decl with optional arguments (fix #6708)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -181,6 +181,9 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				c.error('invalid use of reserved type `$param.name` as a parameter name',
 					param.pos)
 			}
+			if param.typ.has_flag(.optional) {
+				c.error('optional type argument is not supported currently', param.type_pos)
+			}
 			if !param.typ.is_ptr() { // value parameter, i.e. on stack - check for `[heap]`
 				arg_typ_sym := c.table.sym(param.typ)
 				if arg_typ_sym.kind == .struct_ {

--- a/vlib/v/checker/tests/fn_arg_of_optional_err.out
+++ b/vlib/v/checker/tests/fn_arg_of_optional_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/fn_arg_of_optional_err.vv:1:19: error: optional type argument is not supported currently
+    1 | fn optional_arg(x ?int) {
+      |                   ^
+    2 |     println('int type: $x')
+    3 | }

--- a/vlib/v/checker/tests/fn_arg_of_optional_err.vv
+++ b/vlib/v/checker/tests/fn_arg_of_optional_err.vv
@@ -1,0 +1,7 @@
+fn optional_arg(x ?int) {
+	println('int type: $x')
+}
+
+fn main() {
+	optional_arg(1)
+}


### PR DESCRIPTION
This PR check error for fn decl with optional arguments (fix #6708).

- Check error for fn decl with optional arguments.
- Add test.

```v
fn optional_arg(x ?int) {
	println('int type: $x')
}

fn main() {
	optional_arg(1)
}

PS D:\Test\v\tt1> v run .
./tt1.v:1:19: error: optional type argument is not supported currently
    1 | fn optional_arg(x ?int) {
      |                   ^
    2 |     println('int type: $x')
    3 | }
```