### PR TITLE
Added type 18 for pg boolean data type

### DIFF
--- a/vlib/pg/orm.v
+++ b/vlib/pg/orm.v
@@ -215,6 +215,9 @@ fn str_to_primitive(str string, typ int) ?orm.Primitive {
 		16 {
 			return orm.Primitive(str.i8() == 1)
 		}
+		18 {
+			return orm.Primitive(str == 't')
+		}
 		// i8
 		5 {
 			return orm.Primitive(str.i8())


### PR DESCRIPTION
PG can return bools as `t` or `f`. Currently this is not supported and throws an error for an unknown type of 18



<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
