### PR TITLE
math: fix error for math.abs(0.0)/math.abs(0) (related #14165)

### DIFF
--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -408,6 +408,16 @@ fn test_abs() {
 	}
 }
 
+fn test_abs_zero() {
+	ret1 := math.abs(0)
+	println(ret1)
+	assert '$ret1' == '0'
+
+	ret2 := math.abs(0.0)
+	println(ret2)
+	assert '$ret2' == '0'
+}
+
 fn test_floor() {
 	for i := 0; i < math.vf_.len; i++ {
 		f := floor(math.vf_[i])

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -409,11 +409,11 @@ fn test_abs() {
 }
 
 fn test_abs_zero() {
-	ret1 := math.abs(0)
+	ret1 := abs(0)
 	println(ret1)
 	assert '$ret1' == '0'
 
-	ret2 := math.abs(0.0)
+	ret2 := abs(0.0)
 	println(ret2)
 	assert '$ret2' == '0'
 }

--- a/vlib/math/mathutil.v
+++ b/vlib/math/mathutil.v
@@ -18,5 +18,5 @@ pub fn max<T>(a T, b T) T {
 // abs returns the absolute value of `a`
 [inline]
 pub fn abs<T>(a T) T {
-	return if a > 0 { a } else { -a }
+	return if a < 0 { -a } else { a }
 }


### PR DESCRIPTION
This PR fix error for math.abs(0.0)/math.abs(0) (related #14165).

- Fix error for math.abs(0.0)/math.abs(0).
- Add test.

```v
import math

fn main() {
	ret1 := math.abs(0)
	println(ret1)
	assert '$ret1' == '0'

	ret2 := math.abs(0.0)
	println(ret2)
	assert '$ret2' == '0'
}

PS D:\Test\v\tt1> v run .
0
0
```
```v
module main

import math
import rand

const nmax = 20

fn main() {
	println(' N    average    analytical    (error)')
	println('===  =========  ============  =========')
	for n in 1 .. nmax + 1 {
		a := avg(n)
		b := ana(n)
		println('${n:3} ${a:9.4f} ${b:12.4f} ${math.abs(a - b) / b * 100.0:8.2f}%')
	}
}

fn avg(n int) f64 {
	tests := int(1e6)
	mut sum := 0
	for _ in 0 .. tests {
		mut v := []bool{len: nmax, init: false}
		mut x := 0
		for !v[x] {
			v[x] = true
			sum++
			x = rand.intn(n) or { 0 }
		}
	}
	return f64(sum) / tests
}

fn ana(n int) f64 {
	nn := f64(n)
	mut term := 1.0
	mut sum := 1.0
	for i := n - 1; i >= 1; i-- {
		term *= i / nn
		sum += term
	}
	return sum
}

PS D:\Test\v\tt1> v run .
 N    average    analytical    (error)
===  =========  ============  =========
  1    1.0000       1.0000     0.00%
  2    1.4999       1.5000     0.01%
  3    1.8886       1.8889     0.01%
  4    2.2192       2.2188     0.02%
  5    2.5098       2.5104     0.02%
  6    2.7731       2.7747     0.06%
  7    3.0206       3.0181     0.08%
  8    3.2469       3.2450     0.06%
  9    3.4616       3.4583     0.09%
 10    3.6642       3.6602     0.11%
 11    3.8525       3.8524     0.00%
 12    4.0366       4.0361     0.01%
 13    4.2155       4.2123     0.07%
 14    4.3794       4.3820     0.06%
 15    4.5471       4.5458     0.03%
 16    4.7054       4.7043     0.02%
 17    4.8604       4.8579     0.05%
 18    5.0054       5.0071     0.03%
 19    5.1540       5.1522     0.03%
 20    5.2955       5.2936     0.04%
```