### PR TITLE
cgen: fix error for if expr with nested match expr (fix #14093)

### DIFF
--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -20,6 +20,9 @@ fn (mut g Gen) need_tmp_var_in_if(node ast.IfExpr) bool {
 					if is_noreturn_callexpr(stmt.expr) {
 						return true
 					}
+					if stmt.expr is ast.MatchExpr {
+						return true
+					}
 					if stmt.expr is ast.CallExpr {
 						if stmt.expr.is_method {
 							left_sym := g.table.sym(stmt.expr.receiver_type)

--- a/vlib/v/tests/if_expr_with_nested_match_expr_test.v
+++ b/vlib/v/tests/if_expr_with_nested_match_expr_test.v
@@ -1,0 +1,12 @@
+fn test_if_expr_with_nested_match_expr() {
+	a := if true {
+		match `a` {
+			`a` { 0 }
+			else { 1 }
+		}
+	} else {
+		3
+	}
+	println(a)
+	assert a == 0
+}


### PR DESCRIPTION
This PR fix error for if expr with nested match expr (fix #14093).

- Fix error for if expr with nested match expr.
- Add test.

```v
fn main() {
	a := if true {
		match `a` {
			`a` { 0 }
			else { 1 }
		}
	} else {
		3
	}
	println(a)
	assert a == 0
}

PS D:\Test\v\tt1> v run .
0
```