### PR TITLE
pg: resolve string datetime

### DIFF
--- a/vlib/pg/orm.v
+++ b/vlib/pg/orm.v
@@ -266,6 +266,11 @@ fn str_to_primitive(str string, typ int) ?orm.Primitive {
 			return orm.Primitive(str)
 		}
 		orm.time {
+			if str.contains_any(' /:-') {
+				date_time_str := time.parse(str) ?
+				return orm.Primitive(date_time_str)
+			}
+
 			timestamp := str.int()
 			return orm.Primitive(time.unix(timestamp))
 		}


### PR DESCRIPTION
Currently the PG ORM only resolves `int` based date time values.
This PR resolves string based date time values. This is achieved by checking for ` /:-` characters in the value, if they exist the value is then given to `time.parse`. 

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
