### PR TITLE
Fix msg

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -708,8 +708,8 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 	}
 	if node.concrete_types.len > 0 && func.generic_names.len > 0
 		&& node.concrete_types.len != func.generic_names.len {
-		desc := if node.concrete_types.len > func.generic_names.len { 'many' } else { 'little' }
-		c.error('too $desc generic parameters got $node.concrete_types.len, expected $func.generic_names.len',
+		plural := if node.concrete_types.len == 1 { '' } else { 's' }
+		c.error('expected $func.generic_names.len generic parameter$plural, got $node.concrete_types.len',
 			node.concrete_list_pos)
 	}
 	for concrete_type in node.concrete_types {
@@ -1231,12 +1231,8 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 		}
 		if node.concrete_types.len > 0 && method.generic_names.len > 0
 			&& node.concrete_types.len != method.generic_names.len {
-			desc := if node.concrete_types.len > method.generic_names.len {
-				'many'
-			} else {
-				'little'
-			}
-			c.error('too $desc generic parameters got $node.concrete_types.len, expected $method.generic_names.len',
+			plural := if node.concrete_types.len == 1 { '' } else { 's' }
+			c.error('expected $method.generic_names.len generic parameter$plural, got $node.concrete_types.len',
 				node.concrete_list_pos)
 		}
 		for concrete_type in node.concrete_types {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -708,7 +708,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 	}
 	if node.concrete_types.len > 0 && func.generic_names.len > 0
 		&& node.concrete_types.len != func.generic_names.len {
-		plural := if node.concrete_types.len == 1 { '' } else { 's' }
+		plural := if func.generic_names.len == 1 { '' } else { 's' }
 		c.error('expected $func.generic_names.len generic parameter$plural, got $node.concrete_types.len',
 			node.concrete_list_pos)
 	}
@@ -1231,7 +1231,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 		}
 		if node.concrete_types.len > 0 && method.generic_names.len > 0
 			&& node.concrete_types.len != method.generic_names.len {
-			plural := if node.concrete_types.len == 1 { '' } else { 's' }
+			plural := if method.generic_names.len == 1 { '' } else { 's' }
 			c.error('expected $method.generic_names.len generic parameter$plural, got $node.concrete_types.len',
 				node.concrete_list_pos)
 		}

--- a/vlib/v/checker/tests/generics_fn_arguments_count_err.out
+++ b/vlib/v/checker/tests/generics_fn_arguments_count_err.out
@@ -1,25 +1,25 @@
-vlib/v/checker/tests/generics_fn_arguments_count_err.vv:12:18: error: too little generic parameters got 1, expected 2
+vlib/v/checker/tests/generics_fn_arguments_count_err.vv:12:18: error: expected 2 generic parameters, got 1
    10 |
    11 | fn main() {
    12 |     ret1 := get_name<int>(11, 22)
       |                     ~~~~~
    13 |     println(ret1)
    14 |
-vlib/v/checker/tests/generics_fn_arguments_count_err.vv:15:18: error: too many generic parameters got 3, expected 2
+vlib/v/checker/tests/generics_fn_arguments_count_err.vv:15:18: error: expected 2 generic parameters, got 3
    13 |     println(ret1)
    14 |
    15 |     ret2 := get_name<int, int, string>(11, 22, 'hello')
       |                     ~~~~~~~~~~~~~~~~~~
    16 |     println(ret2)
    17 |
-vlib/v/checker/tests/generics_fn_arguments_count_err.vv:19:22: error: too little generic parameters got 1, expected 2
+vlib/v/checker/tests/generics_fn_arguments_count_err.vv:19:22: error: expected 2 generic parameters, got 1
    17 |
    18 |     foo := Foo{}
    19 |     ret3 := foo.get_name<int>(11, 22)
       |                         ~~~~~
    20 |     println(ret3)
    21 |
-vlib/v/checker/tests/generics_fn_arguments_count_err.vv:22:22: error: too many generic parameters got 3, expected 2
+vlib/v/checker/tests/generics_fn_arguments_count_err.vv:22:22: error: expected 2 generic parameters, got 3
    20 |     println(ret3)
    21 |
    22 |     ret4 := foo.get_name<int, int, string>(11, 22, 'hello')

--- a/vlib/v/checker/tests/generics_too_many_parameters.out
+++ b/vlib/v/checker/tests/generics_too_many_parameters.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/generics_too_many_parameters.vv:6:8: error: too many generic parameters got 5, expected 1
-    4 | 
+vlib/v/checker/tests/generics_too_many_parameters.vv:6:8: error: expected 1 generic parameter, got 5
+    4 |
     5 | fn main() {
     6 |     foo<bool, int, bool, bool, int>(1)
       |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes error messages when number of generic parameters don't match. Message is now shorter, and grammatically correct.