### PR TITLE
checker: fix error for generic method on nested struct (fix #14098)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1223,7 +1223,8 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 		rec_sym := c.table.sym(node.left_type)
 		rec_is_generic := left_type.has_flag(.generic)
 		if rec_sym.info is ast.Struct {
-			if rec_is_generic && node.concrete_types.len == 0 {
+			if rec_is_generic && node.concrete_types.len == 0
+				&& method.generic_names.len == rec_sym.info.generic_types.len {
 				node.concrete_types = rec_sym.info.generic_types
 			} else if !rec_is_generic && rec_sym.info.concrete_types.len > 0
 				&& node.concrete_types.len > 0

--- a/vlib/v/tests/generics_method_on_nested_struct2_test.v
+++ b/vlib/v/tests/generics_method_on_nested_struct2_test.v
@@ -1,0 +1,38 @@
+struct Outer<T> {
+mut:
+	inner Inner<T>
+}
+
+struct Inner<T> {
+	val T
+}
+
+fn (mut i Inner<T>) next<S>(input S) f64 {
+	$if S is f32 {
+		return 32
+	} $else {
+		panic('"$S.name" is not supported')
+		return 0
+	}
+}
+
+fn (mut o Outer<T>) next<S>(input S) f64 {
+	$if S is f32 {
+		return o.inner.next(input)
+	} $else {
+		panic('"$S.name" is not supported')
+		return 0
+	}
+}
+
+fn test_generics_method_on_nested_struct() {
+	mut outer := Outer<f64>{
+		inner: Inner<f64>{
+			val: 1.1
+		}
+	}
+
+	res := outer.next(f32(99.0))
+	println(res)
+	assert res == 32.0
+}


### PR DESCRIPTION
This PR fix error for generic method on nested struct (fix #14098).

- Fix error for generic method on nested struct.
- Add test.

```v
struct Outer<T> {
mut:
	inner Inner<T>
}

struct Inner<T> {
	val T
}

fn (mut i Inner<T>) next<S>(input S) f64 {
	$if S is f32 {
		return 32
	} $else {
		panic('"$S.name" is not supported')
		return 0
	}
}

fn (mut o Outer<T>) next<S>(input S) f64 {
	$if S is f32 {
		return o.inner.next(input)
	} $else {
		panic('"$S.name" is not supported')
		return 0
	}
}

fn main() {
	mut outer := Outer<f64>{
		inner: Inner<f64>{
			val: 1.1
		}
	}

	res := outer.next(f32(99.0))
	println(res)
	assert res == 32.0
}

PS D:\Test\v\tt1> v run .
32.
```