### PR TITLE
parser: fix inline array's element access (fix #14249)

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1557,3 +1557,15 @@ fn test_generic_mutable_arrays() {
 	mut arr := [1, 2, 3]
 	assert example(mut arr) == [1, 2, 3]
 }
+
+struct Ok {}
+
+fn test_inline_array_element_access() {
+	println([Ok{}][0])
+	a1 := [Ok{}][0]
+	assert a1 == Ok{}
+
+	println([1][0])
+	a2 := [1][0]
+	assert a2 == 1
+}

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -65,7 +65,8 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 		}
 		last_pos = p.tok.pos()
 		p.check(.rsbr)
-		if exprs.len == 1 && p.tok.kind in [.name, .amp, .lsbr] && p.tok.line_nr == line_nr {
+		if exprs.len == 1 && p.tok.line_nr == line_nr
+			&& (p.tok.kind in [.name, .amp] || (p.tok.kind == .lsbr && p.is_array_type())) {
 			// [100]u8
 			elem_type = p.parse_type()
 			if p.table.sym(elem_type).name == 'byte' {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -480,6 +480,27 @@ pub fn (p &Parser) peek_token_after_var_list() token.Token {
 	return tok
 }
 
+fn (p &Parser) is_array_type() bool {
+	mut i := 1
+	mut tok := p.tok
+	line_nr := p.tok.line_nr
+
+	for {
+		tok = p.peek_token(i)
+		if tok.line_nr != line_nr {
+			return false
+		}
+		if tok.kind in [.name, .amp] {
+			return true
+		}
+		i++
+		if tok.kind == .lsbr || tok.kind != .rsbr {
+			continue
+		}
+	}
+	return false
+}
+
 pub fn (mut p Parser) open_scope() {
 	p.scope = &ast.Scope{
 		parent: p.scope


### PR DESCRIPTION
This PR fix inline array's element access (fix #14249).

- Fix inline array's element access.
- Add test.

```v
struct Ok {}

fn main() {
	println([Ok{}][0])
	a1 := [Ok{}][0]
	assert a1 == Ok{}

	println([1][0])
	a2 := [1][0]
	assert a2 == 1
}

PS D:\Test\v\tt1> v run .
Ok{}
1
```