### PR TITLE
checker: fix error for match sumtype that referenced before (fix #14246)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3656,6 +3656,7 @@ pub fn (mut c Checker) mark_as_referenced(mut node ast.Expr, as_interface bool) 
 								node.obj.is_auto_heap = true
 							}
 						}
+						.sum_type, .interface_ {}
 						else {
 							node.obj.is_auto_heap = true
 						}

--- a/vlib/v/tests/match_reference_sumtype_var_test.v
+++ b/vlib/v/tests/match_reference_sumtype_var_test.v
@@ -1,0 +1,42 @@
+struct Player {
+mut:
+	x     int
+	y     int
+	level int
+}
+
+struct Enemy {
+mut:
+	x      int
+	y      int
+	damage f64
+}
+
+type PlayerOrEnemy = Enemy | Player
+
+fn test_match_reference_sumtype_var() {
+	mut entity := PlayerOrEnemy(Player{10, 12, 3})
+
+	x_move := 11
+	y_move := 22
+
+	mut ref := &entity
+
+	match mut entity {
+		Player {
+			entity.x += x_move
+			entity.y += y_move
+
+			println('Player is moved to $entity.x, $entity.y and its level is $entity.level')
+		}
+		Enemy {
+			entity.x += x_move
+			entity.y += y_move
+
+			println('Enemy is moved to $entity.x, $entity.y and its damage is $entity.damage')
+		}
+	}
+
+	println(typeof(ref).name)
+	assert true
+}


### PR DESCRIPTION
This PR fix error for match sumtype that referenced before (fix #14246).

- Fix error for match sumtype that referenced before.
- Add test.

```v
struct Player {
mut:
	x     int
	y     int
	level int
}

struct Enemy {
mut:
	x      int
	y      int
	damage f64
}

type PlayerOrEnemy = Enemy | Player

fn test_match_reference_sumtype_var() {
	mut entity := PlayerOrEnemy(Player{10, 12, 3})

	x_move := 11
	y_move := 22

	mut ref := &entity

	match mut entity {
		Player {
			entity.x += x_move
			entity.y += y_move

			println('Player is moved to $entity.x, $entity.y and its level is $entity.level')
		}
		Enemy {
			entity.x += x_move
			entity.y += y_move

			println('Enemy is moved to $entity.x, $entity.y and its damage is $entity.damage')
		}
	}

	println(typeof(ref).name)
	assert true
}

PS D:\Test\v\tt1> v run .
Player is moved to 21, 34 and its level is 3
&PlayerOrEnemy
```