### PR TITLE
checker: simplify checking array.contains() argument

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1927,13 +1927,10 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 		// c.warn('use `value in arr` instead of `arr.contains(value)`', node.pos)
 		if node.args.len != 1 {
 			c.error('`.contains()` expected 1 argument, but got $node.args.len', node.pos)
-		} else {
-			arg_typ := ast.mktyp(c.expr(node.args[0].expr))
-			elem_typ_str := c.table.type_to_str(elem_typ)
-			arg_typ_str := c.table.type_to_str(arg_typ)
-			if !left_sym.has_method('contains') && elem_typ_str != arg_typ_str {
-				c.error('`.contains()` expected `$elem_typ_str` argument, but got `$arg_typ_str`',
-					node.pos)
+		} else if !left_sym.has_method('contains') {
+			arg_typ := c.expr(node.args[0].expr)
+			c.check_expected_call_arg(arg_typ, elem_typ, node.language, node.args[0]) or {
+				c.error('$err.msg() in argument 1 to `.contains()`', node.args[0].pos)
 			}
 		}
 		node.return_type = ast.bool_type

--- a/vlib/v/checker/tests/array_contains_args_err.out
+++ b/vlib/v/checker/tests/array_contains_args_err.out
@@ -1,8 +1,8 @@
-vlib/v/checker/tests/array_contains_args_err.vv:3:17: error: `.contains()` expected `int` argument, but got `[]int`
+vlib/v/checker/tests/array_contains_args_err.vv:3:26: error: cannot use `[]int` as `int` in argument 1 to `.contains()`
     1 | fn main() {
     2 |     arr := [0]
     3 |     mut ret := [0].contains([0])
-      |                    ~~~~~~~~~~~~~
+      |                             ~~~
     4 |     ret = [0].contains()
     5 |     ret = [0, 1, 2].contains(0, 1, 2)
 vlib/v/checker/tests/array_contains_args_err.vv:4:12: error: `.contains()` expected 1 argument, but got 0
@@ -19,17 +19,17 @@ vlib/v/checker/tests/array_contains_args_err.vv:5:18: error: `.contains()` expec
       |                     ~~~~~~~~~~~~~~~~~
     6 |     ret = [0].contains('a')
     7 |     ret = [0].contains(arr)
-vlib/v/checker/tests/array_contains_args_err.vv:6:12: error: `.contains()` expected `int` argument, but got `string`
+vlib/v/checker/tests/array_contains_args_err.vv:6:21: error: cannot use `string` as `int` in argument 1 to `.contains()`
     4 |     ret = [0].contains()
     5 |     ret = [0, 1, 2].contains(0, 1, 2)
     6 |     ret = [0].contains('a')
-      |               ~~~~~~~~~~~~~
+      |                        ~~~
     7 |     ret = [0].contains(arr)
     8 |     println(ret)
-vlib/v/checker/tests/array_contains_args_err.vv:7:12: error: `.contains()` expected `int` argument, but got `[]int`
+vlib/v/checker/tests/array_contains_args_err.vv:7:21: error: cannot use `[]int` as `int` in argument 1 to `.contains()`
     5 |     ret = [0, 1, 2].contains(0, 1, 2)
     6 |     ret = [0].contains('a')
     7 |     ret = [0].contains(arr)
-      |               ~~~~~~~~~~~~~
+      |                        ~~~
     8 |     println(ret)
     9 | }


### PR DESCRIPTION
This PR simplify checking array.contains() argument.

- Use `c.check_expected_call_arg()` to handle.