### PR TITLE
parser: fix generic anon fn decl with type only argument (fix #14118)

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -783,9 +783,10 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 	} else {
 		p.tok.lit
 	}
+	is_generic_type := p.tok.kind == .name && p.tok.lit.len == 1 && p.tok.lit[0].is_capital()
 
 	types_only := p.tok.kind in [.amp, .ellipsis, .key_fn, .lsbr]
-		|| (p.peek_tok.kind == .comma && p.table.known_type(argname))
+		|| (p.peek_tok.kind == .comma && (p.table.known_type(argname) || is_generic_type))
 		|| p.peek_tok.kind == .dot || p.peek_tok.kind == .rpar
 		|| (p.tok.kind == .key_mut && (p.peek_token(2).kind == .comma
 		|| p.peek_token(2).kind == .rpar || (p.peek_tok.kind == .name

--- a/vlib/v/tests/generics_anon_fn_decl_with_type_only_arg_test.v
+++ b/vlib/v/tests/generics_anon_fn_decl_with_type_only_arg_test.v
@@ -1,0 +1,13 @@
+fn test_generics_anon_fn_decl_with_type_only_arg() {
+	ret := func_b<int>(11, 22, add)
+	println(ret)
+	assert ret == 33
+}
+
+fn add(a int, b int) int {
+	return a + b
+}
+
+fn func_b<T>(x T, y T, f fn (T, T) T) T {
+	return f(x, y)
+}


### PR DESCRIPTION
This PR fix generic anon fn decl with type only argument (fix #14118).

- Fix generic anon fn decl with type only argument.
- Add test.

```v
fn main() {
	ret := func_b<int>(11, 22, add)
	println(ret)
}

fn add(a int, b int) int {
	return a + b
}

fn func_b<T>(x T, y T, f fn (T, T) T) T {
	return f(x, y)
}

PS D:\Test\v\tt1> v run .
33
```