### PR TITLE
checker: fix error for fn with array of aliases argument (fix #14116)

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -335,7 +335,8 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			left_elem_type := c.table.unaliased_type(left_info.elem_type)
 			right_info := right_sym.info as ast.Array
 			right_elem_type := c.table.unaliased_type(right_info.elem_type)
-			if left_info.nr_dims == right_info.nr_dims && left_elem_type == right_elem_type {
+			if left_type_unwrapped.nr_muls() == right_type_unwrapped.nr_muls()
+				&& left_info.nr_dims == right_info.nr_dims && left_elem_type == right_elem_type {
 				continue
 			}
 		}

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -895,6 +895,16 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 			if param.typ.has_flag(.generic) {
 				continue
 			}
+			if param_typ_sym.kind == .array && arg_typ_sym.kind == .array {
+				param_info := param_typ_sym.info as ast.Array
+				param_elem_type := c.table.unaliased_type(param_info.elem_type)
+				arg_info := arg_typ_sym.info as ast.Array
+				arg_elem_type := c.table.unaliased_type(arg_info.elem_type)
+				if param.typ.nr_muls() == arg_typ.nr_muls()
+					&& param_info.nr_dims == arg_info.nr_dims && param_elem_type == arg_elem_type {
+					continue
+				}
+			}
 			if c.pref.translated || c.file.is_translated {
 				// TODO duplicated logic in check_types() (check_types.v)
 				// Allow enums to be used as ints and vice versa in translated code
@@ -1389,6 +1399,19 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 				// if arg_typ_sym.kind == .string && typ_sym.has_method('str') {
 				// continue
 				// }
+				param_typ_sym := c.table.sym(exp_arg_typ)
+				arg_typ_sym := c.table.sym(got_arg_typ)
+				if param_typ_sym.kind == .array && arg_typ_sym.kind == .array {
+					param_info := param_typ_sym.info as ast.Array
+					param_elem_type := c.table.unaliased_type(param_info.elem_type)
+					arg_info := arg_typ_sym.info as ast.Array
+					arg_elem_type := c.table.unaliased_type(arg_info.elem_type)
+					if exp_arg_typ.nr_muls() == got_arg_typ.nr_muls()
+						&& param_info.nr_dims == arg_info.nr_dims
+						&& param_elem_type == arg_elem_type {
+						continue
+					}
+				}
 				if got_arg_typ != ast.void_type {
 					c.error('$err.msg() in argument ${i + 1} to `${left_sym.name}.$method_name`',
 						arg.pos)

--- a/vlib/v/tests/fn_with_array_of_aliases_argument_test.v
+++ b/vlib/v/tests/fn_with_array_of_aliases_argument_test.v
@@ -1,0 +1,24 @@
+fn show_array_of_u8(data []u8) string {
+	println(data)
+	return '$data'
+}
+
+struct Foo {}
+
+fn (f Foo) show_array_of_u8(data []u8) string {
+	println(data)
+	return '$data'
+}
+
+fn test_fn_with_array_of_aliases_argument() {
+	a := [byte(1), 2, 3]
+
+	s1 := show_array_of_u8(a)
+	println(s1)
+	assert s1 == '[0x01, 0x02, 0x03]'
+
+	foo := Foo{}
+	s2 := foo.show_array_of_u8(a)
+	println(s2)
+	assert s2 == '[0x01, 0x02, 0x03]'
+}


### PR DESCRIPTION
This PR fix error for fn with array of aliases argument (fix #14116).

- Fix error for fn with array of aliases argument.
- Add test.

```v
fn show_array_of_u8(data []u8) string {
	println(data)
	return '$data'
}

struct Foo {}

fn (f Foo) show_array_of_u8(data []u8) string {
	println(data)
	return '$data'
}

fn main() {
	a := [byte(1), 2, 3]

	s1 := show_array_of_u8(a)
	println(s1)
	assert s1 == '[0x01, 0x02, 0x03]'

	foo := Foo{}
	s2 := foo.show_array_of_u8(a)
	println(s2)
	assert s2 == '[0x01, 0x02, 0x03]'
}

PS D:\Test\v\tt1> v run .
[0x01, 0x02, 0x03]
[0x01, 0x02, 0x03]
[0x01, 0x02, 0x03]
[0x01, 0x02, 0x03]
```