### PR TITLE
ast, checker, cgen: fix error for multi-return in or expr (fix #14167)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1156,7 +1156,7 @@ pub fn (mut t Table) find_or_register_multi_return(mr_typs []Type) int {
 	mut name := '('
 	mut cname := 'multi_return'
 	for i, mr_typ in mr_typs {
-		mr_type_sym := t.sym(mr_typ)
+		mr_type_sym := t.sym(mktyp(mr_typ))
 		ref, cref := if mr_typ.is_ptr() { '&', 'ref_' } else { '', '' }
 		name += '$ref$mr_type_sym.name'
 		cname += '_$cref$mr_type_sym.cname'

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -252,9 +252,15 @@ pub fn (mut c Checker) check_basic(got ast.Type, expected ast.Type) bool {
 	if exp_sym.kind == .multi_return && got_sym.kind == .multi_return {
 		exp_types := exp_sym.mr_info().types
 		got_types := got_sym.mr_info().types.map(ast.mktyp(it))
-		if exp_types == got_types {
-			return true
+		if exp_types.len != got_types.len {
+			return false
 		}
+		for i in 0 .. exp_types.len {
+			if !c.check_types(got_types[i], exp_types[i]) {
+				return false
+			}
+		}
+		return true
 	}
 	// array/map as argument
 	if got_sym.kind in [.array, .map, .array_fixed] && exp_sym.kind == got_sym.kind {

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -248,6 +248,14 @@ pub fn (mut c Checker) check_basic(got ast.Type, expected ast.Type) bool {
 		return true
 	}
 	got_sym, exp_sym := c.table.sym(got), c.table.sym(expected)
+	// multi return
+	if exp_sym.kind == .multi_return && got_sym.kind == .multi_return {
+		exp_types := exp_sym.mr_info().types
+		got_types := got_sym.mr_info().types.map(ast.mktyp(it))
+		if exp_types == got_types {
+			return true
+		}
+	}
 	// array/map as argument
 	if got_sym.kind in [.array, .map, .array_fixed] && exp_sym.kind == got_sym.kind {
 		if c.table.type_to_str(got) == c.table.type_to_str(expected).trim('&') {

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -217,16 +217,6 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 					if is_noreturn_callexpr(last_expr.expr) {
 						continue
 					}
-					node_sym := c.table.sym(node.typ)
-					last_sym := c.table.sym(last_expr.typ)
-					if node_sym.kind == .multi_return && last_sym.kind == .multi_return {
-						node_types := node_sym.mr_info().types
-						last_types := last_sym.mr_info().types.map(ast.mktyp(it))
-						if node_types == last_types {
-							continue
-						}
-					}
-
 					c.error('mismatched types `${c.table.type_to_str(node.typ)}` and `${c.table.type_to_str(last_expr.typ)}`',
 						node.pos)
 				}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3861,10 +3861,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 }
 
 fn (mut g Gen) concat_expr(node ast.ConcatExpr) {
-	mut styp := g.typ(node.return_type)
-	if g.inside_return {
-		styp = g.typ(g.fn_decl.return_type)
-	}
+	styp := g.typ(node.return_type)
 	sym := g.table.sym(node.return_type)
 	is_multi := sym.kind == .multi_return
 	if !is_multi {

--- a/vlib/v/tests/multiret_in_or_expr_test.v
+++ b/vlib/v/tests/multiret_in_or_expr_test.v
@@ -1,11 +1,31 @@
-fn multi_return() ?(int, int) {
+fn multi_return1() ?(int, int) {
 	return 1, 2
 }
 
-fn test_multi_return_in_or_expr() {
-	a, b := multi_return() or { 0, -1 }
+fn multi_return2() ?(i64, i64) {
+	return 11, 22
+}
 
-	println('$a, $b')
-	assert a == 1
-	assert b == 2
+fn multi_return3() ?(int, i64) {
+	return 11, 22
+}
+
+fn test_multi_return_in_or_expr() {
+	a1, b1 := multi_return1() or { 0, -1 }
+
+	println('$a1, $b1')
+	assert a1 == 1
+	assert b1 == 2
+
+	a2, b2 := multi_return2() or { 0, -1 }
+
+	println('$a2, $b2')
+	assert a2 == 11
+	assert b2 == 22
+
+	a3, b3 := multi_return3() or { 0, -1 }
+
+	println('$a3, $b3')
+	assert a3 == 11
+	assert b3 == 22
 }

--- a/vlib/v/tests/multiret_in_or_expr_test.v
+++ b/vlib/v/tests/multiret_in_or_expr_test.v
@@ -1,0 +1,11 @@
+fn multi_return() ?(int, int) {
+	return 1, 2
+}
+
+fn test_multi_return_in_or_expr() {
+	a, b := multi_return() or { 0, -1 }
+
+	println('$a, $b')
+	assert a == 1
+	assert b == 2
+}


### PR DESCRIPTION
This PR fix error for multi-return in or expr (fix #14167).

- Fix error for multi-return in or expr.
- Add test.

```v
fn multi_return1() ?(int, int) {
	return 1, 2
}

fn multi_return2() ?(i64, i64) {
	return 11, 22
}

fn multi_return3() ?(int, i64) {
	return 11, 22
}

fn main() {
	a1, b1 := multi_return1() or { 0, -1 }

	println('$a1, $b1')
	assert a1 == 1
	assert b1 == 2

	a2, b2 := multi_return2() or { 0, -1 }

	println('$a2, $b2')
	assert a2 == 11
	assert b2 == 22

	a3, b3 := multi_return3() or { 0, -1 }

	println('$a3, $b3')
	assert a3 == 11
	assert b3 == 22
}

PS D:\Test\v\tt1> v run .
1, 2
11, 22
11, 22
```