### PR TITLE
cgen: fix go anon fn call with ref argument (fix #14192)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1915,6 +1915,13 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 				g.gowrappers.write_string(call_args_str)
 			} else {
 				for i in 0 .. expr.args.len {
+					expected_nr_muls := expr.expected_arg_types[i].nr_muls()
+					arg_nr_muls := expr.args[i].typ.nr_muls()
+					if arg_nr_muls > expected_nr_muls {
+						g.gowrappers.write_string('*'.repeat(arg_nr_muls - expected_nr_muls))
+					} else if arg_nr_muls < expected_nr_muls {
+						g.gowrappers.write_string('&'.repeat(expected_nr_muls - arg_nr_muls))
+					}
 					g.gowrappers.write_string('arg->arg${i + 1}')
 					if i != expr.args.len - 1 {
 						g.gowrappers.write_string(', ')

--- a/vlib/v/tests/go_anon_fn_call_with_ref_arg_test.v
+++ b/vlib/v/tests/go_anon_fn_call_with_ref_arg_test.v
@@ -1,0 +1,57 @@
+import net.html
+import net.http
+import vweb
+
+struct App {
+	vweb.Context
+}
+
+struct HtmlData {
+mut:
+	inner_html string
+	data       []&HtmlData
+}
+
+fn convert_to_html_data(tag html.Tag) &HtmlData {
+	println('convert_to_html_data')
+	if tag.children.len == 0 {
+		return &HtmlData{
+			inner_html: tag.content
+			data: []
+		}
+	}
+
+	mut node := &HtmlData{
+		inner_html: tag.content
+		data: []&HtmlData{}
+	}
+
+	for child in tag.children {
+		child_data := convert_to_html_data(child)
+		node.data << child_data
+	}
+	return node
+}
+
+fn test_go_anon_fn_call_with_ref_arg() {
+	app := App{}
+	// vweb.run(app, 8081)
+	print('Hello, world!')
+	assert true
+}
+
+['/index']
+pub fn (mut app App) index() vweb.Result {
+	res := http.get('https://www.nzx.com/markets/NZSX') or {
+		http.new_response(status: .internal_server_error)
+	}
+	mut data := html.parse(res.text)
+	table := data.get_tag_by_attribute_value('class', 'small-12 medium-8 columns content')[0]
+
+	go fn (table html.Tag) {
+		final_table := convert_to_html_data(table)
+		println(final_table)
+	}(table)
+
+	return app.html(table.children.str())
+}

--- a/vlib/v/tests/go_anon_fn_call_with_ref_arg_test.v
+++ b/vlib/v/tests/go_anon_fn_call_with_ref_arg_test.v
@@ -1,57 +1,15 @@
-import net.html
-import net.http
-import vweb
-
-struct App {
-	vweb.Context
-}
-
-struct HtmlData {
-mut:
-	inner_html string
-	data       []&HtmlData
-}
-
-fn convert_to_html_data(tag html.Tag) &HtmlData {
-	println('convert_to_html_data')
-	if tag.children.len == 0 {
-		return &HtmlData{
-			inner_html: tag.content
-			data: []
-		}
-	}
-
-	mut node := &HtmlData{
-		inner_html: tag.content
-		data: []&HtmlData{}
-	}
-
-	for child in tag.children {
-		child_data := convert_to_html_data(child)
-		node.data << child_data
-	}
-	return node
+struct Foo {
+	bar string
 }
 
 fn test_go_anon_fn_call_with_ref_arg() {
-	app := App{}
-	// vweb.run(app, 8081)
-	print('Hello, world!')
-	assert true
-}
-
-['/index']
-pub fn (mut app App) index() vweb.Result {
-	res := http.get('https://www.nzx.com/markets/NZSX') or {
-		http.new_response(status: .internal_server_error)
+	foo := &Foo{
+		bar: 'hello'
 	}
-	mut data := html.parse(res.text)
-	table := data.get_tag_by_attribute_value('class', 'small-12 medium-8 columns content')[0]
-
-	go fn (table html.Tag) {
-		final_table := convert_to_html_data(table)
-		println(final_table)
-	}(table)
-
-	return app.html(table.children.str())
+	g := go fn (foo Foo) string {
+		return foo.bar
+	}(foo)
+	ret := g.wait()
+	println(ret)
+	assert ret == 'hello'
 }


### PR DESCRIPTION
This PR fix go anon fn call with ref argument (fix #14192).

- Fix go anon fn call with ref argument.
- Add test.

```v
struct Foo {
	bar string
}

fn main() {
	foo := &Foo{
		bar: 'hello'
	}
	g := go fn (foo Foo) string {
		return foo.bar
	}(foo)
	ret := g.wait()
	println(ret)
	assert ret == 'hello'
}

PS D:\Test\v\tt1> v run .
hello
```

```v
import net.html
import net.http
import vweb

struct App {
	vweb.Context
}

struct HtmlData {
mut:
	inner_html string
	data       []&HtmlData
}

fn convert_to_html_data(tag html.Tag) &HtmlData {
	println('convert_to_html_data')
	if tag.children.len == 0 {
		return &HtmlData{
			inner_html: tag.content
			data: []
		}
	}

	mut node := &HtmlData{
		inner_html: tag.content
		data: []&HtmlData{}
	}

	for child in tag.children {
		child_data := convert_to_html_data(child)
		node.data << child_data
	}
	return node
}

fn main() {
	app := App{}
	vweb.run(app, 8081)
	print('Hello, world!')
	assert true
}

['/index']
pub fn (mut app App) index() vweb.Result {
	res := http.get('https://www.nzx.com/markets/NZSX') or {
		http.new_response(status: .internal_server_error)
	}
	mut data := html.parse(res.text)
	table := data.get_tag_by_attribute_value('class', 'small-12 medium-8 columns content')[0]

	go fn (table html.Tag) {
		final_table := convert_to_html_data(table)
		println(final_table)
	}(table)

	return app.html(table.children.str())
}

PS D:\Test\v\tt1> v run .
[Vweb] Running app on http://localhost:8081/

```