### PR TITLE
bootstrap: remove -I ./thirdparty/stdatomic/nix from make files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,7 +429,7 @@ jobs:
       - name: Test new v.c
         run: |
           .\v.exe -o v.c cmd/v
-          gcc -Werror -I ./thirdparty/stdatomic/win -municode -w v.c
+          gcc -Werror -municode -w v.c
       - name: Install dependencies
         run: |
           .\v.exe setup-freetype
@@ -534,7 +534,7 @@ jobs:
       - name: Test new v.c
         run: |
           .\v.exe -o v.c cmd/v
-          .\thirdparty\tcc\tcc.exe -I ./thirdparty/stdatomic/win -Werror -w -ladvapi32 -bt10 v.c
+          .\thirdparty\tcc\tcc.exe -Werror -w -ladvapi32 -bt10 v.c
       - name: Install dependencies
         run: |
           .\v.exe setup-freetype
@@ -575,7 +575,7 @@ jobs:
         ##          .\v.exe wipe-cache
         ##          .\make.bat -tcc32
         ##      - name: Test new v.c
-        ##        run: .\v.exe -o v.c cmd/v && .\thirdparty\tcc\tcc.exe -I ./thirdparty/stdatomic/win -Werror -g -w -ladvapi32 -bt10 v.c
+        ##        run: .\v.exe -o v.c cmd/v && .\thirdparty\tcc\tcc.exe -Werror -g -w -ladvapi32 -bt10 v.c
         ##      - name: v doctor
         ##        run: ./v doctor
         ##

--- a/.github/workflows/ci_bootstrapping_works.yml
+++ b/.github/workflows/ci_bootstrapping_works.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 30
     env:
       VFLAGS: -cc tcc -no-retry-compilation
-      B_CFLAGS: -g -std=gnu11 -I ./thirdparty/stdatomic/nix -w
+      B_CFLAGS: -g -std=gnu11 -w
       B_LFLAGS: -lm -lpthread
     steps:
       - uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 30
     env:
       VFLAGS: -cc clang
-      B_CFLAGS: -g -std=gnu11 -I ./thirdparty/stdatomic/nix -w
+      B_CFLAGS: -g -std=gnu11 -w
       B_LFLAGS: -lm -lpthread
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci_cross.yml
+++ b/.github/workflows/ci_cross.yml
@@ -71,14 +71,14 @@ jobs:
       - name: v.c can be compiled and run with -os cross
         run: |
           ./v -os cross -o /tmp/v.c cmd/v
-          gcc  -g -std=gnu11 -I ./thirdparty/stdatomic/nix -w -o v_from_vc /tmp/v.c  -lm -lpthread
+          gcc  -g -std=gnu11 -w -o v_from_vc /tmp/v.c  -lm -lpthread
           ls -lart v_from_vc
           ./v_from_vc version
 
       - name: v_win.c can be compiled and run with -os windows
         run: |
           ./v -cc msvc -os windows -o /tmp/v_win.c cmd/v
-          x86_64-w64-mingw32-gcc -I ./thirdparty/stdatomic/win /tmp/v_win.c -std=c99 -w -municode -o v_from_vc.exe
+          x86_64-w64-mingw32-gcc /tmp/v_win.c -std=c99 -w -municode -o v_from_vc.exe
           ls -lart v_from_vc.exe
           wine64 ./v_from_vc.exe version
 

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,10 +1,10 @@
 FROM mstorsjo/llvm-mingw
 
-LABEL maintainer="Vitaly Takmazov <vitalyster@gmail.com>"
+LABEL maintainer="Delyan Angelov <delian66@gmail.com>"
 COPY . .
 RUN make
 RUN ./v -os windows -o v.c cmd/v
-RUN x86_64-w64-mingw32-gcc v.c -std=c99 -I ./thirdparty/stdatomic/win -w -municode -o v.exe
+RUN x86_64-w64-mingw32-gcc v.c -std=c99 -w -municode -o v.exe
 RUN file v.exe
 
 CMD [ "bash" ]

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -84,13 +84,13 @@ endif
 
 all: latest_vc latest_tcc
 ifdef WIN32
-	$(CC) $(CFLAGS) -std=c99 -municode -w -I ./thirdparty/stdatomic/nix -o v1.exe $(VC)/$(VCFILE) $(LDFLAGS)
+	$(CC) $(CFLAGS) -std=c99 -municode -w -o v1.exe $(VC)/$(VCFILE) $(LDFLAGS)
 	v1.exe -no-parallel -o v2.exe $(VFLAGS) cmd/v
 	v2.exe -o $(V) $(VFLAGS) cmd/v
 	del v1.exe
 	del v2.exe
 else
-	$(CC) $(CFLAGS) -std=gnu99 -w -I ./thirdparty/stdatomic/nix -o v1.exe $(VC)/$(VCFILE) -lm -lpthread $(LDFLAGS)
+	$(CC) $(CFLAGS) -std=gnu99 -w -o v1.exe $(VC)/$(VCFILE) -lm -lpthread $(LDFLAGS)
 	./v1.exe -no-parallel -o v2.exe $(VFLAGS) cmd/v
 	./v2.exe -o $(V) $(VFLAGS) cmd/v
 	rm -rf v1.exe v2.exe

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LDFLAGS ?=
 all:
 	rm -rf vc/
 	git clone --depth 1 --quiet https://github.com/vlang/vc
-	$(CC) $(CFLAGS) -std=gnu11 -w -I ./thirdparty/stdatomic/nix -o v1 vc/v.c -lm -lexecinfo -lpthread $(LDFLAGS)
+	$(CC) $(CFLAGS) -std=gnu11 -w -o v1 vc/v.c -lm -lexecinfo -lpthread $(LDFLAGS)
 	./v1 -no-parallel -o v2 $(VFLAGS) cmd/v
 	./v2 -o v $(VFLAGS) cmd/v
 	rm -rf v1 v2 vc/

--- a/cmd/tools/vtest-all.v
+++ b/cmd/tools/vtest-all.v
@@ -210,9 +210,8 @@ fn get_all_commands() []Command {
 		rmfile: 'examples/tetris/tetris'
 	}
 	$if macos || linux {
-		ipath := '$vroot/thirdparty/stdatomic/nix'
 		res << Command{
-			line: '$vexe -o v.c cmd/v && cc -Werror -I ${os.quoted_path(ipath)} v.c -lpthread -lm && rm -rf a.out'
+			line: '$vexe -o v.c cmd/v && cc -Werror v.c -lpthread -lm && rm -rf a.out'
 			label: 'v.c should be buildable with no warnings...'
 			okmsg: 'v.c can be compiled without warnings. This is good :)'
 			rmfile: 'v.c'

--- a/make.bat
+++ b/make.bat
@@ -119,7 +119,7 @@ REM By default, use tcc, since we have it prebuilt:
 :tcc_strap
 :tcc32_strap
 echo  ^> Attempting to build v_win.c with "!tcc_exe!"
-"!tcc_exe!" -Bthirdparty/tcc -Ithirdparty/stdatomic/win -bt10 -g -w -o v.exe vc\v_win.c -ladvapi32
+"!tcc_exe!" -Bthirdparty/tcc -bt10 -g -w -o v.exe vc\v_win.c -ladvapi32
 if %ERRORLEVEL% NEQ 0 goto :compile_error
 echo  ^> Compiling .\v.exe with itself
 v.exe -keepc -g -showcc -cc "!tcc_exe!" -cflags -Bthirdparty/tcc -o v2.exe cmd/v
@@ -137,7 +137,7 @@ if %ERRORLEVEL% NEQ 0 (
 )
 
 echo  ^> Attempting to build v_win.c with Clang
-clang -std=c99 -Ithirdparty/stdatomic/win -municode -g -w -o v.exe .\vc\v_win.c -ladvapi32
+clang -std=c99 -municode -g -w -o v.exe .\vc\v_win.c -ladvapi32
 if %ERRORLEVEL% NEQ 0 (
 	echo In most cases, compile errors happen because the version of Clang installed is too old
 	clang --version
@@ -160,7 +160,7 @@ if %ERRORLEVEL% NEQ 0 (
 )
 
 echo  ^> Attempting to build v_win.c with GCC
-gcc -std=c99 -municode -Ithirdparty/stdatomic/win -g -w -o v.exe .\vc\v_win.c -ladvapi32
+gcc -std=c99 -municode -g -w -o v.exe .\vc\v_win.c -ladvapi32
 if %ERRORLEVEL% NEQ 0 (
 	echo In most cases, compile errors happen because the version of GCC installed is too old
 	gcc --version
@@ -202,7 +202,7 @@ if exist "%InstallDir%\Common7\Tools\vsdevcmd.bat" (
 set ObjFile=.v.c.obj
 
 echo  ^> Attempting to build v_win.c with MSVC
-cl.exe /volatile:ms /I thirdparty\stdatomic\win /Fo%ObjFile% /O2 /MD /D_VBOOTSTRAP vc\v_win.c user32.lib kernel32.lib advapi32.lib shell32.lib /link /nologo /out:v.exe /incremental:no
+cl.exe /volatile:ms /Fo%ObjFile% /O2 /MD /D_VBOOTSTRAP vc\v_win.c user32.lib kernel32.lib advapi32.lib shell32.lib /link /nologo /out:v.exe /incremental:no
 if %ERRORLEVEL% NEQ 0 (
     echo In some cases, compile errors happen because of the MSVC compiler version
     cl.exe

--- a/vlib/sync/stdatomic/1.declarations.c.v
+++ b/vlib/sync/stdatomic/1.declarations.c.v
@@ -5,8 +5,10 @@ module stdatomic
 
 $if windows {
 	#flag -I @VEXEROOT/thirdparty/stdatomic/win
+	#insert "@VEXEROOT/thirdparty/stdatomic/win/atomic.h"
 } $else {
 	#flag -I @VEXEROOT/thirdparty/stdatomic/nix
+	#insert "@VEXEROOT/thirdparty/stdatomic/nix/atomic.h"
 }
 
 $if linux {
@@ -46,12 +48,6 @@ $if linux {
 		}
 		#flag -latomic
 	}
-}
-
-$if windows {
-	#insert "@VEXEROOT/thirdparty/stdatomic/win/atomic.h"
-} $else {
-	#insert "@VEXEROOT/thirdparty/stdatomic/nix/atomic.h"
 }
 
 // The following functions are actually generic in C


### PR DESCRIPTION
Cleanup the bootstrapping commands.
For most platforms, `gcc v.c -lpthread` should be enough.