### PR TITLE
vlib: fixed bst child access if root is none

### DIFF
--- a/vlib/datatypes/bstree.v
+++ b/vlib/datatypes/bstree.v
@@ -93,13 +93,13 @@ fn (mut bst BSTree<T>) insert_helper(mut node BSTreeNode<T>, value T) bool {
 
 // contains checks if an element with a given `value` is inside the BST.
 pub fn (bst &BSTree<T>) contains(value T) bool {
-	return bst == 0 || bst.contains_helper(bst.root, value)
+	return bst.contains_helper(bst.root, value)
 }
 
 // contains_helper is a helper function to walk the tree, and return
 // the absence or presence of the `value`.
 fn (bst &BSTree<T>) contains_helper(node &BSTreeNode<T>, value T) bool {
-	if bst == 0 || node == 0 || !node.is_init {
+	if node == 0 || !node.is_init {
 		return false
 	}
 	if node.value < value {
@@ -113,7 +113,7 @@ fn (bst &BSTree<T>) contains_helper(node &BSTreeNode<T>, value T) bool {
 
 // remove removes an element with `value` from the BST.
 pub fn (mut bst BSTree<T>) remove(value T) bool {
-	if bst.root == 0 {
+	if bst.is_empty() {
 		return false
 	}
 	return bst.remove_helper(mut bst.root, value, false)
@@ -153,7 +153,7 @@ fn (mut bst BSTree<T>) remove_helper(mut node BSTreeNode<T>, value T, left bool)
 
 // get_max_from_right returns the max element of the BST following the right branch.
 fn (bst &BSTree<T>) get_max_from_right(node &BSTreeNode<T>) &BSTreeNode<T> {
-	if node == 0 || bst == 0 {
+	if node == 0 {
 		return new_none_node<T>(false)
 	}
 	right_node := node.right
@@ -165,7 +165,7 @@ fn (bst &BSTree<T>) get_max_from_right(node &BSTreeNode<T>) &BSTreeNode<T> {
 
 // get_min_from_left returns the min element of the BST by following the left branch.
 fn (bst &BSTree<T>) get_min_from_left(node &BSTreeNode<T>) &BSTreeNode<T> {
-	if node == 0 || bst == 0 {
+	if node == 0 {
 		return new_none_node<T>(false)
 	}
 	left_node := node.left
@@ -177,7 +177,7 @@ fn (bst &BSTree<T>) get_min_from_left(node &BSTreeNode<T>) &BSTreeNode<T> {
 
 // is_empty checks if the BST is empty
 pub fn (bst &BSTree<T>) is_empty() bool {
-	return bst == 0 || bst.root == 0
+	return bst.root == 0
 }
 
 // in_order_traversal traverses the BST in order, and returns the result as an array.
@@ -189,7 +189,7 @@ pub fn (bst &BSTree<T>) in_order_traversal() []T {
 
 // in_order_traversal_helper helps traverse the BST, and accumulates the result in the `result` array.
 fn (bst &BSTree<T>) in_order_traversal_helper(node &BSTreeNode<T>, mut result []T) {
-	if bst == 0 || node == 0 || !node.is_init {
+	if node == 0 || !node.is_init {
 		return
 	}
 	bst.in_order_traversal_helper(node.left, mut result)
@@ -207,7 +207,7 @@ pub fn (bst &BSTree<T>) post_order_traversal() []T {
 // post_order_traversal_helper is a helper function that traverses the BST in post order,
 // accumulating the result in an array.
 fn (bst &BSTree<T>) post_order_traversal_helper(node &BSTreeNode<T>, mut result []T) {
-	if bst == 0 || node == 0 || !node.is_init {
+	if node == 0 || !node.is_init {
 		return
 	}
 
@@ -226,7 +226,7 @@ pub fn (bst &BSTree<T>) pre_order_traversal() []T {
 // pre_order_traversal_helper is a helper function to traverse the BST
 // in pre order and accumulates the results in an array.
 fn (bst &BSTree<T>) pre_order_traversal_helper(node &BSTreeNode<T>, mut result []T) {
-	if bst == 0 || node == 0 || !node.is_init {
+	if node == 0 || !node.is_init {
 		return
 	}
 	result << node.value
@@ -236,7 +236,7 @@ fn (bst &BSTree<T>) pre_order_traversal_helper(node &BSTreeNode<T>, mut result [
 
 // get_node is a helper method to ge the internal rapresentation of the node with the `value`.
 fn (bst &BSTree<T>) get_node(node &BSTreeNode<T>, value T) &BSTreeNode<T> {
-	if bst == 0 || node == 0 || !node.is_init {
+	if node == 0 || !node.is_init {
 		return new_none_node<T>(false)
 	}
 	if node.value == value {
@@ -257,7 +257,7 @@ fn (bst &BSTree<T>) get_node(node &BSTreeNode<T>, value T) &BSTreeNode<T> {
 // left_value, exist := bst.to_left(10)
 //```
 pub fn (bst &BSTree<T>) to_left(value T) ?T {
-	if bst == 0 {
+	if bst.is_empty() {
 		return none
 	}
 	node := bst.get_node(bst.root, value)
@@ -276,7 +276,7 @@ pub fn (bst &BSTree<T>) to_left(value T) ?T {
 // left_value, exist := bst.to_right(10)
 //```
 pub fn (bst &BSTree<T>) to_right(value T) ?T {
-	if bst == 0 {
+	if bst.is_empty() {
 		return none
 	}
 	node := bst.get_node(bst.root, value)
@@ -290,7 +290,7 @@ pub fn (bst &BSTree<T>) to_right(value T) ?T {
 // max return the max element inside the BST.
 // Time complexity O(N) if the BST is not balanced
 pub fn (bst &BSTree<T>) max() ?T {
-	if bst == 0 {
+	if bst.is_empty() {
 		return none
 	}
 	max := bst.get_max_from_right(bst.root)
@@ -303,7 +303,7 @@ pub fn (bst &BSTree<T>) max() ?T {
 // min return the minimum element in the BST.
 // Time complexity O(N) if the BST is not balanced.
 pub fn (bst &BSTree<T>) min() ?T {
-	if bst == 0 {
+	if bst.is_empty() {
 		return none
 	}
 	min := bst.get_min_from_left(bst.root)

--- a/vlib/datatypes/bstree.v
+++ b/vlib/datatypes/bstree.v
@@ -93,13 +93,13 @@ fn (mut bst BSTree<T>) insert_helper(mut node BSTreeNode<T>, value T) bool {
 
 // contains checks if an element with a given `value` is inside the BST.
 pub fn (bst &BSTree<T>) contains(value T) bool {
-	return bst.contains_helper(bst.root, value)
+	return bst == 0 || bst.contains_helper(bst.root, value)
 }
 
 // contains_helper is a helper function to walk the tree, and return
 // the absence or presence of the `value`.
 fn (bst &BSTree<T>) contains_helper(node &BSTreeNode<T>, value T) bool {
-	if node == 0 || !node.is_init {
+	if bst == 0 || node == 0 || !node.is_init {
 		return false
 	}
 	if node.value < value {
@@ -153,6 +153,9 @@ fn (mut bst BSTree<T>) remove_helper(mut node BSTreeNode<T>, value T, left bool)
 
 // get_max_from_right returns the max element of the BST following the right branch.
 fn (bst &BSTree<T>) get_max_from_right(node &BSTreeNode<T>) &BSTreeNode<T> {
+	if node == 0 || bst == 0 {
+		return new_none_node<T>(false)
+	}
 	right_node := node.right
 	if right_node == 0 || !right_node.is_init {
 		return node
@@ -162,6 +165,9 @@ fn (bst &BSTree<T>) get_max_from_right(node &BSTreeNode<T>) &BSTreeNode<T> {
 
 // get_min_from_left returns the min element of the BST by following the left branch.
 fn (bst &BSTree<T>) get_min_from_left(node &BSTreeNode<T>) &BSTreeNode<T> {
+	if node == 0 || bst == 0 {
+		return new_none_node<T>(false)
+	}
 	left_node := node.left
 	if left_node == 0 || !left_node.is_init {
 		return node
@@ -171,7 +177,7 @@ fn (bst &BSTree<T>) get_min_from_left(node &BSTreeNode<T>) &BSTreeNode<T> {
 
 // is_empty checks if the BST is empty
 pub fn (bst &BSTree<T>) is_empty() bool {
-	return bst.root == 0
+	return bst == 0 || bst.root == 0
 }
 
 // in_order_traversal traverses the BST in order, and returns the result as an array.
@@ -183,7 +189,7 @@ pub fn (bst &BSTree<T>) in_order_traversal() []T {
 
 // in_order_traversal_helper helps traverse the BST, and accumulates the result in the `result` array.
 fn (bst &BSTree<T>) in_order_traversal_helper(node &BSTreeNode<T>, mut result []T) {
-	if node == 0 || !node.is_init {
+	if bst == 0 || node == 0 || !node.is_init {
 		return
 	}
 	bst.in_order_traversal_helper(node.left, mut result)
@@ -201,7 +207,7 @@ pub fn (bst &BSTree<T>) post_order_traversal() []T {
 // post_order_traversal_helper is a helper function that traverses the BST in post order,
 // accumulating the result in an array.
 fn (bst &BSTree<T>) post_order_traversal_helper(node &BSTreeNode<T>, mut result []T) {
-	if node == 0 || !node.is_init {
+	if bst == 0 || node == 0 || !node.is_init {
 		return
 	}
 
@@ -220,7 +226,7 @@ pub fn (bst &BSTree<T>) pre_order_traversal() []T {
 // pre_order_traversal_helper is a helper function to traverse the BST
 // in pre order and accumulates the results in an array.
 fn (bst &BSTree<T>) pre_order_traversal_helper(node &BSTreeNode<T>, mut result []T) {
-	if node == 0 || !node.is_init {
+	if bst == 0 || node == 0 || !node.is_init {
 		return
 	}
 	result << node.value
@@ -230,7 +236,7 @@ fn (bst &BSTree<T>) pre_order_traversal_helper(node &BSTreeNode<T>, mut result [
 
 // get_node is a helper method to ge the internal rapresentation of the node with the `value`.
 fn (bst &BSTree<T>) get_node(node &BSTreeNode<T>, value T) &BSTreeNode<T> {
-	if node == 0 || !node.is_init {
+	if bst == 0 || node == 0 || !node.is_init {
 		return new_none_node<T>(false)
 	}
 	if node.value == value {
@@ -251,6 +257,9 @@ fn (bst &BSTree<T>) get_node(node &BSTreeNode<T>, value T) &BSTreeNode<T> {
 // left_value, exist := bst.to_left(10)
 //```
 pub fn (bst &BSTree<T>) to_left(value T) ?T {
+	if bst == 0 {
+		return none
+	}
 	node := bst.get_node(bst.root, value)
 	if !node.is_init {
 		return none
@@ -267,6 +276,9 @@ pub fn (bst &BSTree<T>) to_left(value T) ?T {
 // left_value, exist := bst.to_right(10)
 //```
 pub fn (bst &BSTree<T>) to_right(value T) ?T {
+	if bst == 0 {
+		return none
+	}
 	node := bst.get_node(bst.root, value)
 	if !node.is_init {
 		return none
@@ -278,6 +290,9 @@ pub fn (bst &BSTree<T>) to_right(value T) ?T {
 // max return the max element inside the BST.
 // Time complexity O(N) if the BST is not balanced
 pub fn (bst &BSTree<T>) max() ?T {
+	if bst == 0 {
+		return none
+	}
 	max := bst.get_max_from_right(bst.root)
 	if !max.is_init {
 		return none
@@ -288,6 +303,9 @@ pub fn (bst &BSTree<T>) max() ?T {
 // min return the minimum element in the BST.
 // Time complexity O(N) if the BST is not balanced.
 pub fn (bst &BSTree<T>) min() ?T {
+	if bst == 0 {
+		return none
+	}
 	min := bst.get_min_from_left(bst.root)
 	if !min.is_init {
 		return none

--- a/vlib/datatypes/bstree_test.v
+++ b/vlib/datatypes/bstree_test.v
@@ -116,6 +116,7 @@ fn test_remove_from_bst_two() {
 // check if we are able to get the max from the BST.
 fn test_get_max_in_bst() {
 	mut bst := BSTree<int>{}
+	assert (bst.max() or {-1}) == -1
 	assert bst.insert(10)
 	assert bst.insert(20)
 	assert bst.insert(21)
@@ -127,6 +128,7 @@ fn test_get_max_in_bst() {
 // check if we are able to get the min from the BST.
 fn test_get_min_in_bst() {
 	mut bst := BSTree<int>{}
+	assert (bst.min() or {-1}) == -1
 	assert bst.insert(10)
 	assert bst.insert(20)
 	assert bst.insert(21)

--- a/vlib/datatypes/bstree_test.v
+++ b/vlib/datatypes/bstree_test.v
@@ -116,7 +116,7 @@ fn test_remove_from_bst_two() {
 // check if we are able to get the max from the BST.
 fn test_get_max_in_bst() {
 	mut bst := BSTree<int>{}
-	assert (bst.max() or {-1}) == -1
+	assert (bst.max() or { -1 }) == -1
 	assert bst.insert(10)
 	assert bst.insert(20)
 	assert bst.insert(21)
@@ -128,7 +128,7 @@ fn test_get_max_in_bst() {
 // check if we are able to get the min from the BST.
 fn test_get_min_in_bst() {
 	mut bst := BSTree<int>{}
-	assert (bst.min() or {-1}) == -1
+	assert (bst.min() or { -1 }) == -1
 	assert bst.insert(10)
 	assert bst.insert(20)
 	assert bst.insert(21)

--- a/vlib/v/checker/tests/check_err_msg_with_generics.out
+++ b/vlib/v/checker/tests/check_err_msg_with_generics.out
@@ -4,24 +4,24 @@ vlib/v/checker/tests/check_err_msg_with_generics.vv:15:10: error: cannot cast st
    15 |     println(int(typ))
       |             ~~~~~~~~
    16 | }
-vlib/datatypes/bstree.v:190:17: error: cannot append `T` to `[]T`
-  188 |     }
-  189 |     bst.in_order_traversal_helper(node.left, mut result)
-  190 |     result << node.value
+vlib/datatypes/bstree.v:196:17: error: cannot append `T` to `[]T`
+  194 |     }
+  195 |     bst.in_order_traversal_helper(node.left, mut result)
+  196 |     result << node.value
       |                    ~~~~~
-  191 |     bst.in_order_traversal_helper(node.right, mut result)
-  192 | }
-vlib/datatypes/bstree.v:210:17: error: cannot append `T` to `[]T`
-  208 |     bst.post_order_traversal_helper(node.left, mut result)
-  209 |     bst.post_order_traversal_helper(node.right, mut result)
-  210 |     result << node.value
+  197 |     bst.in_order_traversal_helper(node.right, mut result)
+  198 | }
+vlib/datatypes/bstree.v:216:17: error: cannot append `T` to `[]T`
+  214 |     bst.post_order_traversal_helper(node.left, mut result)
+  215 |     bst.post_order_traversal_helper(node.right, mut result)
+  216 |     result << node.value
       |                    ~~~~~
-  211 | }
-  212 |
-vlib/datatypes/bstree.v:226:17: error: cannot append `T` to `[]T`
-  224 |         return
-  225 |     }
-  226 |     result << node.value
+  217 | }
+  218 |
+vlib/datatypes/bstree.v:232:17: error: cannot append `T` to `[]T`
+  230 |         return
+  231 |     }
+  232 |     result << node.value
       |                    ~~~~~
-  227 |     bst.pre_order_traversal_helper(node.left, mut result)
-  228 |     bst.pre_order_traversal_helper(node.right, mut result)
+  233 |     bst.pre_order_traversal_helper(node.left, mut result)
+  234 |     bst.pre_order_traversal_helper(node.right, mut result)


### PR DESCRIPTION
Fixed child access handling for 'none' == root added tests.
Mentioned in #14059.