### PR TITLE
Allow recursive optional struct type (fix #14185)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1359,7 +1359,8 @@ pub fn (t &Table) has_deep_child_no_ref(ts &TypeSymbol, name string) bool {
 	if ts.info is Struct {
 		for field in ts.info.fields {
 			sym := t.sym(field.typ)
-			if !field.typ.is_ptr() && (sym.name == name || t.has_deep_child_no_ref(sym, name)) {
+			if !field.typ.is_ptr() && !field.typ.has_flag(.optional)
+				&& (sym.name == name || t.has_deep_child_no_ref(sym, name)) {
 				return true
 			}
 		}

--- a/vlib/v/parser/tests/recurisive_optional_struct.out
+++ b/vlib/v/parser/tests/recurisive_optional_struct.out
@@ -1,4 +1,4 @@
-./recurisive_optional_struct.vv:9:8: error: invalid recursive struct `NodeC`
+vlib/v/parser/tests/recurisive_optional_struct.vv:9:8: error: invalid recursive struct `NodeC`
     7 | }
     8 |
     9 | struct NodeC {

--- a/vlib/v/parser/tests/recurisive_optional_struct.out
+++ b/vlib/v/parser/tests/recurisive_optional_struct.out
@@ -1,0 +1,7 @@
+./recurisive_optional_struct.vv:9:8: error: invalid recursive struct `NodeC`
+    7 | }
+    8 |
+    9 | struct NodeC {
+      |        ~~~~~
+   10 |     next NodeC
+   11 | }

--- a/vlib/v/parser/tests/recurisive_optional_struct.vv
+++ b/vlib/v/parser/tests/recurisive_optional_struct.vv
@@ -1,0 +1,11 @@
+struct NodeA {
+	next ?NodeA
+}
+
+struct NodeB {
+	next &NodeB
+}
+
+struct NodeC {
+	next NodeC
+}


### PR DESCRIPTION
- Fix #14185, allow recursive optional struct type since it wraps owner struct type as a pointer type under the hood