### PR TITLE
builtin: add `string.len_utf8()` method

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -295,6 +295,12 @@ pub fn (cp &char) vstring_literal_with_len(len int) string {
 	}
 }
 
+// len_utf8 returns the number of runes contained in the string `s`.
+[inline]
+pub fn (s string) len_utf8() int {
+	return utf8_str_len(s)
+}
+
 // clone_static returns an independent copy of a given array.
 // It should be used only in -autofree generated code.
 fn (a string) clone_static() string {

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -296,9 +296,14 @@ pub fn (cp &char) vstring_literal_with_len(len int) string {
 }
 
 // len_utf8 returns the number of runes contained in the string `s`.
-[inline]
 pub fn (s string) len_utf8() int {
-	return utf8_str_len(s)
+	mut l := 0
+	mut i := 0
+	for i < s.len {
+		l++
+		i += ((0xe5000000 >> ((unsafe { s.str[i] } >> 3) & 0x1e)) & 3) + 1
+	}
+	return l
 }
 
 // clone_static returns an independent copy of a given array.

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -27,6 +27,9 @@ fn test_add() {
 fn test_len_utf8() {
 	assert 'Vlang'.len_utf8() == 5
 	assert 'María'.len_utf8() == 5
+	assert '姓名'.len_utf8() == 2
+	assert 'Слово'.len_utf8() == 5
+	assert 'Λέξη'.len_utf8() == 4
 }
 
 fn test_ends_with() {

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -24,6 +24,11 @@ fn test_add() {
 	assert a.ends_with('3')
 }
 
+fn test_len_utf8() {
+	assert 'Vlang'.len_utf8() == 5
+	assert 'María'.len_utf8() == 5
+}
+
 fn test_ends_with() {
 	a := 'browser.v'
 	assert a.ends_with('.v')

--- a/vlib/builtin/utf8.v
+++ b/vlib/builtin/utf8.v
@@ -66,6 +66,18 @@ pub fn utf32_decode_to_buffer(code u32, buf &u8) int {
 	return 0
 }
 
+// utf8_str_len returns the number of runes contained in the string.
+[deprecated: 'use `string.len_utf8()` instead']
+pub fn utf8_str_len(s string) int {
+	mut l := 0
+	mut i := 0
+	for i < s.len {
+		l++
+		i += ((0xe5000000 >> ((unsafe { s.str[i] } >> 3) & 0x1e)) & 3) + 1
+	}
+	return l
+}
+
 // Convert utf8 to utf32
 // the original implementation did not check for
 // valid utf8 in the string, and could result in

--- a/vlib/builtin/utf8.v
+++ b/vlib/builtin/utf8.v
@@ -134,17 +134,6 @@ fn utf8_len(c u8) int {
 	return b
 }
 
-// utf8_str_len returns the number of runes contained in the string.
-pub fn utf8_str_len(s string) int {
-	mut l := 0
-	mut i := 0
-	for i < s.len {
-		l++
-		i += ((0xe5000000 >> ((unsafe { s.str[i] } >> 3) & 0x1e)) & 3) + 1
-	}
-	return l
-}
-
 // Calculate string length for formatting, i.e. number of "characters"
 // This is simplified implementation. if you need specification compliant width,
 // use utf8.east_asian.display_width.

--- a/vlib/builtin/utf8.v
+++ b/vlib/builtin/utf8.v
@@ -68,6 +68,7 @@ pub fn utf32_decode_to_buffer(code u32, buf &u8) int {
 
 // utf8_str_len returns the number of runes contained in the string.
 [deprecated: 'use `string.len_utf8()` instead']
+[deprecated_after: '2022-05-28']
 pub fn utf8_str_len(s string) int {
 	mut l := 0
 	mut i := 0

--- a/vlib/builtin/utf8.v
+++ b/vlib/builtin/utf8.v
@@ -134,7 +134,7 @@ fn utf8_len(c u8) int {
 	return b
 }
 
-// Calculate string length for in number of codepoints
+// utf8_str_len returns the number of runes contained in the string.
 pub fn utf8_str_len(s string) int {
 	mut l := 0
 	mut i := 0

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3146,7 +3146,7 @@ fn (mut g Gen) char_literal(node ast.CharLiteral) {
 		return
 	}
 	// TODO: optimize use L-char instead of u32 when possible
-	if utf8_str_len(node.val) < node.val.len {
+	if node.val.len_utf8() < node.val.len {
 		g.write('((rune)0x$node.val.utf32_code().hex() /* `$node.val` */)')
 		return
 	}


### PR DESCRIPTION
This PR adds a method to `string` called `len_utf8` that returns the number of runes the string has.