### PR TITLE
builtin: add `map.values()`

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -634,12 +634,8 @@ pub fn (m &map) values() array {
 	mut item := unsafe { &u8(values.data) }
 
 	if m.key_values.deletes == 0 {
-		for i := 0; i < m.key_values.len; i++ {
-			unsafe {
-				pvalue := m.key_values.value(i)
-				m.clone_fn(item, pvalue)
-				item = item + m.value_bytes
-			}
+		unsafe {
+			vmemcpy(item, m.key_values.values, m.value_bytes * m.key_values.len)
 		}
 		return values
 	}
@@ -650,7 +646,7 @@ pub fn (m &map) values() array {
 		}
 		unsafe {
 			pvalue := m.key_values.value(i)
-			m.clone_fn(item, pvalue)
+			vmemcpy(item, pvalue, m.value_bytes)
 			item = item + m.value_bytes
 		}
 	}

--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -47,6 +47,16 @@ fn test_keys_many() {
 	assert keys == strings
 }
 
+fn test_values_many() {
+	mut m := map[string]int{}
+	for i, s in strings {
+		m[s] = i
+	}
+	values := m.values()
+	assert values.len == strings.len
+	assert values.len == m.len
+}
+
 fn test_deletes_many() {
 	mut m := map[string]int{}
 	for i, s in strings {
@@ -59,6 +69,7 @@ fn test_deletes_many() {
 	}
 	assert m.len == 0
 	assert m.keys().len == 0
+	assert m.values().len == 0
 }
 
 struct User {
@@ -103,6 +114,13 @@ fn test_map() {
 	assert m['hi'] == 0
 	assert m.keys().len == 1
 	assert m.keys()[0] == 'hello'
+	// Test `.values()`
+	values := m.values()
+	assert values.len == 1
+	assert 80 !in values
+	assert 101 in values
+	assert m.values().len == 1
+	assert m.values()[0] == 101
 	// //
 	mut users := map[string]User{}
 	users['1'] = User{'Peter'}
@@ -580,6 +598,7 @@ fn test_int_keys() {
 		4: 16
 		5: 25
 	}
+	assert m2.values() == [9, 16, 25]
 
 	assert m2.len == 3
 	// clone
@@ -634,6 +653,16 @@ fn test_voidptr_keys() {
 	assert m[&v] == 'var'
 	assert m[&m] == 'map'
 	assert m.len == 2
+}
+
+fn test_voidptr_values() {
+	mut m := map[string]voidptr{}
+	v := 5
+	m['var'] = &v
+	m['map'] = &m
+	assert m['var'] == &v
+	assert m['map'] == &m
+	assert m.values().len == 2
 }
 
 fn test_rune_keys() {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1123,7 +1123,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	if left_sym.kind == .array && method_name in array_builtin_methods {
 		return c.array_builtin_method_call(mut node, left_type, c.table.sym(left_type))
 	} else if (left_sym.kind == .map || final_left_sym.kind == .map)
-		&& method_name in ['clone', 'keys', 'move', 'delete'] {
+		&& method_name in ['clone', 'keys', 'values', 'move', 'delete'] {
 		if left_sym.kind == .map {
 			return c.map_builtin_method_call(mut node, left_type, left_sym)
 		} else {
@@ -1805,12 +1805,16 @@ fn (mut c Checker) map_builtin_method_call(mut node ast.CallExpr, left_type ast.
 			}
 			ret_type = ret_type.clear_flag(.shared_f)
 		}
-		'keys' {
+		'keys', 'values' {
 			if node.args.len != 0 {
-				c.error('`.keys()` does not have any arguments', node.args[0].pos)
+				c.error('`.${method_name}()` does not have any arguments', node.args[0].pos)
 			}
 			info := left_sym.info as ast.Map
-			typ := c.table.find_or_register_array(info.key_type)
+			typ := if method_name == 'keys' {
+				c.table.find_or_register_array(info.key_type)
+			} else {
+				c.table.find_or_register_array(info.value_type)
+			}
 			ret_type = ast.Type(typ)
 		}
 		'delete' {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1044,6 +1044,8 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	} else if final_left_sym.kind == .map {
 		if node.name == 'keys' {
 			name = 'map_keys'
+		} else if node.name == 'values' {
+			name = 'map_values'
 		}
 	}
 	if g.pref.obfuscate && g.cur_mod.name == 'main' && name.starts_with('main__')


### PR DESCRIPTION
In addition to `map.keys()`, add `map.values()`.
JS has `Map.prototype.values()`, Python has `dict.values()`, C# has `Dictionary<TKey,TValue>.Values`... It was time for V to have its own.

⚠️ - I only managed to make it work for maps with the same type for the key and the value. I feel like I'm close to making it work completely but as it's my first time messing with more low-level things I'll need some help 🙂

TODO:
- [x] different key/value type support
- [x] add tests