### PR TITLE
builtin: fix `-cc gcc -gc boehm` on linux and macos

### DIFF
--- a/cmd/tools/vtest-all.v
+++ b/cmd/tools/vtest-all.v
@@ -83,7 +83,7 @@ fn get_all_commands() []Command {
 		}
 		if os.getenv('V_CI_MUSL').len == 0 {
 			for compiler_name in ['clang', 'gcc'] {
-				if cc := os.find_abs_path_of_executable(compiler_name) {
+				if _ := os.find_abs_path_of_executable(compiler_name) {
 					res << Command{
 						line: '$vexe -cc $compiler_name -gc boehm run examples/hello_world.v'
 						okmsg: '`v -cc $compiler_name -gc boehm run examples/hello_world.v` works'

--- a/cmd/tools/vtest-all.v
+++ b/cmd/tools/vtest-all.v
@@ -81,6 +81,18 @@ fn get_all_commands() []Command {
 			runcmd: .execute
 			expect: 'Hello, World!\n'
 		}
+		if os.getenv('V_CI_MUSL').len == 0 {
+			for compiler_name in ['clang', 'gcc'] {
+				if cc := os.find_abs_path_of_executable(compiler_name) {
+					res << Command{
+						line: '$vexe -cc $compiler_name -gc boehm run examples/hello_world.v'
+						okmsg: '`v -cc $compiler_name -gc boehm run examples/hello_world.v` works'
+						runcmd: .execute
+						expect: 'Hello, World!\n'
+					}
+				}
+			}
+		}
 		res << Command{
 			line: '$vexe interpret examples/hello_world.v'
 			okmsg: 'V can interpret hello world.'

--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -32,13 +32,14 @@ $if dynamic_boehm ? {
 	$if macos || linux {
 		#flag -DGC_PTHREADS=1
 		#flag -I@VEXEROOT/thirdparty/libgc/include
-		#flag -lpthread -ldl
+		#flag -lpthread
 		$if (prod && !tinyc && !debug) || !(amd64 || arm64 || i386 || arm32) {
 			// TODO: replace the architecture check with a `!$exists("@VEXEROOT/thirdparty/tcc/lib/libgc.a")` comptime call
 			#flag @VEXEROOT/thirdparty/libgc/gc.o
 		} $else {
 			#flag @VEXEROOT/thirdparty/tcc/lib/libgc.a
 		}
+		#flag -ldl
 	} $else $if freebsd {
 		// Tested on FreeBSD 13.0-RELEASE-p3, with clang, gcc and tcc:
 		#flag -DBUS_PAGE_FAULT=T_PAGEFLT


### PR DESCRIPTION
when building something with `-gc boehm` flag with gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
```
/usr/bin/ld: /home/lemon/git/v/thirdparty/tcc/lib/libgc.a(gc.o): in function `GC_dlopen':
gc.c:(.text+0xd493): undefined reference to `dlopen'
collect2: error: ld returned 1 exit status
```
this happens due to the order of `-ldl` flags.