### PR TITLE
vpm: fix get_all_modules()

### DIFF
--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -589,12 +589,17 @@ fn get_all_modules() []string {
 		// get the start index of the module entry
 		mut start_index := s.index_after(start_token, read_len)
 		if start_index == -1 {
-			break
+			start_token = '<a href="/mod'
+			start_index = s.index_after(start_token, read_len)
+			if start_index == -1 {
+				break
+			}
 		}
 		// get the index of the end of anchor (a) opening tag
 		// we use the previous start_index to make sure we are getting a module and not just a random 'a' tag
-		start_token = "'>"
+		start_token = '>'
 		start_index = s.index_after(start_token, start_index) + start_token.len
+
 		// get the index of the end of module entry
 		end_index := s.index_after(end_token, start_index)
 		if end_index == -1 {

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -584,7 +584,7 @@ fn get_all_modules() []string {
 	mut read_len := 0
 	mut modules := []string{}
 	for read_len < s.len {
-		mut start_token := '<a href="/mod'
+		mut start_token := "<a href='/mod"
 		end_token := '</a>'
 		// get the start index of the module entry
 		mut start_index := s.index_after(start_token, read_len)
@@ -593,7 +593,7 @@ fn get_all_modules() []string {
 		}
 		// get the index of the end of anchor (a) opening tag
 		// we use the previous start_index to make sure we are getting a module and not just a random 'a' tag
-		start_token = '">'
+		start_token = "'>"
 		start_index = s.index_after(start_token, start_index) + start_token.len
 		// get the index of the end of module entry
 		end_index := s.index_after(end_token, start_index)


### PR DESCRIPTION
Fixes broken `get_all_modules` in cmd/tools/vpm.v.
`a` tags on [vpm.vlang.io](http://vpm.vlang.io) uses the single quotation mark, while `get_all_modules` was searching for double quotation marks.

<img src="https://user-images.githubusercontent.com/16439221/164135331-837ca1c6-d861-48c8-9efd-f034156a377b.png" width="600">

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
