### PR TITLE
builtin: ignore C++ exception errors

### DIFF
--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -243,7 +243,7 @@ fn unhandled_exception_handler(e &ExceptionPointers) int {
 	match e.exception_record.code {
 		// These are 'used' by the backtrace printer
 		// so we dont want to catch them...
-		0x4001000A, 0x40010006 {
+		0x4001000A, 0x40010006, 0xE06D7363 {
 			return 0
 		}
 		else {


### PR DESCRIPTION
Multiple people have experienced issues with `os.cp()` throwing seemingly random errors on Windows but neither crashing the program nor working unexpectedly.
On Discord, we have decided to ignore all `0xE06D7363` errors, as they should not be handled by V and seem to not matter anyway.
This change resolved the issue for me.