### PR TITLE
cgen: fix error for generic sumtype casting to typenode (fix #14184)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5207,9 +5207,10 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 	// Make sure the sum type can be cast to this type (the types
 	// are the same), otherwise panic.
 	// g.insert_before('
-	styp := g.typ(node.typ)
-	sym := g.table.sym(node.typ)
-	mut expr_type_sym := g.table.sym(node.expr_type)
+	unwrapped_node_typ := g.unwrap_generic(node.typ)
+	styp := g.typ(unwrapped_node_typ)
+	sym := g.table.sym(unwrapped_node_typ)
+	mut expr_type_sym := g.table.sym(g.unwrap_generic(node.expr_type))
 	if mut expr_type_sym.info is ast.SumType {
 		dot := if node.expr_type.is_ptr() { '->' } else { '.' }
 		g.write('/* as */ *($styp*)__as_cast(')
@@ -5223,9 +5224,8 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 		g.write(')')
 		g.write(dot)
 		// g.write('typ, /*expected:*/$node.typ)')
-		sidx := g.type_sidx(node.typ)
-		expected_sym := g.table.sym(node.typ)
-		g.write('_typ, $sidx) /*expected idx: $sidx, name: $expected_sym.name */ ')
+		sidx := g.type_sidx(unwrapped_node_typ)
+		g.write('_typ, $sidx) /*expected idx: $sidx, name: $sym.name */ ')
 
 		// fill as cast name table
 		for variant in expr_type_sym.info.variants {

--- a/vlib/v/tests/generic_sumtype_cast_test.v
+++ b/vlib/v/tests/generic_sumtype_cast_test.v
@@ -1,0 +1,50 @@
+module main
+
+struct Empty {}
+
+struct Node<T> {
+	value T
+mut:
+	next Tree<T>
+}
+
+type Tree<T> = Empty | Node<T>
+
+fn create<T>() Tree<T> {
+	empty := Empty{}
+	mut curr := Node<T>{10, empty}
+	for _ in 0 .. 10 {
+		curr.next = Node<T>{20, empty}
+	}
+
+	return curr
+}
+
+fn create_node<T>(args []T) Tree<T> {
+	empty := Empty{}
+	if args.len == 0 {
+		return empty
+	}
+
+	mut curr := Node<T>{args[0], empty}
+
+	for i := 1; i < args.len; i += 1 {
+		curr.next = Node<T>{args[i], empty}
+		curr = curr.next as Node<T>
+	}
+
+	return curr
+}
+
+fn merge_nodes<T>(head Tree<T>) Tree<T> {
+	println('$head')
+
+	return Empty{}
+}
+
+fn test_generic_sumtype_cast() {
+	node := create_node<int>([0, 3, 1, 0, 4, 5, 2, 0])
+	merge_nodes(node)
+	create<int>()
+	assert true
+}


### PR DESCRIPTION
This PR fix error for generic sumtype casting to typenode (fix #14184).

- Fix error for generic sumtype casting to typenode.
- Add test.

```v
module main

struct Empty {}

struct Node<T> {
	value T
mut:
	next Tree<T>
}

type Tree<T> = Empty | Node<T>

fn create<T>() Tree<T> {
	empty := Empty{}
	mut curr := Node<T>{10, empty}
	for _ in 0 .. 10 {
		curr.next = Node<T>{20, empty}
	}

	return curr
}

fn create_node<T>(args []T) Tree<T> {
	empty := Empty{}
	if args.len == 0 {
		return empty
	}

	mut curr := Node<T>{args[0], empty}

	for i := 1; i < args.len; i += 1 {
		curr.next = Node<T>{args[i], empty}
		curr = curr.next as Node<T>
	}

	return curr
}

fn merge_nodes<T>(head Tree<T>) Tree<T> {
	println('$head')

	return Empty{}
}

fn main() {
	node := create_node<int>([0, 3, 1, 0, 4, 5, 2, 0])
	merge_nodes(node)
	create<int>()
	assert true
}

PS D:\Test\v\tt1> v run .
Tree<int>(Node<int>{
    value: 0
    next: Tree<int>(Empty{})
})
```