### PR TITLE
Template: Replace `@` intelligently

### DIFF
--- a/vlib/v/parser/tmpl.v
+++ b/vlib/v/parser/tmpl.v
@@ -101,9 +101,6 @@ fn replace_at_symbol(line string) string {
 	mut pos := 0
 	mut rline := line
 	for pos < rline.len {
-		println('pos = $pos')
-		println('rline = $rline')
-
 		c1 := rline[pos]
 
 		if c1 != `@` || pos >= line.len {
@@ -160,8 +157,9 @@ fn replace_at_symbol(line string) string {
 
 		// @ident or @struct.ident
 		if (c2 >= `a` && c2 <= `z`) || (c2 >= `A` && c2 <= `Z`) || c2 == `_` {
+			// println('rline = $rline')
 			replace_at = true
-			mut dot_allowed := false
+			mut dot_allowed := true
 
 			// ensure that everything until space is valid ident
 			for inner_pos < rline.len {
@@ -172,23 +170,19 @@ fn replace_at_symbol(line string) string {
 
 				if (c2 < `a` || c2 > `z`) && (c2 < `A` || c2 > `Z`) && (c2 < `0` || c2 > `9`)
 					&& c2 != `_` {
-					match c2 {
-						`.` {
-							if dot_allowed {
-								dot_allowed = false
-							} else {
-								replace_at = false
-								break
-							}
+					if c2 == `.` {
+						if dot_allowed {
+							dot_allowed = false
+						} else {
+							replace_at = false
+							break
 						}
-						else {
-							dot_allowed == true
-						}
+					} else {
+						dot_allowed == true
 					}
-
-					replace_at = false
-					break
 				}
+				// println('c2 = $c2')
+				// println('dot_allowed = $dot_allowed')
 				inner_pos++
 			}
 		}

--- a/vlib/v/parser/v_parser_test.v
+++ b/vlib/v/parser/v_parser_test.v
@@ -261,3 +261,33 @@ fn test_fn_is_html_open_tag() {
 	b = is_html_open_tag('style', s)
 	assert b == false
 }
+
+fn test_fn_replace_at_symbol() {
+	mut s := "@message"
+	mut b := replace_at_symbol(s)
+	assert b == r"$message"
+
+	s = "@_message"
+	b = replace_at_symbol(s)
+	assert b == r"$_message"
+
+	s = "@ms.id"
+	b = replace_at_symbol(s)
+	assert b == r"$ms.id"
+
+	s = "@ ms.id"
+	b = replace_at_symbol(s)
+	assert b == r"@ ms.id"
+
+	s = "@{if cond {'TRUE'} else {'FALSE'}}"
+	b = replace_at_symbol(s)
+	assert b == r"${if cond {'TRUE'} else {'FALSE'}}"
+
+	s = "@{if cond {'}}'} else {'{{'}}"
+	b = replace_at_symbol(s)
+	assert b == r"${if cond {'}}'} else {'{{'}}"
+
+	s = "@1.2.3"
+	b = replace_at_symbol(s)
+	assert b == "@1.2.3"
+}

--- a/vlib/v/parser/v_parser_test.v
+++ b/vlib/v/parser/v_parser_test.v
@@ -263,21 +263,25 @@ fn test_fn_is_html_open_tag() {
 }
 
 fn test_fn_replace_at_symbol() {
-	mut s := "@message"
+	mut s := '@message'
 	mut b := replace_at_symbol(s)
-	assert b == r"$message"
+	assert b == r'$message'
 
-	s = "@_message"
+	s = '@_message'
 	b = replace_at_symbol(s)
-	assert b == r"$_message"
+	assert b == r'$_message'
 
-	s = "@ms.id"
+	s = '@ms.id'
 	b = replace_at_symbol(s)
-	assert b == r"$ms.id"
+	assert b == r'$ms.id'
 
-	s = "@ ms.id"
+	s = '@id1 @ id2'
 	b = replace_at_symbol(s)
-	assert b == r"@ ms.id"
+	assert b == r'$id1 @ id2'
+
+	s = '@ id1 @id2'
+	b = replace_at_symbol(s)
+	assert b == r'@ id1 $id2'
 
 	s = "@{if cond {'TRUE'} else {'FALSE'}}"
 	b = replace_at_symbol(s)
@@ -287,7 +291,11 @@ fn test_fn_replace_at_symbol() {
 	b = replace_at_symbol(s)
 	assert b == r"${if cond {'}}'} else {'{{'}}"
 
-	s = "@1.2.3"
+	s = '@1.2.3'
 	b = replace_at_symbol(s)
-	assert b == "@1.2.3"
+	assert b == s
+
+	s = '@ ms.id'
+	b = replace_at_symbol(s)
+	assert b == s
 }


### PR DESCRIPTION
Fixes #14104.

Added a function which receives a line of template code and  replaces all `@` symbols based on if it conforms to 
-@ident 
-@struct.ident 
-@{code}

Added tests in v_parser_test.v

New to open source so please let me know how to improve this.