### PR TITLE
time: fix unix add

### DIFF
--- a/vlib/time/unix.v
+++ b/vlib/time/unix.v
@@ -81,12 +81,7 @@ fn calculate_date_from_offset(day_offset_ i64) (int, int, int) {
 		day_offset %= 365
 	}
 	if day_offset < 0 {
-		year--
-		if is_leap_year(year) {
-			day_offset += 366
-		} else {
-			day_offset += 365
-		}
+		day_offset +=  1
 	}
 	if is_leap_year(year) {
 		if day_offset > 31 + 29 - 1 {


### PR DESCRIPTION
Adding 60 seconds to the beginning 2000 caused a rollover. Instead of subtracting a year, just added a day to `day_offset`


Honestly I'm not 100% sure why it works (I think it has something to do with modulo negative number), but I did test against dates provided in #14019 and it works correctly