### PR TITLE
all: add `compile_error` and `compile_warn` comptime functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -*Not yet released, changelog is not full*
 - Introduce `isize` and `usize` types, deprecate `size_t` in favor of `usize`.
 - Add `datatypes` and `datatypes.fsm` modules.
+- Add `compile_error` and `compile_warn` comptime functions.
 
 -## V 0.2.4
 -*Not yet released, changelog is not full*

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5453,7 +5453,7 @@ V can bring in values at compile time from environment variables.
 These two comptime functions are very useful for displaying custom errors/warnings during
 compile time.
 
-Both receive as their only argument a literal string that contains the message to display:
+Both receive as their only argument a string literal that contains the message to display:
 
 ```v
 // x.v

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5433,9 +5433,6 @@ numbers: [1, 2, 3]
 3
 ```
 
-
-
-
 #### `$env`
 
 ```v
@@ -5450,6 +5447,34 @@ fn main() {
 V can bring in values at compile time from environment variables.
 `$env('ENV_VAR')` can also be used in top-level `#flag` and `#include` statements:
 `#flag linux -I $env('JAVA_HOME')/include`.
+
+#### `$compile_error` and `$compile_warn`
+
+These two comptime functions are very useful for displaying custom errors/warnings during
+compile time.
+
+Both receive as their only argument a literal string that contains the message to display:
+
+```v
+// x.v
+module main
+
+$if linux {
+    $compile_error('Linux is not supported')
+}
+
+fn main() {
+}
+
+$ v run x.v
+x.v:4:5: error: Linux is not supported
+    2 |
+    3 | $if linux {
+    4 |     $compile_error('Linux is not supported')
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5 | }
+    6 |
+```
 
 ### Environment specific files
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5455,7 +5455,7 @@ compile time.
 
 Both receive as their only argument a string literal that contains the message to display:
 
-```v
+```v failcompile nofmt
 // x.v
 module main
 

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -10,6 +10,13 @@ import v.pkgconfig
 
 fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) ast.Type {
 	node.left_type = c.expr(node.left)
+	if node.method_name == 'compile_error' {
+		c.error(node.args_var, node.pos)
+		return ast.void_type
+	} else if node.method_name == 'compile_warn' {
+		c.warn(node.args_var, node.pos)
+		return ast.void_type
+	}
 	if node.is_env {
 		env_value := util.resolve_env_value("\$env('$node.args_var')", false) or {
 			c.error(err.msg(), node.env_pos)

--- a/vlib/v/checker/tests/compile_error.out
+++ b/vlib/v/checker/tests/compile_error.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/compile_error.vv:4:5: error: Only Serenity is supported
+    2 | 
+    3 | $if !serenity {
+    4 |     $compile_error('Only Serenity is supported')
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5 | }
+    6 |
+vlib/v/checker/tests/compile_error.vv:8:5: error: On non Vinix this warning should be shown
+    6 | 
+    7 | $if !vinix {
+    8 |     $compile_warn('On non Vinix this warning should be shown')
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    9 | }
+   10 |

--- a/vlib/v/checker/tests/compile_error.vv
+++ b/vlib/v/checker/tests/compile_error.vv
@@ -1,0 +1,15 @@
+module main
+
+$if !serenity {
+    $compile_error('Only Serenity is supported')
+}
+
+$if !vinix {
+    $compile_warn('On non Vinix this warning should be shown')
+}
+
+fn main() {
+	println('Hello from Serenity')
+}
+	
+	

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -88,7 +88,7 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 	}
 	start_pos := p.tok.pos()
 	p.check(.dollar)
-	error_msg := 'only `\$tmpl()`, `\$env()`, `\$embed_file()`, `\$pkgconfig()`, `\$vweb.html()`, `\$compile_error` and `\$compile_warn` comptime functions are supported right now'
+	error_msg := 'only `\$tmpl()`, `\$env()`, `\$embed_file()`, `\$pkgconfig()`, `\$vweb.html()`, `\$compile_error()` and `\$compile_warn()` comptime functions are supported right now'
 	if p.peek_tok.kind == .dot {
 		name := p.check_name() // skip `vweb.html()` TODO
 		if name != 'vweb' {


### PR DESCRIPTION
This PR adds the `compile_error` and `compile_warn` comptime functions.

Both are very useful for handling cases where, for example, a certain generic type, or an operating system, is not supported.

```v
$ cat x.v
module main

$if linux {
    $compile_error('Linux is not supported')
}

fn main() {
}

$ ./v2 run x.v
x.v:4:5: error: Linux is not supported
    2 |
    3 | $if linux {
    4 |     $compile_error('Linux is not supported')
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    5 | }
    6 |

```