### PR TITLE
parser, checker, cgen: fix error for fn call using anon fn call argument (fix #14149)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -578,6 +578,17 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 		found = true
 		return ast.string_type
 	}
+	if !found && node.left is ast.CallExpr {
+		c.expr(node.left)
+		expr := node.left as ast.CallExpr
+		sym := c.table.sym(expr.return_type)
+		if sym.kind == .function {
+			info := sym.info as ast.FnType
+			node.return_type = info.func.return_type
+			found = true
+			func = info.func
+		}
+	}
 	// already prefixed (mod.fn) or C/builtin/main
 	if !found {
 		if f := c.table.find_fn(fn_name) {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -637,11 +637,12 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 	// see my comment in parser near anon_fn
 	if node.left is ast.AnonFn {
 		g.expr(node.left)
-	}
-	if node.left is ast.IndexExpr && node.name == '' {
+	} else if node.left is ast.IndexExpr && node.name == '' {
 		g.is_fn_index_call = true
 		g.expr(node.left)
 		g.is_fn_index_call = false
+	} else if node.left is ast.CallExpr && node.name == '' {
+		g.expr(node.left)
 	}
 	if node.should_be_skipped {
 		return

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2327,6 +2327,18 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 				p.error_with_pos('unexpected $p.prev_tok', p.prev_tok.pos())
 			}
 			node = p.call_expr(language, mod)
+			if p.tok.kind == .lpar && p.prev_tok.line_nr == p.tok.line_nr {
+				p.next()
+				pos := p.tok.pos()
+				args := p.call_args()
+				p.check(.rpar)
+				node = ast.CallExpr{
+					left: node
+					args: args
+					pos: pos
+					scope: p.scope
+				}
+			}
 		}
 	} else if (p.peek_tok.kind == .lcbr || (p.peek_tok.kind == .lt && lit0_is_capital))
 		&& (!p.inside_match || (p.inside_select && prev_tok_kind == .arrow && lit0_is_capital))

--- a/vlib/v/tests/fn_call_using_anon_fn_call_args.v
+++ b/vlib/v/tests/fn_call_using_anon_fn_call_args.v
@@ -1,0 +1,19 @@
+fn foofun1(op string) fn () string {
+	return fn () string {
+		return 'x passed'
+	}
+}
+
+fn foofun2(op string) fn () int {
+	return fn () int {
+		return 22
+	}
+}
+
+fn test_fn_call_using_anon_fn_call_arg() {
+	println(main.foofun1('1')())
+	assert main.foofun1('1')() == 'x passed'
+
+	println(main.foofun2('1')())
+	assert main.foofun2('1')() == 22
+}


### PR DESCRIPTION
This PR fix error for fn call using anon fn call argument (fix #14149).

- Fix error for fn call using anon fn call argument.
- Add test.

```v
fn foofun1(op string) fn () string {
	return fn () string {
		return 'x passed'
	}
}

fn foofun2(op string) fn () int {
	return fn () int {
		return 22
	}
}

fn main() {
	println(main.foofun1('1')())
	assert main.foofun1('1')() == 'x passed'

	println(main.foofun2('1')())
	assert main.foofun2('1')() == 22
}

PS D:\Test\v\tt1> v run .
x passed
22
```