### PR TITLE
checker: check map builtin method's arguments

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1743,6 +1743,9 @@ fn (mut c Checker) map_builtin_method_call(mut node ast.CallExpr, left_type ast.
 	mut ret_type := ast.void_type
 	match method_name {
 		'clone', 'move' {
+			if node.args.len != 0 {
+				c.error('`.${method_name}()` does not have any arguments', node.args[0].pos)
+			}
 			if method_name[0] == `m` {
 				c.fail_if_immutable(node.left)
 			}
@@ -1754,6 +1757,9 @@ fn (mut c Checker) map_builtin_method_call(mut node ast.CallExpr, left_type ast.
 			ret_type = ret_type.clear_flag(.shared_f)
 		}
 		'keys' {
+			if node.args.len != 0 {
+				c.error('`.keys()` does not have any arguments', node.args[0].pos)
+			}
 			info := left_sym.info as ast.Map
 			typ := c.table.find_or_register_array(info.key_type)
 			ret_type = ast.Type(typ)

--- a/vlib/v/checker/tests/map_builtin_method_args_err.out
+++ b/vlib/v/checker/tests/map_builtin_method_args_err.out
@@ -1,0 +1,21 @@
+vlib/v/checker/tests/map_builtin_method_args_err.vv:4:16: error: `.clone()` does not have any arguments
+    2 |     mut m := {11: 22}
+    3 |
+    4 |     a1 := m.clone(11)
+      |                   ~~
+    5 |     println(a1)
+    6 |
+vlib/v/checker/tests/map_builtin_method_args_err.vv:7:15: error: `.move()` does not have any arguments
+    5 |     println(a1)
+    6 |
+    7 |     a2 := m.move(11)
+      |                  ~~
+    8 |     println(a2)
+    9 |
+vlib/v/checker/tests/map_builtin_method_args_err.vv:10:15: error: `.keys()` does not have any arguments
+    8 |     println(a2)
+    9 |
+   10 |     a3 := m.keys('aaa')
+      |                  ~~~~~
+   11 |     println(a3)
+   12 | }

--- a/vlib/v/checker/tests/map_builtin_method_args_err.vv
+++ b/vlib/v/checker/tests/map_builtin_method_args_err.vv
@@ -1,0 +1,12 @@
+fn main() {
+	mut m := {11: 22}
+
+	a1 := m.clone(11)
+	println(a1)
+
+	a2 := m.move(11)
+	println(a2)
+
+	a3 := m.keys('aaa')
+	println(a3)
+}


### PR DESCRIPTION
This PR check map builtin method's arguments.

- Check map builtin method's arguments.
- Add test.

```v
fn main() {
	mut m := {11: 22}

	a1 := m.clone(11)
	println(a1)

	a2 := m.move(11)
	println(a2)

	a3 := m.keys('aaa')
	println(a3)
}

PS D:\Test\v\tt1> v run .
./tt1.v:4:16: error: `.clone()` does not have any arguments
    2 |     mut m := {11: 22}
    3 |
    4 |     a1 := m.clone(11)
      |                   ~~
    5 |     println(a1)
    6 |
./tt1.v:7:15: error: `.move()` does not have any arguments
    5 |     println(a1)
    6 |
    7 |     a2 := m.move(11)
      |                  ~~
    8 |     println(a2)
    9 |
./tt1.v:10:15: error: `.keys()` does not have any arguments
    8 |     println(a2)
    9 |
   10 |     a3 := m.keys('aaa')
      |                  ~~~~~
   11 |     println(a3)
   12 | }
```