### PR TITLE
checker: check error for returning aliases of fixed array (fix #14344)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -92,7 +92,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				}
 			}
 		}
-		return_sym := c.table.sym(node.return_type)
+		return_sym := c.table.final_sym(node.return_type)
 		if return_sym.info is ast.MultiReturn {
 			for multi_type in return_sym.info.types {
 				multi_sym := c.table.sym(multi_type)

--- a/vlib/v/checker/tests/return_aliases_of_fixed_array.out
+++ b/vlib/v/checker/tests/return_aliases_of_fixed_array.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/return_aliases_of_fixed_array.vv:8:18: error: fixed array cannot be returned by function
+    6 | }
+    7 |
+    8 | fn (v Mat) foo() Mat {
+      |                  ~~~
+    9 |     return v
+   10 | }
+vlib/v/checker/tests/return_aliases_of_fixed_array.vv:12:10: error: fixed array cannot be returned by function
+   10 | }
+   11 |
+   12 | fn bar() Mat {
+      |          ~~~
+   13 |     return Mat([[1, 2]!, [3, 4]!]!)
+   14 | }

--- a/vlib/v/checker/tests/return_aliases_of_fixed_array.vv
+++ b/vlib/v/checker/tests/return_aliases_of_fixed_array.vv
@@ -1,0 +1,14 @@
+type Mat = [2][2]int
+
+fn main() {
+	a := Mat([[1, 2]!, [3, 4]!]!)
+	println(a.foo())
+}
+
+fn (v Mat) foo() Mat {
+	return v
+}
+
+fn bar() Mat {
+	return Mat([[1, 2]!, [3, 4]!]!)
+}


### PR DESCRIPTION
This PR check error for returning aliases of fixed array (fix #14344).

- Check error for returning aliases of fixed array.
- Add test.

```v
type Mat = [2][2]int

fn main() {
	a := Mat([[1, 2]!, [3, 4]!]!)
	println(a.foo())
}

fn (v Mat) foo() Mat {
	return v
}

fn bar() Mat {
	return Mat([[1, 2]!, [3, 4]!]!)
}

PS D:\Test\v\tt1> v run .
./tt1.v:8:18: error: fixed array cannot be returned by function
    6 | }
    7 |
    8 | fn (v Mat) foo() Mat {
      |                  ~~~
    9 |     return v
   10 | }
./tt1.v:12:10: error: fixed array cannot be returned by function
   10 | }
   11 |
   12 | fn bar() Mat {
      |          ~~~
   13 |     return Mat([[1, 2]!, [3, 4]!]!)
   14 | }
```