### PR TITLE
checker: check error for optional argument in dump() (fix #14312)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2670,6 +2670,7 @@ pub fn (mut c Checker) expr(node_ ast.Expr) ast.Type {
 		}
 		ast.DumpExpr {
 			node.expr_type = c.expr(node.expr)
+			c.check_expr_opt_call(node.expr, node.expr_type)
 			etidx := node.expr_type.idx()
 			if etidx == ast.void_type_idx {
 				c.error('dump expression can not be void', node.expr.pos())

--- a/vlib/v/checker/tests/optional_in_dump_err.out
+++ b/vlib/v/checker/tests/optional_in_dump_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/optional_in_dump_err.vv:10:7: error: create() returns an option, so it should have either an `or {}` block, or `?` at the end
+    8 |
+    9 | fn main() {
+   10 |     dump(create())
+      |          ~~~~~~~~
+   11 | }

--- a/vlib/v/checker/tests/optional_in_dump_err.vv
+++ b/vlib/v/checker/tests/optional_in_dump_err.vv
@@ -1,0 +1,11 @@
+struct AStruct {
+	field1 int
+}
+
+fn create() ?AStruct {
+	return AStruct{123}
+}
+
+fn main() {
+	dump(create())
+}


### PR DESCRIPTION
This PR check error for optional argument in dump() (fix #14312).

- Check error for optional argument in dump().
- Add test.

```v
struct AStruct {
	field1 int
}

fn create() ?AStruct {
	return AStruct{123}
}

fn main() {
	dump(create())
}

PS D:\Test\v\tt1> v run .
./tt1.v:10:7: error: create() returns an option, so it should have either an `or {}` block, or `?` at the end
    8 |
    9 | fn main() {
   10 |     dump(create())
      |          ~~~~~~~~
   11 | }
```