### PR TITLE
cgen: fix error for anon fn decl inside ternary (fix #14148)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -379,7 +379,10 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 	defer {
 		g.tmp_count = ctmp
 	}
+	prev_inside_ternary := g.inside_ternary
+	g.inside_ternary = 0
 	g.stmts(node.stmts)
+	g.inside_ternary = prev_inside_ternary
 	if node.is_noreturn {
 		g.writeln('\twhile(1);')
 	}

--- a/vlib/v/tests/anon_fn_decl_inside_ternary_test.v
+++ b/vlib/v/tests/anon_fn_decl_inside_ternary_test.v
@@ -1,0 +1,25 @@
+fn foofun(op rune) fn () string {
+	return match op {
+		`1` {
+			fn () string {
+				return '1 passed'
+			}
+		}
+		`2` {
+			fn () string {
+				return '2 passed'
+			}
+		}
+		else {
+			fn () string {
+				return 'Nor 1 or 2 passed'
+			}
+		}
+	}
+}
+
+fn test_anon_fn_decl_inside_ternary() {
+	a := foofun(`1`)
+	println(a())
+	assert a() == '1 passed'
+}


### PR DESCRIPTION
This PR fix error for anon fn decl inside ternary (fix #14148).

- Fix error for anon fn decl inside ternary.
- Add test.

```v
fn foofun(op rune) fn () string {
	return match op {
		`1` {
			fn () string {
				return '1 passed'
			}
		}
		`2` {
			fn () string {
				return '2 passed'
			}
		}
		else {
			fn () string {
				return 'Nor 1 or 2 passed'
			}
		}
	}
}

fn main() {
	a := foofun(`1`)
	println(a())
	assert a() == '1 passed'
}

PS D:\Test\v\tt1> v run .
1 passed
```