### PR TITLE
builder: improve macOS 10.5 and PPC support

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -3,6 +3,7 @@
 // that can be found in the LICENSE file.
 module builder
 
+import math
 import os
 import v.cflag
 import v.pref
@@ -206,6 +207,14 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	if v.pref.os == .macos && os.exists('/opt/procursus') {
 		ccoptions.linker_flags << '-Wl,-rpath,/opt/procursus/lib'
 	}
+	mut user_darwin_version := math.inf(1)
+	mut user_darwin_ppc := false
+	$if macos {
+		user_darwin_version = os.uname().release.split('.')[0].int()
+		if os.uname().machine == 'Power Macintosh' {
+			user_darwin_ppc = true
+		}
+	}
 	ccoptions.debug_mode = v.pref.is_debug
 	ccoptions.guessed_compiler = v.pref.ccompiler
 	if ccoptions.guessed_compiler == 'cc' && v.pref.is_prod {
@@ -251,7 +260,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 		]
 	}
 	if ccoptions.is_cc_gcc {
-		if ccoptions.debug_mode {
+		if ccoptions.debug_mode && user_darwin_version > 9 {
 			debug_options = ['-g', '-no-pie']
 		}
 		optimization_options = ['-O3', '-fno-strict-aliasing', '-flto']
@@ -334,7 +343,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	}
 	// macOS code can include objective C  TODO remove once objective C is replaced with C
 	if v.pref.os == .macos || v.pref.os == .ios {
-		if !ccoptions.is_cc_tcc {
+		if !ccoptions.is_cc_tcc && !user_darwin_ppc {
 			ccoptions.source_args << '-x objective-c'
 		}
 	}

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -3,7 +3,6 @@
 // that can be found in the LICENSE file.
 module builder
 
-import math
 import os
 import v.cflag
 import v.pref
@@ -207,7 +206,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	if v.pref.os == .macos && os.exists('/opt/procursus') {
 		ccoptions.linker_flags << '-Wl,-rpath,/opt/procursus/lib'
 	}
-	mut user_darwin_version := math.inf(1)
+	mut user_darwin_version := 999_999_999
 	mut user_darwin_ppc := false
 	$if macos {
 		user_darwin_version = os.uname().release.split('.')[0].int()
@@ -260,8 +259,11 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 		]
 	}
 	if ccoptions.is_cc_gcc {
-		if ccoptions.debug_mode && user_darwin_version > 9 {
-			debug_options = ['-g', '-no-pie']
+		if ccoptions.debug_mode {
+			debug_options = ['-g']
+			if user_darwin_version > 9 {
+				debug_options << '-no-pie'
+			}
 		}
 		optimization_options = ['-O3', '-fno-strict-aliasing', '-flto']
 	}


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR aims to improve building V on macOS 10.5 (Darwin 9) as well as on PowerPC machines.

First, the `-no-pie` flag introduced in https://github.com/vlang/v/pull/2607 isn't supported by `/usr/bin/ld` on macOS 10.5 and below (see [ticket](https://trac.macports.org/ticket/34064)). Removing it helps to fix a build error: ([full logs](https://trac.macports.org/attachment/ticket/64913/main_10.5.8_gcc6_errno_removed.log))

```
gcc-mp-6: error: unrecognized command line option '-no-pie'; did you mean '-no-pie'?
```

The `-x objective-c` appears to cause a build error on PowerPC: ([full logs](https://trac.macports.org/attachment/ticket/64913/main_10.5.8_v3.log))

```
/opt/local/lib/gcc6/gcc/ppc-apple-darwin9/6.5.0/include/stdatomic.h:40:1: sorry, unimplemented: '_Atomic' in Objective-C
typedef _Atomic _Bool atomic_bool;
```

The build fails with this error on 10.5 PPC, but not on 10.6 i386 or x86_64. This seemed more likely to be a PowerPC issue rather than a 10.5 problem, so I removed the flag based on that.

Although this then means that users on PowerPC macs can't run Objective-C code with V, I thought that this was an acceptable compromise since they can then at least run V in the first place.

See https://trac.macports.org/ticket/64913 for the full context behind this PR.

Finally, it goes without saying, but thank you to the V maintainers for your work on this amazing language. ⭐️