### PR TITLE
checker: check error for array.index() argument

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1935,6 +1935,14 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 		}
 		node.return_type = ast.bool_type
 	} else if method_name == 'index' {
+		if node.args.len != 1 {
+			c.error('`.index()` expected 1 argument, but got $node.args.len', node.pos)
+		} else if !left_sym.has_method('index') {
+			arg_typ := c.expr(node.args[0].expr)
+			c.check_expected_call_arg(arg_typ, elem_typ, node.language, node.args[0]) or {
+				c.error('$err.msg() in argument 1 to `.index()`', node.args[0].pos)
+			}
+		}
 		node.return_type = ast.int_type
 	} else if method_name in ['first', 'last', 'pop'] {
 		if node.args.len != 0 {

--- a/vlib/v/checker/tests/array_index_args_err.out
+++ b/vlib/v/checker/tests/array_index_args_err.out
@@ -1,0 +1,35 @@
+vlib/v/checker/tests/array_index_args_err.vv:3:23: error: cannot use `[]int` as `int` in argument 1 to `.index()`
+    1 | fn main() {
+    2 |     arr := [0]
+    3 |     mut ret := [0].index([0])
+      |                          ~~~
+    4 |     ret = [0].index()
+    5 |     ret = [0, 1, 2].index(0, 1, 2)
+vlib/v/checker/tests/array_index_args_err.vv:4:12: error: `.index()` expected 1 argument, but got 0
+    2 |     arr := [0]
+    3 |     mut ret := [0].index([0])
+    4 |     ret = [0].index()
+      |               ~~~~~~~
+    5 |     ret = [0, 1, 2].index(0, 1, 2)
+    6 |     ret = [0].index('a')
+vlib/v/checker/tests/array_index_args_err.vv:5:18: error: `.index()` expected 1 argument, but got 3
+    3 |     mut ret := [0].index([0])
+    4 |     ret = [0].index()
+    5 |     ret = [0, 1, 2].index(0, 1, 2)
+      |                     ~~~~~~~~~~~~~~
+    6 |     ret = [0].index('a')
+    7 |     ret = [0].index(arr)
+vlib/v/checker/tests/array_index_args_err.vv:6:18: error: cannot use `string` as `int` in argument 1 to `.index()`
+    4 |     ret = [0].index()
+    5 |     ret = [0, 1, 2].index(0, 1, 2)
+    6 |     ret = [0].index('a')
+      |                     ~~~
+    7 |     ret = [0].index(arr)
+    8 |     println(ret)
+vlib/v/checker/tests/array_index_args_err.vv:7:18: error: cannot use `[]int` as `int` in argument 1 to `.index()`
+    5 |     ret = [0, 1, 2].index(0, 1, 2)
+    6 |     ret = [0].index('a')
+    7 |     ret = [0].index(arr)
+      |                     ~~~
+    8 |     println(ret)
+    9 | }

--- a/vlib/v/checker/tests/array_index_args_err.vv
+++ b/vlib/v/checker/tests/array_index_args_err.vv
@@ -1,0 +1,9 @@
+fn main() {
+	arr := [0]
+	mut ret := [0].index([0])
+	ret = [0].index()
+	ret = [0, 1, 2].index(0, 1, 2)
+	ret = [0].index('a')
+	ret = [0].index(arr)
+	println(ret)
+}


### PR DESCRIPTION
This PR check error for array.index() argument.

- Check error for array.index() argument.
- Add test.

```v
fn main() {
	arr := [0]
	mut ret := [0].index([0])
	ret = [0].index()
	ret = [0, 1, 2].index(0, 1, 2)
	ret = [0].index('a')
	ret = [0].index(arr)
	println(ret)
}

PS D:\Test\v\tt1> v run .
./tt1.v:3:23: error: cannot use `[]int` as `int` in argument 1 to `.index()`
    1 | fn main() {
    2 |     arr := [0]
    3 |     mut ret := [0].index([0])
      |                          ~~~
    4 |     ret = [0].index()
    5 |     ret = [0, 1, 2].index(0, 1, 2)
./tt1.v:4:12: error: `.index()` expected 1 argument, but got 0
    2 |     arr := [0]
    3 |     mut ret := [0].index([0])
    4 |     ret = [0].index()
      |               ~~~~~~~
    5 |     ret = [0, 1, 2].index(0, 1, 2)
    6 |     ret = [0].index('a')
./tt1.v:5:18: error: `.index()` expected 1 argument, but got 3
    3 |     mut ret := [0].index([0])
    4 |     ret = [0].index()
    5 |     ret = [0, 1, 2].index(0, 1, 2)
      |                     ~~~~~~~~~~~~~~
    6 |     ret = [0].index('a')
    7 |     ret = [0].index(arr)
./tt1.v:6:18: error: cannot use `string` as `int` in argument 1 to `.index()`
    4 |     ret = [0].index()
    5 |     ret = [0, 1, 2].index(0, 1, 2)
    6 |     ret = [0].index('a')
      |                     ~~~
    7 |     ret = [0].index(arr)
    8 |     println(ret)
./tt1.v:7:18: error: cannot use `[]int` as `int` in argument 1 to `.index()`
    5 |     ret = [0, 1, 2].index(0, 1, 2)
    6 |     ret = [0].index('a')
    7 |     ret = [0].index(arr)
      |                     ~~~
    8 |     println(ret)
    9 | }
```