### PR TITLE
cgen: fix use of C reserved words inside `defer` statement (fix #14101)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ language, very similar to the way it is right now.
 
 ### Linux, macOS, Windows, *BSD, Solaris, WSL, Android, etc.
 
-Usually installing V is quite simple if you have an environment that already has a 
-functional `git` installation. 
+Usually installing V is quite simple if you have an environment that already has a
+functional `git` installation.
 
 * *(* ***PLEASE NOTE:*** *If you run into any trouble or you have a different operating
-system or Linux distribution that doesn't install or work immediately, please see 
+system or Linux distribution that doesn't install or work immediately, please see
 [Installation Issues](https://github.com/vlang/v/discussions/categories/installation-issues)
 and search for your OS and problem. If you can't find your problem, please add it to an
 existing discussion if one exists for your OS, or create a new one if a main discussion

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -299,7 +299,7 @@ fn (mut g Gen) gen_assign_stmt(node_ ast.AssignStmt) {
 					g.write(' = ${styp}_${util.replace_op(extracted_op)}(')
 					method := g.table.find_method(left_sym, extracted_op) or {
 						// the checker will most likely have found this, already...
-						g.error('assignemnt operator `$extracted_op=` used but no `$extracted_op` method defined',
+						g.error('assignment operator `$extracted_op=` used but no `$extracted_op` method defined',
 							node.pos)
 						ast.Fn{}
 					}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -16,7 +16,7 @@ import sync.pool
 
 const (
 	// Note: some of the words in c_reserved, are not reserved in C, but are
-	// in C++, or have special meaning in V, thus need escaping too. small`
+	// in C++, or have special meaning in V, thus need escaping too. `small`
 	// should not be needed, but see:
 	// https://stackoverflow.com/questions/5874215/what-is-rpcndr-h
 	c_reserved     = ['array', 'auto', 'bool', 'break', 'calloc', 'case', 'char', 'class', 'complex',

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -15,9 +15,10 @@ import v.depgraph
 import sync.pool
 
 const (
-	// Note: some of the words in c_reserved, are not reserved in C,
-	// but are in C++, or have special meaning in V, thus need escaping too.
-	// `small` should not be needed, but see: https://stackoverflow.com/questions/5874215/what-is-rpcndr-h
+	// Note: some of the words in c_reserved, are not reserved in C, but are
+	// in C++, or have special meaning in V, thus need escaping too. small`
+	// should not be needed, but see:
+	// https://stackoverflow.com/questions/5874215/what-is-rpcndr-h
 	c_reserved     = ['array', 'auto', 'bool', 'break', 'calloc', 'case', 'char', 'class', 'complex',
 		'const', 'continue', 'default', 'delete', 'do', 'double', 'else', 'enum', 'error', 'exit',
 		'export', 'extern', 'false', 'float', 'for', 'free', 'goto', 'if', 'inline', 'int', 'link',
@@ -1590,10 +1591,6 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 	if !g.skip_stmt_pos {
 		g.set_current_pos_as_last_stmt_pos()
 	}
-	defer {
-	}
-	// println('g.stmt()')
-	// g.writeln('//// stmt start')
 	match node {
 		ast.EmptyStmt {}
 		ast.AsmStmt {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -337,7 +337,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 					}
 					info := var.obj as ast.Var
 					if g.table.sym(info.typ).kind != .function {
-						g.writeln('${g.typ(info.typ)}$deref $var.name;')
+						g.writeln('${g.typ(info.typ)}$deref ${c_name(var.name)};')
 					}
 				}
 			}

--- a/vlib/v/tests/defer/defer_test.v
+++ b/vlib/v/tests/defer/defer_test.v
@@ -154,3 +154,20 @@ fn num() int {
 	}
 	return ret
 }
+
+fn close(i int) {
+	eprintln("Close $i")
+}
+
+fn test_defer_with_reserved_words() {
+	if 1 == 1 {
+		single := 1
+		defer { close(single) }
+	}
+	if 2 == 2 {
+		double := 9
+		defer { close(double) }
+	}
+	eprintln("Done")
+	assert true
+}

--- a/vlib/v/tests/defer/defer_test.v
+++ b/vlib/v/tests/defer/defer_test.v
@@ -156,18 +156,22 @@ fn num() int {
 }
 
 fn close(i int) {
-	eprintln("Close $i")
+	eprintln('Close $i')
 }
 
 fn test_defer_with_reserved_words() {
 	if 1 == 1 {
 		single := 1
-		defer { close(single) }
+		defer {
+			close(single)
+		}
 	}
 	if 2 == 2 {
 		double := 9
-		defer { close(double) }
+		defer {
+			close(double)
+		}
 	}
-	eprintln("Done")
+	eprintln('Done')
 	assert true
 }


### PR DESCRIPTION
This PR fix use of C reserved words inside `defer` statement, and also adds a test (fix #14101).

```v
fn close(i int) {
	eprintln("Close $i")
}

fn main() {
	if 1 == 1 {
		single := 1
		defer { close(single) }
	}
	if 2 == 2 {
		double := 9
		defer { close(double) }
	}
	eprintln("Done")
}
```
```
$ ./v2 run x.v
Done
Close 9
Close 1
```