### PR TITLE
checker: fix error for array of sumtype appending literal value (fix #14196)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -935,13 +935,13 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					return ast.void_type
 				} else if left_value_sym.kind == .sum_type {
 					if right_final.kind != .array {
-						if !c.table.is_sumtype_or_in_variant(left_value_type, right_type) {
+						if !c.table.is_sumtype_or_in_variant(left_value_type, ast.mktyp(right_type)) {
 							c.error('cannot append `$right_sym.name` to `$left_sym.name`',
 								right_pos)
 						}
 					} else {
 						right_value_type := c.table.value_type(right_type)
-						if !c.table.is_sumtype_or_in_variant(left_value_type, right_value_type) {
+						if !c.table.is_sumtype_or_in_variant(left_value_type, ast.mktyp(right_value_type)) {
 							c.error('cannot append `$right_sym.name` to `$left_sym.name`',
 								right_pos)
 						}

--- a/vlib/v/tests/array_of_sumtype_append_literal_type_test.v
+++ b/vlib/v/tests/array_of_sumtype_append_literal_type_test.v
@@ -1,0 +1,20 @@
+type Typ_var = f64 | int
+
+fn test_array_of_sumtype_append_literal_type() {
+	mut arr := []Typ_var{}
+
+	// literal int/float type error
+	arr << 123
+	arr << 1.23
+
+	// cast/wrap in type
+	arr << int(123)
+	arr << f64(1.23)
+	arr << Typ_var(456)
+	arr << Typ_var(4.56)
+
+	println(arr)
+
+	assert arr[0] == Typ_var(123)
+	assert arr[1] == Typ_var(1.23)
+}


### PR DESCRIPTION
This PR fix error for array of sumtype appending literal value (fix #14196).

- Fix error for array of sumtype appending literal value.
- Add test.

```v
type Typ_var = f64 | int

fn main() {
	mut arr := []Typ_var{}

	// literal int/float type error
	arr << 123
	arr << 1.23

	// cast/wrap in type
	arr << int(123)
	arr << f64(1.23)
	arr << Typ_var(456)
	arr << Typ_var(4.56)

	println(arr)

	assert arr[0] == Typ_var(123)
	assert arr[1] == Typ_var(1.23)
}

PS D:\Test\v\tt1> v run .
[Typ_var(123), Typ_var(1.23), Typ_var(123), Typ_var(1.23), Typ_var(456), Typ_var(4.56)]
```