### PR TITLE
checker: check array builtin method's arguments

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1878,6 +1878,9 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 		c.check_map_and_filter(false, elem_typ, node)
 		node.return_type = ast.bool_type
 	} else if method_name == 'clone' {
+		if node.args.len != 0 {
+			c.error('`.clone()` does not have any arguments', node.args[0].pos)
+		}
 		// need to return `array_xxx` instead of `array`
 		// in ['clone', 'str'] {
 		node.receiver_type = left_type.ref()
@@ -1908,6 +1911,9 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 	} else if method_name == 'index' {
 		node.return_type = ast.int_type
 	} else if method_name in ['first', 'last', 'pop'] {
+		if node.args.len != 0 {
+			c.error('`.${method_name}()` does not have any arguments', node.args[0].pos)
+		}
 		node.return_type = array_info.elem_type
 		if method_name == 'pop' {
 			c.fail_if_immutable(node.left)

--- a/vlib/v/checker/tests/array_builtin_method_args_err.out
+++ b/vlib/v/checker/tests/array_builtin_method_args_err.out
@@ -1,0 +1,28 @@
+vlib/v/checker/tests/array_builtin_method_args_err.vv:4:18: error: `.clone()` does not have any arguments
+    2 |     arr := [1, 2, 3]
+    3 |
+    4 |     a1 := arr.clone(22)
+      |                     ~~
+    5 |     println(a1)
+    6 |
+vlib/v/checker/tests/array_builtin_method_args_err.vv:7:18: error: `.first()` does not have any arguments
+    5 |     println(a1)
+    6 |
+    7 |     a2 := arr.first('a2')
+      |                     ~~~~
+    8 |     println(a2)
+    9 |
+vlib/v/checker/tests/array_builtin_method_args_err.vv:10:17: error: `.last()` does not have any arguments
+    8 |     println(a2)
+    9 |
+   10 |     a3 := arr.last(1)
+      |                    ^
+   11 |     println(a3)
+   12 |
+vlib/v/checker/tests/array_builtin_method_args_err.vv:13:16: error: `.pop()` does not have any arguments
+   11 |     println(a3)
+   12 |
+   13 |     a4 := arr.pop(2)
+      |                   ^
+   14 |     println(a4)
+   15 | }

--- a/vlib/v/checker/tests/array_builtin_method_args_err.vv
+++ b/vlib/v/checker/tests/array_builtin_method_args_err.vv
@@ -1,0 +1,15 @@
+fn main() {
+	arr := [1, 2, 3]
+
+	a1 := arr.clone(22)
+	println(a1)
+
+	a2 := arr.first('a2')
+	println(a2)
+
+	a3 := arr.last(1)
+	println(a3)
+
+	a4 := arr.pop(2)
+	println(a4)
+}


### PR DESCRIPTION
This PR check array builtin method's arguments.

- Check array builtin method's arguments.
- Add test.

```v
fn main() {
	arr := [1, 2, 3]

	a1 := arr.clone(22)
	println(a1)

	a2 := arr.first('a2')
	println(a2)

	a3 := arr.last(1)
	println(a3)

	a4 := arr.pop(2)
	println(a4)
}

PS D:\Test\v\tt1> v run .
./tt1.v:4:18: error: `.clone()` does not have any arguments
    2 |     arr := [1, 2, 3]
    3 | 
    4 |     a1 := arr.clone(22)
      |                     ~~
    5 |     println(a1)
    6 |
./tt1.v:7:18: error: `.first()` does not have any arguments
    5 |     println(a1)
    6 | 
    7 |     a2 := arr.first('a2')
      |                     ~~~~
    8 |     println(a2)
    9 |
./tt1.v:10:17: error: `.last()` does not have any arguments
    8 |     println(a2)
    9 | 
   10 |     a3 := arr.last(1)
      |                    ^
   11 |     println(a3)
   12 |
./tt1.v:13:16: error: `.pop()` does not have any arguments
   11 |     println(a3)
   12 | 
   13 |     a4 := arr.pop(2)
      |                   ^
   14 |     println(a4)
   15 | }
```