### PR TITLE
v/util: add math to builtin_module_names (temporary fix for C2V)

### DIFF
--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -36,7 +36,7 @@ const (
 	]
 )
 
-const builtin_module_names = ['builtin', 'strconv', 'strings', 'dlmalloc']
+const builtin_module_names = ['builtin', 'strconv', 'strings', 'dlmalloc', 'math']
 
 pub fn module_is_builtin(mod string) bool {
 	// NOTE: using util.builtin_module_parts here breaks -usecache on macos


### PR DESCRIPTION
This change is required so `_const_` is not prepended to constant names
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
