### PR TITLE
cgen: fix error for fixed array in operate (fix #14264)

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -472,7 +472,7 @@ fn (mut g Gen) infix_expr_in_op(node ast.InfixExpr) {
 				return
 			}
 		}
-		if right.sym.info is ast.Array {
+		if right.sym.info is ast.ArrayFixed {
 			elem_type := right.sym.info.elem_type
 			elem_type_ := g.unwrap(elem_type)
 			if elem_type_.sym.kind == .sum_type {

--- a/vlib/v/tests/fixed_array_in_op_test.v
+++ b/vlib/v/tests/fixed_array_in_op_test.v
@@ -5,4 +5,14 @@ fn test_fixed_array_in_op() {
 
 	ch := `"`
 	assert ch in [`"`, `'`]!
+
+	fixed_arr := [1, 2, 3]!
+
+	b1 := 2 in fixed_arr
+	println(b1)
+	assert b1
+
+	b2 := 5 !in fixed_arr
+	println(b2)
+	assert b2
 }


### PR DESCRIPTION
This PR fix error for fixed array in operate (fix #14264).

- Fix error for fixed array in operate.
- Add test.

```v
fn main() {
	fixed_arr := [1, 2, 3]!

	b1 := 2 in fixed_arr
	println(b1)
	assert b1

	b2 := 5 !in fixed_arr
	println(b2)
	assert b2
}

PS D:\Test\v\tt1> v run .
true
true
```