### PR TITLE
cgen: callconv support for fns from ptr

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -314,11 +314,32 @@ fn (mut g Gen) gen_assign_stmt(node_ ast.AssignStmt) {
 				}
 				func := right_sym.info as ast.FnType
 				ret_styp := g.typ(func.func.return_type)
-				g.write('$ret_styp (*${g.get_ternary_name(ident.name)}) (')
+
+				mut call_conv := ''
+				mut msvc_call_conv := ''
+				for attr in func.func.attrs {
+					match attr.name {
+						'callconv' {
+							if g.is_cc_msvc {
+								msvc_call_conv = '__$attr.arg '
+							} else {
+								call_conv = '$attr.arg'
+							}
+						}
+						else {}
+					}
+				}
+				call_conv_attribute_suffix := if call_conv.len != 0 {
+					'__attribute__(($call_conv))'
+				} else {
+					''
+				}
+
+				g.write('$ret_styp ($msvc_call_conv*${g.get_ternary_name(ident.name)}) (')
 				def_pos := g.definitions.len
 				g.fn_decl_params(func.func.params, voidptr(0), false)
 				g.definitions.go_back(g.definitions.len - def_pos)
-				g.write(')')
+				g.write(')$call_conv_attribute_suffix')
 			} else {
 				if is_decl {
 					if is_inside_ternary {


### PR DESCRIPTION
Hi,

I noticed when you create a fn from a ptr which have a defined callconv it don't write it at cgen exemple:

```v
module main

[callconv: 'fastcall']
type P_Cool = fn (string)

[callconv: 'fastcall']
fn cool(hello string) {
	dump(hello)
}

fn main() {
	cool('hi')

	fn_add := voidptr(&cool)
	dump('cool add -> $fn_add')
	o_fn := &P_Cool(fn_add)
	o_fn('no')
}
```

at the line where `o_fn := &P_Cool(fn_add)` it generate this:

```c
void (*o_fn) (string ) = ((main__P_Cool*)(fn_add));
```

as you can see the fastcall is missing and this is what I tried to fix in this pr :) exemple:

expected:
```c
void (*o_fn) (string )__attribute__((fastcall)) = ((main__P_Cool*)(fn_add));
```
or for msvc:
```c
void (__fastcall*o_fn) (string ) = ((main__P_Cool*)(fn_add));
```

Thanks for taking attention of this pr :)