### PR TITLE
parser: check interface field name using uppercase letter (fix #14226)

### DIFF
--- a/vlib/v/checker/tests/interface_field_name_err.out
+++ b/vlib/v/checker/tests/interface_field_name_err.out
@@ -1,0 +1,20 @@
+vlib/v/checker/tests/interface_field_name_err.vv:2:2: error: field name `Age` cannot contain uppercase letters, use snake_case instead
+    1 | interface Animal {
+    2 |     Age int
+      |     ~~~
+    3 |     Foo &int
+    4 |     Bar []string
+vlib/v/checker/tests/interface_field_name_err.vv:3:2: error: field name `Foo` cannot contain uppercase letters, use snake_case instead
+    1 | interface Animal {
+    2 |     Age int
+    3 |     Foo &int
+      |     ~~~
+    4 |     Bar []string
+    5 | }
+vlib/v/checker/tests/interface_field_name_err.vv:4:2: error: field name `Bar` cannot contain uppercase letters, use snake_case instead
+    2 |     Age int
+    3 |     Foo &int
+    4 |     Bar []string
+      |     ~~~
+    5 | }
+    6 |

--- a/vlib/v/checker/tests/interface_field_name_err.vv
+++ b/vlib/v/checker/tests/interface_field_name_err.vv
@@ -1,0 +1,8 @@
+interface Animal {
+	Age int
+	Foo &int
+	Bar []string
+}
+
+fn main() {
+}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -517,7 +517,8 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 	mut ifaces := []ast.InterfaceEmbedding{}
 	for p.tok.kind != .rcbr && p.tok.kind != .eof {
 		if p.tok.kind == .name && p.tok.lit.len > 0 && p.tok.lit[0].is_capital()
-			&& p.peek_tok.kind != .lpar {
+			&& (p.peek_tok.line_nr != p.tok.line_nr
+			|| p.peek_tok.kind !in [.name, .amp, .lsbr, .lpar]) {
 			iface_pos := p.tok.pos()
 			mut iface_name := p.tok.lit
 			iface_type := p.parse_type()


### PR DESCRIPTION
This PR check interface field name using uppercase letter (fix #14226).

- Check interface field name using uppercase letter.
- Add test.

```v
interface Animal {
	Age int
	Foo &int
	Bar []string
}

fn main() {
}

PS D:\Test\v\tt1> v run .
./tt1.v:2:2: error: field name `Age` cannot contain uppercase letters, use snake_case instead
    1 | interface Animal {
    2 |     Age int
      |     ~~~
    3 |     Foo &int
    4 |     Bar []string
./tt1.v:3:2: error: field name `Foo` cannot contain uppercase letters, use snake_case instead
    1 | interface Animal {
    2 |     Age int
    3 |     Foo &int
      |     ~~~
    4 |     Bar []string
    5 | }
./tt1.v:4:2: error: field name `Bar` cannot contain uppercase letters, use snake_case instead
    2 |     Age int
    3 |     Foo &int
    4 |     Bar []string
      |     ~~~
    5 | }
    6 |
```