### PR TITLE
checker: fix error for assigning array of aliases (fix #14082)

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -336,6 +336,17 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			c.error('use `array2 $node.op.str() array1.clone()` instead of `array2 $node.op.str() array1` (or use `unsafe`)',
 				node.pos)
 		}
+		if left_sym.kind == .array && right_sym.kind == .array {
+			// `mut arr := [u8(1),2,3]`
+			// `arr = [byte(4),5,6]`
+			left_info := left_sym.info as ast.Array
+			left_elem_type := c.table.unaliased_type(left_info.elem_type)
+			right_info := right_sym.info as ast.Array
+			right_elem_type := c.table.unaliased_type(right_info.elem_type)
+			if left_info.nr_dims == right_info.nr_dims && left_elem_type == right_elem_type {
+				continue
+			}
+		}
 		if left_sym.kind == .array_fixed && !c.inside_unsafe && node.op in [.assign, .decl_assign]
 			&& right_sym.kind == .array_fixed && (left is ast.Ident && !left.is_blank_ident())
 			&& right is ast.Ident {

--- a/vlib/v/tests/assign_array_of_aliases_test.v
+++ b/vlib/v/tests/assign_array_of_aliases_test.v
@@ -1,0 +1,10 @@
+fn test_assign_array_of_aliases() {
+	mut arr := [u8(1), 2, 3]
+	arr = [byte(4), 5, 6]
+
+	println(arr)
+	assert arr.len == 3
+	assert arr[0] == 4
+	assert arr[1] == 5
+	assert arr[2] == 6
+}


### PR DESCRIPTION
This PR fix error for assigning array of aliases (fix #14082).

- Fix error for assigning array of aliases.
- Add test.

```v
fn main() {
	mut arr := [u8(1), 2, 3]
	arr = [byte(4), 5, 6]

	println(arr)
	assert arr.len == 3
	assert arr[0] == 4
	assert arr[1] == 5
	assert arr[2] == 6
}

PS D:\Test\v\tt1> v run .
[0x04, 0x05, 0x06]
```