### PR TITLE
ast: fix error for complex map operating (fix #14174)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -2072,6 +2072,10 @@ pub fn (mut lx IndexExpr) recursive_mapset_is_setter(val bool) {
 		if lx.left.is_map {
 			lx.left.recursive_mapset_is_setter(val)
 		}
+	} else if mut lx.left is SelectorExpr {
+		if mut lx.left.expr is IndexExpr {
+			lx.left.expr.recursive_mapset_is_setter(val)
+		}
 	}
 }
 

--- a/vlib/v/tests/complex_map_op_test.v
+++ b/vlib/v/tests/complex_map_op_test.v
@@ -1,0 +1,24 @@
+fn test_complex_map_op() {
+	mut test_map := map[string]Point_map{}
+
+	test_map['test1'].points['point3'] << Point{10, 20}
+	test_map['test2'].points['point4'] << Point{50, 60}
+
+	println(test_map)
+	assert test_map.len == 2
+	assert Point{10, 20} in test_map['test1'].points['point3']
+	assert Point{50, 60} in test_map['test2'].points['point4']
+	assert Point{10, 20} !in test_map['test2'].points['point4']
+	assert Point{1, 2} !in test_map['test1'].points['point3']
+}
+
+struct Point {
+mut:
+	x int
+	y int
+}
+
+struct Point_map {
+mut:
+	points map[string][]Point
+}


### PR DESCRIPTION
This PR fix error for complex map operating (fix #14174).

- Fix error for complex map operating.
- Add test.

```v
fn main() {
	mut test_map := map[string]Point_map{}

	test_map['test1'].points['point3'] << Point{10, 20}
	test_map['test2'].points['point4'] << Point{50, 60}

	println(test_map)
	assert test_map.len == 2
	assert Point{10, 20} in test_map['test1'].points['point3']
	assert Point{50, 60} in test_map['test2'].points['point4']
	assert Point{10, 20} !in test_map['test2'].points['point4']
	assert Point{1, 2} !in test_map['test1'].points['point3']
}

struct Point {
mut:
	x int
	y int
}

struct Point_map {
mut:
	points map[string][]Point
}

PS D:\Test\v\tt1> v run .
{'test1': Point_map{
    points: {'point3': [Point{
        x: 10
        y: 20
    }]}
}, 'test2': Point_map{
    points: {'point4': [Point{
        x: 50
        y: 60
    }]}
}}
```