### PR TITLE
builtin: improve support for large arrays (`[]int{len: 1_000_000_000}` now works), fix an arr.repeat() bug

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -209,61 +209,82 @@ fn test_compare_ints() {
     assert compare_ints(a, a) == 0
 }
 */
-fn test_repeat() {
-	{
-		a := [0].repeat(5)
-		assert a.len == 5
-		assert a[0] == 0 && a[1] == 0 && a[2] == 0 && a[3] == 0 && a[4] == 0
+
+fn test_repeat_int() {
+	a := [1234].repeat(5)
+	dump(a)
+	assert a.len == 5
+	for x in a {
+		assert x == 1234
 	}
-	{
-		a := [1.1].repeat(10)
-		assert a[0] == 1.1
-		assert a[5] == 1.1
-		assert a[9] == 1.1
-	}
-	{
-		a := [i64(-123)].repeat(10)
-		assert a[0] == -123
-		assert a[5] == -123
-		assert a[9] == -123
-	}
-	{
-		a := [u64(123)].repeat(10)
-		assert a[0] == 123
-		assert a[5] == 123
-		assert a[9] == 123
-	}
-	{
-		a := [1.1].repeat(10)
-		assert a[0] == 1.1
-		assert a[5] == 1.1
-		assert a[9] == 1.1
-	}
-	{
-		a := [1, 2].repeat(2)
-		assert a[0] == 1
-		assert a[1] == 2
-		assert a[2] == 1
-		assert a[3] == 2
-	}
-	{
-		a := ['1', 'abc'].repeat(2)
-		assert a[0] == '1'
-		assert a[1] == 'abc'
-		assert a[2] == '1'
-		assert a[3] == 'abc'
-	}
-	{
-		mut a := ['1', 'abc'].repeat(0)
-		assert a.len == 0
-		a << 'abc'
-		assert a[0] == 'abc'
-	}
+}
+
+fn test_repeat_f64() {
+	a := [1.1].repeat(10)
+	dump(a)
+	assert a.len == 10
+	assert a[0] == 1.1
+	assert a[5] == 1.1
+	assert a[9] == 1.1
+}
+
+fn test_repeat_f32() {
+	a := [f32(1.1)].repeat(10)
+	dump(a)
+	assert a.len == 10
+	assert a[0] == f32(1.1)
+	assert a[5] == f32(1.1)
+	assert a[9] == f32(1.1)
+}
+
+fn test_repeat_i64() {
+	a := [i64(-123)].repeat(10)
+	dump(a)
+	assert a.len == 10
+	assert a[0] == -123
+	assert a[5] == -123
+	assert a[9] == -123
+}
+
+fn test_repeat_u64() {
+	a := [u64(123)].repeat(10)
+	assert a[0] == 123
+	assert a[5] == 123
+	assert a[9] == 123
+}
+
+fn test_repeat_several_ints() {
+	a := [1, 2].repeat(2)
+	dump(a)
+	assert a.len == 4
+	assert a[0] == 1
+	assert a[1] == 2
+	assert a[2] == 1
+	assert a[3] == 2
+}
+
+fn test_repeat_several_strings_2() {
+	a := ['1', 'abc'].repeat(2)
+	dump(a)
+	assert a.len == 4
+	assert a[0] == '1'
+	assert a[1] == 'abc'
+	assert a[2] == '1'
+	assert a[3] == 'abc'
+}
+
+fn test_repeat_several_strings_0() {
+	mut a := ['1', 'abc'].repeat(0)
+	dump(a)
+	assert a.len == 0
+	a << 'abc'
+	assert a[0] == 'abc'
 }
 
 fn test_deep_repeat() {
 	mut a3 := [[[1, 1], [2, 2], [3, 3]], [[4, 4], [5, 5], [6, 6]]]
 	r := a3.repeat(3)
+	dump(r)
 	a3[1][1][0] = 17
 	assert r == [
 		[[1, 1], [2, 2], [3, 3]],

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -276,7 +276,7 @@ __global total_m = i64(0)
 // malloc returns a `byteptr` pointing to the memory address of the allocated space.
 // unlike the `calloc` family of functions - malloc will not zero the memory block.
 [unsafe]
-pub fn malloc(n int) &u8 {
+pub fn malloc(n isize) &u8 {
 	if n <= 0 {
 		panic('malloc($n <= 0)')
 	}
@@ -319,7 +319,7 @@ pub fn malloc(n int) &u8 {
 }
 
 [unsafe]
-pub fn malloc_noscan(n int) &u8 {
+pub fn malloc_noscan(n isize) &u8 {
 	if n <= 0 {
 		panic('malloc_noscan($n <= 0)')
 	}
@@ -370,7 +370,7 @@ pub fn malloc_noscan(n int) &u8 {
 // previously allocated with `malloc`, `v_calloc` or `vcalloc`.
 // Please, see also realloc_data, and use it instead if possible.
 [unsafe]
-pub fn v_realloc(b &u8, n int) &u8 {
+pub fn v_realloc(b &u8, n isize) &u8 {
 	$if trace_realloc ? {
 		C.fprintf(C.stderr, c'v_realloc %6d\n', n)
 	}
@@ -441,7 +441,7 @@ pub fn realloc_data(old_data &u8, old_size int, new_size int) &u8 {
 // vcalloc dynamically allocates a zeroed `n` bytes block of memory on the heap.
 // vcalloc returns a `byteptr` pointing to the memory address of the allocated space.
 // Unlike `v_calloc` vcalloc checks for negative values given in `n`.
-pub fn vcalloc(n int) &u8 {
+pub fn vcalloc(n isize) &u8 {
 	if n < 0 {
 		panic('calloc($n < 0)')
 	} else if n == 0 {
@@ -462,7 +462,7 @@ pub fn vcalloc(n int) &u8 {
 
 // special versions of the above that allocate memory which is not scanned
 // for pointers (but is collected) when the Boehm garbage collection is used
-pub fn vcalloc_noscan(n int) &u8 {
+pub fn vcalloc_noscan(n isize) &u8 {
 	$if trace_vcalloc ? {
 		total_m += n
 		C.fprintf(C.stderr, c'vcalloc_noscan %6d total %10d\n', n, total_m)

--- a/vlib/builtin/cfns_wrapper.c.v
+++ b/vlib/builtin/cfns_wrapper.c.v
@@ -18,7 +18,7 @@ pub fn vstrlen_char(s &char) int {
 // The memory areas *MUST NOT OVERLAP*.  Use vmemmove, if the memory
 // areas do overlap. vmemcpy returns a pointer to `dest`.
 [inline; unsafe]
-pub fn vmemcpy(dest voidptr, const_src voidptr, n int) voidptr {
+pub fn vmemcpy(dest voidptr, const_src voidptr, n isize) voidptr {
 	unsafe {
 		return C.memcpy(dest, const_src, n)
 	}
@@ -30,7 +30,7 @@ pub fn vmemcpy(dest voidptr, const_src voidptr, n int) voidptr {
 // `src` or `dest`, and the bytes are then copied from the temporary array
 // to `dest`. vmemmove returns a pointer to `dest`.
 [inline; unsafe]
-pub fn vmemmove(dest voidptr, const_src voidptr, n int) voidptr {
+pub fn vmemmove(dest voidptr, const_src voidptr, n isize) voidptr {
 	unsafe {
 		return C.memmove(dest, const_src, n)
 	}
@@ -49,7 +49,7 @@ pub fn vmemmove(dest voidptr, const_src voidptr, n int) voidptr {
 // You should use a function that performs comparisons in constant time for
 // this.
 [inline; unsafe]
-pub fn vmemcmp(const_s1 voidptr, const_s2 voidptr, n int) int {
+pub fn vmemcmp(const_s1 voidptr, const_s2 voidptr, n isize) int {
 	unsafe {
 		return C.memcmp(const_s1, const_s2, n)
 	}
@@ -58,7 +58,7 @@ pub fn vmemcmp(const_s1 voidptr, const_s2 voidptr, n int) int {
 // vmemset fills the first `n` bytes of the memory area pointed to by `s`,
 // with the constant byte `c`. It returns a pointer to the memory area `s`.
 [inline; unsafe]
-pub fn vmemset(s voidptr, c int, n int) voidptr {
+pub fn vmemset(s voidptr, c int, n isize) voidptr {
 	unsafe {
 		return C.memset(s, c, n)
 	}

--- a/vlib/builtin/linux_bare/old/mm_bare.v
+++ b/vlib/builtin/linux_bare/old/mm_bare.v
@@ -31,7 +31,7 @@ pub fn mm_free(addr &byte) Errno {
 	return sys_munmap(ap, size)
 }
 
-pub fn mem_copy(dest0 voidptr, src0 voidptr, n int) voidptr {
+pub fn mem_copy(dest0 voidptr, src0 voidptr, n isize) voidptr {
 	mut dest := &u8(dest0)
 	src := &u8(src0)
 	for i in 0 .. n {
@@ -41,7 +41,7 @@ pub fn mem_copy(dest0 voidptr, src0 voidptr, n int) voidptr {
 }
 
 [unsafe]
-pub fn malloc(n int) &byte {
+pub fn malloc(n isize) &byte {
 	if n < 0 {
 		panic('malloc(<0)')
 	}

--- a/vlib/builtin/prealloc.c.v
+++ b/vlib/builtin/prealloc.c.v
@@ -21,16 +21,16 @@ __global g_memory_block &VMemoryBlock
 struct VMemoryBlock {
 mut:
 	id        int
-	cap       int
+	cap       isize
 	start     &byte = 0
 	previous  &VMemoryBlock = 0
-	remaining int
+	remaining isize
 	current   &u8 = 0
 	mallocs   int
 }
 
 [unsafe]
-fn vmemory_block_new(prev &VMemoryBlock, at_least int) &VMemoryBlock {
+fn vmemory_block_new(prev &VMemoryBlock, at_least isize) &VMemoryBlock {
 	mut v := unsafe { &VMemoryBlock(C.calloc(1, sizeof(VMemoryBlock))) }
 	if prev != 0 {
 		v.id = prev.id + 1
@@ -45,7 +45,7 @@ fn vmemory_block_new(prev &VMemoryBlock, at_least int) &VMemoryBlock {
 }
 
 [unsafe]
-fn vmemory_block_malloc(n int) &byte {
+fn vmemory_block_malloc(n isize) &byte {
 	unsafe {
 		if g_memory_block.remaining < n {
 			g_memory_block = vmemory_block_new(g_memory_block, n)
@@ -95,12 +95,12 @@ fn prealloc_vcleanup() {
 }
 
 [unsafe]
-fn prealloc_malloc(n int) &byte {
+fn prealloc_malloc(n isize) &byte {
 	return unsafe { vmemory_block_malloc(n) }
 }
 
 [unsafe]
-fn prealloc_realloc(old_data &byte, old_size int, new_size int) &byte {
+fn prealloc_realloc(old_data &byte, old_size isize, new_size isize) &byte {
 	new_ptr := unsafe { vmemory_block_malloc(new_size) }
 	min_size := if old_size < new_size { old_size } else { new_size }
 	unsafe { C.memcpy(new_ptr, old_data, min_size) }
@@ -108,7 +108,7 @@ fn prealloc_realloc(old_data &byte, old_size int, new_size int) &byte {
 }
 
 [unsafe]
-fn prealloc_calloc(n int) &byte {
+fn prealloc_calloc(n isize) &byte {
 	new_ptr := unsafe { vmemory_block_malloc(n) }
 	unsafe { C.memset(new_ptr, 0, n) }
 	return new_ptr

--- a/vlib/v/tests/big_array_allocation_test.v
+++ b/vlib/v/tests/big_array_allocation_test.v
@@ -1,0 +1,19 @@
+[direct_array_access]
+fn test_big_int_array() {
+	dump(sizeof(isize))
+	mut maxn := 500_000_000 // try allocating ~2GB worth of integers on 32bit platforms
+	if sizeof(isize) > 4 {
+		maxn = 1_000_000_000 // 1 billion integers, when each is 4 bytes => require ~4GB
+	}
+	dump(maxn)
+	mut data := []int{len: maxn}
+
+	// ensure that all of the elements are written at least once, to prevent the OS from cheating:
+	for i in 0 .. maxn {
+		data[i] = i
+	}
+	assert data[0] == 0
+	assert data[maxn - 1] == maxn - 1
+	dump(data#[0..10])
+	dump(data#[-10..])
+}


### PR DESCRIPTION
Before there was a segfault for code like this (in .repeat):
```v
n := 1000*1000*1000
mut data := [0].repeat(n)
```