### PR TITLE
ast, parser: fix error for complex map operating (fix #14174)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -2074,9 +2074,16 @@ pub fn (mut lx IndexExpr) recursive_mapset_is_setter(val bool) {
 		if lx.left.is_map {
 			lx.left.recursive_mapset_is_setter(val)
 		}
+	}
+}
+
+pub fn (mut lx IndexExpr) recursive_arraymap_set_is_setter() {
+	lx.is_setter = true
+	if mut lx.left is IndexExpr {
+		lx.left.recursive_arraymap_set_is_setter()
 	} else if mut lx.left is SelectorExpr {
 		if mut lx.left.expr is IndexExpr {
-			lx.left.expr.recursive_mapset_is_setter(val)
+			lx.left.expr.recursive_arraymap_set_is_setter()
 		}
 	}
 }

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -423,7 +423,7 @@ pub fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_iden
 			right := p.expr(precedence - 1)
 			pos.update_last_line(p.prev_tok.line_nr)
 			if mut node is ast.IndexExpr {
-				node.recursive_mapset_is_setter(true)
+				node.recursive_arraymap_set_is_setter()
 			}
 			node = ast.InfixExpr{
 				left: node

--- a/vlib/v/tests/complex_map_op_test.v
+++ b/vlib/v/tests/complex_map_op_test.v
@@ -1,15 +1,31 @@
-fn test_complex_map_op() {
+fn test_complex_map_op1() {
 	mut test_map := map[string]Point_map{}
 
 	test_map['test1'].points['point3'] << Point{10, 20}
 	test_map['test2'].points['point4'] << Point{50, 60}
 
 	println(test_map)
+
 	assert test_map.len == 2
 	assert Point{10, 20} in test_map['test1'].points['point3']
 	assert Point{50, 60} in test_map['test2'].points['point4']
 	assert Point{10, 20} !in test_map['test2'].points['point4']
 	assert Point{1, 2} !in test_map['test1'].points['point3']
+}
+
+fn test_complex_map_op2() {
+	mut test_map := map[string]map[string][]Point{}
+
+	test_map['test1']['point3'] << Point{10, 20}
+	test_map['test2']['point4'] << Point{50, 60}
+
+	println(test_map)
+
+	assert test_map.len == 2
+	assert Point{10, 20} in test_map['test1']['point3']
+	assert Point{50, 60} in test_map['test2']['point4']
+	assert Point{10, 20} !in test_map['test2']['point4']
+	assert Point{1, 2} !in test_map['test1']['point3']
 }
 
 struct Point {


### PR DESCRIPTION
This PR fix error for complex map operating. (fix #14174)

- Fix error for complex map operating. 
- Add test.

```v
fn main() {
	mut test_map := map[string]map[string][]Point{}
	test_map['test1']['point3'] << Point{10, 20}
	test_map['test2']['point4'] << Point{50, 60}

	println(test_map)

	assert test_map.len == 2
	assert Point{10, 20} in test_map['test1']['point3']
	assert Point{50, 60} in test_map['test2']['point4']
	assert Point{10, 20} !in test_map['test2']['point4']
	assert Point{1, 2} !in test_map['test1']['point3']
}

struct Point {
mut:
	x int
	y int
}

PS D:\Test\v\tt1> v run .
{'test1': {'point3': [Point{
    x: 10
    y: 20
}]}, 'test2': {'point4': [Point{
    x: 50
    y: 60
}]}}
```