### PR TITLE
checker: check argument mismatch of array.filter/all/any() (fix #14271)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1778,6 +1778,11 @@ fn (mut c Checker) check_map_and_filter(is_map bool, elem_typ ast.Type, node ast
 				c.error('type mismatch, `$arg_expr.name` must return a bool', arg_expr.pos)
 			}
 		}
+		ast.StringLiteral, ast.StringInterLiteral {
+			if !is_map {
+				c.error('type mismatch, should use e.g. `${node.name}(it > 2)`', arg_expr.pos)
+			}
+		}
 		else {}
 	}
 }

--- a/vlib/v/checker/tests/array_filter_arg_mismatch_err.out
+++ b/vlib/v/checker/tests/array_filter_arg_mismatch_err.out
@@ -1,0 +1,21 @@
+vlib/v/checker/tests/array_filter_arg_mismatch_err.vv:17:20: error: type mismatch, should use e.g. `filter(it > 2)`
+   15 |     }]
+   16 |
+   17 |     a1 := list.filter('it.value > 2')
+      |                       ~~~~~~~~~~~~~~
+   18 |     println(a1)
+   19 |
+vlib/v/checker/tests/array_filter_arg_mismatch_err.vv:20:17: error: type mismatch, should use e.g. `any(it > 2)`
+   18 |     println(a1)
+   19 |
+   20 |     a2 := list.any('it.value > 2')
+      |                    ~~~~~~~~~~~~~~
+   21 |     println(a2)
+   22 |
+vlib/v/checker/tests/array_filter_arg_mismatch_err.vv:23:17: error: type mismatch, should use e.g. `all(it > 2)`
+   21 |     println(a2)
+   22 |
+   23 |     a3 := list.all('it.value > 2')
+      |                    ~~~~~~~~~~~~~~
+   24 |     println(a3)
+   25 | }

--- a/vlib/v/checker/tests/array_filter_arg_mismatch_err.vv
+++ b/vlib/v/checker/tests/array_filter_arg_mismatch_err.vv
@@ -1,0 +1,25 @@
+module main
+
+pub struct Row {
+pub mut:
+	value int
+}
+
+fn main() {
+	mut list := [Row{
+		value: 1
+	}, Row{
+		value: 2
+	}, Row{
+		value: 3
+	}]
+
+	a1 := list.filter('it.value > 2')
+	println(a1)
+
+	a2 := list.any('it.value > 2')
+	println(a2)
+
+	a3 := list.all('it.value > 2')
+	println(a3)
+}


### PR DESCRIPTION
This PR check argument mismatch of array.filter/all/any() (fix #14271).

- Check argument mismatch of array.filter/all/any().
- Add test.

```v
module main

pub struct Row {
pub mut:
	value int
}

fn main() {
	mut list := [Row{
		value: 1
	}, Row{
		value: 2
	}, Row{
		value: 3
	}]

	a1 := list.filter('it.value > 2')
	println(a1)

	a2 := list.any('it.value > 2')
	println(a2)

	a3 := list.all('it.value > 2')
	println(a3)
}

PS D:\Test\v\tt1> v run .
./tt1.v:17:20: error: type mismatch, should use e.g. `filter(it > 2)`
   15 |     }]
   16 |
   17 |     a1 := list.filter('it.value > 2')
      |                       ~~~~~~~~~~~~~~
   18 |     println(a1)
   19 |
./tt1.v:20:17: error: type mismatch, should use e.g. `any(it > 2)`
   18 |     println(a1)
   19 |
   20 |     a2 := list.any('it.value > 2')
      |                    ~~~~~~~~~~~~~~
   21 |     println(a2)
   22 |
./tt1.v:23:17: error: type mismatch, should use e.g. `all(it > 2)`
   21 |     println(a2)
   22 |
   23 |     a3 := list.all('it.value > 2')
      |                    ~~~~~~~~~~~~~~
   24 |     println(a3)
   25 | }
```