### PR TITLE
checker: fix error for fn with multi return (fix #14085)

### DIFF
--- a/vlib/v/tests/fn_multi_return_test.v
+++ b/vlib/v/tests/fn_multi_return_test.v
@@ -1,0 +1,49 @@
+fn multret1(i int, j int) (int, int) {
+	return if i > j { i, 10 } else { 10, j }
+}
+
+fn multret2(i int, j int) (int, int) {
+	return match i > j {
+		true { i, 10 }
+		false { 10, j }
+	}
+}
+
+fn multret3(i int, j int) (int, int) {
+	if i > j {
+		return i, 10
+	} else {
+		return 10, j
+	}
+}
+
+fn multret4(i int, j int) (int, int) {
+	match i > j {
+		true { return i, 10 }
+		false { return 10, j }
+	}
+}
+
+fn test_fn_multi_return() {
+	mut a, mut b := 0, 0
+
+	println(multret1(3, 14))
+	a, b = multret1(3, 14)
+	assert a == 10
+	assert b == 14
+
+	println(multret2(3, 14))
+	a, b = multret2(3, 14)
+	assert a == 10
+	assert b == 14
+
+	println(multret3(3, 14))
+	a, b = multret3(3, 14)
+	assert a == 10
+	assert b == 14
+
+	println(multret4(3, 14))
+	a, b = multret4(3, 14)
+	assert a == 10
+	assert b == 14
+}


### PR DESCRIPTION
This PR fix error for fn with multi return (fix #14085).

- Fix error for fn with multi return.
- Add test.

```v
fn multret1(i int, j int) (int, int) {
	return if i > j { i, 10 } else { 10, j }
}

fn multret2(i int, j int) (int, int) {
	return match i > j {
		true { i, 10 }
		false { 10, j }
	}
}

fn multret3(i int, j int) (int, int) {
	if i > j {
		return i, 10
	} else {
		return 10, j
	}
}

fn multret4(i int, j int) (int, int) {
	match i > j {
		true { return i, 10 }
		false { return 10, j }
	}
}

fn main() {
	mut a, mut b := 0, 0

	println(multret1(3, 14))
	a, b = multret1(3, 14)
	assert a == 10
	assert b == 14

	println(multret2(3, 14))
	a, b = multret2(3, 14)
	assert a == 10
	assert b == 14

	println(multret3(3, 14))
	a, b = multret3(3, 14)
	assert a == 10
	assert b == 14

	println(multret4(3, 14))
	a, b = multret4(3, 14)
	assert a == 10
	assert b == 14
}

PS D:\Test\v\tt1> v run .
(10, 14)
(10, 14)
(10, 14)
(10, 14)
```