### PR TITLE
Allow static (fixed) arrays in `in` operator

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -662,6 +662,15 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					}
 					node.left_type = map_info.key_type
 				}
+				.array_fixed {
+					if left_sym.kind !in [.sum_type, .interface_] {
+						elem_type := right_final.array_fixed_info().elem_type
+						c.check_expected(left_type, elem_type) or {
+							c.error('left operand to `$node.op` does not match the fixed array element type: $err.msg()',
+								left_right_pos)
+						}
+					}
+				}
 				else {
 					c.error('`$node.op.str()` can only be used with arrays and maps',
 						node.pos)

--- a/vlib/v/gen/js/infix.v
+++ b/vlib/v/gen/js/infix.v
@@ -282,7 +282,7 @@ fn (mut g JsGen) infix_in_not_in_op(node ast.InfixExpr) {
 	if node.op == .not_in {
 		g.write('!')
 	}
-	if r_sym.unaliased_sym.kind == .array {
+	if r_sym.unaliased_sym.kind in [.array, .array_fixed] {
 		fn_name := g.gen_array_contains_method(node.right_type)
 		g.write('(${fn_name}(')
 		g.expr(node.right)

--- a/vlib/v/tests/fixed_array_in_op_test.v
+++ b/vlib/v/tests/fixed_array_in_op_test.v
@@ -1,0 +1,8 @@
+fn test_fixed_array_in_op() {
+	assert 1 in [1, 2]!
+	assert `a` in [`a`, `b`]!
+	assert "a" in ["a", "b"]!
+
+	ch := `"`
+	assert ch in [`"`, `'`]!
+}

--- a/vlib/v/tests/fixed_array_in_op_test.v
+++ b/vlib/v/tests/fixed_array_in_op_test.v
@@ -1,7 +1,7 @@
 fn test_fixed_array_in_op() {
 	assert 1 in [1, 2]!
 	assert `a` in [`a`, `b`]!
-	assert "a" in ["a", "b"]!
+	assert 'a' in ['a', 'b']!
 
 	ch := `"`
 	assert ch in [`"`, `'`]!


### PR DESCRIPTION
- Fixed #14113, now static (fixed) arrays are able to be used as right expression of `in` infix expression.