### PR TITLE
docs: add link for V's standard library

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1,5 +1,7 @@
 # V Documentation
 
+(See https://modules.vlang.io/ for documentation of V's standard library)
+
 ## Introduction
 
 V is a statically typed compiled programming language designed for building maintainable software.


### PR DESCRIPTION
New V users often do not know where to find documentation for V's standard library.  Putting a link at the top of V's documentation will be a great help for them