### PR TITLE
os, builtin: add Windows support for Process.stdin_write

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -316,7 +316,7 @@ fn C.ReadConsole(in_input_handle voidptr, out_buffer voidptr, in_chars_to_read u
 
 fn C.WriteConsole() voidptr
 
-fn C.WriteFile() voidptr
+fn C.WriteFile(hFile voidptr, lpBuffer voidptr, nNumberOfBytesToRead u32, lpNumberOfBytesRead C.LPDWORD, lpOverlapped voidptr) bool
 
 fn C._wchdir(dirname &u16)
 

--- a/vlib/os/process_windows.c.v
+++ b/vlib/os/process_windows.c.v
@@ -87,7 +87,7 @@ fn (mut p Process) win_spawn_process() int {
 		set_handle_info_ok1 := C.SetHandleInformation(wdata.child_stdout_read, C.HANDLE_FLAG_INHERIT,
 			0)
 		failed_cfn_report_error(set_handle_info_ok1, 'SetHandleInformation')
-		
+
 		// stderr
 		create_pipe_ok2 := C.CreatePipe(voidptr(&wdata.child_stderr_read), voidptr(&wdata.child_stderr_write),
 			voidptr(&sa), 0)
@@ -95,7 +95,7 @@ fn (mut p Process) win_spawn_process() int {
 		set_handle_info_ok2 := C.SetHandleInformation(wdata.child_stderr_read, C.HANDLE_FLAG_INHERIT,
 			0)
 		failed_cfn_report_error(set_handle_info_ok2, 'SetHandleInformation stderr')
-		
+
 		// stdin
 		create_pipe_ok3 := C.CreatePipe(voidptr(&wdata.child_stdin_read), voidptr(&wdata.child_stdin_write),
 			voidptr(&sa), 0)
@@ -103,7 +103,7 @@ fn (mut p Process) win_spawn_process() int {
 		set_handle_info_ok3 :=  C.SetHandleInformation(wdata.child_stdin_write, C.HANDLE_FLAG_INHERIT,
 			0)
 		failed_cfn_report_error(set_handle_info_ok3, 'SetHandleInformation stdin')
-		
+
 		start_info.h_std_input = wdata.child_stdin_write
 		start_info.h_std_output = wdata.child_stdout_write
 		start_info.h_std_error = wdata.child_stderr_write
@@ -196,7 +196,7 @@ fn (mut p Process) win_write_string(idx int, s string) {
 	buf := []u8{len: 4096}
 	mut bytes_written := int(0)
 	unsafe {
-		C.WriteFile(rhandle, buf, buf.cap, voidptr(&bytes_written), voidptr(0))
+		C.WriteFile(rhandle, &buf[0], buf.cap, voidptr(&bytes_written), voidptr(0))
 	}
 }
 

--- a/vlib/os/process_windows.c.v
+++ b/vlib/os/process_windows.c.v
@@ -46,8 +46,8 @@ fn close_valid_handle(p voidptr) {
 
 pub struct WProcess {
 pub mut:
-	proc_info    ProcessInformation
-	command_line [65536]u8
+	proc_info         ProcessInformation
+	command_line      [65536]u8
 	child_stdin_read  &u32
 	child_stdin_write &u32
 	//
@@ -100,7 +100,7 @@ fn (mut p Process) win_spawn_process() int {
 		create_pipe_ok3 := C.CreatePipe(voidptr(&wdata.child_stdin_read), voidptr(&wdata.child_stdin_write),
 			voidptr(&sa), 0)
 		failed_cfn_report_error(create_pipe_ok3, 'CreatePipe stdin')
-		set_handle_info_ok3 :=  C.SetHandleInformation(wdata.child_stdin_write, C.HANDLE_FLAG_INHERIT,
+		set_handle_info_ok3 := C.SetHandleInformation(wdata.child_stdin_write, C.HANDLE_FLAG_INHERIT,
 			0)
 		failed_cfn_report_error(set_handle_info_ok3, 'SetHandleInformation stdin')
 


### PR DESCRIPTION
Adds Windows support for writing to a child process' standard input. 

Test is TODO hence being a draft PR for a moment