### PR TITLE
net.smtp: correct date in smtp body

### DIFF
--- a/vlib/net/smtp/smtp.v
+++ b/vlib/net/smtp/smtp.v
@@ -236,7 +236,7 @@ fn (mut c Client) send_body(cfg Mail) ? {
 	sb.write_string('Date: $date\r\n')
 	sb.write_string('Subject: $cfg.subject\r\n')
 	if is_html {
-		sb.write_string('Content-Type: text/html; charset=ISO-8859-1')
+		sb.write_string('Content-Type: text/html; charset=UTF-8')
 	} else {
 		sb.write_string('Content-Type: text/plain; charset=UTF-8')
 	}

--- a/vlib/net/smtp/smtp.v
+++ b/vlib/net/smtp/smtp.v
@@ -227,7 +227,7 @@ fn (mut c Client) send_data() ? {
 
 fn (mut c Client) send_body(cfg Mail) ? {
 	is_html := cfg.body_type == .html
-	date := cfg.date.utc_string().trim_right(' UTC') // TODO
+	date := cfg.date.custom_format('ddd, D MMM YYYY HH:mm ZZ')
 	mut sb := strings.new_builder(200)
 	sb.write_string('From: $cfg.from\r\n')
 	sb.write_string('To: <$cfg.to>\r\n')
@@ -237,6 +237,8 @@ fn (mut c Client) send_body(cfg Mail) ? {
 	sb.write_string('Subject: $cfg.subject\r\n')
 	if is_html {
 		sb.write_string('Content-Type: text/html; charset=ISO-8859-1')
+	} else {
+		sb.write_string('Content-Type: text/plain; charset=UTF-8')
 	}
 	sb.write_string('\r\n\r\n')
 	sb.write_string(cfg.body)


### PR DESCRIPTION
- 'ZZ' time zone: GMX, a very popular german email server insists on the 'ZZ' time zone info. Otherwise the mail body is rejected (see also RFC2822, 3.3)
- Content type for plain text should be UFT-8 because V also operates with UTF-8, for html I don't know



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
