### PR TITLE
checker: check struct field name using uppercase letters (fix #14219)

### DIFF
--- a/vlib/v/checker/tests/struct_field_name_err.out
+++ b/vlib/v/checker/tests/struct_field_name_err.out
@@ -1,13 +1,20 @@
-vlib/v/checker/tests/struct_field_name_err.vv:2:2: error: field name `Architecture` cannot contain uppercase letters, use snake_case instead
+vlib/v/checker/tests/struct_field_name_err.vv:2:2: error: field name `Foo` cannot contain uppercase letters, use snake_case instead
     1 | struct Release {
-    2 |     Architecture []string
-      |     ~~~~~~~~~~~~~~~~~~~~~
-    3 |     Components   []string
-    4 | }
-vlib/v/checker/tests/struct_field_name_err.vv:3:2: error: field name `Components` cannot contain uppercase letters, use snake_case instead
+    2 |     Foo          string
+      |     ~~~~~~~~~~~~~~~~~~~
+    3 |     Bar          &int
+    4 |     Architecture []string
+vlib/v/checker/tests/struct_field_name_err.vv:3:2: error: field name `Bar` cannot contain uppercase letters, use snake_case instead
     1 | struct Release {
-    2 |     Architecture []string
-    3 |     Components   []string
+    2 |     Foo          string
+    3 |     Bar          &int
+      |     ~~~~~~~~~~~~~~~~~
+    4 |     Architecture []string
+    5 | }
+vlib/v/checker/tests/struct_field_name_err.vv:4:2: error: field name `Architecture` cannot contain uppercase letters, use snake_case instead
+    2 |     Foo          string
+    3 |     Bar          &int
+    4 |     Architecture []string
       |     ~~~~~~~~~~~~~~~~~~~~~
-    4 | }
-    5 |
+    5 | }
+    6 |

--- a/vlib/v/checker/tests/struct_field_name_err.vv
+++ b/vlib/v/checker/tests/struct_field_name_err.vv
@@ -1,9 +1,8 @@
 struct Release {
+	Foo          string
+	Bar          &int
 	Architecture []string
-	Components   []string
 }
 
 fn main() {
-	r := Release{}
-	println(r)
 }

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -185,6 +185,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 				is_field_volatile = true
 			}
 			is_embed := ((p.tok.lit.len > 1 && p.tok.lit[0].is_capital()
+				&& (p.peek_tok.line_nr != p.tok.line_nr || p.peek_tok.kind !in [.name, .amp])
 				&& (p.peek_tok.kind != .lsbr || p.peek_token(2).kind != .rsbr))
 				|| p.peek_tok.kind == .dot) && language == .v && p.peek_tok.kind != .key_fn
 			is_on_top := ast_fields.len == 0 && !(is_field_mut || is_field_global)


### PR DESCRIPTION
This PR check struct field name using uppercase letters (fix #14219).

- Check struct field name using uppercase letters.
- Add test.

```v
struct Release {
	Foo          string
	Bar          &int
	Architecture []string
}

fn main() {
}

PS D:\Test\v\tt1> v run .
./tt1.v:2:2: error: field name `Foo` cannot contain uppercase letters, use snake_case instead
    1 | struct Release {
    2 |     Foo          string
      |     ~~~~~~~~~~~~~~~~~~~
    3 |     Bar          &int
    4 |     Architecture []string
./tt1.v:3:2: error: field name `Bar` cannot contain uppercase letters, use snake_case instead
    1 | struct Release {
    2 |     Foo          string
    3 |     Bar          &int
      |     ~~~~~~~~~~~~~~~~~
    4 |     Architecture []string
    5 | }
./tt1.v:4:2: error: field name `Architecture` cannot contain uppercase letters, use snake_case instead
    2 |     Foo          string
    3 |     Bar          &int
    4 |     Architecture []string
      |     ~~~~~~~~~~~~~~~~~~~~~
    5 | }
    6 |
```