### PR TITLE
vlib: Add OpenBSD to allowed_os_overrides and set up sokol properly.

### DIFF
--- a/vlib/sokol/c/declaration.c.v
+++ b/vlib/sokol/c/declaration.c.v
@@ -10,6 +10,7 @@ pub const (
 #flag darwin -fobjc-arc
 #flag linux -lX11 -lGL -lXcursor -lXi -lpthread
 #flag freebsd -L/usr/local/lib -lX11 -lGL -lXcursor -lXi
+#flag openbsd -L/usr/X11R6/lib -lX11 -lGL -lXcursor -lXi
 #flag windows -lgdi32
 // METAL
 $if macos {
@@ -27,6 +28,7 @@ $if ios {
 // OPENGL
 #flag linux -DSOKOL_GLCORE33
 #flag freebsd -DSOKOL_GLCORE33
+#flag openbsd -DSOKOL_GLCORE33
 //#flag darwin -framework OpenGL -framework Cocoa -framework QuartzCore
 // D3D
 #flag windows -DSOKOL_GLCORE33
@@ -41,6 +43,7 @@ $if ios {
 #flag windows -DSOKOL_NO_ENTRY
 #flag windows -DSOKOL_WIN32_FORCE_MAIN
 #flag freebsd -DSOKOL_NO_ENTRY
+#flag openbsd -DSOKOL_NO_ENTRY
 #flag solaris -DSOKOL_NO_ENTRY
 // TODO end
 

--- a/vlib/v/ast/cflags.v
+++ b/vlib/v/ast/cflags.v
@@ -25,7 +25,8 @@ pub fn (mut t Table) parse_cflag(cflg string, mod string, ctimedefines []string)
 		return none
 	}
 	mut fos := ''
-	mut allowed_os_overrides := ['linux', 'darwin', 'freebsd', 'windows', 'mingw', 'solaris']
+	mut allowed_os_overrides := ['linux', 'darwin', 'freebsd', 'openbsd', 'windows', 'mingw',
+		'solaris']
 	allowed_os_overrides << ctimedefines
 	for os_override in allowed_os_overrides {
 		if !flag.starts_with(os_override) {


### PR DESCRIPTION
Hello --

This PR does two things:
1. Allows `#flag openbsd` to be used
2. Sets up Sokol on OpenBSD

Combined, this PR allows `ved` to build and run on OpenBSD.

Thanks!