### PR TITLE
cgen: fix declare assigning fixed array_init with it (fix #14248)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -440,7 +440,7 @@ fn (mut g Gen) gen_assign_stmt(node_ ast.AssignStmt) {
 				} else if is_decl {
 					if is_fixed_array_init && !has_val {
 						if val is ast.ArrayInit {
-							g.array_init(val)
+							g.array_init(val, ident.name)
 						} else {
 							g.write('{0}')
 						}
@@ -451,7 +451,11 @@ fn (mut g Gen) gen_assign_stmt(node_ ast.AssignStmt) {
 						if val.is_auto_deref_var() {
 							g.write('*')
 						}
-						g.expr(val)
+						if val is ast.ArrayInit {
+							g.array_init(val, ident.name)
+						} else {
+							g.expr(val)
+						}
 						if is_auto_heap {
 							g.write('))')
 						}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2879,7 +2879,7 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 			g.expr(node.expr)
 		}
 		ast.ArrayInit {
-			g.array_init(node)
+			g.array_init(node, '')
 		}
 		ast.AsCast {
 			g.as_cast(node)

--- a/vlib/v/tests/array_with_it_test.v
+++ b/vlib/v/tests/array_with_it_test.v
@@ -1,6 +1,17 @@
 fn test_array_with_it() {
 	assert [0, 1, 2, 3, 4, 5]! == [6]int{init: it}
+	a1 := [6]int{init: it}
+	assert a1 == [0, 1, 2, 3, 4, 5]!
+
 	assert [0, 1, 4, 9, 16, 25] == []int{len: 6, init: it * it}
+	a2 := []int{len: 6, init: it * it}
+	assert a2 == [0, 1, 4, 9, 16, 25]
+
 	assert [1, 2, 3, 4, 5] == []int{len: 5, init: it + 1}
+	a3 := []int{len: 5, init: it + 1}
+	assert a3 == [1, 2, 3, 4, 5]
+
 	assert [5, 4, 3, 2, 1] == []int{len: 5, init: 5 - it}
+	a4 := []int{len: 5, init: 5 - it}
+	assert a4 == [5, 4, 3, 2, 1]
 }


### PR DESCRIPTION
This PR fix declare assigning fixed array_init with it (fix #14248).

- Fix declare assigning fixed array_init with it.
- Add test in tests/array_with_it_test.v.

```v
fn main() {
	a1 := [4]int{init: it}
	println(a1)

	a2 := []int{len: 4, init: it * 2}
	println(a2)
}

PS D:\Test\v\tt1> v run .
[0, 1, 2, 3]
[0, 2, 4, 6]
```