### PR TITLE
checker: check error in for_c_stmt with optional call

### DIFF
--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -17,7 +17,7 @@ fn (mut c Checker) for_c_stmt(node ast.ForCStmt) {
 			for right in node.inc.right {
 				if right is ast.CallExpr {
 					if right.or_block.stmts.len > 0 {
-						c.error('disallow using optional call in conditions of for_c_stmt',
+						c.error('optionals are not allowed in `for` statement condition',
 							right.pos)
 					}
 				}

--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -13,6 +13,16 @@ fn (mut c Checker) for_c_stmt(node ast.ForCStmt) {
 	}
 	c.expr(node.cond)
 	if node.has_inc {
+		if node.inc is ast.AssignStmt {
+			for right in node.inc.right {
+				if right is ast.CallExpr {
+					if right.or_block.stmts.len > 0 {
+						c.error('disallow using optional call in conditions of for_c_stmt',
+							right.pos)
+					}
+				}
+			}
+		}
 		c.stmt(node.inc)
 	}
 	c.check_loop_label(node.label, node.pos)

--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -17,7 +17,7 @@ fn (mut c Checker) for_c_stmt(node ast.ForCStmt) {
 			for right in node.inc.right {
 				if right is ast.CallExpr {
 					if right.or_block.stmts.len > 0 {
-						c.error('optionals are not allowed in `for` statement condition (yet)',
+						c.error('optionals are not allowed in `for statement increment` (yet)',
 							right.pos)
 					}
 				}

--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -17,7 +17,7 @@ fn (mut c Checker) for_c_stmt(node ast.ForCStmt) {
 			for right in node.inc.right {
 				if right is ast.CallExpr {
 					if right.or_block.stmts.len > 0 {
-						c.error('optionals are not allowed in `for` statement condition',
+						c.error('optionals are not allowed in `for` statement condition, it is not implemented yet',
 							right.pos)
 					}
 				}

--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -17,7 +17,7 @@ fn (mut c Checker) for_c_stmt(node ast.ForCStmt) {
 			for right in node.inc.right {
 				if right is ast.CallExpr {
 					if right.or_block.stmts.len > 0 {
-						c.error('optionals are not allowed in `for` statement condition, it is not implemented yet',
+						c.error('optionals are not allowed in `for` statement condition (yet)',
 							right.pos)
 					}
 				}

--- a/vlib/v/checker/tests/for_c_stmt_with_optional_call.out
+++ b/vlib/v/checker/tests/for_c_stmt_with_optional_call.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/for_c_stmt_with_optional_call.vv:15:31: error: disallow using optional call in conditions of for_c_stmt
+   13 |     for t := 0; t < tests; t++ {
+   14 |         mut v := []bool{len: nmax, init: false}
+   15 |         for x := 0; !v[x]; x = rand.intn(n) or { 0 } {
+      |                                     ~~~~~~~
+   16 |             v[x] = true
+   17 |             sum++

--- a/vlib/v/checker/tests/for_c_stmt_with_optional_call.out
+++ b/vlib/v/checker/tests/for_c_stmt_with_optional_call.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/for_c_stmt_with_optional_call.vv:15:31: error: optionals are not allowed in `for` statement condition, it is not implemented yet
+vlib/v/checker/tests/for_c_stmt_with_optional_call.vv:15:31: error: optionals are not allowed in `for` statement condition (yet)
    13 |     for t := 0; t < tests; t++ {
    14 |         mut v := []bool{len: nmax, init: false}
    15 |         for x := 0; !v[x]; x = rand.intn(n) or { 0 } {

--- a/vlib/v/checker/tests/for_c_stmt_with_optional_call.out
+++ b/vlib/v/checker/tests/for_c_stmt_with_optional_call.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/for_c_stmt_with_optional_call.vv:15:31: error: optionals are not allowed in `for` statement condition (yet)
+vlib/v/checker/tests/for_c_stmt_with_optional_call.vv:15:31: error: optionals are not allowed in `for statement increment` (yet)
    13 |     for t := 0; t < tests; t++ {
    14 |         mut v := []bool{len: nmax, init: false}
    15 |         for x := 0; !v[x]; x = rand.intn(n) or { 0 } {

--- a/vlib/v/checker/tests/for_c_stmt_with_optional_call.out
+++ b/vlib/v/checker/tests/for_c_stmt_with_optional_call.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/for_c_stmt_with_optional_call.vv:15:31: error: disallow using optional call in conditions of for_c_stmt
+vlib/v/checker/tests/for_c_stmt_with_optional_call.vv:15:31: error: optionals are not allowed in `for` statement condition
    13 |     for t := 0; t < tests; t++ {
    14 |         mut v := []bool{len: nmax, init: false}
    15 |         for x := 0; !v[x]; x = rand.intn(n) or { 0 } {

--- a/vlib/v/checker/tests/for_c_stmt_with_optional_call.out
+++ b/vlib/v/checker/tests/for_c_stmt_with_optional_call.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/for_c_stmt_with_optional_call.vv:15:31: error: optionals are not allowed in `for` statement condition
+vlib/v/checker/tests/for_c_stmt_with_optional_call.vv:15:31: error: optionals are not allowed in `for` statement condition, it is not implemented yet
    13 |     for t := 0; t < tests; t++ {
    14 |         mut v := []bool{len: nmax, init: false}
    15 |         for x := 0; !v[x]; x = rand.intn(n) or { 0 } {

--- a/vlib/v/checker/tests/for_c_stmt_with_optional_call.vv
+++ b/vlib/v/checker/tests/for_c_stmt_with_optional_call.vv
@@ -1,0 +1,31 @@
+import rand
+import math { abs }
+
+const nmax = 20
+
+fn ana(n int) f64 {
+	return 1.0 // haven't started
+}
+
+fn avg(n int) f64 {
+	tests := 1e4
+	mut sum := 0
+	for t := 0; t < tests; t++ {
+		mut v := []bool{len: nmax, init: false}
+		for x := 0; !v[x]; x = rand.intn(n) or { 0 } {
+			v[x] = true
+			sum++
+		}
+	}
+	return f64(sum) / tests
+}
+
+fn main() {
+	println(' N   average   analytical   (error)')
+	println('=== ========= ============ =========')
+	for n in 1 .. nmax + 1 {
+		a := avg(n)
+		b := ana(n)
+		println('${n:3} ${a:9.4f} ${b:12.4f} (${(abs(a - b) / b * 100):6.2f}%)')
+	}
+}


### PR DESCRIPTION
This PR check error in for_c_stmt with optional call (fix #14165).

- Check error in for_c_stmt with optional call.
- Add test.
- It is recommended that the RAND function not use optional.

```v
import rand
import math { abs }

const nmax = 20

fn ana(n int) f64 {
	return 1.0 // haven't started
}

fn avg(n int) f64 {
	tests := 1e4
	mut sum := 0
	for t := 0; t < tests; t++ {
		mut v := []bool{len: nmax, init: false}
		for x := 0; !v[x]; x = rand.intn(n) or { 0 } {
			v[x] = true
			sum++
		}
	}
	return f64(sum) / tests
}

fn main() {
	println(' N   average   analytical   (error)')
	println('=== ========= ============ =========')
	for n in 1 .. nmax + 1 {
		a := avg(n)
		b := ana(n)
		println('${n:3} ${a:9.4f} ${b:12.4f} (${(abs(a - b) / b * 100):6.2f}%)')
	}
}

PS D:\Test\v\tt1> v run .
./tt1.v:15:31: error: optionals are not allowed in `for` statement condition, it is not implemented yet
   13 |     for t := 0; t < tests; t++ {
   14 |         mut v := []bool{len: nmax, init: false}
   15 |         for x := 0; !v[x]; x = rand.intn(n) or { 0 } {
      |                                     ~~~~~~~
   16 |             v[x] = true
   17 |             sum++
```