### PR TITLE
checker, gen: add support for a [minify] struct attribute 

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -202,6 +202,7 @@ pub:
 	pos token.Pos
 }
 
+[minify]
 pub struct StringLiteral {
 pub:
 	val      string
@@ -246,6 +247,7 @@ pub enum GenericKindField {
 }
 
 // `foo.bar`
+[minify]
 pub struct SelectorExpr {
 pub:
 	pos        token.Pos
@@ -287,6 +289,7 @@ pub:
 	is_skipped bool      // module main can be skipped in single file programs
 }
 
+[minify]
 pub struct StructField {
 pub:
 	pos              token.Pos
@@ -333,6 +336,7 @@ pub mut:
 }
 
 // const declaration
+[minify]
 pub struct ConstDecl {
 pub:
 	is_pub bool
@@ -344,6 +348,7 @@ pub mut:
 	is_block     bool // const() block
 }
 
+[minify]
 pub struct StructDecl {
 pub:
 	pos           token.Pos
@@ -380,6 +385,7 @@ pub:
 	comments []Comment
 }
 
+[minify]
 pub struct InterfaceDecl {
 pub:
 	name          string
@@ -431,6 +437,7 @@ pub mut:
 //    ...a
 //    field1: 'hello'
 // }`
+[minify]
 pub struct StructInit {
 pub:
 	pos             token.Pos
@@ -484,6 +491,7 @@ pub mut:
 }
 
 // function or method declaration
+[minify]
 pub struct FnDecl {
 pub:
 	name            string // 'math.bits.normalize'
@@ -542,6 +550,7 @@ pub mut:
 }
 
 // break, continue
+[minify]
 pub struct BranchStmt {
 pub:
 	kind  token.Kind
@@ -550,6 +559,7 @@ pub:
 }
 
 // function or method call expr
+[minify]
 pub struct CallExpr {
 pub:
 	pos      token.Pos
@@ -589,6 +599,7 @@ pub struct AutofreeArgVar {
 }
 */
 // function call argument: `f(callarg)`
+[minify]
 pub struct CallArg {
 pub:
 	is_mut   bool
@@ -612,6 +623,7 @@ pub mut:
 	types []Type
 }
 
+[minify]
 pub struct Var {
 pub:
 	name            string
@@ -657,6 +669,7 @@ pub:
 	//        12 <- the current casted type (typ)
 }
 
+[minify]
 pub struct GlobalField {
 pub:
 	name        string
@@ -749,6 +762,7 @@ pub mut:
 
 // TODO: (joe) remove completely, use ident.obj
 // instead which points to the scope object
+[minify]
 pub struct IdentVar {
 pub mut:
 	typ         Type
@@ -771,6 +785,7 @@ pub enum IdentKind {
 }
 
 // A single identifier
+[minify]
 pub struct Ident {
 pub:
 	language Language
@@ -816,6 +831,7 @@ pub fn (i &Ident) var_info() IdentVar {
 
 // left op right
 // See: token.Kind.is_infix
+[minify]
 pub struct InfixExpr {
 pub:
 	op      token.Kind
@@ -846,6 +862,7 @@ pub mut:
 }
 
 // See: token.Kind.is_prefix
+[minify]
 pub struct PrefixExpr {
 pub:
 	op  token.Kind
@@ -857,6 +874,7 @@ pub mut:
 	is_option  bool // IfGuard
 }
 
+[minify]
 pub struct IndexExpr {
 pub:
 	pos token.Pos
@@ -874,6 +892,7 @@ pub mut:
 	is_gated  bool // #[] gated array
 }
 
+[minify]
 pub struct IfExpr {
 pub:
 	is_comptime   bool
@@ -921,6 +940,7 @@ pub mut:
 	scope    &Scope
 }
 
+[minify]
 pub struct MatchExpr {
 pub:
 	tok_kind token.Kind
@@ -1000,6 +1020,7 @@ pub mut:
 	scope &Scope
 }
 
+[minify]
 pub struct ForInStmt {
 pub:
 	key_var    string
@@ -1060,6 +1081,7 @@ pub:
 }
 */
 // variable assign statement
+[minify]
 pub struct AssignStmt {
 pub:
 	op           token.Kind // include: =,:=,+=,-=,*=,/= and so on; for a list of all the assign operators, see vlib/token/token.v
@@ -1099,6 +1121,7 @@ pub mut:
 }
 
 // enum field in enum declaration
+[minify]
 pub struct EnumField {
 pub:
 	name          string
@@ -1111,6 +1134,7 @@ pub mut:
 }
 
 // enum declaration
+[minify]
 pub struct EnumDecl {
 pub:
 	name             string
@@ -1161,6 +1185,7 @@ pub:
 // TODO: handle this differently
 // v1 excludes non current os ifdefs so
 // the defer's never get added in the first place
+[minify]
 pub struct DeferStmt {
 pub:
 	stmts []Stmt
@@ -1199,6 +1224,7 @@ pub:
 	pos  token.Pos
 }
 
+[minify]
 pub struct ArrayInit {
 pub:
 	pos           token.Pos   // `[]` in []Type{} position
@@ -1242,6 +1268,7 @@ pub mut:
 	elem_type Type
 }
 
+[minify]
 pub struct MapInit {
 pub:
 	pos       token.Pos
@@ -1257,6 +1284,7 @@ pub mut:
 }
 
 // s[10..20]
+[minify]
 pub struct RangeExpr {
 pub:
 	has_high bool
@@ -1279,6 +1307,7 @@ pub mut:
 	pos       token.Pos
 }
 
+[minify]
 pub struct AsmStmt {
 pub:
 	arch        pref.Arch
@@ -1296,6 +1325,7 @@ pub mut:
 	local_labels  []string // local to the assembly block
 }
 
+[minify]
 pub struct AsmTemplate {
 pub mut:
 	name         string
@@ -1460,6 +1490,7 @@ pub const (
 	}
 )
 
+[minify]
 pub struct AssertStmt {
 pub:
 	pos token.Pos
@@ -1511,6 +1542,7 @@ pub:
 */
 
 // deprecated
+[minify]
 pub struct Assoc {
 pub:
 	var_name string
@@ -1555,6 +1587,7 @@ pub mut:
 	expr Expr
 }
 
+[minify]
 pub struct TypeOf {
 pub:
 	pos token.Pos
@@ -1563,6 +1596,7 @@ pub mut:
 	expr_type Type
 }
 
+[minify]
 pub struct DumpExpr {
 pub:
 	pos token.Pos
@@ -1598,6 +1632,7 @@ pub mut:
 	val string
 }
 
+[minify]
 pub struct ComptimeSelector {
 pub:
 	has_parens bool // if $() is used, for vfmt
@@ -1609,6 +1644,7 @@ pub mut:
 	typ        Type
 }
 
+[minify]
 pub struct ComptimeCall {
 pub:
 	pos         token.Pos

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -655,6 +655,7 @@ pub mut:
 
 // used for smartcasting only
 // struct fields change type in scopes
+[minify]
 pub struct ScopeStructField {
 pub:
 	struct_type Type // type of struct
@@ -695,6 +696,7 @@ pub mut:
 	end_comments []Comment
 }
 
+[minify]
 pub struct EmbeddedFile {
 pub:
 	rpath            string // used in the source code, as an ID/key to the embed
@@ -979,6 +981,7 @@ pub mut:
 	expected_type Type // for debugging only
 }
 
+[minify]
 pub struct SelectBranch {
 pub:
 	pos           token.Pos
@@ -1204,6 +1207,7 @@ pub mut:
 	expr Expr
 }
 
+[minify]
 pub struct GoExpr {
 pub:
 	pos token.Pos
@@ -1296,6 +1300,7 @@ pub mut:
 	high Expr
 }
 
+[minify]
 pub struct CastExpr {
 pub mut:
 	arg       Expr   // `n` in `string(buf, n)`
@@ -1572,6 +1577,7 @@ pub mut:
 	typ  Type
 }
 
+[minify]
 pub struct OffsetOf {
 pub:
 	struct_type Type

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -295,6 +295,7 @@ pub:
 	pos              token.Pos
 	type_pos         token.Pos
 	comments         []Comment
+	i                int
 	has_default_expr bool
 	attrs            []Attr
 	is_pub           bool

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1125,7 +1125,6 @@ pub mut:
 }
 
 // enum field in enum declaration
-[minify]
 pub struct EnumField {
 pub:
 	name          string

--- a/vlib/v/ast/attr.v
+++ b/vlib/v/ast/attr.v
@@ -14,6 +14,7 @@ pub enum AttrKind {
 }
 
 // e.g. `[unsafe]`
+[minify]
 pub struct Attr {
 pub:
 	name    string // [name]

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -9,7 +9,7 @@ import v.cflag
 import v.token
 import v.util
 
-[heap]
+[heap; minify]
 pub struct Table {
 mut:
 	parsing_type string // name of the type to enable recursive type parsing
@@ -86,6 +86,7 @@ pub fn (t &Table) panic(message string) {
 	t.panic_handler(t, message)
 }
 
+[minify]
 pub struct Fn {
 pub:
 	is_variadic     bool

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -127,6 +127,7 @@ fn (f &Fn) method_equals(o &Fn) bool {
 		&& f.name == o.name
 }
 
+[minify]
 pub struct Param {
 pub:
 	pos         token.Pos
@@ -829,7 +830,6 @@ pub fn (mut t Table) register_sym(sym TypeSymbol) int {
 	idx = t.type_symbols.len
 	t.type_symbols << &TypeSymbol{
 		...sym
-		size: if sym.size == 0 { -1 } else { sym.size }
 	}
 	t.type_symbols[idx].idx = idx
 	t.type_idxs[sym.name] = idx

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -828,6 +828,7 @@ pub fn (mut t Table) register_sym(sym TypeSymbol) int {
 	idx = t.type_symbols.len
 	t.type_symbols << &TypeSymbol{
 		...sym
+		size: if sym.size == 0 { -1 } else { sym.size }
 	}
 	t.type_symbols[idx].idx = idx
 	t.type_idxs[sym.name] = idx

--- a/vlib/v/ast/type_size_test.v
+++ b/vlib/v/ast/type_size_test.v
@@ -41,14 +41,22 @@ fn test_type_size() ? {
 
 	mut t := b.table
 
-	assert sizeof(T01) == t.type_size(t.type_idxs['main.T01'] ?)
-	assert sizeof(T02) == t.type_size(t.type_idxs['main.T02'] ?)
-	assert sizeof(T03) == t.type_size(t.type_idxs['main.T03'] ?)
-	assert sizeof(T04) == t.type_size(t.type_idxs['main.T04'] ?)
-	assert sizeof(T05) == t.type_size(t.type_idxs['main.T05'] ?)
-	assert sizeof(T06) == t.type_size(t.type_idxs['main.T06'] ?)
-	assert sizeof(T07) == t.type_size(t.type_idxs['main.T07'] ?)
-	assert sizeof(T08) == t.type_size(t.type_idxs['main.T08'] ?)
+	size01, _ := t.type_size(t.type_idxs['main.T01'] ?)
+	assert sizeof(T01) == size01
+	size02, _ := t.type_size(t.type_idxs['main.T02'] ?)
+	assert sizeof(T02) == size02
+	size03, _ := t.type_size(t.type_idxs['main.T03'] ?)
+	assert sizeof(T03) == size03
+	size04, _ := t.type_size(t.type_idxs['main.T04'] ?)
+	assert sizeof(T04) == size04
+	size05, _ := t.type_size(t.type_idxs['main.T05'] ?)
+	assert sizeof(T05) == size05
+	size06, _ := t.type_size(t.type_idxs['main.T06'] ?)
+	assert sizeof(T06) == size06
+	size07, _ := t.type_size(t.type_idxs['main.T07'] ?)
+	assert sizeof(T07) == size07
+	size08, _ := t.type_size(t.type_idxs['main.T08'] ?)
+	assert sizeof(T08) == size08
 
 	println('done')
 }

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -80,6 +80,7 @@ pub fn pref_arch_to_table_language(pref_arch pref.Arch) Language {
 // Each TypeSymbol is entered into `Table.types`.
 // See also: Table.sym.
 
+[minify]
 pub struct TypeSymbol {
 pub:
 	parent_idx int
@@ -840,9 +841,7 @@ pub fn (t &Table) type_size(typ Type) int {
 	}
 	mut res := 0
 	match sym.kind {
-		.placeholder, .void, .none_, .generic_inst {
-
-		}
+		.placeholder, .void, .none_, .generic_inst {}
 		.voidptr, .byteptr, .charptr, .function, .usize, .isize, .any, .thread, .chan {
 			res = t.pointer_size
 		}
@@ -974,6 +973,7 @@ pub fn (kinds []Kind) str() string {
 	return kinds_str
 }
 
+[minify]
 pub struct Struct {
 pub:
 	attrs []Attr
@@ -997,6 +997,7 @@ pub mut:
 	concrete_types []Type // concrete types, e.g. <int, string>
 }
 
+[minify]
 pub struct Interface {
 pub mut:
 	types   []Type // all types that implement this interface
@@ -1020,6 +1021,7 @@ pub:
 	uses_exprs       bool
 }
 
+[minify]
 pub struct Alias {
 pub:
 	parent_type Type
@@ -1042,6 +1044,7 @@ pub mut:
 	elem_type Type
 }
 
+[minify]
 pub struct ArrayFixed {
 pub:
 	size      int
@@ -1067,6 +1070,7 @@ pub mut:
 	value_type Type
 }
 
+[minify]
 pub struct SumType {
 pub mut:
 	fields       []StructField
@@ -1313,6 +1317,7 @@ fn (t Table) shorten_user_defined_typenames(originalname string, import_aliases 
 	return res
 }
 
+[minify]
 pub struct FnSignatureOpts {
 	skip_receiver bool
 	type_only     bool

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -644,8 +644,8 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				} else if is_left_type_signed != is_right_type_signed
 					&& left_type != ast.int_literal_type_idx
 					&& right_type != ast.int_literal_type_idx {
-					ls := c.table.type_size(left_type)
-					rs := c.table.type_size(right_type)
+					ls, _ := c.table.type_size(left_type)
+					rs, _ := c.table.type_size(right_type)
 					// prevent e.g. `u32 == i16` but not `u16 == i32` as max_u16 fits in i32
 					// TODO u32 == i32, change < to <=
 					if (is_left_type_signed && ls < rs) || (is_right_type_signed && rs < ls) {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -54,7 +54,7 @@ fn all_valid_comptime_idents() []string {
 	return res
 }
 
-[heap]
+[heap; minify]
 pub struct Checker {
 	pref &pref.Preferences // Preferences shared from V struct
 pub mut:
@@ -3721,8 +3721,12 @@ pub fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 				c.error('unexpected `&`, expecting expression', node.right.pos)
 			}
 		} else if mut node.right is ast.SelectorExpr {
+			right_sym := c.table.sym(right_type)
 			expr_sym := c.table.sym(node.right.expr_type)
-			if expr_sym.kind == .struct_ && (expr_sym.info as ast.Struct).is_minify {
+			if expr_sym.kind == .struct_ && (expr_sym.info as ast.Struct).is_minify
+				&& (node.right.typ == ast.bool_type_idx || (right_sym.kind == .enum_
+				&& !(right_sym.info as ast.Enum).is_flag
+				&& !(right_sym.info as ast.Enum).uses_exprs)) {
 				c.error('cannot take address of field in struct `${c.table.type_to_str(node.right.expr_type)}`, which is tagged as `[minify]`',
 					node.pos.extend(node.right.pos))
 			}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3720,6 +3720,12 @@ pub fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 			if node.right.op == .amp {
 				c.error('unexpected `&`, expecting expression', node.right.pos)
 			}
+		} else if mut node.right is ast.SelectorExpr {
+			expr_sym := c.table.sym(node.right.expr_type)
+			if expr_sym.kind == .struct_ && (expr_sym.info as ast.Struct).is_minify {
+				c.error('cannot take address of field in struct `${c.table.type_to_str(node.right.expr_type)}`, which is tagged as `[minify]`',
+					node.pos.extend(node.right.pos))
+			}
 		}
 	}
 	// TODO: testing ref/deref strategy

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -127,7 +127,8 @@ fn (mut c Checker) eval_comptime_const_expr(expr ast.Expr, nlevel int) ?ast.Comp
 		//	return expr.val.i64()
 		// }
 		ast.SizeOf {
-			return c.table.type_size(expr.typ)
+			s, _ := c.table.type_size(expr.typ)
+			return s
 		}
 		ast.FloatLiteral {
 			x := expr.val.f64()

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -169,9 +169,13 @@ fn minify_sort_fn(a &ast.StructField, b &ast.StructField) int {
 		}
 	}
 
-	a_size := t.type_size(a.typ)
-	b_size := t.type_size(b.typ)
-	return if a_size > b_size {
+	a_size, a_align := t.type_size(a.typ)
+	b_size, b_align := t.type_size(b.typ)
+	return if a_align > b_align {
+		-1
+	} else if a_align < b_align {
+		1
+	} else if a_size > b_size {
 		-1
 	} else if a_size < b_size {
 		1

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -153,7 +153,13 @@ fn minify_sort_fn(a &ast.StructField, b &ast.StructField) int {
 			if b_sym.kind == .enum_ {
 				a_nr_vals := (a_sym.info as ast.Enum).vals.len
 				b_nr_vals := (b_sym.info as ast.Enum).vals.len
-				return if a_nr_vals > b_nr_vals { -1 } else if a_nr_vals < b_nr_vals { 1 } else { 0 }
+				return if a_nr_vals > b_nr_vals {
+					-1
+				} else if a_nr_vals < b_nr_vals {
+					1
+				} else {
+					0
+				}
 			}
 			return 1
 		}
@@ -165,7 +171,13 @@ fn minify_sort_fn(a &ast.StructField, b &ast.StructField) int {
 
 	a_size := t.type_size(a.typ)
 	b_size := t.type_size(b.typ)
-	return if a_size > b_size { -1 } else if a_size < b_size { 1 } else { 0 }
+	return if a_size > b_size {
+		-1
+	} else if a_size < b_size {
+		1
+	} else {
+		0
+	}
 }
 
 pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -327,6 +327,11 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 						node.pos)
 				}
 			}
+			mut info_fields_sorted := []ast.StructField{}
+			if node.is_short {
+				info_fields_sorted = info.fields.clone()
+				info_fields_sorted.sort(a.i < b.i)
+			}
 			mut inited_fields := []string{}
 			for i, mut field in node.fields {
 				mut field_info := ast.StructField{}
@@ -337,7 +342,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 						// We should just stop here.
 						break
 					}
-					field_info = info.fields[i]
+					field_info = info_fields_sorted[i]
 					field_name = field_info.name
 					node.fields[i].name = field_name
 				} else {

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -92,6 +92,7 @@ pub fn (sk SymbolKind) str() string {
 	}
 }
 
+[minify]
 pub struct Doc {
 pub mut:
 	prefs     &pref.Preferences = new_vdoc_preferences()
@@ -121,6 +122,7 @@ pub mut:
 	platform            Platform
 }
 
+[minify]
 pub struct DocNode {
 pub mut:
 	name        string

--- a/vlib/v/errors/errors.v
+++ b/vlib/v/errors/errors.v
@@ -10,6 +10,7 @@ pub enum Reporter {
 	gen
 }
 
+[minify]
 pub struct Error {
 pub:
 	message   string

--- a/vlib/v/fmt/comments.v
+++ b/vlib/v/fmt/comments.v
@@ -16,7 +16,7 @@ pub enum CommentsLevel {
 // - level:  either .keep (don't indent), or .indent (increment indentation)
 // - iembed: a /* ... */ block comment used inside expressions; // comments the whole line
 // - prev_line: the line number of the previous token to save linebreaks
-[params]
+[minify; params]
 pub struct CommentsOptions {
 	has_nl    bool = true
 	inline    bool

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -15,6 +15,7 @@ const (
 	max_len = [0, 35, 60, 85, 93, 100]
 )
 
+[minify]
 pub struct Fmt {
 pub mut:
 	file               ast.File

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4850,7 +4850,7 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 											bits_needed++
 											l >>= 1
 										}
-										size_suffix = ' : ${bits_needed}'
+										size_suffix = ' : $bits_needed'
 									}
 								}
 							}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4837,7 +4837,7 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 						field_name := c_name(field.name)
 						volatile_prefix := if field.is_volatile { 'volatile ' } else { '' }
 						mut size_suffix := ''
-						if is_minify {
+						if is_minify && !g.is_cc_msvc {
 							if field.typ == ast.bool_type_idx {
 								size_suffix = ' : 1'
 							} else {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -492,7 +492,8 @@ fn (mut g Gen) gen_anon_fn(mut node ast.AnonFn) {
 	g.indent--
 	ps := g.table.pointer_size
 	is_big_cutoff := if g.pref.os == .windows || g.pref.arch == .arm32 { ps } else { ps * 2 }
-	is_big := g.table.type_size(node.decl.return_type) > is_big_cutoff
+	rt_size, _ := g.table.type_size(node.decl.return_type)
+	is_big := rt_size > is_big_cutoff
 	g.write('}, sizeof($ctx_struct)))')
 
 	mut sb := strings.new_builder(512)

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -22,7 +22,7 @@ mut:
 	// XXX WHY gen_exit fn (expr ast.Expr)
 }
 
-[heap]
+[heap; minify]
 pub struct Gen {
 	out_name string
 	pref     &pref.Preferences // Preferences shared from V struct

--- a/vlib/v/live/common.v
+++ b/vlib/v/live/common.v
@@ -8,6 +8,7 @@ pub type FNLinkLiveSymbols = fn (linkcb voidptr)
 
 pub type FNLiveReloadCB = fn (info &LiveReloadInfo)
 
+[minify]
 pub struct LiveReloadInfo {
 pub:
 	vexe             string  // full path to the v compiler

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -14,6 +14,7 @@ import v.errors
 import os
 import hash.fnv1a
 
+[minify]
 pub struct Parser {
 	pref &pref.Preferences
 mut:

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3480,6 +3480,7 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 	mut vals := []string{}
 	// mut default_exprs := []ast.Expr{}
 	mut fields := []ast.EnumField{}
+	mut uses_exprs := false
 	for p.tok.kind != .eof && p.tok.kind != .rcbr {
 		pos := p.tok.pos()
 		val := p.check_name()
@@ -3491,6 +3492,7 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 			p.next()
 			expr = p.expr(0)
 			has_expr = true
+			uses_exprs = true
 		}
 		fields << ast.EnumField{
 			name: val
@@ -3538,6 +3540,7 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 			vals: vals
 			is_flag: is_flag
 			is_multi_allowed: is_multi_allowed
+			uses_exprs: uses_exprs
 		}
 		is_pub: is_pub
 	})

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -103,6 +103,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 	mut end_comments := []ast.Comment{}
 	if !no_body {
 		p.check(.lcbr)
+		mut i := 0
 		for p.tok.kind != .rcbr {
 			mut comments := []ast.Comment{}
 			for p.tok.kind == .comment {
@@ -267,6 +268,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 					pos: field_pos
 					type_pos: type_pos
 					comments: comments
+					i: i
 					default_expr: default_expr
 					has_default_expr: has_default_expr
 					attrs: p.attrs
@@ -283,6 +285,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 				pos: field_pos
 				type_pos: type_pos
 				comments: comments
+				i: i
 				default_expr: default_expr
 				has_default_expr: has_default_expr
 				attrs: p.attrs
@@ -292,12 +295,14 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 				is_volatile: is_field_volatile
 			}
 			p.attrs = []
+			i++
 		}
 		p.top_level_statement_end()
 		last_line = p.tok.line_nr
 		p.check(.rcbr)
 	}
-	t := ast.TypeSymbol{
+	is_minify := attrs.contains('minify')
+	mut t := ast.TypeSymbol{
 		kind: .struct_
 		language: language
 		name: name
@@ -309,7 +314,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 			is_typedef: attrs.contains('typedef')
 			is_union: is_union
 			is_heap: attrs.contains('heap')
-			is_minify: attrs.contains('minify')
+			is_minify: is_minify
 			is_generic: generic_types.len > 0
 			generic_types: generic_types
 			attrs: attrs

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -309,6 +309,7 @@ fn (mut p Parser) struct_decl() ast.StructDecl {
 			is_typedef: attrs.contains('typedef')
 			is_union: is_union
 			is_heap: attrs.contains('heap')
+			is_minify: attrs.contains('minify')
 			is_generic: generic_types.len > 0
 			generic_types: generic_types
 			attrs: attrs

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -88,7 +88,7 @@ const (
 		'cflags', 'path', 'arch']
 )
 
-[heap]
+[heap; minify]
 pub struct Preferences {
 pub mut:
 	os          OS // the OS to compile for

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -23,6 +23,7 @@ const (
 	backslash    = `\\`
 )
 
+[minify]
 pub struct Scanner {
 pub mut:
 	file_path         string // '/path/to/file.v'

--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -3,6 +3,7 @@
 // that can be found in the LICENSE file.
 module token
 
+[minify]
 pub struct Token {
 pub:
 	kind    Kind   // the token number/enum; for quick comparisons

--- a/vlib/v/vet/vet.v
+++ b/vlib/v/vet/vet.v
@@ -22,6 +22,7 @@ pub enum ErrorType {
 	trailing_space
 }
 
+[minify]
 pub struct Error {
 pub mut:
 	kind ErrorKind [required]

--- a/x.v
+++ b/x.v
@@ -1,0 +1,9 @@
+[minify]
+struct Foo {
+        x u8
+        i int
+        b u16
+}
+
+f := Foo{1, 2, 3}
+println(f)


### PR DESCRIPTION
If specified, this new attribute will cause V to optimize the layout of a struct's fields, in order to try to reduce the amount of memory wasted due to padding for the fields' alignment. It will also use C bitfields to make boolean fields take up 1 bit of memory, not 8; and makes enums only take up the number of bits strictly needed to store its different variants.

I added the attribute to some of the V compiler's structs as well, and this decreased the maximum amount of RAM taken up by `./v -o v2.c cmd/v` by almost 8 MB.
